### PR TITLE
fix(precompile): only set recurrent fields for hybrid models

### DIFF
--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -194,6 +194,7 @@ class ModelWorker:
         self.max_padded_batch_size, self.max_padded_num_tokens = self.get_max_padded_size()
 
         # precompile
+        from sgl_jax.srt.mem_cache.memory_pool import HybridReqToTokenPool
         from sgl_jax.srt.model_executor.compilation_manager import CompilationManager
 
         self.compilation_manager = CompilationManager(
@@ -206,6 +207,9 @@ class ModelWorker:
             max_req_len=self.max_req_len,
             vocab_size=self.model_config.vocab_size,
             multimodal=server_args.multimodal,
+            is_hybrid_recurrent=isinstance(
+                self.model_runner.req_to_token_pool, HybridReqToTokenPool
+            ),
         )
 
         self.parent_process = psutil.Process().parent()

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -35,6 +35,7 @@ class CompilationManager:
         max_req_len: int,
         vocab_size: int,
         multimodal: bool = False,
+        is_hybrid_recurrent: bool = False,
     ):
         self.dp_size = dp_size
         self.tp_size = tp_size
@@ -46,6 +47,7 @@ class CompilationManager:
         self.multimodal = multimodal
         self.moe_backend = server_args.moe_backend
         self.enable_static_lora = server_args.enable_static_lora
+        self.is_hybrid_recurrent = is_hybrid_recurrent
 
         self.token_buckets = self._compute_token_buckets(server_args.precompile_token_paddings)
         self.bs_buckets = self._compute_bs_buckets(server_args.precompile_bs_paddings)
@@ -310,8 +312,8 @@ class CompilationManager:
             per_dp_bs_size=per_dp_bs_size,
             real_bs_per_dp=[bs] * dp_size,
             logits_indices_selector=np.arange(bs, dtype=np.int32),
-            recurrent_indices=np.zeros(bs, dtype=np.int32),
-            has_initial_state=np.zeros(bs, dtype=np.bool_),
+            recurrent_indices=(np.zeros(bs, dtype=np.int32) if self.is_hybrid_recurrent else None),
+            has_initial_state=(np.zeros(bs, dtype=np.bool_) if self.is_hybrid_recurrent else None),
         )
 
     # ---- Lazy compilation tracking ----


### PR DESCRIPTION
## Summary
- Non-hybrid models (e.g. Qwen3-8B) have `recurrent_indices=None` at runtime, but `_make_dummy_batch` unconditionally set them to `np.zeros(bs)`, causing pytree structure mismatch → JIT cache miss (`RuntimeError: Cache miss occurred 1 times`)
- Add `is_hybrid_recurrent` flag to `CompilationManager`, detected via `isinstance(req_to_token_pool, HybridReqToTokenPool)`
- Recurrent fields (`recurrent_indices`, `has_initial_state`) are now only populated in dummy batch when the model actually uses hybrid recurrent state

## Test plan
- [ ] CI `test_chunked_prefill_size.py` (Qwen3-8B with `--chunked-prefill-size 2048`) should pass without cache miss
- [ ] Hybrid model (Ling-2.6-flash) precompile should still work correctly with recurrent fields present