### PR TITLE
fix: remove process_count guards for multi-process sharding

### DIFF
--- a/python/sgl_jax/srt/layers/attention/fla/linear_attention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/fla/linear_attention_backend.py
@@ -114,11 +114,7 @@ class LinearAttentionBackend(nnx.Module):
         # Multi-host (process_count > 1): leave sharding=None; the arrays are
         # small metadata (cu_seqlens, scatter_idx) and will be replicated by
         # shard_map's in_specs=P() when consumed by the model.
-        sharding = (
-            NamedSharding(self.mesh, P())
-            if self.mesh is not None and jax.process_count() == 1
-            else None
-        )
+        sharding = NamedSharding(self.mesh, P()) if self.mesh is not None else None
         cu_seqlens_dev, scatter_idx_dev = device_array((cu_seqlens, scatter_idx), sharding=sharding)
         return LinearAttentionMetadata(cu_seqlens_dev=cu_seqlens_dev, scatter_idx=scatter_idx_dev)
 

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -160,7 +160,7 @@ class FlashAttention(AttentionBackend):
             metadata.distribution,
         ) = device_array(
             (num_seqs, cu_q_lens, cu_kv_lens, page_indices, seq_lens, distribution),
-            sharding=(NamedSharding(self.mesh, P()) if jax.process_count() == 1 else None),
+            sharding=(NamedSharding(self.mesh, P())),
         )
         return metadata
 
@@ -275,7 +275,7 @@ class FlashAttention(AttentionBackend):
             metadata.distribution,
         ) = device_array(
             (num_seqs, cu_q_lens, cu_kv_lens, page_indices, seq_lens, distribution),
-            sharding=(NamedSharding(self.mesh, P()) if jax.process_count() == 1 else None),
+            sharding=(NamedSharding(self.mesh, P())),
         )
         return metadata
 
@@ -387,7 +387,7 @@ class FlashAttention(AttentionBackend):
                     seq_lens_list[i],
                     distribution,
                 ),
-                sharding=(NamedSharding(self.mesh, P()) if jax.process_count() == 1 else None),
+                sharding=(NamedSharding(self.mesh, P())),
             )
             metadata.append(metadata_tmp)
         return metadata

--- a/python/sgl_jax/srt/layers/logits_processor.py
+++ b/python/sgl_jax/srt/layers/logits_processor.py
@@ -187,7 +187,7 @@ class LogitsMetadata:
             extend_return_logprob = extend_return_top_logprob = extend_token_ids_logprob = False
             extend_logprob_pruned_lens_cpu = extend_seq_lens_cpu = None
 
-        sharding = NamedSharding(mesh, P()) if jax.process_count() == 1 else None
+        sharding = NamedSharding(mesh, P())
 
         return cls(
             forward_mode=batch.forward_mode,

--- a/python/sgl_jax/srt/model_executor/forward_batch_info.py
+++ b/python/sgl_jax/srt/model_executor/forward_batch_info.py
@@ -332,31 +332,19 @@ class ForwardBatch:
                 batch.extend_prefix_lens,
                 batch.extend_seq_lens,
             ),
-            sharding=(
-                NamedSharding(model_runner.mesh, PartitionSpec())
-                if jax.process_count() == 1
-                else None
-            ),
+            sharding=(NamedSharding(model_runner.mesh, PartitionSpec())),
         )
         mrope_positions = None
         if batch.mrope_positions is not None:
             (mrope_positions,) = device_array(
                 (batch.mrope_positions,),
-                sharding=(
-                    NamedSharding(model_runner.mesh, PartitionSpec(None, None))
-                    if jax.process_count() == 1
-                    else None
-                ),
+                sharding=(NamedSharding(model_runner.mesh, PartitionSpec(None, None))),
             )
         input_embedding = None
         if batch.input_embedding is not None:
             (input_embedding,) = device_array(
                 (batch.input_embedding,),
-                sharding=(
-                    NamedSharding(model_runner.mesh, PartitionSpec(None, None))
-                    if jax.process_count() == 1
-                    else None
-                ),
+                sharding=(NamedSharding(model_runner.mesh, PartitionSpec(None, None))),
             )
         if input_embedding is not None:
             input_embedding = input_embedding.astype(jnp.bfloat16)
@@ -372,11 +360,7 @@ class ForwardBatch:
                     batch.lora_token_indices,
                     batch.lora_ranks,
                 ),
-                sharding=(
-                    NamedSharding(model_runner.mesh, PartitionSpec())
-                    if jax.process_count() == 1
-                    else None
-                ),
+                sharding=(NamedSharding(model_runner.mesh, PartitionSpec())),
             )
         else:
             (lora_scalings, lora_token_indices, lora_ranks) = (
@@ -389,11 +373,7 @@ class ForwardBatch:
         if batch.apply_for_deepstack:
             (deepstack_visual_embedding,) = device_array(
                 (batch.deepstack_visual_embedding,),
-                sharding=(
-                    NamedSharding(model_runner.mesh, PartitionSpec(None, None))
-                    if jax.process_count() == 1
-                    else None
-                ),
+                sharding=(NamedSharding(model_runner.mesh, PartitionSpec(None, None))),
             )
         if deepstack_visual_embedding is not None:
             deepstack_visual_embedding = deepstack_visual_embedding.astype(jnp.bfloat16)

--- a/python/sgl_jax/srt/sampling/sampling_batch_info.py
+++ b/python/sgl_jax/srt/sampling/sampling_batch_info.py
@@ -110,7 +110,7 @@ class SamplingMetadata:
         mesh: Mesh = None,
         vocab_size: int = 32000,
     ) -> SamplingMetadata:
-        sharding = NamedSharding(mesh, PartitionSpec()) if jax.process_count() == 1 else None
+        sharding = NamedSharding(mesh, PartitionSpec())
         if batch.sampling_info.sampling_seeds is not None:
             sampling_seeds_device = device_array(
                 batch.sampling_info.sampling_seeds, sharding=sharding
@@ -136,9 +136,7 @@ class SamplingMetadata:
         # Extract penalty information from penalizer orchestrator
         linear_penalty_device = None
         do_penalties = False
-        linear_penalty_sharding = (
-            NamedSharding(mesh, PartitionSpec(None, "tensor")) if jax.process_count() == 1 else None
-        )
+        linear_penalty_sharding = NamedSharding(mesh, PartitionSpec(None, "tensor"))
 
         # Handle linear penalty independently (created by update_penalties)
         if (

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -82,22 +82,14 @@ class EAGLEWorker(ModelWorker):
             if self.draft_model_runner.model.hot_token_ids is not None:
                 self.hot_token_ids = device_array(
                     self.draft_model_runner.model.hot_token_ids,
-                    sharding=(
-                        NamedSharding(self.model_runner.mesh, P())
-                        if jax.process_count() == 1
-                        else None
-                    ),
+                    sharding=(NamedSharding(self.model_runner.mesh, P())),
                 )
         else:
             if self.hot_token_ids is not None:
                 head = head.clone()
                 self.hot_token_ids = device_array(
                     self.draft_model_runner.model.hot_token_ids,
-                    sharding=(
-                        NamedSharding(self.model_runner.mesh, P())
-                        if jax.process_count() == 1
-                        else None
-                    ),
+                    sharding=(NamedSharding(self.model_runner.mesh, P())),
                 )
                 head.data = head.data[self.hot_token_ids]
 
@@ -638,9 +630,7 @@ class EAGLEWorker(ModelWorker):
         scores = None
         positions_base = device_array(
             np.repeat(model_worker_batch.seq_lens, self.topk),
-            sharding=(
-                NamedSharding(self.model_runner.mesh, P()) if jax.process_count() == 1 else None
-            ),
+            sharding=(NamedSharding(self.model_runner.mesh, P())),
         )
         logits_metadata = None
         metadata_per_step = self.draft_model_runner.attn_backend.get_eagle_multi_step_metadata(

--- a/python/sgl_jax/srt/utils/jax_utils.py
+++ b/python/sgl_jax/srt/utils/jax_utils.py
@@ -197,7 +197,14 @@ def get_available_device_memory(
 
 
 def device_array(*data, sharding=None, **kwargs) -> jax.Array:
-    return jax.device_put(*data, device=sharding, **kwargs)
+    if sharding is None:
+        return jax.device_put(*data, device=sharding, **kwargs)
+
+    def _to_device(arr):
+        arr = np.asarray(arr)
+        return jax.make_array_from_callback(arr.shape, sharding, lambda idx, a=arr: a[idx])
+
+    return jax.tree.map(_to_device, *data)
 
 
 _IS_TPU_RUNTIME_CACHED: bool | None = None

--- a/python/sgl_jax/test/test_flashattention.py
+++ b/python/sgl_jax/test/test_flashattention.py
@@ -315,9 +315,7 @@ def create_test_data(
 
         fb.attn_backend.forward_metadata.custom_mask = device_array(
             (fb.spec_info.custom_mask),
-            sharding=(
-                NamedSharding(attention_backend.mesh, P()) if jax.process_count() == 1 else None
-            ),
+            sharding=(NamedSharding(attention_backend.mesh, P())),
         )
     return fb, current_kv_cache, q, k, v
 

--- a/test/srt/lora/test_bgmv_backend.py
+++ b/test/srt/lora/test_bgmv_backend.py
@@ -274,9 +274,7 @@ class TestBgmvLoRABackend(CustomTestCase):
                 batch.lora_scalings,
                 batch.lora_token_indices,
             ),
-            sharding=(
-                NamedSharding(self.mesh, PartitionSpec()) if jax.process_count() == 1 else None
-            ),
+            sharding=(NamedSharding(self.mesh, PartitionSpec())),
         )
         return lora_scalings, lora_token_indices
 


### PR DESCRIPTION
## Summary

- Remove all `if jax.process_count() == 1` guards — always apply `NamedSharding` regardless of process count
- Upgrade `device_array` to use `jax.make_array_from_callback` when sharding is provided, enabling correct per-device array creation in multi-process setups
- Also fix the same pattern in `linear_attention_backend.py` (missed in primatrix#245)

Cherry-picked from primatrix/sglang-jax#245 and adapted for main (keeps replicated `PartitionSpec` values, no data-parallel sharding changes).

## Changes (9 files, +25 / -58)

| File | Change |
|------|--------|
| `srt/utils/jax_utils.py` | Upgrade `device_array` to use `make_array_from_callback` when sharding is set |
| `srt/layers/attention/flashattention_backend.py` | Remove 3 guards |
| `srt/layers/logits_processor.py` | Remove 1 guard |
| `srt/model_executor/forward_batch_info.py` | Remove 5 guards |
| `srt/sampling/sampling_batch_info.py` | Remove 2 guards |
| `srt/speculative/eagle_worker.py` | Remove 3 guards |
| `srt/layers/attention/fla/linear_attention_backend.py` | Remove 1 guard (bonus, not in original PR) |
| `test/test_flashattention.py` | Remove 1 guard |
| `test/srt/lora/test_bgmv_backend.py` | Remove 1 guard |

## Test plan

- [ ] Verify no remaining `process_count() == 1` guards: `grep -r "process_count() == 1" python/ test/`
- [ ] Run single-host inference to confirm no regression
- [ ] Run multi-host inference to confirm sharding works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)