### PR TITLE
ci: add runner utilization daily report (P2-6)

### DIFF
--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -33,6 +33,7 @@ jobs:
           python-version: '3.12'
 
       - name: Generate Utilization Report
+        id: report
         timeout-minutes: 30
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -46,8 +47,25 @@ jobs:
           fi
           if [ -n "$RUNNER_FILTER" ]; then
             python scripts/ci/utils/runner_utilization_report.py \
-              --repo "$REPO" --hours "$REPORT_HOURS" --filter "$RUNNER_FILTER"
+              --repo "$REPO" --hours "$REPORT_HOURS" --filter "$RUNNER_FILTER" \
+              --output report.md
           else
             python scripts/ci/utils/runner_utilization_report.py \
-              --repo "$REPO" --hours "$REPORT_HOURS"
+              --repo "$REPO" --hours "$REPORT_HOURS" \
+              --output report.md
           fi
+
+      - name: Post to Slack
+        if: secrets.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          REPORT=$(cat report.md)
+          jq -n --arg text "${REPORT}"$'\n\n'"<${RUN_URL}|View full report>" \
+            '{text: $text}' | \
+            curl -sf -X POST -H 'Content-type: application/json' \
+              -d @- "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -37,8 +37,13 @@ jobs:
         timeout-minutes: 30
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUNNER_FILTER: ${{ inputs.filter || '' }}
         run: |
+          FILTER_ARG=""
+          if [ -n "$RUNNER_FILTER" ]; then
+            FILTER_ARG="--filter $RUNNER_FILTER"
+          fi
           python scripts/ci/utils/runner_utilization_report.py \
             --repo ${{ github.repository }} \
             --hours ${{ inputs.hours || '24' }} \
-            ${{ inputs.filter && format('--filter {0}', inputs.filter) || '' }}
+            $FILTER_ARG

--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -1,0 +1,44 @@
+name: Runner Utilization Report
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # Daily at 8 AM UTC
+  pull_request:
+    paths:
+      - '.github/workflows/runner-utilization.yml'
+      - 'scripts/ci/utils/runner_utilization_report.py'
+  workflow_dispatch:
+    inputs:
+      hours:
+        description: 'Time window in hours'
+        required: false
+        default: '24'
+        type: string
+      filter:
+        description: 'Filter runner labels (e.g., arc-runner-v6e-1, arc-runner-v6e-4)'
+        required: false
+        type: string
+
+jobs:
+  report:
+    name: Generate Report
+    if: github.repository == 'sgl-project/sglang-jax'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Generate Utilization Report
+        timeout-minutes: 30
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/ci/utils/runner_utilization_report.py \
+            --repo ${{ github.repository }} \
+            --hours ${{ inputs.hours || '24' }} \
+            ${{ inputs.filter && format('--filter {0}', inputs.filter) || '' }}

--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -60,12 +60,16 @@ jobs:
           fi
 
       - name: Post to Slack
-        if: success() && secrets.SLACK_WEBHOOK_URL != ''
+        if: success()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL not set, skipping."
+            exit 0
+          fi
           SUMMARY=$(cat slack_summary.txt)
           jq -n --arg text "$SUMMARY" \
             '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":$text}}]}' | \
-            curl -sf -X POST -H 'Content-type: application/json' \
+            curl --fail-with-body -X POST -H 'Content-type: application/json' \
               -d @- "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -48,11 +48,11 @@ jobs:
           if [ -n "$RUNNER_FILTER" ]; then
             python scripts/ci/utils/runner_utilization_report.py \
               --repo "$REPO" --hours "$REPORT_HOURS" --filter "$RUNNER_FILTER" \
-              --output report.md
+              --output report.md --slack-summary slack_summary.txt
           else
             python scripts/ci/utils/runner_utilization_report.py \
               --repo "$REPO" --hours "$REPORT_HOURS" \
-              --output report.md
+              --output report.md --slack-summary slack_summary.txt
           fi
 
       - name: Post to Slack
@@ -64,8 +64,8 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          REPORT=$(cat report.md)
-          jq -n --arg text "${REPORT}"$'\n\n'"<${RUN_URL}|View full report>" \
+          SUMMARY=$(cat slack_summary.txt)
+          jq -n --arg text "${SUMMARY}"$'\n\n'"<${RUN_URL}|View full report>" \
             '{text: $text}' | \
             curl -sf -X POST -H 'Content-type: application/json' \
               -d @- "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -36,7 +36,7 @@ jobs:
         id: report
         timeout-minutes: 30
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RUNNER_LIST_TOKEN || secrets.GITHUB_TOKEN }}
           RUNNER_FILTER: ${{ inputs.filter || '' }}
           REPORT_HOURS: ${{ inputs.hours || '24' }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -38,12 +38,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNNER_FILTER: ${{ inputs.filter || '' }}
+          REPORT_HOURS: ${{ inputs.hours || '24' }}
         run: |
+          if ! [[ "$REPORT_HOURS" =~ ^[0-9]+$ ]]; then
+            echo "Error: hours must be numeric, got: $REPORT_HOURS"
+            exit 1
+          fi
           FILTER_ARG=""
           if [ -n "$RUNNER_FILTER" ]; then
             FILTER_ARG="--filter $RUNNER_FILTER"
           fi
           python scripts/ci/utils/runner_utilization_report.py \
             --repo ${{ github.repository }} \
-            --hours ${{ inputs.hours || '24' }} \
+            --hours "$REPORT_HOURS" \
             $FILTER_ARG

--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -40,32 +40,32 @@ jobs:
           RUNNER_FILTER: ${{ inputs.filter || '' }}
           REPORT_HOURS: ${{ inputs.hours || '24' }}
           REPO: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           if ! [[ "$REPORT_HOURS" =~ ^[0-9]+$ ]]; then
             echo "Error: hours must be numeric, got: $REPORT_HOURS"
             exit 1
           fi
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           if [ -n "$RUNNER_FILTER" ]; then
             python scripts/ci/utils/runner_utilization_report.py \
               --repo "$REPO" --hours "$REPORT_HOURS" --filter "$RUNNER_FILTER" \
-              --output report.md --slack-summary slack_summary.txt
+              --output report.md --slack-output slack_summary.txt --run-url "$RUN_URL"
           else
             python scripts/ci/utils/runner_utilization_report.py \
               --repo "$REPO" --hours "$REPORT_HOURS" \
-              --output report.md --slack-summary slack_summary.txt
+              --output report.md --slack-output slack_summary.txt --run-url "$RUN_URL"
           fi
 
       - name: Post to Slack
-        if: secrets.SLACK_WEBHOOK_URL != ''
+        if: success() && secrets.SLACK_WEBHOOK_URL != ''
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
-          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           SUMMARY=$(cat slack_summary.txt)
-          jq -n --arg text "${SUMMARY}"$'\n\n'"<${RUN_URL}|View full report>" \
-            '{text: $text}' | \
+          jq -n --arg text "$SUMMARY" \
+            '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":$text}}]}' | \
             curl -sf -X POST -H 'Content-type: application/json' \
               -d @- "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -3,10 +3,6 @@ name: Runner Utilization Report
 on:
   schedule:
     - cron: '0 8 * * *'  # Daily at 8 AM UTC
-  pull_request:
-    paths:
-      - '.github/workflows/runner-utilization.yml'
-      - 'scripts/ci/utils/runner_utilization_report.py'
   workflow_dispatch:
     inputs:
       hours:

--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -24,6 +24,9 @@ jobs:
     name: Generate Report
     if: github.repository == 'sgl-project/sglang-jax'
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -39,16 +39,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNNER_FILTER: ${{ inputs.filter || '' }}
           REPORT_HOURS: ${{ inputs.hours || '24' }}
+          REPO: ${{ github.repository }}
         run: |
           if ! [[ "$REPORT_HOURS" =~ ^[0-9]+$ ]]; then
             echo "Error: hours must be numeric, got: $REPORT_HOURS"
             exit 1
           fi
-          FILTER_ARG=""
           if [ -n "$RUNNER_FILTER" ]; then
-            FILTER_ARG="--filter $RUNNER_FILTER"
+            python scripts/ci/utils/runner_utilization_report.py \
+              --repo "$REPO" --hours "$REPORT_HOURS" --filter "$RUNNER_FILTER"
+          else
+            python scripts/ci/utils/runner_utilization_report.py \
+              --repo "$REPO" --hours "$REPORT_HOURS"
           fi
-          python scripts/ci/utils/runner_utilization_report.py \
-            --repo ${{ github.repository }} \
-            --hours "$REPORT_HOURS" \
-            $FILTER_ARG

--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Post to Slack
         if: success()
+        continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -22,7 +22,15 @@ def run_gh_command(args, max_retries=5):
     """Run a gh CLI command with exponential backoff retry on transient failure."""
     for attempt in range(max_retries):
         try:
-            return subprocess.run(["gh"] + args, capture_output=True, text=True, check=True).stdout
+            return subprocess.run(
+                ["gh"] + args, capture_output=True, text=True, check=True, timeout=120
+            ).stdout
+        except subprocess.TimeoutExpired:
+            if attempt == max_retries - 1:
+                raise
+            wait = (2**attempt) + random.uniform(0, 1)
+            print(f"Retry {attempt + 1}/{max_retries} in {wait:.1f}s: command timed out")
+            time.sleep(wait)
         except subprocess.CalledProcessError as e:
             err_lower = str(e.stderr).lower()
             if "rate limit" not in err_lower and any(
@@ -127,14 +135,14 @@ def get_runners(repo, online_only=False):
                 if inferred:
                     runner.setdefault("labels", []).append({"name": inferred})
         return runners
-    except subprocess.CalledProcessError as e:
-        err_str = str(e.stderr)
+    except (subprocess.CalledProcessError, RuntimeError) as e:
+        err_str = str(getattr(e, "stderr", e))
         if "rate limit" in err_str.lower():
             print("Warning: GitHub API rate limit hit; runner count unavailable.")
         elif "403" in err_str or "must have admin" in err_str.lower():
             print("Note: No admin access to list runners; count estimated from job data.")
         else:
-            raise
+            print(f"Warning: Failed to list runners ({e}); count unavailable.")
         return []
 
 
@@ -158,36 +166,20 @@ def calculate_concurrency_metrics(jobs, window_start, window_end, num_runners):
             if s < e:
                 events += [(s, +1), (e, -1)]
     if not events:
-        return {
-            "peak_concurrent": 0,
-            "avg_concurrent": 0.0,
-            "saturation_pct": None,
-            "peak_queue": None,
-        }
+        return {"peak_concurrent": 0, "peak_queue": None}
     events.sort(key=lambda e: (e[0], e[1]))
     current = peak = 0
-    weighted_sum = 0.0
-    prev_time = window_start
     for event_time, delta in events:
-        if event_time > prev_time:
-            weighted_sum += current * (event_time - prev_time).total_seconds()
-            prev_time = event_time
         current += delta
         peak = max(peak, current)
-    if prev_time < window_end:
-        weighted_sum += current * (window_end - prev_time).total_seconds()
-    ws = (window_end - window_start).total_seconds()
-    avg = weighted_sum / ws if ws > 0 else 0.0
     return {
         "peak_concurrent": peak,
-        "avg_concurrent": avg,
-        "saturation_pct": (avg / num_runners * 100) if num_runners > 0 else None,
         "peak_queue": max(0, peak - num_runners) if num_runners > 0 else None,
     }
 
 
 def _percentile(sorted_values, p):
-    """Floor-index percentile: P95 equals max for samples < 20."""
+    """Floor-index percentile: P95 equals max for samples <= 20."""
     if not sorted_values:
         return 0.0
     return sorted_values[min(int(len(sorted_values) * p / 100), len(sorted_values) - 1)]
@@ -560,7 +552,7 @@ def format_slack_summary(report_data, hours, run_url=""):
     text = "\n".join(lines)
     # Slack Block Kit section text has a 3000 character limit
     if len(text) > 2900:
-        text = text[:2900] + "\n… (truncated)"
+        text = text[:2900].rsplit("\n", 1)[0] + "\n… (truncated)"
     return text
 
 
@@ -573,8 +565,8 @@ def main():
     parser.add_argument("--slack-output", type=str, help="Slack summary output file path")
     parser.add_argument("--run-url", type=str, default="", help="Actions run URL for Slack link")
     args = parser.parse_args()
-    if args.hours < 1:
-        parser.error("--hours must be a positive integer")
+    if args.hours < 1 or args.hours > 168:
+        parser.error("--hours must be between 1 and 168")
 
     report_data = calculate_utilization(args.repo, args.hours, args.filter)
     report = format_report(report_data, args.hours)

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -36,7 +36,10 @@ def run_gh_command(args, max_retries=5):
             return result.stdout
         except subprocess.CalledProcessError as e:
             err = str(e.stderr)
-            if any(p in err for p in _NON_RETRYABLE_PATTERNS):
+            err_lower = err.lower()
+            if "rate limit" in err_lower:
+                pass  # fall through to backoff
+            elif any(p in err for p in _NON_RETRYABLE_PATTERNS):
                 raise
             if attempt == max_retries - 1:
                 raise
@@ -48,32 +51,48 @@ def run_gh_command(args, max_retries=5):
 
 
 def get_workflow_runs(repo, hours=24):
-    """Fetch workflow runs from the past N hours with pagination."""
+    """Fetch workflow runs from the past N hours with manual pagination and early stop."""
     cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
-
-    output = run_gh_command(
-        [
-            "api",
-            f"/repos/{repo}/actions/runs",
-            "--paginate",
-            "-f",
-            "per_page=100",
-            "--jq",
-            ".workflow_runs[]",
-        ]
-    )
-
     runs = []
-    for line in output.strip().splitlines():
-        if line.strip():
-            try:
-                run = json.loads(line)
-                created = parse_time(run.get("created_at"))
-                if created and created < cutoff:
+    page = 1
+    per_page = 100
+
+    while True:
+        output = run_gh_command(
+            [
+                "api",
+                f"/repos/{repo}/actions/runs",
+                "-f",
+                f"per_page={per_page}",
+                "-f",
+                f"page={page}",
+                "--jq",
+                ".workflow_runs[]",
+            ]
+        )
+
+        if not output.strip():
+            break
+
+        page_count = 0
+        hit_cutoff = False
+        for line in output.strip().splitlines():
+            if line.strip():
+                try:
+                    run = json.loads(line)
+                    created = parse_time(run.get("created_at"))
+                    if created and created < cutoff:
+                        hit_cutoff = True
+                        continue
+                    runs.append(run)
+                    page_count += 1
+                except json.JSONDecodeError:
                     continue
-                runs.append(run)
-            except json.JSONDecodeError:
-                continue
+
+        if hit_cutoff or page_count < per_page:
+            break
+
+        page += 1
 
     return runs
 

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -45,15 +45,12 @@ def run_gh_command(args, max_retries=10):
 def get_workflow_runs(repo, hours=24):
     """Fetch workflow runs from the past N hours with pagination."""
     cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
-    cutoff_str = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     output = run_gh_command(
         [
             "api",
             f"/repos/{repo}/actions/runs",
             "--paginate",
-            "-f",
-            f"created=>={cutoff_str}",
             "-f",
             "per_page=100",
             "--jq",
@@ -65,7 +62,11 @@ def get_workflow_runs(repo, hours=24):
     for line in output.strip().splitlines():
         if line.strip():
             try:
-                runs.append(json.loads(line))
+                run = json.loads(line)
+                created = parse_time(run.get("created_at"))
+                if created and created < cutoff:
+                    continue
+                runs.append(run)
             except json.JSONDecodeError:
                 continue
 
@@ -142,7 +143,13 @@ def get_runners(repo, online_only=True):
                     continue
         return runners
     except subprocess.CalledProcessError as e:
-        if "403" in str(e.stderr) or "Must have admin rights" in str(e.stderr):
+        err_str = str(e.stderr)
+        if "rate limit" in err_str.lower():
+            print(
+                "Warning: GitHub API rate limit hit while listing runners; runner count will be unavailable."
+            )
+            return []
+        if "403" in err_str or "Must have admin rights" in err_str:
             print(
                 "Note: No admin access to list runners; runner count will be estimated from job data."
             )
@@ -282,7 +289,12 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
     with ThreadPoolExecutor(max_workers=4) as executor:
         futures = {executor.submit(fetch_run_jobs, run): run for run in runs}
         for future in as_completed(futures):
-            run_id, jobs = future.result()
+            try:
+                run_id, jobs = future.result()
+            except Exception as e:
+                print(f"Warning: unexpected error fetching jobs: {e}")
+                fetch_failures += 1
+                continue
             if jobs is None:
                 fetch_failures += 1
                 continue
@@ -329,7 +341,7 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
             if merged and start <= merged[-1][1]:
                 merged[-1] = (merged[-1][0], max(merged[-1][1], end))
             else:
-                merged.append([start, end])
+                merged.append((start, end))
 
         busy_seconds = sum((e - s).total_seconds() for s, e in merged)
 

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -20,8 +20,11 @@ DEFAULT_LABELS_TO_IGNORE = {"self-hosted", "Linux", "X64", "ARM64"}
 GITHUB_HOSTED_LABELS = {"ubuntu-latest", "ubuntu-22.04", "ubuntu-24.04"}
 
 
-def run_gh_command(args, max_retries=10):
-    """Run a gh CLI command with exponential backoff retry on failure."""
+_NON_RETRYABLE_PATTERNS = ("401", "403", "404", "422", "not found", "Must have admin")
+
+
+def run_gh_command(args, max_retries=5):
+    """Run a gh CLI command with exponential backoff retry on transient failure."""
     for attempt in range(max_retries):
         try:
             result = subprocess.run(
@@ -32,9 +35,11 @@ def run_gh_command(args, max_retries=10):
             )
             return result.stdout
         except subprocess.CalledProcessError as e:
+            err = str(e.stderr)
+            if any(p in err for p in _NON_RETRYABLE_PATTERNS):
+                raise
             if attempt == max_retries - 1:
                 raise
-            # Exponential backoff with jitter
             wait = (2**attempt) + random.uniform(0, 1)
             print(
                 f"Command failed (attempt {attempt + 1}/{max_retries}), retrying in {wait:.1f}s: {e.stderr.strip()}"
@@ -190,8 +195,8 @@ def calculate_concurrency_metrics(jobs, window_start, window_end, num_runners):
         return {
             "peak_concurrent": 0,
             "avg_concurrent": 0.0,
-            "saturation_pct": 0.0,
-            "peak_queue": 0,
+            "saturation_pct": None,
+            "peak_queue": None,
         }
 
     # At equal timestamps, process end events (delta=-1) before start events
@@ -220,8 +225,8 @@ def calculate_concurrency_metrics(jobs, window_start, window_end, num_runners):
     window_seconds = (window_end - window_start).total_seconds()
     avg_concurrent = weighted_sum / window_seconds if window_seconds > 0 else 0.0
 
-    saturation_pct = (avg_concurrent / num_runners * 100.0) if num_runners > 0 else 0.0
-    peak_queue = max(0, peak - num_runners)
+    saturation_pct = (avg_concurrent / num_runners * 100.0) if num_runners > 0 else None
+    peak_queue = max(0, peak - num_runners) if num_runners > 0 else None
 
     return {
         "peak_concurrent": peak,
@@ -358,7 +363,7 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
             label_jobs.get(label, []),
             window_start,
             window_end,
-            num_runners if num_runners > 0 else 1,
+            num_runners,
         )
 
         results[label] = {
@@ -429,8 +434,10 @@ def format_report(results, hours, fetch_failure_pct=0.0):
         avg = conc["avg_concurrent"]
         sat = conc["saturation_pct"]
         queue = conc["peak_queue"]
+        sat_str = f"{sat:.1f}%" if sat is not None else "N/A"
+        queue_str = str(queue) if queue is not None else "N/A"
 
-        lines.append(f"| `{label}` | {peak} | {avg:.2f} | {sat:.1f}% | {queue} |")
+        lines.append(f"| `{label}` | {peak} | {avg:.2f} | {sat_str} | {queue_str} |")
 
     lines.append("")
 
@@ -454,7 +461,7 @@ def format_report(results, hours, fetch_failure_pct=0.0):
             )
             has_recommendation = True
 
-        if conc["peak_queue"] > 0:
+        if conc["peak_queue"] is not None and conc["peak_queue"] > 0:
             lines.append(
                 f"- **`{label}`**: Peak queue depth of {conc['peak_queue']} job(s) detected. Jobs had to wait for a free runner."
             )

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -47,45 +47,27 @@ def get_workflow_runs(repo, hours=24):
     cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
     cutoff_str = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
 
+    output = run_gh_command(
+        [
+            "api",
+            f"/repos/{repo}/actions/runs",
+            "--paginate",
+            "-f",
+            f"created=>={cutoff_str}",
+            "-f",
+            "per_page=100",
+            "--jq",
+            ".workflow_runs[]",
+        ]
+    )
+
     runs = []
-    page = 1
-    per_page = 100
-
-    while True:
-        output = run_gh_command(
-            [
-                "api",
-                f"/repos/{repo}/actions/runs",
-                "--paginate",
-                "-f",
-                f"created=>={cutoff_str}",
-                "-f",
-                f"per_page={per_page}",
-                "-f",
-                f"page={page}",
-                "--jq",
-                ".workflow_runs[]",
-            ]
-        )
-
-        if not output.strip():
-            break
-
-        page_runs = []
-        for line in output.strip().splitlines():
-            if line.strip():
-                try:
-                    page_runs.append(json.loads(line))
-                except json.JSONDecodeError:
-                    continue
-
-        if not page_runs:
-            break
-
-        runs.extend(page_runs)
-
-        # gh --paginate handles pagination automatically; break after first call
-        break
+    for line in output.strip().splitlines():
+        if line.strip():
+            try:
+                runs.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
 
     return runs
 

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""
+Runner Utilization Report
+
+Analyzes GitHub Actions job data to calculate runner utilization metrics.
+Reports idle time, active time, and utilization percentage per runner label.
+"""
+
+import argparse
+import json
+import os
+import random
+import subprocess
+import time
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timedelta, timezone
+
+DEFAULT_LABELS_TO_IGNORE = {"self-hosted", "Linux", "X64", "ARM64"}
+GITHUB_HOSTED_LABELS = {"ubuntu-latest", "ubuntu-22.04", "ubuntu-24.04"}
+
+
+def run_gh_command(args, max_retries=10):
+    """Run a gh CLI command with exponential backoff retry on failure."""
+    for attempt in range(max_retries):
+        try:
+            result = subprocess.run(
+                ["gh"] + args,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return result.stdout
+        except subprocess.CalledProcessError as e:
+            if attempt == max_retries - 1:
+                raise
+            # Exponential backoff with jitter
+            wait = (2**attempt) + random.uniform(0, 1)
+            print(
+                f"Command failed (attempt {attempt + 1}/{max_retries}), retrying in {wait:.1f}s: {e.stderr.strip()}"
+            )
+            time.sleep(wait)
+
+
+def get_workflow_runs(repo, hours=24):
+    """Fetch workflow runs from the past N hours with pagination."""
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
+    cutoff_str = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    runs = []
+    page = 1
+    per_page = 100
+
+    while True:
+        output = run_gh_command(
+            [
+                "api",
+                f"/repos/{repo}/actions/runs",
+                "--paginate",
+                "-f",
+                f"created=>={cutoff_str}",
+                "-f",
+                f"per_page={per_page}",
+                "-f",
+                f"page={page}",
+                "--jq",
+                ".workflow_runs[]",
+            ]
+        )
+
+        if not output.strip():
+            break
+
+        page_runs = []
+        for line in output.strip().splitlines():
+            if line.strip():
+                try:
+                    page_runs.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+
+        if not page_runs:
+            break
+
+        runs.extend(page_runs)
+
+        # gh --paginate handles pagination automatically; break after first call
+        break
+
+    return runs
+
+
+def get_jobs_for_run(repo, run_id):
+    """Fetch all jobs for a workflow run, including retried attempts."""
+    jobs = []
+    page = 1
+    per_page = 100
+
+    while True:
+        output = run_gh_command(
+            [
+                "api",
+                f"/repos/{repo}/actions/runs/{run_id}/jobs",
+                "-f",
+                "filter=all",
+                "-f",
+                f"per_page={per_page}",
+                "-f",
+                f"page={page}",
+                "--jq",
+                ".jobs[]",
+            ]
+        )
+
+        if not output.strip():
+            break
+
+        page_jobs = []
+        for line in output.strip().splitlines():
+            if line.strip():
+                try:
+                    page_jobs.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+
+        if not page_jobs:
+            break
+
+        jobs.extend(page_jobs)
+
+        if len(page_jobs) < per_page:
+            break
+
+        page += 1
+
+    return jobs
+
+
+def get_runners(repo, online_only=True):
+    """Fetch self-hosted runners for the repo; degrades gracefully if no admin access."""
+    try:
+        output = run_gh_command(
+            [
+                "api",
+                f"/repos/{repo}/actions/runners",
+                "--paginate",
+                "--jq",
+                ".runners[]",
+            ]
+        )
+        runners = []
+        for line in output.strip().splitlines():
+            if line.strip():
+                try:
+                    runner = json.loads(line)
+                    if online_only and runner.get("status") != "online":
+                        continue
+                    runners.append(runner)
+                except json.JSONDecodeError:
+                    continue
+        return runners
+    except subprocess.CalledProcessError as e:
+        if "403" in str(e.stderr) or "Must have admin rights" in str(e.stderr):
+            print(
+                "Note: No admin access to list runners; runner count will be estimated from job data."
+            )
+            return []
+        raise
+
+
+def parse_time(time_str):
+    """Parse an ISO 8601 timestamp string into a timezone-aware datetime."""
+    if not time_str:
+        return None
+    # Handle both 'Z' suffix and '+00:00' offset forms
+    time_str = time_str.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(time_str)
+    except ValueError:
+        return None
+
+
+def calculate_concurrency_metrics(jobs, window_start, window_end, num_runners):
+    """
+    Use a sweep-line algorithm to compute peak and average concurrent jobs,
+    saturation percentage, and peak queue depth.
+    """
+    events = []
+    for job in jobs:
+        start = parse_time(job.get("started_at"))
+        end = parse_time(job.get("completed_at"))
+        if start and end and start < end:
+            # Clamp to the reporting window
+            start = max(start, window_start)
+            end = min(end, window_end)
+            if start < end:
+                events.append((start, +1))
+                events.append((end, -1))
+
+    if not events:
+        return {
+            "peak_concurrent": 0,
+            "avg_concurrent": 0.0,
+            "saturation_pct": 0.0,
+            "peak_queue": 0,
+        }
+
+    events.sort(key=lambda e: (e[0], e[1]))
+
+    current = 0
+    peak = 0
+    # Weighted sum of (concurrent_count * duration_seconds) for average
+    weighted_sum = 0.0
+    prev_time = window_start
+
+    for event_time, delta in events:
+        if event_time > prev_time:
+            duration = (event_time - prev_time).total_seconds()
+            weighted_sum += current * duration
+            prev_time = event_time
+        current += delta
+        peak = max(peak, current)
+
+    # Final segment to window_end
+    if prev_time < window_end:
+        duration = (window_end - prev_time).total_seconds()
+        weighted_sum += current * duration
+
+    window_seconds = (window_end - window_start).total_seconds()
+    avg_concurrent = weighted_sum / window_seconds if window_seconds > 0 else 0.0
+
+    saturation_pct = (avg_concurrent / num_runners * 100.0) if num_runners > 0 else 0.0
+    peak_queue = max(0, peak - num_runners)
+
+    return {
+        "peak_concurrent": peak,
+        "avg_concurrent": avg_concurrent,
+        "saturation_pct": saturation_pct,
+        "peak_queue": peak_queue,
+    }
+
+
+_NON_GPU_WORKFLOW_HINTS = (
+    "lint",
+    "release",
+    "runner utilization",
+    "summize",  # CI Trend Summary (nightly-test-summize)
+)
+
+
+def _likely_no_gpu_jobs(workflow_name):
+    """Return True if this workflow name suggests it has no GPU/TPU jobs."""
+    name_lower = workflow_name.lower()
+    return any(hint in name_lower for hint in _NON_GPU_WORKFLOW_HINTS)
+
+
+def calculate_utilization(repo, hours=24, runner_filter=None):
+    """
+    Main calculation: fetch runs and jobs, aggregate per-label utilization,
+    concurrency metrics, and host-level busy time.
+    """
+    window_end = datetime.now(timezone.utc)
+    window_start = window_end - timedelta(hours=hours)
+
+    print(f"Fetching workflow runs for {repo} in the past {hours} hours...")
+    runs = get_workflow_runs(repo, hours=hours)
+    print(f"Found {len(runs)} workflow runs.")
+
+    # Fetch runners once; fall back gracefully
+    runners_list = get_runners(repo, online_only=False)
+
+    # Build label -> runner count map
+    label_runner_count = defaultdict(int)
+    for runner in runners_list:
+        labels = {lbl["name"] for lbl in runner.get("labels", [])}
+        for lbl in labels:
+            if lbl not in DEFAULT_LABELS_TO_IGNORE and lbl not in GITHUB_HOSTED_LABELS:
+                label_runner_count[lbl] += 1
+
+    fetch_failures = 0
+    total_runs = len(runs)
+
+    # Per-label: list of (started_at, completed_at) intervals
+    label_intervals = defaultdict(list)
+    # Per-label: all jobs (for concurrency sweep)
+    label_jobs = defaultdict(list)
+
+    def fetch_run_jobs(run):
+        if _likely_no_gpu_jobs(run.get("name", "")):
+            return run["id"], []
+        try:
+            return run["id"], get_jobs_for_run(repo, run["id"])
+        except Exception as e:
+            print(f"Warning: failed to fetch jobs for run {run['id']}: {e}")
+            return run["id"], None
+
+    print("Fetching job details (parallel, max 4 workers)...")
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = {executor.submit(fetch_run_jobs, run): run for run in runs}
+        for future in as_completed(futures):
+            run_id, jobs = future.result()
+            if jobs is None:
+                fetch_failures += 1
+                continue
+            for job in jobs:
+                if job.get("status") != "completed":
+                    continue
+                labels = set(job.get("labels", []))
+                # Strip generic labels to identify the meaningful runner label
+                meaningful = labels - DEFAULT_LABELS_TO_IGNORE - GITHUB_HOSTED_LABELS
+                if not meaningful:
+                    continue
+                if runner_filter and not any(runner_filter in lbl for lbl in meaningful):
+                    continue
+
+                started = parse_time(job.get("started_at"))
+                completed = parse_time(job.get("completed_at"))
+                if not started or not completed or completed <= started:
+                    continue
+                # Clamp to window
+                eff_start = max(started, window_start)
+                eff_end = min(completed, window_end)
+                if eff_start >= eff_end:
+                    continue
+
+                for lbl in meaningful:
+                    label_intervals[lbl].append((eff_start, eff_end))
+                    label_jobs[lbl].append(job)
+
+    fetch_failure_pct = (fetch_failures / total_runs * 100.0) if total_runs > 0 else 0.0
+    window_seconds = (window_end - window_start).total_seconds()
+
+    results = {}
+    all_labels = set(label_intervals.keys()) | set(label_runner_count.keys())
+
+    for label in sorted(all_labels):
+        if runner_filter and runner_filter not in label:
+            continue
+        intervals = label_intervals.get(label, [])
+        num_runners = label_runner_count.get(label, 0)
+
+        # Merge overlapping intervals to compute total busy time
+        merged = []
+        for start, end in sorted(intervals):
+            if merged and start <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+            else:
+                merged.append([start, end])
+
+        busy_seconds = sum((e - s).total_seconds() for s, e in merged)
+
+        # Capacity: num_runners * window_seconds (0 if unknown)
+        capacity_seconds = num_runners * window_seconds if num_runners > 0 else 0.0
+        utilization_pct = (
+            (busy_seconds / capacity_seconds * 100.0) if capacity_seconds > 0 else None
+        )
+
+        # Total job seconds (sum of all individual job durations, not merged)
+        total_job_seconds = sum((e - s).total_seconds() for s, e in intervals)
+
+        concurrency = calculate_concurrency_metrics(
+            label_jobs.get(label, []),
+            window_start,
+            window_end,
+            num_runners if num_runners > 0 else 1,
+        )
+
+        results[label] = {
+            "num_runners": num_runners,
+            "busy_seconds": busy_seconds,
+            "capacity_seconds": capacity_seconds,
+            "utilization_pct": utilization_pct,
+            "total_job_seconds": total_job_seconds,
+            "job_count": len(label_jobs.get(label, [])),
+            "concurrency": concurrency,
+        }
+
+    return results, fetch_failure_pct
+
+
+def format_report(results, hours, fetch_failure_pct=0.0):
+    """Format the utilization results as a Markdown report."""
+    lines = []
+    lines.append(f"# Runner Utilization Report (Past {hours} Hours)")
+    lines.append("")
+
+    now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines.append(f"_Generated at {now_utc}_")
+    lines.append("")
+
+    if fetch_failure_pct > 0:
+        lines.append(
+            f"> **Warning:** {fetch_failure_pct:.1f}% of workflow runs could not be fetched (API errors). Results may be incomplete."
+        )
+        lines.append("")
+
+    if not results:
+        lines.append("No runner activity found in the specified time window.")
+        return "\n".join(lines)
+
+    # Utilization table
+    lines.append("## Utilization by Runner Label")
+    lines.append("")
+    lines.append("| Runner Label | Runners | Jobs | Busy Time | Capacity | Utilization |")
+    lines.append("|---|---|---|---|---|---|")
+
+    for label, data in sorted(results.items()):
+        num_runners = data["num_runners"] or "N/A"
+        job_count = data["job_count"]
+        busy_h = data["busy_seconds"] / 3600
+        cap_h = data["capacity_seconds"] / 3600 if data["capacity_seconds"] else None
+        util = data["utilization_pct"]
+
+        busy_str = f"{busy_h:.1f}h"
+        cap_str = f"{cap_h:.1f}h" if cap_h is not None else "N/A"
+        util_str = f"{util:.1f}%" if util is not None else "N/A"
+
+        lines.append(
+            f"| `{label}` | {num_runners} | {job_count} | {busy_str} | {cap_str} | {util_str} |"
+        )
+
+    lines.append("")
+
+    # Concurrency analysis
+    lines.append("## Concurrency Analysis")
+    lines.append("")
+    lines.append("| Runner Label | Peak Concurrent | Avg Concurrent | Saturation | Peak Queue |")
+    lines.append("|---|---|---|---|---|")
+
+    for label, data in sorted(results.items()):
+        conc = data["concurrency"]
+        peak = conc["peak_concurrent"]
+        avg = conc["avg_concurrent"]
+        sat = conc["saturation_pct"]
+        queue = conc["peak_queue"]
+
+        lines.append(f"| `{label}` | {peak} | {avg:.2f} | {sat:.1f}% | {queue} |")
+
+    lines.append("")
+
+    # Recommendations
+    lines.append("## Recommendations")
+    lines.append("")
+
+    has_recommendation = False
+    for label, data in sorted(results.items()):
+        util = data["utilization_pct"]
+        conc = data["concurrency"]
+
+        if util is not None and util > 80:
+            lines.append(
+                f"- **`{label}`**: High utilization ({util:.1f}%). Consider adding more runners to reduce queue time."
+            )
+            has_recommendation = True
+        elif util is not None and util < 10 and data["job_count"] > 0:
+            lines.append(
+                f"- **`{label}`**: Low utilization ({util:.1f}%). Runner capacity may be over-provisioned."
+            )
+            has_recommendation = True
+
+        if conc["peak_queue"] > 0:
+            lines.append(
+                f"- **`{label}`**: Peak queue depth of {conc['peak_queue']} job(s) detected. Jobs had to wait for a free runner."
+            )
+            has_recommendation = True
+
+    if not has_recommendation:
+        lines.append(
+            "No immediate action required. All runner labels appear within normal utilization bounds."
+        )
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate runner utilization report")
+    parser.add_argument(
+        "--repo", default="sgl-project/sglang-jax", help="GitHub repository (owner/name)"
+    )
+    parser.add_argument("--hours", type=int, default=24, help="Time window in hours (default: 24)")
+    parser.add_argument(
+        "--filter", type=str, dest="filter", help="Filter runner labels (substring match)"
+    )
+    parser.add_argument("--output", type=str, help="Output file path (default: stdout)")
+    args = parser.parse_args()
+
+    results, fetch_failure_pct = calculate_utilization(
+        repo=args.repo,
+        hours=args.hours,
+        runner_filter=args.filter,
+    )
+
+    report = format_report(results, hours=args.hours, fetch_failure_pct=fetch_failure_pct)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(report)
+        print(f"Report written to {args.output}")
+    else:
+        print(report)
+
+    # Write to GitHub Actions step summary if available
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a") as f:
+            f.write(report)
+        print("Report appended to GITHUB_STEP_SUMMARY.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-"""
-Runner Utilization Report
-
-Analyzes GitHub Actions job data to calculate runner utilization metrics.
-Reports idle time, active time, and utilization percentage per runner label.
-"""
+"""Runner Utilization Report — analyzes GitHub Actions job data for runner metrics."""
 
 import argparse
 import json
@@ -19,246 +14,148 @@ from datetime import datetime, timedelta, timezone
 
 DEFAULT_LABELS_TO_IGNORE = {"self-hosted", "Linux", "X64", "ARM64"}
 GITHUB_HOSTED_LABELS = {"ubuntu-latest", "ubuntu-22.04", "ubuntu-24.04"}
-
-
 _NON_RETRYABLE_PATTERNS = ("401", "403", "404", "422", "not found", "must have admin")
+_NON_GPU_HINTS = ("lint", "release", "runner utilization", "summize")
 
 
 def run_gh_command(args, max_retries=5):
     """Run a gh CLI command with exponential backoff retry on transient failure."""
     for attempt in range(max_retries):
         try:
-            result = subprocess.run(
-                ["gh"] + args,
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            return result.stdout
+            return subprocess.run(["gh"] + args, capture_output=True, text=True, check=True).stdout
         except subprocess.CalledProcessError as e:
-            err = str(e.stderr)
-            err_lower = err.lower()
-            if "rate limit" in err_lower:
-                pass  # fall through to backoff
-            elif any(p in err_lower for p in _NON_RETRYABLE_PATTERNS):
+            err_lower = str(e.stderr).lower()
+            if "rate limit" not in err_lower and any(
+                p in err_lower for p in _NON_RETRYABLE_PATTERNS
+            ):
                 raise
             if attempt == max_retries - 1:
                 raise
             wait = (2**attempt) + random.uniform(0, 1)
-            print(
-                f"Command failed (attempt {attempt + 1}/{max_retries}), retrying in {wait:.1f}s: {e.stderr.strip()}"
-            )
+            print(f"Retry {attempt + 1}/{max_retries} in {wait:.1f}s: {e.stderr.strip()}")
             time.sleep(wait)
 
 
-def get_workflow_runs(repo, hours=24):
-    """Fetch workflow runs from the past N hours with manual pagination and early stop."""
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
-    runs = []
-    page = 1
-    per_page = 100
-
+def _paginated_gh_api(endpoint, params=None, jq_filter=None, stop_fn=None):
+    """Generic paginated GitHub API fetcher."""
+    page, per_page, all_items = 1, 100, []
     while True:
-        output = run_gh_command(
-            [
-                "api",
-                f"/repos/{repo}/actions/runs",
-                "--method",
-                "GET",
-                "-f",
-                f"per_page={per_page}",
-                "-f",
-                f"page={page}",
-                "-f",
-                "sort=created",
-                "-f",
-                "direction=desc",
-                "--jq",
-                ".workflow_runs[]",
-            ]
-        )
-
+        args = [
+            "api",
+            endpoint,
+            "--method",
+            "GET",
+            "-f",
+            f"per_page={per_page}",
+            "-f",
+            f"page={page}",
+        ]
+        for k, v in (params or {}).items():
+            args.extend(["-f", f"{k}={v}"])
+        if jq_filter:
+            args.extend(["--jq", jq_filter])
+        output = run_gh_command(args)
         if not output.strip():
             break
-
-        page_count = 0
-        hit_cutoff = False
+        page_count, stop = 0, False
         for line in output.strip().splitlines():
             if not line.strip():
                 continue
             page_count += 1
             try:
-                run = json.loads(line)
-                created = parse_time(run.get("created_at"))
-                if created and created < cutoff:
-                    hit_cutoff = True
-                    continue
-                runs.append(run)
+                item = json.loads(line)
             except json.JSONDecodeError:
                 continue
-
-        if hit_cutoff or page_count < per_page:
+            if stop_fn and stop_fn(item):
+                stop = True
+                continue
+            all_items.append(item)
+        if stop or page_count < per_page:
             break
-
         page += 1
+    return all_items
 
-    return runs
+
+def get_workflow_runs(repo, hours=24):
+    """Fetch workflow runs from the past N hours."""
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
+    return _paginated_gh_api(
+        f"/repos/{repo}/actions/runs",
+        params={"sort": "created", "direction": "desc"},
+        jq_filter=".workflow_runs[]",
+        stop_fn=lambda r: (t := parse_time(r.get("created_at"))) is not None and t < cutoff,
+    )
 
 
 def get_jobs_for_run(repo, run_id):
     """Fetch all jobs for a workflow run, including retried attempts."""
-    jobs = []
-    page = 1
-    per_page = 100
+    return _paginated_gh_api(
+        f"/repos/{repo}/actions/runs/{run_id}/jobs",
+        params={"filter": "all"},
+        jq_filter=".jobs[]",
+    )
 
-    while True:
-        output = run_gh_command(
-            [
-                "api",
-                f"/repos/{repo}/actions/runs/{run_id}/jobs",
-                "--method",
-                "GET",
-                "-f",
-                "filter=all",
-                "-f",
-                f"per_page={per_page}",
-                "-f",
-                f"page={page}",
-                "--jq",
-                ".jobs[]",
-            ]
-        )
 
-        if not output.strip():
-            break
-
-        page_jobs = []
-        for line in output.strip().splitlines():
-            if line.strip():
-                try:
-                    page_jobs.append(json.loads(line))
-                except json.JSONDecodeError:
-                    continue
-
-        if not page_jobs:
-            break
-
-        jobs.extend(page_jobs)
-
-        if len(page_jobs) < per_page:
-            break
-
-        page += 1
-
-    return jobs
+def _meaningful_labels(label_dicts):
+    """Extract meaningful labels from a list of {"name": ...} dicts."""
+    return {d["name"] for d in label_dicts} - DEFAULT_LABELS_TO_IGNORE - GITHUB_HOSTED_LABELS
 
 
 def get_runners(repo, online_only=False):
-    """Fetch self-hosted runners for the repo; degrades gracefully if no admin access."""
+    """Fetch self-hosted runners; degrades gracefully without admin access."""
     try:
-        output = run_gh_command(
-            [
-                "api",
-                f"/repos/{repo}/actions/runners",
-                "--method",
-                "GET",
-                "--paginate",
-                "--jq",
-                ".runners[]",
-            ]
+        runners = _paginated_gh_api(
+            f"/repos/{repo}/actions/runners",
+            jq_filter=".runners[]",
         )
-        runners = []
-        for line in output.strip().splitlines():
-            if line.strip():
-                try:
-                    runner = json.loads(line)
-                    if online_only and runner.get("status") != "online":
-                        continue
-                    runners.append(runner)
-                except json.JSONDecodeError:
-                    continue
-
-        # Infer labels from runner name when labels array is empty
+        if online_only:
+            runners = [r for r in runners if r.get("status") == "online"]
         for runner in runners:
-            labels = {lbl["name"] for lbl in runner.get("labels", [])}
-            meaningful = labels - DEFAULT_LABELS_TO_IGNORE - GITHUB_HOSTED_LABELS
-            if not meaningful:
+            if not _meaningful_labels(runner.get("labels", [])):
                 name = runner.get("name", "")
                 m = re.match(r"^(arc-runner-v6e-\d+)-", name)
-                if m:
-                    inferred = m.group(1)
-                elif "cpu-runner" in name or name.startswith("runnerdeploy-"):
-                    inferred = "arc-runner-cpu"
-                else:
-                    inferred = None
+                inferred = (
+                    m.group(1)
+                    if m
+                    else (
+                        "arc-runner-cpu"
+                        if ("cpu-runner" in name or name.startswith("runnerdeploy-"))
+                        else None
+                    )
+                )
                 if inferred:
                     runner.setdefault("labels", []).append({"name": inferred})
-
         return runners
     except subprocess.CalledProcessError as e:
         err_str = str(e.stderr)
         if "rate limit" in err_str.lower():
-            print(
-                "Warning: GitHub API rate limit hit while listing runners; runner count will be unavailable."
-            )
-            return []
-        if "403" in err_str or "must have admin" in err_str.lower():
-            print(
-                "Note: No admin access to list runners; runner count will be estimated from job data."
-            )
-            return []
-        raise
-
-
-def get_fleet_status(runners):
-    """Aggregate per-label fleet status from runner list."""
-    status = defaultdict(lambda: {"total": 0, "online": 0, "offline": 0, "busy": 0, "idle": 0})
-    for runner in runners:
-        labels = {lbl["name"] for lbl in runner.get("labels", [])}
-        meaningful = labels - DEFAULT_LABELS_TO_IGNORE - GITHUB_HOSTED_LABELS
-        for lbl in meaningful:
-            s = status[lbl]
-            s["total"] += 1
-            if runner.get("status") == "online":
-                s["online"] += 1
-                if runner.get("busy"):
-                    s["busy"] += 1
-                else:
-                    s["idle"] += 1
-            else:
-                s["offline"] += 1
-    return dict(status)
+            print("Warning: GitHub API rate limit hit; runner count unavailable.")
+        elif "403" in err_str or "must have admin" in err_str.lower():
+            print("Note: No admin access to list runners; count estimated from job data.")
+        else:
+            raise
+        return []
 
 
 def parse_time(time_str):
     """Parse an ISO 8601 timestamp string into a timezone-aware datetime."""
     if not time_str:
         return None
-    # Handle both 'Z' suffix and '+00:00' offset forms
-    time_str = time_str.replace("Z", "+00:00")
     try:
-        return datetime.fromisoformat(time_str)
+        return datetime.fromisoformat(time_str.replace("Z", "+00:00"))
     except ValueError:
         return None
 
 
 def calculate_concurrency_metrics(jobs, window_start, window_end, num_runners):
-    """
-    Use a sweep-line algorithm to compute peak and average concurrent jobs,
-    saturation percentage, and peak queue depth.
-    """
+    """Sweep-line algorithm for peak/avg concurrent jobs, saturation, queue depth."""
     events = []
     for job in jobs:
-        start = parse_time(job.get("started_at"))
-        end = parse_time(job.get("completed_at"))
-        if start and end and start < end:
-            # Clamp to the reporting window
-            start = max(start, window_start)
-            end = min(end, window_end)
-            if start < end:
-                events.append((start, +1))
-                events.append((end, -1))
-
+        s, e = parse_time(job.get("started_at")), parse_time(job.get("completed_at"))
+        if s and e and s < e:
+            s, e = max(s, window_start), min(e, window_end)
+            if s < e:
+                events += [(s, +1), (e, -1)]
     if not events:
         return {
             "peak_concurrent": 0,
@@ -266,111 +163,89 @@ def calculate_concurrency_metrics(jobs, window_start, window_end, num_runners):
             "saturation_pct": None,
             "peak_queue": None,
         }
-
     events.sort(key=lambda e: (e[0], e[1]))
-
-    current = 0
-    peak = 0
-    # Weighted sum of (concurrent_count * duration_seconds) for average
+    current = peak = 0
     weighted_sum = 0.0
     prev_time = window_start
-
     for event_time, delta in events:
         if event_time > prev_time:
-            duration = (event_time - prev_time).total_seconds()
-            weighted_sum += current * duration
+            weighted_sum += current * (event_time - prev_time).total_seconds()
             prev_time = event_time
         current += delta
         peak = max(peak, current)
-
-    # Final segment to window_end
     if prev_time < window_end:
-        duration = (window_end - prev_time).total_seconds()
-        weighted_sum += current * duration
-
-    window_seconds = (window_end - window_start).total_seconds()
-    avg_concurrent = weighted_sum / window_seconds if window_seconds > 0 else 0.0
-
-    saturation_pct = (avg_concurrent / num_runners * 100.0) if num_runners > 0 else None
-    peak_queue = max(0, peak - num_runners) if num_runners > 0 else None
-
+        weighted_sum += current * (window_end - prev_time).total_seconds()
+    ws = (window_end - window_start).total_seconds()
+    avg = weighted_sum / ws if ws > 0 else 0.0
     return {
         "peak_concurrent": peak,
-        "avg_concurrent": avg_concurrent,
-        "saturation_pct": saturation_pct,
-        "peak_queue": peak_queue,
+        "avg_concurrent": avg,
+        "saturation_pct": (avg / num_runners * 100) if num_runners > 0 else None,
+        "peak_queue": max(0, peak - num_runners) if num_runners > 0 else None,
     }
-
-
-_NON_GPU_WORKFLOW_HINTS = (
-    "lint",
-    "release",
-    "runner utilization",
-    "summize",  # CI Trend Summary (nightly-test-summize)
-)
-
-
-def _likely_no_gpu_jobs(workflow_name):
-    """Return True if this workflow name suggests it has no GPU/TPU jobs."""
-    name_lower = workflow_name.lower()
-    return any(hint in name_lower for hint in _NON_GPU_WORKFLOW_HINTS)
 
 
 def _percentile(sorted_values, p):
     if not sorted_values:
         return 0.0
-    idx = int(len(sorted_values) * p / 100)
-    return sorted_values[min(idx, len(sorted_values) - 1)]
+    return sorted_values[min(int(len(sorted_values) * p / 100), len(sorted_values) - 1)]
+
+
+def _format_duration(seconds):
+    """Format seconds into a human-readable string."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    m = seconds / 60
+    return f"{m:.1f}m" if m < 60 else f"{m / 60:.1f}h"
 
 
 def calculate_utilization(repo, hours=24, runner_filter=None):
-    """
-    Main calculation: fetch runs and jobs, aggregate per-label utilization,
-    concurrency metrics, and host-level busy time.
-    """
+    """Fetch runs/jobs, aggregate per-label utilization and concurrency metrics."""
     window_end = datetime.now(timezone.utc)
     window_start = window_end - timedelta(hours=hours)
-
     print(f"Fetching workflow runs for {repo} in the past {hours} hours...")
     runs = get_workflow_runs(repo, hours=hours)
     print(f"Found {len(runs)} workflow runs.")
 
-    # Fetch runners once; fall back gracefully
     runners_list = get_runners(repo, online_only=False)
 
-    fleet_status = get_fleet_status(runners_list)
-
-    # Build label -> runner count map
+    # Fleet status aggregation
+    fleet_status = defaultdict(
+        lambda: {"total": 0, "online": 0, "offline": 0, "busy": 0, "idle": 0}
+    )
     label_runner_count = defaultdict(int)
     for runner in runners_list:
-        labels = {lbl["name"] for lbl in runner.get("labels", [])}
-        for lbl in labels:
-            if lbl not in DEFAULT_LABELS_TO_IGNORE and lbl not in GITHUB_HOSTED_LABELS:
-                label_runner_count[lbl] += 1
+        meaningful = _meaningful_labels(runner.get("labels", []))
+        for lbl in meaningful:
+            label_runner_count[lbl] += 1
+            fs = fleet_status[lbl]
+            fs["total"] += 1
+            if runner.get("status") == "online":
+                fs["online"] += 1
+                fs["busy" if runner.get("busy") else "idle"] += 1
+            else:
+                fs["offline"] += 1
+    fleet_status = dict(fleet_status)
 
-    fetch_failures = 0
-    total_runs = len(runs)
-
+    fetch_failures, total_runs = 0, len(runs)
     label_intervals = defaultdict(list)
     label_jobs = defaultdict(list)
     label_queue_waits = defaultdict(list)
     label_job_durations = defaultdict(list)
     label_conclusions = defaultdict(list)
-    all_jobs_enriched = []
+    failed_jobs = []
     workflow_stats = defaultdict(
         lambda: defaultdict(lambda: {"job_count": 0, "total_duration": 0.0})
     )
-    hourly_buckets = defaultdict(int)
 
     def fetch_run_jobs(run):
-        wf_name = run.get("name", "")
-        run_url = run.get("html_url", "")
-        if _likely_no_gpu_jobs(wf_name):
+        wf_name, run_url = run.get("name", ""), run.get("html_url", "")
+        if any(h in wf_name.lower() for h in _NON_GPU_HINTS):
             return run["id"], wf_name, run_url, []
         try:
             return run["id"], wf_name, run_url, get_jobs_for_run(repo, run["id"])
-        except Exception as e:
-            print(f"Warning: failed to fetch jobs for run {run['id']}: {e}")
+        except Exception as exc:
+            print(f"Warning: failed to fetch jobs for run {run['id']}: {exc}")
             return run["id"], wf_name, run_url, None
 
     print("Fetching job details (parallel, max 4 workers)...")
@@ -379,8 +254,8 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
         for future in as_completed(futures):
             try:
                 run_id, wf_name, run_url, jobs = future.result()
-            except Exception as e:
-                print(f"Warning: unexpected error fetching jobs: {e}")
+            except Exception as exc:
+                print(f"Warning: unexpected error fetching jobs: {exc}")
                 fetch_failures += 1
                 continue
             if jobs is None:
@@ -389,165 +264,156 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
             for job in jobs:
                 if job.get("status") != "completed":
                     continue
-                labels = set(job.get("labels", []))
-                # Strip generic labels to identify the meaningful runner label
-                meaningful = labels - DEFAULT_LABELS_TO_IGNORE - GITHUB_HOSTED_LABELS
+                meaningful = (
+                    set(job.get("labels", [])) - DEFAULT_LABELS_TO_IGNORE - GITHUB_HOSTED_LABELS
+                )
                 if not meaningful:
                     continue
-                if runner_filter and not any(runner_filter in lbl for lbl in meaningful):
+                if runner_filter and not any(runner_filter in l for l in meaningful):
                     continue
-
                 started = parse_time(job.get("started_at"))
                 completed = parse_time(job.get("completed_at"))
                 created = parse_time(job.get("created_at"))
                 if not started or not completed or completed <= started:
                     continue
-
                 wait_s = 0.0
                 if created and started > created:
                     wait_s = (started - created).total_seconds()
                     for lbl in meaningful:
                         label_queue_waits[lbl].append(wait_s)
-
                 eff_start = max(started, window_start)
                 eff_end = min(completed, window_end)
                 if eff_start >= eff_end:
                     continue
-
+                duration_s = (eff_end - eff_start).total_seconds()
+                conclusion = job.get("conclusion", "unknown")
                 for lbl in meaningful:
                     label_intervals[lbl].append((eff_start, eff_end))
                     label_jobs[lbl].append(job)
-
-                duration_s = (eff_end - eff_start).total_seconds()
-                for lbl in meaningful:
                     label_job_durations[lbl].append(duration_s)
-                    label_conclusions[lbl].append(job.get("conclusion", "unknown"))
+                    label_conclusions[lbl].append(conclusion)
                     workflow_stats[wf_name][lbl]["job_count"] += 1
                     workflow_stats[wf_name][lbl]["total_duration"] += duration_s
+                if conclusion == "failure":
+                    failed_jobs.append(
+                        {
+                            "workflow": wf_name,
+                            "job_name": job.get("name", ""),
+                            "duration": duration_s,
+                            "label": ", ".join(sorted(meaningful)),
+                            "url": job.get("html_url", run_url),
+                        }
+                    )
 
-                all_jobs_enriched.append(
-                    {
-                        "workflow": wf_name,
-                        "job_name": job.get("name", ""),
-                        "duration": duration_s,
-                        "wait": wait_s,
-                        "conclusion": job.get("conclusion", "unknown"),
-                        "label": ", ".join(sorted(meaningful)),
-                        "url": job.get("html_url", run_url),
-                    }
-                )
-
-                hourly_buckets[started.hour] += 1
-
-    fetch_failure_pct = (fetch_failures / total_runs * 100.0) if total_runs > 0 else 0.0
+    fetch_failure_pct = (fetch_failures / total_runs * 100) if total_runs > 0 else 0.0
     window_seconds = (window_end - window_start).total_seconds()
 
     results = {}
-    all_labels = set(label_intervals.keys()) | set(label_runner_count.keys())
-
-    for label in sorted(all_labels):
+    for label in sorted(set(label_intervals) | set(label_runner_count)):
         if runner_filter and runner_filter not in label:
             continue
         intervals = label_intervals.get(label, [])
         num_runners = label_runner_count.get(label, 0)
-
-        # Merge overlapping intervals to compute total busy time
         merged = []
-        for start, end in sorted(intervals):
-            if merged and start <= merged[-1][1]:
-                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        for s, e in sorted(intervals):
+            if merged and s <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], e))
             else:
-                merged.append((start, end))
-
-        busy_seconds = sum((e - s).total_seconds() for s, e in merged)
-        total_job_seconds = sum((e - s).total_seconds() for s, e in intervals)
-
-        capacity_seconds = num_runners * window_seconds if num_runners > 0 else 0.0
-        utilization_pct = (
-            (total_job_seconds / capacity_seconds * 100.0) if capacity_seconds > 0 else None
-        )
-
-        concurrency = calculate_concurrency_metrics(
-            label_jobs.get(label, []),
-            window_start,
-            window_end,
-            num_runners,
-        )
-
+                merged.append((s, e))
+        total_job_s = sum((e - s).total_seconds() for s, e in intervals)
+        cap_s = num_runners * window_seconds if num_runners > 0 else 0.0
         waits = sorted(label_queue_waits.get(label, []))
         durations = sorted(label_job_durations.get(label, []))
         conclusions = label_conclusions.get(label, [])
-        success_count = conclusions.count("success")
-        failure_count = conclusions.count("failure")
-        cancelled_count = conclusions.count("cancelled")
-        total_concluded = len(conclusions)
-
         results[label] = {
             "num_runners": num_runners,
-            "busy_seconds": busy_seconds,
-            "capacity_seconds": capacity_seconds,
-            "utilization_pct": utilization_pct,
-            "total_job_seconds": total_job_seconds,
+            "utilization_pct": (total_job_s / cap_s * 100) if cap_s > 0 else None,
             "job_count": len(label_jobs.get(label, [])),
-            "concurrency": concurrency,
-            "avg_queue_wait": sum(waits) / len(waits) if waits else 0.0,
-            "max_queue_wait": max(waits) if waits else 0.0,
-            "wait_p50": _percentile(waits, 50),
+            "concurrency": calculate_concurrency_metrics(
+                label_jobs.get(label, []),
+                window_start,
+                window_end,
+                num_runners,
+            ),
             "wait_p95": _percentile(waits, 95),
             "duration_p50": _percentile(durations, 50),
             "duration_p95": _percentile(durations, 95),
-            "duration_p99": _percentile(durations, 99),
-            "duration_max": max(durations) if durations else 0.0,
-            "success_count": success_count,
-            "failure_count": failure_count,
-            "cancelled_count": cancelled_count,
-            "total_concluded": total_concluded,
+            "success_count": conclusions.count("success"),
+            "failure_count": conclusions.count("failure"),
+            "total_concluded": len(conclusions),
+        }
+
+    wf_aggregates = {}
+    for wf_name, label_data in workflow_stats.items():
+        wf_aggregates[wf_name] = {
+            "total_jobs": sum(v["job_count"] for v in label_data.values()),
+            "total_duration": sum(v["total_duration"] for v in label_data.values()),
+            "labels": sorted(label_data.keys()),
         }
 
     return {
         "per_label": results,
         "fleet_status": fleet_status,
         "fetch_failure_pct": fetch_failure_pct,
-        "all_jobs": all_jobs_enriched,
+        "failed_jobs": failed_jobs,
         "workflow_stats": dict(workflow_stats),
-        "hourly_buckets": dict(hourly_buckets),
+        "wf_aggregates": wf_aggregates,
     }
 
 
-def _format_duration(seconds):
-    """Format seconds into a human-readable string (e.g. '2m 30s', '1h 5m')."""
-    if seconds < 60:
-        return f"{seconds:.0f}s"
-    minutes = seconds / 60
-    if minutes < 60:
-        return f"{minutes:.1f}m"
-    hours = minutes / 60
-    return f"{hours:.1f}h"
+def _generate_recommendations(results, fleet_status, wf_aggregates):
+    """Generate recommendation strings shared by full report and Slack summary."""
+    recs = []
+    grand_total = sum(a["total_duration"] for a in wf_aggregates.values())
+    for label, d in sorted(results.items()):
+        util, conc = d["utilization_pct"], d["concurrency"]
+        tc, fc = d["total_concluded"], d["failure_count"]
+        if util is not None and util > 80:
+            recs.append(
+                f"**`{label}`**: High utilization ({util:.1f}%). Consider adding more runners."
+            )
+        elif util is not None and util < 10 and d["job_count"] > 0:
+            recs.append(f"**`{label}`**: Low utilization ({util:.1f}%). May be over-provisioned.")
+        if conc["peak_queue"] is not None and conc["peak_queue"] > 0:
+            recs.append(
+                f"**`{label}`**: Peak queue depth {conc['peak_queue']}. Jobs waited for runners."
+            )
+        if tc > 5 and fc / tc > 0.2:
+            recs.append(f"**`{label}`**: High failure rate ({fc}/{tc}, {fc / tc * 100:.1f}%).")
+        if d["wait_p95"] > 600:
+            recs.append(
+                f"**`{label}`**: Long queue wait (P95 = {_format_duration(d['wait_p95'])}). Consider scaling."
+            )
+    for label, s in sorted(fleet_status.items()):
+        if s["offline"] > 0:
+            recs.append(f"**`{label}`**: {s['offline']} runner(s) offline.")
+    if grand_total > 0:
+        for wf, a in sorted(
+            wf_aggregates.items(), key=lambda x: x[1]["total_duration"], reverse=True
+        ):
+            if a["total_duration"] > 0.5 * grand_total:
+                pct = a["total_duration"] / grand_total * 100
+                recs.append(
+                    f"Workflow **`{wf}`** accounts for {pct:.0f}% of runner time "
+                    f"({_format_duration(a['total_duration'])} of {_format_duration(grand_total)})."
+                )
+    return recs
 
 
 def format_report(report_data, hours):
-    """Format the utilization results as a Markdown report."""
+    """Format utilization results as a Markdown report (5 sections)."""
     results = report_data["per_label"]
     fleet_status = report_data["fleet_status"]
-    fetch_failure_pct = report_data["fetch_failure_pct"]
-    all_jobs = report_data["all_jobs"]
-    workflow_stats = report_data["workflow_stats"]
-    hourly_buckets = report_data["hourly_buckets"]
-
-    lines = []
-    lines.append(f"# Runner Utilization Report (Past {hours} Hours)")
+    wf_aggregates = report_data["wf_aggregates"]
+    failed_jobs = report_data["failed_jobs"]
+    lines = [f"# Runner Utilization Report (Past {hours} Hours)", ""]
+    lines.append(f"_Generated at {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}_")
     lines.append("")
-
-    now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    lines.append(f"_Generated at {now_utc}_")
-    lines.append("")
-
-    if fetch_failure_pct > 0:
+    if report_data["fetch_failure_pct"] > 0:
         lines.append(
-            f"> **Warning:** {fetch_failure_pct:.1f}% of workflow runs could not be fetched (API errors). Results may be incomplete."
+            f"> **Warning:** {report_data['fetch_failure_pct']:.1f}% of runs could not be fetched."
         )
         lines.append("")
-
     if not results and not fleet_status:
         lines.append("No runner activity found in the specified time window.")
         return "\n".join(lines)
@@ -565,243 +431,77 @@ def format_report(report_data, hours):
     else:
         lines.append("No runner data available (admin token required).")
     lines.append("")
-
     if not results:
         lines.append("No runner activity found in the specified time window.")
         return "\n".join(lines)
 
-    # Utilization table
-    lines.append("## Utilization by Runner Label")
-    lines.append("")
-    lines.append("| Runner Label | Runners | Jobs | Busy Time | Capacity | Utilization |")
-    lines.append("|---|---|---|---|---|---|")
-
-    for label, data in sorted(results.items()):
-        num_runners = data["num_runners"] or "N/A"
-        job_count = data["job_count"]
-        busy_h = data["busy_seconds"] / 3600
-        cap_h = data["capacity_seconds"] / 3600 if data["capacity_seconds"] else None
-        util = data["utilization_pct"]
-
-        busy_str = f"{busy_h:.1f}h"
-        cap_str = f"{cap_h:.1f}h" if cap_h is not None else "N/A"
-        util_str = f"{util:.1f}%" if util is not None else "N/A"
-
-        lines.append(
-            f"| `{label}` | {num_runners} | {job_count} | {busy_str} | {cap_str} | {util_str} |"
-        )
-
-    lines.append("")
-
-    # Concurrency analysis
-    lines.append("## Concurrency Analysis")
+    # Utilization Summary
+    lines.append("## Utilization Summary")
     lines.append("")
     lines.append(
-        "| Runner Label | Peak Concurrent | Avg Concurrent | Saturation | Peak Queue | Wait P50 | Wait P95 | Wait Max |"
+        "| Runner Label | Runners | Jobs | Utilization | Peak Conc "
+        "| Queue P95 | Duration P50 | Duration P95 | Success Rate |"
     )
-    lines.append("|---|---|---|---|---|---|---|---|")
-
-    for label, data in sorted(results.items()):
-        conc = data["concurrency"]
-        peak = conc["peak_concurrent"]
-        avg = conc["avg_concurrent"]
-        sat = conc["saturation_pct"]
-        queue = conc["peak_queue"]
-        sat_str = f"{sat:.1f}%" if sat is not None else "N/A"
-        queue_str = str(queue) if queue is not None else "N/A"
-        wait_p50 = _format_duration(data["wait_p50"])
-        wait_p95 = _format_duration(data["wait_p95"])
-        max_wait = _format_duration(data["max_queue_wait"])
-
+    lines.append("|---|---|---|---|---|---|---|---|---|")
+    for label, d in sorted(results.items()):
+        nr = d["num_runners"] or "N/A"
+        util = f"{d['utilization_pct']:.1f}%" if d["utilization_pct"] is not None else "N/A"
+        tc = d["total_concluded"]
+        rate = f"{d['success_count'] / tc * 100:.1f}%" if tc > 0 else "N/A"
         lines.append(
-            f"| `{label}` | {peak} | {avg:.2f} | {sat_str} | {queue_str} | {wait_p50} | {wait_p95} | {max_wait} |"
+            f"| `{label}` | {nr} | {d['job_count']} | {util} "
+            f"| {d['concurrency']['peak_concurrent']} | {_format_duration(d['wait_p95'])} "
+            f"| {_format_duration(d['duration_p50'])} | {_format_duration(d['duration_p95'])} | {rate} |"
         )
-
     lines.append("")
 
-    # Job Duration
-    lines.append("## Job Duration")
-    lines.append("")
-    lines.append("| Runner Label | Jobs | P50 | P95 | P99 | Max |")
-    lines.append("|---|---|---|---|---|---|")
-
-    for label, data in sorted(results.items()):
-        job_count = data["job_count"]
-        p50 = _format_duration(data["duration_p50"])
-        p95 = _format_duration(data["duration_p95"])
-        p99 = _format_duration(data["duration_p99"])
-        dmax = _format_duration(data["duration_max"])
-        lines.append(f"| `{label}` | {job_count} | {p50} | {p95} | {p99} | {dmax} |")
-
-    lines.append("")
-
-    # Top 10 Workflows by Runner Time
+    # Top 10 Workflows
     lines.append("## Top 10 Workflows by Runner Time")
     lines.append("")
     lines.append("| # | Workflow | Jobs | Total Time | Avg Duration | Runner Labels |")
     lines.append("|---|---|---|---|---|---|")
-
-    # Aggregate across labels per workflow
-    wf_aggregates = {}
-    for wf_name, label_data in workflow_stats.items():
-        total_jobs = sum(v["job_count"] for v in label_data.values())
-        total_duration = sum(v["total_duration"] for v in label_data.values())
-        labels_used = sorted(label_data.keys())
-        wf_aggregates[wf_name] = {
-            "total_jobs": total_jobs,
-            "total_duration": total_duration,
-            "labels": labels_used,
-        }
-
     sorted_wfs = sorted(wf_aggregates.items(), key=lambda x: x[1]["total_duration"], reverse=True)
-    for rank, (wf_name, agg) in enumerate(sorted_wfs[:10], start=1):
-        avg_duration = agg["total_duration"] / agg["total_jobs"] if agg["total_jobs"] > 0 else 0.0
-        labels_str = ", ".join(agg["labels"])
+    for rank, (wf, a) in enumerate(sorted_wfs[:10], start=1):
+        avg = a["total_duration"] / a["total_jobs"] if a["total_jobs"] > 0 else 0
         lines.append(
-            f"| {rank} | {wf_name} | {agg['total_jobs']} | {_format_duration(agg['total_duration'])} | {_format_duration(avg_duration)} | {labels_str} |"
+            f"| {rank} | {wf} | {a['total_jobs']} | {_format_duration(a['total_duration'])} "
+            f"| {_format_duration(avg)} | {', '.join(a['labels'])} |"
         )
-
     lines.append("")
 
-    # Top 10 Slowest Jobs
-    lines.append("## Top 10 Slowest Jobs")
-    lines.append("")
-    lines.append("| # | Workflow | Job | Duration | Wait | Runner Label | Link |")
-    lines.append("|---|---|---|---|---|---|---|")
-
-    sorted_jobs = sorted(all_jobs, key=lambda j: j["duration"], reverse=True)
-    for rank, job in enumerate(sorted_jobs[:10], start=1):
-        lines.append(
-            f"| {rank} | {job['workflow']} | {job['job_name']} | {_format_duration(job['duration'])} | {_format_duration(job['wait'])} | {job['label']} | [Run]({job['url']}) |"
-        )
-
-    lines.append("")
-
-    # Job Success Rate
-    lines.append("## Job Success Rate")
-    lines.append("")
-    lines.append("| Runner Label | Total | Success | Failure | Cancelled | Success Rate |")
-    lines.append("|---|---|---|---|---|---|")
-
-    for label, data in sorted(results.items()):
-        total = data["total_concluded"]
-        success = data["success_count"]
-        failure = data["failure_count"]
-        cancelled = data["cancelled_count"]
-        rate_str = f"{success / total * 100:.1f}%" if total > 0 else "N/A"
-        lines.append(f"| `{label}` | {total} | {success} | {failure} | {cancelled} | {rate_str} |")
-
-    lines.append("")
-
-    # Failed Jobs (max 20)
+    # Failed Jobs (max 5)
     lines.append("## Failed Jobs")
     lines.append("")
-    failed_jobs = [j for j in all_jobs if j["conclusion"] == "failure"]
     if failed_jobs:
-        failed_jobs_sorted = sorted(failed_jobs, key=lambda j: j["duration"], reverse=True)
         lines.append("| Workflow | Job | Duration | Runner Label | Link |")
         lines.append("|---|---|---|---|---|")
-        for job in failed_jobs_sorted[:20]:
+        for j in sorted(failed_jobs, key=lambda j: j["duration"], reverse=True)[:5]:
             lines.append(
-                f"| {job['workflow']} | {job['job_name']} | {_format_duration(job['duration'])} | {job['label']} | [Run]({job['url']}) |"
+                f"| {j['workflow']} | {j['job_name']} | {_format_duration(j['duration'])} "
+                f"| {j['label']} | [Run]({j['url']}) |"
             )
     else:
         lines.append("No failed jobs in this period.")
-
-    lines.append("")
-
-    # Hourly Distribution
-    lines.append("## Hourly Distribution (UTC)")
-    lines.append("")
-    lines.append("| Period (UTC) | Jobs Started |")
-    lines.append("|---|---|")
-    for start, end in [(0, 6), (6, 12), (12, 18), (18, 24)]:
-        count = sum(hourly_buckets.get(h, 0) for h in range(start, end))
-        lines.append(f"| {start:02d}:00–{end - 1:02d}:59 | {count} |")
-
     lines.append("")
 
     # Recommendations
     lines.append("## Recommendations")
     lines.append("")
-
     recs = _generate_recommendations(results, fleet_status, wf_aggregates)
-    if recs:
-        for r in recs:
-            lines.append(f"- {r}")
-    else:
-        lines.append(
-            "No immediate action required. All runner labels appear within normal utilization bounds."
-        )
-
+    for r in recs:
+        lines.append(f"- {r}")
+    if not recs:
+        lines.append("No immediate action required. All runners within normal bounds.")
     lines.append("")
     return "\n".join(lines)
 
 
-def _generate_recommendations(results, fleet_status, wf_aggregates):
-    """Generate recommendation strings shared by full report and Slack summary."""
-    recs = []
-    grand_total_duration = sum(agg["total_duration"] for agg in wf_aggregates.values())
-
-    for label, data in sorted(results.items()):
-        util = data["utilization_pct"]
-        conc = data["concurrency"]
-        total_concluded = data["total_concluded"]
-        failure_count = data["failure_count"]
-
-        if util is not None and util > 80:
-            recs.append(
-                f"**`{label}`**: High utilization ({util:.1f}%). Consider adding more runners to reduce queue time."
-            )
-        elif util is not None and util < 10 and data["job_count"] > 0:
-            recs.append(
-                f"**`{label}`**: Low utilization ({util:.1f}%). Runner capacity may be over-provisioned."
-            )
-
-        if conc["peak_queue"] is not None and conc["peak_queue"] > 0:
-            recs.append(
-                f"**`{label}`**: Peak queue depth of {conc['peak_queue']} job(s) detected. Jobs had to wait for a free runner."
-            )
-
-        if total_concluded > 5 and failure_count / total_concluded > 0.2:
-            recs.append(
-                f"**`{label}`**: High failure rate ({failure_count}/{total_concluded} jobs, {failure_count / total_concluded * 100:.1f}%). Investigate job failures."
-            )
-
-        if data["wait_p95"] > 600:
-            recs.append(
-                f"**`{label}`**: Long queue wait detected (P95 wait = {_format_duration(data['wait_p95'])}). Consider scaling runners."
-            )
-
-    for label, s in sorted(fleet_status.items()):
-        if s["offline"] > 0:
-            recs.append(
-                f"**`{label}`**: {s['offline']} runner(s) are offline. Check runner health."
-            )
-
-    if grand_total_duration > 0:
-        sorted_wfs = sorted(
-            wf_aggregates.items(), key=lambda x: x[1]["total_duration"], reverse=True
-        )
-        for wf_name, agg in sorted_wfs:
-            if agg["total_duration"] > 0.5 * grand_total_duration:
-                pct = agg["total_duration"] / grand_total_duration * 100
-                recs.append(
-                    f"Workflow **`{wf_name}`** accounts for {pct:.0f}% of total runner time ({_format_duration(agg['total_duration'])} of {_format_duration(grand_total_duration)})."
-                )
-
-    return recs
-
-
 def format_slack_summary(report_data, hours, run_url=""):
-    """Format a Slack mrkdwn summary with fleet status, utilization, and recommendations."""
+    """Format a compact Slack mrkdwn summary."""
     results = report_data["per_label"]
     fleet_status = report_data["fleet_status"]
-    workflow_stats = report_data["workflow_stats"]
-
+    wf_aggregates = report_data["wf_aggregates"]
     lines = [f"*Runner Utilization Report (Past {hours} Hours)*"]
-
-    # Fleet Status
     lines.append("")
     lines.append("*Fleet Status*")
     if fleet_status:
@@ -811,117 +511,84 @@ def format_slack_summary(report_data, hours, run_url=""):
             )
     else:
         lines.append("Fleet data unavailable (admin token required)")
-
     if not results:
-        lines.append("")
-        lines.append("No runner activity in this period.")
+        lines += ["", "No runner activity in this period."]
         if run_url:
-            lines.append("")
-            lines.append(f"<{run_url}|View full report>")
+            lines += ["", f"<{run_url}|View full report>"]
         return "\n".join(lines)
 
-    # Utilization
     lines.append("")
     lines.append("*Utilization*")
-    util_parts = []
-    for label, data in sorted(results.items()):
-        util = data["utilization_pct"]
-        util_parts.append(f"`{label}`: {util:.1f}%" if util is not None else f"`{label}`: N/A")
-    lines.append("• " + " | ".join(util_parts))
-
-    # Queue Wait P95
+    lines.append(
+        "• "
+        + " | ".join(
+            (
+                f"`{l}`: {d['utilization_pct']:.1f}%"
+                if d["utilization_pct"] is not None
+                else f"`{l}`: N/A"
+            )
+            for l, d in sorted(results.items())
+        )
+    )
     lines.append("")
     lines.append("*Queue Wait (P95)*")
-    wait_parts = []
-    for label, data in sorted(results.items()):
-        wait_parts.append(f"`{label}`: {_format_duration(data['wait_p95'])}")
-    lines.append("• " + " | ".join(wait_parts))
-
-    # Success Rate
+    lines.append(
+        "• "
+        + " | ".join(
+            f"`{l}`: {_format_duration(d['wait_p95'])}" for l, d in sorted(results.items())
+        )
+    )
     lines.append("")
     lines.append("*Success Rate*")
     rate_parts = []
-    for label, data in sorted(results.items()):
-        if data["total_concluded"] > 0:
-            rate = data["success_count"] / data["total_concluded"] * 100
-            failures = data["failure_count"]
-            part = f"`{label}`: {rate:.1f}%"
-            if failures > 0:
-                part += f" ({failures} failures)"
-            rate_parts.append(part)
+    for l, d in sorted(results.items()):
+        if d["total_concluded"] > 0:
+            p = f"`{l}`: {d['success_count'] / d['total_concluded'] * 100:.1f}%"
+            if d["failure_count"] > 0:
+                p += f" ({d['failure_count']} failures)"
+            rate_parts.append(p)
         else:
-            rate_parts.append(f"`{label}`: N/A")
+            rate_parts.append(f"`{l}`: N/A")
     lines.append("• " + " | ".join(rate_parts))
-
-    # Recommendations
-    wf_aggregates = {}
-    for wf_name, label_data in workflow_stats.items():
-        total_jobs = sum(v["job_count"] for v in label_data.values())
-        total_duration = sum(v["total_duration"] for v in label_data.values())
-        wf_aggregates[wf_name] = {
-            "total_jobs": total_jobs,
-            "total_duration": total_duration,
-            "labels": sorted(label_data.keys()),
-        }
 
     recs = _generate_recommendations(results, fleet_status, wf_aggregates)
     lines.append("")
     if recs:
         lines.append("*Recommendations*")
         for r in recs:
-            clean = r.replace("**", "").replace("`", "`")
-            lines.append(f"• {clean}")
+            lines.append(f"• {r.replace('**`', '*`').replace('`**', '`*')}")
     else:
         lines.append("No issues detected.")
-
     if run_url:
-        lines.append("")
-        lines.append(f"<{run_url}|View full report>")
-
+        lines += ["", f"<{run_url}|View full report>"]
     return "\n".join(lines)
 
 
 def main():
     parser = argparse.ArgumentParser(description="Generate runner utilization report")
-    parser.add_argument(
-        "--repo", default="sgl-project/sglang-jax", help="GitHub repository (owner/name)"
-    )
-    parser.add_argument("--hours", type=int, default=24, help="Time window in hours (default: 24)")
-    parser.add_argument(
-        "--filter", type=str, dest="filter", help="Filter runner labels (substring match)"
-    )
+    parser.add_argument("--repo", default="sgl-project/sglang-jax", help="GitHub repository")
+    parser.add_argument("--hours", type=int, default=24, help="Time window in hours")
+    parser.add_argument("--filter", type=str, help="Filter runner labels (substring match)")
     parser.add_argument("--output", type=str, help="Output file path (default: stdout)")
     parser.add_argument("--slack-output", type=str, help="Slack summary output file path")
-    parser.add_argument(
-        "--run-url", type=str, default="", help="GitHub Actions run URL for Slack link"
-    )
+    parser.add_argument("--run-url", type=str, default="", help="Actions run URL for Slack link")
     args = parser.parse_args()
-
     if args.hours < 1:
         parser.error("--hours must be a positive integer")
 
-    report_data = calculate_utilization(
-        repo=args.repo,
-        hours=args.hours,
-        runner_filter=args.filter,
-    )
-
-    report = format_report(report_data, hours=args.hours)
-
+    report_data = calculate_utilization(args.repo, args.hours, args.filter)
+    report = format_report(report_data, args.hours)
     if args.output:
         with open(args.output, "w") as f:
             f.write(report)
         print(f"Report written to {args.output}")
     else:
         print(report)
-
     if args.slack_output:
-        summary = format_slack_summary(report_data, hours=args.hours, run_url=args.run_url)
+        summary = format_slack_summary(report_data, args.hours, args.run_url)
         with open(args.slack_output, "w") as f:
             f.write(summary)
         print(f"Slack summary written to {args.slack_output}")
-
-    # Write to GitHub Actions step summary if available
     step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if step_summary:
         with open(step_summary, "a") as f:

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -77,17 +77,18 @@ def get_workflow_runs(repo, hours=24):
         page_count = 0
         hit_cutoff = False
         for line in output.strip().splitlines():
-            if line.strip():
-                try:
-                    run = json.loads(line)
-                    created = parse_time(run.get("created_at"))
-                    if created and created < cutoff:
-                        hit_cutoff = True
-                        continue
-                    runs.append(run)
-                    page_count += 1
-                except json.JSONDecodeError:
+            if not line.strip():
+                continue
+            page_count += 1
+            try:
+                run = json.loads(line)
+                created = parse_time(run.get("created_at"))
+                if created and created < cutoff:
+                    hit_cutoff = True
                     continue
+                runs.append(run)
+            except json.JSONDecodeError:
+                continue
 
         if hit_cutoff or page_count < per_page:
             break

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta, timezone
 DEFAULT_LABELS_TO_IGNORE = {"self-hosted", "Linux", "X64", "ARM64"}
 GITHUB_HOSTED_LABELS = {"ubuntu-latest", "ubuntu-22.04", "ubuntu-24.04"}
 _NON_RETRYABLE_PATTERNS = ("401", "403", "404", "422", "not found", "must have admin")
-_NON_GPU_HINTS = ("lint", "release", "runner utilization", "summize")
+_NON_GPU_HINTS = ("lint", "release", "runner utilization", "summize")  # nightly-test-summize.yml
 
 
 def run_gh_command(args, max_retries=5):
@@ -167,7 +167,7 @@ def calculate_concurrency_metrics(jobs, window_start, window_end, num_runners):
                 events += [(s, +1), (e, -1)]
     if not events:
         return {"peak_concurrent": 0, "peak_queue": None}
-    events.sort(key=lambda e: (e[0], e[1]))
+    events.sort(key=lambda ev: (ev[0], ev[1]))
     current = peak = 0
     for event_time, delta in events:
         current += delta
@@ -428,7 +428,7 @@ def format_report(report_data, hours):
     lines.append("")
     lines.append(
         "| Runner Label | Runners | Jobs | Utilization | Peak Conc "
-        "| Queue P95 | Duration P50 | Duration P95 | Success Rate |"
+        "| Queue P95* | Duration P50 | Duration P95 | Success Rate |"
     )
     lines.append("|---|---|---|---|---|---|---|---|---|")
     for label, d in sorted(results.items()):
@@ -441,6 +441,8 @@ def format_report(report_data, hours):
             f"| {d['concurrency']['peak_concurrent']} | {_format_duration(d['wait_p95'])} "
             f"| {_format_duration(d['duration_p50'])} | {_format_duration(d['duration_p95'])} | {rate} |"
         )
+    lines.append("")
+    lines.append("_* Queue P95 is computed among jobs that waited (excludes 0s waits)._")
     lines.append("")
 
     # Top 10 Workflows

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -160,6 +160,8 @@ def get_runners(repo, online_only=False):
             [
                 "api",
                 f"/repos/{repo}/actions/runners",
+                "--method",
+                "GET",
                 "--paginate",
                 "--jq",
                 ".runners[]",
@@ -697,11 +699,11 @@ def format_report(report_data, hours):
     failed_jobs = [j for j in all_jobs if j["conclusion"] == "failure"]
     if failed_jobs:
         failed_jobs_sorted = sorted(failed_jobs, key=lambda j: j["duration"], reverse=True)
-        lines.append("| Workflow | Job | Conclusion | Duration | Runner Label | Link |")
-        lines.append("|---|---|---|---|---|---|")
+        lines.append("| Workflow | Job | Duration | Runner Label | Link |")
+        lines.append("|---|---|---|---|---|")
         for job in failed_jobs_sorted[:20]:
             lines.append(
-                f"| {job['workflow']} | {job['job_name']} | {job['conclusion']} | {_format_duration(job['duration'])} | {job['label']} | [Run]({job['url']}) |"
+                f"| {job['workflow']} | {job['job_name']} | {_format_duration(job['duration'])} | {job['label']} | [Run]({job['url']}) |"
             )
     else:
         lines.append("No failed jobs in this period.")
@@ -711,10 +713,14 @@ def format_report(report_data, hours):
     # Hourly Distribution
     lines.append("## Hourly Distribution (UTC)")
     lines.append("")
-    lines.append("| Hour | Jobs Started |")
-    lines.append("|---|---|")
-    for h in range(24):
-        lines.append(f"| {h:02d}:00 | {hourly_buckets.get(h, 0)} |")
+    active_hours = [(h, hourly_buckets[h]) for h in range(24) if hourly_buckets.get(h, 0) > 0]
+    if active_hours:
+        lines.append("| Hour | Jobs Started |")
+        lines.append("|---|---|")
+        for h, count in active_hours:
+            lines.append(f"| {h:02d}:00 | {count} |")
+    else:
+        lines.append("No jobs started in this period.")
 
     lines.append("")
 
@@ -788,6 +794,55 @@ def format_report(report_data, hours):
     return "\n".join(lines)
 
 
+def format_slack_summary(report_data, hours):
+    """Format a compact plain-text summary for Slack (no markdown tables)."""
+    results = report_data["per_label"]
+    fleet_status = report_data["fleet_status"]
+    recommendations = []
+
+    lines = [f"*Runner Utilization Report (Past {hours} Hours)*", ""]
+
+    for label in sorted(set(list(results.keys()) + list(fleet_status.keys()))):
+        parts = [f"• *{label}*:"]
+        fs = fleet_status.get(label)
+        if fs:
+            parts.append(f"{fs['total']} runners ({fs['online']} online, {fs['busy']} busy)")
+        data = results.get(label)
+        if data:
+            parts.append(f"{data['job_count']} jobs")
+            util = data["utilization_pct"]
+            if util is not None:
+                parts.append(f"utilization {util:.1f}%")
+            if data["wait_p95"] > 0:
+                parts.append(f"wait P95 {_format_duration(data['wait_p95'])}")
+            rate = (
+                f"{data['success_count'] / data['total_concluded'] * 100:.0f}%"
+                if data["total_concluded"] > 0
+                else "N/A"
+            )
+            parts.append(f"success rate {rate}")
+        lines.append(" | ".join(parts))
+
+    for label, data in sorted(results.items()):
+        if data["wait_p95"] > 600:
+            recommendations.append(
+                f"⚠ {label}: P95 queue wait {_format_duration(data['wait_p95'])}"
+            )
+        if data["total_concluded"] > 5 and data["failure_count"] / data["total_concluded"] > 0.2:
+            recommendations.append(
+                f"⚠ {label}: {data['failure_count']}/{data['total_concluded']} jobs failed"
+            )
+
+    if recommendations:
+        lines.append("")
+        lines.extend(recommendations)
+    else:
+        lines.append("")
+        lines.append("✓ No issues detected")
+
+    return "\n".join(lines)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Generate runner utilization report")
     parser.add_argument(
@@ -798,6 +853,7 @@ def main():
         "--filter", type=str, dest="filter", help="Filter runner labels (substring match)"
     )
     parser.add_argument("--output", type=str, help="Output file path (default: stdout)")
+    parser.add_argument("--slack-summary", type=str, help="Write Slack summary to this file")
     args = parser.parse_args()
 
     if args.hours < 1:
@@ -817,6 +873,12 @@ def main():
         print(f"Report written to {args.output}")
     else:
         print(report)
+
+    if args.slack_summary:
+        slack = format_slack_summary(report_data, hours=args.hours)
+        with open(args.slack_summary, "w") as f:
+            f.write(slack)
+        print(f"Slack summary written to {args.slack_summary}")
 
     # Write to GitHub Actions step summary if available
     step_summary = os.environ.get("GITHUB_STEP_SUMMARY")

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -62,6 +62,8 @@ def get_workflow_runs(repo, hours=24):
             [
                 "api",
                 f"/repos/{repo}/actions/runs",
+                "--method",
+                "GET",
                 "-f",
                 f"per_page={per_page}",
                 "-f",
@@ -113,6 +115,8 @@ def get_jobs_for_run(repo, run_id):
             [
                 "api",
                 f"/repos/{repo}/actions/runs/{run_id}/jobs",
+                "--method",
+                "GET",
                 "-f",
                 "filter=all",
                 "-f",

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -10,6 +10,7 @@ import argparse
 import json
 import os
 import random
+import re
 import subprocess
 import time
 from collections import defaultdict
@@ -152,7 +153,7 @@ def get_jobs_for_run(repo, run_id):
     return jobs
 
 
-def get_runners(repo, online_only=True):
+def get_runners(repo, online_only=False):
     """Fetch self-hosted runners for the repo; degrades gracefully if no admin access."""
     try:
         output = run_gh_command(
@@ -174,6 +175,23 @@ def get_runners(repo, online_only=True):
                     runners.append(runner)
                 except json.JSONDecodeError:
                     continue
+
+        # Infer labels from runner name when labels array is empty
+        for runner in runners:
+            labels = {lbl["name"] for lbl in runner.get("labels", [])}
+            meaningful = labels - DEFAULT_LABELS_TO_IGNORE - GITHUB_HOSTED_LABELS
+            if not meaningful:
+                name = runner.get("name", "")
+                m = re.match(r"^(arc-runner-v6e-\d+)-", name)
+                if m:
+                    inferred = m.group(1)
+                elif "cpu-runner" in name or name.startswith("runnerdeploy-"):
+                    inferred = "arc-runner-cpu"
+                else:
+                    inferred = None
+                if inferred:
+                    runner.setdefault("labels", []).append({"name": inferred})
+
         return runners
     except subprocess.CalledProcessError as e:
         err_str = str(e.stderr)
@@ -188,6 +206,26 @@ def get_runners(repo, online_only=True):
             )
             return []
         raise
+
+
+def get_fleet_status(runners):
+    """Aggregate per-label fleet status from runner list."""
+    status = defaultdict(lambda: {"total": 0, "online": 0, "offline": 0, "busy": 0, "idle": 0})
+    for runner in runners:
+        labels = {lbl["name"] for lbl in runner.get("labels", [])}
+        meaningful = labels - DEFAULT_LABELS_TO_IGNORE - GITHUB_HOSTED_LABELS
+        for lbl in meaningful:
+            s = status[lbl]
+            s["total"] += 1
+            if runner.get("status") == "online":
+                s["online"] += 1
+                if runner.get("busy"):
+                    s["busy"] += 1
+                else:
+                    s["idle"] += 1
+            else:
+                s["offline"] += 1
+    return dict(status)
 
 
 def parse_time(time_str):
@@ -276,6 +314,13 @@ def _likely_no_gpu_jobs(workflow_name):
     return any(hint in name_lower for hint in _NON_GPU_WORKFLOW_HINTS)
 
 
+def _percentile(sorted_values, p):
+    if not sorted_values:
+        return 0.0
+    idx = int(len(sorted_values) * p / 100)
+    return sorted_values[min(idx, len(sorted_values) - 1)]
+
+
 def calculate_utilization(repo, hours=24, runner_filter=None):
     """
     Main calculation: fetch runs and jobs, aggregate per-label utilization,
@@ -291,6 +336,8 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
     # Fetch runners once; fall back gracefully
     runners_list = get_runners(repo, online_only=False)
 
+    fleet_status = get_fleet_status(runners_list)
+
     # Build label -> runner count map
     label_runner_count = defaultdict(int)
     for runner in runners_list:
@@ -305,22 +352,31 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
     label_intervals = defaultdict(list)
     label_jobs = defaultdict(list)
     label_queue_waits = defaultdict(list)
+    label_job_durations = defaultdict(list)
+    label_conclusions = defaultdict(list)
+    all_jobs_enriched = []
+    workflow_stats = defaultdict(
+        lambda: defaultdict(lambda: {"job_count": 0, "total_duration": 0.0})
+    )
+    hourly_buckets = defaultdict(int)
 
     def fetch_run_jobs(run):
-        if _likely_no_gpu_jobs(run.get("name", "")):
-            return run["id"], []
+        wf_name = run.get("name", "")
+        run_url = run.get("html_url", "")
+        if _likely_no_gpu_jobs(wf_name):
+            return run["id"], wf_name, run_url, []
         try:
-            return run["id"], get_jobs_for_run(repo, run["id"])
+            return run["id"], wf_name, run_url, get_jobs_for_run(repo, run["id"])
         except Exception as e:
             print(f"Warning: failed to fetch jobs for run {run['id']}: {e}")
-            return run["id"], None
+            return run["id"], wf_name, run_url, None
 
     print("Fetching job details (parallel, max 4 workers)...")
     with ThreadPoolExecutor(max_workers=4) as executor:
         futures = {executor.submit(fetch_run_jobs, run): run for run in runs}
         for future in as_completed(futures):
             try:
-                run_id, jobs = future.result()
+                run_id, wf_name, run_url, jobs = future.result()
             except Exception as e:
                 print(f"Warning: unexpected error fetching jobs: {e}")
                 fetch_failures += 1
@@ -345,10 +401,11 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
                 if not started or not completed or completed <= started:
                     continue
 
+                wait_s = 0.0
                 if created and started > created:
-                    wait_seconds = (started - created).total_seconds()
+                    wait_s = (started - created).total_seconds()
                     for lbl in meaningful:
-                        label_queue_waits[lbl].append(wait_seconds)
+                        label_queue_waits[lbl].append(wait_s)
 
                 eff_start = max(started, window_start)
                 eff_end = min(completed, window_end)
@@ -358,6 +415,27 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
                 for lbl in meaningful:
                     label_intervals[lbl].append((eff_start, eff_end))
                     label_jobs[lbl].append(job)
+
+                duration_s = (eff_end - eff_start).total_seconds()
+                for lbl in meaningful:
+                    label_job_durations[lbl].append(duration_s)
+                    label_conclusions[lbl].append(job.get("conclusion", "unknown"))
+                    workflow_stats[wf_name][lbl]["job_count"] += 1
+                    workflow_stats[wf_name][lbl]["total_duration"] += duration_s
+
+                all_jobs_enriched.append(
+                    {
+                        "workflow": wf_name,
+                        "job_name": job.get("name", ""),
+                        "duration": duration_s,
+                        "wait": wait_s,
+                        "conclusion": job.get("conclusion", "unknown"),
+                        "label": ", ".join(sorted(meaningful)),
+                        "url": job.get("html_url", run_url),
+                    }
+                )
+
+                hourly_buckets[started.hour] += 1
 
     fetch_failure_pct = (fetch_failures / total_runs * 100.0) if total_runs > 0 else 0.0
     window_seconds = (window_end - window_start).total_seconds()
@@ -394,9 +472,13 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
             num_runners,
         )
 
-        waits = label_queue_waits.get(label, [])
-        avg_queue_wait = sum(waits) / len(waits) if waits else 0.0
-        max_queue_wait = max(waits) if waits else 0.0
+        waits = sorted(label_queue_waits.get(label, []))
+        durations = sorted(label_job_durations.get(label, []))
+        conclusions = label_conclusions.get(label, [])
+        success_count = conclusions.count("success")
+        failure_count = conclusions.count("failure")
+        cancelled_count = conclusions.count("cancelled")
+        total_concluded = len(conclusions)
 
         results[label] = {
             "num_runners": num_runners,
@@ -406,11 +488,28 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
             "total_job_seconds": total_job_seconds,
             "job_count": len(label_jobs.get(label, [])),
             "concurrency": concurrency,
-            "avg_queue_wait": avg_queue_wait,
-            "max_queue_wait": max_queue_wait,
+            "avg_queue_wait": sum(waits) / len(waits) if waits else 0.0,
+            "max_queue_wait": max(waits) if waits else 0.0,
+            "wait_p50": _percentile(waits, 50),
+            "wait_p95": _percentile(waits, 95),
+            "duration_p50": _percentile(durations, 50),
+            "duration_p95": _percentile(durations, 95),
+            "duration_p99": _percentile(durations, 99),
+            "duration_max": max(durations) if durations else 0.0,
+            "success_count": success_count,
+            "failure_count": failure_count,
+            "cancelled_count": cancelled_count,
+            "total_concluded": total_concluded,
         }
 
-    return results, fetch_failure_pct
+    return {
+        "per_label": results,
+        "fleet_status": fleet_status,
+        "fetch_failure_pct": fetch_failure_pct,
+        "all_jobs": all_jobs_enriched,
+        "workflow_stats": dict(workflow_stats),
+        "hourly_buckets": dict(hourly_buckets),
+    }
 
 
 def _format_duration(seconds):
@@ -424,8 +523,15 @@ def _format_duration(seconds):
     return f"{hours:.1f}h"
 
 
-def format_report(results, hours, fetch_failure_pct=0.0):
+def format_report(report_data, hours):
     """Format the utilization results as a Markdown report."""
+    results = report_data["per_label"]
+    fleet_status = report_data["fleet_status"]
+    fetch_failure_pct = report_data["fetch_failure_pct"]
+    all_jobs = report_data["all_jobs"]
+    workflow_stats = report_data["workflow_stats"]
+    hourly_buckets = report_data["hourly_buckets"]
+
     lines = []
     lines.append(f"# Runner Utilization Report (Past {hours} Hours)")
     lines.append("")
@@ -439,6 +545,24 @@ def format_report(results, hours, fetch_failure_pct=0.0):
             f"> **Warning:** {fetch_failure_pct:.1f}% of workflow runs could not be fetched (API errors). Results may be incomplete."
         )
         lines.append("")
+
+    if not results and not fleet_status:
+        lines.append("No runner activity found in the specified time window.")
+        return "\n".join(lines)
+
+    # Fleet Status
+    lines.append("## Fleet Status")
+    lines.append("")
+    if fleet_status:
+        lines.append("| Runner Label | Total | Online | Offline | Busy | Idle |")
+        lines.append("|---|---|---|---|---|---|")
+        for label, s in sorted(fleet_status.items()):
+            lines.append(
+                f"| `{label}` | {s['total']} | {s['online']} | {s['offline']} | {s['busy']} | {s['idle']} |"
+            )
+    else:
+        lines.append("No runner data available (admin token required).")
+    lines.append("")
 
     if not results:
         lines.append("No runner activity found in the specified time window.")
@@ -471,9 +595,9 @@ def format_report(results, hours, fetch_failure_pct=0.0):
     lines.append("## Concurrency Analysis")
     lines.append("")
     lines.append(
-        "| Runner Label | Peak Concurrent | Avg Concurrent | Saturation | Peak Queue | Avg Wait | Max Wait |"
+        "| Runner Label | Peak Concurrent | Avg Concurrent | Saturation | Peak Queue | Wait P50 | Wait P95 | Wait Max |"
     )
-    lines.append("|---|---|---|---|---|---|---|")
+    lines.append("|---|---|---|---|---|---|---|---|")
 
     for label, data in sorted(results.items()):
         conc = data["concurrency"]
@@ -483,12 +607,114 @@ def format_report(results, hours, fetch_failure_pct=0.0):
         queue = conc["peak_queue"]
         sat_str = f"{sat:.1f}%" if sat is not None else "N/A"
         queue_str = str(queue) if queue is not None else "N/A"
-        avg_wait = _format_duration(data["avg_queue_wait"])
+        wait_p50 = _format_duration(data["wait_p50"])
+        wait_p95 = _format_duration(data["wait_p95"])
         max_wait = _format_duration(data["max_queue_wait"])
 
         lines.append(
-            f"| `{label}` | {peak} | {avg:.2f} | {sat_str} | {queue_str} | {avg_wait} | {max_wait} |"
+            f"| `{label}` | {peak} | {avg:.2f} | {sat_str} | {queue_str} | {wait_p50} | {wait_p95} | {max_wait} |"
         )
+
+    lines.append("")
+
+    # Job Duration
+    lines.append("## Job Duration")
+    lines.append("")
+    lines.append("| Runner Label | Jobs | P50 | P95 | P99 | Max |")
+    lines.append("|---|---|---|---|---|---|")
+
+    for label, data in sorted(results.items()):
+        job_count = data["job_count"]
+        p50 = _format_duration(data["duration_p50"])
+        p95 = _format_duration(data["duration_p95"])
+        p99 = _format_duration(data["duration_p99"])
+        dmax = _format_duration(data["duration_max"])
+        lines.append(f"| `{label}` | {job_count} | {p50} | {p95} | {p99} | {dmax} |")
+
+    lines.append("")
+
+    # Top 10 Workflows by Runner Time
+    lines.append("## Top 10 Workflows by Runner Time")
+    lines.append("")
+    lines.append("| # | Workflow | Jobs | Total Time | Avg Duration | Runner Labels |")
+    lines.append("|---|---|---|---|---|---|")
+
+    # Aggregate across labels per workflow
+    wf_aggregates = {}
+    for wf_name, label_data in workflow_stats.items():
+        total_jobs = sum(v["job_count"] for v in label_data.values())
+        total_duration = sum(v["total_duration"] for v in label_data.values())
+        labels_used = sorted(label_data.keys())
+        wf_aggregates[wf_name] = {
+            "total_jobs": total_jobs,
+            "total_duration": total_duration,
+            "labels": labels_used,
+        }
+
+    sorted_wfs = sorted(wf_aggregates.items(), key=lambda x: x[1]["total_duration"], reverse=True)
+    for rank, (wf_name, agg) in enumerate(sorted_wfs[:10], start=1):
+        avg_duration = agg["total_duration"] / agg["total_jobs"] if agg["total_jobs"] > 0 else 0.0
+        labels_str = ", ".join(agg["labels"])
+        lines.append(
+            f"| {rank} | {wf_name} | {agg['total_jobs']} | {_format_duration(agg['total_duration'])} | {_format_duration(avg_duration)} | {labels_str} |"
+        )
+
+    lines.append("")
+
+    # Top 10 Slowest Jobs
+    lines.append("## Top 10 Slowest Jobs")
+    lines.append("")
+    lines.append("| # | Workflow | Job | Duration | Wait | Runner Label | Link |")
+    lines.append("|---|---|---|---|---|---|---|")
+
+    sorted_jobs = sorted(all_jobs, key=lambda j: j["duration"], reverse=True)
+    for rank, job in enumerate(sorted_jobs[:10], start=1):
+        lines.append(
+            f"| {rank} | {job['workflow']} | {job['job_name']} | {_format_duration(job['duration'])} | {_format_duration(job['wait'])} | {job['label']} | [Run]({job['url']}) |"
+        )
+
+    lines.append("")
+
+    # Job Success Rate
+    lines.append("## Job Success Rate")
+    lines.append("")
+    lines.append("| Runner Label | Total | Success | Failure | Cancelled | Success Rate |")
+    lines.append("|---|---|---|---|---|---|")
+
+    for label, data in sorted(results.items()):
+        total = data["total_concluded"]
+        success = data["success_count"]
+        failure = data["failure_count"]
+        cancelled = data["cancelled_count"]
+        rate_str = f"{success / total * 100:.1f}%" if total > 0 else "N/A"
+        lines.append(f"| `{label}` | {total} | {success} | {failure} | {cancelled} | {rate_str} |")
+
+    lines.append("")
+
+    # Failed Jobs (max 20)
+    lines.append("## Failed Jobs")
+    lines.append("")
+    failed_jobs = [j for j in all_jobs if j["conclusion"] == "failure"]
+    if failed_jobs:
+        failed_jobs_sorted = sorted(failed_jobs, key=lambda j: j["duration"], reverse=True)
+        lines.append("| Workflow | Job | Conclusion | Duration | Runner Label | Link |")
+        lines.append("|---|---|---|---|---|---|")
+        for job in failed_jobs_sorted[:20]:
+            lines.append(
+                f"| {job['workflow']} | {job['job_name']} | {job['conclusion']} | {_format_duration(job['duration'])} | {job['label']} | [Run]({job['url']}) |"
+            )
+    else:
+        lines.append("No failed jobs in this period.")
+
+    lines.append("")
+
+    # Hourly Distribution
+    lines.append("## Hourly Distribution (UTC)")
+    lines.append("")
+    lines.append("| Hour | Jobs Started |")
+    lines.append("|---|---|")
+    for h in range(24):
+        lines.append(f"| {h:02d}:00 | {hourly_buckets.get(h, 0)} |")
 
     lines.append("")
 
@@ -497,9 +723,15 @@ def format_report(results, hours, fetch_failure_pct=0.0):
     lines.append("")
 
     has_recommendation = False
+
+    # Grand total across all workflows for dominance check
+    grand_total_duration = sum(agg["total_duration"] for agg in wf_aggregates.values())
+
     for label, data in sorted(results.items()):
         util = data["utilization_pct"]
         conc = data["concurrency"]
+        total_concluded = data["total_concluded"]
+        failure_count = data["failure_count"]
 
         if util is not None and util > 80:
             lines.append(
@@ -517,6 +749,35 @@ def format_report(results, hours, fetch_failure_pct=0.0):
                 f"- **`{label}`**: Peak queue depth of {conc['peak_queue']} job(s) detected. Jobs had to wait for a free runner."
             )
             has_recommendation = True
+
+        if total_concluded > 5 and failure_count / total_concluded > 0.2:
+            lines.append(
+                f"- **`{label}`**: High failure rate ({failure_count}/{total_concluded} jobs, {failure_count / total_concluded * 100:.1f}%). Investigate job failures."
+            )
+            has_recommendation = True
+
+        if data["wait_p95"] > 600:
+            lines.append(
+                f"- **`{label}`**: Long queue wait detected (P95 wait = {_format_duration(data['wait_p95'])}). Consider scaling runners."
+            )
+            has_recommendation = True
+
+    # Fleet offline runner warnings
+    for label, s in sorted(fleet_status.items()):
+        if s["offline"] > 0:
+            lines.append(
+                f"- **`{label}`**: {s['offline']} runner(s) are offline. Check runner health."
+            )
+            has_recommendation = True
+
+    # Workflow dominance warning
+    if grand_total_duration > 0:
+        for wf_name, agg in sorted_wfs:
+            if agg["total_duration"] > 0.5 * grand_total_duration:
+                lines.append(
+                    f"- **Workflow `{wf_name}`** accounts for more than 50% of total runner time ({_format_duration(agg['total_duration'])} of {_format_duration(grand_total_duration)}). Review if this is expected."
+                )
+                has_recommendation = True
 
     if not has_recommendation:
         lines.append(
@@ -542,13 +803,13 @@ def main():
     if args.hours < 1:
         parser.error("--hours must be a positive integer")
 
-    results, fetch_failure_pct = calculate_utilization(
+    report_data = calculate_utilization(
         repo=args.repo,
         hours=args.hours,
         runner_filter=args.filter,
     )
 
-    report = format_report(results, hours=args.hours, fetch_failure_pct=fetch_failure_pct)
+    report = format_report(report_data, hours=args.hours)
 
     if args.output:
         with open(args.output, "w") as f:

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -20,7 +20,7 @@ DEFAULT_LABELS_TO_IGNORE = {"self-hosted", "Linux", "X64", "ARM64"}
 GITHUB_HOSTED_LABELS = {"ubuntu-latest", "ubuntu-22.04", "ubuntu-24.04"}
 
 
-_NON_RETRYABLE_PATTERNS = ("401", "403", "404", "422", "not found", "Must have admin")
+_NON_RETRYABLE_PATTERNS = ("401", "403", "404", "422", "not found", "must have admin")
 
 
 def run_gh_command(args, max_retries=5):
@@ -39,7 +39,7 @@ def run_gh_command(args, max_retries=5):
             err_lower = err.lower()
             if "rate limit" in err_lower:
                 pass  # fall through to backoff
-            elif any(p in err for p in _NON_RETRYABLE_PATTERNS):
+            elif any(p in err_lower for p in _NON_RETRYABLE_PATTERNS):
                 raise
             if attempt == max_retries - 1:
                 raise
@@ -66,6 +66,10 @@ def get_workflow_runs(repo, hours=24):
                 f"per_page={per_page}",
                 "-f",
                 f"page={page}",
+                "-f",
+                "sort=created",
+                "-f",
+                "direction=desc",
                 "--jq",
                 ".workflow_runs[]",
             ]
@@ -174,7 +178,7 @@ def get_runners(repo, online_only=True):
                 "Warning: GitHub API rate limit hit while listing runners; runner count will be unavailable."
             )
             return []
-        if "403" in err_str or "Must have admin rights" in err_str:
+        if "403" in err_str or "must have admin" in err_str.lower():
             print(
                 "Note: No admin access to list runners; runner count will be estimated from job data."
             )
@@ -219,9 +223,7 @@ def calculate_concurrency_metrics(jobs, window_start, window_end, num_runners):
             "peak_queue": None,
         }
 
-    # At equal timestamps, process end events (delta=-1) before start events
-    # (delta=+1) to avoid transiently inflating the concurrent count.
-    events.sort(key=lambda e: (e[0], -e[1]))
+    events.sort(key=lambda e: (e[0], e[1]))
 
     current = 0
     peak = 0
@@ -296,10 +298,9 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
     fetch_failures = 0
     total_runs = len(runs)
 
-    # Per-label: list of (started_at, completed_at) intervals
     label_intervals = defaultdict(list)
-    # Per-label: all jobs (for concurrency sweep)
     label_jobs = defaultdict(list)
+    label_queue_waits = defaultdict(list)
 
     def fetch_run_jobs(run):
         if _likely_no_gpu_jobs(run.get("name", "")):
@@ -336,9 +337,15 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
 
                 started = parse_time(job.get("started_at"))
                 completed = parse_time(job.get("completed_at"))
+                created = parse_time(job.get("created_at"))
                 if not started or not completed or completed <= started:
                     continue
-                # Clamp to window
+
+                if created and started > created:
+                    wait_seconds = (started - created).total_seconds()
+                    for lbl in meaningful:
+                        label_queue_waits[lbl].append(wait_seconds)
+
                 eff_start = max(started, window_start)
                 eff_end = min(completed, window_end)
                 if eff_start >= eff_end:
@@ -369,15 +376,12 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
                 merged.append((start, end))
 
         busy_seconds = sum((e - s).total_seconds() for s, e in merged)
+        total_job_seconds = sum((e - s).total_seconds() for s, e in intervals)
 
-        # Capacity: num_runners * window_seconds (0 if unknown)
         capacity_seconds = num_runners * window_seconds if num_runners > 0 else 0.0
         utilization_pct = (
-            (busy_seconds / capacity_seconds * 100.0) if capacity_seconds > 0 else None
+            (total_job_seconds / capacity_seconds * 100.0) if capacity_seconds > 0 else None
         )
-
-        # Total job seconds (sum of all individual job durations, not merged)
-        total_job_seconds = sum((e - s).total_seconds() for s, e in intervals)
 
         concurrency = calculate_concurrency_metrics(
             label_jobs.get(label, []),
@@ -385,6 +389,10 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
             window_end,
             num_runners,
         )
+
+        waits = label_queue_waits.get(label, [])
+        avg_queue_wait = sum(waits) / len(waits) if waits else 0.0
+        max_queue_wait = max(waits) if waits else 0.0
 
         results[label] = {
             "num_runners": num_runners,
@@ -394,9 +402,22 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
             "total_job_seconds": total_job_seconds,
             "job_count": len(label_jobs.get(label, [])),
             "concurrency": concurrency,
+            "avg_queue_wait": avg_queue_wait,
+            "max_queue_wait": max_queue_wait,
         }
 
     return results, fetch_failure_pct
+
+
+def _format_duration(seconds):
+    """Format seconds into a human-readable string (e.g. '2m 30s', '1h 5m')."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes = seconds / 60
+    if minutes < 60:
+        return f"{minutes:.1f}m"
+    hours = minutes / 60
+    return f"{hours:.1f}h"
 
 
 def format_report(results, hours, fetch_failure_pct=0.0):
@@ -445,8 +466,10 @@ def format_report(results, hours, fetch_failure_pct=0.0):
     # Concurrency analysis
     lines.append("## Concurrency Analysis")
     lines.append("")
-    lines.append("| Runner Label | Peak Concurrent | Avg Concurrent | Saturation | Peak Queue |")
-    lines.append("|---|---|---|---|---|")
+    lines.append(
+        "| Runner Label | Peak Concurrent | Avg Concurrent | Saturation | Peak Queue | Avg Wait | Max Wait |"
+    )
+    lines.append("|---|---|---|---|---|---|---|")
 
     for label, data in sorted(results.items()):
         conc = data["concurrency"]
@@ -456,8 +479,12 @@ def format_report(results, hours, fetch_failure_pct=0.0):
         queue = conc["peak_queue"]
         sat_str = f"{sat:.1f}%" if sat is not None else "N/A"
         queue_str = str(queue) if queue is not None else "N/A"
+        avg_wait = _format_duration(data["avg_queue_wait"])
+        max_wait = _format_duration(data["max_queue_wait"])
 
-        lines.append(f"| `{label}` | {peak} | {avg:.2f} | {sat_str} | {queue_str} |")
+        lines.append(
+            f"| `{label}` | {peak} | {avg:.2f} | {sat_str} | {queue_str} | {avg_wait} | {max_wait} |"
+        )
 
     lines.append("")
 
@@ -507,6 +534,9 @@ def main():
     )
     parser.add_argument("--output", type=str, help="Output file path (default: stdout)")
     args = parser.parse_args()
+
+    if args.hours < 1:
+        parser.error("--hours must be a positive integer")
 
     results, fetch_failure_pct = calculate_utilization(
         repo=args.repo,

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -34,6 +34,7 @@ def run_gh_command(args, max_retries=5):
             wait = (2**attempt) + random.uniform(0, 1)
             print(f"Retry {attempt + 1}/{max_retries} in {wait:.1f}s: {e.stderr.strip()}")
             time.sleep(wait)
+    raise RuntimeError("run_gh_command: exhausted retries without raising")
 
 
 def _paginated_gh_api(endpoint, params=None, jq_filter=None, stop_fn=None):
@@ -68,7 +69,7 @@ def _paginated_gh_api(endpoint, params=None, jq_filter=None, stop_fn=None):
                 continue
             if stop_fn and stop_fn(item):
                 stop = True
-                continue
+                break
             all_items.append(item)
         if stop or page_count < per_page:
             break
@@ -186,6 +187,7 @@ def calculate_concurrency_metrics(jobs, window_start, window_end, num_runners):
 
 
 def _percentile(sorted_values, p):
+    """Floor-index percentile: P95 equals max for samples < 20."""
     if not sorted_values:
         return 0.0
     return sorted_values[min(int(len(sorted_values) * p / 100), len(sorted_values) - 1)]
@@ -314,12 +316,6 @@ def calculate_utilization(repo, hours=24, runner_filter=None):
             continue
         intervals = label_intervals.get(label, [])
         num_runners = label_runner_count.get(label, 0)
-        merged = []
-        for s, e in sorted(intervals):
-            if merged and s <= merged[-1][1]:
-                merged[-1] = (merged[-1][0], max(merged[-1][1], e))
-            else:
-                merged.append((s, e))
         total_job_s = sum((e - s).total_seconds() for s, e in intervals)
         cap_s = num_runners * window_seconds if num_runners > 0 else 0.0
         waits = sorted(label_queue_waits.get(label, []))
@@ -561,7 +557,11 @@ def format_slack_summary(report_data, hours, run_url=""):
         lines.append("No issues detected.")
     if run_url:
         lines += ["", f"<{run_url}|View full report>"]
-    return "\n".join(lines)
+    text = "\n".join(lines)
+    # Slack Block Kit section text has a 3000 character limit
+    if len(text) > 2900:
+        text = text[:2900] + "\n… (truncated)"
+    return text
 
 
 def main():

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -187,7 +187,9 @@ def calculate_concurrency_metrics(jobs, window_start, window_end, num_runners):
             "peak_queue": 0,
         }
 
-    events.sort(key=lambda e: (e[0], e[1]))
+    # At equal timestamps, process end events (delta=-1) before start events
+    # (delta=+1) to avoid transiently inflating the concurrent count.
+    events.sort(key=lambda e: (e[0], -e[1]))
 
     current = 0
     peak = 0

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -713,14 +713,11 @@ def format_report(report_data, hours):
     # Hourly Distribution
     lines.append("## Hourly Distribution (UTC)")
     lines.append("")
-    active_hours = [(h, hourly_buckets[h]) for h in range(24) if hourly_buckets.get(h, 0) > 0]
-    if active_hours:
-        lines.append("| Hour | Jobs Started |")
-        lines.append("|---|---|")
-        for h, count in active_hours:
-            lines.append(f"| {h:02d}:00 | {count} |")
-    else:
-        lines.append("No jobs started in this period.")
+    lines.append("| Period (UTC) | Jobs Started |")
+    lines.append("|---|---|")
+    for start, end in [(0, 6), (6, 12), (12, 18), (18, 24)]:
+        count = sum(hourly_buckets.get(h, 0) for h in range(start, end))
+        lines.append(f"| {start:02d}:00–{end - 1:02d}:59 | {count} |")
 
     lines.append("")
 
@@ -728,9 +725,22 @@ def format_report(report_data, hours):
     lines.append("## Recommendations")
     lines.append("")
 
-    has_recommendation = False
+    recs = _generate_recommendations(results, fleet_status, wf_aggregates)
+    if recs:
+        for r in recs:
+            lines.append(f"- {r}")
+    else:
+        lines.append(
+            "No immediate action required. All runner labels appear within normal utilization bounds."
+        )
 
-    # Grand total across all workflows for dominance check
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _generate_recommendations(results, fleet_status, wf_aggregates):
+    """Generate recommendation strings shared by full report and Slack summary."""
+    recs = []
     grand_total_duration = sum(agg["total_duration"] for agg in wf_aggregates.values())
 
     for label, data in sorted(results.items()):
@@ -740,105 +750,133 @@ def format_report(report_data, hours):
         failure_count = data["failure_count"]
 
         if util is not None and util > 80:
-            lines.append(
-                f"- **`{label}`**: High utilization ({util:.1f}%). Consider adding more runners to reduce queue time."
+            recs.append(
+                f"**`{label}`**: High utilization ({util:.1f}%). Consider adding more runners to reduce queue time."
             )
-            has_recommendation = True
         elif util is not None and util < 10 and data["job_count"] > 0:
-            lines.append(
-                f"- **`{label}`**: Low utilization ({util:.1f}%). Runner capacity may be over-provisioned."
+            recs.append(
+                f"**`{label}`**: Low utilization ({util:.1f}%). Runner capacity may be over-provisioned."
             )
-            has_recommendation = True
 
         if conc["peak_queue"] is not None and conc["peak_queue"] > 0:
-            lines.append(
-                f"- **`{label}`**: Peak queue depth of {conc['peak_queue']} job(s) detected. Jobs had to wait for a free runner."
+            recs.append(
+                f"**`{label}`**: Peak queue depth of {conc['peak_queue']} job(s) detected. Jobs had to wait for a free runner."
             )
-            has_recommendation = True
 
         if total_concluded > 5 and failure_count / total_concluded > 0.2:
-            lines.append(
-                f"- **`{label}`**: High failure rate ({failure_count}/{total_concluded} jobs, {failure_count / total_concluded * 100:.1f}%). Investigate job failures."
+            recs.append(
+                f"**`{label}`**: High failure rate ({failure_count}/{total_concluded} jobs, {failure_count / total_concluded * 100:.1f}%). Investigate job failures."
             )
-            has_recommendation = True
 
         if data["wait_p95"] > 600:
-            lines.append(
-                f"- **`{label}`**: Long queue wait detected (P95 wait = {_format_duration(data['wait_p95'])}). Consider scaling runners."
+            recs.append(
+                f"**`{label}`**: Long queue wait detected (P95 wait = {_format_duration(data['wait_p95'])}). Consider scaling runners."
             )
-            has_recommendation = True
 
-    # Fleet offline runner warnings
     for label, s in sorted(fleet_status.items()):
         if s["offline"] > 0:
-            lines.append(
-                f"- **`{label}`**: {s['offline']} runner(s) are offline. Check runner health."
+            recs.append(
+                f"**`{label}`**: {s['offline']} runner(s) are offline. Check runner health."
             )
-            has_recommendation = True
 
-    # Workflow dominance warning
     if grand_total_duration > 0:
+        sorted_wfs = sorted(
+            wf_aggregates.items(), key=lambda x: x[1]["total_duration"], reverse=True
+        )
         for wf_name, agg in sorted_wfs:
             if agg["total_duration"] > 0.5 * grand_total_duration:
-                lines.append(
-                    f"- **Workflow `{wf_name}`** accounts for more than 50% of total runner time ({_format_duration(agg['total_duration'])} of {_format_duration(grand_total_duration)}). Review if this is expected."
+                pct = agg["total_duration"] / grand_total_duration * 100
+                recs.append(
+                    f"Workflow **`{wf_name}`** accounts for {pct:.0f}% of total runner time ({_format_duration(agg['total_duration'])} of {_format_duration(grand_total_duration)})."
                 )
-                has_recommendation = True
 
-    if not has_recommendation:
-        lines.append(
-            "No immediate action required. All runner labels appear within normal utilization bounds."
-        )
-
-    lines.append("")
-    return "\n".join(lines)
+    return recs
 
 
-def format_slack_summary(report_data, hours):
-    """Format a compact plain-text summary for Slack (no markdown tables)."""
+def format_slack_summary(report_data, hours, run_url=""):
+    """Format a Slack mrkdwn summary with fleet status, utilization, and recommendations."""
     results = report_data["per_label"]
     fleet_status = report_data["fleet_status"]
-    recommendations = []
+    workflow_stats = report_data["workflow_stats"]
 
-    lines = [f"*Runner Utilization Report (Past {hours} Hours)*", ""]
+    lines = [f"*Runner Utilization Report (Past {hours} Hours)*"]
 
-    for label in sorted(set(list(results.keys()) + list(fleet_status.keys()))):
-        parts = [f"• *{label}*:"]
-        fs = fleet_status.get(label)
-        if fs:
-            parts.append(f"{fs['total']} runners ({fs['online']} online, {fs['busy']} busy)")
-        data = results.get(label)
-        if data:
-            parts.append(f"{data['job_count']} jobs")
-            util = data["utilization_pct"]
-            if util is not None:
-                parts.append(f"utilization {util:.1f}%")
-            if data["wait_p95"] > 0:
-                parts.append(f"wait P95 {_format_duration(data['wait_p95'])}")
-            rate = (
-                f"{data['success_count'] / data['total_concluded'] * 100:.0f}%"
-                if data["total_concluded"] > 0
-                else "N/A"
+    # Fleet Status
+    lines.append("")
+    lines.append("*Fleet Status*")
+    if fleet_status:
+        for label, s in sorted(fleet_status.items()):
+            lines.append(
+                f"• `{label}`: {s['total']} runners ({s['online']} online, {s['busy']} busy)"
             )
-            parts.append(f"success rate {rate}")
-        lines.append(" | ".join(parts))
-
-    for label, data in sorted(results.items()):
-        if data["wait_p95"] > 600:
-            recommendations.append(
-                f"⚠ {label}: P95 queue wait {_format_duration(data['wait_p95'])}"
-            )
-        if data["total_concluded"] > 5 and data["failure_count"] / data["total_concluded"] > 0.2:
-            recommendations.append(
-                f"⚠ {label}: {data['failure_count']}/{data['total_concluded']} jobs failed"
-            )
-
-    if recommendations:
-        lines.append("")
-        lines.extend(recommendations)
     else:
+        lines.append("Fleet data unavailable (admin token required)")
+
+    if not results:
         lines.append("")
-        lines.append("✓ No issues detected")
+        lines.append("No runner activity in this period.")
+        if run_url:
+            lines.append("")
+            lines.append(f"<{run_url}|View full report>")
+        return "\n".join(lines)
+
+    # Utilization
+    lines.append("")
+    lines.append("*Utilization*")
+    util_parts = []
+    for label, data in sorted(results.items()):
+        util = data["utilization_pct"]
+        util_parts.append(f"`{label}`: {util:.1f}%" if util is not None else f"`{label}`: N/A")
+    lines.append("• " + " | ".join(util_parts))
+
+    # Queue Wait P95
+    lines.append("")
+    lines.append("*Queue Wait (P95)*")
+    wait_parts = []
+    for label, data in sorted(results.items()):
+        wait_parts.append(f"`{label}`: {_format_duration(data['wait_p95'])}")
+    lines.append("• " + " | ".join(wait_parts))
+
+    # Success Rate
+    lines.append("")
+    lines.append("*Success Rate*")
+    rate_parts = []
+    for label, data in sorted(results.items()):
+        if data["total_concluded"] > 0:
+            rate = data["success_count"] / data["total_concluded"] * 100
+            failures = data["failure_count"]
+            part = f"`{label}`: {rate:.1f}%"
+            if failures > 0:
+                part += f" ({failures} failures)"
+            rate_parts.append(part)
+        else:
+            rate_parts.append(f"`{label}`: N/A")
+    lines.append("• " + " | ".join(rate_parts))
+
+    # Recommendations
+    wf_aggregates = {}
+    for wf_name, label_data in workflow_stats.items():
+        total_jobs = sum(v["job_count"] for v in label_data.values())
+        total_duration = sum(v["total_duration"] for v in label_data.values())
+        wf_aggregates[wf_name] = {
+            "total_jobs": total_jobs,
+            "total_duration": total_duration,
+            "labels": sorted(label_data.keys()),
+        }
+
+    recs = _generate_recommendations(results, fleet_status, wf_aggregates)
+    lines.append("")
+    if recs:
+        lines.append("*Recommendations*")
+        for r in recs:
+            clean = r.replace("**", "").replace("`", "`")
+            lines.append(f"• {clean}")
+    else:
+        lines.append("No issues detected.")
+
+    if run_url:
+        lines.append("")
+        lines.append(f"<{run_url}|View full report>")
 
     return "\n".join(lines)
 
@@ -853,7 +891,10 @@ def main():
         "--filter", type=str, dest="filter", help="Filter runner labels (substring match)"
     )
     parser.add_argument("--output", type=str, help="Output file path (default: stdout)")
-    parser.add_argument("--slack-summary", type=str, help="Write Slack summary to this file")
+    parser.add_argument("--slack-output", type=str, help="Slack summary output file path")
+    parser.add_argument(
+        "--run-url", type=str, default="", help="GitHub Actions run URL for Slack link"
+    )
     args = parser.parse_args()
 
     if args.hours < 1:
@@ -874,11 +915,11 @@ def main():
     else:
         print(report)
 
-    if args.slack_summary:
-        slack = format_slack_summary(report_data, hours=args.hours)
-        with open(args.slack_summary, "w") as f:
-            f.write(slack)
-        print(f"Slack summary written to {args.slack_summary}")
+    if args.slack_output:
+        summary = format_slack_summary(report_data, hours=args.hours, run_url=args.run_url)
+        with open(args.slack_output, "w") as f:
+            f.write(summary)
+        print(f"Slack summary written to {args.slack_output}")
 
     # Write to GitHub Actions step summary if available
     step_summary = os.environ.get("GITHUB_STEP_SUMMARY")


### PR DESCRIPTION
## Summary

- Add `.github/workflows/runner-utilization.yml`: a daily cron (08:00 UTC) workflow that reports ARC runner utilization for the past 24 hours
- Add `scripts/ci/utils/runner_utilization_report.py`: self-contained script (only depends on `gh` CLI) that fetches workflow runs and jobs via the GitHub API, computes per-label busy/idle/utilization metrics using a sweep-line concurrency algorithm, and writes a Markdown report to stdout and `GITHUB_STEP_SUMMARY`

Key implementation details:
- `run_gh_command()` retries up to 5 times with exponential backoff + jitter, fails fast on non-retryable errors (401/403/404/422)
- `get_jobs_for_run()` uses `filter=all` to capture retried job attempts
- `get_runners()` degrades gracefully when `GITHUB_TOKEN` lacks admin runner-list access
- `calculate_concurrency_metrics()` uses a sweep-line event sort to compute peak/avg concurrent jobs, saturation %, and peak queue depth
- `_likely_no_gpu_jobs()` skips lint / release / runner-utilization / summize workflows to avoid fetching jobs from runs with no TPU runners
- Report is written to `GITHUB_STEP_SUMMARY` so it appears inline in the Actions run summary tab
- `workflow_dispatch` input `filter` allows ad-hoc filtering by runner label substring (e.g. `arc-runner-v6e-4`)

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` with default inputs and verify the step summary tab shows the Markdown report
- [ ] Trigger with `--filter arc-runner-v6e-1` to confirm label filtering works
- [ ] Verify the workflow does not run on forks (guarded by `if: github.repository == 'sgl-project/sglang-jax'`)
- [ ] Confirm no pip packages are installed — only `gh` CLI is required (pre-installed on `ubuntu-latest`)

Closes #1142