### PR TITLE
feat: support structured output

### DIFF
--- a/docs/basic_usage/features/radix_cache.md
+++ b/docs/basic_usage/features/radix_cache.md
@@ -49,7 +49,7 @@ Key components:
    - Uses min-heap to select leaf nodes by `last_access_time`
    - Only evicts nodes with `lock_ref == 0`
 
-The radix tree is stored on CPU while KV data uses GPU memory pools.
+The radix tree is stored on CPU while KV data uses TPU memory pools.
 
 ## Usage
 

--- a/docs/features/chunked_prefill.md
+++ b/docs/features/chunked_prefill.md
@@ -16,7 +16,7 @@ The primary objectives of chunked prefill are:
 
 Traditional LLM inference processes entire prefill requests as single units, which can cause issues with very long sequences:
 - **Prefill phase**: Processes entire input prompt in parallel, but long sequences can exceed memory limits
-- **Memory constraints**: Large prefill requests may not fit in available GPU memory or batch size limits
+- **Memory constraints**: Large prefill requests may not fit in available TPU memory or batch size limits
 
 Chunked prefill addresses this by breaking large prefill requests into smaller chunks that can be processed sequentially, allowing the system to handle much longer input sequences without running out of memory.
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "flax~=0.12.0",
     "huggingface-hub~=0.34.3",
     "jinja2~=3.1.6",
+    "llguidance~=1.3.0",
     "modelscope~=1.28.2",
     "msgpack-python~=0.5.6",
     "numpy~=2.2.6",

--- a/python/sgl_jax/bench_one_batch.py
+++ b/python/sgl_jax/bench_one_batch.py
@@ -14,7 +14,7 @@ python -m sglang.bench_one_batch --model-path meta-llama/Meta-Llama-3-8B-Instruc
 # Usage (correctness test):
 python -m sglang.bench_one_batch --model-path TinyLlama/TinyLlama-1.1B-Chat-v0.4 --correct
 
-## Reference output (of the correctness test above, can be gpu dependent):
+## Reference output (of the correctness test above, can be tpu dependent):
 input_ids=[[1, 450, 7483, 310, 3444, 338], [1, 450, 7483, 310, 278, 3303, 13187, 290, 338], [1, 20628, 338, 263, 6575, 1460, 2462, 322, 306, 763]]
 
 prefill logits (first half): tensor([[-10.0312,  -9.5000,   0.8931,  ...,  -4.9414,  -3.2422,  -3.3633],

--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -220,7 +220,7 @@ class ModelConfig:
         return self.hf_text_config.num_attention_heads
 
     def get_num_kv_heads(self, tensor_parallel_size) -> int:
-        """Returns the number of KV heads per GPU."""
+        """Returns the number of KV heads per TP size."""
         from sgl_jax.srt.utils.jax_utils import get_num_kv_heads_by_tp
 
         total_num_kv_heads = self.get_total_num_kv_heads()

--- a/python/sgl_jax/srt/constrained/__init__.py
+++ b/python/sgl_jax/srt/constrained/__init__.py
@@ -1,0 +1,14 @@
+"""Constrained decoding with grammar backends."""
+
+from sgl_jax.srt.constrained.base_grammar_backend import (
+    BaseGrammarBackend,
+    BaseGrammarObject,
+)
+from sgl_jax.srt.constrained.llguidance_backend import GuidanceBackend, GuidanceGrammar
+
+__all__ = [
+    "BaseGrammarBackend",
+    "BaseGrammarObject",
+    "GuidanceBackend",
+    "GuidanceGrammar",
+]

--- a/python/sgl_jax/srt/constrained/base_grammar_backend.py
+++ b/python/sgl_jax/srt/constrained/base_grammar_backend.py
@@ -1,0 +1,179 @@
+"""Base classes for grammar-constrained decoding backends."""
+
+import concurrent.futures as futures
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import numpy as np
+
+from sgl_jax.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+class BaseGrammarObject:
+    """Base class for grammar objects that maintain state during generation."""
+
+    def __init__(self):
+        self.finished = False
+
+    def accept_token(self, token: int):
+        raise NotImplementedError()
+
+    def allocate_vocab_mask(self, vocab_size: int, batch_size: int):
+        raise NotImplementedError()
+
+    def fill_vocab_mask(self, vocab_mask: np.ndarray, idx: int):
+        raise NotImplementedError()
+
+    def is_terminated(self) -> bool:
+        raise NotImplementedError()
+
+    def copy(self):
+        raise NotImplementedError()
+
+
+class BaseGrammarBackend:
+    """Base class for grammar backends with async compilation support."""
+
+    def __init__(self, num_threads: int = 4):
+        """Initialize the grammar backend.
+
+        Args:
+            num_threads: Number of threads for async grammar compilation.
+        """
+        self.executor = ThreadPoolExecutor(max_workers=num_threads)
+        self.cache: dict[tuple[str, str], Any] = {}
+
+    def get_cached_or_future_value(self, key: tuple[str, str]) -> tuple[Any, bool]:
+        """Get a cached grammar object or submit async compilation.
+
+        Args:
+            key: Tuple of (constraint_type, constraint_string)
+                 e.g., ("json", schema_str) or ("regex", pattern)
+
+        Returns:
+            Tuple of (grammar_object or Future, cache_hit: bool)
+        """
+        if key in self.cache:
+            value = self.cache[key]
+            # Check if it's a completed grammar or still a Future
+            if isinstance(value, futures.Future):
+                return value, False  # Still compiling
+            else:
+                return value, True  # Cache hit
+
+        # Not in cache, submit async compilation
+        key_type, key_string = key
+        future = self.executor.submit(self._dispatch, key_type, key_string)
+        self.cache[key] = future
+        return future, False
+
+    def set_cache(self, key: tuple[str, str], value: BaseGrammarObject):
+        """Store a compiled grammar in the cache.
+
+        Args:
+            key: Cache key
+            value: Compiled grammar object
+        """
+        self.cache[key] = value
+
+    def _dispatch(self, key_type: str, key_string: str) -> BaseGrammarObject:
+        """Dispatch grammar creation based on type.
+
+        Args:
+            key_type: Type of constraint ("json", "regex", "ebnf", "structural_tag")
+            key_string: Constraint string (JSON schema, regex pattern, etc.)
+
+        Returns:
+            Compiled grammar object
+        """
+        if key_type == "json":
+            return self.dispatch_json(key_string)
+        elif key_type == "regex":
+            return self.dispatch_regex(key_string)
+        elif key_type == "ebnf":
+            return self.dispatch_ebnf(key_string)
+        elif key_type == "structural_tag":
+            return self.dispatch_structural_tag(key_string)
+        else:
+            raise ValueError(f"Unknown constraint type: {key_type}")
+
+    def dispatch_json(self, key_string: str) -> BaseGrammarObject:
+        """Create a grammar from JSON schema.
+
+        Args:
+            key_string: JSON schema string
+
+        Returns:
+            Grammar object
+        """
+        raise NotImplementedError()
+
+    def dispatch_regex(self, key_string: str) -> BaseGrammarObject:
+        """Create a grammar from regex pattern.
+
+        Args:
+            key_string: Regex pattern string
+
+        Returns:
+            Grammar object
+        """
+        raise NotImplementedError()
+
+    def dispatch_ebnf(self, key_string: str) -> BaseGrammarObject:
+        """Create a grammar from EBNF definition.
+
+        Args:
+            key_string: EBNF grammar string
+
+        Returns:
+            Grammar object
+        """
+        raise NotImplementedError()
+
+    def dispatch_structural_tag(self, key_string: str) -> BaseGrammarObject:
+        """Create a grammar from structural tag configuration.
+
+        Args:
+            key_string: JSON string of structural tag config
+
+        Returns:
+            Grammar object
+        """
+        raise NotImplementedError()
+
+    def shutdown(self):
+        """Shutdown the thread pool executor."""
+        self.executor.shutdown(wait=False)
+
+
+# Sentinel object for invalid/failed grammar compilation
+INVALID_GRAMMAR_OBJ = BaseGrammarObject()
+
+
+def create_grammar_backend(
+    server_args: ServerArgs,
+    tokenizer,
+    vocab_size: int,
+    eos_token_ids: set | None = None,
+) -> BaseGrammarBackend | None:
+    name = server_args.grammar_backend
+
+    if name == "llguidance":
+        from sgl_jax.srt.constrained.llguidance_backend import GuidanceBackend
+
+        grammar_backend = GuidanceBackend(
+            tokenizer=tokenizer,
+            num_threads=4,
+            n_vocab=vocab_size,
+            any_whitespace=not server_args.constrained_json_disable_any_whitespace,
+            whitespace_pattern=server_args.constrained_json_whitespace_pattern,
+        )
+    elif name == "none":
+        return None
+    else:
+        raise ValueError(f"Invalid grammar backend: {name}")
+
+    return grammar_backend

--- a/python/sgl_jax/srt/constrained/bitmask_ops.py
+++ b/python/sgl_jax/srt/constrained/bitmask_ops.py
@@ -1,0 +1,106 @@
+"""JAX-based bitmask operations for vocabulary masking on TPU."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from llguidance import LLInterpreter
+
+
+def allocate_token_bitmask(batch_size: int, vocab_size: int) -> np.ndarray:
+    """Allocate a token bitmask array.
+
+    Args:
+        batch_size: Batch size
+        vocab_size: Vocabulary size
+
+    Returns:
+        Numpy array of shape [batch_size, vocab_size // 32] with dtype int32
+    """
+    num_int32_per_vocab = (vocab_size + 31) // 32
+    return np.zeros((batch_size, num_int32_per_vocab), dtype=np.int32)
+
+
+def fill_token_bitmask(
+    matcher: LLInterpreter,
+    vocab_mask: np.ndarray,
+    batch_idx: int,
+):
+    """Fill the bitmask for a specific batch index using llguidance matcher.
+
+    Args:
+        matcher: LLMatcher or LLInterpreter instance
+        vocab_mask: Bitmask array of shape [batch_size, vocab_size // 32], dtype=int32
+        batch_idx: Index in the batch to fill
+    """
+    assert vocab_mask.dtype == np.int32, "Mask must be int32"
+    assert vocab_mask.ndim == 2, "Mask must be 2D"
+    v = vocab_mask[batch_idx, :]
+    matcher.unsafe_compute_mask_ptr(
+        v.ctypes.data,
+        v.nbytes,
+    )
+
+
+@jax.jit
+def apply_token_bitmask(
+    logits: jnp.ndarray,
+    vocab_mask: jnp.ndarray,
+) -> jnp.ndarray:
+    """Apply token bitmask to logits.
+
+    Sets logits to -inf where the bitmask bit is 0.
+
+    Args:
+        logits: Logits array of shape [batch_size, vocab_size]
+        vocab_mask: Packed bitmask array of shape [batch_size, vocab_size // 32]
+
+    Returns:
+        Masked logits array of shape [batch_size, vocab_size]
+    """
+    if vocab_mask is None:
+        return logits
+
+    # Unpack the bitmask from int32 to bool (full length = num_int32 * 32)
+    unpacked_mask_full = unpack_bitmask(vocab_mask)  # [Bmask, num_int32*32]
+    vocab_size = logits.shape[-1]
+    mask_len = unpacked_mask_full.shape[-1]
+
+    # Match vocab dimension statically: pad with False or crop as needed
+    if mask_len < vocab_size:
+        pad = vocab_size - mask_len
+        unpacked_mask = jnp.pad(
+            unpacked_mask_full,
+            ((0, 0), (0, pad)),
+            mode="constant",
+            constant_values=False,
+        )
+    elif mask_len > vocab_size:
+        unpacked_mask = unpacked_mask_full[:, :vocab_size]
+    else:
+        unpacked_mask = unpacked_mask_full
+
+    # Apply mask: set logits to -inf where mask is False (broadcast batch if needed)
+    masked_logits = jnp.where(unpacked_mask, logits, -jnp.inf)
+    return masked_logits
+
+
+def unpack_bitmask(vocab_mask: jnp.ndarray) -> jnp.ndarray:
+    """Unpack int32 bitmask to boolean array (no dynamic slicing).
+
+    Args:
+        vocab_mask: Packed bitmask [batch_size, num_int32]
+
+    Returns:
+        Boolean mask [batch_size, num_int32 * 32]
+    """
+    # For each int32, extract 32 bits
+    bit_indices = jnp.arange(32)[None, :]  # [1, 32]
+
+    def unpack_batch_item(mask_row):
+        # mask_row: [num_int32]
+        bits = jnp.bitwise_and(mask_row[:, None], 1 << bit_indices) != 0  # [num_int32, 32]
+        return bits.reshape(-1)  # [num_int32 * 32]
+
+    # Apply to all batch items
+    unpacked = jax.vmap(unpack_batch_item)(vocab_mask)  # [batch, num_int32*32]
+    return unpacked

--- a/python/sgl_jax/srt/constrained/llguidance_backend.py
+++ b/python/sgl_jax/srt/constrained/llguidance_backend.py
@@ -1,0 +1,168 @@
+"""LLGuidance backend for grammar-constrained decoding (JAX-compatible)."""
+
+import json
+import logging
+import os
+
+import numpy as np
+from llguidance import LLMatcher, LLTokenizer, StructTag, grammar_from
+from llguidance.hf import from_tokenizer
+
+from sgl_jax.srt.constrained.base_grammar_backend import (
+    INVALID_GRAMMAR_OBJ,
+    BaseGrammarBackend,
+    BaseGrammarObject,
+)
+
+from .bitmask_ops import allocate_token_bitmask, fill_token_bitmask
+
+logger = logging.getLogger(__name__)
+
+
+class GuidanceGrammar(BaseGrammarObject):
+    """Grammar object using llguidance library."""
+
+    def __init__(
+        self,
+        llguidance_tokenizer: LLTokenizer,
+        serialized_grammar: str,
+    ):
+        """Initialize a guidance grammar.
+
+        Args:
+            llguidance_tokenizer: LLTokenizer instance
+            serialized_grammar: Serialized grammar string from llguidance
+        """
+        super().__init__()
+        self.llguidance_tokenizer = llguidance_tokenizer
+        self.serialized_grammar = serialized_grammar
+
+        # Create matcher from serialized grammar
+        self.ll_matcher = LLMatcher(
+            llguidance_tokenizer,
+            serialized_grammar,
+            log_level=int(os.environ.get("LLGUIDANCE_LOG_LEVEL", "1")),
+        )
+
+        # Cached bitmask (reused across calls)
+        self.bitmask: np.ndarray | None = None
+
+    def accept_token(self, token: int):
+        """Accept a token and update the grammar state."""
+        if not self.ll_matcher.consume_token(token):
+            self.finished = True
+
+    def allocate_vocab_mask(self, vocab_size: int, batch_size: int) -> np.ndarray:
+        """Allocate a vocabulary bitmask."""
+        if self.bitmask is None or self.bitmask.shape[0] < batch_size:
+            self.bitmask = allocate_token_bitmask(batch_size, vocab_size)
+            bitmask = self.bitmask
+        else:
+            bitmask = self.bitmask[:batch_size]
+        return bitmask
+
+    def fill_vocab_mask(self, vocab_mask: np.ndarray, idx: int):
+        """Fill the vocabulary bitmask for this grammar at batch index."""
+        if self.ll_matcher.is_stopped():
+            self.finished = True
+            return
+
+        n_ll_cols = (int(self.llguidance_tokenizer.vocab_size) + 31) // 32
+        sub_mask = vocab_mask[:, :n_ll_cols]
+
+        fill_token_bitmask(
+            self.ll_matcher,
+            sub_mask,
+            idx,
+        )
+
+    def is_terminated(self) -> bool:
+        """Check if the grammar has terminated."""
+        return self.ll_matcher.is_stopped()
+
+    def copy(self):
+        return GuidanceGrammar(
+            llguidance_tokenizer=self.llguidance_tokenizer,
+            serialized_grammar=self.serialized_grammar,
+        )
+
+
+class GuidanceBackend(BaseGrammarBackend):
+    """LLGuidance backend implementation (JAX-compatible)."""
+
+    def __init__(
+        self,
+        tokenizer,
+        any_whitespace: bool = True,
+        whitespace_pattern: str | None = None,
+        n_vocab: int = 0,
+        num_threads: int = 4,
+    ):
+        """Initialize the llguidance backend.
+
+        Args:
+            tokenizer: HuggingFace tokenizer
+            whitespace_pattern: Pattern for JSON whitespace (default: flexible)
+            num_threads: Number of threads for async compilation
+        """
+        super().__init__(num_threads=num_threads)
+
+        self.any_whitespace = any_whitespace
+        self.whitespace_pattern = whitespace_pattern
+        self.llguidance_tokenizer = from_tokenizer(tokenizer, n_vocab=n_vocab)
+
+        logger.info("Initialized GuidanceBackend with whitespace_pattern=%s", whitespace_pattern)
+
+    def _from_serialized(self, serialized_grammar) -> GuidanceGrammar:
+        try:
+            return GuidanceGrammar(
+                llguidance_tokenizer=self.llguidance_tokenizer,
+                serialized_grammar=serialized_grammar,
+            )
+        except Exception as e:
+            logger.error("Hit invalid grammar: %s, %s", serialized_grammar, e)
+            return INVALID_GRAMMAR_OBJ
+
+    def dispatch_json(self, key_string: str) -> GuidanceGrammar:
+        try:
+            serialized_grammar = LLMatcher.grammar_from_json_schema(
+                key_string,
+                defaults={
+                    "whitespace_flexible": self.any_whitespace,
+                    "whitespace_pattern": self.whitespace_pattern,
+                },
+            )
+        except Exception as e:
+            logger.error("Hit invalid json_schema: %s, %s", key_string, e)
+            return INVALID_GRAMMAR_OBJ
+        return self._from_serialized(serialized_grammar)
+
+    def dispatch_regex(self, key_string: str) -> GuidanceGrammar:
+        serialized_grammar = grammar_from("regex", key_string)
+        return self._from_serialized(serialized_grammar)
+
+    def dispatch_ebnf(self, key_string: str) -> GuidanceGrammar:
+        try:
+            serialized_grammar = grammar_from("ebnf", key_string)
+            return self._from_serialized(serialized_grammar)
+        except ValueError as e:
+            logger.error("Hit invalid ebnf: %s, %s", key_string, e)
+            return INVALID_GRAMMAR_OBJ
+
+    def dispatch_structural_tag(self, key_string: str) -> GuidanceGrammar:
+        try:
+            structural_tag = json.loads(key_string)
+            tags = [
+                StructTag(
+                    begin=structure["begin"],
+                    grammar=structure["schema"],
+                    end=structure["end"],
+                    trigger=structural_tag["triggers"][0],  # TODO?
+                )
+                for structure in structural_tag["structures"]
+            ]
+            g = StructTag.to_grammar(tags)
+            return self._from_serialized(g)
+        except Exception as e:
+            logging.error("Hit invalid structural_tag: %s, %s", key_string, e)
+            return INVALID_GRAMMAR_OBJ

--- a/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
+++ b/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
@@ -39,6 +39,7 @@ from sgl_jax.srt.managers.io_struct import GenerateReqInput
 from sgl_jax.srt.managers.template_manager import TemplateManager
 from sgl_jax.srt.managers.tokenizer_manager import TokenizerManager
 from sgl_jax.srt.reasoning_parser import ReasoningParser
+from sgl_jax.utils import convert_json_schema_to_str
 
 logger = logging.getLogger(__name__)
 
@@ -328,17 +329,15 @@ Assistant: {% endif %}"""
         }
 
         if request.response_format and request.response_format.type == "json_schema":
-            # sampling_params["json_schema"] = convert_json_schema_to_str(
-            #     request.response_format.json_schema.schema_
-            # )
-            pass
+            sampling_params["json_schema"] = convert_json_schema_to_str(
+                request.response_format.json_schema.schema_
+            )
         elif request.response_format and request.response_format.type == "json_object":
             sampling_params["json_schema"] = '{"type": "object"}'
         elif request.response_format and request.response_format.type == "structural_tag":
-            # sampling_params["structural_tag"] = convert_json_schema_to_str(
-            #     request.response_format.model_dump(by_alias=True)
-            # )
-            pass
+            sampling_params["structural_tag"] = convert_json_schema_to_str(
+                request.response_format.model_dump(by_alias=True)
+            )
 
         # Check if there are already existing output constraints
         has_existing_constraints = (
@@ -353,10 +352,9 @@ Assistant: {% endif %}"""
         elif tool_call_constraint:
             constraint_type, constraint_value = tool_call_constraint
             if constraint_type == "structural_tag":
-                # sampling_params[constraint_type] = convert_json_schema_to_str(
-                #     constraint_value.model_dump(by_alias=True)
-                # )
-                pass
+                sampling_params[constraint_type] = convert_json_schema_to_str(
+                    constraint_value.model_dump(by_alias=True)
+                )
             else:
                 sampling_params[constraint_type] = constraint_value
         return sampling_params

--- a/python/sgl_jax/srt/model_executor/forward_batch_info.py
+++ b/python/sgl_jax/srt/model_executor/forward_batch_info.py
@@ -8,10 +8,10 @@ ScheduleBatch -> ModelWorkerBatch -> ForwardBatch
 - ScheduleBatch is managed by `scheduler.py::Scheduler`.
   It contains high-level scheduling data. Most of the data is on the CPU.
 - ModelWorkerBatch is managed by `tp_worker.py::TpModelWorker`.
-  It is a subset of `ScheduleBatch` that only contains data related to the model forward on GPU.
-  It will be transformed from CPU scheduler to GPU model runner.
+  It is a subset of `ScheduleBatch` that only contains data related to the model forward on TPU.
+  It will be transformed from CPU scheduler to TPU model runner.
 - ForwardBatch is managed by `model_runner.py::ModelRunner`.
-  It contains low-level tensor data. Most of the data consists of GPU tensors.
+  It contains low-level tensor data. Most of the data consists of TPU tensors.
 """
 
 from __future__ import annotations

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -505,7 +505,6 @@ class ModelRunner:
         self,
         logits_output: LogitsProcessorOutput,
         sampling_metadata: SamplingMetadata,
-        positions: jax.Array,
     ) -> jax.Array:
         """Sample and compute logprobs and update logits_output.
 
@@ -520,7 +519,6 @@ class ModelRunner:
         return self.jitted_sampler(
             logits_output,
             sampling_metadata,
-            positions,
         )
 
     def set_num_token_hybrid(self):

--- a/python/sgl_jax/test/constrained/test_bitmask_ops.py
+++ b/python/sgl_jax/test/constrained/test_bitmask_ops.py
@@ -1,0 +1,117 @@
+import ctypes
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.constrained.bitmask_ops import (
+    allocate_token_bitmask,
+    apply_token_bitmask,
+    fill_token_bitmask,
+    unpack_bitmask,
+)
+
+
+class MockLLInterpreter:
+    """A minimal mock of LLInterpreter that writes an int32 mask pattern.
+
+    It fills the provided pointer with precomputed int32 values that represent
+    allowed token indices via bit positions.
+    """
+
+    def __init__(self, values: np.ndarray):
+        assert values.dtype == np.int32
+        self.values = values
+
+    def unsafe_compute_mask_ptr(self, ptr: int, nbytes: int):
+        expected_nbytes = self.values.size * 4
+        assert nbytes == expected_nbytes
+        buf = (ctypes.c_int32 * self.values.size).from_address(ptr)
+        for i in range(self.values.size):
+            buf[i] = int(self.values[i])
+
+
+class BitmaskOpsTest(unittest.TestCase):
+    def test_allocate_token_bitmask(self):
+        batch_size = 2
+        vocab_size = 33  # requires 2 int32 slots
+        mask = allocate_token_bitmask(batch_size, vocab_size)
+        self.assertEqual(mask.shape, (2, 2))
+        self.assertEqual(mask.dtype, np.int32)
+        self.assertTrue(np.all(mask == 0))
+
+    def test_fill_and_unpack_bitmask(self):
+        # Prepare a 2-row bitmask; vocab_size=80 -> 3 int32 values per row
+        batch_size = 2
+        vocab_size = 80
+        mask = allocate_token_bitmask(batch_size, vocab_size)
+
+        # Allow token indices spread across three int32s, including edge bits
+        # int 0: 0, 5, 31
+        # int 1: 32, 39, 63
+        # int 2: 64, 70, 79
+        allowed = [0, 5, 31, 32, 39, 63, 64, 70, 79]
+        val0 = (1 << 0) | (1 << 5) | (1 << 31)
+        val1 = (1 << 0) | (1 << (39 - 32)) | (1 << (63 - 32))  # indices 32, 39, 63
+        val2 = (1 << 0) | (1 << (70 - 64)) | (1 << (79 - 64))  # indices 64, 70, 79
+        values = np.array([val0, val1, val2], dtype=np.int64).astype(np.int32)
+
+        matcher = MockLLInterpreter(values)
+        # Fill only row 1; row 0 remains zeros
+        fill_token_bitmask(matcher, mask, batch_idx=1)
+
+        # Row 0 should be all zeros
+        np.testing.assert_array_equal(mask[0], np.zeros_like(mask[0]))
+        # Row 1 should match the pattern
+        np.testing.assert_array_equal(mask[1], values)
+
+        # Unpack and verify booleans
+        unpacked = unpack_bitmask(jnp.array(mask))  # shape [2, num_int32 * 32]
+        self.assertEqual(unpacked.shape[0], 2)
+        num_bits = unpacked.shape[1]
+        # Check row 0: all False
+        self.assertFalse(bool(unpacked[0].any()))
+        # Check row 1: allowed indices are True; others False
+        row1 = np.array(unpacked[1])  # to numpy for easy indexing
+        for i in range(num_bits):
+            if i in allowed:
+                self.assertTrue(row1[i])
+            else:
+                self.assertFalse(row1[i])
+
+    def test_apply_token_bitmask(self):
+        # vocab_size=80 -> 3 int32s per row
+        batch_size = 2
+        vocab_size = 80
+        mask = allocate_token_bitmask(batch_size, vocab_size)
+
+        # Allow only a few indices for row 1
+        allowed = [0, 5, 31, 32, 39, 63, 64, 70, 79]
+        val0 = (1 << 0) | (1 << 5) | (1 << 31)
+        val1 = (1 << 0) | (1 << (39 - 32)) | (1 << (63 - 32))
+        val2 = (1 << 0) | (1 << (70 - 64)) | (1 << (79 - 64))
+        mask[1, :] = np.array([val0, val1, val2], dtype=np.int64).astype(np.int32)
+
+        logits = jnp.arange(batch_size * vocab_size, dtype=jnp.float32).reshape(
+            batch_size, vocab_size
+        )
+
+        masked = apply_token_bitmask(logits, jnp.array(mask))
+        masked_np = np.array(masked)
+
+        # Row 0 should be entirely -inf (no allowed tokens)
+        self.assertTrue(np.isneginf(masked_np[0]).all())
+
+        # Row 1: allowed indices keep original values, others -inf
+        for i in range(vocab_size):
+            if i in allowed:
+                self.assertTrue(
+                    np.isfinite(masked_np[1, i])
+                    and np.isclose(masked_np[1, i], float(vocab_size + i))
+                )
+            else:
+                self.assertTrue(np.isneginf(masked_np[1, i]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -29,7 +29,7 @@ from sgl_jax.srt.server_args import ServerArgs
 from sgl_jax.srt.utils.common_utils import get_bool_env_var, retry
 
 DEFAULT_MODEL_NAME_FOR_TEST = "Qwen/Qwen3-8B"
-DEFAULT_SMALL_MODEL_NAME_FOR_TEST = "Qwen/Qwen-1_8B-Chat"
+DEFAULT_SMALL_MODEL_NAME_FOR_TEST = "Qwen/Qwen3-1.7B"
 QWEN3_8B = "Qwen/Qwen3-8B"
 QWEN3_MOE_30B = "Qwen/Qwen3-30B-A3B"
 QWEN2_5_7B_INSTRUCT = "Qwen/Qwen2.5-7B-Instruct"

--- a/python/sgl_jax/utils.py
+++ b/python/sgl_jax/utils.py
@@ -1,7 +1,10 @@
+import json
 import logging
 import traceback
 from collections.abc import Callable
 from typing import Any
+
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -34,3 +37,33 @@ def find_printable_text(text: str) -> str:
 def get_exception_traceback() -> str:
     """Get the current exception traceback as a string."""
     return traceback.format_exc()
+
+
+def convert_json_schema_to_str(json_schema: dict | str | type[BaseModel]) -> str:
+    """Convert a JSON schema to a string.
+    Parameters
+    ----------
+    json_schema
+        The JSON schema.
+    Returns
+    -------
+    str
+        The JSON schema converted to a string.
+    Raises
+    ------
+    ValueError
+        If the schema is not a dictionary, a string or a Pydantic class.
+    """
+    if isinstance(json_schema, dict):
+        schema_str = json.dumps(json_schema)
+    elif isinstance(json_schema, str):
+        schema_str = json_schema
+    elif issubclass(json_schema, BaseModel):
+        schema_str = json.dumps(json_schema.model_json_schema())
+    else:
+        raise ValueError(
+            f"Cannot parse schema {json_schema}. The schema must be either "
+            + "a Pydantic class, a dictionary or a string that contains the JSON "
+            + "schema specification"
+        )
+    return schema_str

--- a/scripts/killall_sglang.sh
+++ b/scripts/killall_sglang.sh
@@ -7,7 +7,7 @@ tpu-info
 # Clean SGLang processes
 pgrep -f 'sglang::|sglang-jax::|sglang\.launch_server|sglang\.bench|sglang\.data_parallel|sglang\.srt|sgl_jax\.launch_server|sgl_jax\.srt|sgl_jax\.bench|sgl_jax\.data_parallel' | xargs -r kill -9 || true
 
-# Clean all GPU processes if any argument is provided
+# Clean all TPU processes if any argument is provided
 if [ $# -gt 0 ]; then
     # Kill TPU processes
     if command -v tpu-info >/dev/null 2>&1; then

--- a/test/srt/openai_server/features/test_ebnf.py
+++ b/test/srt/openai_server/features/test_ebnf.py
@@ -1,0 +1,126 @@
+import re
+import unittest
+
+import openai
+
+from sgl_jax.srt.hf_transformers_utils import get_tokenizer
+from sgl_jax.srt.utils import kill_process_tree
+from sgl_jax.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+# -------------------------------------------------------------------------
+#    EBNF Test Class: TestOpenAIServerEBNF
+#    Launches the server with xgrammar, has only EBNF tests
+# -------------------------------------------------------------------------
+class TestOpenAIServerEBNF(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.api_key = "sk-123456"
+
+        # passing xgrammar specifically
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            api_key=cls.api_key,
+            other_args=[
+                "--trust-remote-code",
+                "--skip-server-warmup",
+                "--random-seed",
+                "3",
+                "--mem-fraction-static",
+                "0.8",
+                "--chunked-prefill-size",
+                "2048",
+                "--download-dir",
+                "/dev/shm",
+                "--dtype",
+                "bfloat16",
+                "--precompile-bs-paddings",
+                "16",
+                "--precompile-token-paddings",
+                "16384",
+                "--max-running-requests",
+                "16",
+                "--page-size",
+                "64",
+                "--grammar-backend",
+                "llguidance",
+            ],
+            env={
+                "JAX_COMPILATION_CACHE_DIR": "/tmp/jax_compilation_cache",
+            },
+        )
+        cls.base_url += "/v1"
+        cls.tokenizer = get_tokenizer(DEFAULT_SMALL_MODEL_NAME_FOR_TEST)
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_ebnf(self):
+        """
+        Ensure we can pass `ebnf` to the local openai server
+        and that it enforces the grammar.
+        """
+        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
+        ebnf_grammar = r"""
+        root ::= "Hello" | "Hi" | "Hey"
+        """
+        pattern = re.compile(r"^(Hello|Hi|Hey)[.!?]*\s*$")
+
+        response = client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": "You are a helpful EBNF test bot."},
+                {"role": "user", "content": "Say a greeting (Hello, Hi, or Hey)."},
+            ],
+            temperature=0,
+            max_tokens=32,
+            extra_body={"ebnf": ebnf_grammar},
+        )
+        text = response.choices[0].message.content.strip()
+        self.assertTrue(len(text) > 0, "Got empty text from EBNF generation")
+        self.assertRegex(text, pattern, f"Text '{text}' doesn't match EBNF choices")
+
+    def test_ebnf_strict_json(self):
+        """
+        A stricter EBNF that produces exactly {"name":"Alice"} format
+        with no trailing punctuation or extra fields.
+        """
+        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
+        ebnf_grammar = r"""
+        root    ::= "{" pair "}"
+        pair    ::= "\"name\"" ":" string
+        string  ::= "\"" [A-Za-z]+ "\""
+        """
+        pattern = re.compile(r'^\{"name":"[A-Za-z]+"\}$')
+
+        response = client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": "EBNF mini-JSON generator."},
+                {
+                    "role": "user",
+                    "content": "Generate single key JSON with only letters.",
+                },
+            ],
+            temperature=0,
+            max_tokens=64,
+            extra_body={"ebnf": ebnf_grammar},
+        )
+        text = response.choices[0].message.content.strip()
+        self.assertTrue(len(text) > 0, "Got empty text from EBNF strict JSON test")
+        self.assertRegex(text, pattern, f"Text '{text}' not matching the EBNF strict JSON shape")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/openai_server/features/test_json_mode.py
+++ b/test/srt/openai_server/features/test_json_mode.py
@@ -1,0 +1,134 @@
+"""
+python3 -m unittest openai_server.features.test_json_mode.TestJSONModeLLGuidance.test_json_mode_response
+python3 -m unittest openai_server.features.test_json_mode.TestJSONModeLLGuidance.test_json_mode_with_streaming
+"""
+
+import json
+import unittest
+
+import openai
+
+from sgl_jax.srt.utils import kill_process_tree
+from sgl_jax.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    popen_launch_server,
+)
+
+
+def setup_class(cls, backend):
+    cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+    cls.base_url = DEFAULT_URL_FOR_TEST
+
+    cls.process = popen_launch_server(
+        cls.model,
+        cls.base_url,
+        timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+        other_args=[
+            "--trust-remote-code",
+            "--skip-server-warmup",
+            "--random-seed",
+            "3",
+            "--mem-fraction-static",
+            "0.8",
+            "--chunked-prefill-size",
+            "2048",
+            "--download-dir",
+            "/dev/shm",
+            "--dtype",
+            "bfloat16",
+            "--precompile-bs-paddings",
+            "16",
+            "--precompile-token-paddings",
+            "16384",
+            "--max-running-requests",
+            "16",
+            "--page-size",
+            "64",
+            "--grammar-backend",
+            backend,
+        ],
+        env={
+            "JAX_COMPILATION_CACHE_DIR": "/tmp/jax_compilation_cache",
+        },
+    )
+    cls.client = openai.Client(api_key="EMPTY", base_url=f"{cls.base_url}/v1")
+
+
+class TestJSONModeLLGuidance(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        setup_class(cls, "llguidance")
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_json_mode_response(self):
+        """Test that response_format json_object (also known as "json mode") produces valid JSON, even without a system prompt that mentions JSON."""
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                # We are deliberately omitting "That produces JSON" or similar phrases from the assistant prompt so that we don't have misleading test results
+                {
+                    "role": "system",
+                    "content": "You are a helpful AI assistant that gives a short answer.",
+                },
+                {"role": "user", "content": "What is the capital of Bulgaria?"},
+            ],
+            temperature=0,
+            max_tokens=128,
+            response_format={"type": "json_object"},
+        )
+        text = response.choices[0].message.content
+
+        print(f"Response ({len(text)} characters): {text}")
+
+        # Verify the response is valid JSON
+        try:
+            js_obj = json.loads(text)
+        except json.JSONDecodeError as e:
+            self.fail(f"Response is not valid JSON. Error: {e}. Response: {text}")
+
+        # Verify it's actually an object (dict)
+        self.assertIsInstance(js_obj, dict, f"Response is not a JSON object: {text}")
+
+    def test_json_mode_with_streaming(self):
+        """Test that streaming with json_object response (also known as "json mode") format works correctly, even without a system prompt that mentions JSON."""
+        stream = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                # We are deliberately omitting "That produces JSON" or similar phrases from the assistant prompt so that we don't have misleading test results
+                {
+                    "role": "system",
+                    "content": "You are a helpful AI assistant that gives a short answer.",
+                },
+                {"role": "user", "content": "What is the capital of Bulgaria?"},
+            ],
+            temperature=0,
+            max_tokens=128,
+            response_format={"type": "json_object"},
+            stream=True,
+        )
+
+        # Collect all chunks
+        chunks = []
+        for chunk in stream:
+            if chunk.choices[0].delta.content is not None:
+                chunks.append(chunk.choices[0].delta.content)
+        full_response = "".join(chunks)
+
+        print(f"Concatenated Response ({len(full_response)} characters): {full_response}")
+
+        # Verify the combined response is valid JSON
+        try:
+            js_obj = json.loads(full_response)
+        except json.JSONDecodeError as e:
+            self.fail(f"Streamed response is not valid JSON. Error: {e}. Response: {full_response}")
+
+        self.assertIsInstance(js_obj, dict)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/openai_server/features/test_structural_tag.py
+++ b/test/srt/openai_server/features/test_structural_tag.py
@@ -1,0 +1,203 @@
+"""
+python3 -m unittest test.srt.openai_server.features.test_structural_tag
+"""
+
+import json
+import re
+import unittest
+from typing import Any
+
+import openai
+
+from sgl_jax.srt.utils import kill_process_tree
+from sgl_jax.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+def setup_class(cls, backend: str):
+    cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+    cls.base_url = DEFAULT_URL_FOR_TEST
+
+    cls.process = popen_launch_server(
+        cls.model,
+        cls.base_url,
+        timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+        other_args=[
+            "--trust-remote-code",
+            "--skip-server-warmup",
+            "--random-seed",
+            "3",
+            "--mem-fraction-static",
+            "0.8",
+            "--chunked-prefill-size",
+            "2048",
+            "--download-dir",
+            "/dev/shm",
+            "--dtype",
+            "bfloat16",
+            "--precompile-bs-paddings",
+            "16",
+            "--precompile-token-paddings",
+            "16384",
+            "--max-running-requests",
+            "16",
+            "--page-size",
+            "64",
+            "--grammar-backend",
+            backend,
+        ],
+        env={
+            "JAX_COMPILATION_CACHE_DIR": "/tmp/jax_compilation_cache",
+        },
+    )
+
+
+class TestStructuralTagXGrammarBackend(CustomTestCase):
+    model: str
+    base_url: str
+    process: Any
+
+    @classmethod
+    def setUpClass(cls):
+        setup_class(cls, backend="llguidance")
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_stag_constant_str_openai(self):
+        client = openai.Client(api_key="EMPTY", base_url=f"{self.base_url}/v1")
+
+        tool_get_current_weather = {
+            "type": "function",
+            "function": {
+                "name": "get_current_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {
+                            "type": "string",
+                            "description": "The city to find the weather for, e.g. 'San Francisco'",
+                        },
+                        "state": {
+                            "type": "string",
+                            "description": "the two-letter abbreviation for the state that the city is"
+                            " in, e.g. 'CA' which would mean 'California'",
+                        },
+                        "unit": {
+                            "type": "string",
+                            "description": "The unit to fetch the temperature in",
+                            "enum": ["celsius", "fahrenheit"],
+                        },
+                    },
+                    "required": ["city", "state", "unit"],
+                },
+            },
+        }
+
+        tool_get_current_date = {
+            "type": "function",
+            "function": {
+                "name": "get_current_date",
+                "description": "Get the current date and time for a given timezone",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "timezone": {
+                            "type": "string",
+                            "description": "The timezone to fetch the current date and time for, e.g. 'America/New_York'",
+                        }
+                    },
+                    "required": ["timezone"],
+                },
+            },
+        }
+
+        schema_get_current_weather = tool_get_current_weather["function"]["parameters"]
+        schema_get_current_date = tool_get_current_date["function"]["parameters"]
+
+        response = client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {
+                    "role": "system",
+                    "content": f"""
+# Tool Instructions
+- Always execute python code in messages that you share.
+- When looking for real time information use relevant functions if available else fallback to brave_search
+You have access to the following functions:
+Use the function 'get_current_weather' to: Get the current weather in a given location
+{tool_get_current_weather["function"]}
+Use the function 'get_current_date' to: Get the current date and time for a given timezone
+{tool_get_current_date["function"]}
+If a you choose to call a function ONLY reply in the following format:
+<{{start_tag}}={{function_name}}>{{parameters}}{{end_tag}}
+where
+start_tag => `<function`
+parameters => a JSON dict with the function argument name as key and function argument value as value.
+end_tag => `</function>`
+Here is an example,
+<function=example_function_name>{{"example_name": "example_value"}}</function>
+Reminder:
+- Function calls MUST follow the specified format
+- Required parameters MUST be specified
+- Only call one function at a time
+- Put the entire function call reply on one line
+- Always add your sources when using search results to answer the user query
+You are a helpful assistant.""",
+                },
+                {
+                    "role": "user",
+                    "content": "You are in New York. Please get the current date and time, and the weather.",
+                },
+            ],
+            response_format={
+                "type": "structural_tag",
+                "structures": [
+                    {
+                        "begin": "<function=get_current_weather>",
+                        "schema": schema_get_current_weather,
+                        "end": "</function>",
+                    },
+                    {
+                        "begin": "<function=get_current_date>",
+                        "schema": schema_get_current_date,
+                        "end": "</function>",
+                    },
+                ],
+                "triggers": ["<function="],
+            },
+        )
+
+        text = response.choices[0].message.content
+        print(f"{text=}")
+        # Use non-greedy matching to capture only the first closing tag
+        m = re.search(r"<function=get_current_date>(.*?)</function>", text, flags=re.S)
+        self.assertIsNotNone(m, f"Tagged date call not found in: {text}")
+        inner = m.group(1).strip()
+        print(f"{inner=}")
+        parsed = json.loads(inner)
+        self.assertEqual(parsed["timezone"], "America/New_York")
+
+        # Optionally also verify weather call if present
+        m_w = re.search(r"<function=get_current_weather>(.*?)</function>", text, flags=re.S)
+        if m_w is not None:
+            inner_w = m_w.group(1).strip()
+            try:
+                parsed_w = json.loads(inner_w)
+            except Exception:
+                self.fail(f"Weather function body is not valid JSON: {inner_w}")
+            # Basic keys should exist per schema
+            self.assertIn("city", parsed_w)
+            self.assertIn("state", parsed_w)
+            self.assertIn("unit", parsed_w)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -219,6 +219,9 @@ suites = {
         TestFile("test/srt/openai_server/basic/test_serving_chat.py", 0.1),
         TestFile("test/srt/openai_server/basic/test_serving_completions.py", 0.1),
         TestFile("test/srt/openai_server/basic/test_openai_server.py", 1),
+        TestFile("test/srt/openai_server/features/test_ebnf.py", 2),
+        TestFile("test/srt/openai_server/features/test_json_mode.py", 2),
+        TestFile("test/srt/openai_server/features/test_structural_tag.py", 2),
         TestFile("test/srt/test_srt_engine.py", 1),
     ],
     "e2e-test-tpu-v6e-4": [


### PR DESCRIPTION
CLOSES: #331 

## Motivation

- Provide reliable, machine-parseable outputs for downstream systems (APIs, automations, UI forms) without brittle post-processing.
- Reduce hallucinations by constraining generation to valid shapes (JSON Schema), formats (EBNF), or patterns (regex).
- Unify a single feature across OpenAI-compatible endpoints and the SRT engine.
- Support modern tool/function-calling by validating and constraining arguments, while preserving streaming and performance.

## Modifications

- Adds structured output via grammar-constrained decoding (JSON Schema, regex, EBNF, structural tags) powered by llguidance.
- Introduces JAX/TPU-friendly vocab bitmasking and applies masks in the sampler for token filtering.
- Extends scheduler pipeline: async grammar compilation + caching, timeout/invalid handling, grammar termination checks, and mask propagation (incl. overlap mode).
- Updates OpenAI-serving path to accept response_format schemas and pass them into sampling params.
- Adds utils to serialize JSON Schema, new server args to control JSON whitespace behavior.
- Adds dependency llguidance~=1.3.0.

## Accuracy Tests
Launch Server:
```
MODEL_NAME="Qwen/Qwen3-8B"
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache \
python3 -u -m sgl_jax.launch_server \
--model-path ${MODEL_NAME} \
--trust-remote-code \
--tp-size=4 \
--device=tpu \
--mem-fraction-static=0.8 \
--chunked-prefill-size=2048 \
--download-dir=/tmp \
--dtype=bfloat16 \
--max-running-requests 256 \
--skip-server-warmup \
--page-size=128 \
--disable-radix-cache
```
Result:
gsm8k (bsz=128)
<img width="1576" height="216" alt="image" src="https://github.com/user-attachments/assets/9612d965-dfca-4545-98de-013198e4f1b6" />
mmlu (bsz=128)
<img width="702" height="1668" alt="image" src="https://github.com/user-attachments/assets/2ad66287-2614-4810-a259-0d0520cdd297" />

## Benchmarking and Profiling
testing methodology reference: [qwen3_benchmark](https://github.com/sgl-project/sglang-jax/blob/main/docs/performance/qwen3_benchmark.md)
Launch Server:
```
MODEL_NAME="Qwen/Qwen3-8B"
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache \
python3 -u -m sgl_jax.launch_server \
--model-path ${MODEL_NAME} \
--trust-remote-code \
--tp-size=4 \
--device=tpu \
--mem-fraction-static=0.8 \
--chunked-prefill-size=2048 \
--download-dir=/tmp \
--dtype=bfloat16 \
--max-running-requests 256 \
--skip-server-warmup \
--page-size=128 \
--disable-radix-cache
```
Result:
| ISL/OSL | Batch Size | TTFT(ms)_SGL_JAX | ITL(ms)_SGL_JAX | Input_Throughput(tok/s)_SGL_JAX | Output_Throughput(tok/s)_SGL_JAX |
|--------------|------------|------------|------------|------------|------------|
| 1024/1024 | 8 | 111.08 | 6.47 | 1211.24 | 1211.24 |
| 1024/1024 | 16 | 222.74 | 7.00 | 2211.26 | 2211.26 |
| 1024/1024 | 32 | 446.10 | 8.94 | 3401.68 | 3401.68 |
| 1024/1024 | 64 | 892.66 | 12.72 | 4699.88 | 4699.88 |
| 1024/1024 | 128 | 1783.95 | 17.67 | 6686.18 | 6686.18 |
| 1024/1024 | 256 | 3571.60 | 20.23 | 10217.53 | 10217.53 |
| 4096/1024 | 8 | 470.00 | 6.75 | 4434.91 | 1108.73 |
| 4096/1024 | 16 | 940.60 | 7.53 | 7552.57 | 1888.14 |
| 4096/1024 | 32 | 1881.49 | 9.63 | 11101.33 | 2775.33 |
| 4096/1024 | 64 | 3763.20 | 14.13 | 14027.13 | 3506.78 |
| 4096/1024 | 128 | 7526.70 | 25.14 | 14315.07 | 3578.77 |
| 4096/1024 | 256 | 15063.07 | 25.15 | 14730.04 | 3682.51 |
| 8192/1024 | 8 | 1031.10 | 6.70 | 8266.00 | 1033.25 |
| 8192/1024 | 16 | 2062.76 | 8.57 | 12063.21 | 1507.90 |
| 8192/1024 | 32 | 4125.87 | 13.37 | 14671.70 | 1833.96 |
| 8192/1024 | 64 | 8250.86 | 23.17 | 16355.67 | 2044.46 |
| 8192/1024 | 128 | 16500.94 | 24.04 | 16123.97 | 2015.50 |
| 8192/1024 | 256 | 33000.86 | 24.13 | 16150.66 | 2018.83 |

## Test command
### e2e test
```
python3 test/srt/openai_server/features/test_ebnf.py
python3 test/srt/openai_server/features/test_json_mode.py
python3 test/srt/openai_server/features/test_structural_tag.py
```

### unit test
```
python3 python/sgl_jax/test/constrained/test_bitmask_ops.py
```

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
