### PR TITLE
[Fixed 853] use call_soon_threadsafe to set event in right loop

### DIFF
--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -1,6 +1,7 @@
 """TokenizerManager is a process that tokenizes the text."""
 
 import asyncio
+import contextlib
 import copy
 import dataclasses
 import json
@@ -86,6 +87,7 @@ class ReqState:
 
     # For metrics
     created_time: float
+    event_loop: asyncio.AbstractEventLoop | None = None
     finished_time: float = 0.0
     first_token_time: float = 0.0
     last_time: float = 0.0
@@ -438,11 +440,37 @@ class TokenizerManager:
         created_time: float | None = None,
     ):
         self.send_to_scheduler.send_pyobj(tokenized_obj)
-        state = ReqState([], False, asyncio.Event(), obj, created_time=created_time)
+        # Capture the caller's event loop so that _notify_state_event can use
+        # call_soon_threadsafe when handle_loop runs on a different thread
+        # (e.g. enable_engine_loop_run_forever_daemon mode).
+        try:
+            caller_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            caller_loop = None
+        state = ReqState(
+            [], False, asyncio.Event(), obj, created_time=created_time, event_loop=caller_loop
+        )
         # Handle rid being a list (single element) or string
         rid_key = obj.rid[0] if isinstance(obj.rid, list) else obj.rid
         self.rid_to_state[rid_key] = state
         return state
+
+    def _notify_state_event(self, state: ReqState) -> None:
+        """Thread-safe wrapper around state.event.set().
+
+        If enable_engine_loop_run_forever_daemon was enabled, handle_loop would run on the daemon_loop thread, but the asyncio.Event's
+        internal Future belongs to the eval_loop (the loop that called
+        _send_one_request).  Calling fut.set_result() from the wrong thread
+        does not wake up eval_loop's selector.  call_soon_threadsafe writes to
+        the self-pipe so the selector returns from epoll_wait immediately.
+        """
+        loop = state.event_loop
+        if loop is not None:
+            with contextlib.suppress(RuntimeError):
+                # RuntimeError: loop is already closed (request timed-out / cancelled).
+                loop.call_soon_threadsafe(state.event.set)
+        else:
+            state.event.set()
 
     async def _wait_one_response(
         self,
@@ -1024,7 +1052,7 @@ class TokenizerManager:
                 del self.rid_to_state[rid]
 
             state.out_list.append(out_dict)
-            state.event.set()
+            self._notify_state_event(state)
 
             # Log metrics and dump
             if self.dump_requests_folder and state.finished and state.obj.log_metrics:

--- a/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
+++ b/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
@@ -422,7 +422,7 @@ class MultimodalTokenizer(TokenizerManager):
                 },
             }
         )
-        state.event.set()
+        self._notify_state_event(state)
         logger.info("Abort completed for rid=%s", recv_obj.rid)
 
     async def generate_request(
@@ -910,6 +910,10 @@ class MultimodalTokenizer(TokenizerManager):
         `rid_to_state` keyed by the request id.
         """
         self.send_to_scheduler.send_pyobj(tokenized_obj)
+        try:
+            caller_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            caller_loop = None
         state = MMReqState(
             rid=tokenized_obj.rid,
             out_list=[],
@@ -917,6 +921,7 @@ class MultimodalTokenizer(TokenizerManager):
             event=asyncio.Event(),
             obj=obj,
             created_time=created_time,
+            event_loop=caller_loop,
         )
         self.rid_to_state[tokenized_obj.rid] = state
         return state


### PR DESCRIPTION
Fixed #853.

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.

# Result

**Before fix**

Run `SGLANG_WAIT_TIMEOUT=10 python scripts/grpo_demo_llama3_qwen2.py --root-dir=/tmp/grpo_test --num-batches=20 --rollout-engine sglang_jax`.

<img width="977" height="770" alt="image" src="https://github.com/user-attachments/assets/8a23c2d1-a8d3-4514-960b-b4f617415fae" />


**Fixed**

<img width="674" height="363" alt="image" src="https://github.com/user-attachments/assets/e75c9146-029b-4be5-bcd3-bf7356118140" />
