### PR TITLE
fix(mem_cache): port upstream sglang PR #12224 KV memory unification

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -64,6 +64,8 @@ GLOBAL_SERVER_ARGS_KEYS = [
     "disable_radix_cache",
     "speculative_accept_threshold_single",
     "speculative_accept_threshold_acc",
+    "speculative_algorithm",
+    "speculative_eagle_topk",
     "enable_deterministic_sampling",
     "chunked_prefill_size",
 ]
@@ -250,6 +252,12 @@ class Req:
         # The prefix length of the last prefix matching
         self.last_matched_prefix_len: int = 0
 
+        # For req-level memory management
+        self.kv_committed_len = 0
+        self.kv_allocated_len = 0
+        self.kv_committed_freed = False
+        self.kv_overallocated_freed = False
+
         # Whether or not if it is chunked. It increments whenever
         # it is chunked, and decrement whenever chunked request is
         # processed.
@@ -386,6 +394,30 @@ class Req:
             self.last_matched_prefix_len = len(self.prefix_indices)
         self.extend_input_len = len(self.fill_ids) - len(self.prefix_indices)
 
+    def pop_committed_kv_cache(self) -> int:
+        """Return the length of committed KV cache and mark them as freed."""
+        # NOTE: This function is called exactly once after the request is finished.
+        spec_algo = global_server_args_dict.get("speculative_algorithm")
+        topk = global_server_args_dict.get("speculative_eagle_topk")
+
+        enable_kv_committed_len = spec_algo is None or topk is None or topk == 1
+        if enable_kv_committed_len:
+            assert (
+                not self.kv_committed_freed
+            ), f"Committed KV cache already freed ({self.kv_committed_len=})"
+            self.kv_committed_freed = True
+            return self.kv_committed_len
+        else:
+            return len(self.origin_input_ids) + max(len(self.output_ids) - 1, 0)
+
+    def pop_overallocated_kv_cache(self) -> tuple[int, int]:
+        """Return the range of over-allocated KV cache and mark them as freed."""
+        assert (
+            not self.kv_overallocated_freed
+        ), f"Overallocated KV cache already freed, {self.kv_committed_len=}, {self.kv_allocated_len=}"
+        self.kv_overallocated_freed = True
+        return self.kv_committed_len, self.kv_allocated_len
+
     def adjust_max_prefix_ids(self):
         self.fill_ids = self.origin_input_ids + self.output_ids
         input_len = len(self.fill_ids)
@@ -517,6 +549,10 @@ class Req:
         self.swa_evicted_seqlen = 0
         self.extend_batch_idx = 0
         self.decode_batch_idx = 0
+        self.kv_committed_len = 0
+        self.kv_allocated_len = 0
+        self.kv_committed_freed = False
+        self.kv_overallocated_freed = False
 
     def set_finish_with_abort(self, error_msg: str):
         # set it to one token to skip the long prefill
@@ -840,6 +876,10 @@ class ScheduleBatch:
             req.req_pool_idx = req_pool_indices[i]
             assert seq_len - pre_len == req.extend_input_len
 
+            # update req-level memory management fields
+            req.kv_committed_len = seq_len
+            req.kv_allocated_len = seq_len
+
             prefix_indices = req.prefix_indices
             if pre_len > 0:
                 # note: prefix_indices has to locate on device, or will meet Received incompatible devices for jitted computation
@@ -1150,6 +1190,8 @@ class ScheduleBatch:
 
         for req in self.reqs:
             req.decode_batch_idx += 1
+            req.kv_committed_len += 1
+            req.kv_allocated_len += 1
 
     def filter_batch(
         self,

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -11,6 +11,7 @@ from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
 from sgl_jax.srt.layers.routed_experts_capturer import get_global_experts_capturer
 from sgl_jax.srt.managers.io_struct import AbortReq, BatchTokenIDOut
 from sgl_jax.srt.managers.schedule_batch import BaseFinishReason, Req, ScheduleBatch
+from sgl_jax.srt.mem_cache.common import release_kv_cache
 from sgl_jax.srt.precision_tracer import precision_tracer
 from sgl_jax.srt.utils.common_utils import cdiv
 
@@ -90,15 +91,11 @@ class SchedulerOutputProcessorMixin:
         # Check finish conditions
         logprob_pt = 0
         for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
-            if req.is_retracted:
+            if req.finished() or req.is_retracted:
+                # decode req in mixed batch or retracted req
                 continue
 
             req.latest_bid = batch.bid
-
-            if self.is_mixed_chunk and self.enable_overlap and req.finished():
-                j = len(batch.out_cache_loc) - len(batch.reqs) + i
-                self.token_to_kv_pool_allocator.free(batch.out_cache_loc[j : j + 1])
-                continue
 
             if req.is_chunked <= 0:
                 # req output_ids are set here
@@ -122,7 +119,7 @@ class SchedulerOutputProcessorMixin:
                             >= precision_tracer.get_max_requests()
                         ):
                             precision_tracer.stop_trace()
-                    self.tree_cache.cache_finished_req(req)
+                    release_kv_cache(req, self.tree_cache)
                 elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                     # This updates radix so others can match
                     self.tree_cache.cache_unfinished_req(req)
@@ -276,21 +273,15 @@ class SchedulerOutputProcessorMixin:
         # Check finish condition
         for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
             req: Req
+            if self.enable_overlap and (req.finished() or req.is_retracted):
+                # NOTE: This (req.finished() or req.is_retracted) should only happen when overlap scheduling is enabled.
+                # And all the over-allocated tokens will be freed in `release_kv_cache`.
+                continue
+
             if req.is_retracted:
                 continue
 
             req.latest_bid = batch.bid
-
-            indices_to_free = None
-            if self.enable_overlap and req.finished():
-                if self.page_size == 1:
-                    indices_to_free = batch.out_cache_loc[i : i + 1]
-                else:
-                    if (len(req.origin_input_ids) + len(req.output_ids) - 1) % self.page_size == 0:
-                        indices_to_free = batch.out_cache_loc[i : i + 1]
-                if indices_to_free is not None:
-                    self.token_to_kv_pool_allocator.free(indices_to_free)
-                continue
 
             new_accepted_len = 1
             if batch.spec_algorithm is None or batch.spec_algorithm.is_none():
@@ -335,7 +326,7 @@ class SchedulerOutputProcessorMixin:
                         >= precision_tracer.get_max_requests()
                     ):
                         precision_tracer.stop_trace()
-                self.tree_cache.cache_finished_req(req)
+                release_kv_cache(req, self.tree_cache)
 
             if req.return_output_logprob_only:
                 req.output_token_logprobs_val.append(next_token_logprobs[i])

--- a/python/sgl_jax/srt/mem_cache/chunk_cache.py
+++ b/python/sgl_jax/srt/mem_cache/chunk_cache.py
@@ -33,12 +33,10 @@ class ChunkCache(BasePrefixCache):
             last_host_node=None,
         )
 
-    def cache_finished_req(self, req: Req):
-        kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx,
-            # For decode server: if req.output_ids is empty, we want to free all req.origin_input_ids
-            : len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0),
-        ]
+    def cache_finished_req(self, req: Req, is_insert: bool = True):
+        kv_committed_len = req.pop_committed_kv_cache()
+        # For decode server: if req.output_ids is empty, we want to free all req.origin_input_ids
+        kv_indices = self.req_to_token_pool.req_to_token[req.req_pool_idx, :kv_committed_len]
         self.req_to_token_pool.free(req.req_pool_idx)
         self.token_to_kv_pool_allocator.free(kv_indices)
 

--- a/python/sgl_jax/srt/mem_cache/common.py
+++ b/python/sgl_jax/srt/mem_cache/common.py
@@ -100,3 +100,28 @@ def available_and_evictable_str(tree_cache) -> str:
         available_size = token_to_kv_pool_allocator.available_size()
         evictable_size = tree_cache.evictable_size()
         return f"Available tokens: {available_size + evictable_size} ({available_size=} + {evictable_size=})\n"
+
+
+def release_kv_cache(req, tree_cache: BasePrefixCache, is_insert: bool = True) -> None:
+    from sgl_jax.srt.managers.schedule_batch import global_server_args_dict
+    from sgl_jax.srt.utils.common_utils import cdiv
+
+    tree_cache.cache_finished_req(req, is_insert=is_insert)
+    start_p, end_p = req.pop_overallocated_kv_cache()
+
+    page_size = tree_cache.page_size
+    spec_algo = global_server_args_dict.get("speculative_algorithm")
+
+    if spec_algo is None:
+        assert (
+            start_p == end_p
+        ), f"Unexpected overallocated KV cache, {req.kv_committed_len=}, {req.kv_allocated_len=}"
+
+    if page_size > 1:
+        start_p = cdiv(start_p, page_size) * page_size
+
+    if start_p >= end_p:
+        return
+
+    indices_to_free = tree_cache.req_to_token_pool.req_to_token[req.req_pool_idx, start_p:end_p]
+    tree_cache.token_to_kv_pool_allocator.free(indices_to_free)

--- a/python/sgl_jax/srt/mem_cache/radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/radix_cache.py
@@ -254,24 +254,24 @@ class RadixCache(BasePrefixCache):
 
         return self._insert_helper(self.root_node, converted_key, value)
 
-    def cache_finished_req(self, req: Req):
+    def cache_finished_req(self, req: Req, is_insert: bool = True):
         """Cache completed requests"""
-        all_token_len = len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
+        committed_kv_len = req.pop_committed_kv_cache()
         if self.disable:
             kv_indices = self.req_to_token_pool.read(
                 req.req_pool_idx,
-                all_token_len,
+                committed_kv_len,
             )
             kv_indices = kv_indices[kv_indices != 0]
             self.token_to_kv_pool_allocator.free(kv_indices)
             self.req_to_token_pool.free(req.req_pool_idx)
             return
 
-        token_ids = (req.origin_input_ids + req.output_ids)[:all_token_len]
+        token_ids = (req.origin_input_ids + req.output_ids)[:committed_kv_len]
         # For EAGLE radix cache, we will convert the key to bigram key, e.g. [1,2,3,4] -> [(1,2), (2,3), (3,4)], the length will -1. ((len([(1,2), (2,3), (3,4)]) = len([1,2,3,4]) - 1))
         # So for the corresponding kv length should also -1. Then we get the actual_kv_len, and use it to do later calculation and slicing.
-        actual_kv_len = all_token_len - 1 if self.is_eagle else all_token_len
-        kv_indices = self.req_to_token_pool.read(req.req_pool_idx, all_token_len)
+        actual_kv_len = committed_kv_len - 1 if self.is_eagle else committed_kv_len
+        kv_indices = self.req_to_token_pool.read(req.req_pool_idx, committed_kv_len)
         kv_indices = kv_indices[kv_indices != 0]
 
         if self.page_size != 1:

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -375,18 +375,19 @@ class SWARadixCache(BasePrefixCache):
             value = [x for x in key.token_ids]
         return self._insert_helper(self.root_node, key, value, prev_prefix_len)
 
-    def cache_finished_req(self, req: Req) -> None:
+    def cache_finished_req(self, req: Req, is_insert: bool = True) -> None:
         """Cache request when it finishes."""
+        committed_kv_len = req.pop_committed_kv_cache()
         if self.disable:
             kv_indices = self.req_to_token_pool.req_to_token[
                 req.req_pool_idx,
-                : len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0),
+                :committed_kv_len,
             ]
             self.token_to_kv_pool_allocator.free(kv_indices)
             self.req_to_token_pool.free(req.req_pool_idx)
             return
 
-        token_ids = (req.origin_input_ids + req.output_ids)[:-1]
+        token_ids = (req.origin_input_ids + req.output_ids)[:committed_kv_len][:-1]
         kv_indices = self.req_to_token_pool.req_to_token[req.req_pool_idx, : len(token_ids)]
 
         if self.page_size != 1:

--- a/python/sgl_jax/test/mem_cache/test_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_radix_cache.py
@@ -436,6 +436,21 @@ class MockRequest:
         self.prefix_indices = prefix_indices
         self.last_node = last_node
         self.extra_key = extra_key
+        self.rid = "mock-req"
+        self.kv_committed_len = len(origin_input_ids) + max(len(output_ids) - 1, 0)
+        self.kv_allocated_len = self.kv_committed_len
+        self.kv_committed_freed = False
+        self.kv_overallocated_freed = False
+
+    def pop_committed_kv_cache(self) -> int:
+        assert not self.kv_committed_freed
+        self.kv_committed_freed = True
+        return self.kv_committed_len
+
+    def pop_overallocated_kv_cache(self):
+        assert not self.kv_overallocated_freed
+        self.kv_overallocated_freed = True
+        return self.kv_committed_len, self.kv_allocated_len
 
 
 class TestRadixCacheWithRequests(unittest.TestCase):


### PR DESCRIPTION
## Goal

Fix the `token_to_kv_pool_allocator memory leak detected!` crash that fires on a plain `engine.async_generate` call (no abort/retract needed). This bug also makes `test/srt/test_engine_determine_generation.py` and similar tests fail at the baseline stage before any of their actual logic runs.

## Root cause

KV cache release is scattered across multiple paths, causing the same slot to be freed twice:

1. `RadixCache.cache_finished_req` **infers** committed length via `len(input) + max(len(output) - 1, 0)` and frees the corresponding KV.
2. `scheduler_output_processor_mixin.py` additionally ad-hoc frees `out_cache_loc[i:i+1]` (the extra slot allocated during decode) in the overlap+finished branch.

The slot allocated at decode step N **falls into both paths → double free**.

## How to reproduce the original bug

Pre-fix, with Qwen3-8B + tp_size=4 + chunked_prefill_size=4 + a single short prompt + max_new_tokens=200, on a v6e-2x2 pod:

1. Start an `Engine` with `page_size=1, disable_radix_cache=False`.
2. Call `engine.async_generate(prompt, sampling_params={\"temperature\": 0.0, \"max_new_tokens\": 200})` once.
3. Wait briefly so the scheduler hits idle and runs `check_memory()`.
4. The scheduler hard-asserts:

   ```
   ValueError: token_to_kv_pool_allocator memory leak detected!
   [dp=0] expected=480452, avail=480244, evict=212, protected=0
   ```

   `avail + evict + protected` exceeds `expected` by 1, then the scheduler `SIGQUIT`s the worker.

The same bug presents differently across the four `(page_size, radix)` configurations:

| page_size | radix | over-count | reason |
|---|---|---|---|
| 1 | on  | +1 | direct exposure of the 1-slot double free |
| 1 | off | +1 | same direct exposure |
| 4 | on  | +4 | the page-granularity formula amplifies the sub-page leak by `page_size` |
| 4 | off | 0 | `PagedAllocator.setdiff1d` defense silently masks duplicate page frees |

The decode-step-N slot is included by **both** paths: `cache_finished_req` reads `req_to_token[idx, :all_token_len]` (whose tail equals the decode-N slot), AND the mixin overlap branch frees `out_cache_loc[i:i+1]` (which is exactly the same slot).

## How the fix works

Port upstream sglang [PR #12224](https://github.com/sgl-project/sglang/pull/12224) — *\"Unify memory management across (overlap, non-overlap) × (page>=1) × (spec, non-spec, spec v2) × (retract, finished)\"*.

The core idea is **explicit tracking + a single release entry point**:

- Each `Req` explicitly tracks `kv_committed_len` (number of tokens with valid KV) and `kv_allocated_len` (number of slots reserved, may be > committed). These fields are updated tightly alongside each allocation step in `prepare_for_extend` / `prepare_for_decode` / `reset_for_retract`.
- A new `release_kv_cache(req, tree_cache)` is the **single** entry point for finished-req KV release: it calls `cache_finished_req` to release the committed range, then frees the over-allocated range `[committed_len, allocated_len)`.
- `cache_finished_req` now uses `req.pop_committed_kv_cache()` instead of the inferred-length formula, with an idempotent guard preventing double pops.
- The two ad-hoc frees in the mixin (the source of the double free) are deleted; finished reqs go through `release_kv_cache`. The overlap-finished `continue` guard is preserved so a finished req appearing in the next batch is not processed again.

## Verification

Four `(page_size, radix on/off)` configurations on a v6e-2x2 pod with Qwen3-8B + single prompt + max_new_tokens=200, asserting `scheduler.check_memory()` no longer trips and the allocator invariant `available + evictable == capacity` holds:

| page_size | radix | before | after | available + evictable / capacity |
|---|---|---|---|---|
| 1 | on  | LEAK +1 | NO_LEAK ✅ | 480239 + 213 / 480452 |
| 1 | off | LEAK +1 | NO_LEAK ✅ | 480452 +   0 / 480452 |
| 4 | on  | LEAK +4 | NO_LEAK ✅ | 480240 + 212 / 480452 |
| 4 | off | NO_LEAK (masked) | NO_LEAK ✅ | 480452 +   0 / 480452 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)