### PR TITLE
fix: penalty

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1956,6 +1956,7 @@ class ScheduleBatch:
         top_ks = np.ones(total_bs, dtype=np.int32)
         min_ps = np.zeros(total_bs, dtype=np.float32)
         sampling_seeds = None
+        linear_penalty = None  # lazily allocated only if any DP rank has penalties
 
         offset_bs = 0
         has_sampling_seeds = False
@@ -1989,6 +1990,17 @@ class ScheduleBatch:
                     has_sampling_seeds = True
                 sampling_seeds[offset_bs : offset_bs + dp_bs] = dp_sampling.sampling_seeds[:dp_bs]
 
+            # Compute per-DP penalties (no-op if not required) and stitch into the
+            # merged buffer using the same per-DP slot offset as the other arrays.
+            dp_sampling.update_penalties()
+            if dp_sampling.linear_penalty is not None and dp_sampling.linear_penalty.size > 0:
+                if linear_penalty is None:
+                    linear_penalty = np.zeros(
+                        (total_bs, dp_sampling.linear_penalty.shape[1]),
+                        dtype=dp_sampling.linear_penalty.dtype,
+                    )
+                linear_penalty[offset_bs : offset_bs + dp_bs] = dp_sampling.linear_penalty[:dp_bs]
+
             # Move to next DP rank's slot (fixed slot size)
             offset_bs += per_dp_bs_size
 
@@ -2000,6 +2012,7 @@ class ScheduleBatch:
             vocab_size=vocab_size,
             is_all_greedy=is_all_greedy,
             sampling_seeds=sampling_seeds if has_sampling_seeds else None,
+            linear_penalty=linear_penalty,
             grammars=[req.grammar for req in all_reqs] if self.has_grammar else None,
         )
 
@@ -2731,7 +2744,9 @@ class ModelWorkerSamplingInfo:
         return ret
 
     def update_penalties(self):
-        self.linear_penalty = None
+        # No-op: linear_penalty is pre-computed during ScheduleBatch._merge_sampling_info.
+        # Kept for API parity with SamplingBatchInfo.update_penalties (called by overlap thread).
+        return
 
     def update_grammar_vocab_mask(self):
         """Update vocabulary masks from grammars before sampling."""

--- a/python/sgl_jax/srt/sampling/penaltylib/orchestrator.py
+++ b/python/sgl_jax/srt/sampling/penaltylib/orchestrator.py
@@ -7,22 +7,19 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
-    from sgl_jax.srt.managers.schedule_batch import ScheduleBatch
+    from sgl_jax.srt.managers.schedule_batch import ScheduleReqsInfo
 
 
 class BatchedPenalizerOrchestrator:
     def __init__(
         self,
         vocab_size: int,
-        batch: ScheduleBatch,
+        reqs_info: ScheduleReqsInfo,
         penalizers: set[type[_BatchedPenalizer]],
     ):
         self.vocab_size = vocab_size
-        self._batch_ref = weakref.ref(batch)
+        self._reqs_info_ref = weakref.ref(reqs_info)
         self.penalizers = {Penalizer: Penalizer(self) for Penalizer in penalizers}
-
-        # No longer need internal penalty array management -
-        # work directly on the provided linear_penalty array
 
         is_required = False
         for penalizer in self.penalizers.values():
@@ -31,23 +28,19 @@ class BatchedPenalizerOrchestrator:
         self.is_required = is_required
 
     @property
-    def batch(self) -> ScheduleBatch | None:
-        return self._batch_ref()
+    def reqs_info(self) -> ScheduleReqsInfo | None:
+        return self._reqs_info_ref()
 
-    @batch.setter
-    def batch(self, value: ScheduleBatch | None):
+    @reqs_info.setter
+    def reqs_info(self, value: ScheduleReqsInfo | None):
         if value is None:
-            self._batch_ref = lambda: None
+            self._reqs_info_ref = lambda: None
         else:
-            self._batch_ref = weakref.ref(value)
+            self._reqs_info_ref = weakref.ref(value)
 
     def reqs(self):
-        """Get all requests from all DP ranks."""
-        all_reqs = []
-        for info in self.batch.reqs_info:
-            if info.reqs:
-                all_reqs.extend(info.reqs)
-        return all_reqs
+        info = self.reqs_info
+        return info.reqs if info is not None and info.reqs else []
 
     def cumulate_output_tokens(self, output_ids: np.ndarray):
         """

--- a/python/sgl_jax/srt/sampling/sampling_batch_info.py
+++ b/python/sgl_jax/srt/sampling/sampling_batch_info.py
@@ -138,7 +138,6 @@ class SamplingMetadata:
         )
 
         # Extract penalty information from penalizer orchestrator
-        # TODO: @Brian fix penalty with DataParallel
         linear_penalty_device = None
         do_penalties = False
         linear_penalty_sharding = NamedSharding(mesh, PartitionSpec("data", "tensor"))
@@ -347,7 +346,7 @@ class SamplingBatchInfo:
         cls,
         info: ScheduleReqsInfo,
         vocab_size: int,
-        batch: ScheduleBatch = None,  # Optional: needed for penalizer_orchestrator
+        batch: ScheduleBatch = None,  # Unused; kept for backward-compat with callers
     ):
         global_server_args_dict = cls._get_global_server_args_dict()
         enable_deterministic = global_server_args_dict["enable_deterministic_sampling"]
@@ -369,13 +368,10 @@ class SamplingBatchInfo:
             else None
         )
 
-        # Initialize penalty orchestrator
-        # Note: penalizer_orchestrator requires the full ScheduleBatch object to access
-        # global batch state for penalties (frequency, presence, min_new_tokens).
-        # In DP mode, pass the full batch; the orchestrator will handle per-request penalties.
+        # Per-DP penalty orchestrator: scoped to this rank's reqs only.
         penalizer_orchestrator = penaltylib.BatchedPenalizerOrchestrator(
             vocab_size=vocab_size,
-            batch=batch,  # Full ScheduleBatch needed for global state
+            reqs_info=info,
             penalizers={
                 penaltylib.BatchedFrequencyPenalizer,
                 penaltylib.BatchedMinNewTokensPenalizer,


### PR DESCRIPTION
## Motivation

After the DP refactor on `merge/dp`, the penalty system (`frequency_penalty` / `presence_penalty` / `min_new_tokens`) was silently broken for **all `dp_size` values, including `dp_size=1`**. The sampler always received an all-zero `linear_penalty` and `do_penalties=False`, so penalty parameters had no effect on token selection. Existing CI didn't catch this because `test/srt/test_features.py`'s penalty tests only assert `200 OK` + `"text" in response`, not actual behavioral effect.

Three concrete defects in the post-DP data flow:

1. **`ScheduleBatch._merge_sampling_info`** (`schedule_batch.py:1937-2004`) builds `ModelWorkerSamplingInfo` from per-DP `SamplingBatchInfo` but only copies `temperatures / top_ps / top_ks / min_ps / sampling_seeds / is_all_greedy / grammars`. `linear_penalty` and `penalizer_orchestrator` stay at their dataclass `None` defaults.
2. **`ModelWorkerSamplingInfo.update_penalties`** (`schedule_batch.py:2733-2734`) was a stub that does `self.linear_penalty = None`. The overlap thread (`tp_worker_overlap_thread.py:162`) calls it, wiping any value that managed to get through.
3. **`BatchedPenalizerOrchestrator.reqs()`** (`orchestrator.py:44-50`) iterated `batch.reqs_info` and concatenated **all DP ranks' requests**, so each per-DP orchestrator allocated `token_frequencies` of shape `(global_bs, vocab_size)` but `cumulate_output_tokens` was fed only per-DP `info.output_ids` — internal arrays were sized wrong and only the first N rows were ever updated.

Downstream: `SamplingMetadata.from_model_worker_batch` saw `linear_penalty=None`, `penalizer_orchestrator=None`, fell into the cached zero-penalty fast path, set `do_penalties=False`.

## Modifications

Surgical fix that keeps the existing per-DP `SamplingBatchInfo` + per-DP orchestrator design.

**`python/sgl_jax/srt/sampling/penaltylib/orchestrator.py`**
- Orchestrator now holds `weakref.ref(reqs_info)` to the per-DP `ScheduleReqsInfo` instead of the global `ScheduleBatch`.
- `reqs()` returns `self._reqs_info_ref().reqs` only — no cross-DP concatenation. This makes `_prepare`, `_cumulate_output_tokens`, `_filter`, `_merge` all see consistent per-DP sizes that match the existing `cumulate_output_tokens(info.output_ids)` call pattern.

**`python/sgl_jax/srt/sampling/sampling_batch_info.py`**
- `from_schedule_batch` constructs the orchestrator with `reqs_info=info` (per-DP) instead of `batch=batch` (global).
- Removed the stale `# TODO @Brian fix penalty with DataParallel` comment in `from_model_worker_batch`.

**`python/sgl_jax/srt/managers/schedule_batch.py`**
- `_merge_sampling_info` now calls `info.sampling_info.update_penalties()` per DP rank, then concatenates the per-DP `linear_penalty` arrays into the merged `ModelWorkerSamplingInfo.linear_penalty` using the same offset/padding scheme already used for `temperatures`. Buffer is allocated lazily — only when at least one DP rank has penalties — preserving the `_get_or_create_zero_penalty_device` fast path.
- `ModelWorkerSamplingInfo.update_penalties` is now a true no-op (penalties already pre-computed during merge); the `tp_worker_overlap_thread.py:162` call becomes inert instead of destructive.

No changes needed to `sampler.py`, `tp_worker.py`, `scheduler_output_processor_mixin.py`, or any model file. The `from_model_worker_batch` path that reads `linear_penalty` was already correct and is now naturally hit.

## Accuracy Tests

Validated on TPU v6e-1 (test-cc cluster) with `Qwen/Qwen3-1.7B` against the functional penalty test suite added in #973 (`test/srt/test_penalty.py`), which uses vocabulary-diversity differential assertions across 5 fixed seeds at `temperature=0.8`.

| Mode | Server flag | Result | Wall time |
|---|---|---|---|
| Overlap on (default) | (none) | **5/5 passed** | 253s |
| Overlap off | `--disable-overlap-schedule` | **5/5 passed** | 96s |

Tests exercised:
- `test_frequency_penalty_reduces_word_repetition`
- `test_presence_penalty_reduces_topic_repetition`
- `test_combined_penalties_reduce_repetition`
- `test_penalty_edge_cases_negative_penalty_values` (negative penalty → lower diversity)
- `test_penalty_edge_cases_extreme_penalty_values` (penalty=2.0 → strongly higher diversity)

## Benchmarking and Profiling

No perf regression expected — the merge-phase computation already happens in scheduler thread and reuses the same `update_penalties()` / `apply()` paths that ran in pre-DP code. The lazy buffer allocation keeps the no-penalty workload identical to before.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve. — fixes the DP-induced penalty regression on `merge/dp`; depends on #973 being merged for CI coverage.
- [x] The test plan, such as providing test command.
  - `python3 -m unittest test/srt/test_penalty.py -v` (overlap on, default)
  - Same with `--disable-overlap-schedule` injected into the launch args (manual verification, see Accuracy Tests table)
- [ ] (Optional) The necessary documentation update.
