### PR TITLE
perf(bailing-moe-linear): split GLA QKV at load time to skip post-projection all-to-all

### DIFF
--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -68,14 +68,36 @@ class BailingMoELinearAttention(nnx.Module):
 
         inner_size = self.num_heads * self.head_dim
         qkv_bias = getattr(config, "use_bias", False) or getattr(config, "use_qkv_bias", False)
-        self.qkv_proj = LinearBase(
+        # Separate Q/K/V projections (Qwen-style): each shard naturally aligns
+        # with the per-head TP cut, so the [T, num_heads, head_dim] reshape in
+        # __call__ is a no-op metadata change and avoids the all-gather that a
+        # fused-then-split layout would force under explicit sharding.
+        self.q_proj = LinearBase(
             input_size=self.hidden_size,
-            output_size=3 * inner_size,
+            output_size=inner_size,
             use_bias=qkv_bias,
             kernel_axes=(None, "tensor"),
             params_dtype=dtype,
             mesh=mesh,
-            scope_name="query_key_value",
+            scope_name="q_proj",
+        )
+        self.k_proj = LinearBase(
+            input_size=self.hidden_size,
+            output_size=inner_size,
+            use_bias=qkv_bias,
+            kernel_axes=(None, "tensor"),
+            params_dtype=dtype,
+            mesh=mesh,
+            scope_name="k_proj",
+        )
+        self.v_proj = LinearBase(
+            input_size=self.hidden_size,
+            output_size=inner_size,
+            use_bias=qkv_bias,
+            kernel_axes=(None, "tensor"),
+            params_dtype=dtype,
+            mesh=mesh,
+            scope_name="v_proj",
         )
         self.g_proj = LinearBase(
             input_size=self.hidden_size,
@@ -151,17 +173,25 @@ class BailingMoELinearAttention(nnx.Module):
         forward_batch: ForwardBatch,
         recurrent_state_pool,
     ) -> tuple[jax.Array, tuple]:
-        qkv, _ = self.qkv_proj(hidden_states)
-        qkv = qkv.astype(jnp.float32)
-        if self.linear_silu:
-            qkv = jax.nn.silu(qkv)
+        q, _ = self.q_proj(hidden_states)
+        k, _ = self.k_proj(hidden_states)
+        v, _ = self.v_proj(hidden_states)
 
-        qkv = jax.lax.reshape(
-            qkv,
-            (hidden_states.shape[0], 3, self.num_heads, self.head_dim),
-            out_sharding=NamedSharding(self.mesh, P("data", None, "tensor", None)),
-        )
-        q, k, v = qkv[:, 0], qkv[:, 1], qkv[:, 2]
+        q = q.astype(jnp.float32)
+        k = k.astype(jnp.float32)
+        v = v.astype(jnp.float32)
+        if self.linear_silu:
+            q = jax.nn.silu(q)
+            k = jax.nn.silu(k)
+            v = jax.nn.silu(v)
+
+        head_shard = NamedSharding(self.mesh, P("data", "tensor", None))
+        q = q.reshape(hidden_states.shape[0], self.num_heads, self.head_dim,
+                      out_sharding=head_shard)
+        k = k.reshape(hidden_states.shape[0], self.num_heads, self.head_dim,
+                      out_sharding=head_shard)
+        v = v.reshape(hidden_states.shape[0], self.num_heads, self.head_dim,
+                      out_sharding=head_shard)
 
         if self.q_norm is not None:
             q = self.q_norm(q)
@@ -770,7 +800,11 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
         ap = f"{prefix}.attention"
         tp = f"{target}.self_attn"
         mappings[f"{ap}.query_key_value.weight"] = WeightMapping(
-            target_path=f"{tp}.qkv_proj.weight",
+            target_path=[
+                f"{tp}.q_proj.weight",
+                f"{tp}.k_proj.weight",
+                f"{tp}.v_proj.weight",
+            ],
             sharding=(None, "tensor"),
             transpose=True,
         )

--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -6,7 +6,6 @@ import jax
 import numpy as np
 from flax import nnx
 from jax import numpy as jnp
-from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 from transformers import PretrainedConfig
 
@@ -53,30 +52,57 @@ def is_linear_layer(layer_idx: int | None, layer_group_size: int) -> bool:
 def _restripe_qkv_weight(w, *, mesh, tp_size, num_heads_local, head_dim):
     """HF ``[Q_full|K_full|V_full]`` → stripe-interleaved ``[Q_r0|K_r0|V_r0|...]``.
 
+    Each TP rank gathers the full QKV along the ``tensor`` axis, applies the
+    column permutation locally, then slices out its own stripe block. Wrapping
+    the data movement in :func:`jax.shard_map` keeps it valid under JAX's
+    explicit-sharding mode (where a bare ``with_sharding_constraint`` + reshape
+    is rejected because the reshape crosses a sharded axis).
+
     Hoisted to module scope so all decoder layers share one jit cache entry
     (closure-captured Python ints would otherwise force a recompile per layer).
     """
-    hidden = w.shape[0]
-    full_qkv = w.shape[1]
-    w_full = jax.lax.with_sharding_constraint(w, NamedSharding(mesh, P(None, None)))
-    w_full = w_full.reshape(hidden, 3, tp_size, num_heads_local, head_dim)
-    w_full = jnp.transpose(w_full, (0, 2, 1, 3, 4))
-    w_full = w_full.reshape(hidden, full_qkv)
-    return jax.lax.with_sharding_constraint(
-        w_full, NamedSharding(mesh, P(None, "tensor"))
-    )
+
+    def _local(w_local):
+        w_full = jax.lax.all_gather(w_local, axis_name="tensor", axis=1, tiled=True)
+        hidden = w_full.shape[0]
+        full_qkv = w_full.shape[1]
+        w_full = w_full.reshape(hidden, 3, tp_size, num_heads_local, head_dim)
+        w_full = jnp.transpose(w_full, (0, 2, 1, 3, 4))
+        w_full = w_full.reshape(hidden, full_qkv)
+        rank = jax.lax.axis_index("tensor")
+        block = full_qkv // tp_size
+        return jax.lax.dynamic_slice_in_dim(w_full, rank * block, block, axis=1)
+
+    return jax.shard_map(
+        _local,
+        mesh=mesh,
+        in_specs=P(None, "tensor"),
+        out_specs=P(None, "tensor"),
+        check_vma=False,
+    )(w)
 
 
 @functools.partial(
     jax.jit, static_argnames=("mesh", "tp_size", "num_heads_local", "head_dim")
 )
 def _restripe_qkv_bias(b, *, mesh, tp_size, num_heads_local, head_dim):
-    full_qkv = b.shape[0]
-    b_full = jax.lax.with_sharding_constraint(b, NamedSharding(mesh, P(None)))
-    b_full = b_full.reshape(3, tp_size, num_heads_local, head_dim)
-    b_full = jnp.transpose(b_full, (1, 0, 2, 3))
-    b_full = b_full.reshape(full_qkv)
-    return jax.lax.with_sharding_constraint(b_full, NamedSharding(mesh, P("tensor")))
+    def _local(b_local):
+        b_full = jax.lax.all_gather(b_local, axis_name="tensor", axis=0, tiled=True)
+        full_qkv = b_full.shape[0]
+        b_full = b_full.reshape(3, tp_size, num_heads_local, head_dim)
+        b_full = jnp.transpose(b_full, (1, 0, 2, 3))
+        b_full = b_full.reshape(full_qkv)
+        rank = jax.lax.axis_index("tensor")
+        block = full_qkv // tp_size
+        return jax.lax.dynamic_slice_in_dim(b_full, rank * block, block, axis=0)
+
+    return jax.shard_map(
+        _local,
+        mesh=mesh,
+        in_specs=P("tensor"),
+        out_specs=P("tensor"),
+        check_vma=False,
+    )(b)
 
 
 class BailingMoELinearAttention(nnx.Module):

--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -1,5 +1,4 @@
 import copy
-import functools
 import logging
 
 import jax
@@ -20,7 +19,7 @@ from sgl_jax.srt.layers.embeddings import (
     get_rope,
 )
 from sgl_jax.srt.layers.layernorm import RMSNorm
-from sgl_jax.srt.layers.linear import LinearBase, MergedColumnParallelLinear
+from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
 from sgl_jax.srt.layers.moe import (
     EPMoE,
@@ -47,38 +46,6 @@ def is_linear_layer(layer_idx: int | None, layer_group_size: int) -> bool:
     return (layer_idx + 1) % layer_group_size != 0
 
 
-@functools.partial(
-    jax.jit, static_argnames=("mesh", "tp_size", "num_heads_local", "head_dim")
-)
-def _restripe_qkv_weight(w, *, mesh, tp_size, num_heads_local, head_dim):
-    """HF ``[Q_full|K_full|V_full]`` → stripe-interleaved ``[Q_r0|K_r0|V_r0|...]``.
-
-    Hoisted to module scope so all decoder layers share one jit cache entry
-    (closure-captured Python ints would otherwise force a recompile per layer).
-    """
-    hidden = w.shape[0]
-    full_qkv = w.shape[1]
-    w_full = jax.lax.with_sharding_constraint(w, NamedSharding(mesh, P(None, None)))
-    w_full = w_full.reshape(hidden, 3, tp_size, num_heads_local, head_dim)
-    w_full = jnp.transpose(w_full, (0, 2, 1, 3, 4))
-    w_full = w_full.reshape(hidden, full_qkv)
-    return jax.lax.with_sharding_constraint(
-        w_full, NamedSharding(mesh, P(None, "tensor"))
-    )
-
-
-@functools.partial(
-    jax.jit, static_argnames=("mesh", "tp_size", "num_heads_local", "head_dim")
-)
-def _restripe_qkv_bias(b, *, mesh, tp_size, num_heads_local, head_dim):
-    full_qkv = b.shape[0]
-    b_full = jax.lax.with_sharding_constraint(b, NamedSharding(mesh, P(None)))
-    b_full = b_full.reshape(3, tp_size, num_heads_local, head_dim)
-    b_full = jnp.transpose(b_full, (1, 0, 2, 3))
-    b_full = b_full.reshape(full_qkv)
-    return jax.lax.with_sharding_constraint(b_full, NamedSharding(mesh, P("tensor")))
-
-
 class BailingMoELinearAttention(nnx.Module):
     """BailingMoeV2.5 GLA block wired through RadixLightningAttention."""
 
@@ -96,22 +63,16 @@ class BailingMoELinearAttention(nnx.Module):
             config, "head_dim", config.hidden_size // config.num_attention_heads
         )
         self.mesh = mesh
-        self.tp_size = mesh.shape.get("tensor", 1)
         self.linear_silu = getattr(config, "use_linear_silu", getattr(config, "linear_silu", False))
         self.linear_rope = getattr(config, "linear_rope", True)
 
         inner_size = self.num_heads * self.head_dim
         qkv_bias = getattr(config, "use_bias", False) or getattr(config, "use_qkv_bias", False)
-        # Fused Q/K/V with stripe-interleaved per-rank layout
-        # ``[Q_my | K_my | V_my]``: keeps the post-projection split contiguous
-        # within each TP shard, so the ``[T, num_heads, head_dim]`` reshape
-        # below is a pure no-op slice on local data instead of an all-to-all.
-        # ``post_load_weights`` rewrites the loaded HF block-concat weight
-        # into that layout; see the docstring there for the column permutation.
-        self.qkv_proj = MergedColumnParallelLinear(
+        self.qkv_proj = LinearBase(
             input_size=self.hidden_size,
-            output_sizes=[inner_size, inner_size, inner_size],
+            output_size=3 * inner_size,
             use_bias=qkv_bias,
+            kernel_axes=(None, "tensor"),
             params_dtype=dtype,
             mesh=mesh,
             scope_name="query_key_value",
@@ -195,31 +156,12 @@ class BailingMoELinearAttention(nnx.Module):
         if self.linear_silu:
             qkv = jax.nn.silu(qkv)
 
-        tp_size = self.tp_size
-        num_heads_local = self.num_heads // tp_size
-        head_dim = self.head_dim
-
-        def _split_local(qkv_local):
-            # Per-shard layout is ``[Q_my | K_my | V_my]`` along the last axis,
-            # so a contiguous 3-way split is a pure local op (no all-to-all).
-            t_local = qkv_local.shape[0]
-            q_local, k_local, v_local = jnp.split(qkv_local, 3, axis=-1)
-            q_local = q_local.reshape(t_local, num_heads_local, head_dim)
-            k_local = k_local.reshape(t_local, num_heads_local, head_dim)
-            v_local = v_local.reshape(t_local, num_heads_local, head_dim)
-            return q_local, k_local, v_local
-
-        q, k, v = jax.shard_map(
-            _split_local,
-            mesh=self.mesh,
-            in_specs=P("data", "tensor"),
-            out_specs=(
-                P("data", "tensor", None),
-                P("data", "tensor", None),
-                P("data", "tensor", None),
-            ),
-            check_vma=False,
-        )(qkv)
+        qkv = jax.lax.reshape(
+            qkv,
+            (hidden_states.shape[0], 3, self.num_heads, self.head_dim),
+            out_sharding=NamedSharding(self.mesh, P("data", None, "tensor", None)),
+        )
+        q, k, v = qkv[:, 0], qkv[:, 1], qkv[:, 2]
 
         if self.q_norm is not None:
             q = self.q_norm(q)
@@ -235,49 +177,6 @@ class BailingMoELinearAttention(nnx.Module):
         attn_output = self.g_norm(attn_output) * jax.nn.sigmoid(gate)
         output, _ = self.dense(attn_output)
         return output, pool_updates
-
-    def post_load_weights(self) -> None:
-        """Permute the loaded HF block-concat QKV weight into stripe-interleaved layout.
-
-        ``WeightLoader`` lands the HuggingFace ``query_key_value`` weight as
-        ``[hidden, 3*M]`` with HF-native column order
-        ``[Q_full | K_full | V_full]`` and TP shard ``(None, "tensor")``.
-        That layout cuts each TP rank's local columns mid-component (rank 0
-        sees only Q heads), so the per-shard ``[T_local, H_local, head_dim]``
-        view assumed by :meth:`__call__` would require an all-to-all.
-
-        We rearrange columns to the stripe-interleaved layout
-        ``[Q_rank0 | K_rank0 | V_rank0 | Q_rank1 | ...]`` so the same
-        ``(None, "tensor")`` shard places ``[Q_my | K_my | V_my]`` contiguously
-        on each device. The reshape runs once per layer at load time inside a
-        single jit; the temporary fully-replicated tensor is one layer's QKV
-        weight (~96 MiB at bf16 for Ling-2.6-flash).
-
-        Bias follows the same layout when present.
-        """
-        tp_size = self.tp_size
-        if tp_size == 1:
-            return
-        num_heads_local = self.num_heads // tp_size
-        head_dim = self.head_dim
-        mesh = self.mesh
-
-        self.qkv_proj.weight.value = _restripe_qkv_weight(
-            self.qkv_proj.weight.value,
-            mesh=mesh,
-            tp_size=tp_size,
-            num_heads_local=num_heads_local,
-            head_dim=head_dim,
-        )
-
-        if self.qkv_proj.bias is not None:
-            self.qkv_proj.bias.value = _restripe_qkv_bias(
-                self.qkv_proj.bias.value,
-                mesh=mesh,
-                tp_size=tp_size,
-                num_heads_local=num_heads_local,
-                head_dim=head_dim,
-            )
 
 
 class BailingMoEGQAAttention(nnx.Module):
@@ -788,8 +687,6 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
         loader.load_weights_from_safetensors(mappings)
         for layer in self.model.layers:
             if isinstance(layer.self_attn, DeepseekV3Attention):
-                layer.self_attn.post_load_weights()
-            elif isinstance(layer.self_attn, BailingMoELinearAttention):
                 layer.self_attn.post_load_weights()
         logger.info("BailingMoeV2.5 weights loaded successfully!")
 

--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -19,7 +19,7 @@ from sgl_jax.srt.layers.embeddings import (
     get_rope,
 )
 from sgl_jax.srt.layers.layernorm import RMSNorm
-from sgl_jax.srt.layers.linear import LinearBase, MergedColumnParallelLinear
+from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
 from sgl_jax.srt.layers.moe import (
     EPMoE,
@@ -123,21 +123,28 @@ class BailingMoELinearAttention(nnx.Module):
         )
         self.mesh = mesh
         self.tp_size = mesh.shape.get("tensor", 1)
+        assert self.num_heads % self.tp_size == 0, (
+            f"BailingMoE GLA: num_heads={self.num_heads} must divide TP={self.tp_size} "
+            f"(restripe assumes num_heads_local = num_heads // tp_size is integral)."
+        )
         self.linear_silu = getattr(config, "use_linear_silu", getattr(config, "linear_silu", False))
         self.linear_rope = getattr(config, "linear_rope", True)
 
         inner_size = self.num_heads * self.head_dim
         qkv_bias = getattr(config, "use_bias", False) or getattr(config, "use_qkv_bias", False)
-        # Fused Q/K/V with stripe-interleaved per-rank layout
-        # ``[Q_my | K_my | V_my]``: keeps the post-projection split contiguous
-        # within each TP shard, so the ``[T, num_heads, head_dim]`` reshape
-        # below is a pure no-op slice on local data instead of an all-to-all.
-        # ``post_load_weights`` rewrites the loaded HF block-concat weight
-        # into that layout; see the docstring there for the column permutation.
-        self.qkv_proj = MergedColumnParallelLinear(
+        # Fused Q/K/V: weight is [hidden, 3*inner_size] with stripe-interleaved
+        # per-rank layout ``[Q_my | K_my | V_my]``, enforced by
+        # ``post_load_weights`` rewriting the loaded HF block-concat columns.
+        # Keeps the post-projection split contiguous within each TP shard, so
+        # the ``[T, num_heads, head_dim]`` reshape below is a pure no-op slice
+        # on local data instead of an all-to-all. Q/K/V are equal-sized here,
+        # so plain ``LinearBase`` suffices (no need for
+        # ``MergedColumnParallelLinear``'s per-component metadata).
+        self.qkv_proj = LinearBase(
             input_size=self.hidden_size,
-            output_sizes=[inner_size, inner_size, inner_size],
+            output_size=3 * inner_size,
             use_bias=qkv_bias,
+            kernel_axes=(None, "tensor"),
             params_dtype=dtype,
             mesh=mesh,
             scope_name="query_key_value",

--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -6,6 +6,7 @@ import jax
 import numpy as np
 from flax import nnx
 from jax import numpy as jnp
+from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 from transformers import PretrainedConfig
 
@@ -52,57 +53,30 @@ def is_linear_layer(layer_idx: int | None, layer_group_size: int) -> bool:
 def _restripe_qkv_weight(w, *, mesh, tp_size, num_heads_local, head_dim):
     """HF ``[Q_full|K_full|V_full]`` → stripe-interleaved ``[Q_r0|K_r0|V_r0|...]``.
 
-    Each TP rank gathers the full QKV along the ``tensor`` axis, applies the
-    column permutation locally, then slices out its own stripe block. Wrapping
-    the data movement in :func:`jax.shard_map` keeps it valid under JAX's
-    explicit-sharding mode (where a bare ``with_sharding_constraint`` + reshape
-    is rejected because the reshape crosses a sharded axis).
-
     Hoisted to module scope so all decoder layers share one jit cache entry
     (closure-captured Python ints would otherwise force a recompile per layer).
     """
-
-    def _local(w_local):
-        w_full = jax.lax.all_gather(w_local, axis_name="tensor", axis=1, tiled=True)
-        hidden = w_full.shape[0]
-        full_qkv = w_full.shape[1]
-        w_full = w_full.reshape(hidden, 3, tp_size, num_heads_local, head_dim)
-        w_full = jnp.transpose(w_full, (0, 2, 1, 3, 4))
-        w_full = w_full.reshape(hidden, full_qkv)
-        rank = jax.lax.axis_index("tensor")
-        block = full_qkv // tp_size
-        return jax.lax.dynamic_slice_in_dim(w_full, rank * block, block, axis=1)
-
-    return jax.shard_map(
-        _local,
-        mesh=mesh,
-        in_specs=P(None, "tensor"),
-        out_specs=P(None, "tensor"),
-        check_vma=False,
-    )(w)
+    hidden = w.shape[0]
+    full_qkv = w.shape[1]
+    w_full = jax.lax.with_sharding_constraint(w, NamedSharding(mesh, P(None, None)))
+    w_full = w_full.reshape(hidden, 3, tp_size, num_heads_local, head_dim)
+    w_full = jnp.transpose(w_full, (0, 2, 1, 3, 4))
+    w_full = w_full.reshape(hidden, full_qkv)
+    return jax.lax.with_sharding_constraint(
+        w_full, NamedSharding(mesh, P(None, "tensor"))
+    )
 
 
 @functools.partial(
     jax.jit, static_argnames=("mesh", "tp_size", "num_heads_local", "head_dim")
 )
 def _restripe_qkv_bias(b, *, mesh, tp_size, num_heads_local, head_dim):
-    def _local(b_local):
-        b_full = jax.lax.all_gather(b_local, axis_name="tensor", axis=0, tiled=True)
-        full_qkv = b_full.shape[0]
-        b_full = b_full.reshape(3, tp_size, num_heads_local, head_dim)
-        b_full = jnp.transpose(b_full, (1, 0, 2, 3))
-        b_full = b_full.reshape(full_qkv)
-        rank = jax.lax.axis_index("tensor")
-        block = full_qkv // tp_size
-        return jax.lax.dynamic_slice_in_dim(b_full, rank * block, block, axis=0)
-
-    return jax.shard_map(
-        _local,
-        mesh=mesh,
-        in_specs=P("tensor"),
-        out_specs=P("tensor"),
-        check_vma=False,
-    )(b)
+    full_qkv = b.shape[0]
+    b_full = jax.lax.with_sharding_constraint(b, NamedSharding(mesh, P(None)))
+    b_full = b_full.reshape(3, tp_size, num_heads_local, head_dim)
+    b_full = jnp.transpose(b_full, (1, 0, 2, 3))
+    b_full = b_full.reshape(full_qkv)
+    return jax.lax.with_sharding_constraint(b_full, NamedSharding(mesh, P("tensor")))
 
 
 class BailingMoELinearAttention(nnx.Module):

--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -19,7 +19,7 @@ from sgl_jax.srt.layers.embeddings import (
     get_rope,
 )
 from sgl_jax.srt.layers.layernorm import RMSNorm
-from sgl_jax.srt.layers.linear import LinearBase
+from sgl_jax.srt.layers.linear import LinearBase, MergedColumnParallelLinear
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
 from sgl_jax.srt.layers.moe import (
     EPMoE,
@@ -123,28 +123,21 @@ class BailingMoELinearAttention(nnx.Module):
         )
         self.mesh = mesh
         self.tp_size = mesh.shape.get("tensor", 1)
-        assert self.num_heads % self.tp_size == 0, (
-            f"BailingMoE GLA: num_heads={self.num_heads} must divide TP={self.tp_size} "
-            f"(restripe assumes num_heads_local = num_heads // tp_size is integral)."
-        )
         self.linear_silu = getattr(config, "use_linear_silu", getattr(config, "linear_silu", False))
         self.linear_rope = getattr(config, "linear_rope", True)
 
         inner_size = self.num_heads * self.head_dim
         qkv_bias = getattr(config, "use_bias", False) or getattr(config, "use_qkv_bias", False)
-        # Fused Q/K/V: weight is [hidden, 3*inner_size] with stripe-interleaved
-        # per-rank layout ``[Q_my | K_my | V_my]``, enforced by
-        # ``post_load_weights`` rewriting the loaded HF block-concat columns.
-        # Keeps the post-projection split contiguous within each TP shard, so
-        # the ``[T, num_heads, head_dim]`` reshape below is a pure no-op slice
-        # on local data instead of an all-to-all. Q/K/V are equal-sized here,
-        # so plain ``LinearBase`` suffices (no need for
-        # ``MergedColumnParallelLinear``'s per-component metadata).
-        self.qkv_proj = LinearBase(
+        # Fused Q/K/V with stripe-interleaved per-rank layout
+        # ``[Q_my | K_my | V_my]``: keeps the post-projection split contiguous
+        # within each TP shard, so the ``[T, num_heads, head_dim]`` reshape
+        # below is a pure no-op slice on local data instead of an all-to-all.
+        # ``post_load_weights`` rewrites the loaded HF block-concat weight
+        # into that layout; see the docstring there for the column permutation.
+        self.qkv_proj = MergedColumnParallelLinear(
             input_size=self.hidden_size,
-            output_size=3 * inner_size,
+            output_sizes=[inner_size, inner_size, inner_size],
             use_bias=qkv_bias,
-            kernel_axes=(None, "tensor"),
             params_dtype=dtype,
             mesh=mesh,
             scope_name="query_key_value",

--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -33,7 +33,7 @@ from sgl_jax.srt.layers.radix_lightning_attention import RadixLightningAttention
 from sgl_jax.srt.mem_cache.memory_pool import KVCache, MemoryPools
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
 from sgl_jax.srt.models.deepseek_v3 import DeepseekV3Attention, DeepseekV3MLP
-from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+from sgl_jax.srt.utils.weight_utils import HeadContext, WeightLoader, WeightMapping
 
 logger = logging.getLogger(__name__)
 
@@ -186,12 +186,15 @@ class BailingMoELinearAttention(nnx.Module):
             v = jax.nn.silu(v)
 
         head_shard = NamedSharding(self.mesh, P("data", "tensor", None))
-        q = q.reshape(hidden_states.shape[0], self.num_heads, self.head_dim,
-                      out_sharding=head_shard)
-        k = k.reshape(hidden_states.shape[0], self.num_heads, self.head_dim,
-                      out_sharding=head_shard)
-        v = v.reshape(hidden_states.shape[0], self.num_heads, self.head_dim,
-                      out_sharding=head_shard)
+        q = q.reshape(
+            hidden_states.shape[0], self.num_heads, self.head_dim, out_sharding=head_shard
+        )
+        k = k.reshape(
+            hidden_states.shape[0], self.num_heads, self.head_dim, out_sharding=head_shard
+        )
+        v = v.reshape(
+            hidden_states.shape[0], self.num_heads, self.head_dim, out_sharding=head_shard
+        )
 
         if self.q_norm is not None:
             q = self.q_norm(q)
@@ -799,6 +802,23 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
     def _add_linear_attention_mappings(self, mappings: dict, prefix: str, target: str) -> None:
         ap = f"{prefix}.attention"
         tp = f"{target}.self_attn"
+        # GLA layers use the unpatched hf_text_config head dims (head_dim=128,
+        # num_kv_heads_for_linear_attn=num_attention_heads). model_config.head_dim
+        # has been overwritten to MLA's qk_head_dim by patch_model_config — pin
+        # the loader to the layer-local truth so QKV slicing matches the layer
+        # weights actually built for this projection.
+        gla_head_dim = getattr(
+            self.config, "head_dim", self.config.hidden_size // self.config.num_attention_heads
+        )
+        gla_kv_heads = getattr(
+            self.config, "num_kv_heads_for_linear_attn", self.config.num_attention_heads
+        )
+        gla_heads = HeadContext(
+            num_heads=self.config.num_attention_heads,
+            num_kv_heads=gla_kv_heads,
+            head_dim=gla_head_dim,
+            v_head_dim=gla_head_dim,
+        )
         mappings[f"{ap}.query_key_value.weight"] = WeightMapping(
             target_path=[
                 f"{tp}.q_proj.weight",
@@ -807,6 +827,7 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
             ],
             sharding=(None, "tensor"),
             transpose=True,
+            head_context=gla_heads,
         )
         mappings[f"{ap}.g_proj.weight"] = WeightMapping(
             target_path=f"{tp}.g_proj.weight",

--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import logging
 
 import jax
@@ -19,7 +20,7 @@ from sgl_jax.srt.layers.embeddings import (
     get_rope,
 )
 from sgl_jax.srt.layers.layernorm import RMSNorm
-from sgl_jax.srt.layers.linear import LinearBase
+from sgl_jax.srt.layers.linear import LinearBase, MergedColumnParallelLinear
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
 from sgl_jax.srt.layers.moe import (
     EPMoE,
@@ -46,6 +47,38 @@ def is_linear_layer(layer_idx: int | None, layer_group_size: int) -> bool:
     return (layer_idx + 1) % layer_group_size != 0
 
 
+@functools.partial(
+    jax.jit, static_argnames=("mesh", "tp_size", "num_heads_local", "head_dim")
+)
+def _restripe_qkv_weight(w, *, mesh, tp_size, num_heads_local, head_dim):
+    """HF ``[Q_full|K_full|V_full]`` → stripe-interleaved ``[Q_r0|K_r0|V_r0|...]``.
+
+    Hoisted to module scope so all decoder layers share one jit cache entry
+    (closure-captured Python ints would otherwise force a recompile per layer).
+    """
+    hidden = w.shape[0]
+    full_qkv = w.shape[1]
+    w_full = jax.lax.with_sharding_constraint(w, NamedSharding(mesh, P(None, None)))
+    w_full = w_full.reshape(hidden, 3, tp_size, num_heads_local, head_dim)
+    w_full = jnp.transpose(w_full, (0, 2, 1, 3, 4))
+    w_full = w_full.reshape(hidden, full_qkv)
+    return jax.lax.with_sharding_constraint(
+        w_full, NamedSharding(mesh, P(None, "tensor"))
+    )
+
+
+@functools.partial(
+    jax.jit, static_argnames=("mesh", "tp_size", "num_heads_local", "head_dim")
+)
+def _restripe_qkv_bias(b, *, mesh, tp_size, num_heads_local, head_dim):
+    full_qkv = b.shape[0]
+    b_full = jax.lax.with_sharding_constraint(b, NamedSharding(mesh, P(None)))
+    b_full = b_full.reshape(3, tp_size, num_heads_local, head_dim)
+    b_full = jnp.transpose(b_full, (1, 0, 2, 3))
+    b_full = b_full.reshape(full_qkv)
+    return jax.lax.with_sharding_constraint(b_full, NamedSharding(mesh, P("tensor")))
+
+
 class BailingMoELinearAttention(nnx.Module):
     """BailingMoeV2.5 GLA block wired through RadixLightningAttention."""
 
@@ -63,16 +96,22 @@ class BailingMoELinearAttention(nnx.Module):
             config, "head_dim", config.hidden_size // config.num_attention_heads
         )
         self.mesh = mesh
+        self.tp_size = mesh.shape.get("tensor", 1)
         self.linear_silu = getattr(config, "use_linear_silu", getattr(config, "linear_silu", False))
         self.linear_rope = getattr(config, "linear_rope", True)
 
         inner_size = self.num_heads * self.head_dim
         qkv_bias = getattr(config, "use_bias", False) or getattr(config, "use_qkv_bias", False)
-        self.qkv_proj = LinearBase(
+        # Fused Q/K/V with stripe-interleaved per-rank layout
+        # ``[Q_my | K_my | V_my]``: keeps the post-projection split contiguous
+        # within each TP shard, so the ``[T, num_heads, head_dim]`` reshape
+        # below is a pure no-op slice on local data instead of an all-to-all.
+        # ``post_load_weights`` rewrites the loaded HF block-concat weight
+        # into that layout; see the docstring there for the column permutation.
+        self.qkv_proj = MergedColumnParallelLinear(
             input_size=self.hidden_size,
-            output_size=3 * inner_size,
+            output_sizes=[inner_size, inner_size, inner_size],
             use_bias=qkv_bias,
-            kernel_axes=(None, "tensor"),
             params_dtype=dtype,
             mesh=mesh,
             scope_name="query_key_value",
@@ -156,12 +195,31 @@ class BailingMoELinearAttention(nnx.Module):
         if self.linear_silu:
             qkv = jax.nn.silu(qkv)
 
-        qkv = jax.lax.reshape(
-            qkv,
-            (hidden_states.shape[0], 3, self.num_heads, self.head_dim),
-            out_sharding=NamedSharding(self.mesh, P("data", None, "tensor", None)),
-        )
-        q, k, v = qkv[:, 0], qkv[:, 1], qkv[:, 2]
+        tp_size = self.tp_size
+        num_heads_local = self.num_heads // tp_size
+        head_dim = self.head_dim
+
+        def _split_local(qkv_local):
+            # Per-shard layout is ``[Q_my | K_my | V_my]`` along the last axis,
+            # so a contiguous 3-way split is a pure local op (no all-to-all).
+            t_local = qkv_local.shape[0]
+            q_local, k_local, v_local = jnp.split(qkv_local, 3, axis=-1)
+            q_local = q_local.reshape(t_local, num_heads_local, head_dim)
+            k_local = k_local.reshape(t_local, num_heads_local, head_dim)
+            v_local = v_local.reshape(t_local, num_heads_local, head_dim)
+            return q_local, k_local, v_local
+
+        q, k, v = jax.shard_map(
+            _split_local,
+            mesh=self.mesh,
+            in_specs=P("data", "tensor"),
+            out_specs=(
+                P("data", "tensor", None),
+                P("data", "tensor", None),
+                P("data", "tensor", None),
+            ),
+            check_vma=False,
+        )(qkv)
 
         if self.q_norm is not None:
             q = self.q_norm(q)
@@ -177,6 +235,49 @@ class BailingMoELinearAttention(nnx.Module):
         attn_output = self.g_norm(attn_output) * jax.nn.sigmoid(gate)
         output, _ = self.dense(attn_output)
         return output, pool_updates
+
+    def post_load_weights(self) -> None:
+        """Permute the loaded HF block-concat QKV weight into stripe-interleaved layout.
+
+        ``WeightLoader`` lands the HuggingFace ``query_key_value`` weight as
+        ``[hidden, 3*M]`` with HF-native column order
+        ``[Q_full | K_full | V_full]`` and TP shard ``(None, "tensor")``.
+        That layout cuts each TP rank's local columns mid-component (rank 0
+        sees only Q heads), so the per-shard ``[T_local, H_local, head_dim]``
+        view assumed by :meth:`__call__` would require an all-to-all.
+
+        We rearrange columns to the stripe-interleaved layout
+        ``[Q_rank0 | K_rank0 | V_rank0 | Q_rank1 | ...]`` so the same
+        ``(None, "tensor")`` shard places ``[Q_my | K_my | V_my]`` contiguously
+        on each device. The reshape runs once per layer at load time inside a
+        single jit; the temporary fully-replicated tensor is one layer's QKV
+        weight (~96 MiB at bf16 for Ling-2.6-flash).
+
+        Bias follows the same layout when present.
+        """
+        tp_size = self.tp_size
+        if tp_size == 1:
+            return
+        num_heads_local = self.num_heads // tp_size
+        head_dim = self.head_dim
+        mesh = self.mesh
+
+        self.qkv_proj.weight.value = _restripe_qkv_weight(
+            self.qkv_proj.weight.value,
+            mesh=mesh,
+            tp_size=tp_size,
+            num_heads_local=num_heads_local,
+            head_dim=head_dim,
+        )
+
+        if self.qkv_proj.bias is not None:
+            self.qkv_proj.bias.value = _restripe_qkv_bias(
+                self.qkv_proj.bias.value,
+                mesh=mesh,
+                tp_size=tp_size,
+                num_heads_local=num_heads_local,
+                head_dim=head_dim,
+            )
 
 
 class BailingMoEGQAAttention(nnx.Module):
@@ -687,6 +788,8 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
         loader.load_weights_from_safetensors(mappings)
         for layer in self.model.layers:
             if isinstance(layer.self_attn, DeepseekV3Attention):
+                layer.self_attn.post_load_weights()
+            elif isinstance(layer.self_attn, BailingMoELinearAttention):
                 layer.self_attn.post_load_weights()
         logger.info("BailingMoeV2.5 weights loaded successfully!")
 

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -2551,6 +2551,10 @@ class WeightLoader:
     def _split_qkv_weight(
         self, params: nnx.State, hf_key: str, weight: jax.Array, mapping: WeightMapping
     ):
+        # Hybrid-attention models (MLA + GLA, etc.) should set mapping.head_context
+        # (see HeadContext / _resolve_heads). Without it, head dims fall back to the
+        # loader-global cache from __init__, which patch_model_config may have
+        # overwritten to a different arch's head_dim — silently mis-slicing weights.
         jax_paths = mapping.target_path
 
         num_heads, num_kv_heads, head_dim_original, v_head_dim = self._resolve_heads(mapping)

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -49,6 +49,28 @@ def _reinterpret_dtype_if_needed(data: np.ndarray, target_dtype: jnp.dtype) -> n
 
 
 @dataclass
+class HeadContext:
+    """Per-mapping override for the loader's head-config globals.
+
+    Why: Hybrid-attention models (MLA + GLA, MoE + dense, ...) cache one
+    (num_heads, num_kv_heads, head_dim, v_head_dim) tuple at WeightLoader
+    init time from model_config. If a layer's true head config diverges
+    from that tuple — e.g. BailingMoE V2.5's patch_model_config sets
+    head_dim to MLA's qk_head_dim=192 while GLA layers stay at 128 —
+    every head_dim-derived computation in _split_qkv_weight /
+    _apply_kv_head_padding silently mis-slices the weight.
+
+    Any field left None falls back to the loader-global value, so this
+    is opt-in and backward-compatible for Qwen/Llama/MLA mappings.
+    """
+
+    num_heads: int | None = None
+    num_kv_heads: int | None = None
+    head_dim: int | None = None  # unpadded; loader applies TPU 128-padding on top
+    v_head_dim: int | None = None
+
+
+@dataclass
 class WeightMapping:
     target_path: str | list[str]
     sharding: tuple | None = None
@@ -63,6 +85,7 @@ class WeightMapping:
     concat_axis: int | None = None
     is_eagle3: bool = False
     physical_to_logical_map: np.ndarray | None = None
+    head_context: HeadContext | None = None
 
     def __post_init__(self):
         if self.sharding is None:
@@ -2471,7 +2494,7 @@ class WeightLoader:
             axis, times = mapping.repeat
             processed_weight = jnp.repeat(processed_weight, times, axis=axis)
         if mapping.kv_head_padding:
-            processed_weight = self._apply_kv_head_padding(processed_weight, hf_key)
+            processed_weight = self._apply_kv_head_padding(processed_weight, hf_key, mapping)
 
         sharded_weight = self._shard_weight(processed_weight, mapping.sharding)
 
@@ -2503,37 +2526,61 @@ class WeightLoader:
     ):
         self._split_qkv_weight(params, hf_key, weight, mapping)
 
+    def _resolve_heads(self, mapping: WeightMapping) -> tuple[int, int, int, int]:
+        """Return (num_heads, num_kv_heads, head_dim_original, v_head_dim).
+
+        Per-mapping `head_context` fields override the loader-global head
+        config; unset (None) fields fall back to the loader defaults so
+        mappings without a head_context keep their previous behavior.
+        """
+        ctx = mapping.head_context
+        if ctx is None:
+            return (
+                self.num_heads,
+                self.num_kv_heads,
+                self.head_dim_original,
+                self.v_head_dim,
+            )
+        return (
+            ctx.num_heads if ctx.num_heads is not None else self.num_heads,
+            ctx.num_kv_heads if ctx.num_kv_heads is not None else self.num_kv_heads,
+            ctx.head_dim if ctx.head_dim is not None else self.head_dim_original,
+            ctx.v_head_dim if ctx.v_head_dim is not None else self.v_head_dim,
+        )
+
     def _split_qkv_weight(
         self, params: nnx.State, hf_key: str, weight: jax.Array, mapping: WeightMapping
     ):
         jax_paths = mapping.target_path
 
-        v_head_dim = getattr(self, "v_head_dim", self.head_dim_original)
+        num_heads, num_kv_heads, head_dim_original, v_head_dim = self._resolve_heads(mapping)
+        head_dim_pad = (head_dim_original + 127) // 128 * 128 - head_dim_original
+        head_dim_padded = head_dim_original + head_dim_pad
         v_head_dim_pad = (v_head_dim + 127) // 128 * 128 - v_head_dim
         v_head_dim_padded = v_head_dim + v_head_dim_pad
 
         if hf_key.endswith(".bias"):
-            q_dim = self.num_heads * self.head_dim_original
-            k_dim = self.num_kv_heads * self.head_dim_original
-            v_dim = self.num_kv_heads * v_head_dim
+            q_dim = num_heads * head_dim_original
+            k_dim = num_kv_heads * head_dim_original
+            v_dim = num_kv_heads * v_head_dim
 
             q_bias = weight[:q_dim]
             k_bias = weight[q_dim : q_dim + k_dim]
             v_bias = weight[q_dim + k_dim : q_dim + k_dim + v_dim]
 
-            if mapping.head_dim_padding and self.head_dim_pad > 0:
-                q_bias = jnp.reshape(q_bias, (self.num_heads, self.head_dim_original))
-                q_bias = jnp.pad(q_bias, ((0, 0), (0, self.head_dim_pad)))
-                q_bias = jnp.reshape(q_bias, (self.num_heads * self.head_dim,))
+            if mapping.head_dim_padding and head_dim_pad > 0:
+                q_bias = jnp.reshape(q_bias, (num_heads, head_dim_original))
+                q_bias = jnp.pad(q_bias, ((0, 0), (0, head_dim_pad)))
+                q_bias = jnp.reshape(q_bias, (num_heads * head_dim_padded,))
 
-                k_bias = jnp.reshape(k_bias, (self.num_kv_heads, self.head_dim_original))
-                k_bias = jnp.pad(k_bias, ((0, 0), (0, self.head_dim_pad)))
-                k_bias = jnp.reshape(k_bias, (self.num_kv_heads * self.head_dim,))
+                k_bias = jnp.reshape(k_bias, (num_kv_heads, head_dim_original))
+                k_bias = jnp.pad(k_bias, ((0, 0), (0, head_dim_pad)))
+                k_bias = jnp.reshape(k_bias, (num_kv_heads * head_dim_padded,))
 
             if mapping.head_dim_padding and v_head_dim_pad > 0:
-                v_bias = jnp.reshape(v_bias, (self.num_kv_heads, v_head_dim))
+                v_bias = jnp.reshape(v_bias, (num_kv_heads, v_head_dim))
                 v_bias = jnp.pad(v_bias, ((0, 0), (0, v_head_dim_pad)))
-                v_bias = jnp.reshape(v_bias, (self.num_kv_heads * v_head_dim_padded,))
+                v_bias = jnp.reshape(v_bias, (num_kv_heads * v_head_dim_padded,))
 
             splits = [q_bias, k_bias, v_bias]
         elif "scale" in hf_key and weight.ndim == 2:
@@ -2545,8 +2592,8 @@ class WeightLoader:
             quant_cfg = getattr(self.model_config, "quantization_config", None)
             block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
 
-            q_dim = self.num_heads * self.head_dim_original
-            k_dim = self.num_kv_heads * self.head_dim_original
+            q_dim = num_heads * head_dim_original
+            k_dim = num_kv_heads * head_dim_original
 
             q_blocks = math.ceil(q_dim / block_size)
             k_blocks = math.ceil(k_dim / block_size)
@@ -2568,9 +2615,9 @@ class WeightLoader:
 
             splits = [q_scale, k_scale, v_scale]
         else:
-            q_dim = self.num_heads * self.head_dim_original
-            k_dim = self.num_kv_heads * self.head_dim_original
-            v_dim = self.num_kv_heads * v_head_dim
+            q_dim = num_heads * head_dim_original
+            k_dim = num_kv_heads * head_dim_original
+            v_dim = num_kv_heads * v_head_dim
 
             if mapping.transpose:
                 q_weight = weight[:, :q_dim]
@@ -2581,62 +2628,62 @@ class WeightLoader:
                 k_weight = weight[q_dim : q_dim + k_dim, :]
                 v_weight = weight[q_dim + k_dim : q_dim + k_dim + v_dim, :]
 
-            if mapping.head_dim_padding and self.head_dim_pad > 0:
+            if mapping.head_dim_padding and head_dim_pad > 0:
                 if mapping.transpose:
                     q_weight = jnp.reshape(
                         q_weight,
-                        (self.hidden_size, self.num_heads, self.head_dim_original),
+                        (self.hidden_size, num_heads, head_dim_original),
                     )
-                    q_weight = jnp.pad(q_weight, ((0, 0), (0, 0), (0, self.head_dim_pad)))
+                    q_weight = jnp.pad(q_weight, ((0, 0), (0, 0), (0, head_dim_pad)))
                     q_weight = jnp.reshape(
-                        q_weight, (self.hidden_size, self.num_heads * self.head_dim)
+                        q_weight, (self.hidden_size, num_heads * head_dim_padded)
                     )
 
                     k_weight = jnp.reshape(
                         k_weight,
-                        (self.hidden_size, self.num_kv_heads, self.head_dim_original),
+                        (self.hidden_size, num_kv_heads, head_dim_original),
                     )
-                    k_weight = jnp.pad(k_weight, ((0, 0), (0, 0), (0, self.head_dim_pad)))
+                    k_weight = jnp.pad(k_weight, ((0, 0), (0, 0), (0, head_dim_pad)))
                     k_weight = jnp.reshape(
-                        k_weight, (self.hidden_size, self.num_kv_heads * self.head_dim)
+                        k_weight, (self.hidden_size, num_kv_heads * head_dim_padded)
                     )
                 else:
                     q_weight = jnp.reshape(
                         q_weight,
-                        (self.num_heads, self.head_dim_original, self.hidden_size),
+                        (num_heads, head_dim_original, self.hidden_size),
                     )
-                    q_weight = jnp.pad(q_weight, ((0, 0), (0, self.head_dim_pad), (0, 0)))
+                    q_weight = jnp.pad(q_weight, ((0, 0), (0, head_dim_pad), (0, 0)))
                     q_weight = jnp.reshape(
-                        q_weight, (self.num_heads * self.head_dim, self.hidden_size)
+                        q_weight, (num_heads * head_dim_padded, self.hidden_size)
                     )
 
                     k_weight = jnp.reshape(
                         k_weight,
-                        (self.num_kv_heads, self.head_dim_original, self.hidden_size),
+                        (num_kv_heads, head_dim_original, self.hidden_size),
                     )
-                    k_weight = jnp.pad(k_weight, ((0, 0), (0, self.head_dim_pad), (0, 0)))
+                    k_weight = jnp.pad(k_weight, ((0, 0), (0, head_dim_pad), (0, 0)))
                     k_weight = jnp.reshape(
-                        k_weight, (self.num_kv_heads * self.head_dim, self.hidden_size)
+                        k_weight, (num_kv_heads * head_dim_padded, self.hidden_size)
                     )
 
             if mapping.head_dim_padding and v_head_dim_pad > 0:
                 if mapping.transpose:
                     v_weight = jnp.reshape(
                         v_weight,
-                        (self.hidden_size, self.num_kv_heads, v_head_dim),
+                        (self.hidden_size, num_kv_heads, v_head_dim),
                     )
                     v_weight = jnp.pad(v_weight, ((0, 0), (0, 0), (0, v_head_dim_pad)))
                     v_weight = jnp.reshape(
-                        v_weight, (self.hidden_size, self.num_kv_heads * v_head_dim_padded)
+                        v_weight, (self.hidden_size, num_kv_heads * v_head_dim_padded)
                     )
                 else:
                     v_weight = jnp.reshape(
                         v_weight,
-                        (self.num_kv_heads, v_head_dim, self.hidden_size),
+                        (num_kv_heads, v_head_dim, self.hidden_size),
                     )
                     v_weight = jnp.pad(v_weight, ((0, 0), (0, v_head_dim_pad), (0, 0)))
                     v_weight = jnp.reshape(
-                        v_weight, (self.num_kv_heads * v_head_dim_padded, self.hidden_size)
+                        v_weight, (num_kv_heads * v_head_dim_padded, self.hidden_size)
                     )
 
             splits = [q_weight, k_weight, v_weight]
@@ -2645,7 +2692,7 @@ class WeightLoader:
             processed_weight = split_weight
 
             if mapping.kv_head_padding and ("k_proj" in jax_path or "v_proj" in jax_path):
-                processed_weight = self._apply_kv_head_padding(processed_weight, jax_path)
+                processed_weight = self._apply_kv_head_padding(processed_weight, jax_path, mapping)
 
             sharded_weight = self._shard_weight(processed_weight, mapping.sharding)
 
@@ -2692,22 +2739,48 @@ class WeightLoader:
 
         return current_level
 
-    def _apply_kv_head_padding(self, weight: jax.Array, hf_key: str) -> jax.Array:
+    def _apply_kv_head_padding(
+        self,
+        weight: jax.Array,
+        hf_key: str,
+        mapping: WeightMapping | None = None,
+    ) -> jax.Array:
         """Apply KV head padding/replication when tp_size > total_kv_heads.
 
         Handles:
         1. Bias/Scale (1D or 2D with shape[0]=heads) -> Pad Axis 0
         2. Standard Weight (2D with shape[1]=heads*dim) -> Pad Axis 1
         3. Static Quant Weight (2D with shape[0]=heads*dim) -> Pad Axis 0
+
+        When `mapping.head_context` is set, derive total_kv_heads and the
+        head_dim used for stride/dimension matching from the per-mapping
+        override instead of the loader-global model_config tuple. This is
+        what lets hybrid-attention models (e.g. MLA + GLA) share one
+        loader without one branch's head config silently corrupting the
+        other.
         """
-        if not (
-            any(proj in hf_key for proj in ["k_proj", "v_proj"])
-            and self.model_config.needs_kv_head_replication(self.sharding_size)
-        ):
+        if not any(proj in hf_key for proj in ["k_proj", "v_proj"]):
             return weight
 
-        total_kv_heads = self.model_config.get_total_num_kv_heads()
-        num_replicas = self.model_config.get_num_kv_head_replicas(self.sharding_size)
+        ctx = mapping.head_context if mapping is not None else None
+        if ctx is not None and (ctx.num_kv_heads is not None or ctx.head_dim is not None):
+            _, total_kv_heads, head_dim_original, _ = self._resolve_heads(mapping)
+            if self.sharding_size <= total_kv_heads:
+                return weight
+            num_replicas = (self.sharding_size + total_kv_heads - 1) // total_kv_heads
+            head_dim_pad = (head_dim_original + 127) // 128 * 128 - head_dim_original
+            head_dim = (
+                head_dim_original + head_dim_pad
+                if (mapping is not None and mapping.head_dim_padding)
+                else head_dim_original
+            )
+        else:
+            if not self.model_config.needs_kv_head_replication(self.sharding_size):
+                return weight
+            total_kv_heads = self.model_config.get_total_num_kv_heads()
+            num_replicas = self.model_config.get_num_kv_head_replicas(self.sharding_size)
+            head_dim = self.head_dim
+
         padding_strategy = self.model_config.get_kv_padding_strategy()
 
         target_axis = -1
@@ -2717,15 +2790,15 @@ class WeightLoader:
         if dim0 == total_kv_heads:
             target_axis = 0
             step_size = 1
-        elif dim0 == total_kv_heads * self.head_dim:
+        elif dim0 == total_kv_heads * head_dim:
             target_axis = 0
-            step_size = self.head_dim
+            step_size = head_dim
 
         if target_axis == -1 and weight.ndim > 1:
             dim1 = weight.shape[1]
-            if dim1 == total_kv_heads * self.head_dim:
+            if dim1 == total_kv_heads * head_dim:
                 target_axis = 1
-                step_size = self.head_dim
+                step_size = head_dim
 
         if target_axis == -1:
             return weight
@@ -2747,10 +2820,7 @@ class WeightLoader:
         elif padding_strategy == "zero":
             target_heads_total = total_kv_heads * num_replicas
 
-            if step_size == 1:
-                target_len = target_heads_total
-            else:
-                target_len = target_heads_total * self.head_dim
+            target_len = target_heads_total if step_size == 1 else target_heads_total * head_dim
 
             current_len = weight.shape[target_axis]
             padding_len = target_len - current_len

--- a/python/sgl_jax/test/test_bailing_moe_linear.py
+++ b/python/sgl_jax/test/test_bailing_moe_linear.py
@@ -14,6 +14,7 @@ from sgl_jax.srt.models.bailing_moe_linear import (
 )
 from sgl_jax.srt.models.deepseek_v3 import DeepseekV3Attention
 from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+from sgl_jax.srt.utils.weight_utils import HeadContext
 
 
 def _tiny_config(**overrides):
@@ -133,14 +134,21 @@ def test_weight_mapping_contains_linear_mla_dense_and_shared_mlp_keys():
         type("DummyModelConfig", (), {"quantization_config": None})()
     )
 
-    assert (
-        mappings["model.layers.0.attention.query_key_value.weight"].target_path
-        == [
-            "model.layers.0.self_attn.q_proj.weight",
-            "model.layers.0.self_attn.k_proj.weight",
-            "model.layers.0.self_attn.v_proj.weight",
-        ]
+    assert mappings["model.layers.0.attention.query_key_value.weight"].target_path == [
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.self_attn.k_proj.weight",
+        "model.layers.0.self_attn.v_proj.weight",
+    ]
+    gla_ctx = mappings["model.layers.0.attention.query_key_value.weight"].head_context
+    assert isinstance(gla_ctx, HeadContext), (
+        "GLA QKV-split mapping must carry head_context — without it, the loader "
+        "falls back to model_config.head_dim which patch_model_config overwrites "
+        "to MLA's qk_head_dim, silently mis-slicing GLA weights."
     )
+    assert gla_ctx.num_heads == cfg.num_attention_heads
+    assert gla_ctx.num_kv_heads == cfg.num_attention_heads
+    assert gla_ctx.head_dim == cfg.head_dim
+    assert gla_ctx.v_head_dim == cfg.head_dim
     assert (
         mappings["model.layers.0.attention.g_norm.weight"].target_path
         == "model.layers.0.self_attn.g_norm.weight"

--- a/python/sgl_jax/test/test_bailing_moe_linear.py
+++ b/python/sgl_jax/test/test_bailing_moe_linear.py
@@ -135,7 +135,11 @@ def test_weight_mapping_contains_linear_mla_dense_and_shared_mlp_keys():
 
     assert (
         mappings["model.layers.0.attention.query_key_value.weight"].target_path
-        == "model.layers.0.self_attn.qkv_proj.weight"
+        == [
+            "model.layers.0.self_attn.q_proj.weight",
+            "model.layers.0.self_attn.k_proj.weight",
+            "model.layers.0.self_attn.v_proj.weight",
+        ]
     )
     assert (
         mappings["model.layers.0.attention.g_norm.weight"].target_path


### PR DESCRIPTION
…k layout

Replace the per-projection Q/K/V LinearBase trio in the GLA block with a single MergedColumnParallelLinear and rearrange the loaded HF [Q_full|K_full|V_full] columns into [Q_r0|K_r0|V_r0|Q_r1|...] at load time via post_load_weights. The (None,"tensor") shard then places [Q_my|K_my|V_my] contiguously on each device, so the post-projection 3-way split + reshape is a pure local op (no all-to-all collective).

Restripe helpers are hoisted to module scope as jit-cached functions (static_argnames on mesh/tp_size/num_heads_local/head_dim) so all 28 decoder layers reuse one compiled program. tp_size is cached on the attention module to keep __call__ and post_load_weights consistent.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
