### PR TITLE
ci: add event_name dimension to PR Test concurrency group (P1-4)

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -25,8 +25,8 @@ on:
       - ".github/workflows/pr-test.yml"
 
 concurrency:
-  group: pr-test-${{ github.ref }}
-  cancel-in-progress: true
+  group: pr-test-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # =============================================== check changes ====================================================


### PR DESCRIPTION
## Summary
- Add `event_name` dimension to concurrency group: `pr-test-${{ github.ref }}` → `pr-test-${{ github.event_name }}-${{ github.ref }}`
- Make `cancel-in-progress` conditional: only cancel for `pull_request` events, not `push` (post-merge)

## Why
Post-merge runs on `main` were sharing the same concurrency group as PR runs. A merge to main could cancel an in-progress PR test for the same branch, contributing to the 38.4% cancel rate.

## Note
The `matrix.stage` dimension from the design spec is deferred to P1-3 (stage-based PR Test), since stages don't exist yet.

## Test plan
- [ ] PR push cancels previous PR run on same branch (preserved)
- [ ] Post-merge push to main does NOT cancel in-progress PR run

Closes #1132

🤖 Generated with [Claude Code](https://claude.com/claude-code)