### PR TITLE
avoid cache_miss in compute_logits, sample, truncate_logits_processor_output and so on

### DIFF
--- a/docs/features/attention_backend.md
+++ b/docs/features/attention_backend.md
@@ -8,7 +8,7 @@ SGLang JAX adopts a plugin-based design pattern for Attention Backends, enabling
 ### Abstract Base Class Design
 All attention backends inherit from the `AttentionBackend` base class (`python/sgl_jax/srt/layers/attention/base_attn_backend.py`), which defines two core abstract methods:
 
-- `init_forward_metadata(forward_batch)`: Initialize metadata required for forward pass
+- `get_forward_metadata(forward_batch)`: Initialize metadata required for forward pass and return it
 - `__call__(q, k, v, layer, forward_batch, **kwargs)`: Execute the actual attention computation
 
 ### Unified Interface Design
@@ -38,11 +38,11 @@ class YourCustomAttention(AttentionBackend):
 
 ### 2. Implement Required Methods
 
-#### ```init_forward_metadata``` Method
+#### ```get_forward_metadata``` Method
 ```python
-def init_forward_metadata(self, forward_batch: ForwardBatch):
-    """Initialize forward pass metadata"""
-    # Create your required metadata based on forward_batch
+def get_forward_metadata(self, batch: ModelWorkerBatch):
+    """get forward pass metadata"""
+    # Create your required metadata based on model_worker_batch and return it
     # e.g., compute sequence lengths, create indices, etc.
     pass
 ```

--- a/python/sgl_jax/srt/layers/attention/base_attn_backend.py
+++ b/python/sgl_jax/srt/layers/attention/base_attn_backend.py
@@ -9,6 +9,7 @@ from flax import nnx
 
 if TYPE_CHECKING:
     from sgl_jax.srt.layers.radix_attention import RadixAttention
+    from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
     from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
 
 
@@ -16,8 +17,8 @@ class AttentionBackend(nnx.Module):
     """The base class of attention backends"""
 
     @abstractmethod
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
-        """Init the metadata for a forward pass."""
+    def get_forward_metadata(self, batch: ModelWorkerBatch):
+        """Init the metadata for a forward pass and return it"""
         raise NotImplementedError()
 
     def __call__(

--- a/python/sgl_jax/srt/layers/attention/native_backend.py
+++ b/python/sgl_jax/srt/layers/attention/native_backend.py
@@ -8,6 +8,7 @@ from jax.tree_util import register_pytree_node_class
 
 from sgl_jax.srt.layers.attention.base_attn_backend import AttentionBackend
 from sgl_jax.srt.layers.radix_attention import AttentionType, RadixAttention
+from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 
 
@@ -38,8 +39,8 @@ class NativeAttention(AttentionBackend):
             num_attn_heads=aux_data["num_heads"], num_kv_heads=aux_data["num_kv_heads"]
         )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
-        """Init the metadata for a forward pass."""
+    def get_forward_metadata(self, batch: ModelWorkerBatch):
+        """Init the metadata for a forward pass and return it."""
         return None
 
     def __call__(

--- a/python/sgl_jax/test/model_executor/test_model_runner.py
+++ b/python/sgl_jax/test/model_executor/test_model_runner.py
@@ -19,7 +19,7 @@ from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch, ForwardM
 from sgl_jax.srt.model_executor.model_runner import ModelRunner
 from sgl_jax.srt.model_loader.loader import JAXModelLoader
 from sgl_jax.srt.precision_tracer import precision_tracer
-from sgl_jax.srt.sampling.sampling_batch_info import SamplingBatchInfo
+from sgl_jax.srt.sampling.sampling_batch_info import SamplingBatchInfo, SamplingMetadata
 from sgl_jax.srt.server_args import ServerArgs
 from sgl_jax.test.test_utils import create_device_mesh
 
@@ -250,7 +250,10 @@ class TestModelRunner(unittest.TestCase):
 
         # Sample the first token from extend output
         current_token = self.model_runner.sampler(
-            extend_output, sampling_info=model_worker_batch.sampling_info
+            extend_output,
+            sampling_metadata=SamplingMetadata.from_model_worker_batch(
+                model_worker_batch.sampling_info
+            ),
         )
 
         # Collect all generated tokens
@@ -276,7 +279,10 @@ class TestModelRunner(unittest.TestCase):
 
             # Sample next token for the next iteration
             current_token = self.model_runner.sampler(
-                decode_output, sampling_info=model_worker_batch.sampling_info
+                decode_output,
+                sampling_metadata=SamplingMetadata.from_model_worker_batch(
+                    model_worker_batch.sampling_info
+                ),
             )
             all_generated_tokens.append(current_token)
             print(f"step {step} current_token added: {current_token}")


### PR DESCRIPTION
## Command

```bash
# start server
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache  python3 -u -m sgl_jax.launch_server --model-path Qwen/Qwen3-8B --trust-remote-code  --dist-init-addr=0.0.0.0:10011 --nnodes=1  --tp-size=4 --device=tpu --random-seed=3 --node-rank=0 --mem-fraction-static=0.8 --chunked-prefill-size=8192 --download-dir=/tmp --dtype=bfloat16 --precompile-bs-paddings 10 64 --max-running-requests 64 --max-total-tokens 257536 --skip-server-warmup --attention-backend=fa --precompile-token-paddings 8192 --page-size=64

# profile
curl -X POST 'http://127.0.0.1:30000/start_profile' -d '{"output_dir": "/home/gcpuser/aolemila/profile", "num_steps": 10}' -H 'Content-Type: application/json'

# benchmark
python3 -m sgl_jax.bench_serving \
--backend sgl-jax \
--dataset-name random \
--num-prompts 10 \
--random-input 1024 \
--random-output 1024 \
--random-range-ratio 1 \
--warmup-requests 0

# evalscope(0.17.1)
evalscope eval  --model Qwen-8B --api-url http://127.0.0.1:30000/v1/chat/completions --api-key EMPTY --eval-type service --datasets gsm8k --eval-batch-size 64
```


## Result

### Benchmark

```bash
============ Serving Benchmark Result ============
Backend:                                 sgl-jax
Traffic request rate:                    inf
Max request concurrency:                 not set
Successful requests:                     10
Benchmark duration (s):                  45.27
Total input tokens:                      10240
Total generated tokens:                  10240
Total generated tokens (retokenized):    10234
Request throughput (req/s):              0.22
Input token throughput (tok/s):          226.19
Output token throughput (tok/s):         226.19
Total token throughput (tok/s):          452.38
Concurrency:                             10.00
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   45261.52
Median E2E Latency (ms):                 45261.58
---------------Time to First Token----------------
Mean TTFT (ms):                          615.54
Median TTFT (ms):                        716.82
P99 TTFT (ms):                           717.57
---------------Inter-Token Latency----------------
Mean ITL (ms):                           43.64
Median ITL (ms):                         11.54
P95 ITL (ms):                            11.85
P99 ITL (ms):                            12.11
Max ITL (ms):                            32701.49
==================================================
```

### Accuracy
+---------+-----------+-----------------+----------+-------+---------+---------+
| Model   | Dataset   | Metric          | Subset   |   Num |   Score | Cat.0   |
+=========+===========+=================+==========+=======+=========+=========+
| Qwen-8B | gsm8k     | AverageAccuracy | main     |  1319 |  0.9128 | default |
+---------+-----------+-----------------+----------+-------+---------+---------+