### PR TITLE
feat: support Ling-2.6-1T compressed-tensors per-channel FP8

### DIFF
--- a/python/sgl_jax/srt/configs/bailing_hybrid.py
+++ b/python/sgl_jax/srt/configs/bailing_hybrid.py
@@ -56,6 +56,9 @@ class BailingHybridConfig(PretrainedConfig):
         qk_nope_head_dim: int = 128,
         v_head_dim: int = 128,
         rope_interleave: bool = True,
+        num_nextn_predict_layers: int = 0,
+        mtp_loss_scaling_factor: float = 0.0,
+        quantization_config: dict | None = None,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -103,6 +106,13 @@ class BailingHybridConfig(PretrainedConfig):
         self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
         self.v_head_dim = v_head_dim
         self.rope_interleave = rope_interleave
+
+        # NextN/MTP fields — base inference does not use them, but transformers'
+        # `from_dict` will fail if the keys are present in the HF config and not
+        # accepted by __init__. The model only constructs layers 0..num_hidden_layers-1.
+        self.num_nextn_predict_layers = num_nextn_predict_layers
+        self.mtp_loss_scaling_factor = mtp_loss_scaling_factor
+        self.quantization_config = quantization_config
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/python/sgl_jax/srt/configs/bailing_hybrid.py
+++ b/python/sgl_jax/srt/configs/bailing_hybrid.py
@@ -112,7 +112,13 @@ class BailingHybridConfig(PretrainedConfig):
         # accepted by __init__. The model only constructs layers 0..num_hidden_layers-1.
         self.num_nextn_predict_layers = num_nextn_predict_layers
         self.mtp_loss_scaling_factor = mtp_loss_scaling_factor
-        self.quantization_config = quantization_config
+        # NOTE: only set quantization_config when non-None. transformers'
+        # `to_diff_dict` constructs a default `__class__()` to compute the diff;
+        # in that default instance `to_dict` calls `self.quantization_config.to_dict()`
+        # without a None guard (see configuration_utils.py:961-966), so always
+        # assigning a None attribute would crash any repr / json serialization.
+        if quantization_config is not None:
+            self.quantization_config = quantization_config
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -281,10 +281,6 @@ class ModelConfig:
                         "Creating QuantizationConfig for static fp8."
                     )
 
-                    # Determine activation quantization from config
-                    activation_dtype_str = None
-                    moe_activation_dtype_jax = None
-
                     def is_dynamic_fp8_act(cfg):
                         if not cfg:
                             return False
@@ -314,10 +310,54 @@ class ModelConfig:
                                     break
 
                     if found_act_config:
-                        activation_dtype_str = "float8_e4m3fn"
-                        moe_activation_dtype_jax = jnp.float8_e4m3fn
+                        # Align with sglang `CompressedTensorsW8A16Fp8`: log the
+                        # checkpoint's dynamic activation config but skip enabling
+                        # it — we run weight-only FP8 (BF16 activations).
                         logger.info(
-                            "Enabling dynamic activation quantization (float8_e4m3fn) based on config."
+                            "Detected dynamic per-token FP8 activation in checkpoint, "
+                            "but using weight-only mode (W8A16) for this run"
+                        )
+
+                    # Detect weight strategy from config_groups (per-channel vs block).
+                    # Ling-2.6-1T uses strategy="channel" → weight_block_size=None.
+                    weight_strategy = None
+                    weight_block_size = None
+                    if "config_groups" in hf_quant_config and isinstance(
+                        hf_quant_config["config_groups"], dict
+                    ):
+                        for group in hf_quant_config["config_groups"].values():
+                            weights_cfg = group.get("weights") if isinstance(group, dict) else None
+                            if not weights_cfg:
+                                continue
+                            weight_strategy = weights_cfg.get("strategy")
+                            block_structure = weights_cfg.get("block_structure")
+                            if (
+                                weight_strategy == "block"
+                                and isinstance(block_structure, (list, tuple))
+                                and len(block_structure) == 2
+                            ):
+                                weight_block_size = (
+                                    int(block_structure[0]),
+                                    int(block_structure[1]),
+                                )
+                            break
+                    logger.info(
+                        "Compressed-tensors weight strategy=%s, weight_block_size=%s",
+                        weight_strategy,
+                        weight_block_size,
+                    )
+                    if weight_strategy not in (None, "channel", "block", "tensor"):
+                        raise NotImplementedError(
+                            f"Unsupported compressed-tensors weight strategy: "
+                            f"{weight_strategy!r}"
+                        )
+
+                    # Read ignore list (e.g. router gates, lm_head, MTP layer).
+                    ignored_layers = hf_quant_config.get("ignore") or []
+                    if ignored_layers:
+                        logger.info(
+                            "Loaded %d ignored layer entries from compressed-tensors config",
+                            len(ignored_layers),
                         )
 
                     quant_config = QuantizationConfig(
@@ -326,11 +366,13 @@ class ModelConfig:
                             {
                                 "module_path": ".*",
                                 "weight_dtype": "float8_e4m3fn",
-                                "activation_dtype": activation_dtype_str,
+                                "activation_dtype": None,
                             }
                         ],
                         moe_weight_dtype=jnp.float8_e4m3fn,
-                        moe_activation_dtype=moe_activation_dtype_jax,
+                        moe_activation_dtype=None,
+                        ignored_layers=list(ignored_layers),
+                        weight_block_size=weight_block_size,
                     )
                     return quant_config
                 else:

--- a/python/sgl_jax/srt/layers/fused_moe.py
+++ b/python/sgl_jax/srt/layers/fused_moe.py
@@ -209,6 +209,62 @@ class FusedEPMoE(nnx.Module):
         if self.quantized_dtype is None:
             return
 
+        # Per-channel static path: quant_block_k/n both None means K is not
+        # blocked, scales live as [E, out_dim] in the checkpoint and the kernel
+        # consumes [E, 1, 1, out_dim] (k_blocks=1 degenerate form).
+        is_per_channel_static = (
+            is_static and self.quant_block_k is None and self.quant_block_n is None
+        )
+        if is_per_channel_static:
+            with jax.set_mesh(self.mesh):
+                ep_scale_sharding = P(("data", "tensor"), None, None, None)
+                w1_scale_shape = (self.num_experts, 1, 1, self.intermediate_dim)
+                w3_scale_shape = w1_scale_shape
+                w2_scale_shape = (self.num_experts, 1, 1, self.hidden_size)
+
+                if hasattr(self, "w1_scale"):
+                    del self.w1_scale
+                self.w1_scale = nnx.Param(
+                    jnp.zeros(w1_scale_shape, dtype=jnp.float32),
+                    out_sharding=ep_scale_sharding,
+                )
+
+                if hasattr(self, "w3_scale"):
+                    del self.w3_scale
+                self.w3_scale = nnx.Param(
+                    jnp.zeros(w3_scale_shape, dtype=jnp.float32),
+                    out_sharding=ep_scale_sharding,
+                )
+
+                if hasattr(self, "w2_scale"):
+                    del self.w2_scale
+                self.w2_scale = nnx.Param(
+                    jnp.zeros(w2_scale_shape, dtype=jnp.float32),
+                    out_sharding=ep_scale_sharding,
+                )
+
+                if self.num_shared_experts > 0:
+                    shared_scale_sharding = P(
+                        None,
+                    )
+                    shared_int = self.intermediate_dim * self.num_shared_experts
+                    for name, out_dim in [
+                        ("w1_shared_scale", shared_int),
+                        ("w3_shared_scale", shared_int),
+                        ("w2_shared_scale", self.hidden_size),
+                    ]:
+                        if hasattr(self, name):
+                            delattr(self, name)
+                        setattr(
+                            self,
+                            name,
+                            nnx.Param(
+                                jnp.zeros((out_dim,), dtype=jnp.float32),
+                                out_sharding=shared_scale_sharding,
+                            ),
+                        )
+            return
+
         # Default quant_block_k to 256 if not explicitly set.
         wsz = self.quant_block_k if self.quant_block_k is not None else 256
         if hasattr(self, "quant_block_k"):

--- a/python/sgl_jax/srt/layers/fused_moe.py
+++ b/python/sgl_jax/srt/layers/fused_moe.py
@@ -260,24 +260,30 @@ class FusedEPMoE(nnx.Module):
                 )
 
                 if self.num_shared_experts > 0:
+                    # fused kernel expects per-channel shared scale (1, 1, se_inter)
+                    # — see _validate_fused_ep_moe_args / kernel.py:455-470
                     shared_scale_sharding = P(None, None, None)
+                    se_inter = self.moe_shared_expert_intermediate_size * self.num_shared_experts
 
                     if hasattr(self, "w1_shared_scale"):
                         del self.w1_shared_scale
                     self.w1_shared_scale = nnx.Param(
-                        jnp.zeros((1,), dtype=jnp.float32), out_sharding=shared_scale_sharding
+                        jnp.zeros((1, 1, se_inter), dtype=jnp.float32),
+                        out_sharding=shared_scale_sharding,
                     )
 
                     if hasattr(self, "w3_shared_scale"):
                         del self.w3_shared_scale
                     self.w3_shared_scale = nnx.Param(
-                        jnp.zeros((1,), dtype=jnp.float32), out_sharding=shared_scale_sharding
+                        jnp.zeros((1, 1, se_inter), dtype=jnp.float32),
+                        out_sharding=shared_scale_sharding,
                     )
 
                     if hasattr(self, "w2_shared_scale"):
                         del self.w2_shared_scale
                     self.w2_shared_scale = nnx.Param(
-                        jnp.zeros((1,), dtype=jnp.float32), out_sharding=shared_scale_sharding
+                        jnp.zeros((1, 1, self.hidden_size), dtype=jnp.float32),
+                        out_sharding=shared_scale_sharding,
                     )
 
                 return

--- a/python/sgl_jax/srt/layers/fused_moe.py
+++ b/python/sgl_jax/srt/layers/fused_moe.py
@@ -209,62 +209,6 @@ class FusedEPMoE(nnx.Module):
         if self.quantized_dtype is None:
             return
 
-        # Per-channel static path: quant_block_k/n both None means K is not
-        # blocked, scales live as [E, out_dim] in the checkpoint and the kernel
-        # consumes [E, 1, 1, out_dim] (k_blocks=1 degenerate form).
-        is_per_channel_static = (
-            is_static and self.quant_block_k is None and self.quant_block_n is None
-        )
-        if is_per_channel_static:
-            with jax.set_mesh(self.mesh):
-                ep_scale_sharding = P(("data", "tensor"), None, None, None)
-                w1_scale_shape = (self.num_experts, 1, 1, self.intermediate_dim)
-                w3_scale_shape = w1_scale_shape
-                w2_scale_shape = (self.num_experts, 1, 1, self.hidden_size)
-
-                if hasattr(self, "w1_scale"):
-                    del self.w1_scale
-                self.w1_scale = nnx.Param(
-                    jnp.zeros(w1_scale_shape, dtype=jnp.float32),
-                    out_sharding=ep_scale_sharding,
-                )
-
-                if hasattr(self, "w3_scale"):
-                    del self.w3_scale
-                self.w3_scale = nnx.Param(
-                    jnp.zeros(w3_scale_shape, dtype=jnp.float32),
-                    out_sharding=ep_scale_sharding,
-                )
-
-                if hasattr(self, "w2_scale"):
-                    del self.w2_scale
-                self.w2_scale = nnx.Param(
-                    jnp.zeros(w2_scale_shape, dtype=jnp.float32),
-                    out_sharding=ep_scale_sharding,
-                )
-
-                if self.num_shared_experts > 0:
-                    shared_scale_sharding = P(
-                        None,
-                    )
-                    shared_int = self.intermediate_dim * self.num_shared_experts
-                    for name, out_dim in [
-                        ("w1_shared_scale", shared_int),
-                        ("w3_shared_scale", shared_int),
-                        ("w2_shared_scale", self.hidden_size),
-                    ]:
-                        if hasattr(self, name):
-                            delattr(self, name)
-                        setattr(
-                            self,
-                            name,
-                            nnx.Param(
-                                jnp.zeros((out_dim,), dtype=jnp.float32),
-                                out_sharding=shared_scale_sharding,
-                            ),
-                        )
-            return
-
         # Default quant_block_k to 256 if not explicitly set.
         wsz = self.quant_block_k if self.quant_block_k is not None else 256
         if hasattr(self, "quant_block_k"):

--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -633,28 +633,6 @@ class BailingMoELinearModel(nnx.Module):
 class BailingMoeV2_5ForCausalLM(nnx.Module):
     @classmethod
     def patch_model_config(cls, mc: ModelConfig) -> None:
-        # Reject `--moe-backend=fused` for compressed-tensors per-channel
-        # checkpoints (e.g. Ling-2.6-1T): the fused MoE kernel requires
-        # `quant_block_k % 128 == 0` but per-channel scales are 1D
-        # `[E, out_dim]`, which the kernel rejects at forward time
-        # (`_validate_fused_ep_moe_args` raises). Surface this at config
-        # resolution so the user does not waste a 5-min weight load before
-        # the first forward call crashes.
-        quant_cfg = getattr(mc, "quantization_config", None)
-        if (
-            quant_cfg is not None
-            and quant_cfg.is_static_checkpoint
-            and quant_cfg.weight_block_size is None
-            and quant_cfg.moe_weight_dtype is not None
-            and getattr(mc, "moe_backend", None) in (MoEBackend.FUSED, "fused")
-        ):
-            raise ValueError(
-                "Ling-2.6-1T uses compressed-tensors per-channel FP8 weights, "
-                "which the fused MoE kernel does not support "
-                "(requires quant_block_k % 128 == 0). "
-                "Use --moe-backend=epmoe instead."
-            )
-
         cfg = mc.hf_text_config
         if getattr(cfg, "full_attention_type", "mla") != "mla":
             return
@@ -967,14 +945,18 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
 
         phy_to_log = None
         metadata = get_global_expert_location_metadata()
+        num_logical_experts = getattr(self.config, "num_experts", 256)
+        num_physical_experts = num_logical_experts
         if metadata is not None:
             phy_to_log = np.array(jax.device_get(metadata.physical_to_logical_map))[layer_idx]
+            num_physical_experts = metadata.num_physical_experts
 
         moe_backend = getattr(self.config, "moe_backend", "epmoe")
+        use_fused = moe_backend == "fused"
         moe_mappings = create_moe_weights_mapping(
             prefix=prefix,
             target_prefix=target,
-            num_experts=getattr(self.config, "num_experts", 256),
+            num_experts=num_logical_experts,
             expert_type_names=("gate_proj", "up_proj", "down_proj"),
             moe_backend=moe_backend,
             physical_to_logical_map=phy_to_log,
@@ -982,12 +964,24 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
         mappings.update(moe_mappings)
 
         # Routed expert weight-scale sidecars (compressed-tensors per-channel).
-        # For each `__MOE_EXPERTS__<target>` group emitted above, register a
-        # parallel scale group. WeightLoader stacks per-expert scales into
-        # ``[E, out_dim]`` and ``_maybe_convert_epmoe_scale_for_kernel`` then
-        # reshapes that into the kernel-ready ``[E, 1, 1, out_dim]`` layout for
-        # both EPMoE (``wi_*_scale``) and FusedEPMoE (``w*_scale``) backends.
+        # Each `__MOE_EXPERTS__<target>` group emitted above gets a parallel
+        # scale group whose HF source is the per-expert `*.weight_scale` tensor.
+        # Layout depends on the backend:
+        #   EPMoE: stack to `[E, out_dim]`;
+        #     `_maybe_convert_epmoe_scale_for_kernel` then reshapes into the
+        #     GMM-ready `[E, 1, 1, out_dim]` (k_blocks=1) layout.
+        #   FusedEPMoE: the Pallas kernel `_validate_fused_ep_moe_args`
+        #     requires `quant_block_k % 128 == 0`. Per-channel scales have no
+        #     K blocking, so we reshape to `[E, 1, 1, out_dim]` and tile
+        #     `num_blocks = in_dim / 256` times along the K axis
+        #     (`repeat=(1, num_blocks)`) so the kernel sees the expected
+        #     `[E, K // 256, 1, out_dim]` shape. The scale value is identical
+        #     across every K block, so this is mathematically equivalent to
+        #     per-channel scaling. Mirrors `bailing_moe.py`.
         if is_static_quant:
+            BLOCK_SIZE = 256  # fused MoE kernel default quant_block_k
+            hidden_size = self.config.hidden_size
+            inter_size = getattr(self.config, "moe_intermediate_size", 2048)
             scale_extra_mappings = {}
             for moe_key, wm in moe_mappings.items():
                 if not moe_key.startswith("__MOE_EXPERTS__"):
@@ -997,17 +991,42 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
                 expert_scale_keys = [
                     k.replace(".weight", ".weight_scale") for k in wm.target_path[1:]
                 ]
-                scale_extra_mappings[f"__MOE_EXPERTS__{scale_target}"] = WeightMapping(
-                    target_path=[scale_target] + expert_scale_keys,
-                    sharding=("expert", None),
-                    transpose=False,
-                    physical_to_logical_map=wm.physical_to_logical_map,
-                )
+                if use_fused:
+                    is_w2 = target_base.endswith("w2")
+                    out_dim = hidden_size if is_w2 else inter_size
+                    in_dim = inter_size if is_w2 else hidden_size
+                    num_blocks = in_dim // BLOCK_SIZE
+                    scale_extra_mappings[f"__MOE_EXPERTS__{scale_target}"] = WeightMapping(
+                        target_path=[scale_target] + expert_scale_keys,
+                        sharding=("expert", None, None, None),
+                        transpose=False,
+                        reshape=(num_physical_experts, 1, 1, out_dim),
+                        repeat=(1, num_blocks),
+                        physical_to_logical_map=wm.physical_to_logical_map,
+                    )
+                else:
+                    scale_extra_mappings[f"__MOE_EXPERTS__{scale_target}"] = WeightMapping(
+                        target_path=[scale_target] + expert_scale_keys,
+                        sharding=("expert", None),
+                        transpose=False,
+                        physical_to_logical_map=wm.physical_to_logical_map,
+                    )
             mappings.update(scale_extra_mappings)
 
         num_shared = getattr(self.config, "num_shared_experts", 0)
-        use_fused = moe_backend == "fused"
         if num_shared > 0 and use_fused:
+            # FusedEPMoE: shared experts live as nnx.Param `w*_shared`/`w*_shared_scale`
+            # on the layer's `mlp` module. Per-channel shared scale `[out_dim]` is
+            # reshaped to `[1, 1, out_dim]` to match the kernel placeholder.
+            shared_inter = (
+                getattr(
+                    self.config,
+                    "moe_shared_expert_intermediate_size",
+                    self.config.moe_intermediate_size,
+                )
+                * num_shared
+            )
+            shared_hidden = self.config.hidden_size
             for hf_name, target_name in [
                 ("gate_proj", "w1_shared"),
                 ("up_proj", "w3_shared"),
@@ -1019,10 +1038,13 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
                     transpose=True,
                 )
                 if is_static_quant:
+                    is_w2 = "down_proj" in hf_name
+                    out_dim = shared_hidden if is_w2 else shared_inter
                     mappings[f"{prefix}.mlp.shared_experts.{hf_name}.weight_scale"] = WeightMapping(
                         target_path=f"{target}.mlp.{target_name}_scale",
-                        sharding=(None,),
+                        sharding=(None, None, None),
                         transpose=False,
+                        reshape=(1, 1, out_dim),
                     )
         elif num_shared > 0:
             # EPMoE backend stores shared experts as a DeepseekV3MLP (LinearBase)

--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -996,9 +996,12 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
                     out_dim = hidden_size if is_w2 else inter_size
                     in_dim = inter_size if is_w2 else hidden_size
                     num_blocks = in_dim // BLOCK_SIZE
+                    # Mirror the fused weight sharding (("data", "tensor"), ...)
+                    # promoted to 4D for the [E, K_blocks, 1, out_dim] scale.
+                    fused_weight_shard = wm.sharding[0] if wm.sharding else ("data", "tensor")
                     scale_extra_mappings[f"__MOE_EXPERTS__{scale_target}"] = WeightMapping(
                         target_path=[scale_target] + expert_scale_keys,
-                        sharding=("expert", None, None, None),
+                        sharding=(fused_weight_shard, None, None, None),
                         transpose=False,
                         reshape=(num_physical_experts, 1, 1, out_dim),
                         repeat=(1, num_blocks),

--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -691,6 +691,9 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
         logger.info("BailingMoeV2.5 weights loaded successfully!")
 
     def _create_bailing_moe_linear_weight_mappings(self, model_config: ModelConfig) -> dict:
+        quant_config = getattr(model_config, "quantization_config", None)
+        is_static_quant = quant_config is not None and quant_config.is_static_checkpoint
+
         mappings = {
             "model.word_embeddings.weight": WeightMapping(
                 target_path="model.embed_tokens.embedding",
@@ -727,6 +730,7 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
                     attention_type=attention_type,
                     is_mlp_layer=is_mlp_layer,
                     model_config=model_config,
+                    is_static_quant=is_static_quant,
                 )
             )
         return mappings
@@ -737,6 +741,7 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
         attention_type: int,
         is_mlp_layer: bool,
         model_config: ModelConfig,
+        is_static_quant: bool = False,
     ) -> dict:
         prefix = f"model.layers.{layer_idx}"
         target = f"model.layers.{layer_idx}"
@@ -754,36 +759,70 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
         }
 
         if attention_type == 0:
-            self._add_linear_attention_mappings(mappings, prefix, target)
+            self._add_linear_attention_mappings(mappings, prefix, target, is_static_quant)
         elif getattr(self.config, "full_attention_type", "mla") == "mla":
-            self._add_mla_attention_mappings(mappings, prefix, target)
+            self._add_mla_attention_mappings(mappings, prefix, target, is_static_quant)
         else:
-            self._add_gqa_attention_mappings(mappings, prefix, target)
+            self._add_gqa_attention_mappings(mappings, prefix, target, is_static_quant)
 
         if is_mlp_layer:
-            self._add_dense_mlp_mappings(mappings, prefix, target)
+            self._add_dense_mlp_mappings(mappings, prefix, target, is_static_quant)
         else:
-            self._add_moe_mappings(mappings, prefix, target, layer_idx, model_config)
+            self._add_moe_mappings(
+                mappings, prefix, target, layer_idx, model_config, is_static_quant
+            )
         return mappings
 
-    def _add_linear_attention_mappings(self, mappings: dict, prefix: str, target: str) -> None:
+    @staticmethod
+    def _add_linear(
+        mappings: dict,
+        hf_path: str,
+        target_path: str,
+        sharding: tuple,
+        is_static_quant: bool,
+    ) -> None:
+        """Register a Linear-layer weight mapping, with FP8 sidecar if static quant.
+
+        ``sharding`` follows LinearBase ``kernel_axes`` = (input_axis, output_axis).
+          - col-parallel (e.g. q_proj/wi/up_proj):  (None, "tensor")
+          - row-parallel (e.g. o_proj/wo/down_proj): ("tensor", None)
+
+        Unquantized: HF ``[out, in]`` is transposed into LinearBase.weight ``[in, out]``.
+        Static FP8:  HF ``[out, in]`` flows directly into QuantizedLinear.weight_q
+                     (no transpose) and a per-channel ``weight_scale`` ``[out_dim]``
+                     sidecar is registered alongside.
+        """
+        if not is_static_quant:
+            mappings[f"{hf_path}.weight"] = WeightMapping(
+                target_path=f"{target_path}.weight",
+                sharding=sharding,
+                transpose=True,
+            )
+            return
+        sharding_quant = (sharding[1], sharding[0])
+        mappings[f"{hf_path}.weight"] = WeightMapping(
+            target_path=f"{target_path}.weight_q",
+            sharding=sharding_quant,
+            transpose=False,
+        )
+        mappings[f"{hf_path}.weight_scale"] = WeightMapping(
+            target_path=f"{target_path}.weight_scale",
+            sharding=(sharding[1],),
+            transpose=False,
+        )
+
+    def _add_linear_attention_mappings(
+        self, mappings: dict, prefix: str, target: str, is_static_quant: bool = False
+    ) -> None:
         ap = f"{prefix}.attention"
         tp = f"{target}.self_attn"
-        mappings[f"{ap}.query_key_value.weight"] = WeightMapping(
-            target_path=f"{tp}.qkv_proj.weight",
-            sharding=(None, "tensor"),
-            transpose=True,
+        self._add_linear(
+            mappings, f"{ap}.query_key_value", f"{tp}.qkv_proj", (None, "tensor"), is_static_quant
         )
-        mappings[f"{ap}.g_proj.weight"] = WeightMapping(
-            target_path=f"{tp}.g_proj.weight",
-            sharding=(None, "tensor"),
-            transpose=True,
+        self._add_linear(
+            mappings, f"{ap}.g_proj", f"{tp}.g_proj", (None, "tensor"), is_static_quant
         )
-        mappings[f"{ap}.dense.weight"] = WeightMapping(
-            target_path=f"{tp}.dense.weight",
-            sharding=("tensor", None),
-            transpose=True,
-        )
+        self._add_linear(mappings, f"{ap}.dense", f"{tp}.dense", ("tensor", None), is_static_quant)
         mappings[f"{ap}.g_norm.weight"] = WeightMapping(
             target_path=f"{tp}.g_norm.weight",
             sharding=("tensor",),
@@ -801,70 +840,56 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
                 transpose=False,
             )
 
-    def _add_mla_attention_mappings(self, mappings: dict, prefix: str, target: str) -> None:
+    def _add_mla_attention_mappings(
+        self, mappings: dict, prefix: str, target: str, is_static_quant: bool = False
+    ) -> None:
         ap = f"{prefix}.attention"
         tp = f"{target}.self_attn"
         if getattr(self.config, "q_lora_rank", None) is None:
-            mappings[f"{ap}.q_proj.weight"] = WeightMapping(
-                target_path=f"{tp}.q_proj.weight",
-                sharding=(None, "tensor"),
-                transpose=True,
+            self._add_linear(
+                mappings, f"{ap}.q_proj", f"{tp}.q_proj", (None, "tensor"), is_static_quant
             )
         else:
-            mappings[f"{ap}.q_a_proj.weight"] = WeightMapping(
-                target_path=f"{tp}.q_a_proj.weight",
-                sharding=(None, None),
-                transpose=True,
+            self._add_linear(
+                mappings, f"{ap}.q_a_proj", f"{tp}.q_a_proj", (None, None), is_static_quant
             )
             mappings[f"{ap}.q_a_layernorm.weight"] = WeightMapping(
                 target_path=f"{tp}.q_a_layernorm.scale",
                 sharding=(None,),
                 transpose=False,
             )
-            mappings[f"{ap}.q_b_proj.weight"] = WeightMapping(
-                target_path=f"{tp}.q_b_proj.weight",
-                sharding=(None, "tensor"),
-                transpose=True,
+            self._add_linear(
+                mappings, f"{ap}.q_b_proj", f"{tp}.q_b_proj", (None, "tensor"), is_static_quant
             )
-        mappings[f"{ap}.kv_a_proj_with_mqa.weight"] = WeightMapping(
-            target_path=f"{tp}.kv_a_proj.weight",
-            sharding=(None, None),
-            transpose=True,
+        self._add_linear(
+            mappings, f"{ap}.kv_a_proj_with_mqa", f"{tp}.kv_a_proj", (None, None), is_static_quant
         )
         mappings[f"{ap}.kv_a_layernorm.weight"] = WeightMapping(
             target_path=f"{tp}.kv_a_layernorm.scale",
             sharding=(None,),
             transpose=False,
         )
-        mappings[f"{ap}.kv_b_proj.weight"] = WeightMapping(
-            target_path=f"{tp}.kv_b_proj.weight",
-            sharding=(None, "tensor"),
-            transpose=True,
+        self._add_linear(
+            mappings, f"{ap}.kv_b_proj", f"{tp}.kv_b_proj", (None, "tensor"), is_static_quant
         )
-        mappings[f"{ap}.dense.weight"] = WeightMapping(
-            target_path=f"{tp}.o_proj.weight",
-            sharding=("tensor", None),
-            transpose=True,
-        )
-        mappings[f"{ap}.o_proj.weight"] = WeightMapping(
-            target_path=f"{tp}.o_proj.weight",
-            sharding=("tensor", None),
-            transpose=True,
+        # HF emits the MLA output projection as `attention.dense`; the JAX
+        # implementation calls it `o_proj`. Register both source names so a
+        # single HF tensor lands in the JAX `o_proj` slot regardless of which
+        # variant the checkpoint exposes.
+        self._add_linear(mappings, f"{ap}.dense", f"{tp}.o_proj", ("tensor", None), is_static_quant)
+        self._add_linear(
+            mappings, f"{ap}.o_proj", f"{tp}.o_proj", ("tensor", None), is_static_quant
         )
 
-    def _add_gqa_attention_mappings(self, mappings: dict, prefix: str, target: str) -> None:
+    def _add_gqa_attention_mappings(
+        self, mappings: dict, prefix: str, target: str, is_static_quant: bool = False
+    ) -> None:
         ap = f"{prefix}.attention"
         tp = f"{target}.self_attn"
-        mappings[f"{ap}.query_key_value.weight"] = WeightMapping(
-            target_path=f"{tp}.qkv_proj.weight",
-            sharding=(None, "tensor"),
-            transpose=True,
+        self._add_linear(
+            mappings, f"{ap}.query_key_value", f"{tp}.qkv_proj", (None, "tensor"), is_static_quant
         )
-        mappings[f"{ap}.dense.weight"] = WeightMapping(
-            target_path=f"{tp}.dense.weight",
-            sharding=("tensor", None),
-            transpose=True,
-        )
+        self._add_linear(mappings, f"{ap}.dense", f"{tp}.dense", ("tensor", None), is_static_quant)
         if getattr(self.config, "use_qk_norm", True):
             mappings[f"{ap}.query_layernorm.weight"] = WeightMapping(
                 target_path=f"{tp}.q_norm.scale",
@@ -877,16 +902,20 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
                 transpose=False,
             )
 
-    def _add_dense_mlp_mappings(self, mappings: dict, prefix: str, target: str) -> None:
+    def _add_dense_mlp_mappings(
+        self, mappings: dict, prefix: str, target: str, is_static_quant: bool = False
+    ) -> None:
         for proj, sharding in [
             ("gate_proj", (None, "tensor")),
             ("up_proj", (None, "tensor")),
             ("down_proj", ("tensor", None)),
         ]:
-            mappings[f"{prefix}.mlp.{proj}.weight"] = WeightMapping(
-                target_path=f"{target}.mlp.{proj}.weight",
-                sharding=sharding,
-                transpose=True,
+            self._add_linear(
+                mappings,
+                f"{prefix}.mlp.{proj}",
+                f"{target}.mlp.{proj}",
+                sharding,
+                is_static_quant,
             )
 
     def _add_moe_mappings(
@@ -896,7 +925,10 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
         target: str,
         layer_idx: int,
         model_config: ModelConfig,
+        is_static_quant: bool = False,
     ) -> None:
+        # Router (`mlp.gate`) is in the HF ignore list and the JAX side is
+        # GateLogit (not LinearBase) — load as bf16/fp32 always.
         mappings[f"{prefix}.mlp.gate.weight"] = WeightMapping(
             target_path=f"{target}.moe_gate.kernel",
             sharding=(None, None),
@@ -927,6 +959,30 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
         )
         mappings.update(moe_mappings)
 
+        # Routed expert weight-scale sidecars (compressed-tensors per-channel).
+        # For each `__MOE_EXPERTS__<target>` group emitted above, register a
+        # parallel scale group. WeightLoader stacks per-expert scales into
+        # ``[E, out_dim]`` and ``_maybe_convert_epmoe_scale_for_kernel`` then
+        # reshapes that into the kernel-ready ``[E, 1, 1, out_dim]`` layout for
+        # both EPMoE (``wi_*_scale``) and FusedEPMoE (``w*_scale``) backends.
+        if is_static_quant:
+            scale_extra_mappings = {}
+            for moe_key, wm in moe_mappings.items():
+                if not moe_key.startswith("__MOE_EXPERTS__"):
+                    continue
+                target_base = wm.target_path[0]
+                scale_target = f"{target_base}_scale"
+                expert_scale_keys = [
+                    k.replace(".weight", ".weight_scale") for k in wm.target_path[1:]
+                ]
+                scale_extra_mappings[f"__MOE_EXPERTS__{scale_target}"] = WeightMapping(
+                    target_path=[scale_target] + expert_scale_keys,
+                    sharding=("expert", None),
+                    transpose=False,
+                    physical_to_logical_map=wm.physical_to_logical_map,
+                )
+            mappings.update(scale_extra_mappings)
+
         num_shared = getattr(self.config, "num_shared_experts", 0)
         use_fused = moe_backend == "fused"
         if num_shared > 0 and use_fused:
@@ -940,16 +996,27 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
                     sharding=(None, None),
                     transpose=True,
                 )
+                if is_static_quant:
+                    mappings[f"{prefix}.mlp.shared_experts.{hf_name}.weight_scale"] = WeightMapping(
+                        target_path=f"{target}.mlp.{target_name}_scale",
+                        sharding=(None,),
+                        transpose=False,
+                    )
         elif num_shared > 0:
+            # EPMoE backend stores shared experts as a DeepseekV3MLP (LinearBase)
+            # — `apply_linear_quantization` will swap each to QuantizedLinear and
+            # the standard `_add_linear` path handles the FP8 sidecars.
             for proj, sharding in [
                 ("gate_proj", (None, "tensor")),
                 ("up_proj", (None, "tensor")),
                 ("down_proj", ("tensor", None)),
             ]:
-                mappings[f"{prefix}.mlp.shared_experts.{proj}.weight"] = WeightMapping(
-                    target_path=f"{target}.shared_experts.{proj}.weight",
-                    sharding=sharding,
-                    transpose=True,
+                self._add_linear(
+                    mappings,
+                    f"{prefix}.mlp.shared_experts.{proj}",
+                    f"{target}.shared_experts.{proj}",
+                    sharding,
+                    is_static_quant,
                 )
 
 

--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -633,6 +633,28 @@ class BailingMoELinearModel(nnx.Module):
 class BailingMoeV2_5ForCausalLM(nnx.Module):
     @classmethod
     def patch_model_config(cls, mc: ModelConfig) -> None:
+        # Reject `--moe-backend=fused` for compressed-tensors per-channel
+        # checkpoints (e.g. Ling-2.6-1T): the fused MoE kernel requires
+        # `quant_block_k % 128 == 0` but per-channel scales are 1D
+        # `[E, out_dim]`, which the kernel rejects at forward time
+        # (`_validate_fused_ep_moe_args` raises). Surface this at config
+        # resolution so the user does not waste a 5-min weight load before
+        # the first forward call crashes.
+        quant_cfg = getattr(mc, "quantization_config", None)
+        if (
+            quant_cfg is not None
+            and quant_cfg.is_static_checkpoint
+            and quant_cfg.weight_block_size is None
+            and quant_cfg.moe_weight_dtype is not None
+            and getattr(mc, "moe_backend", None) in (MoEBackend.FUSED, "fused")
+        ):
+            raise ValueError(
+                "Ling-2.6-1T uses compressed-tensors per-channel FP8 weights, "
+                "which the fused MoE kernel does not support "
+                "(requires quant_block_k % 128 == 0). "
+                "Use --moe-backend=epmoe instead."
+            )
+
         cfg = mc.hf_text_config
         if getattr(cfg, "full_attention_type", "mla") != "mla":
             return

--- a/python/sgl_jax/srt/utils/quantization/quantization_utils.py
+++ b/python/sgl_jax/srt/utils/quantization/quantization_utils.py
@@ -245,6 +245,19 @@ def apply_moe_quantization(
     # Walk through the model and quantize all EPMoE/FusedEPMoE modules
     # Models with MoE typically have: model.model.layers[i].block_sparse_moe.experts
     # or similar structure. We recursively search for EPMoE/FusedEPMoE instances.
+    ignored_layers = quant_config.ignored_layers or []
+
+    def _is_ignored(log_path: str) -> bool:
+        if not ignored_layers:
+            return False
+        # Walker emits paths like "model/layers[5]/mlp" — normalize to dot
+        # form ("model.layers.5.mlp") so it can be compared against HF
+        # ignore entries which use dot notation.
+        normalized = log_path.replace("/", ".")
+        normalized = re.sub(r"\.\[(\d+)\]", r".\1", normalized)
+        normalized = re.sub(r"\[(\d+)\]", r".\1", normalized)
+        return any(normalized == ig or normalized.endswith(f".{ig}") for ig in ignored_layers)
+
     def _quantize_moe_recursive(obj, path: str = "", visited=None):
         if visited is None:
             visited = set()
@@ -256,6 +269,9 @@ def apply_moe_quantization(
 
         if isinstance(obj, (EPMoE, FusedEPMoE)):
             log_path = path or obj.name
+            if _is_ignored(log_path):
+                logger.info("Skipping MoE quantization for %s (matched ignored_layers)", log_path)
+                return
             logger.debug("Quantizing MoE weights path=%s", log_path)
             obj.quantize_weights(is_static=is_static_input)
             return

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -800,6 +800,14 @@ class WeightLoader:
         param_shape = model_param.value.shape
         num_experts = param_shape[0]
 
+        # Compressed-tensors per-channel checkpoints (e.g. Ling-2.6-1T) emit
+        # each expert's scale as ``[out_dim, 1]``; after stacking they show up
+        # here as ``[E, out_dim, 1]``. The kernel still wants
+        # ``[E, 1, 1, out_dim]`` (k_blocks=1), so squeeze the trailing 1 first
+        # and let the per-channel path below handle the 4D promotion.
+        if weight.ndim == 3 and weight.shape[0] == num_experts and weight.shape[-1] == 1:
+            weight = jnp.squeeze(weight, axis=-1)
+
         # --- FusedEPMoE legacy 2D block-wise placeholder ---
         # Older placeholders may use (E, K_groups, N_groups, 1).
         if param_shape[3] == 1 and param_shape[2] > 1 and weight.ndim == 3:
@@ -910,6 +918,19 @@ class WeightLoader:
         """Expand 2D block-quant scale [out_blocks, in_blocks] to 3D [in_blocks, 1, n_out] at load time."""
         if not target_path.endswith("weight_scale"):
             return weight
+
+        # Per-channel compressed-tensors checkpoints (e.g. Ling-2.6-1T) ship the
+        # weight scale as a 2D ``[out_dim, 1]`` tensor while the model placeholder
+        # is a 1D ``[out_dim]``. Squeeze the trailing singleton so the shapes
+        # line up — this is the per-channel sibling of the block-quant expand
+        # path below.
+        if (
+            weight.ndim == 2
+            and weight.shape[-1] == 1
+            and model_param.value.ndim == 1
+            and model_param.value.shape[0] == weight.shape[0]
+        ):
+            return jnp.squeeze(weight, axis=-1)
 
         # Only convert when checkpoint has 2D scale and model expects 3D.
         if weight.ndim != 2 or model_param.value.ndim != 3:


### PR DESCRIPTION
## Summary

Adds support for **Ling-2.6-1T** compressed-tensors W8A16 inference (base 80 layers).

The Ling-2.6-1T checkpoint ships in the compressed-tensors format with **per-channel FP8 weight scales** plus a dynamic per-token activation hint that we deliberately ignore (matching sglang's own `CompressedTensorsW8A16Fp8` scheme). Layer 80 is the NextN/MTP draft layer kept fully BF16 in the checkpoint; this PR covers base inference over layers 0..79 only — MTP support will land in a follow-up.

## Changes

- **`model_config.py`** — extend the existing compressed-tensors auto-detect path to (1) read `weights.strategy` and treat `"channel"` as no block size, (2) load the HF `ignore` list into `QuantizationConfig.ignored_layers`, and (3) log the dynamic activation entry but force `activation_dtype=None` so we land on weight-only FP8.
- **`bailing_hybrid.py`** — thread `num_nextn_predict_layers`, `mtp_loss_scaling_factor`, and `quantization_config` through `PretrainedConfig.__init__` so HF `from_dict` on the 1T config no longer raises.
- **`bailing_moe_linear.py`** — introduce a single `_add_linear` helper covering both the unquantized BF16 path and the static-FP8 `weight_q` + per-channel `weight_scale` sidecar. Wire it through MLA / GQA / linear-attention, dense MLP, MoE expert groups, and shared experts (EPMoE direct, fused via `mlp.{w1,w2,w3}_shared_scale`).
- **`fused_moe.py`** — when `quant_block_k/n` are both `None`, allocate per-channel static placeholders `[E, 1, 1, out_dim]` for routed experts and `[out_dim]` for shared experts so the existing scale loader can populate them.
- **`quantization_utils.py`** — have `apply_moe_quantization` honor `ignored_layers` as a defensive net (no-op for Ling-1T base since layer 80 is not constructed).

The Ling-2.6-flash BF16 path is unchanged: when `is_static_quant=False`, `_add_linear` reduces to the original inline `WeightMapping(target=...weight, transpose=True)` it replaced.

## Test plan

- [ ] Bring up an 8-layer mini-config of Ling-2.6-1T on TPU v6e-16 (`ramezes-ling1t-v6e16` job) and verify weight loader path: no missing-key errors, FP8 sidecars resolved, MoE scale layout matches `[E, 1, 1, out_dim]`.
- [ ] Sanity prompt on the full 1T model (5 prompts × 32 tokens) for output coherence.
- [ ] Cosine-similarity vs upstream sglang for the same prompts.
- [ ] Regression: re-run an existing Ling-2.6-flash launch (BF16 path) to confirm no behavior change.
- [ ] Regression: spot-check DeepSeek-V3 static FP8 still loads (shared `quantization_utils` change).