### PR TITLE
feat(mem_cache): add HybridLinearKVPool for hybrid linear-recurrent models

### DIFF
--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -1222,6 +1222,132 @@ class MLATokenToKVPool(KVCache):
 
 
 @register_pytree_node_class
+class HybridLinearKVPool(KVCache):
+    """KV cache wrapper for hybrid linear-recurrent models (e.g. Kimi-Linear).
+
+    Composition + global->physical id translation. Owns ONE inner KV pool
+    sized to len(full_attention_layer_ids); KDA / linear-recurrent layers do
+    not allocate KV slots here (they live in RecurrentStatePool).
+
+    Translates GLOBAL layer_id -> inner-pool physical index in every
+    accessor, so attention backends and models stay global-`layer_id`-aware.
+    """
+
+    def __init__(
+        self,
+        size: int,
+        page_size: int,
+        dtype: jnp.dtype,
+        full_attention_layer_ids: list[int],
+        mesh: Mesh,
+        token_to_kv_pool_class: type[KVCache] = MHATokenToKVPool,
+        **kvcache_kwargs,
+    ):
+        self.mesh = mesh
+        self.full_attention_layer_ids = list(full_attention_layer_ids)
+        self.full_layer_nums = len(self.full_attention_layer_ids)
+
+        self.full_kv_pool = token_to_kv_pool_class(
+            size=size,
+            page_size=page_size,
+            dtype=dtype,
+            layer_num=self.full_layer_nums,
+            mesh=mesh,
+            **kvcache_kwargs,
+        )
+
+        self.full_attention_layer_id_mapping: dict[int, int] = {
+            global_id: i for i, global_id in enumerate(self.full_attention_layer_ids)
+        }
+        self.mem_usage = self.full_kv_pool.mem_usage
+
+    # ---- accessors (translate then delegate) -------------------------------
+
+    def _to_physical(self, layer_id: int) -> int:
+        if layer_id not in self.full_attention_layer_id_mapping:
+            raise ValueError(
+                f"layer_id {layer_id} is not a full-attention layer "
+                f"(KDA/linear-recurrent layers do not use the KV pool); "
+                f"full_attention_layer_ids={self.full_attention_layer_ids}"
+            )
+        return self.full_attention_layer_id_mapping[layer_id]
+
+    def get_fused_kv_buffer(self, layer_id: int) -> jax.Array:
+        return self.full_kv_pool.get_fused_kv_buffer(self._to_physical(layer_id))
+
+    def get_kv_buffer(self, layer_id: int):
+        return self.full_kv_pool.get_kv_buffer(self._to_physical(layer_id))
+
+    def set_kv_buffer(
+        self,
+        layer_id: int,
+        loc: jax.Array,
+        cache_k: jax.Array,
+        cache_v: jax.Array = None,
+        is_decode: bool = False,
+    ) -> None:
+        self.full_kv_pool.set_kv_buffer(
+            self._to_physical(layer_id), loc, cache_k, cache_v, is_decode
+        )
+
+    def replace_buffer(self, kv_buffer: list[jax.Array]) -> None:
+        """Accept COMPACTED list (length L_full, in full_attention_layer_ids order).
+
+        Differs from SWAKVPool.replace_buffer which expects full-length input —
+        KDA layers don't write KV pool, so the model emits a compacted list.
+        """
+        if len(kv_buffer) != self.full_layer_nums:
+            raise ValueError(
+                f"HybridLinearKVPool.replace_buffer expects compacted list of "
+                f"length {self.full_layer_nums} "
+                f"(= len(full_attention_layer_ids)={self.full_attention_layer_ids}), "
+                f"got {len(kv_buffer)}"
+            )
+        self.full_kv_pool.replace_buffer(kv_buffer)
+
+    # ---- delegated bulk ops ------------------------------------------------
+
+    def get_kv_size_bytes(self):
+        return self.full_kv_pool.get_kv_size_bytes()
+
+    def get_cpu_copy(self, indices):
+        return self.full_kv_pool.get_cpu_copy(indices)
+
+    def load_cpu_copy(self, kv_cache_host, indices):
+        return self.full_kv_pool.load_cpu_copy(kv_cache_host, indices)
+
+    def clear_cache(self, indices: jax.Array):
+        return self.full_kv_pool.clear_cache(indices)
+
+    # full_kv_pool MUST be a pytree child (not aux_data): MemoryPools'
+    # donate_argnames=["memory_pools"] needs the inner KV buffers as leaves.
+
+    def tree_flatten(self):
+        children = (self.full_kv_pool,)
+        aux_data = {
+            "mesh": self.mesh,
+            "mem_usage": self.mem_usage,
+            "full_attention_layer_ids": tuple(self.full_attention_layer_ids),
+            "full_layer_nums": self.full_layer_nums,
+            "full_attention_layer_id_mapping": tuple(
+                sorted(self.full_attention_layer_id_mapping.items())
+            ),
+        }
+        return (children, aux_data)
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        obj = object.__new__(cls)
+        obj.mesh = aux_data["mesh"]
+        obj.mem_usage = aux_data["mem_usage"]
+        obj.full_attention_layer_ids = list(aux_data["full_attention_layer_ids"])
+        obj.full_layer_nums = aux_data["full_layer_nums"]
+        obj.full_attention_layer_id_mapping = dict(aux_data["full_attention_layer_id_mapping"])
+        obj.full_kv_pool = children[0]
+        return obj
+
+
+@register_pytree_node_class
 class MemoryPools:
     """Pytree container that uniformly manages multiple pool replace operations."""
 

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -1262,11 +1262,7 @@ class HybridLinearKVPool(KVCache):
         self._sync_inner_pool_attrs()
 
     def _sync_inner_pool_attrs(self) -> None:
-        """Sync public KVCache attributes from inner pool.
-
-        Called in __init__ and tree_unflatten to ensure HybridLinearKVPool
-        exposes the same interface as other KVCache implementations.
-        """
+        """Sync public attributes from inner pool for interface compatibility."""
         self.size = self.full_kv_pool.size
         self.page_size = self.full_kv_pool.page_size
         self.dtype = self.full_kv_pool.dtype
@@ -1275,7 +1271,7 @@ class HybridLinearKVPool(KVCache):
         self.start_layer = self.full_kv_pool.start_layer
         self.end_layer = self.full_kv_pool.end_layer
         self.mem_usage = self.full_kv_pool.mem_usage
-        self.kv_sharding = getattr(self.full_kv_pool, "kv_sharding", None)
+        self.kv_sharding = self.full_kv_pool.kv_sharding
 
     def _to_physical(self, layer_id: int) -> int:
         if layer_id not in self.full_attention_layer_id_mapping:

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -1259,7 +1259,23 @@ class HybridLinearKVPool(KVCache):
         self.full_attention_layer_id_mapping: dict[int, int] = {
             global_id: i for i, global_id in enumerate(self.full_attention_layer_ids)
         }
+        self._sync_inner_pool_attrs()
+
+    def _sync_inner_pool_attrs(self) -> None:
+        """Sync public KVCache attributes from inner pool.
+
+        Called in __init__ and tree_unflatten to ensure HybridLinearKVPool
+        exposes the same interface as other KVCache implementations.
+        """
+        self.size = self.full_kv_pool.size
+        self.page_size = self.full_kv_pool.page_size
+        self.dtype = self.full_kv_pool.dtype
+        self.layer_num = self.full_kv_pool.layer_num
+        self.mesh = self.full_kv_pool.mesh
+        self.start_layer = self.full_kv_pool.start_layer
+        self.end_layer = self.full_kv_pool.end_layer
         self.mem_usage = self.full_kv_pool.mem_usage
+        self.kv_sharding = getattr(self.full_kv_pool, "kv_sharding", None)
 
     def _to_physical(self, layer_id: int) -> int:
         if layer_id not in self.full_attention_layer_id_mapping:
@@ -1321,25 +1337,20 @@ class HybridLinearKVPool(KVCache):
     def tree_flatten(self):
         children = (self.full_kv_pool,)
         aux_data = {
-            "mesh": self.mesh,
-            "mem_usage": self.mem_usage,
             "full_attention_layer_ids": tuple(self.full_attention_layer_ids),
-            "full_layer_nums": self.full_layer_nums,
-            "full_attention_layer_id_mapping": tuple(
-                sorted(self.full_attention_layer_id_mapping.items())
-            ),
         }
         return (children, aux_data)
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
         obj = object.__new__(cls)
-        obj.mesh = aux_data["mesh"]
-        obj.mem_usage = aux_data["mem_usage"]
         obj.full_attention_layer_ids = list(aux_data["full_attention_layer_ids"])
-        obj.full_layer_nums = aux_data["full_layer_nums"]
-        obj.full_attention_layer_id_mapping = dict(aux_data["full_attention_layer_id_mapping"])
+        obj.full_layer_nums = len(obj.full_attention_layer_ids)
+        obj.full_attention_layer_id_mapping = {
+            global_id: i for i, global_id in enumerate(obj.full_attention_layer_ids)
+        }
         obj.full_kv_pool = children[0]
+        obj._sync_inner_pool_attrs()
         return obj
 
 

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -1333,18 +1333,24 @@ class HybridLinearKVPool(KVCache):
     def tree_flatten(self):
         children = (self.full_kv_pool,)
         aux_data = {
+            "mesh": self.mesh,
+            "mem_usage": self.mem_usage,
             "full_attention_layer_ids": tuple(self.full_attention_layer_ids),
+            "full_layer_nums": self.full_layer_nums,
+            "full_attention_layer_id_mapping": tuple(
+                sorted(self.full_attention_layer_id_mapping.items())
+            ),
         }
         return (children, aux_data)
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
         obj = object.__new__(cls)
+        obj.mesh = aux_data["mesh"]
+        obj.mem_usage = aux_data["mem_usage"]
         obj.full_attention_layer_ids = list(aux_data["full_attention_layer_ids"])
-        obj.full_layer_nums = len(obj.full_attention_layer_ids)
-        obj.full_attention_layer_id_mapping = {
-            global_id: i for i, global_id in enumerate(obj.full_attention_layer_ids)
-        }
+        obj.full_layer_nums = aux_data["full_layer_nums"]
+        obj.full_attention_layer_id_mapping = dict(aux_data["full_attention_layer_id_mapping"])
         obj.full_kv_pool = children[0]
         obj._sync_inner_pool_attrs()
         return obj

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -1261,8 +1261,6 @@ class HybridLinearKVPool(KVCache):
         }
         self.mem_usage = self.full_kv_pool.mem_usage
 
-    # ---- accessors (translate then delegate) -------------------------------
-
     def _to_physical(self, layer_id: int) -> int:
         if layer_id not in self.full_attention_layer_id_mapping:
             raise ValueError(
@@ -1304,8 +1302,6 @@ class HybridLinearKVPool(KVCache):
                 f"got {len(kv_buffer)}"
             )
         self.full_kv_pool.replace_buffer(kv_buffer)
-
-    # ---- delegated bulk ops ------------------------------------------------
 
     def get_kv_size_bytes(self):
         return self.full_kv_pool.get_kv_size_bytes()

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -373,6 +373,7 @@ class ModelRunnerKVCacheMixin:
             TokenToKVPoolAllocator,
         )
         from sgl_jax.srt.mem_cache.memory_pool import (
+            HybridLinearKVPool,
             MHATokenToKVPool,
             ReqToTokenPool,
             SWAKVPool,
@@ -423,29 +424,62 @@ class ModelRunnerKVCacheMixin:
                     "model config; got "
                     f"kv_lora_rank={kv_lora_rank}, qk_rope_head_dim={qk_rope_head_dim}."
                 )
-            self.token_to_kv_pool = MLATokenToKVPool(
-                size=self.max_total_num_tokens,
-                page_size=self.page_size,
-                dtype=self.kv_cache_dtype,
-                kv_lora_rank=kv_lora_rank,
-                qk_rope_head_dim=qk_rope_head_dim,
-                layer_num=self._kv_pool_layer_count(),
-                mesh=self.mesh,
-                dp_size=dp_size,
-            )
+
+            if has_recurrent_state:
+                # Hybrid recurrent: wrap to allocate only L_full KV slots
+                recurrent_cfg = self.linear_recurrent_config
+                self.token_to_kv_pool = HybridLinearKVPool(
+                    size=self.max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    full_attention_layer_ids=recurrent_cfg.full_attention_layer_ids,
+                    mesh=self.mesh,
+                    token_to_kv_pool_class=MLATokenToKVPool,
+                    kv_lora_rank=kv_lora_rank,
+                    qk_rope_head_dim=qk_rope_head_dim,
+                    dp_size=dp_size,
+                )
+            else:
+                self.token_to_kv_pool = MLATokenToKVPool(
+                    size=self.max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    kv_lora_rank=kv_lora_rank,
+                    qk_rope_head_dim=qk_rope_head_dim,
+                    layer_num=self._kv_pool_layer_count(),
+                    mesh=self.mesh,
+                    dp_size=dp_size,
+                )
         else:
-            self.token_to_kv_pool = MHATokenToKVPool(
-                size=self.max_total_num_tokens,
-                page_size=self.page_size,
-                dtype=self.kv_cache_dtype,
-                head_num=self.model_config.get_total_num_kv_heads_with_replication(
-                    self.attention_tp_size
-                ),
-                head_dim=(self.model_config.head_dim + 127) // 128 * 128,
-                layer_num=self._kv_pool_layer_count(),
-                mesh=self.mesh,
-                dp_size=dp_size,
-            )
+            if has_recurrent_state:
+                # Hybrid recurrent: wrap to allocate only L_full KV slots
+                recurrent_cfg = self.linear_recurrent_config
+                self.token_to_kv_pool = HybridLinearKVPool(
+                    size=self.max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    full_attention_layer_ids=recurrent_cfg.full_attention_layer_ids,
+                    mesh=self.mesh,
+                    token_to_kv_pool_class=MHATokenToKVPool,
+                    head_num=self.model_config.get_total_num_kv_heads_with_replication(
+                        self.attention_tp_size
+                    ),
+                    head_dim=(self.model_config.head_dim + 127) // 128 * 128,
+                    dp_size=dp_size,
+                )
+            else:
+                self.token_to_kv_pool = MHATokenToKVPool(
+                    size=self.max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    head_num=self.model_config.get_total_num_kv_heads_with_replication(
+                        self.attention_tp_size
+                    ),
+                    head_dim=(self.model_config.head_dim + 127) // 128 * 128,
+                    layer_num=self._kv_pool_layer_count(),
+                    mesh=self.mesh,
+                    dp_size=dp_size,
+                )
 
         # --- MemoryPools wrapper (+ hybrid ReqToTokenPool) ---
         if has_recurrent_state:

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -365,6 +365,42 @@ class ModelRunnerKVCacheMixin:
 
         return max_num_reqs
 
+    def _maybe_wrap_hybrid_kv_pool(
+        self: ModelRunner,
+        token_to_kv_pool_class: type,
+        **kvcache_kwargs,
+    ):
+        """Wrap KV pool with HybridLinearKVPool if has_recurrent_state.
+
+        Args:
+            token_to_kv_pool_class: The inner KV pool class (MHATokenToKVPool or MLATokenToKVPool)
+            **kvcache_kwargs: Additional kwargs for the inner pool (e.g., kv_lora_rank, head_num)
+
+        Returns:
+            HybridLinearKVPool if linear_recurrent_config is set, otherwise the inner pool directly.
+        """
+        if self.linear_recurrent_config is not None:
+            from sgl_jax.srt.mem_cache.memory_pool import HybridLinearKVPool
+
+            return HybridLinearKVPool(
+                size=self.max_total_num_tokens,
+                page_size=self.page_size,
+                dtype=self.kv_cache_dtype,
+                full_attention_layer_ids=self.linear_recurrent_config.full_attention_layer_ids,
+                mesh=self.mesh,
+                token_to_kv_pool_class=token_to_kv_pool_class,
+                **kvcache_kwargs,
+            )
+
+        return token_to_kv_pool_class(
+            size=self.max_total_num_tokens,
+            page_size=self.page_size,
+            dtype=self.kv_cache_dtype,
+            layer_num=self._kv_pool_layer_count(),
+            mesh=self.mesh,
+            **kvcache_kwargs,
+        )
+
     def _init_pools(self: ModelRunner, max_num_reqs: int, dp_size: int):
         """Create ReqToTokenPool, KV pool, allocator, and MemoryPools."""
         from sgl_jax.srt.mem_cache.allocator import (
@@ -373,7 +409,6 @@ class ModelRunnerKVCacheMixin:
             TokenToKVPoolAllocator,
         )
         from sgl_jax.srt.mem_cache.memory_pool import (
-            HybridLinearKVPool,
             MHATokenToKVPool,
             ReqToTokenPool,
             SWAKVPool,
@@ -425,61 +460,21 @@ class ModelRunnerKVCacheMixin:
                     f"kv_lora_rank={kv_lora_rank}, qk_rope_head_dim={qk_rope_head_dim}."
                 )
 
-            if has_recurrent_state:
-                # Hybrid recurrent: wrap to allocate only L_full KV slots
-                recurrent_cfg = self.linear_recurrent_config
-                self.token_to_kv_pool = HybridLinearKVPool(
-                    size=self.max_total_num_tokens,
-                    page_size=self.page_size,
-                    dtype=self.kv_cache_dtype,
-                    full_attention_layer_ids=recurrent_cfg.full_attention_layer_ids,
-                    mesh=self.mesh,
-                    token_to_kv_pool_class=MLATokenToKVPool,
-                    kv_lora_rank=kv_lora_rank,
-                    qk_rope_head_dim=qk_rope_head_dim,
-                    dp_size=dp_size,
-                )
-            else:
-                self.token_to_kv_pool = MLATokenToKVPool(
-                    size=self.max_total_num_tokens,
-                    page_size=self.page_size,
-                    dtype=self.kv_cache_dtype,
-                    kv_lora_rank=kv_lora_rank,
-                    qk_rope_head_dim=qk_rope_head_dim,
-                    layer_num=self._kv_pool_layer_count(),
-                    mesh=self.mesh,
-                    dp_size=dp_size,
-                )
+            self.token_to_kv_pool = self._maybe_wrap_hybrid_kv_pool(
+                MLATokenToKVPool,
+                kv_lora_rank=kv_lora_rank,
+                qk_rope_head_dim=qk_rope_head_dim,
+                dp_size=dp_size,
+            )
         else:
-            if has_recurrent_state:
-                # Hybrid recurrent: wrap to allocate only L_full KV slots
-                recurrent_cfg = self.linear_recurrent_config
-                self.token_to_kv_pool = HybridLinearKVPool(
-                    size=self.max_total_num_tokens,
-                    page_size=self.page_size,
-                    dtype=self.kv_cache_dtype,
-                    full_attention_layer_ids=recurrent_cfg.full_attention_layer_ids,
-                    mesh=self.mesh,
-                    token_to_kv_pool_class=MHATokenToKVPool,
-                    head_num=self.model_config.get_total_num_kv_heads_with_replication(
-                        self.attention_tp_size
-                    ),
-                    head_dim=(self.model_config.head_dim + 127) // 128 * 128,
-                    dp_size=dp_size,
-                )
-            else:
-                self.token_to_kv_pool = MHATokenToKVPool(
-                    size=self.max_total_num_tokens,
-                    page_size=self.page_size,
-                    dtype=self.kv_cache_dtype,
-                    head_num=self.model_config.get_total_num_kv_heads_with_replication(
-                        self.attention_tp_size
-                    ),
-                    head_dim=(self.model_config.head_dim + 127) // 128 * 128,
-                    layer_num=self._kv_pool_layer_count(),
-                    mesh=self.mesh,
-                    dp_size=dp_size,
-                )
+            self.token_to_kv_pool = self._maybe_wrap_hybrid_kv_pool(
+                MHATokenToKVPool,
+                head_num=self.model_config.get_total_num_kv_heads_with_replication(
+                    self.attention_tp_size
+                ),
+                head_dim=(self.model_config.head_dim + 127) // 128 * 128,
+                dp_size=dp_size,
+            )
 
         # --- MemoryPools wrapper (+ hybrid ReqToTokenPool) ---
         if has_recurrent_state:


### PR DESCRIPTION
## Motivation

PR #1034 (Hybrid Memory Pool) merged successfully but was missing **HybridLinearKVPool** from PR #985. This class is essential for hybrid linear-recurrent models (e.g., Kimi-Linear) that mix full-attention layers (MLA/MHA) with linear-recurrent layers (KDA/GLA).

**Problem**: Current architecture assumes all layers use KV cache, causing unnecessary KV slot allocation for linear layers that only need recurrent state.

## Modifications

### 1. HybridLinearKVPool class (`memory_pool.py`)
- Wraps inner KV pool sized to `len(full_attention_layer_ids)` only
- Translates global layer_id → physical index in all accessors
- Accepts **compacted buffer lists** (only full-attention layer outputs)
- Raises clear errors when linear layers try to access KV pool
- Registered as pytree with `full_kv_pool` as children (not aux_data)

### 2. Integration (`model_runner_kv_cache_mixin.py`)
- Import `HybridLinearKVPool`
- Wrap MLA pool when `has_recurrent_state=True`
- Wrap MHA pool when `has_recurrent_state=True`

## Design Decisions

1. **Backward compatible**: Non-hybrid models unaffected
2. **Compacted semantics**: `replace_buffer()` expects length = `len(full_attention_layer_ids)`
3. **Pytree compatible**: `full_kv_pool` as children ensures JAX donate works
4. **Clear errors**: Helpful error messages for debugging

## Files Changed

- `python/sgl_jax/srt/mem_cache/memory_pool.py` (+124 lines)
- `python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py` (+58/-22 lines)

## Checklist

- [x] Code follows project style (pre-commit hooks passed)
- [x] Backward compatible
- [x] Completes missing piece from PR #1034