### PR TITLE
fix: cache loc miss when page_size > 1

### DIFF
--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -241,11 +241,17 @@ class ModelWorker:
         ) as pbar:
             for bs in pbar:
                 pbar.set_postfix(bs=bs)
+                # use same page aligned with precompile cache_loc_paddings
+                aligned_cache_loc_size = (
+                    (bs * self.max_req_len + self.page_size - 1)
+                    // self.page_size
+                    * self.page_size
+                )
                 model_worker_batch = self.generate_model_worker_batch(
                     bs,
                     bs,
                     ForwardMode.DECODE,
-                    bs * self.max_req_len,
+                    aligned_cache_loc_size,
                 )
                 sampling_metadata = SamplingMetadata.from_model_worker_batch(
                     model_worker_batch, 0, self.mesh


### PR DESCRIPTION
fix  cache loc miss when page_size > 1, Introduced in https://github.com/sgl-project/sglang-jax/pull/215

```
[2025-09-25 07:54:09] Prefill batch. #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0,
Debug: total_aligned_length=128, precompiled=10485504, actual=10485504
Debug: total_aligned_length=128, precompiled=40960, actual=40960
DEBUG:2025-09-25 07:54:10,681:jax._src.dispatch:198: Finished tracing + transforming jitted_run_model for pjit in 0.741432667 sec
[2025-09-25 07:54:10] Finished tracing + transforming jitted_run_model for pjit in 0.741432667 sec
Debug: total_aligned_length=128, precompiled=40960, actual=40960
WARNING:2025-09-25 07:54:11,605:jax._src.pjit:1346: TRACING CACHE MISS at /home/gcpuser/sky_workdir/pm/sglang-jax/python/sgl_jax/srt/model_executor/model_runner.py:372 (_forward) costing 741.726 ms because:
  for jitted_run_model defined at /home/gcpuser/sky_workdir/pm/sglang-jax/python/sgl_jax/srt/model_executor/model_runner.py:129
  all previously seen cache keys are different. Closest previous key:
  * key with different input types:
      types now: model_state_leaves[0]: bf16[151936,4096], model_state_leaves[1]: u32[], m...
        * at forward_batch[8], now i32[40960] and before i32[40959]
[2025-09-25 07:54:11] TRACING CACHE MISS at /home/gcpuser/sky_workdir/pm/sglang-jax/python/sgl_jax/srt/model_executor/model_runner.py:372 (_forward) costing 741.726 ms because:
  for jitted_run_model defined at /home/gcpuser/sky_workdir/pm/sglang-jax/python/sgl_jax/srt/model_executor/model_runner.py:129
  all previously seen cache keys are different. Closest previous key:
  * key with different input types:
      types now: model_state_leaves[0]: bf16[151936,4096], model_state_leaves[1]: u32[], m...
        * at forward_batch[8], now i32[40960] and before i32[40959]
```