### PR TITLE
fix(logprob): scalar input_token_logprobs + bucketed logprob path (host RAM + JIT churn)

### DIFF
--- a/python/sgl_jax/srt/layers/logits_processor.py
+++ b/python/sgl_jax/srt/layers/logits_processor.py
@@ -109,6 +109,7 @@ class LogitsMetadata:
     extend_logprob_pruned_lens_cpu: list[int] | None = None
     top_logprobs_nums: list[int] | None = None
     extend_input_logprob_token_ids_device: jax.Array | None = None
+    input_logprob_indices_device: jax.Array | None = None
     token_ids_logprobs: list[list[int]] | None = None
 
     # logits and logprobs post processing
@@ -123,9 +124,11 @@ class LogitsMetadata:
             self.accept_lens,
             self.logits_indices,
             self.extend_input_logprob_token_ids_device,
+            self.input_logprob_indices_device,
             self.temperature,
             self.top_p,
         )
+        has_padded_input_logprob_indices = self.input_logprob_indices_device is not None
 
         aux_data = {
             "forward_mode": self.forward_mode,
@@ -133,9 +136,15 @@ class LogitsMetadata:
             "extend_return_logprob": self.extend_return_logprob,
             "extend_return_top_logprob": self.extend_return_top_logprob,
             "extend_token_ids_logprob": self.extend_token_ids_logprob,
-            "extend_seq_lens_cpu": self.extend_seq_lens_cpu,
-            "extend_logprob_start_lens_cpu": self.extend_logprob_start_lens_cpu,
-            "extend_logprob_pruned_lens_cpu": self.extend_logprob_pruned_lens_cpu,
+            "extend_seq_lens_cpu": (
+                None if has_padded_input_logprob_indices else self.extend_seq_lens_cpu
+            ),
+            "extend_logprob_start_lens_cpu": (
+                None if has_padded_input_logprob_indices else self.extend_logprob_start_lens_cpu
+            ),
+            "extend_logprob_pruned_lens_cpu": (
+                None if has_padded_input_logprob_indices else self.extend_logprob_pruned_lens_cpu
+            ),
             "top_logprobs_nums": self.top_logprobs_nums,
             "token_ids_logprobs": self.token_ids_logprobs,
             "temp_scaled_logprobs": self.temp_scaled_logprobs,
@@ -152,8 +161,9 @@ class LogitsMetadata:
         obj.accept_lens = children[1]
         obj.logits_indices = children[2]
         obj.extend_input_logprob_token_ids_device = children[3]
-        obj.temperature = children[4]
-        obj.top_p = children[5]
+        obj.input_logprob_indices_device = children[4]
+        obj.temperature = children[5]
+        obj.top_p = children[6]
 
         obj.forward_mode = aux_data["forward_mode"]
         obj.capture_hidden_mode = aux_data["capture_hidden_mode"]
@@ -220,6 +230,9 @@ class LogitsMetadata:
             extend_input_logprob_token_ids_device=device_array(
                 batch.extend_input_logprob_token_ids, sharding=sharding
             ),
+            input_logprob_indices_device=device_array(
+                batch.input_logprob_indices, sharding=sharding
+            ),
         )
 
 
@@ -259,6 +272,28 @@ class LogitsProcessor(nnx.Module):
             in_specs=(P("data", "tensor"), P("data")),
             out_specs=P("data", "tensor"),
         )(logits, indices)
+
+    def _select_input_token_logprobs(
+        self, input_logprobs: jax.Array, token_ids: jax.Array | None
+    ) -> jax.Array:
+        # Keep the public input_token_logprobs API scalar-per-token. Returning
+        # full vocab rows here makes host memory scale as tokens * vocab_size.
+        # By the time we reach this function, extend_return_logprob is True
+        # (gated in __call__), so at least one req has extend_len - start_len
+        # > 0. Both the padded path (np.zeros over total_token_size in
+        # get_model_worker_batch) and the non-padded chunk concat produce a
+        # non-None token_ids in that case. A None here means an upstream
+        # regression dropped the gather ids — fail loudly rather than
+        # silently returning None to the user.
+        assert token_ids is not None, (
+            "extend_input_logprob_token_ids_device must be populated when "
+            "extend_return_logprob=True; got None"
+        )
+        token_ids = token_ids.reshape((-1,))
+        row_ids = np.arange(input_logprobs.shape[0], dtype=np.int64)
+        out_sharding = NamedSharding(self.mesh, P(None))
+        selected = input_logprobs.at[(row_ids, token_ids)].get(out_sharding=out_sharding)
+        return selected.reshape((input_logprobs.shape[0],))
 
     @named_scope
     def __call__(
@@ -303,39 +338,44 @@ class LogitsProcessor(nnx.Module):
             # 1. pruned_states: hidden states that we want logprobs from.
             # 2. sample_indices: Indices that have sampled tokens.
             # 3. input_logprob_indices: Indices that have input logprob tokens.
-            sample_index_pt = -1
-            sample_indices = []
-            input_logprob_indices_pt = 0
-            input_logprob_indices = []
-            pt, pruned_states = 0, []
+            if logits_metadata.input_logprob_indices_device is not None:
+                pruned_states = hidden_states
+                sample_indices = logits_metadata.logits_indices
+                input_logprob_indices = logits_metadata.input_logprob_indices_device
+            else:
+                sample_index_pt = -1
+                sample_indices = []
+                input_logprob_indices_pt = 0
+                input_logprob_indices = []
+                pt, pruned_states = 0, []
 
-            for extend_logprob_start_len, extend_len in zip(
-                logits_metadata.extend_logprob_start_lens_cpu,
-                logits_metadata.extend_seq_lens_cpu,
-            ):
-                start_len = extend_logprob_start_len
-                pruned_states.append(hidden_states[pt + start_len : pt + extend_len])
-                pt += extend_len
-                sample_index_pt += extend_len - start_len
-                sample_indices.append(sample_index_pt)
-                input_logprob_indices.extend(
-                    [
-                        input_logprob_indices_pt + i
-                        for i in range(extend_len - extend_logprob_start_len)
-                    ]
+                for extend_logprob_start_len, extend_len in zip(
+                    logits_metadata.extend_logprob_start_lens_cpu,
+                    logits_metadata.extend_seq_lens_cpu,
+                ):
+                    start_len = extend_logprob_start_len
+                    pruned_states.append(hidden_states[pt + start_len : pt + extend_len])
+                    pt += extend_len
+                    sample_index_pt += extend_len - start_len
+                    sample_indices.append(sample_index_pt)
+                    input_logprob_indices.extend(
+                        [
+                            input_logprob_indices_pt + i
+                            for i in range(extend_len - extend_logprob_start_len)
+                        ]
+                    )
+                    input_logprob_indices_pt += extend_len - start_len
+
+                pruned_states = jnp.concat(pruned_states)
+                sample_indices = device_array(
+                    np.array(
+                        sample_indices,
+                        dtype=np.int64,
+                    ),
                 )
-                input_logprob_indices_pt += extend_len - start_len
-
-            pruned_states = jnp.concat(pruned_states)
-            sample_indices = device_array(
-                np.array(
-                    sample_indices,
-                    dtype=np.int64,
-                ),
-            )
-            input_logprob_indices = device_array(
-                np.array(input_logprob_indices, dtype=np.int64),
-            )
+                input_logprob_indices = device_array(
+                    np.array(input_logprob_indices, dtype=np.int64),
+                )
 
         # Compute logits for both input and sampled tokens.
         logits = self._get_logits(pruned_states, lm_head)
@@ -384,21 +424,22 @@ class LogitsProcessor(nnx.Module):
             del hidden_states, logits
 
             # Normalize the logprob w/o temperature, top-p
-            pruned_lens = device_array(
-                np.array(
-                    logits_metadata.extend_logprob_pruned_lens_cpu,
-                ),
-            )
-            if logits_metadata.temp_scaled_logprobs:
-                logits_metadata.temperature = jnp.repeat(
-                    logits_metadata.temperature.reshape(-1),
-                    pruned_lens,
-                ).reshape(-1, 1)
-            if logits_metadata.top_p_normalized_logprobs:
-                logits_metadata.top_p = jnp.repeat(
-                    logits_metadata.top_p,
-                    pruned_lens,
+            if logits_metadata.temp_scaled_logprobs or logits_metadata.top_p_normalized_logprobs:
+                pruned_lens = device_array(
+                    np.array(
+                        logits_metadata.extend_logprob_pruned_lens_cpu,
+                    ),
                 )
+                if logits_metadata.temp_scaled_logprobs:
+                    logits_metadata.temperature = jnp.repeat(
+                        logits_metadata.temperature.reshape(-1),
+                        pruned_lens,
+                    ).reshape(-1, 1)
+                if logits_metadata.top_p_normalized_logprobs:
+                    logits_metadata.top_p = jnp.repeat(
+                        logits_metadata.top_p,
+                        pruned_lens,
+                    )
             input_logprobs = self.compute_temp_top_p_normalized_logprobs(
                 input_logprobs, logits_metadata
             )
@@ -420,12 +461,10 @@ class LogitsProcessor(nnx.Module):
             else:
                 input_token_ids_logprobs_val = input_token_ids_logprobs_idx = None
 
-            out_sharding = NamedSharding(self.mesh, P(None))
-            indices = (
-                np.arange(input_logprobs.shape[0]),
+            input_token_logprobs = self._select_input_token_logprobs(
+                input_logprobs,
                 logits_metadata.extend_input_logprob_token_ids_device,
             )
-            input_token_logprobs = input_logprobs.at[indices].get(out_sharding=out_sharding)
 
             return LogitsProcessorOutput(
                 next_token_logits=sampled_logits,

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2411,6 +2411,56 @@ class ScheduleBatch:
             top_logprobs_nums = None
             token_ids_logprobs = None
 
+        use_padded_input_logprob = (
+            self.forward_mode.is_extend()
+            and not self.enable_overlap
+            and not self.return_hidden_states
+            and not (top_logprobs_nums and any(x > 0 for x in top_logprobs_nums))
+            and not (token_ids_logprobs and any(x is not None for x in token_ids_logprobs))
+        )
+        input_logprob_indices = None
+        merged_extend_input_logprob_token_ids = None
+        if self.return_logprob:
+            if use_padded_input_logprob:
+                input_logprob_indices = np.zeros(total_token_size, dtype=np.int32)
+                merged_extend_input_logprob_token_ids = np.zeros(total_token_size, dtype=np.int32)
+                token_offset = 0
+                for info in self.reqs_info:
+                    out_pt = token_offset
+                    local_pt = 0
+                    token_id_pt = 0
+                    starts = info.extend_logprob_start_lens or []
+                    token_ids = info.extend_input_logprob_token_ids
+                    for extend_len, start_len in zip(info.extend_lens or [], starts):
+                        num_logprobs = max(extend_len - start_len, 0)
+                        if num_logprobs > 0:
+                            end_pt = out_pt + num_logprobs
+                            input_logprob_indices[out_pt:end_pt] = np.arange(
+                                local_pt + start_len,
+                                local_pt + extend_len,
+                                dtype=np.int32,
+                            )
+                            if token_ids is not None:
+                                merged_extend_input_logprob_token_ids[out_pt:end_pt] = token_ids[
+                                    token_id_pt : token_id_pt + num_logprobs
+                                ]
+                            out_pt = end_pt
+                            token_id_pt += num_logprobs
+                        local_pt += extend_len
+                    token_offset += per_dp_token_padding
+            else:
+                # Merge per-DP extend_input_logprob_token_ids (set on info at L1099 when
+                # return_logprob=True). Previously hardcoded None below, which combined
+                # with the new server-side scalar gather caused 'NoneType.reshape' in
+                # LogitsProcessor._select_input_token_logprobs.
+                chunks = [
+                    info.extend_input_logprob_token_ids
+                    for info in self.reqs_info
+                    if getattr(info, "extend_input_logprob_token_ids", None) is not None
+                ]
+                if chunks:
+                    merged_extend_input_logprob_token_ids = np.concatenate(chunks)
+
         return ModelWorkerBatch(
             bid=bid,
             forward_mode=self.forward_mode,
@@ -2430,7 +2480,8 @@ class ScheduleBatch:
             extend_prefix_lens=extend_prefix_lens,
             extend_seq_lens=extend_seq_lens,
             extend_logprob_start_lens=extend_logprob_start_lens,
-            extend_input_logprob_token_ids=None,
+            extend_input_logprob_token_ids=merged_extend_input_logprob_token_ids,
+            input_logprob_indices=input_logprob_indices,
             logits_indices=logits_indices,
             lora_ids=lora_ids,
             real_bs=real_bs,
@@ -2916,6 +2967,10 @@ class ModelWorkerBatch:
     # `arr[selector]` once after device_get to put per-req outputs back
     # into original order, removing the need for per-rank index math.
     logits_indices_selector: np.ndarray | None = None
+
+    # Pre-bucketed per-token gather indices for the padded logprob path; None on
+    # the legacy variable-shape path and on non-extend batches.
+    input_logprob_indices: np.ndarray | None = None
 
     # For Data Parallelism
     dp_size: int = 1

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -27,6 +27,47 @@ logger = logging.getLogger(__name__)
 DEFAULT_FORCE_STREAM_INTERVAL = 50
 
 
+def _input_logprob_lens_per_dp(batch: ScheduleBatch) -> list[int] | None:
+    if not batch.forward_mode.is_extend():
+        return None
+
+    lens_per_dp = []
+    for info in batch.reqs_info:
+        extend_lens = info.extend_lens or []
+        start_lens = info.extend_logprob_start_lens or []
+        lens_per_dp.append(
+            sum(
+                max(extend_len - start_len, 0)
+                for extend_len, start_len in zip(extend_lens, start_lens)
+            )
+        )
+    return lens_per_dp
+
+
+def _materialize_input_token_logprobs(input_token_logprobs, lens_per_dp: list[int] | None = None):
+    input_shape = getattr(input_token_logprobs, "shape", None)
+    if input_shape is not None and len(input_shape) != 1:
+        raise RuntimeError(
+            "input_token_logprobs must be a 1-D scalar logprob array before "
+            f"host transfer; got shape {input_shape}. This would expose "
+            "full-vocab logprob rows in meta_info and can exhaust host RAM."
+        )
+    host_logprobs = np.asarray(jax.device_get(input_token_logprobs))
+
+    values = host_logprobs.astype(float).tolist()
+    if lens_per_dp:
+        valid_len = sum(lens_per_dp)
+        if len(values) != valid_len and len(values) % len(lens_per_dp) == 0:
+            per_dp_token_size = len(values) // len(lens_per_dp)
+            compact_values = []
+            offset = 0
+            for dp_valid_len in lens_per_dp:
+                compact_values.extend(values[offset : offset + dp_valid_len])
+                offset += per_dp_token_size
+            values = compact_values
+    return tuple(values)
+
+
 class SchedulerOutputProcessorMixin:
     """
     This class implements the output processing logic for Scheduler.
@@ -52,7 +93,11 @@ class SchedulerOutputProcessorMixin:
         result: GenerationBatchResult,
         launch_done: threading.Event | None = None,
     ):
-        skip_stream_req = None
+        # On dp>1 each dp rank can have its own chunked-in-flight req, so this
+        # must hold up to `dp_size` reqs, not just one. A single-Req variable
+        # (the pre-DP design) silently leaked unchunked reqs into stream_output
+        # with `input_token_logprobs_val` still None, crashing the consumer.
+        skip_stream_reqs: set = set()
 
         assert self.is_generation
         (
@@ -84,8 +129,9 @@ class SchedulerOutputProcessorMixin:
                         logits_output.next_token_logprobs
                     ).astype(float)
                 if logits_output.input_token_logprobs is not None:
-                    logits_output.input_token_logprobs = tuple(
-                        jax.device_get(logits_output.input_token_logprobs).astype(float)
+                    logits_output.input_token_logprobs = _materialize_input_token_logprobs(
+                        logits_output.input_token_logprobs,
+                        _input_logprob_lens_per_dp(batch),
                     )
         hidden_state_offset = 0
         per_dp_bs_size = batch.per_dp_bs_size
@@ -199,10 +245,9 @@ class SchedulerOutputProcessorMixin:
                 else:
                     # being chunked reqs' prefill is not finished
                     req.is_chunked -= 1
-                    # There is only at most one request being currently chunked.
-                    # Because this request does not finish prefill,
-                    # we don't want to stream the request currently being chunked.
-                    skip_stream_req = req
+                    # On dp>1, multiple reqs (one per dp rank) can be chunked
+                    # in the same batch; collect all so stream_output skips them.
+                    skip_stream_reqs.add(id(req))
 
                     # Incrementally update input logprobs.
                     if req.return_logprob:
@@ -239,7 +284,7 @@ class SchedulerOutputProcessorMixin:
             all_reqs,
             batch.return_logprob,
             batch.return_output_logprob_only,
-            skip_stream_req,
+            skip_stream_reqs,
             cache_miss_count,
         )
 
@@ -655,13 +700,18 @@ class SchedulerOutputProcessorMixin:
         reqs: list[Req],
         return_logprob: bool,
         return_output_logprob_only: bool,
-        skip_req: Req | None = None,
+        skip_reqs: set | Req | None = None,
         cache_miss_count: int = None,
     ):
-        """Stream the output to detokenizer."""
+        """Stream the output to detokenizer.
+
+        `skip_reqs` accepts either a `set` of `id(req)` to skip, or a single
+        `Req` (back-compat). A set is required on dp>1 because more than one
+        req can be mid-chunked in the same batch.
+        """
         assert self.is_generation
         self.stream_output_generation(
-            reqs, return_logprob, return_output_logprob_only, skip_req, cache_miss_count
+            reqs, return_logprob, return_output_logprob_only, skip_reqs, cache_miss_count
         )
 
     def stream_output_generation(
@@ -669,9 +719,15 @@ class SchedulerOutputProcessorMixin:
         reqs: list[Req],
         return_logprob: bool,
         return_output_logprob_only: bool,
-        skip_req: Req | None = None,
+        skip_reqs: set | Req | None = None,
         cache_miss_count: int = None,
     ):
+        if skip_reqs is None:
+            skip_ids: set = set()
+        elif isinstance(skip_reqs, set):
+            skip_ids = skip_reqs
+        else:
+            skip_ids = {id(skip_reqs)}
         rids = []
         finished_reasons: list[BaseFinishReason] = []
 
@@ -723,7 +779,7 @@ class SchedulerOutputProcessorMixin:
             ) = output_token_ids_logprobs_idx = None
 
         for req in reqs:
-            if req is skip_req:
+            if id(req) in skip_ids:
                 continue
 
             if req.finished():

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -312,6 +312,7 @@ class CompilationManager:
             token_ids_logprobs=None,
             extend_logprob_start_lens=None,
             logits_indices=logits_indices,
+            input_logprob_indices=None,
             capture_hidden_mode=(
                 CaptureHiddenMode.FULL if self.multimodal else CaptureHiddenMode.NULL
             ),

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -353,6 +353,7 @@ suites = {
         TestFile("test/srt/test_features.py", 10),
         TestFile("test/srt/test_chunked_prefill_size.py", 5),
         # TestFile("test/srt/test_sliding_window_attention.py", 30), # add after gpt-oss supported
+        TestFile("test/srt/test_logprobs_dp.py", 8),
         TestFile("test/srt/test_model_loader.py", 5),
         TestFile("test/srt/test_deepseek_v2_lite_models.py", 10),
         TestFile("test/srt/quantization/test_w8_quantization.py", 10),

--- a/test/srt/test_logprobs.py
+++ b/test/srt/test_logprobs.py
@@ -46,6 +46,17 @@ class TestLogprobsDense(unittest.TestCase):
         """Clean up after all tests - shutdown the engine."""
         cls.engine.shutdown()
 
+    def assert_scalar_logprobs(self, logprobs, key):
+        for i, (logprob, _, _) in enumerate(logprobs):
+            if logprob is None:
+                continue
+            self.assertFalse(
+                isinstance(logprob, (list, tuple)),
+                f"{key}[{i}] should be a scalar logprob, got {type(logprob)}",
+            )
+            shape = getattr(logprob, "shape", ())
+            self.assertEqual(shape, (), f"{key}[{i}] should be scalar, got shape {shape}")
+
     def test_logprobs(self):
         ## prompt = "please introduce yourself"
         input_ids = [151646, 151644, 30021, 19131, 6133, 151645, 151648, 198]
@@ -70,6 +81,7 @@ class TestLogprobsDense(unittest.TestCase):
             len(input_ids) - start_len,
             "input_token_logprobs is invalid",
         )
+        self.assert_scalar_logprobs(output_meta["input_token_logprobs"], "input_token_logprobs")
         self.assertEqual(
             len(output_meta["output_token_logprobs"]),
             len(output["output_ids"]),

--- a/test/srt/test_logprobs_dp.py
+++ b/test/srt/test_logprobs_dp.py
@@ -1,0 +1,142 @@
+import math
+import os
+import unittest
+
+from sgl_jax.srt.entrypoints.engine import Engine
+from sgl_jax.test.test_utils import DEEPSEEK_R1_DISTILL_QWEN_1_5B
+
+os.environ["JAX_COMPILATION_CACHE_DIR"] = "/tmp/jit_cache"
+
+
+print("Running on Google TPU")
+# tp_size=4 with dp_size=2 builds a [2, 2] mesh in scheduler.create_device_mesh
+# (ici_parallelism=[dp_size, tp_size // dp_size]), i.e. 4 devices total — fits the
+# 4-chip TPU runner. Cannot be merged into test_logprobs.py because that file
+# runs on the 1-chip runner.
+DP_REGRESSION_ENGINE_CONFIG = {
+    "model_path": DEEPSEEK_R1_DISTILL_QWEN_1_5B,
+    "random_seed": 27,
+    "device": "tpu",
+    "dtype": "bfloat16",
+    "trust_remote_code": True,
+    "skip_server_warmup": True,
+    "mem_fraction_static": 0.8,
+    "disable_overlap_schedule": True,
+    "use_sort_for_toppk_minp": True,
+    "log_level": "info",
+    "tp_size": 4,
+    "dp_size": 2,
+    "chunked_prefill_size": 128,
+    "max_running_requests": 64,
+    "page_size": 64,
+    "max_total_tokens": 32768,
+    "precompile_token_paddings": [128, 256, 512, 1024],
+    "precompile_bs_paddings": [1, 4, 8],
+}
+
+
+class TestLogprobsDpChunkedPrefill(unittest.TestCase):
+    """Regression for the dp>1 chunked-prefill skip-tracking bug.
+
+    Pre-fix, `process_batch_result_prefill` used `skip_stream_req: Req | None`,
+    a single slot. On dp>1, each dp rank can have its own chunked-in-flight req,
+    so all but the last-assigned one leaked into `stream_output` with
+    `input_token_logprobs_val == None`. TokenizerManager then either crashed
+    (`'NoneType' object is not iterable`) or, if coerced to `[]`, returned
+    truncated logprobs that produced inf PPL downstream.
+
+    This test forces multiple in-flight chunked reqs across dp ranks by
+    submitting prompts longer than chunked_prefill_size, with dp_size=2, and
+    asserts every req returns full, finite, scalar input_token_logprobs.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        print(f"Launching dp=2 tp=2 Engine with {DEEPSEEK_R1_DISTILL_QWEN_1_5B}...")
+        cls.engine = Engine(**DP_REGRESSION_ENGINE_CONFIG)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.engine.shutdown()
+
+    def test_dp2_multi_req_chunked_prefill_logprobs(self):
+        # 4 prompts of varying lengths, all > chunked_prefill_size=128 so each
+        # spans multiple chunks. Different lengths ensure chunk boundaries
+        # don't coincide, maximizing the chance multiple reqs are mid-prefill
+        # in the same batch step (the dp>1 leak condition).
+        base = [151646, 151644, 30021, 19131, 6133, 151645, 151648, 198]
+        prompts = [
+            base * 20,  # 160 tokens
+            base * 25,  # 200 tokens
+            base * 30,  # 240 tokens
+            base * 35,  # 280 tokens
+        ]
+        sampling_params = [{"n": 1, "top_k": 1, "max_new_tokens": 2}] * len(prompts)
+
+        output = self.engine.generate(
+            input_ids=prompts,
+            sampling_params=sampling_params,
+            return_logprob=True,
+            logprob_start_len=[0] * len(prompts),
+        )
+
+        self.assertEqual(len(output), len(prompts), "must return one result per req")
+
+        for i, (out, prompt) in enumerate(zip(output, prompts)):
+            meta = out["meta_info"]
+            self.assertIsNotNone(
+                meta.get("input_token_logprobs"),
+                f"req[{i}]: input_token_logprobs is None — chunked-skip leak",
+            )
+            self.assertEqual(
+                len(meta["input_token_logprobs"]),
+                len(prompt),
+                f"req[{i}]: expected {len(prompt)} input logprobs, got "
+                f"{len(meta['input_token_logprobs'])} — truncated by chunked-skip leak",
+            )
+            for j, (logprob, token_id, _) in enumerate(meta["input_token_logprobs"]):
+                # With logprob_start_len=0, the first token has no preceding
+                # context to score against — it MUST be None. Every other
+                # position MUST be a finite scalar; partial chunked-skip leaks
+                # show up as scattered None/inf in the middle of the sequence,
+                # which a length-only check would miss.
+                if j == 0:
+                    self.assertIsNone(
+                        logprob,
+                        f"req[{i}][0]: expected None (no prior context), got {logprob}",
+                    )
+                    self.assertEqual(
+                        token_id,
+                        prompt[j],
+                        f"req[{i}][0]: token_id mismatch {token_id} vs prompt {prompt[j]}",
+                    )
+                    continue
+                self.assertIsNotNone(
+                    logprob,
+                    f"req[{i}][{j}]: logprob is None mid-sequence — chunked-skip leak",
+                )
+                shape = getattr(logprob, "shape", ())
+                self.assertEqual(
+                    shape,
+                    (),
+                    f"req[{i}][{j}]: logprob must be scalar, got shape {shape}",
+                )
+                self.assertFalse(
+                    isinstance(logprob, (list, tuple)),
+                    f"req[{i}][{j}]: logprob must be scalar, got {type(logprob)}",
+                )
+                self.assertTrue(
+                    math.isfinite(float(logprob)),
+                    f"req[{i}][{j}]: logprob is non-finite ({logprob}) — "
+                    f"likely empty-logprobs→inf-PPL from chunked-skip leak",
+                )
+                self.assertEqual(
+                    token_id,
+                    prompt[j],
+                    f"req[{i}][{j}]: token_id mismatch {token_id} vs prompt "
+                    f"{prompt[j]} — index alignment regression",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1176.

- **Symptom 1 (true leak)** — `LogitsProcessor.__call__` now gathers the realized-token logprob on-device before host transfer, so `meta_info["input_token_logprobs"][i][0]` is a scalar (or `None`) instead of a full `[1, vocab_size]` row. `scheduler_output_processor_mixin._materialize_input_token_logprobs` adds a 1-D shape guard so a regression here is caught at the boundary instead of silently OOM-ing the scheduler.
- **Symptom 2 (recompile churn)** — JIT cache key stabilized in the logprob path: when the padded path is active, `LogitsMetadata.tree_flatten` drops the per-batch `extend_seq_lens_cpu` / `extend_logprob_start_lens_cpu` / `extend_logprob_pruned_lens_cpu` aux entries, and `ScheduleBatch.get_model_worker_batch` builds bucketed `input_logprob_indices` / `merged_extend_input_logprob_token_ids` padded to `total_token_size`. `LogitsProcessor.__call__` consumes those instead of rebuilding a variable-length `jnp.concat` per batch.
- **DP>1 chunked-prefill follow-up** — `process_batch_result_prefill` used a single-slot `skip_stream_req` that silently dropped all-but-one chunked req on dp>1, surfacing as `NoneType` crashes / truncated logprobs in `TokenizerManager`. Replaced with a `set` of `id(req)`; `stream_output` accepts both shapes for back-compat.

## Test plan

- [x] `pre-commit run --files <changed>` — all hooks Passed (ruff, black, isort, codespell, mypy)
- [x] New unit test `test/srt/test_logprobs.py::TestLogprobsDpChunkedPrefill::test_dp2_multi_req_chunked_prefill_logprobs` — exercises 4 varying-length prompts (160–280 tokens) with `dp_size=2`, `chunked_prefill_size=128` so multiple reqs are mid-prefill in the same batch; asserts every position is a finite scalar (or `None` only at index 0)
- [x] Existing `TestLogprobsDense::test_logprobs` extended with `assert_scalar_logprobs` to lock in the Symptom 1 contract
- [ ] CI on TPU v6e (gated by `run-ci` label)
