### PR TITLE
[CI P0-7] Add success aggregator + remove continue-on-error for nightly/daily

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -18,7 +18,6 @@ jobs:
   nightly-test-accuracy-text-models-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-1
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -56,7 +55,6 @@ jobs:
   nightly-test-perf-text-models-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-1
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -100,7 +98,6 @@ jobs:
   nightly-test-perf-trace-text-models-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-1
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -138,3 +135,40 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           python3 scripts/ci/publish_traces.py --traces-dir ./test/nightly_test_output
+
+  nightly-test-daily-finish:
+    needs: [
+      nightly-test-accuracy-text-models-1-tpu-daily,
+      nightly-test-perf-text-models-1-tpu-daily,
+      nightly-test-perf-trace-text-models-1-tpu-daily,
+    ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all daily job statuses
+        run: |
+          echo "=== Daily Test Results ==="
+          echo "accuracy-1-tpu-daily: ${{ needs.nightly-test-accuracy-text-models-1-tpu-daily.result }}"
+          echo "perf-text-1-tpu-daily: ${{ needs.nightly-test-perf-text-models-1-tpu-daily.result }}"
+          echo "perf-trace-1-tpu-daily: ${{ needs.nightly-test-perf-trace-text-models-1-tpu-daily.result }}"
+          echo ""
+
+          has_failure=false
+          for job_result in \
+            "accuracy-1-tpu-daily=${{ needs.nightly-test-accuracy-text-models-1-tpu-daily.result }}" \
+            "perf-text-1-tpu-daily=${{ needs.nightly-test-perf-text-models-1-tpu-daily.result }}" \
+            "perf-trace-1-tpu-daily=${{ needs.nightly-test-perf-trace-text-models-1-tpu-daily.result }}"; do
+            job_name="${job_result%%=*}"
+            result="${job_result#*=}"
+            if [ "$result" != "success" ]; then
+              echo "::error::${job_name} did not succeed: ${result}"
+              has_failure=true
+            fi
+          done
+
+          if [ "$has_failure" = "true" ]; then
+            echo "::error::One or more daily test jobs failed"
+            exit 1
+          fi
+
+          echo "All daily test jobs passed"

--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -142,7 +142,7 @@ jobs:
       nightly-test-perf-text-models-1-tpu-daily,
       nightly-test-perf-trace-text-models-1-tpu-daily,
     ]
-    if: always()
+    if: always() && github.repository == 'sgl-project/sglang-jax'
     runs-on: ubuntu-latest
     steps:
       - name: Check all daily job statuses

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1 , 2, 3]
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -86,7 +85,6 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1 , 2, 3 , 4, 5]
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -129,7 +127,6 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1 , 2, 3, 4, 5, 6, 7]
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -173,7 +170,6 @@ jobs:
   nightly-test-perf-text-models-4-tpu-part1:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-4
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -239,7 +235,6 @@ jobs:
   nightly-test-perf-text-models-4-tpu-part2:
       if: github.repository == 'sgl-project/sglang-jax'
       runs-on: arc-runner-v6e-4
-      continue-on-error: true
       env:
         TZ: Asia/Shanghai
       steps:
@@ -283,7 +278,6 @@ jobs:
   nightly-test-perf-text-models-4-tpu-part3:
         if: github.repository == 'sgl-project/sglang-jax'
         runs-on: arc-runner-v6e-4
-        continue-on-error: true
         env:
           TZ: Asia/Shanghai
         steps:
@@ -331,7 +325,6 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1 , 2, 3, 4, 5, 6, 7]
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -374,7 +367,6 @@ jobs:
   nightly-test-perf-trace-text-models-4-tpu-part1:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-4
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -418,7 +410,6 @@ jobs:
   nightly-test-perf-trace-text-models-4-tpu-part2:
       if: github.repository == 'sgl-project/sglang-jax'
       runs-on: arc-runner-v6e-4
-      continue-on-error: true
       env:
         TZ: Asia/Shanghai
       steps:
@@ -479,3 +470,58 @@ jobs:
             echo "$SHA,$AUTHOR,$MSG,$RUN_URL" >> $FILE
             echo "CSV line added: $SHA, $AUTHOR, $MSG"
             python3 scripts/ci/publish_bench_and_perf.py --source-dir ./meta
+
+  nightly-test-finish:
+    needs: [
+      nightly-test-accuracy-text-models-1-tpu,
+      nightly-test-accuracy-text-models-4-tpu,
+      nightly-test-perf-text-models-1-tpu,
+      nightly-test-perf-text-models-4-tpu-part1,
+      nightly-test-perf-text-models-4-tpu-part2,
+      nightly-test-perf-text-models-4-tpu-part3,
+      nightly-test-perf-trace-text-models-1-tpu,
+      nightly-test-perf-trace-text-models-4-tpu-part1,
+      nightly-test-perf-trace-text-models-4-tpu-part2,
+    ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all nightly job statuses
+        run: |
+          echo "=== Nightly Test Results ==="
+          echo "accuracy-1-tpu: ${{ needs.nightly-test-accuracy-text-models-1-tpu.result }}"
+          echo "accuracy-4-tpu: ${{ needs.nightly-test-accuracy-text-models-4-tpu.result }}"
+          echo "perf-text-1-tpu: ${{ needs.nightly-test-perf-text-models-1-tpu.result }}"
+          echo "perf-text-4-tpu-part1: ${{ needs.nightly-test-perf-text-models-4-tpu-part1.result }}"
+          echo "perf-text-4-tpu-part2: ${{ needs.nightly-test-perf-text-models-4-tpu-part2.result }}"
+          echo "perf-text-4-tpu-part3: ${{ needs.nightly-test-perf-text-models-4-tpu-part3.result }}"
+          echo "perf-trace-1-tpu: ${{ needs.nightly-test-perf-trace-text-models-1-tpu.result }}"
+          echo "perf-trace-4-tpu-part1: ${{ needs.nightly-test-perf-trace-text-models-4-tpu-part1.result }}"
+          echo "perf-trace-4-tpu-part2: ${{ needs.nightly-test-perf-trace-text-models-4-tpu-part2.result }}"
+          echo ""
+
+          has_failure=false
+          for job_result in \
+            "accuracy-1-tpu=${{ needs.nightly-test-accuracy-text-models-1-tpu.result }}" \
+            "accuracy-4-tpu=${{ needs.nightly-test-accuracy-text-models-4-tpu.result }}" \
+            "perf-text-1-tpu=${{ needs.nightly-test-perf-text-models-1-tpu.result }}" \
+            "perf-text-4-tpu-part1=${{ needs.nightly-test-perf-text-models-4-tpu-part1.result }}" \
+            "perf-text-4-tpu-part2=${{ needs.nightly-test-perf-text-models-4-tpu-part2.result }}" \
+            "perf-text-4-tpu-part3=${{ needs.nightly-test-perf-text-models-4-tpu-part3.result }}" \
+            "perf-trace-1-tpu=${{ needs.nightly-test-perf-trace-text-models-1-tpu.result }}" \
+            "perf-trace-4-tpu-part1=${{ needs.nightly-test-perf-trace-text-models-4-tpu-part1.result }}" \
+            "perf-trace-4-tpu-part2=${{ needs.nightly-test-perf-trace-text-models-4-tpu-part2.result }}"; do
+            job_name="${job_result%%=*}"
+            result="${job_result#*=}"
+            if [ "$result" != "success" ]; then
+              echo "::error::${job_name} did not succeed: ${result}"
+              has_failure=true
+            fi
+          done
+
+          if [ "$has_failure" = "true" ]; then
+            echo "::error::One or more nightly test jobs failed"
+            exit 1
+          fi
+
+          echo "All nightly test jobs passed"

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -483,7 +483,7 @@ jobs:
       nightly-test-perf-trace-text-models-4-tpu-part1,
       nightly-test-perf-trace-text-models-4-tpu-part2,
     ]
-    if: always()
+    if: always() && github.repository == 'sgl-project/sglang-jax'
     runs-on: ubuntu-latest
     steps:
       - name: Check all nightly job statuses


### PR DESCRIPTION
## Summary

Two coupled changes that **must land together**:

1. **Add aggregator jobs** — `nightly-test-finish` (nightly-test.yml) and `nightly-test-daily-finish` (nightly-test-daily.yml) that aggregate all test job conclusions into a single pass/fail signal
2. **Remove all `continue-on-error: true`** — 9 in nightly-test.yml + 3 in nightly-test-daily.yml = 12 total

### Why both are needed
- Only removing `continue-on-error` → workflow shows red but no single aggregation point
- Only adding aggregator → aggregator sees "success" for actually-failed jobs (continue-on-error masks the real conclusion)

### Impact
- `gh run list` will now reflect **actual** job outcomes (currently always shows "success")
- Enables downstream automation: ci-failure-monitor (#1134), Release Gate (#1135), Nightly Health Gate
- **Team should expect nightly/daily workflows to start reporting failures** — these are real failures that were previously hidden

## Test plan
- [ ] Trigger nightly workflow via `workflow_dispatch` → verify `nightly-test-finish` runs and reports correct aggregated status
- [ ] Trigger daily workflow → verify `nightly-test-daily-finish` reports correct status
- [ ] If a job fails, verify workflow conclusion = failure (not success)
- [ ] Verify `gh run view <run_id> --json conclusion` matches actual outcomes

Closes #1125