### PR TITLE
feat: merge penalties precompile into extend and decode precompile

### DIFF
--- a/python/sgl_jax/bench_one_batch.py
+++ b/python/sgl_jax/bench_one_batch.py
@@ -286,7 +286,10 @@ def _run_forward_and_sample(model_runner, batch: ScheduleBatch, token_first_arg:
 
     pad_size = len(model_worker_batch.seq_lens) - model_worker_batch.real_bs
     sampling_metadata = SamplingMetadata.from_model_worker_batch(
-        model_worker_batch, pad_size=pad_size, mesh=model_runner.mesh
+        model_worker_batch,
+        pad_size=pad_size,
+        mesh=model_runner.mesh,
+        vocab_size=model_runner.model_config.vocab_size,
     )
     next_token_ids = model_runner.sample(logits_output, sampling_metadata)
 

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -770,7 +770,6 @@ class ScheduleBatch:
         self.sampling_info = SamplingBatchInfo.from_schedule_batch(
             self,
             self.model_config.vocab_size,
-            getattr(self.model_config, "tie_word_embeddings", False),
         )
 
     def new_page_count_next_decode(self, selected_indices: list[int] | None = None):
@@ -888,7 +887,6 @@ class ScheduleBatch:
         self.sampling_info = SamplingBatchInfo.from_schedule_batch(
             self,
             self.model_config.vocab_size,
-            getattr(self.model_config, "tie_word_embeddings", False),
         )
 
     def prepare_for_decode(self):

--- a/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
@@ -159,6 +159,7 @@ class ModelWorkerClient:
                 model_worker_batch,
                 len(model_worker_batch.seq_lens) - model_worker_batch.real_bs,
                 self.mesh,
+                self.worker.model_config.vocab_size,
             )
 
         forward_metadata = self.worker.model_runner.attn_backend.get_forward_metadata(

--- a/python/sgl_jax/test/model_executor/test_model_runner.py
+++ b/python/sgl_jax/test/model_executor/test_model_runner.py
@@ -238,7 +238,7 @@ class TestModelRunner(unittest.TestCase):
         current_token = self.model_runner.sampler(
             extend_output,
             sampling_metadata=SamplingMetadata.from_model_worker_batch(
-                model_worker_batch.sampling_info
+                model_worker_batch.sampling_info, vocab_size=self.model_config.vocab_size
             ),
         )
 
@@ -267,7 +267,7 @@ class TestModelRunner(unittest.TestCase):
             current_token = self.model_runner.sampler(
                 decode_output,
                 sampling_metadata=SamplingMetadata.from_model_worker_batch(
-                    model_worker_batch.sampling_info
+                    model_worker_batch.sampling_info, vocab_size=self.model_config.vocab_size
                 ),
             )
             all_generated_tokens.append(current_token)

--- a/python/sgl_jax/test/run_curl.py
+++ b/python/sgl_jax/test/run_curl.py
@@ -17,6 +17,9 @@ def run_curl(args):
         "sampling_params": {
             "temperature": args.temperature,
             "max_new_tokens": getattr(args, "max_new_tokens", 10),
+            "frequency_penalty": getattr(args, "frequency_penalty", 0.0),
+            "presence_penalty": getattr(args, "presence_penalty", 0.0),
+            "min_new_tokens": getattr(args, "min_new_tokens", 0),
         },
         "text": args.text,
         "return_logprob": getattr(args, "return_logprob", False),
@@ -80,6 +83,12 @@ if __name__ == "__main__":
         "--logprob-start-len",
         type=int,
     )
+    parser.add_argument(
+        "--frequency-penalty",
+        type=float,
+    )
+    parser.add_argument("--presence-penalty", type=float)
+    parser.add_argument("--min-new-tokens", type=int)
     args = parser.parse_args()
 
     run_curl(args)

--- a/test/srt/test_features.py
+++ b/test/srt/test_features.py
@@ -526,6 +526,7 @@ class TestFeatures(CustomTestCase):
             text="Say hello hello hello",
             temperature=0.5,
             max_new_tokens=1,
+            frequency_penalty=0.2,
         )
 
         # Test frequency penalty = 1.0
@@ -542,6 +543,7 @@ class TestFeatures(CustomTestCase):
             text="The weather is nice today. The weather",
             temperature=0.5,
             max_new_tokens=2,
+            frequency_penalty=0.2,
         )
         resp_with_penalty = run_curl(args)
         if "cache_miss_count" not in resp_with_penalty["meta_info"]:
@@ -556,6 +558,7 @@ class TestFeatures(CustomTestCase):
             text="The weather is nice today. The weather",
             temperature=0.5,
             max_new_tokens=1,
+            presence_penalty=0.2,
         )
 
         resp_with_penalty = run_curl(args)
@@ -570,6 +573,7 @@ class TestFeatures(CustomTestCase):
             text="The weather is nice today. The weather",
             temperature=0.5,
             max_new_tokens=2,
+            presence_penalty=0.2,
         )
 
         resp_with_penalty = run_curl(args)
@@ -586,9 +590,11 @@ class TestFeatures(CustomTestCase):
             text="Hello",
             temperature=0.0,
             max_new_tokens=1,
+            min_new_tokens=1,
         )
 
         resp_with_min_tokens = run_curl(args)
+
         if "cache_miss_count" not in resp_with_min_tokens["meta_info"]:
             raise "[min_new_tokens] cache_miss_count is missed in response"
         self.assertEqual(resp_with_min_tokens["meta_info"]["cache_miss_count"], 0)
@@ -600,6 +606,7 @@ class TestFeatures(CustomTestCase):
             text="Hello",
             temperature=0.0,
             max_new_tokens=2,
+            min_new_tokens=2,
         )
 
         resp_with_min_tokens = run_curl(args)
@@ -697,6 +704,7 @@ class TestNoOverlapSchedule(CustomTestCase):
             text="Say hello hello hello",
             temperature=0.5,
             max_new_tokens=1,
+            frequency_penalty=0.2,
         )
 
         # Test frequency penalty = 1.0
@@ -713,6 +721,7 @@ class TestNoOverlapSchedule(CustomTestCase):
             text="The weather is nice today. The weather",
             temperature=0.5,
             max_new_tokens=2,
+            frequency_penalty=0.2,
         )
         resp_with_penalty = run_curl(args)
         if "cache_miss_count" not in resp_with_penalty["meta_info"]:
@@ -727,6 +736,7 @@ class TestNoOverlapSchedule(CustomTestCase):
             text="The weather is nice today. The weather",
             temperature=0.5,
             max_new_tokens=1,
+            presence_penalty=0.2,
         )
 
         resp_with_penalty = run_curl(args)
@@ -740,6 +750,7 @@ class TestNoOverlapSchedule(CustomTestCase):
             text="The weather is nice today. The weather",
             temperature=0.5,
             max_new_tokens=2,
+            presence_penalty=0.2,
         )
 
         resp_with_penalty = run_curl(args)
@@ -756,6 +767,7 @@ class TestNoOverlapSchedule(CustomTestCase):
             text="Hello",
             temperature=0.0,
             max_new_tokens=1,
+            min_new_tokens=1,
         )
 
         resp_with_min_tokens = run_curl(args)
@@ -769,6 +781,7 @@ class TestNoOverlapSchedule(CustomTestCase):
             text="Hello",
             temperature=0.0,
             max_new_tokens=2,
+            min_new_tokens=2,
         )
 
         # decode


### PR DESCRIPTION
After the merge, the original `linear_penalty` implementation causes a JIT cache miss. The JAX JIT compiler focuses on structures rather than values. During the precompilation phase, when `linear_penalty` is a `jax.Array` but `do_penalty` is False at runtime, `linear_penalty` becomes `None`. This results in a TRACING CACHE MISS error. To ensure the effectiveness of precompilation, the pytree structure must remain stable, ensuring that linear_penalty consistently remains a jax.Array.

Before updating, precompile qwen3-8B with tp=4:
```
[2025-10-29 08:23:33] [Scheduler] Begins to run worker precompile.
[2025-10-29 08:23:33] [EXTEND] Begin to precompile bs_paddings=[256] token_paddings=[256, 512, 1024, 2048]
[2025-10-29 08:24:18] [EXTEND] Precompile finished in 45 secs
[2025-10-29 08:24:18] [DECODE] Begin to precompile bs_paddings=[1, 2, 4, 8, 16, 32, 64, 128, 256]
[2025-10-29 08:25:43] [DECODE] Precompile finished in 85 secs
[2025-10-29 08:25:43] [PENALTIES] Begin to precompile penalty applications bs_paddings=[1, 2, 4, 8, 16, 32, 64, 128, 256]
[2025-10-29 08:26:14] [PENALTIES] Precompile finished in 31 secs
```
After updating:
```
[2025-10-29 08:17:51] [Scheduler] Begins to run worker precompile.
[2025-10-29 08:17:51] [EXTEND] Begin to precompile bs_paddings=[256] token_paddings=[256, 512, 1024, 2048]
[2025-10-29 08:18:36] [EXTEND] Precompile finished in 45 secs
[2025-10-29 08:18:36] [DECODE] Begin to precompile bs_paddings=[1, 2, 4, 8, 16, 32, 64, 128, 256]
[2025-10-29 08:20:01] [DECODE] Precompile finished in 86 secs
```