### PR TITLE
[CI P0-2] Fix release-pypi.yml path filter

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths:
-      - "python/sglang/version.py"
+      - "python/sgl_jax/version.py"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Fix broken path filter in `release-pypi.yml`: `python/sglang/version.py` → `python/sgl_jax/version.py`
- Auto-trigger on version bump has never worked due to this typo — releases required manual `workflow_dispatch`

## Test plan
- [ ] After merge, push a commit modifying `python/sgl_jax/version.py` to main → verify `release-pypi.yml` triggers automatically
- [ ] Verify `workflow_dispatch` manual trigger still works as fallback

Closes #1120