### PR TITLE
fix(gmm): ensure default block_m divides m (#1099)

### DIFF
--- a/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/tuned_block_sizes.py
+++ b/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/tuned_block_sizes.py
@@ -559,7 +559,11 @@ def get_default_gmm_block_sizes(m: int, k: int, n: int, g: int) -> tuple[int, in
     # topk=2, m=topk * num_tokens=64, in this case, 2*m//g will be less than
     # 512.
     tm = round_up_to_multiple_of_128_within_limit(2 * m // g, 512)
-    tm = min(tm, m)  # there's a requirement that m % tm == 0
+    tm = min(tm, m)
+    # _calculate_num_tiles requires m % tm == 0; the min() above only handles
+    # tm > m. Step down to the largest 128-multiple that divides m (#1099).
+    while tm > 128 and m % tm != 0:
+        tm -= 128
     # k/n correspond to n_input_features/n_output_features in the matmul so they
     # are normally greater than 2048, unless the num shards is large.
     tk = round_up_to_multiple_of_128_within_limit(k, 2048)

--- a/python/sgl_jax/test/kernels/gmm_test.py
+++ b/python/sgl_jax/test/kernels/gmm_test.py
@@ -152,6 +152,17 @@ def reference_gmm(
 @jtu.with_config(jax_numpy_dtype_promotion="standard")
 class GmmTest(jtu.JaxTestCase):
 
+    @parameterized.product(m=[128, 512, 896, 1024, 1152, 2048], g=[6, 8, 384])
+    def test_default_block_m_divides_m(self, m, g):
+        # Regression for #1099: dp=2 V2.5-Pro hits m=1024,g=6 -> tm=384 (no divide).
+        from sgl_jax.srt.kernels.gmm.megablox_gmm_kernel.tuned_block_sizes import (
+            get_default_gmm_block_sizes,
+        )
+
+        tm, _, _ = get_default_gmm_block_sizes(m, 6144, 2048, g)
+        self.assertEqual(m % tm, 0, f"m={m} g={g} -> tm={tm} does not divide m")
+        self.assertEqual(tm % 128, 0)
+
     @parameterized.product(
         batch_size=[128],
         in_size=[512, 1024],


### PR DESCRIPTION
## Summary
`get_default_gmm_block_sizes` computes `tm = min(round_up_128(2m/g), m)`; the `min()` only handles `tm > m`, so when `tm < m` and doesn't divide `m` (e.g. `m=1024, g=6 → tm=384`), `_calculate_num_tiles` raises. Hit on V2.5-Pro `--dp-size 2 --disable-precompile` (per_dp 64 × 2 × top_k 8 = 1024).

Fix: after `min()`, step `tm` down to the largest 128-multiple that divides `m`.

Closes #1099. Orthogonal to #1079 (which removed the outer `moe.py` pad — a no-op for `m=1024` which is already 128-aligned).

## Test plan
- [x] `pytest sgl_jax/test/kernels/gmm_test.py -k test_default_block_m_divides_m` (18 cases, m∈{128,512,896,1024,1152,2048} × g∈{6,8,384})
- [x] v6e-64 V2.5-Pro `--tp 64 --dp 2 --ep 64 --moe-backend epmoe --disable-precompile` nospec: GMM log shows `(256, 2048, 2048)` for key `(1024, 6144, 2048, 384, 6, ...)`, `/generate` succeeds