### PR TITLE
test(penalty): add functional tests for penalty parameters

### DIFF
--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -517,6 +517,7 @@ suites = {
         TestFile("test/srt/openai_server/features/test_structural_tag.py", 2),
         TestFile("test/srt/test_srt_engine.py", 1),
         TestFile("test/srt/test_logprobs.py", 3),
+        TestFile("test/srt/test_penalty.py", 12),
         TestFile("test/srt/test_qwen1_5_models_dummy.py", 3),
         TestFile("test/srt/lora/test_bgmv_backend.py", 6),
         TestFile("test/srt/lora/test_dynamic_lora.py", 10),

--- a/test/srt/test_penalty.py
+++ b/test/srt/test_penalty.py
@@ -127,6 +127,16 @@ class TestPenalty(CustomTestCase):
                 f"{avg_baseline:.1f} -> {avg_penalty:.1f}",
             )
 
+    def test_frequency_penalty_reduces_word_repetition(self):
+        """frequency_penalty should reduce repetition of a target word."""
+        prompt = (
+            "Write exactly 10 very small sentences, each containing the word "
+            "'data'. Use the word 'data' as much as possible."
+        )
+        baseline_params = {"frequency_penalty": 0.0}
+        penalty_params = {"frequency_penalty": 1.99}
+        self._test_penalty_effect(prompt, baseline_params, penalty_params, "data")
+
     def test_server_alive(self):
         """Sanity check: server is up and /v1/chat/completions responds."""
         resp = requests.post(

--- a/test/srt/test_penalty.py
+++ b/test/srt/test_penalty.py
@@ -146,6 +146,22 @@ class TestPenalty(CustomTestCase):
         penalty_params = {"presence_penalty": 1.99}
         self._test_penalty_effect(prompt, baseline_params, penalty_params, "machine learning")
 
+    def test_combined_penalties_reduce_repetition(self):
+        """Combined frequency + presence penalties should reduce repetition."""
+        prompt = (
+            "Write exactly 10 short sentences, each containing the word 'data'. "
+            "Use the word 'data' as much as possible."
+        )
+        baseline_params = {
+            "frequency_penalty": 0.0,
+            "presence_penalty": 0.0,
+        }
+        penalty_params = {
+            "frequency_penalty": 1.99,
+            "presence_penalty": 1.99,
+        }
+        self._test_penalty_effect(prompt, baseline_params, penalty_params, "data", max_tokens=100)
+
     def test_server_alive(self):
         """Sanity check: server is up and /v1/chat/completions responds."""
         resp = requests.post(

--- a/test/srt/test_penalty.py
+++ b/test/srt/test_penalty.py
@@ -1,0 +1,85 @@
+"""
+Functional tests for penalty parameters (frequency / presence / combined).
+
+Ports sglang PR #11931 to sgl-jax. Validates that penalty params actually
+shape token output distribution, not merely that the server accepts them.
+
+Note: sgl-jax does not currently implement repetition_penalty
+(no BatchedRepetitionPenalizer in penaltylib/), so no test here passes
+repetition_penalty.
+
+Usage:
+    python3 -m unittest test_penalty.TestPenalty -v
+"""
+
+import re
+import unittest
+
+import requests
+
+from sgl_jax.srt.utils import kill_process_tree
+from sgl_jax.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+class TestPenalty(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            device="tpu",
+            other_args=[
+                "--trust-remote-code",
+                "--skip-server-warmup",
+                "--random-seed",
+                "3",
+                "--mem-fraction-static",
+                "0.65",
+                "--max-prefill-tokens",
+                "8192",
+                "--download-dir",
+                "/dev/shm/",
+                "--dtype",
+                "bfloat16",
+                "--attention-backend",
+                "fa",
+                "--page-size",
+                "64",
+                "--max-running-requests",
+                "64",
+            ],
+            env={
+                "JAX_COMPILATION_CACHE_DIR": "/tmp/jax_compilation_cache",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_server_alive(self):
+        """Sanity check: server is up and /v1/chat/completions responds."""
+        resp = requests.post(
+            self.base_url + "/v1/chat/completions",
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": "Say hi."}],
+                "max_tokens": 8,
+                "temperature": 0.0,
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("choices", resp.json())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/srt/test_penalty.py
+++ b/test/srt/test_penalty.py
@@ -66,6 +66,67 @@ class TestPenalty(CustomTestCase):
     def tearDownClass(cls):
         kill_process_tree(cls.process.pid)
 
+    def run_generate_with_prompt(self, prompt, sampling_params, max_tokens=100):
+        """POST to /v1/chat/completions with the given prompt and params."""
+        sampling_params.setdefault("temperature", 0.05)
+        sampling_params.setdefault("top_p", 1.0)
+
+        response = requests.post(
+            self.base_url + "/v1/chat/completions",
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": max_tokens,
+                **sampling_params,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        content = result["choices"][0]["message"]["content"]
+        return content
+
+    def count_word_repetitions(self, text, word):
+        """Count occurrences of `word` in `text` (case-insensitive, word-boundary)."""
+        return len(re.findall(r"\b" + re.escape(word) + r"\b", text.lower()))
+
+    def _test_penalty_effect(
+        self,
+        prompt,
+        baseline_params,
+        penalty_params,
+        target_word,
+        expected_reduction=True,
+        max_tokens=50,
+    ):
+        """Run baseline vs penalty 5 times each; compare mean target-word counts."""
+        baseline_counts = []
+        penalty_counts = []
+
+        for _ in range(5):
+            baseline_output = self.run_generate_with_prompt(prompt, baseline_params, max_tokens)
+            penalty_output = self.run_generate_with_prompt(prompt, penalty_params, max_tokens)
+
+            baseline_counts.append(self.count_word_repetitions(baseline_output, target_word))
+            penalty_counts.append(self.count_word_repetitions(penalty_output, target_word))
+
+        avg_baseline = sum(baseline_counts) / len(baseline_counts)
+        avg_penalty = sum(penalty_counts) / len(penalty_counts)
+
+        if expected_reduction:
+            self.assertLess(
+                avg_penalty,
+                avg_baseline,
+                f"Penalty should reduce '{target_word}' repetition: "
+                f"{avg_baseline:.1f} -> {avg_penalty:.1f}",
+            )
+        else:
+            self.assertGreater(
+                avg_penalty,
+                avg_baseline,
+                f"Negative penalty should increase '{target_word}' repetition: "
+                f"{avg_baseline:.1f} -> {avg_penalty:.1f}",
+            )
+
     def test_server_alive(self):
         """Sanity check: server is up and /v1/chat/completions responds."""
         resp = requests.post(

--- a/test/srt/test_penalty.py
+++ b/test/srt/test_penalty.py
@@ -1,8 +1,10 @@
 """
 Functional tests for penalty parameters (frequency / presence / combined).
 
-Ports sglang PR #11931 to sgl-jax. Validates that penalty params actually
-shape token output distribution, not merely that the server accepts them.
+Ports sglang PR #11931 to sgl-jax (aligned with the evolved upstream form
+that uses vocabulary diversity + fixed seeds for stability). Validates that
+penalty params actually shape token output distribution, not merely that
+the server accepts them.
 
 Note: sgl-jax does not currently implement repetition_penalty
 (no BatchedRepetitionPenalizer in penaltylib/), so no test here passes
@@ -66,10 +68,13 @@ class TestPenalty(CustomTestCase):
     def tearDownClass(cls):
         kill_process_tree(cls.process.pid)
 
-    def run_generate_with_prompt(self, prompt, sampling_params, max_tokens=100):
+    def run_generate_with_prompt(self, prompt, sampling_params, max_tokens=100, seed=None):
         """POST to /v1/chat/completions with the given prompt and params."""
+        sampling_params = sampling_params.copy()
         sampling_params.setdefault("temperature", 0.05)
         sampling_params.setdefault("top_p", 1.0)
+        if seed is not None:
+            sampling_params["seed"] = seed
 
         response = requests.post(
             self.base_url + "/v1/chat/completions",
@@ -85,69 +90,93 @@ class TestPenalty(CustomTestCase):
         content = result["choices"][0]["message"]["content"]
         return content
 
-    def count_word_repetitions(self, text, word):
-        """Count occurrences of `word` in `text` (case-insensitive, word-boundary)."""
-        return len(re.findall(r"\b" + re.escape(word) + r"\b", text.lower()))
+    def _get_vocab_diversity(self, text):
+        """Calculate vocabulary diversity as unique_words / total_words.
+
+        Higher values mean more diverse (less repetitive) text.
+        """
+        words = re.findall(r"\b\w+\b", text.lower())
+        if not words:
+            return 1.0
+        return len(set(words)) / len(words)
 
     def _test_penalty_effect(
         self,
         prompt,
         baseline_params,
         penalty_params,
-        target_word,
         expected_reduction=True,
-        max_tokens=50,
+        max_tokens=150,
     ):
-        """Run baseline vs penalty 5 times each; compare mean target-word counts."""
-        baseline_counts = []
-        penalty_counts = []
+        """Generic test for penalty effects using vocabulary diversity.
 
-        for _ in range(5):
-            baseline_output = self.run_generate_with_prompt(prompt, baseline_params, max_tokens)
-            penalty_output = self.run_generate_with_prompt(prompt, penalty_params, max_tokens)
+        Measures unique_words/total_words ratio instead of counting a specific
+        word, because penalties affect ALL token probabilities -- the model may
+        avoid some repeated tokens while using others more.
+        """
+        # Use higher temperature so penalties can actually affect token selection.
+        # The default temperature (0.05) is near-greedy, making penalty adjustments
+        # to logits ineffective since the top token still dominates.
+        baseline_params = baseline_params.copy()
+        penalty_params = penalty_params.copy()
+        baseline_params.setdefault("temperature", 0.8)
+        penalty_params.setdefault("temperature", 0.8)
 
-            baseline_counts.append(self.count_word_repetitions(baseline_output, target_word))
-            penalty_counts.append(self.count_word_repetitions(penalty_output, target_word))
+        base_seed = 42
+        baseline_diversities = []
+        penalty_diversities = []
 
-        avg_baseline = sum(baseline_counts) / len(baseline_counts)
-        avg_penalty = sum(penalty_counts) / len(penalty_counts)
+        for i in range(5):
+            seed = base_seed + i
+            baseline_output = self.run_generate_with_prompt(
+                prompt, baseline_params, max_tokens, seed=seed
+            )
+            penalty_output = self.run_generate_with_prompt(
+                prompt, penalty_params, max_tokens, seed=seed
+            )
+
+            baseline_diversities.append(self._get_vocab_diversity(baseline_output))
+            penalty_diversities.append(self._get_vocab_diversity(penalty_output))
+
+        avg_baseline = sum(baseline_diversities) / len(baseline_diversities)
+        avg_penalty = sum(penalty_diversities) / len(penalty_diversities)
 
         if expected_reduction:
-            self.assertLess(
-                avg_penalty,
-                avg_baseline,
-                f"Penalty should reduce '{target_word}' repetition: "
-                f"{avg_baseline:.1f} -> {avg_penalty:.1f}",
-            )
-        else:
             self.assertGreater(
                 avg_penalty,
                 avg_baseline,
-                f"Negative penalty should increase '{target_word}' repetition: "
-                f"{avg_baseline:.1f} -> {avg_penalty:.1f}",
+                f"Penalty should increase vocab diversity: "
+                f"{avg_baseline:.3f} -> {avg_penalty:.3f}",
+            )
+        else:
+            self.assertLess(
+                avg_penalty,
+                avg_baseline,
+                f"Negative penalty should decrease vocab diversity: "
+                f"{avg_baseline:.3f} -> {avg_penalty:.3f}",
             )
 
     def test_frequency_penalty_reduces_word_repetition(self):
-        """frequency_penalty should reduce repetition of a target word."""
+        """frequency_penalty should increase vocabulary diversity."""
         prompt = (
             "Write exactly 10 very small sentences, each containing the word "
             "'data'. Use the word 'data' as much as possible."
         )
         baseline_params = {"frequency_penalty": 0.0}
         penalty_params = {"frequency_penalty": 1.99}
-        self._test_penalty_effect(prompt, baseline_params, penalty_params, "data")
+        self._test_penalty_effect(prompt, baseline_params, penalty_params)
 
     def test_presence_penalty_reduces_topic_repetition(self):
-        """presence_penalty should reduce topic repetition."""
+        """presence_penalty should increase vocabulary diversity."""
         prompt = (
             "Write the word 'machine learning' exactly 20 times in a row, " "separated by spaces."
         )
         baseline_params = {"presence_penalty": 0.0}
         penalty_params = {"presence_penalty": 1.99}
-        self._test_penalty_effect(prompt, baseline_params, penalty_params, "machine learning")
+        self._test_penalty_effect(prompt, baseline_params, penalty_params)
 
     def test_combined_penalties_reduce_repetition(self):
-        """Combined frequency + presence penalties should reduce repetition."""
+        """Combined frequency + presence penalties should increase vocab diversity."""
         prompt = (
             "Write exactly 10 short sentences, each containing the word 'data'. "
             "Use the word 'data' as much as possible."
@@ -160,10 +189,10 @@ class TestPenalty(CustomTestCase):
             "frequency_penalty": 1.99,
             "presence_penalty": 1.99,
         }
-        self._test_penalty_effect(prompt, baseline_params, penalty_params, "data", max_tokens=100)
+        self._test_penalty_effect(prompt, baseline_params, penalty_params)
 
     def test_penalty_edge_cases_negative_penalty_values(self):
-        """Negative penalty values should increase repetition (expected_reduction=False)."""
+        """Negative penalty values should decrease vocabulary diversity."""
         prompt = "Write the word 'test' exactly 15 times in a row, separated by spaces."
         baseline_params = {
             "frequency_penalty": 0.0,
@@ -177,13 +206,11 @@ class TestPenalty(CustomTestCase):
             prompt,
             baseline_params,
             negative_penalty_params,
-            "test",
             expected_reduction=False,
-            max_tokens=60,
         )
 
     def test_penalty_edge_cases_extreme_penalty_values(self):
-        """Extreme penalty values should strongly reduce repetition."""
+        """Extreme penalty values should strongly increase vocabulary diversity."""
         prompt = "Write the word 'extreme' exactly 20 times in a row, separated by spaces."
         baseline_params = {
             "frequency_penalty": 0.0,
@@ -193,14 +220,7 @@ class TestPenalty(CustomTestCase):
             "frequency_penalty": 2.0,
             "presence_penalty": 2.0,
         }
-        self._test_penalty_effect(
-            prompt,
-            baseline_params,
-            extreme_penalty_params,
-            "extreme",
-            expected_reduction=True,
-            max_tokens=80,
-        )
+        self._test_penalty_effect(prompt, baseline_params, extreme_penalty_params)
 
 
 if __name__ == "__main__":

--- a/test/srt/test_penalty.py
+++ b/test/srt/test_penalty.py
@@ -137,6 +137,15 @@ class TestPenalty(CustomTestCase):
         penalty_params = {"frequency_penalty": 1.99}
         self._test_penalty_effect(prompt, baseline_params, penalty_params, "data")
 
+    def test_presence_penalty_reduces_topic_repetition(self):
+        """presence_penalty should reduce topic repetition."""
+        prompt = (
+            "Write the word 'machine learning' exactly 20 times in a row, " "separated by spaces."
+        )
+        baseline_params = {"presence_penalty": 0.0}
+        penalty_params = {"presence_penalty": 1.99}
+        self._test_penalty_effect(prompt, baseline_params, penalty_params, "machine learning")
+
     def test_server_alive(self):
         """Sanity check: server is up and /v1/chat/completions responds."""
         resp = requests.post(

--- a/test/srt/test_penalty.py
+++ b/test/srt/test_penalty.py
@@ -182,19 +182,25 @@ class TestPenalty(CustomTestCase):
             max_tokens=60,
         )
 
-    def test_server_alive(self):
-        """Sanity check: server is up and /v1/chat/completions responds."""
-        resp = requests.post(
-            self.base_url + "/v1/chat/completions",
-            json={
-                "model": self.model,
-                "messages": [{"role": "user", "content": "Say hi."}],
-                "max_tokens": 8,
-                "temperature": 0.0,
-            },
+    def test_penalty_edge_cases_extreme_penalty_values(self):
+        """Extreme penalty values should strongly reduce repetition."""
+        prompt = "Write the word 'extreme' exactly 20 times in a row, separated by spaces."
+        baseline_params = {
+            "frequency_penalty": 0.0,
+            "presence_penalty": 0.0,
+        }
+        extreme_penalty_params = {
+            "frequency_penalty": 2.0,
+            "presence_penalty": 2.0,
+        }
+        self._test_penalty_effect(
+            prompt,
+            baseline_params,
+            extreme_penalty_params,
+            "extreme",
+            expected_reduction=True,
+            max_tokens=80,
         )
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("choices", resp.json())
 
 
 if __name__ == "__main__":

--- a/test/srt/test_penalty.py
+++ b/test/srt/test_penalty.py
@@ -162,6 +162,26 @@ class TestPenalty(CustomTestCase):
         }
         self._test_penalty_effect(prompt, baseline_params, penalty_params, "data", max_tokens=100)
 
+    def test_penalty_edge_cases_negative_penalty_values(self):
+        """Negative penalty values should increase repetition (expected_reduction=False)."""
+        prompt = "Write the word 'test' exactly 15 times in a row, separated by spaces."
+        baseline_params = {
+            "frequency_penalty": 0.0,
+            "presence_penalty": 0.0,
+        }
+        negative_penalty_params = {
+            "frequency_penalty": -0.5,
+            "presence_penalty": -0.25,
+        }
+        self._test_penalty_effect(
+            prompt,
+            baseline_params,
+            negative_penalty_params,
+            "test",
+            expected_reduction=False,
+            max_tokens=60,
+        )
+
     def test_server_alive(self):
         """Sanity check: server is up and /v1/chat/completions responds."""
         resp = requests.post(


### PR DESCRIPTION
## Summary

- Adds `test/srt/test_penalty.py` with 5 functional behavioral tests for `frequency_penalty` / `presence_penalty`, ported from sglang main repo PR [sgl-project/sglang#11931](https://github.com/sgl-project/sglang/pull/11931) and aligned with its evolved upstream form (vocabulary-diversity assertion + fixed seeds + `temperature=0.8`).
- Registers the new test in the `e2e-test-tpu-v6e-1` suite in `test/srt/run_suite.py`.

## Why

`test/srt/test_features.py` already has smoke-level penalty tests (`test_frequency_penalty`, `test_presence_penalty`, `test_min_new_tokens_penalty`, `test_combined_penalties`) but they only assert `\"text\" in response` and `cache_miss_count == 0`. They do **not** verify whether penalty parameters actually shape the output distribution. This PR fills that gap.

## What's inside `test/srt/test_penalty.py`

`class TestPenalty(CustomTestCase)` brings up a single small-model server (`Qwen/Qwen3-1.7B`, single-chip TPU, light args — no `--tp`, no `--precompile-*-paddings`) once via `popen_launch_server`, then runs:

| Test | Asserts |
| --- | --- |
| `test_frequency_penalty_reduces_word_repetition` | `frequency_penalty=1.99` increases vocab diversity vs `0.0` |
| `test_presence_penalty_reduces_topic_repetition` | `presence_penalty=1.99` increases vocab diversity vs `0.0` |
| `test_combined_penalties_reduce_repetition` | combined freq + presence at 1.99 increases vocab diversity |
| `test_penalty_edge_cases_negative_penalty_values` | negative penalties (-0.5 / -0.25) **decrease** vocab diversity (`expected_reduction=False`) |
| `test_penalty_edge_cases_extreme_penalty_values` | extreme penalties (2.0 / 2.0) strongly increase vocab diversity |

Helper `_test_penalty_effect` runs each test 5x with fixed seeds (`42 + i`), at `temperature=0.8` (so penalty adjustments to logits actually flip token selection), and compares mean `unique_words / total_words` ratios. Stochastic flakes are absorbed by `CustomTestCase`'s built-in retry mechanism.

## Note on `repetition_penalty`

sgl-jax currently has **no** `BatchedRepetitionPenalizer` in `python/sgl_jax/srt/sampling/penaltylib/` — the parameter is accepted at every API layer (HTTP / OpenAI / Engine) and validated in `SamplingParams`, but is silently dropped before reaching the sampler. To avoid misleading green checks, none of the new tests pass `repetition_penalty`; the module docstring documents this.

This PR is **test-only** and does not implement the missing penalizer.

## Test plan

- [x] Run `python3 -m unittest test/srt/test_penalty.py -v` on the project's TPU v6e-1 SkyPilot cluster (Qwen3-1.7B fits a single chip).
- [x] Verify `e2e-test-tpu-v6e-1` CI suite picks up the new file (`test/srt/test_penalty.py`, `estimated_time=12`).
- [ ] Confirm the negative-penalty test passes — this is the most stochastic test; if flaky, `SGLANG_TEST_MAX_RETRY` retry should absorb it.

## References

- Upstream sglang PR (as merged): [sgl-project/sglang#11931](https://github.com/sgl-project/sglang/pull/11931)
- Upstream evolved form mirrored here: `test/registered/sampling/test_penalty.py` in sgl-project/sglang main

🤖 Generated with [Claude Code](https://claude.com/claude-code)