### PR TITLE
fix(scheduler): align TEST_RETRACT with upstream sglang

### DIFF
--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1680,7 +1680,9 @@ class Scheduler(
 
         # Check if decode out of memory
         if not batch.check_decode_mem() or (
-            TEST_RETRACT and self.forward_ct % TEST_RETRACT_INTERVAL == 0
+            TEST_RETRACT
+            and batch.batch_size() > 10
+            and self.forward_ct % TEST_RETRACT_INTERVAL == 0
         ):
             old_ratio = self.new_token_ratio
 

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1679,10 +1679,8 @@ class Scheduler(
             return batch
 
         # Check if decode out of memory
-        if not batch.check_decode_mem() or (
-            TEST_RETRACT
-            and batch.batch_size() > 10
-            and self.forward_ct % TEST_RETRACT_INTERVAL == 0
+        if (kv_full_retract_flag := not batch.check_decode_mem()) or (
+            TEST_RETRACT and self.forward_ct % TEST_RETRACT_INTERVAL == 0
         ):
             old_ratio = self.new_token_ratio
 
@@ -1698,8 +1696,14 @@ class Scheduler(
                 else:
                     self.send_to_tokenizer.send_pyobj(abort_out)
 
+            msg_prefix = (
+                "KV cache pool is full. Retract requests."
+                if kv_full_retract_flag
+                else "Testing retraction."
+            )
             logger.info(
-                "KV cache pool is full. Retract requests. #retracted_reqs: %d, #aborted_reqs: %d, #new_token_ratio: %.4f -> %.4f",
+                "%s #retracted_reqs: %d, #aborted_reqs: %d, #new_token_ratio: %.4f -> %.4f",
+                msg_prefix,
                 num_retracted_reqs,
                 len(reqs_to_abort),
                 old_ratio,

--- a/test/srt/test_retract_decode.py
+++ b/test/srt/test_retract_decode.py
@@ -1,8 +1,10 @@
 """Integration tests for the retract / release_kv_cache path.
 
-SGLANG_TEST_RETRACT=1 forces retract on batch_size > 10. Pass criterion:
-the worker stays alive (process.poll() is None) -- a leak would trip
-scheduler.check_memory() and SIGQUIT.
+SGLANG_TEST_RETRACT=1 forces retract every TEST_RETRACT_INTERVAL (default 3)
+forward steps. TEST_RETRACT_NO_PREFILL_BS caps prefill admission to bound
+the retract-prefill loop. Pass criterion: the worker stays alive
+(process.poll() is None) -- a leak would trip scheduler.check_memory()
+and SIGQUIT.
 """
 
 import time
@@ -67,6 +69,7 @@ class _BaseRetractDecode(CustomTestCase):
             other_args=launch_args,
             env={
                 "SGLANG_TEST_RETRACT": "1",
+                "SGLANG_TEST_RETRACT_NO_PREFILL_BS": "6",
                 "JAX_COMPILATION_CACHE_DIR": "/tmp/jax_compilation_cache",
             },
         )


### PR DESCRIPTION
## Summary
- PR #994 ported the upstream `forward_ct % TEST_RETRACT_INTERVAL` trigger but missed setting `TEST_RETRACT_NO_PREFILL_BS` in the test, causing `test_retract_decode.py` to enter an infinite retract→re-prefill loop (hang or ~87× slowdown)
- Align with upstream sglang's full mechanism:
  - **Trigger**: `forward_ct % interval` with `kv_full_retract_flag` walrus operator to distinguish real OOM from test retract
  - **Test**: set `SGLANG_TEST_RETRACT_NO_PREFILL_BS=6` (matching upstream `test_scheduler_control.py`) to cap prefill admission and bound the loop
  - **Log**: differentiate `"KV cache pool is full."` (real OOM) from `"Testing retraction."` (test-forced) to prevent misleading logs

## Test plan
- [ ] CI `e2e-test-4-tpu (1)` shard passes with `test_retract_decode.py` completing in expected time (~12s)
- [ ] No regression in other e2e test shards

Fixes #1229