### PR TITLE
fix(swa): graceful abort instead of crash when decode OOM after retract

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -976,7 +976,9 @@ class ScheduleBatch:
         self._evict_tree_cache_if_needed(num_tokens)
         return self._is_available_size_sufficient(num_tokens)
 
-    def retract_decode(self, server_args: ServerArgs):
+    def retract_decode(
+        self, server_args: ServerArgs
+    ) -> tuple[list[Req], float, list[Req]]:
         """Retract the decoding requests when there is not enough memory."""
         sorted_indices = list(range(len(self.reqs)))
 
@@ -990,19 +992,11 @@ class ScheduleBatch:
 
         retracted_reqs = []
         first_iter = True
-        while (not self.check_decode_mem(selected_indices=sorted_indices)) or first_iter:
+        while first_iter or (
+            not self.check_decode_mem(selected_indices=sorted_indices)
+        ):
             if len(sorted_indices) == 1:
-                # Corner case: only one request left
-                if self.is_hybrid:
-                    full_available_size = self.token_to_kv_pool_allocator.full_available_size()
-                    swa_available_size = self.token_to_kv_pool_allocator.swa_available_size()
-                    assert (
-                        full_available_size > 0 and swa_available_size > 0
-                    ), f"No space left for only one request in SWA mode {full_available_size=}, {swa_available_size=}"
-                else:
-                    assert (
-                        self.token_to_kv_pool_allocator.available_size() > 0
-                    ), f"No space left for only one request, {self.token_to_kv_pool_allocator.available_size()=}"
+                # Keep at least one request in the loop; handle OOM below.
                 break
 
             first_iter = False
@@ -1011,11 +1005,26 @@ class ScheduleBatch:
             retracted_reqs.append(req)
             self.release_req(idx, len(sorted_indices), server_args)
 
-            if len(retracted_reqs) == 0:
-                # Corner case: only one request left
-                raise ValueError(
-                    "Failed to retract any request. No space left for only one request."
-                )
+        # If the last remaining request still can't fit, abort it gracefully
+        # instead of crashing the scheduler (follows upstream sglang).
+        reqs_to_abort: list[Req] = []
+        if len(sorted_indices) <= 1 and not self.check_decode_mem(
+            selected_indices=sorted_indices
+        ):
+            last_idx = sorted_indices.pop()
+            last_req = self.reqs[last_idx]
+            last_req.to_finish = FINISH_ABORT(
+                "Out of memory even after retracting all other requests "
+                "in the decode batch. Aborting the last request.",
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                "InternalServerError",
+            )
+            reqs_to_abort.append(last_req)
+            self.release_req(last_idx, 0, server_args)
+            logger.warning(
+                "retract_decode: aborted last request %s due to OOM",
+                last_req.rid,
+            )
 
         self.filter_batch(keep_indices=sorted_indices)
 
@@ -1025,10 +1034,10 @@ class ScheduleBatch:
 
         new_estimate_ratio = (
             total_decoded_tokens + global_config.retract_decode_steps * len(self.reqs)
-        ) / total_max_new_tokens
+        ) / (total_max_new_tokens + 1)  # +1 to avoid zero division when all reqs aborted
         new_estimate_ratio = min(1.0, new_estimate_ratio)
 
-        return retracted_reqs, new_estimate_ratio
+        return retracted_reqs, new_estimate_ratio, reqs_to_abort
 
     def release_req(self, idx: int, remaing_req_count: int, server_args: ServerArgs):
         req = self.reqs[idx]

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -976,9 +976,7 @@ class ScheduleBatch:
         self._evict_tree_cache_if_needed(num_tokens)
         return self._is_available_size_sufficient(num_tokens)
 
-    def retract_decode(
-        self, server_args: ServerArgs
-    ) -> tuple[list[Req], float, list[Req]]:
+    def retract_decode(self, server_args: ServerArgs) -> tuple[list[Req], float, list[Req]]:
         """Retract the decoding requests when there is not enough memory."""
         sorted_indices = list(range(len(self.reqs)))
 
@@ -992,9 +990,7 @@ class ScheduleBatch:
 
         retracted_reqs = []
         first_iter = True
-        while first_iter or (
-            not self.check_decode_mem(selected_indices=sorted_indices)
-        ):
+        while first_iter or (not self.check_decode_mem(selected_indices=sorted_indices)):
             if len(sorted_indices) == 1:
                 # Keep at least one request in the loop; handle OOM below.
                 break
@@ -1008,9 +1004,7 @@ class ScheduleBatch:
         # If the last remaining request still can't fit, abort it gracefully
         # instead of crashing the scheduler (follows upstream sglang).
         reqs_to_abort: list[Req] = []
-        if len(sorted_indices) <= 1 and not self.check_decode_mem(
-            selected_indices=sorted_indices
-        ):
+        if len(sorted_indices) <= 1 and not self.check_decode_mem(selected_indices=sorted_indices):
             last_idx = sorted_indices.pop()
             last_req = self.reqs[last_idx]
             last_req.to_finish = FINISH_ABORT(
@@ -1034,7 +1028,9 @@ class ScheduleBatch:
 
         new_estimate_ratio = (
             total_decoded_tokens + global_config.retract_decode_steps * len(self.reqs)
-        ) / (total_max_new_tokens + 1)  # +1 to avoid zero division when all reqs aborted
+        ) / (
+            total_max_new_tokens + 1
+        )  # +1 to avoid zero division when all reqs aborted
         new_estimate_ratio = min(1.0, new_estimate_ratio)
 
         return retracted_reqs, new_estimate_ratio, reqs_to_abort

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1298,13 +1298,24 @@ class Scheduler(
         ):
             old_ratio = self.new_token_ratio
 
-            retracted_reqs, new_token_ratio = batch.retract_decode(self.server_args)
+            retracted_reqs, new_token_ratio, reqs_to_abort = batch.retract_decode(
+                self.server_args
+            )
             num_retracted_reqs = len(retracted_reqs)
             self.new_token_ratio = new_token_ratio
 
+            # Send abort responses so clients get an error instead of a hung connection
+            for req in reqs_to_abort:
+                abort_out = AbortReq(rid=req.rid)
+                if self._comm_backend is not None:
+                    self._comm_backend.send_pyobj(abort_out)
+                else:
+                    self.send_to_tokenizer.send_pyobj(abort_out)
+
             logger.info(
-                "KV cache pool is full. Retract requests. #retracted_reqs: %d, #new_token_ratio: %.4f -> %.4f",
+                "KV cache pool is full. Retract requests. #retracted_reqs: %d, #aborted_reqs: %d, #new_token_ratio: %.4f -> %.4f",
                 num_retracted_reqs,
+                len(reqs_to_abort),
                 old_ratio,
                 self.new_token_ratio,
             )
@@ -1318,6 +1329,9 @@ class Scheduler(
 
         if batch.batch_size() < initial_bs:
             batch.batch_is_full = False
+
+        if batch.is_empty():
+            return batch
 
         # Update batch arrays
         batch.prepare_for_decode()

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1298,9 +1298,7 @@ class Scheduler(
         ):
             old_ratio = self.new_token_ratio
 
-            retracted_reqs, new_token_ratio, reqs_to_abort = batch.retract_decode(
-                self.server_args
-            )
+            retracted_reqs, new_token_ratio, reqs_to_abort = batch.retract_decode(self.server_args)
             num_retracted_reqs = len(retracted_reqs)
             self.new_token_ratio = new_token_ratio
 


### PR DESCRIPTION
## Problem
When decode KV cache is exhausted in SWA hybrid mode, the server crashes instead of gracefully degrading.

### Env
Running 16K benchmark on v6e-64 with `swa_full_tokens_ratio=0.2` and `page_size=256`. KV cache is split into two independent pools:
- **full pool**: 569,344 tokens (80%) for full attention layers
- **swa pool**: 113,664 tokens (20%) for sliding window attention layers

When many 16K sequences are decoding simultaneously, full pool usage approaches 1.0.

### Crash path

The scheduler calls `check_decode_mem` before each decode step. When memory is insufficient, it calls `retract_decode` to remove requests one by one (sorted by output length), freeing their KV cache until memory is sufficient.

The crash occurs in the **corner case where only 1 request remains but memory is still insufficient** — the old code hits an `assert` crash:

```python
if len(sorted_indices) == 1:
    if self.is_hybrid:
        assert (full_available_size > 0 and swa_available_size > 0), ...
    else:
        assert (self.token_to_kv_pool_allocator.available_size() > 0), ...
    break
```

In SWA hybrid mode with 16K sequences, a single request's KV footprint can be large enough that even after freeing all other requests, the next decode page allocation cannot be satisfied. The assert fails and the server exits.

Since the retract log message is printed **after** `retract_decode` returns (`scheduler.py`), and the assert throws inside the function, no retract messages appear in the server log — only the crash.

### Dead code

The old code also contained unreachable dead code: `if len(retracted_reqs) == 0` checked after `retracted_reqs.append(req)`, which can never be True.

## Fix

Following sglang's approach (`schedule_batch.py:2100-2133`), replace the crash with a graceful abort:

### `schedule_batch.py` — `retract_decode`

1. Remove `assert` crash — `break` out of the loop when 1 request remains
2. After the loop, re-check `check_decode_mem`. If still insufficient, set `FINISH_ABORT` on the last request, release its KV cache, and return it via a new `reqs_to_abort` list
3. Add zero-division guard: `total_max_new_tokens + 1` (needed because the batch can now become empty after abort — this was impossible before since the old code either kept the last request or crashed)
4. Remove unreachable dead code

### `scheduler.py` — `update_running_batch`

1. Handle `reqs_to_abort`: send `AbortReq` to the tokenizer so clients receive an HTTP 500 error response instead of a hung connection
2. Add `batch.is_empty()` guard to skip `prepare_for_decode` when all requests have been retracted/aborted

## Verification

- All 41 SWA unit tests pass
- Re-ran the same 16K benchmark on v6e-64 (256 prompts, input=16384, output=1024, concurrency=128): 256/256 requests completed successfully, server did not crash

## Test plan

- [x] SWA unit tests pass (`test_swa_allocator.py`)
- [x] 16K benchmark on v6e-64: 256/256 successful, no crash