### PR TITLE
fix(dummy_loader): always create moe_mesh for expert-sharded weights

### DIFF
--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -2356,19 +2356,20 @@ class WeightLoader:
 
             if mapping.sharding and "expert" in mapping.sharding:
                 ep_size = getattr(self.model_config.hf_config, "ep_size", 1)
-                if ep_size > 1:
-                    world_size = self.mesh.shape.get("data", 1) * self.mesh.shape.get("tensor", 1)
-                    tp_size = world_size // ep_size
+                world_size = self.mesh.shape.get("data", 1) * self.mesh.shape.get("tensor", 1)
+                tp_size = world_size // ep_size
 
-                    devices = self.mesh.devices.flatten()
-                    moe_mesh = jax.sharding.Mesh(
-                        devices.reshape(ep_size, tp_size), axis_names=("expert", "tensor")
-                    )
-                    final_sharding_spec = P(*mapping.sharding)
-                    final_sharding = jax.sharding.NamedSharding(moe_mesh, final_sharding_spec)
-                else:
-                    final_sharding_spec = P(*mapping.sharding)
-                    final_sharding = jax.sharding.NamedSharding(self.mesh, final_sharding_spec)
+                devices = self.mesh.devices.flatten()
+                moe_mesh = jax.sharding.Mesh(
+                    devices.reshape(ep_size, tp_size),
+                    axis_names=("expert", "tensor"),
+                    axis_types=(
+                        jax.sharding.AxisType.Explicit,
+                        jax.sharding.AxisType.Explicit,
+                    ),
+                )
+                final_sharding_spec = P(*mapping.sharding)
+                final_sharding = jax.sharding.NamedSharding(moe_mesh, final_sharding_spec)
             else:
                 final_sharding_spec = P(*mapping.sharding) if mapping.sharding else P()
                 final_sharding = jax.sharding.NamedSharding(self.mesh, final_sharding_spec)


### PR DESCRIPTION
## Summary

- `_load_dummy_weights` only created a `moe_mesh` with `("expert", "tensor")` axes when `ep_size > 1`, falling back to `self.mesh` `("data", "tensor")` otherwise. This caused `NamedSharding(self.mesh, P("expert", ...))` to crash because the mesh has no `"expert"` axis.
- Always create `moe_mesh` when sharding contains `"expert"`, matching the real weight loading paths (lines 2032 and 2145 in `weight_utils.py`). Also adds `axis_types=Explicit` consistent with other mesh constructions.

## Test plan

- [x] Verified on v7x 2x2x2 (16 devices, 2 hosts) with `Qwen3-30B-A3B --load-format dummy --tp-size=16 --nnodes=2`: dummy weights load successfully and server enters precompile stage.

Fixes #1022