### PR TITLE
fix(openai): isinstance(dict) -> Mapping for BatchEncoding unwrap

### DIFF
--- a/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
+++ b/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
@@ -3,7 +3,7 @@ import json
 import logging
 import time
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
 from typing import Any
 
 import orjson
@@ -253,7 +253,9 @@ Assistant: {% endif %}"""
                 **chat_template_kwargs,
             )
 
-        if isinstance(prompt_ids, dict) and "input_ids" in prompt_ids:
+        # BatchEncoding (returned by e.g. MiniMax-M2's apply_chat_template on
+        # transformers>=5) inherits UserDict, not dict — use Mapping to cover both.
+        if isinstance(prompt_ids, Mapping) and "input_ids" in prompt_ids:
             prompt_ids = prompt_ids["input_ids"]
 
         if assistant_prefix:


### PR DESCRIPTION
## Summary
- `tokenizer.apply_chat_template(tokenize=True)` returns `BatchEncoding` (a dict subclass) instead of `list[int]` for some chat templates on transformers>=5 (observed with `MiniMaxAI/MiniMax-M2`, transformers 5.9.0)
- Downstream `GenerateReqInput` validation then rejects with `input_ids should be a list of lists for batch processing`
- Unwrap `prompt_ids["input_ids"]` when a dict is returned

## Repro
```python
from transformers import AutoTokenizer
t = AutoTokenizer.from_pretrained("MiniMaxAI/MiniMax-M2", trust_remote_code=True)
out = t.apply_chat_template([{"role":"user","content":"hi"}], tokenize=True, add_generation_prompt=True)
type(out)  # -> BatchEncoding, not list
```

## Test plan
- [x] `/v1/chat/completions` with MiniMax-M2 returns 200 instead of 400 after fix (verified via hotfix on v6e-16)
- [x] `ruff check` passes