### PR TITLE
fix: support SWA radix cache

### DIFF
--- a/docs/design/swa_eviction_and_lru_strategy.md
+++ b/docs/design/swa_eviction_and_lru_strategy.md
@@ -1,0 +1,325 @@
+# SWA Eviction and LRU Strategy
+
+## 1. Dual-Pool Architecture
+
+```
++-----------------------------------------------------------+
+|                      KV Cache Memory                      |
+|                                                           |
+|  +-------------------------+  +-------------------------+ |
+|  |       Full Pool         |  |        SWA Pool         | |
+|  |   (Full Attention lys)  |  |   (Sliding Window lys)  | |
+|  |                         |  |                         | |
+|  |   Grows with seqlen     |  |   Bounded by window     | |
+|  |   Never evicted per-req |  |   Evicted outside window| |
+|  +-------------------------+  +-------------------------+ |
+|                                                           |
+|  Linked by full_to_swa_index_mapping:                     |
+|    full_idx --> swa_idx  (or 0 if SWA freed)              |
++-----------------------------------------------------------+
+```
+
+### Key Terms
+
+| Term | Meaning |
+|------|---------|
+| `swa_evicted_seqlen` | SWA slots `[0, swa_evicted_seqlen)` have been freed |
+| `protected prefix` | Prefix `[0, protected_prefix_len)` owned by the radix tree, derived from the request's locked `last_node` path; per-request eviction cannot touch it |
+| `last_matched_prefix_len` | Page-aligned cached prefix length kept on the request for writeback / retract bookkeeping |
+| `tombstone` | Tree node: full KV retained, SWA KV freed |
+
+## 2. Two Cache Modes at a Glance
+
+```
+ChunkCache (--disable-radix-cache)       SWARadixCache (radix cache enabled)
++-------------------------------+        +-------------------------------+
+| No tree. Request owns all     |        | Radix tree caches KV for     |
+| slots. Freed on completion.   |        | prefix reuse across reqs.    |
+| No prefix sharing.            |        | Tree outlives requests.      |
++-------------------------------+        +-------------------------------+
+```
+
+## 3. Per-Request SWA Eviction
+
+Frees SWA slots outside the sliding window from a request's `req_to_token` buffer.
+
+Two code paths, depending on cache mode:
+
+**ChunkCache path** (`ScheduleBatch._evict_swa`):
+```
+_evict_swa(req, pre_len, sliding_window_size, page_size):
+
+  # If tree_cache is SWARadixCache, delegate to evict_req_swa (see below)
+  1. Target: new_evicted = max(swa_evicted_seqlen, pre_len - sliding_window - page_size)
+  2. Align:  new_evicted = page_floor(new_evicted)   [only if page_size > 1]
+  3. Free:   free_swa( slots[swa_evicted_seqlen : new_evicted] )
+```
+
+**SWARadixCache path** (`SWARadixCache.evict_req_swa`):
+```
+evict_req_swa(req, pre_len):
+
+  1. Derive: protected_prefix_len = _node_prefix_len(req.last_node)
+  2. Clamp:  swa_evicted_seqlen = max(swa_evicted_seqlen, protected_prefix_len)
+  3. Target: new_evicted = max(swa_evicted_seqlen, pre_len - sliding_window - page_size)
+  4. Align:  new_evicted = page_floor(new_evicted)   [only if page_size > 1]
+  5. Free:   free_swa( slots[swa_evicted_seqlen : new_evicted] )
+```
+
+Steps 1-2 are unique to the SWARadixCache path — they protect the tree-owned
+prefix from being evicted. The `- page_size` safety margin in step 3 prevents
+`swa_evicted_seqlen` from reaching the live leaf boundary, ensuring
+`_insert_helper` can always create a non-tombstone leaf.
+
+```
+Example (sliding_window=128, page_size=256, seqlen=2049, decode pre_len=2048):
+
+  ChunkCache path: new_evicted = 2048 - 128 - 256 = 1664
+                   page_floor(1664, 256) = 1536
+
+  0         1536         2048
+  |..........|############|
+   freed SWA   retained
+               (window + page)
+  ^                        ^
+  swa_evicted=1536    seqlen=2049
+```
+
+### When does it run?
+
+| Phase  | ChunkCache | SWARadixCache                             |
+|--------|------------|-------------------------------------------|
+| Extend | Yes        | **No** (skipped; `isinstance(tree_cache, ChunkCache)` gate) |
+| Decode | Yes        | Yes (delegates to `evict_req_swa` with tree-derived protected prefix) |
+
+## 4. Extend Phase Behavior
+
+### 4.1 ChunkCache -- Proactive Eviction
+
+With overlap scheduling, `pre_len` is shifted back by `chunked_prefill_size`
+when `enable_overlap=True` and `req.is_chunked > 0`.
+There is no explicit `extend_batch_idx` gate — the first two chunks naturally
+produce no eviction because `pre_len - chunked_prefill_size` is too small to
+exceed `sliding_window + page_size`.
+
+```
+8K tokens, chunk_size=2048, sliding_window=128, page_size=256, overlap=True
+
+       0       2048      4096      6144      8192
+       |        |         |         |         |
+Chk 1: |########|                              pre_len=0-2048<0, no eviction
+       alloc [0,2048)
+
+Chk 2: |################|                     pre_len=2048-2048=0, no eviction
+       alloc [0,4096)
+
+Chk 3: |.........|################|           pre_len=4096-2048=2048
+       freed     retained                     new_evicted=2048-128-256=1664
+       [0,1536)                                page_floor(1664,256)=1536
+
+Chk 4: |..................|################|  pre_len=6144-2048=4096
+       freed              retained            new_evicted=4096-128-256=3712
+       [0,3584)                                page_floor(3712,256)=3584
+
+  . = freed SWA    # = retained SWA
+```
+
+Without overlap (`enable_overlap=False`), `pre_len` is not adjusted.
+Each chunk directly evicts based on the full `len(req.prefix_indices)`:
+
+```
+Chk 1: |########|                              pre_len=0, nothing
+Chk 2: |........|################|             pre_len=2048, evict [0,1536)
+Chk 3: |.................|################|    pre_len=4096, evict [1536,3584)
+```
+
+### 4.2 SWARadixCache -- Deferred to Tree
+
+```
+8K tokens, chunk_size=2048, sliding_window=128, page_size=256
+
+       0       2048      4096      6144      8192
+       |        |         |         |         |
+Chk 1: |########|
+       _evict_swa: SKIPPED
+       cache_unfinished_req --> tree owns [0,2048), all non-tombstone
+       protected prefix = 2048 (derived from last_node)
+
+Chk 2: |################|
+       _evict_swa: SKIPPED
+       cache_unfinished_req --> tree owns [0,4096), all non-tombstone
+       protected prefix = 4096 (derived from last_node)
+
+       ... chunks 3, 4 ...  protected prefix = 8192
+
+First decode step:
+  protected_prefix_len = prefix_len(last_node) = 8192
+  swa_evicted = max(0, 8192) = 8192
+  new_evicted = max(8192, 8192-128-256) = 8192
+  --> NO EVICTION (all tree-protected)
+
+  # = SWA in tree (non-tombstone, only freed by tree Phase 2)
+```
+
+**Trade-off**: Prefill SWA slots stay in tree until pool pressure triggers
+tree-level eviction. The ownership boundary now lives inside the cache layer
+instead of a request field, but prefill is still less SWA-efficient than ChunkCache.
+
+## 5. Tree-Level Eviction (SWARadixCache)
+
+Triggered by allocation pressure (`evict_from_tree_cache` when pool space < needed).
+
+### Phase 1 -- Full Eviction (delete leaf nodes)
+
+Frees **both** full + SWA KV. Removes node from tree entirely.
+
+```
+Before:                             After evicting leaf B:
+
+root --> [A 0..2048] --> [B] leaf   root --> [A 0..2048] --> [C] leaf
+                     --> [C] leaf
+                                    B: full+SWA freed, node deleted
+
+If parent becomes childless tombstone --> cascade delete:
+
+root --> [A tombstone] --> [B] leaf       root (empty)
+         only child                       A, B both deleted
+```
+
+### Phase 2 -- SWA-Only Eviction (tombstone internal nodes)
+
+Uses `swa_lru_list` to find LRU nodes. Two sub-cases:
+
+**Internal node** (has children): frees **only SWA** KV via `free_swa()`.
+Full KV kept for prefix matching. Node becomes a tombstone, removed from
+`swa_lru_list` but stays in `full_lru_list`.
+
+**Leaf node** (no children): cannot become tombstone (leaf-must-not-be-tombstone
+invariant), so it is fully deleted — frees **both** full + SWA via `free()`,
+removed from both LRU lists, then cascade delete fires on parent.
+
+```
+Internal node case:
+
+Before:                                After Phase 2 on node A:
+
+root --> [A 0..2048] --> [B] leaf      root --> [A 0..2048] --> [B] leaf
+          full+SWA   --> [C] leaf               TOMBSTONE   --> [C] leaf
+                                                 full only
+```
+
+### Gradual Tombstone Progression (LRU order, head --> tail)
+
+```
+          [0..2048]    [2048..4096]   [4096..6144]   [6144..8192]
+
+Initial:  full+SWA --> full+SWA  --> full+SWA  --> full+SWA
+
+Round 1:  TOMBSTONE--> full+SWA  --> full+SWA  --> full+SWA
+          full only
+
+Round 2:  TOMBSTONE--> TOMBSTONE --> full+SWA  --> full+SWA
+          full only    full only
+
+Round 3:  TOMBSTONE--> TOMBSTONE --> TOMBSTONE --> full+SWA
+          full only    full only     full only     ^ only tail
+                                                     retains SWA
+```
+
+## 6. Tombstone Insert Logic
+
+`_insert_helper` has two sets of tombstone branch logic:
+
+- **Inside the while loop**: healing of **existing** tombstone nodes
+- **After the while loop**: tombstone split when creating **new** nodes
+
+### 6.1 Existing Tombstone Healing (while loop)
+
+When insert walks through an existing tombstone node beyond
+`update_kv_after_len`, it checks `swa_evicted_seqlen` against
+`[node_start, node_end)`:
+
+```
+  BRANCH 1: swa_evicted <= node_start  --> revive entire node
+  BRANCH 2: node_start < swa_evicted < node_end --> split, revive back half
+  BRANCH 3: swa_evicted >= node_end    --> keep tombstone, free incoming value
+```
+
+Branch 1 fires during `cache_unfinished_req` (`swa_evicted_seqlen = 0`)
+when `_match_prefix_helper` truncated the prefix due to tombstone safety.
+
+Branches 2/3 fire during `cache_finished_req` when a prior request's
+decode nodes have been tombstoned and the current request generated
+identical decode tokens (e.g. greedy decoding with the same prefix).
+
+### 6.2 New Node Tombstone Split (after while loop)
+
+When insert has remaining unmatched tokens (`len(key) > 0`), it creates
+new nodes.  Invariant: **leaf nodes must never be tombstone**.
+
+```
+  Case 1: swa_evicted <= total_prefix_length
+          --> create non-tombstone leaf (normal path for cache_unfinished_req)
+
+  Case 2: total_prefix_length < swa_evicted < total_prefix_length + len(key)
+          --> split into tombstone prefix + non-tombstone leaf
+              (normal path for cache_finished_req: decode suffix split)
+
+  Case 3: swa_evicted >= total_prefix_length + len(key)
+          --> all remaining SWA evicted, cannot create non-tombstone leaf
+              free incoming value and return (defensive guard, kept safe
+              by the extra `- page_size` in `_evict_swa` frontier)
+```
+
+### 6.3 Trigger Conditions
+
+| Call site | `swa_evicted_seqlen` | Existing tombstone | New nodes |
+|-----------|---------------------|--------------------|-----------|
+| `cache_unfinished_req` | Always 0 | Branch 1 only | Case 1 only |
+| `cache_finished_req` | >= protected prefix length | Prefill nodes: skip zone. Prior req's decode nodes: Branch 1/2/3 | Case 2 (normal), Case 3 (defensive) |
+
+## 7. LRU Policy
+
+```
++-----------------------------------------------------+
+|                   full_lru_list                     |
+|  Tracks: ALL non-root nodes                         |
+|  Used by: Phase 1 (find LRU leaf for full eviction) |
+|                                                     |
+|  LRU <--- old nodes --- recent nodes ---> MRU       |
++-----------------------------------------------------+
+
++-----------------------------------------------------+
+|                   swa_lru_list                      |
+|  Tracks: non-root, NON-TOMBSTONE nodes only         |
+|  Used by: Phase 2 (find LRU node for SWA eviction)  |
+|                                                     |
+|  Tombstone nodes REMOVED from this list.            |
+|  Revived nodes RE-INSERTED at MRU.                  |
++-----------------------------------------------------+
+```
+
+On prefix match, the **deepest matched node** and all ancestors are
+reset to MRU in both lists, keeping frequently accessed prefixes fresh.
+
+## 8. Summary
+
+```
++-------------------+-----------------+------------------------+
+|                   | ChunkCache      | SWARadixCache          |
++-------------------+-----------------+------------------------+
+| Extend SWA evict  | Proactive       | Skipped                |
+|                   | (per chunk)     | (tree handles)         |
++-------------------+-----------------+------------------------+
+| Decode SWA evict  | From pos 0      | From                   |
+|                   |                 | protected tree prefix  |
++-------------------+-----------------+------------------------+
+| Prefill SWA waste | Low (bounded)   | Higher (until          |
+|                   |                 | Phase 2 evicts)        |
++-------------------+-----------------+------------------------+
+| Prefix reuse      | None            | Yes (via tree)         |
++-------------------+-----------------+------------------------+
+| SWA reclamation   | Per-request     | Tree Phase 2           |
+|                   | _evict_swa      | (reactive, LRU)        |
++-------------------+-----------------+------------------------+
+```

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -19,6 +19,7 @@ ScheduleBatch -> ModelWorkerBatch -> ForwardBatch
 
 import dataclasses
 import logging
+import os
 import threading
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
@@ -1333,7 +1334,9 @@ class ScheduleBatch:
         )
 
         if self.forward_mode is not None and self.forward_mode.is_decode():
-            evict_interval = max(min(sliding_window_size, page_size), 1)
+            multiplier = float(os.environ.get("SGL_JAX_SWA_EVICTION_INTERVAL_MULTIPLIER", "1.0"))
+            evict_interval = max(page_size, int(sliding_window_size * multiplier))
+            evict_interval = (evict_interval // page_size) * page_size
             for dp_rank, info in enumerate(self.reqs_info):
                 if not info.reqs:
                     continue
@@ -1361,9 +1364,13 @@ class ScheduleBatch:
                 continue
             for req in info.reqs:
                 pre_len = len(req.prefix_indices)
-                if self.enable_overlap and req.is_chunked > 0:
-                    if chunked_prefill_size is not None and chunked_prefill_size > 0:
-                        pre_len -= chunked_prefill_size
+                if (
+                    self.enable_overlap
+                    and req.is_chunked > 0
+                    and chunked_prefill_size is not None
+                    and chunked_prefill_size > 0
+                ):
+                    pre_len -= chunked_prefill_size
                 self._evict_swa(req, pre_len, sliding_window_size, page_size, dp_rank)
 
     def _evict_swa(

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1357,10 +1357,10 @@ class ScheduleBatch:
 
         chunked_prefill_size = global_server_args_dict["chunked_prefill_size"]
         for dp_rank, info in enumerate(self.reqs_info):
-            if not info.reqs or info.prefix_lens is None:
+            if not info.reqs:
                 continue
-            for i, req in enumerate(info.reqs):
-                pre_len = info.prefix_lens[i]
+            for req in info.reqs:
+                pre_len = len(req.prefix_indices)
                 if self.enable_overlap and req.is_chunked > 0:
                     if chunked_prefill_size is not None and chunked_prefill_size > 0:
                         pre_len -= chunked_prefill_size

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1045,8 +1045,7 @@ class ScheduleBatch:
             )
 
         # Evict SWA tokens outside sliding window
-        if self.is_hybrid:
-            self.maybe_evict_swa()
+        self.maybe_evict_swa()
 
     def new_page_count_next_decode(
         self,
@@ -1264,7 +1263,7 @@ class ScheduleBatch:
             self.req_to_token_pool.free(req.req_pool_idx)
         else:
             last_uncached_pos = (
-                len(req.prefix_indices) // server_args.page_size
+                req.last_matched_prefix_len // server_args.page_size
             ) * server_args.page_size
             token_indices = self.req_to_token_pool.req_to_token[
                 req.req_pool_idx, last_uncached_pos : seq_lens_cpu[idx]
@@ -1334,10 +1333,6 @@ class ScheduleBatch:
         )
 
         if self.forward_mode is not None and self.forward_mode.is_decode():
-            # Evict at the smaller of sliding_window_size and page_size to avoid
-            # stale SWA slot accumulation. For large windows (e.g., 4096) this
-            # prevents holding memory far beyond what's needed; for small windows
-            # (e.g., 128) it aligns with the natural eviction boundary.
             evict_interval = max(min(sliding_window_size, page_size), 1)
             for dp_rank, info in enumerate(self.reqs_info):
                 if not info.reqs:
@@ -1354,19 +1349,19 @@ class ScheduleBatch:
         if self.forward_mode is None or not self.forward_mode.is_extend():
             return
 
+        # Only do per-request SWA eviction during extend for ChunkCache.
+        # For SWARadixCache, extend-time ownership stays with the tree and
+        # eviction is deferred to tree insert / tree-pressure handling.
+        if not isinstance(self.tree_cache, ChunkCache):
+            return
+
+        chunked_prefill_size = global_server_args_dict["chunked_prefill_size"]
         for dp_rank, info in enumerate(self.reqs_info):
-            if not info.reqs:
+            if not info.reqs or info.prefix_lens is None:
                 continue
-            for req in info.reqs:
-                pre_len = len(req.prefix_indices)
+            for i, req in enumerate(info.reqs):
+                pre_len = info.prefix_lens[i]
                 if self.enable_overlap and req.is_chunked > 0:
-                    # In overlap mode, the previous chunk's forward may still be
-                    # in-flight reading SWA pages for positions
-                    # [len_{N-2} - sliding_window, len_{N-1}). Subtracting
-                    # chunked_prefill_size from pre_len shifts the eviction
-                    # boundary back by exactly one chunk, which mathematically
-                    # keeps new_evicted <= len_{N-2} - sliding_window.
-                    chunked_prefill_size = global_server_args_dict.get("chunked_prefill_size")
                     if chunked_prefill_size is not None and chunked_prefill_size > 0:
                         pre_len -= chunked_prefill_size
                 self._evict_swa(req, pre_len, sliding_window_size, page_size, dp_rank)
@@ -1380,7 +1375,11 @@ class ScheduleBatch:
         dp_rank: int = 0,
     ):
         """Free SWA pool slots for tokens outside the sliding window."""
-        new_evicted = max(req.swa_evicted_seqlen, pre_len - sliding_window_size)
+        if isinstance(self.tree_cache, SWARadixCache):
+            self.tree_cache.evict_req_swa(req, pre_len, dp_rank=dp_rank)
+            return
+
+        new_evicted = max(req.swa_evicted_seqlen, pre_len - sliding_window_size - page_size)
         if page_size > 1:
             new_evicted = (new_evicted // page_size) * page_size
         if new_evicted <= req.swa_evicted_seqlen:
@@ -1388,15 +1387,7 @@ class ScheduleBatch:
         free_slots = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, req.swa_evicted_seqlen : new_evicted
         ]
-        # Count actual SWA slots that will be freed (those with active mapping)
-        num_swa_freed = self.token_to_kv_pool_allocator.count_swa_mapped(
-            free_slots, dp_rank=dp_rank
-        )
         self.token_to_kv_pool_allocator.free_swa(free_slots, dp_rank=dp_rank)
-        # Notify cache layer: these slots were protected (node is locked),
-        # so adjust swa_protected_size_ to prevent bookkeeping leak.
-        if num_swa_freed > 0 and isinstance(self.tree_cache, SWARadixCache):
-            self.tree_cache.adjust_swa_protected_size(-num_swa_freed, dp_rank=dp_rank)
         req.swa_evicted_seqlen = new_evicted
 
     def prepare_for_decode(self):
@@ -1407,8 +1398,7 @@ class ScheduleBatch:
         """
         self.forward_mode = ForwardMode.DECODE
 
-        if self.is_hybrid:
-            self.maybe_evict_swa()
+        self.maybe_evict_swa()
 
         # Process each DP rank
         for dp_rank in range(self.dp_size):

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1341,9 +1341,7 @@ class ScheduleBatch:
                 if not info.reqs:
                     continue
                 for req in info.reqs:
-                    if req.decode_batch_idx > 0 and (
-                        evict_interval <= 1 or req.decode_batch_idx % evict_interval == 1
-                    ):
+                    if req.decode_batch_idx % evict_interval == 1:
                         self._evict_swa(
                             req, req.seqlen - 1, sliding_window_size, page_size, dp_rank
                         )

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -371,7 +371,8 @@ class SWARadixCache(BasePrefixCache):
             last_host_node=last_node,
         )
 
-    def insert(self, key: RadixKey | list, value=None, prev_prefix_len: int = 0) -> int:
+    def insert(self, key: RadixKey | list, value=None, prev_prefix_len: int = 0,
+               swa_evicted_seqlen: int = 0) -> int:
         if self.disable:
             return 0
 
@@ -381,7 +382,8 @@ class SWARadixCache(BasePrefixCache):
 
         if value is None:
             value = [x for x in key.token_ids]
-        return self._insert_helper(self.root_node, key, value, prev_prefix_len)
+        return self._insert_helper(self.root_node, key, value, prev_prefix_len,
+                                    swa_evicted_seqlen=swa_evicted_seqlen)
 
     def cache_finished_req(self, req: Req) -> None:
         """Cache request when it finishes."""
@@ -413,7 +415,8 @@ class SWARadixCache(BasePrefixCache):
         self.insert(
             RadixKey(token_ids[:page_aligned_len], req.extra_key, req.dp_rank),
             page_aligned_kv_indices,
-            len(req.prefix_indices),
+            req.last_matched_prefix_len,
+            swa_evicted_seqlen=req.swa_evicted_seqlen,
         )
 
         # Remove req slot release the cache lock
@@ -441,33 +444,36 @@ class SWARadixCache(BasePrefixCache):
 
         # Radix Cache takes one ref in memory pool
         # Note: the insert function already frees the overlapped kv_indices
+        old_prefix_len = req.last_matched_prefix_len
         new_prefix_len = self.insert(
             RadixKey(page_aligned_token_ids, req.extra_key, req.dp_rank),
             page_aligned_kv_indices,
-            len(req.prefix_indices),
+            old_prefix_len,
+            swa_evicted_seqlen=req.swa_evicted_seqlen,
         )
 
-        # The prefix indices could be updated, reuse it
-        new_indices, new_last_node, _, _ = self.match_prefix(
+        match_result = self.match_prefix(
             RadixKey(page_aligned_token_ids, req.extra_key, req.dp_rank)
         )
-        assert len(req.prefix_indices) <= len(new_indices), f"{req.prefix_indices=}, {new_indices=}"
+        new_indices = match_result.device_indices
+        new_last_node = match_result.last_device_node
+        assert old_prefix_len <= len(new_indices), f"{old_prefix_len=}, {new_indices=}"
         assert new_prefix_len <= len(new_indices), f"{new_prefix_len=}, {new_indices=}"
         self.req_to_token_pool.write(
-            (req.req_pool_idx, slice(len(req.prefix_indices), len(new_indices))),
-            new_indices[len(req.prefix_indices) :],
+            (req.req_pool_idx, slice(old_prefix_len, len(new_indices))),
+            new_indices[old_prefix_len:],
         )
 
         self.dec_lock_ref(req.last_node, req.swa_uuid_for_lock)
         swa_uuid_for_lock = self.inc_lock_ref(new_last_node)
 
-        # `req.prefix_indices` will be used in `PrefillAdder::add_chunked_req` later
         if self.page_size != 1:
-            req.prefix_indices = np.concatenate([new_indices, kv_indices[len(new_indices) :]])
+            req.prefix_indices = np.concatenate([new_indices, kv_indices[len(new_indices):]])
         else:
             req.prefix_indices = new_indices
         req.last_node = new_last_node
         req.swa_uuid_for_lock = swa_uuid_for_lock
+        req.last_matched_prefix_len = len(new_indices)
 
     def pretty_print(self) -> None:
         self._print_helper(self.root_node, 0)
@@ -515,7 +521,6 @@ class SWARadixCache(BasePrefixCache):
 
                 # 3. delete the leaf node
                 self._delete_leaf(x)
-                self.swa_evictable_size_[node_dp_rank] -= actual_swa_free
 
                 # 4. Iteratively delete tombstone leaves to maintain invariant that leaf nodes are not tombstone
                 x, leaf_full_num_evicted = self._iteratively_delete_tombstone_leaf(x)
@@ -559,7 +564,6 @@ class SWARadixCache(BasePrefixCache):
 
                     # 3. tombstone the node
                     self._tombstone_internal_node(x)
-                    self.swa_evictable_size_[node_dp_rank] -= actual_swa_free
                 else:
                     assert (
                         x.full_lock_ref == 0
@@ -577,7 +581,6 @@ class SWARadixCache(BasePrefixCache):
 
                     # 3. delete the leaf node
                     self._delete_leaf(x)
-                    self.swa_evictable_size_[node_dp_rank] -= actual_swa_free
 
                     # 4. Iteratively delete tombstone leaves to maintain invariant that leaf nodes are not tombstone
                     self._iteratively_delete_tombstone_leaf(x)
@@ -671,9 +674,11 @@ class SWARadixCache(BasePrefixCache):
         self.full_lru_list.sanity_check(self)
         self.swa_lru_list.sanity_check(self)
 
-    def evictable_size(self, dp_rank: int = 0) -> tuple[int, int]:
-        # Note: use full_evictable_size() and swa_evictable_size() instead.
-        raise NotImplementedError
+    def evictable_size(self, dp_rank: int = 0) -> int:
+        return min(
+            self.full_evictable_size_[dp_rank],
+            self.swa_evictable_size_[dp_rank],
+        )
 
     def full_evictable_size(self, dp_rank: int = 0) -> int:
         return self.full_evictable_size_[dp_rank]
@@ -715,17 +720,36 @@ class SWARadixCache(BasePrefixCache):
         # protected size refers to the size of the swa cache that is locked
         return self.swa_protected_size_[dp_rank]
 
-    def adjust_swa_protected_size(self, delta: int, dp_rank: int = 0):
-        """Adjust swa_protected_size_ when SWA slots are freed outside the cache layer.
+    def _node_prefix_len(self, node: TreeNode | None) -> int:
+        prefix_len = 0
+        while node and node != self.root_node:
+            prefix_len += len(node.value)
+            node = node.parent
+        return prefix_len
 
-        Called by _evict_swa (schedule_batch.py) which directly frees SWA slots
-        via allocator.free_swa() for tokens that fell outside the sliding window.
-        Since those tokens belong to locked (protected) nodes, the freed count
-        must be subtracted from swa_protected_size_ to keep bookkeeping correct.
-        """
-        if self.disable:
+    def evict_req_swa(self, req: "Req", pre_len: int, dp_rank: int = 0) -> None:
+        """Free request-owned SWA slots while preserving the tree-owned prefix."""
+        protected_prefix_len = self._node_prefix_len(req.last_node)
+        assert (
+            protected_prefix_len % self.page_size == 0
+        ), f"protected_prefix_len must be page aligned, {protected_prefix_len=}, {self.page_size=}"
+
+        req.swa_evicted_seqlen = max(req.swa_evicted_seqlen, protected_prefix_len)
+
+        new_evicted = max(
+            req.swa_evicted_seqlen,
+            pre_len - self.sliding_window_size - self.page_size,
+        )
+        if self.page_size > 1:
+            new_evicted = (new_evicted // self.page_size) * self.page_size
+        if new_evicted <= req.swa_evicted_seqlen:
             return
-        self.swa_protected_size_[dp_rank] += delta
+
+        free_slots = self.req_to_token_pool.req_to_token[
+            req.req_pool_idx, req.swa_evicted_seqlen : new_evicted
+        ]
+        self.token_to_kv_pool_allocator.free_swa(free_slots, dp_rank=dp_rank)
+        req.swa_evicted_seqlen = new_evicted
 
     def all_values_flatten(self) -> jnp.Array:
         values = []
@@ -759,9 +783,10 @@ class SWARadixCache(BasePrefixCache):
             child = node.children[child_key]
 
             # update best_value_len and best_last_node if needed
-            if child.swa_tombstone and match_len_since_tombstone >= self.sliding_window_size:
-                best_value_len = len(value)
-                best_last_node = node
+            if child.swa_tombstone:
+                if match_len_since_tombstone >= self.sliding_window_size:
+                    best_value_len = len(value)
+                    best_last_node = node
                 match_len_since_tombstone = 0
 
             prefix_len = self.key_match_fn(child.key, key)
@@ -787,17 +812,16 @@ class SWARadixCache(BasePrefixCache):
             best_value_len = len(value)
             best_last_node = node
 
-        # update time for matched nodes, and make nodes closer to root to be least recently used
-        # this allows swa to evict nodes closer to root first
-        self.full_lru_list.reset_node_and_parents_mru(best_last_node, self.root_node)
-        self.swa_lru_list.reset_node_and_parents_mru(best_last_node, self.root_node)
+        last_node = node
 
-        # This last_access_time is for sanity check, can be deleted after validation in production
+        self.full_lru_list.reset_node_and_parents_mru(last_node, self.root_node)
+        self.swa_lru_list.reset_node_and_parents_mru(last_node, self.root_node)
+
         cur_time = time.monotonic()
-        while node:
-            node.last_access_time = cur_time
+        while last_node:
+            last_node.last_access_time = cur_time
             cur_time -= 0.0001
-            node = node.parent
+            last_node = last_node.parent
 
         return value[:best_value_len], best_last_node
 
@@ -840,7 +864,26 @@ class SWARadixCache(BasePrefixCache):
             self.swa_lru_list.insert_mru(child)
         return new_node
 
-    def _insert_helper(self, node: TreeNode, key: RadixKey, value, update_kv_after_len: int) -> int:
+    def _add_new_node(self, parent: TreeNode, key: RadixKey, value,
+                      swa_tombstone: bool = False) -> TreeNode:
+        assert len(key) > 0
+        child_key = self.get_child_key_fn(key)
+        new_node = TreeNode()
+        new_node.parent = parent
+        new_node.key = key
+        new_node.value = np.array(value, copy=True)
+        new_node.swa_tombstone = swa_tombstone
+        new_node_dp_rank = key.dp_rank if key.dp_rank is not None else 0
+        parent.children[child_key] = new_node
+        self.full_lru_list.insert_mru(new_node)
+        self.full_evictable_size_[new_node_dp_rank] += len(value)
+        if not swa_tombstone:
+            self.swa_lru_list.insert_mru(new_node)
+            self.swa_evictable_size_[new_node_dp_rank] += len(value)
+        return new_node
+
+    def _insert_helper(self, node: TreeNode, key: RadixKey, value,
+                        update_kv_after_len: int, swa_evicted_seqlen: int = 0) -> int:
         # Update the last access time from root to leaf, so that
         # swa will tombstone the node closer to root first
         node.last_access_time = time.monotonic()
@@ -867,29 +910,51 @@ class SWARadixCache(BasePrefixCache):
                 new_node = self._split_node(node, prefix_len)
                 node = new_node
 
-            # if tombstone after update_kv_after_len, update node.value to be the input value.
-            # This is needed because it is possible that the last sliding window size tokens
-            # contains tombstone. If this is the case and we don't update the kv value, then
-            # the prefill prefix matching will stuck.
             if update_kv_after_len < total_prefix_length + prefix_len:
                 first_diff_idx = max(0, update_kv_after_len - total_prefix_length)
                 node_dp_rank = node.key.dp_rank if node.key and node.key.dp_rank is not None else 0
+                node_start = total_prefix_length
+                node_end = total_prefix_length + prefix_len
+
                 if node.swa_tombstone:
                     assert (
                         node.swa_lock_ref == 0
                     ), f"tombstone swa_lock_ref should always be 0, {node.full_lock_ref=}, {node.swa_lock_ref=}, {node.id=}"
-                    self.token_to_kv_pool_allocator.free(
-                        node.value[first_diff_idx:], dp_rank=node_dp_rank
-                    )
-                    node.value = np.array(value[:prefix_len], copy=True)
-                    node.swa_tombstone = False
+                    assert (
+                        swa_evicted_seqlen % self.page_size == 0
+                    ), f"swa_evicted_seqlen must be page aligned, {swa_evicted_seqlen=}, {self.page_size=}"
 
-                    # insert the node into the lru lists
-                    self.swa_lru_list.insert_mru(node)
+                    if swa_evicted_seqlen <= node_start:
+                        # Branch 1: entire node's SWA not per-request evicted → revive
+                        self.token_to_kv_pool_allocator.free(
+                            node.value[first_diff_idx:], dp_rank=node_dp_rank
+                        )
+                        node.value = np.array(value[:prefix_len], copy=True)
+                        node.swa_tombstone = False
+                        self.swa_lru_list.insert_mru(node)
+                        self.swa_evictable_size_[node_dp_rank] += len(node.value)
 
-                    self.swa_evictable_size_[node_dp_rank] += self._swa_eff_len(
-                        node.value, dp_rank=node_dp_rank
-                    )
+                    elif swa_evicted_seqlen < node_end:
+                        # Branch 2: eviction boundary falls within this node → split
+                        start_update_idx = swa_evicted_seqlen - node_start
+                        self.token_to_kv_pool_allocator.free(
+                            node.value[start_update_idx:prefix_len], dp_rank=node_dp_rank
+                        )
+                        self._split_node(node, start_update_idx)
+                        node.value = np.array(value[start_update_idx:prefix_len], copy=True)
+                        node.swa_tombstone = False
+                        self.swa_lru_list.insert_mru(node)
+                        self.swa_evictable_size_[node_dp_rank] += len(node.value)
+                        value_dp_rank = key.dp_rank if key.dp_rank is not None else 0
+                        self.token_to_kv_pool_allocator.free(
+                            value[first_diff_idx:start_update_idx], dp_rank=value_dp_rank
+                        )
+                    else:
+                        # Branch 3: entire node's SWA already per-request evicted → keep tombstone
+                        value_dp_rank = key.dp_rank if key.dp_rank is not None else 0
+                        self.token_to_kv_pool_allocator.free(
+                            value[first_diff_idx:prefix_len], dp_rank=value_dp_rank
+                        )
                 else:
                     # value_dp_rank from the key parameter passed into _insert_helper
                     value_dp_rank = key.dp_rank if key.dp_rank is not None else 0
@@ -905,18 +970,20 @@ class SWARadixCache(BasePrefixCache):
                 child_key = self.get_child_key_fn(key)
 
         if len(key):
-            new_node = TreeNode()
-            new_node.parent = node
-            new_node.key = key
-            new_node.value = np.array(value, copy=True)
-            self.full_lru_list.insert_mru(new_node)
-            self.swa_lru_list.insert_mru(new_node)
-            node.children[child_key] = new_node
-            new_node_dp_rank = key.dp_rank if key.dp_rank is not None else 0
-            self.full_evictable_size_[new_node_dp_rank] += len(value)
-            self.swa_evictable_size_[new_node_dp_rank] += self._swa_eff_len(
-                new_node.value, dp_rank=new_node_dp_rank
-            )
+            if swa_evicted_seqlen >= total_prefix_length + len(key):
+                value_dp_rank = key.dp_rank if key.dp_rank is not None else 0
+                self.token_to_kv_pool_allocator.free(value, dp_rank=value_dp_rank)
+                return total_prefix_length
+
+            if (swa_evicted_seqlen > total_prefix_length
+                    and swa_evicted_seqlen < total_prefix_length + len(key)):
+                swa_tombstone_len = swa_evicted_seqlen - total_prefix_length
+                node = self._add_new_node(node, key[:swa_tombstone_len],
+                                          value[:swa_tombstone_len], swa_tombstone=True)
+                key = key[swa_tombstone_len:]
+                value = value[swa_tombstone_len:]
+
+            self._add_new_node(node, key, value, swa_tombstone=False)
 
         return total_prefix_length
 
@@ -949,26 +1016,25 @@ class SWARadixCache(BasePrefixCache):
     def _delete_leaf(self, node: TreeNode) -> None:
         assert not node.swa_tombstone, f"Invariant violated: leaf node is a tombstone, {node.id=}"
         assert len(node.children) == 0, f"leaf node has children, {node.id=}"
-        for k, v in node.parent.children.items():
-            if v == node:
-                break
-        del node.parent.children[k]
-        # Track evictable size per DP rank
+        key = self.get_child_key_fn(node.key)
+        v = node.parent.children.pop(key, None)
+        assert v == node, f"parent does not have child key, {key}"
         node_dp_rank = node.key.dp_rank if node.key and node.key.dp_rank is not None else 0
         self.full_evictable_size_[node_dp_rank] -= len(node.value)
+        self.swa_evictable_size_[node_dp_rank] -= len(node.value)
 
     def _tombstone_internal_node(self, node: TreeNode) -> None:
         assert len(node.children) != 0, f"Cannot tombstone a leaf node, {node.id=}"
         node.swa_tombstone = True
+        node_dp_rank = node.key.dp_rank if node.key and node.key.dp_rank is not None else 0
+        self.swa_evictable_size_[node_dp_rank] -= len(node.value)
 
     def _delete_tombstone_leaf(self, node: TreeNode) -> None:
         assert node.swa_tombstone, f"Deleting a unexpected non-tombstone leaf node, {node.id=}"
         assert len(node.children) == 0, f"leaf node has children, {node.id=}"
-        for k, v in node.parent.children.items():
-            if v == node:
-                break
-        del node.parent.children[k]
-        # Track evictable size per DP rank
+        key = self.get_child_key_fn(node.key)
+        v = node.parent.children.pop(key, None)
+        assert v == node, f"parent does not have child key, {key}"
         node_dp_rank = node.key.dp_rank if node.key and node.key.dp_rank is not None else 0
         self.full_evictable_size_[node_dp_rank] -= len(node.key)
 

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -733,7 +733,7 @@ class SWARadixCache(BasePrefixCache):
             node = node.parent
         return prefix_len
 
-    def evict_req_swa(self, req: "Req", pre_len: int, dp_rank: int = 0) -> None:
+    def evict_req_swa(self, req: Req, pre_len: int, dp_rank: int = 0) -> None:
         """Free request-owned SWA slots while preserving the tree-owned prefix."""
         protected_prefix_len = self._node_prefix_len(req.last_node)
         assert (

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -371,8 +371,13 @@ class SWARadixCache(BasePrefixCache):
             last_host_node=last_node,
         )
 
-    def insert(self, key: RadixKey | list, value=None, prev_prefix_len: int = 0,
-               swa_evicted_seqlen: int = 0) -> int:
+    def insert(
+        self,
+        key: RadixKey | list,
+        value=None,
+        prev_prefix_len: int = 0,
+        swa_evicted_seqlen: int = 0,
+    ) -> int:
         if self.disable:
             return 0
 
@@ -382,8 +387,9 @@ class SWARadixCache(BasePrefixCache):
 
         if value is None:
             value = [x for x in key.token_ids]
-        return self._insert_helper(self.root_node, key, value, prev_prefix_len,
-                                    swa_evicted_seqlen=swa_evicted_seqlen)
+        return self._insert_helper(
+            self.root_node, key, value, prev_prefix_len, swa_evicted_seqlen=swa_evicted_seqlen
+        )
 
     def cache_finished_req(self, req: Req) -> None:
         """Cache request when it finishes."""
@@ -468,7 +474,7 @@ class SWARadixCache(BasePrefixCache):
         swa_uuid_for_lock = self.inc_lock_ref(new_last_node)
 
         if self.page_size != 1:
-            req.prefix_indices = np.concatenate([new_indices, kv_indices[len(new_indices):]])
+            req.prefix_indices = np.concatenate([new_indices, kv_indices[len(new_indices) :]])
         else:
             req.prefix_indices = new_indices
         req.last_node = new_last_node
@@ -864,8 +870,9 @@ class SWARadixCache(BasePrefixCache):
             self.swa_lru_list.insert_mru(child)
         return new_node
 
-    def _add_new_node(self, parent: TreeNode, key: RadixKey, value,
-                      swa_tombstone: bool = False) -> TreeNode:
+    def _add_new_node(
+        self, parent: TreeNode, key: RadixKey, value, swa_tombstone: bool = False
+    ) -> TreeNode:
         assert len(key) > 0
         child_key = self.get_child_key_fn(key)
         new_node = TreeNode()
@@ -882,8 +889,14 @@ class SWARadixCache(BasePrefixCache):
             self.swa_evictable_size_[new_node_dp_rank] += len(value)
         return new_node
 
-    def _insert_helper(self, node: TreeNode, key: RadixKey, value,
-                        update_kv_after_len: int, swa_evicted_seqlen: int = 0) -> int:
+    def _insert_helper(
+        self,
+        node: TreeNode,
+        key: RadixKey,
+        value,
+        update_kv_after_len: int,
+        swa_evicted_seqlen: int = 0,
+    ) -> int:
         # Update the last access time from root to leaf, so that
         # swa will tombstone the node closer to root first
         node.last_access_time = time.monotonic()
@@ -975,11 +988,14 @@ class SWARadixCache(BasePrefixCache):
                 self.token_to_kv_pool_allocator.free(value, dp_rank=value_dp_rank)
                 return total_prefix_length
 
-            if (swa_evicted_seqlen > total_prefix_length
-                    and swa_evicted_seqlen < total_prefix_length + len(key)):
+            if (
+                swa_evicted_seqlen > total_prefix_length
+                and swa_evicted_seqlen < total_prefix_length + len(key)
+            ):
                 swa_tombstone_len = swa_evicted_seqlen - total_prefix_length
-                node = self._add_new_node(node, key[:swa_tombstone_len],
-                                          value[:swa_tombstone_len], swa_tombstone=True)
+                node = self._add_new_node(
+                    node, key[:swa_tombstone_len], value[:swa_tombstone_len], swa_tombstone=True
+                )
                 key = key[swa_tombstone_len:]
                 value = value[swa_tombstone_len:]
 

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -901,18 +901,26 @@ class ModelRunner(BaseModelRunner):
         self.model_config.full_attention_layer_ids = full_attention_layer_ids
 
         # Algorithm:
-        # Existing max_total_num_tokens is per layer and assume all layers have the same number of tokens.
-        # - Find total # of tokens available across layers.
-        # - Calculate full_max_total_num_tokens and swa_max_total_num_tokens based on the given swa_full_tokens_ratio.
+        # total_tokens is in "full-layer-equivalent token-layer" units,
+        # when swa kv_head_num is not same as full kv_head_num, the constraint is:
+        #   swa_tokens * swa_layers * ratio + full_tokens * full_layers = total_tokens
+        #   swa_tokens = full_tokens * swa_full_tokens_ratio
         total_tokens = self.max_total_num_tokens * self.adjust_layer_num()
         full_layers_num = len(full_attention_layer_ids)
         swa_layers_num = len(swa_attention_layer_ids)
         swa_full_tokens_ratio = self.server_args.swa_full_tokens_ratio
 
-        # Solve the equations:
-        # 1. swa_max_total_num_tokens * swa_layers_num + full_max_total_num_tokens * full_layers_num == total_tokens
-        # 2. full_max_total_num_tokens * swa_full_tokens_ratio == swa_max_total_num_tokens
-        denominator = swa_full_tokens_ratio * swa_layers_num + full_layers_num
+        swa_num_kv_heads = getattr(self.model_config.hf_config, "swa_num_key_value_heads", None)
+        if swa_num_kv_heads is not None:
+            from sgl_jax.srt.utils.jax_utils import get_num_kv_heads_by_tp
+
+            full_heads = self.model_config.get_num_kv_heads(self.attention_tp_size)
+            swa_heads = get_num_kv_heads_by_tp(swa_num_kv_heads, self.attention_tp_size)
+            ratio = swa_heads / full_heads
+        else:
+            ratio = 1.0
+
+        denominator = swa_full_tokens_ratio * swa_layers_num * ratio + full_layers_num
         self.full_max_total_num_tokens = int(total_tokens / denominator)
         self.swa_max_total_num_tokens = int(self.full_max_total_num_tokens * swa_full_tokens_ratio)
 

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -391,7 +391,6 @@ class ModelRunner(BaseModelRunner):
         if swa_num_kv_heads is None:
             return self.model_config.num_hidden_layers
 
-        num_kv_heads = self.model_config.hf_config.num_key_value_heads
         # Compute SWA vs full layer counts from hybrid_layer_pattern
         pattern = getattr(self.model_config.hf_config, "hybrid_layer_pattern", None)
         if pattern is None:
@@ -399,8 +398,12 @@ class ModelRunner(BaseModelRunner):
         swa_layers = sum(1 for p in pattern if p == 1)
         full_layers = sum(1 for p in pattern if p == 0)
 
-        # Effective layer count weighted by KV head ratio
-        effective = (swa_num_kv_heads / num_kv_heads) * swa_layers + full_layers
+        from sgl_jax.srt.utils.jax_utils import get_num_kv_heads_by_tp
+
+        full_heads_per_device = self.model_config.get_num_kv_heads(self.attention_tp_size)
+        swa_heads_per_device = get_num_kv_heads_by_tp(swa_num_kv_heads, self.attention_tp_size)
+        ratio = swa_heads_per_device / full_heads_per_device
+        effective = ratio * swa_layers + full_layers
         return effective
 
     def _compute_cell_size(self) -> int:
@@ -435,7 +438,7 @@ class ModelRunner(BaseModelRunner):
             )
 
         return (
-            self.model_config.get_num_kv_heads(self.tp_size)
+            self.model_config.get_num_kv_heads(self.attention_tp_size)
             * align128(self.model_config.head_dim)
             * 2
             * num_layers

--- a/python/sgl_jax/test/mem_cache/test_swa_allocator.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_allocator.py
@@ -584,11 +584,15 @@ class TestSWAOverlapSafety(CustomTestCase):
         from sgl_jax.srt.managers.schedule_batch import ScheduleBatch, ScheduleReqsInfo
         from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
 
-        tree_cache = ChunkCache(
-            req_to_token_pool=self.req_to_token_pool,
-            token_to_kv_pool_allocator=self.alloc,
-            page_size=self.page_size,
-        ) if forward_mode.is_extend() else None
+        tree_cache = (
+            ChunkCache(
+                req_to_token_pool=self.req_to_token_pool,
+                token_to_kv_pool_allocator=self.alloc,
+                page_size=self.page_size,
+            )
+            if forward_mode.is_extend()
+            else None
+        )
 
         reqs_info = ScheduleReqsInfo(
             reqs=[req],

--- a/python/sgl_jax/test/mem_cache/test_swa_allocator.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_allocator.py
@@ -417,7 +417,7 @@ class TestSWAEviction(CustomTestCase):
 
     def _evict(self, req, pre_len):
         """Wrapper around the eviction logic matching _evict_swa."""
-        new_evicted = max(req.swa_evicted_seqlen, pre_len - self.sliding_window)
+        new_evicted = max(req.swa_evicted_seqlen, pre_len - self.sliding_window - self.page_size)
         if self.page_size > 1:
             new_evicted = (new_evicted // self.page_size) * self.page_size
         if new_evicted <= req.swa_evicted_seqlen:
@@ -430,14 +430,14 @@ class TestSWAEviction(CustomTestCase):
 
     # 16
     def test_evict_basic(self):
-        """100 tokens, window=64 → evicts [0, 36)."""
+        """100 tokens, window=64, page_size=1 → evicts [0, 35)."""
         req = self._make_req(origin_len=100, output_len=0)
         self._setup_req_tokens(req, 100)
         pre_len = 100  # len(origin) + len(output) - 1 = 100 + 0 - 1, but for extend pre_len=100
 
         swa_before = self.alloc.swa_available_size()
         self._evict(req, pre_len)
-        expected_evicted = pre_len - self.sliding_window  # 36
+        expected_evicted = pre_len - self.sliding_window - self.page_size  # 35
         self.assertEqual(req.swa_evicted_seqlen, expected_evicted)
         self.assertEqual(self.alloc.swa_available_size(), swa_before + expected_evicted)
 
@@ -469,8 +469,7 @@ class TestSWAEviction(CustomTestCase):
 
     # 19
     def test_evict_page_aligned(self):
-        """page_size=4: frontier aligns down to page boundary."""
-        # Recreate with page_size=4
+        """page_size=4: frontier includes the extra safety page and aligns down."""
         page_size = 4
         kvcache = _make_swa_pool(size=256, size_swa=256, page_size=page_size, mesh=self.mesh)
         alloc = SWATokenToKVPoolAllocator(
@@ -483,20 +482,20 @@ class TestSWAEviction(CustomTestCase):
         self.assertIsNotNone(indices)
         req_pool.req_to_token[req.req_pool_idx, :100] = indices
 
-        # pre_len=100, window=64 → raw evicted=36 → page-aligned=36//4*4=36
-        new_evicted = max(req.swa_evicted_seqlen, 100 - self.sliding_window)
-        new_evicted = (new_evicted // page_size) * page_size  # 36
-        self.assertEqual(new_evicted, 36)
+        # pre_len=100, window=64, page=4 → raw evicted=32 → page-aligned=32
+        new_evicted = max(req.swa_evicted_seqlen, 100 - self.sliding_window - page_size)
+        new_evicted = (new_evicted // page_size) * page_size
+        self.assertEqual(new_evicted, 32)
 
-        # pre_len=101 → raw=37 → aligned=36 (no change from 36)
-        new_evicted2 = max(36, 101 - self.sliding_window)
+        # pre_len=101 → raw=33 → aligned=32 (no change from 32)
+        new_evicted2 = max(32, 101 - self.sliding_window - page_size)
         new_evicted2 = (new_evicted2 // page_size) * page_size
-        self.assertEqual(new_evicted2, 36)
+        self.assertEqual(new_evicted2, 32)
 
-        # pre_len=104 → raw=40 → aligned=40
-        new_evicted3 = max(36, 104 - self.sliding_window)
+        # pre_len=104 → raw=36 → aligned=36
+        new_evicted3 = max(32, 104 - self.sliding_window - page_size)
         new_evicted3 = (new_evicted3 // page_size) * page_size
-        self.assertEqual(new_evicted3, 40)
+        self.assertEqual(new_evicted3, 36)
 
     # 20
     def test_evict_within_window_noop(self):
@@ -517,7 +516,7 @@ class TestSWAEviction(CustomTestCase):
         swa_before = self.alloc.swa_available_size()
 
         self._evict(req, 128)
-        expected_freed = 128 - self.sliding_window  # 64
+        expected_freed = 128 - self.sliding_window - self.page_size  # 63
         self.assertEqual(self.alloc.swa_available_size(), swa_before + expected_freed)
 
 
@@ -583,6 +582,13 @@ class TestSWAOverlapSafety(CustomTestCase):
 
     def _make_batch(self, req, *, enable_overlap, forward_mode, prefix_lens=None, chunked_req=None):
         from sgl_jax.srt.managers.schedule_batch import ScheduleBatch, ScheduleReqsInfo
+        from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
+
+        tree_cache = ChunkCache(
+            req_to_token_pool=self.req_to_token_pool,
+            token_to_kv_pool_allocator=self.alloc,
+            page_size=self.page_size,
+        ) if forward_mode.is_extend() else None
 
         reqs_info = ScheduleReqsInfo(
             reqs=[req],
@@ -593,7 +599,7 @@ class TestSWAOverlapSafety(CustomTestCase):
             reqs_info=[reqs_info],
             req_to_token_pool=self.req_to_token_pool,
             token_to_kv_pool_allocator=self.alloc,
-            tree_cache=None,
+            tree_cache=tree_cache,
             is_hybrid=True,
             model_config=SimpleNamespace(sliding_window=self.sliding_window),
             forward_mode=forward_mode,
@@ -636,7 +642,7 @@ class TestSWAOverlapSafety(CustomTestCase):
         swa_before = self.alloc.swa_available_size()
         batch.maybe_evict_swa()
 
-        expected = req.seqlen - 1 - self.sliding_window
+        expected = req.seqlen - 1 - self.sliding_window - self.page_size
         self.assertEqual(req.swa_evicted_seqlen, expected)
         self.assertEqual(self.alloc.swa_available_size(), swa_before + expected)
 
@@ -698,7 +704,7 @@ class TestSWAOverlapSafety(CustomTestCase):
                 # len_{N-2} = max(0, cumulative - chunked_prefill_size).
                 in_flight_low = max(
                     0,
-                    cumulative - self.chunked_prefill_size - self.sliding_window,
+                    cumulative - self.chunked_prefill_size - self.sliding_window - self.page_size,
                 )
                 self.assertLessEqual(
                     req.swa_evicted_seqlen,

--- a/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
@@ -102,6 +102,86 @@ class TestSWARadixCache(CustomTestCase):
         self.assertEqual(len(idx), n)
         return idx
 
+    # ------------------------------------------------------------------ #
+    #  Helpers for tombstone / size-consistency tests                      #
+    # ------------------------------------------------------------------ #
+
+    def _find_node_by_key_prefix(self, start_token):
+        """Walk tree from root to find the node whose key starts with start_token."""
+        root = self.cache.root_node
+        child_key = self.cache.get_child_key_fn(
+            RadixKey([start_token], None)
+        )
+        if child_key in root.children:
+            return root.children[child_key]
+        return None
+
+    def _make_small_cache(self, sliding_window_size=4):
+        """Create a cache with a small sliding window for tombstone tests."""
+        return SWARadixCache(
+            req_to_token_pool=self.req_pool,
+            token_to_kv_pool_allocator=self.allocator,
+            sliding_window_size=sliding_window_size,
+            page_size=1,
+            disable=False,
+        )
+
+    def _verify_size_consistency_for(self, cache, msg: str = ""):
+        """Walk the tree and verify that tracked sizes match actual tree content."""
+        full_total = 0
+        swa_total = 0
+        stack = [cache.root_node]
+        while stack:
+            node = stack.pop()
+            if node != cache.root_node and node.value is not None:
+                full_total += len(node.value)
+                if not node.swa_tombstone:
+                    swa_total += len(node.value)
+            stack.extend(node.children.values())
+
+        actual_full = cache.full_evictable_size_ + cache.full_protected_size_
+        actual_swa = cache.swa_evictable_size_ + cache.swa_protected_size_
+        self.assertEqual(
+            full_total, actual_full,
+            f"full size mismatch: tree={full_total}, tracked={actual_full}. {msg}",
+        )
+        self.assertEqual(
+            swa_total, actual_swa,
+            f"swa size mismatch: tree={swa_total}, tracked={actual_swa}. {msg}",
+        )
+
+    def _make_tree_with_tombstone(self):
+        """
+        Helper: insert two sequences that share a prefix into a small-window cache,
+        then SWA-evict the shared prefix so it becomes a tombstone.
+
+        Tree structure after setup:
+          root → [0..9] (internal, tombstone after evict)
+                    ├→ [10..14] (leaf A suffix)
+                    └→ [20..24] (leaf B suffix)
+
+        Returns (cache, key_a, val_a, key_b, val_b).
+        """
+        cache = self._make_small_cache(sliding_window_size=4)
+
+        shared = list(range(0, 10))
+        key_a = shared + list(range(10, 15))
+        key_b = shared + list(range(20, 25))
+        val_a = self._alloc_indices(len(key_a))
+        val_b = self._alloc_indices(len(key_b))
+
+        cache.insert(key_a, value=val_a, prev_prefix_len=0)
+        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+
+        # SWA-evict: evict the shared internal node (LRU, oldest access)
+        cache.evict(full_num_tokens=0, swa_num_tokens=len(shared))
+
+        return cache, key_a, val_a, key_b, val_b
+
+    # ------------------------------------------------------------------ #
+    #  Original tests (preserved from local)                               #
+    # ------------------------------------------------------------------ #
+
     def test_insert_and_match_exact(self):
         """Insert a single sequence and match the same key."""
         key = list(range(100, 110))
@@ -495,113 +575,599 @@ class TestSWARadixCache(CustomTestCase):
         self.assertEqual(allocator.swa_available_size(dp_rank=1), initial_swa[1])
 
 
-    def test_delete_leaf_updates_swa_evictable_size(self):
-        cache = self.cache
-        indices = self._alloc_indices(10)
-        cache.insert(RadixKey(list(range(10)), None), indices)
-        self.assertEqual(cache.swa_evictable_size_, 10)
-        cache.evict(10, 0)
-        self.assertEqual(cache.swa_evictable_size_, 0)
-        self.assertEqual(cache.full_evictable_size_, 0)
-
-    def test_tombstone_internal_updates_swa_evictable_size(self):
-        cache = self.cache
-        indices_a = self._alloc_indices(10)
-        cache.insert(RadixKey(list(range(10)), None), indices_a)
-        indices_b = self._alloc_indices(5)
-        cache.insert(RadixKey(list(range(10)) + list(range(100, 105)), None), indices_b)
-        initial_swa = cache.swa_evictable_size_
-        cache.evict(0, 10)
-        self.assertEqual(cache.swa_evictable_size_, initial_swa - 10)
-
-    def test_insert_tombstone_full_revive(self):
-        """swa_evicted_seqlen=0 -> fully revive tombstone."""
-        cache = self.cache
-        idx1 = self._alloc_indices(10)
-        cache.insert(RadixKey(list(range(10)), None), idx1)
-        idx2 = self._alloc_indices(5)
-        cache.insert(RadixKey(list(range(10)) + list(range(100, 105)), None), idx2)
-        cache.evict(0, 10)  # tombstone the shared prefix
-        swa_after = cache.swa_evictable_size_
-        new_idx = self._alloc_indices(10)
-        cache.insert(
-            RadixKey(list(range(10)), None),
-            new_idx,
-            prev_prefix_len=0,
-            swa_evicted_seqlen=0,
-        )
-        self.assertEqual(cache.swa_evictable_size_, swa_after + 10)
-
-    def test_insert_tombstone_no_revive(self):
-        """swa_evicted_seqlen past node -> keep tombstone."""
-        cache = self.cache
-        idx1 = self._alloc_indices(10)
-        cache.insert(RadixKey(list(range(10)), None), idx1)
-        idx2 = self._alloc_indices(5)
-        cache.insert(RadixKey(list(range(10)) + list(range(100, 105)), None), idx2)
-        cache.evict(0, 10)
-        swa_after = cache.swa_evictable_size_
-        new_idx = self._alloc_indices(10)
-        cache.insert(
-            RadixKey(list(range(10)), None),
-            new_idx,
-            prev_prefix_len=0,
-            swa_evicted_seqlen=10,
-        )
-        self.assertEqual(cache.swa_evictable_size_, swa_after)
-
-    def test_new_node_all_swa_evicted(self):
-        """All in evicted range -> don't create node (no tombstone leaf)."""
-        cache = self.cache
-        idx = self._alloc_indices(10)
-        cache.insert(RadixKey(list(range(10)), None), idx, swa_evicted_seqlen=10)
-        self.assertEqual(cache.full_evictable_size_, 0)
-
-    def test_new_node_split_at_eviction_boundary(self):
-        """Eviction boundary in middle -> front tombstone + back live."""
-        cache = self.cache
-        idx = self._alloc_indices(10)
-        cache.insert(RadixKey(list(range(10)), None), idx, swa_evicted_seqlen=5)
-        self.assertEqual(cache.full_evictable_size_, 10)
-        self.assertEqual(cache.swa_evictable_size_, 5)
-
     def test_evictable_size_returns_min(self):
         cache = self.cache
         indices = self._alloc_indices(10)
         cache.insert(RadixKey(list(range(10)), None), indices)
         self.assertEqual(cache.evictable_size(), 10)
 
-    def test_insert_then_evict_then_reinsert_cycle(self):
-        """Full cycle: insert -> tombstone -> re-insert with swa_evicted_seqlen."""
-        cache = self.cache
-        idx1 = self._alloc_indices(15)
-        cache.insert(RadixKey(list(range(15)), None), idx1)
-        idx2 = self._alloc_indices(5)
-        cache.insert(RadixKey(list(range(10)) + list(range(200, 205)), None), idx2)
-        cache.evict(0, 10)  # tombstone shared prefix
-        new_idx = self._alloc_indices(15)
-        cache.insert(
-            RadixKey(list(range(15)), None),
-            new_idx,
-            prev_prefix_len=0,
-            swa_evicted_seqlen=5,
-        )
-        cache.sanity_check()
+    # ------------------------------------------------------------------ #
+    #  T1-T12: Tombstone / protected-prefix correctness tests             #
+    # ------------------------------------------------------------------ #
 
-    def test_sanity_check_after_complex_operations(self):
-        cache = self.cache
-        for i in range(5):
-            idx = self._alloc_indices(10)
-            cache.insert(RadixKey(list(range(i * 3, i * 3 + 10)), None), idx)
-        cache.evict(5, 5)
-        for i in range(3):
-            idx = self._alloc_indices(8)
+    def test_tombstone_creation(self):
+        """T1: SWA evict creates tombstone on internal node, swa_evictable_size_ decreases."""
+        cache = self._make_small_cache(sliding_window_size=4)
+
+        shared = list(range(0, 10))
+        key_a = shared + list(range(10, 15))
+        key_b = shared + list(range(20, 25))
+        val_a = self._alloc_indices(len(key_a))
+        val_b = self._alloc_indices(len(key_b))
+
+        cache.insert(key_a, value=val_a, prev_prefix_len=0)
+        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+
+        full_before, swa_before = cache.total_size()
+        self.assertEqual(full_before, swa_before)  # no tombstones yet
+        swa_evictable_before = cache.swa_evictable_size()
+
+        # SWA evict the shared prefix
+        cache.evict(full_num_tokens=0, swa_num_tokens=len(shared))
+
+        full_after, swa_after = cache.total_size()
+        # Full tokens unchanged (tombstone keeps full), SWA tokens decreased
+        self.assertEqual(full_after, full_before)
+        self.assertLess(swa_after, swa_before)
+
+        # swa_evictable_size_ should have decreased
+        swa_evictable_after = cache.swa_evictable_size()
+        self.assertLess(swa_evictable_after, swa_evictable_before)
+
+        # Walk the tree to find the shared internal node and verify tombstone
+        child_key = cache.get_child_key_fn(RadixKey([0], None))
+        internal_node = cache.root_node.children[child_key]
+        self.assertTrue(internal_node.swa_tombstone)
+        self.assertEqual(len(internal_node.value), 10)
+
+        self._verify_size_consistency_for(cache, "after tombstone creation")
+
+    def test_tombstone_prefix_match(self):
+        """T2: Tombstone node does not affect prefix matching results when sliding window is satisfied."""
+        cache, key_a, val_a, key_b, val_b = self._make_tree_with_tombstone()
+
+        # With sliding_window_size=4 and suffix length=5 (>4), matching should still work
+        match_a = cache.match_prefix(key_a)
+        self.assertEqual(len(match_a.device_indices), len(key_a))
+
+        match_b = cache.match_prefix(key_b)
+        self.assertEqual(len(match_b.device_indices), len(key_b))
+
+    def test_tombstone_healing_branch1(self):
+        """T3: swa_evicted_seqlen <= node_start → full revive of tombstone."""
+        cache, key_a, val_a, key_b, val_b = self._make_tree_with_tombstone()
+
+        # Verify shared prefix is tombstone by walking tree
+        child_key = cache.get_child_key_fn(RadixKey([0], None))
+        tombstone_node = cache.root_node.children[child_key]
+        self.assertTrue(tombstone_node.swa_tombstone)
+
+        # Re-insert key_a with swa_evicted_seqlen=0 (Branch 1: not evicted)
+        new_val = self._alloc_indices(len(key_a))
+        cache.insert(
+            key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=0
+        )
+
+        # The tombstone should be healed (revived)
+        healed_node = cache.root_node.children[child_key]
+        self.assertFalse(healed_node.swa_tombstone)
+
+        self._verify_size_consistency_for(cache, "after branch 1 healing")
+
+    def test_tombstone_healing_branch2(self):
+        """T4: swa_evicted_seqlen in middle of tombstone node → split and partial revive."""
+        cache, key_a, val_a, key_b, val_b = self._make_tree_with_tombstone()
+
+        # Verify shared prefix is tombstone
+        child_key = cache.get_child_key_fn(RadixKey([0], None))
+        tombstone_node = cache.root_node.children[child_key]
+        self.assertTrue(tombstone_node.swa_tombstone)
+
+        # Re-insert with swa_evicted_seqlen=5 (in the middle of shared[0:10])
+        # Branch 2: split at position 5, revive [5:10], keep [0:5] as tombstone
+        new_val = self._alloc_indices(len(key_a))
+        cache.insert(
+            key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=5
+        )
+
+        # Walk tree: root → [0:5] (tombstone) → [5:10] (revived) → {[10:15], [20:24]}
+        front_node = cache.root_node.children[child_key]
+        self.assertTrue(front_node.swa_tombstone)
+        self.assertEqual(len(front_node.value), 5)
+
+        # The back node [5:10] should have been revived
+        # It should be a child of front_node
+        self.assertGreater(len(front_node.children), 0)
+        # Find the child whose key starts with token 5
+        back_child_key = cache.get_child_key_fn(RadixKey([5], None))
+        self.assertIn(back_child_key, front_node.children)
+        back_node = front_node.children[back_child_key]
+        self.assertFalse(back_node.swa_tombstone)
+        self.assertEqual(len(back_node.value), 5)
+
+        self._verify_size_consistency_for(cache, "after branch 2 healing")
+
+    def test_tombstone_healing_branch3(self):
+        """T5: swa_evicted_seqlen >= node_end → keep tombstone."""
+        cache, key_a, val_a, key_b, val_b = self._make_tree_with_tombstone()
+
+        # Verify shared prefix is tombstone
+        child_key = cache.get_child_key_fn(RadixKey([0], None))
+        self.assertTrue(cache.root_node.children[child_key].swa_tombstone)
+
+        # Re-insert with swa_evicted_seqlen=15 (>= node_end=10)
+        # Branch 3: entire node already evicted → keep tombstone
+        new_val = self._alloc_indices(len(key_a))
+        cache.insert(
+            key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=15
+        )
+
+        # The shared prefix should still be tombstone
+        self.assertTrue(cache.root_node.children[child_key].swa_tombstone)
+
+        self._verify_size_consistency_for(cache, "after branch 3 (keep tombstone)")
+
+    def test_cascade_delete_tombstone(self):
+        """T6: Leaf delete cascades to tombstone parent."""
+        cache, key_a, val_a, key_b, val_b = self._make_tree_with_tombstone()
+
+        full_before, _ = cache.total_size()
+
+        # Evict enough full tokens to delete all leaves, which cascade to tombstone parent
+        cache.evict(full_num_tokens=full_before, swa_num_tokens=0)
+
+        full_after, swa_after = cache.total_size()
+        self.assertEqual(full_after, 0)
+        self.assertEqual(swa_after, 0)
+
+        self._verify_size_consistency_for(cache, "after cascade delete")
+
+    def test_size_tracking_consistency(self):
+        """T7: Insert/evict/delete cycle — sizes match actual tree at every step."""
+        cache = self._make_small_cache(sliding_window_size=4)
+        keys = [list(range(i * 100, i * 100 + 20)) for i in range(5)]
+        vals = [self._alloc_indices(20) for _ in range(5)]
+
+        # Insert all
+        for k, v in zip(keys, vals):
+            cache.insert(k, value=v, prev_prefix_len=0)
+            self._verify_size_consistency_for(cache, f"after insert {k[0]}")
+
+        # SWA evict some
+        cache.evict(full_num_tokens=0, swa_num_tokens=20)
+        self._verify_size_consistency_for(cache, "after swa evict 20")
+
+        # Full evict some
+        cache.evict(full_num_tokens=20, swa_num_tokens=0)
+        self._verify_size_consistency_for(cache, "after full evict 20")
+
+        # Insert more (reuse prefix)
+        new_key = keys[0] + [999, 998, 997]
+        new_val = self._alloc_indices(len(new_key))
+        cache.insert(new_key, value=new_val, prev_prefix_len=0)
+        self._verify_size_consistency_for(cache, "after re-insert with extension")
+
+        # Evict everything
+        full_total, _ = cache.total_size()
+        cache.evict(full_num_tokens=full_total, swa_num_tokens=0)
+        self._verify_size_consistency_for(cache, "after evict all")
+
+    def test_protected_prefix_basic(self):
+        """T8: The protected tree prefix prevents swa_evicted_seqlen from corrupting tree slots during insert."""
+        cache = self._make_small_cache(sliding_window_size=4)
+        key = list(range(0, 20))
+        val_first = self._alloc_indices(len(key))
+
+        # First insert: puts everything into tree
+        cache.insert(key, value=val_first, prev_prefix_len=0)
+
+        # Match to confirm
+        match = cache.match_prefix(key)
+        self.assertEqual(len(match.device_indices), 20)
+
+        # SWA-evict to create tombstone
+        cache.evict(full_num_tokens=0, swa_num_tokens=20)
+
+        # Second insert with protected_prefix_len=10 (prev_prefix_len) and swa_evicted_seqlen=5
+        # Branch 2 applies: swa_evicted_seqlen(5) < node_end(20), split at 5, revive [5:20]
+        val_second = self._alloc_indices(len(key))
+        cache.insert(
+            key, value=val_second, prev_prefix_len=10, swa_evicted_seqlen=5
+        )
+
+        # Match should still return 20 tokens (sliding_window=4, suffix > 4)
+        match2 = cache.match_prefix(key)
+        self.assertEqual(len(match2.device_indices), 20)
+
+        self._verify_size_consistency_for(cache, "after protected prefix insert")
+
+    def test_new_node_tombstone_split(self):
+        """T9: New node crossing swa_evicted_seqlen boundary → correct split."""
+        cache = self._make_small_cache(sliding_window_size=4)
+        key = list(range(0, 20))
+        val = self._alloc_indices(len(key))
+
+        # Insert with swa_evicted_seqlen=10 → new node should be split:
+        # [0:10] as tombstone + [10:20] as non-tombstone
+        cache.insert(key, value=val, prev_prefix_len=0, swa_evicted_seqlen=10)
+
+        full_total, swa_total = cache.total_size()
+        self.assertEqual(full_total, 20)
+        self.assertEqual(swa_total, 10)  # only [10:20] has SWA
+
+        # Verify tree structure: root should have one child (tombstone [0:10])
+        # which has one child (non-tombstone [10:20])
+        root = cache.root_node
+        self.assertEqual(len(root.children), 1)
+        child_key = list(root.children.keys())[0]
+        tombstone_node = root.children[child_key]
+        self.assertTrue(tombstone_node.swa_tombstone)
+        self.assertEqual(len(tombstone_node.value), 10)
+
+        self.assertEqual(len(tombstone_node.children), 1)
+        leaf_key = list(tombstone_node.children.keys())[0]
+        leaf_node = tombstone_node.children[leaf_key]
+        self.assertFalse(leaf_node.swa_tombstone)
+        self.assertEqual(len(leaf_node.value), 10)
+
+        # Match should return all 20 tokens (sliding_window=4, non-tombstone suffix=10 > 4)
+        match = cache.match_prefix(key)
+        self.assertEqual(len(match.device_indices), 20)
+
+        self._verify_size_consistency_for(cache, "after new node tombstone split")
+
+    def test_evict_both_pools(self):
+        """T10: Phase 1 (leaf) + Phase 2 (tombstone) interleaved eviction."""
+        cache = self._make_small_cache(sliding_window_size=4)
+        shared = list(range(0, 8))
+        key_a = shared + list(range(10, 18))
+        key_b = shared + list(range(20, 28))
+        val_a = self._alloc_indices(len(key_a))
+        val_b = self._alloc_indices(len(key_b))
+
+        cache.insert(key_a, value=val_a, prev_prefix_len=0)
+        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+
+        full_before, swa_before = cache.total_size()
+        self.assertEqual(full_before, swa_before)
+
+        # Phase 2 SWA evict: should tombstone the shared prefix
+        cache.evict(full_num_tokens=0, swa_num_tokens=len(shared))
+        full_mid, swa_mid = cache.total_size()
+        self.assertEqual(full_mid, full_before)  # full unchanged
+        self.assertLess(swa_mid, swa_before)  # SWA decreased
+        self._verify_size_consistency_for(cache, "after phase 2 evict")
+
+        # Phase 1 full evict: should delete leaf + cascade tombstone
+        cache.evict(full_num_tokens=8, swa_num_tokens=0)
+        full_after, swa_after = cache.total_size()
+        self.assertLess(full_after, full_mid)
+        self._verify_size_consistency_for(cache, "after phase 1 evict")
+
+    def test_insert_after_tombstone_evict_cycle(self):
+        """T11: Multiple insert→evict→insert cycles — no size leaks."""
+        cache = self._make_small_cache(sliding_window_size=4)
+
+        for cycle in range(5):
+            key = list(range(cycle * 100, cycle * 100 + 16))
+            val = self._alloc_indices(len(key))
+            cache.insert(key, value=val, prev_prefix_len=0)
+            self._verify_size_consistency_for(cache, f"cycle {cycle} insert")
+
+            # SWA evict some
+            cache.evict(full_num_tokens=0, swa_num_tokens=8)
+            self._verify_size_consistency_for(cache, f"cycle {cycle} swa evict")
+
+            # Re-insert with new values (simulating healing)
+            new_val = self._alloc_indices(len(key))
             cache.insert(
-                RadixKey(list(range(i * 3, i * 3 + 8)), None),
-                idx,
-                swa_evicted_seqlen=3,
+                key, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=0
             )
-        cache.sanity_check()
+            self._verify_size_consistency_for(cache, f"cycle {cycle} re-insert")
+
+        # Final full evict
+        full_total, _ = cache.total_size()
+        cache.evict(full_num_tokens=full_total + 100, swa_num_tokens=0)
+        full_final, swa_final = cache.total_size()
+        self.assertEqual(full_final, 0, "full size should be 0 after evict all")
+        self.assertEqual(swa_final, 0, "swa size should be 0 after evict all")
+        self._verify_size_consistency_for(cache, "after final evict all")
+
+    def test_size_tracking_fuzz(self):
+        """T12: Random operations, verify size consistency at each step."""
+        import random
+
+        rng = random.Random(42)
+        cache = self._make_small_cache(sliding_window_size=4)
+
+        for step in range(50):
+            op = rng.choice(["insert", "evict_swa", "evict_full"])
+            if op == "insert":
+                length = rng.randint(4, 32)
+                start = rng.randint(0, 500)
+                key = list(range(start, start + length))
+                val = self._alloc_indices(length)
+                swa_evicted = rng.choice([0, 0, 0, rng.randint(0, length)])
+                cache.insert(
+                    key, value=val, prev_prefix_len=0,
+                    swa_evicted_seqlen=swa_evicted,
+                )
+            elif op == "evict_swa":
+                amount = rng.randint(1, 16)
+                cache.evict(full_num_tokens=0, swa_num_tokens=amount)
+            else:
+                amount = rng.randint(1, 16)
+                cache.evict(full_num_tokens=amount, swa_num_tokens=0)
+
+            self._verify_size_consistency_for(cache, f"fuzz step {step} op={op}")
+
+    # ------------------------------------------------------------------ #
+    #  T13-T22: Gap fix verification tests                                #
+    # ------------------------------------------------------------------ #
+
+    def test_tombstone_reset_unconditional(self):
+        """T13: _match_prefix_helper resets match_len_since_tombstone even when
+        sliding window check fails.
+
+        Scenario: Two consecutive tombstone nodes on the path. Before the fix,
+        the second tombstone would NOT reset match_len_since_tombstone because
+        the first tombstone already set it to 0 (< sliding_window_size), so the
+        condition was False and the reset was skipped. After the fix, the reset
+        is unconditional.
+        """
+        cache = self._make_small_cache(sliding_window_size=4)
+
+        # Build a tree: root → [0..4] → [5..9] → [10..14] (leaf)
+        # We insert two sequences to force a split so the shared prefixes become
+        # internal nodes that we can tombstone independently.
+        shared1 = list(range(0, 5))
+        shared2 = list(range(5, 10))
+        suffix_a = list(range(10, 15))
+        suffix_b = list(range(20, 25))
+
+        key_a = shared1 + shared2 + suffix_a
+        key_b = shared1 + shared2 + suffix_b
+        val_a = self._alloc_indices(len(key_a))
+        val_b = self._alloc_indices(len(key_b))
+
+        cache.insert(key_a, value=val_a, prev_prefix_len=0)
+        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+
+        # SWA-evict both shared prefixes: first [0..4], then [5..9]
+        # This creates two consecutive tombstone nodes
+        cache.evict(full_num_tokens=0, swa_num_tokens=10)
+
+        # Walk tree to verify two tombstones
+        child_key_0 = cache.get_child_key_fn(RadixKey([0], None))
+        node_0_4 = cache.root_node.children[child_key_0]
+        self.assertTrue(node_0_4.swa_tombstone, "First shared prefix should be tombstone")
+
+        # Match should still work: suffix (5 tokens) > sliding_window (4)
+        match_a = cache.match_prefix(key_a)
+        # Even with two consecutive tombstones, the suffix after the last tombstone
+        # should be enough to match if it exceeds sliding_window_size
+        self.assertGreater(len(match_a.device_indices), 0)
+
+        self._verify_size_consistency_for(cache, "after double tombstone match")
+
+    def test_new_leaf_never_tombstone(self):
+        """T14: When swa_evicted_seqlen >= total_prefix_length + len(key),
+        all remaining tokens are SWA-evicted. No node is created (can't be
+        non-tombstone because SWA is gone, can't be tombstone leaf because
+        of the leaf-must-not-be-tombstone invariant). Value is freed and
+        insert returns early.
+        """
+        cache = self._make_small_cache(sliding_window_size=4)
+        key = list(range(0, 10))
+        val = self._alloc_indices(len(key))
+
+        # Insert with swa_evicted_seqlen=20 (>> total_prefix_length + len(key) = 10)
+        # Upstream behavior: free value, return early, no node created
+        cache.insert(key, value=val, prev_prefix_len=0, swa_evicted_seqlen=20)
+
+        full_total, swa_total = cache.total_size()
+        # No node created → tree is empty
+        self.assertEqual(full_total, 0)
+        self.assertEqual(swa_total, 0)
+
+        # Root should have no children
+        self.assertEqual(len(cache.root_node.children), 0)
+
+        self._verify_size_consistency_for(cache, "after all-evicted insert")
+
+    def test_new_leaf_never_tombstone_exact_boundary(self):
+        """T15: swa_evicted_seqlen == total_prefix_length + len(key) boundary case.
+
+        When swa_evicted_seqlen exactly equals total_prefix_length + len(key),
+        all tokens are SWA-evicted. No node is created, value is freed.
+        """
+        cache = self._make_small_cache(sliding_window_size=4)
+        key = list(range(0, 10))
+        val = self._alloc_indices(len(key))
+
+        # swa_evicted_seqlen == total_prefix_length(0) + len(key)(10) = 10
+        cache.insert(key, value=val, prev_prefix_len=0, swa_evicted_seqlen=10)
+
+        full_total, swa_total = cache.total_size()
+        # No node created → tree is empty
+        self.assertEqual(full_total, 0)
+        self.assertEqual(swa_total, 0)
+
+        # Root should have no children
+        self.assertEqual(len(cache.root_node.children), 0)
+
+        self._verify_size_consistency_for(cache, "after exact boundary insert")
+
+    def test_delete_leaf_uses_child_key_fn(self):
+        """T17: _delete_leaf correctly removes nodes using get_child_key_fn lookup."""
+        cache = self._make_small_cache(sliding_window_size=4)
+
+        # Insert two sequences sharing a prefix to create internal + leaf structure
+        shared = list(range(0, 5))
+        key_a = shared + list(range(10, 15))
+        key_b = shared + list(range(20, 25))
+        val_a = self._alloc_indices(len(key_a))
+        val_b = self._alloc_indices(len(key_b))
+
+        cache.insert(key_a, value=val_a, prev_prefix_len=0)
+        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+
+        full_before, swa_before = cache.total_size()
+        self.assertEqual(full_before, 15)  # 5 shared + 5 suffix_a + 5 suffix_b
+
+        # The tree has: root → [0..4] (internal) → {[10..14] (leaf A), [20..24] (leaf B)}
+        # Evict one leaf by full eviction
+        cache.evict(full_num_tokens=5, swa_num_tokens=0)
+
+        full_after, swa_after = cache.total_size()
+        self.assertLess(full_after, full_before)
+
+        # Verify tree is still consistent
+        self._verify_size_consistency_for(cache, "after leaf delete via child_key_fn")
+
+    def test_delete_tombstone_leaf_uses_child_key_fn(self):
+        """T18: _delete_tombstone_leaf correctly removes tombstone nodes using get_child_key_fn."""
+        cache, key_a, val_a, key_b, val_b = self._make_tree_with_tombstone()
+
+        # At this point: shared prefix is tombstone, two leaves exist
+        full_before, _ = cache.total_size()
+
+        # Full evict everything — should cascade delete tombstone parent via _delete_tombstone_leaf
+        cache.evict(full_num_tokens=full_before, swa_num_tokens=0)
+
+        full_after, swa_after = cache.total_size()
+        self.assertEqual(full_after, 0)
+        self.assertEqual(swa_after, 0)
+
+        # Root should have no children
+        self.assertEqual(len(cache.root_node.children), 0)
+        self._verify_size_consistency_for(cache, "after tombstone cascade delete via child_key_fn")
+
+    def test_evict_req_swa_uses_locked_tree_boundary(self):
+        """T19: Request SWA eviction derives its protected boundary from the locked tree path."""
+        cache = self._make_small_cache(sliding_window_size=4)
+        key = list(range(0, 20))
+        tree_indices = self._alloc_indices(len(key))
+        cache.insert(key, value=tree_indices, prev_prefix_len=0)
+        match = cache.match_prefix(key)
+
+        tail_indices = self._alloc_indices(10)
+        req_indices = np.concatenate([tree_indices, tail_indices])
+        self.req_pool.req_to_token[0, :30] = req_indices
+
+        class MockReq:
+            def __init__(self, last_node):
+                self.swa_evicted_seqlen = 3
+                self.req_pool_idx = 0
+                self.last_node = last_node
+
+        req = MockReq(match.last_device_node)
+        swa_before = self.allocator.swa_available_size()
+
+        cache.evict_req_swa(req, pre_len=30)
+
+        # Protected prefix is 20, so only uncached tail slots [20:25) are reclaimed.
+        self.assertEqual(req.swa_evicted_seqlen, 25)
+        self.assertEqual(self.allocator.swa_available_size(), swa_before + 5)
+        self.assertEqual(self.allocator.count_swa_mapped(tree_indices), len(tree_indices))
+        self.assertEqual(self.allocator.count_swa_mapped(tail_indices[:5]), 0)
+        self.assertEqual(self.allocator.count_swa_mapped(tail_indices[5:]), 5)
+
+    def test_evict_req_swa_page_alignment_uses_tree_boundary(self):
+        """T20: Request SWA eviction aligns by page size using the tree-derived protected boundary."""
+        paged_cache = SWARadixCache(
+            req_to_token_pool=self.req_pool,
+            token_to_kv_pool_allocator=self.allocator,
+            sliding_window_size=4,
+            page_size=4,
+            disable=False,
+        )
+
+        key = list(range(0, 8))
+        tree_indices = self._alloc_indices(len(key))
+        paged_cache.insert(key, value=tree_indices, prev_prefix_len=0)
+        match = paged_cache.match_prefix(key)
+
+        tail_indices = self._alloc_indices(12)
+        req_indices = np.concatenate([tree_indices, tail_indices])
+        self.req_pool.req_to_token[0, :20] = req_indices
+
+        class MockReq:
+            def __init__(self, last_node):
+                self.swa_evicted_seqlen = 0
+                self.req_pool_idx = 0
+                self.last_node = last_node
+
+        req = MockReq(match.last_device_node)
+
+        paged_cache.evict_req_swa(req, pre_len=20)
+
+        # Protected prefix is 8. The eviction frontier is 20 - 4 - 4 = 12, already aligned.
+        self.assertEqual(req.swa_evicted_seqlen, 12)
+        self.assertEqual(self.allocator.count_swa_mapped(tree_indices), len(tree_indices))
+        self.assertEqual(self.allocator.count_swa_mapped(tail_indices[:4]), 0)
+        self.assertEqual(self.allocator.count_swa_mapped(tail_indices[4:]), 8)
+
+    def test_swa_evicted_seqlen_page_alignment_assertion(self):
+        """T21: _insert_helper asserts swa_evicted_seqlen % page_size == 0 when handling tombstones."""
+        # Create a paged cache with page_size=4
+        paged_cache = SWARadixCache(
+            req_to_token_pool=self.req_pool,
+            token_to_kv_pool_allocator=self.allocator,
+            sliding_window_size=64,
+            page_size=4,
+            disable=False,
+        )
+
+        # Insert then tombstone: create a sequence, evict its SWA to make tombstone
+        shared = list(range(0, 8))
+        key_a = shared + list(range(10, 18))
+        key_b = shared + list(range(20, 28))
+        val_a = self._alloc_indices(len(key_a))
+        val_b = self._alloc_indices(len(key_b))
+
+        paged_cache.insert(key_a, value=val_a, prev_prefix_len=0)
+        paged_cache.insert(key_b, value=val_b, prev_prefix_len=0)
+        paged_cache.evict(full_num_tokens=0, swa_num_tokens=8)
+
+        # Re-inserting with non-page-aligned swa_evicted_seqlen should assert
+        new_val = self._alloc_indices(len(key_a))
+        with self.assertRaises(AssertionError):
+            paged_cache.insert(
+                key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=3
+            )
+
+    def test_cache_unfinished_req_writeback_range(self):
+        """T22: cache_unfinished_req writes back from last_matched_prefix_len, not len(prefix_indices)."""
+        cache = self._make_small_cache(sliding_window_size=64)
+
+        # Simulate first insert (initial request)
+        key_part1 = list(range(0, 10))
+        val1 = self._alloc_indices(len(key_part1))
+        cache.insert(key_part1, value=val1, prev_prefix_len=0)
+
+        # After first insert, match should return all 10 tokens
+        match1 = cache.match_prefix(key_part1)
+        self.assertEqual(len(match1.device_indices), 10)
+
+        # Insert extended sequence (simulating cache_unfinished_req)
+        key_full = list(range(0, 20))
+        val2 = self._alloc_indices(len(key_full))
+        new_prefix_len = cache.insert(
+            key_full, value=val2, prev_prefix_len=10, swa_evicted_seqlen=0
+        )
+
+        # Match the full key
+        match2 = cache.match_prefix(key_full)
+        self.assertEqual(len(match2.device_indices), 20)
+
+        # Verify old cached indices are preserved (not overwritten)
+        np.testing.assert_array_equal(
+            np.asarray(match2.device_indices[:10]),
+            np.asarray(match1.device_indices),
+        )
+
+        self._verify_size_consistency_for(cache, "after simulated cache_unfinished_req")
 
 
 class TestSchedulerCacheInit(CustomTestCase):

--- a/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
@@ -495,6 +495,115 @@ class TestSWARadixCache(CustomTestCase):
         self.assertEqual(allocator.swa_available_size(dp_rank=1), initial_swa[1])
 
 
+    def test_delete_leaf_updates_swa_evictable_size(self):
+        cache = self.cache
+        indices = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), indices)
+        self.assertEqual(cache.swa_evictable_size_, 10)
+        cache.evict(10, 0)
+        self.assertEqual(cache.swa_evictable_size_, 0)
+        self.assertEqual(cache.full_evictable_size_, 0)
+
+    def test_tombstone_internal_updates_swa_evictable_size(self):
+        cache = self.cache
+        indices_a = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), indices_a)
+        indices_b = self._alloc_indices(5)
+        cache.insert(RadixKey(list(range(10)) + list(range(100, 105)), None), indices_b)
+        initial_swa = cache.swa_evictable_size_
+        cache.evict(0, 10)
+        self.assertEqual(cache.swa_evictable_size_, initial_swa - 10)
+
+    def test_insert_tombstone_full_revive(self):
+        """swa_evicted_seqlen=0 -> fully revive tombstone."""
+        cache = self.cache
+        idx1 = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), idx1)
+        idx2 = self._alloc_indices(5)
+        cache.insert(RadixKey(list(range(10)) + list(range(100, 105)), None), idx2)
+        cache.evict(0, 10)  # tombstone the shared prefix
+        swa_after = cache.swa_evictable_size_
+        new_idx = self._alloc_indices(10)
+        cache.insert(
+            RadixKey(list(range(10)), None),
+            new_idx,
+            prev_prefix_len=0,
+            swa_evicted_seqlen=0,
+        )
+        self.assertEqual(cache.swa_evictable_size_, swa_after + 10)
+
+    def test_insert_tombstone_no_revive(self):
+        """swa_evicted_seqlen past node -> keep tombstone."""
+        cache = self.cache
+        idx1 = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), idx1)
+        idx2 = self._alloc_indices(5)
+        cache.insert(RadixKey(list(range(10)) + list(range(100, 105)), None), idx2)
+        cache.evict(0, 10)
+        swa_after = cache.swa_evictable_size_
+        new_idx = self._alloc_indices(10)
+        cache.insert(
+            RadixKey(list(range(10)), None),
+            new_idx,
+            prev_prefix_len=0,
+            swa_evicted_seqlen=10,
+        )
+        self.assertEqual(cache.swa_evictable_size_, swa_after)
+
+    def test_new_node_all_swa_evicted(self):
+        """All in evicted range -> don't create node (no tombstone leaf)."""
+        cache = self.cache
+        idx = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), idx, swa_evicted_seqlen=10)
+        self.assertEqual(cache.full_evictable_size_, 0)
+
+    def test_new_node_split_at_eviction_boundary(self):
+        """Eviction boundary in middle -> front tombstone + back live."""
+        cache = self.cache
+        idx = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), idx, swa_evicted_seqlen=5)
+        self.assertEqual(cache.full_evictable_size_, 10)
+        self.assertEqual(cache.swa_evictable_size_, 5)
+
+    def test_evictable_size_returns_min(self):
+        cache = self.cache
+        indices = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), indices)
+        self.assertEqual(cache.evictable_size(), 10)
+
+    def test_insert_then_evict_then_reinsert_cycle(self):
+        """Full cycle: insert -> tombstone -> re-insert with swa_evicted_seqlen."""
+        cache = self.cache
+        idx1 = self._alloc_indices(15)
+        cache.insert(RadixKey(list(range(15)), None), idx1)
+        idx2 = self._alloc_indices(5)
+        cache.insert(RadixKey(list(range(10)) + list(range(200, 205)), None), idx2)
+        cache.evict(0, 10)  # tombstone shared prefix
+        new_idx = self._alloc_indices(15)
+        cache.insert(
+            RadixKey(list(range(15)), None),
+            new_idx,
+            prev_prefix_len=0,
+            swa_evicted_seqlen=5,
+        )
+        cache.sanity_check()
+
+    def test_sanity_check_after_complex_operations(self):
+        cache = self.cache
+        for i in range(5):
+            idx = self._alloc_indices(10)
+            cache.insert(RadixKey(list(range(i * 3, i * 3 + 10)), None), idx)
+        cache.evict(5, 5)
+        for i in range(3):
+            idx = self._alloc_indices(8)
+            cache.insert(
+                RadixKey(list(range(i * 3, i * 3 + 8)), None),
+                idx,
+                swa_evicted_seqlen=3,
+            )
+        cache.sanity_check()
+
+
 class TestSchedulerCacheInit(CustomTestCase):
     """Tests for scheduler cache type selection with hybrid models (#202)."""
 

--- a/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
@@ -109,9 +109,7 @@ class TestSWARadixCache(CustomTestCase):
     def _find_node_by_key_prefix(self, start_token):
         """Walk tree from root to find the node whose key starts with start_token."""
         root = self.cache.root_node
-        child_key = self.cache.get_child_key_fn(
-            RadixKey([start_token], None)
-        )
+        child_key = self.cache.get_child_key_fn(RadixKey([start_token], None))
         if child_key in root.children:
             return root.children[child_key]
         return None
@@ -139,14 +137,20 @@ class TestSWARadixCache(CustomTestCase):
                     swa_total += len(node.value)
             stack.extend(node.children.values())
 
-        actual_full = sum(cache.full_evictable_size_.values()) + sum(cache.full_protected_size_.values())
-        actual_swa = sum(cache.swa_evictable_size_.values()) + sum(cache.swa_protected_size_.values())
+        actual_full = sum(cache.full_evictable_size_.values()) + sum(
+            cache.full_protected_size_.values()
+        )
+        actual_swa = sum(cache.swa_evictable_size_.values()) + sum(
+            cache.swa_protected_size_.values()
+        )
         self.assertEqual(
-            full_total, actual_full,
+            full_total,
+            actual_full,
             f"full size mismatch: tree={full_total}, tracked={actual_full}. {msg}",
         )
         self.assertEqual(
-            swa_total, actual_swa,
+            swa_total,
+            actual_swa,
             f"swa size mismatch: tree={swa_total}, tracked={actual_swa}. {msg}",
         )
 
@@ -574,7 +578,6 @@ class TestSWARadixCache(CustomTestCase):
         self.assertEqual(allocator.swa_available_size(dp_rank=0), initial_swa[0])
         self.assertEqual(allocator.swa_available_size(dp_rank=1), initial_swa[1])
 
-
     def test_evictable_size_returns_min(self):
         cache = self.cache
         indices = self._alloc_indices(10)
@@ -644,9 +647,7 @@ class TestSWARadixCache(CustomTestCase):
 
         # Re-insert key_a with swa_evicted_seqlen=0 (Branch 1: not evicted)
         new_val = self._alloc_indices(len(key_a))
-        cache.insert(
-            key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=0
-        )
+        cache.insert(key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=0)
 
         # The tombstone should be healed (revived)
         healed_node = cache.root_node.children[child_key]
@@ -666,9 +667,7 @@ class TestSWARadixCache(CustomTestCase):
         # Re-insert with swa_evicted_seqlen=5 (in the middle of shared[0:10])
         # Branch 2: split at position 5, revive [5:10], keep [0:5] as tombstone
         new_val = self._alloc_indices(len(key_a))
-        cache.insert(
-            key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=5
-        )
+        cache.insert(key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=5)
 
         # Walk tree: root → [0:5] (tombstone) → [5:10] (revived) → {[10:15], [20:24]}
         front_node = cache.root_node.children[child_key]
@@ -698,9 +697,7 @@ class TestSWARadixCache(CustomTestCase):
         # Re-insert with swa_evicted_seqlen=15 (>= node_end=10)
         # Branch 3: entire node already evicted → keep tombstone
         new_val = self._alloc_indices(len(key_a))
-        cache.insert(
-            key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=15
-        )
+        cache.insert(key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=15)
 
         # The shared prefix should still be tombstone
         self.assertTrue(cache.root_node.children[child_key].swa_tombstone)
@@ -771,9 +768,7 @@ class TestSWARadixCache(CustomTestCase):
         # Second insert with protected_prefix_len=10 (prev_prefix_len) and swa_evicted_seqlen=5
         # Branch 2 applies: swa_evicted_seqlen(5) < node_end(20), split at 5, revive [5:20]
         val_second = self._alloc_indices(len(key))
-        cache.insert(
-            key, value=val_second, prev_prefix_len=10, swa_evicted_seqlen=5
-        )
+        cache.insert(key, value=val_second, prev_prefix_len=10, swa_evicted_seqlen=5)
 
         # Match should still return 20 tokens (sliding_window=4, suffix > 4)
         match2 = cache.match_prefix(key)
@@ -860,9 +855,7 @@ class TestSWARadixCache(CustomTestCase):
 
             # Re-insert with new values (simulating healing)
             new_val = self._alloc_indices(len(key))
-            cache.insert(
-                key, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=0
-            )
+            cache.insert(key, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=0)
             self._verify_size_consistency_for(cache, f"cycle {cycle} re-insert")
 
         # Final full evict
@@ -889,7 +882,9 @@ class TestSWARadixCache(CustomTestCase):
                 val = self._alloc_indices(length)
                 swa_evicted = rng.choice([0, 0, 0, rng.randint(0, length)])
                 cache.insert(
-                    key, value=val, prev_prefix_len=0,
+                    key,
+                    value=val,
+                    prev_prefix_len=0,
                     swa_evicted_seqlen=swa_evicted,
                 )
             elif op == "evict_swa":
@@ -1133,9 +1128,7 @@ class TestSWARadixCache(CustomTestCase):
         # Re-inserting with non-page-aligned swa_evicted_seqlen should assert
         new_val = self._alloc_indices(len(key_a))
         with self.assertRaises(AssertionError):
-            paged_cache.insert(
-                key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=3
-            )
+            paged_cache.insert(key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=3)
 
     def test_cache_unfinished_req_writeback_range(self):
         """T22: cache_unfinished_req writes back from last_matched_prefix_len, not len(prefix_indices)."""
@@ -1153,9 +1146,7 @@ class TestSWARadixCache(CustomTestCase):
         # Insert extended sequence (simulating cache_unfinished_req)
         key_full = list(range(0, 20))
         val2 = self._alloc_indices(len(key_full))
-        new_prefix_len = cache.insert(
-            key_full, value=val2, prev_prefix_len=10, swa_evicted_seqlen=0
-        )
+        cache.insert(key_full, value=val2, prev_prefix_len=10, swa_evicted_seqlen=0)
 
         # Match the full key
         match2 = cache.match_prefix(key_full)

--- a/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
@@ -139,8 +139,8 @@ class TestSWARadixCache(CustomTestCase):
                     swa_total += len(node.value)
             stack.extend(node.children.values())
 
-        actual_full = cache.full_evictable_size_ + cache.full_protected_size_
-        actual_swa = cache.swa_evictable_size_ + cache.swa_protected_size_
+        actual_full = sum(cache.full_evictable_size_.values()) + sum(cache.full_protected_size_.values())
+        actual_swa = sum(cache.swa_evictable_size_.values()) + sum(cache.swa_protected_size_.values())
         self.assertEqual(
             full_total, actual_full,
             f"full size mismatch: tree={full_total}, tracked={actual_full}. {msg}",


### PR DESCRIPTION
> close #993

## Summary

This PR adds sliding-window attention (SWA) support to the radix cache, enabling KV prefix reuse for hybrid models (e.g., MiMo) that mix full-attention and sliding-window-attention layers.

Previously, SWA was only supported with `ChunkCache` (`--disable-radix-cache`). This PR extends support to the radix tree cache (`SWARadixCache`), allowing prefix sharing across requests while correctly managing the dual-pool (full + SWA) KV memory.

## Core Changes

| Area | Change |
|------|--------|
| `SWARadixCache.evict_req_swa` | Per-request SWA eviction with tree-owned prefix protection. Uses `_node_prefix_len(req.last_node)` to derive the protected boundary, preventing eviction of tree-cached SWA slots. |
| `_evict_swa` safety margin | Eviction formula changed from `pre_len - sliding_window` to `pre_len - sliding_window - page_size`. The extra `- page_size` margin prevents `swa_evicted_seqlen` from reaching the live leaf boundary, ensuring `_insert_helper` can always create a non-tombstone leaf. |
| `_insert_helper` tombstone logic | Two sets of tombstone branch handling: (1) **Existing tombstone healing** (while loop) — 3 branches based on `swa_evicted_seqlen` vs `[node_start, node_end)`: full revive, split+partial revive, keep tombstone. (2) **New node tombstone split** (after while loop) — 3 cases ensuring leaf-must-not-be-tombstone invariant. |
| `_match_prefix_helper` | Stops at tombstone nodes to prevent returning SWA-freed slots as valid prefix. Unconditionally resets tombstone counter on each call. |
| Phase 2 SWA-only eviction | Uses `swa_lru_list` to find LRU nodes. Internal nodes become tombstones (SWA freed, full retained). Leaf nodes are fully deleted (both pools) to preserve the leaf-must-not-be-tombstone invariant, with cascade delete on parent. |
| Extend path gating | `isinstance(self.tree_cache, ChunkCache)` check — SWA eviction during extend only fires for `ChunkCache`, not `SWARadixCache`. For radix cache, SWA reclamation is deferred to tree-level Phase 2 eviction. |
| `release_req` | Use `req.last_matched_prefix_len` instead of `len(req.prefix_indices)` for cache boundary calculation. |
| `set_num_token_hybrid` | Fix memory allocation bug: SWA layer cost was double-discounted when distributing KV cache budget between full and SWA pools. The distribution equation now correctly weights SWA token-layers by the head ratio, recovering ~38.8% previously wasted HBM. |
| `evict_interval` formula | Aligned with upstream sglang ([#22645](https://github.com/sgl-project/sglang/pull/22645)). Lower bound changed from `max(min(sw, ps), 1)` to `max(page_size, int(sliding_window_size * multiplier))` with page alignment. Adds `SGL_JAX_SWA_EVICTION_INTERVAL_MULTIPLIER` env var (default `1.0`) to tune the SWA-waste vs. eviction-overhead tradeoff at runtime. |

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `SGL_JAX_SWA_EVICTION_INTERVAL_MULTIPLIER` | `1.0` | Controls the trade-off between SWA memory waste and eviction overhead during decode. The eviction interval is computed as `max(page_size, int(sliding_window_size * multiplier))`, then page-aligned. A larger multiplier reduces eviction frequency (lower overhead) but holds more SWA tokens beyond the sliding window (higher memory usage). |

**Example:**

```bash
# Default: evict every sliding_window_size tokens (page-aligned)
# For sliding_window=128, page_size=256 → evict_interval=256

# Memory-tight large-batch: evict more aggressively (smaller interval)
export SGL_JAX_SWA_EVICTION_INTERVAL_MULTIPLIER=0.5
# → evict_interval = max(256, int(128 * 0.5)) = 256 (page_size dominates)

# Memory-rich low-QPS: evict less often to reduce overhead
export SGL_JAX_SWA_EVICTION_INTERVAL_MULTIPLIER=4.0
# → evict_interval = max(256, int(128 * 4.0)) = 512
```

## Tombstone Healing (3 Branches)

When `_insert_helper` walks through an existing tombstone node beyond `update_kv_after_len`, it checks `swa_evicted_seqlen` against `[node_start, node_end)`:

| Branch | Condition | Action |
|--------|-----------|--------|
| 1 | `swa_evicted <= node_start` | Revive entire node (re-allocate SWA slots) |
| 2 | `node_start < swa_evicted < node_end` | Split node, revive back half only |
| 3 | `swa_evicted >= node_end` | Keep tombstone, free incoming SWA value |

## Test Coverage

| Category | Tests | Description |
|----------|-------|-------------|
| Tombstone lifecycle | 6 | Creation, prefix match, 3-branch healing, cascade delete |
| Size tracking | 3 | Consistency checks, fuzz testing (50-step random ops) |
| Protected prefix | 3 | Tree boundary protection, page alignment, `evict_req_swa` |
| New node invariants | 3 | Tombstone split, leaf-never-tombstone, exact boundary |
| Delete correctness | 2 | `get_child_key_fn` usage for O(1) delete |
| Writeback | 1 | `cache_unfinished_req` writeback range |
| DP rank isolation | 6 | Namespace isolation, shared namespace, multi-rank batching |
| Allocator safety margin | 5 | Updated expectations for `- page_size` formula |
| **Total** | **69** | 42 radix cache + 27 allocator |

## E2E Accuracy Validation (MiMo-V2-Flash on TPU v6e-16)

### Server Launch Command

```bash
export RANK=0  # 0-3 for each node
JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -u -m sgl_jax.launch_server \
    --model-path /models/MiMo-V2-Flash \
    --trust-remote-code \
    --tp-size 16 --dp-size 4 --ep-size 16 \
    --moe-backend fused \
    --nnodes 4 --node-rank "$RANK" \
    --dist-init-addr <node0-ip>:30000 \
    --host 0.0.0.0 --port 30271 \
    --page-size 256 \
    --context-length 262144 \
    --chunked-prefill-size 2048 \
    --dtype bfloat16 \
    --mem-fraction-static 0.85 \
    --swa-full-tokens-ratio 0.2 \
    --skip-server-warmup \
    --log-level info \
    --max-running-requests 128
```

### AIME2025 Results

| Subset | Num | Score |
|--------|-----|-------|
| AIME2025-I | 15 | **0.8667** |
| AIME2025-II | 15 | **0.9333** |
| **OVERALL** | **30** | **0.9000** |

### MMLU-Redux Results

| Benchmark | Num | Accuracy |
|-----------|-----|----------|
| MMLU-Redux | 5330 | **91.33%** |

Config: `temperature=0.0, top_p=1, max_tokens=16384, repeat=1`

## Design Document

Added `docs/design/swa_eviction_and_lru_strategy.md` covering:
- Dual-pool architecture (full pool + SWA pool)
- Per-request SWA eviction (ChunkCache vs SWARadixCache paths)
- Extend phase behavior (proactive vs deferred)
- Tree-level eviction (Phase 1 full delete + Phase 2 SWA-only tombstone)
- Tombstone insert logic (existing healing + new node split)
- LRU policy (dual lists: `full_lru_list` + `swa_lru_list`)

## Motivation

SWA layers only need recent tokens within the sliding window, but without radix cache support, every request allocated full-length SWA KV buffers with no prefix reuse. This wastes significant memory for models with many SWA layers (e.g., MiMo-V2-Flash has 39 SWA layers out of 48 total).

With this PR, SWA slots outside the window are freed progressively (per-request during decode, tree-level Phase 2 under memory pressure), while full KV remains in the tree for prefix matching. This reduces SWA memory usage to approximately `sliding_window + page_size` tokens per request for SWA layers.