### PR TITLE
ci: move CPU-only unit tests to dedicated CPU runner (#1137)

### DIFF
--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -1,6 +1,10 @@
 name: 'Setup Python venv'
 description: 'Create Python 3.12 venv, install uv and project dependencies'
 inputs:
+  install-target:
+    description: 'Project install target passed to `uv pip install -e` (e.g. "python[cpu]", "python[all]")'
+    required: false
+    default: 'python[all]'
   extra-packages:
     description: 'Space-separated list of extra pip packages to install (e.g. "evalscope==1.0.0")'
     required: false
@@ -11,12 +15,13 @@ runs:
     - name: Create venv and install dependencies
       shell: bash
       env:
+        INSTALL_TARGET: ${{ inputs.install-target }}
         EXTRA_PACKAGES: ${{ inputs.extra-packages }}
       run: |
         python3.12 -m venv .venv
         source .venv/bin/activate
         pip install uv
-        uv pip install -e "python[all]"
+        uv pip install -e "$INSTALL_TARGET"
         if [ -n "$EXTRA_PACKAGES" ]; then
           set -f
           # shellcheck disable=SC2086

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -126,6 +126,7 @@ jobs:
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          USE_DEVICE_TYPE: cpu
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -121,6 +121,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
+        with:
+          install-target: python[cpu]
       - name: Run unit test
         timeout-minutes: 30
         shell: bash
@@ -128,10 +132,6 @@ jobs:
           SGLANG_JAX_IS_IN_CI: true
           USE_DEVICE_TYPE: cpu
         run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install -e "python[cpu]"
           python test/srt/run_suite.py --suite unit-test-cpu
 
   # =============================================== e2e-test ===============================================

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -114,6 +114,25 @@ jobs:
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite unit-test-tpu-v6e-4 --auto-partition-id ${{ matrix.part }} --auto-partition-size 2
 
+  unit-test-cpu:
+    needs: [check-changes]
+    if: github.event.pull_request.draft == false && needs.check-changes.outputs.main_package == 'true'
+    runs-on: arc-runner-cpu
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Run unit test
+        timeout-minutes: 30
+        shell: bash
+        env:
+          SGLANG_JAX_IS_IN_CI: true
+        run: |
+          python3.12 -m venv .venv
+          source .venv/bin/activate
+          pip install uv
+          uv pip install -e "python[cpu]"
+          python test/srt/run_suite.py --suite unit-test-cpu
+
   # =============================================== e2e-test ===============================================
   e2e-test-1-tpu:
     needs: [check-changes]
@@ -306,6 +325,7 @@ jobs:
       accurancy-test-4-tpu,
       unit-test-1-tpu,
       unit-test-4-tpu,
+      unit-test-cpu,
       e2e-test-1-tpu,
       e2e-test-4-tpu,
       pallas-kernel-benchmark,
@@ -319,6 +339,7 @@ jobs:
           echo "check-changes: ${{ needs.check-changes.result }}"
           echo "unit-test-1-tpu: ${{ needs.unit-test-1-tpu.result }}"
           echo "unit-test-4-tpu: ${{ needs.unit-test-4-tpu.result }}"
+          echo "unit-test-cpu: ${{ needs.unit-test-cpu.result }}"
           echo "e2e-test-1-tpu: ${{ needs.e2e-test-1-tpu.result }}"
           echo "e2e-test-4-tpu: ${{ needs.e2e-test-4-tpu.result }}"
           echo "accurancy-test-1-tpu: ${{ needs.accurancy-test-1-tpu.result }}"
@@ -350,6 +371,7 @@ jobs:
             for job_result in \
               "unit-test-1-tpu=${{ needs.unit-test-1-tpu.result }}" \
               "unit-test-4-tpu=${{ needs.unit-test-4-tpu.result }}" \
+              "unit-test-cpu=${{ needs.unit-test-cpu.result }}" \
               "e2e-test-1-tpu=${{ needs.e2e-test-1-tpu.result }}" \
               "e2e-test-4-tpu=${{ needs.e2e-test-4-tpu.result }}" \
               "accurancy-test-1-tpu=${{ needs.accurancy-test-1-tpu.result }}" \

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -482,7 +482,6 @@ suites = {
         TestFile("python/sgl_jax/test/test_sampler.py", 1),
         TestFile("python/sgl_jax/test/test_utils.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_kv_cache.py", 1),
-        TestFile("python/sgl_jax/test/mem_cache/test_radix_cache.py", 1),
         TestFile("python/sgl_jax/test/speculative/test_eagle_tree_build.py", 1),
         TestFile("python/sgl_jax/test/speculative/test_eagle_utils.py", 1),
         TestFile("python/sgl_jax/test/multimodal/test_wan_vae_precision.py", 1),
@@ -514,6 +513,7 @@ suites = {
         TestFile("python/sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_swa_allocator.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_swa_radix_cache.py", 1),
+        TestFile("python/sgl_jax/test/mem_cache/test_radix_cache.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_paged_allocator_multi_dp.py", 1),
     ],
     "unit-test-tpu-v6e-4": [

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -480,9 +480,7 @@ suites = {
         TestFile("python/sgl_jax/test/test_moe_topk.py", 1),
         TestFile("python/sgl_jax/test/kernels/fused_moe_v1_test.py", 9),
         TestFile("python/sgl_jax/test/test_sampler.py", 1),
-        TestFile("python/sgl_jax/test/test_compilation_manager.py", 1),
         TestFile("python/sgl_jax/test/test_utils.py", 1),
-        TestFile("python/sgl_jax/test/test_kernel_utils.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_kv_cache.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_radix_cache.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_swa_radix_cache.py", 1),
@@ -492,23 +490,29 @@ suites = {
         TestFile("python/sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py", 1),
         TestFile("python/sgl_jax/test/speculative/test_eagle_tree_build.py", 1),
         TestFile("python/sgl_jax/test/speculative/test_eagle_utils.py", 1),
-        TestFile("python/sgl_jax/test/speculative/test_spec_info.py", 0.2, runner="pytest"),
-        TestFile("python/sgl_jax/test/models/test_mimo_v2_nextn.py", 0.2, runner="pytest"),
         TestFile("python/sgl_jax/test/multimodal/test_wan_vae_precision.py", 1),
         TestFile("python/sgl_jax/test/multimodal/test_vae_scheduler.py", 2.5),
         TestFile("python/sgl_jax/test/multimodal/test_flash_attention_kernel.py", 1),
         TestFile("python/sgl_jax/test/layers/test_group_rmsnorm.py", 1, runner="pytest"),
         TestFile("test/srt/lora/test_bgmv_backend.py", 4),
         TestFile("test/srt/lora/test_align_lora_accuracy.py", 3.5),
-        # GDN (gated DeltaNet) — CPU-only unit tests; each pins
-        # JAX_PLATFORMS=cpu + 8 fake devices in its header, so they run on
-        # any TPU runner without consuming TPU chips.
-        TestFile("python/sgl_jax/test/kernels/gdn/test_gated_delta.py", 1),
-        TestFile("python/sgl_jax/test/kernels/gdn/test_ragged_gated_delta_rule_ref.py", 1),
         TestFile("python/sgl_jax/test/layers/test_gdn_backend.py", 1),
         TestFile("python/sgl_jax/test/layers/test_merged_column_parallel_linear.py", 1),
         TestFile("python/sgl_jax/test/layers/test_qwen3_5_gated_delta_net.py", 1),
+    ],
+    # CPU-only unit tests — moved off arc-runner-v6e-1 to a dedicated
+    # CPU runner so they don't consume TPU capacity. Either pure
+    # Python / numpy / mocks (no JAX device ops) or JAX kernels whose
+    # header already pins JAX_PLATFORMS=cpu and which target CPU
+    # reference implementations.
+    "unit-test-cpu": [
         TestFile("test/srt/test_tokenizer_manager_event.py", 0.1),
+        TestFile("python/sgl_jax/test/test_compilation_manager.py", 1),
+        TestFile("python/sgl_jax/test/test_kernel_utils.py", 1),
+        TestFile("python/sgl_jax/test/speculative/test_spec_info.py", 0.2, runner="pytest"),
+        TestFile("python/sgl_jax/test/models/test_mimo_v2_nextn.py", 0.2, runner="pytest"),
+        TestFile("python/sgl_jax/test/kernels/gdn/test_gated_delta.py", 1),
+        TestFile("python/sgl_jax/test/kernels/gdn/test_ragged_gated_delta_rule_ref.py", 1),
     ],
     "unit-test-tpu-v6e-4": [
         TestFile("python/sgl_jax/test/test_mesh.py", 1),

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -483,11 +483,6 @@ suites = {
         TestFile("python/sgl_jax/test/test_utils.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_kv_cache.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_radix_cache.py", 1),
-        TestFile("python/sgl_jax/test/mem_cache/test_swa_radix_cache.py", 1),
-        TestFile("python/sgl_jax/test/mem_cache/test_swa_allocator.py", 1),
-        TestFile("python/sgl_jax/test/mem_cache/test_req_to_token_pool.py", 1),
-        TestFile("python/sgl_jax/test/mem_cache/test_paged_allocator_multi_dp.py", 1),
-        TestFile("python/sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py", 1),
         TestFile("python/sgl_jax/test/speculative/test_eagle_tree_build.py", 1),
         TestFile("python/sgl_jax/test/speculative/test_eagle_utils.py", 1),
         TestFile("python/sgl_jax/test/multimodal/test_wan_vae_precision.py", 1),
@@ -504,7 +499,9 @@ suites = {
     # CPU runner so they don't consume TPU capacity. Either pure
     # Python / numpy / mocks (no JAX device ops) or JAX kernels whose
     # header already pins JAX_PLATFORMS=cpu and which target CPU
-    # reference implementations.
+    # reference implementations. mem_cache pool/allocator/cache tests
+    # have a conditional CPU pin gated on USE_DEVICE_TYPE=cpu — the
+    # cpu-test CI job sets that env var.
     "unit-test-cpu": [
         TestFile("test/srt/test_tokenizer_manager_event.py", 0.1),
         TestFile("python/sgl_jax/test/test_compilation_manager.py", 1),
@@ -513,6 +510,11 @@ suites = {
         TestFile("python/sgl_jax/test/models/test_mimo_v2_nextn.py", 0.2, runner="pytest"),
         TestFile("python/sgl_jax/test/kernels/gdn/test_gated_delta.py", 1),
         TestFile("python/sgl_jax/test/kernels/gdn/test_ragged_gated_delta_rule_ref.py", 1),
+        TestFile("python/sgl_jax/test/mem_cache/test_req_to_token_pool.py", 1),
+        TestFile("python/sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py", 1),
+        TestFile("python/sgl_jax/test/mem_cache/test_swa_allocator.py", 1),
+        TestFile("python/sgl_jax/test/mem_cache/test_swa_radix_cache.py", 1),
+        TestFile("python/sgl_jax/test/mem_cache/test_paged_allocator_multi_dp.py", 1),
     ],
     "unit-test-tpu-v6e-4": [
         TestFile("python/sgl_jax/test/test_mesh.py", 1),


### PR DESCRIPTION
## Summary

Implements [#1137](https://github.com/sgl-project/sglang-jax/issues/1137): move pure-CPU unit tests off `arc-runner-v6e-1` onto the dedicated `arc-runner-cpu`, freeing TPU capacity.

- New `unit-test-cpu` suite in `test/srt/run_suite.py` (7 files)
- New `unit-test-cpu` job in `pr-test.yml`: `runs-on: arc-runner-cpu`, installs `python[cpu]` (no `jax[tpu]`), wired into `pr-test-finish` `needs` + success gate
- Removed the same 7 entries from `unit-test-tpu-v6e-1`

## Migrated files

Pure Python / numpy / mocks (no JAX device ops):
- `test/srt/test_tokenizer_manager_event.py`
- `python/sgl_jax/test/test_compilation_manager.py`
- `python/sgl_jax/test/test_kernel_utils.py`
- `python/sgl_jax/test/speculative/test_spec_info.py`
- `python/sgl_jax/test/models/test_mimo_v2_nextn.py`

JAX kernels whose header already pins `JAX_PLATFORMS=cpu` and which target CPU reference implementations:
- `python/sgl_jax/test/kernels/gdn/test_gated_delta.py`
- `python/sgl_jax/test/kernels/gdn/test_ragged_gated_delta_rule_ref.py`

## Intentionally NOT migrated

GDN backend / merged column-parallel linear / Qwen3.5 gated-delta-net glue tests pin CPU in their header but exercise **TPU-targeted backend code paths** (shard_map pipelines, TP layout). Keeping them on the TPU runner preserves import-path coverage on real TPU.

This PR does NOT introduce pytest markers — that is [#1144 (P3-1)](https://github.com/sgl-project/sglang-jax/issues/1144) and is decoupled from this one by going through the existing `run_suite.py` suite-dictionary mechanism.

## Test plan

- [ ] `unit-test-cpu` job runs on `arc-runner-cpu` and passes
- [ ] `unit-test-1-tpu` (TPU runner) no longer runs the 7 migrated files; total wall time goes down
- [ ] Forcing a failure in one of the 7 CPU files blocks `pr-test-finish`
- [ ] No overlap between `unit-test-cpu` and `unit-test-tpu-v6e-1` (verified locally)

Closes #1137