### PR TITLE
test: fix test_flashattention mesh

### DIFF
--- a/python/sgl_jax/test/test_flashattention.py
+++ b/python/sgl_jax/test/test_flashattention.py
@@ -229,7 +229,11 @@ def create_test_data(
 
     # init attention backend
     attention_backend = FlashAttention(
-        num_heads, num_kv_heads, head_dim, page_size=page_size
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        page_size=page_size,
+        mesh=mesh,
     )
     forward_mode = ForwardMode.EXTEND if mode == "prefill" else ForwardMode.DECODE
 


### PR DESCRIPTION
Fix a bug introduced in https://github.com/sgl-project/sglang-jax/pull/198/files where FlashAttention is not constructed correctly in test_flash_attention.py

the err msg was:
```
Test JAX attention accuracy against native fa
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/bytedance/sglang-jax/python/sgl_jax/srt/utils/common_utils.py", line 378, in retry
    return fn()
  File "/home/bytedance/sglang-jax/python/sgl_jax/test/test_utils.py", line 138, in <lambda>
    lambda: super(CustomTestCase, self)._callTestMethod(method),
  File "/usr/lib/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()
  File "/home/bytedance/sglang-jax/python/sgl_jax/test/test_flashattention.py", line 599, in test_gqa_decode_accuracy_page_size_64
    self.run_test(
  File "/home/bytedance/sglang-jax/python/sgl_jax/test/test_flashattention.py", line 298, in run_test
    forward_batch, q, k, v = create_test_data(
  File "/home/bytedance/sglang-jax/python/sgl_jax/test/test_flashattention.py", line 274, in create_test_data
    fb.attn_backend.forward_metadata = attention_backend.get_forward_metadata(mwb)
  File "/home/bytedance/sglang-jax/python/sgl_jax/srt/layers/attention/flashattention_backend.py", line 155, in get_forward_metadata
    NamedSharding(self.mesh, P()) if jax.process_count() == 1 else None
TypeError: __init__(): incompatible function arguments. The following argument types are supported:
    1. __init__(self, mesh: object, spec: object, memory_kind: object | None = None, _logical_device_ids: object | None = None) -> None

Invoked with types: jax.sharding.NamedSharding, NoneType, jax.sharding.PartitionSpec
```