### PR TITLE
fix(scheduler): restore batch_size > 10 guard for TEST_RETRACT

### DIFF
--- a/.github/workflows/nightly-slack-notify.yml
+++ b/.github/workflows/nightly-slack-notify.yml
@@ -24,7 +24,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Classify failures
         id: classify

--- a/.github/workflows/nightly-slack-notify.yml
+++ b/.github/workflows/nightly-slack-notify.yml
@@ -22,15 +22,41 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check for failures and notify
-        shell: bash
+      - name: Check for failures
         env:
           GH_TOKEN: ${{ github.token }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
-          WORKFLOW_NAME: ${{ github.event.workflow_run.name || 'Manual Check' }}
-          RUN_URL: ${{ github.event.workflow_run.html_url || format('https://github.com/{0}/actions/runs/{1}', github.repository, github.event.inputs.run_id) }}
-          COMMIT_SHA: ${{ github.event.workflow_run.head_sha || 'N/A' }}
-          COMMIT_AUTHOR: ${{ github.event.workflow_run.head_commit.author.name || github.event.workflow_run.actor.login || 'unknown' }}
-        run: python3 scripts/ci/slack_notify.py
+        run: |
+          RUN_ID="${{ github.event.workflow_run.id || github.event.inputs.run_id }}"
+          WORKFLOW_NAME="${{ github.event.workflow_run.name || 'Manual Check' }}"
+          RUN_URL="${{ github.event.workflow_run.html_url || format('https://github.com/{0}/actions/runs/{1}', github.repository, github.event.inputs.run_id) }}"
+          COMMIT_SHA="${{ github.event.workflow_run.head_sha || 'N/A' }}"
+          COMMIT_AUTHOR="${{ github.event.workflow_run.head_commit.author.name || github.event.workflow_run.actor.login || 'unknown' }}"
+          python3 scripts/ci/slack_notify.py \
+            --repo "$REPO" \
+            --run-id "$RUN_ID" \
+            --workflow-name "$WORKFLOW_NAME" \
+            --run-url "$RUN_URL" \
+            --commit-sha "$COMMIT_SHA" \
+            --commit-author "$COMMIT_AUTHOR" \
+            --slack-output slack_summary.txt
+
+      - name: Post to Slack
+        if: success()
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL not set, skipping."
+            exit 0
+          fi
+          SUMMARY=$(cat slack_summary.txt)
+          if [ -z "$SUMMARY" ]; then
+            echo "No failures detected, skipping Slack notification."
+            exit 0
+          fi
+          jq -n --arg text "$SUMMARY" \
+            '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":$text}}]}' | \
+            curl --fail-with-body -X POST -H 'Content-type: application/json' \
+              -d @- "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/nightly-slack-notify.yml
+++ b/.github/workflows/nightly-slack-notify.yml
@@ -17,13 +17,17 @@ jobs:
   notify-failure:
     if: github.event.workflow_run.conclusion == 'failure' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check for failures
+      - name: Classify failures
+        id: classify
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -42,8 +46,93 @@ jobs:
           --commit-author "$COMMIT_AUTHOR"
           --slack-output slack_summary.txt
 
+      - name: AI bug analysis
+        id: ai_analysis
+        if: steps.classify.outputs.has_bugs == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          track_progress: false
+          prompt: |
+            # Nightly CI Bug Analysis
+
+            REPO: ${{ github.repository }}
+            RUN_ID: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+
+            You are analyzing failed nightly CI jobs that have been
+            pre-classified as likely bugs (not timeouts, resource exhaustion,
+            or infrastructure issues).
+
+            The file `classification.json` in the working directory contains
+            the failure classification for all jobs. Focus ONLY on jobs where
+            `failure_type` is `"bug"`.
+
+            ## Investigation steps
+
+            1. Read `classification.json` to identify bug-type jobs.
+            2. Fetch failure logs:
+               `gh run view <RUN_ID> --log-failed`
+               Focus on tracebacks, assertion errors, and test failures.
+               If logs are large, grep for the actual failing assertion /
+               traceback / non-zero exit rather than reading everything.
+            3. Inspect the source code at HEAD to understand the failing
+               code paths if needed.
+            4. Summarize the root cause in 1-2 sentences per job.
+
+            ## Required output
+
+            Write a file `ai_bug_analysis.txt` with a concise plain-text
+            summary (max 800 chars total) suitable for inclusion in a Slack
+            notification. Use this format — one entry per bug-type job:
+
+            *<job_name>*: <1-2 sentence root cause and suggested fix>
+
+            No markdown headers, no code blocks, no bullet points.
+            Keep it terse — this goes into a Slack notification with a
+            3000 character limit.
+
+            ## Discipline
+
+            - Do not invent facts. If evidence is unavailable, say so.
+            - Do not push code changes.
+            - English output throughout.
+          claude_args: |
+            --model claude-opus-4-7
+            --allowedTools "Read,Grep,Glob,Bash(gh run view:*),Bash(gh api:*),Bash(cat:*),Bash(echo:*),Write"
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          API_TIMEOUT_MS: "3000000"
+          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+          ANTHROPIC_MODEL: claude-opus-4-7
+          ANTHROPIC_SMALL_FAST_MODEL: claude-opus-4-7
+          ANTHROPIC_DEFAULT_SONNET_MODEL: claude-sonnet-4-6
+          ANTHROPIC_DEFAULT_OPUS_MODEL: claude-opus-4-7
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-opus-4-7
+          CLAUDE_CODE_LOG_LEVEL: debug
+
+      - name: Finalize summary with AI analysis
+        if: steps.ai_analysis.conclusion == 'success'
+        env:
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name || 'Manual Check' }}
+          RUN_URL: ${{ github.event.workflow_run.html_url || format('https://github.com/{0}/actions/runs/{1}', github.repository, github.event.inputs.run_id) }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha || 'N/A' }}
+          COMMIT_AUTHOR: ${{ github.event.workflow_run.head_commit.author.name || github.event.workflow_run.actor.login || 'unknown' }}
+        run: >
+          python3 scripts/ci/slack_notify.py
+          --repo "$REPO"
+          --run-id "$RUN_ID"
+          --workflow-name "$WORKFLOW_NAME"
+          --run-url "$RUN_URL"
+          --commit-sha "$COMMIT_SHA"
+          --commit-author "$COMMIT_AUTHOR"
+          --from-classification classification.json
+          --ai-analysis ai_bug_analysis.txt
+          --slack-output slack_summary.txt
+
       - name: Post to Slack
-        if: success()
+        if: always() && steps.classify.conclusion == 'success'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -61,3 +150,14 @@ jobs:
             '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":$text}}]}' | \
             curl --fail-with-body -X POST -H 'Content-type: application/json' \
               -d @- "$SLACK_WEBHOOK_URL"
+
+      - name: Upload classification artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-failure-classification-${{ github.run_number }}
+          path: |
+            classification.json
+            ai_bug_analysis.txt
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/nightly-slack-notify.yml
+++ b/.github/workflows/nightly-slack-notify.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   notify-failure:
+    if: github.event.workflow_run.conclusion == 'failure' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -26,20 +27,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-        run: |
-          RUN_ID="${{ github.event.workflow_run.id || github.event.inputs.run_id }}"
-          WORKFLOW_NAME="${{ github.event.workflow_run.name || 'Manual Check' }}"
-          RUN_URL="${{ github.event.workflow_run.html_url || format('https://github.com/{0}/actions/runs/{1}', github.repository, github.event.inputs.run_id) }}"
-          COMMIT_SHA="${{ github.event.workflow_run.head_sha || 'N/A' }}"
-          COMMIT_AUTHOR="${{ github.event.workflow_run.head_commit.author.name || github.event.workflow_run.actor.login || 'unknown' }}"
-          python3 scripts/ci/slack_notify.py \
-            --repo "$REPO" \
-            --run-id "$RUN_ID" \
-            --workflow-name "$WORKFLOW_NAME" \
-            --run-url "$RUN_URL" \
-            --commit-sha "$COMMIT_SHA" \
-            --commit-author "$COMMIT_AUTHOR" \
-            --slack-output slack_summary.txt
+          RUN_ID: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name || 'Manual Check' }}
+          RUN_URL: ${{ github.event.workflow_run.html_url || format('https://github.com/{0}/actions/runs/{1}', github.repository, github.event.inputs.run_id) }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha || 'N/A' }}
+          COMMIT_AUTHOR: ${{ github.event.workflow_run.head_commit.author.name || github.event.workflow_run.actor.login || 'unknown' }}
+        run: >
+          python3 scripts/ci/slack_notify.py
+          --repo "$REPO"
+          --run-id "$RUN_ID"
+          --workflow-name "$WORKFLOW_NAME"
+          --run-url "$RUN_URL"
+          --commit-sha "$COMMIT_SHA"
+          --commit-author "$COMMIT_AUTHOR"
+          --slack-output slack_summary.txt
 
       - name: Post to Slack
         if: success()

--- a/.github/workflows/nightly-slack-notify.yml
+++ b/.github/workflows/nightly-slack-notify.yml
@@ -1,0 +1,36 @@
+name: Nightly Slack Notify
+
+on:
+  workflow_run:
+    workflows:
+      - "Nightly Test"
+      - "Nightly Test Daily"
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Workflow run ID to check (for manual testing)"
+        required: true
+
+jobs:
+  notify-failure:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for failures and notify
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name || 'Manual Check' }}
+          RUN_URL: ${{ github.event.workflow_run.html_url || format('https://github.com/{0}/actions/runs/{1}', github.repository, github.event.inputs.run_id) }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha || 'N/A' }}
+          COMMIT_AUTHOR: ${{ github.event.workflow_run.head_commit.author.name || github.event.workflow_run.actor.login || 'unknown' }}
+        run: python3 scripts/ci/slack_notify.py

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1680,7 +1680,9 @@ class Scheduler(
 
         # Check if decode out of memory
         if not batch.check_decode_mem() or (
-            TEST_RETRACT and self.forward_ct % TEST_RETRACT_INTERVAL == 0
+            TEST_RETRACT
+            and batch.batch_size() > 10
+            and self.forward_ct % TEST_RETRACT_INTERVAL == 0
         ):
             old_ratio = self.new_token_ratio
 

--- a/scripts/ci/bisect_preflight.py
+++ b/scripts/ci/bisect_preflight.py
@@ -25,7 +25,16 @@ import subprocess
 import sys
 from typing import Dict, List, Optional, Tuple
 
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "utils"))
+from failure_classifier import REPORTABLE_CONCLUSIONS, classify_failure
+
 ELIGIBLE_WORKFLOWS = frozenset(["PR Test", "Nightly Test", "Nightly Test Daily", "TPU Multi Test"])
+
+_BISECT_CLASSIFICATION_MAP = {
+    "timeout": "infrastructure",
+    "resource_exhaustion": "infrastructure",
+    "infrastructure": "infrastructure",
+}
 
 
 def run_gh(args: List[str]) -> str:
@@ -242,6 +251,8 @@ def main() -> int:
                 issue_number=issue_number,
             )
             return 0
+        if _try_preclassify_and_skip(repo, run_id, info.get("html_url", "none"), issue_number):
+            return 0
         write_outputs(
             {
                 "eligible": "true",
@@ -294,6 +305,8 @@ def main() -> int:
 
     if found:
         print(f"Found eligible run: {found['id']} ({found['name']})")
+        if _try_preclassify_and_skip(repo, found["id"], found["html_url"], issue_number):
+            return 0
         write_outputs(
             {
                 "eligible": "true",
@@ -320,6 +333,91 @@ def main() -> int:
         issue_number=issue_number,
     )
     return 0
+
+
+def _fetch_job_log_tail(repo: str, job_id: str, max_lines: int = 300) -> str:
+    """Fetch the last max_lines of a job's log. Returns empty string on failure."""
+    try:
+        output = run_gh(["api", f"repos/{repo}/actions/jobs/{job_id}/logs"])
+        lines = output.splitlines()
+        if len(lines) > max_lines:
+            lines = lines[-max_lines:]
+        return "\n".join(lines)
+    except RuntimeError:
+        return ""
+
+
+def _preclassify_run(repo: str, run_id: str) -> Optional[str]:
+    """Pre-classify failed jobs to skip AI for obvious non-bug failures.
+
+    Returns a skip reason string if ALL failures are non-bug (timeout,
+    resource_exhaustion, infrastructure). Returns None if any bug-type
+    failure exists and AI analysis is needed.
+    """
+    try:
+        raw = run_gh(
+            [
+                "api",
+                f"repos/{repo}/actions/runs/{run_id}/jobs",
+                "--paginate",
+                "--jq",
+                '.jobs[] | select(.conclusion != null and .conclusion != "success" '
+                'and .conclusion != "skipped" and .conclusion != "cancelled") '
+                "| {name, id: (.id|tostring), conclusion}",
+            ]
+        )
+    except RuntimeError:
+        return None
+
+    if not raw.strip():
+        return None
+
+    failed_jobs = []
+    for line in raw.strip().splitlines():
+        if not line.strip():
+            continue
+        try:
+            failed_jobs.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    if not failed_jobs:
+        return None
+
+    classifications = {}
+    for job in failed_jobs:
+        log_text = _fetch_job_log_tail(repo, job["id"])
+        ft = classify_failure(log_text, job.get("conclusion"))
+        classifications[job["name"]] = ft
+        print(f"  preclassify: {job['name']} → {ft}")
+
+    bug_jobs = [name for name, ft in classifications.items() if ft == "bug"]
+    if bug_jobs:
+        return None
+
+    type_summary = ", ".join(f"{name} ({ft})" for name, ft in classifications.items())
+    return (
+        f"All {len(classifications)} failed job(s) are non-bug failures "
+        f"(pre-classified by deterministic pattern matching): {type_summary}. "
+        f"AI analysis skipped."
+    )
+
+
+def _try_preclassify_and_skip(repo: str, run_id: str, run_url: str, issue_number: str) -> bool:
+    """Attempt pre-classification. If all failures are non-bug, write skip and return True."""
+    print("Pre-classifying failed jobs...")
+    skip_reason = _preclassify_run(repo, run_id)
+    if skip_reason:
+        print(f"Skipping AI: {skip_reason}")
+        write_skip_result(
+            skip_reason,
+            skip_type="no_eligible",
+            run_id=run_id,
+            run_url=run_url,
+            issue_number=issue_number,
+        )
+        return True
+    return False
 
 
 if __name__ == "__main__":

--- a/scripts/ci/bisect_preflight.py
+++ b/scripts/ci/bisect_preflight.py
@@ -26,15 +26,9 @@ import sys
 from typing import Dict, List, Optional, Tuple
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "utils"))
-from failure_classifier import REPORTABLE_CONCLUSIONS, classify_failure
+from failure_classifier import classify_run
 
 ELIGIBLE_WORKFLOWS = frozenset(["PR Test", "Nightly Test", "Nightly Test Daily", "TPU Multi Test"])
-
-_BISECT_CLASSIFICATION_MAP = {
-    "timeout": "infrastructure",
-    "resource_exhaustion": "infrastructure",
-    "infrastructure": "infrastructure",
-}
 
 
 def run_gh(args: List[str]) -> str:
@@ -335,89 +329,27 @@ def main() -> int:
     return 0
 
 
-def _fetch_job_log_tail(repo: str, job_id: str, max_lines: int = 300) -> str:
-    """Fetch the last max_lines of a job's log. Returns empty string on failure."""
-    try:
-        output = run_gh(["api", f"repos/{repo}/actions/jobs/{job_id}/logs"])
-        lines = output.splitlines()
-        if len(lines) > max_lines:
-            lines = lines[-max_lines:]
-        return "\n".join(lines)
-    except RuntimeError:
-        return ""
-
-
-def _preclassify_run(repo: str, run_id: str) -> Optional[str]:
-    """Pre-classify failed jobs to skip AI for obvious non-bug failures.
-
-    Returns a skip reason string if ALL failures are non-bug (timeout,
-    resource_exhaustion, infrastructure). Returns None if any bug-type
-    failure exists and AI analysis is needed.
-    """
-    try:
-        raw = run_gh(
-            [
-                "api",
-                f"repos/{repo}/actions/runs/{run_id}/jobs",
-                "--paginate",
-                "--jq",
-                '.jobs[] | select(.conclusion != null and .conclusion != "success" '
-                'and .conclusion != "skipped" and .conclusion != "cancelled") '
-                "| {name, id: (.id|tostring), conclusion}",
-            ]
-        )
-    except RuntimeError:
-        return None
-
-    if not raw.strip():
-        return None
-
-    failed_jobs = []
-    for line in raw.strip().splitlines():
-        if not line.strip():
-            continue
-        try:
-            failed_jobs.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
-
-    if not failed_jobs:
-        return None
-
-    classifications = {}
-    for job in failed_jobs:
-        log_text = _fetch_job_log_tail(repo, job["id"])
-        ft = classify_failure(log_text, job.get("conclusion"))
-        classifications[job["name"]] = ft
-        print(f"  preclassify: {job['name']} → {ft}")
-
-    bug_jobs = [name for name, ft in classifications.items() if ft == "bug"]
-    if bug_jobs:
-        return None
-
-    type_summary = ", ".join(f"{name} ({ft})" for name, ft in classifications.items())
-    return (
-        f"All {len(classifications)} failed job(s) are non-bug failures "
-        f"(pre-classified by deterministic pattern matching): {type_summary}. "
-        f"AI analysis skipped."
-    )
-
-
 def _try_preclassify_and_skip(repo: str, run_id: str, run_url: str, issue_number: str) -> bool:
     """Attempt pre-classification. If all failures are non-bug, write skip and return True."""
     print("Pre-classifying failed jobs...")
-    skip_reason = _preclassify_run(repo, run_id)
-    if skip_reason:
-        print(f"Skipping AI: {skip_reason}")
-        write_skip_result(
-            skip_reason,
-            skip_type="no_eligible",
-            run_id=run_id,
-            run_url=run_url,
-            issue_number=issue_number,
-        )
-        return True
-    return False
+    failed_jobs, has_bugs = classify_run(repo, run_id)
+    if not failed_jobs or has_bugs:
+        return False
+    type_summary = ", ".join(f"{j['name']} ({j['failure_type']})" for j in failed_jobs)
+    skip_reason = (
+        f"All {len(failed_jobs)} failed job(s) are non-bug failures "
+        f"(pre-classified by deterministic pattern matching): {type_summary}. "
+        f"AI analysis skipped."
+    )
+    print(f"Skipping AI: {skip_reason}")
+    write_skip_result(
+        skip_reason,
+        skip_type="no_eligible",
+        run_id=run_id,
+        run_url=run_url,
+        issue_number=issue_number,
+    )
+    return True
 
 
 if __name__ == "__main__":

--- a/scripts/ci/slack_notify.py
+++ b/scripts/ci/slack_notify.py
@@ -3,101 +3,10 @@
 import argparse
 import json
 import os
-import random
-import subprocess
 import sys
-import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "utils"))
-from failure_classifier import FAILURE_TYPES, REPORTABLE_CONCLUSIONS, classify_failure
-
-_NON_RETRYABLE_PATTERNS = ("401", "403", "404", "422", "not found")
-
-
-def run_gh_command(args, max_retries=5):
-    """Run a gh CLI command with exponential backoff retry on transient failure."""
-    for attempt in range(max_retries):
-        try:
-            return subprocess.run(
-                ["gh"] + args, capture_output=True, text=True, check=True, timeout=120
-            ).stdout
-        except subprocess.TimeoutExpired:
-            if attempt == max_retries - 1:
-                raise
-            wait = (2**attempt) + random.uniform(0, 1)
-            print(f"Retry {attempt + 1}/{max_retries} in {wait:.1f}s: command timed out")
-            time.sleep(wait)
-        except subprocess.CalledProcessError as e:
-            err_lower = str(e.stderr).lower()
-            if "rate limit" not in err_lower and any(
-                p in err_lower for p in _NON_RETRYABLE_PATTERNS
-            ):
-                raise
-            if attempt == max_retries - 1:
-                raise
-            wait = (2**attempt) + random.uniform(0, 1)
-            print(f"Retry {attempt + 1}/{max_retries} in {wait:.1f}s: {e.stderr.strip()}")
-            time.sleep(wait)
-    raise RuntimeError("run_gh_command: exhausted retries without raising")
-
-
-def get_failed_jobs(repo, run_id):
-    """Query GitHub API for jobs with reportable conclusions in the given run."""
-    failed = []
-    page = 1
-    while True:
-        output = run_gh_command(
-            [
-                "api",
-                f"repos/{repo}/actions/runs/{run_id}/jobs",
-                "--method",
-                "GET",
-                "-f",
-                "per_page=100",
-                "-f",
-                f"page={page}",
-            ]
-        )
-        data = json.loads(output)
-        jobs = data.get("jobs", [])
-        for job in jobs:
-            if job.get("conclusion") in REPORTABLE_CONCLUSIONS:
-                failed.append(
-                    {
-                        "name": job["name"],
-                        "id": job["id"],
-                        "html_url": job["html_url"],
-                        "conclusion": job["conclusion"],
-                    }
-                )
-        if len(jobs) < 100:
-            break
-        page += 1
-    return failed
-
-
-def fetch_job_logs(repo, job_id, max_lines=500):
-    """Fetch logs for a single job, truncated to last max_lines lines."""
-    try:
-        output = run_gh_command(
-            ["api", f"repos/{repo}/actions/jobs/{job_id}/logs"],
-            max_retries=3,
-        )
-        lines = output.splitlines()
-        if len(lines) > max_lines:
-            lines = lines[-max_lines:]
-        return "\n".join(lines)
-    except Exception as e:
-        print(f"Warning: failed to fetch logs for job {job_id}: {e}")
-        return ""
-
-
-def classify_jobs(repo, failed_jobs):
-    """Fetch logs and classify each failed job. Mutates jobs in-place."""
-    for job in failed_jobs:
-        log_text = fetch_job_logs(repo, job["id"])
-        job["failure_type"] = classify_failure(log_text, job.get("conclusion"))
-        print(f"  {job['name']}: {job['failure_type']}")
+from failure_classifier import FAILURE_TYPES, classify_jobs, get_failed_jobs
 
 
 def format_slack_summary(workflow_name, run_url, commit_sha, author, failed_jobs, ai_analysis=""):

--- a/scripts/ci/slack_notify.py
+++ b/scripts/ci/slack_notify.py
@@ -1,0 +1,110 @@
+"""Check nightly CI run for job failures and send Slack notification."""
+
+import json
+import os
+import sys
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+def get_failed_jobs(repo, run_id, token):
+    """Query GitHub API for jobs with conclusion=failure in the given run."""
+    failed = []
+    page = 1
+    while True:
+        url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100&page={page}"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        req = Request(url, headers=headers)
+        with urlopen(req) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        for job in data.get("jobs", []):
+            if job.get("conclusion") == "failure":
+                failed.append(job["name"])
+        if len(data.get("jobs", [])) < 100:
+            break
+        page += 1
+    return failed
+
+
+def send_slack_notification(webhook_url, workflow_name, run_url, commit_sha, author, failed_jobs):
+    """Send a Slack Block Kit notification for failed nightly jobs."""
+    short_sha = commit_sha[:7] if len(commit_sha) >= 7 else commit_sha
+    payload = {
+        "blocks": [
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": ":red_circle: Nightly CI Failure"},
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {"type": "mrkdwn", "text": f"*Workflow:*\n{workflow_name}"},
+                    {"type": "mrkdwn", "text": f"*Commit:*\n{short_sha}"},
+                    {"type": "mrkdwn", "text": f"*Author:*\n{author}"},
+                    {"type": "mrkdwn", "text": f"*Run:*\n<{run_url}|View failed run>"},
+                ],
+            },
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"*Failed jobs:*\n{', '.join(failed_jobs)}"},
+            },
+        ],
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = Request(
+        webhook_url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    try:
+        with urlopen(req) as resp:
+            pass
+    except HTTPError as e:
+        print(f"Slack webhook failed: {e.code} {e.reason}")
+        sys.exit(1)
+
+
+def main():
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("Error: GH_TOKEN or GITHUB_TOKEN must be set")
+        sys.exit(1)
+
+    repo = os.environ.get("REPO")
+    run_id = os.environ.get("RUN_ID")
+    if not repo or not run_id:
+        print("Error: REPO and RUN_ID must be set")
+        sys.exit(1)
+
+    try:
+        failed_jobs = get_failed_jobs(repo, run_id, token)
+    except Exception as e:
+        print(f"Error querying jobs for run {run_id}: {e}")
+        sys.exit(1)
+
+    if not failed_jobs:
+        print("No failed jobs found — skipping notification")
+        return
+
+    print(f"Failed jobs: {', '.join(failed_jobs)}")
+
+    webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
+    if not webhook_url:
+        print("::warning::SLACK_WEBHOOK_URL not configured — skipping Slack notification")
+        return
+
+    workflow_name = os.environ.get("WORKFLOW_NAME", "Unknown")
+    run_url = os.environ.get("RUN_URL", "")
+    commit_sha = os.environ.get("COMMIT_SHA", "N/A")
+    commit_author = os.environ.get("COMMIT_AUTHOR", "unknown")
+
+    send_slack_notification(
+        webhook_url, workflow_name, run_url, commit_sha, commit_author, failed_jobs
+    )
+    print("Slack notification sent")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/slack_notify.py
+++ b/scripts/ci/slack_notify.py
@@ -8,54 +8,10 @@ import subprocess
 import sys
 import time
 
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "utils"))
+from failure_classifier import FAILURE_TYPES, REPORTABLE_CONCLUSIONS, classify_failure
+
 _NON_RETRYABLE_PATTERNS = ("401", "403", "404", "422", "not found")
-
-_RESOURCE_EXHAUSTION_PATTERNS = [
-    "resource_exhausted",
-    "outofmemoryerror",
-    "memoryerror",
-    "oom",
-    "killed",
-    "signal 9",
-    "cannot allocate memory",
-    "resource temporarily unavailable",
-    "xla::runtime::xlaruntimeerror",
-]
-
-_TIMEOUT_PATTERNS = [
-    "the operation was cancelled",
-    "the runner has received a shutdown signal",
-    "timeout after",
-    "timeouterror",
-    "deadline exceeded",
-    "timed out",
-]
-
-_INFRASTRUCTURE_PATTERNS = [
-    "unable to connect",
-    "connection refused",
-    "connection reset",
-    "connectionerror",
-    "503 service unavailable",
-    "502 bad gateway",
-    "500 internal server error",
-    "serviceunavailable",
-    "unavailable",
-    "httperror",
-    "google.api_core.exceptions",
-    "preempted",
-    "was preempted",
-    "tpu is not healthy",
-    "could not find device",
-    "failed to create tpu",
-]
-
-_FAILURE_EMOJI = {
-    "timeout": ":hourglass:",
-    "resource_exhaustion": ":boom:",
-    "infrastructure": ":cloud:",
-    "bug": ":beetle:",
-}
 
 
 def run_gh_command(args, max_retries=5):
@@ -86,7 +42,7 @@ def run_gh_command(args, max_retries=5):
 
 
 def get_failed_jobs(repo, run_id):
-    """Query GitHub API for jobs with conclusion=failure in the given run."""
+    """Query GitHub API for jobs with reportable conclusions in the given run."""
     failed = []
     page = 1
     while True:
@@ -105,7 +61,7 @@ def get_failed_jobs(repo, run_id):
         data = json.loads(output)
         jobs = data.get("jobs", [])
         for job in jobs:
-            if job.get("conclusion") == "failure":
+            if job.get("conclusion") in REPORTABLE_CONCLUSIONS:
                 failed.append(
                     {
                         "name": job["name"],
@@ -136,37 +92,11 @@ def fetch_job_logs(repo, job_id, max_lines=500):
         return ""
 
 
-def classify_failure(log_text):
-    """Classify failure type from job log text.
-
-    Returns one of: 'timeout', 'resource_exhaustion', 'infrastructure', 'bug'.
-    Priority: resource_exhaustion > timeout > infrastructure > bug (default).
-    """
-    if not log_text:
-        return "bug"
-
-    log_lower = log_text.lower()
-
-    for pattern in _RESOURCE_EXHAUSTION_PATTERNS:
-        if pattern in log_lower:
-            return "resource_exhaustion"
-
-    for pattern in _TIMEOUT_PATTERNS:
-        if pattern in log_lower:
-            return "timeout"
-
-    for pattern in _INFRASTRUCTURE_PATTERNS:
-        if pattern in log_lower:
-            return "infrastructure"
-
-    return "bug"
-
-
 def classify_jobs(repo, failed_jobs):
     """Fetch logs and classify each failed job. Mutates jobs in-place."""
     for job in failed_jobs:
         log_text = fetch_job_logs(repo, job["id"])
-        job["failure_type"] = classify_failure(log_text)
+        job["failure_type"] = classify_failure(log_text, job.get("conclusion"))
         print(f"  {job['name']}: {job['failure_type']}")
 
 
@@ -181,8 +111,10 @@ def format_slack_summary(workflow_name, run_url, commit_sha, author, failed_jobs
     lines.append("")
     lines.append(f"*Failed jobs ({len(failed_jobs)}):*")
     for job in failed_jobs:
-        emoji = _FAILURE_EMOJI.get(job["failure_type"], ":question:")
-        lines.append(f"• {emoji} <{job['html_url']}|{job['name']}> [{job['failure_type']}]")
+        ft = FAILURE_TYPES.get(job["failure_type"], FAILURE_TYPES["bug"])
+        safe_name = job["name"].replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        safe_name = safe_name.replace("|", "/")
+        lines.append(f"• {ft['emoji']} <{job['html_url']}|{safe_name}> [{ft['label']}]")
 
     if ai_analysis:
         lines.append("")

--- a/scripts/ci/slack_notify.py
+++ b/scripts/ci/slack_notify.py
@@ -1,109 +1,134 @@
-"""Check nightly CI run for job failures and send Slack notification."""
+"""Check nightly CI run for job failures and generate Slack notification."""
 
+import argparse
 import json
 import os
+import random
+import subprocess
 import sys
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
+import time
+
+_NON_RETRYABLE_PATTERNS = ("401", "403", "404", "422", "not found")
 
 
-def get_failed_jobs(repo, run_id, token):
+def run_gh_command(args, max_retries=5):
+    """Run a gh CLI command with exponential backoff retry on transient failure."""
+    for attempt in range(max_retries):
+        try:
+            return subprocess.run(
+                ["gh"] + args, capture_output=True, text=True, check=True, timeout=120
+            ).stdout
+        except subprocess.TimeoutExpired:
+            if attempt == max_retries - 1:
+                raise
+            wait = (2**attempt) + random.uniform(0, 1)
+            print(f"Retry {attempt + 1}/{max_retries} in {wait:.1f}s: command timed out")
+            time.sleep(wait)
+        except subprocess.CalledProcessError as e:
+            err_lower = str(e.stderr).lower()
+            if "rate limit" not in err_lower and any(
+                p in err_lower for p in _NON_RETRYABLE_PATTERNS
+            ):
+                raise
+            if attempt == max_retries - 1:
+                raise
+            wait = (2**attempt) + random.uniform(0, 1)
+            print(f"Retry {attempt + 1}/{max_retries} in {wait:.1f}s: {e.stderr.strip()}")
+            time.sleep(wait)
+    raise RuntimeError("run_gh_command: exhausted retries without raising")
+
+
+def get_failed_jobs(repo, run_id):
     """Query GitHub API for jobs with conclusion=failure in the given run."""
     failed = []
     page = 1
     while True:
-        url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100&page={page}"
-        headers = {
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
-        req = Request(url, headers=headers)
-        with urlopen(req) as resp:
-            data = json.loads(resp.read().decode("utf-8"))
-        for job in data.get("jobs", []):
+        output = run_gh_command(
+            [
+                "api",
+                f"repos/{repo}/actions/runs/{run_id}/jobs",
+                "--method",
+                "GET",
+                "-f",
+                "per_page=100",
+                "-f",
+                f"page={page}",
+            ]
+        )
+        data = json.loads(output)
+        jobs = data.get("jobs", [])
+        for job in jobs:
             if job.get("conclusion") == "failure":
                 failed.append(job["name"])
-        if len(data.get("jobs", [])) < 100:
+        if len(jobs) < 100:
             break
         page += 1
     return failed
 
 
-def send_slack_notification(webhook_url, workflow_name, run_url, commit_sha, author, failed_jobs):
-    """Send a Slack Block Kit notification for failed nightly jobs."""
+def format_slack_summary(workflow_name, run_url, commit_sha, author, failed_jobs):
+    """Format a compact Slack mrkdwn summary for nightly failure notification."""
     short_sha = commit_sha[:7] if len(commit_sha) >= 7 else commit_sha
-    payload = {
-        "blocks": [
-            {
-                "type": "header",
-                "text": {"type": "plain_text", "text": ":red_circle: Nightly CI Failure"},
-            },
-            {
-                "type": "section",
-                "fields": [
-                    {"type": "mrkdwn", "text": f"*Workflow:*\n{workflow_name}"},
-                    {"type": "mrkdwn", "text": f"*Commit:*\n{short_sha}"},
-                    {"type": "mrkdwn", "text": f"*Author:*\n{author}"},
-                    {"type": "mrkdwn", "text": f"*Run:*\n<{run_url}|View failed run>"},
-                ],
-            },
-            {
-                "type": "section",
-                "text": {"type": "mrkdwn", "text": f"*Failed jobs:*\n{', '.join(failed_jobs)}"},
-            },
-        ],
-    }
-    data = json.dumps(payload).encode("utf-8")
-    req = Request(
-        webhook_url, data=data, headers={"Content-Type": "application/json"}, method="POST"
-    )
-    try:
-        with urlopen(req) as resp:
-            pass
-    except HTTPError as e:
-        print(f"Slack webhook failed: {e.code} {e.reason}")
-        sys.exit(1)
+    lines = [":red_circle: *Nightly CI Failure*"]
+    lines.append("")
+    lines.append(f"*Workflow:* {workflow_name}")
+    lines.append(f"*Commit:* `{short_sha}` by {author}")
+    lines.append(f"*Run:* <{run_url}|View failed run>")
+    lines.append("")
+    lines.append(f"*Failed jobs ({len(failed_jobs)}):*")
+    for job in failed_jobs:
+        lines.append(f"• {job}")
+    text = "\n".join(lines)
+    if len(text) > 2900:
+        text = text[:2900].rsplit("\n", 1)[0] + "\n… (truncated)"
+    return text
 
 
 def main():
-    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
-    if not token:
-        print("Error: GH_TOKEN or GITHUB_TOKEN must be set")
-        sys.exit(1)
-
-    repo = os.environ.get("REPO")
-    run_id = os.environ.get("RUN_ID")
-    if not repo or not run_id:
-        print("Error: REPO and RUN_ID must be set")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(description="Check nightly CI for failures")
+    parser.add_argument("--repo", required=True, help="GitHub repository (owner/name)")
+    parser.add_argument("--run-id", required=True, help="Workflow run ID to check")
+    parser.add_argument("--workflow-name", default="Unknown", help="Name of the workflow")
+    parser.add_argument("--run-url", default="", help="URL to the workflow run")
+    parser.add_argument("--commit-sha", default="N/A", help="Head commit SHA")
+    parser.add_argument("--commit-author", default="unknown", help="Commit author")
+    parser.add_argument("--slack-output", type=str, help="Slack summary output file path")
+    args = parser.parse_args()
 
     try:
-        failed_jobs = get_failed_jobs(repo, run_id, token)
+        failed_jobs = get_failed_jobs(args.repo, args.run_id)
     except Exception as e:
-        print(f"Error querying jobs for run {run_id}: {e}")
+        print(f"Error querying jobs for run {args.run_id}: {e}")
         sys.exit(1)
 
     if not failed_jobs:
         print("No failed jobs found — skipping notification")
+        if args.slack_output:
+            with open(args.slack_output, "w") as f:
+                f.write("")
         return
 
     print(f"Failed jobs: {', '.join(failed_jobs)}")
 
-    webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
-    if not webhook_url:
-        print("::warning::SLACK_WEBHOOK_URL not configured — skipping Slack notification")
-        return
-
-    workflow_name = os.environ.get("WORKFLOW_NAME", "Unknown")
-    run_url = os.environ.get("RUN_URL", "")
-    commit_sha = os.environ.get("COMMIT_SHA", "N/A")
-    commit_author = os.environ.get("COMMIT_AUTHOR", "unknown")
-
-    send_slack_notification(
-        webhook_url, workflow_name, run_url, commit_sha, commit_author, failed_jobs
+    summary = format_slack_summary(
+        args.workflow_name, args.run_url, args.commit_sha, args.commit_author, failed_jobs
     )
-    print("Slack notification sent")
+
+    if args.slack_output:
+        with open(args.slack_output, "w") as f:
+            f.write(summary)
+        print(f"Slack summary written to {args.slack_output}")
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a") as f:
+            f.write(f"## Nightly CI Failure\n\n")
+            f.write(f"**Workflow:** {args.workflow_name}\n\n")
+            f.write(f"**Commit:** {args.commit_sha[:7]} by {args.commit_author}\n\n")
+            f.write(f"**Failed jobs ({len(failed_jobs)}):**\n\n")
+            for job in failed_jobs:
+                f.write(f"- {job}\n")
+        print("Report appended to GITHUB_STEP_SUMMARY.")
 
 
 if __name__ == "__main__":

--- a/scripts/ci/slack_notify.py
+++ b/scripts/ci/slack_notify.py
@@ -1,4 +1,4 @@
-"""Check nightly CI run for job failures and generate Slack notification."""
+"""Check nightly CI run for job failures, classify failure types, and generate Slack notification."""
 
 import argparse
 import json
@@ -9,6 +9,53 @@ import sys
 import time
 
 _NON_RETRYABLE_PATTERNS = ("401", "403", "404", "422", "not found")
+
+_RESOURCE_EXHAUSTION_PATTERNS = [
+    "resource_exhausted",
+    "outofmemoryerror",
+    "memoryerror",
+    "oom",
+    "killed",
+    "signal 9",
+    "cannot allocate memory",
+    "resource temporarily unavailable",
+    "xla::runtime::xlaruntimeerror",
+]
+
+_TIMEOUT_PATTERNS = [
+    "the operation was cancelled",
+    "the runner has received a shutdown signal",
+    "timeout after",
+    "timeouterror",
+    "deadline exceeded",
+    "timed out",
+]
+
+_INFRASTRUCTURE_PATTERNS = [
+    "unable to connect",
+    "connection refused",
+    "connection reset",
+    "connectionerror",
+    "503 service unavailable",
+    "502 bad gateway",
+    "500 internal server error",
+    "serviceunavailable",
+    "unavailable",
+    "httperror",
+    "google.api_core.exceptions",
+    "preempted",
+    "was preempted",
+    "tpu is not healthy",
+    "could not find device",
+    "failed to create tpu",
+]
+
+_FAILURE_EMOJI = {
+    "timeout": ":hourglass:",
+    "resource_exhaustion": ":boom:",
+    "infrastructure": ":cloud:",
+    "bug": ":beetle:",
+}
 
 
 def run_gh_command(args, max_retries=5):
@@ -59,15 +106,72 @@ def get_failed_jobs(repo, run_id):
         jobs = data.get("jobs", [])
         for job in jobs:
             if job.get("conclusion") == "failure":
-                failed.append(job["name"])
+                failed.append(
+                    {
+                        "name": job["name"],
+                        "id": job["id"],
+                        "html_url": job["html_url"],
+                        "conclusion": job["conclusion"],
+                    }
+                )
         if len(jobs) < 100:
             break
         page += 1
     return failed
 
 
-def format_slack_summary(workflow_name, run_url, commit_sha, author, failed_jobs):
-    """Format a compact Slack mrkdwn summary for nightly failure notification."""
+def fetch_job_logs(repo, job_id, max_lines=500):
+    """Fetch logs for a single job, truncated to last max_lines lines."""
+    try:
+        output = run_gh_command(
+            ["api", f"repos/{repo}/actions/jobs/{job_id}/logs"],
+            max_retries=3,
+        )
+        lines = output.splitlines()
+        if len(lines) > max_lines:
+            lines = lines[-max_lines:]
+        return "\n".join(lines)
+    except Exception as e:
+        print(f"Warning: failed to fetch logs for job {job_id}: {e}")
+        return ""
+
+
+def classify_failure(log_text):
+    """Classify failure type from job log text.
+
+    Returns one of: 'timeout', 'resource_exhaustion', 'infrastructure', 'bug'.
+    Priority: resource_exhaustion > timeout > infrastructure > bug (default).
+    """
+    if not log_text:
+        return "bug"
+
+    log_lower = log_text.lower()
+
+    for pattern in _RESOURCE_EXHAUSTION_PATTERNS:
+        if pattern in log_lower:
+            return "resource_exhaustion"
+
+    for pattern in _TIMEOUT_PATTERNS:
+        if pattern in log_lower:
+            return "timeout"
+
+    for pattern in _INFRASTRUCTURE_PATTERNS:
+        if pattern in log_lower:
+            return "infrastructure"
+
+    return "bug"
+
+
+def classify_jobs(repo, failed_jobs):
+    """Fetch logs and classify each failed job. Mutates jobs in-place."""
+    for job in failed_jobs:
+        log_text = fetch_job_logs(repo, job["id"])
+        job["failure_type"] = classify_failure(log_text)
+        print(f"  {job['name']}: {job['failure_type']}")
+
+
+def format_slack_summary(workflow_name, run_url, commit_sha, author, failed_jobs, ai_analysis=""):
+    """Format Slack mrkdwn summary with failure types and per-job links."""
     short_sha = commit_sha[:7] if len(commit_sha) >= 7 else commit_sha
     lines = [":red_circle: *Nightly CI Failure*"]
     lines.append("")
@@ -77,11 +181,27 @@ def format_slack_summary(workflow_name, run_url, commit_sha, author, failed_jobs
     lines.append("")
     lines.append(f"*Failed jobs ({len(failed_jobs)}):*")
     for job in failed_jobs:
-        lines.append(f"• {job}")
+        emoji = _FAILURE_EMOJI.get(job["failure_type"], ":question:")
+        lines.append(f"• {emoji} <{job['html_url']}|{job['name']}> [{job['failure_type']}]")
+
+    if ai_analysis:
+        lines.append("")
+        lines.append("*AI Analysis:*")
+        lines.append(ai_analysis)
+
     text = "\n".join(lines)
     if len(text) > 2900:
         text = text[:2900].rsplit("\n", 1)[0] + "\n… (truncated)"
     return text
+
+
+def _write_github_output(name, value):
+    """Write a name=value pair to GITHUB_OUTPUT."""
+    output_file = os.environ.get("GITHUB_OUTPUT", "")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"{name}={value}\n")
+    print(f"  output: {name}={value}")
 
 
 def main():
@@ -93,25 +213,74 @@ def main():
     parser.add_argument("--commit-sha", default="N/A", help="Head commit SHA")
     parser.add_argument("--commit-author", default="unknown", help="Commit author")
     parser.add_argument("--slack-output", type=str, help="Slack summary output file path")
+    parser.add_argument(
+        "--from-classification",
+        type=str,
+        help="Regenerate summary from saved classification JSON (skip API calls)",
+    )
+    parser.add_argument(
+        "--ai-analysis",
+        type=str,
+        help="Path to file containing AI analysis text to include in summary",
+    )
     args = parser.parse_args()
 
-    try:
-        failed_jobs = get_failed_jobs(args.repo, args.run_id)
-    except Exception as e:
-        print(f"Error querying jobs for run {args.run_id}: {e}")
-        sys.exit(1)
+    ai_analysis = ""
+    if args.ai_analysis and os.path.isfile(args.ai_analysis):
+        with open(args.ai_analysis) as f:
+            ai_analysis = f.read().strip()
 
-    if not failed_jobs:
-        print("No failed jobs found — skipping notification")
-        if args.slack_output:
-            with open(args.slack_output, "w") as f:
-                f.write("")
-        return
+    if args.from_classification:
+        with open(args.from_classification) as f:
+            data = json.load(f)
+        failed_jobs = data["failed_jobs"]
+        print(f"Loaded {len(failed_jobs)} jobs from {args.from_classification}")
+    else:
+        try:
+            failed_jobs = get_failed_jobs(args.repo, args.run_id)
+        except Exception as e:
+            print(f"Error querying jobs for run {args.run_id}: {e}")
+            sys.exit(1)
 
-    print(f"Failed jobs: {', '.join(failed_jobs)}")
+        if not failed_jobs:
+            print("No failed jobs found — skipping notification")
+            if args.slack_output:
+                with open(args.slack_output, "w") as f:
+                    f.write("")
+            _write_github_output("has_bugs", "false")
+            return
+
+        print(f"Failed jobs: {', '.join(j['name'] for j in failed_jobs)}")
+        print("Classifying failures...")
+        classify_jobs(args.repo, failed_jobs)
+
+        bug_jobs = [j for j in failed_jobs if j["failure_type"] == "bug"]
+        _write_github_output("has_bugs", "true" if bug_jobs else "false")
+
+        classification_data = {
+            "failed_jobs": [
+                {
+                    "name": j["name"],
+                    "id": j["id"],
+                    "html_url": j["html_url"],
+                    "failure_type": j["failure_type"],
+                }
+                for j in failed_jobs
+            ],
+            "has_bugs": bool(bug_jobs),
+            "bug_job_names": [j["name"] for j in bug_jobs],
+        }
+        with open("classification.json", "w") as f:
+            json.dump(classification_data, f, indent=2)
+        print("Classification written to classification.json")
 
     summary = format_slack_summary(
-        args.workflow_name, args.run_url, args.commit_sha, args.commit_author, failed_jobs
+        args.workflow_name,
+        args.run_url,
+        args.commit_sha,
+        args.commit_author,
+        failed_jobs,
+        ai_analysis,
     )
 
     if args.slack_output:
@@ -122,12 +291,14 @@ def main():
     step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if step_summary:
         with open(step_summary, "a") as f:
-            f.write(f"## Nightly CI Failure\n\n")
+            f.write("## Nightly CI Failure\n\n")
             f.write(f"**Workflow:** {args.workflow_name}\n\n")
             f.write(f"**Commit:** {args.commit_sha[:7]} by {args.commit_author}\n\n")
             f.write(f"**Failed jobs ({len(failed_jobs)}):**\n\n")
             for job in failed_jobs:
-                f.write(f"- {job}\n")
+                f.write(f"- [{job['name']}]({job['html_url']}) — {job['failure_type']}\n")
+            if ai_analysis:
+                f.write(f"\n**AI Analysis:**\n\n{ai_analysis}\n")
         print("Report appended to GITHUB_STEP_SUMMARY.")
 
 

--- a/scripts/ci/utils/failure_classifier.py
+++ b/scripts/ci/utils/failure_classifier.py
@@ -1,0 +1,74 @@
+"""Failure classification for CI jobs.
+
+Shared module used by slack_notify.py (nightly notifications) and
+potentially bisect_preflight.py (auto-bisect eligibility).
+
+To add a new failure type:
+  1. Add a compiled regex to the _*_RE constants below.
+  2. Add an entry in FAILURE_TYPES with label and emoji.
+  3. Add a branch in classify_failure() at the correct priority level.
+"""
+
+import re
+
+FAILURE_TYPES = {
+    "timeout": {"label": "timeout", "emoji": ":hourglass:"},
+    "resource_exhaustion": {"label": "resource_exhaustion", "emoji": ":boom:"},
+    "infrastructure": {"label": "infrastructure", "emoji": ":cloud:"},
+    "bug": {"label": "bug", "emoji": ":beetle:"},
+}
+
+REPORTABLE_CONCLUSIONS = {"failure", "timed_out", "startup_failure"}
+
+_RESOURCE_EXHAUSTION_RE = re.compile(
+    r"resource_exhausted|outofmemoryerror|memoryerror"
+    r"|\boom\b"
+    r"|cannot allocate memory|resource temporarily unavailable"
+    r"|killed by signal|signal 9",
+    re.IGNORECASE,
+)
+
+_TIMEOUT_RE = re.compile(
+    r"the operation was cancelled"
+    r"|the runner has received a shutdown signal"
+    r"|timeout after"
+    r"|timeouterror"
+    r"|deadline exceeded"
+    r"|timed out",
+    re.IGNORECASE,
+)
+
+_INFRASTRUCTURE_RE = re.compile(
+    r"unable to connect|connection refused|connection reset|connectionerror"
+    r"|503 service unavailable|502 bad gateway|500 internal server error"
+    r"|serviceunavailable"
+    r"|httperror|google\.api_core\.exceptions"
+    r"|preempted|was preempted|tpu is not healthy"
+    r"|could not find device|failed to create tpu",
+    re.IGNORECASE,
+)
+
+
+def classify_failure(log_text, conclusion=None):
+    """Classify failure type from job log text and/or GitHub conclusion.
+
+    Returns one of: 'timeout', 'resource_exhaustion', 'infrastructure', 'bug'.
+    Priority: conclusion-based → resource_exhaustion → timeout → infrastructure → bug.
+    """
+    if conclusion == "startup_failure":
+        return "infrastructure"
+    if conclusion == "timed_out":
+        return "timeout"
+    if not log_text:
+        return "bug"
+
+    if _RESOURCE_EXHAUSTION_RE.search(log_text):
+        return "resource_exhaustion"
+
+    if _TIMEOUT_RE.search(log_text):
+        return "timeout"
+
+    if _INFRASTRUCTURE_RE.search(log_text):
+        return "infrastructure"
+
+    return "bug"


### PR DESCRIPTION
## Summary
- PR #994 replaced the `TEST_RETRACT` trigger condition from `batch_size() > 10` to `forward_ct % TEST_RETRACT_INTERVAL == 0`, which fires every 3 forward steps regardless of batch size
- With small running batches (2-3 requests), this causes an infinite retract→re-prefill loop: requests are retracted before completing any meaningful decode, leading to `test_retract_decode.py` hanging to job timeout or running ~87× expected time
- Restore the `batch_size() > 10` guard alongside the interval check, matching the contract documented in `test_retract_decode.py`

## Test plan
- [ ] CI `e2e-test-4-tpu (1)` shard passes with `test_retract_decode.py` completing in expected time (~12s)
- [ ] No regression in other e2e test shards

Fixes #1229