### PR TITLE
ci: add CI failure monitor workflow (P1-8)

### DIFF
--- a/.github/workflows/ci-failure-monitor.yml
+++ b/.github/workflows/ci-failure-monitor.yml
@@ -1,0 +1,52 @@
+name: CI Failure Monitor
+
+on:
+  workflow_run:
+    workflows:
+      - "Nightly Test"
+      - "Nightly Test Daily"
+      - "PR Test"
+      - "Release PyPI"
+    types:
+      - completed
+
+permissions:
+  issues: write
+  actions: read
+  contents: read
+
+jobs:
+  monitor:
+    if: >-
+      github.repository == 'sgl-project/sglang-jax' &&
+      github.event.workflow_run.conclusion != 'success' &&
+      github.event.workflow_run.conclusion != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Get commit author
+        id: author
+        run: |
+          AUTHOR=$(gh api repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }} --jq '.commit.author.name // "unknown"' 2>/dev/null || echo "unknown")
+          echo "name=$AUTHOR" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run failure monitor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/ci/ci_failure_monitor.py \
+            --run-id "${{ github.event.workflow_run.id }}" \
+            --repo "${{ github.repository }}" \
+            --workflow-name "${{ github.event.workflow_run.name }}" \
+            --run-url "${{ github.event.workflow_run.html_url }}" \
+            --commit-sha "${{ github.event.workflow_run.head_sha }}" \
+            --commit-author "${{ steps.author.outputs.name }}"

--- a/.github/workflows/ci-failure-monitor.yml
+++ b/.github/workflows/ci-failure-monitor.yml
@@ -20,7 +20,8 @@ jobs:
     if: >-
       github.repository == 'sgl-project/sglang-jax' &&
       github.event.workflow_run.conclusion != 'success' &&
-      github.event.workflow_run.conclusion != 'skipped'
+      github.event.workflow_run.conclusion != 'skipped' &&
+      (github.event.workflow_run.name != 'PR Test' || github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-failure-monitor.yml
+++ b/.github/workflows/ci-failure-monitor.yml
@@ -21,6 +21,7 @@ jobs:
       github.repository == 'sgl-project/sglang-jax' &&
       github.event.workflow_run.conclusion != 'success' &&
       github.event.workflow_run.conclusion != 'skipped' &&
+      github.event.workflow_run.conclusion != 'cancelled' &&
       (github.event.workflow_run.name != 'PR Test' || github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-failure-monitor.yml
+++ b/.github/workflows/ci-failure-monitor.yml
@@ -34,20 +34,28 @@ jobs:
 
       - name: Get commit author
         id: author
-        run: |
-          AUTHOR=$(gh api repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }} --jq '.commit.author.name // "unknown"' 2>/dev/null || echo "unknown")
-          echo "name=$AUTHOR" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          AUTHOR=$(gh api "repos/$REPO/commits/$COMMIT_SHA" --jq '.commit.author.name // "unknown"' 2>/dev/null || echo "unknown")
+          echo "name=$AUTHOR" >> $GITHUB_OUTPUT
 
       - name: Run failure monitor
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RUN_ID: ${{ github.event.workflow_run.id }}
+          INPUT_REPO: ${{ github.repository }}
+          INPUT_WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          INPUT_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          INPUT_COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+          INPUT_COMMIT_AUTHOR: ${{ steps.author.outputs.name }}
         run: |
           python scripts/ci/ci_failure_monitor.py \
-            --run-id "${{ github.event.workflow_run.id }}" \
-            --repo "${{ github.repository }}" \
-            --workflow-name "${{ github.event.workflow_run.name }}" \
-            --run-url "${{ github.event.workflow_run.html_url }}" \
-            --commit-sha "${{ github.event.workflow_run.head_sha }}" \
-            --commit-author "${{ steps.author.outputs.name }}"
+            --run-id "$INPUT_RUN_ID" \
+            --repo "$INPUT_REPO" \
+            --workflow-name "$INPUT_WORKFLOW_NAME" \
+            --run-url "$INPUT_RUN_URL" \
+            --commit-sha "$INPUT_COMMIT_SHA" \
+            --commit-author "$INPUT_COMMIT_AUTHOR"

--- a/scripts/ci/ci_failure_monitor.py
+++ b/scripts/ci/ci_failure_monitor.py
@@ -1,0 +1,253 @@
+"""CI Failure Monitor — detect failed jobs and create/update GitHub issues.
+
+Triggered by workflow_run completion. Inspects job-level conclusions (not
+run-level, since continue-on-error masks failures) and manages issues:
+- Creates a new issue if no open issue exists for the failed job
+- Appends a comment to the existing open issue if one already exists
+- Multiple failed jobs from the same run are consolidated in one comment
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+EXCLUDED_JOBS = frozenset(
+    {
+        "check-changes",
+        "pr-test-finish",
+        "nightly-test-finish",
+        "nightly-test-daily-finish",
+    }
+)
+
+LABEL = "ci-failure"
+
+
+def gh(*args: str, json_output: bool = False) -> str | dict | list:
+    cmd = ["gh"] + list(args)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        print(f"gh command failed: {' '.join(cmd)}", file=sys.stderr)
+        print(f"stderr: {result.stderr}", file=sys.stderr)
+        raise RuntimeError(f"gh exited {result.returncode}")
+    if json_output:
+        return json.loads(result.stdout)
+    return result.stdout.strip()
+
+
+def get_failed_jobs(run_id: str, repo: str) -> list[dict]:
+    jobs = gh(
+        "api",
+        f"repos/{repo}/actions/runs/{run_id}/jobs",
+        "--paginate",
+        "--jq",
+        ".jobs[]",
+        json_output=True,
+    )
+    if isinstance(jobs, dict):
+        jobs = [jobs]
+
+    failed = []
+    for job in jobs:
+        name = job.get("name", "")
+        conclusion = job.get("conclusion", "")
+        if name in EXCLUDED_JOBS:
+            continue
+        if conclusion in ("failure", "cancelled", "timed_out"):
+            failed.append(
+                {
+                    "name": name,
+                    "conclusion": conclusion,
+                    "html_url": job.get("html_url", ""),
+                    "started_at": job.get("started_at", ""),
+                    "completed_at": job.get("completed_at", ""),
+                    "runner_name": job.get("runner_name", "unknown"),
+                }
+            )
+    return failed
+
+
+def find_open_issue(repo: str, job_name: str) -> dict | None:
+    issues = gh(
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--label",
+        LABEL,
+        "--state",
+        "open",
+        "--search",
+        f"in:title [CI Failure] {job_name}",
+        "--json",
+        "number,title",
+        "--limit",
+        "5",
+        json_output=True,
+    )
+    if not issues:
+        return None
+    expected_title = f"[CI Failure] {job_name}"
+    for issue in issues:
+        if issue["title"] == expected_title:
+            return issue
+    return None
+
+
+def create_issue(repo: str, job_name: str, body: str) -> int:
+    title = f"[CI Failure] {job_name}"
+    result = gh(
+        "issue",
+        "create",
+        "--repo",
+        repo,
+        "--title",
+        title,
+        "--body",
+        body,
+        "--label",
+        LABEL,
+    )
+    print(f"Created issue: {result}")
+    for part in result.split("/"):
+        if part.isdigit():
+            return int(part)
+    return 0
+
+
+def add_comment(repo: str, issue_number: int, body: str) -> None:
+    gh(
+        "issue",
+        "comment",
+        "--repo",
+        repo,
+        str(issue_number),
+        "--body",
+        body,
+    )
+    print(f"Added comment to issue #{issue_number}")
+
+
+def build_issue_body(
+    job_name: str,
+    workflow_name: str,
+    run_id: str,
+    run_url: str,
+    conclusion: str,
+    job_url: str,
+    runner_name: str,
+    commit_sha: str,
+    commit_author: str,
+) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    return f"""## CI Failure: {job_name}
+
+| Field | Value |
+|-------|-------|
+| **Workflow** | {workflow_name} |
+| **Job** | `{job_name}` |
+| **Conclusion** | `{conclusion}` |
+| **Runner** | `{runner_name}` |
+| **Run** | [#{run_id}]({run_url}) |
+| **Job logs** | [View logs]({job_url}) |
+| **Commit** | `{commit_sha[:8]}` by {commit_author} |
+| **Detected at** | {now} |
+
+This issue was auto-created by the CI Failure Monitor.
+"""
+
+
+def build_comment_body(
+    workflow_name: str,
+    run_id: str,
+    run_url: str,
+    failed_jobs: list[dict],
+    commit_sha: str,
+    commit_author: str,
+) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines = [f"### Failure recurrence — {now}\n"]
+    lines.append(
+        f"**Workflow:** {workflow_name} | **Run:** [#{run_id}]({run_url}) | **Commit:** `{commit_sha[:8]}` by {commit_author}\n"
+    )
+
+    if len(failed_jobs) == 1:
+        j = failed_jobs[0]
+        lines.append(
+            f"- **{j['name']}** — `{j['conclusion']}` on `{j['runner_name']}` ([logs]({j['html_url']}))"
+        )
+    else:
+        for j in failed_jobs:
+            lines.append(
+                f"- **{j['name']}** — `{j['conclusion']}` on `{j['runner_name']}` ([logs]({j['html_url']}))"
+            )
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="CI Failure Monitor")
+    parser.add_argument("--run-id", required=True, help="GitHub Actions run ID")
+    parser.add_argument("--repo", required=True, help="owner/repo")
+    parser.add_argument("--workflow-name", required=True, help="Workflow name")
+    parser.add_argument("--run-url", required=True, help="Workflow run URL")
+    parser.add_argument("--commit-sha", required=True, help="Commit SHA")
+    parser.add_argument("--commit-author", default="unknown", help="Commit author")
+    parser.add_argument("--dry-run", action="store_true", help="Print actions without executing")
+    args = parser.parse_args()
+
+    print(f"Checking run {args.run_id} for failed jobs...")
+    failed_jobs = get_failed_jobs(args.run_id, args.repo)
+
+    if not failed_jobs:
+        print("No failed jobs detected. All clear.")
+        return
+
+    print(f"Found {len(failed_jobs)} failed job(s):")
+    for j in failed_jobs:
+        print(f"  - {j['name']}: {j['conclusion']}")
+
+    jobs_by_name: dict[str, list[dict]] = {}
+    for j in failed_jobs:
+        jobs_by_name.setdefault(j["name"], []).append(j)
+
+    for job_name, jobs in jobs_by_name.items():
+        existing = find_open_issue(args.repo, job_name)
+
+        if existing:
+            comment = build_comment_body(
+                args.workflow_name,
+                args.run_id,
+                args.run_url,
+                jobs,
+                args.commit_sha,
+                args.commit_author,
+            )
+            if args.dry_run:
+                print(f"[DRY RUN] Would comment on issue #{existing['number']}:\n{comment}\n")
+            else:
+                add_comment(args.repo, existing["number"], comment)
+        else:
+            j = jobs[0]
+            body = build_issue_body(
+                job_name,
+                args.workflow_name,
+                args.run_id,
+                args.run_url,
+                j["conclusion"],
+                j["html_url"],
+                j["runner_name"],
+                args.commit_sha,
+                args.commit_author,
+            )
+            if args.dry_run:
+                print(f"[DRY RUN] Would create issue for {job_name}:\n{body}\n")
+            else:
+                create_issue(args.repo, job_name, body)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/ci_failure_monitor.py
+++ b/scripts/ci/ci_failure_monitor.py
@@ -17,6 +17,8 @@ from datetime import datetime, timezone
 EXCLUDED_JOBS = frozenset(
     {
         "check-changes",
+        "coordinator",
+        "decide",
         "pr-test-finish",
         "nightly-test-finish",
         "nightly-test-daily-finish",
@@ -28,30 +30,41 @@ LABEL = "ci-failure"
 
 def gh(*args: str, json_output: bool = False) -> str | dict | list:
     cmd = ["gh"] + list(args)
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
     if result.returncode != 0:
         print(f"gh command failed: {' '.join(cmd)}", file=sys.stderr)
         print(f"stderr: {result.stderr}", file=sys.stderr)
         raise RuntimeError(f"gh exited {result.returncode}")
     if json_output:
-        return json.loads(result.stdout)
+        text = result.stdout.strip()
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return [json.loads(line) for line in text.splitlines() if line.strip()]
     return result.stdout.strip()
 
 
 def get_failed_jobs(run_id: str, repo: str) -> list[dict]:
-    jobs = gh(
+    response = gh(
         "api",
         f"repos/{repo}/actions/runs/{run_id}/jobs",
         "--paginate",
-        "--jq",
-        ".jobs[]",
         json_output=True,
     )
-    if isinstance(jobs, dict):
-        jobs = [jobs]
+    if isinstance(response, dict):
+        all_jobs = response.get("jobs", [])
+    elif isinstance(response, list):
+        all_jobs = []
+        for item in response:
+            if isinstance(item, dict) and "jobs" in item:
+                all_jobs.extend(item["jobs"])
+            elif isinstance(item, dict):
+                all_jobs.append(item)
+    else:
+        all_jobs = []
 
     failed = []
-    for job in jobs:
+    for job in all_jobs:
         name = job.get("name", "")
         conclusion = job.get("conclusion", "")
         if name in EXCLUDED_JOBS:
@@ -85,7 +98,7 @@ def find_open_issue(repo: str, job_name: str) -> dict | None:
         "--json",
         "number,title",
         "--limit",
-        "5",
+        "20",
         json_output=True,
     )
     if not issues:

--- a/scripts/ci/ci_failure_monitor.py
+++ b/scripts/ci/ci_failure_monitor.py
@@ -10,6 +10,7 @@ run-level, since continue-on-error masks failures) and manages issues:
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -27,10 +28,16 @@ EXCLUDED_JOBS = frozenset(
 
 LABEL = "ci-failure"
 
+MATRIX_SUFFIX_RE = re.compile(r"\s*\(.*\)$")
+
 
 def gh(*args: str, json_output: bool = False) -> str | dict | list:
     cmd = ["gh"] + list(args)
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    except subprocess.TimeoutExpired:
+        print(f"gh command timed out: {' '.join(cmd)}", file=sys.stderr)
+        raise RuntimeError(f"gh timed out after 180s: {' '.join(cmd)}")
     if result.returncode != 0:
         print(f"gh command failed: {' '.join(cmd)}", file=sys.stderr)
         print(f"stderr: {result.stderr}", file=sys.stderr)
@@ -66,8 +73,9 @@ def get_failed_jobs(run_id: str, repo: str) -> list[dict]:
     failed = []
     for job in all_jobs:
         name = job.get("name", "")
+        base_name = MATRIX_SUFFIX_RE.sub("", name)
         conclusion = job.get("conclusion", "")
-        if name in EXCLUDED_JOBS:
+        if base_name in EXCLUDED_JOBS:
             continue
         if conclusion in ("failure", "timed_out"):
             failed.append(
@@ -225,7 +233,8 @@ def main():
 
     jobs_by_name: dict[str, list[dict]] = {}
     for j in failed_jobs:
-        jobs_by_name.setdefault(j["name"], []).append(j)
+        base_name = MATRIX_SUFFIX_RE.sub("", j["name"])
+        jobs_by_name.setdefault(base_name, []).append(j)
 
     for job_name, jobs in jobs_by_name.items():
         existing = find_open_issue(args.repo, job_name)

--- a/scripts/ci/ci_failure_monitor.py
+++ b/scripts/ci/ci_failure_monitor.py
@@ -9,7 +9,6 @@ run-level, since continue-on-error masks failures) and manages issues:
 
 import argparse
 import json
-import os
 import re
 import subprocess
 import sys

--- a/scripts/ci/ci_failure_monitor.py
+++ b/scripts/ci/ci_failure_monitor.py
@@ -69,7 +69,7 @@ def get_failed_jobs(run_id: str, repo: str) -> list[dict]:
         conclusion = job.get("conclusion", "")
         if name in EXCLUDED_JOBS:
             continue
-        if conclusion in ("failure", "cancelled", "timed_out"):
+        if conclusion in ("failure", "timed_out"):
             failed.append(
                 {
                     "name": name,


### PR DESCRIPTION
## Summary
- Add `ci-failure-monitor.yml` workflow triggered by `workflow_run` completion on Nightly Test, Nightly Test Daily, PR Test, and Release PyPI
- Add `scripts/ci/ci_failure_monitor.py` that inspects **job-level** conclusions (critical: `continue-on-error` masks failures at run level)
- Auto-creates `[CI Failure] <job-name>` issues with the `ci-failure` label when a job fails
- Appends comments to existing open issues on failure recurrence (avoids duplicate issues)
- Excludes administrative jobs (`check-changes`, `*-finish` aggregators)
- Supports `--dry-run` mode for local testing

## Test plan
- [ ] Trigger a nightly workflow manually and verify the monitor runs on completion
- [ ] Verify issue creation with correct labels and formatting
- [ ] Verify comment appending on subsequent failures of the same job
- [ ] Verify `ci-failure` label is created in the repo before first use

Closes #1134