### PR TITLE
fix: bench one batch

### DIFF
--- a/python/sgl_jax/bench_one_batch.py
+++ b/python/sgl_jax/bench_one_batch.py
@@ -52,6 +52,7 @@ import json
 import logging
 import os
 import time
+from types import SimpleNamespace
 
 import jax
 import numpy as np
@@ -69,6 +70,7 @@ from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
 from sgl_jax.srt.sampling.sampling_params import SamplingParams
 from sgl_jax.srt.server_args import PortArgs, ServerArgs
 from sgl_jax.srt.utils import configure_logger, kill_process_tree
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
 
 
 @dataclasses.dataclass
@@ -138,9 +140,11 @@ def load_model(server_args, port_args, tp_rank):
     # Use a size-1 'data' axis and shard across the 'tensor' axis per tp_size.
     all_devices = jax.devices()
     tp = min(server_args.tp_size, len(all_devices))
-    devices = all_devices[:tp]
-    devices_array = np.array(devices, dtype=object).reshape((1, tp))
-    mesh = jax.sharding.Mesh(devices_array, ("data", "tensor"))
+    mesh = create_device_mesh(
+        ici_parallelism=[-1, tp],
+        dcn_parallelism=[1, 1],
+        device_indexes=server_args.device_indexes,
+    )
 
     model_runner = ModelRunner(
         model_config=model_config,
@@ -239,11 +243,16 @@ def prepare_synthetic_inputs_for_latency_test(batch_size, input_len, custom_inpu
 
 
 def extend(reqs, model_runner):
+    # Create dummy tree_cache for benchmarks (no prefix caching, just allocation)
+    dummy_tree_cache = SimpleNamespace(
+        token_to_kv_pool_allocator=model_runner.token_to_kv_pool_allocator,
+    )
+
     batch = ScheduleBatch.init_new(
         reqs=reqs,
         req_to_token_pool=model_runner.req_to_token_pool,
         token_to_kv_pool_allocator=model_runner.token_to_kv_pool_allocator,
-        tree_cache=None,
+        tree_cache=dummy_tree_cache,
         model_config=model_runner.model_config,
         enable_overlap=False,
         enable_custom_logit_processor=False,
@@ -306,8 +315,6 @@ def _run_forward_and_sample(model_runner, batch: ScheduleBatch, token_first_arg:
     logits_metadata = LogitsMetadata.from_model_worker_batch(
         model_worker_batch, mesh=model_runner.mesh
     )
-    positions = model_worker_batch.positions
-
     logits_output, _ = model_runner.forward(forward_batch, logits_metadata=logits_metadata)
 
     pad_size = len(model_worker_batch.seq_lens) - model_worker_batch.real_bs
@@ -317,7 +324,7 @@ def _run_forward_and_sample(model_runner, batch: ScheduleBatch, token_first_arg:
         mesh=model_runner.mesh,
         vocab_size=model_runner.model_config.vocab_size,
     )
-    next_token_ids = model_runner.sample(logits_output, sampling_metadata, positions)
+    next_token_ids, _, _ = model_runner.sample(logits_output, sampling_metadata)
     # NOTE(Bob): seems that now next_token_ids is a jax array, not a numpy array
 
     return next_token_ids, logits_output.next_token_logits
@@ -433,10 +440,13 @@ def latency_test_run_once(
 
     # Decode
     decode_latencies = []
+    # Convert JAX array to numpy array for decode
+    next_token_ids_cpu = np.array(next_token_ids)
     for i in range(output_len - 1):
         synchronize(device)
         tic = time.perf_counter()
-        next_token_ids, _ = decode(next_token_ids, batch, model_runner)
+        next_token_ids, _ = decode(next_token_ids_cpu, batch, model_runner)
+        next_token_ids_cpu = np.array(next_token_ids)
         synchronize(device)
         latency = time.perf_counter() - tic
         tot_latency += latency
@@ -593,17 +603,6 @@ def main(server_args, bench_args):
             bs_max,
             in_max,
             out_max,
-        )
-
-    # Prefer native attention on single-TPU runs to avoid large FA compile-time temps
-    if (
-        (server_args.device is None or server_args.device == "tpu")
-        and server_args.tp_size == 1
-        and getattr(server_args, "attention_backend", "fa") == "fa"
-    ):
-        server_args.attention_backend = "native"
-        logging.info(
-            "Switching attention backend to 'native' for single TPU to reduce compile-time memory"
         )
 
     _set_envs_and_config(server_args)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

Fix https://github.com/sgl-project/sglang-jax/issues/626

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

```
uv run python -m sgl_jax.bench_one_batch --model-path Qwen/Qwen2.5-0.5B --attention-backend fa
[2026-01-06 07:50:26 TP0] Precision tracer globally disabled
[2026-01-06 07:50:27 TP0] KV heads distribution for GQA model: original_kv_heads=2, tp_size=1, each device gets 2 head(s), no replication needed, padding_strategy=replicate
Fetching 10 files: 100%|██████████████████████████████████| 10/10 [00:00<00:00, 119495.84it/s]
[2026-01-06 07:50:27 TP0] Qwen2ForCausalLM config dtype: <class 'jax.numpy.bfloat16'>
[2026-01-06 07:50:27 TP0] Scanning metadata for 1 model files (single host only)...
Scanning Metadata: 100%|█████████████████████████████████████| 1/1 [00:00<00:00, 197.00file/s]
[2026-01-06 07:50:27 TP0] Starting parallel weight loading via JAX Lazy Loader...
Loading Regular Weights:   3%|▉                               | 9/314 [00:00<00:09, 33.09it/s][2026-01-06 07:50:27 TP0] No file found for weight: model.layers.0.self_attn.o_proj.bias
[2026-01-06 07:50:27 TP0] No file found for weight: model.layers.1.self_attn.o_proj.bias
Loading Regular Weights:  11%|███▏                          | 34/314 [00:00<00:02, 116.64it/s][2026-01-06 07:50:27 TP0] No file found for weight: model.layers.2.self_attn.o_proj.bias
[2026-01-06 07:50:27 TP0] No file found for weight: model.layers.3.self_attn.o_proj.bias
[2026-01-06 07:50:27 TP0] No file found for weight: model.layers.4.self_attn.o_proj.bias
[2026-01-06 07:50:27 TP0] No file found for weight: model.layers.5.self_attn.o_proj.bias
Loading Regular Weights:  28%|████████▎                     | 87/314 [00:00<00:00, 261.72it/s][2026-01-06 07:50:27 TP0] No file found for weight: model.layers.6.self_attn.o_proj.bias
[2026-01-06 07:50:27 TP0] No file found for weight: model.layers.7.self_attn.o_proj.bias
[2026-01-06 07:50:27 TP0] No file found for weight: model.layers.8.self_attn.o_proj.bias
[2026-01-06 07:50:27 TP0] No file found for weight: model.layers.9.self_attn.o_proj.bias
Loading Regular Weights:  45%|████████████▉                | 140/314 [00:00<00:00, 348.59it/s][2026-01-06 07:50:27 TP0] No file found for weight: model.layers.10.self_attn.o_proj.bias
[2026-01-06 07:50:27 TP0] No file found for weight: model.layers.11.self_attn.o_proj.bias
[2026-01-06 07:50:28 TP0] No file found for weight: model.layers.12.self_attn.o_proj.bias
[2026-01-06 07:50:28 TP0] No file found for weight: model.layers.13.self_attn.o_proj.bias
Loading Regular Weights:  61%|█████████████████▊           | 193/314 [00:00<00:00, 401.49it/s][2026-01-06 07:50:28 TP0] No file found for weight: model.layers.14.self_attn.o_proj.bias
[2026-01-06 07:50:28 TP0] No file found for weight: model.layers.15.self_attn.o_proj.bias
[2026-01-06 07:50:28 TP0] No file found for weight: model.layers.16.self_attn.o_proj.bias
[2026-01-06 07:50:28 TP0] No file found for weight: model.layers.17.self_attn.o_proj.bias
[2026-01-06 07:50:28 TP0] No file found for weight: model.layers.18.self_attn.o_proj.bias
Loading Regular Weights:  80%|███████████████████████      | 250/314 [00:00<00:00, 453.85it/s][2026-01-06 07:50:28 TP0] No file found for weight: model.layers.19.self_attn.o_proj.bias
[2026-01-06 07:50:28 TP0] No file found for weight: model.layers.20.self_attn.o_proj.bias
[2026-01-06 07:50:28 TP0] No file found for weight: model.layers.21.self_attn.o_proj.bias
[2026-01-06 07:50:28 TP0] No file found for weight: model.layers.22.self_attn.o_proj.bias
Loading Regular Weights:  98%|████████████████████████████▎| 307/314 [00:00<00:00, 487.31it/s][2026-01-06 07:50:28 TP0] No file found for weight: model.layers.23.self_attn.o_proj.bias
Loading Regular Weights: 100%|█████████████████████████████| 314/314 [00:00<00:00, 349.13it/s]
Loading MoE Weights: 0it [00:00, ?it/s]
[2026-01-06 07:50:28 TP0] All weights loaded successfully.
[2026-01-06 07:50:28 TP0] Qwen2 weights loaded successfully!
[2026-01-06 07:50:28 TP0] ModelRunner kv_cache_dtype: <class 'jax.numpy.bfloat16'>
[2026-01-06 07:50:28 TP0] TPU Memory profiling: available_device_memory=30.3GB, available_kv_cache=26.6GB, max_tokens=1161136, cell_size=24576bytes
[2026-01-06 07:50:28 TP0] ModelRunner max_total_num_tokens: 1145
[2026-01-06 07:50:28 TP0] Creating fused KV buffers for 24 layers
[2026-01-06 07:50:28 TP0] Total fused KV cache memory per layer: 0.00 GB, dtype: <class 'jax.numpy.bfloat16'>
[2026-01-06 07:50:29 TP0] Total time to create 24 buffers: 0.85 seconds
[2026-01-06 07:50:29 TP0] JAX Fused KV Cache allocated. #tokens: 1145, Fused KV size: 0.03 GB
max_total_num_tokens=1145
Warmup ...
Prefill. latency: 7.90675 s, throughput:    129.51 token/s
Decode 0. Batch size: 1, latency: 4.37638 s, throughput:      0.23 token/s
Decode 1. Batch size: 1, latency: 4.35324 s, throughput:      0.23 token/s
Decode 2. Batch size: 1, latency: 4.23565 s, throughput:      0.24 token/s
Decode 3. Batch size: 1, latency: 4.40413 s, throughput:      0.23 token/s
Decode 4. Batch size: 1, latency: 4.47916 s, throughput:      0.22 token/s
Decode.  median latency: 4.35324 s, median throughput:      0.23 token/s
Total. latency: 73.485 s, throughput:     14.15 token/s
Benchmark ...
Prefill. latency: 0.00641 s, throughput: 159650.79 token/s
Decode 0. Batch size: 1, latency: 0.00440 s, throughput:    227.39 token/s
Decode 1. Batch size: 1, latency: 0.00438 s, throughput:    228.35 token/s
Decode 2. Batch size: 1, latency: 0.00436 s, throughput:    229.52 token/s
Decode 3. Batch size: 1, latency: 0.00433 s, throughput:    230.97 token/s
Decode 4. Batch size: 1, latency: 0.00434 s, throughput:    230.27 token/s
Decode.  median latency: 0.00428 s, median throughput:    233.38 token/s
Total. latency:  0.071 s, throughput:  14692.97 token/s
```

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
