### PR TITLE
fix(glm4_moe): transpose HF [out, in] weights to LinearBase [in, out]

### DIFF
--- a/python/sgl_jax/srt/models/glm4_moe.py
+++ b/python/sgl_jax/srt/models/glm4_moe.py
@@ -577,24 +577,24 @@ class Glm4MoeForCausalLM(nnx.Module):
         mappings[f"{prefix}.self_attn.q_proj.weight"] = WeightMapping(
             target_path=f"{target_prefix}.self_attn.q_proj.{w_name}",
             sharding=(None, "tensor"),
-            transpose=False,
+            transpose=True,
         )
         mappings[f"{prefix}.self_attn.k_proj.weight"] = WeightMapping(
             target_path=f"{target_prefix}.self_attn.k_proj.{w_name}",
             sharding=(None, "tensor"),
-            transpose=False,
+            transpose=True,
             kv_head_padding=True,
         )
         mappings[f"{prefix}.self_attn.v_proj.weight"] = WeightMapping(
             target_path=f"{target_prefix}.self_attn.v_proj.{w_name}",
             sharding=(None, "tensor"),
-            transpose=False,
+            transpose=True,
             kv_head_padding=True,
         )
         mappings[f"{prefix}.self_attn.o_proj.weight"] = WeightMapping(
             target_path=f"{target_prefix}.self_attn.c_proj.{w_name}",
             sharding=("tensor", None),
-            transpose=False,
+            transpose=True,
         )
 
         # Biases
@@ -651,17 +651,17 @@ class Glm4MoeForCausalLM(nnx.Module):
             mappings[f"{prefix}.mlp.gate_proj.weight"] = WeightMapping(
                 target_path=f"{target_prefix}.mlp.gate_proj.{w_name}",
                 sharding=(None, "tensor"),
-                transpose=False,
+                transpose=True,
             )
             mappings[f"{prefix}.mlp.up_proj.weight"] = WeightMapping(
                 target_path=f"{target_prefix}.mlp.up_proj.{w_name}",
                 sharding=(None, "tensor"),
-                transpose=False,
+                transpose=True,
             )
             mappings[f"{prefix}.mlp.down_proj.weight"] = WeightMapping(
                 target_path=f"{target_prefix}.mlp.down_proj.{w_name}",
                 sharding=("tensor", None),
-                transpose=False,
+                transpose=True,
             )
             if is_static_quant:
                 mappings[f"{prefix}.mlp.gate_proj.weight_scale"] = WeightMapping(
@@ -783,17 +783,17 @@ class Glm4MoeForCausalLM(nnx.Module):
                 mappings[f"{prefix}.mlp.shared_experts.gate_proj.weight"] = WeightMapping(
                     target_path=f"{target_prefix}.shared_experts.gate_proj.{w_name}",
                     sharding=(None, "tensor"),
-                    transpose=False,
+                    transpose=True,
                 )
                 mappings[f"{prefix}.mlp.shared_experts.up_proj.weight"] = WeightMapping(
                     target_path=f"{target_prefix}.shared_experts.up_proj.{w_name}",
                     sharding=(None, "tensor"),
-                    transpose=False,
+                    transpose=True,
                 )
                 mappings[f"{prefix}.mlp.shared_experts.down_proj.weight"] = WeightMapping(
                     target_path=f"{target_prefix}.shared_experts.down_proj.{w_name}",
                     sharding=("tensor", None),
-                    transpose=False,
+                    transpose=True,
                 )
                 if is_static_quant:
                     mappings[f"{prefix}.mlp.shared_experts.gate_proj.weight_scale"] = WeightMapping(


### PR DESCRIPTION
## Summary

`python/sgl_jax/srt/models/glm4_moe.py` registers `WeightMapping(... transpose=False ...)` for 10 linear weights (q/k/v/o, dense MLP gate/up/down, shared_experts gate/up/down). HF safetensors stores `nn.Linear` weights in PyTorch `[out, in]` convention, but `sgl-jax` `LinearBase` (`linear.py:53-60`) expects `[in, out]` so its `dot_general` contracts on `weight.axis_0 == input_size`. Without `transpose=True`, the loader leaves the array in HF layout and the first prefill crashes:

```
TypeError: dot_general requires contracting dimensions to have the same shape,
           got (4096,) and (12288,).
```

(`q_proj` at layer 0: input `hidden=4096` vs HF weight `axis_0=out=12288`)

This PR flips those 10 entries to `transpose=True`. Matches the convention used by every other model file in `python/sgl_jax/srt/models/` (`qwen3.py`, `deepseek_v3.py`, `bailing_moe.py`, `mimo.py`, `kimi_linear.py`, `glm5_moe.py`, …).

## Evidence — HF actual storage

Verified by reading the safetensors header shapes from `zai-org/GLM-4.5-Air`, `zai-org/GLM-4.5`, `zai-org/GLM-4.6`, and `zai-org/GLM-4.7` via HF byte-range download. All four checkpoints declare `architectures: ["Glm4MoeForCausalLM"]` / `model_type: glm4_moe` (i.e. they all load through this file) and use the same `[out, in]` PyTorch storage convention:

| Tensor | GLM-4.5-Air | GLM-4.5 | GLM-4.6 | GLM-4.7 | Pattern |
|---|---|---|---|---|---|
| `self_attn.q_proj.weight` | `[12288, 4096]` | `[12288, 5120]` | `[12288, 5120]` | `[12288, 5120]` | `[num_heads*head_dim, hidden]` |
| `self_attn.k_proj.weight` | `[1024, 4096]` | `[1024, 5120]` | `[1024, 5120]` | `[1024, 5120]` | `[num_kv_heads*head_dim, hidden]` |
| `self_attn.v_proj.weight` | `[1024, 4096]` | `[1024, 5120]` | `[1024, 5120]` | `[1024, 5120]` | `[num_kv_heads*head_dim, hidden]` |
| `self_attn.o_proj.weight` | `[4096, 12288]` | `[5120, 12288]` | `[5120, 12288]` | `[5120, 12288]` | `[hidden, num_heads*head_dim]` |
| `mlp.{gate,up}_proj.weight` | `[10944, 4096]` | `[12288, 5120]` | `[12288, 5120]` | `[12288, 5120]` | `[intermediate_size, hidden]` |
| `mlp.down_proj.weight` | `[4096, 10944]` | `[5120, 12288]` | `[5120, 12288]` | `[5120, 12288]` | `[hidden, intermediate_size]` |
| `shared_experts.{gate,up}_proj.weight` | `[1408, 4096]` | `[1536, 5120]` | `[1536, 5120]` | `[1536, 5120]` | `[moe_intermediate_size, hidden]` |
| `shared_experts.down_proj.weight` | `[4096, 1408]` | `[5120, 1536]` | `[5120, 1536]` | `[5120, 1536]` | `[hidden, moe_intermediate_size]` |

All 10 entries require transposition to fit `LinearBase`'s `[in, out]` shape. The patch consequently covers every model that targets `Glm4MoeForCausalLM`: **GLM-4.5, GLM-4.5-Air, GLM-4.6, and GLM-4.7** (and any future variant that reuses this architecture class).

GLM-4.7 additionally sets `use_qk_norm=True`, which adds 1D `q_norm.weight` / `k_norm.weight` tensors. Those go through the existing norm path with `transpose=False` (1D, no axes to swap) and are not touched by this PR.

**Not changed**:
- Routed expert weights (`block_sparse_moe.experts.{gate,up,down}_proj`) — already use `transpose=True` via `create_moe_weights_mapping` helper
- `moe_gate.kernel` router — already `transpose=True`
- FP8 `weight_scale` entries — GLM-4.5/4.6/4.7/Air BF16 checkpoints don't instantiate them (`is_static_quant=False`); when GLM-FP8 lands these will need a separate review
- Embeddings (`embed_tokens.weight`, `lm_head.weight`) — `[vocab, hidden]` is the natural format for embedding lookup, doesn't go through `dot_general`
- All norm `*.weight` (RMSNorm scale, including the new `q_norm`/`k_norm` in GLM-4.7) — 1D, no axes to swap

## Cross-check: `glm5_moe.py` is unaffected

GLM-5 (`zai-org/GLM-5`, architecture `GlmMoeDsaForCausalLM`, `model_type: glm_moe_dsa`) uses a separate model file (`glm5_moe.py`) where every linear `WeightMapping` already sets `transpose=True`. Verified by probing the actual HF shapes for `q_a_proj`, `q_b_proj`, `kv_a_proj_with_mqa`, `kv_b_proj`, `o_proj`, `indexer.{wq_b,wk,weights_proj}`, dense MLP gate/up/down, shared_experts gate/up/down, routed experts.0, and `moe_gate.kernel` — every one of them follows the same `[out, in]` PyTorch convention and is already correctly transposed in `glm5_moe.py`. No patch is needed there.

## Why this stayed hidden

The bug was present from the moment `glm4_moe.py` was added in #907 ("Adding GLM-4.7", merged 2026-05-01) and persisted unnoticed across subsequent touches to the file. Two concrete code paths explain why it didn't surface earlier — the asymmetry between the FP8 and BF16 loaders is what matters:

### 1. PR #907's manual verification used an FP8 checkpoint

The launch command in #907's PR description points at `--model-path <path>/GLM-4.7-FP8`. This routes through `is_static_quant=True` and engages the FP8 dequant pipeline, not the BF16 direct-load path.

### 2. The FP8 dequant pipeline contains a runtime layout autodetect that compensates for `transpose=False`

`_block_dequant` in `python/sgl_jax/srt/utils/weight_utils.py` inspects the loaded `weight_q` against the scale's `out_dim` and inserts a `jnp.transpose` if the on-disk layout is HF `[out, in]`:

```python
in_blocks = weight_scale.shape[0]
out_dim = weight_scale.shape[2]
dim0, dim1 = weight_q.shape

if dim1 == out_dim:
    pass  # Model layout [in, out], no kv-padding
elif dim0 == out_dim:
    weight_q = jnp.transpose(weight_q)  # HF layout [out, in]
```

When `WeightMapping.transpose=False` and the source weight is HF `[out, in]`, `_block_dequant` silently fixes the layout during dequant. The resulting BF16 tensor handed to `LinearBase` is correctly `[in, out]`, so `dot_general` runs without the shape error.

### 3. The BF16 direct-load path has no equivalent autodetect

When `is_static_quant=False` (BF16 checkpoint, no `weight_scale`), the loader copies the on-disk tensor directly into `LinearBase.weight` and never enters `_block_dequant`. The `WeightMapping.transpose` flag is the *only* mechanism that can rotate the layout to `[in, out]`, and with `transpose=False` the array stays in HF `[out, in]` form. The first `dot_general` then sees `weight.axis_0 = out_features = 12288` against `x.last = hidden = 4096` and aborts with the shape mismatch above.

### Net effect

| Loader path | `transpose=False` outcome |
|---|---|
| FP8 (`is_static_quant=True`) | `_block_dequant` autodetects HF layout and fixes it during dequant → works |
| **BF16 (this PR's target)** | **direct copy into `LinearBase`, no autodetect → `dot_general` crashes on first prefill** |

Anyone who has tried to load `zai-org/GLM-4.5{-Air,}` / `GLM-4.6` / `GLM-4.7` (BF16) since #907 landed will have hit the same `dot_general (4096,) vs (12288,)` mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)