### PR TITLE
[CI P0-3] Split shared concurrency group across 3 nightly workflows

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -10,7 +10,7 @@ on:
       - "python/sgl_jax/version.py"
   workflow_dispatch:
 concurrency:
-  group: nightly-test-${{ github.ref }}
+  group: nightly-test-daily-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/nightly-test-summize.yml
+++ b/.github/workflows/nightly-test-summize.yml
@@ -10,7 +10,7 @@ on:
       - "python/sgl_jax/version.py"
   workflow_dispatch:
 concurrency:
-  group: nightly-test-${{ github.ref }}
+  group: nightly-test-summize-${{ github.ref }}
   cancel-in-progress: true
 
 


### PR DESCRIPTION
## Summary
- Split the shared concurrency group `nightly-test-${{ github.ref }}` so the 3 nightly workflows stop cancelling each other
- `nightly-test-daily.yml` → `nightly-test-daily-${{ github.ref }}`
- `nightly-test-summize.yml` → `nightly-test-summize-${{ github.ref }}`
- `nightly-test.yml` unchanged (keeps the original key)

This is the root cause of **14 consecutive cancelled nightly runs** (0% success rate since 2026-01-30). The summize workflow at 22:30 UTC was cancelling the nightly-test started at 16:00 UTC.

## Test plan
- [ ] Trigger all 3 nightly workflows concurrently via `workflow_dispatch` → verify none gets cancelled
- [ ] Trigger the same workflow twice → verify the second run cancels the first (same-workflow concurrency preserved)

Closes #1121