### PR TITLE
[CI P0-10] Reduce nightly/daily timeouts to max(P95×3, 60min)

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
-        timeout-minutes: 3000
+        timeout-minutes: 60
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -63,7 +63,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run performance test for text models
-        timeout-minutes: 1800
+        timeout-minutes: 60
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -107,7 +107,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run performance test for text models
-        timeout-minutes: 18000
+        timeout-minutes: 60
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
-        timeout-minutes: 3000
+        timeout-minutes: 1000
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -136,7 +136,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run performance test for text models
-        timeout-minutes: 18000
+        timeout-minutes: 840
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -181,7 +181,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run performance test for text models
-        timeout-minutes: 18000
+        timeout-minutes: 430
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -247,7 +247,7 @@ jobs:
           uses: actions/checkout@v4
 
         - name: Run performance test for text models
-          timeout-minutes: 18000
+          timeout-minutes: 390
           env:
 
             TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -291,7 +291,7 @@ jobs:
             uses: actions/checkout@v4
 
           - name: Run performance test for text models
-            timeout-minutes: 18000
+            timeout-minutes: 400
             env:
 
               TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -338,7 +338,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run performance test for text models
-        timeout-minutes: 18000
+        timeout-minutes: 120
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -382,7 +382,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run performance test trace for text models
-        timeout-minutes: 18000
+        timeout-minutes: 365
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -426,7 +426,7 @@ jobs:
           uses: actions/checkout@v4
 
         - name: Run performance test trace for text models
-          timeout-minutes: 18000
+          timeout-minutes: 230
           env:
 
             TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}


### PR DESCRIPTION
## Summary
- Reduce nightly/daily job timeouts from extreme values (up to 18000 min / 12.5 days) to reasonable ceilings using formula `max(P95×3, 60min)`
- A hung job previously could occupy a TPU runner for up to **12.5 days** before timeout kill
- 11 jobs adjusted across `nightly-test.yml` (8) and `nightly-test-daily.yml` (3)
- `accuracy-4-tpu` (1200 min, 4.2× P95) left unchanged as already reasonable

### Timeout Changes

| Job | Before | After | P95 |
|---|---|---|---|
| accuracy-1-tpu | 3000 | 1000 | 333 min |
| perf-text-1-tpu | 18000 | 840 | 280 min |
| perf-text-4-tpu-part1 | 18000 | 430 | 143 min |
| perf-text-4-tpu-part2 | 18000 | 390 | 128 min |
| perf-text-4-tpu-part3 | 18000 | 400 | 133 min |
| perf-trace-1-tpu | 18000 | 120 | 40 min |
| perf-trace-4-tpu-part1 | 18000 | 365 | 121 min |
| perf-trace-4-tpu-part2 | 18000 | 230 | 76 min |
| accuracy-1-tpu-daily | 3000 | 60 | 17 min |
| perf-text-1-tpu-daily | 1800 | 60 | 5 min |
| perf-trace-1-tpu-daily | 18000 | 60 | 5 min |

## Test plan
- [ ] Trigger nightly/daily workflows → verify all jobs complete within new timeouts
- [ ] Monitor over 2-3 cycles for any false timeout kills

Closes #1128