### PR TITLE
ci: trigger pr-review only on /review comment

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,8 +1,6 @@
 name: PR Review (Claude)
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created]
 
@@ -14,12 +12,10 @@ permissions:
 
 concurrency:
   group: >-
-    pr-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{
+    pr-review-${{ github.event.issue.number }}-${{
       (
-        (github.event_name == 'pull_request')
-        || (github.event_name == 'issue_comment'
-            && startsWith(github.event.comment.body, '/review')
-            && contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.comment.author_association))
+        startsWith(github.event.comment.body, '/review')
+        && contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.comment.author_association)
       )
       && 'active'
       || github.run_id
@@ -29,11 +25,9 @@ concurrency:
 jobs:
   review:
     if: >
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
-      || (github.event_name == 'issue_comment'
-          && github.event.issue.pull_request != null
-          && startsWith(github.event.comment.body, '/review')
-          && contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.comment.author_association))
+      github.event.issue.pull_request != null
+      && startsWith(github.event.comment.body, '/review')
+      && contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -42,15 +36,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" = "issue_comment" ]; then
-            PR_NUMBER=${{ github.event.issue.number }}
-            HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid -q .headRefOid)
-            HEAD_REF=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName -q .headRefName)
-          else
-            PR_NUMBER=${{ github.event.pull_request.number }}
-            HEAD_SHA=${{ github.event.pull_request.head.sha }}
-            HEAD_REF=${{ github.event.pull_request.head.ref }}
-          fi
+          PR_NUMBER=${{ github.event.issue.number }}
+          HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid -q .headRefOid)
+          HEAD_REF=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName -q .headRefName)
           echo "number=$PR_NUMBER"  >> "$GITHUB_OUTPUT"
           echo "sha=$HEAD_SHA"      >> "$GITHUB_OUTPUT"
           echo "ref=$HEAD_REF"      >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Background

The `PR Review (Claude)` workflow currently runs automatically on every PR open/push, producing a `review` check run in the PR checks summary. Even though it's not in the ruleset's required status checks (only `lint` and `pr-test-finish` gate merges), a failed run still shows up as a red ❌ in the failing checks list and is easy to mistake for a merge blocker.

GitHub Actions' execution model guarantees a check run for every job that starts — the workflow author can't suppress it. The only way to keep it out of the checks list is to not let it run on PR events.

GitHub Apps like Gemini Code Assist and CodeRabbit avoid this because they post via the Review/Comment API, which doesn't produce check runs. We use `anthropics/claude-code-action@v1`, which runs as a GitHub Action and does not have that option.

## Change

Drop the `pull_request` trigger; keep only `issue_comment`. The workflow now runs only when an OWNER or COLLABORATOR posts a `/review` comment on the PR.

Cleanup of branches made dead by this change:
- `concurrency` group key no longer needs `pull_request.number || issue.number` or the `event_name` branch
- The job `if` keeps only the `issue_comment` branch
- The `Resolve PR ref` step no longer needs the if/else branch

## Impact

- No automatic review on PR open/push — the PR checks list stays clean
- Trigger a review on demand by commenting `/review`
- Merge gating is unchanged (`lint` + `pr-test-finish` — this workflow was never part of it)

## Test plan

- [x] YAML syntax validates
- [ ] After merge, confirm a new PR no longer shows `PR Review (Claude) / review` by default
- [ ] Confirm `/review` comment still triggers the workflow end-to-end