### PR TITLE
improve flash att perf

### DIFF
--- a/python/sgl_jax/srt/multimodal/kernels/flash_attention.py
+++ b/python/sgl_jax/srt/multimodal/kernels/flash_attention.py
@@ -96,7 +96,7 @@ class BlockSizes:
         # TODO(apaszke,sharadmv): Select better parameters based on a heuristic.
         del batch_size, num_heads, q_seq_len, kv_len, d_model  # Unused.
         return BlockSizes(
-            block_q=128,
+            block_q=256,
             block_k_major=128,
             block_k=128,
             block_b=1,
@@ -422,9 +422,9 @@ def _flash_attention_kernel_single_batch_single_step(
     block_q = q_tile_ref.shape[2]
 
     assert kv_seq_len == block_k_major == block_k
-
     q = q_tile_ref[batch_idx]  # [block_q, head_dim]
     k = k_tile_ref[batch_idx]  # [block_k, head_dim]
+
     s = jax.lax.dot_general(
         q, k, TRANS_B_DIM_NUMBERS, preferred_element_type=jnp.float32
     )  # [block_q, block_k]
@@ -439,8 +439,7 @@ def _flash_attention_kernel_single_batch_single_step(
         repeats, rem = divmod(block_k, NUM_LANES)
         if rem:
             raise NotImplementedError(f"kv block size must be a multiple of {NUM_LANES}")
-        q_segment_ids = q_segment_ids_tile_ref[batch_idx[0]]  # [block_q, NUM_LANES].
-        q_segment_ids = jnp.tile(q_segment_ids, (1, repeats))  # [block_q, block_k].
+        q_segment_ids = q_segment_ids_tile_ref[batch_idx[0], :, :1]  # [block_q, 1]
         kv_segment_ids = kv_segment_ids_tile_ref[batch_idx[0], :1]  # [1, block_k].
         mask = jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
 
@@ -452,12 +451,12 @@ def _flash_attention_kernel_single_batch_single_step(
         col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
         causal_mask = col_ids <= row_ids
         mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
-    s = s if mask is None else s + jnp.where(mask, 0.0, mask_value)
+    s = s if mask is None else jnp.where(mask, s, mask_value)
 
-    m = jnp.max(s, axis=1)[:, None]
+    m = jnp.max(s, axis=1, keepdims=True)
     p = jnp.exp(s - m)
-    l = jnp.sum(p, axis=1)[:, None]
-    p /= l
+    l = jnp.sum(p, axis=1, keepdims=True)
+    p *= jax.lax.reciprocal(l)
 
     if m_ref is not None:
         m_ref[batch_idx] = lax.broadcast_in_dim(m, m_ref.shape[2:], range(2))

--- a/python/sgl_jax/srt/multimodal/layers/attention/layer.py
+++ b/python/sgl_jax/srt/multimodal/layers/attention/layer.py
@@ -112,8 +112,8 @@ class USPAttention(nnx.Module):
         value = jnp.transpose(value, (0, 2, 1, 3))
         q_len = query.shape[2]
         kv_len = key.shape[2]
-        align_q_len = align_to(q_len, 128)
-        align_kv_len = align_to(kv_len, 128)
+        align_q_len = align_to(q_len, 256)
+        align_kv_len = align_to(kv_len, 256)
         seg_q = None
         seg_kv = None
         segment_ids = None

--- a/python/sgl_jax/test/multimodal/test_flash_attention_kernel.py
+++ b/python/sgl_jax/test/multimodal/test_flash_attention_kernel.py
@@ -13,8 +13,8 @@ from sgl_jax.srt.multimodal.kernels.flash_attention import SegmentIds, flash_att
 def jit_flash_attention(q, k, v):
     q_len = q.shape[2]
     kv_len = k.shape[2]
-    align_q_len = align_to(q_len, 128)
-    align_kv_len = align_to(kv_len, 128)
+    align_q_len = align_to(q_len, 256)
+    align_kv_len = align_to(kv_len, 256)
     seg_q = None
     seg_kv = None
     segment_ids = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
Try to reduce VPU usage and increase block_q size
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
remove tile operator and change block_q size to 256
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
```
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python3 -u -m sgl_jax.launch_server --multimodal --model-path=/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers --precompile-token-paddings=8192 --precompile-bs-paddings=64 --vae-decode-precompile-width-height 480*832 --vae-decode-precompile-frame-paddings 11 41
```
```
time curl http://localhost:30000/api/v1/videos/generation -H "Content-Type: application/json" -d '{"prompt": "A curious raccoon", "size": "480*832", "num_frames": 41, "num_inference_steps": 50}'
```

https://github.com/user-attachments/assets/dea1768d-17df-428c-8f92-398da51fbec1


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
1st 1m21.401s
2nd 58.241s
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
