### PR TITLE
feat(mem_cache): Hybrid Memory Pool system (Step 2: HybridReqToTokenPool)

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -214,6 +214,10 @@ class Req:
 
         # Memory pool info
         self.req_pool_idx: int | None = None
+        # Recurrent state slot for hybrid linear-recurrent models (e.g.
+        # Kimi-Linear / Mamba). None when the model has no linear recurrent
+        # layers; HybridReqToTokenPool.alloc/free maintain this field.
+        self.recurrent_pool_idx: int | None = None
 
         # Check finish
         self.tokenizer = None

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -158,6 +158,122 @@ class ReqToTokenPool:
         self.free_slots = list(range(self.size))
 
 
+class HybridReqToTokenPool(ReqToTokenPool):
+    """Coordinates KV slot + recurrent state slot allocation for hybrid models.
+
+    Owns the recurrent slot allocator state (recurrent_free_slots and the
+    req_pool_idx -> recurrent_pool_idx mapping) so RecurrentStatePool stays a
+    pure pytree leaf safe for JIT donate. The host-side allocator state must
+    NOT enter a JIT-donated pytree (would otherwise reset on tree_unflatten),
+    therefore this class is intentionally NOT registered as a pytree node.
+
+    Slot 0 of RecurrentStatePool is reserved as the dummy slot; the mapping
+    defaults to 0 so an unallocated req lands on the dummy slot. Mirrors the
+    sglang PyTorch MambaPool free_slots semantics.
+    """
+
+    def __init__(
+        self,
+        size: int,
+        max_context_len: int,
+        dtype: np.dtype,
+        recurrent_state_pool,
+    ):
+        super().__init__(size=size, max_context_len=max_context_len, dtype=dtype)
+        self.recurrent_state_pool = recurrent_state_pool
+        # 1-indexed: slot 0 in RecurrentStatePool buffers is the dummy slot;
+        # valid slots are 1..size. Mapping entries default to 0 so an
+        # unallocated req lands on the dummy slot.
+        self.recurrent_free_slots: list[int] = list(range(1, recurrent_state_pool.size + 1))
+        self.req_index_to_recurrent_index_mapping = np.zeros(size, dtype=np.int32)
+
+    def alloc(self, reqs: list[Req]) -> list[int] | None:
+        """Coordinate KV slot + recurrent slot allocation; atomic semantics.
+
+        Strategy:
+          1. Pre-check recurrent capacity for fresh allocs.
+          2. super().alloc(reqs) — KV slot path is already atomic (returns
+             None and leaves req fields untouched on capacity miss).
+          3. Batch-slice the needed recurrent slots, clear-on-alloc all of
+             them in one recurrent_state_pool.clear_slot call (avoids
+             per-slot JIT scatter overhead), then assign + write mapping.
+
+        Reuse path: a req that already holds recurrent_pool_idx (e.g. the
+        next chunk of a chunked prefill) keeps its slot — recurrent_free_slots
+        is untouched and the mapping entry is rewritten to the same value.
+        Mirrors the parent's "req_pool_idx is not None -> reuse" contract.
+        """
+        # Pre-check recurrent capacity (only fresh reqs consume a slot).
+        needed_recurrent = sum(1 for req in reqs if req.recurrent_pool_idx is None)
+        if needed_recurrent > len(self.recurrent_free_slots):
+            return None
+
+        # KV slot (parent is atomic). On capacity miss req fields stay untouched
+        # and we have not yet mutated any recurrent state.
+        kv_indices = super().alloc(reqs)
+        if kv_indices is None:
+            return None
+
+        # Atomic batch slice + single clear-on-alloc covering every newly-
+        # handed-out slot.
+        new_recurrent_slots = self.recurrent_free_slots[:needed_recurrent]
+        self.recurrent_free_slots = self.recurrent_free_slots[needed_recurrent:]
+
+        if new_recurrent_slots:
+            self.recurrent_state_pool.clear_slot(new_recurrent_slots)
+
+        cursor = 0
+        for req in reqs:
+            if req.recurrent_pool_idx is None:
+                req.recurrent_pool_idx = new_recurrent_slots[cursor]
+                cursor += 1
+            self.req_index_to_recurrent_index_mapping[req.req_pool_idx] = req.recurrent_pool_idx
+
+        return kv_indices
+
+    def free(self, req: Req) -> None:
+        """Release recurrent slot first, then KV slot.
+
+        Recurrent-first / KV-second is the inverse of alloc (KV-first /
+        recurrent-second), so a partially constructed req can never end up
+        with a freed KV slot but a still-held recurrent slot.
+
+        Idempotent on the recurrent side when req.recurrent_pool_idx is None.
+        """
+        self.free_recurrent_cache(req)
+        super().free(req)
+
+    def free_recurrent_cache(self, req: Req) -> None:
+        """Release the recurrent state slot held by req. Idempotent.
+
+        Returns the slot to recurrent_free_slots, sets req.recurrent_pool_idx
+        back to None and resets the mapping entry to the dummy slot (0).
+        Safe to call when the req has no recurrent slot allocated.
+        """
+        if req.recurrent_pool_idx is None:
+            return
+        self.recurrent_free_slots.append(req.recurrent_pool_idx)
+        self.req_index_to_recurrent_index_mapping[req.req_pool_idx] = 0
+        req.recurrent_pool_idx = None
+
+    def get_linear_recurrent_indices(self, req_pool_indices):
+        """Translate req_pool_idx -> recurrent_pool_idx via the host mapping.
+
+        Accepts an np.ndarray (or list[int]) and returns the same-shape
+        np.ndarray of recurrent_pool_idx values.
+        """
+        return self.req_index_to_recurrent_index_mapping[req_pool_indices]
+
+    def clear(self) -> None:
+        """Full reset: KV slot allocator + recurrent slot allocator + recurrent
+        buffers + mapping zeroed. Called from flush_cache.
+        """
+        super().clear()
+        self.recurrent_state_pool.clear()
+        self.recurrent_free_slots = list(range(1, self.recurrent_state_pool.size + 1))
+        self.req_index_to_recurrent_index_mapping[:] = 0
+
+
 @register_pytree_node_class
 class KVCache(abc.ABC):
     @abc.abstractmethod

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -161,15 +161,18 @@ class ReqToTokenPool:
 class HybridReqToTokenPool(ReqToTokenPool):
     """Coordinates KV slot + recurrent state slot allocation for hybrid models.
 
-    Owns the recurrent slot allocator state (recurrent_free_slots and the
-    req_pool_idx -> recurrent_pool_idx mapping) so RecurrentStatePool stays a
-    pure pytree leaf safe for JIT donate. The host-side allocator state must
+    Owns the recurrent slot allocator state (per-DP recurrent_free_slots and
+    the req_pool_idx -> recurrent_pool_idx mapping) so RecurrentStatePool stays
+    a pure pytree leaf safe for JIT donate. The host-side allocator state must
     NOT enter a JIT-donated pytree (would otherwise reset on tree_unflatten),
     therefore this class is intentionally NOT registered as a pytree node.
 
-    Slot 0 of RecurrentStatePool is reserved as the dummy slot; the mapping
-    defaults to 0 so an unallocated req lands on the dummy slot. Mirrors the
-    sglang PyTorch MambaPool free_slots semantics.
+    DP indexing: recurrent_pool_idx is a per-rank LOCAL index, not global.
+    RecurrentStatePool's first buffer dim is sharded on the 'data' axis, so
+    each DP rank's local view is the slice [0, slots_per_rank). Slot 0 of
+    that local view is the dummy slot; valid local slots are 1..slots_per_rank.
+    The mapping defaults to 0 so an unallocated req lands on the dummy slot.
+    Mirrors the sglang PyTorch MambaPool free_slots semantics.
     """
 
     def __init__(
@@ -178,34 +181,54 @@ class HybridReqToTokenPool(ReqToTokenPool):
         max_context_len: int,
         dtype: np.dtype,
         recurrent_state_pool,
+        dp_size: int = 1,
     ):
         super().__init__(size=size, max_context_len=max_context_len, dtype=dtype)
         self.recurrent_state_pool = recurrent_state_pool
-        # 1-indexed: slot 0 in RecurrentStatePool buffers is the dummy slot;
-        # valid slots are 1..size. Mapping entries default to 0 so an
-        # unallocated req lands on the dummy slot.
-        self.recurrent_free_slots: list[int] = list(range(1, recurrent_state_pool.size + 1))
+        self.dp_size = dp_size
+        # Per-rank capacity. RecurrentStatePool ceil-pads its physical buffer
+        # to (size+1) for DP divisibility; valid slots per rank are
+        # 1..slots_per_rank in that rank's local buffer view.
+        self.slots_per_rank = recurrent_state_pool.size // dp_size
+        self.recurrent_free_slots: list[list[int]] = [
+            list(range(1, self.slots_per_rank + 1)) for _ in range(dp_size)
+        ]
         self.req_index_to_recurrent_index_mapping = np.zeros(size, dtype=np.int32)
+
+    @staticmethod
+    def _dp_rank(req: Req) -> int:
+        return req.dp_rank if req.dp_rank is not None else 0
 
     def alloc(self, reqs: list[Req]) -> list[int] | None:
         """Coordinate KV slot + recurrent slot allocation; atomic semantics.
 
+        Callers (prepare_for_extend / decode) iterate per-DP, so all reqs in
+        a single alloc() call share the same dp_rank — the slot is drawn
+        from that rank's free list.
+
         Strategy:
-          1. Pre-check recurrent capacity for fresh allocs.
+          1. Pre-check recurrent capacity on the target rank.
           2. super().alloc(reqs) — KV slot path is already atomic (returns
              None and leaves req fields untouched on capacity miss).
-          3. Batch-slice the needed recurrent slots, clear-on-alloc all of
-             them in one recurrent_state_pool.clear_slot call (avoids
-             per-slot JIT scatter overhead), then assign + write mapping.
+          3. Pop recurrent slots, clear-on-alloc all of them in one
+             recurrent_state_pool.clear_slot call (avoids per-slot JIT
+             scatter overhead), then assign + write mapping.
 
         Reuse path: a req that already holds recurrent_pool_idx (e.g. the
-        next chunk of a chunked prefill) keeps its slot — recurrent_free_slots
-        is untouched and the mapping entry is rewritten to the same value.
-        Mirrors the parent's "req_pool_idx is not None -> reuse" contract.
+        next chunk of a chunked prefill) keeps its slot — the rank's free
+        list is untouched and the mapping entry is rewritten to the same
+        value. Mirrors the parent's "req_pool_idx is not None -> reuse"
+        contract.
         """
-        # Pre-check recurrent capacity (only fresh reqs consume a slot).
+        if not reqs:
+            return []
+
+        dp_rank = self._dp_rank(reqs[0])
+        free = self.recurrent_free_slots[dp_rank]
+
+        # Pre-check recurrent capacity on this rank (only fresh reqs consume).
         needed_recurrent = sum(1 for req in reqs if req.recurrent_pool_idx is None)
-        if needed_recurrent > len(self.recurrent_free_slots):
+        if needed_recurrent > len(free):
             return None
 
         # KV slot (parent is atomic). On capacity miss req fields stay untouched
@@ -214,20 +237,16 @@ class HybridReqToTokenPool(ReqToTokenPool):
         if kv_indices is None:
             return None
 
-        # Atomic batch slice + single clear-on-alloc covering every newly-
-        # handed-out slot.
-        new_recurrent_slots = self.recurrent_free_slots[:needed_recurrent]
-        self.recurrent_free_slots = self.recurrent_free_slots[needed_recurrent:]
+        new_recurrent_slots: list[int] = []
+        for req in reqs:
+            if req.recurrent_pool_idx is None:
+                slot = free.pop(0)
+                req.recurrent_pool_idx = slot
+                new_recurrent_slots.append(slot)
+            self.req_index_to_recurrent_index_mapping[req.req_pool_idx] = req.recurrent_pool_idx
 
         if new_recurrent_slots:
             self.recurrent_state_pool.clear_slot(new_recurrent_slots)
-
-        cursor = 0
-        for req in reqs:
-            if req.recurrent_pool_idx is None:
-                req.recurrent_pool_idx = new_recurrent_slots[cursor]
-                cursor += 1
-            self.req_index_to_recurrent_index_mapping[req.req_pool_idx] = req.recurrent_pool_idx
 
         return kv_indices
 
@@ -246,13 +265,14 @@ class HybridReqToTokenPool(ReqToTokenPool):
     def free_recurrent_cache(self, req: Req) -> None:
         """Release the recurrent state slot held by req. Idempotent.
 
-        Returns the slot to recurrent_free_slots, sets req.recurrent_pool_idx
+        Returns the slot to the rank's free list, sets req.recurrent_pool_idx
         back to None and resets the mapping entry to the dummy slot (0).
         Safe to call when the req has no recurrent slot allocated.
         """
         if req.recurrent_pool_idx is None:
             return
-        self.recurrent_free_slots.append(req.recurrent_pool_idx)
+        dp_rank = self._dp_rank(req)
+        self.recurrent_free_slots[dp_rank].append(req.recurrent_pool_idx)
         self.req_index_to_recurrent_index_mapping[req.req_pool_idx] = 0
         req.recurrent_pool_idx = None
 
@@ -260,18 +280,22 @@ class HybridReqToTokenPool(ReqToTokenPool):
         """Translate req_pool_idx -> recurrent_pool_idx via the host mapping.
 
         Accepts an np.ndarray (or list[int]) and returns the same-shape
-        np.ndarray of recurrent_pool_idx values.
+        np.ndarray of recurrent_pool_idx values (per-rank local indices).
         """
         return self.req_index_to_recurrent_index_mapping[req_pool_indices]
 
+    def recurrent_available_size(self, dp_rank: int = 0) -> int:
+        return len(self.recurrent_free_slots[dp_rank])
+
     def clear(self) -> None:
-        """Full reset: KV slot allocator + recurrent slot allocator + recurrent
-        buffers + mapping zeroed. Called from flush_cache.
+        """Full reset: KV slot allocator + per-rank recurrent slot allocators
+        + recurrent buffers + mapping zeroed. Called from flush_cache.
         """
         super().clear()
         self.recurrent_state_pool.clear()
-        self.recurrent_free_slots = list(range(1, self.recurrent_state_pool.size + 1))
-        self.req_index_to_recurrent_index_mapping[:] = 0
+        for rank in range(self.dp_size):
+            self.recurrent_free_slots[rank] = list(range(1, self.slots_per_rank + 1))
+        self.req_index_to_recurrent_index_mapping.fill(0)
 
 
 @register_pytree_node_class

--- a/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
+++ b/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
@@ -83,16 +83,6 @@ class RecurrentStatePool:
         # total_slots: size+1 (for dummy slot 0), ceil to dp_size
         self.total_slots = _ceil_to(size + 1, dp_size)
 
-        assert size > 0, f"size must be > 0, got {size}"
-        assert num_heads > 0
-        assert head_dim > 0
-        assert num_k_heads > 0
-        assert head_k_dim > 0
-        assert (
-            conv_kernel_size >= 2
-        ), f"conv_kernel_size must be >= 2 (got {conv_kernel_size}); K=1 produces empty conv buffers."
-        assert self.proj_size > 0
-
         self.mesh = mesh
         self.recurrent_partition_axis = recurrent_partition_axis
         self.conv_partition_axis = conv_partition_axis

--- a/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
+++ b/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
@@ -1,0 +1,297 @@
+"""RecurrentStatePool -- recurrent + conv state buffer pool for linear recurrent layers.
+
+Dual list containers:
+    recurrent_buffers: list[jax.Array], length L, each [total_slots, H, D, D]
+    conv_buffers: list[list[jax.Array]], outer L, inner 1, each [total_slots, proj_size, K-1]
+
+Slot 0 reserved as dummy; valid slots start from 1 (aligned with sglang MambaPool).
+total_slots = ceil_to_dp(size + 1, dp_size) so the slot dim is evenly divisible
+by dp_size for P("data", ...) sharding.
+
+Pure buffer pool: slot allocator state lives in HybridReqToTokenPool.
+Does NOT inherit from KVCache.
+"""
+
+from __future__ import annotations
+
+import os
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from jax.tree_util import register_pytree_node_class
+
+_DTYPE_MAP = {
+    "float32": jnp.float32,
+    "bfloat16": jnp.bfloat16,
+    "float16": jnp.float16,
+}
+
+
+def _resolve_dtype(env_var: str, default):
+    name = os.environ.get(env_var)
+    return _DTYPE_MAP[name] if name else default
+
+
+def _ceil_to(value: int, divisor: int) -> int:
+    return (value + divisor - 1) // divisor * divisor
+
+
+@register_pytree_node_class
+class RecurrentStatePool:
+    """Recurrent + conv state buffer pool (per-slot indexing, no slot allocator)."""
+
+    def __init__(
+        self,
+        linear_recurrent_layer_ids: list[int],
+        size: int,
+        num_heads: int,
+        head_dim: int,
+        conv_kernel_size: int,
+        mesh: Mesh,
+        dp_size: int = 1,
+        recurrent_partition_axis: str = "tensor",
+        conv_partition_axis: str = "tensor",
+        data_partition_axis: str = "data",
+        temporal_dtype=None,
+        conv_dtype=None,
+        num_k_heads: int | None = None,
+        head_k_dim: int | None = None,
+    ):
+        if temporal_dtype is None:
+            temporal_dtype = _resolve_dtype("SGLANG_JAX_RECURRENT_STATE_DTYPE", jnp.float32)
+        if conv_dtype is None:
+            conv_dtype = _resolve_dtype("SGLANG_JAX_CONV_STATE_DTYPE", jnp.bfloat16)
+        self.temporal_dtype = temporal_dtype
+        self.conv_dtype = conv_dtype
+
+        if num_k_heads is None:
+            num_k_heads = num_heads
+        if head_k_dim is None:
+            head_k_dim = head_dim
+
+        assert len(set(linear_recurrent_layer_ids)) == len(linear_recurrent_layer_ids), (
+            f"linear_recurrent_layer_ids must not contain duplicates, "
+            f"got {linear_recurrent_layer_ids}"
+        )
+        self.linear_recurrent_layer_ids: list[int] = list(linear_recurrent_layer_ids)
+        self.layers_mapping: dict[int, int] = {
+            layer_id: idx for idx, layer_id in enumerate(self.linear_recurrent_layer_ids)
+        }
+        self.num_linear_recurrent_layers: int = len(self.linear_recurrent_layer_ids)
+
+        self.size = size
+        self.dp_size = dp_size
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.num_k_heads = num_k_heads
+        self.head_k_dim = head_k_dim
+        self.conv_kernel_size = conv_kernel_size
+
+        proj_v = num_heads * head_dim
+        proj_k = num_k_heads * head_k_dim
+        self.proj_size = proj_v + 2 * proj_k
+
+        # total_slots: size+1 (for dummy slot 0), ceil to dp_size
+        self.total_slots = _ceil_to(size + 1, dp_size)
+
+        assert size > 0, f"size must be > 0, got {size}"
+        assert num_heads > 0
+        assert head_dim > 0
+        assert num_k_heads > 0
+        assert head_k_dim > 0
+        assert (
+            conv_kernel_size >= 2
+        ), f"conv_kernel_size must be >= 2 (got {conv_kernel_size}); K=1 produces empty conv buffers."
+        assert self.proj_size > 0
+
+        self.mesh = mesh
+        self.recurrent_partition_axis = recurrent_partition_axis
+        self.conv_partition_axis = conv_partition_axis
+        self.data_partition_axis = data_partition_axis
+
+        recurrent_axis_size = mesh.shape[recurrent_partition_axis]
+        conv_axis_size = mesh.shape[conv_partition_axis]
+        assert num_heads % recurrent_axis_size == 0, (
+            f"num_heads {num_heads} must be divisible by "
+            f"'{recurrent_partition_axis}' size {recurrent_axis_size}"
+        )
+        assert num_k_heads % recurrent_axis_size == 0, (
+            f"num_k_heads {num_k_heads} must be divisible by "
+            f"'{recurrent_partition_axis}' size {recurrent_axis_size}"
+        )
+        assert self.proj_size % conv_axis_size == 0, (
+            f"proj_size {self.proj_size} must be divisible by "
+            f"'{conv_partition_axis}' size {conv_axis_size}"
+        )
+
+        self.recurrent_sharding = NamedSharding(
+            mesh, P(data_partition_axis, recurrent_partition_axis, None, None)
+        )
+        self.conv_sharding = NamedSharding(mesh, P(data_partition_axis, conv_partition_axis, None))
+
+        self.recurrent_buffers, self.conv_buffers = self._create_buffers()
+
+    def _create_buffers(self) -> tuple[list, list]:
+        recurrent_shape = (self.total_slots, self.num_heads, self.head_dim, self.head_dim)
+        conv_shape = (self.total_slots, self.proj_size, self.conv_kernel_size - 1)
+        temporal_dtype = self.temporal_dtype
+        conv_dtype = self.conv_dtype
+
+        with self.mesh:
+            recurrent_buffers = []
+            for _ in range(self.num_linear_recurrent_layers):
+                buf = jax.jit(
+                    lambda: jnp.zeros(shape=recurrent_shape, dtype=temporal_dtype),
+                    out_shardings=self.recurrent_sharding,
+                )()
+                recurrent_buffers.append(buf)
+
+            conv_buffers = []
+            for _ in range(self.num_linear_recurrent_layers):
+                inner = []
+                buf = jax.jit(
+                    lambda: jnp.zeros(shape=conv_shape, dtype=conv_dtype),
+                    out_shardings=self.conv_sharding,
+                )()
+                inner.append(buf)
+                conv_buffers.append(inner)
+
+        return recurrent_buffers, conv_buffers
+
+    def clear_slot(self, idx_or_indices) -> None:
+        """Zero the per-slot buffers for the given slot(s). Used for clear-on-alloc."""
+        indices = [idx_or_indices] if isinstance(idx_or_indices, int) else list(idx_or_indices)
+        if not indices:
+            return
+
+        idx_arr = jnp.asarray(indices, dtype=jnp.int32)
+        with jax.set_mesh(self.mesh):
+            for layer in range(self.num_linear_recurrent_layers):
+                self.recurrent_buffers[layer] = self.recurrent_buffers[layer].at[idx_arr].set(0)
+                for inner in range(len(self.conv_buffers[layer])):
+                    self.conv_buffers[layer][inner] = (
+                        self.conv_buffers[layer][inner].at[idx_arr].set(0)
+                    )
+
+    def get_linear_recurrent_layer_cache(self, layer_id: int):
+        """Read the per-layer view, keyed by model-global layer_id.
+
+        Returns (recurrent_per_layer, conv_per_layer).
+        """
+        if layer_id not in self.layers_mapping:
+            raise ValueError(
+                f"layer_id={layer_id} is not a registered linear recurrent layer. "
+                f"Registered: {self.linear_recurrent_layer_ids}"
+            )
+        idx = self.layers_mapping[layer_id]
+        return self.recurrent_buffers[idx], self.conv_buffers[idx]
+
+    def replace_buffer(self, buffers) -> None:
+        """Update both buffer-list references after a JIT donate.
+
+        buffers: tuple[list[jax.Array], list[list[jax.Array]]]
+        """
+        new_recurrent, new_conv = buffers
+
+        assert len(new_recurrent) == self.num_linear_recurrent_layers
+        assert len(new_conv) == self.num_linear_recurrent_layers
+        for layer in range(self.num_linear_recurrent_layers):
+            assert len(new_conv[layer]) == len(self.conv_buffers[layer])
+
+        tp_degenerate = self.mesh.shape.get("tensor", 1) == 1
+        for layer in range(self.num_linear_recurrent_layers):
+            buf = new_recurrent[layer]
+            if tp_degenerate and hasattr(self, "recurrent_sharding"):
+                buf = jax.device_put(buf, self.recurrent_sharding)
+            self.recurrent_buffers[layer] = buf
+
+        for layer in range(self.num_linear_recurrent_layers):
+            for i in range(len(new_conv[layer])):
+                buf = new_conv[layer][i]
+                if tp_degenerate and hasattr(self, "conv_sharding"):
+                    buf = jax.device_put(buf, self.conv_sharding)
+                self.conv_buffers[layer][i] = buf
+
+    def clear(self) -> None:
+        """Full reset: zero out every layer's recurrent + conv buffer."""
+        for layer in range(self.num_linear_recurrent_layers):
+            self.recurrent_buffers[layer] = jnp.zeros_like(self.recurrent_buffers[layer])
+            for inner in range(len(self.conv_buffers[layer])):
+                self.conv_buffers[layer][inner] = jnp.zeros_like(self.conv_buffers[layer][inner])
+
+    # --- pytree ---
+    def tree_flatten(self):
+        children = (self.recurrent_buffers, self.conv_buffers)
+        aux = (
+            tuple(self.linear_recurrent_layer_ids),
+            self.size,
+            self.dp_size,
+            self.total_slots,
+            self.num_heads,
+            self.head_dim,
+            self.num_k_heads,
+            self.head_k_dim,
+            self.conv_kernel_size,
+            self.temporal_dtype,
+            self.conv_dtype,
+            self.mesh,
+            self.recurrent_partition_axis,
+            self.conv_partition_axis,
+            self.data_partition_axis,
+            self.recurrent_sharding,
+            self.conv_sharding,
+        )
+        return children, aux
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        (
+            linear_recurrent_layer_ids_tup,
+            size,
+            dp_size,
+            total_slots,
+            num_heads,
+            head_dim,
+            num_k_heads,
+            head_k_dim,
+            conv_kernel_size,
+            temporal_dtype,
+            conv_dtype,
+            mesh,
+            recurrent_partition_axis,
+            conv_partition_axis,
+            data_partition_axis,
+            recurrent_sharding,
+            conv_sharding,
+        ) = aux_data
+        obj = cls.__new__(cls)
+        obj.linear_recurrent_layer_ids = list(linear_recurrent_layer_ids_tup)
+        obj.layers_mapping = {
+            layer_id: idx for idx, layer_id in enumerate(obj.linear_recurrent_layer_ids)
+        }
+        obj.num_linear_recurrent_layers = len(obj.linear_recurrent_layer_ids)
+        obj.size = size
+        obj.dp_size = dp_size
+        obj.total_slots = total_slots
+        obj.num_heads = num_heads
+        obj.head_dim = head_dim
+        obj.num_k_heads = num_k_heads
+        obj.head_k_dim = head_k_dim
+        obj.conv_kernel_size = conv_kernel_size
+        obj.temporal_dtype = temporal_dtype
+        obj.conv_dtype = conv_dtype
+        proj_v = num_heads * head_dim
+        proj_k = num_k_heads * head_k_dim
+        obj.proj_size = proj_v + 2 * proj_k
+        obj.mesh = mesh
+        obj.recurrent_partition_axis = recurrent_partition_axis
+        obj.conv_partition_axis = conv_partition_axis
+        obj.data_partition_axis = data_partition_axis
+        obj.recurrent_sharding = recurrent_sharding
+        obj.conv_sharding = conv_sharding
+        new_recurrent, new_conv = children
+        obj.recurrent_buffers = list(new_recurrent)
+        obj.conv_buffers = [list(inner) for inner in new_conv]
+        return obj

--- a/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
+++ b/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
@@ -194,6 +194,7 @@ class RecurrentStatePool:
             tuple(self.linear_recurrent_layer_ids),
             self.size,
             self.dp_size,
+            self.total_slots,
             self.num_heads,
             self.head_dim,
             self.num_k_heads,
@@ -205,6 +206,8 @@ class RecurrentStatePool:
             self.recurrent_partition_axis,
             self.conv_partition_axis,
             self.data_partition_axis,
+            self.recurrent_sharding,
+            self.conv_sharding,
         )
         return children, aux
 
@@ -214,6 +217,7 @@ class RecurrentStatePool:
             linear_recurrent_layer_ids_tup,
             size,
             dp_size,
+            total_slots,
             num_heads,
             head_dim,
             num_k_heads,
@@ -225,6 +229,8 @@ class RecurrentStatePool:
             recurrent_partition_axis,
             conv_partition_axis,
             data_partition_axis,
+            recurrent_sharding,
+            conv_sharding,
         ) = aux_data
         obj = cls.__new__(cls)
         obj.linear_recurrent_layer_ids = list(linear_recurrent_layer_ids_tup)
@@ -234,7 +240,7 @@ class RecurrentStatePool:
         obj.num_linear_recurrent_layers = len(obj.linear_recurrent_layer_ids)
         obj.size = size
         obj.dp_size = dp_size
-        obj.total_slots = _ceil_to(size + 1, dp_size)
+        obj.total_slots = total_slots
         obj.num_heads = num_heads
         obj.head_dim = head_dim
         obj.num_k_heads = num_k_heads
@@ -249,10 +255,8 @@ class RecurrentStatePool:
         obj.recurrent_partition_axis = recurrent_partition_axis
         obj.conv_partition_axis = conv_partition_axis
         obj.data_partition_axis = data_partition_axis
-        obj.recurrent_sharding = NamedSharding(
-            mesh, P(data_partition_axis, recurrent_partition_axis, None, None)
-        )
-        obj.conv_sharding = NamedSharding(mesh, P(data_partition_axis, conv_partition_axis, None))
+        obj.recurrent_sharding = recurrent_sharding
+        obj.conv_sharding = conv_sharding
         new_recurrent, new_conv = children
         obj.recurrent_buffers = list(new_recurrent)
         obj.conv_buffers = [list(inner) for inner in new_conv]

--- a/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
+++ b/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
@@ -1,16 +1,4 @@
-"""RecurrentStatePool -- recurrent + conv state buffer pool for linear recurrent layers.
-
-Dual list containers:
-    recurrent_buffers: list[jax.Array], length L, each [total_slots, H, D, D]
-    conv_buffers: list[list[jax.Array]], outer L, inner 1, each [total_slots, proj_size, K-1]
-
-Slot 0 reserved as dummy; valid slots start from 1 (aligned with sglang MambaPool).
-total_slots = ceil_to_dp(size + 1, dp_size) so the slot dim is evenly divisible
-by dp_size for P("data", ...) sharding.
-
-Pure buffer pool: slot allocator state lives in HybridReqToTokenPool.
-Does NOT inherit from KVCache.
-"""
+"""RecurrentStatePool -- buffer pool for linear recurrent layers (KDA/Mamba/GDN)."""
 
 from __future__ import annotations
 
@@ -40,7 +28,6 @@ def _ceil_to(value: int, divisor: int) -> int:
 
 @register_pytree_node_class
 class RecurrentStatePool:
-    """Recurrent + conv state buffer pool (per-slot indexing, no slot allocator)."""
 
     def __init__(
         self,
@@ -161,7 +148,6 @@ class RecurrentStatePool:
         return recurrent_buffers, conv_buffers
 
     def clear_slot(self, idx_or_indices) -> None:
-        """Zero the per-slot buffers for the given slot(s). Used for clear-on-alloc."""
         indices = [idx_or_indices] if isinstance(idx_or_indices, int) else list(idx_or_indices)
         if not indices:
             return
@@ -176,10 +162,6 @@ class RecurrentStatePool:
                     )
 
     def get_linear_recurrent_layer_cache(self, layer_id: int):
-        """Read the per-layer view, keyed by model-global layer_id.
-
-        Returns (recurrent_per_layer, conv_per_layer).
-        """
         if layer_id not in self.layers_mapping:
             raise ValueError(
                 f"layer_id={layer_id} is not a registered linear recurrent layer. "
@@ -189,10 +171,6 @@ class RecurrentStatePool:
         return self.recurrent_buffers[idx], self.conv_buffers[idx]
 
     def replace_buffer(self, buffers) -> None:
-        """Update both buffer-list references after a JIT donate.
-
-        buffers: tuple[list[jax.Array], list[list[jax.Array]]]
-        """
         new_recurrent, new_conv = buffers
 
         assert len(new_recurrent) == self.num_linear_recurrent_layers
@@ -215,7 +193,6 @@ class RecurrentStatePool:
                 self.conv_buffers[layer][i] = buf
 
     def clear(self) -> None:
-        """Full reset: zero out every layer's recurrent + conv buffer."""
         for layer in range(self.num_linear_recurrent_layers):
             self.recurrent_buffers[layer] = jnp.zeros_like(self.recurrent_buffers[layer])
             for inner in range(len(self.conv_buffers[layer])):

--- a/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
+++ b/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
@@ -165,22 +165,21 @@ class RecurrentStatePool:
 
         assert len(new_recurrent) == self.num_linear_recurrent_layers
         assert len(new_conv) == self.num_linear_recurrent_layers
-        for layer in range(self.num_linear_recurrent_layers):
-            assert len(new_conv[layer]) == len(self.conv_buffers[layer])
 
+        # tp_size==1 sharding fix: see MHATokenToKVPool.replace_buffer
         tp_degenerate = self.mesh.shape.get("tensor", 1) == 1
         for layer in range(self.num_linear_recurrent_layers):
             buf = new_recurrent[layer]
-            if tp_degenerate and hasattr(self, "recurrent_sharding"):
+            if tp_degenerate:
                 buf = jax.device_put(buf, self.recurrent_sharding)
             self.recurrent_buffers[layer] = buf
 
-        for layer in range(self.num_linear_recurrent_layers):
+            assert len(new_conv[layer]) == len(self.conv_buffers[layer])
             for i in range(len(new_conv[layer])):
-                buf = new_conv[layer][i]
-                if tp_degenerate and hasattr(self, "conv_sharding"):
-                    buf = jax.device_put(buf, self.conv_sharding)
-                self.conv_buffers[layer][i] = buf
+                cbuf = new_conv[layer][i]
+                if tp_degenerate:
+                    cbuf = jax.device_put(cbuf, self.conv_sharding)
+                self.conv_buffers[layer][i] = cbuf
 
     def clear(self) -> None:
         for layer in range(self.num_linear_recurrent_layers):
@@ -195,7 +194,6 @@ class RecurrentStatePool:
             tuple(self.linear_recurrent_layer_ids),
             self.size,
             self.dp_size,
-            self.total_slots,
             self.num_heads,
             self.head_dim,
             self.num_k_heads,
@@ -207,8 +205,6 @@ class RecurrentStatePool:
             self.recurrent_partition_axis,
             self.conv_partition_axis,
             self.data_partition_axis,
-            self.recurrent_sharding,
-            self.conv_sharding,
         )
         return children, aux
 
@@ -218,7 +214,6 @@ class RecurrentStatePool:
             linear_recurrent_layer_ids_tup,
             size,
             dp_size,
-            total_slots,
             num_heads,
             head_dim,
             num_k_heads,
@@ -230,8 +225,6 @@ class RecurrentStatePool:
             recurrent_partition_axis,
             conv_partition_axis,
             data_partition_axis,
-            recurrent_sharding,
-            conv_sharding,
         ) = aux_data
         obj = cls.__new__(cls)
         obj.linear_recurrent_layer_ids = list(linear_recurrent_layer_ids_tup)
@@ -241,7 +234,7 @@ class RecurrentStatePool:
         obj.num_linear_recurrent_layers = len(obj.linear_recurrent_layer_ids)
         obj.size = size
         obj.dp_size = dp_size
-        obj.total_slots = total_slots
+        obj.total_slots = _ceil_to(size + 1, dp_size)
         obj.num_heads = num_heads
         obj.head_dim = head_dim
         obj.num_k_heads = num_k_heads
@@ -256,8 +249,10 @@ class RecurrentStatePool:
         obj.recurrent_partition_axis = recurrent_partition_axis
         obj.conv_partition_axis = conv_partition_axis
         obj.data_partition_axis = data_partition_axis
-        obj.recurrent_sharding = recurrent_sharding
-        obj.conv_sharding = conv_sharding
+        obj.recurrent_sharding = NamedSharding(
+            mesh, P(data_partition_axis, recurrent_partition_axis, None, None)
+        )
+        obj.conv_sharding = NamedSharding(mesh, P(data_partition_axis, conv_partition_axis, None))
         new_recurrent, new_conv = children
         obj.recurrent_buffers = list(new_recurrent)
         obj.conv_buffers = [list(inner) for inner in new_conv]

--- a/python/sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py
@@ -32,13 +32,14 @@ def _mesh_dp_tp(dp_size):
     return Mesh(devices, ("data", "tensor"))
 
 
-def _make_req(req_pool_idx=None, is_chunked=0, kv_committed_len=0):
+def _make_req(req_pool_idx=None, is_chunked=0, kv_committed_len=0, dp_rank=None):
     """Minimal Req surrogate exposing only the attributes hybrid pool reads."""
     return SimpleNamespace(
         req_pool_idx=req_pool_idx,
         recurrent_pool_idx=None,
         is_chunked=is_chunked,
         kv_committed_len=kv_committed_len,
+        dp_rank=dp_rank,
     )
 
 
@@ -59,6 +60,7 @@ def _make_pool(size=4, mesh=None, dp_size=1):
         max_context_len=8,
         dtype=np.int32,
         recurrent_state_pool=rsp,
+        dp_size=dp_size,
     )
     return pool, rsp
 
@@ -99,16 +101,16 @@ class TestHybridReqToTokenPool(CustomTestCase):
                 rsp.recurrent_buffers[0] = rsp.recurrent_buffers[0].at[slot].set(7.5)
 
                 req_a.is_chunked = 1
-                rec_before = list(pool.recurrent_free_slots)
+                rec_before = list(pool.recurrent_free_slots[0])
 
                 if case == "partial_reuse":
                     req_b = _make_req()
                     pool.alloc([req_a, req_b])
-                    self.assertEqual(len(pool.recurrent_free_slots), len(rec_before) - 1)
+                    self.assertEqual(len(pool.recurrent_free_slots[0]), len(rec_before) - 1)
                     self.assertNotEqual(req_b.recurrent_pool_idx, slot)
                 else:
                     pool.alloc([req_a])
-                    self.assertEqual(pool.recurrent_free_slots, rec_before)
+                    self.assertEqual(pool.recurrent_free_slots[0], rec_before)
 
                 # Reused slot retains its sentinel (not cleared on alloc).
                 self.assertEqual(req_a.recurrent_pool_idx, slot)
@@ -132,7 +134,7 @@ class TestHybridReqToTokenPool(CustomTestCase):
                     reqs = [_make_req() for _ in range(4)]
 
                 kv_before = list(pool.free_slots)
-                rec_before = list(pool.recurrent_free_slots)
+                rec_before = list(pool.recurrent_free_slots[0])
                 mapping_before = pool.req_index_to_recurrent_index_mapping.copy()
 
                 self.assertIsNone(pool.alloc(reqs))
@@ -140,7 +142,7 @@ class TestHybridReqToTokenPool(CustomTestCase):
                     self.assertIsNone(req.req_pool_idx)
                     self.assertIsNone(req.recurrent_pool_idx)
                 self.assertEqual(pool.free_slots, kv_before)
-                self.assertEqual(pool.recurrent_free_slots, rec_before)
+                self.assertEqual(pool.recurrent_free_slots[0], rec_before)
                 self.assertTrue(
                     bool((pool.req_index_to_recurrent_index_mapping == mapping_before).all())
                 )
@@ -150,7 +152,7 @@ class TestHybridReqToTokenPool(CustomTestCase):
         pool, _ = _make_pool(size=3)
         reqs = [_make_req() for _ in range(3)]
         self.assertIsNotNone(pool.alloc(reqs))
-        self.assertEqual(pool.recurrent_free_slots, [])
+        self.assertEqual(pool.recurrent_free_slots[0], [])
 
     def test_alloc_assert_on_unsanctioned_reuse(self):
         """Inherits parent assert: a req holding req_pool_idx but is_chunked
@@ -175,7 +177,7 @@ class TestHybridReqToTokenPool(CustomTestCase):
 
                 if case == "no_recurrent_slot":
                     pool.free_recurrent_cache(req)
-                    rec_free_before = list(pool.recurrent_free_slots)
+                    rec_free_before = list(pool.recurrent_free_slots[0])
 
                 kv_free_before = len(pool.free_slots)
                 pool.free(req)
@@ -185,10 +187,10 @@ class TestHybridReqToTokenPool(CustomTestCase):
                 self.assertIsNone(req.req_pool_idx)
                 self.assertIsNone(req.recurrent_pool_idx)
                 if case == "full":
-                    self.assertIn(rec_slot, pool.recurrent_free_slots)
+                    self.assertIn(rec_slot, pool.recurrent_free_slots[0])
                 else:
-                    # no_recurrent_slot: recurrent_free_slots unchanged by free()
-                    self.assertEqual(pool.recurrent_free_slots, rec_free_before)
+                    # no_recurrent_slot: rank's free list unchanged by free()
+                    self.assertEqual(pool.recurrent_free_slots[0], rec_free_before)
 
     def test_alloc_after_free_clears_recurrent_buffer(self):
         """clear-on-alloc reuse path: write non-zero, free, re-alloc -> zeroed.
@@ -214,7 +216,7 @@ class TestHybridReqToTokenPool(CustomTestCase):
         pool.clear()
 
         self.assertEqual(pool.free_slots, list(range(pool.size)))
-        self.assertEqual(pool.recurrent_free_slots, [1, 2, 3, 4])
+        self.assertEqual(pool.recurrent_free_slots, [[1, 2, 3, 4]])
         self.assertTrue(bool(jnp.all(rsp.recurrent_buffers[0] == 0)))
         self.assertTrue(bool((pool.req_index_to_recurrent_index_mapping == 0).all()))
 
@@ -250,13 +252,13 @@ class TestHybridReqToTokenPool(CustomTestCase):
         """Sanity for the smallest usable pool. Confirms there is no implicit
         assumption that size > 1 in alloc / free / mapping paths."""
         pool, rsp = _make_pool(size=1)
-        self.assertEqual(pool.recurrent_free_slots, [1])
+        self.assertEqual(pool.recurrent_free_slots, [[1]])
         self.assertEqual(pool.req_index_to_recurrent_index_mapping.shape, (1,))
 
         req = _make_req()
         self.assertIsNotNone(pool.alloc([req]))
         self.assertEqual(req.recurrent_pool_idx, 1)
-        self.assertEqual(pool.recurrent_free_slots, [])
+        self.assertEqual(pool.recurrent_free_slots, [[]])
 
         # Second alloc on a drained size=1 pool must fail atomically.
         req2 = _make_req()
@@ -265,36 +267,86 @@ class TestHybridReqToTokenPool(CustomTestCase):
         self.assertIsNone(req2.recurrent_pool_idx)
 
         pool.free(req)
-        self.assertEqual(pool.recurrent_free_slots, [1])
+        self.assertEqual(pool.recurrent_free_slots, [[1]])
 
 
 class TestHybridReqToTokenPoolDP(CustomTestCase):
+    """dp_size > 1 contracts: per-rank allocator state, LOCAL slot indexing,
+    cross-rank isolation."""
+
     @classmethod
     def setUpClass(cls):
         if len(jax.devices()) < 2:
             raise unittest.SkipTest("DP tests need >= 2 devices")
 
-    def test_dp_capacity_decoupled_from_total_slots(self):
-        """Host-side allocator capacity is decoupled from RecurrentStatePool's
-        DP-padded total_slots. With dp_size=2 and size=3, total_slots ceils
-        to 4 for buffer divisibility; recurrent_free_slots still hands out
-        exactly 3 valid slots [1..3]. Full alloc/free roundtrip must work
-        identically to the dp_size=1 case.
+    def test_init_per_rank_local_indexing(self):
+        """Each rank gets its own free list of LOCAL indices [1..slots_per_rank].
+        slots_per_rank = rsp.size // dp_size; the rank's local view of the
+        DP-sharded buffer indexes into its own slice."""
+        mesh = _mesh_dp_tp(dp_size=2)
+        pool, rsp = _make_pool(size=4, mesh=mesh, dp_size=2)
+        self.assertEqual(pool.dp_size, 2)
+        self.assertEqual(pool.slots_per_rank, 2)  # 4 // 2
+        self.assertEqual(pool.recurrent_free_slots, [[1, 2], [1, 2]])
+
+    def test_alloc_routes_to_req_dp_rank(self):
+        """alloc(reqs) draws slots from the rank named by reqs[0].dp_rank;
+        the other rank's free list stays untouched. Slots returned are
+        per-rank local indices (so two reqs on different ranks can both
+        legitimately hold local slot 1)."""
+        mesh = _mesh_dp_tp(dp_size=2)
+        pool, _ = _make_pool(size=4, mesh=mesh, dp_size=2)
+
+        reqs_rank0 = [_make_req(dp_rank=0), _make_req(dp_rank=0)]
+        self.assertIsNotNone(pool.alloc(reqs_rank0))
+        self.assertEqual(pool.recurrent_free_slots[0], [])
+        self.assertEqual(pool.recurrent_free_slots[1], [1, 2])
+        self.assertEqual(sorted(r.recurrent_pool_idx for r in reqs_rank0), [1, 2])
+
+        reqs_rank1 = [_make_req(dp_rank=1)]
+        self.assertIsNotNone(pool.alloc(reqs_rank1))
+        # rank 1 gets local slot 1 (independent allocator state).
+        self.assertEqual(reqs_rank1[0].recurrent_pool_idx, 1)
+        self.assertEqual(pool.recurrent_free_slots[1], [2])
+
+    def test_alloc_capacity_miss_is_per_rank(self):
+        """A capacity miss on one rank must not mutate the other rank's
+        free list or any req fields (atomic per-rank semantics)."""
+        mesh = _mesh_dp_tp(dp_size=2)
+        pool, _ = _make_pool(size=4, mesh=mesh, dp_size=2)
+
+        # Drain rank 0.
+        pool.alloc([_make_req(dp_rank=0), _make_req(dp_rank=0)])
+        rank1_before = list(pool.recurrent_free_slots[1])
+
+        # Third rank-0 req triggers per-rank capacity miss.
+        third = _make_req(dp_rank=0)
+        self.assertIsNone(pool.alloc([third]))
+        self.assertIsNone(third.req_pool_idx)
+        self.assertIsNone(third.recurrent_pool_idx)
+        # Rank 1 untouched.
+        self.assertEqual(pool.recurrent_free_slots[1], rank1_before)
+
+    def test_free_routes_to_req_dp_rank(self):
+        """free(req) returns the slot to the rank named by req.dp_rank.
+        Cross-rank free routing must not corrupt the other rank's free list.
         """
         mesh = _mesh_dp_tp(dp_size=2)
-        pool, rsp = _make_pool(size=3, mesh=mesh, dp_size=2)
-        self.assertEqual(rsp.size, 3)
-        self.assertEqual(rsp.total_slots, 4)  # ceil(3+1, 2)
-        self.assertEqual(pool.recurrent_free_slots, [1, 2, 3])
+        pool, _ = _make_pool(size=4, mesh=mesh, dp_size=2)
 
-        reqs = [_make_req(), _make_req(), _make_req()]
-        self.assertIsNotNone(pool.alloc(reqs))
-        self.assertEqual(pool.recurrent_free_slots, [])
+        req0 = _make_req(dp_rank=0)
+        req1 = _make_req(dp_rank=1)
+        pool.alloc([req0])
+        pool.alloc([req1])
+        # Both got local slot 1.
+        self.assertEqual(req0.recurrent_pool_idx, 1)
+        self.assertEqual(req1.recurrent_pool_idx, 1)
+        self.assertEqual(pool.recurrent_free_slots, [[2], [2]])
 
-        pool.free(reqs[0])
-        req_new = _make_req()
-        self.assertIsNotNone(pool.alloc([req_new]))
-        self.assertEqual(pool.recurrent_free_slots, [])
+        pool.free(req0)
+        # Rank 0 reclaims slot 1; rank 1 still holds slot 1.
+        self.assertEqual(pool.recurrent_free_slots[0], [2, 1])
+        self.assertEqual(pool.recurrent_free_slots[1], [2])
 
 
 if __name__ == "__main__":

--- a/python/sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py
@@ -1,0 +1,301 @@
+# cd python && USE_DEVICE_TYPE=cpu python -m pytest sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py -v
+
+import os
+import unittest
+from types import SimpleNamespace
+
+if os.environ.get("USE_DEVICE_TYPE") == "cpu":
+    os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+    os.environ["JAX_PLATFORMS"] = "cpu"
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh
+
+from sgl_jax.srt.mem_cache.memory_pool import HybridReqToTokenPool
+from sgl_jax.srt.mem_cache.recurrent_state_pool import RecurrentStatePool
+from sgl_jax.test.test_utils import CustomTestCase
+
+
+def _mesh_tp_only():
+    """DP=1, TP=N mesh. RecurrentStatePool requires both 'data' and 'tensor'
+    axes (sharding spec is P('data', 'tensor', None, ...))."""
+    devices = np.array(jax.devices()).reshape(1, -1)
+    return Mesh(devices, ("data", "tensor"))
+
+
+def _mesh_dp_tp(dp_size):
+    """DP=dp_size, TP=N/dp_size mesh."""
+    n = len(jax.devices())
+    devices = np.array(jax.devices()).reshape(dp_size, n // dp_size)
+    return Mesh(devices, ("data", "tensor"))
+
+
+def _make_req(req_pool_idx=None, is_chunked=0, kv_committed_len=0):
+    """Minimal Req surrogate exposing only the attributes hybrid pool reads."""
+    return SimpleNamespace(
+        req_pool_idx=req_pool_idx,
+        recurrent_pool_idx=None,
+        is_chunked=is_chunked,
+        kv_committed_len=kv_committed_len,
+    )
+
+
+def _make_pool(size=4, mesh=None, dp_size=1):
+    if mesh is None:
+        mesh = _mesh_tp_only()
+    rsp = RecurrentStatePool(
+        linear_recurrent_layer_ids=[0],
+        size=size,
+        num_heads=mesh.shape["tensor"],
+        head_dim=2,
+        conv_kernel_size=4,
+        mesh=mesh,
+        dp_size=dp_size,
+    )
+    pool = HybridReqToTokenPool(
+        size=size,
+        max_context_len=8,
+        dtype=np.int32,
+        recurrent_state_pool=rsp,
+    )
+    return pool, rsp
+
+
+class TestHybridReqToTokenPool(CustomTestCase):
+    def test_alloc_fresh(self):
+        """Fresh alloc: writes both indices, mapping[req_pool_idx] =
+        recurrent_pool_idx, get_linear_recurrent_indices returns the same."""
+        pool, _ = _make_pool(size=4)
+        reqs = [_make_req(), _make_req(), _make_req(), _make_req()]
+        slots = pool.alloc(reqs)
+
+        self.assertEqual(len(slots), 4)
+        for req in reqs:
+            self.assertIsNotNone(req.req_pool_idx)
+            self.assertGreaterEqual(req.recurrent_pool_idx, 1)
+            self.assertEqual(
+                pool.req_index_to_recurrent_index_mapping[req.req_pool_idx],
+                req.recurrent_pool_idx,
+            )
+
+        req_pool_indices = np.array([r.req_pool_idx for r in reqs])
+        recurrent_indices = pool.get_linear_recurrent_indices(req_pool_indices)
+        for req, rec in zip(reqs, recurrent_indices):
+            self.assertEqual(rec, req.recurrent_pool_idx)
+
+    def test_alloc_reuse(self):
+        """Reuse path: req with recurrent_pool_idx + is_chunked > 0 keeps
+        its slot. Buffer content at the held slot must NOT be cleared."""
+        for case in ("partial_reuse", "full_reuse"):
+            with self.subTest(case=case):
+                pool, rsp = _make_pool(size=4)
+                req_a = _make_req()
+                pool.alloc([req_a])
+
+                # Stamp a sentinel value at the held slot.
+                slot = req_a.recurrent_pool_idx
+                rsp.recurrent_buffers[0] = rsp.recurrent_buffers[0].at[slot].set(7.5)
+
+                req_a.is_chunked = 1
+                rec_before = list(pool.recurrent_free_slots)
+
+                if case == "partial_reuse":
+                    req_b = _make_req()
+                    pool.alloc([req_a, req_b])
+                    self.assertEqual(len(pool.recurrent_free_slots), len(rec_before) - 1)
+                    self.assertNotEqual(req_b.recurrent_pool_idx, slot)
+                else:
+                    pool.alloc([req_a])
+                    self.assertEqual(pool.recurrent_free_slots, rec_before)
+
+                # Reused slot retains its sentinel (not cleared on alloc).
+                self.assertEqual(req_a.recurrent_pool_idx, slot)
+                self.assertTrue(bool(jnp.all(rsp.recurrent_buffers[0][slot] == 7.5)))
+
+    def test_alloc_atomic_on_miss(self):
+        """Capacity miss must not partially mutate any state. Covers the
+        recurrent-side pre-check, the KV-side parent atomic guarantee, and
+        the off-by-one boundary (capacity vs capacity + 1)."""
+        for case in ("recurrent_miss", "kv_miss", "off_by_one"):
+            with self.subTest(case=case):
+                if case == "recurrent_miss":
+                    pool, _ = _make_pool(size=2)
+                    reqs = [_make_req(), _make_req(), _make_req()]
+                elif case == "kv_miss":
+                    pool, _ = _make_pool(size=4)
+                    pool.free_slots = pool.free_slots[:1]  # leave 1 KV slot
+                    reqs = [_make_req(), _make_req()]
+                else:  # off_by_one: capacity = N, request N+1
+                    pool, _ = _make_pool(size=3)
+                    reqs = [_make_req() for _ in range(4)]
+
+                kv_before = list(pool.free_slots)
+                rec_before = list(pool.recurrent_free_slots)
+                mapping_before = pool.req_index_to_recurrent_index_mapping.copy()
+
+                self.assertIsNone(pool.alloc(reqs))
+                for req in reqs:
+                    self.assertIsNone(req.req_pool_idx)
+                    self.assertIsNone(req.recurrent_pool_idx)
+                self.assertEqual(pool.free_slots, kv_before)
+                self.assertEqual(pool.recurrent_free_slots, rec_before)
+                self.assertTrue(
+                    bool((pool.req_index_to_recurrent_index_mapping == mapping_before).all())
+                )
+
+    def test_alloc_at_exact_capacity_succeeds(self):
+        """Capacity == request: must succeed and drain free pools to empty."""
+        pool, _ = _make_pool(size=3)
+        reqs = [_make_req() for _ in range(3)]
+        self.assertIsNotNone(pool.alloc(reqs))
+        self.assertEqual(pool.recurrent_free_slots, [])
+
+    def test_alloc_assert_on_unsanctioned_reuse(self):
+        """Inherits parent assert: a req holding req_pool_idx but is_chunked
+        == 0 and kv_committed_len == 0 indicates a missed free() — must raise."""
+        pool, _ = _make_pool()
+        req = _make_req()
+        pool.alloc([req])
+        # is_chunked still 0, kv_committed_len still 0 -> reuse must raise.
+        with self.assertRaises(AssertionError):
+            pool.alloc([req])
+
+    def test_free_releases_both_slots(self):
+        """free(req) releases KV slot AND recurrent slot; idempotent on the
+        recurrent side when req.recurrent_pool_idx is None."""
+        for case in ("full", "no_recurrent_slot"):
+            with self.subTest(case=case):
+                pool, _ = _make_pool()
+                req = _make_req()
+                pool.alloc([req])
+                kv_slot = req.req_pool_idx
+                rec_slot = req.recurrent_pool_idx
+
+                if case == "no_recurrent_slot":
+                    pool.free_recurrent_cache(req)
+                    rec_free_before = list(pool.recurrent_free_slots)
+
+                kv_free_before = len(pool.free_slots)
+                pool.free(req)
+
+                self.assertIn(kv_slot, pool.free_slots)
+                self.assertEqual(len(pool.free_slots), kv_free_before + 1)
+                self.assertIsNone(req.req_pool_idx)
+                self.assertIsNone(req.recurrent_pool_idx)
+                if case == "full":
+                    self.assertIn(rec_slot, pool.recurrent_free_slots)
+                else:
+                    # no_recurrent_slot: recurrent_free_slots unchanged by free()
+                    self.assertEqual(pool.recurrent_free_slots, rec_free_before)
+
+    def test_alloc_after_free_clears_recurrent_buffer(self):
+        """clear-on-alloc reuse path: write non-zero, free, re-alloc -> zeroed.
+        Critical: protects against stale state leaking into a reused slot."""
+        pool, rsp = _make_pool()
+        req = _make_req()
+        pool.alloc([req])
+        rsp.recurrent_buffers[0] = rsp.recurrent_buffers[0].at[req.recurrent_pool_idx].set(99.0)
+        pool.free_recurrent_cache(req)
+
+        new_req = _make_req()
+        pool.alloc([new_req])
+        self.assertTrue(bool(jnp.all(rsp.recurrent_buffers[0][new_req.recurrent_pool_idx] == 0)))
+
+    def test_clear_resets_then_realloc(self):
+        """clear() resets KV + recurrent allocators, recurrent + conv buffers,
+        and mapping; subsequent alloc must work as on a fresh pool."""
+        pool, rsp = _make_pool(size=4)
+        reqs = [_make_req(), _make_req()]
+        pool.alloc(reqs)
+        rsp.recurrent_buffers[0] = jnp.ones_like(rsp.recurrent_buffers[0])
+
+        pool.clear()
+
+        self.assertEqual(pool.free_slots, list(range(pool.size)))
+        self.assertEqual(pool.recurrent_free_slots, [1, 2, 3, 4])
+        self.assertTrue(bool(jnp.all(rsp.recurrent_buffers[0] == 0)))
+        self.assertTrue(bool((pool.req_index_to_recurrent_index_mapping == 0).all()))
+
+        # Realloc after clear must succeed and assign fresh indices.
+        new_reqs = [_make_req(), _make_req()]
+        self.assertIsNotNone(pool.alloc(new_reqs))
+        for req in new_reqs:
+            self.assertIsNotNone(req.req_pool_idx)
+            self.assertGreaterEqual(req.recurrent_pool_idx, 1)
+
+    def test_allocator_survives_jit_donate_cycle(self):
+        """Critical regression: allocator state lives on HybridReqToTokenPool,
+        NOT inside the JIT-donated RecurrentStatePool pytree. After a simulated
+        JIT-donate cycle on RecurrentStatePool, subsequent allocations must
+        observe the persisted free_slots state — otherwise alloc would
+        silently re-hand the same slot to two reqs.
+        """
+        pool, rsp = _make_pool(size=4)
+        req_a, req_b = _make_req(), _make_req()
+        pool.alloc([req_a, req_b])
+        slot_a, slot_b = req_a.recurrent_pool_idx, req_b.recurrent_pool_idx
+
+        # Simulate a JIT-donate cycle on RecurrentStatePool.
+        leaves, treedef = jax.tree_util.tree_flatten(rsp)
+        pool.recurrent_state_pool = jax.tree_util.tree_unflatten(treedef, leaves)
+
+        # Allocator must NOT have reset to constructor default.
+        req_c = _make_req()
+        pool.alloc([req_c])
+        self.assertNotIn(req_c.recurrent_pool_idx, {slot_a, slot_b})
+
+    def test_size_one_minimal_pool(self):
+        """Sanity for the smallest usable pool. Confirms there is no implicit
+        assumption that size > 1 in alloc / free / mapping paths."""
+        pool, rsp = _make_pool(size=1)
+        self.assertEqual(pool.recurrent_free_slots, [1])
+        self.assertEqual(pool.req_index_to_recurrent_index_mapping.shape, (1,))
+
+        req = _make_req()
+        self.assertIsNotNone(pool.alloc([req]))
+        self.assertEqual(req.recurrent_pool_idx, 1)
+        self.assertEqual(pool.recurrent_free_slots, [])
+
+        # Second alloc on a drained size=1 pool must fail atomically.
+        req2 = _make_req()
+        self.assertIsNone(pool.alloc([req2]))
+        self.assertIsNone(req2.req_pool_idx)
+        self.assertIsNone(req2.recurrent_pool_idx)
+
+        pool.free(req)
+        self.assertEqual(pool.recurrent_free_slots, [1])
+
+
+class TestHybridReqToTokenPoolDP(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if len(jax.devices()) < 2:
+            raise unittest.SkipTest("DP tests need >= 2 devices")
+
+    def test_dp_capacity_decoupled_from_total_slots(self):
+        """Host-side allocator capacity is decoupled from RecurrentStatePool's
+        DP-padded total_slots. With dp_size=2 and size=3, total_slots ceils
+        to 4 for buffer divisibility; recurrent_free_slots still hands out
+        exactly 3 valid slots [1..3]. Full alloc/free roundtrip must work
+        identically to the dp_size=1 case.
+        """
+        mesh = _mesh_dp_tp(dp_size=2)
+        pool, rsp = _make_pool(size=3, mesh=mesh, dp_size=2)
+        self.assertEqual(rsp.size, 3)
+        self.assertEqual(rsp.total_slots, 4)  # ceil(3+1, 2)
+        self.assertEqual(pool.recurrent_free_slots, [1, 2, 3])
+
+        reqs = [_make_req(), _make_req(), _make_req()]
+        self.assertIsNotNone(pool.alloc(reqs))
+        self.assertEqual(pool.recurrent_free_slots, [])
+
+        pool.free(reqs[0])
+        req_new = _make_req()
+        self.assertIsNotNone(pool.alloc([req_new]))
+        self.assertEqual(pool.recurrent_free_slots, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `HybridReqToTokenPool` extending `ReqToTokenPool` to coordinate KV slot + recurrent state slot allocation atomically for hybrid linear-recurrent models (Kimi-Linear, Mamba)
- Companion to `RecurrentStatePool` (#1031): host-side allocator state lives here so the buffer pool stays a pure pytree leaf safe for JIT donate
- Add `Req.recurrent_pool_idx` field as part of the contract

## Stacking note

This is Step 2 of N for the hybrid memory pool stack (Step 1: #1031). The diff currently contains the #1031 commits as base; will rebase onto main once #1031 merges, leaving only the ~420-line Step 2 diff.

## Design

- Reuse semantics align with the parent `ReqToTokenPool.alloc(reqs)` contract: a req holding `recurrent_pool_idx` (e.g. the next chunk of a chunked prefill) keeps its slot. No sticky-flag bookkeeping needed.
- Atomic alloc: pre-check recurrent capacity, then `super().alloc`, then batch-slice the new recurrent slots with a single `clear_slot` call (avoids per-slot JIT scatter overhead).
- `free(req)` is recurrent-first / KV-second (inverse of alloc), so a partially constructed req can never end up with a freed KV slot but a still-held recurrent slot.
- Class is intentionally NOT registered as a pytree node — host-side allocator state must not enter a JIT-donated pytree (would otherwise reset on tree_unflatten).

## Test plan

- [x] Unit tests: 11 cases + 7 subTests covering fresh / reuse / atomic-on-miss / clear-on-alloc / jit-donate-cycle / dp-capacity boundaries
- [x] Base `ReqToTokenPool` tests unaffected
- [ ] Integration test after upcoming Steps land