### PR TITLE
fix(req_to_token_pool): eliminate cross-stream race on chunked prefill

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -750,14 +750,14 @@ class ScheduleBatch:
         """Check if batch is empty (no requests in any DP rank)."""
         return self.batch_size() == 0
 
-    def alloc_req_slots(self, num_reqs: int):
-        req_pool_indices = self.req_to_token_pool.alloc(num_reqs)
+    def alloc_req_slots(self, reqs):
+        req_pool_indices = self.req_to_token_pool.alloc(reqs)
         if req_pool_indices is None:
             raise RuntimeError(
                 "alloc_req_slots runs out of memory. "
                 "Please set a smaller number for `--max-running-requests`. "
                 f"{self.req_to_token_pool.available_size()=}, "
-                f"{num_reqs=}, "
+                f"{len(reqs)=}, "
             )
         return req_pool_indices
 
@@ -904,7 +904,7 @@ class ScheduleBatch:
 
             # Allocate req slots
             bs = len(reqs)
-            req_pool_indices = self.alloc_req_slots(bs)
+            req_pool_indices = self.alloc_req_slots(reqs)
 
             # Init arrays
             input_ids = [r.fill_ids[len(r.prefix_indices) :] for r in reqs]
@@ -921,8 +921,7 @@ class ScheduleBatch:
             # Copy prefix and do some basic check
             extend_input_logprob_token_ids = []
 
-            for i, (req, seq_len, pre_len) in enumerate(zip(reqs, seq_lens, prefix_lens)):
-                req.req_pool_idx = req_pool_indices[i]
+            for req, seq_len, pre_len in zip(reqs, seq_lens, prefix_lens):
                 assert seq_len - pre_len == req.extend_input_len
 
                 prefix_indices = req.prefix_indices
@@ -1261,7 +1260,7 @@ class ScheduleBatch:
                 req.req_pool_idx, : seq_lens_cpu[idx]
             ]
             self.token_to_kv_pool_allocator.free(token_indices, dp_rank)
-            self.req_to_token_pool.free(req.req_pool_idx)
+            self.req_to_token_pool.free(req)
         else:
             last_uncached_pos = (
                 req.last_matched_prefix_len // server_args.page_size
@@ -1270,7 +1269,7 @@ class ScheduleBatch:
                 req.req_pool_idx, last_uncached_pos : seq_lens_cpu[idx]
             ]
             self.token_to_kv_pool_allocator.free(token_indices, dp_rank)
-            self.req_to_token_pool.free(req.req_pool_idx)
+            self.req_to_token_pool.free(req)
 
             # release the last node
             if self.is_hybrid:

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1422,8 +1422,8 @@ class Scheduler(
                 # only finished requests to running_batch.
                 chunked_req_to_exclude[dp_rank] = self.chunked_reqs[dp_rank]
                 self.tree_cache.cache_unfinished_req(self.chunked_reqs[dp_rank])
-                # chunked request keeps its rid but will get a new req_pool_idx
-                self.req_to_token_pool.free(self.chunked_reqs[dp_rank].req_pool_idx)
+                # The chunked req keeps its req_pool_idx across batches; the
+                # next alloc(reqs) reuses the slot in place.
 
         # Merge the prefill batch into the running batch
         if self.last_batch and self.last_batch.forward_mode.is_extend():

--- a/python/sgl_jax/srt/mem_cache/chunk_cache.py
+++ b/python/sgl_jax/srt/mem_cache/chunk_cache.py
@@ -39,7 +39,7 @@ class ChunkCache(BasePrefixCache):
             # For decode server: if req.output_ids is empty, we want to free all req.origin_input_ids
             : len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0),
         ]
-        self.req_to_token_pool.free(req.req_pool_idx)
+        self.req_to_token_pool.free(req)
         self.token_to_kv_pool_allocator.free(
             kv_indices, req.dp_rank if req.dp_rank is not None else 0
         )

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -121,21 +121,39 @@ class ReqToTokenPool:
         """Return number of available request slots"""
         return len(self.free_slots)
 
-    def alloc(self, need_size: int = 1) -> list[int]:
-        """Allocate request slots"""
-        if need_size > len(self.free_slots):
+    def alloc(self, reqs: list) -> list[int] | None:
+        """Allocate request slots for a batch of reqs.
+
+        Reqs whose ``req_pool_idx`` is already non-None keep their slot
+        (in-place reuse for chunked-prefill follow-ups); only reqs without
+        a slot consume from ``free_slots``.
+
+        Atomic: returns None and leaves every req field untouched if the
+        remaining capacity cannot satisfy the fresh allocations.
+        """
+        new_count = sum(1 for r in reqs if r.req_pool_idx is None)
+        if new_count > len(self.free_slots):
             return None
 
-        select_indices = self.free_slots[:need_size]
-        self.free_slots = self.free_slots[need_size:]
-        return select_indices
+        new_slots = self.free_slots[:new_count]
+        self.free_slots = self.free_slots[new_count:]
 
-    def free(self, free_index: int | list[int]):
-        """Free request slots"""
-        if isinstance(free_index, int):
-            self.free_slots.append(free_index)
-        else:
-            self.free_slots.extend(free_index)
+        cursor = 0
+        for r in reqs:
+            if r.req_pool_idx is None:
+                r.req_pool_idx = new_slots[cursor]
+                cursor += 1
+        return [r.req_pool_idx for r in reqs]
+
+    def free(self, req):
+        """Release ``req``'s slot and clear ``req.req_pool_idx``.
+
+        Clearing the field prevents a stale idx from leaking to a later
+        caller after the slot is re-handed.
+        """
+        assert req.req_pool_idx is not None, "double free or free of an unallocated req"
+        self.free_slots.append(req.req_pool_idx)
+        req.req_pool_idx = None
 
     def clear(self):
         """Clear all allocation states"""

--- a/python/sgl_jax/srt/mem_cache/radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/radix_cache.py
@@ -285,7 +285,7 @@ class RadixCache(BasePrefixCache):
             )
             kv_indices = kv_indices[kv_indices != 0]
             self.token_to_kv_pool_allocator.free(kv_indices, dp_rank=dp_rank)
-            self.req_to_token_pool.free(req.req_pool_idx)
+            self.req_to_token_pool.free(req)
             return
 
         token_ids = (req.origin_input_ids + req.output_ids)[:all_token_len]
@@ -323,7 +323,7 @@ class RadixCache(BasePrefixCache):
         self.token_to_kv_pool_allocator.free(kv_indices[page_aligned_len:], dp_rank=dp_rank)
 
         # Remove request slot and release cache lock
-        self.req_to_token_pool.free(req.req_pool_idx)
+        self.req_to_token_pool.free(req)
         self.dec_lock_ref(req.last_node)
 
     def cache_unfinished_req(self, req: Req):

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -400,7 +400,7 @@ class SWARadixCache(BasePrefixCache):
                 : len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0),
             ]
             self.token_to_kv_pool_allocator.free(kv_indices, dp_rank=dp_rank)
-            self.req_to_token_pool.free(req.req_pool_idx)
+            self.req_to_token_pool.free(req)
             return
 
         token_ids = (req.origin_input_ids + req.output_ids)[:-1]
@@ -426,7 +426,7 @@ class SWARadixCache(BasePrefixCache):
         )
 
         # Remove req slot release the cache lock
-        self.req_to_token_pool.free(req.req_pool_idx)
+        self.req_to_token_pool.free(req)
         self.dec_lock_ref(req.last_node, req.swa_uuid_for_lock)
 
     def cache_unfinished_req(self, req: Req, chunked=False) -> None:

--- a/python/sgl_jax/test/mem_cache/test_req_to_token_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_req_to_token_pool.py
@@ -1,0 +1,150 @@
+# cd python && USE_DEVICE_TYPE=cpu python -m pytest sgl_jax/test/mem_cache/test_req_to_token_pool.py -v
+
+import os
+import unittest
+
+if os.environ.get("USE_DEVICE_TYPE") == "cpu":
+    os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+    os.environ["JAX_PLATFORMS"] = "cpu"
+
+import numpy as np
+
+from sgl_jax.srt.mem_cache.memory_pool import ReqToTokenPool
+from sgl_jax.test.test_utils import CustomTestCase
+
+
+class FakeReq:
+    """Minimal Req surrogate exposing only the attributes ReqToTokenPool reads."""
+
+    def __init__(self, req_pool_idx=None):
+        self.req_pool_idx = req_pool_idx
+
+
+class TestReqToTokenPoolAlloc(CustomTestCase):
+    """Contract tests for ReqToTokenPool.alloc(reqs)."""
+
+    def setUp(self):
+        self.pool = ReqToTokenPool(size=4, max_context_len=16, dtype=np.int32)
+
+    def test_alloc_fresh_assigns_indices(self):
+        reqs = [FakeReq(), FakeReq(), FakeReq()]
+        indices = self.pool.alloc(reqs)
+
+        self.assertIsNotNone(indices)
+        self.assertEqual(len(indices), len(reqs))
+        for req, idx in zip(reqs, indices):
+            self.assertIsNotNone(req.req_pool_idx)
+            self.assertEqual(req.req_pool_idx, idx)
+        self.assertEqual(len(set(indices)), len(indices), "indices must be unique")
+        self.assertEqual(self.pool.available_size(), 4 - len(reqs))
+
+    def test_alloc_atomic_on_capacity_miss(self):
+        # Shrink free_slots to two slots so a 3-req batch overflows.
+        self.pool.free_slots = [0, 1]
+        reqs = [FakeReq(), FakeReq(), FakeReq()]
+
+        indices = self.pool.alloc(reqs)
+
+        self.assertIsNone(indices)
+        for req in reqs:
+            self.assertIsNone(req.req_pool_idx, "req fields must stay untouched")
+        self.assertEqual(self.pool.free_slots, [0, 1])
+
+    def test_alloc_mixed_reuse_and_fresh(self):
+        retained = FakeReq(req_pool_idx=0)
+        fresh_a = FakeReq()
+        fresh_b = FakeReq()
+        self.pool.free_slots = [1, 2, 3]
+
+        indices = self.pool.alloc([retained, fresh_a, fresh_b])
+
+        self.assertIsNotNone(indices)
+        self.assertEqual(indices[0], 0)
+        self.assertEqual(retained.req_pool_idx, 0)
+        self.assertEqual(indices[1], 1)
+        self.assertEqual(indices[2], 2)
+        self.assertEqual(fresh_a.req_pool_idx, 1)
+        self.assertEqual(fresh_b.req_pool_idx, 2)
+        self.assertEqual(self.pool.free_slots, [3])
+
+    def test_alloc_atomic_with_partial_reuse(self):
+        retained = FakeReq(req_pool_idx=5)  # outside [0, size); ok for the test
+        # Only one fresh slot left, but two fresh reqs requested -> overflow.
+        self.pool.free_slots = [0]
+        fresh_a = FakeReq()
+        fresh_b = FakeReq()
+
+        indices = self.pool.alloc([retained, fresh_a, fresh_b])
+
+        self.assertIsNone(indices)
+        self.assertEqual(retained.req_pool_idx, 5, "reuse req must stay set")
+        self.assertIsNone(fresh_a.req_pool_idx)
+        self.assertIsNone(fresh_b.req_pool_idx)
+        self.assertEqual(self.pool.free_slots, [0])
+
+
+class TestReqToTokenPoolFree(CustomTestCase):
+    def setUp(self):
+        self.pool = ReqToTokenPool(size=4, max_context_len=16, dtype=np.int32)
+
+    def test_alloc_then_free_then_alloc_roundtrip(self):
+        req = FakeReq()
+        self.pool.alloc([req])
+        idx = req.req_pool_idx
+        self.assertIsNotNone(idx)
+
+        self.pool.free(req)
+        self.assertIsNone(req.req_pool_idx)
+        self.assertIn(idx, self.pool.free_slots, "freed slot must return to the pool")
+
+        # Next alloc must hand out a slot again (any slot - identity not required).
+        self.pool.alloc([req])
+        self.assertIsNotNone(req.req_pool_idx)
+
+    def test_double_free_rejected(self):
+        """Free of a req without a slot must fail loudly, not pollute free_slots."""
+        req = FakeReq()
+        self.pool.alloc([req])
+        self.pool.free(req)
+
+        free_slots_before = list(self.pool.free_slots)
+        with self.assertRaises(AssertionError):
+            self.pool.free(req)
+        self.assertEqual(self.pool.free_slots, free_slots_before)
+
+
+class TestReqToTokenPoolChunkedReqLifecycle(CustomTestCase):
+    """End-to-end lock-in for chunked-req slot ownership across batches."""
+
+    def setUp(self):
+        self.pool = ReqToTokenPool(size=4, max_context_len=16, dtype=np.int32)
+
+    def test_chunked_req_survives_across_batches(self):
+        chunked = FakeReq()
+        peer = FakeReq()
+        self.pool.alloc([chunked, peer])
+        chunked_idx = chunked.req_pool_idx
+        self.assertIsNotNone(chunked_idx)
+        self.assertNotEqual(chunked_idx, peer.req_pool_idx)
+
+        # Scheduler caches the unfinished chunked req without freeing
+        # its slot; the peer finishes and is freed normally.
+        self.pool.free(peer)
+        self.assertIsNone(peer.req_pool_idx)
+
+        # Round 2: chunked req comes back with req_pool_idx still set;
+        # alloc must treat this as in-place reuse, not a fresh alloc.
+        new_peer = FakeReq()
+        indices = self.pool.alloc([chunked, new_peer])
+
+        self.assertIsNotNone(indices)
+        self.assertEqual(
+            chunked.req_pool_idx,
+            chunked_idx,
+            "chunked req must retain its slot across batches",
+        )
+        self.assertNotEqual(new_peer.req_pool_idx, chunked_idx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -453,6 +453,7 @@ suites = {
         TestFile("python/sgl_jax/test/mem_cache/test_radix_cache.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_swa_radix_cache.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_swa_allocator.py", 1),
+        TestFile("python/sgl_jax/test/mem_cache/test_req_to_token_pool.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_paged_allocator_multi_dp.py", 1),
         TestFile("python/sgl_jax/test/speculative/test_eagle_tree_build.py", 1),
         TestFile("python/sgl_jax/test/speculative/test_eagle_utils.py", 1),


### PR DESCRIPTION
## Motivation

Closes the chunked-prefill ownership item in #992 by aligning `ReqToTokenPool` with the upstream sglang fix in https://github.com/sgl-project/sglang/pull/17850 .

Under chunked prefill with the request pool near capacity, the scheduler used to free a chunked request's `req_pool` slot in `get_next_batch_to_run` and rely on the next allocation to hand the slot back. The freed slot could be re-handed to a different request whose matched-prefix indices were then written to the same row of `req_to_token` while the previous batch's forward was still reading that row's host buffer. JAX provides no happen-before between host numpy mutations and an in-flight dispatch, and on the PJRT host-CPU zero-copy path the host write is the device buffer; the result is silent KV gather corruption.

## Modifications

- `ReqToTokenPool.alloc(reqs)` is now req-aware. Reqs whose `req_pool_idx` is already non-None are treated as in-place reuse and do not consume `free_slots`. Atomic on capacity miss: returns `None` and leaves every req field untouched.
- `ReqToTokenPool.free(req)` releases the slot and clears `req.req_pool_idx`, preventing a stale value from leaking to a later caller after the slot has been re-handed.
- The explicit `req_to_token_pool.free(...)` for chunked requests in `Scheduler.get_next_batch_to_run` is removed; the chunked req keeps its `req_pool_idx` and the next `alloc(reqs)` reuses it in place.
- All call sites switch to the req-aware API:
  - `ScheduleBatch.alloc_req_slots(reqs)`
  - `ScheduleBatch.release_req` (retract path, both branches)
  - `ChunkCache.cache_finished_req`
  - `RadixCache.cache_finished_req` (both branches)
  - `SWARadixCache.cache_finished_req` (both branches)
- New unit tests under `python/sgl_jax/test/mem_cache/test_req_to_token_pool.py` lock in: fresh allocation, in-place reuse, atomic capacity miss (with and without partial reuse), free-clears-req-field, alloc/free roundtrip, and end-to-end chunked-req survival across batches. Registered in `test/srt/run_suite.py`.

## Accuracy Tests

N/A — semantics-preserving for non-chunked paths; chunked paths gain slot-ownership stability that the new unit tests cover.

## Benchmarking and Profiling

N/A — perf-neutral by design (one fewer free + alloc pair per chunked batch boundary, slight positive but not measured).

## Checklist

- [x] Format your code (pre-commit run --files passes on all touched files).
- [x] Add unit tests (test_req_to_token_pool.py, registered in run_suite.py).
- [ ] Update documentation - N/A.
- [ ] Provide accuracy and speed benchmark results - N/A (see above).
- [x] Follow the SGLang code style guidance.
- [ ] Work with maintainers to merge your PR.