### PR TITLE
perf(lightning): shard per-layer alibi slope across tensor axis

### DIFF
--- a/python/sgl_jax/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/lightning_backend.py
@@ -20,7 +20,9 @@ from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from flax import nnx
+from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.layers.attention.hybrid_linear_attn_backend import (
@@ -64,10 +66,25 @@ def _build_alibi_base_slopes(num_heads: int) -> list[float]:
     )
 
 
-def _compute_layer_slope(layer_id: int, num_hidden_layers: int, num_heads: int) -> jnp.ndarray:
-    """Per-layer slope decay used as ``g_gamma`` by the simple_gla kernels."""
-    base_slopes = jnp.asarray(_build_alibi_base_slopes(num_heads), dtype=jnp.float32)
-    return -base_slopes * (1 - (layer_id - 1) / (num_hidden_layers - 1) + 1e-5)
+def _compute_layer_slope(
+    layer_id: int,
+    num_hidden_layers: int,
+    num_heads: int,
+    mesh: jax.sharding.Mesh | None = None,
+) -> jax.Array:
+    """Per-layer slope decay used as ``g_gamma`` by the simple_gla kernels.
+
+    Returned array is sharded along the ``tensor`` axis when ``mesh`` is
+    provided, matching how the slope is consumed inside the jitted forward
+    (``P("tensor")``). Constructing it as single-device on the host caused
+    ``shard_device_array`` to reshard it on every forward step.
+    """
+    base = np.asarray(_build_alibi_base_slopes(num_heads), dtype=np.float32)
+    slope_np = -base * (1 - (layer_id - 1) / (num_hidden_layers - 1) + 1e-5)
+    if mesh is None:
+        return jnp.asarray(slope_np)
+    sharding = NamedSharding(mesh, P("tensor"))
+    return jax.make_array_from_callback(slope_np.shape, sharding, lambda idx: slope_np[idx])
 
 
 class LightningAttnBackend(LinearRecurrentAttnBackend):
@@ -108,7 +125,7 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
         ):
             self.tp_slope = nnx.data(
                 {
-                    lid: _compute_layer_slope(lid, num_hidden_layers, num_heads)
+                    lid: _compute_layer_slope(lid, num_hidden_layers, num_heads, mesh)
                     for lid in linear_recurrent_layer_ids
                 }
             )


### PR DESCRIPTION
## Summary

Fixes a hidden ``shard_device_array`` reshard fired on every forward step in models that use ``LightningAttnBackend`` (Ling-2.6-flash and friends).

## Root cause

``LightningAttnBackend`` pre-computes one ``(num_heads,)`` float32 ALiBi slope per linear-attention layer at ``__init__`` and stashes them in ``nnx.data({lid: slope})``. The slopes were constructed via ``jnp.asarray`` on the host with no sharding, producing single-device ``jax.Array`` values that landed on device 0.

Because the jitted forward consumes each slope with ``in_sharding`` ``PartitionSpec(\"tensor\")``, JAX reshards the single-device array to all TP devices via ``shard_device_array`` on every forward step — once per linear-attention layer.

On Ling-2.6-flash (28 linear-attention layers, tp=16) this was **28 reshards per decode step**.

## Diagnostic evidence

Hooked ``jax._src.array.shard_device_array`` for the first 3 forward steps:

**Before** (commit ``9470d8a4``, main head):
```
[shard_device_array DIAG] step 0 done, total shard_device_array calls so far: 28
[shard_device_array DIAG] step 1 done, total shard_device_array calls so far: 56
[shard_device_array DIAG] step 2 done, total shard_device_array calls so far: 84

unique pattern: shape=(32,) dtype=float32
                src=(num_devices=1, spec=None)
                -> dst=(num_devices=16, spec=PartitionSpec('tensor',))
```

**After** (this PR):
```
[shard_device_array DIAG] step 0 done, total shard_device_array calls so far: 0
[shard_device_array DIAG] step 1 done, total shard_device_array calls so far: 0
[shard_device_array DIAG] step 2 done, total shard_device_array calls so far: 0
```

## Fix

Construct the slope directly with ``NamedSharding(mesh, P(\"tensor\"))`` via ``make_array_from_callback`` so each device only ever sees its own shard and the ``shard_device_array`` reshard never triggers. ``mesh=None`` keeps backward-compat (test path).

Also verified KDA backend and other linear-attention backends (gdn, qwen3.5 gated_delta_net) — they wrap their per-layer params in ``nnx.Param`` which goes through the weight loader and gets correctly sharded, so they don't have this bug. Only ``LightningAttnBackend`` constructs the slope outside the param loader path.

## Verification

Setup: TPU v6e-16 (4 host), Ling-2.6-flash, epmoe, dp=4, ep=16, conc=256, 1k input / 1k output.

| | before | after |
|--|--|--|
| ``shard_device_array`` calls per forward | 28 | **0** |
| GSM8K accuracy (200 examples) | n/a | **95.5%** (no regression) |

Numerical equivalence: the formula is unchanged — only the destination sharding is fixed up front instead of being inferred and resharded later.

## Test plan
- [x] GSM8K @ 50 examples: 100%
- [x] GSM8K @ 200 examples: 95.5% (matches Ling-2.6-flash baseline)
- [x] DIAG hook confirms ``shard_device_array`` reshards drop from 28/step to 0/step
- [x] ``mesh=None`` backward-compat path returns identical numerical values