### PR TITLE
feat(kda): add KDA attention components

### DIFF
--- a/python/sgl_jax/srt/kernels/kda/__init__.py
+++ b/python/sgl_jax/srt/kernels/kda/__init__.py
@@ -1,0 +1,4 @@
+from sgl_jax.srt.kernels.kda.kda import chunk_kda_fwd as chunk_kda
+from sgl_jax.srt.kernels.kda.naive import naive_recurrent_kda
+
+__all__ = ["chunk_kda", "naive_recurrent_kda"]

--- a/python/sgl_jax/srt/kernels/kda/kda.py
+++ b/python/sgl_jax/srt/kernels/kda/kda.py
@@ -1,0 +1,1278 @@
+# Adapted from https://github.com/primatrix/pallas-kernel (rev 3c691ad3)
+# Vendored to remove external dependency after the upstream repository went private.
+#
+# This file merges the following modules into a single file:
+#   - tops/utils.py (cdiv, align_up, pad_to_multiple, prepare_lens, prepare_chunk_indices, assert_shape, assert_shape_or_none)
+#   - tops/ops/utils.py (exp, exp2, get_interpret)
+#   - tops/ops/common/cumsum.py (chunk_local_cumsum_vector via _chunk_cumsum_kernel)
+#   - tops/ops/kda/chunk_intra_fwd.py (_solve_unit_lower_triangular, _kda_fwd_intra_kernel, kda_fwd_intra)
+#   - tops/ops/common/chunk_delta_h.py (_prepare_chunk_offsets, _chunk_gated_delta_rule_fwd_kernel, chunk_gated_delta_rule_fwd_h)
+#   - tops/ops/gla/chunk.py (_chunk_kda_fwd_o_gk_varlen_kernel renamed to _chunk_kda_fwd_o_gk_pl_kernel, chunk_kda_fwd_o_gk_varlen renamed to chunk_kda_fwd_o_gk)
+#   - tops/ops/kda/gate.py (kda_gate_chunk_cumsum, pallas_kda_gate_cumsum)
+#   - tops/ops/kda/chunk_fwd.py (_align_seqs, _unalign_output, chunk_kda_fwd)
+"""KDA chunked forward pass for variable-length sequences (self-contained)."""
+
+from __future__ import annotations
+
+import functools
+import math
+import os
+from functools import singledispatch
+
+import jax
+import jax.experimental.pallas as pl
+import jax.numpy as jnp
+from jax.experimental.pallas import dslice
+from jax.experimental.pallas import tpu as pltpu
+
+# ============================================================================
+# Utilities
+# ============================================================================
+
+
+@singledispatch
+def cdiv(x: int, y: int):
+    return (x + y - 1) // y
+
+
+@cdiv.register
+def _cdiv_jax(x: jax.Array, y: int):
+    return (x + y - 1) // y
+
+
+def align_up(x: int, align: int):
+    return cdiv(x, align) * align
+
+
+@singledispatch
+def pad_to_multiple(x, multiple: int, axis: int, val):
+    raise NotImplementedError(f"pad_to_multiple is not implemented for type {type(x)}")
+
+
+@pad_to_multiple.register
+def _pad_to_multiple_jax(x: jax.Array, multiple: int | list, axis: int | list, val):
+    if isinstance(multiple, int):
+        multiple = [multiple]
+    if isinstance(axis, int):
+        axis = [axis]
+    assert len(multiple) == len(axis)
+    shape = list(x.shape)
+    pad_width = [(0, 0)] * len(shape)
+    for idx in range(len(axis)):
+        ax = axis[idx]
+        mu = multiple[idx]
+        remainder = shape[ax] % mu
+        if remainder != 0:
+            pad_width[ax] = (0, mu - remainder)
+    return jnp.pad(x, pad_width, constant_values=val)
+
+
+def prepare_lens(cu_seqlens: jax.Array) -> jax.Array:
+    return cu_seqlens[1:] - cu_seqlens[:-1]
+
+
+def prepare_chunk_indices(
+    cu_seqlens: jax.Array,
+    chunk_size: int,
+    max_T: int | None = None,
+) -> jax.Array:
+    lens = prepare_lens(cu_seqlens)
+    n_chunks = cdiv(lens, chunk_size)
+    num_seqs = len(lens)
+    total_nt = max_T // chunk_size
+    seq_ids = jnp.repeat(
+        jnp.arange(num_seqs, dtype=jnp.int32), n_chunks, total_repeat_length=total_nt
+    )
+    prefix_chunks = jnp.concatenate([jnp.zeros(1, dtype=jnp.int32), jnp.cumsum(n_chunks)])
+    seq_offsets = jnp.repeat(prefix_chunks[:-1], n_chunks, total_repeat_length=total_nt)
+    block_ids = jnp.arange(total_nt, dtype=jnp.int32) - seq_offsets
+    return jnp.stack([seq_ids, block_ids], axis=1)
+
+
+def assert_shape_or_none(x, expected_shape, name="tensor"):
+    if x is None:
+        return
+    if isinstance(x, (list, tuple)):
+        has_names = isinstance(name, (list, tuple)) and len(name) == len(x)
+        for i, tensor in enumerate(x):
+            if tensor is not None:
+                curr_name = name[i] if has_names else f"{name}_{i}"
+                assert (
+                    tensor.shape == expected_shape
+                ), f"[{curr_name}] Expected shape {expected_shape}, got {tensor.shape}"
+    else:
+        assert x.shape == expected_shape, f"[{name}] Expected shape {expected_shape}, got {x.shape}"
+
+
+def assert_shape(x, expected_shape, name="tensor"):
+    if isinstance(x, (list, tuple)):
+        has_names = isinstance(name, (list, tuple)) and len(name) == len(x)
+        for i, tensor in enumerate(x):
+            curr_name = name[i] if has_names else f"{name}_{i}"
+            assert (
+                tensor.shape == expected_shape
+            ), f"[{curr_name}] Expected shape {expected_shape}, got {tensor.shape}"
+    else:
+        assert x.shape == expected_shape, f"[{name}] Expected shape {expected_shape}, got {x.shape}"
+
+
+def exp(x):
+    return jnp.exp(x.astype(jnp.float32))
+
+
+def exp2(x):
+    return jnp.exp2(x.astype(jnp.float32))
+
+
+def get_interpret() -> bool:
+    env = os.environ.get("PALLAS_INTERPRET", "")
+    return env.strip().lower() in ("1", "true")
+
+
+# ============================================================================
+# Chunk-local cumulative sum (varlen Pallas kernel only)
+# ============================================================================
+
+_VMEM_HW_LIMIT_BYTES = 30 * 1024 * 1024
+
+
+def _chunk_cumsum_kernel(
+    cu_seqlens_ref,
+    chunk_indices_ref,
+    s_ref,
+    o_ref,
+    *,
+    BT: int,
+    NT: int,
+    REVERSE: bool,
+    HAS_SCALE: bool,
+    scale: float,
+):
+    num_steps = int(math.log2(BT))
+
+    def body(i_t, _):
+        i_n = chunk_indices_ref[i_t, 0]
+        local_i_t = chunk_indices_ref[i_t, 1]
+        bos = cu_seqlens_ref[i_n]
+        start_t = bos + local_i_t * BT
+        start_t = pl.multiple_of(start_t, BT)
+
+        s = s_ref[:, dslice(start_t, BT), :].astype(jnp.float32)
+
+        if REVERSE:
+            for d in range(num_steps):
+                stride = 1 << d
+                top = s[:, : BT - stride, :] + s[:, stride:, :]
+                bot = s[:, BT - stride :, :]
+                s = jnp.concatenate([top, bot], axis=1)
+        else:
+            for d in range(num_steps):
+                stride = 1 << d
+                top = s[:, :stride, :]
+                bot = s[:, stride:, :] + s[:, :-stride, :]
+                s = jnp.concatenate([top, bot], axis=1)
+
+        if HAS_SCALE:
+            s = s * scale
+
+        o_ref[:, dslice(start_t, BT), :] = s.astype(o_ref.dtype)
+        return 0
+
+    jax.lax.fori_loop(0, NT, body, 0)
+
+
+def chunk_local_cumsum_vector(
+    g: jax.Array,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: float | None = None,
+    cu_seqlens: jax.Array | None = None,
+    head_first: bool = False,
+    output_dtype: jnp.dtype | None = jnp.float32,
+    chunk_indices: jax.Array | None = None,
+) -> jax.Array:
+    assert g.ndim == 4, f"g must be 4-D, got {g.ndim}-D"
+    assert chunk_size == 2 ** (chunk_size.bit_length() - 1), "chunk_size must be power of 2"
+    assert cu_seqlens is not None, "This varlen-only module requires cu_seqlens"
+
+    BT = chunk_size
+    BS = 128
+    BB = 8
+
+    if head_first:
+        B, H, T, S = g.shape
+        g_flat = g.reshape(B * H, T, S)
+    else:
+        B, T, H, S = g.shape
+        g_flat = jnp.transpose(g, (0, 2, 1, 3)).reshape(B * H, T, S)
+
+    BH = B * H
+    out_dtype = output_dtype or g.dtype
+    HAS_SCALE = scale is not None
+    scale_val = scale if scale is not None else 1.0
+
+    interpret = get_interpret()
+
+    pad_S = (BS - (S % BS)) % BS
+    if pad_S > 0:
+        g_flat = jnp.pad(g_flat, ((0, 0), (0, 0), (0, pad_S)))
+    S_padded = S + pad_S
+    NS = S_padded // BS
+
+    pad_BH = (BB - (BH % BB)) % BB
+    if pad_BH > 0:
+        g_flat = jnp.pad(g_flat, ((0, pad_BH), (0, 0), (0, 0)))
+    BH_padded = BH + pad_BH
+
+    if chunk_indices is None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = len(chunk_indices)
+
+    g_flat = jnp.pad(g_flat, ((0, 0), (0, BT), (0, 0)))
+    T_alloc = T + BT
+
+    elem_bytes = 4
+    while BB > 1 and 4 * BB * T_alloc * BS * elem_bytes > _VMEM_HW_LIMIT_BYTES:
+        BB //= 2
+    NBH = BH_padded // BB
+
+    grid = (NS, NBH)
+    kernel = functools.partial(
+        _chunk_cumsum_kernel,
+        BT=BT,
+        NT=NT,
+        REVERSE=reverse,
+        HAS_SCALE=HAS_SCALE,
+        scale=scale_val,
+    )
+
+    def _index_map(i_s, i_bb, *_):
+        return (i_bb, 0, i_s)
+
+    o_flat = pl.pallas_call(
+        kernel,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=2,
+            grid=grid,
+            in_specs=[pl.BlockSpec(block_shape=(BB, T_alloc, BS), index_map=_index_map)],
+            out_specs=pl.BlockSpec(block_shape=(BB, T_alloc, BS), index_map=_index_map),
+        ),
+        out_shape=jax.ShapeDtypeStruct(g_flat.shape, out_dtype),
+        interpret=interpret,
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "parallel")),
+    )(cu_seqlens, chunk_indices, g_flat)
+
+    o_flat = o_flat[:BH, :T, :S]
+
+    if head_first:
+        return o_flat.reshape(B, H, T, S)
+    else:
+        return jnp.transpose(o_flat.reshape(B, H, T, S), (0, 2, 1, 3))
+
+
+# ============================================================================
+# KDA intra-chunk forward (varlen only)
+# ============================================================================
+
+
+def _solve_unit_lower_triangular(A, b):
+    N, D = b.shape
+    BS = 16
+    num_blocks = N // BS
+    A = A.astype(jnp.float32)
+    b = b.astype(jnp.float32)
+
+    blocks = jnp.split(b, num_blocks, axis=0)
+
+    for i in range(num_blocks):
+        start = i * BS
+        end = (i + 1) * BS
+        A_ii = A[start:end, start:end]
+        x_block = blocks[i]
+
+        rows = [x_block[r] for r in range(BS)]
+        for j in range(BS):
+            if j > 0:
+                vec = A_ii[j, :j][None, :]
+                mat = jnp.stack(rows[:j])
+                correction = jax.lax.dot_general(
+                    vec,
+                    mat,
+                    (((1,), (0,)), ((), ())),
+                    preferred_element_type=jnp.float32,
+                ).squeeze(axis=0)
+                rows[j] = rows[j] - correction
+
+        x_block = jnp.stack(rows)
+        blocks[i] = x_block
+
+        if i < num_blocks - 1:
+            rest_start = (i + 1) * BS
+            x_rest = jnp.concatenate(blocks[i + 1 :], axis=0)
+            A_rest = A[rest_start:, start:end]
+            update = jax.lax.dot_general(
+                A_rest,
+                x_block,
+                (((1,), (0,)), ((), ())),
+                preferred_element_type=jnp.float32,
+            )
+            x_rest = x_rest - update
+            remaining = num_blocks - 1 - i
+            new_blocks = jnp.split(x_rest, remaining, axis=0)
+            for idx, nb in enumerate(new_blocks):
+                blocks[i + 1 + idx] = nb
+
+    return jnp.concatenate(blocks, axis=0)
+
+
+def _kda_fwd_intra_kernel(
+    q_ref,
+    k_ref,
+    g_ref,
+    beta_ref,
+    v_ref,
+    u_out_ref,
+    w_out_ref,
+    qg_out_ref,
+    kg_out_ref,
+    Aqk_out_ref,
+    Akk_inv_out_ref,
+    *,
+    chunk_size,
+    head_dim,
+    value_dim,
+    scale,
+    disable_recompute,
+    safe_gate,
+):
+    dtype = q_ref.dtype
+    q = q_ref[0, 0, 0]
+    k = k_ref[0, 0, 0]
+    g = g_ref[0, 0, 0]
+    beta = beta_ref[0, 0, 0]
+    v = v_ref[0, 0, 0]
+
+    BT = chunk_size
+
+    g_f32 = g.astype(jnp.float32)
+    q_f32 = q.astype(jnp.float32)
+    k_f32 = k.astype(jnp.float32)
+    beta_f32 = beta.astype(jnp.float32)
+
+    # Build Aqk and L directly using exp2(g[i] - g[j]).
+    # For causal (i >= j): g_cumsum[i] <= g_cumsum[j], so g[i]-g[j] <= 0,
+    # giving exp2 in (0, 1].  This avoids the split-normalization overflow
+    # that occurs with exp2(g-gn) when per-step gate changes exceed ~127.
+    causal_bt = jnp.tril(jnp.ones((BT, BT), dtype=jnp.float32))
+    strict_bt = jnp.tril(jnp.ones((BT, BT), dtype=jnp.float32), k=-1)
+
+    # g_diff[i, j, k] = g[i, k] - g[j, k];  shape [BT, BT, K]
+    g_diff = g_f32[:, None, :] - g_f32[None, :, :]
+    # Mask anti-causal entries to -126 before exp2 to prevent overflow;
+    # they will be zeroed by causal_bt / strict_bt anyway.
+    g_diff = jnp.where(causal_bt[:, :, None] > 0, g_diff, -126.0)
+    decay = exp2(jnp.maximum(g_diff, -126.0))  # [BT, BT, K]
+
+    # Aqk[i, j] = scale * sum_k q[i,k] * k[j,k] * decay[i,j,k]
+    Aqk = scale * jnp.sum(q_f32[:, None, :] * decay * k_f32[None, :, :], axis=-1)
+    Aqk = (Aqk * causal_bt).astype(dtype)
+
+    # L[i, j] = beta[i] * sum_k k[i,k] * k[j,k] * decay[i,j,k]   (i > j)
+    L = jnp.sum(k_f32[:, None, :] * decay * k_f32[None, :, :], axis=-1) * beta_f32 * strict_bt
+
+    v_beta = v.astype(jnp.float32) * beta_f32
+    k_eg_beta = k_f32 * exp2(g_f32) * beta_f32
+    identity = jnp.eye(BT, dtype=jnp.float32)
+
+    combined_b = jnp.concatenate([v_beta, k_eg_beta, identity], axis=-1)
+    combined_x = _solve_unit_lower_triangular(L, combined_b)
+
+    u = combined_x[:, :value_dim]
+    w = combined_x[:, value_dim : value_dim + head_dim]
+    A_inv = combined_x[:, value_dim + head_dim :]
+
+    g_last = g_f32[BT - 1 : BT, :]
+    kg = k_f32 * exp2(g_last - g_f32)
+
+    qg = q_f32 * exp2(g_f32) if disable_recompute else jnp.zeros_like(q_f32)
+
+    u_out_ref[0, 0, 0] = u.astype(u_out_ref.dtype)
+    w_out_ref[0, 0, 0] = w.astype(w_out_ref.dtype)
+    qg_out_ref[0, 0, 0] = qg.astype(qg_out_ref.dtype)
+    kg_out_ref[0, 0, 0] = kg.astype(kg_out_ref.dtype)
+    Aqk_out_ref[0, 0, 0] = Aqk.astype(Aqk_out_ref.dtype)
+    Akk_inv_out_ref[0, 0, 0] = A_inv.astype(Akk_inv_out_ref.dtype)
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "chunk_size",
+        "scale",
+        "safe_gate",
+        "disable_recompute",
+    ],
+)
+def kda_fwd_intra(
+    q,
+    k,
+    v,
+    gk,
+    beta,
+    scale,
+    cu_seqlens,
+    chunk_size=64,
+    chunk_indices=None,
+    safe_gate=True,
+    disable_recompute=False,
+):
+    assert cu_seqlens is not None, "cu_seqlens must be provided for varlen"
+    B, T, H, K = q.shape
+    V = v.shape[-1]
+    BT = chunk_size
+    assert B == 1, f"varlen requires B=1 (packed layout), got B={B}"
+    assert BT >= 16 and BT % 16 == 0
+
+    assert_shape(q, (B, T, H, K), "q")
+    assert_shape(k, (B, T, H, K), "k")
+    assert_shape(v, (B, T, H, V), "v")
+    assert_shape(gk, (B, T, H, K), "gk")
+    assert_shape(beta, (B, T, H), "beta")
+
+    N = cu_seqlens.shape[0] - 1
+    T_alloc = T + BT
+
+    pad4d = lambda x: jnp.pad(x, ((0, 0), (0, BT), (0, 0), (0, 0)))
+    q_pad, k_pad, gk_pad, v_pad = pad4d(q), pad4d(k), pad4d(gk), pad4d(v)
+    beta_pad = jnp.pad(beta.reshape(B, T, H, 1), ((0, 0), (0, BT), (0, 0), (0, 0)))
+
+    cu_i32 = cu_seqlens.astype(jnp.int32)
+    seq_lens = jnp.diff(cu_i32)
+    chunks_per_seq = (seq_lens + BT - 1) // BT
+    cum_chunks = jnp.pad(jnp.cumsum(chunks_per_seq), (1, 0))
+    total_chunks = cum_chunks[-1]
+
+    NC_max = len(chunk_indices) if chunk_indices is not None else T // BT + N
+    flat_idx = jnp.arange(NC_max, dtype=jnp.int32)
+    is_valid = flat_idx < total_chunks
+
+    seq_id = jnp.minimum(jnp.searchsorted(cum_chunks[1:], flat_idx, side="right"), N - 1)
+    local_ci = flat_idx - cum_chunks[seq_id]
+    bos = cu_i32[seq_id]
+    # After _align_seqs, every sequence is BT-aligned, so all chunks are full.
+    # No partial-chunk masking needed.
+    chunk_starts = jnp.where(is_valid, bos + local_ci * BT, 0)
+
+    def gather(x_pad, D):
+        def extract(start):
+            return jax.lax.dynamic_slice(x_pad, (0, start, 0, 0), (1, BT, H, D))[0]
+
+        return jax.vmap(extract)(chunk_starts)
+
+    q_c, k_c, gk_c, beta_c, v_c = (
+        gather(q_pad, K),
+        gather(k_pad, K),
+        gather(gk_pad, K),
+        gather(beta_pad, 1),
+        gather(v_pad, V),
+    )
+
+    def _to_bhnd(x):
+        return x.transpose(2, 0, 1, 3)[None]
+
+    q_r, k_r, g_r, beta_r, v_r = (
+        _to_bhnd(q_c),
+        _to_bhnd(k_c),
+        _to_bhnd(gk_c),
+        _to_bhnd(beta_c),
+        _to_bhnd(v_c),
+    )
+
+    grid = (B, H, NC_max)
+
+    def _make_spec(last_dim):
+        return pl.BlockSpec(
+            index_map=lambda i, j, n: (i, j, n, 0, 0), block_shape=(1, 1, 1, BT, last_dim)
+        )
+
+    u_r, w_r, qg_r, kg_r, Aqk_r, Akk_inv_r = pl.pallas_call(
+        functools.partial(
+            _kda_fwd_intra_kernel,
+            chunk_size=BT,
+            head_dim=K,
+            value_dim=V,
+            scale=scale,
+            disable_recompute=disable_recompute,
+            safe_gate=safe_gate,
+        ),
+        interpret=get_interpret(),
+        out_shape=[
+            jax.ShapeDtypeStruct((B, H, NC_max, BT, V), q.dtype),
+            jax.ShapeDtypeStruct((B, H, NC_max, BT, K), q.dtype),
+            jax.ShapeDtypeStruct((B, H, NC_max, BT, K), q.dtype),
+            jax.ShapeDtypeStruct((B, H, NC_max, BT, K), q.dtype),
+            jax.ShapeDtypeStruct((B, H, NC_max, BT, BT), q.dtype),
+            jax.ShapeDtypeStruct((B, H, NC_max, BT, BT), q.dtype),
+        ],
+        in_specs=[_make_spec(K), _make_spec(K), _make_spec(K), _make_spec(1), _make_spec(V)],
+        out_specs=[
+            _make_spec(V),
+            _make_spec(K),
+            _make_spec(K),
+            _make_spec(K),
+            _make_spec(BT),
+            _make_spec(BT),
+        ],
+        grid=grid,
+        compiler_params=pltpu.CompilerParams(
+            dimension_semantics=("parallel", "parallel", "parallel")
+        ),
+    )(q_r, k_r, g_r, beta_r, v_r)
+
+    pos = chunk_starts[:, None] + jnp.arange(BT)[None, :]
+    pos = jnp.where(is_valid[:, None], pos, T_alloc - 1)
+    flat_pos = pos.reshape(-1)
+
+    def _scatter(chunks_r, D):
+        chunks = chunks_r[0].transpose(1, 2, 0, 3)
+        flat_chunks = chunks.reshape(-1, H, D)
+        out = jnp.zeros((T_alloc, H, D), dtype=chunks.dtype)
+        out = out.at[flat_pos].add(flat_chunks)
+        return out[:T][None]
+
+    w_out, u_out, kg_out = _scatter(w_r, K), _scatter(u_r, V), _scatter(kg_r, K)
+    Aqk_out, Akk_out = _scatter(Aqk_r, BT), _scatter(Akk_inv_r, BT)
+    qg_out = _scatter(qg_r, K) if disable_recompute else None
+
+    return w_out, u_out, qg_out, kg_out, Aqk_out, Akk_out
+
+
+# ============================================================================
+# Delta-rule inter-chunk state propagation (varlen only)
+# ============================================================================
+
+
+def _prepare_chunk_offsets(seqlens, chunk_size):
+    return jnp.pad(
+        cdiv(jnp.diff(seqlens), chunk_size).astype(jnp.int32),
+        (1, 0),
+        constant_values=0,
+    ).cumsum(-1)
+
+
+def _chunk_gated_delta_rule_fwd_kernel(
+    seqlens_ref,
+    chunk_offsets_ref,
+    k_ref,
+    v_ref,
+    w_ref,
+    g_ref,
+    gk_ref,
+    h0_ref,
+    h_ref,
+    v_new_ref,
+    ht_ref,
+    scratch_ref,
+    *,
+    NT,
+    USE_G,
+    USE_GK,
+    USE_INITIAL_STATE,
+    STORE_FINAL_STATE,
+    SAVE_NEW_VALUE,
+    USE_EXP2,
+):
+    idx_n = pl.program_id(0)
+    idx_nt = pl.program_id(2)
+
+    bos = seqlens_ref[idx_n]
+    eos = seqlens_ref[idx_n + 1]
+    real_NT = (eos - bos) // k_ref.shape[2]
+
+    BT = k_ref.shape[2]
+    K, V = k_ref.shape[-1], v_ref.shape[-1]
+    b_k = k_ref[0, 0]
+
+    @pl.when(idx_nt == 0)
+    def _():
+        scratch_ref[...] = jnp.zeros([K, V], dtype=jnp.float32)
+        if USE_INITIAL_STATE:
+            scratch_ref[...] = h0_ref[0, 0].astype(jnp.float32)
+
+    @pl.when(idx_nt < real_NT)
+    def _():
+        h_ref[0, 0, 0] = scratch_ref[...].astype(h_ref.dtype)
+
+        b_w = w_ref[0, 0]
+        b_v = jnp.dot(
+            b_w.astype(jnp.float32),
+            scratch_ref[...],
+            precision=jax.lax.Precision.HIGHEST,
+            preferred_element_type=jnp.float32,
+        )
+        b_u = v_ref[0, 0]
+        b_v = b_u.astype(b_v.dtype) - b_v
+        if SAVE_NEW_VALUE:
+            v_new_ref[0, 0] = b_v.astype(v_new_ref.dtype)
+
+        if USE_G:
+            b_g = g_ref[0, 0, :, 0]
+            b_g_last = g_ref[0, 0, BT - 1, 0].astype(jnp.float32)
+            if USE_EXP2:
+                b_v = b_v * exp2(b_g_last - b_g)[:, None]
+                b_g_last = exp2(b_g_last)
+            else:
+                b_v = b_v * exp(b_g_last - b_g)[:, None]
+                b_g_last = exp(b_g_last)
+            scratch_ref[...] *= b_g_last
+        if USE_GK:
+            b_gk_last = gk_ref[0, 0, BT - 1].astype(jnp.float32)
+            if USE_EXP2:
+                scratch_ref[...] *= exp2(b_gk_last)[:, None]
+            else:
+                scratch_ref[...] *= exp(b_gk_last)[:, None]
+
+        scratch_ref[...] += jnp.dot(
+            b_k.astype(jnp.float32).T,
+            b_v.astype(jnp.float32),
+            precision=jax.lax.Precision.HIGHEST,
+            preferred_element_type=jnp.float32,
+        )
+
+    @pl.when(idx_nt == real_NT - 1)
+    def _():
+        if STORE_FINAL_STATE:
+            ht_ref[0, 0] = scratch_ref[...].astype(ht_ref.dtype)
+
+
+def chunk_gated_delta_rule_fwd_h(
+    k,
+    w,
+    u,
+    g=None,
+    gk=None,
+    initial_state=None,
+    output_final_state=False,
+    chunk_size=64,
+    save_new_value=True,
+    use_exp2=True,
+    cu_seqlens=None,
+    chunk_indices=None,
+):
+    B, T, H, K = k.shape
+    V = u.shape[-1]
+    BT = chunk_size
+
+    assert cu_seqlens is not None, "This varlen-only module requires cu_seqlens"
+    assert B == 1, f"varlen mode requires B==1, got B={B}"
+
+    N = cu_seqlens.shape[-1] - 1
+    assert_shape(k, (B, T, H, K), "k")
+    assert_shape(w, (B, T, H, K), "w")
+    assert_shape(u, (B, T, H, V), "u")
+    assert_shape_or_none(g, (B, T, H), "g")
+    assert_shape_or_none(gk, (B, T, H, K), "gk")
+    assert_shape_or_none(initial_state, (N, H, K, V), "initial_state")
+    assert K <= 256, "current kernel does not support head dimension larger than 256."
+
+    # --- Varlen launcher ---
+    k = k.astype(jnp.float32)
+    w = w.astype(jnp.float32)
+    u_f32 = u.astype(jnp.float32)
+
+    K_PADSIZE = int(align_up(K, 128))
+    V_ALIGNED = int(align_up(V, 128))
+
+    assert chunk_indices is not None
+    NT = len(chunk_indices)
+    NT_max = T // BT
+    chunk_offsets = _prepare_chunk_offsets(cu_seqlens, BT)
+    assert initial_state is None or initial_state.shape == (N, H, K, V)
+
+    T_alloc = T + BT
+
+    k_pad = (
+        jnp.pad(k, ((0, 0), (0, BT), (0, 0), (0, K_PADSIZE - K)))
+        if K_PADSIZE > K
+        else jnp.pad(k, ((0, 0), (0, BT), (0, 0), (0, 0)))
+    )
+    w_pad = (
+        jnp.pad(w, ((0, 0), (0, BT), (0, 0), (0, K_PADSIZE - K)))
+        if K_PADSIZE > K
+        else jnp.pad(w, ((0, 0), (0, BT), (0, 0), (0, 0)))
+    )
+    k_t = jnp.transpose(k_pad, (0, 2, 1, 3))
+    w_t = jnp.transpose(w_pad, (0, 2, 1, 3))
+
+    v_pad = (
+        jnp.pad(u_f32, ((0, 0), (0, BT), (0, 0), (0, V_ALIGNED - V)))
+        if V_ALIGNED > V
+        else jnp.pad(u_f32, ((0, 0), (0, BT), (0, 0), (0, 0)))
+    )
+    v_t = jnp.transpose(v_pad, (0, 2, 1, 3))
+
+    if g is not None:
+        g_fp32 = g.astype(jnp.float32).reshape(B, T, H, 1)
+        g_fp32 = pad_to_multiple(g_fp32, 128, -1, 0)
+        g_fp32 = jnp.pad(g_fp32, ((0, 0), (0, BT), (0, 0), (0, 0)))
+        g_t = jnp.transpose(g_fp32, (0, 2, 1, 3))
+    else:
+        g_t = None
+
+    if gk is not None:
+        gk_fp32 = gk.astype(jnp.float32)
+        if K_PADSIZE > K:
+            gk_fp32 = jnp.pad(gk_fp32, ((0, 0), (0, 0), (0, 0), (0, K_PADSIZE - K)))
+        gk_fp32 = jnp.pad(gk_fp32, ((0, 0), (0, BT), (0, 0), (0, 0)))
+        gk_t = jnp.transpose(gk_fp32, (0, 2, 1, 3))
+    else:
+        gk_t = None
+
+    if initial_state is not None:
+        h0 = initial_state
+        if V_ALIGNED > V:
+            h0 = jnp.pad(h0, ((0, 0), (0, 0), (0, 0), (0, V_ALIGNED - V)))
+        if K_PADSIZE > K:
+            h0 = jnp.pad(h0, ((0, 0), (0, 0), (0, K_PADSIZE - K), (0, 0)))
+    else:
+        h0 = None
+
+    g_pad_size = g_t.shape[-1] if g_t is not None else 128
+    h_spec = jax.ShapeDtypeStruct([B, NT, H, K_PADSIZE, V_ALIGNED], k.dtype)
+    v_new_spec = (
+        jax.ShapeDtypeStruct([B, H, T_alloc, V_ALIGNED], jnp.float32) if save_new_value else None
+    )
+    ht_spec = (
+        jax.ShapeDtypeStruct([N, H, K_PADSIZE, V_ALIGNED], jnp.float32)
+        if output_final_state
+        else None
+    )
+
+    def _t_index_map(n, h, nt, seqlens_ref, chunk_offsets_ref):
+        bos = pl.multiple_of(seqlens_ref[n], BT)
+        block_idx = jnp.minimum(bos // BT + nt, T // BT)
+        return (0, h, block_idx, 0)
+
+    def _h_index_map(n, h, nt, seqlens_ref, chunk_offsets_ref):
+        bos = pl.multiple_of(seqlens_ref[n], BT)
+        chunk_idx = jnp.minimum(bos // BT + nt, NT - 1)
+        return (0, chunk_idx, h, 0, 0)
+
+    k_blockspec = pl.BlockSpec([1, 1, BT, K_PADSIZE], index_map=_t_index_map)
+    v_blockspec = pl.BlockSpec([1, 1, BT, V_ALIGNED], index_map=_t_index_map)
+    w_blockspec = pl.BlockSpec([1, 1, BT, K_PADSIZE], index_map=_t_index_map)
+    g_blockspec = (
+        pl.BlockSpec([1, 1, BT, g_pad_size], index_map=_t_index_map) if g is not None else None
+    )
+    gk_blockspec = (
+        pl.BlockSpec([1, 1, BT, K_PADSIZE], index_map=_t_index_map) if gk is not None else None
+    )
+    h0_blockspec = (
+        pl.BlockSpec([1, 1, K_PADSIZE, V_ALIGNED], index_map=lambda n, h, nt, *_: (n, h, 0, 0))
+        if initial_state is not None
+        else None
+    )
+
+    h_blockspec_out = pl.BlockSpec([1, 1, 1, K_PADSIZE, V_ALIGNED], index_map=_h_index_map)
+    v_new_blockspec_out = (
+        pl.BlockSpec([1, 1, BT, V_ALIGNED], index_map=_t_index_map) if save_new_value else None
+    )
+    ht_blockspec_out = (
+        pl.BlockSpec([1, 1, K_PADSIZE, V_ALIGNED], index_map=lambda n, h, nt, *_: (n, h, 0, 0))
+        if output_final_state
+        else None
+    )
+
+    scratch = pltpu.VMEM((K_PADSIZE, V_ALIGNED), jnp.float32)
+    grid = (N, H, NT_max)
+    interpret = get_interpret()
+
+    h_out, v_new_out, ht_out = pl.pallas_call(
+        functools.partial(
+            _chunk_gated_delta_rule_fwd_kernel,
+            NT=NT,
+            USE_G=(g is not None),
+            USE_GK=(gk is not None),
+            USE_INITIAL_STATE=(initial_state is not None),
+            STORE_FINAL_STATE=output_final_state,
+            SAVE_NEW_VALUE=save_new_value,
+            USE_EXP2=use_exp2,
+        ),
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=2,
+            grid=grid,
+            in_specs=[
+                k_blockspec,
+                v_blockspec,
+                w_blockspec,
+                g_blockspec,
+                gk_blockspec,
+                h0_blockspec,
+            ],
+            out_specs=[h_blockspec_out, v_new_blockspec_out, ht_blockspec_out],
+            scratch_shapes=[scratch],
+        ),
+        compiler_params=pltpu.CompilerParams(
+            dimension_semantics=("parallel", "parallel", "arbitrary")
+        ),
+        out_shape=[h_spec, v_new_spec, ht_spec],
+        interpret=interpret,
+    )(cu_seqlens, chunk_offsets, k_t, v_t, w_t, g_t, gk_t, h0)
+
+    h_out = h_out[:, :, :, :K, :V]
+    v_new_out = jnp.transpose(v_new_out[:, :, :T, :V], (0, 2, 1, 3)) if save_new_value else None
+    ht_out = ht_out[:, :, :K, :V] if output_final_state else None
+
+    return h_out, v_new_out, ht_out
+
+
+# ============================================================================
+# kda forward O+GK (varlen only)
+# ============================================================================
+
+
+def _chunk_kda_fwd_o_gk_pl_kernel(
+    q_ref,
+    v_ref,
+    g_ref,
+    h_ref,
+    A_ref,
+    o_ref,
+    *,
+    BT,
+    scale,
+    USE_EXP2,
+):
+    b_q = q_ref[0, 0]
+    b_g = g_ref[0, 0]
+    b_v = v_ref[0, 0]
+    b_h = h_ref[0, 0]
+    b_A = A_ref[0, 0]
+
+    b_g_f32 = b_g.astype(jnp.float32)
+    b_q_f32 = b_q.astype(jnp.float32)
+    # Compute inter-chunk output: o = scale * q * exp2(g) @ h.
+    # Use g[0] (first position, largest cumsum) as reference to avoid overflow/underflow:
+    #   exp2(g[t]) = exp2(g[t] - g[0]) * exp2(g[0])
+    # g[t] - g[0] ≤ 0 for all t (cumsum is monotonically decreasing), so exp2 is safe.
+    # Factor exp2(g[0]) into h to preserve the matmul structure.
+    _exp_fn = exp2 if USE_EXP2 else exp
+    b_g_ref = b_g_f32[0:1, :]  # [1, K] — reference point
+    b_qg = b_q_f32 * _exp_fn(jnp.maximum(b_g_f32 - b_g_ref, -126.0))
+    # Scale h rows: h_scaled[k, v] = h[k, v] * exp2(g_ref[k])
+    b_h_scaled = b_h.astype(jnp.float32) * _exp_fn(jnp.maximum(b_g_ref[0], -126.0))[:, None]
+    b_o = jnp.dot(
+        b_qg, b_h_scaled, precision=jax.lax.Precision.HIGHEST, preferred_element_type=jnp.float32
+    )
+    b_o *= scale
+
+    m_s = jnp.arange(BT)[:, None] >= jnp.arange(BT)[None, :]
+    b_A_f32 = jnp.where(m_s, b_A, 0.0).astype(jnp.float32)
+    b_o += jnp.dot(
+        b_A_f32,
+        b_v.astype(jnp.float32),
+        precision=jax.lax.Precision.HIGHEST,
+        preferred_element_type=jnp.float32,
+    )
+
+    o_ref[0, 0] = b_o.astype(o_ref.dtype)
+
+
+def chunk_kda_fwd_o_gk(
+    q,
+    v,
+    g,
+    A,
+    h,
+    scale,
+    *,
+    cu_seqlens,
+    chunk_indices=None,
+    chunk_size=64,
+    use_exp2=False,
+):
+    assert cu_seqlens is not None, "This varlen-only module requires cu_seqlens"
+    B, T, H, K = q.shape
+    V = v.shape[-1]
+    BT = chunk_size
+    NT_h = h.shape[1]
+    assert B == 1
+    assert T % BT == 0
+
+    N = cu_seqlens.shape[0] - 1
+    T_alloc = T + BT
+
+    pad4d = lambda x: jnp.pad(x, ((0, 0), (0, BT), (0, 0), (0, 0)))
+    q_pad, v_pad, g_pad, A_pad = pad4d(q), pad4d(v), pad4d(g), pad4d(A)
+
+    cu_i32 = cu_seqlens.astype(jnp.int32)
+    seq_lens = jnp.diff(cu_i32)
+    chunks_per_seq = (seq_lens + BT - 1) // BT
+    cum_chunks = jnp.pad(jnp.cumsum(chunks_per_seq), (1, 0))
+    total_chunks = cum_chunks[-1]
+
+    NC_max = len(chunk_indices) if chunk_indices is not None else T // BT + N
+    flat_idx = jnp.arange(NC_max, dtype=jnp.int32)
+    is_valid = flat_idx < total_chunks
+
+    seq_id = jnp.minimum(jnp.searchsorted(cum_chunks[1:], flat_idx, side="right"), N - 1)
+    local_ci = flat_idx - cum_chunks[seq_id]
+    bos = cu_i32[seq_id]
+    # After _align_seqs, every sequence is BT-aligned — no partial chunks.
+    chunk_starts = jnp.where(is_valid, bos + local_ci * BT, 0)
+
+    def gather(x_pad, D):
+        def extract(start):
+            return jax.lax.dynamic_slice(x_pad, (0, start, 0, 0), (1, BT, H, D))[0]
+
+        return jax.vmap(extract)(chunk_starts)
+
+    q_c, v_c, g_c, A_c = gather(q_pad, K), gather(v_pad, V), gather(g_pad, K), gather(A_pad, BT)
+
+    _q = q_c.transpose(2, 0, 1, 3)
+    _v = v_c.transpose(2, 0, 1, 3)
+    _g = g_c.transpose(2, 0, 1, 3)
+    _A = A_c.transpose(2, 0, 1, 3)
+
+    _h = h[0].transpose(1, 0, 2, 3)
+    if NC_max > NT_h:
+        _h = jnp.pad(_h, ((0, 0), (0, NC_max - NT_h), (0, 0), (0, 0)))
+    elif NC_max < NT_h:
+        _h = _h[:, :NC_max]
+
+    q_spec = pl.BlockSpec([1, 1, BT, K], index_map=lambda h, nt: (h, nt, 0, 0))
+    g_spec = pl.BlockSpec([1, 1, BT, K], index_map=lambda h, nt: (h, nt, 0, 0))
+    v_spec = pl.BlockSpec([1, 1, BT, V], index_map=lambda h, nt: (h, nt, 0, 0))
+    A_spec = pl.BlockSpec([1, 1, BT, BT], index_map=lambda h, nt: (h, nt, 0, 0))
+    h_spec = pl.BlockSpec([1, 1, K, V], index_map=lambda h, nt: (h, nt, 0, 0))
+    o_shape = jax.ShapeDtypeStruct([H, NC_max, BT, V], v.dtype)
+    o_spec = pl.BlockSpec([1, 1, BT, V], index_map=lambda h, nt: (h, nt, 0, 0))
+
+    o_r = pl.pallas_call(
+        functools.partial(_chunk_kda_fwd_o_gk_pl_kernel, BT=BT, scale=scale, USE_EXP2=use_exp2),
+        grid=(H, NC_max),
+        out_shape=o_shape,
+        in_specs=[q_spec, v_spec, g_spec, h_spec, A_spec],
+        out_specs=o_spec,
+        compiler_params=pltpu.CompilerParams(disable_bounds_checks=True),
+        interpret=get_interpret(),
+    )(_q, _v, _g, _h, _A)
+
+    pos = chunk_starts[:, None] + jnp.arange(BT)[None, :]
+    pos = jnp.where(is_valid[:, None], pos, T_alloc - 1)
+    flat_pos = pos.reshape(-1)
+
+    o_chunks = o_r.transpose(1, 2, 0, 3).reshape(-1, H, V)
+    out = jnp.zeros((T_alloc, H, V), dtype=o_chunks.dtype)
+    out = out.at[flat_pos].add(o_chunks)
+    return out[:T][None]
+
+
+# ============================================================================
+# KDA gate cumsum helpers
+# ============================================================================
+
+_RCP_LN2 = 1.0 / math.log(2)
+
+
+def kda_gate_chunk_cumsum(
+    g,
+    A_log,
+    chunk_size,
+    scale=None,
+    dt_bias=None,
+    cu_seqlens=None,
+    output_dtype=jnp.float32,
+    chunk_indices=None,
+    lower_bound=None,
+):
+    B, T, H, K = g.shape
+    assert_shape(g, (B, T, H, K), "g")
+    assert A_log.shape == (H,), f"A_log shape {A_log.shape} != ({H},)"
+
+    g_f32 = g.astype(jnp.float32)
+    if dt_bias is not None:
+        g_f32 = g_f32 + dt_bias.astype(jnp.float32).reshape(H, K)
+
+    A = A_log.astype(jnp.float32)
+    if lower_bound is None:
+        g_act = -exp(A).reshape(1, 1, H, 1) * jax.nn.softplus(g_f32)
+    else:
+        g_act = lower_bound * jax.nn.sigmoid(exp(A).reshape(1, 1, H, 1) * g_f32)
+
+    return chunk_local_cumsum_vector(
+        g_act,
+        chunk_size=chunk_size,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        head_first=False,
+        output_dtype=output_dtype or jnp.float32,
+        chunk_indices=chunk_indices,
+    )
+
+
+def pallas_kda_gate_cumsum(
+    g,
+    chunk_size,
+    reverse=False,
+    scale=_RCP_LN2,
+    cu_seqlens=None,
+    head_first=False,
+    output_dtype=jnp.float32,
+    chunk_indices=None,
+):
+    B, T, H, K = g.shape
+    assert_shape(g, (B, T, H, K), "g")
+    assert T % chunk_size == 0, f"T={T} must be divisible by chunk_size={chunk_size}"
+
+    return chunk_local_cumsum_vector(
+        g,
+        chunk_size=chunk_size,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        head_first=False,
+        output_dtype=jnp.float32,
+    )
+
+
+# ============================================================================
+# Varlen alignment helpers
+# ============================================================================
+
+
+def _align_seqs(tensors_4d, tensors_3d, cu_seqlens, align):
+    N = cu_seqlens.shape[0] - 1
+    T_old = tensors_4d[0].shape[1]
+
+    seg_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+    padded_lens = ((seg_lens + align - 1) // align) * align
+    padded_cu = jnp.concatenate([jnp.zeros(1, dtype=jnp.int32), jnp.cumsum(padded_lens)])
+    T_new = ((T_old + N * (align - 1) + align - 1) // align) * align
+
+    def _build_gather(i, gather_idx):
+        old_start = cu_seqlens[i]
+        new_start = padded_cu[i]
+        sl = seg_lens[i]
+        j = jnp.arange(T_new)
+        in_seg = (j >= new_start) & (j < new_start + sl)
+        src = old_start + (j - new_start)
+        return jnp.where(in_seg, src, gather_idx)
+
+    gather_idx = jnp.full(T_new, T_old, dtype=jnp.int32)
+    gather_idx = jax.lax.fori_loop(0, N, _build_gather, gather_idx)
+
+    def repack_4d(t):
+        return jnp.pad(t, ((0, 0), (0, T_new - T_old), (0, 0), (0, 0)))[:, gather_idx]
+
+    def repack_3d(t):
+        return jnp.pad(t, ((0, 0), (0, T_new - T_old), (0, 0)))[:, gather_idx]
+
+    return (
+        [repack_4d(t) for t in tensors_4d],
+        [repack_3d(t) for t in tensors_3d],
+        padded_cu,
+        cu_seqlens,
+    )
+
+
+def _unalign_output(o, orig_cu_seqlens, aligned_cu_seqlens, T_out):
+    N = orig_cu_seqlens.shape[0] - 1
+    orig_seg_lens = orig_cu_seqlens[1:] - orig_cu_seqlens[:-1]
+
+    def _build_gather(i, gather_idx):
+        orig_start = orig_cu_seqlens[i]
+        aligned_start = aligned_cu_seqlens[i]
+        sl = orig_seg_lens[i]
+        j = jnp.arange(T_out)
+        in_seg = (j >= orig_start) & (j < orig_start + sl)
+        src = aligned_start + (j - orig_start)
+        return jnp.where(in_seg, src, gather_idx)
+
+    gather_idx = jnp.zeros(T_out, dtype=jnp.int32)
+    gather_idx = jax.lax.fori_loop(0, N, _build_gather, gather_idx)
+    return o[:, gather_idx]
+
+
+# ============================================================================
+# Main entry point
+# ============================================================================
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=(
+        "scale",
+        "output_final_state",
+        "use_qk_l2norm_in_kernel",
+        "chunk_size",
+        "safe_gate",
+        "lower_bound",
+        "use_gate_in_kernel",
+        "disable_recompute",
+        "return_intermediate_states",
+        "cp_context",
+        "transpose_state_layout",
+    ),
+)
+def chunk_kda_fwd(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    g: jax.Array,
+    beta: jax.Array,
+    scale: float,
+    initial_state: jax.Array,
+    output_final_state: bool,
+    cu_seqlens: jax.Array,
+    use_qk_l2norm_in_kernel: bool = False,
+    chunk_indices: jax.Array | None = None,
+    chunk_size: int = 64,
+    safe_gate: bool = True,
+    lower_bound: float | None = None,
+    use_gate_in_kernel: bool = False,
+    A_log: jax.Array | None = None,
+    dt_bias: jax.Array | None = None,
+    disable_recompute: bool = False,
+    return_intermediate_states: bool = False,
+    cp_context: None = None,
+    transpose_state_layout: bool = False,
+):
+    """KDA chunked forward pass for variable-length sequences (varlen).
+
+    cu_seqlens must not be None. B must be 1 (packed layout).
+
+    Four-stage pipeline:
+      1. Gate activation + chunk-local cumsum
+      2. Intra-chunk delta-rule solve via Neumann series
+      3. Inter-chunk hidden state propagation via delta-rule recurrence
+      4. Output computation (inter-chunk state + intra-chunk attention)
+
+    Returns:
+        12-tuple: o, final_state, g, Aqk, Akk, w, u, qg, kg, v_new, h, initial_state
+    """
+    B, T, H, K = q.shape
+    V = v.shape[-1]
+    BT = chunk_size
+
+    assert use_qk_l2norm_in_kernel is False
+    assert cp_context is None
+    assert not transpose_state_layout
+    assert not return_intermediate_states
+    assert not disable_recompute
+
+    assert_shape(q, (B, T, H, K), "q")
+    assert_shape(k, (B, T, H, K), "k")
+    assert_shape(v, (B, T, H, V), "v")
+    assert cu_seqlens is not None, "cu_seqlens must not be None for varlen path"
+    assert B == 1, f"varlen requires B=1 (packed layout), got B={B}"
+
+    N = cu_seqlens.shape[-1] - 1
+    assert_shape(beta, (B, T, H), "beta")
+    assert_shape_or_none(initial_state, (N, H, K, V), "initial_state")
+
+    # Varlen alignment
+    _orig_cu_seqlens = cu_seqlens
+    T_input = T
+    [q, k, v, g], [beta], cu_seqlens, _ = _align_seqs(
+        [q, k, v, g],
+        [beta],
+        cu_seqlens,
+        align=BT,
+    )
+    T = q.shape[1]
+    chunk_indices = prepare_chunk_indices(cu_seqlens, BT, max_T=T)
+
+    assert T % BT == 0
+
+    # Fix: _align_seqs pads g with 0, but softplus(0 + dt_bias) != 0 when
+    # use_gate_in_kernel=True, producing non-zero gate activation at padding
+    # positions.  This corrupts g_last (used for state propagation in Stage 3)
+    # and kg (used for state update).  Set padding g to a large negative so
+    # softplus(large_neg + dt_bias) ≈ 0, neutralising padding positions.
+    if use_gate_in_kernel:
+        orig_lens = _orig_cu_seqlens[1:] - _orig_cu_seqlens[:-1]
+        aligned_starts = cu_seqlens[:-1]
+        pos = jnp.arange(T)
+        in_range = (pos[None, :] >= aligned_starts[:, None]) & (
+            pos[None, :] < (aligned_starts + orig_lens)[:, None]
+        )
+        valid_mask = in_range.any(axis=0)  # [T]
+        g = jnp.where(valid_mask[None, :, None, None], g, -1e4)
+
+    # Step 1: Gate cumsum
+    if use_gate_in_kernel:
+        assert A_log is not None
+        g_cumsum = kda_gate_chunk_cumsum(
+            g=g,
+            A_log=A_log,
+            chunk_size=BT,
+            scale=_RCP_LN2,
+            dt_bias=dt_bias,
+            lower_bound=lower_bound,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+    else:
+        g_cumsum = pallas_kda_gate_cumsum(
+            g=g,
+            scale=_RCP_LN2,
+            chunk_size=chunk_size,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+
+    # Step 2: Intra-chunk solve
+    w, u, qg, kg, Aqk, Akk = kda_fwd_intra(
+        q=q,
+        k=k,
+        v=v,
+        gk=g_cumsum,
+        beta=beta,
+        scale=scale,
+        safe_gate=safe_gate,
+        chunk_size=BT,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+    # Step 3: Inter-chunk state propagation
+    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+        k=kg,
+        w=w,
+        u=u,
+        gk=g_cumsum,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        chunk_size=BT,
+        use_exp2=True,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+    # Step 4: Output computation
+    o = chunk_kda_fwd_o_gk(
+        q=q,
+        v=v_new,
+        g=g_cumsum,
+        A=Aqk,
+        h=h,
+        scale=scale,
+        chunk_size=BT,
+        use_exp2=True,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+
+    # Cast output back to input dtype (e.g. bfloat16)
+    o = o.astype(q.dtype)
+
+    # Unalign output
+    o = _unalign_output(o, _orig_cu_seqlens, cu_seqlens, T_input)
+
+    # Release intermediates
+    w, u, qg, kg, v_new, h = None, None, None, None, None, None
+    if use_gate_in_kernel:
+        g_cumsum = None
+
+    return o, final_state, g_cumsum, Aqk, Akk, w, u, qg, kg, v_new, h, initial_state

--- a/python/sgl_jax/srt/kernels/kda/naive.py
+++ b/python/sgl_jax/srt/kernels/kda/naive.py
@@ -1,0 +1,114 @@
+# Adapted from https://github.com/primatrix/pallas-kernel (rev 3c691ad3)
+# Vendored to remove external dependency after the upstream repository went private.
+#
+# This file corresponds to tops/ops/kda/naive.py in the upstream repository.
+
+import jax
+import jax.numpy as jnp
+
+
+def acc_dtype(input_dtype) -> jnp.dtype:
+    """Accumulator dtype: fp64 for fp64 inputs, fp32 otherwise."""
+    return jnp.float64 if input_dtype == jnp.float64 else jnp.float32
+
+
+def naive_recurrent_kda(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    g: jax.Array,
+    beta: jax.Array,
+    scale: float | None = None,
+    initial_state: jax.Array | None = None,
+    output_final_state: bool = False,
+) -> tuple[jax.Array, jax.Array | None]:
+    """
+    Core recurrence (per timestep):
+        S' = S_{t-1} * exp(g_t)                            decay
+        residual = v_t - k_t^T @ S'                        prediction error
+        S_t = S' + beta_t * k_t ⊗ residual                 delta update
+        o_t = (q_t * scale)^T @ S_t                        output
+
+    Dtype behavior (matching FLA):
+      - All inputs cast to fp32 for computation
+      - Hidden state S is fp32 accumulator
+      - Output o computed in fp32, cast back to original dtype
+      - Final state S stays in fp32
+      - fp64 mode: all computation in fp64, no precision cast
+
+    Args:
+        q:               [B, T, H, K] — Queries
+        k:               [B, T, H, K] — Keys
+        v:               [B, T, H, V] — Values
+        g:               [B, T, H, K] — Per-element gate in log-space (e.g., -exp(A)*softplus(g))
+        beta:            [B, T, H]    — Learning rate / step size for delta rule
+        scale:           Scalar query scale. Defaults to K ** -0.5.
+        initial_state:   [B, H, K, V] — Initial hidden state. Optional.
+        output_final_state: Whether to return the final hidden state.
+
+    Returns:
+        o:           [B, T, H, V] — Output (original input dtype)
+        final_state: [B, H, K, V] in fp32 (or fp64), or None
+    """
+    orig_dtype, acc_dt = v.dtype, acc_dtype(q.dtype)
+
+    assert q.ndim == 4, f"q must be 4D [B,T,H,K], got {q.ndim}D"
+    assert k.shape == q.shape, f"k shape {k.shape} != q shape {q.shape}"
+    assert (
+        v.ndim == 4 and v.shape[:3] == q.shape[:3]
+    ), f"v shape {v.shape} incompatible with q shape {q.shape}"
+    assert g.ndim == 4 and g.shape == q.shape, f"g shape {g.shape} != q shape {q.shape}"
+    assert beta.ndim == 3 and beta.shape == q.shape[:3], f"beta shape {beta.shape} != {q.shape[:3]}"
+
+    B, T, H, K, V = *q.shape, v.shape[-1]
+
+    if initial_state is not None:
+        assert initial_state.shape == (
+            B,
+            H,
+            K,
+            V,
+        ), f"initial_state shape {initial_state.shape} != ({B}, {H}, {K}, {V})"
+
+    if scale is None:
+        scale = K**-0.5
+
+    # [B, T, H, K] -> [B, H, T, K], cast to acc_dt
+    q, k, v, g = (jnp.transpose(x, (0, 2, 1, 3)).astype(acc_dt) for x in (q, k, v, g))
+    # q: [B, H, T, K]   k: [B, H, T, K]   v: [B, H, T, V]   g: [B, H, T, K]
+
+    # [B, T, H] -> [B, H, T]
+    beta = jnp.transpose(beta, (0, 2, 1)).astype(acc_dt)  # [B, H, T]
+
+    q = q * scale  # [B, H, T, K]
+
+    S = jnp.zeros((B, H, K, V), dtype=acc_dt)  # [B, H, K, V] hidden state
+    if initial_state is not None:
+        S += initial_state.astype(acc_dt)  # [B, H, K, V]
+    o = jnp.zeros((B, H, T, V), dtype=acc_dt)  # [B, H, T, V] output buffer
+
+    for i in range(T):
+        q_i = q[:, :, i]  # [B, H, K]
+        k_i = k[:, :, i]  # [B, H, K]
+        v_i = v[:, :, i]  # [B, H, V]
+        g_i = g[:, :, i]  # [B, H, K]
+        b_i = beta[:, :, i]  # [B, H]
+
+        # 1. Decay the state
+        # exp(g_i): [B, H, K] -> [B, H, K, 1] via broadcast
+        S = S * jnp.exp(g_i)[..., None]  # [B, H, K, V]
+
+        # 2. Delta rule update
+        # k_i[..., None]: [B, H, K, 1],  k_i[..., None] * S: [B, H, K, V]
+        v_predicted = (k_i[..., None] * S).sum(-2)  # [B, H, V]
+        residual = v_i - v_predicted  # [B, H, V]
+
+        # b_i[..., None] * k_i: [B, H, K],  einsum -> [B, H, K, V]
+        S = S + jnp.einsum("bhk,bhv->bhkv", b_i[..., None] * k_i, residual)  # [B, H, K, V]
+
+        # 3. Compute output: einsum [B,H,K] x [B,H,K,V] -> [B, H, V]
+        o = o.at[:, :, i].set(jnp.einsum("bhk,bhkv->bhv", q_i, S))  # [B, H, V]
+
+    final_state = S if output_final_state else None  # [B, H, K, V] or None
+    # [B, H, T, V] -> [B, T, H, V], cast back to orig_dtype
+    return jnp.transpose(o, (0, 2, 1, 3)).astype(orig_dtype), final_state

--- a/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -22,8 +21,6 @@ if TYPE_CHECKING:
     from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
     from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
     from sgl_jax.srt.model_executor.model_runner import ModelRunner
-
-logger = logging.getLogger(__name__)
 
 
 # --- Linear (state-based) attention base classes ----------------------------
@@ -72,7 +69,7 @@ class LinearRecurrentAttnBackend(AttentionBackend):
         """Return the metadata for a forward pass."""
         metadata = LinearRecurrentAttnBackendMetadata()
 
-        # cu_q_lens per DP rank section (each section starts from 0)
+        # Unified 2D reshape logic for all dp_size (including dp_size=1)
         if batch.forward_mode == ForwardMode.EXTEND:
             ext_2d = batch.extend_seq_lens.reshape(batch.dp_size, batch.per_dp_bs_size)
             cu_q_2d = np.zeros((batch.dp_size, batch.per_dp_bs_size + 1), dtype=np.int32)

--- a/python/sgl_jax/srt/layers/attention/linear/__init__.py
+++ b/python/sgl_jax/srt/layers/attention/linear/__init__.py
@@ -1,0 +1,3 @@
+from sgl_jax.srt.layers.attention.linear.kda_backend import KDAAttnBackend
+
+__all__ = ["KDAAttnBackend"]

--- a/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.kernels.kda import chunk_kda, naive_recurrent_kda
+from sgl_jax.srt.layers.attention.hybrid_linear_attn_backend import (
+    LinearRecurrentAttnBackend,
+)
+from sgl_jax.srt.layers.attention.linear.short_convolution import short_convolution
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.layers.radix_linear_attention import RadixLinearAttention
+    from sgl_jax.srt.mem_cache.recurrent_state_pool import RecurrentStatePool
+    from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+def l2_normalize(x: jax.Array, epsilon: float = 1e-6) -> jax.Array:
+    """L2-normalize along the last axis. Computed in fp32, cast back to input dtype."""
+    norm = jnp.linalg.norm(x.astype(jnp.float32), axis=-1, keepdims=True)
+    return (x.astype(jnp.float32) / jnp.maximum(norm, epsilon)).astype(x.dtype)
+
+
+class KDAAttnBackend(LinearRecurrentAttnBackend):
+    """Attention backend for KDA (Kimi Delta Attention) linear attention."""
+
+    def __init__(self, mesh: jax.sharding.Mesh = None):
+        super().__init__(
+            mesh=mesh,
+        )
+
+    def __call__(
+        self,
+        q: jax.Array,
+        k: jax.Array,
+        v: jax.Array,
+        a: jax.Array,
+        b: jax.Array,
+        layer: RadixLinearAttention,
+        forward_batch: ForwardBatch,
+        pool: RecurrentStatePool,
+        **kwargs,
+    ) -> jax.Array:
+        recurrent_indices = self.forward_metadata.recurrent_indices
+        ssm_states, conv_states = self.get_state(pool, layer.layer_id, recurrent_indices)
+        q_conv_w = layer.q_conv1d.weight.value
+        k_conv_w = layer.k_conv1d.weight.value
+        v_conv_w = layer.v_conv1d.weight.value
+        # _unpack_conv_states splits proj_size in 3 equal pieces; only valid
+        # when proj_q == proj_k == proj_v (Kimi-Linear shape).
+        assert (
+            q_conv_w.shape[0] == k_conv_w.shape[0] == v_conv_w.shape[0]
+        ), f"unequal Q/K/V proj widths: {q_conv_w.shape[0]}/{k_conv_w.shape[0]}/{v_conv_w.shape[0]}"
+        q_state, k_state, v_state = self._unpack_conv_states(conv_states)
+
+        cu_q_lens = self.forward_metadata.cu_q_lens
+        if forward_batch.forward_mode == ForwardMode.EXTEND:
+            q, q_state_new = self._short_conv_extend(
+                q, q_conv_w, q_state, cu_q_lens, layer.activation
+            )
+            k, k_state_new = self._short_conv_extend(
+                k, k_conv_w, k_state, cu_q_lens, layer.activation
+            )
+            v, v_state_new = self._short_conv_extend(
+                v, v_conv_w, v_state, cu_q_lens, layer.activation
+            )
+        else:
+            q, q_state_new = short_convolution(
+                q,
+                q_conv_w,
+                q_state,
+                cu_q_lens,
+                forward_batch.forward_mode,
+                activation=layer.activation,
+            )
+            k, k_state_new = short_convolution(
+                k,
+                k_conv_w,
+                k_state,
+                cu_q_lens,
+                forward_batch.forward_mode,
+                activation=layer.activation,
+            )
+            v, v_state_new = short_convolution(
+                v,
+                v_conv_w,
+                v_state,
+                cu_q_lens,
+                forward_batch.forward_mode,
+                activation=layer.activation,
+            )
+        new_conv_packed = self._pack_conv_states(q_state_new, k_state_new, v_state_new)
+
+        q = q.reshape(q.shape[0], layer.num_q_heads, layer.head_q_dim)
+        k = k.reshape(k.shape[0], layer.num_k_heads, layer.head_k_dim)
+        v = v.reshape(v.shape[0], layer.num_v_heads, layer.head_v_dim)
+        a = a.reshape(a.shape[0], layer.num_q_heads, layer.head_q_dim)
+        b = b.reshape(b.shape[0], layer.num_q_heads)
+
+        # KDA requires L2-normalized q/k for all paths; upstream fuses this
+        # via use_qk_l2norm_in_kernel=True, while current kernel doesn't support.
+        q = l2_normalize(q)
+        k = l2_normalize(k)
+
+        if forward_batch.forward_mode == ForwardMode.EXTEND:
+            output, new_recurrent = self._forward_extend(
+                q,
+                k,
+                v,
+                a,
+                b,
+                ssm_states,
+                cu_q_lens,
+                layer,
+                scale=layer.scale,
+            )
+        elif forward_batch.forward_mode == ForwardMode.DECODE:
+            output, new_recurrent = self._forward_decode(
+                q,
+                k,
+                v,
+                a,
+                b,
+                ssm_states,
+                layer,
+                scale=layer.scale,
+            )
+        else:
+            raise NotImplementedError(f"KDA does not support {forward_batch.forward_mode}")
+
+        new_ssm_full = self.set_ssm_state(pool, layer.layer_id, recurrent_indices, new_recurrent)
+        new_conv_full_list = self.set_conv_state(
+            pool, layer.layer_id, recurrent_indices, new_conv_packed
+        )
+        return output.reshape(output.shape[0], -1), (new_ssm_full, new_conv_full_list)
+
+    def get_state(self, recurrent_state_pool, layer_id, recurrent_indices):
+        """Return per-request views of (ssm, conv) state for this layer."""
+        recurrent_buffer, conv_buffer_list = self.get_layer_cache(
+            recurrent_state_pool,
+            layer_id,
+        )
+        assert len(conv_buffer_list) == 1, (
+            f"KDA expects exactly 1 conv buffer per layer "
+            f"(reserved RecurrentStatePool inner-list length); got {len(conv_buffer_list)}"
+        )
+        conv_buffer = conv_buffer_list[0]
+
+        ssm = jax.shard_map(
+            lambda buf, idx: buf[idx],
+            mesh=self.mesh,
+            in_specs=(P("data", "tensor", None, None), P("data")),
+            out_specs=P("data", "tensor", None, None),
+            check_vma=False,
+        )(recurrent_buffer, recurrent_indices)
+
+        conv = jax.shard_map(
+            lambda buf, idx: buf[idx],
+            mesh=self.mesh,
+            in_specs=(P("data", "tensor", None), P("data")),
+            out_specs=P("data", "tensor", None),
+            check_vma=False,
+        )(conv_buffer, recurrent_indices)
+
+        has_initial_state = self.forward_metadata.has_initial_state
+        if has_initial_state is not None:
+            ssm = jnp.where(has_initial_state[:, None, None, None], ssm, 0.0)
+            conv = jnp.where(has_initial_state[:, None, None], conv, 0.0)
+
+        return ssm, conv
+
+    def set_ssm_state(self, recurrent_state_pool, layer_id, recurrent_indices, new_recurrent):
+        """Scatter per-request ``new_recurrent`` into the FULL pool buffer."""
+        full_recurrent, _ = self.get_layer_cache(recurrent_state_pool, layer_id)
+
+        return jax.shard_map(
+            lambda buf, idx, val: buf.at[idx].set(val),
+            mesh=self.mesh,
+            in_specs=(
+                P("data", "tensor", None, None),
+                P("data"),
+                P("data", "tensor", None, None),
+            ),
+            out_specs=P("data", "tensor", None, None),
+            check_vma=False,
+        )(full_recurrent, recurrent_indices, new_recurrent)
+
+    def set_conv_state(self, recurrent_state_pool, layer_id, recurrent_indices, new_conv_packed):
+        """Scatter per-request packed conv state into the FULL pool buffer."""
+        _, conv_buffer_list = self.get_layer_cache(recurrent_state_pool, layer_id)
+        assert len(conv_buffer_list) == 1
+        full_conv = conv_buffer_list[0]
+
+        new_conv_full = jax.shard_map(
+            lambda buf, idx, val: buf.at[idx].set(val),
+            mesh=self.mesh,
+            in_specs=(
+                P("data", "tensor", None),
+                P("data"),
+                P("data", "tensor", None),
+            ),
+            out_specs=P("data", "tensor", None),
+            check_vma=False,
+        )(full_conv, recurrent_indices, new_conv_packed)
+        return [new_conv_full]
+
+    # ------------------------------------------------------------------
+    # Forward mode implementations
+    # ------------------------------------------------------------------
+
+    def _short_conv_extend(
+        self,
+        x: jax.Array,
+        weight: jax.Array,
+        cache: jax.Array,
+        cu_seqlens: jax.Array,
+        activation,
+    ) -> tuple[jax.Array, jax.Array]:
+        """EXTEND-path conv wrapped in shard_map."""
+
+        def _call(x, weight, cache, cu_seqlens):
+            return short_convolution(
+                x, weight, cache, cu_seqlens, ForwardMode.EXTEND, activation=activation
+            )
+
+        sharded = jax.shard_map(
+            _call,
+            mesh=self.mesh,
+            in_specs=(
+                P("data", "tensor"),  # x [T, hidden]
+                P("tensor", None),  # weight [hidden, K]
+                P("data", "tensor", None),  # cache [B, hidden, K-1]
+                P("data"),  # cu_seqlens [B+1]
+            ),
+            out_specs=(
+                P("data", "tensor"),  # y [T, hidden]
+                P("data", "tensor", None),  # new_cache [B, hidden, K-1]
+            ),
+            check_vma=False,
+        )
+        return sharded(x, weight, cache, cu_seqlens)
+
+    def _forward_extend(
+        self,
+        q: jax.Array,
+        k: jax.Array,
+        v: jax.Array,
+        g: jax.Array,
+        beta: jax.Array,
+        initial_state: jax.Array,
+        cu_seqlens: jax.Array,
+        layer: RadixLinearAttention,
+        scale: float | None = None,
+    ) -> tuple[jax.Array, jax.Array]:
+        """Chunked prefill via Pallas kernel."""
+        if layer.A_log is None or layer.dt_bias is None:
+            raise ValueError("KDA gate activation requires layer.A_log and layer.dt_bias")
+        H = q.shape[-2]
+        # kda_gate_chunk_cumsum requires A_log shape (H,); layer stores [1,1,H,1].
+        A_log = layer.A_log.value.reshape(H)
+        dt_bias = layer.dt_bias.value.reshape(H, -1)
+        scale = scale if scale is not None else layer.scale
+
+        def _chunk_kda_call(q, k, v, g, beta, initial_state, cu_seqlens, A_log, dt_bias):
+            o, final_state, *_ = chunk_kda(
+                q,
+                k,
+                v,
+                g,
+                beta,
+                scale=scale,
+                initial_state=initial_state,
+                output_final_state=True,
+                cu_seqlens=cu_seqlens,
+                use_gate_in_kernel=True,
+                A_log=A_log,
+                dt_bias=dt_bias,
+            )
+            return o, final_state
+
+        sharded = jax.shard_map(
+            _chunk_kda_call,
+            mesh=self.mesh,
+            in_specs=(
+                P(None, "data", "tensor", None),  # q [1, T, H, K]
+                P(None, "data", "tensor", None),  # k [1, T, H, K]
+                P(None, "data", "tensor", None),  # v [1, T, H, V]
+                P(None, "data", "tensor", None),  # g [1, T, H, K]
+                P(None, "data", "tensor"),  # beta [1, T, H]
+                P("data", "tensor", None, None),  # initial_state [N, H, K, V]
+                P("data"),  # cu_seqlens [N+1]
+                P("tensor"),  # A_log [H]
+                P("tensor", None),  # dt_bias [H, K]
+            ),
+            out_specs=(
+                P(None, "data", "tensor", None),  # output [1, T, H, V]
+                P("data", "tensor", None, None),  # final_state [N, H, K, V]
+            ),
+            check_vma=False,
+        )
+        # Kernel expects [1, T_packed, H, K] packed layout; strip after.
+        o, final_state = sharded(
+            q[None, ...],
+            k[None, ...],
+            v[None, ...],
+            g[None, ...],
+            beta[None, ...],
+            initial_state,
+            cu_seqlens,
+            A_log,
+            dt_bias,
+        )
+        return o[0], final_state
+
+    def _forward_decode(
+        self,
+        q: jax.Array,
+        k: jax.Array,
+        v: jax.Array,
+        g: jax.Array,
+        beta: jax.Array,
+        initial_state: jax.Array,
+        layer: RadixLinearAttention,
+        scale: float | None = None,
+    ) -> tuple[jax.Array, jax.Array]:
+        """Single-step decode via naive JAX recurrence (Pallas decode TBD)."""
+        g = self._fused_kda_gate(layer, g)
+
+        def _decode_kernel(q_d, k_d, v_d, g_d, beta_d, h0):
+            o, final_state = naive_recurrent_kda(
+                q_d[:, None, ...],
+                k_d[:, None, ...],
+                v_d[:, None, ...],
+                g_d[:, None, ...],
+                beta_d[:, None, ...],
+                scale=scale,
+                initial_state=h0,
+                output_final_state=True,
+            )
+            return o[:, 0], final_state
+
+        sharded = jax.shard_map(
+            _decode_kernel,
+            mesh=self.mesh,
+            in_specs=(
+                P("data", "tensor", None),  # q [B, H, K]
+                P("data", "tensor", None),  # k [B, H, K]
+                P("data", "tensor", None),  # v [B, H, V]
+                P("data", "tensor", None),  # g [B, H, K]
+                P("data", "tensor"),  # beta [B, H]
+                P("data", "tensor", None, None),  # h0 [B, H, K, V]
+            ),
+            out_specs=(
+                P("data", "tensor", None),  # o [B, H, V]
+                P("data", "tensor", None, None),  # final_state [B, H, K, V]
+            ),
+            check_vma=False,
+        )
+        return sharded(q, k, v, g, beta, initial_state)
+
+    def _fused_kda_gate(
+        self,
+        layer: RadixLinearAttention,
+        g: jax.Array,
+    ) -> jax.Array:
+        """JAX-side gate activation used by the DECODE path."""
+        if layer.A_log is None or layer.dt_bias is None:
+            raise ValueError("KDA gate activation requires layer.A_log and layer.dt_bias")
+        H = g.shape[-2]
+        orig_dtype = g.dtype
+        g32 = g.astype(jnp.float32) + layer.dt_bias.value.reshape(H, -1).astype(jnp.float32)
+        out = -jnp.exp(layer.A_log.value.reshape(H, 1).astype(jnp.float32)) * jax.nn.softplus(g32)
+        return out.astype(orig_dtype)
+
+    def _unpack_conv_states(
+        self,
+        conv_states: jax.Array,
+    ) -> tuple[jax.Array, jax.Array, jax.Array]:
+        """Slice ``[B, proj_size, K-1]`` into per-stream Q/K/V caches."""
+        D = conv_states.shape[1]
+        assert D % 3 == 0, f"conv_states channel dim {D} must be divisible by 3"
+        q, k, v = jnp.split(conv_states, 3, axis=1)
+        return q, k, v
+
+    def _pack_conv_states(
+        self,
+        q_state: jax.Array,
+        k_state: jax.Array,
+        v_state: jax.Array,
+    ) -> jax.Array:
+        """Concat per-stream ``[B, D, K-1]`` caches → packed ``[B, proj_size, K-1]``."""
+        return jnp.concatenate([q_state, k_state, v_state], axis=1)
+
+
+__all__ = ["KDAAttnBackend"]

--- a/python/sgl_jax/srt/layers/attention/linear/short_convolution.py
+++ b/python/sgl_jax/srt/layers/attention/linear/short_convolution.py
@@ -1,0 +1,188 @@
+"""Short depthwise causal conv1d used by linear-attention backends (e.g. KDA).
+
+The convolution is intentionally implemented as a stateless function (not an
+nnx Module) so backends can freely combine it with their own weight containers
+and cache layouts. Two execution paths are provided:
+
+* ``decode`` — single-token step that appends the new token to a per-sequence
+  ``[B, D, K-1]`` cache, runs the conv on the resulting K-token window, and
+  drops the oldest slot before writing back.
+* ``extend`` — variable-length packed prefill that consumes ``cu_seqlens`` to
+  build a per-token sliding window mixing prior cache and in-sequence tokens.
+
+State convention follows vLLM / Mamba: cache has width ``K-1`` and stores the
+prior ``K-1`` tokens (the current token is supplied via ``x`` at call time).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import jax
+import jax.numpy as jnp
+
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+
+# Map of supported activation names → callable. ``None`` means identity.
+_ACTIVATION_FNS: dict[str | None, Callable[[jax.Array], jax.Array] | None] = {
+    None: None,
+    "silu": jax.nn.silu,
+    "swish": jax.nn.silu,
+    "gelu": jax.nn.gelu,
+    "relu": jax.nn.relu,
+    "sigmoid": jax.nn.sigmoid,
+    "tanh": jnp.tanh,
+}
+
+
+def _resolve_activation(
+    activation: str | Callable[[jax.Array], jax.Array] | None,
+) -> Callable[[jax.Array], jax.Array] | None:
+    """Resolve an activation spec to a callable (or None for identity).
+
+    Accepts either a name from ``_ACTIVATION_FNS`` or a user-supplied callable.
+    """
+    if activation is None or callable(activation):
+        return activation
+    if activation not in _ACTIVATION_FNS:
+        raise ValueError(
+            f"short_convolution activation must be one of {sorted(k for k in _ACTIVATION_FNS if k is not None)} "
+            f"or a callable; got {activation!r}"
+        )
+    return _ACTIVATION_FNS[activation]
+
+
+def short_convolution(
+    x: jax.Array,
+    weight: jax.Array,
+    cache: jax.Array,
+    cu_seqlens: jax.Array | None,
+    forward_mode: ForwardMode,
+    bias: jax.Array | None = None,
+    activation: str | Callable[[jax.Array], jax.Array] | None = "silu",
+) -> tuple[jax.Array, jax.Array]:
+    """Depthwise causal conv1d with per-sequence cache.
+
+    Args:
+        x: ``[T, D]`` for ``EXTEND`` (packed varlen) or ``[B, D]`` for ``DECODE``.
+        weight: depthwise kernel ``[D, K]``.
+        cache: per-sequence rolling buffer ``[B, D, K-1]`` storing the prior
+            ``K-1`` tokens (zeros for fresh sequences). The current token is
+            supplied via ``x`` and not written into the input cache.
+        cu_seqlens: ``[N+1]`` cumulative sequence lengths; required for
+            ``EXTEND``, ignored for ``DECODE``.
+        forward_mode: ``ForwardMode.DECODE`` or ``ForwardMode.EXTEND``.
+        bias: optional ``[D]`` channel bias added before the activation.
+        activation: name (e.g. ``"silu"``, ``"gelu"``, ``"sigmoid"``), a
+            user-supplied callable, or ``None`` for identity.
+
+    Returns:
+        ``(y, new_cache)`` where ``y`` matches the leading dims of ``x`` and
+        ``new_cache`` has the same shape as ``cache``.
+    """
+    activation_fn = _resolve_activation(activation)
+
+    weight = _normalize_weight(weight)
+
+    if forward_mode == ForwardMode.DECODE:
+        return _decode_conv(x, weight, cache, bias, activation_fn)
+    if cu_seqlens is None:
+        raise ValueError("short_convolution(EXTEND) requires cu_seqlens")
+    return _extend_conv(x, weight, cache, cu_seqlens, bias, activation_fn)
+
+
+def _normalize_weight(weight: jax.Array) -> jax.Array:
+    """Reduce common conv-weight layouts to ``[D, K]``."""
+    # Squeeze the depthwise singleton axis if the loader handed us [D, 1, K].
+    if weight.ndim == 3 and weight.shape[1] == 1:
+        weight = weight[:, 0, :]
+    return weight
+
+
+def _apply_activation(
+    y: jax.Array,
+    activation_fn: Callable[[jax.Array], jax.Array] | None,
+) -> jax.Array:
+    if activation_fn is None:
+        return y
+    return activation_fn(y)
+
+
+def _decode_conv(
+    x: jax.Array,  # [B, D]
+    conv_kernel: jax.Array,  # [D, K]
+    cache: jax.Array,  # [B, D, K-1]
+    bias: jax.Array | None,
+    activation_fn: Callable[[jax.Array], jax.Array] | None,
+) -> tuple[jax.Array, jax.Array]:
+    # expand x shape from [B, D] to [B, D, 1]
+    new_cache = jnp.concatenate([cache, x[..., None]], axis=-1)
+    y = jnp.einsum("bck,ck->bc", new_cache, conv_kernel.astype(new_cache.dtype))
+    if bias is not None:
+        y = y + bias.astype(y.dtype)
+    y = _apply_activation(y, activation_fn)
+    # return the last K-1 conv state
+    return y, new_cache[:, :, 1:]
+
+
+def _extend_conv(
+    x: jax.Array,  # [T, D]
+    conv_kernel: jax.Array,  # [D, K]
+    cache: jax.Array,  # [B, D, K-1]
+    cu_seqlens: jax.Array,
+    bias: jax.Array | None,
+    activation_fn: Callable[[jax.Array], jax.Array] | None,
+) -> tuple[jax.Array, jax.Array]:
+    T = x.shape[0]
+    K = conv_kernel.shape[-1]
+    W = K - 1  # cache width
+
+    # Locate every output token within its owning sequence.
+    token_idx = jnp.arange(T, dtype=cu_seqlens.dtype)
+    seq_ids = jnp.searchsorted(cu_seqlens[1:], token_idx, side="right")
+    starts = cu_seqlens[:-1][seq_ids]
+
+    # Build the K-tap window ending at each token: source positions
+    # ``[t-(K-1), ..., t]``. Positions inside the same sequence read from x;
+    # positions reaching back across the sequence boundary read from cache.
+    offsets = jnp.arange(K, dtype=cu_seqlens.dtype) - (K - 1)
+    source_idx = token_idx[:, None] + offsets[None, :]
+    from_x = source_idx >= starts[:, None]
+
+    safe_x_idx = jnp.clip(source_idx, 0, jnp.maximum(T - 1, 0))
+    # x[safe_x_idx]: [T, K, D] (advanced indexing puts the index axes first).
+    # Swap to [T, D, K] so the einsum spec matches the decode path's "bck,ck".
+    x_window = jnp.swapaxes(x[safe_x_idx], 1, 2)  # [T, D, K]
+
+    # cache holds the prior W = K-1 tokens at slots [0, W-1]. Map source
+    # position p (where p < starts[seq]) to cache slot ``W + (p - starts)``.
+    # cache[seq_ids] is already [T, D, W]; gather along the time axis (=2).
+    cache_pos = jnp.clip(W + source_idx - starts[:, None], 0, W - 1)
+    cache_window = jnp.take_along_axis(
+        cache[seq_ids],  # [T, D, W]
+        cache_pos[:, None, :],  # [T, 1, K] -> broadcasts over D
+        axis=2,
+    )  # [T, D, K]
+    window = jnp.where(from_x[:, None, :], x_window, cache_window)  # [T, D, K]
+    y = jnp.einsum("tck,ck->tc", window, conv_kernel.astype(window.dtype))
+    if bias is not None:
+        y = y + bias.astype(y.dtype)
+    y = _apply_activation(y, activation_fn)
+
+    # Compute the new per-sequence cache: the last W = K-1 input tokens of
+    # each sequence, falling back to the prior cache when the sequence is
+    # shorter than W.
+    ends = cu_seqlens[1:]
+    state_offsets = jnp.arange(W, dtype=cu_seqlens.dtype)
+    final_idx = ends[:, None] - W + state_offsets[None, :]
+    final_from_x = final_idx >= cu_seqlens[:-1, None]
+    safe_final_idx = jnp.clip(final_idx, 0, jnp.maximum(T - 1, 0))
+    final_x = jnp.swapaxes(x[safe_final_idx], 1, 2)
+    final_cache_pos = jnp.clip(W + final_idx - cu_seqlens[:-1, None], 0, W - 1)
+    final_cache = jnp.take_along_axis(cache, final_cache_pos[:, None, :], axis=2)
+    new_cache = jnp.where(final_from_x[:, None, :], final_x, final_cache)
+
+    return y, new_cache
+
+
+__all__ = ["short_convolution"]

--- a/python/sgl_jax/test/test_kda_attention.py
+++ b/python/sgl_jax/test/test_kda_attention.py
@@ -1,0 +1,619 @@
+import unittest
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.kernels.kda import naive_recurrent_kda
+from sgl_jax.srt.layers.attention.linear.kda_backend import KDAAttnBackend, l2_normalize
+from sgl_jax.srt.layers.radix_linear_attention import RadixLinearAttention
+from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
+from sgl_jax.srt.mem_cache.recurrent_state_pool import RecurrentStatePool
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+
+mesh = create_device_mesh(ici_parallelism=[1, -1], dcn_parallelism=[1, 1])
+jax.sharding.set_mesh(mesh)
+
+
+def _scaled_randn(rng: np.random.Generator, shape, scale: float = 0.1) -> np.ndarray:
+    # scale=0.1 is a test-only hack: it shrinks the recurrent state so bf16 noise
+    # in the delta-rule update fits the global atol=1e-2 (shared with flashattn).
+    # Kernel correctness is validated end-to-end (MMLU-pro on tp4dp4, PR #1047);
+    # only inputs that grow the state need it (q/k/v/a/b + initial state).
+    return rng.standard_normal(shape).astype(np.float32) * scale
+
+
+def make_nnx_depthwise_conv(weight_dk: jax.Array) -> nnx.Conv:
+    """Build an nnx.Conv matching short_convolution's [D, K] depthwise kernel."""
+    weight = jnp.asarray(np.asarray(weight_dk), dtype=weight_dk.dtype)
+    hidden, kernel_size = weight.shape
+    conv = nnx.Conv(
+        in_features=hidden,
+        out_features=hidden,
+        kernel_size=(kernel_size,),
+        feature_group_count=hidden,
+        padding=[(kernel_size - 1, 0)],
+        use_bias=False,
+        rngs=nnx.Rngs(0),
+        dtype=weight.dtype,
+        param_dtype=weight.dtype,
+    )
+    conv.kernel.value = jnp.transpose(weight, (1, 0))[:, None, :].astype(conv.kernel.value.dtype)
+    return conv
+
+
+def ref_short_convolution(
+    x: jax.Array,
+    weight: jax.Array,
+    cache: jax.Array,
+    cu_seqlens: jax.Array,
+    forward_mode: ForwardMode,
+) -> tuple[jax.Array, jax.Array]:
+    """nnx.Conv baseline. All inputs must be unsharded host tensors."""
+    conv = make_nnx_depthwise_conv(weight)
+    kernel_size = conv.kernel.value.shape[0]
+    cache_width = kernel_size - 1
+
+    if forward_mode == ForwardMode.DECODE:
+        outputs = []
+        for i in range(x.shape[0]):
+            history = jnp.swapaxes(cache[i], 0, 1)
+            full = jnp.concatenate([history, x[i : i + 1]], axis=0)
+            y = conv(full[None, ...])[0]
+            outputs.append(jax.nn.silu(y[-1:]))
+        y = jnp.concatenate(outputs, axis=0)
+        new_cache = jnp.concatenate([cache, x[..., None]], axis=-1)[:, :, 1:]
+        return y, new_cache
+
+    pieces = []
+    new_cache = []
+    cu = np.asarray(cu_seqlens)
+    for i in range(len(cu) - 1):
+        start, end = int(cu[i]), int(cu[i + 1])
+        seq = x[start:end]
+        history = jnp.swapaxes(cache[i], 0, 1)
+        seq_with_history = jnp.concatenate([history, seq], axis=0)
+        y = conv(seq_with_history[None, ...])[0][cache_width:]
+        pieces.append(jax.nn.silu(y))
+
+        if seq.shape[0] >= cache_width:
+            new_cache.append(jnp.swapaxes(seq[-cache_width:], 0, 1))
+        else:
+            new_cache.append(jnp.concatenate([cache[i, :, seq.shape[0] :], seq.T], axis=1))
+
+    return jnp.concatenate(pieces, axis=0), jnp.stack(new_cache, axis=0)
+
+
+def ref_kda_attention(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    a: jax.Array,
+    b: jax.Array,
+    layer: RadixLinearAttention,
+    cu_seqlens: jax.Array,
+    initial_ssm_state: jax.Array,
+    initial_conv_state: jax.Array,
+    forward_mode: ForwardMode,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """KDA reference. All tensor inputs (q/k/v/a/b/initial_*) must be
+    unsharded host arrays. Layer params are unsharded locally.
+    """
+    num_heads = layer.num_q_heads
+    head_dim = layer.head_q_dim
+
+    a_log = jnp.asarray(np.asarray(layer.A_log.value), dtype=layer.A_log.value.dtype)
+    dt_bias = jnp.asarray(np.asarray(layer.dt_bias.value), dtype=layer.dt_bias.value.dtype)
+
+    q_state, k_state, v_state = jnp.split(initial_conv_state, 3, axis=1)
+    q, q_state = ref_short_convolution(
+        q,
+        layer.q_conv1d.weight.value,
+        q_state,
+        cu_seqlens,
+        forward_mode,
+    )
+    k, k_state = ref_short_convolution(
+        k,
+        layer.k_conv1d.weight.value,
+        k_state,
+        cu_seqlens,
+        forward_mode,
+    )
+    v, v_state = ref_short_convolution(
+        v,
+        layer.v_conv1d.weight.value,
+        v_state,
+        cu_seqlens,
+        forward_mode,
+    )
+
+    q = l2_normalize(q.reshape(q.shape[0], num_heads, head_dim))
+    k = l2_normalize(k.reshape(k.shape[0], num_heads, head_dim))
+    v = v.reshape(v.shape[0], num_heads, head_dim)
+    g = a.reshape(a.shape[0], num_heads, head_dim)
+    g = -jnp.exp(a_log.reshape(num_heads, 1).astype(jnp.float32)) * jax.nn.softplus(
+        g.astype(jnp.float32) + dt_bias.reshape(num_heads, head_dim).astype(jnp.float32)
+    )
+    g = g.astype(q.dtype)
+
+    cu = np.asarray(cu_seqlens)
+    outputs = []
+    states = []
+    for i in range(len(cu) - 1):
+        start, end = int(cu[i]), int(cu[i + 1])
+        o_i, state_i = naive_recurrent_kda(
+            q[start:end][None],
+            k[start:end][None],
+            v[start:end][None],
+            g[start:end][None],
+            b[start:end][None],
+            scale=layer.scale,
+            initial_state=initial_ssm_state[i : i + 1],
+            output_final_state=True,
+        )
+        outputs.append(o_i[0])
+        states.append(state_i[0])
+
+    output = jnp.concatenate(outputs, axis=0).reshape(q.shape[0], -1)
+    ssm_state = jnp.stack(states, axis=0)
+    conv_state = jnp.concatenate([q_state, k_state, v_state], axis=1)
+    return output, ssm_state, conv_state
+
+
+def create_random_states(
+    batch_size: int,
+    num_heads: int,
+    head_dim: int,
+    conv_kernel_size: int,
+    dtype,
+    rng: np.random.Generator,
+) -> tuple[jax.Array, jax.Array]:
+    hidden = num_heads * head_dim
+    ssm = jnp.asarray(
+        _scaled_randn(rng, (batch_size, num_heads, head_dim, head_dim)),
+        dtype=jnp.float32,
+    )
+    conv = jnp.asarray(
+        _scaled_randn(rng, (batch_size, hidden * 3, conv_kernel_size - 1)),
+        dtype=dtype,
+    )
+    return ssm, conv
+
+
+def write_initial_state(
+    pool: RecurrentStatePool,
+    layer_id: int,
+    recurrent_indices: np.ndarray,
+    ssm_state: jax.Array,
+    conv_state: jax.Array,
+) -> None:
+    recurrent_buffer, conv_buffer_list = pool.get_linear_recurrent_layer_cache(layer_id)
+    recurrent_buffer = recurrent_buffer.at[recurrent_indices].set(
+        ssm_state, out_sharding=pool.recurrent_sharding
+    )
+    conv_buffer = (
+        conv_buffer_list[0].at[recurrent_indices].set(conv_state, out_sharding=pool.conv_sharding)
+    )
+    pool.replace_buffer(([recurrent_buffer], [[conv_buffer]]))
+
+
+def gather_ssm(pool: RecurrentStatePool, recurrent_buffer: jax.Array, indices: np.ndarray):
+    return recurrent_buffer.at[indices].get(out_sharding=pool.recurrent_sharding)
+
+
+def gather_conv(pool: RecurrentStatePool, conv_buffer: jax.Array, indices: np.ndarray):
+    return conv_buffer.at[indices].get(out_sharding=pool.conv_sharding)
+
+
+def create_test_data(
+    mode: str,
+    seq_lens: list[int],
+    num_heads: int,
+    head_dim: int,
+    conv_kernel_size: int,
+    dtype,
+    rng: np.random.Generator,
+    test_mesh: jax.sharding.Mesh = mesh,
+    layer_id: int = 0,
+    all_have_initial_state: bool | list[bool] = False,
+    initial_ssm_state: jax.Array | None = None,
+    initial_conv_state: jax.Array | None = None,
+):
+    assert mode in ("prefill", "decode")
+    forward_mode = ForwardMode.EXTEND if mode == "prefill" else ForwardMode.DECODE
+    batch_size = len(seq_lens)
+
+    if isinstance(all_have_initial_state, bool):
+        has_initial_state_per_req = [all_have_initial_state] * batch_size
+    else:
+        assert len(all_have_initial_state) == batch_size, (
+            f"has_initial_state list length {len(all_have_initial_state)} "
+            f"!= batch_size {batch_size}"
+        )
+        has_initial_state_per_req = list(all_have_initial_state)
+
+    total_tokens = sum(seq_lens)
+    hidden = num_heads * head_dim
+    conv_sharding = NamedSharding(test_mesh, P("tensor", None))
+    param_head_sharding = NamedSharding(test_mesh, P("tensor", None))
+
+    def normal(shape, scale=0.1):
+        return jnp.asarray(_scaled_randn(rng, shape, scale), dtype=dtype)
+
+    def conv_weight():
+        return jax.device_put(normal((hidden, conv_kernel_size), scale=1.0), conv_sharding)
+
+    layer = RadixLinearAttention(
+        layer_id=layer_id,
+        num_q_heads=num_heads,
+        num_k_heads=num_heads,
+        num_v_heads=num_heads,
+        head_q_dim=head_dim,
+        head_k_dim=head_dim,
+        head_v_dim=head_dim,
+        q_conv1d=SimpleNamespace(weight=SimpleNamespace(value=conv_weight())),
+        k_conv1d=SimpleNamespace(weight=SimpleNamespace(value=conv_weight())),
+        v_conv1d=SimpleNamespace(weight=SimpleNamespace(value=conv_weight())),
+        activation="silu",
+        A_log=SimpleNamespace(
+            value=jax.device_put(normal((num_heads, 1), scale=1.0), param_head_sharding)
+        ),
+        dt_bias=SimpleNamespace(
+            value=jax.device_put(normal((num_heads, head_dim), scale=1.0), param_head_sharding)
+        ),
+        scale=head_dim**-0.5,
+    )
+    pool = RecurrentStatePool(
+        linear_recurrent_layer_ids=[layer_id],
+        size=batch_size,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        conv_kernel_size=conv_kernel_size,
+        mesh=test_mesh,
+        dp_size=1,
+        recurrent_partition_axis="tensor",
+        conv_partition_axis="tensor",
+        data_partition_axis="data",
+        temporal_dtype=jnp.float32,
+        conv_dtype=dtype,
+    )
+    # q/k/v/a/b unsharded for ref; reshard in run_test for the backend call.
+    q = normal((total_tokens, hidden))
+    k = normal((total_tokens, hidden))
+    v = normal((total_tokens, hidden))
+    a = normal((total_tokens, hidden))
+    b = normal((total_tokens, num_heads))
+
+    recurrent_indices = np.arange(1, batch_size + 1, dtype=np.int32)
+    initial_ssm_state_dev = initial_ssm_state
+    initial_conv_state_dev = initial_conv_state
+
+    if initial_ssm_state_dev is None or initial_conv_state_dev is None:
+        random_ssm, random_conv = create_random_states(
+            batch_size, num_heads, head_dim, conv_kernel_size, dtype, rng
+        )
+        if initial_ssm_state_dev is None:
+            initial_ssm_state_dev = random_ssm
+        if initial_conv_state_dev is None:
+            initial_conv_state_dev = random_conv
+
+    # Reshard initial state for the (sharded) pool; keep host copies for ref.
+    initial_ssm_state_dev_sharded = jax.device_put(initial_ssm_state_dev, pool.recurrent_sharding)
+    initial_conv_state_dev_sharded = jax.device_put(initial_conv_state_dev, pool.conv_sharding)
+    write_initial_state(
+        pool,
+        layer_id,
+        recurrent_indices,
+        initial_ssm_state_dev_sharded,
+        initial_conv_state_dev_sharded,
+    )
+
+    seq_lens_np = np.asarray(seq_lens, dtype=np.int32)
+    input_ids = np.arange(total_tokens, dtype=np.int32)
+    positions = np.arange(total_tokens, dtype=np.int32)
+    out_cache_loc = np.arange(total_tokens, dtype=np.int32)
+    req_pool_indices = np.arange(batch_size, dtype=np.int32)
+    extend_seq_lens = seq_lens_np if mode == "prefill" else None
+    extend_prefix_lens = np.zeros(batch_size, dtype=np.int32) if mode == "prefill" else None
+    has_initial_state_np = np.asarray(has_initial_state_per_req, dtype=np.bool_)
+
+    backend = KDAAttnBackend(mesh=test_mesh)
+
+    mwb = ModelWorkerBatch(
+        bid=1,
+        forward_mode=forward_mode,
+        input_ids=input_ids,
+        real_input_ids_len=input_ids.shape[0],
+        seq_lens=seq_lens_np,
+        out_cache_loc=out_cache_loc,
+        req_pool_indices=req_pool_indices,
+        sampling_info=None,
+        positions=positions,
+        cache_loc=out_cache_loc,
+        extend_seq_lens=extend_seq_lens,
+        extend_prefix_lens=extend_prefix_lens,
+        return_logprob=False,
+        return_output_logprob_only=False,
+        top_logprobs_nums=None,
+        token_ids_logprobs=None,
+        extend_logprob_start_lens=None,
+        extend_input_logprob_token_ids=None,
+        logits_indices=np.cumsum(seq_lens_np) - 1 if mode == "prefill" else None,
+        real_bs=batch_size,
+        real_bs_per_dp=[batch_size],
+        dp_size=1,
+        per_dp_bs_size=batch_size,
+        spec_info=None,
+        recurrent_indices=recurrent_indices,
+        has_initial_state=has_initial_state_np,
+    )
+
+    dummy_model_config = type(
+        "DummyModelConfig",
+        (),
+        {"is_embedding": False, "hf_config": type("DummyHFConfig", (), {"architectures": []})()},
+    )()
+    dummy_runner = type(
+        "DummyRunner",
+        (),
+        {"mesh": test_mesh, "attn_backend": backend, "model_config": dummy_model_config},
+    )()
+    fb = ForwardBatch.init_new(mwb, dummy_runner)
+    fb.attn_backend.forward_metadata = backend.get_forward_metadata(mwb)
+
+    mask = jnp.asarray(has_initial_state_per_req, dtype=jnp.bool_)
+    initial_ssm_ref = jnp.where(
+        mask[:, None, None, None], initial_ssm_state_dev, jnp.zeros_like(initial_ssm_state_dev)
+    )
+    initial_conv_ref = jnp.where(
+        mask[:, None, None], initial_conv_state_dev, jnp.zeros_like(initial_conv_state_dev)
+    )
+    return fb, pool, layer, q, k, v, a, b, initial_ssm_ref, initial_conv_ref, recurrent_indices
+
+
+class TestKDAAttention(unittest.TestCase):
+    NUM_HEADS = 32
+    HEAD_DIM = 128
+    CONV_KERNEL_SIZE = 4
+    DTYPE = jnp.bfloat16
+
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self.rng = np.random.default_rng(0)
+        self.rtol = 2e-2
+        self.atol = 1e-2
+
+    def run_test(
+        self,
+        mode,
+        seq_lens,
+        mode_args=None,
+        test_mesh: jax.sharding.Mesh = mesh,
+        all_have_initial_state: bool | list[bool] = False,
+        initial_ssm_state: jax.Array | None = None,
+        initial_conv_state: jax.Array | None = None,
+    ):
+        if mode_args is None:
+            mode_args = (self.NUM_HEADS, self.HEAD_DIM, self.CONV_KERNEL_SIZE, self.DTYPE)
+        num_heads, head_dim, conv_kernel_size, dtype = mode_args
+
+        (
+            forward_batch,
+            pool,
+            layer,
+            q,
+            k,
+            v,
+            a,
+            b,
+            initial_ssm_ref,
+            initial_conv_ref,
+            recurrent_indices,
+        ) = create_test_data(
+            mode,
+            seq_lens,
+            num_heads,
+            head_dim,
+            conv_kernel_size,
+            dtype,
+            self.rng,
+            test_mesh=test_mesh,
+            all_have_initial_state=all_have_initial_state,
+            initial_ssm_state=initial_ssm_state,
+            initial_conv_state=initial_conv_state,
+        )
+
+        expected, expected_ssm, expected_conv = ref_kda_attention(
+            q,
+            k,
+            v,
+            a,
+            b,
+            layer,
+            forward_batch.attn_backend.forward_metadata.cu_q_lens,
+            initial_ssm_ref,
+            initial_conv_ref,
+            forward_batch.forward_mode,
+        )
+
+        # Shard q/k/v/a/b for the actual backend call.
+        hidden_sharding = NamedSharding(test_mesh, P("data", "tensor"))
+        head_sharding = NamedSharding(test_mesh, P("data", "tensor"))
+        q_dev = jax.device_put(q, hidden_sharding)
+        k_dev = jax.device_put(k, hidden_sharding)
+        v_dev = jax.device_put(v, hidden_sharding)
+        a_dev = jax.device_put(a, hidden_sharding)
+        b_dev = jax.device_put(b, head_sharding)
+        actual, (recurrent_buffer, conv_buffer_list) = layer(
+            forward_batch, q_dev, k_dev, v_dev, a_dev, b_dev, pool
+        )
+        actual_ssm = gather_ssm(pool, recurrent_buffer, recurrent_indices)
+        actual_conv = gather_conv(pool, conv_buffer_list[0], recurrent_indices)
+
+        np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), self.rtol, self.atol)
+        np.testing.assert_allclose(
+            np.asarray(actual_ssm), np.asarray(expected_ssm), self.rtol, self.atol
+        )
+        np.testing.assert_allclose(
+            np.asarray(actual_conv), np.asarray(expected_conv), self.rtol, self.atol
+        )
+        return layer, pool, recurrent_indices, recurrent_buffer, conv_buffer_list
+
+    def random_states(self, batch_size: int):
+        return create_random_states(
+            batch_size,
+            self.NUM_HEADS,
+            self.HEAD_DIM,
+            self.CONV_KERNEL_SIZE,
+            self.DTYPE,
+            self.rng,
+        )
+
+    def test_single_seq_extend_no_shard(self):
+        one_device_mesh = create_device_mesh(
+            ici_parallelism=[1, 1],
+            dcn_parallelism=[1, 1],
+            devices=[jax.devices()[0]],
+        )
+        # Override module-level mesh so the 1-device pool sharding matches.
+        with jax.sharding.set_mesh(one_device_mesh):
+            self.run_test("prefill", [128], test_mesh=one_device_mesh)
+
+    def test_single_seq_extend(self):
+        self.run_test("prefill", [128])
+
+    def test_multi_seq_extend(self):
+        self.run_test("prefill", [64, 128, 32])
+
+    def test_extend_short_seqs(self):
+        self.run_test("prefill", [3, 7, 1])
+
+    def test_extend_with_initial_state(self):
+        ssm, conv = self.random_states(batch_size=1)
+        self.run_test(
+            "prefill",
+            [64],
+            all_have_initial_state=True,
+            initial_ssm_state=ssm,
+            initial_conv_state=conv,
+        )
+
+    def test_single_step_decode(self):
+        ssm, conv = self.random_states(batch_size=1)
+        self.run_test(
+            "decode",
+            [1],
+            all_have_initial_state=True,
+            initial_ssm_state=ssm,
+            initial_conv_state=conv,
+        )
+
+    def test_multi_request_decode(self):
+        ssm, conv = self.random_states(batch_size=3)
+        self.run_test(
+            "decode",
+            [1, 1, 1],
+            all_have_initial_state=True,
+            initial_ssm_state=ssm,
+            initial_conv_state=conv,
+        )
+
+    def test_decode_mixed_new_continuing(self):
+        ssm, conv = self.random_states(batch_size=4)
+        self.run_test(
+            "decode",
+            [1, 1, 1, 1],
+            all_have_initial_state=[True, False, True, False],
+            initial_ssm_state=ssm,
+            initial_conv_state=conv,
+        )
+
+    def test_extend_then_decode(self):
+        layer, pool, recurrent_indices, recurrent_buffer, conv_buffer_list = self.run_test(
+            "prefill", [128]
+        )
+        pool.replace_buffer(([recurrent_buffer], [conv_buffer_list]))
+
+        ssm_ref = gather_ssm(pool, recurrent_buffer, recurrent_indices)
+        conv_ref = gather_conv(pool, conv_buffer_list[0], recurrent_indices)
+        # Pool gather is sharded; ref needs unsharded.
+        ssm_ref = jnp.asarray(np.asarray(ssm_ref), dtype=ssm_ref.dtype)
+        conv_ref = jnp.asarray(np.asarray(conv_ref), dtype=conv_ref.dtype)
+        for _ in range(4):
+            (
+                forward_batch,
+                _pool,
+                _layer,
+                q,
+                k,
+                v,
+                a,
+                b,
+                _initial_ssm_ref,
+                _initial_conv_ref,
+                _recurrent_indices,
+            ) = create_test_data(
+                "decode",
+                [1],
+                self.NUM_HEADS,
+                self.HEAD_DIM,
+                self.CONV_KERNEL_SIZE,
+                self.DTYPE,
+                self.rng,
+                all_have_initial_state=True,
+                initial_ssm_state=ssm_ref,
+                initial_conv_state=conv_ref,
+            )
+            forward_batch.attn_backend.forward_metadata.recurrent_indices = jax.device_put(
+                jnp.asarray(recurrent_indices),
+                NamedSharding(mesh, P("data")),
+            )
+            expected, ssm_ref, conv_ref = ref_kda_attention(
+                q,
+                k,
+                v,
+                a,
+                b,
+                layer,
+                forward_batch.attn_backend.forward_metadata.cu_q_lens,
+                ssm_ref,
+                conv_ref,
+                ForwardMode.DECODE,
+            )
+            hidden_sharding = NamedSharding(mesh, P("data", "tensor"))
+            head_sharding = NamedSharding(mesh, P("data", "tensor"))
+            q_dev = jax.device_put(q, hidden_sharding)
+            k_dev = jax.device_put(k, hidden_sharding)
+            v_dev = jax.device_put(v, hidden_sharding)
+            a_dev = jax.device_put(a, hidden_sharding)
+            b_dev = jax.device_put(b, head_sharding)
+            actual, (recurrent_buffer, conv_buffer_list) = layer(
+                forward_batch, q_dev, k_dev, v_dev, a_dev, b_dev, pool
+            )
+            np.testing.assert_allclose(
+                np.asarray(actual), np.asarray(expected), self.rtol, self.atol
+            )
+            np.testing.assert_allclose(
+                np.asarray(gather_ssm(pool, recurrent_buffer, recurrent_indices)),
+                np.asarray(ssm_ref),
+                self.rtol,
+                self.atol,
+            )
+            np.testing.assert_allclose(
+                np.asarray(gather_conv(pool, conv_buffer_list[0], recurrent_indices)),
+                np.asarray(conv_ref),
+                self.rtol,
+                self.atol,
+            )
+            pool.replace_buffer(([recurrent_buffer], [conv_buffer_list]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sgl_jax/test/test_kda_attention_dp.py
+++ b/python/sgl_jax/test/test_kda_attention_dp.py
@@ -1,0 +1,854 @@
+import unittest
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.kernels.kda import naive_recurrent_kda
+from sgl_jax.srt.layers.attention.linear.kda_backend import KDAAttnBackend, l2_normalize
+from sgl_jax.srt.layers.radix_linear_attention import RadixLinearAttention
+from sgl_jax.srt.managers.schedule_batch import PADDING_BUCKETS, ModelWorkerBatch
+from sgl_jax.srt.mem_cache.recurrent_state_pool import RecurrentStatePool
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sgl_jax.srt.utils.common_utils import pad_to_bucket
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+from sgl_jax.test.test_utils import CustomTestCase
+
+
+def _scaled_randn(rng: np.random.Generator, shape, scale: float = 0.1) -> np.ndarray:
+    # scale=0.1 is a test-only hack: it shrinks the recurrent state so bf16 noise
+    # in the delta-rule update fits the global atol=1e-2 (shared with flashattn).
+    # Kernel correctness is validated end-to-end (MMLU-pro on tp4dp4, PR #1047);
+    # only inputs that grow the state need it (q/k/v/a/b + initial state).
+    return rng.standard_normal(shape).astype(np.float32) * scale
+
+
+# Reference baselines duplicated from test_kda_attention.py — keep in sync.
+
+
+def make_nnx_depthwise_conv(weight_dk: jax.Array) -> nnx.Conv:
+    """Build an nnx.Conv matching short_convolution's [D, K] depthwise kernel."""
+    weight = jnp.asarray(np.asarray(weight_dk), dtype=weight_dk.dtype)
+    hidden, kernel_size = weight.shape
+    conv = nnx.Conv(
+        in_features=hidden,
+        out_features=hidden,
+        kernel_size=(kernel_size,),
+        feature_group_count=hidden,
+        padding=[(kernel_size - 1, 0)],
+        use_bias=False,
+        rngs=nnx.Rngs(0),
+        dtype=weight.dtype,
+        param_dtype=weight.dtype,
+    )
+    conv.kernel.value = jnp.transpose(weight, (1, 0))[:, None, :].astype(conv.kernel.value.dtype)
+    return conv
+
+
+def ref_short_convolution(
+    x: jax.Array,
+    weight: jax.Array,
+    cache: jax.Array,
+    cu_seqlens: jax.Array,
+    forward_mode: ForwardMode,
+) -> tuple[jax.Array, jax.Array]:
+    """nnx.Conv baseline. All inputs must be unsharded host tensors."""
+    conv = make_nnx_depthwise_conv(weight)
+    kernel_size = conv.kernel.value.shape[0]
+    cache_width = kernel_size - 1
+
+    if forward_mode == ForwardMode.DECODE:
+        outputs = []
+        for i in range(x.shape[0]):
+            history = jnp.swapaxes(cache[i], 0, 1)
+            full = jnp.concatenate([history, x[i : i + 1]], axis=0)
+            y = conv(full[None, ...])[0]
+            outputs.append(jax.nn.silu(y[-1:]))
+        y = jnp.concatenate(outputs, axis=0)
+        new_cache = jnp.concatenate([cache, x[..., None]], axis=-1)[:, :, 1:]
+        return y, new_cache
+
+    pieces = []
+    new_cache = []
+    cu = np.asarray(cu_seqlens)
+    for i in range(len(cu) - 1):
+        start, end = int(cu[i]), int(cu[i + 1])
+        seq = x[start:end]
+        history = jnp.swapaxes(cache[i], 0, 1)
+        seq_with_history = jnp.concatenate([history, seq], axis=0)
+        y = conv(seq_with_history[None, ...])[0][cache_width:]
+        pieces.append(jax.nn.silu(y))
+
+        if seq.shape[0] >= cache_width:
+            new_cache.append(jnp.swapaxes(seq[-cache_width:], 0, 1))
+        else:
+            new_cache.append(jnp.concatenate([cache[i, :, seq.shape[0] :], seq.T], axis=1))
+
+    return jnp.concatenate(pieces, axis=0), jnp.stack(new_cache, axis=0)
+
+
+def ref_kda_attention(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    a: jax.Array,
+    b: jax.Array,
+    layer: RadixLinearAttention,
+    cu_seqlens: jax.Array,
+    initial_ssm_state: jax.Array,
+    initial_conv_state: jax.Array,
+    forward_mode: ForwardMode,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """KDA reference. All tensor inputs (q/k/v/a/b/initial_*) must be
+    unsharded host arrays. Layer params are unsharded locally.
+    """
+    num_heads = layer.num_q_heads
+    head_dim = layer.head_q_dim
+
+    a_log = jnp.asarray(np.asarray(layer.A_log.value), dtype=layer.A_log.value.dtype)
+    dt_bias = jnp.asarray(np.asarray(layer.dt_bias.value), dtype=layer.dt_bias.value.dtype)
+
+    q_state, k_state, v_state = jnp.split(initial_conv_state, 3, axis=1)
+    q, q_state = ref_short_convolution(
+        q,
+        layer.q_conv1d.weight.value,
+        q_state,
+        cu_seqlens,
+        forward_mode,
+    )
+    k, k_state = ref_short_convolution(
+        k,
+        layer.k_conv1d.weight.value,
+        k_state,
+        cu_seqlens,
+        forward_mode,
+    )
+    v, v_state = ref_short_convolution(
+        v,
+        layer.v_conv1d.weight.value,
+        v_state,
+        cu_seqlens,
+        forward_mode,
+    )
+
+    q = l2_normalize(q.reshape(q.shape[0], num_heads, head_dim))
+    k = l2_normalize(k.reshape(k.shape[0], num_heads, head_dim))
+    v = v.reshape(v.shape[0], num_heads, head_dim)
+    g = a.reshape(a.shape[0], num_heads, head_dim)
+    g = -jnp.exp(a_log.reshape(num_heads, 1).astype(jnp.float32)) * jax.nn.softplus(
+        g.astype(jnp.float32) + dt_bias.reshape(num_heads, head_dim).astype(jnp.float32)
+    )
+    g = g.astype(q.dtype)
+
+    cu = np.asarray(cu_seqlens)
+    outputs = []
+    states = []
+    for i in range(len(cu) - 1):
+        start, end = int(cu[i]), int(cu[i + 1])
+        o_i, state_i = naive_recurrent_kda(
+            q[start:end][None],
+            k[start:end][None],
+            v[start:end][None],
+            g[start:end][None],
+            b[start:end][None],
+            scale=layer.scale,
+            initial_state=initial_ssm_state[i : i + 1],
+            output_final_state=True,
+        )
+        outputs.append(o_i[0])
+        states.append(state_i[0])
+
+    output = jnp.concatenate(outputs, axis=0).reshape(q.shape[0], -1)
+    ssm_state = jnp.stack(states, axis=0)
+    conv_state = jnp.concatenate([q_state, k_state, v_state], axis=1)
+    return output, ssm_state, conv_state
+
+
+def set_mesh(tp_size: int, dp_size: int):
+    if tp_size * dp_size != jax.device_count():
+        raise RuntimeError(
+            f"tp_size * dp_size must equal to available device count {jax.device_count()}, but got tp_size {tp_size}, dp_size {dp_size}"
+        )
+    mesh = create_device_mesh(ici_parallelism=[dp_size, tp_size], dcn_parallelism=[1, 1])
+    jax.sharding.set_mesh(mesh)
+    return mesh
+
+
+def create_test_data(
+    mode: str,
+    lens_per_rank: dict[int, list[int]],  # {dp_rank: [seq_len, ...]}
+    num_heads: int,
+    head_dim: int,
+    conv_kernel_size: int,
+    dtype,
+    mesh,
+    dp_size: int,
+    seed: int = 0,
+    has_initial_state_per_rank: (
+        dict[int, list[bool]] | None
+    ) = None,  # {dp_rank: [has_initial_state per request]}
+):
+    """Build a ForwardBatch + RecurrentStatePool + global padded q/k/v/a/b for DP testing.
+
+    Layout strides:
+      - prefill: token-axis strided by per_dp_token_padding
+      - decode:  batch-axis strided by per_dp_bs_padding (q/k/v are [B,...])
+    Per-rank initial states are written into the pool buffer slots
+    `[dp_rank * (slots_per_rank + 1) + 1, ...]` (slot 0 of each rank reserved).
+    """
+    assert mode in ("prefill", "decode")
+    is_prefill = mode == "prefill"
+    forward_mode = ForwardMode.EXTEND if is_prefill else ForwardMode.DECODE
+    hidden = num_heads * head_dim
+    layer_id = 0
+
+    # 1. Padding: per-DP token / bs buckets.
+    max_tokens_per_dp = 0
+    max_bs_per_dp = 0
+    for reqs in lens_per_rank.values():
+        toks = sum(reqs) if is_prefill else len(reqs)
+        max_tokens_per_dp = max(max_tokens_per_dp, toks)
+        max_bs_per_dp = max(max_bs_per_dp, len(reqs))
+    per_dp_token_padding, _ = pad_to_bucket(max(max_tokens_per_dp, 1), PADDING_BUCKETS)
+    per_dp_bs_padding, _ = pad_to_bucket(max(max_bs_per_dp, 1), [1, 2, 4, 8, 16, 32, 64])
+
+    total_tokens = per_dp_token_padding * dp_size
+    total_bs = per_dp_bs_padding * dp_size
+
+    # In prefill q/k/v are [T, hidden]; in decode they are [B, hidden].
+    global_input_size = total_tokens if is_prefill else total_bs
+
+    # 2. Pool. Pool size must be divisible by dp_size; use per_dp_bs_padding * dp_size.
+    pool_size = per_dp_bs_padding * dp_size
+    pool = RecurrentStatePool(
+        linear_recurrent_layer_ids=[layer_id],
+        size=pool_size,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        conv_kernel_size=conv_kernel_size,
+        mesh=mesh,
+        dp_size=dp_size,
+        recurrent_partition_axis="tensor",
+        conv_partition_axis="tensor",
+        data_partition_axis="data",
+        temporal_dtype=jnp.float32,
+        conv_dtype=dtype,
+    )
+    slots_per_rank = pool.slots_per_rank  # valid slots per rank (excl. dummy)
+    rank_stride = slots_per_rank + 1  # +1 dummy at index 0 per rank
+
+    # 3. Layer (RadixLinearAttention) with sharded random params.
+    rng = np.random.default_rng(seed)
+    conv_sharding = NamedSharding(mesh, P("tensor", None))
+    param_head_sharding = NamedSharding(mesh, P("tensor", None))
+
+    def normal(shape, scale=0.1):
+        return jnp.asarray(_scaled_randn(rng, shape, scale), dtype=dtype)
+
+    def conv_weight():
+        return jax.device_put(normal((hidden, conv_kernel_size), scale=1.0), conv_sharding)
+
+    layer = RadixLinearAttention(
+        layer_id=layer_id,
+        num_q_heads=num_heads,
+        num_k_heads=num_heads,
+        num_v_heads=num_heads,
+        head_q_dim=head_dim,
+        head_k_dim=head_dim,
+        head_v_dim=head_dim,
+        q_conv1d=SimpleNamespace(weight=SimpleNamespace(value=conv_weight())),
+        k_conv1d=SimpleNamespace(weight=SimpleNamespace(value=conv_weight())),
+        v_conv1d=SimpleNamespace(weight=SimpleNamespace(value=conv_weight())),
+        activation="silu",
+        A_log=SimpleNamespace(
+            value=jax.device_put(normal((num_heads, 1), scale=1.0), param_head_sharding)
+        ),
+        dt_bias=SimpleNamespace(
+            value=jax.device_put(normal((num_heads, head_dim), scale=1.0), param_head_sharding)
+        ),
+        scale=head_dim**-0.5,
+    )
+
+    # 4. Per-rank random data + initial state (host NumPy; resharded later).
+    q_global = np.zeros((global_input_size, hidden), dtype=np.float32)
+    k_global = np.zeros((global_input_size, hidden), dtype=np.float32)
+    v_global = np.zeros((global_input_size, hidden), dtype=np.float32)
+    a_global = np.zeros((global_input_size, hidden), dtype=np.float32)
+    b_global = np.zeros((global_input_size, num_heads), dtype=np.float32)
+
+    seq_lens_cpu = np.zeros(total_bs, dtype=np.int32)
+    extend_seq_lens_cpu = np.zeros(total_bs, dtype=np.int32) if is_prefill else None
+    extend_prefix_lens_cpu = np.zeros(total_bs, dtype=np.int32) if is_prefill else None
+    recurrent_indices_cpu = np.zeros(total_bs, dtype=np.int32)
+    has_initial_state_cpu = np.zeros(total_bs, dtype=np.bool_)
+
+    # Pool init state buffers: full [total_slots, ...] layout, per-rank shards.
+    ssm_init_full_dev = np.zeros(
+        (pool.total_slots, num_heads, head_dim, head_dim), dtype=np.float32
+    )
+    conv_init_full_dev = np.zeros(
+        (pool.total_slots, pool.proj_size, conv_kernel_size - 1), dtype=np.float32
+    )
+
+    per_dp_infos = {}
+    for dp_rank in range(dp_size):
+        reqs = lens_per_rank.get(dp_rank, [])
+        rank_rng = np.random.default_rng(seed + dp_rank * 100 + 1)
+
+        bs_offset = dp_rank * per_dp_bs_padding
+        token_offset = dp_rank * per_dp_token_padding
+        slot_base = dp_rank * rank_stride  # dummy at slot_base, valid at slot_base+1 ..
+
+        rank_q_blocks, rank_k_blocks, rank_v_blocks = [], [], []
+        rank_a_blocks, rank_b_blocks = [], []
+        rank_seq_lens = []
+        rank_initial_ssm_ref = []
+        rank_initial_conv_ref = []
+        rank_indices = []
+        cursor = 0
+        for i, q_len in enumerate(reqs):
+            q_i = _scaled_randn(rank_rng, (q_len, hidden))
+            k_i = _scaled_randn(rank_rng, (q_len, hidden))
+            v_i = _scaled_randn(rank_rng, (q_len, hidden))
+            a_i = _scaled_randn(rank_rng, (q_len, hidden))
+            b_i = _scaled_randn(rank_rng, (q_len, num_heads))
+
+            req_has_initial_state = (
+                has_initial_state_per_rank is not None
+                and i < len(has_initial_state_per_rank.get(dp_rank, []))
+                and bool(has_initial_state_per_rank[dp_rank][i])
+            )
+            ssm_i_dev = _scaled_randn(rank_rng, (num_heads, head_dim, head_dim))
+            conv_i_dev = _scaled_randn(rank_rng, (pool.proj_size, conv_kernel_size - 1))
+            ssm_i_ref = ssm_i_dev if req_has_initial_state else np.zeros_like(ssm_i_dev)
+            conv_i_ref = conv_i_dev if req_has_initial_state else np.zeros_like(conv_i_dev)
+
+            # Per-rank local slot index: 1..slots_per_rank.
+            local_slot = i + 1
+            global_slot = slot_base + local_slot
+            recurrent_indices_cpu[bs_offset + i] = local_slot
+            seq_lens_cpu[bs_offset + i] = q_len
+            if is_prefill:
+                extend_seq_lens_cpu[bs_offset + i] = q_len
+                extend_prefix_lens_cpu[bs_offset + i] = 0
+            has_initial_state_cpu[bs_offset + i] = req_has_initial_state
+
+            ssm_init_full_dev[global_slot] = ssm_i_dev
+            conv_init_full_dev[global_slot] = conv_i_dev
+
+            if is_prefill:
+                slc = slice(token_offset + cursor, token_offset + cursor + q_len)
+                q_global[slc] = q_i
+                k_global[slc] = k_i
+                v_global[slc] = v_i
+                a_global[slc] = a_i
+                b_global[slc] = b_i
+                cursor += q_len
+            else:
+                # Decode: q_len must be 1; place at batch slot.
+                assert q_len == 1, f"decode requires q_len=1, got {q_len}"
+                idx = bs_offset + i
+                q_global[idx] = q_i[0]
+                k_global[idx] = k_i[0]
+                v_global[idx] = v_i[0]
+                a_global[idx] = a_i[0]
+                b_global[idx] = b_i[0]
+
+            rank_q_blocks.append(q_i)
+            rank_k_blocks.append(k_i)
+            rank_v_blocks.append(v_i)
+            rank_a_blocks.append(a_i)
+            rank_b_blocks.append(b_i)
+            rank_seq_lens.append(q_len)
+            rank_initial_ssm_ref.append(ssm_i_ref)
+            rank_initial_conv_ref.append(conv_i_ref)
+            rank_indices.append(local_slot)
+        per_dp_infos[dp_rank] = {
+            "q": rank_q_blocks,
+            "k": rank_k_blocks,
+            "v": rank_v_blocks,
+            "a": rank_a_blocks,
+            "b": rank_b_blocks,
+            "seq_lens": rank_seq_lens,
+            "initial_ssm_ref": rank_initial_ssm_ref,
+            "initial_conv_ref": rank_initial_conv_ref,
+            "indices": rank_indices,
+        }
+
+    # 5. Push pool init state (full buffer, sharded P("data","tensor",None,None)).
+    ssm_init_dev = jax.device_put(
+        jnp.asarray(ssm_init_full_dev, dtype=pool.temporal_dtype), pool.recurrent_sharding
+    )
+    conv_init_dev = jax.device_put(
+        jnp.asarray(conv_init_full_dev, dtype=pool.conv_dtype), pool.conv_sharding
+    )
+    pool.replace_buffer(([ssm_init_dev], [[conv_init_dev]]))
+
+    # 6. Build mwb + ForwardBatch.
+    input_ids_cpu = np.zeros(global_input_size, dtype=np.int32)
+    positions_cpu = np.zeros(global_input_size, dtype=np.int32)
+    out_cache_loc_cpu = np.arange(global_input_size, dtype=np.int32)
+    req_pool_indices_cpu = np.arange(total_bs, dtype=np.int32)
+
+    real_bs_per_dp = [len(lens_per_rank.get(r, [])) for r in range(dp_size)]
+    backend = KDAAttnBackend(mesh=mesh)
+
+    mwb = ModelWorkerBatch(
+        bid=1,
+        forward_mode=forward_mode,
+        input_ids=input_ids_cpu,
+        real_input_ids_len=input_ids_cpu.shape[0],
+        seq_lens=seq_lens_cpu,
+        out_cache_loc=out_cache_loc_cpu,
+        req_pool_indices=req_pool_indices_cpu,
+        positions=positions_cpu,
+        cache_loc=out_cache_loc_cpu,
+        extend_seq_lens=extend_seq_lens_cpu,
+        extend_prefix_lens=extend_prefix_lens_cpu,
+        sampling_info=None,
+        return_logprob=False,
+        return_output_logprob_only=False,
+        top_logprobs_nums=None,
+        token_ids_logprobs=None,
+        extend_logprob_start_lens=None,
+        extend_input_logprob_token_ids=None,
+        logits_indices=(np.zeros(total_bs, dtype=np.int32) if is_prefill else None),
+        real_bs=total_bs,
+        real_bs_per_dp=real_bs_per_dp,
+        dp_size=dp_size,
+        per_dp_bs_size=per_dp_bs_padding,
+        spec_info=None,
+        recurrent_indices=recurrent_indices_cpu,
+        has_initial_state=has_initial_state_cpu,
+    )
+
+    # ForwardBatch.init_new is the production entrypoint (see test_flashattention_dp.py).
+    dummy_model_config = type(
+        "DummyModelConfig",
+        (),
+        {"is_embedding": False, "hf_config": type("DummyHFConfig", (), {"architectures": []})()},
+    )()
+    dummy_runner = type(
+        "DummyRunner",
+        (),
+        {"mesh": mesh, "attn_backend": backend, "model_config": dummy_model_config},
+    )()
+    fb = ForwardBatch.init_new(mwb, dummy_runner)
+    fb.attn_backend.forward_metadata = backend.get_forward_metadata(mwb)
+
+    # Shard q/k/v/a/b for the actual backend call.
+    hidden_sharding = NamedSharding(mesh, P("data", "tensor"))
+    head_sharding = NamedSharding(mesh, P("data", "tensor"))
+    q_dev = jax.device_put(jnp.asarray(q_global, dtype=dtype), hidden_sharding)
+    k_dev = jax.device_put(jnp.asarray(k_global, dtype=dtype), hidden_sharding)
+    v_dev = jax.device_put(jnp.asarray(v_global, dtype=dtype), hidden_sharding)
+    a_dev = jax.device_put(jnp.asarray(a_global, dtype=dtype), hidden_sharding)
+    b_dev = jax.device_put(jnp.asarray(b_global, dtype=dtype), head_sharding)
+
+    return (
+        fb,
+        pool,
+        layer,
+        q_dev,
+        k_dev,
+        v_dev,
+        a_dev,
+        b_dev,
+        per_dp_infos,
+        per_dp_bs_padding,
+        per_dp_token_padding,
+    )
+
+
+def compute_dp_reference_kda(
+    mode: str,
+    per_dp_infos: dict,
+    layer: RadixLinearAttention,
+    dp_size: int,
+    per_dp_bs_padding: int,
+    per_dp_token_padding: int,
+    num_heads: int,
+    head_dim: int,
+    dtype,
+) -> tuple[np.ndarray, dict[int, tuple[np.ndarray, np.ndarray]]]:
+    """Per-rank baseline composed into a global padded layout.
+
+    For each dp_rank: pack per-request blocks, run ref_kda_attention once,
+    write result into the rank's stride in the global output.
+
+    Returns (global_out, {dp_rank: (final_ssm, final_conv)}).
+    """
+    is_prefill = mode == "prefill"
+    forward_mode = ForwardMode.EXTEND if is_prefill else ForwardMode.DECODE
+    hidden = num_heads * head_dim
+    global_output_size = (
+        dp_size * per_dp_token_padding if is_prefill else dp_size * per_dp_bs_padding
+    )
+    global_out = np.zeros((global_output_size, hidden), dtype=np.float32)
+    per_dp_final_states = {}
+
+    for dp_rank in range(dp_size):
+        info = per_dp_infos[dp_rank]
+        if not info["seq_lens"]:
+            continue
+        token_offset = dp_rank * per_dp_token_padding
+        bs_offset = dp_rank * per_dp_bs_padding
+
+        # Pack per-request blocks + cu_seqlens + stacked initial states.
+        q_packed = jnp.asarray(np.concatenate(info["q"], axis=0), dtype=dtype)
+        k_packed = jnp.asarray(np.concatenate(info["k"], axis=0), dtype=dtype)
+        v_packed = jnp.asarray(np.concatenate(info["v"], axis=0), dtype=dtype)
+        a_packed = jnp.asarray(np.concatenate(info["a"], axis=0), dtype=dtype)
+        b_packed = jnp.asarray(np.concatenate(info["b"], axis=0), dtype=dtype)
+        cu_seqlens = jnp.asarray([0] + np.cumsum(info["seq_lens"]).tolist(), dtype=jnp.int32)
+        initial_ssm = jnp.asarray(np.stack(info["initial_ssm_ref"], axis=0), dtype=jnp.float32)
+        initial_conv = jnp.asarray(np.stack(info["initial_conv_ref"], axis=0), dtype=dtype)
+
+        rank_out, final_ssm, final_conv = ref_kda_attention(
+            q_packed,
+            k_packed,
+            v_packed,
+            a_packed,
+            b_packed,
+            layer,
+            cu_seqlens,
+            initial_ssm,
+            initial_conv,
+            forward_mode,
+        )
+        rank_out_np = np.asarray(rank_out).reshape(-1, hidden)
+        per_dp_final_states[dp_rank] = (np.asarray(final_ssm), np.asarray(final_conv))
+
+        if is_prefill:
+            valid = sum(info["seq_lens"])
+            global_out[token_offset : token_offset + valid] = rank_out_np
+        else:
+            num_seqs = len(info["seq_lens"])
+            global_out[bs_offset : bs_offset + num_seqs] = rank_out_np
+    return global_out, per_dp_final_states
+
+
+def assert_pool_state_per_rank(
+    rec_buf: jax.Array,
+    conv_buf: jax.Array,
+    ref_ssm_per_rank: dict[int, np.ndarray],
+    ref_conv_per_rank: dict[int, np.ndarray],
+    per_dp_infos: dict,
+    dp_size: int,
+    rtol: float,
+    atol: float,
+    err_prefix: str,
+):
+    rec_np = np.asarray(rec_buf)
+    conv_np = np.asarray(conv_buf)
+    rank_stride = rec_np.shape[0] // dp_size
+    for dp_rank in range(dp_size):
+        info = per_dp_infos[dp_rank]
+        if not info["seq_lens"]:
+            continue
+        slot_base = dp_rank * rank_stride
+        global_slots = [slot_base + s for s in info["indices"]]
+        actual_ssm = rec_np[global_slots]
+        actual_conv = conv_np[global_slots]
+        np.testing.assert_allclose(
+            actual_ssm,
+            ref_ssm_per_rank[dp_rank],
+            rtol=rtol,
+            atol=atol,
+            err_msg=f"{err_prefix}: pool ssm rank {dp_rank}",
+        )
+        np.testing.assert_allclose(
+            actual_conv,
+            ref_conv_per_rank[dp_rank],
+            rtol=rtol,
+            atol=atol,
+            err_msg=f"{err_prefix}: pool conv rank {dp_rank}",
+        )
+
+
+class TestKDAAttentionDP(CustomTestCase):
+    NUM_HEADS = 32
+    HEAD_DIM = 128
+    CONV_KERNEL_SIZE = 4
+    DTYPE = jnp.bfloat16
+
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self.rtol = 2e-2
+        self.atol = 2e-2
+
+    def _run_test(
+        self,
+        mode: str,
+        lens_per_rank: dict[int, list[int]],
+        dp_size: int,
+        tp_size: int,
+        has_initial_state_per_rank: dict[int, list[bool]] | None = None,
+    ):
+        mesh = set_mesh(tp_size=tp_size, dp_size=dp_size)
+        (
+            fb,
+            pool,
+            layer,
+            q,
+            k,
+            v,
+            a,
+            b,
+            per_dp_infos,
+            per_dp_bs_padding,
+            per_dp_token_padding,
+        ) = create_test_data(
+            mode,
+            lens_per_rank,
+            self.NUM_HEADS,
+            self.HEAD_DIM,
+            self.CONV_KERNEL_SIZE,
+            self.DTYPE,
+            mesh,
+            dp_size=dp_size,
+            has_initial_state_per_rank=has_initial_state_per_rank,
+        )
+        expected, ref_states = compute_dp_reference_kda(
+            mode,
+            per_dp_infos,
+            layer,
+            dp_size=dp_size,
+            per_dp_bs_padding=per_dp_bs_padding,
+            per_dp_token_padding=per_dp_token_padding,
+            num_heads=self.NUM_HEADS,
+            head_dim=self.HEAD_DIM,
+            dtype=self.DTYPE,
+        )
+        actual, (rec_buf, conv_buf_list) = layer(fb, q, k, v, a, b, pool)
+        actual_np = np.asarray(actual)
+
+        # Compare only rank-valid positions; padded slots hold kernel garbage.
+        is_prefill = mode == "prefill"
+        for dp_rank in range(dp_size):
+            info = per_dp_infos[dp_rank]
+            if not info["seq_lens"]:
+                continue
+            valid = sum(info["seq_lens"]) if is_prefill else len(info["seq_lens"])
+            offset = dp_rank * per_dp_token_padding if is_prefill else dp_rank * per_dp_bs_padding
+            np.testing.assert_allclose(
+                actual_np[offset : offset + valid],
+                expected[offset : offset + valid],
+                rtol=self.rtol,
+                atol=self.atol,
+                err_msg=f"DP rank {dp_rank} output mismatch",
+            )
+
+        ref_ssm_per_rank = {r: s for r, (s, _) in ref_states.items()}
+        ref_conv_per_rank = {r: c for r, (_, c) in ref_states.items()}
+        assert_pool_state_per_rank(
+            rec_buf,
+            conv_buf_list[0],
+            ref_ssm_per_rank,
+            ref_conv_per_rank,
+            per_dp_infos,
+            dp_size=dp_size,
+            rtol=self.rtol,
+            atol=self.atol,
+            err_prefix=mode,
+        )
+        # Returned for chained tests like extend_then_decode.
+        return SimpleNamespace(
+            mesh=mesh,
+            fb=fb,
+            pool=pool,
+            layer=layer,
+            rec_buf=rec_buf,
+            conv_buf_list=conv_buf_list,
+            per_dp_infos=per_dp_infos,
+            per_dp_bs_padding=per_dp_bs_padding,
+            per_dp_token_padding=per_dp_token_padding,
+            ref_ssm_per_rank=ref_ssm_per_rank,
+            ref_conv_per_rank=ref_conv_per_rank,
+        )
+
+    def test_extend_dp4_tp1(self):
+        self._run_test(
+            "prefill",
+            {0: [128], 1: [64], 2: [32, 64], 3: [128]},
+            dp_size=4,
+            tp_size=1,
+        )
+
+    def test_extend_sparse_ranks_dp4(self):
+        self._run_test(
+            "prefill",
+            {0: [64], 1: [], 2: [128], 3: []},
+            dp_size=4,
+            tp_size=1,
+        )
+
+    def test_decode_dp4_tp1(self):
+        self._run_test(
+            "decode",
+            {0: [1, 1], 1: [1], 2: [1, 1], 3: [1]},
+            dp_size=4,
+            tp_size=1,
+        )
+
+    def test_decode_sparse_ranks_dp4(self):
+        self._run_test(
+            "decode",
+            {0: [], 1: [1, 1], 2: [], 3: [1]},
+            dp_size=4,
+            tp_size=1,
+        )
+
+    def test_decode_unbalanced_dp4(self):
+        # Unbalanced bs across DP ranks; per_dp_bs_padding bucketed to max.
+        self._run_test(
+            "decode",
+            {0: [1], 1: [1, 1, 1], 2: [1], 3: [1, 1, 1, 1]},
+            dp_size=4,
+            tp_size=1,
+        )
+
+    def test_extend_dp2_tp2(self):
+        self._run_test(
+            "prefill",
+            {0: [128, 64], 1: [32]},
+            dp_size=2,
+            tp_size=2,
+        )
+
+    def test_dp_state_isolation_dp4(self):
+        # Per-rank distinct initial state; verifies no cross-rank state leakage.
+        lens = {0: [1, 1], 1: [1], 2: [1, 1], 3: [1]}
+        has_initial_state_per_rank = {rank: [True] * len(reqs) for rank, reqs in lens.items()}
+        self._run_test(
+            "decode",
+            lens,
+            dp_size=4,
+            tp_size=1,
+            has_initial_state_per_rank=has_initial_state_per_rank,
+        )
+
+    def test_dp_mixed_new_continuing_dp4(self):
+        lens = {0: [1, 1], 1: [1, 1], 2: [1, 1], 3: [1, 1]}
+        has_initial_state_per_rank = {
+            0: [False, False],
+            1: [True, True],
+            2: [True, False],
+            3: [False, True],
+        }
+        self._run_test(
+            "decode",
+            lens,
+            dp_size=4,
+            tp_size=1,
+            has_initial_state_per_rank=has_initial_state_per_rank,
+        )
+
+    def test_dp_extend_then_decode_dp4(self):
+        # Multi-round prefill -> decode handover under DP; reuses _run_test for prefill.
+        dp_size, tp_size = 4, 1
+        lens_prefill = {0: [128], 1: [64], 2: [32, 64], 3: [128]}
+        prefill = self._run_test("prefill", lens_prefill, dp_size=dp_size, tp_size=tp_size)
+        rec_buf = prefill.rec_buf
+        conv_buf_list = prefill.conv_buf_list
+        ref_ssm_per_rank = prefill.ref_ssm_per_rank
+        ref_conv_per_rank = prefill.ref_conv_per_rank
+
+        decode_lens = {r: [1] * len(reqs) for r, reqs in lens_prefill.items()}
+        for step in range(4):
+            (
+                fb_d,
+                _pool_d,
+                _layer_d,
+                q_d,
+                k_d,
+                v_d,
+                a_d,
+                b_d,
+                per_dp_infos_d,
+                per_dp_bs_padding_d,
+                per_dp_token_padding_d,
+            ) = create_test_data(
+                "decode",
+                decode_lens,
+                self.NUM_HEADS,
+                self.HEAD_DIM,
+                self.CONV_KERNEL_SIZE,
+                self.DTYPE,
+                prefill.mesh,
+                dp_size=dp_size,
+                seed=100 + step,
+                has_initial_state_per_rank={
+                    r: [True] * len(reqs) for r, reqs in decode_lens.items()
+                },
+            )
+
+            round_metadata = fb_d.attn_backend.forward_metadata
+            fb_d.attn_backend = prefill.fb.attn_backend
+            fb_d.attn_backend.forward_metadata = round_metadata
+            prefill.pool.replace_buffer(([rec_buf], [conv_buf_list]))
+
+            actual_d, (rec_buf, conv_buf_list) = prefill.layer(
+                fb_d, q_d, k_d, v_d, a_d, b_d, prefill.pool
+            )
+            actual_d_np = np.asarray(actual_d)
+
+            for dp_rank in range(dp_size):
+                if dp_rank in ref_ssm_per_rank:
+                    ssm_stack = ref_ssm_per_rank[dp_rank]
+                    conv_stack = ref_conv_per_rank[dp_rank]
+                    per_dp_infos_d[dp_rank]["initial_ssm_ref"] = [
+                        ssm_stack[i] for i in range(ssm_stack.shape[0])
+                    ]
+                    per_dp_infos_d[dp_rank]["initial_conv_ref"] = [
+                        conv_stack[i] for i in range(conv_stack.shape[0])
+                    ]
+
+            expected_d, ref_states_d = compute_dp_reference_kda(
+                "decode",
+                per_dp_infos_d,
+                prefill.layer,
+                dp_size=dp_size,
+                per_dp_bs_padding=per_dp_bs_padding_d,
+                per_dp_token_padding=per_dp_token_padding_d,
+                num_heads=self.NUM_HEADS,
+                head_dim=self.HEAD_DIM,
+                dtype=self.DTYPE,
+            )
+            ref_ssm_per_rank = {r: s for r, (s, _) in ref_states_d.items()}
+            ref_conv_per_rank = {r: c for r, (_, c) in ref_states_d.items()}
+
+            for dp_rank in range(dp_size):
+                info_d = per_dp_infos_d[dp_rank]
+                if not info_d["seq_lens"]:
+                    continue
+                num_seqs = len(info_d["seq_lens"])
+                offset = dp_rank * per_dp_bs_padding_d
+                np.testing.assert_allclose(
+                    actual_d_np[offset : offset + num_seqs],
+                    expected_d[offset : offset + num_seqs],
+                    rtol=self.rtol,
+                    atol=self.atol,
+                    err_msg=f"decode round {step}: rank {dp_rank}",
+                )
+
+            assert_pool_state_per_rank(
+                rec_buf,
+                conv_buf_list[0],
+                ref_ssm_per_rank,
+                ref_conv_per_rank,
+                per_dp_infos_d,
+                dp_size=dp_size,
+                rtol=self.rtol,
+                atol=self.atol,
+                err_prefix=f"decode round {step}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sgl_jax/test/test_short_conv.py
+++ b/python/sgl_jax/test/test_short_conv.py
@@ -1,0 +1,455 @@
+"""Tests for ``short_convolution`` against an ``nnx.Conv`` baseline.
+
+``short_convolution`` is variable-length aware (it accepts a packed
+``[total_tokens, hidden]`` input together with ``cu_seqlens``) while
+``nnx.Conv`` operates on a single ``[1, T, D]`` sample. To compare them we
+run ``short_convolution`` once on the packed batch, then run ``nnx.Conv``
+sequence-by-sequence and concatenate the per-sequence outputs back into the
+packed layout. Decode mode is also exercised by stepping the conv one token
+at a time and checking the rolling cache against the equivalent ``nnx.Conv``
+output on the full prefix.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+
+from sgl_jax.srt.layers.attention.linear.short_convolution import short_convolution
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+from sgl_jax.test.test_utils import CustomTestCase
+
+
+def _make_weight(rng: np.random.Generator, hidden: int, kernel: int, dtype):
+    """Random depthwise conv kernel, shape [D, K]."""
+    w = rng.standard_normal((hidden, kernel)).astype(np.float32) * 0.1
+    return jnp.asarray(w, dtype=dtype)
+
+
+def _make_nnx_conv(weight_dk: jax.Array, kernel_size: int, hidden: int):
+    """Build an ``nnx.Conv`` whose kernel matches ``weight_dk`` ([D, K]).
+
+    nnx.Conv depthwise convention with ``feature_group_count=hidden`` and
+    ``in_features=hidden`` expects kernel shape ``[K, 1, D]``. We construct
+    a fresh module then overwrite its kernel.
+    """
+    conv = nnx.Conv(
+        in_features=hidden,
+        out_features=hidden,
+        kernel_size=(kernel_size,),
+        feature_group_count=hidden,
+        padding=[(kernel_size - 1, 0)],  # left-pad → causal
+        use_bias=False,
+        rngs=nnx.Rngs(0),
+        dtype=weight_dk.dtype,
+        param_dtype=weight_dk.dtype,
+    )
+    # weight_dk: [D, K]  ->  nnx kernel: [K, 1, D]
+    kernel_kid = jnp.transpose(weight_dk, (1, 0))[:, None, :]
+    conv.kernel.value = kernel_kid.astype(conv.kernel.value.dtype)
+    return conv
+
+
+def _baseline_extend(
+    x_packed: jax.Array,
+    cu_seqlens: jax.Array,
+    conv: nnx.Conv,
+    initial_cache: jax.Array,
+) -> jax.Array:
+    """Run nnx.Conv per sequence and concat outputs back to packed layout.
+
+    For each sequence, prepend the K-1 tokens of its initial cache so the
+    causal conv sees the same history as ``short_convolution``. The cache
+    width is ``K-1`` (vLLM convention) and stores the prior K-1 tokens
+    in temporal order.
+    """
+    K = conv.kernel.value.shape[0]
+    pieces = []
+    cu = np.asarray(cu_seqlens)
+    for i in range(len(cu) - 1):
+        start, end = int(cu[i]), int(cu[i + 1])
+        seq = x_packed[start:end]  # [T_i, D]
+        # Cache holds the prior K-1 tokens; use them all as history.
+        history = initial_cache[i]  # [D, K-1]
+        history_t = jnp.swapaxes(history, 0, 1)  # [K-1, D]
+        seq_with_history = jnp.concatenate([history_t, seq], axis=0)  # [K-1+T_i, D]
+        # nnx.Conv expects [B, T, D]; we used left-pad of K-1 already, but
+        # we also baked the real history in. To prevent double-counting,
+        # use ``padding="VALID"`` semantics by manually trimming: run with
+        # the conv's own (K-1, 0) left pad, then drop the first K-1 outputs
+        # corresponding to the injected history.
+        y = conv(seq_with_history[None, ...])[0]  # [(K-1)+T_i, D]
+        y = y[K - 1 :]  # drop outputs over the injected history
+        pieces.append(jax.nn.silu(y))
+    return jnp.concatenate(pieces, axis=0)
+
+
+def _baseline_decode(
+    x_step: jax.Array,  # [B, D]
+    prior_inputs: list[jax.Array],  # per-seq history of past tokens, each [T_i, D]
+    conv: nnx.Conv,
+) -> jax.Array:
+    """Decode baseline: run nnx.Conv on (history + new_token) per seq, take
+    the last output position."""
+    K = conv.kernel.value.shape[0]
+    outs = []
+    for i, hist in enumerate(prior_inputs):
+        full = jnp.concatenate([hist, x_step[i : i + 1]], axis=0)  # [T+1, D]
+        # Pad on the left so the conv is causal even when T+1 < K.
+        if full.shape[0] < K:
+            pad = jnp.zeros((K - full.shape[0], full.shape[1]), dtype=full.dtype)
+            full = jnp.concatenate([pad, full], axis=0)
+        y = conv(full[None, ...])[0]  # padding=(K-1,0) → output length = full.shape[0]
+        outs.append(jax.nn.silu(y[-1:]))
+    return jnp.concatenate(outs, axis=0)
+
+
+class ShortConvolutionTest(CustomTestCase):
+    """Compare ``short_convolution`` against an ``nnx.Conv`` baseline."""
+
+    def setUp(self):
+        super().setUp()
+        self.rng = np.random.default_rng(0)
+        self.dtype = jnp.float32  # use fp32 for tighter numerical comparison
+        self.atol = 1e-4
+        self.rtol = 1e-4
+
+    # ------------------------------------------------------------------
+    # EXTEND mode
+    # ------------------------------------------------------------------
+
+    def _run_extend_case(self, seq_lens, hidden, kernel, has_prior_cache):
+        total = sum(seq_lens)
+        cu_seqlens = jnp.asarray(np.concatenate([[0], np.cumsum(seq_lens)]), dtype=jnp.int32)
+        x = jnp.asarray(
+            self.rng.standard_normal((total, hidden)).astype(np.float32),
+            dtype=self.dtype,
+        )
+        weight = _make_weight(self.rng, hidden, kernel, self.dtype)
+
+        B = len(seq_lens)
+        W = kernel - 1  # vLLM-style cache width
+        if has_prior_cache:
+            cache = jnp.asarray(
+                self.rng.standard_normal((B, hidden, W)).astype(np.float32),
+                dtype=self.dtype,
+            )
+        else:
+            cache = jnp.zeros((B, hidden, W), dtype=self.dtype)
+
+        # short_convolution: one shot over the packed batch.
+        y_short, new_cache = short_convolution(
+            x,
+            weight,
+            cache,
+            cu_seqlens,
+            ForwardMode.EXTEND,
+            bias=None,
+            activation="silu",
+        )
+        self.assertEqual(y_short.shape, (total, hidden))
+        self.assertEqual(new_cache.shape, (B, hidden, W))
+
+        # Baseline: nnx.Conv per sequence with injected history.
+        conv = _make_nnx_conv(weight, kernel, hidden)
+        y_ref = _baseline_extend(x, cu_seqlens, conv, cache)
+
+        np.testing.assert_allclose(
+            np.asarray(y_short),
+            np.asarray(y_ref),
+            atol=self.atol,
+            rtol=self.rtol,
+        )
+
+        # New cache should be the last W = K-1 input tokens of each sequence,
+        # falling back to prior cache slots when the sequence is shorter.
+        cu = np.asarray(cu_seqlens)
+        for i in range(B):
+            start, end = int(cu[i]), int(cu[i + 1])
+            T_i = end - start
+            seq = np.asarray(x[start:end])  # [T_i, D]
+            old = np.asarray(cache[i])  # [D, W]
+            expected = (
+                seq[-W:].T  # [D, W]
+                if T_i >= W
+                else np.concatenate([old[:, T_i:], seq.T], axis=1)  # [D, W]
+            )
+            np.testing.assert_allclose(
+                np.asarray(new_cache[i]),
+                expected,
+                atol=self.atol,
+                rtol=self.rtol,
+            )
+
+    def test_extend_single_sequence_no_prior_cache(self):
+        self._run_extend_case(seq_lens=[7], hidden=1024, kernel=4, has_prior_cache=False)
+
+    def test_extend_multi_sequence_no_prior_cache(self):
+        self._run_extend_case(seq_lens=[5, 3, 9], hidden=1024, kernel=4, has_prior_cache=False)
+
+    def test_extend_multi_sequence_with_prior_cache(self):
+        self._run_extend_case(seq_lens=[5, 3, 9], hidden=1024, kernel=4, has_prior_cache=True)
+
+    def test_extend_short_sequence_with_prior_cache(self):
+        # Sequence shorter than kernel → new cache must mix prior cache
+        # tail with the few new tokens.
+        self._run_extend_case(seq_lens=[1, 2, 3], hidden=1024, kernel=4, has_prior_cache=True)
+
+    def test_extend_kernel_size_2(self):
+        self._run_extend_case(seq_lens=[3, 4], hidden=1024, kernel=2, has_prior_cache=True)
+
+    # ------------------------------------------------------------------
+    # DECODE mode
+    # ------------------------------------------------------------------
+
+    def test_decode_single_step_against_baseline(self):
+        B, hidden, kernel = 3, 1024, 4
+        W = kernel - 1
+        weight = _make_weight(self.rng, hidden, kernel, self.dtype)
+
+        # Build a per-sequence prior history of varying lengths so the cache
+        # represents a real prefix.
+        histories = [
+            jnp.asarray(
+                self.rng.standard_normal((L, hidden)).astype(np.float32),
+                dtype=self.dtype,
+            )
+            for L in [5, 2, 7]
+        ]
+        # Construct the cache: width W = K-1, holds the last W prior tokens
+        # in temporal order. If the history is shorter than W, left-pad with
+        # zeros (slot W-1 is the most recent).
+        cache = np.zeros((B, hidden, W), dtype=np.float32)
+        for i, h in enumerate(histories):
+            h_np = np.asarray(h)
+            take = min(W, h_np.shape[0])
+            # Place the last `take` tokens into the rightmost slots.
+            cache[i, :, W - take :] = h_np[-take:].T
+        cache = jnp.asarray(cache, dtype=self.dtype)
+
+        x_step = jnp.asarray(
+            self.rng.standard_normal((B, hidden)).astype(np.float32),
+            dtype=self.dtype,
+        )
+
+        y_short, new_cache = short_convolution(
+            x_step,
+            weight,
+            cache,
+            cu_seqlens=None,
+            forward_mode=ForwardMode.DECODE,
+            bias=None,
+            activation="silu",
+        )
+        self.assertEqual(y_short.shape, (B, hidden))
+        self.assertEqual(new_cache.shape, (B, hidden, W))
+
+        conv = _make_nnx_conv(weight, kernel, hidden)
+        y_ref = _baseline_decode(x_step, histories, conv)
+
+        np.testing.assert_allclose(
+            np.asarray(y_short),
+            np.asarray(y_ref),
+            atol=self.atol,
+            rtol=self.rtol,
+        )
+
+        # New cache should equal old cache shifted left + new x at slot W-1.
+        for i in range(B):
+            old = np.asarray(cache[i])
+            expected = np.concatenate([old[:, 1:], np.asarray(x_step[i])[:, None]], axis=1)
+            np.testing.assert_allclose(
+                np.asarray(new_cache[i]),
+                expected,
+                atol=self.atol,
+                rtol=self.rtol,
+            )
+
+    def test_decode_rolling_matches_extend(self):
+        """Decoding token-by-token should match running extend on the full
+        sequence in one shot."""
+        T, hidden, kernel = 6, 1024, 4
+        W = kernel - 1
+        seq = jnp.asarray(
+            self.rng.standard_normal((T, hidden)).astype(np.float32),
+            dtype=self.dtype,
+        )
+        weight = _make_weight(self.rng, hidden, kernel, self.dtype)
+
+        # One-shot extend (single sequence, no prior cache).
+        cu = jnp.asarray([0, T], dtype=jnp.int32)
+        y_extend, _ = short_convolution(
+            seq,
+            weight,
+            jnp.zeros((1, hidden, W), dtype=self.dtype),
+            cu,
+            ForwardMode.EXTEND,
+            bias=None,
+            activation="silu",
+        )
+
+        # Token-by-token decode starting from a zero cache.
+        cache = jnp.zeros((1, hidden, W), dtype=self.dtype)
+        outs = []
+        for t in range(T):
+            y_step, cache = short_convolution(
+                seq[t : t + 1],
+                weight,
+                cache,
+                cu_seqlens=None,
+                forward_mode=ForwardMode.DECODE,
+                bias=None,
+                activation="silu",
+            )
+            outs.append(y_step)
+        y_decode = jnp.concatenate(outs, axis=0)
+
+        np.testing.assert_allclose(
+            np.asarray(y_decode),
+            np.asarray(y_extend),
+            atol=self.atol,
+            rtol=self.rtol,
+        )
+
+    # ------------------------------------------------------------------
+    # Bias / activation paths
+    # ------------------------------------------------------------------
+
+    def test_bias_added_before_activation(self):
+        T, hidden, kernel = 4, 1024, 3
+        x = jnp.asarray(
+            self.rng.standard_normal((T, hidden)).astype(np.float32),
+            dtype=self.dtype,
+        )
+        weight = _make_weight(self.rng, hidden, kernel, self.dtype)
+        bias = jnp.asarray(
+            self.rng.standard_normal((hidden,)).astype(np.float32),
+            dtype=self.dtype,
+        )
+        cache = jnp.zeros((1, hidden, kernel - 1), dtype=self.dtype)
+        cu = jnp.asarray([0, T], dtype=jnp.int32)
+
+        y_with_bias, _ = short_convolution(
+            x, weight, cache, cu, ForwardMode.EXTEND, bias=bias, activation="silu"
+        )
+        y_no_bias, _ = short_convolution(
+            x, weight, cache, cu, ForwardMode.EXTEND, bias=None, activation=None
+        )
+        # silu(no_bias_pre + bias) should differ from no_bias and not be
+        # simply (no_bias + bias) because of the silu nonlinearity.
+        diff = np.asarray(y_with_bias) - np.asarray(y_no_bias)
+        self.assertGreater(float(np.max(np.abs(diff))), 1e-4)
+
+    def test_activation_none_skips_silu(self):
+        T, hidden, kernel = 4, 1024, 3
+        x = jnp.asarray(
+            self.rng.standard_normal((T, hidden)).astype(np.float32),
+            dtype=self.dtype,
+        )
+        weight = _make_weight(self.rng, hidden, kernel, self.dtype)
+        cache = jnp.zeros((1, hidden, kernel - 1), dtype=self.dtype)
+        cu = jnp.asarray([0, T], dtype=jnp.int32)
+
+        y_silu, _ = short_convolution(
+            x, weight, cache, cu, ForwardMode.EXTEND, bias=None, activation="silu"
+        )
+        y_none, _ = short_convolution(
+            x, weight, cache, cu, ForwardMode.EXTEND, bias=None, activation=None
+        )
+        np.testing.assert_allclose(
+            np.asarray(y_silu),
+            np.asarray(jax.nn.silu(y_none)),
+            atol=self.atol,
+            rtol=self.rtol,
+        )
+
+    def test_invalid_activation_raises(self):
+        with self.assertRaises(ValueError):
+            short_convolution(
+                jnp.zeros((1, 4)),
+                jnp.zeros((4, 3)),
+                jnp.zeros((1, 4, 2)),
+                jnp.asarray([0, 1], dtype=jnp.int32),
+                ForwardMode.EXTEND,
+                activation="not_a_real_activation",
+            )
+
+    def test_activation_named_relu_matches_jax_relu(self):
+        T, hidden, kernel = 4, 1024, 3
+        x = jnp.asarray(
+            self.rng.standard_normal((T, hidden)).astype(np.float32),
+            dtype=self.dtype,
+        )
+        weight = _make_weight(self.rng, hidden, kernel, self.dtype)
+        cache = jnp.zeros((1, hidden, kernel - 1), dtype=self.dtype)
+        cu = jnp.asarray([0, T], dtype=jnp.int32)
+
+        y_relu, _ = short_convolution(
+            x, weight, cache, cu, ForwardMode.EXTEND, bias=None, activation="relu"
+        )
+        y_none, _ = short_convolution(
+            x, weight, cache, cu, ForwardMode.EXTEND, bias=None, activation=None
+        )
+        np.testing.assert_allclose(
+            np.asarray(y_relu),
+            np.asarray(jax.nn.relu(y_none)),
+            atol=self.atol,
+            rtol=self.rtol,
+        )
+
+    def test_activation_callable_is_used(self):
+        T, hidden, kernel = 4, 1024, 3
+        x = jnp.asarray(
+            self.rng.standard_normal((T, hidden)).astype(np.float32),
+            dtype=self.dtype,
+        )
+        weight = _make_weight(self.rng, hidden, kernel, self.dtype)
+        cache = jnp.zeros((1, hidden, kernel - 1), dtype=self.dtype)
+        cu = jnp.asarray([0, T], dtype=jnp.int32)
+
+        y_callable, _ = short_convolution(
+            x, weight, cache, cu, ForwardMode.EXTEND, bias=None, activation=jax.nn.gelu
+        )
+        y_none, _ = short_convolution(
+            x, weight, cache, cu, ForwardMode.EXTEND, bias=None, activation=None
+        )
+        np.testing.assert_allclose(
+            np.asarray(y_callable),
+            np.asarray(jax.nn.gelu(y_none)),
+            atol=self.atol,
+            rtol=self.rtol,
+        )
+
+    def test_extend_requires_cu_seqlens(self):
+        with self.assertRaises(ValueError):
+            short_convolution(
+                jnp.zeros((1, 4)),
+                jnp.zeros((4, 3)),
+                jnp.zeros((1, 4, 2)),
+                cu_seqlens=None,
+                forward_mode=ForwardMode.EXTEND,
+            )
+
+
+class ShortConvolutionBF16Test(ShortConvolutionTest):
+    """Same suite as ShortConvolutionTest but with bf16 inputs/weights.
+
+    bf16 has ~3 decimal digits of mantissa, so we relax the tolerances
+    accordingly. This exercises the dtype-preserving code path: the
+    convolution should run end-to-end in bf16 (no internal fp32
+    upcast) and match an nnx.Conv baseline that also runs in bf16.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.dtype = jnp.bfloat16
+        self.atol = 1e-2
+        self.rtol = 1e-2
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -478,6 +478,8 @@ suites = {
         TestFile("python/sgl_jax/test/test_mesh.py", 1),
         TestFile("python/sgl_jax/test/test_linear_tp.py", 1, runner="pytest"),
         TestFile("python/sgl_jax/test/layers/test_linear_attention.py", 5, runner="pytest"),
+        TestFile("python/sgl_jax/test/test_kda_attention.py", 4),
+        TestFile("python/sgl_jax/test/test_kda_attention_dp.py", 4),
         TestFile("test/srt/test_moe_block_quant_e2e.py", 5, runner="pytest"),
     ],
     "kernel-performance-test-tpu-v6e-1": [


### PR DESCRIPTION
## Summary

Adds the KDA (Kimi Delta Attention) inference components for sglang-jax, enabling hybrid linear-attention model serving (e.g. Kimi-Linear, #937). Includes DP support via `shard_map`.

## Changes

**Kernels** (`srt/kernels/kda/`)
- `kda.py` — chunked Pallas forward (gate cumsum → intra-chunk delta-rule solve → inter-chunk state propagation → output computation), varlen alignment helpers
- `naive.py` — step-by-step recurrent reference, used as decode path and test baseline

**Layers** (`srt/layers/attention/linear/`)
- `short_convolution.py` — stateless depthwise causal conv1d with EXTEND (cu_seqlens-aware) and DECODE (rolling cache) paths
- `kda_backend.py` — `KDAAttnBackend` extending `LinearRecurrentAttnBackend`: conv → L2 norm → recurrent kernel dispatch, conv state pack/unpack, pool gather/scatter via `shard_map` for DP

**Tests** (`test/`)
- `test_short_conv.py` — 24 tests, conv correctness vs `nnx.Conv` baseline (fp32 + bf16)
- `test_kda_attention.py` — 9 backend tests at TP=4 (rtol/atol = 2e-2 / 1e-2)
- `test_kda_attention_dp.py` — 9 DP tests covering DP=4/TP=1 and DP=2/TP=2 (sparse ranks, unbalanced batches, mixed `has_initial_state`, multi-round prefill→decode)

## Test plan

- [x] `pytest python/sgl_jax/test/test_short_conv.py` → 24/24 (TPU v6e-4)
- [x] `pytest python/sgl_jax/test/test_kda_attention.py` → 9/9 (TPU v6e-4)
- [x] `pytest python/sgl_jax/test/test_kda_attention_dp.py` → 9/9 (TPU v6e-4)

## References

- RFC: #1038
- Issue: #937
- Hybrid memory pool: #1034
- Linear attention dispatch: #1041