### PR TITLE
fix(ci): restrict Slack notify to main, skip AI analysis for infra failures

### DIFF
--- a/.github/workflows/nightly-slack-notify.yml
+++ b/.github/workflows/nightly-slack-notify.yml
@@ -3,10 +3,11 @@ name: Nightly Slack Notify
 on:
   workflow_run:
     workflows:
-      - "Nightly Test"
       - "Nightly Test Daily"
     types:
       - completed
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       run_id:
@@ -82,7 +83,7 @@ jobs:
             ## Required output
 
             Write a file `ai_bug_analysis.txt` with a concise plain-text
-            summary (max 800 chars total) suitable for inclusion in a Slack
+            summary (max 400 chars total) suitable for inclusion in a Slack
             notification. Use this format — one entry per bug-type job:
 
             *<job_name>*: <1-2 sentence root cause and suggested fix>

--- a/.github/workflows/postmerge-pr-comment.yml
+++ b/.github/workflows/postmerge-pr-comment.yml
@@ -1,0 +1,40 @@
+name: Post-merge PR Comment
+
+on:
+  workflow_run:
+    workflows:
+      - "PR Test"
+    types:
+      - requested
+    branches:
+      - main
+
+jobs:
+  comment-on-pr:
+    if: >-
+      github.repository == 'sgl-project/sglang-jax'
+      && github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Find merged PR and post comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          PR_NUMBER=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
+            --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR found for commit $HEAD_SHA, skipping."
+            exit 0
+          fi
+          echo "Found PR #$PR_NUMBER for commit ${HEAD_SHA:0:7}"
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body ":arrows_counterclockwise: Post-merge test started: [Run #${RUN_ID}](${RUN_URL})"

--- a/.github/workflows/regression-slack-notify.yml
+++ b/.github/workflows/regression-slack-notify.yml
@@ -1,0 +1,83 @@
+name: Regression Slack Notify
+
+on:
+  workflow_run:
+    workflows:
+      - "CI Auto Bisect"
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "CI Auto Bisect run ID (for manual testing)"
+        required: true
+
+jobs:
+  notify-regression:
+    if: >-
+      github.repository == 'sgl-project/sglang-jax'
+      && (github.event_name == 'workflow_dispatch'
+          || github.event.workflow_run.conclusion != 'cancelled')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Download analysis artifact
+        id: download
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BISECT_RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
+        run: |
+          ARTIFACT_ID=$(gh api "repos/$REPO/actions/runs/$BISECT_RUN_ID/artifacts" \
+            --jq '.artifacts[] | select(.name | startswith("ci-auto-bisect-")) | .id' \
+            | head -1)
+          if [ -z "$ARTIFACT_ID" ]; then
+            echo "No analysis artifact found, skipping."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          gh api "repos/$REPO/actions/artifacts/$ARTIFACT_ID/zip" > artifact.zip
+          unzip -o artifact.zip
+          if [ ! -f analysis_result.json ]; then
+            echo "analysis_result.json not found in artifact, skipping."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+      - name: Check regression and format message
+        if: steps.download.outputs.found == 'true'
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          python3 scripts/ci/regression_notify.py
+          --analysis analysis_result.json
+          --repo "${{ github.repository }}"
+          --slack-output slack_summary.txt
+
+      - name: Post to Slack
+        if: steps.gate.outputs.send_slack == 'true'
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL not set, skipping."
+            exit 0
+          fi
+          SUMMARY=$(cat slack_summary.txt)
+          if [ -z "$SUMMARY" ]; then
+            echo "Empty summary, skipping."
+            exit 0
+          fi
+          jq -n --arg text "$SUMMARY" \
+            '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":$text}}]}' | \
+            curl --fail-with-body -X POST -H 'Content-type: application/json' \
+              -d @- "$SLACK_WEBHOOK_URL"

--- a/scripts/ci/regression_notify.py
+++ b/scripts/ci/regression_notify.py
@@ -1,0 +1,144 @@
+"""Check CI Auto Bisect result and generate Slack notification for code regressions."""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "utils"))
+from github_output import write_github_output
+
+
+def _run_gh(args):
+    """Run a gh CLI command, return stdout."""
+    return subprocess.run(
+        ["gh"] + args, capture_output=True, text=True, check=True, timeout=60
+    ).stdout
+
+
+def _escape_mrkdwn(text):
+    """Escape Slack mrkdwn special characters."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def format_regression_summary(
+    short_sha,
+    run_url,
+    failed_jobs,
+    root_cause,
+    suggested_fix,
+    pr_url=None,
+    pr_number=None,
+    branch_unverified=False,
+):
+    """Format Slack mrkdwn summary for a post-merge regression."""
+    pr_link = ""
+    if pr_url and pr_number:
+        pr_link = f"  |  <{pr_url}|PR #{pr_number}>"
+
+    header = ":rotating_light: *Post-merge Regression Detected*"
+    if branch_unverified:
+        header += "  :warning: _branch unverified_"
+
+    commit_part = f"`{short_sha}`" if short_sha else "_unknown commit_"
+    lines = [
+        header,
+        f"{commit_part}{pr_link}  |  <{run_url}|View run>",
+        "",
+        f"*Failed jobs:* {_escape_mrkdwn(failed_jobs)}",
+        f"*Root cause:* {_escape_mrkdwn(root_cause)}",
+        f"*Suggested fix:* {_escape_mrkdwn(suggested_fix)}",
+    ]
+
+    text = "\n".join(lines)
+    if len(text) > 2900:
+        text = text[:2900].rsplit("\n", 1)[0] + "\n… (truncated)"
+    return text
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Gate and format regression Slack notification")
+    parser.add_argument("--analysis", required=True, help="Path to analysis_result.json")
+    parser.add_argument("--repo", required=True, help="GitHub repository (owner/name)")
+    parser.add_argument("--slack-output", required=True, help="File to write Slack message text")
+    args = parser.parse_args()
+
+    with open(args.analysis) as f:
+        result = json.load(f)
+
+    classification = result.get("classification", "")
+    if classification != "code_regression":
+        print(f"Classification is '{classification}', not code_regression. Skipping.")
+        write_github_output("send_slack", "false")
+        return
+
+    original_run_id = result.get("run_id", "")
+    try:
+        run_meta = json.loads(
+            _run_gh(
+                [
+                    "api",
+                    f"repos/{args.repo}/actions/runs/{original_run_id}",
+                    "--jq",
+                    "{branch: .head_branch, sha: .head_sha}",
+                ]
+            )
+        )
+    except Exception as e:
+        print(f"Failed to query original run {original_run_id}: {e}")
+        print("Sending degraded notification with branch-unverified warning.")
+        run_meta = {"branch": "unknown", "sha": ""}
+
+    head_branch = run_meta["branch"]
+    branch_unverified = head_branch == "unknown"
+    if not branch_unverified and head_branch != "main":
+        print(f"Original run was on branch '{head_branch}', not main. Skipping.")
+        write_github_output("send_slack", "false")
+        return
+
+    head_sha = run_meta["sha"]
+    short_sha = head_sha[:7] if head_sha else ""
+    run_url = result.get("run_url", "")
+    failed_jobs = ", ".join(result.get("failed_jobs", []))
+    root_cause = result.get("root_cause", "")
+    suggested_fix = result.get("suggested_fix", "")
+
+    pr_url = None
+    pr_number = None
+    if head_sha:
+        try:
+            pr_json = json.loads(
+                _run_gh(
+                    [
+                        "api",
+                        f"repos/{args.repo}/commits/{head_sha}/pulls",
+                        "--jq",
+                        ".[0] | {number, html_url}",
+                    ]
+                )
+            )
+            pr_number = pr_json.get("number")
+            pr_url = pr_json.get("html_url")
+        except Exception:
+            pass
+
+    summary = format_regression_summary(
+        short_sha,
+        run_url,
+        failed_jobs,
+        root_cause,
+        suggested_fix,
+        pr_url,
+        pr_number,
+        branch_unverified=branch_unverified,
+    )
+
+    with open(args.slack_output, "w") as f:
+        f.write(summary)
+    print(f"Slack summary written to {args.slack_output}")
+    write_github_output("send_slack", "true")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/slack_notify.py
+++ b/scripts/ci/slack_notify.py
@@ -7,23 +7,25 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "utils"))
 from failure_classifier import FAILURE_TYPES, classify_jobs, get_failed_jobs
+from github_output import write_github_output
 
 
-def format_slack_summary(workflow_name, run_url, commit_sha, author, failed_jobs, ai_analysis=""):
-    """Format Slack mrkdwn summary with failure types and per-job links."""
+def format_slack_summary(run_url, commit_sha, author, failed_jobs, ai_analysis=""):
+    """Format compact Slack mrkdwn summary."""
+    display_jobs = [j for j in failed_jobs if not j["name"].endswith("-finish")]
     short_sha = commit_sha[:7] if len(commit_sha) >= 7 else commit_sha
-    lines = [":red_circle: *Nightly CI Failure*"]
+    job_word = "job" if len(display_jobs) == 1 else "jobs"
+    lines = [
+        f":red_circle: *Nightly CI Failure* — {len(display_jobs)} {job_word} failed  |  <{run_url}|View run>"
+    ]
+    safe_author = author.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    lines.append(f"`{short_sha}` by {safe_author}")
     lines.append("")
-    lines.append(f"*Workflow:* {workflow_name}")
-    lines.append(f"*Commit:* `{short_sha}` by {author}")
-    lines.append(f"*Run:* <{run_url}|View failed run>")
-    lines.append("")
-    lines.append(f"*Failed jobs ({len(failed_jobs)}):*")
-    for job in failed_jobs:
+    for job in display_jobs:
         ft = FAILURE_TYPES.get(job["failure_type"], FAILURE_TYPES["bug"])
         safe_name = job["name"].replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
         safe_name = safe_name.replace("|", "/")
-        lines.append(f"• {ft['emoji']} <{job['html_url']}|{safe_name}> [{ft['label']}]")
+        lines.append(f"• {ft['emoji']} {safe_name} [{ft['label']}]")
 
     if ai_analysis:
         lines.append("")
@@ -34,15 +36,6 @@ def format_slack_summary(workflow_name, run_url, commit_sha, author, failed_jobs
     if len(text) > 2900:
         text = text[:2900].rsplit("\n", 1)[0] + "\n… (truncated)"
     return text
-
-
-def _write_github_output(name, value):
-    """Write a name=value pair to GITHUB_OUTPUT."""
-    output_file = os.environ.get("GITHUB_OUTPUT", "")
-    if output_file:
-        with open(output_file, "a") as f:
-            f.write(f"{name}={value}\n")
-    print(f"  output: {name}={value}")
 
 
 def main():
@@ -88,7 +81,7 @@ def main():
             if args.slack_output:
                 with open(args.slack_output, "w") as f:
                     f.write("")
-            _write_github_output("has_bugs", "false")
+            write_github_output("has_bugs", "false")
             return
 
         print(f"Failed jobs: {', '.join(j['name'] for j in failed_jobs)}")
@@ -98,7 +91,7 @@ def main():
         needs_ai_jobs = [
             j for j in failed_jobs if j["failure_type"] in ("bug", "resource_exhaustion")
         ]
-        _write_github_output("has_bugs", "true" if needs_ai_jobs else "false")
+        write_github_output("has_bugs", "true" if needs_ai_jobs else "false")
 
         classification_data = {
             "failed_jobs": [
@@ -118,7 +111,6 @@ def main():
         print("Classification written to classification.json")
 
     summary = format_slack_summary(
-        args.workflow_name,
         args.run_url,
         args.commit_sha,
         args.commit_author,

--- a/scripts/ci/tests/test_notify.py
+++ b/scripts/ci/tests/test_notify.py
@@ -1,0 +1,212 @@
+"""Tests for failure_classifier, slack_notify, and regression_notify."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "utils"))
+
+from failure_classifier import _FINISH_GATE_RE, _INFRASTRUCTURE_RE, classify_failure
+from regression_notify import _escape_mrkdwn, format_regression_summary
+from slack_notify import format_slack_summary
+
+
+class TestClassifyFailure(unittest.TestCase):
+    """Test classify_failure regex-based classification."""
+
+    def test_scheduling_failure_is_infrastructure(self):
+        log = "FailedScheduling pod/gke-test-0 0/3 nodes available"
+        self.assertEqual(classify_failure(log), "infrastructure")
+
+    def test_not_trigger_scale_up_is_infrastructure(self):
+        log = "NotTriggerScaleUp: max node group size reached"
+        self.assertEqual(classify_failure(log), "infrastructure")
+
+    def test_node_affinity_is_infrastructure(self):
+        log = "0/3 nodes: didn't match Pod's node affinity/selector"
+        self.assertEqual(classify_failure(log), "infrastructure")
+
+    def test_scale_up_failed_is_infrastructure(self):
+        self.assertEqual(classify_failure("in backoff after failed scale-up"), "infrastructure")
+        self.assertEqual(classify_failure("scale-up failed for pool"), "infrastructure")
+
+    def test_real_bug_not_misclassified(self):
+        self.assertEqual(classify_failure("FAILED test_foo - AssertionError"), "bug")
+
+    def test_real_bug_with_finish_text_not_misclassified(self):
+        """Regression: 'did not succeed' in logs must NOT make a real bug into infra."""
+        log = (
+            "FAILED test_foo.py::test_bar - AssertionError: expected 1 got 2\n"
+            "::error::job-x did not succeed: failure\n"
+            "::error::One or more daily test jobs failed\n"
+        )
+        self.assertEqual(classify_failure(log), "bug")
+
+    def test_oom_is_resource_exhaustion(self):
+        self.assertEqual(
+            classify_failure("OutOfMemoryError: RESOURCE_EXHAUSTED"), "resource_exhaustion"
+        )
+
+    def test_timeout_is_timeout(self):
+        self.assertEqual(classify_failure("the operation was cancelled"), "timeout")
+
+    def test_connection_refused_is_infrastructure(self):
+        self.assertEqual(classify_failure("connection refused"), "infrastructure")
+
+    def test_preempted_is_infrastructure(self):
+        self.assertEqual(classify_failure("TPU was preempted"), "infrastructure")
+
+    def test_empty_log_is_bug(self):
+        self.assertEqual(classify_failure(""), "bug")
+
+    def test_conclusion_startup_failure(self):
+        self.assertEqual(
+            classify_failure("any log", conclusion="startup_failure"), "infrastructure"
+        )
+
+    def test_conclusion_timed_out(self):
+        self.assertEqual(classify_failure("any log", conclusion="timed_out"), "timeout")
+
+
+class TestFinishGateRegex(unittest.TestCase):
+    """Test _FINISH_GATE_RE matches finish-gate job names."""
+
+    def test_nightly_finish(self):
+        self.assertTrue(_FINISH_GATE_RE.search("nightly-test-daily-finish"))
+
+    def test_pr_finish(self):
+        self.assertTrue(_FINISH_GATE_RE.search("pr-test-finish"))
+
+    def test_weekly_finish(self):
+        self.assertTrue(_FINISH_GATE_RE.search("nightly-test-finish"))
+
+    def test_regular_job_no_match(self):
+        self.assertIsNone(_FINISH_GATE_RE.search("e2e-test-4-tpu (2)"))
+        self.assertIsNone(_FINISH_GATE_RE.search("unit-test-1-tpu (0)"))
+
+    def test_finish_mid_name_no_match(self):
+        self.assertIsNone(_FINISH_GATE_RE.search("finish-setup-job"))
+
+
+class TestInfrastructureRegexNoFalsePositives(unittest.TestCase):
+    """Ensure _INFRASTRUCTURE_RE does NOT match generic phrases."""
+
+    def test_did_not_succeed_not_matched(self):
+        self.assertIsNone(_INFRASTRUCTURE_RE.search("job did not succeed: failure"))
+
+    def test_one_or_more_jobs_failed_not_matched(self):
+        self.assertIsNone(_INFRASTRUCTURE_RE.search("One or more daily test jobs failed"))
+
+    def test_assertion_error_not_matched(self):
+        self.assertIsNone(_INFRASTRUCTURE_RE.search("AssertionError: expected 1 got 2"))
+
+
+class TestFormatSlackSummary(unittest.TestCase):
+    """Test format_slack_summary output."""
+
+    def _make_jobs(self, names_and_types):
+        return [
+            {"name": n, "failure_type": t, "html_url": f"https://example.com/{i}"}
+            for i, (n, t) in enumerate(names_and_types)
+        ]
+
+    def test_finish_gate_excluded_from_count(self):
+        jobs = self._make_jobs(
+            [
+                ("e2e-test-4-tpu (0)", "bug"),
+                ("nightly-test-daily-finish", "infrastructure"),
+            ]
+        )
+        summary = format_slack_summary("https://run", "abc1234567", "author", jobs)
+        self.assertIn("1 job failed", summary)
+        self.assertNotIn("2 jobs", summary)
+        self.assertNotIn("nightly-test-daily-finish", summary)
+
+    def test_singular_plural(self):
+        jobs_1 = self._make_jobs([("job-a", "bug")])
+        jobs_2 = self._make_jobs([("job-a", "bug"), ("job-b", "timeout")])
+        self.assertIn("1 job failed", format_slack_summary("url", "sha1234567", "a", jobs_1))
+        self.assertIn("2 jobs failed", format_slack_summary("url", "sha1234567", "a", jobs_2))
+
+    def test_author_escaped(self):
+        jobs = self._make_jobs([("job", "bug")])
+        summary = format_slack_summary("url", "sha1234567", "a<b&c", jobs)
+        self.assertIn("a&lt;b&amp;c", summary)
+        self.assertNotIn("a<b&c", summary)
+
+    def test_truncation(self):
+        jobs = self._make_jobs([(f"very-long-job-name-{i}", "bug") for i in range(100)])
+        summary = format_slack_summary("url", "sha1234567", "author", jobs)
+        self.assertLessEqual(len(summary), 2950)
+        self.assertIn("truncated", summary)
+
+
+class TestFormatRegressionSummary(unittest.TestCase):
+    """Test format_regression_summary output."""
+
+    def test_basic_format(self):
+        summary = format_regression_summary(
+            "abc1234",
+            "https://run/1",
+            "job-a, job-b",
+            "bad commit",
+            "revert it",
+            "https://pr/1",
+            42,
+        )
+        self.assertIn(":rotating_light:", summary)
+        self.assertIn("`abc1234`", summary)
+        self.assertIn("PR #42", summary)
+        self.assertIn("job-a, job-b", summary)
+        self.assertIn("bad commit", summary)
+        self.assertIn("revert it", summary)
+        self.assertNotIn("unverified", summary)
+
+    def test_degraded_branch_unverified(self):
+        summary = format_regression_summary(
+            "",
+            "https://run/1",
+            "job-a",
+            "cause",
+            "fix",
+            branch_unverified=True,
+        )
+        self.assertIn("branch unverified", summary)
+        self.assertIn("unknown commit", summary)
+        self.assertNotIn("`", summary.split("View run")[0].split("unknown commit")[0])
+
+    def test_no_pr(self):
+        summary = format_regression_summary(
+            "abc1234",
+            "https://run/1",
+            "job-a",
+            "cause",
+            "fix",
+        )
+        self.assertNotIn("PR #", summary)
+        self.assertIn("View run", summary)
+
+    def test_mrkdwn_escaped(self):
+        summary = format_regression_summary(
+            "abc1234",
+            "https://run/1",
+            "job<a>",
+            "a & b < c",
+            "x > y",
+        )
+        self.assertIn("job&lt;a&gt;", summary)
+        self.assertIn("a &amp; b &lt; c", summary)
+        self.assertIn("x &gt; y", summary)
+
+
+class TestEscapeMrkdwn(unittest.TestCase):
+    def test_escapes_special_chars(self):
+        self.assertEqual(_escape_mrkdwn("a & b < c > d"), "a &amp; b &lt; c &gt; d")
+
+    def test_no_change_for_plain_text(self):
+        self.assertEqual(_escape_mrkdwn("hello world"), "hello world")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/utils/failure_classifier.py
+++ b/scripts/ci/utils/failure_classifier.py
@@ -51,7 +51,10 @@ _INFRASTRUCTURE_RE = re.compile(
     r"|serviceunavailable"
     r"|httperror|google\.api_core\.exceptions"
     r"|preempted|was preempted|tpu is not healthy"
-    r"|could not find device|failed to create tpu",
+    r"|could not find device|failed to create tpu"
+    r"|failedscheduling|nottriggerscaleup"
+    r"|max node group size reached|failed scale-up|scale-up failed"
+    r"|didn't match pod's node affinity",
     re.IGNORECASE,
 )
 
@@ -159,9 +162,16 @@ def fetch_job_logs(repo, job_id, max_lines=500):
         return ""
 
 
+_FINISH_GATE_RE = re.compile(r"-finish$", re.IGNORECASE)
+
+
 def classify_jobs(repo, failed_jobs):
     """Fetch logs and classify each failed job. Mutates jobs in-place, adding 'failure_type'."""
     for job in failed_jobs:
+        if _FINISH_GATE_RE.search(job["name"]):
+            job["failure_type"] = "infrastructure"
+            print(f"  {job['name']}: infrastructure (finish gate)")
+            continue
         log_text = fetch_job_logs(repo, job["id"])
         job["failure_type"] = classify_failure(log_text, job.get("conclusion"))
         print(f"  {job['name']}: {job['failure_type']}")

--- a/scripts/ci/utils/github_output.py
+++ b/scripts/ci/utils/github_output.py
@@ -1,0 +1,12 @@
+"""Shared helper for writing GitHub Actions step outputs."""
+
+import os
+
+
+def write_github_output(name, value):
+    """Write a name=value pair to GITHUB_OUTPUT."""
+    output_file = os.environ.get("GITHUB_OUTPUT", "")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"{name}={value}\n")
+    print(f"  output: {name}={value}")


### PR DESCRIPTION
## Summary

### Slack notification improvements
- Only trigger nightly Slack notifications for `main` branch failures (not personal/feature branches)
- Remove stale `"Nightly Test"` workflow from the trigger list (deleted in #1218)
- Compact Slack message: merge header + job count + run link into one line, drop per-job links and workflow name field
- Reduce AI analysis char budget from 800 → 400
- Escape author name for Slack mrkdwn injection safety
- Fix `"1 jobs failed"` → `"1 job failed"` singular/plural grammar

### Failure classifier: k8s scheduling + finish-gate detection
- Add k8s scheduling failure patterns (`FailedScheduling`, `NotTriggerScaleUp`, node affinity mismatch, `max node group size reached`) to `_INFRASTRUCTURE_RE` so Pod scheduling issues are classified as `infrastructure` instead of `bug`
- Classify finish/aggregator gate jobs (names ending in `-finish`) as `infrastructure` by job name, not log content — avoids false positives where a real bug log also contains finish-gate phrases like "did not succeed"

### New: Post-merge PR comment (`postmerge-pr-comment.yml`)
- When PR Test starts on `main` (push event), find the merged PR via commit SHA and post a comment with the run link
- Authors can track post-merge test status directly from their PR

### New: Regression Slack notification (`regression-slack-notify.yml`)
- When CI Auto Bisect completes, download its `analysis_result.json` artifact
- If `classification == "code_regression"` and the original run was on `main`, send a Slack notification with failed jobs, root cause, and suggested fix
- Supports `workflow_dispatch` for manual testing

### Motivation

Recent nightly failures were caused by GKE node pool capacity exhaustion. The classifier didn't recognize k8s scheduling errors, fell through to `"bug"`, triggered AI analysis, and wasted tokens on what was obviously an infra issue. Additionally, post-merge test failures had no proactive notification — results lived only in GitHub check status.

## Test plan
- [x] Existing 49 CI script tests pass (these predate this PR and do not cover the new classifier patterns or `format_slack_summary` changes)
- [x] Manually verified new classifier patterns: scheduling → infrastructure, finish-gate by name → infrastructure, real bugs with finish-gate text in logs → still bug, OOM → still resource_exhaustion
- [ ] Verify `workflow_dispatch` still works for manual testing
- [ ] Confirm notifications no longer fire for non-main branches
- [ ] Check Slack message renders correctly in mrkdwn format
- [ ] Test `regression-slack-notify` via `workflow_dispatch` with a known bisect run ID
- [ ] Merge a PR and verify `postmerge-pr-comment` posts the run link

🤖 Generated with [Claude Code](https://claude.com/claude-code)