### PR TITLE
fix(mla): reject page size one

### DIFF
--- a/python/sgl_jax/srt/layers/attention/mla_backend.py
+++ b/python/sgl_jax/srt/layers/attention/mla_backend.py
@@ -105,6 +105,12 @@ class MLAAttentionBackend(AttentionBackend):
         # TODO(tuner): hardcoded 4, matches upstream — should be autotuned.
         decode_batch_size: int = 4,
     ):
+        assert page_size > 1, (
+            "MLA attention backend does not support page_size=1. "
+            "The MLA v2 kernel packs KV slots and infers the effective page size "
+            "from cache_kv.shape[1] * kv_packing, which makes page_size=1 "
+            "inconsistent with allocator and metadata page semantics."
+        )
         self.num_heads = num_attn_heads
         self.kv_lora_rank = kv_lora_rank
         self.qk_nope_head_dim = qk_nope_head_dim


### PR DESCRIPTION
## Summary

- Reject `page_size=1` for the absorbed MLA backend at initialization time.
- Explain the packed KV page-size mismatch in the assertion message.
- Link the investigation issue: #1074.

## Rationale

The MLA v2 kernel packs KV slots by dtype and infers the effective page size from `cache_kv.shape[1] * kv_packing`. For bf16, `kv_packing=2`, so configured `page_size=1` produces an effective kernel page size of 2 while allocator and metadata still use logical page size 1. This can lead to corrupted KV addressing and garbled generation.

## Testing

- `git commit` pre-commit hooks passed, including ruff, isort, and mypy.
