### PR TITLE
ci: auto-trigger pr-review on open with non-blocking action

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,6 +1,8 @@
 name: PR Review (Claude)
 
 on:
+  pull_request:
+    types: [opened]
   issue_comment:
     types: [created]
 
@@ -12,10 +14,13 @@ permissions:
 
 concurrency:
   group: >-
-    pr-review-${{ github.event.issue.number }}-${{
+    pr-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{
       (
-        startsWith(github.event.comment.body, '/review')
-        && contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.comment.author_association)
+        github.event_name == 'pull_request'
+        || (
+          startsWith(github.event.comment.body, '/review')
+          && contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.comment.author_association)
+        )
       )
       && 'active'
       || github.run_id
@@ -25,9 +30,11 @@ concurrency:
 jobs:
   review:
     if: >
-      github.event.issue.pull_request != null
-      && startsWith(github.event.comment.body, '/review')
-      && contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.comment.author_association)
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+      || (github.event_name == 'issue_comment'
+          && github.event.issue.pull_request != null
+          && startsWith(github.event.comment.body, '/review')
+          && contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -36,9 +43,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_NUMBER=${{ github.event.issue.number }}
-          HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid -q .headRefOid)
-          HEAD_REF=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName -q .headRefName)
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            PR_NUMBER=${{ github.event.issue.number }}
+            HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid -q .headRefOid)
+            HEAD_REF=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName -q .headRefName)
+          else
+            PR_NUMBER=${{ github.event.pull_request.number }}
+            HEAD_SHA=${{ github.event.pull_request.head.sha }}
+            HEAD_REF=${{ github.event.pull_request.head.ref }}
+          fi
           echo "number=$PR_NUMBER"  >> "$GITHUB_OUTPUT"
           echo "sha=$HEAD_SHA"      >> "$GITHUB_OUTPUT"
           echo "ref=$HEAD_REF"      >> "$GITHUB_OUTPUT"
@@ -49,6 +62,7 @@ jobs:
           fetch-depth: 0
 
       - uses: anthropics/claude-code-action@v1
+        continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
           track_progress: true

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,7 +2,7 @@ name: PR Review (Claude)
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
## Background

After #1182, the `PR Review (Claude)` workflow only runs when an OWNER or COLLABORATOR posts `/review` on a PR. That keeps the checks list clean but loses the auto-review-on-open behavior, which is the most useful trigger point (first reviewer signal on a fresh PR).

This PR brings auto-trigger back while still keeping the checks list visually clean.

## Change

- **Trigger**: `pull_request: [opened, ready_for_review]`. The review runs once when the PR is first created, and once more when a draft PR is marked ready for review. Push/synchronize/reopen do **not** re-trigger it.
- **Keep `/review` comment trigger** for on-demand re-runs after changes.
- **`continue-on-error: true`** on the `anthropics/claude-code-action` step. Internal action failures (OIDC token, model API, etc.) no longer surface as a red ❌ on the PR check. The check stays green; reviewers should treat the inline comments and summary the action posts as the actual signal, not the check color.

Concurrency, job `if`, and the `Resolve PR ref` step are restored to handle both event types (similar to the version prior to #1182).

## Rationale for skipping subsequent pushes

- Most PRs iterate several times after open. Re-running the LLM review on every push burns API budget and clutters the PR with stale comments.
- The PR author or a reviewer can always force a fresh review with a `/review` comment when they want one.
- Draft PRs opened as draft don't trigger the review (the `draft == false` guard still applies to `opened`); they get one review when flipped to ready_for_review.

## Why `continue-on-error` instead of dropping the check entirely

GitHub Actions always emits a check run per job — the workflow author can't suppress it. `continue-on-error: true` at the step level makes the step's `conclusion` resolve to `success` even when the action exits non-zero, so the resulting check run is green. The job itself doesn't fail, and merge gating is unaffected either way (the review check is not in the required status checks).

## Impact

- Fresh PRs get an automatic Claude review on open.
- Draft → ready transition triggers one review.
- Subsequent pushes are quiet — no auto-review churn.
- `/review` on a comment still triggers a fresh run on demand.
- The `PR Review (Claude) / review` check appears in the PR checks list and stays green regardless of action-internal failures.

## Test plan

- [x] YAML syntax validates
- [ ] After merge, opening a new (non-draft) PR triggers exactly one review run
- [ ] Opening a draft PR does not trigger; flipping it to ready triggers one run
- [ ] Pushing additional commits to a non-draft PR does **not** trigger a new review
- [ ] Commenting `/review` triggers a fresh review
- [ ] If the action fails internally, the check still shows green ✅