### PR TITLE
fix(embed): preserve data sharding in Embed output

### DIFF
--- a/python/sgl_jax/srt/layers/embeddings.py
+++ b/python/sgl_jax/srt/layers/embeddings.py
@@ -102,7 +102,7 @@ class Embed(nnx.Module):
         if self.num_embeddings == 1:
             return jnp.broadcast_to(embedding, inputs.shape + (self.features,))
 
-        output_pspec = P(*([None] * inputs.ndim), self.kernel_axes[-1])
+        output_pspec = P("data", *([None] * (inputs.ndim - 1)), self.kernel_axes[-1])
         output_sharding = NamedSharding(self.mesh, output_pspec)
         output = embedding.at[inputs].get(out_sharding=output_sharding)
         return output


### PR DESCRIPTION
## Summary

`Embed.__call__` forced its output sharding to `P(None, ..., kernel_axes[-1])`, which collapses the `"data"` axis even though `forward_batch.input_ids` enters the layer as `P("data")` (see `forward_batch_info.py:339`).

Combined with vocab-parallel embedding weights (`kernel_axes=("tensor", None)`, used by every model — Qwen3, Qwen3-MoE, Bailing-MoE, GLM4-MoE, Kimi-Linear, etc.), this forces XLA to insert two collectives at the embedding boundary:

- **all-reduce over `tensor`** — required to combine the vocab-parallel partial lookups (correct, this is the intended cost of vocab-parallel embedding).
- **all-gather over `data`** — *unnecessary*, only needed because the output spec asks for replicated batch.

After all that, downstream attention layers (column-parallel `q/k/v_proj`) re-scatter the batch back. So the data-axis all-gather is pure overhead.

## Fix

Change the output spec to preserve the input's batch-axis sharding:

```python
# before
output_pspec = P(*([None] * inputs.ndim), self.kernel_axes[-1])
# after
output_pspec = P("data", *([None] * (inputs.ndim - 1)), self.kernel_axes[-1])
```

Equivalent to `P("data", None)` for the standard 1D `input_ids` case, and generalizes correctly to `(batch, seq, ...)` shapes.

## Effect

- Eliminates the embedding-stage `all-gather` on the `"data"` axis observed in xprof traces.
- Vocab-axis `all-reduce` is unchanged (still required for vocab-parallel correctness).
- Downstream `q_proj` (`kernel_axes=(None, "tensor")`) accepts `P("data", None)` directly, so no new collectives are introduced anywhere else.

## Test plan

- [ ] `pytest test/srt/test_bench_serving_dense_tp_4.py` — confirm throughput thresholds still pass.
- [ ] Inspect xprof trace on Qwen3-8B TP=4: the `all-gather.858` immediately after the `Embed` framework scope should disappear; the `all-reduce` on the tensor axis should remain.
- [ ] Verify accuracy parity on a short MMLU subset.