### PR TITLE
support tie_word_embeddings

### DIFF
--- a/python/sgl_jax/srt/layers/logits_processor.py
+++ b/python/sgl_jax/srt/layers/logits_processor.py
@@ -210,14 +210,14 @@ class LogitsMetadata:
 class LogitsProcessor(nnx.Module):
     """Logits processor for the model."""
 
-    def __init__(self, vocab_size: int, lm_head: Embed, mesh: Mesh):
+    def __init__(self, vocab_size: int, mesh: Mesh):
         self.vocab_size = vocab_size
-        self.lm_head = lm_head
         self.mesh = mesh
 
     def __call__(
         self,
         hidden_states: jax.Array,
+        lm_head: Embed,
         logits_metadata: LogitsMetadata,
     ) -> LogitsProcessorOutput:
         if logits_metadata.forward_mode.is_decode_or_idle():
@@ -276,7 +276,7 @@ class LogitsProcessor(nnx.Module):
             )
 
         # Compute logits for both input and sampled tokens.
-        logits = self._get_logits(pruned_states, self.lm_head)
+        logits = self._get_logits(pruned_states, lm_head)
         sampled_logits = logits[sample_indices] if sample_indices is not None else logits
 
         hidden_states_to_store: jax.Array | None = None

--- a/python/sgl_jax/srt/models/llama.py
+++ b/python/sgl_jax/srt/models/llama.py
@@ -383,8 +383,9 @@ class LlamaForCausalLM(nnx.Module):
         self.dtype = dtype
         logger.info("LlamaForCausalLM config dtype: %s", self.dtype)
         self.transformer = LlamaModel(config, dtype=self.dtype, rngs=rngs)
-        self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size, rngs=rngs)
-        self.logits_processor = LogitsProcessor(config.vocab_size, self.lm_head, self.mesh)
+        if not getattr(self.config, "tie_word_embeddings", True):
+            self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size, rngs=rngs)
+        self.logits_processor = LogitsProcessor(config.vocab_size, self.mesh)
 
     def load_weights(self, model_config: ModelConfig, rng_key: jax.Array):
         self.rng = nnx.Rngs(rng_key)
@@ -527,7 +528,12 @@ class LlamaForCausalLM(nnx.Module):
         hidden_states, layers_kv_fused, layers_callback_flag = self.transformer(
             forward_batch, token_to_kv_pool
         )
-        output = self.logits_processor(hidden_states, logits_metadata)
+        if not getattr(self.config, "tie_word_embeddings", True):
+            output = self.logits_processor(hidden_states, self.lm_head, logits_metadata)
+        else:
+            output = self.logits_processor(
+                hidden_states, self.transformer.embed_tokens, logits_metadata
+            )
         return output, layers_kv_fused, layers_callback_flag
 
 

--- a/python/sgl_jax/srt/models/qwen2.py
+++ b/python/sgl_jax/srt/models/qwen2.py
@@ -322,8 +322,9 @@ class Qwen2ForCausalLM(nnx.Module):
         self.dtype = dtype
         logger.info("Qwen2ForCausalLM config dtype: %s", self.dtype)
         self.transformer = Qwen2Model(config, dtype=self.dtype, rngs=rngs)
-        self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size, rngs=rngs)
-        self.logits_processor = LogitsProcessor(config.vocab_size, self.lm_head, self.mesh)
+        if not getattr(self.config, "tie_word_embeddings", True):
+            self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size, rngs=rngs)
+        self.logits_processor = LogitsProcessor(config.vocab_size, self.mesh)
 
     def load_weights(self, model_config: ModelConfig, rng_key: jax.Array):
         self.rng = nnx.Rngs(rng_key)
@@ -466,7 +467,12 @@ class Qwen2ForCausalLM(nnx.Module):
         hidden_states, layers_kv_fused, layers_callback_flag = self.transformer(
             forward_batch, token_to_kv_pool
         )
-        output = self.logits_processor(hidden_states, logits_metadata)
+        if not getattr(self.config, "tie_word_embeddings", True):
+            output = self.logits_processor(hidden_states, self.lm_head, logits_metadata)
+        else:
+            output = self.logits_processor(
+                hidden_states, self.transformer.embed_tokens, logits_metadata
+            )
         return output, layers_kv_fused, layers_callback_flag
 
 

--- a/python/sgl_jax/srt/models/qwen3.py
+++ b/python/sgl_jax/srt/models/qwen3.py
@@ -361,8 +361,9 @@ class Qwen3ForCausalLM(nnx.Module):
         self.dtype = dtype
         logger.info("QWen3ForCausalLMModel config dtype: %s", self.dtype)
         self.transformer = QWen3Model(config, dtype=self.dtype, rngs=rngs)
-        self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size, rngs=rngs)
-        self.logits_processor = LogitsProcessor(config.vocab_size, self.lm_head, self.mesh)
+        if not getattr(self.config, "tie_word_embeddings", True):
+            self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size, rngs=rngs)
+        self.logits_processor = LogitsProcessor(config.vocab_size, self.mesh)
 
     def load_weights(self, model_config: ModelConfig, rng_key: jax.Array):
         self.rng = nnx.Rngs(rng_key)
@@ -515,7 +516,12 @@ class Qwen3ForCausalLM(nnx.Module):
         hidden_states, layers_kv_fused, layers_callback_flag = self.transformer(
             forward_batch, token_to_kv_pool
         )
-        output = self.logits_processor(hidden_states, logits_metadata)
+        if not getattr(self.config, "tie_word_embeddings", True):
+            output = self.logits_processor(hidden_states, self.lm_head, logits_metadata)
+        else:
+            output = self.logits_processor(
+                hidden_states, self.transformer.embed_tokens, logits_metadata
+            )
         return output, layers_kv_fused, layers_callback_flag
 
 

--- a/python/sgl_jax/srt/models/qwen3_moe.py
+++ b/python/sgl_jax/srt/models/qwen3_moe.py
@@ -344,8 +344,9 @@ class Qwen3MoeForCausalLM(nnx.Module):
         self.dtype = dtype
         logger.info("QWen3MoeForCausalLMModel config dtype: %s", self.dtype)
         self.transformer = QWen3MoeModel(config, dtype=self.dtype, rngs=rngs, mesh=mesh)
-        self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size, rngs=rngs)
-        self.logits_processor = LogitsProcessor(config.vocab_size, self.lm_head, self.mesh)
+        if not getattr(self.config, "tie_word_embeddings", True):
+            self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size, rngs=rngs)
+        self.logits_processor = LogitsProcessor(config.vocab_size, self.mesh)
 
     def load_weights(self, model_config: ModelConfig, rng_key: jax.Array):
         self.rng = nnx.Rngs(rng_key)
@@ -515,7 +516,12 @@ class Qwen3MoeForCausalLM(nnx.Module):
         logits_metadata: LogitsMetadata,
     ):
         hidden_states, layers_kv_fused = self.transformer(forward_batch, token_to_kv_pool)
-        output = self.logits_processor(hidden_states, logits_metadata)
+        if not getattr(self.config, "tie_word_embeddings", True):
+            output = self.logits_processor(hidden_states, self.lm_head, logits_metadata)
+        else:
+            output = self.logits_processor(
+                hidden_states, self.transformer.embed_tokens, logits_metadata
+            )
         return output, layers_kv_fused, True
 
 


### PR DESCRIPTION
- serving launch 
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache  python3 -u -m sgl_jax.launch_server \
--model-path Qwen/Qwen3-8B \
--trust-remote-code  \
--dist-init-addr=0.0.0.0:10011 \
--nnodes=1  \
--tp-size=4 \
--device=tpu \
--random-seed=3 \
--node-rank=0 \
--mem-fraction-static=0.8 \
--chunked-prefill-size=2048 \
--download-dir=/tmp \
--dtype=bfloat16 \
--max-running-requests 256 \
--skip-server-warmup \
--page-size=128  \
--disable-radix-cache

- accuracy
evalscope eval  --model Qwen-8B --api-url http://127.0.0.1:30000/v1/chat/completions --api-key EMPTY --eval-type service --datasets gsm8k --eval-batch-size 64

<img width="795" height="252" alt="image" src="https://github.com/user-attachments/assets/2d319ac2-f116-4708-b7ad-7a81d6c3df16" />

- performance
python3 -m sgl_jax.bench_serving --backend sgl-jax --dataset-name random --num-prompts 48 --random-input 1024 --random-output 1024 --random-range-ratio 1 --warmup-requests 0 --max-concurrency=16
<img width="473" height="423" alt="image" src="https://github.com/user-attachments/assets/19d72dbb-8336-4ed2-b65a-1766a3e0b07a" />

