### PR TITLE
Feat/update kv cache update

### DIFF
--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -818,11 +818,14 @@ def update_kv_cache_vectorized(
     slice_lens = jnp.where(loc == -1, 0, 1).astype(jnp.int32)
     num_slices = total_tokens
 
-    # num_slices_per_block = get_num_slices_per_block(k, k_cache)
-    if page_size == 1:
-        num_slices_per_block = 4
-    else:
-        num_slices_per_block = page_size
+    # head_num, cache_len, new_kv_len, head_dim, page_size
+    num_slices_per_block = get_best_num_slices_per_block(
+        k.shape[1],
+        k_cache.shape[0],
+        k.shape[0],
+        k.shape[2],
+        page_size,
+    )
 
     slot_mapping = get_slot_mapping(
         num_slices_per_block=num_slices_per_block,
@@ -854,6 +857,61 @@ def update_kv_cache_vectorized(
     )
 
     return k_cache, v_cache
+
+
+def get_best_num_slices_per_block(head_num, cache_len, new_kv_len, head_dim, page_size):
+    # keep same to original implementation
+    if page_size == 1:
+        num_slices_per_block = 4
+    else:
+        num_slices_per_block = page_size
+
+    return num_slices_per_block
+
+    # note: the following logic will be supported in the future, the best num_slices_per_block is right tested well currently.
+    # search domain, ensure list is sorted
+    head_num_config = [8, 16, 32]
+    max_cache_len_config = [80000, 160000, 320000, 640000, 1280000]
+    new_kv_len_config = [1024, 2048, 4096, 9182, 16384]
+    head_dim_config = [128]
+    page_size_config = [64, 128, 256]
+
+    def find_value(lst, target_num) -> int:
+        left, right = 0, len(lst) - 1
+
+        if not lst or target_num < lst[0] or target_num > lst[-1]:
+            return -1
+
+        while left <= right:
+            mid = (left + right) // 2
+            if lst[mid] == target_num:
+                return lst[mid]
+            elif lst[mid] < target_num:
+                left = mid + 1
+            else:
+                right = mid - 1
+
+        if left < len(lst):
+            return lst[left]
+        else:
+            return -1
+
+    hn_val = find_value(head_num_config, head_num)
+    mcl_val = find_value(max_cache_len_config, cache_len)
+    nkl_val = find_value(new_kv_len_config, new_kv_len)
+    hd_val = find_value(head_dim_config, head_dim)
+    ps_val = find_value(page_size_config, page_size)
+
+    if (
+        hn_val != -1
+        and mcl_val != -1
+        and nkl_val != -1
+        and hd_val != -1
+        and ps_val != -1
+    ):
+        return best_num_slices_per_block_config[
+            f"hn_{hn_val}_mcl_{mcl_val}_nvl_{nkl_val}_hd_{hd_val}_ps_{ps_val}"
+        ]
 
 
 # @partial(jax.jit, static_argnames=["layer_id"])
@@ -985,3 +1043,232 @@ class MLATokenToKVPool(KVCache):
             self.kv_buffer[layer_id] = (
                 self.kv_buffer[layer_id].at[indices].set(kv_device)
             )
+
+
+best_num_slices_per_block_config = {
+    "hn_8_mcl_80000_nvl_1024_hd_128_ps_64": 16,
+    "hn_8_mcl_80000_nvl_2048_hd_128_ps_64": 32,
+    "hn_8_mcl_80000_nvl_4096_hd_128_ps_64": 64,
+    "hn_8_mcl_80000_nvl_9182_hd_128_ps_64": 32,
+    "hn_8_mcl_80000_nvl_16384_hd_128_ps_64": 512,
+    "hn_8_mcl_160000_nvl_1024_hd_128_ps_64": 16,
+    "hn_8_mcl_160000_nvl_2048_hd_128_ps_64": 8,
+    "hn_8_mcl_160000_nvl_4096_hd_128_ps_64": 64,
+    "hn_8_mcl_160000_nvl_9182_hd_128_ps_64": 32,
+    "hn_8_mcl_160000_nvl_16384_hd_128_ps_64": 128,
+    "hn_8_mcl_320000_nvl_1024_hd_128_ps_64": 16,
+    "hn_8_mcl_320000_nvl_2048_hd_128_ps_64": 16,
+    "hn_8_mcl_320000_nvl_4096_hd_128_ps_64": 32,
+    "hn_8_mcl_320000_nvl_9182_hd_128_ps_64": 16,
+    "hn_8_mcl_320000_nvl_16384_hd_128_ps_64": 256,
+    "hn_8_mcl_640000_nvl_1024_hd_128_ps_64": 4,
+    "hn_8_mcl_640000_nvl_2048_hd_128_ps_64": 64,
+    "hn_8_mcl_640000_nvl_4096_hd_128_ps_64": 64,
+    "hn_8_mcl_640000_nvl_9182_hd_128_ps_64": 32,
+    "hn_8_mcl_640000_nvl_16384_hd_128_ps_64": 64,
+    "hn_8_mcl_1280000_nvl_1024_hd_128_ps_64": 1024,
+    "hn_8_mcl_1280000_nvl_2048_hd_128_ps_64": 4,
+    "hn_8_mcl_1280000_nvl_4096_hd_128_ps_64": 16,
+    "hn_8_mcl_1280000_nvl_9182_hd_128_ps_64": 256,
+    "hn_8_mcl_1280000_nvl_16384_hd_128_ps_64": 1024,
+    "hn_16_mcl_80000_nvl_1024_hd_128_ps_64": 16,
+    "hn_16_mcl_80000_nvl_2048_hd_128_ps_64": 32,
+    "hn_16_mcl_80000_nvl_4096_hd_128_ps_64": 64,
+    "hn_16_mcl_80000_nvl_9182_hd_128_ps_64": 32,
+    "hn_16_mcl_80000_nvl_16384_hd_128_ps_64": 2048,
+    "hn_16_mcl_160000_nvl_1024_hd_128_ps_64": 4,
+    "hn_16_mcl_160000_nvl_2048_hd_128_ps_64": 16,
+    "hn_16_mcl_160000_nvl_4096_hd_128_ps_64": 512,
+    "hn_16_mcl_160000_nvl_9182_hd_128_ps_64": 128,
+    "hn_16_mcl_160000_nvl_16384_hd_128_ps_64": 64,
+    "hn_16_mcl_320000_nvl_1024_hd_128_ps_64": 8,
+    "hn_16_mcl_320000_nvl_2048_hd_128_ps_64": 16,
+    "hn_16_mcl_320000_nvl_4096_hd_128_ps_64": 16,
+    "hn_16_mcl_320000_nvl_9182_hd_128_ps_64": 8,
+    "hn_16_mcl_320000_nvl_16384_hd_128_ps_64": 256,
+    "hn_16_mcl_640000_nvl_1024_hd_128_ps_64": 128,
+    "hn_16_mcl_640000_nvl_2048_hd_128_ps_64": 4,
+    "hn_16_mcl_640000_nvl_4096_hd_128_ps_64": 32,
+    "hn_16_mcl_640000_nvl_9182_hd_128_ps_64": 64,
+    "hn_16_mcl_640000_nvl_16384_hd_128_ps_64": 512,
+    "hn_16_mcl_1280000_nvl_1024_hd_128_ps_64": 128,
+    "hn_16_mcl_1280000_nvl_2048_hd_128_ps_64": 2,
+    "hn_16_mcl_1280000_nvl_4096_hd_128_ps_64": 2048,
+    "hn_16_mcl_1280000_nvl_9182_hd_128_ps_64": 8,
+    "hn_16_mcl_1280000_nvl_16384_hd_128_ps_64": 8,
+    "hn_32_mcl_80000_nvl_1024_hd_128_ps_64": 256,
+    "hn_32_mcl_80000_nvl_2048_hd_128_ps_64": 32,
+    "hn_32_mcl_80000_nvl_4096_hd_128_ps_64": 16,
+    "hn_32_mcl_80000_nvl_9182_hd_128_ps_64": 512,
+    "hn_32_mcl_80000_nvl_16384_hd_128_ps_64": 4096,
+    "hn_32_mcl_160000_nvl_1024_hd_128_ps_64": 8,
+    "hn_32_mcl_160000_nvl_2048_hd_128_ps_64": 8,
+    "hn_32_mcl_160000_nvl_4096_hd_128_ps_64": 512,
+    "hn_32_mcl_160000_nvl_9182_hd_128_ps_64": 64,
+    "hn_32_mcl_160000_nvl_16384_hd_128_ps_64": 1024,
+    "hn_32_mcl_320000_nvl_1024_hd_128_ps_64": 4,
+    "hn_32_mcl_320000_nvl_2048_hd_128_ps_64": 512,
+    "hn_32_mcl_320000_nvl_4096_hd_128_ps_64": 256,
+    "hn_32_mcl_320000_nvl_9182_hd_128_ps_64": 8,
+    "hn_32_mcl_320000_nvl_16384_hd_128_ps_64": 64,
+    "hn_32_mcl_640000_nvl_1024_hd_128_ps_64": 2048,
+    "hn_32_mcl_640000_nvl_2048_hd_128_ps_64": 8,
+    "hn_32_mcl_640000_nvl_4096_hd_128_ps_64": 256,
+    "hn_32_mcl_640000_nvl_9182_hd_128_ps_64": 256,
+    "hn_32_mcl_640000_nvl_16384_hd_128_ps_64": 16,
+    "hn_32_mcl_1280000_nvl_1024_hd_128_ps_64": 256,
+    "hn_32_mcl_1280000_nvl_2048_hd_128_ps_64": 512,
+    "hn_32_mcl_1280000_nvl_4096_hd_128_ps_64": 4096,
+    "hn_32_mcl_1280000_nvl_9182_hd_128_ps_64": 128,
+    "hn_32_mcl_1280000_nvl_16384_hd_128_ps_64": 1024,
+    "hn_8_mcl_80000_nvl_1024_hd_128_ps_128": 8,
+    "hn_8_mcl_80000_nvl_2048_hd_128_ps_128": 32,
+    "hn_8_mcl_80000_nvl_4096_hd_128_ps_128": 64,
+    "hn_8_mcl_80000_nvl_9182_hd_128_ps_128": 1024,
+    "hn_8_mcl_80000_nvl_16384_hd_128_ps_128": 16,
+    "hn_8_mcl_160000_nvl_1024_hd_128_ps_128": 16,
+    "hn_8_mcl_160000_nvl_2048_hd_128_ps_128": 4,
+    "hn_8_mcl_160000_nvl_4096_hd_128_ps_128": 64,
+    "hn_8_mcl_160000_nvl_9182_hd_128_ps_128": 32,
+    "hn_8_mcl_160000_nvl_16384_hd_128_ps_128": 4096,
+    "hn_8_mcl_320000_nvl_1024_hd_128_ps_128": 32,
+    "hn_8_mcl_320000_nvl_2048_hd_128_ps_128": 8,
+    "hn_8_mcl_320000_nvl_4096_hd_128_ps_128": 16,
+    "hn_8_mcl_320000_nvl_9182_hd_128_ps_128": 32,
+    "hn_8_mcl_320000_nvl_16384_hd_128_ps_128": 16,
+    "hn_8_mcl_640000_nvl_1024_hd_128_ps_128": 8,
+    "hn_8_mcl_640000_nvl_2048_hd_128_ps_128": 16,
+    "hn_8_mcl_640000_nvl_4096_hd_128_ps_128": 16,
+    "hn_8_mcl_640000_nvl_9182_hd_128_ps_128": 16,
+    "hn_8_mcl_640000_nvl_16384_hd_128_ps_128": 4096,
+    "hn_8_mcl_1280000_nvl_1024_hd_128_ps_128": 128,
+    "hn_8_mcl_1280000_nvl_2048_hd_128_ps_128": 32,
+    "hn_8_mcl_1280000_nvl_4096_hd_128_ps_128": 256,
+    "hn_8_mcl_1280000_nvl_9182_hd_128_ps_128": 1024,
+    "hn_8_mcl_1280000_nvl_16384_hd_128_ps_128": 32,
+    "hn_16_mcl_80000_nvl_1024_hd_128_ps_128": 128,
+    "hn_16_mcl_80000_nvl_2048_hd_128_ps_128": 8,
+    "hn_16_mcl_80000_nvl_4096_hd_128_ps_128": 2048,
+    "hn_16_mcl_80000_nvl_9182_hd_128_ps_128": 1024,
+    "hn_16_mcl_80000_nvl_16384_hd_128_ps_128": 256,
+    "hn_16_mcl_160000_nvl_1024_hd_128_ps_128": 8,
+    "hn_16_mcl_160000_nvl_2048_hd_128_ps_128": 1024,
+    "hn_16_mcl_160000_nvl_4096_hd_128_ps_128": 2048,
+    "hn_16_mcl_160000_nvl_9182_hd_128_ps_128": 4096,
+    "hn_16_mcl_160000_nvl_16384_hd_128_ps_128": 16,
+    "hn_16_mcl_320000_nvl_1024_hd_128_ps_128": 8,
+    "hn_16_mcl_320000_nvl_2048_hd_128_ps_128": 128,
+    "hn_16_mcl_320000_nvl_4096_hd_128_ps_128": 256,
+    "hn_16_mcl_320000_nvl_9182_hd_128_ps_128": 1024,
+    "hn_16_mcl_320000_nvl_16384_hd_128_ps_128": 32,
+    "hn_16_mcl_640000_nvl_1024_hd_128_ps_128": 2,
+    "hn_16_mcl_640000_nvl_2048_hd_128_ps_128": 8,
+    "hn_16_mcl_640000_nvl_4096_hd_128_ps_128": 8,
+    "hn_16_mcl_640000_nvl_9182_hd_128_ps_128": 32,
+    "hn_16_mcl_640000_nvl_16384_hd_128_ps_128": 4,
+    "hn_16_mcl_1280000_nvl_1024_hd_128_ps_128": 32,
+    "hn_16_mcl_1280000_nvl_2048_hd_128_ps_128": 16,
+    "hn_16_mcl_1280000_nvl_4096_hd_128_ps_128": 128,
+    "hn_16_mcl_1280000_nvl_9182_hd_128_ps_128": 64,
+    "hn_16_mcl_1280000_nvl_16384_hd_128_ps_128": 2048,
+    "hn_32_mcl_80000_nvl_1024_hd_128_ps_128": 2,
+    "hn_32_mcl_80000_nvl_2048_hd_128_ps_128": 4,
+    "hn_32_mcl_80000_nvl_4096_hd_128_ps_128": 256,
+    "hn_32_mcl_80000_nvl_9182_hd_128_ps_128": 8,
+    "hn_32_mcl_80000_nvl_16384_hd_128_ps_128": 512,
+    "hn_32_mcl_160000_nvl_1024_hd_128_ps_128": 16,
+    "hn_32_mcl_160000_nvl_2048_hd_128_ps_128": 1024,
+    "hn_32_mcl_160000_nvl_4096_hd_128_ps_128": 512,
+    "hn_32_mcl_160000_nvl_9182_hd_128_ps_128": 8,
+    "hn_32_mcl_160000_nvl_16384_hd_128_ps_128": 4096,
+    "hn_32_mcl_320000_nvl_1024_hd_128_ps_128": 256,
+    "hn_32_mcl_320000_nvl_2048_hd_128_ps_128": 256,
+    "hn_32_mcl_320000_nvl_4096_hd_128_ps_128": 256,
+    "hn_32_mcl_320000_nvl_9182_hd_128_ps_128": 1024,
+    "hn_32_mcl_320000_nvl_16384_hd_128_ps_128": 4,
+    "hn_32_mcl_640000_nvl_1024_hd_128_ps_128": 512,
+    "hn_32_mcl_640000_nvl_2048_hd_128_ps_128": 4096,
+    "hn_32_mcl_640000_nvl_4096_hd_128_ps_128": 4,
+    "hn_32_mcl_640000_nvl_9182_hd_128_ps_128": 2,
+    "hn_32_mcl_640000_nvl_16384_hd_128_ps_128": 1024,
+    "hn_32_mcl_1280000_nvl_1024_hd_128_ps_128": 32,
+    "hn_32_mcl_1280000_nvl_2048_hd_128_ps_128": 2048,
+    "hn_32_mcl_1280000_nvl_4096_hd_128_ps_128": 128,
+    "hn_32_mcl_1280000_nvl_9182_hd_128_ps_128": 1024,
+    "hn_32_mcl_1280000_nvl_16384_hd_128_ps_128": 1024,
+    "hn_8_mcl_80000_nvl_1024_hd_128_ps_256": 2,
+    "hn_8_mcl_80000_nvl_2048_hd_128_ps_256": 4,
+    "hn_8_mcl_80000_nvl_4096_hd_128_ps_256": 2,
+    "hn_8_mcl_80000_nvl_9182_hd_128_ps_256": 512,
+    "hn_8_mcl_80000_nvl_16384_hd_128_ps_256": 2048,
+    "hn_8_mcl_160000_nvl_1024_hd_128_ps_256": 4,
+    "hn_8_mcl_160000_nvl_2048_hd_128_ps_256": 256,
+    "hn_8_mcl_160000_nvl_4096_hd_128_ps_256": 128,
+    "hn_8_mcl_160000_nvl_9182_hd_128_ps_256": 2048,
+    "hn_8_mcl_160000_nvl_16384_hd_128_ps_256": 2048,
+    "hn_8_mcl_320000_nvl_1024_hd_128_ps_256": 4,
+    "hn_8_mcl_320000_nvl_2048_hd_128_ps_256": 1024,
+    "hn_8_mcl_320000_nvl_4096_hd_128_ps_256": 64,
+    "hn_8_mcl_320000_nvl_9182_hd_128_ps_256": 16,
+    "hn_8_mcl_320000_nvl_16384_hd_128_ps_256": 512,
+    "hn_8_mcl_640000_nvl_1024_hd_128_ps_256": 1024,
+    "hn_8_mcl_640000_nvl_2048_hd_128_ps_256": 8,
+    "hn_8_mcl_640000_nvl_4096_hd_128_ps_256": 16,
+    "hn_8_mcl_640000_nvl_9182_hd_128_ps_256": 16,
+    "hn_8_mcl_640000_nvl_16384_hd_128_ps_256": 4096,
+    "hn_8_mcl_1280000_nvl_1024_hd_128_ps_256": 64,
+    "hn_8_mcl_1280000_nvl_2048_hd_128_ps_256": 2,
+    "hn_8_mcl_1280000_nvl_4096_hd_128_ps_256": 2048,
+    "hn_8_mcl_1280000_nvl_9182_hd_128_ps_256": 1024,
+    "hn_8_mcl_1280000_nvl_16384_hd_128_ps_256": 128,
+    "hn_16_mcl_80000_nvl_1024_hd_128_ps_256": 2,
+    "hn_16_mcl_80000_nvl_2048_hd_128_ps_256": 16,
+    "hn_16_mcl_80000_nvl_4096_hd_128_ps_256": 64,
+    "hn_16_mcl_80000_nvl_9182_hd_128_ps_256": 256,
+    "hn_16_mcl_80000_nvl_16384_hd_128_ps_256": 16,
+    "hn_16_mcl_160000_nvl_1024_hd_128_ps_256": 4,
+    "hn_16_mcl_160000_nvl_2048_hd_128_ps_256": 2,
+    "hn_16_mcl_160000_nvl_4096_hd_128_ps_256": 128,
+    "hn_16_mcl_160000_nvl_9182_hd_128_ps_256": 16,
+    "hn_16_mcl_160000_nvl_16384_hd_128_ps_256": 8,
+    "hn_16_mcl_320000_nvl_1024_hd_128_ps_256": 16,
+    "hn_16_mcl_320000_nvl_2048_hd_128_ps_256": 8,
+    "hn_16_mcl_320000_nvl_4096_hd_128_ps_256": 4,
+    "hn_16_mcl_320000_nvl_9182_hd_128_ps_256": 8,
+    "hn_16_mcl_320000_nvl_16384_hd_128_ps_256": 8,
+    "hn_16_mcl_640000_nvl_1024_hd_128_ps_256": 512,
+    "hn_16_mcl_640000_nvl_2048_hd_128_ps_256": 1024,
+    "hn_16_mcl_640000_nvl_4096_hd_128_ps_256": 2048,
+    "hn_16_mcl_640000_nvl_9182_hd_128_ps_256": 4096,
+    "hn_16_mcl_640000_nvl_16384_hd_128_ps_256": 32,
+    "hn_16_mcl_1280000_nvl_1024_hd_128_ps_256": 4,
+    "hn_16_mcl_1280000_nvl_2048_hd_128_ps_256": 2,
+    "hn_16_mcl_1280000_nvl_4096_hd_128_ps_256": 1024,
+    "hn_16_mcl_1280000_nvl_9182_hd_128_ps_256": 2048,
+    "hn_16_mcl_1280000_nvl_16384_hd_128_ps_256": 16,
+    "hn_32_mcl_80000_nvl_1024_hd_128_ps_256": 4,
+    "hn_32_mcl_80000_nvl_2048_hd_128_ps_256": 256,
+    "hn_32_mcl_80000_nvl_4096_hd_128_ps_256": 4096,
+    "hn_32_mcl_80000_nvl_9182_hd_128_ps_256": 128,
+    "hn_32_mcl_80000_nvl_16384_hd_128_ps_256": 512,
+    "hn_32_mcl_160000_nvl_1024_hd_128_ps_256": 64,
+    "hn_32_mcl_160000_nvl_2048_hd_128_ps_256": 4096,
+    "hn_32_mcl_160000_nvl_4096_hd_128_ps_256": 4096,
+    "hn_32_mcl_160000_nvl_9182_hd_128_ps_256": 256,
+    "hn_32_mcl_160000_nvl_16384_hd_128_ps_256": 128,
+    "hn_32_mcl_320000_nvl_1024_hd_128_ps_256": 4,
+    "hn_32_mcl_320000_nvl_2048_hd_128_ps_256": 64,
+    "hn_32_mcl_320000_nvl_4096_hd_128_ps_256": 1024,
+    "hn_32_mcl_320000_nvl_9182_hd_128_ps_256": 256,
+    "hn_32_mcl_320000_nvl_16384_hd_128_ps_256": 32,
+    "hn_32_mcl_640000_nvl_1024_hd_128_ps_256": 256,
+    "hn_32_mcl_640000_nvl_2048_hd_128_ps_256": 8,
+    "hn_32_mcl_640000_nvl_4096_hd_128_ps_256": 64,
+    "hn_32_mcl_640000_nvl_9182_hd_128_ps_256": 32,
+    "hn_32_mcl_640000_nvl_16384_hd_128_ps_256": 32,
+    "hn_32_mcl_1280000_nvl_1024_hd_128_ps_256": 256,
+    "hn_32_mcl_1280000_nvl_2048_hd_128_ps_256": 2048,
+    "hn_32_mcl_1280000_nvl_4096_hd_128_ps_256": 8,
+    "hn_32_mcl_1280000_nvl_9182_hd_128_ps_256": 4,
+    "hn_32_mcl_1280000_nvl_16384_hd_128_ps_256": 2,
+}


### PR DESCRIPTION
## Command

```bash
# start server

JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache  python3 -u -m sgl_jax.launch_server \
--model-path Qwen/Qwen3-8B \
--trust-remote-code  \
--dist-init-addr=0.0.0.0:10011 \
--nnodes=1  \
--tp-size=4 \
--device=tpu \
--random-seed=3 \
--node-rank=0 \
--mem-fraction-static=0.8 \
--chunked-prefill-size=2048 \
--download-dir=/tmp \
--dtype=bfloat16 \
--max-running-requests 256 \
--skip-server-warmup \
--page-size=64  \
--disable-radix-cache

# benchmark

python3 -m sgl_jax.bench_serving \
--backend sgl-jax \
--dataset-name random \
--num-prompts 16 \
--random-input 1024 \
--random-output 1024 \
--random-range-ratio 1 \
--warmup-requests 0
```


## Result

### Comparison with VLLM

`1Kin_1Kout_32bs`

**TTFT[Mean/Median]**
- SGL: 414.90/417.28ms
- VLLM: 440.42/439.84ms

**ITL[Mean/Median]**
- 14.00/12.56ms
- 12.87/12.56ms


### Improvement in kv_cache_update_kernel
236us -> 94us.

**new**
<img width="395" height="106" alt="image" src="https://github.com/user-attachments/assets/0a117f37-3a99-4021-94c6-489a03c24288" />

**old**
<img width="350" height="93" alt="image" src="https://github.com/user-attachments/assets/150effc0-17f0-4e10-8580-2943a6646d3c" />




## Accuracy

```bash
+---------+-----------+-----------------+----------+-------+---------+---------+
| Model   | Dataset   | Metric          | Subset   |   Num |   Score | Cat.0   |
+=========+===========+=================+==========+=======+=========+=========+
| Qwen-8B | gsm8k     | AverageAccuracy | main     |  1319 |  0.9113 | default |
+---------+-----------+-----------------+----------+-------+---------+---------+
```