### PR TITLE
add flash attention kernel for dit

### DIFF
--- a/python/sgl_jax/srt/multimodal/kernels/flash_attention.py
+++ b/python/sgl_jax/srt/multimodal/kernels/flash_attention.py
@@ -1,0 +1,831 @@
+# adapted from https://github.com/jax-ml/jax/blob/main/jax/experimental/pallas/ops/tpu/flash_attention.py
+# ruff: noqa: E741
+"""Flash Attention TPU kernel."""
+from __future__ import annotations
+
+import dataclasses
+import functools
+import math
+from typing import Any, NamedTuple
+
+import jax
+import jax.numpy as jnp
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+DEFAULT_MASK_VALUE = -0.7 * float(jnp.finfo(jnp.dtype("float32")).max)
+NUM_LANES = 128
+NUM_SUBLANES = 8
+
+
+class SegmentIds(NamedTuple):
+    """SegmentIds for Q and KV sequences.
+
+    SegmentIds are used to generate segment mask, which prevents attention between
+    different segments in the input sequence. Each array is a list of ids
+    (integers).
+    Only the token with the same id can attend to each other.
+
+    Attributes:
+      q: segment ids along the Q sequence.
+      kv: segment ids along the KV sequence.
+    """
+
+    q: jax.Array  # [batch_size, q_seq_len]
+    kv: jax.Array  # [batch_size, kv_seq_len]
+
+
+@dataclasses.dataclass(frozen=True)
+class BlockSizes:
+    """Tile sizes parameterizing FlashAttention kernels.
+
+    Those parameters have negligible effect on numerics, but affect performance
+    greatly.
+    """
+
+    block_q: int
+    block_k_major: int
+    block_k: int
+    block_b: int
+
+    block_q_major_dkv: int | None = None
+    block_k_major_dkv: int | None = None
+    block_k_dkv: int | None = None
+    block_q_dkv: int | None = None
+
+    block_k_major_dq: int | None = None
+    block_k_dq: int | None = None
+    block_q_dq: int | None = None
+
+    def __post_init__(self):
+        def verify_major_minor(prefix, suffix, major, minor):
+            if minor > major:
+                raise ValueError(
+                    f"{prefix}{suffix}={minor} should be smaller than"
+                    f" {prefix}_major{suffix}={major}"
+                )
+            if major % minor != 0:
+                raise ValueError(
+                    f"{prefix}{suffix}={minor} should divide" f" {prefix}_major{suffix}={major}"
+                )
+
+        verify_major_minor("block_k", "", self.block_k_major, self.block_k)
+        if self.block_q_major_dkv is not None and self.block_q_dkv is not None:
+            verify_major_minor("block_q", "_dkv", self.block_q_major_dkv, self.block_q_dkv)
+        if self.block_k_major_dkv is not None and self.block_k_dkv is not None:
+            verify_major_minor("block_k", "_dkv", self.block_k_major_dkv, self.block_k_dkv)
+        if self.block_k_major_dq is not None and self.block_k_dq is not None:
+            verify_major_minor("block_k", "_dq", self.block_k_major_dq, self.block_k_dq)
+
+    @property
+    def has_backward_blocks(self) -> bool:
+        backward_blocks = (
+            self.block_q_major_dkv,
+            self.block_k_major_dkv,
+            self.block_q_dkv,
+            self.block_k_dkv,
+            self.block_k_major_dq,
+            self.block_k_dq,
+            self.block_q_dq,
+        )
+        return all(b is not None for b in backward_blocks)
+
+    @classmethod
+    def get_default(cls, batch_size, num_heads, q_seq_len, kv_len, d_model):
+        # TODO(apaszke,sharadmv): Select better parameters based on a heuristic.
+        del batch_size, num_heads, q_seq_len, kv_len, d_model  # Unused.
+        return BlockSizes(
+            block_q=128,
+            block_k_major=128,
+            block_k=128,
+            block_b=1,
+            block_q_major_dkv=128,
+            block_k_major_dkv=128,
+            block_k_dkv=128,
+            block_q_dkv=128,
+            block_k_major_dq=128,
+            block_k_dq=128,
+            block_q_dq=128,
+        )
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "causal",
+        "sm_scale",
+        "block_sizes",
+        "debug",
+        "interpret",
+        "vmem_limit_bytes",
+    ],
+)
+def flash_attention(
+    q,  # [batch_size, num_heads, q_seq_len, d_model]
+    k,  # [batch_size, num_heads, kv_seq_len, d_model]
+    v,  # [batch_size, num_heads, kv_seq_len, d_model]
+    ab=None,  # [batch_size, num_heads, q_seq_len, kv_seq_len]
+    segment_ids=None,  # q of [batch_size, q_seq_len] and kv of [batch_size, kv_seq_len]
+    *,
+    causal: bool = False,
+    sm_scale: float = 1.0,
+    block_sizes: BlockSizes | None = None,
+    debug: bool = False,
+    interpret: bool = False,  # interpret=True for cpu
+    vmem_limit_bytes: int = 128 * 1024 * 1024,
+):
+    batch_size, num_heads, q_seq_len, d_model = q.shape
+    batch_size_k, num_heads_k, kv_seq_len, d_model_k = k.shape
+    batch_size_v, num_heads_v, kv_seq_len_v, d_model_v = v.shape
+    if batch_size != batch_size_k or batch_size != batch_size_v:
+        raise ValueError(
+            f"Batch size mismatch: got {batch_size}, {batch_size_k} and"
+            f" {batch_size_v} (for q, k, v respectively)"
+        )
+    if num_heads != num_heads_k or num_heads != num_heads_v:
+        raise ValueError(
+            f"Head count mismatch: got {num_heads}, {num_heads_k},"
+            f" {num_heads_v} (for q, k, v respectively)"
+        )
+    if d_model != d_model_k:
+        raise ValueError(
+            f"Model dimension mismatch: got {d_model} and {d_model_k} (for q and k" " respectively)"
+        )
+    if d_model != d_model_v:
+        raise NotImplementedError("V model dimension unequal to KV model dimension unsupported")
+    if kv_seq_len != kv_seq_len_v:
+        raise ValueError(f"KV sequence length mismatch: got {kv_seq_len} and {kv_seq_len_v}")
+    if ab is not None and ab.shape != (batch_size, num_heads, q_seq_len, kv_seq_len):
+        raise ValueError(
+            f"Attention bias shape mismatch: expected ({batch_size=},"
+            f" {num_heads=}, {q_seq_len=}, {kv_seq_len=}), got {ab.shape}"
+        )
+    if segment_ids is not None:
+        if segment_ids.q.shape != (batch_size, q_seq_len):
+            raise ValueError(
+                f"Q segment ids shape mismatch: expected ({batch_size=},"
+                f" {q_seq_len=},), got {segment_ids.q.shape}"
+            )
+        if segment_ids.kv.shape != (batch_size, kv_seq_len):
+            raise ValueError(
+                f"KV segment ids shape mismatch: expected ({batch_size=},"
+                f" {kv_seq_len=},), got {segment_ids.kv.shape}"
+            )
+    if block_sizes is None:
+        block_sizes = BlockSizes.get_default(batch_size, num_heads, q_seq_len, kv_seq_len, d_model)
+        # todo: tune the block sizes properly.
+        if kv_seq_len <= 92800:
+            # Override block_k/block_k_major to use `_flash_attention_kernel_single_batch_single_step`.
+            block_sizes = BlockSizes(
+                block_q=block_sizes.block_q,
+                block_b=block_sizes.block_b,
+                block_k_major=kv_seq_len,
+                block_k=kv_seq_len,
+            )
+    return _flash_attention(
+        q,
+        k,
+        v,
+        ab,
+        segment_ids,
+        False,
+        causal,
+        sm_scale,
+        block_sizes,
+        debug,
+        interpret,
+        vmem_limit_bytes,
+    )
+
+
+def _flash_attention(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    save_residuals,
+    causal,
+    sm_scale,
+    block_sizes,
+    debug,
+    interpret,
+    vmem_limit_bytes,
+):
+    return _flash_attention_impl(
+        q,
+        k,
+        v,
+        ab,
+        segment_ids,
+        save_residuals,
+        causal,
+        sm_scale,
+        block_sizes.block_b,
+        block_sizes.block_q,
+        block_sizes.block_k_major,
+        block_sizes.block_k,
+        debug,
+        interpret,
+        vmem_limit_bytes,
+    )
+
+
+def _flash_attention_fwd(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    save_residuals,
+    causal,
+    sm_scale,
+    block_sizes,
+    debug,
+):
+    if save_residuals:
+        raise NotImplementedError("Higher-order AD not supported")
+    o, l, m = _flash_attention(q, k, v, ab, segment_ids, True, causal, sm_scale, block_sizes, debug)
+    return o, (q, k, v, ab, segment_ids, o, l, m)
+
+
+MIN_BLOCK_SIZE = 128
+TRANS_B_DIM_NUMBERS = (((1,), (1,)), ((), ()))
+
+
+def below_or_on_diag(r, r_blk_size, c, c_blk_size):
+    # A block is considered below or on diagonal as long as the bottom left
+    # corner of the block is below or on diagonal.
+    return ((r + 1) * r_blk_size - 1) > (c * c_blk_size)
+
+
+def _flash_attention_kernel(q_tile_ref, *args, **kwargs):
+    block_b = q_tile_ref.shape[0]
+    # If we're not going to tile the softmax, then we can avoid a bunch of VPU ops.
+    if kwargs["block_k"] == kwargs["kv_seq_len"]:
+        kernel = _flash_attention_kernel_single_batch_single_step
+    else:
+        kernel = _flash_attention_kernel_single_batch
+    for batch_idx in range(block_b):
+        kernel((batch_idx, 0), q_tile_ref, *args, **kwargs)
+
+
+def _flash_attention_kernel_single_batch(
+    batch_idx: tuple[int, ...],
+    q_tile_ref,
+    k_tile_ref,
+    v_tile_ref,
+    ab_tile_ref,
+    q_segment_ids_tile_ref,
+    kv_segment_ids_tile_ref,  # Input arrays
+    o_tile_ref,  # Output arrays
+    l_ref,
+    m_ref,
+    m_scratch_ref,
+    l_scratch_ref,
+    acc_scratch_ref,
+    *,
+    causal,
+    sm_scale,
+    block_k,
+    kv_seq_len,
+    mask_value,
+):
+    block_k_major = k_tile_ref.shape[2]
+    block_q = q_tile_ref.shape[2]
+    head_dim = q_tile_ref.shape[-1]
+
+    kv_seq_idx = pl.program_id(3)
+
+    @pl.when(kv_seq_idx == 0)
+    def start_new_sequence():
+        m_scratch_ref[batch_idx] = jnp.full(m_scratch_ref.shape[2:], -jnp.inf, jnp.float32)
+        l_scratch_ref[batch_idx] = jnp.zeros(l_scratch_ref.shape[2:], jnp.float32)
+        acc_scratch_ref[batch_idx] = jnp.zeros(acc_scratch_ref.shape[2:], jnp.float32)
+
+    q_seq_idx = pl.program_id(2)
+    should_run = below_or_on_diag(q_seq_idx, block_q, kv_seq_idx, block_k_major) if causal else True
+
+    @pl.when(should_run)
+    def run():
+        @pl.loop(0, block_k_major, step=block_k, unroll=True)
+        def _body(start_k):
+            m_prev = m_scratch_ref[batch_idx]
+            l_prev = l_scratch_ref[batch_idx]
+
+            q = q_tile_ref[batch_idx]  # [block_q, head_dim]
+            k = k_tile_ref[
+                (*batch_idx, pl.dslice(start_k, block_k), slice(None))
+            ]  # [block_k, head_dim]
+
+            s = jax.lax.dot_general(
+                q, k, TRANS_B_DIM_NUMBERS, preferred_element_type=jnp.float32
+            )  # [block_q, block_k]
+
+            # Add attention bias if needed.
+            # TODO(tanburn) Should the attention bias be added before or after
+            # multiplication by sm_scale?
+            if ab_tile_ref is not None:
+                ab = ab_tile_ref[(*batch_idx, pl.dslice(None), pl.dslice(start_k, block_k))].astype(
+                    jnp.float32
+                )
+                s += ab
+
+            if sm_scale != 1.0:
+                s *= sm_scale
+
+            mask = None
+            if q_segment_ids_tile_ref is not None:
+                repeats, rem = divmod(block_k, NUM_LANES)
+                if rem:
+                    raise NotImplementedError(f"kv block size must be a multiple of {NUM_LANES}")
+                q_segment_ids = jnp.tile(
+                    q_segment_ids_tile_ref[batch_idx[0]], (1, repeats)
+                )  # [block_q, block_k].
+                kv_segment_ids = kv_segment_ids_tile_ref[
+                    batch_idx[0], :1, pl.dslice(start_k, block_k)
+                ]  # [1, block_k].
+                mask = jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
+
+            if causal:
+                mask_shape = (block_q, block_k)
+                row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+                row_ids += q_seq_idx * block_q
+                col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+                col_ids += kv_seq_idx * block_k_major + start_k
+                causal_mask = col_ids <= row_ids
+                mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+
+            s = s if mask is None else s + jnp.where(mask, 0.0, mask_value)
+
+            m_curr = jnp.max(s, axis=1)[:, None]  # Row max, shape [block_q, 1].
+            m_next = jnp.maximum(m_prev, m_curr)  # Shape [block_q, 128].
+
+            block_k_repeats, rem = divmod(block_k, MIN_BLOCK_SIZE)
+            if rem:
+                raise NotImplementedError(f"{block_k=} should be a multiple of {MIN_BLOCK_SIZE}")
+            p = jnp.exp(s - jnp.tile(m_next, (1, block_k_repeats)))
+
+            alpha = jnp.exp(m_prev - m_next)  # Shape [block_q, 128].
+
+            l_corr = alpha * l_prev
+
+            l_next = jnp.sum(p, axis=1)[:, None] + l_corr  # Shape [block_q, 128]
+
+            head_dim_repeats, rem = divmod(head_dim, MIN_BLOCK_SIZE)
+            l_broadcast = lambda l: jnp.tile(l, (1, head_dim_repeats))
+            if rem:
+                if head_dim_repeats == 0:
+                    l_broadcast = lambda l: l[:, :head_dim]
+                else:
+                    raise NotImplementedError(
+                        f"{head_dim=} should be a multiple of {MIN_BLOCK_SIZE} if larger"
+                    )
+            l_scratch_ref[batch_idx] = l_next
+            m_scratch_ref[batch_idx] = m_next
+
+            l_next_inv_safe = jnp.where(l_next == 0.0, 1.0, 1.0 / l_next)
+            acc_scratch_ref[batch_idx] *= l_broadcast(l_corr * l_next_inv_safe)
+            v = v_tile_ref[(*batch_idx, pl.dslice(start_k, block_k), slice(None))]
+            o_curr = jax.lax.dot(p.astype(v.dtype), v, preferred_element_type=jnp.float32)
+            acc_scratch_ref[batch_idx] += o_curr * l_broadcast(l_next_inv_safe)
+
+    @pl.when(kv_seq_idx == (kv_seq_len // block_k_major) - 1)
+    def store_output():
+        o_tile_ref[batch_idx] = acc_scratch_ref[batch_idx].astype(o_tile_ref.dtype)
+        if l_ref is not None:
+            l_ref[batch_idx] = l_scratch_ref[batch_idx].astype(l_ref.dtype)
+        if m_ref is not None:
+            m_ref[batch_idx] = m_scratch_ref[batch_idx].astype(m_ref.dtype)
+
+
+def _flash_attention_kernel_single_batch_single_step(
+    batch_idx: tuple[int, ...],
+    q_tile_ref,
+    k_tile_ref,
+    v_tile_ref,
+    ab_tile_ref,
+    q_segment_ids_tile_ref,
+    kv_segment_ids_tile_ref,  # Input arrays
+    o_tile_ref,  # Output arrays
+    l_ref: Any | None = None,
+    m_ref: Any | None = None,
+    *,
+    causal,
+    sm_scale,
+    block_k,
+    kv_seq_len,
+    mask_value,
+):
+    block_k_major = k_tile_ref.shape[2]
+    block_q = q_tile_ref.shape[2]
+
+    assert kv_seq_len == block_k_major == block_k
+
+    q = q_tile_ref[batch_idx]  # [block_q, head_dim]
+    k = k_tile_ref[batch_idx]  # [block_k, head_dim]
+    s = jax.lax.dot_general(
+        q, k, TRANS_B_DIM_NUMBERS, preferred_element_type=jnp.float32
+    )  # [block_q, block_k]
+
+    if ab_tile_ref is not None:
+        s += ab_tile_ref[batch_idx].astype(jnp.float32)
+    if sm_scale != 1.0:
+        s *= sm_scale
+
+    mask = None
+    if q_segment_ids_tile_ref is not None:
+        repeats, rem = divmod(block_k, NUM_LANES)
+        if rem:
+            raise NotImplementedError(f"kv block size must be a multiple of {NUM_LANES}")
+        q_segment_ids = q_segment_ids_tile_ref[batch_idx[0]]  # [block_q, NUM_LANES].
+        q_segment_ids = jnp.tile(q_segment_ids, (1, repeats))  # [block_q, block_k].
+        kv_segment_ids = kv_segment_ids_tile_ref[batch_idx[0], :1]  # [1, block_k].
+        mask = jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
+
+    if causal:
+        q_seq_idx = pl.program_id(2)
+        mask_shape = (block_q, block_k)
+        row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+        row_ids += q_seq_idx * block_q
+        col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+        causal_mask = col_ids <= row_ids
+        mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+    s = s if mask is None else s + jnp.where(mask, 0.0, mask_value)
+
+    m = jnp.max(s, axis=1)[:, None]
+    p = jnp.exp(s - m)
+    l = jnp.sum(p, axis=1)[:, None]
+    p /= l
+
+    if m_ref is not None:
+        m_ref[batch_idx] = lax.broadcast_in_dim(m, m_ref.shape[2:], range(2))
+    if l_ref is not None:
+        l_ref[batch_idx] = lax.broadcast_in_dim(l, l_ref.shape[2:], range(2))
+
+    v = v_tile_ref[batch_idx]
+    o_tile_ref[batch_idx] = jax.lax.dot(
+        p.astype(v.dtype), v, preferred_element_type=jnp.float32
+    ).astype(o_tile_ref.dtype)
+
+
+def _bytes(x: jax.Array | jax.ShapeDtypeStruct) -> int:
+    return math.prod(x.shape) * x.dtype.itemsize
+
+
+def _fwd_cost_estimate(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    ab: jax.Array | None,
+    segment_ids: SegmentIds | None,
+    *,
+    causal: bool,
+    sm_scale: jax.Array | None,
+    kernel_inputs_specs,
+    kernel_outputs_specs,
+) -> pl.CostEstimate | None:
+    body_cost = pl.estimate_cost(
+        mha_reference, q, k, v, ab, segment_ids, causal=causal, sm_scale=sm_scale
+    )
+    input_bytes = sum(_bytes(x) for x in jax.tree.leaves(kernel_inputs_specs))
+    output_bytes = sum(_bytes(x) for x in jax.tree.leaves(kernel_outputs_specs))
+    return pl.CostEstimate(
+        flops=body_cost.flops,
+        transcendentals=body_cost.transcendentals,
+        bytes_accessed=input_bytes + output_bytes,
+    )
+
+
+def _flash_attention_impl(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    save_residuals,
+    causal,
+    sm_scale,
+    block_b,
+    block_q,
+    block_k_major,
+    block_k,
+    debug,
+    interpret,
+    vmem_limit_bytes,
+):
+    batch_size, num_heads, q_seq_len, head_dim = q.shape
+    _, _, kv_seq_len, _ = k.shape
+    _verify_block("block_q", "q_seq_len", block_q, q_seq_len, should_divide=False)
+    _verify_block("block_k_major", "kv_seq_len", block_k_major, kv_seq_len)
+    _verify_block("block_k", "kv_seq_len", block_k, kv_seq_len)
+    _verify_block("block_b", "batch", block_b, batch_size, should_divide=False)
+
+    # TODO(apaszke): Tile over heads as well.
+    grid = (
+        pl.cdiv(batch_size, block_b),
+        num_heads,
+        pl.cdiv(q_seq_len, block_q),
+        kv_seq_len // block_k_major,
+    )
+
+    def q_index_map(batch_index, head_index, q_seq_index, _):
+        return (batch_index, head_index, q_seq_index, 0)
+
+    def kv_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+        if causal:
+            # If the kv block is skipped, prefetch the next valid kv block, i.e. the
+            # 0th one to be used for the next block_q rows.
+            next_kv_index = lax.select(
+                below_or_on_diag(q_seq_index, block_q, kv_seq_index, block_k_major),
+                kv_seq_index,
+                0,
+            )
+        else:
+            next_kv_index = kv_seq_index
+        return (batch_index, head_index, next_kv_index, 0)
+
+    def ab_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+        if causal:
+            should_run = below_or_on_diag(q_seq_index, block_q, kv_seq_index, block_k_major)
+            # If the ab block is skipped, prefetch the next valid ab block, i.e. the
+            # 0th kv to be used for the next block_q rows.
+            next_q_index = lax.select(
+                should_run,
+                q_seq_index,
+                lax.select(q_seq_index == (q_seq_len // block_q) - 1, 0, q_seq_index + 1),
+            )
+            next_kv_index = lax.select(should_run, kv_seq_index, 0)
+        else:
+            next_q_index = q_seq_index
+            next_kv_index = kv_seq_index
+
+        return (batch_index, head_index, next_q_index, next_kv_index)
+
+    def o_index_map(batch_index, head_index, q_seq_index, _):
+        return (batch_index, head_index, q_seq_index, 0)
+
+    def lm_index_map(batch_index, head_index, q_seq_index, _):
+        return (batch_index, head_index, q_seq_index, 0)
+
+    kernel = functools.partial(
+        _flash_attention_kernel,
+        causal=causal,
+        mask_value=DEFAULT_MASK_VALUE,
+        sm_scale=sm_scale,
+        block_k=block_k,
+        kv_seq_len=kv_seq_len,
+    )
+    out_shape = jax.ShapeDtypeStruct(shape=q.shape, dtype=q.dtype)
+    out_shape = [out_shape]
+    out_specs = [pl.BlockSpec((block_b, 1, block_q, head_dim), o_index_map)]
+
+    if block_k != kv_seq_len:
+        m_scratch = pltpu.VMEM((block_b, 1, block_q, MIN_BLOCK_SIZE), jnp.float32)
+        l_scratch = pltpu.VMEM((block_b, 1, block_q, MIN_BLOCK_SIZE), jnp.float32)
+        acc_scratch = pltpu.VMEM((block_b, 1, block_q, head_dim), jnp.float32)
+        scratch_shapes = [m_scratch, l_scratch, acc_scratch]
+    else:
+        scratch_shapes = []
+
+    if save_residuals:
+        out_specs = [
+            *out_specs,
+            pl.BlockSpec((block_b, 1, block_q, MIN_BLOCK_SIZE), lm_index_map),
+            pl.BlockSpec((block_b, 1, block_q, MIN_BLOCK_SIZE), lm_index_map),
+        ]
+        l = jax.ShapeDtypeStruct(
+            (batch_size, num_heads, q_seq_len, MIN_BLOCK_SIZE), dtype=jnp.float32
+        )
+        m = jax.ShapeDtypeStruct(
+            (batch_size, num_heads, q_seq_len, MIN_BLOCK_SIZE), dtype=jnp.float32
+        )
+        out_shape = (*out_shape, l, m)
+    else:
+        out_specs = [*out_specs, None, None]
+        out_shape = (*out_shape, None, None)
+
+    ab_block_spec = (
+        pl.BlockSpec((block_b, 1, block_q, block_k_major), ab_index_map) if ab is not None else None
+    )
+
+    q_segment_ids_spec = kv_segment_ids_spec = None
+    q_segment_ids = kv_segment_ids = None
+    if segment_ids is not None:
+
+        def q_segment_ids_index_map(batch_index, head_index, q_seq_index, _):
+            del head_index
+            return (batch_index, q_seq_index, 0)
+
+        def kv_segment_ids_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+            del head_index
+            if causal:
+                next_kv_index = lax.select(
+                    below_or_on_diag(q_seq_index, block_q, kv_seq_index, block_k_major),
+                    kv_seq_index,
+                    0,
+                )
+            else:
+                next_kv_index = kv_seq_index
+            return (batch_index, 0, next_kv_index)
+
+        q_segment_ids_spec = pl.BlockSpec((block_b, block_q, NUM_LANES), q_segment_ids_index_map)
+        kv_segment_ids_spec = pl.BlockSpec(
+            (block_b, NUM_SUBLANES, block_k_major), kv_segment_ids_index_map
+        )
+
+        q_segment_ids = jax.lax.broadcast_in_dim(
+            segment_ids.q,
+            (batch_size, q_seq_len, NUM_LANES),
+            (
+                0,
+                1,
+            ),
+        )
+        kv_segment_ids = jax.lax.broadcast_in_dim(
+            segment_ids.kv,
+            (batch_size, NUM_SUBLANES, kv_seq_len),
+            (
+                0,
+                2,
+            ),
+        )
+
+    in_specs = [
+        pl.BlockSpec((block_b, 1, block_q, head_dim), q_index_map),
+        pl.BlockSpec((block_b, 1, block_k_major, head_dim), kv_index_map),
+        pl.BlockSpec((block_b, 1, block_k_major, head_dim), kv_index_map),
+        ab_block_spec,
+        q_segment_ids_spec,
+        kv_segment_ids_spec,
+    ]
+
+    o, *aux = pl.pallas_call(
+        kernel,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=0,
+            grid=grid,
+            in_specs=in_specs,
+            out_specs=out_specs,
+            scratch_shapes=scratch_shapes,
+        ),
+        out_shape=out_shape,
+        debug=debug,
+        interpret=interpret,
+        compiler_params=pltpu.CompilerParams(
+            dimension_semantics=(
+                "parallel",
+                "parallel",
+                "parallel",
+                "arbitrary",
+            ),
+            vmem_limit_bytes=vmem_limit_bytes,
+        ),
+        cost_estimate=_fwd_cost_estimate(
+            q,
+            k,
+            v,
+            ab,
+            segment_ids,
+            causal=causal,
+            sm_scale=sm_scale,
+            kernel_inputs_specs=(q, k, v, ab, q_segment_ids, kv_segment_ids),
+            kernel_outputs_specs=out_shape,
+        ),
+    )(q, k, v, ab, q_segment_ids, kv_segment_ids)
+    if save_residuals:
+        l, m = (v[..., 0] for v in aux[-2:])
+        return (o, l, m)
+    else:
+        return o
+
+
+# For autograd testing.
+def mha_reference_no_custom_vjp(
+    q,
+    k,
+    v,
+    ab: jax.Array | None = None,
+    segment_ids: SegmentIds | None = None,
+    *,
+    causal: bool = False,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    sm_scale: float = 1.0,
+    save_residuals: bool = False,
+):
+    logits = jnp.einsum("bhqc,bhkc->bhqk", q, k)
+    if ab is not None:
+        logits += ab
+    if sm_scale != 1.0:
+        logits *= sm_scale
+
+    mask = None
+    if segment_ids is not None:
+        mask = segment_ids.q[:, :, None] == segment_ids.kv[:, None, :]
+        mask = mask[:, None, :, :]
+
+    if causal:
+        _, _, q_seq_len, _ = q.shape
+        _, _, kv_seq_len, _ = k.shape
+        mask_shape = (q_seq_len, kv_seq_len)
+        row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+        col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+        causal_mask = (col_ids <= row_ids)[None, None, :, :]
+        mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+
+    logits = logits if mask is None else logits + jnp.where(mask, 0.0, mask_value)
+
+    m = logits.max(axis=-1)
+    unnormalized = jnp.exp(logits - m[..., None])
+    l = unnormalized.sum(axis=-1)
+    weights = unnormalized / l[..., None]
+    out = jnp.einsum("bhqk,bhkc->bhqc", weights, v)
+    if save_residuals:
+        return out, l, m
+    return out
+
+
+@functools.partial(jax.jit, static_argnames=["causal", "mask_value", "sm_scale"])
+@jax.default_matmul_precision("bfloat16")
+def mha_reference(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids: SegmentIds | None = None,
+    causal: bool = False,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    sm_scale=1.0,
+):
+    return _mha_reference(
+        q,
+        k,
+        v,
+        ab,
+        segment_ids,
+        causal=causal,
+        mask_value=mask_value,
+        sm_scale=sm_scale,
+        save_residuals=False,
+    )
+
+
+def _mha_reference(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids: SegmentIds | None,
+    causal: bool,
+    mask_value: float,
+    sm_scale: float,
+    save_residuals: bool,
+):
+    return mha_reference_no_custom_vjp(
+        q,
+        k,
+        v,
+        ab,
+        segment_ids,
+        causal=causal,
+        mask_value=mask_value,
+        sm_scale=sm_scale,
+        save_residuals=save_residuals,
+    )
+
+
+def _mha_reference_fwd(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids: SegmentIds | None,
+    causal: bool,
+    mask_value: float,
+    sm_scale: float,
+    save_residuals: bool,
+):
+    if save_residuals:
+        raise NotImplementedError
+    res = _mha_reference(
+        q,
+        k,
+        v,
+        ab,
+        segment_ids,
+        causal=causal,
+        mask_value=mask_value,
+        sm_scale=sm_scale,
+        save_residuals=True,
+    )
+    assert isinstance(res, tuple)
+    out, l, m = res
+    return out, (q, k, v, ab, segment_ids, out, l, m)
+
+
+def _verify_block(block_name, dim_name, block, dim, should_divide=True):
+    if block > dim:
+        raise ValueError(f"{block_name}={block} should be smaller or equal to {dim_name}={dim}")
+    if should_divide and dim % block != 0:
+        raise ValueError(f"{dim_name}={dim} should be divisible by {block_name}={block}")

--- a/python/sgl_jax/srt/multimodal/layers/attention/flash_attention_backend.py
+++ b/python/sgl_jax/srt/multimodal/layers/attention/flash_attention_backend.py
@@ -1,0 +1,53 @@
+import jax
+import jax.experimental.pallas as pl
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.layers.attention.base_attn_backend import AttentionBackend
+from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
+from sgl_jax.srt.multimodal.kernels.flash_attention import flash_attention
+
+
+def align_to(x, a):
+    return pl.cdiv(x, a) * a
+
+
+class FlashAttentionBackend(AttentionBackend):
+    def __init__(self, mesh, sm_scale=1.0, causal=False, vmem_limit_bytes=128 * 1024 * 1024):
+        in_specs = (
+            P("data", "tensor", None, None),  # q
+            P("data", "tensor", None, None),  # k
+            P("data", "tensor", None, None),  # v
+            P(),  # segment_ids
+        )
+        out_specs = P("data", "tensor", None, None)
+
+        def _flash_attention(q, k, v, segment_ids):
+            return flash_attention(
+                q,
+                k,
+                v,
+                segment_ids=segment_ids,
+                sm_scale=sm_scale,
+                causal=causal,
+                vmem_limit_bytes=vmem_limit_bytes,
+            )
+
+        self.jit_flash_attention = jax.jit(
+            jax.shard_map(
+                _flash_attention, mesh=mesh, in_specs=in_specs, out_specs=out_specs, check_vma=False
+            )
+        )
+
+    def __call__(
+        self,
+        q,  # [batch_size, head_nums, req_len, head_dim]
+        k,  # [batch_size, head_nums, kv_len, head_dim]
+        v,  # [batch_size, head_nums, kv_len, head_dim]
+        segment_ids,
+    ):
+        output = self.jit_flash_attention(q, k, v, segment_ids)
+        return output
+
+    def get_forward_metadata(self, batch: ModelWorkerBatch):
+        """Init the metadata for a forward pass and return it"""
+        return None

--- a/python/sgl_jax/srt/multimodal/layers/attention/layer.py
+++ b/python/sgl_jax/srt/multimodal/layers/attention/layer.py
@@ -1,8 +1,18 @@
 import math
 
 import jax
+import jax.experimental.pallas as pl
 import jax.numpy as jnp
 from flax import nnx
+
+from sgl_jax.srt.multimodal.kernels.flash_attention import SegmentIds
+from sgl_jax.srt.multimodal.layers.attention.flash_attention_backend import (
+    FlashAttentionBackend,
+)
+
+
+def align_to(x, a):
+    return pl.cdiv(x, a) * a
 
 
 def simple_attention(query, key, value, scale=None, causal=False):
@@ -64,6 +74,7 @@ class USPAttention(nnx.Module):
         layer_id: int = 0,
         logit_cap: float | None = None,
         scaling: float | None = None,
+        mesh: jax.sharding.Mesh | None = None,
         **extra_impl_args,
     ) -> None:
         super().__init__()
@@ -77,6 +88,10 @@ class USPAttention(nnx.Module):
         self.layer_id = layer_id
         self.logit_cap = logit_cap or None
         self.scaling = scaling
+        self.mesh = mesh
+        self.attention_backend = FlashAttentionBackend(
+            mesh=self.mesh, sm_scale=self.softmax_scale, causal=False
+        )
 
     def __call__(
         self,
@@ -92,9 +107,37 @@ class USPAttention(nnx.Module):
 
         Note: Replicated tensors are not supported in this implementation.
         """
-        # Use simple attention for diffusion (no KV cache needed)
-        if req is None:
-            return simple_attention(query, key, value, self.softmax_scale, self.causal)
-
-        # TODO refactor flashattention backend
-        return req.attention_backend(query, key, value, self, None, None, 0)
+        query = jnp.transpose(query, (0, 2, 1, 3))
+        key = jnp.transpose(key, (0, 2, 1, 3))
+        value = jnp.transpose(value, (0, 2, 1, 3))
+        q_len = query.shape[2]
+        kv_len = key.shape[2]
+        align_q_len = align_to(q_len, 128)
+        align_kv_len = align_to(kv_len, 128)
+        seg_q = None
+        seg_kv = None
+        segment_ids = None
+        if q_len != align_q_len:
+            query = jnp.pad(query, ((0, 0), (0, 0), (0, align_q_len - q_len), (0, 0)))
+            seg_q = jnp.concatenate(
+                [
+                    jnp.ones((query.shape[0], q_len)),
+                    jnp.zeros((query.shape[0], align_q_len - q_len)),
+                ],
+                axis=1,
+            )
+        if kv_len != align_kv_len:
+            key = jnp.pad(key, ((0, 0), (0, 0), (0, align_kv_len - kv_len), (0, 0)))
+            value = jnp.pad(value, ((0, 0), (0, 0), (0, align_kv_len - kv_len), (0, 0)))
+            seg_kv = jnp.concatenate(
+                [
+                    jnp.ones((key.shape[0], kv_len)),
+                    jnp.zeros((key.shape[0], align_kv_len - kv_len)),
+                ],
+                axis=1,
+            )
+        if seg_q is not None and seg_kv is not None:
+            segment_ids = SegmentIds(q=seg_q, kv=seg_kv)
+        output = self.attention_backend(query, key, value, segment_ids)
+        output = output[:, :, :q_len, :]
+        return jnp.transpose(output, (0, 2, 1, 3))

--- a/python/sgl_jax/srt/multimodal/models/wan/diffusion/wan_dit.py
+++ b/python/sgl_jax/srt/multimodal/models/wan/diffusion/wan_dit.py
@@ -105,6 +105,7 @@ class WanTransformerBlock(nnx.Module):
             num_heads=num_heads,
             head_size=dim // num_heads,
             causal=False,
+            mesh=mesh,
         )
         self.hidden_dim = dim
         self.num_attention_heads = num_heads
@@ -348,6 +349,7 @@ class WanSelfAttention(nnx.Module):
             dropout_rate=0,
             softmax_scale=None,
             causal=False,
+            mesh=mesh,
         )
 
     def __call__(self, x: jax.Array, context: jax.Array, context_lens: int):

--- a/python/sgl_jax/test/multimodal/test_flash_attention_kernel.py
+++ b/python/sgl_jax/test/multimodal/test_flash_attention_kernel.py
@@ -1,0 +1,78 @@
+import unittest
+
+import jax
+import jax.experimental.pallas as pl
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.multimodal.kernels.flash_attention import SegmentIds, flash_attention
+
+
+@jax.jit
+def jit_flash_attention(q, k, v):
+    q_len = q.shape[2]
+    kv_len = k.shape[2]
+    align_q_len = align_to(q_len, 128)
+    align_kv_len = align_to(kv_len, 128)
+    seg_q = None
+    seg_kv = None
+    segment_ids = None
+    if q_len != align_q_len:
+        q = jnp.pad(q, ((0, 0), (0, 0), (0, align_q_len - q_len), (0, 0)))
+        seg_q = jnp.concatenate(
+            [jnp.ones((q.shape[0], q_len)), jnp.zeros((q.shape[0], align_q_len - q_len))], axis=1
+        )
+    if kv_len != align_kv_len:
+        k = jnp.pad(k, ((0, 0), (0, 0), (0, align_kv_len - kv_len), (0, 0)))
+        v = jnp.pad(v, ((0, 0), (0, 0), (0, align_kv_len - kv_len), (0, 0)))
+        seg_kv = jnp.concatenate(
+            [jnp.ones((k.shape[0], kv_len)), jnp.zeros((k.shape[0], align_kv_len - kv_len))], axis=1
+        )
+    if seg_q is not None and seg_kv is not None:
+        segment_ids = SegmentIds(q=seg_q, kv=seg_kv)
+    output = flash_attention(q, k, v, segment_ids=segment_ids, causal=False)
+    output = output[:, :, :q_len, :]
+    return output
+
+
+def simple_attention(q, k, v):
+    attn_weights = jnp.einsum("bhsd,bhtd->bhst", q, k)
+    attn_weights = jax.nn.softmax(attn_weights, axis=-1)
+    output = jnp.einsum("bhst,bhtd->bhsd", attn_weights, v)
+    return output
+
+
+def align_to(a, b):
+    return pl.cdiv(a, b) * b
+
+
+class TestFlashAttentionKernel(unittest.TestCase):
+    """Test flash attention kernel"""
+
+    def test_accuracy(self):
+        """Test flash attention accuracy"""
+        mesh = jax.make_mesh(
+            (1, 1, 1, 1), axis_names=("x", "y", "z", "p"), devices=[jax.devices()[0]]
+        )
+        sharding = jax.sharding.NamedSharding(mesh, P(None, None, None, None))
+        q_shape = (2, 12, 120, 128)
+        kv_shape = (2, 12, 60, 128)
+        key = jax.random.PRNGKey(1)
+        key1, key2 = jax.random.split(key, num=2)
+        q = jax.random.normal(key, q_shape)
+        k = jax.random.normal(key1, kv_shape)
+        v = jax.random.normal(key2, kv_shape)
+
+        q = jax.device_put(q, sharding)
+        k = jax.device_put(k, sharding)
+        v = jax.device_put(v, sharding)
+
+        flash_output = jit_flash_attention(q, k, v)
+        simple_output = simple_attention(q, k, v)
+        print(flash_output.shape, simple_output.shape)
+        np.testing.assert_allclose(np.array(flash_output), np.array(simple_output), 1e-5, 1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -422,6 +422,7 @@ suites = {
         TestFile("python/sgl_jax/test/speculative/test_eagle_utils.py", 1),
         TestFile("python/sgl_jax/test/multimodal/test_wan_vae_precision.py", 1),
         TestFile("python/sgl_jax/test/multimodal/test_vae_scheduler.py", 2),
+        TestFile("python/sgl_jax/test/multimodal/test_flash_attention_kernel.py", 2),
         TestFile("test/srt/lora/test_bgmv_backend.py", 5),
         TestFile("test/srt/lora/test_align_lora_accuracy.py", 10),
     ],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
diffusion stage runs too slow
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- add flash attention for dit, compared to the JAX version of the API, it adds interpret and vmem_limit_bytes parameters

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
```
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python3 -u -m sgl_jax.launch_server --multimodal --model-path=/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers --precompile-token-paddings=8192 --precompile-bs-paddings=64 --vae-decode-precompile-width-height 480*832 --vae-decode-precompile-frame-paddings 11 41
```
```
curl http://localhost:30000/api/v1/videos/generation -H "Content-Type: application/json" -d '{"prompt": "A curious raccoon", "size": "480*832", "num_frames": 41, "num_inference_steps": 50}'
```

https://github.com/user-attachments/assets/05e7de42-29ad-4f61-91a6-7075748eb460

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
e2e 3m15s->1m30s
before optimization
<img width="318" height="715" alt="image" src="https://github.com/user-attachments/assets/368eb047-75bb-4264-9898-34eb811b1ac6" />

after optimization
<img width="1088" height="691" alt="86509335-CD41-4F6F-BD7E-4D34954CFBD5" src="https://github.com/user-attachments/assets/f858402a-78b9-4ca1-9baf-f9ca451d96b5" />

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
