### PR TITLE
feat(tokenizer): add fastokens backend

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -50,6 +50,9 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
 ]
+fastokens = [
+    "fastokens>=0.1.1,<0.2.0",
+]
 tpu = [
     "jax[tpu]==0.8.1",
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -64,6 +64,7 @@ cpu = [
 ]
 all = [
     "jax[tpu]==0.8.1",
+    "fastokens>=0.1.1,<0.2.0",
 ]
 multimodal = [
     "torch",

--- a/python/sgl_jax/srt/hf_transformers_utils.py
+++ b/python/sgl_jax/srt/hf_transformers_utils.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import os
+import threading
 import warnings
 from pathlib import Path
 
@@ -179,6 +180,46 @@ def get_context_length(config):
 
 # A fast LLaMA tokenizer with the pre-processed `tokenizer.json` file.
 _FAST_LLAMA_TOKENIZER = "hf-internal-testing/llama-tokenizer"
+_FASTOKENS_PATCHED = False
+_FASTOKENS_PATCH_LOCK = threading.Lock()
+
+
+def _validate_tokenizer_backend(tokenizer_backend: str):
+    if tokenizer_backend not in {"huggingface", "fastokens"}:
+        raise ValueError(
+            "Unsupported tokenizer_backend "
+            f"{tokenizer_backend!r}. Expected 'huggingface' or 'fastokens'."
+        )
+
+
+def _ensure_fastokens_patched():
+    """Monkey-patch transformers process-wide to use the fastokens backend once."""
+    global _FASTOKENS_PATCHED
+    if _FASTOKENS_PATCHED:
+        return
+
+    with _FASTOKENS_PATCH_LOCK:
+        if _FASTOKENS_PATCHED:
+            return
+
+        try:
+            import fastokens
+        except ImportError:
+            raise ImportError(
+                "The fastokens package is required when tokenizer_backend='fastokens'. "
+                "Install it with: pip install 'sglang-jax[fastokens]'"
+            ) from None
+
+        fastokens.patch_transformers()
+        _FASTOKENS_PATCHED = True
+
+
+def _raise_fastokens_load_error(tokenizer_name: str, error: Exception):
+    raise RuntimeError(
+        f"fastokens failed to load tokenizer for {tokenizer_name!r}. "
+        "This model's tokenizer may not be supported by fastokens. "
+        "Use tokenizer_backend='huggingface' to use the default backend."
+    ) from error
 
 
 def get_tokenizer(
@@ -187,12 +228,19 @@ def get_tokenizer(
     tokenizer_mode: str = "auto",
     trust_remote_code: bool = False,
     tokenizer_revision: str | None = None,
+    tokenizer_backend: str = "huggingface",
     sub_dir: str = "",
     **kwargs,
 ) -> PreTrainedTokenizer | PreTrainedTokenizerFast | TiktokenTokenizer:
     """Gets a tokenizer for the given model name via Huggingface."""
+    _validate_tokenizer_backend(tokenizer_backend)
+
     if tokenizer_name.endswith(".json"):
+        # Tiktoken JSON files use their own backend and do not go through transformers.
         return TiktokenTokenizer(tokenizer_name)
+
+    if tokenizer_backend == "fastokens":
+        _ensure_fastokens_patched()
 
     if tokenizer_mode == "slow":
         if kwargs.get("use_fast", False):
@@ -229,6 +277,9 @@ def get_tokenizer(
             **kwargs,
         )
     except TypeError as e:
+        if tokenizer_backend == "fastokens":
+            _raise_fastokens_load_error(tokenizer_name, e)
+
         # The LLaMA tokenizer causes a protobuf error in some environments.
         err_msg = (
             "Failed to load the tokenizer. If you are using a LLaMA V1 model "
@@ -250,8 +301,15 @@ def get_tokenizer(
                 "or using the `--trust-remote-code` flag in the CLI."
             )
             raise RuntimeError(err_msg) from e
-        else:
-            raise e
+
+        if tokenizer_backend == "fastokens":
+            _raise_fastokens_load_error(tokenizer_name, e)
+
+        raise e
+    except (OSError, RuntimeError) as e:
+        if tokenizer_backend == "fastokens":
+            _raise_fastokens_load_error(tokenizer_name, e)
+        raise
 
     if not isinstance(tokenizer, PreTrainedTokenizerFast):
         warnings.warn(

--- a/python/sgl_jax/srt/hf_transformers_utils.py
+++ b/python/sgl_jax/srt/hf_transformers_utils.py
@@ -1,6 +1,7 @@
 """Utilities for Huggingface Transformers."""
 
 import contextlib
+import logging
 import os
 import threading
 import warnings
@@ -23,6 +24,8 @@ from sgl_jax.srt.configs.bailing_hybrid import BailingHybridConfig
 from sgl_jax.srt.configs.kimi_linear import KimiLinearConfig
 from sgl_jax.srt.managers.tiktoken_tokenizer import TiktokenTokenizer
 from sgl_jax.srt.utils.common_utils import is_remote_url, lru_cache_frozenset
+
+logger = logging.getLogger(__name__)
 
 
 class GlmMoeDsaConfig(PretrainedConfig):
@@ -212,13 +215,15 @@ def _ensure_fastokens_patched():
 
         fastokens.patch_transformers()
         _FASTOKENS_PATCHED = True
+        logger.info("fastokens backend enabled - transformers patched successfully")
 
 
 def _raise_fastokens_load_error(tokenizer_name: str, error: Exception):
     raise RuntimeError(
         f"fastokens failed to load tokenizer for {tokenizer_name!r}. "
-        "This model's tokenizer may not be supported by fastokens. "
-        "Use tokenizer_backend='huggingface' to use the default backend."
+        "This model's tokenizer may not be supported by fastokens — "
+        "see https://github.com/crusoecloud/fastokens. "
+        "Re-run without --tokenizer-backend=fastokens to use the default backend."
     ) from error
 
 
@@ -276,23 +281,28 @@ def get_tokenizer(
             clean_up_tokenization_spaces=False,
             **kwargs,
         )
-    except TypeError as e:
+    except Exception as e:
         if tokenizer_backend == "fastokens":
             _raise_fastokens_load_error(tokenizer_name, e)
 
-        # The LLaMA tokenizer causes a protobuf error in some environments.
-        err_msg = (
-            "Failed to load the tokenizer. If you are using a LLaMA V1 model "
-            f"consider using '{_FAST_LLAMA_TOKENIZER}' instead of the "
-            "original tokenizer."
-        )
-        raise RuntimeError(err_msg) from e
-    except ValueError as e:
+        if isinstance(e, TypeError):
+            # The LLaMA tokenizer causes a protobuf error in some environments.
+            err_msg = (
+                "Failed to load the tokenizer. If you are using a LLaMA V1 model "
+                f"consider using '{_FAST_LLAMA_TOKENIZER}' instead of the "
+                "original tokenizer."
+            )
+            raise RuntimeError(err_msg) from e
+
         # If the error pertains to the tokenizer class not existing or not
         # currently being imported, suggest using the --trust-remote-code flag.
-        if not trust_remote_code and (
-            "does not exist or is not currently imported." in str(e)
-            or "requires you to execute the tokenizer file" in str(e)
+        if (
+            isinstance(e, ValueError)
+            and not trust_remote_code
+            and (
+                "does not exist or is not currently imported." in str(e)
+                or "requires you to execute the tokenizer file" in str(e)
+            )
         ):
             err_msg = (
                 "Failed to load the tokenizer. If the tokenizer is a custom "
@@ -302,13 +312,6 @@ def get_tokenizer(
             )
             raise RuntimeError(err_msg) from e
 
-        if tokenizer_backend == "fastokens":
-            _raise_fastokens_load_error(tokenizer_name, e)
-
-        raise e
-    except (OSError, RuntimeError) as e:
-        if tokenizer_backend == "fastokens":
-            _raise_fastokens_load_error(tokenizer_name, e)
         raise
 
     if not isinstance(tokenizer, PreTrainedTokenizerFast):

--- a/python/sgl_jax/srt/managers/detokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/detokenizer_manager.py
@@ -78,6 +78,7 @@ class DetokenizerManager:
                 tokenizer_mode=server_args.tokenizer_mode,
                 trust_remote_code=server_args.trust_remote_code,
                 revision=server_args.revision,
+                tokenizer_backend=server_args.tokenizer_backend,
                 sub_dir=tokenizer_subdir,
             )
 

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -551,6 +551,7 @@ class Scheduler(
                 tokenizer_mode=server_args.tokenizer_mode,
                 trust_remote_code=server_args.trust_remote_code,
                 revision=server_args.revision,
+                tokenizer_backend=server_args.tokenizer_backend,
                 sub_dir=tokenizer_subdir,
             )
 

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -173,6 +173,7 @@ class TokenizerManager:
                 tokenizer_mode=server_args.tokenizer_mode,
                 trust_remote_code=server_args.trust_remote_code,
                 revision=server_args.revision,
+                tokenizer_backend=server_args.tokenizer_backend,
                 sub_dir=tokenizer_subdir,
             )
 

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -35,6 +35,7 @@ class ServerArgs:
     model_path: str
     tokenizer_path: str | None = None
     tokenizer_mode: str = "auto"
+    tokenizer_backend: str = "huggingface"
     skip_tokenizer_init: bool = False
     load_format: str = "auto"
     model_loader_extra_config: str = "{}"
@@ -307,6 +308,17 @@ class ServerArgs:
             help="Tokenizer mode. 'auto' will use the fast "
             "tokenizer if available, and 'slow' will "
             "always use the slow tokenizer.",
+        )
+        parser.add_argument(
+            "--tokenizer-backend",
+            type=str,
+            default=ServerArgs.tokenizer_backend,
+            choices=["huggingface", "fastokens"],
+            help="Tokenizer backend. 'huggingface' uses the default HuggingFace "
+            "tokenizers library, and 'fastokens' uses the fastokens library "
+            "for faster tokenization. The fastokens patch is process-wide after "
+            "it is enabled. Requires the fastokens package to be installed: "
+            "pip install 'sglang-jax[fastokens]'.",
         )
         parser.add_argument(
             "--skip-tokenizer-init",

--- a/python/sgl_jax/test/test_hf_transformers_fastokens.py
+++ b/python/sgl_jax/test/test_hf_transformers_fastokens.py
@@ -60,7 +60,7 @@ class TestFastokensBackend(unittest.TestCase):
             ),
             self.assertRaisesRegex(
                 RuntimeError,
-                "Use tokenizer_backend='huggingface' to use the default backend",
+                "Re-run without --tokenizer-backend=fastokens to use the default backend",
             ),
         ):
             hf_transformers_utils.get_tokenizer(

--- a/python/sgl_jax/test/test_hf_transformers_fastokens.py
+++ b/python/sgl_jax/test/test_hf_transformers_fastokens.py
@@ -1,0 +1,81 @@
+import unittest
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+TOKENIZER_MODEL = "Qwen/Qwen3-0.6B"
+TEST_TEXTS = [
+    "Hello, world!",
+    "SGLang JAX tokenizer parity.\n" * 2048,
+]
+
+try:
+    import fastokens  # noqa: F401
+
+    HAS_FASTOKENS = True
+except ImportError:
+    HAS_FASTOKENS = False
+
+
+@unittest.skipUnless(HAS_FASTOKENS, "fastokens package not installed")
+class TestFastokensBackend(unittest.TestCase):
+    def test_01_fastokens_matches_huggingface_token_ids(self):
+        from fastokens._compat import _TokenizerShim
+
+        from sgl_jax.srt.hf_transformers_utils import get_tokenizer
+
+        # Load the Hugging Face reference before enabling fastokens, because
+        # fastokens.patch_transformers() is process-wide.
+        hf_tokenizer = get_tokenizer(TOKENIZER_MODEL)
+        hf_token_ids = [hf_tokenizer.encode(text, add_special_tokens=False) for text in TEST_TEXTS]
+
+        fastokens_tokenizer = get_tokenizer(
+            TOKENIZER_MODEL,
+            tokenizer_backend="fastokens",
+        )
+        fastokens_backend = getattr(fastokens_tokenizer, "_tokenizer", None)
+        self.assertIsInstance(fastokens_backend, _TokenizerShim)
+
+        fastokens_token_ids = [
+            fastokens_tokenizer.encode(text, add_special_tokens=False) for text in TEST_TEXTS
+        ]
+
+        self.assertEqual(fastokens_token_ids, hf_token_ids)
+        self.assertGreater(len(fastokens_token_ids[-1]), 1000)
+        self.assertEqual(
+            fastokens_tokenizer.decode(fastokens_token_ids[0], skip_special_tokens=True),
+            TEST_TEXTS[0],
+        )
+
+    def test_02_fastokens_load_error_is_actionable(self):
+        from sgl_jax.srt import hf_transformers_utils
+
+        hf_transformers_utils._ensure_fastokens_patched()
+
+        with (
+            TemporaryDirectory() as tokenizer_dir,
+            patch.object(
+                hf_transformers_utils.AutoTokenizer,
+                "from_pretrained",
+                side_effect=RuntimeError("unsupported tokenizer"),
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "Use tokenizer_backend='huggingface' to use the default backend",
+            ),
+        ):
+            hf_transformers_utils.get_tokenizer(
+                tokenizer_dir,
+                tokenizer_backend="fastokens",
+            )
+
+
+class TestTokenizerBackendValidation(unittest.TestCase):
+    def test_invalid_tokenizer_backend_is_rejected(self):
+        from sgl_jax.srt.hf_transformers_utils import get_tokenizer
+
+        with self.assertRaisesRegex(ValueError, "Unsupported tokenizer_backend"):
+            get_tokenizer(TOKENIZER_MODEL, tokenizer_backend="not-a-backend")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Port the merged upstream SGLang fastokens tokenizer backend from https://github.com/sgl-project/sglang/pull/23753 into SGL-JAX.

This keeps Hugging Face tokenizers as the default while adding an opt-in `--tokenizer-backend fastokens` path for faster CPU-side tokenization on supported tokenizer families. The change targets tokenizer-manager TTFT overhead for long prompts and is intentionally narrow: no model forward path, kernel, scheduler policy, or default serving behavior changes.

No separate RFC/design doc is included because this is a small, opt-in port of an already-reviewed upstream SGLang feature rather than a new SGL-JAX architecture feature.

## Modifications

- Add optional `fastokens` extra: `fastokens>=0.1.1,<0.2.0`.
- Add `--tokenizer-backend {huggingface,fastokens}` to `ServerArgs`; default remains `huggingface`.
- Patch Transformers once, process-wide, when `fastokens` is selected.
- Return clear errors when `fastokens` is not installed or does not support the requested tokenizer.
- Thread `server_args.tokenizer_backend` through tokenizer initialization in tokenizer, detokenizer, and scheduler managers.
- Add tests for Hugging Face/fastokens token-id parity, fastokens shim usage, actionable fastokens load errors, and invalid backend validation. Fastokens-specific tests skip unless `fastokens` is installed.

## Accuracy Tests

This does not change model weights, model forward code, sampling, logits, or generated-token selection. The validation here is tokenizer token-id equivalence for a supported tokenizer.

- `PYTHONPATH=python python/.venv/bin/python -m unittest sgl_jax.test.test_hf_transformers_fastokens -v`
  - checks `Qwen/Qwen3-0.6B` Hugging Face vs fastokens token IDs on short and long prompts
  - checks `tokenizer._tokenizer` is fastokens `_TokenizerShim`
  - checks fastokens load failures give an actionable fallback message
  - checks invalid `tokenizer_backend` values are rejected
- `PYTHONPATH=python python -m unittest python.sgl_jax.test.test_hf_transformers_fastokens -v`
  - no-fastokens environment: fastokens-specific tests skip, invalid-backend validation still runs
- Smoke checked CLI parsing stores `tokenizer_backend="fastokens"`.

- TPU VM dummy-weight server startup smoke on TPU VM (`v6e-1`, `europe-west4-a`): launched `Qwen/Qwen3-0.6B` with `--load-format=dummy --device=tpu --tp-size=1 --tokenizer-backend fastokens`; `/health` returned 200 and logs showed `tokenizer_backend='fastokens'` plus `fastokens.patch_transformers` in tokenizer, detokenizer, and scheduler processes.

## Benchmarking and Profiling

Tokenizer-only microbenchmarks with `Qwen/Qwen3-0.6B`, 36,864-token prompt, 20 encode iterations after warmup:

Local development machine:

| Backend | Median encode time | Mean encode time |
| --- | ---: | ---: |
| Hugging Face | 34.889 ms | 34.925 ms |
| fastokens | 0.938 ms | 0.935 ms |

TPU VM host CPU (`v6e-1`, `europe-west4-a`):

| Backend | Median encode time | Mean encode time |
| --- | ---: | ---: |
| Hugging Face | 34.506 ms | 34.623 ms |
| fastokens | 1.301 ms | 1.311 ms |

No end-to-end TPU performance benchmark was run because this PR only adds an opt-in tokenizer backend and does not change the default path.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.

Additional checks run:

- `pre-commit run --files python/pyproject.toml python/sgl_jax/srt/hf_transformers_utils.py python/sgl_jax/srt/managers/detokenizer_manager.py python/sgl_jax/srt/managers/scheduler.py python/sgl_jax/srt/managers/tokenizer_manager.py python/sgl_jax/srt/server_args.py python/sgl_jax/test/test_hf_transformers_fastokens.py`
- `ruff check python/sgl_jax/srt/hf_transformers_utils.py python/sgl_jax/srt/server_args.py python/sgl_jax/srt/managers/tokenizer_manager.py python/sgl_jax/srt/managers/detokenizer_manager.py python/sgl_jax/srt/managers/scheduler.py python/sgl_jax/test/test_hf_transformers_fastokens.py`
- `git diff --check`
- `python/.venv/bin/python -m py_compile python/sgl_jax/srt/hf_transformers_utils.py python/sgl_jax/srt/server_args.py python/sgl_jax/srt/managers/tokenizer_manager.py python/sgl_jax/srt/managers/detokenizer_manager.py python/sgl_jax/srt/managers/scheduler.py python/sgl_jax/test/test_hf_transformers_fastokens.py`