### PR TITLE
feat: Allow sequence parallel and enable it for grok-2

### DIFF
--- a/python/sgl_jax/global_config.py
+++ b/python/sgl_jax/global_config.py
@@ -45,5 +45,10 @@ class GlobalConfig:
         self.enable_precache_with_tracing = True
         self.enable_parallel_encoding = True
 
+        # Control whether row parallel linear/MoE activation needs to be reduce-scattered.
+        # 128 is a conservative number. 8 is the minimum number in order to fully utilize
+        # VPU sub-lanes
+        self.tpu_scatter_min_local_size = int(os.environ.get("TPU_SCATTER_MIN_LOCAL_SIZE", 128))
+
 
 global_config = GlobalConfig()

--- a/python/sgl_jax/srt/kernels/quantized_matmul/kernel.py
+++ b/python/sgl_jax/srt/kernels/quantized_matmul/kernel.py
@@ -10,6 +10,7 @@ from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import (
     get_safe_blockwise_tuned_value,
     should_use_blockwise_kernel,
 )
+from sgl_jax.srt.utils.parallel_utils import should_scatter
 from sgl_jax.srt.utils.quantization.quantization_utils import quantize_tensor_simple
 
 
@@ -22,6 +23,7 @@ def xla_quantized_matmul_local(
     compute_dtype: jnp.dtype | None = None,
     weight_block_size: tuple[int, int] | None = None,
     activation_quant_dtype: jnp.dtype | None = None,
+    output_scatter_dimension: int | None = None,
 ) -> jax.Array:
     """
     Local quantized matmul for use inside shard_map.
@@ -124,6 +126,14 @@ def xla_quantized_matmul_local(
     out = out.astype(out_dtype)
     # Sum partial results across devices (single all-reduce)
     if reduce_axis is not None:
-        out = lax.psum(out, axis_name=reduce_axis)
+        mesh = jax.sharding.get_abstract_mesh()
+        if output_scatter_dimension is not None and should_scatter(
+            out.shape[output_scatter_dimension], mesh.shape[reduce_axis]
+        ):
+            out = lax.psum_scatter(
+                out, axis_name=reduce_axis, scatter_dimension=output_scatter_dimension, tiled=True
+            )
+        else:
+            out = lax.psum(out, axis_name=reduce_axis)
 
     return out

--- a/python/sgl_jax/srt/kernels/quantized_matmul/kernel.py
+++ b/python/sgl_jax/srt/kernels/quantized_matmul/kernel.py
@@ -10,7 +10,6 @@ from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import (
     get_safe_blockwise_tuned_value,
     should_use_blockwise_kernel,
 )
-from sgl_jax.srt.utils.parallel_utils import should_scatter
 from sgl_jax.srt.utils.quantization.quantization_utils import quantize_tensor_simple
 
 
@@ -124,12 +123,12 @@ def xla_quantized_matmul_local(
             out = out.astype(compute_dtype) * jnp.expand_dims(w_scale, 0).astype(compute_dtype)
 
     out = out.astype(out_dtype)
-    # Sum partial results across devices (single all-reduce)
+    # Reduce across the contracted (input) axis. Caller passes
+    # ``output_scatter_dimension`` only when it has already decided that a
+    # reduce-scatter on that dim is appropriate AND wired ``out_specs``
+    # accordingly; otherwise we do a plain all-reduce.
     if reduce_axis is not None:
-        mesh = jax.sharding.get_abstract_mesh()
-        if output_scatter_dimension is not None and should_scatter(
-            out.shape[output_scatter_dimension], mesh.shape[reduce_axis]
-        ):
+        if output_scatter_dimension is not None:
             out = lax.psum_scatter(
                 out, axis_name=reduce_axis, scatter_dimension=output_scatter_dimension, tiled=True
             )

--- a/python/sgl_jax/srt/kernels/quantized_matmul/kernel.py
+++ b/python/sgl_jax/srt/kernels/quantized_matmul/kernel.py
@@ -10,7 +10,6 @@ from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import (
     get_safe_blockwise_tuned_value,
     should_use_blockwise_kernel,
 )
-from sgl_jax.srt.utils.parallel_utils import should_scatter
 from sgl_jax.srt.utils.quantization.quantization_utils import quantize_tensor_simple
 
 
@@ -131,12 +130,12 @@ def xla_quantized_matmul_local(
             out = out.astype(compute_dtype) * jnp.expand_dims(w_scale, 0).astype(compute_dtype)
 
     out = out.astype(out_dtype)
-    # Sum partial results across devices (single all-reduce)
+    # Reduce across the contracted (input) axis. Caller passes
+    # ``output_scatter_dimension`` only when it has already decided that a
+    # reduce-scatter on that dim is appropriate AND wired ``out_specs``
+    # accordingly; otherwise we do a plain all-reduce.
     if reduce_axis is not None:
-        mesh = jax.sharding.get_abstract_mesh()
-        if output_scatter_dimension is not None and should_scatter(
-            out.shape[output_scatter_dimension], mesh.shape[reduce_axis]
-        ):
+        if output_scatter_dimension is not None:
             out = lax.psum_scatter(
                 out, axis_name=reduce_axis, scatter_dimension=output_scatter_dimension, tiled=True
             )

--- a/python/sgl_jax/srt/kernels/quantized_matmul/kernel.py
+++ b/python/sgl_jax/srt/kernels/quantized_matmul/kernel.py
@@ -10,6 +10,7 @@ from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import (
     get_safe_blockwise_tuned_value,
     should_use_blockwise_kernel,
 )
+from sgl_jax.srt.utils.parallel_utils import should_scatter
 from sgl_jax.srt.utils.quantization.quantization_utils import quantize_tensor_simple
 
 
@@ -23,6 +24,7 @@ def xla_quantized_matmul_local(
     weight_block_size: tuple[int, int] | None = None,
     activation_quant_dtype: jnp.dtype | None = None,
     allow_narrow_n_blockwise: bool = False,
+    output_scatter_dimension: int | None = None,
 ) -> jax.Array:
     """
     Local quantized matmul for use inside shard_map.
@@ -131,6 +133,14 @@ def xla_quantized_matmul_local(
     out = out.astype(out_dtype)
     # Sum partial results across devices (single all-reduce)
     if reduce_axis is not None:
-        out = lax.psum(out, axis_name=reduce_axis)
+        mesh = jax.sharding.get_abstract_mesh()
+        if output_scatter_dimension is not None and should_scatter(
+            out.shape[output_scatter_dimension], mesh.shape[reduce_axis]
+        ):
+            out = lax.psum_scatter(
+                out, axis_name=reduce_axis, scatter_dimension=output_scatter_dimension, tiled=True
+            )
+        else:
+            out = lax.psum(out, axis_name=reduce_axis)
 
     return out

--- a/python/sgl_jax/srt/layers/linear.py
+++ b/python/sgl_jax/srt/layers/linear.py
@@ -11,6 +11,7 @@ from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import expand_block_scale
 from sgl_jax.srt.kernels.quantized_matmul.kernel import xla_quantized_matmul_local
+from sgl_jax.srt.utils.parallel_utils import should_scatter
 from sgl_jax.srt.utils.profiling_utils import named_scope
 from sgl_jax.srt.utils.quantization.quantization_utils import quantize_tensor
 
@@ -39,6 +40,7 @@ class LinearBase(nnx.Module):
         params_dtype: jnp.dtype | None = jnp.bfloat16,
         kernel_axes: Sequence[str | None] | None = None,
         scope_name: str = "linear_base",
+        output_scatter_dimension: int | None = None,
     ):
         """Initialize parameters and quantization method."""
         self.skip_bias_add = skip_bias_add
@@ -46,6 +48,7 @@ class LinearBase(nnx.Module):
         self.kernel_axes = kernel_axes
         self.mesh = mesh
         self.name = scope_name
+        self.output_scatter_dimension = output_scatter_dimension
 
         self.weight = nnx.Param(
             jax.random.normal(
@@ -128,6 +131,7 @@ class QuantizedLinear(nnx.Module):
         compute_dtype: jnp.dtype | None = None,
         weight_block_size: tuple[int, int] | None = None,
         scope_name: str = "quantized_linear",
+        output_scatter_dimension: int | None = None,
     ):
         """Initialize the quantized linear layer with pre-quantized weights."""
         # Auto-expand 2D block-quant scale to 3D kernel-ready layout.
@@ -154,6 +158,7 @@ class QuantizedLinear(nnx.Module):
         self.compute_dtype = compute_dtype
         self.weight_block_size = weight_block_size
         self.name = scope_name
+        self.output_scatter_dimension = output_scatter_dimension
 
     @classmethod
     def from_linear(
@@ -290,6 +295,7 @@ class QuantizedLinear(nnx.Module):
             params_dtype=linear.params_dtype,
             weight_block_size=effective_weight_block_size,
             scope_name=f"quantized_{linear.name}",
+            output_scatter_dimension=linear.output_scatter_dimension,
         )
 
     @named_scope
@@ -329,7 +335,29 @@ class QuantizedLinear(nnx.Module):
             # Per-channel scale: [n_out]
             w_scale_spec = P(output_axis)
         in_specs = (P("data", input_axis), P(output_axis, input_axis), w_scale_spec)
+
         out_specs = P("data", output_axis)
+
+        if self.output_scatter_dimension is not None and should_scatter(
+            x.shape[self.output_scatter_dimension], self.mesh.shape[input_axis]
+        ):
+            # Stack ``input_axis`` on top of any existing partition (e.g.
+            # ``"data"`` from DP) on the scatter dim so DP+SP compose. Each
+            # (dp, tp) rank then owns 1/(dp*tp) of that dim.
+            #
+            existing = out_specs[self.output_scatter_dimension]
+            if existing is None:
+                combined = input_axis
+            elif isinstance(existing, tuple):
+                combined = existing + (input_axis,)
+            else:
+                combined = (existing, input_axis)
+            out_specs = P(
+                *(
+                    combined if i == self.output_scatter_dimension else axis
+                    for i, axis in enumerate(out_specs)
+                )
+            )
 
         output = shard_map(
             partial(
@@ -339,6 +367,7 @@ class QuantizedLinear(nnx.Module):
                 compute_dtype=self.compute_dtype,
                 weight_block_size=self.weight_block_size,
                 activation_quant_dtype=self.activation_dtype,
+                output_scatter_dimension=self.output_scatter_dimension,
             ),
             mesh=self.mesh,
             in_specs=in_specs,

--- a/python/sgl_jax/srt/layers/linear.py
+++ b/python/sgl_jax/srt/layers/linear.py
@@ -11,7 +11,7 @@ from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import expand_block_scale
 from sgl_jax.srt.kernels.quantized_matmul.kernel import xla_quantized_matmul_local
-from sgl_jax.srt.utils.parallel_utils import should_scatter
+from sgl_jax.srt.utils.parallel_utils import prepare_scattered_spec_if_needed
 from sgl_jax.srt.utils.profiling_utils import named_scope
 from sgl_jax.srt.utils.quantization.quantization_utils import quantize_tensor
 
@@ -338,26 +338,19 @@ class QuantizedLinear(nnx.Module):
 
         out_specs = P("data", output_axis)
 
-        if self.output_scatter_dimension is not None and should_scatter(
-            x.shape[self.output_scatter_dimension], self.mesh.shape[input_axis]
-        ):
-            # Stack ``input_axis`` on top of any existing partition (e.g.
-            # ``"data"`` from DP) on the scatter dim so DP+SP compose. Each
-            # (dp, tp) rank then owns 1/(dp*tp) of that dim.
-            #
-            existing = out_specs[self.output_scatter_dimension]
-            if existing is None:
-                combined = input_axis
-            elif isinstance(existing, tuple):
-                combined = existing + (input_axis,)
-            else:
-                combined = (existing, input_axis)
-            out_specs = P(
-                *(
-                    combined if i == self.output_scatter_dimension else axis
-                    for i, axis in enumerate(out_specs)
-                )
+        # When ``output_scatter_dimension`` is set, stack ``input_axis`` onto
+        # whatever already partitions that dim (e.g. ``"data"`` from DP) so
+        # DP+SP compose. 
+        if self.output_scatter_dimension is not None:
+            out_specs, do_scatter = prepare_scattered_spec_if_needed(
+                out_specs,
+                self.output_scatter_dimension,
+                scatter_axis=input_axis,
+                full_dim_size=x.shape[self.output_scatter_dimension],
+                mesh=self.mesh,
             )
+        else:
+            do_scatter = False
 
         output = shard_map(
             partial(
@@ -367,7 +360,9 @@ class QuantizedLinear(nnx.Module):
                 compute_dtype=self.compute_dtype,
                 weight_block_size=self.weight_block_size,
                 activation_quant_dtype=self.activation_dtype,
-                output_scatter_dimension=self.output_scatter_dimension,
+                # Pass the dim only when we've actually decided to scatter,
+                # so the kernel doesn't need to second-guess us.
+                output_scatter_dimension=self.output_scatter_dimension if do_scatter else None,
             ),
             mesh=self.mesh,
             in_specs=in_specs,

--- a/python/sgl_jax/srt/layers/linear.py
+++ b/python/sgl_jax/srt/layers/linear.py
@@ -340,7 +340,7 @@ class QuantizedLinear(nnx.Module):
 
         # When ``output_scatter_dimension`` is set, stack ``input_axis`` onto
         # whatever already partitions that dim (e.g. ``"data"`` from DP) so
-        # DP+SP compose. 
+        # DP+SP compose.
         if self.output_scatter_dimension is not None:
             out_specs, do_scatter = prepare_scattered_spec_if_needed(
                 out_specs,

--- a/python/sgl_jax/srt/layers/linear.py
+++ b/python/sgl_jax/srt/layers/linear.py
@@ -11,6 +11,7 @@ from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import expand_block_scale
 from sgl_jax.srt.kernels.quantized_matmul.kernel import xla_quantized_matmul_local
+from sgl_jax.srt.utils.parallel_utils import should_scatter
 from sgl_jax.srt.utils.profiling_utils import named_scope
 from sgl_jax.srt.utils.quantization.quantization_utils import quantize_tensor
 
@@ -39,6 +40,7 @@ class LinearBase(nnx.Module):
         params_dtype: jnp.dtype | None = jnp.bfloat16,
         kernel_axes: Sequence[str | None] | None = None,
         scope_name: str = "linear_base",
+        output_scatter_dimension: int | None = None,
     ):
         """Initialize parameters and quantization method."""
         self.skip_bias_add = skip_bias_add
@@ -46,6 +48,7 @@ class LinearBase(nnx.Module):
         self.kernel_axes = kernel_axes
         self.mesh = mesh
         self.name = scope_name
+        self.output_scatter_dimension = output_scatter_dimension
 
         self.weight = nnx.Param(
             jax.random.normal(
@@ -129,6 +132,7 @@ class QuantizedLinear(nnx.Module):
         weight_block_size: tuple[int, int] | None = None,
         allow_narrow_n_blockwise: bool = False,
         scope_name: str = "quantized_linear",
+        output_scatter_dimension: int | None = None,
     ):
         """Initialize the quantized linear layer with pre-quantized weights."""
         # Auto-expand 2D block-quant scale to 3D kernel-ready layout.
@@ -156,6 +160,7 @@ class QuantizedLinear(nnx.Module):
         self.weight_block_size = weight_block_size
         self.allow_narrow_n_blockwise = allow_narrow_n_blockwise
         self.name = scope_name
+        self.output_scatter_dimension = output_scatter_dimension
 
     @classmethod
     def from_linear(
@@ -294,6 +299,7 @@ class QuantizedLinear(nnx.Module):
             weight_block_size=effective_weight_block_size,
             allow_narrow_n_blockwise=allow_narrow_n_blockwise,
             scope_name=f"quantized_{linear.name}",
+            output_scatter_dimension=linear.output_scatter_dimension,
         )
 
     @named_scope
@@ -333,7 +339,29 @@ class QuantizedLinear(nnx.Module):
             # Per-channel scale: [n_out]
             w_scale_spec = P(output_axis)
         in_specs = (P("data", input_axis), P(output_axis, input_axis), w_scale_spec)
+
         out_specs = P("data", output_axis)
+
+        if self.output_scatter_dimension is not None and should_scatter(
+            x.shape[self.output_scatter_dimension], self.mesh.shape[input_axis]
+        ):
+            # Stack ``input_axis`` on top of any existing partition (e.g.
+            # ``"data"`` from DP) on the scatter dim so DP+SP compose. Each
+            # (dp, tp) rank then owns 1/(dp*tp) of that dim.
+            #
+            existing = out_specs[self.output_scatter_dimension]
+            if existing is None:
+                combined = input_axis
+            elif isinstance(existing, tuple):
+                combined = existing + (input_axis,)
+            else:
+                combined = (existing, input_axis)
+            out_specs = P(
+                *(
+                    combined if i == self.output_scatter_dimension else axis
+                    for i, axis in enumerate(out_specs)
+                )
+            )
 
         output = shard_map(
             partial(
@@ -344,6 +372,7 @@ class QuantizedLinear(nnx.Module):
                 weight_block_size=self.weight_block_size,
                 activation_quant_dtype=self.activation_dtype,
                 allow_narrow_n_blockwise=self.allow_narrow_n_blockwise,
+                output_scatter_dimension=self.output_scatter_dimension,
             ),
             mesh=self.mesh,
             in_specs=in_specs,

--- a/python/sgl_jax/srt/layers/linear.py
+++ b/python/sgl_jax/srt/layers/linear.py
@@ -11,7 +11,7 @@ from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import expand_block_scale
 from sgl_jax.srt.kernels.quantized_matmul.kernel import xla_quantized_matmul_local
-from sgl_jax.srt.utils.parallel_utils import should_scatter
+from sgl_jax.srt.utils.parallel_utils import prepare_scattered_spec_if_needed
 from sgl_jax.srt.utils.profiling_utils import named_scope
 from sgl_jax.srt.utils.quantization.quantization_utils import quantize_tensor
 
@@ -342,26 +342,19 @@ class QuantizedLinear(nnx.Module):
 
         out_specs = P("data", output_axis)
 
-        if self.output_scatter_dimension is not None and should_scatter(
-            x.shape[self.output_scatter_dimension], self.mesh.shape[input_axis]
-        ):
-            # Stack ``input_axis`` on top of any existing partition (e.g.
-            # ``"data"`` from DP) on the scatter dim so DP+SP compose. Each
-            # (dp, tp) rank then owns 1/(dp*tp) of that dim.
-            #
-            existing = out_specs[self.output_scatter_dimension]
-            if existing is None:
-                combined = input_axis
-            elif isinstance(existing, tuple):
-                combined = existing + (input_axis,)
-            else:
-                combined = (existing, input_axis)
-            out_specs = P(
-                *(
-                    combined if i == self.output_scatter_dimension else axis
-                    for i, axis in enumerate(out_specs)
-                )
+        # When ``output_scatter_dimension`` is set, stack ``input_axis`` onto
+        # whatever already partitions that dim (e.g. ``"data"`` from DP) so
+        # DP+SP compose. 
+        if self.output_scatter_dimension is not None:
+            out_specs, do_scatter = prepare_scattered_spec_if_needed(
+                out_specs,
+                self.output_scatter_dimension,
+                scatter_axis=input_axis,
+                full_dim_size=x.shape[self.output_scatter_dimension],
+                mesh=self.mesh,
             )
+        else:
+            do_scatter = False
 
         output = shard_map(
             partial(
@@ -372,7 +365,9 @@ class QuantizedLinear(nnx.Module):
                 weight_block_size=self.weight_block_size,
                 activation_quant_dtype=self.activation_dtype,
                 allow_narrow_n_blockwise=self.allow_narrow_n_blockwise,
-                output_scatter_dimension=self.output_scatter_dimension,
+                # Pass the dim only when we've actually decided to scatter,
+                # so the kernel doesn't need to second-guess us.
+                output_scatter_dimension=self.output_scatter_dimension if do_scatter else None,
             ),
             mesh=self.mesh,
             in_specs=in_specs,

--- a/python/sgl_jax/srt/layers/linear.py
+++ b/python/sgl_jax/srt/layers/linear.py
@@ -344,7 +344,7 @@ class QuantizedLinear(nnx.Module):
 
         # When ``output_scatter_dimension`` is set, stack ``input_axis`` onto
         # whatever already partitions that dim (e.g. ``"data"`` from DP) so
-        # DP+SP compose. 
+        # DP+SP compose.
         if self.output_scatter_dimension is not None:
             out_specs, do_scatter = prepare_scattered_spec_if_needed(
                 out_specs,

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -1,5 +1,7 @@
 """GMM-based Expert-Parallel MoE layer and weight mapping utilities."""
 
+from functools import partial
+
 import jax
 from flax import nnx
 from jax import numpy as jnp
@@ -407,6 +409,20 @@ class EPMoE(nnx.Module):
         # Activation quantization is now handled per-GEMM inside _gmm_compute
         # (aligned with sglang-gpu scheme: quantize before each GEMM, dequantize after)
 
+        # Decide once whether SP should reduce-scatter the post-MoE result.
+        # Three things downstream consume this: the shard_map ``out_specs``,
+        # ``_forward``'s ``psum`` vs ``psum_scatter`` choice, and the
+        # post-shard_map reshard back to the original mesh. They MUST agree
+        # — if they ever diverge, ``out_specs`` lies about what the kernel
+        # produced and shard_map concatenates duplicates (see the bug fixed
+        # in ``QuantizedLinear``). Safe today only because input is
+        # pre-replicated to ``P(None)``; hoisting the decision keeps it safe
+        # if that ever changes.
+        do_scatter = (
+            self.enable_sequence_parallel
+            and should_scatter(hidden_states.shape[0], self.tp_size)
+        )
+
         # Run MoE computation on the expert-parallel mesh
         with jax.sharding.use_abstract_mesh(self.updated_mesh):
             hidden_states_reshard = jax.sharding.reshard(hidden_states, P(None))
@@ -430,14 +446,9 @@ class EPMoE(nnx.Module):
                 scale_name="wo_scale",
             )
 
-            if self.enable_sequence_parallel and should_scatter(
-                hidden_states.shape[0], self.tp_size
-            ):
-                out_specs = P("tensor", None)
-            else:
-                out_specs = P(None)
+            out_specs = P("tensor", None) if do_scatter else P(None)
             result = shard_map(
-                self._forward,
+                partial(self._forward, do_scatter=do_scatter),
                 mesh=self.moe_mesh,
                 in_specs=(
                     P(None),
@@ -473,18 +484,12 @@ class EPMoE(nnx.Module):
                 None,
             )
 
-        # Reshard result back to original mesh.
-        # When sequence parallel is on AND the scatter fired inside shard_map,
-        # the token dim is already striped across the moe_mesh "tensor" axis;
-        # preserve that by also striping it across the original mesh's
-        # ("data", "tensor") so the next decoder layer keeps the SP shard.
-        # Otherwise fall back to DP-only sharding on "data".
-        if self.enable_sequence_parallel and should_scatter(
-            hidden_states.shape[0], self.tp_size
-        ):
-            token_axis = ("data", "tensor")
-        else:
-            token_axis = "data"
+        # Reshard result back to original mesh. When the scatter fired inside
+        # shard_map the token dim is already striped across moe_mesh's
+        # "tensor" axis; preserve that by combining ``"data"`` with
+        # ``"tensor"`` on the original mesh so the next decoder layer keeps
+        # the SP shard. Otherwise fall back to DP-only on ``"data"``.
+        token_axis = ("data", "tensor") if do_scatter else "data"
         out_pspec = P(token_axis, *([None] * (result.ndim - 1)))
         return jax.sharding.reshard(result, jax.sharding.NamedSharding(self.mesh, out_pspec))
 
@@ -502,6 +507,8 @@ class EPMoE(nnx.Module):
         w0_kernel_bias=None,
         w1_kernel_bias=None,
         wo_kernel_bias=None,
+        *,
+        do_scatter: bool = False,
     ):
         expert_shard_id = jax.lax.axis_index("expert")
 
@@ -546,8 +553,10 @@ class EPMoE(nnx.Module):
 
         # All-reduce after unpermute: communication volume is (T, hidden_size)
         # instead of (T * top_k, hidden_size), reducing by a factor of top_k.
+        # ``do_scatter`` is decided once in ``__call__`` so this branch and
+        # the outer ``out_specs`` can never disagree.
         if self.tp_size > 1:
-            if self.enable_sequence_parallel and should_scatter(output.shape[0], self.tp_size):
+            if do_scatter:
                 # scatter on sequence/token dimension
                 output = jax.lax.psum_scatter(output, "tensor", scatter_dimension=0, tiled=True)
             else:

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -13,6 +13,7 @@ from sgl_jax.srt.kernels.gmm.megablox_gmm_backend import gmm
 # Re-export for backward compatibility: external code imports from this module.
 from sgl_jax.srt.layers.fused_moe import FusedEPMoE  # noqa: F401
 from sgl_jax.srt.layers.gate import GateLogit, TopK  # noqa: F401
+from sgl_jax.srt.utils.parallel_utils import should_scatter
 from sgl_jax.srt.utils.profiling_utils import named_scope
 from sgl_jax.srt.utils.quantization.quantization_utils import (
     quantize_tensor,
@@ -37,6 +38,7 @@ class EPMoE(nnx.Module):
         quantization_config=None,
         physical_to_logical_map: "jax.Array | None" = None,
         pre_gather_quant_dtype=None,
+        enable_sequence_parallel=False,
     ):
         self.num_experts_per_tok = num_experts_per_tok
         self.physical_to_logical_map = physical_to_logical_map
@@ -57,6 +59,7 @@ class EPMoE(nnx.Module):
         self.mesh = mesh
         self.activation = activation
         self.hidden_size = hidden_size
+        self.enable_sequence_parallel = enable_sequence_parallel
 
         # Get quantization settings from config
         self.quantized_dtype = (
@@ -427,6 +430,12 @@ class EPMoE(nnx.Module):
                 scale_name="wo_scale",
             )
 
+            if self.enable_sequence_parallel and should_scatter(
+                hidden_states.shape[0], self.tp_size
+            ):
+                out_specs = P("tensor", None)
+            else:
+                out_specs = P(None)
             result = shard_map(
                 self._forward,
                 mesh=self.moe_mesh,
@@ -447,7 +456,7 @@ class EPMoE(nnx.Module):
                     P("expert", None, "tensor"),
                     P("expert", None, None),
                 ),
-                out_specs=P(None),
+                out_specs=out_specs,
                 check_vma=False,
             )(
                 hidden_states_reshard,
@@ -464,9 +473,20 @@ class EPMoE(nnx.Module):
                 None,
             )
 
-        # Reshard result back to original mesh
-        replicated_pspec = P("data", *([None] * (result.ndim - 1)))
-        return jax.sharding.reshard(result, jax.sharding.NamedSharding(self.mesh, replicated_pspec))
+        # Reshard result back to original mesh.
+        # When sequence parallel is on AND the scatter fired inside shard_map,
+        # the token dim is already striped across the moe_mesh "tensor" axis;
+        # preserve that by also striping it across the original mesh's
+        # ("data", "tensor") so the next decoder layer keeps the SP shard.
+        # Otherwise fall back to DP-only sharding on "data".
+        if self.enable_sequence_parallel and should_scatter(
+            hidden_states.shape[0], self.tp_size
+        ):
+            token_axis = ("data", "tensor")
+        else:
+            token_axis = "data"
+        out_pspec = P(token_axis, *([None] * (result.ndim - 1)))
+        return jax.sharding.reshard(result, jax.sharding.NamedSharding(self.mesh, out_pspec))
 
     def _forward(
         self,
@@ -527,7 +547,11 @@ class EPMoE(nnx.Module):
         # All-reduce after unpermute: communication volume is (T, hidden_size)
         # instead of (T * top_k, hidden_size), reducing by a factor of top_k.
         if self.tp_size > 1:
-            output = jax.lax.psum(output, "tensor")
+            if self.enable_sequence_parallel and should_scatter(output.shape[0], self.tp_size):
+                # scatter on sequence/token dimension
+                output = jax.lax.psum_scatter(output, "tensor", scatter_dimension=0, tiled=True)
+            else:
+                output = jax.lax.psum(output, "tensor")
         if self.ep_size > 1:
             output = self._combine(output)
 

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -418,9 +418,8 @@ class EPMoE(nnx.Module):
         # in ``QuantizedLinear``). Safe today only because input is
         # pre-replicated to ``P(None)``; hoisting the decision keeps it safe
         # if that ever changes.
-        do_scatter = (
-            self.enable_sequence_parallel
-            and should_scatter(hidden_states.shape[0], self.tp_size)
+        do_scatter = self.enable_sequence_parallel and should_scatter(
+            hidden_states.shape[0], self.tp_size
         )
 
         # Run MoE computation on the expert-parallel mesh

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -318,6 +318,9 @@ class ModelRunner(BaseModelRunner):
         # DeepseekV3DecoderLayer to construct DeepseekV3Attention; harmless on
         # non-MLA models that ignore the attribute.
         self.model_config.hf_config.use_absorbed_mla = self.server_args.attention_backend == "fa"
+        self.model_config.hf_config.enable_sequence_parallel = (
+            self.server_args.enable_sequence_parallel
+        )
 
         if self.server_args.ep_dispatch_algorithm:
             with jax.set_mesh(self.mesh):

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -315,6 +315,9 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         # DeepseekV3DecoderLayer to construct DeepseekV3Attention; harmless on
         # non-MLA models that ignore the attribute.
         self.model_config.hf_config.use_absorbed_mla = self.server_args.attention_backend == "fa"
+        self.model_config.hf_config.enable_sequence_parallel = (
+            self.server_args.enable_sequence_parallel
+        )
 
         if self.server_args.ep_dispatch_algorithm:
             with jax.set_mesh(self.mesh):

--- a/python/sgl_jax/srt/models/grok.py
+++ b/python/sgl_jax/srt/models/grok.py
@@ -195,7 +195,7 @@ class Grok1MLP(nnx.Module):
             params_dtype=dtype,
             kernel_axes=("tensor", None),
             mesh=mesh,
-            output_scatter_dimension=0,
+            output_scatter_dimension=0 if enable_sequence_parallel else None,
         )
         self.act_fn = GeluAndMul(approximate="tanh")
         self.layer_id = layer_id
@@ -401,7 +401,7 @@ class Grok1Attention(nnx.Module):
         layer_id: int = 0,
         max_position: int = 4096 * 32,
         rope_theta: float = 10000,
-        enable_sequence_parallel: int | None = None,
+        enable_sequence_parallel: bool = False,
     ) -> None:
         super().__init__()
         self.config = config
@@ -457,7 +457,7 @@ class Grok1Attention(nnx.Module):
             params_dtype=jnp.bfloat16,
             kernel_axes=("tensor", None),
             mesh=mesh,
-            output_scatter_dimension=0,
+            output_scatter_dimension=0 if enable_sequence_parallel else None,
         )
 
         # Initialize rotary embeddings based on scaling configuration
@@ -598,6 +598,7 @@ class Grok1DecoderLayer(nnx.Module):
             layer_id=layer_id,
             rope_theta=rope_theta,
             mesh=mesh,
+            enable_sequence_parallel=getattr(config, "enable_sequence_parallel", False),
         )
 
         # Feed-forward networks

--- a/python/sgl_jax/srt/models/grok.py
+++ b/python/sgl_jax/srt/models/grok.py
@@ -168,6 +168,7 @@ class Grok1MLP(nnx.Module):
         mesh: jax.sharding.Mesh,
         dtype: jnp.dtype = jnp.bfloat16,
         reduce_results: bool = True,
+        enable_sequence_parallel: bool = False,
     ) -> None:
         super().__init__()
 
@@ -194,13 +195,21 @@ class Grok1MLP(nnx.Module):
             params_dtype=dtype,
             kernel_axes=("tensor", None),
             mesh=mesh,
+            output_scatter_dimension=0,
         )
         self.act_fn = GeluAndMul(approximate="tanh")
         self.layer_id = layer_id
         self.reduce_results = reduce_results
+        self.mesh = mesh
+        self.enable_sequence_parallel = enable_sequence_parallel
 
     @log_shardings("GrokMLP")
     def __call__(self, x: jax.Array) -> jax.Array:
+        # Unshard activations if sequence parallel enabled, otherwise no-op
+        with jax.sharding.use_abstract_mesh(self.mesh.abstract_mesh):
+            spec = jax.sharding.PartitionSpec(*([None] * len(x.shape)))
+            x = jax.sharding.reshard(x, spec)
+
         gate, _ = self.gate_proj(x)
         up, _ = self.up_proj(x)
         x, _ = self.act_fn(gate, up)
@@ -280,6 +289,7 @@ class Grok1MoE(nnx.Module):
                 dtype=dtype,
                 layer_id=layer_id,
                 quantization_config=getattr(config, "quantization_config", None),
+                enable_sequence_parallel=getattr(config, "enable_sequence_parallel", False),
             )
 
     @log_shardings("GrokMoE")
@@ -288,6 +298,11 @@ class Grok1MoE(nnx.Module):
         hidden_states: jax.Array,
         dispatch_info: ExpertLocationMetadata | None = None,
     ) -> tuple[jax.Array, jax.Array | None]:
+        # Unshard activations if sequence parallel enabled, otherwise no-op
+        with jax.sharding.use_abstract_mesh(self.mesh.abstract_mesh):
+            spec = jax.sharding.PartitionSpec(*([None] * len(hidden_states.shape)))
+            hidden_states = jax.sharding.reshard(hidden_states, spec)
+
         # Router computation with soft capping
         router_logits, _ = self.gate(hidden_states)
 
@@ -386,6 +401,7 @@ class Grok1Attention(nnx.Module):
         layer_id: int = 0,
         max_position: int = 4096 * 32,
         rope_theta: float = 10000,
+        enable_sequence_parallel: int | None = None,
     ) -> None:
         super().__init__()
         self.config = config
@@ -401,6 +417,7 @@ class Grok1Attention(nnx.Module):
         self.scaling = self.head_dim**-0.5
         self.rope_theta = rope_theta
         self.mesh = mesh
+        self.enable_sequence_parallel = enable_sequence_parallel
 
         rope_scaling = get_rope_scaling(config)
         self.rope_rotate_half_dims = getattr(config, "rope_rotate_half_dims", False)
@@ -440,6 +457,7 @@ class Grok1Attention(nnx.Module):
             params_dtype=jnp.bfloat16,
             kernel_axes=("tensor", None),
             mesh=mesh,
+            output_scatter_dimension=0,
         )
 
         # Initialize rotary embeddings based on scaling configuration
@@ -488,6 +506,11 @@ class Grok1Attention(nnx.Module):
         # Short circuit for empty sequences
         if hidden_states.shape[0] == 0:
             return hidden_states, hidden_states
+
+        # Unshard activations if sequence parallel enabled, otherwise no-op
+        with jax.sharding.use_abstract_mesh(self.mesh.abstract_mesh):
+            spec = jax.sharding.PartitionSpec(*([None] * len(hidden_states.shape)))
+            hidden_states = jax.sharding.reshard(hidden_states, spec)
 
         # Project Q, K, V separately
         q, _ = self.q_proj(hidden_states)
@@ -540,6 +563,7 @@ class Grok1Attention(nnx.Module):
 
         # Project output
         output, _ = self.o_proj(attn_output)
+
         return output, kv_fused
 
 
@@ -603,6 +627,7 @@ class Grok1DecoderLayer(nnx.Module):
                     layer_id=layer_id,
                     reduce_results=False,
                     mesh=mesh,
+                    enable_sequence_parallel=getattr(config, "enable_sequence_parallel", False),
                 )
         else:
             raise NotImplementedError()
@@ -901,6 +926,11 @@ class Grok1ForCausalLM(nnx.Module):
             token_to_kv_pool,
             None,
         )
+
+        # Unshard activations if sequence parallel enabled, otherwise no-op
+        with jax.sharding.use_abstract_mesh(self.mesh.abstract_mesh):
+            hidden_states = jax.sharding.reshard(hidden_states, jax.sharding.PartitionSpec(None))
+
         output = self.logits_processor(hidden_states, cast(Embed, self.lm_head), logits_metadata)
 
         return output, layers_kv_fused, True, layers_topk_ids

--- a/python/sgl_jax/srt/models/grok.py
+++ b/python/sgl_jax/srt/models/grok.py
@@ -168,6 +168,7 @@ class Grok1MLP(nnx.Module):
         mesh: jax.sharding.Mesh,
         dtype: jnp.dtype = jnp.bfloat16,
         reduce_results: bool = True,
+        enable_sequence_parallel: bool = False,
     ) -> None:
         super().__init__()
 
@@ -194,13 +195,21 @@ class Grok1MLP(nnx.Module):
             params_dtype=dtype,
             kernel_axes=("tensor", None),
             mesh=mesh,
+            output_scatter_dimension=0,
         )
         self.act_fn = GeluAndMul(approximate="tanh")
         self.layer_id = layer_id
         self.reduce_results = reduce_results
+        self.mesh = mesh
+        self.enable_sequence_parallel = enable_sequence_parallel
 
     @log_shardings("GrokMLP")
     def __call__(self, x: jax.Array) -> jax.Array:
+        # Unshard activations if sequence parallel enabled, otherwise no-op
+        with jax.sharding.use_abstract_mesh(self.mesh.abstract_mesh):
+            spec = jax.sharding.PartitionSpec(*([None] * len(x.shape)))
+            x = jax.sharding.reshard(x, spec)
+
         gate, _ = self.gate_proj(x)
         up, _ = self.up_proj(x)
         x, _ = self.act_fn(gate, up)
@@ -280,6 +289,7 @@ class Grok1MoE(nnx.Module):
                 dtype=dtype,
                 layer_id=layer_id,
                 quantization_config=getattr(config, "quantization_config", None),
+                enable_sequence_parallel=getattr(config, "enable_sequence_parallel", False),
             )
 
     @log_shardings("GrokMoE")
@@ -288,6 +298,11 @@ class Grok1MoE(nnx.Module):
         hidden_states: jax.Array,
         dispatch_info: ExpertLocationMetadata | None = None,
     ) -> tuple[jax.Array, jax.Array | None]:
+        # Unshard activations if sequence parallel enabled, otherwise no-op
+        with jax.sharding.use_abstract_mesh(self.mesh.abstract_mesh):
+            spec = jax.sharding.PartitionSpec(*([None] * len(hidden_states.shape)))
+            hidden_states = jax.sharding.reshard(hidden_states, spec)
+
         # Router computation with soft capping
         router_logits, _ = self.gate(hidden_states)
 
@@ -386,6 +401,7 @@ class Grok1Attention(nnx.Module):
         layer_id: int = 0,
         max_position: int = 4096 * 32,
         rope_theta: float = 10000,
+        enable_sequence_parallel: int | None = None,
     ) -> None:
         super().__init__()
         self.config = config
@@ -401,6 +417,7 @@ class Grok1Attention(nnx.Module):
         self.scaling = self.head_dim**-0.5
         self.rope_theta = rope_theta
         self.mesh = mesh
+        self.enable_sequence_parallel = enable_sequence_parallel
 
         rope_scaling = get_rope_scaling(config)
         self.rope_rotate_half_dims = getattr(config, "rope_rotate_half_dims", False)
@@ -440,6 +457,7 @@ class Grok1Attention(nnx.Module):
             params_dtype=jnp.bfloat16,
             kernel_axes=("tensor", None),
             mesh=mesh,
+            output_scatter_dimension=0,
         )
 
         # Initialize rotary embeddings based on scaling configuration
@@ -488,6 +506,11 @@ class Grok1Attention(nnx.Module):
         # Short circuit for empty sequences
         if hidden_states.shape[0] == 0:
             return hidden_states, hidden_states
+
+        # Unshard activations if sequence parallel enabled, otherwise no-op
+        with jax.sharding.use_abstract_mesh(self.mesh.abstract_mesh):
+            spec = jax.sharding.PartitionSpec(*([None] * len(hidden_states.shape)))
+            hidden_states = jax.sharding.reshard(hidden_states, spec)
 
         # Project Q, K, V separately
         q, _ = self.q_proj(hidden_states)
@@ -540,6 +563,7 @@ class Grok1Attention(nnx.Module):
 
         # Project output
         output, _ = self.o_proj(attn_output)
+
         return output, kv_fused
 
 
@@ -603,6 +627,7 @@ class Grok1DecoderLayer(nnx.Module):
                     layer_id=layer_id,
                     reduce_results=False,
                     mesh=mesh,
+                    enable_sequence_parallel=getattr(config, "enable_sequence_parallel", False),
                 )
         else:
             raise NotImplementedError()
@@ -902,6 +927,11 @@ class Grok1ForCausalLM(nnx.Module):
             kv_pool,
             None,
         )
+
+        # Unshard activations if sequence parallel enabled, otherwise no-op
+        with jax.sharding.use_abstract_mesh(self.mesh.abstract_mesh):
+            hidden_states = jax.sharding.reshard(hidden_states, jax.sharding.PartitionSpec(None))
+
         output = self.logits_processor(hidden_states, cast(Embed, self.lm_head), logits_metadata)
 
         return output, layers_kv_fused, True, layers_topk_ids

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -78,6 +78,7 @@ class ServerArgs:
     ep_size: int = 1
     ep_num_redundant_experts: int = 0
     ep_dispatch_algorithm: str | None = None
+    enable_sequence_parallel: bool = False
     stream_interval: int = 1
     stream_output: bool = False
     random_seed: int | None = None
@@ -604,6 +605,12 @@ class ServerArgs:
             choices=["static", "dynamic", "fake"],
             default=ServerArgs.ep_dispatch_algorithm,
             help="Expert parallel dispatch algorithm.",
+        )
+        parser.add_argument(
+            "--enable-sequence-parallel",
+            action="store_true",
+            default=ServerArgs.enable_sequence_parallel,
+            help="Enable sequence parallelism.",
         )
         parser.add_argument(
             "--stream-interval",

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -80,6 +80,7 @@ class ServerArgs:
     ep_size: int = 1
     ep_num_redundant_experts: int = 0
     ep_dispatch_algorithm: str | None = None
+    enable_sequence_parallel: bool = False
     stream_interval: int = 1
     stream_output: bool = False
     random_seed: int | None = None
@@ -624,6 +625,12 @@ class ServerArgs:
             choices=["static", "dynamic", "fake"],
             default=ServerArgs.ep_dispatch_algorithm,
             help="Expert parallel dispatch algorithm.",
+        )
+        parser.add_argument(
+            "--enable-sequence-parallel",
+            action="store_true",
+            default=ServerArgs.enable_sequence_parallel,
+            help="Enable sequence parallelism.",
         )
         parser.add_argument(
             "--stream-interval",

--- a/python/sgl_jax/srt/utils/parallel_utils.py
+++ b/python/sgl_jax/srt/utils/parallel_utils.py
@@ -31,8 +31,8 @@ def prepare_scattered_spec_if_needed(
     """Stack ``scatter_axis`` onto ``out_specs[scatter_dim]`` if scatter fires.
 
     The decision uses the *local* shard size — ``full_dim_size`` divided by
-    however many mesh axes already partition ``scatter_dim``. 
-    
+    however many mesh axes already partition ``scatter_dim``.
+
     In the cases like DP attention, there's existing DP sharding on the sequences dimension. This
     will influence sequence parallel behavior
 
@@ -46,9 +46,7 @@ def prepare_scattered_spec_if_needed(
     else:
         existing_factor = mesh.shape[existing]
 
-    if not should_scatter(
-        full_dim_size // existing_factor, mesh.shape[scatter_axis]
-    ):
+    if not should_scatter(full_dim_size // existing_factor, mesh.shape[scatter_axis]):
         return out_specs, False
 
     if existing is None:
@@ -58,7 +56,5 @@ def prepare_scattered_spec_if_needed(
     else:
         combined = (existing, scatter_axis)
 
-    new_out_specs = P(
-        *(combined if i == scatter_dim else axis for i, axis in enumerate(out_specs))
-    )
+    new_out_specs = P(*(combined if i == scatter_dim else axis for i, axis in enumerate(out_specs)))
     return new_out_specs, True

--- a/python/sgl_jax/srt/utils/parallel_utils.py
+++ b/python/sgl_jax/srt/utils/parallel_utils.py
@@ -1,0 +1,16 @@
+from sgl_jax.global_config import global_config
+
+
+def should_scatter(dim_size: int, num_devices: int) -> bool:
+    """Return True if a row-parallel output should be reduce-scattered on `dim`.
+
+    Requires the per-device slice to be at least ``tpu_scatter_min_local_size``
+    and the full dimension to divide evenly across devices (a hard requirement
+    of ``psum_scatter(..., tiled=True)``).
+    """
+    if num_devices <= 1:
+        return False
+    return (
+        dim_size >= num_devices * global_config.tpu_scatter_min_local_size
+        and dim_size % num_devices == 0
+    )

--- a/python/sgl_jax/srt/utils/parallel_utils.py
+++ b/python/sgl_jax/srt/utils/parallel_utils.py
@@ -1,3 +1,8 @@
+import math
+
+import jax
+from jax.sharding import PartitionSpec as P
+
 from sgl_jax.global_config import global_config
 
 
@@ -14,3 +19,46 @@ def should_scatter(dim_size: int, num_devices: int) -> bool:
         dim_size >= num_devices * global_config.tpu_scatter_min_local_size
         and dim_size % num_devices == 0
     )
+
+
+def prepare_scattered_spec_if_needed(
+    out_specs: P,
+    scatter_dim: int,
+    scatter_axis: str,
+    full_dim_size: int,
+    mesh: jax.sharding.Mesh,
+) -> tuple[P, bool]:
+    """Stack ``scatter_axis`` onto ``out_specs[scatter_dim]`` if scatter fires.
+
+    The decision uses the *local* shard size — ``full_dim_size`` divided by
+    however many mesh axes already partition ``scatter_dim``. 
+    
+    In the cases like DP attention, there's existing DP sharding on the sequences dimension. This
+    will influence sequence parallel behavior
+
+    Returns ``(new_out_specs, did_combine)``.
+    """
+    existing = out_specs[scatter_dim]
+    if existing is None:
+        existing_factor = 1
+    elif isinstance(existing, tuple):
+        existing_factor = math.prod(mesh.shape[a] for a in existing)
+    else:
+        existing_factor = mesh.shape[existing]
+
+    if not should_scatter(
+        full_dim_size // existing_factor, mesh.shape[scatter_axis]
+    ):
+        return out_specs, False
+
+    if existing is None:
+        combined: tuple[str, ...] | str = scatter_axis
+    elif isinstance(existing, tuple):
+        combined = existing + (scatter_axis,)
+    else:
+        combined = (existing, scatter_axis)
+
+    new_out_specs = P(
+        *(combined if i == scatter_dim else axis for i, axis in enumerate(out_specs))
+    )
+    return new_out_specs, True

--- a/python/sgl_jax/test/layers/test_sequence_parallel.py
+++ b/python/sgl_jax/test/layers/test_sequence_parallel.py
@@ -335,9 +335,12 @@ class TestGrokLayerSequenceParallelWiring(CustomTestCase):
 
         kwargs_by_callee: dict[str, list[str]] = {}
         for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-                if node.func.id in {"Grok1Attention", "Grok1MLP"}:
-                    kwargs_by_callee[node.func.id] = [kw.arg for kw in node.keywords]
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id in {"Grok1Attention", "Grok1MLP"}
+            ):
+                kwargs_by_callee[node.func.id] = [kw.arg for kw in node.keywords]
 
         self.assertIn(
             "Grok1Attention",
@@ -430,9 +433,7 @@ class TestDpSpComposition(CustomTestCase):
         mesh = _make_dp_tp_mesh(dp_size=2, tp_size=4)
         # EPMoE.tp_size = world_size / ep_size = 8 → SP threshold = 8 * 128.
         batch = 8 * _MIN_LOCAL
-        x, topk_weights, topk_ids = _make_moe_inputs(
-            batch, self.HIDDEN_SIZE, self.NUM_EXPERTS
-        )
+        x, topk_weights, topk_ids = _make_moe_inputs(batch, self.HIDDEN_SIZE, self.NUM_EXPERTS)
 
         with jax.set_mesh(mesh):
             moe_sp = self._build_moe(mesh, enable_sequence_parallel=True)
@@ -446,9 +447,7 @@ class TestDpSpComposition(CustomTestCase):
 
         # See TestEPMoESequenceParallel for the noise-floor rationale (atol
         # sized to bf16 reduction-order drift on tens-of-thousands magnitudes).
-        np.testing.assert_allclose(
-            _as_fp32(out_sp), _as_fp32(out_base), rtol=0.1, atol=2048.0
-        )
+        np.testing.assert_allclose(_as_fp32(out_sp), _as_fp32(out_base), rtol=0.1, atol=2048.0)
 
     def _build_moe(self, mesh: Mesh, *, enable_sequence_parallel: bool) -> EPMoE:
         return EPMoE(

--- a/python/sgl_jax/test/layers/test_sequence_parallel.py
+++ b/python/sgl_jax/test/layers/test_sequence_parallel.py
@@ -32,6 +32,7 @@ from sgl_jax.test.test_utils import CustomTestCase
 _MESH = create_device_mesh(ici_parallelism=[1, -1], dcn_parallelism=[1, 1])
 _TP_SIZE = _MESH.shape.get("tensor", 1)
 _MIN_LOCAL = 128  # default tpu_scatter_min_local_size
+_TOTAL_DEVICES = len(jax.devices())
 
 
 def _spec_dim(sharding, dim):
@@ -63,10 +64,13 @@ class TestQuantizedLinearScatter(CustomTestCase):
         batch = _TP_SIZE * _MIN_LOCAL  # exactly at threshold
         scatter_out, baseline_out = self._run_pair(batch)
 
-        # Scatter path: output sharded on dim 0 over the tensor axis.
-        self.assertEqual(_spec_dim(scatter_out.sharding, 0), "tensor")
-        # Baseline: fully replicated (psum without scatter).
-        self.assertIsNone(_spec_dim(baseline_out.sharding, 0))
+        # Scatter path: dim 0 stripes across the data and tensor axes
+        # (data axis is size 1 here so it's effectively just "tensor", but
+        # the spec records both names — see TestDpSpComposition for the
+        # observable dp>1 case).
+        self.assertEqual(_spec_dim(scatter_out.sharding, 0), ("data", "tensor"))
+        # Baseline: DP-only sharding (no SP combine).
+        self.assertEqual(_spec_dim(baseline_out.sharding, 0), "data")
 
         # Same math, just different communication pattern. Tolerances cover
         # bf16 reduction-order drift over a 256-wide row-parallel sum (max
@@ -82,12 +86,12 @@ class TestQuantizedLinearScatter(CustomTestCase):
         batch = _TP_SIZE * (_MIN_LOCAL // 2)
         scatter_out, _ = self._run_pair(batch)
 
-        # Falls back to fully-replicated (no scatter).
-        self.assertIsNone(_spec_dim(scatter_out.sharding, 0))
+        # Falls back to DP-only sharding (no scatter combine).
+        self.assertEqual(_spec_dim(scatter_out.sharding, 0), "data")
 
     @unittest.skipIf(_TP_SIZE < 2, "Needs >=2 tensor-parallel devices.")
     def test_scatter_disabled_when_dimension_is_none(self):
-        """``output_scatter_dimension=None`` always replicates regardless of size."""
+        """``output_scatter_dimension=None`` keeps the DP-only spec regardless of size."""
         batch = _TP_SIZE * _MIN_LOCAL  # would-be scatter size
         x_host, weight_q, weight_scale = _make_quant_linear_inputs(batch, in_dim=256, out_dim=512)
 
@@ -96,7 +100,8 @@ class TestQuantizedLinearScatter(CustomTestCase):
             x = jax.device_put(x_host, NamedSharding(_MESH, P(None, "tensor")))
             out, _ = ql(x)
 
-        self.assertIsNone(_spec_dim(out.sharding, 0))
+        # No combine: dim 0 keeps the baseline ``"data"`` axis.
+        self.assertEqual(_spec_dim(out.sharding, 0), "data")
 
     def _run_pair(self, batch: int):
         in_dim, out_dim = 256, 512
@@ -185,15 +190,19 @@ class TestEPMoESequenceParallel(CustomTestCase):
                 out_sp = moe_sp(x, topk_weights, topk_ids)
                 out_base = moe_base(x, topk_weights, topk_ids)
 
-        self.assertEqual(_spec_dim(out_sp.sharding, 0), "tensor")
-        self.assertIsNone(_spec_dim(out_base.sharding, 0))
+        # Post-MoE reshard combines ``"data"`` (DP, size 1 here) with
+        # ``"tensor"`` (SP) on dim 0. With dp=1 the data axis is just a
+        # label, but the spec still records both names.
+        self.assertEqual(_spec_dim(out_sp.sharding, 0), ("data", "tensor"))
+        # SP off → DP-only spec on dim 0.
+        self.assertEqual(_spec_dim(out_base.sharding, 0), "data")
 
         np.testing.assert_allclose(_as_fp32(out_sp), _as_fp32(out_base), rtol=0.1, atol=2048.0)
 
     @unittest.skipIf(_TP_SIZE < 2, "Needs >=2 tensor-parallel devices.")
     def test_seq_parallel_replicates_below_threshold(self):
         """With seq-parallel ON but a tiny batch, ``should_scatter`` returns
-        False and we fall back to the fully-replicated psum path."""
+        False and we fall back to the DP-only psum path."""
         mesh = _make_moe_mesh(ep_size=1, tp_size=_TP_SIZE)
         batch = _TP_SIZE  # 8 tokens with tp=8 → way below 8*128
         x, topk_weights, topk_ids = _make_moe_inputs(batch, self.HIDDEN_SIZE, self.NUM_EXPERTS)
@@ -203,12 +212,13 @@ class TestEPMoESequenceParallel(CustomTestCase):
             with jax.set_mesh(moe_sp.moe_mesh):
                 out_sp = moe_sp(x, topk_weights, topk_ids)
 
-        self.assertIsNone(_spec_dim(out_sp.sharding, 0))
+        # Below threshold → no SP combine, dim 0 keeps the DP-only spec.
+        self.assertEqual(_spec_dim(out_sp.sharding, 0), "data")
 
     @unittest.skipIf(_TP_SIZE < 2, "Needs >=2 tensor-parallel devices.")
     def test_seq_parallel_disabled_always_replicates(self):
-        """``enable_sequence_parallel=False`` is the pre-21a6cf8d behavior:
-        the output is always fully replicated, regardless of batch size."""
+        """``enable_sequence_parallel=False`` keeps the DP-only spec on dim 0
+        regardless of batch size — the pre-feature behavior."""
         mesh = _make_moe_mesh(ep_size=1, tp_size=_TP_SIZE)
         batch = _TP_SIZE * _MIN_LOCAL  # would otherwise scatter
         x, topk_weights, topk_ids = _make_moe_inputs(batch, self.HIDDEN_SIZE, self.NUM_EXPERTS)
@@ -218,7 +228,7 @@ class TestEPMoESequenceParallel(CustomTestCase):
             with jax.set_mesh(moe.moe_mesh):
                 out = moe(x, topk_weights, topk_ids)
 
-        self.assertIsNone(_spec_dim(out.sharding, 0))
+        self.assertEqual(_spec_dim(out.sharding, 0), "data")
 
     def _build_moe(self, mesh: Mesh, *, enable_sequence_parallel: bool) -> EPMoE:
         return EPMoE(
@@ -347,6 +357,110 @@ class TestGrokLayerSequenceParallelWiring(CustomTestCase):
                 kwargs_by_callee["Grok1MLP"],
                 "Grok1DecoderLayer must thread enable_sequence_parallel into Grok1MLP.",
             )
+
+
+def _make_dp_tp_mesh(dp_size: int, tp_size: int) -> Mesh:
+    """Make a ``(dp_size, tp_size)`` mesh with axis names ``("data", "tensor")``.
+
+    Used to exercise the DP+SP composition path where the scatter dim must
+    combine ``"data"`` (from DP) with ``"tensor"`` (from SP) instead of
+    clobbering the former.
+    """
+    devices = np.array(jax.devices()[: dp_size * tp_size]).reshape(dp_size, tp_size)
+    return Mesh(
+        devices,
+        axis_names=("data", "tensor"),
+        axis_types=(jax.sharding.AxisType.Explicit,) * 2,
+    )
+
+
+class TestDpSpComposition(CustomTestCase):
+    """Verify scatter dim stripes across BOTH ``data`` and ``tensor`` under DP+SP.
+
+    The dp_size=1 tests above can't catch the wrong code path
+    ``out_specs[scatter_dim] = input_axis`` (clobbers ``"data"``) vs the
+    correct one ``out_specs[scatter_dim] = ("data", input_axis)`` (combines).
+    With dp_size>1 the difference becomes observable on the output sharding.
+    """
+
+    HIDDEN_SIZE = 512
+    INTERMEDIATE_DIM = 1024
+    NUM_EXPERTS = 4
+
+    @unittest.skipIf(_TOTAL_DEVICES < 8, "Needs >=8 devices for dp=2, tp=4.")
+    def test_quantized_linear_scatter_combines_data_and_tensor(self):
+        """SP firing under DP shards dim 0 across ``("data", "tensor")``."""
+        mesh = _make_dp_tp_mesh(dp_size=2, tp_size=4)
+        # Per-device local size after both splits must be >= _MIN_LOCAL for
+        # ``should_scatter`` to fire, so batch >= dp * tp * _MIN_LOCAL.
+        batch = 2 * 4 * _MIN_LOCAL
+        in_dim, out_dim = 256, 512
+        x_host, weight_q, weight_scale = _make_quant_linear_inputs(batch, in_dim, out_dim)
+
+        with jax.set_mesh(mesh):
+            ql_scatter = _build_quant_linear(
+                weight_q, weight_scale, mesh, output_scatter_dimension=0
+            )
+            ql_baseline = _build_quant_linear(
+                weight_q, weight_scale, mesh, output_scatter_dimension=None
+            )
+            x = jax.device_put(x_host, NamedSharding(mesh, P("data", "tensor")))
+            out_scatter, _ = ql_scatter(x)
+            out_baseline, _ = ql_baseline(x)
+
+        # The whole point of this test: dim 0 should stripe across BOTH axes,
+        # not have "data" replaced by "tensor".
+        self.assertEqual(_spec_dim(out_scatter.sharding, 0), ("data", "tensor"))
+        # Baseline keeps the DP-only sharding.
+        self.assertEqual(_spec_dim(out_baseline.sharding, 0), "data")
+
+        np.testing.assert_allclose(
+            _as_fp32(out_scatter), _as_fp32(out_baseline), rtol=0.05, atol=1.0
+        )
+
+    @unittest.skipIf(_TOTAL_DEVICES < 8, "Needs >=8 devices for dp=2, tp=4.")
+    def test_epmoe_seq_parallel_combines_data_and_tensor(self):
+        """SP firing inside EPMoE under DP preserves the scatter post-reshard.
+
+        With ep_size=1, ``EPMoE.tp_size`` collapses to ``world_size`` (= 8).
+        The post-shard_map reshard must target ``P(("data", "tensor"), None)``
+        on the original mesh; otherwise the SP scatter is all-gathered away
+        at the MoE→next-layer seam.
+        """
+        mesh = _make_dp_tp_mesh(dp_size=2, tp_size=4)
+        # EPMoE.tp_size = world_size / ep_size = 8 → SP threshold = 8 * 128.
+        batch = 8 * _MIN_LOCAL
+        x, topk_weights, topk_ids = _make_moe_inputs(
+            batch, self.HIDDEN_SIZE, self.NUM_EXPERTS
+        )
+
+        with jax.set_mesh(mesh):
+            moe_sp = self._build_moe(mesh, enable_sequence_parallel=True)
+            moe_base = self._build_moe(mesh, enable_sequence_parallel=False)
+            with jax.set_mesh(moe_sp.moe_mesh):
+                out_sp = moe_sp(x, topk_weights, topk_ids)
+                out_base = moe_base(x, topk_weights, topk_ids)
+
+        self.assertEqual(_spec_dim(out_sp.sharding, 0), ("data", "tensor"))
+        self.assertEqual(_spec_dim(out_base.sharding, 0), "data")
+
+        # See TestEPMoESequenceParallel for the noise-floor rationale (atol
+        # sized to bf16 reduction-order drift on tens-of-thousands magnitudes).
+        np.testing.assert_allclose(
+            _as_fp32(out_sp), _as_fp32(out_base), rtol=0.1, atol=2048.0
+        )
+
+    def _build_moe(self, mesh: Mesh, *, enable_sequence_parallel: bool) -> EPMoE:
+        return EPMoE(
+            hidden_size=self.HIDDEN_SIZE,
+            num_experts=self.NUM_EXPERTS,
+            num_experts_per_tok=1,
+            ep_size=1,
+            mesh=mesh,
+            intermediate_dim=self.INTERMEDIATE_DIM,
+            quantization_config=None,
+            enable_sequence_parallel=enable_sequence_parallel,
+        )
 
 
 if __name__ == "__main__":

--- a/python/sgl_jax/test/layers/test_sequence_parallel.py
+++ b/python/sgl_jax/test/layers/test_sequence_parallel.py
@@ -1,0 +1,353 @@
+"""Sequence-parallel scatter tests for QuantizedLinear, EPMoE, and Grok modules.
+
+Both layers fall back to a full all-reduce when ``should_scatter`` returns
+False (small batches or tp_size==1) and switch to a reduce-scatter on the
+sequence/token dimension when it returns True. These tests exercise both
+branches and verify the result is numerically equivalent.
+
+The Grok wiring tests guard against regressions of the form "the flag is
+plumbed through ``ServerArgs`` and the model config but doesn't actually
+reach the projection that needs to scatter."
+"""
+
+import ast
+import inspect
+import unittest
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.layers.linear import QuantizedLinear
+from sgl_jax.srt.layers.moe import EPMoE
+from sgl_jax.srt.models.grok import Grok1Attention, Grok1DecoderLayer, Grok1MLP
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+from sgl_jax.srt.utils.quantization.quantization_utils import quantize_tensor
+from sgl_jax.test.test_utils import CustomTestCase
+
+_MESH = create_device_mesh(ici_parallelism=[1, -1], dcn_parallelism=[1, 1])
+_TP_SIZE = _MESH.shape.get("tensor", 1)
+_MIN_LOCAL = 128  # default tpu_scatter_min_local_size
+
+
+def _spec_dim(sharding, dim):
+    """Return the partition-axis name at `dim` (or None if unsharded).
+
+    Tolerates ``PartitionSpec`` of any length: missing trailing entries are
+    treated as None, matching JAX's own semantics.
+    """
+    spec = sharding.spec
+    return spec[dim] if dim < len(spec) else None
+
+
+def _as_fp32(x):
+    """Cast to fp32 numpy for tolerance-based comparison.
+
+    ``psum`` and ``psum_scatter`` are mathematically identical but XLA may
+    pick different reduction trees, so per-element bf16 outputs can drift by
+    a few ULPs. Compare in fp32 with rtol/atol sized to that drift.
+    """
+    return np.asarray(x).astype(np.float32)
+
+
+class TestQuantizedLinearScatter(CustomTestCase):
+    """``QuantizedLinear.output_scatter_dimension`` behavior."""
+
+    @unittest.skipIf(_TP_SIZE < 2, "Needs >=2 tensor-parallel devices.")
+    def test_scatter_active_above_threshold(self):
+        """At/above threshold, output is reduce-scattered on dim 0 over `tensor`."""
+        batch = _TP_SIZE * _MIN_LOCAL  # exactly at threshold
+        scatter_out, baseline_out = self._run_pair(batch)
+
+        # Scatter path: output sharded on dim 0 over the tensor axis.
+        self.assertEqual(_spec_dim(scatter_out.sharding, 0), "tensor")
+        # Baseline: fully replicated (psum without scatter).
+        self.assertIsNone(_spec_dim(baseline_out.sharding, 0))
+
+        # Same math, just different communication pattern. Tolerances cover
+        # bf16 reduction-order drift over a 256-wide row-parallel sum (max
+        # observed abs diff ~0.5 against mean |y| ~12).
+        np.testing.assert_allclose(
+            _as_fp32(scatter_out), _as_fp32(baseline_out), rtol=0.05, atol=1.0
+        )
+
+    @unittest.skipIf(_TP_SIZE < 2, "Needs >=2 tensor-parallel devices.")
+    def test_scatter_inactive_below_threshold(self):
+        """Below the per-device min size, scatter is suppressed → psum path."""
+        # Pick a batch divisible by tp_size but well below threshold.
+        batch = _TP_SIZE * (_MIN_LOCAL // 2)
+        scatter_out, _ = self._run_pair(batch)
+
+        # Falls back to fully-replicated (no scatter).
+        self.assertIsNone(_spec_dim(scatter_out.sharding, 0))
+
+    @unittest.skipIf(_TP_SIZE < 2, "Needs >=2 tensor-parallel devices.")
+    def test_scatter_disabled_when_dimension_is_none(self):
+        """``output_scatter_dimension=None`` always replicates regardless of size."""
+        batch = _TP_SIZE * _MIN_LOCAL  # would-be scatter size
+        x_host, weight_q, weight_scale = _make_quant_linear_inputs(batch, in_dim=256, out_dim=512)
+
+        with jax.set_mesh(_MESH):
+            ql = _build_quant_linear(weight_q, weight_scale, _MESH, output_scatter_dimension=None)
+            x = jax.device_put(x_host, NamedSharding(_MESH, P(None, "tensor")))
+            out, _ = ql(x)
+
+        self.assertIsNone(_spec_dim(out.sharding, 0))
+
+    def _run_pair(self, batch: int):
+        in_dim, out_dim = 256, 512
+        x_host, weight_q, weight_scale = _make_quant_linear_inputs(batch, in_dim, out_dim)
+
+        with jax.set_mesh(_MESH):
+            ql_scatter = _build_quant_linear(
+                weight_q, weight_scale, _MESH, output_scatter_dimension=0
+            )
+            ql_baseline = _build_quant_linear(
+                weight_q, weight_scale, _MESH, output_scatter_dimension=None
+            )
+
+            x = jax.device_put(x_host, NamedSharding(_MESH, P(None, "tensor")))
+            out_scatter, _ = ql_scatter(x)
+            out_baseline, _ = ql_baseline(x)
+
+        return out_scatter, out_baseline
+
+
+def _make_quant_linear_inputs(batch: int, in_dim: int, out_dim: int):
+    key = jax.random.PRNGKey(0)
+    k_x, k_w = jax.random.split(key)
+    x_host = jax.random.normal(k_x, (batch, in_dim), dtype=jnp.bfloat16)
+    w_host = jax.random.normal(k_w, (out_dim, in_dim), dtype=jnp.bfloat16)
+    weight_q, weight_scale = quantize_tensor(jnp.int8, w_host.astype(jnp.float32), axis=1)
+    return x_host, weight_q, weight_scale
+
+
+def _build_quant_linear(weight_q, weight_scale, mesh, *, output_scatter_dimension):
+    ql = QuantizedLinear(
+        weight_q=weight_q,
+        weight_scale=weight_scale,
+        bias=None,
+        activation_dtype=None,
+        mesh=mesh,
+        kernel_axes=("tensor", None),
+        params_dtype=jnp.bfloat16,
+        compute_dtype=jnp.bfloat16,
+        output_scatter_dimension=output_scatter_dimension,
+    )
+    # Row-parallel: weight is [out, in]; shard on the input axis.
+    ql.weight_q = nnx.Param(weight_q, out_sharding=P(None, "tensor"))
+    ql.weight_scale = nnx.Param(weight_scale, out_sharding=P(None))
+    return ql
+
+
+def _make_moe_mesh(ep_size: int, tp_size: int) -> Mesh:
+    devices = np.array(jax.devices()[: ep_size * tp_size]).reshape(ep_size, tp_size)
+    return Mesh(
+        devices,
+        axis_names=("data", "tensor"),
+        axis_types=(jax.sharding.AxisType.Explicit, jax.sharding.AxisType.Explicit),
+    )
+
+
+def _make_moe_inputs(batch: int, hidden_size: int, num_experts: int):
+    key = jax.random.PRNGKey(7)
+    k_x, k_topk = jax.random.split(key)
+    x = jax.random.normal(k_x, (batch, hidden_size), dtype=jnp.bfloat16)
+    topk_weights = jnp.ones((batch, 1), dtype=jnp.bfloat16)
+    topk_ids = jax.random.randint(k_topk, (batch, 1), 0, num_experts)
+    return x, topk_weights, topk_ids
+
+
+class TestEPMoESequenceParallel(CustomTestCase):
+    """``EPMoE.enable_sequence_parallel`` scatter behavior."""
+
+    HIDDEN_SIZE = 512
+    INTERMEDIATE_DIM = 1024
+    NUM_EXPERTS = 4
+
+    @unittest.skipIf(_TP_SIZE < 2, "Needs >=2 tensor-parallel devices.")
+    def test_seq_parallel_scatters_above_threshold(self):
+        """With seq-parallel ON and a large enough batch, output is scattered
+        on dim 0 over `tensor`, and matches the all-reduce baseline."""
+        mesh = _make_moe_mesh(ep_size=1, tp_size=_TP_SIZE)
+        batch = _TP_SIZE * _MIN_LOCAL
+        x, topk_weights, topk_ids = _make_moe_inputs(batch, self.HIDDEN_SIZE, self.NUM_EXPERTS)
+
+        with jax.set_mesh(mesh):
+            moe_sp = self._build_moe(mesh, enable_sequence_parallel=True)
+            moe_base = self._build_moe(mesh, enable_sequence_parallel=False)
+
+            with jax.set_mesh(moe_sp.moe_mesh):
+                out_sp = moe_sp(x, topk_weights, topk_ids)
+                out_base = moe_base(x, topk_weights, topk_ids)
+
+        self.assertEqual(_spec_dim(out_sp.sharding, 0), "tensor")
+        self.assertIsNone(_spec_dim(out_base.sharding, 0))
+
+        np.testing.assert_allclose(_as_fp32(out_sp), _as_fp32(out_base), rtol=0.1, atol=2048.0)
+
+    @unittest.skipIf(_TP_SIZE < 2, "Needs >=2 tensor-parallel devices.")
+    def test_seq_parallel_replicates_below_threshold(self):
+        """With seq-parallel ON but a tiny batch, ``should_scatter`` returns
+        False and we fall back to the fully-replicated psum path."""
+        mesh = _make_moe_mesh(ep_size=1, tp_size=_TP_SIZE)
+        batch = _TP_SIZE  # 8 tokens with tp=8 → way below 8*128
+        x, topk_weights, topk_ids = _make_moe_inputs(batch, self.HIDDEN_SIZE, self.NUM_EXPERTS)
+
+        with jax.set_mesh(mesh):
+            moe_sp = self._build_moe(mesh, enable_sequence_parallel=True)
+            with jax.set_mesh(moe_sp.moe_mesh):
+                out_sp = moe_sp(x, topk_weights, topk_ids)
+
+        self.assertIsNone(_spec_dim(out_sp.sharding, 0))
+
+    @unittest.skipIf(_TP_SIZE < 2, "Needs >=2 tensor-parallel devices.")
+    def test_seq_parallel_disabled_always_replicates(self):
+        """``enable_sequence_parallel=False`` is the pre-21a6cf8d behavior:
+        the output is always fully replicated, regardless of batch size."""
+        mesh = _make_moe_mesh(ep_size=1, tp_size=_TP_SIZE)
+        batch = _TP_SIZE * _MIN_LOCAL  # would otherwise scatter
+        x, topk_weights, topk_ids = _make_moe_inputs(batch, self.HIDDEN_SIZE, self.NUM_EXPERTS)
+
+        with jax.set_mesh(mesh):
+            moe = self._build_moe(mesh, enable_sequence_parallel=False)
+            with jax.set_mesh(moe.moe_mesh):
+                out = moe(x, topk_weights, topk_ids)
+
+        self.assertIsNone(_spec_dim(out.sharding, 0))
+
+    def _build_moe(self, mesh: Mesh, *, enable_sequence_parallel: bool) -> EPMoE:
+        return EPMoE(
+            hidden_size=self.HIDDEN_SIZE,
+            num_experts=self.NUM_EXPERTS,
+            num_experts_per_tok=1,
+            ep_size=1,
+            mesh=mesh,
+            intermediate_dim=self.INTERMEDIATE_DIM,
+            quantization_config=None,
+            enable_sequence_parallel=enable_sequence_parallel,
+        )
+
+
+def _single_node_mesh() -> Mesh:
+    """Mesh covering all visible devices on the ``tensor`` axis.
+
+    Constructor wiring tests don't run forward, so a 1-device mesh is fine,
+    but we use the full mesh so the test exercises the same sharding pathway
+    used at runtime.
+    """
+    devices = np.array(jax.devices()).reshape(1, -1)
+    return Mesh(
+        devices,
+        axis_names=("data", "tensor"),
+        axis_types=(jax.sharding.AxisType.Explicit,) * 2,
+    )
+
+
+class TestGrokLayerSequenceParallelWiring(CustomTestCase):
+    """Verify ``enable_sequence_parallel`` reaches the projection that needs it.
+
+    These were the silent-failure modes called out in review: the flag exists
+    on ``ServerArgs`` and propagates onto the model config, but if a layer
+    forgets to thread it into its row-parallel projection, sequence parallel
+    becomes a no-op for that layer.
+    """
+
+    def test_grok1_mlp_wires_scatter_when_enabled(self):
+        mesh = _single_node_mesh()
+        with jax.set_mesh(mesh):
+            mlp = Grok1MLP(
+                hidden_size=128,
+                intermediate_size=256,
+                layer_id=0,
+                mesh=mesh,
+                enable_sequence_parallel=True,
+            )
+        # Only down_proj (row-parallel) should scatter; gate/up are column-parallel.
+        self.assertEqual(mlp.down_proj.output_scatter_dimension, 0)
+        self.assertIsNone(mlp.gate_proj.output_scatter_dimension)
+        self.assertIsNone(mlp.up_proj.output_scatter_dimension)
+
+    def test_grok1_mlp_disables_scatter_by_default(self):
+        mesh = _single_node_mesh()
+        with jax.set_mesh(mesh):
+            mlp = Grok1MLP(hidden_size=128, intermediate_size=256, layer_id=0, mesh=mesh)
+        self.assertIsNone(mlp.down_proj.output_scatter_dimension)
+
+    def test_grok1_attention_wires_scatter_when_enabled(self):
+        mesh = _single_node_mesh()
+        cfg = SimpleNamespace(head_dim=64)
+        with jax.set_mesh(mesh):
+            attn = Grok1Attention(
+                config=cfg,
+                hidden_size=128,
+                num_heads=2,
+                num_kv_heads=2,
+                mesh=mesh,
+                enable_sequence_parallel=True,
+            )
+        self.assertEqual(attn.o_proj.output_scatter_dimension, 0)
+        # q/k/v projections are column-parallel; they don't scatter on output.
+        self.assertIsNone(attn.q_proj.output_scatter_dimension)
+        self.assertIsNone(attn.k_proj.output_scatter_dimension)
+        self.assertIsNone(attn.v_proj.output_scatter_dimension)
+
+    def test_grok1_attention_disables_scatter_by_default(self):
+        mesh = _single_node_mesh()
+        cfg = SimpleNamespace(head_dim=64)
+        with jax.set_mesh(mesh):
+            attn = Grok1Attention(
+                config=cfg,
+                hidden_size=128,
+                num_heads=2,
+                num_kv_heads=2,
+                mesh=mesh,
+            )
+        self.assertIsNone(attn.o_proj.output_scatter_dimension)
+
+    def test_grok1_decoder_layer_threads_flag_to_attention_and_mlp(self):
+        """Static check: ``Grok1DecoderLayer.__init__`` forwards
+        ``config.enable_sequence_parallel`` to both the ``Grok1Attention`` and
+        the ``Grok1MLP`` constructors.
+
+        Done via AST inspection instead of full instantiation: building a
+        ``Grok1DecoderLayer`` requires a complete MoE setup (gate, experts,
+        weight allocation) which is far heavier than what this assertion
+        needs. The bug class we're guarding against — forgetting to pass the
+        kwarg through — is structural and visible in the source.
+        """
+        src = inspect.getsource(Grok1DecoderLayer.__init__)
+        tree = ast.parse(src.lstrip())
+
+        kwargs_by_callee: dict[str, list[str]] = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id in {"Grok1Attention", "Grok1MLP"}:
+                    kwargs_by_callee[node.func.id] = [kw.arg for kw in node.keywords]
+
+        self.assertIn(
+            "Grok1Attention",
+            kwargs_by_callee,
+            "Grok1DecoderLayer.__init__ no longer instantiates Grok1Attention",
+        )
+        self.assertIn(
+            "enable_sequence_parallel",
+            kwargs_by_callee["Grok1Attention"],
+            "Grok1DecoderLayer must thread enable_sequence_parallel into Grok1Attention; "
+            "without it, attention's o_proj never reduce-scatters even with the flag set.",
+        )
+        # Grok1MLP only appears in the residual-MoE branch; assert only if present.
+        if "Grok1MLP" in kwargs_by_callee:
+            self.assertIn(
+                "enable_sequence_parallel",
+                kwargs_by_callee["Grok1MLP"],
+                "Grok1DecoderLayer must thread enable_sequence_parallel into Grok1MLP.",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_parallel_utils.py
+++ b/test/srt/test_parallel_utils.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import patch
+
+from sgl_jax.srt.utils.parallel_utils import should_scatter
+
+
+class TestShouldScatter(unittest.TestCase):
+    def setUp(self):
+        self.patcher = patch(
+            "sgl_jax.srt.utils.parallel_utils.global_config.tpu_scatter_min_local_size",
+            128,
+        )
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_single_device_never_scatters(self):
+        self.assertFalse(should_scatter(dim_size=8192, num_devices=1))
+        self.assertFalse(should_scatter(dim_size=8192, num_devices=0))
+
+    def test_below_min_local_size_does_not_scatter(self):
+        # 4 * 128 = 512 is the minimum; 256 is below.
+        self.assertFalse(should_scatter(dim_size=256, num_devices=4))
+
+    def test_exactly_min_local_size_scatters(self):
+        self.assertTrue(should_scatter(dim_size=512, num_devices=4))
+
+    def test_above_min_local_size_scatters(self):
+        self.assertTrue(should_scatter(dim_size=2048, num_devices=4))
+
+    def test_not_divisible_does_not_scatter(self):
+        # Above threshold (4 * 128 = 512) but 513 % 4 != 0.
+        self.assertFalse(should_scatter(dim_size=513, num_devices=4))
+
+    def test_respects_configured_min_local_size(self):
+        with patch(
+            "sgl_jax.srt.utils.parallel_utils.global_config.tpu_scatter_min_local_size",
+            64,
+        ):
+            # 4 * 64 = 256, so 256 now qualifies.
+            self.assertTrue(should_scatter(dim_size=256, num_devices=4))
+            self.assertFalse(should_scatter(dim_size=128, num_devices=4))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

For TP-sharded models on TPU (grok-2, TP=8), the reduce across the row-parallel of out-projections of attention, down-projections of MLP, weighted sum of expert activations of MoE was a plain `psum` that broadcasts the full hidden activation back to every device. And the following RMSNorm was observed to be very slow, mainly due to that the operations are done on VPU and grok-2 uses dual RMSNorm.
<img width="733" height="258" alt="image" src="https://github.com/user-attachments/assets/9550a88e-8743-4538-af13-1f1f0551d2b8" />

When enabling sequence parallel, each device only needs to do 1/TP compute for RMSNorm, this reduced the time cost linearly when the global tensor is large enough.
<img width="664" height="383" alt="image" src="https://github.com/user-attachments/assets/0c919dbf-8f5c-4346-9429-672313a0e8ae" />

This PR introduces **sequence parallel** for grok-2: the row-parallel reductions become `psum_scatter` along the sequence dimension when the per-device slice is large enough to be worthwhile (default threshold ≥128 tokens/device), and all-gather activations back at the beginning of attention and MLP + MoE.

The feature is gated behind a new opt-in server flag and defaults to off, so existing behavior is unchanged.

## Other options
A fused dual RMSNorm kernel can also help with the RMSNorm slowness. This is an orthogonal solution and in the case of large seq_len the sequence parallel turns to have better performance.

## Modifications

- **New server arg `--enable-sequence-parallel`** (`server_args.py`), default `False`, plumbed through `model_runner.py` into `model_config.hf_config.enable_sequence_parallel`.
- **New helper `should_scatter(dim_size, num_devices)`** (`srt/utils/parallel_utils.py`) — returns `True` only when the local slice is ≥ `tpu_scatter_min_local_size` (default 128, overridable via `TPU_SCATTER_MIN_LOCAL_SIZE` env var) and the dim divides evenly across devices (hard requirement of `psum_scatter(tiled=True)`).
- **`QuantizedLinear` (and `xla_quantized_matmul_local`)** now accept an `output_scatter_dimension`. When set and `should_scatter(...)` is true, the post-matmul all-reduce is replaced with `psum_scatter(tiled=True)` along that dim, and `out_specs` is updated to reflect the sharded output.
- **`EPMoE`** wires `enable_sequence_parallel` down through the `shard_map`: when enabled and the token dimension is scatter-eligible, the internal `psum` over the `"tensor"` axis becomes a `psum_scatter(scatter_dimension=0, tiled=True)`, the shard_map `out_specs` switches from `P(None)` to `P("tensor", None)`, and the result is resharded back to the original mesh via the sharded pspec instead of a full replication.
- **`Grok1MLP` / grok.py**: threads `enable_sequence_parallel` through to the row-parallel down-projection and sets `output_scatter_dimension=0` on the affected `QuantizedLinear`s.
- **`global_config.py`**: adds `tpu_scatter_min_local_size` (default 128).
- **Unit test**: `test/srt/test_parallel_utils.py` covers the `should_scatter` predicate (num_devices ≤ 1, non-divisible dim, below-threshold, exactly-at-threshold).

## Accuracy Tests

### Unit tests
Ran unit tests in `python/sgl_jax/test/` folder
[unit-test-sp-0423.txt](https://github.com/user-attachments/files/27030239/unit-test-sp-0423.txt)
The only test failure also happens in main branch
[unit-test-sp-0423-gmm-main.txt](https://github.com/user-attachments/files/27030267/unit-test-sp-0423-gmm-main.txt)

### E2E accuracy tests
Benchmark: **GPQA-Diamond** (198 items), 5-shot (evalscope auto-forces 5-shot for `Idavidrein/gpqa`), sampling `temperature=0.5, top_p=0.8, top_k=40, max_tokens=4096`, run via `evalscope` against `sgl_jax.launch_server` serving `xai-org/grok-2` on TPU (`--tp-size=8 --dtype=bfloat16 --quantization-config-path=fp8_grok.yaml --disable-radix-cache --page-size=128 --random-seed=3`).

5 runs each on this branch (default-off: `enable_sequence_parallel=False`) and on `main` at commit `7907875a`:

| Branch                                 | n | Mean     | Min    | Max    | Stdev  | Runs                                           |
|----------------------------------------|--:|---------:|-------:|-------:|-------:|------------------------------------------------|
| main @ 7907875a                        | 5 | 0.4707   | 0.4495 | 0.4949 | 0.0165 | 0.4495, 0.4747, 0.4949, 0.4697, 0.4646         |
| allow-sequence-parallel-dev (flag=off) | 5 | 0.4697   | 0.4444 | 0.4848 | 0.0171 | 0.4798, 0.4848, 0.4444, 0.4798, 0.4596         |

- Δmean = +0.0010 (main higher), Welch's t = 0.094 — no detectable difference.
- The observed per-run spread is consistent with sampling noise (binomial 1σ on 198 items at ~47% is ≈3.5pp).
- This demonstrates **no regression on the default-off path**. The flag-on path (actual sequence-parallel execution) was not exercised here because `launch-grok.sh` does not pass `--enable-sequence-parallel`; a separate accuracy run with the flag set is recommended before enabling it by default.

## Benchmarking and Profiling

### Summary

| Metric | Direction | sp_fixed wins / total | Mean Δ | Median Δ | Range |
|---|---|---|---|---|---|
| Total token throughput | higher is better | 15 / 18 | +24.63% | +3.16% | -36.7% … +396.1% |
| Output token throughput | higher is better | 15 / 18 | +24.17% | +3.16% | -36.7% … +393.3% |
| Median ITL | lower is better | 5 / 9 | -0.03% | -0.03% | -0.3% … +0.1% |
| Mean ITL | lower is better | 7 / 9 | +4.35% | -0.85% | -4.4% … +33.0% |
| Mean TTFT | lower is better | 15 / 18 | +90.86% | -8.99% | -38.3% … +1816.2% |
| Median E2E | lower is better | 17 / 18 | -9.15% | -4.50% | -95.6% … +7.7% |

**Reading the summary**: Median ITL is the steady-state decode metric — it's effectively flat (±0.3%) across all 9 OSL=1024 configs. Throughput and TTFT means are skewed by first-request JIT-compile spikes on the cold-start SP run (see the `1024/1024, conc=8` row which shows TTFT +1816% — that's a single cold-compile request inflating the mean, not a real regression).

### Side-by-side (all 18 configs)

| ISL / OSL | Conc | TotTput main | TotTput sp | Δ Tput | ITL med main | ITL med sp | Δ ITL med | ITL P95 main | ITL P95 sp | ITL P99 main | ITL P99 sp | TTFT main (ms) | TTFT sp | Δ TTFT |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| 1024 / 1 | 8 | 192.31 | 189.22 | -1.6% | 0.00 | 0.00 |  | 0.00 | 0.00 | 0.00 | 0.00 | 42615 | 43315 | +1.6% |
| 1024 / 1 | 16 | 296.66 | 401.82 | +35.4% | 0.00 | 0.00 |  | 0.00 | 0.00 | 0.00 | 0.00 | 45105 | 30695 | -31.9% |
| 1024 / 1 | 64 | 2044.94 | 2064.04 | +0.9% | 0.00 | 0.00 |  | 0.00 | 0.00 | 0.00 | 0.00 | 9554 | 9279 | -2.9% |
| 1024 / 1024 | 8 | 844.86 | 534.69 | -36.7% | 18.68 | 18.69 | +0.1% | 19.69 | 19.55 | 37.91 | 37.73 | 453 | 8684 | +1816.2% |
| 1024 / 1024 | 16 | 1421.08 | 1435.53 | +1.0% | 21.20 | 21.20 | +0.0% | 22.19 | 21.93 | 41.66 | 42.19 | 919 | 792 | -13.8% |
| 1024 / 1024 | 64 | 2112.16 | 1683.62 | -20.3% | 30.45 | 30.44 | -0.0% | 32.00 | 31.73 | 111.22 | 102.72 | 12339 | 12455 | +0.9% |
| 4096 / 1 | 8 | 2441.95 | 12114.96 | +396.1% | 0.00 | 0.00 |  | 0.00 | 0.00 | 0.00 | 0.00 | 3894 | 2402 | -38.3% |
| 4096 / 1 | 16 | 10821.91 | 11501.83 | +6.3% | 0.00 | 0.00 |  | 0.00 | 0.00 | 0.00 | 0.00 | 5264 | 4849 | -7.9% |
| 4096 / 1 | 64 | 10718.07 | 11361.49 | +6.0% | 0.00 | 0.00 |  | 0.00 | 0.00 | 0.00 | 0.00 | 20467 | 19264 | -5.9% |
| 4096 / 1024 | 8 | 1852.57 | 1868.11 | +0.8% | 18.73 | 18.75 | +0.1% | 19.27 | 19.55 | 19.55 | 19.95 | 1866 | 1846 | -1.1% |
| 4096 / 1024 | 16 | 2946.78 | 2995.21 | +1.6% | 21.28 | 21.21 | -0.3% | 21.95 | 22.03 | 22.41 | 22.47 | 3493 | 3173 | -9.2% |
| 4096 / 1024 | 64 | 5875.50 | 6042.51 | +2.8% | 30.69 | 30.66 | -0.1% | 31.90 | 31.62 | 32.85 | 32.84 | 12645 | 11510 | -9.0% |
| 8192 / 1 | 8 | 13206.16 | 14931.27 | +13.1% | 0.00 | 0.00 |  | 0.00 | 0.00 | 0.00 | 0.00 | 4242 | 3752 | -11.5% |
| 8192 / 1 | 16 | 13241.09 | 14970.32 | +13.1% | 0.00 | 0.00 |  | 0.00 | 0.00 | 0.00 | 0.00 | 8356 | 7391 | -11.5% |
| 8192 / 1 | 64 | 13255.88 | 14993.04 | +13.1% | 0.00 | 0.00 |  | 0.00 | 0.00 | 0.00 | 0.00 | 33072 | 29240 | -11.6% |
| 8192 / 1024 | 8 | 2939.56 | 3010.09 | +2.4% | 19.63 | 19.62 | -0.1% | 20.20 | 20.27 | 20.47 | 20.64 | 2846 | 2517 | -11.5% |
| 8192 / 1024 | 16 | 4388.20 | 4540.47 | +3.5% | 23.11 | 23.13 | +0.1% | 23.77 | 24.05 | 24.07 | 24.48 | 4936 | 4535 | -8.1% |
| 8192 / 1024 | 64 | 6735.37 | 7116.67 | +5.7% | 36.45 | 36.44 | -0.0% | 37.29 | 37.32 | 38.29 | 38.22 | 24908 | 22666 | -9.0% |

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.

### Test command

```bash
# Unit test for the new helper
python -m pytest python/sgl_jax/test -x -v --tb=short --ignore=python/sgl_jax/test/multimodal 2>&1 | tee /cache/logs/tests/unit-test-sp-0423.txt

# Accuracy (default-off path, as tested here):
python3 -m sgl_jax.launch_server --model xai-org/grok-2 --trust-remote-code \
  --tp-size=8 --device=tpu --dtype=bfloat16 \
  --quantization-config-path=fp8_grok.yaml --page-size=128 \
  --tokenizer-path alvarobartt/grok-2-tokenizer \
  --disable-radix-cache --chunked-prefill-size 16384 --max-running-requests 256

evalscope eval --model xai-org/grok-2 \
  --api-url http://127.0.0.1:30000/v1/chat/completions --api-key EMPTY \
  --eval-type openai_api --datasets gpqa_diamond --dataset-hub huggingface \
  --eval-batch-size 198 \
  --dataset-args '{"gpqa_diamond": {"dataset_id": "Idavidrein/gpqa", "subset_list": ["gpqa_diamond"]}}' \
  --generation-config '{"temperature": 0.5,"top_p":0.8,"top_k":40, "max_tokens": 4096}'

# Benchmark
#!/bin/bash

set -e

if [ -z "$1" ]; then
    echo "Usage: $0 <engine>"
    echo "engine: sgl-jax, sglang-oai or vllm"
    exit 1
fi

backend=${1}
num_prompts_per_concurrency=3
input_seq_lens=(1024 4096 8192)
output_seq_lens=(1 1024) # 1 for TTFT
max_concurrencies=(8 16 64)

for input_seq_len in "${input_seq_lens[@]}"; do
    for output_seq_len in "${output_seq_lens[@]}"; do
        echo "======================================="
        echo "Testing with ISL/OSL: $input_seq_len/$output_seq_len"
        echo "======================================="
        for max_concurrency in "${max_concurrencies[@]}"; do
            echo "benchmark on max_concurrency=$max_concurrency"
            num_prompts=$((num_prompts_per_concurrency * max_concurrency))
            uv run python -m sgl_jax.bench_serving \
              --backend ${backend} \
              --dataset-name random \
              --num-prompts ${num_prompts} \
              --random-input-len ${input_seq_len} \
              --random-output-len ${output_seq_len} \
              --max-concurrency ${max_concurrency} \
              --random-range-ratio 1 \
              --disable-ignore-eos \
              --warmup-requests 0 \
              --tokenizer alvarobartt/grok-2-tokenizer
        done
    done
done

# Accuracy + perf with the feature enabled: add --enable-sequence-parallel
# to the launch-server command above.
```
