### PR TITLE
[CI] P0 CI gate improvements (P0-1/2/3/4/7/10)

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -10,7 +10,7 @@ on:
       - "python/sgl_jax/version.py"
   workflow_dispatch:
 concurrency:
-  group: nightly-test-${{ github.ref }}
+  group: nightly-test-daily-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -18,7 +18,6 @@ jobs:
   nightly-test-accuracy-text-models-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-1
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -28,7 +27,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
-        timeout-minutes: 3000
+        timeout-minutes: 60
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -56,14 +55,13 @@ jobs:
   nightly-test-perf-text-models-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-1
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run performance test for text models
-        timeout-minutes: 1800
+        timeout-minutes: 60
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -100,14 +98,13 @@ jobs:
   nightly-test-perf-trace-text-models-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-1
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run performance test for text models
-        timeout-minutes: 18000
+        timeout-minutes: 60
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -138,3 +135,40 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           python3 scripts/ci/publish_traces.py --traces-dir ./test/nightly_test_output
+
+  nightly-test-daily-finish:
+    needs: [
+      nightly-test-accuracy-text-models-1-tpu-daily,
+      nightly-test-perf-text-models-1-tpu-daily,
+      nightly-test-perf-trace-text-models-1-tpu-daily,
+    ]
+    if: always() && github.repository == 'sgl-project/sglang-jax'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all daily job statuses
+        run: |
+          echo "=== Daily Test Results ==="
+          echo "accuracy-1-tpu-daily: ${{ needs.nightly-test-accuracy-text-models-1-tpu-daily.result }}"
+          echo "perf-text-1-tpu-daily: ${{ needs.nightly-test-perf-text-models-1-tpu-daily.result }}"
+          echo "perf-trace-1-tpu-daily: ${{ needs.nightly-test-perf-trace-text-models-1-tpu-daily.result }}"
+          echo ""
+
+          has_failure=false
+          for job_result in \
+            "accuracy-1-tpu-daily=${{ needs.nightly-test-accuracy-text-models-1-tpu-daily.result }}" \
+            "perf-text-1-tpu-daily=${{ needs.nightly-test-perf-text-models-1-tpu-daily.result }}" \
+            "perf-trace-1-tpu-daily=${{ needs.nightly-test-perf-trace-text-models-1-tpu-daily.result }}"; do
+            job_name="${job_result%%=*}"
+            result="${job_result#*=}"
+            if [ "$result" != "success" ]; then
+              echo "::error::${job_name} did not succeed: ${result}"
+              has_failure=true
+            fi
+          done
+
+          if [ "$has_failure" = "true" ]; then
+            echo "::error::One or more daily test jobs failed"
+            exit 1
+          fi
+
+          echo "All daily test jobs passed"

--- a/.github/workflows/nightly-test-summize.yml
+++ b/.github/workflows/nightly-test-summize.yml
@@ -10,14 +10,12 @@ on:
       - "python/sgl_jax/version.py"
   workflow_dispatch:
 concurrency:
-  group: nightly-test-${{ github.ref }}
+  group: nightly-test-summize-${{ github.ref }}
   cancel-in-progress: true
 
 
 permissions:
   contents: write
-  pull-requests: write
-  issues: write
 
 jobs:
   generate-summary:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1 , 2, 3]
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -32,7 +31,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
-        timeout-minutes: 3000
+        timeout-minutes: 1000
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -86,7 +85,6 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1 , 2, 3 , 4, 5]
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -129,14 +127,13 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1 , 2, 3, 4, 5, 6, 7]
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run performance test for text models
-        timeout-minutes: 18000
+        timeout-minutes: 840
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -173,7 +170,6 @@ jobs:
   nightly-test-perf-text-models-4-tpu-part1:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-4
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -181,7 +177,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run performance test for text models
-        timeout-minutes: 18000
+        timeout-minutes: 430
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -239,7 +235,6 @@ jobs:
   nightly-test-perf-text-models-4-tpu-part2:
       if: github.repository == 'sgl-project/sglang-jax'
       runs-on: arc-runner-v6e-4
-      continue-on-error: true
       env:
         TZ: Asia/Shanghai
       steps:
@@ -247,7 +242,7 @@ jobs:
           uses: actions/checkout@v4
 
         - name: Run performance test for text models
-          timeout-minutes: 18000
+          timeout-minutes: 390
           env:
 
             TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -283,7 +278,6 @@ jobs:
   nightly-test-perf-text-models-4-tpu-part3:
         if: github.repository == 'sgl-project/sglang-jax'
         runs-on: arc-runner-v6e-4
-        continue-on-error: true
         env:
           TZ: Asia/Shanghai
         steps:
@@ -291,7 +285,7 @@ jobs:
             uses: actions/checkout@v4
 
           - name: Run performance test for text models
-            timeout-minutes: 18000
+            timeout-minutes: 400
             env:
 
               TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -331,14 +325,13 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1 , 2, 3, 4, 5, 6, 7]
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Run performance test for text models
-        timeout-minutes: 18000
+        timeout-minutes: 120
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -374,7 +367,6 @@ jobs:
   nightly-test-perf-trace-text-models-4-tpu-part1:
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: arc-runner-v6e-4
-    continue-on-error: true
     env:
       TZ: Asia/Shanghai
     steps:
@@ -382,7 +374,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run performance test trace for text models
-        timeout-minutes: 18000
+        timeout-minutes: 365
         env:
 
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -418,7 +410,6 @@ jobs:
   nightly-test-perf-trace-text-models-4-tpu-part2:
       if: github.repository == 'sgl-project/sglang-jax'
       runs-on: arc-runner-v6e-4
-      continue-on-error: true
       env:
         TZ: Asia/Shanghai
       steps:
@@ -426,7 +417,7 @@ jobs:
           uses: actions/checkout@v4
 
         - name: Run performance test trace for text models
-          timeout-minutes: 18000
+          timeout-minutes: 230
           env:
 
             TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -479,3 +470,58 @@ jobs:
             echo "$SHA,$AUTHOR,$MSG,$RUN_URL" >> $FILE
             echo "CSV line added: $SHA, $AUTHOR, $MSG"
             python3 scripts/ci/publish_bench_and_perf.py --source-dir ./meta
+
+  nightly-test-finish:
+    needs: [
+      nightly-test-accuracy-text-models-1-tpu,
+      nightly-test-accuracy-text-models-4-tpu,
+      nightly-test-perf-text-models-1-tpu,
+      nightly-test-perf-text-models-4-tpu-part1,
+      nightly-test-perf-text-models-4-tpu-part2,
+      nightly-test-perf-text-models-4-tpu-part3,
+      nightly-test-perf-trace-text-models-1-tpu,
+      nightly-test-perf-trace-text-models-4-tpu-part1,
+      nightly-test-perf-trace-text-models-4-tpu-part2,
+    ]
+    if: always() && github.repository == 'sgl-project/sglang-jax'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all nightly job statuses
+        run: |
+          echo "=== Nightly Test Results ==="
+          echo "accuracy-1-tpu: ${{ needs.nightly-test-accuracy-text-models-1-tpu.result }}"
+          echo "accuracy-4-tpu: ${{ needs.nightly-test-accuracy-text-models-4-tpu.result }}"
+          echo "perf-text-1-tpu: ${{ needs.nightly-test-perf-text-models-1-tpu.result }}"
+          echo "perf-text-4-tpu-part1: ${{ needs.nightly-test-perf-text-models-4-tpu-part1.result }}"
+          echo "perf-text-4-tpu-part2: ${{ needs.nightly-test-perf-text-models-4-tpu-part2.result }}"
+          echo "perf-text-4-tpu-part3: ${{ needs.nightly-test-perf-text-models-4-tpu-part3.result }}"
+          echo "perf-trace-1-tpu: ${{ needs.nightly-test-perf-trace-text-models-1-tpu.result }}"
+          echo "perf-trace-4-tpu-part1: ${{ needs.nightly-test-perf-trace-text-models-4-tpu-part1.result }}"
+          echo "perf-trace-4-tpu-part2: ${{ needs.nightly-test-perf-trace-text-models-4-tpu-part2.result }}"
+          echo ""
+
+          has_failure=false
+          for job_result in \
+            "accuracy-1-tpu=${{ needs.nightly-test-accuracy-text-models-1-tpu.result }}" \
+            "accuracy-4-tpu=${{ needs.nightly-test-accuracy-text-models-4-tpu.result }}" \
+            "perf-text-1-tpu=${{ needs.nightly-test-perf-text-models-1-tpu.result }}" \
+            "perf-text-4-tpu-part1=${{ needs.nightly-test-perf-text-models-4-tpu-part1.result }}" \
+            "perf-text-4-tpu-part2=${{ needs.nightly-test-perf-text-models-4-tpu-part2.result }}" \
+            "perf-text-4-tpu-part3=${{ needs.nightly-test-perf-text-models-4-tpu-part3.result }}" \
+            "perf-trace-1-tpu=${{ needs.nightly-test-perf-trace-text-models-1-tpu.result }}" \
+            "perf-trace-4-tpu-part1=${{ needs.nightly-test-perf-trace-text-models-4-tpu-part1.result }}" \
+            "perf-trace-4-tpu-part2=${{ needs.nightly-test-perf-trace-text-models-4-tpu-part2.result }}"; do
+            job_name="${job_result%%=*}"
+            result="${job_result#*=}"
+            if [ "$result" != "success" ]; then
+              echo "::error::${job_name} did not succeed: ${result}"
+              has_failure=true
+            fi
+          done
+
+          if [ "$has_failure" = "true" ]; then
+            echo "::error::One or more nightly test jobs failed"
+            exit 1
+          fi
+
+          echo "All nightly test jobs passed"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -6,18 +6,22 @@ on:
       - main
       - "epic/*"
     paths:
-      - "python/**"
+      - "python/sgl_jax/**"
+      - "python/*.toml"
       - "scripts/**"
       - "test/**"
+      - "benchmark/kernels/**"
       - ".github/workflows/pr-test.yml"
   pull_request:
     branches:
       - main
       - "epic/*"
     paths:
-      - "python/**"
+      - "python/sgl_jax/**"
+      - "python/*.toml"
       - "scripts/**"
       - "test/**"
+      - "benchmark/kernels/**"
       - ".github/workflows/pr-test.yml"
 
 concurrency:
@@ -311,6 +315,7 @@ jobs:
 
   pr-test-finish:
     needs: [
+      check-changes,
       performance-test-1-tpu,
       performance-test-4-tpu,
       accurancy-test-1-tpu,
@@ -321,16 +326,71 @@ jobs:
       e2e-test-4-tpu,
       pallas-kernel-benchmark,
     ]
-    runs-on: arc-runner-v6e-1
+    if: always()
+    runs-on: ubuntu-latest
     steps:
       - name: Check all dependent job statuses
         run: |
-          results=(${{ join(needs.*.result, ' ') }})
-          for result in "${results[@]}"; do
-            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
-              echo "Job failed with result: $result"
-              exit 1
+          echo "=== Job Results ==="
+          echo "check-changes: ${{ needs.check-changes.result }}"
+          echo "unit-test-1-tpu: ${{ needs.unit-test-1-tpu.result }}"
+          echo "unit-test-4-tpu: ${{ needs.unit-test-4-tpu.result }}"
+          echo "e2e-test-1-tpu: ${{ needs.e2e-test-1-tpu.result }}"
+          echo "e2e-test-4-tpu: ${{ needs.e2e-test-4-tpu.result }}"
+          echo "accurancy-test-1-tpu: ${{ needs.accurancy-test-1-tpu.result }}"
+          echo "accurancy-test-4-tpu: ${{ needs.accurancy-test-4-tpu.result }}"
+          echo "performance-test-1-tpu: ${{ needs.performance-test-1-tpu.result }}"
+          echo "performance-test-4-tpu: ${{ needs.performance-test-4-tpu.result }}"
+          echo "pallas-kernel-benchmark: ${{ needs.pallas-kernel-benchmark.result }}"
+          echo ""
+
+          # check-changes must succeed
+          if [ "${{ needs.check-changes.result }}" != "success" ]; then
+            echo "::error::check-changes did not succeed: ${{ needs.check-changes.result }}"
+            exit 1
+          fi
+
+          # If no relevant files changed, all test skips are by-design
+          main_package="${{ needs.check-changes.outputs.main_package }}"
+          pallas_kernel="${{ needs.check-changes.outputs.pallas_kernel }}"
+
+          if [ "$main_package" != "true" ] && [ "$pallas_kernel" != "true" ]; then
+            echo "No relevant file changes detected — all test skips are by design"
+            exit 0
+          fi
+
+          # Check jobs that should have run
+          has_failure=false
+
+          if [ "$main_package" = "true" ]; then
+            for job_result in \
+              "unit-test-1-tpu=${{ needs.unit-test-1-tpu.result }}" \
+              "unit-test-4-tpu=${{ needs.unit-test-4-tpu.result }}" \
+              "e2e-test-1-tpu=${{ needs.e2e-test-1-tpu.result }}" \
+              "e2e-test-4-tpu=${{ needs.e2e-test-4-tpu.result }}" \
+              "accurancy-test-1-tpu=${{ needs.accurancy-test-1-tpu.result }}" \
+              "accurancy-test-4-tpu=${{ needs.accurancy-test-4-tpu.result }}" \
+              "performance-test-1-tpu=${{ needs.performance-test-1-tpu.result }}" \
+              "performance-test-4-tpu=${{ needs.performance-test-4-tpu.result }}"; do
+              job_name="${job_result%%=*}"
+              result="${job_result#*=}"
+              if [ "$result" != "success" ]; then
+                echo "::error::${job_name} did not succeed: ${result}"
+                has_failure=true
+              fi
+            done
+          fi
+
+          if [ "$pallas_kernel" = "true" ]; then
+            result="${{ needs.pallas-kernel-benchmark.result }}"
+            if [ "$result" != "success" ]; then
+              echo "::error::pallas-kernel-benchmark did not succeed: ${result}"
+              has_failure=true
             fi
-          done
-          echo "All jobs completed successfully"
-          exit 0
+          fi
+
+          if [ "$has_failure" = "true" ]; then
+            exit 1
+          fi
+
+          echo "All required test jobs passed"

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths:
-      - "python/sglang/version.py"
+      - "python/sgl_jax/version.py"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Consolidates all P0-level CI gate improvements into a single refactor PR.

- **P0-1** (#1118): Fix `pr-test-finish` skipped blind spot — add `if: always()`, distinguish by-design skip vs upstream failure, change runner to `ubuntu-latest`; align `on.paths` with `check-changes` filter (`python/**` → `python/sgl_jax/**` + `python/*.toml`, add `benchmark/kernels/**`)
- **P0-2** (#1119): Fix `release-pypi.yml` path filter (`python/sglang/version.py` → `python/sgl_jax/version.py`)
- **P0-3** (#1122): Split shared concurrency group across 3 nightly workflows to prevent mutual cancellation
- **P0-4** (#1120): Narrow `nightly-test-summize.yml` permissions to `contents: write` only (remove unused `pull-requests: write` and `issues: write`)
- **P0-7** (#1124): Remove all 12× `continue-on-error: true` from nightly + daily jobs; add `nightly-test-finish` and `nightly-test-daily-finish` aggregator jobs
- **P0-10** (#1125): Reduce nightly/daily timeouts from 3000–18000 min to max(P95×3, 60min)

## Files changed
| File | Changes |
|------|---------|
| `pr-test.yml` | P0-1: rewrite aggregator + align path filters |
| `release-pypi.yml` | P0-2: fix 1-line path |
| `nightly-test-summize.yml` | P0-3: split concurrency group; P0-4: narrow permissions |
| `nightly-test-daily.yml` | P0-3: split concurrency group; P0-7: remove continue-on-error + add aggregator; P0-10: reduce timeouts |
| `nightly-test.yml` | P0-7: remove continue-on-error + add aggregator; P0-10: reduce timeouts |

## Test plan
- [ ] PR CI triggers on `pr-test.yml` change and `pr-test-finish` works correctly
- [ ] Nightly workflows can be triggered via `workflow_dispatch` post-merge
- [ ] Failed test job causes aggregator to report failure
- [ ] Timeout values aligned with P95 runtime data

Closes #1118, closes #1119, closes #1120, closes #1122, closes #1124, closes #1125

Supersedes #1148, #1149, #1152, #1155

🤖 Generated with [Claude Code](https://claude.com/claude-code)