### PR TITLE
ci: add Slack notification for nightly failures (P3-2)

### DIFF
--- a/.github/workflows/nightly-slack-notify.yml
+++ b/.github/workflows/nightly-slack-notify.yml
@@ -1,0 +1,163 @@
+name: Nightly Slack Notify
+
+on:
+  workflow_run:
+    workflows:
+      - "Nightly Test"
+      - "Nightly Test Daily"
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Workflow run ID to check (for manual testing)"
+        required: true
+
+jobs:
+  notify-failure:
+    if: github.event.workflow_run.conclusion == 'failure' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Classify failures
+        id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name || 'Manual Check' }}
+          RUN_URL: ${{ github.event.workflow_run.html_url || format('https://github.com/{0}/actions/runs/{1}', github.repository, github.event.inputs.run_id) }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha || 'N/A' }}
+          COMMIT_AUTHOR: ${{ github.event.workflow_run.head_commit.author.name || github.event.workflow_run.actor.login || 'unknown' }}
+        run: >
+          python3 scripts/ci/slack_notify.py
+          --repo "$REPO"
+          --run-id "$RUN_ID"
+          --workflow-name "$WORKFLOW_NAME"
+          --run-url "$RUN_URL"
+          --commit-sha "$COMMIT_SHA"
+          --commit-author "$COMMIT_AUTHOR"
+          --slack-output slack_summary.txt
+
+      - name: AI bug analysis
+        id: ai_analysis
+        if: steps.classify.outputs.has_bugs == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          track_progress: false
+          prompt: |
+            # Nightly CI Bug Analysis
+
+            REPO: ${{ github.repository }}
+            RUN_ID: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+
+            You are analyzing failed nightly CI jobs that have been
+            pre-classified as likely bugs (not timeouts, resource exhaustion,
+            or infrastructure issues).
+
+            The file `classification.json` in the working directory contains
+            the failure classification for all jobs. Focus ONLY on jobs where
+            `failure_type` is `"bug"`.
+
+            ## Investigation steps
+
+            1. Read `classification.json` to identify bug-type jobs.
+            2. Fetch failure logs:
+               `gh run view <RUN_ID> --log-failed`
+               Focus on tracebacks, assertion errors, and test failures.
+               If logs are large, grep for the actual failing assertion /
+               traceback / non-zero exit rather than reading everything.
+            3. Inspect the source code at HEAD to understand the failing
+               code paths if needed.
+            4. Summarize the root cause in 1-2 sentences per job.
+
+            ## Required output
+
+            Write a file `ai_bug_analysis.txt` with a concise plain-text
+            summary (max 800 chars total) suitable for inclusion in a Slack
+            notification. Use this format — one entry per bug-type job:
+
+            *<job_name>*: <1-2 sentence root cause and suggested fix>
+
+            No markdown headers, no code blocks, no bullet points.
+            Keep it terse — this goes into a Slack notification with a
+            3000 character limit.
+
+            ## Discipline
+
+            - Do not invent facts. If evidence is unavailable, say so.
+            - Do not push code changes.
+            - English output throughout.
+          claude_args: |
+            --model claude-opus-4-7
+            --allowedTools "Read,Grep,Glob,Bash(gh run view:*),Bash(gh api:*),Bash(cat:*),Bash(echo:*),Write"
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          API_TIMEOUT_MS: "3000000"
+          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+          ANTHROPIC_MODEL: claude-opus-4-7
+          ANTHROPIC_SMALL_FAST_MODEL: claude-opus-4-7
+          ANTHROPIC_DEFAULT_SONNET_MODEL: claude-sonnet-4-6
+          ANTHROPIC_DEFAULT_OPUS_MODEL: claude-opus-4-7
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-opus-4-7
+          CLAUDE_CODE_LOG_LEVEL: debug
+
+      - name: Finalize summary with AI analysis
+        if: steps.ai_analysis.conclusion == 'success'
+        env:
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name || 'Manual Check' }}
+          RUN_URL: ${{ github.event.workflow_run.html_url || format('https://github.com/{0}/actions/runs/{1}', github.repository, github.event.inputs.run_id) }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha || 'N/A' }}
+          COMMIT_AUTHOR: ${{ github.event.workflow_run.head_commit.author.name || github.event.workflow_run.actor.login || 'unknown' }}
+        run: >
+          python3 scripts/ci/slack_notify.py
+          --repo "$REPO"
+          --run-id "$RUN_ID"
+          --workflow-name "$WORKFLOW_NAME"
+          --run-url "$RUN_URL"
+          --commit-sha "$COMMIT_SHA"
+          --commit-author "$COMMIT_AUTHOR"
+          --from-classification classification.json
+          --ai-analysis ai_bug_analysis.txt
+          --slack-output slack_summary.txt
+
+      - name: Post to Slack
+        if: always() && steps.classify.conclusion == 'success'
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL not set, skipping."
+            exit 0
+          fi
+          SUMMARY=$(cat slack_summary.txt)
+          if [ -z "$SUMMARY" ]; then
+            echo "No failures detected, skipping Slack notification."
+            exit 0
+          fi
+          jq -n --arg text "$SUMMARY" \
+            '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":$text}}]}' | \
+            curl --fail-with-body -X POST -H 'Content-type: application/json' \
+              -d @- "$SLACK_WEBHOOK_URL"
+
+      - name: Upload classification artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-failure-classification-${{ github.run_number }}
+          path: |
+            classification.json
+            ai_bug_analysis.txt
+          retention-days: 14
+          if-no-files-found: ignore

--- a/scripts/ci/bisect_preflight.py
+++ b/scripts/ci/bisect_preflight.py
@@ -25,6 +25,9 @@ import subprocess
 import sys
 from typing import Dict, List, Optional, Tuple
 
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "utils"))
+from failure_classifier import classify_run
+
 ELIGIBLE_WORKFLOWS = frozenset(["PR Test", "Nightly Test", "Nightly Test Daily", "TPU Multi Test"])
 
 
@@ -242,6 +245,8 @@ def main() -> int:
                 issue_number=issue_number,
             )
             return 0
+        if _try_preclassify_and_skip(repo, run_id, info.get("html_url", "none"), issue_number):
+            return 0
         write_outputs(
             {
                 "eligible": "true",
@@ -294,6 +299,8 @@ def main() -> int:
 
     if found:
         print(f"Found eligible run: {found['id']} ({found['name']})")
+        if _try_preclassify_and_skip(repo, found["id"], found["html_url"], issue_number):
+            return 0
         write_outputs(
             {
                 "eligible": "true",
@@ -320,6 +327,84 @@ def main() -> int:
         issue_number=issue_number,
     )
     return 0
+
+
+def _post_classification_comment(
+    repo: str, run_id: str, run_url: str, issue_number: str, failed_jobs: list
+) -> None:
+    """Post a PR comment summarizing pre-classified failures."""
+    if not issue_number:
+        print("No issue_number — skipping comment")
+        return
+
+    marker = f"<!-- ci-auto-bisect:run_id={run_id} -->"
+    try:
+        existing = run_gh(
+            [
+                "api",
+                f"repos/{repo}/issues/{issue_number}/comments",
+                "--paginate",
+                "--jq",
+                ".[].body",
+            ]
+        )
+        if marker in existing:
+            print(f"Comment for run {run_id} already exists — skipping")
+            return
+    except RuntimeError:
+        return
+
+    github_emoji = {
+        "timeout": "⏳",
+        "infrastructure": "☁️",
+        "resource_exhaustion": "\U0001f4a5",
+        "bug": "\U0001fab2",
+    }
+    lines = [marker]
+    lines.append(f"## CI Auto Bisect — run {run_id}\n")
+    lines.append(f"**[View run]({run_url})**\n")
+    lines.append("All failures classified as non-code issues (AI analysis skipped):\n")
+    for job in failed_jobs:
+        emoji = github_emoji.get(job["failure_type"], "")
+        lines.append(
+            f"- {emoji} **{job['name']}** — {job['failure_type']}" f" ([view]({job['html_url']}))"
+        )
+    lines.append("\n_Re-run the workflow if the issue was transient._")
+
+    body = "\n".join(lines)
+    try:
+        run_gh(["issue", "comment", issue_number, "--repo", repo, "--body", body])
+        print(f"Posted classification comment on #{issue_number}")
+    except RuntimeError as e:
+        print(f"Warning: failed to post comment: {e}")
+
+
+def _try_preclassify_and_skip(repo: str, run_id: str, run_url: str, issue_number: str) -> bool:
+    """Attempt pre-classification. If all failures are non-bug, write skip and return True."""
+    print("Pre-classifying failed jobs...")
+    try:
+        failed_jobs, needs_ai = classify_run(repo, run_id)
+    except Exception as exc:
+        print(f"Warning: pre-classification failed ({exc}), proceeding to AI analysis")
+        return False
+    if not failed_jobs or needs_ai:
+        return False
+    _post_classification_comment(repo, run_id, run_url, issue_number, failed_jobs)
+    type_summary = ", ".join(f"{j['name']} ({j['failure_type']})" for j in failed_jobs)
+    skip_reason = (
+        f"All {len(failed_jobs)} failed job(s) are non-bug failures "
+        f"(pre-classified by deterministic pattern matching): {type_summary}. "
+        f"AI analysis skipped."
+    )
+    print(f"Skipping AI: {skip_reason}")
+    write_skip_result(
+        skip_reason,
+        skip_type="no_eligible",
+        run_id=run_id,
+        run_url=run_url,
+        issue_number=issue_number,
+    )
+    return True
 
 
 if __name__ == "__main__":

--- a/scripts/ci/slack_notify.py
+++ b/scripts/ci/slack_notify.py
@@ -1,0 +1,149 @@
+"""Check nightly CI run for job failures, classify failure types, and generate Slack notification."""
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "utils"))
+from failure_classifier import FAILURE_TYPES, classify_jobs, get_failed_jobs
+
+
+def format_slack_summary(workflow_name, run_url, commit_sha, author, failed_jobs, ai_analysis=""):
+    """Format Slack mrkdwn summary with failure types and per-job links."""
+    short_sha = commit_sha[:7] if len(commit_sha) >= 7 else commit_sha
+    lines = [":red_circle: *Nightly CI Failure*"]
+    lines.append("")
+    lines.append(f"*Workflow:* {workflow_name}")
+    lines.append(f"*Commit:* `{short_sha}` by {author}")
+    lines.append(f"*Run:* <{run_url}|View failed run>")
+    lines.append("")
+    lines.append(f"*Failed jobs ({len(failed_jobs)}):*")
+    for job in failed_jobs:
+        ft = FAILURE_TYPES.get(job["failure_type"], FAILURE_TYPES["bug"])
+        safe_name = job["name"].replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        safe_name = safe_name.replace("|", "/")
+        lines.append(f"• {ft['emoji']} <{job['html_url']}|{safe_name}> [{ft['label']}]")
+
+    if ai_analysis:
+        lines.append("")
+        lines.append("*AI Analysis:*")
+        lines.append(ai_analysis)
+
+    text = "\n".join(lines)
+    if len(text) > 2900:
+        text = text[:2900].rsplit("\n", 1)[0] + "\n… (truncated)"
+    return text
+
+
+def _write_github_output(name, value):
+    """Write a name=value pair to GITHUB_OUTPUT."""
+    output_file = os.environ.get("GITHUB_OUTPUT", "")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"{name}={value}\n")
+    print(f"  output: {name}={value}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check nightly CI for failures")
+    parser.add_argument("--repo", required=True, help="GitHub repository (owner/name)")
+    parser.add_argument("--run-id", required=True, help="Workflow run ID to check")
+    parser.add_argument("--workflow-name", default="Unknown", help="Name of the workflow")
+    parser.add_argument("--run-url", default="", help="URL to the workflow run")
+    parser.add_argument("--commit-sha", default="N/A", help="Head commit SHA")
+    parser.add_argument("--commit-author", default="unknown", help="Commit author")
+    parser.add_argument("--slack-output", type=str, help="Slack summary output file path")
+    parser.add_argument(
+        "--from-classification",
+        type=str,
+        help="Regenerate summary from saved classification JSON (skip API calls)",
+    )
+    parser.add_argument(
+        "--ai-analysis",
+        type=str,
+        help="Path to file containing AI analysis text to include in summary",
+    )
+    args = parser.parse_args()
+
+    ai_analysis = ""
+    if args.ai_analysis and os.path.isfile(args.ai_analysis):
+        with open(args.ai_analysis) as f:
+            ai_analysis = f.read().strip()
+
+    if args.from_classification:
+        with open(args.from_classification) as f:
+            data = json.load(f)
+        failed_jobs = data["failed_jobs"]
+        print(f"Loaded {len(failed_jobs)} jobs from {args.from_classification}")
+    else:
+        try:
+            failed_jobs = get_failed_jobs(args.repo, args.run_id)
+        except Exception as e:
+            print(f"Error querying jobs for run {args.run_id}: {e}")
+            sys.exit(1)
+
+        if not failed_jobs:
+            print("No failed jobs found — skipping notification")
+            if args.slack_output:
+                with open(args.slack_output, "w") as f:
+                    f.write("")
+            _write_github_output("has_bugs", "false")
+            return
+
+        print(f"Failed jobs: {', '.join(j['name'] for j in failed_jobs)}")
+        print("Classifying failures...")
+        classify_jobs(args.repo, failed_jobs)
+
+        needs_ai_jobs = [
+            j for j in failed_jobs if j["failure_type"] in ("bug", "resource_exhaustion")
+        ]
+        _write_github_output("has_bugs", "true" if needs_ai_jobs else "false")
+
+        classification_data = {
+            "failed_jobs": [
+                {
+                    "name": j["name"],
+                    "id": j["id"],
+                    "html_url": j["html_url"],
+                    "failure_type": j["failure_type"],
+                }
+                for j in failed_jobs
+            ],
+            "has_bugs": bool(needs_ai_jobs),
+            "bug_job_names": [j["name"] for j in needs_ai_jobs],
+        }
+        with open("classification.json", "w") as f:
+            json.dump(classification_data, f, indent=2)
+        print("Classification written to classification.json")
+
+    summary = format_slack_summary(
+        args.workflow_name,
+        args.run_url,
+        args.commit_sha,
+        args.commit_author,
+        failed_jobs,
+        ai_analysis,
+    )
+
+    if args.slack_output:
+        with open(args.slack_output, "w") as f:
+            f.write(summary)
+        print(f"Slack summary written to {args.slack_output}")
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a") as f:
+            f.write("## Nightly CI Failure\n\n")
+            f.write(f"**Workflow:** {args.workflow_name}\n\n")
+            f.write(f"**Commit:** {args.commit_sha[:7]} by {args.commit_author}\n\n")
+            f.write(f"**Failed jobs ({len(failed_jobs)}):**\n\n")
+            for job in failed_jobs:
+                f.write(f"- [{job['name']}]({job['html_url']}) — {job['failure_type']}\n")
+            if ai_analysis:
+                f.write(f"\n**AI Analysis:**\n\n{ai_analysis}\n")
+        print("Report appended to GITHUB_STEP_SUMMARY.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/utils/failure_classifier.py
+++ b/scripts/ci/utils/failure_classifier.py
@@ -1,0 +1,182 @@
+"""Failure classification for CI jobs.
+
+Shared module used by slack_notify.py and bisect_preflight.py.
+All failure-related logic lives here: fetching failed jobs, pulling
+logs, classifying failure types.
+
+To add a new failure type:
+  1. Add a compiled regex to the _*_RE constants below.
+  2. Add an entry in FAILURE_TYPES with label and emoji.
+  3. Add a branch in classify_failure() at the correct priority level.
+"""
+
+import json
+import random
+import re
+import subprocess
+import time
+
+FAILURE_TYPES = {
+    "timeout": {"label": "timeout", "emoji": ":hourglass:"},
+    "resource_exhaustion": {"label": "resource_exhaustion", "emoji": ":boom:"},
+    "infrastructure": {"label": "infrastructure", "emoji": ":cloud:"},
+    "bug": {"label": "bug", "emoji": ":beetle:"},
+}
+
+REPORTABLE_CONCLUSIONS = {"failure", "timed_out", "startup_failure"}
+
+_NON_RETRYABLE_PATTERNS = ("401", "403", "404", "422", "not found")
+
+_RESOURCE_EXHAUSTION_RE = re.compile(
+    r"resource_exhausted|outofmemoryerror|memoryerror"
+    r"|\boom\b"
+    r"|cannot allocate memory|resource temporarily unavailable"
+    r"|killed by signal|signal 9",
+    re.IGNORECASE,
+)
+
+_TIMEOUT_RE = re.compile(
+    r"the operation was cancelled"
+    r"|the runner has received a shutdown signal"
+    r"|timeout after"
+    r"|timeouterror"
+    r"|deadline exceeded"
+    r"|timed out",
+    re.IGNORECASE,
+)
+
+_INFRASTRUCTURE_RE = re.compile(
+    r"unable to connect|connection refused|connection reset|connectionerror"
+    r"|503 service unavailable|502 bad gateway|500 internal server error"
+    r"|serviceunavailable"
+    r"|httperror|google\.api_core\.exceptions"
+    r"|preempted|was preempted|tpu is not healthy"
+    r"|could not find device|failed to create tpu",
+    re.IGNORECASE,
+)
+
+
+def classify_failure(log_text, conclusion=None):
+    """Classify failure type from job log text and/or GitHub conclusion.
+
+    Returns one of: 'timeout', 'resource_exhaustion', 'infrastructure', 'bug'.
+    Priority: conclusion-based → resource_exhaustion → timeout → infrastructure → bug.
+    """
+    if conclusion == "startup_failure":
+        return "infrastructure"
+    if conclusion == "timed_out":
+        return "timeout"
+    if not log_text:
+        return "bug"
+
+    if _RESOURCE_EXHAUSTION_RE.search(log_text):
+        return "resource_exhaustion"
+
+    if _TIMEOUT_RE.search(log_text):
+        return "timeout"
+
+    if _INFRASTRUCTURE_RE.search(log_text):
+        return "infrastructure"
+
+    return "bug"
+
+
+def run_gh_command(args, max_retries=5):
+    """Run a gh CLI command with exponential backoff retry on transient failure."""
+    for attempt in range(max_retries):
+        try:
+            return subprocess.run(
+                ["gh"] + args, capture_output=True, text=True, check=True, timeout=120
+            ).stdout
+        except subprocess.TimeoutExpired:
+            if attempt == max_retries - 1:
+                raise
+            wait = (2**attempt) + random.uniform(0, 1)
+            print(f"Retry {attempt + 1}/{max_retries} in {wait:.1f}s: command timed out")
+            time.sleep(wait)
+        except subprocess.CalledProcessError as e:
+            err_lower = str(e.stderr).lower()
+            if "rate limit" not in err_lower and any(
+                p in err_lower for p in _NON_RETRYABLE_PATTERNS
+            ):
+                raise
+            if attempt == max_retries - 1:
+                raise
+            wait = (2**attempt) + random.uniform(0, 1)
+            print(f"Retry {attempt + 1}/{max_retries} in {wait:.1f}s: {e.stderr.strip()}")
+            time.sleep(wait)
+    raise RuntimeError("run_gh_command: exhausted retries without raising")
+
+
+def get_failed_jobs(repo, run_id):
+    """Query GitHub API for jobs with reportable conclusions in the given run."""
+    failed = []
+    page = 1
+    while True:
+        output = run_gh_command(
+            [
+                "api",
+                f"repos/{repo}/actions/runs/{run_id}/jobs",
+                "--method",
+                "GET",
+                "-f",
+                "per_page=100",
+                "-f",
+                f"page={page}",
+            ]
+        )
+        data = json.loads(output)
+        jobs = data.get("jobs", [])
+        for job in jobs:
+            if job.get("conclusion") in REPORTABLE_CONCLUSIONS:
+                failed.append(
+                    {
+                        "name": job["name"],
+                        "id": job["id"],
+                        "html_url": job["html_url"],
+                        "conclusion": job["conclusion"],
+                    }
+                )
+        if len(jobs) < 100:
+            break
+        page += 1
+    return failed
+
+
+def fetch_job_logs(repo, job_id, max_lines=500):
+    """Fetch logs for a single job, truncated to last max_lines lines."""
+    try:
+        output = run_gh_command(
+            ["api", f"repos/{repo}/actions/jobs/{job_id}/logs"],
+            max_retries=3,
+        )
+        lines = output.splitlines()
+        if len(lines) > max_lines:
+            lines = lines[-max_lines:]
+        return "\n".join(lines)
+    except Exception as e:
+        print(f"Warning: failed to fetch logs for job {job_id}: {e}")
+        return ""
+
+
+def classify_jobs(repo, failed_jobs):
+    """Fetch logs and classify each failed job. Mutates jobs in-place, adding 'failure_type'."""
+    for job in failed_jobs:
+        log_text = fetch_job_logs(repo, job["id"])
+        job["failure_type"] = classify_failure(log_text, job.get("conclusion"))
+        print(f"  {job['name']}: {job['failure_type']}")
+
+
+def classify_run(repo, run_id):
+    """High-level: fetch failed jobs for a run and classify each one.
+
+    Returns (failed_jobs, needs_ai) where failed_jobs is a list of dicts
+    with 'failure_type' populated, and needs_ai is True if any job is
+    'bug' or 'resource_exhaustion' (types that require AI analysis).
+    """
+    failed_jobs = get_failed_jobs(repo, run_id)
+    if not failed_jobs:
+        return [], False
+    classify_jobs(repo, failed_jobs)
+    needs_ai = any(j["failure_type"] in ("bug", "resource_exhaustion") for j in failed_jobs)
+    return failed_jobs, needs_ai


### PR DESCRIPTION
## Summary
- Add `nightly-slack-notify.yml` workflow triggered by `workflow_run` on "Nightly Test" and "Nightly Test Daily" completion
- Only fires on `conclusion == 'failure'` — success runs produce no notification
- Uses `SLACK_WEBHOOK_URL` secret with `curl` (no third-party actions)
- Message includes: workflow name, commit SHA, author, link to failed run

## Admin setup required
- [ ] Configure `SLACK_WEBHOOK_URL` repository secret with Slack Incoming Webhook URL

## Verification
- [ ] Nightly workflow failure → Slack message appears in configured channel
- [ ] PR Test failure does NOT trigger Slack notification
- [ ] Nightly success does NOT trigger Slack notification

Supersedes #1172
Closes #1145