### PR TITLE
[Bug-Fixed] add run_main_thread_loop_forever in server_args

### DIFF
--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -128,12 +128,14 @@ class TokenizerManager:
         )
         self.crash_dump_folder = server_args.crash_dump_folder
         self.crash_dump_performed = False  # Flag to ensure dump is only called once
+        self.event_loop = None  # Store the event loop to use
 
         # Init inter-process communication
         context = zmq.asyncio.Context(2)
         self.recv_from_detokenizer = get_zmq_socket(
             context, zmq.PULL, port_args.tokenizer_ipc_name, True
         )
+
         self.send_to_scheduler = get_zmq_socket(
             context, zmq.PUSH, port_args.scheduler_input_ipc_name, True
         )
@@ -440,6 +442,7 @@ class TokenizerManager:
         """Wait for the response of one request."""
         while True:
             try:
+
                 await asyncio.wait_for(state.event.wait(), timeout=self.wait_timeout)
             except TimeoutError:
                 if request is not None and await request.is_disconnected():
@@ -785,10 +788,19 @@ class TokenizerManager:
             return
 
         self.no_create_loop = True
-        loop = asyncio.get_event_loop()
-        self.asyncio_tasks.add(loop.create_task(print_exception_wrapper(self.handle_loop)))
+        # Use the provided event loop if available, otherwise get the current one
+        loop = self.event_loop if self.event_loop is not None else asyncio.get_event_loop()
 
-        self.event_loop = loop
+        try:
+            current_running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_running_loop = None
+
+        if current_running_loop == loop:
+            task = loop.create_task(print_exception_wrapper(self.handle_loop))
+            self.asyncio_tasks.add(task)
+        else:
+            asyncio.run_coroutine_threadsafe(print_exception_wrapper(self.handle_loop), loop)
 
         # We cannot add signal handler when the tokenizer manager is not in
         # the main thread due to the CPython limitation.

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -164,6 +164,9 @@ class ServerArgs:
     enable_static_lora: bool | None = None
     lora_scaling: float | None = None
 
+    # For engine
+    enable_engine_loop_run_forever_daemon: bool | None = None
+
     def __post_init__(self):
         # Set missing default values
         if self.tokenizer_path is None:
@@ -956,6 +959,11 @@ class ServerArgs:
             type=float,
             default=ServerArgs.lora_scaling,
             help="Lora scaling is required for static LoRA, scaling = alpha/rank",
+        )
+        parser.add_argument(
+            "--enable-engine-loop-run-forever-daemon",
+            action="store_true",
+            help="Run engine loop forever when engine.async_generate is called in other threads, this is used in Tunix",
         )
 
     @classmethod

--- a/python/sgl_jax/srt/utils/common_utils.py
+++ b/python/sgl_jax/srt/utils/common_utils.py
@@ -641,3 +641,12 @@ class ConcurrentCounter:
         other tasks to run while waiting. When the counter becomes zero, the coroutine resumes.
         """
         await self.wait_for(lambda count: count == 0)
+
+
+def get_or_create_loop():
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

Fix #628 from SGLangJax aspect.

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

1. Add `enable-engine-loop-run-forever-daemon`, run engine.loop in another loop forever.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.

## Result

Partly Fixed Version:
- Tunix: lance-fix: [73a7db1393c8c76de435256c0b1c3583283a1751](https://github.com/google/tunix/commit/73a7db1393c8c76de435256c0b1c3583283a1751#diff-b0fdcac1b1211345a402b46d9931f7b42873ed163f2a490bd628e61014438125)(with a lots of debug log which will be removed)
- SGLangJax: primatrix:fix/tunix-async_generate-in-multi-threads: [ff107a3a7af33a6f00d263f2f88273543b660ead](https://github.com/sgl-project/sglang-jax/pull/629/commits)

<img width="1639" height="616" alt="image" src="https://github.com/user-attachments/assets/37bbd207-f4a0-450a-8a80-a0c2c9ba3af5" />


See more in [Partly Fixed Hang Dump](https://drive.google.com/file/d/1y4q5oeOf2TavOjyCXdXKUM7A6hOaX9Rt/view?usp=drive_link).