### PR TITLE
test(nightly): add server infra smoke tests (#1207)

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -67,11 +67,30 @@ jobs:
       id-token: write
     secrets: inherit
 
+  nightly-infra-smoke-1-tpu-daily:
+    if: github.repository == 'sgl-project/sglang-jax'
+    runs-on: arc-runner-v6e-1
+    env:
+      TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
+      - name: Run infra smoke tests (#1207)
+        timeout-minutes: 30
+        run: |
+          cd test/srt
+          python3 run_suite.py --suite nightly-infra-smoke-tpu-v6e-1
+
   nightly-test-daily-finish:
     needs: [
       nightly-test-accuracy-text-models-1-tpu-daily,
       nightly-test-perf-text-models-1-tpu-daily,
       multi-host-test-mimo-flash-daily,
+      nightly-infra-smoke-1-tpu-daily,
     ]
     if: always() && github.repository == 'sgl-project/sglang-jax'
     runs-on: ubuntu-latest
@@ -82,13 +101,15 @@ jobs:
           echo "accuracy-1-tpu-daily: ${{ needs.nightly-test-accuracy-text-models-1-tpu-daily.result }}"
           echo "perf-text-1-tpu-daily: ${{ needs.nightly-test-perf-text-models-1-tpu-daily.result }}"
           echo "multi-host-mimo-flash-daily: ${{ needs.multi-host-test-mimo-flash-daily.result }}"
+          echo "infra-smoke-1-tpu-daily: ${{ needs.nightly-infra-smoke-1-tpu-daily.result }}"
           echo ""
 
           has_failure=false
           for job_result in \
             "accuracy-1-tpu-daily=${{ needs.nightly-test-accuracy-text-models-1-tpu-daily.result }}" \
             "perf-text-1-tpu-daily=${{ needs.nightly-test-perf-text-models-1-tpu-daily.result }}" \
-            "multi-host-mimo-flash-daily=${{ needs.multi-host-test-mimo-flash-daily.result }}"; do
+            "multi-host-mimo-flash-daily=${{ needs.multi-host-test-mimo-flash-daily.result }}" \
+            "infra-smoke-1-tpu-daily=${{ needs.nightly-infra-smoke-1-tpu-daily.result }}"; do
             job_name="${job_result%%=*}"
             result="${job_result#*=}"
             if [ "$result" != "success" ]; then

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -242,6 +242,11 @@ suites = {
     # Daily workflow keeps running so new cases can be added without restructuring CI.
     "nightly-test-accuracy-text-models-tpu-v6e-1-daily": [],
     "nightly-test-perf-text-models-tpu-v6e-1-daily": [],
+    # Infra smoke tests (#1207): radix-cache consistency, request logger, bench-serving self-check.
+    # Paths relative to test/srt/ (CI invokes via `cd test/srt && python3 run_suite.py`).
+    "nightly-infra-smoke-tpu-v6e-1": [
+        TestFile("test_nightly_infra_smoke.py", 15),
+    ],
     "sglang_dependency_test": [],
     "unit-test-tpu-v6e-1": [
         TestFile("python/sgl_jax/test/kernels/quantized_linear_test.py", 0.3, runner="pytest"),
@@ -296,6 +301,7 @@ suites = {
         TestFile("test/srt/openai_server/basic/test_serving_chat.py", 0.1),
         TestFile("test/srt/openai_server/basic/test_serving_completions.py", 0.1),
         TestFile("test/srt/test_reasoning_parser.py", 0.1),
+        TestFile("test/srt/test_server_info.py", 0.1),
     ],
     "unit-test-tpu-v6e-4": [
         TestFile("python/sgl_jax/test/test_mesh.py", 0.4),

--- a/test/srt/test_nightly_infra_smoke.py
+++ b/test/srt/test_nightly_infra_smoke.py
@@ -1,0 +1,262 @@
+"""Server-infrastructure smoke tests for nightly CI.
+
+Three tests verify fundamental server paths using Qwen3-1.7B:
+  1. Radix cache consistency: prefix reuse, padding/non-padding, page-crossing
+  2. Request logger: sequential + concurrent field completeness, no dropped entries
+  3. Bench-serving self-check: queueing under load, variable-length batching
+"""
+
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import requests
+
+from sgl_jax.bench_serving import run_benchmark
+from sgl_jax.srt.utils import kill_process_tree
+from sgl_jax.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    get_benchmark_args,
+    popen_launch_server,
+)
+
+_MODEL = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+_BASE_URL = DEFAULT_URL_FOR_TEST
+
+_COMMON_SERVER_ARGS = [
+    "--skip-server-warmup",
+    "--dtype",
+    "bfloat16",
+    "--mem-fraction-static",
+    "0.8",
+    "--max-running-requests",
+    "16",
+    "--page-size",
+    "64",
+    "--random-seed",
+    "42",
+]
+
+_SAMPLING_PARAMS = {"temperature": 0, "max_new_tokens": 32}
+
+_PROMPT_A = "The capital of France is"
+_PROMPT_A_EXTENDED = "The capital of France is Paris. The capital of Germany is"
+_PROMPT_LONG = (
+    "In the field of artificial intelligence, large language models have shown "
+    "remarkable capabilities in natural language processing. These models can "
+    "perform text generation, translation, summarization, and question answering. "
+    "The most important breakthrough in this area is"
+)
+# max_new_tokens=80 crosses page boundary with page_size=64
+_RADIX_SAMPLING_PARAMS = {"temperature": 0, "max_new_tokens": 80}
+
+
+def _generate(base_url, prompt, sampling_params):
+    response = requests.post(
+        f"{base_url}/generate",
+        json={"text": prompt, "sampling_params": sampling_params},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _kill_and_wait(process, timeout=5):
+    kill_process_tree(process.pid)
+    try:
+        process.wait(timeout=timeout)
+    except Exception:
+        pass
+
+
+class TestRadixCacheConsistency(CustomTestCase):
+
+    def test_radix_on_off_consistency(self):
+        test_prompts = [
+            ("short", _PROMPT_A),
+            ("prefix_hit", _PROMPT_A_EXTENDED),
+            ("long", _PROMPT_LONG),
+        ]
+
+        outputs = {}
+        for mode, extra_args in [
+            ("radix_on", []),
+            ("radix_off", ["--disable-radix-cache"]),
+        ]:
+            process = popen_launch_server(
+                _MODEL,
+                _BASE_URL,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=[*_COMMON_SERVER_ARGS, *extra_args],
+            )
+            try:
+                for name, prompt in test_prompts:
+                    result = _generate(_BASE_URL, prompt, _RADIX_SAMPLING_PARAMS)
+                    outputs[(mode, name)] = result["text"]
+
+                if mode == "radix_on":
+                    result = _generate(_BASE_URL, _PROMPT_A, _RADIX_SAMPLING_PARAMS)
+                    outputs[("radix_on", "short_rehit")] = result["text"]
+            finally:
+                _kill_and_wait(process)
+                time.sleep(2)
+
+        for name, _ in test_prompts:
+            self.assertEqual(
+                outputs[("radix_on", name)],
+                outputs[("radix_off", name)],
+                f"Radix on/off outputs differ for '{name}' with greedy sampling",
+            )
+
+        self.assertEqual(
+            outputs[("radix_on", "short")],
+            outputs[("radix_on", "short_rehit")],
+            "Radix cache hit produced different output for re-sent short prompt",
+        )
+
+
+class TestRequestLogger(CustomTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        fd, cls._log_path = tempfile.mkstemp(suffix=".log")
+        cls._log_fh = os.fdopen(fd, "w")
+        cls.process = popen_launch_server(
+            _MODEL,
+            _BASE_URL,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                *_COMMON_SERVER_ARGS,
+                "--disable-radix-cache",
+                "--log-requests",
+                "--log-requests-level",
+                "2",
+            ],
+            return_stdout_stderr=(subprocess.DEVNULL, cls._log_fh),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "process", None) is not None:
+            _kill_and_wait(cls.process)
+        if getattr(cls, "_log_fh", None) is not None and not cls._log_fh.closed:
+            try:
+                cls._log_fh.close()
+            except Exception:
+                pass
+        if getattr(cls, "_log_path", None):
+            try:
+                os.unlink(cls._log_path)
+            except FileNotFoundError:
+                pass
+
+    def test_request_log_completeness_and_count(self):
+        num_requests = 16
+
+        marker_seq = f"SEQ_{time.time_ns()}"
+        for i in range(num_requests):
+            _generate(
+                _BASE_URL,
+                f"Prompt {marker_seq} #{i}: {_PROMPT_A}",
+                _SAMPLING_PARAMS,
+            )
+
+        marker_conc = f"CONC_{time.time_ns()}"
+        with ThreadPoolExecutor(max_workers=num_requests) as pool:
+            futures = [
+                pool.submit(
+                    _generate,
+                    _BASE_URL,
+                    f"Prompt {marker_conc} #{i}: {_PROMPT_A}",
+                    _SAMPLING_PARAMS,
+                )
+                for i in range(num_requests)
+            ]
+            for f in as_completed(futures):
+                f.result()
+
+        time.sleep(2)
+
+        with open(self._log_path) as f:
+            log_content = f.read()
+
+        lines = log_content.splitlines()
+
+        for marker, label in [
+            (marker_seq, "sequential"),
+            (marker_conc, "concurrent"),
+        ]:
+            receive = [ln for ln in lines if "Receive: obj=" in ln and marker in ln]
+            finish = [ln for ln in lines if "Finish: obj=" in ln and marker in ln]
+
+            self.assertEqual(
+                len(receive),
+                num_requests,
+                f"Expected {num_requests} Receive entries for {label}, got {len(receive)}",
+            )
+            self.assertEqual(
+                len(finish),
+                num_requests,
+                f"Expected {num_requests} Finish entries for {label}, got {len(finish)}",
+            )
+
+            for line in finish:
+                for field in ("rid=", "text=", "sampling_params="):
+                    self.assertIn(
+                        field,
+                        line,
+                        f"Finish log line missing '{field}' in {label} batch: {line[:200]}",
+                    )
+
+
+class TestBenchServingSelf(CustomTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = _MODEL
+        cls.base_url = _BASE_URL
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                *_COMMON_SERVER_ARGS,
+                "--disable-radix-cache",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "process", None) is not None:
+            _kill_and_wait(cls.process)
+
+    def test_bench_serving_runs_to_completion(self):
+        num_prompts = 32
+        args = get_benchmark_args(
+            base_url=self.base_url,
+            dataset_name="random",
+            device="tpu",
+            num_prompts=num_prompts,
+            request_rate=float("inf"),
+            random_input_len=128,
+            random_output_len=16,
+            max_concurrency=16,
+            random_range_ratio=0.5,
+        )
+        res = run_benchmark(args)
+
+        self.assertEqual(
+            res["completed"],
+            num_prompts,
+            f"Only {res['completed']}/{num_prompts} completed",
+        )
+        self.assertGreater(res["output_throughput"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_server_info.py
+++ b/test/srt/test_server_info.py
@@ -1,0 +1,81 @@
+"""Endpoint-level tests for ``/get_server_info``.
+
+Regression guard that validates the response schema of ``/get_server_info`` —
+the introspection surface that monitoring tools and routers scrape.  Uses stub
+injection (no model server needed), runs on CPU.
+
+Reference: sglang GPU ``test/registered/unit/entrypoints/test_server_info.py``
+"""
+
+import asyncio
+import dataclasses
+import unittest
+from types import SimpleNamespace
+
+from sgl_jax.srt.entrypoints import http_server
+from sgl_jax.srt.server_args import ServerArgs
+from sgl_jax.test.test_utils import CustomTestCase
+
+
+def _call_server_info_with(server_args: ServerArgs) -> dict:
+    """Invoke ``http_server.get_server_info()`` against a stub global state.
+
+    Bypasses the FastAPI HTTP layer: the handler is an ``async def`` that reads
+    the module-level ``_global_state``, so wiring a ``SimpleNamespace`` stub via
+    ``set_global_state`` and awaiting the coroutine directly is enough to
+    exercise the handler logic without booting a model server.
+    """
+
+    async def _fake_internal_state():
+        return [{"last_gen_throughput": 0.0, "memory_usage": {"kvcache": 0.0, "token_capacity": 0}}]
+
+    stub_state = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            server_args=server_args,
+            get_internal_state=_fake_internal_state,
+        ),
+        scheduler_info={"max_req_input_len": 1024},
+    )
+    prior_state = http_server._global_state
+    http_server.set_global_state(stub_state)
+    try:
+        return asyncio.run(http_server.get_server_info())
+    finally:
+        http_server._global_state = prior_state
+
+
+class TestServerInfoFieldsPreserved(CustomTestCase):
+    """Regression guard: every field existing consumers depend on must remain
+    visible in the ``/get_server_info`` response.
+    """
+
+    def test_every_server_args_field_appears_in_response(self):
+        args = ServerArgs(model_path="dummy")
+        info = _call_server_info_with(args)
+        for field in dataclasses.fields(ServerArgs):
+            self.assertIn(
+                field.name,
+                info,
+                f"ServerArgs field '{field.name}' missing from /get_server_info response",
+            )
+
+    def test_internal_states_and_version_keys_preserved(self):
+        args = ServerArgs(model_path="dummy")
+        info = _call_server_info_with(args)
+        self.assertIn("internal_states", info)
+        self.assertIsInstance(info["internal_states"], list)
+        self.assertGreater(len(info["internal_states"]), 0)
+        self.assertIn("version", info)
+
+    def test_scheduler_info_fields_merged(self):
+        args = ServerArgs(model_path="dummy")
+        info = _call_server_info_with(args)
+        self.assertIn(
+            "max_req_input_len",
+            info,
+            "scheduler_info field 'max_req_input_len' missing — scheduler_info not merged",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add three server-infrastructure smoke tests using Qwen3-1.7B (smallest available model)
  - **TestRadixCacheConsistency**: 3 prompts (short / prefix-hit / long page-crossing), radix on vs off, verifies identical output under greedy sampling; also verifies cache rehit determinism
  - **TestRequestLogger**: verifies `--log-requests --log-requests-level 2` captures Receive/Finish entries with expected fields (`rid`, `text`, `sampling_params`) for every request, no dropped entries
  - **TestBenchServingSelf**: verifies `bench_serving` tool runs to completion with minimal workload (32 prompts)
- Add stub-based `/get_server_info` schema regression guard (CPU-only, no model needed)
  - **TestServerInfoFieldsPreserved**: asserts every `ServerArgs` field, `internal_states`, `version`, and `scheduler_info` fields remain in the response — catches silent field drops that would break monitoring tools
- Register `nightly-infra-smoke-tpu-v6e-1` suite in `run_suite.py`
- Wire new `nightly-infra-smoke-1-tpu-daily` job into `nightly-test-daily.yml` with 30-min timeout

Closes #1207. Refs: #1117.

## Launch commands

Base server args shared by the three TPU smoke tests:

```bash
python3 -m sgl_jax.launch_server \
  --model-path Qwen/Qwen3-1.7B \
  --skip-server-warmup --dtype bfloat16 \
  --mem-fraction-static 0.8 --max-running-requests 16 \
  --page-size 64 --random-seed 42
```

Per-test variants:

| Test | Additional args |
|------|----------------|
| `TestRadixCacheConsistency` (radix on) | _(none — radix cache enabled by default)_ |
| `TestRadixCacheConsistency` (radix off) | `--disable-radix-cache` |
| `TestRequestLogger` | `--disable-radix-cache --log-requests --log-requests-level 2` |
| `TestBenchServingSelf` | `--disable-radix-cache` |

Note: `--device tpu` and `--trust-remote-code` are added automatically by `popen_launch_server()`.

`TestServerInfoFieldsPreserved` requires no server — it uses stub injection on CPU.

## Test commands

```bash
# TPU smoke tests (nightly)
cd test/srt
python3 run_suite.py --suite nightly-infra-smoke-tpu-v6e-1

# Server info schema guard (CPU, runs on every PR)
python -m pytest test/srt/test_server_info.py -v
```

## Files changed

- `test/srt/test_nightly_infra_smoke.py` — 3 test classes (radix cache, request logger, bench serving)
- `test/srt/test_server_info.py` — stub-based `/get_server_info` schema regression guard (CPU-only, ~5s)
- `test/srt/run_suite.py` — register `nightly-infra-smoke-tpu-v6e-1` suite + add `test_server_info.py` to `unit-test-cpu`
- `.github/workflows/nightly-test-daily.yml` — new `nightly-infra-smoke-1-tpu-daily` job + finish wiring

## What's intentionally not in this PR

- **`test_scheduler_status`** from #1207 future tasks: partially covered by `test_server_info.py` (schema stability of `/get_server_info`). The log format stability aspect (asserting `log_prefill_stats` / `log_decode_stats` output format) is not yet covered.
- **`test_server_recovery`**: already covered by existing `test/srt/test_retract_decode.py` (see [investigation comment](https://github.com/sgl-project/sglang-jax/issues/1207#issuecomment-4562804974))
- **`test_weight_loader_hf`**: the "shm cache" feature does not exist in the codebase (see investigation comment linked above)
- **Slash command integration** (`/run-nightly infra.<case_key>`) — tracked under #1208
- **Merge conflict with #1244**: both PRs modify `nightly-test-daily.yml` `needs` array and status check loop from the same base; the second to merge will need a conflict resolution

## Contributor checklist

### Threshold rationale

| Test | Pass criteria | Rationale |
|------|--------------|-----------|
| `test_radix_cache_consistency` | Byte-equal output for radix on vs off | Greedy sampling (temperature=0) with fixed random seed must produce identical text regardless of cache mode |
| `test_request_log_completeness_and_count` | Exactly N Receive + N Finish log entries; each Finish contains `rid=`, `text=`, `sampling_params=` | Level-2 logging includes all fields without truncation; entry count must match request count |
| `test_bench_serving_runs_to_completion` | All 32 prompts complete; output_throughput > 0 | Functional self-check only, no performance thresholds |
| `test_server_info_fields_preserved` | All `ServerArgs` dataclass fields + `internal_states` + `version` + `scheduler_info` keys present | Schema regression guard — catches silent field drops that break downstream consumers |

### Estimated wall-clock

**TPU smoke tests** (`test_nightly_infra_smoke.py`):

| Run | Duration |
|-----|----------|
| Run 1 | 184.86s (3:04) |
| Run 2 | 184.55s (3:04) |
| Run 3 | 184.66s (3:04) |

All runs with warm XLA cache (CI runners have persistent `JAX_COMPILATION_CACHE_DIR`). Cold-cache first run adds ~60-80s for compilation. Well within the 15-min suite budget and 30-min CI timeout.

**Server info schema guard** (`test_server_info.py`): ~5s on CPU.

### Stability

**Local (TPU v6e-4 pod, single chip via `TPU_VISIBLE_CHIPS=0`)** — 3 consecutive runs, all passed:

```
Run 1: 3 passed in 184.86s — OK
Run 2: 3 passed in 184.55s — OK
Run 3: 3 passed in 184.66s — OK
```

Variance: <0.4s across runs (negligible). Tested on 2026-05-28.

**CI (`arc-runner-v6e-1`)** — 3 nightly workflow dispatches, `nightly-infra-smoke-1-tpu-daily` job all passed:

| Run | infra-smoke result | Link |
|-----|--------------------|------|
| #1 | ✅ success | [26613889896](https://github.com/sgl-project/sglang-jax/actions/runs/26613889896) |
| #2 | ✅ success | [26614464840](https://github.com/sgl-project/sglang-jax/actions/runs/26614464840) |
| #3 | ✅ success | [26615034368](https://github.com/sgl-project/sglang-jax/actions/runs/26615034368) |

Server info schema guard — deterministic (stub-based, no variance).

## Test plan

- [x] All three TPU test classes pass on TPU v6e (verified 3/3 local runs)
- [x] Server info schema guard passes on CPU (verified locally, 3/3 passed in 5.26s)
- [x] Nightly CI `nightly-infra-smoke-1-tpu-daily` passes on `arc-runner-v6e-1` (verified 3/3 CI runs)
- [x] Existing nightly daily jobs are unaffected (accuracy/perf jobs pass in all 3 runs)



