### PR TITLE
fix(moe): drop redundant outer LHS pad in EPMoE._gmm_compute (fixes SparseCore halt at decode)

### DIFF
--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -596,22 +596,15 @@ class EPMoE(nnx.Module):
         else:
             x = inputs_2d[token_indices].astype(self.dtype)
 
-        # TODO(Qinghan): DeepSeek-V2-Lite has num_experts_per_tok=6, so with
-        # the default power-of-2 bs bucketing `padded_bs * 6` can land on a
-        # value > 16 that isn't a multiple of 16 (e.g. bs=4 -> size_m=24),
-        # which is why this padding is necessary. Models with power-of-2
-        # top_k (Grok=2, DeepSeek-V3=8, Qwen3-MoE=8) wouldn't need it.
-        from jax.experimental.pallas import tpu as pltpu
-
-        sublane_align = pltpu.get_tpu_info().get_sublane_tiling(x.dtype)
-        # TODO: remove once bucketing guarantees total_tokens*top_k divisible by GMM tile_m=128.
-        gmm_tile_m = 128
-        align = max(sublane_align, gmm_tile_m)
-        pad_size = (-x.shape[0]) % align
-        if pad_size > 0:
-            x = jnp.pad(x, ((0, pad_size), (0, 0)))
-            group_sizes = group_sizes.at[-1].add(pad_size)
-
+        # NOTE: do NOT pad LHS / bump group_sizes here. The megablox backend
+        # ``gmm`` (sgl_jax/srt/kernels/gmm/megablox_gmm_backend.py:67-73)
+        # already pads ``lhs`` to its required alignment (32 for v2, 128 for
+        # v1), bumps ``group_sizes[-1]`` accordingly, and slices the output
+        # back to the original ``m`` afterwards. An outer pre-pad is at best
+        # redundant; in practice the previous workaround pre-padded to a
+        # hard-coded ``128`` which forced v2 (alignment=32) into a 4x larger
+        # tile, hit a kernel auto-tiler edge case at decode bs=8 / top_k=8
+        # (m=64 -> 128) and triggered an on-device SparseCore halt.
         group_sizes = group_sizes.astype(jnp.int32)
         act_q_dtype = self.activation_quantized_dtype
 


### PR DESCRIPTION
## Problem

`EPMoE._gmm_compute` in `python/sgl_jax/srt/layers/moe.py` pre-pads the GMM input (`x`) and bumps `group_sizes[-1]` before calling `gmm()`. The padding was originally added to align `x.shape[0]` to the TPU sublane tiling, then later widened to always align to a hard-coded `gmm_tile_m = 128`. **Both layers are redundant** with the megablox backend's own alignment handling, and the 128-aligned layer **actively breaks decode on `gmm_v2`** for some shapes — it forces the auto-tiler into a larger tile that hits an on-device check and the TPU SparseCore halts.

## What the megablox backend already does

`megablox_gmm_backend.gmm` (`python/sgl_jax/srt/kernels/gmm/megablox_gmm_backend.py`) is the single entry point for both v1 and v2 GMM kernels and already provides a **closed alignment contract**, in two halves:

### Half 1 — pad before the kernel (lines 67-73)

```python
m = lhs.shape[0]                              # remember the original m
pad_size = 0
alignment = 32 if use_gmm_v2 else 128         # v2: 32, v1: 128
if not interpret and m % alignment != 0:
    pad_size = alignment - (m % alignment)
    lhs = jax.lax.pad(lhs, jnp.zeros((), dtype=lhs.dtype),
                      ((0, pad_size, 0), (0, 0, 0)))
    group_sizes = group_sizes.at[-1].add(pad_size)   # last expert absorbs the pad rows
```

### Half 2 — slice back after the kernel (lines 114-116)

```python
if pad_size > 0:
    out = out[:m]                             # caller sees exactly the original m rows
return out
```

The caller's `out.shape[0]` is always `== lhs.shape[0]` it passed in. The padding is fully invisible to anything above this function.

## Why the contract holds for every code path

### v2 path (no quantization or per-channel scale — the common case)

Wrapper alignment: 32. Kernel real requirement: **none on m**.

`gmm_v2` (`gmm_v2.py:690-720`) only asserts shape, not divisibility:

```python
assert lhs.shape == (size_m, size_k)
size_lhs_sublane = pltpu.get_tpu_info().get_sublane_tiling(lhs.dtype)
size_lhs_sublane = min(size_lhs_sublane, size_m)   # auto-clamps sublane to fit any m
```

and the kernel body uses Pallas's partial-tile primitive (`gmm_v2.py:126`):

```python
bounded_slice_gm = pl.BoundedSlice(cfgs.tiles.tile_m // cfgs.dims.size_lhs_sublane)
```

`pl.BoundedSlice` automatically handles "the last tile has fewer rows than `tile_m`". **The v2 kernel is mathematically correct for arbitrary `m`**; the wrapper's pad-to-32 is a perf hint (avoid pathological tiny `m` going through the partial-tile branch), not a correctness requirement.

### v1 path (subchannel quantization / older kernel)

Wrapper alignment: 128. Kernel real requirement: **`m % tile_m == 0`** is hard-enforced (`gmm.py:77-81`):

```python
def _calculate_num_tiles(x: int, tx: int) -> int:
    tiles, rem = divmod(x, tx)
    if rem:
        raise ValueError(f"{x} must be divisible by x-dimension tile size ({tx}).")
    return tiles
```

Unlike v2, v1 does not use `BoundedSlice` — it really requires `m` to divide `tile_m`. But v1's `tile_m` candidates are constrained to multiples of 128 by `tuned_block_sizes.py:562`:

```python
tm = round_up_to_multiple_of_128_within_limit(2 * m // g, 512)
tm = min(tm, m)  # there's a requirement that m % tm == 0
```

so the candidate set is `{128, 256, 384, 512}` ⊆ multiples of 128. After the wrapper pads `m` to a multiple of 128, `m % 128 == 0` ⇒ `m % {128, 256, 384, 512} == 0` ⇒ `_calculate_num_tiles` cannot raise. **On v1 the wrapper's 128-pad is correctness-mandatory and provably sufficient.**

### Boundary cases that bypass the kernel entirely

- **Interpret mode** (CPU testing): `not interpret` short-circuits the pad branch (`megablox_gmm_backend.py:70`). Interpret mode runs the Python emulator, not Pallas tile splitting; no alignment constraint exists, so no pad is needed.
- **`m == 0`**: `EPMoE._gmm_compute:584-585` already early-returns:

  ```python
  if token_indices.shape[0] == 0:
      return jnp.zeros((0, wo_kernel.shape[-1]), dtype=inputs_2d.dtype)
  ```

  so `gmm()` is never reached.

### Contract summary

| Path | wrapper alignment | kernel's real requirement on m | what wrapper's pad does | failure mode |
|---|---|---|---|---|
| v2 (no/per-channel quant) | 32 | none (BoundedSlice handles any m) | perf hint, avoids pathological partial tile | 0 — kernel runs at any m |
| v1 (subchannel quant) | 128 | `m % tile_m == 0` with `tile_m ∈ {128, 256, 384, 512}` | rounds m up to 128k → divisibility provably satisfied | 0 — constraint always met after pad |
| interpret (CPU) | pad skipped | none | — | 0 — no Pallas tiling involved |
| `m == 0` | gmm not entered | — | — | 0 — caller early-returns |

The caller's only obligation is `lhs.shape == (m, k)` and `group_sizes.sum() == m`. Everything about alignment, padding, and slicing back to `m` is owned end-to-end by `megablox_gmm_backend.gmm`.

## Why the outer pad actively breaks v2

Given the contract above, the outer pad in `EPMoE._gmm_compute` adds nothing for correctness. But it **is** harmful on v2:

- v2's internal alignment is **32**, but the outer code rounds up to **128** — a 4x over-pad on the v2 path.
- After the outer pre-pad, `gmm_v2` sees a much larger `m` than the caller actually has, and the auto-tiler (`calculate_tiling`) picks a tile size optimized for that inflated `m`.
- For some shape × tile combinations, the chosen larger tile trips an on-device check at the SparseCore stage and the kernel halts:

  ```
  INTERNAL: Accelerator device halted prematurely, perhaps due to
  an on-device check-failure. Node ... halted unexpectedly at tag:pc
  SparseCoreSequencer:0:0x9 ...
  ```

Without the outer pre-pad, v2 sees the caller's natural `m`, picks a smaller tile that doesn't trigger the check, and runs cleanly.

## Coverage matrix (delete the outer pad → all cases fall back to the wrapper)

| Model | top_k | bs | x.shape[0] = bs·top_k | wrapper alignment (v2) | net pad | result |
|---|---|---|---|---|---|---|
| Ling-2.6-Flash (BailingMoE) | 8 | 8 | 64 | 32 | 0 (already aligned) | runs at m=64 |
| DeepSeek-V3 | 8 | 4 | 32 | 32 | 0 | runs at m=32 |
| Qwen3-MoE | 8 | 8 | 64 | 32 | 0 | runs at m=64 |
| Grok-2 | 2 | 8 | 16 | 32 | 16 → m=32 (sliced back to 16) | runs at m=32 |
| **DeepSeek-V2-Lite** (the case the original `TODO(Qinghan)` worried about) | 6 | 4 | 24 | 32 | 8 → m=32 (sliced back to 24) | runs at m=32 |
| FP8-quantized models on v1 path | any | any | any | 128 | rounded up to 128 (sliced back) | divides any tile_m candidate |

The original `TODO(Qinghan)` justified the sublane-aligned outer pad with DeepSeek-V2-Lite's `top_k=6` (e.g. `bs=4 → m=24`). That case is already covered by the wrapper's v2 alignment of 32. The 128-aligned `gmm_tile_m` workaround on top of that was a second redundant layer, not a fix.

## Fix

Delete the outer pad block in `EPMoE._gmm_compute`. Let `megablox_gmm_backend.gmm` be the single source of truth for LHS alignment. (See diff: `+9 / -16`.)

## Why this is safe

- **No correctness regression**: every shape reachable by callers is still aligned by the wrapper before the kernel sees it; `out = out[:m]` gives callers exactly the same logical output rows as before.
- **No quantization regression**: the v1 / FP8 alignment requirement (`m % tile_m == 0`, tile_m ∈ {128, 256, 384, 512}) is still enforced by the wrapper's `alignment = 128`.
- **No DeepSeek-V2-Lite regression**: see coverage matrix — `top_k=6` cases still get padded to a multiple of 32 by megablox v2 and sliced back.
- **No `_unpermute` mismatch**: the outer pad's `group_sizes.at[-1].add(pad_size)` and the wrapper's are functionally identical; from the caller's perspective `gmm` returns exactly `m` rows in both cases (it slices `out[:m]` before returning), so the downstream `_unpermute` sees the same shape it always did.
- **Performance neutral or better**: removes the 4x over-pad on the v2 path; for shapes that were already aligned to 128, the kernel still pads internally to 128 (no change).
- **Cleaner contract**: the leaky abstraction (outer code "knowing" `tile_m=128`) is removed. Future changes to the kernel's alignment policy (e.g. a v3 that uses 64) won't need a corresponding edit in `EPMoE`.

## Verification

Reproduced on a serving deployment that previously crashed in `_precompile_decode` with the SparseCore halt above; after this fix the precompile completes, the server reaches `ready to roll`, and downstream end-to-end accuracy is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)