### PR TITLE
perf(lightning): fuse DECODE state I/O into a single Pallas kernel (Ling-2.6-flash)

### DIFF
--- a/python/sgl_jax/srt/kernels/simple_gla/__init__.py
+++ b/python/sgl_jax/srt/kernels/simple_gla/__init__.py
@@ -1,0 +1,3 @@
+from sgl_jax.srt.kernels.simple_gla.simple_gla_fused import decode_simple_gla_fused
+
+__all__ = ["decode_simple_gla_fused"]

--- a/python/sgl_jax/srt/kernels/simple_gla/simple_gla_fused.py
+++ b/python/sgl_jax/srt/kernels/simple_gla/simple_gla_fused.py
@@ -90,6 +90,7 @@ def _decode_simple_gla_kernel(
         for n in range(N):
             bank = n % 2
             wait gather(token n) on sem_gather[bank]
+            if n >= 2: wait scatter(token n-2) on sem_scatter[bank]
             for each head h in 0..H-1:
                 materialise h_in_buf[bank, h] as fp32 scratch (masked by
                     has_init AND pool_idx != 0)
@@ -97,7 +98,6 @@ def _decode_simple_gla_kernel(
                 o_ref[n, h, :] = sum(q * h_new, axis=K) * scale
                 stage h_to_scatter (masked to 0 when pool_idx == 0) into
                     h_out_buf[bank, h]
-            if n >= 2: wait scatter(token n-2) on sem_scatter[bank]
             start scatter(token n) → buf  via sem_scatter[bank]
             if n+2 < N: start gather(token n+2) → h_in_buf[bank]
 
@@ -157,7 +157,14 @@ def _decode_simple_gla_kernel(
         # 1) Wait for this token's gather to land.
         pltpu.make_async_copy(_buf_in_slice(n), h_in_buf.at[bank], sem_gather.at[bank]).wait()
 
-        # 2) Per-head 2D compute.
+        # 2) Wait for prior scatter on this bank (token n-2) before
+        #    reusing h_out_buf[bank] as the next scatter source.
+        if n >= 2:
+            pltpu.make_async_copy(
+                h_out_buf.at[bank], _buf_out_slice(n - 2), sem_scatter.at[bank]
+            ).wait()
+
+        # 3) Per-head 2D compute.
         for h in range(H):
             decay_h = jnp.exp(g_gamma_ref[h].astype(jnp.float32))  # scalar
 
@@ -179,16 +186,10 @@ def _decode_simple_gla_kernel(
             h_to_scatter_h = jnp.where(scatter_mask, h_new_h, 0.0)
             h_out_buf.at[bank, h][...] = h_to_scatter_h.astype(h_out_buf.dtype)
 
-        # 4) Wait for prior scatter on this bank (token n-2) to drain.
-        if n >= 2:
-            pltpu.make_async_copy(
-                h_out_buf.at[bank], _buf_out_slice(n - 2), sem_scatter.at[bank]
-            ).wait()
-
-        # 5) Start scatter for this token (H heads at once — single DMA).
+        # 4) Start scatter for this token (H heads at once — single DMA).
         pltpu.make_async_copy(h_out_buf.at[bank], _buf_out_slice(n), sem_scatter.at[bank]).start()
 
-        # 6) Pre-issue gather for token (n + 2) using h_in_buf[bank]
+        # 5) Pre-issue gather for token (n + 2) using h_in_buf[bank]
         #    (consumed by step 2 above).
         if n + 2 < N:
             pltpu.make_async_copy(
@@ -239,6 +240,9 @@ def _launch_decode_simple_gla(
       I-3: ``disable_semaphore_checks=True`` is required because the
            kernel uses raw ``make_async_copy`` for the async double-buffer
            pipeline. Pattern matches ``ragged_paged_attention_v3.py``.
+      I-4: Only a single K tile is supported for DECODE. The output block
+           does not reduce partial sums across K programs, so ``K > 128``
+           must fail fast in the launcher.
     """
     interpret = get_interpret()
 
@@ -246,7 +250,7 @@ def _launch_decode_simple_gla(
     V = v.shape[-1]
     BK = min(K, 128)
     BV = min(V, 128)
-    assert K % BK == 0
+    assert K == BK, f"decode_simple_gla_fused only supports K <= 128; got K={K}"
     assert V % BV == 0
 
     # In-launcher pre-flatten — see I-1 above.

--- a/python/sgl_jax/srt/kernels/simple_gla/simple_gla_fused.py
+++ b/python/sgl_jax/srt/kernels/simple_gla/simple_gla_fused.py
@@ -1,0 +1,365 @@
+"""Fused DECODE Pallas kernel for the GLA recurrent attention.
+
+Replaces the JAX ``fused_recurrent_simple_gla`` scan + the explicit JAX
+gather/scatter shard_maps around the recurrent state buffer with a single
+Pallas kernel that does in-kernel async DMA gather/scatter.
+
+Design:
+  * Single Pallas program per (k_block, v_block); the token loop is
+    inside the kernel so the output block can be the full ``(N, H, BV)``
+    tensor (avoids the "two programs writing the same output block"
+    constraint that would force per-head Python serialization).
+  * Token-level async double-buffer: 2 VMEM banks (``h_in_buf``,
+    ``h_out_buf``) and 2 DMA semaphores each. Each DMA carries all H
+    heads of one token in a single contiguous ``(H, BK, BV)`` chunk.
+  * Per-head 2D compute inside the per-token step. Mosaic TPU does not
+    currently support 1D→3D vector layout casts (``vector<H>`` →
+    ``vector<H×1×1>`` is rejected by ``infer-vector-layout``), so the
+    H-vectorised compute body cannot be expressed cleanly; per-head 2D
+    tiles avoid the issue while keeping the DMA H-batched.
+  * Default-precision dot, matching the JAX reference ``_scan_segment``
+    body.
+  * Conditional logic: gather is always issued (slot 0 is dummy zeros
+    by convention); compute is masked with ``(has_init AND pool_idx != 0)``;
+    scatter is always issued but the staged value is masked to 0 when
+    ``pool_idx == 0`` (preserves dummy-slot-is-zero invariant). Keeps
+    semaphore counts balanced across all branches.
+  * ``disable_semaphore_checks=True`` (pattern from RPA v3) skips the
+    Mosaic kernel-exit semaphore-balance assertion; we still drain the
+    last two scatters inside the kernel for HBM coherence vs downstream
+    readers of the aliased buffer.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect as _inspect
+
+import jax
+import jax.experimental.pallas as pl
+import jax.experimental.pallas.tpu as pltpu
+import jax.numpy as jnp
+
+from sgl_jax.srt.kernels.simple_gla.simple_gla import get_interpret
+
+_COMPILER_PARAMS_SUPPORTS_SEMAPHORE_CHECKS = (
+    "disable_semaphore_checks" in _inspect.signature(pltpu.CompilerParams).parameters
+)
+
+
+def _semaphore_kwargs(disable_semaphore_checks: bool) -> dict:
+    """Forward `disable_semaphore_checks` only if the running jaxlib supports it."""
+    if _COMPILER_PARAMS_SUPPORTS_SEMAPHORE_CHECKS:
+        return {"disable_semaphore_checks": disable_semaphore_checks}
+    return {}
+
+
+def _decode_simple_gla_kernel(
+    # BlockSpec inputs (full-tensor blocks; grid is (1, 1) outside)
+    q_ref,  # (N, H, BK)
+    k_ref,  # (N, H, BK)
+    v_ref,  # (N, H, BV)
+    # SMEM inputs
+    g_gamma_ref,  # [H]
+    recurrent_indices_ref,  # [N]
+    has_initial_state_ref,  # [N]
+    # ANY-memory inputs (HBM-resident, kernel manages DMA)
+    recurrent_buffer_ref,  # [total_slots*H, K, V] — pre-flattened
+    # Outputs
+    o_ref,  # (N, H, BV)
+    updated_recurrent_buffer_ref,  # [total_slots*H, K, V] — aliased
+    # Scratch
+    h_in_buf,  # VMEM (2, H, BK, BV) buffer.dtype
+    h_out_buf,  # VMEM (2, H, BK, BV) buffer.dtype
+    sem_gather,  # SemaphoreType.DMA((2,))
+    sem_scatter,  # SemaphoreType.DMA((2,))
+    *,
+    BK: int,
+    BV: int,
+    scale: float,
+    N: int,
+    H: int,
+):
+    """Single Pallas program per (k_block, v_block); ALL tokens + ALL heads inside.
+
+    Pipeline (token-level async double-buffer):
+        prologue:
+            start gather(token 0) → h_in_buf[0]   via sem_gather[0]
+            if N >= 2: start gather(token 1) → h_in_buf[1] via sem_gather[1]
+
+        for n in range(N):
+            bank = n % 2
+            wait gather(token n) on sem_gather[bank]
+            for each head h in 0..H-1:
+                materialise h_in_buf[bank, h] as fp32 scratch (masked by
+                    has_init AND pool_idx != 0)
+                h_new = h_old * exp(g_gamma[h]) + outer(k, v)
+                o_ref[n, h, :] = sum(q * h_new, axis=K) * scale
+                stage h_to_scatter (masked to 0 when pool_idx == 0) into
+                    h_out_buf[bank, h]
+            if n >= 2: wait scatter(token n-2) on sem_scatter[bank]
+            start scatter(token n) → buf  via sem_scatter[bank]
+            if n+2 < N: start gather(token n+2) → h_in_buf[bank]
+
+        drain:
+            wait scatter(N-1) on sem_scatter[(N-1)%2]
+            if N >= 2: wait scatter(N-2) on sem_scatter[(N-2)%2]
+
+    Notes:
+      * ``recurrent_buffer_ref`` is pre-flattened to (total_slots*H, K, V)
+        by the launcher (workaround for a JAX 0.8.x interpret-mode
+        RefReshaper bug). Slot indexing uses ``pl.ds(pool_idx * H, H)`` to
+        pull all H consecutive heads for one token in a single DMA.
+      * The ``h_to_scatter`` mask protects the dummy slot 0 invariant:
+        when pool_idx[n] == 0, we still scatter (keeping sem balance),
+        but the scattered value is zeros, so slot 0 stays zero-valued.
+    """
+    i_k = pl.program_id(0)
+    i_v = pl.program_id(1)
+
+    def _buf_in_slice(n_token: int):
+        pool_idx = recurrent_indices_ref[n_token]
+        return recurrent_buffer_ref.at[
+            pl.ds(pool_idx * H, H),
+            pl.ds(i_k * BK, BK),
+            pl.ds(i_v * BV, BV),
+        ]
+
+    def _buf_out_slice(n_token: int):
+        pool_idx = recurrent_indices_ref[n_token]
+        return updated_recurrent_buffer_ref.at[
+            pl.ds(pool_idx * H, H),
+            pl.ds(i_k * BK, BK),
+            pl.ds(i_v * BV, BV),
+        ]
+
+    # ───── Prologue: kick off gathers for tokens 0 and 1 ─────
+    pltpu.make_async_copy(_buf_in_slice(0), h_in_buf.at[0], sem_gather.at[0]).start()
+    if N >= 2:
+        pltpu.make_async_copy(_buf_in_slice(1), h_in_buf.at[1], sem_gather.at[1]).start()
+
+    # Per-head decay scalars are loaded inside the per-head loop below.
+    # Mosaic TPU's infer-vector-layout rejects 1D→3D reshapes
+    # (``vector<H>`` → ``vector<H×1×1>``), so we can't broadcast a (H,)
+    # decay vector against a (H, BK, BV) scratch. Per-head 2D tiles avoid
+    # the issue; the DMA stays H-batched.
+
+    # ───── Steady-state ping-pong loop over tokens ─────
+    for n in range(N):
+        bank = n % 2
+        pool_idx = recurrent_indices_ref[n]
+        has_init = has_initial_state_ref[n]
+        # pool_idx == 0 means dummy slot ⇒ no prior state.
+        # has_init == False means new sequence ⇒ no prior state.
+        use_state = jnp.logical_and(has_init, pool_idx != 0)
+        scatter_mask = pool_idx != 0
+
+        # 1) Wait for this token's gather to land.
+        pltpu.make_async_copy(_buf_in_slice(n), h_in_buf.at[bank], sem_gather.at[bank]).wait()
+
+        # 2) Per-head 2D compute.
+        for h in range(H):
+            decay_h = jnp.exp(g_gamma_ref[h].astype(jnp.float32))  # scalar
+
+            gathered_h = h_in_buf.at[bank, h][...].astype(jnp.float32)  # (BK, BV)
+            h_old_h = jnp.where(use_state, gathered_h, 0.0)
+
+            q_h = q_ref[n, h, :].astype(jnp.float32)  # (BK,)
+            k_h = k_ref[n, h, :].astype(jnp.float32)  # (BK,)
+            v_h = v_ref[n, h, :].astype(jnp.float32)  # (BV,)
+
+            h_new_h = h_old_h * decay_h + k_h[:, None] * v_h[None, :]  # (BK, BV)
+
+            # Dot mirrors ``_scan_segment``'s default-precision sum.
+            o_h = jnp.sum(q_h[:, None] * h_new_h, axis=0) * scale  # (BV,)
+            o_ref[n, h, :] = o_h.astype(o_ref.dtype)
+
+            # Mask to zeros when pool_idx == 0 so writing back to dummy
+            # slot 0 leaves it unchanged.
+            h_to_scatter_h = jnp.where(scatter_mask, h_new_h, 0.0)
+            h_out_buf.at[bank, h][...] = h_to_scatter_h.astype(h_out_buf.dtype)
+
+        # 4) Wait for prior scatter on this bank (token n-2) to drain.
+        if n >= 2:
+            pltpu.make_async_copy(
+                h_out_buf.at[bank], _buf_out_slice(n - 2), sem_scatter.at[bank]
+            ).wait()
+
+        # 5) Start scatter for this token (H heads at once — single DMA).
+        pltpu.make_async_copy(h_out_buf.at[bank], _buf_out_slice(n), sem_scatter.at[bank]).start()
+
+        # 6) Pre-issue gather for token (n + 2) using h_in_buf[bank]
+        #    (consumed by step 2 above).
+        if n + 2 < N:
+            pltpu.make_async_copy(
+                _buf_in_slice(n + 2), h_in_buf.at[bank], sem_gather.at[bank]
+            ).start()
+
+    # ───── Drain: wait for the two trailing scatters ─────
+    last1_bank = (N - 1) % 2
+    pltpu.make_async_copy(
+        h_out_buf.at[last1_bank], _buf_out_slice(N - 1), sem_scatter.at[last1_bank]
+    ).wait()
+    if N >= 2:
+        last2_bank = (N - 2) % 2
+        pltpu.make_async_copy(
+            h_out_buf.at[last2_bank], _buf_out_slice(N - 2), sem_scatter.at[last2_bank]
+        ).wait()
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=["scale"],
+    donate_argnames=["recurrent_buffer"],
+)
+def _launch_decode_simple_gla(
+    q: jax.Array,  # [N, H, K]
+    k: jax.Array,  # [N, H, K]
+    v: jax.Array,  # [N, H, V]
+    g_gamma: jax.Array,  # [H]
+    recurrent_buffer: jax.Array,  # [total_slots, H, K, V]
+    recurrent_indices: jax.Array,  # [N]
+    has_initial_state: jax.Array,  # [N]
+    *,
+    scale: float,
+) -> tuple[jax.Array, jax.Array]:
+    """Launch the DECODE fused Pallas kernel.
+
+    Grid is (cdiv(K, BK), cdiv(V, BV)) — the token dim N is iterated
+    inside the kernel. Block specs are full-tensor blocks; each program
+    covers one (BK, BV) tile across ALL tokens and ALL heads.
+
+    Notes:
+      I-1: ``recurrent_buffer`` is pre-flattened to (total_slots*H, K, V)
+           so the kernel can use ``pl.ds(pool_idx * H, H)`` to gather all
+           H heads of one token in a single contiguous DMA.
+      I-2: ``input_output_aliases={6: 1}`` — input position 6 is the flat
+           recurrent buffer (after q, k, v, g_gamma, indices, has_init);
+           output position 1 is the flat updated buffer.
+      I-3: ``disable_semaphore_checks=True`` is required because the
+           kernel uses raw ``make_async_copy`` for the async double-buffer
+           pipeline. Pattern matches ``ragged_paged_attention_v3.py``.
+    """
+    interpret = get_interpret()
+
+    N, H, K = q.shape
+    V = v.shape[-1]
+    BK = min(K, 128)
+    BV = min(V, 128)
+    assert K % BK == 0
+    assert V % BV == 0
+
+    # In-launcher pre-flatten — see I-1 above.
+    buf_total_slots = recurrent_buffer.shape[0]
+    buf_flat_shape = (buf_total_slots * H, K, V)
+    recurrent_buffer_flat = jnp.reshape(recurrent_buffer, buf_flat_shape)
+
+    # Grid: K and V blocking only. N is iterated inside the kernel so
+    # the output block can be the full (N, H, BV) tensor.
+    grid = (pl.cdiv(K, BK), pl.cdiv(V, BV))
+
+    def q_index_map(k_i, _v_i):
+        return 0, 0, k_i
+
+    def k_index_map(k_i, _v_i):
+        return 0, 0, k_i
+
+    def v_index_map(_k_i, v_i):
+        return 0, 0, v_i
+
+    def o_index_map(_k_i, v_i):
+        return 0, 0, v_i
+
+    in_specs = [
+        pl.BlockSpec((N, H, BK), q_index_map),
+        pl.BlockSpec((N, H, BK), k_index_map),
+        pl.BlockSpec((N, H, BV), v_index_map),
+        pl.BlockSpec(memory_space=pltpu.SMEM),  # g_gamma
+        pl.BlockSpec(memory_space=pltpu.SMEM),  # recurrent_indices
+        pl.BlockSpec(memory_space=pltpu.SMEM),  # has_initial_state
+        pl.BlockSpec(memory_space=pltpu.ANY),  # recurrent_buffer (HBM)
+    ]
+    out_specs = [
+        pl.BlockSpec((N, H, BV), o_index_map),
+        pl.BlockSpec(memory_space=pltpu.ANY),  # updated_recurrent_buffer
+    ]
+    out_shape = [
+        jax.ShapeDtypeStruct((N, H, V), q.dtype),
+        # IMPORTANT: input AND output pre-flattened to the same shape,
+        # required by input_output_aliases.
+        jax.ShapeDtypeStruct(buf_flat_shape, recurrent_buffer.dtype),
+    ]
+
+    scratch_shapes = [
+        # Two banks for inbound gather staging (kept in buffer dtype).
+        # Each bank holds (H, BK, BV) — one token's worth of all heads.
+        pltpu.VMEM((2, H, BK, BV), recurrent_buffer.dtype),
+        # Two banks for outbound scatter staging (kept in buffer dtype).
+        pltpu.VMEM((2, H, BK, BV), recurrent_buffer.dtype),
+        # 2-element DMA semaphore arrays for gather and scatter.
+        pltpu.SemaphoreType.DMA((2,)),
+        pltpu.SemaphoreType.DMA((2,)),
+    ]
+
+    kernel = functools.partial(_decode_simple_gla_kernel, BK=BK, BV=BV, scale=scale, N=N, H=H)
+
+    o, updated_buffer_flat = pl.pallas_call(
+        kernel,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=0,
+            grid=grid,
+            in_specs=in_specs,
+            out_specs=out_specs,
+            scratch_shapes=scratch_shapes,
+        ),
+        out_shape=out_shape,
+        interpret=interpret,
+        compiler_params=pltpu.CompilerParams(
+            dimension_semantics=("parallel", "parallel"),
+            vmem_limit_bytes=128 * 1024 * 1024,
+            **(_semaphore_kwargs(True)),  # see launcher I-3
+        ),
+        input_output_aliases={6: 1},  # see launcher I-2
+    )(
+        q,
+        k,
+        v,
+        g_gamma,
+        recurrent_indices,
+        has_initial_state,
+        recurrent_buffer_flat,
+    )
+
+    # Restore the original (total_slots, H, K, V) view for the caller.
+    updated_buffer = jnp.reshape(updated_buffer_flat, recurrent_buffer.shape)
+    return o, updated_buffer
+
+
+def decode_simple_gla_fused(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    recurrent_buffer: jax.Array,
+    recurrent_indices: jax.Array,
+    has_initial_state: jax.Array,
+    *,
+    g_gamma: jax.Array,
+    scale: float | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    """DECODE fused entry point. Returns (o, updated_recurrent_buffer)."""
+    K = q.shape[-1]
+    if scale is None:
+        scale = K**-0.5
+    return _launch_decode_simple_gla(
+        q,
+        k,
+        v,
+        g_gamma,
+        recurrent_buffer,
+        recurrent_indices,
+        has_initial_state,
+        scale=float(scale),
+    )
+
+
+__all__ = ["decode_simple_gla_fused"]

--- a/python/sgl_jax/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/lightning_backend.py
@@ -1,15 +1,11 @@
-"""LightningAttnBackend — GLA (Gated Linear Attention) backend.
+"""LightningAttnBackend — GLA backend.
 
-Extends LinearRecurrentAttnBackend to provide:
-- Chunked prefill via simple_gla_fwd (Pallas kernel, varlen — kernel pads each
-  sequence internally, so cu_seqlens carries real lengths)
-- Decode via fused_recurrent_simple_gla (jax.lax.scan)
-- Recurrent state management through RecurrentStatePool (no conv state)
+DECODE uses ``decode_simple_gla_fused`` (Pallas, in-kernel async DMA
+gather/scatter on the recurrent state buffer).
 
-Aligns with upstream sglang's LightningAttentionBackend(MambaAttnBackendBase) pattern.
-Per-layer ALiBi slope decay is owned here (indexed by layer_id), mirroring
-upstream's ``self.tp_slope[layer.layer_id]``; the model layer only carries
-identification + head shape via ``RadixLightningAttention``.
+EXTEND uses the baseline ``simple_gla_fwd`` (Pallas) wrapped with JAX
+gather/scatter — a fused EXTEND variant existed but was reverted as
+slower than the baseline path used here.
 """
 
 from __future__ import annotations
@@ -34,13 +30,14 @@ from sgl_jax.srt.utils.profiling_utils import named_scope
 logger = logging.getLogger(__name__)
 
 try:
-    from sgl_jax.srt.kernels.simple_gla.simple_gla import (
-        fused_recurrent_simple_gla,
-        simple_gla_fwd,
-    )
+    from sgl_jax.srt.kernels.simple_gla.simple_gla import simple_gla_fwd
 except ModuleNotFoundError:
     simple_gla_fwd = None
-    fused_recurrent_simple_gla = None
+
+try:
+    from sgl_jax.srt.kernels.simple_gla.simple_gla_fused import decode_simple_gla_fused
+except ModuleNotFoundError:
+    decode_simple_gla_fused = None
 
 if TYPE_CHECKING:
     from sgl_jax.srt.layers.radix_lightning_attention import RadixLightningAttention
@@ -74,10 +71,9 @@ def _compute_layer_slope(
 ) -> jax.Array:
     """Per-layer slope decay used as ``g_gamma`` by the simple_gla kernels.
 
-    Returned array is sharded along the ``tensor`` axis when ``mesh`` is
-    provided, matching how the slope is consumed inside the jitted forward
-    (``P("tensor")``). Constructing it as single-device on the host caused
-    ``shard_device_array`` to reshard it on every forward step.
+    Sharded along the ``tensor`` axis when ``mesh`` is provided, matching
+    the ``P("tensor")`` spec the slope is consumed with inside the jitted
+    forward.
     """
     base = np.asarray(_build_alibi_base_slopes(num_heads), dtype=np.float32)
     slope_np = -base * (1 - (layer_id - 1) / (num_hidden_layers - 1) + 1e-5)
@@ -142,8 +138,9 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
         recurrent_state_pool,
         **kwargs,
     ) -> tuple[jax.Array, tuple]:
-        recurrent_indices = self.forward_metadata.recurrent_indices
-        ssm_states = self.get_state(recurrent_state_pool, layer.layer_id, recurrent_indices)
+        md = self.forward_metadata
+        recurrent_buffer, _ = self.get_layer_cache(recurrent_state_pool, layer.layer_id)
+
         try:
             slope = self.tp_slope[layer.layer_id]
         except KeyError:
@@ -155,63 +152,31 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
             ) from None
 
         if forward_batch.forward_mode == ForwardMode.DECODE:
-            output, new_recurrent = self._forward_decode(q, k, v, ssm_states, slope)
+            output, new_buffer = self._forward_decode(
+                q,
+                k,
+                v,
+                recurrent_buffer,
+                md.recurrent_indices,
+                md.has_initial_state,
+                slope,
+            )
         elif forward_batch.forward_mode == ForwardMode.EXTEND:
-            output, new_recurrent = self._forward_extend(q, k, v, ssm_states, slope)
+            output, new_buffer = self._forward_extend(
+                q,
+                k,
+                v,
+                recurrent_buffer,
+                md.recurrent_indices,
+                md.has_initial_state,
+                slope,
+            )
         else:
             raise NotImplementedError(
                 f"LightningAttnBackend does not support {forward_batch.forward_mode}"
             )
 
-        new_ssm_full = self.set_ssm_state(
-            recurrent_state_pool, layer.layer_id, recurrent_indices, new_recurrent
-        )
-        return output.reshape(output.shape[0], -1), (new_ssm_full, [])
-
-    def get_state(self, recurrent_state_pool, layer_id, recurrent_indices):
-        """Gather recurrent states using shard_map."""
-        recurrent_buffer, _ = self.get_layer_cache(recurrent_state_pool, layer_id)
-
-        def _gather_local(buf, indices):
-            return buf[indices]
-
-        state = jax.shard_map(
-            _gather_local,
-            mesh=self.mesh,
-            in_specs=(
-                P("data", "tensor", None, None),
-                P("data"),
-            ),
-            out_specs=P("data", "tensor", None, None),
-            check_vma=False,
-        )(recurrent_buffer, recurrent_indices)
-        has_initial_state = self.forward_metadata.has_initial_state
-        if has_initial_state is not None:
-            state = jnp.where(has_initial_state[:, None, None, None], state, 0.0)
-        return state
-
-    def set_ssm_state(self, recurrent_state_pool, layer_id, recurrent_indices, new_recurrent):
-        """Scatter recurrent states using shard_map."""
-        recurrent_buffer, _ = self.get_layer_cache(recurrent_state_pool, layer_id)
-
-        def _scatter_local(buf, indices, state):
-            # whenever indices == 0, write val otherwise
-            keep_mask = (indices == 0).reshape(-1, 1, 1, 1)
-            old = buf[indices]
-            safe_val = jnp.where(keep_mask, old, state)
-            return buf.at[indices].set(safe_val)
-
-        return jax.shard_map(
-            _scatter_local,
-            mesh=self.mesh,
-            in_specs=(
-                P("data", "tensor", None, None),
-                P("data"),
-                P("data", "tensor", None, None),
-            ),
-            out_specs=P("data", "tensor", None, None),
-            check_vma=False,
-        )(recurrent_buffer, recurrent_indices, new_recurrent)
+        return output.reshape(output.shape[0], -1), (new_buffer, [])
 
     @named_scope("lightning_decode")
     def _forward_decode(
@@ -219,48 +184,45 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
         q: jax.Array,
         k: jax.Array,
         v: jax.Array,
-        ssm_states: jax.Array,
+        recurrent_buffer: jax.Array,
+        recurrent_indices: jax.Array,
+        has_initial_state: jax.Array,
         slope: jnp.ndarray,
     ) -> tuple[jax.Array, jax.Array]:
-        """Decode forward using shard_map."""
-        if fused_recurrent_simple_gla is None:
-            raise ImportError("simple_gla kernel is required for GLA decode")
+        """Decode forward via fused Pallas kernel with in-kernel state DMA."""
+        if decode_simple_gla_fused is None:
+            raise ImportError("simple_gla_fused kernel is required for GLA decode")
 
-        ssm_states = ssm_states.astype(jnp.float32)
-
-        def _decode_fn(q_local, k_local, v_local, gamma, h0):
-            q_d = q_local[:, None, :, :]
-            k_d = k_local[:, None, :, :]
-            v_d = v_local[:, None, :, :]
-            output_d, new_state = fused_recurrent_simple_gla(
-                q_d,
-                k_d,
-                v_d,
+        def _decode_fn(q_l, k_l, v_l, gamma, buf_l, idx_l, has_l):
+            return decode_simple_gla_fused(
+                q_l,
+                k_l,
+                v_l,
+                recurrent_buffer=buf_l,
+                recurrent_indices=idx_l,
+                has_initial_state=has_l,
                 g_gamma=gamma,
-                initial_state=h0,
-                output_final_state=True,
                 scale=None,
             )
-            return output_d[:, 0, :, :], new_state
 
-        output, new_state = jax.shard_map(
+        return jax.shard_map(
             _decode_fn,
             mesh=self.mesh,
             in_specs=(
-                P("data", "tensor", None),  # q
-                P("data", "tensor", None),  # k
-                P("data", "tensor", None),  # v
-                P("tensor"),  # slope
-                P("data", "tensor", None, None),  # ssm_states
+                P("data", "tensor", None),
+                P("data", "tensor", None),
+                P("data", "tensor", None),
+                P("tensor"),
+                P("data", "tensor", None, None),
+                P("data"),
+                P("data"),
             ),
             out_specs=(
                 P("data", "tensor", None),
                 P("data", "tensor", None, None),
             ),
             check_vma=False,
-        )(q, k, v, slope, ssm_states)
-
-        return output, new_state
+        )(q, k, v, slope, recurrent_buffer, recurrent_indices, has_initial_state)
 
     @named_scope("lightning_extend")
     def _forward_extend(
@@ -268,50 +230,59 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
         q: jax.Array,
         k: jax.Array,
         v: jax.Array,
-        ssm_states: jax.Array,
+        recurrent_buffer: jax.Array,
+        recurrent_indices: jax.Array,
+        has_initial_state: jax.Array,
         slope: jnp.ndarray,
     ) -> tuple[jax.Array, jax.Array]:
-        """Extend forward using shard_map."""
+        """Extend forward via baseline simple_gla_fwd + JAX gather/scatter."""
         if simple_gla_fwd is None:
             raise ImportError("simple_gla kernel is required for GLA prefill")
 
         cu_seqlens = self.forward_metadata.cu_q_lens
-        ssm_states = ssm_states.astype(jnp.float32)
         chunk_size = self.chunk_size
 
-        def _prefill_fn(q_local, k_local, v_local, gamma, h0, cu_seqlens_p):
+        def _prefill_fn(q_l, k_l, v_l, gamma, buf_l, idx_l, has_l, cu_l):
+            h0 = buf_l[idx_l]
+            h0 = jnp.where(has_l[:, None, None, None], h0, 0.0)
+
             output, ht = simple_gla_fwd(
-                q_local[None],
-                k_local[None],
-                v_local[None],
+                q_l[None],
+                k_l[None],
+                v_l[None],
                 g_gamma=gamma,
                 h0=h0,
-                cu_seqlens_dev=cu_seqlens_p,
+                cu_seqlens_dev=cu_l,
                 scale=None,
                 use_ht=True,
                 chunk_size=chunk_size,
             )
-            return output[0], ht
 
-        output, new_state = jax.shard_map(
+            # Skip writing back to dummy slot 0.
+            keep_mask = (idx_l == 0).reshape(-1, 1, 1, 1)
+            safe_val = jnp.where(keep_mask, buf_l[idx_l], ht)
+            new_buf = buf_l.at[idx_l].set(safe_val)
+            return output[0], new_buf
+
+        return jax.shard_map(
             _prefill_fn,
             mesh=self.mesh,
             in_specs=(
-                P("data", "tensor", None),  # q: always has "data" axis
-                P("data", "tensor", None),  # k
-                P("data", "tensor", None),  # v
-                P("tensor"),  # slope: replicated
-                P("data", "tensor", None, None),  # ssm_states
-                P("data"),  # cu_seqlens
+                P("data", "tensor", None),
+                P("data", "tensor", None),
+                P("data", "tensor", None),
+                P("tensor"),
+                P("data", "tensor", None, None),
+                P("data"),
+                P("data"),
+                P("data"),
             ),
             out_specs=(
                 P("data", "tensor", None),
                 P("data", "tensor", None, None),
             ),
             check_vma=False,
-        )(q, k, v, slope, ssm_states, cu_seqlens)
-
-        return output, new_state
+        )(q, k, v, slope, recurrent_buffer, recurrent_indices, has_initial_state, cu_seqlens)
 
 
 __all__ = ["LightningAttnBackend"]

--- a/python/sgl_jax/test/kernels/simple_gla_fused_test.py
+++ b/python/sgl_jax/test/kernels/simple_gla_fused_test.py
@@ -1,0 +1,366 @@
+"""Kernel-level unit tests for ``decode_simple_gla_fused``.
+
+These tests exercise the fused DECODE Pallas kernel directly (no shard_map,
+no full backend pipeline) against the JAX reference path
+``fused_recurrent_simple_gla``. Integration with the LightningAttn backend
+is covered separately by ``test/layers/test_lightning_backend.py``.
+
+Run locally on Mac (no TPU):
+    PALLAS_INTERPRET=1 pytest python/sgl_jax/test/kernels/simple_gla_fused_test.py -v
+
+Run on TPU:
+    pytest python/sgl_jax/test/kernels/simple_gla_fused_test.py -v
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+# Reference path (the kernel we are replacing).
+from sgl_jax.srt.kernels.simple_gla.simple_gla import fused_recurrent_simple_gla
+
+# Fused twin under test.
+from sgl_jax.srt.kernels.simple_gla.simple_gla_fused import decode_simple_gla_fused
+
+# K = V (simple GLA constraint); BK = BV = 128 statically in Pallas kernel.
+_DEFAULT_DTYPE = jnp.float32
+_ATOL = 1e-3
+_RTOL = 1e-3
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────
+def _make_g_gamma(num_heads: int, seed: int = 0) -> jax.Array:
+    rng = np.random.default_rng(seed)
+    return jnp.asarray(rng.uniform(-0.1, -0.01, size=(num_heads,)), dtype=jnp.float32)
+
+
+def _make_buffer(
+    total_slots: int,
+    num_heads: int,
+    head_dim: int,
+    seed: int = 1,
+    dtype: jnp.dtype = _DEFAULT_DTYPE,
+) -> jax.Array:
+    rng = np.random.default_rng(seed)
+    buf = rng.normal(size=(total_slots, num_heads, head_dim, head_dim))
+    # Slot 0 is the dummy — must be zero by RecurrentStatePool convention.
+    buf[0] = 0
+    return jnp.asarray(buf, dtype=dtype)
+
+
+def _make_qkv(num_seqs, num_heads, head_dim, seed, dtype=_DEFAULT_DTYPE, scale=0.1):
+    rng = np.random.default_rng(seed)
+    q = jnp.asarray(rng.normal(size=(num_seqs, num_heads, head_dim)), dtype=dtype) * scale
+    k = jnp.asarray(rng.normal(size=(num_seqs, num_heads, head_dim)), dtype=dtype) * scale
+    v = jnp.asarray(rng.normal(size=(num_seqs, num_heads, head_dim)), dtype=dtype) * scale
+    return q, k, v
+
+
+def _baseline_decode(q, k, v, buf, indices, has_init, gamma):
+    """Reproduce the old decode path: gather → fused_recurrent_simple_gla → scatter."""
+    h0 = buf[indices]
+    if has_init is not None:
+        h0 = jnp.where(has_init[:, None, None, None], h0, 0.0)
+
+    q_d = q[:, None, :, :]
+    k_d = k[:, None, :, :]
+    v_d = v[:, None, :, :]
+    o_d, ht = fused_recurrent_simple_gla(
+        q_d,
+        k_d,
+        v_d,
+        g_gamma=gamma,
+        initial_state=h0,
+        output_final_state=True,
+        scale=None,
+    )
+    keep_mask = (indices == 0).reshape(-1, 1, 1, 1)
+    safe_val = jnp.where(keep_mask, buf[indices], ht)
+    new_buf = buf.at[indices].set(safe_val)
+    return o_d[:, 0, :, :], new_buf
+
+
+def _run_pair(q, k, v, buf, indices, has_init, gamma):
+    """Run reference + fused on snapshot copies; return (o_ref, buf_ref, o_fused, buf_fused)."""
+    # Fused donates ``recurrent_buffer``; run baseline first on a fresh copy
+    # so it can still read the original buf.
+    buf_snapshot = jnp.asarray(np.asarray(buf))
+    o_ref, buf_ref = _baseline_decode(q, k, v, buf_snapshot, indices, has_init, gamma)
+    o_fused, buf_fused = decode_simple_gla_fused(
+        q,
+        k,
+        v,
+        recurrent_buffer=buf,
+        recurrent_indices=indices,
+        has_initial_state=has_init,
+        g_gamma=gamma,
+        scale=None,
+    )
+    return o_ref, buf_ref, o_fused, buf_fused
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Equivalence tests vs reference path
+# ─────────────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "num_seqs,num_heads,head_dim",
+    [
+        (4, 2, 128),  # original tiny case
+        (4, 8, 128),  # H=8 matches Ling-2.6-flash per-shard
+        (1, 8, 128),  # single-token decode (smallest grid)
+        (16, 8, 128),  # mid batch
+        (32, 8, 128),  # production decode batch (128 concurrency / 4 dp shards)
+    ],
+)
+def test_decode_basic_equivalence(num_seqs, num_heads, head_dim):
+    """Fused kernel output matches reference for varying (N, H) at K=V=128."""
+    total_slots = num_seqs + 1
+    indices = jnp.arange(1, num_seqs + 1, dtype=jnp.int32)
+    has_init = jnp.full((num_seqs,), True, dtype=jnp.bool_)
+
+    q, k, v = _make_qkv(num_seqs, num_heads, head_dim, seed=50)
+    buf = _make_buffer(total_slots, num_heads, head_dim, seed=51)
+    gamma = _make_g_gamma(num_heads, seed=52)
+
+    o_ref, buf_ref, o_fused, buf_fused = _run_pair(q, k, v, buf, indices, has_init, gamma)
+    np.testing.assert_allclose(np.asarray(o_fused), np.asarray(o_ref), atol=_ATOL, rtol=_RTOL)
+    np.testing.assert_allclose(np.asarray(buf_fused), np.asarray(buf_ref), atol=_ATOL, rtol=_RTOL)
+
+
+def test_decode_dummy_slot_skipped():
+    """``pool_idx == 0`` (dummy slot) must leave slot 0 contents bit-equal."""
+    H, D = 8, 128
+    num_seqs = 3
+    total_slots = num_seqs + 1
+    indices = jnp.asarray([1, 0, 2], dtype=jnp.int32)  # middle one targets dummy slot
+    has_init = jnp.asarray([True, True, True], dtype=jnp.bool_)
+
+    q, k, v = _make_qkv(num_seqs, H, D, seed=60)
+    buf = _make_buffer(total_slots, H, D, seed=61)
+    gamma = _make_g_gamma(H, seed=62)
+    buf_orig = np.asarray(buf)  # snapshot for post-call asserts on buf[0]
+
+    o_ref, buf_ref, o_fused, buf_fused = _run_pair(q, k, v, buf, indices, has_init, gamma)
+
+    np.testing.assert_allclose(np.asarray(o_fused), np.asarray(o_ref), atol=_ATOL, rtol=_RTOL)
+    # Dummy slot 0 must be bit-identical to the pre-call buffer.
+    np.testing.assert_array_equal(np.asarray(buf_fused[0]), buf_orig[0])
+    # Other slots: kernel result matches reference.
+    np.testing.assert_allclose(
+        np.asarray(buf_fused[1]), np.asarray(buf_ref[1]), atol=_ATOL, rtol=_RTOL
+    )
+    np.testing.assert_allclose(
+        np.asarray(buf_fused[2]), np.asarray(buf_ref[2]), atol=_ATOL, rtol=_RTOL
+    )
+
+
+def test_decode_has_initial_state_false():
+    """``has_initial_state == False`` ⇒ treat gathered state as zero."""
+    H, D = 8, 128
+    num_seqs = 4
+    total_slots = num_seqs + 1
+    indices = jnp.asarray([1, 2, 3, 4], dtype=jnp.int32)
+    has_init = jnp.asarray([False, False, False, False], dtype=jnp.bool_)
+
+    q, k, v = _make_qkv(num_seqs, H, D, seed=70)
+    buf = _make_buffer(total_slots, H, D, seed=71)
+    gamma = _make_g_gamma(H, seed=72)
+
+    o_ref, buf_ref, o_fused, buf_fused = _run_pair(q, k, v, buf, indices, has_init, gamma)
+    np.testing.assert_allclose(np.asarray(o_fused), np.asarray(o_ref), atol=_ATOL, rtol=_RTOL)
+    np.testing.assert_allclose(np.asarray(buf_fused), np.asarray(buf_ref), atol=_ATOL, rtol=_RTOL)
+
+
+def test_decode_mixed_init_and_dummy():
+    """Mixed has_init / pool_idx == 0 within one batch — the most realistic case
+    that hits all three conditional branches simultaneously (warm seq with state,
+    cold seq with no state, dummy padding slot)."""
+    H, D = 8, 128
+    num_seqs = 6
+    total_slots = num_seqs + 2
+    # mix:  warm-with-state, dummy, cold-no-state, warm-with-state, dummy, cold-no-state
+    indices = jnp.asarray([1, 0, 3, 4, 0, 6], dtype=jnp.int32)
+    has_init = jnp.asarray([True, True, False, True, False, False], dtype=jnp.bool_)
+
+    q, k, v = _make_qkv(num_seqs, H, D, seed=80)
+    buf = _make_buffer(total_slots, H, D, seed=81)
+    gamma = _make_g_gamma(H, seed=82)
+    buf_orig = np.asarray(buf)
+
+    o_ref, buf_ref, o_fused, buf_fused = _run_pair(q, k, v, buf, indices, has_init, gamma)
+
+    np.testing.assert_allclose(np.asarray(o_fused), np.asarray(o_ref), atol=_ATOL, rtol=_RTOL)
+    # Dummy slot still zero.
+    np.testing.assert_array_equal(np.asarray(buf_fused[0]), buf_orig[0])
+    # All non-touched slots (2, 5, 7) untouched.
+    for untouched in [2, 5, 7]:
+        np.testing.assert_array_equal(np.asarray(buf_fused[untouched]), buf_orig[untouched])
+    # All touched non-dummy slots match reference.
+    for touched in [1, 3, 4, 6]:
+        np.testing.assert_allclose(
+            np.asarray(buf_fused[touched]),
+            np.asarray(buf_ref[touched]),
+            atol=_ATOL,
+            rtol=_RTOL,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Behavioral tests (buffer corruption, dummy invariant, determinism, propagation)
+# ─────────────────────────────────────────────────────────────────────────
+def test_decode_untouched_slots_unchanged():
+    """Slots not in ``recurrent_indices`` must be byte-identical after the call."""
+    H, D = 8, 128
+    total_slots = 16
+    # Only touch slots 1, 4, 9 — leave 0 (dummy), 2-3, 5-8, 10-15 untouched.
+    indices = jnp.asarray([1, 4, 9], dtype=jnp.int32)
+    has_init = jnp.asarray([True, True, True], dtype=jnp.bool_)
+    num_seqs = indices.shape[0]
+
+    q, k, v = _make_qkv(num_seqs, H, D, seed=90)
+    buf = _make_buffer(total_slots, H, D, seed=91)
+    gamma = _make_g_gamma(H, seed=92)
+    buf_orig = np.asarray(buf)
+
+    _o, buf_fused = decode_simple_gla_fused(
+        q,
+        k,
+        v,
+        recurrent_buffer=buf,
+        recurrent_indices=indices,
+        has_initial_state=has_init,
+        g_gamma=gamma,
+        scale=None,
+    )
+    touched = {1, 4, 9}
+    for s in range(total_slots):
+        if s in touched:
+            continue
+        np.testing.assert_array_equal(
+            np.asarray(buf_fused[s]),
+            buf_orig[s],
+            err_msg=f"slot {s} (untouched) was modified",
+        )
+
+
+def test_decode_deterministic():
+    """Same inputs across two calls produce bit-identical outputs (donated input
+    means we feed a fresh copy on the second call)."""
+    H, D = 8, 128
+    num_seqs = 8
+    total_slots = num_seqs + 1
+    indices = jnp.arange(1, num_seqs + 1, dtype=jnp.int32)
+    has_init = jnp.full((num_seqs,), True, dtype=jnp.bool_)
+
+    q, k, v = _make_qkv(num_seqs, H, D, seed=100)
+    buf_np = np.asarray(_make_buffer(total_slots, H, D, seed=101))
+    gamma = _make_g_gamma(H, seed=102)
+
+    o1, buf1 = decode_simple_gla_fused(
+        q,
+        k,
+        v,
+        recurrent_buffer=jnp.asarray(buf_np),
+        recurrent_indices=indices,
+        has_initial_state=has_init,
+        g_gamma=gamma,
+        scale=None,
+    )
+    o2, buf2 = decode_simple_gla_fused(
+        q,
+        k,
+        v,
+        recurrent_buffer=jnp.asarray(buf_np),
+        recurrent_indices=indices,
+        has_initial_state=has_init,
+        g_gamma=gamma,
+        scale=None,
+    )
+    np.testing.assert_array_equal(np.asarray(o1), np.asarray(o2))
+    np.testing.assert_array_equal(np.asarray(buf1), np.asarray(buf2))
+
+
+def test_decode_state_propagation_multistep():
+    """Chain N successive decode calls and verify the state evolves the same way
+    in fused vs reference (catches scatter ordering / aliasing bugs)."""
+    H, D = 8, 128
+    num_seqs = 4
+    n_steps = 5
+    total_slots = num_seqs + 1
+    indices = jnp.arange(1, num_seqs + 1, dtype=jnp.int32)
+
+    # First step: cold (has_init=False). Subsequent steps: warm.
+    buf_ref = _make_buffer(total_slots, H, D, seed=110)
+    buf_fused = jnp.asarray(np.asarray(buf_ref))
+    gamma = _make_g_gamma(H, seed=111)
+
+    for step in range(n_steps):
+        has_init = jnp.full((num_seqs,), step > 0, dtype=jnp.bool_)
+        q, k, v = _make_qkv(num_seqs, H, D, seed=120 + step)
+
+        # Reference branch
+        o_ref, buf_ref_new = _baseline_decode(q, k, v, buf_ref, indices, has_init, gamma)
+        buf_ref = buf_ref_new
+
+        # Fused branch (donates its buf; pass fresh copy each step)
+        buf_fused_in = jnp.asarray(np.asarray(buf_fused))
+        o_fused, buf_fused = decode_simple_gla_fused(
+            q,
+            k,
+            v,
+            recurrent_buffer=buf_fused_in,
+            recurrent_indices=indices,
+            has_initial_state=has_init,
+            g_gamma=gamma,
+            scale=None,
+        )
+
+        np.testing.assert_allclose(
+            np.asarray(o_fused),
+            np.asarray(o_ref),
+            atol=_ATOL,
+            rtol=_RTOL,
+            err_msg=f"output mismatch at step {step}",
+        )
+        np.testing.assert_allclose(
+            np.asarray(buf_fused),
+            np.asarray(buf_ref),
+            atol=_ATOL,
+            rtol=_RTOL,
+            err_msg=f"buffer mismatch at step {step}",
+        )
+
+
+def test_decode_repeated_dummy_keeps_slot0_zero():
+    """Repeated calls with some dummy-slot targets must not pollute slot 0."""
+    H, D = 8, 128
+    total_slots = 8
+    gamma = _make_g_gamma(H, seed=130)
+    buf = _make_buffer(total_slots, H, D, seed=131)
+
+    for step in range(4):
+        # Every step routes one of the 4 seqs to slot 0.
+        indices = jnp.asarray([1, 0, 3, 5], dtype=jnp.int32)
+        has_init = jnp.full((4,), True, dtype=jnp.bool_)
+        q, k, v = _make_qkv(4, H, D, seed=140 + step)
+        _o, buf = decode_simple_gla_fused(
+            q,
+            k,
+            v,
+            recurrent_buffer=buf,
+            recurrent_indices=indices,
+            has_initial_state=has_init,
+            g_gamma=gamma,
+            scale=None,
+        )
+        # Slot 0 must remain exactly zero across every step.
+        np.testing.assert_array_equal(
+            np.asarray(buf[0]),
+            np.zeros((H, D, D), dtype=np.asarray(buf).dtype),
+            err_msg=f"slot 0 polluted after step {step}",
+        )

--- a/python/sgl_jax/test/layers/test_lightning_backend_dp.py
+++ b/python/sgl_jax/test/layers/test_lightning_backend_dp.py
@@ -348,9 +348,20 @@ class TestDPDecode:
         k_np = rng.standard_normal((B, 1, H, K)).astype(np.float32)
         v_np = rng.standard_normal((B, 1, H, K)).astype(np.float32)
 
-        # Different initial states per DP shard
+        # Distinct initial states per DP shard. Shard 1's h0 is 2x larger
+        # so the post-step state magnitudes are distinguishable; iid
+        # same-scale draws would land within rtol=0.1 and the magnitude
+        # assertion below would degenerate into a no-op.
+        #
+        # ``_make_mock_pool`` with ``dp_size=2`` allocates a
+        # (B_per_rank + 1)-slot local buffer per rank; the first
+        # B_per_rank entries of ``h0_np`` go to rank 0's local slots
+        # [1..B_per_rank] and the next B_per_rank entries go to rank 1's
+        # local slots [1..B_per_rank]. Per-rank batch indices must
+        # therefore be LOCAL (e.g. [1, 2] for B_per_rank=2), matching
+        # ``test_decode_dp2_tp2_matches_tp4``.
         h0_shard0 = rng.standard_normal((2, H, K, K)).astype(np.float32)
-        h0_shard1 = rng.standard_normal((2, H, K, K)).astype(np.float32)
+        h0_shard1 = rng.standard_normal((2, H, K, K)).astype(np.float32) * 2.0
         h0_np = np.concatenate([h0_shard0, h0_shard1], axis=0)
 
         mesh_dp = create_device_mesh(ici_parallelism=[2, 2], dcn_parallelism=[1, 1])
@@ -361,15 +372,19 @@ class TestDPDecode:
                 num_hidden_layers=80,
                 num_heads=H,
             )
-            rec_indices = np.arange(1, B + 1, dtype=np.int32)
+            # Default ``recurrent_indices=None`` → [1, ..., B_per_rank] per rank.
+            local_indices = np.arange(1, B // 2 + 1, dtype=np.int32)
             pool, _ = _make_mock_pool(
-                _LAYER_ID, jnp.array(h0_np), rec_indices, dp_size=2, mesh=mesh_dp
+                _LAYER_ID, jnp.array(h0_np), local_indices, dp_size=2, mesh=mesh_dp
             )
+            # Batch-side indices: tile per-rank local indices so each rank's
+            # shard receives its own [1, 2] (within local-buffer bounds).
+            batch_rec_indices = np.tile(local_indices, 2)
 
             batch = SimpleNamespace(
                 forward_mode=ForwardMode.DECODE,
                 seq_lens=np.ones(B, dtype=np.int32),
-                recurrent_indices=rec_indices,
+                recurrent_indices=batch_rec_indices,
                 has_initial_state=np.ones(B, dtype=np.bool_),
                 dp_size=2,
                 per_dp_bs_size=B // 2,
@@ -385,17 +400,17 @@ class TestDPDecode:
             v = jnp.array(v_np).reshape(B, H, K)
 
             out, pu = backend(q, k, v, layer=layer, forward_batch=fb, recurrent_state_pool=pool)
-            state = _extract_state(pu, rec_indices)
+            state = _extract_state(pu, local_indices, dp_size=2)
 
-        # Verify each request's output reflects its distinct initial state
-        # Requests 0,1 (shard 0) should differ from requests 2,3 (shard 1)
+        # Verify each request's output reflects its distinct initial state.
+        # state_np shape is (B, H, K, K) with the first 2 rows belonging to
+        # DP rank 0 (h0_shard0) and the last 2 to rank 1 (h0_shard1 = 2×).
         state_np = np.array(state)
-
-        # State magnitude should reflect initial state scale
         shard0_mag = np.abs(state_np[:2]).mean()
         shard1_mag = np.abs(state_np[2:]).mean()
 
-        # Shard 1 had 2x larger h0 → should have noticeably different magnitude
+        # Shard 1 had 2× larger h0 → post-step magnitudes should differ
+        # noticeably (>10%). Catches state leakage between DP shards.
         assert not np.allclose(
             shard0_mag, shard1_mag, rtol=0.1
         ), "DP shards should have distinct state magnitudes"

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -261,6 +261,7 @@ suites = {
         TestFile("python/sgl_jax/test/layers/test_group_rmsnorm.py", 0.1, runner="pytest"),
         TestFile("test/srt/lora/test_bgmv_backend.py", 7),
         TestFile("test/srt/lora/test_align_lora_accuracy.py", 5.5),
+        TestFile("python/sgl_jax/test/kernels/simple_gla_fused_test.py", 1, runner="pytest"),
         TestFile("python/sgl_jax/test/layers/test_gdn_backend.py", 0.6),
         TestFile("python/sgl_jax/test/layers/test_merged_column_parallel_linear.py", 0.1),
         TestFile("python/sgl_jax/test/layers/test_qwen3_5_gated_delta_net.py", 0.5),


### PR DESCRIPTION
## Summary

Replace the JAX three-stage `get_state` → `_forward_decode` (`fused_recurrent_simple_gla` scan) → `set_ssm_state` DECODE pipeline in `LightningAttnBackend` with a single Pallas `_launch_decode_simple_gla` that owns the recurrent-state HBM gather + scatter via in-kernel async DMA double-buffer.

- New file `python/sgl_jax/srt/kernels/simple_gla/simple_gla_fused.py` (~370 lines) implements the DECODE fused Pallas kernel
- 2-bank VMEM ping-pong for inbound (gather) and outbound (scatter) state plus 2-element DMA semaphore arrays; each DMA carries one token's worth across all H heads in a single contiguous `(H, BK, BV)` chunk
- Uses `disable_semaphore_checks=True` + in-kernel drain (pattern from `ragged_paged_attention_v3.py`) to safely leave the async pipeline at kernel exit
- Per-head 2D compute inside the per-token step; Mosaic does not yet support the 1D→3D vector layout that an H-vectorised body would need
- Conditional handling (`pool_idx == 0` dummy slot, `has_init == False` first decode step) folded into the pipeline via masks so semaphore counts stay balanced
- `tp_slope` (per-layer ALiBi slope vector) is constructed mesh-aware via `jax.make_array_from_callback(..., NamedSharding(mesh, P("tensor")))` so the outer pjit dispatch does not have to re-shard it on every step
- EXTEND path unchanged (still uses baseline `simple_gla_fwd` + JAX gather/scatter)

## Test

- New kernel-level UT `python/sgl_jax/test/kernels/simple_gla_fused_test.py` (12 cases) — equivalence vs `fused_recurrent_simple_gla` across shapes, dummy-slot, has_init combinations, untouched-slot integrity, determinism, multi-step state propagation; registered in `unit-test-tpu-v6e-1` via `test/srt/run_suite.py`
- `test/layers/test_lightning_backend_dp.py::test_decode_dp_state_isolation` updated: per-rank indices now use the local convention (matching the rest of the file) and `h0_shard1` is scaled `* 2.0` so the magnitude assertion is meaningful

## End-to-end validation on Ling-2.6-flash (TPU v6e-16, TP=16/DP=4/EP=16)

Server config matches PR #1043 (`--page-size 128 --chunked-prefill-size 2048 --dtype bfloat16 --mem-fraction-static 0.90 --max-running-requests 256 --attention-backend fa --moe-backend epmoe --disable-radix-cache --context-length 65536`). Baseline = `main` HEAD; both runs back-to-back on the same cluster.

### Eval accuracy

| Benchmark | Ling-2.6-flash official | sglang-jax PR #1043 baseline | **This branch** |
|---|---:|---:|---:|
| AIME26 (30 problems, T=0.6, max_tokens=32768, parallel=30) | 73.85 | 76.67 | **80.00 (24/30)** |
| GSM8K (1319 problems, T=0.0, max_tokens=2048, parallel=256) | — | — | **95.98 (1266/1319)** |

Both eval runs: 0 request errors / 0 truncations. AIME26 ±1 problem vs PR #1043 is sampling noise on 30 problems.

### Serving benchmark (`bench_serving`, 256 prompts × 128 concurrency, fresh server per run)

**Short context (input=4096, output=1024):**

| Metric | baseline | This branch | Δ |
|---|---:|---:|---:|
| Successful requests | 256/256 | 256/256 | — |
| Benchmark duration (s) | 86.05 | 84.91 | −1.3% |
| **Median ITL (ms)** (steady-state per-token decode latency) | **19.60** | **18.78** | **−4.2%** |
| P95 ITL (ms) | 20.14 | 19.79 | −1.7% |
| Mean TPOT (ms) | 30.28 | 29.58 | −2.3% |
| Output throughput (tok/s) | 3046.34 | 3087.48 | +1.35% |

#### What the profiling shows
baseline:
￼
<img width="1180" height="1026" alt="image" src="https://github.com/user-attachments/assets/52698f72-c0b8-45aa-a047-9392363c86f5" />
we can find the scatter in baseline is reduct and in per decode step level, **fused 18.76ms vs baseline 19.57ms**

**Long context (input=16384, output=1024):**

| Metric | baseline | This branch | Δ |
|---|---:|---:|---:|
| Successful requests | 256/256 | 256/256 | — |
| Benchmark duration (s) | 283.22 | 279.70 | −1.2% |
| Median ITL (ms) | 34.18 | 34.35 | +0.5% (within noise) |
| Output throughput (tok/s) | 925.59 | 937.24 | +1.3% |

Long context shifts the decode bottleneck to MLA attention (KV cache scales with context, GLA recurrent state does not), so the per-step GLA savings drop from ~10% of TPOT (4k) to ~5% (16k); not a regression on per-token latency, small win on throughput / duration.