### PR TITLE
feat(ci): single-host 4-TPU perf sweeps + reusable perf scheme (#1202)

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -1,7 +1,7 @@
 name: Nightly Test Daily
 
-# NOTE: As of #1218 the daily nightly suites are empty shells. Coverage will
-# be redefined under #1117 (nightly vs daily split decision). The workflow is
+# NOTE: The daily nightly suites are currently empty shells. Coverage will be
+# redefined as part of the nightly vs daily split decision. The workflow is
 # kept so any new daily case can be added by populating run_suite.py without
 # restructuring CI.
 
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
-      - name: Run accuracy daily suite (currently empty — see #1117)
+      - name: Run accuracy daily suite
         timeout-minutes: 10
         run: |
           cd test/srt
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
-      - name: Run perf daily suite (currently empty — see #1117)
+      - name: Run perf daily suite
         timeout-minutes: 10
         run: |
           cd test/srt
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
-      - name: Run infra smoke tests (#1207)
+      - name: Run infra smoke tests
         timeout-minutes: 30
         run: |
           cd test/srt
@@ -126,6 +126,82 @@ jobs:
           cd test/srt
           python3 nightly/single_host/suite_runner.py --suite accuracy-text-models-v6e-4
 
+  nightly-test-perf-text-models-4-tpu-daily:
+    if: github.repository == 'sgl-project/sglang-jax'
+    runs-on: arc-runner-v6e-4
+    env:
+      TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
+      SGLANG_JAX_PROFILER_DIR: ${{ github.workspace }}/test/nightly_test_output/perf/traces
+      RESULTS_DIR: ${{ github.workspace }}/test/nightly_test_output/perf
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
+      - name: Run 4-TPU perf daily suite
+        timeout-minutes: 480
+        env:
+          # Token for the trailing-baseline gate's ci-data reads (anonymous API
+          # gets rate-limited, silently disabling the trailing gate).
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+        run: |
+          cd test/srt
+          python3 nightly/single_host/suite_runner.py --suite perf-text-models-v6e-4
+      - name: Publish perf CSV to ci-data (main only)
+        if: github.ref == 'refs/heads/main' && github.repository == 'sgl-project/sglang-jax'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          # Stage as perf/<date>/<file>.csv — publish.py preserves the path under
+          # --source-dir, landing at ci-data perf/<date>/ (caller owns the layout).
+          DATE=$(date +'%Y-%m-%d')
+          STAGE=./perf_csv_stage/perf/$DATE
+          mkdir -p "$STAGE"
+          if cp ${{ github.workspace }}/test/nightly_test_output/perf/*.csv "$STAGE"/ 2>/dev/null; then
+            python3 scripts/ci/publish.py --data-type perf --source-dir ./perf_csv_stage
+          else
+            echo "::warning::No perf CSV to publish — suite produced no per-model CSV"
+          fi
+      - name: Publish perf traces to ci-data (main only)
+        if: github.ref == 'refs/heads/main' && github.repository == 'sgl-project/sglang-jax'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          # Namespace traces by date/run so runs don't pile up at the ci-data root.
+          DATE=$(date +'%Y-%m-%d')
+          STAGE=./perf_trace_stage/traces/$DATE/single-host-perf-${{ github.run_id }}
+          mkdir -p "$STAGE"
+          if cp -r ${{ github.workspace }}/test/nightly_test_output/perf/traces/. "$STAGE"/ 2>/dev/null; then
+            python3 scripts/ci/publish.py --data-type trace --source-dir ./perf_trace_stage
+          else
+            echo "::warning::No perf traces to publish"
+          fi
+      - name: Publish perf JSON to observability dashboard mount (main only)
+        if: github.ref == 'refs/heads/main' && github.repository == 'sgl-project/sglang-jax'
+        run: |
+          # observability bucket is gcsfuse-mounted (like /models), so this is a
+          # plain copy; layout matches multi-host, single-host- prefix marks source.
+          DATE=$(date +'%Y-%m-%d')
+          DEST="/observability-storage/${DATE}/single-host-perf-${{ github.run_id }}"
+          mkdir -p "$DEST"
+          cp ${{ github.workspace }}/test/nightly_test_output/perf/*.json "$DEST"/ 2>/dev/null \
+            && echo "Published perf JSON to $DEST" \
+            || echo "No perf JSON to publish"
+      - name: Upload perf results (per-model CSV + xprof traces)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-results-v6e-4-${{ github.run_id }}
+          path: ${{ github.workspace }}/test/nightly_test_output/perf
+          if-no-files-found: warn
+          retention-days: 30
+
   nightly-test-daily-finish:
     needs: [
       nightly-test-accuracy-text-models-1-tpu-daily,
@@ -134,6 +210,7 @@ jobs:
       multi-host-test-mimo-flash-daily,
       nightly-infra-smoke-1-tpu-daily,
       nightly-test-accuracy-text-models-4-tpu-daily,
+      nightly-test-perf-text-models-4-tpu-daily,
     ]
     if: always() && github.repository == 'sgl-project/sglang-jax'
     runs-on: ubuntu-latest
@@ -147,6 +224,7 @@ jobs:
           echo "multi-host-mimo-flash-daily: ${{ needs.multi-host-test-mimo-flash-daily.result }}"
           echo "infra-smoke-1-tpu-daily: ${{ needs.nightly-infra-smoke-1-tpu-daily.result }}"
           echo "accuracy-4-tpu-daily: ${{ needs.nightly-test-accuracy-text-models-4-tpu-daily.result }}"
+          echo "perf-4-tpu-daily: ${{ needs.nightly-test-perf-text-models-4-tpu-daily.result }}"
           echo ""
 
           has_failure=false
@@ -156,7 +234,8 @@ jobs:
             "openai-api-surface-1-tpu-daily=${{ needs.nightly-test-openai-api-surface-1-tpu-daily.result }}" \
             "multi-host-mimo-flash-daily=${{ needs.multi-host-test-mimo-flash-daily.result }}" \
             "infra-smoke-1-tpu-daily=${{ needs.nightly-infra-smoke-1-tpu-daily.result }}" \
-            "accuracy-4-tpu-daily=${{ needs.nightly-test-accuracy-text-models-4-tpu-daily.result }}"; do
+            "accuracy-4-tpu-daily=${{ needs.nightly-test-accuracy-text-models-4-tpu-daily.result }}" \
+            "perf-4-tpu-daily=${{ needs.nightly-test-perf-text-models-4-tpu-daily.result }}"; do
             job_name="${job_result%%=*}"
             result="${job_result#*=}"
             if [ "$job_name" = "multi-host-mimo-flash-daily" ] && [ "$result" = "skipped" ]; then

--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -656,7 +656,9 @@ class ProfileReqInput:
     # 1: Enables Python tracing (this is the default).
     python_tracer_level: int | None = None
     stage_id: int | None = None  # Which stage to count steps for (multimodal only)
-    profile_by_stage: bool = False  # Whether to profile prefill/decode separately
+    # Accept None from clients (e.g. bench_serving) that omit this field; None is
+    # treated as False (no per-stage profiling) by the scheduler boolean check.
+    profile_by_stage: bool | None = False  # Whether to profile prefill/decode separately
     profile_stages: list[str] | None = None  # Stages to profile, e.g. ["prefill", "decode"]
 
 
@@ -676,7 +678,7 @@ class ProfileReq:
     python_tracer_level: int | None = None
     profile_id: str | None = None
     stage_id: int | None = None
-    profile_by_stage: bool = False
+    profile_by_stage: bool | None = False
     profile_stages: list[str] | None = None
 
 

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -644,7 +644,7 @@ class TokenizerManager:
         host_tracer_level: int | None = None,
         python_tracer_level: int | None = None,
         stage_id: int | None = None,
-        profile_by_stage: bool = False,
+        profile_by_stage: bool | None = False,
         profile_stages: list[str] | None = None,
     ):
         self.auto_create_handle_loop()

--- a/scripts/ci/publish.py
+++ b/scripts/ci/publish.py
@@ -268,7 +268,17 @@ def publish(source_dir, data_type, run_id, run_number):
         def make_commit_message(count):
             return f"Nightly traces for run {run_id} at {run_number} ({count} files)"
 
-    else:  # bench or perf
+    elif data_type == "perf":
+        # Per-model perf CSV. Like bench, the path under --source-dir is preserved
+        # as-is; callers stage perf/<date>/<file>.csv (the caller owns the layout).
+        file_extension = ".csv"
+        no_files_msg = "No perf csv files found to upload"
+        success_msg = "Successfully published all perf csv files in a single commit"
+
+        def make_commit_message(count):
+            return f"Perf CSV of Nightly-test for run {run_id} at {run_number} ({count} files)"
+
+    else:  # bench
         file_extension = ".csv"
         no_files_msg = "No csv files found to upload"
         success_msg = "Successfully published all csv files in a single commit"
@@ -366,7 +376,7 @@ def main():
         type=str,
         required=True,
         choices=["bench", "perf", "trace"],
-        help="Type of data to publish: bench/perf (scans .csv) or trace (scans .json.gz)",
+        help="Type of data to publish: bench (scans .csv, ci-data root), perf (scans .csv, under perf/), or trace (scans .json.gz)",
     )
     args = parser.parse_args()
 

--- a/test/srt/nightly/cases.py
+++ b/test/srt/nightly/cases.py
@@ -32,6 +32,117 @@ class PerfCase:
     request_rate: float = float("inf")
     seed: int = 42
     flush_cache: bool = False
+    # Absolute-floor gate: {csv_column: min_value}. Set only on the points that
+    # have a floor (the representative point); the gate skips it when None.
+    floors: dict[str, float] | None = None
+    # Set on the one representative point that captures an xprof trace.
+    capture_trace: bool = False
+    profile_num_steps: int | None = None
+
+
+@dataclass(frozen=True)
+class PerfParams:
+    """Sweep + gate config for one perf model/config, à la sglang's
+    ``PerformanceTestParams``. The sweep is split into two intents: prefill points
+    (``output_len=1``, stress prefill — gated on in_tps + TTFT) and decode points
+    (``output_len`` long, stress decode — gated on in_tps + out_tps + ITL).
+    Defaults give a KV-safe 6-point grid; the decode concurrencies a given server
+    can actually hold are KV-bound (see the perf suite registration), so override
+    ``decode_concurrencies``/``profile_point`` per model. Override only the fields
+    you need at suite registration so the config lives next to the case, not in a
+    separate file::
+
+        PerfParams(floors={"out_tps": 657})                  # default grid + a floor
+        PerfParams(decode_concurrencies=(16, 32),            # dense (KV ceiling ~41)
+                   profile_point=(32, 4096, 1024),
+                   floors={"out_tps": 657})
+
+    ``profile_point`` is the one point that carries the floor + xprof trace; it
+    must exist in the grid (else nothing is floored/traced — a ValueError).
+
+    ``prefill_floor_point`` is the prefill representative point that carries an
+    absolute ``in_tps`` floor (``prefill_floors``), symmetric to the decode
+    ``out_tps`` floor on ``profile_point`` but with no trace. If set it must also
+    exist in the grid (else a ValueError).
+
+    Every ``decode_concurrencies`` entry must be ``<=`` the server's KV decode
+    ceiling (model + config dependent; see the measured ceilings at the perf
+    suite registration). A point above the ceiling cannot be held concurrently —
+    it queues instead of saturating, so it under-reports throughput rather than
+    failing fast. The ceiling can't be known statically, so this is a convention,
+    not a validated constraint.
+    """
+
+    # Prefill points (output_len=1): prefill throughput + TTFT.
+    prefill_concurrencies: tuple[int, ...] = (8, 32)
+    prefill_input_lens: tuple[int, ...] = (4096, 8192)
+    # Decode points (output_len=decode_output_len): adds output throughput + ITL.
+    # Default kept KV-safe (both v6e-4 configs hold c64); per-model overrides at
+    # registration push it up to each server's verified ceiling.
+    decode_concurrencies: tuple[int, ...] = (32, 64)
+    decode_input_lens: tuple[int, ...] = (4096,)
+    decode_output_len: int = 1024
+    # The single point that captures a trace (profiling perturbs the measurement,
+    # so it is not enabled everywhere) and how many steps to profile.
+    profile_point: tuple[int, int, int] = (64, 4096, 1024)
+    profile_num_steps: int = 10
+    # Absolute-floor gate for the representative point, {csv_column: min_value}.
+    floors: dict[str, float] | None = None
+    # Prefill representative: in_tps (prefill throughput) absolute floor. No trace
+    # (trace stays on profile_point/decode). Set per model at registration.
+    prefill_floor_point: tuple[int, int, int] | None = None
+    prefill_floors: dict[str, float] | None = None
+
+
+def _perf_num_prompts(concurrency: int, output_len: int) -> int:
+    # Enough queued requests to hold the target concurrency in steady state
+    # (request_rate=inf): a prefill point finishes each request fast, so it needs
+    # a deeper queue than a decode point to stay saturated.
+    if output_len <= 1:
+        return max(concurrency * 8, 256)
+    return max(concurrency * 4, 128)
+
+
+def perf_sweep_cases(prefix: str, params: PerfParams | None = None) -> list["PerfCase"]:
+    """Build the PerfCase points for one model/config from ``params``.
+
+    ``prefix`` names the model+config (e.g. ``qwen3-32b``); each point is
+    ``<prefix>-c<concurrency>-i<input_len>-o<output_len>``. The representative
+    point (``params.profile_point``) carries the floors + trace flag, so the
+    whole config is declared in one place at suite registration.
+    """
+    p = params or PerfParams()
+    # Two intents: prefill (output_len=1) + decode (output_len=decode_output_len).
+    points = [(c, i, 1) for c in p.prefill_concurrencies for i in p.prefill_input_lens]
+    points += [
+        (c, i, p.decode_output_len) for c in p.decode_concurrencies for i in p.decode_input_lens
+    ]
+    if p.profile_point not in points:
+        raise ValueError(
+            f"{prefix}: profile_point {p.profile_point} is not in the sweep grid; "
+            "no point would carry floors/trace"
+        )
+    if p.prefill_floor_point is not None and p.prefill_floor_point not in points:
+        raise ValueError(f"{prefix}: prefill_floor_point {p.prefill_floor_point} not in grid")
+    cases: list[PerfCase] = []
+    for concurrency, input_len, output_len in points:
+        pt = (concurrency, input_len, output_len)
+        is_repr = pt == p.profile_point  # decode repr: trace + out_tps floor
+        is_prefill_repr = p.prefill_floor_point is not None and pt == p.prefill_floor_point
+        point_floors = p.floors if is_repr else (p.prefill_floors if is_prefill_repr else None)
+        cases.append(
+            PerfCase(
+                name=f"{prefix}-c{concurrency}-i{input_len}-o{output_len}",
+                input_len=input_len,
+                output_len=output_len,
+                num_prompts=_perf_num_prompts(concurrency, output_len),
+                max_concurrency=concurrency,
+                floors=point_floors,
+                capture_trace=is_repr,  # trace only at decode repr
+                profile_num_steps=p.profile_num_steps if is_repr else None,
+            )
+        )
+    return cases
 
 
 @dataclass(frozen=True)

--- a/test/srt/nightly/drivers.py
+++ b/test/srt/nightly/drivers.py
@@ -1,0 +1,98 @@
+"""Case drivers: build args + invoke run_eval / run_benchmark for one case.
+
+``run_eval_for_case`` (accuracy) is shared by the single- and multi-host runners.
+``run_benchmark_for_case`` (perf) is single-host only — the multi-host perf runner
+calls ``run_benchmark`` inline. Each host runner does its own logging / gating and
+feeds the returned metrics to ``results.py`` (``build_*_result`` + ``write_*``).
+"""
+
+import os
+import sys
+
+_NIGHTLY_DIR = os.path.dirname(os.path.abspath(__file__))
+if _NIGHTLY_DIR not in sys.path:
+    sys.path.insert(0, _NIGHTLY_DIR)
+
+from cases import AccuracyCase, PerfCase  # noqa: E402
+
+
+def run_eval_for_case(case: AccuracyCase, base_url: str):
+    """Drive ``run_eval`` for one case against a live server at ``base_url``.
+
+    Returns ``(metrics, started_at, finished_at)``.
+    """
+    import time
+    from types import SimpleNamespace
+
+    from run_eval import run_eval
+
+    gen = case.generation_config or {}
+    # Forward the full sampler config. run_eval routes the SGLang-only params
+    # (SGLANG_EXTRA_SAMPLING_PARAMS) into extra_body; cherry-picking a subset
+    # here would let a case set e.g. top_k in generation_config, record it in
+    # the summary, yet silently drop it before it reaches the sampler.
+    args = SimpleNamespace(
+        base_url=base_url,
+        host=None,
+        port=None,
+        model=case.model_id,
+        eval_name=case.dataset,
+        num_examples=case.limit,
+        num_threads=case.eval_batch_size,
+        temperature=gen.get("temperature", 0.0),
+        max_tokens=gen.get("max_tokens", 2048),
+        top_p=gen.get("top_p"),
+        top_k=gen.get("top_k"),
+        min_p=gen.get("min_p"),
+        presence_penalty=gen.get("presence_penalty"),
+        repetition_penalty=gen.get("repetition_penalty"),
+        frequency_penalty=gen.get("frequency_penalty"),
+        seed=gen.get("seed"),
+        chat_template_kwargs=gen.get("chat_template_kwargs"),
+    )
+    started_at = time.time()
+    metrics = run_eval(args)
+    finished_at = time.time()
+    return metrics, started_at, finished_at
+
+
+def run_benchmark_for_case(
+    case: PerfCase,
+    base_url: str,
+    tokenizer: str,
+    *,
+    profile: bool = False,
+    profile_num_steps: int | None = None,
+):
+    """Drive ``run_benchmark`` for one perf sweep point against a live server.
+
+    ``tokenizer`` is the served model path (PerfCase carries no model_id — the
+    model comes from the launch profile). When ``profile`` is set, bench_serving
+    drives /start_profile + /stop_profile (the server writes the trace to
+    $SGLANG_JAX_PROFILER_DIR); ``profile=False`` keeps args.profile=None,
+    bench_serving's "off" sentinel. Returns the ``metrics`` dict.
+    """
+    from sgl_jax.bench_serving import run_benchmark
+    from sgl_jax.test.test_utils import get_benchmark_args
+
+    args = get_benchmark_args(
+        base_url=base_url,
+        dataset_name="random",
+        device="tpu",
+        tokenizer=tokenizer,
+        num_prompts=case.num_prompts,
+        random_input_len=case.input_len,
+        random_output_len=case.output_len,
+        max_concurrency=case.max_concurrency,
+        random_range_ratio=1.0,
+        request_rate=case.request_rate,
+        seed=case.seed,
+        warmup_requests=0,
+    )
+    args.output_file = "/dev/null"
+    args.flush_cache = case.flush_cache
+    args.profile = True if profile else None
+    if profile and profile_num_steps is not None:
+        args.profile_num_steps = profile_num_steps
+
+    return run_benchmark(args)

--- a/test/srt/nightly/launch_profiles/qwen3-32b-fa-v6e-4.yaml
+++ b/test/srt/nightly/launch_profiles/qwen3-32b-fa-v6e-4.yaml
@@ -1,0 +1,27 @@
+# Qwen3-32B dense on v6e-4, TP4, fa — correctness gate for the perf sweep's 32B
+# config (same model/TP/precision/attention). Runtime knobs (max-running-requests,
+# radix cache) follow accuracy convention; they affect throughput, not correctness.
+name: qwen3_32b-fa-tp4
+target: v6e-4
+model_path: Qwen/Qwen3-32B
+tp_size: 4
+dp_size: 1
+port: 30011
+server_args:
+  - --skip-server-warmup
+  - --random-seed
+  - "3"
+  - --download-dir
+  - /dev/shm/
+  - --dtype
+  - bfloat16
+  - --page-size
+  - "256"
+  - --attention-backend
+  - fa
+  - --mem-fraction-static
+  - "0.9"
+  - --max-prefill-tokens
+  - "8192"
+  - --max-running-requests
+  - "128"

--- a/test/srt/nightly/launch_profiles/qwen3-32b-perf-v6e-4.yaml
+++ b/test/srt/nightly/launch_profiles/qwen3-32b-perf-v6e-4.yaml
@@ -1,0 +1,27 @@
+# Qwen3-32B (bf16) on v6e-4, TP4, attention-backend fa. Perf sweep; radix cache
+# disabled so hit-rate cannot skew the baseline.
+name: qwen3_32b-perf-tp4
+target: v6e-4
+model_path: Qwen/Qwen3-32B
+tp_size: 4
+dp_size: 1
+port: 30060
+server_args:
+  - --skip-server-warmup
+  - --random-seed
+  - "3"
+  - --mem-fraction-static
+  - "0.9"
+  - --max-prefill-tokens
+  - "8192"
+  - --download-dir
+  - /dev/shm/
+  - --dtype
+  - bfloat16
+  - --attention-backend
+  - fa
+  - --page-size
+  - "256"
+  - --max-running-requests
+  - "256"
+  - --disable-radix-cache

--- a/test/srt/nightly/launch_profiles/qwen3-moe-epmoe-perf-v6e-4.yaml
+++ b/test/srt/nightly/launch_profiles/qwen3-moe-epmoe-perf-v6e-4.yaml
@@ -1,0 +1,30 @@
+# Qwen3-MoE-30B-A3B (bf16) on v6e-4, full-EP (TP4/EP4), moe-backend epmoe.
+# Perf sweep; radix cache disabled so hit-rate cannot skew the baseline.
+name: qwen3_moe-epmoe-perf-tp4-ep4
+target: v6e-4
+model_path: Qwen/Qwen3-30B-A3B
+tp_size: 4
+dp_size: 1
+ep_size: 4
+port: 30061
+server_args:
+  - --skip-server-warmup
+  - --random-seed
+  - "3"
+  - --mem-fraction-static
+  - "0.9"
+  - --max-prefill-tokens
+  - "8192"
+  - --download-dir
+  - /dev/shm/
+  - --dtype
+  - bfloat16
+  - --attention-backend
+  - fa
+  - --page-size
+  - "256"
+  - --max-running-requests
+  - "256"
+  - --disable-radix-cache
+  - --moe-backend
+  - epmoe

--- a/test/srt/nightly/launch_profiles/qwen3-moe-fused-perf-v6e-4.yaml
+++ b/test/srt/nightly/launch_profiles/qwen3-moe-fused-perf-v6e-4.yaml
@@ -1,0 +1,31 @@
+# Qwen3-MoE-30B-A3B (bf16) on v6e-4, full-EP (TP4/EP4), moe-backend fused.
+# Perf sweep; radix cache disabled so hit-rate cannot skew the baseline.
+# NB: fused needs --max-running-requests a multiple of ep_size (256 % 4 == 0).
+name: qwen3_moe-fused-perf-tp4-ep4
+target: v6e-4
+model_path: Qwen/Qwen3-30B-A3B
+tp_size: 4
+dp_size: 1
+ep_size: 4
+port: 30062
+server_args:
+  - --skip-server-warmup
+  - --random-seed
+  - "3"
+  - --mem-fraction-static
+  - "0.9"
+  - --max-prefill-tokens
+  - "8192"
+  - --download-dir
+  - /dev/shm/
+  - --dtype
+  - bfloat16
+  - --attention-backend
+  - fa
+  - --page-size
+  - "256"
+  - --max-running-requests
+  - "256"
+  - --disable-radix-cache
+  - --moe-backend
+  - fused

--- a/test/srt/nightly/multi_host/accuracy_case_runner.py
+++ b/test/srt/nightly/multi_host/accuracy_case_runner.py
@@ -16,9 +16,10 @@ for _p in (_TEST_SRT, _NIGHTLY_DIR, _SELF_DIR):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
+from drivers import run_eval_for_case
 from multi_host_suite import AccuracyCase, SuiteError
 from profile_loader import LaunchProfile
-from results import build_accuracy_result, run_eval_for_case, write_accuracy_result
+from results import build_accuracy_result, write_result
 
 
 def run_accuracy_case(case: AccuracyCase, profile: LaunchProfile) -> None:
@@ -45,7 +46,7 @@ def run_accuracy_case(case: AccuracyCase, profile: LaunchProfile) -> None:
         case, profile.name, profile.target, metrics, started_at, finished_at
     )
 
-    out_path = write_accuracy_result(summary, case.name)
+    out_path = write_result(summary, case.name)
     if out_path is not None:
         print(f"[multi-host-suite] Wrote accuracy summary to {out_path}", flush=True)
     else:

--- a/test/srt/nightly/multi_host/perf_case_runner.py
+++ b/test/srt/nightly/multi_host/perf_case_runner.py
@@ -1,11 +1,8 @@
 """Perf case runner: drives bench_serving against a given server URL."""
 
-import json
-import os
-from pathlib import Path
-
 from multi_host_suite import PerfCase
 from profile_loader import LaunchProfile
+from results import write_perf_json
 
 
 def run_perf_case(case: PerfCase, profile: LaunchProfile) -> None:
@@ -40,23 +37,13 @@ def run_perf_case(case: PerfCase, profile: LaunchProfile) -> None:
     )
     metrics = run_benchmark(args)
 
-    summary = {
-        "type": "perf",
-        "case": case.name,
-        "profile": profile.name,
-        "target": profile.target,
-        **metrics,
-    }
-    # default=float handles numpy scalars returned by bench_serving.
-    summary_json = json.dumps(summary, indent=2, sort_keys=True, default=float)
-    print("[multi-host-suite] Perf summary:", flush=True)
-    print(f"[multi-host-suite] {summary_json}", flush=True)
-
-    results_dir = os.environ.get("RESULTS_DIR")
-    if results_dir:
-        out_path = Path(results_dir) / f"{case.name}.json"
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(summary_json)
-
+    # Incomplete points (OOM / dropped requests) aren't persisted — see the
+    # single-host runner.
     if metrics.get("completed") != case.num_prompts:
         raise RuntimeError(f"Expected completed={case.num_prompts}, got {metrics.get('completed')}")
+
+    out_path = write_perf_json(case, profile.name, profile.target, metrics)
+    if out_path is not None:
+        print(f"[multi-host-suite] Wrote perf summary to {out_path}", flush=True)
+    else:
+        print("[multi-host-suite] RESULTS_DIR unset; skipping perf summary write", flush=True)

--- a/test/srt/nightly/perf_baseline.py
+++ b/test/srt/nightly/perf_baseline.py
@@ -1,0 +1,194 @@
+"""Trailing-baseline lookup from the ci-data repo.
+
+Returns the mean of a sweep point's metric over the last N nights, for the
+trailing half of the dual-threshold perf gate. Reads the per-model CSVs at
+``perf/<YYYY-MM-DD>/daily_performance_results_<model>_tp_<n>.csv`` (written by
+``publish.py --data-type perf``), locating a point by its file (model + tpu_size)
+and its ``(concurrency, input, output)`` row.
+
+Degrades safely: any failure (offline, no token, insufficient history, malformed
+data) returns ``None`` so the caller falls back to the absolute floor alone.
+Network reads are best-effort and never raise.
+"""
+
+import csv
+import io
+import json
+import math
+import os
+import urllib.request
+from urllib.error import HTTPError, URLError
+
+CI_DATA_OWNER = "pathfinder-pf"
+CI_DATA_REPO = "sglang-jax-ci-data"
+CI_DATA_PERF_SUBDIR = "perf"
+
+# Trailing gate: current must be >= mean(last N nights) * (1 - tolerance);
+# skipped until N nights of history exist. Placeholders pending observed noise.
+TRAILING_TOLERANCE = 0.05
+TRAILING_MIN_NIGHTS = 5
+
+
+# Regression direction per metric: "higher" = a regression is a drop
+# (throughput), "lower" = a regression is a rise (latency). Single source of
+# truth for both the trailing gate (gated_metrics) and the absolute-floor gate
+# (results.gate_perf_result), so a floor on a latency metric is checked the
+# right way round.
+METRIC_DIRECTION: dict[str, str] = {
+    "in_tps": "higher",
+    "out_tps": "higher",
+    "ttft_ms": "lower",
+    "itl_ms": "lower",
+}
+
+
+# Metrics the trailing gate compares, by point type. A prefill-only point
+# (output<=1) has no meaningful decode throughput/ITL, so it gates prefill
+# throughput + TTFT; a decode point adds output throughput + ITL.
+def gated_metrics(output_len: int) -> dict[str, str]:
+    if output_len <= 1:
+        metrics = ("in_tps", "ttft_ms")
+    else:
+        metrics = ("in_tps", "out_tps", "itl_ms")
+    return {m: METRIC_DIRECTION[m] for m in metrics}
+
+
+# Per-process caches: a gate run reads the same date folders / CSV many times
+# (every point × metric) — fetch once. Failures cache too (via the _FETCHED
+# flag), so an unreachable API isn't re-hit on every lookup.
+_DATE_FOLDERS_CACHE: list[str] | None = None
+_DATE_FOLDERS_FETCHED = False
+_CSV_ROWS_CACHE: dict[tuple[str, str], list[dict]] = {}
+
+
+def _get(url: str, token: str | None, timeout: int = 30) -> bytes | None:
+    headers = {"User-Agent": "sglang-jax-perf-baseline"}
+    if token:
+        headers["Authorization"] = f"token {token}"
+    req = urllib.request.Request(url, headers=headers)
+    # Retry once on a connection-level fault (DNS/reset/timeout); any HTTPError
+    # (404, 403 rate-limit, even 5xx) is returned as-is without retry.
+    for attempt in range(2):
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return resp.read()
+        except HTTPError:
+            return None
+        except (URLError, TimeoutError, OSError):
+            if attempt == 0:
+                continue
+            return None
+    return None
+
+
+def _list_date_folders(token: str | None) -> list[str]:
+    """Sorted ``perf/<date>`` folder names (oldest first), or []. Cached incl. failures."""
+    global _DATE_FOLDERS_CACHE, _DATE_FOLDERS_FETCHED
+    if _DATE_FOLDERS_FETCHED:
+        return _DATE_FOLDERS_CACHE or []
+    _DATE_FOLDERS_FETCHED = True
+    url = (
+        f"https://api.github.com/repos/{CI_DATA_OWNER}/{CI_DATA_REPO}"
+        f"/contents/{CI_DATA_PERF_SUBDIR}"
+    )
+    raw = _get(url, token)
+    if raw is None:
+        return []
+    try:
+        items = json.loads(raw)
+    except (ValueError, TypeError):
+        return []
+    _DATE_FOLDERS_CACHE = sorted(
+        i["name"] for i in items if isinstance(i, dict) and i.get("type") == "dir"
+    )
+    return _DATE_FOLDERS_CACHE
+
+
+def _fetch_rows(date_str: str, csv_filename: str, token: str | None) -> list[dict] | None:
+    """Download + parse one night's CSV into rows (cached per (date, file))."""
+    key = (date_str, csv_filename)
+    if key in _CSV_ROWS_CACHE:
+        return _CSV_ROWS_CACHE[key]
+    raw_url = (
+        f"https://raw.githubusercontent.com/{CI_DATA_OWNER}/{CI_DATA_REPO}/main"
+        f"/{CI_DATA_PERF_SUBDIR}/{date_str}/{csv_filename}"
+    )
+    raw = _get(raw_url, token)
+    if raw is None:
+        return None  # don't cache a transient miss — let a later lookup retry
+    rows = list(csv.DictReader(io.StringIO(raw.decode("utf-8"))))
+    _CSV_ROWS_CACHE[key] = rows
+    return rows
+
+
+def _fetch_metric(
+    date_str: str,
+    csv_filename: str,
+    concurrency: int,
+    input_len: int,
+    output_len: int,
+    column: str,
+    token: str | None,
+) -> float | None:
+    """Read one night's ``column`` for the matching sweep row, or None."""
+    rows = _fetch_rows(date_str, csv_filename, token)
+    if not rows:
+        return None
+    try:
+        for row in rows:
+            if (
+                int(row["concurrency"]) == concurrency
+                and int(row["input"]) == input_len
+                and int(row["output"]) == output_len
+            ):
+                val = row.get(column)
+                if val in (None, ""):
+                    return None
+                f = float(val)
+                # Drop non-finite: a NaN in the window makes the mean NaN and
+                # `value < NaN` always False (a silent pass).
+                return f if math.isfinite(f) else None
+    except (ValueError, TypeError, KeyError):
+        return None
+    return None
+
+
+def fetch_trailing_baseline(
+    csv_filename: str,
+    concurrency: int,
+    input_len: int,
+    output_len: int,
+    column: str,
+    n: int,
+    token: str | None = None,
+) -> float | None:
+    """Mean of one sweep point's ``column`` over the most recent ``n`` nights.
+
+    The point is identified by its per-model CSV file (``csv_filename``) and the
+    ``(concurrency, input, output)`` row within it. Returns ``None`` (caller
+    skips the trailing gate) when fewer than ``n`` nights carry a usable value,
+    or on any network/parse failure. ``token`` defaults to ``$GITHUB_TOKEN``;
+    the ci-data repo is public so anonymous reads also work (subject to a lower
+    rate limit).
+    """
+    if token is None:
+        token = os.getenv("GITHUB_TOKEN")
+
+    dates = _list_date_folders(token)
+    if not dates:
+        return None
+
+    # Walk newest-first, collecting up to n usable values.
+    values: list[float] = []
+    for date_str in reversed(dates):
+        val = _fetch_metric(
+            date_str, csv_filename, concurrency, input_len, output_len, column, token
+        )
+        if val is not None:
+            values.append(val)
+        if len(values) >= n:
+            break
+
+    if len(values) < n:
+        return None
+    return sum(values) / len(values)

--- a/test/srt/nightly/results.py
+++ b/test/srt/nightly/results.py
@@ -1,16 +1,17 @@
-"""Single source of truth for the ``accuracy_result.v1.yaml`` document shape.
+"""Single source of truth for the nightly result shapes.
 
-Both the single-host runner (``test/srt/nightly/single_host/accuracy_case_runner.py``)
-and the multi-host runner (``test/srt/nightly/multi_host/accuracy_case_runner.py``)
-build and write their result JSON here, so the schema in
-``test/srt/nightly/schemas/accuracy_result.v1.yaml`` has exactly one
-producer-side implementation and the two runners cannot drift.
+Accuracy emits ``accuracy_result.v1.yaml`` JSON (``build_accuracy_result`` +
+``write_result``). Perf emits per-model CSV (``build_perf_result`` +
+``write_perf_csv``) in the column layout ``scripts/ci/plot_perf.py`` and the
+trailing-baseline gate consume.
 
-Bump ``ACCURACY_RESULT_SCHEMA_VERSION`` (and add a matching changelog entry to
-the schema file) whenever the document shape changes.
+Bump ``ACCURACY_RESULT_SCHEMA_VERSION`` (with a schema-file changelog entry)
+whenever the accuracy document shape changes.
 """
 
+import csv
 import json
+import math
 import os
 import subprocess
 import sys
@@ -21,7 +22,7 @@ _NIGHTLY_DIR = os.path.dirname(os.path.abspath(__file__))
 if _NIGHTLY_DIR not in sys.path:
     sys.path.insert(0, _NIGHTLY_DIR)
 
-from cases import AccuracyCase  # noqa: E402
+from cases import AccuracyCase, PerfCase  # noqa: E402
 
 ACCURACY_RESULT_SCHEMA_VERSION = "1.0.0"
 
@@ -108,11 +109,11 @@ def build_accuracy_result(
     }
 
 
-def write_accuracy_result(result: dict, case_name: str) -> Path | None:
+def write_result(result: dict, case_name: str) -> Path | None:
     """Write ``result`` to ``$RESULTS_DIR/<case_name>.json``.
 
-    Returns the path written, or ``None`` when ``RESULTS_DIR`` is unset (so
-    callers can log the skip in their own voice).
+    Type-agnostic (accuracy or perf). Returns the path written, or ``None`` when
+    ``RESULTS_DIR`` is unset (so callers can log the skip in their own voice).
     """
     results_dir = os.environ.get("RESULTS_DIR")
     if not results_dir:
@@ -123,44 +124,239 @@ def write_accuracy_result(result: dict, case_name: str) -> Path | None:
     return out_path
 
 
-def run_eval_for_case(case: AccuracyCase, base_url: str):
-    """Drive ``run_eval`` for one case against a live server at ``base_url``.
+def build_perf_result(
+    case: PerfCase,
+    profile_name: str,
+    target: str,
+    metrics: dict,
+    xprof_collected: bool = False,
+) -> dict:
+    """Build one perf-result record for a finished sweep point.
 
-    Shared by the single- and multi-host accuracy runners so the eval-args
-    construction + ``run_eval`` call live in one place. Returns
-    ``(metrics, started_at, finished_at)``; each host runner does its own
-    logging / gating and calls ``build_accuracy_result`` + ``write_accuracy_result``.
+    Translates ``run_benchmark``'s raw metric names (``output_throughput``, ...)
+    into the published CSV column names (``out_tps``, ...) — the single place
+    this mapping happens; the gate, floors, baseline, and writer all use the CSV
+    names. ``passed`` starts completion-only and is finalized by ``gate_perf_result``.
     """
-    import time
-    from types import SimpleNamespace
 
-    from run_eval import run_eval
+    def _f(key: str) -> float:
+        # Headline metrics default to 0.0 only as a guard; a completed run (the
+        # gate) is trusted to return all of these from run_benchmark.
+        return float(metrics.get(key, 0.0))
 
-    gen = case.generation_config or {}
-    # Forward the full sampler config. run_eval routes the SGLang-only params
-    # (SGLANG_EXTRA_SAMPLING_PARAMS) into extra_body; cherry-picking a subset
-    # here would let a case set e.g. top_k in generation_config, record it in
-    # the summary, yet silently drop it before it reaches the sampler.
-    args = SimpleNamespace(
-        base_url=base_url,
-        host=None,
-        port=None,
-        model=case.model_id,
-        eval_name=case.dataset,
-        num_examples=case.limit,
-        num_threads=case.eval_batch_size,
-        temperature=gen.get("temperature", 0.0),
-        max_tokens=gen.get("max_tokens", 2048),
-        top_p=gen.get("top_p"),
-        top_k=gen.get("top_k"),
-        min_p=gen.get("min_p"),
-        presence_penalty=gen.get("presence_penalty"),
-        repetition_penalty=gen.get("repetition_penalty"),
-        frequency_penalty=gen.get("frequency_penalty"),
-        seed=gen.get("seed"),
-        chat_template_kwargs=gen.get("chat_template_kwargs"),
+    completed = metrics.get("completed") if isinstance(metrics, dict) else None
+
+    return {
+        # CSV columns (plot_perf / ci-data layout); see PERF_CSV_COLUMNS. The
+        # per-server profile name is the model_name label so the epmoe and fused
+        # MoE servers (same HF checkpoint) get distinct files and plot legends.
+        "model_name": profile_name,
+        "tpu_size": _tpu_size(target),
+        "concurrency": case.max_concurrency,
+        "input": case.input_len,
+        "output": case.output_len,
+        "ttft_ms": _f("median_ttft_ms"),
+        "itl_ms": _f("median_itl_ms"),
+        "in_tps": _f("input_throughput"),
+        "out_tps": _f("output_throughput"),
+        # Gate-helper fields (not written to CSV).
+        "case": case.name,
+        "completed": completed,
+        "num_prompts": case.num_prompts,
+        "xprof_collected": xprof_collected,
+        # Dual-gate verdicts; populated by gate_perf_result() before the gate
+        # returns. completion-only until then (None = gate not evaluated).
+        "passed": completed == case.num_prompts,
+        "absolute_floor_passed": None,
+        "trailing_passed": None,
+        "baseline_source": None,
+    }
+
+
+# plot_perf.py (and the ci-data perf trend) consume these columns; keep the
+# names and order in sync with scripts/ci/plot_perf.py and the ci-data history.
+PERF_CSV_COLUMNS = (
+    "concurrency",
+    "input",
+    "output",
+    "ttft_ms",
+    "itl_ms",
+    "in_tps",
+    "out_tps",
+    "model_name",
+    "tpu_size",
+)
+
+
+def _tpu_size(target: str) -> int:
+    # "v6e-4" -> 4, "v6e-1" -> 1; default 1 if unparsable.
+    try:
+        return int(str(target).rsplit("-", 1)[-1])
+    except (ValueError, IndexError):
+        return 1
+
+
+def perf_csv_filename(model_name: str, tpu_size: int) -> str:
+    """``daily_performance_results_<model>_tp_<n>.csv`` — the name plot_perf.py
+    defaults to and the ci-data history uses. Shared by writer and baseline reader."""
+    model_dir_name = str(model_name).replace("/", "_")
+    return f"daily_performance_results_{model_dir_name}_tp_{tpu_size}.csv"
+
+
+def write_perf_csv(result: dict) -> Path | None:
+    """Append one sweep point to ``$RESULTS_DIR/<perf_csv_filename>`` (one CSV per
+    model). Returns the path, or ``None`` when ``RESULTS_DIR`` is unset."""
+    results_dir = os.environ.get("RESULTS_DIR")
+    if not results_dir:
+        return None
+    out_path = Path(results_dir) / perf_csv_filename(result["model_name"], result["tpu_size"])
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    row = {col: result[col] for col in PERF_CSV_COLUMNS}
+    write_header = not out_path.exists()
+    with out_path.open("a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=PERF_CSV_COLUMNS)
+        if write_header:
+            writer.writeheader()
+        writer.writerow(row)
+    return out_path
+
+
+def write_perf_json(case: PerfCase, profile_name: str, target: str, metrics: dict) -> Path | None:
+    """Write one perf point as ``$RESULTS_DIR/<case>.json`` for the GCS dashboard.
+
+    Shared by the single- and multi-host runners — emits ``{type, case, profile,
+    target}`` plus the flat ``run_benchmark`` metrics, the shape the dashboard's
+    PerfSummary schema reads. Distinct from the per-model CSV (which feeds the
+    ci-data trend plot); single-host writes both, multi-host writes only this.
+    Returns the path, or ``None`` when ``RESULTS_DIR`` is unset.
+    """
+    results_dir = os.environ.get("RESULTS_DIR")
+    if not results_dir:
+        return None
+    summary = {
+        "type": "perf",
+        "case": case.name,
+        "profile": profile_name,
+        "target": target,
+        **(metrics if isinstance(metrics, dict) else {}),
+    }
+    # request_rate is inf for the concurrency sweep; json.dumps would write it as
+    # the bare token `Infinity`, which JS JSON.parse rejects (the dashboard would
+    # drop the whole case). Map non-finite top-level floats to None (valid JSON).
+    summary = {
+        k: (None if isinstance(v, float) and not math.isfinite(v) else v)
+        for k, v in summary.items()
+    }
+    out_path = Path(results_dir) / f"{case.name}.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    # default=float handles numpy scalars returned by bench_serving.
+    out_path.write_text(json.dumps(summary, indent=2, sort_keys=True, default=float))
+    return out_path
+
+
+def gate_perf_result(case: PerfCase, result: dict) -> tuple[str, str] | None:
+    """Dual-threshold perf gate (single-host runner).
+
+    Evaluates three gates in order and records each verdict back into ``result``
+    (so the emitted CSV row carries the pass/fail) before returning the first
+    failure as ``(kind, message)`` or ``None`` if all pass:
+
+    1. **completion** — ``completed == num_prompts`` (OOM / dropped requests).
+       Tagged ``"case"`` (a real bug, CI does not retry).
+    2. **absolute floor** — per-metric hard minimum from ``case.floors``.
+       Tagged ``"threshold"``.
+    3. **trailing baseline** — each point's metrics (``gated_metrics``: a prefill
+       point gates in_tps + ttft, a decode point adds out_tps + itl) within
+       ``tolerance`` of their last-N-night mean — a drop for throughput, a rise
+       for latency. Skipped (not failed) until ``TRAILING_MIN_NIGHTS`` exist.
+       Tagged ``"threshold"``.
+
+    Mutates ``result`` in place (verdict fields + final ``passed``).
+    """
+    from perf_baseline import (
+        METRIC_DIRECTION,
+        TRAILING_MIN_NIGHTS,
+        TRAILING_TOLERANCE,
+        fetch_trailing_baseline,
+        gated_metrics,
     )
-    started_at = time.time()
-    metrics = run_eval(args)
-    finished_at = time.time()
-    return metrics, started_at, finished_at
+
+    # 1. completion
+    completed = result.get("completed")
+    if completed != case.num_prompts:
+        result["absolute_floor_passed"] = None
+        result["trailing_passed"] = None
+        result["passed"] = False
+        return ("case", f"{case.name}: completed={completed}/{case.num_prompts}")
+
+    floors = case.floors or {}
+
+    # 2. absolute floor — per-metric hard minimum/maximum, by metric direction
+    # (higher-is-better → fail under floor; lower-is-better latency → fail over
+    # floor). Today's registered floors are all out_tps (higher), so this is the
+    # same `value < floor` as before; the direction split only matters if a
+    # latency floor (e.g. ttft_ms) is ever registered.
+    floor_failures: list[str] = []
+    for metric, floor in floors.items():
+        if floor is None:
+            continue
+        value = result.get(metric)
+        if value is None:
+            continue
+        if METRIC_DIRECTION.get(metric, "higher") == "lower":
+            if value > floor:
+                floor_failures.append(f"{metric}={value:.1f} > floor {floor:.1f}")
+        elif value < floor:
+            floor_failures.append(f"{metric}={value:.1f} < floor {floor:.1f}")
+    result["absolute_floor_passed"] = not floor_failures
+
+    # 3. trailing baseline (best-effort; skipped when history < min nights).
+    # Per-point metrics (gated_metrics): a prefill point gates in_tps + ttft, a
+    # decode point adds out_tps + itl. Independent of the absolute floor.
+    n = TRAILING_MIN_NIGHTS
+    tol = TRAILING_TOLERANCE
+    csv_filename = perf_csv_filename(result["model_name"], result["tpu_size"])
+    trailing_failures: list[str] = []
+    trailing_evaluated = False
+    for metric, direction in gated_metrics(result["output"]).items():
+        value = result.get(metric)
+        if value is None:
+            continue
+        # A non-positive latency means the metric is missing/degenerate (build_perf_result
+        # defaults missing latencies to 0.0), not a record-low latency — skip it rather
+        # than letting `0.0 > bound` silently pass the lower-is-better gate.
+        if direction == "lower" and value <= 0:
+            continue
+        mean = fetch_trailing_baseline(
+            csv_filename,
+            result["concurrency"],
+            result["input"],
+            result["output"],
+            metric,
+            n,
+        )
+        if mean is None:
+            continue  # insufficient history -> skip this metric's trailing gate
+        trailing_evaluated = True
+        if direction == "higher":
+            bound = mean * (1.0 - tol)
+            if value < bound:
+                trailing_failures.append(f"{metric}={value:.1f} < {mean:.1f}*(1-{tol})={bound:.1f}")
+        else:  # lower-is-better (latency)
+            bound = mean * (1.0 + tol)
+            if value > bound:
+                trailing_failures.append(f"{metric}={value:.1f} > {mean:.1f}*(1+{tol})={bound:.1f}")
+    if trailing_evaluated:
+        result["trailing_passed"] = not trailing_failures
+        result["baseline_source"] = f"ci-data last-{n} mean"
+    else:
+        result["trailing_passed"] = None
+        result["baseline_source"] = f"skipped (<{n} nights history)"
+
+    result["passed"] = result["absolute_floor_passed"] and result["trailing_passed"] is not False
+
+    if floor_failures:
+        return ("threshold", f"{case.name} absolute-floor: {'; '.join(floor_failures)}")
+    if trailing_failures:
+        return ("threshold", f"{case.name} trailing: {'; '.join(trailing_failures)}")
+    return None

--- a/test/srt/nightly/single_host/README.md
+++ b/test/srt/nightly/single_host/README.md
@@ -1,32 +1,37 @@
 # Single-host tests
 
-Accuracy tests for models that fit on a single host (e.g. v6e-1 / v6e-4, issue #1200).
+Accuracy and performance tests for models that fit on a single host (v6e-1 / v6e-4).
 
-This is the single-host analogue of `../multi_host/`. The two share the same
-host-neutral contract (`../cases.py`, `../profiles.py`, `../results.py`) and the
-same `../launch_profiles/` directory, so adding a case looks the same on both
-sides. **The only difference:** the multi-host runner coordinates several pod
-ranks around one logical server, while the single-host runner launches one
-server locally (`nnodes=1`) and evaluates against it directly.
+The single-host analogue of `../multi_host/`. Both share the same host-neutral
+contract — `../cases.py` (case dataclasses), `../profiles.py` (launch),
+`../results.py` (emitters + gate), `../drivers.py` (case drivers) — and the same
+`../launch_profiles/` directory, so adding a case looks the same on both sides.
+The difference: multi-host coordinates several pod ranks around one logical
+server; single-host launches one local server (`nnodes=1`) and evaluates against
+it directly.
 
-## Adding a new test takes two steps
+`AccuracyCase` and `PerfCase` are dispatched by type to their case runner —
+accuracy gates on score, perf on a dual threshold (completion + absolute floor +
+trailing baseline) — sharing the same profile contract, result emitter, and
+exit-code scheme.
+
+## Adding an accuracy gate
 
 ### Step 1: Write a launch profile
 
-Create a YAML under `test/srt/nightly/launch_profiles/` describing how to start
-the server. This is the **same directory and same schema** the multi-host suites
-use (see `../multi_host/README.md` for the full field reference).
+A YAML under `../launch_profiles/` — the same directory and schema the multi-host
+suites use (see `../multi_host/README.md` for the full field reference):
 
 ```yaml
-# test/srt/nightly/launch_profiles/<your-model>-<target>.yaml
-name: <run name>                    # label for this launch
-target: <target-name>               # hardware target tag, e.g. v6e-4
-model_path: <your-model-path>       # HF repo path or local path
+# ../launch_profiles/<your-model>-<target>.yaml
+name: <run name>
+target: v6e-4                        # hardware target tag
+model_path: <hf-repo-or-local-path>
 tp_size: 4
 dp_size: 1
-ep_size: null                       # optional; only for MoE
+ep_size: null                        # optional; only for MoE
 port: 30010
-server_args:                        # extra flags forwarded to launch_server
+server_args:                         # extra flags forwarded to launch_server
   - --attention-backend
   - fa
   - --dtype
@@ -36,60 +41,94 @@ server_args:                        # extra flags forwarded to launch_server
 ```
 
 `--model-path / --host / --port / --tp-size / --dp-size / --ep-size / --nnodes /
---node-rank / --dist-init-addr` are managed by the launch runtime and **cannot**
-be set in `server_args` (the validator rejects them). One profile == one full
-server config — there is no per-run override layer.
+--node-rank / --dist-init-addr` are managed by the runtime and rejected in
+`server_args`. One profile == one full server config; no per-run override layer.
 
 ### Step 2: Register the run in `SUITES`
 
-Open `test/srt/nightly/single_host/suite_runner.py` and add a `SingleHostRun` to
-the suite's `runs` list. A `SingleHostRun` mirrors the multi-host `ModelRun`
-(`launch_profile` + `cases`):
+Add a `SingleHostRun` (mirrors the multi-host `ModelRun`: `launch_profile` +
+`cases`) to the suite's `runs` list in `suite_runner.py`:
 
 ```python
-SUITES: dict[str, SingleHostSuite] = {
-    "accuracy-text-models-v6e-4": SingleHostSuite(
-        name="accuracy-text-models-v6e-4",
-        runs=[
-            # ... existing entries ...
-            SingleHostRun(
-                launch_profile="<your-model>-<target>.yaml",
-                cases=[_gsm8k_case("<case-name>", "<hub-id-for-tokenizer>", 0.90, 64)],
-            ),
-        ],
-    ),
-}
+SingleHostRun(
+    launch_profile="<your-model>-<target>.yaml",
+    cases=[_gsm8k_case("<case-name>", "<hub-id-for-tokenizer>", 0.90, 64)],
+),
 ```
 
-`launch_profile` is the **bare filename** under `launch_profiles/` — identical to
-the multi-host convention. `_gsm8k_case(name, model_id, threshold, eval_batch_size)`
-is the in-file helper for the standard gsm8k gate; build an `AccuracyCase`
-directly if you need a different dataset or sampling config. Set
-`score_threshold=None` for a warn-only case (runs and records a score, but does
-not gate / fail the suite).
+`_gsm8k_case(name, model_id, threshold, eval_batch_size)` is the in-file helper
+for the standard gsm8k gate; build an `AccuracyCase` directly for a different
+dataset. `score_threshold=None` makes a warn-only case (records a score, does not
+gate).
+
+## Adding a perf sweep
+
+A perf case is a sweep split by intent — prefill (`c{8,32} x i{4k,8k} x o1`) and
+decode (`c{…} x i4k x o1024`). Decode concurrency is KV-bound, so points are
+filtered to what each server can actually run concurrently (dense ceiling ~41 →
+`c{16,32}`; MoE ~118 → `c{32,64,96}`). `perf_sweep_cases(prefix, PerfParams(...))`
+(in `../cases.py`) builds the points; `PerfParams` defaults to a KV-safe grid
+(decode `c{32,64}`) — override grid / floors per suite.
+
+### Step 1: Write a launch profile
+
+Same as accuracy, with two perf conventions: one profile per variant (epmoe vs
+fused are separate files) and `--disable-radix-cache` so cache hit-rate can't
+skew the baseline.
+
+### Step 2: Register the run in the perf suite
+
+```python
+SingleHostRun(
+    launch_profile="<model>-<variant>-perf-v6e-4.yaml",
+    cases=perf_sweep_cases("<prefix>", PerfParams(
+        decode_concurrencies=(16, 32),
+        profile_point=(32, 4096, 1024),
+        floors={"out_tps": 865.6},          # decode repr: out_tps floor + xprof trace
+        prefill_floor_point=(32, 4096, 1),
+        prefill_floors={"in_tps": 15629.7}, # prefill repr: in_tps floor, no trace
+    )),
+),
+```
+
+`PerfParams` carries two absolute floors, each on a representative point that
+must exist in the grid: `floors` (`out_tps`) on `profile_point` — the decode repr,
+which also captures the xprof trace — and `prefill_floors` (`in_tps`) on
+`prefill_floor_point` — the prefill repr (no trace). Floors travel next to the
+case so they can't be forgotten. Every point appends a row to the per-model CSV
+(`daily_performance_results_<model>_tp_<n>.csv`, the layout `plot_perf.py` and the
+trailing baseline read); on main nightly the CSV publishes to ci-data and the
+per-case JSON to the observability dashboard. See the `PerfParams` docstring in
+`../cases.py` for more.
+
+> `perf_sweep_cases` is single-host only. Multi-host perf is a separate, lighter
+> path (completion check + dashboard JSON only — no CSV / floor / trailing gate).
 
 ## Running it
 
 ```bash
 cd test/srt
 python3 nightly/single_host/suite_runner.py --suite accuracy-text-models-v6e-4
+python3 nightly/single_host/suite_runner.py --suite perf-text-models-v6e-4
 ```
 
-- `--cases qwen3-8b-fa,ds-v2-lite-mla` — run only the named cases (comma-separated).
-- `--dry-run` — print the resolved suite as JSON without launching anything.
+- `--cases qwen3-8b-fa,qwen3-32b-c32-i4096-o1024` — run only the named cases
+  (for perf, individual sweep-point names — handy for a single-point smoke run).
+- `--dry-run` — print the resolved suite as JSON without launching.
 
-Pass/fail is conveyed through the process **exit code** (same scheme as the
-multi-host runner) so CI can classify the result:
+Pass/fail is conveyed through the process **exit code**:
 
-| Exit code | Meaning                                              |
-|-----------|-----------------------------------------------------|
-| `0`       | all cases passed                                    |
-| `10`      | infra / server launch failure — caller may retry    |
-| `20`      | a case finished but scored below threshold          |
-| `30`      | a case crashed unexpectedly (bug) — do not retry    |
+| Exit code | Meaning |
+|-----------|---------|
+| `0`  | all cases passed |
+| `10` | infra / server launch failure — caller may retry |
+| `20` | a threshold miss — accuracy below score, or a perf metric below its floor / trailing baseline |
+| `30` | a case crashed, or a perf point did not complete — do not retry |
 
 ## Triggering CI
 
-The v6e-4 suite is wired into `.github/workflows/nightly-test-daily.yml` (job
-`nightly-test-accuracy-text-models-4-tpu-daily`), which runs
-`--suite accuracy-text-models-v6e-4` on the `arc-runner-v6e-4` runner.
+The v6e-4 suites run on the `arc-runner-v6e-4` runner via
+`.github/workflows/nightly-test-daily.yml`:
+
+- `nightly-test-accuracy-text-models-4-tpu-daily` → `--suite accuracy-text-models-v6e-4`
+- `nightly-test-perf-text-models-4-tpu-daily` → `--suite perf-text-models-v6e-4`

--- a/test/srt/nightly/single_host/accuracy_case_runner.py
+++ b/test/srt/nightly/single_host/accuracy_case_runner.py
@@ -18,17 +18,14 @@ for _p in (_TEST_SRT, _NIGHTLY_DIR, _SELF_DIR):
         sys.path.insert(0, _p)
 
 from cases import AccuracyCase  # noqa: E402
+from drivers import run_eval_for_case  # noqa: E402
 from profiles import (  # noqa: E402
     LaunchProfile,
     RuntimeConfig,
     build_other_server_args,
     load_profile,
 )
-from results import (  # noqa: E402
-    build_accuracy_result,
-    run_eval_for_case,
-    write_accuracy_result,
-)
+from results import build_accuracy_result, write_result  # noqa: E402
 
 from sgl_jax.test.test_utils import (  # noqa: E402
     _local_or_hf,
@@ -42,9 +39,9 @@ _LAUNCH_PROFILES_DIR = os.path.join(_NIGHTLY_DIR, "launch_profiles")
 # server's HTTP port.
 _DIST_INIT_PORT_OFFSET = 5000
 
-# Default gsm8k sampling for the 4-TPU accuracy gates (#1200): greedy decode.
+# Default gsm8k sampling for the 4-TPU accuracy gates: greedy decode.
 # Cases reference this so every AccuracyCase carries an explicit
-# generation_config, matching the per-case convention from #1226.
+# generation_config, matching the per-case convention.
 GSM8K_GENERATION_CONFIG = {"temperature": 0.0, "max_tokens": 2048}
 
 
@@ -80,7 +77,7 @@ def run_accuracy_case(
 
     result = build_accuracy_result(case, profile_name, target, metrics, started_at, finished_at)
 
-    out_path = write_accuracy_result(result, case.name)
+    out_path = write_result(result, case.name)
     if out_path is not None:
         print(f"[accuracy-runner] Wrote result to {out_path}", flush=True)
 

--- a/test/srt/nightly/single_host/perf_case_runner.py
+++ b/test/srt/nightly/single_host/perf_case_runner.py
@@ -1,0 +1,85 @@
+"""Single-host perf helpers, used by ``single_host/suite_runner.py``.
+
+Runs one ``PerfCase`` sweep point against a live server and appends a row to the
+per-model CSV. Driver/emitter (``run_benchmark_for_case`` / ``build_perf_result``
+/ ``write_perf_csv``) live in ``results.py``; the sweep grid in ``cases.py``.
+"""
+
+import os
+import sys
+
+_SELF_DIR = os.path.dirname(os.path.abspath(__file__))
+_NIGHTLY_DIR = os.path.dirname(_SELF_DIR)
+_TEST_SRT = os.path.dirname(_NIGHTLY_DIR)
+for _p in (_TEST_SRT, _NIGHTLY_DIR, _SELF_DIR):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from cases import PerfCase  # noqa: E402
+from drivers import run_benchmark_for_case  # noqa: E402
+from results import (  # noqa: E402
+    build_perf_result,
+    gate_perf_result,
+    write_perf_csv,
+    write_perf_json,
+)
+
+
+def run_perf_case(
+    case: PerfCase,
+    base_url: str,
+    tokenizer: str,
+    profile_name: str,
+    target: str,
+) -> tuple[dict, tuple[str, str] | None]:
+    """Run one PerfCase sweep point against an already-running server.
+
+    Appends one row to the per-model CSV in ``$RESULTS_DIR`` when set. Returns
+    the full result dict (including ``completed`` and ``passed``); gating is left
+    to the caller.
+    """
+    xprof = case.capture_trace
+    print(
+        f"[perf-runner] Running case name={case.name}, base_url={base_url}, "
+        f"concurrency={case.max_concurrency}, input_len={case.input_len}, "
+        f"output_len={case.output_len}, num_prompts={case.num_prompts}, profile={xprof}",
+        flush=True,
+    )
+
+    metrics = run_benchmark_for_case(
+        case,
+        base_url,
+        tokenizer,
+        profile=xprof,
+        profile_num_steps=case.profile_num_steps if xprof else None,
+    )
+
+    result = build_perf_result(case, profile_name, target, metrics, xprof_collected=xprof)
+    fail = gate_perf_result(case, result)
+
+    # Incomplete points (OOM / dropped requests) aren't persisted — a partial
+    # metric must not pollute the trend or baseline. Threshold failures ran fully
+    # and are recorded.
+    incomplete = fail is not None and fail[0] == "case"
+    if incomplete:
+        print(
+            f"[perf-runner] {case.name}: incomplete "
+            f"(completed={result['completed']}/{case.num_prompts}) — skipping CSV/JSON",
+            flush=True,
+        )
+    else:
+        out_path = write_perf_csv(result)
+        if out_path is not None:
+            print(f"[perf-runner] Wrote result to {out_path}", flush=True)
+        json_path = write_perf_json(case, profile_name, target, metrics)
+        if json_path is not None:
+            print(f"[perf-runner] Wrote dashboard JSON to {json_path}", flush=True)
+
+    print(
+        f"[perf-runner] {case.name}: completed={result['completed']}/{case.num_prompts}, "
+        f"out_tps={result['out_tps']:.1f}, "
+        f"ttft={result['ttft_ms']:.1f}ms, itl={result['itl_ms']:.1f}ms",
+        flush=True,
+    )
+
+    return result, fail

--- a/test/srt/nightly/single_host/suite_runner.py
+++ b/test/srt/nightly/single_host/suite_runner.py
@@ -1,20 +1,16 @@
-"""Single-host nightly accuracy suites (v6e-1 / v6e-4).
+"""Single-host nightly suites (v6e-1 / v6e-4) — accuracy and perf.
 
-The single-host analogue of ``multi_host/suite_runner.py``, with the same data
-model: a suite is a list of runs, each run is one launch profile plus a list of
-cases evaluated against the single server it launches. Run it directly (the
-4-TPU daily CI job does)::
+The single-host analogue of ``multi_host/suite_runner.py``: a suite is a list of
+runs, each run one launch profile + the cases evaluated against the server it
+launches (nnodes=1). Run it directly (the 4-TPU daily CI jobs do)::
 
     cd test/srt
     python3 nightly/single_host/suite_runner.py --suite accuracy-text-models-v6e-4
+    python3 nightly/single_host/suite_runner.py --suite perf-text-models-v6e-4
 
-Each ``SingleHostRun`` mirrors the multi-host ``ModelRun`` (``launch_profile`` +
-``cases``): all server args live in the profile YAML (one profile per config —
-e.g. epmoe vs fused are separate profiles), so there is no per-run override layer.
-The runner launches one server on this host (nnodes=1) from the profile,
-evaluates each ``AccuracyCase`` via ``accuracy_case_runner``, and gates on the
-score. Pass/fail is conveyed through the process exit code (same tagged codes as
-the multi-host runner) so CI can classify the result.
+``AccuracyCase`` / ``PerfCase`` are dispatched by type to their case runner.
+Pass/fail is conveyed through the process exit code (same tagged codes as the
+multi-host runner) so CI can classify the result.
 """
 
 import argparse
@@ -36,7 +32,14 @@ from accuracy_case_runner import (  # noqa: E402
     profile_server_spec,
     run_accuracy_case,
 )
-from cases import AccuracyCase, SuiteError  # noqa: E402
+from cases import (  # noqa: E402
+    AccuracyCase,
+    PerfCase,
+    PerfParams,
+    SuiteError,
+    perf_sweep_cases,
+)
+from perf_case_runner import run_perf_case  # noqa: E402
 
 from sgl_jax.srt.utils import kill_process_tree  # noqa: E402
 from sgl_jax.test.test_utils import (  # noqa: E402
@@ -62,7 +65,7 @@ class SingleHostRun:
     """
 
     launch_profile: str
-    cases: tuple[AccuracyCase, ...]
+    cases: tuple[AccuracyCase | PerfCase, ...]
 
     def __post_init__(self):
         # Allow call sites to pass a list for readability; freeze to a tuple.
@@ -91,10 +94,17 @@ SUITES: dict[str, SingleHostSuite] = {
     "accuracy-text-models-v6e-4": SingleHostSuite(
         name="accuracy-text-models-v6e-4",
         runs=[
-            # 1.1.1 Qwen3-8B dense × fa, TP4 (native variant out of scope — tracked in #1297)
+            # 1.1.1 Qwen3-8B dense × fa, TP4 (native variant out of scope)
             SingleHostRun(
                 launch_profile="qwen3-8b-fa-v6e-4.yaml",
                 cases=[_gsm8k_case("qwen3-8b-fa", "Qwen/Qwen3-8B", 0.85, 128)],
+            ),
+            # Qwen3-32B dense × fa, TP4 — correctness gate for the perf 32B config.
+            # Threshold 0.92 = measured gsm8k ~0.97 less ~0.05 margin to absorb
+            # run-to-run noise (same convention as the MoE/dense cases above).
+            SingleHostRun(
+                launch_profile="qwen3-32b-fa-v6e-4.yaml",
+                cases=[_gsm8k_case("qwen3-32b-fa", "Qwen/Qwen3-32B", 0.92, 128)],
             ),
             # 1.1.2 DeepSeek-Coder-V2-Lite-Instruct × {mla, fa_mha}, DP4×TP4
             SingleHostRun(
@@ -135,9 +145,8 @@ SUITES: dict[str, SingleHostSuite] = {
                 ],
             ),
             # 1.1.5 Qwen3-MoE-30B-A3B-FP8 (static FP8 checkpoint) × {epmoe, fused},
-            # TP4/EP4, drift gate vs bf16. Calibrated on v6e-4 after the FP8 loader
-            # fix (#1291): epmoe mean ~0.934, fused mean ~0.937 (≈ bf16). epmoe gated
-            # one notch below to absorb run-to-run gsm8k noise observed in CI.
+            # TP4/EP4, drift gate vs bf16. epmoe gated one notch below fused to
+            # absorb run-to-run gsm8k noise observed in CI.
             SingleHostRun(
                 launch_profile="qwen3-moe-fp8-epmoe-v6e-4.yaml",
                 cases=[_gsm8k_case("qwen3-moe-fp8-epmoe", "Qwen/Qwen3-30B-A3B-FP8", 0.92, 64)],
@@ -145,6 +154,59 @@ SUITES: dict[str, SingleHostSuite] = {
             SingleHostRun(
                 launch_profile="qwen3-moe-fp8-fused-v6e-4.yaml",
                 cases=[_gsm8k_case("qwen3-moe-fp8-fused", "Qwen/Qwen3-30B-A3B-FP8", 0.93, 64)],
+            ),
+        ],
+    ),
+    # 4-TPU perf sweeps. One server per model/config; concurrency points filtered
+    # to what each server can actually run concurrently (decode is KV-bound:
+    # dense ceiling ~41, MoE ~118 at i4096/o1024). Prefill (c{8,32} × i{4k,8k} × o1)
+    # fills for all; decode (× i4k × o1024) is trimmed per model. radix cache
+    # disabled. One full profile per config, at the largest decode point that fills.
+    "perf-text-models-v6e-4": SingleHostSuite(
+        name="perf-text-models-v6e-4",
+        runs=[
+            # 2.1.1 Qwen3-32B dense, TP4 + fa. Decode KV ceiling ~41 -> {16,32};
+            # repr/trace at c32 (c64 exceeds the ceiling).
+            SingleHostRun(
+                launch_profile="qwen3-32b-perf-v6e-4.yaml",
+                cases=perf_sweep_cases(
+                    "qwen3-32b",
+                    PerfParams(
+                        decode_concurrencies=(16, 32),
+                        profile_point=(32, 4096, 1024),
+                        floors={"out_tps": 865.6},
+                        prefill_floor_point=(32, 4096, 1),
+                        prefill_floors={"in_tps": 15629.7},
+                    ),
+                ),
+            ),
+            # 2.1.2a Qwen3-MoE-30B-A3B, full-EP (TP4/EP4), moe-backend=epmoe.
+            # Decode KV ceiling ~118 -> {32,64,96}; repr/trace at c64.
+            SingleHostRun(
+                launch_profile="qwen3-moe-epmoe-perf-v6e-4.yaml",
+                cases=perf_sweep_cases(
+                    "qwen3-moe-epmoe",
+                    PerfParams(
+                        decode_concurrencies=(32, 64, 96),
+                        floors={"out_tps": 1534.1},
+                        prefill_floor_point=(32, 4096, 1),
+                        prefill_floors={"in_tps": 24039.9},
+                    ),
+                ),
+            ),
+            # 2.1.2b Qwen3-MoE-30B-A3B, full-EP (TP4/EP4), moe-backend=fused.
+            # Same KV ceiling as epmoe (same checkpoint) -> {32,64,96}; repr at c64.
+            SingleHostRun(
+                launch_profile="qwen3-moe-fused-perf-v6e-4.yaml",
+                cases=perf_sweep_cases(
+                    "qwen3-moe-fused",
+                    PerfParams(
+                        decode_concurrencies=(32, 64, 96),
+                        floors={"out_tps": 1601.3},
+                        prefill_floor_point=(32, 4096, 1),
+                        prefill_floors={"in_tps": 31954.6},
+                    ),
+                ),
             ),
         ],
     ),
@@ -173,10 +235,11 @@ def run_one(run: SingleHostRun) -> None:
     """Launch one server for ``run`` and evaluate its cases.
 
     Collects per-case failures across all of ``run.cases`` — both gating misses
-    (threshold / no-score) and unexpected crashes from ``run_accuracy_case`` — and
-    raises a single SuiteError tagged with the dominant kind (a crash maps to
-    ``case`` so it surfaces as EXIT_CASE_CRASH, not retryable infra). Only genuine
-    infra errors (profile load, server launch) propagate as-is.
+    and unexpected crashes from the case runner — and raises a single SuiteError
+    tagged with the dominant kind (a crash maps to ``case`` so it surfaces as
+    EXIT_CASE_CRASH, not retryable infra). Only genuine infra errors (profile
+    load, server launch) propagate as-is. ``AccuracyCase`` and ``PerfCase`` are
+    dispatched by type to their case runner.
     """
     profile = load_profile_file(run.launch_profile)
     spec = profile_server_spec(profile)
@@ -191,12 +254,17 @@ def run_one(run: SingleHostRun) -> None:
     try:
         for case in run.cases:
             try:
-                result = run_accuracy_case(case, spec["base_url"], profile.name, profile.target)
+                if isinstance(case, PerfCase):
+                    result, fail = run_perf_case(
+                        case, spec["base_url"], spec["model"], profile.name, profile.target
+                    )
+                else:
+                    result = run_accuracy_case(case, spec["base_url"], profile.name, profile.target)
+                    fail = _gate_accuracy(case, result)
             except Exception as exc:  # noqa: BLE001 — a case crash is a bug, not infra
                 _log(f"{case.name}: CRASH — {exc!r}")
                 failures.append(("case", f"{case.name}: {exc!r}"))
                 continue
-            fail = _gate_accuracy(case, result)
             if fail:
                 _log(f"{case.name}: FAIL ({fail[0]}) — {fail[1]}")
                 failures.append(fail)
@@ -249,8 +317,9 @@ def _dry_run(suite: SingleHostSuite) -> dict:
                 "cases": [
                     {
                         "case": case.name,
-                        "model_id": case.model_id,
-                        "score_threshold": case.score_threshold,
+                        # accuracy-only fields; absent on PerfCase
+                        "model_id": getattr(case, "model_id", None),
+                        "score_threshold": getattr(case, "score_threshold", None),
                     }
                     for case in run.cases
                 ],
@@ -261,7 +330,7 @@ def _dry_run(suite: SingleHostSuite) -> dict:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run single-host SGL-JAX accuracy suites")
+    parser = argparse.ArgumentParser(description="Run single-host SGL-JAX nightly suites")
     parser.add_argument("--suite", required=True, choices=sorted(SUITES))
     parser.add_argument(
         "--cases",


### PR DESCRIPTION
Closes #1202

Nightly 4-TPU perf sweeps for Qwen3-32B and Qwen3-MoE (epmoe/fused), as a reusable scheme parallel to the accuracy nightly — shared driver/emitter/grid (`drivers.py` / `results.py` / `cases.py`), thin per-host wrappers. Each sweep point emits a **per-model CSV** (ci-data trend) and a **per-case JSON** (observability dashboard), gated by a dual-threshold judge. Multi-host reuses the JSON emitter on a lighter path (completion check only). See `single_host/README.md` for the layering and how to add a case.

## Grid — per-model, KV-filtered

Points are split by intent — **prefill** (`output=1`) and **decode** (`output=1024`), all `--disable-radix-cache` — and kept only if the server can actually run the concurrency. "Run N" means the scheduler's `#running-req` truly holds N in-flight, not N requested with the surplus queued behind a smaller running batch. The hard limit is **KV cache**: max decode concurrency ≈ KV-pool tokens / per-request tokens. A point above the ceiling just queues and reports the ceiling's throughput under a bigger label, so it's dropped.

Measured ceilings on v6e-4 (`mem-fraction` 0.9, `max-running-requests` 256, in4096/out1024, steady-state `#running-req`):

| model | KV pool tokens | decode ceiling | prefill |
|---|---|---|---|
| Qwen3-32B dense | 210,688 | **41** (2 KV heads) | 256 |
| Qwen3-MoE-30B-A3B (epmoe/fused) | 605,440 | **118** (1 KV head) | 256 |

Retained grid — every point verified to fill (`#running-req` = concurrency, ~0 queue, no preemption):

| model | profile | prefill `c` (×i{4k,8k}) | decode `c` (×i4k) | repr (trace + floor) |
|---|---|---|---|---|
| Qwen3-32B | `qwen3-32b-perf-v6e-4.yaml` (TP4+fa) | 8, 32 | 16, 32 | `c32` |
| MoE epmoe | `qwen3-moe-epmoe-perf-v6e-4.yaml` (TP4/EP4) | 8, 32 | 32, 64, 96 | `c64` |
| MoE fused | `qwen3-moe-fused-perf-v6e-4.yaml` (TP4/EP4) | 8, 32 | 32, 64, 96 | `c64` |

No decode concurrency ≥128 fills on any model — every ceiling is below it (dense 41, MoE 118) — so the issue's c256 (and c128) are dropped across the board. Dense is tighter still: its 41-ceiling also rules out c64, leaving decode `{16,32}`; the MoE 118-ceiling admits up to `c96`. Prefill (`output=1`) is never KV-bound, so the swept `c{8,32}` fill on all three models.

## Dual-threshold gate (Mandatory — failure blocks nightly)

`gate_perf_result`, in order:
1. **completion** — `completed == num_prompts` (OOM / dropped requests).
2. **absolute floor** — per-metric, by direction (throughput → fail under floor; latency → fail over). Registered as `out_tps` at the decode repr + `in_tps` at the prefill repr.
3. **trailing baseline** — within `tol` of the last-N-night mean (`gated_metrics`: prefill gates in_tps+TTFT, decode adds out_tps+ITL; drop for throughput, rise for latency). Skipped until `TRAILING_MIN_NIGHTS` of history exist.

Completion-failed points aren't persisted, so a partial measurement never pollutes the trend or baseline.

### Absolute floors = `min(3 runs) × 0.85`

Calibrated on the KV-filtered grid, each repr point verified to fill. The decode repr carries an `out_tps` floor; the prefill repr (`c32,i4096,o1`) carries a symmetric `in_tps` floor (prefill throughput, no trace).

Decode repr — `out_tps`:

| model | repr point | run1 / run2 / run3 | min | floor |
|---|---|---|---|---|
| qwen3-32b | `c32,i4096,o1024` | 1019.9 / 1018.4 / 1018.4 | 1018.4 | **865.6** |
| epmoe | `c64,i4096,o1024` | 1804.8 / 1805.2 / 1805.0 | 1804.8 | **1534.1** |
| fused | `c64,i4096,o1024` | 1883.9 / 1884.2 / 1884.0 | 1883.9 | **1601.3** |

Prefill repr — `in_tps` (`c32,i4096,o1`, num_prompts=1024; not KV-bound, so it fills on all three):

| model | repr point | run1 / run2 / run3 | min | floor |
|---|---|---|---|---|
| qwen3-32b | `c32,i4096,o1` | 18387.84 / 18391.24 / 18390.92 | 18387.84 | **15629.7** |
| epmoe | `c32,i4096,o1` | 28282.20 / 28288.00 / 28288.47 | 28282.20 | **24039.9** |
| fused | `c32,i4096,o1` | 37593.64 / 37601.00 / 37599.87 | 37593.64 | **31954.6** |

Run-to-run spread <1%, so the 15% margin is comfortably loose.

## Correctness gate for the perf 32B config

The perf suite measures Qwen3-32B (bf16/TP4/fa) with random data — throughput only, no output check, and Qwen3-32B had **no** correctness test in the nightly. Added a Qwen3-32B gsm8k accuracy case (same model/TP/attention; `max-running-requests`/radix-cache per accuracy convention; threshold 0.92, measured ~0.97) so a numerics regression on that config is caught by accuracy, not only the perf floor.

## Changes

- **New**: `drivers.py` (case drivers extracted from `results.py`), `perf_baseline.py` (cached ci-data trailing lookup), 3 perf launch profiles + the `qwen3-32b-fa` accuracy profile.
- `results.py` / `cases.py`: `build_perf_result` + `write_perf_csv`/`write_perf_json` + `gate_perf_result`; `PerfCase`/`PerfParams`/`perf_sweep_cases` (grid + per-case floors travel with the case — no separate sweep/threshold file). Accuracy path untouched (`write_accuracy_result`→`write_result` rename).
- single- + multi-host perf case runners; `publish.py --data-type perf`; `nightly-test-daily.yml` v6e-4 perf job (CSV→ci-data, JSON→observability mount, xprof artifact).
- `fix(profile)`: `ProfileReq` / `start_profile` accept `profile_by_stage: bool | None` so bench-driven profiling no longer 400s (xprof traces were silently lost).

## Test plan

- [x] dry-run + unit (gate 3 paths incl. direction, metric translation, CSV/JSON, `perf_baseline` cache, inf→null); consumer checks (`plot_perf.py` reads the CSV, dashboard `parseCaseDetail` reads the JSON)
- [x] black / ruff / isort clean
- [x] floors calibrated from 3× fills on the KV-filtered grid (table above)
- [x] **full nightly green**: 3 perf servers + 20/20 sweep points, 9/9 accuracy incl. the new 32B gate (gsm8k 0.9447), 0 crashes / 0 infra failures
- [ ] 3-night trailing-gate activation (auto, post-merge once ci-data history ≥5 nights)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
