### PR TITLE
feat(qwen3-vl): three-JIT split for ViT + LLM + precompile

### DIFF
--- a/docs/design/qwen3vl_three_jit_split.md
+++ b/docs/design/qwen3vl_three_jit_split.md
@@ -1,0 +1,349 @@
+# Qwen3-VL Three-JIT Split — Design Document
+
+## 1. Motivation
+
+Today the entire `Qwen3VLForConditionalGeneration.__call__` — vision encoder, embed splice, and language model — lives inside a single JIT closure (`jitted_run_model` in `model_runner.py:211`). Two consequences:
+
+1. **`pixel_values` shape participates in the JIT cache key.** Different image bucket sizes (`_MM_PATCH_BUCKETS = (256, 1024, 4096)`) each force a fresh recompilation of the *entire* 7B+ViT model graph.
+2. **No precompile coverage for the vision path.** `CompilationManager` only synthesizes text-only dummy batches, so any user serving an image hits a multi-minute cold compile on the first request of each bucket.
+
+Both the upstream sglang torch runtime and the tpu-inference JAX runtime solve this by splitting the multimodal forward into independent JIT boundaries:
+- sglang torch only captures the language model in CUDA graphs; ViT runs eager and feeds `input_embeds` into the captured graph.
+- tpu-inference compiles three independent functions (`embed_multimodal_fn`, `embed_input_ids_fn`, `model_fn`) and AOT-precompiles all power-of-two patch buckets at startup.
+
+This document describes how sgl-jax adopts the three-JIT pattern for Qwen3-VL, with the bucket and precompile machinery aligned to the tpu-inference design. The work lands as a new PR independent of #1189 (which contains the ViT splash kernel and Control-plane review fixes).
+
+## 2. Requirements and Non-Goals
+
+### Functional Requirements
+
+- Vision encoder runs in its own JIT boundary, keyed on `n_patches_bucket` only.
+- LLM JIT cache is shared between text-only and multimodal extends (no `pixel_values` in cache key).
+- Patch buckets are powers of two derived from `chunked_prefill_size * spatial_merge_unit`, replacing the hardcoded `(256, 1024, 4096)` ladder.
+- Precompile coverage at startup for every power-of-two patch bucket, eliminating cold-compile cost on first image request.
+- No regression on text-only paths or decode paths.
+- No regression on existing tests: `test_qwen3_vl_models.py` (`test_logit_alignment_vs_hf`, `test_multi_image_prefill`).
+
+### Non-Goals (S3 follow-ups, separate PR)
+
+- **Per-image embedding cache** (content-hash keyed, cross-request reuse).
+- **Chunked-prefill `items_offset` + `find_chunk_items_and_check_cache` + `assemble_chunk_embedding`** algorithm for cross-chunk image reuse.
+- **`offload_mm_features_to_cpu`** for GPU memory release after ViT.
+- **Retraction support** from CPU-side `mm_inputs` copy.
+- **Applying the split to `qwen2_5_vl` / `qwen3_omni_thinker`** (Qwen3-VL only for this PR).
+- **Three-JIT encoder cache integration** — depends on the per-image cache landing first.
+
+## 3. Architecture
+
+### Current (Monolithic JIT)
+
+```
+ForwardBatch (pixel_values, image_grid_thw, input_ids, ...)
+       │
+       ▼
+┌────────────────────────────────────────────────────────┐
+│ jitted_run_model (single JIT, ~7B + 700M params)       │
+│                                                        │
+│ Qwen3VLForConditionalGeneration.__call__:              │
+│   if extend AND pixel_values is not None:              │
+│       vision_features = self.visual(pixel_values, ...) │ ← ViT
+│       embed splice → forward_batch.input_embedding     │ ← scatter
+│       full_deepstack scatter                           │
+│   self.model(forward_batch, ...)                       │ ← LLM
+│   self.logits_processor(...)                           │
+│                                                        │
+│ Cache key: (input_ids_len, pixel_values.shape, ...)    │
+│ → Every new pixel_values bucket recompiles entire ~8B  │
+│   graph (≈30–90s per bucket on TPU v6e).               │
+└────────────────────────────────────────────────────────┘
+```
+
+### Target (Three-JIT Split)
+
+```
+ForwardBatch (pixel_values, image_grid_thw, input_ids, ...)
+       │
+       ▼ (Python orchestration in model_runner.run_model_wrapper)
+       │
+       ├─ if multimodal AND extend AND pixel_values is not None:
+       │
+       │     ┌─────────────────────────────────────────────────┐
+       │     │ jitted_visual_encode (NEW, ViT only ~700M)      │
+       │     │                                                 │
+       │     │   inputs:  pixel_values  [n_patches_bucket,1536]│
+       │     │           image_grid_thw (static tuple)         │
+       │     │           cu_seqlens, n_real_images             │
+       │     │   outputs: vision_main      [N_padded_tokens,H] │
+       │     │           vision_deepstack [...,H*N_ds]         │
+       │     │                                                 │
+       │     │   Cache key: (n_patches_bucket, image_grid_thw, │
+       │     │              n_real_images_bucket)              │
+       │     └─────────────────────────────────────────────────┘
+       │                              │
+       │                              ▼ (S3 hook point — encoder_cache lookup)
+       │                              │
+       │     ┌─────────────────────────────────────────────────┐
+       │     │ jitted_splice_embeds (NEW)                      │
+       │     │                                                 │
+       │     │   inputs:  input_ids        [seq_len]           │
+       │     │           vision_main      [N_padded_tokens,H]  │
+       │     │           vision_deepstack [...,H*N_ds]         │
+       │     │           placeholder_positions [N_padded_tokens]│
+       │     │   outputs: input_embedding    [seq_len, H]      │
+       │     │           deepstack_embedding [seq_len, H*N_ds] │
+       │     │                                                 │
+       │     │   logic:   text = embed_tokens(input_ids)       │
+       │     │           input_embedding =                     │
+       │     │             text.at[positions].set(vision_main) │
+       │     │           deepstack = zeros.at[positions].set(  │
+       │     │                       vision_deepstack)         │
+       │     │                                                 │
+       │     │   Cache key: (seq_len, N_padded_tokens)         │
+       │     │                                                 │
+       │     │   Note: embed_tokens IS here (option A, matches │
+       │     │   tpu-inference). The output is fully-spliced.  │
+       │     │   See §4.1.                                     │
+       │     └─────────────────────────────────────────────────┘
+       │                              │
+       │                              ▼
+       │           forward_batch = replace(forward_batch,
+       │              input_embedding=input_embedding,
+       │              deepstack_visual_embedding=deepstack,
+       │           )
+       │
+       ▼
+┌────────────────────────────────────────────────────────┐
+│ jitted_run_model (REUSED, LLM only ~7B)                │
+│                                                        │
+│ Qwen3VLForConditionalGeneration.__call__:              │
+│   # ViT path removed — input_embedding is pre-filled   │
+│   self.model(forward_batch, ...)                       │
+│   self.logits_processor(...)                           │
+│                                                        │
+│ Cache key: (input_ids_len, ...) — pixel_values gone.   │
+│ → Same JIT serves text-only AND multimodal extends.    │
+└────────────────────────────────────────────────────────┘
+```
+
+### Text-only / Decode Path (Unchanged)
+
+When `pixel_values` is None (text-only extend, all decode mode), the orchestrator skips both vision JITs and calls `jitted_run_model` directly. The LLM internally runs `embed_tokens(input_ids)` as today (`Qwen3VLLanguageModel.__call__:850`).
+
+## 4. Design
+
+### 4.1 `embed_tokens` Placement (Q1=A, matches tpu-inference)
+
+`embed_tokens(input_ids)` runs inside `jitted_splice_embeds`, not the LLM JIT. Concretely:
+
+- **Multimodal extend:** orchestrator calls splice JIT, which produces a fully-spliced `input_embedding` of shape `[seq_len, hidden]`. LLM JIT receives `forward_batch.input_embedding` and skips its own `embed_tokens` call.
+- **Text-only extend / decode:** orchestrator does NOT call splice JIT. `forward_batch.input_embedding` stays `None`. LLM JIT runs `embed_tokens(input_ids)` internally as today.
+
+The LLM-side `Qwen3VLLanguageModel.__call__` semantics are **unchanged from the current implementation** — it already branches on `forward_batch.input_embedding is None` (line 850). All we change is when the orchestrator populates `input_embedding`: today it happens inside the model's `__call__`; with this PR it happens via the orchestrator before `jitted_run_model` is entered.
+
+**Cache key isolation:**
+
+| JIT | Cache key dimensions | Variance source |
+|---|---|---|
+| `jitted_visual_encode` | `(n_patches_bucket, image_grid_thw, n_real_images_bucket)` | ViT inputs only |
+| `jitted_splice_embeds` | `(seq_len_bucket, N_padded_tokens_bucket)` | Splice geometry |
+| `jitted_run_model` (LLM) | `(seq_len_bucket, ...)` — same as text-only path | No image axes |
+
+Critically, the LLM JIT cache is **fully shared** between text-only and multimodal extends, because `forward_batch.input_embedding` is always one of:
+- `None` (text-only / decode): LLM does `embed_tokens(input_ids)`.
+- `[seq_len, hidden]` (multimodal): LLM uses it directly.
+
+In both cases, the LLM JIT input pytree has the same shape footprint. No `pixel_values` and no `N_padded_tokens` ever participate in the LLM cache key.
+
+**Rationale for choosing A over the alternative "splice does scatter only, LLM overlays":** the overlay approach forces `placeholder_positions` (whose length depends on `N_padded_tokens`) into the LLM JIT cache key, breaking LLM cache sharing between text-only and multimodal extends. A is strictly cleaner.
+
+### 4.2 Orchestration
+
+Implemented in `ModelRunner._make_jitted_funcs` and `run_model_wrapper` (the existing wrapper at `model_runner.py:250`):
+
+```python
+def run_model_wrapper(forward_batch, logits_metadata):
+    needs_visual = (
+        self.is_multimodal_model
+        and forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
+        and forward_batch.pixel_values is not None
+    )
+    if needs_visual:
+        vision_main, vision_deepstack = self.jitted_visual_encode(forward_batch)
+        input_embedding, deepstack_embedding = self.jitted_splice_embeds(
+            forward_batch.input_ids,
+            vision_main,
+            vision_deepstack,
+            forward_batch.placeholder_positions,
+        )
+        forward_batch = dataclasses.replace(
+            forward_batch,
+            input_embedding=input_embedding,
+            deepstack_visual_embedding=deepstack_embedding,
+        )
+    return self.jitted_run_model_impl(forward_batch, logits_metadata)
+```
+
+The `is_multimodal_model` flag is detected by checking whether the model class exposes `encode_visual` and `splice_embeds` methods. Non-VLM models and Qwen3-VL until this PR lands skip the new path entirely.
+
+### 4.3 Model Class Changes (`qwen3_vl.py`)
+
+Add two new pure-function methods on `Qwen3VLForConditionalGeneration`:
+
+```python
+def encode_visual(self, forward_batch):
+    """Run ViT + deepstack split. Pure function of the visual fields of forward_batch.
+
+    Inputs (read from forward_batch):
+        pixel_values, image_grid_thw, cu_seqlens, n_real_images
+    Returns: (vision_main [N_padded, H], vision_deepstack [N_padded, H*N_ds])
+    """
+    vision_features = self.visual(
+        forward_batch.pixel_values,
+        forward_batch.image_grid_thw,
+        cu_seqlens=forward_batch.cu_seqlens,
+        n_real_images=forward_batch.n_real_images,
+    )
+    return self.separate_deepstack_embeds(vision_features)
+
+def splice_embeds(self, input_ids, vision_main, vision_deepstack, placeholder_positions):
+    """Embed text tokens + scatter vision embeddings at placeholder positions.
+
+    Returns: (input_embedding [seq_len, H], deepstack_embedding [seq_len, H*N_ds])
+    """
+    repl = NamedSharding(self.mesh, P())
+    text_embeds = self.model.embed_tokens(input_ids)
+    text_embeds_repl = jax.sharding.reshard(text_embeds, repl)
+    input_embedding = text_embeds_repl.at[placeholder_positions].set(
+        vision_main.astype(text_embeds_repl.dtype)
+    )
+
+    zero_deepstack = jnp.zeros(
+        (input_embedding.shape[0], vision_deepstack.shape[-1]),
+        dtype=input_embedding.dtype,
+        device=repl,
+    )
+    deepstack_embedding = zero_deepstack.at[placeholder_positions].set(
+        vision_deepstack.astype(input_embedding.dtype)
+    )
+    return input_embedding, deepstack_embedding
+```
+
+`Qwen3VLForConditionalGeneration.__call__` strips the inline ViT block (lines 962–1002 today): the orchestrator has already populated `forward_batch.input_embedding` and `forward_batch.deepstack_visual_embedding` when applicable. The LLM-side `Qwen3VLLanguageModel.__call__` is **unchanged** — its existing `forward_batch.input_embedding is None` branch (line 850) already handles both paths correctly.
+
+### 4.4 Bucket Derivation
+
+Replace the hardcoded `_MM_PATCH_BUCKETS = (256, 1024, 4096)` in `schedule_batch.py` with a derived ladder:
+
+```python
+def compute_patch_buckets(chunked_prefill_size: int, spatial_merge_size: int,
+                          min_patches: int = 16) -> tuple[int, ...]:
+    """Power-of-two ladder from min_patches to next_pow2(max_patches)."""
+    spatial_merge_unit = spatial_merge_size ** 2
+    max_patches = chunked_prefill_size * spatial_merge_unit
+    min_shift = max(1, (min_patches - 1).bit_length())
+    max_shift = max(min_shift, (max_patches - 1).bit_length())
+    return tuple(1 << i for i in range(min_shift, max_shift + 1))
+```
+
+For Qwen3-VL with `spatial_merge_size=2` (so `spatial_merge_unit=4`) and `chunked_prefill_size=4096`:
+
+```
+max_patches = 16384
+buckets = (16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384)
+```
+
+The bucket list is computed once at startup and threaded through the same way the existing `_MM_PATCH_BUCKETS` is consumed (`_collect_mm_tensors`, `CompilationManager`). The `_MM_IMAGE_BUCKETS = (1, 2, 4, 8)` for `n_padded_images` stays as-is for now.
+
+The `_pick_bucket` overflow warning landed in PR #1189 stays in place; with the derived ladder reaching `chunked_prefill_size * spatial_merge_unit`, overflow becomes nearly impossible for in-spec requests.
+
+### 4.5 Precompile Strategy
+
+`CompilationManager` gains two new precompile passes. They run only when `model_runner.is_multimodal_model` is true.
+
+**`_precompile_visual_encode`** — patches-only ladder (Q2 simplification):
+
+```python
+for n_patches in self.patch_buckets:                       # ~11 buckets
+    dummy_fb = self._make_dummy_visual_batch(
+        n_patches=n_patches, n_real_images=1, ...
+    )
+    self.jitted_visual_encode(dummy_fb)                   # triggers AOT compile
+```
+
+We fix `n_real_images=1` (most common single-image case). Multi-image cases trigger lazy compile on first occurrence; the `_pick_bucket` warning surfaces the recompile so we can grow the precompile set later if usage patterns warrant.
+
+**`_precompile_splice`** — small Cartesian product:
+
+```python
+for seq_len in self.token_buckets:                         # ~4 buckets
+    for n_padded_tokens in self.visual_token_buckets:      # ~3 buckets (small subset)
+        if n_padded_tokens > seq_len: continue            # impossible
+        self.jitted_splice_embeds(dummy_input_ids,
+                                  dummy_vision_main,
+                                  dummy_vision_deepstack,
+                                  dummy_positions)
+```
+
+Splice is a single scatter — each compile is sub-second. The Cartesian product (≤12 compiles) is cheap.
+
+`_precompile_extend` / `_precompile_decode` are unchanged. The dummy batches they generate continue to have `pixel_values=None`, so the LLM JIT graph no longer has any image-specific shape variants. **The LLM JIT is now identical for text-only and multimodal extends.**
+
+### 4.6 ForwardBatch Contract Changes
+
+`ForwardBatch` already exposes `input_embedding` and `deepstack_visual_embedding` (see `forward_batch_info.py:430`). The contract changes are:
+
+- **Before:** `input_embedding` is populated inside `Qwen3VLForConditionalGeneration.__call__` via side-effecting assignment (`forward_batch.input_embedding = ...`).
+- **After:** `input_embedding` is populated by the orchestrator via `dataclasses.replace(forward_batch, input_embedding=...)` before `jitted_run_model` is entered.
+
+Verify `ForwardBatch` supports `dataclasses.replace` (it is a plain `@dataclass`, so it should). If frozen, replace with a custom `.replace()` helper that preserves pytree registration.
+
+### 4.7 Test Plan
+
+| Layer | What | How |
+|---|---|---|
+| Unit | `compute_patch_buckets` correctness | Existing test pattern in `test/srt/`; assert shape of returned tuple for representative `chunked_prefill_size` values. |
+| Unit | `splice_embeds` correctness | Construct deterministic `vision_main` / `placeholder_positions`, run JIT, assert scattered output equals reference numpy implementation. |
+| Unit | `encode_visual` shape contract | For each `n_patches_bucket`, dummy `pixel_values=zeros`, assert output shapes. |
+| Integration | Precompile coverage | Server start with `--tp-size 4 --context-length 8192 --page-size 128` (no `--disable-precompile`); log inspection confirms 11 visual-encode buckets + 12 splice buckets compiled at startup. |
+| Integration | First request latency | Send single multimodal request immediately after server ready; measure end-to-end latency. Expectation: no multi-minute cold compile (would indicate precompile missed the bucket). |
+| Regression | Existing `test_qwen3_vl_models.py` | `test_logit_alignment_vs_hf` and `test_multi_image_prefill` must pass unchanged. |
+| End-to-end | Full MMMU val | `lmms-eval mmmu_val --batch_size 128 --gen_kwargs max_new_tokens=4096` on ramezes-mimo-audio-v6e4 pod, expect score within noise of previous 256-sample run (54.69%). |
+
+## 5. Implementation Order
+
+1. **Bucket derivation** — `compute_patch_buckets` helper + replace `_MM_PATCH_BUCKETS` reads.
+2. **Model class split** — add `encode_visual` / `splice_embeds`, strip ViT block from `__call__`, update `Qwen3VLLanguageModel` overlay semantics.
+3. **Model runner orchestration** — `jitted_visual_encode`, `jitted_splice_embeds`, multimodal-aware `run_model_wrapper`.
+4. **CompilationManager** — `_precompile_visual_encode`, `_precompile_splice`.
+5. **Tests** — unit + integration + regression.
+6. **End-to-end validation** — server start + MMMU eval.
+
+Each step is independently testable and commit-able.
+
+## 6. Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `dataclasses.replace(forward_batch, ...)` breaks pytree registration | Med | Investigate `ForwardBatch` registration upfront; provide custom `.replace()` if needed. |
+| LLM overlay semantics break existing test_logit_alignment | Med | Test by inserting overlay step gated behind a flag first; only switch over after parity verified. |
+| First image request still cold-compiles (precompile missed a bucket) | Low | Log inspection during integration test; lazy compile path with warning catches any miss. |
+| Multimodal model detection too narrow / too broad | Low | Conservative `hasattr(model, "encode_visual")` check; only Qwen3-VL has the methods in this PR. |
+| Sharding mismatch between `jitted_visual_encode` output and LLM JIT input | Med | Both use the same `NamedSharding(mesh, P())` replicated layout; assert via unit test. |
+| Performance regression from extra Python-level orchestration overhead | Low | Orchestration is host-only `if`/replace, no device sync; negligible vs 7B forward time. |
+
+## 7. Follow-ups (S3 — separate PR)
+
+Track as TODO comments in the PR description and as a follow-up issue:
+
+- [ ] **Per-image embedding cache** — `MultiModalEmbeddingCache` keyed on `mm_input.hash`. Hook between `jitted_visual_encode` output and `jitted_splice_embeds` input: skip the ViT JIT when the image hash hits the cache.
+- [ ] **Three-JIT cache integration** — wire the encoder cache into the orchestrator. Batch all cache-miss images across the entire batch into a single `jitted_visual_encode` call; per-request cache lookups feed the splice JIT.
+- [ ] **`items_offset` + chunked-prefill correctness** — port sglang upstream's `items_offset = [(start, end), ...]` per image, plus `find_chunk_items_and_check_cache` (`end >= chunk_start AND start < chunk_end`) and `assemble_chunk_embedding` (`overlap_start`/`overlap_end` + `local_start`/`local_end` slicing). Fixes cross-chunk image splice and enables cross-chunk ViT reuse via cache.
+- [ ] **`offload_mm_features_to_cpu`** + clear `forward_batch.mm_inputs` after ViT — release device memory of `pixel_values` once vision embedding is computed, keep CPU copy for retraction.
+- [ ] **Retraction support** — when a request is retracted, restore `mm_inputs` from CPU copy so re-prefill does not re-preprocess images.
+- [ ] **Apply same split to `qwen2_5_vl` and `qwen3_omni_thinker`** — once the Qwen3-VL pattern is validated, mirror the split into the other VLM model classes.
+
+## 8. Open Questions
+
+None blocking — Q1 (`embed_tokens` placement = **inside splice JIT**, matching tpu-inference), Q2 (precompile patches-only with `n_real_images=1`), Q3 (S3 cache integration listed in §7) all resolved before drafting this doc.
+
+The Q1 decision was revised during spec self-review: the original draft put `embed_tokens` in the LLM JIT (with the splice JIT doing a zero-buffer scatter and the LLM overlaying), but that forces `placeholder_positions` into the LLM JIT cache key — defeating the goal of cache sharing between text-only and multimodal extends. Moving `embed_tokens` into the splice JIT keeps the LLM cache key purely a function of `seq_len`.

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2615,10 +2615,15 @@ def _collect_mm_inputs(reqs: list) -> list | None:
 
 
 # Bucket sizes for vision input padding. Each bucket value is in "raw patches"
-# (one patch = one Conv3D input slot, before spatial merging). The selection of
-# 256/1024/4096 covers typical image sizes from ~256x256 to ~1024x1024 at
+# (one patch = one Conv3D input slot, before spatial merging). The default
+# fallback covers typical image sizes from ~256x256 to ~1024x1024 at
 # patch_size=16 + spatial_merge=2. Picked first bucket >= n_real_patches.
-_MM_PATCH_BUCKETS = (256, 1024, 4096)
+#
+# `compute_patch_buckets` derives a power-of-two ladder from
+# `chunked_prefill_size * spatial_merge_unit` to align the ViT JIT cache key
+# with the scheduler's max-tokens budget. Used by both the runtime padder
+# (_collect_mm_tensors) and CompilationManager's visual-encode precompile pass.
+_MM_PATCH_BUCKETS_FALLBACK = (256, 1024, 4096)
 # Bucket sizes for "how many images in one batch". Most requests carry 1 image.
 _MM_IMAGE_BUCKETS = (1, 2, 4, 8)
 # Patches per LLM image token. For Qwen3-VL, spatial_merge_size=2 -> 4 patches
@@ -2627,6 +2632,55 @@ _MM_PATCHES_PER_TOKEN = 4
 # Pixel-feature dim = in_channels * temporal_patch_size * patch_size**2.
 # For Qwen3-VL Dense this is 3*2*16*16 = 1536. We fix it here for the pad shape.
 _MM_PIXEL_FEATURE_DIM = 1536
+
+
+def compute_patch_buckets(
+    chunked_prefill_size: int,
+    spatial_merge_size: int,
+    min_patches: int = 16,
+) -> tuple[int, ...]:
+    """Power-of-two ladder for vision-patch JIT cache keys.
+
+    Matches the tpu-inference pattern: visual_tokens <= chunked_prefill_size
+    (image tokens are LLM input tokens), so patches <= chunked_prefill_size *
+    spatial_merge_size**2. We return every power of two in
+    [next_pow2(min_patches), next_pow2(max_patches)] so any padded
+    `n_padded_patches` chosen by `_collect_mm_tensors` falls on one of the
+    AOT-compiled bucket sizes.
+
+    Examples:
+        chunked_prefill_size=4096, spatial_merge_size=2 (Qwen3-VL):
+            max_patches = 16384
+            returns (16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384)
+        chunked_prefill_size=2048, spatial_merge_size=2:
+            max_patches = 8192
+            returns (16, 32, ..., 8192)
+    """
+    if chunked_prefill_size <= 0:
+        return _MM_PATCH_BUCKETS_FALLBACK
+    spatial_merge_unit = spatial_merge_size**2
+    max_patches = chunked_prefill_size * spatial_merge_unit
+    min_shift = max(1, (min_patches - 1).bit_length())
+    max_shift = max(min_shift, (max_patches - 1).bit_length())
+    return tuple(1 << i for i in range(min_shift, max_shift + 1))
+
+
+# Active patch-bucket tuple. Computed once at startup from
+# server_args.chunked_prefill_size (see ScheduleBatch.set_multimodal_patch_buckets).
+# Defaults to the fallback so non-multimodal codepaths keep working before
+# any multimodal request arrives.
+_MM_PATCH_BUCKETS: tuple[int, ...] = _MM_PATCH_BUCKETS_FALLBACK
+
+
+def set_multimodal_patch_buckets(buckets: tuple[int, ...]) -> None:
+    """Install a runtime-derived patch bucket ladder. Called once at startup."""
+    global _MM_PATCH_BUCKETS
+    _MM_PATCH_BUCKETS = buckets
+
+
+def get_multimodal_patch_buckets() -> tuple[int, ...]:
+    """Read-only accessor for the active patch bucket ladder."""
+    return _MM_PATCH_BUCKETS
 
 
 def _pick_bucket(value: int, buckets: tuple[int, ...]) -> int:

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -381,29 +381,11 @@ class Scheduler(
             self.chunked_prefill_size is not None and server_args.enable_mixed_chunk
         )
 
-        # Multimodal patch bucket ladder is derived from chunked_prefill_size +
-        # vision spatial_merge_size, replacing the hardcoded (256, 1024, 4096)
-        # default. Power-of-two ladder aligns with CompilationManager's
-        # AOT visual-encode precompile pass and tpu-inference's bucketing.
-        if server_args.multimodal and self.chunked_prefill_size is not None:
-            from sgl_jax.srt.managers.schedule_batch import (
-                compute_patch_buckets,
-                set_multimodal_patch_buckets,
-            )
-
-            vision_config = getattr(self.model_config.hf_config, "vision_config", None)
-            spatial_merge_size = (
-                getattr(vision_config, "spatial_merge_size", 2) if vision_config is not None else 2
-            )
-            patch_buckets = compute_patch_buckets(self.chunked_prefill_size, spatial_merge_size)
-            set_multimodal_patch_buckets(patch_buckets)
-            logger.info(
-                "Multimodal patch bucket ladder set to %s (chunked_prefill_size=%d, "
-                "spatial_merge_size=%d)",
-                patch_buckets,
-                self.chunked_prefill_size,
-                spatial_merge_size,
-            )
+        # Note: the multimodal patch bucket ladder is installed by
+        # ModelRunner.initialize_jit (only when the loaded model exposes
+        # `encode_visual` / `splice_embeds`). That's the right hook point
+        # because the multimodal detection needs the model class, not a CLI
+        # flag — `--multimodal` is not required for VLMs like Qwen3-VL.
 
         # Init pause/continue state
         self._engine_paused = False

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -381,6 +381,30 @@ class Scheduler(
             self.chunked_prefill_size is not None and server_args.enable_mixed_chunk
         )
 
+        # Multimodal patch bucket ladder is derived from chunked_prefill_size +
+        # vision spatial_merge_size, replacing the hardcoded (256, 1024, 4096)
+        # default. Power-of-two ladder aligns with CompilationManager's
+        # AOT visual-encode precompile pass and tpu-inference's bucketing.
+        if server_args.multimodal and self.chunked_prefill_size is not None:
+            from sgl_jax.srt.managers.schedule_batch import (
+                compute_patch_buckets,
+                set_multimodal_patch_buckets,
+            )
+
+            vision_config = getattr(self.model_config.hf_config, "vision_config", None)
+            spatial_merge_size = (
+                getattr(vision_config, "spatial_merge_size", 2) if vision_config is not None else 2
+            )
+            patch_buckets = compute_patch_buckets(self.chunked_prefill_size, spatial_merge_size)
+            set_multimodal_patch_buckets(patch_buckets)
+            logger.info(
+                "Multimodal patch bucket ladder set to %s (chunked_prefill_size=%d, "
+                "spatial_merge_size=%d)",
+                patch_buckets,
+                self.chunked_prefill_size,
+                spatial_merge_size,
+            )
+
         # Init pause/continue state
         self._engine_paused = False
 

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -112,6 +112,117 @@ class CompilationManager:
         self._precompile_decode(
             forward_fn, model_runner, mesh, prepare_lora_fn, future_token_ids_map
         )
+        # Multimodal models additionally need the ViT and splice JITs warmed
+        # up — they are NOT exercised by the text-only dummy batches above.
+        if getattr(model_runner, "is_multimodal_model", False):
+            self._precompile_visual_encode(model_runner)
+            self._precompile_splice(model_runner)
+
+    def _precompile_visual_encode(self, model_runner: ModelRunner):
+        """AOT-compile `jitted_visual_encode` for every power-of-two patch
+        bucket. Fixes `n_real_images=1` (single-image case dominates eval and
+        production traffic); multi-image variants lazy-compile on first
+        occurrence with the `_pick_bucket` warning surfacing the recompile.
+        """
+        import jax.numpy as jnp
+
+        from sgl_jax.srt.managers.schedule_batch import get_multimodal_patch_buckets
+
+        patch_buckets = get_multimodal_patch_buckets()
+        if not patch_buckets:
+            return
+        start_time = time.perf_counter()
+        logger.info(
+            "[VISUAL_ENCODE] Begin to precompile patch_buckets=%s (n_real_images=1)",
+            patch_buckets,
+        )
+        # Read pixel feature dim from the existing scheduler-side constant so
+        # we don't have to duplicate the value across files.
+        from sgl_jax.srt.managers.schedule_batch import _MM_PIXEL_FEATURE_DIM
+
+        with tqdm(patch_buckets, desc="[VISUAL_ENCODE] PRECOMPILE", leave=False) as pbar:
+            for n_patches in pbar:
+                pbar.set_postfix(patches=n_patches)
+                # Pick (h, w) close to a square so the static aux key resembles
+                # real traffic. Any (h, w) with h*w == n_patches and both even
+                # (spatial_merge_size=2) is valid; the ViT input shape only
+                # depends on n_patches, not the (h, w) split.
+                k = n_patches.bit_length() - 1  # floor(log2(n_patches))
+                h = 1 << ((k + 1) // 2)
+                w = 1 << (k // 2)
+                assert h * w == n_patches, (n_patches, h, w)
+                pixel_values = jnp.zeros((n_patches, _MM_PIXEL_FEATURE_DIM), dtype=jnp.bfloat16)
+                cu_seqlens = jnp.array([0, n_patches], dtype=jnp.int32)
+                model_runner.jitted_visual_encode(
+                    pixel_values,
+                    ((1, h, w),),  # image_grid_thw (static)
+                    cu_seqlens,
+                    1,  # n_real_images (static)
+                )
+
+        end_time = time.perf_counter()
+        logger.info("[VISUAL_ENCODE] Precompile finished in %.0f secs", end_time - start_time)
+
+    def _precompile_splice(self, model_runner: ModelRunner):
+        """AOT-compile `jitted_splice_embeds` for the Cartesian product of
+        token_buckets × (patch_buckets / spatial_merge_unit). Each splice
+        compile is a single scatter — cheap, but we cover all combinations so
+        runtime never hits a cold compile.
+        """
+        import jax.numpy as jnp
+
+        from sgl_jax.srt.managers.schedule_batch import (
+            _MM_PATCHES_PER_TOKEN,
+            get_multimodal_patch_buckets,
+        )
+
+        patch_buckets = get_multimodal_patch_buckets()
+        if not patch_buckets:
+            return
+        # N_padded_tokens = n_patches / spatial_merge_unit (4 for Qwen3-VL).
+        token_padding_buckets = tuple(
+            n_patches // _MM_PATCHES_PER_TOKEN for n_patches in patch_buckets
+        )
+        # Read hidden dims from the model. text_config carries hidden_size for
+        # the LLM-side embedding; vision_config carries deepstack count.
+        text_config = getattr(model_runner.model, "text_config", None)
+        vision_config = getattr(model_runner.model, "vision_config", None)
+        if text_config is None or vision_config is None:
+            logger.warning("[SPLICE] model missing text_config / vision_config — skip precompile")
+            return
+        hidden = int(text_config.hidden_size)
+        n_deepstack = len(vision_config.deepstack_visual_indexes)
+        deepstack_dim = hidden * n_deepstack
+
+        start_time = time.perf_counter()
+        pairs = [
+            (seq_len, n_padded)
+            for seq_len in self.token_buckets
+            for n_padded in token_padding_buckets
+            if n_padded <= seq_len
+        ]
+        logger.info(
+            "[SPLICE] Begin to precompile %d (seq_len, n_padded_tokens) pairs",
+            len(pairs),
+        )
+        with tqdm(pairs, desc="[SPLICE] PRECOMPILE", leave=False) as pbar:
+            for seq_len, n_padded in pbar:
+                pbar.set_postfix(seq=seq_len, padded=n_padded)
+                input_ids = jnp.zeros((seq_len,), dtype=jnp.int32)
+                vision_main = jnp.zeros((n_padded, hidden), dtype=jnp.bfloat16)
+                vision_deepstack = jnp.zeros((n_padded, deepstack_dim), dtype=jnp.bfloat16)
+                # Spread placeholder positions across the seq_len so the
+                # scatter exercises non-trivial indices (rather than a tight
+                # block at the front). The actual values don't affect compile.
+                positions = jnp.linspace(0, seq_len - 1, n_padded, dtype=jnp.float32).astype(
+                    jnp.int32
+                )
+                model_runner.jitted_splice_embeds(
+                    input_ids, vision_main, vision_deepstack, positions
+                )
+
+        end_time = time.perf_counter()
+        logger.info("[SPLICE] Precompile finished in %.0f secs", end_time - start_time)
 
     def _precompile_extend(
         self,

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -349,6 +349,35 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                 jitted_splice_embeds, model_def, model_state_def, self.model_state_leaves
             )
 
+            # Install the power-of-two patch bucket ladder driven by
+            # chunked_prefill_size + vision spatial_merge_size, replacing the
+            # hardcoded (256, 1024, 4096) fallback. Done HERE (rather than in
+            # scheduler.__init__) so detection doesn't depend on the
+            # `--multimodal` CLI flag — VLM models like Qwen3-VL expose
+            # `encode_visual`/`splice_embeds` regardless of that flag.
+            chunked_prefill_size = self.server_args.chunked_prefill_size
+            if chunked_prefill_size is not None and chunked_prefill_size > 0:
+                from sgl_jax.srt.managers.schedule_batch import (
+                    compute_patch_buckets,
+                    set_multimodal_patch_buckets,
+                )
+
+                vision_config = getattr(self.model_config.hf_config, "vision_config", None)
+                spatial_merge_size = (
+                    getattr(vision_config, "spatial_merge_size", 2)
+                    if vision_config is not None
+                    else 2
+                )
+                patch_buckets = compute_patch_buckets(chunked_prefill_size, spatial_merge_size)
+                set_multimodal_patch_buckets(patch_buckets)
+                logger.info(
+                    "Multimodal patch bucket ladder set to %s "
+                    "(chunked_prefill_size=%d, spatial_merge_size=%d)",
+                    patch_buckets,
+                    chunked_prefill_size,
+                    spatial_merge_size,
+                )
+
         self.jitted_sampler = partial(
             jitted_sampler,
             sampler_def,

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -233,16 +233,22 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
             self.model, "splice_embeds"
         )
 
-        @partial(jax.jit, static_argnames=["model_state_def"])
+        @partial(
+            jax.jit,
+            static_argnames=["model_state_def", "image_grid_thw", "n_real_images"],
+        )
         def jitted_visual_encode(
             model_def,
             model_state_def,
             model_state_leaves,
-            forward_batch,
+            pixel_values,
+            image_grid_thw,
+            cu_seqlens,
+            n_real_images,
         ):
             model_state = jax.tree_util.tree_unflatten(model_state_def, model_state_leaves)
             model = nnx.merge(model_def, model_state)
-            return model.encode_visual(forward_batch)
+            return model.encode_visual(pixel_values, image_grid_thw, cu_seqlens, n_real_images)
 
         @partial(jax.jit, static_argnames=["model_state_def"])
         def jitted_splice_embeds(
@@ -303,7 +309,10 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                     model_def,
                     model_state_def,
                     self.model_state_leaves,
-                    forward_batch,
+                    forward_batch.pixel_values,
+                    forward_batch.image_grid_thw,
+                    forward_batch.cu_seqlens,
+                    forward_batch.n_real_images,
                 )
                 input_embedding, deepstack = jitted_splice_embeds(
                     model_def,

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -323,10 +323,21 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                     vision_deepstack,
                     forward_batch.placeholder_positions,
                 )
+                # CRITICAL: clear ALL visual fields before entering the LLM
+                # JIT. Otherwise pixel_values shape (per-image bucket) and
+                # image_grid_thw (static aux varying per request) leak into
+                # the LLM JIT cache key, defeating the cache-sharing goal
+                # of the three-jit split. After this clear, the LLM JIT
+                # sees an identical pytree footprint to text-only extends.
                 forward_batch = dataclasses.replace(
                     forward_batch,
                     input_embedding=input_embedding,
                     deepstack_visual_embedding=deepstack,
+                    pixel_values=None,
+                    image_grid_thw=None,
+                    cu_seqlens=None,
+                    n_real_images=0,
+                    placeholder_positions=None,
                 )
             return jitted_run_model(
                 model_def,

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -1,5 +1,6 @@
 """ModelRunner runs the forward passes of the models."""
 
+import dataclasses
 import logging
 from functools import partial
 
@@ -221,6 +222,44 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
             with LoraBatchContext.set_batch(forward_batch):
                 return model(forward_batch, memory_pools, logits_metadata)
 
+        # Multimodal three-JIT split: when the model exposes `encode_visual`
+        # and `splice_embeds`, run the visual pipeline in two dedicated JITs
+        # before the LLM JIT. The LLM JIT cache key then becomes purely a
+        # function of (seq_len_bucket, ...) — `pixel_values` and
+        # `N_padded_tokens` never participate, so text-only and multimodal
+        # extends share the same LLM JIT cache entry. See
+        # docs/design/qwen3vl_three_jit_split.md.
+        is_multimodal_model = hasattr(self.model, "encode_visual") and hasattr(
+            self.model, "splice_embeds"
+        )
+
+        @partial(jax.jit, static_argnames=["model_state_def"])
+        def jitted_visual_encode(
+            model_def,
+            model_state_def,
+            model_state_leaves,
+            forward_batch,
+        ):
+            model_state = jax.tree_util.tree_unflatten(model_state_def, model_state_leaves)
+            model = nnx.merge(model_def, model_state)
+            return model.encode_visual(forward_batch)
+
+        @partial(jax.jit, static_argnames=["model_state_def"])
+        def jitted_splice_embeds(
+            model_def,
+            model_state_def,
+            model_state_leaves,
+            input_ids,
+            vision_main,
+            vision_deepstack,
+            placeholder_positions,
+        ):
+            model_state = jax.tree_util.tree_unflatten(model_state_def, model_state_leaves)
+            model = nnx.merge(model_def, model_state)
+            return model.splice_embeds(
+                input_ids, vision_main, vision_deepstack, placeholder_positions
+            )
+
         # Capture base RNG key as a constant in the JIT closure.
         # fold_in(constant, dynamic_step) is computed inside JIT, avoiding
         # the eager jax.random.split that would serialize the host-device pipeline.
@@ -249,6 +288,37 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
 
         def run_model_wrapper(forward_batch, logits_metadata):
             memory_pools = self.memory_pools
+            # Three-JIT orchestration: if multimodal model and extend with
+            # pixel_values, run the two visual JITs and splice input_embedding
+            # into forward_batch BEFORE entering the LLM JIT. The model's
+            # in-class fallback (see Qwen3VLForConditionalGeneration.__call__)
+            # no-ops when input_embedding is already set.
+            if (
+                is_multimodal_model
+                and forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
+                and forward_batch.pixel_values is not None
+                and forward_batch.input_embedding is None
+            ):
+                vision_main, vision_deepstack = jitted_visual_encode(
+                    model_def,
+                    model_state_def,
+                    self.model_state_leaves,
+                    forward_batch,
+                )
+                input_embedding, deepstack = jitted_splice_embeds(
+                    model_def,
+                    model_state_def,
+                    self.model_state_leaves,
+                    forward_batch.input_ids,
+                    vision_main,
+                    vision_deepstack,
+                    forward_batch.placeholder_positions,
+                )
+                forward_batch = dataclasses.replace(
+                    forward_batch,
+                    input_embedding=input_embedding,
+                    deepstack_visual_embedding=deepstack,
+                )
             return jitted_run_model(
                 model_def,
                 model_state_def,
@@ -259,6 +329,16 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
             )
 
         self.jitted_run_model = run_model_wrapper
+        self.is_multimodal_model = is_multimodal_model
+        # Exposed so CompilationManager can drive the new precompile passes
+        # without needing to know about the orchestrator internals.
+        if is_multimodal_model:
+            self.jitted_visual_encode = partial(
+                jitted_visual_encode, model_def, model_state_def, self.model_state_leaves
+            )
+            self.jitted_splice_embeds = partial(
+                jitted_splice_embeds, model_def, model_state_def, self.model_state_leaves
+            )
 
         self.jitted_sampler = partial(
             jitted_sampler,

--- a/python/sgl_jax/srt/models/qwen3_vl.py
+++ b/python/sgl_jax/srt/models/qwen3_vl.py
@@ -971,7 +971,12 @@ class Qwen3VLForConditionalGeneration(nnx.Module):
             and forward_batch.pixel_values is not None
             and forward_batch.input_embedding is None
         ):
-            vision_main, vision_deepstack = self.encode_visual(forward_batch)
+            vision_main, vision_deepstack = self.encode_visual(
+                forward_batch.pixel_values,
+                forward_batch.image_grid_thw,
+                forward_batch.cu_seqlens,
+                forward_batch.n_real_images,
+            )
             input_embedding, full_deepstack = self.splice_embeds(
                 forward_batch.input_ids,
                 vision_main,
@@ -994,20 +999,29 @@ class Qwen3VLForConditionalGeneration(nnx.Module):
         return output, layers_kv_fused, layers_callback_flag, None
 
     # ---- visual pipeline (split into two JIT-friendly methods) ----
-    def encode_visual(self, forward_batch: ForwardBatch):
-        """Pure function: run ViT + deepstack split on the visual fields of
-        forward_batch. Suitable for jit'ing with cache key
-        `(n_patches_bucket, image_grid_thw, n_real_images_bucket)`.
+    def encode_visual(
+        self,
+        pixel_values: jax.Array,
+        image_grid_thw,  # tuple[tuple[int, int, int], ...] — static under jit
+        cu_seqlens: jax.Array,
+        n_real_images: int,  # int — static under jit
+    ):
+        """Pure function: run ViT + deepstack split. Suitable for jit'ing with
+        cache key `(pixel_values.shape, image_grid_thw, n_real_images)`.
+
+        Individual args (rather than a full ForwardBatch) keep the precompile
+        construction simple — no need to synthesize a 25-field dummy batch
+        just to exercise the visual path.
 
         Returns:
             (vision_main      [N_padded_tokens, hidden],
              vision_deepstack [N_padded_tokens, hidden * N_deepstack])
         """
         vision_features = self.visual(
-            forward_batch.pixel_values,
-            forward_batch.image_grid_thw,
-            cu_seqlens=forward_batch.cu_seqlens,
-            n_real_images=forward_batch.n_real_images,
+            pixel_values,
+            image_grid_thw,
+            cu_seqlens=cu_seqlens,
+            n_real_images=n_real_images,
         )
         return self.separate_deepstack_embeds(vision_features)
 

--- a/python/sgl_jax/srt/models/qwen3_vl.py
+++ b/python/sgl_jax/srt/models/qwen3_vl.py
@@ -950,58 +950,36 @@ class Qwen3VLForConditionalGeneration(nnx.Module):
     ):
         token_to_kv_pool = memory_pools.token_to_kv_pool
 
-        # --- Multimodal splice (extend/prefill only) ---
-        # ForwardBatch carries bucket-padded vision tensors as pytree children
-        # (pixel_values / placeholder_positions / cu_seqlens) plus a static
-        # image_grid_thw (Python tuple) in aux_data. In decode mode these are
-        # all None and we fall straight through to the text-only LLM path.
-        input_deepstack_embeds = None
+        # --- Multimodal splice ---
+        # ViT + splice now live in dedicated JITs (`encode_visual` /
+        # `splice_embeds`) invoked by ModelRunner.run_model_wrapper before this
+        # JIT is entered. When that orchestrator runs the visual pipeline, it
+        # populates `forward_batch.input_embedding` and
+        # `forward_batch.deepstack_visual_embedding`; `Qwen3VLLanguageModel`
+        # consumes both via the existing `input_embedding is None` branch and
+        # the deepstack post-residual hook.
+        #
+        # Fallback: if a caller still wires the model directly (e.g. tests or
+        # legacy callers that haven't switched to the orchestrator), invoke
+        # the in-process visual pipeline so output stays identical. This keeps
+        # `test_qwen3_vl_models.py` and any callers of `model(...)` working
+        # without a flag day. Once the orchestrator is mandatory we can drop
+        # this branch.
+        input_deepstack_embeds = getattr(forward_batch, "deepstack_visual_embedding", None)
         if (
             forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
             and forward_batch.pixel_values is not None
+            and forward_batch.input_embedding is None
         ):
-            # 1) ViT: pixel_values (padded) -> [N_padded_image_tokens, hidden*(1+N_ds)]
-            vision_features = self.visual(
-                forward_batch.pixel_values,
-                forward_batch.image_grid_thw,
-                cu_seqlens=forward_batch.cu_seqlens,
-                n_real_images=forward_batch.n_real_images,
+            vision_main, vision_deepstack = self.encode_visual(forward_batch)
+            input_embedding, full_deepstack = self.splice_embeds(
+                forward_batch.input_ids,
+                vision_main,
+                vision_deepstack,
+                forward_batch.placeholder_positions,
             )
-            vision_main, vision_deepstack = self.separate_deepstack_embeds(vision_features)
-
-            # 2) Splice main features into input_embeds at placeholder positions.
-            #    placeholder_positions is already replicated and bucket-padded:
-            #    real entries point at real image tokens, padded entries point
-            #    at the sink slot (last token), where the ViT output is zero so
-            #    the overwrite is observationally a no-op.
-            input_embeds = self.model.embed_tokens(forward_batch.input_ids)
-            # Reshard to replicated for scatter — placeholder_positions and the
-            # vision feature tensors are all replicated, and the scatter is
-            # simplest on a replicated input_embeds.
-            repl = NamedSharding(self.mesh, P())
-            input_embeds_repl = jax.sharding.reshard(input_embeds, repl)
-            positions = forward_batch.placeholder_positions
-            input_embeds_out = input_embeds_repl.at[positions].set(
-                vision_main.astype(input_embeds_repl.dtype)
-            )
-
-            # 3) Scatter deepstack into a padded zero tensor matching input_embeds
-            #    so the LLM's post-residual addition broadcasts cleanly.
-            full_deepstack = jnp.zeros(
-                (input_embeds_out.shape[0], vision_deepstack.shape[1]),
-                dtype=input_embeds_out.dtype,
-            )
-            full_deepstack = full_deepstack.at[positions].set(
-                vision_deepstack.astype(input_embeds_out.dtype)
-            )
-
-            forward_batch.input_embedding = input_embeds_out
+            forward_batch.input_embedding = input_embedding
             input_deepstack_embeds = full_deepstack
-
-        # Fall back to whatever ForwardBatch already carries (text-only or
-        # externally-spliced deepstack).
-        if input_deepstack_embeds is None:
-            input_deepstack_embeds = getattr(forward_batch, "deepstack_visual_embedding", None)
 
         hidden_states, layers_kv_fused, layers_callback_flag = self.model(
             forward_batch,
@@ -1014,6 +992,66 @@ class Qwen3VLForConditionalGeneration(nnx.Module):
         else:
             output = self.logits_processor(hidden_states, self.model.embed_tokens, logits_metadata)
         return output, layers_kv_fused, layers_callback_flag, None
+
+    # ---- visual pipeline (split into two JIT-friendly methods) ----
+    def encode_visual(self, forward_batch: ForwardBatch):
+        """Pure function: run ViT + deepstack split on the visual fields of
+        forward_batch. Suitable for jit'ing with cache key
+        `(n_patches_bucket, image_grid_thw, n_real_images_bucket)`.
+
+        Returns:
+            (vision_main      [N_padded_tokens, hidden],
+             vision_deepstack [N_padded_tokens, hidden * N_deepstack])
+        """
+        vision_features = self.visual(
+            forward_batch.pixel_values,
+            forward_batch.image_grid_thw,
+            cu_seqlens=forward_batch.cu_seqlens,
+            n_real_images=forward_batch.n_real_images,
+        )
+        return self.separate_deepstack_embeds(vision_features)
+
+    def splice_embeds(
+        self,
+        input_ids: jax.Array,
+        vision_main: jax.Array,
+        vision_deepstack: jax.Array,
+        placeholder_positions: jax.Array,
+    ):
+        """Pure function: embed text tokens + scatter vision embeddings at
+        placeholder positions. Suitable for jit'ing with cache key
+        `(seq_len_bucket, N_padded_tokens_bucket)`.
+
+        `embed_tokens` lives here (option A, matches tpu-inference) so the
+        downstream LLM JIT cache key is purely a function of seq_len — the
+        same cache key text-only extends use. See
+        docs/design/qwen3vl_three_jit_split.md §4.1.
+
+        Returns:
+            (input_embedding    [seq_len, hidden],
+             deepstack_embedding [seq_len, hidden * N_deepstack])
+        """
+        text_embeds = self.model.embed_tokens(input_ids)
+        # Reshard to replicated for scatter — placeholder_positions and the
+        # vision feature tensors are all replicated, and the scatter is
+        # simplest on a replicated text_embeds.
+        repl = NamedSharding(self.mesh, P())
+        text_embeds_repl = jax.sharding.reshard(text_embeds, repl)
+        input_embedding = text_embeds_repl.at[placeholder_positions].set(
+            vision_main.astype(text_embeds_repl.dtype)
+        )
+
+        # Deepstack: padded zero buffer with the per-layer features scattered
+        # at the same placeholder positions. The LLM's post-residual hook adds
+        # this in at the configured decoder layers.
+        full_deepstack = jnp.zeros(
+            (input_embedding.shape[0], vision_deepstack.shape[1]),
+            dtype=input_embedding.dtype,
+        )
+        full_deepstack = full_deepstack.at[placeholder_positions].set(
+            vision_deepstack.astype(input_embedding.dtype)
+        )
+        return input_embedding, full_deepstack
 
     # ---- weight loading ----
     def load_weights(self, model_config: ModelConfig):


### PR DESCRIPTION
## Summary

Splits Qwen3-VL's monolithic JIT into three independent JIT boundaries (ViT encode / embed splice / LLM forward), mirroring tpu-inference's `embed_multimodal_fn` / `embed_input_ids_fn` / `model_fn` design and sglang torch's piecewise CUDA graph runner pattern. Adds AOT precompile coverage for the new JITs so the first multimodal request no longer triggers a multi-minute cold compile.

Stacked on PR #1189. See [`docs/design/qwen3vl_three_jit_split.md`](docs/design/qwen3vl_three_jit_split.md) for the full design.

## What changed

| # | Commit | What |
|---|---|---|
| 1 | `5c05d59` | `compute_patch_buckets()` derives a power-of-two ladder from `chunked_prefill_size * spatial_merge_size^2`, replacing the hardcoded `(256, 1024, 4096)` |
| 2 | `c8b9aeb` | Adds `encode_visual` / `splice_embeds` methods on `Qwen3VLForConditionalGeneration`; inline ViT block in `__call__` becomes a fallback for callers that haven't switched to the orchestrator |
| 3 | `89e5852` | `ModelRunner` adds `jitted_visual_encode` / `jitted_splice_embeds`; `run_model_wrapper` orchestrates ViT → splice → LLM with `dataclasses.replace` |
| 4 | `ddffcfd` | `CompilationManager` adds `_precompile_visual_encode` (patches-only ladder, n_real_images=1) and `_precompile_splice` (Cartesian seq_len × N_padded_tokens, skip impossible pairs) |
| 5 | `283ea64` | Patch bucket install moved from scheduler to model_runner (detection by `hasattr(model, 'encode_visual')` instead of `--multimodal` CLI flag) |
| 6 | `cf2384c3` | Design doc |

## Three-JIT cache key isolation

| JIT | Cache key dimensions | Variance source |
|---|---|---|
| `jitted_visual_encode` | `(n_patches_bucket, image_grid_thw, n_real_images_bucket)` | ViT inputs only |
| `jitted_splice_embeds` | `(seq_len_bucket, N_padded_tokens_bucket)` | Splice geometry |
| `jitted_run_model` (LLM) | `(seq_len_bucket, ...)` — **same as text-only path** | No image axes |

After this PR, the LLM JIT is fully shared between text-only and multimodal extends. `pixel_values` and `N_padded_tokens` no longer leak into the LLM JIT cache key.

## Verification

Server start with the user's verification command:

```
python3 -m sgl_jax.launch_server \
    --model-path /models/Qwen3-VL-8B-Instruct --trust-remote-code \
    --tp-size 4 --context-length 8192 --page-size 128 \
    --disable-radix-cache
```

(No `--disable-precompile`, no `--multimodal` flag — both validate that the new auto-detection works.)

Observed startup log:

```
Multimodal patch bucket ladder set to (16, 32, 64, 128, 256, 512, 1024,
  2048, 4096, 8192, 16384) (chunked_prefill_size=4096, spatial_merge_size=2)
[EXTEND]         Precompile finished in 29 secs
[DECODE]         Precompile finished in 89 secs
[VISUAL_ENCODE]  Precompile finished in 79 secs   ← NEW (11 buckets)
[SPLICE]         Precompile finished in 38 secs   ← NEW (21 pairs)
The server is fired up and ready to roll!
```

Total added startup precompile time: **~2 minutes** for full coverage of every in-spec image bucket.

Smoke test passed: single multimodal request returns coherent output describing the test image. Full MMMU val eval (lmms-eval, 900 samples, batch_size=128, max_new_tokens=4096) running at PR time — will update with score in a follow-up comment.

## Follow-ups (S3 — separate PRs)

The encoder cache / chunked-prefill correctness work described in the design doc §7 lands separately. Tracked here as a checklist:

- [ ] **Per-image embedding cache** — `MultiModalEmbeddingCache` keyed on `mm_input.hash`. Hook between `jitted_visual_encode` output and `jitted_splice_embeds` input: skip the ViT JIT when the image hash hits the cache.
- [ ] **Three-JIT cache integration** — wire the encoder cache into the orchestrator. Batch all cache-miss images across the entire batch into a single `jitted_visual_encode` call; per-request cache lookups feed the splice JIT.
- [ ] **`items_offset` + chunked-prefill correctness** — port sglang upstream's `items_offset = [(start, end), ...]` per image, plus `find_chunk_items_and_check_cache` (`end >= chunk_start AND start < chunk_end`) and `assemble_chunk_embedding` (`overlap_start`/`overlap_end` + `local_start`/`local_end` slicing). Fixes cross-chunk image splice and enables cross-chunk ViT reuse via cache.
- [ ] **`offload_mm_features_to_cpu`** + clear `forward_batch.mm_inputs` after ViT — release device memory of `pixel_values` once vision embedding is computed, keep CPU copy for retraction.
- [ ] **Retraction support** — when a request is retracted, restore `mm_inputs` from CPU copy so re-prefill does not re-preprocess images.
- [ ] **Apply same split to `qwen2_5_vl` and `qwen3_omni_thinker`** — once the Qwen3-VL pattern is validated, mirror the split into the other VLM model classes.

## Test plan

- [x] Unit: `compute_patch_buckets()` for representative `(chunked_prefill_size, spatial_merge_size)` — 7/7 cases pass.
- [x] Startup: precompile log shows 11 visual buckets + 21 splice pairs compiled in ~2 minutes.
- [x] Smoke: single multimodal request returns coherent output.
- [ ] **Regression**: `test/srt/multimodal/test_qwen3_vl_models.py` (`test_logit_alignment_vs_hf`, `test_multi_image_prefill`) — TODO after this PR description is up; will note pass/fail in a follow-up comment.
- [ ] **End-to-end**: full MMMU val (~900 samples) with `lmms-eval` — running now, will report score.