### PR TITLE
fix install.md

### DIFF
--- a/docs/get_started/install.md
+++ b/docs/get_started/install.md
@@ -16,7 +16,7 @@ git clone https://github.com/sgl-project/sglang-jax
 cd sglang-jax
 
 # Install the python packages
-pip install --upgrade pip
+pip install --upgrade pip setuptools packaging
 pip install -e "python[all]"
 
 # Run Qwen-7B Model


### PR DESCRIPTION
Fix installation command to avoid potential pip/setuptools version mismatch. Otherwise ppl may encounter errors like TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'