### PR TITLE
feat(spec): MultiLayerEAGLEWorker/MultiLayerDraftWorker (#1053 P1-4)

### DIFF
--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -144,6 +144,16 @@ class ModelConfig:
 
         if is_draft_model and self.hf_config.architectures[0] == "MiMoV2ForCausalLM":
             self.hf_config.architectures[0] = "MiMoV2MTPForCausalLM"
+            # Each draft runner is a single SWA layer; without this the KV pool
+            # sizes for all 70 target layers and OOMs.
+            self.hf_config.num_hidden_layers = 1
+            if self.quantization_config is not None:
+                # eh_proj / o_proj are BF16 in model_mtp.safetensors (no
+                # weight_scale_inv); keep them as plain LinearBase so mappings
+                # can target `.weight` instead of `.weight_q`.
+                ignored = list(self.quantization_config.ignored_layers or [])
+                ignored.extend(["model.eh_proj", "model.mtp_block.self_attn.o_proj"])
+                self.quantization_config.ignored_layers = ignored
         # Check model type
         self.is_generation = is_generation_model(self.hf_config.architectures, is_embedding)
         self.is_multimodal = False

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -555,25 +555,21 @@ def _ragged_paged_attention_kernel_loop(
         sem = sems.at[4, bkvmask_sem_idx]
         kvmask_vmem_ref = bkvmask_ref.at[bkvmask_sem_idx]
 
-        # custom_mask rows are host-padded to page-aligned kv_len (8-divisible
-        # and shape-stable within a page) while kv_lens_ref keeps the unaligned
-        # value for _fetch_bkv. Mask stride = cu_kv_lens delta (page-aligned).
-        mask_kv_len = pl.multiple_of(cu_kv_lens_ref[seq_idx + 1] - cu_kv_lens_ref[seq_idx], 8)
+        kv_len = kv_lens_ref[seq_idx]
+        mask_len = kv_len
         mask_start = bkvmask_idx * bkv_sz
-        mask_left = mask_kv_len - mask_start
-        load_kvmask_sz = pl.multiple_of(jnp.minimum(bkv_sz, mask_left), 8)
+        mask_left = mask_len - mask_start
+        load_kvmask_sz = jnp.minimum(bkv_sz, mask_left)
 
         q_len_start = cu_q_lens_ref[seq_idx] + bq_idx * bq_sz
         q_end = cu_q_lens_ref[seq_idx + 1]
         load_q_sz = jnp.minimum(bq_sz, q_end - q_len_start)
 
-        cur_seq_mask_start = pl.multiple_of(cu_seq_mask_lens[seq_idx], 8)
-        cur_bq_mask_start = cur_seq_mask_start + bq_idx * bq_sz * mask_kv_len
-
-        zero_sz = pl.multiple_of(bkv_sz - load_kvmask_sz, 8)
+        cur_seq_mask_start = cu_seq_mask_lens[seq_idx]
+        cur_bq_mask_start = cur_seq_mask_start + bq_idx * bq_sz * kv_len
 
         def loop_body(i, _):
-            start = pl.multiple_of(cur_bq_mask_start + i * mask_kv_len + mask_start, 8)
+            start = cur_bq_mask_start + i * kv_len + mask_start
             _async_copy(
                 custom_mask_ref.at[pl.ds(start, load_kvmask_sz)],
                 kvmask_vmem_ref.at[i, pl.ds(0, load_kvmask_sz)],
@@ -581,8 +577,8 @@ def _ragged_paged_attention_kernel_loop(
                 wait,
             )
             _async_copy(
-                zero_mask_ref.at[pl.ds(0, zero_sz)],
-                kvmask_vmem_ref.at[i, pl.ds(load_kvmask_sz, zero_sz)],
+                zero_mask_ref.at[pl.ds(0, bkv_sz - load_kvmask_sz)],
+                kvmask_vmem_ref.at[i, pl.ds(load_kvmask_sz, bkv_sz - load_kvmask_sz)],
                 sem,
                 wait,
             )
@@ -1756,12 +1752,9 @@ def ragged_paged_attention(
             custom_mask = custom_mask.astype(jnp.int32)
         custom_mask = jnp.repeat(jnp.expand_dims(custom_mask, axis=1), repeats=head_dim, axis=1)
 
-        # Prepare cu_seq_mask_lens for custom mask. Host pads each mask row
-        # to page-aligned kv_len (= cu_kv_lens delta), so per-seq stride uses
-        # that aligned length to keep DMA offset/size tiling(8)-divisible.
+        # Prepare cu_seq_mask_lens for custom mask.
         q_lens = cu_q_lens[1:] - cu_q_lens[:-1]
-        aligned_kv_lens = cu_kv_lens[1:] - cu_kv_lens[:-1]
-        seq_mask_lens = aligned_kv_lens * q_lens
+        seq_mask_lens = kv_lens * q_lens
         cu_seq_mask_lens = jnp.concatenate(
             [jnp.array([0], dtype=jnp.int32), jnp.cumsum(seq_mask_lens)]
         )

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -366,6 +366,7 @@ def _ragged_paged_attention_kernel_loop(
     skip_kv_mask: bool = False,
     tpu_version: int = 6,
     debug_mode: bool = False,
+    mask_aligned_to_cu_kv: bool = False,
 ):
     assert q_hbm_ref.shape == o_hbm_ref.shape
     assert q_hbm_ref.shape[-1] == kv_cache_hbm_ref.shape[-1]
@@ -555,21 +556,33 @@ def _ragged_paged_attention_kernel_loop(
         sem = sems.at[4, bkvmask_sem_idx]
         kvmask_vmem_ref = bkvmask_ref.at[bkvmask_sem_idx]
 
-        kv_len = kv_lens_ref[seq_idx]
-        mask_len = kv_len
+        if mask_aligned_to_cu_kv:
+            # Host padded each mask row to the page-aligned kv_len (= cu_kv_lens
+            # delta), so stride/offset/size are statically tiling(8)-divisible.
+            mask_kv_len = pl.multiple_of(cu_kv_lens_ref[seq_idx + 1] - cu_kv_lens_ref[seq_idx], 8)
+        else:
+            mask_kv_len = kv_lens_ref[seq_idx]
         mask_start = bkvmask_idx * bkv_sz
-        mask_left = mask_len - mask_start
+        mask_left = mask_kv_len - mask_start
         load_kvmask_sz = jnp.minimum(bkv_sz, mask_left)
+        if mask_aligned_to_cu_kv:
+            load_kvmask_sz = pl.multiple_of(load_kvmask_sz, 8)
 
         q_len_start = cu_q_lens_ref[seq_idx] + bq_idx * bq_sz
         q_end = cu_q_lens_ref[seq_idx + 1]
         load_q_sz = jnp.minimum(bq_sz, q_end - q_len_start)
 
         cur_seq_mask_start = cu_seq_mask_lens[seq_idx]
-        cur_bq_mask_start = cur_seq_mask_start + bq_idx * bq_sz * kv_len
+        cur_bq_mask_start = cur_seq_mask_start + bq_idx * bq_sz * mask_kv_len
+        zero_sz = bkv_sz - load_kvmask_sz
+        if mask_aligned_to_cu_kv:
+            cur_seq_mask_start = pl.multiple_of(cur_seq_mask_start, 8)
+            zero_sz = pl.multiple_of(zero_sz, 8)
 
         def loop_body(i, _):
-            start = cur_bq_mask_start + i * kv_len + mask_start
+            start = cur_bq_mask_start + i * mask_kv_len + mask_start
+            if mask_aligned_to_cu_kv:
+                start = pl.multiple_of(start, 8)
             _async_copy(
                 custom_mask_ref.at[pl.ds(start, load_kvmask_sz)],
                 kvmask_vmem_ref.at[i, pl.ds(0, load_kvmask_sz)],
@@ -577,8 +590,8 @@ def _ragged_paged_attention_kernel_loop(
                 wait,
             )
             _async_copy(
-                zero_mask_ref.at[pl.ds(0, bkv_sz - load_kvmask_sz)],
-                kvmask_vmem_ref.at[i, pl.ds(load_kvmask_sz, bkv_sz - load_kvmask_sz)],
+                zero_mask_ref.at[pl.ds(0, zero_sz)],
+                kvmask_vmem_ref.at[i, pl.ds(load_kvmask_sz, zero_sz)],
                 sem,
                 wait,
             )
@@ -1746,15 +1759,22 @@ def ragged_paged_attention(
     if out_dtype is None:
         out_dtype = jnp.float32 if q.dtype == jnp.float32 else jnp.bfloat16
 
+    # When page_size>=256 the dynamic mask slice in _fetch_mask fails
+    # Mosaic's tiling(8) proof; under that condition the host pads each
+    # mask row to the page-aligned kv_len (= cu_kv_lens delta). Derive
+    # the gate here from kv_cache shape (static) so it survives jit
+    # tracing without an extra kwarg from the backend.
+    mask_aligned_to_cu_kv = int(page_size) >= 256
+
     # Prepare custom mask.
     if custom_mask is not None:
         if custom_mask.dtype == jnp.bool_:
             custom_mask = custom_mask.astype(jnp.int32)
         custom_mask = jnp.repeat(jnp.expand_dims(custom_mask, axis=1), repeats=head_dim, axis=1)
 
-        # Prepare cu_seq_mask_lens for custom mask.
         q_lens = cu_q_lens[1:] - cu_q_lens[:-1]
-        seq_mask_lens = kv_lens * q_lens
+        mask_kv_lens = (cu_kv_lens[1:] - cu_kv_lens[:-1]) if mask_aligned_to_cu_kv else kv_lens
+        seq_mask_lens = mask_kv_lens * q_lens
         cu_seq_mask_lens = jnp.concatenate(
             [jnp.array([0], dtype=jnp.int32), jnp.cumsum(seq_mask_lens)]
         )
@@ -1881,6 +1901,7 @@ def ragged_paged_attention(
                 skip_kv_mask=skip_kv_mask,
                 tpu_version=tpu_version,
                 debug_mode=debug_mode,
+                mask_aligned_to_cu_kv=mask_aligned_to_cu_kv,
             ),
             grid_spec=pltpu.PrefetchScalarGridSpec(
                 num_scalar_prefetch=len(scalar_prefetches),

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -555,21 +555,25 @@ def _ragged_paged_attention_kernel_loop(
         sem = sems.at[4, bkvmask_sem_idx]
         kvmask_vmem_ref = bkvmask_ref.at[bkvmask_sem_idx]
 
-        kv_len = kv_lens_ref[seq_idx]
-        mask_len = kv_len
+        # custom_mask rows are host-padded to page-aligned kv_len (8-divisible
+        # and shape-stable within a page) while kv_lens_ref keeps the unaligned
+        # value for _fetch_bkv. Mask stride = cu_kv_lens delta (page-aligned).
+        mask_kv_len = pl.multiple_of(cu_kv_lens_ref[seq_idx + 1] - cu_kv_lens_ref[seq_idx], 8)
         mask_start = bkvmask_idx * bkv_sz
-        mask_left = mask_len - mask_start
-        load_kvmask_sz = jnp.minimum(bkv_sz, mask_left)
+        mask_left = mask_kv_len - mask_start
+        load_kvmask_sz = pl.multiple_of(jnp.minimum(bkv_sz, mask_left), 8)
 
         q_len_start = cu_q_lens_ref[seq_idx] + bq_idx * bq_sz
         q_end = cu_q_lens_ref[seq_idx + 1]
         load_q_sz = jnp.minimum(bq_sz, q_end - q_len_start)
 
-        cur_seq_mask_start = cu_seq_mask_lens[seq_idx]
-        cur_bq_mask_start = cur_seq_mask_start + bq_idx * bq_sz * kv_len
+        cur_seq_mask_start = pl.multiple_of(cu_seq_mask_lens[seq_idx], 8)
+        cur_bq_mask_start = cur_seq_mask_start + bq_idx * bq_sz * mask_kv_len
+
+        zero_sz = pl.multiple_of(bkv_sz - load_kvmask_sz, 8)
 
         def loop_body(i, _):
-            start = cur_bq_mask_start + i * kv_len + mask_start
+            start = pl.multiple_of(cur_bq_mask_start + i * mask_kv_len + mask_start, 8)
             _async_copy(
                 custom_mask_ref.at[pl.ds(start, load_kvmask_sz)],
                 kvmask_vmem_ref.at[i, pl.ds(0, load_kvmask_sz)],
@@ -577,8 +581,8 @@ def _ragged_paged_attention_kernel_loop(
                 wait,
             )
             _async_copy(
-                zero_mask_ref.at[pl.ds(0, bkv_sz - load_kvmask_sz)],
-                kvmask_vmem_ref.at[i, pl.ds(load_kvmask_sz, bkv_sz - load_kvmask_sz)],
+                zero_mask_ref.at[pl.ds(0, zero_sz)],
+                kvmask_vmem_ref.at[i, pl.ds(load_kvmask_sz, zero_sz)],
                 sem,
                 wait,
             )
@@ -1752,9 +1756,12 @@ def ragged_paged_attention(
             custom_mask = custom_mask.astype(jnp.int32)
         custom_mask = jnp.repeat(jnp.expand_dims(custom_mask, axis=1), repeats=head_dim, axis=1)
 
-        # Prepare cu_seq_mask_lens for custom mask.
+        # Prepare cu_seq_mask_lens for custom mask. Host pads each mask row
+        # to page-aligned kv_len (= cu_kv_lens delta), so per-seq stride uses
+        # that aligned length to keep DMA offset/size tiling(8)-divisible.
         q_lens = cu_q_lens[1:] - cu_q_lens[:-1]
-        seq_mask_lens = kv_lens * q_lens
+        aligned_kv_lens = cu_kv_lens[1:] - cu_kv_lens[:-1]
+        seq_mask_lens = aligned_kv_lens * q_lens
         cu_seq_mask_lens = jnp.concatenate(
             [jnp.array([0], dtype=jnp.int32), jnp.cumsum(seq_mask_lens)]
         )

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -114,7 +114,7 @@ def ref_ragged_paged_attention(
         ), f"use custom_mask, custom_mask length {custom_mask.size=} must larger than total kv length {jnp.cumsum(kv_lens)[-1]=}"
     if mask_value is None:
         mask_value = DEFAULT_MASK_VALUE
-    _, _, num_kv_heads, head_dim = k_pages.shape
+    _, page_size, num_kv_heads, head_dim = k_pages.shape
     num_q_heads = queries.shape[1]
     assert num_q_heads % num_kv_heads == 0
     num_query_per_kv = num_q_heads // num_kv_heads
@@ -122,8 +122,11 @@ def ref_ragged_paged_attention(
     mask_len_list = []
     for i in range(num_seqs[0]):
         kv_len = kv_lens[i]
+        # custom_mask rows are padded to the page-aligned kv_len so the kernel's
+        # DMA offset/size are 8-divisible; ref must use the same stride.
+        aligned_kv_len = ((kv_len + page_size - 1) // page_size) * page_size
         q_len = cu_q_lens[i + 1] - cu_q_lens[i]
-        mask_len_list.append(q_len * kv_len)
+        mask_len_list.append(q_len * aligned_kv_len)
     mask_lens = jnp.array(mask_len_list, dtype=jnp.int32)
     cu_mask_lens = jnp.concatenate([jnp.array([0], dtype=jnp.int32), jnp.cumsum(mask_lens)])
 
@@ -151,13 +154,14 @@ def ref_ragged_paged_attention(
             kv_span = jax.lax.broadcasted_iota(jnp.int32, attn.shape, 2)
             mask = q_span < kv_span
         else:
+            aligned_kv_len = ((kv_len + page_size - 1) // page_size) * page_size
             mask_start = cu_mask_lens[i]
             mask_end = cu_mask_lens[i + 1]
             mask = custom_mask[mask_start:mask_end]
             mask = (
                 jnp.repeat(jnp.expand_dims(mask, axis=0), num_q_heads, axis=0).reshape(
-                    num_q_heads, q_len, kv_len
-                )
+                    num_q_heads, q_len, aligned_kv_len
+                )[:, :, :kv_len]
                 < 1
             )
         if sliding_window is not None:

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -114,7 +114,7 @@ def ref_ragged_paged_attention(
         ), f"use custom_mask, custom_mask length {custom_mask.size=} must larger than total kv length {jnp.cumsum(kv_lens)[-1]=}"
     if mask_value is None:
         mask_value = DEFAULT_MASK_VALUE
-    _, page_size, num_kv_heads, head_dim = k_pages.shape
+    _, _, num_kv_heads, head_dim = k_pages.shape
     num_q_heads = queries.shape[1]
     assert num_q_heads % num_kv_heads == 0
     num_query_per_kv = num_q_heads // num_kv_heads
@@ -122,11 +122,8 @@ def ref_ragged_paged_attention(
     mask_len_list = []
     for i in range(num_seqs[0]):
         kv_len = kv_lens[i]
-        # custom_mask rows are padded to the page-aligned kv_len so the kernel's
-        # DMA offset/size are 8-divisible; ref must use the same stride.
-        aligned_kv_len = ((kv_len + page_size - 1) // page_size) * page_size
         q_len = cu_q_lens[i + 1] - cu_q_lens[i]
-        mask_len_list.append(q_len * aligned_kv_len)
+        mask_len_list.append(q_len * kv_len)
     mask_lens = jnp.array(mask_len_list, dtype=jnp.int32)
     cu_mask_lens = jnp.concatenate([jnp.array([0], dtype=jnp.int32), jnp.cumsum(mask_lens)])
 
@@ -154,14 +151,13 @@ def ref_ragged_paged_attention(
             kv_span = jax.lax.broadcasted_iota(jnp.int32, attn.shape, 2)
             mask = q_span < kv_span
         else:
-            aligned_kv_len = ((kv_len + page_size - 1) // page_size) * page_size
             mask_start = cu_mask_lens[i]
             mask_end = cu_mask_lens[i + 1]
             mask = custom_mask[mask_start:mask_end]
             mask = (
                 jnp.repeat(jnp.expand_dims(mask, axis=0), num_q_heads, axis=0).reshape(
-                    num_q_heads, q_len, aligned_kv_len
-                )[:, :, :kv_len]
+                    num_q_heads, q_len, kv_len
+                )
                 < 1
             )
         if sliding_window is not None:

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -233,29 +233,6 @@ class FlashAttention(AttentionBackend):
         if batch.forward_mode.is_target_verify():
             seq_lens += extend_seq_lens
             aligned_seq_lens = ((seq_lens + self.page_size - 1) // self.page_size) * self.page_size
-            # rpa_v3 _fetch_mask DMA needs the per-row slice size 8-aligned. Pad
-            # each draft-token row from kv_len to page-aligned kv_len (multiple
-            # of 8, and constant within a page so the mask shape is bucket-stable
-            # across decode steps). seq_lens itself stays unaligned for
-            # _fetch_bkv's cache/new split.
-            if metadata.custom_mask is not None:
-                q = batch.spec_info.draft_token_num
-                cm = np.asarray(jax.device_get(metadata.custom_mask))
-                out, off = [], 0
-                for i in range(batch.real_bs):
-                    kl, kla = int(seq_lens[i]), int(aligned_seq_lens[i])
-                    row = cm[off : off + q * kl].reshape(q, kl)
-                    out.append(np.pad(row, ((0, 0), (0, kla - kl))).reshape(-1))
-                    off += q * kl
-                padded_tail = (
-                    q * int(aligned_seq_lens[batch.real_bs :].sum())
-                    if padded_batch_size > batch.real_bs
-                    else 0
-                )
-                metadata.custom_mask = device_array(
-                    np.pad(np.concatenate(out), (0, padded_tail)).astype(np.int32),
-                    sharding=NamedSharding(self.mesh, P()),
-                )
         else:
             aligned_seq_lens = (
                 (batch.seq_lens + self.page_size - 1) // self.page_size

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -233,6 +233,29 @@ class FlashAttention(AttentionBackend):
         if batch.forward_mode.is_target_verify():
             seq_lens += extend_seq_lens
             aligned_seq_lens = ((seq_lens + self.page_size - 1) // self.page_size) * self.page_size
+            # Hybrid-SWA targets at page_size>=256 hit Mosaic's tiling(8) proof
+            # in rpa_v3._fetch_mask. Pad each mask row to page-aligned kv_len so
+            # the kernel can use cu_kv_lens delta as a statically-8-divisible
+            # stride. Dense targets (EAGLE3) keep the unpadded path so accept-
+            # rate / cache-hit behavior is unchanged.
+            if metadata.custom_mask is not None and self.page_size >= 256:
+                q = batch.spec_info.draft_token_num
+                cm = np.asarray(jax.device_get(metadata.custom_mask))
+                out, off = [], 0
+                for i in range(batch.real_bs):
+                    kl, kla = int(seq_lens[i]), int(aligned_seq_lens[i])
+                    row = cm[off : off + q * kl].reshape(q, kl)
+                    out.append(np.pad(row, ((0, 0), (0, kla - kl))).reshape(-1))
+                    off += q * kl
+                padded_tail = (
+                    q * int(aligned_seq_lens[batch.real_bs :].sum())
+                    if padded_batch_size > batch.real_bs
+                    else 0
+                )
+                metadata.custom_mask = device_array(
+                    np.pad(np.concatenate(out), (0, padded_tail)).astype(np.int32),
+                    sharding=NamedSharding(self.mesh, P()),
+                )
         else:
             aligned_seq_lens = (
                 (batch.seq_lens + self.page_size - 1) // self.page_size

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -233,6 +233,29 @@ class FlashAttention(AttentionBackend):
         if batch.forward_mode.is_target_verify():
             seq_lens += extend_seq_lens
             aligned_seq_lens = ((seq_lens + self.page_size - 1) // self.page_size) * self.page_size
+            # rpa_v3 _fetch_mask DMA needs the per-row slice size 8-aligned. Pad
+            # each draft-token row from kv_len to page-aligned kv_len (multiple
+            # of 8, and constant within a page so the mask shape is bucket-stable
+            # across decode steps). seq_lens itself stays unaligned for
+            # _fetch_bkv's cache/new split.
+            if metadata.custom_mask is not None:
+                q = batch.spec_info.draft_token_num
+                cm = np.asarray(jax.device_get(metadata.custom_mask))
+                out, off = [], 0
+                for i in range(batch.real_bs):
+                    kl, kla = int(seq_lens[i]), int(aligned_seq_lens[i])
+                    row = cm[off : off + q * kl].reshape(q, kl)
+                    out.append(np.pad(row, ((0, 0), (0, kla - kl))).reshape(-1))
+                    off += q * kl
+                padded_tail = (
+                    q * int(aligned_seq_lens[batch.real_bs :].sum())
+                    if padded_batch_size > batch.real_bs
+                    else 0
+                )
+                metadata.custom_mask = device_array(
+                    np.pad(np.concatenate(out), (0, padded_tail)).astype(np.int32),
+                    sharding=NamedSharding(self.mesh, P()),
+                )
         else:
             aligned_seq_lens = (
                 (batch.seq_lens + self.page_size - 1) // self.page_size
@@ -303,6 +326,16 @@ class FlashAttention(AttentionBackend):
             (cu_q_lens, cu_kv_lens, page_indices, seq_lens, distribution),
             sharding=(NamedSharding(self.mesh, P("data"))),
         )
+        # Hybrid SWA targets need swa_page_indices for TARGET_VERIFY too,
+        # otherwise SWA layers index the swa sub-pool with full-pool page ids.
+        swa_mapping = getattr(self, "swa_index_mapping", None)
+        if swa_mapping is not None:
+            mapping = swa_mapping[0] if isinstance(swa_mapping, list) else swa_mapping
+            full_loc = (page_indices.astype(np.int64) * self.page_size).astype(np.int32)
+            metadata.swa_page_indices = device_array(
+                (np.asarray(mapping)[full_loc] // self.page_size).astype(np.int32),
+                sharding=NamedSharding(self.mesh, P("data")),
+            )
         return metadata
 
     def get_eagle_multi_step_metadata(self, batch: ModelWorkerBatch):

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -299,9 +299,14 @@ class Scheduler(
 
         # launch draft worker
         if self.spec_algorithm is not None and self.spec_algorithm.is_eagle():
-            from sgl_jax.srt.speculative.eagle_worker import EAGLEWorker
+            if self.spec_algorithm.is_nextn():
+                from sgl_jax.srt.speculative.multi_layer_eagle_worker import (
+                    MultiLayerEAGLEWorker as _SpecWorkerCls,
+                )
+            else:
+                from sgl_jax.srt.speculative.eagle_worker import EAGLEWorker as _SpecWorkerCls
 
-            self.draft_worker = EAGLEWorker(
+            self.draft_worker = _SpecWorkerCls(
                 server_args=server_args,
                 target_worker=self.tp_worker,
             )
@@ -1802,7 +1807,15 @@ class Scheduler(
                 next_token_ids = np.array(jax.device_get(next_token_ids_device))
                 self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
         else:
-            model_worker_batch = batch.get_spec_model_worker_batch(
+            # Spec prefill must use the same padded mwb as nospec so target
+            # forward sees identical input shapes; get_spec_model_worker_batch
+            # skips token/bs padding which can shift logits via MoE EP dispatch.
+            _get = (
+                batch.get_model_worker_batch
+                if batch.forward_mode.is_extend()
+                else batch.get_spec_model_worker_batch
+            )
+            model_worker_batch = _get(
                 precompile_token_paddings,
                 precompile_bs_paddings,
                 precompile_cache_loc_paddings,

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -303,7 +303,12 @@ class Scheduler(
             # Multi-layer vs single-layer is a model property (how many MTP heads
             # the target ships), not a CLI-algorithm property. NEXTN with a single
             # MTP head behaves exactly like EAGLE (same head run N times).
+            # DeepSeek-style configs expose num_nextn_predict_layers; MiMo-style
+            # configs don't, so fall back to --speculative-num-steps under NEXTN
+            # (one MTP weight set per step).
             n_mtp = getattr(self.tp_worker.model_config.hf_config, "num_nextn_predict_layers", None)
+            if n_mtp is None and self.spec_algorithm.is_nextn():
+                n_mtp = server_args.speculative_num_steps
             self._spec_multi_layer = n_mtp is not None and n_mtp > 1
             if self._spec_multi_layer:
                 from sgl_jax.srt.speculative.multi_layer_eagle_worker import (

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -304,7 +304,9 @@ class Scheduler(
                     MultiLayerEAGLEWorker as _SpecWorkerCls,
                 )
             else:
-                from sgl_jax.srt.speculative.eagle_worker import EAGLEWorker as _SpecWorkerCls
+                from sgl_jax.srt.speculative.eagle_worker import (
+                    EAGLEWorker as _SpecWorkerCls,
+                )
 
             self.draft_worker = _SpecWorkerCls(
                 server_args=server_args,

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1809,22 +1809,26 @@ class Scheduler(
                 next_token_ids = np.array(jax.device_get(next_token_ids_device))
                 self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
         else:
-            # NEXTN (MoE+EP target) prefill must use the same padded mwb as
-            # nospec so target forward sees identical input shapes (#1090).
-            # Dense EAGLE/EAGLE3 targets don't need this and EagleDraftWorker
-            # doesn't yet handle padded prefill mwb, so keep the unpadded path.
-            _get = (
-                batch.get_model_worker_batch
-                if batch.forward_mode.is_extend() and self.spec_algorithm.is_nextn()
-                else batch.get_spec_model_worker_batch
-            )
-            model_worker_batch = _get(
-                precompile_token_paddings,
-                precompile_bs_paddings,
-                precompile_cache_loc_paddings,
-                self.page_size,
-                self.server_args.enable_static_lora,
-            )
+            if batch.forward_mode.is_extend() and self.spec_algorithm.is_nextn():
+                # NEXTN (MoE+EP target) prefill must use the same padded mwb as
+                # nospec so target forward sees identical input shapes (#1090).
+                # Dense EAGLE/EAGLE3 targets don't need this and EagleDraftWorker
+                # doesn't yet handle padded prefill mwb.
+                model_worker_batch = batch.get_model_worker_batch(
+                    precompile_token_paddings,
+                    precompile_bs_paddings,
+                    precompile_cache_loc_paddings,
+                    self.page_size,
+                    self.server_args.enable_static_lora,
+                )
+            else:
+                model_worker_batch = batch.get_spec_model_worker_batch(
+                    precompile_token_paddings,
+                    precompile_bs_paddings,
+                    precompile_cache_loc_paddings,
+                    self.page_size,
+                    self.server_args.enable_static_lora,
+                )
             batch_output = self.draft_worker.forward_batch_speculative_generation(
                 model_worker_batch
             )

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1809,12 +1809,13 @@ class Scheduler(
                 next_token_ids = np.array(jax.device_get(next_token_ids_device))
                 self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
         else:
-            # Spec prefill must use the same padded mwb as nospec so target
-            # forward sees identical input shapes; get_spec_model_worker_batch
-            # skips token/bs padding which can shift logits via MoE EP dispatch.
+            # NEXTN (MoE+EP target) prefill must use the same padded mwb as
+            # nospec so target forward sees identical input shapes (#1090).
+            # Dense EAGLE/EAGLE3 targets don't need this and EagleDraftWorker
+            # doesn't yet handle padded prefill mwb, so keep the unpadded path.
             _get = (
                 batch.get_model_worker_batch
-                if batch.forward_mode.is_extend()
+                if batch.forward_mode.is_extend() and self.spec_algorithm.is_nextn()
                 else batch.get_spec_model_worker_batch
             )
             model_worker_batch = _get(

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -298,8 +298,14 @@ class Scheduler(
         )
 
         # launch draft worker
+        self._spec_multi_layer = False
         if self.spec_algorithm is not None and self.spec_algorithm.is_eagle():
-            if self.spec_algorithm.is_nextn():
+            # Multi-layer vs single-layer is a model property (how many MTP heads
+            # the target ships), not a CLI-algorithm property. NEXTN with a single
+            # MTP head behaves exactly like EAGLE (same head run N times).
+            n_mtp = getattr(self.tp_worker.model_config.hf_config, "num_nextn_predict_layers", None)
+            self._spec_multi_layer = n_mtp is not None and n_mtp > 1
+            if self._spec_multi_layer:
                 from sgl_jax.srt.speculative.multi_layer_eagle_worker import (
                     MultiLayerEAGLEWorker as _SpecWorkerCls,
                 )
@@ -1809,11 +1815,11 @@ class Scheduler(
                 next_token_ids = np.array(jax.device_get(next_token_ids_device))
                 self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
         else:
-            if batch.forward_mode.is_extend() and self.spec_algorithm.is_nextn():
-                # NEXTN (MoE+EP target) prefill must use the same padded mwb as
-                # nospec so target forward sees identical input shapes (#1090).
-                # Dense EAGLE/EAGLE3 targets don't need this and EagleDraftWorker
-                # doesn't yet handle padded prefill mwb.
+            if batch.forward_mode.is_extend() and self._spec_multi_layer:
+                # Multi-layer-MTP (MoE+EP target) prefill must use the same padded
+                # mwb as nospec so target forward sees identical shapes (#1090).
+                # EagleDraftWorker doesn't yet handle padded prefill mwb, so gate
+                # on the worker selection rather than the algorithm flag.
                 model_worker_batch = batch.get_model_worker_batch(
                     precompile_token_paddings,
                     precompile_bs_paddings,

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -350,8 +350,11 @@ class SchedulerOutputProcessorMixin:
                 if req.finished():
                     self.maybe_collect_routed_experts(req)
                     if batch.spec_algorithm is not None and batch.spec_algorithm.is_eagle():
-                        cur_allocate_len = info.spec_info.allocate_lens[i]
-                        all_token_len = len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
+                        cur_allocate_len = int(info.spec_info.allocate_lens[i])
+                        actual_token_len = len(req.origin_input_ids) + max(
+                            len(req.output_ids) - 1, 0
+                        )
+                        all_token_len = actual_token_len
                         if self.page_size > 1:
                             all_token_len = cdiv(all_token_len, self.page_size) * self.page_size
                         kv_indices = self.req_to_token_pool.req_to_token[
@@ -366,6 +369,16 @@ class SchedulerOutputProcessorMixin:
                         ), f"redundant kv indices {len(kv_indices)=} should less than {EagleDraftInput.ALLOC_LEN_PER_DECODE=}"
 
                         self.token_to_kv_pool_allocator.free(kv_indices, dp_rank)
+                        # Spec decode allocates via EagleDraftInput.prepare_for_decode,
+                        # not ScheduleBatch.prepare_for_decode, so kv_committed_len is
+                        # never bumped past prefill. cache_finished_req would then
+                        # free only the prefill page and leak every decode-allocated
+                        # page (visible on idle check_memory at bs=1). Use the
+                        # *unaligned* actual token count: ChunkCache.cache_finished_req
+                        # does NOT filter 0-valued req_to_token entries, so a
+                        # page-aligned length would free the page-0 sentinel.
+                        req.kv_committed_len = actual_token_len
+                        req.kv_allocated_len = actual_token_len
                     # End trace for finished request
                     if precision_tracer.get_trace_active():
                         precision_tracer.set_request_status_to_completed(req.rid)

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -819,5 +819,13 @@ class MiMoV2FlashForCausalLM(nnx.Module):
 
         return output, {"token_to_kv_pool": layers_kv_fused}, True, layers_topk_ids
 
+    def get_embed_and_head(self):
+        embed = self.model.embed_tokens.embedding.value
+        if not getattr(self.config, "tie_word_embeddings", True):
+            head = self.lm_head.embedding.value
+        else:
+            head = embed
+        return embed, head
+
 
 EntryClass = [MiMoV2FlashForCausalLM]

--- a/python/sgl_jax/srt/models/mimo_v2_nextn.py
+++ b/python/sgl_jax/srt/models/mimo_v2_nextn.py
@@ -146,6 +146,9 @@ class MiMoV2ModelNextN(nnx.Module):
     ) -> tuple[jax.Array, list[jax.Array]]:
         embed = self.embed_tokens(forward_batch.input_ids)
         hidden_in = forward_batch.spec_info.hidden_states
+        emb_sh = jax.typeof(embed).sharding
+        if isinstance(emb_sh, jax.sharding.NamedSharding):
+            hidden_in = jax.sharding.reshard(hidden_in, emb_sh)
         hidden_states, _ = self.eh_proj(
             jnp.concatenate((self.enorm(embed), self.hnorm(hidden_in)), axis=-1)
         )
@@ -192,7 +195,7 @@ class MiMoV2MTPForCausalLM(nnx.Module):
         output = self.logits_processor(
             hidden_states, self.lm_head, logits_metadata, aux_hidden_states=None
         )
-        return output, layers_kv_fused, []
+        return output, layers_kv_fused, True, None
 
     def load_weights(self, model_config: ModelConfig):
         self.loader = WeightLoader(

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -4,10 +4,12 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 import jax
+import numpy as np
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
 if TYPE_CHECKING:
+    from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
     from sgl_jax.srt.managers.tp_worker import ModelWorker
 
 
@@ -28,29 +30,190 @@ class BaseDraftWorker(ABC):
 
     Concrete implementations hold the draft model runner and own all
     draft-specific logic (multi-step decode, tree building, extend).
-    Standard EAGLE uses ``EagleDraftWorker``; MTP will use
+    Standard EAGLE uses ``EagleDraftWorker``; MTP uses
     ``MultiLayerDraftWorker``.
     """
 
+    @property
     @abstractmethod
-    def draft(self):
+    def draft_model_runner(self):
+        """Primary model runner (multi-runner workers return a designated one)."""
+
+    @abstractmethod
+    def draft(self, model_worker_batch):
+        pass
+
+    @abstractmethod
+    def draft_extend_for_prefill(self, model_worker_batch, hidden_states, next_token_ids):
+        pass
+
+    @abstractmethod
+    def draft_extend_for_decode(self, model_worker_batch, batch_output):
         pass
 
 
-class BaseSpecWorker(ABC):
+class BaseSpecWorker:
     """Speculative decode orchestrator.
 
     Owns a ``target_worker`` (the full model) and a ``draft_worker``
-    (the draft/MTP model).  Concrete subclasses implement the main
-    entry point and connect their specific draft/verify logic.
+    (the draft/MTP model). The orchestration loop (prefill → draft →
+    verify → draft_extend) and ``verify()`` itself are spec-algorithm-
+    agnostic, so they live here; subclasses only differ in which
+    ``BaseDraftWorker`` they construct.
     """
 
-    @property
-    @abstractmethod
-    def target_worker(self) -> ModelWorker:
-        pass
+    def __init__(self, server_args, target_worker: ModelWorker, draft_worker: BaseDraftWorker):
+        self.server_args = server_args
+        self._target_worker = target_worker
+        self._draft_worker = draft_worker
+
+        self.topk = server_args.speculative_eagle_topk
+        self.speculative_num_steps = server_args.speculative_num_steps
+        self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
+        self.page_size = server_args.page_size
+        self.mesh = target_worker.mesh
+
+        from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
+
+        self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
+
+        (
+            self.precompile_token_paddings,
+            self.precompile_bs_paddings,
+            self.precompile_cache_loc_paddings,
+        ) = target_worker.get_precompile_paddings()
 
     @property
-    @abstractmethod
+    def target_worker(self) -> ModelWorker:
+        return self._target_worker
+
+    @property
     def draft_worker(self) -> BaseDraftWorker:
-        pass
+        return self._draft_worker
+
+    # -- Main entry point --
+
+    def forward_batch_speculative_generation(self, model_worker_batch: ModelWorkerBatch):
+        from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+        from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
+
+        if model_worker_batch.forward_mode.is_extend():
+            # FIXME(pc) add padding logic here
+            if model_worker_batch.sampling_info.temperatures.ndim == 1:
+                model_worker_batch.sampling_info.temperatures = (
+                    model_worker_batch.sampling_info.temperatures[:, None]
+                )
+            sampling_metadata = SamplingMetadata.from_model_worker_batch(
+                model_worker_batch,
+                len(model_worker_batch.seq_lens) - model_worker_batch.real_bs,
+                self.mesh,
+                vocab_size=self.target_worker.model_config.vocab_size,
+            )
+            logits_output, next_token_ids, cache_miss_count, bid, _seq_lens = (
+                self.forward_target_extend(model_worker_batch, sampling_metadata)
+            )
+            self.draft_worker.draft_extend_for_prefill(
+                model_worker_batch, logits_output.hidden_states, next_token_ids
+            )
+            return GenerationBatchResult(
+                logits_output=logits_output,
+                next_token_ids=next_token_ids,
+                next_draft_input=model_worker_batch.spec_info,
+                allocate_lens=model_worker_batch.seq_lens[: model_worker_batch.real_bs],
+                bid=bid,
+                cache_miss_count=cache_miss_count,
+                extend_input_len_per_req=None,
+                extend_logprob_start_len_per_req=None,
+            )
+
+        cur_allocate_lens = model_worker_batch.spec_info.allocate_lens
+        self.draft_worker.draft(model_worker_batch)
+        batch_output = self.verify(model_worker_batch, cur_allocate_lens)
+        self.draft_worker.draft_extend_for_decode(model_worker_batch, batch_output)
+        return batch_output
+
+    def forward_target_extend(self, model_worker_batch: ModelWorkerBatch, sampling_metadata):
+        from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode
+
+        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
+        logits_output, next_token_ids, cache_miss_count = (
+            self.target_worker.forward_batch_generation(
+                model_worker_batch, sampling_metadata=sampling_metadata
+            )
+        )
+        return (
+            logits_output,
+            next_token_ids,
+            cache_miss_count,
+            model_worker_batch.bid,
+            model_worker_batch.seq_lens,
+        )
+
+    def verify(self, model_worker_batch: ModelWorkerBatch, cur_allocate_lens: jax.Array):
+        from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+        from sgl_jax.srt.speculative.eagle_util import EagleDraftInput, EagleVerifyInput
+
+        spec_info: EagleVerifyInput = model_worker_batch.spec_info
+        spec_info.allocate_lens = cur_allocate_lens
+        spec_info.prepare_for_verify(model_worker_batch, self.page_size, self.target_worker)
+        forward_metadata = self.target_worker.model_runner.attn_backend.get_eagle_forward_metadata(
+            model_worker_batch
+        )
+
+        logits_output, _, cache_miss_count = self.target_worker.forward_batch_generation(
+            model_worker_batch, skip_sample=True, forward_metadata=forward_metadata
+        )
+        logits_output.next_token_logits, logits_output.hidden_states = replicate_to_mesh(
+            self.mesh, logits_output.next_token_logits, logits_output.hidden_states
+        )
+        spec_info.hidden_states = logits_output.hidden_states
+        (
+            predict,
+            verified_id,
+            accept_length,
+            accept_index,
+        ) = spec_info.sample(
+            model_worker_batch,
+            logits_output,
+            self.draft_worker.draft_model_runner.rngs,
+            self.mesh,
+        )
+        # accept_index uses -1 for rejected slots; gathering with -1 picks the
+        # global last element, so dext later writes rejected tokens' draft-KV at
+        # a foreign position inside each req's page (corrupts prefix KV for all
+        # but the last req at bs>1). Redirect -1 to each req's own last slot.
+        # accept_index has length bs*(spec_steps+1); the gathered tensors have
+        # length bs*draft_token_num — equal at topk=1, distinct at topk>1.
+        draft_n = self.speculative_num_draft_tokens
+        accept_width = self.speculative_num_steps + 1
+        req_ids = np.arange(len(accept_index)) // accept_width
+        per_req_last = req_ids * draft_n + draft_n - 1
+        safe_index = np.where(accept_index >= 0, accept_index, per_req_last)
+        logits_output.next_token_logits = logits_output.next_token_logits[safe_index, :]
+        logits_output.hidden_states = logits_output.hidden_states[safe_index, :]
+        model_worker_batch.positions = model_worker_batch.positions[safe_index]
+        new_seq_lens = model_worker_batch.seq_lens + accept_length
+        next_draft_input = EagleDraftInput(
+            verified_id=verified_id,
+            new_seq_lens=new_seq_lens,
+            allocate_lens=cur_allocate_lens,
+            hidden_states=logits_output.hidden_states,
+        )
+
+        model_worker_batch.spec_info = next_draft_input
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=predict,
+            next_draft_input=next_draft_input,
+            accept_lens=accept_length,
+            # FIXME(pc) this field is for overlap
+            allocate_lens=cur_allocate_lens,
+            bid=model_worker_batch.bid,
+            cache_miss_count=cache_miss_count,
+            extend_input_len_per_req=None,
+            extend_logprob_start_len_per_req=None,
+        )

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -4,23 +4,16 @@ import time
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 from tqdm import tqdm
 
 from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
 from sgl_jax.srt.layers.sampler import get_token_ids_logprobs, get_top_logprobs
-from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch, ScheduleBatch
-from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+from sgl_jax.srt.managers.schedule_batch import ScheduleBatch
 from sgl_jax.srt.managers.tp_worker import ModelWorker
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
-from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
-from sgl_jax.srt.speculative.base_worker import BaseSpecWorker, replicate_to_mesh
+from sgl_jax.srt.speculative.base_worker import BaseSpecWorker
 from sgl_jax.srt.speculative.eagle_draft_worker import EagleDraftWorker
-from sgl_jax.srt.speculative.eagle_util import (
-    EagleDraftInput,
-    EagleVerifyInput,
-    EagleVerifyOutput,
-)
+from sgl_jax.srt.speculative.eagle_util import EagleDraftInput, EagleVerifyOutput
 from sgl_jax.srt.utils.common_utils import get_bool_env_var
 
 logger = logging.getLogger(__name__)
@@ -36,172 +29,14 @@ class EAGLEWorker(BaseSpecWorker):
     """
 
     def __init__(self, server_args, target_worker: ModelWorker, draft_worker=None):
-        self.server_args = server_args
-        self._target_worker = target_worker
-        self._draft_worker = draft_worker or EagleDraftWorker(server_args, target_worker)
-
-        self.topk = server_args.speculative_eagle_topk
-        self.speculative_num_steps = server_args.speculative_num_steps
-        self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
-        self.page_size = server_args.page_size
-        self.mesh = target_worker.mesh
-
-        from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
-
-        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
-            server_args.speculative_algorithm
+        super().__init__(
+            server_args,
+            target_worker,
+            draft_worker or EagleDraftWorker(server_args, target_worker),
         )
 
-        self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
-
-        (
-            precompile_token_paddings,
-            precompile_bs_paddings,
-            precompile_cache_loc_paddings,
-        ) = target_worker.get_precompile_paddings()
-        self.precompile_bs_paddings = precompile_bs_paddings
-        self.precompile_cache_loc_paddings = precompile_cache_loc_paddings
-        self.precompile_token_paddings = precompile_token_paddings
-
-    # -- BaseSpecWorker interface --
-
-    @property
-    def target_worker(self) -> ModelWorker:
-        return self._target_worker
-
-    @property
-    def draft_worker(self) -> EagleDraftWorker:
-        return self._draft_worker
-
-    def forward_batch_speculative_generation(
-        self,
-        model_worker_batch: ModelWorkerBatch,
-    ):
-        if model_worker_batch.forward_mode.is_extend():
-            # FIXME(pc) add padding logic here
-            if model_worker_batch.sampling_info.temperatures.ndim == 1:
-                model_worker_batch.sampling_info.temperatures = (
-                    model_worker_batch.sampling_info.temperatures[:, None]
-                )
-            sampling_metadata = SamplingMetadata.from_model_worker_batch(
-                model_worker_batch,
-                len(model_worker_batch.seq_lens) - model_worker_batch.real_bs,
-                self.mesh,
-                vocab_size=self.target_worker.model_config.vocab_size,
-            )
-            # target extend
-            logits_output, next_token_ids, cache_miss_count, bid, seq_lens = (
-                self.forward_target_extend(model_worker_batch, sampling_metadata)
-            )
-            # draft extend for Update Draft State
-            self.draft_worker.draft_extend_for_prefill(
-                model_worker_batch, logits_output.hidden_states, next_token_ids
-            )
-            # FIXME(pc) refactor this to batch output
-            batch_output = GenerationBatchResult(
-                logits_output=logits_output,
-                next_token_ids=next_token_ids,
-                next_draft_input=model_worker_batch.spec_info,
-                allocate_lens=model_worker_batch.seq_lens[: model_worker_batch.real_bs],
-                bid=bid,
-                cache_miss_count=cache_miss_count,
-                extend_input_len_per_req=None,
-                extend_logprob_start_len_per_req=None,
-            )
-            return batch_output
-
-        else:
-            cur_allocate_lens = model_worker_batch.spec_info.allocate_lens
-            self.draft_worker.draft(model_worker_batch)
-
-            batch_output = self.verify(model_worker_batch, cur_allocate_lens)
-
-            self.draft_worker.draft_extend_for_decode(model_worker_batch, batch_output)
-
-            return batch_output
-
-    # -- Target model methods --
-
-    def forward_target_extend(
-        self, model_worker_batch: ModelWorkerBatch, sample_meta_data: SamplingMetadata
-    ) -> tuple[LogitsProcessorOutput, jax.Array, int, int, np.ndarray]:
-        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
-        logits_output, next_token_ids, cache_miss_count = (
-            self.target_worker.forward_batch_generation(
-                model_worker_batch, sampling_metadata=sample_meta_data
-            )
-        )
-        return (
-            logits_output,
-            next_token_ids,
-            cache_miss_count,
-            model_worker_batch.bid,
-            model_worker_batch.seq_lens,
-        )
-
-    # -- Verify --
-
-    def verify(self, model_worker_batch: ModelWorkerBatch, cur_allocate_lens: jax.Array):
-        spec_info: EagleVerifyInput = model_worker_batch.spec_info
-        spec_info.allocate_lens = cur_allocate_lens
-        spec_info.prepare_for_verify(model_worker_batch, self.page_size, self.target_worker)
-        forward_metadata = self.target_worker.model_runner.attn_backend.get_eagle_forward_metadata(
-            model_worker_batch
-        )
-
-        logits_output, _, cache_miss_count = self.target_worker.forward_batch_generation(
-            model_worker_batch, skip_sample=True, forward_metadata=forward_metadata
-        )
-        logits_output.next_token_logits, logits_output.hidden_states = replicate_to_mesh(
-            self.mesh, logits_output.next_token_logits, logits_output.hidden_states
-        )
-        spec_info.hidden_states = logits_output.hidden_states
-        (
-            predict,
-            verified_id,
-            accept_length,
-            accept_index,
-        ) = spec_info.sample(
-            model_worker_batch,
-            logits_output,
-            self.draft_worker.draft_model_runner.rngs,
-            self.mesh,
-        )
-        # accept_index uses -1 for rejected slots; gathering with -1 picks the
-        # global last element, so dext later writes rejected tokens' draft-KV at
-        # a foreign position inside each req's page (corrupts prefix KV for all
-        # but the last req at bs>1). Redirect -1 to each req's own last slot.
-        # accept_index has length bs*(spec_steps+1); the gathered tensors have
-        # length bs*draft_token_num — equal at topk=1, distinct at topk>1.
-        draft_n = self.speculative_num_draft_tokens
-        accept_width = self.speculative_num_steps + 1
-        req_ids = np.arange(len(accept_index)) // accept_width
-        per_req_last = req_ids * draft_n + draft_n - 1
-        safe_index = np.where(accept_index >= 0, accept_index, per_req_last)
-        logits_output.next_token_logits = logits_output.next_token_logits[safe_index, :]
-        logits_output.hidden_states = logits_output.hidden_states[safe_index, :]
-        model_worker_batch.positions = model_worker_batch.positions[safe_index]
-        new_seq_lens = model_worker_batch.seq_lens + accept_length
-        next_draft_input = EagleDraftInput(
-            verified_id=verified_id,
-            new_seq_lens=new_seq_lens,
-            allocate_lens=cur_allocate_lens,
-            hidden_states=logits_output.hidden_states,
-        )
-
-        model_worker_batch.spec_info = next_draft_input
-        return GenerationBatchResult(
-            logits_output=logits_output,
-            next_token_ids=predict,
-            next_draft_input=next_draft_input,
-            accept_lens=accept_length,
-            # FIXME(pc) this field is for overlap
-            allocate_lens=cur_allocate_lens,
-            bid=model_worker_batch.bid,
-            cache_miss_count=cache_miss_count,
-            extend_input_len_per_req=None,
-            extend_logprob_start_len_per_req=None,
-        )
+    # -- BaseSpecWorker provides target_worker/draft_worker/verify/
+    #    forward_target_extend/forward_batch_speculative_generation --
 
     # -- Logprob post-processing --
 

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -35,10 +35,10 @@ class EAGLEWorker(BaseSpecWorker):
     scheduler interface is unchanged.
     """
 
-    def __init__(self, server_args, target_worker: ModelWorker):
+    def __init__(self, server_args, target_worker: ModelWorker, draft_worker=None):
         self.server_args = server_args
         self._target_worker = target_worker
-        self._draft_worker = EagleDraftWorker(server_args, target_worker)
+        self._draft_worker = draft_worker or EagleDraftWorker(server_args, target_worker)
 
         self.topk = server_args.speculative_eagle_topk
         self.speculative_num_steps = server_args.speculative_num_steps

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -75,8 +75,11 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         self.hot_token_ids = None
 
         self.num_mtp_layers = self.speculative_num_steps
+        assert self.num_mtp_layers > 1
         cfg_mtp = getattr(target_worker.model_config.hf_config, "num_nextn_predict_layers", None)
-        assert cfg_mtp is not None and cfg_mtp > 1 and cfg_mtp == self.num_mtp_layers, (
+        # MiMo-style configs omit num_nextn_predict_layers; only enforce equality
+        # when the field exists (scheduler routes here iff n_mtp>1 either way).
+        assert cfg_mtp is None or cfg_mtp == self.num_mtp_layers, (
             f"--speculative-num-steps={self.speculative_num_steps} must equal the "
             f"model's num_nextn_predict_layers={cfg_mtp} (one runner per MTP layer)"
         )

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -1,0 +1,318 @@
+"""MiMo-V2.5-Pro multi-layer MTP draft worker (#1053 P1-4).
+
+Differs from ``EagleDraftWorker`` in that the N draft steps each use a
+*different* draft model runner (one per ``mtp_layer_idx``), with hidden
+states flowing layer→layer (layer i's output hidden becomes layer i+1's
+``spec_info.hidden_states``). Everything else — padding, tree build,
+verify-input construction, replicate helpers — is reused from
+``EagleDraftWorker``.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata
+from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
+from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+from sgl_jax.srt.managers.tp_worker import ModelWorker
+from sgl_jax.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
+from sgl_jax.srt.speculative.base_worker import replicate_to_mesh
+from sgl_jax.srt.speculative.eagle_draft_worker import (
+    EagleDraftWorker,
+    select_top_k_tokens,
+    topk_probs_from_logits,
+    update_eagle_lists,
+    update_forward_batch_info,
+)
+from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
+from sgl_jax.srt.utils.jax_utils import device_array
+
+logger = logging.getLogger(__name__)
+
+
+def _server_args_with_mtp_layer(server_args, layer_idx: int):
+    sa = copy.copy(server_args)
+    override = json.loads(sa.json_model_override_args or "{}")
+    override["mtp_layer_idx"] = layer_idx
+    sa.json_model_override_args = json.dumps(override)
+    return sa
+
+
+class MultiLayerDraftWorker(EagleDraftWorker):
+    """N independent draft model runners, one per MTP layer.
+
+    ``speculative_num_steps`` must equal the number of MTP layers (one
+    draft step per layer). ``draft_model_runner`` resolves to layer 0's
+    runner for code paths that need a single runner handle (KV-pool
+    sizing, attention-backend type, mesh — all identical across layers).
+    """
+
+    def __init__(self, server_args, target_worker: ModelWorker):
+        self.server_args = server_args
+        self.target_worker_ref = target_worker
+        self.topk = server_args.speculative_eagle_topk
+        self.speculative_num_steps = server_args.speculative_num_steps
+        self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
+        self.page_size = server_args.page_size
+        from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
+        self.hot_token_ids = None
+
+        self.num_mtp_layers = self.speculative_num_steps
+        req_to_token_pool, _ = target_worker.get_memory_pool()
+
+        self._workers: list[ModelWorker] = []
+        for i in range(self.num_mtp_layers):
+            sa = _server_args_with_mtp_layer(server_args, i)
+            self._workers.append(
+                ModelWorker(
+                    sa,
+                    target_worker.mesh,
+                    req_to_token_pool=req_to_token_pool,
+                    is_draft_worker=True,
+                )
+            )
+        self._worker = self._workers[0]
+
+        EagleDraftInput.ALLOC_LEN_PER_DECODE = max(
+            self.speculative_num_steps * self.topk, self.speculative_num_draft_tokens
+        )
+
+        for w in self._workers:
+            self._share_embed_head_one(target_worker, w)
+
+        target_slot_range = target_worker.model_runner.max_total_num_tokens
+        for i, w in enumerate(self._workers):
+            draft_pool = w.model_runner.max_total_num_tokens
+            assert draft_pool >= target_slot_range, (
+                f"MTP layer {i} draft KV pool ({draft_pool}) < target slot range "
+                f"({target_slot_range})"
+            )
+            w.model_runner.initialize_jit()
+
+        (
+            self.precompile_token_paddings,
+            self.precompile_bs_paddings,
+            self.precompile_cache_loc_paddings,
+        ) = target_worker.get_precompile_paddings()
+
+    def _share_embed_head_one(self, target_worker: ModelWorker, draft_worker: ModelWorker):
+        embed, head = target_worker.model_runner.model.get_embed_and_head()
+        m = draft_worker.model_runner.model
+        if getattr(m, "load_lm_head_from_target", False):
+            m.set_embed_and_head(embed, head)
+        else:
+            m.set_embed(embed)
+
+    @property
+    def draft_model_runner(self):
+        return self._workers[0].model_runner
+
+    def runner(self, step: int):
+        return self._workers[step].model_runner
+
+    # ---- per-layer overrides ------------------------------------------------
+
+    def draft_forward(self, model_worker_batch: ModelWorkerBatch):
+        topk_p = model_worker_batch.spec_info.topk_p
+        topk_index = model_worker_batch.spec_info.topk_index
+        hidden_states = model_worker_batch.spec_info.hidden_states
+        bs = model_worker_batch.seq_lens.shape[0]
+        step_min_1 = self.speculative_num_steps - 1
+        score_list = jnp.empty((bs, 1 + step_min_1 * self.topk, self.topk))
+        token_list = jnp.empty(
+            (bs, self.topk + step_min_1 * self.topk * self.topk), dtype=jnp.int32
+        )
+        parents_list = jnp.empty((bs, self.topk + 1 + step_min_1 * self.topk))
+        scores = None
+        positions_base = device_array(
+            np.repeat(model_worker_batch.seq_lens, self.topk),
+            sharding=NamedSharding(self.mesh, P()),
+        )
+        logits_metadata = LogitsMetadata.from_model_worker_batch(model_worker_batch, self.mesh)
+
+        # Per-layer attention metadata: each layer has its own KV pool, so
+        # page_indices differ; positions/seq_lens are shared so we only need
+        # the i-th step's metadata from layer i.
+        metadata_per_layer = [
+            w.model_runner.attn_backend.get_eagle_multi_step_metadata(model_worker_batch)
+            for w in self._workers
+        ]
+
+        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
+        forward_batch.out_cache_loc = np.empty((1,))
+        forward_batch.cache_loc = np.empty((1,))
+        forward_batch.spec_info = EagleDraftInput()
+        forward_batch.spec_info.hidden_states = jnp.empty(
+            (bs * self.topk, hidden_states.shape[1])
+        )
+
+        for i in range(self.speculative_num_steps):
+            input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
+                i, topk_p, topk_index, hidden_states, scores, self.topk
+            )
+            score_list, token_list, parents_list = update_eagle_lists(
+                i, score_list, token_list, parents_list, tree_info, self.topk
+            )
+            if i == self.speculative_num_steps - 1:
+                break
+
+            forward_batch = update_forward_batch_info(
+                forward_batch, i, input_ids, hidden_states, positions_base
+            )
+            mr = self.runner(i)
+            mr.attn_backend.forward_metadata = metadata_per_layer[i][i]
+            forward_batch.bid = model_worker_batch.bid
+            logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)
+
+            topk_p, topk_index = topk_probs_from_logits(
+                logits_output.next_token_logits, self.topk
+            )
+            if self.hot_token_ids is not None:
+                topk_index = self.hot_token_ids[topk_index]
+            hidden_states = replicate_to_mesh(self.mesh, logits_output.hidden_states)
+
+        return score_list, token_list, parents_list
+
+    def draft_extend_for_prefill(
+        self,
+        model_worker_batch: ModelWorkerBatch,
+        hidden_states: jax.Array,
+        next_token_ids: jax.Array,
+    ) -> None:
+        """Prefill-extend across all MTP layers.
+
+        Layer 0 consumes the target's full-prefix hidden_states; layer i>0
+        consumes layer i-1's output hidden. Each layer writes its own
+        prefix KV. Only layer 0's topk/hidden are kept as the next-round
+        draft state (draft step 0 starts from layer 0).
+        """
+        verified_id_np = np.asarray(jax.device_get(next_token_ids))[: model_worker_batch.real_bs]
+        model_worker_batch.spec_info = EagleDraftInput(
+            hidden_states=hidden_states,
+            verified_id=verified_id_np,
+            num_tokens_per_batch=np.asarray(1, dtype=jnp.int32),
+            num_tokens_for_logprob_per_batch=np.asarray(1, dtype=jnp.int32),
+            allocate_lens=model_worker_batch.seq_lens,
+        )
+        model_worker_batch.return_hidden_states = False
+        model_worker_batch.spec_info.prepare_for_extend_after_target_prefill(
+            model_worker_batch=model_worker_batch
+        )
+        # FULL: layer i+1 needs layer i's per-token hidden over the whole prefix.
+        model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.FULL
+        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
+        last_idx = model_worker_batch.logits_indices
+
+        layer0_out = None
+        cur_hidden = hidden_states
+        for i, w in enumerate(self._workers):
+            mr = w.model_runner
+            model_worker_batch.spec_info.hidden_states = cur_hidden
+            forward_batch = ForwardBatch.init_new(model_worker_batch, mr)
+            forward_batch.return_logprob = False
+            mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(
+                model_worker_batch
+            )
+            forward_batch.forward_mode = ForwardMode.EXTEND
+            logits_output, _, _ = mr.forward(
+                forward_batch,
+                logits_metadata=LogitsMetadata.from_model_worker_batch(
+                    model_worker_batch, self.mesh
+                ),
+            )
+            cur_hidden = logits_output.hidden_states
+            if i == 0:
+                layer0_out = logits_output
+
+        # Next-round draft state = layer 0's last-token hidden + topk (draft step 0
+        # starts from layer 0 with target's last hidden, so we cache layer 0's
+        # output here so step 0 can be skipped).
+        rep_logits, rep_hidden = replicate_to_mesh(
+            self.mesh,
+            layer0_out.next_token_logits, layer0_out.hidden_states
+        )
+        layer0_out.next_token_logits = rep_logits[: model_worker_batch.real_bs, :]
+        layer0_out.hidden_states = rep_hidden[last_idx][: model_worker_batch.real_bs]
+        model_worker_batch.spec_info.hidden_states = hidden_states
+        model_worker_batch.spec_info.allocate_lens = model_worker_batch.seq_lens[
+            : model_worker_batch.real_bs
+        ]
+        self.capture_for_decode(layer0_out, model_worker_batch.spec_info)
+
+    def draft_extend_for_decode(
+        self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
+    ) -> None:
+        """Decode-extend across all MTP layers (each updates its own KV).
+
+        Same chaining as prefill: layer 0 consumes target verify hidden,
+        layer i>0 consumes layer i-1's output. Only layer 0's topk/hidden
+        become the next-round draft state.
+        """
+        if batch_output.next_draft_input.verified_id.shape[0] <= 0:
+            return
+        target_hidden = batch_output.logits_output.hidden_states
+
+        # prepare_for_extend_after_verify mutates mwb.seq_lens / input_ids /
+        # spec_info in place — call it once (semantics are layer-independent),
+        # then per layer only swap hidden_states + recompute forward_metadata
+        # against that layer's KV pool.
+        draft_input = EagleDraftInput(
+            hidden_states=target_hidden, allocate_lens=batch_output.allocate_lens
+        )
+        mwb, logits_metadata = draft_input.prepare_for_extend_after_verify(
+            model_worker_batch,
+            self.draft_model_runner,
+            batch_output,
+            self.speculative_num_draft_tokens,
+        )
+        if mwb.input_ids.shape[0] <= 0:
+            return
+
+        layer0_logits = None
+        cur_hidden = target_hidden
+        for i, w in enumerate(self._workers):
+            mr = w.model_runner
+            mwb.spec_info.hidden_states = cur_hidden
+            mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(mwb)
+            forward_batch = ForwardBatch.init_new(mwb, mr)
+            logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)
+            if i == 0:
+                layer0_logits = logits_output
+            cur_hidden = logits_output.hidden_states
+
+        select_index = (
+            np.arange(len(model_worker_batch.seq_lens[: model_worker_batch.real_bs]))
+            * (self.speculative_num_steps + 1)
+            + batch_output.accept_lens[: model_worker_batch.real_bs]
+            - 1
+        )
+        rep_logits, rep_hidden = replicate_to_mesh(
+            self.mesh,
+            layer0_logits.next_token_logits, layer0_logits.hidden_states
+        )
+        topk_p, topk_index = topk_probs_from_logits(rep_logits[select_index], self.topk)
+        batch_output.next_draft_input.hidden_states = rep_hidden[select_index]
+        batch_output.next_draft_input.topk_p = topk_p
+        batch_output.next_draft_input.topk_index = topk_index
+        batch_output.next_draft_input.verified_id = batch_output.next_draft_input.verified_id[
+            select_index
+        ]
+        batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
+        batch_output.accept_lens = batch_output.accept_lens[: model_worker_batch.real_bs]

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -76,7 +76,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
 
         self.num_mtp_layers = self.speculative_num_steps
         cfg_mtp = getattr(target_worker.model_config.hf_config, "num_nextn_predict_layers", None)
-        assert cfg_mtp is None or cfg_mtp == self.num_mtp_layers, (
+        assert cfg_mtp is not None and cfg_mtp > 1 and cfg_mtp == self.num_mtp_layers, (
             f"--speculative-num-steps={self.speculative_num_steps} must equal the "
             f"model's num_nextn_predict_layers={cfg_mtp} (one runner per MTP layer)"
         )

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -159,9 +159,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         forward_batch.out_cache_loc = np.empty((1,))
         forward_batch.cache_loc = np.empty((1,))
         forward_batch.spec_info = EagleDraftInput()
-        forward_batch.spec_info.hidden_states = jnp.empty(
-            (bs * self.topk, hidden_states.shape[1])
-        )
+        forward_batch.spec_info.hidden_states = jnp.empty((bs * self.topk, hidden_states.shape[1]))
 
         for i in range(self.speculative_num_steps):
             input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
@@ -181,9 +179,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
             forward_batch.bid = model_worker_batch.bid
             logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)
 
-            topk_p, topk_index = topk_probs_from_logits(
-                logits_output.next_token_logits, self.topk
-            )
+            topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
             if self.hot_token_ids is not None:
                 topk_index = self.hot_token_ids[topk_index]
             hidden_states = replicate_to_mesh(self.mesh, logits_output.hidden_states)
@@ -245,8 +241,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         # starts from layer 0 with target's last hidden, so we cache layer 0's
         # output here so step 0 can be skipped).
         rep_logits, rep_hidden = replicate_to_mesh(
-            self.mesh,
-            layer0_out.next_token_logits, layer0_out.hidden_states
+            self.mesh, layer0_out.next_token_logits, layer0_out.hidden_states
         )
         layer0_out.next_token_logits = rep_logits[: model_worker_batch.real_bs, :]
         layer0_out.hidden_states = rep_hidden[last_idx][: model_worker_batch.real_bs]
@@ -304,8 +299,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
             - 1
         )
         rep_logits, rep_hidden = replicate_to_mesh(
-            self.mesh,
-            layer0_logits.next_token_logits, layer0_logits.hidden_states
+            self.mesh, layer0_logits.next_token_logits, layer0_logits.hidden_states
         )
         topk_p, topk_index = topk_probs_from_logits(rep_logits[select_index], self.topk)
         batch_output.next_draft_input.hidden_states = rep_hidden[select_index]

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -75,6 +75,11 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         self.hot_token_ids = None
 
         self.num_mtp_layers = self.speculative_num_steps
+        cfg_mtp = getattr(target_worker.model_config.hf_config, "num_nextn_predict_layers", None)
+        assert cfg_mtp is None or cfg_mtp == self.num_mtp_layers, (
+            f"--speculative-num-steps={self.speculative_num_steps} must equal the "
+            f"model's num_nextn_predict_layers={cfg_mtp} (one runner per MTP layer)"
+        )
         req_to_token_pool, _ = target_worker.get_memory_pool()
 
         self._workers: list[ModelWorker] = []

--- a/python/sgl_jax/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_eagle_worker.py
@@ -1,0 +1,23 @@
+"""MiMo-V2.5-Pro multi-layer MTP spec orchestrator (#1053 P1-4).
+
+Thin wrapper over ``EAGLEWorker`` that swaps the draft worker for
+``MultiLayerDraftWorker``. Orchestration (prefill/decode dispatch,
+``verify()``, precompile) is identical to standard EAGLE — only the draft
+side differs (N runners, layer→layer hidden chaining).
+"""
+
+from __future__ import annotations
+
+from sgl_jax.srt.managers.tp_worker import ModelWorker
+from sgl_jax.srt.speculative.eagle_worker import EAGLEWorker
+from sgl_jax.srt.speculative.multi_layer_draft_worker import MultiLayerDraftWorker
+
+
+class MultiLayerEAGLEWorker(EAGLEWorker):
+
+    def __init__(self, server_args, target_worker: ModelWorker):
+        super().__init__(
+            server_args,
+            target_worker,
+            draft_worker=MultiLayerDraftWorker(server_args, target_worker),
+        )

--- a/python/sgl_jax/srt/speculative/spec_info.py
+++ b/python/sgl_jax/srt/speculative/spec_info.py
@@ -59,16 +59,24 @@ class SpeculativeAlgorithm(IntEnum):
     NONE = auto()
     EAGLE = auto()
     EAGLE3 = auto()
+    NEXTN = auto()
     STANDALONE = auto()
 
     def is_none(self):
         return self == SpeculativeAlgorithm.NONE
 
     def is_eagle(self):
-        return self == SpeculativeAlgorithm.EAGLE or self == SpeculativeAlgorithm.EAGLE3
+        return self in (
+            SpeculativeAlgorithm.EAGLE,
+            SpeculativeAlgorithm.EAGLE3,
+            SpeculativeAlgorithm.NEXTN,
+        )
 
     def is_eagle3(self):
         return self == SpeculativeAlgorithm.EAGLE3
+
+    def is_nextn(self):
+        return self == SpeculativeAlgorithm.NEXTN
 
     def is_standalone(self):
         return self == SpeculativeAlgorithm.STANDALONE
@@ -78,6 +86,7 @@ class SpeculativeAlgorithm(IntEnum):
         name_map = {
             "EAGLE": SpeculativeAlgorithm.EAGLE,
             "EAGLE3": SpeculativeAlgorithm.EAGLE3,
+            "NEXTN": SpeculativeAlgorithm.NEXTN,
             "STANDALONE": SpeculativeAlgorithm.STANDALONE,
             None: SpeculativeAlgorithm.NONE,
         }

--- a/python/sgl_jax/test/test_flashattention.py
+++ b/python/sgl_jax/test/test_flashattention.py
@@ -90,22 +90,15 @@ def create_qkv_cache(
     return q, k, v
 
 
-def create_custom_mask(lens, page_size):
-    # Kernel contract: each sequence's mask rows are padded to the page-aligned
-    # kv_len (cu_kv_lens stride), so DMA offset/size stay 8-divisible. Pad with
-    # False (=0 → masked out) and flatten.
+def create_custom_mask(lens):
     q_lens = [q_len for q_len, _ in lens]
     custom_masks = []
     for bid, seq_len in enumerate([kv_len for _, kv_len in lens]):
         q_len = q_lens[bid]
         prefix_len = seq_len - q_len
-        aligned_kv_len = ((seq_len + page_size - 1) // page_size) * page_size
         prefix_mask = jnp.full((q_len, prefix_len), True, dtype=jnp.bool)
         random_q_mask = jax.random.uniform(jax.random.PRNGKey(42), (q_len, q_len)) < 0.5
-        pad_mask = jnp.full((q_len, aligned_kv_len - seq_len), False, dtype=jnp.bool)
-        custom_masks.append(
-            jnp.concatenate([prefix_mask, random_q_mask, pad_mask], axis=1).flatten()
-        )
+        custom_masks.append(jnp.concatenate([prefix_mask, random_q_mask], axis=1).flatten())
 
     return jnp.concatenate(custom_masks)
 
@@ -287,7 +280,7 @@ def create_test_data(
 
     if not causal:
         forward_mode = ForwardMode.EXTEND
-        custom_mask = create_custom_mask(lens, page_size)
+        custom_mask = create_custom_mask(lens)
         spec_info = EagleVerifyInput(
             draft_token=None,
             custom_mask=custom_mask,

--- a/python/sgl_jax/test/test_flashattention.py
+++ b/python/sgl_jax/test/test_flashattention.py
@@ -90,15 +90,22 @@ def create_qkv_cache(
     return q, k, v
 
 
-def create_custom_mask(lens):
+def create_custom_mask(lens, page_size):
+    # Kernel contract: each sequence's mask rows are padded to the page-aligned
+    # kv_len (cu_kv_lens stride), so DMA offset/size stay 8-divisible. Pad with
+    # False (=0 → masked out) and flatten.
     q_lens = [q_len for q_len, _ in lens]
     custom_masks = []
     for bid, seq_len in enumerate([kv_len for _, kv_len in lens]):
         q_len = q_lens[bid]
         prefix_len = seq_len - q_len
+        aligned_kv_len = ((seq_len + page_size - 1) // page_size) * page_size
         prefix_mask = jnp.full((q_len, prefix_len), True, dtype=jnp.bool)
         random_q_mask = jax.random.uniform(jax.random.PRNGKey(42), (q_len, q_len)) < 0.5
-        custom_masks.append(jnp.concatenate([prefix_mask, random_q_mask], axis=1).flatten())
+        pad_mask = jnp.full((q_len, aligned_kv_len - seq_len), False, dtype=jnp.bool)
+        custom_masks.append(
+            jnp.concatenate([prefix_mask, random_q_mask, pad_mask], axis=1).flatten()
+        )
 
     return jnp.concatenate(custom_masks)
 
@@ -280,7 +287,7 @@ def create_test_data(
 
     if not causal:
         forward_mode = ForwardMode.EXTEND
-        custom_mask = create_custom_mask(lens)
+        custom_mask = create_custom_mask(lens, page_size)
         spec_info = EagleVerifyInput(
             draft_token=None,
             custom_mask=custom_mask,


### PR DESCRIPTION
Part of #1053 Phase 1 (P1-4). Stacked on `epic/mtp-refactor-phase1` (#1080 merged).

## What

3-layer MTP for MiMo-V2.5-Pro via `MultiLayerEAGLEWorker` + `MultiLayerDraftWorker`:
- N independent draft `ModelWorker`s (one per `mtp_layer_idx`), hidden states chained layer→layer in `draft_extend_*`
- `draft_forward` step *i* uses runner *i* (per-layer KV pool, per-layer `forward_metadata`)
- Verify/orchestration reused from `BaseSpecWorker` via `draft_worker` injection

Two commits:
- `5db87f1f` — functional: `MultiLayer*` + NEXTN wire-up + model/config/kernel adaptations
- `b731d0c6` — refactor: lift `verify`/`forward_target_extend`/`forward_batch_speculative_generation` to `BaseSpecWorker` (fold #1080 review item (1)/(4); `EAGLEWorker` reduced to `draft_worker` injection + logprob/precompile)

## Includes

- `SpeculativeAlgorithm.NEXTN` + scheduler dispatch
- `model_config`: draft arch→`MiMoV2MTPForCausalLM`, `num_hidden_layers=1`, quant ignore `eh_proj`/`o_proj` (BF16 in checkpoint)
- `mimo_v2_nextn`: 4-tuple `__call__` + concat reshard; `mimo_v2_flash`: `get_embed_and_head`
- `flashattention_backend`: TARGET_VERIFY `custom_mask` page-align pad + `swa_page_indices` for hybrid
- `rpa_v3`: `_fetch_mask` aligned mask stride + `pl.multiple_of` hints (kernel side of mask pad)
- spec prefill via padded `get_model_worker_batch` (epmoe padding-sensitivity, see below)

## E2E (v6e-64, V2.5-Pro, `--ep-size 64 --moe-backend epmoe`, bs=1 topk=1 greedy)

| | |
|---|---|
| crash-free | ✓ prefill / 3×draft_extend / draft_forward / verify / decode loop |
| accept-len | warm 8-round mean **2.53** (5-prompt mix: natural / code / periodic) |
| output vs nospec | first token matches; first ~13–30 tokens match per prompt |

### Known limitation: spec ≠ nospec on MoE+EP after ~13–30 tokens

Verify-stage divergence is **not** a verify-logic bug — it's upstream `EPMoE` bf16 padding-sensitivity: `get_spec_model_worker_batch` doesn't pad tokens/bs (vs nospec's `get_model_worker_batch`), so the same real tokens land at different row indices inside per-expert GMM groups after `_permute`'s `argsort(topk_ids)` → bf16 accumulation order differs → occasional argmax flip. Padded prefill (this PR) makes the first token match; verify (4-token) vs nospec decode (1-token) are inherently different shapes. Dense targets (P1-0 Llama) unaffected. Tracked in #1090 — likely needs a router-side padding mask.

## TODO (follow-up, not blocking)

- [ ] #1080 review (3): `run_spec_decode_precompile` only warms layer 0 via `_worker` delegation (currently `--disable-precompile` in E2E)
- [ ] `draft_forward` per-layer semantics: tested `runner(i+1)` @ step-0 position — accept-len dropped (3.5→2.0), reverted; current `runner(i)` @ step-i is empirically best but the layer/token-shift contract vs MiMo training needs confirming
- [ ] `EagleDraftWorker.__init__` extract `_init_common()` (review (4) full version) — `MultiLayerDraftWorker.__init__` still copies ~20 lines

## Test plan

- [x] v6e-64 E2E: 3-layer MTP load + serve + 6-prompt generate, no crash
- [x] accept-len ≥2.5 (warm)
- [x] spec output = nospec for first N≥13 tokens
- [ ] CI `test_speculative_decoding.py` (P1-8 will add NEXTN case)