### PR TITLE
ci: reusable venv setup and flaky test retry (P1-5, P1-14)

### DIFF
--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -18,8 +18,11 @@ runs:
         pip install uv
         uv pip install -e "python[all]"
         if [ -n "$EXTRA_PACKAGES" ]; then
+          set -f
+          # shellcheck disable=SC2086
           uv pip install $EXTRA_PACKAGES
+          set +f
         fi
     - name: Add venv to PATH
       shell: bash
-      run: echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
+      run: echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH

--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -18,9 +18,7 @@ runs:
         pip install uv
         uv pip install -e "python[all]"
         if [ -n "$EXTRA_PACKAGES" ]; then
-          for pkg in $EXTRA_PACKAGES; do
-            uv pip install "$pkg"
-          done
+          uv pip install $EXTRA_PACKAGES
         fi
     - name: Add venv to PATH
       shell: bash

--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -1,0 +1,25 @@
+name: 'Setup Python venv'
+description: 'Create Python 3.12 venv, install uv and project dependencies'
+inputs:
+  extra-packages:
+    description: 'Space-separated list of extra pip packages to install (e.g. "evalscope==1.0.0")'
+    required: false
+    default: ''
+runs:
+  using: "composite"
+  steps:
+    - name: Create venv and install dependencies
+      shell: bash
+      run: |
+        python3.12 -m venv .venv
+        source .venv/bin/activate
+        pip install uv
+        uv pip install -e "python[all]"
+        if [ -n "${{ inputs.extra-packages }}" ]; then
+          for pkg in ${{ inputs.extra-packages }}; do
+            uv pip install "$pkg"
+          done
+        fi
+    - name: Add venv to PATH
+      shell: bash
+      run: echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH

--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -10,13 +10,15 @@ runs:
   steps:
     - name: Create venv and install dependencies
       shell: bash
+      env:
+        EXTRA_PACKAGES: ${{ inputs.extra-packages }}
       run: |
         python3.12 -m venv .venv
         source .venv/bin/activate
         pip install uv
         uv pip install -e "python[all]"
-        if [ -n "${{ inputs.extra-packages }}" ]; then
-          for pkg in ${{ inputs.extra-packages }}; do
+        if [ -n "$EXTRA_PACKAGES" ]; then
+          for pkg in $EXTRA_PACKAGES; do
             uv pip install "$pkg"
           done
         fi

--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -40,7 +40,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-accuracy-text-models-tpu-v6e-1-daily
+          python3 run_suite.py --suite nightly-test-accuracy-text-models-tpu-v6e-1-daily --reruns 2
       - name: Publish traces to storage repo
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
@@ -78,7 +78,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1-daily
+          python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1-daily --reruns 2
 
       - name: Publish traces to storage repo
         env:
@@ -118,7 +118,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-perf-trace-text-models-tpu-v6e-1-daily
+          python3 run_suite.py --suite nightly-test-perf-trace-text-models-tpu-v6e-1-daily --reruns 2
 
       - name: Publish traces to storage repo
         env:

--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -78,7 +78,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1-daily --reruns 2
+          python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1-daily
 
       - name: Publish traces to storage repo
         env:
@@ -118,7 +118,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-perf-trace-text-models-tpu-v6e-1-daily --reruns 2
+          python3 run_suite.py --suite nightly-test-perf-trace-text-models-tpu-v6e-1-daily
 
       - name: Publish traces to storage repo
         env:

--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -23,18 +23,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
+        with:
+          extra-packages: 'evalscope==1.0.0'
       - name: Run eval test for text models
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
         timeout-minutes: 60
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
-          uv pip install evalscope==1.0.0
-
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export BENCH_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/benchmark/$OUTPUT_DIR_NAME"
           echo "BENCH_OUTPUT_DIR=$BENCH_OUTPUT_DIR" >> $GITHUB_ENV
@@ -60,6 +58,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Run performance test for text models
         timeout-minutes: 60
         env:
@@ -69,11 +69,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
-
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/perf/$OUTPUT_DIR_NAME"
           echo "PERF_OUTPUT_DIR=$PERF_OUTPUT_DIR" >> $GITHUB_ENV
@@ -103,6 +98,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Run performance test for text models
         timeout-minutes: 60
         env:
@@ -112,11 +109,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
-
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/trace/$OUTPUT_DIR_NAME"
           echo "PERF_OUTPUT_DIR=$PERF_OUTPUT_DIR" >> $GITHUB_ENV

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -27,18 +27,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
+        with:
+          extra-packages: 'evalscope==1.0.0'
       - name: Run eval test for text models
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
         timeout-minutes: 1000
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
-          uv pip install evalscope==1.0.0
-
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export BENCH_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/benchmark/$OUTPUT_DIR_NAME"
           echo "BENCH_OUTPUT_DIR=$BENCH_OUTPUT_DIR" >> $GITHUB_ENV
@@ -90,19 +88,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
+        with:
+          extra-packages: 'evalscope==1.0.0'
       - name: Run eval test for text models
         env:
             HF_TOKEN: ${{ secrets.HF_TOKEN }}
             HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
         timeout-minutes: 1200
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
-          uv pip install evalscope==1.0.0
-
-
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export BENCH_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/benchmark/$OUTPUT_DIR_NAME"
           echo "BENCH_OUTPUT_DIR=$BENCH_OUTPUT_DIR" >> $GITHUB_ENV
@@ -132,6 +127,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Run performance test for text models
         timeout-minutes: 840
         env:
@@ -141,11 +138,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
-
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/perf/$OUTPUT_DIR_NAME"
           echo "PERF_OUTPUT_DIR=$PERF_OUTPUT_DIR" >> $GITHUB_ENV
@@ -176,6 +168,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Run performance test for text models
         timeout-minutes: 430
         env:
@@ -185,11 +179,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
-
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/perf/$OUTPUT_DIR_NAME"
           echo "PERF_OUTPUT_DIR=$PERF_OUTPUT_DIR" >> $GITHUB_ENV
@@ -241,6 +230,8 @@ jobs:
         - name: Checkout code
           uses: actions/checkout@v4
 
+        - name: Setup Python environment
+          uses: ./.github/actions/setup-venv
         - name: Run performance test for text models
           timeout-minutes: 390
           env:
@@ -250,11 +241,6 @@ jobs:
             HF_TOKEN: ${{ secrets.HF_TOKEN }}
             HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
           run: |
-            python3.12 -m venv .venv
-            source .venv/bin/activate
-            pip install uv
-            uv pip install -e "python[all]"
-
             export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
             export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/perf/$OUTPUT_DIR_NAME"
             echo "PERF_OUTPUT_DIR=$PERF_OUTPUT_DIR" >> $GITHUB_ENV
@@ -284,6 +270,8 @@ jobs:
           - name: Checkout code
             uses: actions/checkout@v4
 
+          - name: Setup Python environment
+            uses: ./.github/actions/setup-venv
           - name: Run performance test for text models
             timeout-minutes: 400
             env:
@@ -293,11 +281,6 @@ jobs:
               HF_TOKEN: ${{ secrets.HF_TOKEN }}
               HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
             run: |
-              python3.12 -m venv .venv
-              source .venv/bin/activate
-              pip install uv
-              uv pip install -e "python[all]"
-
               export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
               export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/perf/$OUTPUT_DIR_NAME"
               echo "PERF_OUTPUT_DIR=$PERF_OUTPUT_DIR" >> $GITHUB_ENV
@@ -330,6 +313,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Run performance test for text models
         timeout-minutes: 120
         env:
@@ -339,11 +324,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
-
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/trace/$OUTPUT_DIR_NAME"
           echo "PERF_OUTPUT_DIR=$PERF_OUTPUT_DIR" >> $GITHUB_ENV
@@ -373,6 +353,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Run performance test trace for text models
         timeout-minutes: 365
         env:
@@ -382,11 +364,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
-
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/trace/$OUTPUT_DIR_NAME"
           echo "PERF_OUTPUT_DIR=$PERF_OUTPUT_DIR" >> $GITHUB_ENV
@@ -416,6 +393,8 @@ jobs:
         - name: Checkout code
           uses: actions/checkout@v4
 
+        - name: Setup Python environment
+          uses: ./.github/actions/setup-venv
         - name: Run performance test trace for text models
           timeout-minutes: 230
           env:
@@ -425,11 +404,6 @@ jobs:
             HF_TOKEN: ${{ secrets.HF_TOKEN }}
             HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
           run: |
-            python3.12 -m venv .venv
-            source .venv/bin/activate
-            pip install uv
-            uv pip install -e "python[all]"
-
             export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
             export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/trace/$OUTPUT_DIR_NAME"
             echo "PERF_OUTPUT_DIR=$PERF_OUTPUT_DIR" >> $GITHUB_ENV

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -147,7 +147,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 8 --reruns 2
+          python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 8
 
       - name: Publish traces to storage repo
         env:
@@ -188,7 +188,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part1 --reruns 2
+          python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part1
 
       - name: Publish traces to storage repo
         env:
@@ -250,7 +250,7 @@ jobs:
 
             bash scripts/killall_sglang.sh
             cd test/srt
-            python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part2 --reruns 2
+            python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part2
 
         - name: Publish traces to storage repo
           env:
@@ -290,7 +290,7 @@ jobs:
 
               bash scripts/killall_sglang.sh
               cd test/srt
-              python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part3 --reruns 2
+              python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part3
 
           - name: Publish traces to storage repo
             env:
@@ -333,7 +333,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-perf-trace-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 8 --reruns 2
+          python3 run_suite.py --suite nightly-test-perf-trace-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 8
 
       - name: Publish traces to storage repo
         env:
@@ -373,7 +373,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite  nightly-test-perf-trace-text-models-tpu-v6e-4-part1 --reruns 2
+          python3 run_suite.py --suite  nightly-test-perf-trace-text-models-tpu-v6e-4-part1
 
       - name: Publish traces to storage repo
         env:
@@ -413,7 +413,7 @@ jobs:
 
             bash scripts/killall_sglang.sh
             cd test/srt
-            python3 run_suite.py --suite  nightly-test-perf-trace-text-models-tpu-v6e-4-part2 --reruns 2
+            python3 run_suite.py --suite  nightly-test-perf-trace-text-models-tpu-v6e-4-part2
 
         - name: Publish traces to storage repo
           env:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -44,7 +44,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-accuracy-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 4
+          python3 run_suite.py --suite nightly-test-accuracy-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 --reruns 2
       - name: Publish traces to storage repo
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
@@ -105,7 +105,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-accuracy-text-models-tpu-v6e-4 --auto-partition-id ${{ matrix.part }} --auto-partition-size 6
+          python3 run_suite.py --suite nightly-test-accuracy-text-models-tpu-v6e-4 --auto-partition-id ${{ matrix.part }} --auto-partition-size 6 --reruns 2
       - name: Publish traces to storage repo
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
@@ -147,7 +147,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 8
+          python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 8 --reruns 2
 
       - name: Publish traces to storage repo
         env:
@@ -188,7 +188,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part1
+          python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part1 --reruns 2
 
       - name: Publish traces to storage repo
         env:
@@ -250,7 +250,7 @@ jobs:
 
             bash scripts/killall_sglang.sh
             cd test/srt
-            python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part2
+            python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part2 --reruns 2
 
         - name: Publish traces to storage repo
           env:
@@ -290,7 +290,7 @@ jobs:
 
               bash scripts/killall_sglang.sh
               cd test/srt
-              python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part3
+              python3 run_suite.py --suite  nightly-test-perf-text-models-tpu-v6e-4-part3 --reruns 2
 
           - name: Publish traces to storage repo
             env:
@@ -333,7 +333,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite nightly-test-perf-trace-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 8
+          python3 run_suite.py --suite nightly-test-perf-trace-text-models-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 8 --reruns 2
 
       - name: Publish traces to storage repo
         env:
@@ -373,7 +373,7 @@ jobs:
 
           bash scripts/killall_sglang.sh
           cd test/srt
-          python3 run_suite.py --suite  nightly-test-perf-trace-text-models-tpu-v6e-4-part1
+          python3 run_suite.py --suite  nightly-test-perf-trace-text-models-tpu-v6e-4-part1 --reruns 2
 
       - name: Publish traces to storage repo
         env:
@@ -413,7 +413,7 @@ jobs:
 
             bash scripts/killall_sglang.sh
             cd test/srt
-            python3 run_suite.py --suite  nightly-test-perf-trace-text-models-tpu-v6e-4-part2
+            python3 run_suite.py --suite  nightly-test-perf-trace-text-models-tpu-v6e-4-part2 --reruns 2
 
         - name: Publish traces to storage repo
           env:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -12,6 +12,7 @@ on:
       - "test/**"
       - "benchmark/kernels/**"
       - ".github/workflows/pr-test.yml"
+      - ".github/actions/**"
   pull_request:
     branches:
       - main
@@ -23,6 +24,7 @@ on:
       - "test/**"
       - "benchmark/kernels/**"
       - ".github/workflows/pr-test.yml"
+      - ".github/actions/**"
 
 concurrency:
   group: pr-test-${{ github.ref }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -79,6 +79,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Run unit test
         timeout-minutes: 60
         shell: bash
@@ -86,10 +88,6 @@ jobs:
           SGLANG_JAX_IS_IN_CI: true
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
           python test/srt/run_suite.py --suite unit-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 3
 
   unit-test-4-tpu:
@@ -103,16 +101,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Run unit test
         timeout-minutes: 30
         env:
           SGLANG_JAX_IS_IN_CI: true
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite unit-test-tpu-v6e-4 --auto-partition-id ${{ matrix.part }} --auto-partition-size 2
 
@@ -128,6 +124,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Run e2e test
         timeout-minutes: 120
         shell: bash
@@ -137,10 +135,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite e2e-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 1
 
@@ -156,6 +150,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Run e2e test
         timeout-minutes: 120
         shell: bash
@@ -165,10 +161,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite e2e-test-tpu-v6e-4 --auto-partition-id ${{ matrix.part }} --auto-partition-size 3
 
@@ -185,6 +177,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Evaluate accuracy
         timeout-minutes: 20
         env:
@@ -193,10 +187,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite accuracy-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 1
 
@@ -213,6 +203,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Evaluate MoE accuracy (TP=4)
         timeout-minutes: 50
         env:
@@ -221,10 +213,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite accuracy-test-tpu-v6e-4 --timeout-per-file 3000 --auto-partition-id ${{ matrix.part }} --auto-partition-size 1
 
@@ -242,6 +230,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Benchmark performance
         timeout-minutes: 30
         env:
@@ -250,10 +240,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite performance-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 1
 
@@ -270,6 +256,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Benchmark performance (tp=4)
         timeout-minutes: 50
 
@@ -279,10 +267,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite performance-test-tpu-v6e-4 --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 3000
 
@@ -298,6 +282,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
       - name: Run test
         timeout-minutes: 120
         shell: bash
@@ -307,10 +293,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[all]"
           python test/srt/run_suite.py --suite kernel-performance-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 2
 
   pr-test-finish:

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -66,7 +66,7 @@ def run_unittest_files(
     files: list[TestFile],
     timeout_per_file: float,
     reruns: int = 0,
-    reruns_delay: int = 10,
+    reruns_delay: float = 10,
     only_rerun: list[str] | None = None,
 ):
     tic = time.perf_counter()
@@ -692,7 +692,7 @@ if __name__ == "__main__":
     )
     arg_parser.add_argument(
         "--reruns-delay",
-        type=int,
+        type=float,
         default=10,
         help="Delay in seconds between reruns (default: 10).",
     )
@@ -701,7 +701,9 @@ if __name__ == "__main__":
         type=str,
         nargs="+",
         default=None,
-        help="Only rerun tests matching these error patterns (e.g. TimeoutError ConnectionError). Passed to pytest-rerunfailures --only-rerun.",
+        help="Only rerun tests matching these error patterns (e.g. TimeoutError ConnectionError). "
+        "Passed to pytest-rerunfailures --only-rerun. Only effective for pytest runner files; "
+        "file-level retry for unittest runner is not filtered by this option.",
     )
     args = arg_parser.parse_args()
     print(f"{args=}")

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -62,7 +62,9 @@ def cleanup_model_cache():
                         print(f"Failed to clean model cache: {e}\n", flush=True)
 
 
-def run_unittest_files(files: list[TestFile], timeout_per_file: float):
+def run_unittest_files(
+    files: list[TestFile], timeout_per_file: float, reruns: int = 0, reruns_delay: int = 0
+):
     tic = time.perf_counter()
     success = True
 
@@ -127,6 +129,8 @@ def run_unittest_files(files: list[TestFile], timeout_per_file: float):
                         "--with",
                         "pytest",
                     ]
+                    if reruns > 0:
+                        cmd.extend(["--with", "pytest-rerunfailures"])
                     for dep in file_entry.extra_deps or []:
                         cmd.extend(["--with", dep])
                     cmd.extend(
@@ -138,6 +142,8 @@ def run_unittest_files(files: list[TestFile], timeout_per_file: float):
                             filename,
                         ]
                     )
+                    if reruns > 0:
+                        cmd.extend(["--reruns", str(reruns), "--reruns-delay", str(reruns_delay)])
                 else:
                     cmd = [sys.executable, filename]
 
@@ -166,6 +172,21 @@ def run_unittest_files(files: list[TestFile], timeout_per_file: float):
 
         try:
             ret_code = run_with_timeout(run_one_file, args=(filename,), timeout=timeout_per_file)
+            if ret_code != 0 and reruns > 0 and file_entry.runner != "pytest":
+                for attempt in range(1, reruns + 1):
+                    print(
+                        f"\n[rerun {attempt}/{reruns}] {filename} failed, retrying after {reruns_delay}s...\n",
+                        flush=True,
+                    )
+                    time.sleep(reruns_delay)
+                    ret_code = run_with_timeout(
+                        run_one_file, args=(filename,), timeout=timeout_per_file
+                    )
+                    if ret_code == 0:
+                        print(
+                            f"\n[rerun {attempt}/{reruns}] {filename} passed on retry\n", flush=True
+                        )
+                        break
             assert ret_code == 0, f"expected return code 0, but {filename} returned {ret_code}"
         except TimeoutError:
             kill_process_tree(process.pid)
@@ -651,6 +672,18 @@ if __name__ == "__main__":
         type=int,
         help="Use auto load balancing. The number of parts.",
     )
+    arg_parser.add_argument(
+        "--reruns",
+        type=int,
+        default=0,
+        help="Number of times to retry a failed test file (0 = no retry). For pytest runner, also enables per-test retry via pytest-rerunfailures.",
+    )
+    arg_parser.add_argument(
+        "--reruns-delay",
+        type=int,
+        default=10,
+        help="Delay in seconds between reruns (default: 10).",
+    )
     args = arg_parser.parse_args()
     print(f"{args=}")
 
@@ -663,5 +696,7 @@ if __name__ == "__main__":
 
     print("The running tests are ", [f.name for f in files])
 
-    exit_code = run_unittest_files(files, args.timeout_per_file)
+    exit_code = run_unittest_files(
+        files, args.timeout_per_file, reruns=args.reruns, reruns_delay=args.reruns_delay
+    )
     exit(exit_code)

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -63,7 +63,11 @@ def cleanup_model_cache():
 
 
 def run_unittest_files(
-    files: list[TestFile], timeout_per_file: float, reruns: int = 0, reruns_delay: int = 0
+    files: list[TestFile],
+    timeout_per_file: float,
+    reruns: int = 0,
+    reruns_delay: int = 10,
+    only_rerun: list[str] | None = None,
 ):
     tic = time.perf_counter()
     success = True
@@ -130,7 +134,7 @@ def run_unittest_files(
                         "pytest",
                     ]
                     if reruns > 0:
-                        cmd.extend(["--with", "pytest-rerunfailures"])
+                        cmd.extend(["--with", "pytest-rerunfailures==14.0"])
                     for dep in file_entry.extra_deps or []:
                         cmd.extend(["--with", dep])
                     cmd.extend(
@@ -144,6 +148,8 @@ def run_unittest_files(
                     )
                     if reruns > 0:
                         cmd.extend(["--reruns", str(reruns), "--reruns-delay", str(reruns_delay)])
+                        for pattern in only_rerun or []:
+                            cmd.extend(["--only-rerun", pattern])
                 else:
                     cmd = [sys.executable, filename]
 
@@ -172,21 +178,27 @@ def run_unittest_files(
 
         try:
             ret_code = run_with_timeout(run_one_file, args=(filename,), timeout=timeout_per_file)
-            if ret_code != 0 and reruns > 0 and file_entry.runner != "pytest":
-                for attempt in range(1, reruns + 1):
-                    print(
-                        f"\n[rerun {attempt}/{reruns}] {filename} failed, retrying after {reruns_delay}s...\n",
-                        flush=True,
-                    )
-                    time.sleep(reruns_delay)
-                    ret_code = run_with_timeout(
-                        run_one_file, args=(filename,), timeout=timeout_per_file
-                    )
-                    if ret_code == 0:
+            if ret_code != 0 and reruns > 0:
+                # pytest exit 1 = test case failures already retried by pytest-rerunfailures;
+                # only file-level retry on infrastructure errors (exit 2/3/5)
+                if file_entry.runner == "pytest" and ret_code == 1:
+                    pass
+                else:
+                    for attempt in range(1, reruns + 1):
                         print(
-                            f"\n[rerun {attempt}/{reruns}] {filename} passed on retry\n", flush=True
+                            f"\n[rerun {attempt}/{reruns}] {filename} failed (exit {ret_code}), retrying after {reruns_delay}s...\n",
+                            flush=True,
                         )
-                        break
+                        time.sleep(reruns_delay)
+                        ret_code = run_with_timeout(
+                            run_one_file, args=(filename,), timeout=timeout_per_file
+                        )
+                        if ret_code == 0:
+                            print(
+                                f"\n[rerun {attempt}/{reruns}] {filename} passed on retry\n",
+                                flush=True,
+                            )
+                            break
             assert ret_code == 0, f"expected return code 0, but {filename} returned {ret_code}"
         except TimeoutError:
             kill_process_tree(process.pid)
@@ -684,6 +696,13 @@ if __name__ == "__main__":
         default=10,
         help="Delay in seconds between reruns (default: 10).",
     )
+    arg_parser.add_argument(
+        "--only-rerun",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Only rerun tests matching these error patterns (e.g. TimeoutError ConnectionError). Passed to pytest-rerunfailures --only-rerun.",
+    )
     args = arg_parser.parse_args()
     print(f"{args=}")
 
@@ -697,6 +716,10 @@ if __name__ == "__main__":
     print("The running tests are ", [f.name for f in files])
 
     exit_code = run_unittest_files(
-        files, args.timeout_per_file, reruns=args.reruns, reruns_delay=args.reruns_delay
+        files,
+        args.timeout_per_file,
+        reruns=args.reruns,
+        reruns_delay=args.reruns_delay,
+        only_rerun=args.only_rerun,
     )
     exit(exit_code)


### PR DESCRIPTION
## Summary
- Create `.github/actions/setup-venv/action.yml` composite action that encapsulates the repeated 4-line venv+install pattern
- Replace 21 inline setup blocks across `pr-test.yml`, `nightly-test.yml`, and `nightly-test-daily.yml` with single-line `uses: ./.github/actions/setup-venv`
- Support optional `extra-packages` input for jobs needing additional deps (e.g. `evalscope==1.0.0`)
- Add `.venv/bin` to `GITHUB_PATH` so subsequent steps use the venv automatically without `source activate`
- Net reduction: -100 lines, +73 lines (including the new action file)

## Test plan
- [ ] Verify PR test workflows create venv and install dependencies correctly
- [ ] Verify nightly accuracy jobs install evalscope via `extra-packages` input
- [ ] Verify subsequent run steps can access Python and installed packages from the venv

Closes #1133