### PR TITLE
remove with_sharding_constraint

### DIFF
--- a/python/sgl_jax/srt/layers/sampler.py
+++ b/python/sgl_jax/srt/layers/sampler.py
@@ -4,8 +4,7 @@ from flax import nnx
 from jax import lax
 from jax import numpy as jnp
 from jax import random
-from jax.sharding import Mesh, NamedSharding
-from jax.sharding import PartitionSpec as P
+from jax.sharding import Mesh
 
 from sgl_jax.srt.layers.binary_search import topk_mask, topp_mask
 from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
@@ -29,8 +28,6 @@ class Sampler(nnx.Module):
     def _regular_sampling(self, operands):
         """Regular sampling branch"""
         logits, sampling_metadata, positions, rng, mesh, use_sort_for_toppk_minp = operands
-
-        logits = lax.with_sharding_constraint(logits, NamedSharding(mesh, P(None, None)))
 
         # Validate broadcast compatibility for temperature division
         logits_batch_size = logits.shape[0]


### PR DESCRIPTION
# Tests
- case1: test profile whether all_gather exists
- case2: test benchmark, compared with #297
- case3: test math-500 accuracy, compared with #287
- case4: with_temperature_penalty & without_temperature, compared with #245

# Results


## case1: Profile

```bash
# launch server
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache \
uv run python -u -m sgl_jax.launch_server \
--model-path Qwen/Qwen3-32B \
--trust-remote-code  \
--tp-size=4 \
--device=tpu \
--mem-fraction-static=0.95 \
--chunked-prefill-size=2048 \
--download-dir=/tmp \
--dtype=bfloat16 \
--max-running-requests 256 \
--skip-server-warmup \
--page-size=128  \
--disable-radix-cache

# profile
uv run python -m sgl_jax.bench_serving --backend sglang-oai --dataset-name random --num-prompts 384 --random-input-len 4096 --random-output-len 1 --max-concurrency 128 --random-range-ratio 1  --disable-ignore-eos --warmup-requests 0
```

No all_gather in sampling. We add `lax.cond` for penalty so there exists two conditions.

<img width="737" height="247" alt="image" src="https://github.com/user-attachments/assets/22abca1d-d1d7-42b1-abe2-10aa7e0d1676" />




## case2: Benchmark

Note: 
- When input length is 4096 and batch_size is 128, current median TTFT is 25672.42ms, compared with 25731.12ms in blog.
- Launching server and doing benchmark refer to #270.
- Different tpu-v6e-4 machines' performance vary from each other. Here I tested #af32f095880ff676ed23eec19bc79584b5e20717 again on the machine which is used to test the current branch.

Conclusion: Current branch does not perform worse.

**Same Machine**

<img width="1526" height="1824" alt="qwen3-32B_input4096_output1024" src="https://github.com/user-attachments/assets/86866ecf-38d5-4d1d-ada9-bf0e68efcee1" />

<img width="1535" height="1824" alt="qwen3-32B_input8192_output1024" src="https://github.com/user-attachments/assets/88c521ea-a5ac-44fd-a6cc-e727d17b696e" />



**Different Machines**
<img width="1526" height="1824" alt="qwen3-32B_input4096_output1024" src="https://github.com/user-attachments/assets/83dffd49-32e4-4149-9f81-48442c05dcb7" />

<img width="1537" height="1824" alt="qwen3-32B_input8192_output1024" src="https://github.com/user-attachments/assets/2bc4d074-472f-4e15-8a9a-a2fc8d25bb32" />



## case3: Math-500

```bash
# launch server
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python3 -u -m sgl_jax.launch_server \
--model-path deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B \
--trust-remote-code  \
--tp-size=4 \
--device=tpu \
--mem-fraction-static=0.8 \
--chunked-prefill-size=2048 \
--download-dir=/tmp \
--dtype=bfloat16 \
--max-running-requests 256 \
--skip-server-warmup \
--page-size=128  \
--disable-radix-cache \
--use-sort-for-toppk-minp

# eval (evalscope==0.17.1), more config information see at the Complete eval config.
## Sampling parameters refer to https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B.
## Eval generation config refers to https://evalscope.readthedocs.io/zh-cn/latest/best_practice/eval_qwq.html#id5.
evalscope eval  --model deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B \
--api-url http://127.0.0.1:30000/v1/chat/completions \
--api-key EMPTY \
--eval-type service \
--datasets math_500  \
--eval-batch-size 64 \
--dataset-args '{"math_500":{"metric_list":["Pass@1"]}}' --generation-config '{"max_tokens": 32768, "temperature": 0.6, "top_p": 0.95, "n": 1}' \
--timeout 120000 \
--model-args precision=jnp.bfloat16
```

**Grades**

```bash
+-------------------------------+-----------+----------+----------+-------+---------+---------+
| Model                         | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+===============================+===========+==========+==========+=======+=========+=========+
| DeepSeek-R1-Distill-Qwen-1.5B | math_500  | Pass@1   | Level 1  |    43 |  0.9535 | default |
+-------------------------------+-----------+----------+----------+-------+---------+---------+
| DeepSeek-R1-Distill-Qwen-1.5B | math_500  | Pass@1   | Level 2  |    90 |  0.9444 | default |
+-------------------------------+-----------+----------+----------+-------+---------+---------+
| DeepSeek-R1-Distill-Qwen-1.5B | math_500  | Pass@1   | Level 3  |   105 |  0.8667 | default |
+-------------------------------+-----------+----------+----------+-------+---------+---------+
| DeepSeek-R1-Distill-Qwen-1.5B | math_500  | Pass@1   | Level 4  |   128 |  0.7969 | default |
+-------------------------------+-----------+----------+----------+-------+---------+---------+
| DeepSeek-R1-Distill-Qwen-1.5B | math_500  | Pass@1   | Level 5  |   134 |  0.5896 | default |
+-------------------------------+-----------+----------+----------+-------+---------+---------+
| DeepSeek-R1-Distill-Qwen-1.5B | math_500  | Pass@1   | OVERALL  |   500 |  0.796  | -       |
+-------------------------------+-----------+----------+----------+-------+---------+---------+

+-------------------------------+-----------+----------+----------+-------+---------+---------+
| Model                         | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+===============================+===========+==========+==========+=======+=========+=========+
| DeepSeek-R1-Distill-Qwen-1.5B | math_500  | Pass@1   | Level 1  |    43 |  0.9302 | default |
+-------------------------------+-----------+----------+----------+-------+---------+---------+
| DeepSeek-R1-Distill-Qwen-1.5B | math_500  | Pass@1   | Level 2  |    90 |  0.9222 | default |
+-------------------------------+-----------+----------+----------+-------+---------+---------+
| DeepSeek-R1-Distill-Qwen-1.5B | math_500  | Pass@1   | Level 3  |   105 |  0.8857 | default |
+-------------------------------+-----------+----------+----------+-------+---------+---------+
| DeepSeek-R1-Distill-Qwen-1.5B | math_500  | Pass@1   | Level 4  |   128 |  0.7812 | default |
+-------------------------------+-----------+----------+----------+-------+---------+---------+
| DeepSeek-R1-Distill-Qwen-1.5B | math_500  | Pass@1   | Level 5  |   134 |  0.6418 | default |
+-------------------------------+-----------+----------+----------+-------+---------+---------+
| DeepSeek-R1-Distill-Qwen-1.5B | math_500  | Pass@1   | OVERALL  |   500 |  0.804  | -       |
+-------------------------------+-----------+----------+----------+-------+---------+---------+

```


## case4: Temperature & Penalty

```bash
# launch server
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache \
python3 -u -m sgl_jax.launch_server \
--model-path Qwen/Qwen3-8B \
--trust-remote-code  \
--tp-size=4 \
--device=tpu \
--mem-fraction-static=0.8 \
--chunked-prefill-size=2048 \
--download-dir=/tmp \
--dtype=bfloat16 \
--max-running-requests 256 \
--skip-server-warmup \
--page-size=128  \
--disable-radix-cache


# eval(evalscope==0.17.1)
## eval_without_temperature
evalscope eval  --model Qwen/Qwen3-8B --api-url http://127.0.0.1:30000/v1/chat/completions --api-key EMPTY --eval-type service --datasets gsm8k --eval-batch-size 64
## eval_with_temperature_penalty
- Note: Parameters refer to https://huggingface.co/Qwen/Qwen3-8B non-thinking mode
evalscope eval  --model Qwen/Qwen3-8B --api-url http://127.0.0.1:30000/v1/chat/completions --api-key EMPTY --eval-type service --datasets gsm8k --eval-batch-size 64 --generation-config '{"temperature": 0.7,"top_p":0.8,"top_k":20,"min_p":0.0,"presence_penalty":0.5}'
```

**eval_without_temperature**

Compared with #245, 0.9083 vs 0.9083.

```bash
+----------+-----------+-----------------+----------+-------+---------+---------+
| Model    | Dataset   | Metric          | Subset   |   Num |   Score | Cat.0   |
+==========+===========+=================+==========+=======+=========+=========+
| Qwen3-8B | gsm8k     | AverageAccuracy | main     |  1319 |  0.9083 | default |
+----------+-----------+-----------------+----------+-------+---------+---------+
```

**eval_with_temperature_penalty**

Compared with #245, 0.9462 vs 0.953.

```bash
+----------+-----------+-----------------+----------+-------+---------+---------+
| Model    | Dataset   | Metric          | Subset   |   Num |   Score | Cat.0   |
+==========+===========+=================+==========+=======+=========+=========+
| Qwen3-8B | gsm8k     | AverageAccuracy | main     |  1319 |   0.953 | default |
+----------+-----------+-----------------+----------+-------+---------+---------+
```
