### PR TITLE
perf(bailing-moe-linear): split GLA QKV at load time (+ hybrid-attn HeadContext, static-quant)

### DIFF
--- a/python/sgl_jax/srt/models/bailing_moe_linear.py
+++ b/python/sgl_jax/srt/models/bailing_moe_linear.py
@@ -68,14 +68,35 @@ class BailingMoELinearAttention(nnx.Module):
 
         inner_size = self.num_heads * self.head_dim
         qkv_bias = getattr(config, "use_bias", False) or getattr(config, "use_qkv_bias", False)
-        self.qkv_proj = LinearBase(
+        # Separate Q/K/V projections: each per-head TP shard already aligns with
+        # the [T, num_heads, head_dim] reshape, so the reshape is a metadata op
+        # (no all-gather).
+        self.q_proj = LinearBase(
             input_size=self.hidden_size,
-            output_size=3 * inner_size,
+            output_size=inner_size,
             use_bias=qkv_bias,
             kernel_axes=(None, "tensor"),
             params_dtype=dtype,
             mesh=mesh,
-            scope_name="query_key_value",
+            scope_name="q_proj",
+        )
+        self.k_proj = LinearBase(
+            input_size=self.hidden_size,
+            output_size=inner_size,
+            use_bias=qkv_bias,
+            kernel_axes=(None, "tensor"),
+            params_dtype=dtype,
+            mesh=mesh,
+            scope_name="k_proj",
+        )
+        self.v_proj = LinearBase(
+            input_size=self.hidden_size,
+            output_size=inner_size,
+            use_bias=qkv_bias,
+            kernel_axes=(None, "tensor"),
+            params_dtype=dtype,
+            mesh=mesh,
+            scope_name="v_proj",
         )
         self.g_proj = LinearBase(
             input_size=self.hidden_size,
@@ -151,17 +172,28 @@ class BailingMoELinearAttention(nnx.Module):
         forward_batch: ForwardBatch,
         recurrent_state_pool,
     ) -> tuple[jax.Array, tuple]:
-        qkv, _ = self.qkv_proj(hidden_states)
-        qkv = qkv.astype(jnp.float32)
-        if self.linear_silu:
-            qkv = jax.nn.silu(qkv)
+        q, _ = self.q_proj(hidden_states)
+        k, _ = self.k_proj(hidden_states)
+        v, _ = self.v_proj(hidden_states)
 
-        qkv = jax.lax.reshape(
-            qkv,
-            (hidden_states.shape[0], 3, self.num_heads, self.head_dim),
-            out_sharding=NamedSharding(self.mesh, P("data", None, "tensor", None)),
+        q = q.astype(jnp.float32)
+        k = k.astype(jnp.float32)
+        v = v.astype(jnp.float32)
+        if self.linear_silu:
+            q = jax.nn.silu(q)
+            k = jax.nn.silu(k)
+            v = jax.nn.silu(v)
+
+        head_shard = NamedSharding(self.mesh, P("data", "tensor", None))
+        q = q.reshape(
+            hidden_states.shape[0], self.num_heads, self.head_dim, out_sharding=head_shard
         )
-        q, k, v = qkv[:, 0], qkv[:, 1], qkv[:, 2]
+        k = k.reshape(
+            hidden_states.shape[0], self.num_heads, self.head_dim, out_sharding=head_shard
+        )
+        v = v.reshape(
+            hidden_states.shape[0], self.num_heads, self.head_dim, out_sharding=head_shard
+        )
 
         if self.q_norm is not None:
             q = self.q_norm(q)
@@ -816,9 +848,40 @@ class BailingMoeV2_5ForCausalLM(nnx.Module):
     ) -> None:
         ap = f"{prefix}.attention"
         tp = f"{target}.self_attn"
-        self._add_linear(
-            mappings, f"{ap}.query_key_value", f"{tp}.qkv_proj", (None, "tensor"), is_static_quant
-        )
+        if is_static_quant:
+            # Static FP8: apply_linear_quantization swaps each q/k/v_proj LinearBase
+            # into a QuantizedLinear pair, so the fused HF QKV must fan out to six
+            # targets (q/k/v × {weight_q, weight_scale}). Sharding axis is swapped
+            # and transpose=False because static-FP8 stores [out, in] directly into
+            # weight_q.
+            mappings[f"{ap}.query_key_value.weight"] = WeightMapping(
+                target_path=[
+                    f"{tp}.q_proj.weight_q",
+                    f"{tp}.k_proj.weight_q",
+                    f"{tp}.v_proj.weight_q",
+                ],
+                sharding=("tensor", None),
+                transpose=False,
+            )
+            mappings[f"{ap}.query_key_value.weight_scale"] = WeightMapping(
+                target_path=[
+                    f"{tp}.q_proj.weight_scale",
+                    f"{tp}.k_proj.weight_scale",
+                    f"{tp}.v_proj.weight_scale",
+                ],
+                sharding=("tensor", None),
+                transpose=False,
+            )
+        else:
+            mappings[f"{ap}.query_key_value.weight"] = WeightMapping(
+                target_path=[
+                    f"{tp}.q_proj.weight",
+                    f"{tp}.k_proj.weight",
+                    f"{tp}.v_proj.weight",
+                ],
+                sharding=(None, "tensor"),
+                transpose=True,
+            )
         self._add_linear(
             mappings, f"{ap}.g_proj", f"{tp}.g_proj", (None, "tensor"), is_static_quant
         )

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -141,13 +141,17 @@ class WeightLoader:
             # Use original count for replication logic
             self.num_kv_heads = model_config.get_total_num_kv_heads()
             self.hidden_size = model_config.hidden_size
-            self.head_dim_original = getattr(
-                model_config, "head_dim", self.hidden_size // self.num_heads
-            )
+            # Read head_dim / v_head_dim from hf_text_config rather than model_config:
+            # patch_model_config writes mc.head_dim for KV-cache / MemoryPools sizing,
+            # but the loader needs the per-layer truth for split-QKV weight slicing.
+            # hf_text_config stays unpatched so split-QKV slicing is correct for
+            # hybrid-attention models.
+            hf_cfg = getattr(model_config, "hf_text_config", model_config)
+            self.head_dim_original = getattr(hf_cfg, "head_dim", self.hidden_size // self.num_heads)
 
             self.head_dim_pad = (self.head_dim_original + 127) // 128 * 128 - self.head_dim_original
             self.head_dim = self.head_dim_original
-            self.v_head_dim = getattr(model_config, "v_head_dim", self.head_dim_original)
+            self.v_head_dim = getattr(hf_cfg, "v_head_dim", self.head_dim_original)
         if hasattr(self.mesh, "shape") and "tensor" in self.mesh.shape:
             self.sharding_size = self.mesh.shape["tensor"]
         else:
@@ -2768,10 +2772,9 @@ class WeightLoader:
         elif padding_strategy == "zero":
             target_heads_total = total_kv_heads * num_replicas
 
-            if step_size == 1:
-                target_len = target_heads_total
-            else:
-                target_len = target_heads_total * self.head_dim
+            target_len = (
+                target_heads_total if step_size == 1 else target_heads_total * self.head_dim
+            )
 
             current_len = weight.shape[target_axis]
             padding_len = target_len - current_len

--- a/python/sgl_jax/test/test_bailing_moe_linear.py
+++ b/python/sgl_jax/test/test_bailing_moe_linear.py
@@ -133,10 +133,11 @@ def test_weight_mapping_contains_linear_mla_dense_and_shared_mlp_keys():
         type("DummyModelConfig", (), {"quantization_config": None})()
     )
 
-    assert (
-        mappings["model.layers.0.attention.query_key_value.weight"].target_path
-        == "model.layers.0.self_attn.qkv_proj.weight"
-    )
+    assert mappings["model.layers.0.attention.query_key_value.weight"].target_path == [
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.self_attn.k_proj.weight",
+        "model.layers.0.self_attn.v_proj.weight",
+    ]
     assert (
         mappings["model.layers.0.attention.g_norm.weight"].target_path
         == "model.layers.0.self_attn.g_norm.weight"
@@ -157,6 +158,42 @@ def test_weight_mapping_contains_linear_mla_dense_and_shared_mlp_keys():
         mappings["model.layers.0.mlp.down_proj.weight"].target_path
         == "model.layers.0.mlp.down_proj.weight"
     )
+
+
+def test_weight_mapping_static_quant_gla_splits_into_weight_q_and_scale():
+    cfg = _tiny_config(num_hidden_layers=2, layer_group_size=2, full_attention_type="mla")
+    model = object.__new__(BailingMoeV2_5ForCausalLM)
+    object.__setattr__(model, "config", cfg)
+    object.__setattr__(
+        model,
+        "model",
+        type("DummyInnerModel", (), {"decoder_attention_types": [0, 1]})(),
+    )
+
+    class _FakeQuantCfg:
+        is_static_checkpoint = True
+
+    mappings = model._create_bailing_moe_linear_weight_mappings(
+        type("DummyModelConfig", (), {"quantization_config": _FakeQuantCfg()})()
+    )
+
+    qkv_w = mappings["model.layers.0.attention.query_key_value.weight"]
+    assert qkv_w.target_path == [
+        "model.layers.0.self_attn.q_proj.weight_q",
+        "model.layers.0.self_attn.k_proj.weight_q",
+        "model.layers.0.self_attn.v_proj.weight_q",
+    ]
+    assert qkv_w.sharding == ("tensor", None)
+    assert qkv_w.transpose is False
+
+    qkv_s = mappings["model.layers.0.attention.query_key_value.weight_scale"]
+    assert qkv_s.target_path == [
+        "model.layers.0.self_attn.q_proj.weight_scale",
+        "model.layers.0.self_attn.k_proj.weight_scale",
+        "model.layers.0.self_attn.v_proj.weight_scale",
+    ]
+    assert qkv_s.sharding == ("tensor", None)
+    assert qkv_s.transpose is False
 
 
 def test_weight_mapping_contains_moe_shared_expert_and_gqa_fallback_keys():


### PR DESCRIPTION
## Motivation

Pre-PR, BailingMoE V2.5's GLA `qkv_proj` outputs `[T, 3*N*D]` stripe-sharded on the `tensor` mesh axis. The subsequent `reshape -> [T, 3, N, D]` with `out_sharding=P("data", None, "tensor", None)` requires the global layout to be `[Q|K|V]` block-concat, not stripe-by-rank, so XLA must insert an `all-gather` collective to materialize the right shape before slicing q/k/v. This is per-layer collective traffic across **28 GLA decoder layers** on the critical path.

Splitting fused QKV into three independent column-parallel `q_proj`/`k_proj`/`v_proj` LinearBases (Qwen3-style) lets each per-projection shard naturally align with the per-head TP cut → the `[T, num_heads, head_dim]` reshape becomes pure metadata, no collective.

Two coordinated fixes ride along:
- **Hybrid attention support** — BailingMoE V2.5 mixes MLA (`head_dim = qk_nope + qk_rope = 192`) and GLA (`head_dim = 128`). `patch_model_config` writes MLA's value into `model_config.head_dim` so the KV cache / MemoryPools / attention backend size MLA-shaped buffers — correct for those consumers, but it leaves the loader's split-QKV slicing reading the wrong `head_dim` for GLA. Fix: `WeightLoader.__init__` reads `head_dim` / `v_head_dim` from `hf_text_config` (untouched by `patch_model_config`) rather than `model_config`. Every existing split-QKV caller has `mc.head_dim == hf_text_config.head_dim` (no patch), so behavior is preserved; the GLA case now reads 128 instead of the patched 192.
- **Static-quant adaptation** — #1087's `is_static_quant` path needed adapting for the split layout. After `apply_linear_quantization` swaps each LinearBase into a QuantizedLinear pair, the HF fused QKV must fan out to 6 targets (q/k/v × {weight_q, weight_scale}) instead of 1 fused qkv_proj.weight_q.

## Modifications

- `python/sgl_jax/srt/models/bailing_moe_linear.py`
  - Replace fused `qkv_proj` with `q_proj`/`k_proj`/`v_proj` trio in `BailingMoELinearAttention`. `__call__` does 3 matmuls + 3 reshapes (pure metadata).
  - `_add_linear_attention_mappings` registers list-typed `target_path = [q, k, v]` for the split.
  - `is_static_quant=True` branch fans out HF fused QKV to 6 targets (mirrors `bailing_moe.py:592-611` for the GQA path).
- `python/sgl_jax/srt/utils/weight_utils.py`
  - `WeightLoader.__init__` reads `head_dim` / `v_head_dim` from `hf_text_config` rather than `model_config`. Audit in commit message confirms zero-regression for every existing caller.
- `python/sgl_jax/test/test_bailing_moe_linear.py` — pin contract on the new GLA split mapping shape; new test for static-quant 6-target split.

## Accuracy Tests

### Numerical equivalence (isolated layer microbench, TPU v6e-4, TP=4)

Built `FusedQKV` and `SplitQKV` modules with bit-identical weights (one HF tensor split into 3 slices), ran same input through both, compared q/k/v outputs:

| T (tokens) | scenario | max \|fused − split\| (q, k, v) |
|---:|---|:---:|
| 8192 | prefill | **0.000e+00** |
| 2048 | prefill chunk | **0.000e+00** |
| 128 | decode bs=128 | **0.000e+00** |
| 16 | decode bs=16 | **0.000e+00** |

### Unit tests

```
PYTHONPATH=python python3 -m pytest python/sgl_jax/test/test_bailing_moe_linear.py -k "weight_mapping" -v
```

All 3 tests pass:
- `test_weight_mapping_contains_linear_mla_dense_and_shared_mlp_keys` — pins the non-quant split mapping shape on GLA.
- `test_weight_mapping_contains_moe_shared_expert_and_gqa_fallback_keys` — GQA fallback path unchanged.
- `test_weight_mapping_static_quant_gla_splits_into_weight_q_and_scale` — pins the static-quant 6-target split contract.

## Benchmarking and Profiling

### Microbench — isolated GLA QKV layer (TPU v6e-4, TP=4, hidden=4096, N=32, D=128, bf16)

30 iterations, 5 warmup, same random weights:

| T | scenario | Fused (ms) | Split (ms) | Speedup | Saved/call |
|---:|---|---:|---:|---:|---:|
| 8192 | prefill | 1.793 | 0.747 | **2.40×** | 1.046 ms |
| 2048 | prefill chunk | 0.719 | 0.480 | **1.50×** | 0.239 ms |
| 128 | decode bs=128 | 0.383 | 0.362 | 1.06× | 0.021 ms |
| 16 | decode bs=16 | 0.377 | 0.380 | 0.99× | -0.003 ms |

HLO collective op count consistent across all sizes:

| variant | all-gather | all-to-all | all-reduce | reduce-scatter | collective-permute |
|---|---:|---:|---:|---:|---:|
| Fused | **1** | 0 | 0 | 0 | 0 |
| Split | **0** | 0 | 0 | 0 | 0 |

### Op-level breakdown via xprof

**T=128 (decode bs=128), per call:**

| op | Fused (μs) | Split (μs) | Δ |
|---|---:|---:|---:|
| matmul fusion | 19.1 (1×) | 23.1 (3×7.7) | +4.0 |
| **all-gather** | **20.0** | **0** | **−20.0** |
| copy ops | 1.0 | 2.4 (3×0.80) | +1.4 |
| slice_bitcast (framework scope: `squeeze`) | 1.0 | 0 | −1.0 |
| barrier-cores | 20.6 | 23.6 | +3.0 |
| **Net** | | | **−12.6 μs (split saves)** |
<img width="661" height="245" alt="image" src="https://github.com/user-attachments/assets/266f7c89-8945-4b09-ac3f-67d0c067c4e9" />
<img width="472" height="233" alt="image" src="https://github.com/user-attachments/assets/71db0d07-753f-42cc-bf8a-61206c0c68e8" />



**T=16 (decode bs=16), per call:**

| op | Fused (μs) | Split (μs) | Δ |
|---|---:|---:|---:|
| matmul fusion | 18.3 (1×) | 22.5 (3×7.5) | +4.2 |
| **all-gather** | **8.83** | **0** | **−8.83** |
| copy ops | ~0.08 | 1.47 (3×0.49) | +1.4 |
| slice_bitcast (framework scope: `squeeze`) | 0.54 | 0 | −0.54 |
| barrier-cores | 11.0 | 9.6 | −1.4 |
| **Net** | | | **−5.2 μs (split saves)** |
<img width="751" height="231" alt="image" src="https://github.com/user-attachments/assets/dc368490-f93d-40d8-b52b-4ac66fb57ea4" />
<img width="443" height="226" alt="image" src="https://github.com/user-attachments/assets/f68c3156-e877-4684-89b2-979748245375" />


> Note on `barrier-cores`: in microbench it absorbs host-dispatch idle gaps and is much larger than what production sees. In a real model forward where many ops are dispatched in one jit call, barrier-cores is typically 1-5 μs per op-boundary.

**Screenshots:** _(TODO: upload xprof timeline screenshots showing fused `all-gather.5` op vs split's collective-free path)_

### Full-model bench — Ling-2.6-flash on TPU v6e × 16 chips

> ⚠️ **Treat the absolute Δ values below as informational, not as a precise speedup claim.** End-to-end serving benchmarks (`bench_serving` against a live server with sampling, scheduler, MoE dispatch, padding-bucket churn, etc.) carry **non-trivial run-to-run variance**, especially on `decode bs=128` where compute is already saturated and most of the spread comes from queueing and bucket-transition jitter rather than per-step compute. A single point-comparison can easily move several percent in either direction across reruns. The **structural** signal — fewer collectives on the critical path — is best read from the xprof traces below, not from any single number in this table.

`bench_serving --backend sgl-jax --dataset-name random --random-range-ratio 1.0`
Config: TP=16, DP=4, EP=16, epmoe, bf16, chunked-prefill=2048, ctx=32k, max_running_requests=256
main `b2daa46d` vs this branch (`3aa99120`), single run each:

| Scene | req/s Δ | TTFT med Δ | TPOT med Δ | TPOT p99 Δ |
|---|---:|---:|---:|---:|
| prefill_in8k_out1_bs64  | +8.1% | −7.6% | n/a | n/a |
| decode_in1k_out8k_bs16  | +3.8% | −7.1% | −3.8% | −4.1% |
| decode_in1k_out8k_bs32  | +1.9% | +1.1% | −2.4% | −1.1% |
| decode_in1k_out8k_bs64  | +2.2% | −7.2% | −2.2% | −2.0% |
| decode_in1k_out8k_bs128 | −0.1% | −7.8% | +5.2% | −4.7% |

> negative = PR faster/better; positive = PR slower/worse

These traces are the load-bearing evidence; they show the structural change directly without depending on serving-bench variance.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve. — stated in the Motivation section above.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update. — N/A (internal refactor, no public API surface change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



