### PR TITLE
refactor(spec): split EAGLEWorker into BaseSpecWorker/BaseDraftWorker…

### DIFF
--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -3,8 +3,24 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+import jax
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
 if TYPE_CHECKING:
     from sgl_jax.srt.managers.tp_worker import ModelWorker
+
+
+def replicate_to_mesh(
+    mesh: jax.sharding.Mesh, *arrs: jax.Array
+) -> tuple[jax.Array, ...] | jax.Array:
+    """Replicate arrays across a mesh under explicit sharding.
+
+    JIT outputs are typically vocab/data-sharded; spec-decode host orchestration
+    (top_k, gather, build_tree) needs replicated arrays.
+    """
+    out = jax.device_put(arrs, NamedSharding(mesh, P()))
+    return out[0] if len(out) == 1 else out
 
 
 class BaseDraftWorker(ABC):
@@ -19,6 +35,16 @@ class BaseDraftWorker(ABC):
     @abstractmethod
     def draft(self):
         pass
+
+    @property
+    @abstractmethod
+    def sampling_rngs(self):
+        """RNGs used by the spec worker's tree-sampling step.
+
+        Concrete implementations decide which runner's rngs to expose.
+        Single-runner workers usually return ``self.draft_model_runner.rngs``;
+        multi-runner workers (MTP) return the rngs from a designated runner.
+        """
 
 
 class BaseSpecWorker(ABC):

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import jax
+
+    from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
+    from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+    from sgl_jax.srt.model_executor.model_runner import ModelRunner
+
+
+class BaseDraftWorker(ABC):
+    """Draft model worker interface for speculative decoding.
+
+    Concrete implementations hold the draft model runner and own all
+    draft-specific logic (multi-step decode, tree building, extend).
+    Standard EAGLE uses ``EagleDraftWorker``; MTP will use
+    ``MultiLayerDraftWorker``.
+    """
+
+    @property
+    @abstractmethod
+    def draft_model_runner(self) -> ModelRunner: ...
+
+    @abstractmethod
+    def draft(self, model_worker_batch: ModelWorkerBatch) -> None:
+        """Run multi-step draft decode.
+
+        Mutates ``model_worker_batch.spec_info`` from an
+        ``EagleDraftInput`` to an ``EagleVerifyInput``.
+        """
+
+    @abstractmethod
+    def draft_extend_for_prefill(
+        self,
+        model_worker_batch: ModelWorkerBatch,
+        hidden_states: jax.Array,
+        next_token_ids: jax.Array,
+    ) -> None:
+        """Run draft model extend after target prefill.
+
+        Populates ``model_worker_batch.spec_info`` with the draft state
+        needed for the next decode round.
+        """
+
+    @abstractmethod
+    def draft_extend_for_decode(
+        self,
+        model_worker_batch: ModelWorkerBatch,
+        batch_output: GenerationBatchResult,
+    ) -> None:
+        """Run draft extend after target verify.
+
+        Updates ``batch_output.next_draft_input`` with hidden_states,
+        topk_p, topk_index for the next decode iteration.
+        """
+
+
+class BaseSpecWorker(ABC):
+    """Speculative decode orchestrator.
+
+    Owns a ``target_worker`` (the full model) and a ``draft_worker``
+    (the draft/MTP model).  Subclasses implement the top-level
+    ``forward_batch_speculative_generation`` entry point; shared logic
+    such as ``verify`` lives here.
+    """
+
+    def __init__(self, server_args, target_worker, draft_worker: BaseDraftWorker):
+        self.server_args = server_args
+        self.target_worker = target_worker
+        self.draft_worker = draft_worker
+
+        self.topk = server_args.speculative_eagle_topk
+        self.speculative_num_steps = server_args.speculative_num_steps
+        self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
+        self.page_size = server_args.page_size
+        self.mesh = target_worker.mesh
+
+        from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
+
+        self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
+
+    @abstractmethod
+    def forward_batch_speculative_generation(
+        self, model_worker_batch: ModelWorkerBatch
+    ) -> GenerationBatchResult:
+        """Main entry point called by the scheduler."""

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -36,16 +36,6 @@ class BaseDraftWorker(ABC):
     def draft(self):
         pass
 
-    @property
-    @abstractmethod
-    def sampling_rngs(self):
-        """RNGs used by the spec worker's tree-sampling step.
-
-        Concrete implementations decide which runner's rngs to expose.
-        Single-runner workers usually return ``self.draft_model_runner.rngs``;
-        multi-runner workers (MTP) return the rngs from a designated runner.
-        """
-
 
 class BaseSpecWorker(ABC):
     """Speculative decode orchestrator.

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -38,7 +38,3 @@ class BaseSpecWorker(ABC):
     @abstractmethod
     def draft_worker(self) -> BaseDraftWorker:
         pass
-
-    @abstractmethod
-    def clear_cache_pool(self):
-        pass

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -42,11 +42,3 @@ class BaseSpecWorker(ABC):
     @abstractmethod
     def clear_cache_pool(self):
         pass
-
-    def on_verify_complete_cpu(self, num_correct_drafts_per_req: list[int]) -> None:  # noqa: B027
-        """Hook called after verify finishes and accept counts are on CPU.
-
-        Default no-op. Adaptive-aware workers override this to feed the
-        controller without forcing a GPU->CPU sync in the worker hot path.
-        """
-        pass

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -4,11 +4,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import jax
-
-    from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
-    from sgl_jax.srt.managers.scheduler import GenerationBatchResult
-    from sgl_jax.srt.model_executor.model_runner import ModelRunner
+    from sgl_jax.srt.managers.tp_worker import ModelWorker
 
 
 class BaseDraftWorker(ABC):
@@ -20,74 +16,37 @@ class BaseDraftWorker(ABC):
     ``MultiLayerDraftWorker``.
     """
 
-    @property
     @abstractmethod
-    def draft_model_runner(self) -> ModelRunner: ...
-
-    @abstractmethod
-    def draft(self, model_worker_batch: ModelWorkerBatch) -> None:
-        """Run multi-step draft decode.
-
-        Mutates ``model_worker_batch.spec_info`` from an
-        ``EagleDraftInput`` to an ``EagleVerifyInput``.
-        """
-
-    @abstractmethod
-    def draft_extend_for_prefill(
-        self,
-        model_worker_batch: ModelWorkerBatch,
-        hidden_states: jax.Array,
-        next_token_ids: jax.Array,
-    ) -> None:
-        """Run draft model extend after target prefill.
-
-        Populates ``model_worker_batch.spec_info`` with the draft state
-        needed for the next decode round.
-        """
-
-    @abstractmethod
-    def draft_extend_for_decode(
-        self,
-        model_worker_batch: ModelWorkerBatch,
-        batch_output: GenerationBatchResult,
-    ) -> None:
-        """Run draft extend after target verify.
-
-        Updates ``batch_output.next_draft_input`` with hidden_states,
-        topk_p, topk_index for the next decode iteration.
-        """
+    def draft(self):
+        pass
 
 
 class BaseSpecWorker(ABC):
     """Speculative decode orchestrator.
 
     Owns a ``target_worker`` (the full model) and a ``draft_worker``
-    (the draft/MTP model).  Subclasses implement the top-level
-    ``forward_batch_speculative_generation`` entry point; shared logic
-    such as ``verify`` lives here.
+    (the draft/MTP model).  Concrete subclasses implement the main
+    entry point and connect their specific draft/verify logic.
     """
 
-    def __init__(self, server_args, target_worker, draft_worker: BaseDraftWorker):
-        self.server_args = server_args
-        self.target_worker = target_worker
-        self.draft_worker = draft_worker
+    @property
+    @abstractmethod
+    def target_worker(self) -> ModelWorker:
+        pass
 
-        self.topk = server_args.speculative_eagle_topk
-        self.speculative_num_steps = server_args.speculative_num_steps
-        self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
-        self.page_size = server_args.page_size
-        self.mesh = target_worker.mesh
-
-        from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
-
-        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
-            server_args.speculative_algorithm
-        )
-
-        self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
+    @property
+    @abstractmethod
+    def draft_worker(self) -> BaseDraftWorker:
+        pass
 
     @abstractmethod
-    def forward_batch_speculative_generation(
-        self, model_worker_batch: ModelWorkerBatch
-    ) -> GenerationBatchResult:
-        """Main entry point called by the scheduler."""
+    def clear_cache_pool(self):
+        pass
+
+    def on_verify_complete_cpu(self, num_correct_drafts_per_req: list[int]) -> None:  # noqa: B027
+        """Hook called after verify finishes and accept counts are on CPU.
+
+        Default no-op. Adaptive-aware workers override this to feed the
+        controller without forcing a GPU->CPU sync in the worker hot path.
+        """
+        pass

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -1,0 +1,643 @@
+import functools
+import logging
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessorOutput
+from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
+from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+from sgl_jax.srt.managers.tp_worker import ModelWorker
+from sgl_jax.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
+from sgl_jax.srt.speculative.base_worker import BaseDraftWorker
+from sgl_jax.srt.speculative.eagle_util import (
+    EagleDraftInput,
+    EagleVerifyInput,
+    build_tree_kernel_efficient,
+    build_tree_mask_for_draft_decode,
+)
+from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+from sgl_jax.srt.utils.common_utils import get_bool_env_var
+from sgl_jax.srt.utils.jax_utils import device_array
+
+logger = logging.getLogger(__name__)
+RETURN_ORIGINAL_LOGPROB = get_bool_env_var("RETURN_ORIGINAL_LOGPROB")
+
+
+class EagleDraftWorker(ModelWorker, BaseDraftWorker):
+    """EAGLE draft model worker.
+
+    Holds the draft model runner and implements draft-specific logic:
+    multi-step decode, tree building, prefill extend, and decode extend.
+    """
+
+    def __init__(self, server_args, target_worker: ModelWorker):
+        self.server_args = server_args
+        self.target_worker_ref = target_worker
+        self.topk = server_args.speculative_eagle_topk
+        self.speculative_num_steps = server_args.speculative_num_steps
+        self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
+        self.page_size = server_args.page_size
+        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
+        self.hot_token_ids = None
+
+        req_to_token_pool, _ = target_worker.get_memory_pool()
+
+        # ModelWorker.__init__ creates the draft model runner
+        # (must be called last to ensure model state is correct)
+        super().__init__(
+            server_args,
+            target_worker.mesh,
+            req_to_token_pool=req_to_token_pool,
+            is_draft_worker=True,
+        )
+
+        EagleDraftInput.ALLOC_LEN_PER_DECODE = max(
+            self.speculative_num_steps * self.topk, self.speculative_num_draft_tokens
+        )
+
+        self._share_embed_head(target_worker)
+
+        target_slot_range = target_worker.model_runner.max_total_num_tokens
+        draft_pool_size = self.draft_model_runner.max_total_num_tokens
+        assert draft_pool_size >= target_slot_range, (
+            f"Draft KV pool ({draft_pool_size}) must be >= "
+            f"target slot range ({target_slot_range}). "
+            "Check --mem-fraction-static or --kv-cache-dtype."
+        )
+
+        self.model_runner.initialize_jit()
+
+        (
+            precompile_token_paddings,
+            precompile_bs_paddings,
+            precompile_cache_loc_paddings,
+        ) = target_worker.get_precompile_paddings()
+        self.precompile_bs_paddings = precompile_bs_paddings
+        self.precompile_cache_loc_paddings = precompile_cache_loc_paddings
+        self.precompile_token_paddings = precompile_token_paddings
+
+    def _share_embed_head(self, target_worker: ModelWorker):
+        embed, head = target_worker.model_runner.model.get_embed_and_head()
+
+        if self.speculative_algorithm.is_eagle3():
+            if (
+                hasattr(self.draft_model_runner.model, "load_lm_head_from_target")
+                and self.draft_model_runner.model.load_lm_head_from_target
+            ):
+                self.draft_model_runner.model.set_embed_and_head(embed, head)
+            else:
+                self.draft_model_runner.model.set_embed(embed)
+
+            if self.draft_model_runner.model.hot_token_ids is not None:
+                self.hot_token_ids = device_array(
+                    self.draft_model_runner.model.hot_token_ids,
+                    sharding=(NamedSharding(self.model_runner.mesh, P())),
+                )
+        else:
+            if self.hot_token_ids is not None:
+                head = head.clone()
+                self.hot_token_ids = device_array(
+                    self.draft_model_runner.model.hot_token_ids,
+                    sharding=(NamedSharding(self.model_runner.mesh, P())),
+                )
+                head.data = head.data[self.hot_token_ids]
+
+            self.draft_model_runner.model.set_embed_and_head(embed, head)
+
+    @property
+    def draft_model_runner(self):
+        return self.get_model_runner()
+
+    # -- BaseDraftWorker interface --
+
+    def draft(self, model_worker_batch: ModelWorkerBatch) -> None:
+        self.padding_for_decode(model_worker_batch)
+        score_list, token_list, parents_list = self.draft_forward(model_worker_batch)
+        verified_seq_lens = model_worker_batch.seq_lens - 1
+        max_seq_len = int(np.max(verified_seq_lens)) if verified_seq_lens.size > 0 else 1
+        max_context_len = self._pick_context_len(max_seq_len)
+        (
+            tree_mask,
+            position,
+            retrive_index,
+            retrive_next_token,
+            retrive_next_sibling,
+            draft_tokens,
+        ) = build_tree_kernel_efficient(
+            model_worker_batch.spec_info.verified_id,
+            score_list,
+            token_list,
+            parents_list,
+            verified_seq_lens,
+            np.sum(verified_seq_lens),
+            self.topk,
+            self.speculative_num_draft_tokens,
+            max_context_len,
+            model_worker_batch.seq_lens.shape[0],
+            model_worker_batch.speculative_num_steps,
+            self.mesh,
+        )
+        model_worker_batch.spec_info = EagleVerifyInput(
+            draft_token=draft_tokens,
+            custom_mask=tree_mask,
+            positions=position,
+            retrive_index=retrive_index,
+            retrive_next_token=retrive_next_token,
+            retrive_next_sibling=retrive_next_sibling,
+            retrive_cum_len=None,
+            spec_steps=self.speculative_num_steps,
+            topk=self.topk,
+            draft_token_num=self.speculative_num_draft_tokens,
+            capture_hidden_mode=CaptureHiddenMode.LAST,
+            seq_lens_sum=model_worker_batch.seq_lens_sum,
+            seq_lens_cpu=model_worker_batch.seq_lens,
+        )
+
+    def draft_extend_for_prefill(
+        self,
+        model_worker_batch: ModelWorkerBatch,
+        hidden_states: jax.Array,
+        next_token_ids: jax.Array,
+    ) -> None:
+        verified_id_np = np.asarray(jax.device_get(next_token_ids))[: model_worker_batch.real_bs]
+        model_worker_batch.spec_info = EagleDraftInput(
+            hidden_states=hidden_states,
+            verified_id=verified_id_np,
+            num_tokens_per_batch=np.asarray(1, dtype=jnp.int32),
+            num_tokens_for_logprob_per_batch=np.asarray(1, dtype=jnp.int32),
+            allocate_lens=model_worker_batch.seq_lens,
+        )
+        model_worker_batch.return_hidden_states = False
+        model_worker_batch.spec_info.prepare_for_extend_after_target_prefill(
+            model_worker_batch=model_worker_batch
+        )
+        model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.LAST
+        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
+        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
+        forward_batch.return_logprob = False
+
+        forward_metadata = self.draft_model_runner.attn_backend.get_eagle_forward_metadata(
+            model_worker_batch
+        )
+
+        self.draft_model_runner.attn_backend.forward_metadata = forward_metadata
+        forward_batch.forward_mode = ForwardMode.EXTEND
+
+        logits_output, _, _ = self.draft_model_runner.forward(
+            forward_batch,
+            logits_metadata=LogitsMetadata.from_model_worker_batch(model_worker_batch, self.mesh),
+        )
+        logits_output.next_token_logits = logits_output.next_token_logits[
+            : model_worker_batch.real_bs, :
+        ]
+        if len(logits_output.hidden_states.shape) == 1:
+            logits_output.hidden_states = jnp.expand_dims(logits_output.hidden_states, axis=0)
+        assert isinstance(forward_batch.spec_info, EagleDraftInput)
+        forward_batch.spec_info.allocate_lens = model_worker_batch.seq_lens[
+            : model_worker_batch.real_bs
+        ]
+
+        self.capture_for_decode(logits_output, forward_batch.spec_info)
+
+    def draft_extend_for_decode(
+        self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
+    ) -> None:
+        if batch_output.next_draft_input.verified_id.shape[0] <= 0:
+            return
+        draft_input = EagleDraftInput(
+            hidden_states=batch_output.logits_output.hidden_states,
+            allocate_lens=batch_output.allocate_lens,
+        )
+        model_worker_batch, logits_metadata = draft_input.prepare_for_extend_after_verify(
+            model_worker_batch,
+            self.draft_model_runner,
+            batch_output,
+            self.speculative_num_draft_tokens,
+        )
+
+        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
+        if forward_batch.input_ids.shape[0] <= 0:
+            return
+        draft_logits_output, _, _ = self.draft_model_runner.forward(
+            forward_batch,
+            logits_metadata=logits_metadata,
+        )
+        select_index = (
+            np.arange(len(model_worker_batch.seq_lens[: model_worker_batch.real_bs]))
+            * (self.speculative_num_steps + 1)
+            + batch_output.accept_lens[: model_worker_batch.real_bs]
+            - 1
+        )
+        rep_logits, rep_hidden = self._replicate(
+            draft_logits_output.next_token_logits, draft_logits_output.hidden_states
+        )
+        draft_logits_output.next_token_logits = rep_logits[select_index]
+        draft_logits_output.hidden_states = rep_hidden[select_index]
+        topk_p, topk_index = topk_probs_from_logits(
+            draft_logits_output.next_token_logits, self.topk
+        )
+
+        batch_output.next_draft_input.hidden_states = draft_logits_output.hidden_states
+        batch_output.next_draft_input.topk_p = topk_p
+        batch_output.next_draft_input.topk_index = topk_index
+        batch_output.next_draft_input.verified_id = batch_output.next_draft_input.verified_id[
+            select_index
+        ]
+        batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
+        batch_output.accept_lens = batch_output.accept_lens[: model_worker_batch.real_bs]
+
+    # -- Internal draft helpers --
+
+    def _replicate(self, *arrs: jax.Array) -> tuple[jax.Array, ...] | jax.Array:
+        rep = NamedSharding(self.mesh, P())
+        out = jax.device_put(arrs, rep)
+        return out[0] if len(out) == 1 else out
+
+    def capture_for_decode(
+        self, logits_output: LogitsProcessorOutput, draft_input: EagleDraftInput
+    ):
+        topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
+        draft_input.topk_p = topk_p
+        draft_input.topk_index = topk_index
+        draft_input.hidden_states = self._replicate(logits_output.hidden_states)
+
+    def padding_for_decode(self, model_worker_batch: ModelWorkerBatch):
+        _, padding_bs_index = self.get_padding_bs(model_worker_batch.real_bs)
+        self.copy_model_worker_batch_to_cpu(model_worker_batch)
+        model_worker_batch.spec_info.prepare_for_draft_decode(
+            model_worker_batch, self.topk, self.speculative_num_steps
+        )
+        model_worker_batch.seq_lens = model_worker_batch.seq_lens
+        seq_lens_cpu = model_worker_batch.seq_lens
+        page_size = self.page_size
+        req_to_token_pool, _ = self.target_worker_ref.get_memory_pool()
+        token_indices_with_all_reqs = req_to_token_pool.req_to_token[
+            model_worker_batch.req_pool_indices
+        ]
+        spec_info = model_worker_batch.spec_info
+        assert isinstance(spec_info, EagleDraftInput)
+        cache_loc_flat = np.array([], dtype=np.int32)
+        if len(seq_lens_cpu) > 0:
+            valid_mask = seq_lens_cpu > 0
+            if np.any(valid_mask):
+                valid_indices = np.where(valid_mask)[0]
+                valid_allocate_lens = spec_info.allocate_lens[valid_mask]
+                aligned_lengths = ((valid_allocate_lens + page_size - 1) // page_size) * page_size
+                total_aligned_length = np.sum(aligned_lengths)
+                cache_loc_flat = np.zeros(total_aligned_length, dtype=np.int32)
+                offset = 0
+                for i, (seq_idx, allocate_len, aligned_len) in enumerate(
+                    zip(valid_indices, valid_allocate_lens, aligned_lengths)
+                ):
+                    cache_loc_flat[offset : offset + allocate_len] = token_indices_with_all_reqs[
+                        seq_idx, :allocate_len
+                    ]
+                    offset += aligned_len
+        total_cache_loc_size = self.precompile_cache_loc_paddings[padding_bs_index]
+        assert total_cache_loc_size >= len(cache_loc_flat)
+        cache_loc_cpu = np.empty(total_cache_loc_size, dtype=np.int32)
+        if len(cache_loc_flat) > 0:
+            cache_loc_cpu[: len(cache_loc_flat)] = cache_loc_flat
+        if len(cache_loc_flat) < total_cache_loc_size:
+            cache_loc_cpu[len(cache_loc_flat) :] = 0
+
+        model_worker_batch.cache_loc = cache_loc_cpu
+        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
+
+        topk_index = spec_info.topk_index
+        if self.hot_token_ids is not None:
+            model_worker_batch.spec_info.topk_index = self.hot_token_ids[topk_index]
+        if self.topk > 1:
+            self.draft_model_runner.attn_backend.forward_metadata.custom_mask = (
+                build_tree_mask_for_draft_decode(
+                    model_worker_batch.seq_lens,
+                    topk=topk_index.shape[1],
+                    speculative_step_id=0,
+                    parents_list=None,
+                )
+            )
+        bs = self.precompile_bs_paddings[padding_bs_index]
+        if bs - model_worker_batch.spec_info.verified_id.shape[0] > 0:
+            model_worker_batch.spec_info.verified_id = np.pad(
+                model_worker_batch.spec_info.verified_id,
+                ((0, bs - model_worker_batch.spec_info.verified_id.shape[0]),),
+            )
+        if bs - model_worker_batch.spec_info.topk_p.shape[0] > 0:
+            model_worker_batch.spec_info.topk_p = np.pad(
+                model_worker_batch.spec_info.topk_p,
+                (
+                    (0, bs - model_worker_batch.spec_info.topk_p.shape[0]),
+                    (0, 0),
+                ),
+            )
+        if bs - model_worker_batch.seq_lens.shape[0] > 0:
+            model_worker_batch.seq_lens = np.pad(
+                model_worker_batch.seq_lens, ((0, bs - model_worker_batch.seq_lens.shape[0]),)
+            )
+            if model_worker_batch.spec_info.allocate_lens is not None:
+                model_worker_batch.spec_info.allocate_lens = np.pad(
+                    model_worker_batch.spec_info.allocate_lens,
+                    ((0, bs - model_worker_batch.spec_info.allocate_lens.shape[0]),),
+                )
+        if bs - model_worker_batch.spec_info.topk_index.shape[0] > 0:
+            model_worker_batch.spec_info.topk_index = np.pad(
+                model_worker_batch.spec_info.topk_index,
+                (
+                    (0, bs - model_worker_batch.spec_info.topk_index.shape[0]),
+                    (0, 0),
+                ),
+            )
+        if bs - model_worker_batch.spec_info.hidden_states.shape[0] > 0:
+            model_worker_batch.spec_info.hidden_states = np.pad(
+                model_worker_batch.spec_info.hidden_states,
+                (
+                    (0, bs - model_worker_batch.spec_info.hidden_states.shape[0]),
+                    (0, 0),
+                ),
+            )
+        model_worker_batch.speculative_eagle_topk = self.topk
+        model_worker_batch.speculative_num_steps = self.speculative_num_steps
+        model_worker_batch.speculative_num_draft_tokens = self.speculative_num_draft_tokens
+        model_worker_batch.input_ids = np.empty(bs * self.topk, np.int32)
+        model_worker_batch.positions = np.empty(bs * self.topk, np.int32)
+
+    def draft_forward(self, model_worker_batch: ModelWorkerBatch):
+        topk_p, topk_index, hidden_states = (
+            model_worker_batch.spec_info.topk_p,
+            model_worker_batch.spec_info.topk_index,
+            model_worker_batch.spec_info.hidden_states,
+        )
+        bs = model_worker_batch.seq_lens.shape[0]
+        step_min_1 = self.speculative_num_steps - 1
+        score_list: jax.Array = jnp.empty((bs, 1 + step_min_1 * self.topk, self.topk))
+        token_list: jax.Array = jnp.empty(
+            (bs, self.topk + step_min_1 * self.topk * self.topk), dtype=jnp.int32
+        )
+        parents_list: jax.Array = jnp.empty((bs, self.topk + 1 + step_min_1 * self.topk))
+        scores = None
+        positions_base = device_array(
+            np.repeat(model_worker_batch.seq_lens, self.topk),
+            sharding=(NamedSharding(self.model_runner.mesh, P())),
+        )
+        logits_metadata = None
+        metadata_per_step = self.draft_model_runner.attn_backend.get_eagle_multi_step_metadata(
+            model_worker_batch,
+        )
+        assert isinstance(metadata_per_step, list)
+        logits_metadata = LogitsMetadata.from_model_worker_batch(
+            model_worker_batch, self.draft_model_runner.mesh
+        )
+        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
+        forward_batch.out_cache_loc = np.empty((1,))
+        forward_batch.cache_loc = np.empty((1,))
+        forward_batch.spec_info = EagleDraftInput()
+        forward_batch.spec_info.hidden_states = jnp.empty((bs * self.topk, hidden_states.shape[1]))
+        for i in range(self.speculative_num_steps):
+
+            input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
+                i, topk_p, topk_index, hidden_states, scores, self.topk
+            )
+            score_list, token_list, parents_list = update_eagle_lists(
+                i, score_list, token_list, parents_list, tree_info, self.topk
+            )
+            if i == self.speculative_num_steps - 1:
+                break
+
+            forward_batch = update_forward_batch_info(
+                forward_batch, i, input_ids, hidden_states, positions_base
+            )
+            self.draft_model_runner.attn_backend.forward_metadata = metadata_per_step[i]
+
+            forward_batch.bid = model_worker_batch.bid
+            logits_output, _, _ = self.draft_model_runner.forward(
+                forward_batch,
+                logits_metadata=logits_metadata,
+            )
+
+            topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
+
+            if self.hot_token_ids is not None:
+                topk_index = self.hot_token_ids[topk_index]
+            hidden_states = self._replicate(logits_output.hidden_states)
+
+        return score_list, token_list, parents_list
+
+    def _pick_context_len(self, max_seq_len: int) -> int:
+        max_seq_len = max(int(max_seq_len), 1)
+        if self.precompile_token_paddings:
+            for padding in self.precompile_token_paddings:
+                if padding >= max_seq_len:
+                    return padding
+        return 1 << (max_seq_len - 1).bit_length()
+
+    def copy_model_worker_batch_to_cpu(self, model_worker_batch: ModelWorkerBatch):
+        model_worker_batch.input_ids = np.array(
+            jax.device_get(model_worker_batch.input_ids), dtype=model_worker_batch.input_ids.dtype
+        )
+        model_worker_batch.seq_lens = np.array(
+            jax.device_get(model_worker_batch.seq_lens), dtype=model_worker_batch.seq_lens.dtype
+        )
+        model_worker_batch.out_cache_loc = np.array(
+            jax.device_get(model_worker_batch.out_cache_loc),
+            dtype=model_worker_batch.out_cache_loc.dtype,
+        )
+        model_worker_batch.positions = np.array(
+            jax.device_get(model_worker_batch.positions), dtype=model_worker_batch.positions.dtype
+        )
+        model_worker_batch.req_pool_indices = np.array(
+            jax.device_get(model_worker_batch.req_pool_indices),
+            dtype=model_worker_batch.req_pool_indices.dtype,
+        )
+        model_worker_batch.cache_loc = np.array(
+            jax.device_get(model_worker_batch.cache_loc), dtype=model_worker_batch.cache_loc.dtype
+        )
+        model_worker_batch.extend_prefix_lens = (
+            np.array(
+                jax.device_get(model_worker_batch.extend_prefix_lens),
+                dtype=model_worker_batch.extend_prefix_lens.dtype,
+            )
+            if model_worker_batch.extend_prefix_lens is not None
+            else None
+        )
+        model_worker_batch.extend_seq_lens = (
+            np.array(
+                jax.device_get(model_worker_batch.extend_seq_lens),
+                dtype=model_worker_batch.extend_seq_lens.dtype,
+            )
+            if model_worker_batch.extend_seq_lens is not None
+            else None
+        )
+
+    def get_padding_bs(self, real_bs: int) -> int:
+        self.precompile_bs_paddings.sort()
+        select_bs_index = -1
+        bs_padding_size = 0
+        for i, size in enumerate(self.precompile_bs_paddings):
+            if size >= real_bs:
+                bs_padding_size = size - real_bs
+                select_bs_index = i
+                break
+        if select_bs_index < 0:
+            raise RuntimeError("did not get comperate padding bs, it should not happened")
+        return bs_padding_size, select_bs_index
+
+
+# ---------------------------------------------------------------------------
+# Module-level JIT helpers (used exclusively by EagleDraftWorker)
+# ---------------------------------------------------------------------------
+
+
+@functools.partial(jax.jit, static_argnames=["topk"])
+def topk_probs_from_logits(
+    logits: jax.Array, topk: int, axis: int = -1
+) -> tuple[jax.Array, jax.Array]:
+    """Return top-k probabilities without materializing the full softmax tensor."""
+    working_logits = jnp.moveaxis(logits, axis, -1) if axis != -1 else logits
+    # TODO(#1053 Phase 2): replace this all-gather with a sharded top-k +
+    # logsumexp over the vocab axis for DP/TP scalability.
+    sh = jax.typeof(working_logits).sharding
+    if isinstance(sh, NamedSharding):
+        working_logits = jax.sharding.reshard(working_logits, NamedSharding(sh.mesh, P()))
+    topk_logits, topk_index = jax.lax.top_k(working_logits, topk)
+    logsumexp = jax.nn.logsumexp(working_logits, axis=-1, keepdims=True)
+    topk_probs = jnp.exp(topk_logits - logsumexp)
+
+    if axis != -1:
+        topk_probs = jnp.moveaxis(topk_probs, -1, axis)
+        topk_index = jnp.moveaxis(topk_index, -1, axis)
+
+    return topk_probs, topk_index
+
+
+def fast_topk(values, topk, axis=-1):
+    working_values = jnp.moveaxis(values, axis, -1) if axis != -1 else values
+    result_vals, result_indices = jax.lax.top_k(working_values, topk)
+
+    if axis != -1:
+        result_vals = jnp.moveaxis(result_vals, -1, axis)
+        result_indices = jnp.moveaxis(result_indices, -1, axis)
+
+    return result_vals, result_indices
+
+
+@functools.partial(jax.jit, static_argnames=["i", "topk"])
+def update_eagle_lists(
+    i: int,
+    score_list: jax.Array,
+    token_list: jax.Array,
+    parents_list: jax.Array,
+    tree_info: tuple[jax.Array, jax.Array, jax.Array],
+    topk: int,
+):
+    bs = score_list.shape[0]
+    scores_update, tokens_update, parents_update = tree_info
+    if i == 0:
+        score_list = score_list.at[:bs, :1, :].set(scores_update[:bs])
+        token_list = token_list.at[:bs, :topk].set(tokens_update[:bs])
+        parents_list = parents_list.at[:bs, : topk + 1].set(parents_update[:bs])
+    else:
+        score_start = 1 + (i - 1) * topk
+        token_start = topk + (i - 1) * topk * topk
+        parent_start = topk + 1 + (i - 1) * topk
+
+        score_list = score_list.at[:bs, score_start : score_start + topk, :].set(scores_update[:bs])
+        token_list = token_list.at[:bs, token_start : token_start + topk * topk].set(
+            tokens_update[:bs]
+        )
+        parents_list = parents_list.at[:bs, parent_start : parent_start + topk].set(
+            parents_update[:bs]
+        )
+    return score_list, token_list, parents_list
+
+
+# FIXME(pc) this should be jitted or convert as np.ndarray
+# @functools.partial(jax.jit, static_argnames=["i"])
+def update_forward_batch_info(
+    forward_batch: ForwardBatch,
+    i: int,
+    input_ids: jax.Array,
+    hidden_states: jax.Array,
+    positions_base: jax.Array,
+) -> ForwardBatch:
+    forward_batch.input_ids = input_ids
+    # FIXME(pc) hiddenstate will become NAN when forward path is very long, we still have no reason for this
+    forward_batch.spec_info.hidden_states = hidden_states
+    forward_batch.positions = positions_base + i
+    return forward_batch
+
+
+def select_top_k_tokens(
+    i: int,
+    topk_p: jax.Array,
+    topk_index: jax.Array,
+    hidden_states: jax.Array,
+    scores: jax.Array,
+    topk: int,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    if i == 0:
+        return select_top_k_tokens_step_0(topk_p, topk_index, hidden_states, scores, topk)
+    else:
+        return select_top_k_tokens_step_greater_0(
+            jnp.asarray(i), topk_p, topk_index, hidden_states, scores, topk
+        )
+
+
+@functools.partial(jax.jit, static_argnames=["topk"])
+def select_top_k_tokens_step_0(
+    topk_p: jax.Array,
+    topk_index: jax.Array,
+    hidden_states: jax.Array,
+    scores: jax.Array,
+    topk: int,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    input_ids = topk_index.flatten()
+    hidden_states = jnp.repeat(hidden_states, topk, axis=0)
+    scores = topk_p
+    tree_info = (
+        jnp.expand_dims(topk_p, axis=1),
+        topk_index,
+        jnp.tile(
+            jnp.expand_dims(jnp.arange(-1, topk, dtype=jnp.float32), axis=0),
+            (topk_p.shape[0], 1),
+        ),
+    )
+    return input_ids, hidden_states, scores, tree_info
+
+
+@functools.partial(jax.jit, static_argnames=["topk"])
+def select_top_k_tokens_step_greater_0(
+    i: jax.Array,
+    topk_p: jax.Array,
+    topk_index: jax.Array,
+    hidden_states: jax.Array,
+    scores: jax.Array,
+    topk: int,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    expand_scores = jax.lax.mul(jnp.expand_dims(scores, axis=2), topk_p.reshape(-1, topk, topk))
+    topk_cs_p, topk_cs_index = fast_topk(
+        expand_scores.reshape(expand_scores.shape[0], -1), topk, axis=-1
+    )
+    scores = topk_cs_p
+    topk_index = topk_index.reshape(-1, topk**2)
+    input_ids = jnp.take_along_axis(topk_index, topk_cs_index, axis=1).flatten()
+    if hidden_states.shape[0] > 0:
+        selected_input_index = topk_cs_index.flatten() // topk + jnp.repeat(
+            jnp.arange(0, hidden_states.shape[0], topk), topk
+        )
+        hidden_states = hidden_states[selected_input_index, :]
+    tree_info = (
+        expand_scores,
+        topk_index,
+        topk_cs_index + (topk**2 * (i - 1) + topk),
+    )
+    return input_ids, hidden_states, scores, tree_info

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -121,10 +121,6 @@ class EagleDraftWorker(BaseDraftWorker):
         return self._worker.get_model_runner()
 
     @property
-    def sampling_rngs(self):
-        return self.draft_model_runner.rngs
-
-    @property
     def mesh(self):
         return self._worker.mesh
 

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -31,11 +31,12 @@ logger = logging.getLogger(__name__)
 RETURN_ORIGINAL_LOGPROB = get_bool_env_var("RETURN_ORIGINAL_LOGPROB")
 
 
-class EagleDraftWorker(ModelWorker, BaseDraftWorker):
+class EagleDraftWorker(BaseDraftWorker):
     """EAGLE draft model worker.
 
-    Holds the draft model runner and implements draft-specific logic:
-    multi-step decode, tree building, prefill extend, and decode extend.
+    Holds a ``ModelWorker`` (the draft model runner) via composition and
+    implements draft-specific logic: multi-step decode, tree building,
+    prefill extend, and decode extend.
     """
 
     def __init__(self, server_args, target_worker: ModelWorker):
@@ -52,9 +53,9 @@ class EagleDraftWorker(ModelWorker, BaseDraftWorker):
 
         req_to_token_pool, _ = target_worker.get_memory_pool()
 
-        # ModelWorker.__init__ creates the draft model runner
-        # (must be called last to ensure model state is correct)
-        super().__init__(
+        # Compose a ModelWorker for the draft model (instead of inheriting)
+        # Must be created last to ensure model state is correct.
+        self._worker = ModelWorker(
             server_args,
             target_worker.mesh,
             req_to_token_pool=req_to_token_pool,
@@ -75,7 +76,7 @@ class EagleDraftWorker(ModelWorker, BaseDraftWorker):
             "Check --mem-fraction-static or --kv-cache-dtype."
         )
 
-        self.model_runner.initialize_jit()
+        self._worker.model_runner.initialize_jit()
 
         (
             precompile_token_paddings,
@@ -101,14 +102,14 @@ class EagleDraftWorker(ModelWorker, BaseDraftWorker):
             if self.draft_model_runner.model.hot_token_ids is not None:
                 self.hot_token_ids = device_array(
                     self.draft_model_runner.model.hot_token_ids,
-                    sharding=(NamedSharding(self.model_runner.mesh, P())),
+                    sharding=(NamedSharding(self._worker.mesh, P())),
                 )
         else:
             if self.hot_token_ids is not None:
                 head = head.clone()
                 self.hot_token_ids = device_array(
                     self.draft_model_runner.model.hot_token_ids,
-                    sharding=(NamedSharding(self.model_runner.mesh, P())),
+                    sharding=(NamedSharding(self._worker.mesh, P())),
                 )
                 head.data = head.data[self.hot_token_ids]
 
@@ -116,7 +117,26 @@ class EagleDraftWorker(ModelWorker, BaseDraftWorker):
 
     @property
     def draft_model_runner(self):
-        return self.get_model_runner()
+        return self._worker.get_model_runner()
+
+    @property
+    def mesh(self):
+        return self._worker.mesh
+
+    @property
+    def model_config(self):
+        return self._worker.model_config
+
+    @property
+    def compilation_manager(self):
+        return self._worker.compilation_manager
+
+    @property
+    def max_req_len(self):
+        return self._worker.max_req_len
+
+    def get_max_padded_size(self):
+        return self._worker.get_max_padded_size()
 
     # -- BaseDraftWorker interface --
 
@@ -387,7 +407,7 @@ class EagleDraftWorker(ModelWorker, BaseDraftWorker):
         scores = None
         positions_base = device_array(
             np.repeat(model_worker_batch.seq_lens, self.topk),
-            sharding=(NamedSharding(self.model_runner.mesh, P())),
+            sharding=(NamedSharding(self.mesh, P())),
         )
         logits_metadata = None
         metadata_per_step = self.draft_model_runner.attn_backend.get_eagle_multi_step_metadata(

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -16,7 +16,7 @@ from sgl_jax.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
-from sgl_jax.srt.speculative.base_worker import BaseDraftWorker
+from sgl_jax.srt.speculative.base_worker import BaseDraftWorker, replicate_to_mesh
 from sgl_jax.srt.speculative.eagle_util import (
     EagleDraftInput,
     EagleVerifyInput,
@@ -71,9 +71,10 @@ class EagleDraftWorker(BaseDraftWorker):
         target_slot_range = target_worker.model_runner.max_total_num_tokens
         draft_pool_size = self.draft_model_runner.max_total_num_tokens
         assert draft_pool_size >= target_slot_range, (
-            f"Draft KV pool ({draft_pool_size}) must be >= "
-            f"target slot range ({target_slot_range}). "
-            "Check --mem-fraction-static or --kv-cache-dtype."
+            f"draft KV pool ({draft_pool_size}) < target allocator slot range "
+            f"({target_slot_range}); high-slot draft KV reads/writes will be "
+            f"garbage. Hybrid target without the post-set_num_token_hybrid "
+            f"draft_runner_cache_size overwrite hits this."
         )
 
         self._worker.model_runner.initialize_jit()
@@ -118,6 +119,10 @@ class EagleDraftWorker(BaseDraftWorker):
     @property
     def draft_model_runner(self):
         return self._worker.get_model_runner()
+
+    @property
+    def sampling_rngs(self):
+        return self.draft_model_runner.rngs
 
     @property
     def mesh(self):
@@ -258,8 +263,8 @@ class EagleDraftWorker(BaseDraftWorker):
             + batch_output.accept_lens[: model_worker_batch.real_bs]
             - 1
         )
-        rep_logits, rep_hidden = self._replicate(
-            draft_logits_output.next_token_logits, draft_logits_output.hidden_states
+        rep_logits, rep_hidden = replicate_to_mesh(
+            self.mesh, draft_logits_output.next_token_logits, draft_logits_output.hidden_states
         )
         draft_logits_output.next_token_logits = rep_logits[select_index]
         draft_logits_output.hidden_states = rep_hidden[select_index]
@@ -278,18 +283,13 @@ class EagleDraftWorker(BaseDraftWorker):
 
     # -- Internal draft helpers --
 
-    def _replicate(self, *arrs: jax.Array) -> tuple[jax.Array, ...] | jax.Array:
-        rep = NamedSharding(self.mesh, P())
-        out = jax.device_put(arrs, rep)
-        return out[0] if len(out) == 1 else out
-
     def capture_for_decode(
         self, logits_output: LogitsProcessorOutput, draft_input: EagleDraftInput
     ):
         topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
         draft_input.topk_p = topk_p
         draft_input.topk_index = topk_index
-        draft_input.hidden_states = self._replicate(logits_output.hidden_states)
+        draft_input.hidden_states = replicate_to_mesh(self.mesh, logits_output.hidden_states)
 
     def padding_for_decode(self, model_worker_batch: ModelWorkerBatch):
         _, padding_bs_index = self.get_padding_bs(model_worker_batch.real_bs)
@@ -448,7 +448,7 @@ class EagleDraftWorker(BaseDraftWorker):
 
             if self.hot_token_ids is not None:
                 topk_index = self.hot_token_ids[topk_index]
-            hidden_states = self._replicate(logits_output.hidden_states)
+            hidden_states = replicate_to_mesh(self.mesh, logits_output.hidden_states)
 
         return score_list, token_list, parents_list
 

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -38,8 +38,23 @@ class EAGLEWorker(BaseSpecWorker):
     """
 
     def __init__(self, server_args, target_worker: ModelWorker):
-        draft_worker = EagleDraftWorker(server_args, target_worker)
-        super().__init__(server_args, target_worker, draft_worker)
+        self.server_args = server_args
+        self._target_worker = target_worker
+        self._draft_worker = EagleDraftWorker(server_args, target_worker)
+
+        self.topk = server_args.speculative_eagle_topk
+        self.speculative_num_steps = server_args.speculative_num_steps
+        self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
+        self.page_size = server_args.page_size
+        self.mesh = target_worker.mesh
+
+        from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
+
+        self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
 
         (
             precompile_token_paddings,
@@ -51,6 +66,18 @@ class EAGLEWorker(BaseSpecWorker):
         self.precompile_token_paddings = precompile_token_paddings
 
     # -- BaseSpecWorker interface --
+
+    @property
+    def target_worker(self) -> ModelWorker:
+        return self._target_worker
+
+    @property
+    def draft_worker(self) -> EagleDraftWorker:
+        return self._draft_worker
+
+    def clear_cache_pool(self):
+        # TODO: implement when scheduler/runtime needs explicit pool clearing
+        pass
 
     def forward_batch_speculative_generation(
         self,

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -75,10 +75,6 @@ class EAGLEWorker(BaseSpecWorker):
     def draft_worker(self) -> EagleDraftWorker:
         return self._draft_worker
 
-    def clear_cache_pool(self):
-        # TODO: implement when scheduler/runtime needs explicit pool clearing
-        pass
-
     def forward_batch_speculative_generation(
         self,
         model_worker_batch: ModelWorkerBatch,

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -5,8 +5,6 @@ import time
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax.sharding import NamedSharding
-from jax.sharding import PartitionSpec as P
 from tqdm import tqdm
 
 from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
@@ -16,7 +14,7 @@ from sgl_jax.srt.managers.scheduler import GenerationBatchResult
 from sgl_jax.srt.managers.tp_worker import ModelWorker
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
 from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
-from sgl_jax.srt.speculative.base_worker import BaseSpecWorker
+from sgl_jax.srt.speculative.base_worker import BaseSpecWorker, replicate_to_mesh
 from sgl_jax.srt.speculative.eagle_draft_worker import EagleDraftWorker
 from sgl_jax.srt.speculative.eagle_util import (
     EagleDraftInput,
@@ -143,11 +141,6 @@ class EAGLEWorker(BaseSpecWorker):
 
     # -- Verify --
 
-    def _replicate(self, *arrs: jax.Array) -> tuple[jax.Array, ...] | jax.Array:
-        rep = NamedSharding(self.mesh, P())
-        out = jax.device_put(arrs, rep)
-        return out[0] if len(out) == 1 else out
-
     def verify(self, model_worker_batch: ModelWorkerBatch, cur_allocate_lens: jax.Array):
         spec_info: EagleVerifyInput = model_worker_batch.spec_info
         spec_info.allocate_lens = cur_allocate_lens
@@ -159,8 +152,8 @@ class EAGLEWorker(BaseSpecWorker):
         logits_output, _, cache_miss_count = self.target_worker.forward_batch_generation(
             model_worker_batch, skip_sample=True, forward_metadata=forward_metadata
         )
-        logits_output.next_token_logits, logits_output.hidden_states = self._replicate(
-            logits_output.next_token_logits, logits_output.hidden_states
+        logits_output.next_token_logits, logits_output.hidden_states = replicate_to_mesh(
+            self.mesh, logits_output.next_token_logits, logits_output.hidden_states
         )
         spec_info.hidden_states = logits_output.hidden_states
         (
@@ -171,7 +164,7 @@ class EAGLEWorker(BaseSpecWorker):
         ) = spec_info.sample(
             model_worker_batch,
             logits_output,
-            self.draft_worker.draft_model_runner.rngs,
+            self.draft_worker.sampling_rngs,
             self.mesh,
         )
         # accept_index uses -1 for rejected slots; gathering with -1 picks the

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -164,7 +164,7 @@ class EAGLEWorker(BaseSpecWorker):
         ) = spec_info.sample(
             model_worker_batch,
             logits_output,
-            self.draft_worker.sampling_rngs,
+            self.draft_worker.draft_model_runner.rngs,
             self.mesh,
         )
         # accept_index uses -1 for rejected slots; gathering with -1 picks the

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -1,4 +1,3 @@
-import functools
 import itertools
 import logging
 import time
@@ -10,110 +9,48 @@ from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 from tqdm import tqdm
 
-from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessorOutput
+from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
 from sgl_jax.srt.layers.sampler import get_token_ids_logprobs, get_top_logprobs
 from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch, ScheduleBatch
 from sgl_jax.srt.managers.scheduler import GenerationBatchResult
 from sgl_jax.srt.managers.tp_worker import ModelWorker
-from sgl_jax.srt.model_executor.forward_batch_info import (
-    CaptureHiddenMode,
-    ForwardBatch,
-    ForwardMode,
-)
+from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
 from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
+from sgl_jax.srt.speculative.base_worker import BaseSpecWorker
+from sgl_jax.srt.speculative.eagle_draft_worker import EagleDraftWorker
 from sgl_jax.srt.speculative.eagle_util import (
     EagleDraftInput,
     EagleVerifyInput,
     EagleVerifyOutput,
-    build_tree_kernel_efficient,
-    build_tree_mask_for_draft_decode,
 )
-from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
 from sgl_jax.srt.utils.common_utils import get_bool_env_var
-from sgl_jax.srt.utils.jax_utils import device_array
 
 logger = logging.getLogger(__name__)
 RETURN_ORIGINAL_LOGPROB = get_bool_env_var("RETURN_ORIGINAL_LOGPROB")
 
 
-class EAGLEWorker(ModelWorker):
+class EAGLEWorker(BaseSpecWorker):
+    """Standard EAGLE speculative decode orchestrator.
+
+    Composes a ``target_worker`` (full model) with an ``EagleDraftWorker``
+    (draft model).  Implements the ``BaseSpecWorker`` contract so the
+    scheduler interface is unchanged.
+    """
+
     def __init__(self, server_args, target_worker: ModelWorker):
-        self.server_args = server_args
-        self.target_worker = target_worker
-        self.topk = server_args.speculative_eagle_topk
-        self.speculative_num_steps = server_args.speculative_num_steps
-        self.topk = server_args.speculative_eagle_topk
-        self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
-        self.page_size = server_args.page_size
-        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
-            server_args.speculative_algorithm
-        )
-        self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
-        self.hot_token_ids = None
+        draft_worker = EagleDraftWorker(server_args, target_worker)
+        super().__init__(server_args, target_worker, draft_worker)
 
-        # Initialize dummy tensors for EAGLE operations
-        self.num_new_pages_per_topk = None
-        self.extend_lens = None
-
-        # this must be put at last to make sure model state is correct
-        super().__init__(
-            server_args,
-            target_worker.mesh,
-            req_to_token_pool=self.req_to_token_pool,
-            is_draft_worker=True,
-        )
-        EagleDraftInput.ALLOC_LEN_PER_DECODE = max(
-            self.speculative_num_steps * self.topk, self.speculative_num_draft_tokens
-        )
-        embed, head = self.target_worker.model_runner.model.get_embed_and_head()
-
-        if self.speculative_algorithm.is_eagle3():
-            # most cases EAGLE3 models don't share lm_head
-            # but some models (e.g. nvidia/gpt-oss-120b-Eagle3) shares
-            if (
-                hasattr(self.draft_model_runner.model, "load_lm_head_from_target")
-                and self.draft_model_runner.model.load_lm_head_from_target
-            ):
-                self.draft_model_runner.model.set_embed_and_head(embed, head)
-            else:
-                self.draft_model_runner.model.set_embed(embed)
-
-            # grab hot token ids
-            if self.draft_model_runner.model.hot_token_ids is not None:
-                self.hot_token_ids = device_array(
-                    self.draft_model_runner.model.hot_token_ids,
-                    sharding=(NamedSharding(self.model_runner.mesh, P())),
-                )
-        else:
-            if self.hot_token_ids is not None:
-                head = head.clone()
-                self.hot_token_ids = device_array(
-                    self.draft_model_runner.model.hot_token_ids,
-                    sharding=(NamedSharding(self.model_runner.mesh, P())),
-                )
-                head.data = head.data[self.hot_token_ids]
-
-            # Share the embedding and lm_head
-            self.draft_model_runner.model.set_embed_and_head(embed, head)
-
-        target_slot_range = self.target_worker.model_runner.max_total_num_tokens
-        draft_pool_size = self.draft_model_runner.max_total_num_tokens
-        assert draft_pool_size >= target_slot_range, (
-            f"draft KV pool ({draft_pool_size}) < target allocator slot range "
-            f"({target_slot_range}); high-slot draft KV reads/writes will be "
-            f"garbage. Hybrid target without the post-set_num_token_hybrid "
-            f"draft_runner_cache_size overwrite hits this."
-        )
-
-        self.model_runner.initialize_jit()
         (
             precompile_token_paddings,
             precompile_bs_paddings,
             precompile_cache_loc_paddings,
-        ) = self.target_worker.get_precompile_paddings()
+        ) = target_worker.get_precompile_paddings()
         self.precompile_bs_paddings = precompile_bs_paddings
         self.precompile_cache_loc_paddings = precompile_cache_loc_paddings
         self.precompile_token_paddings = precompile_token_paddings
+
+    # -- BaseSpecWorker interface --
 
     def forward_batch_speculative_generation(
         self,
@@ -121,9 +58,6 @@ class EAGLEWorker(ModelWorker):
     ):
         if model_worker_batch.forward_mode.is_extend():
             # FIXME(pc) add padding logic here
-            # Only reshape temperatures if they're 1D (from_schedule_batch produces 1D,
-            # but generate_for_precompile_all_greedy produces 2D with shape (bs, 1))
-
             if model_worker_batch.sampling_info.temperatures.ndim == 1:
                 model_worker_batch.sampling_info.temperatures = (
                     model_worker_batch.sampling_info.temperatures[:, None]
@@ -132,14 +66,14 @@ class EAGLEWorker(ModelWorker):
                 model_worker_batch,
                 len(model_worker_batch.seq_lens) - model_worker_batch.real_bs,
                 self.mesh,
-                vocab_size=self.model_config.vocab_size,
+                vocab_size=self.target_worker.model_config.vocab_size,
             )
             # target extend
             logits_output, next_token_ids, cache_miss_count, bid, seq_lens = (
                 self.forward_target_extend(model_worker_batch, sampling_metadata)
             )
             # draft extend for Update Draft State
-            self.forward_draft_extend(
+            self.draft_worker.draft_extend_for_prefill(
                 model_worker_batch, logits_output.hidden_states, next_token_ids
             )
             # FIXME(pc) refactor this to batch output
@@ -157,13 +91,15 @@ class EAGLEWorker(ModelWorker):
 
         else:
             cur_allocate_lens = model_worker_batch.spec_info.allocate_lens
-            self.draft(model_worker_batch)
+            self.draft_worker.draft(model_worker_batch)
 
             batch_output = self.verify(model_worker_batch, cur_allocate_lens)
 
-            self.draft_extend_after_verify(model_worker_batch, batch_output)
+            self.draft_worker.draft_extend_for_decode(model_worker_batch, batch_output)
 
             return batch_output
+
+    # -- Target model methods --
 
     def forward_target_extend(
         self, model_worker_batch: ModelWorkerBatch, sample_meta_data: SamplingMetadata
@@ -182,287 +118,12 @@ class EAGLEWorker(ModelWorker):
             model_worker_batch.seq_lens,
         )
 
-    def forward_draft_extend(
-        self,
-        model_worker_batch: ModelWorkerBatch,
-        hidden_states: jax.Array,
-        next_token_ids: jax.Array,
-    ):
-        # FIXME(pc) move this all prepare to prepare_for_extend_after_target_prefill
-        verified_id_np = np.asarray(jax.device_get(next_token_ids))[: model_worker_batch.real_bs]
-        model_worker_batch.spec_info = EagleDraftInput(
-            hidden_states=hidden_states,
-            verified_id=verified_id_np,
-            num_tokens_per_batch=np.asarray(1, dtype=jnp.int32),
-            num_tokens_for_logprob_per_batch=np.asarray(1, dtype=jnp.int32),
-            allocate_lens=model_worker_batch.seq_lens,
-        )
-        model_worker_batch.return_hidden_states = False
-        model_worker_batch.spec_info.prepare_for_extend_after_target_prefill(
-            model_worker_batch=model_worker_batch
-        )
-        model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.LAST
-        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
-        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
-        forward_batch.return_logprob = False
-
-        # Set forward_metadata for draft_model_runner's attention backend
-        forward_metadata = self.draft_model_runner.attn_backend.get_eagle_forward_metadata(
-            model_worker_batch
-        )
-
-        self.draft_model_runner.attn_backend.forward_metadata = forward_metadata
-        forward_batch.forward_mode = ForwardMode.EXTEND
-        # last_idx = np.cumsum(model_worker_batch.extend_seq_lens, axis=0) - 1
-
-        logits_output, _, _ = self.draft_model_runner.forward(
-            forward_batch,
-            logits_metadata=LogitsMetadata.from_model_worker_batch(model_worker_batch, self.mesh),
-        )
-        logits_output.next_token_logits = logits_output.next_token_logits[
-            : model_worker_batch.real_bs, :
-        ]
-        if len(logits_output.hidden_states.shape) == 1:
-            logits_output.hidden_states = jnp.expand_dims(logits_output.hidden_states, axis=0)
-        assert isinstance(forward_batch.spec_info, EagleDraftInput)
-        forward_batch.spec_info.allocate_lens = model_worker_batch.seq_lens[
-            : model_worker_batch.real_bs
-        ]
-
-        self.capture_for_decode(logits_output, forward_batch.spec_info)
-
-    def copy_model_worker_batch_to_cpu(self, model_worker_batch: ModelWorkerBatch):
-        model_worker_batch.input_ids = np.array(
-            jax.device_get(model_worker_batch.input_ids), dtype=model_worker_batch.input_ids.dtype
-        )
-        model_worker_batch.seq_lens = np.array(
-            jax.device_get(model_worker_batch.seq_lens), dtype=model_worker_batch.seq_lens.dtype
-        )
-        model_worker_batch.out_cache_loc = np.array(
-            jax.device_get(model_worker_batch.out_cache_loc),
-            dtype=model_worker_batch.out_cache_loc.dtype,
-        )
-        model_worker_batch.positions = np.array(
-            jax.device_get(model_worker_batch.positions), dtype=model_worker_batch.positions.dtype
-        )
-        model_worker_batch.req_pool_indices = np.array(
-            jax.device_get(model_worker_batch.req_pool_indices),
-            dtype=model_worker_batch.req_pool_indices.dtype,
-        )
-        model_worker_batch.cache_loc = np.array(
-            jax.device_get(model_worker_batch.cache_loc), dtype=model_worker_batch.cache_loc.dtype
-        )
-        model_worker_batch.extend_prefix_lens = (
-            np.array(
-                jax.device_get(model_worker_batch.extend_prefix_lens),
-                dtype=model_worker_batch.extend_prefix_lens.dtype,
-            )
-            if model_worker_batch.extend_prefix_lens is not None
-            else None
-        )
-        model_worker_batch.extend_seq_lens = (
-            np.array(
-                jax.device_get(model_worker_batch.extend_seq_lens),
-                dtype=model_worker_batch.extend_seq_lens.dtype,
-            )
-            if model_worker_batch.extend_seq_lens is not None
-            else None
-        )
-
-    @property
-    def draft_model_runner(self):
-        return self.get_model_runner()
+    # -- Verify --
 
     def _replicate(self, *arrs: jax.Array) -> tuple[jax.Array, ...] | jax.Array:
-        # jit outputs are vocab/data-sharded; eagle host orchestration (top_k,
-        # gather, build_tree) needs replicated arrays under explicit-sharding.
         rep = NamedSharding(self.mesh, P())
         out = jax.device_put(arrs, rep)
         return out[0] if len(out) == 1 else out
-
-    def capture_for_decode(
-        self, logits_output: LogitsProcessorOutput, draft_input: EagleDraftInput
-    ):
-        topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
-        draft_input.topk_p = topk_p
-        draft_input.topk_index = topk_index
-        draft_input.hidden_states = self._replicate(logits_output.hidden_states)
-
-    def get_padding_bs(self, real_bs: int) -> int:
-        self.precompile_bs_paddings.sort()
-        select_bs_index = -1
-        bs_padding_size = 0
-        for i, size in enumerate(self.precompile_bs_paddings):
-            if size >= real_bs:
-                bs_padding_size = size - real_bs
-                select_bs_index = i
-                break
-        if select_bs_index < 0:
-            raise RuntimeError("did not get comperate padding bs, it should not happened")
-        return bs_padding_size, select_bs_index
-
-    def padding_for_decode(self, model_worker_batch: ModelWorkerBatch):
-        _, padding_bs_index = self.get_padding_bs(model_worker_batch.real_bs)
-        self.copy_model_worker_batch_to_cpu(model_worker_batch)
-        model_worker_batch.spec_info.prepare_for_draft_decode(
-            model_worker_batch, self.topk, self.speculative_num_steps
-        )
-        # get unpadded seq_lens
-        model_worker_batch.seq_lens = model_worker_batch.seq_lens
-        seq_lens_cpu = model_worker_batch.seq_lens
-        page_size = self.page_size
-        token_indices_with_all_reqs = self.req_to_token_pool.req_to_token[
-            model_worker_batch.req_pool_indices
-        ]
-        spec_info = model_worker_batch.spec_info
-        assert isinstance(spec_info, EagleDraftInput)
-        cache_loc_flat = np.array([], dtype=np.int32)
-        if len(seq_lens_cpu) > 0:
-            # Filter out empty sequences
-            valid_mask = seq_lens_cpu > 0
-            if np.any(valid_mask):
-                valid_indices = np.where(valid_mask)[0]
-                valid_allocate_lens = spec_info.allocate_lens[valid_mask]
-                # Calculate aligned lengths for all valid sequences at once
-                aligned_lengths = ((valid_allocate_lens + page_size - 1) // page_size) * page_size
-                total_aligned_length = np.sum(aligned_lengths)
-                # Pre-allocate the result array
-                cache_loc_flat = np.zeros(total_aligned_length, dtype=np.int32)
-                # Fill the array efficiently
-                offset = 0
-                for i, (seq_idx, allocate_len, aligned_len) in enumerate(
-                    zip(valid_indices, valid_allocate_lens, aligned_lengths)
-                ):
-                    # Copy the actual data
-                    cache_loc_flat[offset : offset + allocate_len] = token_indices_with_all_reqs[
-                        seq_idx, :allocate_len
-                    ]
-                    # Padding is already zero from initialization
-                    offset += aligned_len
-        total_cache_loc_size = self.precompile_cache_loc_paddings[padding_bs_index]
-        assert total_cache_loc_size >= len(cache_loc_flat)
-        cache_loc_cpu = np.empty(total_cache_loc_size, dtype=np.int32)
-        if len(cache_loc_flat) > 0:
-            cache_loc_cpu[: len(cache_loc_flat)] = cache_loc_flat
-        # Initialize padding area to ensure multiprocess consistency
-        if len(cache_loc_flat) < total_cache_loc_size:
-            cache_loc_cpu[len(cache_loc_flat) :] = 0
-
-        model_worker_batch.cache_loc = cache_loc_cpu
-        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
-
-        # out_cache_loc = model_worker_batch.out_cache_loc
-        topk_index = spec_info.topk_index
-        if self.hot_token_ids is not None:
-            model_worker_batch.spec_info.topk_index = self.hot_token_ids[topk_index]
-        # if we need custom mask, we should create for all at once and update it within loop
-        # we should optimize build_tree_mask_for_draft_decode to a kernel
-        if self.topk > 1:
-            self.draft_model_runner.attn_backend.forward_metadata.custom_mask = (
-                build_tree_mask_for_draft_decode(
-                    model_worker_batch.seq_lens,
-                    topk=topk_index.shape[1],
-                    speculative_step_id=0,
-                    parents_list=None,
-                )
-            )
-        bs = self.precompile_bs_paddings[padding_bs_index]
-        if bs - model_worker_batch.spec_info.verified_id.shape[0] > 0:
-            model_worker_batch.spec_info.verified_id = np.pad(
-                model_worker_batch.spec_info.verified_id,
-                ((0, bs - model_worker_batch.spec_info.verified_id.shape[0]),),
-            )
-        if bs - model_worker_batch.spec_info.topk_p.shape[0] > 0:
-            model_worker_batch.spec_info.topk_p = np.pad(
-                model_worker_batch.spec_info.topk_p,
-                (
-                    (0, bs - model_worker_batch.spec_info.topk_p.shape[0]),
-                    (0, 0),
-                ),
-            )
-        if bs - model_worker_batch.seq_lens.shape[0] > 0:
-            model_worker_batch.seq_lens = np.pad(
-                model_worker_batch.seq_lens, ((0, bs - model_worker_batch.seq_lens.shape[0]),)
-            )
-            if model_worker_batch.spec_info.allocate_lens is not None:
-                model_worker_batch.spec_info.allocate_lens = np.pad(
-                    model_worker_batch.spec_info.allocate_lens,
-                    ((0, bs - model_worker_batch.spec_info.allocate_lens.shape[0]),),
-                )
-        if bs - model_worker_batch.spec_info.topk_index.shape[0] > 0:
-            model_worker_batch.spec_info.topk_index = np.pad(
-                model_worker_batch.spec_info.topk_index,
-                (
-                    (0, bs - model_worker_batch.spec_info.topk_index.shape[0]),
-                    (0, 0),
-                ),
-            )
-        if bs - model_worker_batch.spec_info.hidden_states.shape[0] > 0:
-            model_worker_batch.spec_info.hidden_states = np.pad(
-                model_worker_batch.spec_info.hidden_states,
-                (
-                    (0, bs - model_worker_batch.spec_info.hidden_states.shape[0]),
-                    (0, 0),
-                ),
-            )
-        # Forward multiple steps
-        model_worker_batch.speculative_eagle_topk = self.topk
-        model_worker_batch.speculative_num_steps = self.speculative_num_steps
-        model_worker_batch.speculative_num_draft_tokens = self.speculative_num_draft_tokens
-        model_worker_batch.input_ids = np.empty(bs * self.topk, np.int32)
-        model_worker_batch.positions = np.empty(bs * self.topk, np.int32)
-
-    def draft(self, model_worker_batch: ModelWorkerBatch):
-        self.padding_for_decode(model_worker_batch)
-        score_list, token_list, parents_list = self.draft_forward(model_worker_batch)
-        verified_seq_lens = model_worker_batch.seq_lens - 1
-        max_seq_len = int(np.max(verified_seq_lens)) if verified_seq_lens.size > 0 else 1
-        max_context_len = self._pick_context_len(max_seq_len)
-        (
-            tree_mask,
-            position,
-            retrive_index,
-            retrive_next_token,
-            retrive_next_sibling,
-            draft_tokens,
-        ) = build_tree_kernel_efficient(
-            model_worker_batch.spec_info.verified_id,
-            score_list,
-            token_list,
-            parents_list,
-            verified_seq_lens,
-            np.sum(verified_seq_lens),
-            self.topk,
-            self.speculative_num_draft_tokens,
-            max_context_len,
-            model_worker_batch.seq_lens.shape[0],
-            model_worker_batch.speculative_num_steps,
-            self.mesh,
-        )
-        model_worker_batch.spec_info = EagleVerifyInput(
-            draft_token=draft_tokens,
-            custom_mask=tree_mask,
-            positions=position,
-            retrive_index=retrive_index,
-            retrive_next_token=retrive_next_token,
-            retrive_next_sibling=retrive_next_sibling,
-            retrive_cum_len=None,
-            spec_steps=self.speculative_num_steps,
-            topk=self.topk,
-            draft_token_num=self.speculative_num_draft_tokens,
-            capture_hidden_mode=CaptureHiddenMode.LAST,
-            seq_lens_sum=model_worker_batch.seq_lens_sum,
-            seq_lens_cpu=model_worker_batch.seq_lens,
-        )
-        return model_worker_batch.spec_info
-
-    def _pick_context_len(self, max_seq_len: int) -> int:
-        max_seq_len = max(int(max_seq_len), 1)
-        if self.precompile_token_paddings:
-            for padding in self.precompile_token_paddings:
-                if padding >= max_seq_len:
-                    return padding
-        return 1 << (max_seq_len - 1).bit_length()
 
     def verify(self, model_worker_batch: ModelWorkerBatch, cur_allocate_lens: jax.Array):
         spec_info: EagleVerifyInput = model_worker_batch.spec_info
@@ -487,7 +148,7 @@ class EAGLEWorker(ModelWorker):
         ) = spec_info.sample(
             model_worker_batch,
             logits_output,
-            self.model_runner.rngs,
+            self.draft_worker.draft_model_runner.rngs,
             self.mesh,
         )
         # accept_index uses -1 for rejected slots; gathering with -1 picks the
@@ -526,13 +187,14 @@ class EAGLEWorker(ModelWorker):
             extend_logprob_start_len_per_req=None,
         )
 
+    # -- Logprob post-processing --
+
     def add_logprob_values(
         self,
         batch: ScheduleBatch,
         res: EagleVerifyOutput,
         logits_output: LogitsProcessorOutput,
     ):
-        # Extract args
         logits_output = res.logits_output
         top_logprobs_nums = batch.top_logprobs_nums
         token_ids_logprobs = batch.token_ids_logprobs
@@ -541,8 +203,6 @@ class EAGLEWorker(ModelWorker):
 
         temperatures = batch.sampling_info.temperatures
         num_draft_tokens = batch.spec_info.draft_token_num
-        # acceptance indices are the indices in a "flattened" batch.
-        # dividing it to num_draft_tokens will yield the actual batch index.
         temperatures = temperatures[accepted_indices // num_draft_tokens]
         if RETURN_ORIGINAL_LOGPROB:
             logprobs = jax.nn.log_softmax(logits_output.next_token_logits, axis=-1)
@@ -551,7 +211,6 @@ class EAGLEWorker(ModelWorker):
         batch_next_token_ids = res.verified_id
         num_tokens_per_req = [accept + 1 for accept in res.accept_length_per_req_cpu]
 
-        # We should repeat top_logprobs_nums to match num_tokens_per_req.
         top_logprobs_nums_repeat_interleaved = []
         token_ids_logprobs_repeat_interleaved = []
         for num, num_tokens in zip(top_logprobs_nums, num_tokens_per_req):
@@ -559,12 +218,6 @@ class EAGLEWorker(ModelWorker):
         for token_ids, num_tokens in zip(token_ids_logprobs, num_tokens_per_req):
             token_ids_logprobs_repeat_interleaved.extend([token_ids] * num_tokens)
 
-        # Extract logprobs.
-        # NOTE: get_top_logprobs / get_token_ids_logprobs now return device
-        # dense tensors; per-req trimming happens on host downstream. This
-        # spec-decode path doesn't currently route through that host
-        # slicing, so it is best-effort and may need follow-up alongside
-        # the broader spec+DP+logprob unification.
         if any(x > 0 for x in top_logprobs_nums):
             (
                 logits_output.next_token_top_logprobs_val,
@@ -587,7 +240,6 @@ class EAGLEWorker(ModelWorker):
             batch_next_token_ids,
         ]
 
-        # Add output logprobs to the request
         pt = 0
         next_token_logprobs = logits_output.next_token_logprobs.tolist()
         verified_ids = batch_next_token_ids.tolist()
@@ -605,118 +257,7 @@ class EAGLEWorker(ModelWorker):
                         )
                 pt += 1
 
-    def draft_extend_after_verify(
-        self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
-    ):
-        if batch_output.next_draft_input.verified_id.shape[0] <= 0:
-            return
-        draft_input = EagleDraftInput(
-            hidden_states=batch_output.logits_output.hidden_states,
-            allocate_lens=batch_output.allocate_lens,
-        )
-        model_worker_batch, logits_meatadata = draft_input.prepare_for_extend_after_verify(
-            model_worker_batch,
-            self.draft_model_runner,
-            batch_output,
-            self.speculative_num_draft_tokens,
-        )
-
-        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
-        if forward_batch.input_ids.shape[0] <= 0:
-            return
-        draft_logits_output, _, _ = self.draft_model_runner.forward(
-            forward_batch,
-            logits_metadata=logits_meatadata,
-        )
-        select_index = (
-            np.arange(len(model_worker_batch.seq_lens[: model_worker_batch.real_bs]))
-            * (self.speculative_num_steps + 1)
-            + batch_output.accept_lens[: model_worker_batch.real_bs]
-            - 1
-        )
-        rep_logits, rep_hidden = self._replicate(
-            draft_logits_output.next_token_logits, draft_logits_output.hidden_states
-        )
-        draft_logits_output.next_token_logits = rep_logits[select_index]
-        draft_logits_output.hidden_states = rep_hidden[select_index]
-        topk_p, topk_index = topk_probs_from_logits(
-            draft_logits_output.next_token_logits, self.topk
-        )
-
-        # prepare for next draft decode
-        batch_output.next_draft_input.hidden_states = draft_logits_output.hidden_states
-        batch_output.next_draft_input.topk_p = topk_p
-        batch_output.next_draft_input.topk_index = topk_index
-        batch_output.next_draft_input.verified_id = batch_output.next_draft_input.verified_id[
-            select_index
-        ]
-        batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
-        batch_output.accept_lens = batch_output.accept_lens[: model_worker_batch.real_bs]
-
-    def draft_forward(self, model_worker_batch: ModelWorkerBatch):
-        topk_p, topk_index, hidden_states = (
-            model_worker_batch.spec_info.topk_p,
-            model_worker_batch.spec_info.topk_index,
-            model_worker_batch.spec_info.hidden_states,
-        )
-        bs = model_worker_batch.seq_lens.shape[0]
-        step_min_1 = self.speculative_num_steps - 1
-        score_list: jax.Array = jnp.empty((bs, 1 + step_min_1 * self.topk, self.topk))
-        token_list: jax.Array = jnp.empty(
-            (bs, self.topk + step_min_1 * self.topk * self.topk), dtype=jnp.int32
-        )
-        parents_list: jax.Array = jnp.empty((bs, self.topk + 1 + step_min_1 * self.topk))
-        scores = None
-        positions_base = device_array(
-            np.repeat(model_worker_batch.seq_lens, self.topk),
-            sharding=(NamedSharding(self.model_runner.mesh, P())),
-        )
-        logits_metadata = None
-        metadata_per_step = self.draft_model_runner.attn_backend.get_eagle_multi_step_metadata(
-            model_worker_batch,
-        )
-        assert isinstance(metadata_per_step, list)
-        # we just use logits_metadata's forward mode and capture mode, it will not be modified within the loop
-        logits_metadata = LogitsMetadata.from_model_worker_batch(
-            model_worker_batch, self.draft_model_runner.mesh
-        )
-        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
-        forward_batch.out_cache_loc = np.empty((1,))
-        forward_batch.cache_loc = np.empty((1,))
-        forward_batch.spec_info = EagleDraftInput()
-        forward_batch.spec_info.hidden_states = jnp.empty((bs * self.topk, hidden_states.shape[1]))
-        for i in range(self.speculative_num_steps):
-
-            input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
-                i, topk_p, topk_index, hidden_states, scores, self.topk
-            )
-            # update_eagle_lists and update_forward_batch_info this two function will make accept rate very low if be jitted
-            # FIXME we should find it out why lead this ?
-            score_list, token_list, parents_list = update_eagle_lists(
-                i, score_list, token_list, parents_list, tree_info, self.topk
-            )
-            if i == self.speculative_num_steps - 1:
-                break
-
-            forward_batch = update_forward_batch_info(
-                forward_batch, i, input_ids, hidden_states, positions_base
-            )
-            self.draft_model_runner.attn_backend.forward_metadata = metadata_per_step[i]
-
-            # Run forward
-            forward_batch.bid = model_worker_batch.bid
-            logits_output, _, _ = self.draft_model_runner.forward(
-                forward_batch,
-                logits_metadata=logits_metadata,
-            )
-
-            topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
-
-            if self.hot_token_ids is not None:
-                topk_index = self.hot_token_ids[topk_index]
-            hidden_states = self._replicate(logits_output.hidden_states)
-
-        return score_list, token_list, parents_list
+    # -- Precompilation --
 
     def run_spec_decode_precompile(self):
         self.precompile_spec_extend()
@@ -731,7 +272,7 @@ class EAGLEWorker(ModelWorker):
             self.precompile_token_paddings,
         )
 
-        bs, _ = self.get_max_padded_size()
+        bs, _ = self.draft_worker.get_max_padded_size()
         pairs = list(itertools.product([bs], self.precompile_token_paddings))
 
         with tqdm(pairs, desc="[SPEC_EXTEND] PRECOMPILE", leave=False) as pbar:
@@ -742,7 +283,7 @@ class EAGLEWorker(ModelWorker):
                 if bs > num_tokens:
                     logger.warning("bs=%s > num_tokens=%s, skip this pair", bs, num_tokens)
                     continue
-                model_worker_batch = self.compilation_manager._make_dummy_batch(
+                model_worker_batch = self.draft_worker.compilation_manager._make_dummy_batch(
                     bs,
                     num_tokens,
                     ForwardMode.EXTEND,
@@ -767,11 +308,12 @@ class EAGLEWorker(ModelWorker):
         ) as pbar:
             for bs in pbar:
                 pbar.set_postfix(bs=bs)
-                # use same page aligned with precompile cache_loc_paddings
                 aligned_cache_loc_size = (
-                    (bs * self.max_req_len + self.page_size - 1) // self.page_size * self.page_size
+                    (bs * self.draft_worker.max_req_len + self.page_size - 1)
+                    // self.page_size
+                    * self.page_size
                 )
-                model_worker_batch = self.compilation_manager._make_dummy_batch(
+                model_worker_batch = self.draft_worker.compilation_manager._make_dummy_batch(
                     bs,
                     bs,
                     ForwardMode.DECODE,
@@ -788,7 +330,7 @@ class EAGLEWorker(ModelWorker):
                     ),
                     topk_index=jnp.ones((bs, self.topk), dtype=jnp.int32),
                     hidden_states=jnp.ones(
-                        (bs, self.model_config.hidden_size),
+                        (bs, self.draft_worker.model_config.hidden_size),
                         dtype=jnp.bfloat16 if self.server_args.dtype == "bfloat16" else jnp.float32,
                     ),
                     verified_id=jnp.ones((bs,), dtype=jnp.int32),
@@ -806,153 +348,3 @@ class EAGLEWorker(ModelWorker):
 
         end_time = time.perf_counter()
         logger.info("[SPEC_DECODE] Precompile finished in %.0f secs", end_time - start_time)
-
-
-@functools.partial(jax.jit, static_argnames=["topk"])
-def topk_probs_from_logits(
-    logits: jax.Array, topk: int, axis: int = -1
-) -> tuple[jax.Array, jax.Array]:
-    """Return top-k probabilities without materializing the full softmax tensor."""
-    working_logits = jnp.moveaxis(logits, axis, -1) if axis != -1 else logits
-    # TODO(#1053 Phase 2): replace this all-gather with a sharded top-k +
-    # logsumexp over the vocab axis for DP/TP scalability.
-    sh = jax.typeof(working_logits).sharding
-    if isinstance(sh, NamedSharding):
-        working_logits = jax.sharding.reshard(working_logits, NamedSharding(sh.mesh, P()))
-    topk_logits, topk_index = jax.lax.top_k(working_logits, topk)
-    logsumexp = jax.nn.logsumexp(working_logits, axis=-1, keepdims=True)
-    topk_probs = jnp.exp(topk_logits - logsumexp)
-
-    if axis != -1:
-        topk_probs = jnp.moveaxis(topk_probs, -1, axis)
-        topk_index = jnp.moveaxis(topk_index, -1, axis)
-
-    return topk_probs, topk_index
-
-
-def fast_topk(values, topk, axis=-1):
-    working_values = jnp.moveaxis(values, axis, -1) if axis != -1 else values
-    result_vals, result_indices = jax.lax.top_k(working_values, topk)
-
-    if axis != -1:
-        result_vals = jnp.moveaxis(result_vals, -1, axis)
-        result_indices = jnp.moveaxis(result_indices, -1, axis)
-
-    return result_vals, result_indices
-
-
-@functools.partial(jax.jit, static_argnames=["i", "topk"])
-def update_eagle_lists(
-    i: int,
-    score_list: jax.Array,
-    token_list: jax.Array,
-    parents_list: jax.Array,
-    tree_info: tuple[jax.Array, jax.Array, jax.Array],
-    topk: int,
-):
-    bs = score_list.shape[0]
-    scores_update, tokens_update, parents_update = tree_info
-    if i == 0:
-        score_list = score_list.at[:bs, :1, :].set(scores_update[:bs])
-        token_list = token_list.at[:bs, :topk].set(tokens_update[:bs])
-        parents_list = parents_list.at[:bs, : topk + 1].set(parents_update[:bs])
-    else:
-        score_start = 1 + (i - 1) * topk
-        token_start = topk + (i - 1) * topk * topk
-        parent_start = topk + 1 + (i - 1) * topk
-
-        score_list = score_list.at[:bs, score_start : score_start + topk, :].set(scores_update[:bs])
-        token_list = token_list.at[:bs, token_start : token_start + topk * topk].set(
-            tokens_update[:bs]
-        )
-        parents_list = parents_list.at[:bs, parent_start : parent_start + topk].set(
-            parents_update[:bs]
-        )
-    return score_list, token_list, parents_list
-
-
-# FIXME(pc) this should be jitted or convert as np.ndarray
-# @functools.partial(jax.jit, static_argnames=["i"])
-def update_forward_batch_info(
-    forward_batch: ForwardBatch,
-    i: int,
-    input_ids: jax.Array,
-    hidden_states: jax.Array,
-    positions_base: jax.Array,
-) -> ForwardBatch:
-    forward_batch.input_ids = input_ids
-    # FIXME(pc) hiddenstate will become NAN when forward path is very long, we still have no reason for this
-    forward_batch.spec_info.hidden_states = hidden_states
-    forward_batch.positions = positions_base + i
-    return forward_batch
-
-
-def select_top_k_tokens(
-    i: int,
-    topk_p: jax.Array,
-    topk_index: jax.Array,
-    hidden_states: jax.Array,
-    scores: jax.Array,
-    topk: int,
-) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
-    if i == 0:
-        return select_top_k_tokens_step_0(topk_p, topk_index, hidden_states, scores, topk)
-    else:
-        return select_top_k_tokens_step_greater_0(
-            jnp.asarray(i), topk_p, topk_index, hidden_states, scores, topk
-        )
-
-
-@functools.partial(jax.jit, static_argnames=["topk"])
-def select_top_k_tokens_step_0(
-    topk_p: jax.Array,
-    topk_index: jax.Array,
-    hidden_states: jax.Array,
-    scores: jax.Array,
-    topk: int,
-) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
-    # The first step after extend
-    input_ids = topk_index.flatten()
-    hidden_states = jnp.repeat(hidden_states, topk, axis=0)
-    scores = topk_p  # shape: (b, topk)
-    tree_info = (
-        jnp.expand_dims(topk_p, axis=1),  # shape: (b, 1, topk)
-        topk_index,  # shape: (b, topk)
-        jnp.tile(
-            jnp.expand_dims(jnp.arange(-1, topk, dtype=jnp.float32), axis=0),
-            (topk_p.shape[0], 1),
-        ),  # shape: (b, topk + 1)
-    )
-    return input_ids, hidden_states, scores, tree_info
-
-
-@functools.partial(jax.jit, static_argnames=["topk"])
-def select_top_k_tokens_step_greater_0(
-    i: jax.Array,
-    topk_p: jax.Array,
-    topk_index: jax.Array,
-    hidden_states: jax.Array,
-    scores: jax.Array,
-    topk: int,
-) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
-    # The later decode steps
-    expand_scores = jax.lax.mul(
-        jnp.expand_dims(scores, axis=2), topk_p.reshape(-1, topk, topk)
-    )  # (b, topk, 1) x (b, topk ,topk) -> (b, topk, topk)
-    topk_cs_p, topk_cs_index = fast_topk(
-        expand_scores.reshape(expand_scores.shape[0], -1), topk, axis=-1
-    )  # (b, topk)
-    scores = topk_cs_p  # shape: (b, topk)
-    topk_index = topk_index.reshape(-1, topk**2)
-    input_ids = jnp.take_along_axis(topk_index, topk_cs_index, axis=1).flatten()
-    if hidden_states.shape[0] > 0:
-        selected_input_index = topk_cs_index.flatten() // topk + jnp.repeat(
-            jnp.arange(0, hidden_states.shape[0], topk), topk
-        )
-        hidden_states = hidden_states[selected_input_index, :]
-    tree_info = (
-        expand_scores,  # shape: (b, topk, topk)
-        topk_index,  # shape: (b, topk * topk)
-        topk_cs_index + (topk**2 * (i - 1) + topk),  # shape: (b, topk)
-    )
-    return input_ids, hidden_states, scores, tree_info


### PR DESCRIPTION
… + EagleDraftWorker (P1-2)

Extract abstract base classes (BaseSpecWorker, BaseDraftWorker) and move draft logic into EagleDraftWorker so MultiLayerEAGLEWorker/MultiLayerDraftWorker (P1-4) can reuse the same verify/data-contract path.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
