### PR TITLE
[CI P0-4] Narrow nightly-test-summize.yml permissions

### DIFF
--- a/.github/workflows/nightly-test-summize.yml
+++ b/.github/workflows/nightly-test-summize.yml
@@ -16,8 +16,6 @@ concurrency:
 
 permissions:
   contents: write
-  pull-requests: write
-  issues: write
 
 jobs:
   generate-summary:


### PR DESCRIPTION
## Summary
- Remove unused `pull-requests: write` and `issues: write` permissions from `nightly-test-summize.yml`
- Only `contents: write` is actually needed (for pushing summary data to external repo)
- Reduces attack surface per GitHub Actions least-privilege principle

> Note: `issues: write` should be re-added when ci-failure-monitor (#1134) or trend alerting (P2-2) lands.

## Test plan
- [ ] Verify nightly summize workflow still runs successfully (summary data push works with `contents: write` only)

Closes #1122