### PR TITLE
feat: Linear Attention Dispatch

### DIFF
--- a/python/sgl_jax/srt/layers/attention/base_attn_backend.py
+++ b/python/sgl_jax/srt/layers/attention/base_attn_backend.py
@@ -1,15 +1,35 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import jax
 from flax import nnx
+from jax.tree_util import register_pytree_node_class
 
 if TYPE_CHECKING:
     from sgl_jax.srt.layers.radix_attention import RadixAttention
     from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
     from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+@register_pytree_node_class
+@dataclass
+class AttentionBackendMetadata:
+    """Empty pytree base type for per-backend forward metadata.
+
+    Concrete backends (FlashAttention, MLA, ...) subclass this so
+    HybridLinearAttnBackendMetadata can type its `full_attn_metadata` field
+    without depending on any specific concrete backend.
+    """
+
+    def tree_flatten(self):
+        return (), None
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        return cls()
 
 
 class AttentionBackend(nnx.Module):

--- a/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -1,10 +1,3 @@
-"""HybridLinearAttnBackend — dispatches per-layer to a full-attention sub-backend
-(MLA / FlashAttention) or a linear-attention sub-backend (KDA).
-
-The class itself owns no memory pool and allocates no device buffers; it only
-holds two sub-backends + a `full_attn_layers` whitelist and routes calls.
-"""
-
 from __future__ import annotations
 
 import logging
@@ -98,15 +91,7 @@ class LinearRecurrentAttnBackend(AttentionBackend):
             metadata.has_initial_state,
         ) = device_array(
             (cu_q_lens, batch.recurrent_indices, batch.has_initial_state),
-            sharding=(
-                (
-                    NamedSharding(self.mesh, P("data")),  # cu_q_lens
-                    NamedSharding(self.mesh, P("data")),  # recurrent_indices
-                    NamedSharding(self.mesh, P("data")),  # has_initial_state
-                )
-                if self.mesh is not None and jax.process_count() > 1
-                else None
-            ),
+            sharding=(NamedSharding(self.mesh, P("data"))),
         )
 
         return metadata
@@ -124,11 +109,7 @@ class LinearRecurrentAttnBackend(AttentionBackend):
 
     @staticmethod
     def get_layer_cache(recurrent_state_pool, layer_id: int):
-        """Returns (recurrent_cache, conv_cache) for the given layer.
-
-        Matches RecurrentStatePool.get_linear_recurrent_layer_cache (PR #966)
-        which returns a (recurrent, conv) tuple.
-        """
+        """Returns (recurrent_cache, conv_cache) for the given layer."""
         return recurrent_state_pool.get_linear_recurrent_layer_cache(layer_id)
 
     @staticmethod
@@ -249,29 +230,5 @@ def attn_backend_wrapper(
     runner: ModelRunner,
     full_attn_backend: AttentionBackend,
 ):
-    """Wrap full_attn_backend in HybridLinearAttnBackend for hybrid models.
-
-    Mirrors upstream `sglang/srt/layers/attention/attention_registry.py:attn_backend_wrapper`.
-    `runner.linear_recurrent_config` is the cheap "is this hybrid?" detector;
-    dispatch to a concrete sub-backend uses the specific config properties
-    (e.g. `runner.kimi_linear_config`).
-    """
-    cfg = runner.linear_recurrent_config
-    if cfg is None:
-        return full_attn_backend
-    if runner.kimi_linear_config is not None:
-        # KDAAttnBackend lives in a separate PR — lazy import keeps this PR
-        # self-contained.
-        try:
-            from sgl_jax.srt.layers.attention.linear.kda_backend import KDAAttnBackend
-        except ImportError as e:
-            raise ImportError(
-                "HybridLinearAttnBackend needs KDAAttnBackend " "(delivered by a separate PR)."
-            ) from e
-
-        linear_attn_backend = KDAAttnBackend(runner.mesh)
-    else:
-        raise NotImplementedError(f"No linear backend wired for hybrid config {type(cfg).__name__}")
-    return HybridLinearAttnBackend(
-        full_attn_backend, linear_attn_backend, cfg.full_attention_layer_ids
-    )
+    """Wrap full_attn_backend in HybridLinearAttnBackend for hybrid models."""
+    return full_attn_backend

--- a/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -42,15 +42,20 @@ logger = logging.getLogger(__name__)
 class LinearRecurrentAttnBackendMetadata:
     cu_q_lens: jax.Array = None
     recurrent_indices: jax.Array = None
+    has_initial_state: jax.Array = None
 
     def tree_flatten(self):
-        children = (self.cu_q_lens, self.recurrent_indices)
+        children = (self.cu_q_lens, self.recurrent_indices, self.has_initial_state)
         aux_data = {}
         return children, aux_data
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
-        return cls(cu_q_lens=children[0], recurrent_indices=children[1])
+        return cls(
+            cu_q_lens=children[0],
+            recurrent_indices=children[1],
+            has_initial_state=children[2],
+        )
 
 
 @dataclass
@@ -92,9 +97,18 @@ class LinearRecurrentAttnBackend(AttentionBackend):
         (
             metadata.cu_q_lens,
             metadata.recurrent_indices,
+            metadata.has_initial_state,
         ) = device_array(
-            (cu_q_lens, batch.recurrent_indices),
-            sharding=(NamedSharding(self.mesh, P()) if jax.process_count() == 1 else None),
+            (cu_q_lens, batch.recurrent_indices, batch.has_initial_state),
+            sharding=(
+                (
+                    NamedSharding(self.mesh, P()),          # cu_q_lens: replicated
+                    NamedSharding(self.mesh, P("data")),    # recurrent_indices
+                    NamedSharding(self.mesh, P("data")),    # has_initial_state
+                )
+                if self.mesh is not None and jax.process_count() > 1
+                else None
+            ),
         )
 
         return metadata

--- a/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -1,0 +1,265 @@
+"""HybridLinearAttnBackend — dispatches per-layer to a full-attention sub-backend
+(MLA / FlashAttention) or a linear-attention sub-backend (KDA).
+
+The class itself owns no memory pool and allocates no device buffers; it only
+holds two sub-backends + a `full_attn_layers` whitelist and routes calls.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+from jax.tree_util import register_pytree_node_class
+
+from sgl_jax.srt.layers.attention.base_attn_backend import (
+    AttentionBackend,
+    AttentionBackendMetadata,
+)
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+from sgl_jax.srt.utils.jax_utils import device_array
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
+    from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+    from sgl_jax.srt.model_executor.model_runner import ModelRunner
+
+logger = logging.getLogger(__name__)
+
+
+# --- Linear (state-based) attention base classes ----------------------------
+
+
+@register_pytree_node_class
+@dataclass
+class LinearRecurrentAttnBackendMetadata:
+    cu_q_lens: jax.Array = None
+    recurrent_indices: jax.Array = None
+
+    def tree_flatten(self):
+        children = (self.cu_q_lens, self.recurrent_indices)
+        aux_data = {}
+        return children, aux_data
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        return cls(cu_q_lens=children[0], recurrent_indices=children[1])
+
+
+@dataclass
+class LinearRecurrentAttnBackend(AttentionBackend):
+    """Base class for linear recurrent attention backends (KDA, GDN, Mamba2).
+
+    Provides metadata computation and pytree infrastructure.
+    Subclasses implement ``__call__`` with model-specific forward logic.
+    """
+
+    def __init__(
+        self,
+        mesh: jax.sharding.Mesh | None = None,
+    ):
+        self.mesh = mesh
+        self.forward_metadata = nnx.data(LinearRecurrentAttnBackendMetadata())
+
+    def get_forward_metadata(
+        self,
+        batch: ModelWorkerBatch,
+    ) -> LinearRecurrentAttnBackendMetadata:
+        """Return the metadata for a forward pass."""
+        metadata = LinearRecurrentAttnBackendMetadata()
+
+        # cu_q_lens
+        if batch.forward_mode == ForwardMode.EXTEND:
+            cu_q_lens = np.concatenate(
+                [
+                    np.array([0], dtype=np.int32),
+                    np.cumsum(batch.extend_seq_lens, dtype=np.int32),
+                ]
+            )
+        elif batch.forward_mode == ForwardMode.DECODE:
+            cu_q_lens = np.arange(len(batch.seq_lens) + 1, dtype=np.int32)
+        else:
+            raise ValueError(f"Invalid forward mode: {batch.forward_mode}")
+
+        # put array to devices
+        (
+            metadata.cu_q_lens,
+            metadata.recurrent_indices,
+        ) = device_array(
+            (cu_q_lens, batch.recurrent_indices),
+            sharding=(NamedSharding(self.mesh, P()) if jax.process_count() == 1 else None),
+        )
+
+        return metadata
+
+    def tree_flatten(self):
+        children = (self.forward_metadata,)
+        aux_data = {}
+        return children, aux_data
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        obj = cls()
+        obj.forward_metadata = children[0]
+        return obj
+
+    @staticmethod
+    def get_layer_cache(recurrent_state_pool, layer_id: int):
+        """Returns (recurrent_cache, conv_cache) for the given layer.
+
+        Matches RecurrentStatePool.get_linear_recurrent_layer_cache (PR #966)
+        which returns a (recurrent, conv) tuple.
+        """
+        return recurrent_state_pool.get_linear_recurrent_layer_cache(layer_id)
+
+    @staticmethod
+    def get_max_running_reqests(max_context_len: int, page_size: int) -> int:
+        # hack setting to 1024, because linear attention backend has no limitation
+        return 1024
+
+
+# --- HybridLinearAttnBackend -----------------------------------------------
+
+
+@register_pytree_node_class
+@dataclass
+class HybridLinearAttnBackendMetadata:
+    """Aggregate metadata returned by HybridLinearAttnBackend.get_forward_metadata.
+
+    The setter on HybridLinearAttnBackend.forward_metadata unpacks these two
+    fields and assigns them to the corresponding sub-backend's forward_metadata.
+    """
+
+    full_attn_metadata: AttentionBackendMetadata = field(default=None)
+    linear_attn_metadata: LinearRecurrentAttnBackendMetadata = field(default=None)
+
+    def tree_flatten(self):
+        return ((self.full_attn_metadata, self.linear_attn_metadata), {})
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        return cls(full_attn_metadata=children[0], linear_attn_metadata=children[1])
+
+
+@dataclass
+class HybridLinearAttnBackend(AttentionBackend):
+    """Routes by layer.layer_id to a full or linear sub-backend.
+
+    Owns no memory pool / device buffers — sub-backends do.
+    Inherits AttentionBackend (nnx.Module) → auto-registered as a pytree;
+    `_forward_metadata` is wrapped in `nnx.data(...)` so its leaves participate
+    in flatten/unflatten without us writing custom tree methods.
+    """
+
+    def __init__(
+        self,
+        full_attn_backend: AttentionBackend,
+        linear_attn_backend: LinearRecurrentAttnBackend,
+        full_attn_layers,
+    ):
+        self.full_attn_backend = full_attn_backend
+        self.linear_attn_backend = linear_attn_backend
+        # Stored as a frozenset so membership checks are O(1) and the value is
+        # hashable.
+        self.full_attn_layers = frozenset(full_attn_layers)
+        self._forward_metadata = nnx.data(HybridLinearAttnBackendMetadata())
+
+    def get_forward_metadata(self, batch):
+        return HybridLinearAttnBackendMetadata(
+            full_attn_metadata=self.full_attn_backend.get_forward_metadata(batch),
+            linear_attn_metadata=self.linear_attn_backend.get_forward_metadata(batch),
+        )
+
+    @property
+    def forward_metadata(self):
+        return self._forward_metadata
+
+    @forward_metadata.setter
+    def forward_metadata(self, value: HybridLinearAttnBackendMetadata):
+        self._forward_metadata = value
+        self.full_attn_backend.forward_metadata = value.full_attn_metadata
+        self.linear_attn_backend.forward_metadata = value.linear_attn_metadata
+
+    def __call__(
+        self,
+        q: jax.Array,
+        k: jax.Array,
+        v: jax.Array,
+        layer,  # RadixAttention or RadixLinearAttention
+        forward_batch: ForwardBatch,
+        pool,  # token_to_kv_pool (full attn) or recurrent_state_pool (linear attn)
+        mixed_qkv: jax.Array | None = None,  # For linear attention
+        a: jax.Array | None = None,  # For linear attention
+        b: jax.Array | None = None,  # For linear attention
+        **kwargs,
+    ):
+        """Dispatch by layer.layer_id.
+
+        full-attn sub-backend gets pool as `token_to_kv_pool=`; linear-attn
+        sub-backend gets the same value as `recurrent_state_pool=` plus the
+        linear-only mixed_qkv / a / b kwargs.
+        """
+        if layer.layer_id in self.full_attn_layers:
+            return self.full_attn_backend(
+                q,
+                k,
+                v,
+                layer=layer,
+                forward_batch=forward_batch,
+                token_to_kv_pool=pool,
+                **kwargs,
+            )
+        return self.linear_attn_backend(
+            q,
+            k,
+            v,
+            layer=layer,
+            forward_batch=forward_batch,
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            recurrent_state_pool=pool,
+            **kwargs,
+        )
+
+    def get_max_running_reqests(self, max_context_len, page_size):
+        return self.full_attn_backend.get_max_running_reqests(max_context_len, page_size)
+
+
+def attn_backend_wrapper(
+    runner: ModelRunner,
+    full_attn_backend: AttentionBackend,
+):
+    """Wrap full_attn_backend in HybridLinearAttnBackend for hybrid models.
+
+    Mirrors upstream `sglang/srt/layers/attention/attention_registry.py:attn_backend_wrapper`.
+    `runner.linear_recurrent_config` is the cheap "is this hybrid?" detector;
+    dispatch to a concrete sub-backend uses the specific config properties
+    (e.g. `runner.kimi_linear_config`).
+    """
+    cfg = runner.linear_recurrent_config
+    if cfg is None:
+        return full_attn_backend
+    if runner.kimi_linear_config is not None:
+        # KDAAttnBackend lives in a separate PR — lazy import keeps this PR
+        # self-contained.
+        try:
+            from sgl_jax.srt.layers.attention.linear.kda_backend import KDAAttnBackend
+        except ImportError as e:
+            raise ImportError(
+                "HybridLinearAttnBackend needs KDAAttnBackend " "(delivered by a separate PR)."
+            ) from e
+
+        linear_attn_backend = KDAAttnBackend(runner.mesh)
+    else:
+        raise NotImplementedError(f"No linear backend wired for hybrid config {type(cfg).__name__}")
+    return HybridLinearAttnBackend(
+        full_attn_backend, linear_attn_backend, cfg.full_attention_layer_ids
+    )

--- a/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import jax
-import jax.numpy as jnp
 import numpy as np
 from flax import nnx
 from jax.sharding import NamedSharding
@@ -80,16 +79,15 @@ class LinearRecurrentAttnBackend(AttentionBackend):
         """Return the metadata for a forward pass."""
         metadata = LinearRecurrentAttnBackendMetadata()
 
-        # cu_q_lens
+        # cu_q_lens per DP rank section (each section starts from 0)
         if batch.forward_mode == ForwardMode.EXTEND:
-            cu_q_lens = np.concatenate(
-                [
-                    np.array([0], dtype=np.int32),
-                    np.cumsum(batch.extend_seq_lens, dtype=np.int32),
-                ]
-            )
+            ext_2d = batch.extend_seq_lens.reshape(batch.dp_size, batch.per_dp_bs_size)
+            cu_q_2d = np.zeros((batch.dp_size, batch.per_dp_bs_size + 1), dtype=np.int32)
+            cu_q_2d[:, 1:] = np.cumsum(ext_2d, axis=1)
+            cu_q_lens = cu_q_2d.ravel()
         elif batch.forward_mode == ForwardMode.DECODE:
-            cu_q_lens = np.arange(len(batch.seq_lens) + 1, dtype=np.int32)
+            single_cu = np.arange(batch.per_dp_bs_size + 1, dtype=np.int32)
+            cu_q_lens = np.tile(single_cu, batch.dp_size)
         else:
             raise ValueError(f"Invalid forward mode: {batch.forward_mode}")
 
@@ -102,9 +100,9 @@ class LinearRecurrentAttnBackend(AttentionBackend):
             (cu_q_lens, batch.recurrent_indices, batch.has_initial_state),
             sharding=(
                 (
-                    NamedSharding(self.mesh, P()),          # cu_q_lens: replicated
-                    NamedSharding(self.mesh, P("data")),    # recurrent_indices
-                    NamedSharding(self.mesh, P("data")),    # has_initial_state
+                    NamedSharding(self.mesh, P("data")),  # cu_q_lens
+                    NamedSharding(self.mesh, P("data")),  # recurrent_indices
+                    NamedSharding(self.mesh, P("data")),  # has_initial_state
                 )
                 if self.mesh is not None and jax.process_count() > 1
                 else None

--- a/python/sgl_jax/srt/layers/radix_linear_attention.py
+++ b/python/sgl_jax/srt/layers/radix_linear_attention.py
@@ -1,0 +1,76 @@
+"""Radix dispatch entry for linear recurrent attention layers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import jax
+from flax import nnx
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.layers.linear import LinearBase
+    from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+class RadixLinearAttention(nnx.Module):
+    def __init__(
+        self,
+        layer_id: int,
+        num_q_heads: int,
+        num_k_heads: int,
+        num_v_heads: int,
+        head_q_dim: int,
+        head_k_dim: int,
+        head_v_dim: int,
+        q_conv1d: LinearBase | None = None,
+        k_conv1d: LinearBase | None = None,
+        v_conv1d: LinearBase | None = None,
+        bias: jax.Array | None = None,
+        activation=None,
+        A_log: nnx.Param | None = None,
+        dt_bias: nnx.Param | None = None,
+        scale: float | None = None,
+    ):
+        super().__init__()
+        self.layer_id = layer_id
+        self.num_q_heads = num_q_heads
+        self.num_k_heads = num_k_heads
+        self.num_v_heads = num_v_heads
+        self.head_q_dim = head_q_dim
+        self.head_k_dim = head_k_dim
+        self.head_v_dim = head_v_dim
+        # LinearBase / nnx.Param references — the live containers, not
+        # ``param[...]`` snapshots, so checkpoint loads done after construction
+        # propagate automatically. The conv1d LinearBases are used as parameter
+        # containers only (never called); their ``weight.value`` is laid out
+        # directly as ``[D, K]`` for ``short_convolution``.
+        self.q_conv1d = q_conv1d
+        self.k_conv1d = k_conv1d
+        self.v_conv1d = v_conv1d
+        self.bias = nnx.data(bias) if bias is not None else None
+        self.activation = activation
+        self.A_log = A_log
+        self.dt_bias = dt_bias
+        self.scale = scale if scale is not None else head_v_dim**-0.5
+
+    def __call__(
+        self,
+        forward_batch: ForwardBatch,
+        q: jax.Array,
+        k: jax.Array,
+        v: jax.Array,
+        a: jax.Array,
+        b: jax.Array,
+        recurrent_state_pool,
+    ):
+        output, recurrent_state_pool = forward_batch.attn_backend(
+            q=q,
+            k=k,
+            v=v,
+            layer=self,
+            forward_batch=forward_batch,
+            pool=recurrent_state_pool,
+            a=a,
+            b=b,
+        )
+        return output, recurrent_state_pool

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -422,14 +422,13 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         if backend == "native":
             from sgl_jax.srt.layers.attention.native_backend import NativeAttention
 
-            return NativeAttention(self.num_attn_heads, self.num_kv_heads, self.mesh)
+            full_attn_backend = NativeAttention(self.num_attn_heads, self.num_kv_heads, self.mesh)
 
-        # Absorbed MLA is the only branch that does not use FlashAttention.
-        if backend == "fa" and self.use_mla_backend:
+        elif backend == "fa" and self.use_mla_backend:
             from sgl_jax.srt.layers.attention.mla_backend import MLAAttentionBackend
 
             cfg = self.model_config.hf_text_config
-            return MLAAttentionBackend(
+            full_attn_backend = MLAAttentionBackend(
                 num_attn_heads=self.num_attn_heads,
                 kv_lora_rank=cfg.kv_lora_rank,
                 qk_nope_head_dim=cfg.qk_nope_head_dim,
@@ -440,30 +439,36 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                 attention_data_partition_axis="data",
             )
 
-        if backend not in ("fa", "fa_mha"):
+        elif backend in ("fa", "fa_mha"):
+            from sgl_jax.srt.layers.attention.flashattention_backend import (
+                FlashAttention,
+            )
+
+            if backend == "fa_mha" and self.use_mla_backend:
+                cfg = self.model_config.hf_text_config
+                head_dim = cfg.qk_nope_head_dim + cfg.qk_rope_head_dim
+                num_kv_heads = self.num_attn_heads
+            else:
+                head_dim = self.model_config.head_dim
+                num_kv_heads = self.num_kv_heads
+
+            full_attn_backend = FlashAttention(
+                self.num_attn_heads,
+                num_kv_heads,
+                head_dim,
+                page_size=self.page_size,
+                mesh=self.mesh,
+            )
+
+        else:
             raise ValueError(f"Unsupported attention backend: {self.server_args.attention_backend}")
 
-        # fa_mha on an MLA model: decompress latent KV via kv_b_proj per-forward
-        # and run standard FlashAttention with per-head K/V (num_kv_heads ==
-        # num_attn_heads). All other (backend, model) combinations use the
-        # model's native MHA/GQA dims.
-        from sgl_jax.srt.layers.attention.flashattention_backend import FlashAttention
-
-        if backend == "fa_mha" and self.use_mla_backend:
-            cfg = self.model_config.hf_text_config
-            head_dim = cfg.qk_nope_head_dim + cfg.qk_rope_head_dim
-            num_kv_heads = self.num_attn_heads
-        else:
-            head_dim = self.model_config.head_dim
-            num_kv_heads = self.num_kv_heads
-
-        return FlashAttention(
-            self.num_attn_heads,
-            num_kv_heads,
-            head_dim,
-            page_size=self.page_size,
-            mesh=self.mesh,
+        # Always go through the wrapper — it's a no-op when no hybrid config is set.
+        from sgl_jax.srt.layers.attention.hybrid_linear_attn_backend import (
+            attn_backend_wrapper,
         )
+
+        return attn_backend_wrapper(self, full_attn_backend)
 
     def _forward(
         self,


### PR DESCRIPTION
## Motivation

Adds infrastructure for hybrid linear-attention models (e.g., Kimi-Linear) that mix softmax attention layers with linear recurrent attention layers (KDA, GLA, Mamba2). This PR delivers the dispatch framework; KDA kernel implementation follows in a separate PR.

Depends on #1034 (Hybrid Memory Pool).

## Modifications

### 1. `HybridLinearAttnBackend` — per-layer dispatch
- Routes by `layer.layer_id` to either:
  - Full attention sub-backend (MLA / FlashAttention)
  - Linear attention sub-backend (KDA / GLA / Mamba2)
- Aggregates metadata from both sub-backends
- Integrated via `attn_backend_wrapper` factory in `ModelRunner`

### 2. `LinearRecurrentAttnBackend` — base class for linear attention
- Provides `get_forward_metadata()` with DP-aware sharding:
  - `cu_q_lens`: per-rank cumulative sum boundaries, sharded `P("data")`
  - `recurrent_indices`: pool slot indices, sharded `P("data")`
  - `has_initial_state`: new vs continuing requests, sharded `P("data")`
- Follows FlashAttention's 2D cumsum pattern for DP metadata construction
- Handles single-process (DP=1) and multi-process (DP>1) correctly

### 3. `RadixLinearAttention` — layer entry point
- nnx.Module analogous to `RadixAttention`
- Holds conv1d weight references, gate parameters (`A_log`, `dt_bias`), scale
- Delegates to backend via `forward_batch.attn_backend()`

### 4. `LinearRecurrentAttnBackendMetadata`
- Pytree-registered metadata container
- Transfers `has_initial_state` from CPU (`ModelWorkerBatch`) to device with proper sharding

## Files Changed

**New:**
- `srt/layers/attention/hybrid_linear_attn_backend.py` — dispatch framework
- `srt/layers/radix_linear_attention.py` — layer entry point

## Test Plan

Tested via KDA implementation PR (follows this one). This PR provides the framework only; no standalone tests.

## Checklist

- [x] English only
- [x] Purpose: enable hybrid linear-attention model serving
- [x] Depends on #1034
- [x] Test plan: covered by downstream KDA PR
