### PR TITLE
[WIP] debug(kimi_linear): dump intermediates per forward for accuracy debug

### DIFF
--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -248,6 +248,9 @@ class ModelWorker:
     def run_precompile(self, future_token_ids_map=None):
         self.precompile_extend(future_token_ids_map)
         self.precompile_decode(future_token_ids_map)
+        from sgl_jax.srt.utils.debug_utils import mark_warmup_complete
+
+        mark_warmup_complete()
 
     def precompile_extend(self, future_token_ids_map=None):
         start_time = time.perf_counter()

--- a/python/sgl_jax/srt/models/kimi_linear.py
+++ b/python/sgl_jax/srt/models/kimi_linear.py
@@ -21,6 +21,7 @@ from sgl_jax.srt.layers.moe import EPMoE, create_moe_weights_mapping
 from sgl_jax.srt.layers.radix_linear_attention import RadixLinearAttention
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
 from sgl_jax.srt.models.deepseek_v3 import DeepseekV3Attention as KimiMLAAttention
+from sgl_jax.srt.utils.debug_utils import begin_forward, dump_array
 from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
 
 logger = logging.getLogger(__name__)
@@ -285,6 +286,7 @@ class KimiDecoderLayer(nnx.Module):
         dtype: jnp.dtype = jnp.bfloat16,
     ):
         super().__init__()
+        self.layer_idx = layer_idx
         self.hidden_size = config.hidden_size
         self.is_kda = config.is_kda_layer(layer_idx)
 
@@ -416,6 +418,8 @@ class KimiDecoderLayer(nnx.Module):
         residual: jax.Array | None = None,
         dispatch_info: ExpertLocationMetadata | None = None,
     ):
+        tag = f"layer_{self.layer_idx:02d}"
+
         # Pre-norm residual pattern
         if residual is None:
             residual = hidden_states
@@ -424,6 +428,7 @@ class KimiDecoderLayer(nnx.Module):
             hidden_states += residual
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
+        dump_array(f"{tag}_input_layernorm", hidden_states)
 
         # Attention
         if self.is_kda:
@@ -437,34 +442,42 @@ class KimiDecoderLayer(nnx.Module):
             forward_batch,
             kv_pool,
         )
+        dump_array(f"{tag}_attn_out", hidden_states)
         # Post-attention residual + norm
         hidden_states += residual
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
+        dump_array(f"{tag}_post_attention_layernorm", hidden_states)
 
         # MLP (MoE or dense)
         if self.is_moe_layer:
             if self.shared_experts is not None:
                 shared_output = self.shared_experts(hidden_states)
+                dump_array(f"{tag}_shared_experts", shared_output)
             else:
                 shared_output = None
 
             router_logits = self.moe_gate(hidden_states)
+            dump_array(f"{tag}_moe_gate", router_logits)
             correction_bias = self.moe_gate.bias.value if self.moe_gate.bias is not None else None
             topk_weights, topk_ids = self.topk(
                 router_logits, correction_bias, dispatch_info=dispatch_info
             )
+            dump_array(f"{tag}_topk_weights", topk_weights)
+            dump_array(f"{tag}_topk_ids", topk_ids)
 
             if self.use_fused:
                 token_valid_mask = forward_batch.get_token_valid_mask(hidden_states.shape[0])
                 topk_ids = jnp.where(token_valid_mask[:, None], topk_ids, -1)
 
             hidden_states = self.block_sparse_moe(hidden_states, topk_weights, topk_ids)
+            dump_array(f"{tag}_block_sparse_moe", hidden_states)
 
             if shared_output is not None:
                 hidden_states = hidden_states + shared_output
         else:
             hidden_states = self.mlp(hidden_states)
+            dump_array(f"{tag}_mlp", hidden_states)
             topk_ids = None
 
         return hidden_states, residual, kv_fused, topk_ids
@@ -515,6 +528,7 @@ class KimiModel(nnx.Module):
         memory_pools,
     ) -> tuple[jax.Array, list, list, list]:
         hidden_states = self.embed_tokens(forward_batch.input_ids)
+        dump_array("embed_tokens", hidden_states)
 
         residual = None
         layers_kv_fused = []
@@ -522,7 +536,7 @@ class KimiModel(nnx.Module):
         layers_conv_buffers = []
         layers_topk_ids = []
 
-        for layer in self.layers:
+        for i, layer in enumerate(self.layers):
             hidden_states, residual, attn_state, topk_ids = layer(
                 forward_batch.positions,
                 hidden_states,
@@ -531,6 +545,7 @@ class KimiModel(nnx.Module):
                 residual,
                 dispatch_info=forward_batch.expert_location_metadata,
             )
+            dump_array(f"layer_{i:02d}_out", hidden_states)
             if layer.is_kda:
                 rec_buf, conv_buf_list = attn_state
                 layers_recurrent_buffers.append(rec_buf)
@@ -543,6 +558,7 @@ class KimiModel(nnx.Module):
             hidden_states += residual
 
         hidden_states = self.norm(hidden_states)
+        dump_array("model_norm", hidden_states)
         return (
             hidden_states,
             layers_kv_fused,
@@ -589,6 +605,9 @@ class KimiLinearForCausalLM(nnx.Module):
         memory_pools,
         logits_metadata: LogitsMetadata,
     ):
+        begin_forward(
+            "prefill" if forward_batch.forward_mode.is_prefill() else "decode"
+        )
         hidden_states, layers_kv_fused, layers_recurrent_state, layers_topk_ids = self.model(
             forward_batch,
             memory_pools,
@@ -597,6 +616,7 @@ class KimiLinearForCausalLM(nnx.Module):
             output = self.logits_processor(hidden_states, self.lm_head, logits_metadata)
         else:
             output = self.logits_processor(hidden_states, self.model.embed_tokens, logits_metadata)
+        dump_array("logits", output.next_token_logits)
         return (
             output,
             {

--- a/python/sgl_jax/srt/models/kimi_linear.py
+++ b/python/sgl_jax/srt/models/kimi_linear.py
@@ -27,12 +27,14 @@ from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
 logger = logging.getLogger(__name__)
 
 
-def _replicate_for_dump(x: jax.Array) -> jax.Array:
+def _replicate_for_dump(x: jax.Array, mesh: jax.sharding.Mesh) -> jax.Array:
     """Force ``x`` to a fully-replicated sharding so heterogeneously-sharded
     operands (e.g. tensor-sharded q/k/v vs replicated f_a/g_a) can be
-    concatenated for the GPU-style fused-proj dumps."""
+    concatenated for the GPU-style fused-proj dumps. ``mesh`` must be the
+    same mesh used to build the module (tracer.sharding is unavailable
+    under explicit-sharding jit, so we pass it explicitly)."""
     return jax.lax.with_sharding_constraint(
-        x, jax.sharding.NamedSharding(x.sharding.mesh, jax.sharding.PartitionSpec())
+        x, jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
     )
 
 
@@ -46,6 +48,7 @@ class KimiMLP(nnx.Module):
         dump_prefix: str = "",
     ):
         super().__init__()
+        self.mesh = mesh
         self.dump_prefix = dump_prefix
         self.gate_proj = LinearBase(
             input_size=hidden_size,
@@ -87,7 +90,11 @@ class KimiMLP(nnx.Module):
             dump_array(
                 f"{p}_gate_up_proj_out",
                 jnp.concatenate(
-                    [_replicate_for_dump(gate), _replicate_for_dump(up)], axis=-1
+                    [
+                        _replicate_for_dump(gate, self.mesh),
+                        _replicate_for_dump(up, self.mesh),
+                    ],
+                    axis=-1,
                 ),
                 forward_mode,
             )
@@ -306,12 +313,12 @@ class KimiDeltaAttention(nnx.Module):
                 f"{p}_fused_qkvbfg_a_proj_out",
                 jnp.concatenate(
                     [
-                        _replicate_for_dump(q),
-                        _replicate_for_dump(k),
-                        _replicate_for_dump(v),
-                        _replicate_for_dump(b_out),
-                        _replicate_for_dump(f_a_out),
-                        _replicate_for_dump(g_a),
+                        _replicate_for_dump(q, self.mesh),
+                        _replicate_for_dump(k, self.mesh),
+                        _replicate_for_dump(v, self.mesh),
+                        _replicate_for_dump(b_out, self.mesh),
+                        _replicate_for_dump(f_a_out, self.mesh),
+                        _replicate_for_dump(g_a, self.mesh),
                     ],
                     axis=-1,
                 ),
@@ -338,7 +345,10 @@ class KimiDeltaAttention(nnx.Module):
             dump_array(
                 f"{p}_fused_fg_b_proj_out",
                 jnp.concatenate(
-                    [_replicate_for_dump(raw_gate), _replicate_for_dump(output_gate)],
+                    [
+                        _replicate_for_dump(raw_gate, self.mesh),
+                        _replicate_for_dump(output_gate, self.mesh),
+                    ],
                     axis=-1,
                 ),
                 fm,

--- a/python/sgl_jax/srt/models/kimi_linear.py
+++ b/python/sgl_jax/srt/models/kimi_linear.py
@@ -21,7 +21,7 @@ from sgl_jax.srt.layers.moe import EPMoE, create_moe_weights_mapping
 from sgl_jax.srt.layers.radix_linear_attention import RadixLinearAttention
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
 from sgl_jax.srt.models.deepseek_v3 import DeepseekV3Attention as KimiMLAAttention
-from sgl_jax.srt.utils.debug_utils import begin_forward, dump_array
+from sgl_jax.srt.utils.debug_utils import dump_array
 from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
 
 logger = logging.getLogger(__name__)
@@ -419,6 +419,7 @@ class KimiDecoderLayer(nnx.Module):
         dispatch_info: ExpertLocationMetadata | None = None,
     ):
         tag = f"layer_{self.layer_idx:02d}"
+        fm = forward_batch.forward_mode
 
         # Pre-norm residual pattern
         if residual is None:
@@ -428,7 +429,7 @@ class KimiDecoderLayer(nnx.Module):
             hidden_states += residual
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
-        dump_array(f"{tag}_input_layernorm", hidden_states)
+        dump_array(f"{tag}_input_layernorm", hidden_states, fm)
 
         # Attention
         if self.is_kda:
@@ -442,43 +443,43 @@ class KimiDecoderLayer(nnx.Module):
             forward_batch,
             kv_pool,
         )
-        dump_array(f"{tag}_attn_out", hidden_states)
+        dump_array(f"{tag}_attn_out", hidden_states, fm)
         # Post-attention residual + norm
         hidden_states += residual
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
-        dump_array(f"{tag}_post_attention_layernorm", hidden_states)
+        dump_array(f"{tag}_post_attention_layernorm", hidden_states, fm)
 
         # MLP (MoE or dense)
         if self.is_moe_layer:
             if self.shared_experts is not None:
                 shared_output = self.shared_experts(hidden_states)
-                dump_array(f"{tag}_shared_experts", shared_output)
+                dump_array(f"{tag}_shared_experts", shared_output, fm)
             else:
                 shared_output = None
 
             router_logits = self.moe_gate(hidden_states)
-            dump_array(f"{tag}_moe_gate", router_logits)
+            dump_array(f"{tag}_moe_gate", router_logits, fm)
             correction_bias = self.moe_gate.bias.value if self.moe_gate.bias is not None else None
             topk_weights, topk_ids = self.topk(
                 router_logits, correction_bias, dispatch_info=dispatch_info
             )
-            dump_array(f"{tag}_topk_weights", topk_weights)
-            dump_array(f"{tag}_topk_ids", topk_ids)
+            dump_array(f"{tag}_topk_weights", topk_weights, fm)
+            dump_array(f"{tag}_topk_ids", topk_ids, fm)
 
             if self.use_fused:
                 token_valid_mask = forward_batch.get_token_valid_mask(hidden_states.shape[0])
                 topk_ids = jnp.where(token_valid_mask[:, None], topk_ids, -1)
 
             hidden_states = self.block_sparse_moe(hidden_states, topk_weights, topk_ids)
-            dump_array(f"{tag}_block_sparse_moe", hidden_states)
+            dump_array(f"{tag}_block_sparse_moe", hidden_states, fm)
 
             if shared_output is not None:
                 hidden_states = hidden_states + shared_output
-                dump_array(f"{tag}_moe_plus_shared_experts", hidden_states)
+                dump_array(f"{tag}_moe_plus_shared_experts", hidden_states, fm)
         else:
             hidden_states = self.mlp(hidden_states)
-            dump_array(f"{tag}_mlp", hidden_states)
+            dump_array(f"{tag}_mlp", hidden_states, fm)
             topk_ids = None
 
         return hidden_states, residual, kv_fused, topk_ids
@@ -528,8 +529,9 @@ class KimiModel(nnx.Module):
         forward_batch: ForwardBatch,
         memory_pools,
     ) -> tuple[jax.Array, list, list, list]:
+        fm = forward_batch.forward_mode
         hidden_states = self.embed_tokens(forward_batch.input_ids)
-        dump_array("embed_tokens", hidden_states)
+        dump_array("embed_tokens", hidden_states, fm)
 
         residual = None
         layers_kv_fused = []
@@ -546,7 +548,7 @@ class KimiModel(nnx.Module):
                 residual,
                 dispatch_info=forward_batch.expert_location_metadata,
             )
-            dump_array(f"layer_{i:02d}_out", hidden_states)
+            dump_array(f"layer_{i:02d}_out", hidden_states, fm)
             if layer.is_kda:
                 rec_buf, conv_buf_list = attn_state
                 layers_recurrent_buffers.append(rec_buf)
@@ -559,7 +561,7 @@ class KimiModel(nnx.Module):
             hidden_states += residual
 
         hidden_states = self.norm(hidden_states)
-        dump_array("model_norm", hidden_states)
+        dump_array("model_norm", hidden_states, fm)
         return (
             hidden_states,
             layers_kv_fused,
@@ -606,9 +608,7 @@ class KimiLinearForCausalLM(nnx.Module):
         memory_pools,
         logits_metadata: LogitsMetadata,
     ):
-        begin_forward(
-            "prefill" if forward_batch.forward_mode.is_prefill() else "decode"
-        )
+        fm = forward_batch.forward_mode
         hidden_states, layers_kv_fused, layers_recurrent_state, layers_topk_ids = self.model(
             forward_batch,
             memory_pools,
@@ -617,7 +617,7 @@ class KimiLinearForCausalLM(nnx.Module):
             output = self.logits_processor(hidden_states, self.lm_head, logits_metadata)
         else:
             output = self.logits_processor(hidden_states, self.model.embed_tokens, logits_metadata)
-        dump_array("logits", output.next_token_logits)
+        dump_array("logits", output.next_token_logits, fm)
         return (
             output,
             {

--- a/python/sgl_jax/srt/models/kimi_linear.py
+++ b/python/sgl_jax/srt/models/kimi_linear.py
@@ -475,6 +475,7 @@ class KimiDecoderLayer(nnx.Module):
 
             if shared_output is not None:
                 hidden_states = hidden_states + shared_output
+                dump_array(f"{tag}_moe_plus_shared_experts", hidden_states)
         else:
             hidden_states = self.mlp(hidden_states)
             dump_array(f"{tag}_mlp", hidden_states)

--- a/python/sgl_jax/srt/models/kimi_linear.py
+++ b/python/sgl_jax/srt/models/kimi_linear.py
@@ -34,8 +34,10 @@ class KimiMLP(nnx.Module):
         intermediate_size: int,
         mesh: jax.sharding.Mesh,
         dtype: jnp.dtype = jnp.bfloat16,
+        dump_prefix: str = "",
     ):
         super().__init__()
+        self.dump_prefix = dump_prefix
         self.gate_proj = LinearBase(
             input_size=hidden_size,
             output_size=intermediate_size,
@@ -64,10 +66,21 @@ class KimiMLP(nnx.Module):
             scope_name="down_proj",
         )
 
-    def __call__(self, hidden_states: jax.Array) -> jax.Array:
+    def __call__(self, hidden_states: jax.Array, forward_mode=None) -> jax.Array:
+        p = self.dump_prefix
+        dump_array(f"{p}_inputs", hidden_states, forward_mode)
         gate, _ = self.gate_proj(hidden_states)
+        dump_array(f"{p}_gate_proj_out", gate, forward_mode)
         up, _ = self.up_proj(hidden_states)
-        output, _ = self.down_proj(jax.nn.silu(gate) * up)
+        dump_array(f"{p}_up_proj_out", up, forward_mode)
+        # GPU equivalent: fused gate_up_proj.output = concat([gate, up], -1)
+        dump_array(
+            f"{p}_gate_up_proj_out", jnp.concatenate([gate, up], axis=-1), forward_mode
+        )
+        act = jax.nn.silu(gate) * up
+        dump_array(f"{p}_act_fn_out", act, forward_mode)
+        output, _ = self.down_proj(act)
+        dump_array(f"{p}_down_proj_out", output, forward_mode)
         return output
 
 
@@ -248,31 +261,69 @@ class KimiDeltaAttention(nnx.Module):
         recurrent_state_pool,
     ) -> tuple[jax.Array, object]:
         del positions
+        fm = forward_batch.forward_mode
+        p = f"layer_{self.layer_idx:02d}_self_attn"
+
+        dump_array(f"{p}_inputs_hidden_states", hidden_states, fm)
 
         q, _ = self.q_proj(hidden_states)
         k, _ = self.k_proj(hidden_states)
         v, _ = self.v_proj(hidden_states)
+        dump_array(f"{p}_q_proj_out", q, fm)
+        dump_array(f"{p}_k_proj_out", k, fm)
+        dump_array(f"{p}_v_proj_out", v, fm)
 
-        raw_gate, _ = self.f_b_proj(self.f_a_proj(hidden_states)[0])
-        raw_gate = raw_gate.reshape(hidden_states.shape[0], self.num_heads, self.head_dim)
-        beta = jax.nn.sigmoid(self.b_proj(hidden_states)[0].astype(jnp.float32))
+        f_a_out, _ = self.f_a_proj(hidden_states)
+        dump_array(f"{p}_f_a_proj_out", f_a_out, fm)
+        raw_gate, _ = self.f_b_proj(f_a_out)
+        dump_array(f"{p}_f_b_proj_out", raw_gate, fm)
+        raw_gate_3d = raw_gate.reshape(hidden_states.shape[0], self.num_heads, self.head_dim)
+
+        b_out, _ = self.b_proj(hidden_states)
+        dump_array(f"{p}_b_proj_out", b_out, fm)
+        beta = jax.nn.sigmoid(b_out.astype(jnp.float32))
+
+        g_a, _ = self.g_a_proj(hidden_states)
+        dump_array(f"{p}_g_a_proj_out", g_a, fm)
+
+        # GPU equivalent: fused_qkvbfg_a_proj.output = concat([Q, K, V, B, F_a, G_a], -1)
+        dump_array(
+            f"{p}_fused_qkvbfg_a_proj_out",
+            jnp.concatenate([q, k, v, b_out, f_a_out, g_a], axis=-1),
+            fm,
+        )
 
         o, recurrent_state_pool = self.attn(
             forward_batch,
             q,
             k,
             v,
-            raw_gate,
+            raw_gate_3d,
             beta,
             recurrent_state_pool,
         )
+        dump_array(f"{p}_attn_kernel_out", o, fm)
         o = o.reshape(hidden_states.shape[0], self.num_heads, self.head_dim)
 
-        g_a, _ = self.g_a_proj(hidden_states)
         output_gate, _ = self.g_b_proj(g_a)
-        output_gate = output_gate.reshape(hidden_states.shape[0], self.num_heads, self.head_dim)
-        o = self.o_norm(o, output_gate).reshape(hidden_states.shape[0], self.projection_size)
+        dump_array(f"{p}_g_b_proj_out", output_gate, fm)
+
+        # GPU equivalent: fused_fg_b_proj.output = concat([F_b, G_b], -1)
+        dump_array(
+            f"{p}_fused_fg_b_proj_out",
+            jnp.concatenate([raw_gate, output_gate], axis=-1),
+            fm,
+        )
+
+        output_gate_3d = output_gate.reshape(
+            hidden_states.shape[0], self.num_heads, self.head_dim
+        )
+        o_normed = self.o_norm(o, output_gate_3d)
+        dump_array(f"{p}_o_norm_out", o_normed, fm)
+        o = o_normed.reshape(hidden_states.shape[0], self.projection_size)
+        dump_array(f"{p}_o_proj_in", o, fm)
         o, _ = self.o_proj(o)
+        dump_array(f"{p}_o_proj_out", o, fm)
 
         return o, recurrent_state_pool
 
@@ -330,6 +381,7 @@ class KimiDecoderLayer(nnx.Module):
                 intermediate_size=config.intermediate_size,
                 mesh=mesh,
                 dtype=dtype,
+                dump_prefix=f"layer_{layer_idx:02d}_mlp",
             )
             self.moe_gate = None
         else:
@@ -392,6 +444,7 @@ class KimiDecoderLayer(nnx.Module):
                     intermediate_size=config.moe_intermediate_size * config.num_shared_experts,
                     mesh=mesh,
                     dtype=dtype,
+                    dump_prefix=f"layer_{layer_idx:02d}_shared_experts",
                 )
             else:
                 self.shared_experts = None
@@ -420,6 +473,10 @@ class KimiDecoderLayer(nnx.Module):
     ):
         tag = f"layer_{self.layer_idx:02d}"
         fm = forward_batch.forward_mode
+
+        dump_array(f"{tag}_inputs_hidden_states", hidden_states, fm)
+        if residual is not None:
+            dump_array(f"{tag}_inputs_residual", residual, fm)
 
         # Pre-norm residual pattern
         if residual is None:
@@ -453,7 +510,7 @@ class KimiDecoderLayer(nnx.Module):
         # MLP (MoE or dense)
         if self.is_moe_layer:
             if self.shared_experts is not None:
-                shared_output = self.shared_experts(hidden_states)
+                shared_output = self.shared_experts(hidden_states, fm)
                 dump_array(f"{tag}_shared_experts", shared_output, fm)
             else:
                 shared_output = None
@@ -478,7 +535,7 @@ class KimiDecoderLayer(nnx.Module):
                 hidden_states = hidden_states + shared_output
                 dump_array(f"{tag}_moe_plus_shared_experts", hidden_states, fm)
         else:
-            hidden_states = self.mlp(hidden_states)
+            hidden_states = self.mlp(hidden_states, fm)
             dump_array(f"{tag}_mlp", hidden_states, fm)
             topk_ids = None
 

--- a/python/sgl_jax/srt/models/kimi_linear.py
+++ b/python/sgl_jax/srt/models/kimi_linear.py
@@ -30,10 +30,10 @@ logger = logging.getLogger(__name__)
 def _replicate_for_dump(x: jax.Array, mesh: jax.sharding.Mesh) -> jax.Array:
     """Force ``x`` to a fully-replicated sharding so heterogeneously-sharded
     operands (e.g. tensor-sharded q/k/v vs replicated f_a/g_a) can be
-    concatenated for the GPU-style fused-proj dumps. ``mesh`` must be the
-    same mesh used to build the module (tracer.sharding is unavailable
-    under explicit-sharding jit, so we pass it explicitly)."""
-    return jax.lax.with_sharding_constraint(
+    concatenated for the GPU-style fused-proj dumps. Uses
+    ``jax.sharding.reshard`` because ``with_sharding_constraint`` degrades
+    to a same-sharding assertion under fully explicit-sharding meshes."""
+    return jax.sharding.reshard(
         x, jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
     )
 

--- a/python/sgl_jax/srt/models/kimi_linear.py
+++ b/python/sgl_jax/srt/models/kimi_linear.py
@@ -21,10 +21,19 @@ from sgl_jax.srt.layers.moe import EPMoE, create_moe_weights_mapping
 from sgl_jax.srt.layers.radix_linear_attention import RadixLinearAttention
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
 from sgl_jax.srt.models.deepseek_v3 import DeepseekV3Attention as KimiMLAAttention
-from sgl_jax.srt.utils.debug_utils import dump_array
+from sgl_jax.srt.utils.debug_utils import dump_array, is_dump_enabled
 from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
 
 logger = logging.getLogger(__name__)
+
+
+def _replicate_for_dump(x: jax.Array) -> jax.Array:
+    """Force ``x`` to a fully-replicated sharding so heterogeneously-sharded
+    operands (e.g. tensor-sharded q/k/v vs replicated f_a/g_a) can be
+    concatenated for the GPU-style fused-proj dumps."""
+    return jax.lax.with_sharding_constraint(
+        x, jax.sharding.NamedSharding(x.sharding.mesh, jax.sharding.PartitionSpec())
+    )
 
 
 class KimiMLP(nnx.Module):
@@ -74,9 +83,14 @@ class KimiMLP(nnx.Module):
         up, _ = self.up_proj(hidden_states)
         dump_array(f"{p}_up_proj_out", up, forward_mode)
         # GPU equivalent: fused gate_up_proj.output = concat([gate, up], -1)
-        dump_array(
-            f"{p}_gate_up_proj_out", jnp.concatenate([gate, up], axis=-1), forward_mode
-        )
+        if is_dump_enabled():
+            dump_array(
+                f"{p}_gate_up_proj_out",
+                jnp.concatenate(
+                    [_replicate_for_dump(gate), _replicate_for_dump(up)], axis=-1
+                ),
+                forward_mode,
+            )
         act = jax.nn.silu(gate) * up
         dump_array(f"{p}_act_fn_out", act, forward_mode)
         output, _ = self.down_proj(act)
@@ -287,11 +301,22 @@ class KimiDeltaAttention(nnx.Module):
         dump_array(f"{p}_g_a_proj_out", g_a, fm)
 
         # GPU equivalent: fused_qkvbfg_a_proj.output = concat([Q, K, V, B, F_a, G_a], -1)
-        dump_array(
-            f"{p}_fused_qkvbfg_a_proj_out",
-            jnp.concatenate([q, k, v, b_out, f_a_out, g_a], axis=-1),
-            fm,
-        )
+        if is_dump_enabled():
+            dump_array(
+                f"{p}_fused_qkvbfg_a_proj_out",
+                jnp.concatenate(
+                    [
+                        _replicate_for_dump(q),
+                        _replicate_for_dump(k),
+                        _replicate_for_dump(v),
+                        _replicate_for_dump(b_out),
+                        _replicate_for_dump(f_a_out),
+                        _replicate_for_dump(g_a),
+                    ],
+                    axis=-1,
+                ),
+                fm,
+            )
 
         o, recurrent_state_pool = self.attn(
             forward_batch,
@@ -309,11 +334,15 @@ class KimiDeltaAttention(nnx.Module):
         dump_array(f"{p}_g_b_proj_out", output_gate, fm)
 
         # GPU equivalent: fused_fg_b_proj.output = concat([F_b, G_b], -1)
-        dump_array(
-            f"{p}_fused_fg_b_proj_out",
-            jnp.concatenate([raw_gate, output_gate], axis=-1),
-            fm,
-        )
+        if is_dump_enabled():
+            dump_array(
+                f"{p}_fused_fg_b_proj_out",
+                jnp.concatenate(
+                    [_replicate_for_dump(raw_gate), _replicate_for_dump(output_gate)],
+                    axis=-1,
+                ),
+                fm,
+            )
 
         output_gate_3d = output_gate.reshape(
             hidden_states.shape[0], self.num_heads, self.head_dim

--- a/python/sgl_jax/srt/utils/debug_utils.py
+++ b/python/sgl_jax/srt/utils/debug_utils.py
@@ -57,6 +57,13 @@ def _dump_dir() -> Path | None:
     return Path(raw) if raw else None
 
 
+def is_dump_enabled() -> bool:
+    """True when SGL_DUMP_DIR is set. Use at call sites to gate any extra
+    array construction (e.g. fused-proj concats) so unused work is never
+    traced when dumping is off."""
+    return _dump_dir() is not None
+
+
 def _local_device_count() -> int:
     global _local_dev_n
     if _local_dev_n is None:

--- a/python/sgl_jax/srt/utils/debug_utils.py
+++ b/python/sgl_jax/srt/utils/debug_utils.py
@@ -3,13 +3,22 @@
 Set ``SGL_DUMP_DIR`` to enable dumping; unset/empty disables it at trace time
 so there is zero runtime overhead in production.
 
-Each forward writes into a per-mode subdir, automatically rolled by a host
-counter every time ``begin_forward`` is called::
+Each forward writes into a per-mode subdir (``prefill`` / ``decode_1`` /
+``decode_2``...) auto-derived from a host-side per-tag counter. No explicit
+"begin forward" call is required — each ``dump_array`` invocation carries
+``forward_mode`` (or a mode-string) so the bucket can be computed independently.
+
+Multi-device caveat: ``jax.debug.callback`` does not support ``ordered=True``
+when the jit runs on more than one device, so callbacks fire **once per local
+device** with no inter-callback ordering guarantee. The host computes
+``forward_idx`` and ``shard_idx`` from the per-tag counter divided by the
+local device count, which is robust to interleaving::
 
     SGL_DUMP_DIR/
         prefill/
-            embed_tokens_p0_i0000.npy
-            layer_00_input_layernorm_p0_i0000.npy
+            embed_tokens_p0_s0.npy        # shard 0
+            embed_tokens_p0_s1.npy        # shard 1, ...
+            layer_00_attn_out_p0_s0.npy
             ...
         decode_1/
             ...
@@ -18,13 +27,11 @@ counter every time ``begin_forward`` is called::
 
 Usage inside a jitted model::
 
-    from sgl_jax.srt.utils.debug_utils import begin_forward, dump_array
+    from sgl_jax.srt.utils.debug_utils import dump_array
 
     def __call__(self, forward_batch, ...):
-        begin_forward("prefill" if forward_batch.forward_mode.is_prefill()
-                      else "decode")
         x = self.embed(forward_batch.input_ids)
-        dump_array("embed_tokens", x)
+        dump_array("embed_tokens", x, forward_batch.forward_mode)
         ...
 """
 
@@ -40,9 +47,8 @@ import numpy as np
 
 _DUMP_DIR_ENV = "SGL_DUMP_DIR"
 _lock = threading.Lock()
-_tag_counter: dict[str, int] = {}
-_mode_counter: dict[str, int] = {}
-_current_subdir: str | None = None
+_tag_counter: dict[tuple[str, str], int] = {}
+_local_dev_n: int | None = None
 
 
 def _dump_dir() -> Path | None:
@@ -50,40 +56,56 @@ def _dump_dir() -> Path | None:
     return Path(raw) if raw else None
 
 
-def _format_subdir(mode_kind: str, idx: int) -> str:
-    # idx is 1-based. Match user-requested layout: "prefill" (no suffix on
-    # first occurrence) and "decode_1", "decode_2", ...
-    if mode_kind == "prefill" and idx == 1:
+def _local_device_count() -> int:
+    global _local_dev_n
+    if _local_dev_n is None:
+        try:
+            _local_dev_n = max(1, jax.local_device_count())
+        except Exception:
+            _local_dev_n = 1
+    return _local_dev_n
+
+
+def _resolve_mode_kind(forward_mode) -> str:
+    if forward_mode is None:
+        return "default"
+    if isinstance(forward_mode, str):
+        return forward_mode
+    if hasattr(forward_mode, "is_prefill"):
+        return "prefill" if forward_mode.is_prefill() else "decode"
+    return str(forward_mode)
+
+
+def _format_subdir(mode_kind: str, forward_idx: int) -> str:
+    # Match user-requested layout: "prefill" (no suffix on first occurrence)
+    # and "decode_1", "decode_2", ...
+    if mode_kind == "prefill" and forward_idx == 1:
         return "prefill"
-    return f"{mode_kind}_{idx}"
+    return f"{mode_kind}_{forward_idx}"
 
 
-def _host_begin_forward(mode_kind: str) -> None:
-    global _current_subdir
-    with _lock:
-        idx = _mode_counter.get(mode_kind, 0) + 1
-        _mode_counter[mode_kind] = idx
-        _tag_counter.clear()
-        _current_subdir = _format_subdir(mode_kind, idx)
-
-
-def _host_save(tag: str, summary: bool, array: np.ndarray) -> None:
+def _host_save(tag: str, mode_kind: str, summary: bool, array: np.ndarray) -> None:
     out_dir = _dump_dir()
     if out_dir is None:
         return
-    sub = _current_subdir or "default"
+    n = _local_device_count()
+    with _lock:
+        key = (tag, mode_kind)
+        idx = _tag_counter.get(key, 0)
+        _tag_counter[key] = idx + 1
+    forward_idx = idx // n + 1
+    shard_idx = idx % n
+    sub = _format_subdir(mode_kind, forward_idx)
     full_dir = out_dir / sub
     full_dir.mkdir(parents=True, exist_ok=True)
-    with _lock:
-        idx = _tag_counter.get(tag, 0)
-        _tag_counter[tag] = idx + 1
     proc = jax.process_index()
-    path = full_dir / f"{tag}_p{proc}_i{idx:04d}.npy"
+    path = full_dir / f"{tag}_p{proc}_s{shard_idx}.npy"
     np.save(path, array)
     if summary:
-        n_nan = int(np.isnan(array).sum()) if np.issubdtype(array.dtype, np.floating) else 0
-        n_inf = int(np.isinf(array).sum()) if np.issubdtype(array.dtype, np.floating) else 0
-        finite = np.isfinite(array) if np.issubdtype(array.dtype, np.floating) else None
+        is_float = np.issubdtype(array.dtype, np.floating)
+        n_nan = int(np.isnan(array).sum()) if is_float else 0
+        n_inf = int(np.isinf(array).sum()) if is_float else 0
+        finite = np.isfinite(array) if is_float else None
         if finite is not None and finite.any():
             vals = array[finite].astype(np.float32)
             stats = (
@@ -101,44 +123,38 @@ def _host_save(tag: str, summary: bool, array: np.ndarray) -> None:
         )
 
 
-def begin_forward(mode_kind: str, *, ordered: bool = True) -> None:
-    """Roll the per-mode counter and switch to a fresh subdir for this forward.
-
-    Call once at the top of the model's ``__call__``. ``mode_kind`` should be
-    a short string like ``"prefill"`` or ``"decode"``. The host counter
-    derives the actual subdir name (``prefill``, ``decode_1``, ``decode_2`` ...).
-
-    No-op if ``SGL_DUMP_DIR`` is unset (decided at trace time).
-    """
-    if _dump_dir() is None:
-        return
-    jax.debug.callback(_host_begin_forward, mode_kind, ordered=ordered)
-
-
 def dump_array(
     tag: str,
     array,
+    forward_mode=None,
     *,
     summary: bool = True,
     gather: bool = False,
-    ordered: bool = True,
 ) -> None:
     """Dump a (possibly sharded) array to disk from inside jit.
 
-    Files land under ``$SGL_DUMP_DIR/<subdir>/<tag>_p<process>_i<NNNN>.npy``,
-    where ``<subdir>`` is set by the most recent :func:`begin_forward` call.
+    Files land under ``$SGL_DUMP_DIR/<subdir>/<tag>_p<process>_s<shard>.npy``.
+    The subdir is derived from ``forward_mode`` plus a host counter that
+    advances every time the same tag is dumped; once the counter wraps past
+    the local device count, ``forward_idx`` increments and a new subdir is
+    used.
 
     Args:
-        tag: Logical name; used in the filename and to sequence repeated dumps.
-        array: jax array. Sharded arrays dump per-process local shards by
-            default; set ``gather=True`` to first replicate.
-        summary: Print a one-line min/max/nan summary alongside the file write.
-        gather: Replicate to a fully-replicated layout before dumping. Requires
-            being inside a mesh context.
-        ordered: Pass through to ``jax.debug.callback`` to preserve order.
+        tag: Logical name; used in the filename and to sequence dumps.
+        array: jax array. Sharded arrays dump per-shard local data by default;
+            set ``gather=True`` to first replicate (single content per shard).
+        forward_mode: A ``ForwardMode`` enum (must expose ``is_prefill()``),
+            a string like ``"prefill"`` / ``"decode"``, or ``None`` (bucket
+            is named ``"default"``). Pass ``forward_batch.forward_mode`` from
+            inside the model for automatic ``prefill`` / ``decode_N`` buckets.
+        summary: Print a one-line min/max/nan summary per file.
+        gather: Replicate to a fully-replicated layout before dumping.
+            Requires being inside a mesh context.
     """
     if _dump_dir() is None:
         return
+
+    mode_kind = _resolve_mode_kind(forward_mode)
 
     if gather and hasattr(array, "sharding") and hasattr(array.sharding, "mesh"):
         replicated = jax.sharding.NamedSharding(
@@ -147,13 +163,12 @@ def dump_array(
         array = jax.lax.with_sharding_constraint(array, replicated)
 
     array = jnp.asarray(array)
-    jax.debug.callback(_host_save, tag, summary, array, ordered=ordered)
+    # ordered=False is required: ordered debug effects raise
+    # `ValueError: ordered effects are not supported for more than 1 device`.
+    jax.debug.callback(_host_save, tag, mode_kind, summary, array, ordered=False)
 
 
 def reset_dump_state() -> None:
-    """Reset all host-side counters and current subdir. For tests."""
-    global _current_subdir
+    """Reset all host-side counters. For tests."""
     with _lock:
         _tag_counter.clear()
-        _mode_counter.clear()
-        _current_subdir = None

--- a/python/sgl_jax/srt/utils/debug_utils.py
+++ b/python/sgl_jax/srt/utils/debug_utils.py
@@ -49,6 +49,7 @@ _DUMP_DIR_ENV = "SGL_DUMP_DIR"
 _lock = threading.Lock()
 _tag_counter: dict[tuple[str, str], int] = {}
 _local_dev_n: int | None = None
+_warmup_complete: bool = False
 
 
 def _dump_dir() -> Path | None:
@@ -87,6 +88,11 @@ def _format_subdir(mode_kind: str, forward_idx: int) -> str:
 def _host_save(tag: str, mode_kind: str, summary: bool, array: np.ndarray) -> None:
     out_dir = _dump_dir()
     if out_dir is None:
+        return
+    if not _warmup_complete:
+        # Precompile / warmup pass: callback fires but we drop the write so
+        # the real first forward starts from idx 0 (subdir "prefill" /
+        # "decode_1") instead of being shifted by the precompile count.
         return
     n = _local_device_count()
     with _lock:
@@ -170,5 +176,23 @@ def dump_array(
 
 def reset_dump_state() -> None:
     """Reset all host-side counters. For tests."""
+    global _warmup_complete
     with _lock:
         _tag_counter.clear()
+        _warmup_complete = False
+
+
+def mark_warmup_complete() -> None:
+    """Signal that precompile / warmup is done. Until this is called,
+    ``dump_array`` callbacks still fire but the host drops every write, so
+    precompile forwards do not consume the ``prefill`` / ``decode_N`` slots.
+    On call, per-tag counters are cleared so the first real forward starts
+    at ``forward_idx = 1``.
+
+    Hook point: call once at the end of ``tp_worker.run_precompile()``.
+    Idempotent.
+    """
+    global _warmup_complete
+    with _lock:
+        _tag_counter.clear()
+        _warmup_complete = True

--- a/python/sgl_jax/srt/utils/debug_utils.py
+++ b/python/sgl_jax/srt/utils/debug_utils.py
@@ -1,0 +1,159 @@
+"""Debug helpers for dumping intermediate arrays from inside jit.
+
+Set ``SGL_DUMP_DIR`` to enable dumping; unset/empty disables it at trace time
+so there is zero runtime overhead in production.
+
+Each forward writes into a per-mode subdir, automatically rolled by a host
+counter every time ``begin_forward`` is called::
+
+    SGL_DUMP_DIR/
+        prefill/
+            embed_tokens_p0_i0000.npy
+            layer_00_input_layernorm_p0_i0000.npy
+            ...
+        decode_1/
+            ...
+        decode_2/
+            ...
+
+Usage inside a jitted model::
+
+    from sgl_jax.srt.utils.debug_utils import begin_forward, dump_array
+
+    def __call__(self, forward_batch, ...):
+        begin_forward("prefill" if forward_batch.forward_mode.is_prefill()
+                      else "decode")
+        x = self.embed(forward_batch.input_ids)
+        dump_array("embed_tokens", x)
+        ...
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+_DUMP_DIR_ENV = "SGL_DUMP_DIR"
+_lock = threading.Lock()
+_tag_counter: dict[str, int] = {}
+_mode_counter: dict[str, int] = {}
+_current_subdir: str | None = None
+
+
+def _dump_dir() -> Path | None:
+    raw = os.environ.get(_DUMP_DIR_ENV, "").strip()
+    return Path(raw) if raw else None
+
+
+def _format_subdir(mode_kind: str, idx: int) -> str:
+    # idx is 1-based. Match user-requested layout: "prefill" (no suffix on
+    # first occurrence) and "decode_1", "decode_2", ...
+    if mode_kind == "prefill" and idx == 1:
+        return "prefill"
+    return f"{mode_kind}_{idx}"
+
+
+def _host_begin_forward(mode_kind: str) -> None:
+    global _current_subdir
+    with _lock:
+        idx = _mode_counter.get(mode_kind, 0) + 1
+        _mode_counter[mode_kind] = idx
+        _tag_counter.clear()
+        _current_subdir = _format_subdir(mode_kind, idx)
+
+
+def _host_save(tag: str, summary: bool, array: np.ndarray) -> None:
+    out_dir = _dump_dir()
+    if out_dir is None:
+        return
+    sub = _current_subdir or "default"
+    full_dir = out_dir / sub
+    full_dir.mkdir(parents=True, exist_ok=True)
+    with _lock:
+        idx = _tag_counter.get(tag, 0)
+        _tag_counter[tag] = idx + 1
+    proc = jax.process_index()
+    path = full_dir / f"{tag}_p{proc}_i{idx:04d}.npy"
+    np.save(path, array)
+    if summary:
+        n_nan = int(np.isnan(array).sum()) if np.issubdtype(array.dtype, np.floating) else 0
+        n_inf = int(np.isinf(array).sum()) if np.issubdtype(array.dtype, np.floating) else 0
+        finite = np.isfinite(array) if np.issubdtype(array.dtype, np.floating) else None
+        if finite is not None and finite.any():
+            vals = array[finite].astype(np.float32)
+            stats = (
+                f"min={vals.min():.6g} max={vals.max():.6g} "
+                f"mean={vals.mean():.6g} absmax={np.abs(vals).max():.6g}"
+            )
+        elif finite is None:
+            stats = f"int min={int(array.min())} max={int(array.max())}"
+        else:
+            stats = "all non-finite"
+        print(
+            f"[dump:{sub}] {path.name} shape={array.shape} dtype={array.dtype} "
+            f"nan={n_nan} inf={n_inf} {stats}",
+            flush=True,
+        )
+
+
+def begin_forward(mode_kind: str, *, ordered: bool = True) -> None:
+    """Roll the per-mode counter and switch to a fresh subdir for this forward.
+
+    Call once at the top of the model's ``__call__``. ``mode_kind`` should be
+    a short string like ``"prefill"`` or ``"decode"``. The host counter
+    derives the actual subdir name (``prefill``, ``decode_1``, ``decode_2`` ...).
+
+    No-op if ``SGL_DUMP_DIR`` is unset (decided at trace time).
+    """
+    if _dump_dir() is None:
+        return
+    jax.debug.callback(_host_begin_forward, mode_kind, ordered=ordered)
+
+
+def dump_array(
+    tag: str,
+    array,
+    *,
+    summary: bool = True,
+    gather: bool = False,
+    ordered: bool = True,
+) -> None:
+    """Dump a (possibly sharded) array to disk from inside jit.
+
+    Files land under ``$SGL_DUMP_DIR/<subdir>/<tag>_p<process>_i<NNNN>.npy``,
+    where ``<subdir>`` is set by the most recent :func:`begin_forward` call.
+
+    Args:
+        tag: Logical name; used in the filename and to sequence repeated dumps.
+        array: jax array. Sharded arrays dump per-process local shards by
+            default; set ``gather=True`` to first replicate.
+        summary: Print a one-line min/max/nan summary alongside the file write.
+        gather: Replicate to a fully-replicated layout before dumping. Requires
+            being inside a mesh context.
+        ordered: Pass through to ``jax.debug.callback`` to preserve order.
+    """
+    if _dump_dir() is None:
+        return
+
+    if gather and hasattr(array, "sharding") and hasattr(array.sharding, "mesh"):
+        replicated = jax.sharding.NamedSharding(
+            array.sharding.mesh, jax.sharding.PartitionSpec()
+        )
+        array = jax.lax.with_sharding_constraint(array, replicated)
+
+    array = jnp.asarray(array)
+    jax.debug.callback(_host_save, tag, summary, array, ordered=ordered)
+
+
+def reset_dump_state() -> None:
+    """Reset all host-side counters and current subdir. For tests."""
+    global _current_subdir
+    with _lock:
+        _tag_counter.clear()
+        _mode_counter.clear()
+        _current_subdir = None

--- a/python/sgl_jax/srt/utils/debug_utils.py
+++ b/python/sgl_jax/srt/utils/debug_utils.py
@@ -8,21 +8,21 @@ Each forward writes into a per-mode subdir (``prefill`` / ``decode_1`` /
 "begin forward" call is required — each ``dump_array`` invocation carries
 ``forward_mode`` (or a mode-string) so the bucket can be computed independently.
 
-Multi-device caveat: ``jax.debug.callback`` does not support ``ordered=True``
-when the jit runs on more than one device, so callbacks fire **once per local
-device** with no inter-callback ordering guarantee. The host computes
-``forward_idx`` and ``shard_idx`` from the per-tag counter divided by the
-local device count, which is robust to interleaving::
+Under SPMD jit each program-level ``dump_array`` call fires the host
+callback exactly once per process (the array is gathered to host before
+the callback runs), so the per-tag counter advances by 1 per forward and
+``forward_idx = counter + 1`` directly. Each process writes one file per
+forward::
 
     SGL_DUMP_DIR/
         prefill/
-            embed_tokens_p0_s0.npy        # shard 0
-            embed_tokens_p0_s1.npy        # shard 1, ...
-            layer_00_attn_out_p0_s0.npy
+            embed_tokens_p0.npy
+            layer_00_attn_out_p0.npy
             ...
         decode_1/
             ...
         decode_2/
+            ...
             ...
 
 Usage inside a jitted model::
@@ -48,7 +48,6 @@ import numpy as np
 _DUMP_DIR_ENV = "SGL_DUMP_DIR"
 _lock = threading.Lock()
 _tag_counter: dict[tuple[str, str], int] = {}
-_local_dev_n: int | None = None
 _warmup_complete: bool = False
 
 
@@ -62,16 +61,6 @@ def is_dump_enabled() -> bool:
     array construction (e.g. fused-proj concats) so unused work is never
     traced when dumping is off."""
     return _dump_dir() is not None
-
-
-def _local_device_count() -> int:
-    global _local_dev_n
-    if _local_dev_n is None:
-        try:
-            _local_dev_n = max(1, jax.local_device_count())
-        except Exception:
-            _local_dev_n = 1
-    return _local_dev_n
 
 
 def _resolve_mode_kind(forward_mode) -> str:
@@ -98,21 +87,24 @@ def _host_save(tag: str, mode_kind: str, summary: bool, array: np.ndarray) -> No
         return
     if not _warmup_complete:
         # Precompile / warmup pass: callback fires but we drop the write so
-        # the real first forward starts from idx 0 (subdir "prefill" /
-        # "decode_1") instead of being shifted by the precompile count.
+        # the real first forward starts from forward_idx 1 instead of being
+        # shifted by the precompile count.
         return
-    n = _local_device_count()
     with _lock:
         key = (tag, mode_kind)
         idx = _tag_counter.get(key, 0)
         _tag_counter[key] = idx + 1
-    forward_idx = idx // n + 1
-    shard_idx = idx % n
+    # Under SPMD jit each program-level dump_array call fires the host
+    # callback exactly once per process (the array is gathered to host
+    # before the callback runs), so the per-tag counter advances by 1 per
+    # forward and `idx + 1` is the forward index directly. No shard split
+    # in the filename: each process writes one file per forward.
+    forward_idx = idx + 1
     sub = _format_subdir(mode_kind, forward_idx)
     full_dir = out_dir / sub
     full_dir.mkdir(parents=True, exist_ok=True)
     proc = jax.process_index()
-    path = full_dir / f"{tag}_p{proc}_s{shard_idx}.npy"
+    path = full_dir / f"{tag}_p{proc}.npy"
     np.save(path, array)
     if summary:
         is_float = np.issubdtype(array.dtype, np.floating)
@@ -146,16 +138,17 @@ def dump_array(
 ) -> None:
     """Dump a (possibly sharded) array to disk from inside jit.
 
-    Files land under ``$SGL_DUMP_DIR/<subdir>/<tag>_p<process>_s<shard>.npy``.
-    The subdir is derived from ``forward_mode`` plus a host counter that
-    advances every time the same tag is dumped; once the counter wraps past
-    the local device count, ``forward_idx`` increments and a new subdir is
-    used.
+    Files land under ``$SGL_DUMP_DIR/<subdir>/<tag>_p<process>.npy``. The
+    subdir is derived from ``forward_mode`` plus a host counter that
+    advances every time the same tag is dumped (one increment per
+    program-level forward).
 
     Args:
         tag: Logical name; used in the filename and to sequence dumps.
-        array: jax array. Sharded arrays dump per-shard local data by default;
-            set ``gather=True`` to first replicate (single content per shard).
+        array: jax array. SPMD jit gathers it to host before the callback
+            runs, so each process sees its full local view; on a single
+            process this is the full unsharded tensor. ``gather=True``
+            forces an explicit fully-replicated reshard first.
         forward_mode: A ``ForwardMode`` enum (must expose ``is_prefill()``),
             a string like ``"prefill"`` / ``"decode"``, or ``None`` (bucket
             is named ``"default"``). Pass ``forward_batch.forward_mode`` from


### PR DESCRIPTION
Add a debug_utils helper that uses jax.debug.callback to dump arrays from inside jit, with a per-mode subdir (prefill / decode_1 / decode_2) auto-rolled by a host counter. Activated via SGL_DUMP_DIR env var; no-op at trace time when unset.

Instrument kimi_linear.py with dumps at:
- KimiDecoderLayer: input_layernorm, attn_out, post_attention_layernorm, shared_experts, moe_gate, topk_weights, topk_ids, block_sparse_moe / mlp
- KimiModel: embed_tokens, per-layer output, final norm
- KimiLinearForCausalLM: begin_forward at entry + logits at exit

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
