### PR TITLE
ci: stage PR test into 3 phases with fail-fast (P1-3)

### DIFF
--- a/.github/workflows/coordinator.yml
+++ b/.github/workflows/coordinator.yml
@@ -33,7 +33,6 @@ on:
       should_run:
         description: "Should any tests run (not draft AND has relevant changes)"
         value: ${{ jobs.decide.outputs.should_run }}
-  workflow_dispatch:
 
 jobs:
   decide:

--- a/.github/workflows/coordinator.yml
+++ b/.github/workflows/coordinator.yml
@@ -33,6 +33,7 @@ on:
       should_run:
         description: "Should any tests run (not draft AND has relevant changes)"
         value: ${{ jobs.decide.outputs.should_run }}
+  workflow_dispatch:
 
 jobs:
   decide:
@@ -70,12 +71,15 @@ jobs:
 
       - name: Detect PR metadata
         id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            is_draft="${{ github.event.pull_request.draft }}"
-            head_repo="${{ github.event.pull_request.head.repo.full_name }}"
-            base_repo="${{ github.event.pull_request.base.repo.full_name }}"
-            if [ "$head_repo" != "$base_repo" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            is_draft="$PR_DRAFT"
+            if [ "$PR_HEAD_REPO" != "$PR_BASE_REPO" ]; then
               is_fork="true"
             else
               is_fork="false"
@@ -89,6 +93,9 @@ jobs:
 
       - name: Detect labels and commit message
         id: labels
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           run_full="false"
           requires_4tpu="false"
@@ -96,21 +103,20 @@ jobs:
           run_perf_trace="false"
           run_accuracy_extra="false"
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
-            if echo "$LABELS" | grep -q '"test:full"'; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if echo "$PR_LABELS" | grep -q '"test:full"'; then
               run_full="true"
             fi
-            if echo "$LABELS" | grep -q '"test:multi-chip"'; then
+            if echo "$PR_LABELS" | grep -q '"test:multi-chip"'; then
               requires_4tpu="true"
             fi
-            if echo "$LABELS" | grep -q '"test:perf"'; then
+            if echo "$PR_LABELS" | grep -q '"test:perf"'; then
               run_perf="true"
             fi
-            if echo "$LABELS" | grep -q '"test:perf-trace"'; then
+            if echo "$PR_LABELS" | grep -q '"test:perf-trace"'; then
               run_perf_trace="true"
             fi
-            if echo "$LABELS" | grep -q '"test:accuracy-extra"'; then
+            if echo "$PR_LABELS" | grep -q '"test:accuracy-extra"'; then
               run_accuracy_extra="true"
             fi
           fi

--- a/.github/workflows/coordinator.yml
+++ b/.github/workflows/coordinator.yml
@@ -1,0 +1,155 @@
+name: Coordinator
+
+on:
+  workflow_call:
+    outputs:
+      main_package:
+        description: "PR changed main package code"
+        value: ${{ jobs.decide.outputs.main_package }}
+      pallas_kernel:
+        description: "PR changed Pallas kernel code"
+        value: ${{ jobs.decide.outputs.pallas_kernel }}
+      is_draft:
+        description: "PR is a draft"
+        value: ${{ jobs.decide.outputs.is_draft }}
+      is_fork_pr:
+        description: "PR comes from a fork"
+        value: ${{ jobs.decide.outputs.is_fork_pr }}
+      run_full:
+        description: "Run full test suite (label test:full or [full-ci] in commit msg)"
+        value: ${{ jobs.decide.outputs.run_full }}
+      requires_4tpu:
+        description: "Run 4-TPU tests (label test:multi-chip or distributed path changes)"
+        value: ${{ jobs.decide.outputs.requires_4tpu }}
+      run_perf:
+        description: "Run performance tests (label test:perf)"
+        value: ${{ jobs.decide.outputs.run_perf }}
+      run_perf_trace:
+        description: "Run performance trace tests (label test:perf-trace)"
+        value: ${{ jobs.decide.outputs.run_perf_trace }}
+      run_accuracy_extra:
+        description: "Run extra accuracy tests (label test:accuracy-extra)"
+        value: ${{ jobs.decide.outputs.run_accuracy_extra }}
+      should_run:
+        description: "Should any tests run (not draft AND has relevant changes)"
+        value: ${{ jobs.decide.outputs.should_run }}
+
+jobs:
+  decide:
+    runs-on: ubuntu-latest
+    outputs:
+      main_package: ${{ steps.filter.outputs.main_package }}
+      pallas_kernel: ${{ steps.filter.outputs.pallas_kernel }}
+      is_draft: ${{ steps.meta.outputs.is_draft }}
+      is_fork_pr: ${{ steps.meta.outputs.is_fork_pr }}
+      run_full: ${{ steps.labels.outputs.run_full }}
+      requires_4tpu: ${{ steps.labels.outputs.requires_4tpu }}
+      run_perf: ${{ steps.labels.outputs.run_perf }}
+      run_perf_trace: ${{ steps.labels.outputs.run_perf_trace }}
+      run_accuracy_extra: ${{ steps.labels.outputs.run_accuracy_extra }}
+      should_run: ${{ steps.summary.outputs.should_run }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Detect file changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            main_package:
+              - "python/sgl_jax/**"
+              - "python/*.toml"
+              - "scripts/**"
+              - "test/**"
+              - ".github/workflows/pr-test.yml"
+            pallas_kernel:
+              - "python/sgl_jax/kernels/**"
+              - "benchmark/kernels/**"
+              - ".github/workflows/pr-test.yml"
+
+      - name: Detect PR metadata
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            is_draft="${{ github.event.pull_request.draft }}"
+            head_repo="${{ github.event.pull_request.head.repo.full_name }}"
+            base_repo="${{ github.event.pull_request.base.repo.full_name }}"
+            if [ "$head_repo" != "$base_repo" ]; then
+              is_fork="true"
+            else
+              is_fork="false"
+            fi
+          else
+            is_draft="false"
+            is_fork="false"
+          fi
+          echo "is_draft=$is_draft" >> $GITHUB_OUTPUT
+          echo "is_fork_pr=$is_fork" >> $GITHUB_OUTPUT
+
+      - name: Detect labels and commit message
+        id: labels
+        run: |
+          run_full="false"
+          requires_4tpu="false"
+          run_perf="false"
+          run_perf_trace="false"
+          run_accuracy_extra="false"
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+            if echo "$LABELS" | grep -q '"test:full"'; then
+              run_full="true"
+            fi
+            if echo "$LABELS" | grep -q '"test:multi-chip"'; then
+              requires_4tpu="true"
+            fi
+            if echo "$LABELS" | grep -q '"test:perf"'; then
+              run_perf="true"
+            fi
+            if echo "$LABELS" | grep -q '"test:perf-trace"'; then
+              run_perf_trace="true"
+            fi
+            if echo "$LABELS" | grep -q '"test:accuracy-extra"'; then
+              run_accuracy_extra="true"
+            fi
+          fi
+
+          COMMIT_MSG=$(git log -1 --format='%s %b')
+          if echo "$COMMIT_MSG" | grep -qi '\[full-ci\]'; then
+            run_full="true"
+          fi
+
+          echo "run_full=$run_full" >> $GITHUB_OUTPUT
+          echo "requires_4tpu=$requires_4tpu" >> $GITHUB_OUTPUT
+          echo "run_perf=$run_perf" >> $GITHUB_OUTPUT
+          echo "run_perf_trace=$run_perf_trace" >> $GITHUB_OUTPUT
+          echo "run_accuracy_extra=$run_accuracy_extra" >> $GITHUB_OUTPUT
+
+      - name: Summarize decisions
+        id: summary
+        run: |
+          is_draft="${{ steps.meta.outputs.is_draft }}"
+          main_package="${{ steps.filter.outputs.main_package }}"
+          pallas_kernel="${{ steps.filter.outputs.pallas_kernel }}"
+
+          if [ "$is_draft" = "true" ]; then
+            should_run="false"
+          elif [ "$main_package" = "true" ] || [ "$pallas_kernel" = "true" ]; then
+            should_run="true"
+          else
+            should_run="false"
+          fi
+          echo "should_run=$should_run" >> $GITHUB_OUTPUT
+
+          echo "=== Coordinator Decisions ==="
+          echo "main_package: $main_package"
+          echo "pallas_kernel: $pallas_kernel"
+          echo "is_draft: $is_draft"
+          echo "is_fork_pr: ${{ steps.meta.outputs.is_fork_pr }}"
+          echo "run_full: ${{ steps.labels.outputs.run_full }}"
+          echo "requires_4tpu: ${{ steps.labels.outputs.requires_4tpu }}"
+          echo "run_perf: ${{ steps.labels.outputs.run_perf }}"
+          echo "run_perf_trace: ${{ steps.labels.outputs.run_perf_trace }}"
+          echo "run_accuracy_extra: ${{ steps.labels.outputs.run_accuracy_extra }}"
+          echo "should_run: $should_run"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -25,8 +25,8 @@ on:
       - ".github/workflows/pr-test.yml"
 
 concurrency:
-  group: pr-test-${{ github.ref }}
-  cancel-in-progress: true
+  group: pr-test-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # =============================================== coordinator ====================================================

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -316,6 +316,13 @@ jobs:
             exit 1
           fi
 
+          # If coordinator decided not to run tests (e.g. draft PR), skips are by-design
+          should_run="${{ needs.coordinator.outputs.should_run }}"
+          if [ "$should_run" != "true" ]; then
+            echo "should_run is false (e.g. draft PR) — all test skips are by design"
+            exit 0
+          fi
+
           # If no relevant files changed, all test skips are by-design
           main_package="${{ needs.coordinator.outputs.main_package }}"
           pallas_kernel="${{ needs.coordinator.outputs.pallas_kernel }}"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -29,47 +29,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # =============================================== check changes ====================================================
-  check-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      main_package: ${{ steps.filter.outputs.main_package }}
-      pallas_kernel: ${{ steps.filter.outputs.pallas_kernel }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-      # TODO: use run-ci label when sglang-jax-bot exists
-      # - name: Fail if the PR does not have the 'run-ci' label
-      #   if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-ci')
-      #   run: |
-      #     echo "This pull request does not have the 'run-ci' label. Failing the workflow."
-      #     exit 1
-
-      - name: Fail if the PR is a draft
-        if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
-        run: |
-          echo "This pull request is a draft. Failing the workflow."
-          exit 1
-
-      - name: Detect file changes
-        id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            main_package:
-              - "python/sgl_jax/**"
-              - "python/*.toml"
-              - "scripts/**"
-              - "test/**"
-              - ".github/workflows/pr-test.yml"
-            pallas_kernel:
-              - "python/sgl_jax/kernels/**"
-              - "benchmark/kernels/**"
-              - ".github/workflows/pr-test.yml"
+  # =============================================== coordinator ====================================================
+  coordinator:
+    uses: ./.github/workflows/coordinator.yml
   # =============================================== unit-test ====================================================
   unit-test-1-tpu:
-    needs: [check-changes]
-    if: github.event.pull_request.draft == false && needs.check-changes.outputs.main_package == 'true'
+    needs: [coordinator]
+    if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
     runs-on: arc-runner-v6e-1
     #runs-on: ubuntu-slim
     strategy:
@@ -93,8 +59,8 @@ jobs:
           python test/srt/run_suite.py --suite unit-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 3
 
   unit-test-4-tpu:
-    needs: [check-changes]
-    if: github.event.pull_request.draft == false && needs.check-changes.outputs.main_package == 'true'
+    needs: [coordinator]
+    if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
     runs-on: arc-runner-v6e-4
     strategy:
       fail-fast: false
@@ -118,8 +84,8 @@ jobs:
 
   # =============================================== e2e-test ===============================================
   e2e-test-1-tpu:
-    needs: [check-changes]
-    if: github.event.pull_request.draft == false && needs.check-changes.outputs.main_package == 'true'
+    needs: [coordinator]
+    if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
     runs-on: arc-runner-v6e-1
     strategy:
       fail-fast: false
@@ -146,8 +112,8 @@ jobs:
 
 
   e2e-test-4-tpu:
-    needs: [check-changes]
-    if: github.event.pull_request.draft == false && needs.check-changes.outputs.main_package == 'true'
+    needs: [coordinator]
+    if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
     runs-on: arc-runner-v6e-4
     strategy:
       fail-fast: false
@@ -174,8 +140,8 @@ jobs:
 
   # =============================================== accurancy-test ===============================================
   accurancy-test-1-tpu:
-    needs: [check-changes]
-    if: github.event.pull_request.draft == false && needs.check-changes.outputs.main_package == 'true'
+    needs: [coordinator]
+    if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
     runs-on: arc-runner-v6e-1
     strategy:
       fail-fast: false
@@ -201,8 +167,8 @@ jobs:
           python test/srt/run_suite.py --suite accuracy-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 1
 
   accurancy-test-4-tpu:
-    needs: [check-changes]
-    if: github.event.pull_request.draft == false && needs.check-changes.outputs.main_package == 'true'
+    needs: [coordinator]
+    if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
 
     runs-on: arc-runner-v6e-4
     strategy:
@@ -230,8 +196,8 @@ jobs:
 
   # =============================================== performance-test ===============================================
   performance-test-1-tpu:
-    needs: [check-changes]
-    if: github.event.pull_request.draft == false && needs.check-changes.outputs.main_package == 'true'
+    needs: [coordinator]
+    if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
 
     runs-on: arc-runner-v6e-1
     strategy:
@@ -258,8 +224,8 @@ jobs:
           python test/srt/run_suite.py --suite performance-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 1
 
   performance-test-4-tpu:
-    needs: [check-changes]
-    if: github.event.pull_request.draft == false && needs.check-changes.outputs.main_package == 'true'
+    needs: [coordinator]
+    if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
 
     runs-on: arc-runner-v6e-4
     strategy:
@@ -288,8 +254,8 @@ jobs:
 
   # =============================================== kernel-benchmark ===============================================
   pallas-kernel-benchmark:
-    needs: [check-changes]
-    if: github.event.pull_request.draft == false && needs.check-changes.outputs.pallas_kernel == 'true'
+    needs: [coordinator]
+    if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.pallas_kernel == 'true'
     runs-on: arc-runner-v6e-1
     strategy:
       fail-fast: false
@@ -315,7 +281,7 @@ jobs:
 
   pr-test-finish:
     needs: [
-      check-changes,
+      coordinator,
       performance-test-1-tpu,
       performance-test-4-tpu,
       accurancy-test-1-tpu,
@@ -332,7 +298,7 @@ jobs:
       - name: Check all dependent job statuses
         run: |
           echo "=== Job Results ==="
-          echo "check-changes: ${{ needs.check-changes.result }}"
+          echo "coordinator: ${{ needs.coordinator.result }}"
           echo "unit-test-1-tpu: ${{ needs.unit-test-1-tpu.result }}"
           echo "unit-test-4-tpu: ${{ needs.unit-test-4-tpu.result }}"
           echo "e2e-test-1-tpu: ${{ needs.e2e-test-1-tpu.result }}"
@@ -344,15 +310,15 @@ jobs:
           echo "pallas-kernel-benchmark: ${{ needs.pallas-kernel-benchmark.result }}"
           echo ""
 
-          # check-changes must succeed
-          if [ "${{ needs.check-changes.result }}" != "success" ]; then
-            echo "::error::check-changes did not succeed: ${{ needs.check-changes.result }}"
+          # coordinator must succeed
+          if [ "${{ needs.coordinator.result }}" != "success" ]; then
+            echo "::error::coordinator did not succeed: ${{ needs.coordinator.result }}"
             exit 1
           fi
 
           # If no relevant files changed, all test skips are by-design
-          main_package="${{ needs.check-changes.outputs.main_package }}"
-          pallas_kernel="${{ needs.check-changes.outputs.pallas_kernel }}"
+          main_package="${{ needs.coordinator.outputs.main_package }}"
+          pallas_kernel="${{ needs.coordinator.outputs.pallas_kernel }}"
 
           if [ "$main_package" != "true" ] && [ "$pallas_kernel" != "true" ]; then
             echo "No relevant file changes detected — all test skips are by design"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -32,12 +32,12 @@ jobs:
   # =============================================== coordinator ====================================================
   coordinator:
     uses: ./.github/workflows/coordinator.yml
-  # =============================================== unit-test ====================================================
+
+  # =============================================== Stage 1: fast unit tests ========================================
   unit-test-1-tpu:
     needs: [coordinator]
     if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
     runs-on: arc-runner-v6e-1
-    #runs-on: ubuntu-slim
     strategy:
       fail-fast: false
       matrix:
@@ -58,8 +58,19 @@ jobs:
           uv pip install -e "python[all]"
           python test/srt/run_suite.py --suite unit-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 3
 
-  unit-test-4-tpu:
+  cpu-test:
     needs: [coordinator]
+    if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run CPU tests (placeholder)
+        timeout-minutes: 10
+        run: |
+          echo "cpu-test suite not yet available, skipping"
+
+  # =============================================== Stage 2: multi-chip + e2e + accuracy ============================
+  unit-test-4-tpu:
+    needs: [coordinator, unit-test-1-tpu, cpu-test]
     if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
     runs-on: arc-runner-v6e-4
     strategy:
@@ -82,9 +93,8 @@ jobs:
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite unit-test-tpu-v6e-4 --auto-partition-id ${{ matrix.part }} --auto-partition-size 2
 
-  # =============================================== e2e-test ===============================================
   e2e-test-1-tpu:
-    needs: [coordinator]
+    needs: [coordinator, unit-test-1-tpu, cpu-test]
     if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
     runs-on: arc-runner-v6e-1
     strategy:
@@ -110,9 +120,8 @@ jobs:
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite e2e-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 1
 
-
   e2e-test-4-tpu:
-    needs: [coordinator]
+    needs: [coordinator, unit-test-1-tpu, cpu-test]
     if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
     runs-on: arc-runner-v6e-4
     strategy:
@@ -138,9 +147,8 @@ jobs:
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite e2e-test-tpu-v6e-4 --auto-partition-id ${{ matrix.part }} --auto-partition-size 3
 
-  # =============================================== accurancy-test ===============================================
-  accurancy-test-1-tpu:
-    needs: [coordinator]
+  accuracy-test-1-tpu:
+    needs: [coordinator, unit-test-1-tpu, cpu-test]
     if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
     runs-on: arc-runner-v6e-1
     strategy:
@@ -149,8 +157,7 @@ jobs:
         part: [0]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@v5
       - name: Evaluate accuracy
         timeout-minutes: 20
         env:
@@ -166,10 +173,9 @@ jobs:
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite accuracy-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 1
 
-  accurancy-test-4-tpu:
-    needs: [coordinator]
+  accuracy-test-4-tpu:
+    needs: [coordinator, unit-test-1-tpu, cpu-test]
     if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
-
     runs-on: arc-runner-v6e-4
     strategy:
       fail-fast: false
@@ -177,8 +183,7 @@ jobs:
         part: [0]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@v5
       - name: Evaluate MoE accuracy (TP=4)
         timeout-minutes: 50
         env:
@@ -194,11 +199,10 @@ jobs:
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite accuracy-test-tpu-v6e-4 --timeout-per-file 3000 --auto-partition-id ${{ matrix.part }} --auto-partition-size 1
 
-  # =============================================== performance-test ===============================================
+  # =============================================== Stage 3: performance benchmarks =================================
   performance-test-1-tpu:
-    needs: [coordinator]
+    needs: [coordinator, unit-test-4-tpu, e2e-test-1-tpu, e2e-test-4-tpu, accuracy-test-1-tpu, accuracy-test-4-tpu]
     if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
-
     runs-on: arc-runner-v6e-1
     strategy:
       fail-fast: false
@@ -206,8 +210,7 @@ jobs:
         part: [0]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@v5
       - name: Benchmark performance
         timeout-minutes: 30
         env:
@@ -224,9 +227,8 @@ jobs:
           python test/srt/run_suite.py --suite performance-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 1
 
   performance-test-4-tpu:
-    needs: [coordinator]
+    needs: [coordinator, unit-test-4-tpu, e2e-test-1-tpu, e2e-test-4-tpu, accuracy-test-1-tpu, accuracy-test-4-tpu]
     if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.main_package == 'true'
-
     runs-on: arc-runner-v6e-4
     strategy:
       fail-fast: false
@@ -234,11 +236,9 @@ jobs:
         part: [0, 1]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@v5
       - name: Benchmark performance (tp=4)
         timeout-minutes: 50
-
         env:
           SGLANG_JAX_IS_IN_CI: true
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
@@ -252,7 +252,8 @@ jobs:
           bash scripts/killall_sglang.sh
           python test/srt/run_suite.py --suite performance-test-tpu-v6e-4 --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 3000
 
-  # =============================================== kernel-benchmark ===============================================
+  # =============================================== kernel benchmark (independent) ==================================
+  # Independent of the stage chain: triggered by pallas_kernel changes, not main_package.
   pallas-kernel-benchmark:
     needs: [coordinator]
     if: needs.coordinator.outputs.should_run == 'true' && needs.coordinator.outputs.pallas_kernel == 'true'
@@ -279,17 +280,19 @@ jobs:
           uv pip install -e "python[all]"
           python test/srt/run_suite.py --suite kernel-performance-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 2
 
+  # =============================================== finish gate =====================================================
   pr-test-finish:
     needs: [
       coordinator,
-      performance-test-1-tpu,
-      performance-test-4-tpu,
-      accurancy-test-1-tpu,
-      accurancy-test-4-tpu,
       unit-test-1-tpu,
+      cpu-test,
       unit-test-4-tpu,
       e2e-test-1-tpu,
       e2e-test-4-tpu,
+      accuracy-test-1-tpu,
+      accuracy-test-4-tpu,
+      performance-test-1-tpu,
+      performance-test-4-tpu,
       pallas-kernel-benchmark,
     ]
     if: always()
@@ -299,14 +302,23 @@ jobs:
         run: |
           echo "=== Job Results ==="
           echo "coordinator: ${{ needs.coordinator.result }}"
+          echo ""
+          echo "--- Stage 1 ---"
           echo "unit-test-1-tpu: ${{ needs.unit-test-1-tpu.result }}"
+          echo "cpu-test: ${{ needs.cpu-test.result }}"
+          echo ""
+          echo "--- Stage 2 ---"
           echo "unit-test-4-tpu: ${{ needs.unit-test-4-tpu.result }}"
           echo "e2e-test-1-tpu: ${{ needs.e2e-test-1-tpu.result }}"
           echo "e2e-test-4-tpu: ${{ needs.e2e-test-4-tpu.result }}"
-          echo "accurancy-test-1-tpu: ${{ needs.accurancy-test-1-tpu.result }}"
-          echo "accurancy-test-4-tpu: ${{ needs.accurancy-test-4-tpu.result }}"
+          echo "accuracy-test-1-tpu: ${{ needs.accuracy-test-1-tpu.result }}"
+          echo "accuracy-test-4-tpu: ${{ needs.accuracy-test-4-tpu.result }}"
+          echo ""
+          echo "--- Stage 3 ---"
           echo "performance-test-1-tpu: ${{ needs.performance-test-1-tpu.result }}"
           echo "performance-test-4-tpu: ${{ needs.performance-test-4-tpu.result }}"
+          echo ""
+          echo "--- Independent ---"
           echo "pallas-kernel-benchmark: ${{ needs.pallas-kernel-benchmark.result }}"
           echo ""
 
@@ -338,11 +350,12 @@ jobs:
           if [ "$main_package" = "true" ]; then
             for job_result in \
               "unit-test-1-tpu=${{ needs.unit-test-1-tpu.result }}" \
+              "cpu-test=${{ needs.cpu-test.result }}" \
               "unit-test-4-tpu=${{ needs.unit-test-4-tpu.result }}" \
               "e2e-test-1-tpu=${{ needs.e2e-test-1-tpu.result }}" \
               "e2e-test-4-tpu=${{ needs.e2e-test-4-tpu.result }}" \
-              "accurancy-test-1-tpu=${{ needs.accurancy-test-1-tpu.result }}" \
-              "accurancy-test-4-tpu=${{ needs.accurancy-test-4-tpu.result }}" \
+              "accuracy-test-1-tpu=${{ needs.accuracy-test-1-tpu.result }}" \
+              "accuracy-test-4-tpu=${{ needs.accuracy-test-4-tpu.result }}" \
               "performance-test-1-tpu=${{ needs.performance-test-1-tpu.result }}" \
               "performance-test-4-tpu=${{ needs.performance-test-4-tpu.result }}"; do
               job_name="${job_result%%=*}"

--- a/docs/developer_guide/ci_architecture.md
+++ b/docs/developer_guide/ci_architecture.md
@@ -68,8 +68,8 @@ Testing follows a progressive strategy:
 | unit-test-4-tpu | 4x TPU | - | All unit test pass|
 | performance-test-1-tpu (including cache miss check) | 1x TPU | - | Latency, Throughput|
 | performance-test-4-tpu (including cache miss check) | 4x TPU | - | Latency, Throughput|
-| accurancy-test-1-tpu | 1x TPU | - | Model Evaluation  |
-| accurancy-test-4-tpu | 4x TPU | - | Model Evaluation  |
+| accuracy-test-1-tpu | 1x TPU | - | Model Evaluation  |
+| accuracy-test-4-tpu | 4x TPU | - | Model Evaluation  |
 | pallas-kernel-benchmark | 1x TPU | - | Speed |
 | e2e-test-1-tpu | 1x TPU | - | Accuracy |
 | e2e-test-4-tpu | 4x TPU | - | Accuracy |
@@ -96,8 +96,8 @@ Coming soon
 | unit-test-4-tpu | 4x TPU | - | All unit test pass|
 | performance-test-1-tpu (including cache miss check) | 1x TPU | - | Latency, Throughput|
 | performance-test-4-tpu (including cache miss check) | 4x TPU | - | Latency, Throughput|
-| accurancy-test-1-tpu | 1x TPU | - | Model Evaluation  |
-| accurancy-test-4-tpu | 4x TPU | - | Model Evaluation  |
+| accuracy-test-1-tpu | 1x TPU | - | Model Evaluation  |
+| accuracy-test-4-tpu | 4x TPU | - | Model Evaluation  |
 | pallas-kernel-benchmark | 1x TPU | - | Speed |
 | e2e-test-1-tpu | 1x TPU | - | Accuracy |
 | e2e-test-4-tpu | 4x TPU | - | Accuracy |


### PR DESCRIPTION
## Summary

- Restructure `pr-test.yml` from flat parallel execution into a **3-stage pipeline** with fail-fast behavior, so Stage 1 failures skip expensive downstream jobs and save TPU resources
- Fix `accurancy` → `accuracy` typo in job IDs and docs
- Add `cpu-test` placeholder job in Stage 1 (to be enabled by #1163)

### Stage Design

```
coordinator
  ├─ unit-test-1-tpu        (Stage 1, v6e-1 ×3)
  ├─ cpu-test                (Stage 1, placeholder)
  │
  │  ── Stage 1 pass ──
  │
  ├─ unit-test-4-tpu        (Stage 2, v6e-4 ×2)
  ├─ e2e-test-1-tpu         (Stage 2, v6e-1 ×1)
  ├─ e2e-test-4-tpu         (Stage 2, v6e-4 ×3)
  ├─ accuracy-test-1-tpu    (Stage 2, v6e-1 ×1)
  ├─ accuracy-test-4-tpu    (Stage 2, v6e-4 ×1)
  │
  │  ── Stage 2 pass ──
  │
  ├─ performance-test-1-tpu (Stage 3, v6e-1 ×1)
  ├─ performance-test-4-tpu (Stage 3, v6e-4 ×2)
  │
  └─ pallas-kernel-benchmark (independent, v6e-1 ×2)

  └─ pr-test-finish          (always, aggregates all results)
```

`pallas-kernel-benchmark` is kept independent of the stage chain because it is triggered by `pallas_kernel` changes (different condition than `main_package`).

### Dependencies

- Depends on #1160 and #1162 (rebase after merge)

## Test plan

- [x] YAML syntax validated (`yaml.safe_load`)
- [x] `accurancy` fully removed (`grep -rn` confirms zero remaining occurrences)
- [x] All `checkout@v5` standardized
- [x] Code review passed (stage chain, `if:` conditions, `pr-test-finish` references)
- [ ] CI run validates stage dependency chain end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)