### PR TITLE
feat: roll back kvheads replication

### DIFF
--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -168,10 +168,7 @@ class ModelConfig:
 
     # adapted from https://github.com/vllm-project/vllm/blob/main/vllm/config.py#L289
     def get_total_num_kv_heads(self) -> int:
-        """Returns the total number of KV heads (original, not padded)."""
-        # Use original value if it was overridden for TP
-        if hasattr(self, "_original_hf_num_key_value_heads"):
-            return self._original_hf_num_key_value_heads
+        """Returns the total number of KV heads."""
         # For GPTBigCode & Falcon:
         # NOTE: for falcon, when new_decoder_architecture is True, the
         # multi_query flag is ignored and we use n_head_kv for the number of
@@ -220,114 +217,12 @@ class ModelConfig:
 
     def get_num_kv_heads(self, tensor_parallel_size) -> int:
         """Returns the number of KV heads per GPU."""
-        from sgl_jax.srt.utils.jax_utils import get_num_kv_heads_by_tp
-
         total_num_kv_heads = self.get_total_num_kv_heads()
-        return get_num_kv_heads_by_tp(total_num_kv_heads, tensor_parallel_size)
-
-    def get_num_kv_heads_with_padding(self, tensor_parallel_size: int) -> int:
-        original_kv_heads = self.get_num_kv_heads(tensor_parallel_size)
-        return original_kv_heads + (original_kv_heads % 2)
-
-    def get_original_num_kv_heads(self, tensor_parallel_size: int) -> int:
-        return self.get_num_kv_heads(tensor_parallel_size)
-
-    def needs_kv_heads_padding(self, tensor_parallel_size: int) -> bool:
-        return self.get_num_kv_heads(tensor_parallel_size) % 2 == 1
-
-    def get_num_kv_head_replicas(self, tensor_parallel_size: int) -> int:
-        """Returns the number of replicas for each original KV head."""
-        from sgl_jax.srt.utils.jax_utils import get_num_kv_head_replicas
-
-        total_num_kv_heads = self.get_total_num_kv_heads()
-        return get_num_kv_head_replicas(total_num_kv_heads, tensor_parallel_size)
-
-    def needs_kv_head_replication(self, tensor_parallel_size: int) -> bool:
-        """Returns True if KV heads need to be replicated across devices."""
-        total_num_kv_heads = self.get_total_num_kv_heads()
-        return tensor_parallel_size >= total_num_kv_heads
-
-    def get_original_kv_head_id(self, tp_rank: int, tensor_parallel_size: int) -> int:
-        """Returns which original KV head this device should use."""
-        from sgl_jax.srt.utils.jax_utils import get_original_kv_head_id
-
-        total_num_kv_heads = self.get_total_num_kv_heads()
-        return get_original_kv_head_id(
-            tp_rank, total_num_kv_heads, tensor_parallel_size
-        )
-
-    def is_gqa_model(self) -> bool:
-        return self.get_total_num_kv_heads() < self.num_attention_heads
-
-    def get_kv_padding_strategy(self) -> str:
-        if self.is_gqa_model():
-            # GQA models should replicate existing kv heads to maintain attention semantics
-            return "replicate"
-        else:
-            # MHA models can use zero padding since all heads are equivalent
-            return "zero"
-
-    def log_kv_heads_padding_info(self, tensor_parallel_size: int):
-        """Log KV heads padding and replication information during initialization."""
-        original_kv_heads = self.get_original_num_kv_heads(tensor_parallel_size)
-        padded_kv_heads = self.get_num_kv_heads_with_padding(tensor_parallel_size)
-        needs_padding = self.needs_kv_heads_padding(tensor_parallel_size)
-        needs_replication = self.needs_kv_head_replication(tensor_parallel_size)
-        num_replicas = self.get_num_kv_head_replicas(tensor_parallel_size)
-
-        model_type = "GQA" if self.is_gqa_model() else "MHA"
-        total_original = self.get_total_num_kv_heads()
-
-        if needs_replication:
-            logger.info(
-                f"KV heads replication enabled for {model_type} model: "
-                f"total_kv_heads={total_original}, tp_size={tensor_parallel_size}, "
-                f"each device gets {original_kv_heads} head(s), "
-                f"each original head replicated {num_replicas} times"
-            )
-
-        if needs_padding:
-            total_padded = padded_kv_heads * tensor_parallel_size
-            logger.info(
-                f"KV heads padding enabled: "
-                f"kv_heads_per_device={original_kv_heads} -> padded={padded_kv_heads} "
-                f"(total effective: {total_padded}) for tiling optimization"
-            )
-        else:
-            logger.info(
-                f"KV heads padding not needed: kv_heads_per_device={original_kv_heads} is already even"
-            )
-
-    def configure_for_tensor_parallel(self, tensor_parallel_size: int):
-        """Configure model config for tensor parallel execution with padding."""
-        # Get per-device counts
-        padded_per_device = self.get_num_kv_heads_with_padding(tensor_parallel_size)
-
-        # Store original values for reference
-        self._original_num_key_value_heads = self.num_key_value_heads
-
-        # Handle cases where HF config doesn't have num_key_value_heads (MHA models)
-        if hasattr(self.hf_text_config, "num_key_value_heads"):
-            self._original_hf_num_key_value_heads = (
-                self.hf_text_config.num_key_value_heads
-            )
-        else:
-            # For MHA models without this attribute, it equals num_attention_heads
-            self._original_hf_num_key_value_heads = (
-                self.hf_text_config.num_attention_heads
-            )
-
-        # CRITICAL: Set to TOTAL padded count for global sharding
-        # JAX tensor parallel will automatically shard this across devices
-        padded_total = padded_per_device * tensor_parallel_size
-        self.num_key_value_heads = padded_total
-
-        # Only set HF config if the attribute exists, otherwise create it
-        if hasattr(self.hf_text_config, "num_key_value_heads"):
-            self.hf_text_config.num_key_value_heads = padded_total
-        else:
-            # For MHA models, dynamically add the attribute
-            setattr(self.hf_text_config, "num_key_value_heads", padded_total)
+        # If tensor parallelism is used, we divide the number of KV heads by
+        # the tensor parallel size. We will replicate the KV heads in the
+        # case where the number of KV heads is smaller than the tensor
+        # parallel size so each GPU has at least one KV head.
+        return max(1, total_num_kv_heads // tensor_parallel_size)
 
     # adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/config.py
     def _parse_quant_hf_config(self):

--- a/python/sgl_jax/srt/models/qwen3_moe.py
+++ b/python/sgl_jax/srt/models/qwen3_moe.py
@@ -406,13 +406,11 @@ class Qwen3MoeForCausalLM(nnx.Module):
                 target_path=f"{target_prefix}.self_attn.k_proj.weight",
                 sharding=(None, "tensor"),
                 transpose=True,
-                kv_head_padding=True,
             ),
             f"{prefix}.self_attn.v_proj.weight": WeightMapping(
                 target_path=f"{target_prefix}.self_attn.v_proj.weight",
                 sharding=(None, "tensor"),
                 transpose=True,
-                kv_head_padding=True,
             ),
             f"{prefix}.self_attn.o_proj.weight": WeightMapping(
                 target_path=f"{target_prefix}.self_attn.c_proj.weight",
@@ -442,13 +440,11 @@ class Qwen3MoeForCausalLM(nnx.Module):
                     target_path=f"{target_prefix}.self_attn.k_proj.bias",
                     sharding=(None,),
                     transpose=False,
-                    kv_head_padding=True,
                 ),
                 f"{prefix}.self_attn.v_proj.bias": WeightMapping(
                     target_path=f"{target_prefix}.self_attn.v_proj.bias",
                     sharding=(None,),
                     transpose=False,
-                    kv_head_padding=True,
                 ),
                 f"{prefix}.self_attn.o_proj.bias": WeightMapping(
                     target_path=f"{target_prefix}.self_attn.c_proj.bias",

--- a/python/sgl_jax/srt/utils/jax_utils.py
+++ b/python/sgl_jax/srt/utils/jax_utils.py
@@ -4,64 +4,6 @@ import jax.numpy as jnp
 from jax.sharding import NamedSharding, PartitionSpec
 
 
-def get_num_kv_heads_by_tp(total_num_kv_heads: int, tp_size: int) -> int:
-    """
-    Calculate the number of KV heads per device for tensor parallelism.
-
-    Args:
-        total_num_kv_heads: Total number of KV heads in the model
-        tp_size: Tensor parallel size (number of devices)
-
-    Returns:
-        Number of KV heads per device
-    """
-    if tp_size >= total_num_kv_heads:
-        # When tp_size >= total_kv_heads, each device gets 1 KV head
-        # Multiple devices will replicate the same original KV head
-        return 1
-    else:
-        # Normal case: divide KV heads across devices
-        return (total_num_kv_heads + tp_size - 1) // tp_size
-
-
-def get_num_kv_head_replicas(total_num_kv_heads: int, tp_size: int) -> int:
-    """
-    Calculate how many replicas each original KV head has across devices.
-
-    Args:
-        total_num_kv_heads: Total number of KV heads in the model
-        tp_size: Tensor parallel size (number of devices)
-
-    Returns:
-        Number of replicas per original KV head
-    """
-    if tp_size >= total_num_kv_heads:
-        return (tp_size + total_num_kv_heads - 1) // total_num_kv_heads
-    else:
-        return 1
-
-
-def get_original_kv_head_id(tp_rank: int, total_num_kv_heads: int, tp_size: int) -> int:
-    """
-    Determine which original KV head this device should replicate.
-
-    Args:
-        tp_rank: Current device rank (0-based)
-        total_num_kv_heads: Total number of KV heads in the model
-        tp_size: Tensor parallel size
-
-    Returns:
-        ID of the original KV head to replicate (0-based)
-    """
-    if tp_size >= total_num_kv_heads:
-        num_kv_head_replicas = get_num_kv_head_replicas(total_num_kv_heads, tp_size)
-        return tp_rank // num_kv_head_replicas
-    else:
-        # Normal case: each device gets a different range of KV heads
-        kv_heads_per_device = get_num_kv_heads_by_tp(total_num_kv_heads, tp_size)
-        return (tp_rank * kv_heads_per_device) % total_num_kv_heads
-
-
 def get_available_device_memory(device, distributed=False, empty_cache=True):
     """
     Get available memory for device:device_id.


### PR DESCRIPTION
fix https://github.com/sgl-project/sglang-jax/issues/193
# Performance
## Qwen3-8B
1024 Input 1024 Output
```
============ Serving Benchmark Result ============
Backend:                                 sgl-jax
Traffic request rate:                    inf
Max request concurrency:                 128
Successful requests:                     384
Benchmark duration (s):                  58.60
Total input tokens:                      393216
Total generated tokens:                  393216
Total generated tokens (retokenized):    392839
Request throughput (req/s):              6.55
Input token throughput (tok/s):          6710.72
Output token throughput (tok/s):         6710.72
Total token throughput (tok/s):          13421.43
Concurrency:                             127.66
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   19479.11
Median E2E Latency (ms):                 19463.84
---------------Time to First Token----------------
Mean TTFT (ms):                          966.67
Median TTFT (ms):                        943.85
P99 TTFT (ms):                           1795.40
---------------Inter-Token Latency----------------
Mean ITL (ms):                           18.10
Median ITL (ms):                         17.18
P95 ITL (ms):                            18.08
P99 ITL (ms):                            18.49
Max ITL (ms):                            1614.95
==================================================

4096 Input 1024 Output

============ Serving Benchmark Result ============
Backend:                                 sgl-jax
Traffic request rate:                    inf
Max request concurrency:                 128
Successful requests:                     384
Benchmark duration (s):                  133.87
Total input tokens:                      1572864
Total generated tokens:                  393216
Total generated tokens (retokenized):    392071
Request throughput (req/s):              2.87
Input token throughput (tok/s):          11749.27
Output token throughput (tok/s):         2937.32
Total token throughput (tok/s):          14686.59
Concurrency:                             116.21
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   40513.86
Median E2E Latency (ms):                 36912.65
---------------Time to First Token----------------
Mean TTFT (ms):                          9183.51
Median TTFT (ms):                        4310.03
P99 TTFT (ms):                           38219.82
---------------Inter-Token Latency----------------
Mean ITL (ms):                           30.63
Median ITL (ms):                         28.95
P95 ITL (ms):                            29.70
P99 ITL (ms):                            30.03
Max ITL (ms):                            7060.86
==================================================
```

# Accuracy
```
+---------------------+-----------+-----------------+----------+-------+---------+---------+
| Model               | Dataset   | Metric          | Subset   |   Num |   Score | Cat.0   |
+=====================+===========+=================+==========+=======+=========+=========+
| Qwen2.5-7B-Instruct | gsm8k     | AverageAccuracy | main     |  1319 |  0.8514 | default |
+---------------------+-----------+-----------------+----------+-------+---------+---------+

+---------------+-----------+-----------------+----------+-------+---------+---------+
| Model         | Dataset   | Metric          | Subset   |   Num |   Score | Cat.0   |
+===============+===========+=================+==========+=======+=========+=========+
| Qwen3-30B-A3B | gsm8k     | AverageAccuracy | main     |  1319 |  0.9378 | default |
+---------------+-----------+-----------------+----------+-------+---------+---------+
```