### PR TITLE
[feature] integrate with tunix

### DIFF
--- a/python/sgl_jax/srt/entrypoints/engine.py
+++ b/python/sgl_jax/srt/entrypoints/engine.py
@@ -206,6 +206,9 @@ class Engine(EngineBase):
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
         return await generator.__anext__()
+    
+    def get_default_sampling_params(self):
+        pass
 
     def rerank(
         self,

--- a/python/sgl_jax/srt/entrypoints/engine.py
+++ b/python/sgl_jax/srt/entrypoints/engine.py
@@ -26,14 +26,17 @@ import uvloop
 
 from sgl_jax.srt.entrypoints.EngineBase import EngineBase
 from sgl_jax.srt.hf_transformers_utils import get_generation_config
-from sgl_jax.srt.managers.detokenizer_manager import run_detokenizer_process
+from sgl_jax.srt.managers.detokenizer_manager import (
+    run_detokenizer_process,
+    run_detokenizer_thread,
+)
 from sgl_jax.srt.managers.io_struct import (
     EmbeddingReqInput,
     GenerateReqInput,
     ReleaseMemoryOccupationReqInput,
     ResumeMemoryOccupationReqInput,
 )
-from sgl_jax.srt.managers.scheduler import run_scheduler_process
+from sgl_jax.srt.managers.scheduler import run_scheduler_process, run_scheduler_thread
 from sgl_jax.srt.managers.template_manager import TemplateManager
 from sgl_jax.srt.managers.tokenizer_manager import TokenizerManager
 from sgl_jax.srt.sampling.sampling_params import SamplingParams
@@ -43,6 +46,7 @@ from sgl_jax.srt.utils import (
     get_zmq_socket,
     kill_process_tree,
     launch_dummy_health_check_server,
+    pathways_available,
     prepare_model_and_tokenizer,
     set_ulimit,
 )
@@ -88,10 +92,12 @@ class Engine(EngineBase):
         self.port_args = PortArgs.init_new(server_args)
         logger.info(f"{server_args=}")
 
-        # Launch subprocesses
-        tokenizer_manager, template_manager, scheduler_info = _launch_subprocesses(
-            server_args=server_args,
-            port_args=self.port_args,
+        # Launch subprocesses or threads
+        tokenizer_manager, template_manager, scheduler_info = (
+            _launch_subprocesses_or_threads(
+                server_args=server_args,
+                port_args=self.port_args,
+            )
         )
         self.server_args = server_args
         self.tokenizer_manager = tokenizer_manager
@@ -235,6 +241,8 @@ class Engine(EngineBase):
     def shutdown(self):
         """Shutdown the engine"""
         kill_process_tree(os.getpid(), include_parent=False)
+        if pathways_available():
+            self.send_to_rpc.close()
 
     def __enter__(self):
         return self
@@ -418,9 +426,14 @@ def _set_envs_and_config():
         kill_process_tree(os.getpid())
 
     signal.signal(signal.SIGQUIT, sigquit_handler)
+    if not pathways_available():
+        # Set mp start method
+        mp.set_start_method("spawn", force=True)
+    else:
+        ## close resource tracker process
+        from multiprocessing import resource_tracker
 
-    # Set mp start method
-    mp.set_start_method("spawn", force=True)
+        resource_tracker._resource_tracker._fd = -1
 
 
 def _launch_subprocesses(
@@ -524,3 +537,117 @@ def _launch_subprocesses(
     scheduler_info = scheduler_infos[0]
     tokenizer_manager.max_req_input_len = scheduler_info["max_req_input_len"]
     return tokenizer_manager, template_manager, scheduler_info
+
+
+def _launch_threads(
+    server_args, port_args: Optional[PortArgs] = None
+) -> Tuple[TokenizerManager, TemplateManager, Dict]:
+    # Configure global environment
+    configure_logger(server_args)
+    server_args.check_server_args()
+    _set_envs_and_config()
+
+    # Allocate ports for inter-process communications
+    if port_args is None:
+        port_args = PortArgs.init_new(server_args)
+        logger.info(f"{server_args=}")
+
+    # If using model from www.modelscope.cn, first download the model.
+    server_args.model_path, server_args.tokenizer_path = prepare_model_and_tokenizer(
+        server_args.model_path, server_args.tokenizer_path
+    )
+
+    scheduler_threads = []
+    if server_args.dp_size == 1:
+        scheduler_pipe_readers = []
+        reader, writer = mp.Pipe(duplex=False)
+        thread = threading.Thread(
+            target=run_scheduler_thread,
+            args=(
+                server_args,
+                port_args,
+                None,
+                writer,
+            ),
+            daemon=True,
+        )
+        # with memory_saver_adapter.configure_subprocess():
+        thread.start()
+        scheduler_threads.append(thread)
+        scheduler_pipe_readers.append(reader)
+    else:
+        pass
+
+    if server_args.node_rank >= 1:
+        # In multi-node cases, non-zero rank nodes do not need to run tokenizer or detokenizer,
+        # so they can just wait here.
+
+        for reader in scheduler_pipe_readers:
+            data = reader.recv()
+            assert data["status"] == "ready"
+
+        if os.getenv("SGLANG_BLOCK_NONZERO_RANK_CHILDREN") == "0":
+            # When using `Engine` as a Python API, we don't want to block here.
+            return None, None, None
+
+        launch_dummy_health_check_server(server_args.host, server_args.port)
+
+        for thread in scheduler_threads:
+            thread.join()
+            logger.error(
+                f"Scheduler or DataParallelController {thread.name} terminated"
+            )
+        return None, None, None
+
+    # Launch detokenizer thread
+    detoken_thread = threading.Thread(
+        target=run_detokenizer_thread,
+        args=(
+            server_args,
+            port_args,
+        ),
+        daemon=True,
+    )
+    detoken_thread.start()
+
+    # Launch tokenizer process
+    tokenizer_manager = TokenizerManager(server_args, port_args)
+
+    # Initialize templates
+    template_manager = TemplateManager()
+    template_manager.initialize_templates(
+        model_path=server_args.model_path,
+    )
+
+    # Wait for the model to finish loading
+    scheduler_infos = []
+    for i in range(len(scheduler_pipe_readers)):
+        try:
+            data = scheduler_pipe_readers[i].recv()
+        except EOFError:
+            logger.error(
+                f"Node {i} jax_scheduler is dead. Please check if there are relevant logs."
+            )
+            scheduler_threads[i].join()
+            logger.error(f"{scheduler_threads[i].name} eof")
+            raise
+
+        if data["status"] != "ready":
+            raise RuntimeError(
+                "Initialization failed. Please see the error messages above."
+            )
+        scheduler_infos.append(data)
+
+    # Assume all schedulers have the same scheduler_info
+    scheduler_info = scheduler_infos[0]
+    tokenizer_manager.max_req_input_len = scheduler_info["max_req_input_len"]
+    return tokenizer_manager, template_manager, scheduler_info
+
+
+def _launch_subprocesses_or_threads(
+    server_args, port_args: Optional[PortArgs] = None
+) -> Tuple[TokenizerManager, TemplateManager, Dict]:
+    if pathways_available():
+        return _launch_threads(server_args, port_args)
+    else:
+        return _launch_subprocesses(server_args, port_args)

--- a/python/sgl_jax/srt/entrypoints/engine.py
+++ b/python/sgl_jax/srt/entrypoints/engine.py
@@ -389,6 +389,8 @@ class Engine(EngineBase):
                     if self.default_sampling_params.get(p) is not None
                 }
                 self.default_sampling_params = diff_sampling_param
+            else:
+                self.default_sampling_params = {}
 
         if self.default_sampling_params:
             return SamplingParams(**self.default_sampling_params)

--- a/python/sgl_jax/srt/entrypoints/engine.py
+++ b/python/sgl_jax/srt/entrypoints/engine.py
@@ -217,9 +217,6 @@ class Engine(EngineBase):
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
         return await generator.__anext__()
-    
-    def get_default_sampling_params(self):
-        pass
 
     def rerank(
         self,

--- a/python/sgl_jax/srt/entrypoints/http_server.py
+++ b/python/sgl_jax/srt/entrypoints/http_server.py
@@ -30,7 +30,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse, Response, StreamingResponse
 
-from sgl_jax.srt.entrypoints.engine import _launch_subprocesses
+from sgl_jax.srt.entrypoints.engine import _launch_subprocesses_or_threads
 from sgl_jax.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     CompletionRequest,
@@ -809,8 +809,8 @@ def launch_server(
     # Initialize precision tracer enable state in HTTP server process
     precision_tracer.set_enable_precision_tracer(server_args.enable_precision_tracer)
 
-    tokenizer_manager, template_manager, scheduler_info = _launch_subprocesses(
-        server_args=server_args, port_args=None
+    tokenizer_manager, template_manager, scheduler_info = (
+        _launch_subprocesses_or_threads(server_args=server_args, port_args=None)
     )
     set_global_state(
         _GlobalState(

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -101,14 +101,14 @@ class FlashAttention(AttentionBackend):
             cu_q_lens = np.concatenate(
                 [
                     np.array([0], dtype=np.int32),
-                    np.cumsum(batch.extend_seq_lens),
+                    np.cumsum(batch.extend_seq_lens, dtype=np.int32),
                 ]
             )
         elif batch.forward_mode == ForwardMode.DECODE:
-            cu_q_lens = jnp.concatenate(
+            cu_q_lens = np.concatenate(
                 [
-                    np.array([0], dtype=jnp.int32),
-                    np.cumsum(jnp.ones(len(batch.seq_lens), dtype=np.int32)),
+                    np.array([0], dtype=np.int32),
+                    np.cumsum(np.ones(len(batch.seq_lens), dtype=np.int32)),
                 ]
             )
         else:

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -132,6 +132,7 @@ class Req:
         stream: bool = False,
         origin_input_ids_unpadded: Optional[Tuple[int]] = None,
         eos_token_ids: Optional[Set[int]] = None,
+        vocab_size: Optional[int] = None,
     ):
         # Input and output info
         self.rid = rid
@@ -165,6 +166,7 @@ class Req:
         self.to_abort_message: str = None
         self.stream = stream
         self.eos_token_ids = eos_token_ids
+        self.vocab_size = vocab_size
 
         # For incremental decoding
         # ----- | --------- read_ids -------|
@@ -371,6 +373,16 @@ class Req:
             if matched_eos:
                 self.finished_reason = FINISH_MATCHED_TOKEN(matched=last_token_id)
                 return
+
+        if self.vocab_size is not None and (
+            last_token_id > self.vocab_size or last_token_id < 0
+        ):
+            if self.sampling_params.stop_token_ids:
+                self.output_ids[-1] = next(iter(self.sampling_params.stop_token_ids))
+            elif self.eos_token_ids:
+                self.output_ids[-1] = next(iter(self.eos_token_ids))
+            self.finished_reason = FINISH_MATCHED_STR(matched="NaN happened")
+            return
 
         # Check stop strings
         if len(self.sampling_params.stop_strs) > 0:

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -47,6 +47,7 @@ INIT_INCREMENTAL_DETOKENIZATION_OFFSET = 5
 GLOBAL_SERVER_ARGS_KEYS = [
     "device",
     "disable_radix_cache",
+    "enable_deterministic_sampling",
 ]
 
 PADDING_BUCKETS = [1 << i for i in range(6, 21)]

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -558,6 +558,7 @@ class Scheduler(
             token_ids_logprob=recv_req.token_ids_logprob,
             stream=recv_req.stream,
             eos_token_ids=self.model_config.hf_eos_token_id,
+            vocab_size=self.model_config.vocab_size,
         )
         req.tokenizer = self.tokenizer
 

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1102,3 +1102,45 @@ def run_scheduler_process(
         traceback = get_exception_traceback()
         logger.error(f"Scheduler hit an exception: {traceback}")
         parent_process.send_signal(signal.SIGQUIT)
+
+
+def run_scheduler_thread(
+    server_args: ServerArgs,
+    port_args: PortArgs,
+    dp_rank: Optional[int],
+    pipe_writer,
+):
+    # Generate the prefix
+    prefix = ""
+    if server_args.nnodes > 1:
+        prefix += f" NP{server_args.node_rank}"
+
+    # Config the process
+    current_thread = threading.current_thread()
+    current_thread.name = f"sglang::scheduler{prefix.replace(' ', '_')}"
+    faulthandler.enable()
+    current_process = psutil.Process()
+
+    # Configure the logger
+    configure_logger(server_args, prefix=prefix)
+
+    # Create a scheduler and run the event loop
+    try:
+        scheduler = Scheduler(server_args, port_args)
+        pipe_writer.send(
+            {
+                "status": "ready",
+                "max_total_num_tokens": scheduler.max_total_num_tokens,
+                "max_req_input_len": scheduler.max_req_input_len,
+            }
+        )
+
+        if scheduler.enable_overlap:
+            scheduler.event_loop_overlap()
+        else:
+            scheduler.event_loop_normal()
+
+    except Exception:
+        traceback = get_exception_traceback()
+        logger.error(f"Scheduler hit an exception: {traceback}")
+        current_process.send_signal(signal.SIGQUIT)

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -142,6 +142,12 @@ class SchedulerOutputProcessorMixin:
                         logprob_pt += num_input_logprobs
 
         batch.cache_miss_count = cache_miss_count
+
+        if batch.cache_miss_count > 0:
+            logger.info(
+                f"Prefill batch. #bid: {result.bid}, #cache_miss: {cache_miss_count}"
+            )
+
         self.stream_output(
             batch.reqs, batch.return_logprob, skip_stream_req, cache_miss_count
         )

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -934,8 +934,10 @@ class TokenizerManager:
 
             if isinstance(recv_obj, BatchStrOut):
                 state.text += recv_obj.output_strs[i]
+                state.output_ids += recv_obj.output_ids[i]
                 out_dict = {
                     "text": state.text,
+                    "output_ids": state.output_ids,
                     "meta_info": meta_info,
                 }
             elif isinstance(recv_obj, BatchTokenIDOut):

--- a/python/sgl_jax/srt/sampling/sampling_batch_info.py
+++ b/python/sgl_jax/srt/sampling/sampling_batch_info.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING, List, Optional
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from jax.tree_util import register_pytree_node_class
 
-from sgl_jax.srt.sampling.sampling_params import TOP_K_ALL
+from sgl_jax.srt.sampling.sampling_params import DEFAULT_SAMPLING_SEED, TOP_K_ALL
+from sgl_jax.srt.utils import get_bool_env_var
 from sgl_jax.srt.utils.jax_utils import device_array
 
 if TYPE_CHECKING:
@@ -40,6 +41,7 @@ class SamplingMetadata:
     top_ps: jax.Array
     top_ks: jax.Array
     min_ps: jax.Array
+    sampling_seeds: jax.Array
     is_all_greedy: bool = False
     need_min_p_sampling: bool = False
 
@@ -49,14 +51,15 @@ class SamplingMetadata:
             self.top_ps,
             self.top_ks,
             self.min_ps,
+            self.sampling_seeds,
+            self.is_all_greedy,
+            self.need_min_p_sampling,
         )
 
         aux_data = {
             "return_logprob": self.return_logprob,
             "top_logprobs_nums": self.top_logprobs_nums,
             "token_ids_logprobs": self.token_ids_logprobs,
-            "is_all_greedy": self.is_all_greedy,
-            "need_min_p_sampling": self.need_min_p_sampling,
         }
         return (children, aux_data)
 
@@ -68,12 +71,13 @@ class SamplingMetadata:
         obj.top_ps = children[1]
         obj.top_ks = children[2]
         obj.min_ps = children[3]
+        obj.sampling_seeds = children[4]
+        obj.is_all_greedy = children[5]
+        obj.need_min_p_sampling = children[6]
 
         obj.return_logprob = aux_data["return_logprob"]
         obj.top_logprobs_nums = aux_data["top_logprobs_nums"]
         obj.token_ids_logprobs = aux_data["token_ids_logprobs"]
-        obj.is_all_greedy = aux_data["is_all_greedy"]
-        obj.need_min_p_sampling = aux_data["need_min_p_sampling"]
 
         return obj
 
@@ -84,6 +88,9 @@ class SamplingMetadata:
         pad_size: int = 0,
         mesh: Mesh = None,
     ) -> SamplingMetadata:
+        sharding = (
+            NamedSharding(mesh, PartitionSpec()) if jax.process_count() == 1 else None
+        )
         padded_temperatures = np.concat(
             [
                 batch.sampling_info.temperatures,
@@ -101,7 +108,7 @@ class SamplingMetadata:
         padded_top_ks = np.concat(
             [
                 batch.sampling_info.top_ks,
-                np.array([-1] * pad_size, dtype=batch.sampling_info.top_ks.dtype),
+                np.array([1] * pad_size, dtype=batch.sampling_info.top_ks.dtype),
             ]
         )
         padded_min_ps = np.concat(
@@ -110,15 +117,26 @@ class SamplingMetadata:
                 np.array([0.0] * pad_size, dtype=batch.sampling_info.min_ps.dtype),
             ]
         )
+        if batch.sampling_info.sampling_seeds is not None:
+            padded_sampling_seeds = np.concat(
+                [
+                    batch.sampling_info.sampling_seeds,
+                    np.array(
+                        [DEFAULT_SAMPLING_SEED] * pad_size,
+                        dtype=batch.sampling_info.sampling_seeds.dtype,
+                    ),
+                ]
+            )
+            sampling_seeds_device = device_array(
+                padded_sampling_seeds, sharding=sharding
+            )
+        else:
+            sampling_seeds_device = None
 
         (temperatures_device, top_ps_device, top_ks_device, min_ps_device) = (
             device_array(
                 (padded_temperatures, padded_top_ps, padded_top_ks, padded_min_ps),
-                sharding=(
-                    NamedSharding(mesh, PartitionSpec())
-                    if jax.process_count() == 1
-                    else None
-                ),
+                sharding=sharding,
             )
         )
 
@@ -130,6 +148,7 @@ class SamplingMetadata:
             top_ps=top_ps_device,
             top_ks=top_ks_device,
             min_ps=min_ps_device,
+            sampling_seeds=sampling_seeds_device,
             is_all_greedy=batch.sampling_info.is_all_greedy,
             need_min_p_sampling=batch.sampling_info.need_min_p_sampling,
         )
@@ -162,12 +181,26 @@ class SamplingBatchInfo:
     # An event used for overlap schedule
     sampling_info_done: Optional[threading.Event] = None
 
+    sampling_seeds: Optional[np.ndarray] = None
+
+    @classmethod
+    def _get_global_server_args_dict(cls):
+        from sgl_jax.srt.managers.schedule_batch import global_server_args_dict
+
+        return global_server_args_dict
+
     @classmethod
     def generate_for_precompile(cls, bs: int):
-        temperatures = np.array([1.0 for _ in range(bs)], dtype=np.float32)
-        top_ps = np.array([1.0 for _ in range(bs)], dtype=np.float32)
-        top_ks = np.array([-1 for _ in range(bs)], dtype=np.int32)
-        min_ps = np.array([0.0 for _ in range(bs)], dtype=np.float32)
+        temperatures = np.array([0.6 for _ in range(bs)], dtype=np.float32)
+        top_ps = np.array([0.9 for _ in range(bs)], dtype=np.float32)
+        top_ks = np.array([30 for _ in range(bs)], dtype=np.int32)
+        min_ps = np.array([0.6 for _ in range(bs)], dtype=np.float32)
+        if get_bool_env_var("SGLANG_ENABLE_DETERMINISTIC_SAMPLING"):
+            sampling_seeds = np.array(
+                [DEFAULT_SAMPLING_SEED for _ in range(bs)], dtype=np.int32
+            )
+        else:
+            sampling_seeds = None
 
         ret = cls(
             temperatures=temperatures,
@@ -176,14 +209,17 @@ class SamplingBatchInfo:
             min_ps=min_ps,
             is_all_greedy=True,
             need_top_p_sampling=False,
-            need_top_k_sampling=True,
-            need_min_p_sampling=False,
+            need_top_k_sampling=False,
+            need_min_p_sampling=True,
             sampling_info_done=None,
+            sampling_seeds=sampling_seeds,
         )
         return ret
 
     @classmethod
     def from_schedule_batch(cls, batch: ScheduleBatch, vocab_size: int):
+        global_server_args_dict = cls._get_global_server_args_dict()
+        enable_deterministic = global_server_args_dict["enable_deterministic_sampling"]
         reqs = batch.reqs
         temperatures = np.array(
             [r.sampling_params.temperature for r in reqs],
@@ -192,6 +228,15 @@ class SamplingBatchInfo:
         top_ps = np.array([r.sampling_params.top_p for r in reqs], dtype=np.float32)
         top_ks = np.array([r.sampling_params.top_k for r in reqs], dtype=np.int32)
         min_ps = np.array([r.sampling_params.min_p for r in reqs], dtype=np.float32)
+
+        sampling_seeds = (
+            np.array(
+                [r.sampling_params.sampling_seed for r in reqs],
+                dtype=np.int32,
+            )
+            if enable_deterministic
+            else None
+        )
 
         ret = cls(
             temperatures=temperatures,
@@ -202,6 +247,7 @@ class SamplingBatchInfo:
             need_top_p_sampling=any(r.sampling_params.top_p != 1.0 for r in reqs),
             need_top_k_sampling=any(r.sampling_params.top_k != TOP_K_ALL for r in reqs),
             need_min_p_sampling=any(r.sampling_params.min_p > 0 for r in reqs),
+            sampling_seeds=sampling_seeds,
         )
         return ret
 
@@ -217,9 +263,11 @@ class SamplingBatchInfo:
             "top_ps",
             "top_ks",
             "min_ps",
+            "sampling_seeds",
         ]:
             value = getattr(self, item, None)
-            setattr(self, item, value[keep_indices])
+            if value is not None:
+                setattr(self, item, value[keep_indices])
 
     def merge_batch(self, other: "SamplingBatchInfo", mesh: Mesh):
         # Note: because the __len()__ operator is defined on the temperatures tensor,
@@ -230,10 +278,12 @@ class SamplingBatchInfo:
             "top_ps",
             "top_ks",
             "min_ps",
+            "sampling_seeds",
         ]:
             self_val = getattr(self, item, None)
             other_val = getattr(other, item, None)
-            setattr(self, item, np.concat([self_val, other_val]))
+            if self_val is not None and other_val is not None:
+                setattr(self, item, np.concat([self_val, other_val]))
 
         self.is_all_greedy &= other.is_all_greedy
         self.need_top_p_sampling |= other.need_top_p_sampling

--- a/python/sgl_jax/srt/sampling/sampling_params.py
+++ b/python/sgl_jax/srt/sampling/sampling_params.py
@@ -78,10 +78,6 @@ class SamplingParams:
             sampling_seed = DEFAULT_SAMPLING_SEED
         self.sampling_seed = sampling_seed
 
-        print(
-            f"[sampling_params__init__] {get_bool_env_var("SGLANG_ENABLE_DETERMINISTIC_SAMPLING")}"
-        )
-
         # Process some special cases
         if 0 <= self.temperature < _SAMPLING_EPS:
             # top_k = 1 means greedy sampling

--- a/python/sgl_jax/srt/sampling/sampling_params.py
+++ b/python/sgl_jax/srt/sampling/sampling_params.py
@@ -148,3 +148,27 @@ class SamplingParams:
                 else:
                     stop_str_max_len = max(stop_str_max_len, len(stop_str))
             self.stop_str_max_len = stop_str_max_len
+
+    def convert_to_dict(self) -> Dict:
+        # Start with a copy of all instance attributes
+        result = {}
+        for key, value in self.__dict__.items():
+            if key.startswith("_"):
+                continue
+
+            # Handle special conversions
+            if key == "stop_token_ids":
+                # Convert set back to list, or None
+                result[key] = list(value) if value is not None else None
+            # elif key == "top_k":
+            #    # Restore -1 if it was set to TOP_K_ALL
+            #    from sgl_jax.srt.sampling.sampling_params import TOP_K_ALL  # or wherever it's defined
+            #    result[key] = -1 if value == TOP_K_ALL else value
+            elif key == "stop_strs":
+                # The API expects "stop", not "stop_strs"
+                result["stop"] = value
+            else:
+                # Pass through all other fields as-is
+                result[key] = value
+
+        return result

--- a/python/sgl_jax/srt/sampling/sampling_params.py
+++ b/python/sgl_jax/srt/sampling/sampling_params.py
@@ -2,8 +2,11 @@
 
 from typing import Dict, List, Optional, Union
 
+from sgl_jax.srt.utils import get_bool_env_var
+
 _SAMPLING_EPS = 1e-6
 TOP_K_ALL = 1 << 30
+DEFAULT_SAMPLING_SEED = 42
 
 
 class SamplingParams:
@@ -39,6 +42,7 @@ class SamplingParams:
         no_stop_trim: bool = False,
         stream_interval: Optional[int] = None,
         logit_bias: Optional[Dict[str, float]] = None,
+        sampling_seed: Optional[int] = None,
     ) -> None:
         self.max_new_tokens = max_new_tokens
         self.stop_strs = stop
@@ -65,6 +69,18 @@ class SamplingParams:
         self.no_stop_trim = no_stop_trim
         self.stream_interval = stream_interval
         self.logit_bias = logit_bias
+        # Used for deterministic sampling
+        if (
+            get_bool_env_var("SGLANG_ENABLE_DETERMINISTIC_SAMPLING")
+            and sampling_seed is None
+        ):
+            # If deterministic sampling is enabled and sampling_seed is not set, use the default seed
+            sampling_seed = DEFAULT_SAMPLING_SEED
+        self.sampling_seed = sampling_seed
+
+        print(
+            f"[sampling_params__init__] {get_bool_env_var("SGLANG_ENABLE_DETERMINISTIC_SAMPLING")}"
+        )
 
         # Process some special cases
         if 0 <= self.temperature < _SAMPLING_EPS:

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -130,6 +130,9 @@ class ServerArgs:
 
     disable_jax_precompile: bool = False
 
+    # For deterministic sampling
+    enable_deterministic_sampling: bool = False
+
     def __post_init__(self):
         # Set missing default values
         if self.tokenizer_path is None:
@@ -182,6 +185,10 @@ class ServerArgs:
                     "Disabling chunked prefill."
                 )
                 self.chunked_prefill_size = -1
+
+        os.environ["SGLANG_ENABLE_DETERMINISTIC_SAMPLING"] = (
+            "1" if self.enable_deterministic_sampling else "0"
+        )
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):
@@ -755,6 +762,13 @@ class ServerArgs:
             ],
             default=ServerArgs.attention_backend,
             help="Choose the kernels for attention layers.",
+        )
+
+        # For deterministic sampling
+        parser.add_argument(
+            "--enable-deterministic-sampling",
+            action="store_true",
+            help="Enable deterministic sampling",
         )
 
     @classmethod

--- a/python/sgl_jax/srt/utils/__init__.py
+++ b/python/sgl_jax/srt/utils/__init__.py
@@ -13,3 +13,4 @@ from .common_utils import (
     set_ulimit,
     set_uvicorn_logging_configs,
 )
+from .tunix_utils import pathways_available

--- a/python/sgl_jax/srt/utils/tunix_utils.py
+++ b/python/sgl_jax/srt/utils/tunix_utils.py
@@ -1,0 +1,8 @@
+# refer to tunix
+def pathways_available() -> bool:
+    try:
+        import pathwaysutils  # pylint: disable=g-import-not-at-top, unused-import
+
+        return True
+    except ImportError:
+        return False

--- a/python/sgl_jax/test/test_sampler.py
+++ b/python/sgl_jax/test/test_sampler.py
@@ -1,0 +1,109 @@
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.layers.sampler import multinomial_with_seed
+
+
+class TestMultinomialWithSeed(unittest.TestCase):
+
+    def test_deterministic_sampling_with_same_seed(self):
+        """Test that same (inputs, seed) pair always yields the same sample."""
+        # Setup test data
+        batch_size = 4
+        vocab_size = 10
+
+        # Create logits that simulate different temperature scenarios
+        flatter_distribution = jnp.array(
+            [
+                [1.0, 1.1, 0.9, 1.2, 0.8, 1.3, 0.7, 1.4, 0.6, 1.5],
+                [2.0, 2.1, 1.9, 2.2, 1.8, 2.3, 1.7, 2.4, 1.6, 2.5],
+                [0.5, 0.6, 0.4, 0.7, 0.3, 0.8, 0.2, 0.9, 0.1, 1.0],
+                [3.0, 3.1, 2.9, 3.2, 2.8, 3.3, 2.7, 3.4, 2.6, 3.5],
+            ],
+            dtype=jnp.bfloat16,
+        )
+
+        flatter_distribution_processed = jax.nn.softmax(flatter_distribution, axis=-1)
+
+        shaper_distribution = jnp.array(
+            [
+                [1.0, 5.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [2.0, 2.0, 8.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                [0.5, 0.5, 0.5, 7.0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5],
+                [3.0, 3.0, 3.0, 3.0, 9.0, 3.0, 3.0, 3.0, 3.0, 3.0],
+            ],
+            dtype=jnp.bfloat16,
+        )
+
+        shaper_distribution_processed = jax.nn.softmax(shaper_distribution, axis=-1)
+
+        seeds = jnp.array([12345, 67890, 54321, 98765])
+        positions = jnp.array([0, 1, 2, 3])
+
+        test_cases = [
+            ("flatter_distribution", flatter_distribution_processed),
+            ("shaper_distribution", shaper_distribution_processed),
+        ]
+
+        for test_name, inputs in test_cases:
+            with self.subTest(test_name=test_name):
+                # Sample multiple times with the same inputs and seeds
+                samples = []
+                for _ in range(10):  # Run 10 times
+                    sample = multinomial_with_seed((inputs, seeds, positions, None))
+                    samples.append(sample)
+
+                # All samples should be identical
+                first_sample = samples[0]
+                for i, sample in enumerate(samples[1:], 1):
+                    np.testing.assert_array_equal(
+                        first_sample,
+                        sample,
+                        f"Sample {i} differs from first sample for {test_name}",
+                    )
+
+    def test_different_seeds_produce_different_samples(self):
+        """Test that different seeds produce different samples (with high probability)."""
+        batch_size = 1
+        vocab_size = 10
+
+        inputs = jnp.ones((batch_size, vocab_size), dtype=jnp.bfloat16) * 0.1
+        inputs = jax.nn.softmax(inputs, axis=-1)
+        positions = jnp.array([0])
+
+        seeds = [jnp.array([1]), jnp.array([2]), jnp.array([12345]), jnp.array([98765])]
+
+        samples = []
+        for seed in seeds:
+            sample = multinomial_with_seed((inputs, seed, positions, None))
+            samples.append(sample)
+
+        original_len = len(samples)
+        unique_samples = set(tuple(sample.flatten().tolist()) for sample in samples)
+        self.assertEqual(original_len, len(unique_samples))
+
+    def test_output_shape_and_range(self):
+        """Test that output has correct shape and values are in valid range."""
+        batch_size = 3
+        vocab_size = 7
+
+        inputs = jnp.ones((batch_size, vocab_size), dtype=jnp.bfloat16)
+        inputs = jax.nn.softmax(inputs, axis=-1)
+        seeds = jnp.array([1, 2, 3])
+        positions = jnp.array([0, 1, 2])
+
+        sample = multinomial_with_seed((inputs, seeds, positions, None))
+
+        expected_shape = (batch_size, 1)  # Function returns keepdims=True
+        self.assertEqual(sample.shape, expected_shape)
+
+        self.assertTrue(jnp.all(sample >= 0))
+        self.assertTrue(jnp.all(sample < vocab_size))
+        self.assertTrue(sample.dtype in [jnp.int32, jnp.int64])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -150,6 +150,7 @@ suites = {
         TestFile("test/srt/openai_server/basic/test_serving_completions.py", 10),
         TestFile("test/srt/openai_server/basic/test_openai_server.py", 10),
         TestFile("test/srt/test_qwen2_5_models.py", 15),
+        TestFile("test/srt/test_srt_engine.py", 15),
     ],
     "per-commit-tpu-v6e-2": [],
     "per-commit-tpu-v6e-4": [

--- a/test/srt/test_features.py
+++ b/test/srt/test_features.py
@@ -124,18 +124,32 @@ class TestFeatures(CustomTestCase):
                     future.result()["meta_info"]["finish_reason"]["type"], "abort"
                 )
 
-    def test_cache_miss(self):
+    def test_cache_miss_prefill(self):
         args = SimpleNamespace(
             base_url=self.base_url,
             text="the capital of France is",
             temperature=0,
-            max_new_tokens=6,
+            max_new_tokens=1,
         )
 
         resp = run_curl(args)
 
         if "cache_miss_count" not in resp["meta_info"]:
-            raise "cache_miss_count is missed in response"
+            raise "[prefill] cache_miss_count is missed in response"
+        self.assertEqual(resp["meta_info"]["cache_miss_count"], 0)
+
+    def test_cache_miss_decode(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            text="the capital of France is",
+            temperature=0,
+            max_new_tokens=2,
+        )
+
+        resp = run_curl(args)
+
+        if "cache_miss_count" not in resp["meta_info"]:
+            raise "[prefill] cache_miss_count is missed in response"
         self.assertEqual(resp["meta_info"]["cache_miss_count"], 0)
 
     def test_logprobs(self):

--- a/test/srt/test_srt_engine.py
+++ b/test/srt/test_srt_engine.py
@@ -1,0 +1,112 @@
+"""
+Usage:
+python3 -m unittest test_srt_engine.TestSRTEngine.test_1_engine_prompt_ids_output_ids
+"""
+
+from typing import List
+
+from sgl_jax.srt.entrypoints.engine import Engine
+from sgl_jax.srt.hf_transformers_utils import get_tokenizer
+from sgl_jax.srt.sampling.sampling_params import SamplingParams
+from sgl_jax.test.test_utils import QWEN3_8B, CustomTestCase
+
+
+class TestSRTEngine(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model_path = QWEN3_8B
+        cls.engine = Engine(
+            model_path=cls.model_path,
+            trust_remote_code=True,
+            tp_size=1,
+            device="tpu",
+            random_seed=3,
+            node_rank=0,
+            mem_fraction_static=0.6,
+            chunked_prefill_size=1024,
+            download_dir="/tmp",
+            dtype="bfloat16",
+            precompile_bs_paddings=[8],
+            max_running_requests=8,
+            skip_server_warmup=True,
+            attention_backend="fa",
+            precompile_token_paddings=[1024],
+            page_size=64,
+            log_requests=False,
+        )
+        cls.tokenizer = get_tokenizer(cls.model_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.engine.shutdown()
+
+    def tokenize(self, input_string: str) -> List[int]:
+        """Tokenizes the input string."""
+        tokenizer = TestSRTEngine.tokenizer
+        input_ids = tokenizer.encode(input_string)
+        bos_tok = (
+            [tokenizer.bos_token_id]
+            if tokenizer.bos_token_id is not None
+            and tokenizer.bos_token_id
+            and input_ids[0] != tokenizer.bos_token_id
+            else []
+        )
+        eos_tok = (
+            [tokenizer.eos_token_id]
+            if tokenizer.eos_token_id is not None
+            and input_ids[-1] != tokenizer.eos_token_id
+            else []
+        )
+        return bos_tok + input_ids + eos_tok
+
+    def test_1_engine_prompt_ids_output_ids(self):
+        input_strings = ["the capital of China is", "the capital of France is"]
+
+        sampling_params = TestSRTEngine.engine.get_default_sampling_params()
+        sampling_params.max_new_tokens = 10
+        sampling_params.n = 1
+        sampling_params.temperature = 0
+        sampling_params.stop_token_ids = [TestSRTEngine.tokenizer.eos_token_id]
+        sampling_params.skip_special_tokens = True
+
+        sampling_params_dict = sampling_params.convert_to_dict()
+
+        prompt_ids_list = [self.tokenize(x) for x in input_strings]
+        outputs = TestSRTEngine.engine.generate(
+            input_ids=prompt_ids_list,
+            sampling_params=[sampling_params_dict] * 2,
+        )
+
+        self.assertEqual(len(outputs), 2)
+        for item in outputs:
+            decoded_output = TestSRTEngine.tokenizer.decode(
+                item["output_ids"],
+                True,
+            )
+            self.assertEqual(decoded_output, item["text"])
+
+    def test_2_engine_prompt_ids_with_sample_n_output_ids(self):
+        input_strings = ["the capital of China is", "the capital of France is"]
+
+        sampling_params = TestSRTEngine.engine.get_default_sampling_params()
+        sampling_params.max_new_tokens = 10
+        sampling_params.n = 2
+        sampling_params.temperature = 0
+        sampling_params.stop_token_ids = [TestSRTEngine.tokenizer.eos_token_id]
+        sampling_params.skip_special_tokens = True
+
+        sampling_params_dict = sampling_params.convert_to_dict()
+
+        prompt_ids_list = [self.tokenize(x) for x in input_strings]
+        outputs = TestSRTEngine.engine.generate(
+            input_ids=prompt_ids_list,
+            sampling_params=[sampling_params_dict] * 2,
+        )
+
+        self.assertEqual(len(outputs), 4)
+        for item in outputs:
+            decoded_output = TestSRTEngine.tokenizer.decode(
+                item["output_ids"],
+                True,
+            )
+            self.assertEqual(decoded_output, item["text"])

--- a/test/srt/test_srt_engine.py
+++ b/test/srt/test_srt_engine.py
@@ -33,6 +33,7 @@ class TestSRTEngine(CustomTestCase):
             precompile_token_paddings=[1024],
             page_size=64,
             log_requests=False,
+            enable_deterministic_sampling=True,
         )
         cls.tokenizer = get_tokenizer(cls.model_path)
 
@@ -110,3 +111,134 @@ class TestSRTEngine(CustomTestCase):
                 True,
             )
             self.assertEqual(decoded_output, item["text"])
+
+    def test_3_engine_sampling_temperature_top_p_top_k_min_p(self):
+        input_strings = ["the capital of France is"]
+
+        def get_sampling_params(max_new_tokens: int = 1):
+            sampling_params = TestSRTEngine.engine.get_default_sampling_params()
+            sampling_params.max_new_tokens = max_new_tokens
+            sampling_params.n = max_new_tokens
+            sampling_params.temperature = 0
+            sampling_params.stop_token_ids = [TestSRTEngine.tokenizer.eos_token_id]
+            sampling_params.skip_special_tokens = True
+            return sampling_params
+
+        def update_sampling_params(
+            params: SamplingParams,
+            temperature: float = None,
+            top_p: float = None,
+            top_k: int = None,
+            min_p: float = None,
+            sampling_seed: int = None,
+        ):
+            if temperature is not None:
+                params.temperature = temperature
+            if top_p is not None:
+                params.top_p = top_p
+            if top_k is not None:
+                params.top_k = top_k
+            if min_p is not None:
+                params.min_p = min_p
+            if sampling_seed is not None:
+                params.sampling_seed = sampling_seed
+
+        cases = {
+            "[greedy] temperature[0.0]_top_p[1.0]_top_k[-1]_min_p[0.0]": (
+                0.0,
+                1.0,
+                -1,
+                0.0,
+            ),
+            "[greedy] temperature[0.5]_top_p[1.0]_top_k[1]_min_p[0.0]": (
+                0.5,
+                1.0,
+                1,
+                0.0,
+            ),
+            "[not_greedy_top_p_0.9] temperature[0.6]_top_p[0.9]_top_k[-1]_min_p[0.0]": (
+                0.6,
+                0.9,
+                -1,
+                0.0,
+            ),
+            "[not_greedy_top_k_10] temperature[0.6]_top_p[1.0]_top_k[10]_min_p[0.0]": (
+                0.6,
+                1.0,
+                10,
+                0.0,
+            ),
+            "[not_greedy_min_p_0.5] temperature[0.6]_top_p[1.0]_top_k[-1]_min_p[0.5]": (
+                0.6,
+                1.0,
+                -1,
+                0.5,
+            ),  # need_min_p_sampling
+            "[not_greedy_sampling_seed_36] temperature[0.6]_top_p[1.0]_top_k[-1]_min_p[0.0]_sampling_seed[36]": (
+                0.5,
+                1.0,
+                -1,
+                0.0,
+                36,
+            ),
+            "[not_greedy_tempeture_top_p_top_min_p_sampling_seed] temperature[0.5]_top_p[0.9]_top_k[10]_min_p[0.5]_sampling_seed[40]": (
+                0.5,
+                0.9,
+                10,
+                0.5,
+                40,
+            ),
+        }
+
+        prompt_ids_list = [self.tokenize(x) for x in input_strings]
+
+        # prefill
+        sampling_params_prefill = get_sampling_params(1)
+        for case_name, args in cases.items():
+            print(f"[prefill, {case_name}] begins to run")
+            update_sampling_params(sampling_params_prefill, *args)
+            sampling_params_dict = sampling_params_prefill.convert_to_dict()
+            outputs = TestSRTEngine.engine.generate(
+                input_ids=prompt_ids_list,
+                sampling_params=sampling_params_dict,
+            )
+            self.assertEqual(int(outputs[0]["meta_info"]["cache_miss_count"]), 0)
+
+        # decode
+        sampling_params_decode = get_sampling_params(2)
+        for case_name, args in cases.items():
+            print(f"[decode, {case_name}] begins to run")
+            update_sampling_params(sampling_params_decode, *args)
+            sampling_params_dict = sampling_params_decode.convert_to_dict()
+            outputs = TestSRTEngine.engine.generate(
+                input_ids=prompt_ids_list,
+                sampling_params=sampling_params_dict,
+            )
+            self.assertEqual(int(outputs[0]["meta_info"]["cache_miss_count"]), 0)
+
+    def test_4_engine_prompt_ids_with_sample_n_output_ids(self):
+        input_strings = ["the capital of China is"]
+
+        sampling_params = TestSRTEngine.engine.get_default_sampling_params()
+        sampling_params.max_new_tokens = 10
+        sampling_params.n = 20
+        sampling_params.temperature = 0
+        sampling_params.stop_token_ids = [TestSRTEngine.tokenizer.eos_token_id]
+        sampling_params.skip_special_tokens = True
+        # sampling_params.sampling_seed= 30
+
+        sampling_params_dict = sampling_params.convert_to_dict()
+
+        prompt_ids_list = [self.tokenize(x) for x in input_strings]
+        outputs = TestSRTEngine.engine.generate(
+            input_ids=prompt_ids_list,
+            sampling_params=[sampling_params_dict] * 2,
+        )
+
+        # self.assertEqual(len(outputs), 4)
+        # for item in outputs:
+        #     decoded_output = TestSRTEngine.tokenizer.decode(
+        #         item["output_ids"],
+        #         True,
+        #     )
+        #     self.assertEqual(decoded_output, item["text"])


### PR DESCRIPTION
Note: This PR ensures the ability which is required in SGLang-JAX for [RFC](https://github.com/sgl-project/sglang-jax/pull/202).

## Command
```bash
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache \
python3 -u -m sgl_jax.launch_server \
--model-path Qwen/Qwen3-8B \
--trust-remote-code  \
--tp-size=4 \
--device=tpu \
--mem-fraction-static=0.8 \
--chunked-prefill-size=2048 \
--download-dir=/tmp \
--dtype=bfloat16 \
--max-running-requests 256 \
--skip-server-warmup \
--page-size=128  \
--disable-radix-cache --enable-deterministic-sampling 
# Note: The `--enable-deterministic-sampling` can be enabled if you want to sample deterministically.

evalscope eval  --model Qwen-8B --api-url http://127.0.0.1:30000/v1/chat/completions --api-key EMPTY --eval-type service --datasets gsm8k --eval-batch-size 64

python3 -m sgl_jax.bench_serving --backend sgl-jax --dataset-name random --num-prompts 48 --random-input 1024 --random-output 1024 --random-range-ratio 1 --warmup-requests 0 --max-concurrency=16
```

## Accurancy

**not deterministic**

```bash
+---------+-----------+-----------------+----------+-------+---------+---------+
| Model   | Dataset   | Metric          | Subset   |   Num |   Score | Cat.0   |
+=========+===========+=================+==========+=======+=========+=========+
| Qwen-8B | gsm8k     | AverageAccuracy | main     |  1319 |  0.9007 | default |
+---------+-----------+-----------------+----------+-------+---------+---------+
```

**deterministic**

```bash
+---------+-----------+-----------------+----------+-------+---------+---------+
| Model   | Dataset   | Metric          | Subset   |   Num |   Score | Cat.0   |
+=========+===========+=================+==========+=======+=========+=========+
| Qwen-8B | gsm8k     | AverageAccuracy | main     |  1319 |  0.9067 | default |
+---------+-----------+-----------------+----------+-------+---------+---------+
```


## Benchmark

**not deterministic**

```bash
============ Serving Benchmark Result ============
Backend:                                 sgl-jax
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     48
Benchmark duration (s):                  20.11
Total input tokens:                      49152
Total generated tokens:                  49152
Total generated tokens (retokenized):    49113
Request throughput (req/s):              2.39
Input token throughput (tok/s):          2444.40
Output token throughput (tok/s):         2444.40
Total token throughput (tok/s):          4888.79
Concurrency:                             15.99
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6698.71
Median E2E Latency (ms):                 6472.44
---------------Time to First Token----------------
Mean TTFT (ms):                          158.84
Median TTFT (ms):                        162.05
P99 TTFT (ms):                           262.57
---------------Inter-Token Latency----------------
Mean ITL (ms):                           6.39
Median ITL (ms):                         6.04
P95 ITL (ms):                            6.33
P99 ITL (ms):                            6.55
Max ITL (ms):                            227.34
==================================================
```

**deterministic**

```bash
============ Serving Benchmark Result ============
Backend:                                 sgl-jax
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     48
Benchmark duration (s):                  19.34
Total input tokens:                      49152
Total generated tokens:                  49152
Total generated tokens (retokenized):    49113
Request throughput (req/s):              2.48
Input token throughput (tok/s):          2541.48
Output token throughput (tok/s):         2541.48
Total token throughput (tok/s):          5082.96
Concurrency:                             15.99
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6442.53
Median E2E Latency (ms):                 6420.83
---------------Time to First Token----------------
Mean TTFT (ms):                          160.10
Median TTFT (ms):                        163.43
P99 TTFT (ms):                           263.42
---------------Inter-Token Latency----------------
Mean ITL (ms):                           6.14
Median ITL (ms):                         6.02
P95 ITL (ms):                            6.35
P99 ITL (ms):                            6.53
Max ITL (ms):                            227.31
==================================================
```

