### PR TITLE
fix device manager bug for wan22

### DIFF
--- a/python/sgl_jax/srt/utils/mesh_utils.py
+++ b/python/sgl_jax/srt/utils/mesh_utils.py
@@ -42,12 +42,20 @@ def create_device_mesh(
             allow_split_physical_axes=allow_split_physical_axes,
         )
     else:
-        devices_array = mesh_utils.create_device_mesh(
-            ici_parallelism,
-            devices=devices,
-            contiguous_submeshes=False,
-            allow_split_physical_axes=allow_split_physical_axes,
-        )
+        all_devices = jax.devices()
+        is_subset = len(devices) < len(all_devices)
+        if is_subset:
+            # JAX's create_device_mesh infers the full physical TPU topology
+            # and asserts len(devices) == np.prod(dims), which fails when
+            # only a subset of devices is used.  Fall back to a simple reshape.
+            devices_array = np.array(devices).reshape(ici_parallelism)
+        else:
+            devices_array = mesh_utils.create_device_mesh(
+                ici_parallelism,
+                devices=devices,
+                contiguous_submeshes=False,
+                allow_split_physical_axes=allow_split_physical_axes,
+            )
 
     if use_explicit_sharding:
         axis_types = (jax.sharding.AxisType.Explicit,) * len(mesh_axes)


### PR DESCRIPTION
 Issue

  When running a multimodal pipeline with stage configurations that allocate fewer TPU devices than the total available (e.g., 2 out of 4 TPUs on a v4-8), the server crashes with an AssertionError in JAX's _get_physical_tpu_mesh:

  AssertionError: jax_devices=[TpuDevice(id=1, ...), TpuDevice(id=2, ...)] dims=(2, 2, 1) cores_per_chip=1

  Root Cause

  JAX's mesh_utils.create_device_mesh() is designed to work with the complete set of devices in a physical TPU topology. When given a subset of devices, it still attempts to infer the full physical topology from device coordinates and asserts that len(devices) ==
  np.prod(physical_dims).

  For example, on a v4-8 (2×2×1 topology with 4 cores total):
  - If a stage is allocated 2 devices with non-contiguous physical coordinates like (1,0,0) and (0,1,0)
  - JAX infers the full topology as dims=(2,2,1), expecting 4 devices
  - But only 2 devices were provided → assertion fails

  This issue is probabilistically triggered depending on device allocation order:
  - Fails: When allocated devices have non-contiguous physical coordinates
  - May pass: When allocated devices are physically contiguous (e.g., same row), allowing JAX to infer a valid sub-topology

  Reproduction

  Run Wan2.2 model on v4-8 with the default stage config:
  uv run python3 -m sgl_jax.launch_server \
    --multimodal \
    --model-path /models/Wan-AI/Wan2.2-T2V-A14B-Diffusers/ \
    --trust-remote-code \
    --skip-server \
    --disable-precompile

  The stage config allocates:
  - Stage 0 (text_encoder): CPU
  - Stage 1 (transformer): 2 TPUs
  - Stage 2 (VAE): 1 TPU

  Total: 3 out of 4 TPUs used, triggering the subset device issue.

  Fix

  Modified mesh_utils.py to detect when a subset of devices is being used. In such cases, bypass JAX's create_device_mesh() and directly reshape the device array using np.array(devices).reshape(ici_parallelism).

  When all devices are used, the original JAX path is preserved to maintain physical topology optimizations.
