### PR TITLE
feat: radix cache with extra key & Lock the JAX version to 0.8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,5 @@ CLAUDE.md
 
 #gemini code
 .gemini-clipboard
+.gemini/settings.json
+.gemini.md

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -47,13 +47,13 @@ dependencies = [
 dev = [
 ]
 tpu = [
-    "jax[tpu]~=0.8.0",
+    "jax[tpu]==0.8.1",
 ]
 gpu = [
-    "jax[cuda12]~=0.8.0",
+    "jax[cuda12]==0.8.1",
 ]
 all = [
-    "jax[tpu]~=0.8.0",
+    "jax[tpu]==0.8.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/python/sgl_jax/srt/entrypoints/openai/protocol.py
+++ b/python/sgl_jax/srt/entrypoints/openai/protocol.py
@@ -165,6 +165,7 @@ class CompletionRequest(BaseModel):
     ignore_eos: bool = False
     skip_special_tokens: bool = True
     lora_path: list[str | None] | str | None | None = None
+    extra_key: str | None = None
     session_params: dict | None = None
 
     # For PD disaggregation
@@ -424,6 +425,7 @@ class ChatCompletionRequest(BaseModel):
     continue_final_message: bool = False
     skip_special_tokens: bool = True
     lora_path: list[str | None] | str | None | None = None
+    extra_key: str | None = None
     session_params: dict | None = None
     separate_reasoning: bool = True
     stream_reasoning: bool = True

--- a/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
+++ b/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
@@ -82,6 +82,7 @@ class OpenAIServingChat(OpenAIServingBase):
             logprob_start_len=-1,
             top_logprobs_num=request.top_logprobs or 0,
             stream=request.stream,
+            extra_key=request.extra_key,
             rid=request.rid,
         )
 

--- a/python/sgl_jax/srt/entrypoints/openai/serving_completions.py
+++ b/python/sgl_jax/srt/entrypoints/openai/serving_completions.py
@@ -78,11 +78,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
             logprob_start_len=logprob_start_len,
             return_text_in_logprobs=True,
             stream=request.stream,
-            # lora_path=request.lora_path,
-            # bootstrap_host=request.bootstrap_host,
-            # bootstrap_port=request.bootstrap_port,
-            # bootstrap_room=request.bootstrap_room,
-            # return_hidden_states=request.return_hidden_states,
+            extra_key=request.extra_key,
             rid=request.rid,
         )
 

--- a/python/sgl_jax/srt/kernels/update_kv_cache/update_kv_cache.py
+++ b/python/sgl_jax/srt/kernels/update_kv_cache/update_kv_cache.py
@@ -4,7 +4,6 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
-from jax._src import dtypes
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 from jax.sharding import PartitionSpec as P
@@ -46,7 +45,7 @@ def get_num_slices_per_block(new_kv: jax.Array, kv_cache: jax.Array, page_size=1
     ), f"new_kv.dtype={new_kv.dtype} is not equal to kv_cache.dtype={kv_cache.dtype}"
     assert new_kv.dtype != jnp.float16, f"new_kv.dtype={new_kv.dtype} is not supported"
 
-    bits = dtypes.bit_width(kv_cache.dtype)
+    bits = jnp.dtype(kv_cache.dtype).itemsize * 8
     assert bits % 8 == 0, f"bits={bits} is not divisible by 8"
 
     bytes_per_element = bits // 8

--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -111,6 +111,8 @@ class TokenizedGenerateReqInput:
     token_ids_logprob: list[list[int]] | list[int] | None = None
     # Whether to stream output
     stream: bool = False
+    # Extra key for cache namespace isolation (e.g., cache_salt, lora_id)
+    extra_key: str | None = None
 
 
 @dataclass
@@ -130,6 +132,8 @@ class EmbeddingReqInput:
     text: str = ""
     input_ids: list[int] = None
     normalize: bool = True
+    # Extra key for cache namespace isolation
+    extra_key: str | None = None
 
 
 @dataclass
@@ -157,6 +161,8 @@ class GenerateReqInput:
     token_ids_logprob: list[list[int]] | list[int] | None = None
     # Whether to detokenize tokens in text in the returned logprobs.
     return_text_in_logprobs: bool = True
+    # Extra key for cache namespace isolation (e.g., cache_salt)
+    extra_key: list[str] | str | None = None
 
     def _normalize_rid(self, num):
         """Normalize request IDs for batch processing."""

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -610,6 +610,7 @@ class Scheduler(
             top_logprobs_num=recv_req.top_logprobs_num,
             token_ids_logprob=recv_req.token_ids_logprob,
             stream=recv_req.stream,
+            extra_key=recv_req.extra_key,
             eos_token_ids=self.model_config.hf_eos_token_id,
             vocab_size=self.model_config.vocab_size,
         )

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -349,6 +349,7 @@ class TokenizerManager:
             obj.top_logprobs_num,
             obj.token_ids_logprob,
             obj.stream,
+            obj.extra_key,
         )
         # note: When only `return_logprob` is specified, we assume that only the output probability is required.
         if (

--- a/python/sgl_jax/srt/mem_cache/radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/radix_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import heapq
 import time
 from collections import defaultdict
+from collections.abc import Iterator
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -10,13 +11,38 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from sgl_jax.srt.managers.schedule_batch import Req
 from sgl_jax.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache, MatchResult
 from sgl_jax.srt.mem_cache.memory_pool import ReqToTokenPool
 
 if TYPE_CHECKING:
-    pass
+    from sgl_jax.srt.managers.schedule_batch import Req
+
+
+class RadixKey:
+    """
+    Composite key for radix cache that combines token IDs and an optional extra key.
+    The extra key enables cache namespace isolation (e.g., for different LoRA adapters).
+    """
+
+    def __init__(self, token_ids: list[int], extra_key: str | None = None):
+        self.token_ids = token_ids
+        self.extra_key = extra_key
+
+    def __len__(self) -> int:
+        return len(self.token_ids)
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(self.token_ids)
+
+    def __getitem__(self, idx: int | slice) -> RadixKey:
+        if isinstance(idx, slice):
+            return RadixKey(self.token_ids[idx], self.extra_key)
+        return RadixKey([self.token_ids[idx]], self.extra_key)
+
+    def __repr__(self) -> str:
+        preview = self.token_ids[:10]
+        return f"RadixKey(extra_key={self.extra_key!r}, token_ids={preview}{'...' if len(self.token_ids) > 10 else ''})"
 
 
 class TreeNode:
@@ -25,7 +51,7 @@ class TreeNode:
     def __init__(self, id: int | None = None):
         self.children = defaultdict(TreeNode)
         self.parent = None
-        self.key = None
+        self.key: RadixKey = None
         self.value = None
         self.lock_ref = 0
         self.last_access_time = time.monotonic()
@@ -51,25 +77,41 @@ class TreeNode:
         return self.last_access_time < other.last_access_time
 
 
-def _key_match_page_size1(key0: list, key1: list):
+def _check_extra_key(key0: RadixKey, key1: RadixKey):
+    """Check that two RadixKeys have the same extra_key."""
+    if key0.extra_key != key1.extra_key:
+        raise ValueError(
+            f"_key_match should be run on the same extra key, but got key0.extra_key={key0.extra_key} != key1.extra_key={key1.extra_key}"
+        )
+
+
+def _key_match_page_size1(key0: RadixKey, key1: RadixKey):
+    _check_extra_key(key0, key1)
     i = 0
-    for k0, k1 in zip(key0, key1):
+    for k0, k1 in zip(key0.token_ids, key1.token_ids):
         if k0 != k1:
             break
         i += 1
     return i
 
 
-def _key_match_paged(key0: list, key1: list, page_size: int):
+def _key_match_paged(key0: RadixKey, key1: RadixKey, page_size: int):
+    _check_extra_key(key0, key1)
     min_len = min(len(key0), len(key1))
 
     i = 0
     while i < min_len:
-        if key0[i : i + page_size] != key1[i : i + page_size]:
+        if key0.token_ids[i : i + page_size] != key1.token_ids[i : i + page_size]:
             break
         i += page_size
 
     return i
+
+
+def get_child_key(key: RadixKey, page_size: int = 1):
+    """Get child key for tree traversal, incorporating extra_key for namespace isolation."""
+    plain_key = key.token_ids[0] if page_size == 1 else tuple(key.token_ids[:page_size])
+    return plain_key if key.extra_key is None else (key.extra_key, plain_key)
 
 
 def _convert_to_bigram_key(tokens: list[int]) -> list[tuple[int, int]]:
@@ -122,13 +164,10 @@ class RadixCache(BasePrefixCache):
 
         if self.page_size == 1:
             self.key_match_fn = _key_match_page_size1
-            self.get_child_key_fn = lambda key: (int(key[0]) if hasattr(key[0], "item") else key[0])
+            self.get_child_key_fn = get_child_key
         else:
             self.key_match_fn = partial(_key_match_paged, page_size=page_size)
-            # Ensure returning hashable types, convert numpy arrays to Python native types
-            self.get_child_key_fn = lambda key: tuple(
-                int(x) if hasattr(x, "item") else x for x in key[:page_size]
-            )
+            self.get_child_key_fn = partial(get_child_key, page_size=page_size)
         self.reset()
 
     def _create_tokens_data(self, tokens: list[int]) -> np.ndarray:
@@ -139,14 +178,18 @@ class RadixCache(BasePrefixCache):
 
     def reset(self):
         self.root_node = TreeNode()
-        self.root_node.key = []
+        self.root_node.key = RadixKey(token_ids=[], extra_key=None)
         self.root_node.value = []
         self.root_node.lock_ref = 1
         self.evictable_size_ = 0
         self.protected_size_ = 0
 
-    def match_prefix(self, key: list[int], **kwargs) -> MatchResult:
-        key = self.key_convert_fn(key)
+    def match_prefix(self, key: RadixKey | list[int], **kwargs) -> MatchResult:
+        # Support both RadixKey and plain list for backward compatibility
+        if not isinstance(key, RadixKey):
+            extra_key = kwargs.get("extra_key")
+            key = RadixKey(key, extra_key)
+
         if self.disable or len(key) == 0:
             empty_array = np.empty((0,), dtype=np.int32)
 
@@ -157,11 +200,14 @@ class RadixCache(BasePrefixCache):
                 host_hit_length=0,
             )
 
-        if self.page_size != 1:
-            page_aligned_len = len(key) // self.page_size * self.page_size
-            key = key[:page_aligned_len]
+        # Convert and align key
+        converted_key = RadixKey(self.key_convert_fn(key.token_ids), key.extra_key)
 
-        token_sequences, last_node = self._match_prefix_helper(self.root_node, key)
+        if self.page_size != 1:
+            page_aligned_len = len(converted_key) // self.page_size * self.page_size
+            converted_key = converted_key[:page_aligned_len]
+
+        token_sequences, last_node = self._match_prefix_helper(self.root_node, converted_key)
 
         if token_sequences:
             valid_tokens = []
@@ -186,20 +232,27 @@ class RadixCache(BasePrefixCache):
             host_hit_length=0,
         )
 
-    def insert(self, key: list, value=None):
+    def insert(self, key: RadixKey | list, value=None):
         if self.disable:
             return 0
-        key = self.key_convert_fn(key)
+
+        # Support both RadixKey and plain list for backward compatibility
+        if not isinstance(key, RadixKey):
+            key = RadixKey(key, None)
+
+        # Convert key
+        converted_key = RadixKey(self.key_convert_fn(key.token_ids), key.extra_key)
+
         if value is None:
-            value = self._create_tokens_data(key)
+            value = self._create_tokens_data(converted_key.token_ids)
         elif isinstance(value, list):
             value = self._create_tokens_data(value)
 
         if self.is_eagle:
             # Make sure the value len equal to the EAGLE bigram key len
-            value = value[: len(key)]
+            value = value[: len(converted_key)]
 
-        return self._insert_helper(self.root_node, key, value)
+        return self._insert_helper(self.root_node, converted_key, value)
 
     def cache_finished_req(self, req: Req):
         """Cache completed requests"""
@@ -237,7 +290,9 @@ class RadixCache(BasePrefixCache):
             old_prefix_len -= 1
 
         # Radix Cache takes over one reference from memory pool
-        new_prefix_len = self.insert(token_ids[:page_aligned_token_len], page_aligned_kv_indices)
+        new_prefix_len = self.insert(
+            RadixKey(token_ids[:page_aligned_token_len], req.extra_key), page_aligned_kv_indices
+        )
 
         self.token_to_kv_pool_allocator.free(kv_indices[old_prefix_len:new_prefix_len])
         # free the unaligned tail
@@ -277,11 +332,12 @@ class RadixCache(BasePrefixCache):
             old_prefix_len -= 1
 
         # Radix Cache takes over one reference from memory pool
-        new_prefix_len = self.insert(page_aligned_token_ids, page_aligned_kv_indices)
+        radix_key = RadixKey(page_aligned_token_ids, req.extra_key)
+        new_prefix_len = self.insert(radix_key, page_aligned_kv_indices)
         self.token_to_kv_pool_allocator.free(kv_indices[old_prefix_len:new_prefix_len])
 
         # Prefix indices may have been updated, reuse them
-        new_match_result = self.match_prefix(page_aligned_token_ids)
+        new_match_result = self.match_prefix(radix_key)
         new_indices = new_match_result.device_indices  # cpu
         new_last_node = new_match_result.last_device_node
 
@@ -383,7 +439,7 @@ class RadixCache(BasePrefixCache):
 
     ##### Internal Helper Functions #####
 
-    def _match_prefix_helper(self, node: TreeNode, key: list):
+    def _match_prefix_helper(self, node: TreeNode, key: RadixKey):
         node.last_access_time = time.monotonic()
 
         child_key = self.get_child_key_fn(key)
@@ -392,6 +448,7 @@ class RadixCache(BasePrefixCache):
         while len(key) > 0 and child_key in node.children:
             child = node.children[child_key]
             child.last_access_time = time.monotonic()
+
             prefix_len = self.key_match_fn(child.key, key)
             if prefix_len < len(child.key):
                 new_node = self._split_node(child.key, child, prefix_len)
@@ -401,29 +458,34 @@ class RadixCache(BasePrefixCache):
             else:
                 token_sequences.append(child.value)
                 node = child
-                key = key[prefix_len:]
+                key = key[prefix_len:]  # This creates a new RadixKey with sliced tokens
 
                 if len(key):
                     child_key = self.get_child_key_fn(key)
 
         return token_sequences, node
 
-    def _split_node(self, key, child: TreeNode, split_len: int):
+    def _split_node(self, key: RadixKey, child: TreeNode, split_len: int):
         new_node = TreeNode()
-        new_node.children = {self.get_child_key_fn(key[split_len:]): child}
         new_node.parent = child.parent
         new_node.lock_ref = child.lock_ref
         new_node.key = child.key[:split_len]
         new_node.value = child.value[:split_len].copy()
 
+        # Update child
         child.parent = new_node
         child.key = child.key[split_len:]
         child.value = child.value[split_len:].copy()
+
+        # Re-key old child in new_node's children
+        new_node.children = {self.get_child_key_fn(child.key): child}
+
+        # Update parent's reference to new_node
         new_node.parent.children[self.get_child_key_fn(key)] = new_node
 
         return new_node
 
-    def _insert_helper(self, node: TreeNode, key: list, value):
+    def _insert_helper(self, node: TreeNode, key: RadixKey, value):
         if isinstance(value, jnp.ndarray):
             assert value.ndim == 1, "value must be a 1D array"
 
@@ -437,9 +499,10 @@ class RadixCache(BasePrefixCache):
         while len(key) > 0 and child_key in node.children:
             node = node.children[child_key]
             node.last_access_time = time.monotonic()
+
             prefix_len = self.key_match_fn(node.key, key)
             total_prefix_length += prefix_len
-            key = key[prefix_len:]
+            key = key[prefix_len:]  # Slices RadixKey
             value = value[prefix_len:]
 
             if prefix_len < len(node.key):
@@ -469,11 +532,12 @@ class RadixCache(BasePrefixCache):
         print(
             " " * indent,
             len(node.key),
-            node.key[:10] if node.key else [],
+            node.key.token_ids[:10] if node.key else [],
             f"r={node.lock_ref}",
+            f"extra_key={node.key.extra_key if node.key else None}",
             value_info,
         )
-        for key, child in node.children.items():
+        for _, child in node.children.items():
             self._print_helper(child, indent + 2)
 
     def _delete_leaf_no_size_update(self, node):

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -12,6 +12,12 @@ import numpy as np
 from sgl_jax.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
 from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache, MatchResult
 from sgl_jax.srt.mem_cache.memory_pool import ReqToTokenPool
+from sgl_jax.srt.mem_cache.radix_cache import RadixKey
+from sgl_jax.srt.mem_cache.radix_cache import (
+    _key_match_page_size1 as _key_match_page_size1_radix,
+)
+from sgl_jax.srt.mem_cache.radix_cache import _key_match_paged as _key_match_paged_radix
+from sgl_jax.srt.mem_cache.radix_cache import get_child_key
 
 if TYPE_CHECKING:
     from sgl_jax.srt.managers.schedule_batch import Req
@@ -29,7 +35,7 @@ class TreeNode:
     def __init__(self, id: int | None = None):
         self.children = defaultdict(TreeNode)
         self.parent: TreeNode = None
-        self.key: list[int] = None
+        self.key: RadixKey = None
         self.value: np.array | None = None
         # swa_tombstone is used to indicate the kv indices have been freed for swa layers
         self.swa_tombstone = False
@@ -67,27 +73,6 @@ class TreeNode:
 
     def __lt__(self, other: TreeNode):
         return self.last_access_time < other.last_access_time
-
-
-def _key_match_page_size1(key0: list, key1: list):
-    i = 0
-    for k0, k1 in zip(key0, key1):
-        if k0 != k1:
-            break
-        i += 1
-    return i
-
-
-def _key_match_paged(key0: list, key1: list, page_size: int):
-    min_len = min(len(key0), len(key1))
-
-    i = 0
-    while i < min_len:
-        if key0[i : i + page_size] != key1[i : i + page_size]:
-            break
-        i += page_size
-
-    return i
 
 
 def gen_swa_uuid() -> int:
@@ -309,11 +294,11 @@ class SWARadixCache(BasePrefixCache):
         self.disable = disable
 
         if self.page_size == 1:
-            self.key_match_fn = _key_match_page_size1
-            self.get_child_key_fn = lambda key: key[0]
+            self.key_match_fn = _key_match_page_size1_radix
+            self.get_child_key_fn = get_child_key
         else:
-            self.key_match_fn = partial(_key_match_paged, page_size=page_size)
-            self.get_child_key_fn = lambda key: tuple(key[:page_size])
+            self.key_match_fn = partial(_key_match_paged_radix, page_size=page_size)
+            self.get_child_key_fn = partial(get_child_key, page_size=page_size)
 
         self.sliding_window_size = sliding_window_size
         self.reset()
@@ -329,7 +314,7 @@ class SWARadixCache(BasePrefixCache):
 
     def reset(self) -> None:
         self.root_node = TreeNode()
-        self.root_node.key = []
+        self.root_node.key = RadixKey(token_ids=[], extra_key=None)
         self.root_node.value = []
         self.root_node.full_lock_ref = 1
         self.root_node.swa_lock_ref = 1
@@ -341,10 +326,10 @@ class SWARadixCache(BasePrefixCache):
         self.full_lru_list = LRUList(swa=False)
         self.swa_lru_list = LRUList(swa=True)
 
-    def match_prefix(self, key: list[int], **kwargs) -> MatchResult:
+    def match_prefix(self, key: RadixKey | list[int], **kwargs) -> MatchResult:
         """Find the matching prefix from the radix tree.
         Args:
-            key: A list of token IDs to find a matching prefix.
+            key: A RadixKey or list of token IDs to find a matching prefix.
         Returns:
             A tuple of a array of matching prefix token IDs and
             the last node that contains the prefix values. Note that
@@ -352,6 +337,11 @@ class SWARadixCache(BasePrefixCache):
             The last node create a new child if the prefix is shorter
             than the last node's value.
         """
+        # Support both RadixKey and plain list for backward compatibility
+        if not isinstance(key, RadixKey):
+            extra_key = kwargs.get("extra_key")
+            key = RadixKey(key, extra_key)
+
         if self.disable or len(key) == 0:
             return MatchResult(
                 device_indices=np.empty(
@@ -374,12 +364,16 @@ class SWARadixCache(BasePrefixCache):
             last_host_node=last_node,
         )
 
-    def insert(self, key: list, value=None, prev_prefix_len: int = 0) -> int:
+    def insert(self, key: RadixKey | list, value=None, prev_prefix_len: int = 0) -> int:
         if self.disable:
             return 0
 
+        # Support both RadixKey and plain list for backward compatibility
+        if not isinstance(key, RadixKey):
+            key = RadixKey(key, None)
+
         if value is None:
-            value = [x for x in key]
+            value = [x for x in key.token_ids]
         return self._insert_helper(self.root_node, key, value, prev_prefix_len)
 
     def cache_finished_req(self, req: Req) -> None:
@@ -409,7 +403,7 @@ class SWARadixCache(BasePrefixCache):
         # insert the token_ids and kv_indices into the radix tree
         # Note: the insert function already frees the overlapped kv_indices
         self.insert(
-            token_ids[:page_aligned_len],
+            RadixKey(token_ids[:page_aligned_len], req.extra_key),
             page_aligned_kv_indices,
             len(req.prefix_indices),
         )
@@ -441,11 +435,15 @@ class SWARadixCache(BasePrefixCache):
         # Radix Cache takes one ref in memory pool
         # Note: the insert function already frees the overlapped kv_indices
         new_prefix_len = self.insert(
-            page_aligned_token_ids, page_aligned_kv_indices, len(req.prefix_indices)
+            RadixKey(page_aligned_token_ids, req.extra_key),
+            page_aligned_kv_indices,
+            len(req.prefix_indices),
         )
 
         # The prefix indices could be updated, reuse it
-        new_indices, new_last_node, _, _ = self.match_prefix(page_aligned_token_ids)
+        new_indices, new_last_node, _, _ = self.match_prefix(
+            RadixKey(page_aligned_token_ids, req.extra_key)
+        )
         assert len(req.prefix_indices) <= len(new_indices), f"{req.prefix_indices=}, {new_indices=}"
         assert new_prefix_len <= len(new_indices), f"{new_prefix_len=}, {new_indices=}"
         self.req_to_token_pool.write(
@@ -695,7 +693,7 @@ class SWARadixCache(BasePrefixCache):
 
     ##### Internal Helper Functions #####
 
-    def _match_prefix_helper(self, key: list) -> tuple[list[np.array], TreeNode]:
+    def _match_prefix_helper(self, key: RadixKey) -> tuple[list[np.array], TreeNode]:
         """
         SWA prefix matching helper. It factors in the sliding window size such that
         the matched node is guaranteed to either 1. connected to root without swa tombstone,
@@ -721,7 +719,7 @@ class SWARadixCache(BasePrefixCache):
 
             prefix_len = self.key_match_fn(child.key, key)
             if prefix_len < len(child.key):
-                new_node = self._split_node(child.key, child, prefix_len)
+                new_node = self._split_node(child, prefix_len)
                 value.append(new_node.value)
                 if not new_node.swa_tombstone:
                     match_len_since_tombstone += len(new_node.value)
@@ -732,7 +730,7 @@ class SWARadixCache(BasePrefixCache):
                 if not child.swa_tombstone:
                     match_len_since_tombstone += len(child.value)
                 node = child
-                key = key[prefix_len:]
+                key = key[prefix_len:]  # Slices RadixKey
 
                 if len(key):
                     child_key = self.get_child_key_fn(key)
@@ -756,10 +754,9 @@ class SWARadixCache(BasePrefixCache):
 
         return value[:best_value_len], best_last_node
 
-    def _split_node(self, key: list[int], child: TreeNode, split_len: int) -> TreeNode:
+    def _split_node(self, child: TreeNode, split_len: int) -> TreeNode:
         # new_node -> child
         new_node = TreeNode()
-        new_node.children = {self.get_child_key_fn(key[split_len:]): child}
         new_node.parent = child.parent
         new_node.swa_tombstone = child.swa_tombstone
         new_node.full_lock_ref = child.full_lock_ref
@@ -780,7 +777,12 @@ class SWARadixCache(BasePrefixCache):
         child.parent = new_node
         child.key = child.key[split_len:]
         child.value = np.array(child.value[split_len:], copy=True)
-        new_node.parent.children[self.get_child_key_fn(key)] = new_node
+
+        # Re-key old child in new_node's children
+        new_node.children = {self.get_child_key_fn(child.key): child}
+
+        # Update parent's reference to new_node
+        new_node.parent.children[self.get_child_key_fn(new_node.key)] = new_node
 
         # insert the new node and child into the lru lists, insert
         # parent first so that parent is after child in the lru list
@@ -791,7 +793,7 @@ class SWARadixCache(BasePrefixCache):
             self.swa_lru_list.insert_mru(child)
         return new_node
 
-    def _insert_helper(self, node: TreeNode, key: list, value, update_kv_after_len: int) -> int:
+    def _insert_helper(self, node: TreeNode, key: RadixKey, value, update_kv_after_len: int) -> int:
         # Update the last access time from root to leaf, so that
         # swa will tombstone the node closer to root first
         node.last_access_time = time.monotonic()
@@ -811,10 +813,11 @@ class SWARadixCache(BasePrefixCache):
             self.full_lru_list.reset_node_mru(node)
             if not node.swa_tombstone:
                 self.swa_lru_list.reset_node_mru(node)
+
             prefix_len = self.key_match_fn(node.key, key)
 
             if prefix_len < len(node.key):
-                new_node = self._split_node(node.key, node, prefix_len)
+                new_node = self._split_node(node, prefix_len)
                 node = new_node
 
             # if tombstone after update_kv_after_len, update node.value to be the input value.
@@ -839,7 +842,7 @@ class SWARadixCache(BasePrefixCache):
                     self.token_to_kv_pool_allocator.free(value[first_diff_idx:prefix_len])
 
             total_prefix_length += prefix_len
-            key = key[prefix_len:]
+            key = key[prefix_len:]  # Slices RadixKey
             value = value[prefix_len:]
 
             if len(key):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

Cherry-pick from https://github.com/sgl-project/sglang-jax/pull/435, to develop dp radix cache independently.
## Modifications

- Change RadixCache with new RadixKey, so the lora path is considered in prefix match.
- **Attention**: Lock the JAX version to 0.8.1, because the newly released JAX 0.8.2 causes incorrect behavior in returning logprobs https://github.com/sgl-project/sglang-jax/actions/runs/20404369033/job/58632720453?pr=583. We should wait until the version stabilizes or the necessary compatibility fixes are made before upgrading to 0.8.2.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
