### PR TITLE
fix: xai temperature len in kernel

### DIFF
--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention.py
@@ -779,7 +779,10 @@ def _ragged_paged_attention_kernel(
                         # Correctly calculate sequence-relative position
                         prefix_len = kv_len - q_len
                         # `bq_idx * bq_sz` is the offset within the new queries for this sequence
-                        local_q_offset = bq_idx * bq_sz + lax.iota(jnp.int32, q_batch.shape[1])
+                        local_q_offset = (
+                            bq_idx * bq_sz
+                            + lax.iota(jnp.int32, q_batch.shape[1]) // num_q_heads_per_kv_head
+                        )
                         # `base_qidx` is the absolute sequence position
                         base_qidx = prefix_len + local_q_offset
                         # Tile for all KV heads, as the position is the same for each head group.

--- a/python/sgl_jax/test/test_flashattention.py
+++ b/python/sgl_jax/test/test_flashattention.py
@@ -703,105 +703,104 @@ class TestAttention(CustomTestCase):
             max_total_token_size=200000,
         )
 
-    # TODO fix xai temperature len kernel test
-    # def test_gqa_prefill_accuracy_page_size_64_temperature(self):
-    #     """Test JAX attention accuracy against PyTorch reference
-    #     Testcase (1024, 1024) fails on token 607, possible precision issue?
-    #     Token 607: max_diff=0.023438, jax_mean=-0.011597, expected_mean=-0.011597, jax_std=0.048096, expected_std=0.047607
-    #     """
-    #     # Parameters
-    #     num_heads = 32
-    #     num_kv_heads = 8
-    #     head_dim = 128
-    #     lens = [
-    #         (1, 128),
-    #         (3, 20),
-    #         (64, 64),
-    #         (20, 20),
-    #         (125, 125),
-    #         (123, 522),
-    #         (1, 511),
-    #         (1024, 1024),
-    #     ]
-    #     self.run_test(
-    #         "prefill",
-    #         lens,
-    #         (num_heads, head_dim, num_kv_heads, 64, jnp.bfloat16),
-    #         xai_temperature_len=512,
-    #     )
+    def test_gqa_prefill_accuracy_page_size_64_temperature(self):
+        """Test JAX attention accuracy against PyTorch reference
+        Testcase (1024, 1024) fails on token 607, possible precision issue?
+        Token 607: max_diff=0.023438, jax_mean=-0.011597, expected_mean=-0.011597, jax_std=0.048096, expected_std=0.047607
+        """
+        # Parameters
+        num_heads = 32
+        num_kv_heads = 8
+        head_dim = 128
+        lens = [
+            (1, 128),
+            (3, 20),
+            (64, 64),
+            (20, 20),
+            (125, 125),
+            (123, 522),
+            (1, 511),
+            (1024, 1024),
+        ]
+        self.run_test(
+            "prefill",
+            lens,
+            (num_heads, head_dim, num_kv_heads, 64, jnp.bfloat16),
+            xai_temperature_len=512,
+        )
 
-    # def test_gqa_decode_accuracy_page_size_64_temperature(self):
-    #     """Test JAX attention accuracy against native fa"""
-    #     # Parameters
-    #     num_heads = 32
-    #     num_kv_heads = 8
-    #     head_dim = 128
-    #     lens = [
-    #         (1, 119),
-    #         (1, 127),
-    #         (1, 128),
-    #         (1, 129),
-    #         (1, 133),
-    #         (1, 1001),
-    #         (1, 1023),
-    #         (1, 1024),
-    #         (1, 1025),
-    #     ]
+    def test_gqa_decode_accuracy_page_size_64_temperature(self):
+        """Test JAX attention accuracy against native fa"""
+        # Parameters
+        num_heads = 32
+        num_kv_heads = 8
+        head_dim = 128
+        lens = [
+            (1, 119),
+            (1, 127),
+            (1, 128),
+            (1, 129),
+            (1, 133),
+            (1, 1001),
+            (1, 1023),
+            (1, 1024),
+            (1, 1025),
+        ]
 
-    #     self.run_test(
-    #         "decode",
-    #         lens,
-    #         (num_heads, head_dim, num_kv_heads, 64, jnp.bfloat16),
-    #         xai_temperature_len=512,
-    #     )
+        self.run_test(
+            "decode",
+            lens,
+            (num_heads, head_dim, num_kv_heads, 64, jnp.bfloat16),
+            xai_temperature_len=512,
+        )
 
-    # def test_gqa_prefill_accuracy_page_size_1_temperature(self):
-    #     """Test JAX attention accuracy against PyTorch reference"""
-    #     # Parameters
-    #     num_heads = 32
-    #     num_kv_heads = 8
-    #     head_dim = 128
-    #     lens = [
-    #         (1, 128),
-    #         (3, 20),
-    #         (64, 64),
-    #         (20, 20),
-    #         (125, 125),
-    #         (1024, 1024),
-    #         (123, 522),
-    #         (1, 511),
-    #     ]
-    #     self.run_test(
-    #         "prefill",
-    #         lens,
-    #         (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
-    #         xai_temperature_len=512,
-    #     )
+    def test_gqa_prefill_accuracy_page_size_1_temperature(self):
+        """Test JAX attention accuracy against PyTorch reference"""
+        # Parameters
+        num_heads = 32
+        num_kv_heads = 8
+        head_dim = 128
+        lens = [
+            (1, 128),
+            (3, 20),
+            (64, 64),
+            (20, 20),
+            (125, 125),
+            (1024, 1024),
+            (123, 522),
+            (1, 511),
+        ]
+        self.run_test(
+            "prefill",
+            lens,
+            (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
+            xai_temperature_len=512,
+        )
 
-    # def test_gqa_decode_accuracy_page_size_1_temperature(self):
-    #     """Test JAX attention accuracy against native fa"""
-    #     # Parameters
-    #     num_heads = 32
-    #     num_kv_heads = 8
-    #     head_dim = 128
-    #     lens = [
-    #         (1, 119),
-    #         (1, 127),
-    #         (1, 128),
-    #         (1, 129),
-    #         (1, 133),
-    #         (1, 1001),
-    #         (1, 1023),
-    #         (1, 1024),
-    #         (1, 1025),
-    #     ]
+    def test_gqa_decode_accuracy_page_size_1_temperature(self):
+        """Test JAX attention accuracy against native fa"""
+        # Parameters
+        num_heads = 32
+        num_kv_heads = 8
+        head_dim = 128
+        lens = [
+            (1, 119),
+            (1, 127),
+            (1, 128),
+            (1, 129),
+            (1, 133),
+            (1, 1001),
+            (1, 1023),
+            (1, 1024),
+            (1, 1025),
+        ]
 
-    #     self.run_test(
-    #         "decode",
-    #         lens,
-    #         (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
-    #         xai_temperature_len=512,
-    #     )
+        self.run_test(
+            "decode",
+            lens,
+            (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
+            xai_temperature_len=512,
+        )
 
     def test_mha_prefill_with_custom_mask(self):
         """Test JAX attention accuracy against PyTorch reference"""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

Fix SGL-57 https://github.com/sgl-project/sglang-jax/issues/421

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
sky exec sgl-jax-tpu-v6e-32-merge-two-fix-24743 -d -- “cd sglang-jax && source .venv/bin/activate  && JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_server --model-path /models/xai-grok-2 --trust-remote-code --tp-size=32 --device=tpu --random-seed=3 --mem-fraction-static=0.8 --chunked-prefill-size=8192 --download-dir=/dev/shm --dtype=bfloat16 --max-running-requests=128 --skip-server-warmup --page-size=128 --tokenizer-path /models/xai-grok-2/tokenizer.tok.json  --dist-init-addr=10.128.0.94:10015 --nnodes=8 --node-rank=\${SKYPILOT_NODE_RANK}”
```

```
evalscope eval  --model /models/xai-grok-2 --api-url http://127.0.0.1:30000/v1/chat/completions  --api-key EMPTY  --eval-type openai_api --datasets gpqa_diamond --eval-batch-size 198 --dataset-args ‘{“gpqa_diamond”: {“few_shot_num”: 3}}’  --generation-config ‘{“temperature”: 0.5,“top_p”:0.8,“top_k”:40, “max_tokens”: 4096}’
```
<img width="1908" height="514" alt="image" src="https://github.com/user-attachments/assets/4784ab06-c003-435e-a6b9-e752cc15f6bb" />

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
