### PR TITLE
feat: add GET /profile_status endpoint

### DIFF
--- a/python/sgl_jax/srt/entrypoints/http_server.py
+++ b/python/sgl_jax/srt/entrypoints/http_server.py
@@ -403,6 +403,13 @@ async def stop_profile_async():
     )
 
 
+@app.api_route("/profile_status", methods=["GET"])
+async def profile_status_async():
+    """Get profiling status. Returns {"status": "in_progress"} or {"status": "idle"}."""
+    result = await _global_state.tokenizer_manager.get_profile_status()
+    return ORJSONResponse(content={"status": result.message})
+
+
 @app.api_route("/start_trace", methods=["GET", "POST"])
 async def start_trace_async(obj: StartTraceReqInput | None = None):
     """Start precision tracing."""

--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -661,6 +661,7 @@ class ProfileReqInput:
 class ProfileReqType(Enum):
     START_PROFILE = 1
     STOP_PROFILE = 2
+    GET_STATUS = 3
 
 
 @dataclass

--- a/python/sgl_jax/srt/managers/scheduler_profiler_mixing.py
+++ b/python/sgl_jax/srt/managers/scheduler_profiler_mixing.py
@@ -333,5 +333,14 @@ class SchedulerProfilerMixin:
                 recv_req.python_tracer_level,
                 recv_req.profile_id,
             )
+        elif recv_req.type == ProfileReqType.GET_STATUS:
+            return self.get_profile_status()
         else:
             return self.stop_profile()
+
+    def get_profile_status(self) -> ProfileReqOutput:
+        in_progress = self.profile_in_progress or self._profile_manager.is_configured
+        return ProfileReqOutput(
+            success=True,
+            message="in_progress" if in_progress else "idle",
+        )

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -660,6 +660,11 @@ class TokenizerManager:
         req = ProfileReq(type=ProfileReqType.STOP_PROFILE)
         return await self._execute_profile(req)
 
+    async def get_profile_status(self):
+        self.auto_create_handle_loop()
+        req = ProfileReq(type=ProfileReqType.GET_STATUS)
+        return await self._execute_profile(req)
+
     async def _execute_profile(self, req: ProfileReq):
         result = (await self.profile_communicator(req))[0]
         if not result.success:


### PR DESCRIPTION
## Summary
- Adds `GET /profile_status` endpoint returning `{"status": "in_progress"}` or `{"status": "idle"}`
- New `ProfileReqType.GET_STATUS` enum value, routed through existing scheduler profile dispatch
- No side effects — safe to poll repeatedly from CI workflows

Cherry-picked from primatrix/sglang-jax#254.

## Changed files
- `io_struct.py` — `GET_STATUS = 3`
- `scheduler_profiler_mixing.py` — dispatch + `get_profile_status()`
- `tokenizer_manager.py` — `get_profile_status()`
- `http_server.py` — `/profile_status` route

## Test plan
- [x] `curl http://server:port/profile_status` returns `{"status":"idle"}` when no profiling active
- [x] Start profiling, poll `/profile_status`, verify it returns `"in_progress"` then flips to `"idle"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)