### PR TITLE
fix(memory_pool): allow alloc reuse on hybrid model's final prefill chunk

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -210,6 +210,9 @@ class Req:
         self.req_pool_idx: int | None = None
         # Slot in HybridReqToTokenPool's recurrent state pool; None for non-hybrid models.
         self.recurrent_pool_idx: int | None = None
+        # True iff the slot(s) were retained by a free_chunked() call and the
+        # next alloc(reqs) should reuse them instead of fresh-allocating.
+        self._chunked_slot_pinned: bool = False
 
         # Check finish
         self.tokenizer = None
@@ -513,6 +516,7 @@ class Req:
         self.is_chunked = 0
         self.req_pool_idx = None
         self.recurrent_pool_idx = None
+        self._chunked_slot_pinned = False
         self.already_computed = 0
         self.routed_experts = None
         self.latest_bid = None

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -125,8 +125,9 @@ class ReqToTokenPool:
         """Allocate request slots for a list of Req-like objects.
 
         Chunked-prefill semantics:
-        - Reqs already holding a req_pool_idx are skipped (must satisfy
-          is_chunked > 0 -- safety assert).
+        - Reqs already holding a req_pool_idx are skipped iff their slot was
+          explicitly pinned by a previous free_chunked() (req._chunked_slot_pinned).
+          The pin stays sticky until free() clears it on the final chunk.
         - Reqs with no req_pool_idx are allocated from free_slots and have
           req.req_pool_idx written back.
         - If capacity is insufficient, return None and leave every req field
@@ -140,9 +141,10 @@ class ReqToTokenPool:
             if req.req_pool_idx is None:
                 new_count += 1
             else:
-                assert req.is_chunked > 0, (
+                assert getattr(req, "_chunked_slot_pinned", False), (
                     "ReqToTokenPool.alloc: req with existing req_pool_idx must have "
-                    f"is_chunked > 0 (chunked prefill); got is_chunked={req.is_chunked!r}"
+                    "_chunked_slot_pinned=True (slot retained by a previous "
+                    "free_chunked); got an unpinned reuse -- likely a missing free()"
                 )
 
         if new_count > len(self.free_slots):
@@ -183,6 +185,8 @@ class ReqToTokenPool:
         # later caller (the slot may already be re-handed to another req by
         # then). Keeps free / free_chunked / free_recurrent_cache symmetric.
         req.req_pool_idx = None
+        # Defensively clear the pin: a freed slot is never a "retained" slot.
+        req._chunked_slot_pinned = False
 
     def free_chunked(self, chunked_req) -> None:
         """Release for chunked-prefill. Default: identical to free.
@@ -295,11 +299,12 @@ class HybridReqToTokenPool(ReqToTokenPool):
         alloc(reqs) reuses them -- preserves the recurrent state across
         chunks without an alloc/free roundtrip.
 
-        No-op by design: req keeps both req_pool_idx and recurrent_pool_idx;
-        alloc(reqs) sees them set and skips re-allocation, returning the same
-        indices.
+        Pins the slot so alloc(reqs) recognises this as a legitimate reuse
+        (decoupled from the is_chunked counter -- works for the FINAL chunk
+        too, where is_chunked is intentionally 0 to drive output_processor
+        finalize).
         """
-        # Intentional no-op (see docstring).
+        chunked_req._chunked_slot_pinned = True
 
     def free_recurrent_cache(self, req) -> None:
         """Release the recurrent state slot held by `req`. Idempotent.


### PR DESCRIPTION
## Summary
- Fix `AssertionError` in `ReqToTokenPool.alloc` triggered on the final prefill chunk of any chunked-prefill req in hybrid models (e.g. Kimi-Linear).
- The previous `is_chunked > 0` assertion was incompatible with the chunked-prefill state machine on the final chunk: `HybridReqToTokenPool.free_chunked` retains the slot across chunks, while `is_chunked` is intentionally 0 on the final chunk (the per-chunk `+=1` is skipped because `add_chunked_req` returns `None`, and `is_chunked == 0` is required for the output processor's finalize branch).
- Replace the implicit `is_chunked` signal with an explicit `_chunked_slot_pinned` boolean on `Req`, set by `HybridReqToTokenPool.free_chunked` and cleared by `ReqToTokenPool.free`.

## Test plan
- [ ] Kimi-Linear (or other hybrid model) with a prompt long enough to span 3+ `chunked_prefill_size` chunks; verify prefill completes and decode begins.
- [ ] Non-hybrid model with chunked prefill; verify no regression (non-hybrid `free_chunked` still calls `free()` which leaves the pin cleared).
- [ ] Retraction path: `reset_for_retract` clears the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)