### PR TITLE
Adding RPAv3 tuner

### DIFF
--- a/benchmark/kernels/flash_attention/get_block_spec_config_rpa_v3.py
+++ b/benchmark/kernels/flash_attention/get_block_spec_config_rpa_v3.py
@@ -1,0 +1,335 @@
+import functools
+from math import inf
+
+import jax
+import numpy as np
+from utils import create_decode_uniform_data, create_prefill_uniform_data
+
+from sgl_jax.srt.kernels.ragged_paged_attention.ragged_paged_attention_v3 import (
+    ragged_paged_attention,
+)
+from sgl_jax.srt.kernels.utils.perf import multiple_iteration_timeit_from_trace
+
+
+def is_decode_only(max_num_batched_tokens):
+    return max_num_batched_tokens <= 256
+
+
+def benchmark_backend(
+    max_context_len,
+    max_kv_cache_tokens,
+    max_num_batched_tokens,
+    q_head_num,
+    kv_head_num,
+    head_dim,
+    bkv_sz,
+    bq_sz,
+    bkv_csz,
+    bq_csz,
+    page_size,
+    static_q_len,
+):
+    scale = head_dim**-0.5
+    m_block_config = (bq_sz, bkv_sz, bq_csz, bkv_csz)
+    p_block_config = (bq_sz, bkv_sz, bq_csz, bkv_csz)
+    d_block_config = (1, bkv_sz, 1, bkv_csz)
+
+    if not is_decode_only(max_num_batched_tokens):
+        (
+            q,
+            k,
+            v,
+            kv_cache,
+            kv_lens,
+            page_indices,
+            cu_q_lens,
+            cu_kv_lens,
+            num_seqs,
+            seq_lens,
+            _,
+            distribution,
+        ) = create_prefill_uniform_data(
+            max_context_len,
+            max_kv_cache_tokens,
+            max_num_batched_tokens,
+            q_head_num,
+            kv_head_num,
+            head_dim,
+            page_size=page_size,
+        )
+
+        if static_q_len is None:
+            # Updating distribution for mixed kernel
+            distribution = distribution.at[1].set(0)
+    else:
+        (
+            q,
+            k,
+            v,
+            kv_cache,
+            kv_lens,
+            page_indices,
+            cu_q_lens,
+            cu_kv_lens,
+            num_seqs,
+            seq_lens,
+            _,
+            distribution,
+        ) = create_decode_uniform_data(
+            max_context_len,
+            max_kv_cache_tokens,
+            max_num_batched_tokens,
+            q_head_num,
+            kv_head_num,
+            head_dim,
+            page_size=page_size,
+        )
+
+        static_q_len = 1
+
+    @functools.partial(
+        jax.jit,
+        static_argnames=["sm_scale", "m_block_config", "d_block_config", "p_block_config"],
+    )
+    def jitted_attn(
+        q,
+        k,
+        v,
+        kv_cache,
+        kv_lens,
+        page_indices,
+        cu_q_lens,
+        distribution,
+        sm_scale,
+        chunk_prefill_size,
+        m_block_config,
+        p_block_config,
+        d_block_config,
+    ):
+        return ragged_paged_attention(
+            q,
+            k,
+            v,
+            kv_cache,
+            kv_lens,
+            page_indices,
+            cu_q_lens,
+            distribution,
+            sm_scale=sm_scale,
+            chunk_prefill_size=chunk_prefill_size,
+            p_block_sizes=p_block_config,
+            m_block_sizes=m_block_config,
+            d_block_sizes=d_block_config,
+        )
+
+    attn = functools.partial(
+        jitted_attn,
+        q,
+        k,
+        v,
+        kv_cache,
+        kv_lens,
+        page_indices,
+        cu_q_lens,
+        distribution,
+        scale,
+        static_q_len,
+        p_block_config,
+        m_block_config,
+        d_block_config,
+    )
+
+    # Warmup
+    output = attn()
+    jax.block_until_ready(output)
+
+    # Benchmark
+    rpa_case = "d" if static_q_len == 1 else "m" if static_q_len == 0 else "p"
+    scope_name = f"RPA{rpa_case}-p_{page_size}-bq_{bq_sz}_{bq_csz}-bkv_{bkv_sz}_{bkv_csz}"
+    times = multiple_iteration_timeit_from_trace(
+        compute_func=lambda: attn(),
+        data_generator=lambda: (),
+        task=scope_name,
+        tries=3,
+    )
+
+    avg_time = float(np.mean(times)) if times else float("nan")
+
+    return (
+        avg_time,
+        q.dtype,
+        kv_cache.dtype,
+    )
+
+
+def get_tuned_value(
+    max_context_len,
+    max_kv_cache_tokens,
+    max_num_batched_tokens,
+    q_head_num,
+    kv_head_num,
+    head_dim,
+    page_size,
+    static_q_len,
+    block_spec_configs,
+):
+    best_output = inf
+    best_config = None
+
+    for i, (bkv_sz, bq_sz, bkv_csz, bq_csz) in enumerate(block_spec_configs):
+        try:
+            (
+                flash_time,
+                q_dtype,
+                k_dtype,
+            ) = benchmark_backend(
+                max_context_len,
+                max_kv_cache_tokens,
+                max_num_batched_tokens,
+                q_head_num,
+                kv_head_num,
+                head_dim,
+                bkv_sz,
+                bq_sz,
+                bkv_csz,
+                bq_csz,
+                page_size,
+                static_q_len,
+            )
+
+            if flash_time < best_output:
+                best_output = flash_time
+                best_config = (bkv_sz, bq_sz, bkv_csz, bq_csz)
+        except Exception:
+            pass
+    if best_config:
+        print(
+            f"('{q_dtype}', '{k_dtype}', {q_head_num}, {kv_head_num}, {head_dim}, {page_size}, {max_num_batched_tokens}, {static_q_len}): ({best_config[0]}, {best_config[1]}, {best_config[2]}, {best_config[3]}),"
+        )
+
+
+def main():
+    print("JAX devices:", jax.devices())
+    print("Device count:", jax.device_count())
+    print()
+
+    page_size_config = [128]
+    max_num_batched_tokens_config = [
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64,
+        128,
+        256,
+        512,
+        1024,
+        2048,
+        4096,
+        8192,
+        16384,
+    ]
+    q_head_num_config = [1, 2, 4, 8, 16, 32]
+    kv_head_num_config = [1, 2, 4, 8, 16, 32]
+    head_dim_config = [128]
+    max_kv_cache_tokens_config = [600000]
+    all_combinations = []
+    max_context_len = 40960
+    prefill_kernel_chunk_size = [8192]
+
+    for q_head_num in q_head_num_config:
+        for kv_head_num in kv_head_num_config:
+            for head_dim in head_dim_config:
+                for page_size in page_size_config:
+                    for max_kv_cache_tokens in max_kv_cache_tokens_config:
+                        for max_num_batched_tokens in max_num_batched_tokens_config:
+                            for chunk in prefill_kernel_chunk_size:
+                                if q_head_num < kv_head_num or q_head_num % kv_head_num != 0:
+                                    continue
+                                all_combinations.append(
+                                    (
+                                        page_size,
+                                        max_kv_cache_tokens,
+                                        max_num_batched_tokens,
+                                        q_head_num,
+                                        kv_head_num,
+                                        head_dim,
+                                        chunk,
+                                    )
+                                )
+
+    num_kv_per_blk_config = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
+    bkv_csz = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
+    num_queries_per_block_config = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
+    bq_csz = [4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
+
+    prefill_only_block_spec_configs = []
+    for num_kv_per_blk in num_kv_per_blk_config:
+        for num_q_per_blk in num_queries_per_block_config:
+            for num_bkv_csz in bkv_csz:
+                for num_bq_csz in bq_csz:
+                    prefill_only_block_spec_configs.append(
+                        (num_kv_per_blk, num_q_per_blk, num_bkv_csz, num_bq_csz)
+                    )
+
+    decode_only_block_spec_configs = []
+    for num_kv_per_blk in num_kv_per_blk_config:
+        for num_bkv_csz in bkv_csz:
+            decode_only_block_spec_configs.append((num_kv_per_blk, 1, num_bkv_csz, 1))
+
+    for i, (
+        page_size,
+        max_kv_cache_tokens,
+        max_num_batched_tokens,
+        q_head_num,
+        kv_head_num,
+        head_dim,
+        chunk_prefill_size,
+    ) in enumerate(all_combinations):
+        if is_decode_only(max_num_batched_tokens):
+            block_spec_configs = decode_only_block_spec_configs
+
+            # Decode kernel tuning
+            get_tuned_value(
+                max_context_len,
+                max_kv_cache_tokens,
+                max_num_batched_tokens,
+                q_head_num,
+                kv_head_num,
+                head_dim,
+                page_size,
+                1,
+                block_spec_configs,
+            )
+        else:
+            # Mixed kernel tuning
+            get_tuned_value(
+                max_context_len,
+                max_kv_cache_tokens,
+                max_num_batched_tokens,
+                q_head_num,
+                kv_head_num,
+                head_dim,
+                page_size,
+                None,
+                block_spec_configs,
+            )
+
+            # Prefill kernel tuning
+            get_tuned_value(
+                max_context_len,
+                max_kv_cache_tokens,
+                max_num_batched_tokens,
+                q_head_num,
+                kv_head_num,
+                head_dim,
+                page_size,
+                chunk_prefill_size,
+                block_spec_configs,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/flash_attention/get_block_spec_config_rpa_v3.py
+++ b/benchmark/kernels/flash_attention/get_block_spec_config_rpa_v3.py
@@ -89,7 +89,13 @@ def benchmark_backend(
 
     @functools.partial(
         jax.jit,
-        static_argnames=["sm_scale", "m_block_config", "d_block_config", "p_block_config"],
+        static_argnames=[
+            "sm_scale",
+            "chunk_prefill_size",
+            "m_block_config",
+            "d_block_config",
+            "p_block_config",
+        ],
     )
     def jitted_attn(
         q,
@@ -99,6 +105,7 @@ def benchmark_backend(
         kv_lens,
         page_indices,
         cu_q_lens,
+        cu_kv_lens,
         distribution,
         sm_scale,
         chunk_prefill_size,
@@ -114,9 +121,12 @@ def benchmark_backend(
             kv_lens,
             page_indices,
             cu_q_lens,
+            cu_kv_lens,
             distribution,
             sm_scale=sm_scale,
             chunk_prefill_size=chunk_prefill_size,
+            custom_mask=None,
+            attention_sink=None,
             p_block_sizes=p_block_config,
             m_block_sizes=m_block_config,
             d_block_sizes=d_block_config,
@@ -131,6 +141,7 @@ def benchmark_backend(
         kv_lens,
         page_indices,
         cu_q_lens,
+        cu_kv_lens,
         distribution,
         scale,
         static_q_len,
@@ -144,8 +155,9 @@ def benchmark_backend(
     jax.block_until_ready(output)
 
     # Benchmark
-    rpa_case = "d" if static_q_len == 1 else "m" if static_q_len == 0 else "p"
+    rpa_case = "d" if static_q_len == 1 else "m" if static_q_len is None else "p"
     scope_name = f"RPA{rpa_case}-p_{page_size}-bq_{bq_sz}_{bq_csz}-bkv_{bkv_sz}_{bkv_csz}"
+    print(scope_name)
     times = multiple_iteration_timeit_from_trace(
         compute_func=lambda: attn(),
         data_generator=lambda: (),
@@ -304,6 +316,8 @@ def main():
                 block_spec_configs,
             )
         else:
+            block_spec_configs = prefill_only_block_spec_configs
+
             # Mixed kernel tuning
             get_tuned_value(
                 max_context_len,

--- a/benchmark/kernels/flash_attention/get_block_spec_config_rpa_v3.py
+++ b/benchmark/kernels/flash_attention/get_block_spec_config_rpa_v3.py
@@ -57,11 +57,9 @@ def benchmark_backend(
             kv_head_num,
             head_dim,
             page_size=page_size,
+            static_q_len=static_q_len,
         )
 
-        if static_q_len is None:
-            # Updating distribution for mixed kernel
-            distribution = distribution.at[1].set(0)
     else:
         (
             q,
@@ -160,7 +158,6 @@ def benchmark_backend(
     # Benchmark
     rpa_case = "d" if static_q_len == 1 else "m" if static_q_len is None else "p"
     scope_name = f"RPA{rpa_case}-p_{page_size}-bq_{bq_sz}_{bq_csz}-bkv_{bkv_sz}_{bkv_csz}"
-    print(scope_name)
     times = multiple_iteration_timeit_from_trace(
         compute_func=lambda: attn(),
         data_generator=lambda: (),

--- a/benchmark/kernels/flash_attention/get_block_spec_config_rpa_v3.py
+++ b/benchmark/kernels/flash_attention/get_block_spec_config_rpa_v3.py
@@ -28,6 +28,7 @@ def benchmark_backend(
     bq_csz,
     page_size,
     static_q_len,
+    sliding_window_len,
 ):
     scale = head_dim**-0.5
     m_block_config = (bq_sz, bkv_sz, bq_csz, bkv_csz)
@@ -85,8 +86,6 @@ def benchmark_backend(
             page_size=page_size,
         )
 
-        static_q_len = 1
-
     @functools.partial(
         jax.jit,
         static_argnames=[
@@ -95,6 +94,7 @@ def benchmark_backend(
             "m_block_config",
             "d_block_config",
             "p_block_config",
+            "sliding_window_len",
         ],
     )
     def jitted_attn(
@@ -109,9 +109,10 @@ def benchmark_backend(
         distribution,
         sm_scale,
         chunk_prefill_size,
-        m_block_config,
         p_block_config,
+        m_block_config,
         d_block_config,
+        sliding_window_len,
     ):
         return ragged_paged_attention(
             q,
@@ -130,6 +131,7 @@ def benchmark_backend(
             p_block_sizes=p_block_config,
             m_block_sizes=m_block_config,
             d_block_sizes=d_block_config,
+            sliding_window=sliding_window_len,
         )
 
     attn = functools.partial(
@@ -148,6 +150,7 @@ def benchmark_backend(
         p_block_config,
         m_block_config,
         d_block_config,
+        sliding_window_len,
     )
 
     # Warmup
@@ -184,6 +187,7 @@ def get_tuned_value(
     page_size,
     static_q_len,
     block_spec_configs,
+    sliding_window_len,
 ):
     best_output = inf
     best_config = None
@@ -207,6 +211,7 @@ def get_tuned_value(
                 bq_csz,
                 page_size,
                 static_q_len,
+                sliding_window_len,
             )
 
             if flash_time < best_output:
@@ -216,7 +221,7 @@ def get_tuned_value(
             pass
     if best_config:
         print(
-            f"('{q_dtype}', '{k_dtype}', {q_head_num}, {kv_head_num}, {head_dim}, {page_size}, {max_num_batched_tokens}, {static_q_len}): ({best_config[0]}, {best_config[1]}, {best_config[2]}, {best_config[3]}),"
+            f"('{q_dtype}', '{k_dtype}', {q_head_num}, {kv_head_num}, {head_dim}, {page_size}, {max_num_batched_tokens}, {static_q_len} , {sliding_window_len}): ({best_config[0]}, {best_config[1]}, {best_config[2]}, {best_config[3]}),"
         )
 
 
@@ -241,7 +246,6 @@ def main():
         2048,
         4096,
         8192,
-        16384,
     ]
     q_head_num_config = [1, 2, 4, 8, 16, 32]
     kv_head_num_config = [1, 2, 4, 8, 16, 32]
@@ -249,6 +253,7 @@ def main():
     max_kv_cache_tokens_config = [600000]
     all_combinations = []
     max_context_len = 40960
+    sliding_window_len_config = [None]
     prefill_kernel_chunk_size = [8192]
 
     for q_head_num in q_head_num_config:
@@ -258,19 +263,21 @@ def main():
                     for max_kv_cache_tokens in max_kv_cache_tokens_config:
                         for max_num_batched_tokens in max_num_batched_tokens_config:
                             for chunk in prefill_kernel_chunk_size:
-                                if q_head_num < kv_head_num or q_head_num % kv_head_num != 0:
-                                    continue
-                                all_combinations.append(
-                                    (
-                                        page_size,
-                                        max_kv_cache_tokens,
-                                        max_num_batched_tokens,
-                                        q_head_num,
-                                        kv_head_num,
-                                        head_dim,
-                                        chunk,
+                                for sliding_window_len in sliding_window_len_config:
+                                    if q_head_num < kv_head_num or q_head_num % kv_head_num != 0:
+                                        continue
+                                    all_combinations.append(
+                                        (
+                                            page_size,
+                                            max_kv_cache_tokens,
+                                            max_num_batched_tokens,
+                                            q_head_num,
+                                            kv_head_num,
+                                            head_dim,
+                                            chunk,
+                                            sliding_window_len,
+                                        )
                                     )
-                                )
 
     num_kv_per_blk_config = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
     bkv_csz = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
@@ -299,6 +306,7 @@ def main():
         kv_head_num,
         head_dim,
         chunk_prefill_size,
+        sliding_window_len,
     ) in enumerate(all_combinations):
         if is_decode_only(max_num_batched_tokens):
             block_spec_configs = decode_only_block_spec_configs
@@ -314,6 +322,7 @@ def main():
                 page_size,
                 1,
                 block_spec_configs,
+                sliding_window_len,
             )
         else:
             block_spec_configs = prefill_only_block_spec_configs
@@ -329,6 +338,7 @@ def main():
                 page_size,
                 None,
                 block_spec_configs,
+                sliding_window_len,
             )
 
             # Prefill kernel tuning
@@ -342,6 +352,7 @@ def main():
                 page_size,
                 chunk_prefill_size,
                 block_spec_configs,
+                sliding_window_len,
             )
 
 

--- a/benchmark/kernels/flash_attention/utils.py
+++ b/benchmark/kernels/flash_attention/utils.py
@@ -56,13 +56,12 @@ def create_prefill_uniform_data(
     head_dim,
     page_size=128,
     dtype=jnp.bfloat16,
+    static_q_len=None,
     seed=42,
 ):
-    if max_num_batched_tokens > 2048:
-        batch_size = cdiv(max_num_batched_tokens, 2048)
-        seq_lens_list = [2048] * (batch_size - 1) + [
-            max_num_batched_tokens - 2048 * (batch_size - 1)
-        ]
+    if static_q_len is not None:
+        batch_size = cdiv(max_num_batched_tokens, static_q_len)
+        seq_lens_list = [static_q_len] * batch_size
     else:
         batch_size = 1
         seq_lens_list = [max_num_batched_tokens]
@@ -98,7 +97,11 @@ def create_prefill_uniform_data(
     )
 
     num_seqs = jnp.array([batch_size], dtype=jnp.int32)
-    distribution = jnp.array([0, batch_size, batch_size], dtype=jnp.int32)
+    distribution = (
+        jnp.array([0, 0, batch_size], dtype=jnp.int32)
+        if static_q_len is None
+        else jnp.array([0, batch_size, batch_size], dtype=jnp.int32)
+    )
     return (
         q,
         k,

--- a/benchmark/kernels/flash_attention/utils.py
+++ b/benchmark/kernels/flash_attention/utils.py
@@ -98,7 +98,7 @@ def create_prefill_uniform_data(
     )
 
     num_seqs = jnp.array([batch_size], dtype=jnp.int32)
-    distribution = jnp.array([0, 0, batch_size], dtype=jnp.int32)
+    distribution = jnp.array([0, batch_size, batch_size], dtype=jnp.int32)
     return (
         q,
         k,

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -31,6 +31,9 @@ from jax import lax
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
+from sgl_jax.srt.kernels.ragged_paged_attention.rpa_v3_tuned_block_sizes import (
+    get_tuned_block_sizes,
+)
 from sgl_jax.srt.kernels.ragged_paged_attention.util import (
     align_to,
     cdiv,
@@ -1949,6 +1952,31 @@ def ragged_paged_attention(
         return run(scalar_prefetches, q, kv, kv_cache)
 
     def _prepare_block_sizes(block_sizes, case):
+        tuned_values = get_tuned_block_sizes(
+            q.dtype,
+            kv_cache_fused_processed.dtype,
+            actual_num_q_heads,
+            actual_num_kv_heads,
+            head_dim,
+            page_size,
+            max_num_tokens,
+            pages_per_seq,
+            (
+                None
+                if case == RpaCase.MIXED
+                else 1 if case == RpaCase.DECODE else chunk_prefill_size
+            ),
+        )
+
+        if tuned_values is not None:
+            (bkv_sz, bq_sz, bkv_csz, bq_csz) = tuned_values
+            return {
+                "bq_sz": bq_sz,
+                "bkv_sz": bkv_sz,
+                "bq_csz": bq_csz,
+                "bkv_csz": bkv_csz,
+            }
+
         if block_sizes is None:
             return get_default_block_sizes(
                 q.dtype,

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -1966,6 +1966,7 @@ def ragged_paged_attention(
                 if case == RpaCase.MIXED
                 else 1 if case == RpaCase.DECODE else chunk_prefill_size
             ),
+            sliding_window=sliding_window,
         )
 
         if tuned_values is not None:

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/rpa_v3_tuned_block_sizes.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/rpa_v3_tuned_block_sizes.py
@@ -1,0 +1,107 @@
+"""Auto-tuned block sizes for ragged paged attention."""
+
+import logging
+
+import jax.numpy as jnp
+
+from sgl_jax.srt.kernels.ragged_paged_attention.util import get_tpu_version
+from sgl_jax.srt.utils.common_utils import next_power_of_2
+from sgl_jax.srt.utils.jax_utils import get_device_name
+
+logger = logging.getLogger(__name__)
+# key
+#   - device_name
+#     - q dtype
+#     - kv dtype
+#     - q head number
+#     - kv head number
+#     - head dim
+#     - page_size
+#     - max_num_tokens
+#     - static_q_len (Mixed: None, Prefill: Chunked_size, Decode: 1)
+# value:
+#   - (num_kv_per_block, num_queries_per_block, num_compute_kv_per_block, num_compute_queries_per_block)
+TUNED_BLOCK_SIZES = {
+    "TPU v7": {
+        ("bfloat16", "bfloat16", 8, 1, 128, 128, 8192, None): (4096, 512, 1024, 128),
+        ("bfloat16", "bfloat16", 8, 1, 128, 128, 16384, None): (4096, 1024, 1024, 128),
+    },
+}
+
+
+def get_tuned_block_sizes(
+    q_dtype,
+    kv_dtype,
+    actual_num_q_heads,
+    actual_num_kv_heads,
+    head_dim,
+    page_size,
+    max_num_tokens,
+    pages_per_seq,
+    static_q_len,
+) -> tuple[int, int, int, int]:
+    tpu_version = get_tpu_version()
+
+    if tpu_version < 4:
+        raise NotImplementedError("TPU version must be 4 or higher.")
+    keys = get_simplified_key(
+        page_size,
+        q_dtype,
+        kv_dtype,
+        actual_num_q_heads,
+        actual_num_kv_heads,
+        head_dim,
+        max_num_tokens,
+        static_q_len,
+    )
+
+    device_name = keys[0]
+
+    if device_name in TUNED_BLOCK_SIZES and keys[1:] in TUNED_BLOCK_SIZES[device_name]:
+        bkv_sz, bq_sz, bkv_csz, bq_csz = TUNED_BLOCK_SIZES[device_name][keys[1:]]
+        return (bkv_sz, bq_sz, bkv_csz, bq_csz)
+    else:
+        logger.info(
+            "Tuned RPA block sizes not found for %s: page_size=%s, actual_num_q_heads=%s, "
+            "actual_num_kv_heads=%s, head_dim=%s, max_num_tokens=%s, pages_per_seq=%s. Using default block sizes.",
+            device_name,
+            page_size,
+            actual_num_q_heads,
+            actual_num_kv_heads,
+            head_dim,
+            max_num_tokens,
+            pages_per_seq,
+        )
+
+        return None
+
+
+def get_simplified_key(
+    page_size,
+    q_dtype,
+    kv_dtype,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    max_num_tokens,
+    static_q_len,
+):
+    """Get the simplified key to reduce the number of combinations."""
+    assert num_q_heads % num_kv_heads == 0
+    device = get_device_name()
+    q_dtype_name = jnp.dtype(q_dtype).name
+    kv_dtype_name = jnp.dtype(kv_dtype).name
+    num_q_heads = next_power_of_2(num_q_heads)
+    num_kv_heads = next_power_of_2(num_kv_heads)
+
+    return (
+        device,
+        q_dtype_name,
+        kv_dtype_name,
+        num_q_heads,
+        num_kv_heads,
+        (head_dim + 127) // 128 * 128,
+        next_power_of_2(page_size),
+        next_power_of_2(max_num_tokens),
+        static_q_len,
+    )

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/rpa_v3_tuned_block_sizes.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/rpa_v3_tuned_block_sizes.py
@@ -19,12 +19,40 @@ logger = logging.getLogger(__name__)
 #     - page_size
 #     - max_num_tokens
 #     - static_q_len (Mixed: None, Prefill: Chunked_size, Decode: 1)
+#     - sliding windown length
 # value:
 #   - (num_kv_per_block, num_queries_per_block, num_compute_kv_per_block, num_compute_queries_per_block)
 TUNED_BLOCK_SIZES = {
     "TPU v7": {
-        ("bfloat16", "bfloat16", 8, 1, 128, 128, 8192, None): (4096, 512, 1024, 128),
-        ("bfloat16", "bfloat16", 8, 1, 128, 128, 16384, None): (4096, 1024, 1024, 128),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 1, 1, None): (1024, 1, 1024, 1),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 2, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 4, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 8, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 16, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 32, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 64, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 128, 1, None): (4096, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 256, 1, None): (4096, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 512, None, None): (512, 512, 512, 256),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 512, 8192, None): (2048, 1024, 1024, 512),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 1024, None, None): (512, 512, 512, 256),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 1024, 8192, None): (2048, 1024, 1024, 512),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 2048, None, None): (1024, 1024, 1024, 512),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 2048, 8192, None): (2048, 1024, 1024, 512),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 4096, None, None): (1024, 1024, 1024, 512),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 4096, 8192, None): (2048, 1024, 1024, 512),
+        ("bfloat16", "bfloat16", 1, 1, 128, 128, 8192, None, None): (2048, 1024, 1024, 512),
+        ("bfloat16", "bfloat16", 8, 1, 128, 128, 1, 1, None): (1024, 1, 1024, 1),
+        ("bfloat16", "bfloat16", 8, 1, 128, 128, 2, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 8, 1, 128, 128, 4, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 8, 1, 128, 128, 8, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 8, 1, 128, 128, 16, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 8, 1, 128, 128, 32, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 8, 1, 128, 128, 64, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 8, 1, 128, 128, 128, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 8, 1, 128, 128, 256, 1, None): (2048, 1, 2048, 1),
+        ("bfloat16", "bfloat16", 8, 1, 128, 128, 8192, None, None): (4096, 512, 1024, 128),
+        ("bfloat16", "bfloat16", 8, 1, 128, 128, 16384, None, None): (4096, 1024, 1024, 128),
     },
 }
 
@@ -39,6 +67,7 @@ def get_tuned_block_sizes(
     max_num_tokens,
     pages_per_seq,
     static_q_len,
+    sliding_window,
 ) -> tuple[int, int, int, int]:
     tpu_version = get_tpu_version()
 
@@ -53,6 +82,7 @@ def get_tuned_block_sizes(
         head_dim,
         max_num_tokens,
         static_q_len,
+        sliding_window,
     )
 
     device_name = keys[0]
@@ -85,6 +115,7 @@ def get_simplified_key(
     head_dim,
     max_num_tokens,
     static_q_len,
+    sliding_window,
 ):
     """Get the simplified key to reduce the number of combinations."""
     assert num_q_heads % num_kv_heads == 0
@@ -104,4 +135,5 @@ def get_simplified_key(
         next_power_of_2(page_size),
         next_power_of_2(max_num_tokens),
         static_q_len,
+        sliding_window,
     )

--- a/python/sgl_jax/srt/kernels/utils/perf.py
+++ b/python/sgl_jax/srt/kernels/utils/perf.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import random
 import re
+import shutil
 import string
 from typing import Any
 
@@ -99,4 +100,7 @@ def multiple_iteration_timeit_from_trace(
                 jax.block_until_ready(out)
 
     trace = _load_trace(trace_dir)
-    return _extract_marker_durations_ms(trace, task=task)
+    duration_list = _extract_marker_durations_ms(trace, task=task)
+
+    shutil.rmtree(trace_dir)  # Removing the profiles from piling up and consuming storage.
+    return duration_list


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
This PR aims to add the tuner for the new RPAv3 kernel for the PREFILL, DECODE, MIXED sub kernels.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- Added tuner script
- Integrated Grok2 tuned values to the RPAv3 kernel
- Added fix to remove the generated profiles while tuning, which crashes the v7x servers when the capacity is exhausted by tuning profiles.
<!-- Detail the changes made in this pull request. -->

## Tests
**Testing ongoing for tuner changes and integration, once all the scenarios are tested, then only will close the PR.**
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
Got ~500 extra tokens after tuning the MIXED kernel for Grok-2 workload.
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
