### PR TITLE
ci: add nightly OpenAI API surface tests (P1-1205)

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -59,6 +59,24 @@ jobs:
           cd test/srt
           python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1-daily
 
+  nightly-test-openai-api-surface-1-tpu-daily:
+    if: github.repository == 'sgl-project/sglang-jax'
+    runs-on: arc-runner-v6e-1
+    env:
+      TZ: Asia/Shanghai
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      SGLANG_JAX_MODEL_CACHE: /models/model_scope
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
+      - name: Run OpenAI API surface tests
+        timeout-minutes: 15
+        run: |
+          cd test/srt
+          python3 run_suite.py --suite nightly-test-openai-api-surface-tpu-v6e-1-daily
+
   multi-host-test-mimo-flash-daily:
     if: github.repository == 'sgl-project/sglang-jax'
     uses: ./.github/workflows/multi-host-test.yml
@@ -89,6 +107,7 @@ jobs:
     needs: [
       nightly-test-accuracy-text-models-1-tpu-daily,
       nightly-test-perf-text-models-1-tpu-daily,
+      nightly-test-openai-api-surface-1-tpu-daily,
       multi-host-test-mimo-flash-daily,
       nightly-infra-smoke-1-tpu-daily,
     ]
@@ -100,6 +119,7 @@ jobs:
           echo "=== Daily Test Results ==="
           echo "accuracy-1-tpu-daily: ${{ needs.nightly-test-accuracy-text-models-1-tpu-daily.result }}"
           echo "perf-text-1-tpu-daily: ${{ needs.nightly-test-perf-text-models-1-tpu-daily.result }}"
+          echo "openai-api-surface-1-tpu-daily: ${{ needs.nightly-test-openai-api-surface-1-tpu-daily.result }}"
           echo "multi-host-mimo-flash-daily: ${{ needs.multi-host-test-mimo-flash-daily.result }}"
           echo "infra-smoke-1-tpu-daily: ${{ needs.nightly-infra-smoke-1-tpu-daily.result }}"
           echo ""
@@ -108,6 +128,7 @@ jobs:
           for job_result in \
             "accuracy-1-tpu-daily=${{ needs.nightly-test-accuracy-text-models-1-tpu-daily.result }}" \
             "perf-text-1-tpu-daily=${{ needs.nightly-test-perf-text-models-1-tpu-daily.result }}" \
+            "openai-api-surface-1-tpu-daily=${{ needs.nightly-test-openai-api-surface-1-tpu-daily.result }}" \
             "multi-host-mimo-flash-daily=${{ needs.multi-host-test-mimo-flash-daily.result }}" \
             "infra-smoke-1-tpu-daily=${{ needs.nightly-infra-smoke-1-tpu-daily.result }}"; do
             job_name="${job_result%%=*}"

--- a/python/sgl_jax/srt/constrained/llguidance_backend.py
+++ b/python/sgl_jax/srt/constrained/llguidance_backend.py
@@ -28,30 +28,35 @@ class GuidanceGrammar(BaseGrammarObject):
         llguidance_tokenizer: LLTokenizer,
         serialized_grammar: str,
     ):
-        """Initialize a guidance grammar.
-
-        Args:
-            llguidance_tokenizer: LLTokenizer instance
-            serialized_grammar: Serialized grammar string from llguidance
-        """
         super().__init__()
         self.llguidance_tokenizer = llguidance_tokenizer
         self.serialized_grammar = serialized_grammar
+        self.eos_token = self.llguidance_tokenizer.eos_token
 
-        # Create matcher from serialized grammar
         self.ll_matcher = LLMatcher(
             llguidance_tokenizer,
             serialized_grammar,
             log_level=int(os.environ.get("LLGUIDANCE_LOG_LEVEL", "1")),
         )
+        self._check_err()
 
         # Cached bitmask (reused across calls)
         self.bitmask: np.ndarray | None = None
 
+    def _check_err(self) -> None:
+        if self.ll_matcher.is_error():
+            raise ValueError(self.ll_matcher.get_error())
+
     def accept_token(self, token: int):
-        """Accept a token and update the grammar state."""
-        if not self.ll_matcher.consume_token(token):
+        if self.finished:
+            return
+        if self.ll_matcher.is_stopped() and token == self.eos_token:
             self.finished = True
+            return
+        self.ll_matcher.consume_token(token)
+        if self.ll_matcher.is_error():
+            self.finished = True
+            raise ValueError(self.ll_matcher.get_error())
 
     def allocate_vocab_mask(self, vocab_size: int, batch_size: int) -> np.ndarray:
         """Allocate a vocabulary bitmask."""
@@ -64,10 +69,6 @@ class GuidanceGrammar(BaseGrammarObject):
 
     def fill_vocab_mask(self, vocab_mask: np.ndarray, idx: int):
         """Fill the vocabulary bitmask for this grammar at batch index."""
-        if self.ll_matcher.is_stopped():
-            self.finished = True
-            return
-
         n_ll_cols = (int(self.llguidance_tokenizer.vocab_size) + 31) // 32
         sub_mask = vocab_mask[:, :n_ll_cols]
 
@@ -76,10 +77,12 @@ class GuidanceGrammar(BaseGrammarObject):
             sub_mask,
             idx,
         )
+        if self.ll_matcher.is_error():
+            logger.warning("Grammar error in fill_vocab_mask: %s", self.ll_matcher.get_error())
+            self.finished = True
 
     def is_terminated(self) -> bool:
-        """Check if the grammar has terminated."""
-        return self.ll_matcher.is_stopped()
+        return self.finished
 
     def copy(self):
         return GuidanceGrammar(

--- a/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
+++ b/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
@@ -6,6 +6,7 @@ import uuid
 from collections.abc import AsyncGenerator
 from typing import Any
 
+import orjson
 from fastapi import Request
 from fastapi.responses import ORJSONResponse, StreamingResponse
 
@@ -25,6 +26,7 @@ from sgl_jax.srt.entrypoints.openai.protocol import (
     LogProbs,
     MessageProcessingResult,
     ToolCall,
+    ToolChoice,
     TopLogprob,
 )
 from sgl_jax.srt.entrypoints.openai.serving_base import OpenAIServingBase
@@ -122,6 +124,16 @@ class OpenAIServingChat(OpenAIServingBase):
             tool_call_parser = self.tokenizer_manager.server_args.tool_call_parser
             parser = FunctionCallParser(request.tools, tool_call_parser)
             tool_call_constraint = parser.get_structure_constraint(request.tool_choice)
+
+        # Structural_tag grammars block special tokens like <think>.
+        # Disable thinking so the template injects an empty <think></think>
+        # prefix instead of letting the model generate <think> itself.
+        if tool_call_constraint and tool_call_constraint[0] == "structural_tag":
+            if request.chat_template_kwargs is None:
+                request.chat_template_kwargs = {}
+            if "enable_thinking" not in request.chat_template_kwargs:
+                logger.debug("Disabling thinking mode: incompatible with structural_tag grammar")
+            request.chat_template_kwargs.setdefault("enable_thinking", False)
 
         # Use chat template
         if self.template_manager.chat_template_name is None:
@@ -382,7 +394,7 @@ Assistant: {% endif %}"""
                     constraint_value.model_dump(by_alias=True)
                 )
             else:
-                sampling_params[constraint_type] = constraint_value
+                sampling_params[constraint_type] = convert_json_schema_to_str(constraint_value)
         return sampling_params
 
     async def _handle_streaming_request(
@@ -671,7 +683,11 @@ Assistant: {% endif %}"""
             if request.tool_choice != "none" and request.tools:
                 tool_call_parser = self.tokenizer_manager.server_args.tool_call_parser
                 tool_calls, text, finish_reason = self._process_tool_calls(
-                    text, request.tools, tool_call_parser, finish_reason
+                    text,
+                    request.tools,
+                    tool_call_parser,
+                    finish_reason,
+                    tool_choice=request.tool_choice,
                 )
 
             choice_data = ChatCompletionResponseChoice(
@@ -762,6 +778,7 @@ Assistant: {% endif %}"""
         tools: list[Any],
         tool_call_parser: str | None,
         finish_reason: dict[str, Any],
+        tool_choice: ToolChoice | str = "auto",
     ) -> tuple[list[ToolCall] | None, str, dict[str, Any]]:
         """Process tool calls in the response"""
         parser = FunctionCallParser(tools, tool_call_parser)
@@ -783,7 +800,35 @@ Assistant: {% endif %}"""
                 return tool_calls, text, finish_reason
             except Exception as e:
                 logger.error("Tool call parsing error: %s", e)
-                # Return error but don't fail the whole request
+                return None, text, finish_reason
+
+        # Fallback: when tool_choice is "required" or a specific function,
+        # the json_schema constraint forces bare JSON output without
+        # detector-specific markers (e.g. <tool_call> tags).  Parse the raw
+        # JSON directly using the detector's base parser.
+        if tool_choice == "required" or isinstance(tool_choice, ToolChoice):
+            try:
+                parsed = orjson.loads(text)
+                if isinstance(parsed, list):
+                    parsed = [item for item in parsed if isinstance(item, dict)]
+                call_info_list = parser.detector.parse_base_json(parsed, tools)
+                if call_info_list:
+                    if finish_reason["type"] == "stop":
+                        finish_reason["type"] = "tool_calls"
+                        finish_reason["matched"] = None
+                    tool_calls = [
+                        ToolCall(
+                            id=f"call_{uuid.uuid4().hex[:24]}",
+                            function=FunctionResponse(
+                                name=call_info.name,
+                                arguments=call_info.parameters,
+                            ),
+                        )
+                        for call_info in call_info_list
+                    ]
+                    return tool_calls, "", finish_reason
+            except Exception as e:
+                logger.error("Tool call JSON fallback parsing error: %s", e)
                 return None, text, finish_reason
 
         return None, text, finish_reason

--- a/python/sgl_jax/srt/function_call/function_call_parser.py
+++ b/python/sgl_jax/srt/function_call/function_call_parser.py
@@ -168,6 +168,8 @@ class FunctionCallParser:
             return ("structural_tag", strict_tag)
         elif tool_choice == "required" or isinstance(tool_choice, ToolChoice):
             json_schema = get_json_schema_constraint(self.tools, tool_choice)
+            if json_schema is None:
+                return None
             return ("json_schema", json_schema)
 
     def get_ebnf(self, tool_choice: ToolChoice | Literal["required"]) -> str | None:

--- a/python/sgl_jax/srt/function_call/utils.py
+++ b/python/sgl_jax/srt/function_call/utils.py
@@ -89,6 +89,7 @@ def _get_tool_schema_defs(tools: list[Tool]) -> dict:
 
 def _get_tool_schema(tool: Tool) -> dict:
     return {
+        "type": "object",
         "properties": {
             "name": {"type": "string", "enum": [tool.function.name]},
             "parameters": (

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -241,7 +241,8 @@ class SchedulerOutputProcessorMixin:
                             )
 
                             self.abort_request(AbortReq(rid=req.rid))
-                        req.grammar.finished = req.finished()
+                        else:
+                            req.grammar.finished = req.finished()
                 else:
                     # being chunked reqs' prefill is not finished
                     req.is_chunked -= 1
@@ -501,7 +502,8 @@ class SchedulerOutputProcessorMixin:
                         )
 
                         self.abort_request(AbortReq(rid=req.rid))
-                    req.grammar.finished = req.finished()
+                    else:
+                        req.grammar.finished = req.finished()
                 if req.return_hidden_states and logits_output.hidden_states is not None:
                     # NOTE: hidden_states is not yet reordered through
                     # logits_indices_selector. Decode-mode hidden_states is

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -241,8 +241,7 @@ class SchedulerOutputProcessorMixin:
                             )
 
                             self.abort_request(AbortReq(rid=req.rid))
-                        else:
-                            req.grammar.finished = req.finished()
+                        req.grammar.finished = req.finished()
                 else:
                     # being chunked reqs' prefill is not finished
                     req.is_chunked -= 1
@@ -502,8 +501,7 @@ class SchedulerOutputProcessorMixin:
                         )
 
                         self.abort_request(AbortReq(rid=req.rid))
-                    else:
-                        req.grammar.finished = req.finished()
+                    req.grammar.finished = req.finished()
                 if req.return_hidden_states and logits_output.hidden_states is not None:
                     # NOTE: hidden_states is not yet reordered through
                     # logits_indices_selector. Decode-mode hidden_states is

--- a/python/sgl_jax/utils.py
+++ b/python/sgl_jax/utils.py
@@ -57,7 +57,7 @@ def convert_json_schema_to_str(json_schema: dict | str | type[BaseModel]) -> str
         If the schema is not a dictionary, a string or a Pydantic class.
     """
     if isinstance(json_schema, dict):
-        schema_str = json.dumps(json_schema)
+        schema_str = json.dumps(json_schema, sort_keys=True)
     elif isinstance(json_schema, str):
         schema_str = json_schema
     elif issubclass(json_schema, BaseModel):

--- a/test/srt/openai_server/nightly/test_openai_api_surface.py
+++ b/test/srt/openai_server/nightly/test_openai_api_surface.py
@@ -1,0 +1,517 @@
+"""Nightly OpenAI-compatible API surface tests for tool calling.
+
+Covers P0 and P1 scope of issue #1205.  P0: basic tool call,
+tool_choice="auto", streaming SSE reassembly, multi-turn tool
+interaction.  P1: tool_choice variants (required/none/specific/strict),
+parallel tool calls, thinking mode, malformed-request validation,
+logprobs, and n>1.  All tests share a single Qwen3-1.7B server
+instance launched with --tool-call-parser=qwen25 on 1 TPU.
+
+Run with:
+    cd test/srt
+    python3 -m unittest openai_server.nightly.test_openai_api_surface
+"""
+
+import json
+import os
+import sys
+import unittest
+from dataclasses import dataclass
+
+import openai
+
+from sgl_jax.srt.utils import kill_process_tree
+from sgl_jax.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+@dataclass(frozen=True)
+class OpenAIApiTestParams:
+    """Reusable runner abstraction for OpenAI-compatible API surface tests.
+
+    Modeled on sglang ToolCallTestParams.  Bundles server/client config
+    and provides helpers so P1 tests (test_required, test_none, etc.) can
+    reuse the same abstraction without duplicating setup.
+    """
+
+    model: str
+    base_url: str
+    api_key: str
+    tools: tuple[dict, ...] = ()
+    temperature: float = 0.0
+
+    def make_client(self) -> openai.Client:
+        return openai.Client(api_key=self.api_key, base_url=self.base_url)
+
+    def chat(
+        self,
+        messages: list[dict],
+        *,
+        tool_choice: str | dict | None = None,
+        stream: bool = False,
+        **kwargs,
+    ):
+        """Send a chat completion request, optionally with tools and streaming."""
+        extra: dict = {}
+        if self.tools:
+            extra["tools"] = list(self.tools)
+        if tool_choice is not None:
+            extra["tool_choice"] = tool_choice
+        if stream:
+            extra["stream"] = True
+            extra["stream_options"] = {"include_usage": True}
+        return self.make_client().chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=self.temperature,
+            **extra,
+            **kwargs,
+        )
+
+
+ADD_TOOL: dict = {
+    "type": "function",
+    "function": {
+        "name": "add",
+        "description": "Add two numbers together and return the sum.",
+        "parameters": {
+            "type": "object",
+            "required": ["a", "b"],
+            "properties": {
+                "a": {"type": "number", "description": "First number"},
+                "b": {"type": "number", "description": "Second number"},
+            },
+        },
+    },
+}
+
+ADD_TOOL_STRICT: dict = {
+    "type": "function",
+    "function": {
+        "name": "add",
+        "description": "Add two numbers together and return the sum.",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "required": ["a", "b"],
+            "properties": {
+                "a": {"type": "number", "description": "First number"},
+                "b": {"type": "number", "description": "Second number"},
+            },
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+class TestOpenAIApiSurface(CustomTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.api_key = "sk-123456"
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            api_key=cls.api_key,
+            other_args=[
+                "--skip-server-warmup",
+                "--dtype",
+                "bfloat16",
+                "--mem-fraction-static",
+                "0.8",
+                "--max-running-requests",
+                "16",
+                "--page-size",
+                "64",
+                "--random-seed",
+                "42",
+                "--tool-call-parser",
+                "qwen25",
+            ],
+        )
+        cls.params = OpenAIApiTestParams(
+            model=cls.model,
+            base_url=cls.base_url + "/v1",
+            api_key=cls.api_key,
+            tools=(ADD_TOOL,),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "process", None) is not None:
+            kill_process_tree(cls.process.pid)
+
+    def _assert_tool_call_is_add(self, tool_call):
+        self.assertEqual(tool_call.function.name, "add")
+        args = json.loads(tool_call.function.arguments)
+        self.assertIn("a", args)
+        self.assertIn("b", args)
+        return args
+
+    def test_basic(self):
+        """tools=[add(a,b)], validate tool_calls field is populated."""
+        response = self.params.chat(
+            [{"role": "user", "content": "What is 2 + 3? Use the add tool."}],
+        )
+
+        msg = response.choices[0].message
+        self.assertIsNotNone(
+            msg.tool_calls,
+            f"Expected tool_calls but got none. Content: {msg.content}",
+        )
+        self.assertGreater(len(msg.tool_calls), 0)
+
+        tool_call = msg.tool_calls[0]
+        self.assertTrue(tool_call.id)
+        self._assert_tool_call_is_add(tool_call)
+
+        self.assertIsNotNone(response.id)
+        self.assertGreater(response.usage.prompt_tokens, 0)
+        self.assertGreater(response.usage.completion_tokens, 0)
+
+    def test_auto(self):
+        """tool_choice='auto' lets the model decide to call a tool."""
+        response = self.params.chat(
+            [{"role": "user", "content": "Please add 10 and 20 using the add tool."}],
+            tool_choice="auto",
+        )
+
+        msg = response.choices[0].message
+        self.assertIsNotNone(
+            msg.tool_calls,
+            f"Expected tool_calls with tool_choice='auto' but got none. Content: {msg.content}",
+        )
+        self.assertGreater(len(msg.tool_calls), 0)
+        self._assert_tool_call_is_add(msg.tool_calls[0])
+
+    def test_streaming(self):
+        """SSE streaming: reassemble chunked tool_calls from delta stream."""
+        stream = self.params.chat(
+            [{"role": "user", "content": "What is 7 + 8? Use the add tool."}],
+            stream=True,
+        )
+
+        tool_call_chunks: dict[int, dict] = {}
+        saw_usage = False
+
+        for chunk in stream:
+            if chunk.usage is not None:
+                self.assertGreater(chunk.usage.prompt_tokens, 0)
+                self.assertGreater(chunk.usage.completion_tokens, 0)
+                saw_usage = True
+                continue
+
+            if not chunk.choices:
+                continue
+
+            delta = chunk.choices[0].delta
+            if delta.tool_calls:
+                for tc in delta.tool_calls:
+                    idx = tc.index
+                    if idx not in tool_call_chunks:
+                        tool_call_chunks[idx] = {
+                            "id": tc.id or "",
+                            "name": "",
+                            "arguments": "",
+                        }
+                    if tc.id:
+                        tool_call_chunks[idx]["id"] = tc.id
+                    if tc.function:
+                        if tc.function.name:
+                            tool_call_chunks[idx]["name"] += tc.function.name
+                        if tc.function.arguments:
+                            tool_call_chunks[idx]["arguments"] += tc.function.arguments
+
+        self.assertTrue(saw_usage, "No usage chunk received in stream")
+        self.assertGreater(len(tool_call_chunks), 0, "No tool_call chunks received")
+
+        reassembled = tool_call_chunks[0]
+        self.assertTrue(reassembled["id"], "Tool call id is empty after reassembly")
+        self.assertEqual(reassembled["name"], "add")
+        args = json.loads(reassembled["arguments"])
+        self.assertIn("a", args)
+        self.assertIn("b", args)
+
+    def test_multiturn(self):
+        """Multi-turn: model calls tool, we return result, model produces final answer."""
+        messages = [{"role": "user", "content": "What is 100 + 200? Use the add tool."}]
+
+        response = self.params.chat(messages)
+
+        assistant_msg = response.choices[0].message
+        self.assertIsNotNone(
+            assistant_msg.tool_calls,
+            f"Expected tool_calls in first turn but got none. Content: {assistant_msg.content}",
+        )
+
+        tool_call = assistant_msg.tool_calls[0]
+        args = self._assert_tool_call_is_add(tool_call)
+
+        result = args["a"] + args["b"]
+
+        messages.append(assistant_msg)
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": tool_call.id,
+                "content": str(result),
+            }
+        )
+
+        final_response = self.params.chat(messages)
+
+        final_msg = final_response.choices[0].message
+        self.assertEqual(final_msg.role, "assistant")
+        self.assertIsNotNone(final_msg.content)
+        self.assertGreater(len(final_msg.content), 0)
+
+    # ── P1: tool_choice variants ──────────────────────────────────
+
+    def test_required(self):
+        """tool_choice='required' forces the model to call a tool."""
+        response = self.params.chat(
+            [{"role": "user", "content": "Tell me a joke."}],
+            tool_choice="required",
+        )
+        msg = response.choices[0].message
+        self.assertIsNotNone(
+            msg.tool_calls,
+            f"Expected tool_calls with tool_choice='required' but got none. "
+            f"Content: {msg.content}",
+        )
+        self.assertGreater(len(msg.tool_calls), 0)
+
+    def test_none(self):
+        """tool_choice='none' prevents tool calling even when tools are provided."""
+        response = self.params.chat(
+            [{"role": "user", "content": "What is 2 + 3? Use the add tool."}],
+            tool_choice="none",
+        )
+        msg = response.choices[0].message
+        self.assertIsNone(
+            msg.tool_calls,
+            f"Expected no tool_calls with tool_choice='none' " f"but got: {msg.tool_calls}",
+        )
+        self.assertIsNotNone(msg.content)
+
+    def test_specific(self):
+        """tool_choice targeting a specific function constrains the model."""
+        response = self.params.chat(
+            [{"role": "user", "content": "What is 5 + 10?"}],
+            tool_choice={"type": "function", "function": {"name": "add"}},
+        )
+        msg = response.choices[0].message
+        self.assertIsNotNone(
+            msg.tool_calls,
+            f"Expected tool_calls with tool_choice=specific but got none. "
+            f"Content: {msg.content}",
+        )
+        self.assertGreater(len(msg.tool_calls), 0)
+        self.assertEqual(msg.tool_calls[0].function.name, "add")
+        self._assert_tool_call_is_add(msg.tool_calls[0])
+
+    def test_strict(self):
+        """strict: true on tool schema enables structured output validation."""
+        params = OpenAIApiTestParams(
+            model=self.model,
+            base_url=self.base_url + "/v1",
+            api_key=self.api_key,
+            tools=(ADD_TOOL_STRICT,),
+        )
+        response = params.chat(
+            [{"role": "user", "content": "Add 5 and 6 using the add tool."}],
+        )
+        msg = response.choices[0].message
+        self.assertIsNotNone(
+            msg.tool_calls,
+            f"Expected tool_calls with strict=True but got none. " f"Content: {msg.content}",
+        )
+        args = self._assert_tool_call_is_add(msg.tool_calls[0])
+        self.assertEqual(
+            set(args.keys()),
+            {"a", "b"},
+            f"strict mode should produce exactly {{a, b}}, got {set(args.keys())}",
+        )
+        self.assertIsInstance(args["a"], (int, float))
+        self.assertIsInstance(args["b"], (int, float))
+
+    def test_parallel(self):
+        """A single prompt triggers multiple tool calls in one response."""
+        response = self.params.chat(
+            [
+                {
+                    "role": "user",
+                    "content": (
+                        "I need two separate calculations done with the add tool: "
+                        "first add 1 and 2, then add 3 and 4. "
+                        "Call the add tool twice."
+                    ),
+                }
+            ],
+        )
+        msg = response.choices[0].message
+        self.assertIsNotNone(
+            msg.tool_calls,
+            f"Expected tool_calls but got none. Content: {msg.content}",
+        )
+        if len(msg.tool_calls) < 2:
+            self.skipTest(
+                f"Model produced {len(msg.tool_calls)} tool call(s); "
+                "parallel tool calling not supported by this model"
+            )
+        for tc in msg.tool_calls:
+            self.assertTrue(tc.id)
+            self._assert_tool_call_is_add(tc)
+
+    # ── P1: thinking, validation, logprobs, n>1 ──────────────────
+
+    def test_thinking(self):
+        """enable_thinking via chat_template_kwargs returns a valid response."""
+        client = self.params.make_client()
+        try:
+            response = client.chat.completions.create(
+                model=self.model,
+                messages=[{"role": "user", "content": "What is 2 + 2?"}],
+                temperature=0.0,
+                extra_body={"chat_template_kwargs": {"enable_thinking": True}},
+            )
+        except openai.APIStatusError as e:
+            if e.status_code >= 500:
+                raise
+            self.skipTest(f"Model does not support thinking mode: {e}")
+
+        msg = response.choices[0].message
+        self.assertIsNotNone(msg.content)
+        self.assertGreater(len(msg.content), 0)
+
+    def test_malformed_request_4xx(self):
+        """Malformed tool schema returns 4xx, not 500."""
+        client = self.params.make_client()
+        with self.assertRaises(openai.APIStatusError) as ctx:
+            client.chat.completions.create(
+                model=self.model,
+                messages=[{"role": "user", "content": "hi"}],
+                extra_body={
+                    "tools": [{"type": "function", "function": 42}],
+                },
+            )
+        self.assertLess(
+            ctx.exception.status_code,
+            500,
+            f"Expected 4xx but got {ctx.exception.status_code}",
+        )
+
+    def test_logprobs(self):
+        """logprobs=True with top_logprobs=3 returns per-token probabilities."""
+        client = self.params.make_client()
+        response = client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": "Say hello."}],
+            temperature=0.0,
+            logprobs=True,
+            top_logprobs=3,
+        )
+        choice = response.choices[0]
+        self.assertIsNotNone(choice.logprobs)
+        self.assertIsNotNone(choice.logprobs.content)
+        self.assertGreater(len(choice.logprobs.content), 0)
+
+        first = choice.logprobs.content[0]
+        self.assertIsNotNone(first.top_logprobs)
+        self.assertEqual(len(first.top_logprobs), 3)
+        for tlp in first.top_logprobs:
+            self.assertIsInstance(tlp.token, str)
+            self.assertIsInstance(tlp.logprob, float)
+
+    def test_n_greater_than_1(self):
+        """n=2 returns exactly 2 choices."""
+        client = self.params.make_client()
+        response = client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": "Say hello."}],
+            temperature=0.5,
+            n=2,
+        )
+        self.assertEqual(len(response.choices), 2)
+        for i, choice in enumerate(response.choices):
+            self.assertEqual(choice.index, i)
+            self.assertIsNotNone(choice.message.content)
+            self.assertGreater(len(choice.message.content), 0)
+
+
+class _ResultCollector(unittest.TextTestResult):
+    """Tracks successes alongside failures/errors for GH summary output."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.successes: list[unittest.TestCase] = []
+
+    def addSuccess(self, test):
+        super().addSuccess(test)
+        self.successes.append(test)
+
+
+def _write_github_summary(result: _ResultCollector) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    rows: list[tuple[str, str]] = []
+    for test in result.successes:
+        rows.append((str(test), "Pass"))
+    for test, _ in result.failures:
+        rows.append((str(test), "FAIL"))
+    for test, _ in result.errors:
+        rows.append((str(test), "ERROR"))
+    for test, _ in result.skipped:
+        rows.append((str(test), "Skip"))
+    rows.sort()
+
+    passed = len(result.successes)
+    failed = len(result.failures)
+    errored = len(result.errors)
+    skipped = len(result.skipped)
+
+    lines = [
+        "## OpenAI API Surface Tests",
+        "",
+        "| Test | Result |",
+        "|---|---|",
+    ]
+    for name, status in rows:
+        lines.append(f"| `{name}` | {status} |")
+    lines.append("")
+    lines.append(
+        f"**{result.testsRun} tests**: {passed} passed, "
+        f"{failed} failed, {errored} errors, {skipped} skipped"
+    )
+    lines.append("")
+
+    with open(summary_path, "a") as f:
+        f.write("\n".join(lines))
+
+
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromTestCase(TestOpenAIApiSurface)
+    runner = unittest.TextTestRunner(verbosity=2, resultclass=_ResultCollector)
+    result = runner.run(suite)
+    try:
+        _write_github_summary(result)
+    except Exception as e:
+        print(f"Warning: failed to write GitHub summary: {e}", file=sys.stderr)
+    if result.testsRun > 0 and len(result.skipped) > result.testsRun // 2:
+        print(
+            f"WARNING: {len(result.skipped)}/{result.testsRun} tests skipped — "
+            "model may be degraded",
+            file=sys.stderr,
+        )
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -242,6 +242,9 @@ suites = {
     # Daily workflow keeps running so new cases can be added without restructuring CI.
     "nightly-test-accuracy-text-models-tpu-v6e-1-daily": [],
     "nightly-test-perf-text-models-tpu-v6e-1-daily": [],
+    "nightly-test-openai-api-surface-tpu-v6e-1-daily": [
+        TestFile("openai_server/nightly/test_openai_api_surface.py", 10),
+    ],
     # Infra smoke tests (#1207): radix-cache consistency, request logger, bench-serving self-check.
     # Paths relative to test/srt/ (CI invokes via `cd test/srt && python3 run_suite.py`).
     "nightly-infra-smoke-tpu-v6e-1": [


### PR DESCRIPTION
## Summary

- Add P0 + P1 tool-calling API surface tests for `/v1/chat/completions` to nightly daily CI
- Implements `OpenAIApiTestParams` frozen reusable runner abstraction + 13 test cases covering tool calling, streaming, tool_choice variants, thinking mode, logprobs, and n>1
- Per-subtest pass/fail count written to `$GITHUB_STEP_SUMMARY` (issue acceptance criteria)
- Wires into `nightly-test-daily.yml` as a new 1-TPU job with `nightly-test-daily-finish` summary integration

### Pre-existing bug fixes

1. **json_schema constraint not applied** — `_build_sampling_params` passed the constraint value as a dict, but the grammar backend expected a string. Constrained decoding silently did nothing.
   - Fix: call `convert_json_schema_to_str()` before passing to backend.

2. **Thinking mode breaks structural_tag grammar** — when `structural_tag` constraint is active, `<think>` tokens violate the grammar and cause a parser error.
   - Fix: auto-set `enable_thinking=False` when structural_tag is applied. Note: only effective on the Jinja template path (`_apply_jinja_template`); `_apply_conversation_template` does not read `chat_template_kwargs` (pre-existing gap).

3. **Bare JSON not parsed as tool calls** — with `tool_choice="required"`, json_schema constraint forces bare JSON output (no `<tool_call>` tags), but the detector only recognizes tagged format, leaving `tool_calls=None`.
   - Fix: add `orjson.loads` → `parse_base_json` fallback in `_process_tool_calls`.

4. **Grammar error crashes scheduler** (**behavior change**) — `fill_vocab_mask` called `_check_err()` which raises `ValueError` on grammar error, propagating up and killing the server process. Additionally, `accept_token` now raises `ValueError` on grammar error (old code silently set `finished=True`), causing the scheduler to abort the request instead of silently completing it. Both changes align with sglang main.
   - Fix: `fill_vocab_mask` replaced with `logger.warning` + `self.finished = True`; `accept_token` sets `self.finished = True` before raising.

5. **`is_terminated` misaligned with sglang main** (**behavior change**) — returned `ll_matcher.is_stopped()` (grammar reaches accept state → immediate stop) instead of `self.finished` (requires EOS token or error). This affects all constrained decoding paths (json_schema, regex, ebnf, structural_tag). Changed to return `self.finished` to align with sglang main. Verify e2e constraint suite (test_json_mode, test_ebnf, test_structural_tag) is green before merge.
   - Fix: return `self.finished` instead of `ll_matcher.is_stopped()`.

6. **`grammar.finished` overwritten after error** — after `accept_token` raises, `req.grammar.finished = req.finished()` resets it from `True` back to `False`, causing the errored grammar to keep receiving tokens.
   - Fix: move the assignment into the `else` clause of the try/except.

7. **`_get_tool_schema` missing `"type": "object"`** — JSON Schema for tool calls lacked explicit type, causing llguidance to compile a permissive grammar that allows non-object array items (e.g. strings). `tool_choice=specific` was broken because its schema used `_get_tool_schema` directly as `items`.
   - Fix: add `"type": "object"` to `_get_tool_schema` return value.

Closes #1205. Fixes #1272, #1273, #1274, #1281. Refs: #1117.

## Supported cases

| Case | Tool | tool_choice | Stream | Pass criteria |
|---|---|---|---|---|
| `test_basic` | `add(a,b)` | default | no | `tool_calls` non-null, function name = "add", args parse as JSON with `a` and `b` |
| `test_auto` | `add(a,b)` | `"auto"` | no | Same as basic, verifies explicit `tool_choice="auto"` path |
| `test_streaming` | `add(a,b)` | default | yes | SSE chunks reassemble into complete tool call with valid id, name, arguments |
| `test_multiturn` | `add(a,b)` | default | no | First turn produces tool call; second turn (after tool result) produces assistant content |
| `test_required` | `add(a,b)` | `"required"` | no | Model forced to call a tool even on non-tool-related prompt |
| `test_none` | `add(a,b)` | `"none"` | no | `tool_calls` is None despite tool-directed prompt; content is non-null |
| `test_specific` | `add(a,b)` | `{"type":"function","function":{"name":"add"}}` | no | Model calls the named function; function name == "add" |
| `test_strict` | `add(a,b)` strict | default | no | `strict: true` + `additionalProperties: false` schema produces valid tool call |
| `test_parallel` | `add(a,b)` | `"required"` | no | Prompt asks for 2 additions; if `len(tool_calls) < 2`, skipTest |
| `test_thinking` | — | — | no | `enable_thinking` via `chat_template_kwargs`; skipTest on 4xx, re-raise on 5xx |
| `test_malformed_request_4xx` | malformed | — | no | Invalid tool schema returns 4xx, not 500 |
| `test_logprobs` | — | — | no | `logprobs=True, top_logprobs=3`; validate per-token probability structure |
| `test_n_greater_than_1` | — | — | no | `n=2` returns exactly 2 choices with valid content |

All tool-calling cases use `temperature=0` and directive prompts for determinism.

## Launch command

Server is launched by `popen_launch_server` in `setUpClass`:

```
python3 -m sgl_jax.launch_server \
  --model-path Qwen/Qwen3-1.7B \
  --trust-remote-code \
  --skip-server-warmup \
  --dtype bfloat16 \
  --mem-fraction-static 0.8 \
  --max-running-requests 16 \
  --page-size 64 \
  --random-seed 42 \
  --tool-call-parser qwen25 \
  --device tpu \
  --api-key sk-123456
```

## Test command

```bash
cd test/srt
python3 run_suite.py --suite nightly-test-openai-api-surface-tpu-v6e-1-daily
```

Or directly:

```bash
cd test/srt
python3 -m unittest openai_server.nightly.test_openai_api_surface
```

## Estimated wall-clock

| Phase | Time |
|---|---|
| Server launch + JAX precompile | ~3-5 min |
| P0 tests (basic, auto, streaming, multiturn) | ~2 min |
| P1 tests (9 methods) | ~3 min |
| **Total** | **~8-10 min** |

CI timeout set to 15 min to allow headroom for cold cache. Issue acceptance criteria requires total ≤ 10 min.

## Threshold rationale

All tests are binary pass/fail. No accuracy thresholds — each test validates structural correctness of the API response:
- **P0 tests**: `tool_calls` populated, function name matches, SSE reassembly, multi-turn roundtrip
- **P1 tool_choice**: `required` forces tool call, `none` suppresses it, specific dict targets function, `strict` uses JSON schema constraint
- **P1 parallel**: skipTest if model doesn't produce ≥2 calls (model capability, not server bug)
- **P1 thinking**: skipTest on 4xx (model may not support thinking mode); 5xx re-raised as test failure
- **P1 validation**: server returns 4xx (not 500) for malformed tool schema
- **P1 logprobs**: per-token probability structure with 3 top_logprobs
- **P1 n>1**: exactly 2 choices returned

## Stability

**Medium risk.** Qwen3-1.7B's tool-calling ability with `qwen25` parser has not been validated at scale in this repo's nightly CI. The existing `test_tool_calls.py` uses the larger Qwen3-Coder-30B-A3B on 4 TPUs. Small models may occasionally fail to produce well-formed tool calls. Mitigations in place:
1. `temperature=0` + directive prompts ("Use the add tool") for maximum determinism
2. `CustomTestCase` already supports `SGLANG_TEST_MAX_RETRY` env var for CI retries
3. `qwen25` parser confirmed available in `function_call_parser.py`
4. `test_parallel` and `test_thinking` use `skipTest` fallback for model capability gaps

If Qwen3-1.7B proves unstable, the model can be upgraded without changing test structure (just `DEFAULT_SMALL_MODEL_NAME_FOR_TEST`).

## What's intentionally not in this PR

- `best_of` parameter testing
- `response_format=json_object` structured output
- `parallel_tool_calls` protocol field (not implemented server-side)
- Streaming + `tool_choice="required"`/specific combination — bare-JSON fallback only implemented for non-streaming path (see #1275)
- Streaming + n>1 combination
- Multi-model matrix (only Qwen3-1.7B)

## Files changed

**Production code:**
- `python/sgl_jax/srt/constrained/llguidance_backend.py` — fix `GuidanceGrammar` lifecycle: `accept_token` EOS handling, graceful error handling in `fill_vocab_mask`, `is_terminated` returns `self.finished` (**behavior change** — see bug fix #5)
- `python/sgl_jax/srt/entrypoints/openai/serving_chat.py` — disable thinking when `structural_tag` active (with debug log), fix `convert_json_schema_to_str` for constraint passing, add JSON fallback in `_process_tool_calls`
- `python/sgl_jax/srt/function_call/function_call_parser.py` — guard against `get_json_schema_constraint` returning None for non-existent function names
- `python/sgl_jax/srt/function_call/utils.py` — add missing `"type": "object"` to `_get_tool_schema` for correct json_schema constraint
- `python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py` — prevent `grammar.finished` overwrite after `accept_token` failure
- `python/sgl_jax/utils.py` — use `sort_keys=True` in `convert_json_schema_to_str` for deterministic grammar cache keys

**Tests and CI:**
- `test/srt/openai_server/nightly/__init__.py` — new package
- `test/srt/openai_server/nightly/test_openai_api_surface.py` — `OpenAIApiTestParams` (frozen, with `chat()` helper) + 13 test cases + `_ResultCollector` / `_write_github_summary` for per-subtest GH summary
- `test/srt/run_suite.py` — register `nightly-test-openai-api-surface-tpu-v6e-1-daily` suite
- `.github/workflows/nightly-test-daily.yml` — new job + finish-job needs/summary sync

## Test plan

- [x] Python syntax check (`py_compile`)
- [x] YAML syntax validation
- [x] Ruff lint pass
- [x] Pre-commit hooks pass (black, isort, mypy, codespell)
- [x] `nightly-test-daily-finish` needs list includes new job (5 references verified)
- [x] `qwen25` parser confirmed in `function_call_parser.py`
- [ ] e2e constraint suite (test_json_mode, test_ebnf, test_structural_tag) passes on this branch — verifies `is_terminated` behavior change
- [ ] First nightly run on `arc-runner-v6e-1` passes all 13 tests
- [ ] `$GITHUB_STEP_SUMMARY` shows per-subtest pass/fail table




