### PR TITLE
feat: avoid zero nnx params initialization to accelerate server startup

### DIFF
--- a/python/sgl_jax/srt/layers/layernorm.py
+++ b/python/sgl_jax/srt/layers/layernorm.py
@@ -1,49 +1,176 @@
-from functools import partial
-from typing import Optional, Sequence, Tuple, Union
+from typing import Any, Iterable, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
 from flax import nnx
+from flax.nnx import rnglib
+from flax.nnx.nn import dtypes, initializers
+from flax.typing import Array, Axes, Dtype, Initializer
 from jax import lax
 
 
-class RMSNorm(nnx.Module):
-    """RMS normalization."""
+def _canonicalize_axes(rank: int, axes: Axes) -> Tuple[int, ...]:
+    """Returns a tuple of deduplicated, sorted, and positive axes."""
+    if not isinstance(axes, Iterable):
+        axes = (axes,)
+    return tuple({rank + axis if axis < 0 else axis for axis in axes})
 
+
+def _abs_sq(x):
+    """Computes the elementwise square of the absolute value |x|^2."""
+    if jnp.iscomplexobj(x):
+        return lax.square(lax.real(x)) + lax.square(lax.imag(x))
+    else:
+        return lax.square(x)
+
+
+class RMSNorm(nnx.Module):
     def __init__(
         self,
-        hidden_size: int,
+        num_features: int,
+        *,
         epsilon: float = 1e-6,
-        kernel_axes: Optional[Sequence[str]] = None,
-        rngs: nnx.Rngs = None,
+        dtype: Optional[Dtype] = None,
+        param_dtype: Dtype = jnp.float32,
+        use_scale: bool = True,
+        scale_init: Initializer = initializers.ones,
+        reduction_axes: Axes = -1,
+        feature_axes: Axes = -1,
+        axis_name: Optional[str] = None,
+        axis_index_groups: Any = None,
+        use_fast_variance: bool = True,
+        rngs: rnglib.Rngs,
     ):
-        self.variance_epsilon = epsilon
-        self.weight = nnx.Param(
-            nnx.with_partitioning(nnx.initializers.ones, kernel_axes)(
-                rngs.params(), (hidden_size,)
+        feature_shape = (num_features,)
+
+        self.scale: nnx.Param[jax.Array] | None
+        if use_scale:
+            self.scale = nnx.Param(
+                scale_init(jax.random.PRNGKey(0), feature_shape, param_dtype)
             )
+        else:
+            self.scale = None
+
+        self.num_features = num_features
+        self.epsilon = epsilon
+        self.dtype = dtype
+        self.param_dtype = param_dtype
+        self.use_scale = use_scale
+        self.scale_init = scale_init
+        self.reduction_axes = reduction_axes
+        self.feature_axes = feature_axes
+        self.axis_name = axis_name
+        self.axis_index_groups = axis_index_groups
+        self.use_fast_variance = use_fast_variance
+
+    def __call__(self, x, mask: Optional[jax.Array] = None):
+        mean, var = _compute_stats(
+            x,
+            self.reduction_axes,
+            self.dtype,
+            self.axis_name,
+            self.axis_index_groups,
+            use_mean=False,
+            use_fast_variance=self.use_fast_variance,
+            mask=mask,
         )
 
-    def __call__(
-        self, x: jax.Array, residual: Optional[jax.Array] = None
-    ) -> Union[jax.Array, Tuple[jax.Array, jax.Array]]:
-        """Applies layer normalization on the input."""
-        return rmsnorm_forward(x, residual, self.weight, self.variance_epsilon)
+        return _normalize(
+            x,
+            mean,
+            var,
+            self.scale.value if self.scale else None,
+            None,
+            self.reduction_axes,
+            self.feature_axes,
+            self.dtype,
+            self.epsilon,
+        )
 
 
-# @partial(jax.jit, static_argnames=["epsilon"])
-def rmsnorm_forward(
-    x, residual, weight, epsilon
-) -> Union[jax.Array, Tuple[jax.Array, jax.Array]]:
-    orig_dtype = x.dtype
-    x_f32 = jnp.asarray(x, jnp.float32)
-    if residual is not None:
-        x_f32 += jnp.asarray(residual, jnp.float32)
-        residual = x_f32.astype(orig_dtype)
-    mean2 = jnp.mean(lax.square(x_f32), axis=-1, keepdims=True)
-    y = jnp.asarray(x_f32 * lax.rsqrt(mean2 + epsilon), jnp.float32)
-    output = (y * jnp.asarray(weight, jnp.float32)).astype(orig_dtype)
-    if residual is None:
-        return output
+def _compute_stats(
+    x: Array,
+    axes: Axes,
+    dtype: Optional[Dtype],
+    axis_name: Optional[str] = None,
+    axis_index_groups: Any = None,
+    use_mean: bool = True,
+    use_fast_variance: bool = True,
+    mask: Optional[Array] = None,
+):
+    if dtype is None:
+        dtype = jnp.result_type(x)
+    # promote x to at least float32, this avoids half precision computation
+    # but preserves double or complex floating points
+    dtype = jnp.promote_types(dtype, jnp.float32)
+    x = jnp.asarray(x, dtype)
+    axes = _canonicalize_axes(x.ndim, axes)
+
+    def maybe_distributed_mean(*xs, mask=None):
+        mus = tuple(x.mean(axes, where=mask) for x in xs)
+        if axis_name is None:
+            return mus if len(xs) > 1 else mus[0]
+        else:
+            # In the distributed case we stack multiple arrays to speed comms.
+            if len(xs) > 1:
+                reduced_mus = lax.pmean(
+                    jnp.stack(mus, axis=0),
+                    axis_name,
+                    axis_index_groups=axis_index_groups,
+                )
+                return tuple(reduced_mus[i] for i in range(len(xs)))
+            else:
+                return lax.pmean(mus[0], axis_name, axis_index_groups=axis_index_groups)
+
+    if use_mean:
+        if use_fast_variance:
+            mu, mu2 = maybe_distributed_mean(x, _abs_sq(x), mask=mask)
+            # mean2 - _abs_sq(mean) is not guaranteed to be non-negative due
+            # to floating point round-off errors.
+            var = jnp.maximum(0.0, mu2 - _abs_sq(mu))
+        else:
+            mu = maybe_distributed_mean(x, mask=mask)
+            var = maybe_distributed_mean(
+                _abs_sq(x - jnp.expand_dims(mu, axes)), mask=mask
+            )
     else:
-        return output, residual
+        var = maybe_distributed_mean(_abs_sq(x), mask=mask)
+        mu = jnp.zeros_like(var)
+    return mu, var
+
+
+def _normalize(
+    x: Array,
+    mean: Array,
+    var: Array,
+    scale: Optional[Array],
+    bias: Optional[Array],
+    reduction_axes: Axes,
+    feature_axes: Axes,
+    dtype: Optional[Dtype],
+    epsilon: float,
+):
+    reduction_axes = _canonicalize_axes(x.ndim, reduction_axes)
+    feature_axes = _canonicalize_axes(x.ndim, feature_axes)
+    stats_shape = list(x.shape)
+    for axis in reduction_axes:
+        stats_shape[axis] = 1
+    mean = mean.reshape(stats_shape)
+    var = var.reshape(stats_shape)
+    feature_shape = [1] * x.ndim
+    for ax in feature_axes:
+        feature_shape[ax] = x.shape[ax]
+    y = x - mean
+    mul = lax.rsqrt(var + epsilon)
+    args = [x]
+    if scale is not None:
+        scale = scale.reshape(feature_shape)
+        mul *= scale
+        args.append(scale)
+    y *= mul
+    if bias is not None:
+        bias = bias.reshape(feature_shape)
+        y += bias
+        args.append(bias)
+    dtype = dtypes.canonicalize_dtype(*args, dtype=dtype)
+    return jnp.asarray(y, dtype)

--- a/python/sgl_jax/srt/layers/linear.py
+++ b/python/sgl_jax/srt/layers/linear.py
@@ -43,14 +43,14 @@ class LinearBase(nnx.Module):
         self.skip_bias_add = skip_bias_add
         self.weight = nnx.Param(
             nnx.with_partitioning(nnx.initializers.normal(), kernel_axes)(
-                rngs.params(), (input_size, output_size), params_dtype
+                jax.random.PRNGKey(0), (input_size, output_size), params_dtype
             )
         )
         if use_bias:
             self.bias = nnx.Param(
                 nnx.with_partitioning(
                     nnx.initializers.zeros_init(), (kernel_axes[-1],)
-                )(rngs.params(), (output_size,), params_dtype)
+                )(jax.random.PRNGKey(0), (output_size,), params_dtype)
             )
         else:
             self.bias = None

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -61,7 +61,7 @@ class GateLogit(nnx.Module):
 
         self.kernel = nnx.Param(
             nnx.with_partitioning(nnx.initializers.normal(), self.kernel_axes)(
-                rngs.params(), kernel_shape, self.weight_dtype
+                jax.random.PRNGKey(0), kernel_shape, self.weight_dtype
             )
         )
 
@@ -72,7 +72,7 @@ class GateLogit(nnx.Module):
             )
             self.bias = nnx.Param(
                 nnx.with_partitioning(nnx.initializers.zeros_init(), bias_axes)(
-                    rngs.params(), bias_shape, self.weight_dtype
+                    jax.random.PRNGKey(0), bias_shape, self.weight_dtype
                 )
             )
         else:
@@ -133,7 +133,7 @@ class EPMoE(nnx.Module):
 
         self.wi_0 = nnx.Param(
             nnx.with_partitioning(nnx.initializers.normal(), expert_kernel_axes)(
-                rngs.params(),
+                jax.random.PRNGKey(0),
                 (self.experts_per_device, config.hidden_size, intermediate_dim),
                 weight_dtype,
             )
@@ -141,7 +141,7 @@ class EPMoE(nnx.Module):
 
         self.wi_1 = nnx.Param(
             nnx.with_partitioning(nnx.initializers.normal(), expert_kernel_axes)(
-                rngs.params(),
+                jax.random.PRNGKey(0),
                 (self.experts_per_device, config.hidden_size, intermediate_dim),
                 weight_dtype,
             )
@@ -149,7 +149,7 @@ class EPMoE(nnx.Module):
 
         self.wo = nnx.Param(
             nnx.with_partitioning(nnx.initializers.normal(), expert_kernel_axes)(
-                rngs.params(),
+                jax.random.PRNGKey(0),
                 (self.experts_per_device, intermediate_dim, config.hidden_size),
                 weight_dtype,
             )

--- a/python/sgl_jax/srt/models/llama.py
+++ b/python/sgl_jax/srt/models/llama.py
@@ -31,6 +31,7 @@ from sgl_jax.srt.layers.embeddings import (
     RotaryEmbedding,
     get_rope,
 )
+from sgl_jax.srt.layers.layernorm import RMSNorm
 from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.layers.logits_processor import (
     LogitsMetadata,
@@ -249,7 +250,7 @@ class LlamaDecoderLayer(nnx.Module):
             rngs=rngs,
             dtype=dtype,
         )
-        self.input_layernorm = nnx.RMSNorm(
+        self.input_layernorm = RMSNorm(
             config.hidden_size,
             epsilon=config.rms_norm_eps,
             param_dtype=dtype,
@@ -257,7 +258,7 @@ class LlamaDecoderLayer(nnx.Module):
             rngs=rngs,
             dtype=dtype,
         )
-        self.post_attention_layernorm = nnx.RMSNorm(
+        self.post_attention_layernorm = RMSNorm(
             config.hidden_size,
             epsilon=config.rms_norm_eps,
             param_dtype=dtype,
@@ -341,7 +342,7 @@ class LlamaModel(nnx.Module):
             for i in range(config.num_hidden_layers)
         ]
 
-        self.norm = nnx.RMSNorm(
+        self.norm = RMSNorm(
             config.hidden_size,
             epsilon=config.rms_norm_eps,
             param_dtype=dtype,

--- a/python/sgl_jax/srt/models/qwen.py
+++ b/python/sgl_jax/srt/models/qwen.py
@@ -9,6 +9,7 @@ from transformers import PretrainedConfig
 
 from sgl_jax.srt.configs.model_config import ModelConfig
 from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead, RotaryEmbedding
+from sgl_jax.srt.layers.layernorm import RMSNorm
 from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
 from sgl_jax.srt.layers.radix_attention import RadixAttention
@@ -170,7 +171,7 @@ class QWenBlock(nnx.Module):
     ):
         self.layer_id = layer_id
 
-        self.ln_1 = nnx.RMSNorm(
+        self.ln_1 = RMSNorm(
             config.hidden_size,
             epsilon=config.layer_norm_epsilon,
             param_dtype=dtype,
@@ -191,7 +192,7 @@ class QWenBlock(nnx.Module):
             rngs=rngs,
         )
 
-        self.ln_2 = nnx.RMSNorm(
+        self.ln_2 = RMSNorm(
             config.hidden_size,
             epsilon=config.layer_norm_epsilon,
             param_dtype=dtype,
@@ -261,7 +262,7 @@ class QWenModel(nnx.Module):
             for i in range(config.num_hidden_layers)
         ]
 
-        self.ln_f = nnx.RMSNorm(
+        self.ln_f = RMSNorm(
             config.hidden_size,
             epsilon=config.layer_norm_epsilon,
             param_dtype=dtype,

--- a/python/sgl_jax/srt/models/qwen2.py
+++ b/python/sgl_jax/srt/models/qwen2.py
@@ -9,6 +9,7 @@ from transformers import PretrainedConfig
 
 from sgl_jax.srt.configs.model_config import ModelConfig
 from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead, RotaryEmbedding
+from sgl_jax.srt.layers.layernorm import RMSNorm
 from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
 from sgl_jax.srt.layers.radix_attention import RadixAttention
@@ -200,14 +201,14 @@ class Qwen2DecoderLayer(nnx.Module):
             dtype=dtype,
             rngs=rngs,
         )
-        self.input_layernorm = nnx.RMSNorm(
+        self.input_layernorm = RMSNorm(
             config.hidden_size,
             epsilon=config.rms_norm_eps,
             param_dtype=dtype,
             scale_init=nnx.with_partitioning(init_fn, (None,)),
             rngs=rngs,
         )
-        self.post_attention_layernorm = nnx.RMSNorm(
+        self.post_attention_layernorm = RMSNorm(
             config.hidden_size,
             epsilon=config.rms_norm_eps,
             param_dtype=dtype,
@@ -273,7 +274,7 @@ class Qwen2Model(nnx.Module):
             for i in range(config.num_hidden_layers)
         ]
 
-        self.norm = nnx.RMSNorm(
+        self.norm = RMSNorm(
             config.hidden_size,
             epsilon=config.rms_norm_eps,
             param_dtype=dtype,

--- a/python/sgl_jax/srt/models/qwen3.py
+++ b/python/sgl_jax/srt/models/qwen3.py
@@ -9,6 +9,7 @@ from transformers import PretrainedConfig
 
 from sgl_jax.srt.configs.model_config import ModelConfig
 from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead, RotaryEmbedding
+from sgl_jax.srt.layers.layernorm import RMSNorm
 from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
 from sgl_jax.srt.layers.radix_attention import RadixAttention
@@ -48,14 +49,14 @@ class QWen3Attention(nnx.Module):
         self.kv_size = num_kv_heads * self.head_dim
         self.scaling = self.head_dim**-0.5
 
-        self.q_norm = nnx.RMSNorm(
+        self.q_norm = RMSNorm(
             self.head_dim,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
             scale_init=nnx.with_partitioning(init_fn, (None,)),
             rngs=rngs,
         )
-        self.k_norm = nnx.RMSNorm(
+        self.k_norm = RMSNorm(
             self.head_dim,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
@@ -221,14 +222,14 @@ class QWen3DecoderLayer(nnx.Module):
             dtype=dtype,
             rngs=rngs,
         )
-        self.input_layernorm = nnx.RMSNorm(
+        self.input_layernorm = RMSNorm(
             config.hidden_size,
             epsilon=config.rms_norm_eps,
             param_dtype=dtype,
             scale_init=nnx.with_partitioning(init_fn, (None,)),
             rngs=rngs,
         )
-        self.post_attention_layernorm = nnx.RMSNorm(
+        self.post_attention_layernorm = RMSNorm(
             config.hidden_size,
             epsilon=config.rms_norm_eps,
             param_dtype=dtype,
@@ -308,7 +309,7 @@ class QWen3Model(nnx.Module):
             for i in range(config.num_hidden_layers)
         ]
 
-        self.norm = nnx.RMSNorm(
+        self.norm = RMSNorm(
             config.hidden_size,
             epsilon=config.rms_norm_eps,
             param_dtype=dtype,

--- a/python/sgl_jax/srt/models/qwen3_moe.py
+++ b/python/sgl_jax/srt/models/qwen3_moe.py
@@ -9,6 +9,7 @@ from transformers import PretrainedConfig
 
 from sgl_jax.srt.configs.model_config import ModelConfig
 from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead, RotaryEmbedding
+from sgl_jax.srt.layers.layernorm import RMSNorm
 from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
 from sgl_jax.srt.layers.moe import EPMoE, GateLogit
@@ -50,14 +51,14 @@ class QWen3MoeAttention(nnx.Module):
         self.kv_size = num_kv_heads * self.head_dim
         self.scaling = self.head_dim**-0.5
 
-        self.q_norm = nnx.RMSNorm(
+        self.q_norm = RMSNorm(
             self.head_dim,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
             scale_init=nnx.with_partitioning(init_fn, (None,)),
             rngs=rngs,
         )
-        self.k_norm = nnx.RMSNorm(
+        self.k_norm = RMSNorm(
             self.head_dim,
             epsilon=rms_norm_eps,
             param_dtype=dtype,
@@ -213,14 +214,14 @@ class QWen3MoeDecoderLayer(nnx.Module):
                 )
             self.is_moe_layer = True
 
-        self.input_layernorm = nnx.RMSNorm(
+        self.input_layernorm = RMSNorm(
             config.hidden_size,
             epsilon=config.rms_norm_eps,
             param_dtype=dtype,
             scale_init=nnx.with_partitioning(init_fn, (None,)),
             rngs=rngs,
         )
-        self.post_attention_layernorm = nnx.RMSNorm(
+        self.post_attention_layernorm = RMSNorm(
             config.hidden_size,
             epsilon=config.rms_norm_eps,
             param_dtype=dtype,
@@ -296,7 +297,7 @@ class QWen3MoeModel(nnx.Module):
             for i in range(config.num_hidden_layers)
         ]
 
-        self.norm = nnx.RMSNorm(
+        self.norm = RMSNorm(
             config.hidden_size,
             epsilon=config.rms_norm_eps,
             param_dtype=dtype,

--- a/python/sgl_jax/srt/utils/jax_utils.py
+++ b/python/sgl_jax/srt/utils/jax_utils.py
@@ -105,3 +105,31 @@ def is_tpu_runtime() -> bool:
         return len(devs) > 0 and all(d.platform == "tpu" for d in devs)
     except Exception:
         return jax.default_backend() == "tpu"
+
+
+def print_memory(stage_name):
+    """Print current memory usage"""
+    memory = get_memory_usage()
+    print(f"\n[{stage_name}] Memory usage:")
+    for device, usage in memory.items():
+        print(
+            f"  {device}: {usage}GB"
+            if isinstance(usage, float)
+            else f"  {device}: {usage}"
+        )
+    return memory
+
+
+def get_memory_usage():
+    """Get actual memory usage if available"""
+    try:
+        stats = {}
+        for i, device in enumerate(jax.devices()):
+            try:
+                device_stats = device.memory_stats()
+                stats[f"device_{i}"] = device_stats.get("bytes_in_use", 0) / (1024**3)
+            except:
+                stats[f"device_{i}"] = "N/A"
+        return stats
+    except:
+        return {f"device_{i}": "N/A" for i in range(len(jax.devices()))}

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -128,7 +128,7 @@ class WeightLoader:
                     logger.debug(f"Skipping excluded layer weight: {hf_key}")
                 else:
                     logger.warning(f"No mapping found for weight: {hf_key}")
-            nnx.update(self.model, params)
+        nnx.update(self.model, params)
 
         if moe_mappings:
             self._process_moe_expert_weights(params, moe_mappings, expert_weights)


### PR DESCRIPTION
## Startup command
```
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache  python3 -u -m sgl_jax.launch_server --model-path Qwen/Qwen3-8B --trust-remote-code  --dist-init-addr=0.0.0.0:10011 --nnodes=1  --tp-size=4 --device=tpu --random-seed=3 --node-rank=0 --mem-fraction-static=0.8 --chunked-prefill-size=2048 --download-dir=/dev/shm --dtype=bfloat16 --max-running-requests 256 --skip-server-warmup --page-size=128 --disable-radix-cache
```
## Initial model loading time 77s -> 8s
```
# before
[2025-10-16 10:09:17] KV heads distribution for GQA model: original_kv_heads=8, tp_size=4, each device gets 2 head(s), no replication needed, padding_strategy=replicate
Fetching 15 files: 100%|███████████████████████████████████████████████████████████████████████| 15/15 [00:00<00:00, 161734.09it/s]
[2025-10-16 10:09:17] QWen3ForCausalLMModel config dtype: <class 'jax.numpy.bfloat16'>
[2025-10-16 10:10:24] WeightLoader: Will load layers 0 to 35
[LOADING] MODEL WEIGHTS: 100%|██████████████████████████████| 5/5 [00:09<00:00,  1.98s/file, file=model-00005-of-00005.safetensors]
[2025-10-16 10:10:34] Qwen3 weights loaded successfully!

# after
[2025-10-17 04:36:20] KV heads distribution for GQA model: original_kv_heads=8, tp_size=4, each device gets 2 head(s), no replication needed, padding_strategy=replicate
Fetching 15 files: 100%|███████████████████████████████| 15/15 [00:00<00:00, 109990.49it/s]
[2025-10-17 04:36:20] QWen3ForCausalLMModel config dtype: <class 'jax.numpy.bfloat16'>
[2025-10-17 04:36:20] WeightLoader: Will load layers 0 to 35
[LOADING] MODEL WEIGHTS: 100%|█| 5/5 [00:07<00:00,  1.59s/file, file=model-00005-of-00005.s
[2025-10-17 04:36:28] Qwen3 weights loaded successfully!

# after + larger model Qwen3-32B 27s
[2025-10-17 04:44:49] KV heads distribution for GQA model: original_kv_heads=8, tp_size=4, each device gets 2 head(s), no replication needed, padding_strategy=replicate
Fetching 27 files: 100%|████████████████████████████████| 27/27 [00:00<00:00, 58015.48it/s]
[2025-10-17 04:44:49] QWen3ForCausalLMModel config dtype: <class 'jax.numpy.bfloat16'>
[2025-10-17 04:44:49] WeightLoader: Will load layers 0 to 63
[LOADING] MODEL WEIGHTS: 100%|█| 17/17 [00:26<00:00,  1.54s/file, file=model-00017-of-00017
[2025-10-17 04:45:16] Qwen3 weights loaded successfully!
```

## Extend Precompile 72s -> 63s
```
# before
[2025-10-16 10:10:35] [EXTEND] Begin to precompile bs_paddings=[256] token_paddings=[256, 512, 1024, 2048]
[2025-10-16 10:11:44] [EXTEND] Precompile finished in 72 secs

# after
[2025-10-17 04:36:29] [EXTEND] Begin to precompile bs_paddings=[256] token_paddings=[256, 512, 1024, 2048]
[2025-10-17 04:37:32] [EXTEND] Precompile finished in 63 secs
```

## Decode Precompile 261s -> 253s
```
# before
[2025-10-16 10:11:44] [DECODE] Begin to precompile bs_paddings=[1, 2, 4, 8, 16, 32, 64, 128, 256]
[2025-10-16 10:16:04] [DECODE] Precompile finished in 261 secs

# after
[2025-10-17 04:37:32] [DECODE] Begin to precompile bs_paddings=[1, 2, 4, 8, 16, 32, 64, 128, 256]
[2025-10-17 04:41:45] [DECODE] Precompile finished in 253 secs
```

## Benchmark
```
python3 -m sgl_jax.bench_serving --backend sgl-jax --dataset-name random --num-prompts 16 --random-input 1024 --random-output 1024 --random-range-ratio 1 --warmup-requests 0 --max-concurrency 16

============ Serving Benchmark Result ============
Backend:                                 sgl-jax
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     16
Benchmark duration (s):                  6.01
Total input tokens:                      16384
Total generated tokens:                  16384
Total generated tokens (retokenized):    16378
Request throughput (req/s):              2.66
Input token throughput (tok/s):          2727.25
Output token throughput (tok/s):         2727.25
Total token throughput (tok/s):          5454.51
Concurrency:                             15.98
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6000.67
Median E2E Latency (ms):                 6000.69
---------------Time to First Token----------------
Mean TTFT (ms):                          161.30
Median TTFT (ms):                        164.83
P99 TTFT (ms):                           250.55
---------------Inter-Token Latency----------------
Mean ITL (ms):                           5.71
Median ITL (ms):                         5.60
P95 ITL (ms):                            5.92
P99 ITL (ms):                            6.11
Max ITL (ms):                            212.21
==================================================
```
## GSM8K
```
evalscope eval  --model Qwen3-8B --api-url http://127.0.0.1:30000/v1 --api-key EMPTY --eval-type service --datasets gsm8k --eval-batch-size 32

+----------+-----------+-----------------+----------+-------+---------+---------+
| Model    | Dataset   | Metric          | Subset   |   Num |   Score | Cat.0   |
+==========+===========+=================+==========+=======+=========+=========+
| Qwen3-8B | gsm8k     | AverageAccuracy | main     |  1319 |  0.9136 | default |
+----------+-----------+-----------------+----------+-------+---------+---------+
```
