### PR TITLE
ci: CI cleanup — shell unification, publish consolidation, cache monitoring (P2-7)

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         timeout-minutes: 3000
         run: |
           python3.12 -m venv .venv
@@ -50,7 +51,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type bench --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-text-models-1-tpu-daily:
@@ -70,6 +71,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -94,7 +96,7 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
 
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type perf --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-trace-text-models-1-tpu-daily:
@@ -114,6 +116,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -137,4 +140,4 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_traces.py --traces-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type trace --source-dir ./test/nightly_test_output

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         timeout-minutes: 3000
         run: |
           python3.12 -m venv .venv
@@ -54,7 +55,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type bench --source-dir ./test/nightly_test_output
 
       - name: Generate CSV Entry and publish
         env:
@@ -76,7 +77,7 @@ jobs:
           fi
           echo "$SHA,$AUTHOR,$MSG,$RUN_URL" >> $FILE
           echo "CSV line added: $SHA, $AUTHOR, $MSG"
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./meta
+          python3 scripts/ci/publish.py --data-type bench --source-dir ./meta
 
 
   nightly-test-accuracy-text-models-4-tpu:
@@ -96,6 +97,7 @@ jobs:
         env:
             HF_TOKEN: ${{ secrets.HF_TOKEN }}
             HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+            JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         timeout-minutes: 1200
         run: |
           python3.12 -m venv .venv
@@ -119,7 +121,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type bench --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-text-models-1-tpu:
@@ -143,6 +145,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -167,7 +170,7 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
 
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type perf --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-text-models-4-tpu-part1:
@@ -188,6 +191,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -211,7 +215,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type perf --source-dir ./test/nightly_test_output
 
       - name: Generate CSV Entry and publish
         env:
@@ -233,7 +237,7 @@ jobs:
           fi
           echo "$SHA,$AUTHOR,$MSG,$RUN_URL" >> $FILE
           echo "CSV line added: $SHA, $AUTHOR, $MSG"
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./meta
+          python3 scripts/ci/publish.py --data-type perf --source-dir ./meta
 
 
   nightly-test-perf-text-models-4-tpu-part2:
@@ -254,6 +258,7 @@ jobs:
             PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
             HF_TOKEN: ${{ secrets.HF_TOKEN }}
             HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+            JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
           run: |
             python3.12 -m venv .venv
             source .venv/bin/activate
@@ -277,7 +282,7 @@ jobs:
             GITHUB_RUN_ID: ${{ github.run_id }}
             GITHUB_RUN_NUMBER: ${{ github.run_number }}
           run: |
-            python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+            python3 scripts/ci/publish.py --data-type perf --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-text-models-4-tpu-part3:
@@ -298,6 +303,7 @@ jobs:
               PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
               HF_TOKEN: ${{ secrets.HF_TOKEN }}
               HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+              JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
             run: |
               python3.12 -m venv .venv
               source .venv/bin/activate
@@ -321,7 +327,7 @@ jobs:
               GITHUB_RUN_ID: ${{ github.run_id }}
               GITHUB_RUN_NUMBER: ${{ github.run_number }}
             run: |
-              python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+              python3 scripts/ci/publish.py --data-type perf --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-trace-text-models-1-tpu:
@@ -345,6 +351,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -368,7 +375,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_traces.py --traces-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type trace --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-trace-text-models-4-tpu-part1:
@@ -389,6 +396,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         run: |
           python3.12 -m venv .venv
           source .venv/bin/activate
@@ -412,7 +420,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_traces.py --traces-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type trace --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-trace-text-models-4-tpu-part2:
@@ -433,6 +441,7 @@ jobs:
             PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
             HF_TOKEN: ${{ secrets.HF_TOKEN }}
             HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+            JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
           run: |
             python3.12 -m venv .venv
             source .venv/bin/activate
@@ -456,7 +465,7 @@ jobs:
             GITHUB_RUN_ID: ${{ github.run_id }}
             GITHUB_RUN_NUMBER: ${{ github.run_number }}
           run: |
-            python3 scripts/ci/publish_traces.py --traces-dir ./test/nightly_test_output
+            python3 scripts/ci/publish.py --data-type trace --source-dir ./test/nightly_test_output
 
         - name: Generate CSV Entry and publish
           env:
@@ -478,4 +487,4 @@ jobs:
             fi
             echo "$SHA,$AUTHOR,$MSG,$RUN_URL" >> $FILE
             echo "CSV line added: $SHA, $AUTHOR, $MSG"
-            python3 scripts/ci/publish_bench_and_perf.py --source-dir ./meta
+            python3 scripts/ci/publish.py --data-type bench --source-dir ./meta

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Fail if the PR is a draft
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
+        shell: bash
         run: |
           echo "This pull request is a draft. Failing the workflow."
           exit 1
@@ -100,6 +101,7 @@ jobs:
         uses: actions/checkout@v5
       - name: Run unit test
         timeout-minutes: 30
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
         run: |
@@ -179,6 +181,7 @@ jobs:
 
       - name: Evaluate accuracy
         timeout-minutes: 20
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -206,6 +209,7 @@ jobs:
 
       - name: Evaluate MoE accuracy (TP=4)
         timeout-minutes: 50
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -234,6 +238,7 @@ jobs:
 
       - name: Benchmark performance
         timeout-minutes: 30
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -262,6 +267,7 @@ jobs:
       - name: Benchmark performance (tp=4)
         timeout-minutes: 50
 
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -315,6 +321,7 @@ jobs:
     runs-on: arc-runner-v6e-1
     steps:
       - name: Check all dependent job statuses
+        shell: bash
         run: |
           results=(${{ join(needs.*.result, ' ') }})
           for result in "${results[@]}"; do

--- a/scripts/ci/publish.py
+++ b/scripts/ci/publish.py
@@ -1,0 +1,376 @@
+"""
+Unified publish script for CI artifacts (bench, perf, trace) to GitHub repository.
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+def make_github_request(url, token, method="GET", data=None):
+    """Make authenticated request to GitHub API"""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        # "User-Agent": "sglang-ci",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    if data:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(data).encode("utf-8")
+
+    req = Request(url, data=data, headers=headers, method=method)
+
+    try:
+        with urlopen(req) as response:
+            return response.read().decode("utf-8")
+    except HTTPError as e:
+        print(f"GitHub API request failed: {e}")
+        try:
+            error_body = e.read().decode("utf-8")
+            print(f"Error response body: {error_body}")
+            e.error_body = error_body  # Attach for later inspection
+        except Exception:
+            e.error_body = ""
+        raise
+    except Exception as e:
+        print(f"GitHub API request failed with a non-HTTP error: {e}")
+        raise
+
+
+def verify_token_permissions(repo_owner, repo_name, token):
+    """Verify that the token has necessary permissions for the repository"""
+    print("Verifying token permissions...")
+
+    # Check if we can access the repository
+    try:
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}"
+        response = make_github_request(url, token)
+        repo_data = json.loads(response)
+        print(f"Repository access verified: {repo_data['full_name']}")
+    except Exception as e:
+        print(f"Failed to access repository: {e}")
+        return False
+
+    # Check if we can read the repository contents
+    try:
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/contents"
+        response = make_github_request(url, token)
+        print("Repository contents access verified")
+    except Exception as e:
+        print(f"Failed to access repository contents: {e}")
+        return False
+
+    return True
+
+
+def get_branch_sha(repo_owner, repo_name, branch, token):
+    """Get SHA of the branch head"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/refs/heads/{branch}"
+    response = make_github_request(url, token)
+    data = json.loads(response)
+    return data["object"]["sha"]
+
+
+def get_tree_sha(repo_owner, repo_name, commit_sha, token):
+    """Get tree SHA from commit"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/commits/{commit_sha}"
+    response = make_github_request(url, token)
+    data = json.loads(response)
+    return data["tree"]["sha"]
+
+
+def create_blob(repo_owner, repo_name, content, token, max_retries=3):
+    """Create a blob with file content"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/blobs"
+
+    # Encode content as base64 for GitHub API
+    content_b64 = base64.b64encode(content).decode("utf-8")
+
+    data = {"content": content_b64, "encoding": "base64"}
+
+    for attempt in range(max_retries):
+        try:
+            response = make_github_request(url, token, method="POST", data=data)
+            return json.loads(response)["sha"]
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt  # Exponential backoff: 1s, 2s, 4s
+                print(
+                    f"Blob creation failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+
+
+def create_tree(repo_owner, repo_name, base_tree_sha, files, token, max_retries=3):
+    """Create a new tree with files"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/trees"
+
+    tree_items = []
+    for i, (file_path, content) in enumerate(files):
+        # Create blob first to get SHA
+        blob_sha = create_blob(repo_owner, repo_name, content, token)
+        tree_items.append(
+            {
+                "path": file_path,
+                "mode": "100644",
+                "type": "blob",
+                "sha": blob_sha,
+            }
+        )
+        # Progress indicator for large uploads
+        if (i + 1) % 10 == 0 or (i + 1) == len(files):
+            print(f"Created {i + 1}/{len(files)} blobs...")
+
+    data = {"base_tree": base_tree_sha, "tree": tree_items}
+
+    for attempt in range(max_retries):
+        try:
+            response = make_github_request(url, token, method="POST", data=data)
+            return json.loads(response)["sha"]
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                print(
+                    f"Tree creation failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+
+
+def create_commit(repo_owner, repo_name, tree_sha, parent_sha, message, token, max_retries=3):
+    """Create a new commit"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/commits"
+
+    data = {"tree": tree_sha, "parents": [parent_sha], "message": message}
+
+    for attempt in range(max_retries):
+        try:
+            response = make_github_request(url, token, method="POST", data=data)
+            commit_sha = json.loads(response)["sha"]
+
+            # Verify the commit was actually created
+            verify_url = (
+                f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/commits/{commit_sha}"
+            )
+            verify_response = make_github_request(verify_url, token)
+            verify_data = json.loads(verify_response)
+            if verify_data["sha"] != commit_sha:
+                raise Exception(
+                    f"Commit verification failed: expected {commit_sha}, got {verify_data['sha']}"
+                )
+
+            return commit_sha
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                print(
+                    f"Commit creation failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+
+
+def update_branch_ref(repo_owner, repo_name, branch, commit_sha, token, max_retries=3):
+    """Update branch reference to point to new commit"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/refs/heads/{branch}"
+
+    data = {"sha": commit_sha}
+
+    for attempt in range(max_retries):
+        try:
+            make_github_request(url, token, method="PATCH", data=data)
+            return
+        except HTTPError as e:
+            # Check if this is an "Object does not exist" error
+            is_object_not_exist = False
+            if hasattr(e, "error_body"):
+                try:
+                    error_data = json.loads(e.error_body)
+                    if "Object does not exist" in error_data.get("message", ""):
+                        is_object_not_exist = True
+                except Exception:
+                    pass
+
+            if is_object_not_exist and attempt < max_retries - 1:
+                # This might be a transient consistency issue - wait and retry
+                wait_time = 2**attempt
+                print(
+                    f"Branch update failed with 'Object does not exist' (attempt {attempt + 1}/{max_retries}), waiting {wait_time}s for consistency..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                print(
+                    f"Branch update failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+
+
+def collect_files(source_dir, file_extension, target_base_path):
+    """Collect files with the given extension from source_dir for upload."""
+    files_to_upload = []
+
+    if not os.path.exists(source_dir):
+        print(f"Warning: Source directory {source_dir} does not exist")
+        return files_to_upload
+
+    for root, dirs, files in os.walk(source_dir):
+        for file in files:
+            if file.endswith(file_extension):
+                source_file = os.path.join(root, file)
+                rel_path = os.path.relpath(source_file, source_dir)
+                target_path = (
+                    f"{target_base_path}/{rel_path}" if target_base_path != "" else rel_path
+                )
+
+                with open(source_file, "rb") as f:
+                    content = f.read()
+
+                files_to_upload.append((target_path, content))
+
+    return files_to_upload
+
+
+def publish(source_dir, data_type, run_id, run_number):
+    """Publish files to GitHub repository in a single commit."""
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        print("Error: GITHUB_TOKEN environment variable not set")
+        sys.exit(1)
+
+    repo_owner = "pathfinder-pf"
+    repo_name = "sglang-jax-ci-data"
+    branch = "main"
+    target_base_path = ""
+
+    if data_type == "trace":
+        file_extension = ".json.gz"
+        no_files_msg = "No trace files found to upload"
+        success_msg = "Successfully published all traces in a single commit"
+
+        def make_commit_message(count):
+            return f"Nightly traces for run {run_id} at {run_number} ({count} files)"
+
+    else:  # bench or perf
+        file_extension = ".csv"
+        no_files_msg = "No csv files found to upload"
+        success_msg = "Successfully published all csv files in a single commit"
+
+        def make_commit_message(count):
+            return f"CSV files of Nightly-test for run {run_id} at {run_number} ({count} files)"
+
+    files_to_upload = collect_files(source_dir, file_extension, target_base_path)
+
+    if not files_to_upload:
+        print(no_files_msg)
+        return
+
+    print(f"Found {len(files_to_upload)} files to upload")
+
+    if not verify_token_permissions(repo_owner, repo_name, token):
+        print("Token permission verification failed. Please check the token permissions.")
+        sys.exit(1)
+
+    max_retries = 5
+    retry_delay = 5  # seconds
+
+    for attempt in range(max_retries):
+        try:
+            branch_sha = get_branch_sha(repo_owner, repo_name, branch, token)
+            print(f"Current branch head: {branch_sha}")
+
+            tree_sha = get_tree_sha(repo_owner, repo_name, branch_sha, token)
+            print(f"Current tree SHA: {tree_sha}")
+
+            new_tree_sha = create_tree(repo_owner, repo_name, tree_sha, files_to_upload, token)
+            print(f"Created new tree: {new_tree_sha}")
+
+            commit_message = make_commit_message(len(files_to_upload))
+            commit_sha = create_commit(
+                repo_owner,
+                repo_name,
+                new_tree_sha,
+                branch_sha,
+                commit_message,
+                token,
+            )
+            print(f"Created commit: {commit_sha}")
+
+            update_branch_ref(repo_owner, repo_name, branch, commit_sha, token)
+            print("Updated branch reference")
+
+            print(success_msg)
+            return
+
+        except Exception as e:
+            is_retryable = False
+            error_type = "unknown"
+
+            if hasattr(e, "error_body"):
+                if "Update is not a fast forward" in e.error_body:
+                    is_retryable = True
+                    error_type = "fast-forward conflict"
+                elif "Object does not exist" in e.error_body:
+                    is_retryable = True
+                    error_type = "object consistency"
+
+            if isinstance(e, HTTPError) and e.code in [422, 500, 502, 503, 504]:
+                is_retryable = True
+                error_type = f"HTTP {e.code}"
+
+            if is_retryable and attempt < max_retries - 1:
+                print(
+                    f"Attempt {attempt + 1}/{max_retries} failed ({error_type}). Retrying in {retry_delay} seconds..."
+                )
+                time.sleep(retry_delay)
+            else:
+                print(f"Failed to publish after {attempt + 1} attempts: {e}")
+                raise
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Publish CI artifacts to a GitHub repository")
+    parser.add_argument(
+        "--source-dir",
+        type=str,
+        required=True,
+        help="Source directory with files to publish",
+    )
+    parser.add_argument(
+        "--data-type",
+        type=str,
+        required=True,
+        choices=["bench", "perf", "trace"],
+        help="Type of data to publish: bench/perf (scans .csv) or trace (scans .json.gz)",
+    )
+    args = parser.parse_args()
+
+    run_id = os.getenv("GITHUB_RUN_ID", "test")
+    run_number = os.getenv("GITHUB_RUN_NUMBER", "12345")
+
+    if not run_id or not run_number:
+        print("Error: GITHUB_RUN_ID and GITHUB_RUN_NUMBER environment variables must be set")
+        sys.exit(1)
+
+    print(f"Processing files from directory: {args.source_dir}")
+    publish(args.source_dir, args.data_type, run_id, run_number)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **(b) Shell unification**: Add `shell: bash` to all PR Test `run` steps missing it (6 steps)
- **(c) Publish consolidation**: Create unified `scripts/ci/publish.py --data-type bench|perf|trace`, migrate 12+ nightly publish steps. Old scripts kept for backward compatibility
- **(d) Cache monitoring**: Add `JAX_DEBUG_LOG_MODULES=jax._src.compilation_cache_utils` to 9 nightly + 3 daily test jobs for compilation cache hit rate logging

## Scope
Sub-items (b), (c), (d) of P2-7. Sub-item (a) (accuracy rename) handled separately in PR #1162.

## Verification
- [ ] (b) All PR Test job run steps have explicit `shell: bash`
- [ ] (c) `scripts/ci/publish.py` handles bench, perf, trace data types
- [ ] (c) Nightly publish steps use new unified script
- [ ] (d) Cache hit rate data visible in nightly workflow logs

Closes #1143