### PR TITLE
fix(logprob): ShardingTypeError on dp_size>1 for return_logprob

### DIFF
--- a/python/sgl_jax/srt/layers/logits_processor.py
+++ b/python/sgl_jax/srt/layers/logits_processor.py
@@ -444,12 +444,14 @@ class LogitsProcessor(nnx.Module):
                 input_logprobs, logits_metadata
             )
 
-            # Get the logprob of top-k tokens
+            # Get the logprob of top-k tokens. Shared impl lives in sampler;
+            # local import avoids a top-level cycle (sampler imports this module).
             if logits_metadata.extend_return_top_logprob:
-                (
-                    input_top_logprobs_val,
-                    input_top_logprobs_idx,
-                ) = self.get_top_logprobs(input_logprobs, logits_metadata)
+                from sgl_jax.srt.layers.sampler import get_top_logprobs
+
+                input_top_logprobs_val, input_top_logprobs_idx = get_top_logprobs(
+                    input_logprobs, logits_metadata.top_logprobs_nums, self.mesh
+                )
             else:
                 input_top_logprobs_val = input_top_logprobs_idx = None
 
@@ -475,16 +477,6 @@ class LogitsProcessor(nnx.Module):
                 input_token_ids_logprobs_val=input_token_ids_logprobs_val,
                 input_token_ids_logprobs_idx=input_token_ids_logprobs_idx,
             )
-
-    @staticmethod
-    def get_top_logprobs(all_logprobs: jax.Array, logits_metadata: LogitsMetadata):
-        # Return device-side dense `[total_pruned_tokens, max_k]` tensors.
-        # XLA can't stack ragged per-req lists; per-req slicing is done on
-        # host in tp_worker after device_get, using
-        # `extend_logprob_pruned_lens_cpu` and `top_logprobs_nums`.
-        max_k = max(logits_metadata.top_logprobs_nums)
-        values, indices = jax.lax.top_k(all_logprobs, max_k)
-        return values, indices
 
     def compute_temp_top_p_normalized_logprobs(
         self, last_logits: jax.Array, logits_metadata: LogitsMetadata

--- a/python/sgl_jax/srt/layers/sampler.py
+++ b/python/sgl_jax/srt/layers/sampler.py
@@ -93,7 +93,7 @@ class Sampler(nnx.Module):
             (
                 next_token_top_logprobs_val,
                 next_token_top_logprobs_idx,
-            ) = get_top_logprobs(logprobs, sampling_metadata.top_logprobs_nums)
+            ) = get_top_logprobs(logprobs, sampling_metadata.top_logprobs_nums, self.mesh)
 
         # Set token_ids_logprobs if needed.
         # Device side returns the full logprobs[B, vocab]; host slices
@@ -217,9 +217,13 @@ class Sampler(nnx.Module):
         return batch_next_token_ids, logprobs, new_logits_output
 
 
-def get_top_logprobs(logprobs: jax.Array, top_logprobs_nums: list[int]):
+def get_top_logprobs(logprobs: jax.Array, top_logprobs_nums: list[int], mesh: Mesh = None):
     # Return device-side dense `[B, max_k]`. Per-req trimming to k_i is
     # done on host in tp_worker after device_get.
+    # Replicate the vocab (tensor) axis first so the `[B, max_k]` output isn't
+    # left tensor-sharded on max_k, which fails when max_k < tp.
+    if mesh is not None:
+        logprobs = jax.sharding.reshard(logprobs, NamedSharding(mesh, P("data", None)))
     max_k = max(top_logprobs_nums)
     values, indices = jax.lax.top_k(logprobs, max_k)
     return values, indices

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2411,13 +2411,11 @@ class ScheduleBatch:
             top_logprobs_nums = None
             token_ids_logprobs = None
 
-        use_padded_input_logprob = (
-            self.forward_mode.is_extend()
-            and not self.enable_overlap
-            and not self.return_hidden_states
-            and not (top_logprobs_nums and any(x > 0 for x in top_logprobs_nums))
-            and not (token_ids_logprobs and any(x is not None for x in token_ids_logprobs))
-        )
+        # extend+logprob always uses the padded path: the legacy fallback slices
+        # hidden_states per req under P("data","tensor") and crashes when the row
+        # count isn't divisible by dp (dp>1). The padded path supports top_logprobs /
+        # token_ids / overlap at any dp. return_hidden_states still falls back.
+        use_padded_input_logprob = self.forward_mode.is_extend() and not self.return_hidden_states
         input_logprob_indices = None
         merged_extend_input_logprob_token_ids = None
         if self.return_logprob:
@@ -2449,16 +2447,16 @@ class ScheduleBatch:
                         local_pt += extend_len
                     token_offset += per_dp_token_padding
             else:
-                # Merge per-DP extend_input_logprob_token_ids (set on info at L1099 when
-                # return_logprob=True). Previously hardcoded None below, which combined
-                # with the new server-side scalar gather caused 'NoneType.reshape' in
-                # LogitsProcessor._select_input_token_logprobs.
+                # Only extend batches have prompt-token logprobs. Overlap also routes
+                # speculated DECODE batches here carrying a stale extend residual;
+                # sharding it over P("data") crashes when len % dp != 0 (dp>=4). Decode
+                # never reads the field, so gate the merge on is_extend().
                 chunks = [
                     info.extend_input_logprob_token_ids
                     for info in self.reqs_info
                     if getattr(info, "extend_input_logprob_token_ids", None) is not None
                 ]
-                if chunks:
+                if chunks and self.forward_mode.is_extend():
                     merged_extend_input_logprob_token_ids = np.concatenate(chunks)
 
         return ModelWorkerBatch(
@@ -2565,6 +2563,10 @@ class ScheduleBatch:
             new_info.reqs = info.reqs  # Shallow copy (list reference)
             new_info.out_cache_loc = info.out_cache_loc
             new_info.decoding_reqs = info.decoding_reqs
+            # process_batch_result compacts per-DP padded input logprobs via
+            # _input_logprob_lens_per_dp, which reads these.
+            new_info.extend_lens = info.extend_lens
+            new_info.extend_logprob_start_lens = info.extend_logprob_start_lens
             copied_reqs_info.append(new_info)
 
         return ScheduleBatch(

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -123,16 +123,19 @@ class SchedulerOutputProcessorMixin:
                 logits_output.next_token_logprobs = jax.device_get(
                     logits_output.next_token_logprobs
                 ).astype(float)
-            if batch.return_logprob:
-                if logits_output.next_token_logprobs is not None:
-                    logits_output.next_token_logprobs = jax.device_get(
-                        logits_output.next_token_logprobs
-                    ).astype(float)
-                if logits_output.input_token_logprobs is not None:
-                    logits_output.input_token_logprobs = _materialize_input_token_logprobs(
-                        logits_output.input_token_logprobs,
-                        _input_logprob_lens_per_dp(batch),
-                    )
+            if batch.return_logprob and logits_output.next_token_logprobs is not None:
+                logits_output.next_token_logprobs = jax.device_get(
+                    logits_output.next_token_logprobs
+                ).astype(float)
+
+        # Compact the per-DP padded scalar input_token_logprobs so the logprob_pt
+        # walk below stays aligned. Runs for overlap (resolve_last_batch_result
+        # leaves it flat-padded) and non-overlap; no-op when already compact.
+        if batch.return_logprob and logits_output.input_token_logprobs is not None:
+            logits_output.input_token_logprobs = _materialize_input_token_logprobs(
+                logits_output.input_token_logprobs,
+                _input_logprob_lens_per_dp(batch),
+            )
         hidden_state_offset = 0
         per_dp_bs_size = batch.per_dp_bs_size
 

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -31,6 +31,31 @@ from sgl_jax.utils import get_exception_traceback
 logger = logging.getLogger(__name__)
 
 
+def _iter_padded_input_logprob_reqs(model_worker_batch, padded_rows: int):
+    """Yield (slot, row_offset, pruned_len) per req, in DP-rank-then-req order.
+
+    On the padded path the `input_*` device arrays are `dp_size` equal sections
+    of `per_dp_token = padded_rows // dp_size`, with each rank's valid rows packed
+    at its section start — so rank `d` req `r` lives at `[d*per_dp_token + cum, +plen)`.
+    `slot = d*per_dp_bs + r` indexes the DP-interleaved per-req lists; pruned
+    lengths are rebuilt from extend_seq_lens/extend_logprob_start_lens, since
+    extend_logprob_pruned_lens_cpu is nulled on the padded path.
+    """
+    dp_size = model_worker_batch.dp_size
+    per_dp_bs = model_worker_batch.per_dp_bs_size
+    per_dp_token = padded_rows // dp_size
+    eseq = model_worker_batch.extend_seq_lens
+    estart = model_worker_batch.extend_logprob_start_lens
+    for d in range(dp_size):
+        base = d * per_dp_token
+        cum = 0
+        for r in range(model_worker_batch.real_bs_per_dp[d]):
+            slot = d * per_dp_bs + r
+            plen = max(int(eseq[slot]) - int(estart[slot]), 0)
+            yield slot, base + cum, plen
+            cum += plen
+
+
 class ModelWorker:
     """A tensor parallel model worker."""
 
@@ -435,9 +460,7 @@ class ModelWorker:
                 logits_output.next_token_logprobs = jax.device_get(logprobs)[selector]
         if new_logits_output is not None:
             logits_output = new_logits_output
-            self._materialize_logprobs_to_host(
-                logits_output, model_worker_batch, logits_metadata, selector
-            )
+            self._materialize_logprobs_to_host(logits_output, model_worker_batch, selector)
 
         return (
             logits_output,
@@ -449,18 +472,18 @@ class ModelWorker:
         self,
         logits_output: LogitsProcessorOutput,
         model_worker_batch: ModelWorkerBatch,
-        logits_metadata: LogitsMetadata,
         selector: np.ndarray,
     ):
         """Reorder + per-req split logprob tensors from device to host lists.
 
         `next_token_*` tensors are batch-major and routed through `selector`
         to recover original-req order. `input_*` tensors are per prompt-token
-        in DP-rank-then-req order which already matches the original-req
-        order, so they are split directly using `extend_logprob_pruned_lens_cpu`.
-        Per-req `top_logprobs_nums` / `token_ids_logprobs` give the trim k_i /
-        gather columns. Output shape is `list[list[float]]` per req, matching
-        the consumer contract in `scheduler_output_processor_mixin`.
+        in DP-rank-then-req order which already matches the original-req order,
+        so they are split via `_iter_padded_input_logprob_reqs` (per-dp padded
+        sections; per-req pruned lengths reconstructed from the batch). Per-req
+        `top_logprobs_nums` / `token_ids_logprobs` give the trim k_i / gather
+        columns. Output shape is `list[list[float]]` per req, matching the
+        consumer contract in `scheduler_output_processor_mixin`.
         """
 
         def gather(arr, *, as_float=False):
@@ -500,40 +523,39 @@ class ModelWorker:
             logits_output.next_token_token_ids_logprobs_val = per_req_vals
             logits_output.next_token_token_ids_logprobs_idx = per_req_idxs
 
-        pruned_lens = logits_metadata.extend_logprob_pruned_lens_cpu
-
+        # input_* per-token logprobs use the padded layout; split per req via the
+        # helper. (A dp>1 tight fallback never reaches here — it crashes earlier
+        # at the sharded slice; dp=1 is a single section, base 0.)
         if logits_output.input_top_logprobs_val is not None:
             vals = jax.device_get(logits_output.input_top_logprobs_val.astype(jnp.float32))
             idxs = jax.device_get(logits_output.input_top_logprobs_idx)
             per_req_vals, per_req_idxs = [], []
-            pt = 0
-            for k, plen in zip(logits_metadata.top_logprobs_nums, pruned_lens):
+            for slot, off, plen in _iter_padded_input_logprob_reqs(
+                model_worker_batch, vals.shape[0]
+            ):
+                k = top_nums[slot] if top_nums else 0
                 if plen <= 0:
                     per_req_vals.append([])
                     per_req_idxs.append([])
                     continue
-                per_req_vals.append(vals[pt : pt + plen, :k].tolist())
-                per_req_idxs.append(idxs[pt : pt + plen, :k].tolist())
-                pt += plen
+                per_req_vals.append(vals[off : off + plen, :k].tolist())
+                per_req_idxs.append(idxs[off : off + plen, :k].tolist())
             logits_output.input_top_logprobs_val = per_req_vals
             logits_output.input_top_logprobs_idx = per_req_idxs
 
         if logits_output.input_token_ids_logprobs_val is not None:
             full = jax.device_get(logits_output.input_token_ids_logprobs_val.astype(jnp.float32))
             per_req_vals, per_req_idxs = [], []
-            pt = 0
-            for ids, plen in zip(logits_metadata.token_ids_logprobs, pruned_lens):
-                if plen <= 0:
+            for slot, off, plen in _iter_padded_input_logprob_reqs(
+                model_worker_batch, full.shape[0]
+            ):
+                ids = tok_ids[slot] if tok_ids else None
+                if plen <= 0 or not ids:
                     per_req_vals.append([])
                     per_req_idxs.append([])
                     continue
-                if ids:
-                    per_req_vals.append(full[pt : pt + plen][:, ids].tolist())
-                    per_req_idxs.append([list(ids) for _ in range(plen)])
-                else:
-                    per_req_vals.append([])
-                    per_req_idxs.append([])
-                pt += plen
+                per_req_vals.append(full[off : off + plen][:, ids].tolist())
+                per_req_idxs.append([list(ids) for _ in range(plen)])
             logits_output.input_token_ids_logprobs_val = per_req_vals
             logits_output.input_token_ids_logprobs_idx = per_req_idxs
 

--- a/test/srt/test_logprobs.py
+++ b/test/srt/test_logprobs.py
@@ -127,9 +127,9 @@ class TestLogprobsDense(unittest.TestCase):
         )
 
         expected_output_logprobs = [
-            [-0.87109375, 32313, "Okay"],
+            [-0.8515625, 32313, "Okay"],
             [0.0, 11, ","],
-            [-0.318359375, 773, " so"],
+            [-0.3515625, 773, " so"],
         ]
         self.check_output(output_meta, "output_token_logprobs", expected_output_logprobs)
 

--- a/test/srt/test_logprobs_dp.py
+++ b/test/srt/test_logprobs_dp.py
@@ -9,10 +9,8 @@ os.environ["JAX_COMPILATION_CACHE_DIR"] = "/tmp/jit_cache"
 
 
 print("Running on Google TPU")
-# tp_size=4 with dp_size=2 builds a [2, 2] mesh in scheduler.create_device_mesh
-# (ici_parallelism=[dp_size, tp_size // dp_size]), i.e. 4 devices total — fits the
-# 4-chip TPU runner. Cannot be merged into test_logprobs.py because that file
-# runs on the 1-chip runner.
+# tp_size=4 / dp_size=2 -> [dp, tp//dp] = [2, 2] mesh = 4 devices (the TPU runner
+# size). Separate from test_logprobs.py, which runs on the 1-chip runner.
 DP_REGRESSION_ENGINE_CONFIG = {
     "model_path": DEEPSEEK_R1_DISTILL_QWEN_1_5B,
     "random_seed": 27,
@@ -36,18 +34,10 @@ DP_REGRESSION_ENGINE_CONFIG = {
 
 
 class TestLogprobsDpChunkedPrefill(unittest.TestCase):
-    """Regression for the dp>1 chunked-prefill skip-tracking bug.
-
-    Pre-fix, `process_batch_result_prefill` used `skip_stream_req: Req | None`,
-    a single slot. On dp>1, each dp rank can have its own chunked-in-flight req,
-    so all but the last-assigned one leaked into `stream_output` with
-    `input_token_logprobs_val == None`. TokenizerManager then either crashed
-    (`'NoneType' object is not iterable`) or, if coerced to `[]`, returned
-    truncated logprobs that produced inf PPL downstream.
-
-    This test forces multiple in-flight chunked reqs across dp ranks by
-    submitting prompts longer than chunked_prefill_size, with dp_size=2, and
-    asserts every req returns full, finite, scalar input_token_logprobs.
+    """dp>1 chunked-prefill leak: process_batch_result_prefill tracked a single
+    skip_stream_req slot, so on dp>1 all but one mid-chunk req leaked
+    None/truncated input_token_logprobs. Asserts every req returns full, finite,
+    scalar logprobs.
     """
 
     @classmethod
@@ -60,10 +50,8 @@ class TestLogprobsDpChunkedPrefill(unittest.TestCase):
         cls.engine.shutdown()
 
     def test_dp2_multi_req_chunked_prefill_logprobs(self):
-        # 4 prompts of varying lengths, all > chunked_prefill_size=128 so each
-        # spans multiple chunks. Different lengths ensure chunk boundaries
-        # don't coincide, maximizing the chance multiple reqs are mid-prefill
-        # in the same batch step (the dp>1 leak condition).
+        # Prompts all > chunked_prefill_size with distinct lengths -> several reqs
+        # mid-prefill across dp ranks in the same step (the leak condition).
         base = [151646, 151644, 30021, 19131, 6133, 151645, 151648, 198]
         prompts = [
             base * 20,  # 160 tokens
@@ -95,11 +83,9 @@ class TestLogprobsDpChunkedPrefill(unittest.TestCase):
                 f"{len(meta['input_token_logprobs'])} — truncated by chunked-skip leak",
             )
             for j, (logprob, token_id, _) in enumerate(meta["input_token_logprobs"]):
-                # With logprob_start_len=0, the first token has no preceding
-                # context to score against — it MUST be None. Every other
-                # position MUST be a finite scalar; partial chunked-skip leaks
-                # show up as scattered None/inf in the middle of the sequence,
-                # which a length-only check would miss.
+                # logprob_start_len=0: position 0 has no prior context -> None;
+                # every other position must be a finite scalar (partial leaks
+                # scatter None/inf mid-sequence, which a length check would miss).
                 if j == 0:
                     self.assertIsNone(
                         logprob,
@@ -135,6 +121,132 @@ class TestLogprobsDpChunkedPrefill(unittest.TestCase):
                     prompt[j],
                     f"req[{i}][{j}]: token_id mismatch {token_id} vs prompt "
                     f"{prompt[j]} — index alignment regression",
+                )
+
+    def test_dp2_top_logprobs(self):
+        # #1261 overlap-off: top_logprobs + dp>1. Uneven prompts make per-dp
+        # token totals indivisible by dp, which crashed the legacy sharded-slice
+        # fallback.
+        _assert_top_logprobs(self, self.engine)
+
+
+class TestLogprobsDpOverlap(unittest.TestCase):
+    """#1261 / #1276 on the default path (overlap on, dp=4 = the issue's config).
+    dp=4 strictly supersedes dp=2 for the per-DP padded layout.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # tp_size=4 / dp_size=4 -> [4, 1] mesh, the issue's exact tp4/dp4 layout.
+        config = dict(DP_REGRESSION_ENGINE_CONFIG)
+        config["dp_size"] = 4
+        config["disable_overlap_schedule"] = False
+        print(f"Launching dp=4 tp=1 overlap-on Engine with {DEEPSEEK_R1_DISTILL_QWEN_1_5B}...")
+        cls.engine = Engine(**config)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.engine.shutdown()
+
+    def test_overlap_top_logprobs(self):
+        # top_logprobs on the overlap-on default path (pre-#1261 it crashed on the
+        # legacy per-req hidden_states slice).
+        _assert_top_logprobs(self, self.engine)
+
+    def test_overlap_decode_residual_logprobs(self):
+        # dp=4 with overlap, two regressions:
+        # 1. decode crash: the speculated decode batch reuses extend reqs
+        #    (extend_input_logprob_token_ids not cleared); the else-branch concat'd
+        #    their residual and sharded it P("data") -> crash when len % dp != 0.
+        #    Needs n not a multiple of dp: n=3 x (8-1) = 21, 21 % 4 != 0 (the old
+        #    dp=2 test's 4 identical reqs gave 4*r, divisible by 4 too, so it never
+        #    tripped this). max_new_tokens=2 forces the decode step; fix leaves the
+        #    field None for decode.
+        # 2. Identical prompts must give identical scalar logprobs (overlap must
+        #    compact the per-DP padding, else rank>=1 reads padding rows).
+        prompt = [151646, 151644, 30021, 19131, 6133, 151645, 151648, 198]  # 8 tokens
+        n = 3
+        prompts = [list(prompt) for _ in range(n)]
+        start = 1
+        sampling_params = [{"n": 1, "top_k": 1, "max_new_tokens": 2}] * n
+
+        output = self.engine.generate(
+            input_ids=prompts,
+            sampling_params=sampling_params,
+            return_logprob=True,
+            logprob_start_len=[start] * n,
+        )
+        self.assertEqual(len(output), n, "must return one result per req")
+
+        def scalar_logprobs(meta):
+            # entries are (logprob, token_id, _); index 0 is the None placeholder.
+            tok = meta.get("input_token_logprobs")
+            self.assertIsNotNone(tok, "input_token_logprobs is None")
+            return [e[0] for e in tok]
+
+        ref = scalar_logprobs(output[0]["meta_info"])
+        self.assertEqual(len(ref), len(prompt) - start, "ref length mismatch")
+        self.assertIsNone(ref[0], "index 0 must be the None placeholder")
+        for j in range(1, len(ref)):
+            self.assertTrue(math.isfinite(float(ref[j])), f"ref[{j}] non-finite")
+
+        for i in range(1, n):
+            vals = scalar_logprobs(output[i]["meta_info"])
+            self.assertEqual(len(vals), len(ref), f"req[{i}] length mismatch")
+            for j in range(1, len(ref)):
+                self.assertAlmostEqual(
+                    float(vals[j]),
+                    float(ref[j]),
+                    delta=1e-2,
+                    msg=f"req[{i}][{j}]={vals[j]} != req[0][{j}]={ref[j]} — dp=4 overlap "
+                    f"per-DP padded scalar input_token_logprobs mismatch",
+                )
+
+
+def _assert_top_logprobs(test, engine):
+    """Shared #1261 check: uneven prompts + top_logprobs, every req returns
+    `len(prompt) - start` rows of finite width-`k` top logprobs."""
+    base = [151646, 151644, 30021, 19131, 6133, 151645, 151648, 198]
+    prompts = [base * 2, base * 3, base * 1, base * 4]  # 16, 24, 8, 32 tokens
+    start = 1
+    top_logprobs_num = 3
+    sampling_params = [{"n": 1, "top_k": 1, "max_new_tokens": 2}] * len(prompts)
+
+    output = engine.generate(
+        input_ids=prompts,
+        sampling_params=sampling_params,
+        return_logprob=True,
+        logprob_start_len=[start] * len(prompts),
+        top_logprobs_num=[top_logprobs_num] * len(prompts),
+    )
+
+    test.assertEqual(len(output), len(prompts), "must return one result per req")
+    for i, (out, prompt) in enumerate(zip(output, prompts)):
+        meta = out["meta_info"]
+        top = meta.get("input_top_logprobs")
+        test.assertIsNotNone(top, f"req[{i}]: input_top_logprobs is None")
+        test.assertEqual(
+            len(top),
+            len(prompt) - start,
+            f"req[{i}]: expected {len(prompt) - start} input_top_logprobs rows, "
+            f"got {len(top)} — per-dp padded split misaligned",
+        )
+        for j, row in enumerate(top):
+            # index 0 is the None placeholder; later rows are finite width-k lists.
+            if j == 0:
+                test.assertIsNone(row, f"req[{i}][0]: expected None placeholder, got {row}")
+                continue
+            test.assertIsNotNone(row, f"req[{i}][{j}]: unexpected None row mid-sequence")
+            test.assertEqual(
+                len(row),
+                top_logprobs_num,
+                f"req[{i}][{j}]: expected {top_logprobs_num} top logprobs, got {len(row)}",
+            )
+            for entry in row:
+                logprob = entry[0]
+                test.assertTrue(
+                    math.isfinite(float(logprob)),
+                    f"req[{i}][{j}]: non-finite top logprob {logprob}",
                 )
 
 


### PR DESCRIPTION
## Problem

Fixes #1261. On `dp_size > 1`, an extend request with `return_logprob` falls back to the legacy per-req `hidden_states` slice in `LogitsProcessor.__call__`. `_get_logits` forces `P("data","tensor")`, so a row count not divisible by `dp` crashes the server (`ShardingTypeError` at dp=4, `ValueError` at dp=16). Two ways in:

1. The padded input-logprob path (#1177) was skipped for `top_logprobs` / `token_ids_logprobs` / overlap. The default server is overlap-on, so `--tp-size 4 --dp-size 4` crashed regardless of `top_logprobs`.
2. **dp≥4 overlap**: the speculated decode batch reuses extend reqs whose `extend_input_logprob_token_ids` residual is never cleared; the non-padded branch concats it and shards over `P("data")` → crash when the length isn't divisible by `dp` (dp=2 hid it).

## Fix

- **Unify the gate** to `use_padded_input_logprob = is_extend() and not return_hidden_states` for all `dp` — the padded path supports `top_logprobs` / `token_ids` / overlap at any `dp`; only `return_hidden_states` still falls back.
- Per-DP-padding-aware host split in `tp_worker`.
- Reshard vocab to replicated before `top_k` (`logits_processor` + `sampler`) so `[N, k]` isn't left tensor-sharded on `k`.
- Compact the per-DP padded scalar `input_token_logprobs` in the overlap path too (carrying `extend_lens` / `extend_logprob_start_lens` through `ScheduleBatch.copy()`).
- Gate the residual merge on `is_extend()` so decode batches leave it `None` (fixes crash #2).

**Known limitation:** `return_logprob` + `return_hidden_states` on `dp>1` still falls back — host hidden-state extraction isn't padding-aware (separate issue).

## `test/srt/test_logprobs.py` update

`top_logprobs` requests now take the padded path at dp=1 too → a different matmul shape → ~0.02 bf16 rounding shift on the sampled-token `output_token_logprobs` (token selection unchanged). Updated the first expected set (`-0.87109375 → -0.8515625`, `-0.318359375 → -0.3515625`); the second set is unchanged (already on the padded path).

## Validation (TPU v6e-4)

- [x] `tp4 dp4` overlap-on repro fixed; decode-residual crash reproduced pre-fix and fixed
- [x] `test_logprobs_dp.py` 4/4, `test_logprobs.py` 1/1
- [ ] `tp16 dp16` on v6e-16 — TODO
