### PR TITLE
ci: add XLA compilation cache and model cache env vars (P0-9)

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -21,6 +21,8 @@ jobs:
     continue-on-error: true
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -59,6 +61,8 @@ jobs:
     continue-on-error: true
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -103,6 +107,8 @@ jobs:
     continue-on-error: true
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -25,6 +25,8 @@ jobs:
     continue-on-error: true
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -89,6 +91,8 @@ jobs:
     continue-on-error: true
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -132,6 +136,8 @@ jobs:
     continue-on-error: true
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -176,6 +182,8 @@ jobs:
     continue-on-error: true
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -242,6 +250,8 @@ jobs:
       continue-on-error: true
       env:
         TZ: Asia/Shanghai
+        JAX_COMPILATION_CACHE_DIR: /xla-cache
+        SGLANG_JAX_MODEL_CACHE: /models/model_scope
       steps:
         - name: Checkout code
           uses: actions/checkout@v4
@@ -286,6 +296,8 @@ jobs:
         continue-on-error: true
         env:
           TZ: Asia/Shanghai
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
+          SGLANG_JAX_MODEL_CACHE: /models/model_scope
         steps:
           - name: Checkout code
             uses: actions/checkout@v4
@@ -334,6 +346,8 @@ jobs:
     continue-on-error: true
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -377,6 +391,8 @@ jobs:
     continue-on-error: true
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -421,6 +437,8 @@ jobs:
       continue-on-error: true
       env:
         TZ: Asia/Shanghai
+        JAX_COMPILATION_CACHE_DIR: /xla-cache
+        SGLANG_JAX_MODEL_CACHE: /models/model_scope
       steps:
         - name: Checkout code
           uses: actions/checkout@v4

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -80,6 +80,7 @@ jobs:
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -102,6 +103,7 @@ jobs:
         timeout-minutes: 30
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -127,6 +129,7 @@ jobs:
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
@@ -154,6 +157,7 @@ jobs:
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
@@ -181,6 +185,7 @@ jobs:
         timeout-minutes: 20
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
@@ -208,6 +213,7 @@ jobs:
         timeout-minutes: 50
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
@@ -236,6 +242,7 @@ jobs:
         timeout-minutes: 30
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
@@ -264,6 +271,7 @@ jobs:
 
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |
@@ -291,6 +299,7 @@ jobs:
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
         run: |


### PR DESCRIPTION
## Summary

- Add `JAX_COMPILATION_CACHE_DIR=/xla-cache` to all test jobs (9 PR Test + 9 nightly + 3 daily = 21 jobs) to leverage the GCS-mounted XLA compilation cache bucket (`sglang-jax-ci-xla-cache`), avoiding repeated XLA compilations per job
- Add `SGLANG_JAX_MODEL_CACHE=/models/model_scope` to nightly/daily jobs (12 jobs) so they use the existing GCS-mounted model cache instead of falling back to HuggingFace downloads (PR Test already has this)

## Test plan

- [ ] Verify second CI run shows XLA compilation cache hits (check logs for cache hit messages)
- [ ] Verify nightly jobs load models from `/models/model_scope` without HuggingFace fallback
- [ ] Validate YAML syntax (done locally with `yaml.safe_load`)

Closes #1127