### PR TITLE
[Feature]: Add tooling for GLM-4.7

### DIFF
--- a/python/sgl_jax/srt/function_call/function_call_parser.py
+++ b/python/sgl_jax/srt/function_call/function_call_parser.py
@@ -9,6 +9,7 @@ from sgl_jax.srt.entrypoints.openai.protocol import (
 )
 from sgl_jax.srt.function_call.base_format_detector import BaseFormatDetector
 from sgl_jax.srt.function_call.core_types import ToolCallItem
+from sgl_jax.srt.function_call.glm4_moe_detector import Glm4MoeDetector
 from sgl_jax.srt.function_call.glm47_moe_detector import Glm47MoeDetector
 from sgl_jax.srt.function_call.mimo_detector import MiMoDetector
 from sgl_jax.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
@@ -30,6 +31,7 @@ class FunctionCallParser:
         "qwen3_coder": Qwen3CoderDetector,
         "mimo": MiMoDetector,
         "glm47": Glm47MoeDetector,
+        "glm45": Glm4MoeDetector,
     }
 
     def __init__(self, tools: list[Tool], tool_call_parser: str):

--- a/python/sgl_jax/srt/function_call/function_call_parser.py
+++ b/python/sgl_jax/srt/function_call/function_call_parser.py
@@ -9,6 +9,7 @@ from sgl_jax.srt.entrypoints.openai.protocol import (
 )
 from sgl_jax.srt.function_call.base_format_detector import BaseFormatDetector
 from sgl_jax.srt.function_call.core_types import ToolCallItem
+from sgl_jax.srt.function_call.glm47_moe_detector import Glm47MoeDetector
 from sgl_jax.srt.function_call.mimo_detector import MiMoDetector
 from sgl_jax.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
 from sgl_jax.srt.function_call.utils import get_json_schema_constraint
@@ -28,6 +29,7 @@ class FunctionCallParser:
     ToolCallParserEnum: dict[str, type[BaseFormatDetector]] = {
         "qwen3_coder": Qwen3CoderDetector,
         "mimo": MiMoDetector,
+        "glm47": Glm47MoeDetector,
     }
 
     def __init__(self, tools: list[Tool], tool_call_parser: str):

--- a/python/sgl_jax/srt/function_call/glm47_moe_detector.py
+++ b/python/sgl_jax/srt/function_call/glm47_moe_detector.py
@@ -3,7 +3,7 @@ import json
 import logging
 import re
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from sgl_jax.srt.entrypoints.openai.protocol import Tool
 from sgl_jax.srt.function_call.base_format_detector import BaseFormatDetector
@@ -27,9 +27,7 @@ class StreamState(str, Enum):
     IN_VALUE = "IN_VALUE"
 
 
-def get_argument_type(
-    func_name: str, arg_key: str, defined_tools: List[Tool]
-) -> Optional[str]:
+def get_argument_type(func_name: str, arg_key: str, defined_tools: list[Tool]) -> str | None:
     """Get the expected type of a function argument from tool definitions.
 
     Supports complex JSON Schema definitions including:
@@ -91,9 +89,7 @@ def _convert_to_number(value: str) -> Any:
         return value
 
 
-def parse_arguments(
-    json_value: str, arg_type: Optional[str] = None
-) -> Tuple[Any, bool]:
+def parse_arguments(json_value: str, arg_type: str | None = None) -> tuple[Any, bool]:
     """Parse argument value with multiple fallback strategies.
 
     Args:
@@ -166,9 +162,7 @@ class Glm47MoeDetector(BaseFormatDetector):
         self.current_tool_name_sent = False
         self._streamed_raw_length = 0
         self._tool_call_completed = False  # Track if tool call has been completed
-        self._sent_empty_object = (
-            False  # Track if empty object has been sent for no-arg functions
-        )
+        self._sent_empty_object = False  # Track if empty object has been sent for no-arg functions
         self._reset_streaming_state()
 
     def _reset_streaming_state(self) -> None:
@@ -179,9 +173,7 @@ class Glm47MoeDetector(BaseFormatDetector):
         self._xml_tag_buffer = ""
         self._is_first_param = True
         self._value_started = False
-        self._cached_value_type: Optional[str] = (
-            None  # Cache the value type for consistency
-        )
+        self._cached_value_type: str | None = None  # Cache the value type for consistency
         self._tool_call_completed = False  # Reset tool call completion status
         self._sent_empty_object = False  # Reset empty object sent status
 
@@ -189,7 +181,7 @@ class Glm47MoeDetector(BaseFormatDetector):
         """Check if the text contains a glm-4.5 / glm-4.6 format tool call."""
         return self.bot_token in text
 
-    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
+    def detect_and_parse(self, text: str, tools: list[Tool]) -> StreamingParseResult:
         """
         One-time parsing: Detects and parses tool calls in the provided text.
 
@@ -244,7 +236,7 @@ class Glm47MoeDetector(BaseFormatDetector):
             # return the normal text if parsing fails
             return StreamingParseResult(normal_text=text)
 
-    def _get_value_type(self, func_name: str, key: str, tools: List[Tool]) -> str:
+    def _get_value_type(self, func_name: str, key: str, tools: list[Tool]) -> str:
         """Get parameter type from tool definition, with fallback to auto-detection.
 
         Args:
@@ -278,9 +270,7 @@ class Glm47MoeDetector(BaseFormatDetector):
                 return "number"
             # For string values, check if they look like numbers
             elif isinstance(parsed, str):
-                if parsed.isdigit() or (
-                    parsed.startswith("-") and parsed[1:].isdigit()
-                ):
+                if parsed.isdigit() or (parsed.startswith("-") and parsed[1:].isdigit()):
                     return "number"
                 return "string"
         except json.JSONDecodeError:
@@ -316,16 +306,14 @@ class Glm47MoeDetector(BaseFormatDetector):
                 return str(num)
             except (ValueError, AttributeError):
                 # Fallback to string if not a valid number
-                logger.warning(
-                    "Failed to parse '%s' as number, treating as string", value
-                )
+                logger.warning("Failed to parse '%s' as number, treating as string", value)
                 return json.dumps(str(value) if value else "", ensure_ascii=False)
         else:
             # For object/array types, return as-is (should already be valid JSON)
             return value
 
     def _process_xml_to_json_streaming(
-        self, raw_increment: str, func_name: str, tools: List[Tool]
+        self, raw_increment: str, func_name: str, tools: list[Tool]
     ) -> str:
         """Convert XML increment to JSON streaming output using state machine.
 
@@ -359,9 +347,7 @@ class Glm47MoeDetector(BaseFormatDetector):
                     self._current_key = self._xml_tag_buffer[:-10].strip()
                     self._xml_tag_buffer = ""
                     self._stream_state = StreamState.WAITING_VALUE
-                    json_output += (
-                        json.dumps(self._current_key, ensure_ascii=False) + ": "
-                    )
+                    json_output += json.dumps(self._current_key, ensure_ascii=False) + ": "
 
             elif self._stream_state == StreamState.WAITING_VALUE:
                 if self._xml_tag_buffer.endswith("<arg_value>"):
@@ -386,9 +372,7 @@ class Glm47MoeDetector(BaseFormatDetector):
                         # Output any remaining content
                         if final_value:
                             if value_type == "string":
-                                json_output += json.dumps(
-                                    final_value, ensure_ascii=False
-                                )[1:-1]
+                                json_output += json.dumps(final_value, ensure_ascii=False)[1:-1]
                             else:
                                 json_output += final_value
                         # Always output closing quote for string type when value was started
@@ -396,9 +380,7 @@ class Glm47MoeDetector(BaseFormatDetector):
                             json_output += '"'
                     else:
                         # Value was never started (empty or complete in one chunk)
-                        json_output += self._format_value_complete(
-                            self._current_value, value_type
-                        )
+                        json_output += self._format_value_complete(self._current_value, value_type)
 
                     self._xml_tag_buffer = ""
                     self._stream_state = StreamState.BETWEEN
@@ -421,9 +403,7 @@ class Glm47MoeDetector(BaseFormatDetector):
                                 json_output += '"'
                                 self._value_started = True
                             if content:
-                                json_output += json.dumps(content, ensure_ascii=False)[
-                                    1:-1
-                                ]
+                                json_output += json.dumps(content, ensure_ascii=False)[1:-1]
                                 self._current_value += content
                                 self._xml_tag_buffer = ""
                         elif value_type == "number":
@@ -460,7 +440,7 @@ class Glm47MoeDetector(BaseFormatDetector):
 
     def _send_tool_name_if_needed(
         self, func_name: str, has_arg_key: bool, is_tool_end: str
-    ) -> Optional[ToolCallItem]:
+    ) -> ToolCallItem | None:
         """Send tool name if needed.
 
         Args:
@@ -502,8 +482,8 @@ class Glm47MoeDetector(BaseFormatDetector):
         )
 
     def _process_arguments_streaming(
-        self, func_name: str, func_args_raw: str, tools: List[Tool]
-    ) -> Optional[ToolCallItem]:
+        self, func_name: str, func_args_raw: str, tools: list[Tool]
+    ) -> ToolCallItem | None:
         """Process streaming arguments.
 
         Args:
@@ -523,9 +503,7 @@ class Glm47MoeDetector(BaseFormatDetector):
         raw_increment = func_args_raw[self._streamed_raw_length :]
 
         # Convert XML to JSON using state machine
-        json_increment = self._process_xml_to_json_streaming(
-            raw_increment, func_name, tools
-        )
+        json_increment = self._process_xml_to_json_streaming(raw_increment, func_name, tools)
 
         # CRITICAL: Update streamed length BEFORE early return
         # Even if json_increment is empty, the input has been consumed by the state machine
@@ -548,10 +526,10 @@ class Glm47MoeDetector(BaseFormatDetector):
         self,
         func_name: str,
         func_args_raw: str,
-        tools: List[Tool],
+        tools: list[Tool],
         match_end_pos: int,
         current_text: str,
-    ) -> List[ToolCallItem]:
+    ) -> list[ToolCallItem]:
         """Complete tool call processing.
 
         Args:
@@ -598,9 +576,7 @@ class Glm47MoeDetector(BaseFormatDetector):
                 pairs = self.func_arg_regex.findall(func_args_raw)
                 if pairs:
                     arguments = self._parse_argument_pairs(pairs, func_name, tools)
-                    self.prev_tool_call_arr[self.current_tool_id][
-                        "arguments"
-                    ] = arguments
+                    self.prev_tool_call_arr[self.current_tool_id]["arguments"] = arguments
             except Exception as e:
                 logger.debug("Failed to parse arguments: %s", e, exc_info=True)
 
@@ -617,9 +593,7 @@ class Glm47MoeDetector(BaseFormatDetector):
 
         return calls
 
-    def parse_streaming_increment(
-        self, new_text: str, tools: List[Tool]
-    ) -> StreamingParseResult:
+    def parse_streaming_increment(self, new_text: str, tools: list[Tool]) -> StreamingParseResult:
         """
         Streaming incremental parsing tool calls for GLM-4.5 and GLM-4.6 format.
         Uses a state machine to convert XML to JSON incrementally for true character-by-character streaming.
@@ -679,9 +653,7 @@ class Glm47MoeDetector(BaseFormatDetector):
                 return StreamingParseResult(normal_text=normal_text, calls=[])
 
             # Extract match groups using helper method
-            func_name, func_args_raw, is_tool_end = self._extract_match_groups(
-                partial_match
-            )
+            func_name, func_args_raw, is_tool_end = self._extract_match_groups(partial_match)
 
             # Initialize tool call state if needed (keeping existing logic)
             if self.current_tool_id == -1:
@@ -711,17 +683,13 @@ class Glm47MoeDetector(BaseFormatDetector):
             has_arg_key = "<arg_key" in current_text
 
             # Send tool name if needed
-            tool_name_item = self._send_tool_name_if_needed(
-                func_name, has_arg_key, is_tool_end
-            )
+            tool_name_item = self._send_tool_name_if_needed(func_name, has_arg_key, is_tool_end)
             if tool_name_item:
                 calls.append(tool_name_item)
 
             # Process streaming arguments if tool name has been sent
             if self.current_tool_name_sent:
-                arg_item = self._process_arguments_streaming(
-                    func_name, func_args_raw, tools
-                )
+                arg_item = self._process_arguments_streaming(func_name, func_args_raw, tools)
                 if arg_item:
                     calls.append(arg_item)
 
@@ -744,8 +712,8 @@ class Glm47MoeDetector(BaseFormatDetector):
         return StreamingParseResult(normal_text=normal_text, calls=calls)
 
     def _parse_argument_pairs(
-        self, pairs: List[Tuple[str, str]], func_name: str, tools: List[Tool]
-    ) -> Dict[str, Any]:
+        self, pairs: list[tuple[str, str]], func_name: str, tools: list[Tool]
+    ) -> dict[str, Any]:
         """Parse argument key-value pairs with type coercion.
 
         Args:
@@ -786,5 +754,5 @@ class Glm47MoeDetector(BaseFormatDetector):
     def structure_info(self) -> _GetInfoFunc:
         raise NotImplementedError()
 
-    def build_ebnf(self, tools: List[Tool]) -> str:
+    def build_ebnf(self, tools: list[Tool]) -> str:
         raise NotImplementedError()

--- a/python/sgl_jax/srt/function_call/glm47_moe_detector.py
+++ b/python/sgl_jax/srt/function_call/glm47_moe_detector.py
@@ -240,7 +240,7 @@ class Glm47MoeDetector(BaseFormatDetector):
                 calls.extend(self.parse_base_json(match_result, tools))
             return StreamingParseResult(normal_text=normal_text, calls=calls)
         except Exception as e:
-            logger.error(f"Error in detect_and_parse: {e}", exc_info=True)
+            logger.exception("Error in detect_and_parse: %s", e)
             # return the normal text if parsing fails
             return StreamingParseResult(normal_text=text)
 
@@ -317,7 +317,7 @@ class Glm47MoeDetector(BaseFormatDetector):
             except (ValueError, AttributeError):
                 # Fallback to string if not a valid number
                 logger.warning(
-                    f"Failed to parse '{value}' as number, treating as string"
+                    "Failed to parse '%s' as number, treating as string", value
                 )
                 return json.dumps(str(value) if value else "", ensure_ascii=False)
         else:
@@ -602,7 +602,7 @@ class Glm47MoeDetector(BaseFormatDetector):
                         "arguments"
                     ] = arguments
             except Exception as e:
-                logger.debug(f"Failed to parse arguments: {e}", exc_info=True)
+                logger.debug("Failed to parse arguments: %s", e, exc_info=True)
 
         # Clean buffer
         self._buffer = current_text[match_end_pos:]
@@ -738,7 +738,7 @@ class Glm47MoeDetector(BaseFormatDetector):
                     return StreamingParseResult(normal_text=normal_text, calls=calls)
 
         except Exception as e:
-            logger.error(f"Error in parse_streaming_increment: {e}", exc_info=True)
+            logger.exception("Error in parse_streaming_increment: %s", e)
             return StreamingParseResult(normal_text=current_text)
 
         return StreamingParseResult(normal_text=normal_text, calls=calls)

--- a/python/sgl_jax/srt/function_call/glm47_moe_detector.py
+++ b/python/sgl_jax/srt/function_call/glm47_moe_detector.py
@@ -785,3 +785,6 @@ class Glm47MoeDetector(BaseFormatDetector):
 
     def structure_info(self) -> _GetInfoFunc:
         raise NotImplementedError()
+
+    def build_ebnf(self, tools: List[Tool]) -> str:
+        raise NotImplementedError()

--- a/python/sgl_jax/srt/function_call/glm47_moe_detector.py
+++ b/python/sgl_jax/srt/function_call/glm47_moe_detector.py
@@ -1,0 +1,787 @@
+import ast
+import json
+import logging
+import re
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+
+from sgl_jax.srt.entrypoints.openai.protocol import Tool
+from sgl_jax.srt.function_call.base_format_detector import BaseFormatDetector
+from sgl_jax.srt.function_call.core_types import (
+    StreamingParseResult,
+    ToolCallItem,
+    _GetInfoFunc,
+)
+from sgl_jax.srt.function_call.utils import infer_type_from_json_schema
+
+logger = logging.getLogger(__name__)
+
+
+class StreamState(str, Enum):
+    """State machine states for XML to JSON streaming conversion."""
+
+    INIT = "INIT"
+    BETWEEN = "BETWEEN"
+    IN_KEY = "IN_KEY"
+    WAITING_VALUE = "WAITING_VALUE"
+    IN_VALUE = "IN_VALUE"
+
+
+def get_argument_type(
+    func_name: str, arg_key: str, defined_tools: List[Tool]
+) -> Optional[str]:
+    """Get the expected type of a function argument from tool definitions.
+
+    Supports complex JSON Schema definitions including:
+    - Direct type field (including type arrays)
+    - anyOf/oneOf: parameter can be any of multiple types
+    - enum: parameter must be one of enum values
+    - allOf: parameter must satisfy all type definitions
+    - properties: inferred as object type
+    - items: inferred as array type
+
+    Args:
+        func_name: Name of the function/tool
+        arg_key: Name of the argument
+        defined_tools: List of available tools
+
+    Returns:
+        The type string (e.g., 'string', 'number', 'object') or None if not found
+    """
+    name2tool = {tool.function.name: tool for tool in defined_tools}
+
+    # Check if function exists
+    tool = name2tool.get(func_name)
+    if not tool:
+        return None
+
+    # Get parameters safely using getattr
+    params = getattr(tool.function, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+
+    # Navigate to the type using dict.get() for safe access
+    properties = params.get("properties")
+    if not isinstance(properties, dict):
+        return None
+
+    arg_spec = properties.get(arg_key)
+    if isinstance(arg_spec, dict):
+        # Use the new type inference function for complex JSON Schema support
+        return infer_type_from_json_schema(arg_spec)
+
+    return None
+
+
+def _convert_to_number(value: str) -> Any:
+    """Convert string to appropriate number type (int or float).
+
+    Args:
+        value: String value to convert
+
+    Returns:
+        Converted number or original string if conversion fails
+    """
+    try:
+        if "." in value or "e" in value.lower():
+            return float(value)
+        else:
+            return int(value)
+    except (ValueError, AttributeError):
+        return value
+
+
+def parse_arguments(
+    json_value: str, arg_type: Optional[str] = None
+) -> Tuple[Any, bool]:
+    """Parse argument value with multiple fallback strategies.
+
+    Args:
+        json_value: Raw string value to parse
+        arg_type: Expected type hint ('string', 'number', 'object', etc.)
+
+    Returns:
+        Tuple of (parsed_value, is_valid_json)
+    """
+    # Strategy 1: Direct JSON parsing
+    try:
+        parsed_value = json.loads(json_value)
+
+        # Type coercion for number type
+        if arg_type == "number" and isinstance(parsed_value, str):
+            parsed_value = _convert_to_number(parsed_value)
+
+        return parsed_value, True
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Strategy 2: Unescape and parse
+    try:
+        wrapped = json.loads('{"tmp": "' + json_value + '"}')
+        parsed_value = json.loads(wrapped["tmp"])
+
+        if arg_type == "number" and isinstance(parsed_value, str):
+            parsed_value = _convert_to_number(parsed_value)
+
+        return parsed_value, True
+    except (json.JSONDecodeError, ValueError, KeyError):
+        pass
+
+    # Strategy 3: ast.literal_eval
+    try:
+        parsed_value = ast.literal_eval(json_value)
+        return parsed_value, True
+    except (ValueError, SyntaxError):
+        pass
+
+    # Strategy 4: Treat as string
+    try:
+        quoted_value = json.dumps(str(json_value))
+        return json.loads(quoted_value), True
+    except (json.JSONDecodeError, ValueError):
+        return json_value, False
+
+
+class Glm47MoeDetector(BaseFormatDetector):
+    """
+    Detector for GLM-4.7 and GLM-5 models.
+    Assumes function call format:
+      <tool_call>get_weather<arg_key>city</arg_key><arg_value>北京</arg_value><arg_key>date</arg_key><arg_value>2024-06-27</arg_value></tool_call><tool_call>get_weather<arg_key>city</arg_key><arg_value>上海</arg_value><arg_key>date</arg_key><arg_value>2024-06-27</arg_value></tool_call>
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.bot_token = "<tool_call>"
+        self.eot_token = "</tool_call>"
+        self.func_call_regex = r"<tool_call>.*?</tool_call>"
+        self.func_detail_regex = re.compile(
+            r"<tool_call>(.*?)(<arg_key>.*?)?</tool_call>", re.DOTALL
+        )
+        self.func_arg_regex = re.compile(
+            r"<arg_key>(.*?)</arg_key>(?:\\n|\s)*<arg_value>(.*?)</arg_value>",
+            re.DOTALL,
+        )
+        self._last_arguments = ""
+        self.current_tool_id = -1
+        self.current_tool_name_sent = False
+        self._streamed_raw_length = 0
+        self._tool_call_completed = False  # Track if tool call has been completed
+        self._sent_empty_object = (
+            False  # Track if empty object has been sent for no-arg functions
+        )
+        self._reset_streaming_state()
+
+    def _reset_streaming_state(self) -> None:
+        """Reset the streaming state machine for a new tool call."""
+        self._stream_state = StreamState.INIT
+        self._current_key = ""
+        self._current_value = ""
+        self._xml_tag_buffer = ""
+        self._is_first_param = True
+        self._value_started = False
+        self._cached_value_type: Optional[str] = (
+            None  # Cache the value type for consistency
+        )
+        self._tool_call_completed = False  # Reset tool call completion status
+        self._sent_empty_object = False  # Reset empty object sent status
+
+    def has_tool_call(self, text: str) -> bool:
+        """Check if the text contains a glm-4.5 / glm-4.6 format tool call."""
+        return self.bot_token in text
+
+    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
+        """
+        One-time parsing: Detects and parses tool calls in the provided text.
+
+        :param text: The complete text to parse.
+        :param tools: List of available tools.
+        :return: ParseResult indicating success or failure, consumed text, leftover text, and parsed calls.
+        """
+        if self.bot_token not in text:
+            return StreamingParseResult(normal_text=text, calls=[])
+
+        # Extract all normal text (before, between, and after tool calls)
+        normal_text_parts = []
+        last_end = 0
+
+        # Find all tool call matches
+        for match in re.finditer(self.func_call_regex, text, re.DOTALL):
+            # Add text before this tool call
+            if match.start() > last_end:
+                normal_text_parts.append(text[last_end : match.start()])
+            last_end = match.end()
+
+        # Add any remaining text after the last tool call
+        if last_end < len(text):
+            normal_text_parts.append(text[last_end:])
+
+        # Combine all normal text parts
+        normal_text = "".join(normal_text_parts).strip()
+
+        # Parse tool calls
+        match_result_list = re.findall(self.func_call_regex, text, re.DOTALL)
+        calls = []
+        try:
+            for match_result in match_result_list:
+                # Get function name
+                func_detail = self.func_detail_regex.search(match_result)
+                if func_detail is None:
+                    continue
+                func_name = func_detail.group(1) if func_detail.group(1) else ""
+                func_args = func_detail.group(2) if func_detail.group(2) else ""
+                arguments = {}
+                if func_args:
+                    pairs = self.func_arg_regex.findall(func_args)
+                    # Parse arguments using shared method
+                    arguments = self._parse_argument_pairs(pairs, func_name, tools)
+
+                # construct match_result for parse_base_json
+                match_result = {"name": func_name, "parameters": arguments}
+                calls.extend(self.parse_base_json(match_result, tools))
+            return StreamingParseResult(normal_text=normal_text, calls=calls)
+        except Exception as e:
+            logger.error(f"Error in detect_and_parse: {e}", exc_info=True)
+            # return the normal text if parsing fails
+            return StreamingParseResult(normal_text=text)
+
+    def _get_value_type(self, func_name: str, key: str, tools: List[Tool]) -> str:
+        """Get parameter type from tool definition, with fallback to auto-detection.
+
+        Args:
+            func_name: Name of the function
+            key: Parameter name
+            tools: List of available tools
+
+        Returns:
+            Type string: 'string', 'number', 'object', 'array', or 'boolean'
+        """
+        arg_type = get_argument_type(func_name, key, tools)
+        if arg_type:
+            return arg_type
+
+        # Improved auto-detection type from value (best effort)
+        value_content = self._current_value.strip() if self._current_value else ""
+
+        if not value_content:
+            return "string"
+
+        # Try to parse as valid JSON first
+        try:
+            parsed = json.loads(value_content)
+            if isinstance(parsed, dict):
+                return "object"
+            elif isinstance(parsed, list):
+                return "array"
+            elif isinstance(parsed, bool):
+                return "boolean"
+            elif isinstance(parsed, (int, float)):
+                return "number"
+            # For string values, check if they look like numbers
+            elif isinstance(parsed, str):
+                if parsed.isdigit() or (
+                    parsed.startswith("-") and parsed[1:].isdigit()
+                ):
+                    return "number"
+                return "string"
+        except json.JSONDecodeError:
+            # Not valid JSON, try heuristic detection
+            first_char = value_content[0] if value_content else ""
+
+            if first_char.isdigit() or first_char in ["-", "."]:
+                return "number"
+            elif first_char in ["{", "["]:
+                return "object"
+            elif first_char in ['"', "'"]:
+                return "string"
+
+        # Default to string (safest fallback)
+        return "string"
+
+    def _format_value_complete(self, value: str, value_type: str) -> str:
+        """Format complete value based on type.
+
+        Args:
+            value: Raw value string
+            value_type: Expected type ('string', 'number', 'object')
+
+        Returns:
+            Properly formatted JSON value string
+        """
+        if value_type == "string":
+            # Ensure proper JSON string formatting with quotes
+            return json.dumps(value, ensure_ascii=False)
+        elif value_type == "number":
+            try:
+                num = _convert_to_number(value.strip() if value else "")
+                return str(num)
+            except (ValueError, AttributeError):
+                # Fallback to string if not a valid number
+                logger.warning(
+                    f"Failed to parse '{value}' as number, treating as string"
+                )
+                return json.dumps(str(value) if value else "", ensure_ascii=False)
+        else:
+            # For object/array types, return as-is (should already be valid JSON)
+            return value
+
+    def _process_xml_to_json_streaming(
+        self, raw_increment: str, func_name: str, tools: List[Tool]
+    ) -> str:
+        """Convert XML increment to JSON streaming output using state machine.
+
+        This method processes XML fragments character by character and converts them
+        to JSON format incrementally. It maintains state across calls to handle
+        partial XML tags and values.
+
+        Args:
+            raw_increment: New XML content to process
+            func_name: Name of the function being called
+            tools: List of available tools for type inference
+
+        Returns:
+            JSON string increment to append to the output
+        """
+        json_output = ""
+
+        for char in raw_increment:
+            self._xml_tag_buffer += char
+
+            if self._stream_state in [StreamState.INIT, StreamState.BETWEEN]:
+                if self._xml_tag_buffer.endswith("<arg_key>"):
+                    self._stream_state = StreamState.IN_KEY
+                    self._current_key = ""
+                    self._xml_tag_buffer = ""
+                    json_output += "{" if self._is_first_param else ", "
+                    self._is_first_param = False
+
+            elif self._stream_state == StreamState.IN_KEY:
+                if self._xml_tag_buffer.endswith("</arg_key>"):
+                    self._current_key = self._xml_tag_buffer[:-10].strip()
+                    self._xml_tag_buffer = ""
+                    self._stream_state = StreamState.WAITING_VALUE
+                    json_output += (
+                        json.dumps(self._current_key, ensure_ascii=False) + ": "
+                    )
+
+            elif self._stream_state == StreamState.WAITING_VALUE:
+                if self._xml_tag_buffer.endswith("<arg_value>"):
+                    self._stream_state = StreamState.IN_VALUE
+                    self._current_value = ""
+                    self._xml_tag_buffer = ""
+                    self._value_started = False
+                    # Determine and cache the value type at the start
+                    self._cached_value_type = self._get_value_type(
+                        func_name, self._current_key, tools
+                    )
+
+            elif self._stream_state == StreamState.IN_VALUE:
+                if self._xml_tag_buffer.endswith("</arg_value>"):
+                    final_value = self._xml_tag_buffer[:-12]
+                    self._current_value += final_value
+
+                    # Use cached value type for consistency
+                    value_type = self._cached_value_type or "string"
+
+                    if self._value_started:
+                        # Output any remaining content
+                        if final_value:
+                            if value_type == "string":
+                                json_output += json.dumps(
+                                    final_value, ensure_ascii=False
+                                )[1:-1]
+                            else:
+                                json_output += final_value
+                        # Always output closing quote for string type when value was started
+                        if value_type == "string":
+                            json_output += '"'
+                    else:
+                        # Value was never started (empty or complete in one chunk)
+                        json_output += self._format_value_complete(
+                            self._current_value, value_type
+                        )
+
+                    self._xml_tag_buffer = ""
+                    self._stream_state = StreamState.BETWEEN
+                    self._current_value = ""
+                    self._value_started = False
+                    self._cached_value_type = None  # Reset cached type
+                else:
+                    closing_tag = "</arg_value>"
+                    is_potential_closing = len(self._xml_tag_buffer) <= len(
+                        closing_tag
+                    ) and closing_tag.startswith(self._xml_tag_buffer)
+
+                    if not is_potential_closing:
+                        content = self._xml_tag_buffer
+                        # Use cached value type for consistency
+                        value_type = self._cached_value_type or "string"
+
+                        if value_type == "string":
+                            if not self._value_started:
+                                json_output += '"'
+                                self._value_started = True
+                            if content:
+                                json_output += json.dumps(content, ensure_ascii=False)[
+                                    1:-1
+                                ]
+                                self._current_value += content
+                                self._xml_tag_buffer = ""
+                        elif value_type == "number":
+                            if content:
+                                if not self._value_started:
+                                    self._value_started = True
+                                json_output += content
+                                self._current_value += content
+                                self._xml_tag_buffer = ""
+                        else:
+                            # For object/array types, output as-is
+                            if content:
+                                if not self._value_started:
+                                    self._value_started = True
+                                json_output += content
+                                self._current_value += content
+                                self._xml_tag_buffer = ""
+
+        return json_output
+
+    def _extract_match_groups(self, match: re.Match) -> tuple[str, str, str]:
+        """Extract function name, arguments and end marker from regex match.
+
+        Args:
+            match: Regex match object
+
+        Returns:
+            (func_name, func_args_raw, is_tool_end)
+        """
+        func_name = match.group(1).strip()
+        func_args_raw = match.group(2).strip() if match.group(2) else ""
+        is_tool_end = match.group(3) or ""
+        return func_name, func_args_raw, is_tool_end
+
+    def _send_tool_name_if_needed(
+        self, func_name: str, has_arg_key: bool, is_tool_end: str
+    ) -> Optional[ToolCallItem]:
+        """Send tool name if needed.
+
+        Args:
+            func_name: Function name
+            has_arg_key: Whether current text contains <arg_key
+            is_tool_end: Whether end marker is encountered
+
+        Returns:
+            Tool call item or None
+        """
+        if self.current_tool_name_sent:
+            return None
+
+        # Function name completeness check
+        is_func_name_complete = has_arg_key or is_tool_end == self.eot_token
+
+        if not is_func_name_complete:
+            return None
+
+        if not func_name:
+            logger.warning("Empty function name detected, skipping tool call")
+            return None
+
+        # Send tool name
+        self.current_tool_name_sent = True
+        self._streamed_raw_length = 0
+        self._reset_streaming_state()
+
+        # Record tool info
+        self.prev_tool_call_arr[self.current_tool_id] = {
+            "name": func_name,
+            "arguments": {},
+        }
+
+        return ToolCallItem(
+            tool_index=self.current_tool_id,
+            name=func_name,
+            parameters="",
+        )
+
+    def _process_arguments_streaming(
+        self, func_name: str, func_args_raw: str, tools: List[Tool]
+    ) -> Optional[ToolCallItem]:
+        """Process streaming arguments.
+
+        Args:
+            func_name: Function name
+            func_args_raw: Raw argument string
+            tools: List of available tools
+
+        Returns:
+            Tool call item with parameter updates or None
+        """
+        current_raw_length = len(func_args_raw)
+
+        if current_raw_length <= self._streamed_raw_length:
+            return None
+
+        # Get new raw XML content
+        raw_increment = func_args_raw[self._streamed_raw_length :]
+
+        # Convert XML to JSON using state machine
+        json_increment = self._process_xml_to_json_streaming(
+            raw_increment, func_name, tools
+        )
+
+        # CRITICAL: Update streamed length BEFORE early return
+        # Even if json_increment is empty, the input has been consumed by the state machine
+        self._streamed_raw_length = current_raw_length
+
+        if not json_increment:
+            return None
+
+        # Update state
+        self._last_arguments += json_increment
+        self.streamed_args_for_tool[self.current_tool_id] += json_increment
+
+        return ToolCallItem(
+            tool_index=self.current_tool_id,
+            name=None,
+            parameters=json_increment,
+        )
+
+    def _finalize_tool_call(
+        self,
+        func_name: str,
+        func_args_raw: str,
+        tools: List[Tool],
+        match_end_pos: int,
+        current_text: str,
+    ) -> List[ToolCallItem]:
+        """Complete tool call processing.
+
+        Args:
+            func_name: Function name
+            func_args_raw: Raw argument string
+            tools: List of available tools
+            match_end_pos: Match end position
+            current_text: Current text
+
+        Returns:
+            List of tool call items to add
+        """
+        calls = []
+
+        # Handle no-arg function or need to close braces
+        if self._is_first_param and not self._sent_empty_object:
+            # No-arg function
+            calls.append(
+                ToolCallItem(
+                    tool_index=self.current_tool_id,
+                    name=None,
+                    parameters="{}",
+                )
+            )
+            self._last_arguments += "{}"
+            self.streamed_args_for_tool[self.current_tool_id] += "{}"
+            self._sent_empty_object = True
+        elif not self._last_arguments.endswith("}") and not self._sent_empty_object:
+            # Need to close brace
+            calls.append(
+                ToolCallItem(
+                    tool_index=self.current_tool_id,
+                    name=None,
+                    parameters="}",
+                )
+            )
+            self._last_arguments += "}"
+            self.streamed_args_for_tool[self.current_tool_id] += "}"
+            self._sent_empty_object = True
+
+        # Parse final arguments
+        if func_args_raw:
+            try:
+                pairs = self.func_arg_regex.findall(func_args_raw)
+                if pairs:
+                    arguments = self._parse_argument_pairs(pairs, func_name, tools)
+                    self.prev_tool_call_arr[self.current_tool_id][
+                        "arguments"
+                    ] = arguments
+            except Exception as e:
+                logger.debug(f"Failed to parse arguments: {e}", exc_info=True)
+
+        # Clean buffer
+        self._buffer = current_text[match_end_pos:]
+
+        # Reset state for next tool call
+        self._tool_call_completed = True
+        self.current_tool_id += 1
+        self._last_arguments = ""
+        self.current_tool_name_sent = False
+        self._streamed_raw_length = 0
+        self._reset_streaming_state()
+
+        return calls
+
+    def parse_streaming_increment(
+        self, new_text: str, tools: List[Tool]
+    ) -> StreamingParseResult:
+        """
+        Streaming incremental parsing tool calls for GLM-4.5 and GLM-4.6 format.
+        Uses a state machine to convert XML to JSON incrementally for true character-by-character streaming.
+        Outputs JSON increments immediately as XML data arrives.
+        """
+        self._buffer += new_text
+        current_text = self._buffer
+
+        # Check if we have a tool call
+        has_tool_call = self.bot_token in current_text
+
+        if not has_tool_call:
+            # Check if buffer could be the start of a tool call
+            # Keep buffer if it could be a partial match of bot_token
+            is_potential_start = any(
+                self.bot_token.startswith(current_text[-i:])
+                for i in range(1, min(len(current_text), len(self.bot_token)) + 1)
+            )
+
+            if not is_potential_start:
+                # Not a potential tool call, return as normal text
+                # Must return the entire buffer (current_text), not just new_text,
+                # because buffer may contain previously accumulated characters like '<'
+                # that turned out not to be part of a tool call
+                output_text = current_text
+                self._buffer = ""
+                if self.eot_token in output_text:
+                    output_text = output_text.replace(self.eot_token, "")
+                return StreamingParseResult(normal_text=output_text)
+            else:
+                # Could be start of tool call, keep buffering
+                return StreamingParseResult(normal_text="", calls=[])
+
+        # Extract any text before the first bot_token and return it as normal_text
+        normal_text = ""
+        first_bot_token_idx = current_text.find(self.bot_token)
+        if first_bot_token_idx > 0:
+            normal_text = current_text[:first_bot_token_idx]
+            current_text = current_text[first_bot_token_idx:]
+            # Update buffer to only include from the bot token onwards
+            self._buffer = current_text
+
+        if not hasattr(self, "_tool_indices"):
+            self._tool_indices = self._get_tool_indices(tools)
+
+        calls: list[ToolCallItem] = []
+        try:
+            # Try to match a partial or complete tool call
+            # Use a single flexible regex pattern that handles all cases
+            partial_match = re.search(
+                r"<tool_call>(.*?)(?:(<arg_key.*?))?(?:(</tool_call>)|$)",
+                current_text,
+                re.DOTALL,
+            )
+
+            if not partial_match:
+                return StreamingParseResult(normal_text=normal_text, calls=[])
+
+            # Extract match groups using helper method
+            func_name, func_args_raw, is_tool_end = self._extract_match_groups(
+                partial_match
+            )
+
+            # Initialize tool call state if needed (keeping existing logic)
+            if self.current_tool_id == -1:
+                self.current_tool_id = 0
+                self.prev_tool_call_arr = []
+                self.streamed_args_for_tool = [""]
+                self._streamed_raw_length = 0
+                self.current_tool_name_sent = False  # Reset for new tool call
+                self._reset_streaming_state()
+            # Check if this is a continuation of an existing tool call or a new one
+            elif not self.current_tool_name_sent:
+                # Only increment tool_id if we're truly starting a NEW tool call
+                # Don't increment if this is just the first time we're processing
+                # a tool call that was received in the buffer
+                # The key insight: only increment when we've COMPLETED a previous tool call
+                # and now see another bot_token in new_text
+                pass  # Remove the problematic auto-increment logic
+
+            # Ensure tracking arrays are large enough (keeping existing logic)
+            while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                self.prev_tool_call_arr.append({})
+            while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                self.streamed_args_for_tool.append("")
+
+            # Determine if function name is complete by checking for <arg_key> in the full text
+            # This is important for streaming scenarios where args come in later chunks
+            has_arg_key = "<arg_key" in current_text
+
+            # Send tool name if needed
+            tool_name_item = self._send_tool_name_if_needed(
+                func_name, has_arg_key, is_tool_end
+            )
+            if tool_name_item:
+                calls.append(tool_name_item)
+
+            # Process streaming arguments if tool name has been sent
+            if self.current_tool_name_sent:
+                arg_item = self._process_arguments_streaming(
+                    func_name, func_args_raw, tools
+                )
+                if arg_item:
+                    calls.append(arg_item)
+
+                # Finalize tool call if end token is encountered
+                if is_tool_end == self.eot_token and not self._tool_call_completed:
+                    finalize_calls = self._finalize_tool_call(
+                        func_name,
+                        func_args_raw,
+                        tools,
+                        partial_match.end(),
+                        current_text,
+                    )
+                    calls.extend(finalize_calls)
+                    return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+        except Exception as e:
+            logger.error(f"Error in parse_streaming_increment: {e}", exc_info=True)
+            return StreamingParseResult(normal_text=current_text)
+
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def _parse_argument_pairs(
+        self, pairs: List[Tuple[str, str]], func_name: str, tools: List[Tool]
+    ) -> Dict[str, Any]:
+        """Parse argument key-value pairs with type coercion.
+
+        Args:
+            pairs: List of (key, value) tuples from regex matching
+            func_name: Name of the function
+            tools: List of available tools
+
+        Returns:
+            Dictionary of parsed arguments
+        """
+        arguments = {}
+        for arg_key, arg_value in pairs:
+            arg_key = arg_key.strip()
+            arg_type = get_argument_type(func_name, arg_key, tools)
+            parsed_value, is_good_json = parse_arguments(arg_value, arg_type)
+
+            if arg_type == "string":
+                # Only convert to string if explicitly defined as string type
+                if isinstance(parsed_value, str):
+                    arguments[arg_key] = parsed_value
+                elif isinstance(parsed_value, (dict, list)):
+                    # If parsed as dict/list but schema says string, convert to JSON string
+                    arguments[arg_key] = json.dumps(parsed_value, ensure_ascii=False)
+                else:
+                    arguments[arg_key] = str(parsed_value)
+            elif arg_type is None:
+                # If type is not defined, keep the parsed value as-is
+                arguments[arg_key] = parsed_value if is_good_json else arg_value
+            else:
+                # For other types (number, object, array, etc.), use parsed value
+                arguments[arg_key] = parsed_value if is_good_json else arg_value
+
+        return arguments
+
+    def supports_structural_tag(self) -> bool:
+        return False
+
+    def structure_info(self) -> _GetInfoFunc:
+        raise NotImplementedError()

--- a/python/sgl_jax/srt/function_call/glm4_moe_detector.py
+++ b/python/sgl_jax/srt/function_call/glm4_moe_detector.py
@@ -517,9 +517,7 @@ class Glm4MoeDetector(BaseFormatDetector):
                                 )
                             )
                             self._last_arguments += json_increment
-                            self.streamed_args_for_tool[
-                                self.current_tool_id
-                            ] += json_increment
+                            self.streamed_args_for_tool[self.current_tool_id] += json_increment
 
                     if is_tool_end == self.eot_token:
                         if self._is_first_param:
@@ -542,16 +540,12 @@ class Glm4MoeDetector(BaseFormatDetector):
                                 )
                             )
                             self._last_arguments += closing_brace
-                            self.streamed_args_for_tool[
-                                self.current_tool_id
-                            ] += closing_brace
+                            self.streamed_args_for_tool[self.current_tool_id] += closing_brace
 
                         try:
                             pairs = self.func_arg_regex.findall(func_args_raw)
                             if pairs:
-                                arguments = self._parse_argument_pairs(
-                                    pairs, func_name, tools
-                                )
+                                arguments = self._parse_argument_pairs(pairs, func_name, tools)
                                 self.prev_tool_call_arr[self.current_tool_id][
                                     "arguments"
                                 ] = arguments

--- a/python/sgl_jax/srt/function_call/glm4_moe_detector.py
+++ b/python/sgl_jax/srt/function_call/glm4_moe_detector.py
@@ -1,0 +1,622 @@
+import ast
+import json
+import logging
+import re
+from enum import Enum
+from typing import Any
+
+from sgl_jax.srt.entrypoints.openai.protocol import Tool
+from sgl_jax.srt.function_call.base_format_detector import BaseFormatDetector
+from sgl_jax.srt.function_call.core_types import (
+    StreamingParseResult,
+    ToolCallItem,
+    _GetInfoFunc,
+)
+from sgl_jax.srt.function_call.utils import infer_type_from_json_schema
+
+logger = logging.getLogger(__name__)
+
+
+class StreamState(str, Enum):
+    """State machine states for XML to JSON streaming conversion."""
+
+    INIT = "INIT"
+    BETWEEN = "BETWEEN"
+    IN_KEY = "IN_KEY"
+    WAITING_VALUE = "WAITING_VALUE"
+    IN_VALUE = "IN_VALUE"
+
+
+def get_argument_type(func_name: str, arg_key: str, defined_tools: list[Tool]) -> str | None:
+    """Get the expected type of a function argument from tool definitions.
+
+    Supports complex JSON Schema definitions including:
+    - Direct type field (including type arrays)
+    - anyOf/oneOf: parameter can be any of multiple types
+    - enum: parameter must be one of enum values
+    - allOf: parameter must satisfy all type definitions
+    - properties: inferred as object type
+    - items: inferred as array type
+
+    Args:
+        func_name: Name of the function/tool
+        arg_key: Name of the argument
+        defined_tools: List of available tools
+
+    Returns:
+        The type string (e.g., 'string', 'number', 'object') or None if not found
+    """
+    name2tool = {tool.function.name: tool for tool in defined_tools}
+    if func_name not in name2tool:
+        return None
+    tool = name2tool[func_name]
+    properties = (tool.function.parameters or {}).get("properties", {})
+    if not isinstance(properties, dict):
+        properties = {}
+    if arg_key not in properties:
+        return None
+
+    # Use new type inference function for complex JSON Schema support
+    return infer_type_from_json_schema(properties[arg_key])
+
+
+def _convert_to_number(value: str) -> Any:
+    """Convert string to appropriate number type (int or float).
+
+    Args:
+        value: String value to convert
+
+    Returns:
+        Converted number or original string if conversion fails
+    """
+    try:
+        if "." in value or "e" in value.lower():
+            return float(value)
+        else:
+            return int(value)
+    except (ValueError, AttributeError):
+        return value
+
+
+def parse_arguments(json_value: str, arg_type: str | None = None) -> tuple[Any, bool]:
+    """Parse argument value with multiple fallback strategies.
+
+    Args:
+        json_value: Raw string value to parse
+        arg_type: Expected type hint ('string', 'number', 'object', etc.)
+
+    Returns:
+        Tuple of (parsed_value, is_valid_json)
+    """
+    # Strategy 1: Direct JSON parsing
+    try:
+        parsed_value = json.loads(json_value)
+
+        # Type coercion for number type
+        if arg_type == "number" and isinstance(parsed_value, str):
+            parsed_value = _convert_to_number(parsed_value)
+
+        return parsed_value, True
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Strategy 2: Unescape and parse
+    try:
+        wrapped = json.loads('{"tmp": "' + json_value + '"}')
+        parsed_value = json.loads(wrapped["tmp"])
+
+        if arg_type == "number" and isinstance(parsed_value, str):
+            parsed_value = _convert_to_number(parsed_value)
+
+        return parsed_value, True
+    except (json.JSONDecodeError, ValueError, KeyError):
+        pass
+
+    # Strategy 3: ast.literal_eval
+    try:
+        parsed_value = ast.literal_eval(json_value)
+        return parsed_value, True
+    except (ValueError, SyntaxError):
+        pass
+
+    # Strategy 4: Treat as string
+    try:
+        quoted_value = json.dumps(str(json_value))
+        return json.loads(quoted_value), True
+    except (json.JSONDecodeError, ValueError):
+        return json_value, False
+
+
+class Glm4MoeDetector(BaseFormatDetector):
+    """
+    Detector for GLM-4.5 and GLM-4.6 models.
+    Assumes function call format (with actual newlines):
+      <tool_call>get_weather
+      <arg_key>city</arg_key>
+      <arg_value>北京</arg_value>
+      <arg_key>date</arg_key>
+      <arg_value>2024-06-27</arg_value>
+      </tool_call>
+
+    Or with literal \n characters (escaped as \\n in the output):
+      <tool_call>get_weather\n<arg_key>city</arg_key>\n<arg_value>北京</arg_value>\n</tool_call>
+
+    Uses a streaming state machine to convert XML to JSON incrementally for maximum speed.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.bot_token = "<tool_call>"
+        self.eot_token = "</tool_call>"
+        self.func_call_regex = r"<tool_call>.*?</tool_call>"
+        self.func_detail_regex = re.compile(
+            r"<tool_call>(.*?)(?:\\n|\n)(.*)</tool_call>", re.DOTALL
+        )
+        self.func_arg_regex = re.compile(
+            r"<arg_key>(.*?)</arg_key>(?:\\n|\s)*<arg_value>(.*?)</arg_value>",
+            re.DOTALL,
+        )
+        self._last_arguments = ""
+        self.current_tool_id = -1
+        self.current_tool_name_sent = False
+        self._streamed_raw_length = 0
+        self._reset_streaming_state()
+
+    def _reset_streaming_state(self) -> None:
+        """Reset the streaming state machine for a new tool call."""
+        self._stream_state = StreamState.INIT
+        self._current_key = ""
+        self._current_value = ""
+        self._xml_tag_buffer = ""
+        self._is_first_param = True
+        self._value_started = False
+        self._cached_value_type: str | None = None  # Cache the value type for consistency
+
+    def has_tool_call(self, text: str) -> bool:
+        """Check if the text contains a glm-4.5 / glm-4.6 format tool call."""
+        return self.bot_token in text
+
+    def detect_and_parse(self, text: str, tools: list[Tool]) -> StreamingParseResult:
+        """
+        One-time parsing: Detects and parses tool calls in the provided text.
+
+        :param text: The complete text to parse.
+        :param tools: List of available tools.
+        :return: ParseResult indicating success or failure, consumed text, leftover text, and parsed calls.
+        """
+        idx = text.find(self.bot_token)
+        normal_text = text[:idx].strip() if idx != -1 else text
+        if self.bot_token not in text:
+            return StreamingParseResult(normal_text=normal_text, calls=[])
+        match_result_list = re.findall(self.func_call_regex, text, re.DOTALL)
+        calls = []
+        try:
+            for match_result in match_result_list:
+                # Get function name
+                func_detail = self.func_detail_regex.search(match_result)
+                if func_detail is None:
+                    continue
+                func_name = func_detail.group(1) if func_detail.group(1) else ""
+                func_args = func_detail.group(2) if func_detail.group(2) else ""
+                pairs = self.func_arg_regex.findall(func_args)
+
+                # Parse arguments using shared method
+                arguments = self._parse_argument_pairs(pairs, func_name, tools)
+
+                # construct match_result for parse_base_json
+                match_result = {"name": func_name, "parameters": arguments}
+                calls.extend(self.parse_base_json(match_result, tools))
+            return StreamingParseResult(normal_text=normal_text, calls=calls)
+        except Exception as e:
+            logger.exception("Error in detect_and_parse: %s", e)
+            # return the normal text if parsing fails
+            return StreamingParseResult(normal_text=text)
+
+    def _get_value_type(self, func_name: str, key: str, tools: list[Tool]) -> str:
+        """Get parameter type from tool definition, with fallback to auto-detection.
+
+        Args:
+            func_name: Name of the function
+            key: Parameter name
+            tools: List of available tools
+
+        Returns:
+            Type string: 'string', 'number', 'object', 'array', or 'boolean'
+        """
+        arg_type = get_argument_type(func_name, key, tools)
+        if arg_type:
+            return arg_type
+
+        # Improved auto-detection type from value (best effort)
+        value_content = self._current_value.strip() if self._current_value else ""
+
+        if not value_content:
+            return "string"
+
+        # Try to parse as valid JSON first
+        try:
+            parsed = json.loads(value_content)
+            if isinstance(parsed, dict):
+                return "object"
+            elif isinstance(parsed, list):
+                return "array"
+            elif isinstance(parsed, bool):
+                return "boolean"
+            elif isinstance(parsed, (int, float)):
+                return "number"
+            # For string values, check if they look like numbers
+            elif isinstance(parsed, str):
+                if parsed.isdigit() or (parsed.startswith("-") and parsed[1:].isdigit()):
+                    return "number"
+                return "string"
+        except json.JSONDecodeError:
+            # Not valid JSON, try heuristic detection
+            first_char = value_content[0] if value_content else ""
+
+            if first_char.isdigit() or first_char in ["-", "."]:
+                return "number"
+            elif first_char in ["{", "["]:
+                return "object"
+            elif first_char in ['"', "'"]:
+                return "string"
+
+        # Default to string (safest fallback)
+        return "string"
+
+    def _format_value_complete(self, value: str, value_type: str) -> str:
+        """Format complete value based on type.
+
+        Args:
+            value: Raw value string
+            value_type: Expected type ('string', 'number', 'object')
+
+        Returns:
+            Properly formatted JSON value string
+        """
+        if value_type == "string":
+            # Ensure proper JSON string formatting with quotes
+            return json.dumps(value, ensure_ascii=False)
+        elif value_type == "number":
+            try:
+                num = _convert_to_number(value.strip())
+                return str(num)
+            except (ValueError, AttributeError):
+                # Fallback to string if not a valid number
+                logger.warning("Failed to parse '%s' as number, treating as string", value)
+                return json.dumps(str(value), ensure_ascii=False)
+        else:
+            # For object/array types, return as-is (should already be valid JSON)
+            return value
+
+    def _process_xml_to_json_streaming(
+        self, raw_increment: str, func_name: str, tools: list[Tool]
+    ) -> str:
+        """Convert XML increment to JSON streaming output using state machine.
+
+        This method processes XML fragments character by character and converts them
+        to JSON format incrementally. It maintains state across calls to handle
+        partial XML tags and values.
+
+        Args:
+            raw_increment: New XML content to process
+            func_name: Name of the function being called
+            tools: List of available tools for type inference
+
+        Returns:
+            JSON string increment to append to the output
+        """
+        json_output = ""
+
+        for char in raw_increment:
+            self._xml_tag_buffer += char
+
+            if self._stream_state in [StreamState.INIT, StreamState.BETWEEN]:
+                if self._xml_tag_buffer.endswith("<arg_key>"):
+                    self._stream_state = StreamState.IN_KEY
+                    self._current_key = ""
+                    self._xml_tag_buffer = ""
+                    json_output += "{" if self._is_first_param else ", "
+                    self._is_first_param = False
+
+            elif self._stream_state == StreamState.IN_KEY:
+                if self._xml_tag_buffer.endswith("</arg_key>"):
+                    self._current_key = self._xml_tag_buffer[:-10].strip()
+                    self._xml_tag_buffer = ""
+                    self._stream_state = StreamState.WAITING_VALUE
+                    json_output += json.dumps(self._current_key, ensure_ascii=False) + ": "
+
+            elif self._stream_state == StreamState.WAITING_VALUE:
+                if self._xml_tag_buffer.endswith("<arg_value>"):
+                    self._stream_state = StreamState.IN_VALUE
+                    self._current_value = ""
+                    self._xml_tag_buffer = ""
+                    self._value_started = False
+                    # Determine and cache the value type at the start
+                    self._cached_value_type = self._get_value_type(
+                        func_name, self._current_key, tools
+                    )
+
+            elif self._stream_state == StreamState.IN_VALUE:
+                if self._xml_tag_buffer.endswith("</arg_value>"):
+                    final_value = self._xml_tag_buffer[:-12]
+                    self._current_value += final_value
+
+                    # Use cached value type for consistency
+                    value_type = self._cached_value_type or "string"
+
+                    if self._value_started:
+                        # Output any remaining content
+                        if final_value:
+                            if value_type == "string":
+                                json_output += json.dumps(final_value, ensure_ascii=False)[1:-1]
+                            else:
+                                json_output += final_value
+                        # Always output closing quote for string type when value was started
+                        if value_type == "string":
+                            json_output += '"'
+                    else:
+                        # Value was never started (empty or complete in one chunk)
+                        json_output += self._format_value_complete(self._current_value, value_type)
+
+                    self._xml_tag_buffer = ""
+                    self._stream_state = StreamState.BETWEEN
+                    self._current_value = ""
+                    self._value_started = False
+                    self._cached_value_type = None  # Reset cached type
+                else:
+                    closing_tag = "</arg_value>"
+                    is_potential_closing = len(self._xml_tag_buffer) <= len(
+                        closing_tag
+                    ) and closing_tag.startswith(self._xml_tag_buffer)
+
+                    if not is_potential_closing:
+                        content = self._xml_tag_buffer
+                        # Use cached value type for consistency
+                        value_type = self._cached_value_type or "string"
+
+                        if value_type == "string":
+                            if not self._value_started:
+                                json_output += '"'
+                                self._value_started = True
+                            if content:
+                                json_output += json.dumps(content, ensure_ascii=False)[1:-1]
+                                self._current_value += content
+                                self._xml_tag_buffer = ""
+                        elif value_type == "number":
+                            if content:
+                                if not self._value_started:
+                                    self._value_started = True
+                                json_output += content
+                                self._current_value += content
+                                self._xml_tag_buffer = ""
+                        else:
+                            # For object/array types, output as-is
+                            if content:
+                                if not self._value_started:
+                                    self._value_started = True
+                                json_output += content
+                                self._current_value += content
+                                self._xml_tag_buffer = ""
+
+        return json_output
+
+    def parse_streaming_increment(self, new_text: str, tools: list[Tool]) -> StreamingParseResult:
+        """
+        Streaming incremental parsing tool calls for GLM-4.5 and GLM-4.6 format.
+        Uses a state machine to convert XML to JSON incrementally for true character-by-character streaming.
+        Outputs JSON increments immediately as XML data arrives.
+        """
+        self._buffer += new_text
+        current_text = self._buffer
+
+        # Check if we have a tool call
+        has_tool_call = self.bot_token in current_text
+
+        if not has_tool_call:
+            # Check if buffer could be the start of a tool call
+            # Keep buffer if it could be a partial match of bot_token
+            is_potential_start = any(
+                self.bot_token.startswith(current_text[-i:])
+                for i in range(1, min(len(current_text), len(self.bot_token)) + 1)
+            )
+
+            if not is_potential_start:
+                # Not a potential tool call, return as normal text
+                # Must return the entire buffer (current_text), not just new_text,
+                # because buffer may contain previously accumulated characters like '<'
+                # that turned out not to be part of a tool call
+                output_text = current_text
+                self._buffer = ""
+                if self.eot_token in output_text:
+                    output_text = output_text.replace(self.eot_token, "")
+                return StreamingParseResult(normal_text=output_text)
+            else:
+                # Could be start of tool call, keep buffering
+                return StreamingParseResult(normal_text="", calls=[])
+
+        if not hasattr(self, "_tool_indices"):
+            self._tool_indices = self._get_tool_indices(tools)
+
+        calls: list[ToolCallItem] = []
+        try:
+            # Try to match a partial or complete tool call
+            partial_match = re.search(
+                pattern=r"<tool_call>(.*?)(?:\\n|\n)(.*?)(</tool_call>|$)",
+                string=current_text,
+                flags=re.DOTALL,
+            )
+            if partial_match:
+                func_name_raw = partial_match.group(1)
+                func_args_raw = partial_match.group(2)
+                is_tool_end = partial_match.group(3)
+
+                # Only proceed if we have a non-empty function name
+                if func_name_raw is None or not func_name_raw.strip():
+                    # If we only have the start token without a function name,
+                    # continue buffering until we get more content
+                    return StreamingParseResult(normal_text="", calls=[])
+
+                func_name = func_name_raw.strip()
+                func_args_raw = func_args_raw.strip() if func_args_raw else ""
+
+                # Initialize state if this is the first tool call
+                if self.current_tool_id == -1:
+                    self.current_tool_id = 0
+                    self.prev_tool_call_arr = []
+                    self.streamed_args_for_tool = [""]
+                    self._streamed_raw_length = 0
+                    self.current_tool_name_sent = False
+                    self._reset_streaming_state()
+
+                # Ensure we have enough entries in our tracking arrays
+                while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                    self.prev_tool_call_arr.append({})
+                while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                    self.streamed_args_for_tool.append("")
+
+                # Send tool name first if not sent yet
+                if not self.current_tool_name_sent:
+                    calls.append(
+                        ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            name=func_name,
+                            parameters="",
+                        )
+                    )
+                    self.current_tool_name_sent = True
+                    self._streamed_raw_length = 0
+                    self._reset_streaming_state()
+                    # Store the tool call info
+                    self.prev_tool_call_arr[self.current_tool_id] = {
+                        "name": func_name,
+                        "arguments": {},
+                    }
+                else:
+                    # Process XML to JSON streaming
+                    current_raw_length = len(func_args_raw)
+
+                    if current_raw_length > self._streamed_raw_length:
+                        # Get the new raw XML content
+                        raw_increment = func_args_raw[self._streamed_raw_length :]
+
+                        # Convert XML increment to JSON increment using state machine
+                        json_increment = self._process_xml_to_json_streaming(
+                            raw_increment, func_name, tools
+                        )
+
+                        # CRITICAL: Update streamed length BEFORE checking json_increment
+                        # Even if json_increment is empty, the input has been consumed by the state machine
+                        self._streamed_raw_length = current_raw_length
+
+                        if json_increment:
+                            calls.append(
+                                ToolCallItem(
+                                    tool_index=self.current_tool_id,
+                                    name=None,
+                                    parameters=json_increment,
+                                )
+                            )
+                            self._last_arguments += json_increment
+                            self.streamed_args_for_tool[
+                                self.current_tool_id
+                            ] += json_increment
+
+                    if is_tool_end == self.eot_token:
+                        if self._is_first_param:
+                            empty_object = "{}"
+                            calls.append(
+                                ToolCallItem(
+                                    tool_index=self.current_tool_id,
+                                    name=None,
+                                    parameters=empty_object,
+                                )
+                            )
+                            self._last_arguments += empty_object
+                        elif not self._last_arguments.endswith("}"):
+                            closing_brace = "}"
+                            calls.append(
+                                ToolCallItem(
+                                    tool_index=self.current_tool_id,
+                                    name=None,
+                                    parameters=closing_brace,
+                                )
+                            )
+                            self._last_arguments += closing_brace
+                            self.streamed_args_for_tool[
+                                self.current_tool_id
+                            ] += closing_brace
+
+                        try:
+                            pairs = self.func_arg_regex.findall(func_args_raw)
+                            if pairs:
+                                arguments = self._parse_argument_pairs(
+                                    pairs, func_name, tools
+                                )
+                                self.prev_tool_call_arr[self.current_tool_id][
+                                    "arguments"
+                                ] = arguments
+                        except Exception as e:
+                            logger.debug("Failed to parse arguments: %s", e, exc_info=True)
+
+                        # Remove the completed tool call from buffer
+                        self._buffer = current_text[partial_match.end(3) :]
+
+                        result = StreamingParseResult(normal_text="", calls=calls)
+                        self.current_tool_id += 1
+                        self._last_arguments = ""
+                        self.current_tool_name_sent = False
+                        self._streamed_raw_length = 0
+                        self._reset_streaming_state()
+                        return result
+
+            return StreamingParseResult(normal_text="", calls=calls)
+
+        except Exception as e:
+            logger.exception("Error in parse_streaming_increment: %s", e)
+            return StreamingParseResult(normal_text=current_text)
+
+    def _parse_argument_pairs(
+        self, pairs: list[tuple[str, str]], func_name: str, tools: list[Tool]
+    ) -> dict[str, Any]:
+        """Parse argument key-value pairs with type coercion.
+
+        Args:
+            pairs: List of (key, value) tuples from regex matching
+            func_name: Name of the function
+            tools: List of available tools
+
+        Returns:
+            Dictionary of parsed arguments
+        """
+        arguments = {}
+        for arg_key, arg_value in pairs:
+            arg_key = arg_key.strip()
+            arg_type = get_argument_type(func_name, arg_key, tools)
+            parsed_value, is_good_json = parse_arguments(arg_value, arg_type)
+
+            if arg_type == "string":
+                # Only convert to string if explicitly defined as string type
+                if isinstance(parsed_value, str):
+                    arguments[arg_key] = parsed_value
+                elif isinstance(parsed_value, (dict, list)):
+                    # If parsed as dict/list but schema says string, convert to JSON string
+                    arguments[arg_key] = json.dumps(parsed_value, ensure_ascii=False)
+                else:
+                    arguments[arg_key] = str(parsed_value)
+            elif arg_type is None:
+                # If type is not defined, keep the parsed value as-is
+                arguments[arg_key] = parsed_value if is_good_json else arg_value
+            else:
+                # For other types (number, object, array, etc.), use parsed value
+                arguments[arg_key] = parsed_value if is_good_json else arg_value
+
+        return arguments
+
+    def supports_structural_tag(self) -> bool:
+        return False
+
+    def structure_info(self) -> _GetInfoFunc:
+        raise NotImplementedError()
+
+    def build_ebnf(self, tools: list[Tool]) -> str:
+        raise NotImplementedError()

--- a/python/sgl_jax/srt/function_call/utils.py
+++ b/python/sgl_jax/srt/function_call/utils.py
@@ -1,6 +1,6 @@
 from json import JSONDecodeError, JSONDecoder
 from json.decoder import WHITESPACE
-from typing import Any, Literal
+from typing import Any, Dict, List, Literal, Optional
 
 import orjson
 import partial_json_parser
@@ -139,5 +139,108 @@ def get_json_schema_constraint(
         if json_schema_defs:
             json_schema["$defs"] = json_schema_defs
         return json_schema
+
+    return None
+
+
+def infer_type_from_json_schema(schema: Dict[str, Any]) -> Optional[str]:
+    """
+    Infer the primary type of a parameter from JSON Schema.
+
+    Supports complex JSON Schema structures including:
+    - Direct type field (including type arrays)
+    - anyOf/oneOf: parameter can be any of multiple types
+    - enum: parameter must be one of enum values
+    - allOf: parameter must satisfy all type definitions
+    - properties: inferred as object type
+    - items: inferred as array type
+
+    Args:
+        schema: JSON Schema definition
+
+    Returns:
+        Inferred type ('string', 'number', 'object', 'array', etc.) or None
+    """
+    if not isinstance(schema, dict):
+        return None
+
+    # Priority 1: Direct type field (including type arrays)
+    if "type" in schema:
+        type_value = schema["type"]
+        if isinstance(type_value, str):
+            return type_value
+        elif isinstance(type_value, list) and type_value:
+            # Handle type arrays: return first non-null type
+            non_null_types = [t for t in type_value if t != "null"]
+            if non_null_types:
+                return non_null_types[0]
+            return "string"  # If only null, default to string
+
+    # Priority 2: Handle anyOf/oneOf
+    if "anyOf" in schema or "oneOf" in schema:
+        schemas = schema.get("anyOf") or schema.get("oneOf")
+        types = []
+
+        if isinstance(schemas, list):
+            for sub_schema in schemas:
+                inferred_type = infer_type_from_json_schema(sub_schema)
+                if inferred_type:
+                    types.append(inferred_type)
+
+            if types:
+                # If all types are the same, return unified type
+                if len(set(types)) == 1:
+                    return types[0]
+                # When types differ, prioritize string (safest)
+                if "string" in types:
+                    return "string"
+                # Otherwise return first type
+                return types[0]
+
+    # Priority 3: Handle enum (infer type from enum values)
+    if "enum" in schema and isinstance(schema["enum"], list):
+        if not schema["enum"]:
+            return "string"
+
+        # Infer type from enum values
+        enum_types = set()
+        for value in schema["enum"]:
+            if value is None:
+                enum_types.add("null")
+            elif isinstance(value, bool):
+                enum_types.add("boolean")
+            elif isinstance(value, int):
+                enum_types.add("integer")
+            elif isinstance(value, float):
+                enum_types.add("number")
+            elif isinstance(value, str):
+                enum_types.add("string")
+            elif isinstance(value, list):
+                enum_types.add("array")
+            elif isinstance(value, dict):
+                enum_types.add("object")
+
+        # If type is uniform, return that type
+        if len(enum_types) == 1:
+            return enum_types.pop()
+        # Mixed types, prioritize string
+        return "string"
+
+    # Priority 4: Handle allOf (must satisfy all types)
+    if "allOf" in schema and isinstance(schema["allOf"], list):
+        schemas = schema["allOf"]
+        for sub_schema in schemas:
+            inferred_type = infer_type_from_json_schema(sub_schema)
+            if inferred_type and inferred_type != "string":
+                return inferred_type
+        return "string"
+
+    # Priority 5: Infer object type
+    if "properties" in schema:
+        return "object"
+
+    # Priority 6: Infer array type
+    if "items" in schema:
+        return "array"
 
     return None

--- a/python/sgl_jax/srt/function_call/utils.py
+++ b/python/sgl_jax/srt/function_call/utils.py
@@ -1,6 +1,6 @@
 from json import JSONDecodeError, JSONDecoder
 from json.decoder import WHITESPACE
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal
 
 import orjson
 import partial_json_parser
@@ -143,7 +143,7 @@ def get_json_schema_constraint(
     return None
 
 
-def infer_type_from_json_schema(schema: Dict[str, Any]) -> Optional[str]:
+def infer_type_from_json_schema(schema: dict[str, Any]) -> str | None:
     """
     Infer the primary type of a parameter from JSON Schema.
 

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -2,8 +2,8 @@
 
 import concurrent.futures as futures
 import dataclasses
-import json
 import faulthandler
+import json
 import logging
 import os
 import pickle

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -2,6 +2,7 @@
 
 import concurrent.futures as futures
 import dataclasses
+import json
 import faulthandler
 import logging
 import os
@@ -1029,13 +1030,21 @@ class Scheduler(
                 req.set_finish_with_abort(error_msg)
             else:
                 if req.sampling_params.json_schema is not None:
-                    key = ("json", req.sampling_params.json_schema)
+                    schema = req.sampling_params.json_schema
+                    if isinstance(schema, dict):
+                        schema = json.dumps(schema, sort_keys=True)
+                    key = ("json", schema)
                 elif req.sampling_params.regex is not None:
                     key = ("regex", req.sampling_params.regex)
                 elif req.sampling_params.ebnf is not None:
                     key = ("ebnf", req.sampling_params.ebnf)
                 elif req.sampling_params.structural_tag:
-                    key = ("structural_tag", req.sampling_params.structural_tag)
+                    tag = req.sampling_params.structural_tag
+                    if hasattr(tag, "model_dump_json"):
+                        tag = tag.model_dump_json()
+                    elif isinstance(tag, dict):
+                        tag = json.dumps(tag, sort_keys=True)
+                    key = ("structural_tag", tag)
 
                 value, cache_hit = self.grammar_backend.get_cached_or_future_value(key)
                 req.grammar = value

--- a/python/sgl_jax/srt/reasoning_parser.py
+++ b/python/sgl_jax/srt/reasoning_parser.py
@@ -41,16 +41,11 @@ class BaseReasoningFormatDetector:
 
         if self.think_end_token not in processed_text:
             # Check for tool_start_token interruption
-            if (
-                self.tool_start_token is not None
-                and self.tool_start_token in processed_text
-            ):
+            if self.tool_start_token is not None and self.tool_start_token in processed_text:
                 tool_idx = processed_text.find(self.tool_start_token)
                 reasoning_text = processed_text[:tool_idx].strip()
                 normal_text = processed_text[tool_idx:]
-                return StreamingParseResult(
-                    normal_text=normal_text, reasoning_text=reasoning_text
-                )
+                return StreamingParseResult(normal_text=normal_text, reasoning_text=reasoning_text)
             # Assume reasoning was truncated before `</think>` token
             return StreamingParseResult(reasoning_text=processed_text)
 
@@ -79,8 +74,7 @@ class BaseReasoningFormatDetector:
         if self.tool_start_token:
             tokens_to_check.append(self.tool_start_token)
         if any(
-            token.startswith(current_text) and token != current_text
-            for token in tokens_to_check
+            token.startswith(current_text) and token != current_text for token in tokens_to_check
         ):
             return StreamingParseResult()
 
@@ -113,9 +107,7 @@ class BaseReasoningFormatDetector:
                 normal_text = current_text[tool_idx:]
                 self._buffer = ""
                 self._in_reasoning = False
-                return StreamingParseResult(
-                    normal_text=normal_text, reasoning_text=reasoning_text
-                )
+                return StreamingParseResult(normal_text=normal_text, reasoning_text=reasoning_text)
             if self.stream_reasoning:
                 # Stream the content immediately
                 self._buffer = ""

--- a/python/sgl_jax/srt/reasoning_parser.py
+++ b/python/sgl_jax/srt/reasoning_parser.py
@@ -209,7 +209,7 @@ class Glm47Detector(BaseReasoningFormatDetector):
             If True, streams reasoning content as it arrives.
     """
 
-    def __init__(self, stream_reasoning: bool = True, force_reasoning: bool = False):
+    def __init__(self, stream_reasoning: bool = True, force_reasoning: bool = True):
         super().__init__(
             "<think>",
             "</think>",

--- a/python/sgl_jax/srt/reasoning_parser.py
+++ b/python/sgl_jax/srt/reasoning_parser.py
@@ -15,11 +15,13 @@ class BaseReasoningFormatDetector:
         think_end_token: str,
         force_reasoning: bool = False,
         stream_reasoning: bool = True,
+        tool_start_token: str | None = None,
     ):
         self.think_start_token = think_start_token
         self.think_end_token = think_end_token
         self._in_reasoning = force_reasoning
         self.stream_reasoning = stream_reasoning
+        self.tool_start_token = tool_start_token
 
         self._buffer = ""
         self.stripped_think_start = False
@@ -38,6 +40,17 @@ class BaseReasoningFormatDetector:
         processed_text = text.replace(self.think_start_token, "").strip()
 
         if self.think_end_token not in processed_text:
+            # Check for tool_start_token interruption
+            if (
+                self.tool_start_token is not None
+                and self.tool_start_token in processed_text
+            ):
+                tool_idx = processed_text.find(self.tool_start_token)
+                reasoning_text = processed_text[:tool_idx].strip()
+                normal_text = processed_text[tool_idx:]
+                return StreamingParseResult(
+                    normal_text=normal_text, reasoning_text=reasoning_text
+                )
             # Assume reasoning was truncated before `</think>` token
             return StreamingParseResult(reasoning_text=processed_text)
 
@@ -62,9 +75,12 @@ class BaseReasoningFormatDetector:
         current_text = self._buffer
 
         # If the current text is a prefix of the think token, keep buffering
+        tokens_to_check = [self.think_start_token, self.think_end_token]
+        if self.tool_start_token:
+            tokens_to_check.append(self.tool_start_token)
         if any(
             token.startswith(current_text) and token != current_text
-            for token in [self.think_start_token, self.think_end_token]
+            for token in tokens_to_check
         ):
             return StreamingParseResult()
 
@@ -90,6 +106,16 @@ class BaseReasoningFormatDetector:
 
         # Continue with reasoning content
         if self._in_reasoning:
+            # Check for tool_start_token interruption
+            if self.tool_start_token and self.tool_start_token in current_text:
+                tool_idx = current_text.find(self.tool_start_token)
+                reasoning_text = current_text[:tool_idx]
+                normal_text = current_text[tool_idx:]
+                self._buffer = ""
+                self._in_reasoning = False
+                return StreamingParseResult(
+                    normal_text=normal_text, reasoning_text=reasoning_text
+                )
             if self.stream_reasoning:
                 # Stream the content immediately
                 self._buffer = ""
@@ -170,6 +196,29 @@ class KimiDetector(BaseReasoningFormatDetector):
         )
 
 
+class Glm47Detector(BaseReasoningFormatDetector):
+    """
+    Detector for GLM-4.7 models.
+    Assumes reasoning format:
+      (<think>)*(.*)</think>
+
+    GLM-4.7 uses `<tool_call>` as the tool start token to switch from reasoning mode to normal mode.
+
+    Args:
+        stream_reasoning (bool): If False, accumulates reasoning content until the end tag.
+            If True, streams reasoning content as it arrives.
+    """
+
+    def __init__(self, stream_reasoning: bool = True, force_reasoning: bool = False):
+        super().__init__(
+            "<think>",
+            "</think>",
+            force_reasoning=force_reasoning,
+            stream_reasoning=stream_reasoning,
+            tool_start_token="<tool_call>",
+        )
+
+
 class ReasoningParser:
     """
     Parser that handles both streaming and non-streaming scenarios for extracting
@@ -186,6 +235,7 @@ class ReasoningParser:
         "qwen3": Qwen3Detector,
         "mimo": Qwen3Detector,
         "kimi": KimiDetector,
+        "glm47": Glm47Detector,
     }
 
     def __init__(self, model_type: str | None = None, stream_reasoning: bool = True):

--- a/python/sgl_jax/srt/reasoning_parser.py
+++ b/python/sgl_jax/srt/reasoning_parser.py
@@ -188,13 +188,13 @@ class KimiDetector(BaseReasoningFormatDetector):
         )
 
 
-class Glm47Detector(BaseReasoningFormatDetector):
+class Glm45Detector(BaseReasoningFormatDetector):
     """
-    Detector for GLM-4.7 models.
+    Detector for GLM-4.5 / 4.6 / 4.7 models.
     Assumes reasoning format:
       (<think>)*(.*)</think>
 
-    GLM-4.7 uses `<tool_call>` as the tool start token to switch from reasoning mode to normal mode.
+    GLM models use `<tool_call>` as the tool start token to switch from reasoning mode to normal mode.
 
     Args:
         stream_reasoning (bool): If False, accumulates reasoning content until the end tag.
@@ -227,7 +227,7 @@ class ReasoningParser:
         "qwen3": Qwen3Detector,
         "mimo": Qwen3Detector,
         "kimi": KimiDetector,
-        "glm47": Glm47Detector,
+        "glm45": Glm45Detector,
     }
 
     def __init__(self, model_type: str | None = None, stream_reasoning: bool = True):

--- a/python/sgl_jax/srt/reasoning_parser.py
+++ b/python/sgl_jax/srt/reasoning_parser.py
@@ -201,7 +201,7 @@ class Glm45Detector(BaseReasoningFormatDetector):
             If True, streams reasoning content as it arrives.
     """
 
-    def __init__(self, stream_reasoning: bool = True, force_reasoning: bool = True):
+    def __init__(self, stream_reasoning: bool = True, force_reasoning: bool = False):
         super().__init__(
             "<think>",
             "</think>",

--- a/test/srt/function_call/test_glm47_detector.py
+++ b/test/srt/function_call/test_glm47_detector.py
@@ -1,0 +1,59 @@
+import json
+import unittest
+
+from sgl_jax.srt.entrypoints.openai.protocol import Function, Tool
+from sgl_jax.srt.function_call.glm47_moe_detector import Glm47MoeDetector
+from sgl_jax.test.test_utils import CustomTestCase
+
+
+def _tool(name: str, properties: dict | None = None) -> Tool:
+    return Tool(
+        type="function",
+        function=Function(
+            name=name,
+            description=f"{name} tool",
+            parameters={"type": "object", "properties": properties or {}},
+        ),
+    )
+
+
+def _bash_tool() -> Tool:
+    return _tool(
+        "execute_bash",
+        {"command": {"type": "string"}},
+    )
+
+
+class TestGlm47Detector(CustomTestCase):
+    def test_has_tool_call(self):
+        d = Glm47MoeDetector()
+        self.assertTrue(d.has_tool_call("foo<tool_call>bar"))
+        self.assertFalse(d.has_tool_call("just normal text"))
+
+    def test_detect_and_parse_single_call(self):
+        text = (
+            "thinking done\n"
+            "<tool_call>execute_bash<arg_key>command</arg_key><arg_value>ls</arg_value></tool_call>"
+        )
+        result = Glm47MoeDetector().detect_and_parse(text, [_bash_tool()])
+        self.assertEqual(result.normal_text, "thinking done")
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "execute_bash")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args, {"command": "ls"})
+
+    def test_detect_and_parse_two_calls(self):
+        text = (
+            "<tool_call>execute_bash<arg_key>command</arg_key><arg_value>ls</arg_value></tool_call>"
+            "<tool_call>execute_bash<arg_key>command</arg_key><arg_value>pwd</arg_value></tool_call>"
+        )
+        result = Glm47MoeDetector().detect_and_parse(text, [_bash_tool()])
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "execute_bash")
+        self.assertEqual(json.loads(result.calls[0].parameters), {"command": "ls"})
+        self.assertEqual(result.calls[1].name, "execute_bash")
+        self.assertEqual(json.loads(result.calls[1].parameters), {"command": "pwd"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -518,6 +518,8 @@ suites = {
         TestFile("test/srt/openai_server/features/test_json_mode.py", 2),
         TestFile("test/srt/openai_server/features/test_structural_tag.py", 2),
         TestFile("test/srt/function_call/test_mimo_detector.py", 0.1),
+        TestFile("test/srt/function_call/test_glm47_detector.py", 0.1),
+        TestFile("test/srt/test_reasoning_parser.py", 0.1),
         TestFile("test/srt/test_srt_engine.py", 1),
         TestFile("test/srt/test_logprobs.py", 3),
         TestFile("test/srt/test_penalty.py", 12),

--- a/test/srt/test_reasoning_parser.py
+++ b/test/srt/test_reasoning_parser.py
@@ -1,0 +1,23 @@
+import unittest
+
+from sgl_jax.srt.reasoning_parser import ReasoningParser
+from sgl_jax.test.test_utils import CustomTestCase
+
+
+class TestReasoningParserGlm(CustomTestCase):
+    def test_glm47_reasoning(self):
+        parser = ReasoningParser(model_type="glm47")
+        reasoning, normal = parser.parse_non_stream("<think>this is reasoning</think>this is normal")
+        self.assertEqual(reasoning, "this is reasoning")
+        self.assertEqual(normal, "this is normal")
+
+    def test_glm47_interruption(self):
+        parser = ReasoningParser(model_type="glm47")
+        # Glm47Detector uses tool_start_token="<tool_call>"
+        reasoning, normal = parser.parse_non_stream("<think>thinking...<tool_call>func")
+        self.assertEqual(reasoning, "thinking...")
+        self.assertEqual(normal, "<tool_call>func")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_reasoning_parser.py
+++ b/test/srt/test_reasoning_parser.py
@@ -6,7 +6,7 @@ from sgl_jax.test.test_utils import CustomTestCase
 
 class TestReasoningParserGlm(CustomTestCase):
     def test_glm47_reasoning(self):
-        parser = ReasoningParser(model_type="glm47")
+        parser = ReasoningParser(model_type="glm45")
         reasoning, normal = parser.parse_non_stream(
             "<think>this is reasoning</think>this is normal"
         )
@@ -14,8 +14,8 @@ class TestReasoningParserGlm(CustomTestCase):
         self.assertEqual(normal, "this is normal")
 
     def test_glm47_interruption(self):
-        parser = ReasoningParser(model_type="glm47")
-        # Glm47Detector uses tool_start_token="<tool_call>"
+        parser = ReasoningParser(model_type="glm45")
+        # Glm45Detector uses tool_start_token="<tool_call>"
         reasoning, normal = parser.parse_non_stream("<think>thinking...<tool_call>func")
         self.assertEqual(reasoning, "thinking...")
         self.assertEqual(normal, "<tool_call>func")

--- a/test/srt/test_reasoning_parser.py
+++ b/test/srt/test_reasoning_parser.py
@@ -7,7 +7,9 @@ from sgl_jax.test.test_utils import CustomTestCase
 class TestReasoningParserGlm(CustomTestCase):
     def test_glm47_reasoning(self):
         parser = ReasoningParser(model_type="glm47")
-        reasoning, normal = parser.parse_non_stream("<think>this is reasoning</think>this is normal")
+        reasoning, normal = parser.parse_non_stream(
+            "<think>this is reasoning</think>this is normal"
+        )
         self.assertEqual(reasoning, "this is reasoning")
         self.assertEqual(normal, "this is normal")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

This PR implements the reasoning and tool call parsers for **GLM-4.7** in `sglang-jax`, porting the logic from the PyTorch version of SGLang. This enables `sglang-jax` to correctly extract reasoning content and parse the specific XML-like tool call format used by GLM-4.7 models into standard OpenAI-compatible JSON responses.

## Modifications

- **`python/sgl_jax/srt/reasoning_parser.py`**:
  - Added `Glm45Detector` (renamed from `Glm47Detector` to match upstream) to handle `<think>` and `</think>` tags.
  - Updated `BaseReasoningFormatDetector` to support `tool_start_token` (handling interruption of reasoning by `<tool_call>`).
  - Set `force_reasoning=True` for GLM models to prevent reasoning content from leaking into the main response content when the model omits the `<think>` start tag.
  - Registered key `"glm45"` in `DetectorMap` to stay 1:1 with upstream.
- **`python/sgl_jax/srt/function_call/glm47_moe_detector.py`**:
  - Created a new file implementing `Glm47MoeDetector` to parse GLM-4.7's custom XML-like tool call format (`<tool_call>...<arg_key>...</arg_key><arg_value>...</arg_value></tool_call>`).
- **`python/sgl_jax/srt/function_call/glm4_moe_detector.py`**:
  - Ported `Glm4MoeDetector` from upstream to support GLM-4.5 / 4.6 models (which use a slightly different newline format for the same XML tags).
- **`python/sgl_jax/srt/function_call/function_call_parser.py`**:
  - Registered both `"glm45"` and `"glm47"` in `ToolCallParserEnum` to fully support both model families.
- **`python/sgl_jax/srt/function_call/utils.py`**:
  - Added `infer_type_from_json_schema` helper function needed by the GLM detector.
- **`python/sgl_jax/srt/managers/scheduler.py`**:
  - Fixed a `TypeError: unhashable type: 'dict'` bug that occurred when `tool_choice` was forced (dict keys used in grammar cache lookup).
- **`test/srt/run_suite.py`**:
  - Added `test_glm47_detector.py` and `test_reasoning_parser.py` to the test suite.

## Accuracy Tests

Verified with unit tests and integration tests on a running TPU server.

### Unit Tests
- `python3 -m unittest test.srt.test_reasoning_parser` (Passed)
- `python3 -m unittest test.srt.function_call.test_glm47_detector` (Passed after adding stub for `build_ebnf`)

### Integration Tests (Server)

**Example 1: Automatic Tool Selection & Reasoning Separation**
```bash
curl http://localhost:30000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "glm-4.7",
    "messages": [
      {"role": "user", "content": "Calculate 25 * 45 for me."}
    ],
    "tools": [
      {
        "type": "function",
        "function": {
          "name": "calculator",
          "description": "Perform mathematical operations",
          "parameters": {
            "type": "object",
            "properties": {
              "expression": {"type": "string", "description": "The math expression to evaluate"}
            },
            "required": ["expression"]
          }
        }
      }
    ],
    "tool_choice": "auto"
  }'
```
**Output:**
```json
{"id":"2893cde5eabc44c79496f45f83847d26","object":"chat.completion","created":1777757315,"model":"glm-4.7","choices":[{"index":0,"message":{"role":"assistant","content":null,"reasoning_content":"The user wants me to calculate 25 * 45. I should use the calculator function for this.","tool_calls":[{"id":"call_afa0800cf4d6474597dd61ad","index":null,"type":"function","function":{"name":"calculator","arguments":"{\"expression\": \"25 * 45\"}"}}]},"logprobs":null,"finish_reason":"tool_calls","matched_stop":null,"hidden_states":null}],"usage":{"prompt_tokens":177,"total_tokens":212,"completion_tokens":35,"prompt_tokens_details":null}}
```

**Example 2: Multiple Tool Calls in a Single Turn**
```bash
curl http://localhost:30000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "glm-4.7",
    "messages": [
      {"role": "user", "content": "What is the weather in New York and Paris?"}
    ],
    "tools": [
      {
        "type": "function",
        "function": {
          "name": "get_weather",
          "description": "Get the current weather for a location",
          "parameters": {
            "type": "object",
            "properties": {
              "city": {"type": "string", "description": "The city to get weather for"}
            },
            "required": ["city"]
          }
        }
      }
    ],
    "tool_choice": "auto"
  }'
```
**Output:**
```json
{"id":"da263d0d4d2846c7a052e4c23cad061e","object":"chat.completion","created":1777757383,"model":"glm-4.7","choices":[{"index":0,"message":{"role":"assistant","content":"I'll get the current weather for both New York and Paris for you.","reasoning_content":"The user is asking for the weather in two cities: New York and Paris. I have access to a get_weather function that takes a city parameter. I need to make two separate function calls to get the weather for each city.\n\nLet me check the function parameters:\n- get_weather requires a \"city\" parameter (string)\n- Both \"New York\" and \"Paris\" are valid city names\n\nI'll make both function calls.","tool_calls":[{"id":"call_e9713921c1794c69a721713c","index":null,"type":"function","function":{"name":"get_weather","arguments":"{\"city\": \"New York\"}"}},{"id":"call_fcb2c704d6064c17b4fcb30c","index":null,"type":"function","function":{"name":"get_weather","arguments":"{\"city\": \"Paris\"}"}}]},"logprobs":null,"finish_reason":"tool_calls","matched_stop":null,"hidden_states":null}],"usage":{"prompt_tokens":184,"total_tokens":309,"completion_tokens":125,"prompt_tokens_details":null}}
```

## Benchmarking and Profiling

Not applicable. This PR only affects output parsing and does not impact core inference speed.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.

