### PR TITLE
fix: head dim pad in model config

### DIFF
--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -169,6 +169,9 @@ class ModelConfig:
             **kwargs,
         )
 
+    def get_padded_head_dim(self) -> int:
+        return (self.head_dim + 127) // 128 * 128
+
     # adapted from https://github.com/vllm-project/vllm/blob/main/vllm/config.py#L289
     def get_total_num_kv_heads(self) -> int:
         """Returns the total number of KV heads (original, not replicated)."""

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -205,6 +205,7 @@ class ModelRunner:
         self.model_config.configure_for_tensor_parallel(self.tp_size)
         self.model_config.log_kv_heads_info(self.tp_size)
         self.model_config.hf_config.ep_size = self.ep_size
+        self.model_config.hf_config.head_dim_padded = self.model_config.get_padded_head_dim()
 
         self.model = self.model_loader.load_model(
             model_config=self.model_config,

--- a/python/sgl_jax/srt/models/bailing_moe.py
+++ b/python/sgl_jax/srt/models/bailing_moe.py
@@ -210,7 +210,7 @@ class BailingMoEDecoderLayer(nnx.Module):
         rope_theta = getattr(config, "rope_theta", 1000000)
         rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings", 40960)
-        self.head_dim = getattr(config, "head_dim", None)
+        self.head_dim = getattr(config, "head_dim_padded", None)
         use_qk_norm = getattr(config, "use_qk_norm", False)
         if hasattr(config, "partial_rotary_factor"):
             rotary_dim = int(self.head_dim * config.partial_rotary_factor)

--- a/python/sgl_jax/srt/models/llama.py
+++ b/python/sgl_jax/srt/models/llama.py
@@ -216,7 +216,7 @@ class LlamaDecoderLayer(nnx.Module):
         # Support internlm/internlm-7b with bias
         attention_bias = getattr(config, "attention_bias", False) or getattr(config, "bias", False)
 
-        head_dim = getattr(config, "head_dim", None)
+        head_dim = getattr(config, "head_dim_padded", None)
         self.self_attn = LlamaAttention(
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,

--- a/python/sgl_jax/srt/models/qwen2.py
+++ b/python/sgl_jax/srt/models/qwen2.py
@@ -179,7 +179,7 @@ class Qwen2DecoderLayer(nnx.Module):
         rope_theta = getattr(config, "rope_theta", 1000000)
         rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
-        head_dim = getattr(config, "head_dim", None)
+        head_dim = getattr(config, "head_dim_padded", None)
         self.self_attn = Qwen2Attention(
             hidden_size=config.hidden_size,
             num_heads=config.num_attention_heads,

--- a/python/sgl_jax/srt/models/qwen3.py
+++ b/python/sgl_jax/srt/models/qwen3.py
@@ -198,7 +198,7 @@ class QWen3DecoderLayer(nnx.Module):
         rope_theta = getattr(config, "rope_theta", 1000000)
         rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
-        head_dim = getattr(config, "head_dim", None)
+        head_dim = getattr(config, "head_dim_padded", None)
         self.self_attn = QWen3Attention(
             hidden_size=config.hidden_size,
             num_heads=config.num_attention_heads,

--- a/python/sgl_jax/srt/models/qwen3_moe.py
+++ b/python/sgl_jax/srt/models/qwen3_moe.py
@@ -152,7 +152,7 @@ class QWen3MoeDecoderLayer(nnx.Module):
         rope_theta = getattr(config, "rope_theta", 1000000)
         rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings", 40960)
-        head_dim = getattr(config, "head_dim", None)
+        head_dim = getattr(config, "head_dim_padded", None)
 
         self.self_attn = QWen3MoeAttention(
             hidden_size=config.hidden_size,


### PR DESCRIPTION
When passing head_dim from model_config to the attention layer, it must align with the padding specified in weight_loader