### PR TITLE
[BUG] Different Results on Used HBM

### DIFF
--- a/python/sgl_jax/srt/utils/jax_utils.py
+++ b/python/sgl_jax/srt/utils/jax_utils.py
@@ -114,7 +114,7 @@ def get_available_device_memory(device, distributed=False, empty_cache=True):
             stats = dev.memory_stats()
             avail_mem.append(stats["bytes_limit"] - stats["bytes_in_use"])
         avail_mem = jnp.array([min(avail_mem) / (1 << 10)], dtype=jnp.float32)
-    elif device in ("proxy"):
+    elif device == "proxy":
         live_arrays = jax.live_arrays()
         pathways_hbm_used_mem = pathways_hbm_usage_gb(live_arrays, devices)
         avail_mem = jnp.array(


### PR DESCRIPTION
Add `pathways_hbm_used_mem()` function for`pathway` backends in

https://github.com/sgl-project/sglang-jax/blob/main/python/sgl_jax/srt/utils/jax_utils.py#L47

The implementation `pathways_hbm_used_mem` is copied from 

https://github.com/vllm-project/tpu-inference/blob/b832b02020bd42f8c5f9f437ec390812451d50b4/tpu_inference/utils.py#L60-L61

Since we do not have the access to PathWay at this stage. I tested with **tpu-v6e-4**. 

The scripts for reproducing the errors is:

https://github.com/google/tunix/blob/main/scripts/grpo_demo_sglang_jax_rollout.py

The used HBM from `dev.memory_stats()` and `pathways_hbm_usage_gb` are different as following:

```
hbm_used_mem[1606439424, 1606437376, 1606437376, 1606437376]
pathways_hbm_used_mem[1606374936, 1606374912, 1606374912, 1606374912]
hbm_used_mem[1606439424, 1606437376, 1606437376, 1606437376]
pathways_hbm_used_mem[3212749872, 3212749824, 3212749824, 3212749824]
hbm_used_mem[3213076992, 3213074944, 3213074944, 3213074944]
pathways_hbm_used_mem[4819387440, 4819387392, 4819387392, 4819387392]
hbm_used_mem[3213076992, 3213074944, 3213074944, 3213074944]
pathways_hbm_used_mem[6426025008, 6426024960, 6426024960, 6426024960]

```
Fixes #367