### PR TITLE
feat(mem_cache): PR-1 HiCache + PD infra foundation (builder + pytree slot + ABC)

### DIFF
--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -67,6 +67,7 @@ from sgl_jax.srt.managers.tp_worker import ModelWorker
 from sgl_jax.srt.managers.tp_worker_overlap_thread import ModelWorkerClient
 from sgl_jax.srt.managers.utils import validate_input_length
 from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
+from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
 from sgl_jax.srt.mem_cache.radix_cache import RadixCache
 from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
@@ -514,35 +515,18 @@ class Scheduler(
             )
 
     def init_memory_pool_and_cache(self):
-        server_args = self.server_args
         self.req_to_token_pool, self.token_to_kv_pool_allocator = self.tp_worker.get_memory_pool()
-
-        if self.is_hybrid:
-            self.tree_cache = SWARadixCache(
-                req_to_token_pool=self.req_to_token_pool,
-                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-                sliding_window_size=self.sliding_window_size,
-                page_size=self.page_size,
-                disable=server_args.disable_radix_cache,
-            )
-        elif server_args.chunked_prefill_size is not None and server_args.disable_radix_cache:
-            self.tree_cache = ChunkCache(
-                req_to_token_pool=self.req_to_token_pool,
-                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-                page_size=self.page_size,
-            )
-        else:
-            self.tree_cache = RadixCache(
-                req_to_token_pool=self.req_to_token_pool,
-                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-                page_size=self.page_size,
-                disable=server_args.disable_radix_cache,
-                kv_head_num=self.model_config.get_num_kv_heads(self.tp_size),
-                head_dim=self.model_config.head_dim,
-                layer_num=self.model_config.num_hidden_layers,
-                max_seq_len=server_args.max_seq_len,
-                is_eagle=self.spec_algorithm is not None and self.spec_algorithm.is_eagle(),
-            )
+        self.tree_cache = build_kv_cache(
+            req_to_token_pool=self.req_to_token_pool,
+            token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+            server_args=self.server_args,
+            model_config=self.model_config,
+            page_size=self.page_size,
+            tp_size=self.tp_size,
+            is_hybrid=self.is_hybrid,
+            sliding_window_size=self.sliding_window_size,
+            spec_algorithm=self.spec_algorithm,
+        )
 
     def _select_round_robin_dp(self) -> int:
         dp_rank = self.dp_round_robin_counter % self.dp_size

--- a/python/sgl_jax/srt/mem_cache/kv_cache_builder.py
+++ b/python/sgl_jax/srt/mem_cache/kv_cache_builder.py
@@ -1,0 +1,70 @@
+"""Builder for the scheduler's prefix tree cache.
+
+Extracted from ``Scheduler.init_memory_pool_and_cache`` so that future
+cache variants (HiCache wrapper, PD-aware caches, etc.) can plug into a
+single dispatch point instead of growing the scheduler if/elif.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache
+from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
+from sgl_jax.srt.mem_cache.radix_cache import RadixCache
+from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.configs.model_config import ModelConfig
+    from sgl_jax.srt.mem_cache.memory_pool import ReqToTokenPool
+    from sgl_jax.srt.server_args import ServerArgs
+
+
+def build_kv_cache(
+    *,
+    req_to_token_pool: "ReqToTokenPool",
+    token_to_kv_pool_allocator: Any,
+    server_args: "ServerArgs",
+    model_config: "ModelConfig",
+    page_size: int,
+    tp_size: int,
+    is_hybrid: bool,
+    sliding_window_size: int | None,
+    spec_algorithm: Any,
+) -> BasePrefixCache:
+    """Construct the scheduler's prefix-tree cache.
+
+    Dispatch precedence (matches the pre-refactor scheduler logic):
+
+    1. ``is_hybrid`` → :class:`SWARadixCache`
+    2. ``chunked_prefill_size is not None and disable_radix_cache`` →
+       :class:`ChunkCache`
+    3. otherwise → :class:`RadixCache`
+    """
+    if is_hybrid:
+        return SWARadixCache(
+            req_to_token_pool=req_to_token_pool,
+            token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+            sliding_window_size=sliding_window_size,
+            page_size=page_size,
+            disable=server_args.disable_radix_cache,
+        )
+
+    if server_args.chunked_prefill_size is not None and server_args.disable_radix_cache:
+        return ChunkCache(
+            req_to_token_pool=req_to_token_pool,
+            token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+            page_size=page_size,
+        )
+
+    return RadixCache(
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        page_size=page_size,
+        disable=server_args.disable_radix_cache,
+        kv_head_num=model_config.get_num_kv_heads(tp_size),
+        head_dim=model_config.head_dim,
+        layer_num=model_config.num_hidden_layers,
+        max_seq_len=server_args.max_seq_len,
+        is_eagle=spec_algorithm is not None and spec_algorithm.is_eagle(),
+    )

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -1358,10 +1358,24 @@ class HybridLinearKVPool(KVCache):
 
 @register_pytree_node_class
 class MemoryPools:
-    """Pytree container that uniformly manages multiple pool replace operations."""
+    """Pytree container that uniformly manages multiple pool replace operations.
 
-    def __init__(self, **pools):
+    A reserved ``host_pool`` slot is exposed for the upcoming HiCache L2
+    host-side pool (PR-1-5 ``SingleChipHostPool``). It defaults to
+    ``None`` so existing call sites stay backward-compatible; once the
+    HiCache host pool lands it can be passed via the keyword-only
+    ``host_pool`` argument and participates in the pytree as the last
+    leaf-group.
+
+    Note on donation: ``jax.jit(donate_argnames=["memory_pools"])`` in
+    ``model_runner.initialize_jit`` already donates the whole container.
+    Adding the slot changes the ``PyTreeDef`` so jit caches will retrace
+    once on next launch — that is the validation goal of PR-1-2.
+    """
+
+    def __init__(self, *, host_pool=None, **pools):
         self._pools = pools
+        self.host_pool = host_pool
 
     def __getattr__(self, name):
         if name.startswith("_"):
@@ -1375,11 +1389,15 @@ class MemoryPools:
 
     def tree_flatten(self):
         keys = sorted(self._pools.keys())
-        return [self._pools[k] for k in keys], tuple(keys)
+        children = [self._pools[k] for k in keys] + [self.host_pool]
+        return children, tuple(keys)
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
-        return cls(**dict(zip(aux_data, children)))
+        pool_count = len(aux_data)
+        pool_children = children[:pool_count]
+        host_pool = children[pool_count]
+        return cls(host_pool=host_pool, **dict(zip(aux_data, pool_children)))
 
     def replace_all(self, updates) -> None:
         if isinstance(updates, list):

--- a/python/sgl_jax/srt/mem_cache/tree_component.py
+++ b/python/sgl_jax/srt/mem_cache/tree_component.py
@@ -1,0 +1,115 @@
+"""HiCache ``TreeComponent`` ABC + supporting enums (PR-1-3 stub).
+
+Surface only — no behavior yet. Concrete subclasses
+(``FullComponent`` / ``SWAComponent`` / ``RecurrentStateComponent``)
+land in PR-2/PR-3 per the roadmap §6.2/§6.3 task lists.
+
+References:
+- RFC-1 §4.1 (`/Users/jiongxuan/workspace/wiki/.../rfc_1_hicache.md`)
+- roadmap §6.1 PR-1-3
+
+This module deliberately has no runtime side effects: it only declares
+the interface so downstream PRs and tests can import the symbols and
+type-check against them.
+"""
+
+from __future__ import annotations
+
+import abc
+import enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import jax
+
+
+class ComponentType(enum.Enum):
+    """Attention shape a :class:`TreeComponent` handles.
+
+    Mirrors RFC-1 §4.1's three concrete component subclasses; the
+    scheduler / cache builder will dispatch on this enum to wire the
+    right component when a model is loaded.
+    """
+
+    FULL = "full"
+    SWA = "swa"
+    RECURRENT_STATE = "recurrent_state"
+
+
+class CacheTransferPhase(enum.Enum):
+    """Lifecycle state of an L1↔L2 (and later L2↔L3) KV transfer.
+
+    Tracked by :class:`HiCacheController` (PR-2) to keep the scheduler
+    in sync with async ``device_put`` / Pallas ``copy_to_host`` futures.
+    Names match the verbs used in RFC-1 §4.1 hooks so the state machine
+    reads top-to-bottom in the controller log.
+    """
+
+    IDLE = "idle"
+    SCHEDULED = "scheduled"
+    IN_FLIGHT = "in_flight"
+    DONE = "done"
+    FAILED = "failed"
+
+
+class TreeComponent(abc.ABC):
+    """Abstract base for attention-shape-specific HiCache hooks.
+
+    Each subclass owns the per-attention-type policy for moving KV pages
+    between L1 (device) and L2 (host pinned) — and later L3 (storage).
+    Three hooks per the RFC:
+
+    - ``write_through`` — fired on ``UnifiedRadixCache.insert``; enqueue
+      a non-blocking D2H copy for the new page so it is mirrored to L2
+      while the scheduler keeps running forward.
+    - ``write_back`` — fired on ``UnifiedRadixCache.evict``; if L3 is
+      configured, hand the page off for persistence; otherwise a no-op
+      that just releases the L2 slot.
+    - ``prefetch`` — fired on prefix lookup hit when the page lives in
+      L2/L3 only; pull the page back to L1 and block the consumer
+      until the H2D copy is ready.
+
+    Concrete subclasses must declare which :class:`ComponentType` they
+    handle (the scheduler uses this for dispatch).
+    """
+
+    @property
+    @abc.abstractmethod
+    def component_type(self) -> ComponentType:
+        """The attention shape this component owns."""
+
+    @abc.abstractmethod
+    def write_through(
+        self,
+        *,
+        node: Any,
+        device_indices: "jax.Array",
+        host_indices: "jax.Array",
+    ) -> CacheTransferPhase:
+        """Schedule a non-blocking D2H copy for a newly-inserted node."""
+
+    @abc.abstractmethod
+    def write_back(
+        self,
+        *,
+        node: Any,
+        host_indices: "jax.Array",
+    ) -> CacheTransferPhase:
+        """Persist (or release) host pages of a node being evicted."""
+
+    @abc.abstractmethod
+    def prefetch(
+        self,
+        *,
+        node: Any,
+        host_indices: "jax.Array",
+        device_indices: "jax.Array",
+    ) -> CacheTransferPhase:
+        """Pull pages from L2/L3 back to L1; blocks the consumer."""
+
+
+__all__ = [
+    "CacheTransferPhase",
+    "ComponentType",
+    "TreeComponent",
+]

--- a/python/sgl_jax/test/mem_cache/test_kv_cache_builder.py
+++ b/python/sgl_jax/test/mem_cache/test_kv_cache_builder.py
@@ -1,0 +1,163 @@
+"""Tests for ``build_kv_cache`` dispatch.
+
+Three branches must be covered (matches scheduler pre-refactor behavior):
+
+- ``is_hybrid=True``                                             → ``SWARadixCache``
+- ``chunked_prefill_size is not None and disable_radix_cache``   → ``ChunkCache``
+- otherwise                                                      → ``RadixCache``
+
+The real cache classes touch JAX devices on construction, so we patch
+them out — this test guards the dispatch logic and argument forwarding,
+not the cache implementations.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _server_args(disable_radix=False, chunked_prefill=None, max_seq_len=1024):
+    sa = MagicMock()
+    sa.disable_radix_cache = disable_radix
+    sa.chunked_prefill_size = chunked_prefill
+    sa.max_seq_len = max_seq_len
+    return sa
+
+
+def _model_config(num_kv_heads=4, head_dim=128, num_layers=2):
+    mc = MagicMock()
+    mc.get_num_kv_heads.return_value = num_kv_heads
+    mc.head_dim = head_dim
+    mc.num_hidden_layers = num_layers
+    return mc
+
+
+def _default_kwargs(**overrides):
+    kwargs = dict(
+        req_to_token_pool=MagicMock(name="req_to_token_pool"),
+        token_to_kv_pool_allocator=MagicMock(name="alloc"),
+        server_args=_server_args(),
+        model_config=_model_config(),
+        page_size=64,
+        tp_size=1,
+        is_hybrid=False,
+        sliding_window_size=None,
+        spec_algorithm=None,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+@patch("sgl_jax.srt.mem_cache.kv_cache_builder.SWARadixCache")
+@patch("sgl_jax.srt.mem_cache.kv_cache_builder.ChunkCache")
+@patch("sgl_jax.srt.mem_cache.kv_cache_builder.RadixCache")
+class TestKVCacheBuilderDispatch(unittest.TestCase):
+    def test_hybrid_dispatches_to_swa_radix_cache(self, MockRadix, MockChunk, MockSWA):
+        from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
+
+        result = build_kv_cache(
+            **_default_kwargs(
+                server_args=_server_args(disable_radix=True, chunked_prefill=2048),
+                is_hybrid=True,
+                sliding_window_size=256,
+            )
+        )
+
+        MockSWA.assert_called_once()
+        MockChunk.assert_not_called()
+        MockRadix.assert_not_called()
+        self.assertIs(result, MockSWA.return_value)
+
+        call_kwargs = MockSWA.call_args.kwargs
+        self.assertEqual(call_kwargs["sliding_window_size"], 256)
+        self.assertEqual(call_kwargs["page_size"], 64)
+        self.assertTrue(call_kwargs["disable"])
+
+    def test_chunked_prefill_with_disable_radix_dispatches_to_chunk_cache(
+        self, MockRadix, MockChunk, MockSWA
+    ):
+        from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
+
+        result = build_kv_cache(
+            **_default_kwargs(
+                server_args=_server_args(disable_radix=True, chunked_prefill=2048),
+            )
+        )
+
+        MockChunk.assert_called_once()
+        MockSWA.assert_not_called()
+        MockRadix.assert_not_called()
+        self.assertIs(result, MockChunk.return_value)
+
+        call_kwargs = MockChunk.call_args.kwargs
+        self.assertEqual(call_kwargs["page_size"], 64)
+
+    def test_default_dispatches_to_radix_cache(self, MockRadix, MockChunk, MockSWA):
+        from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
+
+        spec = MagicMock()
+        spec.is_eagle.return_value = False
+
+        result = build_kv_cache(**_default_kwargs(spec_algorithm=spec))
+
+        MockRadix.assert_called_once()
+        MockSWA.assert_not_called()
+        MockChunk.assert_not_called()
+        self.assertIs(result, MockRadix.return_value)
+
+        call_kwargs = MockRadix.call_args.kwargs
+        self.assertEqual(call_kwargs["page_size"], 64)
+        self.assertEqual(call_kwargs["max_seq_len"], 1024)
+        self.assertEqual(call_kwargs["kv_head_num"], 4)
+        self.assertEqual(call_kwargs["head_dim"], 128)
+        self.assertEqual(call_kwargs["layer_num"], 2)
+        self.assertFalse(call_kwargs["is_eagle"])
+
+    def test_chunked_prefill_without_disable_radix_still_uses_radix(
+        self, MockRadix, MockChunk, MockSWA
+    ):
+        from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
+
+        build_kv_cache(
+            **_default_kwargs(
+                server_args=_server_args(disable_radix=False, chunked_prefill=2048),
+            )
+        )
+
+        MockRadix.assert_called_once()
+        MockChunk.assert_not_called()
+        MockSWA.assert_not_called()
+
+    def test_eagle_spec_flag_propagates_to_radix_cache(self, MockRadix, MockChunk, MockSWA):
+        from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
+
+        spec = MagicMock()
+        spec.is_eagle.return_value = True
+
+        build_kv_cache(**_default_kwargs(spec_algorithm=spec))
+
+        self.assertTrue(MockRadix.call_args.kwargs["is_eagle"])
+
+    def test_hybrid_takes_precedence_over_chunked_prefill(
+        self, MockRadix, MockChunk, MockSWA
+    ):
+        """If both is_hybrid and (chunked_prefill + disable_radix) are set,
+        is_hybrid wins (matches scheduler if-elif order)."""
+        from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
+
+        build_kv_cache(
+            **_default_kwargs(
+                server_args=_server_args(disable_radix=True, chunked_prefill=2048),
+                is_hybrid=True,
+                sliding_window_size=128,
+            )
+        )
+
+        MockSWA.assert_called_once()
+        MockChunk.assert_not_called()
+        MockRadix.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sgl_jax/test/mem_cache/test_memory_pools_host_slot.py
+++ b/python/sgl_jax/test/mem_cache/test_memory_pools_host_slot.py
@@ -1,0 +1,117 @@
+"""Tests for the reserved ``host_pool`` slot on :class:`MemoryPools`.
+
+PR-1-2: the slot must be backward-compatible — existing call sites that
+construct ``MemoryPools(**pools)`` keep working — and must survive a
+JAX pytree flatten/unflatten round-trip so ``jit(donate_argnames=
+["memory_pools"])`` still sees the whole container as donatable.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+
+from sgl_jax.srt.mem_cache.memory_pool import MemoryPools
+
+
+class _FakePool:
+    """Minimal stand-in for ``KVCache`` / ``RecurrentStatePool`` — opaque
+    leaf so we don't pull TPU dependencies into this unit test.
+
+    Treated as a JAX leaf by default (no pytree registration), so identity
+    is preserved across flatten/unflatten.
+    """
+
+    def __init__(self, tag):
+        self.tag = tag
+
+    def __repr__(self):
+        return f"_FakePool({self.tag!r})"
+
+
+class TestMemoryPoolsHostPoolSlot(unittest.TestCase):
+    def test_default_host_pool_is_none(self):
+        mp = MemoryPools(token_to_kv_pool=_FakePool("kv"))
+        self.assertIsNone(mp.host_pool)
+
+    def test_existing_construction_still_works(self):
+        kv = _FakePool("kv")
+        rsp = _FakePool("rsp")
+        mp = MemoryPools(token_to_kv_pool=kv, recurrent_state_pool=rsp)
+        self.assertIs(mp.token_to_kv_pool, kv)
+        self.assertIs(mp.recurrent_state_pool, rsp)
+        self.assertIsNone(mp.host_pool)
+
+    def test_pytree_roundtrip_without_host_pool(self):
+        kv = _FakePool("kv")
+        mp = MemoryPools(token_to_kv_pool=kv)
+        leaves, treedef = jax.tree_util.tree_flatten(mp)
+        restored = jax.tree_util.tree_unflatten(treedef, leaves)
+        self.assertIs(restored.token_to_kv_pool, kv)
+        self.assertIsNone(restored.host_pool)
+
+    def test_pytree_roundtrip_with_host_pool(self):
+        kv = _FakePool("kv")
+        host = jnp.zeros((4, 8), dtype=jnp.bfloat16)
+        mp = MemoryPools(token_to_kv_pool=kv, host_pool=host)
+        leaves, treedef = jax.tree_util.tree_flatten(mp)
+        restored = jax.tree_util.tree_unflatten(treedef, leaves)
+        self.assertIs(restored.token_to_kv_pool, kv)
+        self.assertTrue(jnp.array_equal(restored.host_pool, host))
+
+    def test_treedef_changes_when_host_pool_present(self):
+        kv = _FakePool("kv")
+        without = MemoryPools(token_to_kv_pool=kv)
+        with_host = MemoryPools(
+            token_to_kv_pool=kv,
+            host_pool=jnp.zeros((2,), dtype=jnp.float32),
+        )
+        _, td_without = jax.tree_util.tree_flatten(without)
+        _, td_with = jax.tree_util.tree_flatten(with_host)
+        # Different PyTreeDef → jit cache will retrace (expected per PR-1-2 ACK).
+        self.assertNotEqual(td_without, td_with)
+
+    def test_pool_keys_remain_sorted_in_flatten(self):
+        kv = _FakePool("kv")
+        rsp = _FakePool("rsp")
+        # constructed in non-sorted order but flatten output should be sorted.
+        mp = MemoryPools(token_to_kv_pool=kv, recurrent_state_pool=rsp)
+        leaves, treedef = jax.tree_util.tree_flatten(mp)
+        restored = jax.tree_util.tree_unflatten(treedef, leaves)
+        self.assertIs(restored.recurrent_state_pool, rsp)
+        self.assertIs(restored.token_to_kv_pool, kv)
+
+    def test_host_pool_not_listed_in_pool_keys(self):
+        """``host_pool`` must NOT leak into the inner ``_pools`` dict —
+        otherwise ``replace_all`` would demand it in ``updates``."""
+        mp = MemoryPools(
+            token_to_kv_pool=_FakePool("kv"),
+            host_pool=jnp.zeros((1,), dtype=jnp.float32),
+        )
+        # replace_all only knows about real pools.
+        self.assertEqual(set(mp._pools.keys()), {"token_to_kv_pool"})
+
+    def test_replace_all_unaffected_by_host_pool(self):
+        kv_orig = _FakePool("kv")
+        kv_new = _FakePool("kv_new")
+        replaced = []
+        kv_orig.replace_buffer = lambda v: replaced.append(v)  # type: ignore[attr-defined]
+
+        mp = MemoryPools(
+            token_to_kv_pool=kv_orig,
+            host_pool=jnp.zeros((1,), dtype=jnp.float32),
+        )
+        mp.replace_all({"token_to_kv_pool": kv_new})
+        self.assertEqual(replaced, [kv_new])
+
+    def test_unknown_pool_lookup_still_raises(self):
+        mp = MemoryPools(token_to_kv_pool=_FakePool("kv"))
+        with self.assertRaises(AttributeError) as cm:
+            _ = mp.nonexistent_pool
+        self.assertIn("MemoryPools has no pool", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sgl_jax/test/mem_cache/test_tree_component.py
+++ b/python/sgl_jax/test/mem_cache/test_tree_component.py
@@ -1,0 +1,86 @@
+"""Surface-level test for PR-1-3 TreeComponent ABC + enums.
+
+Validates:
+- Enum members exist with stable string values (so logs / metrics
+  built on them are not silently re-numbered).
+- :class:`TreeComponent` is genuinely abstract (cannot be instantiated
+  without all three hooks + ``component_type``).
+- A minimal compliant subclass can be instantiated and its
+  ``component_type`` dispatches correctly.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from sgl_jax.srt.mem_cache.tree_component import (
+    CacheTransferPhase,
+    ComponentType,
+    TreeComponent,
+)
+
+
+class TestTreeComponentSurface(unittest.TestCase):
+    def test_component_type_values_are_stable(self):
+        self.assertEqual(ComponentType.FULL.value, "full")
+        self.assertEqual(ComponentType.SWA.value, "swa")
+        self.assertEqual(ComponentType.RECURRENT_STATE.value, "recurrent_state")
+        self.assertEqual(len(ComponentType), 3)
+
+    def test_cache_transfer_phase_values_are_stable(self):
+        expected = {
+            "IDLE": "idle",
+            "SCHEDULED": "scheduled",
+            "IN_FLIGHT": "in_flight",
+            "DONE": "done",
+            "FAILED": "failed",
+        }
+        for name, value in expected.items():
+            self.assertEqual(CacheTransferPhase[name].value, value)
+        self.assertEqual(len(CacheTransferPhase), len(expected))
+
+    def test_tree_component_is_abstract(self):
+        with self.assertRaises(TypeError):
+            TreeComponent()  # type: ignore[abstract]
+
+    def test_subclass_missing_hook_still_abstract(self):
+        class HalfBaked(TreeComponent):
+            @property
+            def component_type(self):
+                return ComponentType.FULL
+
+            # write_through / write_back / prefetch intentionally missing
+
+        with self.assertRaises(TypeError):
+            HalfBaked()  # type: ignore[abstract]
+
+    def test_minimal_compliant_subclass_can_be_instantiated(self):
+        class NoOpComponent(TreeComponent):
+            @property
+            def component_type(self):
+                return ComponentType.FULL
+
+            def write_through(self, *, node, device_indices, host_indices):
+                return CacheTransferPhase.SCHEDULED
+
+            def write_back(self, *, node, host_indices):
+                return CacheTransferPhase.DONE
+
+            def prefetch(self, *, node, host_indices, device_indices):
+                return CacheTransferPhase.IN_FLIGHT
+
+        c = NoOpComponent()
+        self.assertIs(c.component_type, ComponentType.FULL)
+        self.assertIs(
+            c.write_through(node=None, device_indices=None, host_indices=None),
+            CacheTransferPhase.SCHEDULED,
+        )
+        self.assertIs(c.write_back(node=None, host_indices=None), CacheTransferPhase.DONE)
+        self.assertIs(
+            c.prefetch(node=None, host_indices=None, device_indices=None),
+            CacheTransferPhase.IN_FLIGHT,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Foundational refactor for the upcoming HiCache + PD work (RFC-0/1/2).
This PR only lands the framework — no behavior change for existing paths,
no new runtime features.

- **PR-1-1** — Extract `kv_cache_builder.build_kv_cache()` from
  `Scheduler.init_memory_pool_and_cache` (scheduler.py:516-545) so future
  cache variants (HiCache wrapper, PD-aware caches) plug in at one
  dispatch point rather than growing the if/elif. Existing dispatch
  precedence preserved exactly: `SWARadixCache` (when `is_hybrid`) →
  `ChunkCache` (when `chunked_prefill_size and disable_radix_cache`) →
  `RadixCache` (default).
- **PR-1-2** — Reserve a keyword-only `host_pool` slot on the
  `MemoryPools` pytree for the upcoming HiCache L2 host pool. Default
  `None` so every existing call site (`MemoryPools(**pools)`) is
  unchanged. The slot is appended as the last pytree child after the
  sorted pool leaves; `donate_argnames=["memory_pools"]` in
  `model_runner.initialize_jit` keeps working — the `PyTreeDef` changes,
  so the jit cache will retrace once on next launch.
- **PR-1-3** — Add `TreeComponent` ABC + `ComponentType`
  (`FULL` / `SWA` / `RECURRENT_STATE`) + `CacheTransferPhase`
  (`IDLE` → `SCHEDULED` → `IN_FLIGHT` → `DONE` / `FAILED`) enums per
  RFC-1 §4.1. Surface only; concrete components (`FullComponent`,
  `SWAComponent`, `RecurrentStateComponent`) land in PR-2 / PR-3.

## Background

This is the first PR on the HiCache + PD roadmap. The Phase-0
feasibility spike (jx-v6e-16, JAX 0.8.1, 7 + 4 tests) closed the
remaining design risks; the implementation plan and PR sequencing
documents are tracked in an internal RFC and will be opened separately
for community review.

## Deployment requirement called out for follow-up PRs

HiCache L2 and the PD pinned-host transfer path both depend on
`securityContext.capabilities.add: [IPC_LOCK]` on the TPU container —
without it `jax.device_put(x, NamedSharding(..., memory_kind="pinned_host"))`
silently falls back to unpinned host memory and the D2H / H2D bandwidth
collapses to page-cache speeds (default container `RLIMIT_MEMLOCK = 64
KiB`).

Verified on a v6e-16 pod rebuilt with `IPC_LOCK`:

```
$ kubectl exec $POD -- bash -c 'ulimit -l'
unlimited
```

The single-chip host-pool prototype (`SingleChipHostPool`, validated by
the T5 v2 spike: 300 iter `in_place=True`, RSS growth 36.6 MiB; 500 iter
41.6 MiB sub-linear) and the deployment-guide updates that lean on this
requirement will land with **PR-2** when the H2 host pool actually
consumes them.

## Test plan

CPU unit tests (all pass):

```
$ pytest python/sgl_jax/test/mem_cache/test_kv_cache_builder.py        # 6/6
$ pytest python/sgl_jax/test/mem_cache/test_memory_pools_host_slot.py  # 9/9
$ pytest python/sgl_jax/test/mem_cache/test_tree_component.py          # 5/5
```

Scheduler import smoke (refactor doesn't break import-time wiring):

```
$ python -c "from sgl_jax.srt.managers.scheduler import Scheduler"
```

Pre-existing failures in `python/sgl_jax/test/mem_cache/test_kv_cache.py`
(10 cases) reproduce on `main` and are not related to this PR — confirmed
by checking out the affected modules from `main` and rerunning.

## Out of scope (deferred to later PRs)

- `MHATokenToKVPoolHost` (4-chip routed host pool) — PR-2 H2a/b/c
- `HiCacheController` + metrics — PR-2 H4 / H4.5
- `FullComponent` (first concrete `TreeComponent`) — PR-2 H5
- `UnifiedRadixCache` port + 6 HiCache hooks — PR-2 H6a/b + H7
- Pallas `copy_to_host` kernel (D2H ≥10 GB/s) — PR-3 H3
- `SWAComponent` / `RecurrentStateComponent` — PR-3 H8
- PD disaggregation (P1-P11) — PR-4