### PR TITLE
ci: add XLA/model cache env vars, shell unification, publish consolidation (P0-9, P2-7)

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: arc-runner-v6e-1
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,6 +33,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         timeout-minutes: 60
         run: |
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
@@ -47,7 +50,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type bench --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-text-models-1-tpu-daily:
@@ -55,6 +58,8 @@ jobs:
     runs-on: arc-runner-v6e-1
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -68,6 +73,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         run: |
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/perf/$OUTPUT_DIR_NAME"
@@ -87,7 +93,7 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
 
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type perf --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-trace-text-models-1-tpu-daily:
@@ -95,6 +101,8 @@ jobs:
     runs-on: arc-runner-v6e-1
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -108,6 +116,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         run: |
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/trace/$OUTPUT_DIR_NAME"
@@ -126,7 +135,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_traces.py --traces-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type trace --source-dir ./test/nightly_test_output
 
   nightly-test-daily-finish:
     needs: [

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
         part: [0, 1 , 2, 3]
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -35,6 +37,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         timeout-minutes: 1000
         run: |
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
@@ -51,7 +54,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type bench --source-dir ./test/nightly_test_output
 
       - name: Generate CSV Entry and publish
         env:
@@ -73,7 +76,7 @@ jobs:
           fi
           echo "$SHA,$AUTHOR,$MSG,$RUN_URL" >> $FILE
           echo "CSV line added: $SHA, $AUTHOR, $MSG"
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./meta
+          python3 scripts/ci/publish.py --data-type bench --source-dir ./meta
 
 
   nightly-test-accuracy-text-models-4-tpu:
@@ -85,6 +88,8 @@ jobs:
         part: [0, 1 , 2, 3 , 4, 5]
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -96,6 +101,7 @@ jobs:
         env:
             HF_TOKEN: ${{ secrets.HF_TOKEN }}
             HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+            JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         timeout-minutes: 1200
         run: |
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
@@ -112,7 +118,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type bench --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-text-models-1-tpu:
@@ -124,6 +130,8 @@ jobs:
         part: [0, 1 , 2, 3, 4, 5, 6, 7]
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -137,6 +145,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         run: |
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/perf/$OUTPUT_DIR_NAME"
@@ -156,7 +165,7 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
 
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type perf --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-text-models-4-tpu-part1:
@@ -164,6 +173,8 @@ jobs:
     runs-on: arc-runner-v6e-4
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -178,6 +189,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         run: |
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/perf/$OUTPUT_DIR_NAME"
@@ -196,7 +208,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type perf --source-dir ./test/nightly_test_output
 
       - name: Generate CSV Entry and publish
         env:
@@ -218,7 +230,7 @@ jobs:
           fi
           echo "$SHA,$AUTHOR,$MSG,$RUN_URL" >> $FILE
           echo "CSV line added: $SHA, $AUTHOR, $MSG"
-          python3 scripts/ci/publish_bench_and_perf.py --source-dir ./meta
+          python3 scripts/ci/publish.py --data-type perf --source-dir ./meta
 
 
   nightly-test-perf-text-models-4-tpu-part2:
@@ -226,6 +238,8 @@ jobs:
       runs-on: arc-runner-v6e-4
       env:
         TZ: Asia/Shanghai
+        JAX_COMPILATION_CACHE_DIR: /xla-cache
+        SGLANG_JAX_MODEL_CACHE: /models/model_scope
       steps:
         - name: Checkout code
           uses: actions/checkout@v4
@@ -240,6 +254,7 @@ jobs:
             PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
             HF_TOKEN: ${{ secrets.HF_TOKEN }}
             HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+            JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
           run: |
             export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
             export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/perf/$OUTPUT_DIR_NAME"
@@ -258,7 +273,7 @@ jobs:
             GITHUB_RUN_ID: ${{ github.run_id }}
             GITHUB_RUN_NUMBER: ${{ github.run_number }}
           run: |
-            python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+            python3 scripts/ci/publish.py --data-type perf --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-text-models-4-tpu-part3:
@@ -266,6 +281,8 @@ jobs:
         runs-on: arc-runner-v6e-4
         env:
           TZ: Asia/Shanghai
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
+          SGLANG_JAX_MODEL_CACHE: /models/model_scope
         steps:
           - name: Checkout code
             uses: actions/checkout@v4
@@ -280,6 +297,7 @@ jobs:
               PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
               HF_TOKEN: ${{ secrets.HF_TOKEN }}
               HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+              JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
             run: |
               export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
               export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/perf/$OUTPUT_DIR_NAME"
@@ -298,7 +316,7 @@ jobs:
               GITHUB_RUN_ID: ${{ github.run_id }}
               GITHUB_RUN_NUMBER: ${{ github.run_number }}
             run: |
-              python3 scripts/ci/publish_bench_and_perf.py --source-dir ./test/nightly_test_output
+              python3 scripts/ci/publish.py --data-type perf --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-trace-text-models-1-tpu:
@@ -310,6 +328,8 @@ jobs:
         part: [0, 1 , 2, 3, 4, 5, 6, 7]
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -323,6 +343,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         run: |
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/trace/$OUTPUT_DIR_NAME"
@@ -341,7 +362,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_traces.py --traces-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type trace --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-trace-text-models-4-tpu-part1:
@@ -349,6 +370,8 @@ jobs:
     runs-on: arc-runner-v6e-4
     env:
       TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -363,6 +386,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+          JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
         run: |
           export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
           export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/trace/$OUTPUT_DIR_NAME"
@@ -381,7 +405,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_traces.py --traces-dir ./test/nightly_test_output
+          python3 scripts/ci/publish.py --data-type trace --source-dir ./test/nightly_test_output
 
 
   nightly-test-perf-trace-text-models-4-tpu-part2:
@@ -389,6 +413,8 @@ jobs:
       runs-on: arc-runner-v6e-4
       env:
         TZ: Asia/Shanghai
+        JAX_COMPILATION_CACHE_DIR: /xla-cache
+        SGLANG_JAX_MODEL_CACHE: /models/model_scope
       steps:
         - name: Checkout code
           uses: actions/checkout@v4
@@ -403,6 +429,7 @@ jobs:
             PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
             HF_TOKEN: ${{ secrets.HF_TOKEN }}
             HF_HUB_DOWNLOAD_TIMEOUT: ${{ vars.HF_HUB_DOWNLOAD_TIMEOUT }}
+            JAX_DEBUG_LOG_MODULES: jax._src.compilation_cache_utils
           run: |
             export OUTPUT_DIR_NAME=$(date +'%Y-%m-%d')
             export PERF_OUTPUT_DIR="$GITHUB_WORKSPACE/test/nightly_test_output/trace/$OUTPUT_DIR_NAME"
@@ -421,7 +448,7 @@ jobs:
             GITHUB_RUN_ID: ${{ github.run_id }}
             GITHUB_RUN_NUMBER: ${{ github.run_number }}
           run: |
-            python3 scripts/ci/publish_traces.py --traces-dir ./test/nightly_test_output
+            python3 scripts/ci/publish.py --data-type trace --source-dir ./test/nightly_test_output
 
         - name: Generate CSV Entry and publish
           env:
@@ -443,7 +470,7 @@ jobs:
             fi
             echo "$SHA,$AUTHOR,$MSG,$RUN_URL" >> $FILE
             echo "CSV line added: $SHA, $AUTHOR, $MSG"
-            python3 scripts/ci/publish_bench_and_perf.py --source-dir ./meta
+            python3 scripts/ci/publish.py --data-type bench --source-dir ./meta
 
   nightly-test-finish:
     needs: [

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -39,6 +39,7 @@ jobs:
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
         run: |
           python test/srt/run_suite.py --suite unit-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 3
@@ -59,8 +60,10 @@ jobs:
         uses: ./.github/actions/setup-venv
       - name: Run unit test
         timeout-minutes: 30
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
         run: |
           bash scripts/killall_sglang.sh
@@ -104,6 +107,7 @@ jobs:
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
@@ -130,6 +134,7 @@ jobs:
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
@@ -153,8 +158,10 @@ jobs:
         uses: ./.github/actions/setup-venv
       - name: Evaluate accuracy
         timeout-minutes: 20
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
@@ -179,8 +186,10 @@ jobs:
         uses: ./.github/actions/setup-venv
       - name: Evaluate MoE accuracy (TP=4)
         timeout-minutes: 50
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
@@ -204,8 +213,10 @@ jobs:
           extra-packages: evalscope==1.0.0
       - name: Run extra multi-chip accuracy tests
         timeout-minutes: 120
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
@@ -229,8 +240,10 @@ jobs:
           extra-packages: evalscope==1.0.0
       - name: Run extra accuracy tests
         timeout-minutes: 60
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
@@ -255,8 +268,10 @@ jobs:
         uses: ./.github/actions/setup-venv
       - name: Benchmark performance
         timeout-minutes: 30
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
@@ -280,9 +295,10 @@ jobs:
         uses: ./.github/actions/setup-venv
       - name: Benchmark performance (tp=4)
         timeout-minutes: 50
-
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
@@ -304,8 +320,10 @@ jobs:
         uses: ./.github/actions/setup-venv
       - name: Run extra performance tests
         timeout-minutes: 120
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
@@ -327,8 +345,10 @@ jobs:
         uses: ./.github/actions/setup-venv
       - name: Run perf trace tests
         timeout-minutes: 60
+        shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300
@@ -356,6 +376,7 @@ jobs:
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true
+          JAX_COMPILATION_CACHE_DIR: /xla-cache
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HUB_DOWNLOAD_TIMEOUT: 300

--- a/scripts/ci/publish.py
+++ b/scripts/ci/publish.py
@@ -1,0 +1,367 @@
+"""
+Unified publish script for CI artifacts (bench, perf, trace) to GitHub repository.
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+def make_github_request(url, token, method="GET", data=None):
+    """Make authenticated request to GitHub API"""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    if data:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(data).encode("utf-8")
+
+    req = Request(url, data=data, headers=headers, method=method)
+
+    try:
+        with urlopen(req) as response:
+            return response.read().decode("utf-8")
+    except HTTPError as e:
+        print(f"GitHub API request failed: {e}")
+        try:
+            error_body = e.read().decode("utf-8")
+            print(f"Error response body: {error_body}")
+            e.error_body = error_body
+        except Exception:
+            e.error_body = ""
+        raise
+    except Exception as e:
+        print(f"GitHub API request failed with a non-HTTP error: {e}")
+        raise
+
+
+def verify_token_permissions(repo_owner, repo_name, token):
+    """Verify that the token has necessary permissions for the repository"""
+    print("Verifying token permissions...")
+
+    try:
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}"
+        response = make_github_request(url, token)
+        repo_data = json.loads(response)
+        print(f"Repository access verified: {repo_data['full_name']}")
+    except Exception as e:
+        print(f"Failed to access repository: {e}")
+        return False
+
+    try:
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/contents"
+        response = make_github_request(url, token)
+        print("Repository contents access verified")
+    except Exception as e:
+        print(f"Failed to access repository contents: {e}")
+        return False
+
+    return True
+
+
+def get_branch_sha(repo_owner, repo_name, branch, token):
+    """Get SHA of the branch head"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/refs/heads/{branch}"
+    response = make_github_request(url, token)
+    data = json.loads(response)
+    return data["object"]["sha"]
+
+
+def get_tree_sha(repo_owner, repo_name, commit_sha, token):
+    """Get tree SHA from commit"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/commits/{commit_sha}"
+    response = make_github_request(url, token)
+    data = json.loads(response)
+    return data["tree"]["sha"]
+
+
+def create_blob(repo_owner, repo_name, content, token, max_retries=3):
+    """Create a blob with file content"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/blobs"
+
+    content_b64 = base64.b64encode(content).decode("utf-8")
+
+    data = {"content": content_b64, "encoding": "base64"}
+
+    for attempt in range(max_retries):
+        try:
+            response = make_github_request(url, token, method="POST", data=data)
+            return json.loads(response)["sha"]
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                print(
+                    f"Blob creation failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+
+
+def create_tree(repo_owner, repo_name, base_tree_sha, files, token, max_retries=3):
+    """Create a new tree with files"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/trees"
+
+    tree_items = []
+    for i, (file_path, content) in enumerate(files):
+        blob_sha = create_blob(repo_owner, repo_name, content, token)
+        tree_items.append(
+            {
+                "path": file_path,
+                "mode": "100644",
+                "type": "blob",
+                "sha": blob_sha,
+            }
+        )
+        if (i + 1) % 10 == 0 or (i + 1) == len(files):
+            print(f"Created {i + 1}/{len(files)} blobs...")
+
+    data = {"base_tree": base_tree_sha, "tree": tree_items}
+
+    for attempt in range(max_retries):
+        try:
+            response = make_github_request(url, token, method="POST", data=data)
+            return json.loads(response)["sha"]
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                print(
+                    f"Tree creation failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+
+
+def create_commit(repo_owner, repo_name, tree_sha, parent_sha, message, token, max_retries=3):
+    """Create a new commit"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/commits"
+
+    data = {"tree": tree_sha, "parents": [parent_sha], "message": message}
+
+    for attempt in range(max_retries):
+        try:
+            response = make_github_request(url, token, method="POST", data=data)
+            commit_sha = json.loads(response)["sha"]
+
+            verify_url = (
+                f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/commits/{commit_sha}"
+            )
+            verify_response = make_github_request(verify_url, token)
+            verify_data = json.loads(verify_response)
+            if verify_data["sha"] != commit_sha:
+                raise Exception(
+                    f"Commit verification failed: expected {commit_sha}, got {verify_data['sha']}"
+                )
+
+            return commit_sha
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                print(
+                    f"Commit creation failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+
+
+def update_branch_ref(repo_owner, repo_name, branch, commit_sha, token, max_retries=3):
+    """Update branch reference to point to new commit"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/refs/heads/{branch}"
+
+    data = {"sha": commit_sha}
+
+    for attempt in range(max_retries):
+        try:
+            make_github_request(url, token, method="PATCH", data=data)
+            return
+        except HTTPError as e:
+            is_object_not_exist = False
+            if hasattr(e, "error_body"):
+                try:
+                    error_data = json.loads(e.error_body)
+                    if "Object does not exist" in error_data.get("message", ""):
+                        is_object_not_exist = True
+                except Exception:
+                    pass
+
+            if is_object_not_exist and attempt < max_retries - 1:
+                wait_time = 2**attempt
+                print(
+                    f"Branch update failed with 'Object does not exist' (attempt {attempt + 1}/{max_retries}), waiting {wait_time}s for consistency..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                print(
+                    f"Branch update failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+
+
+def collect_files(source_dir, file_extension, target_base_path):
+    """Collect files with the given extension from source_dir for upload."""
+    files_to_upload = []
+
+    if not os.path.exists(source_dir):
+        print(f"Warning: Source directory {source_dir} does not exist")
+        return files_to_upload
+
+    for root, dirs, files in os.walk(source_dir):
+        for file in files:
+            if file.endswith(file_extension):
+                source_file = os.path.join(root, file)
+                rel_path = os.path.relpath(source_file, source_dir)
+                target_path = (
+                    f"{target_base_path}/{rel_path}" if target_base_path != "" else rel_path
+                )
+
+                with open(source_file, "rb") as f:
+                    content = f.read()
+
+                files_to_upload.append((target_path, content))
+
+    return files_to_upload
+
+
+def publish(source_dir, data_type, run_id, run_number):
+    """Publish files to GitHub repository in a single commit."""
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        print("Error: GITHUB_TOKEN environment variable not set")
+        sys.exit(1)
+
+    repo_owner = "pathfinder-pf"
+    repo_name = "sglang-jax-ci-data"
+    branch = "main"
+    target_base_path = ""
+
+    if data_type == "trace":
+        file_extension = ".json.gz"
+        no_files_msg = "No trace files found to upload"
+        success_msg = "Successfully published all traces in a single commit"
+
+        def make_commit_message(count):
+            return f"Nightly traces for run {run_id} at {run_number} ({count} files)"
+
+    else:  # bench or perf
+        file_extension = ".csv"
+        no_files_msg = "No csv files found to upload"
+        success_msg = "Successfully published all csv files in a single commit"
+
+        def make_commit_message(count):
+            return f"CSV files of Nightly-test for run {run_id} at {run_number} ({count} files)"
+
+    files_to_upload = collect_files(source_dir, file_extension, target_base_path)
+
+    if not files_to_upload:
+        print(no_files_msg)
+        return
+
+    print(f"Found {len(files_to_upload)} files to upload")
+
+    if not verify_token_permissions(repo_owner, repo_name, token):
+        print("Token permission verification failed. Please check the token permissions.")
+        sys.exit(1)
+
+    max_retries = 5
+    retry_delay = 5  # seconds
+
+    for attempt in range(max_retries):
+        try:
+            branch_sha = get_branch_sha(repo_owner, repo_name, branch, token)
+            print(f"Current branch head: {branch_sha}")
+
+            tree_sha = get_tree_sha(repo_owner, repo_name, branch_sha, token)
+            print(f"Current tree SHA: {tree_sha}")
+
+            new_tree_sha = create_tree(repo_owner, repo_name, tree_sha, files_to_upload, token)
+            print(f"Created new tree: {new_tree_sha}")
+
+            commit_message = make_commit_message(len(files_to_upload))
+            commit_sha = create_commit(
+                repo_owner,
+                repo_name,
+                new_tree_sha,
+                branch_sha,
+                commit_message,
+                token,
+            )
+            print(f"Created commit: {commit_sha}")
+
+            update_branch_ref(repo_owner, repo_name, branch, commit_sha, token)
+            print("Updated branch reference")
+
+            print(success_msg)
+            return
+
+        except Exception as e:
+            is_retryable = False
+            error_type = "unknown"
+
+            if hasattr(e, "error_body"):
+                if "Update is not a fast forward" in e.error_body:
+                    is_retryable = True
+                    error_type = "fast-forward conflict"
+                elif "Object does not exist" in e.error_body:
+                    is_retryable = True
+                    error_type = "object consistency"
+
+            if isinstance(e, HTTPError) and e.code in [422, 500, 502, 503, 504]:
+                is_retryable = True
+                error_type = f"HTTP {e.code}"
+
+            if is_retryable and attempt < max_retries - 1:
+                print(
+                    f"Attempt {attempt + 1}/{max_retries} failed ({error_type}). Retrying in {retry_delay} seconds..."
+                )
+                time.sleep(retry_delay)
+            else:
+                print(f"Failed to publish after {attempt + 1} attempts: {e}")
+                raise
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Publish CI artifacts to a GitHub repository")
+    parser.add_argument(
+        "--source-dir",
+        type=str,
+        required=True,
+        help="Source directory with files to publish",
+    )
+    parser.add_argument(
+        "--data-type",
+        type=str,
+        required=True,
+        choices=["bench", "perf", "trace"],
+        help="Type of data to publish: bench/perf (scans .csv) or trace (scans .json.gz)",
+    )
+    args = parser.parse_args()
+
+    run_id = os.getenv("GITHUB_RUN_ID", "test")
+    run_number = os.getenv("GITHUB_RUN_NUMBER", "12345")
+
+    if not run_id or not run_number:
+        print("Error: GITHUB_RUN_ID and GITHUB_RUN_NUMBER environment variables must be set")
+        sys.exit(1)
+
+    print(f"Processing files from directory: {args.source_dir}")
+    publish(args.source_dir, args.data_type, run_id, run_number)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -69,6 +69,11 @@ def run_unittest_files(
     reruns_delay: float = 10,
     only_rerun: list[str] | None = None,
 ):
+    # When JAX_COMPILATION_CACHE_DIR is set (e.g. /xla-cache in CI),
+    # jtu.JaxTestCase.setUp() needs this flag to properly manage cache
+    # lifecycle — without it, lazy cache init trips the global-state assertion.
+    os.environ.setdefault("JAX_TEST_WITH_PERSISTENT_COMPILATION_CACHE", "1")
+
     tic = time.perf_counter()
     success = True
 


### PR DESCRIPTION
## Summary

- Add `JAX_COMPILATION_CACHE_DIR=/xla-cache` to all TPU test jobs (13 PR Test + 9 nightly + 3 daily = 25 jobs) to leverage GCS-mounted XLA compilation cache, avoiding repeated compilations per job
- Add `SGLANG_JAX_MODEL_CACHE=/models/model_scope` to nightly/daily jobs (12 jobs) so they use GCS-mounted model cache instead of HuggingFace downloads
- Add `shell: bash` to 9 PR Test run steps that were missing it for shell consistency
- Add `JAX_DEBUG_LOG_MODULES=jax._src.compilation_cache_utils` to nightly/daily test steps for compilation cache hit rate monitoring
- Consolidate `publish_bench_and_perf.py` + `publish_traces.py` into unified `scripts/ci/publish.py --data-type bench|perf|trace`

## Test plan

- [ ] Verify YAML syntax passes validation (done locally with `yaml.safe_load`)
- [ ] Verify second CI run shows XLA compilation cache hits in logs
- [ ] Verify nightly jobs load models from `/models/model_scope` without HuggingFace fallback
- [ ] Verify nightly publish steps correctly invoke `publish.py` with appropriate `--data-type`
- [ ] Verify `JAX_DEBUG_LOG_MODULES` produces cache hit rate data in nightly logs

Closes #1127
Closes #1143

🤖 Generated with [Claude Code](https://claude.com/claude-code)