### PR TITLE
RFC: Add MLA implementation design docs

### DIFF
--- a/docs/design/894-mla-design.md
+++ b/docs/design/894-mla-design.md
@@ -4,17 +4,17 @@
 
 This document describes the design and testing plan for the `MLAAttention` layer in sglang-jax, targeting models that use the MLA architecture (DeepSeek-V2/V3, etc.).
 
-The current implementation uses **non-absorbed (purely native) mode**: `MLAAttention` fully decompresses the latent state into standard Q/K/V tensors during forward, then reuses the existing `RadixAttention` + `SplitMHATokenToKVPool` infrastructure without relying on any MLA-specific attention kernel or compressed KV cache. The goal is to correctly integrate the MLA data flow with minimal system changes.
+The current implementation uses **non-absorbed mode**: `MLAAttention` fully decompresses the latent state into Q/K/V tensors during forward (V is zero-padded to match K's head_dim for KV cache compatibility), then reuses the existing `RadixAttention` + `MHATokenToKVPool` infrastructure without relying on any MLA-specific attention kernel or compressed KV cache. The goal is to correctly integrate the MLA data flow with minimal system changes.
 
-`MLAAttention` is a reusable layer module located at `srt/layers/mla.py`, alongside other layers (`linear.py`, `layernorm.py`, etc.). It does not introduce a new attention backend — attention computation is dispatched through `RadixAttention` to the existing native backend (`srt/layers/attention/native_backend.py`). A future absorbed mode implementation would require adding a dedicated backend under `srt/layers/attention/` along with `MLATokenToKVPool`.
+`MLAAttention` is a reusable layer module located at `srt/layers/mla.py`, alongside other layers (`linear.py`, `layernorm.py`, etc.). It does not introduce a new attention backend — attention computation is dispatched through `RadixAttention` to the existing backend. A future absorbed mode implementation would require adding a dedicated backend under `srt/layers/attention/` along with `MLATokenToKVPool`.
 
 ## Background and Goals
 
 ### Goals
 
 - Provide a reusable MLA layer that correctly implements the MLA Q/K/V projection pipeline.
-- Integrate with existing attention infrastructure (`RadixAttention`, `SplitMHATokenToKVPool`) without modifying these components.
-- Support K_dim != V_dim (192 vs 128) through `SplitMHATokenToKVPool` separate buffers.
+- Integrate with existing attention infrastructure (`RadixAttention`, `MHATokenToKVPool`) without modifying these components.
+- Handle K_dim != V_dim by padding V to match K's head_dim, enabling use of the fused `MHATokenToKVPool`.
 
 ### Non-Goals
 
@@ -39,35 +39,37 @@ graph LR
     kv_split2 -- k_nope --> assemble
     RoPE -- k_rope' --> assemble
     assemble --> RadixAttention
-    kv_split2 -- v --> RadixAttention
-    RadixAttention --> o_proj --> output[hidden]
+    kv_split2 -- v --> pad["pad V to qk_head_dim"]
+    pad --> RadixAttention
+    RadixAttention --> strip["strip V padding"]
+    strip --> o_proj --> output[hidden]
 ```
 
 **Key design decisions:**
 
-1. **Non-absorbed mode**: All decompression is completed in `MLAAttention.__call__`, then standard Q/K/V are handed to `RadixAttention`. The attention layer is unaware of the low-rank origin.
-2. **Split KV cache**: After MLA decompression, K has head_dim=192 and V has head_dim=128. Since K_dim != V_dim, they cannot share a single fused buffer (`MHATokenToKVPool` requires uniform dimensions). `SplitMHATokenToKVPool` maintains two independent buffers (K: `[size, heads, 192]`, V: `[size, heads, 128]`). This is existing sglang-jax infrastructure, not MLA-specific.
+1. **Non-absorbed mode**: All decompression is completed in `MLAAttention.__call__`, then decompressed Q/K/V are handed to `RadixAttention`. The attention layer is unaware of the low-rank origin.
+2. **V padding for fused KV cache**: After MLA decompression, K has head_dim=qk_head_dim and V has head_dim=v_head_dim. Since `MHATokenToKVPool` requires K and V to have the same shape, V is zero-padded to qk_head_dim before being passed to `RadixAttention`. After attention, the padding is stripped from the output before the output projection.
 
 ### Constraints and Boundaries
 
-**The current implementation uses non-absorbed mode.** MLA has two implementation strategies:
+MLA has two implementation strategies — the current implementation uses non-absorbed mode:
 
 | | Non-absorbed (current) | Absorbed (not implemented) |
 |---|---|---|
-| Data flow | Compress -> **decompress to standard Q/K/V** -> standard attention | Compress -> **cache compressed state** -> decompress inside attention |
+| Data flow | Compress -> **decompress to Q/K/V** (V padded to qk_head_dim) -> standard attention | Compress -> **cache compressed state** -> decompress inside attention |
 | KV cache content | Decompressed full K/V | Compressed state (kv_lora_rank + qk_rope_head_dim) |
-| Per-token KV cache | heads x (qk_head_dim + v_head_dim) = 64x(192+128) = 20480 | kv_lora_rank + qk_rope_head_dim = 576 |
-| Attention kernel | Standard `RadixAttention` + `SplitMHATokenToKVPool` | Custom kernel needed (`MLATokenToKVPool` defined but not wired in) |
-| Memory efficiency | Low (20480/576 ~ 35x vs absorbed) | High |
+| Per-token KV cache | heads x (qk_head_dim + qk_head_dim) (V padded to qk_head_dim) | kv_lora_rank + qk_rope_head_dim |
+| Attention kernel | Standard `RadixAttention` + `MHATokenToKVPool` | Custom kernel needed (`MLATokenToKVPool` defined but not wired in) |
+| Memory efficiency | Low (24576/576 ≈ 43x vs absorbed) | High |
 
-The current implementation completes all decompression in `MLAAttention.__call__`, outputting standard Q/K/V tensors before handing off to `RadixAttention`. The attention layer does not need to know the data originates from a low-rank decomposition. K_dim(192) != V_dim(128) is handled by `SplitMHATokenToKVPool` with separate buffers. See [Appendix: Absorbed Mode Roadmap](#appendix-absorbed-mode-roadmap) for the absorbed mode roadmap.
+The current implementation completes all decompression in `MLAAttention.__call__`, outputting decompressed Q/K/V tensors (V padded to qk_head_dim) before handing off to `RadixAttention`. The attention layer does not need to know the data originates from a low-rank decomposition. The padding is stripped after attention, before `o_proj`. See [Appendix: Absorbed Mode Roadmap](#appendix-absorbed-mode-roadmap) for the absorbed mode roadmap.
 
 ### Risks and Mitigations
 
 | Risk | Mitigation |
 |------|-----------|
-| Non-absorbed mode uses ~35x more KV cache than absorbed mode | Acceptable for initial implementation; absorbed mode is a future optimization |
-| bf16 precision loss in chained matmuls | Validated via cosine similarity (>= 0.99) against fp32 reference; allclose is not viable at production dimensions |
+| Non-absorbed mode uses ~43x more KV cache than absorbed mode | Acceptable for initial implementation; absorbed mode is a future optimization |
+| bf16 precision loss in chained matmuls | Q/K/V projection pipeline validated via cosine similarity (>= 0.99) against fp32 reference; attention and o_proj numerical correctness is covered by model-level accuracy tests |
 
 ## Design Details
 
@@ -85,7 +87,7 @@ The current implementation completes all decompression in `MLAAttention.__call__
 
 **Constructor Parameters:** `hidden_size`, `num_heads`, `q_lora_rank`, `kv_lora_rank`, `qk_nope_head_dim`, `qk_rope_head_dim`, `v_head_dim`, `rope_theta`, `rope_interleave`, etc., provided by model configuration.
 
-**Output Shapes:** Q = [tokens, num_heads, qk_head_dim], K = [tokens, num_heads, qk_head_dim], V = [tokens, num_heads, v_head_dim], where qk_head_dim = qk_nope_head_dim + qk_rope_head_dim.
+**Output Shapes (pre-padding):** Q = [tokens, num_heads, qk_head_dim], K = [tokens, num_heads, qk_head_dim], V = [tokens, num_heads, v_head_dim], where qk_head_dim = qk_nope_head_dim + qk_rope_head_dim. Note: V is zero-padded to qk_head_dim before entering RadixAttention.
 
 **Attention Scaling:** `scaling = qk_head_dim^(-0.5)`. The scaling is applied to the full Q.K^T after concatenation, not to the nope or rope portions individually.
 
@@ -131,13 +133,13 @@ Tests use a numpy fp32 reference implementation as the ground-truth oracle, cons
 
 ### Integration Test
 
-`test_radix_attention_integration`: Simulates one decode step to verify that MLA output can be correctly accepted and processed by `RadixAttention` + `SplitMHATokenToKVPool`.
+`test_radix_attention_integration`: Simulates one decode step to verify that MLA output can be correctly accepted and processed by `RadixAttention` + `MHATokenToKVPool`.
 
 **Scenario:** 2 sequences, KV lengths of 4 and 6 (cached history tokens), each sequence currently processing 1 new token (2 query tokens total).
 
 **Flow:**
 
-1. Create `SplitMHATokenToKVPool` (separate K/V buffers), write random prefix KV into the pool to simulate cached historical K/V
+1. Create `MHATokenToKVPool` (fused K/V buffer), write random prefix KV into the pool to simulate cached historical K/V
 2. Build `cache_loc` and `ForwardBatch`, specifying the physical position of each token's KV in the pool
 3. 2 new tokens' hidden states enter `MLAAttention.__call__`, completing Q/K/V projection and RoPE
 4. Hand off to `RadixAttention`: write new tokens' K/V into the pool, perform attention over all historical K/V
@@ -152,13 +154,13 @@ This document does not define model-level e2e accuracy baselines. Model-level en
 
 ## Alternatives
 
-**Absorbed mode**: Cache the compressed latent state instead of decompressed K/V. Requires a custom attention kernel that decompresses on-the-fly during attention computation. ~35x memory reduction but significantly more implementation complexity. Deferred to a future iteration.
+**Absorbed mode**: Cache the compressed latent state instead of decompressed K/V. Requires a custom attention kernel that decompresses on-the-fly during attention computation. ~43x memory reduction but significantly more implementation complexity. Deferred to a future iteration.
 
 ## Appendix: Absorbed Mode Roadmap
 
 > Not in scope for this iteration. This appendix documents future optimization directions for reference.
 
-`MLATokenToKVPool` is already defined in `memory_pool.py` with compressed buffer layout `[size, 1, kv_lora_rank + qk_rope_head_dim]`, but is not wired into the attention pipeline. The full chain for absorbed mode requires changes across multiple components:
+`MLATokenToKVPool` is already defined in `srt/mem_cache/memory_pool.py` with compressed buffer layout `[size, 1, kv_lora_rank + qk_rope_head_dim]`, but is not wired into the attention pipeline. The full chain for absorbed mode requires changes across multiple components:
 
 ```mermaid
 graph TD

--- a/docs/design/894-mla-design.md
+++ b/docs/design/894-mla-design.md
@@ -2,15 +2,17 @@
 
 ## Summary
 
-This document describes the design and testing approach for `MLAAttention` in sglang-jax, targeting DeepSeek-V2 style models (Ling-2.5-1T, etc.).
+This document describes the design and testing plan for the `MLAAttention` layer in sglang-jax, targeting models that use the MLA architecture (DeepSeek-V2/V3, etc.).
 
-MLA can theoretically reduce per-token cache from `heads x (qk_head_dim + v_head_dim)` to `kv_lora_rank + qk_rope_head_dim` via compressed-state KV cache, but **the current implementation uses non-absorbed mode**, which decompresses to standard Q/K/V in `MLAAttention.__call__` and then reuses the existing `RadixAttention` + `SplitMHATokenToKVPool`. Therefore, the current goal is to correctly integrate the MLA data flow with minimal system changes, not to immediately gain the KV cache compression benefits of absorbed mode.
+The current implementation uses **non-absorbed (purely native) mode**: `MLAAttention` fully decompresses the latent state into standard Q/K/V tensors during forward, then reuses the existing `RadixAttention` + `SplitMHATokenToKVPool` infrastructure without relying on any MLA-specific attention kernel or compressed KV cache. The goal is to correctly integrate the MLA data flow with minimal system changes.
+
+`MLAAttention` is a reusable layer module located at `srt/layers/mla.py`, alongside other layers (`linear.py`, `layernorm.py`, etc.). It does not introduce a new attention backend — attention computation is dispatched through `RadixAttention` to the existing native backend (`srt/layers/attention/native_backend.py`). A future absorbed mode implementation would require adding a dedicated backend under `srt/layers/attention/` along with `MLATokenToKVPool`.
 
 ## Background and Goals
 
 ### Goals
 
-- Provide a reusable MLA layer that correctly implements the Q/K/V projection pipeline from [BailingMoeV2_5MultiLatentAttention](https://huggingface.co/inclusionAI/Ling-2.5-1T/blob/main/modeling_bailing_moe_v2_5.py#L580).
+- Provide a reusable MLA layer that correctly implements the MLA Q/K/V projection pipeline.
 - Integrate with existing attention infrastructure (`RadixAttention`, `SplitMHATokenToKVPool`) without modifying these components.
 - Support K_dim != V_dim (192 vs 128) through `SplitMHATokenToKVPool` separate buffers.
 
@@ -81,28 +83,17 @@ The current implementation completes all decompression in `MLAAttention.__call__
 | `kv_b_proj` | (kv_lora_rank, num_heads x (qk_nope_head_dim + v_head_dim)) | kernel: (None, "tensor") |
 | `o_proj` | (num_heads x v_head_dim, hidden_size) | kernel: ("tensor", None) |
 
-**Config (Ling-2.5-1T):**
+**Constructor Parameters:** `hidden_size`, `num_heads`, `q_lora_rank`, `kv_lora_rank`, `qk_nope_head_dim`, `qk_rope_head_dim`, `v_head_dim`, `rope_theta`, `rope_interleave`, etc., provided by model configuration.
 
-| Parameter | Value |
-|-----------|-------|
-| q_lora_rank | 1536 |
-| kv_lora_rank | 512 |
-| qk_nope_head_dim | 128 |
-| qk_rope_head_dim | 64 |
-| v_head_dim | 128 |
-| num_attention_heads | 64 |
-| rope_theta | 6000000.0 |
-| rope_style | interleaved |
+**Output Shapes:** Q = [tokens, num_heads, qk_head_dim], K = [tokens, num_heads, qk_head_dim], V = [tokens, num_heads, v_head_dim], where qk_head_dim = qk_nope_head_dim + qk_rope_head_dim.
 
-**Output shapes:** Q = [tokens, 64, 192], K = [tokens, 64, 192], V = [tokens, 64, 128]
-
-**Attention scaling:** `scaling = qk_head_dim^(-0.5) = 192^(-0.5)`, consistent with HuggingFace BailingMoeV2_5MultiLatentAttention. The scaling is applied to the full Q.K^T after concatenation, not to the nope or rope portions individually.
+**Attention Scaling:** `scaling = qk_head_dim^(-0.5)`. The scaling is applied to the full Q.K^T after concatenation, not to the nope or rope portions individually.
 
 ## Testing
 
 ### Unit Tests
 
-Tests validate the Q/K/V projection pipeline by stepping through `MLAAttention` submodules individually and comparing against an fp64 numpy reference implementation. The reference follows the HuggingFace [BailingMoeV2_5MultiLatentAttention](https://huggingface.co/inclusionAI/Ling-2.5-1T/blob/main/modeling_bailing_moe_v2_5.py#L580) computation flow, adapted for the sglang-jax weight layout (`weight=(in_features, out_features)`, forward = `x @ weight`).
+Tests validate the Q/K/V projection pipeline by stepping through `MLAAttention` submodules individually and comparing against an fp64 numpy reference implementation. The reference follows the standard MLA computation flow, adapted for the sglang-jax weight layout (`weight=(in_features, out_features)`, forward = `x @ weight`).
 
 **Test cases:**
 
@@ -114,18 +105,11 @@ Tests validate the Q/K/V projection pipeline by stepping through `MLAAttention` 
 | `test_full_qkv` | Full Q/K/V projection with RoPE applied and tensors assembled |
 | `test_k_rope_broadcast` | `k_rope` broadcast from 1 head to all heads (all heads must be identical) |
 
-Tests use Ling-2.5-1T production config dimensions:
-- hidden_size=8192
-- num_heads=64
-- q_lora_rank=1536
-- kv_lora_rank=512
-- qk_nope_head_dim=128
-- qk_rope_head_dim=64
-- v_head_dim=128
+Tests use production-scale dimensions sourced from the target model configuration.
 
 #### Correctness Metric
 
-For production-scale dimensions (Ling-2.5-1T config) with bf16 matmuls, element-wise `allclose` is highly sensitive to tolerance settings, leading to two problems:
+For production-scale dimensions with bf16 matmuls, element-wise `allclose` is highly sensitive to tolerance settings, leading to two problems:
 
 - Tolerances too strict cause persistent false positives
 - Relaxed tolerances make the assertion itself lose discriminating power
@@ -133,36 +117,6 @@ For production-scale dimensions (Ling-2.5-1T config) with bf16 matmuls, element-
 Based on empirical calibration results, we use cosine similarity (threshold >= 0.99) as the primary correctness metric, measuring directional agreement between outputs and the fp64 reference.
 
 > FlashInfer uses the same approach in their absorbed-MLA decode kernel tests ([flashinfer-ai/flashinfer#551](https://github.com/flashinfer-ai/flashinfer/pull/551#discussion_r1826453290)). Maintainer confirmed: `"cosine similarity is okay in this case."`
-
-#### Experimental Data
-
-The following results are based on Ling-2.5-1T production config, collected over 100 random samples on 4x TPU v6e (TP=4, `ici_parallelism=[1, -1]`).
-
-**allclose calibration** (only elements with `|expected| > 1.0`):
-
-| Path | max abs error | mean abs error | max rel error |
-|------|--------------|---------------|--------------|
-| Q path | 0.863 | 0.646 | 0.446 |
-| KV k_nope | 0.461 | 0.371 | 0.223 |
-| KV v | 0.449 | 0.365 | 0.222 |
-| Full QKV (Q) | 1.389 | 0.878 | 0.446 |
-| Full QKV (K) | 2.919 | 1.015 | 0.434 |
-| Full QKV (V) | 0.449 | 0.365 | 0.222 |
-
-> Taking Full QKV (K) as an example, max abs error reaches 2.919 (mean is also 1.015), max rel error is 0.434. With a 3x safety factor, `allclose` would require `atol ~ 8.76, rtol ~ 1.30` to pass.
-
-**Cosine similarity:**
-
-| Path | min cosine | mean cosine |
-|------|-----------|-------------|
-| Q path | 0.99999406 | 0.99999450 |
-| KV k_nope | 0.99999329 | 0.99999452 |
-| KV v | 0.99999322 | 0.99999453 |
-| Full QKV (Q) | 0.99999378 | 0.99999422 |
-| Full QKV (K) | 0.99999419 | 0.99999624 |
-| Full QKV (V) | 0.99999322 | 0.99999453 |
-
-> `cosine >= 0.99` means the output vector deviates < 8 degrees from the reference direction. All components have min cosine >= 0.99999, well above the 0.99 threshold with ample margin.
 
 #### Reference Implementation
 
@@ -188,7 +142,7 @@ Tests use a numpy fp64 reference implementation as the ground-truth oracle, cons
 3. 2 new tokens' hidden states enter `MLAAttention.__call__`, completing Q/K/V projection and RoPE
 4. Hand off to `RadixAttention`: write new tokens' K/V into the pool, perform attention over all historical K/V
 
-**Assertions:** Output shape is `[2, 8192]`, no NaN/Inf.
+**Assertions:** Output shape is `[2, hidden_size]`, no NaN/Inf.
 
 > The test uses random weights and random prefix KV without verifying numerical correctness — the focus is validating that MLA's output shapes and dtypes are correctly accepted by the downstream attention + KV cache infrastructure. Numerical correctness is covered by unit tests.
 
@@ -198,21 +152,21 @@ This document does not define model-level e2e accuracy baselines. Model-level en
 
 ## Alternatives
 
-**Absorbed mode**: Cache the compressed latent state (576 dims) instead of decompressed K/V (20480 dims per token). Requires a custom attention kernel that decompresses on-the-fly during attention computation. ~35x memory reduction but significantly more implementation complexity. Deferred to a future iteration.
+**Absorbed mode**: Cache the compressed latent state instead of decompressed K/V. Requires a custom attention kernel that decompresses on-the-fly during attention computation. ~35x memory reduction but significantly more implementation complexity. Deferred to a future iteration.
 
 ## Appendix: Absorbed Mode Roadmap
 
 > Not in scope for this iteration. This appendix documents future optimization directions for reference.
 
-`MLATokenToKVPool` is already defined in `memory_pool.py` with compressed buffer layout `[size, 1, 576]`, but is not wired into the attention pipeline. The full chain for absorbed mode requires changes across multiple components:
+`MLATokenToKVPool` is already defined in `memory_pool.py` with compressed buffer layout `[size, 1, kv_lora_rank + qk_rope_head_dim]`, but is not wired into the attention pipeline. The full chain for absorbed mode requires changes across multiple components:
 
 ```mermaid
 graph TD
     subgraph "MLAAttention.__call__"
         hidden[hidden] --> Q_path["Q path (same as non-absorbed)"]
-        Q_path --> Q["Q [tokens, 64, 192]"]
+        Q_path --> Q["Q [tokens, num_heads, qk_head_dim]"]
         hidden --> kv_a_proj["kv_a_proj"]
-        kv_a_proj --> compressed["compressed [tokens, 1, 576]<br/>(no kv_b_proj decompression)"]
+        kv_a_proj --> compressed["compressed [tokens, 1, latent_dim]<br/>(skip kv_b_proj decompression)"]
     end
 
     subgraph "RadixAttention"

--- a/docs/design/894-mla-design.md
+++ b/docs/design/894-mla-design.md
@@ -67,7 +67,7 @@ The current implementation completes all decompression in `MLAAttention.__call__
 | Risk | Mitigation |
 |------|-----------|
 | Non-absorbed mode uses ~35x more KV cache than absorbed mode | Acceptable for initial implementation; absorbed mode is a future optimization |
-| bf16 precision loss in chained matmuls | Validated via cosine similarity (>= 0.99) against fp64 reference; allclose is not viable at production dimensions |
+| bf16 precision loss in chained matmuls | Validated via cosine similarity (>= 0.99) against fp32 reference; allclose is not viable at production dimensions |
 
 ## Design Details
 
@@ -93,7 +93,7 @@ The current implementation completes all decompression in `MLAAttention.__call__
 
 ### Unit Tests
 
-Tests validate the Q/K/V projection pipeline by stepping through `MLAAttention` submodules individually and comparing against an fp64 numpy reference implementation. The reference follows the standard MLA computation flow, adapted for the sglang-jax weight layout (`weight=(in_features, out_features)`, forward = `x @ weight`).
+Tests validate the Q/K/V projection pipeline by stepping through `MLAAttention` submodules individually and comparing against an fp32 numpy reference implementation. The reference follows the standard MLA computation flow, adapted for the sglang-jax weight layout (`weight=(in_features, out_features)`, forward = `x @ weight`).
 
 **Test cases:**
 
@@ -114,20 +114,20 @@ For production-scale dimensions with bf16 matmuls, element-wise `allclose` is hi
 - Tolerances too strict cause persistent false positives
 - Relaxed tolerances make the assertion itself lose discriminating power
 
-Based on empirical calibration results, we use cosine similarity (threshold >= 0.99) as the primary correctness metric, measuring directional agreement between outputs and the fp64 reference.
+Based on empirical calibration results, we use cosine similarity (threshold >= 0.99) as the primary correctness metric, measuring directional agreement between outputs and the fp32 reference.
 
 > FlashInfer uses the same approach in their absorbed-MLA decode kernel tests ([flashinfer-ai/flashinfer#551](https://github.com/flashinfer-ai/flashinfer/pull/551#discussion_r1826453290)). Maintainer confirmed: `"cosine similarity is okay in this case."`
 
 #### Reference Implementation
 
-Tests use a numpy fp64 reference implementation as the ground-truth oracle, consisting of the following functions:
+Tests use a numpy fp32 reference implementation as the ground-truth oracle, consisting of the following functions:
 
 | Function | Purpose |
 |----------|---------|
-| `numpy_linear_fp64(x, weight)` | `x @ weight` in fp64 |
-| `numpy_rmsnorm_fp64(x, scale, eps)` | RMSNorm |
-| `numpy_rotary_emb_fp64(x, cos, sin)` | Interleaved RoPE |
-| `numpy_mla_qkv_fp64(hidden, positions, weights, config)` | Complete Q/K/V projection pipeline |
+| `numpy_linear_fp32(x, weight)` | `x @ weight` in fp32 |
+| `numpy_rmsnorm_fp32(x, scale, eps)` | RMSNorm |
+| `numpy_rotary_emb_fp32(x, cos, sin)` | Interleaved RoPE |
+| `numpy_mla_qkv_fp32(hidden, positions, weights, config)` | Complete Q/K/V projection pipeline |
 
 ### Integration Test
 

--- a/docs/design/894-mla-design.md
+++ b/docs/design/894-mla-design.md
@@ -1,0 +1,240 @@
+# Multi-head Latent Attention (MLA) Design
+
+## Summary
+
+This document describes the design and testing approach for `MLAAttention` in sglang-jax, targeting DeepSeek-V2 style models (Ling-2.5-1T, etc.).
+
+MLA can theoretically reduce per-token cache from `heads x (qk_head_dim + v_head_dim)` to `kv_lora_rank + qk_rope_head_dim` via compressed-state KV cache, but **the current implementation uses non-absorbed mode**, which decompresses to standard Q/K/V in `MLAAttention.__call__` and then reuses the existing `RadixAttention` + `SplitMHATokenToKVPool`. Therefore, the current goal is to correctly integrate the MLA data flow with minimal system changes, not to immediately gain the KV cache compression benefits of absorbed mode.
+
+## Background and Goals
+
+### Goals
+
+- Provide a reusable MLA layer that correctly implements the Q/K/V projection pipeline from [BailingMoeV2_5MultiLatentAttention](https://huggingface.co/inclusionAI/Ling-2.5-1T/blob/main/modeling_bailing_moe_v2_5.py#L580).
+- Integrate with existing attention infrastructure (`RadixAttention`, `SplitMHATokenToKVPool`) without modifying these components.
+- Support K_dim != V_dim (192 vs 128) through `SplitMHATokenToKVPool` separate buffers.
+
+### Non-Goals
+
+- Absorbed mode (caching compressed state instead of decompressed K/V). Requires a custom attention kernel and is a separate effort.
+- Model-level integration (weight loading, model config parsing). This layer provides the building block; model files compose it.
+
+## Design Overview
+
+`MLAAttention` is implemented as a Flax NNX module. It performs the full MLA data flow internally and outputs standard attention results, making it a drop-in replacement for standard multi-head attention in model definitions.
+
+**Data flow:**
+
+```mermaid
+graph LR
+    hidden[hidden] --> q_a_proj --> q_norm[RMSNorm] --> q_b_proj --> q_split["split(q_nope, q_rope)"]
+    hidden --> kv_a_proj --> kv_split["split(compressed, k_rope_raw)"]
+    kv_split -- compressed --> kv_norm[RMSNorm] --> kv_b_proj --> kv_split2["split(k_nope, v)"]
+    q_split -- q_rope --> RoPE
+    kv_split -- k_rope_raw --> RoPE
+    RoPE -- q_rope' --> assemble["concat -> Q, K"]
+    q_split -- q_nope --> assemble
+    kv_split2 -- k_nope --> assemble
+    RoPE -- k_rope' --> assemble
+    assemble --> RadixAttention
+    kv_split2 -- v --> RadixAttention
+    RadixAttention --> o_proj --> output[hidden]
+```
+
+**Key design decisions:**
+
+1. **Non-absorbed mode**: All decompression is completed in `MLAAttention.__call__`, then standard Q/K/V are handed to `RadixAttention`. The attention layer is unaware of the low-rank origin.
+2. **Split KV cache**: After MLA decompression, K has head_dim=192 and V has head_dim=128. Since K_dim != V_dim, they cannot share a single fused buffer (`MHATokenToKVPool` requires uniform dimensions). `SplitMHATokenToKVPool` maintains two independent buffers (K: `[size, heads, 192]`, V: `[size, heads, 128]`). This is existing sglang-jax infrastructure, not MLA-specific.
+
+### Constraints and Boundaries
+
+**The current implementation uses non-absorbed mode.** MLA has two implementation strategies:
+
+| | Non-absorbed (current) | Absorbed (not implemented) |
+|---|---|---|
+| Data flow | Compress -> **decompress to standard Q/K/V** -> standard attention | Compress -> **cache compressed state** -> decompress inside attention |
+| KV cache content | Decompressed full K/V | Compressed state (kv_lora_rank + qk_rope_head_dim) |
+| Per-token KV cache | heads x (qk_head_dim + v_head_dim) = 64x(192+128) = 20480 | kv_lora_rank + qk_rope_head_dim = 576 |
+| Attention kernel | Standard `RadixAttention` + `SplitMHATokenToKVPool` | Custom kernel needed (`MLATokenToKVPool` defined but not wired in) |
+| Memory efficiency | Low (20480/576 ~ 35x vs absorbed) | High |
+
+The current implementation completes all decompression in `MLAAttention.__call__`, outputting standard Q/K/V tensors before handing off to `RadixAttention`. The attention layer does not need to know the data originates from a low-rank decomposition. K_dim(192) != V_dim(128) is handled by `SplitMHATokenToKVPool` with separate buffers. See [Appendix: Absorbed Mode Roadmap](#appendix-absorbed-mode-roadmap) for the absorbed mode roadmap.
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Non-absorbed mode uses ~35x more KV cache than absorbed mode | Acceptable for initial implementation; absorbed mode is a future optimization |
+| bf16 precision loss in chained matmuls | Validated via cosine similarity (>= 0.99) against fp64 reference; allclose is not viable at production dimensions |
+
+## Design Details
+
+**Module:** `MLAAttention` (Flax NNX)
+
+**Projections:**
+
+| Layer | Shape | Sharding |
+|-------|-------|----------|
+| `q_a_proj` | (hidden_size, q_lora_rank) | kernel: (None, None) |
+| `q_b_proj` | (q_lora_rank, num_heads x qk_head_dim) | kernel: (None, "tensor") |
+| `kv_a_proj` | (hidden_size, kv_lora_rank + qk_rope_head_dim) | kernel: (None, None) |
+| `kv_b_proj` | (kv_lora_rank, num_heads x (qk_nope_head_dim + v_head_dim)) | kernel: (None, "tensor") |
+| `o_proj` | (num_heads x v_head_dim, hidden_size) | kernel: ("tensor", None) |
+
+**Config (Ling-2.5-1T):**
+
+| Parameter | Value |
+|-----------|-------|
+| q_lora_rank | 1536 |
+| kv_lora_rank | 512 |
+| qk_nope_head_dim | 128 |
+| qk_rope_head_dim | 64 |
+| v_head_dim | 128 |
+| num_attention_heads | 64 |
+| rope_theta | 6000000.0 |
+| rope_style | interleaved |
+
+**Output shapes:** Q = [tokens, 64, 192], K = [tokens, 64, 192], V = [tokens, 64, 128]
+
+**Attention scaling:** `scaling = qk_head_dim^(-0.5) = 192^(-0.5)`, consistent with HuggingFace BailingMoeV2_5MultiLatentAttention. The scaling is applied to the full Q.K^T after concatenation, not to the nope or rope portions individually.
+
+## Testing
+
+### Unit Tests
+
+Tests validate the Q/K/V projection pipeline by stepping through `MLAAttention` submodules individually and comparing against an fp64 numpy reference implementation. The reference follows the HuggingFace [BailingMoeV2_5MultiLatentAttention](https://huggingface.co/inclusionAI/Ling-2.5-1T/blob/main/modeling_bailing_moe_v2_5.py#L580) computation flow, adapted for the sglang-jax weight layout (`weight=(in_features, out_features)`, forward = `x @ weight`).
+
+**Test cases:**
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_output_shapes` | Q, K, V output tensor shapes match expected dimensions |
+| `test_q_path` | Q projection chain: `q_a_proj -> RMSNorm -> q_b_proj -> reshape` |
+| `test_kv_path` | KV projection chain: `kv_a_proj -> split -> RMSNorm -> kv_b_proj -> reshape -> split` |
+| `test_full_qkv` | Full Q/K/V projection with RoPE applied and tensors assembled |
+| `test_k_rope_broadcast` | `k_rope` broadcast from 1 head to all heads (all heads must be identical) |
+
+Tests use Ling-2.5-1T production config dimensions:
+- hidden_size=8192
+- num_heads=64
+- q_lora_rank=1536
+- kv_lora_rank=512
+- qk_nope_head_dim=128
+- qk_rope_head_dim=64
+- v_head_dim=128
+
+#### Correctness Metric
+
+For production-scale dimensions (Ling-2.5-1T config) with bf16 matmuls, element-wise `allclose` is highly sensitive to tolerance settings, leading to two problems:
+
+- Tolerances too strict cause persistent false positives
+- Relaxed tolerances make the assertion itself lose discriminating power
+
+Based on empirical calibration results, we use cosine similarity (threshold >= 0.99) as the primary correctness metric, measuring directional agreement between outputs and the fp64 reference.
+
+> FlashInfer uses the same approach in their absorbed-MLA decode kernel tests ([flashinfer-ai/flashinfer#551](https://github.com/flashinfer-ai/flashinfer/pull/551#discussion_r1826453290)). Maintainer confirmed: `"cosine similarity is okay in this case."`
+
+#### Experimental Data
+
+The following results are based on Ling-2.5-1T production config, collected over 100 random samples on 4x TPU v6e (TP=4, `ici_parallelism=[1, -1]`).
+
+**allclose calibration** (only elements with `|expected| > 1.0`):
+
+| Path | max abs error | mean abs error | max rel error |
+|------|--------------|---------------|--------------|
+| Q path | 0.863 | 0.646 | 0.446 |
+| KV k_nope | 0.461 | 0.371 | 0.223 |
+| KV v | 0.449 | 0.365 | 0.222 |
+| Full QKV (Q) | 1.389 | 0.878 | 0.446 |
+| Full QKV (K) | 2.919 | 1.015 | 0.434 |
+| Full QKV (V) | 0.449 | 0.365 | 0.222 |
+
+> Taking Full QKV (K) as an example, max abs error reaches 2.919 (mean is also 1.015), max rel error is 0.434. With a 3x safety factor, `allclose` would require `atol ~ 8.76, rtol ~ 1.30` to pass.
+
+**Cosine similarity:**
+
+| Path | min cosine | mean cosine |
+|------|-----------|-------------|
+| Q path | 0.99999406 | 0.99999450 |
+| KV k_nope | 0.99999329 | 0.99999452 |
+| KV v | 0.99999322 | 0.99999453 |
+| Full QKV (Q) | 0.99999378 | 0.99999422 |
+| Full QKV (K) | 0.99999419 | 0.99999624 |
+| Full QKV (V) | 0.99999322 | 0.99999453 |
+
+> `cosine >= 0.99` means the output vector deviates < 8 degrees from the reference direction. All components have min cosine >= 0.99999, well above the 0.99 threshold with ample margin.
+
+#### Reference Implementation
+
+Tests use a numpy fp64 reference implementation as the ground-truth oracle, consisting of the following functions:
+
+| Function | Purpose |
+|----------|---------|
+| `numpy_linear_fp64(x, weight)` | `x @ weight` in fp64 |
+| `numpy_rmsnorm_fp64(x, scale, eps)` | RMSNorm |
+| `numpy_rotary_emb_fp64(x, cos, sin)` | Interleaved RoPE |
+| `numpy_mla_qkv_fp64(hidden, positions, weights, config)` | Complete Q/K/V projection pipeline |
+
+### Integration Test
+
+`test_radix_attention_integration`: Simulates one decode step to verify that MLA output can be correctly accepted and processed by `RadixAttention` + `SplitMHATokenToKVPool`.
+
+**Scenario:** 2 sequences, KV lengths of 4 and 6 (cached history tokens), each sequence currently processing 1 new token (2 query tokens total).
+
+**Flow:**
+
+1. Create `SplitMHATokenToKVPool` (separate K/V buffers), write random prefix KV into the pool to simulate cached historical K/V
+2. Build `cache_loc` and `ForwardBatch`, specifying the physical position of each token's KV in the pool
+3. 2 new tokens' hidden states enter `MLAAttention.__call__`, completing Q/K/V projection and RoPE
+4. Hand off to `RadixAttention`: write new tokens' K/V into the pool, perform attention over all historical K/V
+
+**Assertions:** Output shape is `[2, 8192]`, no NaN/Inf.
+
+> The test uses random weights and random prefix KV without verifying numerical correctness — the focus is validating that MLA's output shapes and dtypes are correctly accepted by the downstream attention + KV cache infrastructure. Numerical correctness is covered by unit tests.
+
+### Tests Not Covered in This Document
+
+This document does not define model-level e2e accuracy baselines. Model-level end-to-end accuracy is covered separately by the accuracy test suite; this document focuses on layer-level numerical correctness and MLA's integration with existing attention / KV cache infrastructure.
+
+## Alternatives
+
+**Absorbed mode**: Cache the compressed latent state (576 dims) instead of decompressed K/V (20480 dims per token). Requires a custom attention kernel that decompresses on-the-fly during attention computation. ~35x memory reduction but significantly more implementation complexity. Deferred to a future iteration.
+
+## Appendix: Absorbed Mode Roadmap
+
+> Not in scope for this iteration. This appendix documents future optimization directions for reference.
+
+`MLATokenToKVPool` is already defined in `memory_pool.py` with compressed buffer layout `[size, 1, 576]`, but is not wired into the attention pipeline. The full chain for absorbed mode requires changes across multiple components:
+
+```mermaid
+graph TD
+    subgraph "MLAAttention.__call__"
+        hidden[hidden] --> Q_path["Q path (same as non-absorbed)"]
+        Q_path --> Q["Q [tokens, 64, 192]"]
+        hidden --> kv_a_proj["kv_a_proj"]
+        kv_a_proj --> compressed["compressed [tokens, 1, 576]<br/>(no kv_b_proj decompression)"]
+    end
+
+    subgraph "RadixAttention"
+        Q --> FA["FlashAttention.__call__()"]
+        compressed --> FA
+        FA --> call_mla["_call_mla() <- new dispatch path"]
+    end
+
+    subgraph "MLATokenToKVPool"
+        call_mla -- write --> pool["set_kv_buffer(compressed)"]
+    end
+
+    subgraph "Custom Pallas Kernel"
+        call_mla --> kernel["read compressed -> kv_b_proj decompress -> attention"]
+    end
+```
+
+Required changes:
+
+| Component | Change | Complexity |
+|-----------|--------|-----------|
+| `MLAAttention.__call__` | Skip `kv_b_proj` decompression, output compressed state directly | Low |
+| `RadixAttention` | Interface adaptation for compressed KV (or keep compatible via `KVCache` base class) | Low |
+| `FlashAttention.__call__` | Add `isinstance(pool, MLATokenToKVPool)` dispatch to `_call_mla` | Medium |
+| Pallas attention kernel | Fuse `compressed @ kv_b_proj.weight` decompression into block-wise attention loop | High |


### PR DESCRIPTION
## Motivation

Implement the MLA (Multi-head Latent Attention) layer for DeepSeek-V2 style models (Ling-2.5-1T, etc.),as described in #894.

## Modifications

Add design docs: `894-mla-design.md`

## Accuracy Tests

- Unit tests validate Q/K/V projection pipeline against fp32 numpy reference using cosine similarity (threshold >= 0.99). Calibrated over 100 random samples on 4x TPU v6e (TP=4), all components achieve min cosine >= 0.99999.

- Integration test verifies end-to-end decode through `RadixAttention` + `MHATokenToKVPool` on TPU.

**Experimental data (fp32 reference, 100 random samples, 4x TPU v6e TP=4)**

Element-wise error statistics (only elements with `|expected| > 1.0`):

| Path | max abs error | mean abs error | max rel error |
|------|--------------|---------------|--------------|
| Q path | 0.863 | 0.646 | 0.446 |
| KV k_nope | 0.461 | 0.371 | 0.223 |
| KV v | 0.449 | 0.365 | 0.222 |
| Full QKV (Q) | 1.389 | 0.878 | 0.446 |
| Full QKV (K) | 2.919 | 1.015 | 0.434 |
| Full QKV (V) | 0.449 | 0.365 | 0.222 |

Cosine similarity:

| Path | min | mean | max |
|------|-----|------|-----|
| Q path | 0.99999446 | 0.99999481 | 0.99999529 |
| KV k_nope | 0.99999356 | 0.99999464 | 0.99999577 |
| KV v | 0.99999362 | 0.99999464 | 0.99999571 |
| Full QKV (Q) | 0.99999398 | 0.99999452 | 0.99999511 |
| Full QKV (K) | 0.99999452 | 0.99999642 | 0.99999762 |
| Full QKV (V) | 0.99999362 | 0.99999464 | 0.99999571 |

> Recommended `COSINE_THRESHOLD = 0.99` (observed min = 0.99999356)


## Benchmarking and Profiling

N/A — new layer, no existing performance baseline to compare against.
## Checklist

- [ ] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
