### PR TITLE
feat(models): MiMoV2MTPForCausalLM (V2.5-Pro NextN/MTP draft model)

### DIFF
--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -141,6 +141,9 @@ class ModelConfig:
 
         if is_draft_model and self.hf_config.architectures[0] == "MiMoForCausalLM":
             self.hf_config.architectures[0] = "MiMoMTPForCausalLM"
+
+        if is_draft_model and self.hf_config.architectures[0] == "MiMoV2ForCausalLM":
+            self.hf_config.architectures[0] = "MiMoV2MTPForCausalLM"
         # Check model type
         self.is_generation = is_generation_model(self.hf_config.architectures, is_embedding)
         self.is_multimodal = False

--- a/python/sgl_jax/srt/models/mimo_v2_nextn.py
+++ b/python/sgl_jax/srt/models/mimo_v2_nextn.py
@@ -1,0 +1,330 @@
+"""MiMo-V2.5-Pro multi-token-prediction (NextN/MTP) draft model.
+
+One instance loads exactly one of the 3 MTP layers from
+``model_mtp.safetensors`` (selected via ``config.mtp_layer_idx``); the
+``MultiLayerDraftWorker`` (#1053 P1-4) creates one instance per layer. The
+MTP block is a SWA-attention + dense-MLP decoder (not MoE), with the same
+fused-QKV per-shard FP8 layout as the V2.5-Pro target.
+"""
+
+import logging
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from transformers import PretrainedConfig
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead
+from sgl_jax.srt.layers.layernorm import RMSNorm
+from sgl_jax.srt.layers.linear import LinearBase
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
+from sgl_jax.srt.mem_cache.memory_pool import KVCache, MemoryPools
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+from sgl_jax.srt.models.mimo_v2_flash import MiMoV2Attention, MiMoV2MLP
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+
+logger = logging.getLogger(__name__)
+
+
+class MiMoV2NextNDecoderLayer(nnx.Module):
+    """Single MTP decoder block: SWA attention + dense MLP (never MoE)."""
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        layer_id: int = 0,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.layer_id = layer_id
+        rope_theta = getattr(config, "rope_theta", 1000000)
+        rope_scaling = getattr(config, "rope_scaling", None)
+        if isinstance(rope_scaling, dict) and rope_scaling.get("rope_type") == "default":
+            rope_scaling = None
+        max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
+
+        self.self_attn = MiMoV2Attention(
+            hidden_size=config.hidden_size,
+            num_heads=config.swa_num_attention_heads,
+            num_kv_heads=config.swa_num_key_value_heads,
+            max_position_embeddings=max_position_embeddings,
+            rope_theta=getattr(config, "swa_rope_theta", rope_theta),
+            rope_scaling=rope_scaling,
+            head_dim=config.swa_head_dim,
+            v_head_dim=getattr(config, "swa_v_head_dim", None),
+            sliding_window_size=getattr(config, "sliding_window_size", None),
+            attention_sink_bias=getattr(config, "add_swa_attention_sink_bias", False),
+            partial_rotary_factor=getattr(config, "partial_rotary_factor", 1.0),
+            attention_value_scale=getattr(config, "attention_value_scale", None),
+            layer_id=layer_id,
+            dtype=dtype,
+            mesh=mesh,
+        )
+        self.mlp = MiMoV2MLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            layer_id=layer_id,
+            dtype=dtype,
+            mesh=mesh,
+        )
+        self.input_layernorm = RMSNorm(
+            config.hidden_size, epsilon=config.layernorm_epsilon, param_dtype=dtype
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, epsilon=config.layernorm_epsilon, param_dtype=dtype
+        )
+
+    def __call__(
+        self,
+        positions: jax.Array,
+        hidden_states: jax.Array,
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: KVCache,
+        residual: jax.Array | None = None,
+    ) -> tuple[jax.Array, jax.Array, jax.Array, None]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states = hidden_states + residual
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+
+        hidden_states, kv_fused = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+            forward_batch=forward_batch,
+            token_to_kv_pool=token_to_kv_pool,
+        )
+
+        hidden_states = hidden_states + residual
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual, kv_fused, None
+
+
+class MiMoV2ModelNextN(nnx.Module):
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.embed_tokens = Embed(
+            num_embeddings=config.vocab_size,
+            features=config.hidden_size,
+            dtype=dtype,
+            kernel_axes=("tensor", None),
+            param_dtype=dtype,
+            mesh=mesh,
+        )
+        self.enorm = RMSNorm(
+            config.hidden_size, epsilon=config.layernorm_epsilon, param_dtype=dtype
+        )
+        self.hnorm = RMSNorm(
+            config.hidden_size, epsilon=config.layernorm_epsilon, param_dtype=dtype
+        )
+        self.eh_proj = LinearBase(
+            input_size=2 * config.hidden_size,
+            output_size=config.hidden_size,
+            use_bias=False,
+            kernel_axes=(None, None),
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+        self.mtp_block = MiMoV2NextNDecoderLayer(config, mesh=mesh, layer_id=0, dtype=dtype)
+        self.final_layernorm = RMSNorm(
+            config.hidden_size, epsilon=config.layernorm_epsilon, param_dtype=dtype
+        )
+
+    def __call__(
+        self, forward_batch: ForwardBatch, token_to_kv_pool: KVCache
+    ) -> tuple[jax.Array, list[jax.Array]]:
+        embed = self.embed_tokens(forward_batch.input_ids)
+        hidden_in = forward_batch.spec_info.hidden_states
+        hidden_states, _ = self.eh_proj(
+            jnp.concatenate((self.enorm(embed), self.hnorm(hidden_in)), axis=-1)
+        )
+        hidden_states, residual, kv_fused, _ = self.mtp_block(
+            forward_batch.positions, hidden_states, forward_batch, token_to_kv_pool, None
+        )
+        hidden_states = self.final_layernorm(hidden_states + residual)
+        return hidden_states, [kv_fused]
+
+
+class MiMoV2MTPForCausalLM(nnx.Module):
+
+    load_lm_head_from_target = True
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh | None = None,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.config = config
+        self.mesh = mesh
+        self.dtype = dtype
+        self.mtp_layer_idx = getattr(config, "mtp_layer_idx", 0)
+        self.model = MiMoV2ModelNextN(config, mesh=mesh, dtype=dtype)
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            dtype=dtype,
+            param_dtype=dtype,
+            kernel_axes=("tensor", None),
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size, mesh=self.mesh)
+        self._fused_qkv_buffers: dict[int, dict] = {}
+        self.hot_token_ids = None
+
+    def __call__(
+        self,
+        forward_batch: ForwardBatch,
+        memory_pools: MemoryPools,
+        logits_metadata: LogitsMetadata,
+    ):
+        hidden_states, layers_kv_fused = self.model(forward_batch, memory_pools.token_to_kv_pool)
+        output = self.logits_processor(
+            hidden_states, self.lm_head, logits_metadata, aux_hidden_states=None
+        )
+        return output, layers_kv_fused, []
+
+    def load_weights(self, model_config: ModelConfig):
+        self.loader = WeightLoader(
+            model=self, model_config=model_config, mesh=self.mesh, dtype=self.dtype
+        )
+        mappings = self._create_weight_mappings()
+        self.loader.load_weights_from_safetensors(mappings)
+
+        if self.loader.is_static_quant:
+            attn = self.model.mtp_block.self_attn
+            head_dim, v_head_dim = attn.head_dim, attn.v_head_dim
+            # dequant_fused_qkv reads full-attn config fields; the MTP block uses
+            # SWA dims, so derive the split config from the actual layer.
+            mtp_qkv_config = SimpleNamespace(
+                head_dim=head_dim,
+                v_head_dim=v_head_dim,
+                num_attention_heads=attn.q_head_num,
+                num_key_value_heads=attn.k_head_num,
+            )
+            self.loader.dequant_fused_qkv(
+                self._fused_qkv_buffers, [self.model.mtp_block], mtp_qkv_config
+            )
+            self.loader.dequant_fp8_layers(
+                [self.model.mtp_block],
+                specs=[
+                    ("mlp.gate_proj", None),
+                    ("mlp.up_proj", None),
+                    ("mlp.down_proj", None),
+                ],
+            )
+            self.loader.replicate_kv_heads(
+                [self.model.mtp_block],
+                specs=[("self_attn.k_proj", head_dim), ("self_attn.v_proj", v_head_dim)],
+                target_kv_heads_fn=lambda attn: attn.k_head_num,
+            )
+        logger.info(
+            "MiMoV2 MTP layer %d weights loaded (fused-qkv FP8=%s)",
+            self.mtp_layer_idx,
+            self.loader.is_static_quant,
+        )
+
+    def _create_weight_mappings(self) -> dict[str, WeightMapping]:
+        idx = self.mtp_layer_idx
+        prefix = f"model.mtp.layers.{idx}"
+        block = "model.mtp_block"
+        is_fp8 = self.loader.is_static_quant
+
+        mappings: dict[str, WeightMapping] = {
+            f"{prefix}.enorm.weight": WeightMapping(
+                target_path="model.enorm.scale", sharding=(None,), transpose=False
+            ),
+            f"{prefix}.hnorm.weight": WeightMapping(
+                target_path="model.hnorm.scale", sharding=(None,), transpose=False
+            ),
+            f"{prefix}.eh_proj.weight": WeightMapping(
+                target_path="model.eh_proj.weight", sharding=(None, None), transpose=True
+            ),
+            f"{prefix}.final_layernorm.weight": WeightMapping(
+                target_path="model.final_layernorm.scale", sharding=(None,), transpose=False
+            ),
+            f"{prefix}.input_layernorm.weight": WeightMapping(
+                target_path=f"{block}.input_layernorm.scale", sharding=(None,), transpose=False
+            ),
+            f"{prefix}.pre_mlp_layernorm.weight": WeightMapping(
+                target_path=f"{block}.post_attention_layernorm.scale",
+                sharding=(None,),
+                transpose=False,
+            ),
+            f"{prefix}.self_attn.o_proj.weight": WeightMapping(
+                target_path=f"{block}.self_attn.o_proj.weight",
+                sharding=("tensor", None),
+                transpose=True,
+                head_dim_padding=True,
+            ),
+            f"{prefix}.self_attn.attention_sink_bias": WeightMapping(
+                target_path=f"{block}.self_attn.attention_sink_bias",
+                sharding=("tensor",),
+                transpose=False,
+            ),
+        }
+
+        qkv_key = f"{prefix}.self_attn.qkv_proj"
+        if is_fp8 and not self.loader.is_quant_ignored(qkv_key):
+            mappings[f"{qkv_key}.weight"] = WeightMapping(
+                target_path="__FUSED_QKV_WEIGHT__0", sharding=(None, None), transpose=False
+            )
+            mappings[f"{qkv_key}.weight_scale_inv"] = WeightMapping(
+                target_path="__FUSED_QKV_SCALE__0", sharding=(None, None), transpose=False
+            )
+        else:
+            mappings[f"{qkv_key}.weight"] = WeightMapping(
+                target_path=[
+                    f"{block}.self_attn.q_proj.weight",
+                    f"{block}.self_attn.k_proj.weight",
+                    f"{block}.self_attn.v_proj.weight",
+                ],
+                sharding=(None, "tensor"),
+                transpose=True,
+                head_dim_padding=False,
+                kv_head_padding=True,
+            )
+
+        for proj, sharding in [
+            ("gate_proj", (None, "tensor")),
+            ("up_proj", (None, "tensor")),
+            ("down_proj", ("tensor", None)),
+        ]:
+            hf_key = f"{prefix}.mlp.{proj}"
+            suffix = "weight_q" if is_fp8 else "weight"
+            mappings[f"{hf_key}.weight"] = WeightMapping(
+                target_path=f"{block}.mlp.{proj}.{suffix}",
+                sharding=sharding,
+                transpose=True,
+            )
+            if is_fp8:
+                mappings[f"{hf_key}.weight_scale_inv"] = WeightMapping(
+                    target_path=f"{block}.mlp.{proj}.weight_scale",
+                    sharding=(None, None),
+                    transpose=False,
+                )
+
+        return mappings
+
+    def get_embed_and_head(self):
+        return self.model.embed_tokens.embedding.value, self.lm_head.embedding.value
+
+    def set_embed_and_head(self, embed: jax.Array, head: jax.Array) -> None:
+        self.model.embed_tokens.embedding.value = embed
+        self.lm_head.embedding.value = head
+
+    def set_embed(self, embed: jax.Array) -> None:
+        self.model.embed_tokens.embedding.value = embed
+
+
+EntryClass = MiMoV2MTPForCausalLM

--- a/python/sgl_jax/test/models/test_mimo_v2_nextn.py
+++ b/python/sgl_jax/test/models/test_mimo_v2_nextn.py
@@ -1,0 +1,63 @@
+"""Weight-mapping coverage test for MiMoV2MTPForCausalLM.
+
+Verifies, without touching TPU, that the mapping dict covers exactly the
+tensors present in V2.5-Pro's ``model_mtp.safetensors`` for each layer
+index, and that ``mtp_layer_idx`` correctly selects per-layer keys.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+# Ground truth: keys from XiaomiMiMo/MiMo-V2.5-Pro model_mtp.safetensors header
+# (16 tensors per layer × 3 layers = 48). Derived from the live HF header.
+_PER_LAYER_KEYS = [
+    "eh_proj.weight",
+    "enorm.weight",
+    "final_layernorm.weight",
+    "hnorm.weight",
+    "input_layernorm.weight",
+    "mlp.down_proj.weight",
+    "mlp.down_proj.weight_scale_inv",
+    "mlp.gate_proj.weight",
+    "mlp.gate_proj.weight_scale_inv",
+    "mlp.up_proj.weight",
+    "mlp.up_proj.weight_scale_inv",
+    "pre_mlp_layernorm.weight",
+    "self_attn.attention_sink_bias",
+    "self_attn.o_proj.weight",
+    "self_attn.qkv_proj.weight",
+    "self_attn.qkv_proj.weight_scale_inv",
+]
+
+
+def _hf_keys(layer_idx: int) -> set[str]:
+    return {f"model.mtp.layers.{layer_idx}.{k}" for k in _PER_LAYER_KEYS}
+
+
+@pytest.mark.parametrize("layer_idx", [0, 1, 2])
+def test_weight_mapping_covers_safetensors(layer_idx: int):
+    from sgl_jax.srt.models.mimo_v2_nextn import MiMoV2MTPForCausalLM
+
+    model = SimpleNamespace(
+        mtp_layer_idx=layer_idx,
+        loader=SimpleNamespace(is_static_quant=True, is_quant_ignored=lambda k: False),
+    )
+    mappings = MiMoV2MTPForCausalLM._create_weight_mappings(model)
+
+    expected = _hf_keys(layer_idx)
+    got = set(mappings.keys())
+    assert (
+        got == expected
+    ), f"layer {layer_idx}: missing={sorted(expected - got)} extra={sorted(got - expected)}"
+
+    # Per-layer selection: mappings for layer N must not reference any other layer.
+    for other in {0, 1, 2} - {layer_idx}:
+        assert not any(f"mtp.layers.{other}." in k for k in got)
+
+    # Target paths are unique (no two HF keys write the same JAX param).
+    targets = []
+    for m in mappings.values():
+        tp = m.target_path
+        targets.extend(tp if isinstance(tp, list) else [tp])
+    assert len(targets) == len(set(targets)), "duplicate target_path"

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -459,6 +459,7 @@ suites = {
         TestFile("python/sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py", 1),
         TestFile("python/sgl_jax/test/speculative/test_eagle_tree_build.py", 1),
         TestFile("python/sgl_jax/test/speculative/test_eagle_utils.py", 1),
+        TestFile("python/sgl_jax/test/models/test_mimo_v2_nextn.py", 0.2, runner="pytest"),
         TestFile("python/sgl_jax/test/multimodal/test_wan_vae_precision.py", 1),
         TestFile("python/sgl_jax/test/multimodal/test_vae_scheduler.py", 2.5),
         TestFile("python/sgl_jax/test/multimodal/test_flash_attention_kernel.py", 1),


### PR DESCRIPTION
Part of #1053 (P1-3).

## What

Single-layer draft model for MiMo-V2.5-Pro 3-layer MTP. One instance loads exactly one layer from `model_mtp.safetensors` (selected via `config.mtp_layer_idx`, default 0). The `MultiLayerDraftWorker` (#1053 P1-4) will create one instance per layer.

Architecture mirrors sglang GPU [`mimo_v2_nextn.py`](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/models/mimo_v2_nextn.py):

| Class | Composition |
|---|---|
| `MiMoV2NextNDecoderLayer` | SWA `MiMoV2Attention` (with `attention_sink_bias`) + **dense** `MiMoV2MLP` (the MTP block is *not* MoE, unlike the target's 384-expert layers) + input/post-attn layernorm |
| `MiMoV2ModelNextN` | `embed_tokens` + `enorm`/`hnorm` + `eh_proj` (2h→h) + 1 decoder block + `final_layernorm` |
| `MiMoV2MTPForCausalLM` | `load_lm_head_from_target=True`; `load_weights` handles V2.5-Pro's fused-QKV per-shard FP8 layout via `loader.dequant_fused_qkv` + `dequant_fp8_layers` for the dense MLP |

## Weight mapping

Verified against the live `XiaomiMiMo/MiMo-V2.5-Pro/model_mtp.safetensors` header (48 tensors = 16 per layer × 3 layers):

| HF key (`model.mtp.layers.{idx}.*`) | → JAX target | dtype |
|---|---|---|
| `enorm`/`hnorm`/`final_layernorm`/`input_layernorm` | `model.*` / `model.mtp_block.*` `.scale` | BF16 |
| `pre_mlp_layernorm` | `model.mtp_block.post_attention_layernorm.scale` | BF16 |
| `eh_proj.weight` | `model.eh_proj.weight` (transpose) | BF16 |
| `self_attn.qkv_proj.{weight,weight_scale_inv}` | `__FUSED_QKV_{WEIGHT,SCALE}__0` → split q/k/v via `dequant_fused_qkv` | F8_E4M3 |
| `self_attn.o_proj.weight` | `model.mtp_block.self_attn.o_proj.weight` | BF16 |
| `self_attn.attention_sink_bias` | `model.mtp_block.self_attn.attention_sink_bias` | BF16 |
| `mlp.{gate,up,down}_proj.{weight,weight_scale_inv}` | `model.mtp_block.mlp.*.weight_q`/`.weight_scale` → `dequant_fp8_layers` | F8_E4M3 |

`test_mimo_v2_nextn.py` asserts exact key coverage, per-`mtp_layer_idx` selection (layer N maps only `model.mtp.layers.N.*`), and unique target paths.

## Test plan

- [x] `test_mimo_v2_nextn.py` 3/3 passed (CPU, mapping coverage)
- [x] pre-commit clean
- [ ] E2E load+forward numerical verification — deferred to P1-4 (the `MultiLayerDraftWorker` E2E acceptance "bs=1 accept-len ≥2.5, output 100%=nospec" implies per-layer logits correctness; will fix any `dequant_fused_qkv` interface mismatches there)