### PR TITLE
fix(fused_moe): restore pre-acc sync_barrier for EP=32 multi-host correctness

### DIFF
--- a/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
@@ -2739,6 +2739,7 @@ def _fused_ep_moe_kernel(
 
             wait_a2a_scatter_send_batch()
             wait_a2a_gather_recv_all(bt_sem_id=bt_sem_id)
+            sync_barrier()
 
             acc_and_store_output(bt_sem_id=bt_sem_id, out_buf_id=out_buf_id)
 
@@ -2838,6 +2839,7 @@ def _fused_ep_moe_kernel(
             lax.fori_loop(final_se_block, se_total_blocks, cleanup_body, None)
 
             wait_a2a_gather_recv_all(bt_sem_id=bt_sem_id)
+            sync_barrier()
 
             acc_and_store_output(bt_sem_id=bt_sem_id, out_buf_id=out_buf_id)
 


### PR DESCRIPTION
## Summary

- Restore `sync_barrier()` after `wait_a2a_gather_recv_all()` in both batch-scatter and pipelined paths of the fused EP-MoE kernel
- The barrier was removed by #1021 (254e391c), causing TensorCore assertion crashes on EP=32 multi-host setups (4-pod v7x-16t)

## Root Cause

Without the barrier, a fast device can begin `acc_and_store_output()` — reading gather buffers — while a slow device on another host is still writing via ICI gather-send. This data race corrupts HBM contents and triggers a hardware assertion (`TensorCoreSequencer` halt).

On EP=8 single-host the race is masked by low ICI latency, but on EP=32 multi-host (4 pods, 32 devices) the timing window is wide enough to crash reliably.

## Bisect Results (v7x-16t, EP=32, dp=8, 4 hosts, MiMo-V2-Pro)

| Test | Config | Result |
|------|--------|--------|
| Baseline | 481ae803 (parent of #1021) | PASS (6/6 precompile) |
| aeda37f6 | main (includes #1021) | CRASH at step 3 (bs=128, tokens=2048) |
| Test 1 | Force pipelined path (`if False:`) | CRASH at step 1 |
| Test 2 | Restore post-metadata barrier only | CRASH at step 1 |
| **Test 3** | **Restore pre-acc barrier only** | **PASS (6/6 + 2/2 decode)** |

## Test plan

- [x] Precompile passes all 6 EXTEND + 2 DECODE shapes on v7x-16t (EP=32, dp=8, 4 hosts)
- [ ] Kernel benchmark regression check on EP=8 (barrier adds ~12% overhead at decode, per original optimization doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)