### PR TITLE
fix: MiMo V2 fp8 kv per-head fused block dequant and MoE gate f32 precision

### DIFF
--- a/python/sgl_jax/srt/layers/gate.py
+++ b/python/sgl_jax/srt/layers/gate.py
@@ -29,7 +29,7 @@ class GateLogit(nnx.Module):
             jax.random.normal(
                 jax.random.PRNGKey(0),
                 (input_size, num_experts),
-                dtype=self.weight_dtype,
+                dtype=jnp.float32,
                 out_sharding=P(None, None),
             ),
         )
@@ -47,7 +47,7 @@ class GateLogit(nnx.Module):
 
     @named_scope
     def __call__(self, hidden_states: jax.Array) -> tuple[jax.Array, jax.Array | None]:
-        logits = jnp.dot(hidden_states, self.kernel.value)
+        logits = jnp.dot(hidden_states, self.kernel.value, precision=jax.lax.Precision.HIGHEST)
 
         if self.score_func:
             if self.score_func == "softmax":

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -492,6 +492,9 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         self.config = config
         self.dtype = dtype
         self.model = MiMoV2Model(config, dtype=self.dtype, mesh=mesh)
+        # Buffer to hold raw FP8 K/V weights+scales for per-head fused dequant.
+        # Populated during weight loading, consumed by _dequant_fused_kv_heads.
+        self._kv_buffers: dict[int, dict] = {}
 
         if not getattr(self.config, "tie_word_embeddings", True):
             self.lm_head = ParallelLMHead(
@@ -520,6 +523,10 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         # Q/K head_dim padding (192→256) is handled by the kernel internally.
         if self._is_static_quant:
             self._dequantize_fp8_to_bf16()
+            # K+V: fused per-head dequant (cross K/V boundary blocks)
+            self._dequant_fused_kv_heads()
+            # KV head replication for TP alignment (after K/V are bf16 LinearBase)
+            self._ensure_kv_head_replication()
 
     def _is_quant_ignored(self, hf_path: str) -> bool:
         """Check if a HuggingFace weight path is in the quantization ignored_layers list."""
@@ -720,12 +727,12 @@ class MiMoV2FlashForCausalLM(nnx.Module):
 
         for layer_idx, layer in enumerate(self.model.layers):
             attn = layer.self_attn
-            for proj_name in ("q_proj", "k_proj", "v_proj"):
+            # Only Q and o_proj go through QuantizedLinear path.
+            # K/V are handled by _dequant_fused_kv_heads (per-head fused dequant).
+            for proj_name in ("q_proj",):
                 proj = getattr(attn, proj_name)
                 if isinstance(proj, QuantizedLinear):
-                    # Pass head_dim for per-head block quant handling.
-                    # Q/K use head_dim, V uses v_head_dim.
-                    hd = attn.v_head_dim if proj_name == "v_proj" else attn.head_dim
+                    hd = attn.head_dim
                     setattr(attn, proj_name, self._dequantize_quantized_linear(proj, head_dim=hd))
                     logger.info("Dequantized layer %d %s → bf16", layer_idx, proj_name)
 
@@ -739,11 +746,6 @@ class MiMoV2FlashForCausalLM(nnx.Module):
 
         logger.info("FP8 → BF16 dequantization complete.")
 
-        # Fix kv_head_padding for v_proj: the weight loader's _apply_kv_head_padding
-        # uses head_dim (Q/K) for shape matching, so it misses v_proj when
-        # v_head_dim != head_dim. Replicate kv_heads here.
-        self._ensure_kv_head_replication()
-
     def _ensure_kv_head_replication(self):
         """Replicate KV heads for TP alignment when the weight loader missed them."""
         attn = self.model.layers[0].self_attn
@@ -754,6 +756,146 @@ class MiMoV2FlashForCausalLM(nnx.Module):
             v_head_dim=attn.v_head_dim,
             target_kv_heads=attn.k_head_num,
         )
+
+    def _uniform_block_dequant(self, weight, scale, block_size):
+        """Simple uniform block dequant for weight[out_dim, in_dim] * scale[out_blocks, in_blocks].
+
+        Used for layers where K/V are quantized uniformly across all heads
+        (no cross-boundary scale sharing between K and V).
+        """
+        out_dim, in_dim = weight.shape
+        out_blocks = scale.shape[0]
+        padded_out = out_blocks * block_size
+        in_blocks = scale.shape[1]
+        if padded_out > out_dim:
+            weight = jnp.pad(weight, ((0, padded_out - out_dim), (0, 0)))
+        w_4d = weight.astype(jnp.float32).reshape(out_blocks, block_size, in_blocks, block_size)
+        s_4d = scale[:, None, :, None]
+        result = (w_4d * s_4d).reshape(padded_out, in_dim)[:out_dim, :].astype(jnp.bfloat16)
+        return result
+
+    def _dequant_fused_kv_heads(self):
+        """Dequantize FP8 K+V weights with per-layer quantization scheme detection.
+
+        Different layers may use different quantization schemes:
+        - Per-head fused: K+V quantized as fused [K(head_dim), V(v_head_dim)] per KV head.
+          Block boundaries cross K/V boundary, so they must be fused for correct dequant.
+          Signature: k_scale_blocks == num_kv_heads * ceil(head_dim/block_size)
+        - Uniform: K and V quantized independently across the whole tensor.
+          No cross-boundary issue, can dequant K and V separately.
+          Signature: k_scale_blocks == ceil(num_kv_heads * head_dim / block_size)
+        """
+        import math
+
+        from jax.sharding import NamedSharding
+
+        kv_buffers = self._kv_buffers
+        if not kv_buffers:
+            return
+
+        head_dim = self.config.head_dim
+        v_head_dim = getattr(self.config, "v_head_dim", head_dim)
+        quant_cfg = getattr(self, "_quant_config", None)
+        block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+
+        fused_dim = head_dim + v_head_dim
+        blocks_per_head = math.ceil(fused_dim / block_size)
+        padded_dim = blocks_per_head * block_size
+        k_blocks_per_head = math.ceil(head_dim / block_size)
+        v_blocks_per_head = blocks_per_head - k_blocks_per_head
+
+        tp_sharding = NamedSharding(self.mesh, P(None, "tensor"))
+
+        for layer_idx in sorted(kv_buffers.keys()):
+            buf = kv_buffers[layer_idx]
+            k_weight = buf["k_weight"]
+            k_scale = buf["k_scale"]
+            v_weight = buf["v_weight"]
+            v_scale = buf["v_scale"]
+
+            in_dim = k_weight.shape[1]
+            in_blocks = in_dim // block_size
+
+            # Per-layer num_kv_heads from actual weight shape
+            num_kv_heads = k_weight.shape[0] // head_dim
+            k_scale_blocks = k_scale.shape[0]
+
+            # Detect quantization scheme for this layer
+            expected_per_head = num_kv_heads * k_blocks_per_head
+            expected_uniform = math.ceil(num_kv_heads * head_dim / block_size)
+            is_per_head = (
+                k_scale_blocks == expected_per_head and expected_per_head != expected_uniform
+            )
+
+            if is_per_head:
+                # Per-head fused: K+V must be fused because scale blocks cross K/V boundary
+                k_w = k_weight.reshape(num_kv_heads, head_dim, in_dim)
+                v_w = v_weight.reshape(num_kv_heads, v_head_dim, in_dim)
+                k_s = k_scale.reshape(num_kv_heads, k_blocks_per_head, in_blocks)
+                v_s = v_scale.reshape(num_kv_heads, v_blocks_per_head, in_blocks)
+                fused_w = jnp.concatenate([k_w, v_w], axis=1)
+                fused_s = jnp.concatenate([k_s, v_s], axis=1)
+                if fused_dim < padded_dim:
+                    fused_w = jnp.pad(fused_w, ((0, 0), (0, padded_dim - fused_dim), (0, 0)))
+                fused_5d = fused_w.astype(jnp.float32).reshape(
+                    num_kv_heads, blocks_per_head, block_size, in_blocks, block_size
+                )
+                scale_5d = fused_s[:, :, None, :, None]
+                dequanted = (
+                    (fused_5d * scale_5d)
+                    .reshape(num_kv_heads, padded_dim, in_dim)[:, :fused_dim, :]
+                    .astype(jnp.bfloat16)
+                )
+                k_bf16 = dequanted[:, :head_dim, :].reshape(num_kv_heads * head_dim, in_dim)
+                v_bf16 = dequanted[:, head_dim:, :].reshape(num_kv_heads * v_head_dim, in_dim)
+            else:
+                # Uniform: K and V can be dequanted independently
+                k_bf16 = self._uniform_block_dequant(k_weight, k_scale, block_size)
+                v_bf16 = self._uniform_block_dequant(v_weight, v_scale, block_size)
+
+            # Transpose [out, in] → [in, out], shard, replace
+            k_bf16 = jax.device_put(jnp.transpose(k_bf16), tp_sharding)
+            v_bf16 = jax.device_put(jnp.transpose(v_bf16), tp_sharding)
+
+            attn = self.model.layers[layer_idx].self_attn
+            in_k, out_k = k_bf16.shape
+            in_v, out_v = v_bf16.shape
+
+            with jax.set_mesh(self.mesh):
+                k_linear = LinearBase(
+                    input_size=in_k,
+                    output_size=out_k,
+                    kernel_axes=(None, "tensor"),
+                    use_bias=False,
+                    params_dtype=jnp.bfloat16,
+                    mesh=self.mesh,
+                )
+                k_linear.weight = nnx.Param(k_bf16)
+                attn.k_proj = k_linear
+
+                v_linear = LinearBase(
+                    input_size=in_v,
+                    output_size=out_v,
+                    kernel_axes=(None, "tensor"),
+                    use_bias=False,
+                    params_dtype=jnp.bfloat16,
+                    mesh=self.mesh,
+                )
+                v_linear.weight = nnx.Param(v_bf16)
+                attn.v_proj = v_linear
+
+            if layer_idx % 10 == 0 or layer_idx == 0:
+                logger.info(
+                    "Layer %d KV dequant: %s, heads=%d, K=%s V=%s",
+                    layer_idx,
+                    "per-head" if is_per_head else "uniform",
+                    num_kv_heads,
+                    k_bf16.shape,
+                    v_bf16.shape,
+                )
+
+        kv_buffers.clear()
+        logger.info("FP8 KV dequantization complete for all layers.")
 
     def _create_weight_mappings(self) -> dict:
         mappings = {
@@ -797,6 +939,23 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         ]:
             hf_key = f"{prefix}.self_attn.{proj}"
             ignored = self._is_quant_ignored(hf_key)
+
+            # FP8 K/V: bypass QuantizedLinear, store raw FP8 data for fused
+            # per-head dequant (cross K/V boundary blocks).
+            if is_fp8 and not ignored and proj in ("k_proj", "v_proj"):
+                kv_key = "K" if proj == "k_proj" else "V"
+                mappings[f"{hf_key}.weight"] = WeightMapping(
+                    target_path=f"__KV_{kv_key}_WEIGHT__{layer_idx}",
+                    sharding=(None, None),
+                    transpose=False,
+                )
+                mappings[f"{hf_key}.weight_scale_inv"] = WeightMapping(
+                    target_path=f"__KV_{kv_key}_SCALE__{layer_idx}",
+                    sharding=(None, None),
+                    transpose=False,
+                )
+                continue
+
             weight_suffix = "weight" if (not is_fp8 or ignored) else "weight_q"
 
             mappings[f"{hf_key}.weight"] = WeightMapping(

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -1478,6 +1478,28 @@ class WeightLoader:
         jax_path = mapping.target_path
         processed_weight = weight
 
+        # Handle fused KV buffer storage (used by MiMo-V2-Flash per-head dequant).
+        # target_path like "__KV_K_WEIGHT__42" stores into model._kv_buffers.
+        if jax_path.startswith("__KV_"):
+            if hasattr(self.model, "_kv_buffers"):
+                layer_idx = int(jax_path.rsplit("__", 1)[-1])
+                buf = self.model._kv_buffers.setdefault(layer_idx, {})
+                if "K_WEIGHT" in jax_path:
+                    buf["k_weight"] = processed_weight
+                elif "K_SCALE" in jax_path:
+                    buf["k_scale"] = processed_weight
+                elif "V_WEIGHT" in jax_path:
+                    buf["v_weight"] = processed_weight
+                elif "V_SCALE" in jax_path:
+                    buf["v_scale"] = processed_weight
+                logger.info(
+                    "Stored KV buffer %s for layer %d, shape=%s",
+                    jax_path.split("__")[2],
+                    layer_idx,
+                    processed_weight.shape,
+                )
+            return
+
         # Apply output_multiplier_scale to lm_head weights (matching PyTorch implementation)
         if "lm_head" in hf_key and hasattr(self.model_config.hf_config, "output_multiplier_scale"):
             logger.info(


### PR DESCRIPTION
## Summary

- **FP8 KV per-head fused dequant**: MiMo-V2-Flash uses per-head block quantization for K/V where block boundaries cross the K/V split point within each KV head. The old path dequanted K and V independently, producing wrong V values (~6x error). New fused dequant concatenates K+V per head, applies block scales across the boundary, then splits back. Includes per-layer auto-detection of per-head vs uniform quantization schemes.
- **MoE gate f32 precision**: Gate weight kept as f32 (matching checkpoint precision) with `Precision.HIGHEST` for the dot product, preventing expert mis-routing from bf16 truncation in 256-expert MoE.

## Test plan
with MiMo-V2-Flash Model
- [x] AIME2025-I: 14/15 (thinking mode) on 16×v7x with TP=32, DP=4, EP=32
- [x] AIME2025-II: 15/15
- [x] Per-layer quantization scheme auto-detection verified across all 70 layers