### PR TITLE
fix float32 for lm_head

### DIFF
--- a/python/sgl_jax/srt/models/bailing_moe.py
+++ b/python/sgl_jax/srt/models/bailing_moe.py
@@ -450,6 +450,8 @@ class BailingMoEForCausalLM(nnx.Module):
             self.lm_head = ParallelLMHead(
                 config.vocab_size,
                 config.hidden_size,
+                dtype=self.dtype,
+                param_dtype=self.dtype,
                 kernel_axes=("tensor", None),
                 rngs=rngs,
             )

--- a/python/sgl_jax/srt/models/llama.py
+++ b/python/sgl_jax/srt/models/llama.py
@@ -400,6 +400,8 @@ class LlamaForCausalLM(nnx.Module):
             self.lm_head = ParallelLMHead(
                 config.vocab_size,
                 config.hidden_size,
+                dtype=self.dtype,
+                param_dtype=self.dtype,
                 kernel_axes=("tensor", None),
                 rngs=rngs,
             )

--- a/python/sgl_jax/srt/models/qwen.py
+++ b/python/sgl_jax/srt/models/qwen.py
@@ -322,6 +322,8 @@ class QWenLMHeadModel(nnx.Module):
             self.lm_head = ParallelLMHead(
                 vocab_size,
                 config.hidden_size,
+                dtype=self.dtype,
+                param_dtype=self.dtype,
                 kernel_axes=("tensor", None),
                 rngs=rngs,
             )

--- a/python/sgl_jax/srt/models/qwen2.py
+++ b/python/sgl_jax/srt/models/qwen2.py
@@ -339,6 +339,8 @@ class Qwen2ForCausalLM(nnx.Module):
             self.lm_head = ParallelLMHead(
                 config.vocab_size,
                 config.hidden_size,
+                dtype=self.dtype,
+                param_dtype=self.dtype,
                 kernel_axes=("tensor", None),
                 rngs=rngs,
             )

--- a/python/sgl_jax/srt/models/qwen2_moe.py
+++ b/python/sgl_jax/srt/models/qwen2_moe.py
@@ -415,6 +415,8 @@ class Qwen2MoeForCausalLM(nnx.Module):
             self.lm_head = ParallelLMHead(
                 config.vocab_size,
                 config.hidden_size,
+                dtype=self.dtype,
+                param_dtype=self.dtype,
                 kernel_axes=("tensor", None),
                 rngs=rngs,
             )

--- a/python/sgl_jax/srt/models/qwen3.py
+++ b/python/sgl_jax/srt/models/qwen3.py
@@ -376,6 +376,8 @@ class Qwen3ForCausalLM(nnx.Module):
             self.lm_head = ParallelLMHead(
                 config.vocab_size,
                 config.hidden_size,
+                dtype=self.dtype,
+                param_dtype=self.dtype,
                 kernel_axes=("tensor", None),
                 rngs=rngs,
             )

--- a/python/sgl_jax/srt/models/qwen3_moe.py
+++ b/python/sgl_jax/srt/models/qwen3_moe.py
@@ -353,6 +353,8 @@ class Qwen3MoeForCausalLM(nnx.Module):
             self.lm_head = ParallelLMHead(
                 config.vocab_size,
                 config.hidden_size,
+                dtype=self.dtype,
+                param_dtype=self.dtype,
                 kernel_axes=("tensor", None),
                 rngs=rngs,
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
for float32，accuracy decrease
the model output is different from tunix
<img width="622" height="537" alt="image" src="https://github.com/user-attachments/assets/5bfb70dc-2231-4cc9-bd13-d5dcb4fd22ac" />

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
add dtype for lm_head
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
- server
jax == 0.7.1 libtpu==0.0.20, flax==0.0.12, transformers==4.57.1
```
commit a314ef13940f6f20b7470c62638a8ebeb72c1303
export JAX_PLATFORMS=cpu
rm -rf /tmp/jit_cache
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache JAX_USE_SHARDY_PARTITIONER=0 python3 -u -m sgl_jax.launch_server \
--model-path deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B \
--trust-remote-code  \
--tp-size=1 \
--device=cpu \
--mem-fraction-static=0.05 \
--chunked-prefill-size=2048 \
--download-dir=/tmp \
--dtype=float32 \
--attention-backend=native \
--max-running-requests 64 \
--skip-server-warmup \
--page-size=64  \
--max-total-tokens=257536 \
--random-seed=27 \
--precompile-token-paddings=128 \
--precompile-bs-paddings=64 \
--disable-overlap-schedule \
--disable-precompile \
--use-sort-for-toppk-minp \
--enable-precision-tracer \
--log-requests \
--log-requests-level=3 
```
- start trace
curl -H "Content-Type: application/json" -X POST  http://localhost:30000/start_trace -d '{"req_num":1,"save_tensor":true}'
- compare the difference with tunix 
https://github.com/google/tunix/blob/main/tests/model_alignment/qwen_align_test.py

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
- the output's difference
<img width="445" height="618" alt="image" src="https://github.com/user-attachments/assets/1f6aea81-4bb8-4555-8618-7232fb8a7900" />


<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
