### PR TITLE
fix(gate): apply routed_scaling_factor independently of renormalize

### DIFF
--- a/python/sgl_jax/srt/layers/gate.py
+++ b/python/sgl_jax/srt/layers/gate.py
@@ -104,8 +104,8 @@ class TopK(nnx.Module):
 
         if self.renormalize:
             topk_weights = topk_weights / (jnp.sum(topk_weights, axis=-1, keepdims=True))
-            if self.routed_scaling_factor is not None:
-                topk_weights *= self.routed_scaling_factor
+        if self.routed_scaling_factor is not None:
+            topk_weights *= self.routed_scaling_factor
 
         topk_weights = topk_weights.astype(jnp.float32)
 


### PR DESCRIPTION
## Summary

`TopK.__call__` in `python/sgl_jax/srt/layers/gate.py` nests the `routed_scaling_factor` multiplication inside the `if self.renormalize:` branch, so the scaling is silently skipped whenever a model's `norm_topk_prob=False`. The two operations are logically independent — `renormalize` makes the top-k probs sum to 1, `routed_scaling_factor` applies a constant magnitude scaling to the resulting weights — and a model can require any combination of the two.

This PR dedents the scaling step so it always runs:

```python
# before
if self.renormalize:
    topk_weights = topk_weights / (jnp.sum(topk_weights, axis=-1, keepdims=True))
    if self.routed_scaling_factor is not None:           # ← nested, skipped when renormalize=False
        topk_weights *= self.routed_scaling_factor

# after
if self.renormalize:
    topk_weights = topk_weights / (jnp.sum(topk_weights, axis=-1, keepdims=True))
if self.routed_scaling_factor is not None:               # ← top-level, runs unconditionally
    topk_weights *= self.routed_scaling_factor
```

## What goes wrong without this fix

When a model has `norm_topk_prob=False` and `routed_scaling_factor > 1.0`, the current code drops the scaling on the floor. The model trained against `topk_weights × routed_scaling_factor` but inference uses raw `topk_weights` whose sum is much smaller than 1. The MoE block contribution to the residual stream is reduced to `1 / routed_scaling_factor` of its trained magnitude, and after stacking dozens of MoE layers the final logits drift far enough from the training distribution that the model collapses to high-frequency tokens.

Concretely, on `deepseek-ai/DeepSeek-V2` (236B base) the server boots cleanly and serves requests, but every prompt returns degenerate output:

```
prompt: "The quick brown fox jumps over"
output: " the，\n\n\n\n\n\n\n\n\n\n\n\n\n"

prompt: "The capital of China is"
output: " a，\n\n\n\n\n\n\n\n\n\n\n\n\n"

prompt: "Q: What is 17 times 23? A:"
output: " 17 times 23 is 17 times 23 is 17 times"

prompt: "中国的首都是"
output: " & & & & & & & & & & & & & & &"
```

The pattern (fullwidth-comma + newline floods, `& & & &` chains, parrot loops) is the signature of a Transformer whose hidden-state magnitude is several factors off from the training regime. Both `--moe-backend epmoe` and `--moe-backend fused` (with `--max-running-requests 64` to satisfy fused alignment) produce the same garbage, confirming the bug is upstream of the MoE backend choice.

## Affected HuggingFace checkpoints

A survey of ~90 public MoE checkpoints (DeepSeek, Mistral/Mixtral, Snowflake Arctic, DBRX, IBM Granite, Microsoft Phi-MoE, Qwen3-MoE, GLM-4.x / GLM-5, Ling/Ring/Bailing, Kimi-K2, Moonlight, OLMoE, Phi-MoE, MiniMax M1, JetMoE, xverse, Tencent Hunyuan, and others) finds **exactly the DeepSeek V2 / V2.5 / Coder-V2 236B family hits the bug condition** — every single 236B-scale `DeepseekV2ForCausalLM` checkpoint is impacted:

| HF model | size | `norm_topk_prob` | `routed_scaling_factor` | pre-patch behavior |
|---|---|---|---|---|
| `deepseek-ai/DeepSeek-V2` | 236B base | **False** | **16.0** | **broken** — 16× scaling silently dropped |
| `deepseek-ai/DeepSeek-V2-Chat` | 236B chat | **False** | **16.0** | **broken** |
| `deepseek-ai/DeepSeek-V2-Chat-0628` | 236B chat (0628) | **False** | **16.0** | **broken** |
| `deepseek-ai/DeepSeek-V2.5` | 236B v2.5 | **False** | **16.0** | **broken** |
| `deepseek-ai/DeepSeek-V2.5-1210` | 236B v2.5 (1210) | **False** | **16.0** | **broken** |
| `deepseek-ai/DeepSeek-Coder-V2-Instruct` | 236B coder | **False** | **16.0** | **broken** |
| `deepseek-ai/DeepSeek-Coder-V2-Base` | 236B coder base | **False** | **16.0** | **broken** |

DeepSeek-V2-Lite / Coder-V2-Lite / ESFT-vanilla-lite also have `norm_topk_prob=False` but `routed_scaling_factor=1.0` (×1 is a no-op), so the bug has no observable effect. DeepSeek V3 / V3.1 / V3.2 / R1 / DeepSeek-Prover-V2 use `norm_topk_prob=True` and walk the renormalize branch where the scaling executes correctly.

Other MoE vendors avoid the bug condition entirely:

- **No `routed_scaling_factor` field at all** (Mixtral-style routing with implicit topk normalization): Mixtral 8x7B / 8x22B, Snowflake Arctic, IBM Granite MoE, Microsoft Phi-3.5-MoE, JetMoE, xverse, MiniMax M1, Qwen3-MoE — these never enter the `if self.routed_scaling_factor is not None:` branch
- **`norm_topk_prob=True`** (renormalize branch executes): all Ling / Ring / Bailing variants, GLM-4.5 / 4.5-Air / 4.6 / 4.7 / GLM-5, Kimi-K2, Moonlight, DeepSeek V3+ family
- **`norm_topk_prob=False` but `routed_scaling_factor` field absent**: Allen AI OLMoE — effective ×1 scaling, no observable effect

## Compatibility matrix

The patch only affects one cell:

| `renormalize` | `routed_scaling_factor` | Before this PR | After this PR | Net effect | Models in this cell |
|---|---|---|---|---|---|
| True | 1.0 | renormalize, ×1.0 (no-op) | renormalize, ×1.0 (no-op) | identical | GLM-4.5-Air, Qwen3-MoE (no field) |
| True | 2.5 | renormalize, ×2.5 | renormalize, ×2.5 | identical | DSV3 / R1, Ling/Ring, GLM-4.5, GLM-4.6, GLM-4.7, GLM-5, Kimi-K2, Moonlight, ESFT-vanilla |
| False | None / 1.0 | no scaling | no scaling (or ×1.0 no-op) | identical | DSV2-Lite, OLMoE |
| **False** | **>1.0** | **scaling silently dropped** | **scaling applied** | **fixes 7 DeepSeek 236B checkpoints** | **DSV2, V2-Chat (×2), V2.5 (×2), Coder-V2 (×2)** |

Every other model in the model zoo lands in the first three rows and sees zero behavioral change.

## Why this stayed hidden

The buggy nesting was introduced in #240 ("feat: support bailing moe", merged 2025-10-23) when the `TopK.__call__` logic was first written inside `python/sgl_jax/srt/layers/moe.py`. PR #240's accuracy validation covered `inclusionAI/Ling-mini-2.0` (`norm_topk_prob=True, routed_scaling_factor=2.5`) and `Qwen/Qwen3-30B-A3B-Instruct-2507` (`norm_topk_prob=True, routed_scaling_factor=1.0`) — both with `renormalize=True`, both walking the `if renormalize:` branch where the (then-also-required) scaling executes correctly.

#862 ("Feat/support block quant", merged 2026-03-23) refactored the routing logic out of `moe.py` into a new `python/sgl_jax/srt/layers/gate.py` (`+193 -0` for the new file, `-358` net from `moe.py`) and ported the existing block of code byte-for-byte; the bug was carried over unchanged. #862's accuracy validation covered Qwen3-30B-A3B (`renormalize=True`) and Qwen3-8B (dense, no router), so the nested-if behavior was still not exercised.

Every other MoE checkpoint that landed in the model zoo between 2025-10 and 2026-05 — DeepSeek-V2-Lite, DSV3, DSR1, Ling family, MiMo, GLM-4.5 / 4.5-Air / 4.6 / 4.7 — happens to either set `norm_topk_prob=True` or set `routed_scaling_factor=1.0` (Lite tier). The DSV2 236B family is the only zoo entry with `norm_topk_prob=False` and `scaling>1.0`, and `git log -S routed_scaling_factor` shows no commit between #240 and this PR (~7 months) that exercised the `False ∧ >1.0` cell.

## Test plan

- [x] Re-deploy `deepseek-ai/DeepSeek-V2` (236B base) on TPU v6e-32 with this patch, confirm sanity prompts return coherent output (`17 × 23 → 391`, `"capital of France" → " Paris"`, `"中国的首都是" → "北京"`)
🤖 Generated with [Claude Code](https://claude.com/claude-code)