### PR TITLE
fix(model_runner): fail-fast when hybrid recurrent has 0 full-attention layers

### DIFF
--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -514,6 +514,12 @@ class ModelRunner(BaseModelRunner):
         if has_recurrent_state:
             _enforce_recurrent_state_server_constraints(self.server_args)
             _check_state_to_kv_ratio_for_hybrid(self.server_args.state_to_kv_ratio)
+            if len(recurrent_cfg.full_attention_layer_ids) == 0:
+                raise RuntimeError(
+                    "Hybrid recurrent model has 0 full-attention layers; "
+                    "pure-recurrent inference is not supported. "
+                    "Increase num_hidden_layers."
+                )
             if self.is_hybrid:
                 raise NotImplementedError(
                     "state_to_kv_ratio budget split is implemented for the "

--- a/python/sgl_jax/test/model_executor/test_kv_pool_layer_count.py
+++ b/python/sgl_jax/test/model_executor/test_kv_pool_layer_count.py
@@ -166,6 +166,37 @@ class TestInitMemoryPoolHybridRecurrent(CustomTestCase):
         finally:
             ModelRunner.linear_recurrent_config = original_property
 
+    def test_init_memory_pool_rejects_zero_full_attn_layers(self):
+        """Hybrid recurrent path must fail-fast (not crash with
+        ZeroDivisionError) when full_attention_layer_ids is empty."""
+        linear_attn_config = {
+            "kda_layers": [1, 2, 3],
+            "full_attn_layers": [],
+            "num_heads": 8,
+            "head_dim": 128,
+            "short_conv_kernel_size": 4,
+        }
+        cfg = SimpleNamespace(
+            full_attention_layer_ids=[],
+            linear_attn_config=linear_attn_config,
+            is_linear_attn=True,
+        )
+
+        mesh = _mesh_1()
+        runner = self._make_runner(mesh)
+
+        original_property = ModelRunner.linear_recurrent_config
+        try:
+            ModelRunner.linear_recurrent_config = property(lambda self: cfg)
+            with self.assertRaisesRegex(RuntimeError, "0 full-attention layers"):
+                runner.init_memory_pool(
+                    max_num_reqs=8,
+                    max_total_tokens=4096,
+                    total_device_memory=16 * 1024**3,
+                )
+        finally:
+            ModelRunner.linear_recurrent_config = original_property
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

When a hybrid linear-recurrent model (e.g. Kimi-Linear-48B) is loaded with `num_hidden_layers` truncated below the index of the first full-attention layer in `linear_attn_config`, `init_memory_pool` crashes with an opaque `ZeroDivisionError` and the scheduler process never starts:

```
File "/.../model_runner.py", line 533, in init_memory_pool
    self.max_total_num_tokens = kv_budget // self._compute_cell_size()
ZeroDivisionError: integer division or modulo by zero
```

### Root cause

`KimiLinearConfig.full_attention_layer_ids` enumerates `range(num_hidden_layers)` and checks each index against `linear_attn_config["kda_layers"]`. When `num_hidden_layers` is overridden (via `--model-layer-nums`, `--json-model-override-args`, or a hand-edited `config.json`) to a value where every `(i+1) for i in range(num_hidden_layers)` lands inside `kda_layers`, the resulting list is empty.

`_compute_cell_size()` then multiplies by `num_layers = 0` and returns 0, which feeds the division at line 533.

For Kimi-Linear-48B (full-attention layers at 1-indexed positions `[4, 8, 12, 16, 20, 24, 27]`), any `--model-layer-nums N` with `N <= 3` triggers this.

### Why not support pure-recurrent inference

Pure-recurrent inference (no `token_to_kv_pool`, only `RecurrentStatePool`) is a coherent model concept but is **not** wired up in this code path. Adding it requires changes to `MemoryPools` construction, `attn_backend_wrapper`, and the model `forward` output contract — out of scope for a stability fix. Upstream sglang has the same limitation.

## Modification

Add a fail-fast check at the top of the `has_recurrent_state` branch in `init_memory_pool`. If `len(recurrent_cfg.full_attention_layer_ids) == 0`, raise a `RuntimeError` with a readable message instead of letting the divide-by-zero surface ten lines later.

## Test plan

- [x] Added `test_init_memory_pool_rejects_zero_full_attn_layers` in `python/sgl_jax/test/model_executor/test_kv_pool_layer_count.py`, asserting the new `RuntimeError` is raised when `full_attention_layer_ids = []`.
- [x] Existing 3 cases in the same file still pass.
- [x] Pre-commit hooks (ruff / black / mypy / isort / codespell) pass.

```
$ USE_DEVICE_TYPE=cpu python -m pytest sgl_jax/test/model_executor/test_kv_pool_layer_count.py -v
============================== 4 passed in 26.25s ==============================
```

## Notes

- This is a fix-forward on top of the in-flight `epic/support_kimi_linear` branch and only touches the hybrid recurrent path — no impact on dense / MoE / SWA-hybrid models.
- Drafted because final review and merge into `epic/support_kimi_linear` should not be self-applied — please review before merging.