### PR TITLE
feat: Add ngram speculative decoding (Prompt Lookup Decoding, no draft model)

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1603,9 +1603,9 @@ class ScheduleBatch:
         if len(seq_lens_cpu) > 0:
             seq_lens = seq_lens_cpu
             if self.spec_algorithm is not None and not self.spec_algorithm.is_none():
-                if self.forward_mode == ForwardMode.TARGET_VERIFY:
+                if self.forward_mode == ForwardMode.TARGET_VERIFY and self.spec_info is not None:
                     seq_lens = seq_lens_cpu + self.spec_info.draft_token_num
-                elif self.forward_mode == ForwardMode.DECODE:
+                elif self.forward_mode == ForwardMode.DECODE and self.spec_algorithm.is_eagle():
                     from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
 
                     seq_lens = seq_lens_cpu + EagleDraftInput.ALLOC_LEN_PER_DECODE
@@ -1618,7 +1618,8 @@ class ScheduleBatch:
                 if (
                     self.forward_mode == ForwardMode.DECODE
                     and not self.spec_algorithm.is_none()
-                    and self.spec_info.allocate_lens is not None
+                    and self.spec_info is not None
+                    and getattr(self.spec_info, "allocate_lens", None) is not None
                 ):
                     # Explicitly convert to numpy to avoid JAX device synchronization overhead
                     allocated_len_cpu = np.array(self.spec_info.allocate_lens)
@@ -1702,6 +1703,7 @@ class ScheduleBatch:
             spec_info=self.spec_info,
             spec_algorithm=self.spec_algorithm,
             tree_cache=self.tree_cache,
+            reqs=self.reqs,
         )
 
     def _generate_trace_info(self, real_bs: int, bid: int) -> list[str]:
@@ -1971,6 +1973,9 @@ class ModelWorkerBatch:
 
     # MRoPE position information [3, total_tokens]
     mrope_positions: np.ndarray | None = None
+
+    # Request objects (needed by ngram speculative decoding)
+    reqs: list | None = None
 
     def get_original_input_len(self):
         """

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -293,6 +293,13 @@ class Scheduler(
                 server_args=server_args,
                 target_worker=self.tp_worker,
             )
+        elif self.spec_algorithm is not None and self.spec_algorithm.is_ngram():
+            from sgl_jax.srt.speculative.ngram_worker import NgramWorker
+
+            self.draft_worker = NgramWorker(
+                server_args=server_args,
+                target_worker=self.tp_worker,
+            )
 
         # Get token and memory info from the model worker
         (
@@ -1402,6 +1409,9 @@ class Scheduler(
         if self.spec_algorithm is not None and self.spec_algorithm.is_eagle():
             assert isinstance(batch_output.next_draft_input, EagleDraftInput)
             ret.next_draft_input = batch_output.next_draft_input
+            ret.accept_lens = batch_output.accept_lens
+            ret.allocate_lens = batch_output.allocate_lens
+        elif self.spec_algorithm is not None and self.spec_algorithm.is_ngram():
             ret.accept_lens = batch_output.accept_lens
             ret.allocate_lens = batch_output.allocate_lens
         return ret

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -295,7 +295,7 @@ class SchedulerOutputProcessorMixin:
             new_accepted_len = 1
             if batch.spec_algorithm is None or batch.spec_algorithm.is_none():
                 req.output_ids.append(next_token_id)
-            elif self.spec_algorithm.is_eagle():
+            elif self.spec_algorithm.is_eagle() or self.spec_algorithm.is_ngram():
                 req.output_ids.extend(next_token_id)
                 new_accepted_len = len(next_token_id)
 
@@ -319,6 +319,9 @@ class SchedulerOutputProcessorMixin:
                     ), f"redundant kv indices {len(kv_indices)=} should less than {EagleDraftInput.ALLOC_LEN_PER_DECODE=}"
 
                     self.token_to_kv_pool_allocator.free(kv_indices)
+                # Ngram frees unaccepted KV slots inside _forward_decode
+                # for all requests (finished and non-finished), so no
+                # additional freeing is needed here.
                 # End trace for finished request
                 if precision_tracer.get_trace_active():
                     precision_tracer.set_request_status_to_completed(req.rid)

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -152,6 +152,10 @@ class ServerArgs:
     speculative_accept_threshold_single: float = 1.0
     speculative_accept_threshold_acc: float = 1.0
 
+    # Ngram speculative decoding
+    speculative_ngram_max_trie_depth: int = 8
+    speculative_ngram_max_bfs_breadth: int = 1
+
     # For deterministic sampling
     enable_deterministic_sampling: bool = False
     enable_single_process: bool = False
@@ -932,7 +936,7 @@ class ServerArgs:
         parser.add_argument(
             "--speculative-algorithm",
             type=str,
-            choices=["EAGLE", "EAGLE3", "NEXTN", "STANDALONE"],
+            choices=["EAGLE", "EAGLE3", "NEXTN", "STANDALONE", "NGRAM"],
             help="Speculative algorithm.",
             default=ServerArgs.speculative_algorithm,
         )
@@ -980,6 +984,20 @@ class ServerArgs:
             type=float,
             help="The accept probability of a draft token is raised from its target probability p to min(1, p / threshold_acc).",
             default=ServerArgs.speculative_accept_threshold_acc,
+        )
+        parser.add_argument(
+            "--speculative-ngram-max-trie-depth",
+            type=int,
+            help="Maximum depth of the ngram trie (longest stored n-gram).",
+            default=ServerArgs.speculative_ngram_max_trie_depth,
+        )
+        parser.add_argument(
+            "--speculative-ngram-max-bfs-breadth",
+            type=int,
+            help="Maximum BFS breadth when generating draft tokens from the ngram trie. "
+            "Default 1 (chain mode) ensures correct KV cache management. "
+            "Values > 1 (branching) require KV compaction (not yet implemented).",
+            default=ServerArgs.speculative_ngram_max_bfs_breadth,
         )
 
         # For deterministic sampling

--- a/python/sgl_jax/srt/speculative/ngram_cache.py
+++ b/python/sgl_jax/srt/speculative/ngram_cache.py
@@ -1,0 +1,279 @@
+"""Trie-based N-gram cache for speculative decoding draft token generation.
+
+Stores previously decoded token sequences in a trie structure. Given a suffix
+of the most recently generated tokens, the trie is queried via BFS to produce
+a tree of candidate draft tokens that the target model can verify in a single
+forward pass.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict, deque
+from dataclasses import dataclass
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class TrieNode:
+    __slots__ = ("children", "count")
+
+    def __init__(self):
+        self.children: dict[int, TrieNode] = {}
+        self.count: int = 0
+
+
+@dataclass
+class DraftTree:
+    """Result of a BFS query on the trie.
+
+    Attributes:
+        tokens: Flat array of draft token ids, length ``draft_token_num``.
+        mask: Boolean mask of shape ``(draft_token_num, draft_token_num)``
+              where ``mask[i, j] = True`` means token *i* can attend to token *j*.
+        retrive_index: Maps each tree position to its index in the output logits.
+        retrive_next_token: First-child index for tree traversal (-1 = leaf).
+        retrive_next_sibling: Next-sibling index for tree traversal (-1 = none).
+        parent_idx: Parent index for each node (-1 = root child).
+    """
+
+    tokens: np.ndarray
+    mask: np.ndarray
+    retrive_index: np.ndarray
+    retrive_next_token: np.ndarray
+    retrive_next_sibling: np.ndarray
+    parent_idx: np.ndarray
+
+
+class NgramCache:
+    """Trie-based n-gram cache for speculative decoding.
+
+    Not thread-safe -- relies on the scheduler being single-threaded
+    (speculative decoding requires ``--disable-overlap-schedule``).
+
+    Parameters:
+        max_trie_depth: Maximum depth of the trie (longest stored n-gram).
+        max_nodes: Soft cap on trie nodes; insertions stop when exceeded.
+    """
+
+    def __init__(self, max_trie_depth: int = 8, max_nodes: int = 1_000_000):
+        self.root = TrieNode()
+        self.max_trie_depth = max_trie_depth
+        self.max_nodes = max_nodes
+        self._node_count = 0
+
+    def insert(self, token_ids: list[int] | np.ndarray) -> None:
+        """Insert all valid n-gram suffixes from ``token_ids`` into the trie.
+
+        This is a convenience wrapper around :meth:`insert_new_suffixes` that
+        inserts every n-gram (of length ``<= max_trie_depth``) appearing in
+        ``token_ids`` exactly once.
+        """
+        self.insert_new_suffixes(token_ids, prev_len=0)
+
+    def insert_new_suffixes(self, token_ids: list[int] | np.ndarray, prev_len: int) -> None:
+        """Insert only n-grams whose terminal position is >= ``prev_len``.
+
+        This enables incremental updates when new tokens are appended to a
+        sequence without re-incrementing counts for previously seen
+        n-grams. For each new terminal position ``P`` in
+        ``[prev_len, n - 1]`` and each length ``L`` in
+        ``[1, min(max_trie_depth, P + 1)]``, the trie node representing
+        the n-gram ``token_ids[P - L + 1 : P + 1]`` has its ``count``
+        incremented by exactly one (and intermediate nodes along the
+        walk are created if missing, but not incremented -- they count
+        distinct n-grams of their own which will be visited for their
+        own terminal positions).
+
+        Parameters:
+            token_ids: The full token sequence.
+            prev_len: The sequence length that was previously inserted.
+                Pass ``0`` to insert every n-gram from scratch.
+        """
+        n = len(token_ids)
+        first_new_pos = max(int(prev_len), 0)
+        for p in range(first_new_pos, n):
+            max_len = min(self.max_trie_depth, p + 1)
+            for length in range(1, max_len + 1):
+                start = p - length + 1
+                node = self.root
+                abort = False
+                for idx in range(start, p + 1):
+                    tok = int(token_ids[idx])
+                    if tok not in node.children:
+                        if self._node_count >= self.max_nodes:
+                            abort = True
+                            break
+                        node.children[tok] = TrieNode()
+                        self._node_count += 1
+                    node = node.children[tok]
+                if abort:
+                    # Node budget exhausted; stop processing the rest of
+                    # this sequence to avoid inconsistent partial walks.
+                    return
+                # Increment only the terminal node of this n-gram walk.
+                node.count += 1
+
+    def query_bfs(
+        self,
+        suffix: list[int] | np.ndarray,
+        draft_token_num: int,
+        max_bfs_breadth: int,
+    ) -> DraftTree:
+        """Query the trie with ``suffix`` and return up to ``draft_token_num`` draft tokens.
+
+        Uses BFS starting from the trie node matching the longest suffix prefix.
+        Children at each level are ranked by frequency (count) and capped by
+        ``max_bfs_breadth``.
+
+        Returns a ``DraftTree`` with correctly constructed tree traversal indices.
+        """
+        start_node = self._find_best_match(suffix)
+
+        tokens = np.full(draft_token_num, -1, dtype=np.int32)
+        parent_idx = np.full(draft_token_num, -1, dtype=np.int32)
+        children_map: dict[int, list[int]] = defaultdict(list)
+        count = 0
+        real_count = 0
+
+        if start_node is None or not start_node.children:
+            return self._build_empty_draft(draft_token_num)
+
+        queue: deque[tuple[TrieNode, int]] = deque()
+
+        sorted_children = sorted(
+            start_node.children.items(), key=lambda x: x[1].count, reverse=True
+        )[:max_bfs_breadth]
+
+        for tok, child_node in sorted_children:
+            if count >= draft_token_num:
+                break
+            tokens[count] = tok
+            parent_idx[count] = -1
+            children_map[-1].append(count)
+            queue.append((child_node, count))
+            count += 1
+
+        while queue and count < draft_token_num:
+            trie_node, pidx = queue.popleft()
+            if not trie_node.children:
+                continue
+
+            sorted_ch = sorted(trie_node.children.items(), key=lambda x: x[1].count, reverse=True)[
+                :max_bfs_breadth
+            ]
+
+            for tok, child_node in sorted_ch:
+                if count >= draft_token_num:
+                    break
+                tokens[count] = tok
+                parent_idx[count] = pidx
+                children_map[pidx].append(count)
+                queue.append((child_node, count))
+                count += 1
+
+        real_count = count
+
+        # If we produced no real candidates (e.g. ``max_bfs_breadth == 0``
+        # or an empty children dict), fall through to a safe empty tree
+        # with ``parent_idx = [-1, -1, ...]``. Without this guard we
+        # would compute ``pad_parent = max(-1, 0) = 0`` and then set
+        # ``parent_idx[0] = 0``, producing a self-loop that can hang the
+        # ancestry walks in ``_build_draft_tree`` and in the target
+        # verify positions computation.
+        if real_count == 0:
+            return self._build_empty_draft(draft_token_num)
+
+        # Padded positions use -1 (unmatchable sentinel) and are parented
+        # to the last real node so the verify kernel rejects them
+        # immediately. ``pad_parent`` is always a valid real-node index
+        # (>= 0) because ``real_count >= 1`` at this point.
+        if count < draft_token_num:
+            pad_parent = real_count - 1
+            for i in range(count, draft_token_num):
+                tokens[i] = -1
+                parent_idx[i] = pad_parent
+
+        return self._build_draft_tree(tokens, parent_idx, children_map, draft_token_num)
+
+    def _find_best_match(self, suffix: list[int] | np.ndarray) -> TrieNode | None:
+        """Walk the trie to find the deepest node matching the full suffix.
+
+        Tries the full suffix first, then drops the oldest token and retries
+        with shorter suffixes until a complete match is found.
+
+        Returns the deepest matching node with children, or ``self.root``
+        as a last resort.
+        """
+        if len(suffix) == 0:
+            return self.root
+
+        for start in range(len(suffix)):
+            node = self.root
+            matched = True
+            for i in range(start, len(suffix)):
+                tok = int(suffix[i])
+                if tok in node.children:
+                    node = node.children[tok]
+                else:
+                    matched = False
+                    break
+            if matched and node.children:
+                return node
+
+        return self.root
+
+    def _build_draft_tree(
+        self,
+        tokens: np.ndarray,
+        parent_idx: np.ndarray,
+        children_map: dict[int, list[int]],
+        draft_token_num: int,
+    ) -> DraftTree:
+        """Build tree traversal indices from parent relationships."""
+        retrive_index = np.arange(draft_token_num, dtype=np.int32)
+        retrive_next_token = np.full(draft_token_num, -1, dtype=np.int32)
+        retrive_next_sibling = np.full(draft_token_num, -1, dtype=np.int32)
+
+        for pidx, child_indices in children_map.items():
+            if not child_indices:
+                continue
+            if pidx >= 0:
+                retrive_next_token[pidx] = child_indices[0]
+            for j in range(len(child_indices) - 1):
+                retrive_next_sibling[child_indices[j]] = child_indices[j + 1]
+
+        mask = np.zeros((draft_token_num, draft_token_num), dtype=np.bool_)
+        for i in range(draft_token_num):
+            mask[i, i] = True
+            p = parent_idx[i]
+            while p >= 0:
+                mask[i, p] = True
+                p = parent_idx[p]
+
+        return DraftTree(
+            tokens=tokens,
+            mask=mask,
+            retrive_index=retrive_index,
+            retrive_next_token=retrive_next_token,
+            retrive_next_sibling=retrive_next_sibling,
+            parent_idx=parent_idx,
+        )
+
+    def _build_empty_draft(self, draft_token_num: int) -> DraftTree:
+        """Return a degenerate draft tree (no useful candidates)."""
+        return DraftTree(
+            tokens=np.full(draft_token_num, -1, dtype=np.int32),
+            mask=np.eye(draft_token_num, dtype=np.bool_),
+            retrive_index=np.arange(draft_token_num, dtype=np.int32),
+            retrive_next_token=np.full(draft_token_num, -1, dtype=np.int32),
+            retrive_next_sibling=np.full(draft_token_num, -1, dtype=np.int32),
+            parent_idx=np.full(draft_token_num, -1, dtype=np.int32),
+        )
+
+    def reset(self) -> None:
+        """Clear the entire trie."""
+        self.root = TrieNode()
+        self._node_count = 0

--- a/python/sgl_jax/srt/speculative/ngram_worker.py
+++ b/python/sgl_jax/srt/speculative/ngram_worker.py
@@ -41,10 +41,11 @@ class NgramVerifyInput:
 
     Registered as a JAX pytree so the wrapping ``ModelWorkerBatch`` can flow
     through ``jax.jit`` (the target ``forward`` is jitted and inspects every
-    leaf of ``model_worker_batch``). ``custom_mask`` is the only jax.Array
-    leaf; ``draft_token_num`` is static (compile-time) metadata; and
-    ``allocate_lens`` is a host-side numpy array we keep out of the pytree
-    to avoid forcing host->device transfers on every call.
+    leaf of ``model_worker_batch``). ``draft_token_num`` is compile-time
+    metadata; runtime-varying arrays such as ``custom_mask`` and
+    ``allocate_lens`` must stay in the pytree leaves so that they do not
+    participate in JAX's metadata equality checks (which would both crash for
+    bs>=2 and force recompilation whenever the lengths change).
     """
 
     custom_mask: np.ndarray | jax.Array
@@ -52,10 +53,14 @@ class NgramVerifyInput:
     allocate_lens: np.ndarray | None = None
 
     def tree_flatten(self):
-        children = (self.custom_mask,)
+        allocate_lens = (
+            np.empty((0,), dtype=np.int32)
+            if self.allocate_lens is None
+            else np.asarray(self.allocate_lens, dtype=np.int32)
+        )
+        children = (self.custom_mask, allocate_lens)
         aux_data = {
             "draft_token_num": self.draft_token_num,
-            "allocate_lens": self.allocate_lens,
         }
         return (children, aux_data)
 
@@ -64,7 +69,7 @@ class NgramVerifyInput:
         return cls(
             custom_mask=children[0],
             draft_token_num=aux_data["draft_token_num"],
-            allocate_lens=aux_data["allocate_lens"],
+            allocate_lens=(children[1] if len(children[1]) > 0 else None),
         )
 
 
@@ -138,6 +143,19 @@ def _build_custom_mask_flat(
     return np.concatenate(per_req_mask_blocks)
 
 
+def _pick_context_len(
+    max_seq_len: int,
+    precompile_token_paddings: list[int],
+) -> int:
+    """Bucket ``max_seq_len`` to a stable precompile token padding."""
+    max_seq_len = max(int(max_seq_len), 1)
+    if precompile_token_paddings:
+        for padding in sorted(precompile_token_paddings):
+            if padding >= max_seq_len:
+                return padding
+    return 1 << (max_seq_len - 1).bit_length()
+
+
 class NgramWorker:
     """Speculative decoding worker that uses n-gram lookup instead of a draft model."""
 
@@ -177,6 +195,12 @@ class NgramWorker:
                 max_trie_depth=self.max_trie_depth,
             )
         return self._caches[req_id]
+
+    def _get_padding_bs_index(self, real_bs: int) -> tuple[int, int]:
+        for i, size in enumerate(self.precompile_bs_paddings):
+            if size >= real_bs:
+                return size - real_bs, i
+        raise RuntimeError(f"Failed to find precompile batch-size bucket for {real_bs=}")
 
     def _evict_finished_requests(self, active_req_ids: set[str]) -> None:
         stale = [rid for rid in self._caches if rid not in active_req_ids]
@@ -352,21 +376,57 @@ class NgramWorker:
         # positions can never match.
         safe_input_ids = _make_safe_input_ids(draft_tokens_np)
 
+        # Bucket the verify inputs to stable precompile shapes. Without this,
+        # ``custom_mask`` and ``cache_loc`` would grow every decode step and
+        # force a fresh TPU compilation on every iteration.
+        _, padding_bs_index = self._get_padding_bs_index(bs)
+        padded_bs = self.precompile_bs_paddings[padding_bs_index]
+        max_seq_len = int(np.max(seq_lens_before_draft)) if len(seq_lens_before_draft) > 0 else 1
+        context_len = _pick_context_len(max_seq_len, self.precompile_token_paddings)
+
+        padded_input_ids = np.zeros(padded_bs * D, dtype=np.int32)
+        padded_input_ids[: bs * D] = safe_input_ids
+        padded_positions = np.zeros(padded_bs * D, dtype=np.int32)
+        padded_positions[: bs * D] = positions
+
+        padded_seq_lens = np.pad(
+            seq_lens_before_draft,
+            (0, padded_bs - bs),
+            constant_values=0,
+        )
+        padded_req_pool_indices = np.pad(
+            model_worker_batch.req_pool_indices[:bs],
+            (0, padded_bs - bs),
+            constant_values=-1,
+        )
+        padded_allocate_lens = np.pad(
+            allocate_lens,
+            (0, padded_bs - bs),
+            constant_values=0,
+        )
+        padded_custom_mask = np.zeros(
+            padded_bs * D * (context_len + D) + 1,
+            dtype=np.int32,
+        )
+        padded_custom_mask[: len(custom_mask_flat)] = custom_mask_flat
+
         # Set up model_worker_batch for target verify. We keep
         # ``model_worker_batch.seq_lens`` at the rewound value only for
         # the duration of ``get_eagle_forward_metadata`` + target
-        # forward, then restore it before returning.
-        model_worker_batch.input_ids = safe_input_ids
-        model_worker_batch.positions = positions
+        # forward, then restore the original unpadded array before
+        # returning.
+        model_worker_batch.input_ids = padded_input_ids
+        model_worker_batch.positions = padded_positions
         model_worker_batch.forward_mode = ForwardMode.TARGET_VERIFY
-        model_worker_batch.seq_lens[:bs] = seq_lens_before_draft
+        model_worker_batch.seq_lens = padded_seq_lens
+        model_worker_batch.req_pool_indices = padded_req_pool_indices
 
         # Create NgramVerifyInput as spec_info so get_eagle_forward_metadata
         # can access custom_mask and draft_token_num.
         model_worker_batch.spec_info = NgramVerifyInput(
-            custom_mask=jnp.asarray(custom_mask_flat, dtype=jnp.int32),
+            custom_mask=jnp.asarray(padded_custom_mask, dtype=jnp.int32),
             draft_token_num=D,
-            allocate_lens=allocate_lens,
+            allocate_lens=padded_allocate_lens,
         )
 
         # Build cache_loc for the verify forward
@@ -377,9 +437,13 @@ class NgramWorker:
         for i in range(bs):
             seq_len_with_draft = int(seq_lens_before_draft[i]) + D
             cache_loc_parts.append(token_indices[i, :seq_len_with_draft])
-        model_worker_batch.cache_loc = (
-            np.concatenate(cache_loc_parts) if cache_loc_parts else np.array([], dtype=np.int32)
+        cache_loc = np.concatenate(cache_loc_parts) if cache_loc_parts else np.array([], dtype=np.int32)
+        total_cache_loc_size = self.precompile_cache_loc_paddings[padding_bs_index]
+        assert total_cache_loc_size >= len(cache_loc), (
+            f"cache_loc bucket too small: {total_cache_loc_size=} < {len(cache_loc)=}"
         )
+        model_worker_batch.cache_loc = np.zeros(total_cache_loc_size, dtype=np.int32)
+        model_worker_batch.cache_loc[: len(cache_loc)] = cache_loc
 
         try:
             # --- Forward target model ---
@@ -393,10 +457,10 @@ class NgramWorker:
                 model_worker_batch, skip_sample=True, forward_metadata=forward_metadata
             )
         finally:
-            # Restore seq_lens so the scheduler's
+            # Restore the original unpadded seq_lens so the scheduler's
             # ``batch.seq_lens += accept_lens`` lands on the un-rewound
             # value. Must happen even if forward_batch_generation raises.
-            model_worker_batch.seq_lens[:bs] = seq_lens_original
+            model_worker_batch.seq_lens = seq_lens_original
 
         # --- Verify phase ---
         # Note: the verify kernel receives the ORIGINAL draft_tokens_np

--- a/python/sgl_jax/srt/speculative/ngram_worker.py
+++ b/python/sgl_jax/srt/speculative/ngram_worker.py
@@ -1,0 +1,573 @@
+"""N-gram speculative decoding worker for sglang-jax.
+
+Generates draft tokens by querying a trie-based n-gram cache built from
+previously decoded tokens.  No draft model is required -- the target model
+verifies the entire draft tree in a single forward pass.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.tree_util import register_pytree_node_class
+
+from sgl_jax.srt.kernels.speculative.verify_tree_greedy_kernel import verify_tree_greedy
+from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
+from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+from sgl_jax.srt.managers.tp_worker import ModelWorker
+from sgl_jax.srt.mem_cache.common import (
+    alloc_paged_token_slots_extend,
+    alloc_token_slots,
+)
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
+from sgl_jax.srt.speculative.ngram_cache import NgramCache
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+@register_pytree_node_class
+@dataclass
+class NgramVerifyInput:
+    """Lightweight spec_info for ngram verify, compatible with get_eagle_forward_metadata.
+
+    Registered as a JAX pytree so the wrapping ``ModelWorkerBatch`` can flow
+    through ``jax.jit`` (the target ``forward`` is jitted and inspects every
+    leaf of ``model_worker_batch``). ``custom_mask`` is the only jax.Array
+    leaf; ``draft_token_num`` is static (compile-time) metadata; and
+    ``allocate_lens`` is a host-side numpy array we keep out of the pytree
+    to avoid forcing host->device transfers on every call.
+    """
+
+    custom_mask: np.ndarray | jax.Array
+    draft_token_num: int
+    allocate_lens: np.ndarray | None = None
+
+    def tree_flatten(self):
+        children = (self.custom_mask,)
+        aux_data = {
+            "draft_token_num": self.draft_token_num,
+            "allocate_lens": self.allocate_lens,
+        }
+        return (children, aux_data)
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        return cls(
+            custom_mask=children[0],
+            draft_token_num=aux_data["draft_token_num"],
+            allocate_lens=aux_data["allocate_lens"],
+        )
+
+
+def _ensure_chain_mode(max_bfs_breadth: int) -> None:
+    """Assert that ngram speculative decoding is running in chain mode.
+
+    Branching-tree drafts require KV compaction support that the current
+    implementation does not provide, so only chain mode (``breadth == 1``)
+    is supported today.
+    """
+    if max_bfs_breadth != 1:
+        raise ValueError(
+            "ngram speculative decoding currently supports only chain mode "
+            "(--speculative-ngram-max-bfs-breadth=1). Branching-tree KV "
+            "compaction is not yet implemented; see sglang-jax issue #192."
+        )
+
+
+def _make_safe_input_ids(draft_tokens: np.ndarray) -> np.ndarray:
+    """Replace padding sentinels (``-1``) with ``0`` before embedding lookup.
+
+    JAX's ``.at[-1].get()`` wraps negative indices to the end of the
+    embedding table, which would silently give padding positions random
+    (last-row) embeddings. Substituting ``0`` ensures padding positions
+    produce harmless embeddings; the verify kernel still rejects them
+    because ``draft_tokens`` itself retains ``-1`` sentinels.
+    """
+    return np.where(draft_tokens == -1, 0, draft_tokens).astype(np.int32)
+
+
+def _build_custom_mask_flat(
+    seq_lens_before_draft: np.ndarray,
+    parent_idx_per_req: list[np.ndarray],
+    draft_token_num: int,
+) -> np.ndarray:
+    """Build the 1D flat ``custom_mask`` expected by ``ragged_paged_attention``.
+
+    The kernel consumes per-request blocks of size
+    ``q_len * kv_len = D * (seq_lens[i] + D)`` concatenated in request
+    order (see ``ragged_paged_attention.py`` where
+    ``cu_seq_mask_lens = cumsum(kv_lens * q_lens)``). Each block is
+    row-major with query rows = draft token index and columns = KV
+    positions.
+    """
+    bs = len(parent_idx_per_req)
+    if bs == 0:
+        return np.zeros(0, dtype=np.int32)
+
+    per_req_mask_blocks: list[np.ndarray] = []
+    for i in range(bs):
+        sl = int(seq_lens_before_draft[i])
+        parent_idx = parent_idx_per_req[i]
+        block = np.zeros((draft_token_num, sl + draft_token_num), dtype=np.int32)
+        for j in range(draft_token_num):
+            # Attend to every prefix KV position for this request.
+            if sl > 0:
+                block[j, :sl] = 1
+            # Self-attention on this draft token.
+            block[j, sl + j] = 1
+            # Walk up the tree ancestors with an iteration bound so that
+            # any pathological ``parent_idx`` (e.g. a self-loop injected
+            # by a degenerate draft) cannot hang the worker.
+            p = int(parent_idx[j])
+            iterations = 0
+            while p >= 0 and iterations < draft_token_num:
+                block[j, sl + p] = 1
+                p = int(parent_idx[p])
+                iterations += 1
+        per_req_mask_blocks.append(block.reshape(-1))
+
+    return np.concatenate(per_req_mask_blocks)
+
+
+class NgramWorker:
+    """Speculative decoding worker that uses n-gram lookup instead of a draft model."""
+
+    def __init__(self, server_args: ServerArgs, target_worker: ModelWorker):
+        self.server_args = server_args
+        self.target_worker = target_worker
+        self.mesh = target_worker.mesh
+        self.model_config = target_worker.model_config
+        self.page_size = server_args.page_size
+
+        self.draft_token_num: int = server_args.speculative_num_draft_tokens
+        self.speculative_num_draft_tokens: int = server_args.speculative_num_draft_tokens
+        self.max_trie_depth: int = server_args.speculative_ngram_max_trie_depth
+        self.max_bfs_breadth: int = server_args.speculative_ngram_max_bfs_breadth
+        self.speculative_num_steps = server_args.speculative_num_steps
+
+        _ensure_chain_mode(self.max_bfs_breadth)
+
+        self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
+
+        (
+            self.precompile_token_paddings,
+            self.precompile_bs_paddings,
+            self.precompile_cache_loc_paddings,
+        ) = target_worker.get_precompile_paddings()
+
+        # Per-request ngram caches keyed by request id
+        self._caches: dict[str, NgramCache] = {}
+        # Tracks how many tokens of each request have already been inserted
+        # into the trie, so that incremental updates skip already-inserted
+        # n-grams (prevents BUG E count inflation).
+        self._last_inserted_len: dict[str, int] = {}
+
+    def _get_or_create_cache(self, req_id: str) -> NgramCache:
+        if req_id not in self._caches:
+            self._caches[req_id] = NgramCache(
+                max_trie_depth=self.max_trie_depth,
+            )
+        return self._caches[req_id]
+
+    def _evict_finished_requests(self, active_req_ids: set[str]) -> None:
+        stale = [rid for rid in self._caches if rid not in active_req_ids]
+        for rid in stale:
+            del self._caches[rid]
+            self._last_inserted_len.pop(rid, None)
+        # Defensive cleanup: drop any tracker entries that lost their cache.
+        stale_trackers = [rid for rid in self._last_inserted_len if rid not in self._caches]
+        for rid in stale_trackers:
+            self._last_inserted_len.pop(rid, None)
+
+    def forward_batch_speculative_generation(
+        self,
+        model_worker_batch: ModelWorkerBatch,
+    ) -> GenerationBatchResult:
+        """Run one round of ngram speculative decoding.
+
+        For extend (prefill): run the target model and pre-populate ngram caches.
+        For decode: draft via ngram, verify with target model.
+        """
+        reqs = getattr(model_worker_batch, "reqs", None)
+        if reqs:
+            active_ids = {req.rid for req in reqs}
+            self._evict_finished_requests(active_ids)
+
+        if model_worker_batch.forward_mode.is_extend():
+            return self._forward_extend(model_worker_batch)
+        else:
+            return self._forward_decode(model_worker_batch)
+
+    def _forward_extend(self, model_worker_batch: ModelWorkerBatch) -> GenerationBatchResult:
+        """Handle prefill -- run the target model and pre-populate caches."""
+        if model_worker_batch.sampling_info.temperatures.ndim == 1:
+            model_worker_batch.sampling_info.temperatures = (
+                model_worker_batch.sampling_info.temperatures[:, None]
+            )
+        sampling_metadata = SamplingMetadata.from_model_worker_batch(
+            model_worker_batch,
+            len(model_worker_batch.seq_lens) - model_worker_batch.real_bs,
+            self.mesh,
+            vocab_size=self.model_config.vocab_size,
+        )
+        logits_output, next_token_ids, cache_miss_count = (
+            self.target_worker.forward_batch_generation(
+                model_worker_batch, sampling_metadata=sampling_metadata
+            )
+        )
+
+        # Pre-populate ngram caches from prefill tokens so the first
+        # decode step has useful draft candidates.
+        reqs = getattr(model_worker_batch, "reqs", None)
+        if reqs:
+            for req in reqs[: model_worker_batch.real_bs]:
+                cache = self._get_or_create_cache(req.rid)
+                prev_len = self._last_inserted_len.get(req.rid, 0)
+                if len(req.origin_input_ids) > prev_len:
+                    cache.insert_new_suffixes(req.origin_input_ids, prev_len)
+                    self._last_inserted_len[req.rid] = len(req.origin_input_ids)
+
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=next_token_ids,
+            next_draft_input=None,
+            allocate_lens=model_worker_batch.seq_lens[: model_worker_batch.real_bs],
+            bid=model_worker_batch.bid,
+            cache_miss_count=cache_miss_count,
+            extend_input_len_per_req=None,
+            extend_logprob_start_len_per_req=None,
+        )
+
+    def _forward_decode(self, model_worker_batch: ModelWorkerBatch) -> GenerationBatchResult:
+        """Draft via ngram, verify with target model, return accepted tokens."""
+        bs = model_worker_batch.real_bs
+        D = self.draft_token_num
+
+        # --- Draft phase (CPU, no model forward) ---
+        (
+            draft_tokens_np,
+            parent_idx_per_req,
+            retrive_index_np,
+            retrive_next_token_np,
+            retrive_next_sibling_np,
+        ) = self._prepare_draft_tokens_from_batch(model_worker_batch)
+
+        # BUG A fix: do NOT mutate ``batch.seq_lens`` in place.
+        # ``model_worker_batch.seq_lens`` shares memory with
+        # ``batch.seq_lens``; a persistent in-place decrement would drift
+        # the tracked sequence length behind ``req.seqlen`` by one every
+        # decode iteration because the scheduler will then do
+        # ``batch.seq_lens += accept_lens`` on the already-decremented
+        # value. Instead we use a local ``seq_lens_before_draft`` for all
+        # downstream math, temporarily decrement
+        # ``model_worker_batch.seq_lens`` only around the target forward
+        # (mirroring EAGLE's ``prepare_for_verify`` semantics), and
+        # restore the original value before returning so the scheduler's
+        # accept_lens addition lands on the un-rewound value.
+        seq_lens_original = model_worker_batch.seq_lens[:bs].copy()
+        seq_lens_before_draft = seq_lens_original - 1
+
+        # --- Allocate KV cache slots for draft tokens ---
+        allocate_lens = seq_lens_before_draft.copy()
+        new_allocate_lens = allocate_lens + D
+
+        if self.page_size == 1:
+            num_needed = int(np.sum(new_allocate_lens - allocate_lens))
+            out_cache_loc = alloc_token_slots(model_worker_batch.tree_cache, num_needed)
+        else:
+            from sgl_jax.srt.managers.schedule_batch import get_last_loc
+
+            last_loc = get_last_loc(
+                self.req_to_token_pool.req_to_token,
+                model_worker_batch.req_pool_indices[:bs],
+                allocate_lens,
+            )
+            num_needed = int(np.sum(new_allocate_lens - allocate_lens))
+            out_cache_loc = alloc_paged_token_slots_extend(
+                model_worker_batch.tree_cache,
+                allocate_lens,
+                new_allocate_lens,
+                last_loc,
+                num_needed,
+            )
+
+        from sgl_jax.srt.speculative.eagle_util import assign_req_to_token_pool
+
+        assign_req_to_token_pool(
+            model_worker_batch.req_pool_indices[:bs],
+            self.req_to_token_pool,
+            allocate_lens,
+            new_allocate_lens,
+            out_cache_loc,
+        )
+        model_worker_batch.out_cache_loc = out_cache_loc
+
+        # Build positions using tree depth (not linear index).
+        # For branching trees, sibling nodes at the same depth must get
+        # the same position so rotary embeddings are correct. We cap the
+        # walk at ``D`` iterations (BUG G safety) so that any pathological
+        # ``parent_idx`` cycle fails loud instead of hanging.
+        positions = np.zeros(bs * D, dtype=np.int32)
+        for i in range(bs):
+            parent_idx = parent_idx_per_req[i]  # shape (D,)
+            for j in range(D):
+                depth = 0
+                p = j
+                iterations = 0
+                while p >= 0 and parent_idx[p] >= 0 and iterations < D:
+                    depth += 1
+                    p = int(parent_idx[p])
+                    iterations += 1
+                assert iterations < D, (
+                    f"parent_idx cycle detected at request {i}, position {j}: "
+                    f"{parent_idx.tolist()}"
+                )
+                depth = max(depth, 0) if draft_tokens_np[i * D + j] != -1 else 0
+                positions[i * D + j] = int(seq_lens_before_draft[i]) + depth
+
+        # BUG B fix: build the attention ``custom_mask`` as a 1D flat int32
+        # array with per-request blocks of size ``D * (seq_lens[i] + D)``
+        # concatenated in request order. The kernel expects this layout
+        # (see ``ragged_paged_attention.py``:
+        # ``cu_seq_mask_lens = cumsum(kv_lens * q_lens)``) and then
+        # promotes it to (flatten_total_kv_len, head_dim) internally. A
+        # 2D ``(bs*D, total_kv)`` input would get expanded to 3D and
+        # mismatch the kernel's expected DMA shape.
+        custom_mask_flat = _build_custom_mask_flat(seq_lens_before_draft, parent_idx_per_req, D)
+
+        # BUG D fix: ``draft_tokens_np`` may contain ``-1`` padding
+        # sentinels which JAX's embedding ``.at[-1]`` interprets as
+        # negative (wrap-around) indices. Replace padding with ``0``
+        # before the model forward; ``draft_tokens_jax`` below still
+        # carries the ``-1`` for the verify kernel so that padding
+        # positions can never match.
+        safe_input_ids = _make_safe_input_ids(draft_tokens_np)
+
+        # Set up model_worker_batch for target verify. We keep
+        # ``model_worker_batch.seq_lens`` at the rewound value only for
+        # the duration of ``get_eagle_forward_metadata`` + target
+        # forward, then restore it before returning.
+        model_worker_batch.input_ids = safe_input_ids
+        model_worker_batch.positions = positions
+        model_worker_batch.forward_mode = ForwardMode.TARGET_VERIFY
+        model_worker_batch.seq_lens[:bs] = seq_lens_before_draft
+
+        # Create NgramVerifyInput as spec_info so get_eagle_forward_metadata
+        # can access custom_mask and draft_token_num.
+        model_worker_batch.spec_info = NgramVerifyInput(
+            custom_mask=jnp.asarray(custom_mask_flat, dtype=jnp.int32),
+            draft_token_num=D,
+            allocate_lens=allocate_lens,
+        )
+
+        # Build cache_loc for the verify forward
+        token_indices = self.req_to_token_pool.req_to_token[
+            model_worker_batch.req_pool_indices[:bs]
+        ]
+        cache_loc_parts = []
+        for i in range(bs):
+            seq_len_with_draft = int(seq_lens_before_draft[i]) + D
+            cache_loc_parts.append(token_indices[i, :seq_len_with_draft])
+        model_worker_batch.cache_loc = (
+            np.concatenate(cache_loc_parts) if cache_loc_parts else np.array([], dtype=np.int32)
+        )
+
+        try:
+            # --- Forward target model ---
+            forward_metadata = (
+                self.target_worker.model_runner.attn_backend.get_eagle_forward_metadata(
+                    model_worker_batch
+                )
+            )
+
+            logits_output, _, cache_miss_count = self.target_worker.forward_batch_generation(
+                model_worker_batch, skip_sample=True, forward_metadata=forward_metadata
+            )
+        finally:
+            # Restore seq_lens so the scheduler's
+            # ``batch.seq_lens += accept_lens`` lands on the un-rewound
+            # value. Must happen even if forward_batch_generation raises.
+            model_worker_batch.seq_lens[:bs] = seq_lens_original
+
+        # --- Verify phase ---
+        # Note: the verify kernel receives the ORIGINAL draft_tokens_np
+        # (with ``-1`` padding intact) so that padding positions can
+        # never match target predictions; the model forward used the
+        # safe version for embedding lookup.
+        draft_tokens_jax = jnp.asarray(draft_tokens_np, dtype=jnp.int32)
+        retrive_index_jax = jnp.asarray(retrive_index_np, dtype=jnp.int32)
+        retrive_next_token_jax = jnp.asarray(retrive_next_token_np, dtype=jnp.int32)
+        retrive_next_sibling_jax = jnp.asarray(retrive_next_sibling_np, dtype=jnp.int32)
+
+        try:
+            ctx = jax.sharding.use_mesh(self.mesh)
+        except AttributeError:
+            try:
+                ctx = jax.set_mesh(self.mesh)
+            except AttributeError:
+                ctx = self.mesh
+
+        with ctx:
+            accept_index, accept_length, predict = verify_tree_greedy(
+                speculative_num_steps=D,
+                num_draft_tokens=D,
+                draft_tokens=draft_tokens_jax,
+                retrive_index=retrive_index_jax,
+                retrive_next_token=retrive_next_token_jax,
+                retrive_next_sibling=retrive_next_sibling_jax,
+                next_token_logits=logits_output.next_token_logits,
+            )
+
+        accept_length_np = np.asarray(jax.device_get(accept_length))
+        predict_np = np.asarray(jax.device_get(predict))
+        accept_index_np = np.asarray(jax.device_get(accept_index))
+
+        # accept_length from kernel is 0-indexed (0 means 1 accepted token)
+        accept_length_final = accept_length_np[:bs] + 1
+
+        # Build next_token_ids in the stride format expected by
+        # _resolve_spec_decode_token_ids: flat array of length bs*D.
+        next_token_ids_flat = np.zeros(bs * D, dtype=np.int32)
+        for i in range(bs):
+            acc_len = int(accept_length_final[i])
+            row = accept_index_np[i]
+            for j in range(min(acc_len, len(row))):
+                idx = int(row[j])
+                if 0 <= idx < len(predict_np):
+                    next_token_ids_flat[i * D + j] = int(predict_np[idx])
+
+        # --- Free unaccepted KV slots for ALL requests (not just finished) ---
+        # BUG F fix: in addition to freeing the KV cache slots, zero out
+        # the corresponding ``req_to_token`` entries so that a subsequent
+        # lookup can never see the stale slot id.
+        for i in range(bs):
+            used = int(accept_length_final[i])
+            if used < D:
+                start = int(seq_lens_before_draft[i]) + used
+                end = int(seq_lens_before_draft[i]) + D
+                req_idx = model_worker_batch.req_pool_indices[i]
+                kv_indices = self.req_to_token_pool.req_to_token[req_idx, start:end]
+                kv_indices = kv_indices[kv_indices != 0]
+                if len(kv_indices) > 0:
+                    self.token_to_kv_pool_allocator.free(kv_indices)
+                # Clear stale entries so subsequent lookups can't re-use them.
+                self.req_to_token_pool.req_to_token[req_idx, start:end] = 0
+
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=next_token_ids_flat,
+            next_draft_input=None,
+            accept_lens=accept_length_final,
+            allocate_lens=allocate_lens,
+            bid=model_worker_batch.bid,
+            cache_miss_count=cache_miss_count,
+            extend_input_len_per_req=None,
+            extend_logprob_start_len_per_req=None,
+        )
+
+    def _prepare_draft_tokens_from_batch(
+        self, model_worker_batch: ModelWorkerBatch
+    ) -> tuple[np.ndarray, list[np.ndarray], np.ndarray, np.ndarray, np.ndarray]:
+        """Generate draft tokens using the ngram cache.
+
+        Position 0 (D0) is always the **verified_id** -- the last token the
+        model actually produced.  This matches EAGLE's convention and ensures
+        D0's KV is always correct.  Positions 1..D-1 are filled with ngram
+        predictions from the trie cache.
+
+        Returns:
+            draft_tokens_np: Flat (bs*D,) array of draft token ids.
+            parent_idx_per_req: List of (D,) arrays with parent indices per request.
+            retrive_index_np: (bs, D) array of retrival indices.
+            retrive_next_token_np: (bs, D) array of first-child indices.
+            retrive_next_sibling_np: (bs, D) array of next-sibling indices.
+        """
+        bs = model_worker_batch.real_bs
+        D = self.draft_token_num
+
+        all_tokens = np.full(bs * D, -1, dtype=np.int32)
+        all_retrive_index = np.zeros((bs, D), dtype=np.int32)
+        all_retrive_next_token = np.full((bs, D), -1, dtype=np.int32)
+        all_retrive_next_sibling = np.full((bs, D), -1, dtype=np.int32)
+        parent_idx_per_req: list[np.ndarray] = []
+
+        reqs = getattr(model_worker_batch, "reqs", None)
+        if reqs is None:
+            logger.warning("NgramWorker: no request info available, generating empty drafts")
+            parent_idx_per_req = [np.full(D, -1, dtype=np.int32) for _ in range(bs)]
+            return (
+                all_tokens,
+                parent_idx_per_req,
+                all_retrive_index,
+                all_retrive_next_token,
+                all_retrive_next_sibling,
+            )
+
+        ngram_slots = D - 1  # slots available for ngram predictions (D1..D-1)
+
+        for i, req in enumerate(reqs[:bs]):
+            cache = self._get_or_create_cache(req.rid)
+
+            all_toks = req.origin_input_ids + req.output_ids
+            prev_len = self._last_inserted_len.get(req.rid, 0)
+            if len(all_toks) > prev_len:
+                cache.insert_new_suffixes(all_toks, prev_len)
+                self._last_inserted_len[req.rid] = len(all_toks)
+
+            # D0 = verified_id (last token the model actually produced)
+            verified_id = int(all_toks[-1]) if len(all_toks) > 0 else 0
+            base = i * D
+            all_tokens[base] = verified_id
+
+            # D1..D-1 = ngram predictions from the trie
+            parent_idx_local = np.full(D, -1, dtype=np.int32)
+            if ngram_slots > 0:
+                suffix = all_toks[-self.max_trie_depth :]
+                draft = cache.query_bfs(suffix, ngram_slots, self.max_bfs_breadth)
+
+                all_tokens[base + 1 : base + D] = draft.tokens
+
+                # Shift draft tree indices by +1 to account for D0
+                for j in range(ngram_slots):
+                    if draft.retrive_next_token[j] >= 0:
+                        all_retrive_next_token[i, j + 1] = draft.retrive_next_token[j] + 1
+                    if draft.retrive_next_sibling[j] >= 0:
+                        all_retrive_next_sibling[i, j + 1] = draft.retrive_next_sibling[j] + 1
+
+                # D0 -> D1 link (verified_id's first child is the first ngram token)
+                all_retrive_next_token[i, 0] = 1
+
+                # Build parent_idx: D0 is root (-1), D1..D-1 have parents shifted by +1
+                parent_idx_local[0] = -1  # D0 is root
+                for j in range(ngram_slots):
+                    if draft.parent_idx[j] >= 0:
+                        parent_idx_local[j + 1] = draft.parent_idx[j] + 1
+                    else:
+                        parent_idx_local[j + 1] = 0  # root children -> child of D0
+
+            all_retrive_index[i] = np.arange(D, dtype=np.int32) + base
+            parent_idx_per_req.append(parent_idx_local)
+
+        return (
+            all_tokens,
+            parent_idx_per_req,
+            all_retrive_index,
+            all_retrive_next_token,
+            all_retrive_next_sibling,
+        )
+
+    # ------------------------------------------------------------------
+    # Precompile (placeholder for TPU JIT warmup)
+    # ------------------------------------------------------------------
+
+    def run_spec_decode_precompile(self):
+        logger.info("[NGRAM] Ngram speculative decoding does not require precompilation.")

--- a/python/sgl_jax/srt/speculative/spec_info.py
+++ b/python/sgl_jax/srt/speculative/spec_info.py
@@ -13,6 +13,7 @@ class SpeculativeAlgorithm(IntEnum):
     EAGLE = auto()
     EAGLE3 = auto()
     STANDALONE = auto()
+    NGRAM = auto()
 
     def is_none(self):
         return self == SpeculativeAlgorithm.NONE
@@ -26,12 +27,16 @@ class SpeculativeAlgorithm(IntEnum):
     def is_standalone(self):
         return self == SpeculativeAlgorithm.STANDALONE
 
+    def is_ngram(self):
+        return self == SpeculativeAlgorithm.NGRAM
+
     @staticmethod
     def from_string(name: str):
         name_map = {
             "EAGLE": SpeculativeAlgorithm.EAGLE,
             "EAGLE3": SpeculativeAlgorithm.EAGLE3,
             "STANDALONE": SpeculativeAlgorithm.STANDALONE,
+            "NGRAM": SpeculativeAlgorithm.NGRAM,
             None: SpeculativeAlgorithm.NONE,
         }
         if name is not None:

--- a/python/sgl_jax/test/speculative/test_ngram_cache.py
+++ b/python/sgl_jax/test/speculative/test_ngram_cache.py
@@ -211,6 +211,49 @@ class TestSpecInfoIntegration(unittest.TestCase):
         self.assertEqual(SpeculativeAlgorithm.from_string("ngram"), SpeculativeAlgorithm.NGRAM)
         self.assertEqual(SpeculativeAlgorithm.from_string("Ngram"), SpeculativeAlgorithm.NGRAM)
 
+    @unittest.skipUnless(HAS_JAX, "jax is not installed")
+    def test_ngram_verify_input_keeps_allocate_lens_out_of_aux_data(self):
+        import jax.numpy as jnp
+
+        from sgl_jax.srt.speculative.ngram_worker import NgramVerifyInput
+
+        spec = NgramVerifyInput(
+            custom_mask=jnp.array([1, 0, 1], dtype=jnp.int32),
+            draft_token_num=4,
+            allocate_lens=np.array([3, 4], dtype=np.int32),
+        )
+        children, aux_data = spec.tree_flatten()
+
+        self.assertEqual(set(aux_data.keys()), {"draft_token_num"})
+        self.assertEqual(aux_data["draft_token_num"], 4)
+        self.assertEqual(len(children), 2)
+        np.testing.assert_array_equal(np.asarray(children[1]), np.array([3, 4], dtype=np.int32))
+
+    @unittest.skipUnless(HAS_JAX, "jax is not installed")
+    def test_ngram_verify_input_bs2_metadata_can_reuse_jit(self):
+        import jax
+        import jax.numpy as jnp
+
+        from sgl_jax.srt.speculative.ngram_worker import NgramVerifyInput
+
+        @jax.jit
+        def f(spec):
+            return spec.custom_mask + 1
+
+        spec_a = NgramVerifyInput(
+            custom_mask=jnp.array([1, 2], dtype=jnp.int32),
+            draft_token_num=4,
+            allocate_lens=np.array([3, 4], dtype=np.int32),
+        )
+        spec_b = NgramVerifyInput(
+            custom_mask=jnp.array([1, 2], dtype=jnp.int32),
+            draft_token_num=4,
+            allocate_lens=np.array([5, 6], dtype=np.int32),
+        )
+
+        np.testing.assert_array_equal(np.asarray(f(spec_a)), np.array([2, 3], dtype=np.int32))
+        np.testing.assert_array_equal(np.asarray(f(spec_b)), np.array([2, 3], dtype=np.int32))
+
 
 def _count_node(cache: NgramCache, path: list[int]) -> int:
     """Walk the trie following ``path`` and return the terminal node's count.

--- a/python/sgl_jax/test/speculative/test_ngram_cache.py
+++ b/python/sgl_jax/test/speculative/test_ngram_cache.py
@@ -1,0 +1,489 @@
+"""Tests for the N-gram trie cache used in speculative decoding."""
+
+import unittest
+
+import numpy as np
+
+from sgl_jax.srt.speculative.ngram_cache import NgramCache
+
+# JAX is only required by ngram_worker.py. Make its import optional so that
+# the rest of the tests in this module still run on CPU-only machines.
+try:
+    import jax  # noqa: F401
+
+    HAS_JAX = True
+except ImportError:  # pragma: no cover - exercised on CPU-only machines
+    HAS_JAX = False
+
+
+class TestTrieInsertAndQuery(unittest.TestCase):
+    def test_insert_and_exact_match(self):
+        cache = NgramCache(max_trie_depth=4)
+        tokens = [10, 20, 30, 40, 50]
+        cache.insert(tokens)
+
+        draft = cache.query_bfs([30, 40], draft_token_num=4, max_bfs_breadth=3)
+        self.assertEqual(draft.tokens[0], 50)
+
+    def test_bfs_breadth_limit(self):
+        cache = NgramCache(max_trie_depth=4)
+        for suffix_tok in [100, 200, 300, 400, 500]:
+            cache.insert([10, 20, suffix_tok])
+
+        draft = cache.query_bfs([10, 20], draft_token_num=4, max_bfs_breadth=3)
+        unique_root_children = set(draft.tokens[:3].tolist())
+        self.assertLessEqual(len(unique_root_children), 3)
+
+    def test_frequency_ranking(self):
+        cache = NgramCache(max_trie_depth=4)
+        for _ in range(5):
+            cache.insert([10, 20, 100])
+        for _ in range(2):
+            cache.insert([10, 20, 200])
+        cache.insert([10, 20, 300])
+
+        draft = cache.query_bfs([10, 20], draft_token_num=4, max_bfs_breadth=3)
+        self.assertEqual(draft.tokens[0], 100)
+
+    def test_empty_cache_returns_valid_structure(self):
+        cache = NgramCache(max_trie_depth=4)
+        draft = cache.query_bfs([10, 20], draft_token_num=4, max_bfs_breadth=3)
+        self.assertEqual(draft.tokens.shape, (4,))
+        self.assertEqual(draft.retrive_index.shape, (4,))
+        self.assertEqual(draft.retrive_next_token.shape, (4,))
+        self.assertEqual(draft.retrive_next_sibling.shape, (4,))
+        self.assertEqual(draft.mask.shape, (4, 4))
+        self.assertEqual(draft.parent_idx.shape, (4,))
+        # Empty draft uses -1 sentinel tokens
+        self.assertTrue(np.all(draft.tokens == -1))
+
+    def test_deep_chain(self):
+        cache = NgramCache(max_trie_depth=8)
+        tokens = list(range(1, 9))
+        cache.insert(tokens)
+
+        draft = cache.query_bfs([1, 2, 3], draft_token_num=4, max_bfs_breadth=1)
+        self.assertEqual(draft.tokens[0], 4)
+        self.assertEqual(draft.tokens[1], 5)
+        self.assertEqual(draft.tokens[2], 6)
+        self.assertEqual(draft.tokens[3], 7)
+
+    def test_tree_structure_chain(self):
+        cache = NgramCache(max_trie_depth=8)
+        cache.insert([1, 2, 3, 4, 5])
+
+        draft = cache.query_bfs([1, 2], draft_token_num=3, max_bfs_breadth=1)
+        self.assertEqual(draft.tokens[0], 3)
+        self.assertEqual(draft.tokens[1], 4)
+        self.assertEqual(draft.tokens[2], 5)
+
+        self.assertEqual(draft.retrive_next_token[0], 1)
+        self.assertEqual(draft.retrive_next_token[1], 2)
+        self.assertEqual(draft.retrive_next_token[2], -1)
+
+        self.assertEqual(draft.retrive_next_sibling[0], -1)
+        self.assertEqual(draft.retrive_next_sibling[1], -1)
+        self.assertEqual(draft.retrive_next_sibling[2], -1)
+
+        # Chain: parent_idx should be -1 -> 0 -> 1
+        self.assertEqual(draft.parent_idx[0], -1)
+        self.assertEqual(draft.parent_idx[1], 0)
+        self.assertEqual(draft.parent_idx[2], 1)
+
+    def test_tree_structure_branching(self):
+        cache = NgramCache(max_trie_depth=4)
+        cache.insert([1, 2, 10, 11])
+        cache.insert([1, 2, 20, 21])
+
+        draft = cache.query_bfs([1, 2], draft_token_num=4, max_bfs_breadth=3)
+        tokens = draft.tokens.tolist()
+        root_children = set(tokens[:2])
+        self.assertTrue(10 in root_children or 20 in root_children)
+        self.assertTrue(draft.retrive_next_sibling[0] == 1 or draft.retrive_next_sibling[1] == 0)
+
+    def test_mask_ancestry(self):
+        cache = NgramCache(max_trie_depth=8)
+        cache.insert([1, 2, 3, 4, 5])
+
+        draft = cache.query_bfs([1, 2], draft_token_num=3, max_bfs_breadth=1)
+        self.assertTrue(draft.mask[0, 0])
+        self.assertTrue(draft.mask[1, 0])
+        self.assertTrue(draft.mask[1, 1])
+        self.assertTrue(draft.mask[2, 0])
+        self.assertTrue(draft.mask[2, 1])
+        self.assertTrue(draft.mask[2, 2])
+
+    def test_reset(self):
+        cache = NgramCache(max_trie_depth=4)
+        cache.insert([1, 2, 3, 4])
+        cache.reset()
+        draft = cache.query_bfs([1, 2], draft_token_num=4, max_bfs_breadth=3)
+        self.assertTrue(np.all(draft.retrive_next_token == -1))
+
+    def test_padding_uses_sentinel_tokens(self):
+        """Padded positions must use -1 (unmatchable) not copies of real tokens."""
+        cache = NgramCache(max_trie_depth=4)
+        cache.insert([10, 20, 30])
+
+        draft = cache.query_bfs([10, 20], draft_token_num=4, max_bfs_breadth=3)
+        self.assertEqual(draft.tokens[0], 30)
+        self.assertTrue(np.all(draft.tokens[1:] == -1))
+
+    def test_single_suffix_match(self):
+        """Even a single-token suffix should produce candidates."""
+        cache = NgramCache(max_trie_depth=4)
+        cache.insert([5, 10, 15])
+        cache.insert([5, 10, 20])
+
+        draft = cache.query_bfs([10], draft_token_num=4, max_bfs_breadth=3)
+        real_tokens = set(draft.tokens[:2].tolist())
+        self.assertIn(15, real_tokens)
+        self.assertIn(20, real_tokens)
+
+    def test_no_match_returns_root_children(self):
+        """When suffix doesn't match, fall back to root's children."""
+        cache = NgramCache(max_trie_depth=4)
+        cache.insert([100, 200])
+        cache.insert([100, 300])
+
+        draft = cache.query_bfs([999], draft_token_num=4, max_bfs_breadth=3)
+        self.assertEqual(draft.tokens[0], 100)
+
+    def test_max_nodes_cap(self):
+        """Trie should stop growing when max_nodes is reached."""
+        cache = NgramCache(max_trie_depth=4, max_nodes=5)
+        for i in range(100):
+            cache.insert([i, i + 1, i + 2, i + 3])
+        self.assertLessEqual(cache._node_count, 5)
+
+    def test_parent_idx_branching(self):
+        """Parent indices should correctly reflect the tree structure."""
+        cache = NgramCache(max_trie_depth=4)
+        cache.insert([1, 2, 10])
+        cache.insert([1, 2, 20])
+
+        draft = cache.query_bfs([1, 2], draft_token_num=4, max_bfs_breadth=3)
+        # Both root children should have parent_idx == -1
+        self.assertEqual(draft.parent_idx[0], -1)
+        self.assertEqual(draft.parent_idx[1], -1)
+
+    def test_empty_suffix(self):
+        """Empty suffix should return root's children."""
+        cache = NgramCache(max_trie_depth=4)
+        cache.insert([10, 20, 30])
+        draft = cache.query_bfs([], draft_token_num=4, max_bfs_breadth=3)
+        self.assertEqual(draft.tokens[0], 10)
+
+    def test_numpy_input(self):
+        """insert/query should handle numpy arrays correctly."""
+        cache = NgramCache(max_trie_depth=4)
+        cache.insert(np.array([10, 20, 30, 40], dtype=np.int32))
+        draft = cache.query_bfs(
+            np.array([20, 30], dtype=np.int64), draft_token_num=2, max_bfs_breadth=3
+        )
+        self.assertEqual(draft.tokens[0], 40)
+
+    def test_draft_token_num_one(self):
+        """Edge case: requesting exactly one draft token."""
+        cache = NgramCache(max_trie_depth=4)
+        cache.insert([1, 2, 3])
+        draft = cache.query_bfs([1, 2], draft_token_num=1, max_bfs_breadth=3)
+        self.assertEqual(draft.tokens.shape, (1,))
+        self.assertEqual(draft.tokens[0], 3)
+        self.assertEqual(draft.mask.shape, (1, 1))
+
+
+class TestSpecInfoIntegration(unittest.TestCase):
+    @unittest.skipUnless(HAS_JAX, "jax is not installed")
+    def test_ngram_algorithm_enum(self):
+        from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        algo = SpeculativeAlgorithm.from_string("NGRAM")
+        self.assertEqual(algo, SpeculativeAlgorithm.NGRAM)
+        self.assertTrue(algo.is_ngram())
+        self.assertFalse(algo.is_eagle())
+        self.assertFalse(algo.is_none())
+
+    @unittest.skipUnless(HAS_JAX, "jax is not installed")
+    def test_ngram_from_string_case_insensitive(self):
+        from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        self.assertEqual(SpeculativeAlgorithm.from_string("ngram"), SpeculativeAlgorithm.NGRAM)
+        self.assertEqual(SpeculativeAlgorithm.from_string("Ngram"), SpeculativeAlgorithm.NGRAM)
+
+
+def _count_node(cache: NgramCache, path: list[int]) -> int:
+    """Walk the trie following ``path`` and return the terminal node's count.
+
+    Returns ``0`` when the path is not present.
+    """
+    node = cache.root
+    for tok in path:
+        if tok not in node.children:
+            return 0
+        node = node.children[tok]
+    return node.count
+
+
+class TestInsertNewSuffixes(unittest.TestCase):
+    """Tests for BUG E (trie count inflation) fix."""
+
+    def test_insert_new_suffixes_no_double_count(self):
+        """Incremental inserts must not re-increment counts for old n-grams."""
+        cache = NgramCache(max_trie_depth=4)
+
+        tokens_first = [1, 2, 3, 4, 5]
+        cache.insert_new_suffixes(tokens_first, prev_len=0)
+
+        # Record counts for every n-gram ending at positions 0..4.
+        baseline: dict[tuple[int, ...], int] = {}
+        for p in range(len(tokens_first)):
+            for start in range(max(0, p - cache.max_trie_depth + 1), p + 1):
+                ngram = tuple(tokens_first[start : p + 1])
+                baseline[ngram] = _count_node(cache, list(ngram))
+
+        # Now append a new token and insert only the new tail.
+        tokens_extended = tokens_first + [6]
+        cache.insert_new_suffixes(tokens_extended, prev_len=len(tokens_first))
+
+        # All previously-seen n-grams must have their counts unchanged.
+        for ngram, expected in baseline.items():
+            self.assertEqual(
+                _count_node(cache, list(ngram)),
+                expected,
+                f"count for {ngram} changed: expected {expected} " f"after incremental insert",
+            )
+
+        # n-grams ending at the new position 5 must have been inserted
+        # (count >= 1).
+        for start in range(max(0, 5 - cache.max_trie_depth + 1), 6):
+            ngram = tuple(tokens_extended[start:6])
+            self.assertGreaterEqual(_count_node(cache, list(ngram)), 1)
+
+    def test_insert_is_equivalent_to_insert_new_suffixes_prev0(self):
+        """``insert(tokens)`` must equal ``insert_new_suffixes(tokens, 0)``."""
+        cache_a = NgramCache(max_trie_depth=4)
+        cache_b = NgramCache(max_trie_depth=4)
+        tokens = [10, 20, 30, 20, 30, 40, 30, 40, 50]
+        cache_a.insert(tokens)
+        cache_b.insert_new_suffixes(tokens, prev_len=0)
+
+        self.assertEqual(cache_a._node_count, cache_b._node_count)
+        # Walk both tries and compare counts at matching positions.
+        for start in range(len(tokens)):
+            for end in range(start + 1, min(len(tokens), start + 4) + 1):
+                ngram = list(tokens[start:end])
+                self.assertEqual(_count_node(cache_a, ngram), _count_node(cache_b, ngram))
+
+    def test_repeated_incremental_insert_no_inflation(self):
+        """Incremental inserts across many steps should not grow counts
+        for old n-grams."""
+        cache = NgramCache(max_trie_depth=3)
+        tokens = [7, 8, 9, 7, 8, 9, 7, 8, 9, 7, 8, 9]
+
+        # First insertion of just the first 3 tokens.
+        cache.insert_new_suffixes(tokens[:3], prev_len=0)
+        first_count_78 = _count_node(cache, [7, 8])
+        first_count_789 = _count_node(cache, [7, 8, 9])
+
+        # Now grow the sequence one token at a time; the n-gram [7, 8] ending
+        # at position 1 must not get re-incremented once we move past it.
+        for new_len in range(4, len(tokens) + 1):
+            cache.insert_new_suffixes(tokens[:new_len], prev_len=new_len - 1)
+
+        # [7, 8] was inserted 4 times across position-endings (1, 4, 7, 10)
+        # over the 12-token sequence.
+        self.assertEqual(_count_node(cache, [7, 8]), 4)
+        # Count for the 3-gram [7, 8, 9] should match 4 as well (ending at
+        # positions 2, 5, 8, 11).
+        self.assertEqual(_count_node(cache, [7, 8, 9]), 4)
+        # Sanity: the initial counts after the 3-token insert were only 1.
+        self.assertEqual(first_count_78, 1)
+        self.assertEqual(first_count_789, 1)
+
+
+class TestBreadthValidation(unittest.TestCase):
+    """Tests for BUG C (``max_bfs_breadth > 1`` silently accepted) fix."""
+
+    @unittest.skipUnless(HAS_JAX, "jax is not installed")
+    def test_breadth_equal_one_accepted(self):
+        """``max_bfs_breadth == 1`` is the only supported chain-mode value."""
+        from sgl_jax.srt.speculative.ngram_worker import _ensure_chain_mode
+
+        # Must not raise.
+        _ensure_chain_mode(1)
+
+    @unittest.skipUnless(HAS_JAX, "jax is not installed")
+    def test_breadth_greater_than_one_raises(self):
+        """Constructing an NgramWorker with branching breadth must fail."""
+        from sgl_jax.srt.speculative.ngram_worker import _ensure_chain_mode
+
+        for bad_value in (0, 2, 3, 8):
+            with self.assertRaises(ValueError) as cm:
+                _ensure_chain_mode(bad_value)
+            self.assertIn("chain mode", str(cm.exception))
+
+
+class TestBuildEmptyDraftNoCycle(unittest.TestCase):
+    """Tests for BUG G (infinite position walk safety) related fixes."""
+
+    def test_build_empty_draft_parent_idx_all_minus_one(self):
+        """``_build_empty_draft`` must never produce a ``parent_idx`` cycle."""
+        cache = NgramCache(max_trie_depth=4)
+        draft = cache._build_empty_draft(4)
+        self.assertEqual(draft.parent_idx.tolist(), [-1, -1, -1, -1])
+
+    def test_query_bfs_empty_trie_produces_no_cycle(self):
+        """Querying an empty trie must return an empty draft with no cycles."""
+        cache = NgramCache(max_trie_depth=4)
+        draft = cache.query_bfs([10, 20], draft_token_num=4, max_bfs_breadth=3)
+        self.assertEqual(draft.parent_idx.tolist(), [-1, -1, -1, -1])
+        # Walking the ancestry of every node must terminate in <= D hops.
+        for i in range(4):
+            p = int(draft.parent_idx[i])
+            hops = 0
+            while p >= 0 and hops < 4:
+                p = int(draft.parent_idx[p])
+                hops += 1
+            self.assertLess(hops, 4, "ancestry walk exceeded draft_token_num hops")
+
+    def test_query_bfs_single_real_node_no_self_loop(self):
+        """If only one real node is produced, padded parents must not self-loop."""
+        cache = NgramCache(max_trie_depth=4)
+        # Insert exactly one 1-gram.
+        cache.insert([42])
+        draft = cache.query_bfs([], draft_token_num=4, max_bfs_breadth=3)
+        # First slot is the real node (root-child), rest are padding.
+        self.assertEqual(int(draft.tokens[0]), 42)
+        self.assertEqual(int(draft.parent_idx[0]), -1)
+        for i in range(1, 4):
+            # Padding must attach to a real node index (0), never to itself.
+            self.assertEqual(int(draft.tokens[i]), -1)
+            self.assertEqual(int(draft.parent_idx[i]), 0)
+            self.assertNotEqual(int(draft.parent_idx[i]), i)
+
+
+class TestPaddingSafeInputIds(unittest.TestCase):
+    """Tests for BUG D (padding ``-1`` fed to embedding layer) fix."""
+
+    @unittest.skipUnless(HAS_JAX, "jax is not installed")
+    def test_safe_input_ids_replaces_negatives(self):
+        """``-1`` sentinels in the draft tokens must be replaced with ``0``."""
+        from sgl_jax.srt.speculative.ngram_worker import _make_safe_input_ids
+
+        draft = np.array([5, -1, 7, -1, 9], dtype=np.int32)
+        safe = _make_safe_input_ids(draft)
+
+        self.assertEqual(safe.dtype, np.int32)
+        self.assertFalse(np.any(safe == -1))
+        # Values that were not -1 must be unchanged.
+        self.assertEqual(int(safe[0]), 5)
+        self.assertEqual(int(safe[2]), 7)
+        self.assertEqual(int(safe[4]), 9)
+        # The replacement value must be 0 (harmless index into the
+        # embedding table).
+        self.assertEqual(int(safe[1]), 0)
+        self.assertEqual(int(safe[3]), 0)
+
+    @unittest.skipUnless(HAS_JAX, "jax is not installed")
+    def test_safe_input_ids_no_negative_tokens_unchanged(self):
+        """When no ``-1`` is present, the array must be unchanged."""
+        from sgl_jax.srt.speculative.ngram_worker import _make_safe_input_ids
+
+        draft = np.array([1, 2, 3, 4], dtype=np.int32)
+        safe = _make_safe_input_ids(draft)
+        self.assertTrue(np.array_equal(draft, safe))
+
+
+class TestCustomMaskLayout(unittest.TestCase):
+    """Tests for BUG B (``custom_mask`` wrong shape and layout) fix."""
+
+    @unittest.skipUnless(HAS_JAX, "jax is not installed")
+    def test_custom_mask_layout_single_request_chain(self):
+        """Chain-mode single request: verify the flat mask block layout."""
+        from sgl_jax.srt.speculative.ngram_worker import _build_custom_mask_flat
+
+        # Chain tree of depth 3: D0 -> D1 -> D2.
+        D = 3
+        parent_idx = np.array([-1, 0, 1], dtype=np.int32)
+        seq_lens_before_draft = np.array([5], dtype=np.int32)
+
+        mask = _build_custom_mask_flat(seq_lens_before_draft, [parent_idx], D)
+
+        # Block shape: D x (sl + D) = 3 x 8 = 24 entries.
+        expected_rows = [
+            # D0 attends to 5 prefix positions + itself at column 5 (+ no
+            # ancestors since its parent is -1).
+            [1, 1, 1, 1, 1, 1, 0, 0],
+            # D1 attends to all 5 prefix + itself at column 6 + ancestor D0
+            # at column 5.
+            [1, 1, 1, 1, 1, 1, 1, 0],
+            # D2 attends to all 5 prefix + itself at column 7 + ancestors
+            # D0, D1 at columns 5, 6.
+            [1, 1, 1, 1, 1, 1, 1, 1],
+        ]
+        expected = np.array(expected_rows, dtype=np.int32).reshape(-1)
+
+        self.assertEqual(mask.dtype, np.int32)
+        self.assertEqual(mask.shape, (D * (5 + D),))
+        self.assertTrue(
+            np.array_equal(mask, expected),
+            f"expected {expected.tolist()}, got {mask.tolist()}",
+        )
+
+    @unittest.skipUnless(HAS_JAX, "jax is not installed")
+    def test_custom_mask_layout_uneven_batch(self):
+        """Per-request blocks must respect each request's own seq_len."""
+        from sgl_jax.srt.speculative.ngram_worker import _build_custom_mask_flat
+
+        D = 2
+        # Two requests with different prefix lengths.
+        parent_idx_0 = np.array([-1, 0], dtype=np.int32)
+        parent_idx_1 = np.array([-1, 0], dtype=np.int32)
+        seq_lens_before_draft = np.array([3, 5], dtype=np.int32)
+
+        mask = _build_custom_mask_flat(seq_lens_before_draft, [parent_idx_0, parent_idx_1], D)
+
+        # Request 0: block size D * (3 + D) = 2 * 5 = 10
+        # Request 1: block size D * (5 + D) = 2 * 7 = 14
+        self.assertEqual(mask.shape, (10 + 14,))
+
+        block0 = mask[:10].reshape(D, 3 + D)
+        block1 = mask[10:].reshape(D, 5 + D)
+
+        # Request 0: D0 attends to [prefix 0..2, self at col 3].
+        self.assertTrue(np.array_equal(block0[0], np.array([1, 1, 1, 1, 0])))
+        # D1 attends to [prefix 0..2, ancestor D0 at col 3, self at col 4].
+        self.assertTrue(np.array_equal(block0[1], np.array([1, 1, 1, 1, 1])))
+        # Request 1 analogous with 5 prefix columns.
+        self.assertTrue(np.array_equal(block1[0], np.array([1, 1, 1, 1, 1, 1, 0])))
+        self.assertTrue(np.array_equal(block1[1], np.array([1, 1, 1, 1, 1, 1, 1])))
+
+    @unittest.skipUnless(HAS_JAX, "jax is not installed")
+    def test_custom_mask_layout_empty_batch(self):
+        """Empty batch must return an empty int32 array."""
+        from sgl_jax.srt.speculative.ngram_worker import _build_custom_mask_flat
+
+        mask = _build_custom_mask_flat(np.zeros(0, dtype=np.int32), [], 3)
+        self.assertEqual(mask.dtype, np.int32)
+        self.assertEqual(mask.shape, (0,))
+
+    @unittest.skipUnless(HAS_JAX, "jax is not installed")
+    def test_custom_mask_walk_cycle_is_bounded(self):
+        """A pathological ``parent_idx`` self-loop must not hang."""
+        from sgl_jax.srt.speculative.ngram_worker import _build_custom_mask_flat
+
+        D = 3
+        # Pathological: node 0 claims itself as parent (would infinite-loop
+        # without the iteration bound in _build_custom_mask_flat).
+        parent_idx = np.array([0, 0, 0], dtype=np.int32)
+        seq_lens_before_draft = np.array([2], dtype=np.int32)
+
+        mask = _build_custom_mask_flat(seq_lens_before_draft, [parent_idx], D)
+        # The function must return without hanging; we don't care about the
+        # exact mask values, just that the call terminates.
+        self.assertEqual(mask.shape, (D * (2 + D),))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

Partially addresses #192 ("More Speculative algorithms Support -- Call for Contribution"), specifically the ngram algorithms item.  

RFC / design issue: #927. 

This PR implements **Prompt Lookup Decoding (PLD)** -- a trie-based n-gram speculative decoding algorithm that requires **no draft model**. A per-request trie cache is built from previously decoded tokens; BFS queries produce a chain of draft candidates that the target model verifies in a single forward pass via the existing Pallas `verify_tree_greedy` kernel.

This is useful when:
- No draft model is available for the target model
- Memory is constrained (zero additional model memory)
- The generation contains repetitive patterns (e.g., structured output, code, translations)

**Scope:** This PR covers PLD/ngram only. Suffix Decoding and LookAhead Decoding from the same issue bullet are not included and would be separate follow-up PRs.

## Modifications

**New files (3):**
- `python/sgl_jax/srt/speculative/ngram_cache.py` -- Pure Python/NumPy trie-based n-gram cache. Inserts token sequences as n-gram suffixes, queries via BFS ranked by frequency, and produces draft token trees with `retrive_index`, `retrive_next_token`, `retrive_next_sibling` structures compatible with the existing Pallas verification kernel. Supports incremental insertion (`insert_new_suffixes`) to avoid count inflation across decode iterations.
- `python/sgl_jax/srt/speculative/ngram_worker.py` -- `NgramWorker` class that orchestrates draft/verify without a draft model. On decode: queries the trie, allocates KV cache slots, builds a 1D flat custom_mask matching ragged_paged_attention expected layout, runs the target model on the draft tree, and uses `verify_tree_greedy` to accept/reject tokens. `NgramVerifyInput` is registered as a JAX pytree for JIT compatibility. D0 follows the verified_id convention (last known-correct token at tree root).
- `python/sgl_jax/test/speculative/test_ngram_cache.py` -- 33 unit tests covering trie insertion, BFS querying, frequency ranking, breadth limiting, chain/branching tree structures, mask ancestry correctness, incremental insert (no double-counting), padding sentinel handling, custom_mask 1D layout with uneven batch sizes, cycle detection, and `SpeculativeAlgorithm` enum integration. 10 tests are gated on JAX availability.

**Modified files (5):**
- `python/sgl_jax/srt/speculative/spec_info.py` -- Added `NGRAM` to `SpeculativeAlgorithm` enum with `is_ngram()` method and `from_string("NGRAM")` support.
- `python/sgl_jax/srt/server_args.py` -- Added `--speculative-ngram-max-trie-depth` (default 8) and `--speculative-ngram-max-bfs-breadth` (default 1) CLI args, plus `NGRAM` to algorithm choices.
- `python/sgl_jax/srt/managers/scheduler.py` -- Instantiates `NgramWorker` when `speculative_algorithm=NGRAM`, handles ngram `accept_lens`/`allocate_lens` in result processing.
- `python/sgl_jax/srt/managers/schedule_batch.py` -- Guards `EagleDraftInput.ALLOC_LEN_PER_DECODE` access with `is_eagle()` check so ngram decode does not crash on None. Guards `spec_info.allocate_lens` access with None check. Added `reqs` field to `ModelWorkerBatch` so NgramWorker can access request token histories.
- `python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py` -- Added `is_ngram()` to the `output_ids.extend()` branch so ngram-resolved tokens are appended correctly. Ngram frees unaccepted KV slots inside `_forward_decode`, so no additional freeing in the mixin.

## Accuracy Tests

**Unit tests (33/33 pass on TPU v6e-1, JAX 0.8.1, Python 3.12):**
```bash
python3 -m pytest python/sgl_jax/test/speculative/test_ngram_cache.py -v
# 33 passed in 2.03s
```

**End-to-end test on TPU v6e-1 with Qwen/Qwen3-1.7B (bfloat16, TP=1):**
```bash
python -m sgl_jax.launch_server \
  --model-path Qwen/Qwen3-1.7B \
  --trust-remote-code --skip-server-warmup \
  --mem-fraction-static 0.6 --max-running-requests 8 \
  --speculative-algorithm NGRAM \
  --speculative-num-draft-tokens 4 \
  --speculative-ngram-max-trie-depth 8 \
  --speculative-ngram-max-bfs-breadth 1 \
  --disable-overlap-schedule \
  --page-size 64 --attention-backend fa --dtype bfloat16 --tp-size 1
```

Request 1 (`"The capital of France is"`, 32 tokens, temperature=0.0):
```
Paris. The capital of the United States is Washington, D.C. The capital of the
United Kingdom is London. The capital of the Russian Federation is Moscow.
```

Request 2 (`"Write a haiku about machine learning:"`, 64 tokens, temperature=0.0): 64 tokens of coherent output, 40+ decode iterations with no errors.

Server logs show varying acceptance rates:
- Most steps: `accept-len 1.00` (0.25 ratio -- only D0 accepted)
- Two steps: `accept-len 4.00` (1.00 ratio -- all 4 drafts accepted on repeated patterns like "The capital of")
- Two steps: `accept-len 2.00` (0.50 ratio -- partial acceptance)

Existing speculative decoding tests are unaffected (no regressions).

## Benchmarking and Profiling

This is a correctness-first PR. Throughput on v6e-1 was ~0.14-0.55 tok/s due to single chip + no precompile + first-time JIT compilation. Performance optimization is future work (see Limitations below).

## Usage

```bash
python -m sgl_jax.launch_server \
  --model-path <any-model> \
  --speculative-algorithm NGRAM \
  --speculative-num-draft-tokens 4 \
  --speculative-ngram-max-trie-depth 8 \
  --speculative-ngram-max-bfs-breadth 1 \
  --disable-overlap-schedule \
  --attention-backend fa
```

No draft model path required. The ngram cache builds up automatically as tokens are generated.

## Limitations / Future Work

- **Chain mode only** (`--speculative-ngram-max-bfs-breadth=1`). Branching-tree drafts require KV compaction that is not yet implemented; passing breadth > 1 raises `ValueError`.
- **No precompile support** yet -- `run_spec_decode_precompile` is a no-op, so JIT recompilation happens on new batch sizes.
- **Suffix Decoding and LookAhead Decoding** are not included (separate algorithms from the same #192 bullet).
- **`--disable-overlap-schedule` is required** (same as EAGLE).

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
