### PR TITLE
refactor(spec): per-rank ScheduleBatch.spec_info

### DIFF
--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -213,15 +213,15 @@ class FlashAttention(AttentionBackend):
 
         if batch.forward_mode == ForwardMode.TARGET_VERIFY:
             # convert custom_mask from bool to int32, because dma not support bool type
-            if batch.spec_info.custom_mask.dtype == jnp.bool:
+            if batch.spec_info_padded.custom_mask.dtype == jnp.bool:
                 # FIXME(pc) rm this dtype convert
                 logger.warning(
-                    "batch.spec_info.custom_mask type is  %s, it may make performance very low",
-                    batch.spec_info.custom_mask.dtype,
+                    "batch.spec_info_padded.custom_mask type is  %s, it may make performance very low",
+                    batch.spec_info_padded.custom_mask.dtype,
                 )
-                metadata.custom_mask = batch.spec_info.custom_mask.astype(jnp.int32)
+                metadata.custom_mask = batch.spec_info_padded.custom_mask.astype(jnp.int32)
             else:
-                metadata.custom_mask = batch.spec_info.custom_mask
+                metadata.custom_mask = batch.spec_info_padded.custom_mask
         else:
             metadata.custom_mask = None
 
@@ -230,7 +230,7 @@ class FlashAttention(AttentionBackend):
         if batch.forward_mode.is_target_verify():
             padded_batch_size = len(batch.seq_lens)
             extend_seq_lens = np.zeros(padded_batch_size, dtype=np.int32)
-            extend_seq_lens[batch.logits_indices_selector] = batch.spec_info.draft_token_num
+            extend_seq_lens[batch.logits_indices_selector] = batch.spec_info_padded.draft_token_num
         else:
             extend_seq_lens = batch.extend_seq_lens
         cu_q_lens = _per_dp_cumsum(extend_seq_lens, dp_size, per_dp_bs)
@@ -246,7 +246,7 @@ class FlashAttention(AttentionBackend):
             # stride. Dense targets (EAGLE3) keep the unpadded path so accept-
             # rate / cache-hit behavior is unchanged.
             if metadata.custom_mask is not None and self.page_size >= 256:
-                q = batch.spec_info.draft_token_num
+                q = batch.spec_info_padded.draft_token_num
                 cm = np.asarray(jax.device_get(metadata.custom_mask))
                 # cm is DP-slot-ordered (build_tree got verified_seq_len = mwb.seq_lens-1
                 # over total_bs). Per-slot cm length = q*(verified_seq_len[s]+q); for pad
@@ -292,7 +292,7 @@ class FlashAttention(AttentionBackend):
             # the DP-segmented layout from padding_for_decode (rank r's pages
             # at [r*per_dp_pg : ...]). page_indices (line 212) is already
             # cache_loc[::page_size]//page_size, so re-gather from it per-rank.
-            allocate_lens = batch.spec_info.allocate_lens
+            allocate_lens = batch.spec_info_padded.allocate_lens
             if hasattr(allocate_lens, "device"):
                 allocate_lens = jax.device_get(allocate_lens)
             allocate_lens = np.asarray(allocate_lens)
@@ -370,7 +370,7 @@ class FlashAttention(AttentionBackend):
         # (== selector order), so the per-req gather below stays aligned.
         sel = np.asarray(batch.logits_indices_selector)
         current_seq_lens = np.asarray(batch.seq_lens)[sel]
-        allocate_lens = np.asarray(batch.spec_info.allocate_lens)[sel]
+        allocate_lens = np.asarray(batch.spec_info_padded.allocate_lens)[sel]
 
         draft_allocs = allocate_lens - current_seq_lens
 
@@ -432,7 +432,7 @@ class FlashAttention(AttentionBackend):
 
         if batch.spec_algorithm.is_none():
             raise RuntimeError("should not reach here")
-        assert isinstance(batch.spec_info, EagleDraftInput)
+        assert isinstance(batch.spec_info_padded, EagleDraftInput)
         topk = batch.speculative_eagle_topk
         cu_q_lens = np.tile(np.arange(0, per_dp_bs * topk + 1, topk, dtype=np.int32), dp_size)
         seq_2d = np.asarray(batch.seq_lens).reshape(dp_size, per_dp_bs)

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -240,29 +240,31 @@ class FlashAttention(AttentionBackend):
         if batch.forward_mode.is_target_verify():
             seq_lens += extend_seq_lens
             aligned_seq_lens = ((seq_lens + self.page_size - 1) // self.page_size) * self.page_size
-            # Hybrid-SWA targets at page_size>=256 hit Mosaic's tiling(8) proof
-            # in rpa_v3._fetch_mask. Pad each mask row to page-aligned kv_len so
-            # the kernel can use cu_kv_lens delta as a statically-8-divisible
-            # stride. Dense targets (EAGLE3) keep the unpadded path so accept-
-            # rate / cache-hit behavior is unchanged.
-            if metadata.custom_mask is not None and self.page_size >= 256:
+            # At dp>1 the verify mask must be DP-segmented per rank so each rank's
+            # P("data") shard sees its own slots' mask (the kernel computes
+            # cu_seq_mask_lens from per-rank cu_kv/q starting at 0). Without
+            # repack, the build_tree output sits in cross-rank-flat order, and
+            # rank>0 reads the mask tail (padding zeros) → all-masked verify
+            # → garbage. (#1108 P1-7)
+            #
+            # mask col width depends on rpa_v3's mask_aligned_to_cu_kv switch
+            # (page_size>=256 uses aligned cu_kv_lens; else actual seq_lens),
+            # so pad each row to match — otherwise kernel reads wrong stride.
+            if metadata.custom_mask is not None and dp_size > 1:
                 q = batch.spec_info_padded.draft_token_num
                 cm = np.asarray(jax.device_get(metadata.custom_mask))
                 # cm is DP-slot-ordered (build_tree got verified_seq_len = mwb.seq_lens-1
                 # over total_bs). Per-slot cm length = q*(verified_seq_len[s]+q); for pad
-                # slots verified_seq_len=-1 → q*(q-1). Repack per DP rank (real slots'
-                # rows padded to aligned kv, pad slots = zeros), then pad each rank's
-                # section to a common length so the result shards P("data") and each
-                # rank's locally-computed cu_seq_mask_lens (starting at 0) indexes its
-                # own shard. (#1108 P1-7 — n>1 dp>1 verify mask cross-rank read.)
+                # slots verified_seq_len=-1 → q*(q-1).
                 cm_kl = np.where(seq_lens > 0, seq_lens, q - 1).astype(np.int64)
                 cm_off = np.concatenate([[0], np.cumsum(q * cm_kl)])
+                row_width = aligned_seq_lens if self.page_size >= 256 else seq_lens
                 rank_chunks: list[np.ndarray] = []
                 for r in range(dp_size):
                     parts = []
                     for j in range(per_dp_bs):
                         s = r * per_dp_bs + j
-                        kla = int(aligned_seq_lens[s])
+                        kla = int(row_width[s])
                         if seq_lens[s] > 0:
                             kl = int(seq_lens[s])
                             row = cm[cm_off[s] : cm_off[s] + q * kl].reshape(q, kl)
@@ -279,7 +281,7 @@ class FlashAttention(AttentionBackend):
                 ).astype(np.int32)
                 metadata.custom_mask = device_array(
                     packed,
-                    sharding=NamedSharding(self.mesh, P("data") if dp_size > 1 else P()),
+                    sharding=NamedSharding(self.mesh, P("data")),
                 )
         else:
             aligned_seq_lens = (

--- a/python/sgl_jax/srt/layers/logits_processor.py
+++ b/python/sgl_jax/srt/layers/logits_processor.py
@@ -201,10 +201,10 @@ class LogitsMetadata:
             extend_seq_lens=device_array(batch.extend_seq_lens, sharding=sharding),
             logits_indices=device_array(batch.logits_indices, sharding=sharding),
             accept_lens=(
-                device_array(batch.spec_info.accept_length, sharding=sharding)
-                if batch.spec_info is not None
-                and hasattr(batch.spec_info, "accept_length")
-                and batch.spec_info.accept_length is not None
+                device_array(batch.spec_info_padded.accept_length, sharding=sharding)
+                if batch.spec_info_padded is not None
+                and hasattr(batch.spec_info_padded, "accept_length")
+                and batch.spec_info_padded.accept_length is not None
                 else None
             ),
             extend_seq_lens_cpu=extend_seq_lens_cpu,

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -188,6 +188,13 @@ class EPMoE(nnx.Module):
                         f"Unsupported {scale_name} shape {scale.shape} for weight shape {weight.shape}. "
                         f"Expected k_blocks dimension to be 1 or {expected_k_blocks}."
                     )
+            # FIXME(jax-upgrade): incoming sharding is typically P("expert", None, None, None) —
+            # the EPMoE weight loader passes a 3-tuple ("expert", None, None) that JAX pads
+            # with None on the 4D array — which doesn't textually match the downstream
+            # shard_map in_specs P("expert", None, None, "tensor"). jax 0.8.1 accepts this
+            # because the "tensor" axis is size 1 (ep_size == world_size); jax 0.10.x checks
+            # strictly and will raise. Fix by reshard'ing here like the ndim==3 branches do,
+            # or fix the loader to emit a full 4-tuple.
             return scale
 
         if scale.ndim == 2 and scale.shape == (num_experts, out_dim):

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2155,7 +2155,6 @@ class ScheduleBatch:
             logits_indices_selector=logits_indices_selector,
             capture_hidden_mode=getattr(spec_info, "capture_hidden_mode", CaptureHiddenMode.NULL),
             launch_done=self.launch_done,
-            spec_info=spec_info,
             spec_info_padded=spec_info,
             spec_algorithm=self.spec_algorithm,
             tree_cache=self.tree_cache,
@@ -2570,7 +2569,6 @@ class ScheduleBatch:
                 )
             ),
             launch_done=self.launch_done,
-            spec_info=self.spec_info,
             spec_info_padded=self.spec_info,
             spec_algorithm=self.spec_algorithm,
             tree_cache=self.tree_cache,
@@ -3050,11 +3048,11 @@ class ModelWorkerBatch:
     # Pre-initialized ForwardBatch for overlap scheduling optimization
     forward_batch: Any | None = None
 
-    spec_info: EagleDraftInput | EagleVerifyInput | None = None
-    # Option C boundary field: cross-rank-flat (or scatter-padded under dp>1)
-    # spec input prepared by `_get_spec_decode_mwb_dp`. Forward path reads/
-    # mutates this; the legacy `spec_info` field is being phased out (step C
-    # renames forward-internal references; step E drops `spec_info`).
+    # Option C: spec_info_padded is the only spec field on ModelWorkerBatch.
+    # Layout is cross-rank-flat (or scatter-padded under dp>1) at forward
+    # entry; forward internals may mutate it through EagleVerifyInput before
+    # returning a fresh EagleDraftInput. Scheduler-persisted per-rank spec
+    # state lives on ScheduleBatch.reqs_info[r].spec_info instead.
     spec_info_padded: EagleDraftInput | EagleVerifyInput | None = None
     spec_algorithm: SpeculativeAlgorithm = None
     speculative_num_steps: int = 0

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1605,15 +1605,6 @@ class ScheduleBatch:
             else:
                 info.seq_lens_sum = 0
 
-            # Filter speculative decoding arrays manually (if present)
-            if info.spec_info is not None and info.spec_info.topk_p is not None:
-                keep_indices_jax = jnp.asarray(keep_indices_dp, dtype=jnp.int32)
-                info.spec_info.topk_p = info.spec_info.topk_p[keep_indices_jax]
-                info.spec_info.topk_index = info.spec_info.topk_index[keep_indices_jax]
-                info.spec_info.hidden_states = info.spec_info.hidden_states[keep_indices_jax]
-                info.spec_info.verified_id = info.spec_info.verified_id[keep_indices_jax]
-                info.spec_info.allocate_lens = info.spec_info.allocate_lens[keep_indices_jax]
-
             # Filter logprob lists
             if info.top_logprobs_nums is not None:
                 info.top_logprobs_nums = [info.top_logprobs_nums[i] for i in keep_indices_dp]
@@ -1623,9 +1614,8 @@ class ScheduleBatch:
             if info.sampling_info is not None:
                 info.sampling_info.filter_batch(np.array(keep_indices_dp))
 
-            # Filter spec_info (method call)
+            # Filter spec_info (per-rank EagleDraftInput; handles all 5 spec arrays).
             if info.spec_info is not None:
-                # Note: has_been_filtered logic matches original implementation
                 if chunked_req_to_exclude is not None and len(chunked_req_to_exclude) > 0:
                     has_been_filtered = False
                 else:

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2150,7 +2150,7 @@ class ScheduleBatch:
 
         ``selector[k]`` is the DP-padded slot of the k-th global-flat req
         (== ``logits_indices_selector``). Returns a new ``EagleDraftInput``;
-        the cross-round flat state on ``reqs_info[0].spec_info`` is unchanged.
+        the cross-round flat state on ``reqs_info[r].spec_info`` is unchanged.
         """
 
         def _scatter1(arr):
@@ -2236,6 +2236,15 @@ class ScheduleBatch:
             if not nonnull:
                 kwargs[f] = None
                 continue
+            # All nonempty ranks should agree on which optional fields they
+            # carry — they came from the same per-rank verify split. A partial
+            # mix means the concat length would silently drift from
+            # ``sum(real_bs_per_dp)``; fail loudly instead.
+            assert len(nonnull) == len(nonempty), (
+                f"_concat_spec_info_per_rank: field {f!r} is None on "
+                f"{len(nonempty) - len(nonnull)}/{len(nonempty)} nonempty rank(s); "
+                "all-or-nothing required"
+            )
             if isinstance(nonnull[0], np.ndarray):
                 kwargs[f] = np.concatenate(nonnull, axis=0)
             else:
@@ -2412,8 +2421,6 @@ class ScheduleBatch:
         if self.dp_size > 1:
             return self._get_spec_decode_mwb_dp(bs_paddings, enable_static_lora)
 
-        acc_global_bid()
-
         if self.input_ids is None:
             input_ids_cpu = np.empty(0, dtype=np.int32)
         else:
@@ -2452,13 +2459,14 @@ class ScheduleBatch:
 
         if len(seq_lens_cpu) > 0:
             seq_lens = seq_lens_cpu
-            if self.spec_algorithm is not None and not self.spec_algorithm.is_none():
-                if self.forward_mode == ForwardMode.TARGET_VERIFY:
-                    seq_lens = seq_lens_cpu + self.spec_info.draft_token_num
-                elif self.forward_mode == ForwardMode.DECODE:
-                    from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
+            if (
+                self.spec_algorithm is not None
+                and not self.spec_algorithm.is_none()
+                and self.forward_mode == ForwardMode.DECODE
+            ):
+                from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
 
-                    seq_lens = seq_lens_cpu + EagleDraftInput.ALLOC_LEN_PER_DECODE
+                seq_lens = seq_lens_cpu + EagleDraftInput.ALLOC_LEN_PER_DECODE
             # Filter out empty sequences
             valid_mask = seq_lens > 0
             if np.any(valid_mask):

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1418,9 +1418,12 @@ class ScheduleBatch:
 
         self.maybe_evict_swa()
 
-        # Spec decode: spec_info is global (DP-padded order, on reqs_info[0]);
-        # allocate KV once across all ranks, then return — input_ids/positions
-        # are rebuilt inside forward_batch_speculative_generation.
+        # Spec decode: option C — spec_info is per-rank on reqs_info[r].
+        # prepare_for_decode operates on a cross-rank-flat EagleDraftInput
+        # (asserts allocate_lens.shape[0] == batch_size); rebuild the flat
+        # view via _concat, run prepare_for_decode (mutates allocate_lens +
+        # writes info.out_cache_loc per rank), then split allocate_lens back
+        # to per-rank.
         if self.spec_algorithm is not None and self.spec_algorithm.is_eagle():
             for info in self.reqs_info:
                 if not info.reqs:
@@ -1429,8 +1432,12 @@ class ScheduleBatch:
                     info.seq_lens = None
                     info.out_cache_loc = None
                     info.seq_lens_sum = 0
-            draft_input: EagleDraftInput = self.reqs_info[0].spec_info
-            draft_input.prepare_for_decode(self)
+            flat_spec = self._concat_spec_info_per_rank([info.spec_info for info in self.reqs_info])
+            flat_spec.prepare_for_decode(self)
+            real_bs_per_dp = [len(info.reqs) if info.reqs else 0 for info in self.reqs_info]
+            per_rank_spec = self._split_spec_info_per_rank(flat_spec, real_bs_per_dp)
+            for r, s in enumerate(per_rank_spec):
+                self.reqs_info[r].spec_info = s
             return
 
         # Process each DP rank
@@ -1530,15 +1537,9 @@ class ScheduleBatch:
         if chunked_req_to_exclude is None:
             chunked_req_to_exclude = {}
 
-        # spec_info is global (flat across ranks, on reqs_info[0]); pull it out
-        # so the per-rank loop doesn't clear/filter it with rank-local indices,
-        # accumulate global flat keep-indices, then filter once after the loop.
-        _global_spec = self.reqs_info[0].spec_info
-        self.reqs_info[0].spec_info = None
-        _global_keep: list[int] = []
-        _flat_base = 0
-
-        # Unified DP filtering logic (works for all dp_size including 1)
+        # Unified DP filtering logic (works for all dp_size including 1).
+        # Option C: spec_info is per-rank now (lives on reqs_info[r].spec_info),
+        # so it filters naturally inside the per-rank loop below.
         for dp_rank in range(self.dp_size):
             info = self.reqs_info[dp_rank]
 
@@ -1562,9 +1563,6 @@ class ScheduleBatch:
                     if not info.reqs[i].finished()
                     and (chunked_req is None or info.reqs[i] != chunked_req)
                 ]
-
-            _global_keep.extend(_flat_base + i for i in keep_indices_dp)
-            _flat_base += len(info.reqs)
 
             # Early exit: Clear all if nothing to keep
             if len(keep_indices_dp) == 0:
@@ -1635,20 +1633,6 @@ class ScheduleBatch:
                 info.spec_info.filter_batch(
                     new_indices=keep_indices_dp, has_been_filtered=has_been_filtered
                 )
-
-        # Restore + filter the global spec_info with cross-rank flat indices.
-        if _global_spec is not None and len(_global_keep) > 0:
-            gk = np.asarray(_global_keep, dtype=np.int32)
-            if _global_spec.topk_p is not None:
-                _global_spec.topk_p = _global_spec.topk_p[gk]
-                _global_spec.topk_index = _global_spec.topk_index[gk]
-                _global_spec.hidden_states = _global_spec.hidden_states[gk]
-                _global_spec.verified_id = _global_spec.verified_id[gk]
-            if _global_spec.allocate_lens is not None:
-                _global_spec.allocate_lens = np.asarray(_global_spec.allocate_lens)[gk]
-            self.reqs_info[0].spec_info = _global_spec
-        elif _global_spec is not None and len(_global_keep) == 0:
-            self.reqs_info[0].spec_info = None
 
         # Recalculate global batch flags from all remaining requests
         all_reqs = [req for info in self.reqs_info for req in (info.reqs if info.reqs else [])]
@@ -2108,13 +2092,13 @@ class ScheduleBatch:
             logits_indices_selector,
         ) = self._merge_batch_metadata(per_dp_bs, total_bs)
         sampling_info = self._merge_sampling_info(per_dp_bs, total_bs)
-        # spec_info arrays live global-flat (rank-then-req contiguous, shape
-        # (real_bs,)) on reqs_info[0]. Scatter into DP-padded (total_bs,) slots
-        # via logits_indices_selector so spec_info[i] aligns with seq_lens[i].
-        # padding_for_decode then gathers via valid_mask=seq_lens>0 and gets
-        # back exactly the global-flat order. New object — don't mutate the
-        # cross-round state on reqs_info[0].
-        flat_spec = self.reqs_info[0].spec_info
+        # Option C: per-rank spec_info lives on reqs_info[r].spec_info. Concat
+        # them into a cross-rank-flat EagleDraftInput, then scatter into
+        # DP-padded (total_bs, ...) slots via logits_indices_selector so
+        # spec_info[i] aligns with seq_lens[i]. padding_for_decode gathers via
+        # valid_mask=seq_lens>0 and gets back the global-flat order. New object
+        # — does not mutate the per-rank cross-round state.
+        flat_spec = self._concat_spec_info_per_rank([info.spec_info for info in self.reqs_info])
         spec_info = self._scatter_spec_info_to_dp_slots(
             flat_spec, logits_indices_selector, total_bs
         )
@@ -2172,6 +2156,7 @@ class ScheduleBatch:
             capture_hidden_mode=getattr(spec_info, "capture_hidden_mode", CaptureHiddenMode.NULL),
             launch_done=self.launch_done,
             spec_info=spec_info,
+            spec_info_padded=spec_info,
             spec_algorithm=self.spec_algorithm,
             tree_cache=self.tree_cache,
             mrope_positions=None,
@@ -2437,25 +2422,13 @@ class ScheduleBatch:
         page_size: int,
         enable_static_lora: bool = False,
     ) -> ModelWorkerBatch:
+        # Spec extend always routes through get_model_worker_batch (padded mwb
+        # shared with nospec). Only decode/idle reaches here.
+        assert (
+            self.forward_mode.is_decode_or_idle()
+        ), "spec extend must use get_model_worker_batch, only decode reaches here"
         if self.dp_size > 1:
-            # dp>1 spec extend goes through get_model_worker_batch (padded prefill,
-            # see scheduler._spec_multi_layer); only decode reaches here.
-            assert (
-                self.forward_mode.is_decode_or_idle()
-            ), "spec extend at dp>1 must use get_model_worker_batch (#1053 P1-5b)"
             return self._get_spec_decode_mwb_dp(bs_paddings, enable_static_lora)
-        if self.forward_mode.is_decode_or_idle():
-            extend_seq_lens = extend_prefix_lens = extend_logprob_start_lens = None
-        else:
-            extend_seq_lens = np.array(self.extend_lens, dtype=np.int32)
-            extend_prefix_lens = np.array(self.prefix_lens, dtype=np.int32)
-            extend_logprob_start_lens = self.extend_logprob_start_lens
-        logits_indices = None
-        if self.forward_mode.is_extend() and extend_seq_lens is not None:
-            if len(extend_seq_lens) > 0:
-                logits_indices = np.cumsum(extend_seq_lens, dtype=np.int32) - 1
-            else:
-                logits_indices = np.array([], dtype=np.int32)
 
         acc_global_bid()
 
@@ -2476,44 +2449,18 @@ class ScheduleBatch:
         if self.spec_info is not None and getattr(self.spec_info, "positions", None) is not None:
             positions_cpu = self.spec_info.positions
         else:
-            positions_cpu = None
-
-        # Calculate positions after padding
-        if self.forward_mode.is_extend():
-            # For prefill: create positions for each token in sequences
-            # Calculate total tokens without padding first
-            if positions_cpu is None:
-                lengths = seq_lens_cpu - self.prefix_lens
-                if len(lengths) > 0:
-                    repeats = lengths
-                    total_len = np.sum(repeats)
-                    # Generate range [0, 1, ... len-1] for each sequence
-                    block_starts = np.concatenate(([0], np.cumsum(repeats)[:-1]))
-                    shifts = np.repeat(block_starts, repeats)
-                    ranges = np.arange(total_len) - shifts
-                    # Add prefix_len to each range
-                    positions_cpu = np.repeat(self.prefix_lens, repeats) + ranges
-                    positions_cpu = positions_cpu.astype(seq_lens_cpu.dtype)
-                else:
-                    positions_cpu = np.array([], dtype=seq_lens_cpu.dtype)
-        else:
-            if positions_cpu is None:
-                # For decode: each sequence contributes one token at the next position (seq_len)
-                # Create positions for actual tokens (one per sequence at seq_len)
-                batch_positions = np.maximum(0, seq_lens_cpu - 1)
-                # Create positions array matching the length of input_ids (including padding)
-                positions_cpu = np.zeros(len(batch_positions), dtype=batch_positions.dtype)
-                # Fill in the actual positions for the real tokens
-                # positions = positions.at[: len(batch_positions)].set(batch_positions)
-                positions_cpu[: len(batch_positions)] = batch_positions
+            # Decode: each sequence contributes one token at the next position.
+            batch_positions = np.maximum(0, seq_lens_cpu - 1)
+            positions_cpu = np.zeros(len(batch_positions), dtype=batch_positions.dtype)
+            positions_cpu[: len(batch_positions)] = batch_positions
 
         mrope_positions_cpu = _compute_mrope_positions_for_batch(
             self.reqs,
             self.forward_mode,
             seq_lens_cpu,
             len(input_ids_cpu),
-            extend_prefix_lens,
-            extend_seq_lens,
+            None,
+            None,
         )
 
         cache_loc_flat = np.array([], dtype=np.int32)
@@ -2580,6 +2527,7 @@ class ScheduleBatch:
                     # Assign
                     cache_loc_flat[dst_indices] = source_data
 
+        bid = acc_global_bid()
         if precision_tracer.get_trace_active():
             self._generate_trace_info(real_bs, bid)
         # Extract lora_ids from requests
@@ -2601,11 +2549,11 @@ class ScheduleBatch:
             positions=positions_cpu,
             mrope_positions=mrope_positions_cpu,
             cache_loc=cache_loc_flat,
-            extend_prefix_lens=(extend_prefix_lens if self.forward_mode.is_extend() else None),
-            extend_seq_lens=(extend_seq_lens if self.forward_mode.is_extend() else None),
-            extend_logprob_start_lens=extend_logprob_start_lens,
+            extend_prefix_lens=None,
+            extend_seq_lens=None,
+            extend_logprob_start_lens=None,
             extend_input_logprob_token_ids=self.extend_input_logprob_token_ids,
-            logits_indices=logits_indices,
+            logits_indices=None,
             lora_ids=lora_ids,
             real_bs=real_bs,
             real_bs_per_dp=[real_bs],
@@ -2623,6 +2571,7 @@ class ScheduleBatch:
             ),
             launch_done=self.launch_done,
             spec_info=self.spec_info,
+            spec_info_padded=self.spec_info,
             spec_algorithm=self.spec_algorithm,
             tree_cache=self.tree_cache,
         )
@@ -3102,6 +3051,11 @@ class ModelWorkerBatch:
     forward_batch: Any | None = None
 
     spec_info: EagleDraftInput | EagleVerifyInput | None = None
+    # Option C boundary field: cross-rank-flat (or scatter-padded under dp>1)
+    # spec input prepared by `_get_spec_decode_mwb_dp`. Forward path reads/
+    # mutates this; the legacy `spec_info` field is being phased out (step C
+    # renames forward-internal references; step E drops `spec_info`).
+    spec_info_padded: EagleDraftInput | EagleVerifyInput | None = None
     spec_algorithm: SpeculativeAlgorithm = None
     speculative_num_steps: int = 0
     speculative_eagle_topk: int = 0

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2434,9 +2434,13 @@ class ScheduleBatch:
         req_pool_indices_cpu = self.req_pool_indices
         token_indices_with_all_reqs = self.req_to_token_pool.req_to_token[self.req_pool_indices]
         # FIXME @pc, move this to eagle_worker
-        # If enable spec inference, use positions in spec info firstly
-        if self.spec_info is not None and getattr(self.spec_info, "positions", None) is not None:
-            positions_cpu = self.spec_info.positions
+        # If enable spec inference, use positions in spec info firstly.
+        # Option C: dp=1 fast path reads per-rank reqs_info[0].spec_info.
+        spec_info_local = (
+            self.reqs_info[0].spec_info if self.reqs_info and self.reqs_info[0] else None
+        )
+        if spec_info_local is not None and getattr(spec_info_local, "positions", None) is not None:
+            positions_cpu = spec_info_local.positions
         else:
             # Decode: each sequence contributes one token at the next position.
             batch_positions = np.maximum(0, seq_lens_cpu - 1)
@@ -2472,10 +2476,11 @@ class ScheduleBatch:
                 if (
                     self.forward_mode == ForwardMode.DECODE
                     and not self.spec_algorithm.is_none()
-                    and self.spec_info.allocate_lens is not None
+                    and spec_info_local is not None
+                    and spec_info_local.allocate_lens is not None
                 ):
                     # Explicitly convert to numpy to avoid JAX device synchronization overhead
-                    allocated_len_cpu = np.array(self.spec_info.allocate_lens)
+                    allocated_len_cpu = np.array(spec_info_local.allocate_lens)
                     allocated_len = allocated_len_cpu[: len(self.reqs)]
                     aligned_lengths = ((allocated_len + page_size - 1) // page_size) * page_size
                     alread_allocated_lens = allocated_len
@@ -2553,13 +2558,13 @@ class ScheduleBatch:
                 CaptureHiddenMode.FULL
                 if self.return_hidden_states
                 else (
-                    getattr(self.spec_info, "capture_hidden_mode", CaptureHiddenMode.NULL)
-                    if self.spec_info
+                    getattr(spec_info_local, "capture_hidden_mode", CaptureHiddenMode.NULL)
+                    if spec_info_local
                     else CaptureHiddenMode.NULL
                 )
             ),
             launch_done=self.launch_done,
-            spec_info_padded=self.spec_info,
+            spec_info_padded=spec_info_local,
             spec_algorithm=self.spec_algorithm,
             tree_cache=self.tree_cache,
         )

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2205,6 +2205,76 @@ class ScheduleBatch:
             accept_length_cpu=flat.accept_length_cpu,
         )
 
+    @staticmethod
+    def _split_spec_info_per_rank(flat, real_bs_per_dp: list[int]) -> list:
+        """Slice a cross-rank-flat EagleDraftInput into per-rank EagleDraftInputs.
+
+        ``flat`` layout is ``[rank0 reqs ++ rank1 reqs ++ …]`` with total length
+        ``sum(real_bs_per_dp)``. Empty ranks (``real_bs == 0``) yield ``None``.
+        Used at forward output boundary to write back ``reqs_info[r].spec_info``.
+        """
+        if flat is None:
+            return [None] * len(real_bs_per_dp)
+
+        per_req_fields = (
+            "topk_p",
+            "topk_index",
+            "hidden_states",
+            "verified_id",
+            "allocate_lens",
+            "accept_length",
+            "accept_length_cpu",
+        )
+
+        out = []
+        offset = 0
+        for n in real_bs_per_dp:
+            if n == 0:
+                out.append(None)
+                continue
+            kwargs = {"capture_hidden_mode": flat.capture_hidden_mode}
+            for f in per_req_fields:
+                v = getattr(flat, f, None)
+                kwargs[f] = None if v is None else v[offset : offset + n]
+            out.append(type(flat)(**kwargs))
+            offset += n
+        return out
+
+    @staticmethod
+    def _concat_spec_info_per_rank(per_rank: list):
+        """Concat per-rank EagleDraftInputs into a single cross-rank-flat one.
+
+        ``None`` entries are skipped. Returns ``None`` if every entry is ``None``.
+        Used at forward input boundary (``_get_spec_decode_mwb_dp``) to build the
+        flat shape ``_scatter_spec_info_to_dp_slots`` expects.
+        """
+        nonempty = [s for s in per_rank if s is not None]
+        if not nonempty:
+            return None
+
+        per_req_fields = (
+            "topk_p",
+            "topk_index",
+            "hidden_states",
+            "verified_id",
+            "allocate_lens",
+            "accept_length",
+            "accept_length_cpu",
+        )
+
+        kwargs = {"capture_hidden_mode": nonempty[0].capture_hidden_mode}
+        for f in per_req_fields:
+            vals = [getattr(s, f, None) for s in nonempty]
+            nonnull = [v for v in vals if v is not None]
+            if not nonnull:
+                kwargs[f] = None
+                continue
+            if isinstance(nonnull[0], np.ndarray):
+                kwargs[f] = np.concatenate(nonnull, axis=0)
+            else:
+                kwargs[f] = jnp.concatenate(nonnull, axis=0)
+        return type(nonempty[0])(**kwargs)
+
     def get_model_worker_batch(
         self,
         token_paddings: list,

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1418,12 +1418,9 @@ class ScheduleBatch:
 
         self.maybe_evict_swa()
 
-        # Spec decode: option C — spec_info is per-rank on reqs_info[r].
-        # prepare_for_decode operates on a cross-rank-flat EagleDraftInput
-        # (asserts allocate_lens.shape[0] == batch_size); rebuild the flat
-        # view via _concat, run prepare_for_decode (mutates allocate_lens +
-        # writes info.out_cache_loc per rank), then split allocate_lens back
-        # to per-rank.
+        # prepare_for_decode requires cross-rank-flat allocate_lens
+        # (asserts shape[0] == batch_size); rebuild via _concat, run it, then
+        # split allocate_lens back to per-rank.
         if self.spec_algorithm is not None and self.spec_algorithm.is_eagle():
             for info in self.reqs_info:
                 if not info.reqs:
@@ -1538,8 +1535,6 @@ class ScheduleBatch:
             chunked_req_to_exclude = {}
 
         # Unified DP filtering logic (works for all dp_size including 1).
-        # Option C: spec_info is per-rank now (lives on reqs_info[r].spec_info),
-        # so it filters naturally inside the per-rank loop below.
         for dp_rank in range(self.dp_size):
             info = self.reqs_info[dp_rank]
 
@@ -2082,12 +2077,10 @@ class ScheduleBatch:
             logits_indices_selector,
         ) = self._merge_batch_metadata(per_dp_bs, total_bs)
         sampling_info = self._merge_sampling_info(per_dp_bs, total_bs)
-        # Option C: per-rank spec_info lives on reqs_info[r].spec_info. Concat
-        # them into a cross-rank-flat EagleDraftInput, then scatter into
-        # DP-padded (total_bs, ...) slots via logits_indices_selector so
-        # spec_info[i] aligns with seq_lens[i]. padding_for_decode gathers via
-        # valid_mask=seq_lens>0 and gets back the global-flat order. New object
-        # — does not mutate the per-rank cross-round state.
+        # Concat per-rank spec_info into a cross-rank-flat EagleDraftInput,
+        # then scatter into DP-padded (total_bs, ...) slots so spec_info[i]
+        # aligns with seq_lens[i]. Returns a new object — does not mutate
+        # the per-rank cross-round state on reqs_info[r].spec_info.
         flat_spec = self._concat_spec_info_per_rank([info.spec_info for info in self.reqs_info])
         spec_info = self._scatter_spec_info_to_dp_slots(
             flat_spec, logits_indices_selector, total_bs
@@ -2435,7 +2428,6 @@ class ScheduleBatch:
         token_indices_with_all_reqs = self.req_to_token_pool.req_to_token[self.req_pool_indices]
         # FIXME @pc, move this to eagle_worker
         # If enable spec inference, use positions in spec info firstly.
-        # Option C: dp=1 fast path reads per-rank reqs_info[0].spec_info.
         spec_info_local = (
             self.reqs_info[0].spec_info if self.reqs_info and self.reqs_info[0] else None
         )
@@ -3043,11 +3035,10 @@ class ModelWorkerBatch:
     # Pre-initialized ForwardBatch for overlap scheduling optimization
     forward_batch: Any | None = None
 
-    # Option C: spec_info_padded is the only spec field on ModelWorkerBatch.
-    # Layout is cross-rank-flat (or scatter-padded under dp>1) at forward
-    # entry; forward internals may mutate it through EagleVerifyInput before
+    # Cross-rank-flat (or scatter-padded under dp>1) spec input at forward
+    # entry. Forward internals may mutate it through EagleVerifyInput before
     # returning a fresh EagleDraftInput. Scheduler-persisted per-rank spec
-    # state lives on ScheduleBatch.reqs_info[r].spec_info instead.
+    # state lives on ScheduleBatch.reqs_info[r].spec_info.
     spec_info_padded: EagleDraftInput | EagleVerifyInput | None = None
     spec_algorithm: SpeculativeAlgorithm = None
     speculative_num_steps: int = 0

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1842,8 +1842,6 @@ class Scheduler(
             batch_output = self.draft_worker.forward_batch_speculative_generation(
                 model_worker_batch
             )
-            # Option C: split cross-rank-flat next_draft_input back to per-rank
-            # reqs_info[r].spec_info (symmetric with seq_lens / req_pool_indices).
             per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
                 batch_output.next_draft_input, model_worker_batch.real_bs_per_dp
             )

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1820,11 +1820,10 @@ class Scheduler(
                 next_token_ids = np.array(jax.device_get(next_token_ids_device))
                 self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
         else:
-            if batch.forward_mode.is_extend() and self._spec_multi_layer:
-                # Multi-layer-MTP (MoE+EP target) prefill must use the same padded
-                # mwb as nospec so target forward sees identical shapes (#1090).
-                # EagleDraftWorker doesn't yet handle padded prefill mwb, so gate
-                # on the worker selection rather than the algorithm flag.
+            if batch.forward_mode.is_extend():
+                # Spec extend always uses the padded mwb so target and draft
+                # see identical shapes regardless of dp_size / multi-layer
+                # (#1090 + #1053 P1-5b assert dp>1 spec extend must go here).
                 model_worker_batch = batch.get_model_worker_batch(
                     precompile_token_paddings,
                     precompile_bs_paddings,
@@ -1843,8 +1842,13 @@ class Scheduler(
             batch_output = self.draft_worker.forward_batch_speculative_generation(
                 model_worker_batch
             )
-            # spec_info is global (DP-padded order), stored on rank 0 only.
-            batch.reqs_info[0].spec_info = batch_output.next_draft_input
+            # Option C: split cross-rank-flat next_draft_input back to per-rank
+            # reqs_info[r].spec_info (symmetric with seq_lens / req_pool_indices).
+            per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
+                batch_output.next_draft_input, model_worker_batch.real_bs_per_dp
+            )
+            for r, s in enumerate(per_rank_spec):
+                batch.reqs_info[r].spec_info = s
             accept = batch_output.accept_lens
             if accept is not None:
                 accept = np.asarray(jax.device_get(accept))

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -243,9 +243,8 @@ class SchedulerOutputProcessorMixin:
             cache_miss_count,
         )
 
-        batch.spec_info = result.next_draft_input
-        # Option C: also write per-rank reqs_info[r].spec_info. Keep the
-        # batch.spec_info double-write for now; step E drops it.
+        # Option C: write per-rank reqs_info[r].spec_info; spec_info on
+        # ScheduleBatch itself was removed in step E.
         if result.next_draft_input is not None:
             real_bs_per_dp = [len(info.reqs) if info.reqs else 0 for info in batch.reqs_info]
             per_rank_spec = ScheduleBatch._split_spec_info_per_rank(

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -244,6 +244,15 @@ class SchedulerOutputProcessorMixin:
         )
 
         batch.spec_info = result.next_draft_input
+        # Option C: also write per-rank reqs_info[r].spec_info. Keep the
+        # batch.spec_info double-write for now; step E drops it.
+        if result.next_draft_input is not None:
+            real_bs_per_dp = [len(info.reqs) if info.reqs else 0 for info in batch.reqs_info]
+            per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
+                result.next_draft_input, real_bs_per_dp
+            )
+            for r, s in enumerate(per_rank_spec):
+                batch.reqs_info[r].spec_info = s
 
     def _resolve_spec_decode_token_ids(
         self: Scheduler, result: GenerationBatchResult, batch: ScheduleBatch
@@ -326,10 +335,6 @@ class SchedulerOutputProcessorMixin:
         # aligned with the selector.
         req_idx = 0
 
-        # spec_info is global (on reqs_info[0]); track flat index across ranks
-        # so the finished-req KV-free below can index allocate_lens correctly.
-        global_spec = batch.reqs_info[0].spec_info
-        global_req_base = 0
         for dp_rank in range(batch.dp_size):
             info = batch.reqs_info[dp_rank]
             reqs = info.reqs
@@ -339,7 +344,6 @@ class SchedulerOutputProcessorMixin:
 
             # Skip empty DP ranks
             if not reqs or not dp_output_ids:
-                global_req_base += len(reqs or [])
                 continue
 
             # Check finish condition for each request in this DP rank
@@ -368,7 +372,7 @@ class SchedulerOutputProcessorMixin:
                 if req.finished():
                     self.maybe_collect_routed_experts(req)
                     if batch.spec_algorithm is not None and batch.spec_algorithm.is_eagle():
-                        cur_allocate_len = int(global_spec.allocate_lens[global_req_base + i])
+                        cur_allocate_len = int(info.spec_info.allocate_lens[i])
                         actual_token_len = len(req.origin_input_ids) + max(
                             len(req.output_ids) - 1, 0
                         )
@@ -463,7 +467,6 @@ class SchedulerOutputProcessorMixin:
                     # Tracking as a follow-up; not in scope for this fix.
                     req.hidden_states.append(logits_output.hidden_states[i])
                 req_idx += 1
-            global_req_base += len(reqs)
 
         # Collect all requests from all DP ranks for stream output
         all_reqs = []

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -243,8 +243,6 @@ class SchedulerOutputProcessorMixin:
             cache_miss_count,
         )
 
-        # Option C: write per-rank reqs_info[r].spec_info; spec_info on
-        # ScheduleBatch itself was removed in step E.
         if result.next_draft_input is not None:
             real_bs_per_dp = [len(info.reqs) if info.reqs else 0 for info in batch.reqs_info]
             per_rank_spec = ScheduleBatch._split_spec_info_per_rank(

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -309,7 +309,7 @@ class CompilationManager:
             lora_ids=lora_ids,
             dp_size=dp_size,
             per_dp_bs_size=per_dp_bs_size,
-            real_bs_per_dp=[bs] * dp_size,
+            real_bs_per_dp=[per_dp_bs_size] * dp_size,
             logits_indices_selector=np.arange(bs, dtype=np.int32),
             # Hybrid recurrent backends (e.g. KDA) require these per-batch
             # arrays even at precompile time; slot 0 is RecurrentStatePool's

--- a/python/sgl_jax/srt/model_executor/forward_batch_info.py
+++ b/python/sgl_jax/srt/model_executor/forward_batch_info.py
@@ -409,7 +409,7 @@ class ForwardBatch:
             lora_token_indices=lora_token_indices,
             lora_ranks=lora_ranks,
             attn_backend=model_runner.attn_backend,
-            spec_info=batch.spec_info,
+            spec_info=batch.spec_info_padded,
             spec_algorithm=batch.spec_algorithm,
             capture_hidden_mode=batch.capture_hidden_mode,
             input_embedding=input_embedding,

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -126,7 +126,7 @@ class BaseSpecWorker:
             return GenerationBatchResult(
                 logits_output=logits_output,
                 next_token_ids=next_token_ids,
-                next_draft_input=model_worker_batch.spec_info,
+                next_draft_input=model_worker_batch.spec_info_padded,
                 allocate_lens=np.asarray(model_worker_batch.seq_lens)[
                     model_worker_batch.logits_indices_selector
                 ],
@@ -140,7 +140,7 @@ class BaseSpecWorker:
         # _get_spec_decode_mwb_dp); gather back to global-flat (real_bs,) so the
         # cross-round state on reqs_info[0].spec_info stays flat-ordered.
         sel = model_worker_batch.logits_indices_selector
-        cur_allocate_lens = np.asarray(model_worker_batch.spec_info.allocate_lens)[sel]
+        cur_allocate_lens = np.asarray(model_worker_batch.spec_info_padded.allocate_lens)[sel]
         self.draft_worker.draft(model_worker_batch)
         batch_output = self.verify(model_worker_batch, cur_allocate_lens)
         self.draft_worker.draft_extend_for_decode(model_worker_batch, batch_output)
@@ -167,7 +167,7 @@ class BaseSpecWorker:
         from sgl_jax.srt.managers.scheduler import GenerationBatchResult
         from sgl_jax.srt.speculative.eagle_util import EagleDraftInput, EagleVerifyInput
 
-        spec_info: EagleVerifyInput = model_worker_batch.spec_info
+        spec_info: EagleVerifyInput = model_worker_batch.spec_info_padded
         spec_info.allocate_lens = cur_allocate_lens
         spec_info.prepare_for_verify(model_worker_batch, self.page_size, self.target_worker)
         forward_metadata = self.target_worker.model_runner.attn_backend.get_eagle_forward_metadata(
@@ -214,7 +214,7 @@ class BaseSpecWorker:
             hidden_states=logits_output.hidden_states,
         )
 
-        model_worker_batch.spec_info = next_draft_input
+        model_worker_batch.spec_info_padded = next_draft_input
         return GenerationBatchResult(
             logits_output=logits_output,
             next_token_ids=predict,

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -359,44 +359,38 @@ class EagleDraftWorker(BaseDraftWorker):
                 )
             )
         bs = self.precompile_bs_paddings[padding_bs_index]
-        if bs - model_worker_batch.spec_info_padded.verified_id.shape[0] > 0:
-            model_worker_batch.spec_info_padded.verified_id = np.pad(
-                model_worker_batch.spec_info_padded.verified_id,
-                ((0, bs - model_worker_batch.spec_info_padded.verified_id.shape[0]),),
-            )
-        if bs - model_worker_batch.spec_info_padded.topk_p.shape[0] > 0:
-            model_worker_batch.spec_info_padded.topk_p = np.pad(
-                model_worker_batch.spec_info_padded.topk_p,
-                (
-                    (0, bs - model_worker_batch.spec_info_padded.topk_p.shape[0]),
-                    (0, 0),
-                ),
-            )
+        dp_size = model_worker_batch.dp_size
+        per_dp_padded = bs // dp_size
+
+        def _dp_segment_pad(arr, target_bs):
+            """DP-segmented pad: pad each rank's section separately to per_dp_padded.
+
+            Input arr shape (curr_bs, ...) with curr_bs = per_dp_curr * dp_size.
+            Returns (target_bs, ...) with each rank's slice padded at the end.
+            End-padding the whole array would let shard_map(P("data")) hand a
+            following rank's data to a prior rank.
+            """
+            if arr is None or arr.shape[0] >= target_bs:
+                return arr
+            per_dp_curr = max(arr.shape[0] // dp_size, 1) if dp_size > 0 else arr.shape[0]
+            if dp_size <= 1 or arr.shape[0] % dp_size != 0:
+                # Fallback to end-pad if layout isn't DP-divisible (dp=1 path).
+                pad_widths = [(0, target_bs - arr.shape[0])] + [(0, 0)] * (arr.ndim - 1)
+                return np.pad(arr, pad_widths)
+            reshaped = arr.reshape((dp_size, per_dp_curr) + arr.shape[1:])
+            pad_widths = [(0, 0), (0, per_dp_padded - per_dp_curr)] + [(0, 0)] * (arr.ndim - 1)
+            padded = np.pad(reshaped, pad_widths)
+            return padded.reshape((target_bs,) + arr.shape[1:])
+
+        spec_info_padded = model_worker_batch.spec_info_padded
+        spec_info_padded.verified_id = _dp_segment_pad(spec_info_padded.verified_id, bs)
+        spec_info_padded.topk_p = _dp_segment_pad(spec_info_padded.topk_p, bs)
         if bs - model_worker_batch.seq_lens.shape[0] > 0:
-            model_worker_batch.seq_lens = np.pad(
-                model_worker_batch.seq_lens, ((0, bs - model_worker_batch.seq_lens.shape[0]),)
-            )
-            if model_worker_batch.spec_info_padded.allocate_lens is not None:
-                model_worker_batch.spec_info_padded.allocate_lens = np.pad(
-                    model_worker_batch.spec_info_padded.allocate_lens,
-                    ((0, bs - model_worker_batch.spec_info_padded.allocate_lens.shape[0]),),
-                )
-        if bs - model_worker_batch.spec_info_padded.topk_index.shape[0] > 0:
-            model_worker_batch.spec_info_padded.topk_index = np.pad(
-                model_worker_batch.spec_info_padded.topk_index,
-                (
-                    (0, bs - model_worker_batch.spec_info_padded.topk_index.shape[0]),
-                    (0, 0),
-                ),
-            )
-        if bs - model_worker_batch.spec_info_padded.hidden_states.shape[0] > 0:
-            model_worker_batch.spec_info_padded.hidden_states = np.pad(
-                model_worker_batch.spec_info_padded.hidden_states,
-                (
-                    (0, bs - model_worker_batch.spec_info_padded.hidden_states.shape[0]),
-                    (0, 0),
-                ),
-            )
+            model_worker_batch.seq_lens = _dp_segment_pad(model_worker_batch.seq_lens, bs)
+            if spec_info_padded.allocate_lens is not None:
+                spec_info_padded.allocate_lens = _dp_segment_pad(spec_info_padded.allocate_lens, bs)
+        spec_info_padded.topk_index = _dp_segment_pad(spec_info_padded.topk_index, bs)
+        spec_info_padded.hidden_states = _dp_segment_pad(spec_info_padded.hidden_states, bs)
         model_worker_batch.speculative_eagle_topk = self.topk
         model_worker_batch.speculative_num_steps = self.speculative_num_steps
         model_worker_batch.speculative_num_draft_tokens = self.speculative_num_draft_tokens

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -155,7 +155,7 @@ class EagleDraftWorker(BaseDraftWorker):
             retrive_next_sibling,
             draft_tokens,
         ) = build_tree_kernel_efficient(
-            model_worker_batch.spec_info.verified_id,
+            model_worker_batch.spec_info_padded.verified_id,
             score_list,
             token_list,
             parents_list,
@@ -168,7 +168,7 @@ class EagleDraftWorker(BaseDraftWorker):
             model_worker_batch.speculative_num_steps,
             self.mesh,
         )
-        model_worker_batch.spec_info = EagleVerifyInput(
+        model_worker_batch.spec_info_padded = EagleVerifyInput(
             draft_token=draft_tokens,
             custom_mask=tree_mask,
             positions=position,
@@ -192,7 +192,7 @@ class EagleDraftWorker(BaseDraftWorker):
     ) -> None:
         sel = np.asarray(model_worker_batch.logits_indices_selector)
         verified_id_np = np.asarray(jax.device_get(next_token_ids))[sel]
-        model_worker_batch.spec_info = EagleDraftInput(
+        model_worker_batch.spec_info_padded = EagleDraftInput(
             hidden_states=hidden_states,
             verified_id=verified_id_np,
             num_tokens_per_batch=np.asarray(1, dtype=jnp.int32),
@@ -200,10 +200,10 @@ class EagleDraftWorker(BaseDraftWorker):
             allocate_lens=model_worker_batch.seq_lens,
         )
         model_worker_batch.return_hidden_states = False
-        model_worker_batch.spec_info.prepare_for_extend_after_target_prefill(
+        model_worker_batch.spec_info_padded.prepare_for_extend_after_target_prefill(
             model_worker_batch=model_worker_batch
         )
-        model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.LAST
+        model_worker_batch.spec_info_padded.capture_hidden_mode = CaptureHiddenMode.LAST
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
         forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
         forward_batch.return_logprob = False
@@ -295,7 +295,7 @@ class EagleDraftWorker(BaseDraftWorker):
             max(model_worker_batch.real_bs, len(model_worker_batch.seq_lens))
         )
         self.copy_model_worker_batch_to_cpu(model_worker_batch)
-        model_worker_batch.spec_info.prepare_for_draft_decode(
+        model_worker_batch.spec_info_padded.prepare_for_draft_decode(
             model_worker_batch, self.topk, self.speculative_num_steps
         )
         model_worker_batch.seq_lens = model_worker_batch.seq_lens
@@ -305,7 +305,7 @@ class EagleDraftWorker(BaseDraftWorker):
         token_indices_with_all_reqs = req_to_token_pool.req_to_token[
             model_worker_batch.req_pool_indices
         ]
-        spec_info = model_worker_batch.spec_info
+        spec_info = model_worker_batch.spec_info_padded
         assert isinstance(spec_info, EagleDraftInput)
         # At dp>1 spec_info arrays arrive at (real_bs,) but seq_lens_cpu is
         # (total_bs,); pad allocate_lens up front so valid_mask indexing works
@@ -348,7 +348,7 @@ class EagleDraftWorker(BaseDraftWorker):
 
         topk_index = spec_info.topk_index
         if self.hot_token_ids is not None:
-            model_worker_batch.spec_info.topk_index = self.hot_token_ids[topk_index]
+            model_worker_batch.spec_info_padded.topk_index = self.hot_token_ids[topk_index]
         if self.topk > 1:
             self.draft_model_runner.attn_backend.forward_metadata.custom_mask = (
                 build_tree_mask_for_draft_decode(
@@ -359,16 +359,16 @@ class EagleDraftWorker(BaseDraftWorker):
                 )
             )
         bs = self.precompile_bs_paddings[padding_bs_index]
-        if bs - model_worker_batch.spec_info.verified_id.shape[0] > 0:
-            model_worker_batch.spec_info.verified_id = np.pad(
-                model_worker_batch.spec_info.verified_id,
-                ((0, bs - model_worker_batch.spec_info.verified_id.shape[0]),),
+        if bs - model_worker_batch.spec_info_padded.verified_id.shape[0] > 0:
+            model_worker_batch.spec_info_padded.verified_id = np.pad(
+                model_worker_batch.spec_info_padded.verified_id,
+                ((0, bs - model_worker_batch.spec_info_padded.verified_id.shape[0]),),
             )
-        if bs - model_worker_batch.spec_info.topk_p.shape[0] > 0:
-            model_worker_batch.spec_info.topk_p = np.pad(
-                model_worker_batch.spec_info.topk_p,
+        if bs - model_worker_batch.spec_info_padded.topk_p.shape[0] > 0:
+            model_worker_batch.spec_info_padded.topk_p = np.pad(
+                model_worker_batch.spec_info_padded.topk_p,
                 (
-                    (0, bs - model_worker_batch.spec_info.topk_p.shape[0]),
+                    (0, bs - model_worker_batch.spec_info_padded.topk_p.shape[0]),
                     (0, 0),
                 ),
             )
@@ -376,24 +376,24 @@ class EagleDraftWorker(BaseDraftWorker):
             model_worker_batch.seq_lens = np.pad(
                 model_worker_batch.seq_lens, ((0, bs - model_worker_batch.seq_lens.shape[0]),)
             )
-            if model_worker_batch.spec_info.allocate_lens is not None:
-                model_worker_batch.spec_info.allocate_lens = np.pad(
-                    model_worker_batch.spec_info.allocate_lens,
-                    ((0, bs - model_worker_batch.spec_info.allocate_lens.shape[0]),),
+            if model_worker_batch.spec_info_padded.allocate_lens is not None:
+                model_worker_batch.spec_info_padded.allocate_lens = np.pad(
+                    model_worker_batch.spec_info_padded.allocate_lens,
+                    ((0, bs - model_worker_batch.spec_info_padded.allocate_lens.shape[0]),),
                 )
-        if bs - model_worker_batch.spec_info.topk_index.shape[0] > 0:
-            model_worker_batch.spec_info.topk_index = np.pad(
-                model_worker_batch.spec_info.topk_index,
+        if bs - model_worker_batch.spec_info_padded.topk_index.shape[0] > 0:
+            model_worker_batch.spec_info_padded.topk_index = np.pad(
+                model_worker_batch.spec_info_padded.topk_index,
                 (
-                    (0, bs - model_worker_batch.spec_info.topk_index.shape[0]),
+                    (0, bs - model_worker_batch.spec_info_padded.topk_index.shape[0]),
                     (0, 0),
                 ),
             )
-        if bs - model_worker_batch.spec_info.hidden_states.shape[0] > 0:
-            model_worker_batch.spec_info.hidden_states = np.pad(
-                model_worker_batch.spec_info.hidden_states,
+        if bs - model_worker_batch.spec_info_padded.hidden_states.shape[0] > 0:
+            model_worker_batch.spec_info_padded.hidden_states = np.pad(
+                model_worker_batch.spec_info_padded.hidden_states,
                 (
-                    (0, bs - model_worker_batch.spec_info.hidden_states.shape[0]),
+                    (0, bs - model_worker_batch.spec_info_padded.hidden_states.shape[0]),
                     (0, 0),
                 ),
             )
@@ -405,9 +405,9 @@ class EagleDraftWorker(BaseDraftWorker):
 
     def draft_forward(self, model_worker_batch: ModelWorkerBatch):
         topk_p, topk_index, hidden_states = (
-            model_worker_batch.spec_info.topk_p,
-            model_worker_batch.spec_info.topk_index,
-            model_worker_batch.spec_info.hidden_states,
+            model_worker_batch.spec_info_padded.topk_p,
+            model_worker_batch.spec_info_padded.topk_index,
+            model_worker_batch.spec_info_padded.hidden_states,
         )
         bs = model_worker_batch.seq_lens.shape[0]
         step_min_1 = self.speculative_num_steps - 1

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -681,25 +681,26 @@ class EagleDraftInput:
 
     def filter_batch(self, new_indices: np.ndarray, has_been_filtered: bool = True):
         new_indices = np.asarray(new_indices)
-        if has_been_filtered:
-            # in eagle_utils.py:verify, we have already filtered the batch by `unfinished_index`
-            # therefore, we don't need to filter the batch again in scheduler
-            if len(new_indices) != len(self.topk_p):
-                logger.warning(
-                    "length of new_indices: %d != length of topk_p: %d, this should not happen",
-                    len(new_indices),
-                    len(self.topk_p),
-                )
+        # Option C: dispatch on whether self has already been trimmed to the
+        # surviving subset. Verify path produces a pre-trimmed next_draft_input
+        # so len matches len(new_indices) — truncate is a no-op. Other paths
+        # (draft_extend) leave self at full per-rank size — fall back to fancy
+        # index. has_been_filtered is kept for backward signalling but the
+        # length check is the real guard.
+        if has_been_filtered and len(new_indices) == len(self.topk_p):
             self.topk_p = self.topk_p[: len(new_indices)]
             self.topk_index = self.topk_index[: len(new_indices)]
             self.hidden_states = self.hidden_states[: len(new_indices)]
             self.verified_id = self.verified_id[: len(new_indices)]
+            if self.allocate_lens is not None:
+                self.allocate_lens = np.asarray(self.allocate_lens)[: len(new_indices)]
         else:
-            # in some cases(e.g draft_extend), we have not filtered the batch by `unfinished_index`
             self.topk_p = self.topk_p[new_indices]
             self.topk_index = self.topk_index[new_indices]
             self.hidden_states = self.hidden_states[new_indices]
             self.verified_id = self.verified_id[new_indices]
+            if self.allocate_lens is not None:
+                self.allocate_lens = np.asarray(self.allocate_lens)[new_indices]
 
     def merge_batch(self, spec_info: EagleDraftInput):
         # FIXME(pc) need support overlap here

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -651,16 +651,20 @@ class EagleDraftInput:
             return
 
         batch.input_ids = self.verified_id
-        accept_length_cpu_arr = batch.spec_info.accept_length_cpu
+        # Option C: deprecated path; read per-rank spec_info via reqs_info[0].
+        rank0_spec = batch.reqs_info[0].spec_info if batch.reqs_info else None
+        accept_length_cpu_arr = rank0_spec.accept_length_cpu if rank0_spec else None
         if accept_length_cpu_arr is None:
             accept_length_cpu_host = np.asarray([], dtype=np.int32)
         else:
             accept_length_cpu_host = accept_length_cpu_arr
         batch.extend_lens = (accept_length_cpu_host + 1).tolist()
         batch.extend_num_tokens = sum(batch.extend_lens)
-        batch.seq_lens = batch.spec_info.seq_lens_for_draft_extend
+        batch.seq_lens = rank0_spec.seq_lens_for_draft_extend if rank0_spec else None
         batch.seq_lens_sum = batch.seq_lens.sum().item()
-        batch.req_pool_indices = batch.spec_info.req_pool_indices_for_draft_extend
+        batch.req_pool_indices = (
+            rank0_spec.req_pool_indices_for_draft_extend if rank0_spec else None
+        )
         batch.return_logprob = False
         batch.return_hidden_states = False
 

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -527,7 +527,7 @@ class EagleDraftInput:
         batch_output: GenerationBatchResult,
         speculative_num_draft_tokens: int,
     ):
-        model_worker_batch.spec_info = self
+        model_worker_batch.spec_info_padded = self
         sel = model_worker_batch.logits_indices_selector
         model_worker_batch.seq_lens[sel] = (
             model_worker_batch.seq_lens[sel] + speculative_num_draft_tokens - 1
@@ -548,10 +548,12 @@ class EagleDraftInput:
             - 1
         )
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
-        model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.FULL
+        model_worker_batch.spec_info_padded.capture_hidden_mode = CaptureHiddenMode.FULL
         model_worker_batch.forward_mode = ForwardMode.DRAFT_EXTEND
-        model_worker_batch.spec_info.hidden_states = batch_output.next_draft_input.hidden_states
-        model_worker_batch.spec_info.accept_length = batch_output.accept_lens
+        model_worker_batch.spec_info_padded.hidden_states = (
+            batch_output.next_draft_input.hidden_states
+        )
+        model_worker_batch.spec_info_padded.accept_length = batch_output.accept_lens
         model_worker_batch.input_ids = batch_output.next_draft_input.verified_id
         forward_metadata = draft_model_runner.attn_backend.get_eagle_forward_metadata(
             model_worker_batch
@@ -852,7 +854,7 @@ class EagleVerifyInput:
         # extend_lens = jnp.array([self.draft_token_num] * bs)
         model_worker_batch.return_hidden_states = False
         model_worker_batch.forward_mode = ForwardMode.TARGET_VERIFY
-        model_worker_batch.spec_info = self
+        model_worker_batch.spec_info_padded = self
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
         model_worker_batch.extend_seq_lens = self.draft_token
         # assert model_worker_batch.capture_hidden_mode == spec_info.capture_hidden_mode

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -651,7 +651,6 @@ class EagleDraftInput:
             return
 
         batch.input_ids = self.verified_id
-        # Option C: deprecated path; read per-rank spec_info via reqs_info[0].
         rank0_spec = batch.reqs_info[0].spec_info if batch.reqs_info else None
         accept_length_cpu_arr = rank0_spec.accept_length_cpu if rank0_spec else None
         if accept_length_cpu_arr is None:
@@ -685,12 +684,10 @@ class EagleDraftInput:
 
     def filter_batch(self, new_indices: np.ndarray, has_been_filtered: bool = True):
         new_indices = np.asarray(new_indices)
-        # Option C: dispatch on whether self has already been trimmed to the
-        # surviving subset. Verify path produces a pre-trimmed next_draft_input
-        # so len matches len(new_indices) — truncate is a no-op. Other paths
-        # (draft_extend) leave self at full per-rank size — fall back to fancy
-        # index. has_been_filtered is kept for backward signalling but the
-        # length check is the real guard.
+        # Verify path produces a pre-trimmed next_draft_input so len matches
+        # and truncate is a no-op. Other paths (draft_extend) leave self at
+        # full per-rank size and need fancy-index; the length check is the
+        # real guard, has_been_filtered is kept for backward signalling.
         if has_been_filtered and len(new_indices) == len(self.topk_p):
             self.topk_p = self.topk_p[: len(new_indices)]
             self.topk_index = self.topk_index[: len(new_indices)]

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -509,16 +509,33 @@ class EagleDraftInput:
             self.verified_id.shape[0] == model_worker_batch.real_bs
         ), f"{self.verified_id.shape=} {model_worker_batch.real_bs=}"
 
-        pt = 0
-        for i in range(model_worker_batch.real_bs):
-            extend_len = model_worker_batch.extend_seq_lens[i]
-            input_ids = model_worker_batch.input_ids[pt : pt + extend_len]
-
-            # TODO: batch.input_ids should on tpu
-            model_worker_batch.input_ids[pt : pt + extend_len] = np.concatenate(
-                (input_ids[1:], self.verified_id[i].reshape(1))
-            )
-            pt += extend_len
+        # Walk the DP-padded layout in (rank, slot) order so token offsets line
+        # up with mwb.input_ids' token-major DP layout. Iterating real_bs and
+        # indexing extend_seq_lens by `i` skipped real reqs whose padded slot
+        # index > i (e.g. dp>1 prefill with only rank>0 active).
+        dp_size = model_worker_batch.dp_size
+        per_dp_bs = model_worker_batch.per_dp_bs_size if dp_size > 1 else 1
+        total_tok = len(model_worker_batch.input_ids)
+        per_dp_tok = total_tok // dp_size if dp_size > 0 else total_tok
+        extend_seq_lens = model_worker_batch.extend_seq_lens
+        flat_idx = 0  # index into self.verified_id (cross-rank flat)
+        for dp_rank in range(dp_size):
+            pt = dp_rank * per_dp_tok
+            for slot_in_rank in range(per_dp_bs):
+                slot = dp_rank * per_dp_bs + slot_in_rank
+                extend_len = int(extend_seq_lens[slot])
+                if extend_len == 0:
+                    continue
+                input_ids = model_worker_batch.input_ids[pt : pt + extend_len]
+                model_worker_batch.input_ids[pt : pt + extend_len] = np.concatenate(
+                    (input_ids[1:], self.verified_id[flat_idx].reshape(1))
+                )
+                pt += extend_len
+                flat_idx += 1
+        assert flat_idx == model_worker_batch.real_bs, (
+            f"prepare_for_extend_after_target_prefill mismatch: walked {flat_idx} "
+            f"real reqs but real_bs={model_worker_batch.real_bs}"
+        )
 
     def prepare_for_extend_after_verify(
         self,

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -514,7 +514,9 @@ class EagleDraftInput:
         # indexing extend_seq_lens by `i` skipped real reqs whose padded slot
         # index > i (e.g. dp>1 prefill with only rank>0 active).
         dp_size = model_worker_batch.dp_size
-        per_dp_bs = model_worker_batch.per_dp_bs_size if dp_size > 1 else 1
+        # per_dp_bs_size already covers both dp=1 (= total_bs) and dp>1
+        # (= total_bs / dp). Hardcoding 1 here drops dp=1 multi-req.
+        per_dp_bs = model_worker_batch.per_dp_bs_size
         total_tok = len(model_worker_batch.input_ids)
         per_dp_tok = total_tok // dp_size if dp_size > 0 else total_tok
         extend_seq_lens = model_worker_batch.extend_seq_lens

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -191,7 +191,7 @@ class EAGLEWorker(BaseSpecWorker):
                     + EagleDraftInput.ALLOC_LEN_PER_DECODE,
                 )
                 model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
-                model_worker_batch.spec_info = spec_info
+                model_worker_batch.spec_info_padded = spec_info
                 model_worker_batch.speculative_eagle_topk = self.topk
                 model_worker_batch.speculative_num_draft_tokens = self.speculative_num_draft_tokens
                 model_worker_batch.speculative_num_steps = self.speculative_num_steps

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -53,8 +53,6 @@ class EAGLEWorker(BaseSpecWorker):
         assert len(accepted_indices) == len(logits_output.next_token_logits)
 
         temperatures = batch.sampling_info.temperatures
-        # Option C: draft_token_num is a scalar shared across ranks; reqs_info[0]
-        # is guaranteed to have spec_info populated when this path runs.
         num_draft_tokens = batch.reqs_info[0].spec_info.draft_token_num
         temperatures = temperatures[accepted_indices // num_draft_tokens]
         if RETURN_ORIGINAL_LOGPROB:

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -53,7 +53,9 @@ class EAGLEWorker(BaseSpecWorker):
         assert len(accepted_indices) == len(logits_output.next_token_logits)
 
         temperatures = batch.sampling_info.temperatures
-        num_draft_tokens = batch.spec_info.draft_token_num
+        # Option C: draft_token_num is a scalar shared across ranks; reqs_info[0]
+        # is guaranteed to have spec_info populated when this path runs.
+        num_draft_tokens = batch.reqs_info[0].spec_info.draft_token_num
         temperatures = temperatures[accepted_indices // num_draft_tokens]
         if RETURN_ORIGINAL_LOGPROB:
             logprobs = jax.nn.log_softmax(logits_output.next_token_logits, axis=-1)
@@ -117,10 +119,12 @@ class EAGLEWorker(BaseSpecWorker):
 
     def precompile_spec_extend(self):
         start_time = time.perf_counter()
+        dp_size = self.server_args.dp_size
         logger.info(
-            "[SPEC_EXTEND] Begin to precompile bs_paddings=%s token_paddings=%s",
+            "[SPEC_EXTEND] Begin to precompile bs_paddings=%s token_paddings=%s dp_size=%d",
             self.precompile_bs_paddings[-1:],
             self.precompile_token_paddings,
+            dp_size,
         )
 
         bs, _ = self.draft_worker.get_max_padded_size()
@@ -130,18 +134,24 @@ class EAGLEWorker(BaseSpecWorker):
             for pair in pbar:
                 pair = list(pair)
                 bs, num_tokens = pair[0], pair[1]
-                pbar.set_postfix(bs=bs, tokens=num_tokens)
+                pbar.set_postfix(bs=bs, tokens=num_tokens, dp_size=dp_size)
                 if bs > num_tokens:
                     logger.warning("bs=%s > num_tokens=%s, skip this pair", bs, num_tokens)
                     continue
+                if bs % dp_size != 0:
+                    logger.warning(
+                        "[SPEC_EXTEND] skip bs=%d (not divisible by dp_size=%d)", bs, dp_size
+                    )
+                    continue
+                per_dp_bs = bs // dp_size
                 model_worker_batch = self.draft_worker.compilation_manager._make_dummy_batch(
                     bs,
                     num_tokens,
                     ForwardMode.EXTEND,
                     self.precompile_cache_loc_paddings[-1],
                     speculative_algorithm=self.speculative_algorithm,
-                    dp_size=1,
-                    per_dp_bs_size=bs,
+                    dp_size=dp_size,
+                    per_dp_bs_size=per_dp_bs,
                 )
                 self.forward_batch_speculative_generation(model_worker_batch)
         end_time = time.perf_counter()
@@ -149,16 +159,24 @@ class EAGLEWorker(BaseSpecWorker):
 
     def precompile_spec_decode(self):
         start_time = time.perf_counter()
+        dp_size = self.server_args.dp_size
         logger.info(
-            "[SPEC_DECODE] Begin to precompile bs_paddings=%s",
+            "[SPEC_DECODE] Begin to precompile bs_paddings=%s dp_size=%d",
             self.precompile_bs_paddings,
+            dp_size,
         )
 
         with tqdm(
             self.precompile_bs_paddings, desc="[SPEC_DECODE] PRECOMPILE", leave=False
         ) as pbar:
             for bs in pbar:
-                pbar.set_postfix(bs=bs)
+                pbar.set_postfix(bs=bs, dp_size=dp_size)
+                if bs % dp_size != 0:
+                    logger.warning(
+                        "[SPEC_DECODE] skip bs=%d (not divisible by dp_size=%d)", bs, dp_size
+                    )
+                    continue
+                per_dp_bs = bs // dp_size
                 aligned_cache_loc_size = (
                     (bs * self.draft_worker.max_req_len + self.page_size - 1)
                     // self.page_size
@@ -170,8 +188,8 @@ class EAGLEWorker(BaseSpecWorker):
                     ForwardMode.DECODE,
                     aligned_cache_loc_size,
                     speculative_algorithm=self.speculative_algorithm,
-                    dp_size=1,
-                    per_dp_bs_size=bs,
+                    dp_size=dp_size,
+                    per_dp_bs_size=per_dp_bs,
                 )
                 spec_info = EagleDraftInput(
                     # FIXME(pc) dtype should according to serverargs

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -138,9 +138,9 @@ class MultiLayerDraftWorker(EagleDraftWorker):
     # ---- per-layer overrides ------------------------------------------------
 
     def draft_forward(self, model_worker_batch: ModelWorkerBatch):
-        topk_p = model_worker_batch.spec_info.topk_p
-        topk_index = model_worker_batch.spec_info.topk_index
-        hidden_states = model_worker_batch.spec_info.hidden_states
+        topk_p = model_worker_batch.spec_info_padded.topk_p
+        topk_index = model_worker_batch.spec_info_padded.topk_index
+        hidden_states = model_worker_batch.spec_info_padded.hidden_states
         bs = model_worker_batch.seq_lens.shape[0]
         step_min_1 = self.speculative_num_steps - 1
         score_list = jnp.empty((bs, 1 + step_min_1 * self.topk, self.topk))
@@ -209,7 +209,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         """
         sel = np.asarray(model_worker_batch.logits_indices_selector)
         verified_id_np = np.asarray(jax.device_get(next_token_ids))[sel]
-        model_worker_batch.spec_info = EagleDraftInput(
+        model_worker_batch.spec_info_padded = EagleDraftInput(
             hidden_states=hidden_states,
             verified_id=verified_id_np,
             num_tokens_per_batch=np.asarray(1, dtype=jnp.int32),
@@ -217,11 +217,11 @@ class MultiLayerDraftWorker(EagleDraftWorker):
             allocate_lens=model_worker_batch.seq_lens,
         )
         model_worker_batch.return_hidden_states = False
-        model_worker_batch.spec_info.prepare_for_extend_after_target_prefill(
+        model_worker_batch.spec_info_padded.prepare_for_extend_after_target_prefill(
             model_worker_batch=model_worker_batch
         )
         # FULL: layer i+1 needs layer i's per-token hidden over the whole prefix.
-        model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.FULL
+        model_worker_batch.spec_info_padded.capture_hidden_mode = CaptureHiddenMode.FULL
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
         last_idx = model_worker_batch.logits_indices
 
@@ -229,7 +229,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         cur_hidden = hidden_states
         for i, w in enumerate(self._workers):
             mr = w.model_runner
-            model_worker_batch.spec_info.hidden_states = cur_hidden
+            model_worker_batch.spec_info_padded.hidden_states = cur_hidden
             forward_batch = ForwardBatch.init_new(model_worker_batch, mr)
             forward_batch.return_logprob = False
             mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(
@@ -254,9 +254,11 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         )
         layer0_out.next_token_logits = rep_logits[sel, :]
         layer0_out.hidden_states = rep_hidden[last_idx][sel]
-        model_worker_batch.spec_info.hidden_states = hidden_states
-        model_worker_batch.spec_info.allocate_lens = np.asarray(model_worker_batch.seq_lens)[sel]
-        self.capture_for_decode(layer0_out, model_worker_batch.spec_info)
+        model_worker_batch.spec_info_padded.hidden_states = hidden_states
+        model_worker_batch.spec_info_padded.allocate_lens = np.asarray(model_worker_batch.seq_lens)[
+            sel
+        ]
+        self.capture_for_decode(layer0_out, model_worker_batch.spec_info_padded)
 
     def draft_extend_for_decode(
         self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
@@ -291,7 +293,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         cur_hidden = target_hidden
         for i, w in enumerate(self._workers):
             mr = w.model_runner
-            mwb.spec_info.hidden_states = cur_hidden
+            mwb.spec_info_padded.hidden_states = cur_hidden
             mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(mwb)
             forward_batch = ForwardBatch.init_new(mwb, mr)
             logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)

--- a/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
+++ b/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
@@ -161,7 +161,7 @@ def test_get_spec_decode_mwb_dp_shapes(dp, bs_per_rank):
         seg = mwb.seq_lens[r * per_dp : r * per_dp + per_dp]
         assert np.all(seg[:bs] > 0), f"rank {r} real slots zero: {seg}"
         assert np.all(seg[bs:] == 0), f"rank {r} pad slots nonzero: {seg}"
-    assert mwb.spec_info is not None
+    assert mwb.spec_info_padded is not None
 
 
 @pytest.mark.parametrize(
@@ -250,7 +250,7 @@ def test_filter_batch_then_decode_mwb_round_trip():
     assert np.all(mwb.seq_lens[:per_dp] == 0)
     assert mwb.seq_lens[per_dp] > 0
     # spec_info is now DP-padded (total_bs,); rank 1's data must be at slot per_dp.
-    al = np.asarray(mwb.spec_info.allocate_lens)
+    al = np.asarray(mwb.spec_info_padded.allocate_lens)
     assert al.shape[0] == per_dp * dp
     assert int(al[per_dp]) == 120
     assert int(al[0]) == 0  # rank-0 padding slot
@@ -293,7 +293,7 @@ def test_spec_info_aligns_with_dp_padded_slots(dp, bs_per_rank):
     total_bs = per_dp * dp
 
     # Simulate padding_for_decode's pad-then-valid_mask gather:
-    al = np.asarray(mwb.spec_info.allocate_lens)
+    al = np.asarray(mwb.spec_info_padded.allocate_lens)
     if len(al) < total_bs:
         al = np.pad(al, (0, total_bs - len(al)))
     valid_mask = mwb.seq_lens > 0
@@ -348,7 +348,7 @@ def test_draft_page_indices_dp_segmented(dp, bs_per_rank):
     # global-flat req id k so we can verify which req each page belongs to.
     L_tok, page = 8192, 256
     cache_loc = np.full(L_tok * dp, -1, dtype=np.int32)
-    al = np.asarray(mwb.spec_info.allocate_lens)
+    al = np.asarray(mwb.spec_info_padded.allocate_lens)
     aligned = ((al + page - 1) // page) * page
     intra = np.zeros(dp, dtype=np.int64)
     for s in np.where(mwb.seq_lens > 0)[0]:

--- a/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
+++ b/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
@@ -392,3 +392,77 @@ def test_resolve_spec_decode_token_ids(dp, bs_per_rank, accept_per_slot):
                 assert sb.reqs_info[r].reqs[j].spec_accepted_tokens == a
             else:
                 assert out[slot] == [], f"pad slot {slot} should be []"
+
+
+# ---------------------------------------------------------------------------
+# Option C helpers: split / concat per-rank round-trip
+# ---------------------------------------------------------------------------
+
+
+def _mk_distinct_spec_info(real_bs: int, seed: int = 0) -> EagleDraftInput:
+    """Like ``_mk_spec_info`` but with distinct values so we can detect
+    row reordering / mis-slicing after round-trip."""
+    rng = np.random.default_rng(seed)
+    base = np.arange(real_bs, dtype=np.int32) + seed * 1000
+    return EagleDraftInput(
+        topk_p=rng.random((real_bs, TOPK), dtype=np.float32),
+        topk_index=np.tile(base[:, None], (1, TOPK)).astype(np.int32),
+        hidden_states=np.tile(base[:, None], (1, HIDDEN)).astype(np.float32),
+        verified_id=base.copy(),
+        allocate_lens=(base + 8).astype(np.int32),
+    )
+
+
+@pytest.mark.parametrize(
+    "real_bs_per_dp",
+    [
+        [4],
+        [2, 2],
+        [3, 0],
+        [0, 3],
+        [1, 1, 1, 1],
+        [0, 2, 0, 3],
+    ],
+    ids=["dp1-4", "dp2-2+2", "dp2-3+0", "dp2-0+3", "dp4-1x4", "dp4-mixed"],
+)
+def test_split_concat_spec_info_round_trip(real_bs_per_dp):
+    """split → concat should reproduce the original cross-rank-flat layout."""
+    total = sum(real_bs_per_dp)
+    flat = _mk_distinct_spec_info(total, seed=1)
+
+    parts = ScheduleBatch._split_spec_info_per_rank(flat, real_bs_per_dp)
+    assert len(parts) == len(real_bs_per_dp)
+    for n, p in zip(real_bs_per_dp, parts):
+        if n == 0:
+            assert p is None
+        else:
+            assert p is not None
+            assert p.topk_p.shape == (n, TOPK)
+            assert p.verified_id.shape == (n,)
+            assert p.capture_hidden_mode == flat.capture_hidden_mode
+
+    back = ScheduleBatch._concat_spec_info_per_rank(parts)
+    assert back is not None
+    np.testing.assert_array_equal(np.asarray(back.topk_index), np.asarray(flat.topk_index))
+    np.testing.assert_array_equal(np.asarray(back.verified_id), np.asarray(flat.verified_id))
+    np.testing.assert_array_equal(np.asarray(back.allocate_lens), np.asarray(flat.allocate_lens))
+    np.testing.assert_array_equal(np.asarray(back.hidden_states), np.asarray(flat.hidden_states))
+    np.testing.assert_allclose(np.asarray(back.topk_p), np.asarray(flat.topk_p))
+
+
+def test_split_spec_info_none_passthrough():
+    parts = ScheduleBatch._split_spec_info_per_rank(None, [2, 3])
+    assert parts == [None, None]
+
+
+def test_concat_spec_info_all_none():
+    assert ScheduleBatch._concat_spec_info_per_rank([None, None]) is None
+
+
+def test_concat_spec_info_some_none_skips():
+    """Non-empty rank's data should be preserved when others are None."""
+    s = _mk_distinct_spec_info(3, seed=2)
+    out = ScheduleBatch._concat_spec_info_per_rank([None, s, None])
+    assert out is not None
+    np.testing.assert_array_equal(np.asarray(out.verified_id), np.asarray(s.verified_id))
+    assert out.verified_id.shape == (3,)

--- a/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
+++ b/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
@@ -86,9 +86,8 @@ def _mk_batch(dp_size: int, bs_per_rank: list[int]) -> ScheduleBatch:
         info.spec_info = None
         info.sampling_info = None
         reqs_info.append(info)
-    # Option C: spec_info is per-rank (symmetric with reqs/seq_lens). Build a
-    # cross-rank-flat one then split into reqs_info[r].spec_info so tests
-    # exercise the same layout the production producer/consumer pair uses.
+    # Build a cross-rank-flat EagleDraftInput then split into per-rank slots
+    # so tests exercise the same layout the production producer/consumer uses.
     flat_spec = _mk_spec_info(real_bs)
     per_rank_spec = ScheduleBatch._split_spec_info_per_rank(flat_spec, bs_per_rank)
     for r, s in enumerate(per_rank_spec):
@@ -175,7 +174,7 @@ def test_get_spec_decode_mwb_dp_shapes(dp, bs_per_rank):
     ],
 )
 def test_filter_batch_preserves_global_spec_info(dp, bs_per_rank, finish):
-    """Option C: spec_info filters naturally per-rank in the loop.
+    """spec_info filters naturally per-rank inside the loop.
 
     Tag each rank's spec arrays with a stable offset so we can verify which
     entries survive partial-finish.
@@ -226,7 +225,7 @@ def test_filter_batch_then_decode_mwb_round_trip():
 
     After rank 0 empties, the next `_get_spec_decode_mwb_dp` must still produce
     a dp-divisible mwb whose spec_info aligns with the DP-padded seq_lens slots.
-    Option C: per-rank spec_info on reqs_info[r].spec_info; the concat helper
+    Per-rank spec_info on reqs_info[r].spec_info; the concat helper
     rebuilds the cross-rank-flat view consumed by the scatter helper.
     """
     dp, bs_per_rank = 2, [1, 1]
@@ -277,8 +276,8 @@ def test_spec_info_aligns_with_dp_padded_slots(dp, bs_per_rank):
     """
     sb = _mk_batch(dp, bs_per_rank)
     real_bs = sum(bs_per_rank)
-    # Option C: tag per-rank allocate_lens with global-flat-style indices so
-    # _concat re-assembles the cross-rank-flat view the scatter helper expects.
+    # Tag per-rank allocate_lens with global-flat-style indices so _concat
+    # re-assembles the cross-rank-flat view the scatter helper expects.
     flat_base = 0
     for r, bs in enumerate(bs_per_rank):
         if bs == 0:
@@ -329,7 +328,7 @@ def test_draft_page_indices_dp_segmented(dp, bs_per_rank):
     """
     sb = _mk_batch(dp, bs_per_rank)
     real_bs = sum(bs_per_rank)
-    # Option C: distinct allocate_lens per rank so page boundaries observable.
+    # Distinct allocate_lens per rank so page boundaries are observable.
     flat_base = 0
     for r, bs in enumerate(bs_per_rank):
         if bs == 0:
@@ -433,7 +432,7 @@ def test_resolve_spec_decode_token_ids(dp, bs_per_rank, accept_per_slot):
 
 
 # ---------------------------------------------------------------------------
-# Option C helpers: split / concat per-rank round-trip
+# split / concat per-rank round-trip helpers
 # ---------------------------------------------------------------------------
 
 

--- a/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
+++ b/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
@@ -86,7 +86,13 @@ def _mk_batch(dp_size: int, bs_per_rank: list[int]) -> ScheduleBatch:
         info.spec_info = None
         info.sampling_info = None
         reqs_info.append(info)
-    reqs_info[0].spec_info = _mk_spec_info(real_bs)
+    # Option C: spec_info is per-rank (symmetric with reqs/seq_lens). Build a
+    # cross-rank-flat one then split into reqs_info[r].spec_info so tests
+    # exercise the same layout the production producer/consumer pair uses.
+    flat_spec = _mk_spec_info(real_bs)
+    per_rank_spec = ScheduleBatch._split_spec_info_per_rank(flat_spec, bs_per_rank)
+    for r, s in enumerate(per_rank_spec):
+        reqs_info[r].spec_info = s
 
     sb = ScheduleBatch.__new__(ScheduleBatch)
     sb.__dict__.update(
@@ -169,37 +175,50 @@ def test_get_spec_decode_mwb_dp_shapes(dp, bs_per_rank):
     ],
 )
 def test_filter_batch_preserves_global_spec_info(dp, bs_per_rank, finish):
+    """Option C: spec_info filters naturally per-rank in the loop.
+
+    Tag each rank's spec arrays with a stable offset so we can verify which
+    entries survive partial-finish.
+    """
     sb = _mk_batch(dp, bs_per_rank)
-    real_bs = sum(bs_per_rank)
-    # Tag spec_info arrays so we can verify which entries survive.
-    spec = sb.reqs_info[0].spec_info
-    spec.allocate_lens = np.arange(100, 100 + real_bs, dtype=np.int32)
-    spec.verified_id = np.arange(200, 200 + real_bs, dtype=np.int32)
-    spec.hidden_states = np.arange(real_bs, dtype=np.float32).reshape(real_bs, 1).repeat(HIDDEN, 1)
-    # Compute expected survivors in global-flat order BEFORE marking finished.
-    finish_set = set(finish)
-    expected_keep = []
-    flat = 0
+    # Tag each rank's spec_info arrays with deterministic values.
+    flat_base = 0
     for r, bs in enumerate(bs_per_rank):
-        for j in range(bs):
-            if (r, j) not in finish_set:
-                expected_keep.append(flat)
-            flat += 1
+        if bs == 0:
+            continue
+        spec = sb.reqs_info[r].spec_info
+        spec.allocate_lens = np.arange(100 + flat_base, 100 + flat_base + bs, dtype=np.int32)
+        spec.verified_id = np.arange(200 + flat_base, 200 + flat_base + bs, dtype=np.int32)
+        spec.hidden_states = (
+            np.arange(flat_base, flat_base + bs, dtype=np.float32).reshape(bs, 1).repeat(HIDDEN, 1)
+        )
+        flat_base += bs
+
+    finish_set = set(finish)
     for r, j in finish:
         sb.reqs_info[r].reqs[j]._done = True
 
     sb.filter_batch()
 
-    new_spec = sb.reqs_info[0].spec_info
-    assert new_spec is not None, "global spec_info dropped after partial-finish"
-    assert new_spec.allocate_lens.shape == (len(expected_keep),)
-    assert list(new_spec.allocate_lens) == [100 + i for i in expected_keep]
-    assert list(new_spec.verified_id) == [200 + i for i in expected_keep]
-    assert new_spec.hidden_states.shape == (len(expected_keep), HIDDEN)
-    # Surviving reqs per rank should match.
+    # Per-rank assertions: each rank's spec_info holds exactly its survivors.
+    flat_base = 0
     for r, bs in enumerate(bs_per_rank):
-        kept = bs - sum(1 for fr, fj in finish if fr == r)
-        assert len(sb.reqs_info[r].reqs or []) == kept
+        if bs == 0:
+            assert sb.reqs_info[r].spec_info is None
+            continue
+        kept = [j for j in range(bs) if (r, j) not in finish_set]
+        if not kept:
+            # Early-exit clears spec_info to None.
+            assert sb.reqs_info[r].spec_info is None
+            flat_base += bs
+            continue
+        spec = sb.reqs_info[r].spec_info
+        assert spec is not None, f"rank {r} spec_info dropped"
+        assert list(np.asarray(spec.allocate_lens)) == [100 + flat_base + j for j in kept]
+        assert list(np.asarray(spec.verified_id)) == [200 + flat_base + j for j in kept]
+        assert np.asarray(spec.hidden_states).shape == (len(kept), HIDDEN)
+        assert len(sb.reqs_info[r].reqs or []) == len(kept)
+        flat_base += bs
 
 
 def test_filter_batch_then_decode_mwb_round_trip():
@@ -207,14 +226,20 @@ def test_filter_batch_then_decode_mwb_round_trip():
 
     After rank 0 empties, the next `_get_spec_decode_mwb_dp` must still produce
     a dp-divisible mwb whose spec_info aligns with the DP-padded seq_lens slots.
+    Option C: per-rank spec_info on reqs_info[r].spec_info; the concat helper
+    rebuilds the cross-rank-flat view consumed by the scatter helper.
     """
     dp, bs_per_rank = 2, [1, 1]
     sb = _mk_batch(dp, bs_per_rank)
-    spec = sb.reqs_info[0].spec_info
-    spec.allocate_lens = np.array([110, 120], dtype=np.int32)
+    # Per-rank tagging: rank 0 gets allocate_len=110, rank 1 gets 120.
+    sb.reqs_info[0].spec_info.allocate_lens = np.array([110], dtype=np.int32)
+    sb.reqs_info[1].spec_info.allocate_lens = np.array([120], dtype=np.int32)
     sb.reqs_info[0].reqs[0]._done = True
     sb.filter_batch()
-    # rank 0 empty, rank 1 has 1 req; spec_info global-flat now [120].
+    # rank 0 cleared, rank 1 keeps its [120].
+    assert sb.reqs_info[0].spec_info is None
+    assert list(np.asarray(sb.reqs_info[1].spec_info.allocate_lens)) == [120]
+
     buckets = [b for b in BS_BUCKETS if b >= dp]
     mwb = sb._get_spec_decode_mwb_dp(buckets, enable_static_lora=False)
     assert mwb.real_bs == 1
@@ -252,9 +277,16 @@ def test_spec_info_aligns_with_dp_padded_slots(dp, bs_per_rank):
     """
     sb = _mk_batch(dp, bs_per_rank)
     real_bs = sum(bs_per_rank)
-    spec = sb.reqs_info[0].spec_info
-    # Tag allocate_lens with global-flat indices so we know which req each is.
-    spec.allocate_lens = np.arange(100, 100 + real_bs, dtype=np.int32)
+    # Option C: tag per-rank allocate_lens with global-flat-style indices so
+    # _concat re-assembles the cross-rank-flat view the scatter helper expects.
+    flat_base = 0
+    for r, bs in enumerate(bs_per_rank):
+        if bs == 0:
+            continue
+        sb.reqs_info[r].spec_info.allocate_lens = np.arange(
+            100 + flat_base, 100 + flat_base + bs, dtype=np.int32
+        )
+        flat_base += bs
     buckets = [b for b in BS_BUCKETS if b >= dp]
     mwb = sb._get_spec_decode_mwb_dp(buckets, enable_static_lora=False)
     per_dp = mwb.per_dp_bs_size
@@ -297,9 +329,15 @@ def test_draft_page_indices_dp_segmented(dp, bs_per_rank):
     """
     sb = _mk_batch(dp, bs_per_rank)
     real_bs = sum(bs_per_rank)
-    spec = sb.reqs_info[0].spec_info
-    # Distinct seq_len per req so page boundaries are observable.
-    spec.allocate_lens = np.asarray([256 * (k + 1) + 4 for k in range(real_bs)], dtype=np.int32)
+    # Option C: distinct allocate_lens per rank so page boundaries observable.
+    flat_base = 0
+    for r, bs in enumerate(bs_per_rank):
+        if bs == 0:
+            continue
+        sb.reqs_info[r].spec_info.allocate_lens = np.asarray(
+            [256 * (flat_base + k + 1) + 4 for k in range(bs)], dtype=np.int32
+        )
+        flat_base += bs
     buckets = [b for b in BS_BUCKETS if b >= dp]
     mwb = sb._get_spec_decode_mwb_dp(buckets, enable_static_lora=False)
     per_dp = mwb.per_dp_bs_size

--- a/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
+++ b/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
@@ -503,3 +503,80 @@ def test_concat_spec_info_some_none_skips():
     assert out is not None
     np.testing.assert_array_equal(np.asarray(out.verified_id), np.asarray(s.verified_id))
     assert out.verified_id.shape == (3,)
+
+
+def _mk_batch_with_tagged_spec(
+    dp_size: int, bs_per_rank: list[int], *, tag_base: int
+) -> ScheduleBatch:
+    """``_mk_batch`` + tag per-rank ``spec_info.verified_id`` so that after a
+    cross-rank merge each entry stays traceable to ``(rank, side, idx)``.
+
+    Tag value for rank ``r`` request ``j`` is ``tag_base + r * 1000 + j``.
+    """
+    sb = _mk_batch(dp_size, bs_per_rank)
+    for r, bs in enumerate(bs_per_rank):
+        if bs == 0:
+            continue
+        sb.reqs_info[r].spec_info.verified_id = np.asarray(
+            [tag_base + r * 1000 + j for j in range(bs)], dtype=np.int32
+        )
+    return sb
+
+
+def _expected_after_merge(
+    bs_self: list[int], bs_other: list[int], *, self_base: int, other_base: int
+) -> list[list[int] | None]:
+    """Per-rank expected ``verified_id`` after ``self.merge_batch(other)``.
+
+    Matches ``ScheduleBatch.merge_batch`` semantics:
+    - other rank empty → self unchanged
+    - self rank empty (and other non-empty) → take other's spec_info wholesale
+    - both non-empty → ``EagleDraftInput.merge_batch`` concatenates self ++ other
+    """
+    out: list[list[int] | None] = []
+    for r, (ns, no) in enumerate(zip(bs_self, bs_other)):
+        if no == 0:
+            out.append([self_base + r * 1000 + j for j in range(ns)] if ns > 0 else None)
+            continue
+        if ns == 0:
+            out.append([other_base + r * 1000 + j for j in range(no)])
+            continue
+        out.append(
+            [self_base + r * 1000 + j for j in range(ns)]
+            + [other_base + r * 1000 + j for j in range(no)]
+        )
+    return out
+
+
+@pytest.mark.parametrize(
+    "bs_self,bs_other",
+    [
+        # (a) Both ranks non-empty on both sides → per-rank concat via
+        # EagleDraftInput.merge_batch (the path the refactor was motivated by).
+        ([2, 1], [1, 2]),
+        # (b) Other rank0 empty → merge_batch hits the early `continue` (old
+        # L1685 in pre-refactor numbering); self.r0 must stay tagged with
+        # self's values, r1 still concatenates.
+        ([2, 1], [0, 2]),
+        # (c) Self rank0 empty → merge_batch falls into the overwrite branch
+        # (old L1700) and pulls other's spec_info wholesale; r1 has other
+        # empty so stays as self.
+        ([0, 2], [1, 0]),
+    ],
+)
+def test_merge_batch_per_rank_spec_info(bs_self, bs_other):
+    self_base, other_base = 10_000, 20_000
+    self_sb = _mk_batch_with_tagged_spec(2, bs_self, tag_base=self_base)
+    other_sb = _mk_batch_with_tagged_spec(2, bs_other, tag_base=other_base)
+
+    self_sb.merge_batch(other_sb)
+
+    expected = _expected_after_merge(bs_self, bs_other, self_base=self_base, other_base=other_base)
+    for r, want in enumerate(expected):
+        spec = self_sb.reqs_info[r].spec_info
+        if want is None:
+            assert spec is None, f"rank {r}: expected None spec_info, got {spec}"
+            continue
+        assert spec is not None, f"rank {r}: expected spec_info, got None"
+        got = list(np.asarray(spec.verified_id))
+        assert got == want, f"rank {r}: verified_id {got} != expected {want}"

--- a/python/sgl_jax/test/test_compilation_manager.py
+++ b/python/sgl_jax/test/test_compilation_manager.py
@@ -220,7 +220,7 @@ class TestDummyBatch(unittest.TestCase):
         )
         assert batch.dp_size == 4
         assert batch.per_dp_bs_size == 16
-        assert batch.real_bs_per_dp == [64, 64, 64, 64]
+        assert batch.real_bs_per_dp == [16, 16, 16, 16]
 
     def test_multimodal_capture_hidden(self):
         cm = CompilationManager(

--- a/python/sgl_jax/test/test_flashattention.py
+++ b/python/sgl_jax/test/test_flashattention.py
@@ -325,7 +325,7 @@ def create_test_data(
         logits_indices=np.asarray(extend_seq_lens),
         real_bs=seq_lens.shape[0],
         real_bs_per_dp=[seq_lens.shape[0]],
-        spec_info=spec_info,
+        spec_info_padded=spec_info,
         dp_size=1,
         per_dp_bs_size=seq_lens.shape[0],
     )

--- a/python/sgl_jax/test/test_kda_attention.py
+++ b/python/sgl_jax/test/test_kda_attention.py
@@ -350,7 +350,7 @@ def create_test_data(
         real_bs_per_dp=[batch_size],
         dp_size=1,
         per_dp_bs_size=batch_size,
-        spec_info=None,
+        spec_info_padded=None,
         recurrent_indices=recurrent_indices,
         has_initial_state=has_initial_state_np,
     )

--- a/python/sgl_jax/test/test_kda_attention_dp.py
+++ b/python/sgl_jax/test/test_kda_attention_dp.py
@@ -421,7 +421,7 @@ def create_test_data(
         real_bs_per_dp=real_bs_per_dp,
         dp_size=dp_size,
         per_dp_bs_size=per_dp_bs_padding,
-        spec_info=None,
+        spec_info_padded=None,
         recurrent_indices=recurrent_indices_cpu,
         has_initial_state=has_initial_state_cpu,
     )

--- a/python/sgl_jax/test/test_mla_attention.py
+++ b/python/sgl_jax/test/test_mla_attention.py
@@ -305,7 +305,7 @@ def create_mla_forward_batch(
         real_bs_per_dp=[len(lens)],
         dp_size=1,
         per_dp_bs_size=len(lens),
-        spec_info=None,
+        spec_info_padded=None,
     )
 
     fb = ForwardBatch(


### PR DESCRIPTION
Refactor scheduler-persisted \`spec_info\` from PR #1108's "cross-rank flat on \`reqs_info[0]\`" single-point layout to **per-rank** (symmetric with \`reqs\` / \`seq_lens\` / \`req_pool_indices\`). Forward path stays cross-rank-flat / DP-scatter-padded; boundary code does split/concat conversion.

Five commits map to five steps, each independently runnable:

| Commit | Step | Summary |
|---|---|---|
| \`ee14210e\` | A | Add \`_split/_concat_spec_info_per_rank\` pure-function helpers + CPU round-trip tests |
| \`4c34ccd2\` | B | Boundary swap: input side concat→scatter in \`_get_spec_decode_mwb_dp\`, output side split→write back to \`reqs_info[r].spec_info\`; introduce \`MWB.spec_info_padded\` field; drop \`_global_spec\` pull-out/putback from \`filter_batch\`; route all spec extend through \`get_model_worker_batch\` (\`get_spec_model_worker_batch\` shrinks to decode-only) |
| \`464de2ff\` | C | Rename 30+ forward-internal \`mwb.spec_info\` to \`mwb.spec_info_padded\` across single-layer (\`eagle_draft_worker\`) and multi-layer (\`multi_layer_draft_worker\`); drop \`MWB.spec_info\` dataclass field |
| \`3ea953f4\` | D | Simplify \`filter_batch\` (drop manual 5-field filter; \`EagleDraftInput.filter_batch\` covers all 5 and dispatches by length match instead of trusting \`has_been_filtered\`); make \`padding_for_decode\` **DP-segmented per-field pad** (end-padding lets shard_map(P(\"data\")) hand a following rank's data to a prior rank under dp>1) |
| \`88d6fb28\` | E | Drop \`ScheduleBatch.spec_info\` (mixin's dynamic attribute write removed; all \`self.spec_info\` readers switched to \`reqs_info[0].spec_info\`); cherry-pick PR #1108 follow-up's dp>1 precompile fix (\`compilation_manager.real_bs_per_dp\` + EAGLE worker \`precompile_spec_*\`) |

### Testing done

- **CPU**: \`test_spec_dp_shapes.py\` 37/37 (28 baseline + 9 new round-trip + assertions updated for per-rank layout)
- **Pod single-layer EAGLE3** (\`niu-v6e4-sleep\` 4-chip v6e, Llama-3.1-8B-Instruct + EAGLE3-LLaMA3.1-Instruct-8B):
  - dp=1 single req → reference \`[264,3363,315,30363,11,1989,11,11401,11,323]\` ✓
  - dp=1 concurrent x4 → all reqs match reference ✓
  - dp=2 single req → matches reference ✓

### Known issues (not in scope)

- **dp>1 multi-req concurrent token mismatch**: dp=2 with 2+ concurrent reqs produces wrong (repeating) tokens for half the reqs. Diagnostic logging proves split/concat/scatter/merge_batch are all correct (layouts align with selector); the bug is forward-internal (KV cache or attention-metadata vs dp-shard synchronization). This is an **inherent issue in PR #1108's dp>1 spec extend path**: baseline asserts dp>1 spec extend off, so it was never exercised. This PR finally routes dp>1 spec extend through, surfacing the bug. **Tracked separately; follow-up PR.**
- **Multi-layer EAGLE (MiMo-V2-Pro) end-to-end validation**: code rename covered (\`multi_layer_draft_worker.py\` 11 sites); E2E left to the next stage per plan (single-layer first, then multi-layer).