### PR TITLE
test(rl): bypass jit on KV cache alloc to isolate persistent cache trigger

### DIFF
--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -442,13 +442,15 @@ class MHATokenToKVPool(KVCache):
         with self.mesh:
             self.kv_buffer = []
             for _ in range(self.layer_num):
-                kv_buf = jax.jit(
-                    lambda: jnp.zeros(
-                        shape=fused_buffer_shape,
-                        dtype=self.dtype,
-                    ),
-                    out_shardings=self.kv_sharding,
-                )()
+                # Diagnostic: replace jax.jit(...)() with jax.device_put to bypass
+                # JAX persistent compilation cache deserialization. If
+                # test_multi_engines_in_one_process passes with this change, the
+                # FAILED_PRECONDITION crash is caused by the cached executable
+                # deserialization path of this jit, not by the allocation itself.
+                kv_buf = jax.device_put(
+                    jnp.zeros(shape=fused_buffer_shape, dtype=self.dtype),
+                    self.kv_sharding,
+                )
 
                 self.kv_buffer.append(kv_buf)
 

--- a/test/srt/rl/test_multi_engines_in_one_process.py
+++ b/test/srt/rl/test_multi_engines_in_one_process.py
@@ -33,11 +33,6 @@ def _make_engine(device_indexes: list[int]) -> Engine:
         device="tpu",  # use proxy when running in Pathways
         device_indexes=device_indexes,
         enable_single_process=True,
-        # Diagnostic (paired with memory_pool change): keep precompile disabled so the
-        # only remaining jit on the init path that could hit /xla-cache is the KV
-        # cache allocation jit. Combined with the device_put rewrite there, no jit
-        # call should hit the persistent compilation cache during init.
-        disable_precompile=True,
         skip_server_warmup=True,
         random_seed=3,
         node_rank=0,

--- a/test/srt/rl/test_multi_engines_in_one_process.py
+++ b/test/srt/rl/test_multi_engines_in_one_process.py
@@ -33,6 +33,11 @@ def _make_engine(device_indexes: list[int]) -> Engine:
         device="tpu",  # use proxy when running in Pathways
         device_indexes=device_indexes,
         enable_single_process=True,
+        # Diagnostic (paired with memory_pool change): keep precompile disabled so the
+        # only remaining jit on the init path that could hit /xla-cache is the KV
+        # cache allocation jit. Combined with the device_put rewrite there, no jit
+        # call should hit the persistent compilation cache during init.
+        disable_precompile=True,
         skip_server_warmup=True,
         random_seed=3,
         node_rank=0,


### PR DESCRIPTION
## Context

Issue: #1216 (`test_multi_engines_in_one_process.py` crashes with `FAILED_PRECONDITION: The program continuator has halted unexpectedly` after `JAX_COMPILATION_CACHE_DIR=/xla-cache` was added in 5/22).

Prior experiment: 82b8e68 verified that `disable_precompile=True` alone does **not** fix the crash. Engine A finishes initialization fine, but Engine B crashes during weight loading slow-path:

```
weight_utils.py:2751 jax.device_put(weight, target_sharding)
  → array.py:1267 _array_shard_arg → shard_sharded_device_array_slow_path
  → array.py:1198 x._value
  → array.py:635 _single_device_array_to_np_array_did_copy
  → FAILED_PRECONDITION
```

Notable asymmetry: Engine B's first 5 fast-path weights write successfully to devices [2,3] (host→device), but the first slow-path weight crashes on device→host DMA. This indicates TPU runtime state on devices [2,3] was corrupted **before** Engine B started.

## Hypothesis

After `disable_precompile=True`, the only `jax.jit(...)()` that **actually executes** on the init path (not merely defined) is the KV cache allocation in `mem_cache/memory_pool.py:445`:

```python
with self.mesh:
    for _ in range(self.layer_num):  # 28 layers
        kv_buf = jax.jit(
            lambda: jnp.zeros(shape=fused_buffer_shape, dtype=self.dtype),
            out_shardings=self.kv_sharding,
        )()
```

Evidence this hits the persistent cache:
- CI log: `Total time to create 28 buffers: 0.25 seconds` — too fast for fresh compilation
- After 5/22 commit `de29d9f0`, the `/xla-cache` GCS Fuse mount accumulates compiled executables across runs

`NamedSharding(self.mesh, ...)` constrains where the *executable* runs, but cannot prevent the persistent cache deserialization path (`backend.deserialize_executable`) from registering host-level resources in libtpu (e.g., program continuator slots), which Engine B's later device→host DMA depends on.

## Change

Replace `jax.jit(lambda: jnp.zeros(...), out_shardings=...)()` with `jax.device_put(jnp.zeros(...), sharding)`. This still allocates the same sharded buffer but bypasses the jit/cache deserialization path entirely. Also adds `disable_precompile=True` to the test so this is the only diff vs. the failing-cached scenario.

Engine A's slow-path weight loading already calls `jax.device_put` successfully, so this rewrite should not introduce a new crash by itself.

## Expected CI Outcome

| Result | Conclusion |
|--------|------------|
| `e2e-test-tpu-v6e-4` passes | Persistent cache deserialization of the KV cache jit is the trigger; root cause confirmed |
| Still `FAILED_PRECONDITION` | Some other jit/op on the init path is also hitting the cache — need further investigation |

## Scope

- This PR is **diagnostic only** and will be reverted after the CI result is observed.
- Memory impact of the rewrite is negligible (~0.01 GB per-layer host-side `jnp.zeros` for Qwen3-1.7B).
- No production behavior change is intended.