### PR TITLE
fix(scheduler): align TEST_RETRACT with upstream sglang

### DIFF
--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1702,7 +1702,7 @@ class Scheduler(
             return batch
 
         # Check if decode out of memory
-        if not batch.check_decode_mem() or (
+        if (kv_full_retract_flag := not batch.check_decode_mem()) or (
             TEST_RETRACT and self.forward_ct % TEST_RETRACT_INTERVAL == 0
         ):
             old_ratio = self.new_token_ratio
@@ -1719,13 +1719,22 @@ class Scheduler(
                 else:
                     self.send_to_tokenizer.send_pyobj(abort_out)
 
-            logger.info(
-                "KV cache pool is full. Retract requests. #retracted_reqs: %d, #aborted_reqs: %d, #new_token_ratio: %.4f -> %.4f",
-                num_retracted_reqs,
-                len(reqs_to_abort),
-                old_ratio,
-                self.new_token_ratio,
-            )
+            if kv_full_retract_flag:
+                logger.warning(
+                    "KV cache pool is full. Retract requests."
+                    " #retracted_reqs: %d, #aborted_reqs: %d,"
+                    " #new_token_ratio: %.4f -> %.4f",
+                    num_retracted_reqs,
+                    len(reqs_to_abort),
+                    old_ratio,
+                    self.new_token_ratio,
+                )
+            else:
+                logger.info(
+                    "Testing retraction." " #retracted_reqs: %d, #aborted_reqs: %d",
+                    num_retracted_reqs,
+                    len(reqs_to_abort),
+                )
 
             self._extend_requests_to_queue(retracted_reqs, is_retracted=True)
         else:

--- a/test/srt/test_retract_decode.py
+++ b/test/srt/test_retract_decode.py
@@ -1,8 +1,10 @@
 """Integration tests for the retract / release_kv_cache path.
 
-SGLANG_TEST_RETRACT=1 forces retract on batch_size > 10. Pass criterion:
-the worker stays alive (process.poll() is None) -- a leak would trip
-scheduler.check_memory() and SIGQUIT.
+SGLANG_TEST_RETRACT=1 forces retract every TEST_RETRACT_INTERVAL (default 3)
+forward steps. TEST_RETRACT_NO_PREFILL_BS caps prefill admission to bound
+the retract-prefill loop. Pass criterion: the worker stays alive
+(process.poll() is None) -- a leak would trip scheduler.check_memory()
+and SIGQUIT.
 """
 
 import time
@@ -67,6 +69,7 @@ class _BaseRetractDecode(CustomTestCase):
             other_args=launch_args,
             env={
                 "SGLANG_TEST_RETRACT": "1",
+                "SGLANG_TEST_RETRACT_NO_PREFILL_BS": "6",
                 "JAX_COMPILATION_CACHE_DIR": "/tmp/jax_compilation_cache",
             },
         )


### PR DESCRIPTION
## Summary
- PR #994 ported the upstream `forward_ct % TEST_RETRACT_INTERVAL` trigger but missed setting `TEST_RETRACT_NO_PREFILL_BS` in the test, causing `test_retract_decode.py` to enter an infinite retract→re-prefill loop (hang or ~87× slowdown)
- Align with upstream sglang's full mechanism:
  - **Trigger**: `forward_ct % interval` with `kv_full_retract_flag` walrus operator to distinguish real OOM from test retract
  - **Test**: set `SGLANG_TEST_RETRACT_NO_PREFILL_BS=6` (matching upstream `test_scheduler_control.py`) to cap prefill admission and bound the loop
  - **Log**: differentiate `"KV cache pool is full."` (real OOM) from `"Testing retraction."` (test-forced) to prevent misleading logs

## Test plan
- [ ] CI `e2e-test-4-tpu (1)` shard passes with `test_retract_decode.py` completing in expected time (~12s)
- [ ] No regression in other e2e test shards

Fixes #1229

Replaces #1233 (migrated from fork to upstream branch)