### PR TITLE
feat: Add debug sharding logging utils

### DIFF
--- a/python/sgl_jax/srt/layers/layernorm.py
+++ b/python/sgl_jax/srt/layers/layernorm.py
@@ -216,6 +216,7 @@ class GemmaRMSNorm(nnx.Module):
         x = x.astype(orig_dtype)
         return x if residual is None else (x, residual)
 
+
 def rmsnorm_forward(x, residual, weight, epsilon) -> jax.Array | tuple[jax.Array, jax.Array]:
     orig_dtype = x.dtype
     x_f32 = jnp.asarray(x, jnp.float32)

--- a/python/sgl_jax/srt/layers/layernorm.py
+++ b/python/sgl_jax/srt/layers/layernorm.py
@@ -216,7 +216,6 @@ class GemmaRMSNorm(nnx.Module):
         x = x.astype(orig_dtype)
         return x if residual is None else (x, residual)
 
-
 def rmsnorm_forward(x, residual, weight, epsilon) -> jax.Array | tuple[jax.Array, jax.Array]:
     orig_dtype = x.dtype
     x_f32 = jnp.asarray(x, jnp.float32)

--- a/python/sgl_jax/srt/model_loader/loader.py
+++ b/python/sgl_jax/srt/model_loader/loader.py
@@ -16,6 +16,7 @@ from sgl_jax.srt.configs.load_config import LoadConfig, LoadFormat
 from sgl_jax.srt.configs.model_config import ModelConfig
 from sgl_jax.srt.model_loader.arch import get_model_architecture
 from sgl_jax.srt.utils.common_utils import get_bool_env_var
+from sgl_jax.srt.utils.debug_utils import print_parameter_shardings
 
 logger = logging.getLogger(__name__)
 
@@ -260,6 +261,9 @@ class JAXModelLoader(DefaultModelLoader):
         else:
             logger.info("No quantization config found. Skipping quantization.")
         model.load_weights(model_config)
+
+        print_parameter_shardings(model)
+
         return model
 
 

--- a/python/sgl_jax/srt/models/grok.py
+++ b/python/sgl_jax/srt/models/grok.py
@@ -40,6 +40,7 @@ logger = logging.getLogger(__name__)
 
 init_fn = nnx.initializers.uniform()
 
+
 def _yarn_linear_ramp_mask(low: float, high: float, dim: int, dtype: jnp.dtype) -> jax.Array:
     """Create a linear ramp mask for YaRN scaling."""
     if low == high:

--- a/python/sgl_jax/srt/models/grok.py
+++ b/python/sgl_jax/srt/models/grok.py
@@ -33,12 +33,12 @@ from sgl_jax.srt.layers.moe import EPMoE, create_moe_weights_mapping
 from sgl_jax.srt.layers.radix_attention import RadixAttention
 from sgl_jax.srt.mem_cache.memory_pool import KVCache
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+from sgl_jax.srt.utils.debug_utils import log_shardings
 from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
 
 logger = logging.getLogger(__name__)
 
 init_fn = nnx.initializers.uniform()
-
 
 def _yarn_linear_ramp_mask(low: float, high: float, dim: int, dtype: jnp.dtype) -> jax.Array:
     """Create a linear ramp mask for YaRN scaling."""
@@ -196,6 +196,7 @@ class Grok1MLP(nnx.Module):
         self.layer_id = layer_id
         self.reduce_results = reduce_results
 
+    @log_shardings("GrokMLP")
     def __call__(self, x: jax.Array) -> jax.Array:
         gate, _ = self.gate_proj(x)
         up, _ = self.up_proj(x)
@@ -278,6 +279,7 @@ class Grok1MoE(nnx.Module):
                 quantization_config=getattr(config, "quantization_config", None),
             )
 
+    @log_shardings("GrokMoE")
     def __call__(
         self,
         hidden_states: jax.Array,
@@ -472,6 +474,7 @@ class Grok1Attention(nnx.Module):
         )
         self.attn.xai_temperature_len = getattr(config, "attn_temperature_len", -1)
 
+    @log_shardings("GrokAttention")
     def __call__(
         self,
         positions: jax.Array,

--- a/python/sgl_jax/srt/utils/debug_utils.py
+++ b/python/sgl_jax/srt/utils/debug_utils.py
@@ -1,0 +1,47 @@
+import functools
+import os
+from enum import IntEnum
+
+
+class FrameworkLogLevel(IntEnum):
+    ERROR = 0
+    WARN = 1
+    INFO = 2
+    DEBUG = 3
+    TRACE = 4
+
+
+FRAMEWORK_LOG_LEVEL = FrameworkLogLevel(
+    int(os.environ.get("SGLANG_FRAMEWORK_LOG_LEVEL", "0"))
+)
+
+
+def print_parameter_shardings(model):
+    if FRAMEWORK_LOG_LEVEL < FrameworkLogLevel.DEBUG:
+        return
+    for name, param in model.named_parameters():
+        print(f"{name}: shape={param.value.shape} sharding={param.value.sharding}")
+
+
+def log_shardings(name):
+    def decorator(fn):
+        if FRAMEWORK_LOG_LEVEL < FrameworkLogLevel.DEBUG:
+            return fn
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            for i, a in enumerate(args):
+                if hasattr(a, "aval") and hasattr(a.aval, "sharding"):
+                    print(f"{name} input[{i}]: {a.aval.shape} {a.aval.sharding}")
+            result = fn(*args, **kwargs)
+            if hasattr(result, "aval") and hasattr(result.aval, "sharding"):
+                print(f"{name} output: {result.aval.shape} {result.aval.sharding}")
+            elif isinstance(result, tuple):
+                for i, r in enumerate(result):
+                    if hasattr(r, "aval") and hasattr(r.aval, "sharding"):
+                        print(f"{name} output[{i}]: {r.aval.shape} {r.aval.sharding}")
+            return result
+
+        return wrapper
+
+    return decorator

--- a/python/sgl_jax/srt/utils/debug_utils.py
+++ b/python/sgl_jax/srt/utils/debug_utils.py
@@ -11,9 +11,7 @@ class FrameworkLogLevel(IntEnum):
     TRACE = 4
 
 
-FRAMEWORK_LOG_LEVEL = FrameworkLogLevel(
-    int(os.environ.get("SGLANG_FRAMEWORK_LOG_LEVEL", "0"))
-)
+FRAMEWORK_LOG_LEVEL = FrameworkLogLevel(int(os.environ.get("SGLANG_FRAMEWORK_LOG_LEVEL", "0")))
 
 
 def print_parameter_shardings(model):


### PR DESCRIPTION
  ## Motivation

  Sharding mistakes in JAX models are easy to make and hard to spot — silently falling back from `P('tensor', ...)` to a replicated layout rarely throws, it just burns HBM and bandwidth. Today, debugging this means sprinkling ad-hoc `print(...)` calls in model code (e.g. duplicate `log_shardings` decorators were starting to appear in `layernorm.py` and `grok.py`),
  then ripping them out before merging.

  This PR introduces a single, env-gated debug utility for sharding inspection, and wires it into the Grok path.

  ## Modifications

  **New `python/sgl_jax/srt/utils/debug_utils.py`:**

  - `FrameworkLogLevel` (`IntEnum`): `ERROR=0`, `WARN=1`, `INFO=2`, `DEBUG=3`, `TRACE=4`.
  - `FRAMEWORK_LOG_LEVEL`: read once at import from `SGLANG_FRAMEWORK_LOG_LEVEL` (default `0`). `IntEnum` construction validates the value — unknown levels raise `ValueError` at startup rather than silently mis-gating.
  - `print_parameter_shardings(model)`: iterates `model.named_parameters()` and prints `name: shape=... sharding=...` for every parameter. No-op below `DEBUG`.
  - `log_shardings(name)`: decorator that prints each `__call__` input/output's shape + `NamedSharding` (reads `.aval.sharding` so it works inside `jit`). Returns the original function unwrapped below `DEBUG`, so there's zero runtime overhead at the default level.

  **Wiring:**

  - `python/sgl_jax/srt/model_loader/loader.py`: `JAXModelLoader.load_model` now calls `print_parameter_shardings(model)` after `load_weights` (replaces an unconditional inline loop).
  - `python/sgl_jax/srt/models/grok.py`: `Grok1MLP.__call__`, `Grok1MoE.__call__`, and `Grok1Attention.__call__` are decorated with `@log_shardings("GrokMLP" | "GrokMoE" | "GrokAttention")`.

  **Usage:**

  ```bash
  # default — silent
  python -m sgl_jax.launch_server ...

  # print parameter shardings at load time + activation shardings per forward
  SGLANG_FRAMEWORK_LOG_LEVEL=3 python -m sgl_jax.launch_server ...
```

**Sampled Outputs**
```
# Parameters
model.layers.1.self_attn.k_proj.weight: shape=(8192, 1024) sharding=NamedSharding(mesh=Mesh('data': 1, 'tensor': 8, axis_types=(Explicit, Explicit)), spec=P(None, 'tensor'), memory_kind=device)
model.layers.1.self_attn.o_proj.weight: shape=(8192, 8192) sharding=NamedSharding(mesh=Mesh('data': 1, 'tensor': 8, axis_types=(Explicit, Explicit)), spec=P('tensor', None), memory_kind=device)
model.layers.1.self_attn.q_proj.weight: shape=(8192, 8192) sharding=NamedSharding(mesh=Mesh('data': 1, 'tensor': 8, axis_types=(Explicit, Explicit)), spec=P(None, 'tensor'), memory_kind=device)
model.layers.1.self_attn.v_proj.weight: shape=(8192, 1024) sharding=NamedSharding(mesh=Mesh('data': 1, 'tensor': 8, axis_types=(Explicit, Explicit)), spec=P(None, 'tensor'), memory_kind=device)
model.layers.2.block_sparse_moe.experts.wi_0: shape=(8, 8192, 16384) sharding=NamedSharding(mesh=Mesh('expert': 1, 'tensor': 8, axis_types=(Explicit, Explicit)), spec=P('expert', 'tensor', None), memory_kind=device)
model.layers.2.block_sparse_moe.experts.wi_1: shape=(8, 8192, 16384) sharding=NamedSharding(mesh=Mesh('expert': 1, 'tensor': 8, axis_types=(Explicit, Explicit)), spec=P('expert', 'tensor', None), memory_kind=device)
model.layers.2.block_sparse_moe.experts.wo: shape=(8, 16384, 8192) sharding=NamedSharding(mesh=Mesh('expert': 1, 'tensor': 8, axis_types=(Explicit, Explicit)), spec=P('expert', None, 'tensor'), memory_kind=device)

# Activations
GrokMoE input[1]: (1, 8192) NamedSharding(mesh=AbstractMesh('data': 1, 'tensor': 8, axis_types=(Explicit, Explicit), device_kind=TPU7x, num_cores=1), spec=P(None, None))
GrokMoE output[0]: (1, 8192) NamedSharding(mesh=AbstractMesh('data': 1, 'tensor': 8, axis_types=(Explicit, Explicit), device_kind=TPU7x, num_cores=1), spec=P(None, None))
GrokMoE output[1]: (1, 2) NamedSharding(mesh=AbstractMesh('data': 1, 'tensor': 8, axis_types=(Explicit, Explicit), device_kind=TPU7x, num_cores=1), spec=P(None, None))
dual_norm input[0]: (1, 8192) NamedSharding(mesh=AbstractMesh('data': 1, 'tensor': 8, axis_types=(Explicit, Explicit), device_kind=TPU7x, num_cores=1), spec=P(None, None))
dual_norm input[1]: (1, 8192) NamedSharding(mesh=AbstractMesh('data': 1, 'tensor': 8, axis_types=(Explicit, Explicit), device_kind=TPU7x, num_cores=1), spec=P(None, None))
dual_norm input[2]: (8192,) NamedSharding(mesh=AbstractMesh('data': 1, 'tensor': 8, axis_types=(Explicit, Explicit), device_kind=TPU7x, num_cores=1), spec=P(None,))
dual_norm input[3]: (8192,) NamedSharding(mesh=AbstractMesh('data': 1, 'tensor': 8, axis_types=(Explicit, Explicit), device_kind=TPU7x, num_cores=1), spec=P(None,))
norm input[0]: (1, 8192) NamedSharding(mesh=AbstractMesh('data': 1, 'tensor': 8, axis_types=(Explicit, Explicit), device_kind=TPU7x, num_cores=1), spec=P(None, None))
```

  Accuracy Tests

  No model-math changes — this PR only adds gated instrumentation. Forward numerics are identical between level=0 and level=3 (the decorator calls fn(*args, **kwargs) and returns its result verbatim).

  Benchmarking and Profiling

  Smoke-tested on Grok-2 with --num_hidden_layers=4, TP=8, TPU, launch-grok-4layers.sh + send_request_grok_no_profile.sh (bs=1, input=8192, output=4):

  ┌────────────────────────────┬──────────────────────────────────┬──────────────────────────────────────────┬─────────┬──────────────┬─────────────┐
  │ SGLANG_FRAMEWORK_LOG_LEVEL │ Parameter sharding lines at load │ Activation sharding lines during request │ Latency │  Input tput  │ Output tput │
  ├────────────────────────────┼──────────────────────────────────┼──────────────────────────────────────────┼─────────┼──────────────┼─────────────┤
  │ 0 (default)                │ 0                                │ 0                                        │ 21.44 s │ 402.59 tok/s │ 3.66 tok/s  │
  ├────────────────────────────┼──────────────────────────────────┼──────────────────────────────────────────┼─────────┼──────────────┼─────────────┤
  │ 3 (DEBUG)                  │ 43                               │ 229                                      │ 21.26 s │ 405.91 tok/s │ 3.71 tok/s  │
  └────────────────────────────┴──────────────────────────────────┴──────────────────────────────────────────┴─────────┴──────────────┴─────────────┘

  Latency deltas are within run-to-run noise — the decorator short-circuits to the original function at level=0, and at level=3 the prints happen during tracing (not per-step), so steady-state performance is unaffected.

  Checklist

  - Please use English, otherwise it will be closed.
  - The purpose of the PR, or link existing issues this PR will resolve.
  - The test plan, such as providing test command.
  - (Optional) The necessary documentation update.