### PR TITLE
test(rl): bypass jit on KV cache alloc to isolate persistent cache trigger

### DIFF
--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -442,13 +442,15 @@ class MHATokenToKVPool(KVCache):
         with self.mesh:
             self.kv_buffer = []
             for _ in range(self.layer_num):
-                kv_buf = jax.jit(
-                    lambda: jnp.zeros(
-                        shape=fused_buffer_shape,
-                        dtype=self.dtype,
-                    ),
-                    out_shardings=self.kv_sharding,
-                )()
+                # Diagnostic: replace jax.jit(...)() with jax.device_put to bypass
+                # JAX persistent compilation cache deserialization. If
+                # test_multi_engines_in_one_process passes with this change, the
+                # FAILED_PRECONDITION crash is caused by the cached executable
+                # deserialization path of this jit, not by the allocation itself.
+                kv_buf = jax.device_put(
+                    jnp.zeros(shape=fused_buffer_shape, dtype=self.dtype),
+                    self.kv_sharding,
+                )
 
                 self.kv_buffer.append(kv_buf)
 

--- a/test/srt/rl/test_multi_engines_in_one_process.py
+++ b/test/srt/rl/test_multi_engines_in_one_process.py
@@ -33,11 +33,6 @@ def _make_engine(device_indexes: list[int]) -> Engine:
         device="tpu",  # use proxy when running in Pathways
         device_indexes=device_indexes,
         enable_single_process=True,
-        # Diagnostic (paired with memory_pool change): keep precompile disabled so the
-        # only remaining jit on the init path that could hit /xla-cache is the KV
-        # cache allocation jit. Combined with the device_put rewrite there, no jit
-        # call should hit the persistent compilation cache during init.
-        disable_precompile=True,
         skip_server_warmup=True,
         random_seed=3,
         node_rank=0,

--- a/test/srt/rl/test_multi_engines_in_one_process.py
+++ b/test/srt/rl/test_multi_engines_in_one_process.py
@@ -33,6 +33,11 @@ def _make_engine(device_indexes: list[int]) -> Engine:
         device="tpu",  # use proxy when running in Pathways
         device_indexes=device_indexes,
         enable_single_process=True,
+        # Diagnostic (paired with memory_pool change): keep precompile disabled so the
+        # only remaining jit on the init path that could hit /xla-cache is the KV
+        # cache allocation jit. Combined with the device_put rewrite there, no jit
+        # call should hit the persistent compilation cache during init.
+        disable_precompile=True,
         skip_server_warmup=True,
         random_seed=3,
         node_rank=0,


### PR DESCRIPTION
## Summary

Diagnostic experiment for `test_multi_engines_in_one_process.py` FAILED_PRECONDITION crash (#1216 / #1219 context).

The hypothesis is that the 28× `jax.jit(lambda: jnp.zeros(...), out_shardings=kv_sharding)()` calls in `MHATokenToKVPool.__init__` (memory_pool.py:445) hit `/xla-cache` warm executables and run `deserialize_executable`, which in turn pollutes TPU runtime state and causes Engine B's subsequent `jax.device_put` to crash with `FAILED_PRECONDITION: program continuator has halted`.

This PR replaces the single `jax.jit(...)()` with `jax.device_put(jnp.zeros(...), kv_sharding)`. Per JAX source (`jax/_src/array.py:1171` `shard_device_array` → `pxla.batched_device_put`), this path bypasses XLA compilation entirely — it does not query the persistent compilation cache and does not call `deserialize_executable`.

## Outcome matrix

| PR test result | Conclusion |
|---|---|
| Pass | KV cache jit deserialization is the trigger on its own. |
| Fail | KV cache jit alone is not the trigger; need to look at precompile or earlier-init paths. |

## Companion / prerequisite

Companion to the experiment in commit 82b8e68 (just `disable_precompile=True`), which still crashed on CI — proving precompile alone is not the only contributor. This PR isolates one further variable.

## Test plan

- [x] Local lint clean (isort/ruff/black/codespell)
- [ ] Run `test/srt/rl/test_multi_engines_in_one_process.py::test_01_multi_engine_modes_cache_miss` on tpu-v6e-4 with warm `/xla-cache`