### PR TITLE
fix(moe): auto-adjust bf in effective_for() for non-aligned intermediate_size

### DIFF
--- a/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
@@ -54,6 +54,10 @@ class FusedMoEBlockConfig:
     ) -> FusedMoEBlockConfig:
         """Return the *effective* config after applying kernel override rules.
 
+        If *intermediate_size* is given and ``self.bf`` does not divide it,
+        ``bf`` (and correspondingly ``bfc``) are jointly reduced to the largest
+        multiple of 128 that satisfies both divisibility constraints.
+
         Important: validate after overrides, because these overrides affect the
         actual compiled kernel shapes/scratch.
         """
@@ -3404,7 +3408,6 @@ def fused_ep_moe(
     num_devices = ep_size
 
     num_tokens, hidden_size = tokens.shape
-    num_experts, intermediate_size, _ = w2.shape
     local_num_experts = num_experts // ep_size
     se_inter_size = w2_shared.shape[0] if w2_shared is not None else 0
 

--- a/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
@@ -50,6 +50,7 @@ class FusedMoEBlockConfig:
         ep_size: int,
         dtype: jnp.dtype,
         quant_block_k: int | None = None,
+        intermediate_size: int | None = None,
     ) -> FusedMoEBlockConfig:
         """Return the *effective* config after applying kernel override rules.
 
@@ -96,12 +97,41 @@ class FusedMoEBlockConfig:
             bfc = max(bfc, min_bfc)
             bfc -= bfc % min_bfc
 
-        bse = self.bf if self.bse is None else self.bse
+        bf = self.bf
+        if intermediate_size is not None and intermediate_size % bf != 0:
+            # Joint search: each bf candidate must also admit a feasible bfc,
+            # since quant_block_k can make some (bf, bfc) pairs impossible.
+            reduced = False
+            for bf_candidate in range(bf - 128, 0, -128):
+                if intermediate_size % bf_candidate != 0:
+                    continue
+                bfc_candidate = min(bfc, bf_candidate)
+                while bfc_candidate > 128 and (
+                    bf_candidate % bfc_candidate != 0
+                    or (quant_block_k is not None and bfc_candidate % quant_block_k != 0)
+                ):
+                    bfc_candidate -= 128
+                if (
+                    bf_candidate % bfc_candidate == 0
+                    and (quant_block_k is None or bfc_candidate % quant_block_k == 0)
+                ):
+                    bf = bf_candidate
+                    bfc = bfc_candidate
+                    reduced = True
+                    break
+            if not reduced:
+                quant_info = f" with {quant_block_k=}" if quant_block_k is not None else ""
+                raise ValueError(
+                    f"Cannot find a valid bf (multiple of 128) that divides "
+                    f"{intermediate_size=} with a feasible bfc{quant_info}."
+                )
+
+        bse = bf if self.bse is None else self.bse
 
         return FusedMoEBlockConfig(
             bt=bt,
             bts=bts,
-            bf=self.bf,
+            bf=bf,
             bd1=self.bd1,
             bd2=self.bd2,
             btc=btc,
@@ -3320,11 +3350,11 @@ def fused_ep_moe(
                 "disable_sync_barrier is only supported with disable_a2a=True or ep_size=1."
             )
 
+    num_experts, intermediate_size, _ = w2.shape
     if block_config is None:
         from .tuned_block_configs import get_tuned_fused_moe_block_config
 
         num_tokens, hidden_size = tokens.shape
-        num_experts, intermediate_size, _ = w2.shape
         block_config = get_tuned_fused_moe_block_config(
             num_tokens=num_tokens,
             num_experts=num_experts,
@@ -3342,6 +3372,7 @@ def fused_ep_moe(
         ep_size=ep_size,
         dtype=tokens.dtype,
         quant_block_k=quant_block_k,
+        intermediate_size=intermediate_size,
     )
     _validate_fused_ep_moe_args(
         mesh=mesh,

--- a/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
@@ -115,9 +115,8 @@ class FusedMoEBlockConfig:
                     or (quant_block_k is not None and bfc_candidate % quant_block_k != 0)
                 ):
                     bfc_candidate -= 128
-                if (
-                    bf_candidate % bfc_candidate == 0
-                    and (quant_block_k is None or bfc_candidate % quant_block_k == 0)
+                if bf_candidate % bfc_candidate == 0 and (
+                    quant_block_k is None or bfc_candidate % quant_block_k == 0
                 ):
                     bf = bf_candidate
                     bfc = bfc_candidate

--- a/python/sgl_jax/srt/kernels/fused_moe/v1/tuned_block_configs.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v1/tuned_block_configs.py
@@ -167,7 +167,6 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         ('bfloat16', 'float8_e4m3fn', 4096, 256, 8, 2048, 512, 32, True, True): (128, 512, 2048, 2048, 128, 128, 512, 2048, 2048, 256),
     },
     # MiMoV2Flash: 256 experts, top_k=8, H=4096, I=2048, ep=16, no shared expert, no grouped topk
-    # Tuned on v6e-16 (4x4 topology) with vmem_limit=96MB, 2026-04-08
     "TPU v6e": {
         ('bfloat16', 'bfloat16', 32, 256, 8, 4096, 2048, 16, False, False): (2, 2048, 2048, 2048, 32, 32, 2048, 2048, 2048, 2048),
         ('bfloat16', 'bfloat16', 64, 256, 8, 4096, 2048, 16, False, False): (4, 2048, 2048, 2048, 64, 64, 2048, 2048, 2048, 2048),
@@ -180,8 +179,7 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         ('bfloat16', 'bfloat16', 8192, 256, 8, 4096, 2048, 16, False, False): (512, 1024, 1024, 1024, 256, 256, 1024, 1024, 1024, 1024),
         ('bfloat16', 'bfloat16', 16384, 256, 8, 4096, 2048, 16, False, False): (512, 1024, 1024, 1024, 256, 256, 1024, 1024, 1024, 1024),
         ('bfloat16', 'bfloat16', 32768, 256, 8, 4096, 2048, 16, False, False): (256, 1024, 4096, 4096, 128, 128, 1024, 4096, 4096, 1024),
-        # FP8 (float8_e4m3fn weights, bfloat16 activations), updated for 2D block-wise quant
-        # (block_k=128, block_n=128) on v6e-16, 2026-04-11.
+        # FP8 (float8_e4m3fn weights, bfloat16 activations), 2D block-wise quant (block_k=128, block_n=128)
         ('bfloat16', 'float8_e4m3fn', 32, 256, 8, 4096, 2048, 16, False, False): (2, 2048, 4096, 4096, 2, 2, 2048, 4096, 4096, 2048),
         ('bfloat16', 'float8_e4m3fn', 64, 256, 8, 4096, 2048, 16, False, False): (4, 2048, 4096, 4096, 32, 32, 2048, 4096, 4096, 2048),
         ('bfloat16', 'float8_e4m3fn', 128, 256, 8, 4096, 2048, 16, False, False): (8, 2048, 4096, 4096, 32, 32, 2048, 4096, 4096, 2048),
@@ -193,7 +191,6 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         ('bfloat16', 'float8_e4m3fn', 8192, 256, 8, 4096, 2048, 16, False, False): (512, 512, 2048, 2048, 256, 256, 512, 2048, 2048, 512),
         ('bfloat16', 'float8_e4m3fn', 16384, 256, 8, 4096, 2048, 16, False, False): (512, 512, 2048, 2048, 256, 256, 512, 2048, 2048, 512),
         # 384 experts, top_k=8, H=6144, I=2048, ep=64, FP8 block quant (128x128)
-        # Tuned on v6e-64 (8x8 topology) with vmem_limit=96MB, 2026-04-21
         ('bfloat16', 'float8_e4m3fn', 128, 384, 8, 6144, 2048, 64, False, False): (2, 2048, 2048, 2048, 32, 32, 2048, 2048, 2048, 2048),
         ('bfloat16', 'float8_e4m3fn', 256, 384, 8, 6144, 2048, 64, False, False): (4, 2048, 2048, 2048, 64, 64, 2048, 2048, 2048, 2048),
         ('bfloat16', 'float8_e4m3fn', 512, 384, 8, 6144, 2048, 64, False, False): (8, 2048, 2048, 2048, 32, 32, 2048, 2048, 2048, 2048),
@@ -202,6 +199,17 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         ('bfloat16', 'float8_e4m3fn', 4096, 384, 8, 6144, 2048, 64, False, False): (64, 1024, 2048, 2048, 256, 256, 1024, 2048, 2048, 1024),
         ('bfloat16', 'float8_e4m3fn', 8192, 384, 8, 6144, 2048, 64, False, False): (64, 1024, 2048, 2048, 256, 256, 1024, 2048, 2048, 1024),
         ('bfloat16', 'float8_e4m3fn', 16384, 384, 8, 6144, 2048, 64, False, False): (64, 1024, 2048, 2048, 256, 256, 1024, 2048, 2048, 1024),
+        # Qwen3-MoE: 128 experts, top_k=8, H=2048, I=768, ep=4, no shared expert, no grouped topk
+        ('bfloat16', 'bfloat16', 16, 128, 8, 2048, 768, 4, False, False): (4, 768, 2048, 2048, 8, 8, 768, 2048, 2048, 768),
+        ('bfloat16', 'bfloat16', 32, 128, 8, 2048, 768, 4, False, False): (8, 768, 2048, 2048, 8, 8, 768, 2048, 2048, 768),
+        ('bfloat16', 'bfloat16', 64, 128, 8, 2048, 768, 4, False, False): (16, 768, 2048, 2048, 16, 16, 768, 2048, 2048, 768),
+        ('bfloat16', 'bfloat16', 128, 128, 8, 2048, 768, 4, False, False): (32, 768, 2048, 2048, 32, 32, 768, 2048, 2048, 768),
+        ('bfloat16', 'bfloat16', 256, 128, 8, 2048, 768, 4, False, False): (64, 768, 2048, 2048, 64, 64, 768, 2048, 2048, 768),
+        ('bfloat16', 'bfloat16', 512, 128, 8, 2048, 768, 4, False, False): (128, 768, 2048, 2048, 128, 128, 768, 2048, 2048, 768),
+        ('bfloat16', 'bfloat16', 1024, 128, 8, 2048, 768, 4, False, False): (256, 768, 2048, 2048, 256, 256, 768, 2048, 2048, 768),
+        ('bfloat16', 'bfloat16', 2048, 128, 8, 2048, 768, 4, False, False): (512, 768, 2048, 2048, 128, 128, 768, 2048, 2048, 768),
+        ('bfloat16', 'bfloat16', 4096, 128, 8, 2048, 768, 4, False, False): (512, 768, 2048, 2048, 128, 128, 768, 2048, 2048, 768),
+        ('bfloat16', 'bfloat16', 8192, 128, 8, 2048, 768, 4, False, False): (512, 768, 2048, 2048, 128, 128, 768, 2048, 2048, 768),
     },
     # Fallback for any device kind.
     "*": {},

--- a/python/sgl_jax/srt/kernels/fused_moe/v1/tuned_block_configs.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v1/tuned_block_configs.py
@@ -166,8 +166,8 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         ('bfloat16', 'float8_e4m3fn', 2048, 256, 8, 2048, 512, 32, True, True): (64, 512, 2048, 2048, 64, 64, 512, 2048, 2048, 512),
         ('bfloat16', 'float8_e4m3fn', 4096, 256, 8, 2048, 512, 32, True, True): (128, 512, 2048, 2048, 128, 128, 512, 2048, 2048, 256),
     },
-    # MiMoV2Flash: 256 experts, top_k=8, H=4096, I=2048, ep=16, no shared expert, no grouped topk
     "TPU v6e": {
+        # MiMoV2Flash: 256 experts, top_k=8, H=4096, I=2048, ep=16, no shared expert, no grouped topk
         ('bfloat16', 'bfloat16', 32, 256, 8, 4096, 2048, 16, False, False): (2, 2048, 2048, 2048, 32, 32, 2048, 2048, 2048, 2048),
         ('bfloat16', 'bfloat16', 64, 256, 8, 4096, 2048, 16, False, False): (4, 2048, 2048, 2048, 64, 64, 2048, 2048, 2048, 2048),
         ('bfloat16', 'bfloat16', 128, 256, 8, 4096, 2048, 16, False, False): (8, 2048, 2048, 2048, 128, 128, 2048, 2048, 2048, 2048),

--- a/python/sgl_jax/test/kernels/fused_moe_v1_test.py
+++ b/python/sgl_jax/test/kernels/fused_moe_v1_test.py
@@ -1033,7 +1033,7 @@ class MoEKernelTest(jtu.JaxTestCase):
             bse=512,
         )
         # intermediate_size=384: bf=384 fails (no bfc with 384%bfc==0 and bfc%256==0),
-        # bf=256 fails (384%256!=0), bf=128 fails (128%256!=0) → no solution.
+        # bf=256 fails (384%256!=0), bf=128 passes divisibility but bfc=128 fails quant (128%256!=0).
         with self.assertRaises(ValueError):
             cfg.effective_for(
                 num_tokens=256,

--- a/python/sgl_jax/test/kernels/fused_moe_v1_test.py
+++ b/python/sgl_jax/test/kernels/fused_moe_v1_test.py
@@ -895,6 +895,176 @@ class MoEKernelTest(jtu.JaxTestCase):
             bse=512,
         )
 
+    def test_effective_for_bf_auto_reduction(self):
+        """bf auto-reduces when intermediate_size is not aligned to default bf."""
+        cfg = FusedMoEBlockConfig(
+            bt=32,
+            bf=512,
+            bd1=1024,
+            bd2=1024,
+            btc=32,
+            bfc=512,
+            bd1c=1024,
+            bd2c=1024,
+            bse=512,
+        )
+        eff = cfg.effective_for(
+            num_tokens=256,
+            ep_size=1,
+            dtype=jnp.bfloat16,
+            intermediate_size=768,
+        )
+        self.assertEqual(eff.bf, 384)
+        self.assertEqual(eff.bfc, 384)
+        self.assertEqual(768 % eff.bf, 0)
+        self.assertEqual(eff.bf % eff.bfc, 0)
+
+    def test_effective_for_bf_no_reduction_when_aligned(self):
+        """bf stays unchanged when intermediate_size is already aligned."""
+        cfg = FusedMoEBlockConfig(
+            bt=32,
+            bf=512,
+            bd1=1024,
+            bd2=1024,
+            btc=32,
+            bfc=512,
+            bd1c=1024,
+            bd2c=1024,
+            bse=512,
+        )
+        eff = cfg.effective_for(
+            num_tokens=256,
+            ep_size=1,
+            dtype=jnp.bfloat16,
+            intermediate_size=1024,
+        )
+        self.assertEqual(eff.bf, 512)
+        self.assertEqual(eff.bfc, 512)
+
+    def test_effective_for_bf_reduction_with_quant(self):
+        """bf auto-reduces while preserving quantization alignment on bfc."""
+        cfg = FusedMoEBlockConfig(
+            bt=32,
+            bf=512,
+            bd1=1024,
+            bd2=1024,
+            btc=32,
+            bfc=512,
+            bd1c=1024,
+            bd2c=1024,
+            bse=512,
+        )
+        eff = cfg.effective_for(
+            num_tokens=256,
+            ep_size=1,
+            dtype=jnp.float8_e4m3fn,
+            intermediate_size=768,
+            quant_block_k=128,
+        )
+        self.assertEqual(eff.bf, 384)
+        self.assertEqual(768 % eff.bf, 0)
+        self.assertEqual(eff.bf % eff.bfc, 0)
+        self.assertEqual(eff.bfc % 128, 0)
+
+    def test_effective_for_bf_skips_candidate_when_bfc_infeasible(self):
+        """bf=384 is skipped because quant_block_k=256 makes bfc infeasible; falls back to bf=256."""
+        cfg = FusedMoEBlockConfig(
+            bt=32,
+            bf=512,
+            bd1=1024,
+            bd2=1024,
+            btc=32,
+            bfc=512,
+            bd1c=1024,
+            bd2c=1024,
+            bse=512,
+        )
+        # intermediate_size=768: 768%384==0 but 384 has no bfc satisfying
+        # bf%bfc==0 AND bfc%256==0 (384%256!=0, 128%256!=0).
+        # Must skip 384 and pick bf=256 (768%256==0, bfc=256, 256%256==0).
+        eff = cfg.effective_for(
+            num_tokens=256,
+            ep_size=1,
+            dtype=jnp.float8_e4m3fn,
+            intermediate_size=768,
+            quant_block_k=256,
+        )
+        self.assertEqual(eff.bf, 256)
+        self.assertEqual(768 % eff.bf, 0)
+        self.assertEqual(eff.bf % eff.bfc, 0)
+        self.assertEqual(eff.bfc % 256, 0)
+
+    def test_effective_for_bf_reduction_with_small_bfc(self):
+        """bf reduces correctly when original config has bfc < bf."""
+        cfg = FusedMoEBlockConfig(
+            bt=32,
+            bf=512,
+            bd1=1024,
+            bd2=1024,
+            btc=32,
+            bfc=256,
+            bd1c=1024,
+            bd2c=1024,
+            bse=512,
+        )
+        eff = cfg.effective_for(
+            num_tokens=256,
+            ep_size=1,
+            dtype=jnp.bfloat16,
+            intermediate_size=768,
+        )
+        self.assertEqual(eff.bf, 384)
+        self.assertEqual(768 % eff.bf, 0)
+        # bfc=min(256,384)=256, but 384%256!=0, so must reduce to 128
+        self.assertEqual(eff.bfc, 128)
+        self.assertEqual(eff.bf % eff.bfc, 0)
+
+    def test_effective_for_raises_when_no_valid_bf(self):
+        """Raises when no bf candidate has a feasible bfc under quant constraints."""
+        cfg = FusedMoEBlockConfig(
+            bt=32,
+            bf=512,
+            bd1=1024,
+            bd2=1024,
+            btc=32,
+            bfc=512,
+            bd1c=1024,
+            bd2c=1024,
+            bse=512,
+        )
+        # intermediate_size=384: bf=384 fails (no bfc with 384%bfc==0 and bfc%256==0),
+        # bf=256 fails (384%256!=0), bf=128 fails (128%256!=0) → no solution.
+        with self.assertRaises(ValueError):
+            cfg.effective_for(
+                num_tokens=256,
+                ep_size=1,
+                dtype=jnp.float8_e4m3fn,
+                intermediate_size=384,
+                quant_block_k=256,
+            )
+
+    def test_effective_for_bse_auto_derived_after_reduction(self):
+        """bse auto-derives from reduced bf when bse is None."""
+        cfg = FusedMoEBlockConfig(
+            bt=32,
+            bf=512,
+            bd1=1024,
+            bd2=1024,
+            btc=32,
+            bfc=512,
+            bd1c=1024,
+            bd2c=1024,
+            bse=None,
+        )
+        eff = cfg.effective_for(
+            num_tokens=256,
+            ep_size=1,
+            dtype=jnp.bfloat16,
+            intermediate_size=768,
+        )
+        self.assertEqual(eff.bf, 384)
+        self.assertEqual(eff.bse, 384)
+
 
 if __name__ == "__main__":
     absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
## Summary

- **Bug fix**: `effective_for()` now uses joint bf/bfc search to handle `quant_block_k` constraints. Previously bf was selected first, then bfc separately — when `quant_block_k` made no valid bfc possible for that bf (e.g. `bf=384, quant_block_k=256`: neither `bfc=384` nor `bfc=128` satisfy both `bf%bfc==0` and `bfc%quant_block_k==0`), the method had no way to backtrack and try a smaller bf.
- **UnboundLocalError fix**: hoists `num_experts, intermediate_size, _ = w2.shape` out of the `block_config is None` guard, so `intermediate_size` is available when `effective_for()` is called with a user-supplied `block_config`.
- **Tuned configs**: adds Qwen3-MoE block configs for TPU v6e (128 experts, top_k=8, H=2048, I=768, ep=4). All use `bf=768` to tile the full intermediate dimension in one pass, avoiding the 2-iteration loop from the default fallback `bf=384`.
- **Tests**: 3 new unit tests for the joint search fix, edge cases, and error path.
- **Comment cleanup**: removes date/environment comments from `tuned_block_configs.py` (belong in git history, not code).

Fixes #1249. Supersedes #1258 (closed due to broken git ancestry from force-push on shallow clone).

## Bug Details

When `quant_block_k=256` and `intermediate_size=768`:

1. Default `bf=512` doesn't divide 768, so `effective_for()` searches downward
2. It finds `bf=384` (768 % 384 == 0) and commits to it
3. Then it tries to find a valid `bfc`: needs `384 % bfc == 0` AND `bfc % 256 == 0`
4. `bfc=384`: 384 % 256 ≠ 0. `bfc=256`: 384 % 256 ≠ 0. `bfc=128`: 128 % 256 ≠ 0. **No valid bfc exists.**
5. The correct answer is to skip `bf=384` entirely and use `bf=256` with `bfc=256`

The fix merges the bf and bfc searches into a single loop that validates bfc feasibility before committing to any bf candidate.

## Qwen3-MoE Tuned Config Rationale

**Problem**: Qwen3-MoE has `intermediate_size=768`. The default `bf=512` doesn't divide 768, so `effective_for()` auto-reduces to `bf=384` (largest multiple of 128 ≤ 512 that divides 768). This tiles the F dimension into 768/384 = 2 iterations.

**Tuned solution**: All 10 entries use `bf=768` (full intermediate_size), eliminating the F-dimension tiling loop entirely. This is optimal because 768 is small enough to fit in a single VMEM tile within the 96 MB budget.

Tuned with `bench_fused_moe.py --tune-block-config` on v6e-4 (2×2 topology), VMEM budget 96 MB, `sparse_hotspot` imbalance (hotspot_count=48). Independently verified on v6e-16 (4×4 topology): bf=768, bd1=2048, bd2=2048 confirmed optimal across all tested num_tokens.

### Performance: Tuned (bf=768) vs Default Fallback (bf=384)

Benchmark on v6e-4: `bench_fused_moe.py`, Qwen3-MoE params (128 experts, top_k=8, H=2048, I=768, ep=4), `sparse_hotspot` imbalance, 5 iterations.

| num_tokens | Default bf=384 (ms) | Tuned bf=768 (ms) | Speedup |
|-----------|--------------------|--------------------|---------|
| 16        | 0.215              | 0.128              | **1.68×** |
| 64        | 0.215              | 0.134              | **1.60×** |
| 256       | 0.456              | 0.168              | **2.71×** |
| 1024      | 1.640              | 0.348              | **4.71×** |
| 4096      | 5.802              | 1.136              | **5.11×** |
| 8192      | 10.859             | 2.235              | **4.86×** |

Large batches (1024+) see the largest improvement (4.7×–5.1×) since the F-dimension tiling overhead is amplified across more tokens.

## Test plan

- [x] 7/7 `test_effective_for_*` unit tests pass on TPU v6e
- [x] `test_effective_for_bf_skips_candidate_when_bfc_infeasible`: quant_block_k=256 forces skip of bf=384, picks bf=256
- [x] `test_effective_for_bf_reduction_with_small_bfc`: bfc=256 < bf=512, bfc reduces to 128
- [x] `test_effective_for_raises_when_no_valid_bf`: error path with intermediate_size=384, quant_block_k=256
- [x] Tuning benchmark on v6e-16 confirms bf=768 optimal for Qwen3-MoE params

🤖 Generated with [Claude Code](https://claude.com/claude-code)