### PR TITLE
Change proxy checker when Pathways on Cloud is enabled.

### DIFF
--- a/python/sgl_jax/srt/utils/jax_utils.py
+++ b/python/sgl_jax/srt/utils/jax_utils.py
@@ -116,7 +116,7 @@ def get_available_device_memory(device, distributed=False, empty_cache=True):
             stats = dev.memory_stats()
             avail_mem.append(stats["bytes_limit"] - stats["bytes_in_use"])
         avail_mem = jnp.array([min(avail_mem) / (1 << 10)], dtype=jnp.float32)
-    elif device == "proxy":
+    elif "proxy" in device:
         devices = jax.devices()
         live_arrays = jax.live_arrays()
         pathways_hbm_used_mem = pathways_hbm_usage_gb(live_arrays, devices)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

We set JAX_PLATFORMS=proxy,cpu when we run Pathways workloads, so the device is ('proxy', 'cpu'). In the current implementation, it checks devices == 'proxy' which is inaccurate. 

## Modifications

This PR fixes this issue by checking if 'proxy' is in the device list.

## Accuracy Tests

Run pw workload in local and it's passing.

## Benchmarking and Profiling

NA

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
