### PR TITLE
fix: re-increment is_chunked for ongoing chunked-prefill reqs across DP

### DIFF
--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1518,6 +1518,8 @@ class Scheduler(
             if self.chunked_reqs[dp_rank] is not None:
                 self.chunked_reqs[dp_rank].init_next_round_input()
                 self.chunked_reqs[dp_rank] = adder.add_chunked_req(self.chunked_reqs[dp_rank])
+                if self.chunked_reqs[dp_rank] is not None:
+                    self.chunked_reqs[dp_rank].is_chunked += 1
 
         # Collect existing LoRA IDs in the running batch if LoRA is enabled
         if self.lora_paths is not None:


### PR DESCRIPTION
When a chunked-prefill request is dispatched for its next chunk via adder.add_chunked_req, its is_chunked counter must be re-incremented to match the +1 it will receive on the result side (decremented when the chunk completes). The DP refactor dropped this, so for any 3+ chunk request the counter falls to 0 prematurely; the next chunk's result is then routed through the sample/finish branch instead of the chunked branch, calling cache_finished_req on a still-in-progress req and corrupting req_to_token_pool / KV cache (manifests as over-free asserts and pool leaks at end of bench).

Reproduces in <2s on TPU v6e-64 (16-pod, MiMo-V2-Flash) with chunked_prefill_size=1024 + random_input_len=4096 (every req becomes 4-chunk). After the fix, identical workload completes 32/32 with no asserts and pool leak gone.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
