### PR TITLE
feat: support MiMo-V2-Flash model

### DIFF
--- a/docs/basic_usage/mimo_v2_flash.md
+++ b/docs/basic_usage/mimo_v2_flash.md
@@ -1,6 +1,6 @@
 # MiMo-V2-Flash on SGL-JAX
 
-MiMo-V2-Flash is Xiaomi's 256-expert MoE model with hybrid attention (full attention + sliding window attention), optimized for long-context reasoning tasks. SGL-JAX supports it on TPU v6e with FP8 quantization, tensor parallelism, and expert parallelism.
+MiMo-V2-Flash is Xiaomi's 256-expert MoE model with hybrid attention (full attention + sliding window attention), optimized for long-context reasoning tasks. SGL-JAX supports it on TPU v6e/v7x with FP8 quantization, tensor parallelism, and expert parallelism.
 
 ## Quick Start
 
@@ -57,6 +57,23 @@ Key flags:
 - `--page-size 256`: Recommended page size for SWA eviction efficiency
 - `--disable-radix-cache`: Recommended for multi-node deployments
 
+### Single-node (TPU v7x-8)
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_server \
+    --model-path XiaomiMiMo/MiMo-V2-Flash \
+    --trust-remote-code \
+    --tp-size 8 --ep-size 8 \
+    --moe-backend fused \
+    --host 0.0.0.0 --port 30271 \
+    --page-size 256 --context-length 262144 \
+    --disable-radix-cache --chunked-prefill-size 4096 \
+    --dtype bfloat16 --mem-fraction-static 0.95 \
+    --swa-full-tokens-ratio 0.2 --skip-server-warmup \
+    --max-running-requests 128 \
+    --attention-backend fa
+```
+
 ## Configuration Tips
 
 ### Memory Management
@@ -109,9 +126,10 @@ evalscope eval \
 
 ### TPU Configuration Guide
 
-| TPU Type | Nodes | TP Size | EP Size | mem-fraction-static | max-running-requests |
-|----------|-------|---------|---------|--------------------|-----------------------|
-| v6e-16   | 4     | 16      | 16      | 0.95               | 128                   |
+| TPU Type | Nodes | TP Size | EP Size | chunked-prefill-size | mem-fraction-static | max-running-requests |
+|----------|-------|---------|---------|----------------------|--------------------|-----------------------|
+| v6e-16   | 4     | 16      | 16      | 2048                 | 0.95               | 128                   |
+| v7x-8    | 1     | 8       | 8       | 4096                 | 0.95               | 128                   |
 
 ### SWA Pool Tuning
 - Monitor SWA pool usage via server logs: `swa token usage` and `full token usage`

--- a/docs/basic_usage/mimo_v2_flash.md
+++ b/docs/basic_usage/mimo_v2_flash.md
@@ -4,23 +4,6 @@ MiMo-V2-Flash is Xiaomi's 256-expert MoE model with hybrid attention (full atten
 
 ## Quick Start
 
-### Single-node (TPU v6e-4)
-
-```bash
-JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_server \
-    --model-path XiaomiMiMo/MiMo-V2-Flash \
-    --trust-remote-code \
-    --tp-size 4 --ep-size 4 \
-    --moe-backend epmoe \
-    --nnodes 1 --node-rank 0 \
-    --dist-init-addr 0.0.0.0:30000 \
-    --host 0.0.0.0 --port 30271 \
-    --page-size 256 --context-length 262144 \
-    --chunked-prefill-size 2048 \
-    --dtype bfloat16 --mem-fraction-static 0.9 \
-    --skip-server-warmup
-```
-
 ### Multi-node (TPU v6e-16, 4 nodes)
 
 Launch on each node with the appropriate `--node-rank` (0-3):
@@ -102,7 +85,6 @@ evalscope eval \
 
 | TPU Type | Nodes | TP Size | EP Size | mem-fraction-static | max-running-requests |
 |----------|-------|---------|---------|--------------------|-----------------------|
-| v6e-4    | 1     | 4       | 4       | 0.9                | 32                    |
 | v6e-16   | 4     | 16      | 16      | 0.95               | 128                   |
 
 ### SWA Pool Tuning

--- a/docs/basic_usage/mimo_v2_flash.md
+++ b/docs/basic_usage/mimo_v2_flash.md
@@ -1,0 +1,123 @@
+# MiMo-V2-Flash on SGL-JAX
+
+MiMo-V2-Flash is Xiaomi's 256-expert MoE model with hybrid attention (full attention + sliding window attention), optimized for long-context reasoning tasks. SGL-JAX supports it on TPU v6e with FP8 quantization, tensor parallelism, and expert parallelism.
+
+## Quick Start
+
+### Single-node (TPU v6e-4)
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_server \
+    --model-path XiaomiMiMo/MiMo-V2-Flash \
+    --trust-remote-code \
+    --tp-size 4 --ep-size 4 \
+    --moe-backend epmoe \
+    --nnodes 1 --node-rank 0 \
+    --dist-init-addr 0.0.0.0:30000 \
+    --host 0.0.0.0 --port 30271 \
+    --page-size 256 --context-length 262144 \
+    --chunked-prefill-size 2048 \
+    --dtype bfloat16 --mem-fraction-static 0.9 \
+    --skip-server-warmup
+```
+
+### Multi-node (TPU v6e-16, 4 nodes)
+
+Launch on each node with the appropriate `--node-rank` (0-3):
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_server \
+    --model-path XiaomiMiMo/MiMo-V2-Flash \
+    --trust-remote-code \
+    --tp-size 16 --ep-size 16 \
+    --moe-backend epmoe \
+    --nnodes 4 --node-rank $RANK \
+    --dist-init-addr $MASTER_IP:30000 \
+    --host 0.0.0.0 --port 30271 \
+    --page-size 256 --context-length 262144 \
+    --disable-radix-cache --chunked-prefill-size 2048 \
+    --dtype bfloat16 --mem-fraction-static 0.95 \
+    --swa-full-tokens-ratio 0.2 --skip-server-warmup \
+    --max-running-requests 128
+```
+
+Key flags:
+- `--tp-size / --ep-size`: Match your total TPU chip count across all nodes
+- `--moe-backend epmoe`: Required for expert-parallel MoE dispatch
+- `--swa-full-tokens-ratio 0.2`: Allocates 20% of KV cache pool to full-attention layers, 80% to SWA layers
+- `--page-size 256`: Recommended page size for SWA eviction efficiency
+- `--disable-radix-cache`: Recommended for multi-node deployments
+
+## Configuration Tips
+
+### Memory Management
+- **mem-fraction-static**: Use `0.9`-`0.95` for dedicated serving. MiMo-V2-Flash weights are ~20 GB/chip in FP8.
+- **swa-full-tokens-ratio**: Controls the split between full-attention (9 layers) and SWA (39 layers) KV cache pools. Default `0.2` works well for most workloads.
+- **max-running-requests**: Limit concurrent decoding requests to prevent OOM. `128` is a good starting point for v6e-16.
+
+### Model-Specific Features
+- **Hybrid Attention**: 9 full-attention layers + 39 sliding-window (window=128) layers. SWA layers use a separate KV cache pool with automatic eviction.
+- **v_head_dim**: K head_dim=192, V head_dim=128. Handled transparently by the attention backend.
+- **Attention Sink**: SWA layers use a phantom token in the softmax denominator for numerical stability.
+- **FP8 Quantization**: Weights are natively quantized in FP8. No additional quantization flags needed.
+
+## Benchmarking
+
+### Throughput Testing
+```bash
+uv run python -m sgl_jax.bench_serving \
+    --backend sgl-jax \
+    --dataset-name random \
+    --num-prompts 256 \
+    --random-input 16384 \
+    --random-output 1024 \
+    --max-concurrency 64 \
+    --random-range-ratio 1 \
+    --warmup-requests 0 \
+    --tokenizer XiaomiMiMo/MiMo-V2-Flash
+```
+
+### Accuracy Evaluation
+Using EvalScope for GSM8K accuracy:
+```bash
+pip install evalscope==0.17.1
+
+evalscope eval \
+    --model XiaomiMiMo/MiMo-V2-Flash \
+    --api-url http://127.0.0.1:30271/v1/chat/completions \
+    --api-key EMPTY \
+    --eval-type service \
+    --datasets gsm8k \
+    --eval-batch-size 32 \
+    --generation-config '{"temperature": 0.8, "top_p": 0.95, "max_tokens": 32768}'
+```
+
+| Model | Dataset | Metric | Subset | Num | Score |
+|:------|:--------|:-------|:-------|:----|:------|
+| MiMo-V2-Flash | gsm8k | AverageAccuracy | main | 1319 | 0.9401 |
+
+## Performance Tuning
+
+### TPU Configuration Guide
+
+| TPU Type | Nodes | TP Size | EP Size | mem-fraction-static | max-running-requests |
+|----------|-------|---------|---------|--------------------|-----------------------|
+| v6e-4    | 1     | 4       | 4       | 0.9                | 32                    |
+| v6e-16   | 4     | 16      | 16      | 0.95               | 128                   |
+
+### SWA Pool Tuning
+- Monitor SWA pool usage via server logs: `swa token usage` and `full token usage`
+- If SWA OOM occurs, reduce `--max-running-requests` or increase `--swa-full-tokens-ratio`
+- For long-output workloads, lower `--swa-full-tokens-ratio` to give more capacity to SWA layers
+
+## Troubleshooting
+
+- **OOM Errors**: Reduce `--max-running-requests` or `--mem-fraction-static`. Check both SWA and full-attention pool usage in logs.
+- **SWA Pool Exhaustion**: The SWA pool evicts tokens outside the sliding window automatically. If requests still fail, reduce concurrency.
+- **Compilation Timeout**: Set `JAX_COMPILATION_CACHE_DIR` to persist JIT compilation cache across restarts.
+- **Multi-node Connectivity**: Ensure `--dist-init-addr` points to the rank-0 node's IP and the port is accessible from all nodes.
+
+## Additional Resources
+
+- [MiMo-V2-Flash Model Card](https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash)
+- [SGL-JAX SWA Documentation](../basic_usage/features/)

--- a/docs/basic_usage/mimo_v2_flash.md
+++ b/docs/basic_usage/mimo_v2_flash.md
@@ -8,6 +8,31 @@ MiMo-V2-Flash is Xiaomi's 256-expert MoE model with hybrid attention (full atten
 
 Launch on each node with the appropriate `--node-rank` (0-3):
 
+#### Fused MoE (Recommended)
+
+Uses the fused Pallas kernel which combines expert computation and all-to-all communication into a single optimized operation:
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_server \
+    --model-path XiaomiMiMo/MiMo-V2-Flash \
+    --trust-remote-code \
+    --tp-size 16 --ep-size 16 \
+    --moe-backend fused \
+    --nnodes 4 --node-rank $RANK \
+    --dist-init-addr $MASTER_IP:30000 \
+    --host 0.0.0.0 --port 30271 \
+    --page-size 256 --context-length 262144 \
+    --disable-radix-cache --chunked-prefill-size 2048 \
+    --dtype bfloat16 --mem-fraction-static 0.95 \
+    --swa-full-tokens-ratio 0.2 --skip-server-warmup \
+    --max-running-requests 128 \
+    --attention-backend fa
+```
+
+#### EP MoE (Alternative)
+
+Uses GMM-based expert-parallel dispatch with separate all-to-all communication:
+
 ```bash
 JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_server \
     --model-path XiaomiMiMo/MiMo-V2-Flash \
@@ -21,12 +46,13 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_serv
     --disable-radix-cache --chunked-prefill-size 2048 \
     --dtype bfloat16 --mem-fraction-static 0.95 \
     --swa-full-tokens-ratio 0.2 --skip-server-warmup \
-    --max-running-requests 128
+    --max-running-requests 128 \
+    --attention-backend fa
 ```
 
 Key flags:
 - `--tp-size / --ep-size`: Match your total TPU chip count across all nodes
-- `--moe-backend epmoe`: Required for expert-parallel MoE dispatch
+- `--moe-backend fused|epmoe`: `fused` uses an optimized Pallas kernel; `epmoe` uses GMM-based expert dispatch
 - `--swa-full-tokens-ratio 0.2`: Allocates 20% of KV cache pool to full-attention layers, 80% to SWA layers
 - `--page-size 256`: Recommended page size for SWA eviction efficiency
 - `--disable-radix-cache`: Recommended for multi-node deployments

--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -172,6 +172,7 @@ class ModelConfig:
             "head_dim",
             self.hf_text_config.hidden_size // self.hf_text_config.num_attention_heads,
         )
+        self.v_head_dim = getattr(self.hf_text_config, "v_head_dim", self.head_dim)
 
         self.attention_arch = AttentionArch.MHA
         self.num_attention_heads = self.hf_text_config.num_attention_heads
@@ -246,6 +247,12 @@ class ModelConfig:
 
             if quant_method == "fp8":
                 logger.info("Auto-detected FP8 model. Creating QuantizationConfig for static fp8.")
+                ignored_layers = hf_quant_config.get("ignored_layers")
+                weight_block_size = hf_quant_config.get("weight_block_size")
+                if isinstance(weight_block_size, (list, tuple)) and len(weight_block_size) == 2:
+                    weight_block_size = (int(weight_block_size[0]), int(weight_block_size[1]))
+                else:
+                    weight_block_size = None
                 quant_config = QuantizationConfig(
                     is_static_checkpoint=True,
                     linear_rules=[
@@ -257,6 +264,8 @@ class ModelConfig:
                     ],
                     moe_weight_dtype=jnp.float8_e4m3fn,
                     moe_activation_dtype=None,
+                    ignored_layers=ignored_layers,
+                    weight_block_size=weight_block_size,
                 )
                 return quant_config
 
@@ -476,6 +485,19 @@ class ModelConfig:
         else:
             # For MHA models, dynamically add the attribute
             self.hf_text_config.num_key_value_heads = total_kv_heads
+
+        # Handle swa_num_key_value_heads if present (e.g. MiMo models)
+        if hasattr(self.hf_text_config, "swa_num_key_value_heads"):
+            if not hasattr(self, "_original_swa_num_key_value_heads"):
+                self._original_swa_num_key_value_heads = self.hf_text_config.swa_num_key_value_heads
+            from sgl_jax.srt.utils.jax_utils import get_num_kv_heads_by_tp
+
+            swa_kv_heads_per_device = get_num_kv_heads_by_tp(
+                self._original_swa_num_key_value_heads, tensor_parallel_size
+            )
+            self.hf_text_config.swa_num_key_value_heads = (
+                swa_kv_heads_per_device * tensor_parallel_size
+            )
 
     def get_original_kv_head_id(self, tp_rank: int, tensor_parallel_size: int) -> int:
         """Determine which original KV head this device should use."""

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -85,7 +85,6 @@ class FlashAttention(AttentionBackend):
         head_dim,
         vmem_limit_bytes: int = 64 * (1 << 20),  # 64MB
         page_size: int = 1,
-        attention_sink: int = 0,
         v_head_dim: int | None = None,
         kv_partition_axis: str = "tensor",
         mesh: jax.sharding.Mesh = None,
@@ -98,7 +97,6 @@ class FlashAttention(AttentionBackend):
             self.num_kv_heads = num_attn_heads
         self.head_dim = head_dim
         self.v_head_dim = v_head_dim if v_head_dim is not None else head_dim
-        self.attention_sink = attention_sink
         self.page_size = page_size
         self.kv_partition_axis = kv_partition_axis
         self.forward_metadata = nnx.data(FlashAttentionMetadata())
@@ -438,7 +436,6 @@ class FlashAttention(AttentionBackend):
             "vmem_limit_bytes": self.vmem_limit_bytes,
             "head_dim": self.head_dim,
             "page_size": self.page_size,
-            "attention_sink": self.attention_sink,
             "v_head_dim": self.v_head_dim,
             "kv_partition_axis": self.kv_partition_axis,
             "mesh": self.mesh,
@@ -452,7 +449,6 @@ class FlashAttention(AttentionBackend):
             aux_data["num_kv_heads"],
             aux_data["head_dim"],
             page_size=aux_data["page_size"],
-            attention_sink=aux_data["attention_sink"],
             v_head_dim=aux_data.get("v_head_dim"),
             kv_partition_axis=aux_data.get("kv_partition_axis", "tensor"),
             mesh=aux_data.get("mesh"),
@@ -518,9 +514,9 @@ class FlashAttention(AttentionBackend):
         elif hasattr(token_to_kv_pool, "remap_cache_loc") and self.page_size == 1:
             page_indices_arg = token_to_kv_pool.remap_cache_loc(page_indices_arg, layer.layer_id)
 
-        # Handle attention_sink: if caller didn't pass one but model has attention_sink configured,
-        # use a placeholder scalar so shard_map specs remain consistent
-        if attention_sink is None and self.attention_sink > 0:
+        # Default attention_sink to a zero scalar when not provided so that
+        # shard_map always receives a consistent set of arguments.
+        if attention_sink is None:
             attention_sink = jnp.float32(0.0)
 
         in_specs = (
@@ -536,11 +532,7 @@ class FlashAttention(AttentionBackend):
             P(),  # cu_kv_lens
             P(),  # distribution
             P(),  # custom_mask
-            (
-                P(self.kv_partition_axis)
-                if (attention_sink is not None and attention_sink.ndim > 0)
-                else P()
-            ),  # attention sink: (num_q_heads,), sharded by heads
+            P(),  # attention_sink (replicated scalar or per-head array)
         )
 
         out_specs = (

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -85,7 +85,6 @@ class FlashAttention(AttentionBackend):
         head_dim,
         vmem_limit_bytes: int = 64 * (1 << 20),  # 64MB
         page_size: int = 1,
-        v_head_dim: int | None = None,
         kv_partition_axis: str = "tensor",
         mesh: jax.sharding.Mesh = None,
     ):
@@ -96,7 +95,6 @@ class FlashAttention(AttentionBackend):
         else:
             self.num_kv_heads = num_attn_heads
         self.head_dim = head_dim
-        self.v_head_dim = v_head_dim if v_head_dim is not None else head_dim
         self.page_size = page_size
         self.kv_partition_axis = kv_partition_axis
         self.forward_metadata = nnx.data(FlashAttentionMetadata())
@@ -436,9 +434,6 @@ class FlashAttention(AttentionBackend):
             "vmem_limit_bytes": self.vmem_limit_bytes,
             "head_dim": self.head_dim,
             "page_size": self.page_size,
-            "v_head_dim": self.v_head_dim,
-            "kv_partition_axis": self.kv_partition_axis,
-            "mesh": self.mesh,
         }
         return (children, aux_data)
 
@@ -448,10 +443,8 @@ class FlashAttention(AttentionBackend):
             aux_data["num_heads"],
             aux_data["num_kv_heads"],
             aux_data["head_dim"],
-            page_size=aux_data["page_size"],
-            v_head_dim=aux_data.get("v_head_dim"),
-            kv_partition_axis=aux_data.get("kv_partition_axis", "tensor"),
-            mesh=aux_data.get("mesh"),
+            aux_data["vmem_limit_bytes"],
+            aux_data["page_size"],
         )
 
         obj.forward_metadata = children[0]
@@ -484,17 +477,7 @@ class FlashAttention(AttentionBackend):
                 forward_batch, token_to_kv_pool, layer.layer_id
             )
         else:
-            from sgl_jax.srt.kernels.ragged_paged_attention.util import (
-                align_to,
-                get_dtype_packing,
-            )
-
-            packing = get_dtype_packing(q.dtype)
-            head_dim_aligned = align_to(self.head_dim, 128)
-            heads_per_pack = align_to(self.num_kv_heads * 2, packing) // packing
-            kv_cache_fused = jnp.zeros(
-                (0, self.page_size, heads_per_pack, packing, head_dim_aligned), dtype=q.dtype
-            )
+            kv_cache_fused = jnp.zeros((0, self.num_kv_heads * 2, self.head_dim), dtype=q.dtype)
         scale = (
             1.0 / jnp.sqrt(layer.head_dim)
             if (layer is None or layer.scaling is None)
@@ -514,11 +497,6 @@ class FlashAttention(AttentionBackend):
         elif hasattr(token_to_kv_pool, "remap_cache_loc") and self.page_size == 1:
             page_indices_arg = token_to_kv_pool.remap_cache_loc(page_indices_arg, layer.layer_id)
 
-        # Default attention_sink to a zero scalar when not provided so that
-        # shard_map always receives a consistent set of arguments.
-        if attention_sink is None:
-            attention_sink = jnp.float32(0.0)
-
         in_specs = (
             P(None, self.kv_partition_axis),  # queries
             P(None, self.kv_partition_axis),  # keys (new tokens)
@@ -532,7 +510,9 @@ class FlashAttention(AttentionBackend):
             P(),  # cu_kv_lens
             P(),  # distribution
             P(),  # custom_mask
-            P(),  # attention_sink (replicated scalar or per-head array)
+            (
+                P(self.kv_partition_axis) if attention_sink is not None else P()
+            ),  # attention sink: (num_q_heads,), sharded by heads
         )
 
         out_specs = (

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -85,6 +85,8 @@ class FlashAttention(AttentionBackend):
         head_dim,
         vmem_limit_bytes: int = 64 * (1 << 20),  # 64MB
         page_size: int = 1,
+        attention_sink: int = 0,
+        v_head_dim: int | None = None,
         kv_partition_axis: str = "tensor",
         mesh: jax.sharding.Mesh = None,
     ):
@@ -95,6 +97,8 @@ class FlashAttention(AttentionBackend):
         else:
             self.num_kv_heads = num_attn_heads
         self.head_dim = head_dim
+        self.v_head_dim = v_head_dim if v_head_dim is not None else head_dim
+        self.attention_sink = attention_sink
         self.page_size = page_size
         self.kv_partition_axis = kv_partition_axis
         self.forward_metadata = nnx.data(FlashAttentionMetadata())
@@ -434,6 +438,10 @@ class FlashAttention(AttentionBackend):
             "vmem_limit_bytes": self.vmem_limit_bytes,
             "head_dim": self.head_dim,
             "page_size": self.page_size,
+            "attention_sink": self.attention_sink,
+            "v_head_dim": self.v_head_dim,
+            "kv_partition_axis": self.kv_partition_axis,
+            "mesh": self.mesh,
         }
         return (children, aux_data)
 
@@ -443,8 +451,11 @@ class FlashAttention(AttentionBackend):
             aux_data["num_heads"],
             aux_data["num_kv_heads"],
             aux_data["head_dim"],
-            aux_data["vmem_limit_bytes"],
-            aux_data["page_size"],
+            page_size=aux_data["page_size"],
+            attention_sink=aux_data["attention_sink"],
+            v_head_dim=aux_data.get("v_head_dim"),
+            kv_partition_axis=aux_data.get("kv_partition_axis", "tensor"),
+            mesh=aux_data.get("mesh"),
         )
 
         obj.forward_metadata = children[0]
@@ -477,7 +488,17 @@ class FlashAttention(AttentionBackend):
                 forward_batch, token_to_kv_pool, layer.layer_id
             )
         else:
-            kv_cache_fused = jnp.zeros((0, self.num_kv_heads * 2, self.head_dim), dtype=q.dtype)
+            from sgl_jax.srt.kernels.ragged_paged_attention.util import (
+                align_to,
+                get_dtype_packing,
+            )
+
+            packing = get_dtype_packing(q.dtype)
+            head_dim_aligned = align_to(self.head_dim, 128)
+            heads_per_pack = align_to(self.num_kv_heads * 2, packing) // packing
+            kv_cache_fused = jnp.zeros(
+                (0, self.page_size, heads_per_pack, packing, head_dim_aligned), dtype=q.dtype
+            )
         scale = (
             1.0 / jnp.sqrt(layer.head_dim)
             if (layer is None or layer.scaling is None)
@@ -497,6 +518,11 @@ class FlashAttention(AttentionBackend):
         elif hasattr(token_to_kv_pool, "remap_cache_loc") and self.page_size == 1:
             page_indices_arg = token_to_kv_pool.remap_cache_loc(page_indices_arg, layer.layer_id)
 
+        # Handle attention_sink: if caller didn't pass one but model has attention_sink configured,
+        # use a placeholder scalar so shard_map specs remain consistent
+        if attention_sink is None and self.attention_sink > 0:
+            attention_sink = jnp.float32(0.0)
+
         in_specs = (
             P(None, self.kv_partition_axis),  # queries
             P(None, self.kv_partition_axis),  # keys (new tokens)
@@ -511,7 +537,9 @@ class FlashAttention(AttentionBackend):
             P(),  # distribution
             P(),  # custom_mask
             (
-                P(self.kv_partition_axis) if attention_sink is not None else P()
+                P(self.kv_partition_axis)
+                if (attention_sink is not None and attention_sink.ndim > 0)
+                else P()
             ),  # attention sink: (num_q_heads,), sharded by heads
         )
 

--- a/python/sgl_jax/srt/layers/attention/native_backend.py
+++ b/python/sgl_jax/srt/layers/attention/native_backend.py
@@ -283,7 +283,11 @@ def forward_attention(
     # Apply appropriate masking
     if mode == ForwardMode.EXTEND:
         attn_logits = _apply_extend_mask(
-            attn_logits, seq_lengths, extend_prefix_lens, extend_seq_lens, is_causal,
+            attn_logits,
+            seq_lengths,
+            extend_prefix_lens,
+            extend_seq_lens,
+            is_causal,
             sliding_window_size,
         )
     else:

--- a/python/sgl_jax/srt/layers/attention/native_backend.py
+++ b/python/sgl_jax/srt/layers/attention/native_backend.py
@@ -40,7 +40,11 @@ class NativeAttention(AttentionBackend):
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
-        return cls(num_attn_heads=aux_data["num_heads"], num_kv_heads=aux_data["num_kv_heads"])
+        return cls(
+            num_attn_heads=aux_data["num_heads"],
+            num_kv_heads=aux_data["num_kv_heads"],
+            mesh=aux_data["mesh"],
+        )
 
     def get_forward_metadata(self, batch: ModelWorkerBatch):
         """Init the metadata for a forward pass and return it."""
@@ -55,12 +59,14 @@ class NativeAttention(AttentionBackend):
         layer: RadixAttention,
         forward_batch: ForwardBatch,
         token_to_kv_pool: KVCache,
+        **kwargs,
     ):
         """
         Args:
             q, k, v: Input tensors of shape [total_tokens, hidden_size]
             forward_batch: ForwardBatch object containing seq_lens and batch_size
             is_causal: Whether to apply causal masking
+            **kwargs: Optional keyword arguments, e.g. attention_sink for sink bias.
         Returns:
             Tuple of (output tensor of shape [total_tokens, hidden_size], kv_fused 5D)
         """
@@ -81,6 +87,11 @@ class NativeAttention(AttentionBackend):
         # Get xai_temperature_len from the layer if it exists and pass it down.
         xai_temp_len = getattr(layer, "xai_temperature_len", None)
 
+        # Extract attention sink bias (e.g. MiMo-V2-Flash SWA layers)
+        attention_sink = kwargs.get("attention_sink")
+        if attention_sink is not None and hasattr(attention_sink, "value"):
+            attention_sink = attention_sink.value
+
         attn_output = forward_attention(
             q,
             k_buffer,
@@ -96,6 +107,9 @@ class NativeAttention(AttentionBackend):
             forward_batch.forward_mode,
             self.kv_sharding,
             xai_temperature_len=xai_temp_len,
+            attention_sink=attention_sink,
+            sliding_window_size=layer.sliding_window_size,
+            positions=forward_batch.positions,
         )
 
         # Return full fused KV buffer for this layer so that caller can persist it outside JIT
@@ -115,15 +129,12 @@ class NativeAttention(AttentionBackend):
         The 5D fused buffer is persisted outside JIT. The 3D k/v views are
         used by forward_attention for the actual attention computation.
         """
+        is_decode = forward_batch.forward_mode == ForwardMode.DECODE
+
         if is_tpu_runtime():
-            if forward_batch.forward_mode.is_extend():
-                token_to_kv_pool.set_kv_buffer(
-                    layer_id, forward_batch.out_cache_loc, k, v, is_decode=False
-                )
-            else:
-                token_to_kv_pool.set_kv_buffer(
-                    layer_id, forward_batch.out_cache_loc, k, v, is_decode=True
-                )
+            token_to_kv_pool.set_kv_buffer(
+                layer_id, forward_batch.out_cache_loc, k, v, is_decode=is_decode
+            )
             fused_5d = token_to_kv_pool.get_fused_kv_buffer(layer_id)
         else:
             fused_5d = token_to_kv_pool.set_kv_buffer_legacy(
@@ -167,6 +178,9 @@ def forward_attention(
     mode=ForwardMode.DECODE,
     kv_sharding=None,
     xai_temperature_len: float | None = None,
+    attention_sink: jax.Array | None = None,
+    sliding_window_size: int | None = None,
+    positions: jax.Array | None = None,
 ):
     """
     Forward pass using native JAX implementation with block-diagonal attention.
@@ -185,6 +199,8 @@ def forward_attention(
         scale: scale for the attention weights
         seq_mask: boolean mask of shape [batch_size, total_prefix_len]
         xai_temperature_len: length of the xai temperature
+        sliding_window_size: sliding window size for attention
+        positions: absolute positions of the tokens [total_tokens]
 
     Returns:
         Output tensor of shape[batch_size, hidden_size]
@@ -192,8 +208,8 @@ def forward_attention(
 
     cache_size = k_cache.shape[0]
     safe_loc = jnp.where(loc > 0, loc, cache_size)
-    k_cache = k_cache.at[safe_loc].get(out_sharding=kv_sharding, mode="fill", fill_value=0)
-    v_cache = v_cache.at[safe_loc].get(out_sharding=kv_sharding, mode="fill", fill_value=0)
+    k_heads = k_cache.at[safe_loc].get(out_sharding=kv_sharding, mode="fill", fill_value=0)
+    v_heads = v_cache.at[safe_loc].get(out_sharding=kv_sharding, mode="fill", fill_value=0)
 
     # Handle both 2D and 3D input formats for q
     if len(q.shape) == 2:
@@ -205,16 +221,15 @@ def forward_attention(
         # Already in multi-head format: [num_tokens, num_heads, head_dim]
         num_tokens, num_heads_input, head_dim = q.shape
         assert num_heads_input == num_heads, f"Expected {num_heads} heads, got {num_heads_input}"
-        hidden_size = num_heads * head_dim  # Calculate hidden_size for proper reshaping
         q_heads = q
 
-    # KV cache from get_kv_buffer is already in multi-head format: [cache_size, num_kv_heads, head_dim]
-    k_heads = k_cache
-    v_heads = v_cache
+    # Pad Q to match K cache head_dim if KV pool was 128-aligned (e.g. 192 -> 256)
+    k_cache_head_dim = k_heads.shape[-1]
+    if k_cache_head_dim != head_dim:
+        pad_size = k_cache_head_dim - head_dim
+        q_heads = jnp.pad(q_heads, ((0, 0), (0, 0), (0, pad_size)))
+        head_dim = k_cache_head_dim
 
-    # Transpose for efficient matrix operations
-    # q: shape of (num_heads, num_tokens, head_dim)
-    # k, v: shape of (total_prefix_len, num_heads, head_dim)
     if num_kv_heads != num_heads:
         # For GQA attention, we need to copy k and v heads to match the number of query heads
         num_copies = num_heads // num_kv_heads
@@ -223,19 +238,19 @@ def forward_attention(
         k_heads = jnp.repeat(k_heads, num_copies, axis=1, out_sharding=kv_sharding)
         v_heads = jnp.repeat(v_heads, num_copies, axis=1, out_sharding=kv_sharding)
 
-    # Transpose for matmul: [num_heads, num_tokens, head_dim]
-    q_t = jnp.transpose(q_heads, (1, 0, 2))
-    k_t = jnp.transpose(k_heads, (1, 0, 2))
-    v_t = jnp.transpose(v_heads, (1, 0, 2))
-
     if scale is None:
         scale = 1.0 / jnp.sqrt(head_dim)
-    attn_logits = jnp.einsum("hqd,hkd->hqk", q_t, k_t) * scale
+
+    # Calculate attention logits using (T, H, K) layout
+    # q_heads: [num_tokens, num_heads, head_dim]
+    # k_heads: [cache_size, num_heads, head_dim]
+    attn_logits = jnp.einsum("qhd,khd->qhk", q_heads, k_heads) * scale
     neg_inf = jnp.asarray(jnp.finfo(attn_logits.dtype).min, attn_logits.dtype)
     is_valid = loc > 0
-    attn_logits = jnp.where(is_valid[jnp.newaxis, jnp.newaxis, :], attn_logits, neg_inf)
+    # Broadcast is_valid from [cache_size] to [1, 1, cache_size]
+    attn_logits = jnp.where(is_valid[None, None, :], attn_logits, neg_inf)
 
-    # ** NEW: Apply XAI temperature scaling if specified **
+    # ** Apply XAI temperature scaling if specified **
     if xai_temperature_len is not None and xai_temperature_len > 0:
         query_len = q_heads.shape[0]
 
@@ -255,24 +270,42 @@ def forward_attention(
         temp_factor = log_pos * xai_scale
         regulator = jnp.where(q_positions > xai_temperature_len, temp_factor, 1.0)
 
-        # Broadcast regulator from [num_tokens] to [1, num_tokens, 1] to scale weights
-        attn_logits = attn_logits * regulator[None, :, None]
+        # Broadcast regulator from [num_tokens] to [num_tokens, 1, 1] to scale weights
+        attn_logits = attn_logits * regulator[:, None, None]
 
     # Apply appropriate masking
     if mode == ForwardMode.EXTEND:
         attn_logits = _apply_extend_mask(
-            attn_logits, seq_lengths, extend_prefix_lens, extend_seq_lens, is_causal
+            attn_logits,
+            seq_lengths,
+            extend_prefix_lens,
+            extend_seq_lens,
+            is_causal,
+            sliding_window_size,
         )
     else:
-        attn_logits = _apply_decode_mask(attn_logits, seq_lengths)
+        attn_logits = _apply_decode_mask(attn_logits, seq_lengths, sliding_window_size)
 
-    # Softmax
-    attn_logits = attn_logits - jnp.max(attn_logits, axis=-1, keepdims=True)
-    attn_weights = jax.nn.softmax(attn_logits, axis=-1)
+    # Softmax (with optional attention sink)
+    max_logit = jnp.max(attn_logits, axis=-1, keepdims=True)
+    attn_logits = attn_logits - max_logit
+    exp_logits = jnp.exp(attn_logits)
+    sum_exp = jnp.sum(exp_logits, axis=-1, keepdims=True)
 
-    attn_output = jnp.matmul(attn_weights, v_t)
-    attn_output = jnp.transpose(attn_output, (1, 0, 2))
-    return attn_output.reshape(num_tokens, hidden_size)
+    if attention_sink is not None:
+        # attention_sink: [num_heads] — acts as a phantom token in the softmax denominator.
+        # Broadcast sink from [num_heads] to [1, num_heads, 1] to match max_logit [T, H, 1]
+        sink_term = jnp.exp(attention_sink[None, :, None] - max_logit)
+        sum_exp = sum_exp + sink_term
+
+    attn_weights = exp_logits / sum_exp
+
+    # attn_output: [num_tokens, num_heads, v_head_dim]
+    attn_output = jnp.einsum("qhk,khd->qhd", attn_weights, v_heads)
+
+    # Use v_head_dim from V (may differ from head_dim for split K/V models)
+    v_head_dim = v_heads.shape[-1]
+    return attn_output.reshape(num_tokens, num_heads * v_head_dim)
 
 
 def _apply_extend_mask(
@@ -281,12 +314,13 @@ def _apply_extend_mask(
     extend_prefix_lens: jax.Array,
     extend_seq_lens: jax.Array,
     is_causal: bool = True,
+    sliding_window_size: int | None = None,
 ):
     """
-    Applies a block-diagonal and optionally a causal mask in a unified,
+    Applies a block-diagonal and optionally a causal/SWA mask in a unified,
     efficient way, correctly handling padding.
     """
-    _, query_len, key_len = attn_weights.shape
+    query_len, _, key_len = attn_weights.shape
 
     # --- Create validity masks to handle padding ---
     q_valid_mask = jnp.arange(query_len) < jnp.sum(extend_seq_lens)
@@ -305,8 +339,8 @@ def _apply_extend_mask(
     # --- 2. Create block-diagonal mask ---
     final_mask = q_batch_ids[:, None] == k_batch_ids[None, :]
 
-    # --- 3. Optionally add causal mask ---
-    if is_causal:
+    # --- 3. Optionally add causal/SWA mask ---
+    if is_causal or sliding_window_size is not None:
         q_starts_per_pos = q_starts[q_batch_ids]
         q_relative_positions = jnp.arange(query_len, dtype=jnp.int32) - q_starts_per_pos
         prefix_lens_per_pos = extend_prefix_lens[q_batch_ids]
@@ -315,21 +349,31 @@ def _apply_extend_mask(
         k_starts_per_pos = k_starts[k_batch_ids]
         k_relative_positions = jnp.arange(key_len, dtype=jnp.int32) - k_starts_per_pos
 
-        causal_mask = q_actual_positions[:, None] >= k_relative_positions[None, :]
-        final_mask = final_mask & causal_mask
+        if is_causal:
+            causal_mask = q_actual_positions[:, None] >= k_relative_positions[None, :]
+            final_mask = final_mask & causal_mask
+
+        if sliding_window_size is not None:
+            swa_mask = (
+                q_actual_positions[:, None] - k_relative_positions[None, :] < sliding_window_size
+            )
+            final_mask = final_mask & swa_mask
 
     # --- 4. Apply the final combined mask ---
     # Combine with validity masks to handle padding
     final_mask = final_mask & q_valid_mask[:, None] & k_valid_mask[None, :]
 
     mask_value = jnp.finfo(attn_weights.dtype).min
-    final_mask = final_mask[None, :, :]
+    # Broadcast from [T, K] to [T, 1, K] to match attn_weights [T, H, K]
+    final_mask = final_mask[:, None, :]
     return jnp.where(final_mask, attn_weights, mask_value)
 
 
-def _apply_decode_mask(attn_weights: jax.Array, seq_lengths: jax.Array):
-    """Create a sequence mask that ensures tokens only attend within their sequence."""
-    _, query_len, key_len = attn_weights.shape
+def _apply_decode_mask(
+    attn_weights: jax.Array, seq_lengths: jax.Array, sliding_window_size: int | None = None
+):
+    """Create a sequence mask that ensures tokens only attend within their sequence and window."""
+    query_len, _, key_len = attn_weights.shape
     num_seqs = len(seq_lengths)
 
     def create_decode_sequence_mask():
@@ -337,9 +381,19 @@ def _apply_decode_mask(attn_weights: jax.Array, seq_lengths: jax.Array):
         seq_starts = jnp.cumsum(jnp.concatenate([jnp.array([0]), seq_lengths[:-1]]))
         seq_ends = seq_starts + seq_lengths
         all_positions = jnp.arange(total_prefix_len)
+
+        # Sequence isolation mask
         seq_mask = (all_positions[None, :] >= seq_starts[:, None]) & (
             all_positions[None, :] < seq_ends[:, None]
         )
+
+        if sliding_window_size is not None:
+            # SWA mask: only attend to last W tokens
+            # Current token is at position seq_lengths[i] (which is prefix_len + 1)
+            # Actually, seq_lengths[i] here is the length of the sequence in the cache
+            swa_mask = all_positions[None, :] >= (seq_ends[:, None] - sliding_window_size)
+            seq_mask = seq_mask & swa_mask
+
         return seq_mask
 
     per_sequence_mask = create_decode_sequence_mask()
@@ -347,5 +401,6 @@ def _apply_decode_mask(attn_weights: jax.Array, seq_lengths: jax.Array):
     final_mask = final_mask.at[:num_seqs, :].set(per_sequence_mask)
 
     mask_value = jnp.finfo(attn_weights.dtype).min
-    final_mask = final_mask[None, :, :]
+    # Broadcast from [T, K] to [T, 1, K] to match attn_weights [T, H, K]
+    final_mask = final_mask[:, None, :]
     return jnp.where(final_mask, attn_weights, mask_value)

--- a/python/sgl_jax/srt/layers/attention/native_backend.py
+++ b/python/sgl_jax/srt/layers/attention/native_backend.py
@@ -109,7 +109,6 @@ class NativeAttention(AttentionBackend):
             xai_temperature_len=xai_temp_len,
             attention_sink=attention_sink,
             sliding_window_size=layer.sliding_window_size,
-            positions=forward_batch.positions,
         )
 
         # Return full fused KV buffer for this layer so that caller can persist it outside JIT
@@ -129,12 +128,15 @@ class NativeAttention(AttentionBackend):
         The 5D fused buffer is persisted outside JIT. The 3D k/v views are
         used by forward_attention for the actual attention computation.
         """
-        is_decode = forward_batch.forward_mode == ForwardMode.DECODE
-
         if is_tpu_runtime():
-            token_to_kv_pool.set_kv_buffer(
-                layer_id, forward_batch.out_cache_loc, k, v, is_decode=is_decode
-            )
+            if forward_batch.forward_mode.is_extend():
+                token_to_kv_pool.set_kv_buffer(
+                    layer_id, forward_batch.out_cache_loc, k, v, is_decode=False
+                )
+            else:
+                token_to_kv_pool.set_kv_buffer(
+                    layer_id, forward_batch.out_cache_loc, k, v, is_decode=True
+                )
             fused_5d = token_to_kv_pool.get_fused_kv_buffer(layer_id)
         else:
             fused_5d = token_to_kv_pool.set_kv_buffer_legacy(
@@ -180,7 +182,6 @@ def forward_attention(
     xai_temperature_len: float | None = None,
     attention_sink: jax.Array | None = None,
     sliding_window_size: int | None = None,
-    positions: jax.Array | None = None,
 ):
     """
     Forward pass using native JAX implementation with block-diagonal attention.
@@ -197,10 +198,8 @@ def forward_attention(
         num_heads: number of query heads
         num_kv_heads: number of key/value heads
         scale: scale for the attention weights
-        seq_mask: boolean mask of shape [batch_size, total_prefix_len]
         xai_temperature_len: length of the xai temperature
         sliding_window_size: sliding window size for attention
-        positions: absolute positions of the tokens [total_tokens]
 
     Returns:
         Output tensor of shape[batch_size, hidden_size]
@@ -241,13 +240,10 @@ def forward_attention(
     if scale is None:
         scale = 1.0 / jnp.sqrt(head_dim)
 
-    # Calculate attention logits using (T, H, K) layout
-    # q_heads: [num_tokens, num_heads, head_dim]
-    # k_heads: [cache_size, num_heads, head_dim]
+    # Attention logits using (T, H, K) layout — no transpose needed
     attn_logits = jnp.einsum("qhd,khd->qhk", q_heads, k_heads) * scale
     neg_inf = jnp.asarray(jnp.finfo(attn_logits.dtype).min, attn_logits.dtype)
     is_valid = loc > 0
-    # Broadcast is_valid from [cache_size] to [1, 1, cache_size]
     attn_logits = jnp.where(is_valid[None, None, :], attn_logits, neg_inf)
 
     # ** Apply XAI temperature scaling if specified **
@@ -270,7 +266,7 @@ def forward_attention(
         temp_factor = log_pos * xai_scale
         regulator = jnp.where(q_positions > xai_temperature_len, temp_factor, 1.0)
 
-        # Broadcast regulator from [num_tokens] to [num_tokens, 1, 1] to scale weights
+        # Broadcast regulator from [num_tokens] to [num_tokens, 1, 1]
         attn_logits = attn_logits * regulator[:, None, None]
 
     # Apply appropriate masking
@@ -294,13 +290,12 @@ def forward_attention(
 
     if attention_sink is not None:
         # attention_sink: [num_heads] — acts as a phantom token in the softmax denominator.
-        # Broadcast sink from [num_heads] to [1, num_heads, 1] to match max_logit [T, H, 1]
+        # Broadcast sink from [num_heads] to [1, num_heads, 1] to match (T, H, K) layout
         sink_term = jnp.exp(attention_sink[None, :, None] - max_logit)
         sum_exp = sum_exp + sink_term
 
     attn_weights = exp_logits / sum_exp
 
-    # attn_output: [num_tokens, num_heads, v_head_dim]
     attn_output = jnp.einsum("qhk,khd->qhd", attn_weights, v_heads)
 
     # Use v_head_dim from V (may differ from head_dim for split K/V models)
@@ -364,7 +359,6 @@ def _apply_extend_mask(
     final_mask = final_mask & q_valid_mask[:, None] & k_valid_mask[None, :]
 
     mask_value = jnp.finfo(attn_weights.dtype).min
-    # Broadcast from [T, K] to [T, 1, K] to match attn_weights [T, H, K]
     final_mask = final_mask[:, None, :]
     return jnp.where(final_mask, attn_weights, mask_value)
 
@@ -389,8 +383,6 @@ def _apply_decode_mask(
 
         if sliding_window_size is not None:
             # SWA mask: only attend to last W tokens
-            # Current token is at position seq_lengths[i] (which is prefix_len + 1)
-            # Actually, seq_lengths[i] here is the length of the sequence in the cache
             swa_mask = all_positions[None, :] >= (seq_ends[:, None] - sliding_window_size)
             seq_mask = seq_mask & swa_mask
 
@@ -401,6 +393,5 @@ def _apply_decode_mask(
     final_mask = final_mask.at[:num_seqs, :].set(per_sequence_mask)
 
     mask_value = jnp.finfo(attn_weights.dtype).min
-    # Broadcast from [T, K] to [T, 1, K] to match attn_weights [T, H, K]
     final_mask = final_mask[:, None, :]
     return jnp.where(final_mask, attn_weights, mask_value)

--- a/python/sgl_jax/srt/layers/attention/native_backend.py
+++ b/python/sgl_jax/srt/layers/attention/native_backend.py
@@ -66,7 +66,6 @@ class NativeAttention(AttentionBackend):
             q, k, v: Input tensors of shape [total_tokens, hidden_size]
             forward_batch: ForwardBatch object containing seq_lens and batch_size
             is_causal: Whether to apply causal masking
-            **kwargs: Optional keyword arguments, e.g. attention_sink for sink bias.
         Returns:
             Tuple of (output tensor of shape [total_tokens, hidden_size], kv_fused 5D)
         """
@@ -199,6 +198,7 @@ def forward_attention(
         num_kv_heads: number of key/value heads
         scale: scale for the attention weights
         xai_temperature_len: length of the xai temperature
+        attention_sink: per-head bias for phantom attention sink token
         sliding_window_size: sliding window size for attention
 
     Returns:
@@ -207,8 +207,8 @@ def forward_attention(
 
     cache_size = k_cache.shape[0]
     safe_loc = jnp.where(loc > 0, loc, cache_size)
-    k_heads = k_cache.at[safe_loc].get(out_sharding=kv_sharding, mode="fill", fill_value=0)
-    v_heads = v_cache.at[safe_loc].get(out_sharding=kv_sharding, mode="fill", fill_value=0)
+    k_cache = k_cache.at[safe_loc].get(out_sharding=kv_sharding, mode="fill", fill_value=0)
+    v_cache = v_cache.at[safe_loc].get(out_sharding=kv_sharding, mode="fill", fill_value=0)
 
     # Handle both 2D and 3D input formats for q
     if len(q.shape) == 2:
@@ -220,7 +220,12 @@ def forward_attention(
         # Already in multi-head format: [num_tokens, num_heads, head_dim]
         num_tokens, num_heads_input, head_dim = q.shape
         assert num_heads_input == num_heads, f"Expected {num_heads} heads, got {num_heads_input}"
+        hidden_size = num_heads * head_dim  # Calculate hidden_size for proper reshaping
         q_heads = q
+
+    # KV cache from get_kv_buffer is already in multi-head format: [cache_size, num_kv_heads, head_dim]
+    k_heads = k_cache
+    v_heads = v_cache
 
     # Pad Q to match K cache head_dim if KV pool was 128-aligned (e.g. 192 -> 256)
     k_cache_head_dim = k_heads.shape[-1]
@@ -229,6 +234,9 @@ def forward_attention(
         q_heads = jnp.pad(q_heads, ((0, 0), (0, 0), (0, pad_size)))
         head_dim = k_cache_head_dim
 
+    # Transpose for efficient matrix operations
+    # q: shape of (num_heads, num_tokens, head_dim)
+    # k, v: shape of (total_prefix_len, num_heads, head_dim)
     if num_kv_heads != num_heads:
         # For GQA attention, we need to copy k and v heads to match the number of query heads
         num_copies = num_heads // num_kv_heads
@@ -237,14 +245,17 @@ def forward_attention(
         k_heads = jnp.repeat(k_heads, num_copies, axis=1, out_sharding=kv_sharding)
         v_heads = jnp.repeat(v_heads, num_copies, axis=1, out_sharding=kv_sharding)
 
+    # Transpose for matmul: [num_heads, num_tokens, head_dim]
+    q_t = jnp.transpose(q_heads, (1, 0, 2))
+    k_t = jnp.transpose(k_heads, (1, 0, 2))
+    v_t = jnp.transpose(v_heads, (1, 0, 2))
+
     if scale is None:
         scale = 1.0 / jnp.sqrt(head_dim)
-
-    # Attention logits using (T, H, K) layout — no transpose needed
-    attn_logits = jnp.einsum("qhd,khd->qhk", q_heads, k_heads) * scale
+    attn_logits = jnp.einsum("hqd,hkd->hqk", q_t, k_t) * scale
     neg_inf = jnp.asarray(jnp.finfo(attn_logits.dtype).min, attn_logits.dtype)
     is_valid = loc > 0
-    attn_logits = jnp.where(is_valid[None, None, :], attn_logits, neg_inf)
+    attn_logits = jnp.where(is_valid[jnp.newaxis, jnp.newaxis, :], attn_logits, neg_inf)
 
     # ** Apply XAI temperature scaling if specified **
     if xai_temperature_len is not None and xai_temperature_len > 0:
@@ -266,17 +277,13 @@ def forward_attention(
         temp_factor = log_pos * xai_scale
         regulator = jnp.where(q_positions > xai_temperature_len, temp_factor, 1.0)
 
-        # Broadcast regulator from [num_tokens] to [num_tokens, 1, 1]
-        attn_logits = attn_logits * regulator[:, None, None]
+        # Broadcast regulator from [num_tokens] to [1, num_tokens, 1] to scale weights
+        attn_logits = attn_logits * regulator[None, :, None]
 
     # Apply appropriate masking
     if mode == ForwardMode.EXTEND:
         attn_logits = _apply_extend_mask(
-            attn_logits,
-            seq_lengths,
-            extend_prefix_lens,
-            extend_seq_lens,
-            is_causal,
+            attn_logits, seq_lengths, extend_prefix_lens, extend_seq_lens, is_causal,
             sliding_window_size,
         )
     else:
@@ -290,13 +297,14 @@ def forward_attention(
 
     if attention_sink is not None:
         # attention_sink: [num_heads] — acts as a phantom token in the softmax denominator.
-        # Broadcast sink from [num_heads] to [1, num_heads, 1] to match (T, H, K) layout
-        sink_term = jnp.exp(attention_sink[None, :, None] - max_logit)
+        # Broadcast sink from [num_heads] to [num_heads, 1, 1] to match (H, Q, K) layout
+        sink_term = jnp.exp(attention_sink[:, None, None] - max_logit)
         sum_exp = sum_exp + sink_term
 
     attn_weights = exp_logits / sum_exp
 
-    attn_output = jnp.einsum("qhk,khd->qhd", attn_weights, v_heads)
+    attn_output = jnp.matmul(attn_weights, v_t)
+    attn_output = jnp.transpose(attn_output, (1, 0, 2))
 
     # Use v_head_dim from V (may differ from head_dim for split K/V models)
     v_head_dim = v_heads.shape[-1]
@@ -315,7 +323,7 @@ def _apply_extend_mask(
     Applies a block-diagonal and optionally a causal/SWA mask in a unified,
     efficient way, correctly handling padding.
     """
-    query_len, _, key_len = attn_weights.shape
+    _, query_len, key_len = attn_weights.shape
 
     # --- Create validity masks to handle padding ---
     q_valid_mask = jnp.arange(query_len) < jnp.sum(extend_seq_lens)
@@ -359,7 +367,7 @@ def _apply_extend_mask(
     final_mask = final_mask & q_valid_mask[:, None] & k_valid_mask[None, :]
 
     mask_value = jnp.finfo(attn_weights.dtype).min
-    final_mask = final_mask[:, None, :]
+    final_mask = final_mask[None, :, :]
     return jnp.where(final_mask, attn_weights, mask_value)
 
 
@@ -367,7 +375,7 @@ def _apply_decode_mask(
     attn_weights: jax.Array, seq_lengths: jax.Array, sliding_window_size: int | None = None
 ):
     """Create a sequence mask that ensures tokens only attend within their sequence and window."""
-    query_len, _, key_len = attn_weights.shape
+    _, query_len, key_len = attn_weights.shape
     num_seqs = len(seq_lengths)
 
     def create_decode_sequence_mask():
@@ -375,14 +383,11 @@ def _apply_decode_mask(
         seq_starts = jnp.cumsum(jnp.concatenate([jnp.array([0]), seq_lengths[:-1]]))
         seq_ends = seq_starts + seq_lengths
         all_positions = jnp.arange(total_prefix_len)
-
-        # Sequence isolation mask
         seq_mask = (all_positions[None, :] >= seq_starts[:, None]) & (
             all_positions[None, :] < seq_ends[:, None]
         )
 
         if sliding_window_size is not None:
-            # SWA mask: only attend to last W tokens
             swa_mask = all_positions[None, :] >= (seq_ends[:, None] - sliding_window_size)
             seq_mask = seq_mask & swa_mask
 
@@ -393,5 +398,5 @@ def _apply_decode_mask(
     final_mask = final_mask.at[:num_seqs, :].set(per_sequence_mask)
 
     mask_value = jnp.finfo(attn_weights.dtype).min
-    final_mask = final_mask[:, None, :]
+    final_mask = final_mask[None, :, :]
     return jnp.where(final_mask, attn_weights, mask_value)

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -757,13 +757,12 @@ class ScheduleBatch:
         free_slots = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, req.swa_evicted_seqlen : new_evicted
         ]
-        # Count actual SWA slots that will be freed (those with active mapping)
-        num_swa_freed = self.token_to_kv_pool_allocator.count_swa_mapped(free_slots)
         self.token_to_kv_pool_allocator.free_swa(free_slots)
-        # Notify cache layer: these slots were protected (node is locked),
-        # so adjust swa_protected_size_ to prevent bookkeeping leak.
-        if num_swa_freed > 0 and isinstance(self.tree_cache, SWARadixCache):
-            self.tree_cache.adjust_swa_protected_size(-num_swa_freed)
+        # NOTE: We intentionally do NOT adjust the tree cache's evictable/protected
+        # counters here.  _swa_eff_len (used by inc_lock_ref / dec_lock_ref /
+        # _insert_helper / evict) already reads the live SWA mapping state, so the
+        # counters are naturally correct when tokens enter or leave the tree.
+        # Trying to adjust here causes double-accounting.
         req.swa_evicted_seqlen = new_evicted
 
     def maybe_evict_swa(self, sliding_window_size=None):

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -683,14 +683,6 @@ class SWARadixCache(BasePrefixCache):
         """Adjust swa_protected_size_ by delta (can be negative)."""
         self.swa_protected_size_ += delta
 
-    def notify_swa_mapping_freed(self, num_freed: int):
-        """No-op: _evict_swa frees SWA mappings, but tree cache counters don't
-        need adjustment because _swa_eff_len (used by inc/dec_lock_ref, insert,
-        evict) already reads the live mapping state.  Any adjustment here
-        would cause double-accounting.
-        """
-        pass
-
     def all_values_flatten(self) -> jnp.Array:
         values = []
 

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -28,7 +28,6 @@ logger = logging.getLogger(__name__)
 
 
 class TreeNode:
-
     counter = 0
     swa_uuid_counter = 1
 
@@ -683,6 +682,14 @@ class SWARadixCache(BasePrefixCache):
     def adjust_swa_protected_size(self, delta: int):
         """Adjust swa_protected_size_ by delta (can be negative)."""
         self.swa_protected_size_ += delta
+
+    def notify_swa_mapping_freed(self, num_freed: int):
+        """No-op: _evict_swa frees SWA mappings, but tree cache counters don't
+        need adjustment because _swa_eff_len (used by inc/dec_lock_ref, insert,
+        evict) already reads the live mapping state.  Any adjustment here
+        would cause double-accounting.
+        """
+        pass
 
     def all_values_flatten(self) -> jnp.Array:
         values = []

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -600,7 +600,6 @@ class ModelRunner(BaseModelRunner):
                 self.num_kv_heads,
                 self.model_config.head_dim,
                 page_size=self.page_size,
-                v_head_dim=getattr(self.model_config, "v_head_dim", None),
                 mesh=self.mesh,
             )
         else:

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -600,7 +600,6 @@ class ModelRunner(BaseModelRunner):
                 self.num_kv_heads,
                 self.model_config.head_dim,
                 page_size=self.page_size,
-                attention_sink=getattr(self.model_config, "attention_sink", 0),
                 v_head_dim=getattr(self.model_config, "v_head_dim", None),
                 mesh=self.mesh,
             )

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -515,6 +515,12 @@ class ModelRunner(BaseModelRunner):
 
         # Create KV cache pool
         if self.is_hybrid:
+            # Compute SWA KV head count (may differ from full attention heads)
+            swa_num_kv_heads = getattr(self.model_config.hf_config, "swa_num_key_value_heads", None)
+            if swa_num_kv_heads is not None:
+                swa_head_num = max(swa_num_kv_heads, self.tp_size)
+            else:
+                swa_head_num = None
             self.token_to_kv_pool = SWAKVPool(
                 size=self.full_max_total_num_tokens,
                 size_swa=self.swa_max_total_num_tokens,
@@ -524,6 +530,7 @@ class ModelRunner(BaseModelRunner):
                 head_num=self.model_config.get_total_num_kv_heads_with_replication(self.tp_size),
                 head_dim=(self.model_config.head_dim + 127) // 128 * 128,
                 page_size=self.page_size,
+                swa_head_num=swa_head_num,
                 mesh=self.mesh,
             )
         else:
@@ -593,6 +600,8 @@ class ModelRunner(BaseModelRunner):
                 self.num_kv_heads,
                 self.model_config.head_dim,
                 page_size=self.page_size,
+                attention_sink=getattr(self.model_config, "attention_sink", 0),
+                v_head_dim=getattr(self.model_config, "v_head_dim", None),
                 mesh=self.mesh,
             )
         else:

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -19,7 +19,7 @@ from sgl_jax.srt.layers.moe import EPMoE, GateLogit, TopK, create_moe_weights_ma
 from sgl_jax.srt.layers.radix_attention import RadixAttention
 from sgl_jax.srt.mem_cache.memory_pool import KVCache
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
-from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping, replicate_kv_heads
 
 logger = logging.getLogger(__name__)
 
@@ -734,64 +734,15 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         self._ensure_kv_head_replication()
 
     def _ensure_kv_head_replication(self):
-        """Replicate KV heads for TP alignment when the weight loader missed them.
-
-        When v_head_dim != head_dim, the weight loader's _apply_kv_head_padding
-        can't pattern-match v_proj shapes. We fix that here by checking actual
-        weight dims against expected (tp-aligned) dims and replicating as needed.
-        """
-        from jax.sharding import NamedSharding
-        from jax.sharding import PartitionSpec as P
-
-        for layer_idx, layer in enumerate(self.model.layers):
-            attn = layer.self_attn
-            # attn.k_head_num is already the TP-aligned count (e.g., 16)
-            target_kv_heads = attn.k_head_num
-
-            for proj_name, head_dim in [
-                ("k_proj", attn.head_dim),
-                ("v_proj", attn.v_head_dim),
-            ]:
-                proj = getattr(attn, proj_name)
-                w = proj.weight.value
-                expected_size = target_kv_heads * head_dim
-                actual_size = w.shape[1]
-
-                if actual_size == expected_size:
-                    continue
-
-                # Weight is smaller than expected — needs replication
-                if actual_size > 0 and expected_size % actual_size == 0:
-                    num_replicas = expected_size // actual_size
-                    orig_kv = actual_size // head_dim
-
-                    logger.info(
-                        "KV head replication: layer %d %s %d→%d heads (%d→%d)",
-                        layer_idx,
-                        proj_name,
-                        orig_kv,
-                        target_kv_heads,
-                        actual_size,
-                        expected_size,
-                    )
-
-                    w_full = jax.device_put(w, NamedSharding(self.mesh, P()))
-                    w_3d = w_full.reshape(w.shape[0], orig_kv, head_dim)
-                    w_rep = jnp.repeat(w_3d, num_replicas, axis=1)
-                    w_new = w_rep.reshape(w.shape[0], expected_size)
-                    w_new = jax.device_put(w_new, NamedSharding(self.mesh, P(None, "tensor")))
-
-                    with jax.set_mesh(self.mesh):
-                        new_linear = LinearBase(
-                            input_size=w.shape[0],
-                            output_size=expected_size,
-                            kernel_axes=proj.kernel_axes,
-                            use_bias=False,
-                            params_dtype=jnp.bfloat16,
-                            mesh=self.mesh,
-                        )
-                        new_linear.weight = nnx.Param(w_new)
-                    setattr(attn, proj_name, new_linear)
+        """Replicate KV heads for TP alignment when the weight loader missed them."""
+        attn = self.model.layers[0].self_attn
+        replicate_kv_heads(
+            layers=self.model.layers,
+            mesh=self.mesh,
+            head_dim=attn.head_dim,
+            v_head_dim=attn.v_head_dim,
+            target_kv_heads=attn.k_head_num,
+        )
 
     def _create_weight_mappings(self) -> dict:
         mappings = {

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -471,10 +471,6 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         self.logits_processor = LogitsProcessor(config.vocab_size, mesh=self.mesh)
 
     def load_weights(self, model_config: ModelConfig):
-        # Pre-warm GCSFuse cache: sequential read of large safetensors files
-        # dramatically speeds up subsequent random-access MoE expert loading.
-        self._warmup_safetensors_cache(model_config)
-
         loader = WeightLoader(
             model=self,
             model_config=model_config,
@@ -490,48 +486,6 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         # Q/K head_dim padding (192→256) is handled by the kernel internally.
         if self._is_static_quant:
             self._dequantize_fp8_to_bf16()
-
-    @staticmethod
-    def _warmup_safetensors_cache(model_config: ModelConfig):
-        """Pre-read safetensors files to warm GCSFuse cache.
-
-        GCSFuse random reads are ~400ms per tensor (cold) vs ~1ms (warm).
-        Sequential bulk read fills the cache so MoE loading uses warm reads.
-        """
-        import glob
-        import os
-        from concurrent.futures import ThreadPoolExecutor
-
-        model_path = model_config.model_path
-        st_files = sorted(glob.glob(os.path.join(model_path, "*.safetensors")))
-        if not st_files:
-            return
-
-        total_size = sum(os.path.getsize(f) for f in st_files)
-        logger.info(
-            "Warming up GCSFuse cache: %d files, %.1f GB",
-            len(st_files),
-            total_size / 1024**3,
-        )
-
-        def _read_file(path):
-            """Read file sequentially to populate GCSFuse cache."""
-            buf = bytearray(4 * 1024 * 1024)  # 4MB buffer
-            with open(path, "rb") as f:
-                while f.readinto(buf):
-                    pass
-
-        import time
-
-        t0 = time.time()
-        with ThreadPoolExecutor(max_workers=min(8, len(st_files))) as executor:
-            list(executor.map(_read_file, st_files))
-        t1 = time.time()
-        logger.info(
-            "GCSFuse cache warm-up done: %.1fs (%.0f MB/s)",
-            t1 - t0,
-            total_size / 1024**2 / (t1 - t0) if t1 > t0 else 0,
-        )
 
     def _is_quant_ignored(self, hf_path: str) -> bool:
         """Check if a HuggingFace weight path is in the quantization ignored_layers list."""

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -19,7 +19,11 @@ from sgl_jax.srt.layers.moe import EPMoE, GateLogit, TopK, create_moe_weights_ma
 from sgl_jax.srt.layers.radix_attention import RadixAttention
 from sgl_jax.srt.mem_cache.memory_pool import KVCache
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
-from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping, replicate_kv_heads
+from sgl_jax.srt.utils.weight_utils import (
+    WeightLoader,
+    WeightMapping,
+    replicate_kv_heads,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -11,6 +11,7 @@ from transformers import PretrainedConfig
 
 from sgl_jax.srt.configs.model_config import ModelConfig
 from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead, get_rope
+from sgl_jax.srt.layers.fused_moe import FusedEPMoE
 from sgl_jax.srt.layers.layernorm import RMSNorm
 from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
@@ -94,28 +95,50 @@ class MiMoV2Moe(nnx.Module):
         else:
             self.correction_bias = None
 
+        self.moe_backend = getattr(config, "moe_backend", "epmoe")
+        self.use_fused = self.moe_backend == "fused"
+
         self.topk = TopK(
             topk=num_experts_per_tok,
             renormalize=getattr(config, "norm_topk_prob", True),
         )
 
-        self.experts = EPMoE(
-            hidden_size=config.hidden_size,
-            num_experts=num_experts,
-            num_experts_per_tok=num_experts_per_tok,
-            intermediate_dim=moe_intermediate_size,
-            mesh=mesh,
-            ep_size=config.ep_size,
-            weight_dtype=dtype,
-            dtype=dtype,
-            layer_id=layer_id,
-            quantization_config=getattr(config, "quantization_config", None),
-        )
+        if self.use_fused:
+            self.experts = FusedEPMoE(
+                hidden_size=config.hidden_size,
+                num_experts=num_experts,
+                num_experts_per_tok=num_experts_per_tok,
+                intermediate_dim=moe_intermediate_size,
+                mesh=mesh,
+                activation="silu",
+                ep_size=config.ep_size,
+                weight_dtype=dtype,
+                dtype=dtype,
+                layer_id=layer_id,
+                renormalize_topk_logits=getattr(config, "norm_topk_prob", True),
+                quantization_config=getattr(config, "quantization_config", None),
+            )
+        else:
+            self.experts = EPMoE(
+                hidden_size=config.hidden_size,
+                num_experts=num_experts,
+                num_experts_per_tok=num_experts_per_tok,
+                intermediate_dim=moe_intermediate_size,
+                mesh=mesh,
+                ep_size=config.ep_size,
+                weight_dtype=dtype,
+                dtype=dtype,
+                layer_id=layer_id,
+                quantization_config=getattr(config, "quantization_config", None),
+            )
 
     def __call__(self, hidden_states: jax.Array, forward_batch: ForwardBatch):
         router_logits = self.moe_gate(hidden_states)
         correction_bias = self.correction_bias.value if self.correction_bias is not None else None
         topk_weights, topk_ids = self.topk(router_logits, correction_bias=correction_bias)
+        if self.use_fused:
+            token_valid_mask = forward_batch.get_token_valid_mask(hidden_states.shape[0])
+            topk_ids = jnp.where(token_valid_mask[:, None], topk_ids, -1)
         mlp_output = self.experts(hidden_states, topk_weights, topk_ids)
         return mlp_output, topk_ids
 
@@ -900,6 +923,7 @@ class MiMoV2FlashForCausalLM(nnx.Module):
 
             if is_fp8:
                 augmented = {}
+                use_model_mesh_for_scale = moe_backend == "fused"
                 for key, mapping in moe_mappings.items():
                     augmented[key] = mapping
                     # Add scale mapping for each MoE group
@@ -908,10 +932,15 @@ class MiMoV2FlashForCausalLM(nnx.Module):
                     scale_key = key + "_scale"
                     scale_target = target_param + "_scale"
                     scale_srcs = [p.replace(".weight", ".weight_scale_inv") for p in src_paths]
+                    scale_sharding = (
+                        (("data", "tensor"), None, None)
+                        if use_model_mesh_for_scale
+                        else ("expert", None, None)
+                    )
                     augmented[scale_key] = WeightMapping(
                         target_path=[scale_target] + scale_srcs,
-                        sharding=("expert", None, None),
-                        transpose=False,
+                        sharding=scale_sharding,
+                        transpose=use_model_mesh_for_scale,
                         concat_axis=mapping.concat_axis,
                         physical_to_logical_map=mapping.physical_to_logical_map,
                     )

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -1,0 +1,1008 @@
+"""MiMo-V2-Flash model implementation for SGLang-JAX."""
+
+import logging
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax.sharding import PartitionSpec as P
+from transformers import PretrainedConfig
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead, get_rope
+from sgl_jax.srt.layers.layernorm import RMSNorm
+from sgl_jax.srt.layers.linear import LinearBase
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
+from sgl_jax.srt.layers.moe import EPMoE, GateLogit, TopK, create_moe_weights_mapping
+from sgl_jax.srt.layers.radix_attention import RadixAttention
+from sgl_jax.srt.mem_cache.memory_pool import KVCache
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+
+logger = logging.getLogger(__name__)
+
+
+class MiMoV2MLP(nnx.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        mesh: jax.sharding.Mesh,
+        layer_id: int = 0,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ) -> None:
+        self.layer_id = layer_id
+        self.gate_proj = LinearBase(
+            input_size=hidden_size,
+            output_size=intermediate_size,
+            kernel_axes=(None, "tensor"),
+            use_bias=False,
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+        self.up_proj = LinearBase(
+            input_size=hidden_size,
+            output_size=intermediate_size,
+            kernel_axes=(None, "tensor"),
+            use_bias=False,
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+        self.down_proj = LinearBase(
+            input_size=intermediate_size,
+            output_size=hidden_size,
+            kernel_axes=("tensor", None),
+            use_bias=False,
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+        self.act_fn = jax.nn.silu
+
+    def __call__(self, hidden_states: jax.Array):
+        a1, _ = self.gate_proj(hidden_states)
+        a2, _ = self.up_proj(hidden_states)
+        intermediate_parallel = a2 * self.act_fn(a1)
+        output, _ = self.down_proj(intermediate_parallel)
+        return output
+
+
+class MiMoV2Moe(nnx.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        layer_id: int,
+        mesh: jax.sharding.Mesh = None,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.layer_id = layer_id
+
+        num_experts = getattr(config, "n_routed_experts", getattr(config, "num_experts", 8))
+        num_experts_per_tok = getattr(config, "num_experts_per_tok", 2)
+        moe_intermediate_size = getattr(config, "moe_intermediate_size", config.intermediate_size)
+
+        self.moe_gate = GateLogit(
+            input_size=config.hidden_size,
+            num_experts=num_experts,
+            weight_dtype=dtype,
+            score_func=getattr(config, "scoring_func", "softmax"),
+        )
+
+        self.topk_method = getattr(config, "topk_method", "greedy")
+        if self.topk_method == "noaux_tc":
+            self.correction_bias = nnx.Param(jnp.zeros(num_experts, dtype=jnp.float32))
+        else:
+            self.correction_bias = None
+
+        self.topk = TopK(
+            topk=num_experts_per_tok,
+            renormalize=getattr(config, "norm_topk_prob", True),
+        )
+
+        self.experts = EPMoE(
+            hidden_size=config.hidden_size,
+            num_experts=num_experts,
+            num_experts_per_tok=num_experts_per_tok,
+            intermediate_dim=moe_intermediate_size,
+            mesh=mesh,
+            ep_size=config.ep_size,
+            weight_dtype=dtype,
+            dtype=dtype,
+            layer_id=layer_id,
+            quantization_config=getattr(config, "quantization_config", None),
+        )
+
+    def __call__(self, hidden_states: jax.Array, forward_batch: ForwardBatch):
+        router_logits = self.moe_gate(hidden_states)
+        correction_bias = self.correction_bias.value if self.correction_bias is not None else None
+        topk_weights, topk_ids = self.topk(router_logits, correction_bias=correction_bias)
+        mlp_output = self.experts(hidden_states, topk_weights, topk_ids)
+        return mlp_output, topk_ids
+
+
+class MiMoV2Attention(nnx.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        max_position_embeddings: int,
+        mesh: jax.sharding.Mesh,
+        rope_theta: float = 1000000,
+        rope_scaling: dict[str, Any] | None = None,
+        head_dim: int | None = None,
+        v_head_dim: int | None = None,
+        sliding_window_size: int | None = None,
+        attention_sink_bias: bool = False,
+        partial_rotary_factor: float = 1.0,
+        layer_id: int = 0,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.layer_id = layer_id
+        self.hidden_size = hidden_size
+        self.head_dim = head_dim or hidden_size // num_heads
+        self.q_head_num = num_heads
+        self.k_head_num = num_kv_heads
+        self.v_head_dim = v_head_dim if v_head_dim is not None else self.head_dim
+
+        self.q_size = num_heads * self.head_dim
+        self.k_size = num_kv_heads * self.head_dim
+        self.v_size = num_kv_heads * self.v_head_dim
+        self.scaling = self.head_dim**-0.5
+
+        self.q_proj = LinearBase(
+            input_size=hidden_size,
+            output_size=self.q_size,
+            kernel_axes=(None, "tensor"),
+            use_bias=False,
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+        self.k_proj = LinearBase(
+            input_size=hidden_size,
+            output_size=self.k_size,
+            kernel_axes=(None, "tensor"),
+            use_bias=False,
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+        self.v_proj = LinearBase(
+            input_size=hidden_size,
+            output_size=self.v_size,
+            kernel_axes=(None, "tensor"),
+            use_bias=False,
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+        self.o_proj = LinearBase(
+            input_size=num_heads * self.v_head_dim,
+            output_size=hidden_size,
+            kernel_axes=("tensor", None),
+            use_bias=False,
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=max_position_embeddings,
+            base=rope_theta,
+            is_neox_style=True,
+            rope_scaling=rope_scaling,
+            dtype=dtype,
+            partial_rotary_factor=partial_rotary_factor,
+        )
+
+        self.attn = RadixAttention(
+            num_heads=num_heads,
+            head_dim=self.head_dim,
+            scaling=self.scaling,
+            num_kv_heads=num_kv_heads,
+            layer_id=layer_id,
+            v_head_dim=self.v_head_dim,
+            sliding_window_size=sliding_window_size,
+        )
+
+        self.attention_sink_bias = (
+            nnx.Param(
+                jax.random.normal(
+                    jax.random.PRNGKey(0),
+                    (self.q_head_num,),
+                    dtype=dtype,
+                    out_sharding=P("tensor"),
+                )
+            )
+            if attention_sink_bias
+            else None
+        )
+
+    def __call__(
+        self,
+        positions: jax.Array,
+        hidden_states: jax.Array,
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: KVCache,
+    ) -> tuple[jax.Array, jax.Array]:
+        q, _ = self.q_proj(hidden_states)
+        k, _ = self.k_proj(hidden_states)
+        v, _ = self.v_proj(hidden_states)
+
+        q = q.reshape(-1, self.q_head_num, self.head_dim)
+        k = k.reshape(-1, k.shape[-1] // self.head_dim, self.head_dim)
+        v = v.reshape(-1, v.shape[-1] // self.v_head_dim, self.v_head_dim)
+        # Pad V to match Q/K head_dim for fused KV cache
+        if self.v_head_dim != self.head_dim:
+            pad_size = self.head_dim - self.v_head_dim
+            v = jnp.pad(v, ((0, 0), (0, 0), (0, pad_size)))
+
+        q, k = self.rotary_emb(positions, q, k)
+
+        attn_output, kv_fused = self.attn(
+            q,
+            k,
+            v,
+            forward_batch,
+            token_to_kv_pool,
+            attention_sink=self.attention_sink_bias.value if self.attention_sink_bias else None,
+        )
+
+        # V was padded to head_dim for fused KV cache; slice back to v_head_dim
+        # so o_proj receives the correct input size.
+        if self.head_dim != self.v_head_dim:
+            expected_v_head_dim = self.q_head_num * self.v_head_dim
+            if attn_output.shape[-1] != expected_v_head_dim:
+                padded_head_dim = attn_output.shape[-1] // self.q_head_num
+                attn_output = attn_output.reshape(-1, self.q_head_num, padded_head_dim)
+                attn_output = attn_output[..., : self.v_head_dim]
+                attn_output = attn_output.reshape(-1, expected_v_head_dim)
+
+        output, _ = self.o_proj(attn_output)
+        return output, kv_fused
+
+
+class MiMoV2DecoderLayer(nnx.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        layer_id: int = 0,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.layer_id = layer_id
+        self.hidden_size = config.hidden_size
+        rope_theta = getattr(config, "rope_theta", 1000000)
+        rope_scaling = getattr(config, "rope_scaling", None)
+        max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
+
+        if self._is_swa_layer(config):
+            self.self_attn = MiMoV2Attention(
+                hidden_size=config.hidden_size,
+                num_heads=config.swa_num_attention_heads,
+                num_kv_heads=config.swa_num_key_value_heads,
+                max_position_embeddings=max_position_embeddings,
+                rope_theta=getattr(config, "swa_rope_theta", rope_theta),
+                rope_scaling=rope_scaling,
+                head_dim=config.swa_head_dim,
+                v_head_dim=getattr(config, "swa_v_head_dim", None),
+                sliding_window_size=getattr(config, "sliding_window_size", None),
+                attention_sink_bias=getattr(config, "add_swa_attention_sink_bias", False),
+                partial_rotary_factor=getattr(config, "partial_rotary_factor", 1.0),
+                layer_id=layer_id,
+                dtype=dtype,
+                mesh=mesh,
+            )
+        else:
+            self.self_attn = MiMoV2Attention(
+                hidden_size=config.hidden_size,
+                num_heads=config.num_attention_heads,
+                num_kv_heads=config.num_key_value_heads,
+                max_position_embeddings=max_position_embeddings,
+                rope_theta=rope_theta,
+                rope_scaling=rope_scaling,
+                head_dim=config.head_dim,
+                v_head_dim=getattr(config, "v_head_dim", None),
+                sliding_window_size=0,  # full attention
+                attention_sink_bias=getattr(config, "add_full_attention_sink_bias", False),
+                partial_rotary_factor=getattr(config, "partial_rotary_factor", 1.0),
+                layer_id=layer_id,
+                dtype=dtype,
+                mesh=mesh,
+            )
+
+        self.is_layer_sparse = self._is_moe_layer(config)
+
+        if self.is_layer_sparse:
+            self.mlp = MiMoV2Moe(
+                config=config,
+                layer_id=layer_id,
+                mesh=mesh,
+                dtype=dtype,
+            )
+        else:
+            self.mlp = MiMoV2MLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                layer_id=layer_id,
+                dtype=dtype,
+                mesh=mesh,
+            )
+
+        self.input_layernorm = RMSNorm(
+            config.hidden_size,
+            epsilon=config.layernorm_epsilon,
+            param_dtype=dtype,
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size,
+            epsilon=config.layernorm_epsilon,
+            param_dtype=dtype,
+        )
+
+    def __call__(
+        self,
+        positions: jax.Array,
+        hidden_states: jax.Array,
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: KVCache,
+        residual: jax.Array | None = None,
+    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array | None]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states += residual
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+
+        hidden_states, kv_fused = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+            forward_batch=forward_batch,
+            token_to_kv_pool=token_to_kv_pool,
+        )
+
+        hidden_states += residual
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+
+        if self.is_layer_sparse:
+            mlp_output, topk_ids = self.mlp(hidden_states, forward_batch)
+        else:
+            mlp_output = self.mlp(hidden_states)
+            topk_ids = None
+
+        hidden_states = mlp_output
+        return hidden_states, residual, kv_fused, topk_ids
+
+    def _is_moe_layer(self, config) -> bool:
+        moe_freq = getattr(config, "moe_layer_freq", None)
+        return (
+            moe_freq is not None
+            and 0 <= self.layer_id < len(moe_freq)
+            and not isinstance(moe_freq, int)
+            and moe_freq[self.layer_id]
+        )
+
+    def _is_swa_layer(self, config) -> bool:
+        hybrid = getattr(config, "hybrid_layer_pattern", None)
+        if hybrid is not None and 0 <= self.layer_id < len(hybrid):
+            return hybrid[self.layer_id] == 1
+        return False
+
+
+class MiMoV2Model(nnx.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.config = config
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = Embed(
+            num_embeddings=config.vocab_size,
+            features=config.hidden_size,
+            dtype=dtype,
+            kernel_axes=("tensor", None),
+            param_dtype=dtype,
+            mesh=mesh,
+        )
+
+        self.layers = nnx.data(
+            [
+                MiMoV2DecoderLayer(config=config, layer_id=i, dtype=dtype, mesh=mesh)
+                for i in range(config.num_hidden_layers)
+            ]
+        )
+
+        self.norm = RMSNorm(
+            config.hidden_size,
+            epsilon=config.layernorm_epsilon,
+            param_dtype=dtype,
+        )
+
+    def __call__(self, forward_batch: ForwardBatch, token_to_kv_pool: KVCache):
+        residual = None
+        hidden_states = self.embed_tokens(forward_batch.input_ids)
+
+        layers_kv_fused = []
+        layers_topk_ids = []
+
+        for i, layer in enumerate(self.layers):
+            hidden_states, residual, kv_fused, topk_ids = layer(
+                forward_batch.positions,
+                hidden_states,
+                forward_batch,
+                token_to_kv_pool,
+                residual,
+            )
+            layers_kv_fused.append(kv_fused)
+            layers_topk_ids.append(topk_ids)
+
+        if residual is not None:
+            hidden_states += residual
+
+        hidden_states = self.norm(hidden_states)
+        return hidden_states, layers_kv_fused, layers_topk_ids
+
+
+class MiMoV2FlashForCausalLM(nnx.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.mesh = mesh
+        self.config = config
+        self.dtype = dtype
+        self.model = MiMoV2Model(config, dtype=self.dtype, mesh=mesh)
+
+        if not getattr(self.config, "tie_word_embeddings", True):
+            self.lm_head = ParallelLMHead(
+                config.vocab_size,
+                config.hidden_size,
+                dtype=self.dtype,
+                param_dtype=self.dtype,
+                kernel_axes=("tensor", None),
+            )
+
+        self.logits_processor = LogitsProcessor(config.vocab_size, mesh=self.mesh)
+
+    def load_weights(self, model_config: ModelConfig):
+        # Pre-warm GCSFuse cache: sequential read of large safetensors files
+        # dramatically speeds up subsequent random-access MoE expert loading.
+        self._warmup_safetensors_cache(model_config)
+
+        loader = WeightLoader(
+            model=self,
+            model_config=model_config,
+            mesh=self.mesh,
+            dtype=self.dtype,
+        )
+        self._quant_config = model_config.quantization_config
+        weight_mappings = self._create_weight_mappings()
+        loader.load_weights_from_safetensors(weight_mappings)
+        logger.info("MiMoV2Flash weights loaded successfully!")
+
+        # Post-load: dequantize FP8 attention + layer-0 MLP to bf16.
+        # Q/K head_dim padding (192→256) is handled by the kernel internally.
+        if self._is_static_quant:
+            self._dequantize_fp8_to_bf16()
+
+    @staticmethod
+    def _warmup_safetensors_cache(model_config: ModelConfig):
+        """Pre-read safetensors files to warm GCSFuse cache.
+
+        GCSFuse random reads are ~400ms per tensor (cold) vs ~1ms (warm).
+        Sequential bulk read fills the cache so MoE loading uses warm reads.
+        """
+        import glob
+        import os
+        from concurrent.futures import ThreadPoolExecutor
+
+        model_path = model_config.model_path
+        st_files = sorted(glob.glob(os.path.join(model_path, "*.safetensors")))
+        if not st_files:
+            return
+
+        total_size = sum(os.path.getsize(f) for f in st_files)
+        logger.info(
+            "Warming up GCSFuse cache: %d files, %.1f GB",
+            len(st_files),
+            total_size / 1024**3,
+        )
+
+        def _read_file(path):
+            """Read file sequentially to populate GCSFuse cache."""
+            buf = bytearray(4 * 1024 * 1024)  # 4MB buffer
+            with open(path, "rb") as f:
+                while f.readinto(buf):
+                    pass
+
+        import time
+
+        t0 = time.time()
+        with ThreadPoolExecutor(max_workers=min(8, len(st_files))) as executor:
+            list(executor.map(_read_file, st_files))
+        t1 = time.time()
+        logger.info(
+            "GCSFuse cache warm-up done: %.1fs (%.0f MB/s)",
+            t1 - t0,
+            total_size / 1024**2 / (t1 - t0) if t1 > t0 else 0,
+        )
+
+    def _is_quant_ignored(self, hf_path: str) -> bool:
+        """Check if a HuggingFace weight path is in the quantization ignored_layers list."""
+        quant_cfg = getattr(self, "_quant_config", None)
+        if quant_cfg is None or not quant_cfg.is_static_checkpoint:
+            return True  # not quantized at all
+        ignored = quant_cfg.ignored_layers or []
+        return any(hf_path == ig or hf_path.endswith(f".{ig}") for ig in ignored)
+
+    @property
+    def _is_static_quant(self) -> bool:
+        quant_cfg = getattr(self, "_quant_config", None)
+        return quant_cfg is not None and quant_cfg.is_static_checkpoint
+
+    # ------------------------------------------------------------------
+    # Post-load transforms: dequantize FP8 → BF16, pad head dims
+    # ------------------------------------------------------------------
+
+    def _dequantize_quantized_linear(self, ql, head_dim=None) -> LinearBase:
+        """Dequantize a single QuantizedLinear to bf16 LinearBase.
+
+        weight_q may be in HF layout [out, in] or model layout [in, out]
+        depending on the transpose flag used during loading.
+        weight_scale is in kernel-ready 3D layout [in_blocks, 1, out_dim].
+
+        Handles kv_head_padding: when weight_q has been replicated along the
+        output axis (e.g. 4 kv_heads → 16 for TP), the scale only covers the
+        original (unreplicated) output dimension.  We extract one copy of the
+        original heads, dequantize, then re-replicate in bf16.
+
+        Args:
+            head_dim: If set, enables per-head block quant handling. Required
+                when head_dim % block_size != 0 (e.g., head_dim=192 with
+                block_size=128), as the HF checkpoint uses per-head block
+                boundaries instead of uniform blocks.
+        """
+        weight_q = ql.weight_q.value
+        weight_scale = ql.weight_scale.value
+        logger.info(
+            "Dequant debug: weight_q.shape=%s weight_scale.shape=%s kernel_axes=%s head_dim=%s",
+            weight_q.shape,
+            weight_scale.shape,
+            ql.kernel_axes,
+            head_dim,
+        )
+
+        if weight_scale.ndim == 3:
+            weight_bf16 = self._block_dequant(weight_q, weight_scale, head_dim=head_dim)
+        elif weight_scale.ndim == 2:
+            # 2D block-quant scale: (out_blocks, in_blocks) in HF layout.
+            # Expand to 3D kernel-ready (in_blocks, 1, out_dim) then reuse _block_dequant.
+            from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import (
+                expand_block_scale,
+            )
+
+            # Determine out_dim: weight_q is (in, out) model layout or (out, in) HF layout.
+            _, in_blocks = weight_scale.shape
+            out_dim = weight_q.shape[1] if weight_q.shape[0] % in_blocks == 0 else weight_q.shape[0]
+            block_size_out = 128
+            scale_3d = expand_block_scale(weight_scale, out_dim, block_size_out)
+            weight_bf16 = self._block_dequant(weight_q, scale_3d, head_dim=head_dim)
+        elif weight_scale.ndim == 1:
+            out_dim = weight_scale.shape[0]
+            if weight_q.shape[1] == out_dim:
+                weight_bf16 = (weight_q.astype(jnp.float32) * weight_scale[None, :]).astype(
+                    jnp.bfloat16
+                )
+            else:
+                weight_bf16 = (
+                    jnp.transpose(weight_q).astype(jnp.float32) * weight_scale[None, :]
+                ).astype(jnp.bfloat16)
+        else:
+            raise ValueError(f"Unexpected weight_scale ndim={weight_scale.ndim}")
+
+        # weight_bf16 is now in model layout [in, out]
+        in_features, out_features = weight_bf16.shape
+
+        with jax.set_mesh(ql.mesh):
+            new_linear = LinearBase(
+                input_size=in_features,
+                output_size=out_features,
+                kernel_axes=ql.kernel_axes,
+                use_bias=ql.bias is not None,
+                params_dtype=jnp.bfloat16,
+                mesh=ql.mesh,
+            )
+            new_linear.weight = nnx.Param(weight_bf16)
+            if ql.bias is not None:
+                new_linear.bias = nnx.Param(ql.bias.value.astype(jnp.bfloat16))
+        return new_linear
+
+    def _block_dequant(
+        self, weight_q: jax.Array, weight_scale: jax.Array, head_dim: int | None = None
+    ) -> jax.Array:
+        """Block-dequantize weight_q using 3D scale [in_blocks, 1, out_dim].
+
+        Returns bf16 weight in model layout [in_dim, out_dim].
+        Handles kv_head_padding where weight_q is larger than scale coverage
+        by tiling the scale to match.
+
+        Args:
+            head_dim: If set, enables per-head block quant handling when scale
+                out_dim doesn't match weight dims. The scale is re-indexed using
+                per-head block boundaries instead of uniform block mapping.
+        """
+        import math
+
+        in_blocks = weight_scale.shape[0]
+        out_dim = weight_scale.shape[2]
+
+        # Detect layout and kv-padding
+        dim0, dim1 = weight_q.shape
+
+        if dim1 == out_dim:
+            # Model layout [in, out], no kv-padding
+            pass
+        elif dim0 == out_dim:
+            # HF layout [out, in] — transpose to model layout
+            weight_q = jnp.transpose(weight_q)
+        elif head_dim is not None and dim1 != out_dim and dim0 != out_dim:
+            # Per-head block quant: scale was expanded for wrong n_out.
+            # Determine layout: in_dim must be divisible by in_blocks.
+            if dim0 % in_blocks == 0:
+                actual_out = dim1  # model layout [in, out]
+            else:
+                weight_q = jnp.transpose(weight_q)
+                actual_out = dim0  # was HF layout [out, in]
+
+            # Re-index scale using per-head block boundaries.
+            # The wrongly-expanded scale has uniform block mapping (ch // 128),
+            # but we need per-head mapping where each head's blocks are independent.
+            block_size = out_dim // (out_dim // 128) if out_dim >= 128 else 128
+            block_size = 128  # from weight_block_size config
+            blocks_per_head = math.ceil(head_dim / block_size)
+            num_heads = actual_out // head_dim
+
+            # Build gather index: for each output channel, find the corresponding
+            # channel in the uniformly-expanded scale that has the correct block's value.
+            gather_idx = jnp.array(
+                [
+                    ((j // head_dim) * blocks_per_head + (j % head_dim) // block_size) * block_size
+                    for j in range(actual_out)
+                ]
+            )
+            weight_scale = weight_scale[:, :, gather_idx]  # (in_blocks, 1, actual_out)
+            out_dim = actual_out
+
+            logger.info(
+                "Per-head block dequant: %d heads × head_dim=%d, %d blocks/head, "
+                "remapped scale to (%s)",
+                num_heads,
+                head_dim,
+                blocks_per_head,
+                weight_scale.shape,
+            )
+        elif dim1 > out_dim and dim1 % out_dim == 0:
+            # Model layout [in, kv_padded_out] — tile scale to match
+            kv_replicas = dim1 // out_dim
+            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
+            out_dim = dim1
+            logger.info(
+                "Detected kv_head_padding: tiling scale %dx to match %d out channels",
+                kv_replicas,
+                out_dim,
+            )
+        elif dim0 > out_dim and dim0 % out_dim == 0:
+            # HF layout [kv_padded_out, in] — transpose and tile scale
+            kv_replicas = dim0 // out_dim
+            weight_q = jnp.transpose(weight_q)
+            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
+            out_dim = weight_q.shape[1]
+            logger.info(
+                "Detected kv_head_padding (HF layout): tiling scale %dx to match %d out channels",
+                kv_replicas,
+                out_dim,
+            )
+        else:
+            raise ValueError(
+                f"Cannot match weight_q shape {weight_q.shape} with scale out_dim={out_dim}"
+            )
+
+        # weight_q is now [in_dim, out_dim] in model layout
+        in_dim = weight_q.shape[0]
+        block_k = in_dim // in_blocks
+        weight_f = weight_q.astype(jnp.float32).reshape(in_blocks, block_k, out_dim)
+        weight_bf16 = (weight_f * weight_scale).reshape(in_dim, out_dim).astype(jnp.bfloat16)
+
+        return weight_bf16
+
+    def _dequantize_fp8_to_bf16(self):
+        """Dequantize FP8 QuantizedLinear → bf16 LinearBase.
+
+        Targets:
+        - All layers: self_attn.q_proj, k_proj, v_proj
+        - Layer 0: mlp.gate_proj, up_proj, down_proj (dense MLP only)
+        """
+        from sgl_jax.srt.layers.linear import QuantizedLinear
+
+        for layer_idx, layer in enumerate(self.model.layers):
+            attn = layer.self_attn
+            for proj_name in ("q_proj", "k_proj", "v_proj"):
+                proj = getattr(attn, proj_name)
+                if isinstance(proj, QuantizedLinear):
+                    # Pass head_dim for per-head block quant handling.
+                    # Q/K use head_dim, V uses v_head_dim.
+                    hd = attn.v_head_dim if proj_name == "v_proj" else attn.head_dim
+                    setattr(attn, proj_name, self._dequantize_quantized_linear(proj, head_dim=hd))
+                    logger.info("Dequantized layer %d %s → bf16", layer_idx, proj_name)
+
+            # Layer 0 dense MLP
+            if layer_idx == 0 and not layer.is_layer_sparse:
+                for proj_name in ("gate_proj", "up_proj", "down_proj"):
+                    proj = getattr(layer.mlp, proj_name)
+                    if isinstance(proj, QuantizedLinear):
+                        setattr(layer.mlp, proj_name, self._dequantize_quantized_linear(proj))
+                        logger.info("Dequantized layer 0 MLP %s → bf16", proj_name)
+
+        logger.info("FP8 → BF16 dequantization complete.")
+
+        # Fix kv_head_padding for v_proj: the weight loader's _apply_kv_head_padding
+        # uses head_dim (Q/K) for shape matching, so it misses v_proj when
+        # v_head_dim != head_dim. Replicate kv_heads here.
+        self._ensure_kv_head_replication()
+
+    def _ensure_kv_head_replication(self):
+        """Replicate KV heads for TP alignment when the weight loader missed them.
+
+        When v_head_dim != head_dim, the weight loader's _apply_kv_head_padding
+        can't pattern-match v_proj shapes. We fix that here by checking actual
+        weight dims against expected (tp-aligned) dims and replicating as needed.
+        """
+        from jax.sharding import NamedSharding
+        from jax.sharding import PartitionSpec as P
+
+        for layer_idx, layer in enumerate(self.model.layers):
+            attn = layer.self_attn
+            # attn.k_head_num is already the TP-aligned count (e.g., 16)
+            target_kv_heads = attn.k_head_num
+
+            for proj_name, head_dim in [
+                ("k_proj", attn.head_dim),
+                ("v_proj", attn.v_head_dim),
+            ]:
+                proj = getattr(attn, proj_name)
+                w = proj.weight.value
+                expected_size = target_kv_heads * head_dim
+                actual_size = w.shape[1]
+
+                if actual_size == expected_size:
+                    continue
+
+                # Weight is smaller than expected — needs replication
+                if actual_size > 0 and expected_size % actual_size == 0:
+                    num_replicas = expected_size // actual_size
+                    orig_kv = actual_size // head_dim
+
+                    logger.info(
+                        "KV head replication: layer %d %s %d→%d heads (%d→%d)",
+                        layer_idx,
+                        proj_name,
+                        orig_kv,
+                        target_kv_heads,
+                        actual_size,
+                        expected_size,
+                    )
+
+                    w_full = jax.device_put(w, NamedSharding(self.mesh, P()))
+                    w_3d = w_full.reshape(w.shape[0], orig_kv, head_dim)
+                    w_rep = jnp.repeat(w_3d, num_replicas, axis=1)
+                    w_new = w_rep.reshape(w.shape[0], expected_size)
+                    w_new = jax.device_put(w_new, NamedSharding(self.mesh, P(None, "tensor")))
+
+                    with jax.set_mesh(self.mesh):
+                        new_linear = LinearBase(
+                            input_size=w.shape[0],
+                            output_size=expected_size,
+                            kernel_axes=proj.kernel_axes,
+                            use_bias=False,
+                            params_dtype=jnp.bfloat16,
+                            mesh=self.mesh,
+                        )
+                        new_linear.weight = nnx.Param(w_new)
+                    setattr(attn, proj_name, new_linear)
+
+    def _create_weight_mappings(self) -> dict:
+        mappings = {
+            "model.embed_tokens.weight": WeightMapping(
+                target_path="model.embed_tokens.embedding",
+                sharding=("tensor", None),
+                transpose=False,
+            ),
+            "model.norm.weight": WeightMapping(
+                target_path="model.norm.scale",
+                sharding=(None,),
+                transpose=False,
+            ),
+        }
+
+        if not getattr(self.config, "tie_word_embeddings", True):
+            mappings["lm_head.weight"] = WeightMapping(
+                target_path="lm_head.embedding",
+                sharding=("tensor", None),
+                transpose=False,
+            )
+
+        for layer_idx in range(self.config.num_hidden_layers):
+            mappings.update(self._create_layer_mappings(layer_idx))
+
+        return mappings
+
+    def _create_layer_mappings(self, layer_idx: int) -> dict:
+        prefix = f"model.layers.{layer_idx}"
+        target = prefix
+
+        mappings = {}
+        is_fp8 = self._is_static_quant
+
+        # Attention projections
+        for proj, sharding, kv_pad, hd_pad in [
+            ("q_proj", (None, "tensor"), False, True),
+            ("k_proj", (None, "tensor"), not is_fp8, True),
+            ("v_proj", (None, "tensor"), not is_fp8, False),
+            ("o_proj", ("tensor", None), False, True),
+        ]:
+            hf_key = f"{prefix}.self_attn.{proj}"
+            ignored = self._is_quant_ignored(hf_key)
+            weight_suffix = "weight" if (not is_fp8 or ignored) else "weight_q"
+
+            mappings[f"{hf_key}.weight"] = WeightMapping(
+                target_path=f"{target}.self_attn.{proj}.{weight_suffix}",
+                sharding=sharding,
+                transpose=True,
+                head_dim_padding=hd_pad,
+                kv_head_padding=kv_pad,
+            )
+
+            if is_fp8 and not ignored:
+                mappings[f"{hf_key}.weight_scale_inv"] = WeightMapping(
+                    target_path=f"{target}.self_attn.{proj}.weight_scale",
+                    sharding=(None, None),
+                    transpose=False,
+                )
+
+        # Attention sink bias
+        is_swa = (
+            hasattr(self.config, "hybrid_layer_pattern")
+            and 0 <= layer_idx < len(self.config.hybrid_layer_pattern)
+            and self.config.hybrid_layer_pattern[layer_idx] == 1
+        )
+        has_sink_bias = (is_swa and getattr(self.config, "add_swa_attention_sink_bias", False)) or (
+            not is_swa and getattr(self.config, "add_full_attention_sink_bias", False)
+        )
+        if has_sink_bias:
+            mappings[f"{prefix}.self_attn.attention_sink_bias"] = WeightMapping(
+                target_path=f"{target}.self_attn.attention_sink_bias",
+                sharding=("tensor",),
+                transpose=False,
+            )
+
+        # Layernorms
+        mappings[f"{prefix}.input_layernorm.weight"] = WeightMapping(
+            target_path=f"{target}.input_layernorm.scale",
+            sharding=(None,),
+            transpose=False,
+        )
+        mappings[f"{prefix}.post_attention_layernorm.weight"] = WeightMapping(
+            target_path=f"{target}.post_attention_layernorm.scale",
+            sharding=(None,),
+            transpose=False,
+        )
+
+        # MLP / MoE
+        is_sparse = (
+            hasattr(self.config, "moe_layer_freq")
+            and 0 <= layer_idx < len(self.config.moe_layer_freq)
+            and not isinstance(self.config.moe_layer_freq, int)
+            and self.config.moe_layer_freq[layer_idx]
+        )
+
+        if is_sparse:
+            # MoE gate
+            mappings[f"{prefix}.mlp.gate.weight"] = WeightMapping(
+                target_path=f"{target}.mlp.moe_gate.kernel",
+                sharding=(None, None),
+                transpose=True,
+            )
+
+            # Correction bias for noaux_tc
+            if getattr(self.config, "topk_method", "greedy") == "noaux_tc":
+                mappings[f"{prefix}.mlp.gate.e_score_correction_bias"] = WeightMapping(
+                    target_path=f"{target}.mlp.correction_bias",
+                    sharding=(None,),
+                    transpose=False,
+                )
+
+            # Expert weights — use standard create_moe_weights_mapping
+            num_experts = getattr(
+                self.config,
+                "n_routed_experts",
+                getattr(self.config, "num_experts", 8),
+            )
+            moe_backend = getattr(self.config, "moe_backend", "epmoe")
+
+            moe_mappings = create_moe_weights_mapping(
+                prefix=prefix,
+                target_prefix=target,
+                num_experts=num_experts,
+                moe_backend=moe_backend,
+                moe_path="mlp.experts",
+                source_expert_pattern="{i}",
+            )
+
+            if is_fp8:
+                augmented = {}
+                for key, mapping in moe_mappings.items():
+                    augmented[key] = mapping
+                    # Add scale mapping for each MoE group
+                    target_param = mapping.target_path[0]
+                    src_paths = mapping.target_path[1:]
+                    scale_key = key + "_scale"
+                    scale_target = target_param + "_scale"
+                    scale_srcs = [p.replace(".weight", ".weight_scale_inv") for p in src_paths]
+                    augmented[scale_key] = WeightMapping(
+                        target_path=[scale_target] + scale_srcs,
+                        sharding=("expert", None, None),
+                        transpose=False,
+                        concat_axis=mapping.concat_axis,
+                        physical_to_logical_map=mapping.physical_to_logical_map,
+                    )
+                moe_mappings = augmented
+
+            mappings.update(moe_mappings)
+        else:
+            # Dense MLP
+            for proj, sharding in [
+                ("gate_proj", (None, "tensor")),
+                ("up_proj", (None, "tensor")),
+                ("down_proj", ("tensor", None)),
+            ]:
+                hf_key = f"{prefix}.mlp.{proj}"
+                weight_suffix = "weight_q" if is_fp8 else "weight"
+                mappings[f"{hf_key}.weight"] = WeightMapping(
+                    target_path=f"{target}.mlp.{proj}.{weight_suffix}",
+                    sharding=sharding,
+                    transpose=True,
+                )
+                if is_fp8:
+                    mappings[f"{hf_key}.weight_scale_inv"] = WeightMapping(
+                        target_path=f"{target}.mlp.{proj}.weight_scale",
+                        sharding=(None, None),
+                        transpose=False,
+                    )
+
+        return mappings
+
+    def __call__(
+        self,
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: KVCache,
+        logits_metadata: LogitsMetadata,
+    ):
+        hidden_states, layers_kv_fused, layers_topk_ids = self.model(
+            forward_batch, token_to_kv_pool
+        )
+
+        if not getattr(self.config, "tie_word_embeddings", True):
+            output = self.logits_processor(hidden_states, self.lm_head, logits_metadata)
+        else:
+            output = self.logits_processor(hidden_states, self.model.embed_tokens, logits_metadata)
+
+        return output, layers_kv_fused, True, layers_topk_ids
+
+
+EntryClass = [MiMoV2FlashForCausalLM]

--- a/python/sgl_jax/srt/utils/quantization/quantization_utils.py
+++ b/python/sgl_jax/srt/utils/quantization/quantization_utils.py
@@ -141,6 +141,13 @@ def apply_linear_quantization(
 
     ignored_layers = quant_config.ignored_layers or []
 
+    # Normalize ignored layer patterns: convert HF dot-index (layers.0.) to
+    # bracket-index (layers[0].) since the model walk uses bracket notation.
+    normalized_ignored = []
+    for ig in ignored_layers:
+        normalized_ignored.append(re.sub(r"\.(\d+)\.", r"[\1].", ig))
+    ignored_layers = normalized_ignored
+
     def _find_matching_rule(path: str):
         """Find the first rule that matches the given module path."""
         for rule in compiled_rules:

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -1754,3 +1754,76 @@ class WeightLoader:
 
         layer_num = int(parts[2])
         return layer_num >= self.model_config.num_hidden_layers
+
+
+def replicate_kv_heads(
+    layers,
+    mesh: jax.sharding.Mesh,
+    head_dim: int,
+    v_head_dim: int,
+    target_kv_heads: int,
+):
+    """Replicate KV heads for TP alignment when the weight loader missed them.
+
+    When v_head_dim != head_dim, the weight loader's _apply_kv_head_padding
+    can't pattern-match v_proj shapes. This function fixes that by checking
+    actual weight dims against expected (tp-aligned) dims and replicating.
+
+    Args:
+        layers: List of decoder layers, each with self_attn containing k_proj/v_proj.
+        mesh: JAX mesh for sharding.
+        head_dim: K/Q head dimension.
+        v_head_dim: V head dimension (may differ from head_dim).
+        target_kv_heads: Target number of KV heads after TP alignment.
+    """
+    from jax.sharding import NamedSharding
+    from jax.sharding import PartitionSpec as P
+
+    from sgl_jax.srt.layers.linear import LinearBase
+
+    for layer_idx, layer in enumerate(layers):
+        attn = layer.self_attn
+
+        for proj_name, hd in [
+            ("k_proj", head_dim),
+            ("v_proj", v_head_dim),
+        ]:
+            proj = getattr(attn, proj_name)
+            w = proj.weight.value
+            expected_size = target_kv_heads * hd
+            actual_size = w.shape[1]
+
+            if actual_size == expected_size:
+                continue
+
+            if actual_size > 0 and expected_size % actual_size == 0:
+                num_replicas = expected_size // actual_size
+                orig_kv = actual_size // hd
+
+                logger.info(
+                    "KV head replication: layer %d %s %d→%d heads (%d→%d)",
+                    layer_idx,
+                    proj_name,
+                    orig_kv,
+                    target_kv_heads,
+                    actual_size,
+                    expected_size,
+                )
+
+                w_full = jax.device_put(w, NamedSharding(mesh, P()))
+                w_3d = w_full.reshape(w.shape[0], orig_kv, hd)
+                w_rep = jnp.repeat(w_3d, num_replicas, axis=1)
+                w_new = w_rep.reshape(w.shape[0], expected_size)
+                w_new = jax.device_put(w_new, NamedSharding(mesh, P(None, "tensor")))
+
+                with jax.set_mesh(mesh):
+                    new_linear = LinearBase(
+                        input_size=w.shape[0],
+                        output_size=expected_size,
+                        kernel_axes=proj.kernel_axes,
+                        use_bias=False,
+                        params_dtype=jnp.bfloat16,
+                        mesh=mesh,
+                    )
+                    new_linear.weight = nnx.Param(w_new)
+                setattr(attn, proj_name, new_linear)


### PR DESCRIPTION
## Summary

Add MiMo-V2-Flash model support for TPU v6e/v7x with 256-expert MoE, FP8 quantization, and hybrid attention (9 full-attention + 39 SWA layers).


### Key features

- **MiMo-V2-Flash model** (`mimo_v2_flash.py`, ~1017 lines): Full model implementation with split K/V head dimensions (q/k=192, v=128), sliding window attention, attention sink, and FP8 MoE
- **Split K/V head_dim support**: `v_head_dim` config parameter; FlashAttention and native backend handle `k_head_dim != v_head_dim`
- **Native backend enhancements**: Rewrote `forward_attention` with T-H-K einsum layout, Q padding for 128-aligned K cache, sliding window masking in both extend and decode, attention sink support in softmax
- **SWA bug fix**: Removed double-accounting in SWA eviction tracking that caused OOM under concurrency
- **Documentation**: `docs/basic_usage/mimo_v2_flash.md` with launch commands, config tips, and benchmark results

### Accuracy (GSM8K)

| Model | Dataset | Metric | Subset | Num | Score |
|:------|:--------|:-------|:-------|:----|:------|
| MiMo-V2-Flash | gsm8k | AverageAccuracy | main | 1319 | **0.9401** |

Evaluated on TPU v6e-16 (4 nodes) with `evalscope==0.17.1`, sampling params: `temperature=0.8, top_p=0.95, max_tokens=32768`.

### Throughput Benchmark

256 prompts, input=16384 tokens, output=1024 tokens, concurrency=64 on TPU v6e-16:
- 256/256 requests completed successfully (0 failures)
- No OOM crashes with SWA bug fix applied

## Reproduction

### Environment Setup

```bash
# Clone and install
git clone https://github.com/sgl-project/sglang-jax.git
cd sglang-jax/python && pip install -e .
```

### Launch Server

**Option A: Multi-node TPU v6e-16 (4 nodes, Fused MoE)**

```bash
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_server \
    --model-path XiaomiMiMo/MiMo-V2-Flash \
    --trust-remote-code \
    --tp-size 16 --ep-size 16 \
    --moe-backend fused \
    --nnodes 4 --node-rank $RANK \
    --dist-init-addr $MASTER_IP:30000 \
    --host 0.0.0.0 --port 30271 \
    --page-size 256 --context-length 262144 \
    --disable-radix-cache --chunked-prefill-size 2048 \
    --dtype bfloat16 --mem-fraction-static 0.95 \
    --swa-full-tokens-ratio 0.2 --skip-server-warmup \
    --max-running-requests 128 \
    --attention-backend fa
```

**Option B: Single-node TPU v7x-8 (Fused MoE)**

```bash
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_server \
    --model-path XiaomiMiMo/MiMo-V2-Flash \
    --trust-remote-code \
    --tp-size 8 --ep-size 8 \
    --moe-backend fused \
    --host 0.0.0.0 --port 30271 \
    --page-size 256 --context-length 262144 \
    --disable-radix-cache --chunked-prefill-size 4096 \
    --dtype bfloat16 --mem-fraction-static 0.95 \
    --swa-full-tokens-ratio 0.2 --skip-server-warmup \
    --max-running-requests 128 \
    --attention-backend fa
```

### Throughput Benchmark

```bash
uv run python -m sgl_jax.bench_serving \
    --backend sgl-jax \
    --dataset-name random \
    --num-prompts 256 \
    --random-input 16384 \
    --random-output 1024 \
    --max-concurrency 64 \
    --random-range-ratio 1 \
    --warmup-requests 0 \
    --tokenizer XiaomiMiMo/MiMo-V2-Flash
```

### Accuracy Evaluation (GSM8K)

```bash
pip install evalscope==0.17.1

evalscope eval \
    --model XiaomiMiMo/MiMo-V2-Flash \
    --api-url http://127.0.0.1:30271/v1/chat/completions \
    --api-key EMPTY \
    --eval-type service \
    --datasets gsm8k \
    --eval-batch-size 32 \
    --generation-config '{"temperature": 0.8, "top_p": 0.95, "max_tokens": 32768}'
```

## Test plan

- [x] GKE TPU v6e-16 (4 nodes) end-to-end deployment and serving
- [x] Throughput benchmark: 256 prompts × 16K input / 1K output, concurrency 64 — all passed
- [x] GSM8K accuracy evaluation: 94.01% (1319/1319 questions)
- [x] SWA eviction bug fix verified under high concurrency load

🤖 Generated with [Claude Code](https://claude.com/claude-code)