### PR TITLE
fix(mimo): skip GCSFuse warm-up on non-FUSE mounts

### DIFF
--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -576,6 +576,16 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         from concurrent.futures import ThreadPoolExecutor
 
         model_path = model_config.model_path
+        # Only useful on GCSFuse (cold random reads ~400ms); skip on block-device mounts.
+        try:
+            with open("/proc/mounts") as fp:
+                ms = [ln.split() for ln in fp]
+            mp = max((m for m in ms if model_path.startswith(m[1])), key=lambda m: len(m[1]))
+            if "fuse" not in mp[2]:
+                logger.info("model_path on %s mount, skipping GCSFuse warm-up", mp[2])
+                return
+        except Exception:  # noqa: BLE001
+            pass
         st_files = sorted(glob.glob(os.path.join(model_path, "*.safetensors")))
         if not st_files:
             return


### PR DESCRIPTION
## Motivation

Fixes #1223.

`_warmup_safetensors_cache` reads **all** safetensors on **every** node. On hyperdisk-ml/local-SSD this is pure overhead (no GCSFuse cold-read latency to mitigate) and scales with node count — e.g. V2-Flash on 16×v6e = 4.6TB wasted reads, ~24 min before `load_weights` even starts. Re-runs on every restart.

## Modifications

Check `/proc/mounts` for the fstype of `model_path`'s mount; skip warm-up if not FUSE. Falls through to warm-up on any detection error (safe default).

## Verification

Before: 16 ranks each log `Warming up GCSFuse cache: 145 files, 291.6 GB` then stall ~20 min.
After (v6e-64, hyperdisk-ml ROX): `model_path on ext4 mount, skipping GCSFuse warm-up` → Uvicorn ready in **~3.5 min** (vs ~24 min).

## Checklist

- [x] pre-commit passes
- [x] verified on v6e-64 multi-host

cc @pengchengneo