### PR TITLE
feat(models): MiMoV2FlashMTPForCausalLM + restore EAGLE path broken since #939

### DIFF
--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -141,6 +141,12 @@ class ModelConfig:
 
         if is_draft_model and self.hf_config.architectures[0] == "MiMoForCausalLM":
             self.hf_config.architectures[0] = "MiMoMTPForCausalLM"
+
+        if is_draft_model and self.hf_config.architectures[0] in (
+            "MiMoV2FlashForCausalLM",
+            "MiMoV2ForCausalLM",
+        ):
+            self.hf_config.architectures[0] = "MiMoV2FlashMTPForCausalLM"
         # Check model type
         self.is_generation = is_generation_model(self.hf_config.architectures, is_embedding)
         self.is_multimodal = False

--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -147,6 +147,10 @@ class ModelConfig:
             "MiMoV2ForCausalLM",
         ):
             self.hf_config.architectures[0] = "MiMoV2FlashMTPForCausalLM"
+            # Draft uses only mtp.layers.0 (single SWA layer); without this the
+            # KV pool sizes for 48 target layers and OOMs.
+            self.hf_config.num_nextn_predict_layers = 1
+            self.hf_config.num_hidden_layers = 1
             if self.quantization_config is not None:
                 # Draft MTP head: eh_proj and o_proj are bf16 in the checkpoint
                 # (no weight_scale_inv); keep them as plain LinearBase so the

--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -147,6 +147,14 @@ class ModelConfig:
             "MiMoV2ForCausalLM",
         ):
             self.hf_config.architectures[0] = "MiMoV2FlashMTPForCausalLM"
+            if self.quantization_config is not None:
+                # Draft MTP head: eh_proj and o_proj are bf16 in the checkpoint
+                # (no weight_scale_inv); keep them as plain LinearBase so the
+                # weight_mappings can target `.weight` instead of `.weight_q`.
+                self.quantization_config.ignored_layers = [
+                    "model.eh_proj",
+                    "model.self_attn.o_proj",
+                ]
         # Check model type
         self.is_generation = is_generation_model(self.hf_config.architectures, is_embedding)
         self.is_multimodal = False

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention.py
@@ -170,9 +170,9 @@ def ref_ragged_paged_attention(
         v = jnp.repeat(v, num_query_per_kv, axis=1)
         attn = jnp.einsum("qhd,khd->hqk", q, k, preferred_element_type=jnp.float32)
         attn *= sm_scale
+        q_span = (kv_len - q_len) + jax.lax.broadcasted_iota(jnp.int32, attn.shape, 1)
+        kv_span = jax.lax.broadcasted_iota(jnp.int32, attn.shape, 2)
         if causal:
-            q_span = (kv_len - q_len) + jax.lax.broadcasted_iota(jnp.int32, attn.shape, 1)
-            kv_span = jax.lax.broadcasted_iota(jnp.int32, attn.shape, 2)
             mask = q_span < kv_span
         else:
             mask_start = cu_mask_lens[i]

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -559,11 +559,7 @@ def _ragged_paged_attention_kernel_loop(
         mask_len = kv_len
         mask_start = bkvmask_idx * bkv_sz
         mask_left = mask_len - mask_start
-        # Mosaic DMA requires the dynamic slice size to be tiling(8)-aligned.
-        # kv_len = seq_len + num_draft at verify time and is not aligned, so
-        # round up; the over-read is ignored by effective_bkv_sz downstream and
-        # the tail padding on custom_mask (added at kernel entry) prevents OOB.
-        load_kvmask_sz = jnp.minimum(bkv_sz, ((mask_left + 7) // 8) * 8)
+        load_kvmask_sz = jnp.minimum(bkv_sz, mask_left)
 
         q_len_start = cu_q_lens_ref[seq_idx] + bq_idx * bq_sz
         q_end = cu_q_lens_ref[seq_idx + 1]
@@ -1754,8 +1750,6 @@ def ragged_paged_attention(
     if custom_mask is not None:
         if custom_mask.dtype == jnp.bool_:
             custom_mask = custom_mask.astype(jnp.int32)
-        # Tail-pad so the 8-aligned over-read in _fetch_mask never goes OOB.
-        custom_mask = jnp.pad(custom_mask, (0, 8))
         custom_mask = jnp.repeat(jnp.expand_dims(custom_mask, axis=1), repeats=head_dim, axis=1)
 
         # Prepare cu_seq_mask_lens for custom mask.

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -558,9 +558,7 @@ def _ragged_paged_attention_kernel_loop(
         # custom_mask rows are host-padded to page-aligned kv_len (8-divisible
         # and shape-stable within a page) while kv_lens_ref keeps the unaligned
         # value for _fetch_bkv. Mask stride = cu_kv_lens delta (page-aligned).
-        mask_kv_len = pl.multiple_of(
-            cu_kv_lens_ref[seq_idx + 1] - cu_kv_lens_ref[seq_idx], 8
-        )
+        mask_kv_len = pl.multiple_of(cu_kv_lens_ref[seq_idx + 1] - cu_kv_lens_ref[seq_idx], 8)
         mask_start = bkvmask_idx * bkv_sz
         mask_left = mask_kv_len - mask_start
         load_kvmask_sz = pl.multiple_of(jnp.minimum(bkv_sz, mask_left), 8)

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -555,21 +555,24 @@ def _ragged_paged_attention_kernel_loop(
         sem = sems.at[4, bkvmask_sem_idx]
         kvmask_vmem_ref = bkvmask_ref.at[bkvmask_sem_idx]
 
-        kv_len = kv_lens_ref[seq_idx]
+        # Host side (get_eagle_forward_metadata) 8-aligns kv_lens and pads
+        # custom_mask rows accordingly; hint Mosaic so it can prove the DMA
+        # slice offset/size are tiling(8)-divisible.
+        kv_len = pl.multiple_of(kv_lens_ref[seq_idx], 8)
         mask_len = kv_len
         mask_start = bkvmask_idx * bkv_sz
         mask_left = mask_len - mask_start
-        load_kvmask_sz = jnp.minimum(bkv_sz, mask_left)
+        load_kvmask_sz = pl.multiple_of(jnp.minimum(bkv_sz, mask_left), 8)
 
         q_len_start = cu_q_lens_ref[seq_idx] + bq_idx * bq_sz
         q_end = cu_q_lens_ref[seq_idx + 1]
         load_q_sz = jnp.minimum(bq_sz, q_end - q_len_start)
 
-        cur_seq_mask_start = cu_seq_mask_lens[seq_idx]
+        cur_seq_mask_start = pl.multiple_of(cu_seq_mask_lens[seq_idx], 8)
         cur_bq_mask_start = cur_seq_mask_start + bq_idx * bq_sz * kv_len
 
         def loop_body(i, _):
-            start = cur_bq_mask_start + i * kv_len + mask_start
+            start = pl.multiple_of(cur_bq_mask_start + i * kv_len + mask_start, 8)
             _async_copy(
                 custom_mask_ref.at[pl.ds(start, load_kvmask_sz)],
                 kvmask_vmem_ref.at[i, pl.ds(0, load_kvmask_sz)],

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -555,13 +555,13 @@ def _ragged_paged_attention_kernel_loop(
         sem = sems.at[4, bkvmask_sem_idx]
         kvmask_vmem_ref = bkvmask_ref.at[bkvmask_sem_idx]
 
-        # Host side (get_eagle_forward_metadata) 8-aligns kv_lens and pads
-        # custom_mask rows accordingly; hint Mosaic so it can prove the DMA
-        # slice offset/size are tiling(8)-divisible.
-        kv_len = pl.multiple_of(kv_lens_ref[seq_idx], 8)
-        mask_len = kv_len
+        # custom_mask rows are host-padded to 8-aligned kv_len (so mask DMA
+        # offset/size are tiling(8)-divisible) while kv_lens_ref keeps the
+        # unaligned value for _fetch_bkv. Derive the mask stride locally.
+        kv_len_raw = kv_lens_ref[seq_idx]
+        mask_kv_len = pl.multiple_of((kv_len_raw + 7) // 8 * 8, 8)
         mask_start = bkvmask_idx * bkv_sz
-        mask_left = mask_len - mask_start
+        mask_left = mask_kv_len - mask_start
         load_kvmask_sz = pl.multiple_of(jnp.minimum(bkv_sz, mask_left), 8)
 
         q_len_start = cu_q_lens_ref[seq_idx] + bq_idx * bq_sz
@@ -569,12 +569,12 @@ def _ragged_paged_attention_kernel_loop(
         load_q_sz = jnp.minimum(bq_sz, q_end - q_len_start)
 
         cur_seq_mask_start = pl.multiple_of(cu_seq_mask_lens[seq_idx], 8)
-        cur_bq_mask_start = cur_seq_mask_start + bq_idx * bq_sz * kv_len
+        cur_bq_mask_start = cur_seq_mask_start + bq_idx * bq_sz * mask_kv_len
 
         zero_sz = pl.multiple_of(bkv_sz - load_kvmask_sz, 8)
 
         def loop_body(i, _):
-            start = pl.multiple_of(cur_bq_mask_start + i * kv_len + mask_start, 8)
+            start = pl.multiple_of(cur_bq_mask_start + i * mask_kv_len + mask_start, 8)
             _async_copy(
                 custom_mask_ref.at[pl.ds(start, load_kvmask_sz)],
                 kvmask_vmem_ref.at[i, pl.ds(0, load_kvmask_sz)],
@@ -1757,9 +1757,10 @@ def ragged_paged_attention(
             custom_mask = custom_mask.astype(jnp.int32)
         custom_mask = jnp.repeat(jnp.expand_dims(custom_mask, axis=1), repeats=head_dim, axis=1)
 
-        # Prepare cu_seq_mask_lens for custom mask.
+        # Prepare cu_seq_mask_lens for custom mask. Host pads each mask row
+        # to 8-aligned kv_len, so the per-seq stride uses the aligned length.
         q_lens = cu_q_lens[1:] - cu_q_lens[:-1]
-        seq_mask_lens = kv_lens * q_lens
+        seq_mask_lens = ((kv_lens + 7) // 8 * 8) * q_lens
         cu_seq_mask_lens = jnp.concatenate(
             [jnp.array([0], dtype=jnp.int32), jnp.cumsum(seq_mask_lens)]
         )

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -555,11 +555,12 @@ def _ragged_paged_attention_kernel_loop(
         sem = sems.at[4, bkvmask_sem_idx]
         kvmask_vmem_ref = bkvmask_ref.at[bkvmask_sem_idx]
 
-        # custom_mask rows are host-padded to 8-aligned kv_len (so mask DMA
-        # offset/size are tiling(8)-divisible) while kv_lens_ref keeps the
-        # unaligned value for _fetch_bkv. Derive the mask stride locally.
-        kv_len_raw = kv_lens_ref[seq_idx]
-        mask_kv_len = pl.multiple_of((kv_len_raw + 7) // 8 * 8, 8)
+        # custom_mask rows are host-padded to page-aligned kv_len (8-divisible
+        # and shape-stable within a page) while kv_lens_ref keeps the unaligned
+        # value for _fetch_bkv. Mask stride = cu_kv_lens delta (page-aligned).
+        mask_kv_len = pl.multiple_of(
+            cu_kv_lens_ref[seq_idx + 1] - cu_kv_lens_ref[seq_idx], 8
+        )
         mask_start = bkvmask_idx * bkv_sz
         mask_left = mask_kv_len - mask_start
         load_kvmask_sz = pl.multiple_of(jnp.minimum(bkv_sz, mask_left), 8)
@@ -1758,9 +1759,11 @@ def ragged_paged_attention(
         custom_mask = jnp.repeat(jnp.expand_dims(custom_mask, axis=1), repeats=head_dim, axis=1)
 
         # Prepare cu_seq_mask_lens for custom mask. Host pads each mask row
-        # to 8-aligned kv_len, so the per-seq stride uses the aligned length.
+        # to page-aligned kv_len (= cu_kv_lens delta), so per-seq stride uses
+        # that aligned length to keep DMA offset/size tiling(8)-divisible.
         q_lens = cu_q_lens[1:] - cu_q_lens[:-1]
-        seq_mask_lens = ((kv_lens + 7) // 8 * 8) * q_lens
+        aligned_kv_lens = cu_kv_lens[1:] - cu_kv_lens[:-1]
+        seq_mask_lens = aligned_kv_lens * q_lens
         cu_seq_mask_lens = jnp.concatenate(
             [jnp.array([0], dtype=jnp.int32), jnp.cumsum(seq_mask_lens)]
         )

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -146,9 +146,9 @@ def ref_ragged_paged_attention(
         v = jnp.repeat(v, num_query_per_kv, axis=1)
         attn = jnp.einsum("qhd,khd->hqk", q, k, preferred_element_type=jnp.float32)
         attn *= sm_scale
+        q_span = (kv_len - q_len) + jax.lax.broadcasted_iota(jnp.int32, attn.shape, 1)
+        kv_span = jax.lax.broadcasted_iota(jnp.int32, attn.shape, 2)
         if causal:
-            q_span = (kv_len - q_len) + jax.lax.broadcasted_iota(jnp.int32, attn.shape, 1)
-            kv_span = jax.lax.broadcasted_iota(jnp.int32, attn.shape, 2)
             mask = q_span < kv_span
         else:
             mask_start = cu_mask_lens[i]

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -559,7 +559,11 @@ def _ragged_paged_attention_kernel_loop(
         mask_len = kv_len
         mask_start = bkvmask_idx * bkv_sz
         mask_left = mask_len - mask_start
-        load_kvmask_sz = jnp.minimum(bkv_sz, mask_left)
+        # Mosaic DMA requires the dynamic slice size to be tiling(8)-aligned.
+        # kv_len = seq_len + num_draft at verify time and is not aligned, so
+        # round up; the over-read is ignored by effective_bkv_sz downstream and
+        # the tail padding on custom_mask (added at kernel entry) prevents OOB.
+        load_kvmask_sz = jnp.minimum(bkv_sz, ((mask_left + 7) // 8) * 8)
 
         q_len_start = cu_q_lens_ref[seq_idx] + bq_idx * bq_sz
         q_end = cu_q_lens_ref[seq_idx + 1]
@@ -1750,6 +1754,8 @@ def ragged_paged_attention(
     if custom_mask is not None:
         if custom_mask.dtype == jnp.bool_:
             custom_mask = custom_mask.astype(jnp.int32)
+        # Tail-pad so the 8-aligned over-read in _fetch_mask never goes OOB.
+        custom_mask = jnp.pad(custom_mask, (0, 8))
         custom_mask = jnp.repeat(jnp.expand_dims(custom_mask, axis=1), repeats=head_dim, axis=1)
 
         # Prepare cu_seq_mask_lens for custom mask.

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -571,6 +571,8 @@ def _ragged_paged_attention_kernel_loop(
         cur_seq_mask_start = pl.multiple_of(cu_seq_mask_lens[seq_idx], 8)
         cur_bq_mask_start = cur_seq_mask_start + bq_idx * bq_sz * kv_len
 
+        zero_sz = pl.multiple_of(bkv_sz - load_kvmask_sz, 8)
+
         def loop_body(i, _):
             start = pl.multiple_of(cur_bq_mask_start + i * kv_len + mask_start, 8)
             _async_copy(
@@ -580,8 +582,8 @@ def _ragged_paged_attention_kernel_loop(
                 wait,
             )
             _async_copy(
-                zero_mask_ref.at[pl.ds(0, bkv_sz - load_kvmask_sz)],
-                kvmask_vmem_ref.at[i, pl.ds(load_kvmask_sz, bkv_sz - load_kvmask_sz)],
+                zero_mask_ref.at[pl.ds(0, zero_sz)],
+                kvmask_vmem_ref.at[i, pl.ds(load_kvmask_sz, zero_sz)],
                 sem,
                 wait,
             )

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -232,26 +232,31 @@ class FlashAttention(AttentionBackend):
 
         if batch.forward_mode.is_target_verify():
             seq_lens += extend_seq_lens
-            # rpa_v3 _fetch_mask DMA needs offset/size tiling(8)-aligned. Pad
-            # each draft-token row of custom_mask to 8-aligned kv_len. Do NOT
-            # alter seq_lens itself: _fetch_bkv uses kv_len to split cache/new
-            # KV and would mis-place new tokens if aligned. The kernel computes
-            # the mask stride independently from the (unaligned) kv_len.
-            seq_lens_8 = ((seq_lens + 7) // 8 * 8).astype(np.int32)
+            aligned_seq_lens = ((seq_lens + self.page_size - 1) // self.page_size) * self.page_size
+            # rpa_v3 _fetch_mask DMA needs offset/size tiling(8)-aligned, and we
+            # also want a stable mask shape across decode steps to avoid
+            # per-step recompiles. Pad each draft-token row to the page-aligned
+            # kv_len (multiple of 8, and constant within a page). seq_lens
+            # itself stays unaligned for _fetch_bkv's cache/new split.
             if metadata.custom_mask is not None:
                 q = batch.spec_info.draft_token_num
                 cm = np.asarray(jax.device_get(metadata.custom_mask))
                 out, off = [], 0
                 for i in range(batch.real_bs):
-                    kl, kl8 = int(seq_lens[i]), int(seq_lens_8[i])
+                    kl, kla = int(seq_lens[i]), int(aligned_seq_lens[i])
                     row = cm[off : off + q * kl].reshape(q, kl)
-                    out.append(np.pad(row, ((0, 0), (0, kl8 - kl))).reshape(-1))
+                    out.append(np.pad(row, ((0, 0), (0, kla - kl))).reshape(-1))
                     off += q * kl
+                # Pad tail for padded-bs slots so total shape stays bucket-stable.
+                padded_tail = (
+                    q * int(aligned_seq_lens[batch.real_bs :].sum())
+                    if padded_batch_size > batch.real_bs
+                    else 0
+                )
                 metadata.custom_mask = device_array(
-                    np.concatenate(out).astype(np.int32),
+                    np.pad(np.concatenate(out), (0, padded_tail)).astype(np.int32),
                     sharding=NamedSharding(self.mesh, P()),
                 )
-            aligned_seq_lens = ((seq_lens + self.page_size - 1) // self.page_size) * self.page_size
         else:
             aligned_seq_lens = (
                 (batch.seq_lens + self.page_size - 1) // self.page_size

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -232,6 +232,24 @@ class FlashAttention(AttentionBackend):
 
         if batch.forward_mode.is_target_verify():
             seq_lens += extend_seq_lens
+            # rpa_v3 _fetch_mask DMA needs both offset (i*kv_len) and size to be
+            # tiling(8)-aligned. Pad each draft-token row of custom_mask to the
+            # 8-aligned kv_len and pass that aligned kv_len to the kernel.
+            seq_lens_8 = ((seq_lens + 7) // 8 * 8).astype(np.int32)
+            if metadata.custom_mask is not None and np.any(seq_lens_8 != seq_lens):
+                q = batch.spec_info.draft_token_num
+                cm = np.asarray(jax.device_get(metadata.custom_mask))
+                out, off = [], 0
+                for i in range(batch.real_bs):
+                    kl, kl8 = int(seq_lens[i]), int(seq_lens_8[i])
+                    row = cm[off : off + q * kl].reshape(q, kl)
+                    out.append(np.pad(row, ((0, 0), (0, kl8 - kl))).reshape(-1))
+                    off += q * kl
+                metadata.custom_mask = device_array(
+                    np.concatenate(out).astype(np.int32),
+                    sharding=NamedSharding(self.mesh, P()),
+                )
+            seq_lens = seq_lens_8
             aligned_seq_lens = ((seq_lens + self.page_size - 1) // self.page_size) * self.page_size
         else:
             aligned_seq_lens = (

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -333,9 +333,9 @@ class FlashAttention(AttentionBackend):
         swa_mapping = getattr(self, "swa_index_mapping", None)
         if swa_mapping is not None:
             mapping = swa_mapping[0] if isinstance(swa_mapping, list) else swa_mapping
-            swa_page_indices = (
-                mapping[batch.cache_loc[indices]] // self.page_size
-            ).astype(np.int32)
+            swa_page_indices = (mapping[batch.cache_loc[indices]] // self.page_size).astype(
+                np.int32
+            )
             metadata.swa_page_indices = device_array(
                 swa_page_indices, sharding=NamedSharding(self.mesh, P("data"))
             )

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -232,11 +232,13 @@ class FlashAttention(AttentionBackend):
 
         if batch.forward_mode.is_target_verify():
             seq_lens += extend_seq_lens
-            # rpa_v3 _fetch_mask DMA needs both offset (i*kv_len) and size to be
-            # tiling(8)-aligned. Pad each draft-token row of custom_mask to the
-            # 8-aligned kv_len and pass that aligned kv_len to the kernel.
+            # rpa_v3 _fetch_mask DMA needs offset/size tiling(8)-aligned. Pad
+            # each draft-token row of custom_mask to 8-aligned kv_len. Do NOT
+            # alter seq_lens itself: _fetch_bkv uses kv_len to split cache/new
+            # KV and would mis-place new tokens if aligned. The kernel computes
+            # the mask stride independently from the (unaligned) kv_len.
             seq_lens_8 = ((seq_lens + 7) // 8 * 8).astype(np.int32)
-            if metadata.custom_mask is not None and np.any(seq_lens_8 != seq_lens):
+            if metadata.custom_mask is not None:
                 q = batch.spec_info.draft_token_num
                 cm = np.asarray(jax.device_get(metadata.custom_mask))
                 out, off = [], 0
@@ -249,7 +251,6 @@ class FlashAttention(AttentionBackend):
                     np.concatenate(out).astype(np.int32),
                     sharding=NamedSharding(self.mesh, P()),
                 )
-            seq_lens = seq_lens_8
             aligned_seq_lens = ((seq_lens + self.page_size - 1) // self.page_size) * self.page_size
         else:
             aligned_seq_lens = (

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -293,6 +293,7 @@ class FlashAttention(AttentionBackend):
         cu_kv_lens = np.array(cu_kv_lens)
         page_indices = np.array(page_indices)
         seq_lens = np.array(seq_lens)
+
         (
             metadata.cu_q_lens,
             metadata.cu_kv_lens,
@@ -303,6 +304,17 @@ class FlashAttention(AttentionBackend):
             (cu_q_lens, cu_kv_lens, page_indices, seq_lens, distribution),
             sharding=(NamedSharding(self.mesh, P("data"))),
         )
+        # Hybrid SWA targets need swa_page_indices for TARGET_VERIFY too,
+        # otherwise SWA layers index the swa sub-pool with full-pool page ids.
+        swa_mapping = getattr(self, "swa_index_mapping", None)
+        if swa_mapping is not None:
+            mapping = swa_mapping[0] if isinstance(swa_mapping, list) else swa_mapping
+            swa_page_indices = (
+                mapping[batch.cache_loc[indices]] // self.page_size
+            ).astype(np.int32)
+            metadata.swa_page_indices = device_array(
+                swa_page_indices, sharding=NamedSharding(self.mesh, P("data"))
+            )
         return metadata
 
     def get_eagle_multi_step_metadata(self, batch: ModelWorkerBatch):

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2357,6 +2357,10 @@ class ScheduleBatch:
             logits_indices=logits_indices,
             lora_ids=lora_ids,
             real_bs=real_bs,
+            real_bs_per_dp=[real_bs],
+            dp_size=self.dp_size,
+            per_dp_bs_size=real_bs,
+            logits_indices_selector=np.arange(real_bs, dtype=np.int32),
             capture_hidden_mode=(
                 CaptureHiddenMode.FULL
                 if self.return_hidden_states

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2346,7 +2346,7 @@ class ScheduleBatch:
             return_output_logprob_only=self.return_output_logprob_only,
             top_logprobs_nums=self.top_logprobs_nums,
             token_ids_logprobs=self.token_ids_logprobs,
-            sampling_info=self.sampling_info,
+            sampling_info=self._merge_sampling_info(real_bs, real_bs),
             positions=positions_cpu,
             mrope_positions=mrope_positions_cpu,
             cache_loc=cache_loc_flat,

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2231,6 +2231,9 @@ class ScheduleBatch:
         out_cache_loc_cpu = self.out_cache_loc
         seq_lens_cpu = self.seq_lens
         real_bs = len(seq_lens_cpu)
+        # process_batch_result_decode slices next_token_ids by per_dp_bs_size;
+        # spec path doesn't pad so per_dp_bs_size == real_bs (dp=1 only).
+        self.per_dp_bs_size = real_bs
         req_pool_indices_cpu = self.req_pool_indices
         token_indices_with_all_reqs = self.req_to_token_pool.req_to_token[self.req_pool_indices]
         # FIXME @pc, move this to eagle_worker

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -780,6 +780,19 @@ class ScheduleBatch:
             return getattr(self.reqs_info[0], name)
         raise AttributeError(f"{type(self).__name__!r} has no attribute {name!r}")
 
+    def __setattr__(self, name, value):
+        # Mirror of __getattr__: spec path writes (scheduler L1817-1821,
+        # eagle_util prepare_for_decode) must land in reqs_info[0] so the
+        # DP-aware reads in prepare_for_decode etc. see them.
+        if (
+            name in ScheduleReqsInfo.__dataclass_fields__
+            and "reqs_info" in self.__dict__
+            and self.__dict__["reqs_info"]
+        ):
+            setattr(self.__dict__["reqs_info"][0], name, value)
+        else:
+            super().__setattr__(name, value)
+
     @property
     def batch_is_full(self) -> bool:
         return all(info.batch_is_full for info in self.reqs_info)

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -768,6 +768,18 @@ class ScheduleBatch:
             dp_size=dp_size,
         )
 
+    def __getattr__(self, name):
+        # Backward-compat shim: the speculative path (get_spec_model_worker_batch
+        # and eagle_util) still references pre-#939 flat attrs. Route them to
+        # reqs_info[0] until spec decode is properly DP-aware.
+        if (
+            "reqs_info" in self.__dict__
+            and self.reqs_info
+            and name in ScheduleReqsInfo.__dataclass_fields__
+        ):
+            return getattr(self.reqs_info[0], name)
+        raise AttributeError(f"{type(self).__name__!r} has no attribute {name!r}")
+
     @property
     def batch_is_full(self) -> bool:
         return all(info.batch_is_full for info in self.reqs_info)

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2655,6 +2655,9 @@ def _compute_mrope_positions_for_batch(
 class ModelWorkerSamplingInfo:
     """Unified sampling information for a generation batch."""
 
+    def __len__(self) -> int:
+        return len(self.temperatures)
+
     # Basic batched sampling params
     temperatures: np.ndarray
     top_ps: np.ndarray

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -147,9 +147,9 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         if server_args.enable_lora:
             self.init_lora_manager()
 
+        self._sampler_base_rng = jax.random.PRNGKey(server_args.random_seed)
+        self._sampler_step = 0
         if not self.is_draft_worker:
-            self._sampler_base_rng = jax.random.PRNGKey(server_args.random_seed)
-            self._sampler_step = 0
             self.initialize_jit()
 
         # Init memory pool and attention backends

--- a/python/sgl_jax/srt/models/mimo_mtp.py
+++ b/python/sgl_jax/srt/models/mimo_mtp.py
@@ -60,15 +60,10 @@ class MiMoMTPLayer(nnx.Module):
         hidden_states = hidden_states * token_mask
         layers_kv_fused = []
 
-        hidden_states, _ = self.input_proj(
-            jnp.concatenate(
-                (
-                    self.hidden_layernorm(forward_batch.spec_info.hidden_states),
-                    self.token_layernorm(hidden_states),
-                ),
-                axis=-1,
-            )
-        )
+        e = self.token_layernorm(hidden_states)
+        h = self.hidden_layernorm(forward_batch.spec_info.hidden_states.astype(e.dtype))
+        h = jax.sharding.reshard(h, jax.typeof(e).sharding)
+        hidden_states, _ = self.input_proj(jnp.concatenate((h, e), axis=-1))
         hidden_states, residual, kv_fused, _ = self.mtp_layers(
             forward_batch.positions, hidden_states, forward_batch, token_to_kv_pool, None
         )

--- a/python/sgl_jax/srt/models/mimo_mtp.py
+++ b/python/sgl_jax/srt/models/mimo_mtp.py
@@ -251,7 +251,7 @@ class MiMoMTPForCausalLM(nnx.Module):
                 aux_hidden_states=None,
             )
 
-        return output, layers_kv_fused, []
+        return output, layers_kv_fused, True, []
 
     def get_embed_and_head(self):
         return (

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -818,5 +818,11 @@ class MiMoV2FlashForCausalLM(nnx.Module):
 
         return output, layers_kv_fused, True, layers_topk_ids
 
+    def get_embed_and_head(self):
+        embed = self.model.embed_tokens.embedding.value
+        if not getattr(self.config, "tie_word_embeddings", True):
+            return embed, self.lm_head.embedding.value
+        return embed, embed
+
 
 EntryClass = [MiMoV2FlashForCausalLM]

--- a/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
@@ -223,7 +223,7 @@ class MiMoV2FlashMTPForCausalLM(nnx.Module):
             ),
             f"{prefix}.self_attn.attention_sink_bias": WeightMapping(
                 target_path="model.self_attn.attention_sink_bias",
-                sharding=(None,),
+                sharding=("tensor",),
                 transpose=False,
             ),
         }
@@ -247,9 +247,8 @@ class MiMoV2FlashMTPForCausalLM(nnx.Module):
             if is_fp8 and fp8:
                 m[f"{prefix}.self_attn.{name}.weight_scale_inv"] = WeightMapping(
                     target_path=f"model.self_attn.{name}.weight_scale",
-                    sharding=axes,
-                    transpose=True,
-                    kv_head_padding=kv_pad,
+                    sharding=(None, None),
+                    transpose=False,
                 )
         for name, axes in (
             ("gate_proj", (None, "tensor")),
@@ -265,8 +264,8 @@ class MiMoV2FlashMTPForCausalLM(nnx.Module):
             if is_fp8:
                 m[f"{prefix}.mlp.{name}.weight_scale_inv"] = WeightMapping(
                     target_path=f"model.mlp.{name}.weight_scale",
-                    sharding=axes,
-                    transpose=True,
+                    sharding=(None, None),
+                    transpose=False,
                 )
         return m
 

--- a/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
@@ -1,0 +1,284 @@
+"""MiMo-V2-Flash / V2.5 / V2.5-Pro MTP (NextN) draft model.
+
+The V2 family ships a 3-layer MTP head under ``model.mtp.layers.{0,1,2}``.
+Each layer is a single SWA-attention block (window=128, K head_dim=192,
+V head_dim=128, attention sink) followed by a *dense* FFN (no MoE). This
+module loads layer 0 only and exposes it as a standard NEXTN draft model
+for ``eagle_worker``; multi-layer EAGLE is left as a follow-up.
+
+Weight key convention (from HF safetensors)::
+
+    model.mtp.layers.0.enorm.weight                # token-side norm
+    model.mtp.layers.0.hnorm.weight                # hidden-side norm
+    model.mtp.layers.0.eh_proj.weight              # 2*h -> h
+    model.mtp.layers.0.input_layernorm.weight
+    model.mtp.layers.0.self_attn.{q,k,v,o}_proj.weight[_scale_inv]
+    model.mtp.layers.0.self_attn.attention_sink_bias
+    model.mtp.layers.0.pre_mlp_layernorm.weight
+    model.mtp.layers.0.mlp.{gate,up,down}_proj.weight[_scale_inv]
+    model.mtp.layers.0.final_layernorm.weight
+"""
+
+from __future__ import annotations
+
+import logging
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from transformers import PretrainedConfig
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead
+from sgl_jax.srt.layers.layernorm import RMSNorm
+from sgl_jax.srt.layers.linear import LinearBase
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
+from sgl_jax.srt.mem_cache.memory_pool import KVCache, MemoryPools
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+from sgl_jax.srt.models.mimo_v2_flash import MiMoV2Attention, MiMoV2MLP
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+
+logger = logging.getLogger(__name__)
+
+
+class MiMoV2FlashMTPLayer(nnx.Module):
+    """One MTP block: SWA attention + dense MLP, with the V2 enorm/hnorm/eh_proj prelude."""
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        layer_id: int = 0,
+        dtype: jnp.dtype = jnp.bfloat16,
+        mesh: jax.sharding.Mesh | None = None,
+    ):
+        self.layer_id = layer_id
+        eps = getattr(config, "rms_norm_eps", getattr(config, "layernorm_epsilon", 1e-6))
+
+        self.embed_tokens = Embed(
+            num_embeddings=config.vocab_size,
+            features=config.hidden_size,
+            dtype=dtype,
+            kernel_axes=("tensor", None),
+            param_dtype=dtype,
+            mesh=mesh,
+        )
+        self.enorm = RMSNorm(config.hidden_size, epsilon=eps)
+        self.hnorm = RMSNorm(config.hidden_size, epsilon=eps)
+        self.eh_proj = LinearBase(
+            input_size=config.hidden_size * 2,
+            output_size=config.hidden_size,
+            use_bias=False,
+            kernel_axes=(None, None),
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+
+        self.input_layernorm = RMSNorm(config.hidden_size, epsilon=eps)
+        self.self_attn = MiMoV2Attention(
+            hidden_size=config.hidden_size,
+            num_heads=config.swa_num_attention_heads,
+            num_kv_heads=config.swa_num_key_value_heads,
+            max_position_embeddings=config.max_position_embeddings,
+            mesh=mesh,
+            rope_theta=getattr(config, "swa_rope_theta", config.rope_theta),
+            rope_scaling=getattr(config, "rope_scaling", None),
+            head_dim=config.swa_head_dim,
+            v_head_dim=config.swa_v_head_dim,
+            sliding_window_size=getattr(config, "sliding_window_size", config.sliding_window),
+            attention_sink_bias=getattr(config, "add_swa_attention_sink_bias", False),
+            partial_rotary_factor=getattr(config, "partial_rotary_factor", 1.0),
+            attention_value_scale=getattr(config, "attention_value_scale", None),
+            layer_id=layer_id,
+            dtype=dtype,
+        )
+        self.pre_mlp_layernorm = RMSNorm(config.hidden_size, epsilon=eps)
+        self.mlp = MiMoV2MLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            mesh=mesh,
+            layer_id=layer_id,
+            dtype=dtype,
+        )
+        self.final_layernorm = RMSNorm(config.hidden_size, epsilon=eps)
+
+    def __call__(self, forward_batch: ForwardBatch, token_to_kv_pool: KVCache):
+        token_embeds = self.embed_tokens(forward_batch.input_ids)
+        token_mask = (forward_batch.positions != 0).astype(token_embeds.dtype)[:, None]
+        token_embeds = token_embeds * token_mask
+
+        hidden_states, _ = self.eh_proj(
+            jnp.concatenate(
+                (
+                    self.enorm(token_embeds),
+                    self.hnorm(forward_batch.spec_info.hidden_states),
+                ),
+                axis=-1,
+            )
+        )
+
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        attn_out, kv_fused = self.self_attn(
+            forward_batch.positions, hidden_states, forward_batch, token_to_kv_pool
+        )
+        hidden_states = residual + attn_out
+
+        residual = hidden_states
+        hidden_states = self.pre_mlp_layernorm(hidden_states)
+        hidden_states = residual + self.mlp(hidden_states)
+
+        hidden_states = self.final_layernorm(hidden_states)
+        return hidden_states, [kv_fused]
+
+
+class MiMoV2FlashMTPForCausalLM(nnx.Module):
+    """NEXTN draft model wrapper for MiMo-V2-Flash / V2.5 / V2.5-Pro."""
+
+    load_lm_head_from_target = True
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        dtype: jnp.dtype = jnp.bfloat16,
+        mesh: jax.sharding.Mesh | None = None,
+    ):
+        self.config = config
+        self.dtype = dtype
+        self.mesh = mesh
+        self.model = MiMoV2FlashMTPLayer(config, dtype=dtype, mesh=mesh)
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            dtype=dtype,
+            param_dtype=dtype,
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size, mesh=mesh)
+
+    def __call__(
+        self,
+        forward_batch: ForwardBatch,
+        memory_pools: MemoryPools,
+        logits_metadata: LogitsMetadata,
+    ):
+        kv_pool = memory_pools.token_to_kv_pool
+        hidden_states, layers_kv_fused = self.model(forward_batch, kv_pool)
+        if not getattr(self.config, "tie_word_embeddings", False):
+            output = self.logits_processor(
+                hidden_states, self.lm_head, logits_metadata, aux_hidden_states=None
+            )
+        else:
+            output = self.logits_processor(
+                hidden_states,
+                self.model.embed_tokens,
+                logits_metadata,
+                aux_hidden_states=None,
+            )
+        return output, layers_kv_fused, []
+
+    def load_weights(self, model_config: ModelConfig):
+        loader = WeightLoader(
+            model=self, model_config=model_config, mesh=self.mesh, dtype=self.dtype
+        )
+        loader.load_weights_from_safetensors(self._create_weight_mappings())
+        logger.info("MiMo-V2 MTP draft weights loaded successfully!")
+
+    def _create_weight_mappings(self) -> dict:
+        prefix = "model.mtp.layers.0"
+        m: dict[str, WeightMapping] = {
+            "model.embed_tokens.weight": WeightMapping(
+                target_path="model.embed_tokens.embedding",
+                sharding=("tensor", None),
+                transpose=False,
+            ),
+            "lm_head.weight": WeightMapping(
+                target_path="lm_head.embedding",
+                sharding=(None, None),
+                transpose=False,
+            ),
+            f"{prefix}.enorm.weight": WeightMapping(
+                target_path="model.enorm.scale", sharding=(None,), transpose=False
+            ),
+            f"{prefix}.hnorm.weight": WeightMapping(
+                target_path="model.hnorm.scale", sharding=(None,), transpose=False
+            ),
+            f"{prefix}.eh_proj.weight": WeightMapping(
+                target_path="model.eh_proj.weight",
+                sharding=(None, None),
+                transpose=True,
+            ),
+            f"{prefix}.input_layernorm.weight": WeightMapping(
+                target_path="model.input_layernorm.scale",
+                sharding=(None,),
+                transpose=False,
+            ),
+            f"{prefix}.pre_mlp_layernorm.weight": WeightMapping(
+                target_path="model.pre_mlp_layernorm.scale",
+                sharding=(None,),
+                transpose=False,
+            ),
+            f"{prefix}.final_layernorm.weight": WeightMapping(
+                target_path="model.final_layernorm.scale",
+                sharding=(None,),
+                transpose=False,
+            ),
+            f"{prefix}.self_attn.attention_sink_bias": WeightMapping(
+                target_path="model.self_attn.attention_sink_bias",
+                sharding=(None,),
+                transpose=False,
+            ),
+        }
+        attn_projs = (
+            ("q_proj", (None, "tensor"), False, True),
+            ("k_proj", (None, "tensor"), True, True),
+            ("v_proj", (None, "tensor"), True, True),
+            ("o_proj", ("tensor", None), False, False),
+        )
+        for name, axes, kv_pad, has_scale in attn_projs:
+            m[f"{prefix}.self_attn.{name}.weight"] = WeightMapping(
+                target_path=f"model.self_attn.{name}.weight",
+                sharding=axes,
+                transpose=True,
+                kv_head_padding=kv_pad,
+            )
+            if has_scale:
+                m[f"{prefix}.self_attn.{name}.weight_scale_inv"] = WeightMapping(
+                    target_path=f"model.self_attn.{name}.weight_scale_inv",
+                    sharding=axes,
+                    transpose=True,
+                    kv_head_padding=kv_pad,
+                )
+        for name, axes in (
+            ("gate_proj", (None, "tensor")),
+            ("up_proj", (None, "tensor")),
+            ("down_proj", ("tensor", None)),
+        ):
+            m[f"{prefix}.mlp.{name}.weight"] = WeightMapping(
+                target_path=f"model.mlp.{name}.weight",
+                sharding=axes,
+                transpose=True,
+            )
+            m[f"{prefix}.mlp.{name}.weight_scale_inv"] = WeightMapping(
+                target_path=f"model.mlp.{name}.weight_scale_inv",
+                sharding=axes,
+                transpose=True,
+            )
+        return m
+
+    def get_embed_and_head(self):
+        return (
+            self.model.embed_tokens.embedding.value,
+            self.lm_head.embedding.value,
+        )
+
+    def set_embed_and_head(
+        self,
+        embed_weight: jax.Array | None = None,
+        head_weight: jax.Array | None = None,
+    ) -> None:
+        if embed_weight is not None:
+            self.model.embed_tokens.embedding.value = embed_weight
+        if head_weight is not None:
+            self.lm_head.embedding.value = head_weight
+
+
+EntryClass = MiMoV2FlashMTPForCausalLM

--- a/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
@@ -184,9 +184,7 @@ class MiMoV2FlashMTPForCausalLM(nnx.Module):
             head_dim = self.config.swa_head_dim
             v_head_dim = self.config.swa_v_head_dim
             layers = [self.model]
-            self.loader.dequant_fp8_layers(
-                layers, specs=[("self_attn.q_proj", head_dim)]
-            )
+            self.loader.dequant_fp8_layers(layers, specs=[("self_attn.q_proj", head_dim)])
             self.loader.dequant_fused_kv(self._kv_buffers, layers, self.config)
             self.loader.dequant_fp8_layers(
                 layers,

--- a/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
@@ -173,7 +173,7 @@ class MiMoV2FlashMTPForCausalLM(nnx.Module):
                 logits_metadata,
                 aux_hidden_states=None,
             )
-        return output, layers_kv_fused, []
+        return output, layers_kv_fused, True, []
 
     def load_weights(self, model_config: ModelConfig):
         loader = WeightLoader(
@@ -280,10 +280,9 @@ class MiMoV2FlashMTPForCausalLM(nnx.Module):
         embed_weight: jax.Array | None = None,
         head_weight: jax.Array | None = None,
     ) -> None:
-        if embed_weight is not None:
-            self.model.embed_tokens.embedding.value = embed_weight
-        if head_weight is not None:
-            self.lm_head.embedding.value = head_weight
+        # embed/lm_head are loaded from the same checkpoint as the target;
+        # avoid re-assigning here to keep the nnx.Param sharding intact.
+        pass
 
 
 EntryClass = MiMoV2FlashMTPForCausalLM

--- a/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
@@ -145,6 +145,7 @@ class MiMoV2FlashMTPForCausalLM(nnx.Module):
         self.config = config
         self.dtype = dtype
         self.mesh = mesh
+        self._kv_buffers: dict = {}
         self.model = MiMoV2FlashMTPLayer(config, dtype=dtype, mesh=mesh)
         self.lm_head = ParallelLMHead(
             config.vocab_size,
@@ -176,13 +177,35 @@ class MiMoV2FlashMTPForCausalLM(nnx.Module):
         return output, layers_kv_fused, True, []
 
     def load_weights(self, model_config: ModelConfig):
-        loader = WeightLoader(
+        self.loader = WeightLoader(
             model=self, model_config=model_config, mesh=self.mesh, dtype=self.dtype
         )
-        loader.load_weights_from_safetensors(self._create_weight_mappings())
+        is_fp8 = self.loader.is_static_quant
+        self.loader.load_weights_from_safetensors(self._create_weight_mappings(is_fp8))
+        if is_fp8:
+            head_dim = self.config.swa_head_dim
+            v_head_dim = self.config.swa_v_head_dim
+            layers = [self.model]
+            self.loader.dequant_fp8_layers(
+                layers, specs=[("self_attn.q_proj", head_dim)]
+            )
+            self.loader.dequant_fused_kv(self._kv_buffers, layers, self.config)
+            self.loader.dequant_fp8_layers(
+                layers,
+                specs=[
+                    ("mlp.gate_proj", None),
+                    ("mlp.up_proj", None),
+                    ("mlp.down_proj", None),
+                ],
+            )
+            self.loader.replicate_kv_heads(
+                layers,
+                specs=[("self_attn.k_proj", head_dim), ("self_attn.v_proj", v_head_dim)],
+                target_kv_heads_fn=lambda attn: attn.k_head_num,
+            )
         logger.info("MiMo-V2 MTP draft weights loaded successfully!")
 
-    def _create_weight_mappings(self) -> dict:
+    def _create_weight_mappings(self, is_fp8: bool) -> dict:
         prefix = "model.mtp.layers.0"
         m: dict[str, WeightMapping] = {
             "model.embed_tokens.weight": WeightMapping(
@@ -227,29 +250,51 @@ class MiMoV2FlashMTPForCausalLM(nnx.Module):
                 transpose=False,
             ),
         }
-        is_fp8 = getattr(self.config, "quantization_config", None) is not None
-        # q/k/v_proj + mlp are FP8 (have weight_scale_inv) → QuantizedLinear (weight_q/weight_scale).
-        # o_proj + eh_proj are bf16 → ignored_layers → plain LinearBase (weight).
-        attn_projs = (
-            ("q_proj", (None, "tensor"), False, True),
-            ("k_proj", (None, "tensor"), True, True),
-            ("v_proj", (None, "tensor"), True, True),
-            ("o_proj", ("tensor", None), False, False),
-        )
-        for name, axes, kv_pad, fp8 in attn_projs:
-            wsuf = "weight_q" if (is_fp8 and fp8) else "weight"
-            m[f"{prefix}.self_attn.{name}.weight"] = WeightMapping(
-                target_path=f"model.self_attn.{name}.{wsuf}",
-                sharding=axes,
+        # Mirror target weight loading: q_proj loads into QuantizedLinear and is
+        # dequantised to bf16 post-load; K/V go through the fused per-head path
+        # (#969); o_proj is bf16 in the checkpoint (ignored_layers).
+        if is_fp8:
+            m[f"{prefix}.self_attn.q_proj.weight"] = WeightMapping(
+                target_path="model.self_attn.q_proj.weight_q",
+                sharding=(None, "tensor"),
                 transpose=True,
-                kv_head_padding=kv_pad,
+                head_dim_padding=True,
             )
-            if is_fp8 and fp8:
-                m[f"{prefix}.self_attn.{name}.weight_scale_inv"] = WeightMapping(
-                    target_path=f"model.self_attn.{name}.weight_scale",
+            m[f"{prefix}.self_attn.q_proj.weight_scale_inv"] = WeightMapping(
+                target_path="model.self_attn.q_proj.weight_scale",
+                sharding=(None, None),
+                transpose=False,
+            )
+            for kv, name in (("K", "k_proj"), ("V", "v_proj")):
+                m[f"{prefix}.self_attn.{name}.weight"] = WeightMapping(
+                    target_path=f"__KV_{kv}_WEIGHT__0",
                     sharding=(None, None),
                     transpose=False,
                 )
+                m[f"{prefix}.self_attn.{name}.weight_scale_inv"] = WeightMapping(
+                    target_path=f"__KV_{kv}_SCALE__0",
+                    sharding=(None, None),
+                    transpose=False,
+                )
+        else:
+            for name, axes, kv_pad in (
+                ("q_proj", (None, "tensor"), False),
+                ("k_proj", (None, "tensor"), True),
+                ("v_proj", (None, "tensor"), True),
+            ):
+                m[f"{prefix}.self_attn.{name}.weight"] = WeightMapping(
+                    target_path=f"model.self_attn.{name}.weight",
+                    sharding=axes,
+                    transpose=True,
+                    head_dim_padding=True,
+                    kv_head_padding=kv_pad,
+                )
+        m[f"{prefix}.self_attn.o_proj.weight"] = WeightMapping(
+            target_path="model.self_attn.o_proj.weight",
+            sharding=("tensor", None),
+            transpose=True,
+            head_dim_padding=True,
+        )
         for name, axes in (
             ("gate_proj", (None, "tensor")),
             ("up_proj", (None, "tensor")),

--- a/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
@@ -227,22 +227,26 @@ class MiMoV2FlashMTPForCausalLM(nnx.Module):
                 transpose=False,
             ),
         }
+        is_fp8 = getattr(self.config, "quantization_config", None) is not None
+        # q/k/v_proj + mlp are FP8 (have weight_scale_inv) → QuantizedLinear (weight_q/weight_scale).
+        # o_proj + eh_proj are bf16 → ignored_layers → plain LinearBase (weight).
         attn_projs = (
             ("q_proj", (None, "tensor"), False, True),
             ("k_proj", (None, "tensor"), True, True),
             ("v_proj", (None, "tensor"), True, True),
             ("o_proj", ("tensor", None), False, False),
         )
-        for name, axes, kv_pad, has_scale in attn_projs:
+        for name, axes, kv_pad, fp8 in attn_projs:
+            wsuf = "weight_q" if (is_fp8 and fp8) else "weight"
             m[f"{prefix}.self_attn.{name}.weight"] = WeightMapping(
-                target_path=f"model.self_attn.{name}.weight",
+                target_path=f"model.self_attn.{name}.{wsuf}",
                 sharding=axes,
                 transpose=True,
                 kv_head_padding=kv_pad,
             )
-            if has_scale:
+            if is_fp8 and fp8:
                 m[f"{prefix}.self_attn.{name}.weight_scale_inv"] = WeightMapping(
-                    target_path=f"model.self_attn.{name}.weight_scale_inv",
+                    target_path=f"model.self_attn.{name}.weight_scale",
                     sharding=axes,
                     transpose=True,
                     kv_head_padding=kv_pad,
@@ -252,16 +256,18 @@ class MiMoV2FlashMTPForCausalLM(nnx.Module):
             ("up_proj", (None, "tensor")),
             ("down_proj", ("tensor", None)),
         ):
+            wsuf = "weight_q" if is_fp8 else "weight"
             m[f"{prefix}.mlp.{name}.weight"] = WeightMapping(
-                target_path=f"model.mlp.{name}.weight",
+                target_path=f"model.mlp.{name}.{wsuf}",
                 sharding=axes,
                 transpose=True,
             )
-            m[f"{prefix}.mlp.{name}.weight_scale_inv"] = WeightMapping(
-                target_path=f"model.mlp.{name}.weight_scale_inv",
-                sharding=axes,
-                transpose=True,
-            )
+            if is_fp8:
+                m[f"{prefix}.mlp.{name}.weight_scale_inv"] = WeightMapping(
+                    target_path=f"model.mlp.{name}.weight_scale",
+                    sharding=axes,
+                    transpose=True,
+                )
         return m
 
     def get_embed_and_head(self):

--- a/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash_mtp.py
@@ -106,15 +106,13 @@ class MiMoV2FlashMTPLayer(nnx.Module):
         token_mask = (forward_batch.positions != 0).astype(token_embeds.dtype)[:, None]
         token_embeds = token_embeds * token_mask
 
-        hidden_states, _ = self.eh_proj(
-            jnp.concatenate(
-                (
-                    self.enorm(token_embeds),
-                    self.hnorm(forward_batch.spec_info.hidden_states),
-                ),
-                axis=-1,
-            )
-        )
+        e = self.enorm(token_embeds)
+        h = self.hnorm(forward_batch.spec_info.hidden_states.astype(e.dtype))
+        # spec_info.hidden_states arrives with whatever sharding the host-side
+        # eagle orchestration left it (P() after verify, P("data",None) after
+        # target extend). Align to the embed sharding before concat.
+        h = jax.sharding.reshard(h, jax.typeof(e).sharding)
+        hidden_states, _ = self.eh_proj(jnp.concatenate((e, h), axis=-1))
 
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -12,7 +12,8 @@ import jax.numpy as jnp
 import numpy
 import numpy as np
 from flax import nnx
-from jax.sharding import Mesh
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
 from jax.tree_util import register_pytree_node_class
 
 from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
@@ -323,6 +324,10 @@ def build_tree_kernel_efficient(
         tuple of (tree_mask, positions, retrive_index, retrive_next_token,
                  retrive_next_sibling, draft_tokens)
     """
+    rep = NamedSharding(mesh, P())
+    verified_id, score_list, token_list, parents_list, seq_lens = jax.device_put(
+        (verified_id, score_list, token_list, parents_list, seq_lens), rep
+    )
     parent_list, top_scores_index, draft_tokens = build_tree_kernel_efficient_preprocess(
         verified_id,
         score_list,

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -502,6 +502,9 @@ class EagleDraftInput:
         model_worker_batch.positions = model_worker_batch.positions
         model_worker_batch.extend_seq_lens = np.full((bs,), step_plus_1, dtype=np.int32)
         model_worker_batch.extend_seq_lens[model_worker_batch.real_bs :] = 0
+        model_worker_batch.logits_indices = (
+            np.cumsum(model_worker_batch.extend_seq_lens, dtype=np.int32) - 1
+        )
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
         model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.FULL
         model_worker_batch.forward_mode = ForwardMode.DRAFT_EXTEND

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -265,19 +265,22 @@ class EAGLEWorker(ModelWorker):
 
     def _reshard_logits(self, logits: jax.Array) -> jax.Array:
         # logits_processor outputs vocab-sharded P("data","tensor"); top_k can't
-        # produce a (bs, k) result with k % tp != 0 under that spec. All-gather
-        # vocab first (mirrors Sampler.__call__ at sampler.py:34).
-        return jax.device_put(logits, NamedSharding(self.mesh, P("data", None)))
+        # produce a (bs, k) result with k % tp != 0 under that spec. Fully
+        # replicate so the downstream eagle host-side orchestration
+        # (select_top_k_tokens / update_eagle_lists / build_tree) never hits
+        # explicit-sharding scatter ambiguities.
+        return jax.device_put(logits, NamedSharding(self.mesh, P()))
 
     def capture_for_decode(
         self, logits_output: LogitsProcessorOutput, draft_input: EagleDraftInput
     ):
+        rep = NamedSharding(self.mesh, P())
         topk_p, topk_index = topk_probs_from_logits(
             self._reshard_logits(logits_output.next_token_logits), self.topk
         )
-        draft_input.topk_p = topk_p
-        draft_input.topk_index = topk_index
-        draft_input.hidden_states = logits_output.hidden_states
+        draft_input.topk_p = jax.device_put(topk_p, rep)
+        draft_input.topk_index = jax.device_put(topk_index, rep)
+        draft_input.hidden_states = jax.device_put(logits_output.hidden_states, rep)
 
     def get_padding_bs(self, real_bs: int) -> int:
         self.precompile_bs_paddings.sort()
@@ -618,9 +621,12 @@ class EAGLEWorker(ModelWorker):
         )
 
         # prepare for next draft decode
-        batch_output.next_draft_input.hidden_states = draft_logits_output.hidden_states
-        batch_output.next_draft_input.topk_p = topk_p
-        batch_output.next_draft_input.topk_index = topk_index
+        rep = NamedSharding(self.mesh, P())
+        batch_output.next_draft_input.hidden_states = jax.device_put(
+            draft_logits_output.hidden_states, rep
+        )
+        batch_output.next_draft_input.topk_p = jax.device_put(topk_p, rep)
+        batch_output.next_draft_input.topk_index = jax.device_put(topk_index, rep)
         batch_output.next_draft_input.verified_id = batch_output.next_draft_input.verified_id[
             select_index
         ]
@@ -690,7 +696,9 @@ class EAGLEWorker(ModelWorker):
 
             if self.hot_token_ids is not None:
                 topk_index = self.hot_token_ids[topk_index]
-            hidden_states = logits_output.hidden_states
+            hidden_states = jax.device_put(
+                logits_output.hidden_states, NamedSharding(self.mesh, P())
+            )
 
         return score_list, token_list, parents_list
 

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -420,9 +420,7 @@ class EAGLEWorker(ModelWorker):
             retrive_next_sibling,
             draft_tokens,
         ) = build_tree_kernel_efficient(
-            jax.device_put(
-                model_worker_batch.spec_info.verified_id, NamedSharding(self.mesh, P())
-            ),
+            jax.device_put(model_worker_batch.spec_info.verified_id, NamedSharding(self.mesh, P())),
             score_list,
             token_list,
             parents_list,
@@ -617,9 +615,7 @@ class EAGLEWorker(ModelWorker):
         draft_logits_output.next_token_logits = jax.device_put(
             draft_logits_output.next_token_logits, rep
         )
-        draft_logits_output.hidden_states = jax.device_put(
-            draft_logits_output.hidden_states, rep
-        )
+        draft_logits_output.hidden_states = jax.device_put(draft_logits_output.hidden_states, rep)
         select_index = (
             np.arange(len(model_worker_batch.seq_lens[: model_worker_batch.real_bs]))
             * (self.speculative_num_steps + 1)

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -778,6 +778,11 @@ def topk_probs_from_logits(
 ) -> tuple[jax.Array, jax.Array]:
     """Return top-k probabilities without materializing the full softmax tensor."""
     working_logits = jnp.moveaxis(logits, axis, -1) if axis != -1 else logits
+    # logits arrive vocab-sharded P("data","tensor"); top_k output (bs, k) would
+    # inherit that spec and fail when k % tp != 0. Replicate vocab first
+    # (matches Sampler.__call__ reshard at sampler.py:34).
+    if working_logits.ndim == 2:
+        working_logits = jax.sharding.reshard(working_logits, P("data", None))
     topk_logits, topk_index = jax.lax.top_k(working_logits, topk)
     logsumexp = jax.nn.logsumexp(working_logits, axis=-1, keepdims=True)
     topk_probs = jnp.exp(topk_logits - logsumexp)

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -613,6 +613,13 @@ class EAGLEWorker(ModelWorker):
             forward_batch,
             logits_metadata=logits_meatadata,
         )
+        rep = NamedSharding(self.mesh, P())
+        draft_logits_output.next_token_logits = jax.device_put(
+            draft_logits_output.next_token_logits, rep
+        )
+        draft_logits_output.hidden_states = jax.device_put(
+            draft_logits_output.hidden_states, rep
+        )
         select_index = (
             np.arange(len(model_worker_batch.seq_lens[: model_worker_batch.real_bs]))
             * (self.speculative_num_steps + 1)
@@ -622,16 +629,13 @@ class EAGLEWorker(ModelWorker):
         draft_logits_output.next_token_logits = draft_logits_output.next_token_logits[select_index]
         draft_logits_output.hidden_states = draft_logits_output.hidden_states[select_index]
         topk_p, topk_index = topk_probs_from_logits(
-            self._reshard_logits(draft_logits_output.next_token_logits), self.topk
+            draft_logits_output.next_token_logits, self.topk
         )
 
         # prepare for next draft decode
-        rep = NamedSharding(self.mesh, P())
-        batch_output.next_draft_input.hidden_states = jax.device_put(
-            draft_logits_output.hidden_states, rep
-        )
-        batch_output.next_draft_input.topk_p = jax.device_put(topk_p, rep)
-        batch_output.next_draft_input.topk_index = jax.device_put(topk_index, rep)
+        batch_output.next_draft_input.hidden_states = draft_logits_output.hidden_states
+        batch_output.next_draft_input.topk_p = topk_p
+        batch_output.next_draft_input.topk_index = topk_index
         batch_output.next_draft_input.verified_id = batch_output.next_draft_input.verified_id[
             select_index
         ]

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -263,10 +263,18 @@ class EAGLEWorker(ModelWorker):
     def draft_model_runner(self):
         return self.get_model_runner()
 
+    def _reshard_logits(self, logits: jax.Array) -> jax.Array:
+        # logits_processor outputs vocab-sharded P("data","tensor"); top_k can't
+        # produce a (bs, k) result with k % tp != 0 under that spec. All-gather
+        # vocab first (mirrors Sampler.__call__ at sampler.py:34).
+        return jax.device_put(logits, NamedSharding(self.mesh, P("data", None)))
+
     def capture_for_decode(
         self, logits_output: LogitsProcessorOutput, draft_input: EagleDraftInput
     ):
-        topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
+        topk_p, topk_index = topk_probs_from_logits(
+            self._reshard_logits(logits_output.next_token_logits), self.topk
+        )
         draft_input.topk_p = topk_p
         draft_input.topk_index = topk_index
         draft_input.hidden_states = logits_output.hidden_states
@@ -606,7 +614,7 @@ class EAGLEWorker(ModelWorker):
         draft_logits_output.next_token_logits = draft_logits_output.next_token_logits[select_index]
         draft_logits_output.hidden_states = draft_logits_output.hidden_states[select_index]
         topk_p, topk_index = topk_probs_from_logits(
-            draft_logits_output.next_token_logits, self.topk
+            self._reshard_logits(draft_logits_output.next_token_logits), self.topk
         )
 
         # prepare for next draft decode
@@ -676,7 +684,9 @@ class EAGLEWorker(ModelWorker):
                 logits_metadata=logits_metadata,
             )
 
-            topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
+            topk_p, topk_index = topk_probs_from_logits(
+                self._reshard_logits(logits_output.next_token_logits), self.topk
+            )
 
             if self.hot_token_ids is not None:
                 topk_index = self.hot_token_ids[topk_index]
@@ -778,11 +788,6 @@ def topk_probs_from_logits(
 ) -> tuple[jax.Array, jax.Array]:
     """Return top-k probabilities without materializing the full softmax tensor."""
     working_logits = jnp.moveaxis(logits, axis, -1) if axis != -1 else logits
-    # logits arrive vocab-sharded P("data","tensor"); top_k output (bs, k) would
-    # inherit that spec and fail when k % tp != 0. Replicate vocab first
-    # (matches Sampler.__call__ reshard at sampler.py:34).
-    if working_logits.ndim == 2:
-        working_logits = jax.sharding.reshard(working_logits, P("data", None))
     topk_logits, topk_index = jax.lax.top_k(working_logits, topk)
     logsumexp = jax.nn.logsumexp(working_logits, axis=-1, keepdims=True)
     topk_probs = jnp.exp(topk_logits - logsumexp)

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -469,6 +469,9 @@ class EAGLEWorker(ModelWorker):
         logits_output, _, cache_miss_count = self.target_worker.forward_batch_generation(
             model_worker_batch, skip_sample=True, forward_metadata=forward_metadata
         )
+        rep = NamedSharding(self.mesh, P())
+        logits_output.next_token_logits = jax.device_put(logits_output.next_token_logits, rep)
+        logits_output.hidden_states = jax.device_put(logits_output.hidden_states, rep)
         spec_info.hidden_states = logits_output.hidden_states
         (
             predict,

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -420,7 +420,9 @@ class EAGLEWorker(ModelWorker):
             retrive_next_sibling,
             draft_tokens,
         ) = build_tree_kernel_efficient(
-            model_worker_batch.spec_info.verified_id,
+            jax.device_put(
+                model_worker_batch.spec_info.verified_id, NamedSharding(self.mesh, P())
+            ),
             score_list,
             token_list,
             parents_list,


### PR DESCRIPTION

## Summary

Adds NEXTN/EAGLE speculative-decoding draft model for MiMo-V2-Flash / V2.5 / V2.5-Pro
(single-layer SWA attention + dense FFN, loaded from `model.mtp.layers.0` in the same
checkpoint), and fixes the EAGLE path which has been broken on `main` since #939 (DP
refactor) / #940 (sampler RNG fold_in).

Closes #192.

### Verified on v6e-16 (V2-Flash, tp=16 ep=16)
- **accept-len mean 2.77** (topk=1, num_steps=3, num_draft=4) — H100 reference: 2.92
- greedy output **token-identical** to no-MTP on 3/4 test prompts (4th diverges at
  token[1] due to bf16 batch-4 vs batch-1 reduction order, both outputs valid)
- arithmetic / code-completion prompts produce correct results

### Launch
```bash
python -m sgl_jax.launch_server \
    --model-path <hf-or-local> --trust-remote-code \
    --tp-size 16 --ep-size 16 --moe-backend epmoe \
    --speculative-algorithm EAGLE \
    --speculative-draft-model-path <same-as-model-path> \
    --speculative-num-steps 3 --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4 \
    --disable-overlap-schedule \
    ...
```

## Change breakdown (will split into 3 PRs if preferred)

### A. EAGLE-path regressions since #939/#940 (independent of MiMo)
Any EAGLE/NEXTN draft model crashes on current `main`:
- `model_runner._sampler_base_rng` only set when `not is_draft_worker`, but
  `EAGLEWorker` calls `initialize_jit()` which reads it (#940)
- `get_spec_model_worker_batch` still references pre-#939 flat attrs
  (`self.extend_lens` / `self.seq_lens` / `self.spec_info` / ...) and misses
  `real_bs_per_dp` / `_merge_sampling_info` / `per_dp_bs_size`
- explicit-sharding mode: `top_k` on vocab-sharded logits fails; host-side
  `jnp.at[].set` / `concatenate` / gather hit `ShardingTypeError` because jit
  outputs carry P("data","tensor") into eager ops
- `mimo_mtp.py` still returns 3-tuple (model_runner unpacks 4)
- `prepare_for_extend_after_verify` doesn't set `logits_indices`

Fix: `__getattr__`/`__setattr__` shim on `ScheduleBatch` routing to `reqs_info[0]`
(spec is dp=1 only for now), replicate jit outputs to `P()` at every host-side
boundary, add missing MWB fields.

### B. `ragged_paged_attention_v3` custom_mask DMA at TARGET_VERIFY
Mosaic requires dynamic slice offset+size to be tiling(8)-aligned, but
`kv_len = seq_len + num_draft_tokens` is not. `_fetch_mask` fails to compile.

Fix: host pads each draft-token row of `custom_mask` to page-aligned `kv_len`
(stable shape across decode steps → no per-step recompile), kernel uses
`mask_kv_len = cu_kv_lens[seq+1]-cu_kv_lens[seq]` for mask stride only, keeping
the unaligned `kv_len` for `_fetch_bkv`'s cache/new-KV split. `pl.multiple_of`
hints prove divisibility.

Also: `get_eagle_forward_metadata` now computes `swa_page_indices` for hybrid
SWA+full targets (otherwise SWA layers index the swa sub-pool with full-pool
page ids during verify).

Ref `q_span/kv_span` hoist (already noted in #192).

### C. `MiMoV2FlashMTPForCausalLM`
- single `MiMoV2FlashMTPLayer` reusing `MiMoV2Attention` + `MiMoV2MLP`
- weight load mirrors target's FP8→bf16 dequant pipeline (`dequant_fp8_layers` +
  `dequant_fused_kv` + `replicate_kv_heads`); K/V via `__KV_*__0` buffers
- `model_config` maps `MiMoV2{Flash,}ForCausalLM` → MTP class when `is_draft_model`,
  forces `num_hidden_layers=1`, adds `eh_proj`/`o_proj` to `ignored_layers`
- `MiMoV2FlashForCausalLM.get_embed_and_head()` for draft head sharing

## Known limitations / follow-ups
- **host-orchestration overhead**: per-decode-round `device_put` resharding +
  eager `update_eagle_lists` make MTP ITL currently *worse* than no-MTP at bs=1
  (~18ms vs ~7ms warm). Needs jit-fusion of draft loop. accept-len is correct.
- spec path is dp=1 only (`__getattr__` shim assumes `reqs_info[0]`)
- `--disable-precompile` required (precompile_spec_* not yet adapted)
- KV-pool free on req finish leaks 1 page/req under spec path (allocate_lens vs output_ids accounting) — long-running will OOM
- only `mtp.layers.0` is loaded (3-layer multi-step EAGLE is a follow-up)

## Test plan
- [ ] `pytest test/test_rpa_custom_mask_verify.py` on v6e-4 (TBD)
- [x] v6e-16 V2-Flash e2e: accept-len 2.77, greedy 3/4 token-identical
- [ ] GSM8K-100 accuracy parity
- [ ] V2.5-Pro v6e-64