### PR TITLE
complete to regulate jax.numpy and numpy

### DIFF
--- a/python/sgl_jax/srt/layers/logits_processor.py
+++ b/python/sgl_jax/srt/layers/logits_processor.py
@@ -98,26 +98,11 @@ class LogitsProcessorOutput:
 
         return obj
 
-    def truncate_logits_processor_output(self, idx: jax.Array):
+    def truncate_logits_processor_output(self, idx: np.ndarray):
         # note: here only need to truncate next_token_logits and hidden_states
         self.next_token_logits = self.next_token_logits[idx]
         if self.hidden_states is not None:
             self.hidden_states = self.hidden_states[idx]
-
-        # for field in dataclasses.fields(self):
-        #     value = getattr(self, field.name)
-        #     if value is None:
-        #         continue
-        #     if isinstance(value, jax.Array):
-        #         truncated = value[idx]
-        #         setattr(self, field.name, truncated)
-        #     elif isinstance(value, list):
-        #         if len(value) > 0 and len(idx.shape) == 1:
-        #             idx_list = idx.tolist() if hasattr(idx, 'tolist') else [int(idx)]
-        #             truncated = [value[i] for i in idx_list if i < len(value)]
-        #         else:
-        #             truncated = value
-        #         setattr(self, field.name, truncated)
 
 
 @dataclasses.dataclass

--- a/python/sgl_jax/srt/layers/sampler.py
+++ b/python/sgl_jax/srt/layers/sampler.py
@@ -79,10 +79,7 @@ class Sampler(nnx.Module):
                 ) = get_token_ids_logprobs(logprobs, token_ids_logprobs)
 
             logits_output.next_token_logprobs = logprobs[
-                device_array(
-                    mesh if mesh is not None else jax.sharding.get_abstract_mesh(),
-                    np.arange(len(batch_next_token_ids)),
-                ),
+                np.arange(len(batch_next_token_ids)),
                 batch_next_token_ids,
             ]
 

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -6,6 +6,7 @@ import time
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import jax
+import numpy as np
 
 from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
 from sgl_jax.srt.managers.io_struct import BatchTokenIDOut
@@ -53,6 +54,7 @@ class SchedulerOutputProcessorMixin:
 
         # Move next_token_ids and logprobs to cpu
         next_token_ids = jax.device_get(next_token_ids).tolist()
+        batch.output_ids = np.array(next_token_ids, dtype=np.int32)
         if batch.return_logprob:
             if logits_output.next_token_logprobs is not None:
                 logits_output.next_token_logprobs = jax.device_get(
@@ -145,6 +147,7 @@ class SchedulerOutputProcessorMixin:
 
         # spec decoding handles output logprobs inside verify process.
         next_token_ids = jax.device_get(next_token_ids).tolist()
+        batch.output_ids = np.array(next_token_ids, dtype=np.int32)
         if batch.return_logprob:
             next_token_logprobs = jax.device_get(
                 logits_output.next_token_logprobs

--- a/python/sgl_jax/srt/model_executor/forward_batch_info.py
+++ b/python/sgl_jax/srt/model_executor/forward_batch_info.py
@@ -22,6 +22,9 @@ from functools import total_ordering
 from typing import TYPE_CHECKING, Optional
 
 import jax
+import jax.numpy as jnp
+
+from sgl_jax.srt.utils.jax_utils import device_array
 
 if TYPE_CHECKING:
     from sgl_jax.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -226,15 +229,23 @@ class ForwardBatch:
         return cls(
             forward_mode=batch.forward_mode,
             batch_size=len(batch.seq_lens),
-            input_ids=batch.input_ids,
-            seq_lens=batch.seq_lens,
-            out_cache_loc=batch.out_cache_loc,
-            positions=batch.positions,
-            extend_start_loc=batch.extend_start_loc,
-            req_pool_indices=batch.req_pool_indices,
+            input_ids=device_array(model_runner.mesh, batch.input_ids),
+            seq_lens=jnp.array(batch.seq_lens),
+            out_cache_loc=jnp.array(batch.out_cache_loc),
+            positions=jnp.array(batch.positions),
+            extend_start_loc=jnp.array(batch.extend_start_loc),
+            req_pool_indices=jnp.array(batch.req_pool_indices),
             token_to_kv_pool=model_runner.token_to_kv_pool,
             attn_backend=model_runner.attn_backend,
-            cache_loc=batch.cache_loc,
-            extend_prefix_lens=batch.extend_prefix_lens,
-            extend_seq_lens=batch.extend_seq_lens,
+            cache_loc=jnp.array(batch.cache_loc),
+            extend_prefix_lens=(
+                jnp.array(batch.extend_prefix_lens)
+                if batch.extend_prefix_lens is not None
+                else None
+            ),
+            extend_seq_lens=(
+                jnp.array(batch.extend_seq_lens)
+                if batch.extend_seq_lens is not None
+                else None
+            ),
         )

--- a/python/sgl_jax/srt/utils/jax_utils.py
+++ b/python/sgl_jax/srt/utils/jax_utils.py
@@ -62,7 +62,7 @@ def get_available_device_memory(device, distributed=False, empty_cache=True):
     return int(free_gpu_memory * (1 << 10))
 
 
-def device_array(mesh, data, sharding=None, **kwargs) -> jax.Array:
+def device_array(mesh, *data, sharding=None, **kwargs) -> jax.Array:
     if sharding is None:
         sharding = NamedSharding(mesh, PartitionSpec(None))
-    return jax.device_put(data, device=sharding, **kwargs)
+    return jax.device_put(*data, device=sharding, **kwargs)


### PR DESCRIPTION
## Command

**note**: `evalscope==0.17.1`, newer version(like 1.0.0) has different prompts compared with the old version(like 0.17.1), and this results in different scores, so we fix the version.

```bash
# launch server

JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache  python3 -u -m sgl_jax.launch_server --model-path Qwen/Qwen-7B-Chat --trust-remote-code  --dist-init-addr=0.0.0.0:10011 --nnodes=1  --tp-size=4 --device=tpu --random-seed=3 --node-rank=0 --mem-fraction-static=0.4 --chunked-prefill-size=8192 --download-dir=/tmp --dtype=bfloat16 --jax-precompile-decode-bs-paddings 64 --max-running-requests 64 --skip-server-warmup --attention-backend=fa --jax-precompile-prefill-token-paddings 8192 --page-size=64

# do profile

curl -X POST 'http://127.0.0.1:30000/start_profile' -d '{"output_dir": xxx, "num_steps": 5}' -H 'Content-Type: application/json'

# benchmark

python3 -m sgl_jax.bench_serving --backend sgl-jax --dataset-name random --num-prompts 10 --random-input 512 --random-output 128 --random-range-ratio 1 --warmup-requests 0

# eval

evalscope eval  --model Qwen-7B-Chat --api-url http://127.0.0.1:30000/v1/chat/completions --api-key EMPTY --eval-type service --datasets gsm8k --eval-batch-size 32
```



## Perf Comparison

### Benchmark(Better in TTFT)

**main-9e3c57e84dd8cf44eeb0f05ac4c51c943ad043cf**

```bash
============ Serving Benchmark Result ============
Backend:                                 sgl-jax
Traffic request rate:                    inf
Max request concurrency:                 not set
Successful requests:                     10
Benchmark duration (s):                  7.30
Total input tokens:                      5120
Total generated tokens:                  1280
Total generated tokens (retokenized):    1050
Request throughput (req/s):              1.37
Input token throughput (tok/s):          701.83
Output token throughput (tok/s):         175.46
Total token throughput (tok/s):          877.29
Concurrency:                             9.99
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   7290.31
Median E2E Latency (ms):                 7290.39
---------------Time to First Token----------------
Mean TTFT (ms):                          1906.25
Median TTFT (ms):                        2051.78
P99 TTFT (ms):                           2052.60
---------------Inter-Token Latency----------------
Mean ITL (ms):                           42.39
Median ITL (ms):                         23.79
P95 ITL (ms):                            24.96
P99 ITL (ms):                            697.25
Max ITL (ms):                            2837.80
==================================================
```

**current branch**

```bash
============ Serving Benchmark Result ============
Backend:                                 sgl-jax
Traffic request rate:                    inf
Max request concurrency:                 not set
Successful requests:                     10
Benchmark duration (s):                  4.79
Total input tokens:                      5120
Total generated tokens:                  1280
Total generated tokens (retokenized):    1050
Request throughput (req/s):              2.09
Input token throughput (tok/s):          1068.76
Output token throughput (tok/s):         267.19
Total token throughput (tok/s):          1335.95
Concurrency:                             9.99
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   4785.63
Median E2E Latency (ms):                 4785.58
---------------Time to First Token----------------
Mean TTFT (ms):                          773.47
Median TTFT (ms):                        819.23
P99 TTFT (ms):                           819.84
---------------Inter-Token Latency----------------
Mean ITL (ms):                           31.59
Median ITL (ms):                         23.77
P95 ITL (ms):                            24.83
P99 ITL (ms):                            178.17
Max ITL (ms):                            686.67
==================================================
```


### profile

**main-9e3c57e84dd8cf44eeb0f05ac4c51c943ad043cf**

- prefill

<img width="790" height="784" alt="image" src="https://github.com/user-attachments/assets/739724c9-39c9-43c5-8521-28908f98fb0a" />


- decode

<img width="449" height="805" alt="image" src="https://github.com/user-attachments/assets/3abf1a8c-4772-4751-bd37-6ee0b7a2d9da" />


**current branch**

- prefill

<img width="630" height="657" alt="image" src="https://github.com/user-attachments/assets/5ea5b123-9915-41b9-91b8-04597c1a5927" />

- decode

<img width="284" height="763" alt="image" src="https://github.com/user-attachments/assets/49637d23-6cbc-4a4c-9aaa-bd02e59e6ed2" />


### Conclusion

<img width="917" height="318" alt="image" src="https://github.com/user-attachments/assets/c69ce78a-917e-4d5e-b281-3fa59038a4ea" />

## Accuracy

**main-9e3c57e84dd8cf44eeb0f05ac4c51c943ad043cf**

```bash
+--------------+-----------+-----------------+----------+-------+---------+---------+
| Model        | Dataset   | Metric          | Subset   |   Num |   Score | Cat.0   |
+==============+===========+=================+==========+=======+=========+=========+
| Qwen-7B-Chat | gsm8k     | AverageAccuracy | main     |  1319 |  0.4655 | default |
+--------------+-----------+-----------------+----------+-------+---------+---------+
```

**current branch**

```bash
+--------------+-----------+-----------------+----------+-------+---------+---------+
| Model        | Dataset   | Metric          | Subset   |   Num |   Score | Cat.0   |
+==============+===========+=================+==========+=======+=========+=========+
| Qwen-7B-Chat | gsm8k     | AverageAccuracy | main     |  1319 |  0.4701 | default |
+--------------+-----------+-----------------+----------+-------+---------+---------+
```



