### PR TITLE
ci: add AI-assisted root cause analysis for CI failures (P2-1)

### DIFF
--- a/.github/workflows/ci-auto-bisect.yml
+++ b/.github/workflows/ci-auto-bisect.yml
@@ -49,12 +49,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          INPUT_RUN_ID: ${{ inputs.run_id || github.event.client_payload.run_id }}
+          INPUT_ISSUE_NUMBER: ${{ inputs.issue_number || github.event.client_payload.issue_number }}
         run: |
+          if [[ ! "$INPUT_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "Error: run_id must be numeric, got: $INPUT_RUN_ID"
+            exit 1
+          fi
+          if [[ -n "$INPUT_ISSUE_NUMBER" && ! "$INPUT_ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Error: issue_number must be numeric, got: $INPUT_ISSUE_NUMBER"
+            exit 1
+          fi
+          ISSUE_ARG=""
+          if [[ -n "$INPUT_ISSUE_NUMBER" ]]; then
+            ISSUE_ARG="--issue-number $INPUT_ISSUE_NUMBER"
+          fi
           python scripts/ci/ci_auto_bisect.py \
-            --repo ${{ github.repository }} \
-            --run-id ${{ inputs.run_id || github.event.client_payload.run_id }} \
-            ${{ inputs.issue_number && format('--issue-number {0}', inputs.issue_number) || '' }} \
-            ${{ github.event.client_payload.issue_number && format('--issue-number {0}', github.event.client_payload.issue_number) || '' }}
+            --repo "${{ github.repository }}" \
+            --run-id "$INPUT_RUN_ID" \
+            $ISSUE_ARG
 
       - name: Upload Analysis Results
         if: always()

--- a/.github/workflows/ci-auto-bisect.yml
+++ b/.github/workflows/ci-auto-bisect.yml
@@ -48,7 +48,8 @@ jobs:
         id: bisect
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           INPUT_RUN_ID: ${{ inputs.run_id || github.event.client_payload.run_id }}
           INPUT_ISSUE_NUMBER: ${{ inputs.issue_number || github.event.client_payload.issue_number }}
         run: |

--- a/.github/workflows/ci-auto-bisect.yml
+++ b/.github/workflows/ci-auto-bisect.yml
@@ -1,0 +1,66 @@
+name: CI Auto Bisect
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Failed workflow run ID to analyze'
+        required: true
+        type: string
+      issue_number:
+        description: 'Issue number to comment results on (optional)'
+        required: false
+        type: string
+  repository_dispatch:
+    types: [analysis_request]
+
+concurrency:
+  group: ci-auto-bisect
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+jobs:
+  auto-bisect:
+    if: github.repository == 'sgl-project/sglang-jax'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests anthropic
+
+      - name: Run Auto Bisect
+        id: bisect
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python scripts/ci/ci_auto_bisect.py \
+            --repo ${{ github.repository }} \
+            --run-id ${{ inputs.run_id || github.event.client_payload.run_id }} \
+            ${{ inputs.issue_number && format('--issue-number {0}', inputs.issue_number) || '' }} \
+            ${{ github.event.client_payload.issue_number && format('--issue-number {0}', github.event.client_payload.issue_number) || '' }}
+
+      - name: Upload Analysis Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-auto-bisect-${{ github.run_number }}
+          path: analysis_result.json
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/ci-auto-bisect.yml
+++ b/.github/workflows/ci-auto-bisect.yml
@@ -15,8 +15,8 @@ on:
     types: [analysis_request]
 
 concurrency:
-  group: ci-auto-bisect
-  cancel-in-progress: true
+  group: ci-auto-bisect-${{ inputs.run_id || github.event.client_payload.run_id || github.run_id }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -31,8 +31,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -52,7 +50,12 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           INPUT_RUN_ID: ${{ inputs.run_id || github.event.client_payload.run_id }}
           INPUT_ISSUE_NUMBER: ${{ inputs.issue_number || github.event.client_payload.issue_number }}
+          INPUT_REPO: ${{ github.repository }}
         run: |
+          if [[ -z "$INPUT_RUN_ID" ]]; then
+            echo "Error: run_id is required but was not provided"
+            exit 1
+          fi
           if [[ ! "$INPUT_RUN_ID" =~ ^[0-9]+$ ]]; then
             echo "Error: run_id must be numeric, got: $INPUT_RUN_ID"
             exit 1
@@ -61,14 +64,14 @@ jobs:
             echo "Error: issue_number must be numeric, got: $INPUT_ISSUE_NUMBER"
             exit 1
           fi
-          ISSUE_ARG=""
+          ISSUE_ARGS=()
           if [[ -n "$INPUT_ISSUE_NUMBER" ]]; then
-            ISSUE_ARG="--issue-number $INPUT_ISSUE_NUMBER"
+            ISSUE_ARGS=(--issue-number "$INPUT_ISSUE_NUMBER")
           fi
           python scripts/ci/ci_auto_bisect.py \
-            --repo "${{ github.repository }}" \
+            --repo "$INPUT_REPO" \
             --run-id "$INPUT_RUN_ID" \
-            $ISSUE_ARG
+            "${ISSUE_ARGS[@]}"
 
       - name: Upload Analysis Results
         if: always()

--- a/scripts/ci/ci_auto_bisect.py
+++ b/scripts/ci/ci_auto_bisect.py
@@ -194,13 +194,15 @@ def analyze_with_claude(failed_jobs_info, commit_diff, run_info, api_key, base_u
             return response.content[0].text
         except anthropic.RateLimitError:
             if attempt < 2:
-                time.sleep(4**attempt)
+                delay = 30 * (attempt + 1)
+                print(f"Rate limited, waiting {delay}s before retry...")
+                time.sleep(delay)
             else:
                 raise
         except Exception as e:
             print(f"Claude API error (attempt {attempt + 1}): {e}")
             if attempt < 2:
-                time.sleep(2**attempt)
+                time.sleep(5 * (attempt + 1))
             else:
                 raise
 
@@ -377,13 +379,17 @@ def main():
             f.write(report)
 
     print("Analysis complete!")
-    # Exit with non-zero if it's a confirmed regression, to signal urgency to callers
     known_classifications = {"code_regression", "flaky_test", "infrastructure", "environment"}
     classification = parsed.get("classification")
     if classification not in known_classifications:
         classification = "unknown"
-    if classification == "code_regression" and parsed.get("confidence") == "high":
-        sys.exit(1)
+
+    # Write classification to GITHUB_OUTPUT for downstream steps
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"classification={classification}\n")
+            f.write(f"confidence={parsed.get('confidence', 'unknown')}\n")
 
 
 if __name__ == "__main__":

--- a/scripts/ci/ci_auto_bisect.py
+++ b/scripts/ci/ci_auto_bisect.py
@@ -191,7 +191,7 @@ def analyze_with_claude(failed_jobs_info, commit_diff, run_info, api_key):
             return response.content[0].text
         except anthropic.RateLimitError:
             if attempt < 2:
-                time.sleep(2**attempt)
+                time.sleep(4**attempt)
             else:
                 raise
         except Exception as e:
@@ -349,10 +349,10 @@ def main():
         failed_jobs=[j["name"] for j in failed_jobs_info],
         root_cause=parsed.get("root_cause", ""),
         suggested_fix=parsed.get("suggested_fix", ""),
-        raw_response=raw_response,
+        raw_response="",  # intentionally omitted from artifact
     )
 
-    # 7. Save result
+    # 7. Save result (raw_response excluded to avoid leaking log content)
     with open(args.output, "w") as f:
         json.dump(asdict(result), f, indent=2, default=str)
     print(f"Results saved to {args.output}")

--- a/scripts/ci/ci_auto_bisect.py
+++ b/scripts/ci/ci_auto_bisect.py
@@ -116,9 +116,12 @@ def fetch_commit_diff(repo, sha, token):
     return ""
 
 
-def analyze_with_claude(failed_jobs_info, commit_diff, run_info, api_key):
+def analyze_with_claude(failed_jobs_info, commit_diff, run_info, api_key, base_url=None):
     """Call Claude API to analyze the failure."""
-    client = anthropic.Anthropic(api_key=api_key)
+    kwargs = {"api_key": api_key}
+    if base_url:
+        kwargs["base_url"] = base_url
+    client = anthropic.Anthropic(**kwargs)
 
     prompt_parts = [
         "You are a CI failure analyst for sglang-jax, a JAX-based LLM inference engine running on Google TPU.",
@@ -287,6 +290,7 @@ def main():
 
     github_token = os.environ.get("GITHUB_TOKEN")
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+    anthropic_base_url = os.environ.get("ANTHROPIC_BASE_URL")
 
     if not github_token:
         print("Error: GITHUB_TOKEN not set")
@@ -332,7 +336,9 @@ def main():
 
     # 5. Analyze with Claude
     print("Analyzing with Claude...")
-    raw_response = analyze_with_claude(failed_jobs_info, diff, run_info, anthropic_key)
+    raw_response = analyze_with_claude(
+        failed_jobs_info, diff, run_info, anthropic_key, anthropic_base_url
+    )
     parsed = parse_claude_response(raw_response)
 
     # 6. Build result

--- a/scripts/ci/ci_auto_bisect.py
+++ b/scripts/ci/ci_auto_bisect.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""
+CI Auto Bisect - AI-Assisted Root Cause Analysis
+
+Analyzes failed CI runs using Claude API to identify root causes
+and post analysis results.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import asdict, dataclass
+
+import anthropic
+import requests
+
+GITHUB_API = "https://api.github.com"
+CLAUDE_MODEL = "claude-sonnet-4-6"
+MAX_LOG_CHARS = 50000  # per job, to stay within context
+
+
+@dataclass
+class AnalysisResult:
+    run_id: int
+    run_url: str
+    classification: str  # code_regression, flaky_test, infrastructure, environment
+    confidence: str  # high, medium, low
+    failed_jobs: list
+    root_cause: str
+    suggested_fix: str
+    raw_response: str = ""
+
+
+def gh_get(url, token, params=None):
+    """Make authenticated GitHub API GET request."""
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    resp = requests.get(url, headers=headers, params=params, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def gh_post(url, token, data):
+    """Make authenticated GitHub API POST request."""
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    resp = requests.post(url, headers=headers, json=data, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_run_info(repo, run_id, token):
+    """Fetch workflow run information."""
+    url = f"{GITHUB_API}/repos/{repo}/actions/runs/{run_id}"
+    return gh_get(url, token)
+
+
+def fetch_failed_jobs(repo, run_id, token):
+    """Fetch all jobs for a run, return only failed ones."""
+    jobs = []
+    page = 1
+    while True:
+        url = f"{GITHUB_API}/repos/{repo}/actions/runs/{run_id}/jobs"
+        data = gh_get(url, token, {"per_page": 100, "page": page, "filter": "latest"})
+        jobs.extend(data.get("jobs", []))
+        if len(data.get("jobs", [])) < 100:
+            break
+        page += 1
+    return [j for j in jobs if j.get("conclusion") == "failure"]
+
+
+def fetch_job_log_direct(repo, job_id, token, max_chars=MAX_LOG_CHARS):
+    """Fetch logs for a specific job, truncated to last max_chars."""
+    url = f"{GITHUB_API}/repos/{repo}/actions/jobs/{job_id}/logs"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    try:
+        resp = requests.get(url, headers=headers, timeout=60, allow_redirects=True)
+        if resp.status_code == 200:
+            text = resp.text
+            return text[-max_chars:] if len(text) > max_chars else text
+        print(f"Warning: Log fetch for job {job_id} returned HTTP {resp.status_code}")
+    except requests.RequestException as e:
+        print(f"Warning: Failed to fetch logs for job {job_id}: {e}")
+    return ""
+
+
+def fetch_commit_diff(repo, sha, token):
+    """Fetch the diff for a commit."""
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3.diff",
+    }
+    try:
+        resp = requests.get(
+            f"{GITHUB_API}/repos/{repo}/commits/{sha}",
+            headers=headers,
+            timeout=30,
+        )
+        if resp.status_code == 200:
+            diff = resp.text
+            if len(diff) > 30000:
+                diff = diff[:30000] + "\n... (truncated)"
+            return diff
+    except requests.RequestException as e:
+        print(f"Warning: Failed to fetch commit diff for {sha[:12]}: {e}")
+    return ""
+
+
+def analyze_with_claude(failed_jobs_info, commit_diff, run_info, api_key):
+    """Call Claude API to analyze the failure."""
+    client = anthropic.Anthropic(api_key=api_key)
+
+    prompt_parts = [
+        "You are a CI failure analyst for sglang-jax, a JAX-based LLM inference engine running on Google TPU.",
+        "",
+        "Analyze the following CI failure and classify it.",
+        "",
+        "## Workflow Run",
+        f"- Run ID: {run_info.get('id')}",
+        f"- Branch: {run_info.get('head_branch')}",
+        f"- Commit: {run_info.get('head_sha', '')[:12]}",
+        f"- Event: {run_info.get('event')}",
+        f"- URL: {run_info.get('html_url')}",
+        "",
+    ]
+
+    for job_info in failed_jobs_info:
+        prompt_parts.extend(
+            [
+                f"## Failed Job: {job_info['name']}",
+                f"### Logs (last {MAX_LOG_CHARS} chars):",
+                "```",
+                job_info.get("logs", "(no logs available)"),
+                "```",
+                "",
+            ]
+        )
+
+    if commit_diff:
+        prompt_parts.extend(
+            [
+                "## Commit Diff:",
+                "```diff",
+                commit_diff,
+                "```",
+                "",
+            ]
+        )
+
+    prompt_parts.extend(
+        [
+            "## Instructions",
+            "Classify this failure as exactly ONE of:",
+            "- `code_regression`: A code change broke something",
+            "- `flaky_test`: The test is intermittently failing",
+            "- `infrastructure`: Hardware/runner/network issue",
+            "- `environment`: Dependency/config/environment change",
+            "",
+            "Respond in this exact JSON format:",
+            "```json",
+            "{",
+            '  "classification": "one of the above",',
+            '  "confidence": "high/medium/low",',
+            '  "root_cause": "Clear explanation of what went wrong",',
+            '  "evidence": "What in the logs/diff supports this conclusion",',
+            '  "suggested_fix": "Actionable recommendation"',
+            "}",
+            "```",
+        ]
+    )
+
+    prompt = "\n".join(prompt_parts)
+
+    for attempt in range(3):
+        try:
+            response = client.messages.create(
+                model=CLAUDE_MODEL,
+                max_tokens=4096,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return response.content[0].text
+        except anthropic.RateLimitError:
+            if attempt < 2:
+                time.sleep(2**attempt)
+            else:
+                raise
+        except Exception as e:
+            print(f"Claude API error (attempt {attempt + 1}): {e}")
+            if attempt < 2:
+                time.sleep(2**attempt)
+            else:
+                raise
+
+    return ""
+
+
+def parse_claude_response(raw):
+    """Extract JSON from Claude's response."""
+    json_match = re.search(r"```json\s*(.*?)\s*```", raw, re.DOTALL)
+    if json_match:
+        try:
+            return json.loads(json_match.group(1))
+        except json.JSONDecodeError:
+            pass
+    # Try parsing the whole response as JSON
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {
+            "classification": "unknown",
+            "confidence": "low",
+            "root_cause": raw[:500],
+            "evidence": "",
+            "suggested_fix": "",
+        }
+
+
+def format_markdown_report(result, parsed):
+    """Format analysis result as markdown."""
+    classification_emoji = {
+        "code_regression": "🔴",
+        "flaky_test": "🟡",
+        "infrastructure": "🟠",
+        "environment": "🔵",
+        "unknown": "⚪",
+    }
+    emoji = classification_emoji.get(parsed.get("classification", ""), "⚪")
+
+    lines = [
+        "# CI Failure Analysis",
+        "",
+        f"**Run:** [{result.run_id}]({result.run_url})",
+        f"**Classification:** {emoji} `{parsed.get('classification', 'unknown')}`",
+        f"**Confidence:** {parsed.get('confidence', 'unknown')}",
+        "",
+        "## Failed Jobs",
+        "",
+    ]
+    for job in result.failed_jobs:
+        lines.append(f"- {job}")
+    lines.extend(
+        [
+            "",
+            "## Root Cause",
+            "",
+            parsed.get("root_cause", "Unable to determine"),
+            "",
+            "## Evidence",
+            "",
+            parsed.get("evidence", "N/A"),
+            "",
+            "## Suggested Fix",
+            "",
+            parsed.get("suggested_fix", "N/A"),
+            "",
+            "---",
+            "*Analysis generated by CI Auto Bisect using Claude API*",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def post_issue_comment(repo, issue_number, body, token):
+    """Post a comment on a GitHub issue."""
+    url = f"{GITHUB_API}/repos/{repo}/issues/{issue_number}/comments"
+    gh_post(url, token, {"body": body})
+    print(f"Posted analysis comment on issue #{issue_number}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="AI-assisted CI failure analysis")
+    parser.add_argument("--repo", default="sgl-project/sglang-jax", help="GitHub repo")
+    parser.add_argument("--run-id", required=True, help="Failed workflow run ID")
+    parser.add_argument("--issue-number", type=int, help="Issue number to comment on")
+    parser.add_argument("--output", default="analysis_result.json", help="Output file")
+    args = parser.parse_args()
+
+    github_token = os.environ.get("GITHUB_TOKEN")
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+
+    if not github_token:
+        print("Error: GITHUB_TOKEN not set")
+        sys.exit(1)
+    if not anthropic_key:
+        print("Error: ANTHROPIC_API_KEY not set")
+        sys.exit(1)
+
+    # 1. Fetch run info
+    print(f"Fetching run {args.run_id}...")
+    run_info = fetch_run_info(args.repo, args.run_id, github_token)
+
+    # 2. Get failed jobs
+    print("Fetching failed jobs...")
+    failed_jobs = fetch_failed_jobs(args.repo, args.run_id, github_token)
+    if not failed_jobs:
+        print("No failed jobs found in this run.")
+        sys.exit(0)
+    print(f"Found {len(failed_jobs)} failed jobs")
+
+    # 3. Fetch logs for failed jobs
+    print("Fetching job logs...")
+    failed_jobs_info = []
+    for job in failed_jobs:
+        log = fetch_job_log_direct(args.repo, job["id"], github_token)
+        failed_jobs_info.append(
+            {
+                "name": job["name"],
+                "id": job["id"],
+                "logs": log,
+                "url": job.get("html_url", ""),
+            }
+        )
+
+    # 4. Fetch commit diff
+    sha = run_info.get("head_sha", "")
+    print(f"Fetching diff for commit {sha[:12]}...")
+    diff = fetch_commit_diff(args.repo, sha, github_token)
+
+    # 5. Analyze with Claude
+    print("Analyzing with Claude...")
+    raw_response = analyze_with_claude(failed_jobs_info, diff, run_info, anthropic_key)
+    parsed = parse_claude_response(raw_response)
+
+    # 6. Build result
+    result = AnalysisResult(
+        run_id=int(args.run_id),
+        run_url=run_info.get("html_url", ""),
+        classification=parsed.get("classification", "unknown"),
+        confidence=parsed.get("confidence", "low"),
+        failed_jobs=[j["name"] for j in failed_jobs_info],
+        root_cause=parsed.get("root_cause", ""),
+        suggested_fix=parsed.get("suggested_fix", ""),
+        raw_response=raw_response,
+    )
+
+    # 7. Save result
+    with open(args.output, "w") as f:
+        json.dump(asdict(result), f, indent=2, default=str)
+    print(f"Results saved to {args.output}")
+
+    # 8. Format markdown report
+    report = format_markdown_report(result, parsed)
+
+    # 9. Post to issue if requested
+    if args.issue_number:
+        post_issue_comment(args.repo, args.issue_number, report, github_token)
+
+    # 10. Write to GITHUB_STEP_SUMMARY
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a") as f:
+            f.write(report)
+
+    print("Analysis complete!")
+    # Exit with non-zero if it's a confirmed regression, to signal urgency to callers
+    if parsed.get("classification") == "code_regression" and parsed.get("confidence") == "high":
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/ci_auto_bisect.py
+++ b/scripts/ci/ci_auto_bisect.py
@@ -323,8 +323,12 @@ def main():
 
     # 4. Fetch commit diff
     sha = run_info.get("head_sha", "")
-    print(f"Fetching diff for commit {sha[:12]}...")
-    diff = fetch_commit_diff(args.repo, sha, github_token)
+    if sha:
+        print(f"Fetching diff for commit {sha[:12]}...")
+        diff = fetch_commit_diff(args.repo, sha, github_token)
+    else:
+        print("Warning: head_sha is empty, skipping commit diff fetch.")
+        diff = ""
 
     # 5. Analyze with Claude
     print("Analyzing with Claude...")
@@ -332,8 +336,13 @@ def main():
     parsed = parse_claude_response(raw_response)
 
     # 6. Build result
+    try:
+        run_id_int = int(args.run_id)
+    except ValueError:
+        print(f"Error: run_id must be numeric, got: {args.run_id!r}")
+        sys.exit(1)
     result = AnalysisResult(
-        run_id=int(args.run_id),
+        run_id=run_id_int,
         run_url=run_info.get("html_url", ""),
         classification=parsed.get("classification", "unknown"),
         confidence=parsed.get("confidence", "low"),
@@ -363,7 +372,11 @@ def main():
 
     print("Analysis complete!")
     # Exit with non-zero if it's a confirmed regression, to signal urgency to callers
-    if parsed.get("classification") == "code_regression" and parsed.get("confidence") == "high":
+    known_classifications = {"code_regression", "flaky_test", "infrastructure", "environment"}
+    classification = parsed.get("classification")
+    if classification not in known_classifications:
+        classification = "unknown"
+    if classification == "code_regression" and parsed.get("confidence") == "high":
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci-auto-bisect.yml`: a manually-triggered (and `repository_dispatch`-triggered) workflow that calls `scripts/ci/ci_auto_bisect.py` to analyze a failed CI run using the Claude API.
- Adds `scripts/ci/ci_auto_bisect.py`: fetches failed job logs and the triggering commit diff from the GitHub API, sends them to `claude-sonnet-4-6`, parses the structured JSON response, and reports root cause classification, confidence, evidence, and a suggested fix.

## How to trigger

**Manual dispatch** (Actions tab → CI Auto Bisect → Run workflow):
- `run_id`: the numeric ID of the failed workflow run to analyze (required)
- `issue_number`: GitHub issue to post the analysis comment on (optional)

**Via `repository_dispatch`** (e.g. from another workflow):
```yaml
- uses: peter-evans/repository-dispatch@v3
  with:
    event-type: analysis_request
    client-payload: '{"run_id": "12345678", "issue_number": "42"}'
```

## Output

- Workflow step summary contains the full markdown report.
- `analysis_result.json` is uploaded as a workflow artifact (retained 14 days).
- If `--issue-number` is provided, a comment is posted on that issue.
- The workflow exits with code 1 when the classification is `code_regression` with `high` confidence, making it easy to gate downstream automation.

## Required secrets

| Secret | Purpose |
|--------|---------|
| `ANTHROPIC_API_KEY` | Authenticate Claude API calls |
| `GITHUB_TOKEN` | Built-in; used to read run/job metadata and post issue comments |

`ANTHROPIC_API_KEY` must be added to the repository secrets before the workflow can produce analysis output.

## Test plan

- [ ] Trigger manually with a known-failed run ID and verify the step summary contains a classification + suggested fix.
- [ ] Trigger with `--issue-number` and verify a comment appears on the issue.
- [ ] Verify the workflow does not run on forks (`if: github.repository == 'sgl-project/sglang-jax'` guard).
- [ ] Verify `analysis_result.json` artifact is uploaded even when the script exits with code 1.

Closes #1139
