### PR TITLE
refactor(mem_cache): extract kv cache builder from scheduler

### DIFF
--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -371,6 +371,7 @@ class Scheduler(
         self.per_dp_max_running_requests = self.max_running_requests // self.dp_size
 
         self.is_hybrid = self.tp_worker.is_hybrid
+        self.sliding_window_size = None
         if self.is_hybrid:
             self.sliding_window_size = self.tp_worker.sliding_window_size
             self.full_tokens_per_layer, self.swa_tokens_per_layer = (

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -66,8 +66,8 @@ from sgl_jax.srt.managers.scheduler_profiler_mixing import SchedulerProfilerMixi
 from sgl_jax.srt.managers.tp_worker import ModelWorker
 from sgl_jax.srt.managers.tp_worker_overlap_thread import ModelWorkerClient
 from sgl_jax.srt.managers.utils import validate_input_length
-from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache, SWAChunkCache
-from sgl_jax.srt.mem_cache.radix_cache import RadixCache
+from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
+from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
 from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
 from sgl_jax.srt.multimodal.tokenizer_utils import resolve_tokenizer_subdir
@@ -556,43 +556,21 @@ class Scheduler(
             )
 
     def init_memory_pool_and_cache(self):
-        server_args = self.server_args
-        self.req_to_token_pool, self.token_to_kv_pool_allocator = self.tp_worker.get_memory_pool()
-
-        if self.is_hybrid:
-            if server_args.disable_radix_cache:
-                self.tree_cache = SWAChunkCache(
-                    req_to_token_pool=self.req_to_token_pool,
-                    token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-                    page_size=self.page_size,
-                    sliding_window_size=self.sliding_window_size,
-                )
-            else:
-                self.tree_cache = SWARadixCache(
-                    req_to_token_pool=self.req_to_token_pool,
-                    token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-                    sliding_window_size=self.sliding_window_size,
-                    page_size=self.page_size,
-                    disable=False,
-                )
-        elif server_args.chunked_prefill_size is not None and server_args.disable_radix_cache:
-            self.tree_cache = ChunkCache(
-                req_to_token_pool=self.req_to_token_pool,
-                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-                page_size=self.page_size,
-            )
-        else:
-            self.tree_cache = RadixCache(
-                req_to_token_pool=self.req_to_token_pool,
-                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-                page_size=self.page_size,
-                disable=server_args.disable_radix_cache,
-                kv_head_num=self.model_config.get_num_kv_heads(self.tp_size),
-                head_dim=self.model_config.head_dim,
-                layer_num=self.model_config.num_hidden_layers,
-                max_seq_len=server_args.max_seq_len,
-                is_eagle=self.spec_algorithm is not None and self.spec_algorithm.is_eagle(),
-            )
+        self.req_to_token_pool, self.token_to_kv_pool_allocator = (
+            self.tp_worker.get_memory_pool()
+        )
+        result = build_kv_cache(
+            server_args=self.server_args,
+            model_config=self.model_config,
+            req_to_token_pool=self.req_to_token_pool,
+            token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+            page_size=self.page_size,
+            is_hybrid=self.is_hybrid,
+            sliding_window_size=self.sliding_window_size,
+            tp_size=self.tp_size,
+            spec_algorithm=self.spec_algorithm,
+        )
+        self.tree_cache = result.tree_cache
 
     def _select_round_robin_dp(self) -> int:
         dp_rank = self.dp_round_robin_counter % self.dp_size

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -558,7 +558,7 @@ class Scheduler(
 
     def init_memory_pool_and_cache(self):
         self.req_to_token_pool, self.token_to_kv_pool_allocator = self.tp_worker.get_memory_pool()
-        result = build_kv_cache(
+        self.tree_cache = build_kv_cache(
             server_args=self.server_args,
             model_config=self.model_config,
             req_to_token_pool=self.req_to_token_pool,
@@ -569,7 +569,6 @@ class Scheduler(
             tp_size=self.tp_size,
             spec_algorithm=self.spec_algorithm,
         )
-        self.tree_cache = result.tree_cache
 
     def _select_round_robin_dp(self) -> int:
         dp_rank = self.dp_round_robin_counter % self.dp_size

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -557,9 +557,7 @@ class Scheduler(
             )
 
     def init_memory_pool_and_cache(self):
-        self.req_to_token_pool, self.token_to_kv_pool_allocator = (
-            self.tp_worker.get_memory_pool()
-        )
+        self.req_to_token_pool, self.token_to_kv_pool_allocator = self.tp_worker.get_memory_pool()
         result = build_kv_cache(
             server_args=self.server_args,
             model_config=self.model_config,

--- a/python/sgl_jax/srt/mem_cache/cache_init_params.py
+++ b/python/sgl_jax/srt/mem_cache/cache_init_params.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+    from sgl_jax.srt.mem_cache.memory_pool import ReqToTokenPool
+
+
+@dataclasses.dataclass
+class CacheInitParams:
+    disable: bool
+    req_to_token_pool: ReqToTokenPool
+    token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator
+    page_size: int
+
+    is_eagle: bool = False
+
+    chunked_prefill_size: Optional[int] = None
+    sliding_window_size: Optional[int] = None

--- a/python/sgl_jax/srt/mem_cache/cache_init_params.py
+++ b/python/sgl_jax/srt/mem_cache/cache_init_params.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sgl_jax.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
@@ -17,5 +17,5 @@ class CacheInitParams:
 
     is_eagle: bool = False
 
-    chunked_prefill_size: Optional[int] = None
-    sliding_window_size: Optional[int] = None
+    chunked_prefill_size: int | None = None
+    sliding_window_size: int | None = None

--- a/python/sgl_jax/srt/mem_cache/cache_init_params.py
+++ b/python/sgl_jax/srt/mem_cache/cache_init_params.py
@@ -10,12 +10,10 @@ if TYPE_CHECKING:
 
 @dataclasses.dataclass
 class CacheInitParams:
-    disable: bool
     req_to_token_pool: ReqToTokenPool
     token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator
     page_size: int
 
     is_eagle: bool = False
 
-    chunked_prefill_size: int | None = None
     sliding_window_size: int | None = None

--- a/python/sgl_jax/srt/mem_cache/kv_cache_builder.py
+++ b/python/sgl_jax/srt/mem_cache/kv_cache_builder.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache
 from sgl_jax.srt.mem_cache.cache_init_params import CacheInitParams

--- a/python/sgl_jax/srt/mem_cache/kv_cache_builder.py
+++ b/python/sgl_jax/srt/mem_cache/kv_cache_builder.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache
@@ -18,13 +17,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
-class KVCacheBuildResult:
-    tree_cache: BasePrefixCache
-    is_hybrid_swa: bool
-    sliding_window_size: int | None
-
-
 def build_kv_cache(
     *,
     server_args: ServerArgs,
@@ -36,7 +28,7 @@ def build_kv_cache(
     sliding_window_size: int | None,
     tp_size: int,
     spec_algorithm: SpeculativeAlgorithm | None,
-) -> KVCacheBuildResult:
+) -> BasePrefixCache:
     params = CacheInitParams(
         req_to_token_pool=req_to_token_pool,
         token_to_kv_pool_allocator=token_to_kv_pool_allocator,
@@ -45,7 +37,7 @@ def build_kv_cache(
         sliding_window_size=sliding_window_size,
     )
 
-    tree_cache = create_tree_cache(
+    return create_tree_cache(
         TreeCacheBuildContext(
             server_args=server_args,
             params=params,
@@ -55,10 +47,4 @@ def build_kv_cache(
             model_config=model_config,
             tp_size=tp_size,
         )
-    )
-
-    return KVCacheBuildResult(
-        tree_cache=tree_cache,
-        is_hybrid_swa=is_hybrid,
-        sliding_window_size=sliding_window_size,
     )

--- a/python/sgl_jax/srt/mem_cache/kv_cache_builder.py
+++ b/python/sgl_jax/srt/mem_cache/kv_cache_builder.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache
+from sgl_jax.srt.mem_cache.cache_init_params import CacheInitParams
+from sgl_jax.srt.mem_cache.registry import TreeCacheBuildContext, create_tree_cache
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.configs.model_config import ModelConfig
+    from sgl_jax.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+    from sgl_jax.srt.mem_cache.memory_pool import ReqToTokenPool
+    from sgl_jax.srt.server_args import ServerArgs
+    from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class KVCacheBuildResult:
+    tree_cache: BasePrefixCache
+    is_hybrid_swa: bool
+    sliding_window_size: int | None
+
+
+def build_kv_cache(
+    *,
+    server_args: ServerArgs,
+    model_config: ModelConfig,
+    req_to_token_pool: ReqToTokenPool,
+    token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
+    page_size: int,
+    is_hybrid: bool,
+    sliding_window_size: int | None,
+    tp_size: int,
+    spec_algorithm: SpeculativeAlgorithm | None,
+) -> KVCacheBuildResult:
+    params = CacheInitParams(
+        disable=server_args.disable_radix_cache,
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        page_size=page_size,
+        is_eagle=spec_algorithm is not None and spec_algorithm.is_eagle(),
+        chunked_prefill_size=server_args.chunked_prefill_size,
+        sliding_window_size=sliding_window_size,
+    )
+
+    tree_cache = create_tree_cache(
+        TreeCacheBuildContext(
+            server_args=server_args,
+            params=params,
+            is_hybrid_swa=is_hybrid,
+            disable_radix_cache=server_args.disable_radix_cache,
+            effective_chunked_prefill_size=server_args.chunked_prefill_size,
+            model_config=model_config,
+            tp_size=tp_size,
+        )
+    )
+
+    return KVCacheBuildResult(
+        tree_cache=tree_cache,
+        is_hybrid_swa=is_hybrid,
+        sliding_window_size=sliding_window_size,
+    )

--- a/python/sgl_jax/srt/mem_cache/kv_cache_builder.py
+++ b/python/sgl_jax/srt/mem_cache/kv_cache_builder.py
@@ -38,12 +38,10 @@ def build_kv_cache(
     spec_algorithm: SpeculativeAlgorithm | None,
 ) -> KVCacheBuildResult:
     params = CacheInitParams(
-        disable=server_args.disable_radix_cache,
         req_to_token_pool=req_to_token_pool,
         token_to_kv_pool_allocator=token_to_kv_pool_allocator,
         page_size=page_size,
         is_eagle=spec_algorithm is not None and spec_algorithm.is_eagle(),
-        chunked_prefill_size=server_args.chunked_prefill_size,
         sliding_window_size=sliding_window_size,
     )
 

--- a/python/sgl_jax/srt/mem_cache/registry.py
+++ b/python/sgl_jax/srt/mem_cache/registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING
 
 from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache
 from sgl_jax.srt.mem_cache.cache_init_params import CacheInitParams
@@ -20,7 +20,7 @@ class TreeCacheBuildContext:
     params: CacheInitParams
     is_hybrid_swa: bool
     disable_radix_cache: bool
-    effective_chunked_prefill_size: Optional[int]
+    effective_chunked_prefill_size: int | None
     model_config: ModelConfig
     tp_size: int
 
@@ -49,10 +49,7 @@ def default_radix_cache_factory(ctx: TreeCacheBuildContext) -> BasePrefixCache:
             disable=False,
         )
 
-    if (
-        ctx.effective_chunked_prefill_size is not None
-        and ctx.disable_radix_cache
-    ):
+    if ctx.effective_chunked_prefill_size is not None and ctx.disable_radix_cache:
         from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
 
         return ChunkCache(

--- a/python/sgl_jax/srt/mem_cache/registry.py
+++ b/python/sgl_jax/srt/mem_cache/registry.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
+
+from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache
+from sgl_jax.srt.mem_cache.cache_init_params import CacheInitParams
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.configs.model_config import ModelConfig
+    from sgl_jax.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TreeCacheBuildContext:
+    server_args: ServerArgs
+    params: CacheInitParams
+    is_hybrid_swa: bool
+    disable_radix_cache: bool
+    effective_chunked_prefill_size: Optional[int]
+    model_config: ModelConfig
+    tp_size: int
+
+
+def default_radix_cache_factory(ctx: TreeCacheBuildContext) -> BasePrefixCache:
+    params = ctx.params
+
+    if ctx.is_hybrid_swa:
+        if ctx.disable_radix_cache:
+            from sgl_jax.srt.mem_cache.chunk_cache import SWAChunkCache
+
+            return SWAChunkCache(
+                req_to_token_pool=params.req_to_token_pool,
+                token_to_kv_pool_allocator=params.token_to_kv_pool_allocator,
+                page_size=params.page_size,
+                sliding_window_size=params.sliding_window_size,
+            )
+
+        from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
+
+        return SWARadixCache(
+            req_to_token_pool=params.req_to_token_pool,
+            token_to_kv_pool_allocator=params.token_to_kv_pool_allocator,
+            sliding_window_size=params.sliding_window_size,
+            page_size=params.page_size,
+            disable=False,
+        )
+
+    if (
+        ctx.effective_chunked_prefill_size is not None
+        and ctx.disable_radix_cache
+    ):
+        from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
+
+        return ChunkCache(
+            req_to_token_pool=params.req_to_token_pool,
+            token_to_kv_pool_allocator=params.token_to_kv_pool_allocator,
+            page_size=params.page_size,
+        )
+
+    from sgl_jax.srt.mem_cache.radix_cache import RadixCache
+
+    return RadixCache(
+        req_to_token_pool=params.req_to_token_pool,
+        token_to_kv_pool_allocator=params.token_to_kv_pool_allocator,
+        page_size=params.page_size,
+        disable=ctx.disable_radix_cache,
+        kv_head_num=ctx.model_config.get_num_kv_heads(ctx.tp_size),
+        head_dim=ctx.model_config.head_dim,
+        layer_num=ctx.model_config.num_hidden_layers,
+        max_seq_len=ctx.server_args.max_seq_len,
+        is_eagle=params.is_eagle,
+    )
+
+
+def create_tree_cache(ctx: TreeCacheBuildContext) -> BasePrefixCache:
+    cache = default_radix_cache_factory(ctx)
+
+    logger.info(
+        "Tree cache initialized: impl=%s hybrid_swa=%s",
+        type(cache).__name__,
+        ctx.is_hybrid_swa,
+    )
+    return cache

--- a/python/sgl_jax/test/test_kv_cache_builder.py
+++ b/python/sgl_jax/test/test_kv_cache_builder.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from sgl_jax.srt.mem_cache.kv_cache_builder import KVCacheBuildResult, build_kv_cache
 
@@ -61,9 +61,7 @@ class TestBuildKVCache(unittest.TestCase):
 
     def test_disable_radix_with_chunked_prefill_returns_chunk_cache(self):
         result = build_kv_cache(
-            server_args=_make_server_args(
-                disable_radix_cache=True, chunked_prefill_size=8192
-            ),
+            server_args=_make_server_args(disable_radix_cache=True, chunked_prefill_size=8192),
             model_config=_make_model_config(),
             req_to_token_pool=MagicMock(),
             token_to_kv_pool_allocator=MagicMock(),

--- a/python/sgl_jax/test/test_kv_cache_builder.py
+++ b/python/sgl_jax/test/test_kv_cache_builder.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from sgl_jax.srt.mem_cache.kv_cache_builder import KVCacheBuildResult, build_kv_cache
+from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
 
 
 def _make_server_args(**overrides):
@@ -24,7 +24,7 @@ def _make_model_config():
 
 class TestBuildKVCache(unittest.TestCase):
     def test_default_returns_radix_cache(self):
-        result = build_kv_cache(
+        cache = build_kv_cache(
             server_args=_make_server_args(),
             model_config=_make_model_config(),
             req_to_token_pool=MagicMock(),
@@ -35,15 +35,12 @@ class TestBuildKVCache(unittest.TestCase):
             tp_size=1,
             spec_algorithm=None,
         )
-        self.assertIsInstance(result, KVCacheBuildResult)
         from sgl_jax.srt.mem_cache.radix_cache import RadixCache
 
-        self.assertIsInstance(result.tree_cache, RadixCache)
-        self.assertFalse(result.is_hybrid_swa)
-        self.assertIsNone(result.sliding_window_size)
+        self.assertIsInstance(cache, RadixCache)
 
     def test_disable_radix_no_chunked_prefill_returns_disabled_radix(self):
-        result = build_kv_cache(
+        cache = build_kv_cache(
             server_args=_make_server_args(disable_radix_cache=True),
             model_config=_make_model_config(),
             req_to_token_pool=MagicMock(),
@@ -56,11 +53,11 @@ class TestBuildKVCache(unittest.TestCase):
         )
         from sgl_jax.srt.mem_cache.radix_cache import RadixCache
 
-        self.assertIsInstance(result.tree_cache, RadixCache)
-        self.assertTrue(result.tree_cache.disable)
+        self.assertIsInstance(cache, RadixCache)
+        self.assertTrue(cache.disable)
 
     def test_disable_radix_with_chunked_prefill_returns_chunk_cache(self):
-        result = build_kv_cache(
+        cache = build_kv_cache(
             server_args=_make_server_args(disable_radix_cache=True, chunked_prefill_size=8192),
             model_config=_make_model_config(),
             req_to_token_pool=MagicMock(),
@@ -73,13 +70,13 @@ class TestBuildKVCache(unittest.TestCase):
         )
         from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
 
-        self.assertIsInstance(result.tree_cache, ChunkCache)
+        self.assertIsInstance(cache, ChunkCache)
 
     def test_hybrid_returns_swa_radix_cache(self):
         from sgl_jax.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
 
         mock_allocator = MagicMock(spec=SWATokenToKVPoolAllocator)
-        result = build_kv_cache(
+        cache = build_kv_cache(
             server_args=_make_server_args(),
             model_config=_make_model_config(),
             req_to_token_pool=MagicMock(),
@@ -92,12 +89,10 @@ class TestBuildKVCache(unittest.TestCase):
         )
         from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
 
-        self.assertIsInstance(result.tree_cache, SWARadixCache)
-        self.assertTrue(result.is_hybrid_swa)
-        self.assertEqual(result.sliding_window_size, 4096)
+        self.assertIsInstance(cache, SWARadixCache)
 
     def test_hybrid_disable_radix_returns_swa_chunk_cache(self):
-        result = build_kv_cache(
+        cache = build_kv_cache(
             server_args=_make_server_args(disable_radix_cache=True),
             model_config=_make_model_config(),
             req_to_token_pool=MagicMock(),
@@ -110,12 +105,12 @@ class TestBuildKVCache(unittest.TestCase):
         )
         from sgl_jax.srt.mem_cache.chunk_cache import SWAChunkCache
 
-        self.assertIsInstance(result.tree_cache, SWAChunkCache)
+        self.assertIsInstance(cache, SWAChunkCache)
 
     def test_eagle_spec_algorithm(self):
         spec = MagicMock()
         spec.is_eagle.return_value = True
-        result = build_kv_cache(
+        cache = build_kv_cache(
             server_args=_make_server_args(),
             model_config=_make_model_config(),
             req_to_token_pool=MagicMock(),
@@ -128,8 +123,8 @@ class TestBuildKVCache(unittest.TestCase):
         )
         from sgl_jax.srt.mem_cache.radix_cache import RadixCache
 
-        self.assertIsInstance(result.tree_cache, RadixCache)
-        self.assertTrue(result.tree_cache.is_eagle)
+        self.assertIsInstance(cache, RadixCache)
+        self.assertTrue(cache.is_eagle)
 
 
 if __name__ == "__main__":

--- a/python/sgl_jax/test/test_kv_cache_builder.py
+++ b/python/sgl_jax/test/test_kv_cache_builder.py
@@ -1,0 +1,138 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sgl_jax.srt.mem_cache.kv_cache_builder import KVCacheBuildResult, build_kv_cache
+
+
+def _make_server_args(**overrides):
+    args = MagicMock()
+    args.disable_radix_cache = False
+    args.chunked_prefill_size = None
+    args.max_seq_len = 4096
+    for k, v in overrides.items():
+        setattr(args, k, v)
+    return args
+
+
+def _make_model_config():
+    config = MagicMock()
+    config.get_num_kv_heads.return_value = 8
+    config.head_dim = 128
+    config.num_hidden_layers = 32
+    return config
+
+
+class TestBuildKVCache(unittest.TestCase):
+    def test_default_returns_radix_cache(self):
+        result = build_kv_cache(
+            server_args=_make_server_args(),
+            model_config=_make_model_config(),
+            req_to_token_pool=MagicMock(),
+            token_to_kv_pool_allocator=MagicMock(),
+            page_size=1,
+            is_hybrid=False,
+            sliding_window_size=None,
+            tp_size=1,
+            spec_algorithm=None,
+        )
+        self.assertIsInstance(result, KVCacheBuildResult)
+        from sgl_jax.srt.mem_cache.radix_cache import RadixCache
+
+        self.assertIsInstance(result.tree_cache, RadixCache)
+        self.assertFalse(result.is_hybrid_swa)
+        self.assertIsNone(result.sliding_window_size)
+
+    def test_disable_radix_no_chunked_prefill_returns_disabled_radix(self):
+        result = build_kv_cache(
+            server_args=_make_server_args(disable_radix_cache=True),
+            model_config=_make_model_config(),
+            req_to_token_pool=MagicMock(),
+            token_to_kv_pool_allocator=MagicMock(),
+            page_size=1,
+            is_hybrid=False,
+            sliding_window_size=None,
+            tp_size=1,
+            spec_algorithm=None,
+        )
+        from sgl_jax.srt.mem_cache.radix_cache import RadixCache
+
+        self.assertIsInstance(result.tree_cache, RadixCache)
+        self.assertTrue(result.tree_cache.disable)
+
+    def test_disable_radix_with_chunked_prefill_returns_chunk_cache(self):
+        result = build_kv_cache(
+            server_args=_make_server_args(
+                disable_radix_cache=True, chunked_prefill_size=8192
+            ),
+            model_config=_make_model_config(),
+            req_to_token_pool=MagicMock(),
+            token_to_kv_pool_allocator=MagicMock(),
+            page_size=1,
+            is_hybrid=False,
+            sliding_window_size=None,
+            tp_size=1,
+            spec_algorithm=None,
+        )
+        from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
+
+        self.assertIsInstance(result.tree_cache, ChunkCache)
+
+    def test_hybrid_returns_swa_radix_cache(self):
+        from sgl_jax.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
+
+        mock_allocator = MagicMock(spec=SWATokenToKVPoolAllocator)
+        result = build_kv_cache(
+            server_args=_make_server_args(),
+            model_config=_make_model_config(),
+            req_to_token_pool=MagicMock(),
+            token_to_kv_pool_allocator=mock_allocator,
+            page_size=1,
+            is_hybrid=True,
+            sliding_window_size=4096,
+            tp_size=1,
+            spec_algorithm=None,
+        )
+        from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
+
+        self.assertIsInstance(result.tree_cache, SWARadixCache)
+        self.assertTrue(result.is_hybrid_swa)
+        self.assertEqual(result.sliding_window_size, 4096)
+
+    def test_hybrid_disable_radix_returns_swa_chunk_cache(self):
+        result = build_kv_cache(
+            server_args=_make_server_args(disable_radix_cache=True),
+            model_config=_make_model_config(),
+            req_to_token_pool=MagicMock(),
+            token_to_kv_pool_allocator=MagicMock(),
+            page_size=1,
+            is_hybrid=True,
+            sliding_window_size=4096,
+            tp_size=1,
+            spec_algorithm=None,
+        )
+        from sgl_jax.srt.mem_cache.chunk_cache import SWAChunkCache
+
+        self.assertIsInstance(result.tree_cache, SWAChunkCache)
+
+    def test_eagle_spec_algorithm(self):
+        spec = MagicMock()
+        spec.is_eagle.return_value = True
+        result = build_kv_cache(
+            server_args=_make_server_args(),
+            model_config=_make_model_config(),
+            req_to_token_pool=MagicMock(),
+            token_to_kv_pool_allocator=MagicMock(),
+            page_size=1,
+            is_hybrid=False,
+            sliding_window_size=None,
+            tp_size=1,
+            spec_algorithm=spec,
+        )
+        from sgl_jax.srt.mem_cache.radix_cache import RadixCache
+
+        self.assertIsInstance(result.tree_cache, RadixCache)
+        self.assertTrue(result.tree_cache.is_eagle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -292,6 +292,7 @@ suites = {
         TestFile("python/sgl_jax/test/mem_cache/test_swa_radix_cache.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_radix_cache.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_paged_allocator_multi_dp.py", 1),
+        TestFile("python/sgl_jax/test/test_kv_cache_builder.py", 0.1, runner="pytest"),
         TestFile("test/srt/function_call/test_qwen3_coder_detector.py", 0.1),
         TestFile("test/srt/function_call/test_glm4_moe_detector.py", 0.1),
         TestFile("test/srt/function_call/test_qwen25_detector.py", 0.1),


### PR DESCRIPTION
## Summary
- Port `kv_cache_builder` module structure from upstream sglang (PR #25602-#25607, #25101)
- Extract cache selection logic from `Scheduler.init_memory_pool_and_cache()` into three dedicated files:
  - `cache_init_params.py`: `CacheInitParams` dataclass for bundling cache construction parameters
  - `registry.py`: `TreeCacheBuildContext` + `default_radix_cache_factory` + `create_tree_cache` (cache selection chain)
  - `kv_cache_builder.py`: `build_kv_cache()` entry point + `KVCacheBuildResult`
- Pure refactor, no behavioral changes — same server args produce the same cache type

## Motivation
Prepares the cache subsystem for RFC-1 (HiCache / UnifiedRadixCache) and RFC-2 (PD disaggregation). New cache types can be added in `registry.py` without modifying the scheduler.

## Test plan
- [x] 6 new unit tests covering all cache selection branches (`test_kv_cache_builder.py`)
- [x] All existing `mem_cache/` tests pass (radix_cache, swa_radix_cache, allocator, etc.)
- [x] No changes to existing cache constructors or `ServerArgs`