### PR TITLE
[GLM-5.1] Fix repetition: enable absorbed MLA + adapt MemoryPools interface

### DIFF
--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -486,7 +486,7 @@ class Glm5DecoderLayer(nnx.Module):
             attention_bias=getattr(config, "attention_bias", False),
             dtype=dtype,
             mesh=mesh,
-            use_absorbed=False,
+            use_absorbed=True,
         )
 
         first_k_dense_replace = getattr(config, "first_k_dense_replace", 0)
@@ -727,12 +727,13 @@ class Glm5ForCausalLM(nnx.Module):
     def __call__(
         self,
         forward_batch: ForwardBatch,
-        token_to_kv_pool: KVCache,
+        memory_pools,
         logits_metadata: LogitsMetadata,
     ):
+        kv_pool = memory_pools.token_to_kv_pool
         hidden_states, layers_kv_fused, layers_topk_ids = self.model(
             forward_batch,
-            token_to_kv_pool,
+            kv_pool,
         )
 
         if not getattr(self.config, "tie_word_embeddings", False):
@@ -740,7 +741,7 @@ class Glm5ForCausalLM(nnx.Module):
         else:
             output = self.logits_processor(hidden_states, self.model.embed_tokens, logits_metadata)
 
-        return output, layers_kv_fused, True, layers_topk_ids
+        return output, {"token_to_kv_pool": layers_kv_fused}, True, layers_topk_ids
 
     def load_weights(self, model_config: ModelConfig):
         loader = WeightLoader(


### PR DESCRIPTION
## Motivation

#1037 merged GLM-5.1 with a known repetition issue (#1036). On current `main` the model actually **fails to launch** with two errors, and once those are worked around the repetition root cause turns out to be different from the RFC's diagnosis.

**Root cause of repetition**: `glm5_moe.py:489` hardcodes `use_absorbed=False`, so forward goes through `_forward_mha`. But `model_config` sets `attention_arch=MLA` for `glm_moe_dsa`, which forces `MLAAttentionBackend` — whose KV cache stores the compressed latent `c_KV`, not full K/V. The mha path (a) doesn't pass `q_rope`/`k_rope` separately as the MLA backend requires, and (b) would read latent cache as full KV. This mismatch is what produces garbage logits / repetition, **not** the missing DSA indexer wiring.

**Second bug**: `Glm5ForCausalLM.__call__` still takes `token_to_kv_pool: KVCache`, but `model_runner` on main now passes a `MemoryPools` wrapper (deepseek_v3 was adapted, glm5 was not) → `AttributeError: MemoryPools has no pool 'get_fused_kv_buffer'`.

## Modifications

- `use_absorbed=False` → `True` (line 489): take the `_forward_mqa` absorbed path that matches `MLAAttentionBackend`
- `Glm5ForCausalLM.__call__`: accept `memory_pools`, unpack `.token_to_kv_pool`, return `{"token_to_kv_pool": layers_kv_fused}` (align with `deepseek_v3.py`)

## Accuracy Tests

**Before (#1037 output, dense mha path):**
```
The largest planet in the Solar System is Jupiter, the fifth planet from the Sun, and the largest. Jupiter has a diameter of 142,000 km, ... it is 1,898, and the distance is 1,898, and the distance is 1,898, and the distance is 1,898, ...
```

**After (this PR, absorbed mqa path), TPU v6e-64:**
```
The largest planet in the solar system is Jupiter.
  finish_reason: stop (matched 154827), completion_tokens: 11

The capital of France is Paris.
  finish_reason: stop, completion_tokens: 8
```

GSM8K 5-sample sanity: 5/5 reasoning correct, no repetition (2 truncated by max_tokens=512 in `<think>`, 3 give final answers 72/35/...).

## Launch Command (TPU v6e-64, 16 hosts)

```bash
pip install -U "transformers>=5.5"   # GLM-5.1 tokenizer needs TokenizersBackend
python -m sgl_jax.launch_server \
  --model-path /weights --tokenizer-path /weights --trust-remote-code \
  --tp-size 64 --ep-size 32 --device tpu --random-seed 3 \
  --mem-fraction-static 0.90 --max-running-requests 32 \
  --chunked-prefill-size 2048 --context-length 8192 --page-size 64 \
  --attention-backend fa --disable-radix-cache --disable-precompile \
  --nnodes 16 --node-rank ${RANK} --dist-init-addr ${MASTER}:5000 \
  --host 0.0.0.0 --port 30271
```

Note `--page-size 64` (default `1` fails MLA backend assert) and `--mem-fraction-static 0.90` (BF16 754B = 23.4GB/chip on v6e).

## Benchmark (v6e-64 TP64/EP32 BF16, 1024-in/128-out random)

| concurrency | output tok/s | TPOT (ms) |
|---|---|---|
| 1 | 25.3 | 32.4 |
| 8 | 67.9 | 62.6 |
| 32 | 136.0 | 129.2 |

## Follow-up (not in this PR)

`GlmDsaIndexer` is still a placeholder (top-1 only, no indexer-key cache, batch-local logits). Dense absorbed MLA is correct at short context; full DSA sparse (`index_topk=2048`) for long context is a separate ~300-500 LOC change (port of CUDA `nsa_backend`). Will track in #1036.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.