### PR TITLE
feat: add Dockerfile for JAX server setup with TPU support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,8 @@ RUN mkdir -p /tmp/jit_cache /tmp/models
 # IMPORTANT: To run on TPU VM, you MUST use:
 #   docker run --privileged --network=host sglang-jax --model-path <MODEL> --trust-remote-code
 #
-# TPU access requires:
-#   - --privileged: For necessary system permissions
-#   - --network=host: TPU is accessed via network (gRPC), not device files
-#   - No device mounting needed: TPU is network-based, not /dev-based
-#
-# Note: TPU devices cannot be mounted in Dockerfile (they're network-accessed),
-#       so runtime flags are required for TPU access.
-ENTRYPOINT ["python", "-u", "-m", "sgl_jax.launch_server", "--host", "0.0.0.0", "--port", "30000", "--device=tpu", "--dist-init-addr=0.0.0.0:10011", "--nnodes=1", "--tp-size=4", "--node-rank=0", "--mem-fraction-static=0.8", "--max-prefill-tokens=8192", "--download-dir=/tmp", "--dtype=bfloat16", "--skip-server-warmup", "--enable-single-process", "--grammar-backend=none"]
+# Required Docker flags:
+#   - --privileged: Grants access to all devices including VFIO (/dev/vfio/0,1,2,3)
+#                   and necessary system permissions for TPU operations
+#   - --network=host: Enables gRPC network communication between JAX and TPU Runtime
+ENTRYPOINT ["python", "-u", "-m", "sgl_jax.launch_server", "--host", "0.0.0.0", "--port", "30000", "--dist-init-addr=0.0.0.0:10011", "--nnodes=1", "--tp-size=4", "--node-rank=0", "--mem-fraction-static=0.8", "--max-prefill-tokens=8192", "--download-dir=/tmp", "--dtype=bfloat16", "--skip-server-warmup", "--enable-single-process", "--grammar-backend=none"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

fix #429

deploy backend service in Container.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
Add Dockerfile to build TPU based image.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

### build image
```bash
sg docker -c "docker build -t sglang-jax ."
```

### run container
```bash
sg docker -c "docker run --privileged --network=host -p 30000:30000 sglang-jax --model-path Qwen/Qwen-7B-Chat --trust-remote-code"
```

### output example
<img width="3796" height="2656" alt="docker build   run" src="https://github.com/user-attachments/assets/3f9c917a-c382-4028-ac6b-658b23574691" />

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
