### PR TITLE
chore(profiling): add named_scope to GLA/KDA/short-conv prefill+decode

### DIFF
--- a/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
@@ -12,6 +12,7 @@ from sgl_jax.srt.layers.attention.hybrid_linear_attn_backend import (
 )
 from sgl_jax.srt.layers.attention.linear.short_convolution import short_convolution
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+from sgl_jax.srt.utils.profiling_utils import named_scope
 
 if TYPE_CHECKING:
     from sgl_jax.srt.layers.radix_linear_attention import RadixLinearAttention
@@ -262,6 +263,7 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         )
         return sharded(x, weight, cache, cu_seqlens)
 
+    @named_scope("kda_extend")
     def _forward_extend(
         self,
         q: jax.Array,
@@ -334,6 +336,7 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         )
         return o[0], final_state
 
+    @named_scope("kda_decode")
     def _forward_decode(
         self,
         q: jax.Array,

--- a/python/sgl_jax/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/lightning_backend.py
@@ -27,6 +27,7 @@ from sgl_jax.srt.layers.attention.hybrid_linear_attn_backend import (
     LinearRecurrentAttnBackend,
 )
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+from sgl_jax.srt.utils.profiling_utils import named_scope
 
 logger = logging.getLogger(__name__)
 
@@ -195,6 +196,7 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
             check_vma=False,
         )(recurrent_buffer, recurrent_indices, new_recurrent)
 
+    @named_scope("lightning_decode")
     def _forward_decode(
         self,
         q: jax.Array,
@@ -243,6 +245,7 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
 
         return output, new_state
 
+    @named_scope("lightning_extend")
     def _forward_extend(
         self,
         q: jax.Array,

--- a/python/sgl_jax/srt/layers/attention/linear/short_convolution.py
+++ b/python/sgl_jax/srt/layers/attention/linear/short_convolution.py
@@ -22,6 +22,7 @@ import jax
 import jax.numpy as jnp
 
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+from sgl_jax.srt.utils.profiling_utils import named_scope
 
 # Map of supported activation names → callable. ``None`` means identity.
 _ACTIVATION_FNS: dict[str | None, Callable[[jax.Array], jax.Array] | None] = {
@@ -108,6 +109,7 @@ def _apply_activation(
     return activation_fn(y)
 
 
+@named_scope("short_conv_decode")
 def _decode_conv(
     x: jax.Array,  # [B, D]
     conv_kernel: jax.Array,  # [D, K]
@@ -125,6 +127,7 @@ def _decode_conv(
     return y, new_cache[:, :, 1:]
 
 
+@named_scope("short_conv_extend")
 def _extend_conv(
     x: jax.Array,  # [T, D]
     conv_kernel: jax.Array,  # [D, K]


### PR DESCRIPTION
## Summary
- Decorate the 6 hot paths in the linear-attention stack with `@named_scope` so xprof traces show readable spans instead of anonymous shard_map closures.
- Covers: `lightning_decode` / `lightning_extend`, `kda_decode` / `kda_extend`, `short_conv_decode` / `short_conv_extend`.

## Why
Profiling Ling-2.6-flash on v6e-16 leaves the GLA / KDA / short-conv regions of the trace unlabeled, making it hard to attribute time to prefill vs. decode in the linear-attention layers. Adding scopes is purely cosmetic for traces and a no-op at runtime.

## Notes
- No behavior change. Each function is wrapped by the existing `sgl_jax.srt.utils.profiling_utils.named_scope` decorator.
- The Pallas kernels inside `simple_gla` already surface as named ops in xprof and don't need an extra Python-level scope.

## Test plan
- [ ] Smoke run Ling-2.6-flash on v6e-16 (`scripts/brian_start_ling26.sh`) and confirm new spans appear in the captured trace.
- [ ] No numeric / perf regression on existing CI.