### PR TITLE
Epic/mtp refactor phase1

### DIFF
--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -142,7 +142,10 @@ class ModelConfig:
         if is_draft_model and self.hf_config.architectures[0] == "MiMoForCausalLM":
             self.hf_config.architectures[0] = "MiMoMTPForCausalLM"
 
-        if is_draft_model and self.hf_config.architectures[0] == "MiMoV2ForCausalLM":
+        if is_draft_model and self.hf_config.architectures[0] in (
+            "MiMoV2ForCausalLM",
+            "MiMoV2FlashForCausalLM",
+        ):
             self.hf_config.architectures[0] = "MiMoV2MTPForCausalLM"
             # Each draft runner is a single SWA layer; without this the KV pool
             # sizes for all 70 target layers and OOMs.

--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -144,6 +144,16 @@ class ModelConfig:
 
         if is_draft_model and self.hf_config.architectures[0] == "MiMoV2ForCausalLM":
             self.hf_config.architectures[0] = "MiMoV2MTPForCausalLM"
+            # Each draft runner is a single SWA layer; without this the KV pool
+            # sizes for all 70 target layers and OOMs.
+            self.hf_config.num_hidden_layers = 1
+            if self.quantization_config is not None:
+                # eh_proj / o_proj are BF16 in model_mtp.safetensors (no
+                # weight_scale_inv); keep them as plain LinearBase so mappings
+                # can target `.weight` instead of `.weight_q`.
+                ignored = list(self.quantization_config.ignored_layers or [])
+                ignored.extend(["model.eh_proj", "model.mtp_block.self_attn.o_proj"])
+                self.quantization_config.ignored_layers = ignored
         # Check model type
         self.is_generation = is_generation_model(self.hf_config.architectures, is_embedding)
         self.is_multimodal = False

--- a/python/sgl_jax/srt/configs/quantization_config.py
+++ b/python/sgl_jax/srt/configs/quantization_config.py
@@ -107,6 +107,26 @@ class QuantizationConfig:
     weight_block_size: tuple[int, int] | None = None
     allow_narrow_n_blockwise: bool = False
 
+    def to_dict(self) -> dict:
+        # Required by transformers.PretrainedConfig.to_json_string when this
+        # object is attached as hf_config.quantization_config and the config is
+        # repr'd (e.g. inside JAX_EXPLAIN_CACHE_MISSES diagnostics).
+        return {
+            "linear_rules": self.linear_rules,
+            "moe_weight_dtype": (
+                str(self.moe_weight_dtype) if self.moe_weight_dtype is not None else None
+            ),
+            "moe_activation_dtype": (
+                str(self.moe_activation_dtype) if self.moe_activation_dtype is not None else None
+            ),
+            "is_static_checkpoint": self.is_static_checkpoint,
+            "ignored_layers": self.ignored_layers,
+            "weight_block_size": (
+                list(self.weight_block_size) if self.weight_block_size is not None else None
+            ),
+            "allow_narrow_n_blockwise": self.allow_narrow_n_blockwise,
+        }
+
     @classmethod
     def from_yaml(cls, yaml_path: str) -> "QuantizationConfig":
         """Load quantization config from a YAML file.

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -1634,6 +1634,7 @@ def get_vmem_limit():
         "skip_kv_mask",
         "disable_semaphore_checks",
         "debug_mode",
+        "mask_aligned_to_cu_kv",
     ),
     donate_argnames=("queries", "keys", "values", "kv_cache_fused"),
 )
@@ -1668,6 +1669,7 @@ def ragged_paged_attention(
     skip_kv_mask: bool = False,
     disable_semaphore_checks: bool = True,
     debug_mode: bool = False,
+    mask_aligned_to_cu_kv: bool = False,
 ):
     """Ragged paged attention with fused KV cache.
 
@@ -1759,12 +1761,9 @@ def ragged_paged_attention(
     if out_dtype is None:
         out_dtype = jnp.float32 if q.dtype == jnp.float32 else jnp.bfloat16
 
-    # When page_size>=256 the dynamic mask slice in _fetch_mask fails
-    # Mosaic's tiling(8) proof; under that condition the host pads each
-    # mask row to the page-aligned kv_len (= cu_kv_lens delta). Derive
-    # the gate here from kv_cache shape (static) so it survives jit
-    # tracing without an extra kwarg from the backend.
-    mask_aligned_to_cu_kv = int(page_size) >= 256
+    # mask_aligned_to_cu_kv: when True the kernel uses cu_kv_lens deltas
+    # (page-aligned) as mask row widths; the host must have padded each row
+    # accordingly. target_verify always pads; prefill does not.
 
     # Prepare custom mask.
     if custom_mask is not None:

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -366,6 +366,7 @@ def _ragged_paged_attention_kernel_loop(
     skip_kv_mask: bool = False,
     tpu_version: int = 6,
     debug_mode: bool = False,
+    mask_aligned_to_cu_kv: bool = False,
 ):
     assert q_hbm_ref.shape == o_hbm_ref.shape
     assert q_hbm_ref.shape[-1] == kv_cache_hbm_ref.shape[-1]
@@ -555,21 +556,33 @@ def _ragged_paged_attention_kernel_loop(
         sem = sems.at[4, bkvmask_sem_idx]
         kvmask_vmem_ref = bkvmask_ref.at[bkvmask_sem_idx]
 
-        kv_len = kv_lens_ref[seq_idx]
-        mask_len = kv_len
+        if mask_aligned_to_cu_kv:
+            # Host padded each mask row to the page-aligned kv_len (= cu_kv_lens
+            # delta), so stride/offset/size are statically tiling(8)-divisible.
+            mask_kv_len = pl.multiple_of(cu_kv_lens_ref[seq_idx + 1] - cu_kv_lens_ref[seq_idx], 8)
+        else:
+            mask_kv_len = kv_lens_ref[seq_idx]
         mask_start = bkvmask_idx * bkv_sz
-        mask_left = mask_len - mask_start
+        mask_left = mask_kv_len - mask_start
         load_kvmask_sz = jnp.minimum(bkv_sz, mask_left)
+        if mask_aligned_to_cu_kv:
+            load_kvmask_sz = pl.multiple_of(load_kvmask_sz, 8)
 
         q_len_start = cu_q_lens_ref[seq_idx] + bq_idx * bq_sz
         q_end = cu_q_lens_ref[seq_idx + 1]
         load_q_sz = jnp.minimum(bq_sz, q_end - q_len_start)
 
         cur_seq_mask_start = cu_seq_mask_lens[seq_idx]
-        cur_bq_mask_start = cur_seq_mask_start + bq_idx * bq_sz * kv_len
+        cur_bq_mask_start = cur_seq_mask_start + bq_idx * bq_sz * mask_kv_len
+        zero_sz = bkv_sz - load_kvmask_sz
+        if mask_aligned_to_cu_kv:
+            cur_seq_mask_start = pl.multiple_of(cur_seq_mask_start, 8)
+            zero_sz = pl.multiple_of(zero_sz, 8)
 
         def loop_body(i, _):
-            start = cur_bq_mask_start + i * kv_len + mask_start
+            start = cur_bq_mask_start + i * mask_kv_len + mask_start
+            if mask_aligned_to_cu_kv:
+                start = pl.multiple_of(start, 8)
             _async_copy(
                 custom_mask_ref.at[pl.ds(start, load_kvmask_sz)],
                 kvmask_vmem_ref.at[i, pl.ds(0, load_kvmask_sz)],
@@ -577,8 +590,8 @@ def _ragged_paged_attention_kernel_loop(
                 wait,
             )
             _async_copy(
-                zero_mask_ref.at[pl.ds(0, bkv_sz - load_kvmask_sz)],
-                kvmask_vmem_ref.at[i, pl.ds(load_kvmask_sz, bkv_sz - load_kvmask_sz)],
+                zero_mask_ref.at[pl.ds(0, zero_sz)],
+                kvmask_vmem_ref.at[i, pl.ds(load_kvmask_sz, zero_sz)],
                 sem,
                 wait,
             )
@@ -1746,15 +1759,22 @@ def ragged_paged_attention(
     if out_dtype is None:
         out_dtype = jnp.float32 if q.dtype == jnp.float32 else jnp.bfloat16
 
+    # When page_size>=256 the dynamic mask slice in _fetch_mask fails
+    # Mosaic's tiling(8) proof; under that condition the host pads each
+    # mask row to the page-aligned kv_len (= cu_kv_lens delta). Derive
+    # the gate here from kv_cache shape (static) so it survives jit
+    # tracing without an extra kwarg from the backend.
+    mask_aligned_to_cu_kv = int(page_size) >= 256
+
     # Prepare custom mask.
     if custom_mask is not None:
         if custom_mask.dtype == jnp.bool_:
             custom_mask = custom_mask.astype(jnp.int32)
         custom_mask = jnp.repeat(jnp.expand_dims(custom_mask, axis=1), repeats=head_dim, axis=1)
 
-        # Prepare cu_seq_mask_lens for custom mask.
         q_lens = cu_q_lens[1:] - cu_q_lens[:-1]
-        seq_mask_lens = kv_lens * q_lens
+        mask_kv_lens = (cu_kv_lens[1:] - cu_kv_lens[:-1]) if mask_aligned_to_cu_kv else kv_lens
+        seq_mask_lens = mask_kv_lens * q_lens
         cu_seq_mask_lens = jnp.concatenate(
             [jnp.array([0], dtype=jnp.int32), jnp.cumsum(seq_mask_lens)]
         )
@@ -1881,6 +1901,7 @@ def ragged_paged_attention(
                 skip_kv_mask=skip_kv_mask,
                 tpu_version=tpu_version,
                 debug_mode=debug_mode,
+                mask_aligned_to_cu_kv=mask_aligned_to_cu_kv,
             ),
             grid_spec=pltpu.PrefetchScalarGridSpec(
                 num_scalar_prefetch=len(scalar_prefetches),

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -240,25 +240,27 @@ class FlashAttention(AttentionBackend):
         if batch.forward_mode.is_target_verify():
             seq_lens += extend_seq_lens
             aligned_seq_lens = ((seq_lens + self.page_size - 1) // self.page_size) * self.page_size
-            # At dp>1 the verify mask must be DP-segmented per rank so each rank's
-            # P("data") shard sees its own slots' mask (the kernel computes
-            # cu_seq_mask_lens from per-rank cu_kv/q starting at 0). Without
-            # repack, the build_tree output sits in cross-rank-flat order, and
-            # rank>0 reads the mask tail (padding zeros) → all-masked verify
-            # → garbage. (#1108 P1-7)
-            #
-            # mask col width depends on rpa_v3's mask_aligned_to_cu_kv switch
-            # (page_size>=256 uses aligned cu_kv_lens; else actual seq_lens),
-            # so pad each row to match — otherwise kernel reads wrong stride.
-            if metadata.custom_mask is not None and dp_size > 1:
+            # Verify mask must be (a) DP-segmented per rank when dp>1 so each
+            # rank's P("data") shard sees its own slots, and (b) padded so each
+            # row width = aligned_seq_lens (= cu_kv_lens delta). The RPA kernel
+            # always takes the cu_kv_lens-aligned path now (#1089 used to gate
+            # on page_size>=256, which broke dp=1 + smaller pages — Mosaic
+            # could not prove tiling(8) on the unaligned slice). dp=1 reduces
+            # to a single rank chunk; dp>1 keeps the per-rank repack from
+            # #1108 P1-7.
+            if metadata.custom_mask is not None:
                 q = batch.spec_info_padded.draft_token_num
                 cm = np.asarray(jax.device_get(metadata.custom_mask))
+                # Pin per-rank mask target from the pre-repacking mask capacity
+                # (tree_mask_capacity from build_tree, already bucket-stable).
+                cm_total = len(cm)
+                per_rank_mask_target = ((cm_total // dp_size + 7) // 8) * 8 or 8
                 # cm is DP-slot-ordered (build_tree got verified_seq_len = mwb.seq_lens-1
                 # over total_bs). Per-slot cm length = q*(verified_seq_len[s]+q); for pad
                 # slots verified_seq_len=-1 → q*(q-1).
                 cm_kl = np.where(seq_lens > 0, seq_lens, q - 1).astype(np.int64)
                 cm_off = np.concatenate([[0], np.cumsum(q * cm_kl)])
-                row_width = aligned_seq_lens if self.page_size >= 256 else seq_lens
+                row_width = aligned_seq_lens
                 rank_chunks: list[np.ndarray] = []
                 for r in range(dp_size):
                     parts = []
@@ -274,8 +276,7 @@ class FlashAttention(AttentionBackend):
                     rank_chunks.append(
                         np.concatenate(parts) if parts else np.zeros(0, dtype=cm.dtype)
                     )
-                max_len = max((len(c) for c in rank_chunks), default=0)
-                max_len = ((max_len + 7) // 8) * 8 or 8
+                max_len = max(max((len(c) for c in rank_chunks), default=0), per_rank_mask_target)
                 packed = np.concatenate(
                     [np.pad(c, (0, max_len - len(c))) for c in rank_chunks]
                 ).astype(np.int32)
@@ -565,6 +566,11 @@ class FlashAttention(AttentionBackend):
             ),  # updated kv_cache_fused (head interleaved) - 3D: [total_tokens, num_kv_heads*2, head_dim]
         )
 
+        mask_aligned_to_cu_kv = (
+            self.forward_metadata.custom_mask is not None
+            and forward_batch.forward_mode.is_target_verify()
+        )
+
         def _ragged_paged_attention_with_fused_kv(*args):
             queries, keys, values, kv_cache_fused = args[:4]
             other_args = args[4:]
@@ -583,6 +589,7 @@ class FlashAttention(AttentionBackend):
                 xai_temperature_len=(
                     layer.xai_temperature_len if layer.xai_temperature_len > 0 else None
                 ),
+                mask_aligned_to_cu_kv=mask_aligned_to_cu_kv,
             )
 
             return result, updated_kv_cache_fused

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -233,6 +233,29 @@ class FlashAttention(AttentionBackend):
         if batch.forward_mode.is_target_verify():
             seq_lens += extend_seq_lens
             aligned_seq_lens = ((seq_lens + self.page_size - 1) // self.page_size) * self.page_size
+            # Hybrid-SWA targets at page_size>=256 hit Mosaic's tiling(8) proof
+            # in rpa_v3._fetch_mask. Pad each mask row to page-aligned kv_len so
+            # the kernel can use cu_kv_lens delta as a statically-8-divisible
+            # stride. Dense targets (EAGLE3) keep the unpadded path so accept-
+            # rate / cache-hit behavior is unchanged.
+            if metadata.custom_mask is not None and self.page_size >= 256:
+                q = batch.spec_info.draft_token_num
+                cm = np.asarray(jax.device_get(metadata.custom_mask))
+                out, off = [], 0
+                for i in range(batch.real_bs):
+                    kl, kla = int(seq_lens[i]), int(aligned_seq_lens[i])
+                    row = cm[off : off + q * kl].reshape(q, kl)
+                    out.append(np.pad(row, ((0, 0), (0, kla - kl))).reshape(-1))
+                    off += q * kl
+                padded_tail = (
+                    q * int(aligned_seq_lens[batch.real_bs :].sum())
+                    if padded_batch_size > batch.real_bs
+                    else 0
+                )
+                metadata.custom_mask = device_array(
+                    np.pad(np.concatenate(out), (0, padded_tail)).astype(np.int32),
+                    sharding=NamedSharding(self.mesh, P()),
+                )
         else:
             aligned_seq_lens = (
                 (batch.seq_lens + self.page_size - 1) // self.page_size
@@ -303,6 +326,16 @@ class FlashAttention(AttentionBackend):
             (cu_q_lens, cu_kv_lens, page_indices, seq_lens, distribution),
             sharding=(NamedSharding(self.mesh, P("data"))),
         )
+        # Hybrid SWA targets need swa_page_indices for TARGET_VERIFY too,
+        # otherwise SWA layers index the swa sub-pool with full-pool page ids.
+        swa_mapping = getattr(self, "swa_index_mapping", None)
+        if swa_mapping is not None:
+            mapping = swa_mapping[0] if isinstance(swa_mapping, list) else swa_mapping
+            full_loc = (page_indices.astype(np.int64) * self.page_size).astype(np.int32)
+            metadata.swa_page_indices = device_array(
+                (np.asarray(mapping)[full_loc] // self.page_size).astype(np.int32),
+                sharding=NamedSharding(self.mesh, P("data")),
+            )
         return metadata
 
     def get_eagle_multi_step_metadata(self, batch: ModelWorkerBatch):

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -25,6 +25,17 @@ from sgl_jax.srt.utils.profiling_utils import named_scope
 logger = logging.getLogger(__name__)
 
 
+def _per_dp_cumsum(lens, dp_size: int, per_dp_bs: int) -> np.ndarray:
+    """`(dp*(per_dp_bs+1),)` row-wise cumsum with leading 0 per DP rank.
+
+    At dp=1 reduces to `[0, *cumsum(lens)]`. Replaces the previous
+    ``if dp>1: 2D else: 1D`` branches (review #1108).
+    """
+    cu = np.zeros((dp_size, per_dp_bs + 1), dtype=np.int32)
+    cu[:, 1:] = np.cumsum(np.asarray(lens, dtype=np.int32).reshape(dp_size, per_dp_bs), axis=1)
+    return cu.ravel()
+
+
 @register_pytree_node_class
 @dataclass
 class FlashAttentionMetadata:
@@ -214,19 +225,15 @@ class FlashAttention(AttentionBackend):
         else:
             metadata.custom_mask = None
 
+        dp_size = batch.dp_size
+        per_dp_bs = batch.per_dp_bs_size if dp_size > 1 else len(batch.seq_lens)
         if batch.forward_mode.is_target_verify():
             padded_batch_size = len(batch.seq_lens)
-            real_batch_size = batch.real_bs
-            q_lens = np.array([batch.spec_info.draft_token_num] * real_batch_size, dtype=np.int32)
-            extend_seq_lens = np.pad(q_lens, (0, padded_batch_size - real_batch_size))
+            extend_seq_lens = np.zeros(padded_batch_size, dtype=np.int32)
+            extend_seq_lens[batch.logits_indices_selector] = batch.spec_info.draft_token_num
         else:
             extend_seq_lens = batch.extend_seq_lens
-        cu_q_lens = np.concatenate(
-            [
-                np.array([0], dtype=np.int32),
-                np.cumsum(extend_seq_lens),
-            ]
-        )
+        cu_q_lens = _per_dp_cumsum(extend_seq_lens, dp_size, per_dp_bs)
 
         seq_lens = np.copy(batch.seq_lens)
 
@@ -241,79 +248,80 @@ class FlashAttention(AttentionBackend):
             if metadata.custom_mask is not None and self.page_size >= 256:
                 q = batch.spec_info.draft_token_num
                 cm = np.asarray(jax.device_get(metadata.custom_mask))
-                out, off = [], 0
-                for i in range(batch.real_bs):
-                    kl, kla = int(seq_lens[i]), int(aligned_seq_lens[i])
-                    row = cm[off : off + q * kl].reshape(q, kl)
-                    out.append(np.pad(row, ((0, 0), (0, kla - kl))).reshape(-1))
-                    off += q * kl
-                padded_tail = (
-                    q * int(aligned_seq_lens[batch.real_bs :].sum())
-                    if padded_batch_size > batch.real_bs
-                    else 0
-                )
+                # cm is DP-slot-ordered (build_tree got verified_seq_len = mwb.seq_lens-1
+                # over total_bs). Per-slot cm length = q*(verified_seq_len[s]+q); for pad
+                # slots verified_seq_len=-1 → q*(q-1). Repack per DP rank (real slots'
+                # rows padded to aligned kv, pad slots = zeros), then pad each rank's
+                # section to a common length so the result shards P("data") and each
+                # rank's locally-computed cu_seq_mask_lens (starting at 0) indexes its
+                # own shard. (#1108 P1-7 — n>1 dp>1 verify mask cross-rank read.)
+                cm_kl = np.where(seq_lens > 0, seq_lens, q - 1).astype(np.int64)
+                cm_off = np.concatenate([[0], np.cumsum(q * cm_kl)])
+                rank_chunks: list[np.ndarray] = []
+                for r in range(dp_size):
+                    parts = []
+                    for j in range(per_dp_bs):
+                        s = r * per_dp_bs + j
+                        kla = int(aligned_seq_lens[s])
+                        if seq_lens[s] > 0:
+                            kl = int(seq_lens[s])
+                            row = cm[cm_off[s] : cm_off[s] + q * kl].reshape(q, kl)
+                            parts.append(np.pad(row, ((0, 0), (0, kla - kl))).reshape(-1))
+                        elif kla > 0:
+                            parts.append(np.zeros(q * kla, dtype=cm.dtype))
+                    rank_chunks.append(
+                        np.concatenate(parts) if parts else np.zeros(0, dtype=cm.dtype)
+                    )
+                max_len = max((len(c) for c in rank_chunks), default=0)
+                max_len = ((max_len + 7) // 8) * 8 or 8
+                packed = np.concatenate(
+                    [np.pad(c, (0, max_len - len(c))) for c in rank_chunks]
+                ).astype(np.int32)
                 metadata.custom_mask = device_array(
-                    np.pad(np.concatenate(out), (0, padded_tail)).astype(np.int32),
-                    sharding=NamedSharding(self.mesh, P()),
+                    packed,
+                    sharding=NamedSharding(self.mesh, P("data") if dp_size > 1 else P()),
                 )
         else:
             aligned_seq_lens = (
                 (batch.seq_lens + self.page_size - 1) // self.page_size
             ) * self.page_size
-        cu_kv_lens = np.concatenate(
-            [
-                np.array([0], dtype=np.int32),
-                np.cumsum(aligned_seq_lens),
-            ]
-        )
+        cu_kv_lens = _per_dp_cumsum(aligned_seq_lens, dp_size, per_dp_bs)
 
         if batch.forward_mode == ForwardMode.DRAFT_EXTEND:
-            # Reconstruct page_indices properly respecting ragged allocation
-            page_indices_list = []
-            offset = 0
+            # Truncate each req's page list from allocate_len → seq_len, keeping
+            # the DP-segmented layout from padding_for_decode (rank r's pages
+            # at [r*per_dp_pg : ...]). page_indices (line 212) is already
+            # cache_loc[::page_size]//page_size, so re-gather from it per-rank.
             allocate_lens = batch.spec_info.allocate_lens
-            # Ensure it's accessible as array
             if hasattr(allocate_lens, "device"):
                 allocate_lens = jax.device_get(allocate_lens)
+            allocate_lens = np.asarray(allocate_lens)
+            sel = np.asarray(batch.logits_indices_selector)
+            # allocate_lens here is global-flat (real_bs,) (cur_allocate_lens via
+            # verify); sel is DP-slot indices, only used for rank_of/aligned_seq.
+            assert len(allocate_lens) == len(sel), (len(allocate_lens), len(sel))
+            full_pg = page_indices.shape[0]
+            assert full_pg % dp_size == 0, (full_pg, dp_size)
+            per_dp_pg = full_pg // dp_size
+            alloc_pg = cdiv(allocate_lens.astype(np.int64), self.page_size)
+            need_pg = (aligned_seq_lens[sel] // self.page_size).astype(np.int64)
+            rank_of = (sel // per_dp_bs).astype(np.int64)
+            new_pi = np.zeros(full_pg, dtype=np.int32)
+            src_off = np.zeros(dp_size, dtype=np.int64)
+            dst_off = np.zeros(dp_size, dtype=np.int64)
+            for k in range(len(sel)):
+                r = int(rank_of[k])
+                n = int(need_pg[k])
+                s = r * per_dp_pg + src_off[r]
+                d = r * per_dp_pg + dst_off[r]
+                new_pi[d : d + n] = page_indices[s : s + n]
+                src_off[r] += int(alloc_pg[k])
+                dst_off[r] += n
+            page_indices = new_pi
 
-            num_pages_per_seq = aligned_seq_lens // self.page_size
-
-            for i in range(batch.real_bs):
-                alloc_len = (
-                    (int(allocate_lens[i]) + self.page_size - 1) // self.page_size
-                ) * self.page_size
-                needed_pages = int(num_pages_per_seq[i])
-
-                if needed_pages > 0:
-                    # Get the slice of cache_loc for this request
-                    # We assume batch.cache_loc is ordered and packed according to allocate_lens
-                    req_cache_loc = batch.cache_loc[offset : offset + alloc_len]
-
-                    # Select the first token of each page
-                    # The tokens are at indices 0, page_size, 2*page_size...
-                    # We need `needed_pages` entries.
-
-                    indices = np.arange(needed_pages) * self.page_size
-                    selected = req_cache_loc[indices]
-                    page_indices_list.extend(selected // self.page_size)
-
-                offset += alloc_len
-
-            page_indices = np.pad(
-                np.array(page_indices_list, dtype=np.int32),
-                (0, page_indices.shape[0] - len(page_indices_list)),
-            )
-
-        num_seqs = np.sum(batch.seq_lens > 0, dtype=np.int32).reshape(
-            1,
-        )
-        # Construct distribution for V2 kernel: [decode_end, prefill_end, mixed_end]
-
-        # All sequences are prefill mode
-        distribution = np.array([0, num_seqs.item(), num_seqs.item()], dtype=np.int32)
-
-        cu_q_lens = np.array(cu_q_lens)
-        cu_kv_lens = np.array(cu_kv_lens)
+        seq_2d = np.asarray(batch.seq_lens).reshape(dp_size, per_dp_bs)
+        local_n = np.sum(seq_2d > 0, axis=1, dtype=np.int32)
+        distribution = np.column_stack([np.zeros_like(local_n), local_n, local_n]).ravel()
         page_indices = np.array(page_indices)
         seq_lens = np.array(seq_lens)
         (
@@ -330,10 +338,17 @@ class FlashAttention(AttentionBackend):
         # otherwise SWA layers index the swa sub-pool with full-pool page ids.
         swa_mapping = getattr(self, "swa_index_mapping", None)
         if swa_mapping is not None:
-            mapping = swa_mapping[0] if isinstance(swa_mapping, list) else swa_mapping
             full_loc = (page_indices.astype(np.int64) * self.page_size).astype(np.int32)
+            if isinstance(swa_mapping, list):
+                full_2d = full_loc.reshape(dp_size, -1)
+                swa_2d = np.empty_like(full_2d)
+                for r in range(dp_size):
+                    swa_2d[r] = np.asarray(swa_mapping[r])[full_2d[r]]
+                swa_loc = swa_2d.ravel()
+            else:
+                swa_loc = np.asarray(swa_mapping)[full_loc]
             metadata.swa_page_indices = device_array(
-                (np.asarray(mapping)[full_loc] // self.page_size).astype(np.int32),
+                (swa_loc // self.page_size).astype(np.int32),
                 sharding=NamedSharding(self.mesh, P("data")),
             )
         return metadata
@@ -350,34 +365,50 @@ class FlashAttention(AttentionBackend):
         cu_kv_lens = []
         seq_lens = np.copy(batch.seq_lens)
 
-        # Vectorized preparation
-        real_bs = batch.real_bs
-        current_seq_lens = batch.seq_lens[:real_bs]
-        allocate_lens = batch.spec_info.allocate_lens[:real_bs]
+        # Vectorized preparation. selector maps global-flat req k → DP-padded
+        # slot s_k; cache_loc/page_indices are laid out in valid-slot order
+        # (== selector order), so the per-req gather below stays aligned.
+        sel = np.asarray(batch.logits_indices_selector)
+        current_seq_lens = np.asarray(batch.seq_lens)[sel]
+        allocate_lens = np.asarray(batch.spec_info.allocate_lens)[sel]
 
         draft_allocs = allocate_lens - current_seq_lens
 
         alloc_tokens = current_seq_lens + draft_allocs
         alloc_pages = cdiv(alloc_tokens, self.page_size)
 
-        # src_starts (offset2) is constant across steps
-        src_starts = np.concatenate(([0], np.cumsum(alloc_pages)[:-1]))
-
         full_size = len(original_selected_cache_locs)
+        dp_size = batch.dp_size
+        per_dp_bs = batch.per_dp_bs_size if dp_size > 1 else len(batch.seq_lens)
+        assert full_size % dp_size == 0, (full_size, dp_size)
+        # cache_loc is DP-segmented (padding_for_decode); src_starts must point
+        # into rank r's section [r*per_dp_src_pages : ...], and result_locs
+        # must be written DP-segmented so the P("data") shard gives each rank
+        # its own draft page_indices (otherwise rank>0 reads page 0 → accept~1).
+        per_dp_src_pages = full_size // dp_size
+        TARGET_PADDING = 16384
+        assert TARGET_PADDING % dp_size == 0
+        per_dp_dst_pages = TARGET_PADDING // dp_size
+        rank_of_req = (sel // per_dp_bs).astype(np.int64)
+
+        def _dp_starts(pages, per_dp_base):
+            starts = np.zeros(len(pages), dtype=np.int64)
+            for r in range(dp_size):
+                m = rank_of_req == r
+                if not np.any(m):
+                    continue
+                c = np.cumsum(pages[m])
+                starts[m] = r * per_dp_base + np.concatenate(([0], c[:-1]))
+            return starts
+
+        src_starts = _dp_starts(alloc_pages, per_dp_src_pages)
         seq_lens_list = []
+        valid_slot = np.asarray(batch.seq_lens) > 0
         for speculative_step_id in range(batch.speculative_num_steps):
-            seq_lens = batch.seq_lens + (speculative_step_id)
-            seq_lens[batch.real_bs :] = 0
+            seq_lens = np.where(valid_slot, batch.seq_lens + speculative_step_id, 0)
             seq_lens_list.append(seq_lens)
             aligned_seq_lens = ((seq_lens + self.page_size - 1) // self.page_size) * self.page_size
-            cu_kv_lens.append(
-                np.concatenate(
-                    [
-                        np.array([0], dtype=np.int32),
-                        np.cumsum(aligned_seq_lens),
-                    ]
-                )
-            )
+            cu_kv_lens.append(_per_dp_cumsum(aligned_seq_lens, dp_size, per_dp_bs))
 
             # Vectorized calculation of spec_pages
             step_spec_tokens = (
@@ -385,48 +416,30 @@ class FlashAttention(AttentionBackend):
             )
             step_spec_pages = cdiv(step_spec_tokens, self.page_size)
 
-            total_spec_pages = np.sum(step_spec_pages)
-            dst_starts = np.concatenate(([0], np.cumsum(step_spec_pages)[:-1]))
+            total_spec_pages = int(np.sum(step_spec_pages))
+            dst_starts = _dp_starts(step_spec_pages, per_dp_dst_pages)
+            flat_dst_cum = np.concatenate(([0], np.cumsum(step_spec_pages)[:-1]))
 
-            # Vectorized Gather
             repeats = step_spec_pages
-            gather_indices = np.repeat(src_starts, repeats) + (
-                np.arange(total_spec_pages) - np.repeat(dst_starts, repeats)
-            )
-
+            local_off = np.arange(total_spec_pages) - np.repeat(flat_dst_cum, repeats)
+            gather_indices = np.repeat(src_starts, repeats) + local_off
+            write_indices = np.repeat(dst_starts, repeats) + local_off
             gathered_locs = original_selected_cache_locs[gather_indices]
 
-            # Reconstruct the full array (sparse/padded)
-            result_locs = np.zeros(full_size, dtype=original_selected_cache_locs.dtype)
-            result_locs[:total_spec_pages] = gathered_locs
-
-            page_indices_cur_step = (result_locs // self.page_size).astype(np.int32)
-
-            # FIXME Handle padding, this will be move to precompile
-            TARGET_PADDING = 16384
-            if page_indices_cur_step.shape[0] < TARGET_PADDING:
-                padding_size = TARGET_PADDING - page_indices_cur_step.shape[0]
-                # Use np.pad to keep it on CPU/Numpy until device_array call
-                page_indices_cur_step = np.pad(page_indices_cur_step, (0, padding_size))
-
-            page_indices.append(page_indices_cur_step)
+            result_locs = np.zeros(TARGET_PADDING, dtype=original_selected_cache_locs.dtype)
+            result_locs[write_indices] = gathered_locs
+            page_indices.append((result_locs // self.page_size).astype(np.int32))
 
         if batch.spec_algorithm.is_none():
             raise RuntimeError("should not reach here")
-        else:
-            assert isinstance(batch.spec_info, EagleDraftInput)
-            # it is same across every step
-            cu_q_lens = np.arange(
-                0,
-                len(batch.seq_lens) * batch.speculative_eagle_topk + 1,
-                step=batch.speculative_eagle_topk,
-                dtype=np.int32,
-            )
-        num_seqs = np.sum(batch.seq_lens > 0, dtype=np.int32).reshape(
-            1,
-        )
-
-        distribution = np.array([0, 0, num_seqs.item()], dtype=np.int32)
+        assert isinstance(batch.spec_info, EagleDraftInput)
+        topk = batch.speculative_eagle_topk
+        cu_q_lens = np.tile(np.arange(0, per_dp_bs * topk + 1, topk, dtype=np.int32), dp_size)
+        seq_2d = np.asarray(batch.seq_lens).reshape(dp_size, per_dp_bs)
+        local_n = np.sum(seq_2d > 0, axis=1, dtype=np.int32)
+        distribution = np.column_stack(
+            [np.zeros_like(local_n), np.zeros_like(local_n), local_n]
+        ).ravel()
         metadata = []
         for i in range(batch.speculative_num_steps):
             metadata_tmp = FlashAttentionMetadata()
@@ -533,7 +546,11 @@ class FlashAttention(AttentionBackend):
             P(self.attention_data_partition_axis),  # cu_q_lens
             P(self.attention_data_partition_axis),  # cu_kv_lens
             P(self.attention_data_partition_axis),  # distribution
-            P(),  # custom_mask
+            (
+                P(self.attention_data_partition_axis)
+                if self.forward_metadata.custom_mask is not None
+                else P()
+            ),  # custom_mask: DP-segmented per-rank (cu_seq_mask_lens is rank-local)
             (
                 P(self.kv_partition_axis) if attention_sink is not None else P()
             ),  # attention sink: (num_q_heads,), sharded by heads

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -213,15 +213,15 @@ class FlashAttention(AttentionBackend):
 
         if batch.forward_mode == ForwardMode.TARGET_VERIFY:
             # convert custom_mask from bool to int32, because dma not support bool type
-            if batch.spec_info.custom_mask.dtype == jnp.bool:
+            if batch.spec_info_padded.custom_mask.dtype == jnp.bool:
                 # FIXME(pc) rm this dtype convert
                 logger.warning(
-                    "batch.spec_info.custom_mask type is  %s, it may make performance very low",
-                    batch.spec_info.custom_mask.dtype,
+                    "batch.spec_info_padded.custom_mask type is  %s, it may make performance very low",
+                    batch.spec_info_padded.custom_mask.dtype,
                 )
-                metadata.custom_mask = batch.spec_info.custom_mask.astype(jnp.int32)
+                metadata.custom_mask = batch.spec_info_padded.custom_mask.astype(jnp.int32)
             else:
-                metadata.custom_mask = batch.spec_info.custom_mask
+                metadata.custom_mask = batch.spec_info_padded.custom_mask
         else:
             metadata.custom_mask = None
 
@@ -230,7 +230,7 @@ class FlashAttention(AttentionBackend):
         if batch.forward_mode.is_target_verify():
             padded_batch_size = len(batch.seq_lens)
             extend_seq_lens = np.zeros(padded_batch_size, dtype=np.int32)
-            extend_seq_lens[batch.logits_indices_selector] = batch.spec_info.draft_token_num
+            extend_seq_lens[batch.logits_indices_selector] = batch.spec_info_padded.draft_token_num
         else:
             extend_seq_lens = batch.extend_seq_lens
         cu_q_lens = _per_dp_cumsum(extend_seq_lens, dp_size, per_dp_bs)
@@ -240,29 +240,31 @@ class FlashAttention(AttentionBackend):
         if batch.forward_mode.is_target_verify():
             seq_lens += extend_seq_lens
             aligned_seq_lens = ((seq_lens + self.page_size - 1) // self.page_size) * self.page_size
-            # Hybrid-SWA targets at page_size>=256 hit Mosaic's tiling(8) proof
-            # in rpa_v3._fetch_mask. Pad each mask row to page-aligned kv_len so
-            # the kernel can use cu_kv_lens delta as a statically-8-divisible
-            # stride. Dense targets (EAGLE3) keep the unpadded path so accept-
-            # rate / cache-hit behavior is unchanged.
-            if metadata.custom_mask is not None and self.page_size >= 256:
-                q = batch.spec_info.draft_token_num
+            # At dp>1 the verify mask must be DP-segmented per rank so each rank's
+            # P("data") shard sees its own slots' mask (the kernel computes
+            # cu_seq_mask_lens from per-rank cu_kv/q starting at 0). Without
+            # repack, the build_tree output sits in cross-rank-flat order, and
+            # rank>0 reads the mask tail (padding zeros) → all-masked verify
+            # → garbage. (#1108 P1-7)
+            #
+            # mask col width depends on rpa_v3's mask_aligned_to_cu_kv switch
+            # (page_size>=256 uses aligned cu_kv_lens; else actual seq_lens),
+            # so pad each row to match — otherwise kernel reads wrong stride.
+            if metadata.custom_mask is not None and dp_size > 1:
+                q = batch.spec_info_padded.draft_token_num
                 cm = np.asarray(jax.device_get(metadata.custom_mask))
                 # cm is DP-slot-ordered (build_tree got verified_seq_len = mwb.seq_lens-1
                 # over total_bs). Per-slot cm length = q*(verified_seq_len[s]+q); for pad
-                # slots verified_seq_len=-1 → q*(q-1). Repack per DP rank (real slots'
-                # rows padded to aligned kv, pad slots = zeros), then pad each rank's
-                # section to a common length so the result shards P("data") and each
-                # rank's locally-computed cu_seq_mask_lens (starting at 0) indexes its
-                # own shard. (#1108 P1-7 — n>1 dp>1 verify mask cross-rank read.)
+                # slots verified_seq_len=-1 → q*(q-1).
                 cm_kl = np.where(seq_lens > 0, seq_lens, q - 1).astype(np.int64)
                 cm_off = np.concatenate([[0], np.cumsum(q * cm_kl)])
+                row_width = aligned_seq_lens if self.page_size >= 256 else seq_lens
                 rank_chunks: list[np.ndarray] = []
                 for r in range(dp_size):
                     parts = []
                     for j in range(per_dp_bs):
                         s = r * per_dp_bs + j
-                        kla = int(aligned_seq_lens[s])
+                        kla = int(row_width[s])
                         if seq_lens[s] > 0:
                             kl = int(seq_lens[s])
                             row = cm[cm_off[s] : cm_off[s] + q * kl].reshape(q, kl)
@@ -279,7 +281,7 @@ class FlashAttention(AttentionBackend):
                 ).astype(np.int32)
                 metadata.custom_mask = device_array(
                     packed,
-                    sharding=NamedSharding(self.mesh, P("data") if dp_size > 1 else P()),
+                    sharding=NamedSharding(self.mesh, P("data")),
                 )
         else:
             aligned_seq_lens = (
@@ -292,7 +294,7 @@ class FlashAttention(AttentionBackend):
             # the DP-segmented layout from padding_for_decode (rank r's pages
             # at [r*per_dp_pg : ...]). page_indices (line 212) is already
             # cache_loc[::page_size]//page_size, so re-gather from it per-rank.
-            allocate_lens = batch.spec_info.allocate_lens
+            allocate_lens = batch.spec_info_padded.allocate_lens
             if hasattr(allocate_lens, "device"):
                 allocate_lens = jax.device_get(allocate_lens)
             allocate_lens = np.asarray(allocate_lens)
@@ -370,7 +372,7 @@ class FlashAttention(AttentionBackend):
         # (== selector order), so the per-req gather below stays aligned.
         sel = np.asarray(batch.logits_indices_selector)
         current_seq_lens = np.asarray(batch.seq_lens)[sel]
-        allocate_lens = np.asarray(batch.spec_info.allocate_lens)[sel]
+        allocate_lens = np.asarray(batch.spec_info_padded.allocate_lens)[sel]
 
         draft_allocs = allocate_lens - current_seq_lens
 
@@ -432,7 +434,7 @@ class FlashAttention(AttentionBackend):
 
         if batch.spec_algorithm.is_none():
             raise RuntimeError("should not reach here")
-        assert isinstance(batch.spec_info, EagleDraftInput)
+        assert isinstance(batch.spec_info_padded, EagleDraftInput)
         topk = batch.speculative_eagle_topk
         cu_q_lens = np.tile(np.arange(0, per_dp_bs * topk + 1, topk, dtype=np.int32), dp_size)
         seq_2d = np.asarray(batch.seq_lens).reshape(dp_size, per_dp_bs)

--- a/python/sgl_jax/srt/layers/logits_processor.py
+++ b/python/sgl_jax/srt/layers/logits_processor.py
@@ -202,7 +202,8 @@ class LogitsMetadata:
             logits_indices=device_array(batch.logits_indices, sharding=sharding),
             accept_lens=(
                 device_array(batch.spec_info_padded.accept_length, sharding=sharding)
-                if batch.spec_info_padded is not None
+                if batch.forward_mode.is_draft_extend()
+                and batch.spec_info_padded is not None
                 and hasattr(batch.spec_info_padded, "accept_length")
                 and batch.spec_info_padded.accept_length is not None
                 else None

--- a/python/sgl_jax/srt/layers/logits_processor.py
+++ b/python/sgl_jax/srt/layers/logits_processor.py
@@ -201,10 +201,10 @@ class LogitsMetadata:
             extend_seq_lens=device_array(batch.extend_seq_lens, sharding=sharding),
             logits_indices=device_array(batch.logits_indices, sharding=sharding),
             accept_lens=(
-                device_array(batch.spec_info.accept_length, sharding=sharding)
-                if batch.spec_info is not None
-                and hasattr(batch.spec_info, "accept_length")
-                and batch.spec_info.accept_length is not None
+                device_array(batch.spec_info_padded.accept_length, sharding=sharding)
+                if batch.spec_info_padded is not None
+                and hasattr(batch.spec_info_padded, "accept_length")
+                and batch.spec_info_padded.accept_length is not None
                 else None
             ),
             extend_seq_lens_cpu=extend_seq_lens_cpu,

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -188,6 +188,13 @@ class EPMoE(nnx.Module):
                         f"Unsupported {scale_name} shape {scale.shape} for weight shape {weight.shape}. "
                         f"Expected k_blocks dimension to be 1 or {expected_k_blocks}."
                     )
+            # FIXME(jax-upgrade): incoming sharding is typically P("expert", None, None, None) —
+            # the EPMoE weight loader passes a 3-tuple ("expert", None, None) that JAX pads
+            # with None on the 4D array — which doesn't textually match the downstream
+            # shard_map in_specs P("expert", None, None, "tensor"). jax 0.8.1 accepts this
+            # because the "tensor" axis is size 1 (ep_size == world_size); jax 0.10.x checks
+            # strictly and will raise. Fix by reshard'ing here like the ndim==3 branches do,
+            # or fix the loader to emit a full 4-tuple.
             return scale
 
         if scale.ndim == 2 and scale.shape == (num_experts, out_dim):

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -26,7 +26,6 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import jax
 import numpy as np
-from jax import numpy as jnp
 from jax._src import mesh as mesh_lib
 
 from sgl_jax.global_config import global_config
@@ -2049,7 +2048,7 @@ class ScheduleBatch:
         )
 
     def _get_spec_decode_mwb_dp(
-        self, bs_paddings: list, enable_static_lora: bool
+        self, bs_paddings: list, enable_static_lora: bool, draft_token_num: int = 1
     ) -> ModelWorkerBatch:
         """DP-aware spec-decode ModelWorkerBatch (#1053 P1-5b).
 
@@ -2059,10 +2058,26 @@ class ScheduleBatch:
         ``reqs_info[0]``. ``input_ids``/``positions``/``cache_loc`` are
         placeholders — ``EagleDraftWorker.padding_for_decode`` rebuilds them.
         """
-        max_bs_per_dp = max(
-            (len(i.seq_lens) if i.seq_lens is not None else 0) for i in self.reqs_info
-        )
-        total_bs, _ = pad_to_bucket(max(max_bs_per_dp, 1) * self.dp_size, bs_paddings)
+        # Pin total_bs to the largest precompile bucket so every cell shares
+        # one jit cache entry regardless of runtime bs. Without this, each
+        # smaller bucket (bs_paddings[i] < bs_paddings[-1]) triggers a fresh
+        # trace the first time it's hit. precompile is expected to include a
+        # largest bucket that is a multiple of dp_size; falling back to a
+        # smaller bucket would split the cache key, so assert instead.
+        if not bs_paddings:
+            total_bs = self.dp_size
+        else:
+            max_bs_per_dp = 0
+            for dp_rank in range(self.dp_size):
+                info = self.reqs_info[dp_rank]
+                if info.reqs is not None:
+                    max_bs_per_dp = max(max_bs_per_dp, len(info.reqs))
+            max_bs_per_dp = max(max_bs_per_dp, 1)
+            total_bs, _ = pad_to_bucket(max_bs_per_dp * self.dp_size, bs_paddings)
+            assert total_bs % self.dp_size == 0, (
+                f"padded total_bs={total_bs} is not divisible by dp_size="
+                f"{self.dp_size}; bs_paddings={bs_paddings}"
+            )
         per_dp_bs = total_bs // self.dp_size
         self.per_dp_bs_size = per_dp_bs
         (
@@ -2097,12 +2112,18 @@ class ScheduleBatch:
             )
             for i in self.reqs_info
         ]
-        max_ocl = max((len(c) for c in ocl_chunks), default=0)
+        # Pad each rank's out_cache_loc to per_dp_bs * draft_token_num so the
+        # merged shape is stable across runtime bs. max_chunk_len defensive.
+        max_chunk_len = max((len(c) for c in ocl_chunks), default=0)
+        target_per_rank_ocl = max(per_dp_bs * draft_token_num, max_chunk_len)
         out_cache_loc = (
             np.concatenate(
-                [np.pad(c, (0, max_ocl - len(c)), constant_values=-1) for c in ocl_chunks]
+                [
+                    np.pad(c, (0, target_per_rank_ocl - len(c)), constant_values=-1)
+                    for c in ocl_chunks
+                ]
             )
-            if max_ocl > 0
+            if target_per_rank_ocl > 0
             else np.empty(0, dtype=np.int32)
         )
         return ModelWorkerBatch(
@@ -2183,6 +2204,8 @@ class ScheduleBatch:
         if flat is None:
             return [None] * len(real_bs_per_dp)
 
+        flat._ensure_host()
+
         per_req_fields = (
             "topk_p",
             "topk_index",
@@ -2245,10 +2268,14 @@ class ScheduleBatch:
                 f"{len(nonempty) - len(nonnull)}/{len(nonempty)} nonempty rank(s); "
                 "all-or-nothing required"
             )
+            if len(nonnull) == 1:
+                kwargs[f] = nonnull[0]
+                continue
             if isinstance(nonnull[0], np.ndarray):
                 kwargs[f] = np.concatenate(nonnull, axis=0)
             else:
-                kwargs[f] = jnp.concatenate(nonnull, axis=0)
+                nonnull = [np.asarray(v) for v in nonnull]
+                kwargs[f] = np.concatenate(nonnull, axis=0)
         return type(nonempty[0])(**kwargs)
 
     def get_model_worker_batch(
@@ -2393,7 +2420,10 @@ class ScheduleBatch:
             real_bs_per_dp=real_bs_per_dp,
             logits_indices_selector=logits_indices_selector,
             capture_hidden_mode=(
-                CaptureHiddenMode.FULL if self.return_hidden_states else CaptureHiddenMode.NULL
+                CaptureHiddenMode.FULL
+                if self.return_hidden_states
+                or (self.spec_algorithm is not None and not self.spec_algorithm.is_none())
+                else CaptureHiddenMode.NULL
             ),
             dp_size=self.dp_size,
             per_dp_bs_size=per_dp_bs_padding,
@@ -2403,6 +2433,7 @@ class ScheduleBatch:
             deepstack_visual_embedding=None,
             recurrent_indices=recurrent_indices_cpu,
             has_initial_state=has_initial_state_cpu,
+            spec_algorithm=self.spec_algorithm,
         )
 
     def get_spec_model_worker_batch(
@@ -2412,162 +2443,12 @@ class ScheduleBatch:
         cache_loc_paddings: list,
         page_size: int,
         enable_static_lora: bool = False,
+        draft_token_num: int = 1,
     ) -> ModelWorkerBatch:
-        # Spec extend always routes through get_model_worker_batch (padded mwb
-        # shared with nospec). Only decode/idle reaches here.
         assert (
             self.forward_mode.is_decode_or_idle()
         ), "spec extend must use get_model_worker_batch, only decode reaches here"
-        if self.dp_size > 1:
-            return self._get_spec_decode_mwb_dp(bs_paddings, enable_static_lora)
-
-        if self.input_ids is None:
-            input_ids_cpu = np.empty(0, dtype=np.int32)
-        else:
-            input_ids_cpu = self.input_ids.flatten()
-
-        real_input_ids_len = len(input_ids_cpu)
-        out_cache_loc_cpu = self.out_cache_loc
-        seq_lens_cpu = self.seq_lens
-        real_bs = len(seq_lens_cpu)
-        self.per_dp_bs_size = real_bs
-        req_pool_indices_cpu = self.req_pool_indices
-        token_indices_with_all_reqs = self.req_to_token_pool.req_to_token[self.req_pool_indices]
-        # FIXME @pc, move this to eagle_worker
-        # If enable spec inference, use positions in spec info firstly.
-        spec_info_local = (
-            self.reqs_info[0].spec_info if self.reqs_info and self.reqs_info[0] else None
-        )
-        if spec_info_local is not None and getattr(spec_info_local, "positions", None) is not None:
-            positions_cpu = spec_info_local.positions
-        else:
-            # Decode: each sequence contributes one token at the next position.
-            batch_positions = np.maximum(0, seq_lens_cpu - 1)
-            positions_cpu = np.zeros(len(batch_positions), dtype=batch_positions.dtype)
-            positions_cpu[: len(batch_positions)] = batch_positions
-
-        mrope_positions_cpu = _compute_mrope_positions_for_batch(
-            self.reqs,
-            self.forward_mode,
-            seq_lens_cpu,
-            len(input_ids_cpu),
-            None,
-            None,
-        )
-
-        cache_loc_flat = np.array([], dtype=np.int32)
-
-        if len(seq_lens_cpu) > 0:
-            seq_lens = seq_lens_cpu
-            if (
-                self.spec_algorithm is not None
-                and not self.spec_algorithm.is_none()
-                and self.forward_mode == ForwardMode.DECODE
-            ):
-                from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
-
-                seq_lens = seq_lens_cpu + EagleDraftInput.ALLOC_LEN_PER_DECODE
-            # Filter out empty sequences
-            valid_mask = seq_lens > 0
-            if np.any(valid_mask):
-                valid_indices = np.where(valid_mask)[0]
-                valid_seq_lens = seq_lens[valid_mask]
-                # Calculate aligned lengths for all valid sequences at once
-                if (
-                    self.forward_mode == ForwardMode.DECODE
-                    and not self.spec_algorithm.is_none()
-                    and spec_info_local is not None
-                    and spec_info_local.allocate_lens is not None
-                ):
-                    # Explicitly convert to numpy to avoid JAX device synchronization overhead
-                    allocated_len_cpu = np.array(spec_info_local.allocate_lens)
-                    allocated_len = allocated_len_cpu[: len(self.reqs)]
-                    aligned_lengths = ((allocated_len + page_size - 1) // page_size) * page_size
-                    alread_allocated_lens = allocated_len
-                else:
-                    aligned_lengths = ((valid_seq_lens + page_size - 1) // page_size) * page_size
-                    alread_allocated_lens = valid_seq_lens
-                total_aligned_length = np.sum(aligned_lengths)
-
-                # Pre-allocate the result array
-                cache_loc_flat = np.zeros(total_aligned_length, dtype=np.int32)
-
-                # Vectorized filling of cache_loc_flat
-                # Calculate destination offsets for each block (where each block starts in cache_loc_flat)
-                dst_offsets = np.concatenate(([0], np.cumsum(aligned_lengths)[:-1]))
-
-                # We need to copy 'alread_allocated_lens' elements for each request
-                repeats = alread_allocated_lens
-                total_elements = np.sum(repeats)
-
-                if total_elements > 0:
-                    # 1. Generate Source Indices (row, col) for token_indices_with_all_reqs
-                    row_indices = np.repeat(valid_indices, repeats)
-
-                    # Generate col indices: 0..len-1 for each row
-                    # Using the shift trick: global_range - block_start_offsets
-                    block_starts = np.concatenate(([0], np.cumsum(repeats)[:-1]))
-                    shifts = np.repeat(block_starts, repeats)
-                    col_indices = np.arange(total_elements) - shifts
-
-                    # Extract source data
-                    source_data = token_indices_with_all_reqs[row_indices, col_indices]
-
-                    # 2. Generate Destination Indices for cache_loc_flat
-                    # Base offset for each block + local col index
-                    dst_base_offsets = np.repeat(dst_offsets, repeats)
-                    dst_indices = dst_base_offsets + col_indices
-
-                    # Assign
-                    cache_loc_flat[dst_indices] = source_data
-
-        bid = acc_global_bid()
-        if precision_tracer.get_trace_active():
-            self._generate_trace_info(real_bs, bid)
-        # Extract lora_ids from requests
-        lora_ids = [req.lora_id for req in self.reqs]
-
-        return ModelWorkerBatch(
-            bid=bid,
-            forward_mode=self.forward_mode,
-            input_ids=input_ids_cpu,
-            real_input_ids_len=real_input_ids_len,
-            req_pool_indices=req_pool_indices_cpu,
-            seq_lens=seq_lens_cpu,
-            out_cache_loc=out_cache_loc_cpu,
-            return_logprob=self.return_logprob,
-            return_output_logprob_only=self.return_output_logprob_only,
-            top_logprobs_nums=self.top_logprobs_nums,
-            token_ids_logprobs=self.token_ids_logprobs,
-            sampling_info=self._merge_sampling_info(real_bs, real_bs),
-            positions=positions_cpu,
-            mrope_positions=mrope_positions_cpu,
-            cache_loc=cache_loc_flat,
-            extend_prefix_lens=None,
-            extend_seq_lens=None,
-            extend_logprob_start_lens=None,
-            extend_input_logprob_token_ids=self.extend_input_logprob_token_ids,
-            logits_indices=None,
-            lora_ids=lora_ids,
-            real_bs=real_bs,
-            real_bs_per_dp=[real_bs],
-            dp_size=self.dp_size,
-            per_dp_bs_size=real_bs,
-            logits_indices_selector=np.arange(real_bs, dtype=np.int32),
-            capture_hidden_mode=(
-                CaptureHiddenMode.FULL
-                if self.return_hidden_states
-                else (
-                    getattr(spec_info_local, "capture_hidden_mode", CaptureHiddenMode.NULL)
-                    if spec_info_local
-                    else CaptureHiddenMode.NULL
-                )
-            ),
-            launch_done=self.launch_done,
-            spec_info_padded=spec_info_local,
-            spec_algorithm=self.spec_algorithm,
-            tree_cache=self.tree_cache,
-        )
+        return self._get_spec_decode_mwb_dp(bs_paddings, enable_static_lora, draft_token_num)
 
     def _generate_trace_info(self, real_bs: int, bid: int) -> list[str]:
         """Generate trace information for requests (unified for all dp_size >= 1)."""

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1418,9 +1418,9 @@ class ScheduleBatch:
 
         self.maybe_evict_swa()
 
-        # Spec decode: spec_info is global (DP-padded order, on reqs_info[0]);
-        # allocate KV once across all ranks, then return — input_ids/positions
-        # are rebuilt inside forward_batch_speculative_generation.
+        # prepare_for_decode requires cross-rank-flat allocate_lens
+        # (asserts shape[0] == batch_size); rebuild via _concat, run it, then
+        # split allocate_lens back to per-rank.
         if self.spec_algorithm is not None and self.spec_algorithm.is_eagle():
             for info in self.reqs_info:
                 if not info.reqs:
@@ -1429,8 +1429,12 @@ class ScheduleBatch:
                     info.seq_lens = None
                     info.out_cache_loc = None
                     info.seq_lens_sum = 0
-            draft_input: EagleDraftInput = self.reqs_info[0].spec_info
-            draft_input.prepare_for_decode(self)
+            flat_spec = self._concat_spec_info_per_rank([info.spec_info for info in self.reqs_info])
+            flat_spec.prepare_for_decode(self)
+            real_bs_per_dp = [len(info.reqs) if info.reqs else 0 for info in self.reqs_info]
+            per_rank_spec = self._split_spec_info_per_rank(flat_spec, real_bs_per_dp)
+            for r, s in enumerate(per_rank_spec):
+                self.reqs_info[r].spec_info = s
             return
 
         # Process each DP rank
@@ -1530,15 +1534,7 @@ class ScheduleBatch:
         if chunked_req_to_exclude is None:
             chunked_req_to_exclude = {}
 
-        # spec_info is global (flat across ranks, on reqs_info[0]); pull it out
-        # so the per-rank loop doesn't clear/filter it with rank-local indices,
-        # accumulate global flat keep-indices, then filter once after the loop.
-        _global_spec = self.reqs_info[0].spec_info
-        self.reqs_info[0].spec_info = None
-        _global_keep: list[int] = []
-        _flat_base = 0
-
-        # Unified DP filtering logic (works for all dp_size including 1)
+        # Unified DP filtering logic (works for all dp_size including 1).
         for dp_rank in range(self.dp_size):
             info = self.reqs_info[dp_rank]
 
@@ -1562,9 +1558,6 @@ class ScheduleBatch:
                     if not info.reqs[i].finished()
                     and (chunked_req is None or info.reqs[i] != chunked_req)
                 ]
-
-            _global_keep.extend(_flat_base + i for i in keep_indices_dp)
-            _flat_base += len(info.reqs)
 
             # Early exit: Clear all if nothing to keep
             if len(keep_indices_dp) == 0:
@@ -1607,15 +1600,6 @@ class ScheduleBatch:
             else:
                 info.seq_lens_sum = 0
 
-            # Filter speculative decoding arrays manually (if present)
-            if info.spec_info is not None and info.spec_info.topk_p is not None:
-                keep_indices_jax = jnp.asarray(keep_indices_dp, dtype=jnp.int32)
-                info.spec_info.topk_p = info.spec_info.topk_p[keep_indices_jax]
-                info.spec_info.topk_index = info.spec_info.topk_index[keep_indices_jax]
-                info.spec_info.hidden_states = info.spec_info.hidden_states[keep_indices_jax]
-                info.spec_info.verified_id = info.spec_info.verified_id[keep_indices_jax]
-                info.spec_info.allocate_lens = info.spec_info.allocate_lens[keep_indices_jax]
-
             # Filter logprob lists
             if info.top_logprobs_nums is not None:
                 info.top_logprobs_nums = [info.top_logprobs_nums[i] for i in keep_indices_dp]
@@ -1625,9 +1609,8 @@ class ScheduleBatch:
             if info.sampling_info is not None:
                 info.sampling_info.filter_batch(np.array(keep_indices_dp))
 
-            # Filter spec_info (method call)
+            # Filter spec_info (per-rank EagleDraftInput; handles all 5 spec arrays).
             if info.spec_info is not None:
-                # Note: has_been_filtered logic matches original implementation
                 if chunked_req_to_exclude is not None and len(chunked_req_to_exclude) > 0:
                     has_been_filtered = False
                 else:
@@ -1635,20 +1618,6 @@ class ScheduleBatch:
                 info.spec_info.filter_batch(
                     new_indices=keep_indices_dp, has_been_filtered=has_been_filtered
                 )
-
-        # Restore + filter the global spec_info with cross-rank flat indices.
-        if _global_spec is not None and len(_global_keep) > 0:
-            gk = np.asarray(_global_keep, dtype=np.int32)
-            if _global_spec.topk_p is not None:
-                _global_spec.topk_p = _global_spec.topk_p[gk]
-                _global_spec.topk_index = _global_spec.topk_index[gk]
-                _global_spec.hidden_states = _global_spec.hidden_states[gk]
-                _global_spec.verified_id = _global_spec.verified_id[gk]
-            if _global_spec.allocate_lens is not None:
-                _global_spec.allocate_lens = np.asarray(_global_spec.allocate_lens)[gk]
-            self.reqs_info[0].spec_info = _global_spec
-        elif _global_spec is not None and len(_global_keep) == 0:
-            self.reqs_info[0].spec_info = None
 
         # Recalculate global batch flags from all remaining requests
         all_reqs = [req for info in self.reqs_info for req in (info.reqs if info.reqs else [])]
@@ -2108,13 +2077,11 @@ class ScheduleBatch:
             logits_indices_selector,
         ) = self._merge_batch_metadata(per_dp_bs, total_bs)
         sampling_info = self._merge_sampling_info(per_dp_bs, total_bs)
-        # spec_info arrays live global-flat (rank-then-req contiguous, shape
-        # (real_bs,)) on reqs_info[0]. Scatter into DP-padded (total_bs,) slots
-        # via logits_indices_selector so spec_info[i] aligns with seq_lens[i].
-        # padding_for_decode then gathers via valid_mask=seq_lens>0 and gets
-        # back exactly the global-flat order. New object — don't mutate the
-        # cross-round state on reqs_info[0].
-        flat_spec = self.reqs_info[0].spec_info
+        # Concat per-rank spec_info into a cross-rank-flat EagleDraftInput,
+        # then scatter into DP-padded (total_bs, ...) slots so spec_info[i]
+        # aligns with seq_lens[i]. Returns a new object — does not mutate
+        # the per-rank cross-round state on reqs_info[r].spec_info.
+        flat_spec = self._concat_spec_info_per_rank([info.spec_info for info in self.reqs_info])
         spec_info = self._scatter_spec_info_to_dp_slots(
             flat_spec, logits_indices_selector, total_bs
         )
@@ -2171,7 +2138,7 @@ class ScheduleBatch:
             logits_indices_selector=logits_indices_selector,
             capture_hidden_mode=getattr(spec_info, "capture_hidden_mode", CaptureHiddenMode.NULL),
             launch_done=self.launch_done,
-            spec_info=spec_info,
+            spec_info_padded=spec_info,
             spec_algorithm=self.spec_algorithm,
             tree_cache=self.tree_cache,
             mrope_positions=None,
@@ -2183,7 +2150,7 @@ class ScheduleBatch:
 
         ``selector[k]`` is the DP-padded slot of the k-th global-flat req
         (== ``logits_indices_selector``). Returns a new ``EagleDraftInput``;
-        the cross-round flat state on ``reqs_info[0].spec_info`` is unchanged.
+        the cross-round flat state on ``reqs_info[r].spec_info`` is unchanged.
         """
 
         def _scatter1(arr):
@@ -2204,6 +2171,85 @@ class ScheduleBatch:
             accept_length=flat.accept_length,
             accept_length_cpu=flat.accept_length_cpu,
         )
+
+    @staticmethod
+    def _split_spec_info_per_rank(flat, real_bs_per_dp: list[int]) -> list:
+        """Slice a cross-rank-flat EagleDraftInput into per-rank EagleDraftInputs.
+
+        ``flat`` layout is ``[rank0 reqs ++ rank1 reqs ++ …]`` with total length
+        ``sum(real_bs_per_dp)``. Empty ranks (``real_bs == 0``) yield ``None``.
+        Used at forward output boundary to write back ``reqs_info[r].spec_info``.
+        """
+        if flat is None:
+            return [None] * len(real_bs_per_dp)
+
+        per_req_fields = (
+            "topk_p",
+            "topk_index",
+            "hidden_states",
+            "verified_id",
+            "allocate_lens",
+            "accept_length",
+            "accept_length_cpu",
+        )
+
+        out = []
+        offset = 0
+        for n in real_bs_per_dp:
+            if n == 0:
+                out.append(None)
+                continue
+            kwargs = {"capture_hidden_mode": flat.capture_hidden_mode}
+            for f in per_req_fields:
+                v = getattr(flat, f, None)
+                kwargs[f] = None if v is None else v[offset : offset + n]
+            out.append(type(flat)(**kwargs))
+            offset += n
+        return out
+
+    @staticmethod
+    def _concat_spec_info_per_rank(per_rank: list):
+        """Concat per-rank EagleDraftInputs into a single cross-rank-flat one.
+
+        ``None`` entries are skipped. Returns ``None`` if every entry is ``None``.
+        Used at forward input boundary (``_get_spec_decode_mwb_dp``) to build the
+        flat shape ``_scatter_spec_info_to_dp_slots`` expects.
+        """
+        nonempty = [s for s in per_rank if s is not None]
+        if not nonempty:
+            return None
+
+        per_req_fields = (
+            "topk_p",
+            "topk_index",
+            "hidden_states",
+            "verified_id",
+            "allocate_lens",
+            "accept_length",
+            "accept_length_cpu",
+        )
+
+        kwargs = {"capture_hidden_mode": nonempty[0].capture_hidden_mode}
+        for f in per_req_fields:
+            vals = [getattr(s, f, None) for s in nonempty]
+            nonnull = [v for v in vals if v is not None]
+            if not nonnull:
+                kwargs[f] = None
+                continue
+            # All nonempty ranks should agree on which optional fields they
+            # carry — they came from the same per-rank verify split. A partial
+            # mix means the concat length would silently drift from
+            # ``sum(real_bs_per_dp)``; fail loudly instead.
+            assert len(nonnull) == len(nonempty), (
+                f"_concat_spec_info_per_rank: field {f!r} is None on "
+                f"{len(nonempty) - len(nonnull)}/{len(nonempty)} nonempty rank(s); "
+                "all-or-nothing required"
+            )
+            if isinstance(nonnull[0], np.ndarray):
+                kwargs[f] = np.concatenate(nonnull, axis=0)
+            else:
+                kwargs[f] = jnp.concatenate(nonnull, axis=0)
+        return type(nonempty[0])(**kwargs)
 
     def get_model_worker_batch(
         self,
@@ -2367,27 +2413,13 @@ class ScheduleBatch:
         page_size: int,
         enable_static_lora: bool = False,
     ) -> ModelWorkerBatch:
+        # Spec extend always routes through get_model_worker_batch (padded mwb
+        # shared with nospec). Only decode/idle reaches here.
+        assert (
+            self.forward_mode.is_decode_or_idle()
+        ), "spec extend must use get_model_worker_batch, only decode reaches here"
         if self.dp_size > 1:
-            # dp>1 spec extend goes through get_model_worker_batch (padded prefill,
-            # see scheduler._spec_multi_layer); only decode reaches here.
-            assert (
-                self.forward_mode.is_decode_or_idle()
-            ), "spec extend at dp>1 must use get_model_worker_batch (#1053 P1-5b)"
             return self._get_spec_decode_mwb_dp(bs_paddings, enable_static_lora)
-        if self.forward_mode.is_decode_or_idle():
-            extend_seq_lens = extend_prefix_lens = extend_logprob_start_lens = None
-        else:
-            extend_seq_lens = np.array(self.extend_lens, dtype=np.int32)
-            extend_prefix_lens = np.array(self.prefix_lens, dtype=np.int32)
-            extend_logprob_start_lens = self.extend_logprob_start_lens
-        logits_indices = None
-        if self.forward_mode.is_extend() and extend_seq_lens is not None:
-            if len(extend_seq_lens) > 0:
-                logits_indices = np.cumsum(extend_seq_lens, dtype=np.int32) - 1
-            else:
-                logits_indices = np.array([], dtype=np.int32)
-
-        acc_global_bid()
 
         if self.input_ids is None:
             input_ids_cpu = np.empty(0, dtype=np.int32)
@@ -2402,61 +2434,39 @@ class ScheduleBatch:
         req_pool_indices_cpu = self.req_pool_indices
         token_indices_with_all_reqs = self.req_to_token_pool.req_to_token[self.req_pool_indices]
         # FIXME @pc, move this to eagle_worker
-        # If enable spec inference, use positions in spec info firstly
-        if self.spec_info is not None and getattr(self.spec_info, "positions", None) is not None:
-            positions_cpu = self.spec_info.positions
+        # If enable spec inference, use positions in spec info firstly.
+        spec_info_local = (
+            self.reqs_info[0].spec_info if self.reqs_info and self.reqs_info[0] else None
+        )
+        if spec_info_local is not None and getattr(spec_info_local, "positions", None) is not None:
+            positions_cpu = spec_info_local.positions
         else:
-            positions_cpu = None
-
-        # Calculate positions after padding
-        if self.forward_mode.is_extend():
-            # For prefill: create positions for each token in sequences
-            # Calculate total tokens without padding first
-            if positions_cpu is None:
-                lengths = seq_lens_cpu - self.prefix_lens
-                if len(lengths) > 0:
-                    repeats = lengths
-                    total_len = np.sum(repeats)
-                    # Generate range [0, 1, ... len-1] for each sequence
-                    block_starts = np.concatenate(([0], np.cumsum(repeats)[:-1]))
-                    shifts = np.repeat(block_starts, repeats)
-                    ranges = np.arange(total_len) - shifts
-                    # Add prefix_len to each range
-                    positions_cpu = np.repeat(self.prefix_lens, repeats) + ranges
-                    positions_cpu = positions_cpu.astype(seq_lens_cpu.dtype)
-                else:
-                    positions_cpu = np.array([], dtype=seq_lens_cpu.dtype)
-        else:
-            if positions_cpu is None:
-                # For decode: each sequence contributes one token at the next position (seq_len)
-                # Create positions for actual tokens (one per sequence at seq_len)
-                batch_positions = np.maximum(0, seq_lens_cpu - 1)
-                # Create positions array matching the length of input_ids (including padding)
-                positions_cpu = np.zeros(len(batch_positions), dtype=batch_positions.dtype)
-                # Fill in the actual positions for the real tokens
-                # positions = positions.at[: len(batch_positions)].set(batch_positions)
-                positions_cpu[: len(batch_positions)] = batch_positions
+            # Decode: each sequence contributes one token at the next position.
+            batch_positions = np.maximum(0, seq_lens_cpu - 1)
+            positions_cpu = np.zeros(len(batch_positions), dtype=batch_positions.dtype)
+            positions_cpu[: len(batch_positions)] = batch_positions
 
         mrope_positions_cpu = _compute_mrope_positions_for_batch(
             self.reqs,
             self.forward_mode,
             seq_lens_cpu,
             len(input_ids_cpu),
-            extend_prefix_lens,
-            extend_seq_lens,
+            None,
+            None,
         )
 
         cache_loc_flat = np.array([], dtype=np.int32)
 
         if len(seq_lens_cpu) > 0:
             seq_lens = seq_lens_cpu
-            if self.spec_algorithm is not None and not self.spec_algorithm.is_none():
-                if self.forward_mode == ForwardMode.TARGET_VERIFY:
-                    seq_lens = seq_lens_cpu + self.spec_info.draft_token_num
-                elif self.forward_mode == ForwardMode.DECODE:
-                    from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
+            if (
+                self.spec_algorithm is not None
+                and not self.spec_algorithm.is_none()
+                and self.forward_mode == ForwardMode.DECODE
+            ):
+                from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
 
-                    seq_lens = seq_lens_cpu + EagleDraftInput.ALLOC_LEN_PER_DECODE
+                seq_lens = seq_lens_cpu + EagleDraftInput.ALLOC_LEN_PER_DECODE
             # Filter out empty sequences
             valid_mask = seq_lens > 0
             if np.any(valid_mask):
@@ -2466,10 +2476,11 @@ class ScheduleBatch:
                 if (
                     self.forward_mode == ForwardMode.DECODE
                     and not self.spec_algorithm.is_none()
-                    and self.spec_info.allocate_lens is not None
+                    and spec_info_local is not None
+                    and spec_info_local.allocate_lens is not None
                 ):
                     # Explicitly convert to numpy to avoid JAX device synchronization overhead
-                    allocated_len_cpu = np.array(self.spec_info.allocate_lens)
+                    allocated_len_cpu = np.array(spec_info_local.allocate_lens)
                     allocated_len = allocated_len_cpu[: len(self.reqs)]
                     aligned_lengths = ((allocated_len + page_size - 1) // page_size) * page_size
                     alread_allocated_lens = allocated_len
@@ -2510,6 +2521,7 @@ class ScheduleBatch:
                     # Assign
                     cache_loc_flat[dst_indices] = source_data
 
+        bid = acc_global_bid()
         if precision_tracer.get_trace_active():
             self._generate_trace_info(real_bs, bid)
         # Extract lora_ids from requests
@@ -2531,11 +2543,11 @@ class ScheduleBatch:
             positions=positions_cpu,
             mrope_positions=mrope_positions_cpu,
             cache_loc=cache_loc_flat,
-            extend_prefix_lens=(extend_prefix_lens if self.forward_mode.is_extend() else None),
-            extend_seq_lens=(extend_seq_lens if self.forward_mode.is_extend() else None),
-            extend_logprob_start_lens=extend_logprob_start_lens,
+            extend_prefix_lens=None,
+            extend_seq_lens=None,
+            extend_logprob_start_lens=None,
             extend_input_logprob_token_ids=self.extend_input_logprob_token_ids,
-            logits_indices=logits_indices,
+            logits_indices=None,
             lora_ids=lora_ids,
             real_bs=real_bs,
             real_bs_per_dp=[real_bs],
@@ -2546,13 +2558,13 @@ class ScheduleBatch:
                 CaptureHiddenMode.FULL
                 if self.return_hidden_states
                 else (
-                    getattr(self.spec_info, "capture_hidden_mode", CaptureHiddenMode.NULL)
-                    if self.spec_info
+                    getattr(spec_info_local, "capture_hidden_mode", CaptureHiddenMode.NULL)
+                    if spec_info_local
                     else CaptureHiddenMode.NULL
                 )
             ),
             launch_done=self.launch_done,
-            spec_info=self.spec_info,
+            spec_info_padded=spec_info_local,
             spec_algorithm=self.spec_algorithm,
             tree_cache=self.tree_cache,
         )
@@ -3031,7 +3043,11 @@ class ModelWorkerBatch:
     # Pre-initialized ForwardBatch for overlap scheduling optimization
     forward_batch: Any | None = None
 
-    spec_info: EagleDraftInput | EagleVerifyInput | None = None
+    # Cross-rank-flat (or scatter-padded under dp>1) spec input at forward
+    # entry. Forward internals may mutate it through EagleVerifyInput before
+    # returning a fresh EagleDraftInput. Scheduler-persisted per-rank spec
+    # state lives on ScheduleBatch.reqs_info[r].spec_info.
+    spec_info_padded: EagleDraftInput | EagleVerifyInput | None = None
     spec_algorithm: SpeculativeAlgorithm = None
     speculative_num_steps: int = 0
     speculative_eagle_topk: int = 0

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1418,6 +1418,21 @@ class ScheduleBatch:
 
         self.maybe_evict_swa()
 
+        # Spec decode: spec_info is global (DP-padded order, on reqs_info[0]);
+        # allocate KV once across all ranks, then return — input_ids/positions
+        # are rebuilt inside forward_batch_speculative_generation.
+        if self.spec_algorithm is not None and self.spec_algorithm.is_eagle():
+            for info in self.reqs_info:
+                if not info.reqs:
+                    info.input_ids = None
+                    info.output_ids = None
+                    info.seq_lens = None
+                    info.out_cache_loc = None
+                    info.seq_lens_sum = 0
+            draft_input: EagleDraftInput = self.reqs_info[0].spec_info
+            draft_input.prepare_for_decode(self)
+            return
+
         # Process each DP rank
         for dp_rank in range(self.dp_size):
             info = self.reqs_info[dp_rank]
@@ -1434,13 +1449,6 @@ class ScheduleBatch:
                 continue
 
             bs = len(reqs)
-
-            # Handle spec decoding if enabled
-            if self.spec_algorithm is not None and self.spec_algorithm.is_eagle():
-                # if spec decoding is used, the decode batch is prepared inside
-                # `forward_batch_speculative_generation` after running draft models.
-                draft_input: EagleDraftInput = info.spec_info
-                draft_input.prepare_for_decode(self)
 
             if self.spec_algorithm is not None and not self.spec_algorithm.is_none():
                 continue  # Skip to next DP rank
@@ -1522,6 +1530,14 @@ class ScheduleBatch:
         if chunked_req_to_exclude is None:
             chunked_req_to_exclude = {}
 
+        # spec_info is global (flat across ranks, on reqs_info[0]); pull it out
+        # so the per-rank loop doesn't clear/filter it with rank-local indices,
+        # accumulate global flat keep-indices, then filter once after the loop.
+        _global_spec = self.reqs_info[0].spec_info
+        self.reqs_info[0].spec_info = None
+        _global_keep: list[int] = []
+        _flat_base = 0
+
         # Unified DP filtering logic (works for all dp_size including 1)
         for dp_rank in range(self.dp_size):
             info = self.reqs_info[dp_rank]
@@ -1546,6 +1562,9 @@ class ScheduleBatch:
                     if not info.reqs[i].finished()
                     and (chunked_req is None or info.reqs[i] != chunked_req)
                 ]
+
+            _global_keep.extend(_flat_base + i for i in keep_indices_dp)
+            _flat_base += len(info.reqs)
 
             # Early exit: Clear all if nothing to keep
             if len(keep_indices_dp) == 0:
@@ -1616,6 +1635,20 @@ class ScheduleBatch:
                 info.spec_info.filter_batch(
                     new_indices=keep_indices_dp, has_been_filtered=has_been_filtered
                 )
+
+        # Restore + filter the global spec_info with cross-rank flat indices.
+        if _global_spec is not None and len(_global_keep) > 0:
+            gk = np.asarray(_global_keep, dtype=np.int32)
+            if _global_spec.topk_p is not None:
+                _global_spec.topk_p = _global_spec.topk_p[gk]
+                _global_spec.topk_index = _global_spec.topk_index[gk]
+                _global_spec.hidden_states = _global_spec.hidden_states[gk]
+                _global_spec.verified_id = _global_spec.verified_id[gk]
+            if _global_spec.allocate_lens is not None:
+                _global_spec.allocate_lens = np.asarray(_global_spec.allocate_lens)[gk]
+            self.reqs_info[0].spec_info = _global_spec
+        elif _global_spec is not None and len(_global_keep) == 0:
+            self.reqs_info[0].spec_info = None
 
         # Recalculate global batch flags from all remaining requests
         all_reqs = [req for info in self.reqs_info for req in (info.reqs if info.reqs else [])]
@@ -2046,6 +2079,132 @@ class ScheduleBatch:
             grammars=[req.grammar for req in all_reqs] if self.has_grammar else None,
         )
 
+    def _get_spec_decode_mwb_dp(
+        self, bs_paddings: list, enable_static_lora: bool
+    ) -> ModelWorkerBatch:
+        """DP-aware spec-decode ModelWorkerBatch (#1053 P1-5b).
+
+        Reuses the nospec ``_merge_*`` helpers for per-rank seq_lens /
+        req_pool_indices / sampling_info. ``spec_info`` is global (DP-padded
+        order, see ``EagleDraftInput`` docstring) and lives only on
+        ``reqs_info[0]``. ``input_ids``/``positions``/``cache_loc`` are
+        placeholders — ``EagleDraftWorker.padding_for_decode`` rebuilds them.
+        """
+        max_bs_per_dp = max(
+            (len(i.seq_lens) if i.seq_lens is not None else 0) for i in self.reqs_info
+        )
+        total_bs, _ = pad_to_bucket(max(max_bs_per_dp, 1) * self.dp_size, bs_paddings)
+        per_dp_bs = total_bs // self.dp_size
+        self.per_dp_bs_size = per_dp_bs
+        (
+            req_pool_indices_cpu,
+            seq_lens_cpu,
+            _ext_prefix,
+            _ext_seq,
+            _ext_logprob,
+            _logits_idx,
+            real_bs,
+            real_bs_per_dp,
+            logits_indices_selector,
+        ) = self._merge_batch_metadata(per_dp_bs, total_bs)
+        sampling_info = self._merge_sampling_info(per_dp_bs, total_bs)
+        # spec_info arrays live global-flat (rank-then-req contiguous, shape
+        # (real_bs,)) on reqs_info[0]. Scatter into DP-padded (total_bs,) slots
+        # via logits_indices_selector so spec_info[i] aligns with seq_lens[i].
+        # padding_for_decode then gathers via valid_mask=seq_lens>0 and gets
+        # back exactly the global-flat order. New object — don't mutate the
+        # cross-round state on reqs_info[0].
+        flat_spec = self.reqs_info[0].spec_info
+        spec_info = self._scatter_spec_info_to_dp_slots(
+            flat_spec, logits_indices_selector, total_bs
+        )
+        # Per-rank out_cache_loc chunks (set in spec prepare_for_decode) have
+        # variable length (∝ accept_len). DP-segment: pad each to max_len with
+        # -1 so the P("data") shard in ForwardBatch.init_new gives rank r its
+        # own slots (fa_backend doesn't use it, but native_backend would).
+        ocl_chunks = [
+            (
+                np.asarray(i.out_cache_loc, dtype=np.int32)
+                if i.out_cache_loc is not None and len(i.out_cache_loc) > 0
+                else np.empty(0, dtype=np.int32)
+            )
+            for i in self.reqs_info
+        ]
+        max_ocl = max((len(c) for c in ocl_chunks), default=0)
+        out_cache_loc = (
+            np.concatenate(
+                [np.pad(c, (0, max_ocl - len(c)), constant_values=-1) for c in ocl_chunks]
+            )
+            if max_ocl > 0
+            else np.empty(0, dtype=np.int32)
+        )
+        return ModelWorkerBatch(
+            bid=acc_global_bid(),
+            forward_mode=self.forward_mode,
+            input_ids=np.empty(0, dtype=np.int32),
+            real_input_ids_len=0,
+            req_pool_indices=req_pool_indices_cpu,
+            seq_lens=seq_lens_cpu,
+            out_cache_loc=out_cache_loc,
+            return_logprob=self.return_logprob,
+            return_output_logprob_only=self.return_output_logprob_only,
+            top_logprobs_nums=None,
+            token_ids_logprobs=None,
+            sampling_info=sampling_info,
+            positions=np.empty(0, dtype=np.int32),
+            cache_loc=np.empty(0, dtype=np.int32),
+            extend_prefix_lens=None,
+            extend_seq_lens=None,
+            extend_logprob_start_lens=None,
+            extend_input_logprob_token_ids=None,
+            logits_indices=None,
+            lora_ids=(
+                ["0"] * total_bs
+                if enable_static_lora
+                else [r.lora_id for i in self.reqs_info for r in (i.reqs or [])]
+                + ["0"] * (total_bs - real_bs)
+            ),
+            real_bs=real_bs,
+            real_bs_per_dp=real_bs_per_dp,
+            dp_size=self.dp_size,
+            per_dp_bs_size=per_dp_bs,
+            logits_indices_selector=logits_indices_selector,
+            capture_hidden_mode=getattr(spec_info, "capture_hidden_mode", CaptureHiddenMode.NULL),
+            launch_done=self.launch_done,
+            spec_info=spec_info,
+            spec_algorithm=self.spec_algorithm,
+            tree_cache=self.tree_cache,
+            mrope_positions=None,
+        )
+
+    @staticmethod
+    def _scatter_spec_info_to_dp_slots(flat, selector: np.ndarray, total_bs: int):
+        """Scatter global-flat spec_info arrays into DP-padded ``(total_bs, …)``.
+
+        ``selector[k]`` is the DP-padded slot of the k-th global-flat req
+        (== ``logits_indices_selector``). Returns a new ``EagleDraftInput``;
+        the cross-round flat state on ``reqs_info[0].spec_info`` is unchanged.
+        """
+
+        def _scatter1(arr):
+            if arr is None:
+                return None
+            a = np.asarray(arr)
+            out = np.zeros((total_bs,) + a.shape[1:], dtype=a.dtype)
+            out[selector] = a
+            return out
+
+        return type(flat)(
+            topk_p=_scatter1(flat.topk_p),
+            topk_index=_scatter1(flat.topk_index),
+            hidden_states=_scatter1(flat.hidden_states),
+            verified_id=_scatter1(flat.verified_id),
+            allocate_lens=_scatter1(flat.allocate_lens),
+            capture_hidden_mode=flat.capture_hidden_mode,
+            accept_length=flat.accept_length,
+            accept_length_cpu=flat.accept_length_cpu,
+        )
+
     def get_model_worker_batch(
         self,
         token_paddings: list,
@@ -2208,6 +2367,13 @@ class ScheduleBatch:
         page_size: int,
         enable_static_lora: bool = False,
     ) -> ModelWorkerBatch:
+        if self.dp_size > 1:
+            # dp>1 spec extend goes through get_model_worker_batch (padded prefill,
+            # see scheduler._spec_multi_layer); only decode reaches here.
+            assert (
+                self.forward_mode.is_decode_or_idle()
+            ), "spec extend at dp>1 must use get_model_worker_batch (#1053 P1-5b)"
+            return self._get_spec_decode_mwb_dp(bs_paddings, enable_static_lora)
         if self.forward_mode.is_decode_or_idle():
             extend_seq_lens = extend_prefix_lens = extend_logprob_start_lens = None
         else:

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1843,14 +1843,20 @@ class Scheduler(
             batch_output = self.draft_worker.forward_batch_speculative_generation(
                 model_worker_batch
             )
-            info = batch.reqs_info[0]
-            if batch_output.accept_lens is not None:
-                # Decode
-                info.seq_lens = info.seq_lens + batch_output.accept_lens
-            else:
-                # Prefill
-                info.seq_lens = info.seq_lens + 1
-            info.spec_info = batch_output.next_draft_input
+            # spec_info is global (DP-padded order), stored on rank 0 only.
+            batch.reqs_info[0].spec_info = batch_output.next_draft_input
+            accept = batch_output.accept_lens
+            if accept is not None:
+                accept = np.asarray(jax.device_get(accept))
+            per_dp_bs = model_worker_batch.per_dp_bs_size
+            for dp_rank, info in enumerate(batch.reqs_info):
+                if info.seq_lens is None or len(info.seq_lens) == 0:
+                    continue
+                if accept is not None:
+                    off = dp_rank * per_dp_bs
+                    info.seq_lens = info.seq_lens + accept[off : off + len(info.seq_lens)]
+                else:
+                    info.seq_lens = info.seq_lens + 1
             next_token_ids = np.asarray(jax.device_get(batch_output.next_token_ids))
             self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
             logits_output = batch_output.logits_output

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -298,10 +298,28 @@ class Scheduler(
         )
 
         # launch draft worker
+        self._spec_multi_layer = False
         if self.spec_algorithm is not None and self.spec_algorithm.is_eagle():
-            from sgl_jax.srt.speculative.eagle_worker import EAGLEWorker
+            # Multi-layer vs single-layer is a model property (how many MTP heads
+            # the target ships), not a CLI-algorithm property. NEXTN with a single
+            # MTP head behaves exactly like EAGLE (same head run N times).
+            # DeepSeek-style configs expose num_nextn_predict_layers; MiMo-style
+            # configs don't, so fall back to --speculative-num-steps under NEXTN
+            # (one MTP weight set per step).
+            n_mtp = getattr(self.tp_worker.model_config.hf_config, "num_nextn_predict_layers", None)
+            if n_mtp is None and self.spec_algorithm.is_nextn():
+                n_mtp = server_args.speculative_num_steps
+            self._spec_multi_layer = n_mtp is not None and n_mtp > 1
+            if self._spec_multi_layer:
+                from sgl_jax.srt.speculative.multi_layer_eagle_worker import (
+                    MultiLayerEAGLEWorker as _SpecWorkerCls,
+                )
+            else:
+                from sgl_jax.srt.speculative.eagle_worker import (
+                    EAGLEWorker as _SpecWorkerCls,
+                )
 
-            self.draft_worker = EAGLEWorker(
+            self.draft_worker = _SpecWorkerCls(
                 server_args=server_args,
                 target_worker=self.tp_worker,
             )
@@ -1802,13 +1820,26 @@ class Scheduler(
                 next_token_ids = np.array(jax.device_get(next_token_ids_device))
                 self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
         else:
-            model_worker_batch = batch.get_spec_model_worker_batch(
-                precompile_token_paddings,
-                precompile_bs_paddings,
-                precompile_cache_loc_paddings,
-                self.page_size,
-                self.server_args.enable_static_lora,
-            )
+            if batch.forward_mode.is_extend() and self._spec_multi_layer:
+                # Multi-layer-MTP (MoE+EP target) prefill must use the same padded
+                # mwb as nospec so target forward sees identical shapes (#1090).
+                # EagleDraftWorker doesn't yet handle padded prefill mwb, so gate
+                # on the worker selection rather than the algorithm flag.
+                model_worker_batch = batch.get_model_worker_batch(
+                    precompile_token_paddings,
+                    precompile_bs_paddings,
+                    precompile_cache_loc_paddings,
+                    self.page_size,
+                    self.server_args.enable_static_lora,
+                )
+            else:
+                model_worker_batch = batch.get_spec_model_worker_batch(
+                    precompile_token_paddings,
+                    precompile_bs_paddings,
+                    precompile_cache_loc_paddings,
+                    self.page_size,
+                    self.server_args.enable_static_lora,
+                )
             batch_output = self.draft_worker.forward_batch_speculative_generation(
                 model_worker_batch
             )

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1820,11 +1820,10 @@ class Scheduler(
                 next_token_ids = np.array(jax.device_get(next_token_ids_device))
                 self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
         else:
-            if batch.forward_mode.is_extend() and self._spec_multi_layer:
-                # Multi-layer-MTP (MoE+EP target) prefill must use the same padded
-                # mwb as nospec so target forward sees identical shapes (#1090).
-                # EagleDraftWorker doesn't yet handle padded prefill mwb, so gate
-                # on the worker selection rather than the algorithm flag.
+            if batch.forward_mode.is_extend():
+                # Spec extend always uses the padded mwb so target and draft
+                # see identical shapes regardless of dp_size / multi-layer
+                # (#1090 + #1053 P1-5b assert dp>1 spec extend must go here).
                 model_worker_batch = batch.get_model_worker_batch(
                     precompile_token_paddings,
                     precompile_bs_paddings,
@@ -1843,8 +1842,11 @@ class Scheduler(
             batch_output = self.draft_worker.forward_batch_speculative_generation(
                 model_worker_batch
             )
-            # spec_info is global (DP-padded order), stored on rank 0 only.
-            batch.reqs_info[0].spec_info = batch_output.next_draft_input
+            per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
+                batch_output.next_draft_input, model_worker_batch.real_bs_per_dp
+            )
+            for r, s in enumerate(per_rank_spec):
+                batch.reqs_info[r].spec_info = s
             accept = batch_output.accept_lens
             if accept is not None:
                 accept = np.asarray(jax.device_get(accept))

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1838,6 +1838,7 @@ class Scheduler(
                     precompile_cache_loc_paddings,
                     self.page_size,
                     self.server_args.enable_static_lora,
+                    draft_token_num=self.draft_worker.speculative_num_draft_tokens,
                 )
             batch_output = self.draft_worker.forward_batch_speculative_generation(
                 model_worker_batch

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -248,18 +248,31 @@ class SchedulerOutputProcessorMixin:
     def _resolve_spec_decode_token_ids(
         self: Scheduler, result: GenerationBatchResult, batch: ScheduleBatch
     ) -> list[list[int]]:
-        """Resolve the padding next token ids for speculative decoding with overlap."""
+        """Resolve per-req accepted token lists from the verify output.
 
-        next_token_ids = result.next_token_ids
-        accept_lens = result.accept_lens.tolist()
-        result.num_accepted_tokens = sum(accept_lens) - len(batch.reqs)
-        predict_tokens = []
+        Returns a list of length ``per_dp_bs * dp_size`` (DP-padded order),
+        with ``[]`` at padding slots, so the per-rank slice in
+        ``process_batch_result_decode`` works for any ``dp_size``.
+        """
+        next_token_ids = np.asarray(jax.device_get(result.next_token_ids))
+        accept_lens = np.asarray(jax.device_get(result.accept_lens)).tolist()
         stride = self.draft_worker.speculative_num_draft_tokens
-        for i, req in enumerate(batch.reqs):
-            predict_tokens.append(next_token_ids[i * stride : i * stride + accept_lens[i]])
-            req.spec_verify_ct += 1
-            req.spec_accepted_tokens += accept_lens[i]
-
+        per_dp_bs = batch.per_dp_bs_size
+        total_bs = per_dp_bs * batch.dp_size
+        predict_tokens: list[list[int]] = [[] for _ in range(total_bs)]
+        n_real = 0
+        total_accepted = 0
+        for dp_rank, info in enumerate(batch.reqs_info):
+            base = dp_rank * per_dp_bs
+            for j, req in enumerate(info.reqs or []):
+                i = base + j
+                a = accept_lens[i]
+                predict_tokens[i] = next_token_ids[i * stride : i * stride + a].tolist()
+                req.spec_verify_ct += 1
+                req.spec_accepted_tokens += a
+                total_accepted += a
+                n_real += 1
+        result.num_accepted_tokens = total_accepted - n_real
         return predict_tokens
 
     def process_batch_result_decode(
@@ -313,6 +326,10 @@ class SchedulerOutputProcessorMixin:
         # aligned with the selector.
         req_idx = 0
 
+        # spec_info is global (on reqs_info[0]); track flat index across ranks
+        # so the finished-req KV-free below can index allocate_lens correctly.
+        global_spec = batch.reqs_info[0].spec_info
+        global_req_base = 0
         for dp_rank in range(batch.dp_size):
             info = batch.reqs_info[dp_rank]
             reqs = info.reqs
@@ -322,6 +339,7 @@ class SchedulerOutputProcessorMixin:
 
             # Skip empty DP ranks
             if not reqs or not dp_output_ids:
+                global_req_base += len(reqs or [])
                 continue
 
             # Check finish condition for each request in this DP rank
@@ -350,7 +368,7 @@ class SchedulerOutputProcessorMixin:
                 if req.finished():
                     self.maybe_collect_routed_experts(req)
                     if batch.spec_algorithm is not None and batch.spec_algorithm.is_eagle():
-                        cur_allocate_len = int(info.spec_info.allocate_lens[i])
+                        cur_allocate_len = int(global_spec.allocate_lens[global_req_base + i])
                         actual_token_len = len(req.origin_input_ids) + max(
                             len(req.output_ids) - 1, 0
                         )
@@ -445,6 +463,7 @@ class SchedulerOutputProcessorMixin:
                     # Tracking as a follow-up; not in scope for this fix.
                     req.hidden_states.append(logits_output.hidden_states[i])
                 req_idx += 1
+            global_req_base += len(reqs)
 
         # Collect all requests from all DP ranks for stream output
         all_reqs = []

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -350,8 +350,11 @@ class SchedulerOutputProcessorMixin:
                 if req.finished():
                     self.maybe_collect_routed_experts(req)
                     if batch.spec_algorithm is not None and batch.spec_algorithm.is_eagle():
-                        cur_allocate_len = info.spec_info.allocate_lens[i]
-                        all_token_len = len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
+                        cur_allocate_len = int(info.spec_info.allocate_lens[i])
+                        actual_token_len = len(req.origin_input_ids) + max(
+                            len(req.output_ids) - 1, 0
+                        )
+                        all_token_len = actual_token_len
                         if self.page_size > 1:
                             all_token_len = cdiv(all_token_len, self.page_size) * self.page_size
                         kv_indices = self.req_to_token_pool.req_to_token[
@@ -366,6 +369,16 @@ class SchedulerOutputProcessorMixin:
                         ), f"redundant kv indices {len(kv_indices)=} should less than {EagleDraftInput.ALLOC_LEN_PER_DECODE=}"
 
                         self.token_to_kv_pool_allocator.free(kv_indices, dp_rank)
+                        # Spec decode allocates via EagleDraftInput.prepare_for_decode,
+                        # not ScheduleBatch.prepare_for_decode, so kv_committed_len is
+                        # never bumped past prefill. cache_finished_req would then
+                        # free only the prefill page and leak every decode-allocated
+                        # page (visible on idle check_memory at bs=1). Use the
+                        # *unaligned* actual token count: ChunkCache.cache_finished_req
+                        # does NOT filter 0-valued req_to_token entries, so a
+                        # page-aligned length would free the page-0 sentinel.
+                        req.kv_committed_len = actual_token_len
+                        req.kv_allocated_len = actual_token_len
                     # End trace for finished request
                     if precision_tracer.get_trace_active():
                         precision_tracer.set_request_status_to_completed(req.rid)

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -243,7 +243,13 @@ class SchedulerOutputProcessorMixin:
             cache_miss_count,
         )
 
-        batch.spec_info = result.next_draft_input
+        if result.next_draft_input is not None:
+            real_bs_per_dp = [len(info.reqs) if info.reqs else 0 for info in batch.reqs_info]
+            per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
+                result.next_draft_input, real_bs_per_dp
+            )
+            for r, s in enumerate(per_rank_spec):
+                batch.reqs_info[r].spec_info = s
 
     def _resolve_spec_decode_token_ids(
         self: Scheduler, result: GenerationBatchResult, batch: ScheduleBatch
@@ -326,10 +332,6 @@ class SchedulerOutputProcessorMixin:
         # aligned with the selector.
         req_idx = 0
 
-        # spec_info is global (on reqs_info[0]); track flat index across ranks
-        # so the finished-req KV-free below can index allocate_lens correctly.
-        global_spec = batch.reqs_info[0].spec_info
-        global_req_base = 0
         for dp_rank in range(batch.dp_size):
             info = batch.reqs_info[dp_rank]
             reqs = info.reqs
@@ -339,7 +341,6 @@ class SchedulerOutputProcessorMixin:
 
             # Skip empty DP ranks
             if not reqs or not dp_output_ids:
-                global_req_base += len(reqs or [])
                 continue
 
             # Check finish condition for each request in this DP rank
@@ -368,7 +369,7 @@ class SchedulerOutputProcessorMixin:
                 if req.finished():
                     self.maybe_collect_routed_experts(req)
                     if batch.spec_algorithm is not None and batch.spec_algorithm.is_eagle():
-                        cur_allocate_len = int(global_spec.allocate_lens[global_req_base + i])
+                        cur_allocate_len = int(info.spec_info.allocate_lens[i])
                         actual_token_len = len(req.origin_input_ids) + max(
                             len(req.output_ids) - 1, 0
                         )
@@ -463,7 +464,6 @@ class SchedulerOutputProcessorMixin:
                     # Tracking as a follow-up; not in scope for this fix.
                     req.hidden_states.append(logits_output.hidden_states[i])
                 req_idx += 1
-            global_req_base += len(reqs)
 
         # Collect all requests from all DP ranks for stream output
         all_reqs = []

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -309,7 +309,7 @@ class CompilationManager:
             lora_ids=lora_ids,
             dp_size=dp_size,
             per_dp_bs_size=per_dp_bs_size,
-            real_bs_per_dp=[bs] * dp_size,
+            real_bs_per_dp=[per_dp_bs_size] * dp_size,
             logits_indices_selector=np.arange(bs, dtype=np.int32),
             # Hybrid recurrent backends (e.g. KDA) require these per-batch
             # arrays even at precompile time; slot 0 is RecurrentStatePool's

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -256,6 +256,16 @@ class CompilationManager:
             ModelWorkerSamplingInfo,
         )
         from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode
+        from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        # Runtime ScheduleBatch.spec_algorithm is always SpeculativeAlgorithm
+        # enum (.from_string(None) -> .NONE). Default to .NONE so the dummy
+        # batch's pytree aux matches and precompile shares the cache key with
+        # the no-spec runtime path.
+        if speculative_algorithm is None:
+            spec_algorithm_value = SpeculativeAlgorithm.NONE
+        else:
+            spec_algorithm_value = speculative_algorithm
 
         valid_input_ids = np.array([1] * bs, dtype=jnp.int32)
         invalid_input_ids = np.array([0] * (num_tokens - bs), dtype=jnp.int32)
@@ -305,7 +315,7 @@ class CompilationManager:
             capture_hidden_mode=(
                 CaptureHiddenMode.FULL if self.multimodal else CaptureHiddenMode.NULL
             ),
-            spec_algorithm=speculative_algorithm,
+            spec_algorithm=spec_algorithm_value,
             lora_ids=lora_ids,
             dp_size=dp_size,
             per_dp_bs_size=per_dp_bs_size,

--- a/python/sgl_jax/srt/model_executor/forward_batch_info.py
+++ b/python/sgl_jax/srt/model_executor/forward_batch_info.py
@@ -409,7 +409,7 @@ class ForwardBatch:
             lora_token_indices=lora_token_indices,
             lora_ranks=lora_ranks,
             attn_backend=model_runner.attn_backend,
-            spec_info=batch.spec_info,
+            spec_info=batch.spec_info_padded,
             spec_algorithm=batch.spec_algorithm,
             capture_hidden_mode=batch.capture_hidden_mode,
             input_embedding=input_embedding,

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -248,13 +248,12 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
             return compute_logprobs(mesh, logits, next_tokens)
 
         def run_model_wrapper(forward_batch, logits_metadata):
-            memory_pools = self.memory_pools
             return jitted_run_model(
                 model_def,
                 model_state_def,
                 self.model_state_leaves,
                 forward_batch,
-                memory_pools,
+                self.memory_pools,
                 logits_metadata,
             )
 
@@ -627,8 +626,20 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
             ratio = 1.0
 
         denominator = swa_full_tokens_ratio * swa_layers_num * ratio + full_layers_num
-        self.full_max_total_num_tokens = int(total_tokens / denominator)
-        self.swa_max_total_num_tokens = int(self.full_max_total_num_tokens * swa_full_tokens_ratio)
+        if self.is_draft_worker:
+            if full_layers_num == 0:
+                self.full_max_total_num_tokens = 0
+                self.swa_max_total_num_tokens = self.max_total_num_tokens
+            else:
+                self.full_max_total_num_tokens = self.max_total_num_tokens
+                self.swa_max_total_num_tokens = int(
+                    self.max_total_num_tokens * swa_full_tokens_ratio
+                )
+        else:
+            self.full_max_total_num_tokens = int(total_tokens / denominator)
+            self.swa_max_total_num_tokens = int(
+                self.full_max_total_num_tokens * swa_full_tokens_ratio
+            )
 
         # Align pool sizes to page_size and dp_size for sharding compatibility
         dp_size = self.server_args.dp_size

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -554,49 +554,36 @@ class ModelRunnerKVCacheMixin:
         # 4. Resolve max_num_reqs (needed for spec dec headroom)
         max_num_reqs = self._resolve_max_num_reqs(max_num_reqs)
 
-        # 5. Speculative decoding headroom (needs max_num_reqs)
+        # 5. Speculative decoding: resolve draft/target cache sizes.
+        # Headroom added to max_total_num_tokens BEFORE _apply_token_constraints
+        # so it goes through page_align * dp_size naturally.
         if self.spec_algorithm is not None and not self.spec_algorithm.is_none():
             if self.is_draft_worker:
                 self.max_total_num_tokens = self.server_args.draft_runner_cache_size
                 max_num_reqs = self.server_args.max_num_reqs
             else:
-                self.server_args.draft_runner_cache_size = (
-                    self.max_total_num_tokens
-                    + max_num_reqs
+                spec_headroom = (
+                    max_num_reqs
                     * self.server_args.speculative_num_steps
                     * self.server_args.speculative_eagle_topk
                     + max_num_reqs * self.server_args.speculative_num_draft_tokens
                     + 100
                 )
-                self.max_total_num_tokens = self.server_args.draft_runner_cache_size
+                self.max_total_num_tokens += spec_headroom
                 self.server_args.max_num_reqs = max_num_reqs
+                self.server_args.draft_runner_cache_size = self.max_total_num_tokens
 
-        # 6. Apply constraints (CI, user cap, page align, dp). Draft worker's
-        # pool size is target-derived (must cover target's allocator slot
-        # range), so the user --max-total-tokens cap is not re-applied — it
-        # could otherwise shrink the draft pool below the (post-hybrid) target
-        # range and reintroduce the high-slot garbage this commit fixes.
+        # 6. Apply constraints (CI, user cap, page align, dp).
         self.max_total_num_tokens = self._apply_token_constraints(
             self.max_total_num_tokens,
             None if self.is_draft_worker else max_total_tokens,
             dp_size,
         )
 
-        # 7. Hybrid SWA token split (existing logic, not moved)
+        # 7. Hybrid SWA token split. draft_runner_cache_size was saved
+        # above (per-chip, pre-dp) so the draft won't see hybrid inflation.
         if self.is_hybrid:
             self.set_num_token_hybrid()
-            if (
-                not self.is_draft_worker
-                and self.spec_algorithm is not None
-                and not self.spec_algorithm.is_none()
-            ):
-                # Draft shares target's allocator, whose slot range is the
-                # *post-hybrid* full-pool size. The draft_runner_cache_size set
-                # in step 5 was pre-hybrid; without this overwrite, draft's own
-                # KV pool is smaller than the slot range it indexes into, so any
-                # slot >= pre-hybrid size reads/writes garbage (manifests as
-                # accept[1:]=1 for reqs allocated at high slots).
-                self.server_args.draft_runner_cache_size = self.max_total_num_tokens
 
         if self.max_total_num_tokens <= 0:
             raise RuntimeError("Not enough memory. Please try to increase --mem-fraction-static.")

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -819,5 +819,13 @@ class MiMoV2FlashForCausalLM(nnx.Module):
 
         return output, {"token_to_kv_pool": layers_kv_fused}, True, layers_topk_ids
 
+    def get_embed_and_head(self):
+        embed = self.model.embed_tokens.embedding.value
+        if not getattr(self.config, "tie_word_embeddings", True):
+            head = self.lm_head.embedding.value
+        else:
+            head = embed
+        return embed, head
+
 
 EntryClass = [MiMoV2FlashForCausalLM]

--- a/python/sgl_jax/srt/models/mimo_v2_nextn.py
+++ b/python/sgl_jax/srt/models/mimo_v2_nextn.py
@@ -183,6 +183,7 @@ class MiMoV2MTPForCausalLM(nnx.Module):
         )
         self.logits_processor = LogitsProcessor(config.vocab_size, mesh=self.mesh)
         self._fused_qkv_buffers: dict[int, dict] = {}
+        self._uses_fused_mtp_qkv = False
         self.hot_token_ids = None
 
     def __call__(
@@ -207,17 +208,27 @@ class MiMoV2MTPForCausalLM(nnx.Module):
         if self.loader.is_static_quant:
             attn = self.model.mtp_block.self_attn
             head_dim, v_head_dim = attn.head_dim, attn.v_head_dim
-            # dequant_fused_qkv reads full-attn config fields; the MTP block uses
-            # SWA dims, so derive the split config from the actual layer.
-            mtp_qkv_config = SimpleNamespace(
-                head_dim=head_dim,
-                v_head_dim=v_head_dim,
-                num_attention_heads=attn.q_head_num,
-                num_key_value_heads=attn.k_head_num,
-            )
-            self.loader.dequant_fused_qkv(
-                self._fused_qkv_buffers, [self.model.mtp_block], mtp_qkv_config
-            )
+            if self._uses_fused_mtp_qkv:
+                # dequant_fused_qkv reads full-attn config fields; the MTP block uses
+                # SWA dims, so derive the split config from the actual layer.
+                mtp_qkv_config = SimpleNamespace(
+                    head_dim=head_dim,
+                    v_head_dim=v_head_dim,
+                    num_attention_heads=attn.q_head_num,
+                    num_key_value_heads=attn.k_head_num,
+                )
+                self.loader.dequant_fused_qkv(
+                    self._fused_qkv_buffers, [self.model.mtp_block], mtp_qkv_config
+                )
+            else:
+                self.loader.dequant_fp8_layers(
+                    [self.model.mtp_block],
+                    specs=[
+                        ("self_attn.q_proj", head_dim),
+                        ("self_attn.k_proj", head_dim),
+                        ("self_attn.v_proj", v_head_dim),
+                    ],
+                )
             self.loader.dequant_fp8_layers(
                 [self.model.mtp_block],
                 specs=[
@@ -278,14 +289,21 @@ class MiMoV2MTPForCausalLM(nnx.Module):
         }
 
         qkv_key = f"{prefix}.self_attn.qkv_proj"
-        if is_fp8 and not self.loader.is_quant_ignored(qkv_key):
+        has_fused_qkv = (
+            self.loader.has_weight_on_disk(f"{qkv_key}.weight")
+            if hasattr(self.loader, "has_weight_on_disk")
+            else True
+        )
+        self._uses_fused_mtp_qkv = has_fused_qkv
+
+        if has_fused_qkv and is_fp8 and not self.loader.is_quant_ignored(qkv_key):
             mappings[f"{qkv_key}.weight"] = WeightMapping(
                 target_path="__FUSED_QKV_WEIGHT__0", sharding=(None, None), transpose=False
             )
             mappings[f"{qkv_key}.weight_scale_inv"] = WeightMapping(
                 target_path="__FUSED_QKV_SCALE__0", sharding=(None, None), transpose=False
             )
-        else:
+        elif has_fused_qkv:
             mappings[f"{qkv_key}.weight"] = WeightMapping(
                 target_path=[
                     f"{block}.self_attn.q_proj.weight",
@@ -297,6 +315,28 @@ class MiMoV2MTPForCausalLM(nnx.Module):
                 head_dim_padding=False,
                 kv_head_padding=True,
             )
+        else:
+            for proj, head_dim_padding in [
+                ("q_proj", True),
+                ("k_proj", True),
+                ("v_proj", False),
+            ]:
+                hf_key = f"{prefix}.self_attn.{proj}"
+                ignored = self.loader.is_quant_ignored(hf_key)
+                weight_suffix = "weight" if (not is_fp8 or ignored) else "weight_q"
+                mappings[f"{hf_key}.weight"] = WeightMapping(
+                    target_path=f"{block}.self_attn.{proj}.{weight_suffix}",
+                    sharding=(None, "tensor"),
+                    transpose=True,
+                    head_dim_padding=head_dim_padding,
+                    kv_head_padding=not is_fp8,
+                )
+                if is_fp8 and not ignored:
+                    mappings[f"{hf_key}.weight_scale_inv"] = WeightMapping(
+                        target_path=f"{block}.self_attn.{proj}.weight_scale",
+                        sharding=(None, None),
+                        transpose=False,
+                    )
 
         for proj, sharding in [
             ("gate_proj", (None, "tensor")),

--- a/python/sgl_jax/srt/models/mimo_v2_nextn.py
+++ b/python/sgl_jax/srt/models/mimo_v2_nextn.py
@@ -146,6 +146,9 @@ class MiMoV2ModelNextN(nnx.Module):
     ) -> tuple[jax.Array, list[jax.Array]]:
         embed = self.embed_tokens(forward_batch.input_ids)
         hidden_in = forward_batch.spec_info.hidden_states
+        emb_sh = jax.typeof(embed).sharding
+        if isinstance(emb_sh, jax.sharding.NamedSharding):
+            hidden_in = jax.sharding.reshard(hidden_in, emb_sh)
         hidden_states, _ = self.eh_proj(
             jnp.concatenate((self.enorm(embed), self.hnorm(hidden_in)), axis=-1)
         )
@@ -192,7 +195,7 @@ class MiMoV2MTPForCausalLM(nnx.Module):
         output = self.logits_processor(
             hidden_states, self.lm_head, logits_metadata, aux_hidden_states=None
         )
-        return output, layers_kv_fused, []
+        return output, layers_kv_fused, True, None
 
     def load_weights(self, model_config: ModelConfig):
         self.loader = WeightLoader(

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -116,6 +116,10 @@ class BaseSpecWorker:
             logits_output, next_token_ids, cache_miss_count, bid, _seq_lens = (
                 self.forward_target_extend(model_worker_batch, sampling_metadata)
             )
+            if model_worker_batch.dp_size > 1:
+                from jax.experimental.multihost_utils import process_allgather
+
+                next_token_ids = process_allgather(next_token_ids, tiled=True)
             self.draft_worker.draft_extend_for_prefill(
                 model_worker_batch, logits_output.hidden_states, next_token_ids
             )
@@ -123,14 +127,20 @@ class BaseSpecWorker:
                 logits_output=logits_output,
                 next_token_ids=next_token_ids,
                 next_draft_input=model_worker_batch.spec_info,
-                allocate_lens=model_worker_batch.seq_lens[: model_worker_batch.real_bs],
+                allocate_lens=np.asarray(model_worker_batch.seq_lens)[
+                    model_worker_batch.logits_indices_selector
+                ],
                 bid=bid,
                 cache_miss_count=cache_miss_count,
                 extend_input_len_per_req=None,
                 extend_logprob_start_len_per_req=None,
             )
 
-        cur_allocate_lens = model_worker_batch.spec_info.allocate_lens
+        # spec_info.allocate_lens is DP-padded (total_bs,) at dp>1 (scattered in
+        # _get_spec_decode_mwb_dp); gather back to global-flat (real_bs,) so the
+        # cross-round state on reqs_info[0].spec_info stays flat-ordered.
+        sel = model_worker_batch.logits_indices_selector
+        cur_allocate_lens = np.asarray(model_worker_batch.spec_info.allocate_lens)[sel]
         self.draft_worker.draft(model_worker_batch)
         batch_output = self.verify(model_worker_batch, cur_allocate_lens)
         self.draft_worker.draft_extend_for_decode(model_worker_batch, batch_output)

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -126,7 +126,7 @@ class BaseSpecWorker:
             return GenerationBatchResult(
                 logits_output=logits_output,
                 next_token_ids=next_token_ids,
-                next_draft_input=model_worker_batch.spec_info,
+                next_draft_input=model_worker_batch.spec_info_padded,
                 allocate_lens=np.asarray(model_worker_batch.seq_lens)[
                     model_worker_batch.logits_indices_selector
                 ],
@@ -140,7 +140,7 @@ class BaseSpecWorker:
         # _get_spec_decode_mwb_dp); gather back to global-flat (real_bs,) so the
         # cross-round state on reqs_info[0].spec_info stays flat-ordered.
         sel = model_worker_batch.logits_indices_selector
-        cur_allocate_lens = np.asarray(model_worker_batch.spec_info.allocate_lens)[sel]
+        cur_allocate_lens = np.asarray(model_worker_batch.spec_info_padded.allocate_lens)[sel]
         self.draft_worker.draft(model_worker_batch)
         batch_output = self.verify(model_worker_batch, cur_allocate_lens)
         self.draft_worker.draft_extend_for_decode(model_worker_batch, batch_output)
@@ -167,7 +167,7 @@ class BaseSpecWorker:
         from sgl_jax.srt.managers.scheduler import GenerationBatchResult
         from sgl_jax.srt.speculative.eagle_util import EagleDraftInput, EagleVerifyInput
 
-        spec_info: EagleVerifyInput = model_worker_batch.spec_info
+        spec_info: EagleVerifyInput = model_worker_batch.spec_info_padded
         spec_info.allocate_lens = cur_allocate_lens
         spec_info.prepare_for_verify(model_worker_batch, self.page_size, self.target_worker)
         forward_metadata = self.target_worker.model_runner.attn_backend.get_eagle_forward_metadata(
@@ -214,7 +214,7 @@ class BaseSpecWorker:
             hidden_states=logits_output.hidden_states,
         )
 
-        model_worker_batch.spec_info = next_draft_input
+        model_worker_batch.spec_info_padded = next_draft_input
         return GenerationBatchResult(
             logits_output=logits_output,
             next_token_ids=predict,

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -4,10 +4,12 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 import jax
+import numpy as np
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
 if TYPE_CHECKING:
+    from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
     from sgl_jax.srt.managers.tp_worker import ModelWorker
 
 
@@ -28,29 +30,190 @@ class BaseDraftWorker(ABC):
 
     Concrete implementations hold the draft model runner and own all
     draft-specific logic (multi-step decode, tree building, extend).
-    Standard EAGLE uses ``EagleDraftWorker``; MTP will use
+    Standard EAGLE uses ``EagleDraftWorker``; MTP uses
     ``MultiLayerDraftWorker``.
     """
 
+    @property
     @abstractmethod
-    def draft(self):
+    def draft_model_runner(self):
+        """Primary model runner (multi-runner workers return a designated one)."""
+
+    @abstractmethod
+    def draft(self, model_worker_batch):
+        pass
+
+    @abstractmethod
+    def draft_extend_for_prefill(self, model_worker_batch, hidden_states, next_token_ids):
+        pass
+
+    @abstractmethod
+    def draft_extend_for_decode(self, model_worker_batch, batch_output):
         pass
 
 
-class BaseSpecWorker(ABC):
+class BaseSpecWorker:
     """Speculative decode orchestrator.
 
     Owns a ``target_worker`` (the full model) and a ``draft_worker``
-    (the draft/MTP model).  Concrete subclasses implement the main
-    entry point and connect their specific draft/verify logic.
+    (the draft/MTP model). The orchestration loop (prefill → draft →
+    verify → draft_extend) and ``verify()`` itself are spec-algorithm-
+    agnostic, so they live here; subclasses only differ in which
+    ``BaseDraftWorker`` they construct.
     """
 
-    @property
-    @abstractmethod
-    def target_worker(self) -> ModelWorker:
-        pass
+    def __init__(self, server_args, target_worker: ModelWorker, draft_worker: BaseDraftWorker):
+        self.server_args = server_args
+        self._target_worker = target_worker
+        self._draft_worker = draft_worker
+
+        self.topk = server_args.speculative_eagle_topk
+        self.speculative_num_steps = server_args.speculative_num_steps
+        self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
+        self.page_size = server_args.page_size
+        self.mesh = target_worker.mesh
+
+        from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
+
+        self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
+
+        (
+            self.precompile_token_paddings,
+            self.precompile_bs_paddings,
+            self.precompile_cache_loc_paddings,
+        ) = target_worker.get_precompile_paddings()
 
     @property
-    @abstractmethod
+    def target_worker(self) -> ModelWorker:
+        return self._target_worker
+
+    @property
     def draft_worker(self) -> BaseDraftWorker:
-        pass
+        return self._draft_worker
+
+    # -- Main entry point --
+
+    def forward_batch_speculative_generation(self, model_worker_batch: ModelWorkerBatch):
+        from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+        from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
+
+        if model_worker_batch.forward_mode.is_extend():
+            # FIXME(pc) add padding logic here
+            if model_worker_batch.sampling_info.temperatures.ndim == 1:
+                model_worker_batch.sampling_info.temperatures = (
+                    model_worker_batch.sampling_info.temperatures[:, None]
+                )
+            sampling_metadata = SamplingMetadata.from_model_worker_batch(
+                model_worker_batch,
+                len(model_worker_batch.seq_lens) - model_worker_batch.real_bs,
+                self.mesh,
+                vocab_size=self.target_worker.model_config.vocab_size,
+            )
+            logits_output, next_token_ids, cache_miss_count, bid, _seq_lens = (
+                self.forward_target_extend(model_worker_batch, sampling_metadata)
+            )
+            self.draft_worker.draft_extend_for_prefill(
+                model_worker_batch, logits_output.hidden_states, next_token_ids
+            )
+            return GenerationBatchResult(
+                logits_output=logits_output,
+                next_token_ids=next_token_ids,
+                next_draft_input=model_worker_batch.spec_info,
+                allocate_lens=model_worker_batch.seq_lens[: model_worker_batch.real_bs],
+                bid=bid,
+                cache_miss_count=cache_miss_count,
+                extend_input_len_per_req=None,
+                extend_logprob_start_len_per_req=None,
+            )
+
+        cur_allocate_lens = model_worker_batch.spec_info.allocate_lens
+        self.draft_worker.draft(model_worker_batch)
+        batch_output = self.verify(model_worker_batch, cur_allocate_lens)
+        self.draft_worker.draft_extend_for_decode(model_worker_batch, batch_output)
+        return batch_output
+
+    def forward_target_extend(self, model_worker_batch: ModelWorkerBatch, sampling_metadata):
+        from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode
+
+        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
+        logits_output, next_token_ids, cache_miss_count = (
+            self.target_worker.forward_batch_generation(
+                model_worker_batch, sampling_metadata=sampling_metadata
+            )
+        )
+        return (
+            logits_output,
+            next_token_ids,
+            cache_miss_count,
+            model_worker_batch.bid,
+            model_worker_batch.seq_lens,
+        )
+
+    def verify(self, model_worker_batch: ModelWorkerBatch, cur_allocate_lens: jax.Array):
+        from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+        from sgl_jax.srt.speculative.eagle_util import EagleDraftInput, EagleVerifyInput
+
+        spec_info: EagleVerifyInput = model_worker_batch.spec_info
+        spec_info.allocate_lens = cur_allocate_lens
+        spec_info.prepare_for_verify(model_worker_batch, self.page_size, self.target_worker)
+        forward_metadata = self.target_worker.model_runner.attn_backend.get_eagle_forward_metadata(
+            model_worker_batch
+        )
+
+        logits_output, _, cache_miss_count = self.target_worker.forward_batch_generation(
+            model_worker_batch, skip_sample=True, forward_metadata=forward_metadata
+        )
+        logits_output.next_token_logits, logits_output.hidden_states = replicate_to_mesh(
+            self.mesh, logits_output.next_token_logits, logits_output.hidden_states
+        )
+        spec_info.hidden_states = logits_output.hidden_states
+        (
+            predict,
+            verified_id,
+            accept_length,
+            accept_index,
+        ) = spec_info.sample(
+            model_worker_batch,
+            logits_output,
+            self.draft_worker.draft_model_runner.rngs,
+            self.mesh,
+        )
+        # accept_index uses -1 for rejected slots; gathering with -1 picks the
+        # global last element, so dext later writes rejected tokens' draft-KV at
+        # a foreign position inside each req's page (corrupts prefix KV for all
+        # but the last req at bs>1). Redirect -1 to each req's own last slot.
+        # accept_index has length bs*(spec_steps+1); the gathered tensors have
+        # length bs*draft_token_num — equal at topk=1, distinct at topk>1.
+        draft_n = self.speculative_num_draft_tokens
+        accept_width = self.speculative_num_steps + 1
+        req_ids = np.arange(len(accept_index)) // accept_width
+        per_req_last = req_ids * draft_n + draft_n - 1
+        safe_index = np.where(accept_index >= 0, accept_index, per_req_last)
+        logits_output.next_token_logits = logits_output.next_token_logits[safe_index, :]
+        logits_output.hidden_states = logits_output.hidden_states[safe_index, :]
+        model_worker_batch.positions = model_worker_batch.positions[safe_index]
+        new_seq_lens = model_worker_batch.seq_lens + accept_length
+        next_draft_input = EagleDraftInput(
+            verified_id=verified_id,
+            new_seq_lens=new_seq_lens,
+            allocate_lens=cur_allocate_lens,
+            hidden_states=logits_output.hidden_states,
+        )
+
+        model_worker_batch.spec_info = next_draft_input
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=predict,
+            next_draft_input=next_draft_input,
+            accept_lens=accept_length,
+            # FIXME(pc) this field is for overlap
+            allocate_lens=cur_allocate_lens,
+            bid=model_worker_batch.bid,
+            cache_miss_count=cache_miss_count,
+            extend_input_len_per_req=None,
+            extend_logprob_start_len_per_req=None,
+        )

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -102,7 +102,6 @@ class BaseSpecWorker:
         from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
 
         if model_worker_batch.forward_mode.is_extend():
-            # FIXME(pc) add padding logic here
             if model_worker_batch.sampling_info.temperatures.ndim == 1:
                 model_worker_batch.sampling_info.temperatures = (
                     model_worker_batch.sampling_info.temperatures[:, None]
@@ -136,9 +135,8 @@ class BaseSpecWorker:
                 extend_logprob_start_len_per_req=None,
             )
 
-        # spec_info.allocate_lens is DP-padded (total_bs,) at dp>1 (scattered in
-        # _get_spec_decode_mwb_dp); gather back to global-flat (real_bs,) so the
-        # cross-round state on reqs_info[0].spec_info stays flat-ordered.
+        # spec_info.allocate_lens is DP-padded (total_bs,) at dp>1; gather back
+        # to global-flat (real_bs,) so reqs_info[0].spec_info stays flat-ordered.
         sel = model_worker_batch.logits_indices_selector
         cur_allocate_lens = np.asarray(model_worker_batch.spec_info_padded.allocate_lens)[sel]
         self.draft_worker.draft(model_worker_batch)

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -190,7 +190,8 @@ class EagleDraftWorker(BaseDraftWorker):
         hidden_states: jax.Array,
         next_token_ids: jax.Array,
     ) -> None:
-        verified_id_np = np.asarray(jax.device_get(next_token_ids))[: model_worker_batch.real_bs]
+        sel = np.asarray(model_worker_batch.logits_indices_selector)
+        verified_id_np = np.asarray(jax.device_get(next_token_ids))[sel]
         model_worker_batch.spec_info = EagleDraftInput(
             hidden_states=hidden_states,
             verified_id=verified_id_np,
@@ -218,15 +219,15 @@ class EagleDraftWorker(BaseDraftWorker):
             forward_batch,
             logits_metadata=LogitsMetadata.from_model_worker_batch(model_worker_batch, self.mesh),
         )
-        logits_output.next_token_logits = logits_output.next_token_logits[
-            : model_worker_batch.real_bs, :
-        ]
-        if len(logits_output.hidden_states.shape) == 1:
-            logits_output.hidden_states = jnp.expand_dims(logits_output.hidden_states, axis=0)
+        rep_logits, rep_hidden = replicate_to_mesh(
+            self.mesh, logits_output.next_token_logits, logits_output.hidden_states
+        )
+        logits_output.next_token_logits = rep_logits[sel, :]
+        if len(rep_hidden.shape) == 1:
+            rep_hidden = jnp.expand_dims(rep_hidden, axis=0)
+        logits_output.hidden_states = rep_hidden[sel]
         assert isinstance(forward_batch.spec_info, EagleDraftInput)
-        forward_batch.spec_info.allocate_lens = model_worker_batch.seq_lens[
-            : model_worker_batch.real_bs
-        ]
+        forward_batch.spec_info.allocate_lens = np.asarray(model_worker_batch.seq_lens)[sel]
 
         self.capture_for_decode(logits_output, forward_batch.spec_info)
 
@@ -253,16 +254,15 @@ class EagleDraftWorker(BaseDraftWorker):
             forward_batch,
             logits_metadata=logits_metadata,
         )
-        select_index = (
-            np.arange(len(model_worker_batch.seq_lens[: model_worker_batch.real_bs]))
-            * (self.speculative_num_steps + 1)
-            + batch_output.accept_lens[: model_worker_batch.real_bs]
-            - 1
-        )
+        sel = np.asarray(model_worker_batch.logits_indices_selector)
+        accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
+        select_index = sel * (self.speculative_num_steps + 1) + accept_host[sel] - 1
         rep_logits, rep_hidden = replicate_to_mesh(
             self.mesh, draft_logits_output.next_token_logits, draft_logits_output.hidden_states
         )
-        draft_logits_output.next_token_logits = rep_logits[select_index]
+        # next_token_logits is pruned to (total_bs, vocab); hidden_states is FULL
+        # (total_bs*(steps+1), H). Index logits by slot, hidden by token.
+        draft_logits_output.next_token_logits = rep_logits[sel]
         draft_logits_output.hidden_states = rep_hidden[select_index]
         topk_p, topk_index = topk_probs_from_logits(
             draft_logits_output.next_token_logits, self.topk
@@ -275,7 +275,7 @@ class EagleDraftWorker(BaseDraftWorker):
             select_index
         ]
         batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
-        batch_output.accept_lens = batch_output.accept_lens[: model_worker_batch.real_bs]
+        batch_output.accept_lens = accept_host
 
     # -- Internal draft helpers --
 
@@ -288,7 +288,12 @@ class EagleDraftWorker(BaseDraftWorker):
         draft_input.hidden_states = replicate_to_mesh(self.mesh, logits_output.hidden_states)
 
     def padding_for_decode(self, model_worker_batch: ModelWorkerBatch):
-        _, padding_bs_index = self.get_padding_bs(model_worker_batch.real_bs)
+        # At dp>1 the incoming mwb is already DP-padded to total_bs (== a bucket
+        # value, see _get_spec_decode_mwb_dp); use the larger of real_bs and the
+        # incoming seq_lens length so we don't shrink below the DP layout.
+        _, padding_bs_index = self.get_padding_bs(
+            max(model_worker_batch.real_bs, len(model_worker_batch.seq_lens))
+        )
         self.copy_model_worker_batch_to_cpu(model_worker_batch)
         model_worker_batch.spec_info.prepare_for_draft_decode(
             model_worker_batch, self.topk, self.speculative_num_steps
@@ -302,30 +307,41 @@ class EagleDraftWorker(BaseDraftWorker):
         ]
         spec_info = model_worker_batch.spec_info
         assert isinstance(spec_info, EagleDraftInput)
-        cache_loc_flat = np.array([], dtype=np.int32)
-        if len(seq_lens_cpu) > 0:
-            valid_mask = seq_lens_cpu > 0
-            if np.any(valid_mask):
-                valid_indices = np.where(valid_mask)[0]
-                valid_allocate_lens = spec_info.allocate_lens[valid_mask]
-                aligned_lengths = ((valid_allocate_lens + page_size - 1) // page_size) * page_size
-                total_aligned_length = np.sum(aligned_lengths)
-                cache_loc_flat = np.zeros(total_aligned_length, dtype=np.int32)
-                offset = 0
-                for i, (seq_idx, allocate_len, aligned_len) in enumerate(
-                    zip(valid_indices, valid_allocate_lens, aligned_lengths)
-                ):
-                    cache_loc_flat[offset : offset + allocate_len] = token_indices_with_all_reqs[
-                        seq_idx, :allocate_len
-                    ]
-                    offset += aligned_len
+        # At dp>1 spec_info arrays arrive at (real_bs,) but seq_lens_cpu is
+        # (total_bs,); pad allocate_lens up front so valid_mask indexing works
+        # (the per-field bs-padding loop below would do this anyway, just later).
+        if len(spec_info.allocate_lens) < len(seq_lens_cpu):
+            spec_info.allocate_lens = np.pad(
+                spec_info.allocate_lens, (0, len(seq_lens_cpu) - len(spec_info.allocate_lens))
+            )
+        # DP-segmented cache_loc: rank r's slots occupy
+        # [r*per_dp_cache_len : (r+1)*per_dp_cache_len) so the P("data") shard
+        # gives each rank its own page_indices (not the contiguous-then-padding
+        # layout where rank>0's shard lands in the padding region).
         total_cache_loc_size = self.precompile_cache_loc_paddings[padding_bs_index]
-        assert total_cache_loc_size >= len(cache_loc_flat)
-        cache_loc_cpu = np.empty(total_cache_loc_size, dtype=np.int32)
-        if len(cache_loc_flat) > 0:
-            cache_loc_cpu[: len(cache_loc_flat)] = cache_loc_flat
-        if len(cache_loc_flat) < total_cache_loc_size:
-            cache_loc_cpu[len(cache_loc_flat) :] = 0
+        dp_size = model_worker_batch.dp_size
+        per_dp_bs = model_worker_batch.per_dp_bs_size if dp_size > 1 else len(seq_lens_cpu)
+        assert total_cache_loc_size % dp_size == 0
+        per_dp_cache_len = total_cache_loc_size // dp_size
+        cache_loc_cpu = np.zeros(total_cache_loc_size, dtype=np.int32)
+        valid_mask = seq_lens_cpu > 0
+        if np.any(valid_mask):
+            valid_indices = np.where(valid_mask)[0]
+            valid_allocate_lens = spec_info.allocate_lens[valid_mask]
+            aligned_lengths = ((valid_allocate_lens + page_size - 1) // page_size) * page_size
+            intra_rank_off = np.zeros(dp_size, dtype=np.int64)
+            for seq_idx, allocate_len, aligned_len in zip(
+                valid_indices, valid_allocate_lens, aligned_lengths
+            ):
+                r = int(seq_idx) // per_dp_bs
+                base = r * per_dp_cache_len + intra_rank_off[r]
+                assert (
+                    base + aligned_len <= (r + 1) * per_dp_cache_len
+                ), f"rank {r} cache_loc overflow: {intra_rank_off[r]+aligned_len} > {per_dp_cache_len}"
+                cache_loc_cpu[base : base + allocate_len] = token_indices_with_all_reqs[
+                    seq_idx, :allocate_len
+                ]
+                intra_rank_off[r] += aligned_len
 
         model_worker_batch.cache_loc = cache_loc_cpu
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -68,15 +68,6 @@ class EagleDraftWorker(BaseDraftWorker):
 
         self._share_embed_head(target_worker)
 
-        target_slot_range = target_worker.model_runner.max_total_num_tokens
-        draft_pool_size = self.draft_model_runner.max_total_num_tokens
-        assert draft_pool_size >= target_slot_range, (
-            f"draft KV pool ({draft_pool_size}) < target allocator slot range "
-            f"({target_slot_range}); high-slot draft KV reads/writes will be "
-            f"garbage. Hybrid target without the post-set_num_token_hybrid "
-            f"draft_runner_cache_size overwrite hits this."
-        )
-
         self._worker.model_runner.initialize_jit()
 
         (
@@ -205,6 +196,13 @@ class EagleDraftWorker(BaseDraftWorker):
         )
         model_worker_batch.spec_info_padded.capture_hidden_mode = CaptureHiddenMode.LAST
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
+
+        padded_bs = int(model_worker_batch.seq_lens.shape[0])
+        if verified_id_np.shape[0] < padded_bs:
+            model_worker_batch.spec_info_padded.verified_id = np.pad(
+                verified_id_np, ((0, padded_bs - verified_id_np.shape[0]),)
+            )
+
         forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
         forward_batch.return_logprob = False
 
@@ -219,17 +217,19 @@ class EagleDraftWorker(BaseDraftWorker):
             forward_batch,
             logits_metadata=LogitsMetadata.from_model_worker_batch(model_worker_batch, self.mesh),
         )
+        # Restore real_bs so split_spec_info_per_rank cuts on real_bs_per_dp.
+        model_worker_batch.spec_info_padded.verified_id = verified_id_np
         rep_logits, rep_hidden = replicate_to_mesh(
             self.mesh, logits_output.next_token_logits, logits_output.hidden_states
         )
-        logits_output.next_token_logits = rep_logits[sel, :]
         if len(rep_hidden.shape) == 1:
             rep_hidden = jnp.expand_dims(rep_hidden, axis=0)
-        logits_output.hidden_states = rep_hidden[sel]
+        logits_output.next_token_logits = rep_logits
+        logits_output.hidden_states = rep_hidden
         assert isinstance(forward_batch.spec_info, EagleDraftInput)
         forward_batch.spec_info.allocate_lens = np.asarray(model_worker_batch.seq_lens)[sel]
 
-        self.capture_for_decode(logits_output, forward_batch.spec_info)
+        self.capture_for_decode(logits_output, forward_batch.spec_info, sel=sel)
 
     def draft_extend_for_decode(
         self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
@@ -260,32 +260,45 @@ class EagleDraftWorker(BaseDraftWorker):
         rep_logits, rep_hidden = replicate_to_mesh(
             self.mesh, draft_logits_output.next_token_logits, draft_logits_output.hidden_states
         )
-        # next_token_logits is pruned to (total_bs, vocab); hidden_states is FULL
-        # (total_bs*(steps+1), H). Index logits by slot, hidden by token.
-        draft_logits_output.next_token_logits = rep_logits[sel]
-        draft_logits_output.hidden_states = rep_hidden[select_index]
-        topk_p, topk_index = topk_probs_from_logits(
-            draft_logits_output.next_token_logits, self.topk
-        )
+        # topk_probs_from_logits runs as @jax.jit on bucket-shaped rep_logits;
+        # keep this on device with stable shape.
+        topk_p, topk_index = topk_probs_from_logits(rep_logits, self.topk)
+        # Gather to real_bs on host to avoid variable-shape device gathers.
+        jax.copy_to_host_async(topk_p)
+        jax.copy_to_host_async(topk_index)
+        jax.copy_to_host_async(rep_hidden)
+        verified_id_arr = batch_output.next_draft_input.verified_id
+        if hasattr(verified_id_arr, "copy_to_host_async"):
+            jax.copy_to_host_async(verified_id_arr)
+        topk_p = np.asarray(topk_p)[sel]
+        topk_index = np.asarray(topk_index)[sel]
+        hidden = np.asarray(rep_hidden)[select_index]
+        verified_id = np.asarray(verified_id_arr)[select_index]
 
-        batch_output.next_draft_input.hidden_states = draft_logits_output.hidden_states
+        batch_output.next_draft_input.hidden_states = hidden
         batch_output.next_draft_input.topk_p = topk_p
         batch_output.next_draft_input.topk_index = topk_index
-        batch_output.next_draft_input.verified_id = batch_output.next_draft_input.verified_id[
-            select_index
-        ]
+        batch_output.next_draft_input.verified_id = verified_id
         batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
         batch_output.accept_lens = accept_host
 
     # -- Internal draft helpers --
 
     def capture_for_decode(
-        self, logits_output: LogitsProcessorOutput, draft_input: EagleDraftInput
+        self, logits_output: LogitsProcessorOutput, draft_input: EagleDraftInput, sel=None
     ):
         topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
+        hidden = replicate_to_mesh(self.mesh, logits_output.hidden_states)
+        if sel is not None:
+            jax.copy_to_host_async(topk_p)
+            jax.copy_to_host_async(topk_index)
+            jax.copy_to_host_async(hidden)
+            topk_p = np.asarray(topk_p)[sel]
+            topk_index = np.asarray(topk_index)[sel]
+            hidden = np.asarray(hidden)[sel]
         draft_input.topk_p = topk_p
         draft_input.topk_index = topk_index
-        draft_input.hidden_states = replicate_to_mesh(self.mesh, logits_output.hidden_states)
+        draft_input.hidden_states = hidden
 
     def padding_for_decode(self, model_worker_batch: ModelWorkerBatch):
         # At dp>1 the incoming mwb is already DP-padded to total_bs (== a bucket
@@ -372,7 +385,7 @@ class EagleDraftWorker(BaseDraftWorker):
             """
             if arr is None or arr.shape[0] >= target_bs:
                 return arr
-            per_dp_curr = max(arr.shape[0] // dp_size, 1) if dp_size > 0 else arr.shape[0]
+            per_dp_curr = max(arr.shape[0] // dp_size, 1)
             if dp_size <= 1 or arr.shape[0] % dp_size != 0:
                 # Fallback to end-pad if layout isn't DP-divisible (dp=1 path).
                 pad_widths = [(0, target_bs - arr.shape[0])] + [(0, 0)] * (arr.ndim - 1)
@@ -459,11 +472,9 @@ class EagleDraftWorker(BaseDraftWorker):
         return score_list, token_list, parents_list
 
     def _pick_context_len(self, max_seq_len: int) -> int:
-        max_seq_len = max(int(max_seq_len), 1)
         if self.precompile_token_paddings:
-            for padding in self.precompile_token_paddings:
-                if padding >= max_seq_len:
-                    return padding
+            return self.precompile_token_paddings[-1]
+        max_seq_len = max(int(max_seq_len), 1)
         return 1 << (max_seq_len - 1).bit_length()
 
     def copy_model_worker_batch_to_cpu(self, model_worker_batch: ModelWorkerBatch):
@@ -649,6 +660,10 @@ def select_top_k_tokens_step_greater_0(
     scores: jax.Array,
     topk: int,
 ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    # scores carries the prior step's top-k probs; topk_p comes from the next
+    # draft forward. Target and draft logits can be different dtypes (e.g. MiMo
+    # V2 Flash), so promote before lax.mul which requires matching dtypes.
+    scores = scores.astype(topk_p.dtype)
     expand_scores = jax.lax.mul(jnp.expand_dims(scores, axis=2), topk_p.reshape(-1, topk, topk))
     topk_cs_p, topk_cs_index = fast_topk(
         expand_scores.reshape(expand_scores.shape[0], -1), topk, axis=-1

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -155,7 +155,7 @@ class EagleDraftWorker(BaseDraftWorker):
             retrive_next_sibling,
             draft_tokens,
         ) = build_tree_kernel_efficient(
-            model_worker_batch.spec_info.verified_id,
+            model_worker_batch.spec_info_padded.verified_id,
             score_list,
             token_list,
             parents_list,
@@ -168,7 +168,7 @@ class EagleDraftWorker(BaseDraftWorker):
             model_worker_batch.speculative_num_steps,
             self.mesh,
         )
-        model_worker_batch.spec_info = EagleVerifyInput(
+        model_worker_batch.spec_info_padded = EagleVerifyInput(
             draft_token=draft_tokens,
             custom_mask=tree_mask,
             positions=position,
@@ -192,7 +192,7 @@ class EagleDraftWorker(BaseDraftWorker):
     ) -> None:
         sel = np.asarray(model_worker_batch.logits_indices_selector)
         verified_id_np = np.asarray(jax.device_get(next_token_ids))[sel]
-        model_worker_batch.spec_info = EagleDraftInput(
+        model_worker_batch.spec_info_padded = EagleDraftInput(
             hidden_states=hidden_states,
             verified_id=verified_id_np,
             num_tokens_per_batch=np.asarray(1, dtype=jnp.int32),
@@ -200,10 +200,10 @@ class EagleDraftWorker(BaseDraftWorker):
             allocate_lens=model_worker_batch.seq_lens,
         )
         model_worker_batch.return_hidden_states = False
-        model_worker_batch.spec_info.prepare_for_extend_after_target_prefill(
+        model_worker_batch.spec_info_padded.prepare_for_extend_after_target_prefill(
             model_worker_batch=model_worker_batch
         )
-        model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.LAST
+        model_worker_batch.spec_info_padded.capture_hidden_mode = CaptureHiddenMode.LAST
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
         forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
         forward_batch.return_logprob = False
@@ -295,7 +295,7 @@ class EagleDraftWorker(BaseDraftWorker):
             max(model_worker_batch.real_bs, len(model_worker_batch.seq_lens))
         )
         self.copy_model_worker_batch_to_cpu(model_worker_batch)
-        model_worker_batch.spec_info.prepare_for_draft_decode(
+        model_worker_batch.spec_info_padded.prepare_for_draft_decode(
             model_worker_batch, self.topk, self.speculative_num_steps
         )
         model_worker_batch.seq_lens = model_worker_batch.seq_lens
@@ -305,7 +305,7 @@ class EagleDraftWorker(BaseDraftWorker):
         token_indices_with_all_reqs = req_to_token_pool.req_to_token[
             model_worker_batch.req_pool_indices
         ]
-        spec_info = model_worker_batch.spec_info
+        spec_info = model_worker_batch.spec_info_padded
         assert isinstance(spec_info, EagleDraftInput)
         # At dp>1 spec_info arrays arrive at (real_bs,) but seq_lens_cpu is
         # (total_bs,); pad allocate_lens up front so valid_mask indexing works
@@ -348,7 +348,7 @@ class EagleDraftWorker(BaseDraftWorker):
 
         topk_index = spec_info.topk_index
         if self.hot_token_ids is not None:
-            model_worker_batch.spec_info.topk_index = self.hot_token_ids[topk_index]
+            model_worker_batch.spec_info_padded.topk_index = self.hot_token_ids[topk_index]
         if self.topk > 1:
             self.draft_model_runner.attn_backend.forward_metadata.custom_mask = (
                 build_tree_mask_for_draft_decode(
@@ -359,44 +359,38 @@ class EagleDraftWorker(BaseDraftWorker):
                 )
             )
         bs = self.precompile_bs_paddings[padding_bs_index]
-        if bs - model_worker_batch.spec_info.verified_id.shape[0] > 0:
-            model_worker_batch.spec_info.verified_id = np.pad(
-                model_worker_batch.spec_info.verified_id,
-                ((0, bs - model_worker_batch.spec_info.verified_id.shape[0]),),
-            )
-        if bs - model_worker_batch.spec_info.topk_p.shape[0] > 0:
-            model_worker_batch.spec_info.topk_p = np.pad(
-                model_worker_batch.spec_info.topk_p,
-                (
-                    (0, bs - model_worker_batch.spec_info.topk_p.shape[0]),
-                    (0, 0),
-                ),
-            )
+        dp_size = model_worker_batch.dp_size
+        per_dp_padded = bs // dp_size
+
+        def _dp_segment_pad(arr, target_bs):
+            """DP-segmented pad: pad each rank's section separately to per_dp_padded.
+
+            Input arr shape (curr_bs, ...) with curr_bs = per_dp_curr * dp_size.
+            Returns (target_bs, ...) with each rank's slice padded at the end.
+            End-padding the whole array would let shard_map(P("data")) hand a
+            following rank's data to a prior rank.
+            """
+            if arr is None or arr.shape[0] >= target_bs:
+                return arr
+            per_dp_curr = max(arr.shape[0] // dp_size, 1) if dp_size > 0 else arr.shape[0]
+            if dp_size <= 1 or arr.shape[0] % dp_size != 0:
+                # Fallback to end-pad if layout isn't DP-divisible (dp=1 path).
+                pad_widths = [(0, target_bs - arr.shape[0])] + [(0, 0)] * (arr.ndim - 1)
+                return np.pad(arr, pad_widths)
+            reshaped = arr.reshape((dp_size, per_dp_curr) + arr.shape[1:])
+            pad_widths = [(0, 0), (0, per_dp_padded - per_dp_curr)] + [(0, 0)] * (arr.ndim - 1)
+            padded = np.pad(reshaped, pad_widths)
+            return padded.reshape((target_bs,) + arr.shape[1:])
+
+        spec_info_padded = model_worker_batch.spec_info_padded
+        spec_info_padded.verified_id = _dp_segment_pad(spec_info_padded.verified_id, bs)
+        spec_info_padded.topk_p = _dp_segment_pad(spec_info_padded.topk_p, bs)
         if bs - model_worker_batch.seq_lens.shape[0] > 0:
-            model_worker_batch.seq_lens = np.pad(
-                model_worker_batch.seq_lens, ((0, bs - model_worker_batch.seq_lens.shape[0]),)
-            )
-            if model_worker_batch.spec_info.allocate_lens is not None:
-                model_worker_batch.spec_info.allocate_lens = np.pad(
-                    model_worker_batch.spec_info.allocate_lens,
-                    ((0, bs - model_worker_batch.spec_info.allocate_lens.shape[0]),),
-                )
-        if bs - model_worker_batch.spec_info.topk_index.shape[0] > 0:
-            model_worker_batch.spec_info.topk_index = np.pad(
-                model_worker_batch.spec_info.topk_index,
-                (
-                    (0, bs - model_worker_batch.spec_info.topk_index.shape[0]),
-                    (0, 0),
-                ),
-            )
-        if bs - model_worker_batch.spec_info.hidden_states.shape[0] > 0:
-            model_worker_batch.spec_info.hidden_states = np.pad(
-                model_worker_batch.spec_info.hidden_states,
-                (
-                    (0, bs - model_worker_batch.spec_info.hidden_states.shape[0]),
-                    (0, 0),
-                ),
-            )
+            model_worker_batch.seq_lens = _dp_segment_pad(model_worker_batch.seq_lens, bs)
+            if spec_info_padded.allocate_lens is not None:
+                spec_info_padded.allocate_lens = _dp_segment_pad(spec_info_padded.allocate_lens, bs)
+        spec_info_padded.topk_index = _dp_segment_pad(spec_info_padded.topk_index, bs)
+        spec_info_padded.hidden_states = _dp_segment_pad(spec_info_padded.hidden_states, bs)
         model_worker_batch.speculative_eagle_topk = self.topk
         model_worker_batch.speculative_num_steps = self.speculative_num_steps
         model_worker_batch.speculative_num_draft_tokens = self.speculative_num_draft_tokens
@@ -405,9 +399,9 @@ class EagleDraftWorker(BaseDraftWorker):
 
     def draft_forward(self, model_worker_batch: ModelWorkerBatch):
         topk_p, topk_index, hidden_states = (
-            model_worker_batch.spec_info.topk_p,
-            model_worker_batch.spec_info.topk_index,
-            model_worker_batch.spec_info.hidden_states,
+            model_worker_batch.spec_info_padded.topk_p,
+            model_worker_batch.spec_info_padded.topk_index,
+            model_worker_batch.spec_info_padded.hidden_states,
         )
         bs = model_worker_batch.seq_lens.shape[0]
         step_min_1 = self.speculative_num_steps - 1

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -509,16 +509,35 @@ class EagleDraftInput:
             self.verified_id.shape[0] == model_worker_batch.real_bs
         ), f"{self.verified_id.shape=} {model_worker_batch.real_bs=}"
 
-        pt = 0
-        for i in range(model_worker_batch.real_bs):
-            extend_len = model_worker_batch.extend_seq_lens[i]
-            input_ids = model_worker_batch.input_ids[pt : pt + extend_len]
-
-            # TODO: batch.input_ids should on tpu
-            model_worker_batch.input_ids[pt : pt + extend_len] = np.concatenate(
-                (input_ids[1:], self.verified_id[i].reshape(1))
-            )
-            pt += extend_len
+        # Walk the DP-padded layout in (rank, slot) order so token offsets line
+        # up with mwb.input_ids' token-major DP layout. Iterating real_bs and
+        # indexing extend_seq_lens by `i` skipped real reqs whose padded slot
+        # index > i (e.g. dp>1 prefill with only rank>0 active).
+        dp_size = model_worker_batch.dp_size
+        # per_dp_bs_size already covers both dp=1 (= total_bs) and dp>1
+        # (= total_bs / dp). Hardcoding 1 here drops dp=1 multi-req.
+        per_dp_bs = model_worker_batch.per_dp_bs_size
+        total_tok = len(model_worker_batch.input_ids)
+        per_dp_tok = total_tok // dp_size if dp_size > 0 else total_tok
+        extend_seq_lens = model_worker_batch.extend_seq_lens
+        flat_idx = 0  # index into self.verified_id (cross-rank flat)
+        for dp_rank in range(dp_size):
+            pt = dp_rank * per_dp_tok
+            for slot_in_rank in range(per_dp_bs):
+                slot = dp_rank * per_dp_bs + slot_in_rank
+                extend_len = int(extend_seq_lens[slot])
+                if extend_len == 0:
+                    continue
+                input_ids = model_worker_batch.input_ids[pt : pt + extend_len]
+                model_worker_batch.input_ids[pt : pt + extend_len] = np.concatenate(
+                    (input_ids[1:], self.verified_id[flat_idx].reshape(1))
+                )
+                pt += extend_len
+                flat_idx += 1
+        assert flat_idx == model_worker_batch.real_bs, (
+            f"prepare_for_extend_after_target_prefill mismatch: walked {flat_idx} "
+            f"real reqs but real_bs={model_worker_batch.real_bs}"
+        )
 
     def prepare_for_extend_after_verify(
         self,
@@ -527,7 +546,7 @@ class EagleDraftInput:
         batch_output: GenerationBatchResult,
         speculative_num_draft_tokens: int,
     ):
-        model_worker_batch.spec_info = self
+        model_worker_batch.spec_info_padded = self
         sel = model_worker_batch.logits_indices_selector
         model_worker_batch.seq_lens[sel] = (
             model_worker_batch.seq_lens[sel] + speculative_num_draft_tokens - 1
@@ -548,10 +567,12 @@ class EagleDraftInput:
             - 1
         )
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
-        model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.FULL
+        model_worker_batch.spec_info_padded.capture_hidden_mode = CaptureHiddenMode.FULL
         model_worker_batch.forward_mode = ForwardMode.DRAFT_EXTEND
-        model_worker_batch.spec_info.hidden_states = batch_output.next_draft_input.hidden_states
-        model_worker_batch.spec_info.accept_length = batch_output.accept_lens
+        model_worker_batch.spec_info_padded.hidden_states = (
+            batch_output.next_draft_input.hidden_states
+        )
+        model_worker_batch.spec_info_padded.accept_length = batch_output.accept_lens
         model_worker_batch.input_ids = batch_output.next_draft_input.verified_id
         forward_metadata = draft_model_runner.attn_backend.get_eagle_forward_metadata(
             model_worker_batch
@@ -649,16 +670,19 @@ class EagleDraftInput:
             return
 
         batch.input_ids = self.verified_id
-        accept_length_cpu_arr = batch.spec_info.accept_length_cpu
+        rank0_spec = batch.reqs_info[0].spec_info if batch.reqs_info else None
+        accept_length_cpu_arr = rank0_spec.accept_length_cpu if rank0_spec else None
         if accept_length_cpu_arr is None:
             accept_length_cpu_host = np.asarray([], dtype=np.int32)
         else:
             accept_length_cpu_host = accept_length_cpu_arr
         batch.extend_lens = (accept_length_cpu_host + 1).tolist()
         batch.extend_num_tokens = sum(batch.extend_lens)
-        batch.seq_lens = batch.spec_info.seq_lens_for_draft_extend
+        batch.seq_lens = rank0_spec.seq_lens_for_draft_extend if rank0_spec else None
         batch.seq_lens_sum = batch.seq_lens.sum().item()
-        batch.req_pool_indices = batch.spec_info.req_pool_indices_for_draft_extend
+        batch.req_pool_indices = (
+            rank0_spec.req_pool_indices_for_draft_extend if rank0_spec else None
+        )
         batch.return_logprob = False
         batch.return_hidden_states = False
 
@@ -679,25 +703,24 @@ class EagleDraftInput:
 
     def filter_batch(self, new_indices: np.ndarray, has_been_filtered: bool = True):
         new_indices = np.asarray(new_indices)
-        if has_been_filtered:
-            # in eagle_utils.py:verify, we have already filtered the batch by `unfinished_index`
-            # therefore, we don't need to filter the batch again in scheduler
-            if len(new_indices) != len(self.topk_p):
-                logger.warning(
-                    "length of new_indices: %d != length of topk_p: %d, this should not happen",
-                    len(new_indices),
-                    len(self.topk_p),
-                )
+        # Verify path produces a pre-trimmed next_draft_input so len matches
+        # and truncate is a no-op. Other paths (draft_extend) leave self at
+        # full per-rank size and need fancy-index; the length check is the
+        # real guard, has_been_filtered is kept for backward signalling.
+        if has_been_filtered and len(new_indices) == len(self.topk_p):
             self.topk_p = self.topk_p[: len(new_indices)]
             self.topk_index = self.topk_index[: len(new_indices)]
             self.hidden_states = self.hidden_states[: len(new_indices)]
             self.verified_id = self.verified_id[: len(new_indices)]
+            if self.allocate_lens is not None:
+                self.allocate_lens = np.asarray(self.allocate_lens)[: len(new_indices)]
         else:
-            # in some cases(e.g draft_extend), we have not filtered the batch by `unfinished_index`
             self.topk_p = self.topk_p[new_indices]
             self.topk_index = self.topk_index[new_indices]
             self.hidden_states = self.hidden_states[new_indices]
             self.verified_id = self.verified_id[new_indices]
+            if self.allocate_lens is not None:
+                self.allocate_lens = np.asarray(self.allocate_lens)[new_indices]
 
     def merge_batch(self, spec_info: EagleDraftInput):
         # FIXME(pc) need support overlap here
@@ -852,7 +875,7 @@ class EagleVerifyInput:
         # extend_lens = jnp.array([self.draft_token_num] * bs)
         model_worker_batch.return_hidden_states = False
         model_worker_batch.forward_mode = ForwardMode.TARGET_VERIFY
-        model_worker_batch.spec_info = self
+        model_worker_batch.spec_info_padded = self
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
         model_worker_batch.extend_seq_lens = self.draft_token
         # assert model_worker_batch.capture_hidden_mode == spec_info.capture_hidden_mode

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -518,7 +518,7 @@ class EagleDraftInput:
         # (= total_bs / dp). Hardcoding 1 here drops dp=1 multi-req.
         per_dp_bs = model_worker_batch.per_dp_bs_size
         total_tok = len(model_worker_batch.input_ids)
-        per_dp_tok = total_tok // dp_size if dp_size > 0 else total_tok
+        per_dp_tok = total_tok // dp_size
         extend_seq_lens = model_worker_batch.extend_seq_lens
         flat_idx = 0  # index into self.verified_id (cross-rank flat)
         for dp_rank in range(dp_size):
@@ -701,12 +701,28 @@ class EagleDraftInput:
 
         self.accept_length_cpu = np.asarray(accept_length_cpu_host, dtype=np.int32)
 
+    def _ensure_host(self):
+        """Move device arrays to host (numpy) to avoid variable-shape device ops.
+
+        Spec decode postprocessing (filter_batch, merge_batch, split/concat)
+        operates on per-request arrays whose size varies with real_bs. Keeping
+        these as jax.Array triggers implicit JIT compilation for each new shape.
+        Converting to numpy first and re-uploading at bucket-padded size in
+        _scatter_spec_info_to_dp_slots eliminates those persistent cache misses.
+        """
+        device_fields = ("topk_p", "topk_index", "hidden_states", "verified_id", "accept_length")
+        to_copy = []
+        for f in device_fields:
+            v = getattr(self, f, None)
+            if v is not None and hasattr(v, "copy_to_host_async"):
+                jax.copy_to_host_async(v)
+                to_copy.append(f)
+        for f in to_copy:
+            setattr(self, f, np.asarray(getattr(self, f)))
+
     def filter_batch(self, new_indices: np.ndarray, has_been_filtered: bool = True):
         new_indices = np.asarray(new_indices)
-        # Verify path produces a pre-trimmed next_draft_input so len matches
-        # and truncate is a no-op. Other paths (draft_extend) leave self at
-        # full per-rank size and need fancy-index; the length check is the
-        # real guard, has_been_filtered is kept for backward signalling.
+        self._ensure_host()
         if has_been_filtered and len(new_indices) == len(self.topk_p):
             self.topk_p = self.topk_p[: len(new_indices)]
             self.topk_index = self.topk_index[: len(new_indices)]
@@ -723,7 +739,6 @@ class EagleDraftInput:
                 self.allocate_lens = np.asarray(self.allocate_lens)[new_indices]
 
     def merge_batch(self, spec_info: EagleDraftInput):
-        # FIXME(pc) need support overlap here
         if self.hidden_states is None:
             self.hidden_states = spec_info.hidden_states
             self.verified_id = spec_info.verified_id
@@ -732,10 +747,12 @@ class EagleDraftInput:
             return
         if spec_info.hidden_states is None:
             return
-        self.hidden_states = jnp.concatenate([self.hidden_states, spec_info.hidden_states], axis=0)
-        self.verified_id = jnp.concatenate([self.verified_id, spec_info.verified_id], axis=0)
-        self.topk_p = jnp.concatenate([self.topk_p, spec_info.topk_p])
-        self.topk_index = jnp.concatenate([self.topk_index, spec_info.topk_index])
+        self._ensure_host()
+        spec_info._ensure_host()
+        self.hidden_states = np.concatenate([self.hidden_states, spec_info.hidden_states], axis=0)
+        self.verified_id = np.concatenate([self.verified_id, spec_info.verified_id], axis=0)
+        self.topk_p = np.concatenate([self.topk_p, spec_info.topk_p])
+        self.topk_index = np.concatenate([self.topk_index, spec_info.topk_index])
         self.allocate_lens = np.concatenate([self.allocate_lens, spec_info.allocate_lens])
 
 

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -26,7 +26,6 @@ from sgl_jax.srt.kernels.speculative.build_eagle_tree_structure_kernel import (
     build_eagle_tree_structure,
 )
 from sgl_jax.srt.kernels.speculative.kernel import (
-    create_extend_after_decode_spec_info,
     top_k_renorm_prob,
     top_p_renorm_prob,
     tree_speculative_sampling_target_only,
@@ -660,46 +659,6 @@ class EagleDraftInput:
             accept_length=np.empty((0,), dtype=np.int32),
             accept_length_cpu=np.empty((0,), dtype=np.int32),
         )
-
-    @DeprecationWarning
-    def prepare_extend_after_decode(
-        self,
-        batch: ScheduleBatch,
-    ):
-        if batch.forward_mode.is_idle():
-            return
-
-        batch.input_ids = self.verified_id
-        rank0_spec = batch.reqs_info[0].spec_info if batch.reqs_info else None
-        accept_length_cpu_arr = rank0_spec.accept_length_cpu if rank0_spec else None
-        if accept_length_cpu_arr is None:
-            accept_length_cpu_host = np.asarray([], dtype=np.int32)
-        else:
-            accept_length_cpu_host = accept_length_cpu_arr
-        batch.extend_lens = (accept_length_cpu_host + 1).tolist()
-        batch.extend_num_tokens = sum(batch.extend_lens)
-        batch.seq_lens = rank0_spec.seq_lens_for_draft_extend if rank0_spec else None
-        batch.seq_lens_sum = batch.seq_lens.sum().item()
-        batch.req_pool_indices = (
-            rank0_spec.req_pool_indices_for_draft_extend if rank0_spec else None
-        )
-        batch.return_logprob = False
-        batch.return_hidden_states = False
-
-        self.capture_hidden_mode = CaptureHiddenMode.LAST
-        self.accept_length = self.accept_length + 1
-        self.positions = np.empty_like(batch.input_ids, dtype=np.int32)
-        self.verified_id = np.empty_like(self.accept_length, dtype=np.int32)
-
-        self.positions, self.verified_id = create_extend_after_decode_spec_info(
-            batch.input_ids,
-            batch.seq_lens,
-            self.accept_length,
-            self.positions,
-            self.verified_id,
-        )
-
-        self.accept_length_cpu = np.asarray(accept_length_cpu_host, dtype=np.int32)
 
     def _ensure_host(self):
         """Move device arrays to host (numpy) to avoid variable-shape device ops.

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -528,18 +528,24 @@ class EagleDraftInput:
         speculative_num_draft_tokens: int,
     ):
         model_worker_batch.spec_info = self
-        model_worker_batch.seq_lens[: model_worker_batch.real_bs] = (
-            model_worker_batch.seq_lens[: model_worker_batch.real_bs]
-            + speculative_num_draft_tokens
-            - 1
+        sel = model_worker_batch.logits_indices_selector
+        model_worker_batch.seq_lens[sel] = (
+            model_worker_batch.seq_lens[sel] + speculative_num_draft_tokens - 1
         )
         bs = batch_output.accept_lens.shape[0]
         step_plus_1 = model_worker_batch.input_ids.shape[0] // bs
         model_worker_batch.positions = model_worker_batch.positions
-        model_worker_batch.extend_seq_lens = np.full((bs,), step_plus_1, dtype=np.int32)
-        model_worker_batch.extend_seq_lens[model_worker_batch.real_bs :] = 0
+        model_worker_batch.extend_seq_lens = np.zeros((bs,), dtype=np.int32)
+        model_worker_batch.extend_seq_lens[sel] = step_plus_1
+        # Per-rank-local cumsum: _select_hidden_states is a shard_map rank-local
+        # gather, so indices must be offsets into each rank's own hidden shard.
+        dp = model_worker_batch.dp_size
+        per_dp = model_worker_batch.per_dp_bs_size if dp > 1 else bs
         model_worker_batch.logits_indices = (
-            np.cumsum(model_worker_batch.extend_seq_lens, dtype=np.int32) - 1
+            model_worker_batch.extend_seq_lens.reshape(dp, per_dp)
+            .cumsum(axis=1, dtype=np.int32)
+            .ravel()
+            - 1
         )
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
         model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.FULL
@@ -560,44 +566,52 @@ class EagleDraftInput:
         return model_worker_batch, logits_metadata
 
     def prepare_for_decode(self, schedule_batch: ScheduleBatch):
-        new_allocate_lens = schedule_batch.seq_lens + self.ALLOC_LEN_PER_DECODE - 1
+        # spec_info / allocate_lens are global (flat across DP ranks). Allocate
+        # per-rank (allocator + swa_mapping are per-dp_rank at dp>1); concat
+        # back to global-flat. (#1053 P1-5b — was dp_rank=0 for all, so rank>0
+        # reqs allocated from rank 0's pool / updated swa_mapping[0].)
         bs = schedule_batch.batch_size()
         assert (
             self.allocate_lens.shape[0] == bs
         ), f" {self.allocate_lens.shape[0]=} but batch_size is {bs} "
         page_size = schedule_batch.token_to_kv_pool_allocator.page_size
-
-        if page_size == 1:
-            num_needed_tokens = (new_allocate_lens - self.allocate_lens).sum().item()
-            out_cache_loc = alloc_token_slots(schedule_batch.tree_cache, num_needed_tokens)
-        else:
-            last_loc = get_last_loc(
-                schedule_batch.req_to_token_pool.req_to_token,
-                schedule_batch.req_pool_indices,
-                self.allocate_lens,
+        new_alloc_chunks = []
+        flat_off = 0
+        for dp_rank, info in enumerate(schedule_batch.reqs_info):
+            if info.seq_lens is None or len(info.seq_lens) == 0:
+                continue
+            bs_r = len(info.seq_lens)
+            seq_r = np.asarray(info.seq_lens)
+            new_r = seq_r + self.ALLOC_LEN_PER_DECODE - 1
+            old_r = self.allocate_lens[flat_off : flat_off + bs_r]
+            ext_r = int((new_r - old_r).sum())
+            if page_size == 1:
+                ocl_r = alloc_token_slots(schedule_batch.tree_cache, ext_r, dp_rank=dp_rank)
+            else:
+                last_loc_r = get_last_loc(
+                    schedule_batch.req_to_token_pool.req_to_token,
+                    info.req_pool_indices,
+                    old_r,
+                )
+                ocl_r = alloc_paged_token_slots_extend(
+                    schedule_batch.tree_cache,
+                    old_r,
+                    new_r,
+                    last_loc_r,
+                    ext_r,
+                    dp_rank=dp_rank,
+                )
+            assign_req_to_token_pool(
+                info.req_pool_indices, schedule_batch.req_to_token_pool, old_r, new_r, ocl_r
             )
-            extend_num_tokens = sum(new_allocate_lens - self.allocate_lens).item()
-            out_cache_loc = alloc_paged_token_slots_extend(
-                schedule_batch.tree_cache,
-                self.allocate_lens,
-                new_allocate_lens,
-                last_loc,
-                extend_num_tokens,
-            )
+            new_alloc_chunks.append(new_r)
+            # Per-rank store (matches nospec extend); _get_spec_decode_mwb_dp
+            # DP-segments these so each rank's P("data") shard = its own slots.
+            info.out_cache_loc = np.asarray(ocl_r, dtype=np.int32)
+            flat_off += bs_r
+            info.seq_lens_sum = np.sum(info.seq_lens).item()
 
-        assign_req_to_token_pool(
-            schedule_batch.req_pool_indices,
-            schedule_batch.req_to_token_pool,
-            self.allocate_lens,
-            new_allocate_lens,
-            out_cache_loc,
-        )
-
-        self.allocate_lens = new_allocate_lens
-
-        info = schedule_batch.reqs_info[0]
-        info.seq_lens_sum = np.sum(info.seq_lens).item()
-        info.out_cache_loc = out_cache_loc
+        self.allocate_lens = np.concatenate(new_alloc_chunks)
 
     def prepare_for_draft_decode(
         self, model_worker_batch: ModelWorkerBatch, topk: int, num_steps: int
@@ -828,9 +842,8 @@ class EagleVerifyInput:
         if model_worker_batch.forward_mode.is_idle():
             return
 
-        model_worker_batch.seq_lens[: model_worker_batch.real_bs] = (
-            model_worker_batch.seq_lens[: model_worker_batch.real_bs] - 1
-        )
+        sel = model_worker_batch.logits_indices_selector
+        model_worker_batch.seq_lens[sel] = model_worker_batch.seq_lens[sel] - 1
         model_worker_batch.input_ids = self.draft_token
         model_worker_batch.positions = self.positions
         # bs = batch.batch_size()

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -4,23 +4,16 @@ import time
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 from tqdm import tqdm
 
 from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
 from sgl_jax.srt.layers.sampler import get_token_ids_logprobs, get_top_logprobs
-from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch, ScheduleBatch
-from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+from sgl_jax.srt.managers.schedule_batch import ScheduleBatch
 from sgl_jax.srt.managers.tp_worker import ModelWorker
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
-from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
-from sgl_jax.srt.speculative.base_worker import BaseSpecWorker, replicate_to_mesh
+from sgl_jax.srt.speculative.base_worker import BaseSpecWorker
 from sgl_jax.srt.speculative.eagle_draft_worker import EagleDraftWorker
-from sgl_jax.srt.speculative.eagle_util import (
-    EagleDraftInput,
-    EagleVerifyInput,
-    EagleVerifyOutput,
-)
+from sgl_jax.srt.speculative.eagle_util import EagleDraftInput, EagleVerifyOutput
 from sgl_jax.srt.utils.common_utils import get_bool_env_var
 
 logger = logging.getLogger(__name__)
@@ -35,173 +28,15 @@ class EAGLEWorker(BaseSpecWorker):
     scheduler interface is unchanged.
     """
 
-    def __init__(self, server_args, target_worker: ModelWorker):
-        self.server_args = server_args
-        self._target_worker = target_worker
-        self._draft_worker = EagleDraftWorker(server_args, target_worker)
-
-        self.topk = server_args.speculative_eagle_topk
-        self.speculative_num_steps = server_args.speculative_num_steps
-        self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
-        self.page_size = server_args.page_size
-        self.mesh = target_worker.mesh
-
-        from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
-
-        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
-            server_args.speculative_algorithm
+    def __init__(self, server_args, target_worker: ModelWorker, draft_worker=None):
+        super().__init__(
+            server_args,
+            target_worker,
+            draft_worker or EagleDraftWorker(server_args, target_worker),
         )
 
-        self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
-
-        (
-            precompile_token_paddings,
-            precompile_bs_paddings,
-            precompile_cache_loc_paddings,
-        ) = target_worker.get_precompile_paddings()
-        self.precompile_bs_paddings = precompile_bs_paddings
-        self.precompile_cache_loc_paddings = precompile_cache_loc_paddings
-        self.precompile_token_paddings = precompile_token_paddings
-
-    # -- BaseSpecWorker interface --
-
-    @property
-    def target_worker(self) -> ModelWorker:
-        return self._target_worker
-
-    @property
-    def draft_worker(self) -> EagleDraftWorker:
-        return self._draft_worker
-
-    def forward_batch_speculative_generation(
-        self,
-        model_worker_batch: ModelWorkerBatch,
-    ):
-        if model_worker_batch.forward_mode.is_extend():
-            # FIXME(pc) add padding logic here
-            if model_worker_batch.sampling_info.temperatures.ndim == 1:
-                model_worker_batch.sampling_info.temperatures = (
-                    model_worker_batch.sampling_info.temperatures[:, None]
-                )
-            sampling_metadata = SamplingMetadata.from_model_worker_batch(
-                model_worker_batch,
-                len(model_worker_batch.seq_lens) - model_worker_batch.real_bs,
-                self.mesh,
-                vocab_size=self.target_worker.model_config.vocab_size,
-            )
-            # target extend
-            logits_output, next_token_ids, cache_miss_count, bid, seq_lens = (
-                self.forward_target_extend(model_worker_batch, sampling_metadata)
-            )
-            # draft extend for Update Draft State
-            self.draft_worker.draft_extend_for_prefill(
-                model_worker_batch, logits_output.hidden_states, next_token_ids
-            )
-            # FIXME(pc) refactor this to batch output
-            batch_output = GenerationBatchResult(
-                logits_output=logits_output,
-                next_token_ids=next_token_ids,
-                next_draft_input=model_worker_batch.spec_info,
-                allocate_lens=model_worker_batch.seq_lens[: model_worker_batch.real_bs],
-                bid=bid,
-                cache_miss_count=cache_miss_count,
-                extend_input_len_per_req=None,
-                extend_logprob_start_len_per_req=None,
-            )
-            return batch_output
-
-        else:
-            cur_allocate_lens = model_worker_batch.spec_info.allocate_lens
-            self.draft_worker.draft(model_worker_batch)
-
-            batch_output = self.verify(model_worker_batch, cur_allocate_lens)
-
-            self.draft_worker.draft_extend_for_decode(model_worker_batch, batch_output)
-
-            return batch_output
-
-    # -- Target model methods --
-
-    def forward_target_extend(
-        self, model_worker_batch: ModelWorkerBatch, sample_meta_data: SamplingMetadata
-    ) -> tuple[LogitsProcessorOutput, jax.Array, int, int, np.ndarray]:
-        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
-        logits_output, next_token_ids, cache_miss_count = (
-            self.target_worker.forward_batch_generation(
-                model_worker_batch, sampling_metadata=sample_meta_data
-            )
-        )
-        return (
-            logits_output,
-            next_token_ids,
-            cache_miss_count,
-            model_worker_batch.bid,
-            model_worker_batch.seq_lens,
-        )
-
-    # -- Verify --
-
-    def verify(self, model_worker_batch: ModelWorkerBatch, cur_allocate_lens: jax.Array):
-        spec_info: EagleVerifyInput = model_worker_batch.spec_info
-        spec_info.allocate_lens = cur_allocate_lens
-        spec_info.prepare_for_verify(model_worker_batch, self.page_size, self.target_worker)
-        forward_metadata = self.target_worker.model_runner.attn_backend.get_eagle_forward_metadata(
-            model_worker_batch
-        )
-
-        logits_output, _, cache_miss_count = self.target_worker.forward_batch_generation(
-            model_worker_batch, skip_sample=True, forward_metadata=forward_metadata
-        )
-        logits_output.next_token_logits, logits_output.hidden_states = replicate_to_mesh(
-            self.mesh, logits_output.next_token_logits, logits_output.hidden_states
-        )
-        spec_info.hidden_states = logits_output.hidden_states
-        (
-            predict,
-            verified_id,
-            accept_length,
-            accept_index,
-        ) = spec_info.sample(
-            model_worker_batch,
-            logits_output,
-            self.draft_worker.draft_model_runner.rngs,
-            self.mesh,
-        )
-        # accept_index uses -1 for rejected slots; gathering with -1 picks the
-        # global last element, so dext later writes rejected tokens' draft-KV at
-        # a foreign position inside each req's page (corrupts prefix KV for all
-        # but the last req at bs>1). Redirect -1 to each req's own last slot.
-        # accept_index has length bs*(spec_steps+1); the gathered tensors have
-        # length bs*draft_token_num — equal at topk=1, distinct at topk>1.
-        draft_n = self.speculative_num_draft_tokens
-        accept_width = self.speculative_num_steps + 1
-        req_ids = np.arange(len(accept_index)) // accept_width
-        per_req_last = req_ids * draft_n + draft_n - 1
-        safe_index = np.where(accept_index >= 0, accept_index, per_req_last)
-        logits_output.next_token_logits = logits_output.next_token_logits[safe_index, :]
-        logits_output.hidden_states = logits_output.hidden_states[safe_index, :]
-        model_worker_batch.positions = model_worker_batch.positions[safe_index]
-        new_seq_lens = model_worker_batch.seq_lens + accept_length
-        next_draft_input = EagleDraftInput(
-            verified_id=verified_id,
-            new_seq_lens=new_seq_lens,
-            allocate_lens=cur_allocate_lens,
-            hidden_states=logits_output.hidden_states,
-        )
-
-        model_worker_batch.spec_info = next_draft_input
-        return GenerationBatchResult(
-            logits_output=logits_output,
-            next_token_ids=predict,
-            next_draft_input=next_draft_input,
-            accept_lens=accept_length,
-            # FIXME(pc) this field is for overlap
-            allocate_lens=cur_allocate_lens,
-            bid=model_worker_batch.bid,
-            cache_miss_count=cache_miss_count,
-            extend_input_len_per_req=None,
-            extend_logprob_start_len_per_req=None,
-        )
+    # -- BaseSpecWorker provides target_worker/draft_worker/verify/
+    #    forward_target_extend/forward_batch_speculative_generation --
 
     # -- Logprob post-processing --
 

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -53,7 +53,7 @@ class EAGLEWorker(BaseSpecWorker):
         assert len(accepted_indices) == len(logits_output.next_token_logits)
 
         temperatures = batch.sampling_info.temperatures
-        num_draft_tokens = batch.spec_info.draft_token_num
+        num_draft_tokens = batch.reqs_info[0].spec_info.draft_token_num
         temperatures = temperatures[accepted_indices // num_draft_tokens]
         if RETURN_ORIGINAL_LOGPROB:
             logprobs = jax.nn.log_softmax(logits_output.next_token_logits, axis=-1)
@@ -117,10 +117,12 @@ class EAGLEWorker(BaseSpecWorker):
 
     def precompile_spec_extend(self):
         start_time = time.perf_counter()
+        dp_size = self.server_args.dp_size
         logger.info(
-            "[SPEC_EXTEND] Begin to precompile bs_paddings=%s token_paddings=%s",
+            "[SPEC_EXTEND] Begin to precompile bs_paddings=%s token_paddings=%s dp_size=%d",
             self.precompile_bs_paddings[-1:],
             self.precompile_token_paddings,
+            dp_size,
         )
 
         bs, _ = self.draft_worker.get_max_padded_size()
@@ -130,18 +132,24 @@ class EAGLEWorker(BaseSpecWorker):
             for pair in pbar:
                 pair = list(pair)
                 bs, num_tokens = pair[0], pair[1]
-                pbar.set_postfix(bs=bs, tokens=num_tokens)
+                pbar.set_postfix(bs=bs, tokens=num_tokens, dp_size=dp_size)
                 if bs > num_tokens:
                     logger.warning("bs=%s > num_tokens=%s, skip this pair", bs, num_tokens)
                     continue
+                if bs % dp_size != 0:
+                    logger.warning(
+                        "[SPEC_EXTEND] skip bs=%d (not divisible by dp_size=%d)", bs, dp_size
+                    )
+                    continue
+                per_dp_bs = bs // dp_size
                 model_worker_batch = self.draft_worker.compilation_manager._make_dummy_batch(
                     bs,
                     num_tokens,
                     ForwardMode.EXTEND,
                     self.precompile_cache_loc_paddings[-1],
                     speculative_algorithm=self.speculative_algorithm,
-                    dp_size=1,
-                    per_dp_bs_size=bs,
+                    dp_size=dp_size,
+                    per_dp_bs_size=per_dp_bs,
                 )
                 self.forward_batch_speculative_generation(model_worker_batch)
         end_time = time.perf_counter()
@@ -149,16 +157,24 @@ class EAGLEWorker(BaseSpecWorker):
 
     def precompile_spec_decode(self):
         start_time = time.perf_counter()
+        dp_size = self.server_args.dp_size
         logger.info(
-            "[SPEC_DECODE] Begin to precompile bs_paddings=%s",
+            "[SPEC_DECODE] Begin to precompile bs_paddings=%s dp_size=%d",
             self.precompile_bs_paddings,
+            dp_size,
         )
 
         with tqdm(
             self.precompile_bs_paddings, desc="[SPEC_DECODE] PRECOMPILE", leave=False
         ) as pbar:
             for bs in pbar:
-                pbar.set_postfix(bs=bs)
+                pbar.set_postfix(bs=bs, dp_size=dp_size)
+                if bs % dp_size != 0:
+                    logger.warning(
+                        "[SPEC_DECODE] skip bs=%d (not divisible by dp_size=%d)", bs, dp_size
+                    )
+                    continue
+                per_dp_bs = bs // dp_size
                 aligned_cache_loc_size = (
                     (bs * self.draft_worker.max_req_len + self.page_size - 1)
                     // self.page_size
@@ -170,8 +186,8 @@ class EAGLEWorker(BaseSpecWorker):
                     ForwardMode.DECODE,
                     aligned_cache_loc_size,
                     speculative_algorithm=self.speculative_algorithm,
-                    dp_size=1,
-                    per_dp_bs_size=bs,
+                    dp_size=dp_size,
+                    per_dp_bs_size=per_dp_bs,
                 )
                 spec_info = EagleDraftInput(
                     # FIXME(pc) dtype should according to serverargs
@@ -191,7 +207,7 @@ class EAGLEWorker(BaseSpecWorker):
                     + EagleDraftInput.ALLOC_LEN_PER_DECODE,
                 )
                 model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
-                model_worker_batch.spec_info = spec_info
+                model_worker_batch.spec_info_padded = spec_info
                 model_worker_batch.speculative_eagle_topk = self.topk
                 model_worker_batch.speculative_num_draft_tokens = self.speculative_num_draft_tokens
                 model_worker_batch.speculative_num_steps = self.speculative_num_steps

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -4,6 +4,7 @@ import time
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from tqdm import tqdm
 
 from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
@@ -211,6 +212,17 @@ class EAGLEWorker(BaseSpecWorker):
                 model_worker_batch.speculative_eagle_topk = self.topk
                 model_worker_batch.speculative_num_draft_tokens = self.speculative_num_draft_tokens
                 model_worker_batch.speculative_num_steps = self.speculative_num_steps
+                # Pad out_cache_loc to bs * draft_token_num so verify/draft_extend
+                # forward see the same shape runtime _get_spec_decode_mwb_dp emits.
+                ocl_target = bs * self.speculative_num_draft_tokens
+                if model_worker_batch.out_cache_loc.shape[0] < ocl_target:
+                    pad_len = ocl_target - model_worker_batch.out_cache_loc.shape[0]
+                    model_worker_batch.out_cache_loc = np.concatenate(
+                        [
+                            np.asarray(model_worker_batch.out_cache_loc, dtype=np.int32),
+                            np.full(pad_len, -1, dtype=np.int32),
+                        ]
+                    )
                 self.forward_batch_speculative_generation(model_worker_batch)
 
         end_time = time.perf_counter()

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -1,0 +1,320 @@
+"""MiMo-V2.5-Pro multi-layer MTP draft worker (#1053 P1-4).
+
+Differs from ``EagleDraftWorker`` in that the N draft steps each use a
+*different* draft model runner (one per ``mtp_layer_idx``), with hidden
+states flowing layer→layer (layer i's output hidden becomes layer i+1's
+``spec_info.hidden_states``). Everything else — padding, tree build,
+verify-input construction, replicate helpers — is reused from
+``EagleDraftWorker``.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata
+from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
+from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+from sgl_jax.srt.managers.tp_worker import ModelWorker
+from sgl_jax.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
+from sgl_jax.srt.speculative.base_worker import replicate_to_mesh
+from sgl_jax.srt.speculative.eagle_draft_worker import (
+    EagleDraftWorker,
+    select_top_k_tokens,
+    topk_probs_from_logits,
+    update_eagle_lists,
+    update_forward_batch_info,
+)
+from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
+from sgl_jax.srt.utils.jax_utils import device_array
+
+logger = logging.getLogger(__name__)
+
+
+def _server_args_with_mtp_layer(server_args, layer_idx: int):
+    sa = copy.copy(server_args)
+    override = json.loads(sa.json_model_override_args or "{}")
+    override["mtp_layer_idx"] = layer_idx
+    sa.json_model_override_args = json.dumps(override)
+    return sa
+
+
+class MultiLayerDraftWorker(EagleDraftWorker):
+    """N independent draft model runners, one per MTP layer.
+
+    ``speculative_num_steps`` must equal the number of MTP layers (one
+    draft step per layer). ``draft_model_runner`` resolves to layer 0's
+    runner for code paths that need a single runner handle (KV-pool
+    sizing, attention-backend type, mesh — all identical across layers).
+    """
+
+    def __init__(self, server_args, target_worker: ModelWorker):
+        self.server_args = server_args
+        self.target_worker_ref = target_worker
+        self.topk = server_args.speculative_eagle_topk
+        self.speculative_num_steps = server_args.speculative_num_steps
+        self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
+        self.page_size = server_args.page_size
+        from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
+        self.hot_token_ids = None
+
+        self.num_mtp_layers = self.speculative_num_steps
+        assert self.num_mtp_layers > 1
+        cfg_mtp = getattr(target_worker.model_config.hf_config, "num_nextn_predict_layers", None)
+        # MiMo-style configs omit num_nextn_predict_layers; only enforce equality
+        # when the field exists (scheduler routes here iff n_mtp>1 either way).
+        assert cfg_mtp is None or cfg_mtp == self.num_mtp_layers, (
+            f"--speculative-num-steps={self.speculative_num_steps} must equal the "
+            f"model's num_nextn_predict_layers={cfg_mtp} (one runner per MTP layer)"
+        )
+        req_to_token_pool, _ = target_worker.get_memory_pool()
+
+        self._workers: list[ModelWorker] = []
+        for i in range(self.num_mtp_layers):
+            sa = _server_args_with_mtp_layer(server_args, i)
+            self._workers.append(
+                ModelWorker(
+                    sa,
+                    target_worker.mesh,
+                    req_to_token_pool=req_to_token_pool,
+                    is_draft_worker=True,
+                )
+            )
+        self._worker = self._workers[0]
+
+        EagleDraftInput.ALLOC_LEN_PER_DECODE = max(
+            self.speculative_num_steps * self.topk, self.speculative_num_draft_tokens
+        )
+
+        for w in self._workers:
+            self._share_embed_head_one(target_worker, w)
+
+        target_slot_range = target_worker.model_runner.max_total_num_tokens
+        for i, w in enumerate(self._workers):
+            draft_pool = w.model_runner.max_total_num_tokens
+            assert draft_pool >= target_slot_range, (
+                f"MTP layer {i} draft KV pool ({draft_pool}) < target slot range "
+                f"({target_slot_range})"
+            )
+            w.model_runner.initialize_jit()
+
+        (
+            self.precompile_token_paddings,
+            self.precompile_bs_paddings,
+            self.precompile_cache_loc_paddings,
+        ) = target_worker.get_precompile_paddings()
+
+    def _share_embed_head_one(self, target_worker: ModelWorker, draft_worker: ModelWorker):
+        embed, head = target_worker.model_runner.model.get_embed_and_head()
+        m = draft_worker.model_runner.model
+        if getattr(m, "load_lm_head_from_target", False):
+            m.set_embed_and_head(embed, head)
+        else:
+            m.set_embed(embed)
+
+    @property
+    def draft_model_runner(self):
+        return self._workers[0].model_runner
+
+    def runner(self, step: int):
+        return self._workers[step].model_runner
+
+    # ---- per-layer overrides ------------------------------------------------
+
+    def draft_forward(self, model_worker_batch: ModelWorkerBatch):
+        topk_p = model_worker_batch.spec_info.topk_p
+        topk_index = model_worker_batch.spec_info.topk_index
+        hidden_states = model_worker_batch.spec_info.hidden_states
+        bs = model_worker_batch.seq_lens.shape[0]
+        step_min_1 = self.speculative_num_steps - 1
+        score_list = jnp.empty((bs, 1 + step_min_1 * self.topk, self.topk))
+        token_list = jnp.empty(
+            (bs, self.topk + step_min_1 * self.topk * self.topk), dtype=jnp.int32
+        )
+        parents_list = jnp.empty((bs, self.topk + 1 + step_min_1 * self.topk))
+        scores = None
+        positions_base = device_array(
+            np.repeat(model_worker_batch.seq_lens, self.topk),
+            sharding=NamedSharding(self.mesh, P()),
+        )
+        logits_metadata = LogitsMetadata.from_model_worker_batch(model_worker_batch, self.mesh)
+
+        # Per-layer attention metadata: each layer has its own KV pool, so
+        # page_indices differ; positions/seq_lens are shared so we only need
+        # the i-th step's metadata from layer i.
+        metadata_per_layer = [
+            w.model_runner.attn_backend.get_eagle_multi_step_metadata(model_worker_batch)
+            for w in self._workers
+        ]
+
+        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
+        forward_batch.out_cache_loc = np.empty((1,))
+        forward_batch.cache_loc = np.empty((1,))
+        forward_batch.spec_info = EagleDraftInput()
+        forward_batch.spec_info.hidden_states = jnp.empty((bs * self.topk, hidden_states.shape[1]))
+
+        for i in range(self.speculative_num_steps):
+            input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
+                i, topk_p, topk_index, hidden_states, scores, self.topk
+            )
+            score_list, token_list, parents_list = update_eagle_lists(
+                i, score_list, token_list, parents_list, tree_info, self.topk
+            )
+            if i == self.speculative_num_steps - 1:
+                break
+
+            forward_batch = update_forward_batch_info(
+                forward_batch, i, input_ids, hidden_states, positions_base
+            )
+            mr = self.runner(i)
+            mr.attn_backend.forward_metadata = metadata_per_layer[i][i]
+            forward_batch.bid = model_worker_batch.bid
+            logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)
+
+            topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
+            if self.hot_token_ids is not None:
+                topk_index = self.hot_token_ids[topk_index]
+            hidden_states = replicate_to_mesh(self.mesh, logits_output.hidden_states)
+
+        return score_list, token_list, parents_list
+
+    def draft_extend_for_prefill(
+        self,
+        model_worker_batch: ModelWorkerBatch,
+        hidden_states: jax.Array,
+        next_token_ids: jax.Array,
+    ) -> None:
+        """Prefill-extend across all MTP layers.
+
+        Layer 0 consumes the target's full-prefix hidden_states; layer i>0
+        consumes layer i-1's output hidden. Each layer writes its own
+        prefix KV. Only layer 0's topk/hidden are kept as the next-round
+        draft state (draft step 0 starts from layer 0).
+        """
+        verified_id_np = np.asarray(jax.device_get(next_token_ids))[: model_worker_batch.real_bs]
+        model_worker_batch.spec_info = EagleDraftInput(
+            hidden_states=hidden_states,
+            verified_id=verified_id_np,
+            num_tokens_per_batch=np.asarray(1, dtype=jnp.int32),
+            num_tokens_for_logprob_per_batch=np.asarray(1, dtype=jnp.int32),
+            allocate_lens=model_worker_batch.seq_lens,
+        )
+        model_worker_batch.return_hidden_states = False
+        model_worker_batch.spec_info.prepare_for_extend_after_target_prefill(
+            model_worker_batch=model_worker_batch
+        )
+        # FULL: layer i+1 needs layer i's per-token hidden over the whole prefix.
+        model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.FULL
+        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
+        last_idx = model_worker_batch.logits_indices
+
+        layer0_out = None
+        cur_hidden = hidden_states
+        for i, w in enumerate(self._workers):
+            mr = w.model_runner
+            model_worker_batch.spec_info.hidden_states = cur_hidden
+            forward_batch = ForwardBatch.init_new(model_worker_batch, mr)
+            forward_batch.return_logprob = False
+            mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(
+                model_worker_batch
+            )
+            forward_batch.forward_mode = ForwardMode.EXTEND
+            logits_output, _, _ = mr.forward(
+                forward_batch,
+                logits_metadata=LogitsMetadata.from_model_worker_batch(
+                    model_worker_batch, self.mesh
+                ),
+            )
+            cur_hidden = logits_output.hidden_states
+            if i == 0:
+                layer0_out = logits_output
+
+        # Next-round draft state = layer 0's last-token hidden + topk (draft step 0
+        # starts from layer 0 with target's last hidden, so we cache layer 0's
+        # output here so step 0 can be skipped).
+        rep_logits, rep_hidden = replicate_to_mesh(
+            self.mesh, layer0_out.next_token_logits, layer0_out.hidden_states
+        )
+        layer0_out.next_token_logits = rep_logits[: model_worker_batch.real_bs, :]
+        layer0_out.hidden_states = rep_hidden[last_idx][: model_worker_batch.real_bs]
+        model_worker_batch.spec_info.hidden_states = hidden_states
+        model_worker_batch.spec_info.allocate_lens = model_worker_batch.seq_lens[
+            : model_worker_batch.real_bs
+        ]
+        self.capture_for_decode(layer0_out, model_worker_batch.spec_info)
+
+    def draft_extend_for_decode(
+        self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
+    ) -> None:
+        """Decode-extend across all MTP layers (each updates its own KV).
+
+        Same chaining as prefill: layer 0 consumes target verify hidden,
+        layer i>0 consumes layer i-1's output. Only layer 0's topk/hidden
+        become the next-round draft state.
+        """
+        if batch_output.next_draft_input.verified_id.shape[0] <= 0:
+            return
+        target_hidden = batch_output.logits_output.hidden_states
+
+        # prepare_for_extend_after_verify mutates mwb.seq_lens / input_ids /
+        # spec_info in place — call it once (semantics are layer-independent),
+        # then per layer only swap hidden_states + recompute forward_metadata
+        # against that layer's KV pool.
+        draft_input = EagleDraftInput(
+            hidden_states=target_hidden, allocate_lens=batch_output.allocate_lens
+        )
+        mwb, logits_metadata = draft_input.prepare_for_extend_after_verify(
+            model_worker_batch,
+            self.draft_model_runner,
+            batch_output,
+            self.speculative_num_draft_tokens,
+        )
+        if mwb.input_ids.shape[0] <= 0:
+            return
+
+        layer0_logits = None
+        cur_hidden = target_hidden
+        for i, w in enumerate(self._workers):
+            mr = w.model_runner
+            mwb.spec_info.hidden_states = cur_hidden
+            mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(mwb)
+            forward_batch = ForwardBatch.init_new(mwb, mr)
+            logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)
+            if i == 0:
+                layer0_logits = logits_output
+            cur_hidden = logits_output.hidden_states
+
+        select_index = (
+            np.arange(len(model_worker_batch.seq_lens[: model_worker_batch.real_bs]))
+            * (self.speculative_num_steps + 1)
+            + batch_output.accept_lens[: model_worker_batch.real_bs]
+            - 1
+        )
+        rep_logits, rep_hidden = replicate_to_mesh(
+            self.mesh, layer0_logits.next_token_logits, layer0_logits.hidden_states
+        )
+        topk_p, topk_index = topk_probs_from_logits(rep_logits[select_index], self.topk)
+        batch_output.next_draft_input.hidden_states = rep_hidden[select_index]
+        batch_output.next_draft_input.topk_p = topk_p
+        batch_output.next_draft_input.topk_index = topk_index
+        batch_output.next_draft_input.verified_id = batch_output.next_draft_input.verified_id[
+            select_index
+        ]
+        batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
+        batch_output.accept_lens = batch_output.accept_lens[: model_worker_batch.real_bs]

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -259,6 +259,13 @@ class MultiLayerDraftWorker(EagleDraftWorker):
             self.mesh, layer0_out.next_token_logits, layer0_out.hidden_states
         )
         layer0_out.next_token_logits = rep_logits
+        dp_size = model_worker_batch.dp_size
+        if dp_size > 1:
+            per_dp_tokens = rep_hidden.shape[0] // dp_size
+            per_dp_bs = last_idx.shape[0] // dp_size
+            last_idx = last_idx.copy()
+            for k in range(1, dp_size):
+                last_idx[k * per_dp_bs : (k + 1) * per_dp_bs] += k * per_dp_tokens
         layer0_out.hidden_states = rep_hidden[last_idx]
         model_worker_batch.spec_info_padded.hidden_states = hidden_states
         model_worker_batch.spec_info_padded.allocate_lens = np.asarray(model_worker_batch.seq_lens)[

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -105,13 +105,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         for w in self._workers:
             self._share_embed_head_one(target_worker, w)
 
-        target_slot_range = target_worker.model_runner.max_total_num_tokens
         for i, w in enumerate(self._workers):
-            draft_pool = w.model_runner.max_total_num_tokens
-            assert draft_pool >= target_slot_range, (
-                f"MTP layer {i} draft KV pool ({draft_pool}) < target slot range "
-                f"({target_slot_range})"
-            )
             w.model_runner.initialize_jit()
 
         (
@@ -225,6 +219,17 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
         last_idx = model_worker_batch.logits_indices
 
+        # Pad verified_id from (real_bs,) to (padded_bs,) so jit'd MTP forward
+        # sees the bucket shape every time (forward_batch.spec_info.verified_id
+        # is a pytree leaf; without this each real_bs triggers a fresh trace).
+        # Restored to real_bs after the loop so cross-round flat state stays
+        # flat-ordered. Mirrors single-layer EagleDraftWorker.
+        padded_bs = int(model_worker_batch.seq_lens.shape[0])
+        if verified_id_np.shape[0] < padded_bs:
+            model_worker_batch.spec_info_padded.verified_id = np.pad(
+                verified_id_np, ((0, padded_bs - verified_id_np.shape[0]),)
+            )
+
         layer0_out = None
         cur_hidden = hidden_states
         for i, w in enumerate(self._workers):
@@ -252,13 +257,16 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         rep_logits, rep_hidden = replicate_to_mesh(
             self.mesh, layer0_out.next_token_logits, layer0_out.hidden_states
         )
-        layer0_out.next_token_logits = rep_logits[sel, :]
-        layer0_out.hidden_states = rep_hidden[last_idx][sel]
+        layer0_out.next_token_logits = rep_logits
+        layer0_out.hidden_states = rep_hidden[last_idx]
         model_worker_batch.spec_info_padded.hidden_states = hidden_states
         model_worker_batch.spec_info_padded.allocate_lens = np.asarray(model_worker_batch.seq_lens)[
             sel
         ]
-        self.capture_for_decode(layer0_out, model_worker_batch.spec_info_padded)
+        # Restore real_bs verified_id so split_spec_info_per_rank can cut on
+        # real_bs_per_dp without slicing past the valid region.
+        model_worker_batch.spec_info_padded.verified_id = verified_id_np
+        self.capture_for_decode(layer0_out, model_worker_batch.spec_info_padded, sel=sel)
 
     def draft_extend_for_decode(
         self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
@@ -302,25 +310,31 @@ class MultiLayerDraftWorker(EagleDraftWorker):
             cur_hidden = logits_output.hidden_states
 
         # logits_indices_selector maps global-flat req k → DP-padded slot s_k.
-        # rep_logits/rep_hidden are DP-padded (total_bs*(steps+1), …); gather
-        # each req's accept_len-th entry by slot, producing global-flat
-        # (real_bs, …) for the cross-round spec_info.
+        # rep_logits/rep_hidden are DP-padded (total_bs, …)/(total_bs*(steps+1), …);
+        # keep topk_probs_from_logits running on device with the padded shape
+        # (varying real_bs gather on device would generate a fresh trace per
+        # warmup batch size — see #1090). Gather to real_bs on host.
         sel = np.asarray(model_worker_batch.logits_indices_selector)
         accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
         select_index = sel * (self.speculative_num_steps + 1) + accept_host[sel] - 1
         rep_logits, rep_hidden = replicate_to_mesh(
             self.mesh, layer0_logits.next_token_logits, layer0_logits.hidden_states
         )
-        # next_token_logits is pruned to (total_bs, vocab) (one entry per slot,
-        # already the last-accepted token via logits_indices); hidden_states is
-        # FULL (total_bs*(steps+1), H). Index logits by slot, hidden by token.
-        topk_p, topk_index = topk_probs_from_logits(rep_logits[sel], self.topk)
-        batch_output.next_draft_input.hidden_states = rep_hidden[select_index]
+        topk_p, topk_index = topk_probs_from_logits(rep_logits, self.topk)
+        jax.copy_to_host_async(topk_p)
+        jax.copy_to_host_async(topk_index)
+        jax.copy_to_host_async(rep_hidden)
+        verified_id_arr = batch_output.next_draft_input.verified_id
+        if hasattr(verified_id_arr, "copy_to_host_async"):
+            jax.copy_to_host_async(verified_id_arr)
+        topk_p = np.asarray(topk_p)[sel]
+        topk_index = np.asarray(topk_index)[sel]
+        hidden = np.asarray(rep_hidden)[select_index]
+        verified_id = np.asarray(verified_id_arr)[select_index]
+        batch_output.next_draft_input.hidden_states = hidden
         batch_output.next_draft_input.topk_p = topk_p
         batch_output.next_draft_input.topk_index = topk_index
-        batch_output.next_draft_input.verified_id = batch_output.next_draft_input.verified_id[
-            select_index
-        ]
+        batch_output.next_draft_input.verified_id = verified_id
         batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
         # accept_lens stays DP-padded (total_bs,) — scheduler per-rank seq_lens
         # update and _resolve_spec_decode_token_ids both index by DP slot.

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -207,7 +207,8 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         prefix KV. Only layer 0's topk/hidden are kept as the next-round
         draft state (draft step 0 starts from layer 0).
         """
-        verified_id_np = np.asarray(jax.device_get(next_token_ids))[: model_worker_batch.real_bs]
+        sel = np.asarray(model_worker_batch.logits_indices_selector)
+        verified_id_np = np.asarray(jax.device_get(next_token_ids))[sel]
         model_worker_batch.spec_info = EagleDraftInput(
             hidden_states=hidden_states,
             verified_id=verified_id_np,
@@ -251,12 +252,10 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         rep_logits, rep_hidden = replicate_to_mesh(
             self.mesh, layer0_out.next_token_logits, layer0_out.hidden_states
         )
-        layer0_out.next_token_logits = rep_logits[: model_worker_batch.real_bs, :]
-        layer0_out.hidden_states = rep_hidden[last_idx][: model_worker_batch.real_bs]
+        layer0_out.next_token_logits = rep_logits[sel, :]
+        layer0_out.hidden_states = rep_hidden[last_idx][sel]
         model_worker_batch.spec_info.hidden_states = hidden_states
-        model_worker_batch.spec_info.allocate_lens = model_worker_batch.seq_lens[
-            : model_worker_batch.real_bs
-        ]
+        model_worker_batch.spec_info.allocate_lens = np.asarray(model_worker_batch.seq_lens)[sel]
         self.capture_for_decode(layer0_out, model_worker_batch.spec_info)
 
     def draft_extend_for_decode(
@@ -300,16 +299,20 @@ class MultiLayerDraftWorker(EagleDraftWorker):
                 layer0_logits = logits_output
             cur_hidden = logits_output.hidden_states
 
-        select_index = (
-            np.arange(len(model_worker_batch.seq_lens[: model_worker_batch.real_bs]))
-            * (self.speculative_num_steps + 1)
-            + batch_output.accept_lens[: model_worker_batch.real_bs]
-            - 1
-        )
+        # logits_indices_selector maps global-flat req k → DP-padded slot s_k.
+        # rep_logits/rep_hidden are DP-padded (total_bs*(steps+1), …); gather
+        # each req's accept_len-th entry by slot, producing global-flat
+        # (real_bs, …) for the cross-round spec_info.
+        sel = np.asarray(model_worker_batch.logits_indices_selector)
+        accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
+        select_index = sel * (self.speculative_num_steps + 1) + accept_host[sel] - 1
         rep_logits, rep_hidden = replicate_to_mesh(
             self.mesh, layer0_logits.next_token_logits, layer0_logits.hidden_states
         )
-        topk_p, topk_index = topk_probs_from_logits(rep_logits[select_index], self.topk)
+        # next_token_logits is pruned to (total_bs, vocab) (one entry per slot,
+        # already the last-accepted token via logits_indices); hidden_states is
+        # FULL (total_bs*(steps+1), H). Index logits by slot, hidden by token.
+        topk_p, topk_index = topk_probs_from_logits(rep_logits[sel], self.topk)
         batch_output.next_draft_input.hidden_states = rep_hidden[select_index]
         batch_output.next_draft_input.topk_p = topk_p
         batch_output.next_draft_input.topk_index = topk_index
@@ -317,4 +320,6 @@ class MultiLayerDraftWorker(EagleDraftWorker):
             select_index
         ]
         batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
-        batch_output.accept_lens = batch_output.accept_lens[: model_worker_batch.real_bs]
+        # accept_lens stays DP-padded (total_bs,) — scheduler per-rank seq_lens
+        # update and _resolve_spec_decode_token_ids both index by DP slot.
+        batch_output.accept_lens = accept_host

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -138,9 +138,9 @@ class MultiLayerDraftWorker(EagleDraftWorker):
     # ---- per-layer overrides ------------------------------------------------
 
     def draft_forward(self, model_worker_batch: ModelWorkerBatch):
-        topk_p = model_worker_batch.spec_info.topk_p
-        topk_index = model_worker_batch.spec_info.topk_index
-        hidden_states = model_worker_batch.spec_info.hidden_states
+        topk_p = model_worker_batch.spec_info_padded.topk_p
+        topk_index = model_worker_batch.spec_info_padded.topk_index
+        hidden_states = model_worker_batch.spec_info_padded.hidden_states
         bs = model_worker_batch.seq_lens.shape[0]
         step_min_1 = self.speculative_num_steps - 1
         score_list = jnp.empty((bs, 1 + step_min_1 * self.topk, self.topk))
@@ -209,7 +209,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         """
         sel = np.asarray(model_worker_batch.logits_indices_selector)
         verified_id_np = np.asarray(jax.device_get(next_token_ids))[sel]
-        model_worker_batch.spec_info = EagleDraftInput(
+        model_worker_batch.spec_info_padded = EagleDraftInput(
             hidden_states=hidden_states,
             verified_id=verified_id_np,
             num_tokens_per_batch=np.asarray(1, dtype=jnp.int32),
@@ -217,11 +217,11 @@ class MultiLayerDraftWorker(EagleDraftWorker):
             allocate_lens=model_worker_batch.seq_lens,
         )
         model_worker_batch.return_hidden_states = False
-        model_worker_batch.spec_info.prepare_for_extend_after_target_prefill(
+        model_worker_batch.spec_info_padded.prepare_for_extend_after_target_prefill(
             model_worker_batch=model_worker_batch
         )
         # FULL: layer i+1 needs layer i's per-token hidden over the whole prefix.
-        model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.FULL
+        model_worker_batch.spec_info_padded.capture_hidden_mode = CaptureHiddenMode.FULL
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
         last_idx = model_worker_batch.logits_indices
 
@@ -229,7 +229,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         cur_hidden = hidden_states
         for i, w in enumerate(self._workers):
             mr = w.model_runner
-            model_worker_batch.spec_info.hidden_states = cur_hidden
+            model_worker_batch.spec_info_padded.hidden_states = cur_hidden
             forward_batch = ForwardBatch.init_new(model_worker_batch, mr)
             forward_batch.return_logprob = False
             mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(
@@ -254,9 +254,11 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         )
         layer0_out.next_token_logits = rep_logits[sel, :]
         layer0_out.hidden_states = rep_hidden[last_idx][sel]
-        model_worker_batch.spec_info.hidden_states = hidden_states
-        model_worker_batch.spec_info.allocate_lens = np.asarray(model_worker_batch.seq_lens)[sel]
-        self.capture_for_decode(layer0_out, model_worker_batch.spec_info)
+        model_worker_batch.spec_info_padded.hidden_states = hidden_states
+        model_worker_batch.spec_info_padded.allocate_lens = np.asarray(model_worker_batch.seq_lens)[
+            sel
+        ]
+        self.capture_for_decode(layer0_out, model_worker_batch.spec_info_padded)
 
     def draft_extend_for_decode(
         self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
@@ -291,7 +293,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         cur_hidden = target_hidden
         for i, w in enumerate(self._workers):
             mr = w.model_runner
-            mwb.spec_info.hidden_states = cur_hidden
+            mwb.spec_info_padded.hidden_states = cur_hidden
             mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(mwb)
             forward_batch = ForwardBatch.init_new(mwb, mr)
             logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -316,6 +316,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         # warmup batch size — see #1090). Gather to real_bs on host.
         sel = np.asarray(model_worker_batch.logits_indices_selector)
         accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
+        assert (accept_host[sel] >= 1).all(), f"accept_length < 1: {accept_host[sel]}"
         select_index = sel * (self.speculative_num_steps + 1) + accept_host[sel] - 1
         rep_logits, rep_hidden = replicate_to_mesh(
             self.mesh, layer0_logits.next_token_logits, layer0_logits.hidden_states

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -178,6 +178,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
             )
             mr = self.runner(i)
             mr.attn_backend.forward_metadata = metadata_per_layer[i][i]
+            forward_batch.attn_backend = mr.attn_backend
             forward_batch.bid = model_worker_batch.bid
             logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)
 

--- a/python/sgl_jax/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_eagle_worker.py
@@ -1,0 +1,23 @@
+"""MiMo-V2.5-Pro multi-layer MTP spec orchestrator (#1053 P1-4).
+
+Thin wrapper over ``EAGLEWorker`` that swaps the draft worker for
+``MultiLayerDraftWorker``. Orchestration (prefill/decode dispatch,
+``verify()``, precompile) is identical to standard EAGLE — only the draft
+side differs (N runners, layer→layer hidden chaining).
+"""
+
+from __future__ import annotations
+
+from sgl_jax.srt.managers.tp_worker import ModelWorker
+from sgl_jax.srt.speculative.eagle_worker import EAGLEWorker
+from sgl_jax.srt.speculative.multi_layer_draft_worker import MultiLayerDraftWorker
+
+
+class MultiLayerEAGLEWorker(EAGLEWorker):
+
+    def __init__(self, server_args, target_worker: ModelWorker):
+        super().__init__(
+            server_args,
+            target_worker,
+            draft_worker=MultiLayerDraftWorker(server_args, target_worker),
+        )

--- a/python/sgl_jax/srt/speculative/spec_info.py
+++ b/python/sgl_jax/srt/speculative/spec_info.py
@@ -59,16 +59,24 @@ class SpeculativeAlgorithm(IntEnum):
     NONE = auto()
     EAGLE = auto()
     EAGLE3 = auto()
+    NEXTN = auto()
     STANDALONE = auto()
 
     def is_none(self):
         return self == SpeculativeAlgorithm.NONE
 
     def is_eagle(self):
-        return self == SpeculativeAlgorithm.EAGLE or self == SpeculativeAlgorithm.EAGLE3
+        return self in (
+            SpeculativeAlgorithm.EAGLE,
+            SpeculativeAlgorithm.EAGLE3,
+            SpeculativeAlgorithm.NEXTN,
+        )
 
     def is_eagle3(self):
         return self == SpeculativeAlgorithm.EAGLE3
+
+    def is_nextn(self):
+        return self == SpeculativeAlgorithm.NEXTN
 
     def is_standalone(self):
         return self == SpeculativeAlgorithm.STANDALONE
@@ -78,6 +86,7 @@ class SpeculativeAlgorithm(IntEnum):
         name_map = {
             "EAGLE": SpeculativeAlgorithm.EAGLE,
             "EAGLE3": SpeculativeAlgorithm.EAGLE3,
+            "NEXTN": SpeculativeAlgorithm.NEXTN,
             "STANDALONE": SpeculativeAlgorithm.STANDALONE,
             None: SpeculativeAlgorithm.NONE,
         }

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -136,6 +136,7 @@ class WeightLoader:
         self.mesh = mesh
         self.dtype = dtype
         self.dummy_mode = getattr(model_config, "_dummy_mode", False)
+        self._weight_info_cache: dict[str, list[dict]] | None = None
         if hasattr(model_config, "num_attention_heads"):
             self.num_heads = model_config.num_attention_heads
             # Use original count for replication logic
@@ -185,6 +186,10 @@ class WeightLoader:
             return True
         ignored = quant_cfg.ignored_layers or []
         return any(hf_path == ig or hf_path.endswith(f".{ig}") for ig in ignored)
+
+    def has_weight_on_disk(self, hf_key: str) -> bool:
+        """Return whether a concrete HF weight key exists in the safetensors files."""
+        return hf_key in self._scan_weight_info()
 
     # ------------------------------------------------------------------
     # Post-load hooks: dequant FP8 → BF16, KV head replication
@@ -992,6 +997,9 @@ class WeightLoader:
         """
         Scan all safetensors files to build a mapping from HF key to file info.
         """
+        if self._weight_info_cache is not None:
+            return self._weight_info_cache
+
         # 1. Host 0 does the heavy lifting (Scanning)
         if jax.process_index() == 0:
             model_path = self.model_config.model_path
@@ -1066,6 +1074,7 @@ class WeightLoader:
         if jax.process_index() != 0:
             logger.info("Metadata received. Total keys: %s", len(weight_info))
 
+        self._weight_info_cache = weight_info
         return weight_info
 
     def _create_lazy_tensors(

--- a/python/sgl_jax/test/models/test_mimo_v2_nextn.py
+++ b/python/sgl_jax/test/models/test_mimo_v2_nextn.py
@@ -30,9 +30,24 @@ _PER_LAYER_KEYS = [
     "self_attn.qkv_proj.weight_scale_inv",
 ]
 
+_PER_LAYER_SEPARATE_QKV_KEYS = [
+    k for k in _PER_LAYER_KEYS if not k.startswith("self_attn.qkv_proj.")
+] + [
+    "self_attn.q_proj.weight",
+    "self_attn.q_proj.weight_scale_inv",
+    "self_attn.k_proj.weight",
+    "self_attn.k_proj.weight_scale_inv",
+    "self_attn.v_proj.weight",
+    "self_attn.v_proj.weight_scale_inv",
+]
+
 
 def _hf_keys(layer_idx: int) -> set[str]:
     return {f"model.mtp.layers.{layer_idx}.{k}" for k in _PER_LAYER_KEYS}
+
+
+def _separate_qkv_hf_keys(layer_idx: int) -> set[str]:
+    return {f"model.mtp.layers.{layer_idx}.{k}" for k in _PER_LAYER_SEPARATE_QKV_KEYS}
 
 
 @pytest.mark.parametrize("layer_idx", [0, 1, 2])
@@ -41,7 +56,11 @@ def test_weight_mapping_covers_safetensors(layer_idx: int):
 
     model = SimpleNamespace(
         mtp_layer_idx=layer_idx,
-        loader=SimpleNamespace(is_static_quant=True, is_quant_ignored=lambda k: False),
+        loader=SimpleNamespace(
+            is_static_quant=True,
+            is_quant_ignored=lambda k: False,
+            has_weight_on_disk=lambda k: k.endswith("qkv_proj.weight"),
+        ),
     )
     mappings = MiMoV2MTPForCausalLM._create_weight_mappings(model)
 
@@ -61,3 +80,27 @@ def test_weight_mapping_covers_safetensors(layer_idx: int):
         tp = m.target_path
         targets.extend(tp if isinstance(tp, list) else [tp])
     assert len(targets) == len(set(targets)), "duplicate target_path"
+
+
+@pytest.mark.parametrize("layer_idx", [0, 1, 2])
+def test_weight_mapping_supports_separate_fp8_qkv(layer_idx: int):
+    from sgl_jax.srt.models.mimo_v2_nextn import MiMoV2MTPForCausalLM
+
+    model = SimpleNamespace(
+        mtp_layer_idx=layer_idx,
+        loader=SimpleNamespace(
+            is_static_quant=True,
+            is_quant_ignored=lambda k: False,
+            has_weight_on_disk=lambda k: False,
+        ),
+    )
+    mappings = MiMoV2MTPForCausalLM._create_weight_mappings(model)
+
+    assert set(mappings.keys()) == _separate_qkv_hf_keys(layer_idx)
+    assert mappings[f"model.mtp.layers.{layer_idx}.self_attn.q_proj.weight"].target_path.endswith(
+        "q_proj.weight_q"
+    )
+    assert mappings[
+        f"model.mtp.layers.{layer_idx}.self_attn.k_proj.weight_scale_inv"
+    ].target_path.endswith("k_proj.weight_scale")
+    assert model._uses_fused_mtp_qkv is False

--- a/python/sgl_jax/test/speculative/test_eagle_utils.py
+++ b/python/sgl_jax/test/speculative/test_eagle_utils.py
@@ -4,14 +4,12 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from sgl_jax.srt.kernels.speculative.kernel import create_extend_after_decode_spec_info
 from sgl_jax.srt.kernels.speculative.tree_speculative_sampling_target_only_kernel import (
     tree_speculative_sampling_target_only_pallas_call,
 )
 from sgl_jax.srt.kernels.speculative.verify_tree_greedy_kernel import verify_tree_greedy
-from sgl_jax.srt.speculative.eagle_util import (
-    build_tree_mask_for_draft_decode,
-    create_extend_after_decode_spec_info,
-)
+from sgl_jax.srt.speculative.eagle_util import build_tree_mask_for_draft_decode
 from sgl_jax.test.test_utils import CustomTestCase
 
 

--- a/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
+++ b/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
@@ -1,0 +1,394 @@
+"""CPU-only shape/layout tests for spec-decode DP plumbing (#1053 P1-5b).
+
+Run: JAX_PLATFORMS=cpu pytest test_spec_dp_shapes.py -v
+
+Catches the Python-layer shim/shape/index bugs (P1-5b r4-r9) without a 15-min
+v6e-64 reload. Multi-host sharding errors (process_allgather, P("data")
+shard_shape on real mesh) are NOT covered — those still need hardware.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from sgl_jax.srt.managers.schedule_batch import ScheduleBatch, ScheduleReqsInfo
+from sgl_jax.srt.managers.scheduler_output_processor_mixin import (
+    SchedulerOutputProcessorMixin,
+)
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
+from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+HIDDEN = 8
+TOPK = 1
+DRAFT_N = 4
+
+
+class _Req:
+    def __init__(self, rid: int):
+        self.rid = rid
+        self.lora_id = "0"
+        self._done = False
+        self.output_ids: list[int] = []
+        self.origin_input_ids = [1, 2, 3, 4, 5]
+        self.spec_verify_ct = 0
+        self.spec_accepted_tokens = 0
+        self.is_retracted = False
+        self.return_logprob = False
+        self.return_output_logprob_only = False
+        self.stream = False
+        self.grammar = None
+        self.return_hidden_states = False
+
+    def finished(self) -> bool:
+        return self._done
+
+
+def _mk_spec_info(real_bs: int) -> EagleDraftInput:
+    return EagleDraftInput(
+        topk_p=np.ones((real_bs, TOPK), np.float32),
+        topk_index=np.zeros((real_bs, TOPK), np.int32),
+        hidden_states=np.zeros((real_bs, HIDDEN), np.float32),
+        verified_id=np.zeros((real_bs,), np.int32),
+        allocate_lens=np.full((real_bs,), 8, np.int32),
+    )
+
+
+def _mk_batch(dp_size: int, bs_per_rank: list[int]) -> ScheduleBatch:
+    """Minimal ScheduleBatch for spec-decode DP shape tests.
+
+    Only fills fields read by `_get_spec_decode_mwb_dp` /
+    `_merge_batch_metadata`. Model/pool/tree_cache left None.
+    """
+    assert len(bs_per_rank) == dp_size
+    real_bs = sum(bs_per_rank)
+    reqs_info = []
+    for r, bs in enumerate(bs_per_rank):
+        info = ScheduleReqsInfo()
+        if bs > 0:
+            info.reqs = [_Req(r * 100 + j) for j in range(bs)]
+            info.seq_lens = np.full((bs,), 6 + r, np.int32)
+            info.req_pool_indices = np.arange(r * 10, r * 10 + bs, dtype=np.int32)
+        else:
+            info.reqs = []
+            info.seq_lens = None
+            info.req_pool_indices = None
+        info.out_cache_loc = (
+            np.arange(r * 1000, r * 1000 + bs * DRAFT_N, dtype=np.int32) if bs > 0 else None
+        )
+        info.spec_info = None
+        info.sampling_info = None
+        reqs_info.append(info)
+    reqs_info[0].spec_info = _mk_spec_info(real_bs)
+
+    sb = ScheduleBatch.__new__(ScheduleBatch)
+    sb.__dict__.update(
+        dict(
+            reqs_info=reqs_info,
+            dp_size=dp_size,
+            forward_mode=ForwardMode.DECODE,
+            return_logprob=False,
+            return_output_logprob_only=False,
+            return_hidden_states=False,
+            spec_algorithm=SpeculativeAlgorithm.NEXTN,
+            tree_cache=None,
+            launch_done=None,
+            has_grammar=False,
+            per_dp_bs_size=0,
+        )
+    )
+    return sb
+
+
+@pytest.fixture(autouse=True)
+def _stub_sampling(monkeypatch):
+    monkeypatch.setattr(ScheduleBatch, "_merge_sampling_info", lambda self, per_dp, total: None)
+
+
+BS_BUCKETS = [1, 2, 4, 8, 16]
+
+
+@pytest.mark.parametrize(
+    "dp,bs_per_rank",
+    [
+        (1, [1]),
+        (1, [3]),
+        (2, [1, 0]),
+        (2, [1, 1]),
+        (2, [2, 1]),
+        (2, [0, 2]),
+        (4, [1, 0, 1, 0]),
+        (4, [1, 1, 1, 1]),
+        (4, [2, 1, 0, 3]),
+    ],
+)
+def test_get_spec_decode_mwb_dp_shapes(dp, bs_per_rank):
+    sb = _mk_batch(dp, bs_per_rank)
+    real_bs = sum(bs_per_rank)
+    buckets = [b for b in BS_BUCKETS if b >= dp]
+    mwb = sb._get_spec_decode_mwb_dp(buckets, enable_static_lora=False)
+
+    assert mwb.dp_size == dp
+    assert mwb.real_bs == real_bs
+    assert mwb.real_bs_per_dp == bs_per_rank
+    assert mwb.per_dp_bs_size * dp == len(mwb.seq_lens)
+    # all P("data")-sharded fields must be dp-divisible
+    for name in ("seq_lens", "req_pool_indices", "out_cache_loc"):
+        arr = getattr(mwb, name)
+        assert len(arr) % dp == 0, f"{name} len={len(arr)} not %dp={dp}"
+    # out_cache_loc DP-segmented: rank r's section = its own slots then -1 pad
+    ocl = np.asarray(mwb.out_cache_loc).reshape(dp, -1)
+    for r, bs in enumerate(bs_per_rank):
+        n = bs * DRAFT_N
+        assert list(ocl[r, :n]) == list(range(r * 1000, r * 1000 + n)), (r, ocl[r])
+        assert np.all(ocl[r, n:] == -1), f"rank {r} pad not -1: {ocl[r, n:]}"
+    # seq_lens slot layout: rank r's reqs at [r*per_dp_bs : r*per_dp_bs+bs_r]
+    per_dp = mwb.per_dp_bs_size
+    for r, bs in enumerate(bs_per_rank):
+        seg = mwb.seq_lens[r * per_dp : r * per_dp + per_dp]
+        assert np.all(seg[:bs] > 0), f"rank {r} real slots zero: {seg}"
+        assert np.all(seg[bs:] == 0), f"rank {r} pad slots nonzero: {seg}"
+    assert mwb.spec_info is not None
+
+
+@pytest.mark.parametrize(
+    "dp,bs_per_rank,finish",
+    [
+        (2, [1, 1], [(0, 0)]),  # rank 0 finishes → rank 1 survives (r9 crash repro)
+        (2, [1, 1], [(1, 0)]),  # rank 1 finishes → rank 0 survives
+        (2, [2, 1], [(0, 0)]),  # rank 0 partial → keep rank0[1] + rank1[0]
+        (4, [1, 1, 1, 1], [(0, 0), (2, 0)]),  # ranks 0,2 finish
+        (1, [3], [(0, 1)]),  # dp=1 regression
+    ],
+)
+def test_filter_batch_preserves_global_spec_info(dp, bs_per_rank, finish):
+    sb = _mk_batch(dp, bs_per_rank)
+    real_bs = sum(bs_per_rank)
+    # Tag spec_info arrays so we can verify which entries survive.
+    spec = sb.reqs_info[0].spec_info
+    spec.allocate_lens = np.arange(100, 100 + real_bs, dtype=np.int32)
+    spec.verified_id = np.arange(200, 200 + real_bs, dtype=np.int32)
+    spec.hidden_states = np.arange(real_bs, dtype=np.float32).reshape(real_bs, 1).repeat(HIDDEN, 1)
+    # Compute expected survivors in global-flat order BEFORE marking finished.
+    finish_set = set(finish)
+    expected_keep = []
+    flat = 0
+    for r, bs in enumerate(bs_per_rank):
+        for j in range(bs):
+            if (r, j) not in finish_set:
+                expected_keep.append(flat)
+            flat += 1
+    for r, j in finish:
+        sb.reqs_info[r].reqs[j]._done = True
+
+    sb.filter_batch()
+
+    new_spec = sb.reqs_info[0].spec_info
+    assert new_spec is not None, "global spec_info dropped after partial-finish"
+    assert new_spec.allocate_lens.shape == (len(expected_keep),)
+    assert list(new_spec.allocate_lens) == [100 + i for i in expected_keep]
+    assert list(new_spec.verified_id) == [200 + i for i in expected_keep]
+    assert new_spec.hidden_states.shape == (len(expected_keep), HIDDEN)
+    # Surviving reqs per rank should match.
+    for r, bs in enumerate(bs_per_rank):
+        kept = bs - sum(1 for fr, fj in finish if fr == r)
+        assert len(sb.reqs_info[r].reqs or []) == kept
+
+
+def test_filter_batch_then_decode_mwb_round_trip():
+    """Regression for 2-req partial-finish → next-round decode mwb (r9 crash).
+
+    After rank 0 empties, the next `_get_spec_decode_mwb_dp` must still produce
+    a dp-divisible mwb whose spec_info aligns with the DP-padded seq_lens slots.
+    """
+    dp, bs_per_rank = 2, [1, 1]
+    sb = _mk_batch(dp, bs_per_rank)
+    spec = sb.reqs_info[0].spec_info
+    spec.allocate_lens = np.array([110, 120], dtype=np.int32)
+    sb.reqs_info[0].reqs[0]._done = True
+    sb.filter_batch()
+    # rank 0 empty, rank 1 has 1 req; spec_info global-flat now [120].
+    buckets = [b for b in BS_BUCKETS if b >= dp]
+    mwb = sb._get_spec_decode_mwb_dp(buckets, enable_static_lora=False)
+    assert mwb.real_bs == 1
+    assert mwb.real_bs_per_dp == [0, 1]
+    assert len(mwb.seq_lens) % dp == 0
+    per_dp = mwb.per_dp_bs_size
+    # rank 0 slot(s) all-zero, rank 1 slot 0 has data.
+    assert np.all(mwb.seq_lens[:per_dp] == 0)
+    assert mwb.seq_lens[per_dp] > 0
+    # spec_info is now DP-padded (total_bs,); rank 1's data must be at slot per_dp.
+    al = np.asarray(mwb.spec_info.allocate_lens)
+    assert al.shape[0] == per_dp * dp
+    assert int(al[per_dp]) == 120
+    assert int(al[0]) == 0  # rank-0 padding slot
+
+
+@pytest.mark.parametrize(
+    "dp,bs_per_rank",
+    [
+        (2, [0, 1]),  # rank 0 empty (post-partial-finish shape)
+        (2, [1, 2]),  # unbalanced, rank 1 heavier
+        (4, [0, 1, 0, 2]),
+    ],
+)
+def test_spec_info_aligns_with_dp_padded_slots(dp, bs_per_rank):
+    """Core layout invariant: after `_get_spec_decode_mwb_dp`, spec_info arrays
+    must index-align with DP-padded mwb.seq_lens — i.e., spec_info[i] is the
+    data for the req at slot i (or padding). `padding_for_decode` then uses
+    `valid_mask = seq_lens > 0` to index spec_info.allocate_lens; if spec_info
+    is global-flat (no inter-rank padding) this picks wrong entries.
+
+    Current impl stores spec_info global-flat → this test FAILS for unbalanced
+    bs_per_rank → drives the layout fix (scatter via logits_indices_selector,
+    PR #1108 design question option A).
+    """
+    sb = _mk_batch(dp, bs_per_rank)
+    real_bs = sum(bs_per_rank)
+    spec = sb.reqs_info[0].spec_info
+    # Tag allocate_lens with global-flat indices so we know which req each is.
+    spec.allocate_lens = np.arange(100, 100 + real_bs, dtype=np.int32)
+    buckets = [b for b in BS_BUCKETS if b >= dp]
+    mwb = sb._get_spec_decode_mwb_dp(buckets, enable_static_lora=False)
+    per_dp = mwb.per_dp_bs_size
+    total_bs = per_dp * dp
+
+    # Simulate padding_for_decode's pad-then-valid_mask gather:
+    al = np.asarray(mwb.spec_info.allocate_lens)
+    if len(al) < total_bs:
+        al = np.pad(al, (0, total_bs - len(al)))
+    valid_mask = mwb.seq_lens > 0
+    picked = al[valid_mask]
+
+    # Expected: picked[k] == 100 + k (global-flat order of survivors).
+    assert list(picked) == list(range(100, 100 + real_bs)), (
+        f"layout mismatch: valid_mask picked {list(picked)} from "
+        f"allocate_lens (DP-padded)={list(al)}, seq_lens={list(mwb.seq_lens)}; "
+        f"expected {list(range(100, 100 + real_bs))}. "
+        f"spec_info is global-flat but mwb is DP-padded — needs scatter."
+    )
+
+
+@pytest.mark.parametrize(
+    "dp,bs_per_rank",
+    [
+        (1, [3]),
+        (2, [1, 1]),
+        (2, [2, 1]),
+        (2, [0, 2]),
+        (4, [1, 1, 1, 1]),
+        (4, [2, 1, 0, 3]),
+    ],
+)
+def test_draft_page_indices_dp_segmented(dp, bs_per_rank):
+    """multi_step page_indices must be DP-segmented so the P("data") shard at
+    [r*per_dp_dst:(r+1)*per_dp_dst) gives rank r exactly its own reqs' pages.
+
+    Regression for the rank>0-reads-padding bug (dp=4 garbage output +
+    accept-len ~1): pre-fix the gather wrote contiguous-then-pad, so rank>0's
+    shard landed in the all-zero padding region.
+    """
+    sb = _mk_batch(dp, bs_per_rank)
+    real_bs = sum(bs_per_rank)
+    spec = sb.reqs_info[0].spec_info
+    # Distinct seq_len per req so page boundaries are observable.
+    spec.allocate_lens = np.asarray([256 * (k + 1) + 4 for k in range(real_bs)], dtype=np.int32)
+    buckets = [b for b in BS_BUCKETS if b >= dp]
+    mwb = sb._get_spec_decode_mwb_dp(buckets, enable_static_lora=False)
+    per_dp = mwb.per_dp_bs_size
+    sel = np.asarray(mwb.logits_indices_selector)
+    assert sel.shape == (real_bs,)
+    rank_of = sel // per_dp
+    # cache_loc layout: rank r section = [r*L : (r+1)*L), tokens tagged with
+    # global-flat req id k so we can verify which req each page belongs to.
+    L_tok, page = 8192, 256
+    cache_loc = np.full(L_tok * dp, -1, dtype=np.int32)
+    al = np.asarray(mwb.spec_info.allocate_lens)
+    aligned = ((al + page - 1) // page) * page
+    intra = np.zeros(dp, dtype=np.int64)
+    for s in np.where(mwb.seq_lens > 0)[0]:
+        r = int(s) // per_dp
+        k = int(np.where(sel == s)[0][0])
+        b = r * L_tok + intra[r]
+        cache_loc[b : b + al[s]] = k
+        intra[r] += aligned[s]
+    # multi_step gather (mirror of get_eagle_multi_step_metadata step 0).
+    src_locs = cache_loc[::page]
+    L_pg = L_tok // page
+    alloc_pg = ((al[sel] + page - 1) // page).astype(np.int64)
+    spec_pg = ((mwb.seq_lens[sel] + page - 1) // page).astype(np.int64)
+
+    def starts(pages, base):
+        out = np.zeros(len(pages), dtype=np.int64)
+        for r in range(dp):
+            m = rank_of == r
+            if np.any(m):
+                c = np.cumsum(pages[m])
+                out[m] = r * base + np.concatenate(([0], c[:-1]))
+        return out
+
+    DST, per_dst = 16384, 16384 // dp
+    flat_cum = np.concatenate(([0], np.cumsum(spec_pg)[:-1]))
+    off = np.arange(int(spec_pg.sum())) - np.repeat(flat_cum, spec_pg)
+    gi = np.repeat(starts(alloc_pg, L_pg), spec_pg) + off
+    wi = np.repeat(starts(spec_pg, per_dst), spec_pg) + off
+    result = np.full(DST, -1, dtype=np.int32)
+    result[wi] = src_locs[gi]
+    # Invariant: rank r's section contains exactly rank r's req-ids (in
+    # global-flat order), then -1 padding; never another rank's id or 0-from-pad.
+    for r in range(dp):
+        seg = result[r * per_dst : (r + 1) * per_dst]
+        ks = [k for k in range(real_bs) if rank_of[k] == r]
+        want = np.concatenate([np.full(int(spec_pg[k]), k) for k in ks] or [np.array([], int)])
+        assert list(seg[: len(want)]) == list(want), (r, seg[: len(want) + 2], want)
+        assert np.all(seg[len(want) :] == -1), f"rank {r} pad region nonempty"
+
+
+@pytest.mark.parametrize(
+    "dp,bs_per_rank,accept_per_slot",
+    [
+        (1, [2], [3, 2]),
+        (2, [1, 1], [3, 2]),
+        (2, [1, 2], [3, 0, 2, 1]),  # per_dp=2: slot 1 is rank-0 pad (accept=0)
+        (4, [1, 0, 1, 0], [2, 0, 3, 0]),  # per_dp=1
+    ],
+)
+def test_resolve_spec_decode_token_ids(dp, bs_per_rank, accept_per_slot):
+    """`_resolve_spec_decode_token_ids` must slice next_token_ids by DP-padded
+    slot (not contiguous req index) and return a (total_bs,)-length list with
+    [] at padding slots so the per-rank slice in process_batch_result_decode
+    lands on the right reqs."""
+    sb = _mk_batch(dp, bs_per_rank)
+    total_bs = len(accept_per_slot)
+    sb.per_dp_bs_size = total_bs // dp
+    # Tag next_token_ids so slot s tokens are [s*1000+0, s*1000+1, ...]
+    nt = np.concatenate(
+        [np.arange(s * 1000, s * 1000 + DRAFT_N, dtype=np.int32) for s in range(total_bs)]
+    )
+    result = SimpleNamespace(
+        next_token_ids=nt,
+        accept_lens=np.asarray(accept_per_slot, dtype=np.int32),
+        num_accepted_tokens=None,
+    )
+    sched = SimpleNamespace(draft_worker=SimpleNamespace(speculative_num_draft_tokens=DRAFT_N))
+    out = SchedulerOutputProcessorMixin._resolve_spec_decode_token_ids(sched, result, sb)
+    assert len(out) == total_bs
+    per_dp = sb.per_dp_bs_size
+    for r, bs in enumerate(bs_per_rank):
+        for j in range(per_dp):
+            slot = r * per_dp + j
+            if j < bs:
+                a = accept_per_slot[slot]
+                assert out[slot] == list(
+                    range(slot * 1000, slot * 1000 + a)
+                ), f"slot {slot}: got {out[slot]}, want {a} tokens from {slot*1000}"
+                assert sb.reqs_info[r].reqs[j].spec_accepted_tokens == a
+            else:
+                assert out[slot] == [], f"pad slot {slot} should be []"

--- a/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
+++ b/python/sgl_jax/test/speculative/test_spec_dp_shapes.py
@@ -86,7 +86,12 @@ def _mk_batch(dp_size: int, bs_per_rank: list[int]) -> ScheduleBatch:
         info.spec_info = None
         info.sampling_info = None
         reqs_info.append(info)
-    reqs_info[0].spec_info = _mk_spec_info(real_bs)
+    # Build a cross-rank-flat EagleDraftInput then split into per-rank slots
+    # so tests exercise the same layout the production producer/consumer uses.
+    flat_spec = _mk_spec_info(real_bs)
+    per_rank_spec = ScheduleBatch._split_spec_info_per_rank(flat_spec, bs_per_rank)
+    for r, s in enumerate(per_rank_spec):
+        reqs_info[r].spec_info = s
 
     sb = ScheduleBatch.__new__(ScheduleBatch)
     sb.__dict__.update(
@@ -155,7 +160,7 @@ def test_get_spec_decode_mwb_dp_shapes(dp, bs_per_rank):
         seg = mwb.seq_lens[r * per_dp : r * per_dp + per_dp]
         assert np.all(seg[:bs] > 0), f"rank {r} real slots zero: {seg}"
         assert np.all(seg[bs:] == 0), f"rank {r} pad slots nonzero: {seg}"
-    assert mwb.spec_info is not None
+    assert mwb.spec_info_padded is not None
 
 
 @pytest.mark.parametrize(
@@ -169,37 +174,50 @@ def test_get_spec_decode_mwb_dp_shapes(dp, bs_per_rank):
     ],
 )
 def test_filter_batch_preserves_global_spec_info(dp, bs_per_rank, finish):
+    """spec_info filters naturally per-rank inside the loop.
+
+    Tag each rank's spec arrays with a stable offset so we can verify which
+    entries survive partial-finish.
+    """
     sb = _mk_batch(dp, bs_per_rank)
-    real_bs = sum(bs_per_rank)
-    # Tag spec_info arrays so we can verify which entries survive.
-    spec = sb.reqs_info[0].spec_info
-    spec.allocate_lens = np.arange(100, 100 + real_bs, dtype=np.int32)
-    spec.verified_id = np.arange(200, 200 + real_bs, dtype=np.int32)
-    spec.hidden_states = np.arange(real_bs, dtype=np.float32).reshape(real_bs, 1).repeat(HIDDEN, 1)
-    # Compute expected survivors in global-flat order BEFORE marking finished.
-    finish_set = set(finish)
-    expected_keep = []
-    flat = 0
+    # Tag each rank's spec_info arrays with deterministic values.
+    flat_base = 0
     for r, bs in enumerate(bs_per_rank):
-        for j in range(bs):
-            if (r, j) not in finish_set:
-                expected_keep.append(flat)
-            flat += 1
+        if bs == 0:
+            continue
+        spec = sb.reqs_info[r].spec_info
+        spec.allocate_lens = np.arange(100 + flat_base, 100 + flat_base + bs, dtype=np.int32)
+        spec.verified_id = np.arange(200 + flat_base, 200 + flat_base + bs, dtype=np.int32)
+        spec.hidden_states = (
+            np.arange(flat_base, flat_base + bs, dtype=np.float32).reshape(bs, 1).repeat(HIDDEN, 1)
+        )
+        flat_base += bs
+
+    finish_set = set(finish)
     for r, j in finish:
         sb.reqs_info[r].reqs[j]._done = True
 
     sb.filter_batch()
 
-    new_spec = sb.reqs_info[0].spec_info
-    assert new_spec is not None, "global spec_info dropped after partial-finish"
-    assert new_spec.allocate_lens.shape == (len(expected_keep),)
-    assert list(new_spec.allocate_lens) == [100 + i for i in expected_keep]
-    assert list(new_spec.verified_id) == [200 + i for i in expected_keep]
-    assert new_spec.hidden_states.shape == (len(expected_keep), HIDDEN)
-    # Surviving reqs per rank should match.
+    # Per-rank assertions: each rank's spec_info holds exactly its survivors.
+    flat_base = 0
     for r, bs in enumerate(bs_per_rank):
-        kept = bs - sum(1 for fr, fj in finish if fr == r)
-        assert len(sb.reqs_info[r].reqs or []) == kept
+        if bs == 0:
+            assert sb.reqs_info[r].spec_info is None
+            continue
+        kept = [j for j in range(bs) if (r, j) not in finish_set]
+        if not kept:
+            # Early-exit clears spec_info to None.
+            assert sb.reqs_info[r].spec_info is None
+            flat_base += bs
+            continue
+        spec = sb.reqs_info[r].spec_info
+        assert spec is not None, f"rank {r} spec_info dropped"
+        assert list(np.asarray(spec.allocate_lens)) == [100 + flat_base + j for j in kept]
+        assert list(np.asarray(spec.verified_id)) == [200 + flat_base + j for j in kept]
+        assert np.asarray(spec.hidden_states).shape == (len(kept), HIDDEN)
+        assert len(sb.reqs_info[r].reqs or []) == len(kept)
+        flat_base += bs
 
 
 def test_filter_batch_then_decode_mwb_round_trip():
@@ -207,14 +225,20 @@ def test_filter_batch_then_decode_mwb_round_trip():
 
     After rank 0 empties, the next `_get_spec_decode_mwb_dp` must still produce
     a dp-divisible mwb whose spec_info aligns with the DP-padded seq_lens slots.
+    Per-rank spec_info on reqs_info[r].spec_info; the concat helper
+    rebuilds the cross-rank-flat view consumed by the scatter helper.
     """
     dp, bs_per_rank = 2, [1, 1]
     sb = _mk_batch(dp, bs_per_rank)
-    spec = sb.reqs_info[0].spec_info
-    spec.allocate_lens = np.array([110, 120], dtype=np.int32)
+    # Per-rank tagging: rank 0 gets allocate_len=110, rank 1 gets 120.
+    sb.reqs_info[0].spec_info.allocate_lens = np.array([110], dtype=np.int32)
+    sb.reqs_info[1].spec_info.allocate_lens = np.array([120], dtype=np.int32)
     sb.reqs_info[0].reqs[0]._done = True
     sb.filter_batch()
-    # rank 0 empty, rank 1 has 1 req; spec_info global-flat now [120].
+    # rank 0 cleared, rank 1 keeps its [120].
+    assert sb.reqs_info[0].spec_info is None
+    assert list(np.asarray(sb.reqs_info[1].spec_info.allocate_lens)) == [120]
+
     buckets = [b for b in BS_BUCKETS if b >= dp]
     mwb = sb._get_spec_decode_mwb_dp(buckets, enable_static_lora=False)
     assert mwb.real_bs == 1
@@ -225,7 +249,7 @@ def test_filter_batch_then_decode_mwb_round_trip():
     assert np.all(mwb.seq_lens[:per_dp] == 0)
     assert mwb.seq_lens[per_dp] > 0
     # spec_info is now DP-padded (total_bs,); rank 1's data must be at slot per_dp.
-    al = np.asarray(mwb.spec_info.allocate_lens)
+    al = np.asarray(mwb.spec_info_padded.allocate_lens)
     assert al.shape[0] == per_dp * dp
     assert int(al[per_dp]) == 120
     assert int(al[0]) == 0  # rank-0 padding slot
@@ -252,16 +276,23 @@ def test_spec_info_aligns_with_dp_padded_slots(dp, bs_per_rank):
     """
     sb = _mk_batch(dp, bs_per_rank)
     real_bs = sum(bs_per_rank)
-    spec = sb.reqs_info[0].spec_info
-    # Tag allocate_lens with global-flat indices so we know which req each is.
-    spec.allocate_lens = np.arange(100, 100 + real_bs, dtype=np.int32)
+    # Tag per-rank allocate_lens with global-flat-style indices so _concat
+    # re-assembles the cross-rank-flat view the scatter helper expects.
+    flat_base = 0
+    for r, bs in enumerate(bs_per_rank):
+        if bs == 0:
+            continue
+        sb.reqs_info[r].spec_info.allocate_lens = np.arange(
+            100 + flat_base, 100 + flat_base + bs, dtype=np.int32
+        )
+        flat_base += bs
     buckets = [b for b in BS_BUCKETS if b >= dp]
     mwb = sb._get_spec_decode_mwb_dp(buckets, enable_static_lora=False)
     per_dp = mwb.per_dp_bs_size
     total_bs = per_dp * dp
 
     # Simulate padding_for_decode's pad-then-valid_mask gather:
-    al = np.asarray(mwb.spec_info.allocate_lens)
+    al = np.asarray(mwb.spec_info_padded.allocate_lens)
     if len(al) < total_bs:
         al = np.pad(al, (0, total_bs - len(al)))
     valid_mask = mwb.seq_lens > 0
@@ -297,9 +328,15 @@ def test_draft_page_indices_dp_segmented(dp, bs_per_rank):
     """
     sb = _mk_batch(dp, bs_per_rank)
     real_bs = sum(bs_per_rank)
-    spec = sb.reqs_info[0].spec_info
-    # Distinct seq_len per req so page boundaries are observable.
-    spec.allocate_lens = np.asarray([256 * (k + 1) + 4 for k in range(real_bs)], dtype=np.int32)
+    # Distinct allocate_lens per rank so page boundaries are observable.
+    flat_base = 0
+    for r, bs in enumerate(bs_per_rank):
+        if bs == 0:
+            continue
+        sb.reqs_info[r].spec_info.allocate_lens = np.asarray(
+            [256 * (flat_base + k + 1) + 4 for k in range(bs)], dtype=np.int32
+        )
+        flat_base += bs
     buckets = [b for b in BS_BUCKETS if b >= dp]
     mwb = sb._get_spec_decode_mwb_dp(buckets, enable_static_lora=False)
     per_dp = mwb.per_dp_bs_size
@@ -310,7 +347,7 @@ def test_draft_page_indices_dp_segmented(dp, bs_per_rank):
     # global-flat req id k so we can verify which req each page belongs to.
     L_tok, page = 8192, 256
     cache_loc = np.full(L_tok * dp, -1, dtype=np.int32)
-    al = np.asarray(mwb.spec_info.allocate_lens)
+    al = np.asarray(mwb.spec_info_padded.allocate_lens)
     aligned = ((al + page - 1) // page) * page
     intra = np.zeros(dp, dtype=np.int64)
     for s in np.where(mwb.seq_lens > 0)[0]:
@@ -392,3 +429,154 @@ def test_resolve_spec_decode_token_ids(dp, bs_per_rank, accept_per_slot):
                 assert sb.reqs_info[r].reqs[j].spec_accepted_tokens == a
             else:
                 assert out[slot] == [], f"pad slot {slot} should be []"
+
+
+# ---------------------------------------------------------------------------
+# split / concat per-rank round-trip helpers
+# ---------------------------------------------------------------------------
+
+
+def _mk_distinct_spec_info(real_bs: int, seed: int = 0) -> EagleDraftInput:
+    """Like ``_mk_spec_info`` but with distinct values so we can detect
+    row reordering / mis-slicing after round-trip."""
+    rng = np.random.default_rng(seed)
+    base = np.arange(real_bs, dtype=np.int32) + seed * 1000
+    return EagleDraftInput(
+        topk_p=rng.random((real_bs, TOPK), dtype=np.float32),
+        topk_index=np.tile(base[:, None], (1, TOPK)).astype(np.int32),
+        hidden_states=np.tile(base[:, None], (1, HIDDEN)).astype(np.float32),
+        verified_id=base.copy(),
+        allocate_lens=(base + 8).astype(np.int32),
+    )
+
+
+@pytest.mark.parametrize(
+    "real_bs_per_dp",
+    [
+        [4],
+        [2, 2],
+        [3, 0],
+        [0, 3],
+        [1, 1, 1, 1],
+        [0, 2, 0, 3],
+    ],
+    ids=["dp1-4", "dp2-2+2", "dp2-3+0", "dp2-0+3", "dp4-1x4", "dp4-mixed"],
+)
+def test_split_concat_spec_info_round_trip(real_bs_per_dp):
+    """split → concat should reproduce the original cross-rank-flat layout."""
+    total = sum(real_bs_per_dp)
+    flat = _mk_distinct_spec_info(total, seed=1)
+
+    parts = ScheduleBatch._split_spec_info_per_rank(flat, real_bs_per_dp)
+    assert len(parts) == len(real_bs_per_dp)
+    for n, p in zip(real_bs_per_dp, parts):
+        if n == 0:
+            assert p is None
+        else:
+            assert p is not None
+            assert p.topk_p.shape == (n, TOPK)
+            assert p.verified_id.shape == (n,)
+            assert p.capture_hidden_mode == flat.capture_hidden_mode
+
+    back = ScheduleBatch._concat_spec_info_per_rank(parts)
+    assert back is not None
+    np.testing.assert_array_equal(np.asarray(back.topk_index), np.asarray(flat.topk_index))
+    np.testing.assert_array_equal(np.asarray(back.verified_id), np.asarray(flat.verified_id))
+    np.testing.assert_array_equal(np.asarray(back.allocate_lens), np.asarray(flat.allocate_lens))
+    np.testing.assert_array_equal(np.asarray(back.hidden_states), np.asarray(flat.hidden_states))
+    np.testing.assert_allclose(np.asarray(back.topk_p), np.asarray(flat.topk_p))
+
+
+def test_split_spec_info_none_passthrough():
+    parts = ScheduleBatch._split_spec_info_per_rank(None, [2, 3])
+    assert parts == [None, None]
+
+
+def test_concat_spec_info_all_none():
+    assert ScheduleBatch._concat_spec_info_per_rank([None, None]) is None
+
+
+def test_concat_spec_info_some_none_skips():
+    """Non-empty rank's data should be preserved when others are None."""
+    s = _mk_distinct_spec_info(3, seed=2)
+    out = ScheduleBatch._concat_spec_info_per_rank([None, s, None])
+    assert out is not None
+    np.testing.assert_array_equal(np.asarray(out.verified_id), np.asarray(s.verified_id))
+    assert out.verified_id.shape == (3,)
+
+
+def _mk_batch_with_tagged_spec(
+    dp_size: int, bs_per_rank: list[int], *, tag_base: int
+) -> ScheduleBatch:
+    """``_mk_batch`` + tag per-rank ``spec_info.verified_id`` so that after a
+    cross-rank merge each entry stays traceable to ``(rank, side, idx)``.
+
+    Tag value for rank ``r`` request ``j`` is ``tag_base + r * 1000 + j``.
+    """
+    sb = _mk_batch(dp_size, bs_per_rank)
+    for r, bs in enumerate(bs_per_rank):
+        if bs == 0:
+            continue
+        sb.reqs_info[r].spec_info.verified_id = np.asarray(
+            [tag_base + r * 1000 + j for j in range(bs)], dtype=np.int32
+        )
+    return sb
+
+
+def _expected_after_merge(
+    bs_self: list[int], bs_other: list[int], *, self_base: int, other_base: int
+) -> list[list[int] | None]:
+    """Per-rank expected ``verified_id`` after ``self.merge_batch(other)``.
+
+    Matches ``ScheduleBatch.merge_batch`` semantics:
+    - other rank empty → self unchanged
+    - self rank empty (and other non-empty) → take other's spec_info wholesale
+    - both non-empty → ``EagleDraftInput.merge_batch`` concatenates self ++ other
+    """
+    out: list[list[int] | None] = []
+    for r, (ns, no) in enumerate(zip(bs_self, bs_other)):
+        if no == 0:
+            out.append([self_base + r * 1000 + j for j in range(ns)] if ns > 0 else None)
+            continue
+        if ns == 0:
+            out.append([other_base + r * 1000 + j for j in range(no)])
+            continue
+        out.append(
+            [self_base + r * 1000 + j for j in range(ns)]
+            + [other_base + r * 1000 + j for j in range(no)]
+        )
+    return out
+
+
+@pytest.mark.parametrize(
+    "bs_self,bs_other",
+    [
+        # (a) Both ranks non-empty on both sides → per-rank concat via
+        # EagleDraftInput.merge_batch (the path the refactor was motivated by).
+        ([2, 1], [1, 2]),
+        # (b) Other rank0 empty → merge_batch hits the early `continue` (old
+        # L1685 in pre-refactor numbering); self.r0 must stay tagged with
+        # self's values, r1 still concatenates.
+        ([2, 1], [0, 2]),
+        # (c) Self rank0 empty → merge_batch falls into the overwrite branch
+        # (old L1700) and pulls other's spec_info wholesale; r1 has other
+        # empty so stays as self.
+        ([0, 2], [1, 0]),
+    ],
+)
+def test_merge_batch_per_rank_spec_info(bs_self, bs_other):
+    self_base, other_base = 10_000, 20_000
+    self_sb = _mk_batch_with_tagged_spec(2, bs_self, tag_base=self_base)
+    other_sb = _mk_batch_with_tagged_spec(2, bs_other, tag_base=other_base)
+
+    self_sb.merge_batch(other_sb)
+
+    expected = _expected_after_merge(bs_self, bs_other, self_base=self_base, other_base=other_base)
+    for r, want in enumerate(expected):
+        spec = self_sb.reqs_info[r].spec_info
+        if want is None:
+            assert spec is None, f"rank {r}: expected None spec_info, got {spec}"
+            continue
+        assert spec is not None, f"rank {r}: expected spec_info, got None"
+        got = list(np.asarray(spec.verified_id))
+        assert got == want, f"rank {r}: verified_id {got} != expected {want}"

--- a/python/sgl_jax/test/test_compilation_manager.py
+++ b/python/sgl_jax/test/test_compilation_manager.py
@@ -220,7 +220,7 @@ class TestDummyBatch(unittest.TestCase):
         )
         assert batch.dp_size == 4
         assert batch.per_dp_bs_size == 16
-        assert batch.real_bs_per_dp == [64, 64, 64, 64]
+        assert batch.real_bs_per_dp == [16, 16, 16, 16]
 
     def test_multimodal_capture_hidden(self):
         cm = CompilationManager(

--- a/python/sgl_jax/test/test_flashattention.py
+++ b/python/sgl_jax/test/test_flashattention.py
@@ -325,7 +325,7 @@ def create_test_data(
         logits_indices=np.asarray(extend_seq_lens),
         real_bs=seq_lens.shape[0],
         real_bs_per_dp=[seq_lens.shape[0]],
-        spec_info=spec_info,
+        spec_info_padded=spec_info,
         dp_size=1,
         per_dp_bs_size=seq_lens.shape[0],
     )

--- a/python/sgl_jax/test/test_kda_attention.py
+++ b/python/sgl_jax/test/test_kda_attention.py
@@ -350,7 +350,7 @@ def create_test_data(
         real_bs_per_dp=[batch_size],
         dp_size=1,
         per_dp_bs_size=batch_size,
-        spec_info=None,
+        spec_info_padded=None,
         recurrent_indices=recurrent_indices,
         has_initial_state=has_initial_state_np,
     )

--- a/python/sgl_jax/test/test_kda_attention_dp.py
+++ b/python/sgl_jax/test/test_kda_attention_dp.py
@@ -421,7 +421,7 @@ def create_test_data(
         real_bs_per_dp=real_bs_per_dp,
         dp_size=dp_size,
         per_dp_bs_size=per_dp_bs_padding,
-        spec_info=None,
+        spec_info_padded=None,
         recurrent_indices=recurrent_indices_cpu,
         has_initial_state=has_initial_state_cpu,
     )

--- a/python/sgl_jax/test/test_mla_attention.py
+++ b/python/sgl_jax/test/test_mla_attention.py
@@ -305,7 +305,7 @@ def create_mla_forward_batch(
         real_bs_per_dp=[len(lens)],
         dp_size=1,
         per_dp_bs_size=len(lens),
-        spec_info=None,
+        spec_info_padded=None,
     )
 
     fb = ForwardBatch(

--- a/test/srt/test_speculative_decoding.py
+++ b/test/srt/test_speculative_decoding.py
@@ -1,6 +1,8 @@
+import os
 import unittest
 from types import SimpleNamespace
 
+import requests
 from run_eval import run_eval
 
 from sgl_jax.srt.utils import kill_process_tree
@@ -91,6 +93,87 @@ class TestSpeculativeDecoding(CustomTestCase):
 
         metrics = run_eval(args)
         self.assertGreater(metrics["score"], 0.45)
+
+
+@unittest.skipUnless(
+    os.getenv("SGLANG_NEXTN_E2E_URL"),
+    "MiMo-V2.5-Pro NEXTN needs a v6e-64 multi-host server (1T model); set "
+    "SGLANG_NEXTN_E2E_URL to a running server's base URL to enable.",
+)
+class TestNextNV25Pro(CustomTestCase):
+    """#1053 P1-8: V2.5-Pro 3-layer MTP E2E.
+
+    Unlike ``TestSpeculativeDecoding`` this does NOT launch its own server:
+    V2.5-Pro requires v6e-64 (16 hosts) which ``popen_launch_server`` can't
+    orchestrate. Point ``SGLANG_NEXTN_E2E_URL`` at an externally-managed
+    server started with::
+
+        --speculative-algorithm NEXTN --speculative-num-steps 3
+        --speculative-eagle-topk 1 --speculative-num-draft-tokens 4
+        --tp-size 64 --ep-size 64 --moe-backend epmoe
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = os.environ["SGLANG_NEXTN_E2E_URL"]
+        cls.model = os.getenv("SGLANG_NEXTN_E2E_MODEL", "mimo-v2.5-pro")
+        r = requests.get(f"{cls.base_url}/health", timeout=30)
+        r.raise_for_status()
+
+    def _generate(self, text: str, max_new_tokens: int = 64) -> dict:
+        r = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": text,
+                "sampling_params": {"temperature": 0, "max_new_tokens": max_new_tokens},
+            },
+            timeout=600,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def test_greedy_sanity(self):
+        d = self._generate("The capital of France is", 32)
+        self.assertGreater(d["meta_info"]["completion_tokens"], 16)
+        self.assertGreater(len(d["text"]), 0)
+
+    def test_multi_prompt_stable(self):
+        # Regression for the spec-decode KV leak (idle check_memory crash after
+        # each finished request) and the page>=256 _fetch_mask Mosaic crash:
+        # serially run mixed-length requests crossing the 256-token page
+        # boundary and assert the server stays up across all of them.
+        for n in (32, 280, 48, 96):
+            d = self._generate("def fibonacci(n):\n    if n <= 1:\n        return n\n    return", n)
+            self.assertGreaterEqual(d["meta_info"]["completion_tokens"], n)
+        requests.get(f"{self.base_url}/health", timeout=10).raise_for_status()
+
+    def test_raw_completion_accuracy(self):
+        # run_eval's mmlu uses /v1/chat/completions; V2.5-Pro then emits
+        # <think>...</think> reasoning which the mmlu parser can't score.
+        # Use raw /generate (no chat template) so the model answers in
+        # few-shot completion style. bs=1 only (Phase-1 deliverable scope).
+        cases = [
+            ("What is the capital of France?", ["London", "Paris", "Berlin", "Madrid"], "B"),
+            (
+                "Which planet is known as the Red Planet?",
+                ["Venus", "Mars", "Jupiter", "Saturn"],
+                "B",
+            ),
+            ("What is the chemical symbol for water?", ["CO2", "H2O", "NaCl", "O2"], "B"),
+            ("Who wrote 'Romeo and Juliet'?", ["Dickens", "Shakespeare", "Twain", "Austen"], "B"),
+            ("What is 7 * 8?", ["54", "56", "58", "64"], "B"),
+        ]
+        correct = 0
+        for q, opts, expect in cases:
+            prompt = (
+                f"Question: {q}\n"
+                + "\n".join(f"{c}. {o}" for c, o in zip("ABCD", opts))
+                + "\nAnswer:"
+            )
+            out = self._generate(prompt, 4)["text"].strip()
+            if out[:1].upper() == expect:
+                correct += 1
+        self.assertGreaterEqual(correct, 4, f"raw-completion accuracy {correct}/5")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Epic: MTP Refactor Phase 1

Multi-layer speculative decoding (MTP/NEXTN) for MiMo-V2 models on TPU.

### Commits

1. **`b62b465f` — MultiLayerEAGLEWorker / MultiLayerDraftWorker (#1089)**
   N draft model runners (one per mtp_layer_idx) with 3-layer MTP support for MiMo-V2.5-Pro.

2. **`20287f5f` — NEXTN E2E test (#1097)**
   Environment-gated E2E test for V2.5-Pro NEXTN on v6e-64 multi-host.

3. **`f5d40219` — DP-aware spec decode (#1108)**
   DP-correct padding, per-rank spec_info split/concat, and ScheduleBatch integration for dp_size > 1.

4. **`6e854218` — Per-rank ScheduleBatch.spec_info (#1171)**
   Refactor spec_info into per-rank split/concat helpers (option C), eliminating cross-rank-flat layout.

5. **`6e15718a` — MiMo V2 Flash MTP loading (#1187)**
   Fix draft model weight loading for MiMo-V2-Flash (hybrid SWA architecture).

6. **`9cc3a163` — Fix all cache miss and precompile shapes (#1188)**
   Eliminate post-precompile JIT cache misses: accept_lens pytree alignment, capture_hidden_mode consistency, spec_headroom before dp-scale, draft_runner_cache_size before dp-scale, and pad_to_bucket for spec decode.

### Eval (GSM8K via evalscope)

| Setup | Model | dp | spec | GSM8K Accuracy |
|-------|-------|----|------|----------------|
| Single-host v6e-4 | Llama-3.1-8B-Instruct + EAGLE3 | 1 | EAGLE | 0.81 |
| Single-host v6e-4 | Llama-3.1-8B-Instruct | 1 | nospec | 0.80 |
| Single-host v6e-4 | Llama-3.1-8B-Instruct + EAGLE3 | 2 | EAGLE | 0.81 |
| Single-host v6e-4 | Llama-3.1-8B-Instruct | 2 | nospec | 0.82 |
| Multi-host v6e-256 | MiMo-V2-Flash + NextN | 1 | NEXTN | 0.98 |
| Multi-host v6e-256 | MiMo-V2-Flash | 1 | nospec | 0.98 |
| Multi-host v6e-256 | MiMo-V2-Flash + NextN | 2 | NEXTN | 0.98 |
| Multi-host v6e-256 | MiMo-V2-Flash | 2 | nospec | 0.98 |

### Phase 2 (follow-up)

To keep this PR reviewable, the following work is deferred to Phase 2:

- #1194 — `build_eagle_tree_structure` FULL_MASK OOM at large batch sizes
- #1113 — Eagle3 topk > 1 support
- #1109 — Eagle3 non-greedy sampling