### PR TITLE
fix cache miss for vae decode

### DIFF
--- a/python/sgl_jax/srt/multimodal/common/ServerArgs.py
+++ b/python/sgl_jax/srt/multimodal/common/ServerArgs.py
@@ -19,6 +19,9 @@ class MultimodalServerArgs(ServerArgs):
     text_encoder_precisions: tuple[str, ...] = field(default_factory=lambda: ("fp32",))
     image_encoder_precision: str = "bf16"
 
+    vae_decode_precompile_width_height: list[str] | None = None
+    vae_decode_precompile_frame_paddings: list[int] | None = None
+
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):
         prefix_with_dot = ""
@@ -90,6 +93,39 @@ class MultimodalServerArgs(ServerArgs):
             choices=["fp32", "fp16", "bf16"],
             help="Precision for image encoder",
         )
+
+        parser.add_argument(
+            "--vae-decode-precompile-width-height",
+            type=str,
+            nargs="+",
+            help="Set the list of width and height for jax jit, format width*height",
+        )
+
+        parser.add_argument(
+            "--vae-decode-precompile-frame-paddings",
+            type=int,
+            nargs="+",
+            help="Set the frame count list for jax jit",
+        )
+
+    def __post_init__(self):
+        # Ensure parent validation and default-setting logic runs as well.
+        # dataclasses does not automatically chain __post_init__ implementations
+        # across inheritance, so we need to invoke the base class method
+        # manually.
+        super().__post_init__()
+
+        if self.vae_decode_precompile_width_height is not None:
+            for wh in self.vae_decode_precompile_width_height:
+                if len(wh.split("*")) < 2:
+                    raise Exception("Width and height must be connected with an asterisk *.")
+            if self.vae_decode_precompile_frame_paddings is None:
+                self.vae_decode_precompile_frame_paddings = [1]
+            else:
+                self.vae_decode_precompile_frame_paddings.sort()
+        else:
+            self.vae_decode_precompile_width_height = ["480*832"]
+            self.vae_decode_precompile_frame_paddings = [1]
 
     @classmethod
     def from_cli_args(cls, args: argparse.Namespace):

--- a/python/sgl_jax/srt/multimodal/manager/global_scheduler.py
+++ b/python/sgl_jax/srt/multimodal/manager/global_scheduler.py
@@ -239,8 +239,8 @@ class GlobalScheduler:
             input_ids=input.input_ids,
             negative_input_ids=input.negative_input_ids,
             num_outputs_per_prompt=input.n,
-            height=int(size_str.split("*")[0]),
-            width=int(size_str.split("*")[1]),
+            width=int(size_str.split("*")[0]),
+            height=int(size_str.split("*")[1]),
             num_frames=input.num_frames,
             num_inference_steps=(
                 input.num_inference_steps if input.num_inference_steps is not None else 50

--- a/python/sgl_jax/srt/multimodal/manager/scheduler/vae_scheduler.py
+++ b/python/sgl_jax/srt/multimodal/manager/scheduler/vae_scheduler.py
@@ -2,6 +2,7 @@ import logging
 
 import jax
 import jax.sharding
+import numpy as np
 from jax import NamedSharding
 from jax.sharding import PartitionSpec
 
@@ -65,6 +66,10 @@ class VaeScheduler(SchedulerProfilerMixin):
         self.model_config = model_class.get_config_class()()
         # Track aborted request IDs to skip processing
         self.aborted_rids: set[str] = set()
+        if not server_args.disable_precompile:
+            logger.info("[VAE Scheduler] Begins to run vae worker precompile.")
+            self.vae_worker.run_precompile()
+            logger.info("[VAE Scheduler] Completes vae worker precompile.")
 
     def event_loop_normal(self):
         """Main blocking loop used in non-async environments.
@@ -121,6 +126,21 @@ class VaeScheduler(SchedulerProfilerMixin):
         if hasattr(self.model_config, "shift_factor"):
             req.latents += self.model_config.shift_factor
         req.latents = jax.device_get(req.latents)
+        latents_t_padding = 0
+        if self.server_args.vae_decode_precompile_frame_paddings is not None and hasattr(
+            self.model_config, "scale_factor_temporal"
+        ):
+            for n_frame in self.server_args.vae_decode_precompile_frame_paddings:
+                latents_t = (n_frame - 1) // self.model_config.scale_factor_temporal + 1
+                if latents_t >= req.latents.shape[1]:
+                    latents_t_padding = latents_t - req.latents.shape[1]
+                    break
+        req.latents = np.pad(
+            req.latents,
+            pad_width=((0, 0), (0, latents_t_padding), (0, 0), (0, 0), (0, 0)),
+            mode="constant",
+            constant_values=0,
+        )
 
     def run_vae_batch(self, batch: list[Req]):
         """Run the VAE forward pass for a batch of requests.
@@ -132,8 +152,9 @@ class VaeScheduler(SchedulerProfilerMixin):
         """
 
         for req in batch:
-            output, _ = self.vae_worker.forward(req)
-            req.output = jax.device_get(output)
+            output, cache_miss = self.vae_worker.forward(req)
+            logger.info("VAE forward pass cache miss: %s", cache_miss)
+            req.output = jax.device_get(output[:, : req.num_frames, :, :, :])
             req.latents = None
             self.forward_ct += 1
             self._profile_batch_predicate(None)

--- a/python/sgl_jax/srt/multimodal/model_executor/diffusion/diffusion_model_runner.py
+++ b/python/sgl_jax/srt/multimodal/model_executor/diffusion/diffusion_model_runner.py
@@ -192,6 +192,7 @@ class DiffusionModelRunner(BaseModelRunner):
         )
         self.solver.set_begin_index(0)
         start_time = time.time()
+        import jax._src.test_util as jtu
 
         for step in tqdm(range(num_inference_steps), desc="Diffusion steps"):
             # Check for abort between steps
@@ -213,13 +214,15 @@ class DiffusionModelRunner(BaseModelRunner):
             # Transpose to channel-first (B, T, H, W, C) -> (B, C, T, H, W) for model
             latents_cf = latents.transpose(0, 4, 1, 2, 3)
             # Perform denoising step
-            noise_pred: jax.Array = self.jitted_forward(
-                hidden_states=latents_cf,
-                encoder_hidden_states=text_embeds,
-                timesteps=t_batch,
-                encoder_hidden_states_image=None,
-                guidance_scale=None,
-            )
+            with jtu.count_pjit_cpp_cache_miss() as count:
+                noise_pred: jax.Array = self.jitted_forward(
+                    hidden_states=latents_cf,
+                    encoder_hidden_states=text_embeds,
+                    timesteps=t_batch,
+                    encoder_hidden_states_image=None,
+                    guidance_scale=None,
+                )
+                logger.info("diffusion cache miss count: %d", count())
             if do_classifier_free_guidance:
                 bsz = latents.shape[0] // 2
                 noise_uncond = noise_pred[bsz:]
@@ -259,8 +262,8 @@ class DiffusionModelRunner(BaseModelRunner):
                     if batch.num_frames is not None
                     else 1
                 ),
-                batch.width // self.model_config.scale_factor_spatial,
                 batch.height // self.model_config.scale_factor_spatial,
+                batch.width // self.model_config.scale_factor_spatial,
                 self.model_config.latent_input_dim,
             ),
             dtype=jnp.float32,

--- a/python/sgl_jax/srt/multimodal/model_executor/vae/vae_model_runner.py
+++ b/python/sgl_jax/srt/multimodal/model_executor/vae/vae_model_runner.py
@@ -1,3 +1,4 @@
+import logging
 from functools import partial
 
 import jax
@@ -8,6 +9,8 @@ from sgl_jax.srt.model_executor.base_model_runner import BaseModelRunner
 from sgl_jax.srt.model_loader.loader import get_model_loader
 from sgl_jax.srt.multimodal.configs.config_registry import get_vae_config
 from sgl_jax.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
 
 
 class VaeModelRunner(BaseModelRunner):

--- a/python/sgl_jax/srt/multimodal/model_executor/vae/vae_model_worker.py
+++ b/python/sgl_jax/srt/multimodal/model_executor/vae/vae_model_worker.py
@@ -1,6 +1,18 @@
+import logging
+import time
+
+import numpy as np
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+from tqdm import tqdm
+
+from sgl_jax.srt.multimodal.configs.config_registry import get_vae_config
 from sgl_jax.srt.multimodal.manager.schedule_batch import Req
 from sgl_jax.srt.multimodal.model_executor.vae.vae_model_runner import VaeModelRunner
 from sgl_jax.srt.server_args import ServerArgs
+from sgl_jax.srt.utils.jax_utils import device_array
+
+logger = logging.getLogger(__name__)
 
 
 class VaeModelWorker:
@@ -15,9 +27,51 @@ class VaeModelWorker:
         self.model_runner = VaeModelRunner(
             server_args, mesh, model_class=model_class, stage_sub_dir=stage_sub_dir
         )
+        self.server_args = server_args
+        self.vae_decode_precompile_width_height = server_args.vae_decode_precompile_width_height
+        self.vae_decode_precompile_frame_paddings = server_args.vae_decode_precompile_frame_paddings
+        self.model_config = get_vae_config(self.server_args.model_path)
         # Initialize model here based on model_config
 
     def forward(self, batch: Req):
         # Implement the vae model inference logic here
         # return batch
         return self.model_runner.forward(batch.latents, "decode")
+
+    def run_precompile(self):
+        self.decode_precompile()
+        self.encode_precompile()
+
+    def decode_precompile(self):
+        start_time = time.perf_counter()
+        logger.info(
+            "[VAE DECODE] Begin to precompile width*height=%s",
+            self.vae_decode_precompile_width_height,
+        )
+
+        with tqdm(
+            self.vae_decode_precompile_width_height, desc="[VAE DECODE] PRECOMPILE", leave=False
+        ) as pbar:
+            for wh in pbar:
+                whs = wh.split("*")
+                width, height = int(whs[0]), int(whs[1])
+                assert width % self.model_config.scale_factor_spatial == 0
+                assert height % self.model_config.scale_factor_spatial == 0
+                for t in self.vae_decode_precompile_frame_paddings:
+                    pbar.set_postfix(wh=wh, t=t)
+                    latents_cpu = np.random.random(
+                        (
+                            1,
+                            t // self.model_config.scale_factor_temporal + 1,
+                            height // self.model_config.scale_factor_spatial,
+                            width // self.model_config.scale_factor_spatial,
+                            self.model_config.z_dim,
+                        )
+                    )
+                    latents = device_array(latents_cpu, sharding=(NamedSharding(self.mesh, P())))
+                    self.model_runner.forward(latents, "decode")
+        end_time = time.perf_counter()
+        logger.info("[VAE DECODE] Precompile finished in %.0f secs", end_time - start_time)
+
+    def encode_precompile(self):
+        pass

--- a/python/sgl_jax/test/multimodal/test_vae_scheduler.py
+++ b/python/sgl_jax/test/multimodal/test_vae_scheduler.py
@@ -34,7 +34,7 @@ class TestVaeScheduler(unittest.TestCase):
     def test_run_vae_step(self):
         """Test full scheduler forward pass."""
         x = jnp.array(np.arange(1 * 5 * 3 * 4 * 16), dtype=jnp.float32).reshape(1, 5, 3, 4, 16)
-        req = Req(rid="test", latents=x)
+        req = Req(rid="test", latents=x, num_frames=17)
         self.scheduler.run_vae_batch([req])
         result = self.backend._out_queue.get()
         self.assertEqual(result.output.shape, (1, 17, 24, 32, 3))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
compile vae decode cost too much time, it should be optimizated.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
i add two parameters vae-decode-precompile-width-height and vae-decode-precompile-frame-paddings for vae decode precompile
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
```
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python3 -u -m sgl_jax.launch_server --multimodal --model-path=/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers --log-requests --precompile-token-paddings=8192 --precompile-bs-paddings=64 --vae-decode-precompile-width-height 480*832 --vae-decode-precompile-frame-paddings 11 41
```
```
curl http://localhost:30000/api/v1/videos/generation -H "Content-Type: application/json" -d '{"prompt": "A curious raccoon", "size": "480*832", "num_frames": 41, "num_inference_steps": 50}'
```

https://github.com/user-attachments/assets/9895913e-c777-4cec-a624-b03b892fd8f4


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
e2e 4m38.786s->3m15.541s
before optimization
<img width="527" height="647" alt="image" src="https://github.com/user-attachments/assets/d7bb4e8e-63db-44c4-9c8a-9b4b8d2deaf7" />
after optimization
<img width="1085" height="818" alt="image" src="https://github.com/user-attachments/assets/961ec694-c548-494e-8438-c37a8dbe86d2" />

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
