### PR TITLE
feat(function_call): add qwen25 tool-call parser

### DIFF
--- a/python/sgl_jax/srt/function_call/function_call_parser.py
+++ b/python/sgl_jax/srt/function_call/function_call_parser.py
@@ -12,6 +12,7 @@ from sgl_jax.srt.function_call.core_types import ToolCallItem
 from sgl_jax.srt.function_call.glm4_moe_detector import Glm4MoeDetector
 from sgl_jax.srt.function_call.glm47_moe_detector import Glm47MoeDetector
 from sgl_jax.srt.function_call.mimo_detector import MiMoDetector
+from sgl_jax.srt.function_call.qwen25_detector import Qwen25Detector
 from sgl_jax.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
 from sgl_jax.srt.function_call.utils import get_json_schema_constraint
 
@@ -28,6 +29,7 @@ class FunctionCallParser:
     """
 
     ToolCallParserEnum: dict[str, type[BaseFormatDetector]] = {
+        "qwen25": Qwen25Detector,
         "qwen3_coder": Qwen3CoderDetector,
         "mimo": MiMoDetector,
         "glm47": Glm47MoeDetector,

--- a/python/sgl_jax/srt/function_call/function_call_parser.py
+++ b/python/sgl_jax/srt/function_call/function_call_parser.py
@@ -12,8 +12,8 @@ from sgl_jax.srt.function_call.core_types import ToolCallItem
 from sgl_jax.srt.function_call.glm4_moe_detector import Glm4MoeDetector
 from sgl_jax.srt.function_call.glm47_moe_detector import Glm47MoeDetector
 from sgl_jax.srt.function_call.mimo_detector import MiMoDetector
-from sgl_jax.srt.function_call.qwen25_detector import Qwen25Detector
 from sgl_jax.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
+from sgl_jax.srt.function_call.qwen25_detector import Qwen25Detector
 from sgl_jax.srt.function_call.utils import get_json_schema_constraint
 
 logger = logging.getLogger(__name__)

--- a/python/sgl_jax/srt/function_call/qwen25_detector.py
+++ b/python/sgl_jax/srt/function_call/qwen25_detector.py
@@ -37,7 +37,7 @@ class Qwen25Detector(BaseFormatDetector):
 
     def detect_and_parse(self, text: str, tools: list[Tool]) -> StreamingParseResult:
         idx = text.find(self.bot_token)
-        normal_text = text[:idx] if idx != -1 else text
+        normal_text = text[:idx].strip() if idx != -1 else text
         if idx == -1:
             return StreamingParseResult(normal_text=normal_text, calls=[])
 
@@ -51,9 +51,7 @@ class Qwen25Detector(BaseFormatDetector):
                 logger.warning("Failed to parse Qwen25 tool_call JSON: %s (%s)", match, e)
         return StreamingParseResult(normal_text=normal_text, calls=calls)
 
-    def parse_streaming_increment(
-        self, new_text: str, tools: list[Tool]
-    ) -> StreamingParseResult:
+    def parse_streaming_increment(self, new_text: str, tools: list[Tool]) -> StreamingParseResult:
         result = super().parse_streaming_increment(new_text, tools)
         if not result.normal_text:
             return result

--- a/python/sgl_jax/srt/function_call/qwen25_detector.py
+++ b/python/sgl_jax/srt/function_call/qwen25_detector.py
@@ -1,0 +1,95 @@
+import json
+import logging
+import re
+
+from sgl_jax.srt.entrypoints.openai.protocol import Tool
+from sgl_jax.srt.function_call.base_format_detector import BaseFormatDetector
+from sgl_jax.srt.function_call.core_types import (
+    StreamingParseResult,
+    StructureInfo,
+    _GetInfoFunc,
+)
+from sgl_jax.srt.function_call.ebnf_composer import EBNFComposer
+
+logger = logging.getLogger(__name__)
+
+
+class Qwen25Detector(BaseFormatDetector):
+    """
+    Detector for Qwen 2.5 / Qwen 3 / Ling-2.6 tool-call format.
+
+    Format:
+        <tool_call>
+        {"name": "...", "arguments": {...}}
+        </tool_call>
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.bot_token = "<tool_call>\n"
+        self.eot_token = "\n</tool_call>"
+        self.tool_call_separator = "\n"
+        # Buffer for handling end-tokens that arrive split across streaming chunks.
+        self._normal_text_buffer = ""
+
+    def has_tool_call(self, text: str) -> bool:
+        return self.bot_token in text
+
+    def detect_and_parse(self, text: str, tools: list[Tool]) -> StreamingParseResult:
+        idx = text.find(self.bot_token)
+        normal_text = text[:idx] if idx != -1 else text
+        if idx == -1:
+            return StreamingParseResult(normal_text=normal_text, calls=[])
+
+        pattern = rf"{re.escape(self.bot_token)}(.*?){re.escape(self.eot_token)}"
+        calls = []
+        for match in re.findall(pattern, text, re.DOTALL):
+            try:
+                parsed = json.loads(match.strip())
+                calls.extend(self.parse_base_json(parsed, tools))
+            except json.JSONDecodeError as e:
+                logger.warning("Failed to parse Qwen25 tool_call JSON: %s (%s)", match, e)
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def parse_streaming_increment(
+        self, new_text: str, tools: list[Tool]
+    ) -> StreamingParseResult:
+        result = super().parse_streaming_increment(new_text, tools)
+        if not result.normal_text:
+            return result
+
+        self._normal_text_buffer += result.normal_text
+        # eot_token is "\n</tool_call>"; the leading "\n" is the separator that
+        # the base parser already returns as part of normal_text after a complete
+        # call. Detect/strip the trailing "</tool_call>" tag here.
+        end_no_nl = self.eot_token[1:]
+
+        if end_no_nl in self._normal_text_buffer:
+            cleaned = self._normal_text_buffer.replace(end_no_nl, "")
+            self._normal_text_buffer = ""
+            result.normal_text = cleaned
+        else:
+            partial = self._ends_with_partial_token(self._normal_text_buffer, end_no_nl)
+            if partial:
+                result.normal_text = self._normal_text_buffer[:-partial]
+                self._normal_text_buffer = self._normal_text_buffer[-partial:]
+            else:
+                result.normal_text = self._normal_text_buffer
+                self._normal_text_buffer = ""
+        return result
+
+    def structure_info(self) -> _GetInfoFunc:
+        return lambda name: StructureInfo(
+            begin='<tool_call>\n{"name":"' + name + '", "arguments":',
+            end="}\n</tool_call>",
+            trigger="<tool_call>",
+        )
+
+    def build_ebnf(self, tools: list[Tool]) -> str:
+        return EBNFComposer.build_ebnf(
+            tools,
+            function_format="json",
+            individual_call_start_token=self.bot_token.replace("\n", "\\n"),
+            individual_call_end_token=self.eot_token.replace("\n", "\\n"),
+            tool_call_separator="\\n",
+        )

--- a/test/srt/function_call/test_qwen25_detector.py
+++ b/test/srt/function_call/test_qwen25_detector.py
@@ -53,7 +53,7 @@ class TestQwen25Detector(CustomTestCase):
             "</tool_call>"
         )
         result = Qwen25Detector().detect_and_parse(text, [_weather_tool()])
-        self.assertEqual(result.normal_text, "thinking done\n")
+        self.assertEqual(result.normal_text, "thinking done")
         self.assertEqual(len(result.calls), 1)
         self.assertEqual(result.calls[0].name, "get_weather")
         self.assertEqual(json.loads(result.calls[0].parameters), {"location": "Beijing"})
@@ -79,11 +79,7 @@ class TestQwen25Detector(CustomTestCase):
         self.assertEqual(result.calls, [])
 
     def test_detect_and_parse_unknown_function(self):
-        text = (
-            "<tool_call>\n"
-            '{"name": "mystery", "arguments": {"x": 1}}\n'
-            "</tool_call>"
-        )
+        text = "<tool_call>\n" '{"name": "mystery", "arguments": {"x": 1}}\n' "</tool_call>"
         result = Qwen25Detector().detect_and_parse(text, [_weather_tool()])
         # Unknown function: parse_base_json logs a warning and drops it.
         self.assertEqual(result.calls, [])
@@ -130,9 +126,7 @@ class TestQwen25Detector(CustomTestCase):
         self.assertEqual(r1.normal_text, "plain text. ")
         self.assertEqual(r1.calls, [])
         r2 = det.parse_streaming_increment(
-            "<tool_call>\n"
-            '{"name": "square", "arguments": {"x": 3}}\n'
-            "</tool_call>",
+            "<tool_call>\n" '{"name": "square", "arguments": {"x": 3}}\n' "</tool_call>",
             tools,
         )
         names = [c.name for c in r2.calls if c.name]
@@ -150,6 +144,15 @@ class TestQwen25Detector(CustomTestCase):
         grammar = Qwen25Detector().build_ebnf([_weather_tool(), _square_tool()])
         self.assertIn("get_weather", grammar)
         self.assertIn("square", grammar)
+
+    def test_build_ebnf_compiles(self):
+        """Compile the grammar with llguidance to catch escape/syntax bugs
+        that a substring check would miss (a malformed grammar would still
+        contain the tool name but raise GrammarError at request time)."""
+        from llguidance import grammar_from
+
+        grammar = Qwen25Detector().build_ebnf([_weather_tool(), _square_tool()])
+        grammar_from("lark", grammar)
 
 
 if __name__ == "__main__":

--- a/test/srt/function_call/test_qwen25_detector.py
+++ b/test/srt/function_call/test_qwen25_detector.py
@@ -1,0 +1,158 @@
+"""Unit tests for Qwen25Detector (function-call parser).
+
+Covers the Qwen 2.5 / Qwen 3 / Ling-2.6 tool-call format:
+
+    <tool_call>
+    {"name": "...", "arguments": {...}}
+    </tool_call>
+
+Run with:
+    python -m unittest test.srt.function_call.test_qwen25_detector
+"""
+
+import json
+
+from sgl_jax.srt.entrypoints.openai.protocol import Function, Tool
+from sgl_jax.srt.function_call.qwen25_detector import Qwen25Detector
+from sgl_jax.test.test_utils import CustomTestCase
+
+
+def _tool(name: str, properties: dict | None = None) -> Tool:
+    return Tool(
+        type="function",
+        function=Function(
+            name=name,
+            description=f"{name} tool",
+            parameters={"type": "object", "properties": properties or {}},
+        ),
+    )
+
+
+def _weather_tool() -> Tool:
+    return _tool("get_weather", {"location": {"type": "string"}})
+
+
+def _square_tool() -> Tool:
+    return _tool("square", {"x": {"type": "number"}})
+
+
+class TestQwen25Detector(CustomTestCase):
+    def test_has_tool_call(self):
+        d = Qwen25Detector()
+        self.assertTrue(d.has_tool_call("foo<tool_call>\n{...}\n</tool_call>"))
+        self.assertFalse(d.has_tool_call("plain text only"))
+        # Missing trailing newline after <tool_call> should not match: the
+        # format strictly requires "<tool_call>\n" as the bot_token.
+        self.assertFalse(d.has_tool_call("<tool_call>{...}</tool_call>"))
+
+    def test_detect_and_parse_single_call(self):
+        text = (
+            "thinking done\n"
+            "<tool_call>\n"
+            '{"name": "get_weather", "arguments": {"location": "Beijing"}}\n'
+            "</tool_call>"
+        )
+        result = Qwen25Detector().detect_and_parse(text, [_weather_tool()])
+        self.assertEqual(result.normal_text, "thinking done\n")
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(json.loads(result.calls[0].parameters), {"location": "Beijing"})
+
+    def test_detect_and_parse_two_calls(self):
+        text = (
+            "<tool_call>\n"
+            '{"name": "get_weather", "arguments": {"location": "Beijing"}}\n'
+            "</tool_call>\n"
+            "<tool_call>\n"
+            '{"name": "square", "arguments": {"x": 7}}\n'
+            "</tool_call>"
+        )
+        result = Qwen25Detector().detect_and_parse(text, [_weather_tool(), _square_tool()])
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(json.loads(result.calls[0].parameters), {"location": "Beijing"})
+        self.assertEqual(json.loads(result.calls[1].parameters), {"x": 7})
+
+    def test_detect_and_parse_no_tool_call(self):
+        text = "just a normal answer with no tool"
+        result = Qwen25Detector().detect_and_parse(text, [_weather_tool()])
+        self.assertEqual(result.normal_text, text)
+        self.assertEqual(result.calls, [])
+
+    def test_detect_and_parse_unknown_function(self):
+        text = (
+            "<tool_call>\n"
+            '{"name": "mystery", "arguments": {"x": 1}}\n'
+            "</tool_call>"
+        )
+        result = Qwen25Detector().detect_and_parse(text, [_weather_tool()])
+        # Unknown function: parse_base_json logs a warning and drops it.
+        self.assertEqual(result.calls, [])
+
+    def test_detect_and_parse_malformed_json_skipped(self):
+        text = (
+            "<tool_call>\n"
+            "this is not json\n"
+            "</tool_call>\n"
+            "<tool_call>\n"
+            '{"name": "square", "arguments": {"x": 9}}\n'
+            "</tool_call>"
+        )
+        result = Qwen25Detector().detect_and_parse(text, [_square_tool()])
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "square")
+
+    def test_streaming_split_chunks(self):
+        det = Qwen25Detector()
+        tools = [_square_tool()]
+        chunks = [
+            "<tool_call>\n",
+            '{"name": "squ',
+            'are", "arguments": {"x": ',
+            "42}}\n",
+            "</tool_call>",
+        ]
+        out_calls = []
+        out_normal = ""
+        for ch in chunks:
+            r = det.parse_streaming_increment(ch, tools)
+            out_normal += r.normal_text
+            out_calls.extend(r.calls)
+        names = [c.name for c in out_calls if c.name]
+        self.assertEqual(names, ["square"])
+        joined = "".join(c.parameters for c in out_calls)
+        self.assertEqual(json.loads(joined), {"x": 42})
+        self.assertNotIn("</tool_call>", out_normal)
+
+    def test_streaming_normal_text_then_call(self):
+        det = Qwen25Detector()
+        tools = [_square_tool()]
+        r1 = det.parse_streaming_increment("plain text. ", tools)
+        self.assertEqual(r1.normal_text, "plain text. ")
+        self.assertEqual(r1.calls, [])
+        r2 = det.parse_streaming_increment(
+            "<tool_call>\n"
+            '{"name": "square", "arguments": {"x": 3}}\n'
+            "</tool_call>",
+            tools,
+        )
+        names = [c.name for c in r2.calls if c.name]
+        self.assertIn("square", names)
+        self.assertNotIn("<tool_call>", r2.normal_text)
+        self.assertNotIn("</tool_call>", r2.normal_text)
+
+    def test_structure_info(self):
+        info = Qwen25Detector().structure_info()("get_weather")
+        self.assertEqual(info.trigger, "<tool_call>")
+        self.assertEqual(info.end, "}\n</tool_call>")
+        self.assertTrue(info.begin.startswith('<tool_call>\n{"name":"get_weather"'))
+
+    def test_build_ebnf_contains_tool_name(self):
+        grammar = Qwen25Detector().build_ebnf([_weather_tool(), _square_tool()])
+        self.assertIn("get_weather", grammar)
+        self.assertIn("square", grammar)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `Qwen25Detector` for the `<tool_call>\n{...}\n</tool_call>` JSON format used by Qwen 2.5 / Qwen 3 / Ling-2.6-1T, mirroring the upstream sgl-project/sglang implementation.
- Register it as `qwen25` in `FunctionCallParser.ToolCallParserEnum`.
- Implements `detect_and_parse`, streaming `parse_streaming_increment` (overridden to buffer `</tool_call>` split across chunks), `structure_info`, and `build_ebnf` via `EBNFComposer` (json format).

## Motivation
Ling-2.6-1T's official HF model card recommends `--tool-call-parser qwen25`, but sglang-jax only ships `qwen3_coder` / `mimo` / `glm45` / `glm47` — none of which match the Qwen 2.5 XML-wrapped-JSON tool call format. This PR fills that gap.

## Test plan
- [x] `python -m unittest discover -s test/srt/function_call -p "test_qwen25*.py"` — 10/10 pass (single/multi-call parsing, streaming across chunks, unknown-function handling, malformed JSON skipping, `structure_info`, `build_ebnf`)
- [ ] End-to-end: launch a Qwen2.5 / Ling-2.6-1T server with `--tool-call-parser qwen25`, verify both `tool_choice=auto` and `tool_choice=required` (the latter exercises the EBNF path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)