### PR TITLE
fix: correctly handle positions calculation in the decoding phase

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1076,7 +1076,7 @@ class ScheduleBatch:
         else:
             # For decode: each sequence contributes one token at the next position (seq_len)
             # Create positions for actual tokens (one per sequence at seq_len)
-            batch_positions = seq_lens_cpu  # Next position is current seq_len
+            batch_positions = seq_lens_cpu - 1
             # Create positions array matching the length of input_ids (including padding)
             positions_cpu = np.zeros(len(input_ids_cpu), dtype=batch_positions.dtype)
             # Fill in the actual positions for the real tokens

--- a/test/srt/test_eval_accuracy_large.py
+++ b/test/srt/test_eval_accuracy_large.py
@@ -46,7 +46,7 @@ class TestEvalAccuracyLarge(CustomTestCase):
                 "--mem-fraction-static",
                 "0.4",
                 "--max-prefill-tokens",
-                "4096",
+                "16384",
                 "--download-dir",
                 "/tmp/",
                 "--dtype",

--- a/test/srt/test_qwen3_models.py
+++ b/test/srt/test_qwen3_models.py
@@ -30,7 +30,7 @@ class TestQwenModel(CustomTestCase):
                 "--mem-fraction-static",
                 "0.1",
                 "--max-prefill-tokens",
-                "4096",
+                "16384",
                 "--download-dir",
                 "/tmp/",
                 "--dtype",

--- a/test/srt/test_qwen3_moe_models.py
+++ b/test/srt/test_qwen3_moe_models.py
@@ -30,7 +30,7 @@ class TestQwenModel(CustomTestCase):
                 "--mem-fraction-static",
                 "0.1",
                 "--max-prefill-tokens",
-                "4096",
+                "16384",
                 "--download-dir",
                 "/tmp/",
                 "--dtype",


### PR DESCRIPTION
CLOSES: #87 

## Accuracy
command:
```
evalscope eval  --model Qwen-7B-Chat --api-url http://127.0.0.1:30000/v1 --api-key EMPTY --eval-type openai_api --datasets gsm8k --eval-batch-size 8
```
result: (evalscope: 0.17.1)
<img width="1242" height="170" alt="image" src="https://github.com/user-attachments/assets/8868b10b-2217-4fdf-a717-24c749ed0bb2" />


