### PR TITLE
[CI]: use /models/model_scope GCS cache for CI tests

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -80,6 +80,7 @@ jobs:
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          SGLANG_JAX_MODEL_CACHE: /models/model_scope
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -102,6 +103,7 @@ jobs:
         timeout-minutes: 30
         env:
           SGLANG_JAX_IS_IN_CI: true
+          SGLANG_JAX_MODEL_CACHE: /models/model_scope
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -127,6 +129,7 @@ jobs:
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
@@ -154,6 +157,7 @@ jobs:
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
@@ -181,6 +185,7 @@ jobs:
         timeout-minutes: 20
         env:
           SGLANG_JAX_IS_IN_CI: true
+          SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
@@ -208,6 +213,7 @@ jobs:
         timeout-minutes: 50
         env:
           SGLANG_JAX_IS_IN_CI: true
+          SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
@@ -236,6 +242,7 @@ jobs:
         timeout-minutes: 30
         env:
           SGLANG_JAX_IS_IN_CI: true
+          SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
@@ -264,6 +271,7 @@ jobs:
 
         env:
           SGLANG_JAX_IS_IN_CI: true
+          SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
@@ -291,6 +299,7 @@ jobs:
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |

--- a/python/sgl_jax/test/multimodal/test_diffusion_scheduler.py
+++ b/python/sgl_jax/test/multimodal/test_diffusion_scheduler.py
@@ -8,6 +8,7 @@ from jax.lax import Precision
 
 from sgl_jax.srt.multimodal.common.ServerArgs import MultimodalServerArgs
 from sgl_jax.srt.multimodal.manager.schedule_batch import Req
+from sgl_jax.test.test_utils import WAN2_1_T2V_1_3B
 
 
 # Small config for unit testing to avoid OOM
@@ -53,7 +54,7 @@ class TestDiffusionScheduler(unittest.TestCase):
     def setUpClass(cls):
         cls.mesh = jax.sharding.Mesh(jax.devices(), ("data",))
         cls.server_args = MultimodalServerArgs(
-            model_path="Wan-AI/Wan2.1-T2V-1.3B",
+            model_path=WAN2_1_T2V_1_3B,
             download_dir="/tmp",
         )
         # Patch WanModelConfig with small config before importing DiffusionScheduler

--- a/python/sgl_jax/test/multimodal/test_mimo_audio_tokenizer.py
+++ b/python/sgl_jax/test/multimodal/test_mimo_audio_tokenizer.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 
+from sgl_jax.test.test_utils import MIMO_AUDIO_7B_INSTRUCT
+
 
 def test_multimodal_tokenizer():
     """Test MultimodalTokenizer's _init_audio_processor and _preprocess_audio_to_mel."""
@@ -9,7 +11,7 @@ def test_multimodal_tokenizer():
 
     # Mock server_args
     server_args = MagicMock()
-    server_args.model_path = "XiaomiMiMo/MiMo-Audio-7B-Instruct"
+    server_args.model_path = MIMO_AUDIO_7B_INSTRUCT
     server_args.tokenizer_path = None
     server_args.tokenizer_mode = "auto"
     server_args.skip_tokenizer_init = True

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -46,6 +46,7 @@ def _validate_local_snapshot(d: Path) -> bool:
             for fname in ("tokenizer.json", "tokenizer.model", "tiktoken.model")
         )
         or (d / "vocab.json").is_file()
+        or any(d.glob("*.tiktoken"))
     )
     if not has_tokenizer:
         return False

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import json
 import logging
 import os
 import re
@@ -11,6 +12,7 @@ import time
 import unittest
 from collections.abc import Awaitable, Callable, Sequence
 from contextlib import nullcontext, suppress
+from pathlib import Path
 from types import SimpleNamespace
 
 import jax
@@ -28,26 +30,69 @@ from sgl_jax.srt.sampling.sampling_params import SamplingParams
 from sgl_jax.srt.server_args import ServerArgs
 from sgl_jax.srt.utils.common_utils import get_bool_env_var, retry
 
-DEFAULT_MODEL_NAME_FOR_TEST = "Qwen/Qwen3-8B"
-DEFAULT_SMALL_MODEL_NAME_FOR_TEST = "Qwen/Qwen3-1.7B"
-QWEN3_8B = "Qwen/Qwen3-8B"
-QWEN_7B = "Qwen/Qwen-7B"
+_MODEL_CACHE_ENV = "SGLANG_JAX_MODEL_CACHE"
+_LOCAL_MODEL_LOG_ONCE: set[str] = set()
 
-QWEN3_MOE_30B = "Qwen/Qwen3-30B-A3B"
-QWEN2_5_7B_INSTRUCT = "Qwen/Qwen2.5-7B-Instruct"
-QWEN3_CODER_30B_A3B_INSTRUCT = "Qwen/Qwen3-Coder-30B-A3B-Instruct"
-GEMMA2_2B_IT = "google/gemma-2-2b-it"
 
-BAILING_MOE = "inclusionAI/Ling-mini-2.0"
-DEEPSEEK_R1_DISTILL_QWEN_1_5B = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-DEEPSEEK_V2_LITE = "deepseek-ai/DeepSeek-V2-Lite"
-DEEPSEEK_CODER_V2_LITE_INSTRUCT = "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct"
+def _validate_local_snapshot(d: Path) -> bool:
+    if not (d / "config.json").is_file():
+        return False
+    index = d / "model.safetensors.index.json"
+    if index.is_file():
+        try:
+            meta = json.loads(index.read_text())
+        except Exception:
+            return False
+        shards = set(meta.get("weight_map", {}).values())
+        if not shards:
+            return False
+        return all((d / s).is_file() for s in shards)
+    weights = list(d.glob("*.safetensors")) + list(d.glob("*.bin"))
+    return len(weights) > 0
 
-QWEN3_32B = "google/gemma-2-2b-it"
-QWEN3_32B_EAGLE3 = "AngelSlim/Qwen3-32B_eagle3"
 
-WAN2_1_T2V_1_3B = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
-WAN2_1_T2V_14B = "Wan-AI/Wan2.1-T2V-14B-Diffusers"
+def _local_or_hf(repo: str) -> str:
+    cache = os.environ.get(_MODEL_CACHE_ENV)
+    if not cache:
+        return repo
+    local = Path(cache) / repo
+    if _validate_local_snapshot(local):
+        return str(local)
+    if repo not in _LOCAL_MODEL_LOG_ONCE:
+        _LOCAL_MODEL_LOG_ONCE.add(repo)
+        print(
+            f"[test_utils] cache miss for {repo} under {cache}, " f"falling back to HF download",
+            file=sys.stderr,
+            flush=True,
+        )
+    return repo
+
+
+DEFAULT_MODEL_NAME_FOR_TEST = _local_or_hf("Qwen/Qwen3-8B")
+DEFAULT_SMALL_MODEL_NAME_FOR_TEST = _local_or_hf("Qwen/Qwen3-1.7B")
+QWEN3_8B = _local_or_hf("Qwen/Qwen3-8B")
+QWEN_7B = _local_or_hf("Qwen/Qwen-7B")
+QWEN3_4B = _local_or_hf("Qwen/Qwen3-4B")
+
+QWEN3_MOE_30B = _local_or_hf("Qwen/Qwen3-30B-A3B")
+QWEN2_5_7B_INSTRUCT = _local_or_hf("Qwen/Qwen2.5-7B-Instruct")
+QWEN3_CODER_30B_A3B_INSTRUCT = _local_or_hf("Qwen/Qwen3-Coder-30B-A3B-Instruct")
+GEMMA2_2B_IT = _local_or_hf("google/gemma-2-2b-it")
+
+BAILING_MOE = _local_or_hf("inclusionAI/Ling-mini-2.0")
+DEEPSEEK_R1_DISTILL_QWEN_1_5B = _local_or_hf("deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B")
+DEEPSEEK_V2_LITE = _local_or_hf("deepseek-ai/DeepSeek-V2-Lite")
+DEEPSEEK_CODER_V2_LITE_INSTRUCT = _local_or_hf("deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct")
+
+QWEN3_32B = _local_or_hf("Qwen/Qwen3-32B")
+QWEN3_32B_EAGLE3 = _local_or_hf("AngelSlim/Qwen3-32B_eagle3")
+
+WAN2_1_T2V_1_3B = _local_or_hf("Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
+WAN2_1_T2V_14B = _local_or_hf("Wan-AI/Wan2.1-T2V-14B-Diffusers")
+
+MIMO_AUDIO_7B_INSTRUCT = _local_or_hf("XiaomiMiMo/MiMo-Audio-7B-Instruct")
+UMT5_BASE = _local_or_hf("google/umt5-base")
+QWEN3_OMNI_30B_A3B_INSTRUCT = _local_or_hf("Qwen/Qwen3-Omni-30B-A3B-Instruct")
 
 DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH = 600
 
@@ -297,8 +342,8 @@ def kill_process_tree(parent_pid, include_parent: bool = True, skip_pid: int = N
 
 def generate_server_args() -> ServerArgs:
     return ServerArgs(
-        model_path="Qwen/Qwen-7B",
-        tokenizer_path="Qwen/Qwen-7B",
+        model_path=QWEN_7B,
+        tokenizer_path=QWEN_7B,
         tokenizer_mode="auto",
         skip_tokenizer_init=False,
         load_format="auto",
@@ -349,7 +394,7 @@ def generate_server_args() -> ServerArgs:
         enable_request_time_stats_logging=False,
         kv_events_config=None,
         api_key=None,
-        served_model_name="Qwen/Qwen-7B",
+        served_model_name=QWEN_7B,
         file_storage_path="sglang_storage",
         enable_cache_report=False,
         reasoning_parser=None,

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -27,7 +27,6 @@ from sgl_jax.srt.managers.tp_worker import ModelWorker
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
 from sgl_jax.srt.model_executor.model_runner import ModelRunner
 from sgl_jax.srt.sampling.sampling_params import SamplingParams
-from sgl_jax.srt.server_args import ServerArgs
 from sgl_jax.srt.utils.common_utils import get_bool_env_var, retry
 
 _MODEL_CACHE_ENV = "SGLANG_JAX_MODEL_CACHE"
@@ -340,79 +339,6 @@ def kill_process_tree(parent_pid, include_parent: bool = True, skip_pid: int = N
             itself.send_signal(signal.SIGQUIT)
 
 
-def generate_server_args() -> ServerArgs:
-    return ServerArgs(
-        model_path=QWEN_7B,
-        tokenizer_path=QWEN_7B,
-        tokenizer_mode="auto",
-        skip_tokenizer_init=False,
-        load_format="auto",
-        model_loader_extra_config="{}",
-        trust_remote_code=True,
-        context_length=None,
-        is_embedding=False,
-        revision=None,
-        model_impl="auto",
-        host="127.0.0.1",
-        port=30000,
-        skip_server_warmup=True,
-        warmups=None,
-        dtype="bfloat16",
-        quantization=None,
-        quantization_param_path=None,
-        kv_cache_dtype="auto",
-        mem_fraction_static=0.1,
-        max_running_requests=None,
-        max_total_tokens=None,
-        max_prefill_tokens=4096,
-        schedule_policy="fcfs",
-        schedule_conservativeness=1.0,
-        page_size=1,
-        swa_full_tokens_ratio=0.8,
-        disable_hybrid_swa_memory=False,
-        device="tpu",
-        tp_size=4,
-        stream_interval=1,
-        stream_output=False,
-        random_seed=3,
-        constrained_json_whitespace_pattern=None,
-        watchdog_timeout=300,
-        dist_timeout=None,
-        download_dir="/tmp",
-        sleep_on_idle=False,
-        dp_size=1,
-        log_level="info",
-        log_level_http=None,
-        log_requests=False,
-        log_requests_level=0,
-        crash_dump_folder=None,
-        show_time_cost=False,
-        bucket_time_to_first_token=None,
-        bucket_inter_token_latency=None,
-        bucket_e2e_request_latency=None,
-        decode_log_interval=40,
-        enable_request_time_stats_logging=False,
-        kv_events_config=None,
-        api_key=None,
-        served_model_name=QWEN_7B,
-        file_storage_path="sglang_storage",
-        enable_cache_report=False,
-        reasoning_parser=None,
-        tool_call_parser=None,
-        dist_init_addr="0.0.0.0:10011",
-        nnodes=1,
-        node_rank=0,
-        json_model_override_args="{}",
-        preferred_sampling_params=None,
-        disable_radix_cache=False,
-        allow_auto_truncate=False,
-        max_seq_len=4096,
-        precompile_token_paddings=[1, 8],
-        disable_precompile=False,
-    )
-
-
-# note: add fields value as you want, decrease existing fields is forbidden
 def generate_schedule_batch(
     bs: int, num_tokens_per_req: int, mode: ForwardMode, model_runner: ModelRunner
 ) -> ScheduleBatch:

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -36,6 +36,13 @@ _LOCAL_MODEL_LOG_ONCE: set[str] = set()
 def _validate_local_snapshot(d: Path) -> bool:
     if not (d / "config.json").is_file():
         return False
+
+    has_tokenizer = (d / "tokenizer.json").is_file() or (
+        (d / "tokenizer_config.json").is_file() and (d / "vocab.json").is_file()
+    )
+    if not has_tokenizer:
+        return False
+
     index = d / "model.safetensors.index.json"
     if index.is_file():
         try:
@@ -46,8 +53,12 @@ def _validate_local_snapshot(d: Path) -> bool:
         if not shards:
             return False
         return all((d / s).is_file() for s in shards)
-    weights = list(d.glob("*.safetensors")) + list(d.glob("*.bin"))
-    return len(weights) > 0
+
+    has_single_weight_file = (d / "model.safetensors").is_file() or any(d.glob("*.bin"))
+    has_sharded_weight_file = any(d.glob("*-of-*.safetensors")) or any(d.glob("*-of-*.bin"))
+    if has_sharded_weight_file and not index.is_file():
+        return False
+    return has_single_weight_file
 
 
 def _local_or_hf(repo: str) -> str:

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -34,14 +34,33 @@ _LOCAL_MODEL_LOG_ONCE: set[str] = set()
 
 
 def _validate_local_snapshot(d: Path) -> bool:
-    if not (d / "config.json").is_file():
+    config_path = d / "config.json"
+    if not config_path.is_file():
+        return False
+    if not (d / "tokenizer_config.json").is_file():
         return False
 
-    has_tokenizer = (d / "tokenizer.json").is_file() or (
-        (d / "tokenizer_config.json").is_file() and (d / "vocab.json").is_file()
+    has_tokenizer = (
+        any(
+            (d / fname).is_file()
+            for fname in ("tokenizer.json", "tokenizer.model", "tiktoken.model")
+        )
+        or (d / "vocab.json").is_file()
     )
     if not has_tokenizer:
         return False
+
+    try:
+        config = json.loads(config_path.read_text())
+    except Exception:
+        return False
+    auto_map = config.get("auto_map", {})
+    if isinstance(auto_map, dict):
+        for value in auto_map.values():
+            if isinstance(value, str) and "." in value:
+                module_name = value.split(".")[0]
+                if not (d / f"{module_name}.py").is_file():
+                    return False
 
     index = d / "model.safetensors.index.json"
     if index.is_file():

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -34,6 +34,43 @@ _LOCAL_MODEL_LOG_ONCE: set[str] = set()
 
 
 def _validate_local_snapshot(d: Path) -> bool:
+    if not d.is_dir():
+        return False
+
+    if (d / "model_index.json").is_file():
+        try:
+            model_index = json.loads((d / "model_index.json").read_text())
+        except Exception:
+            return False
+        for component, spec in model_index.items():
+            if component.startswith("_"):
+                continue
+            if not isinstance(spec, list) or len(spec) < 2 or spec[1] is None:
+                continue
+            sub = d / component
+            if not sub.is_dir():
+                return False
+            if not any(sub.iterdir()):
+                return False
+            for index_name in (
+                "diffusion_pytorch_model.safetensors.index.json",
+                "model.safetensors.index.json",
+            ):
+                sub_index = sub / index_name
+                if sub_index.is_file():
+                    try:
+                        meta = json.loads(sub_index.read_text())
+                    except Exception:
+                        return False
+                    shards = set(meta.get("weight_map", {}).values())
+                    if shards and not all((sub / s).is_file() for s in shards):
+                        return False
+                    break
+            else:
+                if any(sub.glob("*-of-*.safetensors")) or any(sub.glob("*-of-*.bin")):
+                    return False
+        return True
+
     config_path = d / "config.json"
     if not config_path.is_file():
         return False

--- a/test/srt/lora/test_align_lora_accuracy.py
+++ b/test/srt/lora/test_align_lora_accuracy.py
@@ -6,11 +6,11 @@ import unittest
 import numpy as np
 
 from sgl_jax.srt.entrypoints.engine import Engine
-from sgl_jax.test.test_utils import CustomTestCase
+from sgl_jax.test.test_utils import QWEN3_4B, CustomTestCase
 
 LORA_SETS = [
     {
-        "base": "Qwen/Qwen3-4B",
+        "base": QWEN3_4B,
         "lora": [
             "y9760210/Qwen3-4B-lora_model",
         ],
@@ -18,7 +18,7 @@ LORA_SETS = [
 ]
 
 LORA_PATHS = ["Qwen3-4B-lora_model", None, "Qwen3-4B-lora_model"]
-BASE_MODEL = "Qwen/Qwen3-4B"
+BASE_MODEL = QWEN3_4B
 DTYPE = "float32"
 NPDTYPE = np.float32
 
@@ -35,7 +35,7 @@ THRESHOLD = 2e-3
 class TestAlignLoRAAccuracy(CustomTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.model_path = "Qwen/Qwen3-4B"
+        cls.model_path = QWEN3_4B
         cls.lora_target_modules = ["all"]
         import os
 

--- a/test/srt/lora/test_dynamic_lora.py
+++ b/test/srt/lora/test_dynamic_lora.py
@@ -29,6 +29,7 @@ from sgl_jax.srt.hf_transformers_utils import get_tokenizer
 from sgl_jax.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
+    QWEN3_4B,
     CustomTestCase,
     kill_process_tree,
     popen_launch_server,
@@ -36,7 +37,7 @@ from sgl_jax.test.test_utils import (
 
 LORA_SETS = [
     {
-        "base": "Qwen/Qwen3-4B",
+        "base": QWEN3_4B,
         "loras": [
             "nissenj/Qwen3-4B-lora-v2",
             "y9760210/Qwen3-4B-lora_model",

--- a/test/srt/lora/test_static_lora.py
+++ b/test/srt/lora/test_static_lora.py
@@ -3,7 +3,7 @@ from typing import List
 
 from sgl_jax.srt.entrypoints.engine import Engine
 from sgl_jax.srt.hf_transformers_utils import get_tokenizer
-from sgl_jax.test.test_utils import CustomTestCase
+from sgl_jax.test.test_utils import QWEN3_4B, CustomTestCase
 
 DTYPE = "bfloat16"
 
@@ -20,7 +20,7 @@ They're used to make predictions on text.
 class TestStaticLoRA(CustomTestCase):
     def test_diff_after_apply_dummy(self):
         print("=================== test_diff_after_apply_dummy =======================")
-        model_path = "Qwen/Qwen3-4B"
+        model_path = QWEN3_4B
         lora_target_modules = ["gate_proj"]
         import os
 

--- a/test/srt/multimodal/test_wan2_1_models.py
+++ b/test/srt/multimodal/test_wan2_1_models.py
@@ -19,7 +19,7 @@ headers = {"Content-Type": "application/json"}
 class TestWan2_1Model(CustomTestCase):
     def test_wan2_1_1_3b(self):
         process = popen_launch_server(
-            "/models/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/",
+            WAN2_1_T2V_1_3B,
             DEFAULT_URL_FOR_TEST,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             device="tpu",
@@ -56,7 +56,7 @@ class TestWan2_1Model(CustomTestCase):
 
     def test_wan2_1_14b(self):
         process = popen_launch_server(
-            "/models/Wan-AI/Wan2.1-T2V-14B-Diffusers/",
+            WAN2_1_T2V_14B,
             DEFAULT_URL_FOR_TEST,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             device="tpu",

--- a/test/srt/nightly-test/test_perf.py
+++ b/test/srt/nightly-test/test_perf.py
@@ -1357,7 +1357,7 @@ class TestModelPerf(CustomTestCase):
                 writer.writerows(results_summary)
 
     def test_qwen3_32B_lora_r32_performance_tp_4(self):
-        model = "Qwen/Qwen3-32B"
+        model = QWEN3_32B
         lora_path = "flyfishxu/DeepNews-LoRA-Qwen3-32B"
         lora_name = ["DeepNews-LoRA-Qwen3-32B"]
         base_url = DEFAULT_URL_FOR_TEST

--- a/test/srt/quantization/test_w8_block_dynamic_quantization.py
+++ b/test/srt/quantization/test_w8_block_dynamic_quantization.py
@@ -12,13 +12,14 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from sgl_jax.srt.utils import kill_process_tree
 from sgl_jax.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
+    QWEN3_8B,
     CustomTestCase,
     popen_launch_server,
 )
 
 
 class TestW8Int8DynamicBlockQuant(CustomTestCase):
-    model = "Qwen/Qwen3-8B"
+    model = QWEN3_8B
     quantization_config_path = "int8_block_128_dynamic.yaml"
     other_args = [
         "--tp-size=4",

--- a/test/srt/quantization/test_w8_moe_block_linear_channel_quantization.py
+++ b/test/srt/quantization/test_w8_moe_block_linear_channel_quantization.py
@@ -12,13 +12,14 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from sgl_jax.srt.utils import kill_process_tree
 from sgl_jax.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
+    QWEN3_MOE_30B,
     CustomTestCase,
     popen_launch_server,
 )
 
 
 class TestW8Int8MoeBlockLinearChannelQuant(CustomTestCase):
-    model = "Qwen/Qwen3-30B-A3B"
+    model = QWEN3_MOE_30B
     quantization_config_path = "int8_moe_block_128_linear_channel_dynamic.yaml"
     other_args = [
         "--tp-size=4",

--- a/test/srt/quantization/test_w8_quantization.py
+++ b/test/srt/quantization/test_w8_quantization.py
@@ -13,6 +13,7 @@ from sgl_jax.srt.utils import kill_process_tree
 from sgl_jax.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
+    QWEN3_32B,
     CustomTestCase,
     popen_launch_server,
 )
@@ -102,7 +103,7 @@ class BaseW8Test(CustomTestCase):
 
 
 class TestW8Int8(BaseW8Test):
-    model = "Qwen/Qwen3-32B"
+    model = QWEN3_32B
     quantization_config_path = "int8.yaml"
     gsm8k_accuracy_threshold = 0.95
     throughput_threshold = 98

--- a/test/srt/test_model_loader.py
+++ b/test/srt/test_model_loader.py
@@ -20,6 +20,7 @@ from sgl_jax.srt.configs.load_config import LoadConfig, LoadFormat
 from sgl_jax.srt.configs.model_config import ModelConfig
 from sgl_jax.srt.model_loader.loader import JAXModelLoader, get_model_loader
 from sgl_jax.srt.models.qwen import QWenLMHeadModel
+from sgl_jax.test.test_utils import QWEN_7B
 
 
 class TestModelLoader(unittest.TestCase):
@@ -177,7 +178,7 @@ class TestModelLoaderWithRealModel(unittest.TestCase):
             str: Either a local path or a HuggingFace model ID
         """
         # Check environment variable first
-        env_path = os.environ.get("TEST_MODEL_PATH", "Qwen/Qwen-7B-Chat")
+        env_path = os.environ.get("TEST_MODEL_PATH", QWEN_7B)
         if env_path:
             # If it's a local path and exists, use it
             if os.path.exists(env_path):

--- a/test/srt/test_qwen3_omni_vision_alignment.py
+++ b/test/srt/test_qwen3_omni_vision_alignment.py
@@ -24,6 +24,7 @@ from sgl_jax.srt.configs.model_config import _get_and_verify_dtype
 from sgl_jax.srt.multimodal.models.qwen3_omni_moe.qwen3_omni_thinker_embedding import (
     Qwen3OmniMoeThinkerEmbedding,
 )
+from sgl_jax.test.test_utils import QWEN3_OMNI_30B_A3B_INSTRUCT
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../python"))
 if project_root not in sys.path:
@@ -1319,7 +1320,7 @@ def main():
     parser = argparse.ArgumentParser(description="Qwen3OmniMoe Vision Encoder alignment tests")
     parser.add_argument(
         "--model_path",
-        default=os.environ.get("QWEN3_OMNI_MODEL_PATH", "/models/Qwen/Qwen3-Omni-30B-A3B-Instruct"),
+        default=os.environ.get("QWEN3_OMNI_MODEL_PATH", QWEN3_OMNI_30B_A3B_INSTRUCT),
     )
     parser.add_argument("--test_type", default="all", choices=["all"] + list(TESTS.keys()))
     parser.add_argument("--tp_size", type=int, default=4)

--- a/test/srt/test_umt5_models_alignment.py
+++ b/test/srt/test_umt5_models_alignment.py
@@ -30,6 +30,7 @@ from sgl_jax.srt.model_executor.forward_batch_info import (  # noqa: E402
 from sgl_jax.srt.models.umt5 import UMT5EncoderModel  # noqa: E402
 from sgl_jax.srt.models.umt5 import UMT5ForConditionalGeneration as UMT5Gen
 from sgl_jax.srt.models.umt5 import UMT5Model
+from sgl_jax.test.test_utils import UMT5_BASE  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -515,7 +516,7 @@ def main():
     from sgl_jax.srt.utils.mesh_utils import create_device_mesh
 
     parser = argparse.ArgumentParser(description="UMT5 alignment tests (JAX vs PyTorch)")
-    parser.add_argument("--model_path", default="google/umt5-base", help="Model path or HF name")
+    parser.add_argument("--model_path", default=UMT5_BASE, help="Model path or HF name")
     parser.add_argument(
         "--test_type", default="all", choices=["all"] + list(TESTS.keys()), help="Test type to run"
     )


### PR DESCRIPTION
## Summary

- Adds an opt-in local-model resolver `_local_or_hf` in `test_utils.py`. When `SGLANG_JAX_MODEL_CACHE` is set and `\${cache}/<repo>/` passes a config + safetensors-shard validation, model constants resolve to the absolute local path; otherwise they silently fall back to the original HF repo string. CI runners (`arc-runner-v6e-{1,4}`) point this env at `/models/model_scope`, the read-only GCS Fuse mount of `gs://inference-model-storage-sgl/model_scope/` (HNS bucket, already laid out by HF org).
- Removes hardcoded HF repo strings from 12 test files; everything goes through `test_utils` constants. Adds `QWEN3_4B`, `MIMO_AUDIO_7B_INSTRUCT`, `UMT5_BASE`, `QWEN3_OMNI_30B_A3B_INSTRUCT` constants.
- Fixes 3 latent bugs found while sweeping the call sites:
  - `QWEN3_32B` was silently aliased to `google/gemma-2-2b-it`.
  - `test_qwen3_omni_vision_alignment` defaulted to `/models/Qwen/...` (old layout, never present).
  - `test_wan2_1_models` hardcoded `/models/Wan-AI/...` paths (old layout, never present).
- All 9 jobs in `pr-test.yml` export `SGLANG_JAX_MODEL_CACHE: /models/model_scope`. No-op outside CI / when cache misses.

## Test plan

- [ ] CI green on this PR (cache hit observed in e2e/accuracy logs - no HF download for cached repos)
- [ ] Confirm cache miss fallback works for repos still being downloaded (Qwen3-4B / DSv2-Lite / Qwen3-32B / Wan2.1-T2V-1.3B / 14B)
- [ ] Local smoke: \`SGLANG_JAX_MODEL_CACHE= python -c "from sgl_jax.test.test_utils import QWEN3_8B; print(QWEN3_8B)"\` returns HF repo string