### PR TITLE
fix(multimodal): restore wan2.1 e2e under DP-aware sharding contracts

### DIFF
--- a/python/sgl_jax/srt/models/umt5.py
+++ b/python/sgl_jax/srt/models/umt5.py
@@ -271,6 +271,13 @@ class UMT5Attention(nnx.Module):
 
         q_h, k_h, v_h = to_heads(q), to_heads(k), to_heads(v)
 
+        # Token axis carries "data" from LinearBase; without this, einsum
+        # would map "data" to both q and k axes -> DuplicateSpecError.
+        qkv_spec = NamedSharding(self.mesh, P("tensor", None, None))
+        q_h = jax.sharding.reshard(q_h, qkv_spec)
+        k_h = jax.sharding.reshard(k_h, qkv_spec)
+        v_h = jax.sharding.reshard(v_h, qkv_spec)
+
         # Compute scores in float32
         scores = jnp.einsum("hqd,hkd->hqk", q_h.astype(jnp.float32), k_h.astype(jnp.float32))
 
@@ -279,6 +286,11 @@ class UMT5Attention(nnx.Module):
         # Fallback if seq_lens is None: assume single sequence
         if q_lens is None:
             q_lens = jnp.array([q.shape[0]], dtype=jnp.int32)
+
+        # seq_lens arrives sharded P("data"); position-bias scatter needs
+        # a replicated index to mix with mesh-less jnp.zeros intermediates.
+        replicated = NamedSharding(self.mesh, P())
+        q_lens = jax.sharding.reshard(q_lens, replicated)
 
         # Add position bias for self-attention (T5-specific)
         if not self.is_cross_attention and hasattr(self, "rel_bias"):
@@ -291,6 +303,7 @@ class UMT5Attention(nnx.Module):
             if self.is_cross_attention
             else q_lens
         )
+        kv_lens = jax.sharding.reshard(kv_lens, replicated)
         is_causal = self.is_decoder and not self.is_cross_attention
 
         # Apply block_diagonal_mask
@@ -465,10 +478,15 @@ class UMT5EncoderModel(nnx.Module):
         deterministic = getattr(forward_batch, "deterministic", True)
         hidden = self.encoder(x, forward_batch, token_to_kv_pool, deterministic)
 
-        # Dummy logits for interface compatibility
+        # Replicate so host-side hidden_states slicing in the output
+        # processor doesn't need an explicit out_sharding.
+        hidden = jax.sharding.reshard(hidden, NamedSharding(self.mesh, P()))
+
+        # Dummy logits at P("data","tensor") to match the sampler's
+        # penalty-add branch and keep lax.cond's two branches consistent.
         bs = forward_batch.seq_lens.shape[0]
         dummy = jnp.zeros((bs, self.config.vocab_size), dtype=self.dtype)
-        dummy = jax.sharding.reshard(dummy, NamedSharding(self.mesh, P(None, "tensor")))
+        dummy = jax.sharding.reshard(dummy, NamedSharding(self.mesh, P("data", "tensor")))
         return LogitsProcessorOutput(next_token_logits=dummy, hidden_states=hidden), [], [], None
 
 

--- a/python/sgl_jax/srt/multimodal/models/wan/diffusion/wan_dit.py
+++ b/python/sgl_jax/srt/multimodal/models/wan/diffusion/wan_dit.py
@@ -717,6 +717,12 @@ class WanTransformer3DModel(nnx.Module):
         # Unpatchify: reshape from patches back to image space
         # hidden_states shape: [batch_size, num_patches, out_channels * patch_volume]
         p_t, p_h, p_w = self.patch_size
+        # proj_out leaves "tensor" on the channel axis; multi-axis split
+        # reshape can't be inferred under that sharding, so drop it.
+        if self.mesh is not None:
+            hidden_states = jax.sharding.reshard(
+                hidden_states, jax.sharding.NamedSharding(self.mesh, jax.sharding.PartitionSpec())
+            )
         hidden_states = hidden_states.reshape(
             batch_size,
             post_patch_num_frames,

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -552,7 +552,7 @@ suites = {
         TestFile("test/srt/test_server_pause_continue.py", 6),
         TestFile("test/srt/rl/test_return_routed_experts.py", 5),
         TestFile("test/srt/rl/test_multi_engines_in_one_process.py", 5),
-        # TestFile("test/srt/multimodal/test_wan2_1_models.py", 30),
+        TestFile("test/srt/multimodal/test_wan2_1_models.py", 5),
     ],
 }
 


### PR DESCRIPTION
## Summary

PR #939 ("dp support") tightened the runtime sharding contract: `LinearBase` outputs `P("data", *, kernel_axes[-1])`, the sampler's `lax.cond` branches need identical output shardings, batch arrays are `P("data")`, and most device-side reshape/index ops became static under Explicit mesh axes. The multimodal Wan2.1 pipeline still works end-to-end with `dp_size=1`, but several spots silently relied on implicit broadcast and now `ShardingTypeError` out — so PR #939 had to disable `test/srt/multimodal/test_wan2_1_models.py` to unblock the merge.

This PR re-enables that test with five focused fixes, **all on the multimodal / UMT5 boundary** so the LLM-generic sampler / output processor paths stay untouched.

### Fixes

- **`umt5._native_attention`** — reshard `q_h/k_h/v_h` to `P("tensor", None, None)` before the QK einsum. Otherwise q and k token axes both carry "data" and the dot output asks for two "data" mappings → `DuplicateSpecError`.
- **`umt5._native_attention`** — reshard `q_lens/kv_lens` to replicated so position-bias scatter (`jnp.zeros(q_len).at[starts].set(1)`) doesn't mix `P("data")` with a mesh-less zeros (`Resource axis: data ... not found in mesh: ()`).
- **`UMT5EncoderModel.__call__`** — reshard `hidden_states` to replicated so the host-side per-request slice in `scheduler_output_processor_mixin` doesn't need an explicit `out_sharding`.
- **`UMT5EncoderModel.__call__`** — emit dummy `next_token_logits` at `P("data","tensor")` (was `P(None,"tensor")`) so the sampler's `lax.cond` penalty-add branch (`P("data","tensor")`) and identity branch return matching shardings.
- **`wan_dit` unpatchify** — reshard `hidden_states` to replicated before the multi-axis reshape; `proj_out` (LinearBase) leaves "tensor" on the channel axis and multi-axis splits on a sharded dim are no longer inferable.

Also re-enables the test in `test/srt/run_suite.py` with `estimated_time=3` (minutes).

### Why no LLM-generic changes

An earlier draft of this PR also patched `Sampler.__call__` (reshard logits up front) and `scheduler_output_processor_mixin` (host-fetch hidden_states before slicing). Both turned out to be redundant once the UMT5 boundary emits the right shardings — and they would have masked latent issues in the LLM path. Pushed those concerns back to the encoder.

## Test plan

- [x] `python3 -u -m unittest test.srt.multimodal.test_wan2_1_models.TestWan2_1Model.test_wan2_1_1_3b` on tpu-v6e-2x2 → HTTP 200 from `/api/v1/videos/generation`, `Ran 1 test in 59.394s, OK`.
- [ ] CI `e2e-test-tpu-v6e-4` suite (now includes the re-enabled `test_wan2_1_models.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)