### PR TITLE
[CI P0-3/P0-10/P0-7] Fix nightly workflow: split concurrency, reduce timeouts, add aggregators

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -10,7 +10,7 @@ on:
       - "python/sgl_jax/version.py"
   workflow_dispatch:
 concurrency:
-  group: nightly-test-${{ github.ref }}
+  group: nightly-test-daily-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -18,7 +18,6 @@ jobs:
   nightly-test-accuracy-text-models-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-1
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -28,7 +27,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
-        timeout-minutes: 3000
+        timeout-minutes: 60
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -56,14 +55,13 @@ jobs:
   nightly-test-perf-text-models-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-1
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run performance test for text models
-        timeout-minutes: 1800
+        timeout-minutes: 60
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -100,14 +98,13 @@ jobs:
   nightly-test-perf-trace-text-models-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-1
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run performance test for text models
-        timeout-minutes: 18000
+        timeout-minutes: 60
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -138,3 +135,40 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           python3 scripts/ci/publish_traces.py --traces-dir ./test/nightly_test_output
+
+  nightly-test-daily-finish:
+    needs: [
+      nightly-test-accuracy-text-models-1-tpu-daily,
+      nightly-test-perf-text-models-1-tpu-daily,
+      nightly-test-perf-trace-text-models-1-tpu-daily,
+    ]
+    if: always() && github.repository == 'sgl-project/sglang-jax'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all daily job statuses
+        run: |
+          echo "=== Daily Test Results ==="
+          echo "accuracy-1-tpu-daily: ${{ needs.nightly-test-accuracy-text-models-1-tpu-daily.result }}"
+          echo "perf-text-1-tpu-daily: ${{ needs.nightly-test-perf-text-models-1-tpu-daily.result }}"
+          echo "perf-trace-1-tpu-daily: ${{ needs.nightly-test-perf-trace-text-models-1-tpu-daily.result }}"
+          echo ""
+
+          has_failure=false
+          for job_result in \
+            "accuracy-1-tpu-daily=${{ needs.nightly-test-accuracy-text-models-1-tpu-daily.result }}" \
+            "perf-text-1-tpu-daily=${{ needs.nightly-test-perf-text-models-1-tpu-daily.result }}" \
+            "perf-trace-1-tpu-daily=${{ needs.nightly-test-perf-trace-text-models-1-tpu-daily.result }}"; do
+            job_name="${job_result%%=*}"
+            result="${job_result#*=}"
+            if [ "$result" != "success" ]; then
+              echo "::error::${job_name} did not succeed: ${result}"
+              has_failure=true
+            fi
+          done
+
+          if [ "$has_failure" = "true" ]; then
+            echo "::error::One or more daily test jobs failed"
+            exit 1
+          fi
+
+          echo "All daily test jobs passed"

--- a/.github/workflows/nightly-test-summize.yml
+++ b/.github/workflows/nightly-test-summize.yml
@@ -10,7 +10,7 @@ on:
       - "python/sgl_jax/version.py"
   workflow_dispatch:
 concurrency:
-  group: nightly-test-${{ github.ref }}
+  group: nightly-test-summize-${{ github.ref }}
   cancel-in-progress: true
 
 

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1 , 2, 3]
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -32,7 +31,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
-        timeout-minutes: 3000
+        timeout-minutes: 1000
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -86,7 +85,6 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1 , 2, 3 , 4, 5]
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -129,14 +127,13 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1 , 2, 3, 4, 5, 6, 7]
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run performance test for text models
-        timeout-minutes: 18000
+        timeout-minutes: 840
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -173,7 +170,6 @@ jobs:
   nightly-test-perf-text-models-4-tpu-part1:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-4
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -181,7 +177,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run performance test for text models
-        timeout-minutes: 18000
+        timeout-minutes: 430
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -239,7 +235,6 @@ jobs:
   nightly-test-perf-text-models-4-tpu-part2:
       if: github.repository == 'sgl-project/sglang-jax'
       runs-on: arc-runner-v6e-4
-      continue-on-error: true
       env:
         TZ: Asia/Shanghai
       steps:
@@ -247,7 +242,7 @@ jobs:
           uses: actions/checkout@v4
 
         - name: Run performance test for text models
-          timeout-minutes: 18000
+          timeout-minutes: 390
           env:
 
             TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -283,7 +278,6 @@ jobs:
   nightly-test-perf-text-models-4-tpu-part3:
         if: github.repository == 'sgl-project/sglang-jax'
         runs-on: arc-runner-v6e-4
-        continue-on-error: true
         env:
           TZ: Asia/Shanghai
         steps:
@@ -291,7 +285,7 @@ jobs:
             uses: actions/checkout@v4
 
           - name: Run performance test for text models
-            timeout-minutes: 18000
+            timeout-minutes: 400
             env:
 
               TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -331,14 +325,13 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1 , 2, 3, 4, 5, 6, 7]
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run performance test for text models
-        timeout-minutes: 18000
+        timeout-minutes: 120
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -374,7 +367,6 @@ jobs:
   nightly-test-perf-trace-text-models-4-tpu-part1:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-4
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -382,7 +374,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run performance test trace for text models
-        timeout-minutes: 18000
+        timeout-minutes: 365
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -418,7 +410,6 @@ jobs:
   nightly-test-perf-trace-text-models-4-tpu-part2:
       if: github.repository == 'sgl-project/sglang-jax'
       runs-on: arc-runner-v6e-4
-      continue-on-error: true
       env:
         TZ: Asia/Shanghai
       steps:
@@ -426,7 +417,7 @@ jobs:
           uses: actions/checkout@v4
 
         - name: Run performance test trace for text models
-          timeout-minutes: 18000
+          timeout-minutes: 230
           env:
 
             TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -479,3 +470,58 @@ jobs:
             echo "$SHA,$AUTHOR,$MSG,$RUN_URL" >> $FILE
             echo "CSV line added: $SHA, $AUTHOR, $MSG"
             python3 scripts/ci/publish_bench_and_perf.py --source-dir ./meta
+
+  nightly-test-finish:
+    needs: [
+      nightly-test-accuracy-text-models-1-tpu,
+      nightly-test-accuracy-text-models-4-tpu,
+      nightly-test-perf-text-models-1-tpu,
+      nightly-test-perf-text-models-4-tpu-part1,
+      nightly-test-perf-text-models-4-tpu-part2,
+      nightly-test-perf-text-models-4-tpu-part3,
+      nightly-test-perf-trace-text-models-1-tpu,
+      nightly-test-perf-trace-text-models-4-tpu-part1,
+      nightly-test-perf-trace-text-models-4-tpu-part2,
+    ]
+    if: always() && github.repository == 'sgl-project/sglang-jax'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all nightly job statuses
+        run: |
+          echo "=== Nightly Test Results ==="
+          echo "accuracy-1-tpu: ${{ needs.nightly-test-accuracy-text-models-1-tpu.result }}"
+          echo "accuracy-4-tpu: ${{ needs.nightly-test-accuracy-text-models-4-tpu.result }}"
+          echo "perf-text-1-tpu: ${{ needs.nightly-test-perf-text-models-1-tpu.result }}"
+          echo "perf-text-4-tpu-part1: ${{ needs.nightly-test-perf-text-models-4-tpu-part1.result }}"
+          echo "perf-text-4-tpu-part2: ${{ needs.nightly-test-perf-text-models-4-tpu-part2.result }}"
+          echo "perf-text-4-tpu-part3: ${{ needs.nightly-test-perf-text-models-4-tpu-part3.result }}"
+          echo "perf-trace-1-tpu: ${{ needs.nightly-test-perf-trace-text-models-1-tpu.result }}"
+          echo "perf-trace-4-tpu-part1: ${{ needs.nightly-test-perf-trace-text-models-4-tpu-part1.result }}"
+          echo "perf-trace-4-tpu-part2: ${{ needs.nightly-test-perf-trace-text-models-4-tpu-part2.result }}"
+          echo ""
+
+          has_failure=false
+          for job_result in \
+            "accuracy-1-tpu=${{ needs.nightly-test-accuracy-text-models-1-tpu.result }}" \
+            "accuracy-4-tpu=${{ needs.nightly-test-accuracy-text-models-4-tpu.result }}" \
+            "perf-text-1-tpu=${{ needs.nightly-test-perf-text-models-1-tpu.result }}" \
+            "perf-text-4-tpu-part1=${{ needs.nightly-test-perf-text-models-4-tpu-part1.result }}" \
+            "perf-text-4-tpu-part2=${{ needs.nightly-test-perf-text-models-4-tpu-part2.result }}" \
+            "perf-text-4-tpu-part3=${{ needs.nightly-test-perf-text-models-4-tpu-part3.result }}" \
+            "perf-trace-1-tpu=${{ needs.nightly-test-perf-trace-text-models-1-tpu.result }}" \
+            "perf-trace-4-tpu-part1=${{ needs.nightly-test-perf-trace-text-models-4-tpu-part1.result }}" \
+            "perf-trace-4-tpu-part2=${{ needs.nightly-test-perf-trace-text-models-4-tpu-part2.result }}"; do
+            job_name="${job_result%%=*}"
+            result="${job_result#*=}"
+            if [ "$result" != "success" ]; then
+              echo "::error::${job_name} did not succeed: ${result}"
+              has_failure=true
+            fi
+          done
+
+          if [ "$has_failure" = "true" ]; then
+            echo "::error::One or more nightly test jobs failed"
+            exit 1
+          fi
+
+          echo "All nightly test jobs passed"


### PR DESCRIPTION
## Summary
- **P0-3** (#1122): Split shared `nightly-test-${{ github.ref }}` concurrency group into 3 independent groups (`nightly-test-*`, `nightly-test-daily-*`, `nightly-test-summize-*`) to prevent mutual cancellation
- **P0-10** (#1125): Reduce nightly/daily timeouts from 3000–18000 min to max(P95×3, 60min) per test-matrix §6.3
- **P0-7** (#1124): Remove all 12× `continue-on-error: true` from nightly + daily jobs and add `nightly-test-finish` / `nightly-test-daily-finish` aggregator jobs to surface real failures

## Files changed
- `.github/workflows/nightly-test.yml` — remove 9× `continue-on-error`, reduce 8 timeouts, add aggregator
- `.github/workflows/nightly-test-daily.yml` — split concurrency group, remove 3× `continue-on-error`, reduce 3 timeouts, add aggregator
- `.github/workflows/nightly-test-summize.yml` — split concurrency group

## Test plan
- [ ] Nightly workflow can be triggered via `workflow_dispatch` without mutual cancellation
- [ ] Failed test job causes aggregator to report failure (workflow conclusion = red)
- [ ] Timeout values aligned with P95 runtime data from test-matrix

Closes #1122, closes #1125, closes #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)