### PR TITLE
perf(moe): align expert tokens to gmm tile size once upstream

### DIFF
--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -9,6 +9,7 @@ from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.eplb.expert_location import get_global_expert_location_metadata
 from sgl_jax.srt.kernels.gmm.megablox_gmm_backend import gmm
+from sgl_jax.srt.kernels.gmm.megablox_gmm_kernel.gmm_v2 import is_supported_by_gmm_v2
 
 # Re-export for backward compatibility: external code imports from this module.
 from sgl_jax.srt.layers.fused_moe import FusedEPMoE  # noqa: F401
@@ -564,15 +565,24 @@ class EPMoE(nnx.Module):
         else:
             x = inputs_2d[token_indices].astype(self.dtype)
 
-        # TODO(Qinghan): DeepSeek-V2-Lite has num_experts_per_tok=6, so with
-        # the default power-of-2 bs bucketing `padded_bs * 6` can land on a
-        # value > 16 that isn't a multiple of 16 (e.g. bs=4 -> size_m=24),
-        # which is why this padding is necessary. Models with power-of-2
-        # top_k (Grok=2, DeepSeek-V3=8, Qwen3-MoE=8) wouldn't need it.
+        # Pad x once to the GMM kernel's row-tile alignment so the three
+        # downstream gmm() calls (w0, w1, wo via intermediate_layer) all see
+        # aligned m and skip their own pad paths.
+        #
+        # gmm_v2 requires m to be a multiple of 32: out_index_map uses floor
+        # for non-last groups vs cdiv for the last group, which produces NaNs
+        # when intermediate group ends fall on sub-tile boundaries.
+        # gmm_v1 prefers a multiple of 128 to fully utilize the MXU.
+        #
+        # Sublane alignment is also required for the LHS layout (e.g. for
+        # DeepSeek-V2-Lite top_k=6 with bs=4, raw size_m=24 isn't sublane
+        # aligned). The kernel-tile alignments above already cover sublane.
         from jax.experimental.pallas import tpu as pltpu
 
         sublane_align = pltpu.get_tpu_info().get_sublane_tiling(x.dtype)
-        pad_size = (-x.shape[0]) % sublane_align
+        kernel_tile_align = 32 if is_supported_by_gmm_v2(w0_kernel_scale) else 128
+        required_align = max(sublane_align, kernel_tile_align)
+        pad_size = (-x.shape[0]) % required_align
         if pad_size > 0:
             x = jnp.pad(x, ((0, pad_size), (0, 0)))
             group_sizes = group_sizes.at[-1].add(pad_size)

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -580,7 +580,10 @@ class EPMoE(nnx.Module):
         from jax.experimental.pallas import tpu as pltpu
 
         sublane_align = pltpu.get_tpu_info().get_sublane_tiling(x.dtype)
-        kernel_tile_align = 32 if is_supported_by_gmm_v2(w0_kernel_scale) else 128
+        gmm_scales = (w0_kernel_scale, w1_kernel_scale, wo_kernel_scale)
+        kernel_tile_align = (
+            32 if all(is_supported_by_gmm_v2(scale) for scale in gmm_scales) else 128
+        )
         required_align = max(sublane_align, kernel_tile_align)
         pad_size = (-x.shape[0]) % required_align
         if pad_size > 0:


### PR DESCRIPTION
## Motivation

`EPMoE._gmm_compute` calls `gmm()` three times per layer (w0, w1, then wo via the SiLU/multiply'd intermediate). The current upstream pad in `_gmm_compute` only aligns x to the sublane tiling (~8 for bf16), which is enough for the LHS layout but not for the GMM kernel's row-tile constraints:

- `gmm_v2` produces NaNs when m falls below its 32-row tile, because `out_index_map` (`gmm_v2.py:106-117`) uses `floor` for non-last groups and `cdiv` for the last group — intermediate group ends on sub-tile boundaries leak NaN accumulator lanes.
- `gmm_v1` underutilizes the MXU below `tile_m = 128`.

Without coordinating these, any fallback inside `gmm()` that pads on the way in allocates a fresh padded LHS per call — for the three calls in `_gmm_compute`, that is **three** `jnp.pad`s per MoE layer, all on the same x (or its activated form), times ~80 MoE layers per forward.

## Change

Pad x once upstream in `_gmm_compute` to `max(sublane_align, kernel_tile_align)`, where `kernel_tile_align` = 32 for v2 / 128 for v1. The padded m flows through `layer_w0` / `layer_w1` / `intermediate_layer` / wo unchanged; `_unpermute` already trims `intermediate.shape[0] > expected_tokens` (`moe.py:691-693`), so the existing exit path handles the trim.

## Test plan

- [ ] Run GSM8K on a non-quantized MoE model on v5p/v7 (e.g. Qwen3-MoE) — score should match main.
- [ ] Run GSM8K on an FP8 MoE model (e.g. DeepSeek-V3-FP8 or GLM-4.7-FP8) — score should match main.
- [ ] Sanity check `gmm_v2` no longer NaNs at small unaligned m. Quick repro:
  ```python
  for m in (8, 33, 64, 96, 160):
      lhs = jnp.ones((m, k), jnp.bfloat16)
      sizes = jnp.array(...)
      out = gmm(lhs, rhs, sizes)
      assert not jnp.isnan(out).any()
  ```
- [ ] Profile a decode batch=1 forward and confirm the three per-layer `jnp.pad` HLOs in EPMoE collapse to one.

## Notes

- Independent of #907's `gmm()`-internal padding; if both land, this PR's upstream pad makes #907's internal pad a no-op for the EPMoE path.
- Does **not** address NaN/perf for non-MoE direct callers of `gmm()` (none in tree today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)