### PR TITLE
CPU: native attention fallback + legacy KVCache path to enable sglang_jax launch

### DIFF
--- a/python/sgl_jax/srt/utils/jax_utils.py
+++ b/python/sgl_jax/srt/utils/jax_utils.py
@@ -109,4 +109,3 @@ def is_tpu_runtime() -> bool:
         return len(devs) > 0 and all(d.platform == "tpu" for d in devs)
     except Exception:
         return jax.default_backend() == "tpu"
-

--- a/python/sgl_jax/srt/utils/jax_utils.py
+++ b/python/sgl_jax/srt/utils/jax_utils.py
@@ -97,3 +97,16 @@ def device_array(mesh, *data, sharding=None, **kwargs) -> jax.Array:
     if sharding is None:
         sharding = NamedSharding(mesh, PartitionSpec())
     return jax.device_put(*data, device=sharding, **kwargs)
+
+
+def is_tpu_runtime() -> bool:
+    """Return True if the current JAX runtime is on TPU devices.
+
+    Prefer checking actual devices; fall back to default backend if necessary.
+    """
+    try:
+        devs = jax.devices()
+        return len(devs) > 0 and all(d.platform == "tpu" for d in devs)
+    except Exception:
+        return jax.default_backend() == "tpu"
+


### PR DESCRIPTION
**Related:** [#204](https://github.com/sgl-project/sglang-jax/issues/204)

## Motivation
This is not a fundamental CPU limitation. Rather:
- The CPU backend is **not currently supported** for some paths, and
- The existing CPU path is **not well supported** (incomplete / inconsistent with GPU).

```
  File "/root/project/llm/sglang-jax/python/sgl_jax/srt/mem_cache/memory_pool.py", line 603, in kv_cache_update_kernel
    async_copy.start()
  File "/root/miniforge3/envs/py312-cuda/lib/python3.12/site-packages/jax/_src/pallas/mosaic/primitives.py", line 215, in start
    dma_start_p.bind(
jax._src.source_info_util.JaxStackTraceBeforeTransformation: TypeError: Shapes must be 1D sequences of concrete values of integer type, got (Traced<int32[]>with<DynamicJaxprTrace>, 16, 128).
If using `jit`, try using `static_argnums` or applying `jit` to smaller subfunctions.
The error occurred while tracing the function kv_cache_update_kernel at /root/project/llm/sglang-jax/python/sgl_jax/srt/mem_cache/memory_pool.py:576 for pallas_call kernel. This concrete value was not available in Python because it depends on the value of the argument slices_ref.
```

## Current issues on CPU
- `FlashAttention` is unavailable on CPU.
- `KVCache.set_kv_buffer` is **not CPU-compatible** and raises at runtime.

## This PR achieves
1. When `device="cpu"`, the attention backend **falls back to the native implementation**.
2. `sglang_jax` **launches successfully on CPU** by using the **legacy** path `KVCache.set_kv_buffer_legacy` instead of `KVCache.set_kv_buffer`.

```
# JAX_PLATFORMS=cpu JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -u -m sgl_jax.launch_server   --model-path Qwen/Qwen3-0.6B   --device=cpu   --xla-backend=cpu   --mem-fraction-static=0.2   --max-prefill-tokens=64   --max-running-requests=1  --log-requests --log-requests-level=2 --log-level-http=debug --show-time-cost --decode-log-interval=1 --enable-request-time-stats-logging
[2025-09-20 22:13:42] server_args=ServerArgs(model_path='Qwen/Qwen3-0.6B', tokenizer_path='Qwen/Qwen3-0.6B', tokenizer_mode='auto', skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=False, context_length=None, is_embedding=False, revision=None, model_impl='auto', host='127.0.0.1', port=30000, skip_server_warmup=False, warmups=None, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', mem_fraction_static=0.2, max_running_requests=1, max_total_tokens=None, max_prefill_tokens=64, chunked_prefill_size=4096, enable_mixed_chunk=False, schedule_policy='fcfs', schedule_conservativeness=1.0, page_size=1, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, device='cpu', tp_size=1, stream_interval=1, stream_output=False, random_seed=42, constrained_json_whitespace_pattern=None, watchdog_timeout=300, dist_timeout=None, download_dir=None, sleep_on_idle=False, dp_size=1, log_level='info', log_level_http='debug', log_requests=True, log_requests_level=2, crash_dump_folder=None, show_time_cost=True, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, decode_log_interval=1, enable_request_time_stats_logging=True, kv_events_config=None, api_key=None, served_model_name='Qwen/Qwen3-0.6B', file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, tool_call_parser=None, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, disable_radix_cache=False, allow_auto_truncate=False, enable_tokenizer_batch_encode=False, disable_overlap_schedule=False, enable_precision_tracer=False, jax_proc_id=None, jax_num_procs=None, xla_backend='cpu', attention_backend='fa', max_seq_len=4096, precompile_token_paddings=None, precompile_bs_paddings=None, disable_jax_precompile=False)
[2025-09-20 22:13:47] Precision tracer globally disabled
[2025-09-20 22:13:47] KV heads distribution for GQA model: original_kv_heads=8, tp_size=1, each device gets 8 head(s), no replication needed, padding_strategy=replicate
Fetching 10 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 114286.21it/s]
[2025-09-20 22:13:47] QWen3ForCausalLMModel config dtype: <class 'jax.numpy.bfloat16'>
[LOADING] MODEL WEIGHTS:   0%|                                                                                                                                                                       | 0/1 [00:00<?, ?file/s, file=model.safetensors][2025-09-20 22:13:54] No mapping found for weight: lm_head.weight
[LOADING] MODEL WEIGHTS: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:05<00:00,  5.24s/file, file=model.safetensors]
[2025-09-20 22:13:59] Qwen3 weights loaded successfully!
[2025-09-20 22:13:59] ModelRunner kv_cache_dtype: <class 'jax.numpy.bfloat16'>
[2025-09-20 22:13:59] TPU Memory profiling: available_device_memory=69.5GB, available_kv_cache=11.3GB, max_tokens=105982, cell_size=114688bytes
[2025-09-20 22:13:59] ModelRunner max_total_num_tokens: 105982
[2025-09-20 22:13:59] Creating fused KV buffers for 28 layers
[2025-09-20 22:13:59] Total fused KV cache memory per layer: 0.20 GB, dtype: <class 'jax.numpy.bfloat16'>
[2025-09-20 22:14:01] Total time to create 28 buffers: 1.98 seconds
[2025-09-20 22:14:01] JAX Fused KV Cache allocated. #tokens: 105982, Fused KV size: 11.32 GB
[2025-09-20 22:14:01] FlashAttention backend is not supported on CPU; falling back to native.
[2025-09-20 22:14:01] Max running requests constraints:
[2025-09-20 22:14:01]   - Server limit: 1 (configured)
[2025-09-20 22:14:01]   - Token pool size: 2
[2025-09-20 22:14:01]   - Attention backend: 4096 (context_len=40960, page_size=1)
[2025-09-20 22:14:01]   → Final max_running_requests: 1
[2025-09-20 22:14:01] [Scheduler] Begins to run worker precompile.
[2025-09-20 22:14:01] [ModelWorkerClient] Begins to run resolve_future_token_ids precompile.
[2025-09-20 22:14:01] [ModelWorkerClient] Completes resolve_future_token_ids precompile. Time cost: 0.04723843187093735 seconds
[2025-09-20 22:14:01] [EXTEND] Begin to precompile bs_paddings=[1] token_paddings=[64]
[EXTEND] PRECOMPILE:   0%|                                                                                                                                                                                    | 0/1 [00:00<?, ?it/s, bs=1, tokens=64]/root/miniforge3/envs/py312-cuda/lib/python3.12/site-packages/jax/_src/interpreters/mlir.py:1233: UserWarning: Some donated buffers were not usable: int32[64], int32[1], int32[64], int32[64], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], bfloat16[105983,16,128], int32[40959], int32[1], int32[1].
See an explanation at https://docs.jax.dev/en/latest/faq.html#buffer-donation.
  warnings.warn("Some donated buffers were not usable:"
[2025-09-20 22:14:13] [EXTEND] Precompile finished in 11 secs
[2025-09-20 22:14:13] [DECODE] Begin to precompile bs_paddings=[1]
[DECODE] PRECOMPILE:   0%|                                                                                                                                                                                               | 0/1 [00:00<?, ?it/s, bs=1]/root/miniforge3/envs/py312-cuda/lib/python3.12/site-packages/jax/_src/interpreters/mlir.py:1233: UserWarning: Some donated buffers were not usable: int32[1], int32[1], int32[1], int32[1], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], bfloat16[64,16,128], int32[40959].
See an explanation at https://docs.jax.dev/en/latest/faq.html#buffer-donation.
  warnings.warn("Some donated buffers were not usable:"
[2025-09-20 22:14:16] [DECODE] Precompile finished in 4 secs
[2025-09-20 22:14:16] [Scheduler] Completes worker precompile.
[2025-09-20 22:14:16] INFO:     Started server process [517190]
[2025-09-20 22:14:16] INFO:     Waiting for application startup.
[2025-09-20 22:14:16] INFO:     Application startup complete.
[2025-09-20 22:14:16] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2025-09-20 22:14:17] INFO:     127.0.0.1:38626 - "GET /get_model_info HTTP/1.1" 200 OK
```

## Implementation notes
- Gate CPU execution to skip `FlashAttention` and select the native attention backend.
- Route CPU to `KVCache.set_kv_buffer_legacy` to avoid the non-CPU-compatible `set_kv_buffer`.
- No behavior change for GPU paths.
