### PR TITLE
fix: skip to initialize grammar backend when tokenizer is not supported

### DIFF
--- a/python/sgl_jax/srt/constrained/base_grammar_backend.py
+++ b/python/sgl_jax/srt/constrained/base_grammar_backend.py
@@ -165,9 +165,9 @@ def create_grammar_backend(
     name = server_args.grammar_backend
 
     if name == "llguidance":
-        from sgl_jax.srt.constrained.llguidance_backend import GuidanceBackend
+        from sgl_jax.srt.constrained.llguidance_backend import get_guidance_backend
 
-        grammar_backend = GuidanceBackend(
+        grammar_backend = get_guidance_backend(
             tokenizer=tokenizer,
             num_threads=4,
             n_vocab=vocab_size,


### PR DESCRIPTION
## Motivation

FIXES: #464 

## Modifications

- skip to initialize grammar backend when tokenizer is not supported.
- add to_finish to support abort req in the middle;  the current implementation causes the request to hang and never return. 

## Accuracy Tests

<None>

## Benchmarking and Profiling

<None>

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
