### PR TITLE
[Fix] rm qwen2 attention o_proj.bias, because it doesnot has this weights

### DIFF
--- a/python/sgl_jax/srt/models/qwen2.py
+++ b/python/sgl_jax/srt/models/qwen2.py
@@ -446,11 +446,6 @@ class Qwen2ForCausalLM(nnx.Module):
                     head_dim_padding=True,
                     kv_head_padding=True,
                 ),
-                f"{prefix}.self_attn.o_proj.bias": WeightMapping(
-                    target_path=f"{target_prefix}.self_attn.o_proj.bias",
-                    sharding=(None,),
-                    transpose=False,
-                ),
             }
             mappings.update(bias_mappings)
 


### PR DESCRIPTION
qwen2 attention o_proj.bias  doesnot has this weights 
avoid warning like 
<img width="1962" height="870" alt="image" src="https://github.com/user-attachments/assets/0cd39935-0c81-41a3-9133-af6cfcb461ad" />

test result
<img width="1410" height="214" alt="image" src="https://github.com/user-attachments/assets/fff015fc-86c4-4ec4-8fcd-f255693b3dce" />