### PR TITLE
fix: model dtype in torch env

### DIFF
--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -437,19 +437,6 @@ _STR_DTYPE_TO_JAX_DTYPE = {
 }
 
 
-def _convert_torch_dtype_to_jax(config_dtype) -> Optional[jnp.dtype]:
-    # In order not to import pytorch package
-    # ugly way for convert pytorch dtype to jax dtype but works :)
-    if (
-        hasattr(config_dtype, "__module__")
-        and config_dtype.__module__
-        and "torch" in config_dtype.__module__
-        and hasattr(config_dtype, "__name__")
-    ):
-        return _STR_DTYPE_TO_JAX_DTYPE.get(config_dtype.__name__, None)
-    return None
-
-
 def _get_and_verify_dtype(
     config: PretrainedConfig,
     dtype: Union[str, jnp.dtype],
@@ -458,7 +445,9 @@ def _get_and_verify_dtype(
     if isinstance(config_dtype, str):
         config_dtype = _STR_DTYPE_TO_JAX_DTYPE.get(config_dtype, None)
     elif config_dtype is not None:
-        config_dtype = _convert_torch_dtype_to_jax(config_dtype)
+        config_dtype = _STR_DTYPE_TO_JAX_DTYPE.get(
+            str(config_dtype).replace("torch.", ""), None
+        )
 
     if config_dtype is None:
         config_dtype = jnp.float32


### PR DESCRIPTION
fix  model dtype in torch env when use auto dtype config bootstrap