### PR TITLE
feat(kimi-linear): port e2e wire-up onto upstream kimi_linear branch

### DIFF
--- a/python/sgl_jax/srt/layers/attention/fla/gated_rmsnorm.py
+++ b/python/sgl_jax/srt/layers/attention/fla/gated_rmsnorm.py
@@ -1,0 +1,39 @@
+"""Gated RMS normalization for linear attention layers.
+
+Computes ``RMSNorm(x) * sigmoid(gate)`` — used by KDA (Kimi Delta Attention)
+as the output normalization before the final projection.
+
+GPU reference: ``sglang/srt/layers/attention/fla/fused_norm_gate.py``
+(``FusedRMSNormGated`` with ``activation="sigmoid"``).
+"""
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from flax.typing import Dtype
+
+
+class GatedRMSNorm(nnx.Module):
+    """RMSNorm with a multiplicative sigmoid gate.
+
+    Given input ``x`` and ``gate`` of the same shape, computes::
+
+        output = (x / sqrt(mean(x^2) + eps)) * weight * sigmoid(gate)
+    """
+
+    def __init__(
+        self,
+        num_features: int,
+        epsilon: float = 1e-6,
+        param_dtype: Dtype = jnp.float32,
+    ):
+        self.weight = nnx.Param(jnp.ones((num_features,), dtype=param_dtype))
+        self.epsilon = epsilon
+
+    def __call__(self, x: jax.Array, gate: jax.Array) -> jax.Array:
+        orig_dtype = x.dtype
+        x_f32 = x.astype(jnp.float32)
+        variance = jnp.mean(jnp.square(x_f32), axis=-1, keepdims=True)
+        x_norm = x_f32 * jax.lax.rsqrt(variance + self.epsilon)
+        x_norm = x_norm * self.weight[...].astype(jnp.float32)
+        return (x_norm * jax.nn.sigmoid(gate.astype(jnp.float32))).astype(orig_dtype)

--- a/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -227,5 +227,22 @@ def attn_backend_wrapper(
     runner: ModelRunner,
     full_attn_backend: AttentionBackend,
 ):
-    """Wrap full_attn_backend in HybridLinearAttnBackend for hybrid models."""
-    return full_attn_backend
+    """Wrap full_attn_backend in HybridLinearAttnBackend for hybrid models.
+
+    For hybrid recurrent models (e.g. Kimi-Linear: KDA + MLA), build the
+    matching linear sub-backend and route by layer_id. For pure full-attn
+    models, return the full_attn_backend unchanged.
+    """
+    cfg = runner.linear_recurrent_config
+    if cfg is None:
+        return full_attn_backend
+
+    # Only supported linear sub-backend today is KDA.
+    from sgl_jax.srt.layers.attention.linear.kda_backend import KDAAttnBackend
+
+    linear_attn_backend = KDAAttnBackend(mesh=runner.mesh)
+    return HybridLinearAttnBackend(
+        full_attn_backend=full_attn_backend,
+        linear_attn_backend=linear_attn_backend,
+        full_attn_layers=cfg.full_attention_layer_ids,
+    )

--- a/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
@@ -42,11 +42,13 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         b: jax.Array,
         layer: RadixLinearAttention,
         forward_batch: ForwardBatch,
-        pool: RecurrentStatePool,
+        recurrent_state_pool: RecurrentStatePool,
         **kwargs,
     ) -> jax.Array:
         recurrent_indices = self.forward_metadata.recurrent_indices
-        ssm_states, conv_states = self.get_state(pool, layer.layer_id, recurrent_indices)
+        ssm_states, conv_states = self.get_state(
+            recurrent_state_pool, layer.layer_id, recurrent_indices
+        )
         q_conv_w = layer.q_conv1d.weight.value
         k_conv_w = layer.k_conv1d.weight.value
         v_conv_w = layer.v_conv1d.weight.value
@@ -132,9 +134,11 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         else:
             raise NotImplementedError(f"KDA does not support {forward_batch.forward_mode}")
 
-        new_ssm_full = self.set_ssm_state(pool, layer.layer_id, recurrent_indices, new_recurrent)
+        new_ssm_full = self.set_ssm_state(
+            recurrent_state_pool, layer.layer_id, recurrent_indices, new_recurrent
+        )
         new_conv_full_list = self.set_conv_state(
-            pool, layer.layer_id, recurrent_indices, new_conv_packed
+            recurrent_state_pool, layer.layer_id, recurrent_indices, new_conv_packed
         )
         return output.reshape(output.shape[0], -1), (new_ssm_full, new_conv_full_list)
 
@@ -174,11 +178,20 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         return ssm, conv
 
     def set_ssm_state(self, recurrent_state_pool, layer_id, recurrent_indices, new_recurrent):
-        """Scatter per-request ``new_recurrent`` into the FULL pool buffer."""
+        """Scatter per-request ``new_recurrent`` into the FULL pool buffer.
+
+        Suppress writes at idx==0: padding rows carry idx=0 and would otherwise
+        pollute the per-rank dummy slot, leaking garbage back as initial state.
+        """
         full_recurrent, _ = self.get_layer_cache(recurrent_state_pool, layer_id)
 
+        def _scatter(buf, idx, val):
+            keep_mask = (idx == 0).reshape(-1, 1, 1, 1)
+            safe_val = jnp.where(keep_mask, buf[idx], val)
+            return buf.at[idx].set(safe_val)
+
         return jax.shard_map(
-            lambda buf, idx, val: buf.at[idx].set(val),
+            _scatter,
             mesh=self.mesh,
             in_specs=(
                 P("data", "tensor", None, None),
@@ -190,13 +203,18 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         )(full_recurrent, recurrent_indices, new_recurrent)
 
     def set_conv_state(self, recurrent_state_pool, layer_id, recurrent_indices, new_conv_packed):
-        """Scatter per-request packed conv state into the FULL pool buffer."""
+        """Scatter per-request packed conv state. Same idx==0 guard as set_ssm_state."""
         _, conv_buffer_list = self.get_layer_cache(recurrent_state_pool, layer_id)
         assert len(conv_buffer_list) == 1
         full_conv = conv_buffer_list[0]
 
+        def _scatter(buf, idx, val):
+            keep_mask = (idx == 0).reshape(-1, 1, 1)
+            safe_val = jnp.where(keep_mask, buf[idx], val)
+            return buf.at[idx].set(safe_val)
+
         new_conv_full = jax.shard_map(
-            lambda buf, idx, val: buf.at[idx].set(val),
+            _scatter,
             mesh=self.mesh,
             in_specs=(
                 P("data", "tensor", None),

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -206,6 +206,7 @@ class ModelWorker:
             max_req_len=self.max_req_len,
             vocab_size=self.model_config.vocab_size,
             multimodal=server_args.multimodal,
+            has_recurrent_state=self.model_runner.linear_recurrent_config is not None,
         )
 
         self.parent_process = psutil.Process().parent()

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -35,6 +35,7 @@ class CompilationManager:
         max_req_len: int,
         vocab_size: int,
         multimodal: bool = False,
+        has_recurrent_state: bool = False,
     ):
         self.dp_size = dp_size
         self.tp_size = tp_size
@@ -44,6 +45,7 @@ class CompilationManager:
         self.max_padded_num_tokens = max_padded_num_tokens
         self.vocab_size = vocab_size
         self.multimodal = multimodal
+        self.has_recurrent_state = has_recurrent_state
         self.moe_backend = server_args.moe_backend
         self.enable_static_lora = server_args.enable_static_lora
 
@@ -310,6 +312,12 @@ class CompilationManager:
             per_dp_bs_size=per_dp_bs_size,
             real_bs_per_dp=[bs] * dp_size,
             logits_indices_selector=np.arange(bs, dtype=np.int32),
+            # Hybrid recurrent backends (e.g. KDA) require these per-batch
+            # arrays even at precompile time; slot 0 is RecurrentStatePool's
+            # per-rank dummy slot, safe to point at. Leave None otherwise so
+            # non-recurrent backends are unaffected.
+            recurrent_indices=(np.zeros(bs, dtype=np.int32) if self.has_recurrent_state else None),
+            has_initial_state=(np.zeros(bs, dtype=np.bool_) if self.has_recurrent_state else None),
         )
 
     # ---- Lazy compilation tracking ----

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -584,11 +584,10 @@ class ModelRunnerKVCacheMixin:
 
     @property
     def linear_recurrent_config(self: ModelRunner):
-        """Return linear recurrent config if the model has linear attention, else None.
-
-        Currently returns None unconditionally — KimiLinearConfig detection
-        will be wired up when the modeling layer lands.
-        """
+        """Return linear recurrent config if the model has linear attention, else None."""
+        hf_cfg = getattr(self.model_config, "hf_config", None)
+        if hf_cfg is not None and getattr(hf_cfg, "linear_attn_config", None) is not None:
+            return hf_cfg
         return None
 
     def _kv_pool_layer_count(self: ModelRunner):


### PR DESCRIPTION
## Motivation

Wire up Kimi-Linear (KDA + MLA hybrid) end-to-end so the server can actually launch and run on top of `feat/support_kimi_linear_model`. The base branch ships KDA kernels (#1051) and the KimiLinear model port, but several glue points are still stubbed or unwired. Without these fixes the server either crashes at startup or, on DP runs, silently produces garbage tokens.

## Modifications

- `HybridLinearAttnBackend.attn_backend_wrapper`: build the real KDA sub-backend and route by `layer_id`. The upstream stub returned `full_attn_backend` unchanged, so KDA layers were never dispatched → server crash.
- `ModelRunner.linear_recurrent_config`: detect KimiLinearConfig by the presence of `linear_attn_config` on `hf_config`. Upstream property unconditionally returned `None`, so hybrid pool init was never triggered.
- `KDAAttnBackend.set_ssm_state` / `set_conv_state`: suppress writes at `idx == 0` (per-rank dummy slot). Padding rows carry `idx=0`; without the guard their scattered values pollute the dummy slot and leak back as initial state, collapsing tp4dp4 mmlu_pro OVERALL from ~0.66 to ~0.27.
- `CompilationManager`: gain a `has_recurrent_state` flag (plumbed from `tp_worker` via `model_runner.linear_recurrent_config`); only fill `recurrent_indices` / `has_initial_state` in the dummy precompile batch when it's set, so non-recurrent backends are unaffected.
- `KDAAttnBackend.__call__`: rename `pool` kwarg to `recurrent_state_pool` so it matches the call site in `HybridLinearAttnBackend.__call__` (`recurrent_state_pool=pool`).
- New: `layers/attention/fla/gated_rmsnorm.py` — gated RMSNorm helper used by KimiLinear.

`HybridLinearAttnBackend.__call__` is kept upstream-clean (no `pool` kwarg aliasing).

## Accuracy Tests

Validated on the parent branch (`feat/kda-e2e-kimi-linear`, same logical changes) via full mmlu_pro on Kimi-Linear-48B-A3B-Instruct, T=1.0, bs=32:

| Config | OVERALL | Wall |
|---|---|---|
| tp16dp1 | 0.6609 | 8h23m47s |
| tp4dp4  | 0.6574 | 9h12m51s |

Pre-fix tp4dp4 collapses to ~0.27 — the dummy-slot guard is the load-bearing fix.

A full re-run of mmlu_pro on this rebased branch is pending; smoke + limit=20 sanity to follow.

## Benchmarking and Profiling

No throughput delta expected vs base branch — same kernels, same forward path; only wire-up + a single-int dummy guard inside scatter shard_maps.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.