### PR TITLE
ci: add pytest-rerunfailures for flaky test retry (P1-14)

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -42,7 +42,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-accuracy-text-models-tpu-v6e-1-daily
+          python3 run_suite.py --suite nightly-test-accuracy-text-models-tpu-v6e-1-daily --reruns 2
       - name: Publish traces to storage repo
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
@@ -83,7 +83,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1-daily
+          python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1-daily --reruns 2
 
       - name: Publish traces to storage repo
         env:
@@ -126,7 +126,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-perf-trace-text-models-tpu-v6e-1-daily
+          python3 run_suite.py --suite nightly-test-perf-trace-text-models-tpu-v6e-1-daily --reruns 2
 
       - name: Publish traces to storage repo
         env:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -46,7 +46,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-accuracy-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 4
+          python3 run_suite.py --suite nightly-test-accuracy-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 --reruns 2
       - name: Publish traces to storage repo
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
@@ -110,7 +110,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-accuracy-text-models-tpu-v6e-4 --auto-partition-id ${{ matrix.part }} --auto-partition-size 6
+          python3 run_suite.py --suite nightly-test-accuracy-text-models-tpu-v6e-4 --auto-partition-id ${{ matrix.part }} --auto-partition-size 6 --reruns 2
       - name: Publish traces to storage repo
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
@@ -155,7 +155,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 8
+          python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 8 --reruns 2
 
       - name: Publish traces to storage repo
         env:
@@ -199,7 +199,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part1
+          python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part1 --reruns 2
 
       - name: Publish traces to storage repo
         env:
@@ -264,7 +264,7 @@ jobs:
 
             bash scripts/killall_sglang.sh
             cd test/srt
-            python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part2
+            python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part2 --reruns 2
 
         - name: Publish traces to storage repo
           env:
@@ -307,7 +307,7 @@ jobs:
 
               bash scripts/killall_sglang.sh
               cd test/srt
-              python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part3
+              python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part3 --reruns 2
 
           - name: Publish traces to storage repo
             env:
@@ -353,7 +353,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-perf-trace-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 8
+          python3 run_suite.py --suite nightly-test-perf-trace-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 8 --reruns 2
 
       - name: Publish traces to storage repo
         env:
@@ -396,7 +396,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite  nightly-test-perf-trace-text-models-tpu-v6e-4-part1
+          python3 run_suite.py --suite  nightly-test-perf-trace-text-models-tpu-v6e-4-part1 --reruns 2
 
       - name: Publish traces to storage repo
         env:
@@ -439,7 +439,7 @@ jobs:
 
             bash scripts/killall_sglang.sh
             cd test/srt
-            python3 run_suite.py --suite  nightly-test-perf-trace-text-models-tpu-v6e-4-part2
+            python3 run_suite.py --suite  nightly-test-perf-trace-text-models-tpu-v6e-4-part2 --reruns 2
 
         - name: Publish traces to storage repo
           env:

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -62,7 +62,9 @@ def cleanup_model_cache():
                         print(f"Failed to clean model cache: {e}\n", flush=True)
 
 
-def run_unittest_files(files: list[TestFile], timeout_per_file: float):
+def run_unittest_files(
+    files: list[TestFile], timeout_per_file: float, reruns: int = 0, reruns_delay: int = 0
+):
     tic = time.perf_counter()
     success = True
 
@@ -127,6 +129,8 @@ def run_unittest_files(files: list[TestFile], timeout_per_file: float):
                         "--with",
                         "pytest",
                     ]
+                    if reruns > 0:
+                        cmd.extend(["--with", "pytest-rerunfailures"])
                     for dep in file_entry.extra_deps or []:
                         cmd.extend(["--with", dep])
                     cmd.extend(
@@ -138,6 +142,8 @@ def run_unittest_files(files: list[TestFile], timeout_per_file: float):
                             filename,
                         ]
                     )
+                    if reruns > 0:
+                        cmd.extend(["--reruns", str(reruns), "--reruns-delay", str(reruns_delay)])
                 else:
                     cmd = [sys.executable, filename]
 
@@ -166,6 +172,21 @@ def run_unittest_files(files: list[TestFile], timeout_per_file: float):
 
         try:
             ret_code = run_with_timeout(run_one_file, args=(filename,), timeout=timeout_per_file)
+            if ret_code != 0 and reruns > 0 and file_entry.runner != "pytest":
+                for attempt in range(1, reruns + 1):
+                    print(
+                        f"\n[rerun {attempt}/{reruns}] {filename} failed, retrying after {reruns_delay}s...\n",
+                        flush=True,
+                    )
+                    time.sleep(reruns_delay)
+                    ret_code = run_with_timeout(
+                        run_one_file, args=(filename,), timeout=timeout_per_file
+                    )
+                    if ret_code == 0:
+                        print(
+                            f"\n[rerun {attempt}/{reruns}] {filename} passed on retry\n", flush=True
+                        )
+                        break
             assert ret_code == 0, f"expected return code 0, but {filename} returned {ret_code}"
         except TimeoutError:
             kill_process_tree(process.pid)
@@ -651,6 +672,18 @@ if __name__ == "__main__":
         type=int,
         help="Use auto load balancing. The number of parts.",
     )
+    arg_parser.add_argument(
+        "--reruns",
+        type=int,
+        default=0,
+        help="Number of times to retry a failed test file (0 = no retry). For pytest runner, also enables per-test retry via pytest-rerunfailures.",
+    )
+    arg_parser.add_argument(
+        "--reruns-delay",
+        type=int,
+        default=10,
+        help="Delay in seconds between reruns (default: 10).",
+    )
     args = arg_parser.parse_args()
     print(f"{args=}")
 
@@ -663,5 +696,7 @@ if __name__ == "__main__":
 
     print("The running tests are ", [f.name for f in files])
 
-    exit_code = run_unittest_files(files, args.timeout_per_file)
+    exit_code = run_unittest_files(
+        files, args.timeout_per_file, reruns=args.reruns, reruns_delay=args.reruns_delay
+    )
     exit(exit_code)


### PR DESCRIPTION
## Summary
- Add `--reruns` and `--reruns-delay` CLI flags to `run_suite.py` with two retry strategies:
  - **pytest runner**: per-test retry via `pytest-rerunfailures` plugin
  - **other runners** (python/unittest): file-level retry with configurable delay
- Enable `--reruns 2` for all 12 `run_suite.py` calls across nightly and daily workflows
- PR test workflows intentionally excluded — PR failures should be investigated, not auto-retried

## Test plan
- [ ] Verify nightly workflow runs with `--reruns 2` correctly retry flaky tests
- [ ] Verify PR test workflows remain unaffected (no `--reruns` flag)
- [ ] Confirm pytest-rerunfailures is installed on-demand only when `--reruns > 0` and runner is pytest

Closes #1138