### PR TITLE
fix: run test_flashattention.py failed on single TPU because of oom

### DIFF
--- a/python/sgl_jax/test/test_flashattention.py
+++ b/python/sgl_jax/test/test_flashattention.py
@@ -281,7 +281,15 @@ class TestAttention(CustomTestCase):
         self.rng_key = jax.random.PRNGKey(42)
         np.random.seed(42)
 
-    def run_test(self, mode, lens, mode_args, sliding_window=None, logit_cap=None):
+    def run_test(
+        self,
+        mode,
+        lens,
+        mode_args,
+        max_total_token_size=710016,
+        sliding_window=None,
+        logit_cap=None,
+    ):
         # Create mock forward_batch
         num_heads, head_dim, num_kv_heads, page_size, dtype = mode_args
 
@@ -299,6 +307,7 @@ class TestAttention(CustomTestCase):
                 "num_hidden_layers": 1,
                 "bf16": is_bf16,
             },
+            max_total_token_size=max_total_token_size,
         )
 
         # Debug cache mapping
@@ -595,9 +604,10 @@ class TestAttention(CustomTestCase):
         self.run_test(
             "prefill",
             lens,
-            (num_heads, head_dim, num_kv_heads, 64, jnp.bfloat16),
+            (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
             sliding_window=sliding_window_size,
             logit_cap=logit_cap,
+            max_total_token_size=200000,
         )
 
     def test_sliding_window_and_soft_cap_decode_accuracy(self):
@@ -619,9 +629,10 @@ class TestAttention(CustomTestCase):
         self.run_test(
             "decode",
             lens,
-            (num_heads, head_dim, num_kv_heads, 64, jnp.bfloat16),
+            (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
             sliding_window=sliding_window_size,
             logit_cap=logit_cap,
+            max_total_token_size=200000,
         )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
run test_flashattention.py failed on single TPU because of oom
```Traceback (most recent call last):
  File "/home/gcpuser/sky_workdir/sglang-jax/python/sgl_jax/srt/utils/common_utils.py", line 364, in retry
    return fn()
           ^^^^
  File "/home/gcpuser/sky_workdir/sglang-jax/python/sgl_jax/test/test_utils.py", line 136, in <lambda>
    lambda: super(CustomTestCase, self)._callTestMethod(method),
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gcpuser/miniconda3/envs/kkx/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/home/gcpuser/sky_workdir/sglang-jax/python/sgl_jax/test/test_flashattention.py", line 596, in test_sliding_window_and_soft_cap_prefill_accuracy
    self.run_test(
  File "/home/gcpuser/sky_workdir/sglang-jax/python/sgl_jax/test/test_flashattention.py", line 322, in run_test
    extend_k, extend_v = write_prefix_tokens_for_kv(
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gcpuser/sky_workdir/sglang-jax/python/sgl_jax/test/test_flashattention.py", line 110, in write_prefix_tokens_for_kv
    token_to_kv_pool.set_kv_buffer(0, prefix_cache_loc, prefix_k, prefix_v)
  File "/home/gcpuser/sky_workdir/sglang-jax/python/sgl_jax/srt/mem_cache/memory_pool.py", line 402, in set_kv_buffer
    self.kv_buffer[layer_idx] = _set_fused_kv_buffer(
                                ^^^^^^^^^^^^^^^^^^^^^
  File "/home/gcpuser/sky_workdir/sglang-jax/python/sgl_jax/srt/mem_cache/memory_pool.py", line 630, in _set_fused_kv_buffer
    return update_fused_kv_cache(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gcpuser/sky_workdir/sglang-jax/python/sgl_jax/srt/mem_cache/memory_pool.py", line 659, in update_fused_kv_cache
    return update_fused_kv_cache_vectorized(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gcpuser/sky_workdir/sglang-jax/python/sgl_jax/srt/mem_cache/memory_pool.py", line 777, in update_fused_kv_cache_vectorized
    kv_cache = kv_cache_update(
               ^^^^^^^^^^^^^^^^
jax.errors.JaxRuntimeError: RESOURCE_EXHAUSTED: Ran out of memory in memory space vmem while allocating on stack for %kv_cache_update.1 = bf16[710080,64,256]{2,1,0:T(8,128)(2,1)} custom-call(%select_n.2, %copy-done.1, %copy-done, %copy.5), custom_call_target="tpu_custom_call", operand_layout_constraints={s32[], s32[3,128]{1,0}, bf16[127,64,256]{2,1,0}, bf16[710080,64,256]{2,1,0}}, output_to_operand_aliasing={{}: (3, {})}, metadata={op_name="jit(kv_cache_update)/pallas_call" source_file="/home/gcpuser/sky_workdir/sglang-jax/python/sgl_jax/srt/kernels/update_kv_cache/update_kv_cache.py" source_line=205 source_end_line=205 source_column=11 source_end_column=83}. Scoped allocation with size 128.00M and limit 32.00M exceeded scoped vmem limit by 96.00M. It should not be possible to run out of scoped vmem - please file a bug against XLA.```
<!-- Describe the purpose and goals of this pull request. -->

```
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
