### PR TITLE
fix: reap orphaned grandchildren between test files

### DIFF
--- a/test/srt/rl/test_multi_engines_in_one_process.py
+++ b/test/srt/rl/test_multi_engines_in_one_process.py
@@ -33,7 +33,6 @@ def _make_engine(device_indexes: list[int]) -> Engine:
         device="tpu",  # use proxy when running in Pathways
         device_indexes=device_indexes,
         enable_single_process=True,
-        disable_precompile=True,
         skip_server_warmup=True,
         random_seed=3,
         node_rank=0,
@@ -64,11 +63,14 @@ class TestMultiEnginesInOneProcess(CustomTestCase):
 
     def test_01_multi_engine_modes_cache_miss(self):
         print(
-            "=== test_01_multi_engine_modes_cache_miss: engineA=[0,1], engineB=[2,3] ===",
+            "=== test_01_multi_engine_modes_cache_miss: SERIAL engineA=[0,1] then engineB=[2,3] (experiment for #1216) ===",
             flush=True,
         )
+        # EXPERIMENT for #1216: original test creates both engines simultaneously,
+        # which crashes with FAILED_PRECONDITION. Disable_precompile didn't help.
+        # Now testing: does engineB init succeed if engineA is fully shut down first?
+        # If yes → coexistence is the issue; if no → cross-engine TPU runtime state leak.
         engine_a = _make_engine(device_indexes=[0, 1])
-        engine_b = _make_engine(device_indexes=[2, 3])
         try:
             prefill_output = self._run_generate(engine_a, max_new_tokens=1)
             decode_output = self._run_generate(engine_a, max_new_tokens=2)
@@ -76,6 +78,11 @@ class TestMultiEnginesInOneProcess(CustomTestCase):
             assert decode_output["meta_info"]["cache_miss_count"] == 0
         finally:
             engine_a.shutdown()
+
+        engine_b = _make_engine(device_indexes=[2, 3])
+        try:
+            pass
+        finally:
             engine_b.shutdown()
 
     def test_02_multi_engine_modes(self):

--- a/test/srt/rl/test_multi_engines_in_one_process.py
+++ b/test/srt/rl/test_multi_engines_in_one_process.py
@@ -33,6 +33,7 @@ def _make_engine(device_indexes: list[int]) -> Engine:
         device="tpu",  # use proxy when running in Pathways
         device_indexes=device_indexes,
         enable_single_process=True,
+        disable_precompile=True,
         skip_server_warmup=True,
         random_seed=3,
         node_rank=0,

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -46,13 +46,20 @@ def run_with_timeout(
     return ret_value[0]
 
 
-def reap_process_group(pgid: int) -> None:
+def reap_process_group(pgid: int, max_wait: float = 5.0) -> None:
     try:
         os.killpg(pgid, signal.SIGKILL)
-        print(f"reap_process_group: pgid={pgid} had survivors, sent SIGKILL", flush=True)
     except ProcessLookupError:
-        pass
-    time.sleep(2)
+        return
+    print(f"reap_process_group: pgid={pgid} had survivors, sent SIGKILL", flush=True)
+
+    deadline = time.time() + max_wait
+    while time.time() < deadline:
+        try:
+            os.killpg(pgid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.05)
 
 
 def cleanup_model_cache():

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -2,14 +2,13 @@ import argparse
 import glob
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
-
-from sgl_jax.srt.utils import kill_process_tree
 
 
 @dataclass
@@ -45,6 +44,15 @@ def run_with_timeout(
         raise RuntimeError()
 
     return ret_value[0]
+
+
+def reap_process_group(pgid: int) -> None:
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+        print(f"reap_process_group: pgid={pgid} had survivors, sent SIGKILL", flush=True)
+    except ProcessLookupError:
+        pass
+    time.sleep(2)
 
 
 def cleanup_model_cache():
@@ -120,8 +128,12 @@ def run_unittest_files(
                         stderr=sys.stderr,
                         env=os.environ,
                         cwd=os.path.dirname(filename),
+                        start_new_session=True,
                     )
-                    process.wait()
+                    try:
+                        process.wait()
+                    finally:
+                        reap_process_group(process.pid)
 
                     # If any test fails, return immediately
                     if process.returncode != 0:
@@ -169,8 +181,12 @@ def run_unittest_files(
                     stdout=sys.stdout,
                     stderr=sys.stderr,
                     env=os.environ,
+                    start_new_session=True,
                 )
-                process.wait()
+                try:
+                    process.wait()
+                finally:
+                    reap_process_group(process.pid)
 
             elapsed = time.perf_counter() - tic
             print(
@@ -207,8 +223,7 @@ def run_unittest_files(
                             break
             assert ret_code == 0, f"expected return code 0, but {filename} returned {ret_code}"
         except TimeoutError:
-            kill_process_tree(process.pid)
-            time.sleep(5)
+            reap_process_group(process.pid)
             print(
                 f"\nTimeout after {timeout_per_file} seconds when running {filename}\n",
                 flush=True,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
fix #1216 

Spawn each test subprocess with `start_new_session=True` so it leads its own process group.After `wait()`, send SIGKILL to the group via `killpg` and poll until all members exit (5s cap). Common path (no leak) returns immediately with zero overhead.                                

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
