### PR TITLE
feat(glm5): support FP8 block-wise checkpoint

### DIFF
--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -252,7 +252,9 @@ class ModelConfig:
 
             if quant_method == "fp8":
                 logger.info("Auto-detected FP8 model. Creating QuantizationConfig for static fp8.")
-                ignored_layers = hf_quant_config.get("ignored_layers")
+                ignored_layers = hf_quant_config.get("ignored_layers") or hf_quant_config.get(
+                    "modules_to_not_convert"
+                )
                 weight_block_size = hf_quant_config.get("weight_block_size")
                 if isinstance(weight_block_size, (list, tuple)) and len(weight_block_size) == 2:
                     weight_block_size = (int(weight_block_size[0]), int(weight_block_size[1]))

--- a/python/sgl_jax/srt/layers/linear.py
+++ b/python/sgl_jax/srt/layers/linear.py
@@ -305,9 +305,11 @@ class QuantizedLinear(nnx.Module):
                     tp = linear.mesh.shape.get(input_axis, 1) if input_axis else 1
                     if input_axis is not None and in_blocks % tp != 0:
                         logger.warning(
-                            "QuantizedLinear %s: in_blocks=%d not divisible by "
-                            "TP=%d on axis %r; replicating reduce axis",
+                            "QuantizedLinear %s [in=%d, out=%d]: in_blocks=%d not "
+                            "divisible by TP=%d on axis %r; replicating reduce axis",
                             linear.name,
+                            in_features,
+                            out_features,
                             in_blocks,
                             tp,
                             input_axis,

--- a/python/sgl_jax/srt/layers/linear.py
+++ b/python/sgl_jax/srt/layers/linear.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Sequence
 from functools import partial
 
@@ -14,6 +15,8 @@ from sgl_jax.srt.kernels.quantized_matmul.kernel import xla_quantized_matmul_loc
 from sgl_jax.srt.utils.parallel_utils import prepare_scattered_spec_if_needed
 from sgl_jax.srt.utils.profiling_utils import named_scope
 from sgl_jax.srt.utils.quantization.quantization_utils import quantize_tensor
+
+logger = logging.getLogger(__name__)
 
 
 class LinearBase(nnx.Module):
@@ -276,19 +279,13 @@ class QuantizedLinear(nnx.Module):
             tuple(weight_block_size) if weight_block_size is not None else None
         )
 
+        kernel_axes = linear.kernel_axes or (None, None)
         if is_static_input:
             # Static checkpoint already stores pre-quantized weights and scales.
             weight = linear.weight.value
 
             if isinstance(weight, jax.ShapeDtypeStruct):
                 in_features, out_features = map(int, weight.shape)
-                kernel_axes = linear.kernel_axes or (None, None)
-                wq_sharding = NamedSharding(linear.mesh, P(kernel_axes[1], kernel_axes[0]))
-                weight_q = jax.ShapeDtypeStruct(
-                    shape=(out_features, in_features),
-                    dtype=weight_dtype,
-                    sharding=wq_sharding,
-                )
 
                 if (
                     effective_weight_block_size is not None
@@ -298,6 +295,24 @@ class QuantizedLinear(nnx.Module):
                         effective_weight_block_size[1]
                     )
                     in_blocks = (in_features + block_k - 1) // block_k
+                    # Row-parallel block-wise layers shard the reduce axis, so
+                    # the in_blocks dimension of the [in_blocks, 1, n_out]
+                    # scale must also tile across TP. When it doesn't (e.g.
+                    # GLM-5.1 dense/shared down_proj: 96/16 blocks vs TP=64),
+                    # fall back to a replicated reduce axis for this layer
+                    # only. The original LinearBase keeps row-parallel.
+                    input_axis = kernel_axes[0]
+                    tp = linear.mesh.shape.get(input_axis, 1) if input_axis else 1
+                    if input_axis is not None and in_blocks % tp != 0:
+                        logger.warning(
+                            "QuantizedLinear %s: in_blocks=%d not divisible by "
+                            "TP=%d on axis %r; replicating reduce axis",
+                            linear.name,
+                            in_blocks,
+                            tp,
+                            input_axis,
+                        )
+                        kernel_axes = (None, kernel_axes[1])
                     # Pre-expanded kernel-ready layout: [in_blocks, 1, n_out].
                     scale_sharding = NamedSharding(
                         linear.mesh, P(kernel_axes[0], None, kernel_axes[1])
@@ -312,6 +327,12 @@ class QuantizedLinear(nnx.Module):
                     weight_scale = jax.ShapeDtypeStruct(
                         shape=(out_features,), dtype=jnp.float32, sharding=scale_sharding
                     )
+                wq_sharding = NamedSharding(linear.mesh, P(kernel_axes[1], kernel_axes[0]))
+                weight_q = jax.ShapeDtypeStruct(
+                    shape=(out_features, in_features),
+                    dtype=weight_dtype,
+                    sharding=wq_sharding,
+                )
                 bias = linear.bias.value if linear.bias is not None else None
             else:
                 if weight.dtype != weight_dtype:
@@ -375,7 +396,7 @@ class QuantizedLinear(nnx.Module):
             bias=bias,
             activation_dtype=activation_dtype,
             mesh=linear.mesh,
-            kernel_axes=linear.kernel_axes,
+            kernel_axes=kernel_axes,
             skip_bias_add=linear.skip_bias_add,
             params_dtype=linear.params_dtype,
             weight_block_size=effective_weight_block_size,

--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -874,7 +874,10 @@ class Glm5ForCausalLM(nnx.Module):
         add_linear(f"{ap}.indexer.wk", f"{tp}.indexer.wk", (None, None))
         # weights_proj is in modules_to_not_convert (HF: indexers_proj) → unquantized.
         add_linear(
-            f"{ap}.indexer.weights_proj", f"{tp}.indexer.weights_proj", (None, None), force_unquant=True
+            f"{ap}.indexer.weights_proj",
+            f"{tp}.indexer.weights_proj",
+            (None, None),
+            force_unquant=True,
         )
         mappings[f"{ap}.indexer.k_norm.weight"] = WeightMapping(
             target_path=f"{tp}.indexer.k_norm.weight", sharding=(None,)
@@ -884,9 +887,13 @@ class Glm5ForCausalLM(nnx.Module):
         )
 
         if is_mlp_layer:
-            add_linear(f"{prefix}.mlp.gate_proj", f"{target_prefix}.mlp.gate_proj", (None, "tensor"))
+            add_linear(
+                f"{prefix}.mlp.gate_proj", f"{target_prefix}.mlp.gate_proj", (None, "tensor")
+            )
             add_linear(f"{prefix}.mlp.up_proj", f"{target_prefix}.mlp.up_proj", (None, "tensor"))
-            add_linear(f"{prefix}.mlp.down_proj", f"{target_prefix}.mlp.down_proj", ("tensor", None))
+            add_linear(
+                f"{prefix}.mlp.down_proj", f"{target_prefix}.mlp.down_proj", ("tensor", None)
+            )
         else:
             mappings[f"{prefix}.mlp.gate.weight"] = WeightMapping(
                 target_path=f"{target_prefix}.moe_gate.kernel",

--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -977,7 +977,9 @@ class GlmMoeDsaForCausalLM(Glm5ForCausalLM):
         # `self_attn.indexers_proj`); translate to sglang-jax module paths so
         # quantize_model leaves the unquantized indexer head-gate as LinearBase.
         if mc.quantization_config is not None and mc.quantization_config.is_static_checkpoint:
-            mc.quantization_config.ignored_layers = ["indexer.weights_proj"]
+            mc.quantization_config.ignored_layers = list(
+                mc.quantization_config.ignored_layers or []
+            ) + ["indexer.weights_proj"]
             # indexer.wk has out_dim=128 == block_size_out (single N-block); the
             # narrow-N guard would reject it but the indexer output is currently
             # discarded so accuracy is unaffected. Match deepseek_v3 config.

--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -303,7 +303,21 @@ class Glm5Attention(nnx.Module):
             return
         if self.kv_b_proj is None:
             return
-        w_kv = self.kv_b_proj.weight.value.reshape(
+        if hasattr(self.kv_b_proj, "weight"):
+            raw_weight = self.kv_b_proj.weight.value
+        else:
+            wq = self.kv_b_proj.weight_q.value
+            ws = self.kv_b_proj.weight_scale.value
+            wq_f32 = wq.T.astype(jnp.float32)
+            if ws.ndim == 3:
+                in_blocks, _, n_out = ws.shape
+                block_k = wq.shape[1] // in_blocks
+                wq_f32 = wq_f32.reshape(in_blocks, block_k, n_out)
+                wq_f32 = (wq_f32 * ws.astype(jnp.float32)).reshape(in_blocks * block_k, n_out)
+            else:
+                wq_f32 = wq_f32 * ws.astype(jnp.float32)[None, :]
+            raw_weight = wq_f32.astype(jnp.bfloat16)
+        w_kv = raw_weight.reshape(
             self.kv_lora_rank,
             self.num_heads,
             self.qk_nope_head_dim + self.v_head_dim,
@@ -815,146 +829,64 @@ class Glm5ForCausalLM(nnx.Module):
             ),
         }
 
-        w_name = "weight_q" if is_static_quant else "weight"
+        def add_linear(hf: str, tgt: str, sharding_std: tuple, force_unquant: bool = False):
+            """Mirror deepseek_v3._create_layer_mappings.add_linear.
 
-        # Attention mappings (separate Q, K, V in checkpoint)
-        # Attention mappings (MLA)
-        mappings[f"{prefix}.self_attn.q_a_proj.weight"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.q_a_proj.{w_name}",
-            sharding=(None, None),
-            transpose=True,
-        )
-        mappings[f"{prefix}.self_attn.q_a_layernorm.weight"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.q_a_layernorm.scale",
-            sharding=(None,),
-        )
-        mappings[f"{prefix}.self_attn.q_b_proj.weight"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.q_b_proj.{w_name}",
-            sharding=(None, "tensor"),
-            transpose=True,
-        )
-        mappings[f"{prefix}.self_attn.kv_a_proj_with_mqa.weight"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.kv_a_proj_with_mqa.{w_name}",
-            sharding=(None, None),
-            transpose=True,
-        )
-        mappings[f"{prefix}.self_attn.kv_a_layernorm.weight"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.kv_a_layernorm.scale",
-            sharding=(None,),
-        )
-        mappings[f"{prefix}.self_attn.kv_b_proj.weight"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.kv_b_proj.{w_name}",
-            sharding=(None, "tensor"),
-            transpose=True,
-        )
-        mappings[f"{prefix}.self_attn.o_proj.weight"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.o_proj.{w_name}",
-            sharding=("tensor", None),
-            transpose=True,
-        )
-
-        # Indexer mappings
-        mappings[f"{prefix}.self_attn.indexer.wq_b.weight"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.indexer.wq_b.{w_name}",
-            sharding=(None, None),
-            transpose=True,
-        )
-        mappings[f"{prefix}.self_attn.indexer.wk.weight"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.indexer.wk.{w_name}",
-            sharding=(None, None),
-            transpose=True,
-        )
-        mappings[f"{prefix}.self_attn.indexer.weights_proj.weight"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.indexer.weights_proj.{w_name}",
-            sharding=(None, None),
-            transpose=True,
-        )
-        mappings[f"{prefix}.self_attn.indexer.k_norm.weight"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.indexer.k_norm.weight",
-            sharding=(None,),
-        )
-        mappings[f"{prefix}.self_attn.indexer.k_norm.bias"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.indexer.k_norm.bias",
-            sharding=(None,),
-        )
-
-        if is_static_quant:
-            mappings[f"{prefix}.self_attn.q_a_proj.weight_scale_inv"] = WeightMapping(
-                target_path=f"{target_prefix}.self_attn.q_a_proj.weight_scale",
-                sharding=(None,),
-                transpose=False,
+            HF weight is [out, in]. Unquantized → LinearBase.weight [in, out]
+            (transpose=True, sharding=kernel_axes). Static FP8 → QuantizedLinear
+            .weight_q [out, in] (transpose=False, sharding swapped) plus the
+            block-wise weight_scale_inv sidecar. force_unquant covers modules in
+            the FP8 checkpoint's modules_to_not_convert (indexer.weights_proj).
+            """
+            if force_unquant or not is_static_quant:
+                mappings[f"{hf}.weight"] = WeightMapping(
+                    target_path=f"{tgt}.weight", sharding=sharding_std, transpose=True
+                )
+                return
+            sharding_q = (sharding_std[1], sharding_std[0])
+            mappings[f"{hf}.weight"] = WeightMapping(
+                target_path=f"{tgt}.weight_q", sharding=sharding_q, transpose=False
             )
-            mappings[f"{prefix}.self_attn.q_b_proj.weight_scale_inv"] = WeightMapping(
-                target_path=f"{target_prefix}.self_attn.q_b_proj.weight_scale",
-                sharding=("tensor",),
-                transpose=False,
-            )
-            mappings[f"{prefix}.self_attn.kv_a_proj_with_mqa.weight_scale_inv"] = WeightMapping(
-                target_path=f"{target_prefix}.self_attn.kv_a_proj_with_mqa.weight_scale",
-                sharding=(None,),
-                transpose=False,
-            )
-            mappings[f"{prefix}.self_attn.kv_b_proj.weight_scale_inv"] = WeightMapping(
-                target_path=f"{target_prefix}.self_attn.kv_b_proj.weight_scale",
-                sharding=("tensor",),
-                transpose=False,
-            )
-            mappings[f"{prefix}.self_attn.o_proj.weight_scale_inv"] = WeightMapping(
-                target_path=f"{target_prefix}.self_attn.o_proj.weight_scale",
-                sharding=(None,),
-                transpose=False,
-            )
-            mappings[f"{prefix}.self_attn.indexer.wk.weight_scale_inv"] = WeightMapping(
-                target_path=f"{target_prefix}.self_attn.indexer.wk.weight_scale",
-                sharding=(None,),
-                transpose=False,
-            )
-            mappings[f"{prefix}.self_attn.indexer.wq_b.weight_scale_inv"] = WeightMapping(
-                target_path=f"{target_prefix}.self_attn.indexer.wq_b.weight_scale",
-                sharding=(None,),
-                transpose=False,
+            # Load 2D block scale [out_blocks, in_blocks] replicated: GLM-5.1 head_dim
+            # 448 → out_blocks not always tp-divisible (kv_b_proj: 224 % 64 ≠ 0).
+            # _maybe_expand_linear_block_scale runs after _shard_weight and expands to
+            # [in_blocks, 1, n_out]; assignment into model_param then reshards to the
+            # QuantizedLinear placeholder's 3D sharding.
+            mappings[f"{hf}.weight_scale_inv"] = WeightMapping(
+                target_path=f"{tgt}.weight_scale", sharding=(None, None), transpose=False
             )
 
-        # DSA Indexer Norm
-        mappings[f"{prefix}.self_attn.indexer.k_norm.weight"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.indexer.k_norm.weight", sharding=(None,)
+        ap = f"{prefix}.self_attn"
+        tp = f"{target_prefix}.self_attn"
+        add_linear(f"{ap}.q_a_proj", f"{tp}.q_a_proj", (None, None))
+        mappings[f"{ap}.q_a_layernorm.weight"] = WeightMapping(
+            target_path=f"{tp}.q_a_layernorm.scale", sharding=(None,)
         )
-        mappings[f"{prefix}.self_attn.indexer.k_norm.bias"] = WeightMapping(
-            target_path=f"{target_prefix}.self_attn.indexer.k_norm.bias", sharding=(None,)
+        add_linear(f"{ap}.q_b_proj", f"{tp}.q_b_proj", (None, "tensor"))
+        add_linear(f"{ap}.kv_a_proj_with_mqa", f"{tp}.kv_a_proj_with_mqa", (None, None))
+        mappings[f"{ap}.kv_a_layernorm.weight"] = WeightMapping(
+            target_path=f"{tp}.kv_a_layernorm.scale", sharding=(None,)
+        )
+        add_linear(f"{ap}.kv_b_proj", f"{tp}.kv_b_proj", (None, "tensor"))
+        add_linear(f"{ap}.o_proj", f"{tp}.o_proj", ("tensor", None))
+
+        add_linear(f"{ap}.indexer.wq_b", f"{tp}.indexer.wq_b", (None, None))
+        add_linear(f"{ap}.indexer.wk", f"{tp}.indexer.wk", (None, None))
+        # weights_proj is in modules_to_not_convert (HF: indexers_proj) → unquantized.
+        add_linear(
+            f"{ap}.indexer.weights_proj", f"{tp}.indexer.weights_proj", (None, None), force_unquant=True
+        )
+        mappings[f"{ap}.indexer.k_norm.weight"] = WeightMapping(
+            target_path=f"{tp}.indexer.k_norm.weight", sharding=(None,)
+        )
+        mappings[f"{ap}.indexer.k_norm.bias"] = WeightMapping(
+            target_path=f"{tp}.indexer.k_norm.bias", sharding=(None,)
         )
 
         if is_mlp_layer:
-            mappings[f"{prefix}.mlp.gate_proj.weight"] = WeightMapping(
-                target_path=f"{target_prefix}.mlp.gate_proj.{w_name}",
-                sharding=(None, "tensor"),
-                transpose=True,
-            )
-            mappings[f"{prefix}.mlp.up_proj.weight"] = WeightMapping(
-                target_path=f"{target_prefix}.mlp.up_proj.{w_name}",
-                sharding=(None, "tensor"),
-                transpose=True,
-            )
-            mappings[f"{prefix}.mlp.down_proj.weight"] = WeightMapping(
-                target_path=f"{target_prefix}.mlp.down_proj.{w_name}",
-                sharding=("tensor", None),
-                transpose=True,
-            )
-            if is_static_quant:
-                mappings[f"{prefix}.mlp.gate_proj.weight_scale_inv"] = WeightMapping(
-                    target_path=f"{target_prefix}.mlp.gate_proj.weight_scale",
-                    sharding=(None, None),
-                    transpose=False,
-                )
-                mappings[f"{prefix}.mlp.up_proj.weight_scale_inv"] = WeightMapping(
-                    target_path=f"{target_prefix}.mlp.up_proj.weight_scale",
-                    sharding=(None, None),
-                    transpose=False,
-                )
-                mappings[f"{prefix}.mlp.down_proj.weight_scale_inv"] = WeightMapping(
-                    target_path=f"{target_prefix}.mlp.down_proj.weight_scale",
-                    sharding=(None, None),
-                    transpose=False,
-                )
+            add_linear(f"{prefix}.mlp.gate_proj", f"{target_prefix}.mlp.gate_proj", (None, "tensor"))
+            add_linear(f"{prefix}.mlp.up_proj", f"{target_prefix}.mlp.up_proj", (None, "tensor"))
+            add_linear(f"{prefix}.mlp.down_proj", f"{target_prefix}.mlp.down_proj", ("tensor", None))
         else:
             mappings[f"{prefix}.mlp.gate.weight"] = WeightMapping(
                 target_path=f"{target_prefix}.moe_gate.kernel",
@@ -997,15 +929,14 @@ class Glm5ForCausalLM(nnx.Module):
                     target_scale_param = target_param + "_scale"
                     scale_src_paths = [p.replace(".weight", ".weight_scale_inv") for p in src_paths]
 
-                    # For GLM-5 FP8, scales are stored as [num_experts, in_blocks, out_blocks]
-                    # We need to transpose them to [num_experts, out_blocks, in_blocks] for moe.py
+                    # Stacked HF scale is [E, out_blocks, in_blocks]. Load EP-sharded
+                    # and replicated on the block dims (matches deepseek_v3); the
+                    # loader's _maybe_convert_epmoe_scale_for_kernel handles the
+                    # [E, out_blocks, k_blocks] → [E, k_blocks, 1, n_out] expand.
                     new_moe_mappings[scale_key] = WeightMapping(
                         target_path=[target_scale_param] + scale_src_paths,
-                        sharding=None,
+                        sharding=("expert", None, None),
                         transpose=False,
-                        transpose_axes=(0, 2, 1),
-                        reshape=None,
-                        repeat=None,
                         concat_axis=mapping.concat_axis,
                         physical_to_logical_map=mapping.physical_to_logical_map,
                     )
@@ -1015,43 +946,11 @@ class Glm5ForCausalLM(nnx.Module):
 
             num_shared = getattr(self.config, "n_shared_experts", 0)
             if num_shared > 0:
-                mappings[f"{prefix}.mlp.shared_experts.gate_proj.weight"] = WeightMapping(
-                    target_path=f"{target_prefix}.shared_experts.gate_proj.{w_name}",
-                    sharding=(None, "tensor"),
-                    transpose=True,
-                )
-                mappings[f"{prefix}.mlp.shared_experts.up_proj.weight"] = WeightMapping(
-                    target_path=f"{target_prefix}.shared_experts.up_proj.{w_name}",
-                    sharding=(None, "tensor"),
-                    transpose=True,
-                )
-                mappings[f"{prefix}.mlp.shared_experts.down_proj.weight"] = WeightMapping(
-                    target_path=f"{target_prefix}.shared_experts.down_proj.{w_name}",
-                    sharding=("tensor", None),
-                    transpose=True,
-                )
-                if is_static_quant:
-                    mappings[f"{prefix}.mlp.shared_experts.gate_proj.weight_scale_inv"] = (
-                        WeightMapping(
-                            target_path=f"{target_prefix}.shared_experts.gate_proj.weight_scale",
-                            sharding=(None,),
-                            transpose=False,
-                        )
-                    )
-                    mappings[f"{prefix}.mlp.shared_experts.up_proj.weight_scale_inv"] = (
-                        WeightMapping(
-                            target_path=f"{target_prefix}.shared_experts.up_proj.weight_scale",
-                            sharding=(None,),
-                            transpose=False,
-                        )
-                    )
-                    mappings[f"{prefix}.mlp.shared_experts.down_proj.weight_scale_inv"] = (
-                        WeightMapping(
-                            target_path=f"{target_prefix}.shared_experts.down_proj.weight_scale",
-                            sharding=(None,),
-                            transpose=False,
-                        )
-                    )
+                sp = f"{prefix}.mlp.shared_experts"
+                st = f"{target_prefix}.shared_experts"
+                add_linear(f"{sp}.gate_proj", f"{st}.gate_proj", (None, "tensor"))
+                add_linear(f"{sp}.up_proj", f"{st}.up_proj", (None, "tensor"))
+                add_linear(f"{sp}.down_proj", f"{st}.down_proj", ("tensor", None))
 
         return mappings
 
@@ -1067,6 +966,15 @@ class GlmMoeDsaForCausalLM(Glm5ForCausalLM):
         mc.v_head_dim = getattr(mc.hf_text_config, "v_head_dim", 256)
         # GLM-5 uses MLA architecture
         mc.attention_arch = AttentionArch.MLA
+        # GLM-5.1-FP8 ships modules_to_not_convert with HF naming (e.g.
+        # `self_attn.indexers_proj`); translate to sglang-jax module paths so
+        # quantize_model leaves the unquantized indexer head-gate as LinearBase.
+        if mc.quantization_config is not None and mc.quantization_config.is_static_checkpoint:
+            mc.quantization_config.ignored_layers = ["indexer.weights_proj"]
+            # indexer.wk has out_dim=128 == block_size_out (single N-block); the
+            # narrow-N guard would reject it but the indexer output is currently
+            # discarded so accuracy is unaffected. Match deepseek_v3 config.
+            mc.quantization_config.allow_narrow_n_blockwise = True
 
 
 EntryClass = [Glm5ForCausalLM, GlmMoeDsaForCausalLM]


### PR DESCRIPTION
## Summary

Enables `zai-org/GLM-5.1-FP8` (block-wise 128×128 e4m3, 750GB) on sglang-jax. PR #1037 shipped the FP8 weight mapping skeleton but it had several bugs that prevented loading; this PR fixes them and gets FP8 serving end-to-end.

Tested on TPU v6e-64 (TP=64, EP=32): sanity + GSM8K correct, **BF16 path verified unchanged** (±2%).

## Changes

**`glm5_moe.py`** (+82/-176)
- `post_load_weights`: dequant FP8 `kv_b_proj` (weight_q × scale) before splitting `w_uk`/`w_uv` for absorbed MLA. Mirrors `deepseek_v3.py`.
- Rewrite linear weight mappings via an `add_linear()` helper (mirrors deepseek_v3). The original `w_name + transpose=True` pattern from #1037 mismatched the `weight_q [out, in]` layout.
- MoE scale mapping `sharding=None → ("expert", None, None)`: replicated scales accumulated ~22 GB/chip and OOM'd at layer 69.
- `patch_model_config`: translate HF `modules_to_not_convert` (`self_attn.indexers_proj`) to the sglang module path `indexer.weights_proj`; set `allow_narrow_n_blockwise=True` (only `indexer.wk` with out_dim=128 hits the narrow-N guard, and its output is discarded).

**`layers/linear.py`** (+30/-7)
- `QuantizedLinear.from_linear`: when a row-parallel block-wise layer's `in_blocks` does not divide TP, fall back to a replicated reduce axis **for that QuantizedLinear only**. GLM-5.1 dense `down_proj` (intermediate=12288 → 96 blocks) and shared `down_proj` (2048 → 16 blocks) don't divide TP=64. The original `LinearBase` keeps row-parallel, so **BF16 is unaffected**.

**`configs/model_config.py`** (+3/-1)
- Read HF `modules_to_not_convert` as `ignored_layers` fallback.

## Test results (updated 2026-05-29)

### Correctness (v6e-64, TP=64/EP=32)
| | BF16 (this PR) | BF16 (main) | FP8 W8A16 (this PR) |
|---|---|---|---|
| Sanity / GSM8K | ✅ | ✅ | ✅ |
| KV cache tokens | 25.6K | 25.6K | **127K (5.0×)** |
| BF16 regression | ±2% | — | — |

### Performance (initial → with follow-up PRs)
| config | 1K cc=8 TPOT | notes |
|---|---|---|
| FP8 W8A16, this PR alone | 78.4 ms | **gmm_v2 rejects block-scale** (`shape[1]=48`), falls back to gmm v1 + unfused permute/mask |
| + #1191 (merged) quantized_matmul tuning | 61.0 ms | dense linear tuned, MoE still v1 |
| + **#1259** gmm_v2 block-scale | ~37 ms (proj.) | unblocks gmm_v2 for block-wise MoE; standalone kernel W8A16-blk **268 μs vs W8A8 319 μs** (16% faster) |

### Production-scale reference (W8A8 on-the-fly, same gmm_v2 path that #1259 unlocks for W8A16)
| platform | config | tok/s | TPOT (ms) | tok/s/chip |
|---|---|---|---|---|
| **Trillium (v6e-64)** | W8A8 tp64 dp8 ep64, 1K/1K cc=460 | **2804** | 131 | 43.8 |
| Ironwood (v7x-16) | W8A8 tp32 dp4 ep32, 1K/1K cc=500 | 2122 | 193 | **132.6** |
| H200×8 ([sgl-cookbook §5.1.2](https://github.com/sgl-project/sgl-cookbook/blob/main/docs/autoregressive/GLM/GLM-5.1.md#512-throughput-benchmark)) | FP8 tp8+MTP+DP, 1K/1K cc=100 | 1215 | 38.7 | 151.9 |

(Different cc reflects each platform's KV-cache capacity; all are at/near their respective throughput peaks.)

**Note**: the `GLM-5.1-FP8` checkpoint specifies `"activation_scheme": "dynamic"` (i.e. W8A8), but this PR only wires up **weight loading** — activations stay bf16, so it currently runs as **W8A16** (bf16×fp8 → no FP8 2× compute). With #1259 it should land between BF16 and the W8A8 reference above (decode/memory-bound close to W8A8; prefill/compute-bound close to BF16). Full W8A8 (block-wise weight + dynamic per-token act) is a follow-up.

## Follow-ups
- [x] #1191 (merged): GLM shapes in quantized_matmul tuning table
- [ ] **#1259**: gmm_v2 block-scale support — required for block-wise FP8 MoE to use gmm_v2
- [ ] **W8A8**: implement dynamic act quant for block-wise weight (honor `activation_scheme: dynamic`) → fp8×fp8 matmul, should reach W8A8 reference perf
- [ ] (optional) dequant `down_proj` on load to BF16 row-parallel (+~37 MB/chip, removes replicated fallback)

Refs #1036.
