### PR TITLE
Feat: add release pypi workflow and bump SGLang-Jax version to 0.0.2

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,31 @@
+name: Release PyPI
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "python/sglang/version.py"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    if: github.repository == 'sgl-project/sglang-jax'
+    runs-on: ubuntu-latest
+    environment: "prod"
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Upload to pypi
+        run: |
+          cd python
+          cp ../README.md ../LICENSE .
+          pip install build
+          python3 -m build
+          pip install twine
+          python3 -m twine upload dist/* -u __token__ -p ${{ secrets.PYPI_TOKEN }}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sglang-jax"
-version = "0.0.1"
+version = "0.0.2"
 description = "JAX backend for SGL"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/python/sgl_jax/version.py
+++ b/python/sgl_jax/version.py
@@ -1,1 +1,2 @@
-__version__ = "0.0.1"
+# Note that it should be consistent with pyproject.toml
+__version__ = "0.0.2"


### PR DESCRIPTION
support sglang-jax release-pypi : https://github.com/sgl-project/sglang-jax/issues/252