### PR TITLE
feat: upgrade jax version to 0.8.0

### DIFF
--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -25,7 +25,7 @@ runs:
       uses: astral-sh/setup-uv@v4
       with:
         version: "latest"
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install skypilot and login
       shell: bash
       run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run test
         timeout-minutes: 120
         run: |
-          uv venv && uv pip install -e python/
+          uv venv --python 3.12 && source .venv/bin/activate && uv pip install -e python/
           bash scripts/killall_sglang.sh
           uv run python test/srt/run_suite.py --suite per-commit-tpu-v6e-1
 
@@ -52,7 +52,7 @@ jobs:
       - name: Run test
         timeout-minutes: 120
         run: |
-          uv venv && uv pip install -e python/
+          uv venv --python 3.12 && source .venv/bin/activate && uv pip install -e python/
           bash scripts/killall_sglang.sh
           uv run python test/srt/run_suite.py --suite per-commit-tpu-v6e-4
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,14 +7,14 @@ name = "sglang-jax"
 version = "0.0.1"
 description = "JAX backend for SGL"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = { file = "LICENSE" }
 
 dependencies = [
     "fastapi~=0.116.1",
-    "flax~=0.10.7",
+    "flax~=0.12.0",
     "huggingface-hub~=0.34.3",
-    "jax[tpu]~=0.6.2",
+    "jax[tpu]~=0.8.0",
     "jinja2~=3.1.6",
     "modelscope~=1.28.2",
     "msgpack-python~=0.5.6",

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -4,6 +4,7 @@ from typing import Tuple
 import jax
 import jax.numpy as jnp
 import numpy as np
+from flax import nnx
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 from jax.tree_util import register_pytree_node_class
@@ -63,7 +64,6 @@ class FlashAttentionMetadata:
         return obj
 
 
-@register_pytree_node_class
 @dataclass
 class FlashAttention(AttentionBackend):
     """Native Attention layer for variable-length sequences using ForwardBatch."""
@@ -87,7 +87,7 @@ class FlashAttention(AttentionBackend):
         self.head_dim = head_dim
         self.page_size = page_size
         self.kv_partition_axis = kv_partition_axis
-        self.forward_metadata = FlashAttentionMetadata()
+        self.forward_metadata = nnx.data(FlashAttentionMetadata())
         self.mesh = mesh
 
     def get_forward_metadata(self, batch: ModelWorkerBatch):

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -458,7 +458,7 @@ class ModelRunner:
         logits_metadata: LogitsMetadata,
     ) -> Tuple[LogitsProcessorOutput, int]:
         # for compatibility, 0.6.3 need to use use_mesh. set_mesh is not have __entry__ attribute.
-        # on jax 0.7.1, we need to use set_mesh.
+        # on jax >=0.7.1, we need to use set_mesh.
         try:
             ctx = jax.sharding.use_mesh(self.mesh)
         except AttributeError:

--- a/python/sgl_jax/srt/models/llama.py
+++ b/python/sgl_jax/srt/models/llama.py
@@ -331,15 +331,17 @@ class LlamaModel(nnx.Module):
             param_dtype=dtype,
         )
 
-        self.layers = [
-            LlamaDecoderLayer(
-                config=config,
-                layer_id=i,
-                dtype=dtype,
-                rngs=rngs,
-            )
-            for i in range(config.num_hidden_layers)
-        ]
+        self.layers = nnx.data(
+            [
+                LlamaDecoderLayer(
+                    config=config,
+                    layer_id=i,
+                    dtype=dtype,
+                    rngs=rngs,
+                )
+                for i in range(config.num_hidden_layers)
+            ]
+        )
 
         self.norm = nnx.RMSNorm(
             config.hidden_size,

--- a/python/sgl_jax/srt/models/qwen.py
+++ b/python/sgl_jax/srt/models/qwen.py
@@ -251,15 +251,17 @@ class QWenModel(nnx.Module):
             param_dtype=dtype,
         )
 
-        self.h = [
-            QWenBlock(
-                config,
-                layer_id=i,
-                dtype=dtype,
-                rngs=rngs,
-            )
-            for i in range(config.num_hidden_layers)
-        ]
+        self.h = nnx.data(
+            [
+                QWenBlock(
+                    config,
+                    layer_id=i,
+                    dtype=dtype,
+                    rngs=rngs,
+                )
+                for i in range(config.num_hidden_layers)
+            ]
+        )
 
         self.ln_f = nnx.RMSNorm(
             config.hidden_size,

--- a/python/sgl_jax/srt/models/qwen2.py
+++ b/python/sgl_jax/srt/models/qwen2.py
@@ -263,15 +263,17 @@ class Qwen2Model(nnx.Module):
             param_dtype=dtype,
         )
 
-        self.layers = [
-            Qwen2DecoderLayer(
-                config=config,
-                layer_id=i,
-                dtype=dtype,
-                rngs=rngs,
-            )
-            for i in range(config.num_hidden_layers)
-        ]
+        self.layers = nnx.data(
+            [
+                Qwen2DecoderLayer(
+                    config=config,
+                    layer_id=i,
+                    dtype=dtype,
+                    rngs=rngs,
+                )
+                for i in range(config.num_hidden_layers)
+            ]
+        )
 
         self.norm = nnx.RMSNorm(
             config.hidden_size,

--- a/python/sgl_jax/srt/models/qwen3.py
+++ b/python/sgl_jax/srt/models/qwen3.py
@@ -298,15 +298,17 @@ class QWen3Model(nnx.Module):
             param_dtype=dtype,
         )
 
-        self.layers = [
-            QWen3DecoderLayer(
-                config=config,
-                layer_id=i,
-                dtype=dtype,
-                rngs=rngs,
-            )
-            for i in range(config.num_hidden_layers)
-        ]
+        self.layers = nnx.data(
+            [
+                QWen3DecoderLayer(
+                    config=config,
+                    layer_id=i,
+                    dtype=dtype,
+                    rngs=rngs,
+                )
+                for i in range(config.num_hidden_layers)
+            ]
+        )
 
         self.norm = nnx.RMSNorm(
             config.hidden_size,

--- a/python/sgl_jax/srt/models/qwen3_moe.py
+++ b/python/sgl_jax/srt/models/qwen3_moe.py
@@ -285,16 +285,18 @@ class QWen3MoeModel(nnx.Module):
             param_dtype=dtype,
         )
 
-        self.layers = [
-            QWen3MoeDecoderLayer(
-                config=config,
-                layer_id=i,
-                dtype=dtype,
-                rngs=rngs,
-                mesh=mesh,
-            )
-            for i in range(config.num_hidden_layers)
-        ]
+        self.layers = nnx.data(
+            [
+                QWen3MoeDecoderLayer(
+                    config=config,
+                    layer_id=i,
+                    dtype=dtype,
+                    rngs=rngs,
+                    mesh=mesh,
+                )
+                for i in range(config.num_hidden_layers)
+            ]
+        )
 
         self.norm = nnx.RMSNorm(
             config.hidden_size,

--- a/scripts/tpu_resource.yaml
+++ b/scripts/tpu_resource.yaml
@@ -13,5 +13,7 @@ setup: |
   if [ -d "sglang-jax" ]; then pip uninstall -y sgl-jax || true && rm -rf sglang-jax; fi
   git clone https://${USERNAME}:${GIT_TOKEN}@github.com/sgl-project/sglang-jax.git
   cd sglang-jax && git fetch origin $REF:$REF && git checkout $REF
+  uv venv --python 3.12
+  source .venv/bin/activate
   uv pip install -e python/
   bash scripts/killall_sglang.sh


### PR DESCRIPTION
### Movitation
Upgrade jax version to 0.8.0.  More information refers to https://github.com/jax-ml/jax/releases/tag/jax-v0.8.0

### Accuracy
```
evalscope eval  --model Qwen/Qwen3-8B --api-url http://127.0.0.1:30000/v1/chat/completions --api-key EMPTY --eval-type service --datasets gsm8k --eval-batch-size 32
```
<img width="1274" height="248" alt="image" src="https://github.com/user-attachments/assets/4d605767-8314-46ee-8264-fa36193e7f6a" />


### Benchmark
```
python3 -m sgl_jax.bench_serving --backend sgl-jax --dataset-name random --num-prompts 16 --random-input 1024 --random-output 1024 --random-range-ratio 1 --warmup-requests 0 --max-concurrency 16
```
<img width="728" height="966" alt="image" src="https://github.com/user-attachments/assets/165f509f-dbd3-498b-8bb3-6b38339aee9a" />
