### PR TITLE
fix(dispatch): gate Kimi-Linear detection through get_kimi_linear_config

### DIFF
--- a/python/sgl_jax/srt/configs/kimi_linear.py
+++ b/python/sgl_jax/srt/configs/kimi_linear.py
@@ -1,5 +1,9 @@
 # Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/configs/kimi_linear.py
 # (which itself is adapted from vllm's kimi_linear config).
+from __future__ import annotations
+
+from typing import Any
+
 from transformers.configuration_utils import PretrainedConfig
 
 
@@ -143,3 +147,27 @@ class KimiLinearConfig(PretrainedConfig):
     @property
     def full_attention_layer_ids(self):
         return [i for i in range(self.num_hidden_layers) if not self.is_kda_layer(i)]
+
+
+def _is_kimi_linear_config(hf_config: Any) -> bool:
+    if getattr(hf_config, "model_type", None) == "kimi_linear":
+        return True
+    architectures = getattr(hf_config, "architectures", None) or []
+    return any(str(arch).startswith("KimiLinear") for arch in architectures)
+
+
+def get_kimi_linear_config(hf_config: Any) -> KimiLinearConfig | None:
+    """Return a KimiLinearConfig if hf_config describes a Kimi-Linear model, else None.
+
+    Mirrors ``configs.bailing_hybrid.get_bailing_hybrid_config`` so the dispatch
+    layer can detect Kimi-Linear and Bailing-hybrid through symmetric helpers
+    instead of comparing model_type strings inline.
+    """
+    if not _is_kimi_linear_config(hf_config):
+        return None
+    if getattr(hf_config, "linear_attn_config", None) is None:
+        return None
+    if isinstance(hf_config, KimiLinearConfig):
+        return hf_config
+    config_kwargs = hf_config.to_dict() if hasattr(hf_config, "to_dict") else dict(vars(hf_config))
+    return KimiLinearConfig(**config_kwargs)

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -618,11 +618,9 @@ class ModelRunnerKVCacheMixin:
 
     @property
     def kimi_linear_config(self: ModelRunner):
-        """Return Kimi-Linear hf_config if the model has KDA linear attention, else None."""
-        hf_cfg = getattr(self.model_config, "hf_config", None)
-        if hf_cfg is not None and getattr(hf_cfg, "linear_attn_config", None) is not None:
-            return hf_cfg
-        return None
+        from sgl_jax.srt.configs.kimi_linear import get_kimi_linear_config
+
+        return get_kimi_linear_config(self.model_config.hf_config)
 
     @property
     def lightning_config(self: ModelRunner):


### PR DESCRIPTION
## Summary
- Both Kimi-Linear and Bailing-hybrid hf_configs carry a `linear_attn_config` attribute, so `kimi_linear_config` was matching Bailing too.
- `attn_backend_wrapper` then routed Bailing into `KDAAttnBackend` instead of `LightningAttnBackend`, which crashed at the first forward.
- Add a `get_kimi_linear_config()` factory in `configs/kimi_linear.py` that mirrors `configs/bailing_hybrid.py:get_bailing_hybrid_config`, and have `ModelRunnerKVCacheMixin.kimi_linear_config` dispatch through it. Detection of the two linear-recurrent paths now lives in symmetric module-local helpers instead of magic strings in the mixin.

## Symptom

Booting Ling-2.6-flash on TPU v6e-16 (4 nodes, EPMOE, dp=4, ep=16) failed during EXTEND precompile bs=512:

```
File "/tmp/sglang-jax/python/sgl_jax/srt/layers/attention/linear/kda_backend.py", line 53, in __call__
    q_conv_w = layer.q_conv1d.weight.value
AttributeError: 'RadixLightningAttention' object has no attribute 'q_conv1d'
```

The dispatch chain:

```
Bailing model.__call__
  → BailingMoeAttention
    → RadixLightningAttention
      → forward_batch.attn_backend(...)
        → HybridLinearAttnBackend.__call__
          → self.linear_attn_backend  ← KDAAttnBackend instead of LightningAttnBackend
            → KDAAttnBackend.__call__
              → layer.q_conv1d.weight  ← 'RadixLightningAttention' has no q_conv1d
```

## Root cause

| model           | hf_config.model_type | hf_config.linear_attn_config        |
|-----------------|----------------------|-------------------------------------|
| Kimi-Linear     | `kimi_linear`        | not None                            |
| Bailing-hybrid  | `bailing_hybrid`     | not None (dict with `kda_layers`)   |

The previous `kimi_linear_config` only checked `linear_attn_config is not None`, so it returned the Bailing hf_config, and `attn_backend_wrapper` constructed a KDA backend for a Lightning attention layer.

## Fix

`configs/bailing_hybrid.py` already exposes `_is_bailing_hybrid_config` + `get_bailing_hybrid_config` helpers, where detection is gated on `model_type == "bailing_hybrid"` (with an `architectures` fallback). Add the symmetric pair in `configs/kimi_linear.py`:

```python
def _is_kimi_linear_config(hf_config) -> bool:
    if getattr(hf_config, "model_type", None) == "kimi_linear":
        return True
    architectures = getattr(hf_config, "architectures", None) or []
    return any(str(arch).startswith("KimiLinear") for arch in architectures)


def get_kimi_linear_config(hf_config) -> KimiLinearConfig | None:
    if not _is_kimi_linear_config(hf_config):
        return None
    if getattr(hf_config, "linear_attn_config", None) is None:
        return None
    if isinstance(hf_config, KimiLinearConfig):
        return hf_config
    config_kwargs = hf_config.to_dict() if hasattr(hf_config, "to_dict") else dict(vars(hf_config))
    return KimiLinearConfig(**config_kwargs)
```

`ModelRunnerKVCacheMixin.kimi_linear_config` becomes a 2-line property that dispatches through `get_kimi_linear_config`, matching the existing `lightning_config` property style.

## Test plan
- [x] Dispatcher routes Kimi-Linear to `KDAAttnBackend` (no behavior change for Kimi).
- [x] Dispatcher routes Bailing-hybrid (Ling-2.6-flash) to `LightningAttnBackend`.
- [x] Server reaches ready and serves requests on Ling-2.6-flash + EPMOE on v6e-16 4-node.
