### PR TITLE
fix(ci): pass auth token via anthropic_api_key input

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -52,6 +52,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           track_progress: true
           prompt: |
             # sgl-jax PR Review
@@ -130,7 +131,6 @@ jobs:
             --allowedTools "Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),mcp__github_inline_comment__create_inline_comment"
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           API_TIMEOUT_MS: "3000000"
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
           ANTHROPIC_MODEL: claude-opus-4-7


### PR DESCRIPTION
## Summary

- `anthropics/claude-code-action@v1` validates credentials at its entry step and only recognizes `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` (see [`action.yml`](https://github.com/anthropics/claude-code-action/blob/main/action.yml) lines 67–71, 295–296).
- `ANTHROPIC_AUTH_TOKEN` is **not** referenced anywhere in the action, so the previous setup failed with:
  > Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.
- Feed the existing `ANTHROPIC_AUTH_TOKEN` secret through the `anthropic_api_key` input so the action validates correctly and the underlying CLI still hits the custom gateway via `ANTHROPIC_BASE_URL` (which IS passed through, line 297).

## Test plan

- [ ] Open / push to a PR after this lands and confirm the **PR Review (Claude)** workflow no longer exits with the `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` validation error.
- [ ] Comment `/review` on a PR and verify the reviewer responds normally (inline comments + summary).