### PR TITLE
Add pure JAX allreduce metadata path for FusedMoe kernel

### DIFF
--- a/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
@@ -510,6 +510,9 @@ def _fused_ep_moe_kernel(
     w1_shared_scale_hbm,  # None | (1, 1, se_inter)
     w3_shared_scale_hbm,  # None | (1, 1, se_inter)
     w2_shared_scale_hbm,  # None | (1, 1, hidden_size)
+    metadata_starts_hbm,  # None | (num_bt, 1, padded_num_experts) int32
+    metadata_sizes_hbm,  # None | (num_bt, 1, padded_num_experts) int32
+    metadata_d2e_counts_hbm,  # None | (num_bt, num_devices, 1, padded_num_experts) int32
     # Output
     output_hbm,  # (local_num_tokens, hidden_size)
     # Scratch
@@ -570,6 +573,7 @@ def _fused_ep_moe_kernel(
     disable_shared_expert: bool = False,
     disable_all_reduce_metadata: bool = False,
     disable_sync_barrier: bool = False,
+    use_jax_allreduce_metadata: bool = True,
     quant_block_k: int | None = None,
     # Kernel tuning params.
     bt: int,  # Outer token tile size (output tiling).
@@ -703,9 +707,88 @@ def _fused_ep_moe_kernel(
             sem=local_sems.at[bt_sem_id, 13],
         ).wait()
 
-    def all_reduce_metadata(*, bt_sem_id, t2e_routing, starts, sizes):
+    def all_reduce_metadata(*, bt_id, bt_sem_id, t2e_routing, starts, sizes):
         send_sem = send_x2_sems.at[0]
         recv_sem = recv_x2_sems.at[0]
+
+        if use_jax_allreduce_metadata and metadata_starts_hbm is not None:
+            metadata_starts_sem = local_sems.at[bt_sem_id, 14]
+            metadata_sizes_sem = local_sems.at[bt_sem_id, 15]
+            metadata_counts_sem = local_sems.at[bt_sem_id, 16]
+            metadata_offsets_sem = local_sems.at[bt_sem_id, 17]
+            metadata_routing_sem = local_sems.at[bt_sem_id, 18]
+
+            def _copy_precomputed(
+                t2e_routing_vmem,
+                d2e_count_vmem,
+                offsets_vmem,
+                starts_vmem,
+                sizes_vmem,
+            ):
+                offsets_vmem[...] = jnp.zeros_like(offsets_vmem)
+                t2e_routing_vmem[...] = t2e_routing
+
+                starts_load = pltpu.async_copy(
+                    src_ref=metadata_starts_hbm.at[bt_id],
+                    dst_ref=starts_vmem,
+                    sem=metadata_starts_sem,
+                )
+                sizes_load = pltpu.async_copy(
+                    src_ref=metadata_sizes_hbm.at[bt_id],
+                    dst_ref=sizes_vmem,
+                    sem=metadata_sizes_sem,
+                )
+                d2e_count_load = pltpu.async_copy(
+                    src_ref=metadata_d2e_counts_hbm.at[bt_id],
+                    dst_ref=d2e_count_vmem,
+                    sem=metadata_counts_sem,
+                )
+
+                offsets_copy = pltpu.async_copy(
+                    src_ref=offsets_vmem,
+                    dst_ref=expert_offsets_x2_smem.at[bt_sem_id],
+                    sem=metadata_offsets_sem,
+                )
+                t2e_routing_copy = pltpu.async_copy(
+                    src_ref=t2e_routing_vmem,
+                    dst_ref=t2e_routing_x2_smem.at[bt_sem_id],
+                    sem=metadata_routing_sem,
+                )
+
+                starts_load.wait()
+                sizes_load.wait()
+                d2e_count_load.wait()
+                starts_copy = pltpu.async_copy(
+                    src_ref=starts_vmem,
+                    dst_ref=expert_starts_x2_smem.at[bt_sem_id],
+                    sem=metadata_starts_sem,
+                )
+                sizes_copy = pltpu.async_copy(
+                    src_ref=sizes_vmem,
+                    dst_ref=expert_sizes_x2_smem.at[bt_sem_id],
+                    sem=metadata_sizes_sem,
+                )
+                d2e_count_copy = pltpu.async_copy(
+                    src_ref=d2e_count_vmem,
+                    dst_ref=d2e_count_x2_smem.at[bt_sem_id],
+                    sem=metadata_counts_sem,
+                )
+
+                t2e_routing_copy.wait()
+                d2e_count_copy.wait()
+                offsets_copy.wait()
+                starts_copy.wait()
+                sizes_copy.wait()
+
+            pl.run_scoped(
+                _copy_precomputed,
+                pltpu.VMEM(t2e_routing_x2_smem.shape[1:], t2e_routing_x2_smem.dtype),
+                pltpu.VMEM(d2e_count_x2_smem.shape[1:], d2e_count_x2_smem.dtype),
+                pltpu.VMEM(expert_offsets_x2_smem.shape[1:], expert_offsets_x2_smem.dtype),
+                pltpu.VMEM(expert_starts_x2_smem.shape[1:], expert_starts_x2_smem.dtype),
+                pltpu.VMEM(expert_sizes_x2_smem.shape[1:], expert_sizes_x2_smem.dtype),
+            )
+            return
 
         # Local-only metadata path for profiling. Not correct for multi-device routing;
         # only use when A2A is disabled (or on ep_size=1).
@@ -2660,14 +2743,18 @@ def _fused_ep_moe_kernel(
         # Prepare t2e_routing
         t2e_routing = b_topk_ids_x2_vmem[bt_sem_id]
 
-        expert_iota = jax.lax.broadcasted_iota(jnp.int32, (1, 1, padded_num_experts), 2)
-        routing_expanded = jnp.expand_dims(t2e_routing[:, :top_k], axis=2)
-        mask = (routing_expanded == expert_iota).astype(jnp.int32)
-        expert_sizes = jnp.sum(mask, axis=(0, 1), keepdims=True).reshape(1, padded_num_experts)
+        if use_jax_allreduce_metadata and metadata_starts_hbm is not None:
+            expert_sizes = jnp.zeros((1, padded_num_experts), dtype=jnp.int32)
+        else:
+            expert_iota = jax.lax.broadcasted_iota(jnp.int32, (1, 1, padded_num_experts), 2)
+            routing_expanded = jnp.expand_dims(t2e_routing[:, :top_k], axis=2)
+            mask = (routing_expanded == expert_iota).astype(jnp.int32)
+            expert_sizes = jnp.sum(mask, axis=(0, 1), keepdims=True).reshape(1, padded_num_experts)
 
         expert_starts = jnp.zeros_like(expert_sizes)
 
         all_reduce_metadata(
+            bt_id=bt_id,
             bt_sem_id=bt_sem_id,
             t2e_routing=t2e_routing,
             starts=expert_starts,
@@ -3076,6 +3163,76 @@ def _validate_fused_ep_moe_args(
                     raise ValueError("w2_shared_scale must be float32")
 
 
+def compute_local_expert_sizes(topk_ids: jax.Array, num_experts: int) -> jax.Array:
+    """Count routed tokens per expert for one local token tile.
+
+    Must be called inside shard_map, where topk_ids is the device-local slice.
+    Invalid/padded expert ids are accumulated into a sentinel bucket and dropped.
+    """
+    flat_ids = topk_ids.flatten()
+    valid = (flat_ids >= 0) & (flat_ids < num_experts)
+    safe_ids = jnp.where(valid, flat_ids, num_experts)
+    counts = jnp.bincount(safe_ids, length=num_experts + 1)[:num_experts]
+    return counts[None, :].astype(jnp.int32)
+
+
+def jax_allreduce_metadata_by_bt(
+    topk_ids: jax.Array,  # (num_tokens, top_k) int32
+    num_experts: int,
+    bt: int,
+    num_devices: int,
+    dp_axis_name: str,
+    tp_axis_name: str,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Compute the per-bt metadata normally produced inside the Pallas kernel.
+
+    Returns:
+        starts: (num_bt, 1, num_experts) int32
+        sizes: (num_bt, 1, num_experts) int32
+        d2e_counts: (num_bt, num_devices, 1, num_experts) int32
+    """
+    num_tokens = topk_ids.shape[0]
+    if num_tokens % bt != 0:
+        raise ValueError(f"Expected local topk_ids tokens ({num_tokens}) to be divisible by {bt=}.")
+
+    topk_ids_by_bt = topk_ids.reshape(num_tokens // bt, bt, topk_ids.shape[-1])
+    local_sizes = jax.vmap(compute_local_expert_sizes, in_axes=(0, None))(
+        topk_ids_by_bt,
+        num_experts,
+    )
+
+    all_sizes = lax.all_gather(
+        local_sizes,
+        axis_name=(dp_axis_name, tp_axis_name),
+        axis=1,
+        tiled=True,
+    )
+    all_sizes = all_sizes.astype(jnp.int32)
+    if all_sizes.shape[1] != num_devices:
+        raise ValueError(
+            f"Expected gathered metadata axis to be {num_devices}, got {all_sizes.shape}."
+        )
+
+    sizes = jnp.sum(all_sizes, axis=1, keepdims=True).astype(jnp.int32)
+
+    dp_rank = lax.axis_index(dp_axis_name)
+    tp_rank = lax.axis_index(tp_axis_name)
+    tp_size = lax.axis_size(tp_axis_name)
+    my_id = dp_rank * tp_size + tp_rank
+    # Only this device's prefix is consumed by the Pallas kernel. Computing
+    # starts for every device adds decode-side work without changing outputs.
+    device_ids = lax.broadcasted_iota(jnp.int32, (num_devices,), 0)
+    prefix_mask = device_ids < my_id
+    starts = jnp.sum(
+        jnp.where(prefix_mask[None, :, None], all_sizes, jnp.zeros_like(all_sizes)),
+        axis=1,
+        keepdims=True,
+    ).astype(jnp.int32)
+
+    d2e_counts = all_sizes[:, :, None, :]
+    return starts, sizes, d2e_counts
+
+
 @functools.partial(
     jax.jit,
     static_argnames=[
@@ -3096,6 +3253,7 @@ def _validate_fused_ep_moe_args(
         "disable_shared_expert",
         "disable_all_reduce_metadata",
         "disable_sync_barrier",
+        "use_jax_allreduce_metadata",
         "quant_block_k",
         "block_config",
         "dp_axis_name",
@@ -3128,6 +3286,7 @@ def fused_ep_moe(
     disable_shared_expert: bool = False,
     disable_all_reduce_metadata: bool = False,
     disable_sync_barrier: bool = False,
+    use_jax_allreduce_metadata: bool = True,
     # Quantization block size along the K (reduction) dimension.  Models with
     # 2D block-wise quantization (block_k, block_n) have their scales expanded
     # to 1D format at weight-loading time by _expand_moe_block_scale(), so the
@@ -3222,6 +3381,7 @@ def fused_ep_moe(
     bt = block_config.bt
     if bt <= 0:
         raise ValueError(f"Expected {bt=} to be > 0.")
+    needs_jax_allreduce = use_jax_allreduce_metadata and ep_size > 1 and not disable_a2a
     padded_num_experts = align_to(num_experts, 128)
     padded_top_k = align_to(top_k, 128)
     t_dtype = tokens.dtype
@@ -3378,7 +3538,7 @@ def fused_ep_moe(
         # Semaphores.
         pltpu.SemaphoreType.DMA((2,)),  # token_stage_x2_sems
         pltpu.SemaphoreType.DMA((3,)),  # acc_stage_x3_sems
-        pltpu.SemaphoreType.DMA((2, 14)),  # local_sems
+        pltpu.SemaphoreType.DMA((2, 19)),  # local_sems
         pltpu.SemaphoreType.DMA((expert_buffer_count,)),  # send_x2_sems
         pltpu.SemaphoreType.DMA((expert_buffer_count,)),  # recv_x2_sems
         pltpu.SemaphoreType.DMA((expert_buffer_count,)),  # gather_send_x2_sems
@@ -3404,6 +3564,7 @@ def fused_ep_moe(
                 disable_shared_expert=disable_shared_expert,
                 disable_all_reduce_metadata=disable_all_reduce_metadata,
                 disable_sync_barrier=disable_sync_barrier,
+                use_jax_allreduce_metadata=use_jax_allreduce_metadata,
                 quant_block_k=quant_block_k,
                 bt=bt,
                 bf=block_config.bf,
@@ -3441,6 +3602,9 @@ def fused_ep_moe(
                     None if w1_shared_scale is None else hbm_block_spec,  # w1_shared_scale_hbm
                     None if w3_shared_scale is None else hbm_block_spec,  # w3_shared_scale_hbm
                     None if w2_shared_scale is None else hbm_block_spec,  # w2_shared_scale_hbm
+                    None if not needs_jax_allreduce else hbm_block_spec,  # metadata_starts_hbm
+                    None if not needs_jax_allreduce else hbm_block_spec,  # metadata_sizes_hbm
+                    None if not needs_jax_allreduce else hbm_block_spec,  # metadata_d2e_counts_hbm
                 ],
                 out_specs=pl.BlockSpec(memory_space=pltpu.MemorySpace.HBM),
                 scratch_shapes=scratch_shapes,
@@ -3555,6 +3719,26 @@ def fused_ep_moe(
         w3_shared_scale=None,
         w2_shared_scale=None,
     ):
+        if needs_jax_allreduce:
+            metadata_starts, metadata_sizes, metadata_d2e_counts = jax_allreduce_metadata_by_bt(
+                topk_ids[:, :top_k],
+                padded_num_experts,
+                bt,
+                num_devices,
+                dp_axis_name,
+                tp_axis_name,
+            )
+            metadata_starts_arg = pltpu.with_memory_space_constraint(metadata_starts, pltpu.HBM)
+            metadata_sizes_arg = pltpu.with_memory_space_constraint(metadata_sizes, pltpu.HBM)
+            metadata_d2e_counts_arg = pltpu.with_memory_space_constraint(
+                metadata_d2e_counts,
+                pltpu.HBM,
+            )
+        else:
+            metadata_starts_arg = None
+            metadata_sizes_arg = None
+            metadata_d2e_counts_arg = None
+
         local_output = fused_moe(
             pltpu.with_memory_space_constraint(tokens, pltpu.HBM),  # tokens_hbm
             pltpu.with_memory_space_constraint(w1, pltpu.HBM),  # w1_hbm
@@ -3615,6 +3799,9 @@ def fused_ep_moe(
                 if w2_shared_scale is None
                 else pltpu.with_memory_space_constraint(w2_shared_scale, pltpu.HBM)
             ),
+            metadata_starts_arg,
+            metadata_sizes_arg,
+            metadata_d2e_counts_arg,
         )
         return local_output
 

--- a/python/sgl_jax/srt/layers/fused_moe.py
+++ b/python/sgl_jax/srt/layers/fused_moe.py
@@ -75,6 +75,7 @@ class FusedEPMoE(nnx.Module):
         disable_shared_expert: bool = False,
         disable_all_reduce_metadata: bool = False,
         disable_sync_barrier: bool = False,
+        use_jax_allreduce_metadata: bool = True,
     ):
         self.hidden_size = hidden_size
         self.num_experts_per_tok = num_experts_per_tok
@@ -103,6 +104,7 @@ class FusedEPMoE(nnx.Module):
         self.disable_shared_expert = disable_shared_expert
         self.disable_all_reduce_metadata = disable_all_reduce_metadata
         self.disable_sync_barrier = disable_sync_barrier
+        self.use_jax_allreduce_metadata = use_jax_allreduce_metadata
 
         metadata = get_global_expert_location_metadata()
         if metadata is not None and layer_id is not None:
@@ -487,6 +489,7 @@ class FusedEPMoE(nnx.Module):
             disable_shared_expert=self.disable_shared_expert,
             disable_all_reduce_metadata=self.disable_all_reduce_metadata,
             disable_sync_barrier=self.disable_sync_barrier,
+            use_jax_allreduce_metadata=self.use_jax_allreduce_metadata,
             # Optional parameters (not used in basic case)
             quant_block_k=quant_block_k,
             w1_scale=w1_scale,

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -306,6 +306,9 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
             self.server_args.ep_num_redundant_experts
         )
         self.model_config.hf_config.moe_backend = self.model_config.moe_backend.value
+        self.model_config.hf_config.use_jax_allreduce_metadata = (
+            not self.server_args.disable_jax_allreduce_metadata
+        )
         # Pick MLA forward path at server start. Only `fa` selects absorbed
         # (the MLA Pallas kernel); `fa_mha` and `native` both decompress latent
         # KV via kv_b_proj and run standard attention. Read by

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -119,6 +119,7 @@ class MiMoV2Moe(nnx.Module):
                 layer_id=layer_id,
                 renormalize_topk_logits=getattr(config, "norm_topk_prob", True),
                 quantization_config=getattr(config, "quantization_config", None),
+                use_jax_allreduce_metadata=getattr(config, "use_jax_allreduce_metadata", True),
             )
         else:
             self.experts = EPMoE(

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -135,6 +135,7 @@ class ServerArgs:
     # Kernel backend
     attention_backend: str | None = "fa"
     moe_backend: str = "epmoe"
+    disable_jax_allreduce_metadata: bool = False
 
     grammar_backend: str | None = None
 
@@ -954,6 +955,17 @@ class ServerArgs:
             choices=["epmoe", "fused", "auto"],
             default=ServerArgs.moe_backend,
             help="The backend to use for MoE models.",
+        )
+
+        parser.add_argument(
+            "--disable-jax-allreduce-metadata",
+            action="store_true",
+            default=ServerArgs.disable_jax_allreduce_metadata,
+            help=(
+                "Disable the pure JAX allreduce metadata path for fused EP-MoE; "
+                "fall back to the Pallas DMA-based allgather. "
+                "Default uses JAX path (recommended)."
+            ),
         )
 
         parser.add_argument(


### PR DESCRIPTION
## Summary
- Add an optional pure JAX allreduce metadata path for EP-MoE and plumb the flag through server args/model runner/model config.
- Compute metadata per MoE tile inside shard_map and pass the precomputed metadata into the Pallas kernel.
- Enable the external metadata path for decode tiles and optimize prefix-start computation to only build the current device prefix.
- Add `--disable-jax-allreduce-metadata` as an opt-out switch.

## Performence
## MiMo-V2-Flash

| EP | Concurrency | Branch | n | Input tok/s | Δ | Output tok/s | Δ | Peak output tok/s | Δ | Median E2E ms | Δ | Median TTFT ms | Δ | Median TPOT ms | Δ | Median ITL ms | Δ | Correctness |
|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
| 8 | 64 | main | 4 | 10,569.41 | baseline | 660.59 | baseline | 2,112.00 | baseline | 73,737.66 | baseline | 40,297.40 | baseline | 43.65 | baseline | 23.71 | baseline | OK |
| 8 | 64 | current_branch | 1 | 10,506.05 | -0.60% | 656.63 | -0.60% | 2,112.00 | +0.00% | 74,816.83 | -1.46% | 40,391.18 | -0.23% | 43.90 | -0.57% | 23.70 | +0.03% | OK |
| 8 | 128 | main | 5 | 10,588.30 | baseline | 661.77 | baseline | 2,112.00 | baseline | 146,626.80 | baseline | 119,060.19 | baseline | 43.58 | baseline | 23.61 | baseline | OK |
| 8 | 128 | current_branch | 1 | 10,470.19 | -1.12% | 654.39 | -1.11% | 2,111.00 | -0.05% | 149,122.14 | -1.70% | 120,527.84 | -1.23% | 43.81 | -0.52% | 23.57 | +0.18% | OK |
| 8 | 512 | main | 1 | 10,609.17 | baseline | 663.07 | baseline | 2,025.00 | baseline | 440,655.32 | baseline | 385,426.95 | baseline | 44.49 | baseline | 23.52 | baseline | OK |
| 8 | 512 | current_branch | 1 | 10,726.32 | +1.10% | 670.39 | +1.10% | 2,112.00 | +4.30% | 435,406.99 | +1.19% | 381,241.62 | +1.09% | 43.60 | +2.00% | 23.66 | -0.60% | OK |
| 32 | 64 | main | 5 | 12,754.03 | baseline | 797.13 | baseline | 2,099.20 | baseline | 82,209.10 | baseline | 26,817.83 | baseline | 53.81 | baseline | 32.83 | baseline | OK |
| 32 | 64 | current_branch | 1 | 12,889.38 | +1.06% | 805.59 | +1.06% | 1,984.00 | -5.49% | 81,551.78 | +0.80% | 26,160.11 | +2.45% | 53.53 | +0.53% | 33.09 | -0.80% | OK |
| 32 | 128 | main | 5 | 14,034.89 | baseline | 877.18 | baseline | 2,636.80 | baseline | 149,384.58 | baseline | 50,365.90 | baseline | 96.44 | baseline | 51.80 | baseline | OK |
| 32 | 128 | current_branch | 1 | 14,155.64 | +0.86% | 884.73 | +0.86% | 2,560.00 | -2.91% | 148,104.88 | +0.86% | 49,144.22 | +2.43% | 96.36 | +0.09% | 52.73 | -1.80% | OK |
| 32 | 256 | main | 3 | 13,681.65 | baseline | 855.10 | baseline | 2,560.00 | baseline | 305,121.41 | baseline | 96,253.20 | baseline | 204.22 | baseline | 112.03 | baseline | OK |
| 32 | 256 | current_branch | 3 | 13,647.32 | -0.25% | 852.96 | -0.25% | 2,389.33 | -6.67% | 305,924.24 | -0.26% | 93,975.41 | +2.37% | 207.23 | -1.48% | 117.02 | -4.46% | OK |
| 32 | 512 | main | 1 | 14,530.56 | baseline | 908.16 | baseline | 3,200.00 | baseline | 357,522.29 | baseline | 191,395.99 | baseline | 185.83 | baseline | 113.57 | baseline | OK |
| 32 | 512 | current_branch | 1 | 14,751.02 | +1.52% | 921.94 | +1.52% | 3,400.00 | +6.25% | 356,354.85 | +0.33% | 186,823.12 | +2.39% | 184.57 | +0.68% | 117.63 | -3.57% | OK |
| 64 | 64 | main | 5 | 17,072.80 | baseline | 1,067.05 | baseline | 2,126.80 | baseline | 61,453.48 | baseline | 15,631.50 | baseline | 44.49 | baseline | 30.60 | baseline | OK |
| 64 | 64 | current_branch | 1 | 18,091.37 | +5.97% | 1,130.71 | +5.97% | 2,240.00 | +5.32% | 58,199.51 | +5.30% | 15,202.20 | +2.75% | 41.54 | +6.63% | 29.56 | +3.41% | OK |
| 64 | 128 | main | 5 | 19,914.52 | baseline | 1,244.66 | baseline | 2,872.80 | baseline | 105,245.57 | baseline | 29,316.47 | baseline | 73.98 | baseline | 45.41 | baseline | OK |
| 64 | 128 | current_branch | 1 | 20,853.03 | +4.71% | 1,303.31 | +4.71% | 3,072.00 | +6.93% | 100,513.82 | +4.50% | 28,444.12 | +2.98% | 70.12 | +5.21% | 44.57 | +1.84% | OK |
| 64 | 512 | main | 1 | 19,045.68 | baseline | 1,190.36 | baseline | 3,472.00 | baseline | 410,213.12 | baseline | 111,316.08 | baseline | 292.01 | baseline | 187.13 | baseline | OK |
| 64 | 512 | current_branch | 1 | 19,060.26 | +0.08% | 1,191.27 | +0.08% | 3,472.00 | +0.00% | 411,333.06 | -0.27% | 107,607.99 | +3.33% | 296.72 | -1.61% | 195.86 | -4.67% | OK |

## MiMo-V2-Pro-Private

| EP | Concurrency | Branch | n | Input tok/s | Δ | Output tok/s | Δ | Peak output tok/s | Δ | Median E2E ms | Δ | Median TTFT ms | Δ | Median TPOT ms | Δ | Median ITL ms | Δ | Correctness |
|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
| 32 | 64 | main | 5 | 12,634.70 | baseline | 789.67 | baseline | 2,233.40 | baseline | 82,957.74 | baseline | 28,725.40 | baseline | 52.83 | baseline | 30.40 | baseline | OK |
| 32 | 64 | current_branch | 1 | 12,708.40 | +0.58% | 794.27 | +0.58% | 2,161.00 | -3.24% | 82,581.45 | +0.45% | 28,327.38 | +1.39% | 52.66 | +0.31% | 30.49 | -0.30% | OK |
| 32 | 128 | main | 5 | 13,500.00 | baseline | 843.75 | baseline | 2,774.60 | baseline | 127,931.97 | baseline | 53,105.68 | baseline | 73.08 | baseline | 40.61 | baseline | OK |
| 32 | 128 | current_branch | 1 | 13,554.53 | +0.40% | 847.16 | +0.40% | 2,704.00 | -2.54% | 122,272.19 | +4.42% | 52,379.19 | +1.37% | 67.92 | +7.06% | 39.37 | +3.06% | OK |
| 32 | 256 | main | 5 | 13,447.90 | baseline | 840.50 | baseline | 2,807.20 | baseline | 260,269.10 | baseline | 146,716.53 | baseline | 76.69 | baseline | 41.85 | baseline | OK |
| 32 | 256 | current_branch | 1 | 13,594.10 | +1.09% | 849.63 | +1.09% | 2,704.00 | -3.68% | 240,262.36 | +7.69% | 142,377.01 | +2.96% | 67.50 | +11.99% | 39.03 | +6.73% | OK |
| 32 | 512 | main | 1 | 13,482.68 | baseline | 842.67 | baseline | 2,496.00 | baseline | 377,196.77 | baseline | 292,170.17 | baseline | 80.26 | baseline | 41.89 | baseline | OK |
| 32 | 512 | current_branch | 1 | 14,110.22 | +4.65% | 881.89 | +4.65% | 2,808.00 | +12.50% | 360,018.44 | +4.55% | 279,896.99 | +4.20% | 75.45 | +5.99% | 39.48 | +5.75% | OK |
| 64 | 64 | main | 5 | 10,094.94 | baseline | 630.93 | baseline | 1,344.00 | baseline | 104,084.30 | baseline | 29,804.31 | baseline | 71.89 | baseline | 48.90 | baseline | OK |
| 64 | 64 | current_branch | 1 | 10,316.84 | +2.20% | 644.80 | +2.20% | 1,408.00 | +4.76% | 101,717.07 | +2.27% | 29,099.60 | +2.36% | 70.53 | +1.90% | 47.93 | +1.98% | OK |
| 64 | 128 | main | 5 | 12,129.02 | baseline | 758.06 | baseline | 2,076.80 | baseline | 172,859.17 | baseline | 55,699.47 | baseline | 114.19 | baseline | 64.55 | baseline | OK |
| 64 | 128 | current_branch | 1 | 12,354.74 | +1.86% | 772.17 | +1.86% | 2,176.00 | +4.78% | 169,706.28 | +1.82% | 54,363.83 | +2.40% | 112.41 | +1.56% | 63.94 | +0.95% | OK |
| 64 | 256 | main | 5 | 13,628.39 | baseline | 851.77 | baseline | 2,966.60 | baseline | 306,273.17 | baseline | 106,600.82 | baseline | 195.23 | baseline | 93.08 | baseline | OK |
| 64 | 256 | current_branch | 1 | 13,750.95 | +0.90% | 859.43 | +0.90% | 2,816.00 | -5.08% | 303,540.66 | +0.89% | 104,058.24 | +2.39% | 195.05 | +0.09% | 95.27 | -2.35% | OK |
| 64 | 512 | main | 1 | 13,559.54 | baseline | 847.47 | baseline | 3,104.00 | baseline | 386,604.09 | baseline | 212,668.08 | baseline | 195.57 | baseline | 119.36 | baseline | OK |
| 64 | 512 | current_branch | 1 | 13,910.67 | +2.59% | 869.42 | +2.59% | 3,199.00 | +3.06% | 375,373.71 | +2.90% | 206,977.91 | +2.68% | 191.41 | +2.13% | 115.01 | +3.64% | OK |

## Testing
- `python -m py_compile python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py python/sgl_jax/srt/layers/fused_moe.py python/sgl_jax/srt/model_executor/model_runner.py python/sgl_jax/srt/models/mimo_v2_flash.py python/sgl_jax/srt/server_args.py`
- Internal TPU serving smoke tests with single chat requests on Flash/Pro models.
- Internal serving benchmark coverage across EP32/EP64 and multiple concurrency levels.