### PR TITLE
fix(tokenizer): eliminate same-loop call_soon_threadsafe schedule race in _wait_one_response

### DIFF
--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -448,21 +448,28 @@ class TokenizerManager:
         return state
 
     def _notify_state_event(self, state: ReqState) -> None:
-        """Thread-safe wrapper around state.event.set().
+        """Wake the consumer waiting on ``state.event``.
 
-        If enable_engine_loop_run_forever_daemon was enabled, handle_loop would run on the daemon_loop thread, but the asyncio.Event's
-        internal Future belongs to the eval_loop (the loop that called
-        _send_one_request).  Calling fut.set_result() from the wrong thread
-        does not wake up eval_loop's selector.  call_soon_threadsafe writes to
-        the self-pipe so the selector returns from epoll_wait immediately.
+        Same-loop callers set the event directly to avoid a
+        schedule-after-clear race in ``_wait_one_response``. Cross-loop
+        callers (``enable_engine_loop_run_forever_daemon``) must go through
+        ``call_soon_threadsafe`` because ``Future.set_result`` from the
+        wrong thread cannot wake the eval-loop's selector.
         """
         loop = state.event_loop
-        if loop is not None:
+        if loop is None:
+            state.event.set()
+            return
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is loop:
+            state.event.set()
+        else:
             with contextlib.suppress(RuntimeError):
                 # RuntimeError: loop is already closed (request timed-out / cancelled).
                 loop.call_soon_threadsafe(state.event.set)
-        else:
-            state.event.set()
 
     async def _wait_one_response(
         self,
@@ -489,10 +496,19 @@ class TokenizerManager:
                         ) from e
                 continue
 
-            out = state.out_list[-1]
-
+            # Drain in one sync block so a deferred cross-loop set cannot
+            # wake the next wait_for against an empty list.
+            out_list = state.out_list
             state.out_list = []
-            if state.finished:
+            finished = state.finished
+            state.event.clear()
+
+            if not out_list:
+                continue
+
+            out = out_list[-1]
+
+            if finished:
                 if self.log_requests:
                     max_length, skip_names, out_skip_names = self.log_request_metadata
                     msg = f"Finish: obj={dataclass_to_string_truncated(obj, max_length, skip_names=skip_names)}, out={dataclass_to_string_truncated(out, max_length, skip_names=out_skip_names)}"
@@ -509,8 +525,6 @@ class TokenizerManager:
 
                 yield out
                 break
-
-            state.event.clear()
 
             if obj.stream:
                 yield out

--- a/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
+++ b/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
@@ -949,10 +949,20 @@ class MultimodalTokenizer(TokenizerManager):
                     ) from None
                 continue
 
-            out = state.out_list[-1]
-
+            # Drain in one sync block so a deferred cross-loop set cannot
+            # wake the next wait_for against an empty list. See
+            # ``TokenizerManager._wait_one_response`` for the rationale.
+            out_list = state.out_list
             state.out_list = []
-            if state.finished:
+            finished = state.finished
+            state.event.clear()
+
+            if not out_list:
+                continue
+
+            out = out_list[-1]
+
+            if finished:
                 if self.log_requests:
                     max_length, skip_names, out_skip_names = self.log_request_metadata
                     msg = f"Finish: obj={dataclass_to_string_truncated(obj, max_length, skip_names=skip_names)}, out={dataclass_to_string_truncated(out, max_length, skip_names=out_skip_names)}"
@@ -968,8 +978,6 @@ class MultimodalTokenizer(TokenizerManager):
 
                 yield out
                 break
-
-            state.event.clear()
 
             if obj.stream:
                 yield out

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -475,6 +475,7 @@ suites = {
         TestFile("python/sgl_jax/test/layers/test_gdn_backend.py", 1),
         TestFile("python/sgl_jax/test/layers/test_merged_column_parallel_linear.py", 1),
         TestFile("python/sgl_jax/test/layers/test_qwen3_5_gated_delta_net.py", 1),
+        TestFile("test/srt/test_tokenizer_manager_event.py", 0.1),
     ],
     "unit-test-tpu-v6e-4": [
         TestFile("python/sgl_jax/test/test_mesh.py", 1),

--- a/test/srt/test_tokenizer_manager_event.py
+++ b/test/srt/test_tokenizer_manager_event.py
@@ -1,0 +1,87 @@
+"""Unit tests for the tokenizer manager event-wakeup race fix (#1091)."""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from sgl_jax.srt.managers.tokenizer_manager import ReqState, TokenizerManager
+
+
+def _make_state(loop):
+    """Build a minimal ReqState for testing _notify_state_event /
+    _wait_one_response in isolation."""
+    return ReqState(
+        out_list=[],
+        finished=False,
+        event=asyncio.Event(),
+        obj=None,
+        created_time=0.0,
+        event_loop=loop,
+    )
+
+
+def _make_tm():
+    """Build a minimal TokenizerManager skeleton without running __init__,
+    just enough for the methods under test."""
+    tm = TokenizerManager.__new__(TokenizerManager)
+    tm.wait_timeout = 0.05
+    tm.log_requests = False
+    tm.dump_requests_folder = None
+    tm.crash_dump_folder = None
+    return tm
+
+
+class TestTokenizerManagerEvent(unittest.IsolatedAsyncioTestCase):
+    """Regression tests for the same-loop event race fixed by #1091."""
+
+    async def test_same_loop_notify_is_synchronous(self):
+        """``_notify_state_event`` in same-loop mode must set the event
+        synchronously so the consumer's ``clear()`` cannot race against a
+        deferred ``set`` deferred by ``call_soon_threadsafe``.
+        """
+        loop = asyncio.get_running_loop()
+        state = _make_state(loop)
+        tm = _make_tm()
+
+        self.assertFalse(state.event.is_set())
+        tm._notify_state_event(state)
+        self.assertTrue(
+            state.event.is_set(),
+            msg=(
+                "Same-loop notify must be synchronous; a deferred "
+                "call_soon_threadsafe set is the root cause of #1091."
+            ),
+        )
+
+    async def test_atomic_drain_handles_stale_wakeup(self):
+        """A stale event ``set`` with an empty ``out_list`` (the cross-loop
+        fallback path can still defer past ``clear()``) must hit the
+        ``if not out_list: continue`` guard, not raise ``IndexError`` on
+        ``out_list[-1]``.
+        """
+        loop = asyncio.get_running_loop()
+        state = _make_state(loop)
+        tm = _make_tm()
+
+        # Simulate a stale set arriving after a prior drain emptied the list.
+        state.event.set()
+        self.assertEqual(state.out_list, [])
+
+        obj = SimpleNamespace(rid="test_rid", stream=True)
+        gen = tm._wait_one_response(obj, state, request=None)
+
+        # First wake: stale (event set + out_list empty) -> drain block
+        #   hits ``if not out_list: continue``.
+        # Second wait: no producer ever sets again -> internal ``wait_for``
+        #   times out after ``tm.wait_timeout``, ``request`` is None ->
+        #   inner ``continue`` keeps looping.
+        # The generator never produces output and (critically) never raises
+        # ``IndexError``. We bound the test by wrapping in an outer
+        # ``wait_for`` that times out, proving we did not crash and we did
+        # not return.
+        with self.assertRaises(asyncio.TimeoutError):
+            await asyncio.wait_for(gen.__anext__(), timeout=0.3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `_notify_state_event`: branch on `running is loop`. Same-loop → direct `state.event.set()`; cross-loop → keep `call_soon_threadsafe` (preserves #854's daemon wakeup for #853).
- `_wait_one_response`: atomic drain — snapshot `out_list`, capture `finished`, `clear()` event in one sync block. Defensive `if not out_list: continue` absorbs residual cross-loop stale wakeups.
- Same drain rewrite applied to `multimodal_tokenizer._wait_one_response`.

## Rationale

**Bug**: `_notify_state_event` (#854) always routes through `call_soon_threadsafe`, even on the same loop. The deferred `set()` fires after the consumer has already drained and `clear()`-ed; the stale wake hits an empty `out_list` → `IndexError` (#1091).

**Fix**: same-loop direct `set()` is sync and race-free; cross-loop still schedules so #853 is preserved. The drain rewrite mirrors upstream sglang `_drain_pending_outputs`. `out_dict` carries cumulative `state.text` / `state.output_ids` refs (detokenizer emits deltas, tokenizer manager accumulates), so `out_list[-1]` already contains every token — no coalescing needed for the default streaming path.

## Verification

Repro from #1091 no longer triggers on PR head; throughput within ±5% of an in-cluster defensive-variant baseline (no regression):

| backend | concurrency | num_prompts | Successful | Mean TPOT | Peak throughput |
|---|---:|---:|---:|---:|---:|
| epmoe | 64  | 256  | **256/256**   | 23.3 ms | 3697 tok/s  |
| epmoe | 128 | 512  | **512/512**   | 35.6 ms | 5760 tok/s  |
| epmoe | 256 | 1024 | **1024/1024** | 64.5 ms | 32319 tok/s |
| fused | 64  | 256  | **256/256**   | 25.0 ms | 3703 tok/s  |

Server logs across all runs: `IndexError=0`, `TransferEncoding=0`, `ASGI Exception=0`.

- Daemon-mode path unchanged; `scripts/grpo_demo_llama3_qwen2.py --rollout-engine sglang_jax` shows no regression.
- Unit tests in `test/srt/test_tokenizer_manager_event.py` (registered in `unit-test-tpu-v6e-1`) cover same-loop synchronous notify and atomic-drain stale-wakeup handling.

## Notes for follow-up

- `_handle_abort_req` in `tokenizer_manager.py:1235` calls `state.event.set()` directly instead of `_notify_state_event`. Latent inconsistency in daemon mode (abort from daemon loop may not wake eval loop until `wait_timeout`); HTTP-server race fixed here is unaffected. Left to a cleanup PR.
- `--skip-tokenizer-init + stream` produces delta `output_ids` rather than cumulative refs; `out_list[-1]` silently drops earlier delta chunks on that path. Fix likely needs porting upstream sglang's `incremental_streaming_output` flag plus a coalesce helper — separate design discussion.

Fixes #1091.
