### PR TITLE
fix(swa): SWA budget check throttles decode concurrency for hybrid models

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1354,34 +1354,44 @@ class ScheduleBatch:
                 if not info.reqs:
                     continue
                 for req in info.reqs:
-                    if req.decode_batch_idx % evict_interval == 1:
-                        self._evict_swa(
-                            req, req.seqlen - 1, sliding_window_size, page_size, dp_rank
-                        )
+                    if isinstance(self.tree_cache, ChunkCache):
+                        # ChunkCache/SWAChunkCache: no tree-node overlap concern,
+                        # evict on every decode step to prevent SWA exhaustion.
+                        if req.decode_batch_idx % evict_interval == 0:
+                            self._evict_swa(
+                                req, req.seqlen - 1, sliding_window_size, page_size, dp_rank
+                            )
+                    else:
+                        # SWARadixCache: skip decode_batch_idx==0 in overlap mode
+                        # because the previous extend batch may still be running.
+                        if req.decode_batch_idx % evict_interval == 1:
+                            self._evict_swa(
+                                req, req.seqlen - 1, sliding_window_size, page_size, dp_rank
+                            )
             return
 
         if self.forward_mode is None or not self.forward_mode.is_extend():
             return
 
-        # Only do per-request SWA eviction during extend for ChunkCache.
-        # For SWARadixCache, extend-time ownership stays with the tree and
-        # eviction is deferred to tree insert / tree-pressure handling.
+        # For SWARadixCache with active tree, extend-time SWA ownership stays
+        # with the tree — eviction is deferred to tree insert / pressure handling.
+        # ChunkCache and SWAChunkCache need direct per-request eviction.
         if not isinstance(self.tree_cache, ChunkCache):
             return
 
         chunked_prefill_size = global_server_args_dict["chunked_prefill_size"]
         for dp_rank, info in enumerate(self.reqs_info):
-            if not info.reqs:
+            if not info.reqs or not info.prefix_lens:
                 continue
-            for req in info.reqs:
-                pre_len = len(req.prefix_indices)
-                if (
-                    self.enable_overlap
-                    and req.is_chunked > 0
-                    and chunked_prefill_size is not None
-                    and chunked_prefill_size > 0
-                ):
-                    pre_len -= chunked_prefill_size
+            for idx, req in enumerate(info.reqs):
+                pre_len = info.prefix_lens[idx]
+                if self.enable_overlap:
+                    # In overlap mode, the previous extend batch is still running
+                    # when we schedule/evict, so skip the first two extend batches.
+                    if req.extend_batch_idx < 2:
+                        continue
+                    if chunked_prefill_size is not None and chunked_prefill_size > 0:
+                        pre_len -= chunked_prefill_size
                 self._evict_swa(req, pre_len, sliding_window_size, page_size, dp_rank)
 
     def _evict_swa(

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1357,6 +1357,9 @@ class ScheduleBatch:
                     if isinstance(self.tree_cache, ChunkCache):
                         # ChunkCache/SWAChunkCache: no tree-node overlap concern,
                         # evict on every decode step to prevent SWA exhaustion.
+                        # TODO(PD-disagg): evicting at decode_batch_idx==0 may
+                        # conflict with KV transfer in a future PD disaggregation
+                        # pipeline; revisit when implementing PD.
                         if req.decode_batch_idx % evict_interval == 0:
                             self._evict_swa(
                                 req, req.seqlen - 1, sliding_window_size, page_size, dp_rank

--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -416,10 +416,12 @@ class PrefillAdder:
             _rem_tokens = min(
                 _rem_tokens, int(self.rem_swa_tokens_for_dp(dp_rank)) - self.page_size
             )
-        if _rem_tokens <= 0 and self.is_hybrid:
-            return req
+        if _rem_tokens <= 0:
+            if self.is_hybrid:
+                return req
+            _rem_tokens = self.rem_chunk_tokens_list[dp_rank]
         truncated = req.extend_input_len > _rem_tokens
-        req.extend_input_len = min(req.extend_input_len, max(_rem_tokens, 0))
+        req.extend_input_len = min(req.extend_input_len, _rem_tokens)
         req.fill_ids = req.fill_ids[: len(req.prefix_indices) + req.extend_input_len]
         self.can_run_list[dp_rank].append(req)
         self._update_prefill_budget(

--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -312,6 +312,7 @@ class PrefillAdder:
                     )
 
         self.is_hybrid = isinstance(self.token_to_kv_pool_allocator, SWATokenToKVPoolAllocator)
+        self.rem_swa_token_offset = [0] * dp_size
 
     def rem_total_tokens_for_dp(self, dp_rank: int) -> int:
         """Calculate remaining total tokens for a specific DP rank.
@@ -337,29 +338,36 @@ class PrefillAdder:
         return available_and_evictable - self.rem_total_token_offset[dp_rank]
 
     def cur_rem_tokens_for_dp(self, dp_rank: int) -> int:
-        """Calculate current remaining tokens for a specific DP rank.
-
-        Args:
-            dp_rank: DP rank to calculate for
-
-        Returns:
-            Available tokens minus current token offset
-        """
         if self.is_hybrid:
-            # For immediate prefill budget, respect both pools since prefill
-            # allocates input_len pages from both full and SWA pools.
-            available_and_evictable = min(
-                self.token_to_kv_pool_allocator.full_available_size(dp_rank=dp_rank)
-                + self.tree_cache.full_evictable_size(dp_rank=dp_rank),
-                self.token_to_kv_pool_allocator.swa_available_size(dp_rank=dp_rank)
-                + self.tree_cache.swa_evictable_size(dp_rank=dp_rank),
-            )
+            available_and_evictable = self.token_to_kv_pool_allocator.full_available_size(
+                dp_rank=dp_rank
+            ) + self.tree_cache.full_evictable_size(dp_rank=dp_rank)
         else:
             available_and_evictable = self.token_to_kv_pool_allocator.available_size(
                 dp_rank=dp_rank
             ) + self.tree_cache.evictable_size(dp_rank=dp_rank)
 
         return available_and_evictable - self.cur_rem_token_offset[dp_rank]
+
+    def rem_swa_tokens_for_dp(self, dp_rank: int) -> int:
+        return (
+            self.token_to_kv_pool_allocator.swa_available_size(dp_rank=dp_rank)
+            + self.tree_cache.swa_evictable_size(dp_rank=dp_rank)
+            - self.rem_swa_token_offset[dp_rank]
+        )
+
+    def _swa_budget_for_req(self, extend_input_len: int, dp_rank: int) -> int:
+        """SWA pool budget per request.
+
+        With chunked prefill + overlap, peak SWA occupancy per request is
+        one chunk plus the sliding window. Floor at sliding_window_size
+        to reserve room for decode phase.
+        """
+        rem_chunk = (
+            self.rem_chunk_tokens_list[dp_rank] if self.rem_chunk_tokens_list is not None else None
+        )
+        alloc = min(extend_input_len, rem_chunk) if rem_chunk is not None else extend_input_len
+        return max(alloc, self.tree_cache.sliding_window_size) + self.page_size
 
     @property
     def rem_total_tokens(self):
@@ -384,7 +392,10 @@ class PrefillAdder:
         return (size + self.page_size - 1) // self.page_size * self.page_size
 
     def budget_state(self):
-        if self.rem_total_tokens <= 0 or self.cur_rem_tokens <= 0:
+        no_token = self.rem_total_tokens <= 0 or self.cur_rem_tokens <= 0
+        if not no_token and self.is_hybrid:
+            no_token = all(self.rem_swa_tokens_for_dp(dp) <= 0 for dp in range(self.dp_size))
+        if no_token:
             return AddReqResult.NO_TOKEN
 
         if self.rem_input_tokens <= 0 or (
@@ -399,8 +410,14 @@ class PrefillAdder:
         _rem_tokens = min(
             self.rem_chunk_tokens_list[dp_rank], int(self.rem_total_tokens_for_dp(dp_rank))
         )
+        if self.is_hybrid:
+            _rem_tokens = min(
+                _rem_tokens, int(self.rem_swa_tokens_for_dp(dp_rank)) - self.page_size
+            )
+        if _rem_tokens <= 0 and self.is_hybrid:
+            return req
         truncated = req.extend_input_len > _rem_tokens
-        req.extend_input_len = min(req.extend_input_len, _rem_tokens)
+        req.extend_input_len = min(req.extend_input_len, max(_rem_tokens, 0))
         req.fill_ids = req.fill_ids[: len(req.prefix_indices) + req.extend_input_len]
         self.can_run_list[dp_rank].append(req)
         self._update_prefill_budget(
@@ -420,14 +437,6 @@ class PrefillAdder:
     def _update_prefill_budget(
         self, prefix_len: int, extend_input_len: int, max_new_tokens: int, dp_rank: int
     ):
-        """Update prefill budget for a specific DP rank.
-
-        Args:
-            prefix_len: Matched prefix length
-            extend_input_len: Input length to extend
-            max_new_tokens: Maximum new tokens to generate
-            dp_rank: DP rank being updated
-        """
         extend_input_len = self.ceil_paged_tokens(extend_input_len)
 
         self.rem_total_token_offset[dp_rank] += extend_input_len + max_new_tokens
@@ -435,6 +444,11 @@ class PrefillAdder:
         self.rem_input_tokens -= extend_input_len
         if self.rem_chunk_tokens_list is not None:
             self.rem_chunk_tokens_list[dp_rank] -= extend_input_len
+
+        if self.is_hybrid:
+            self.rem_swa_token_offset[dp_rank] += self._swa_budget_for_req(
+                extend_input_len, dp_rank
+            )
 
         self.log_hit_tokens += prefix_len
         self.log_input_tokens += extend_input_len
@@ -456,9 +470,14 @@ class PrefillAdder:
 
     def add_one_req_ignore_eos(self, req: Req):
         dp_rank = req.dp_rank if req.dp_rank is not None else 0
-        if self.ceil_paged_tokens(req.extend_input_len) > min(
+        paged_input = self.ceil_paged_tokens(req.extend_input_len)
+        if paged_input > min(
             self.cur_rem_tokens_for_dp(dp_rank), self.rem_total_tokens_for_dp(dp_rank)
         ):
+            return AddReqResult.NO_TOKEN
+        if self.is_hybrid and self._swa_budget_for_req(
+            req.extend_input_len, dp_rank
+        ) > self.rem_swa_tokens_for_dp(dp_rank):
             return AddReqResult.NO_TOKEN
 
         def add_req_state(r, insert_sort=False):
@@ -553,6 +572,11 @@ class PrefillAdder:
         if total_tokens >= self.rem_total_tokens_for_dp(dp_rank):
             return AddReqResult.NO_TOKEN
 
+        if self.is_hybrid:
+            swa_needed = self._swa_budget_for_req(req.extend_input_len, dp_rank)
+            if swa_needed >= self.rem_swa_tokens_for_dp(dp_rank):
+                return AddReqResult.NO_TOKEN
+
         total_can_run = sum(len(v) for v in self.can_run_list.values())
         if real_input_tokens >= self.rem_input_tokens and total_can_run != 0:
             return AddReqResult.OTHER
@@ -561,6 +585,11 @@ class PrefillAdder:
             # self.rem_total_tokens may decrease after the lock acquisition
             if total_tokens >= self.rem_total_tokens_for_dp(dp_rank):
                 return AddReqResult.NO_TOKEN
+
+            if self.is_hybrid:
+                swa_needed = self._swa_budget_for_req(req.extend_input_len, dp_rank)
+                if swa_needed >= self.rem_swa_tokens_for_dp(dp_rank):
+                    return AddReqResult.NO_TOKEN
             req.last_matched_prefix_len = prefix_len
             input_tokens = self.ceil_paged_tokens(req.extend_input_len)
 

--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -367,7 +367,9 @@ class PrefillAdder:
             self.rem_chunk_tokens_list[dp_rank] if self.rem_chunk_tokens_list is not None else None
         )
         alloc = min(extend_input_len, rem_chunk) if rem_chunk is not None else extend_input_len
-        return max(alloc, self.tree_cache.sliding_window_size) + self.page_size
+        return (
+            self.ceil_paged_tokens(max(alloc, self.tree_cache.sliding_window_size)) + self.page_size
+        )
 
     @property
     def rem_total_tokens(self):

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -66,7 +66,7 @@ from sgl_jax.srt.managers.scheduler_profiler_mixing import SchedulerProfilerMixi
 from sgl_jax.srt.managers.tp_worker import ModelWorker
 from sgl_jax.srt.managers.tp_worker_overlap_thread import ModelWorkerClient
 from sgl_jax.srt.managers.utils import validate_input_length
-from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
+from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache, SWAChunkCache
 from sgl_jax.srt.mem_cache.radix_cache import RadixCache
 from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
@@ -518,13 +518,21 @@ class Scheduler(
         self.req_to_token_pool, self.token_to_kv_pool_allocator = self.tp_worker.get_memory_pool()
 
         if self.is_hybrid:
-            self.tree_cache = SWARadixCache(
-                req_to_token_pool=self.req_to_token_pool,
-                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-                sliding_window_size=self.sliding_window_size,
-                page_size=self.page_size,
-                disable=server_args.disable_radix_cache,
-            )
+            if server_args.disable_radix_cache:
+                self.tree_cache = SWAChunkCache(
+                    req_to_token_pool=self.req_to_token_pool,
+                    token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                    page_size=self.page_size,
+                    sliding_window_size=self.sliding_window_size,
+                )
+            else:
+                self.tree_cache = SWARadixCache(
+                    req_to_token_pool=self.req_to_token_pool,
+                    token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                    sliding_window_size=self.sliding_window_size,
+                    page_size=self.page_size,
+                    disable=False,
+                )
         elif server_args.chunked_prefill_size is not None and server_args.disable_radix_cache:
             self.tree_cache = ChunkCache(
                 req_to_token_pool=self.req_to_token_pool,
@@ -1557,6 +1565,11 @@ class Scheduler(
                 len(self.running_batch.reqs_info[dp_rank].reqs) + len(adder.can_run_list[dp_rank])
                 >= self.per_dp_max_running_requests
             ):
+                continue
+
+            # Skip DP ranks with an ongoing chunked request to avoid
+            # creating a second chunked req on the same rank.
+            if self.chunked_reqs[dp_rank] is not None:
                 continue
 
             # Check LoRA constraint: ensure we don't exceed max_loras_per_batch

--- a/python/sgl_jax/srt/mem_cache/chunk_cache.py
+++ b/python/sgl_jax/srt/mem_cache/chunk_cache.py
@@ -4,7 +4,10 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from sgl_jax.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+from sgl_jax.srt.mem_cache.allocator import (
+    BaseTokenToKVPoolAllocator,
+    SWATokenToKVPoolAllocator,
+)
 from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache, MatchResult
 from sgl_jax.srt.mem_cache.memory_pool import ReqToTokenPool
 
@@ -65,3 +68,35 @@ class ChunkCache(BasePrefixCache):
 
     def pretty_print(self):
         return ""
+
+
+class SWAChunkCache(ChunkCache):
+    """ChunkCache with support for sliding window attention.
+
+    Used when disable_radix_cache=True and the model is a hybrid SWA model.
+    """
+
+    def __init__(
+        self,
+        req_to_token_pool: ReqToTokenPool,
+        token_to_kv_pool_allocator: SWATokenToKVPoolAllocator,
+        page_size: int,
+        sliding_window_size: int,
+    ):
+        super().__init__(req_to_token_pool, token_to_kv_pool_allocator, page_size)
+        self.sliding_window_size = sliding_window_size
+
+    def supports_swa(self) -> bool:
+        return True
+
+    def full_evictable_size(self, dp_rank: int = 0) -> int:
+        return 0
+
+    def swa_evictable_size(self, dp_rank: int = 0) -> int:
+        return 0
+
+    def full_protected_size(self, dp_rank: int = 0) -> int:
+        return 0
+
+    def swa_protected_size(self, dp_rank: int = 0) -> int:
+        return 0

--- a/python/sgl_jax/test/mem_cache/test_swa_allocator.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_allocator.py
@@ -699,6 +699,8 @@ class TestSWAOverlapSafety(CustomTestCase):
                 # for the cached portion (len_{k-1} after iter k-1's process).
                 req.prefix_indices = full_row[:cumulative].copy()
                 req.extend_batch_idx = k
+                # Sync batch-level prefix_lens (used by maybe_evict_swa)
+                batch.reqs_info[0].prefix_lens = [cumulative]
 
                 batch.maybe_evict_swa()
 


### PR DESCRIPTION
## Summary

Fixes #1227. Hybrid SWA models (MiMo-V2-Flash) with `disable_radix_cache + chunked_prefill` had decode concurrency throttled from **64 → 16** and server hang (watchdog timeout) due to SWA pool exhaustion.

- Port `SWAChunkCache` from upstream for `disable_radix_cache + hybrid` (replaces broken `SWARadixCache(disable=True)`)
- Fix extend-time SWA eviction: `extend_batch_idx < 2` guard + batch-level `prefix_lens`
- Fix decode-time SWA eviction: evict at `decode_batch_idx == 0` for ChunkCache (safe, no tree-node overlap)
- Decouple SWA budget from full-pool admission with independent tracking

## Reproduction

Server (16-chip v6e, 4 nodes):
```bash
python -m sgl_jax.launch_server \
  --model-path /models/MiMo-V2-Flash --trust-remote-code \
  --tp-size 16 --dp-size 4 --ep-size 16 --moe-backend epmoe \
  --nnodes 4 --node-rank $TPU_WORKER_ID \
  --dist-init-addr $HEAD_SVC:30000 \
  --page-size 256 --context-length 262144 --disable-radix-cache \
  --chunked-prefill-size 2048 --dtype bfloat16 --mem-fraction-static 0.95 \
  --swa-full-tokens-ratio 0.2 --max-running-requests 128 \
  --attention-backend fa --dp-schedule-policy round_robin
```

Benchmark:
```bash
python -m sgl_jax.bench_serving \
  --backend sgl-jax --host 127.0.0.1 --port 30271 \
  --dataset-name random --random-input-len 16384 --random-output-len 1024 \
  --random-range-ratio 1.0 --flush-cache --seed 12345 \
  --request-rate 100 --num-prompts 256 --max-concurrency 64 \
  --tokenizer XiaomiMiMo/MiMo-V2-Flash
```

## Results

### --disable-radix-cache

#### Before (main 1527bf4b)

```
============ Serving Benchmark Result ============
Backend:                                 sgl-jax
Traffic request rate:                    100.0
Max request concurrency:                 64
Successful requests:                     256
Benchmark duration (s):                  495.69
Total input tokens:                      4194304
Total input text tokens:                 4194304
Total generated tokens:                  262144
Total generated tokens (retokenized):    259563
Request throughput (req/s):              0.52
Input token throughput (tok/s):          8461.58
Output token throughput (tok/s):         528.85
Peak output token throughput (tok/s):    1075.00
Peak concurrent requests:                80
Total token throughput (tok/s):          8990.43
Concurrency:                             57.97
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   112244.21
Median E2E Latency (ms):                 123412.99
P90 E2E Latency (ms):                    124237.69
P99 E2E Latency (ms):                    124382.67
---------------Time to First Token----------------
Mean TTFT (ms):                          90895.54
Median TTFT (ms):                        100486.88
P99 TTFT (ms):                           108512.77
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          20.87
Median TPOT (ms):                        21.10
P99 TPOT (ms):                           26.71
---------------Inter-Token Latency----------------
Mean ITL (ms):                           20.87
Median ITL (ms):                         15.24
P95 ITL (ms):                            15.69
P99 ITL (ms):                            15.90
Max ITL (ms):                            12496.70
==================================================
```

#### After (this PR)

```
============ Serving Benchmark Result ============
Backend:                                 sgl-jax
Traffic request rate:                    100.0
Max request concurrency:                 64
Successful requests:                     256
Benchmark duration (s):                  371.68
Total input tokens:                      4194304
Total input text tokens:                 4194304
Total generated tokens:                  262144
Total generated tokens (retokenized):    260691
Request throughput (req/s):              0.69
Input token throughput (tok/s):          11284.74
Output token throughput (tok/s):         705.30
Peak output token throughput (tok/s):    2560.00
Peak concurrent requests:                128
Total token throughput (tok/s):          11990.04
Concurrency:                             63.92
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   92807.61
Median E2E Latency (ms):                 92900.81
P90 E2E Latency (ms):                    92973.71
P99 E2E Latency (ms):                    92983.00
---------------Time to First Token----------------
Mean TTFT (ms):                          33647.47
Median TTFT (ms):                        33100.30
P99 TTFT (ms):                           66688.53
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          57.83
Median TPOT (ms):                        58.27
P99 TPOT (ms):                           87.01
---------------Inter-Token Latency----------------
Mean ITL (ms):                           57.83
Median ITL (ms):                         25.49
P95 ITL (ms):                            26.63
P99 ITL (ms):                            31.06
Max ITL (ms):                            55131.29
==================================================
```

#### Comparison (--disable-radix-cache)

| Metric | Before (main) | After (this PR) | Change |
|---|---|---|---|
| Output throughput (tok/s) | 528.85 | 705.30 | **+33%** |
| Peak output throughput (tok/s) | 1075.00 | 2560.00 | **+138%** |
| Request throughput (req/s) | 0.52 | 0.69 | **+33%** |
| Concurrency | 57.97 | 63.92 | +10% |
| Benchmark duration (s) | 495.69 | 371.68 | **-25%** |
| Mean TTFT (ms) | 90895 | 33647 | **-63%** |
| Mean E2E (ms) | 112244 | 92808 | **-17%** |

### Radix cache enabled (no regression)

#### Before (main 1527bf4b)

```
============ Serving Benchmark Result ============
Backend:                                 sgl-jax
Traffic request rate:                    100.0
Max request concurrency:                 64
Successful requests:                     256
Benchmark duration (s):                  2172.00
Total input tokens:                      4194304
Total input text tokens:                 4194304
Total generated tokens:                  262144
Total generated tokens (retokenized):    261241
Request throughput (req/s):              0.12
Input token throughput (tok/s):          1931.08
Output token throughput (tok/s):         120.69
Peak output token throughput (tok/s):    2073.00
Peak concurrent requests:                121
Total token throughput (tok/s):          2051.77
Concurrency:                             63.45
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   538349.78
Median E2E Latency (ms):                 409570.47
P90 E2E Latency (ms):                    738663.75
P99 E2E Latency (ms):                    738672.85
---------------Time to First Token----------------
Mean TTFT (ms):                          311568.56
Median TTFT (ms):                        305098.35
P99 TTFT (ms):                           519456.63
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          221.68
Median TPOT (ms):                        241.81
P99 TPOT (ms):                           401.64
---------------Inter-Token Latency----------------
Mean ITL (ms):                           221.68
Median ITL (ms):                         30.64
P95 ITL (ms):                            33.33
P99 ITL (ms):                            38.34
Max ITL (ms):                            324790.52
==================================================
```

#### After (this PR)

```
============ Serving Benchmark Result ============
Backend:                                 sgl-jax
Traffic request rate:                    100.0
Max request concurrency:                 64
Successful requests:                     256
Benchmark duration (s):                  1115.29
Total input tokens:                      4194304
Total input text tokens:                 4194304
Total generated tokens:                  262144
Total generated tokens (retokenized):    261362
Request throughput (req/s):              0.23
Input token throughput (tok/s):          3760.73
Output token throughput (tok/s):         235.05
Peak output token throughput (tok/s):    2636.00
Peak concurrent requests:                128
Total token throughput (tok/s):          3995.78
Concurrency:                             63.98
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   278713.63
Median E2E Latency (ms):                 278587.15
P90 E2E Latency (ms):                    279711.37
P99 E2E Latency (ms):                    279972.92
---------------Time to First Token----------------
Mean TTFT (ms):                          128307.45
Median TTFT (ms):                        128154.58
P99 TTFT (ms):                           252503.14
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          147.02
Median TPOT (ms):                        147.32
P99 TPOT (ms):                           267.91
---------------Inter-Token Latency----------------
Mean ITL (ms):                           147.02
Median ITL (ms):                         25.08
P95 ITL (ms):                            26.31
P99 ITL (ms):                            30.17
Max ITL (ms):                            249948.65
==================================================
```

#### Comparison (radix cache enabled)

| Metric | Before (main) | After (this PR) | Change |
|---|---|---|---|
| Output throughput (tok/s) | 120.69 | 235.05 | **+95%** |
| Input throughput (tok/s) | 1931.08 | 3760.73 | **+95%** |
| Benchmark duration (s) | 2172.00 | 1115.29 | **-49%** |
| Mean TTFT (ms) | 311568 | 128307 | **-59%** |
| Mean E2E (ms) | 538349 | 278713 | **-48%** |

### Accuracy (GSM8K, radix cache enabled)

```
evalscope eval --model XiaomiMiMo/MiMo-V2-Flash \
  --api-url http://127.0.0.1:30271/v1/chat/completions --api-key EMPTY \
  --eval-type service --datasets gsm8k --eval-batch-size 32 \
  --generation-config '{"temperature": 0.8,"top_p":0.95}'
```

```json
{
    "name": "MiMo-V2-Flash@gsm8k",
    "dataset_name": "gsm8k",
    "model_name": "MiMo-V2-Flash",
    "score": 0.9136,
    "metrics": [
        {
            "name": "AverageAccuracy",
            "num": 1319,
            "score": 0.9136
        }
    ]
}
```

GSM8K accuracy: **91.36%** (1319 samples, temperature=0.8) — no accuracy regression.

## Test plan

- [x] MiMo-V2-Flash on 16-chip v6e (dp=4, tp=16, ep=16) with `--disable-radix-cache --chunked-prefill-size 2048 --swa-full-tokens-ratio 0.2`
- [x] Decode concurrency reaches 64 (16 per DP)
- [x] No watchdog timeout
- [x] Benchmark completes all 256 prompts
- [x] Radix cache enabled: no regression (+95% throughput vs main)
- [x] GSM8K accuracy 91.36% — no accuracy regression
- [ ] CI P0 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)