### PR TITLE
fix(attention): correct k_rope sharding in fa_mha MLA path

### DIFF
--- a/python/sgl_jax/srt/models/deepseek_v3.py
+++ b/python/sgl_jax/srt/models/deepseek_v3.py
@@ -386,7 +386,7 @@ class DeepseekV3Attention(nnx.Module):
         k_rope = jnp.broadcast_to(
             k_rope,
             (k_rope.shape[0], self.num_heads, self.qk_rope_head_dim),
-            out_sharding=P(None, "tensor", None),
+            out_sharding=P("data", "tensor", None),
         )
 
         q = jnp.concatenate([q_nope, q_rope], axis=-1)


### PR DESCRIPTION
## Summary

Fix `ShardingTypeError` when using `--attention-backend fa_mha` with MLA models (e.g., DeepSeek-V2-Lite-Chat) on TP>1.

- **Root cause**: `_forward_mha` in `deepseek_v3.py` broadcasts `k_rope` with `P(None, "tensor", None)`, missing `"data"` on the batch dimension. When concatenated with `k_nope` (`P("data", "tensor", None)`), the sharding mismatch causes a `ShardingTypeError` at the FlashAttention `shard_map` boundary during EXTEND precompile.
- **Fix**: One-line change — `P(None, "tensor", None)` → `P("data", "tensor", None)`.
- **Reference**: `glm5_moe.py` already has the correct sharding annotation for the same broadcast pattern.
- **Scope**: `bailing_moe_linear.py` and `kimi_linear.py` both import `DeepseekV3Attention` from `deepseek_v3.py`, so this single fix covers all three models.

Fixes #1248

## Test plan

- [ ] Run `DeepSeek-V2-Lite-Chat` with `--attention-backend fa_mha --tp-size 4` on v6e-4 — verify EXTEND precompile succeeds and eval accuracy matches the `fa` backend baseline (~0.69)

🤖 Generated with [Claude Code](https://claude.com/claude-code)