### PR TITLE
test(spec): TestNextNV25Pro E2E (#1053 P1-8)

### DIFF
--- a/test/srt/test_speculative_decoding.py
+++ b/test/srt/test_speculative_decoding.py
@@ -1,6 +1,8 @@
+import os
 import unittest
 from types import SimpleNamespace
 
+import requests
 from run_eval import run_eval
 
 from sgl_jax.srt.utils import kill_process_tree
@@ -91,6 +93,87 @@ class TestSpeculativeDecoding(CustomTestCase):
 
         metrics = run_eval(args)
         self.assertGreater(metrics["score"], 0.45)
+
+
+@unittest.skipUnless(
+    os.getenv("SGLANG_NEXTN_E2E_URL"),
+    "MiMo-V2.5-Pro NEXTN needs a v6e-64 multi-host server (1T model); set "
+    "SGLANG_NEXTN_E2E_URL to a running server's base URL to enable.",
+)
+class TestNextNV25Pro(CustomTestCase):
+    """#1053 P1-8: V2.5-Pro 3-layer MTP E2E.
+
+    Unlike ``TestSpeculativeDecoding`` this does NOT launch its own server:
+    V2.5-Pro requires v6e-64 (16 hosts) which ``popen_launch_server`` can't
+    orchestrate. Point ``SGLANG_NEXTN_E2E_URL`` at an externally-managed
+    server started with::
+
+        --speculative-algorithm NEXTN --speculative-num-steps 3
+        --speculative-eagle-topk 1 --speculative-num-draft-tokens 4
+        --tp-size 64 --ep-size 64 --moe-backend epmoe
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = os.environ["SGLANG_NEXTN_E2E_URL"]
+        cls.model = os.getenv("SGLANG_NEXTN_E2E_MODEL", "mimo-v2.5-pro")
+        r = requests.get(f"{cls.base_url}/health", timeout=30)
+        r.raise_for_status()
+
+    def _generate(self, text: str, max_new_tokens: int = 64) -> dict:
+        r = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": text,
+                "sampling_params": {"temperature": 0, "max_new_tokens": max_new_tokens},
+            },
+            timeout=600,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def test_greedy_sanity(self):
+        d = self._generate("The capital of France is", 32)
+        self.assertGreater(d["meta_info"]["completion_tokens"], 16)
+        self.assertGreater(len(d["text"]), 0)
+
+    def test_multi_prompt_stable(self):
+        # Regression for the spec-decode KV leak (idle check_memory crash after
+        # each finished request) and the page>=256 _fetch_mask Mosaic crash:
+        # serially run mixed-length requests crossing the 256-token page
+        # boundary and assert the server stays up across all of them.
+        for n in (32, 280, 48, 96):
+            d = self._generate("def fibonacci(n):\n    if n <= 1:\n        return n\n    return", n)
+            self.assertGreaterEqual(d["meta_info"]["completion_tokens"], n)
+        requests.get(f"{self.base_url}/health", timeout=10).raise_for_status()
+
+    def test_raw_completion_accuracy(self):
+        # run_eval's mmlu uses /v1/chat/completions; V2.5-Pro then emits
+        # <think>...</think> reasoning which the mmlu parser can't score.
+        # Use raw /generate (no chat template) so the model answers in
+        # few-shot completion style. bs=1 only (Phase-1 deliverable scope).
+        cases = [
+            ("What is the capital of France?", ["London", "Paris", "Berlin", "Madrid"], "B"),
+            (
+                "Which planet is known as the Red Planet?",
+                ["Venus", "Mars", "Jupiter", "Saturn"],
+                "B",
+            ),
+            ("What is the chemical symbol for water?", ["CO2", "H2O", "NaCl", "O2"], "B"),
+            ("Who wrote 'Romeo and Juliet'?", ["Dickens", "Shakespeare", "Twain", "Austen"], "B"),
+            ("What is 7 * 8?", ["54", "56", "58", "64"], "B"),
+        ]
+        correct = 0
+        for q, opts, expect in cases:
+            prompt = (
+                f"Question: {q}\n"
+                + "\n".join(f"{c}. {o}" for c, o in zip("ABCD", opts))
+                + "\nAnswer:"
+            )
+            out = self._generate(prompt, 4)["text"].strip()
+            if out[:1].upper() == expect:
+                correct += 1
+        self.assertGreaterEqual(correct, 4, f"raw-completion accuracy {correct}/5")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked on #1089 — only review e5d56285.

Adds env-gated `TestNextNV25Pro` to `test_speculative_decoding.py`. V2.5-Pro (1T) requires v6e-64 (16 hosts) which `popen_launch_server` can't orchestrate, so this skips unless `SGLANG_NEXTN_E2E_URL` points at an externally-managed NEXTN server.

Three checks at bs=1 topk=1 greedy (Phase-1 deliverable scope):
- `test_greedy_sanity`: single `/generate` succeeds
- `test_multi_prompt_stable`: 4 serial mixed-length reqs (incl. 280-tok crossing the page=256 boundary) all succeed + server alive after idle — regression for #1089's KV-leak and `_fetch_mask` Mosaic fixes
- `test_raw_completion_accuracy`: 5 MMLU-style raw-completion prompts, ≥4/5. Doesn't use `run_eval mmlu` because chat mode triggers `<think>` reasoning that the parser can't score.

### Manual run (v6e-64, V2.5-Pro 3-layer NEXTN, `--ep-size 64 --moe-backend epmoe`)

```
test_greedy_sanity ... ok
test_multi_prompt_stable ... ok
test_raw_completion_accuracy ... ok
Ran 3 tests in 14.445s
crashes: 0
```

accept-len 2.41 over 55 decode rounds (cold+warm; warm-only ~2.5–2.8 from #1089).

In CI (v6e-4) the class is skipped — `TestSpeculativeDecoding` (Qwen3-32B EAGLE3) is unchanged.