### PR TITLE
unpermute einsum optimization

### DIFF
--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -696,7 +696,7 @@ class EPMoE(nnx.Module):
                 padding = jnp.zeros((padding_size, intermediate.shape[1]), dtype=intermediate.dtype)
                 intermediate = jnp.concatenate([intermediate, padding], axis=0)
 
-         # Unsort: gather directly into (N, K, H) by reshaping the small index array.
+        # Unsort: gather directly into (N, K, H) by reshaping the small index array.
         argsort_indices = jnp.argsort(sorted_selected_experts, stable=True)
         total_tokens = weights.shape[0] * weights.shape[1] // self.num_experts_per_tok
         grouped_indices = jnp.reshape(argsort_indices, (total_tokens, self.num_experts_per_tok))

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -696,24 +696,18 @@ class EPMoE(nnx.Module):
                 padding = jnp.zeros((padding_size, intermediate.shape[1]), dtype=intermediate.dtype)
                 intermediate = jnp.concatenate([intermediate, padding], axis=0)
 
+         # Unsort: gather directly into (N, K, H) by reshaping the small index array.
         argsort_indices = jnp.argsort(sorted_selected_experts, stable=True)
-        unsort_intermediate = jnp.take(intermediate, indices=argsort_indices, axis=0)
-
         total_tokens = weights.shape[0] * weights.shape[1] // self.num_experts_per_tok
+        grouped_indices = jnp.reshape(argsort_indices, (total_tokens, self.num_experts_per_tok))
+        grouped_intermediate = jnp.take(intermediate, indices=grouped_indices, axis=0)
 
+        # Weighted sum over K experts via einsum.
         reshaped_weights = jnp.reshape(weights, (total_tokens, self.num_experts_per_tok))
-        reshaped_intermediate = jnp.reshape(
-            unsort_intermediate,
-            (total_tokens, self.num_experts_per_tok, -1),
-        )
-
-        intermediate_fp32 = reshaped_intermediate.astype(jnp.float32)
-        weights_fp32 = reshaped_weights.astype(jnp.float32)
-
         output = jnp.einsum(
-            "BKE,BK -> BE",
-            intermediate_fp32,
-            weights_fp32,
+            "BKE,BK->BE",
+            grouped_intermediate.astype(jnp.float32),
+            reshaped_weights.astype(jnp.float32),
         )
 
         if len(weights.shape) == 2:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
For the unpermute–einsum path, XLA previously reordered the conversion before applying the reshape required for the einsum layout. By reshaping the argsort indices first, XLA can instead reshape bf16 values rather than fp32, eliminating the extra conversion step and yielding an 30% improvement.
## Modifications

gather and reshape weights and intermediates first and then cast dtype to fp32 right before einsum call.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
