### PR TITLE
fix: upgrade JAX from 0.8.1 to 0.9.2

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -54,16 +54,16 @@ fastokens = [
     "fastokens>=0.1.1,<0.2.0",
 ]
 tpu = [
-    "jax[tpu]==0.8.1",
+    "jax[tpu]==0.9.2",
 ]
 gpu = [
-    "jax[cuda12]==0.8.1",
+    "jax[cuda12]==0.9.2",
 ]
 cpu = [
-    "jax[cpu]==0.8.1",
+    "jax[cpu]==0.9.2",
 ]
 all = [
-    "jax[tpu]==0.8.1",
+    "jax[tpu]==0.9.2",
     "fastokens>=0.1.1,<0.2.0",
 ]
 multimodal = [

--- a/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
@@ -3465,6 +3465,39 @@ def fused_ep_moe(
             topk_weights, ((0, 0), (0, padded_top_k - top_k)), mode="constant", constant_values=0
         )
 
+    def _reshard_ep(x):
+        if x is None:
+            return None
+        sharding = jax.sharding.NamedSharding(
+            mesh, P((dp_axis_name, tp_axis_name), *([None] * (x.ndim - 1)))
+        )
+        return jax.reshard(x, sharding)
+
+    def _reshard_replicated(x):
+        if x is None:
+            return None
+        sharding = jax.sharding.NamedSharding(mesh, P(*([None] * x.ndim)))
+        return jax.reshard(x, sharding)
+
+    tokens = _reshard_ep(tokens)
+    w1 = _reshard_ep(w1)
+    w2 = _reshard_ep(w2)
+    w3 = _reshard_ep(w3)
+    w1_scale = _reshard_ep(w1_scale)
+    w2_scale = _reshard_ep(w2_scale)
+    w3_scale = _reshard_ep(w3_scale)
+    b1 = _reshard_ep(b1)
+    b2 = _reshard_ep(b2)
+    b3 = _reshard_ep(b3)
+    topk_weights = _reshard_ep(topk_weights)
+    topk_ids = _reshard_ep(topk_ids)
+    w1_shared = _reshard_replicated(w1_shared)
+    w3_shared = _reshard_replicated(w3_shared)
+    w2_shared = _reshard_replicated(w2_shared)
+    w1_shared_scale = _reshard_replicated(w1_shared_scale)
+    w3_shared_scale = _reshard_replicated(w3_shared_scale)
+    w2_shared_scale = _reshard_replicated(w2_shared_scale)
+
     b1_scratch = None if b1 is None else pltpu.VMEM((2, 1, block_config.bf), jnp.float32)
     b3_scratch = None if b3 is None else pltpu.VMEM((2, 1, block_config.bf), jnp.float32)
     b2_scratch = None if b2 is None else pltpu.VMEM((2, t_packing, 1, bd2_per_pack), jnp.float32)

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -27,6 +27,7 @@ from enum import Enum
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import lax
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
@@ -108,30 +109,39 @@ def ref_ragged_paged_attention(
     attention_sink: jax.Array | float | None = None,
 ):
     """Reference implementation for ragged paged attention."""
+    # Move metadata to host first. This is a non-jitted reference function
+    # and should not depend on device sharding for scalar indexing.
+    kv_lens = np.asarray(jax.device_get(kv_lens))
+    cu_q_lens = np.asarray(jax.device_get(cu_q_lens))
+    page_indices = np.asarray(jax.device_get(page_indices))
+    num_seqs = np.asarray(jax.device_get(num_seqs))
+
     if not causal:
+        total_kv_len = int(np.cumsum(kv_lens)[-1])
         assert (
-            custom_mask is not None and custom_mask.size > jnp.cumsum(kv_lens)[-1]
-        ), f"use custom_mask, custom_mask length {custom_mask.size=} must larger than total kv length {jnp.cumsum(kv_lens)[-1]=}"
+            custom_mask is not None and custom_mask.size > total_kv_len
+        ), f"use custom_mask, custom_mask length {custom_mask.size=} must larger than total kv length {total_kv_len=}"
     if mask_value is None:
         mask_value = DEFAULT_MASK_VALUE
     _, _, num_kv_heads, head_dim = k_pages.shape
     num_q_heads = queries.shape[1]
     assert num_q_heads % num_kv_heads == 0
     num_query_per_kv = num_q_heads // num_kv_heads
+
     outputs = []
     mask_len_list = []
-    for i in range(num_seqs[0]):
-        kv_len = kv_lens[i]
-        q_len = cu_q_lens[i + 1] - cu_q_lens[i]
+    for i in range(int(num_seqs[0])):
+        kv_len = int(kv_lens[i])
+        q_len = int(cu_q_lens[i + 1] - cu_q_lens[i])
         mask_len_list.append(q_len * kv_len)
     mask_lens = jnp.array(mask_len_list, dtype=jnp.int32)
     cu_mask_lens = jnp.concatenate([jnp.array([0], dtype=jnp.int32), jnp.cumsum(mask_lens)])
 
-    for i in range(num_seqs[0]):
-        q_start = cu_q_lens[i]
-        q_end = cu_q_lens[i + 1]
+    for i in range(int(num_seqs[0])):
+        q_start = int(cu_q_lens[i])
+        q_end = int(cu_q_lens[i + 1])
         q_len = q_end - q_start
-        kv_len = kv_lens[i]
+        kv_len = int(kv_lens[i])
         indices = page_indices[i]
         q = queries[q_start:q_end]
         k = k_pages[indices, :, :, :].reshape(-1, num_kv_heads, head_dim)[:kv_len]

--- a/python/sgl_jax/srt/kernels/update_kv_cache/update_kv_cache.py
+++ b/python/sgl_jax/srt/kernels/update_kv_cache/update_kv_cache.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
+from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.utils import cdiv
@@ -117,6 +118,36 @@ def kv_cache_update_kernel(
         async_copy.wait()
 
 
+def _reshape_fused_kv_to_3d(x):
+    """Reshape 5D fused KV to 3D for Pallas kernel.
+
+    [tokens, page_size, packed_heads, packing, head_dim]
+    -> [tokens * page_size, packed_heads * packing, head_dim]
+
+    JAX 0.9.2 requires explicit out_sharding when reshaping sharded arrays.
+    Strips NamedSharding to replicated because pallas_call requires Manual
+    mesh axes and rejects Explicit inputs.
+    """
+    s = x.shape
+    out_shape = (s[0] * s[1], s[2] * s[3], s[4])
+
+    sharding = getattr(x, "sharding", None)
+    if isinstance(sharding, NamedSharding):
+        # Strip Explicit NamedSharding before feeding the 3D views to Pallas.
+        # Pallas kernels expect Manual mesh axes under shard_map and reject
+        # Explicit sharding annotations in JAX 0.9.2.
+        # In the sharded path, the enclosing shard_map out_specs restores the
+        # expected output sharding. In the local/test path, correctness does
+        # not depend on preserving the intermediate sharding annotation.
+        return jax.lax.reshape(
+            x,
+            out_shape,
+            out_sharding=P(None, None, None),
+        )
+
+    return x.reshape(out_shape)
+
+
 def kv_cache_update_impl(
     new_kv,
     slices,
@@ -133,10 +164,8 @@ def kv_cache_update_impl(
     ), f"slices.shape[1]={slices.shape[1]} is not divisible by num_slices_per_block={num_slices_per_block}"
 
     original_cache_shape = kv_cache.shape
-    s = new_kv.shape
-    new_kv = new_kv.reshape(s[0] * s[1], s[2] * s[3], s[4])
-    s = kv_cache.shape
-    kv_cache = kv_cache.reshape(s[0] * s[1], s[2] * s[3], s[4])
+    new_kv = _reshape_fused_kv_to_3d(new_kv)
+    kv_cache = _reshape_fused_kv_to_3d(kv_cache)
 
     _, num_combined_kv_heads, head_dim = new_kv.shape
 

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -537,6 +537,10 @@ class FlashAttention(AttentionBackend):
         elif hasattr(token_to_kv_pool, "remap_cache_loc") and self.page_size == 1:
             page_indices_arg = token_to_kv_pool.remap_cache_loc(page_indices_arg, layer.layer_id)
 
+        q_arg = q.reshape(q.shape[0], -1, self.head_dim)
+        k_arg = k.reshape(k.shape[0], -1, self.head_dim)
+        v_arg = v.reshape(v.shape[0], -1, self.head_dim)
+
         # JAX 0.9.1+ enforces shard_map in_specs match actual input sharding.
         # Derive effective axes from the actual array sharding rather than
         # divisibility, so specs always match what JAX assigned.
@@ -546,23 +550,25 @@ class FlashAttention(AttentionBackend):
         # q and kv may have different head counts (GQA), so compute axes
         # independently. q_axis also requires local_q_heads % local_kv_heads
         # == 0 after sharding, otherwise the kernel sees an invalid head ratio.
-        q_data = effective_axis(q, 0, dpa)
-        q_axis = effective_axis(q, 1, axis)
-        kv_data = effective_axis(k, 0, dpa)
-        kv_axis = effective_axis(k, 1, axis)
-        v_data = effective_axis(v, 0, dpa)
-        v_axis = effective_axis(v, 1, axis)
+        q_data = effective_axis(q_arg, 0, dpa)
+        q_axis = effective_axis(q_arg, 1, axis)
+        kv_data = effective_axis(k_arg, 0, dpa)
+        kv_axis = effective_axis(k_arg, 1, axis)
+        v_data = effective_axis(v_arg, 0, dpa)
+        v_axis = effective_axis(v_arg, 1, axis)
         # GQA head ratio: if q is tensor-sharded, verify local heads are valid.
         if q_axis is not None:
             axis_size = self.mesh.shape.get(axis, 1) if self.mesh else 1
-            local_q = q.shape[1] // axis_size
-            local_kv = k.shape[1] // axis_size if kv_axis is not None else k.shape[1]
+            local_q = q_arg.shape[1] // axis_size
+            local_kv = k_arg.shape[1] // axis_size if kv_axis is not None else k_arg.shape[1]
             if local_q % local_kv != 0:
                 if self.mesh is not None and q_data is not None:
-                    q = jax.reshard(q, NamedSharding(self.mesh, P(q_data, None, None)))
+                    q_arg = jax.reshard(q_arg, NamedSharding(self.mesh, P(q_data, None, None)))
                 q_axis = None
         # v must be consistent with k on the tensor axis.
         if kv_axis != v_axis:
+            if self.mesh is not None:
+                v_arg = jax.reshard(v_arg, NamedSharding(self.mesh, P(v_data, kv_axis, None)))
             v_axis = kv_axis
 
         # kv_cache: [pages, page_size, heads*2//packing, packing, head_dim]
@@ -667,9 +673,9 @@ class FlashAttention(AttentionBackend):
             out_specs=out_specs,
             check_vma=False,
         )(
-            q.reshape(q.shape[0], -1, self.head_dim),
-            k.reshape(k.shape[0], -1, self.head_dim),
-            v.reshape(v.shape[0], -1, self.head_dim),
+            q_arg,
+            k_arg,
+            v_arg,
             kv_cache_fused,
             self.forward_metadata.seq_lens,
             page_indices_arg,
@@ -681,7 +687,7 @@ class FlashAttention(AttentionBackend):
         )
 
         return (
-            attn_output.reshape(q.shape[0], -1),
+            attn_output.reshape(q_arg.shape[0], -1),
             updated_kv_cache_fused,
         )
 

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -19,7 +19,7 @@ from sgl_jax.srt.mem_cache.memory_pool import KVCache
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
 from sgl_jax.srt.utils import cdiv
-from sgl_jax.srt.utils.jax_utils import device_array
+from sgl_jax.srt.utils.jax_utils import device_array, effective_axis
 from sgl_jax.srt.utils.profiling_utils import named_scope
 
 logger = logging.getLogger(__name__)
@@ -537,33 +537,78 @@ class FlashAttention(AttentionBackend):
         elif hasattr(token_to_kv_pool, "remap_cache_loc") and self.page_size == 1:
             page_indices_arg = token_to_kv_pool.remap_cache_loc(page_indices_arg, layer.layer_id)
 
+        # JAX 0.9.1+ enforces shard_map in_specs match actual input sharding.
+        # Derive effective axes from the actual array sharding rather than
+        # divisibility, so specs always match what JAX assigned.
+        axis = self.kv_partition_axis
+        dpa = self.attention_data_partition_axis
+
+        # q and kv may have different head counts (GQA), so compute axes
+        # independently. q_axis also requires local_q_heads % local_kv_heads
+        # == 0 after sharding, otherwise the kernel sees an invalid head ratio.
+        q_data = effective_axis(q, 0, dpa)
+        q_axis = effective_axis(q, 1, axis)
+        kv_data = effective_axis(k, 0, dpa)
+        kv_axis = effective_axis(k, 1, axis)
+        v_data = effective_axis(v, 0, dpa)
+        v_axis = effective_axis(v, 1, axis)
+        # GQA head ratio: if q is tensor-sharded, verify local heads are valid.
+        if q_axis is not None:
+            axis_size = self.mesh.shape.get(axis, 1) if self.mesh else 1
+            local_q = q.shape[1] // axis_size
+            local_kv = k.shape[1] // axis_size if kv_axis is not None else k.shape[1]
+            if local_q % local_kv != 0:
+                if self.mesh is not None and q_data is not None:
+                    q = jax.reshard(q, NamedSharding(self.mesh, P(q_data, None, None)))
+                q_axis = None
+        # v must be consistent with k on the tensor axis.
+        if kv_axis != v_axis:
+            v_axis = kv_axis
+
+        # kv_cache: [pages, page_size, heads*2//packing, packing, head_dim]
+        cache_data = effective_axis(kv_cache_fused, 0, dpa)
+        cache_axis = effective_axis(kv_cache_fused, 2, axis)
+
+        # attention_sink: [num_q_heads] — derive from actual sharding
+        sink_axis = effective_axis(attention_sink, 0, axis) if attention_sink is not None else None
+        if attention_sink is not None and q_axis is None and sink_axis is not None:
+            if self.mesh is not None:
+                attention_sink = jax.reshard(attention_sink, NamedSharding(self.mesh, P()))
+            sink_axis = None
+
+        # Metadata arrays: derive from actual sharding
+        kv_lens_dpa = effective_axis(self.forward_metadata.seq_lens, 0, dpa)
+        page_idx_dpa = effective_axis(page_indices_arg, 0, dpa)
+        cu_q_dpa = effective_axis(self.forward_metadata.cu_q_lens, 0, dpa)
+        cu_kv_dpa = effective_axis(self.forward_metadata.cu_kv_lens, 0, dpa)
+        dist_dpa = effective_axis(self.forward_metadata.distribution, 0, dpa)
+        custom_mask_dpa = (
+            effective_axis(self.forward_metadata.custom_mask, 0, dpa)
+            if self.forward_metadata.custom_mask is not None
+            else None
+        )
+
         in_specs = (
-            P(self.attention_data_partition_axis, self.kv_partition_axis),  # queries
-            P(self.attention_data_partition_axis, self.kv_partition_axis),  # keys (new tokens)
-            P(self.attention_data_partition_axis, self.kv_partition_axis),  # values (new tokens)
-            P(
-                self.attention_data_partition_axis, None, self.kv_partition_axis, None, None
-            ),  # kv_cache_fused (head interleaved)
-            P(self.attention_data_partition_axis),  # kv_lens
-            P(self.attention_data_partition_axis),  # page_indices
-            P(self.attention_data_partition_axis),  # cu_q_lens
-            P(self.attention_data_partition_axis),  # cu_kv_lens
-            P(self.attention_data_partition_axis),  # distribution
+            P(q_data, q_axis),  # queries
+            P(kv_data, kv_axis),  # keys (new tokens)
+            P(v_data, v_axis),  # values (new tokens)
+            P(cache_data, None, cache_axis, None, None),  # kv_cache_fused
+            P(kv_lens_dpa),  # kv_lens
+            P(page_idx_dpa),  # page_indices
+            P(cu_q_dpa),  # cu_q_lens
+            P(cu_kv_dpa),  # cu_kv_lens
+            P(dist_dpa),  # distribution
             (
-                P(self.attention_data_partition_axis)
+                P(custom_mask_dpa)
                 if self.forward_metadata.custom_mask is not None
                 else P()
-            ),  # custom_mask: DP-segmented per-rank (cu_seq_mask_lens is rank-local)
-            (
-                P(self.kv_partition_axis) if attention_sink is not None else P()
-            ),  # attention sink: (num_q_heads,), sharded by heads
+            ),  # custom_mask: DP-segmented per-rank when present
+            P(sink_axis) if attention_sink is not None else P(),  # attention sink
         )
 
         out_specs = (
-            P(self.attention_data_partition_axis, self.kv_partition_axis),  # attention output
-            P(
-                self.attention_data_partition_axis, None, self.kv_partition_axis, None, None
-            ),  # updated kv_cache_fused (head interleaved) - 3D: [total_tokens, num_kv_heads*2, head_dim]
+            P(q_data, q_axis),  # attention output
+            P(cache_data, None, cache_axis, None, None),  # updated kv_cache_fused
         )
 
         mask_aligned_to_cu_kv = (
@@ -571,9 +616,27 @@ class FlashAttention(AttentionBackend):
             and forward_batch.forward_mode.is_target_verify()
         )
 
+        # args layout follows in_specs order: q, k, v, kv_cache, ...,
+        # attention_sink (always last, may be None with P() spec).
         def _ragged_paged_attention_with_fused_kv(*args):
             queries, keys, values, kv_cache_fused = args[:4]
-            other_args = args[4:]
+            other_args = args[4:-1]
+            local_attention_sink = args[-1]
+
+            # When q is tensor-sharded and attention_sink is replicated,
+            # slice to the local shard's heads so the kernel sees aligned dims.
+            if (
+                local_attention_sink is not None
+                and q_axis is not None
+                and sink_axis is None
+                and local_attention_sink.shape[0] >= queries.shape[1]
+            ):
+                local_q_heads = queries.shape[1]
+                tensor_idx = jax.lax.axis_index(axis)
+                start = tensor_idx * local_q_heads
+                local_attention_sink = jax.lax.dynamic_slice_in_dim(
+                    local_attention_sink, start, local_q_heads, axis=0
+                )
 
             # Call fused KV kernel with head interleaving
             result, updated_kv_cache_fused = ragged_paged_attention_v3(
@@ -582,6 +645,7 @@ class FlashAttention(AttentionBackend):
                 values,
                 kv_cache_fused,
                 *other_args,
+                attention_sink=local_attention_sink,
                 causal=causal,
                 sm_scale=scale,
                 sliding_window=layer.sliding_window_size,

--- a/python/sgl_jax/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/gdn_backend.py
@@ -35,6 +35,7 @@ from sgl_jax.srt.layers.attention.hybrid_linear_attn_backend import (
     LinearRecurrentAttnBackend,
 )
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+from sgl_jax.srt.utils.jax_utils import effective_axis
 
 
 def _mesh_tp_size(mesh: jax.sharding.Mesh) -> int:
@@ -200,9 +201,25 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
         """One token per request — single conv1d update + parallel single
         recurrence step across the batch, all inside a shard_map."""
         state_indices = self.forward_metadata.recurrent_indices
-        tp = _mesh_tp_size(self.mesh)
+        mixed_data = effective_axis(mixed_qkv, 0, "data")
+        mixed_axis = effective_axis(mixed_qkv, 1, "tensor")
+        conv_data = effective_axis(conv_state_in, 0, "data")
+        conv_axis = effective_axis(conv_state_in, 1, "tensor")
+        rec_data = effective_axis(recurrent_state_in, 0, "data")
+        rec_axis = effective_axis(recurrent_state_in, 1, "tensor")
+        weight_axis = effective_axis(self.conv1d_weight.value, 0, "tensor")
+        a_log_axis = effective_axis(self.A_log.value, 0, "tensor")
+        dt_bias_axis = effective_axis(self.dt_bias.value, 0, "tensor")
+        b_data = effective_axis(b, 0, "data")
+        b_axis = effective_axis(b, 1, "tensor")
+        a_data = effective_axis(a, 0, "data")
+        a_axis = effective_axis(a, 1, "tensor")
+        idx_data = effective_axis(state_indices, 0, "data")
+
+        tp = _mesh_tp_size(self.mesh) if mixed_axis == "tensor" else 1
+        v_tp = _mesh_tp_size(self.mesh) if b_axis == "tensor" else 1
         n_kq_tp = self.num_k_heads // tp
-        n_v_tp = self.num_v_heads // tp
+        n_v_tp = self.num_v_heads // v_tp
         d_k = self.head_k_dim
         d_v = self.head_v_dim
 
@@ -244,20 +261,20 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
             _decode_local,
             mesh=self.mesh,
             in_specs=(
-                P(None, "tensor"),  # mixed_qkv
-                P(None, "tensor", None),  # conv_state
-                P(None, "tensor", None, None),  # recurrent_state
-                P("tensor", None),  # conv1d weight
-                P("tensor"),  # A_log
-                P("tensor"),  # dt_bias
-                P(None, "tensor"),  # b
-                P(None, "tensor"),  # a
-                P(),  # state_indices (replicated)
+                P(mixed_data, mixed_axis),  # mixed_qkv
+                P(conv_data, conv_axis, None),  # conv_state
+                P(rec_data, rec_axis, None, None),  # recurrent_state
+                P(weight_axis, None),  # conv1d weight
+                P(a_log_axis),  # A_log
+                P(dt_bias_axis),  # dt_bias
+                P(b_data, b_axis),  # b
+                P(a_data, a_axis),  # a
+                P(idx_data),  # state_indices
             ),
             out_specs=(
-                P(None, "tensor", None),  # out [B, n_v, d_v]
-                P(None, "tensor", None),  # new_conv_state [num_blocks, conv_dim, K-1]
-                P(None, "tensor", None, None),  # new_rec_state [num_blocks, n_v, d_k, d_v]
+                P(b_data, b_axis, None),  # out [B, n_v, d_v]
+                P(conv_data, conv_axis, None),  # new_conv_state [num_blocks, conv_dim, K-1]
+                P(rec_data, rec_axis, None, None),  # new_rec_state [num_blocks, n_v, d_k, d_v]
             ),
             check_vma=False,
         )(
@@ -289,9 +306,32 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
         cu_seqlens = meta.cu_q_lens
         state_indices = meta.recurrent_indices
         has_initial_state = meta.has_initial_state
-        tp = _mesh_tp_size(self.mesh)
+        mixed_data = effective_axis(mixed_qkv, 0, "data")
+        mixed_axis = effective_axis(mixed_qkv, 1, "tensor")
+        conv_data = effective_axis(conv_state_in, 0, "data")
+        conv_axis = effective_axis(conv_state_in, 1, "tensor")
+        rec_data = effective_axis(recurrent_state_in, 0, "data")
+        rec_axis = effective_axis(recurrent_state_in, 1, "tensor")
+        weight_axis = effective_axis(self.conv1d_weight.value, 0, "tensor")
+        a_log_axis = effective_axis(self.A_log.value, 0, "tensor")
+        dt_bias_axis = effective_axis(self.dt_bias.value, 0, "tensor")
+        b_data = effective_axis(b, 0, "data")
+        b_axis = effective_axis(b, 1, "tensor")
+        a_data = effective_axis(a, 0, "data")
+        a_axis = effective_axis(a, 1, "tensor")
+        cu_data = effective_axis(cu_seqlens, 0, "data")
+        idx_data = effective_axis(state_indices, 0, "data")
+        init_data = (
+            effective_axis(has_initial_state, 0, "data")
+            if has_initial_state is not None
+            else None
+        )
+        init_spec = P(init_data) if has_initial_state is not None else P()
+
+        tp = _mesh_tp_size(self.mesh) if mixed_axis == "tensor" else 1
+        v_tp = _mesh_tp_size(self.mesh) if b_axis == "tensor" else 1
         n_kq_tp = self.num_k_heads // tp
-        n_v_tp = self.num_v_heads // tp
+        n_v_tp = self.num_v_heads // v_tp
         d_k = self.head_k_dim
         d_v = self.head_v_dim
 
@@ -344,22 +384,22 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
             _extend_local,
             mesh=self.mesh,
             in_specs=(
-                P(None, "tensor"),  # mixed_qkv
-                P(None, "tensor", None),  # conv_state
-                P(None, "tensor", None, None),  # recurrent_state
-                P("tensor", None),  # conv1d weight
-                P("tensor"),  # A_log
-                P("tensor"),  # dt_bias
-                P(None, "tensor"),  # b
-                P(None, "tensor"),  # a
-                P(),  # cu_seqlens (replicated)
-                P(),  # state_indices (replicated)
-                P(),  # has_initial_state (replicated)
+                P(mixed_data, mixed_axis),  # mixed_qkv
+                P(conv_data, conv_axis, None),  # conv_state
+                P(rec_data, rec_axis, None, None),  # recurrent_state
+                P(weight_axis, None),  # conv1d weight
+                P(a_log_axis),  # A_log
+                P(dt_bias_axis),  # dt_bias
+                P(b_data, b_axis),  # b
+                P(a_data, a_axis),  # a
+                P(cu_data),  # cu_seqlens
+                P(idx_data),  # state_indices
+                init_spec,  # has_initial_state
             ),
             out_specs=(
-                P(None, "tensor", None),  # out [T, n_v, d_v]
-                P(None, "tensor", None),  # new_conv_state [num_blocks, conv_dim, K-1]
-                P(None, "tensor", None, None),  # new_rec_state [num_blocks, n_v, d_k, d_v]
+                P(b_data, b_axis, None),  # out [T, n_v, d_v]
+                P(conv_data, conv_axis, None),  # new_conv_state [num_blocks, conv_dim, K-1]
+                P(rec_data, rec_axis, None, None),  # new_rec_state [num_blocks, n_v, d_k, d_v]
             ),
             check_vma=False,
         )(

--- a/python/sgl_jax/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/lightning_backend.py
@@ -25,6 +25,7 @@ from sgl_jax.srt.layers.attention.hybrid_linear_attn_backend import (
     LinearRecurrentAttnBackend,
 )
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+from sgl_jax.srt.utils.jax_utils import effective_axis
 from sgl_jax.srt.utils.profiling_utils import named_scope
 
 logger = logging.getLogger(__name__)
@@ -76,9 +77,9 @@ def _compute_layer_slope(
 ) -> jax.Array:
     """Per-layer slope decay used as ``g_gamma`` by the simple_gla kernels.
 
-    Sharded along the ``tensor`` axis when ``mesh`` is provided, matching
-    the ``P("tensor")`` spec the slope is consumed with inside the jitted
-    forward.
+    Returned array is sharded along the ``tensor`` axis when the head count is
+    divisible by TP. Otherwise it stays replicated so shard_map specs can
+    match the actual array sharding under JAX 0.9.2.
     """
     base = np.asarray(_build_alibi_base_slopes(num_heads), dtype=np.float32)
     slope_np = -base * (1 - (layer_id - 1) / (num_hidden_layers - 1) + 1e-5)
@@ -198,7 +199,17 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
         if decode_simple_gla_fused is None:
             raise ImportError("simple_gla_fused kernel is required for GLA decode")
 
-        head_axis = _head_axis(self.mesh, q.shape[1])
+        q_data = effective_axis(q, 0, "data")
+        q_head = effective_axis(q, 1, "tensor")
+        k_data = effective_axis(k, 0, "data")
+        k_head = effective_axis(k, 1, "tensor")
+        v_data = effective_axis(v, 0, "data")
+        v_head = effective_axis(v, 1, "tensor")
+        slope_head = effective_axis(slope, 0, "tensor")
+        state_data = effective_axis(recurrent_buffer, 0, "data")
+        state_head = effective_axis(recurrent_buffer, 1, "tensor")
+        idx_data = effective_axis(recurrent_indices, 0, "data")
+        has_data = effective_axis(has_initial_state, 0, "data")
 
         def _decode_fn(q_l, k_l, v_l, gamma, buf_l, idx_l, has_l):
             return decode_simple_gla_fused(
@@ -216,17 +227,17 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
             _decode_fn,
             mesh=self.mesh,
             in_specs=(
-                P("data", head_axis, None),
-                P("data", head_axis, None),
-                P("data", head_axis, None),
-                P(head_axis),
-                P("data", head_axis, None, None),
-                P("data"),
-                P("data"),
+                P(q_data, q_head, None),  # q
+                P(k_data, k_head, None),  # k
+                P(v_data, v_head, None),  # v
+                P(slope_head),  # slope
+                P(state_data, state_head, None, None),  # recurrent_buffer
+                P(idx_data),  # recurrent_indices
+                P(has_data),  # has_initial_state
             ),
             out_specs=(
-                P("data", head_axis, None),
-                P("data", head_axis, None, None),
+                P(q_data, q_head, None),
+                P(state_data, state_head, None, None),
             ),
             check_vma=False,
         )(q, k, v, slope, recurrent_buffer, recurrent_indices, has_initial_state)
@@ -248,7 +259,18 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
 
         cu_seqlens = self.forward_metadata.cu_q_lens
         chunk_size = self.chunk_size
-        head_axis = _head_axis(self.mesh, q.shape[1])
+        q_data = effective_axis(q, 0, "data")
+        q_head = effective_axis(q, 1, "tensor")
+        k_data = effective_axis(k, 0, "data")
+        k_head = effective_axis(k, 1, "tensor")
+        v_data = effective_axis(v, 0, "data")
+        v_head = effective_axis(v, 1, "tensor")
+        slope_head = effective_axis(slope, 0, "tensor")
+        state_data = effective_axis(recurrent_buffer, 0, "data")
+        state_head = effective_axis(recurrent_buffer, 1, "tensor")
+        idx_data = effective_axis(recurrent_indices, 0, "data")
+        has_data = effective_axis(has_initial_state, 0, "data")
+        cu_data = effective_axis(cu_seqlens, 0, "data")
 
         def _prefill_fn(q_l, k_l, v_l, gamma, buf_l, idx_l, has_l, cu_l):
             h0 = buf_l[idx_l]
@@ -276,18 +298,18 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
             _prefill_fn,
             mesh=self.mesh,
             in_specs=(
-                P("data", head_axis, None),
-                P("data", head_axis, None),
-                P("data", head_axis, None),
-                P(head_axis),
-                P("data", head_axis, None, None),
-                P("data"),
-                P("data"),
-                P("data"),
+                P(q_data, q_head, None),  # q
+                P(k_data, k_head, None),  # k
+                P(v_data, v_head, None),  # v
+                P(slope_head),  # slope
+                P(state_data, state_head, None, None),  # recurrent_buffer
+                P(idx_data),  # recurrent_indices
+                P(has_data),  # has_initial_state
+                P(cu_data),  # cu_seqlens
             ),
             out_specs=(
-                P("data", head_axis, None),
-                P("data", head_axis, None, None),
+                P(q_data, q_head, None),
+                P(state_data, state_head, None, None),
             ),
             check_vma=False,
         )(q, k, v, slope, recurrent_buffer, recurrent_indices, has_initial_state, cu_seqlens)

--- a/python/sgl_jax/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/lightning_backend.py
@@ -46,6 +46,11 @@ if TYPE_CHECKING:
 _CHUNK_SIZE = 64
 
 
+def _head_axis(mesh: jax.sharding.Mesh | None, num_heads: int) -> str | None:
+    tensor_size = mesh.shape.get("tensor", 1) if mesh else 1
+    return "tensor" if num_heads % tensor_size == 0 else None
+
+
 def _build_alibi_base_slopes(num_heads: int) -> list[float]:
     """ALiBi base slopes matching the HF BailingMoeV2.5 reference."""
 
@@ -79,7 +84,7 @@ def _compute_layer_slope(
     slope_np = -base * (1 - (layer_id - 1) / (num_hidden_layers - 1) + 1e-5)
     if mesh is None:
         return jnp.asarray(slope_np)
-    sharding = NamedSharding(mesh, P("tensor"))
+    sharding = NamedSharding(mesh, P(_head_axis(mesh, num_heads)))
     return jax.make_array_from_callback(slope_np.shape, sharding, lambda idx: slope_np[idx])
 
 
@@ -193,6 +198,8 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
         if decode_simple_gla_fused is None:
             raise ImportError("simple_gla_fused kernel is required for GLA decode")
 
+        head_axis = _head_axis(self.mesh, q.shape[1])
+
         def _decode_fn(q_l, k_l, v_l, gamma, buf_l, idx_l, has_l):
             return decode_simple_gla_fused(
                 q_l,
@@ -209,17 +216,17 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
             _decode_fn,
             mesh=self.mesh,
             in_specs=(
-                P("data", "tensor", None),
-                P("data", "tensor", None),
-                P("data", "tensor", None),
-                P("tensor"),
-                P("data", "tensor", None, None),
+                P("data", head_axis, None),
+                P("data", head_axis, None),
+                P("data", head_axis, None),
+                P(head_axis),
+                P("data", head_axis, None, None),
                 P("data"),
                 P("data"),
             ),
             out_specs=(
-                P("data", "tensor", None),
-                P("data", "tensor", None, None),
+                P("data", head_axis, None),
+                P("data", head_axis, None, None),
             ),
             check_vma=False,
         )(q, k, v, slope, recurrent_buffer, recurrent_indices, has_initial_state)
@@ -241,6 +248,7 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
 
         cu_seqlens = self.forward_metadata.cu_q_lens
         chunk_size = self.chunk_size
+        head_axis = _head_axis(self.mesh, q.shape[1])
 
         def _prefill_fn(q_l, k_l, v_l, gamma, buf_l, idx_l, has_l, cu_l):
             h0 = buf_l[idx_l]
@@ -268,18 +276,18 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
             _prefill_fn,
             mesh=self.mesh,
             in_specs=(
-                P("data", "tensor", None),
-                P("data", "tensor", None),
-                P("data", "tensor", None),
-                P("tensor"),
-                P("data", "tensor", None, None),
+                P("data", head_axis, None),
+                P("data", head_axis, None),
+                P("data", head_axis, None),
+                P(head_axis),
+                P("data", head_axis, None, None),
                 P("data"),
                 P("data"),
                 P("data"),
             ),
             out_specs=(
-                P("data", "tensor", None),
-                P("data", "tensor", None, None),
+                P("data", head_axis, None),
+                P("data", head_axis, None, None),
             ),
             check_vma=False,
         )(q, k, v, slope, recurrent_buffer, recurrent_indices, has_initial_state, cu_seqlens)

--- a/python/sgl_jax/srt/layers/attention/mla_backend.py
+++ b/python/sgl_jax/srt/layers/attention/mla_backend.py
@@ -28,7 +28,7 @@ from jax.tree_util import register_pytree_node_class
 from sgl_jax.srt.kernels.mla.v2.kernel import cdiv, mla_ragged_paged_attention
 from sgl_jax.srt.layers.attention.base_attn_backend import AttentionBackend
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
-from sgl_jax.srt.utils.jax_utils import device_array
+from sgl_jax.srt.utils.jax_utils import device_array, effective_axis
 from sgl_jax.srt.utils.profiling_utils import named_scope
 
 if TYPE_CHECKING:
@@ -307,21 +307,33 @@ class MLAAttentionBackend(AttentionBackend):
 
         dpa = self.attention_data_partition_axis
 
+        # JAX 0.9.1+ enforces shard_map in_specs match actual input sharding.
+        # Derive effective axes from the actual array sharding rather than
+        # divisibility, so specs always match what JAX assigned.
+        effective_dpa = effective_axis(ql_nope, 0, dpa)
+        effective_tensor = effective_axis(ql_nope, 1, "tensor")
+        cache_dpa = effective_axis(cache, 0, dpa)
+        seq_lens_dpa = effective_axis(self.forward_metadata.seq_lens, 0, dpa)
+        page_idx_dpa = effective_axis(self.forward_metadata.page_indices, 0, dpa)
+        cu_q_dpa = effective_axis(self.forward_metadata.cu_q_lens, 0, dpa)
+        cu_kv_dpa = effective_axis(self.forward_metadata.cu_kv_lens, 0, dpa)
+        dist_dpa = effective_axis(self.forward_metadata.distribution, 0, dpa)
+
         in_specs = (
-            P(dpa, "tensor", None),  # ql_nope    [T, n_h/tp, lkv]
-            P(dpa, "tensor", None),  # q_pe       [T, n_h/tp, r]
-            P(dpa, None),  # new_kv_c   [T, lkv]  (single latent, no head axis)
-            P(dpa, None),  # new_k_pe   [T, r]    (single latent)
-            P(dpa, None, None, None),  # cache (page axis sharded by data)
-            P(dpa),  # seq_lens
-            P(dpa),  # page_indices
-            P(dpa),  # cu_q_lens
-            P(dpa),  # cu_kv_lens
-            P(dpa),  # distribution
+            P(effective_dpa, effective_tensor, None),  # ql_nope    [T, n_h/tp, lkv]
+            P(effective_dpa, effective_tensor, None),  # q_pe       [T, n_h/tp, r]
+            P(effective_dpa, None),  # new_kv_c   [T, lkv]  (single latent)
+            P(effective_dpa, None),  # new_k_pe   [T, r]    (single latent)
+            P(cache_dpa, None, None, None),  # cache (page axis)
+            P(seq_lens_dpa),  # seq_lens
+            P(page_idx_dpa),  # page_indices
+            P(cu_q_dpa),  # cu_q_lens
+            P(cu_kv_dpa),  # cu_kv_lens
+            P(dist_dpa),  # distribution
         )
         out_specs = (
-            P(dpa, "tensor", None),  # o_latent       [T, n_h/tp, lkv]
-            P(dpa, None, None, None),  # updated cache  4D
+            P(effective_dpa, effective_tensor, None),  # o_latent  [T, n_h/tp, lkv]
+            P(cache_dpa, None, None, None),  # updated cache  4D
         )
 
         def _run(

--- a/python/sgl_jax/srt/layers/linear.py
+++ b/python/sgl_jax/srt/layers/linear.py
@@ -11,6 +11,7 @@ from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import expand_block_scale
 from sgl_jax.srt.kernels.quantized_matmul.kernel import xla_quantized_matmul_local
+from sgl_jax.srt.utils.jax_utils import effective_axis
 from sgl_jax.srt.utils.parallel_utils import prepare_scattered_spec_if_needed
 from sgl_jax.srt.utils.profiling_utils import named_scope
 from sgl_jax.srt.utils.quantization.quantization_utils import quantize_tensor
@@ -294,8 +295,9 @@ class QuantizedLinear(nnx.Module):
                     effective_weight_block_size is not None
                     and len(effective_weight_block_size) == 2
                 ):
-                    block_n, block_k = int(effective_weight_block_size[0]), int(
-                        effective_weight_block_size[1]
+                    block_n, block_k = (
+                        int(effective_weight_block_size[0]),
+                        int(effective_weight_block_size[1]),
                     )
                     in_blocks = (in_features + block_k - 1) // block_k
                     # Pre-expanded kernel-ready layout: [in_blocks, 1, n_out].
@@ -325,8 +327,9 @@ class QuantizedLinear(nnx.Module):
                     effective_weight_block_size is not None
                     and len(effective_weight_block_size) == 2
                 ):
-                    block_n, block_k = int(effective_weight_block_size[0]), int(
-                        effective_weight_block_size[1]
+                    block_n, block_k = (
+                        int(effective_weight_block_size[0]),
+                        int(effective_weight_block_size[1]),
                     )
                     out_blocks = (weight_q.shape[0] + block_n - 1) // block_n
                     in_blocks = (weight_q.shape[1] + block_k - 1) // block_k
@@ -413,16 +416,22 @@ class QuantizedLinear(nnx.Module):
         # kernel_axes = (input_axis, output_axis):
         #   row-parallel  (e.g., o_proj): ("tensor", None)
         #   col-parallel  (e.g., q_proj): (None, "tensor")
+        # JAX 0.9.1+ enforces in_specs match actual input sharding.
         input_axis, output_axis = self.kernel_axes[0], self.kernel_axes[1]
+        eff_data = effective_axis(x_2d, 0, "data")
+        eff_w_out = effective_axis(self.weight_q.value, 0, output_axis)
+        eff_w_in = effective_axis(self.weight_q.value, 1, input_axis)
         if scale_val.ndim == 3:  # noqa: SIM108
             # Pre-expanded block scale: [in_blocks, 1, n_out]
-            w_scale_spec = P(input_axis, None, output_axis)
+            scale_in = effective_axis(scale_val, 0, input_axis)
+            scale_out = effective_axis(scale_val, 2, output_axis)
+            w_scale_spec = P(scale_in, None, scale_out)
         else:
             # Per-channel scale: [n_out]
-            w_scale_spec = P(output_axis)
-        in_specs = (P("data", input_axis), P(output_axis, input_axis), w_scale_spec)
-
-        out_specs = P("data", output_axis)
+            scale_out = effective_axis(scale_val, 0, output_axis)
+            w_scale_spec = P(scale_out)
+        in_specs = (P(eff_data, eff_w_in), P(eff_w_out, eff_w_in), w_scale_spec)
+        out_specs = P(eff_data, eff_w_out)
 
         # When ``output_scatter_dimension`` is set, stack ``input_axis`` onto
         # whatever already partitions that dim (e.g. ``"data"`` from DP) so

--- a/python/sgl_jax/srt/lora/backend/base_backend.py
+++ b/python/sgl_jax/srt/lora/backend/base_backend.py
@@ -2,6 +2,7 @@ import jax
 from flax import nnx
 from jax.sharding import NamedSharding
 
+from sgl_jax.srt.lora.utils import LoRABatchPlan
 from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
 
 
@@ -12,7 +13,6 @@ class BaseLoRABackend(nnx.Module):
     Args:
         max_loras_per_batch: number of LoRA buffer slots available to the backend.
                              Dynamic LoRA reserves one slot for base-model requests.
-        device: the device where the backend runs.
     """
 
     def __init__(self, max_loras_per_batch: int):
@@ -47,8 +47,8 @@ class BaseLoRABackend(nnx.Module):
         self,
         x: jax.Array,
         weights: jax.Array,
+        base_output: jax.Array,
         sharding: NamedSharding,
-        scalings: jax.Array,
         token_indices: jax.Array,
         *args,
         **kwargs,
@@ -59,6 +59,7 @@ class BaseLoRABackend(nnx.Module):
              x: input matrix with shape (s, r), here s is the sum of all sequence lengths, r is lora rank
              weights: a set of lora weights with shape (num_lora, output_dim, r)
                       usually output_dim is much larger than r
+             base_output: base layer output with shape (s, output_dim)
              sharding: lora_b_output sharding
              token_indices: vector with shape (s,)
         Returns:
@@ -72,6 +73,7 @@ class BaseLoRABackend(nnx.Module):
         qkv_lora_a: jax.Array,
         qkv_lora_b: jax.Array | tuple[jax.Array],
         output_slices: tuple,
+        base_output: jax.Array,
         lora_a_output_sharding: NamedSharding,
         lora_b_output_sharding: NamedSharding,
         scalings: jax.Array,
@@ -90,7 +92,7 @@ class BaseLoRABackend(nnx.Module):
                            a lora_b module for q, with shape (1, num_lora, output_dim_q, r)
                            and a combined lora_b module for kv, with shape (2, num_lora, output_dim_kv, r)
             output_slices: a fixed tuple which has three item, (output_dim_q, output_dim_kv, output_dim_kv)
-            base_output: (s, 2 * output_dim)
+            base_output: base layer output with shape (s, output_dim_q + 2 * output_dim_kv)
             lora_a_output_sharding: lora_a_output sharding
             lora_b_output_sharding: lora_b_output sharding
             scalings: vector with shape (s,), alpha/rank
@@ -118,7 +120,7 @@ class BaseLoRABackend(nnx.Module):
         Args:
             x: input matrix with shape (s, input_dim), here s is the sum of all sequence lengths
             gate_up_lora_a: lora_a module for gate_up_proj, with shape (num_lora, 2 * r, input_dim)
-            gate_up_lora_b: lora_b module for qkv.
+            gate_up_lora_b: lora_b module for gate_up_proj.
                         If passed in as a tensor, its shape should be (num_lora, 2 * output_dim, r)
                         If passed in as a tuple, it should contain two tensors with shape (num_lora, output_dim, r)
             base_output: (s, 2 * output_dim)
@@ -129,14 +131,12 @@ class BaseLoRABackend(nnx.Module):
         Returns:
             result with shape (s, 2 * output_dim)
         """
-        pass
+        raise NotImplementedError
 
     def prepare_lora_batch(
         self,
         model_worker_batch: ModelWorkerBatch,
-        weight_indices: list[int],
-        lora_ranks: list[int],
-        scalings: list[float],
+        batch_plan: LoRABatchPlan,
     ):
         """Prepare the lora weights and batch info for current forward batch.
 
@@ -144,11 +144,7 @@ class BaseLoRABackend(nnx.Module):
         logic for each forward batch.
 
         Args:
-            forward_batch: the ForwardBatch object for current forward pass
-            weight_indices: list of indices of lora weights to be applied for current batch
-            lora_ranks: list of lora ranks corresponding to weight_indices
-            scalings: list of scaling factors corresponding to weight_indices
-            batch_info: optional LoRABatchInfo object, if not provided, the backend should use its own
-                        internal batch info
+            model_worker_batch: the batch object for current forward pass.
+            batch_plan: CPU-side request-to-slot LoRA metadata to expand.
         """
         raise NotImplementedError

--- a/python/sgl_jax/srt/lora/backend/base_backend.py
+++ b/python/sgl_jax/srt/lora/backend/base_backend.py
@@ -10,8 +10,8 @@ class BaseLoRABackend(nnx.Module):
        Each backend has its own implementation of Lora kernels.
 
     Args:
-        max_loras_per_batch: maximum number of different lora weights
-                             that can be applied in a single forward batch.
+        max_loras_per_batch: number of LoRA buffer slots available to the backend.
+                             Dynamic LoRA reserves one slot for base-model requests.
         device: the device where the backend runs.
     """
 

--- a/python/sgl_jax/srt/lora/backend/bgmv_backend.py
+++ b/python/sgl_jax/srt/lora/backend/bgmv_backend.py
@@ -21,6 +21,7 @@ import numpy as np
 from jax.sharding import NamedSharding
 
 from sgl_jax.srt.lora.backend.base_backend import BaseLoRABackend
+from sgl_jax.srt.lora.utils import LoRABatchPlan
 from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
 
@@ -125,7 +126,7 @@ class BgmvLoRABackend(BaseLoRABackend):
                            a lora_b module for q, with shape (1, num_lora, output_dim_q, r)
                            and a combined lora_b module for kv, with shape (2, num_lora, output_dim_kv, r)
             output_slices: a fixed tuple which has three items, (output_dim_q, output_dim_kv, output_dim_kv)
-            base_output: (s, 2 * output_dim)
+            base_output: base layer output with shape (s, output_dim_q + 2 * output_dim_kv)
             lora_a_output_sharding: lora_a_output sharding
             lora_b_output_sharding: lora_b_output sharding
             scalings: vector with shape (s,), alpha/rank
@@ -178,7 +179,7 @@ class BgmvLoRABackend(BaseLoRABackend):
         Args:
             x: input matrix with shape (s, input_dim), here s is the sum of all sequence lengths
             gate_up_lora_a: lora_a module for gate_up_proj, with shape (num_lora, 2 * r, input_dim)
-            gate_up_lora_b: lora_b module for qkv.
+            gate_up_lora_b: lora_b module for gate_up_proj.
                         If passed in as a tensor, its shape should be (num_lora, 2 * output_dim, r)
                         If passed in as a tuple, it should contain two tensors with shape (num_lora, output_dim, r)
             base_output: (s, 2 * output_dim)
@@ -190,7 +191,9 @@ class BgmvLoRABackend(BaseLoRABackend):
             result with shape (s, 2 * output_dim)
         """
         if isinstance(gate_up_lora_b, tuple):
-            gate_up_lora_b_concated = jnp.concat([gate_up_lora_b[0], gate_up_lora_b[1]], axis=1)
+            gate_up_lora_b_concated = jnp.concatenate(
+                [gate_up_lora_b[0], gate_up_lora_b[1]], axis=1
+            )
         else:
             gate_up_lora_b_concated = gate_up_lora_b
 
@@ -214,35 +217,48 @@ class BgmvLoRABackend(BaseLoRABackend):
     def prepare_lora_batch(
         self,
         model_worker_batch: ModelWorkerBatch,
-        weight_indices: list[int],  # [bs,]
-        lora_ranks: list[int],  # [<=max_lora_per_batch,]
-        scalings: list[float],  # [<=max_lora_per_batch,]
+        batch_plan: LoRABatchPlan,
     ):
-        lora_ranks_bs = []
-        scalings_bs = []
-        for indice in weight_indices:
-            lora_ranks_bs.append(lora_ranks[indice])
-            scalings_bs.append(scalings[indice])
+        weight_indices = np.array(batch_plan.weight_indices, dtype=np.int32)
+        lora_ranks_bs = np.array(batch_plan.ranks_for_requests(), dtype=np.int32)
+        scalings_bs = np.array(batch_plan.scalings_for_requests(), dtype=np.float32)
 
-        assert len(model_worker_batch.seq_lens) == len(weight_indices)
-        assert len(model_worker_batch.seq_lens) == len(lora_ranks_bs)
-        assert len(model_worker_batch.seq_lens) == len(scalings_bs)
+        if len(model_worker_batch.seq_lens) != len(weight_indices):
+            raise ValueError(
+                "LoRA batch plan must have one weight index per request: "
+                f"{len(weight_indices)} != {len(model_worker_batch.seq_lens)}"
+            )
 
         target_len = model_worker_batch.input_ids.shape[0]
 
         if model_worker_batch.forward_mode == ForwardMode.EXTEND:
-            scalings_cpu = np.repeat(
-                np.array(scalings_bs, dtype=np.float32), model_worker_batch.extend_seq_lens
-            )
+            if model_worker_batch.extend_seq_lens is None:
+                raise ValueError("LoRA EXTEND batch requires extend_seq_lens")
 
-            lora_token_indices_cpu = np.repeat(
-                np.array(weight_indices, dtype=np.int32), model_worker_batch.extend_seq_lens
-            )
-            lora_ranks_cpu = np.repeat(
-                np.array(lora_ranks_bs, dtype=np.int32), model_worker_batch.extend_seq_lens
-            )
+            extend_seq_lens = np.asarray(model_worker_batch.extend_seq_lens, dtype=np.int64)
+            if len(extend_seq_lens) != len(weight_indices):
+                raise ValueError(
+                    "LoRA EXTEND batch must have one extend length per request: "
+                    f"{len(extend_seq_lens)} != {len(weight_indices)}"
+                )
+            if np.any(extend_seq_lens < 0):
+                raise ValueError(
+                    "LoRA EXTEND batch has negative extend length: "
+                    f"{extend_seq_lens.tolist()}"
+                )
 
-            num_to_pad = target_len - np.sum(model_worker_batch.extend_seq_lens)
+            extend_token_len = int(np.sum(extend_seq_lens))
+            if extend_token_len > target_len:
+                raise ValueError(
+                    "LoRA EXTEND token metadata exceeds target token length: "
+                    f"sum(extend_seq_lens)={extend_token_len}, target_len={target_len}"
+                )
+
+            scalings_cpu = np.repeat(scalings_bs, extend_seq_lens)
+            lora_token_indices_cpu = np.repeat(weight_indices, extend_seq_lens)
+            lora_ranks_cpu = np.repeat(lora_ranks_bs, extend_seq_lens)
+
+            num_to_pad = target_len - extend_token_len
 
             padded_scalings_cpu = scalings_cpu
             padded_lora_token_indices_cpu = lora_token_indices_cpu
@@ -259,9 +275,17 @@ class BgmvLoRABackend(BaseLoRABackend):
                     lora_ranks_cpu, [0, num_to_pad], mode="constant", constant_values=0
                 )
         elif model_worker_batch.forward_mode == ForwardMode.DECODE:
-            padded_scalings_cpu = np.array(scalings_bs, dtype=np.float32)
-            padded_lora_token_indices_cpu = np.array(weight_indices, dtype=np.int32)
-            padded_lora_ranks_cpu = np.array(lora_ranks_bs, dtype=np.int32)
+            padded_scalings_cpu = scalings_bs
+            padded_lora_token_indices_cpu = weight_indices
+            padded_lora_ranks_cpu = lora_ranks_bs
+        else:
+            raise ValueError(f"Unsupported forward mode for LoRA: {model_worker_batch.forward_mode}")
+
+        if len(padded_scalings_cpu) != target_len:
+            raise ValueError(
+                "LoRA token metadata length must match input_ids length: "
+                f"{len(padded_scalings_cpu)} != {target_len}"
+            )
 
         model_worker_batch.lora_scalings = padded_scalings_cpu
         model_worker_batch.lora_token_indices = padded_lora_token_indices_cpu
@@ -365,10 +389,7 @@ def bgmv_expand_slice(
     pad_right = output_array.shape[-1] - (slice_offset + slice_size)
     outputs = jnp.pad(outputs, ((0, 0), (pad_left, pad_right)), mode="constant", constant_values=0)
 
-    if output_array is not None:
-        return output_array + outputs
-    else:
-        return outputs
+    return output_array + outputs
 
 
 def bgmv_jax(

--- a/python/sgl_jax/srt/lora/constants.py
+++ b/python/sgl_jax/srt/lora/constants.py
@@ -1,0 +1,17 @@
+"""Shared LoRA sentinel values.
+
+The BGMV kernels treat adapter indices as ordinary array indices.  The
+serving stack reserves slot 0 for base-model requests by keeping its LoRA
+weights zeroed; that policy belongs to the LoRA manager/memory-pool layer.
+"""
+
+BASE_LORA_ID = "0"
+BASE_LORA_SLOT = 0
+
+
+def is_base_lora_id(lora_id: str | None) -> bool:
+    return lora_id is None or lora_id == BASE_LORA_ID
+
+
+def normalize_lora_id(lora_id: str | None) -> str:
+    return BASE_LORA_ID if lora_id is None else lora_id

--- a/python/sgl_jax/srt/lora/layers.py
+++ b/python/sgl_jax/srt/lora/layers.py
@@ -34,7 +34,26 @@ from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
 if TYPE_CHECKING:
     from sgl_jax.srt.lora.backend.base_backend import BaseLoRABackend
 
-global debug_count
+
+def _restore_base_output_for_rank_zero(
+    base_output: jax.Array,
+    lora_output: jax.Array,
+    ranks: jax.Array | None,
+) -> jax.Array:
+    """Keep no-LoRA rows exact when they share a compiled LoRA batch."""
+    if ranks is None:
+        return lora_output
+
+    if ranks.ndim > lora_output.ndim:
+        raise ValueError(
+            f"LoRA ranks must be broadcastable to output: ranks.ndim={ranks.ndim}, "
+            f"output.ndim={lora_output.ndim}"
+        )
+
+    base_mask = ranks == 0
+    broadcast_shape = base_mask.shape + (1,) * (lora_output.ndim - base_mask.ndim)
+    base_mask = jnp.reshape(base_mask, broadcast_shape)
+    return jnp.where(base_mask, base_output, lora_output)
 
 
 class BaseLayerWithLoRA(nnx.Module):
@@ -80,7 +99,6 @@ class LoRALinear(BaseLayerWithLoRA):
             backend: LoRA backend for computation
         """
         super().__init__(base_layer, lora_backend)
-        self.lora_backend = lora_backend
 
     def set_lora_info(
         self,
@@ -120,12 +138,7 @@ class LoRALinear(BaseLayerWithLoRA):
             sharding=self.lora_b_output_sharding,
             token_indices=token_indices,
         )
-        if ranks is not None:
-            base_mask = ranks == 0
-            while base_mask.ndim < lora_output.ndim:
-                base_mask = base_mask[..., jnp.newaxis]
-            lora_output = jnp.where(base_mask, base_output, lora_output)
-        return lora_output
+        return _restore_base_output_for_rank_zero(base_output, lora_output, ranks)
 
     def __call__(
         self,
@@ -141,6 +154,12 @@ class LoRALinear(BaseLayerWithLoRA):
             Output tensor with LoRA delta added (if enabled) and bias from base_model
         """
         forward_batch = LoraBatchContext.get_batch()
+        if forward_batch is None:
+            raise RuntimeError(
+                "LoRALinear requires LoraBatchContext to be set before forward. "
+                "Ensure LoRAManager.prepare_lora_batch runs and the model forward is "
+                "wrapped in LoraBatchContext.set_batch(...)."
+            )
 
         base_output, output_bias = self.base_layer(x)
 

--- a/python/sgl_jax/srt/lora/layers.py
+++ b/python/sgl_jax/srt/lora/layers.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import jax
+import jax.numpy as jnp
 from flax import nnx
 from jax.sharding import Mesh
 
@@ -104,7 +105,7 @@ class LoRALinear(BaseLayerWithLoRA):
             self.A_buffer = nnx.Param(A_buffer)
             self.B_buffer = nnx.Param(B_buffer)
 
-    def apply_lora(self, base_output, x, scalings, token_indices) -> jax.Array:
+    def apply_lora(self, base_output, x, scalings, token_indices, ranks) -> jax.Array:
         lora_a_output = self.lora_backend.run_lora_a_gemm(
             x=x,
             weights=self.A_buffer,
@@ -119,6 +120,11 @@ class LoRALinear(BaseLayerWithLoRA):
             sharding=self.lora_b_output_sharding,
             token_indices=token_indices,
         )
+        if ranks is not None:
+            base_mask = ranks == 0
+            while base_mask.ndim < lora_output.ndim:
+                base_mask = base_mask[..., jnp.newaxis]
+            lora_output = jnp.where(base_mask, base_output, lora_output)
         return lora_output
 
     def __call__(
@@ -139,7 +145,11 @@ class LoRALinear(BaseLayerWithLoRA):
         base_output, output_bias = self.base_layer(x)
 
         output = self.apply_lora(
-            base_output, x, forward_batch.lora_scalings, forward_batch.lora_token_indices
+            base_output,
+            x,
+            forward_batch.lora_scalings,
+            forward_batch.lora_token_indices,
+            forward_batch.lora_ranks,
         )
         return output, output_bias
 

--- a/python/sgl_jax/srt/lora/lora_manager.py
+++ b/python/sgl_jax/srt/lora/lora_manager.py
@@ -23,6 +23,7 @@ from jax.sharding import Mesh
 
 from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.lora.backend.bgmv_backend import BgmvLoRABackend
+from sgl_jax.srt.lora.constants import is_base_lora_id, normalize_lora_id
 from sgl_jax.srt.lora.layers import BaseLayerWithLoRA
 from sgl_jax.srt.lora.lora import LoRAAdapter
 from sgl_jax.srt.lora.lora_config import LoRAConfig
@@ -98,6 +99,8 @@ class LoRAManager:
         self.mesh = mesh
         self.server_args = server_args
         self.model_config = model_config
+        self.static_lora = bool(getattr(server_args, "enable_static_lora", False))
+        self.num_lora_slots = max_loras_per_batch if self.static_lora else max_loras_per_batch + 1
 
         # Extract model architecture from hf_config
         self.num_layers = base_hf_config.num_hidden_layers
@@ -110,7 +113,6 @@ class LoRAManager:
         self.head_dim = getattr(base_hf_config, "head_dim", None)
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
-        self.static_lora = server_args.enable_static_lora
 
         # Get original num_kv_heads and tp_size for replication
         if model_config is not None:
@@ -263,9 +265,10 @@ class LoRAManager:
     def init_memory_pool(self):
         """Initialize the LoRA memory pool with proper sharding."""
         logger.info(
-            "Initializing LoRA memory pool: num_layers=%d, max_loras_per_batch=%d, max_lora_rank=%d",
+            "Initializing LoRA memory pool: num_layers=%d, max_loras_per_batch=%d, num_lora_slots=%d, max_lora_rank=%d",
             self.num_layers,
             self.max_loras_per_batch,
+            self.num_lora_slots,
             self.max_lora_rank,
         )
         logger.info(
@@ -292,6 +295,7 @@ class LoRAManager:
             head_dim=self.head_dim,
             original_num_kv_heads=self.original_num_kv_heads,
             tp_size=self.tp_size,
+            reserve_base_slot=not self.static_lora,
         )
         self.memory_pool.init_buffers()
 
@@ -371,7 +375,7 @@ class LoRAManager:
 
         # Create LoRA backend
         lora_backend = BgmvLoRABackend(
-            max_loras_per_batch=self.max_loras_per_batch,
+            max_loras_per_batch=self.num_lora_slots,
             max_lora_rank=self.max_lora_rank,
         )
 
@@ -421,22 +425,32 @@ class LoRAManager:
         Raises:
             ValueError: If batch exceeds max_loras_per_batch or adapter not loaded
         """
-        # Load active loras into lora memory pool
-        cur_uids = set(model_worker_batch.lora_ids)
+        # Load active LoRAs into the memory pool. Normalize the base-model
+        # sentinel and keep first-seen order stable so adapter slots are
+        # deterministic across batches.
+        model_worker_batch.lora_ids = [
+            normalize_lora_id(uid) for uid in model_worker_batch.lora_ids
+        ]
+        cur_uids = list(dict.fromkeys(model_worker_batch.lora_ids))
+        real_uids = [uid for uid in cur_uids if not is_base_lora_id(uid)]
 
-        assert len(cur_uids) <= self.max_loras_per_batch
+        if len(real_uids) > self.max_loras_per_batch:
+            raise ValueError(
+                f"Batch uses {len(real_uids)} LoRA adapters, exceeding "
+                f"max_loras_per_batch={self.max_loras_per_batch}"
+            )
 
         weight_indices = [0] * len(model_worker_batch.lora_ids)
-        lora_ranks = [0] * self.max_loras_per_batch
-        scalings = [0] * self.max_loras_per_batch
+        lora_ranks = [0] * self.num_lora_slots
+        scalings = [0] * self.num_lora_slots
         has_new_weights = False
 
         def prepare_static_lora_batch():
             self.lora_backend.prepare_lora_batch(
                 model_worker_batch=model_worker_batch,
                 weight_indices=[0] * len(model_worker_batch.lora_ids),
-                lora_ranks=[self.max_lora_rank] * self.max_loras_per_batch,
-                scalings=[self.server_args.lora_scaling] * self.max_loras_per_batch,
+                lora_ranks=[self.max_lora_rank] * self.num_lora_slots,
+                scalings=[self.server_args.lora_scaling] * self.num_lora_slots,
             )
 
         def prepare_dynamic_lora_batch():
@@ -608,7 +622,7 @@ class LoRAManager:
             from sgl_jax.srt.lora.backend.bgmv_backend import BgmvLoRABackend
 
             self.lora_backend = BgmvLoRABackend(
-                max_loras_per_batch=self.max_loras_per_batch,
+                max_loras_per_batch=self.num_lora_slots,
                 max_lora_rank=self.max_lora_rank,
             )
 

--- a/python/sgl_jax/srt/lora/lora_manager.py
+++ b/python/sgl_jax/srt/lora/lora_manager.py
@@ -29,7 +29,11 @@ from sgl_jax.srt.lora.lora import LoRAAdapter
 from sgl_jax.srt.lora.lora_config import LoRAConfig
 from sgl_jax.srt.lora.lora_memory_pool import LoRAMemoryPool
 from sgl_jax.srt.lora.lora_registry import LoRARef
-from sgl_jax.srt.lora.utils import get_normalized_target_modules, get_target_module_name
+from sgl_jax.srt.lora.utils import (
+    LoRABatchPlan,
+    get_normalized_target_modules,
+    get_target_module_name,
+)
 from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
 
 logger = logging.getLogger(__name__)
@@ -101,6 +105,7 @@ class LoRAManager:
         self.model_config = model_config
         self.static_lora = bool(getattr(server_args, "enable_static_lora", False))
         self.num_lora_slots = max_loras_per_batch if self.static_lora else max_loras_per_batch + 1
+        self.has_new_weights = False
 
         # Extract model architecture from hf_config
         self.num_layers = base_hf_config.num_hidden_layers
@@ -237,11 +242,8 @@ class LoRAManager:
                     unsupported = adapter_target_modules - self.target_modules
                     lora_name = self.lora_refs[lora_id].lora_name
                     raise ValueError(
-                        "LoRA adapter '%s' contains unsupported modules: %s. "
-                        "Specified target_modules: %s",
-                        lora_name,
-                        unsupported,
-                        self.target_modules,
+                        f"LoRA adapter {lora_name!r} contains unsupported modules: "
+                        f"{unsupported}. Specified target_modules: {self.target_modules}"
                     )
             else:
                 # Infer target_modules from adapter
@@ -412,6 +414,39 @@ class LoRAManager:
         """Check if memory pool can support the given LoRA config."""
         return self.memory_pool.can_support(config)
 
+    def _build_static_lora_batch_plan(self, batch_size: int) -> LoRABatchPlan:
+        return LoRABatchPlan.for_static_lora(
+            batch_size=batch_size,
+            num_lora_slots=self.num_lora_slots,
+            rank=self.max_lora_rank,
+            scaling=self.server_args.lora_scaling,
+        )
+
+    def _build_dynamic_lora_batch_plan(
+        self,
+        lora_ids: list[str],
+        cur_uids: list[str],
+    ) -> tuple[LoRABatchPlan, bool]:
+        has_new_weights = self.memory_pool.prepare_lora_batch(
+            cur_uids=cur_uids,
+            lora_adapters=self.loras,
+        )
+
+        weight_indices = []
+        lora_ranks = [0] * self.num_lora_slots
+        scalings = [0.0] * self.num_lora_slots
+
+        for uid in lora_ids:
+            buffer_id = self.memory_pool.get_buffer_id(uid)
+            weight_indices.append(buffer_id)
+
+            if uid in self.loras:
+                lora = self.loras[uid]
+                lora_ranks[buffer_id] = lora.config.r
+                scalings[buffer_id] = lora.scaling
+
+        return LoRABatchPlan(weight_indices, lora_ranks, scalings), has_new_weights
+
     def prepare_lora_batch(self, model_worker_batch: ModelWorkerBatch):
         """
         Prepare LoRA batch for inference.
@@ -426,12 +461,10 @@ class LoRAManager:
             ValueError: If batch exceeds max_loras_per_batch or adapter not loaded
         """
         # Load active LoRAs into the memory pool. Normalize the base-model
-        # sentinel and keep first-seen order stable so adapter slots are
-        # deterministic across batches.
-        model_worker_batch.lora_ids = [
-            normalize_lora_id(uid) for uid in model_worker_batch.lora_ids
-        ]
-        cur_uids = list(dict.fromkeys(model_worker_batch.lora_ids))
+        # sentinel locally and keep first-seen order stable so adapter slots are
+        # deterministic across batches without mutating scheduler-owned input.
+        lora_ids = [normalize_lora_id(uid) for uid in model_worker_batch.lora_ids]
+        cur_uids = list(dict.fromkeys(lora_ids))
         real_uids = [uid for uid in cur_uids if not is_base_lora_id(uid)]
 
         if len(real_uids) > self.max_loras_per_batch:
@@ -440,45 +473,27 @@ class LoRAManager:
                 f"max_loras_per_batch={self.max_loras_per_batch}"
             )
 
-        weight_indices = [0] * len(model_worker_batch.lora_ids)
-        lora_ranks = [0] * self.num_lora_slots
-        scalings = [0] * self.num_lora_slots
+        unknown_uids = [uid for uid in real_uids if uid not in self.loras]
+        if not self.static_lora and unknown_uids:
+            raise ValueError(
+                "LoRA adapters are not loaded: "
+                f"{unknown_uids}. Available adapters: {sorted(self.loras)}"
+            )
+
         has_new_weights = False
 
-        def prepare_static_lora_batch():
-            self.lora_backend.prepare_lora_batch(
-                model_worker_batch=model_worker_batch,
-                weight_indices=[0] * len(model_worker_batch.lora_ids),
-                lora_ranks=[self.max_lora_rank] * self.num_lora_slots,
-                scalings=[self.server_args.lora_scaling] * self.num_lora_slots,
-            )
-
-        def prepare_dynamic_lora_batch():
-            # Load adapters into device memory pool (CPU -> device transfer)
-            has_new_weights = self.memory_pool.prepare_lora_batch(
-                cur_uids=cur_uids,
-                lora_adapters=self.loras,
-            )
-
-            for i, uid in enumerate(model_worker_batch.lora_ids):
-                weight_indices[i] = self.memory_pool.get_buffer_id(uid)
-                if uid is not None and uid in self.loras:
-                    lora = self.loras[uid]
-                    lora_ranks[weight_indices[i]] = lora.config.r
-                    scalings[weight_indices[i]] = lora.scaling
-
-            self.lora_backend.prepare_lora_batch(
-                model_worker_batch=model_worker_batch,
-                weight_indices=weight_indices,
-                lora_ranks=lora_ranks,
-                scalings=scalings,
-            )
-            return has_new_weights
-
         if self.static_lora:
-            prepare_static_lora_batch()
+            batch_plan = self._build_static_lora_batch_plan(len(lora_ids))
         else:
-            has_new_weights = prepare_dynamic_lora_batch()
+            batch_plan, has_new_weights = self._build_dynamic_lora_batch_plan(
+                lora_ids=lora_ids,
+                cur_uids=cur_uids,
+            )
+
+        self.lora_backend.prepare_lora_batch(
+            model_worker_batch=model_worker_batch,
+            batch_plan=batch_plan,
+        )
 
         # Update LoRA layer buffer references after loading new weights
         # This is necessary because JAX arrays are immutable, and load_lora_weight_to_buffer
@@ -637,32 +652,3 @@ class LoRAManager:
 
         # Track the replacement
         self.lora_modules[layer_idx][attr_name] = lora_layer
-
-    def _get_nested_attr(self, obj, attr_path: str):
-        """
-        Get nested attribute using dot notation.
-
-        Args:
-            obj: Object to traverse
-            attr_path: Dot-separated path (e.g., "layers.0.self_attn.q_proj")
-
-        Returns:
-            The nested attribute
-        """
-        for attr in attr_path.split("."):
-            obj = getattr(obj, attr)
-        return obj
-
-    def _set_nested_attr(self, obj, attr_path: str, value):
-        """
-        Set nested attribute using dot notation.
-
-        Args:
-            obj: Object to traverse
-            attr_path: Dot-separated path
-            value: Value to set
-        """
-        parts = attr_path.split(".")
-        for attr in parts[:-1]:
-            obj = getattr(obj, attr)
-        setattr(obj, parts[-1], value)

--- a/python/sgl_jax/srt/lora/lora_memory_pool.py
+++ b/python/sgl_jax/srt/lora/lora_memory_pool.py
@@ -408,9 +408,9 @@ class LoRAMemoryPool:
                     return buffer_id
 
             raise ValueError(
-                "No available buffer slots. Max %d LoRA adapters per batch exceeded; %d total slots are available.",
-                self.max_loras_per_batch,
-                self.num_lora_slots,
+                "No available buffer slots. "
+                f"Max {self.max_loras_per_batch} LoRA adapters per batch exceeded; "
+                f"{self.num_lora_slots} total slots are available."
             )
 
         has_new_weights = False
@@ -453,51 +453,15 @@ class LoRAMemoryPool:
             lora_adapter: LoRA adapter object (None for base model)
         """
 
-        def get_ab_zero_matrix_shape(module_name: str):
-            _, max_lora_rank, input_dim = self._get_lora_a_shape(module_name)
-            a_zero_matrix_shape = (max_lora_rank, input_dim)
-            _, output_dim, max_lora_rank = self._get_lora_b_shape(module_name)
-            b_zero_matrix_shape = (output_dim, max_lora_rank)
-            return a_zero_matrix_shape, b_zero_matrix_shape
-
         with jax.set_mesh(self.mesh):
             if is_base_lora_id(uid):
                 # Base model: zero out the buffer slot
                 logger.debug("Loading base model (zeros) into buffer slot %d", buffer_id)
-                for module_name in self.target_modules:
-                    for layer_id in range(self.num_layers):
-                        a_shape, b_shape = get_ab_zero_matrix_shape(module_name)
-                        # Zero out A buffer
-                        self.A_buffer[module_name][layer_id] = (
-                            self.A_buffer[module_name][layer_id]
-                            .at[buffer_id]
-                            .set(jnp.zeros(a_shape, dtype=self.dtype))
-                        )
-                        # Zero out B buffer
-                        self.B_buffer[module_name][layer_id] = (
-                            self.B_buffer[module_name][layer_id]
-                            .at[buffer_id]
-                            .set(jnp.zeros(b_shape, dtype=self.dtype))
-                        )
+                self._zero_buffer_slot(buffer_id)
                 return
 
             if lora_adapter is None:
-                logger.warning("LoRA adapter %s is None, loading zeros", uid)
-                # Treat as base model if adapter is None
-                for module_name in self.target_modules:
-                    a_shape, b_shape = get_ab_zero_matrix_shape(module_name)
-                    for layer_id in range(self.num_layers):
-                        self.A_buffer[module_name][layer_id] = (
-                            self.A_buffer[module_name][layer_id]
-                            .at[buffer_id]
-                            .set(jnp.zeros(a_shape, dtype=self.dtype))
-                        )
-                        self.B_buffer[module_name][layer_id] = (
-                            self.B_buffer[module_name][layer_id]
-                            .at[buffer_id]
-                            .set(jnp.zeros(b_shape, dtype=self.dtype))
-                        )
-                return
+                raise ValueError(f"LoRA adapter {uid!r} is not loaded")
 
             logger.info(
                 "Loading LoRA adapter %s into buffer slot %d (num_layers=%d, target_modules=%s)",
@@ -516,7 +480,6 @@ class LoRAMemoryPool:
 
                 # Process each target module
                 for module_name in self.target_modules:
-                    a_shape, b_shape = get_ab_zero_matrix_shape(module_name)
                     # Extract and load weights for this module
                     lora_a, lora_b = self._extract_module_weights(
                         layer_weights, layer_id, module_name
@@ -561,16 +524,7 @@ class LoRAMemoryPool:
                             module_name,
                             layer_id,
                         )
-                        self.A_buffer[module_name][layer_id] = (
-                            self.A_buffer[module_name][layer_id]
-                            .at[buffer_id]
-                            .set(jnp.zeros(a_shape, dtype=self.dtype))
-                        )
-                        self.B_buffer[module_name][layer_id] = (
-                            self.B_buffer[module_name][layer_id]
-                            .at[buffer_id]
-                            .set(jnp.zeros(b_shape, dtype=self.dtype))
-                        )
+                        self._zero_buffer_slot(buffer_id, module_name, layer_id)
 
             # Log summary of loaded weights
             logger.info(
@@ -578,6 +532,47 @@ class LoRAMemoryPool:
                 uid,
                 loaded_modules_count,
             )
+
+    def _zero_buffer_slot(
+        self,
+        buffer_id: int,
+        module_name: str | None = None,
+        layer_id: int | None = None,
+    ):
+        """Write zero LoRA weights for one slot, optionally scoped to one module/layer."""
+        if buffer_id < 0 or buffer_id >= self.num_lora_slots:
+            raise ValueError(
+                f"LoRA buffer slot {buffer_id} is out of range for {self.num_lora_slots} slots"
+            )
+        if module_name is not None and module_name not in self.target_modules:
+            raise ValueError(
+                f"Unknown LoRA target module {module_name!r}; "
+                f"available modules: {sorted(self.target_modules)}"
+            )
+        if layer_id is not None and (layer_id < 0 or layer_id >= self.num_layers):
+            raise ValueError(
+                f"LoRA layer_id {layer_id} is out of range for {self.num_layers} layers"
+            )
+
+        module_names = [module_name] if module_name is not None else self.target_modules
+        layer_ids = [layer_id] if layer_id is not None else range(self.num_layers)
+
+        for cur_module_name in module_names:
+            a_shape, b_shape = self._get_zero_matrix_shapes(cur_module_name)
+            zero_a = jnp.zeros(a_shape, dtype=self.dtype)
+            zero_b = jnp.zeros(b_shape, dtype=self.dtype)
+            for cur_layer_id in layer_ids:
+                self.A_buffer[cur_module_name][cur_layer_id] = (
+                    self.A_buffer[cur_module_name][cur_layer_id].at[buffer_id].set(zero_a)
+                )
+                self.B_buffer[cur_module_name][cur_layer_id] = (
+                    self.B_buffer[cur_module_name][cur_layer_id].at[buffer_id].set(zero_b)
+                )
+
+    def _get_zero_matrix_shapes(self, module_name: str) -> tuple[tuple[int, int], tuple[int, int]]:
+        _, a_rank, input_dim = self._get_lora_a_shape(module_name)
+        _, output_dim, b_rank = self._get_lora_b_shape(module_name)
+        return (a_rank, input_dim), (output_dim, b_rank)
 
     def _extract_module_weights(
         self,
@@ -884,7 +879,10 @@ class LoRAMemoryPool:
 
     def get_buffer_id(self, lora_uid: str | None) -> int:
         """Get buffer slot ID for a given LoRA adapter ID."""
-        return self.uid_to_buffer_id[lora_uid]
+        try:
+            return self.uid_to_buffer_id[lora_uid]
+        except KeyError as exc:
+            raise KeyError(f"LoRA adapter {lora_uid!r} is not loaded in the memory pool") from exc
 
     def get_array(self, module_name: str, layer_id: int, is_lora_a: bool) -> jax.Array:
         """

--- a/python/sgl_jax/srt/lora/lora_memory_pool.py
+++ b/python/sgl_jax/srt/lora/lora_memory_pool.py
@@ -24,6 +24,7 @@ import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding
 from jax.tree_util import register_pytree_node_class
 
+from sgl_jax.srt.lora.constants import BASE_LORA_ID, BASE_LORA_SLOT, is_base_lora_id
 from sgl_jax.srt.lora.utils import get_lora_a_sharding, get_lora_b_sharding
 
 if TYPE_CHECKING:
@@ -63,7 +64,8 @@ class LoRAMemoryPool:
     incremental buffer allocation.
 
     Attributes:
-        max_loras_per_batch: Maximum number of LoRA adapters per batch
+        max_loras_per_batch: Maximum number of real LoRA adapters per batch
+        num_lora_slots: Number of device buffer slots, including the base slot
         max_lora_rank: Maximum LoRA rank supported
         num_layers: Number of transformer layers
         target_modules: Set of target module names (e.g., {"qkv_proj", "o_proj"})
@@ -90,12 +92,13 @@ class LoRAMemoryPool:
         head_dim: int | None = None,
         original_num_kv_heads: int | None = None,
         tp_size: int = 1,
+        reserve_base_slot: bool = True,
     ):
         """
         Initialize LoRA memory pool.
 
         Args:
-            max_loras_per_batch: Maximum number of LoRA adapters in a batch
+            max_loras_per_batch: Maximum number of real LoRA adapters in a batch
             max_lora_rank: Maximum LoRA rank to support
             num_layers: Number of transformer layers
             target_modules: Set of target module names
@@ -110,6 +113,8 @@ class LoRAMemoryPool:
             tp_size: Tensor parallel size (for calculating replication)
         """
         self.max_loras_per_batch = max_loras_per_batch
+        self.reserve_base_slot = reserve_base_slot
+        self.num_lora_slots = max_loras_per_batch + int(reserve_base_slot)
         self.max_lora_rank = max_lora_rank
         self.num_layers = num_layers
         self.target_modules = target_modules
@@ -140,7 +145,15 @@ class LoRAMemoryPool:
         # CPU-side tracking (not in pytree)
         # These are mutable Python objects used for bookkeeping
         self.uid_to_buffer_id: dict[str | None, int] = {}
-        self.buffer_id_to_uid: list[str | None | EmptySlot] = [EMPTY_SLOT] * max_loras_per_batch
+        self.buffer_id_to_uid: list[str | None | EmptySlot] = [EMPTY_SLOT] * self.num_lora_slots
+        if reserve_base_slot:
+            self.uid_to_buffer_id.update(
+                {
+                    BASE_LORA_ID: BASE_LORA_SLOT,
+                    None: BASE_LORA_SLOT,
+                }
+            )
+            self.buffer_id_to_uid[BASE_LORA_SLOT] = BASE_LORA_ID
 
         # Device buffers (in pytree) - initialized in init_buffers()
         self.A_buffer: dict[str, list[jax.Array]] = {}
@@ -160,6 +173,8 @@ class LoRAMemoryPool:
         children = (a_buffer_flat, b_buffer_flat)
         aux_data = {
             "max_loras_per_batch": self.max_loras_per_batch,
+            "reserve_base_slot": self.reserve_base_slot,
+            "num_lora_slots": self.num_lora_slots,
             "max_lora_rank": self.max_lora_rank,
             "num_layers": self.num_layers,
             "target_modules": self.target_modules,
@@ -187,6 +202,11 @@ class LoRAMemoryPool:
 
         # Restore attributes
         obj.max_loras_per_batch = aux_data["max_loras_per_batch"]
+        obj.reserve_base_slot = aux_data.get("reserve_base_slot", True)
+        obj.num_lora_slots = aux_data.get(
+            "num_lora_slots",
+            obj.max_loras_per_batch + int(obj.reserve_base_slot),
+        )
         obj.max_lora_rank = aux_data["max_lora_rank"]
         obj.num_layers = aux_data["num_layers"]
         obj.target_modules = aux_data["target_modules"]
@@ -233,7 +253,7 @@ class LoRAMemoryPool:
         """
         Get shape for LoRA A matrix.
 
-        Returns: (max_loras_per_batch, max_lora_rank, input_dim)
+        Returns: (num_lora_slots, max_lora_rank, input_dim)
 
         Note: Shape is global in JAX. Sharding is controlled by sharding spec,
         not by dividing dimensions in the shape.
@@ -254,13 +274,13 @@ class LoRAMemoryPool:
             # Default: hidden_size
             input_dim = self.hidden_size
 
-        return (self.max_loras_per_batch, self.max_lora_rank, input_dim)
+        return (self.num_lora_slots, self.max_lora_rank, input_dim)
 
     def _get_lora_b_shape(self, module_name: str) -> tuple[int, int, int]:
         """
         Get shape for LoRA B matrix.
 
-        Returns: (max_loras_per_batch, output_dim, max_lora_rank)
+        Returns: (num_lora_slots, output_dim, max_lora_rank)
 
         Note: Shape is global in JAX. Sharding is controlled by sharding spec,
         not by dividing dimensions in the shape.
@@ -291,7 +311,7 @@ class LoRAMemoryPool:
             # Default: hidden_size
             output_dim = self.hidden_size
 
-        return (self.max_loras_per_batch, output_dim, self.max_lora_rank)
+        return (self.num_lora_slots, output_dim, self.max_lora_rank)
 
     def _get_lora_a_sharding(self, module_name: str) -> NamedSharding:
         return get_lora_a_sharding(module_name, self.mesh)
@@ -306,9 +326,10 @@ class LoRAMemoryPool:
         Creates A_buffer and B_buffer with proper sharding.
         """
         logger.info(
-            "Initializing LoRA memory pool buffers: num_layers=%d, max_loras_per_batch=%d, max_lora_rank=%d, dtype=%s",
+            "Initializing LoRA memory pool buffers: num_layers=%d, max_loras_per_batch=%d, num_lora_slots=%d, max_lora_rank=%d, dtype=%s",
             self.num_layers,
             self.max_loras_per_batch,
+            self.num_lora_slots,
             self.max_lora_rank,
             self.dtype,
         )
@@ -355,7 +376,7 @@ class LoRAMemoryPool:
 
     def prepare_lora_batch(
         self,
-        cur_uids: set[str | None],
+        cur_uids: list[str | None],
         lora_adapters: dict[str | None, LoRAAdapter],
     ) -> bool:
         """
@@ -376,23 +397,27 @@ class LoRAMemoryPool:
 
         def get_available_buffer_slot(uid: str) -> int:
             """Find next available buffer slot (simple incremental allocation)."""
-            # 0 is reserved for request without LoRA
-            if uid == "0":
-                return 0
-            for buffer_id in range(1, self.max_loras_per_batch + 1):
-                # 0 is reserved for zeros, so add 1 to match user's expectation.
+            # Slot 0 is reserved for requests without LoRA when enabled.
+            if is_base_lora_id(uid):
+                if not self.reserve_base_slot:
+                    raise ValueError("Base LoRA slot is not reserved in this memory pool")
+                return BASE_LORA_SLOT
+            first_adapter_slot = BASE_LORA_SLOT + int(self.reserve_base_slot)
+            for buffer_id in range(first_adapter_slot, self.num_lora_slots):
                 if self.buffer_id_to_uid[buffer_id] == EMPTY_SLOT:
                     return buffer_id
 
             raise ValueError(
-                "No available buffer slots. Max %d LoRA adapters per batch exceeded.",
+                "No available buffer slots. Max %d LoRA adapters per batch exceeded; %d total slots are available.",
                 self.max_loras_per_batch,
+                self.num_lora_slots,
             )
 
         has_new_weights = False
 
         # Load each adapter that's not already loaded
         for uid in cur_uids:
+            uid = BASE_LORA_ID if uid is None else uid
             if uid not in self.uid_to_buffer_id:
                 buffer_id = get_available_buffer_slot(uid)
                 self.uid_to_buffer_id[uid] = buffer_id
@@ -403,6 +428,13 @@ class LoRAMemoryPool:
                 logger.info("Loaded LoRA %s into buffer slot %d", uid, buffer_id)
             else:
                 logger.debug("LoRA %s already in buffer slot %d", uid, self.uid_to_buffer_id[uid])
+
+        if has_new_weights and self.reserve_base_slot:
+            # Slot 0 is the serving-wide no-LoRA sentinel.  Adapter loading is
+            # implemented as functional updates over large sharded buffers; keep
+            # the sentinel invariant explicit so mixed LoRA/base batches never
+            # depend on earlier buffer contents.
+            self.load_lora_weight_to_buffer(BASE_LORA_ID, BASE_LORA_SLOT, None)
 
         return has_new_weights
 
@@ -429,7 +461,7 @@ class LoRAMemoryPool:
             return a_zero_matrix_shape, b_zero_matrix_shape
 
         with jax.set_mesh(self.mesh):
-            if uid is None:
+            if is_base_lora_id(uid):
                 # Base model: zero out the buffer slot
                 logger.debug("Loading base model (zeros) into buffer slot %d", buffer_id)
                 for module_name in self.target_modules:
@@ -865,8 +897,8 @@ class LoRAMemoryPool:
 
         Returns:
             JAX array with shape:
-            - A: (max_loras_per_batch, max_lora_rank, input_dim)
-            - B: (max_loras_per_batch, output_dim, max_lora_rank)
+            - A: (num_lora_slots, max_lora_rank, input_dim)
+            - B: (num_lora_slots, output_dim, max_lora_rank)
         """
         if is_lora_a:
             return self.A_buffer[module_name][layer_id]

--- a/python/sgl_jax/srt/lora/lora_registry.py
+++ b/python/sgl_jax/srt/lora/lora_registry.py
@@ -18,6 +18,7 @@ import asyncio
 from dataclasses import dataclass, field, fields
 from uuid import uuid4
 
+from sgl_jax.srt.lora.constants import BASE_LORA_ID, is_base_lora_id
 from sgl_jax.srt.utils import ConcurrentCounter, RWLock
 
 
@@ -39,6 +40,8 @@ class LoRARef:
     def __post_init__(self):
         if self.lora_id is None:
             raise ValueError("lora_id cannot be None")
+        if self.lora_id == BASE_LORA_ID:
+            raise ValueError(f"lora_id {BASE_LORA_ID!r} is reserved for base-model requests")
 
     def __str__(self) -> str:
         parts = [
@@ -105,15 +108,15 @@ class LoRARegistry:
 
         return lora_ref.lora_id
 
-    async def acquire(self, lora_name: str | list[str]) -> str | list[str]:
+    async def acquire(self, lora_name: str | None | list[str | None]) -> str | list[str]:
         """
         Queries registry for LoRA IDs based on LoRA names and start tracking the usage of the corresponding LoRA adapters
         by incrementing its counter.
         """
 
-        def _lookup(name: str) -> str:
+        def _lookup(name: str | None) -> str:
             if name is None:
-                return None
+                return BASE_LORA_ID
 
             lora_ref = self._registry.get(name, None)
             if lora_ref is None:
@@ -128,6 +131,8 @@ class LoRARegistry:
                 lora_id = _lookup(lora_name)
                 await self._counters[lora_id].increment(notify_all=False)
                 return lora_id
+            elif lora_name is None:
+                return BASE_LORA_ID
             elif isinstance(lora_name, list):
                 lora_ids = [_lookup(name) for name in lora_name]
 
@@ -136,7 +141,7 @@ class LoRARegistry:
                     *[
                         self._counters[id].increment(notify_all=False)
                         for id in lora_ids
-                        if id is not None
+                        if not is_base_lora_id(id)
                     ]
                 )
                 return lora_ids
@@ -150,10 +155,16 @@ class LoRARegistry:
 
         async with self._registry_lock.reader_lock:
             if isinstance(lora_id, str):
+                if is_base_lora_id(lora_id):
+                    return
                 await self._counters[lora_id].decrement()
             elif isinstance(lora_id, list):
                 await asyncio.gather(
-                    *[self._counters[id].decrement() for id in lora_id if id is not None]
+                    *[
+                        self._counters[id].decrement()
+                        for id in lora_id
+                        if not is_base_lora_id(id)
+                    ]
                 )
             else:
                 raise TypeError("lora_id must be either a string or a list of strings.")

--- a/python/sgl_jax/srt/lora/utils.py
+++ b/python/sgl_jax/srt/lora/utils.py
@@ -1,31 +1,85 @@
-from collections.abc import Iterable
+import math
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from enum import Enum
 
-import jax
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
-from jax.tree_util import register_pytree_node_class
 
 
-@register_pytree_node_class
-@dataclass
-class LoRABatchInfo:
-    # scaling of each lora adapter, in shape (num_tokens,)
-    scalings: jax.Array
+@dataclass(frozen=True)
+class LoRABatchPlan:
+    """CPU-side LoRA assignment plan for one scheduler batch.
 
-    # (num_tokens,)
-    token_lora_indices: jax.Array
+    weight_indices is request-granular and points at device-memory LoRA slots.
+    ranks_by_slot and scalings_by_slot are slot-granular metadata. Keeping these
+    together makes the indexing contract explicit before a backend expands it to
+    token-granular arrays.
+    """
 
-    # (num_tokens,)
-    lora_ranks: jax.Array
+    weight_indices: tuple[int, ...]
+    ranks_by_slot: tuple[int, ...]
+    scalings_by_slot: tuple[float, ...]
 
-    def tree_flatten(self):
-        return ((self.scalings, self.token_lora_indices, self.lora_ranks), None)
+    def __init__(
+        self,
+        weight_indices: Sequence[int],
+        ranks_by_slot: Sequence[int],
+        scalings_by_slot: Sequence[float],
+    ):
+        object.__setattr__(self, "weight_indices", tuple(int(idx) for idx in weight_indices))
+        object.__setattr__(self, "ranks_by_slot", tuple(int(rank) for rank in ranks_by_slot))
+        object.__setattr__(
+            self,
+            "scalings_by_slot",
+            tuple(float(scaling) for scaling in scalings_by_slot),
+        )
+        self._validate()
+
+    def _validate(self):
+        if len(self.ranks_by_slot) != len(self.scalings_by_slot):
+            raise ValueError(
+                "LoRA rank and scaling metadata must have the same slot count: "
+                f"{len(self.ranks_by_slot)} != {len(self.scalings_by_slot)}"
+            )
+
+        num_slots = len(self.ranks_by_slot)
+        for request_idx, slot in enumerate(self.weight_indices):
+            if slot < 0 or slot >= num_slots:
+                raise ValueError(
+                    f"LoRA request {request_idx} references slot {slot}, "
+                    f"but only {num_slots} slots are available"
+                )
+
+        for slot, rank in enumerate(self.ranks_by_slot):
+            if rank < 0:
+                raise ValueError(f"LoRA slot {slot} has negative rank {rank}")
+
+        for slot, scaling in enumerate(self.scalings_by_slot):
+            if not math.isfinite(scaling):
+                raise ValueError(f"LoRA slot {slot} has non-finite scaling {scaling}")
+            if scaling < 0:
+                raise ValueError(f"LoRA slot {slot} has negative scaling {scaling}")
 
     @classmethod
-    def tree_unflatten(cls, aux_data, children):
-        return cls(*children)
+    def for_static_lora(
+        cls,
+        batch_size: int,
+        num_lora_slots: int,
+        rank: int,
+        scaling: float,
+    ) -> "LoRABatchPlan":
+        return cls(
+            weight_indices=(0,) * batch_size,
+            ranks_by_slot=(rank,) * num_lora_slots,
+            scalings_by_slot=(scaling,) * num_lora_slots,
+        )
+
+    def ranks_for_requests(self) -> tuple[int, ...]:
+        return tuple(self.ranks_by_slot[slot] for slot in self.weight_indices)
+
+    def scalings_for_requests(self) -> tuple[float, ...]:
+        return tuple(self.scalings_by_slot[slot] for slot in self.weight_indices)
 
 
 class LoRAType(Enum):
@@ -40,9 +94,15 @@ def get_target_module_name(full_module_name: str, target_modules: set[str]) -> s
     If there is a target module name in target_modules that can match full_module_name, return this name
     Else raise ValueError.
     """
-    for target_module in target_modules:
+    ordered_target_modules = sorted(target_modules, key=lambda name: (-len(name), name))
+    for target_module in ordered_target_modules:
+        if full_module_name == target_module or full_module_name.endswith(f".{target_module}"):
+            return target_module
+
+    for target_module in ordered_target_modules:
         if target_module in full_module_name:
             return target_module
+
     raise ValueError(f"Cannot find target module name for {full_module_name} in {target_modules}")
 
 

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -45,6 +45,7 @@ from sgl_jax.srt.mem_cache.common import (
 from sgl_jax.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPool
 from sgl_jax.srt.mem_cache.radix_cache import RadixKey
 from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
+from sgl_jax.srt.lora.constants import BASE_LORA_ID
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
 from sgl_jax.srt.precision_tracer import (
     PrecisionTracerRequestMetadata,
@@ -168,6 +169,7 @@ class Req:
         lora_id: str | None = None,
         extra_key: str | None = None,
         dp_rank: int | None = None,
+        arrival_index: int = 0,
         origin_input_ids_unpadded: tuple[int] | None = None,
         eos_token_ids: set[int] | None = None,
         vocab_size: int | None = None,
@@ -208,8 +210,9 @@ class Req:
             extra_key = (extra_key or "") + lora_id  # lora_id is concatenated to the extra key
 
         self.extra_key = extra_key
-        self.lora_id = lora_id if lora_id is not None else "0"
+        self.lora_id = lora_id if lora_id is not None else BASE_LORA_ID
         self.dp_rank = dp_rank
+        self.arrival_index = arrival_index
 
         # Memory pool info
         self.req_pool_idx: int | None = None
@@ -1833,13 +1836,18 @@ class ScheduleBatch:
         Returns:
             (req_pool_indices, seq_lens, extend_prefix_lens,
              extend_seq_lens, extend_logprob_start_lens, logits_indices, real_bs,
-             real_bs_per_dp, logits_indices_selector)
+             real_bs_per_dp, logits_indices_selector, output_order_selector)
 
         logits_indices_selector maps "original request order"
         (i.e., DP-rank-then-req flat order) to the DP-interleaved padded
         slot in the global batch. It lets host-side code reorder per-req
         outputs (e.g. logprobs) back to original order with one numpy
         gather, instead of rederiving per-rank offsets at every callsite.
+
+        output_order_selector maps request arrival order to the same padded
+        slots. This is used by debug dumps that are consumed outside the
+        scheduler's request loop and therefore need stable client-visible
+        ordering even if scheduling reorders the batch.
         """
         req_pool_indices_cpu = np.full(total_bs, -1, dtype=np.int32)
         seq_lens_cpu = np.zeros(total_bs, dtype=np.int32)
@@ -1859,6 +1867,7 @@ class ScheduleBatch:
         real_bs = 0
         real_bs_per_dp = [0] * self.dp_size
         selector_chunks: list[np.ndarray] = []
+        output_order_pairs: list[tuple[int, int]] = []
 
         for dp_rank in range(self.dp_size):
             info = self.reqs_info[dp_rank]
@@ -1895,12 +1904,22 @@ class ScheduleBatch:
                     )
 
             selector_chunks.append(np.arange(offset_bs, offset_bs + dp_bs, dtype=np.int32))
+            output_order_pairs.extend(
+                (req.arrival_index, offset_bs + local_idx)
+                for local_idx, req in enumerate(info.reqs[:dp_bs])
+            )
             offset_bs += per_dp_bs_size
 
         if selector_chunks:
             logits_indices_selector = np.concatenate(selector_chunks)
         else:
             logits_indices_selector = np.empty(0, dtype=np.int32)
+        if output_order_pairs:
+            output_order_selector = np.array(
+                [slot for _, slot in sorted(output_order_pairs)], dtype=np.int32
+            )
+        else:
+            output_order_selector = np.empty(0, dtype=np.int32)
 
         return (
             req_pool_indices_cpu,
@@ -1912,6 +1931,7 @@ class ScheduleBatch:
             real_bs,
             real_bs_per_dp,
             logits_indices_selector,
+            output_order_selector,
         )
 
     def _merge_cache_loc(
@@ -2335,6 +2355,7 @@ class ScheduleBatch:
             real_bs,
             real_bs_per_dp,
             logits_indices_selector,
+            output_order_selector,
         ) = self._merge_batch_metadata(per_dp_bs_padding, total_bs)
 
         # Step 4: Merge cache_loc from all DP ranks
@@ -2384,11 +2405,15 @@ class ScheduleBatch:
                 all_reqs.extend(info.reqs)
 
         if enable_static_lora:
-            lora_ids = ["0"] * total_bs
+            lora_ids = [BASE_LORA_ID] * total_bs
         else:
-            lora_ids = [req.lora_id for req in all_reqs[:real_bs]]
-            # Pad to total_bs
-            lora_ids = lora_ids + ["0"] * (total_bs - real_bs)
+            lora_ids = [BASE_LORA_ID] * total_bs
+            offset_bs = 0
+            for info in self.reqs_info:
+                if info.reqs:
+                    for local_idx, req in enumerate(info.reqs):
+                        lora_ids[offset_bs + local_idx] = req.lora_id
+                offset_bs += per_dp_bs_padding
 
         # input_embedding = None
 
@@ -2487,6 +2512,7 @@ class ScheduleBatch:
             real_bs=real_bs,
             real_bs_per_dp=real_bs_per_dp,
             logits_indices_selector=logits_indices_selector,
+            output_order_selector=output_order_selector,
             capture_hidden_mode=(
                 CaptureHiddenMode.FULL
                 if self.return_hidden_states
@@ -2967,6 +2993,8 @@ class ModelWorkerBatch:
     # `arr[selector]` once after device_get to put per-req outputs back
     # into original order, removing the need for per-rank index math.
     logits_indices_selector: np.ndarray | None = None
+    # Maps client arrival order to padded batch slots for out-of-band debug dumps.
+    output_order_selector: np.ndarray | None = None
 
     # Pre-bucketed per-token gather indices for the padded logprob path; None on
     # the legacy variable-shape path and on non-extend batches.

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -30,6 +30,7 @@ from sgl_jax.srt.constrained.base_grammar_backend import (
 )
 from sgl_jax.srt.hf_transformers_utils import get_tokenizer
 from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
+from sgl_jax.srt.lora.constants import is_base_lora_id
 from sgl_jax.srt.managers.communication import CommunicationBackend
 from sgl_jax.srt.managers.io_struct import (
     AbortReq,
@@ -404,6 +405,7 @@ class Scheduler(
         self.last_batch: ScheduleBatch | None = None
         self.forward_ct = 0
         self.forward_ct_decode = 0
+        self.request_arrival_index = 0
         self.num_generated_tokens = 0
         self.last_prefill_tokens = 0
         self.last_decode_stats_tic = time.perf_counter()
@@ -1000,6 +1002,9 @@ class Scheduler(
         self,
         recv_req: TokenizedGenerateReqInput,
     ):
+        arrival_index = self.request_arrival_index
+        self.request_arrival_index += 1
+
         # Create a new request
         req = Req(
             recv_req.rid,
@@ -1014,6 +1019,7 @@ class Scheduler(
             lora_id=recv_req.lora_id,
             extra_key=recv_req.extra_key,
             dp_rank=recv_req.dp_rank,
+            arrival_index=arrival_index,
             eos_token_ids=self.model_config.hf_eos_token_id,
             vocab_size=self.model_config.vocab_size,
             return_routed_experts=recv_req.return_routed_experts,
@@ -1592,7 +1598,9 @@ class Scheduler(
             if self.running_batch is not None:
                 for info in self.running_batch.reqs_info:
                     if info.reqs:
-                        lora_set.update([req.lora_id for req in info.reqs])
+                        lora_set.update(
+                            req.lora_id for req in info.reqs if not is_base_lora_id(req.lora_id)
+                        )
 
         # Get requests from the waiting queue to a new prefill batch
         for req in self.waiting_queue:
@@ -1614,14 +1622,20 @@ class Scheduler(
             if self.chunked_reqs[dp_rank] is not None:
                 continue
 
-            # Check LoRA constraint: ensure we don't exceed max_loras_per_batch
+            # Check LoRA constraint: ensure we don't exceed max_loras_per_batch.
+            # Base-model requests use a reserved slot and do not count as adapters.
             # This is GLOBAL - must be same across all DP ranks
             if (
                 self.lora_paths is not None
                 and len(
                     lora_set
-                    | set([req.lora_id for reqs in adder.can_run_list.values() for req in reqs])
-                    | set([req.lora_id])
+                    | set(
+                        pending_req.lora_id
+                        for reqs in adder.can_run_list.values()
+                        for pending_req in reqs
+                        if not is_base_lora_id(pending_req.lora_id)
+                    )
+                    | ({req.lora_id} if not is_base_lora_id(req.lora_id) else set())
                 )
                 > self.max_loras_per_batch
             ):

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -29,6 +29,7 @@ from fastapi import BackgroundTasks
 
 from sgl_jax.srt.configs.model_config import ModelConfig
 from sgl_jax.srt.hf_transformers_utils import get_tokenizer
+from sgl_jax.srt.lora.constants import BASE_LORA_ID, is_base_lora_id
 from sgl_jax.srt.lora.lora_registry import LoRARegistry
 from sgl_jax.srt.managers.io_struct import (
     AbortReq,
@@ -261,9 +262,16 @@ class TokenizerManager:
         self.auto_create_handle_loop()
         obj.normalize_batch_and_arguments()
 
-        # Acquire LoRA ID if lora_path is provided
-        if isinstance(obj, GenerateReqInput) and self.server_args.enable_lora and obj.lora_path:
-            obj.lora_id = await self.lora_registry.acquire(obj.lora_path)
+        # Acquire LoRA ID if lora_path is provided. On LoRA-enabled servers,
+        # base-model requests use an explicit namespace so radix-cache
+        # entries cannot collide with adapter-specific prefixes.
+        if isinstance(obj, GenerateReqInput) and self.server_args.enable_lora:
+            if obj.lora_path:
+                obj.lora_id = await self.lora_registry.acquire(obj.lora_path)
+            elif obj.is_single:
+                obj.lora_id = BASE_LORA_ID
+            else:
+                obj.lora_id = [BASE_LORA_ID] * obj.batch_size
 
         if isinstance(obj, EmbeddingReqInput) and self.is_generation:
             raise ValueError(
@@ -1063,6 +1071,7 @@ class TokenizerManager:
                     isinstance(state.obj, GenerateReqInput)
                     and self.server_args.enable_lora
                     and state.obj.lora_id
+                    and not is_base_lora_id(state.obj.lora_id)
                 ):
                     asyncio.create_task(self.lora_registry.release(state.obj.lora_id))
                 del self.rid_to_state[rid]

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -406,9 +406,11 @@ class ModelWorker:
         save_logits_file_info = os.getenv("DUMP_LAST_LAYER_LOGITS_FILENAMES", None)
         if save_logits_file_info:
             save_logits_with_txt(
-                logits_output.next_token_logits[: model_worker_batch.real_bs, :],
+                logits_output.next_token_logits,
                 save_logits_file_info,
                 forward_batch.forward_mode,
+                selector=model_worker_batch.output_order_selector,
+                real_bs=model_worker_batch.real_bs,
             )
 
         if skip_sample:
@@ -669,9 +671,15 @@ def save_logits_with_txt(
     arr: jax.Array,
     file_info: str,
     forward_mode: ForwardMode,
+    selector: np.ndarray | None = None,
+    real_bs: int | None = None,
 ):
     # format: {prefill_file_name},{decode_file_name}
     file_slice = file_info.split(",")
+    if len(file_slice) != 2:
+        raise ValueError(
+            f"Expected logits dump file_info to contain prefill and decode paths, got {file_info!r}"
+        )
     if forward_mode.is_extend():
         file_name = file_slice[0]
     elif forward_mode.is_decode():
@@ -679,5 +687,31 @@ def save_logits_with_txt(
     else:
         raise ValueError(f"Unsupported {forward_mode} to save logits with txt")
 
-    os.makedirs(os.path.dirname(file_name), exist_ok=True)
-    np.savetxt(file_name, np.asarray(jax.device_get(arr)).flatten(), fmt="%.15f")
+    dump_dir = os.path.dirname(file_name)
+    if dump_dir:
+        os.makedirs(dump_dir, exist_ok=True)
+    arr_host = np.asarray(jax.device_get(arr))
+    if selector is not None and len(selector) > 0:
+        selector = np.asarray(selector, dtype=np.int64)
+        if selector.ndim != 1:
+            raise ValueError(
+                f"Logits dump selector for {forward_mode} must be 1D, got shape {selector.shape}"
+            )
+        if real_bs is not None and len(selector) != real_bs:
+            raise ValueError(
+                f"Logits dump selector length {len(selector)} does not match real_bs={real_bs} "
+                f"for {forward_mode}"
+            )
+        if selector.size and (selector.min() < 0 or selector.max() >= arr_host.shape[0]):
+            raise ValueError(
+                f"Logits dump selector out of bounds for {forward_mode}: "
+                f"selector range=[{selector.min()}, {selector.max()}], rows={arr_host.shape[0]}"
+            )
+        arr_host = arr_host[selector]
+    elif real_bs is not None:
+        if real_bs < 0 or real_bs > arr_host.shape[0]:
+            raise ValueError(
+                f"Invalid real_bs={real_bs} for logits dump with {arr_host.shape[0]} rows"
+            )
+        arr_host = arr_host[:real_bs]
+    np.savetxt(file_name, arr_host.flatten(), fmt="%.15f")

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -354,6 +354,7 @@ class MHATokenToKVPool(KVCache):
         self.head_dim = head_dim
         self.dp_size = dp_size
         self.kv_partition_axis = "tensor"
+        self.effective_kv_partition_axis = "tensor"
         self.attention_data_partition_axis = "data"
 
         self._create_buffers()
@@ -369,6 +370,7 @@ class MHATokenToKVPool(KVCache):
             "head_dim": self.head_dim,
             "dp_size": self.dp_size,
             "kv_partition_axis": self.kv_partition_axis,
+            "effective_kv_partition_axis": self.effective_kv_partition_axis,
             "attention_data_partition_axis": self.attention_data_partition_axis,
             "kv_sharding": self.kv_sharding,
         }
@@ -398,6 +400,9 @@ class MHATokenToKVPool(KVCache):
         obj.head_dim = aux_data["head_dim"]
         obj.dp_size = aux_data.get("dp_size", 1)
         obj.kv_partition_axis = aux_data["kv_partition_axis"]
+        obj.effective_kv_partition_axis = aux_data.get(
+            "effective_kv_partition_axis", aux_data["kv_partition_axis"]
+        )
         obj.attention_data_partition_axis = aux_data.get("attention_data_partition_axis", "data")
         obj.kv_sharding = aux_data["kv_sharding"]
 
@@ -407,9 +412,25 @@ class MHATokenToKVPool(KVCache):
 
     def _create_buffers(self):
         """Create sharded fused KV cache buffers with proper distributed allocation"""
+        # Determine if the tensor axis dimension is large enough to shard.
+        # When head_num * 2 // packing is not divisible by the mesh tensor axis
+        # size (e.g. num_kv_heads=1 on 8 devices), fall back to replicated.
+        packing = get_dtype_packing(self.dtype)
+        tensor_dim = self.head_num * 2 // packing
+        tensor_axis_size = self.mesh.shape.get(self.kv_partition_axis, 1)
+        self.effective_kv_partition_axis = (
+            self.kv_partition_axis if tensor_dim % tensor_axis_size == 0 else None
+        )
+
         self.kv_sharding = NamedSharding(
             self.mesh,
-            P(self.attention_data_partition_axis, None, self.kv_partition_axis, None, None),
+            P(
+                self.attention_data_partition_axis,
+                None,
+                self.effective_kv_partition_axis,
+                None,
+                None,
+            ),
         )
 
         logger.info("Creating fused KV buffers for %s layers", self.layer_num)
@@ -420,7 +441,6 @@ class MHATokenToKVPool(KVCache):
         ), "Cache size must be divisible by dp_size and size must be divisible by page size"
 
         # Hack: this shape is more friendly to rpav3
-        packing = get_dtype_packing(self.dtype)
         fused_buffer_shape = (
             (self.size + self.page_size * self.dp_size) // self.page_size,
             self.page_size,
@@ -529,7 +549,7 @@ class MHATokenToKVPool(KVCache):
             loc=loc,
             kv_cache=self.kv_buffer[layer_idx],
             page_size=page_size,
-            kv_partition_axis=self.kv_partition_axis,
+            kv_partition_axis=self.effective_kv_partition_axis,
             attention_data_partition_axis=self.attention_data_partition_axis,
             mesh=self.mesh,
         )
@@ -586,21 +606,21 @@ class MHATokenToKVPool(KVCache):
         cache_3d = jax.lax.reshape(
             cache_5d,
             (total_cache_tokens, heads_x2_per_pack * packing, head_dim),
-            out_sharding=P(None, self.kv_partition_axis, None),
+            out_sharding=P(None, self.effective_kv_partition_axis, None),
         )
 
         num_tokens, _one, fkv_h, fkv_p, fkv_d = fused_kv.shape
         fused_kv_3d = jax.lax.reshape(
             fused_kv,
             (num_tokens, fkv_h * fkv_p, fkv_d),
-            out_sharding=P(None, self.kv_partition_axis, None),
+            out_sharding=P(None, self.effective_kv_partition_axis, None),
         )
 
         safe_loc = jnp.where(loc >= 0, loc, jnp.int32(total_cache_tokens))
         updated_3d = cache_3d.at[safe_loc].set(
             fused_kv_3d,
             mode="drop",
-            out_sharding=P(None, self.kv_partition_axis, None),
+            out_sharding=P(None, self.effective_kv_partition_axis, None),
         )
 
         # Reshape back to 5D
@@ -608,7 +628,11 @@ class MHATokenToKVPool(KVCache):
             updated_3d,
             (num_pages, page_size, heads_x2_per_pack, packing, head_dim),
             out_sharding=P(
-                self.attention_data_partition_axis, None, self.kv_partition_axis, None, None
+                self.attention_data_partition_axis,
+                None,
+                self.effective_kv_partition_axis,
+                None,
+                None,
             ),
         )
 
@@ -803,7 +827,7 @@ def _set_fused_kv_buffer(
     loc: jax.Array,
     kv_cache: jax.Array,
     page_size: int,
-    kv_partition_axis: str = "tensor",
+    kv_partition_axis: str | None = "tensor",
     attention_data_partition_axis: str = "data",
     mesh: Mesh = None,
 ) -> jax.Array:
@@ -815,7 +839,7 @@ def _set_fused_kv_buffer(
         loc: Location indices [total_tokens], -1 for padding tokens
         kv_cache: Fused KV cache buffer, 5D [pages, page_size, heads//pack, pack, hdim]
         page_size: Page size for vectorized updates
-        kv_partition_axis: Partition axis for sharding
+        kv_partition_axis: Partition axis for sharding (None = replicated)
 
     Returns:
         Updated fused KV cache (5D)
@@ -836,7 +860,7 @@ def update_fused_kv_cache(
     loc: jax.Array,  # [total_tokens], -1 for padding
     kv_cache: jax.Array,  # [num_pages, page_size, heads*2//packing, packing, head_dim]
     page_size: int = 1,
-    kv_partition_axis: str = "tensor",
+    kv_partition_axis: str | None = "tensor",
     data_partition_axis: str = "data",
     mesh: Mesh = None,
 ) -> jax.Array:
@@ -939,7 +963,7 @@ def update_fused_kv_cache_vectorized(
     loc: jax.Array,  # [total_tokens], -1 for padding
     kv_cache: jax.Array,  # [num_pages, page_size, heads*2//packing, packing, head_dim]
     page_size: int,
-    kv_partition_axis: str = "tensor",
+    kv_partition_axis: str | None = "tensor",
     data_partition_axis: str = "data",
     mesh: Mesh = None,
 ) -> jax.Array:
@@ -948,20 +972,7 @@ def update_fused_kv_cache_vectorized(
     by grouping contiguous tokens into page-sized chunks for efficient updates.
     """
 
-    @jax.shard_map(
-        in_specs=(
-            # fused_kv: 5D sharded by data and tensor
-            P(data_partition_axis, None, kv_partition_axis, None, None),
-            # loc: sharded by data
-            P(data_partition_axis),
-            # kv_cache: 5D sharded by data and tensor
-            P(data_partition_axis, None, kv_partition_axis, None, None),
-        ),
-        out_specs=P(data_partition_axis, None, kv_partition_axis, None, None),
-        mesh=mesh,
-        check_vma=False,
-    )
-    def _sharded_update(local_fused_kv, local_loc, local_kv_cache):
+    def _local_update(local_fused_kv, local_loc, local_kv_cache):
         total_tokens = local_loc.shape[0]
         local_loc_int = local_loc.astype(jnp.int32)
 
@@ -994,7 +1005,34 @@ def update_fused_kv_cache_vectorized(
             num_slices_per_block=num_slices_per_block,
         )
 
-    return _sharded_update(fused_kv, loc, kv_cache)
+    if mesh is None:
+        # Local/reference path used by tests and non-distributed callers.
+        # Do not wrap with shard_map because inputs may be replicated on data axis.
+        return _local_update(fused_kv, loc, kv_cache)
+
+    # JAX 0.9.1+ enforces that in_specs match actual input sharding.
+    # Defensive check: if the tensor axis dimension is not divisible by the
+    # mesh axis size, fall back to replicated. This handles callers that pass
+    # kv_partition_axis="tensor" without checking divisibility (e.g. tests).
+    if kv_partition_axis is not None:
+        tensor_dim = fused_kv.shape[2]
+        axis_size = mesh.shape.get(kv_partition_axis, 1)
+        if tensor_dim % axis_size != 0:
+            kv_partition_axis = None
+
+    # Multi-device: wrap with shard_map for SPMD execution.
+    sharded = jax.shard_map(
+        _local_update,
+        in_specs=(
+            P(data_partition_axis, None, kv_partition_axis, None, None),
+            P(data_partition_axis),
+            P(data_partition_axis, None, kv_partition_axis, None, None),
+        ),
+        out_specs=P(data_partition_axis, None, kv_partition_axis, None, None),
+        mesh=mesh,
+        check_vma=False,
+    )
+    return sharded(fused_kv, loc, kv_cache)
 
 
 @register_pytree_node_class

--- a/python/sgl_jax/srt/model_loader/loader.py
+++ b/python/sgl_jax/srt/model_loader/loader.py
@@ -130,6 +130,15 @@ class DefaultModelLoader(BaseModelLoader):
         if is_local:
             hf_folder = model_name_or_path
         else:
+            if os.path.isabs(model_name_or_path):
+                models_prefix = os.path.join(os.path.sep, "models") + os.path.sep
+                if model_name_or_path.startswith(models_prefix):
+                    model_name_or_path = model_name_or_path[len(models_prefix) :].rstrip(
+                        os.path.sep
+                    )
+                # else: not a /models/… path — fall through to snapshot_download
+                # which will resolve the repo id or raise appropriately.
+
             from huggingface_hub import snapshot_download
 
             hf_folder = snapshot_download(

--- a/python/sgl_jax/srt/model_loader/loader.py
+++ b/python/sgl_jax/srt/model_loader/loader.py
@@ -133,11 +133,20 @@ class DefaultModelLoader(BaseModelLoader):
             if os.path.isabs(model_name_or_path):
                 models_prefix = os.path.join(os.path.sep, "models") + os.path.sep
                 if model_name_or_path.startswith(models_prefix):
-                    model_name_or_path = model_name_or_path[len(models_prefix) :].rstrip(
-                        os.path.sep
+                    repo_id = model_name_or_path[len(models_prefix) :].strip(os.path.sep)
+                    if len(repo_id.split(os.path.sep)) == 2:
+                        model_name_or_path = repo_id
+                    else:
+                        raise ValueError(
+                            f"Model path {model_name_or_path!r} does not exist locally and "
+                            "cannot be interpreted as a HuggingFace repo id. Expected either "
+                            "an existing directory or /models/<namespace>/<repo>."
+                        )
+                else:
+                    raise ValueError(
+                        f"Model path {model_name_or_path!r} is absolute but does not exist. "
+                        "Pass an existing local directory or a HuggingFace repo id."
                     )
-                # else: not a /models/… path — fall through to snapshot_download
-                # which will resolve the repo id or raise appropriately.
 
             from huggingface_hub import snapshot_download
 

--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -184,7 +184,9 @@ class BailingMoELinearAttention(nnx.Module):
             k = jax.nn.silu(k)
             v = jax.nn.silu(v)
 
-        head_shard = NamedSharding(self.mesh, P("data", "tensor", None))
+        tensor_size = self.mesh.shape.get("tensor", 1) if self.mesh else 1
+        head_axis = "tensor" if self.num_heads % tensor_size == 0 else None
+        head_shard = NamedSharding(self.mesh, P("data", head_axis, None))
         q = q.reshape(
             hidden_states.shape[0], self.num_heads, self.head_dim, out_sharding=head_shard
         )

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -1091,7 +1091,10 @@ class ServerArgs:
             "--max-loras-per-batch",
             type=int,
             default=8,
-            help="Maximum number of different LoRA adapters that can be used in a single batch.",
+            help=(
+                "Maximum number of different real LoRA adapters that can be used in a "
+                "single batch. Base-model requests do not count toward this limit."
+            ),
         )
         parser.add_argument(
             "--max-lora-rank",

--- a/python/sgl_jax/srt/utils/jax_utils.py
+++ b/python/sgl_jax/srt/utils/jax_utils.py
@@ -207,12 +207,13 @@ def device_array(*data, sharding=None, **kwargs) -> jax.Array:
     return jax.tree.map(_to_device, *data)
 
 
-def effective_axis(x, dim, expected):
-    """Read the actual NamedSharding spec from an array to derive shard_map in_specs.
+def effective_axis(x, dim: int, expected: str):
+    """Return ``expected`` only when an array is exactly sharded that way.
 
     Inside jax.jit the concrete Array sharding may be carried by the tracer
     aval instead of x.sharding; shard_map still validates against that aval
-    sharding.  Returns ``expected`` when the spec matches, ``None`` otherwise.
+    sharding. This helper intentionally does not infer or simplify composite
+    axes; it only mirrors exact per-dimension axis matches for shard_map specs.
     """
     for sharding in (
         getattr(x, "sharding", None),

--- a/python/sgl_jax/srt/utils/jax_utils.py
+++ b/python/sgl_jax/srt/utils/jax_utils.py
@@ -207,6 +207,23 @@ def device_array(*data, sharding=None, **kwargs) -> jax.Array:
     return jax.tree.map(_to_device, *data)
 
 
+def effective_axis(x, dim, expected):
+    """Read the actual NamedSharding spec from an array to derive shard_map in_specs.
+
+    Inside jax.jit the concrete Array sharding may be carried by the tracer
+    aval instead of x.sharding; shard_map still validates against that aval
+    sharding.  Returns ``expected`` when the spec matches, ``None`` otherwise.
+    """
+    for sharding in (
+        getattr(x, "sharding", None),
+        getattr(getattr(x, "aval", None), "sharding", None),
+    ):
+        spec = getattr(sharding, "spec", None)
+        if spec is not None and len(spec) > dim:
+            return expected if spec[dim] == expected else None
+    return None
+
+
 _IS_TPU_RUNTIME_CACHED: bool | None = None
 
 

--- a/python/sgl_jax/srt/utils/mesh_utils.py
+++ b/python/sgl_jax/srt/utils/mesh_utils.py
@@ -33,6 +33,14 @@ def create_device_mesh(
         devices_dict = {device.id: device for device in devices}
         devices = [devices_dict.get(i) for i in list(set(device_indexes))]
     ici_parallelism = fill_unspecified_parallelism(ici_parallelism, len(devices))
+    mesh_device_count = int(np.prod(ici_parallelism))
+    if num_slices == 1 and mesh_device_count < len(devices):
+        devices = devices[:mesh_device_count]
+    elif num_slices == 1 and mesh_device_count > len(devices):
+        raise RuntimeError(
+            f"Requested mesh shape {tuple(ici_parallelism)} needs {mesh_device_count} devices, "
+            f"but only {len(devices)} are available."
+        )
     if num_slices > 1:
         dcn_parallelism = fill_unspecified_parallelism(dcn_parallelism, num_slices)
         devices_array = mesh_utils.create_hybrid_device_mesh(

--- a/python/sgl_jax/test/kernels/fused_moe_v1_test.py
+++ b/python/sgl_jax/test/kernels/fused_moe_v1_test.py
@@ -10,7 +10,6 @@ import jax.numpy as jnp
 import numpy as np
 from absl.testing import absltest, parameterized
 from jax import lax
-from jax._src import test_util as jtu
 from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.kernels.fused_moe.v1.kernel import (
@@ -32,6 +31,14 @@ def cdiv(a, b):
 
 def align_to(x, a):
     return cdiv(x, a) * a
+
+
+def is_tpu_at_least(version):
+    if not jax.devices():
+        return False
+    device_kind = jax.devices()[0].device_kind
+    match = re.search(r"TPU\s*v?(\d+)", device_kind)
+    return match is not None and int(match.group(1)) >= version
 
 
 def gen_moe_inputs(
@@ -133,8 +140,7 @@ def sub_channel_quantize(x, quant_dtype, wsz=256):
     return jnp.concat(w_lst, axis=-2), jnp.expand_dims(jnp.concat(scale_lst, axis=-2), axis=-2)
 
 
-@jtu.with_config(jax_numpy_dtype_promotion="standard")
-class MoEKernelTest(jtu.JaxTestCase):
+class MoEKernelTest(parameterized.TestCase):
 
     def setUp(self):
         super().setUp()
@@ -316,9 +322,12 @@ class MoEKernelTest(jtu.JaxTestCase):
             x = lax.all_gather(x, axis_name="data", axis=0, tiled=True)
             return x
 
+        expected = jax.reshard(
+            expected, jax.sharding.NamedSharding(self.mesh, P(("data", "tensor"), None))
+        )
         actual_host = np.asarray(jax.device_get(_replicate_tokens(actual)))
         expected_host = np.asarray(jax.device_get(_replicate_tokens(expected)))
-        self.assertAllClose(actual_host, expected_host, atol=atol, rtol=rtol)
+        np.testing.assert_allclose(actual_host, expected_host, atol=atol, rtol=rtol)
 
     @parameterized.product(
         renormalize_topk_logits=[True, False],
@@ -498,7 +507,7 @@ class MoEKernelTest(jtu.JaxTestCase):
         w_dtype=[jnp.int8, jnp.float8_e4m3fn, jnp.float8_e5m2, jnp.float4_e2m1fn],
     )
     def test_sub_channel_quantization(self, w_dtype):
-        if w_dtype == jnp.float4_e2m1fn and not jtu.is_device_tpu_at_least(version=7):
+        if w_dtype == jnp.float4_e2m1fn and not is_tpu_at_least(version=7):
             self.skipTest("float4 requires TPUv7+")
         dtype = jnp.bfloat16
         top_k = 8
@@ -539,7 +548,7 @@ class MoEKernelTest(jtu.JaxTestCase):
         With bd1c=1024 and quant_block_k=256, n_sg = 1024/2/256 = 2.
         With bfc=1024 and quant_block_k=256, n_sg2 = 1024/256 = 4.
         """
-        if w_dtype == jnp.float4_e2m1fn and not jtu.is_device_tpu_at_least(version=7):
+        if w_dtype == jnp.float4_e2m1fn and not is_tpu_at_least(version=7):
             self.skipTest("float4 requires TPUv7+")
         dtype = jnp.bfloat16
         top_k = 8
@@ -578,7 +587,7 @@ class MoEKernelTest(jtu.JaxTestCase):
         With bd1c=512 and quant_block_k=128, n_sg = 512/2/128 = 2.
         With bfc=256 and quant_block_k=128, n_sg2 = 256/128 = 2.
         """
-        if w_dtype == jnp.float4_e2m1fn and not jtu.is_device_tpu_at_least(version=7):
+        if w_dtype == jnp.float4_e2m1fn and not is_tpu_at_least(version=7):
             self.skipTest("float4 requires TPUv7+")
         dtype = jnp.bfloat16
         top_k = 8
@@ -617,7 +626,7 @@ class MoEKernelTest(jtu.JaxTestCase):
         With bd1c=1024 and quant_block_k=128, n_sg = 1024/2/128 = 4.
         With bfc=1024 and quant_block_k=128, n_sg2 = 1024/128 = 8.
         """
-        if w_dtype == jnp.float4_e2m1fn and not jtu.is_device_tpu_at_least(version=7):
+        if w_dtype == jnp.float4_e2m1fn and not is_tpu_at_least(version=7):
             self.skipTest("float4 requires TPUv7+")
         dtype = jnp.bfloat16
         top_k = 8
@@ -651,7 +660,7 @@ class MoEKernelTest(jtu.JaxTestCase):
         w_dtype=[jnp.int8, jnp.float8_e4m3fn, jnp.float8_e5m2, jnp.float4_e2m1fn],
     )
     def test_shared_expert_quantized(self, w_dtype):
-        if w_dtype == jnp.float4_e2m1fn and not jtu.is_device_tpu_at_least(version=7):
+        if w_dtype == jnp.float4_e2m1fn and not is_tpu_at_least(version=7):
             self.skipTest("float4 requires TPUv7+")
         dtype = jnp.bfloat16
         top_k = 8
@@ -719,7 +728,7 @@ class MoEKernelTest(jtu.JaxTestCase):
         except Exception as e:
             self.skipTest(f"safetensors is required for this test: {e}")
 
-        if not jtu.is_device_tpu_at_least(version=7):
+        if not is_tpu_at_least(version=7):
             self.skipTest("Expect TPUv7+ for fused MoE kernel.")
 
         layer_idx = int(os.getenv("SGLANG_TEST_LAYER_IDX", "0"))
@@ -860,7 +869,7 @@ class MoEKernelTest(jtu.JaxTestCase):
         )
 
         # Bring both to host for comparison (single-host smoke).
-        self.assertAllClose(
+        np.testing.assert_allclose(
             np.asarray(jax.device_get(actual)),
             np.asarray(jax.device_get(expected)),
             atol=3e-1,
@@ -897,4 +906,4 @@ class MoEKernelTest(jtu.JaxTestCase):
 
 
 if __name__ == "__main__":
-    absltest.main(testLoader=jtu.JaxTestLoader())
+    absltest.main()

--- a/python/sgl_jax/test/mem_cache/test_kv_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_kv_cache.py
@@ -2,18 +2,12 @@ import unittest
 
 import jax
 import jax.numpy as jnp
-from jax.sharding import NamedSharding
-from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.kernels.ragged_paged_attention.util import align_to, get_dtype_packing
 from sgl_jax.srt.mem_cache.memory_pool import merge_kv
 from sgl_jax.srt.mem_cache.memory_pool import (
     update_fused_kv_cache_vectorized as update_fused_kv_cache,
 )
-from sgl_jax.srt.utils.mesh_utils import create_device_mesh
-
-mesh = create_device_mesh(ici_parallelism=[1, -1], dcn_parallelism=[1, 1])
-jax.sharding.set_mesh(mesh)
 
 
 def _make_fused_cache(cache_size, num_heads, head_dim, page_size, dtype=jnp.bfloat16):
@@ -22,8 +16,7 @@ def _make_fused_cache(cache_size, num_heads, head_dim, page_size, dtype=jnp.bflo
     head_dim_aligned = align_to(head_dim, 128)
     num_pages = (cache_size + page_size - 1) // page_size + 1  # +1 sentinel page
     shape = (num_pages, page_size, num_heads * 2 // packing, packing, head_dim_aligned)
-    cache = jnp.zeros(shape, dtype=dtype)
-    return jax.device_put(cache, P(None, None, "tensor", None, None))
+    return jnp.zeros(shape, dtype=dtype)
 
 
 def _extract_kv_from_fused(fused_cache):
@@ -33,14 +26,9 @@ def _extract_kv_from_fused(fused_cache):
     """
     num_pages, page_size, heads_x2_per_pack, packing, head_dim = fused_cache.shape
     total_tokens = num_pages * page_size
-    flat = jax.lax.reshape(
-        fused_cache,
-        (total_tokens, heads_x2_per_pack * packing, head_dim),
-        out_sharding=P(None, "tensor", None),
-    )
-    kv_sharding = NamedSharding(mesh, P(None, "tensor", None))
-    k = flat.at[:, ::2, :].get(out_sharding=kv_sharding)
-    v = flat.at[:, 1::2, :].get(out_sharding=kv_sharding)
+    flat = fused_cache.reshape(total_tokens, heads_x2_per_pack * packing, head_dim)
+    k = flat[:, ::2, :]
+    v = flat[:, 1::2, :]
     return k, v
 
 
@@ -97,12 +85,9 @@ class TestKVCache(unittest.TestCase):
 
         # Merge k/v into 5D fused format
         fused_kv = merge_kv(k, v)
-        fused_kv = jax.device_put(fused_kv, P(None, None, "tensor", None, None))
 
         # Create 5D fused cache
         kv_cache = _make_fused_cache(cache_size, self.num_heads, self.head_dim, page_size)
-
-        loc = jax.device_put(loc, P(None))
 
         return fused_kv, loc, kv_cache, k, v
 
@@ -208,7 +193,6 @@ class TestKVCache(unittest.TestCase):
 
         cache_size = total_tokens + 50
         fused_kv = merge_kv(k, v)
-        fused_kv = jax.device_put(fused_kv, P(None, None, "tensor", None, None))
 
         for page_size in [1, 2, 4, 8]:
             with self.subTest(page_size=page_size):

--- a/python/sgl_jax/test/test_bailing_moe_linear.py
+++ b/python/sgl_jax/test/test_bailing_moe_linear.py
@@ -1,10 +1,13 @@
 import jax
 import jax.numpy as jnp
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.configs.bailing_hybrid import (
     BailingHybridConfig,
     get_bailing_hybrid_config,
 )
+from sgl_jax.srt.layers.attention.linear.lightning_backend import _head_axis
 from sgl_jax.srt.model_loader.arch import get_model_architecture
 from sgl_jax.srt.models.bailing_moe_linear import (
     BailingMoEGQAAttention,
@@ -117,6 +120,23 @@ def test_decoder_layer_selects_gqa_fallback_for_non_mla_full_attention():
         full_layer = BailingMoELinearDecoderLayer(cfg, mesh=mesh, layer_id=1, dtype=jnp.float32)
 
     assert isinstance(full_layer.self_attn, BailingMoEGQAAttention)
+
+
+def test_linear_attention_head_axis_only_shards_divisible_heads():
+    mesh = create_device_mesh(ici_parallelism=[1, -1], dcn_parallelism=[1, 1])
+
+    assert _head_axis(mesh, mesh.shape["tensor"] * 2) == "tensor"
+    assert _head_axis(mesh, 2) is None
+
+    qkv = jnp.ones((3, 48), dtype=jnp.float32)
+    qkv = jax.lax.reshape(
+        qkv,
+        (3, 3, 2, 8),
+        out_sharding=NamedSharding(mesh, P("data", None, _head_axis(mesh, 2), None)),
+    )
+
+    assert qkv.shape == (3, 3, 2, 8)
+    assert qkv.sharding.spec == P("data", None, None, None)
 
 
 def test_weight_mapping_contains_linear_mla_dense_and_shared_mlp_keys():

--- a/python/sgl_jax/test/test_flashattention.py
+++ b/python/sgl_jax/test/test_flashattention.py
@@ -417,11 +417,22 @@ class TestAttention(CustomTestCase):
         # write prefix tokens (k, v are unsharded for safe slicing)
         extend_k, extend_v = write_prefix_tokens_for_kv(forward_batch, token_to_kv_pool, lens, k, v)
 
-        # Shard q/extend_k/extend_v with P("data", "tensor") to match production in_specs
-        dp_sharding = NamedSharding(mesh, P("data", "tensor"))
-        q_shard = jax.device_put(q, dp_sharding)
-        extend_k = jax.device_put(extend_k, dp_sharding)
-        extend_v = jax.device_put(extend_v, dp_sharding)
+        # Shard q/extend_k/extend_v with P("data", "tensor") to match production in_specs.
+        # Fall back to P("data") when head count is not divisible by tensor axis size,
+        # or when local q heads would not be divisible by local kv heads (GQA constraint).
+        axis_size = mesh.shape.get("tensor", 1)
+        kv_tensor = "tensor" if num_kv_heads % axis_size == 0 else None
+        if num_heads % axis_size == 0:
+            local_q = num_heads // axis_size
+            local_kv = num_kv_heads // axis_size if kv_tensor is not None else num_kv_heads
+            q_tensor = "tensor" if local_q % local_kv == 0 else None
+        else:
+            q_tensor = None
+        q_sharding = NamedSharding(mesh, P("data", q_tensor, None))
+        kv_sharding = NamedSharding(mesh, P("data", kv_tensor, None))
+        q_shard = jax.device_put(q, q_sharding)
+        extend_k = jax.device_put(extend_k, kv_sharding)
+        extend_v = jax.device_put(extend_v, kv_sharding)
 
         # JAX attention
         attn = RadixAttention(

--- a/test/srt/lora/misc/hf_runner.py
+++ b/test/srt/lora/misc/hf_runner.py
@@ -1,11 +1,9 @@
 # misc file, only used for dump hf_logprobs
 # adapted from sglang python/sglang/test/runners.py
 # Copyright 2023-2024 SGLang Team
-import json
 import multiprocessing as mp
-import os
 from dataclasses import dataclass
-from typing import Any, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -418,7 +416,7 @@ class HFRunner:
 
             if lora_paths is not None and lora_paths[i] is not None:
                 # Unload the LoRA adapter if it is used
-                model.unload()
+                base_model = model.unload()
 
         return ModelOutput(
             output_strs=output_strs,

--- a/test/srt/lora/test_align_lora_accuracy.py
+++ b/test/srt/lora/test_align_lora_accuracy.py
@@ -37,20 +37,19 @@ class TestAlignLoRAAccuracy(CustomTestCase):
     def setUpClass(cls):
         cls.model_path = QWEN3_4B
         cls.lora_target_modules = ["all"]
-        import os
 
         os.environ["JAX_COMPILATION_CACHE_DIR"] = "/tmp/jit_cache"
         cls.single_prompt_prefill_logits_cpu_dump_filename = (
-            f"./lora_data/sglangjax/single_prompt_prefill_logits_cpu.txt"
+            "./lora_data/sglangjax/single_prompt_prefill_logits_cpu.txt"
         )
         cls.single_prompt_decode_logits_cpu_dump_filename = (
-            f"./lora_data/sglangjax/single_prompt_decode_logits_cpu.txt"
+            "./lora_data/sglangjax/single_prompt_decode_logits_cpu.txt"
         )
         cls.multi_prompts_prefill_logits_tpu_dump_filename = (
-            f"./lora_data/sglangjax/multi_prompts_prefill_logits_tpu.txt"
+            "./lora_data/sglangjax/multi_prompts_prefill_logits_tpu.txt"
         )
         cls.multi_prompts_decode_logits_tpu_dump_filename = (
-            f"./lora_data/sglangjax/multi_prompts_decode_logits_tpu.txt"
+            "./lora_data/sglangjax/multi_prompts_decode_logits_tpu.txt"
         )
 
     def get_sglang_jax_last_layer_logits_hidden_states(
@@ -75,7 +74,7 @@ class TestAlignLoRAAccuracy(CustomTestCase):
         if device == "cpu":
             os.environ["JAX_PLATFORMS"] = "cpu"
         else:
-            del os.environ["JAX_PLATFORMS"]
+            os.environ.pop("JAX_PLATFORMS", None)
         engine = Engine(
             model_path=self.model_path,
             trust_remote_code=True,
@@ -166,7 +165,7 @@ class TestAlignLoRAAccuracy(CustomTestCase):
             prefill_logits, decode_logits = None, None
 
         if return_hidden_states:
-            raise NotImplemented
+            raise NotImplementedError
 
         engine.shutdown()
 
@@ -212,7 +211,8 @@ python3 dump_hf_lora_output.py --model Qwen/Qwen3-4B \
             )
         except BaseException as e:
             print(
-                f"{hf_lora_prefill_logits_file} or {hf_lora_decode_logits_file} does not exist, please generate them firstly with following commands: \n{hf_generate_commands}",
+                f"{hf_lora_prefill_logits_file} or {hf_lora_decode_logits_file} does not exist, "
+                f"please generate them firstly with following commands: \n{hf_generate_commands}\n{e}",
                 flush=True,
             )
             raise
@@ -296,7 +296,8 @@ python3 dump_hf_lora_output.py --model Qwen/Qwen3-4B \
             assert os.path.exists(hf_lora_decode_logits_file)
         except BaseException as e:
             print(
-                f"{hf_lora_decode_logits_file} does not exist, please generate it firstly with following commands: \n{hf_generate_commands}",
+                f"{hf_lora_decode_logits_file} does not exist, "
+                f"please generate it firstly with following commands: \n{hf_generate_commands}\n{e}",
                 flush=True,
             )
             raise
@@ -377,7 +378,8 @@ python3 dump_hf_lora_output.py --model Qwen/Qwen3-4B \
             assert os.path.exists(hf_lora_decode_logits_file)
         except BaseException as e:
             print(
-                f"{hf_lora_decode_logits_file} does not exist, please generate it firstly with following commands: \n{hf_generate_commands}",
+                f"{hf_lora_decode_logits_file} does not exist, "
+                f"please generate it firstly with following commands: \n{hf_generate_commands}\n{e}",
                 flush=True,
             )
             raise

--- a/test/srt/lora/test_bgmv_backend.py
+++ b/test/srt/lora/test_bgmv_backend.py
@@ -15,6 +15,7 @@ import numpy as np
 from jax.sharding import NamedSharding, PartitionSpec
 
 from sgl_jax.srt.lora.backend.bgmv_backend import BgmvLoRABackend
+from sgl_jax.srt.lora.layers import LoRALinear
 from sgl_jax.srt.lora.utils import (
     get_lora_a_output_sharding,
     get_lora_b_output_sharding,
@@ -31,6 +32,16 @@ def safe_matmul(a: jax.Array, b: jax.Array) -> jax.Array:
     """Matrix multiplication with mixed precision handling for bfloat16."""
     result = jnp.matmul(a.astype(jnp.float32), b.astype(jnp.float32))
     return result.astype(a.dtype)
+
+
+class FakeLoRABackend:
+    def run_lora_a_gemm(self, x, weights, sharding, scalings, token_indices):
+        del weights, sharding, scalings, token_indices
+        return x
+
+    def run_lora_b_gemm(self, x, weights, base_output, sharding, token_indices):
+        del x, weights, sharding, token_indices
+        return base_output + 100
 
 
 class BatchComposition(Enum):
@@ -263,6 +274,31 @@ class TestBgmvLoRABackend(CustomTestCase):
         self.mesh = create_device_mesh(
             ici_parallelism=[1, 1],
             dcn_parallelism=[1, 1],
+        )
+
+    def test_lora_linear_rank_zero_rows_return_base_output(self):
+        layer = LoRALinear(base_layer=None, lora_backend=FakeLoRABackend())
+        layer.A_buffer = jnp.empty((0,), dtype=jnp.float32)
+        layer.B_buffer = jnp.empty((0,), dtype=jnp.float32)
+        layer.lora_a_output_sharding = None
+        layer.lora_b_output_sharding = None
+
+        base_output = jnp.arange(12, dtype=jnp.float32).reshape(3, 4)
+        x = jnp.ones((3, 4), dtype=jnp.float32)
+        ranks = jnp.array([8, 0, 8], dtype=jnp.int32)
+
+        output = layer.apply_lora(
+            base_output=base_output,
+            x=x,
+            scalings=jnp.ones((3,), dtype=jnp.float32),
+            token_indices=jnp.array([1, 0, 1], dtype=jnp.int32),
+            ranks=ranks,
+        )
+
+        np.testing.assert_array_equal(np.asarray(output[1]), np.asarray(base_output[1]))
+        lora_rows = jnp.array([0, 2], dtype=jnp.int32)
+        np.testing.assert_array_equal(
+            np.asarray(output[lora_rows]), np.asarray(base_output[lora_rows] + 100)
         )
 
     def get_lora_batch_info_on_device(self, batch: ModelWorkerBatch):

--- a/test/srt/lora/test_bgmv_backend.py
+++ b/test/srt/lora/test_bgmv_backend.py
@@ -15,8 +15,9 @@ import numpy as np
 from jax.sharding import NamedSharding, PartitionSpec
 
 from sgl_jax.srt.lora.backend.bgmv_backend import BgmvLoRABackend
-from sgl_jax.srt.lora.layers import LoRALinear
+from sgl_jax.srt.lora.layers import LoRALinear, _restore_base_output_for_rank_zero
 from sgl_jax.srt.lora.utils import (
+    LoRABatchPlan,
     get_lora_a_output_sharding,
     get_lora_b_output_sharding,
 )
@@ -44,6 +45,11 @@ class FakeLoRABackend:
         return base_output + 100
 
 
+class FakeBaseLayer:
+    def __call__(self, x):
+        return x, None
+
+
 class BatchComposition(Enum):
     UNIFORM = "uniform"
     MIXED = "mixed"
@@ -54,6 +60,57 @@ class BatchComposition(Enum):
 class BatchMode(Enum):
     PREFILL = "prefill"
     DECODE = "decode"
+
+
+class TestRankZeroOutputRestore(unittest.TestCase):
+    def test_supports_missing_ranks_and_broadcast(self):
+        base_output = jnp.arange(24, dtype=jnp.float32).reshape(2, 3, 4)
+        lora_output = base_output + 100
+
+        unchanged = _restore_base_output_for_rank_zero(base_output, lora_output, None)
+        np.testing.assert_array_equal(np.asarray(unchanged), np.asarray(lora_output))
+
+        ranks = jnp.array([[8, 0, 8], [0, 8, 0]], dtype=jnp.int32)
+        output = _restore_base_output_for_rank_zero(base_output, lora_output, ranks)
+
+        expected = np.array(lora_output)
+        expected[0, 1] = np.asarray(base_output[0, 1])
+        expected[1, 0] = np.asarray(base_output[1, 0])
+        expected[1, 2] = np.asarray(base_output[1, 2])
+        np.testing.assert_array_equal(np.asarray(output), expected)
+
+    def test_supports_1d_ranks_for_2d_output(self):
+        base_output = jnp.arange(12, dtype=jnp.float32).reshape(3, 4)
+        lora_output = base_output + 100
+        ranks = jnp.array([8, 0, 16], dtype=jnp.int32)
+
+        output = _restore_base_output_for_rank_zero(base_output, lora_output, ranks)
+
+        expected = np.array(lora_output)
+        expected[1] = np.asarray(base_output[1])
+        np.testing.assert_array_equal(np.asarray(output), expected)
+
+    def test_supports_all_zero_and_all_nonzero_ranks(self):
+        base_output = jnp.arange(12, dtype=jnp.float32).reshape(3, 4)
+        lora_output = base_output + 100
+
+        all_zero = _restore_base_output_for_rank_zero(
+            base_output, lora_output, jnp.zeros((3,), dtype=jnp.int32)
+        )
+        all_nonzero = _restore_base_output_for_rank_zero(
+            base_output, lora_output, jnp.ones((3,), dtype=jnp.int32)
+        )
+
+        np.testing.assert_array_equal(np.asarray(all_zero), np.asarray(base_output))
+        np.testing.assert_array_equal(np.asarray(all_nonzero), np.asarray(lora_output))
+
+    def test_rejects_unbroadcastable_rank_shape(self):
+        base_output = jnp.arange(12, dtype=jnp.float32).reshape(3, 4)
+        lora_output = base_output + 100
+        ranks = jnp.ones((1, 1, 1), dtype=jnp.int32)
+
+        with self.assertRaisesRegex(ValueError, "broadcastable"):
+            _restore_base_output_for_rank_zero(base_output, lora_output, ranks)
 
 
 def reference_lora_a_gemm(
@@ -301,6 +358,16 @@ class TestBgmvLoRABackend(CustomTestCase):
             np.asarray(output[lora_rows]), np.asarray(base_output[lora_rows] + 100)
         )
 
+    def test_lora_linear_requires_batch_context(self):
+        layer = LoRALinear(base_layer=FakeBaseLayer(), lora_backend=FakeLoRABackend())
+        layer.A_buffer = jnp.empty((0,), dtype=jnp.float32)
+        layer.B_buffer = jnp.empty((0,), dtype=jnp.float32)
+        layer.lora_a_output_sharding = None
+        layer.lora_b_output_sharding = None
+
+        with self.assertRaisesRegex(RuntimeError, "LoraBatchContext"):
+            layer(jnp.ones((2, self.input_dim), dtype=jnp.float32))
+
     def get_lora_batch_info_on_device(self, batch: ModelWorkerBatch):
         (
             lora_scalings,
@@ -401,7 +468,11 @@ class TestBgmvLoRABackend(CustomTestCase):
             return_output_logprob_only=False,
             top_logprobs_nums=1,
             token_ids_logprobs=None,
-            extend_seq_lens=np.array(seq_lengths, dtype=np.int32),
+            extend_seq_lens=(
+                np.array(seq_lengths, dtype=np.int32)
+                if forward_mode == ForwardMode.EXTEND
+                else None
+            ),
             extend_prefix_lens=None,
             extend_logprob_start_lens=None,
             extend_input_logprob_token_ids=None,
@@ -477,21 +548,16 @@ class TestBgmvLoRABackend(CustomTestCase):
         scalings = [0] * len(self.lora_configs)
         lora_name_to_idx = {}
 
-        # no_lora_count=1
-
-        for i, lora_name in enumerate(unique_loras):
-            # if lora_name == "_NO_LORA_":
-            lora_name_to_idx[lora_name] = i
-            # else:
-            #    lora_name_to_idx[lora_name] = no_lora_count
-            #    no_lora_count+=1
+        for slot, lora_name in enumerate(unique_loras):
+            lora_name_to_idx[lora_name] = slot
+            rank = self.lora_configs[lora_name][0]
+            lora_ranks[slot] = rank
+            scalings[slot] = 0.0 if rank == 0 else 0.5 + 0.25 * slot
 
         for i, lora_name in enumerate(normalized_assignments):
             weight_indices[i] = lora_name_to_idx[lora_name]
-            lora_ranks[weight_indices[i]] = self.lora_configs[lora_name][0]
-            scalings[weight_indices[i]] = 1.0
 
-        scalings_seq = [1.0 for _ in normalized_assignments]
+        scalings_seq = [scalings[weight_indices[i]] for i in range(len(normalized_assignments))]
 
         weights = {}
         for lora_name in unique_loras:
@@ -537,7 +603,9 @@ class TestBgmvLoRABackend(CustomTestCase):
 
                 max_rank = max(self.lora_configs[name][0] for name in weights.keys())
                 backend = BgmvLoRABackend(max_loras_per_batch=len(weights), max_lora_rank=max_rank)
-                backend.prepare_lora_batch(model_worker_batch, weight_indices, lora_ranks, scalings)
+                backend.prepare_lora_batch(
+                    model_worker_batch, LoRABatchPlan(weight_indices, lora_ranks, scalings)
+                )
                 lora_scalings_device, lora_token_indces_device = self.get_lora_batch_info_on_device(
                     model_worker_batch
                 )
@@ -648,7 +716,9 @@ class TestBgmvLoRABackend(CustomTestCase):
 
                 max_rank = max(self.lora_configs[name][0] for name in weights.keys())
                 backend = BgmvLoRABackend(max_loras_per_batch=len(weights), max_lora_rank=max_rank)
-                backend.prepare_lora_batch(model_worker_batch, weight_indices, lora_ranks, scalings)
+                backend.prepare_lora_batch(
+                    model_worker_batch, LoRABatchPlan(weight_indices, lora_ranks, scalings)
+                )
                 lora_scalings_device, lora_token_indces_device = self.get_lora_batch_info_on_device(
                     model_worker_batch
                 )
@@ -728,7 +798,9 @@ class TestBgmvLoRABackend(CustomTestCase):
 
                 max_rank = max(self.lora_configs[name][0] for name in weights.keys())
                 backend = BgmvLoRABackend(max_loras_per_batch=len(weights), max_lora_rank=max_rank)
-                backend.prepare_lora_batch(model_worker_batch, weight_indices, lora_ranks, scalings)
+                backend.prepare_lora_batch(
+                    model_worker_batch, LoRABatchPlan(weight_indices, lora_ranks, scalings)
+                )
                 lora_scalings_device, lora_token_indces_device = self.get_lora_batch_info_on_device(
                     model_worker_batch
                 )
@@ -809,7 +881,9 @@ class TestBgmvLoRABackend(CustomTestCase):
 
                 max_rank = max(self.lora_configs[name][0] for name in weights.keys())
                 backend = BgmvLoRABackend(max_loras_per_batch=len(weights), max_lora_rank=max_rank)
-                backend.prepare_lora_batch(model_worker_batch, weight_indices, lora_ranks, scalings)
+                backend.prepare_lora_batch(
+                    model_worker_batch, LoRABatchPlan(weight_indices, lora_ranks, scalings)
+                )
                 lora_scalings_device, lora_token_indces_device = self.get_lora_batch_info_on_device(
                     model_worker_batch
                 )
@@ -862,6 +936,162 @@ class TestBgmvLoRABackend(CustomTestCase):
                     err_msg=f"QKV missing k_proj failed for {composition.value}, {mode.value}, batch_size={batch_size}",
                     strict=True,
                 )
+
+    def test_lora_a_gemm_applies_non_unit_scaling(self):
+        backend = BgmvLoRABackend(max_loras_per_batch=2, max_lora_rank=2)
+        x = jnp.array(
+            [
+                [1.0, 2.0, 3.0, 4.0],
+                [2.0, 0.0, 1.0, 3.0],
+                [0.0, 1.0, 0.0, 2.0],
+            ],
+            dtype=jnp.float32,
+        )
+        weights = jnp.array(
+            [
+                [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+                [[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]],
+            ],
+            dtype=jnp.float32,
+        )
+        token_indices = jnp.array([0, 1, 1], dtype=jnp.int32)
+        scalings = jnp.array([0.5, 2.0, 3.0], dtype=jnp.float32)
+
+        output = backend.run_lora_a_gemm(
+            x=x,
+            weights=weights,
+            sharding=NamedSharding(self.mesh, PartitionSpec()),
+            scalings=scalings,
+            token_indices=token_indices,
+        )
+
+        expected = np.array(
+            [
+                [0.5, 1.0],
+                [2.0, 6.0],
+                [0.0, 6.0],
+            ],
+            dtype=np.float32,
+        )
+        np.testing.assert_allclose(np.asarray(output), expected, rtol=1e-5, atol=1e-5)
+
+    def test_prepare_lora_batch_rejects_extend_token_overflow(self):
+        backend = BgmvLoRABackend(max_loras_per_batch=2, max_lora_rank=8)
+        model_worker_batch = self.create_model_worker_batch(
+            np.zeros((4, self.input_dim), dtype=np.float32),
+            [2, 2],
+            BatchMode.PREFILL,
+        )
+        model_worker_batch.input_ids = np.arange(3, dtype=np.int32)
+
+        with self.assertRaisesRegex(ValueError, "exceeds target token length"):
+            backend.prepare_lora_batch(
+                model_worker_batch,
+                LoRABatchPlan(
+                    weight_indices=[0, 1],
+                    ranks_by_slot=[0, 8],
+                    scalings_by_slot=[0.0, 1.0],
+                ),
+            )
+
+    def test_prepare_lora_batch_rejects_negative_extend_length(self):
+        backend = BgmvLoRABackend(max_loras_per_batch=2, max_lora_rank=8)
+        model_worker_batch = self.create_model_worker_batch(
+            np.zeros((4, self.input_dim), dtype=np.float32),
+            [2, 2],
+            BatchMode.PREFILL,
+        )
+        model_worker_batch.extend_seq_lens = np.array([2, -1], dtype=np.int32)
+
+        with self.assertRaisesRegex(ValueError, "negative extend length"):
+            backend.prepare_lora_batch(
+                model_worker_batch,
+                LoRABatchPlan(
+                    weight_indices=[0, 1],
+                    ranks_by_slot=[0, 8],
+                    scalings_by_slot=[0.0, 1.5],
+                ),
+            )
+
+    def test_prepare_lora_batch_pads_extend_metadata(self):
+        backend = BgmvLoRABackend(max_loras_per_batch=2, max_lora_rank=8)
+        model_worker_batch = self.create_model_worker_batch(
+            np.zeros((5, self.input_dim), dtype=np.float32),
+            [1, 2],
+            BatchMode.PREFILL,
+        )
+        model_worker_batch.input_ids = np.arange(5, dtype=np.int32)
+
+        backend.prepare_lora_batch(
+            model_worker_batch,
+            LoRABatchPlan(
+                weight_indices=[0, 1],
+                ranks_by_slot=[0, 8],
+                scalings_by_slot=[0.0, 1.5],
+            ),
+        )
+
+        np.testing.assert_array_equal(
+            model_worker_batch.lora_scalings,
+            np.array([0.0, 1.5, 1.5, 0.0, 0.0], dtype=np.float32),
+        )
+        np.testing.assert_array_equal(
+            model_worker_batch.lora_token_indices,
+            np.array([0, 1, 1, 0, 0], dtype=np.int32),
+        )
+        np.testing.assert_array_equal(
+            model_worker_batch.lora_ranks,
+            np.array([0, 8, 8, 0, 0], dtype=np.int32),
+        )
+
+    def test_prepare_lora_batch_decode_metadata(self):
+        backend = BgmvLoRABackend(max_loras_per_batch=3, max_lora_rank=16)
+        model_worker_batch = self.create_model_worker_batch(
+            np.zeros((3, self.input_dim), dtype=np.float32),
+            [1, 1, 1],
+            BatchMode.DECODE,
+        )
+
+        backend.prepare_lora_batch(
+            model_worker_batch,
+            LoRABatchPlan(
+                weight_indices=[0, 2, 1],
+                ranks_by_slot=[0, 8, 16],
+                scalings_by_slot=[0.0, 0.5, 1.25],
+            ),
+        )
+
+        np.testing.assert_array_equal(
+            model_worker_batch.lora_scalings,
+            np.array([0.0, 1.25, 0.5], dtype=np.float32),
+        )
+        np.testing.assert_array_equal(
+            model_worker_batch.lora_token_indices,
+            np.array([0, 2, 1], dtype=np.int32),
+        )
+        np.testing.assert_array_equal(
+            model_worker_batch.lora_ranks,
+            np.array([0, 16, 8], dtype=np.int32),
+        )
+
+    def test_prepare_lora_batch_rejects_decode_metadata_length_mismatch(self):
+        backend = BgmvLoRABackend(max_loras_per_batch=2, max_lora_rank=8)
+        model_worker_batch = self.create_model_worker_batch(
+            np.zeros((2, self.input_dim), dtype=np.float32),
+            [1, 1],
+            BatchMode.DECODE,
+        )
+        model_worker_batch.input_ids = np.arange(3, dtype=np.int32)
+
+        with self.assertRaisesRegex(ValueError, "metadata length"):
+            backend.prepare_lora_batch(
+                model_worker_batch,
+                LoRABatchPlan(
+                    weight_indices=[0, 1],
+                    ranks_by_slot=[0, 8],
+                    scalings_by_slot=[0.0, 1.0],
+                ),
+            )
 
 
 if __name__ == "__main__":

--- a/test/srt/lora/test_lora_manager_optimization.py
+++ b/test/srt/lora/test_lora_manager_optimization.py
@@ -1,11 +1,13 @@
+import asyncio
 import unittest
 from unittest.mock import MagicMock, patch
 
-import jax
 import jax.numpy as jnp
 
+from sgl_jax.srt.lora.constants import BASE_LORA_ID, BASE_LORA_SLOT
 from sgl_jax.srt.lora.lora_manager import LoRAManager
 from sgl_jax.srt.lora.lora_memory_pool import EMPTY_SLOT, LoRAMemoryPool
+from sgl_jax.srt.lora.lora_registry import LoRARef, LoRARegistry
 from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
 
 
@@ -18,8 +20,9 @@ class TestLoRAManagerOptimization(unittest.TestCase):
         # Mock LoRAMemoryPool
         self.pool = MagicMock(spec=LoRAMemoryPool)
         self.pool.uid_to_buffer_id = {}
-        self.pool.buffer_id_to_uid = [EMPTY_SLOT] * 4
+        self.pool.buffer_id_to_uid = [EMPTY_SLOT] * 5
         self.pool.max_loras_per_batch = 4
+        self.pool.num_lora_slots = 5
         self.pool.target_modules = {"q_proj"}
         self.pool.get_buffer_id.side_effect = lambda uid: self.pool.uid_to_buffer_id.get(uid, 0)
 
@@ -55,8 +58,8 @@ class TestLoRAManagerOptimization(unittest.TestCase):
         lora_adapters = {"lora1": MagicMock()}
 
         # Reset state
-        pool.uid_to_buffer_id = {}
-        pool.buffer_id_to_uid = [EMPTY_SLOT] * 4
+        pool.uid_to_buffer_id = {BASE_LORA_ID: BASE_LORA_SLOT, None: BASE_LORA_SLOT}
+        pool.buffer_id_to_uid = [BASE_LORA_ID] + [EMPTY_SLOT] * pool.max_loras_per_batch
 
         has_new = pool.prepare_lora_batch(cur_uids, lora_adapters)
         self.assertTrue(has_new, "Should return True when loading new LoRA")
@@ -74,6 +77,68 @@ class TestLoRAManagerOptimization(unittest.TestCase):
         has_new = pool.prepare_lora_batch(cur_uids, lora_adapters)
         self.assertTrue(has_new, "Should return True when loading at least one new LoRA")
         self.assertIn("lora2", pool.uid_to_buffer_id)
+
+    def test_memory_pool_capacity_excludes_base_slot(self):
+        """max_loras_per_batch counts real adapters; slot 0 is reserved for base."""
+        pool = LoRAMemoryPool(
+            max_loras_per_batch=2,
+            max_lora_rank=8,
+            num_layers=1,
+            target_modules={"q_proj"},
+            mesh=self.mock_mesh,
+            dtype=jnp.float32,
+        )
+        pool.load_lora_weight_to_buffer = MagicMock()
+
+        self.assertEqual(pool.num_lora_slots, 3)
+        has_new = pool.prepare_lora_batch(
+            [None, "lora1", "lora2"],
+            {"lora1": MagicMock(), "lora2": MagicMock()},
+        )
+
+        self.assertTrue(has_new)
+        self.assertEqual(pool.get_buffer_id(None), BASE_LORA_SLOT)
+        self.assertNotEqual(pool.get_buffer_id("lora1"), BASE_LORA_SLOT)
+        self.assertNotEqual(pool.get_buffer_id("lora2"), BASE_LORA_SLOT)
+
+        with self.assertRaises(ValueError):
+            pool.prepare_lora_batch(
+                [None, "lora1", "lora2", "lora3"],
+                {"lora1": MagicMock(), "lora2": MagicMock(), "lora3": MagicMock()},
+            )
+
+    def test_base_lora_id_uses_reserved_pool_slot(self):
+        """Base-model requests use reserved slot 0 without loading adapter weights."""
+        pool = LoRAMemoryPool(
+            max_loras_per_batch=4,
+            max_lora_rank=8,
+            num_layers=1,
+            target_modules={"q_proj"},
+            mesh=self.mock_mesh,
+            dtype=jnp.float32,
+        )
+        pool.load_lora_weight_to_buffer = MagicMock()
+
+        has_new = pool.prepare_lora_batch([None, BASE_LORA_ID], {})
+
+        self.assertFalse(has_new)
+        self.assertEqual(pool.get_buffer_id(None), BASE_LORA_SLOT)
+        self.assertEqual(pool.get_buffer_id(BASE_LORA_ID), BASE_LORA_SLOT)
+        pool.load_lora_weight_to_buffer.assert_not_called()
+
+    def test_registry_treats_base_lora_id_as_sentinel(self):
+        """The registry should not create counters for base-model requests."""
+        lora_ref = LoRARef(lora_name="adapter", lora_path="/tmp/adapter")
+        registry = LoRARegistry([lora_ref])
+
+        acquired_ids = asyncio.run(registry.acquire([None, "adapter"]))
+
+        self.assertEqual(acquired_ids, [BASE_LORA_ID, lora_ref.lora_id])
+        asyncio.run(registry.release(acquired_ids))
+        asyncio.run(registry.release(BASE_LORA_ID))
+
+        with self.assertRaises(ValueError):
+            LoRARef(lora_id=BASE_LORA_ID, lora_name="reserved")
 
     @patch("sgl_jax.srt.lora.lora_manager.LoRAMemoryPool")
     def test_manager_conditional_update(self, MockPoolClass):

--- a/test/srt/lora/test_lora_manager_optimization.py
+++ b/test/srt/lora/test_lora_manager_optimization.py
@@ -8,6 +8,7 @@ from sgl_jax.srt.lora.constants import BASE_LORA_ID, BASE_LORA_SLOT
 from sgl_jax.srt.lora.lora_manager import LoRAManager
 from sgl_jax.srt.lora.lora_memory_pool import EMPTY_SLOT, LoRAMemoryPool
 from sgl_jax.srt.lora.lora_registry import LoRARef, LoRARegistry
+from sgl_jax.srt.lora.utils import LoRABatchPlan
 from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
 
 
@@ -140,6 +141,73 @@ class TestLoRAManagerOptimization(unittest.TestCase):
         with self.assertRaises(ValueError):
             LoRARef(lora_id=BASE_LORA_ID, lora_name="reserved")
 
+    def test_memory_pool_zero_buffer_slot_clears_selected_module_layer(self):
+        pool = LoRAMemoryPool(
+            max_loras_per_batch=1,
+            max_lora_rank=2,
+            num_layers=2,
+            target_modules={"q_proj"},
+            mesh=self.mock_mesh,
+            dtype=jnp.float32,
+            hidden_size=4,
+            num_attention_heads=1,
+        )
+        pool.A_buffer = {"q_proj": [jnp.ones((2, 2, 4), dtype=jnp.float32) for _ in range(2)]}
+        pool.B_buffer = {"q_proj": [jnp.ones((2, 4, 2), dtype=jnp.float32) for _ in range(2)]}
+
+        pool._zero_buffer_slot(buffer_id=1, module_name="q_proj", layer_id=0)
+
+        self.assertTrue(jnp.all(pool.A_buffer["q_proj"][0][1] == 0))
+        self.assertTrue(jnp.all(pool.B_buffer["q_proj"][0][1] == 0))
+        self.assertTrue(jnp.all(pool.A_buffer["q_proj"][1][1] == 1))
+        self.assertTrue(jnp.all(pool.B_buffer["q_proj"][1][1] == 1))
+
+    def test_lora_batch_plan_validates_slot_metadata(self):
+        plan = LoRABatchPlan(
+            weight_indices=[0, 2, 1],
+            ranks_by_slot=[0, 8, 16],
+            scalings_by_slot=[0.0, 0.5, 1.0],
+        )
+
+        self.assertEqual(plan.ranks_for_requests(), (0, 16, 8))
+        self.assertEqual(plan.scalings_for_requests(), (0.0, 1.0, 0.5))
+
+        with self.assertRaises(ValueError):
+            LoRABatchPlan(weight_indices=[3], ranks_by_slot=[0, 8], scalings_by_slot=[0.0, 1.0])
+        with self.assertRaises(ValueError):
+            LoRABatchPlan(weight_indices=[-1], ranks_by_slot=[0, 8], scalings_by_slot=[0.0, 1.0])
+        with self.assertRaises(ValueError):
+            LoRABatchPlan(weight_indices=[1], ranks_by_slot=[0, -8], scalings_by_slot=[0.0, 1.0])
+        with self.assertRaises(ValueError):
+            LoRABatchPlan(weight_indices=[1], ranks_by_slot=[0, 8], scalings_by_slot=[0.0])
+        with self.assertRaises(ValueError):
+            LoRABatchPlan(weight_indices=[1], ranks_by_slot=[0, 8], scalings_by_slot=[0.0, -1.0])
+        with self.assertRaises(ValueError):
+            LoRABatchPlan(
+                weight_indices=[1],
+                ranks_by_slot=[0, 8],
+                scalings_by_slot=[0.0, float("inf")],
+            )
+        with self.assertRaises(ValueError):
+            LoRABatchPlan(
+                weight_indices=[1],
+                ranks_by_slot=[0, 8],
+                scalings_by_slot=[0.0, float("nan")],
+            )
+
+        empty_plan = LoRABatchPlan(weight_indices=[], ranks_by_slot=[], scalings_by_slot=[])
+        self.assertEqual(empty_plan.ranks_for_requests(), ())
+
+        static_plan = LoRABatchPlan.for_static_lora(
+            batch_size=3,
+            num_lora_slots=4,
+            rank=8,
+            scaling=0.25,
+        )
+        self.assertEqual(static_plan.weight_indices, (0, 0, 0))
+        self.assertEqual(static_plan.ranks_by_slot, (8, 8, 8, 8))
+        self.assertEqual(static_plan.scalings_by_slot, (0.25, 0.25, 0.25, 0.25))
+
     @patch("sgl_jax.srt.lora.lora_manager.LoRAMemoryPool")
     def test_manager_conditional_update(self, MockPoolClass):
         """Test that LoRAManager conditionally calls update_lora_info."""
@@ -162,28 +230,162 @@ class TestLoRAManagerOptimization(unittest.TestCase):
 
         # Manually set attributes needed for prepare_lora_batch
         manager.memory_pool = mock_pool_instance
-        manager.loras = {}
+        mock_lora = MagicMock()
+        mock_lora.config.r = 8
+        mock_lora.scaling = 0.75
+        manager.loras = {"lora1": mock_lora}
         manager.max_loras_per_batch = 4
+        manager.num_lora_slots = 5
         manager.lora_backend = MagicMock()
         manager.update_lora_info = MagicMock()
 
         # Test case 1: memory_pool returns True (new weights)
         mock_pool_instance.prepare_lora_batch.return_value = True
+        mock_pool_instance.get_buffer_id.return_value = 1
 
         batch = MagicMock(spec=ModelWorkerBatch)
         batch.lora_ids = ["lora1"]
 
         manager.prepare_lora_batch(batch)
 
+        manager.lora_backend.prepare_lora_batch.assert_called_once()
+        call_kwargs = manager.lora_backend.prepare_lora_batch.call_args.kwargs
+        self.assertIs(call_kwargs["model_worker_batch"], batch)
+        self.assertEqual(
+            call_kwargs["batch_plan"],
+            LoRABatchPlan(
+                weight_indices=[1],
+                ranks_by_slot=[0, 8, 0, 0, 0],
+                scalings_by_slot=[0.0, 0.75, 0.0, 0.0, 0.0],
+            ),
+        )
         manager.update_lora_info.assert_called_once()
         manager.update_lora_info.reset_mock()
+        manager.lora_backend.prepare_lora_batch.reset_mock()
 
         # Test case 2: memory_pool returns False (no new weights)
         mock_pool_instance.prepare_lora_batch.return_value = False
 
         manager.prepare_lora_batch(batch)
 
+        manager.lora_backend.prepare_lora_batch.assert_called_once()
         manager.update_lora_info.assert_not_called()
+
+    @patch("sgl_jax.srt.lora.lora_manager.LoRAMemoryPool")
+    def test_manager_normalizes_lora_ids_without_mutating_batch(self, MockPoolClass):
+        mock_pool_instance = MockPoolClass.return_value
+        mock_pool_instance.target_modules = {"q_proj"}
+        mock_pool_instance.prepare_lora_batch.return_value = False
+        mock_pool_instance.get_buffer_id.side_effect = lambda uid: 0 if uid == BASE_LORA_ID else 1
+
+        with patch.object(LoRAManager, "init_state"):
+            manager = LoRAManager(
+                base_model=None,
+                base_hf_config=MagicMock(
+                    num_hidden_layers=1, hidden_size=128, num_attention_heads=4
+                ),
+                max_loras_per_batch=4,
+                dtype=jnp.float32,
+                mesh=self.mock_mesh,
+            )
+
+        mock_lora = MagicMock()
+        mock_lora.config.r = 8
+        mock_lora.scaling = 0.75
+        manager.memory_pool = mock_pool_instance
+        manager.loras = {"lora1": mock_lora}
+        manager.max_loras_per_batch = 4
+        manager.num_lora_slots = 5
+        manager.lora_backend = MagicMock()
+
+        batch = MagicMock(spec=ModelWorkerBatch)
+        batch.lora_ids = [None, "lora1"]
+
+        manager.prepare_lora_batch(batch)
+
+        self.assertEqual(batch.lora_ids, [None, "lora1"])
+        mock_pool_instance.prepare_lora_batch.assert_called_once_with(
+            cur_uids=[BASE_LORA_ID, "lora1"],
+            lora_adapters=manager.loras,
+        )
+        self.assertEqual(
+            manager.lora_backend.prepare_lora_batch.call_args.kwargs["batch_plan"],
+            LoRABatchPlan(
+                weight_indices=[0, 1],
+                ranks_by_slot=[0, 8, 0, 0, 0],
+                scalings_by_slot=[0.0, 0.75, 0.0, 0.0, 0.0],
+            ),
+        )
+
+    @patch("sgl_jax.srt.lora.lora_manager.LoRAMemoryPool")
+    def test_manager_rejects_unknown_dynamic_lora(self, MockPoolClass):
+        mock_pool_instance = MockPoolClass.return_value
+        mock_pool_instance.target_modules = {"q_proj"}
+
+        with patch.object(LoRAManager, "init_state"):
+            manager = LoRAManager(
+                base_model=None,
+                base_hf_config=MagicMock(
+                    num_hidden_layers=1, hidden_size=128, num_attention_heads=4
+                ),
+                max_loras_per_batch=4,
+                dtype=jnp.float32,
+                mesh=self.mock_mesh,
+            )
+
+        manager.memory_pool = mock_pool_instance
+        manager.loras = {}
+        manager.max_lora_rank = 8
+        manager.lora_backend = MagicMock()
+
+        batch = MagicMock(spec=ModelWorkerBatch)
+        batch.lora_ids = ["missing-lora"]
+
+        with self.assertRaisesRegex(ValueError, "not loaded"):
+            manager.prepare_lora_batch(batch)
+
+        mock_pool_instance.prepare_lora_batch.assert_not_called()
+        manager.lora_backend.prepare_lora_batch.assert_not_called()
+
+    @patch("sgl_jax.srt.lora.lora_manager.LoRAMemoryPool")
+    def test_manager_static_lora_builds_static_plan(self, MockPoolClass):
+        mock_pool_instance = MockPoolClass.return_value
+        mock_pool_instance.target_modules = {"q_proj"}
+        server_args = MagicMock(enable_static_lora=True, lora_scaling=0.25)
+
+        with patch.object(LoRAManager, "init_state"):
+            manager = LoRAManager(
+                base_model=None,
+                base_hf_config=MagicMock(
+                    num_hidden_layers=1, hidden_size=128, num_attention_heads=4
+                ),
+                max_loras_per_batch=4,
+                max_lora_rank=8,
+                dtype=jnp.float32,
+                mesh=self.mock_mesh,
+                server_args=server_args,
+            )
+
+        manager.memory_pool = mock_pool_instance
+        manager.loras = {}
+        manager.max_lora_rank = 8
+        manager.lora_backend = MagicMock()
+
+        batch = MagicMock(spec=ModelWorkerBatch)
+        batch.lora_ids = [None, None]
+
+        manager.prepare_lora_batch(batch)
+
+        manager.lora_backend.prepare_lora_batch.assert_called_once()
+        self.assertEqual(
+            manager.lora_backend.prepare_lora_batch.call_args.kwargs["batch_plan"],
+            LoRABatchPlan(
+                weight_indices=[0, 0],
+                ranks_by_slot=[8, 8, 8, 8],
+                scalings_by_slot=[0.25, 0.25, 0.25, 0.25],
+            ),
+        )
+        mock_pool_instance.prepare_lora_batch.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Upgrade JAX/JAXlib from 0.8.1 to 0.9.2 and libtpu from 0.0.30 to 0.0.38.
- Fix JAX 0.9.1+ strict `shard_map` `in_specs` enforcement across FlashAttention, MLA, KV cache, linear attention, and fused MoE paths.
- Fix JAX 0.9.2 compatibility issues around `reshape` `out_sharding`, `pallas_call` Manual mesh axes, and the `jax.reshard` API namespace.
- Add sharding-aware helper paths that derive shard specs from actual `NamedSharding` / tracer sharding instead of relying on divisibility heuristics.
- Fix FlashAttention GQA and `attention_sink` sharding behavior under local head-ratio constraints.
- Harden LoRA batching with explicit batch metadata, stable base-model sentinel handling, no-LoRA row preservation, clearer slot accounting, and stronger runtime validation.
- Remove confirmed dead LoRA helper code and tighten backend contracts.
- Stabilize LoRA debug dump request ordering and padded-batch `lora_ids` handling for DP-aware batches.

Closes #1025

## Motivation

JAX 0.9.1+ tightened several sharding contracts that were previously permissive. In particular, `shard_map` now requires `in_specs` to match the actual input sharding instead of silently resharding mismatched inputs. JAX 0.9.2 also exposes stricter behavior around `reshape(..., out_sharding=...)`, Pallas mesh axes, and reshard API placement.

This PR brings SGLang-JAX in line with the newer JAX/libtpu stack used by TPU inference work, while preserving model accuracy and making LoRA batch handling explicit enough to catch invalid runtime state early.

## Modifications

### Core JAX 0.9.2 sharding compatibility

**FlashAttention / MLA / linear attention**
- Add effective-axis helper logic that reads the actual input sharding, including tracer `aval.sharding` inside `jax.jit`.
- Derive `shard_map` `in_specs` / `out_specs` from actual tensor, DP, cache, sequence-length, and metadata sharding.
- Fix FlashAttention GQA behavior when local Q heads are not divisible by local KV heads by resharding Q to replicated where required.
- Fix `attention_sink` sharding by deriving from the actual Q sharding and resharding to replicated when Q is replicated on the tensor axis.

**KV cache / Pallas**
- Add local/test-safe update paths and wrap only multi-device paths with `shard_map`.
- Strip explicit `NamedSharding` where Pallas kernels require Manual mesh axes.
- Convert host-side metadata with `jax.device_get` + numpy where required.

**Fused MoE**
- Replace the old `jax.sharding.reshard` namespace with `jax.reshard`.
- Update tests to avoid relying on removed or unstable JAX internal APIs.

### LoRA correctness and validation

**Batch metadata model**
- Introduce `LoRABatchPlan` as explicit CPU-side LoRA planning metadata:
  - request-granular `weight_indices`
  - slot-granular `ranks_by_slot`
  - slot-granular `scalings_by_slot`
- Validate invalid slot indices, negative ranks, negative scaling, and non-finite scaling before backend expansion.
- Expand request-level metadata to token-level metadata in the backend with explicit EXTEND and DECODE checks.

**Base-model and no-LoRA handling**
- Reserve and normalize the base-model LoRA sentinel consistently.
- Preserve base-model rows exactly in mixed LoRA batches when the rank is zero.
- Reject unloaded dynamic adapters instead of silently falling back to base-model output.
- Reject `None` adapter loads into non-base LoRA slots.

**Backend and memory-pool hardening**
- Align `BaseLoRABackend` method signatures with the BGMV implementation and layer call sites.
- Raise `NotImplementedError` for unimplemented backend methods.
- Validate EXTEND metadata length, negative `extend_seq_lens`, and token-padding invariants.
- Add contextual errors for missing memory-pool slots and invalid buffer zeroing inputs.
- Avoid mutating scheduler-owned `model_worker_batch.lora_ids`; normalization is now local to LoRA planning.
- Remove confirmed dead LoRA helper code and normalize `jnp.concatenate` usage.

### Scheduler / infrastructure

- Add `arrival_index` / `output_order_selector` handling to keep debug dumps stable.
- Write `lora_ids` per padded batch slot in DP-aware scheduling paths.
- Normalize cached `/models/` paths in the model loader.
- Add subset device-mesh support by truncating devices to the requested mesh shape.

## Accuracy Tests

LoRA accuracy was checked against Hugging Face reference outputs. Dense and MoE MMLU checks were also run to cover non-LoRA serving paths affected by the JAX 0.9.2 sharding changes.

| Area | Command | What it validates | Result |
| --- | --- | --- | --- |
| LoRA HF alignment | `python test/srt/lora/test_align_lora_accuracy.py` | LoRA prefill/decode logits vs Hugging Face reference | PASS, `Ran 3 tests in 282.124s` |
| Dense MMLU | `python test/srt/run_suite.py --suite accuracy-test-tpu-v6e-1` | Non-LoRA Qwen/Qwen3-8B serving with FlashAttention | PASS, score `0.735`, total latency `185.960s` |
| MoE MMLU | `python -m unittest test_qwen3_moe_models.TestQwenModel.test_mmlu` | Qwen/Qwen3-30B-A3B serving with `moe_backend=epmoe`, `tp_size=4`, `ep_size=4` | PASS, score `0.578`, total latency `51.503s` |

LoRA alignment details:

| Scenario | Prefill max diff | Prefill mean diff | Decode max diff | Decode mean diff |
| --- | ---: | ---: | ---: | ---: |
| Single prompt | `2.193451e-05` | `3.758544e-06` | `1.907349e-05` | `2.803902e-06` |
| Multi prompt | N/A | N/A | `4.255009e-02` / `9.037256e-02` / `5.063438e-02` | `7.126036e-03` / `2.825490e-02` / `1.182749e-02` |

The multi-prompt values above are absolute logit diffs, not percentages. The test uses `np.testing.assert_allclose(..., atol=9e-2, rtol=9e-2)`, so the largest observed absolute diff (`9.037256e-02`) passes the combined allclose tolerance. The mean diffs stay in the `7e-3` to `2.8e-2` range.

The trailing `multiprocessing.resource_tracker KeyError` after the `OK` line is cleanup noise from the test process; the command exits with status 0.

## Test Plan

### Validation matrix

| Category | Command | Hardware / mode | Status | Notes |
| --- | --- | --- | --- | --- |
| Syntax/import sanity | `python -m compileall -q python/sgl_jax/srt/lora test/srt/lora/test_bgmv_backend.py test/srt/lora/test_lora_manager_optimization.py` | CPU host | PASS | LoRA modules and tests compile cleanly |
| LoRA CPU logic | `JAX_PLATFORMS=cpu python -m unittest test.srt.lora.test_lora_manager_optimization test.srt.lora.test_bgmv_backend.TestRankZeroOutputRestore` | CPU | PASS | `14 tests OK` |
| LoRA TPU backend | `python test/srt/lora/test_bgmv_backend.py` | TPU | PASS | `14 tests OK` |
| LoRA accuracy | `python test/srt/lora/test_align_lora_accuracy.py` | TPU | PASS | `3 tests OK`; HF logit alignment checked |
| Dense non-LoRA accuracy | `python test/srt/run_suite.py --suite accuracy-test-tpu-v6e-1` | TPU v6e-4 environment | PASS | Qwen/Qwen3-8B MMLU score `0.735` |
| MoE E2E accuracy | `python -m unittest test_qwen3_moe_models.TestQwenModel.test_mmlu` | TPU v6e-4, `moe_backend=epmoe` | PASS | Qwen/Qwen3-30B-A3B MMLU score `0.578` |
| Fused MoE E2E attempt | `python -m unittest test_qwen3_moe_models.TestQwenModelForFusedMoE.test_mmlu` | TPU v6e-4, `moe_backend=fused` | BLOCKED | Fails during fused MoE EXTEND precompile: `Expected intermediate_size=768 to be aligned to bf=512` |

The fused MoE result is a current fused kernel block-config/model compatibility limitation for Qwen3-MoE in this environment. It fails before request-level accuracy execution, is not counted as passing evidence for this PR, and does not block the validated default `epmoe` MoE path.

### Unit test suite sharding

On the current TPU v6e-4 environment:

```bash
source .venv/bin/activate
python test/srt/run_suite.py --suite unit-test-tpu-v6e-1 --auto-partition-id 0 --auto-partition-size 3
python test/srt/run_suite.py --suite unit-test-tpu-v6e-1 --auto-partition-id 1 --auto-partition-size 3
python test/srt/run_suite.py --suite unit-test-tpu-v6e-1 --auto-partition-id 2 --auto-partition-size 3
```

Observed:

| Shard | Status | Notes |
| --- | --- | --- |
| `--auto-partition-id 0 --auto-partition-size 3` | FAILED | Non-LoRA `python/sgl_jax/test/test_flashattention.py::test_gqa_prefill_with_custom_mask` hits TPU compile-time VMEM OOM on v6e-4: `64.15M > 64.00M` |
| `--auto-partition-id 1 --auto-partition-size 3` | PASS | Completed successfully |
| `--auto-partition-id 2 --auto-partition-size 3` | PASS | Completed successfully |

The shard-0 failure is a FlashAttention TPU compiler VMEM limit in the current TPU v6e-4 environment. It is tracked here as an environment/compiler limitation and has not been verified on a larger slice in this validation pass.

## Benchmarking and Profiling

No dedicated throughput/latency benchmark is included in this PR. The primary validation focus is dependency compatibility, sharding correctness, and LoRA correctness hardening. This PR does touch sharding and metadata paths that can affect compilation behavior, so a focused `bench_one_batch.py` comparison would be a useful follow-up if performance sign-off is required.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
