### PR TITLE
fix(ci): split pr-review concurrency by whether run will execute

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -13,7 +13,17 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pr-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: >-
+    pr-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{
+      (
+        (github.event_name == 'pull_request')
+        || (github.event_name == 'issue_comment'
+            && startsWith(github.event.comment.body, '/review')
+            && contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.comment.author_association))
+      )
+      && 'active'
+      || github.run_id
+    }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- GitHub Actions evaluates `concurrency` **before** the job's `if:` condition. With `cancel-in-progress: true`, a run that is about to be skipped still legitimately cancels the previous in-progress run.
- On PR-tied `issue_comment` events that fail the `/review` + `author_association` filter (e.g. the claude bot's own comment, a "+1", a teammate's chatter), the empty run preempts a legitimate review run that started moments earlier — leaving both runs effectively dead (one `cancelled`, one `skipped`). Observed live on PR #1110.
- Append an `active` suffix to the concurrency group **only when the run will actually execute**; otherwise use `github.run_id` so each non-executing run sits in its own private group and cannot cancel anything else. Real reviews still preempt earlier real reviews on the same PR.

## Group semantics after this change

| Trigger | Group suffix | Effect |
|---|---|---|
| `pull_request` (sync/open/etc.) | `active` | preempts earlier `active` on same PR |
| `/review` comment from OWNER/COLLABORATOR | `active` | preempts earlier `active` on same PR |
| Any other `issue_comment` (bot reply, chatter) | unique `run_id` | isolated; cannot cancel anything |

## Test plan

- [ ] Trigger this PR's own review by commenting `/review`; confirm the run reaches the action step (not cancelled by the comment it leaves on itself).
- [ ] Push a follow-up commit to this PR; confirm the `pull_request` run preempts any earlier in-flight one on this PR.
- [ ] On an unrelated PR, comment a non-`/review` message; confirm the new `skipped` run does **not** cancel an unrelated in-flight review on the same PR.