### PR TITLE
perf(multimodal): avoid feature hashing for pad values

### DIFF
--- a/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
+++ b/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
@@ -257,6 +257,12 @@ class MMReqState(ReqState):
     rid: str = ""
 
 
+@dataclasses.dataclass(frozen=True)
+class _LoadedMultimodalPayload:
+    data: Any
+    hash: int | None
+
+
 class MultimodalTokenizer(TokenizerManager):
     """Tokenization manager for multimodal requests.
 
@@ -346,7 +352,7 @@ class MultimodalTokenizer(TokenizerManager):
         """
         if hasattr(reqs, "__len__") and len(reqs) > 0 and self.server_args.log_requests:
             logger.info("handle_batch_output %s, self.rid_to_state %s", reqs, self.rid_to_state)
-        if isinstance(reqs, (BatchStrOut, BatchEmbeddingOut, BatchTokenIDOut)):
+        if isinstance(reqs, BatchStrOut | BatchEmbeddingOut | BatchTokenIDOut):
             return super()._handle_batch_output(reqs)
 
         for req in reqs:
@@ -481,18 +487,35 @@ class MultimodalTokenizer(TokenizerManager):
                 "Check model_path and trust_remote_code settings."
             )
         if image_data or video_data or audio_data:
-            images = [
-                self._load_image_from_source(item) for item in image_data
+            image_payloads = [
+                self._load_image_with_hash(item) for item in image_data
             ]  # note: We did not perform a resize operation
+            images = [payload.data for payload in image_payloads]
+            image_hash = self._combine_mm_hashes(
+                [payload.hash for payload in image_payloads],
+                "image",
+            )
             processor_kwargs = {}
             if video_data and self._is_qwen_video_processor():
                 video_config = self._build_qwen_video_config(obj)
-                videos = [self._preprocess_qwen_video(item, video_config) for item in video_data]
+                video_payloads = [
+                    self._preprocess_qwen_video_with_hash(item, video_config) for item in video_data
+                ]
                 processor_kwargs["videos_kwargs"] = {"do_sample_frames": False}
                 processor_kwargs["videos_kwargs"]["fps"] = video_config.get("fps", _QWEN_FPS)
             else:
-                videos = [self._load_video_from_source(item) for item in video_data]
-            audios = [self._load_audio_from_source(item) for item in audio_data]
+                video_payloads = [self._load_video_with_hash(item) for item in video_data]
+            videos = [payload.data for payload in video_payloads]
+            video_hash = self._combine_mm_hashes(
+                [payload.hash for payload in video_payloads],
+                "video",
+            )
+            audio_payloads = [self._load_audio_with_hash(item) for item in audio_data]
+            audios = [payload.data for payload in audio_payloads]
+            audio_hash = self._combine_mm_hashes(
+                [payload.hash for payload in audio_payloads],
+                "audio",
+            )
             processor_out = self.mm_processor(
                 images=images or None,
                 videos=videos or None,
@@ -546,6 +569,7 @@ class MultimodalTokenizer(TokenizerManager):
                 mm_items.append(
                     MultimodalDataItem(
                         modality=Modality.IMAGE,
+                        hash=image_hash,
                         feature=np.asarray(pixel_values),
                     )
                 )
@@ -553,6 +577,7 @@ class MultimodalTokenizer(TokenizerManager):
                 mm_items.append(
                     MultimodalDataItem(
                         modality=Modality.VIDEO,
+                        hash=video_hash,
                         feature=np.asarray(pixel_values_videos),
                     )
                 )
@@ -563,6 +588,7 @@ class MultimodalTokenizer(TokenizerManager):
                 mm_items.append(
                     MultimodalDataItem(
                         modality=Modality.AUDIO,
+                        hash=audio_hash,
                         feature=np.asarray(audio_features),
                     )
                 )
@@ -642,8 +668,17 @@ class MultimodalTokenizer(TokenizerManager):
     def _preprocess_qwen_video(
         self, source: str | bytes | np.ndarray, video_config: dict
     ) -> np.ndarray:
+        return self._preprocess_qwen_video_with_hash(source, video_config).data
+
+    def _preprocess_qwen_video_with_hash(
+        self, source: str | bytes | np.ndarray, video_config: dict
+    ) -> _LoadedMultimodalPayload:
         if isinstance(source, np.ndarray):
-            return self._resize_video_frames(source, video_config)
+            video = self._resize_video_frames(source, video_config)
+            return _LoadedMultimodalPayload(
+                data=video,
+                hash=self._hash_array_payload(video, "qwen_video", video_config),
+            )
 
         if isinstance(source, dict) and "url" in source:
             source = source["url"]
@@ -656,24 +691,49 @@ class MultimodalTokenizer(TokenizerManager):
         tmp_path = None
         try:
             ctx = cpu(0)
+            payload_hash = None
 
             if isinstance(source, bytes):
+                payload_hash = self._hash_payload(source, "qwen_video", video_config)
                 tmp_path = self._write_temp_video(source)
                 vr = VideoReader(tmp_path, ctx=ctx)
             elif isinstance(source, str):
                 if os.path.exists(source):
+                    with open(source, "rb") as video_file:
+                        payload_hash = self._hash_payload(
+                            video_file.read(),
+                            "qwen_video",
+                            video_config,
+                        )
                     vr = VideoReader(source, ctx=ctx)
                 elif source.startswith(("http://", "https://")):
                     resp = requests.get(source, timeout=10)
                     resp.raise_for_status()
+                    payload_hash = self._hash_payload(
+                        resp.content,
+                        "qwen_video",
+                        video_config,
+                    )
                     tmp_path = self._write_temp_video(resp.content)
                     vr = VideoReader(tmp_path, ctx=ctx)
                 elif source.startswith("data:") and "base64," in source:
                     payload = source.split("base64,", 1)[1]
-                    tmp_path = self._write_temp_video(base64.b64decode(payload))
+                    decoded_payload = base64.b64decode(payload)
+                    payload_hash = self._hash_payload(
+                        decoded_payload,
+                        "qwen_video",
+                        video_config,
+                    )
+                    tmp_path = self._write_temp_video(decoded_payload)
                     vr = VideoReader(tmp_path, ctx=ctx)
                 else:
-                    tmp_path = self._write_temp_video(base64.b64decode(source, validate=True))
+                    decoded_payload = base64.b64decode(source, validate=True)
+                    payload_hash = self._hash_payload(
+                        decoded_payload,
+                        "qwen_video",
+                        video_config,
+                    )
+                    tmp_path = self._write_temp_video(decoded_payload)
                     vr = VideoReader(tmp_path, ctx=ctx)
             else:
                 raise ValueError(f"Unsupported video input type: {type(source)}")
@@ -686,7 +746,10 @@ class MultimodalTokenizer(TokenizerManager):
             idx = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
             idx = np.unique(idx)
             video_np = vr.get_batch(idx).asnumpy()
-            return self._resize_video_frames(video_np, video_config)
+            return _LoadedMultimodalPayload(
+                data=self._resize_video_frames(video_np, video_config),
+                hash=payload_hash,
+            )
         finally:
             if tmp_path and os.path.exists(tmp_path):
                 os.unlink(tmp_path)
@@ -748,61 +811,103 @@ class MultimodalTokenizer(TokenizerManager):
         return np.stack(resized_frames, axis=0)
 
     def _load_image_from_source(self, source: str | bytes) -> Image.Image:
+        return self._load_image_with_hash(source).data
+
+    def _load_image_with_hash(self, source: str | bytes) -> _LoadedMultimodalPayload:
         if isinstance(source, dict) and "url" in source:
             source = source["url"]
         if hasattr(source, "url"):
             source = source.url
         if isinstance(source, bytes):
-            return Image.open(io.BytesIO(source)).convert("RGB")
+            return _LoadedMultimodalPayload(
+                data=Image.open(io.BytesIO(source)).convert("RGB"),
+                hash=self._hash_payload(source, "image"),
+            )
         if os.path.exists(source):
-            return Image.open(source).convert("RGB")
+            with open(source, "rb") as image_file:
+                payload = image_file.read()
+            return _LoadedMultimodalPayload(
+                data=Image.open(io.BytesIO(payload)).convert("RGB"),
+                hash=self._hash_payload(payload, "image"),
+            )
         if source.startswith(("http://", "https://")):
             resp = requests.get(source, timeout=10)
             resp.raise_for_status()
-            return Image.open(io.BytesIO(resp.content)).convert("RGB")
+            return _LoadedMultimodalPayload(
+                data=Image.open(io.BytesIO(resp.content)).convert("RGB"),
+                hash=self._hash_payload(resp.content, "image"),
+            )
         if source.startswith("data:") and "base64," in source:
             payload = source.split("base64,", 1)[1]
-            return Image.open(io.BytesIO(base64.b64decode(payload))).convert("RGB")
+            decoded_payload = base64.b64decode(payload)
+            return _LoadedMultimodalPayload(
+                data=Image.open(io.BytesIO(decoded_payload)).convert("RGB"),
+                hash=self._hash_payload(decoded_payload, "image"),
+            )
         try:
-            return Image.open(io.BytesIO(base64.b64decode(source, validate=True))).convert("RGB")
+            decoded_payload = base64.b64decode(source, validate=True)
+            return _LoadedMultimodalPayload(
+                data=Image.open(io.BytesIO(decoded_payload)).convert("RGB"),
+                hash=self._hash_payload(decoded_payload, "image"),
+            )
         except Exception as exc:
             raise ValueError("Unsupported image source format") from exc
 
     def _load_video_from_source(self, source: str | bytes) -> np.ndarray:
+        return self._load_video_with_hash(source).data
+
+    def _load_video_with_hash(self, source: str | bytes) -> _LoadedMultimodalPayload:
         if isinstance(source, dict) and "url" in source:
             source = source["url"]
         if hasattr(source, "url"):
             source = source.url
         if isinstance(source, bytes):
+            payload_hash = self._hash_payload(source, "video")
             with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
                 tmp.write(source)
                 tmp_path = tmp.name
             try:
-                return iio.imread(tmp_path, index=None)
+                return _LoadedMultimodalPayload(
+                    data=iio.imread(tmp_path, index=None),
+                    hash=payload_hash,
+                )
             finally:
                 os.unlink(tmp_path)
         if os.path.exists(source):
-            return iio.imread(source, index=None)
+            with open(source, "rb") as video_file:
+                payload_hash = self._hash_payload(video_file.read(), "video")
+            return _LoadedMultimodalPayload(
+                data=iio.imread(source, index=None),
+                hash=payload_hash,
+            )
         if source.startswith(("http://", "https://")):
             resp = requests.get(source, timeout=10)
             resp.raise_for_status()
+            payload_hash = self._hash_payload(resp.content, "video")
             with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
                 tmp.write(resp.content)
                 tmp_path = tmp.name
             try:
-                return iio.imread(tmp_path, index=None)
+                return _LoadedMultimodalPayload(
+                    data=iio.imread(tmp_path, index=None),
+                    hash=payload_hash,
+                )
             finally:
                 os.unlink(tmp_path)
         raise ValueError("Unsupported video source format")
 
     def _load_audio_from_source(self, source: str | bytes) -> np.ndarray:
+        return self._load_audio_with_hash(source).data
+
+    def _load_audio_with_hash(self, source: str | bytes) -> _LoadedMultimodalPayload:
         if not hasattr(self.mm_processor, "feature_extractor"):
-            return None
+            return _LoadedMultimodalPayload(data=None, hash=None)
         if isinstance(source, dict) and "url" in source:
             source = source["url"]
         if hasattr(source, "url"):
             source = source.url
         if isinstance(source, bytes):
+            payload_hash = self._hash_payload(source, "audio")
             with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp:
                 tmp.write(source)
                 tmp_path = tmp.name
@@ -810,33 +915,56 @@ class MultimodalTokenizer(TokenizerManager):
                 audio_data, _ = librosa.load(
                     tmp_path, self.mm_processor.feature_extractor.sampling_rate
                 )
-                return audio_data
+                return _LoadedMultimodalPayload(data=audio_data, hash=payload_hash)
             finally:
                 os.unlink(tmp_path)
         if os.path.exists(source):
+            with open(source, "rb") as audio_file:
+                payload_hash = self._hash_payload(audio_file.read(), "audio")
             audio_data, _ = librosa.load(source, self.mm_processor.feature_extractor.sampling_rate)
-            return audio_data
+            return _LoadedMultimodalPayload(data=audio_data, hash=payload_hash)
         if source.startswith(("http://", "https://")):
-            try:
-                audio_data, _ = librosa.load(
-                    BytesIO(urlopen(source, timeout=10).read()),
-                    sr=self.mm_processor.feature_extractor.sampling_rate,
-                )
-                return audio_data
-            finally:
-                pass
+            payload = urlopen(source, timeout=10).read()
+            audio_data, _ = librosa.load(
+                BytesIO(payload),
+                sr=self.mm_processor.feature_extractor.sampling_rate,
+            )
+            return _LoadedMultimodalPayload(
+                data=audio_data,
+                hash=self._hash_payload(payload, "audio"),
+            )
         raise ValueError("Unsupported audio source format")
 
-    def _hash_payload(self, payload: bytes) -> int:
-        digest = hashlib.sha256(payload).digest()[:8]
+    def _hash_payload(self, payload: bytes, *metadata: Any) -> int:
+        hasher = hashlib.sha256()
+        for item in metadata:
+            hasher.update(repr(item).encode())
+            hasher.update(b"\0")
+        hasher.update(payload)
+        digest = hasher.digest()[:8]
         return int.from_bytes(digest, byteorder="big", signed=False) % (1 << 31)
+
+    def _hash_array_payload(self, value: np.ndarray, *metadata: Any) -> int:
+        array = np.ascontiguousarray(value)
+        return self._hash_payload(
+            array.tobytes(),
+            *metadata,
+            str(array.dtype),
+            tuple(int(dim) for dim in array.shape),
+        )
+
+    def _combine_mm_hashes(self, hashes: list[int | None], modality: str) -> int | None:
+        valid_hashes = [value for value in hashes if value is not None]
+        if not valid_hashes:
+            return None
+        return self._hash_payload(repr(tuple(valid_hashes)).encode(), modality)
 
     def _hash_mm_items(self, images: list[Image.Image], videos: list[np.ndarray]) -> list[int]:
         pad_values = []
         for image in images:
-            pad_values.append(self._hash_payload(image.tobytes()))
+            pad_values.append(self._hash_payload(image.tobytes(), "image"))
         for video in videos:
-            pad_values.append(self._hash_payload(video.tobytes()))
+            pad_values.append(self._hash_array_payload(video, "video"))
         return pad_values
 
     def _to_grid_list(self, grid_thw: Any) -> list[tuple[int, int, int]] | None:

--- a/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
+++ b/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
@@ -3,6 +3,7 @@ import base64
 import dataclasses
 import hashlib
 import io
+import json
 import logging
 import math
 import os
@@ -699,12 +700,11 @@ class MultimodalTokenizer(TokenizerManager):
                 vr = VideoReader(tmp_path, ctx=ctx)
             elif isinstance(source, str):
                 if os.path.exists(source):
-                    with open(source, "rb") as video_file:
-                        payload_hash = self._hash_payload(
-                            video_file.read(),
-                            "qwen_video",
-                            video_config,
-                        )
+                    payload_hash = self._hash_file_payload(
+                        source,
+                        "qwen_video",
+                        video_config,
+                    )
                     vr = VideoReader(source, ctx=ctx)
                 elif source.startswith(("http://", "https://")):
                     resp = requests.get(source, timeout=10)
@@ -824,11 +824,11 @@ class MultimodalTokenizer(TokenizerManager):
                 hash=self._hash_payload(source, "image"),
             )
         if os.path.exists(source):
-            with open(source, "rb") as image_file:
-                payload = image_file.read()
+            with Image.open(source) as image:
+                image_data = image.convert("RGB")
             return _LoadedMultimodalPayload(
-                data=Image.open(io.BytesIO(payload)).convert("RGB"),
-                hash=self._hash_payload(payload, "image"),
+                data=image_data,
+                hash=self._hash_file_payload(source, "image"),
             )
         if source.startswith(("http://", "https://")):
             resp = requests.get(source, timeout=10)
@@ -874,11 +874,9 @@ class MultimodalTokenizer(TokenizerManager):
             finally:
                 os.unlink(tmp_path)
         if os.path.exists(source):
-            with open(source, "rb") as video_file:
-                payload_hash = self._hash_payload(video_file.read(), "video")
             return _LoadedMultimodalPayload(
                 data=iio.imread(source, index=None),
-                hash=payload_hash,
+                hash=self._hash_file_payload(source, "video"),
             )
         if source.startswith(("http://", "https://")):
             resp = requests.get(source, timeout=10)
@@ -919,10 +917,11 @@ class MultimodalTokenizer(TokenizerManager):
             finally:
                 os.unlink(tmp_path)
         if os.path.exists(source):
-            with open(source, "rb") as audio_file:
-                payload_hash = self._hash_payload(audio_file.read(), "audio")
             audio_data, _ = librosa.load(source, self.mm_processor.feature_extractor.sampling_rate)
-            return _LoadedMultimodalPayload(data=audio_data, hash=payload_hash)
+            return _LoadedMultimodalPayload(
+                data=audio_data,
+                hash=self._hash_file_payload(source, "audio"),
+            )
         if source.startswith(("http://", "https://")):
             payload = urlopen(source, timeout=10).read()
             audio_data, _ = librosa.load(
@@ -937,10 +936,32 @@ class MultimodalTokenizer(TokenizerManager):
 
     def _hash_payload(self, payload: bytes, *metadata: Any) -> int:
         hasher = hashlib.sha256()
-        for item in metadata:
-            hasher.update(repr(item).encode())
-            hasher.update(b"\0")
+        self._update_hash_metadata(hasher, *metadata)
         hasher.update(payload)
+        return self._hash_digest(hasher)
+
+    def _hash_file_payload(self, path: str, *metadata: Any) -> int:
+        hasher = hashlib.sha256()
+        self._update_hash_metadata(hasher, *metadata)
+        with open(path, "rb") as file:
+            for chunk in iter(lambda: file.read(1024 * 1024), b""):
+                hasher.update(chunk)
+        return self._hash_digest(hasher)
+
+    @staticmethod
+    def _update_hash_metadata(hasher: Any, *metadata: Any) -> None:
+        for item in metadata:
+            metadata_payload = json.dumps(
+                item,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ).encode()
+            hasher.update(len(metadata_payload).to_bytes(8, byteorder="big", signed=False))
+            hasher.update(metadata_payload)
+
+    @staticmethod
+    def _hash_digest(hasher: Any) -> int:
         digest = hasher.digest()[:8]
         return int.from_bytes(digest, byteorder="big", signed=False) % (1 << 31)
 
@@ -957,14 +978,17 @@ class MultimodalTokenizer(TokenizerManager):
         valid_hashes = [value for value in hashes if value is not None]
         if not valid_hashes:
             return None
-        return self._hash_payload(repr(tuple(valid_hashes)).encode(), modality)
+        payload = b"".join(
+            value.to_bytes(8, byteorder="big", signed=False) for value in valid_hashes
+        )
+        return self._hash_payload(payload, modality)
 
     def _hash_mm_items(self, images: list[Image.Image], videos: list[np.ndarray]) -> list[int]:
         pad_values = []
         for image in images:
-            pad_values.append(self._hash_payload(image.tobytes(), "image"))
+            pad_values.append(self._hash_payload(image.tobytes()))
         for video in videos:
-            pad_values.append(self._hash_array_payload(video, "video"))
+            pad_values.append(self._hash_payload(video.tobytes()))
         return pad_values
 
     def _to_grid_list(self, grid_thw: Any) -> list[tuple[int, int, int]] | None:

--- a/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
+++ b/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
@@ -257,6 +257,12 @@ class MMReqState(ReqState):
     rid: str = ""
 
 
+@dataclasses.dataclass(frozen=True)
+class _LoadedMultimodalPayload:
+    data: Any
+    hash: int | None
+
+
 class MultimodalTokenizer(TokenizerManager):
     """Tokenization manager for multimodal requests.
 
@@ -346,7 +352,7 @@ class MultimodalTokenizer(TokenizerManager):
         """
         if hasattr(reqs, "__len__") and len(reqs) > 0 and self.server_args.log_requests:
             logger.info("handle_batch_output %s, self.rid_to_state %s", reqs, self.rid_to_state)
-        if isinstance(reqs, (BatchStrOut, BatchEmbeddingOut, BatchTokenIDOut)):
+        if isinstance(reqs, BatchStrOut | BatchEmbeddingOut | BatchTokenIDOut):
             return super()._handle_batch_output(reqs)
 
         for req in reqs:
@@ -481,18 +487,35 @@ class MultimodalTokenizer(TokenizerManager):
                 "Check model_path and trust_remote_code settings."
             )
         if image_data or video_data or audio_data:
-            images = [
-                self._load_image_from_source(item) for item in image_data
+            image_payloads = [
+                self._load_image_with_hash(item) for item in image_data
             ]  # note: We did not perform a resize operation
+            images = [payload.data for payload in image_payloads]
+            image_hash = self._combine_mm_hashes(
+                [payload.hash for payload in image_payloads],
+                "image",
+            )
             processor_kwargs = {}
             if video_data and self._is_qwen_video_processor():
                 video_config = self._build_qwen_video_config(obj)
-                videos = [self._preprocess_qwen_video(item, video_config) for item in video_data]
+                video_payloads = [
+                    self._preprocess_qwen_video_with_hash(item, video_config) for item in video_data
+                ]
                 processor_kwargs["videos_kwargs"] = {"do_sample_frames": False}
                 processor_kwargs["videos_kwargs"]["fps"] = video_config.get("fps", _QWEN_FPS)
             else:
-                videos = [self._load_video_from_source(item) for item in video_data]
-            audios = [self._load_audio_from_source(item) for item in audio_data]
+                video_payloads = [self._load_video_with_hash(item) for item in video_data]
+            videos = [payload.data for payload in video_payloads]
+            video_hash = self._combine_mm_hashes(
+                [payload.hash for payload in video_payloads],
+                "video",
+            )
+            audio_payloads = [self._load_audio_with_hash(item) for item in audio_data]
+            audios = [payload.data for payload in audio_payloads]
+            audio_hash = self._combine_mm_hashes(
+                [payload.hash for payload in audio_payloads],
+                "audio",
+            )
             processor_out = self.mm_processor(
                 images=images or None,
                 videos=videos or None,
@@ -546,6 +569,7 @@ class MultimodalTokenizer(TokenizerManager):
                 mm_items.append(
                     MultimodalDataItem(
                         modality=Modality.IMAGE,
+                        hash=image_hash,
                         feature=np.asarray(pixel_values),
                     )
                 )
@@ -553,6 +577,7 @@ class MultimodalTokenizer(TokenizerManager):
                 mm_items.append(
                     MultimodalDataItem(
                         modality=Modality.VIDEO,
+                        hash=video_hash,
                         feature=np.asarray(pixel_values_videos),
                     )
                 )
@@ -563,6 +588,7 @@ class MultimodalTokenizer(TokenizerManager):
                 mm_items.append(
                     MultimodalDataItem(
                         modality=Modality.AUDIO,
+                        hash=audio_hash,
                         feature=np.asarray(audio_features),
                     )
                 )
@@ -642,8 +668,17 @@ class MultimodalTokenizer(TokenizerManager):
     def _preprocess_qwen_video(
         self, source: str | bytes | np.ndarray, video_config: dict
     ) -> np.ndarray:
+        return self._preprocess_qwen_video_with_hash(source, video_config).data
+
+    def _preprocess_qwen_video_with_hash(
+        self, source: str | bytes | np.ndarray, video_config: dict
+    ) -> _LoadedMultimodalPayload:
         if isinstance(source, np.ndarray):
-            return self._resize_video_frames(source, video_config)
+            video = self._resize_video_frames(source, video_config)
+            return _LoadedMultimodalPayload(
+                data=video,
+                hash=self._hash_array_payload(video, "qwen_video", video_config),
+            )
 
         if isinstance(source, dict) and "url" in source:
             source = source["url"]
@@ -656,24 +691,49 @@ class MultimodalTokenizer(TokenizerManager):
         tmp_path = None
         try:
             ctx = cpu(0)
+            payload_hash = None
 
             if isinstance(source, bytes):
+                payload_hash = self._hash_payload(source, "qwen_video", video_config)
                 tmp_path = self._write_temp_video(source)
                 vr = VideoReader(tmp_path, ctx=ctx)
             elif isinstance(source, str):
                 if os.path.exists(source):
+                    with open(source, "rb") as video_file:
+                        payload_hash = self._hash_payload(
+                            video_file.read(),
+                            "qwen_video",
+                            video_config,
+                        )
                     vr = VideoReader(source, ctx=ctx)
                 elif source.startswith(("http://", "https://")):
                     resp = requests.get(source, timeout=10)
                     resp.raise_for_status()
+                    payload_hash = self._hash_payload(
+                        resp.content,
+                        "qwen_video",
+                        video_config,
+                    )
                     tmp_path = self._write_temp_video(resp.content)
                     vr = VideoReader(tmp_path, ctx=ctx)
                 elif source.startswith("data:") and "base64," in source:
                     payload = source.split("base64,", 1)[1]
-                    tmp_path = self._write_temp_video(base64.b64decode(payload))
+                    decoded_payload = base64.b64decode(payload)
+                    payload_hash = self._hash_payload(
+                        decoded_payload,
+                        "qwen_video",
+                        video_config,
+                    )
+                    tmp_path = self._write_temp_video(decoded_payload)
                     vr = VideoReader(tmp_path, ctx=ctx)
                 else:
-                    tmp_path = self._write_temp_video(base64.b64decode(source, validate=True))
+                    decoded_payload = base64.b64decode(source, validate=True)
+                    payload_hash = self._hash_payload(
+                        decoded_payload,
+                        "qwen_video",
+                        video_config,
+                    )
+                    tmp_path = self._write_temp_video(decoded_payload)
                     vr = VideoReader(tmp_path, ctx=ctx)
             else:
                 raise ValueError(f"Unsupported video input type: {type(source)}")
@@ -686,7 +746,10 @@ class MultimodalTokenizer(TokenizerManager):
             idx = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
             idx = np.unique(idx)
             video_np = vr.get_batch(idx).asnumpy()
-            return self._resize_video_frames(video_np, video_config)
+            return _LoadedMultimodalPayload(
+                data=self._resize_video_frames(video_np, video_config),
+                hash=payload_hash,
+            )
         finally:
             if tmp_path and os.path.exists(tmp_path):
                 os.unlink(tmp_path)
@@ -748,61 +811,103 @@ class MultimodalTokenizer(TokenizerManager):
         return np.stack(resized_frames, axis=0)
 
     def _load_image_from_source(self, source: str | bytes) -> Image.Image:
+        return self._load_image_with_hash(source).data
+
+    def _load_image_with_hash(self, source: str | bytes) -> _LoadedMultimodalPayload:
         if isinstance(source, dict) and "url" in source:
             source = source["url"]
         if hasattr(source, "url"):
             source = source.url
         if isinstance(source, bytes):
-            return Image.open(io.BytesIO(source)).convert("RGB")
+            return _LoadedMultimodalPayload(
+                data=Image.open(io.BytesIO(source)).convert("RGB"),
+                hash=self._hash_payload(source, "image"),
+            )
         if os.path.exists(source):
-            return Image.open(source).convert("RGB")
+            with open(source, "rb") as image_file:
+                payload = image_file.read()
+            return _LoadedMultimodalPayload(
+                data=Image.open(io.BytesIO(payload)).convert("RGB"),
+                hash=self._hash_payload(payload, "image"),
+            )
         if source.startswith(("http://", "https://")):
             resp = requests.get(source, timeout=10)
             resp.raise_for_status()
-            return Image.open(io.BytesIO(resp.content)).convert("RGB")
+            return _LoadedMultimodalPayload(
+                data=Image.open(io.BytesIO(resp.content)).convert("RGB"),
+                hash=self._hash_payload(resp.content, "image"),
+            )
         if source.startswith("data:") and "base64," in source:
             payload = source.split("base64,", 1)[1]
-            return Image.open(io.BytesIO(base64.b64decode(payload))).convert("RGB")
+            decoded_payload = base64.b64decode(payload)
+            return _LoadedMultimodalPayload(
+                data=Image.open(io.BytesIO(decoded_payload)).convert("RGB"),
+                hash=self._hash_payload(decoded_payload, "image"),
+            )
         try:
-            return Image.open(io.BytesIO(base64.b64decode(source, validate=True))).convert("RGB")
+            decoded_payload = base64.b64decode(source, validate=True)
+            return _LoadedMultimodalPayload(
+                data=Image.open(io.BytesIO(decoded_payload)).convert("RGB"),
+                hash=self._hash_payload(decoded_payload, "image"),
+            )
         except Exception as exc:
             raise ValueError("Unsupported image source format") from exc
 
     def _load_video_from_source(self, source: str | bytes) -> np.ndarray:
+        return self._load_video_with_hash(source).data
+
+    def _load_video_with_hash(self, source: str | bytes) -> _LoadedMultimodalPayload:
         if isinstance(source, dict) and "url" in source:
             source = source["url"]
         if hasattr(source, "url"):
             source = source.url
         if isinstance(source, bytes):
+            payload_hash = self._hash_payload(source, "video")
             with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
                 tmp.write(source)
                 tmp_path = tmp.name
             try:
-                return iio.imread(tmp_path, index=None)
+                return _LoadedMultimodalPayload(
+                    data=iio.imread(tmp_path, index=None),
+                    hash=payload_hash,
+                )
             finally:
                 os.unlink(tmp_path)
         if os.path.exists(source):
-            return iio.imread(source, index=None)
+            with open(source, "rb") as video_file:
+                payload_hash = self._hash_payload(video_file.read(), "video")
+            return _LoadedMultimodalPayload(
+                data=iio.imread(source, index=None),
+                hash=payload_hash,
+            )
         if source.startswith(("http://", "https://")):
             resp = requests.get(source, timeout=10)
             resp.raise_for_status()
+            payload_hash = self._hash_payload(resp.content, "video")
             with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
                 tmp.write(resp.content)
                 tmp_path = tmp.name
             try:
-                return iio.imread(tmp_path, index=None)
+                return _LoadedMultimodalPayload(
+                    data=iio.imread(tmp_path, index=None),
+                    hash=payload_hash,
+                )
             finally:
                 os.unlink(tmp_path)
         raise ValueError("Unsupported video source format")
 
     def _load_audio_from_source(self, source: str | bytes) -> np.ndarray:
+        return self._load_audio_with_hash(source).data
+
+    def _load_audio_with_hash(self, source: str | bytes) -> _LoadedMultimodalPayload:
         if not hasattr(self.mm_processor, "feature_extractor"):
-            return None
+            return _LoadedMultimodalPayload(data=None, hash=None)
         if isinstance(source, dict) and "url" in source:
             source = source["url"]
         if hasattr(source, "url"):
             source = source.url
         if isinstance(source, bytes):
+            payload_hash = self._hash_payload(source, "audio")
             with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp:
                 tmp.write(source)
                 tmp_path = tmp.name
@@ -810,35 +915,59 @@ class MultimodalTokenizer(TokenizerManager):
                 audio_data, _ = librosa.load(
                     tmp_path, sr=self.mm_processor.feature_extractor.sampling_rate
                 )
-                return audio_data
+                return _LoadedMultimodalPayload(data=audio_data, hash=payload_hash)
             finally:
                 os.unlink(tmp_path)
         if os.path.exists(source):
+            with open(source, "rb") as audio_file:
+                payload_hash = self._hash_payload(audio_file.read(), "audio")
             audio_data, _ = librosa.load(
-                source, sr=self.mm_processor.feature_extractor.sampling_rate
+                source,
+                sr=self.mm_processor.feature_extractor.sampling_rate,
             )
-            return audio_data
+            return _LoadedMultimodalPayload(data=audio_data, hash=payload_hash)
         if source.startswith(("http://", "https://")):
-            try:
-                audio_data, _ = librosa.load(
-                    BytesIO(urlopen(source, timeout=10).read()),
-                    sr=self.mm_processor.feature_extractor.sampling_rate,
-                )
-                return audio_data
-            finally:
-                pass
+            payload = urlopen(source, timeout=10).read()
+            audio_data, _ = librosa.load(
+                BytesIO(payload),
+                sr=self.mm_processor.feature_extractor.sampling_rate,
+            )
+            return _LoadedMultimodalPayload(
+                data=audio_data,
+                hash=self._hash_payload(payload, "audio"),
+            )
         raise ValueError("Unsupported audio source format")
 
-    def _hash_payload(self, payload: bytes) -> int:
-        digest = hashlib.sha256(payload).digest()[:8]
+    def _hash_payload(self, payload: bytes, *metadata: Any) -> int:
+        hasher = hashlib.sha256()
+        for item in metadata:
+            hasher.update(repr(item).encode())
+            hasher.update(b"\0")
+        hasher.update(payload)
+        digest = hasher.digest()[:8]
         return int.from_bytes(digest, byteorder="big", signed=False) % (1 << 31)
+
+    def _hash_array_payload(self, value: np.ndarray, *metadata: Any) -> int:
+        array = np.ascontiguousarray(value)
+        return self._hash_payload(
+            array.tobytes(),
+            *metadata,
+            str(array.dtype),
+            tuple(int(dim) for dim in array.shape),
+        )
+
+    def _combine_mm_hashes(self, hashes: list[int | None], modality: str) -> int | None:
+        valid_hashes = [value for value in hashes if value is not None]
+        if not valid_hashes:
+            return None
+        return self._hash_payload(repr(tuple(valid_hashes)).encode(), modality)
 
     def _hash_mm_items(self, images: list[Image.Image], videos: list[np.ndarray]) -> list[int]:
         pad_values = []
         for image in images:
-            pad_values.append(self._hash_payload(image.tobytes()))
+            pad_values.append(self._hash_payload(image.tobytes(), "image"))
         for video in videos:
-            pad_values.append(self._hash_payload(video.tobytes()))
+            pad_values.append(self._hash_array_payload(video, "video"))
         return pad_values
 
     def _to_grid_list(self, grid_thw: Any) -> list[tuple[int, int, int]] | None:

--- a/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
+++ b/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
@@ -700,12 +700,15 @@ class MultimodalTokenizer(TokenizerManager):
                 vr = VideoReader(tmp_path, ctx=ctx)
             elif isinstance(source, str):
                 if os.path.exists(source):
-                    payload_hash = self._hash_file_payload(
-                        source,
+                    payload = self._read_file_payload(source)
+                    payload_hash = self._hash_payload(
+                        payload,
                         "qwen_video",
                         video_config,
                     )
-                    vr = VideoReader(source, ctx=ctx)
+                    suffix = os.path.splitext(source)[1] or ".mp4"
+                    tmp_path = self._write_temp_video(payload, suffix=suffix)
+                    vr = VideoReader(tmp_path, ctx=ctx)
                 elif source.startswith(("http://", "https://")):
                     resp = requests.get(source, timeout=10)
                     resp.raise_for_status()
@@ -754,8 +757,8 @@ class MultimodalTokenizer(TokenizerManager):
             if tmp_path and os.path.exists(tmp_path):
                 os.unlink(tmp_path)
 
-    def _write_temp_video(self, payload: bytes) -> str:
-        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+    def _write_temp_video(self, payload: bytes, suffix: str = ".mp4") -> str:
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
             tmp.write(payload)
             return tmp.name
 
@@ -824,11 +827,12 @@ class MultimodalTokenizer(TokenizerManager):
                 hash=self._hash_payload(source, "image"),
             )
         if os.path.exists(source):
-            with Image.open(source) as image:
+            payload = self._read_file_payload(source)
+            with Image.open(io.BytesIO(payload)) as image:
                 image_data = image.convert("RGB")
             return _LoadedMultimodalPayload(
                 data=image_data,
-                hash=self._hash_file_payload(source, "image"),
+                hash=self._hash_payload(payload, "image"),
             )
         if source.startswith(("http://", "https://")):
             resp = requests.get(source, timeout=10)
@@ -874,10 +878,19 @@ class MultimodalTokenizer(TokenizerManager):
             finally:
                 os.unlink(tmp_path)
         if os.path.exists(source):
-            return _LoadedMultimodalPayload(
-                data=iio.imread(source, index=None),
-                hash=self._hash_file_payload(source, "video"),
-            )
+            payload = self._read_file_payload(source)
+            payload_hash = self._hash_payload(payload, "video")
+            suffix = os.path.splitext(source)[1] or ".mp4"
+            with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+                tmp.write(payload)
+                tmp_path = tmp.name
+            try:
+                return _LoadedMultimodalPayload(
+                    data=iio.imread(tmp_path, index=None),
+                    hash=payload_hash,
+                )
+            finally:
+                os.unlink(tmp_path)
         if source.startswith(("http://", "https://")):
             resp = requests.get(source, timeout=10)
             resp.raise_for_status()
@@ -917,13 +930,14 @@ class MultimodalTokenizer(TokenizerManager):
             finally:
                 os.unlink(tmp_path)
         if os.path.exists(source):
+            payload = self._read_file_payload(source)
             audio_data, _ = librosa.load(
-                source,
+                BytesIO(payload),
                 sr=self.mm_processor.feature_extractor.sampling_rate,
             )
             return _LoadedMultimodalPayload(
                 data=audio_data,
-                hash=self._hash_file_payload(source, "audio"),
+                hash=self._hash_payload(payload, "audio"),
             )
         if source.startswith(("http://", "https://")):
             payload = urlopen(source, timeout=10).read()
@@ -943,13 +957,10 @@ class MultimodalTokenizer(TokenizerManager):
         hasher.update(payload)
         return self._hash_digest(hasher)
 
-    def _hash_file_payload(self, path: str, *metadata: Any) -> int:
-        hasher = hashlib.sha256()
-        self._update_hash_metadata(hasher, *metadata)
+    @staticmethod
+    def _read_file_payload(path: str) -> bytes:
         with open(path, "rb") as file:
-            for chunk in iter(lambda: file.read(1024 * 1024), b""):
-                hasher.update(chunk)
-        return self._hash_digest(hasher)
+            return file.read()
 
     @staticmethod
     def _update_hash_metadata(hasher: Any, *metadata: Any) -> None:
@@ -978,9 +989,13 @@ class MultimodalTokenizer(TokenizerManager):
         )
 
     def _combine_mm_hashes(self, hashes: list[int | None], modality: str) -> int | None:
-        valid_hashes = [value for value in hashes if value is not None]
-        if not valid_hashes:
+        if not hashes:
             return None
+        valid_hashes = []
+        for value in hashes:
+            if value is None:
+                return None
+            valid_hashes.append(value)
         payload = b"".join(
             value.to_bytes(8, byteorder="big", signed=False) for value in valid_hashes
         )

--- a/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
+++ b/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
@@ -700,14 +700,12 @@ class MultimodalTokenizer(TokenizerManager):
                 vr = VideoReader(tmp_path, ctx=ctx)
             elif isinstance(source, str):
                 if os.path.exists(source):
-                    payload = self._read_file_payload(source)
-                    payload_hash = self._hash_payload(
-                        payload,
+                    tmp_path, payload_hash = self._snapshot_file_payload(
+                        source,
                         "qwen_video",
                         video_config,
+                        default_suffix=".mp4",
                     )
-                    suffix = os.path.splitext(source)[1] or ".mp4"
-                    tmp_path = self._write_temp_video(payload, suffix=suffix)
                     vr = VideoReader(tmp_path, ctx=ctx)
                 elif source.startswith(("http://", "https://")):
                     resp = requests.get(source, timeout=10)
@@ -827,13 +825,16 @@ class MultimodalTokenizer(TokenizerManager):
                 hash=self._hash_payload(source, "image"),
             )
         if os.path.exists(source):
-            payload = self._read_file_payload(source)
-            with Image.open(io.BytesIO(payload)) as image:
-                image_data = image.convert("RGB")
-            return _LoadedMultimodalPayload(
-                data=image_data,
-                hash=self._hash_payload(payload, "image"),
-            )
+            tmp_path, payload_hash = self._snapshot_file_payload(source, "image")
+            try:
+                with Image.open(tmp_path) as image:
+                    image_data = image.convert("RGB")
+                return _LoadedMultimodalPayload(
+                    data=image_data,
+                    hash=payload_hash,
+                )
+            finally:
+                os.unlink(tmp_path)
         if source.startswith(("http://", "https://")):
             resp = requests.get(source, timeout=10)
             resp.raise_for_status()
@@ -878,12 +879,11 @@ class MultimodalTokenizer(TokenizerManager):
             finally:
                 os.unlink(tmp_path)
         if os.path.exists(source):
-            payload = self._read_file_payload(source)
-            payload_hash = self._hash_payload(payload, "video")
-            suffix = os.path.splitext(source)[1] or ".mp4"
-            with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
-                tmp.write(payload)
-                tmp_path = tmp.name
+            tmp_path, payload_hash = self._snapshot_file_payload(
+                source,
+                "video",
+                default_suffix=".mp4",
+            )
             try:
                 return _LoadedMultimodalPayload(
                     data=iio.imread(tmp_path, index=None),
@@ -924,21 +924,29 @@ class MultimodalTokenizer(TokenizerManager):
                 tmp_path = tmp.name
             try:
                 audio_data, _ = librosa.load(
-                    tmp_path, sr=self.mm_processor.feature_extractor.sampling_rate
+                    tmp_path,
+                    sr=self.mm_processor.feature_extractor.sampling_rate,
                 )
                 return _LoadedMultimodalPayload(data=audio_data, hash=payload_hash)
             finally:
                 os.unlink(tmp_path)
         if os.path.exists(source):
-            payload = self._read_file_payload(source)
-            audio_data, _ = librosa.load(
-                BytesIO(payload),
-                sr=self.mm_processor.feature_extractor.sampling_rate,
+            tmp_path, payload_hash = self._snapshot_file_payload(
+                source,
+                "audio",
+                default_suffix=".mp3",
             )
-            return _LoadedMultimodalPayload(
-                data=audio_data,
-                hash=self._hash_payload(payload, "audio"),
-            )
+            try:
+                audio_data, _ = librosa.load(
+                    tmp_path,
+                    sr=self.mm_processor.feature_extractor.sampling_rate,
+                )
+                return _LoadedMultimodalPayload(
+                    data=audio_data,
+                    hash=payload_hash,
+                )
+            finally:
+                os.unlink(tmp_path)
         if source.startswith(("http://", "https://")):
             payload = urlopen(source, timeout=10).read()
             audio_data, _ = librosa.load(
@@ -957,10 +965,31 @@ class MultimodalTokenizer(TokenizerManager):
         hasher.update(payload)
         return self._hash_digest(hasher)
 
-    @staticmethod
-    def _read_file_payload(path: str) -> bytes:
-        with open(path, "rb") as file:
-            return file.read()
+    def _snapshot_file_payload(
+        self,
+        path: str,
+        *metadata: Any,
+        default_suffix: str = ".tmp",
+    ) -> tuple[str, int]:
+        """Create a temp-file snapshot while hashing the exact bytes copied."""
+        hasher = hashlib.sha256()
+        self._update_hash_metadata(hasher, *metadata)
+        suffix = os.path.splitext(path)[1] or default_suffix
+        tmp_path = None
+        try:
+            with (
+                open(path, "rb") as source_file,
+                tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp,
+            ):
+                tmp_path = tmp.name
+                for chunk in iter(lambda: source_file.read(1024 * 1024), b""):
+                    hasher.update(chunk)
+                    tmp.write(chunk)
+            return tmp_path, self._hash_digest(hasher)
+        except Exception:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+            raise
 
     @staticmethod
     def _update_hash_metadata(hasher: Any, *metadata: Any) -> None:

--- a/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
+++ b/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
@@ -3,6 +3,7 @@ import base64
 import dataclasses
 import hashlib
 import io
+import json
 import logging
 import math
 import os
@@ -699,12 +700,11 @@ class MultimodalTokenizer(TokenizerManager):
                 vr = VideoReader(tmp_path, ctx=ctx)
             elif isinstance(source, str):
                 if os.path.exists(source):
-                    with open(source, "rb") as video_file:
-                        payload_hash = self._hash_payload(
-                            video_file.read(),
-                            "qwen_video",
-                            video_config,
-                        )
+                    payload_hash = self._hash_file_payload(
+                        source,
+                        "qwen_video",
+                        video_config,
+                    )
                     vr = VideoReader(source, ctx=ctx)
                 elif source.startswith(("http://", "https://")):
                     resp = requests.get(source, timeout=10)
@@ -824,11 +824,11 @@ class MultimodalTokenizer(TokenizerManager):
                 hash=self._hash_payload(source, "image"),
             )
         if os.path.exists(source):
-            with open(source, "rb") as image_file:
-                payload = image_file.read()
+            with Image.open(source) as image:
+                image_data = image.convert("RGB")
             return _LoadedMultimodalPayload(
-                data=Image.open(io.BytesIO(payload)).convert("RGB"),
-                hash=self._hash_payload(payload, "image"),
+                data=image_data,
+                hash=self._hash_file_payload(source, "image"),
             )
         if source.startswith(("http://", "https://")):
             resp = requests.get(source, timeout=10)
@@ -874,11 +874,9 @@ class MultimodalTokenizer(TokenizerManager):
             finally:
                 os.unlink(tmp_path)
         if os.path.exists(source):
-            with open(source, "rb") as video_file:
-                payload_hash = self._hash_payload(video_file.read(), "video")
             return _LoadedMultimodalPayload(
                 data=iio.imread(source, index=None),
-                hash=payload_hash,
+                hash=self._hash_file_payload(source, "video"),
             )
         if source.startswith(("http://", "https://")):
             resp = requests.get(source, timeout=10)
@@ -919,13 +917,14 @@ class MultimodalTokenizer(TokenizerManager):
             finally:
                 os.unlink(tmp_path)
         if os.path.exists(source):
-            with open(source, "rb") as audio_file:
-                payload_hash = self._hash_payload(audio_file.read(), "audio")
             audio_data, _ = librosa.load(
                 source,
                 sr=self.mm_processor.feature_extractor.sampling_rate,
             )
-            return _LoadedMultimodalPayload(data=audio_data, hash=payload_hash)
+            return _LoadedMultimodalPayload(
+                data=audio_data,
+                hash=self._hash_file_payload(source, "audio"),
+            )
         if source.startswith(("http://", "https://")):
             payload = urlopen(source, timeout=10).read()
             audio_data, _ = librosa.load(
@@ -940,10 +939,32 @@ class MultimodalTokenizer(TokenizerManager):
 
     def _hash_payload(self, payload: bytes, *metadata: Any) -> int:
         hasher = hashlib.sha256()
-        for item in metadata:
-            hasher.update(repr(item).encode())
-            hasher.update(b"\0")
+        self._update_hash_metadata(hasher, *metadata)
         hasher.update(payload)
+        return self._hash_digest(hasher)
+
+    def _hash_file_payload(self, path: str, *metadata: Any) -> int:
+        hasher = hashlib.sha256()
+        self._update_hash_metadata(hasher, *metadata)
+        with open(path, "rb") as file:
+            for chunk in iter(lambda: file.read(1024 * 1024), b""):
+                hasher.update(chunk)
+        return self._hash_digest(hasher)
+
+    @staticmethod
+    def _update_hash_metadata(hasher: Any, *metadata: Any) -> None:
+        for item in metadata:
+            metadata_payload = json.dumps(
+                item,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ).encode()
+            hasher.update(len(metadata_payload).to_bytes(8, byteorder="big", signed=False))
+            hasher.update(metadata_payload)
+
+    @staticmethod
+    def _hash_digest(hasher: Any) -> int:
         digest = hasher.digest()[:8]
         return int.from_bytes(digest, byteorder="big", signed=False) % (1 << 31)
 
@@ -960,14 +981,17 @@ class MultimodalTokenizer(TokenizerManager):
         valid_hashes = [value for value in hashes if value is not None]
         if not valid_hashes:
             return None
-        return self._hash_payload(repr(tuple(valid_hashes)).encode(), modality)
+        payload = b"".join(
+            value.to_bytes(8, byteorder="big", signed=False) for value in valid_hashes
+        )
+        return self._hash_payload(payload, modality)
 
     def _hash_mm_items(self, images: list[Image.Image], videos: list[np.ndarray]) -> list[int]:
         pad_values = []
         for image in images:
-            pad_values.append(self._hash_payload(image.tobytes(), "image"))
+            pad_values.append(self._hash_payload(image.tobytes()))
         for video in videos:
-            pad_values.append(self._hash_array_payload(video, "video"))
+            pad_values.append(self._hash_payload(video.tobytes()))
         return pad_values
 
     def _to_grid_list(self, grid_thw: Any) -> list[tuple[int, int, int]] | None:

--- a/python/sgl_jax/test/multimodal/test_multimodal_pad_value_hash.py
+++ b/python/sgl_jax/test/multimodal/test_multimodal_pad_value_hash.py
@@ -1,5 +1,7 @@
 import base64
 import io
+import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -102,6 +104,42 @@ class TestMultimodalPadValueHash(unittest.TestCase):
         data_url_payload = tokenizer._load_image_with_hash(data_url)
 
         self.assertEqual(direct_payload.hash, data_url_payload.hash)
+
+    def test_local_image_file_hash_matches_payload_hash(self):
+        tokenizer = object.__new__(MultimodalTokenizer)
+        image_bytes = _png_bytes((64, 80, 96))
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            tmp.write(image_bytes)
+            path = tmp.name
+
+        try:
+            direct_payload = tokenizer._load_image_with_hash(image_bytes)
+            file_payload = tokenizer._load_image_with_hash(path)
+        finally:
+            os.unlink(path)
+
+        self.assertEqual(direct_payload.hash, file_payload.hash)
+
+    def test_hash_metadata_is_canonical_for_dict_order(self):
+        tokenizer = object.__new__(MultimodalTokenizer)
+        payload = b"payload"
+
+        self.assertEqual(
+            tokenizer._hash_payload(payload, {"fps": 2.0, "max_pixels": 123}),
+            tokenizer._hash_payload(payload, {"max_pixels": 123, "fps": 2.0}),
+        )
+
+    def test_combined_hash_preserves_order_and_modality(self):
+        tokenizer = object.__new__(MultimodalTokenizer)
+
+        self.assertNotEqual(
+            tokenizer._combine_mm_hashes([1, 2], "image"),
+            tokenizer._combine_mm_hashes([2, 1], "image"),
+        )
+        self.assertNotEqual(
+            tokenizer._combine_mm_hashes([1, 2], "image"),
+            tokenizer._combine_mm_hashes([1, 2], "video"),
+        )
 
 
 if __name__ == "__main__":

--- a/python/sgl_jax/test/multimodal/test_multimodal_pad_value_hash.py
+++ b/python/sgl_jax/test/multimodal/test_multimodal_pad_value_hash.py
@@ -1,0 +1,108 @@
+import base64
+import io
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+from PIL import Image
+
+from sgl_jax.srt.multimodal.common.modality_enum import (
+    Modality,
+    MultimodalDataItem,
+    pad_input_tokens,
+)
+from sgl_jax.srt.multimodal.manager.multimodal_tokenizer import MultimodalTokenizer
+
+
+def _png_bytes(color: tuple[int, int, int]) -> bytes:
+    image = Image.new("RGB", (8, 8), color=color)
+    output = io.BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+class TestMultimodalPadValueHash(unittest.TestCase):
+    def test_precomputed_hash_skips_feature_hash(self):
+        item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            hash=123456789,
+            feature=np.ones((4, 4), dtype=np.float32),
+        )
+
+        with patch("sgl_jax.srt.multimodal.common.modality_enum.hash_feature") as hash_feature:
+            item.set_pad_value()
+
+        hash_feature.assert_not_called()
+        self.assertEqual(item.pad_value, 123456789 % (1 << 24))
+
+    def test_set_pad_value_falls_back_to_feature_hash(self):
+        item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            feature=np.ones((4, 4), dtype=np.float32),
+        )
+
+        with patch(
+            "sgl_jax.srt.multimodal.common.modality_enum.hash_feature",
+            return_value=987654321,
+        ) as hash_feature:
+            item.set_pad_value()
+
+        hash_feature.assert_called_once()
+        self.assertEqual(item.hash, 987654321)
+        self.assertEqual(item.pad_value, 987654321 % (1 << 24))
+
+    def test_pad_input_tokens_uses_precomputed_hash(self):
+        item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            hash=42,
+            feature=np.ones((2, 2), dtype=np.float32),
+        )
+
+        with patch("sgl_jax.srt.multimodal.common.modality_enum.hash_feature") as hash_feature:
+            padded = pad_input_tokens([1, 999, 2], [item], im_token_id=999)
+
+        hash_feature.assert_not_called()
+        self.assertEqual(padded, [1, 42, 2])
+
+    def test_dict_round_trip_preserves_precomputed_hash(self):
+        item = MultimodalDataItem.from_dict(
+            {
+                "modality": "IMAGE",
+                "hash": 20260506,
+                "feature": np.ones((2, 2), dtype=np.float32),
+            }
+        )
+
+        with patch("sgl_jax.srt.multimodal.common.modality_enum.hash_feature") as hash_feature:
+            item.set_pad_value()
+
+        hash_feature.assert_not_called()
+        self.assertEqual(item.pad_value, 20260506 % (1 << 24))
+
+    def test_image_payload_hash_is_stable_and_content_sensitive(self):
+        tokenizer = object.__new__(MultimodalTokenizer)
+        red_image = _png_bytes((255, 0, 0))
+        red_image_again = bytes(red_image)
+        blue_image = _png_bytes((0, 0, 255))
+
+        red_payload = tokenizer._load_image_with_hash(red_image)
+        red_payload_again = tokenizer._load_image_with_hash(red_image_again)
+        blue_payload = tokenizer._load_image_with_hash(blue_image)
+
+        self.assertEqual(red_payload.hash, red_payload_again.hash)
+        self.assertNotEqual(red_payload.hash, blue_payload.hash)
+        self.assertEqual(red_payload.data.mode, "RGB")
+
+    def test_data_url_hash_matches_decoded_payload_hash(self):
+        tokenizer = object.__new__(MultimodalTokenizer)
+        image_bytes = _png_bytes((16, 32, 48))
+        data_url = "data:image/png;base64," + base64.b64encode(image_bytes).decode()
+
+        direct_payload = tokenizer._load_image_with_hash(image_bytes)
+        data_url_payload = tokenizer._load_image_with_hash(data_url)
+
+        self.assertEqual(direct_payload.hash, data_url_payload.hash)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sgl_jax/test/multimodal/test_multimodal_pad_value_hash.py
+++ b/python/sgl_jax/test/multimodal/test_multimodal_pad_value_hash.py
@@ -120,6 +120,24 @@ class TestMultimodalPadValueHash(unittest.TestCase):
 
         self.assertEqual(direct_payload.hash, file_payload.hash)
 
+    def test_file_payload_snapshot_hashes_copied_bytes(self):
+        tokenizer = object.__new__(MultimodalTokenizer)
+        payload = b"media-payload" * 1024
+        snapshot_path = None
+        with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tmp:
+            tmp.write(payload)
+            path = tmp.name
+
+        try:
+            snapshot_path, snapshot_hash = tokenizer._snapshot_file_payload(path, "image")
+            with open(snapshot_path, "rb") as snapshot_file:
+                self.assertEqual(snapshot_file.read(), payload)
+            self.assertEqual(snapshot_hash, tokenizer._hash_payload(payload, "image"))
+        finally:
+            os.unlink(path)
+            if snapshot_path and os.path.exists(snapshot_path):
+                os.unlink(snapshot_path)
+
     def test_hash_metadata_is_canonical_for_dict_order(self):
         tokenizer = object.__new__(MultimodalTokenizer)
         payload = b"payload"

--- a/python/sgl_jax/test/multimodal/test_multimodal_pad_value_hash.py
+++ b/python/sgl_jax/test/multimodal/test_multimodal_pad_value_hash.py
@@ -141,6 +141,12 @@ class TestMultimodalPadValueHash(unittest.TestCase):
             tokenizer._combine_mm_hashes([1, 2], "video"),
         )
 
+    def test_combined_hash_falls_back_when_any_payload_hash_is_missing(self):
+        tokenizer = object.__new__(MultimodalTokenizer)
+
+        self.assertIsNone(tokenizer._combine_mm_hashes([1, None], "image"))
+        self.assertIsNone(tokenizer._combine_mm_hashes([None], "image"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #1029.

Single-image VLM requests currently derive `MultimodalDataItem.pad_value` by hashing the processed feature tensor when no precomputed hash is present. In a v6e-4 profile of `Qwen/Qwen2.5-VL-7B-Instruct`, this tokenizer-side feature hashing showed up as a measurable host-side request cost:

| Event | Calls | Mean | Total |
|---|---:|---:|---:|
| `MultimodalDataItem.set_pad_value` | 65 | `3412.899us` | `221.838ms` |
| `hash_feature` | 65 | `3316.494us` | `215.572ms` |

The tokenizer already has access to the raw image/video/audio payload bytes before feature preprocessing. This PR carries a stable content hash into `MultimodalDataItem.hash`, allowing `set_pad_value()` to avoid walking large processed feature tensors on the request path.

Related inspiration: Modal's multimodal inference optimization write-up discusses the same general principle of carrying stable media-content identity through preprocessing instead of repeatedly hashing large processed tensors on the request path: https://modal.com/blog/boosting-multimodal-inference-performance-by-greater-than-10-with-a-single-python-dictionary

## Modifications

- Add an internal loaded-payload wrapper that carries both decoded multimodal data and a stable payload hash.
- Compute payload hashes for image, video, and audio inputs while raw bytes are available.
- Include modality and relevant preprocessing metadata in hashes where needed so cache keys remain distinct.
- Set `MultimodalDataItem.hash` before `set_pad_value()` runs.
- Keep `hash_feature` as the fallback for callers without a precomputed hash.
- Add focused unit tests for precomputed hash behavior, fallback behavior, dict round-trip behavior, and image payload hash stability.

## Accuracy Tests

No model output changes are expected. This changes the way multimodal pad values are derived for cache-key differentiation, while preserving the existing feature-hash fallback.

Local validation:

- [x] `uv run --project python python -m unittest sgl_jax.test.multimodal.test_multimodal_pad_value_hash`
- [x] `python3 -m py_compile python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py python/sgl_jax/test/multimodal/test_multimodal_pad_value_hash.py`
- [x] `ruff check python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py python/sgl_jax/test/multimodal/test_multimodal_pad_value_hash.py`
- [x] `pre-commit run --all-files --show-diff-on-failure`

TPU validation:

- [x] Focused unittest passed on v6e-4 before the profiling confirmation run.

## Benchmarking and Profiling

Profiling confirmation on v6e-4 with `Qwen/Qwen2.5-VL-7B-Instruct`:

| Metric | Baseline: feature-tensor hash | Optimized: payload hash |
|---|---:|---:|
| Measured requests | `64/64` HTTP 200 | `64/64` HTTP 200 |
| `hash_feature` calls | `65` | `0` |
| `hash_feature` mean | `3316.494us` | N/A |
| `hash_feature` total | `215.572ms` | N/A |
| `MultimodalDataItem.set_pad_value` calls | `65` | `65` |
| `MultimodalDataItem.set_pad_value` mean | `3412.899us` | `31.320us` |
| `MultimodalDataItem.set_pad_value` total | `221.838ms` | `2.036ms` |
| Request latency median | `0.3174s` | `0.3115s` |
| Request latency p95 | `0.3247s` | `0.3180s` |

The optimized run had one request-level outlier at `8.32436s`; median and p95 remained stable.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update. N/A.
