### PR TITLE
test(bench_serving_dense_tp_4): cap context-length to 3072

### DIFF
--- a/test/srt/test_bench_serving_dense_tp_4.py
+++ b/test/srt/test_bench_serving_dense_tp_4.py
@@ -52,6 +52,8 @@ class TestBenchServingDenseTp4(CustomTestCase):
                 "--page-size",
                 "256",
                 "--disable-radix-cache",
+                "--context-length",
+                "3072",
             ],
             env={
                 "JAX_COMPILATION_CACHE_DIR": "/tmp/jax_compilation_cache",
@@ -105,7 +107,7 @@ class TestBenchServingDenseTp4(CustomTestCase):
                 f"### test_output_throughput_default_tp_4\n"
                 f"Output throughput: {res['output_throughput']:.2f} token/s\n"
             )
-            self.assertGreater(res["output_throughput"], 9866)
+            self.assertGreater(res["output_throughput"], 11000)
 
     def test_ttft_default_tp_4(self):
         args = get_benchmark_args(


### PR DESCRIPTION
## Summary
- Adds `--context-length 3072` to TestBenchServingDenseTp4's server launch args
- Raises `test_output_throughput_default_tp_4` threshold from 9866 → 11000 to match new baseline

## Why
After #934 routed decode-only batches to RPA v3's DECODE sub-kernel, the kernel's default `bkv_sz = min(min_bkv_sz_to_peak, max_kv)` heuristic picks **16384** for this test, because the control plane pads per-seq KV allocation to Qwen3-8B's full 40K `context_len`. The DMA tile is ~16× larger than the test's actual ≤1K-token sequences, wasting HBM bandwidth and causing ~13% throughput regression — main has been intermittently failing this test since 2026-04-22 (e.g. runs `25787533738`, `25713412493`, `25668305532`).

Bounding `--context-length` to 3072 lets RPA pick `bkv_sz=3072` instead. 3072 still covers the worst-case sub-test (`test_itl`: 1024 input + 1024 output = 2048 tokens) with margin.

Full root-cause analysis and alternative fixes are in #1044.

## Verification (TPU v6e-4, single run)
| sub-test | metric | threshold | measured | headroom |
|---|---|---|---|---|
| test_input_throughput | input_throughput | > 64960 | 68859 | +6% |
| test_output_throughput | output_throughput | > 11000 | 12101 | +10% |
| test_ttft | median_ttft_ms | < 38 | 28.56 | 25% |
| test_itl | median_itl_ms | < 8 | 6.29 | 21% |

For comparison: PR #934 baseline (default context-length) measured 9985 tok/s on the same hardware; this change recovers it to 12101 (+21%), even slightly above PR #930's pre-regression 11484.

## Test plan
- [x] All 4 sub-tests pass on TPU v6e-4
- [ ] CI green on PR