### PR TITLE
ci: slash command handler for PR comment-triggered CI operations (P2-5)

### DIFF
--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -1,0 +1,61 @@
+name: Rerun Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'Test suite name (from run_suite.py)'
+        required: true
+        type: string
+      runner:
+        description: 'Runner label (arc-runner-v6e-1, arc-runner-v6e-4, arc-runner-cpu)'
+        required: true
+        type: string
+      ref:
+        description: 'Git ref to checkout (PR branch)'
+        required: true
+        type: string
+      pr_number:
+        description: 'PR number for status comments'
+        required: false
+        type: string
+
+run-name: "rerun-test: ${{ inputs.suite }} [${{ inputs.ref }}]"
+
+jobs:
+  rerun:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
+        with:
+          install-target: ${{ contains(inputs.runner, 'cpu') && 'python[cpu]' || 'python[all]' }}
+
+      - name: Run test suite
+        timeout-minutes: 120
+        env:
+          SGLANG_JAX_IS_IN_CI: true
+          SGLANG_JAX_MODEL_CACHE: /models/model_scope
+          SUITE: ${{ inputs.suite }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_HUB_DOWNLOAD_TIMEOUT: 300
+        run: |
+          bash scripts/killall_sglang.sh 2>/dev/null || true
+          python test/srt/run_suite.py --suite "$SUITE"
+
+      - name: Comment result on PR
+        if: always() && inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          SUITE: ${{ inputs.suite }}
+          STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --body "> **Rerun test** [$SUITE]($RUN_URL): **$STATUS**"

--- a/.github/workflows/slash-command.yml
+++ b/.github/workflows/slash-command.yml
@@ -1,0 +1,131 @@
+name: Slash Command Handler
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  handle-command:
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      actions: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: scripts/ci
+
+      - name: Get PR head branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          head_ref=$(gh pr view "$PR_NUMBER" --json headRefName --jq .headRefName)
+          echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Parse slash command
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          ACTOR: ${{ github.event.comment.user.login }}
+          ACTOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+        run: python3 scripts/ci/slash_command_parse.py
+
+      - name: React to comment
+        if: steps.parse.outputs.valid == 'true' && steps.parse.outputs.permitted == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api repos/"$REPO"/issues/comments/"$COMMENT_ID"/reactions \
+            -f content='+1' --silent
+
+      - name: Reply on permission denied
+        if: steps.parse.outputs.valid == 'true' && steps.parse.outputs.permitted == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          ERROR_MSG: ${{ steps.parse.outputs.error }}
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --body "> **Slash command rejected**: $ERROR_MSG"
+
+      - name: Reply on command error
+        if: >-
+          steps.parse.outputs.valid == 'true' &&
+          steps.parse.outputs.permitted == 'true' &&
+          steps.parse.outputs.error != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          ERROR_MSG: ${{ steps.parse.outputs.error }}
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --body "> **Slash command error**: $ERROR_MSG"
+
+      - name: Rerun failed jobs
+        if: >-
+          steps.parse.outputs.valid == 'true' &&
+          steps.parse.outputs.permitted == 'true' &&
+          steps.parse.outputs.action == 'rerun_failed'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          REPO: ${{ github.repository }}
+        run: python3 scripts/ci/slash_command_dispatch.py
+
+      - name: Add label
+        if: >-
+          steps.parse.outputs.valid == 'true' &&
+          steps.parse.outputs.permitted == 'true' &&
+          steps.parse.outputs.action == 'add_label'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          LABELS_CSV: ${{ steps.parse.outputs.labels_csv }}
+        run: |
+          gh pr edit "$PR_NUMBER" --add-label "$LABELS_CSV"
+          gh pr comment "$PR_NUMBER" \
+            --body "> **Slash command**: Added label(s) \`$LABELS_CSV\` — CI will be triggered by the label event"
+
+      - name: Rerun test group
+        if: >-
+          steps.parse.outputs.valid == 'true' &&
+          steps.parse.outputs.permitted == 'true' &&
+          steps.parse.outputs.action == 'rerun_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          SUITE: ${{ steps.parse.outputs.suite }}
+          RUNNER: ${{ steps.parse.outputs.runner }}
+        run: |
+          gh workflow run rerun-test.yml --ref main \
+            -f suite="$SUITE" \
+            -f runner="$RUNNER" \
+            -f ref="$HEAD_REF" \
+            -f pr_number="$PR_NUMBER"
+          gh pr comment "$PR_NUMBER" \
+            --body "> **Slash command**: Dispatched \`$SUITE\` on \`$RUNNER\` for branch \`$HEAD_REF\`"
+
+      - name: Rerun stage
+        if: >-
+          steps.parse.outputs.valid == 'true' &&
+          steps.parse.outputs.permitted == 'true' &&
+          steps.parse.outputs.action == 'rerun_stage'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          STAGE: ${{ steps.parse.outputs.stage }}
+          STAGE_SUITES_JSON: ${{ steps.parse.outputs.stage_suites_json }}
+        run: python3 scripts/ci/slash_command_stage_dispatch.py

--- a/docs/developer_guide/ci_architecture.md
+++ b/docs/developer_guide/ci_architecture.md
@@ -4,6 +4,9 @@
 - [Overview](#overview)
 - [Architecture Principles](#architecture-principles)
 - [CI/CD Pipeline Categories](#cicd-pipeline-categories)
+  - [Slash Command Handler](#slash-command-handler-slash-commandyml)
+  - [PR Review](#pr-review-pr-reviewyml)
+  - [CI Auto Bisect](#ci-auto-bisect-ci-auto-bisectyml)
   - [Pull Request Testing](#pull-request-testing)
   - [Nightly Testing](#nightly-testing)
   - [Release Automation](#release-automation)
@@ -45,6 +48,48 @@ Testing follows a progressive strategy:
 - Expensive tests (4-TPUs, accuracy) run last
 
 ## CI/CD Pipeline Workflows
+
+### Slash Command Handler (slash-command.yml)
+
+Allows maintainers to trigger targeted CI operations from PR comments instead of
+re-running the entire workflow.
+
+*Trigger:* `issue_comment` (created) — only processed when the comment starts with `/`.
+
+*Permission Model:*
+- `OWNER`, `MEMBER`, `COLLABORATOR` — allowed
+- All other associations — rejected with a reply comment
+
+*Supported Commands:*
+
+| Command | Description |
+|---------|-------------|
+| `/rerun-failed-ci` | Re-run only the failed jobs from the most recent `pr-test` run on the PR branch |
+| `/test perf` | Add the `test:perf` label — the label event triggers CI with perf tests enabled |
+| `/rerun-group <suite>` | Run a specific test suite on the matching runner via `rerun-test.yml`. Suite names from `test/srt/run_suite.py`; runner derived from suffix (`-v6e-1`, `-v6e-4`, `-cpu`) |
+| `/rerun-stage <stage>` | Dispatch all suites in a stage independently via `rerun-test.yml`. Stage: `1`/`fast` (unit), `2`/`medium` (e2e+accuracy), `3`/`heavy` (performance) |
+
+*Architecture:*
+- `scripts/ci/slash_command_parse.py` — pure-Python parser (stdlib only), reads
+  `COMMENT_BODY` / `ACTOR` / `ACTOR_ASSOCIATION` env vars, writes results to `$GITHUB_OUTPUT`
+- `scripts/ci/slash_command_dispatch.py` — dispatch logic for `/rerun-failed-ci`
+- `scripts/ci/slash_command_stage_dispatch.py` — dispatch logic for `/rerun-stage`,
+  loops through each suite in the stage and dispatches `rerun-test.yml` independently
+- `rerun-test.yml` — `workflow_dispatch` workflow for `/rerun-group` and `/rerun-stage`,
+  accepts suite name, runner label, and git ref as inputs
+- The handler workflow reacts with thumbs-up and posts result comments on the PR
+
+### PR Review (pr-review.yml)
+
+AI-powered code review using Claude Code Action. Auto-triggers on PR open/ready_for_review;
+also available on-demand via `/review` comment (`OWNER`/`COLLABORATOR` only).
+
+### CI Auto Bisect (ci-auto-bisect.yml)
+
+AI-powered CI failure analysis. Auto-triggers on failed workflow runs (PR Test, Nightly Test, etc.);
+also available on-demand via `/auto-bisect [run_id]` comment (`OWNER`/`COLLABORATOR` only).
+Classifies failures as `code_regression`, `flaky_test`, `infrastructure`, or `environment`
+and posts analysis results on the associated PR.
 
 ### Pull Request Testing (pr-test.yml)
 *Purpose:* Comprehensive testing for JAX

--- a/scripts/ci/slash_command_dispatch.py
+++ b/scripts/ci/slash_command_dispatch.py
@@ -1,0 +1,100 @@
+"""Dispatch logic for the /rerun-failed-ci slash command.
+
+Finds the latest pr-test workflow run for the PR branch and reruns its
+failed jobs.  Reads GH_TOKEN, HEAD_REF, PR_NUMBER, REPO from env vars
+(set by the YAML env: block) and calls the gh CLI.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+
+def _comment(pr_number, body):
+    subprocess.run(
+        ["gh", "pr", "comment", pr_number, "--body", body],
+        check=True,
+    )
+
+
+def main():
+    head_ref = os.environ.get("HEAD_REF", "")
+    pr_number = os.environ.get("PR_NUMBER", "")
+    repo = os.environ.get("REPO", "")
+
+    result = subprocess.run(
+        [
+            "gh",
+            "run",
+            "list",
+            "--workflow=pr-test.yml",
+            f"--branch={head_ref}",
+            "--status=completed",
+            "--limit=1",
+            "--json",
+            "databaseId,conclusion",
+            "--jq",
+            ".[0]",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        print(
+            f"gh run list failed (exit {result.returncode}): {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        _comment(
+            pr_number,
+            f"> **Slash command**: Failed to query runs for branch `{head_ref}` — please retry",
+        )
+        sys.exit(1)
+
+    raw = result.stdout.strip()
+    if not raw or raw == "null":
+        _comment(
+            pr_number,
+            f"> **Slash command**: No completed pr-test run found for branch `{head_ref}`",
+        )
+        return
+
+    run_info = json.loads(raw)
+    run_id = str(run_info["databaseId"])
+    conclusion = run_info.get("conclusion", "")
+
+    if conclusion == "success":
+        run_url = f"https://github.com/{repo}/actions/runs/{run_id}"
+        _comment(
+            pr_number,
+            f"> **Slash command**: Latest [run #{run_id}]({run_url}) already succeeded — nothing to rerun",
+        )
+        return
+
+    rerun = subprocess.run(
+        ["gh", "run", "rerun", run_id, "--failed"],
+        capture_output=True,
+        text=True,
+    )
+
+    run_url = f"https://github.com/{repo}/actions/runs/{run_id}"
+
+    if rerun.returncode != 0:
+        print(f"gh run rerun failed: {rerun.stderr.strip()}", file=sys.stderr)
+        _comment(
+            pr_number,
+            f"> **Slash command**: Failed to rerun [run #{run_id}]({run_url}) — {rerun.stderr.strip()}",
+        )
+        sys.exit(1)
+
+    _comment(
+        pr_number,
+        f"> **Slash command**: Re-running failed jobs in [run #{run_id}]({run_url})",
+    )
+
+    print(f"Rerun triggered for run {run_id} on branch {head_ref}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/slash_command_parse.py
+++ b/scripts/ci/slash_command_parse.py
@@ -1,0 +1,264 @@
+"""Slash command parser for PR comment-triggered CI operations.
+
+Reads comment body and author information from environment variables,
+parses the slash command, checks permissions, resolves job parameters,
+and writes results to $GITHUB_OUTPUT.
+"""
+
+import json
+import os
+import re
+import sys
+
+ALLOWED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+
+VALID_COMMANDS = {"rerun-failed-ci", "test", "rerun-group", "rerun-stage"}
+
+_SAFE_ARG_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+RUNNER_SUFFIXES = [
+    ("-cpu", "arc-runner-cpu"),
+    ("-v6e-4", "arc-runner-v6e-4"),
+    ("-v6e-1", "arc-runner-v6e-1"),
+]
+
+STAGE_JOBS = {
+    "stage1": ["unit-test-1-tpu", "unit-test-cpu"],
+    "stage2": [
+        "unit-test-4-tpu",
+        "e2e-test-1-tpu",
+        "e2e-test-4-tpu",
+        "accuracy-test-1-tpu",
+        "accuracy-test-4-tpu",
+    ],
+    "stage3": ["performance-test-1-tpu", "performance-test-4-tpu"],
+}
+
+STAGE_ALIASES = {
+    "1": "stage1",
+    "fast": "stage1",
+    "stage1": "stage1",
+    "2": "stage2",
+    "medium": "stage2",
+    "stage2": "stage2",
+    "3": "stage3",
+    "heavy": "stage3",
+    "stage3": "stage3",
+}
+
+JOB_TO_SUITE = {
+    "unit-test-1-tpu": ("unit-test-tpu-v6e-1", "arc-runner-v6e-1"),
+    "unit-test-cpu": ("unit-test-cpu", "arc-runner-cpu"),
+    "unit-test-4-tpu": ("unit-test-tpu-v6e-4", "arc-runner-v6e-4"),
+    "e2e-test-1-tpu": ("e2e-test-tpu-v6e-1", "arc-runner-v6e-1"),
+    "e2e-test-4-tpu": ("e2e-test-tpu-v6e-4", "arc-runner-v6e-4"),
+    "accuracy-test-1-tpu": ("accuracy-test-tpu-v6e-1", "arc-runner-v6e-1"),
+    "accuracy-test-4-tpu": ("accuracy-test-tpu-v6e-4", "arc-runner-v6e-4"),
+    "performance-test-1-tpu": ("performance-test-tpu-v6e-1", "arc-runner-v6e-1"),
+    "performance-test-4-tpu": ("performance-test-tpu-v6e-4", "arc-runner-v6e-4"),
+}
+
+
+def _sanitize_arg(arg, max_len=20):
+    """Strip non-alphanumeric chars and truncate to prevent reflected content injection."""
+    return _SAFE_ARG_RE.sub("", arg)[:max_len]
+
+
+def resolve_runner(suite):
+    """Derive the runner label from a test suite name. Returns None if unknown."""
+    for suffix, runner in RUNNER_SUFFIXES:
+        if suite.endswith(suffix):
+            return runner
+    return None
+
+
+def parse_command(comment_body):
+    """Extract (command, args) from comment body, or (None, []) if invalid."""
+    if not comment_body:
+        return (None, [])
+
+    first_line = comment_body.strip().split("\n")[0].strip()
+    if not first_line.startswith("/"):
+        return (None, [])
+
+    parts = first_line.split()
+    command = parts[0][1:]
+    args = parts[1:]
+
+    if command not in VALID_COMMANDS:
+        return (None, [])
+
+    return (command, args)
+
+
+def check_permission(actor, actor_association):
+    """Return True if the actor is allowed to run slash commands."""
+    return actor_association.upper() in ALLOWED_ASSOCIATIONS
+
+
+def resolve_jobs(command, args):
+    """Map command + args to an action descriptor dict.
+
+    Keys:
+        action     — "rerun_failed" | "add_label" | "rerun_group" | "rerun_stage"
+        suite      — test suite name (for rerun-group)
+        runner     — runner label (for rerun-group)
+        labels     — labels to add to the PR
+        stage      — canonical stage name (for rerun-stage)
+        jobs       — list of pr-test.yml job names (for rerun-stage)
+        error      — non-empty string on invalid input
+    """
+    result = {
+        "action": "",
+        "suite": "",
+        "runner": "",
+        "labels": [],
+        "error": "",
+        "stage": "",
+        "jobs": [],
+    }
+
+    if command == "rerun-failed-ci":
+        result["action"] = "rerun_failed"
+        return result
+
+    if command == "test":
+        if not args:
+            result["error"] = "Missing test type. Usage: /test perf"
+            return result
+        test_type = args[0].lower()
+        if test_type == "perf":
+            result["action"] = "add_label"
+            result["labels"] = ["test:perf"]
+            return result
+        safe = _sanitize_arg(args[0])
+        result["error"] = f"Unknown test type '{safe}'. Valid: perf"
+        return result
+
+    if command == "rerun-group":
+        if not args:
+            result["error"] = "Missing suite name. Usage: /rerun-group <suite-name>"
+            return result
+        suite = _sanitize_arg(args[0], max_len=64)
+        runner = resolve_runner(suite)
+        if runner is None:
+            result["error"] = (
+                f"Cannot determine runner for suite '{suite}'. "
+                "Suite name must end with -v6e-1, -v6e-4, or -cpu"
+            )
+            return result
+        result["action"] = "rerun_group"
+        result["suite"] = suite
+        result["runner"] = runner
+        return result
+
+    if command == "rerun-stage":
+        if not args:
+            result["error"] = "Missing stage. Usage: /rerun-stage <1|2|3|fast|medium|heavy>"
+            return result
+        raw_arg = _sanitize_arg(args[0])
+        stage = STAGE_ALIASES.get(raw_arg.lower())
+        if stage is None:
+            result["error"] = f"Unknown stage '{raw_arg}'. Valid: 1/fast, 2/medium, 3/heavy"
+            return result
+        result["action"] = "rerun_stage"
+        result["stage"] = stage
+        result["jobs"] = STAGE_JOBS[stage]
+        return result
+
+    result["error"] = f"Unknown command '{command}'"
+    return result
+
+
+def write_outputs(outputs):
+    """Write key=value pairs to $GITHUB_OUTPUT."""
+    output_file = os.environ.get("GITHUB_OUTPUT", "")
+    if output_file:
+        with open(output_file, "a") as f:
+            for name, value in outputs.items():
+                f.write(f"{name}={value}\n")
+    else:
+        print("(GITHUB_OUTPUT not set — printing only)", file=sys.stderr)
+
+
+def main():
+    comment_body = os.environ.get("COMMENT_BODY", "")
+    actor = os.environ.get("ACTOR", "")
+    actor_association = os.environ.get("ACTOR_ASSOCIATION", "")
+
+    command, args = parse_command(comment_body)
+
+    if command is None:
+        write_outputs({"valid": "false", "error": "Not a valid slash command"})
+        print("No valid slash command found")
+        return
+
+    permitted = check_permission(actor, actor_association)
+
+    if not permitted:
+        write_outputs(
+            {
+                "valid": "true",
+                "permitted": "false",
+                "command": command,
+                "error": f"Permission denied for {actor} ({actor_association})",
+            }
+        )
+        print(f"Permission denied: {actor} ({actor_association})")
+        return
+
+    job_info = resolve_jobs(command, args)
+
+    if job_info["error"]:
+        write_outputs(
+            {
+                "valid": "true",
+                "permitted": "true",
+                "command": command,
+                "error": job_info["error"],
+            }
+        )
+        print(f"Command error: {job_info['error']}")
+        return
+
+    outputs = {
+        "valid": "true",
+        "permitted": "true",
+        "command": command,
+        "action": job_info["action"],
+        "error": "",
+    }
+    if job_info["suite"]:
+        outputs["suite"] = job_info["suite"]
+    if job_info["runner"]:
+        outputs["runner"] = job_info["runner"]
+    if job_info["labels"]:
+        outputs["labels_csv"] = ",".join(job_info["labels"])
+    if job_info["stage"]:
+        outputs["stage"] = job_info["stage"]
+        suites = []
+        for job in job_info["jobs"]:
+            suite_name, runner = JOB_TO_SUITE[job]
+            suites.append({"suite": suite_name, "runner": runner})
+        outputs["stage_suites_json"] = json.dumps(suites)
+
+    write_outputs(outputs)
+
+    print("=== Slash Command ===")
+    print(f"command: {command}")
+    print(f"args: {args}")
+    print(f"actor: {actor} ({actor_association})")
+    print(f"action: {job_info['action']}")
+    if job_info["suite"]:
+        print(f"suite: {job_info['suite']}")
+    if job_info["runner"]:
+        print(f"runner: {job_info['runner']}")
+    if job_info["labels"]:
+        print(f"labels: {', '.join(job_info['labels'])}")
+    if job_info["stage"]:
+        print(f"stage: {job_info['stage']}")
+        print(f"jobs: {', '.join(job_info['jobs'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/slash_command_stage_dispatch.py
+++ b/scripts/ci/slash_command_stage_dispatch.py
@@ -1,0 +1,88 @@
+"""Dispatch logic for the /rerun-stage slash command.
+
+Reads STAGE_SUITES_JSON (list of {suite, runner} dicts), HEAD_REF,
+PR_NUMBER from env vars and dispatches each suite independently via
+rerun-test.yml.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+
+def _comment(pr_number, body):
+    subprocess.run(
+        ["gh", "pr", "comment", pr_number, "--body", body],
+        check=True,
+    )
+
+
+def main():
+    head_ref = os.environ.get("HEAD_REF", "")
+    pr_number = os.environ.get("PR_NUMBER", "")
+    stage = os.environ.get("STAGE", "")
+    raw_json = os.environ.get("STAGE_SUITES_JSON", "")
+
+    if not raw_json:
+        print("STAGE_SUITES_JSON not set", file=sys.stderr)
+        _comment(
+            pr_number,
+            f"> **Slash command**: Failed to dispatch stage `{stage}` — missing suite data",
+        )
+        sys.exit(1)
+
+    suites = json.loads(raw_json)
+    dispatched = []
+    failed = []
+
+    for entry in suites:
+        suite_name = entry["suite"]
+        runner = entry["runner"]
+        result = subprocess.run(
+            [
+                "gh",
+                "workflow",
+                "run",
+                "rerun-test.yml",
+                "--ref",
+                "main",
+                "-f",
+                f"suite={suite_name}",
+                "-f",
+                f"runner={runner}",
+                "-f",
+                f"ref={head_ref}",
+                "-f",
+                f"pr_number={pr_number}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            dispatched.append(suite_name)
+            print(f"Dispatched {suite_name} on {runner}")
+        else:
+            failed.append(suite_name)
+            print(
+                f"Failed to dispatch {suite_name}: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+
+    lines = []
+    if dispatched:
+        suite_list = ", ".join(f"`{s}`" for s in dispatched)
+        lines.append(f"Dispatched {suite_list} for branch `{head_ref}`")
+    if failed:
+        fail_list = ", ".join(f"`{s}`" for s in failed)
+        lines.append(f"Failed to dispatch {fail_list}")
+
+    body = "; ".join(lines)
+    _comment(pr_number, f"> **Slash command** (`{stage}`): {body}")
+
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add slash command support in PR comments to trigger targeted CI operations instead of re-running the entire workflow
- Permission-gated: only OWNER/MEMBER/COLLABORATOR can trigger commands
- Input sanitized to prevent shell injection

## Slash Commands

| Command | Description |
|---------|-------------|
| `/rerun-failed-ci` | Re-run only the failed jobs from the most recent `pr-test` run on the PR branch |
| `/test perf` | Add the `test:perf` label — the label event triggers CI with perf tests enabled |
| `/rerun-group <suite>` | Run a specific test suite on the matching runner via `rerun-test.yml` |
| `/rerun-stage <stage>` | Dispatch all suites in a stage independently via `rerun-test.yml`. Stage: `1`/`fast`, `2`/`medium`, `3`/`heavy` |

## New files

| File | Description |
|------|-------------|
| `.github/workflows/slash-command.yml` | `issue_comment` workflow — parses command, checks permissions, dispatches |
| `.github/workflows/rerun-test.yml` | `workflow_dispatch` workflow for `/rerun-group` and `/rerun-stage` — runs suite on derived runner |
| `scripts/ci/slash_command_parse.py` | Pure-Python parser (stdlib only) — `parse_command()`, `check_permission()`, `resolve_jobs()` |
| `scripts/ci/slash_command_dispatch.py` | Dispatch logic for `/rerun-failed-ci` — finds latest completed run and reruns failed jobs |
| `scripts/ci/slash_command_stage_dispatch.py` | Dispatch logic for `/rerun-stage` — loops through each suite in the stage and dispatches `rerun-test.yml` |

## Design decisions
- `/test perf` only adds the label — the `labeled` event on pr-test.yml triggers CI automatically (no redundant `gh workflow run`)
- `/rerun-group` derives runner from suite name suffix (`-v6e-1`, `-v6e-4`, `-cpu`) via `endswith` — no mapping table needed
- `/rerun-stage` maps stage names to pr-test.yml job names (`STAGE_JOBS`), then converts to suite+runner pairs (`JOB_TO_SUITE`) for dispatch
- User input sanitized with `_sanitize_arg()` (alphanumeric + hyphens/underscores only); default max 20 chars for stage args, 64 for suite names
- `gh run list` uses `--status=completed` filter to avoid picking up in-progress runs
- Dispatch logic in Python scripts to keep YAML declarative per project conventions

## Docs
- Added `/rerun-stage` to `ci_architecture.md` command table
- Added PR Review and CI Auto Bisect sections to `ci_architecture.md`

Closes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)