### PR TITLE
docs(mimo): enable DP and radix cache in MiMo cookbooks

### DIFF
--- a/docs/basic_usage/mimo_v2.5_pro.md
+++ b/docs/basic_usage/mimo_v2.5_pro.md
@@ -57,10 +57,9 @@ Run the **same** command on every node, only varying `${NODE_RANK}` and pointing
 JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
     --model-path XiaomiMiMo/MiMo-V2.5-Pro \
     --trust-remote-code \
-    --tp-size 32 --ep-size 32 \
+    --tp-size 32 --dp-size 4 --ep-size 32 \
     --moe-backend fused \
     --host 0.0.0.0 --port 30271 \
-    --disable-radix-cache \
     --page-size 256 --context-length 262144 \
     --chunked-prefill-size 4096 \
     --dtype bfloat16 --mem-fraction-static 0.95 \
@@ -79,7 +78,7 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
     --model-path XiaomiMiMo/MiMo-V2.5-Pro \
     --trust-remote-code \
     --port 30271 \
-    --tp-size 64 --ep-size 64 \
+    --tp-size 64 --dp-size 8 --ep-size 64 \
     --context-length 262144 --max-seq-len 4096 \
     --chunked-prefill-size 4096 --max-prefill-tokens 16384 \
     --page-size 256 \
@@ -87,7 +86,6 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
     --max-running-requests 512 \
     --swa-full-tokens-ratio 0.15 \
     --attention-backend fa --moe-backend fused \
-    --disable-radix-cache \
     --nnodes 16 --node-rank ${NODE_RANK} \
     --dist-init-addr ${MASTER_ADDR}
 ```
@@ -97,6 +95,7 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
 ### Key flags
 
 - `--tp-size / --ep-size`: Match the total JAX device count across all nodes. v7x exposes 2 logical devices per chip (32 = 16 chips × 2); v6e exposes 1 (64 = 64 chips × 1).
+- `--dp-size`: Enables data parallelism for the attention path. The attention TP degree becomes `tp_size / dp_size` (8 for both recipes here). MoE layers still run with full `ep_size`.
 - `--moe-backend fused`: Uses the fused Pallas MoE kernel (recommended). `epmoe` is also supported but slower at this scale.
 - `--page-size 256`: Required page size for the SWA pool's eviction logic. Smaller page sizes are not supported with MiMo-V2.5-Pro.
 - `--context-length 262144`: 256K context. Match this to your workload's max prompt + output length.
@@ -104,7 +103,6 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
 - `--swa-full-tokens-ratio`: Fraction of the KV cache pool reserved for full-attention layers. `0.25` for v7x, `0.15` for v6e.
 - `--mem-fraction-static`: Fraction of HBM reserved for weights + KV cache. Lower if the host shares the TPU.
 - `--max-running-requests 512`: Upper bound on concurrent decoding requests.
-- `--disable-radix-cache`: Required for now — radix cache is not yet supported.
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache`: Persists XLA / Pallas compilation cache so subsequent restarts skip the ~4-minute precompile step.
 
 ## Running on GKE (Indexed Job)
@@ -168,10 +166,9 @@ spec:
           JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
               --model-path /models/MiMo-V2.5-Pro \
               --trust-remote-code \
-              --tp-size 32 --ep-size 32 \
+              --tp-size 32 --dp-size 4 --ep-size 32 \
               --moe-backend fused \
               --host 0.0.0.0 --port 30271 \
-              --disable-radix-cache \
               --page-size 256 --context-length 262144 \
               --chunked-prefill-size 4096 \
               --dtype bfloat16 --mem-fraction-static 0.95 \
@@ -265,10 +262,6 @@ Reference numbers measured on TPU v7x-16 (`2x2x4`, `tp=32 ep=32`):
 | MiMo-V2.5-Pro   | aime25  | AveragePass@1 | AIME2025-I  | 15  | 0.8667  |
 | MiMo-V2.5-Pro   | aime25  | AveragePass@1 | AIME2025-II | 15  | 1.0000  |
 | MiMo-V2.5-Pro   | aime25  | AveragePass@1 | OVERALL     | 30  | 0.9334  |
-
-## Known Issues
-
-- Radix cache cannot be enabled yet — always pass `--disable-radix-cache`.
 
 ## Additional Resources
 

--- a/docs/basic_usage/mimo_v2_flash.md
+++ b/docs/basic_usage/mimo_v2_flash.md
@@ -16,13 +16,13 @@ Uses the fused Pallas kernel which combines expert computation and all-to-all co
 JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_server \
     --model-path XiaomiMiMo/MiMo-V2-Flash \
     --trust-remote-code \
-    --tp-size 16 --ep-size 16 \
+    --tp-size 16 --dp-size 4 --ep-size 16 \
     --moe-backend fused \
     --nnodes 4 --node-rank $RANK \
     --dist-init-addr $MASTER_IP:30000 \
     --host 0.0.0.0 --port 30271 \
     --page-size 256 --context-length 262144 \
-    --disable-radix-cache --chunked-prefill-size 2048 \
+    --chunked-prefill-size 2048 \
     --dtype bfloat16 --mem-fraction-static 0.95 \
     --swa-full-tokens-ratio 0.2 --skip-server-warmup \
     --max-running-requests 128 \
@@ -37,13 +37,13 @@ Uses GMM-based expert-parallel dispatch with separate all-to-all communication:
 JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_server \
     --model-path XiaomiMiMo/MiMo-V2-Flash \
     --trust-remote-code \
-    --tp-size 16 --ep-size 16 \
+    --tp-size 16 --dp-size 4 --ep-size 16 \
     --moe-backend epmoe \
     --nnodes 4 --node-rank $RANK \
     --dist-init-addr $MASTER_IP:30000 \
     --host 0.0.0.0 --port 30271 \
     --page-size 256 --context-length 262144 \
-    --disable-radix-cache --chunked-prefill-size 2048 \
+    --chunked-prefill-size 2048 \
     --dtype bfloat16 --mem-fraction-static 0.95 \
     --swa-full-tokens-ratio 0.2 --skip-server-warmup \
     --max-running-requests 128 \
@@ -52,10 +52,10 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_serv
 
 Key flags:
 - `--tp-size / --ep-size`: Match your total TPU chip count across all nodes
+- `--dp-size`: Enables data parallelism for the attention path. The attention TP degree becomes `tp_size / dp_size` (e.g. `16 / 4 = 4`). MoE layers still run with full `ep_size`.
 - `--moe-backend fused|epmoe`: `fused` uses an optimized Pallas kernel; `epmoe` uses GMM-based expert dispatch
 - `--swa-full-tokens-ratio 0.2`: Allocates 20% of KV cache pool to full-attention layers, 80% to SWA layers
 - `--page-size 256`: Recommended page size for SWA eviction efficiency
-- `--disable-radix-cache`: Recommended for multi-node deployments
 
 ### Single-node (TPU v7x-8)
 
@@ -63,11 +63,11 @@ Key flags:
 JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache uv run python -u -m sgl_jax.launch_server \
     --model-path XiaomiMiMo/MiMo-V2-Flash \
     --trust-remote-code \
-    --tp-size 8 --ep-size 8 \
+    --tp-size 8 --dp-size 2 --ep-size 8 \
     --moe-backend fused \
     --host 0.0.0.0 --port 30271 \
     --page-size 256 --context-length 262144 \
-    --disable-radix-cache --chunked-prefill-size 4096 \
+    --chunked-prefill-size 4096 \
     --dtype bfloat16 --mem-fraction-static 0.95 \
     --swa-full-tokens-ratio 0.2 --skip-server-warmup \
     --max-running-requests 128 \
@@ -126,10 +126,10 @@ evalscope eval \
 
 ### TPU Configuration Guide
 
-| TPU Type | Nodes | TP Size | EP Size | chunked-prefill-size | mem-fraction-static | max-running-requests |
-|----------|-------|---------|---------|----------------------|--------------------|-----------------------|
-| v6e-16   | 4     | 16      | 16      | 2048                 | 0.95               | 128                   |
-| v7x-8    | 1     | 8       | 8       | 4096                 | 0.95               | 128                   |
+| TPU Type | Nodes | TP Size | DP Size | EP Size | chunked-prefill-size | mem-fraction-static | max-running-requests |
+|----------|-------|---------|---------|---------|----------------------|--------------------|-----------------------|
+| v6e-16   | 4     | 16      | 4       | 16      | 2048                 | 0.95               | 128                   |
+| v7x-8    | 1     | 8       | 2       | 8       | 4096                 | 0.95               | 128                   |
 
 ### SWA Pool Tuning
 - Monitor SWA pool usage via server logs: `swa token usage` and `full token usage`


### PR DESCRIPTION
## Summary

- DP attention (#939) and SWA radix cache (#989) are now supported, so the MiMo-V2-Flash and MiMo-V2.5-Pro cookbooks can drop `--disable-radix-cache` and recommend a default DP layout.
- `--dp-size` added to every launch command (multi-node v6e-16 / single-node v7x-8 for Flash; v7x-16 / v6e-64 / GKE manifest for Pro), keeping `tp_size` and `ep_size` unchanged so `attn_tp = tp_size / dp_size` lands at 4 (Flash) and 8 (Pro).
- Tip sections updated, `Known Issues` (radix cache) removed in the Pro cookbook, and the v2-Flash TPU configuration table gains a `DP Size` column.

## Test plan

- [ ] Re-run a v6e-16 MiMo-V2-Flash launch with the new flags and confirm radix cache is active.
- [ ] Re-run a v7x-16 MiMo-V2.5-Pro launch with the new flags and confirm DP attention works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)