### PR TITLE
feat(weight): support MiMo-V2.5 fused QKV dequant for hybrid attention

### DIFF
--- a/python/sgl_jax/srt/layers/embeddings.py
+++ b/python/sgl_jax/srt/layers/embeddings.py
@@ -620,7 +620,13 @@ def get_rope(
         else:
             raise ValueError("Unknown RoPE scaling type")
 
-        if scaling_type == "llama3":
+        if scaling_type == "default":
+            # HF transformers uses rope_type="default" to mean "no scaling",
+            # equivalent to rope_scaling=None.  Fall back to plain RotaryEmbedding.
+            rotary_emb = RotaryEmbedding(
+                head_size, rotary_dim, max_position, base, is_neox_style, dtype
+            )
+        elif scaling_type == "llama3":
             scaling_factor = rope_scaling["factor"]
             low_freq_factor = rope_scaling["low_freq_factor"]
             high_freq_factor = rope_scaling["high_freq_factor"]

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -552,8 +552,11 @@ class WeightLoader:
 
         head_dim = config.head_dim
         v_head_dim = getattr(config, "v_head_dim", head_dim)
-        num_heads = config.num_attention_heads
-        num_kv_heads = config.num_key_value_heads
+        full_num_heads = config.num_attention_heads
+        full_num_kv_heads = config.num_key_value_heads
+        swa_num_heads = getattr(config, "swa_num_attention_heads", full_num_heads)
+        swa_num_kv_heads = getattr(config, "swa_num_key_value_heads", full_num_kv_heads)
+        hybrid_layer_pattern = getattr(config, "hybrid_layer_pattern", None)
 
         quant_cfg = getattr(config, "quantization_config", None)
         block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
@@ -561,6 +564,17 @@ class WeightLoader:
         tp_sharding = NamedSharding(self.mesh, P(None, "tensor"))
 
         for layer_idx in sorted(fused_qkv_buffers.keys()):
+            # Hybrid SWA/full-attn models (e.g. MiMo-V2.5) can have different
+            # num_kv_heads per layer; pick the correct head counts based on
+            # hybrid_layer_pattern (1=SWA, 0=full).
+            is_swa = (
+                hybrid_layer_pattern is not None
+                and layer_idx < len(hybrid_layer_pattern)
+                and hybrid_layer_pattern[layer_idx] == 1
+            )
+            num_heads = swa_num_heads if is_swa else full_num_heads
+            num_kv_heads = swa_num_kv_heads if is_swa else full_num_kv_heads
+
             buf = fused_qkv_buffers[layer_idx]
             fused_weight = buf["weight"]  # numpy, [total_qkv, hidden], FP8
             fused_scale = buf["scale"]  # numpy, [total_blocks, in_blocks], f32
@@ -699,8 +713,15 @@ class WeightLoader:
         # Try config value first, then smaller divisors (descending)
         kv_candidates = sorted(set(kv_candidates), reverse=True)
 
-        # TP candidates: all divisors of num_heads (covers any quantization-time TP)
-        tp_candidates = sorted(d for d in range(1, num_heads + 1) if num_heads % d == 0)
+        # TP candidates: all divisors of num_heads, descending.  Prefer the
+        # largest TP that matches because the Q/K/V split must reflect the
+        # actual quantization-time sharding.  When per_shard_total is a
+        # multiple of block_size, smaller TP values also satisfy the
+        # dimension check but produce an incorrect Q/K/V split.
+        tp_candidates = sorted(
+            (d for d in range(1, num_heads + 1) if num_heads % d == 0),
+            reverse=True,
+        )
 
         for orig_kv in kv_candidates:
             for tp in tp_candidates:


### PR DESCRIPTION
## Summary
- **dequant_fused_qkv**: support per-layer num_kv_heads in hybrid SWA/full-attn models (e.g. MiMo-V2.5: SWA=8, full=4) by selecting the correct head count from `hybrid_layer_pattern` when splitting Q/K/V from the fused tensor
- **_infer_qkv_shards**: search TP candidates in descending order to prefer the largest match. Fixes a bug where SWA layers with per_shard_total exactly divisible by block_size would incorrectly match TP=1, producing a wrong Q/K/V split and garbled output
- **get_rope**: handle `rope_type="default"` (HF transformers convention for "no scaling"), used by MiMo-V2.5 config

## Background
MiMo-V2.5 uses fused qkv_proj with per-TP-shard block-wise FP8 quantization (TP=4). The checkpoint layout is `[shard0_QKV | shard1_QKV | ...]`, where each shard's Q/K/V are concatenated before quantization (scales can span K/V boundaries).

Previously, `_infer_qkv_shards` returned n_shards=1 for SWA layers because per_shard_total=3712 is a multiple of block_size=128, making TP=1 and TP=4 both pass the dimension check. With TP=1, the split treated the first 12288 rows as Q, but they actually contained interleaved Q/K/V data from all 4 shards — corrupting all three projections and producing nonsensical output.

## Test plan
- [x] Deployed MiMo-V2.5 on TPU v6e-16 (4 hosts, tp=16, dp=4, ep=16) with correct text generation
- [x] Verified no impact on MiMo-V2-Flash (uses split QKV, does not enter this path) or MiMo-V2-Pro (TP=8, only one TP value matches due to non-aligned per_shard_total)