### PR TITLE
[Tiny Fix] align TestGetMaxRunningReqests with full-only delegation

### DIFF
--- a/python/sgl_jax/test/layers/test_hybrid_linear_attn_backend.py
+++ b/python/sgl_jax/test/layers/test_hybrid_linear_attn_backend.py
@@ -379,18 +379,18 @@ class TestPytreeRoundtrip:
 
 
 # ---------------------------------------------------------------------------
-# TP-4: get_max_running_reqests returns min of sub-backends
+# TP-4: get_max_running_reqests delegates to full_attn_backend
 # ---------------------------------------------------------------------------
 
 
 class TestGetMaxRunningReqests:
-    def test_returns_min_of_subs(self):
+    def test_returns_full_attn_backend_value(self):
         hybrid, _, _ = _make_hybrid(full_max=37, linear_max=99)
         assert hybrid.get_max_running_reqests(1024, 16) == 37
 
-    def test_returns_min_when_linear_smaller(self):
+    def test_ignores_linear_attn_backend_value(self):
         hybrid, _, _ = _make_hybrid(full_max=99, linear_max=10)
-        assert hybrid.get_max_running_reqests(2048, 8) == 10
+        assert hybrid.get_max_running_reqests(2048, 8) == 99
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- PR #974 changed `HybridLinearAttnBackend.get_max_running_reqests` to delegate solely to `full_attn_backend` (dropping the `min()` with `linear_attn_backend`).
- The corresponding TP-4 tests in `test_hybrid_linear_attn_backend.py` still asserted the old "min of subs" behavior, causing `test_returns_min_when_linear_smaller` to fail with `assert 99 == 10`.
- Update the two TP-4 cases (and the section header) to reflect the new contract: returns `full_attn_backend`'s value, ignoring `linear_attn_backend`.

## Test plan
- [x] `pytest python/sgl_jax/test/layers/test_hybrid_linear_attn_backend.py` — 27 passed
- [x] `pytest python/sgl_jax/test/layers/test_hybrid_linear_attn_backend.py::TestGetMaxRunningReqests` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)