### PR TITLE
ci: add AI-assisted root cause analysis for CI failures (P2-1)

### DIFF
--- a/.github/workflows/ci-auto-bisect.yml
+++ b/.github/workflows/ci-auto-bisect.yml
@@ -1,0 +1,235 @@
+name: CI Auto Bisect
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Failed workflow run ID to analyze'
+        required: true
+        type: string
+      issue_number:
+        description: 'Issue number to comment results on (optional)'
+        required: false
+        type: string
+  workflow_run:
+    workflows: ["PR Test", "Nightly Test", "Nightly Test Daily", "TPU Multi Test"]
+    types: [completed]
+  repository_dispatch:
+    types: [analysis_request]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ci-auto-bisect-${{ inputs.run_id || github.event.client_payload.run_id || github.event.workflow_run.id || github.event.comment.id || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+  id-token: write
+
+jobs:
+  auto-bisect:
+    if: >-
+      github.repository == 'sgl-project/sglang-jax'
+      && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'failure')
+      && (github.event_name != 'issue_comment' || (
+           github.event.issue.pull_request != null
+           && startsWith(github.event.comment.body, '/auto-bisect')
+           && contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.comment.author_association)
+         ))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - id: parse_comment
+        if: github.event_name == 'issue_comment'
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: python3 scripts/ci/parse_bisect_comment.py
+
+      - id: bisect
+        if: github.event_name != 'issue_comment' || steps.parse_comment.outputs.valid == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          track_progress: false
+          prompt: |
+            # sgl-jax CI Auto Bisect
+
+            REPO: ${{ github.repository }}
+            RUN_ID: ${{ inputs.run_id || github.event.client_payload.run_id || github.event.workflow_run.id || steps.parse_comment.outputs.run_id }}
+            ISSUE_NUMBER: ${{ inputs.issue_number || github.event.client_payload.issue_number || github.event.workflow_run.pull_requests[0].number || github.event.issue.number }}
+
+            The base repo's `main` is checked out in the current working
+            directory. Note that this is *not* the source tree at the failing
+            run's commit — for PR-specific or fork diffs, use the GitHub
+            compare API rather than the local tree.
+
+            `gh` is authenticated for the repo.
+
+            ## Your job
+
+            Investigate the failed workflow run referenced by RUN_ID, classify
+            the root cause, and emit machine-readable results.
+
+            ## Resolving RUN_ID
+
+            If RUN_ID is empty:
+            - If ISSUE_NUMBER is also empty, write analysis_result.json with
+              classification="infrastructure", confidence="high",
+              root_cause="No RUN_ID or ISSUE_NUMBER provided", and stop.
+            - Otherwise auto-detect from the PR:
+              1. Get PR HEAD SHA:
+                 `gh api repos/${{ github.repository }}/pulls/<ISSUE_NUMBER> --jq .head.sha`
+              2. List failed runs on that SHA:
+                 `gh api "repos/${{ github.repository }}/actions/runs?head_sha=<sha>&status=failure&per_page=20" --jq '.workflow_runs[] | {id, name, conclusion, created_at}'`
+              3. Pick the most recent run whose name is one of:
+                 "PR Test", "Nightly Test", "Nightly Test Daily", "TPU Multi Test".
+                 Use its `id` as RUN_ID for the rest of the investigation.
+              4. If no such failed run exists, write analysis_result.json with
+                 classification="infrastructure", confidence="high",
+                 root_cause="No failed CI runs found for PR <ISSUE_NUMBER> head <sha>",
+                 and stop.
+
+            ## Investigation steps
+
+            1. Pull failure logs and metadata. Do not hard-truncate; grep for
+               the actual failing assertion / traceback / non-zero exit if
+               logs are large:
+               - `gh run view <RUN_ID> --log-failed`
+               - `gh run view <RUN_ID> --json headSha,headBranch,event,htmlUrl,displayTitle,conclusion`
+            2. If `headSha` is non-empty, inspect the change via the GitHub
+               compare API (this works even when `<headSha>` lives on a fork
+               that isn't fetched into the local checkout):
+               - For the single failing commit:
+                 `gh api repos/${{ github.repository }}/compare/<headSha>~1...<headSha>`
+               - For the full PR delta vs `main`:
+                 `gh api repos/${{ github.repository }}/compare/main...<headSha>`
+               The response includes commit metadata, the file list, and the
+               unified patch for each file. Pipe through `jq` to project just
+               what you need.
+               If `headSha` is empty (e.g. workflow_dispatch with no associated
+               commit), state this explicitly in `evidence` and do **not**
+               guess `code_regression`.
+            3. Use `Read` / `Grep` / `Glob` against the working tree (which is
+               `main` HEAD) to verify hypotheses about callers, helpers, or
+               test fixtures. Do not assume the working tree reflects the
+               failing commit's state — for that, rely on the compare API.
+
+            ## Classification
+
+            Pick exactly one of:
+
+            - `code_regression` — a specific code change in the run's commit
+              (or its parents on the same branch) clearly explains the failure.
+            - `flaky_test` — failure pattern is non-deterministic (intermittent
+              timeout, ordering-sensitive assertion, known-flaky markers, retry
+              succeeded elsewhere) with no code change implicated.
+            - `infrastructure` — runner/network/registry/cache/quota issue,
+              e.g. GCS 5xx, TPU pre-emption, runner OOM, GitHub API outage.
+            - `environment` — toolchain/dependency drift, e.g. upstream package
+              published a breaking version, base image changed, secret rotated.
+
+            `confidence` ∈ {low, medium, high}. Use `low` when only one signal
+            supports the classification; reserve `high` for cases where the
+            failure log + diff + source tree all converge on the same cause.
+
+            ## Required outputs
+
+            1. **Write `analysis_result.json` in the working directory** with
+               this exact shape (no extra top-level keys):
+
+               ```json
+               {
+                 "run_id": "<string>",
+                 "run_url": "<string>",
+                 "classification": "code_regression|flaky_test|infrastructure|environment",
+                 "confidence": "low|medium|high",
+                 "failed_jobs": ["<job name>", "..."],
+                 "root_cause": "<one-paragraph explanation>",
+                 "evidence": "<concrete log excerpts / diff hunks / file:line references>",
+                 "suggested_fix": "<actionable next step, or 'none' for flaky/infra>"
+               }
+               ```
+
+            2. **Append a markdown report to `$GITHUB_STEP_SUMMARY`** covering:
+               classification, confidence, run URL, failed jobs, root cause,
+               evidence, suggested fix.
+
+            3. **Echo step outputs** so downstream steps can gate on them:
+
+               ```
+               echo "classification=<value>" >> "$GITHUB_OUTPUT"
+               echo "confidence=<value>"     >> "$GITHUB_OUTPUT"
+               ```
+
+            4. **Comment on the associated PR**.
+
+               First, **resolve the target ISSUE_NUMBER**:
+
+               - If `ISSUE_NUMBER` is already non-empty from the workflow
+                 inputs/event, use it as-is and skip the fork lookup.
+               - If `ISSUE_NUMBER` is empty but `headSha` is non-empty (the
+                 fork-PR scenario — GitHub's privacy design empties
+                 `workflow_run.pull_requests` for fork-originated triggers),
+                 reverse-look up the associated PR via:
+
+                     gh api repos/${{ github.repository }}/commits/<headSha>/pulls
+
+                 - If exactly one open PR is returned, set `ISSUE_NUMBER` to
+                   its `.number`.
+                 - If zero or multiple PRs are returned, skip commenting (still
+                   emit artifact + step summary) and state in `evidence` why
+                   no comment was posted.
+
+               Then, **if `ISSUE_NUMBER` is non-empty**, post results to that
+               issue with an HTML marker so re-runs can be deduplicated:
+
+               - First, list existing comments via
+                 `gh api repos/${{ github.repository }}/issues/<ISSUE_NUMBER>/comments --paginate`
+                 and check whether any comment body already contains the marker
+                 `<!-- ci-auto-bisect:run_id=<RUN_ID> -->`.
+               - If a marker for this RUN_ID already exists, skip posting (or
+                 update the existing comment via `gh api ... -X PATCH` if you
+                 have new findings).
+               - Otherwise, post a new comment via
+                 `gh issue comment <ISSUE_NUMBER> --body ...`. The body **must**
+                 include the marker on its own line, e.g.:
+
+                 ```
+                 <!-- ci-auto-bisect:run_id=<RUN_ID> -->
+                 ## CI Auto Bisect — run <RUN_ID>
+                 ...
+                 ```
+
+            ## Discipline
+
+            - Do not invent facts. If a piece of evidence is unavailable, say
+              so in `evidence` rather than fabricating.
+            - Do not push code changes; do not edit files outside
+              `analysis_result.json`.
+            - English output throughout.
+          claude_args: |
+            --model claude-opus-4-7
+            --allowedTools "Read,Grep,Glob,Bash(gh run view:*),Bash(gh api:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(echo:*),Write"
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          API_TIMEOUT_MS: "3000000"
+          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+          ANTHROPIC_MODEL: claude-opus-4-7
+          ANTHROPIC_SMALL_FAST_MODEL: claude-opus-4-7
+          ANTHROPIC_DEFAULT_SONNET_MODEL: claude-sonnet-4-6
+          ANTHROPIC_DEFAULT_OPUS_MODEL: claude-opus-4-7
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-opus-4-7
+          CLAUDE_CODE_LOG_LEVEL: debug
+
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-auto-bisect-${{ github.run_number }}
+          path: analysis_result.json
+          retention-days: 14
+          if-no-files-found: ignore

--- a/scripts/ci/parse_bisect_comment.py
+++ b/scripts/ci/parse_bisect_comment.py
@@ -1,0 +1,35 @@
+"""Parse /auto-bisect slash command from a GitHub issue comment body.
+
+Reads COMMENT_BODY from env, writes to GITHUB_OUTPUT:
+  valid=true|false
+  run_id=<digits or empty>
+
+Strict syntax: /auto-bisect [run_id]
+  /auto-bisect          -> valid=true, run_id=
+  /auto-bisect 12345    -> valid=true, run_id=12345
+  anything else         -> valid=false, run_id=
+"""
+
+import os
+import re
+import sys
+
+PATTERN = re.compile(r"^/auto-bisect(?:\s+(\d+))?\s*$")
+
+
+def main() -> int:
+    body = os.environ.get("COMMENT_BODY", "").strip()
+    output_path = os.environ["GITHUB_OUTPUT"]
+
+    match = PATTERN.match(body)
+    valid = "true" if match else "false"
+    run_id = (match.group(1) or "") if match else ""
+
+    with open(output_path, "a", encoding="utf-8") as fh:
+        fh.write(f"valid={valid}\n")
+        fh.write(f"run_id={run_id}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci-auto-bisect.yml`, a workflow that uses `anthropics/claude-code-action@v1` to investigate failed CI runs, classify the root cause, and emit a machine-readable report. Replaces the bespoke Python implementation initially proposed in this PR with the official action (no `pip install anthropic`, no Anthropic SDK calls — the action handles auth, retries, and tool gating).

This PR adds a single workflow file. It does not touch `pr-review.yml`, does not extract a shared composite action, and does not modify any other file.

## How it works

**Automatic** — `workflow_run` listens on these workflows; failures trigger ci-auto-bisect:

- PR Test
- Nightly Test
- Nightly Test Daily
- TPU Multi Test

**Manual dispatch** (Actions tab → CI Auto Bisect → Run workflow):

- `run_id` (required): the failed workflow run ID to analyze
- `issue_number` (optional): GitHub issue/PR to post the analysis comment on

**Via `repository_dispatch`** (e.g. from another workflow):

```yaml
- uses: peter-evans/repository-dispatch@v3
  with:
    event-type: analysis_request
    client-payload: '{"run_id": "12345678", "issue_number": "42"}'
```

The job is gated to the upstream repo and (for `workflow_run`) only on failures:

```
if: github.repository == 'sgl-project/sglang-jax'
    && (event_name != 'workflow_run'
        || workflow_run.conclusion == 'failure')
```

## Fork PR coverage

Fork-originated PR Test failures are also analyzed end to end:

- `workflow_run` always executes in the base repo's context, so the agent has access to `ANTHROPIC_AUTH_TOKEN` even when the upstream workflow ran in fork context without secrets.
- GitHub's privacy design empties `workflow_run.pull_requests` for fork-originated triggers. To still post the comment to the right PR, the agent reverse-looks up the PR via `gh api repos/{owner}/{repo}/commits/{headSha}/pulls` and uses the unique open PR (if any) as the comment target.

## Output

- Step summary (rendered on the workflow run page): classification, confidence, run URL, failed jobs, root cause, evidence, suggested fix.
- Artifact `analysis_result.json` (14-day retention) with a fixed schema: `run_id`, `run_url`, `classification`, `confidence`, `failed_jobs`, `root_cause`, `evidence`, `suggested_fix`.
- Step outputs: `classification` and `confidence`, available to downstream steps via `steps.bisect.outputs.*`.
- Optional issue/PR comment when `ISSUE_NUMBER` resolves (via workflow input, `client_payload`, `workflow_run.pull_requests[0].number`, or fork reverse-lookup). Comments carry the marker `<!-- ci-auto-bisect:run_id=<RUN_ID> -->` so re-runs deduplicate on the same RUN_ID.

## Classification

The agent picks exactly one of:

- `code_regression` — a specific code change in the run's commit clearly explains the failure.
- `flaky_test` — non-deterministic failure (intermittent timeout, ordering-sensitive assertion, retry succeeded) with no code change implicated.
- `infrastructure` — runner/network/registry/cache/quota issue.
- `environment` — toolchain/dependency drift.

`confidence` ∈ {low, medium, high}.

## Tool boundary

The agent's `allowed_tools` is intentionally narrow:

```
Read, Grep, Glob, Bash(gh run view:*), Bash(gh api:*), Bash(gh issue view:*), Bash(gh issue comment:*), Bash(echo:*), Write
```

It cannot `git push`, run unrestricted shell, or use `git` locally (commit data is fetched via `gh api .../compare/...` instead, which also makes fork commits reachable). The prompt further restricts writes to `analysis_result.json` only.

## Required secrets

| Secret | Purpose |
|---|---|
| `ANTHROPIC_AUTH_TOKEN` | Authenticate Claude Code agent calls |
| `ANTHROPIC_BASE_URL` | Custom Anthropic API endpoint (optional) |
| `GITHUB_TOKEN` | Built-in; read run/job metadata, post issue comments |

## Test plan

- (Pre-merge) YAML parses cleanly; pre-commit passes.
- (Pre-merge) Job scheduling: a `workflow_dispatch` from this PR branch reaches step setup, OIDC token is obtained, all framework steps complete.
- (Post-merge) Verify auto-trigger: when a monitored workflow fails on `main`, ci-auto-bisect runs end to end with all four output channels populated (artifact, step summary, outputs, comment if `ISSUE_NUMBER` resolves).
- (Post-merge) Verify `workflow_dispatch` from main's Actions tab with a known-failed `run_id`; confirm artifact, step summary, outputs, and (with `issue_number` set) a marker-tagged comment.
- (Post-merge) Verify fork PR coverage: a fork-originated `workflow_run` triggers ci-auto-bisect; the agent reverse-resolves the PR via `commits/{headSha}/pulls` and posts the comment to the right PR.

> Note: `workflow_dispatch` from a PR branch cannot validate end-to-end agent execution. `claude-code-action@v1` performs a server-side workflow validation that requires the workflow file to match the default-branch version byte-for-byte; otherwise the action short-circuits (step reports success, agent does not run). This is the action's security design, not a configuration gap. End-to-end agent behavior can only be verified post-merge.

Closes #1139
