### PR TITLE
fix(fused_moe): add narrow-N blockwise guard to FusedEPMoE init

### DIFF
--- a/python/sgl_jax/srt/layers/fused_moe.py
+++ b/python/sgl_jax/srt/layers/fused_moe.py
@@ -204,6 +204,37 @@ class FusedEPMoE(nnx.Module):
             self.quant_block_k = None
             self.quant_block_n = None
 
+        # Narrow-N safety guard for block-wise FP8/INT8. The blockwise
+        # Pallas kernel collapses on TPU when a Linear's output dim is
+        # <= block_size_out (see `xla_quantized_matmul_local` for the
+        # QuantizedLinear path and `should_use_blockwise_kernel` for the
+        # helper). Mirror that guard here so the fused and epmoe MoE
+        # backends share the same safety surface.
+        if (
+            self.quantized_dtype is not None
+            and self.quant_block_n is not None
+            and not getattr(quantization_config, "allow_narrow_n_blockwise", False)
+        ):
+            from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import (
+                should_use_blockwise_kernel,
+            )
+
+            out_dims = [intermediate_dim, intermediate_dim, hidden_size]  # w1, w3, w2
+            if num_shared_experts and num_shared_experts > 0:
+                se_inter = self.moe_shared_expert_intermediate_size * num_shared_experts
+                out_dims += [se_inter, se_inter, hidden_size]  # w{1,3,2}_shared
+            for out_dim in out_dims:
+                if not should_use_blockwise_kernel(
+                    out_dim=int(out_dim), block_size_out=int(self.quant_block_n)
+                ):
+                    raise RuntimeError(
+                        f"FusedEPMoE blockwise kernel does not support "
+                        f"out_dim={out_dim} with block_size_out={self.quant_block_n} "
+                        f"(known to cause accuracy collapse). Set "
+                        f"allow_narrow_n_blockwise=True in your quantization "
+                        f"config to override."
+                    )
+
     def quantize_weights(self, is_static: bool = False):
         """Quantize MoE weights in-place. Call once after model loading."""
         if self.quantized_dtype is None:


### PR DESCRIPTION
## Summary

`xla_quantized_matmul_local` (in `python/sgl_jax/srt/kernels/quantized_matmul/kernel.py`) raises a hard `RuntimeError` when a block-wise FP8/INT8 weight's output dim is `<= block_size_out`, because the blockwise Pallas kernel on TPU collapses (NaNs / accuracy loss) in that regime. The check is shared through the `should_use_blockwise_kernel` helper (in `python/sgl_jax/srt/kernels/quantized_matmul/blockwise_utils.py`).

`FusedEPMoE` does **not** have an equivalent guard. When a caller wired a model / parallelism combination whose `w1` / `w2` / `w3` or shared-expert weights land in the narrow-N regime, the fused path silently produced wrong outputs (no exception, server boots, every prompt returns degenerate tokens). Switching `--moe-backend` to `epmoe` on the same config would correctly surface the `RuntimeError` via the `QuantizedLinear` path — i.e. the two backends had asymmetric safety surfaces.

This PR adds the same guard at `FusedEPMoE.__init__`:

```python
if (
    self.quantized_dtype is not None
    and self.quant_block_n is not None
    and not getattr(quantization_config, "allow_narrow_n_blockwise", False)
):
    from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import (
        should_use_blockwise_kernel,
    )

    out_dims = [intermediate_dim, intermediate_dim, hidden_size]  # w1, w3, w2
    if num_shared_experts and num_shared_experts > 0:
        se_inter = self.moe_shared_expert_intermediate_size * num_shared_experts
        out_dims += [se_inter, se_inter, hidden_size]  # w{1,3,2}_shared
    for out_dim in out_dims:
        if not should_use_blockwise_kernel(
            out_dim=int(out_dim), block_size_out=int(self.quant_block_n)
        ):
            raise RuntimeError(
                f"FusedEPMoE blockwise kernel does not support "
                f"out_dim={out_dim} with block_size_out={self.quant_block_n} "
                f"(known to cause accuracy collapse). Set "
                f"allow_narrow_n_blockwise=True in your quantization "
                f"config to override."
            )
```

## Why the guard applies to these weights

`FusedEPMoE` only shards the expert axis `E` across `(data, tensor)`. The other two axes of `w1` / `w3` / `w2` are not sharded by this layer, and shared experts are replicated with `P(None, None)`. So **per-rank N == model-level N** for every weight FusedEPMoE owns. The check therefore validates the architectural choice of `intermediate_dim` / `hidden_size` / `se_inter_dim` relative to the quant `block_n`, mirroring how the QuantizedLinear path validates `out_dim` after TP sharding.

The shape map:

| Weight | Shape | Out-dim | Sharding | Per-rank N |
|---|---|---|---|---|
| `w1` (routed gate) | `[E, hidden, intermediate]` | `intermediate_dim` | `P((data,tensor), None, None)` | `intermediate_dim` |
| `w3` (routed up) | `[E, hidden, intermediate]` | `intermediate_dim` | same | `intermediate_dim` |
| `w2` (routed down) | `[E, intermediate, hidden]` | `hidden_size` | same | `hidden_size` |
| `w1_shared` / `w3_shared` (if present) | `[hidden, se_inter]` | `se_inter_dim` | `P(None, None)` (replicated) | `se_inter_dim` |
| `w2_shared` (if present) | `[se_inter, hidden]` | `hidden_size` | replicated | `hidden_size` |

## Behavior matrix

| `quantized_dtype` | `quant_block_n` | `out_dim > block_n` (all w) | `allow_narrow_n_blockwise` | Result |
|---|---|---|---|---|
| `None` | any | n/a | any | unchanged (no quant) |
| set | `None` | n/a | any | unchanged (per-channel path) |
| set | set | True | any | unchanged |
| set | set | False (some w) | True | unchanged (opt-out preserved) |
| **set** | **set** | **False (some w)** | **False** | **NEW: `RuntimeError` at init** |

The escape hatch matches the QuantizedLinear path: DeepSeek-V3 / R1 with explicit `allow_narrow_n_blockwise=True` in their quant config keep working byte-for-byte. Configs without the opt-out now fail loudly at `__init__` instead of silently producing wrong outputs at inference time.

## Why this stayed hidden

`FusedEPMoE` was added with block-wise FP8 support in #862 ("Feat/support block quant"). The PR's accuracy validation covered Qwen3-30B-A3B (no `routed_scaling_factor` → no MoE block-wise quant in that config) and Qwen3-8B (dense, not MoE). The QuantizedLinear-path narrow-N guard was added inside `xla_quantized_matmul_local` at the same time, but never propagated to the FusedEPMoE entry point — the two backends grew separate safety surfaces.

`should_use_blockwise_kernel` itself ships with a docstring explicitly warning about the failure mode it guards:

```
When a tensor-parallel column shard collapses to a single output block
(for example local N=128 with block_size_out=128), the TPU blockwise
kernel can produce NaNs on Qwen3-MoE k/v projections.
```

— but only `QuantizedLinear` calls it. This PR closes that gap for `FusedEPMoE`.

## Test plan

- [ ] CI: confirm Qwen3-30B-A3B / Qwen3-MoE block-quant tests still pass (no new failure — these configs don't hit narrow-N regardless)
- [ ] CI: confirm DeepSeek-V3 / R1 block-quant tests still pass (`allow_narrow_n_blockwise=True` opt-out path)
- [ ] Targeted: construct a synthetic `FusedEPMoE` with `intermediate_dim == quant_block_n` and `allow_narrow_n_blockwise=False`, assert it raises `RuntimeError` at init (and stops raising when the override flag is set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)