### PR TITLE
feat(ci): /run-nightly slash command for single nightly cases on PRs (#1208)

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -1,5 +1,11 @@
 name: Nightly Test Daily
 
+# Inputs (ref/job_filter/cases/pr_number) drive a single-case run on a PR. run-name
+# tags manual workflow_dispatch runs by PR + case; under /run-nightly this is invoked
+# as a reusable workflow, where the run is named by the caller (Slash Command Handler).
+run-name: >-
+  ${{ inputs.pr_number != '' && format('Nightly Test Daily — PR #{0} {1}', inputs.pr_number, inputs.cases || inputs.job_filter) || 'Nightly Test Daily' }}
+
 # NOTE: The daily nightly suites are currently empty shells. Coverage will be
 # redefined as part of the nightly vs daily split decision. The workflow is
 # kept so any new daily case can be added by populating run_suite.py without
@@ -14,8 +20,52 @@ on:
     paths:
       - "python/sgl_jax/version.py"
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to test (PR HEAD for /run-nightly). Empty = this workflow's ref."
+        required: false
+        type: string
+      job_filter:
+        description: "Run only this job (its name). Empty or 'all' runs every daily job."
+        required: false
+        type: string
+        default: "all"
+      cases:
+        description: "Comma-separated case name(s) for single_host/suite_runner.py --cases. Empty = whole suite."
+        required: false
+        type: string
+      pr_number:
+        description: "PR number to comment results on (for /run-nightly). Empty = no comment."
+        required: false
+        type: string
+  # Reusable entry for /run-nightly: invoked via `uses:` from slash-command.yml, so a
+  # PR-triggered nightly is part of the Slash Command Handler run — no standalone
+  # "Nightly Test Daily" run, so the notifier / auto-bisect that watch it don't fire.
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to test (PR HEAD for /run-nightly). Empty = this workflow's ref."
+        required: false
+        type: string
+      job_filter:
+        description: "Run only this job (its name). Empty or 'all' runs every daily job."
+        required: false
+        type: string
+        default: "all"
+      cases:
+        description: "Comma-separated case name(s) for single_host/suite_runner.py --cases. Empty = whole suite."
+        required: false
+        type: string
+      pr_number:
+        description: "PR number to comment results on (for /run-nightly). Empty = no comment."
+        required: false
+        type: string
+
 concurrency:
-  group: nightly-test-daily-${{ github.ref }}
+  # Key by tested ref + job + case: a /run-nightly never cancels the scheduled main
+  # run, and two cases mapping to the same job don't cancel each other (only a repeat
+  # of the same case collapses).
+  group: nightly-test-daily-${{ inputs.ref || github.ref }}-${{ inputs.job_filter || 'all' }}-${{ inputs.cases || 'all' }}
   cancel-in-progress: true
 
 permissions:
@@ -24,7 +74,7 @@ permissions:
 jobs:
 
   nightly-test-accuracy-text-models-1-tpu-daily:
-    if: github.repository == 'sgl-project/sglang-jax'
+    if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-accuracy-text-models-1-tpu-daily')
     runs-on: arc-runner-v6e-1
     env:
       TZ: Asia/Shanghai
@@ -34,6 +84,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
       - name: Run accuracy daily suite
@@ -43,7 +95,7 @@ jobs:
           python3 run_suite.py --suite nightly-test-accuracy-text-models-tpu-v6e-1-daily
 
   nightly-test-perf-text-models-1-tpu-daily:
-    if: github.repository == 'sgl-project/sglang-jax'
+    if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-perf-text-models-1-tpu-daily')
     runs-on: arc-runner-v6e-1
     env:
       TZ: Asia/Shanghai
@@ -53,6 +105,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
       - name: Run perf daily suite
@@ -62,7 +116,7 @@ jobs:
           python3 run_suite.py --suite nightly-test-perf-text-models-tpu-v6e-1-daily
 
   nightly-test-openai-api-surface-1-tpu-daily:
-    if: github.repository == 'sgl-project/sglang-jax'
+    if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-openai-api-surface-1-tpu-daily')
     runs-on: arc-runner-v6e-1
     env:
       TZ: Asia/Shanghai
@@ -72,6 +126,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
       - name: Run OpenAI API surface tests
@@ -90,7 +146,7 @@ jobs:
     secrets: inherit
 
   nightly-infra-smoke-1-tpu-daily:
-    if: github.repository == 'sgl-project/sglang-jax'
+    if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-infra-smoke-1-tpu-daily')
     runs-on: arc-runner-v6e-1
     env:
       TZ: Asia/Shanghai
@@ -100,6 +156,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
       - name: Run infra smoke tests
@@ -109,8 +167,12 @@ jobs:
           python3 run_suite.py --suite nightly-infra-smoke-tpu-v6e-1
 
   nightly-test-accuracy-text-models-4-tpu-daily:
-    if: github.repository == 'sgl-project/sglang-jax'
+    if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-accuracy-text-models-4-tpu-daily')
     runs-on: arc-runner-v6e-4
+    # Read-only + persist-credentials:false — this job runs PR-HEAD code, so it must not
+    # hold a write token; PASS/FAIL is posted from the separate comment job below.
+    permissions:
+      contents: read
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -118,17 +180,53 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
       - name: Run 4-TPU accuracy daily suite
+        id: run
         timeout-minutes: 150
+        env:
+          # /run-nightly passes a single case name here; empty runs the whole suite.
+          CASES: ${{ inputs.cases }}
         run: |
           cd test/srt
-          python3 nightly/single_host/suite_runner.py --suite accuracy-text-models-v6e-4
+          python3 nightly/single_host/suite_runner.py --suite accuracy-text-models-v6e-4 ${CASES:+--cases "$CASES"}
+
+  nightly-test-accuracy-4-tpu-comment:
+    # Posts PASS/FAIL from a clean job (no PR-HEAD code ran here) so the write token
+    # never shares an environment the PR could have tampered with. Skips cancelled
+    # (superseded) / skipped runs.
+    needs: nightly-test-accuracy-text-models-4-tpu-daily
+    if: >-
+      always() && inputs.pr_number != ''
+      && contains(fromJSON('["success", "failure"]'), needs.nightly-test-accuracy-text-models-4-tpu-daily.result)
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment result on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          CASE_KEY: ${{ inputs.cases || 'accuracy-text-models-v6e-4' }}
+          RESULT: ${{ needs.nightly-test-accuracy-text-models-4-tpu-daily.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "$RESULT" = "success" ]; then status="PASS"; else status="FAIL"; fi
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "> **Nightly** [\`$CASE_KEY\`]($RUN_URL): **$status** — see the run's step summary for the score."
 
   nightly-test-perf-text-models-4-tpu-daily:
-    if: github.repository == 'sgl-project/sglang-jax'
+    if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-perf-text-models-4-tpu-daily')
     runs-on: arc-runner-v6e-4
+    # Read-only + persist-credentials:false — runs PR-HEAD code, no write token here;
+    # PASS/FAIL is posted from the separate comment job below.
+    permissions:
+      contents: read
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -138,19 +236,26 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
       - name: Run 4-TPU perf daily suite
+        id: run
         timeout-minutes: 480
         env:
-          # Token for the trailing-baseline gate's ci-data reads (anonymous API
-          # gets rate-limited, silently disabling the trailing gate).
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          # ci-data reads for the trailing-baseline gate (anonymous API gets
+          # rate-limited, disabling that gate). Scheduled runs only — never hand the
+          # PAT to PR-HEAD code, which a /run-nightly dispatch executes here.
+          GITHUB_TOKEN: ${{ inputs.pr_number == '' && secrets.GH_PAT_FOR_NIGHTLY_CI_DATA || '' }}
+          # /run-nightly passes a single case name here; empty runs the whole suite.
+          CASES: ${{ inputs.cases }}
         run: |
           cd test/srt
-          python3 nightly/single_host/suite_runner.py --suite perf-text-models-v6e-4
+          python3 nightly/single_host/suite_runner.py --suite perf-text-models-v6e-4 ${CASES:+--cases "$CASES"}
       - name: Publish perf CSV to ci-data (main only)
-        if: github.ref == 'refs/heads/main' && github.repository == 'sgl-project/sglang-jax'
+        if: github.ref == 'refs/heads/main' && github.repository == 'sgl-project/sglang-jax' && inputs.pr_number == ''
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
           GITHUB_RUN_ID: ${{ github.run_id }}
@@ -167,7 +272,7 @@ jobs:
             echo "::warning::No perf CSV to publish — suite produced no per-model CSV"
           fi
       - name: Publish perf traces to ci-data (main only)
-        if: github.ref == 'refs/heads/main' && github.repository == 'sgl-project/sglang-jax'
+        if: github.ref == 'refs/heads/main' && github.repository == 'sgl-project/sglang-jax' && inputs.pr_number == ''
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
           GITHUB_RUN_ID: ${{ github.run_id }}
@@ -183,7 +288,7 @@ jobs:
             echo "::warning::No perf traces to publish"
           fi
       - name: Publish perf JSON to observability dashboard mount (main only)
-        if: github.ref == 'refs/heads/main' && github.repository == 'sgl-project/sglang-jax'
+        if: github.ref == 'refs/heads/main' && github.repository == 'sgl-project/sglang-jax' && inputs.pr_number == ''
         run: |
           # observability bucket is gcsfuse-mounted (like /models), so this is a
           # plain copy; layout matches multi-host, single-host- prefix marks source.
@@ -202,6 +307,30 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
+  nightly-test-perf-4-tpu-comment:
+    # Same trust-boundary split as the accuracy comment job: PASS/FAIL posted from a
+    # clean job that never ran PR-HEAD code. Skips cancelled (superseded) / skipped.
+    needs: nightly-test-perf-text-models-4-tpu-daily
+    if: >-
+      always() && inputs.pr_number != ''
+      && contains(fromJSON('["success", "failure"]'), needs.nightly-test-perf-text-models-4-tpu-daily.result)
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment result on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          CASE_KEY: ${{ inputs.cases || 'perf-text-models-v6e-4' }}
+          RESULT: ${{ needs.nightly-test-perf-text-models-4-tpu-daily.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "$RESULT" = "success" ]; then status="PASS"; else status="FAIL"; fi
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "> **Nightly (perf)** [\`$CASE_KEY\`]($RUN_URL): **$status** — see the run's step summary."
+
   nightly-test-daily-finish:
     needs: [
       nightly-test-accuracy-text-models-1-tpu-daily,
@@ -212,7 +341,7 @@ jobs:
       nightly-test-accuracy-text-models-4-tpu-daily,
       nightly-test-perf-text-models-4-tpu-daily,
     ]
-    if: always() && github.repository == 'sgl-project/sglang-jax'
+    if: always() && github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all')
     runs-on: ubuntu-latest
     steps:
       - name: Check all daily job statuses

--- a/.github/workflows/slash-command.yml
+++ b/.github/workflows/slash-command.yml
@@ -10,16 +10,27 @@ jobs:
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/')
     runs-on: ubuntu-latest
+    # Per-job least privilege: handle-command parses untrusted comment text, so it gets
+    # only what its own steps need (reactions, replies, dispatching rerun-test).
     permissions:
       contents: read
       issues: write
       pull-requests: write
       actions: write
+    outputs:
+      action: ${{ steps.parse.outputs.action }}
+      pull_ref: ${{ steps.pr.outputs.pull_ref }}
+      nightly_job: ${{ steps.parse.outputs.nightly_job }}
+      nightly_cases: ${{ steps.parse.outputs.nightly_cases }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          sparse-checkout: scripts/ci
+          # test/srt/nightly: the slash parser enumerates the suite catalog by
+          # running suite_runner.py --caselist to derive /run-nightly cases.
+          sparse-checkout: |
+            scripts/ci
+            test/srt/nightly
 
       - name: Get PR head branch
         id: pr
@@ -27,8 +38,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
+          # pull_ref (refs/pull/<N>/head) is what /run-nightly dispatches against —
+          # a fork PR's branch name isn't in the base repo. head_ref is for display.
           head_ref=$(gh pr view "$PR_NUMBER" --json headRefName --jq .headRefName)
           echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
+          echo "pull_ref=refs/pull/$PR_NUMBER/head" >> "$GITHUB_OUTPUT"
 
       - name: Parse slash command
         id: parse
@@ -39,7 +53,8 @@ jobs:
         run: python3 scripts/ci/slash_command_parse.py
 
       - name: React to comment
-        if: steps.parse.outputs.valid == 'true' && steps.parse.outputs.permitted == 'true'
+        # run-nightly gets 🚀 from its own step below (not 👍), so exclude it here.
+        if: steps.parse.outputs.valid == 'true' && steps.parse.outputs.permitted == 'true' && steps.parse.outputs.command != 'run-nightly'
         env:
           GH_TOKEN: ${{ github.token }}
           COMMENT_ID: ${{ github.event.comment.id }}
@@ -70,6 +85,22 @@ jobs:
         run: |
           gh pr comment "$PR_NUMBER" \
             --body "> **Slash command error**: $ERROR_MSG"
+
+      - name: React confused on invalid run-nightly
+        # Bad case_key: 😕 for an at-a-glance signal; the "Reply on command error"
+        # comment above carries the detail (valid chars / valid keys).
+        if: >-
+          steps.parse.outputs.valid == 'true' &&
+          steps.parse.outputs.permitted == 'true' &&
+          steps.parse.outputs.command == 'run-nightly' &&
+          steps.parse.outputs.error != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api repos/"$REPO"/issues/comments/"$COMMENT_ID"/reactions \
+            -f content='confused' --silent
 
       - name: Rerun failed jobs
         if: >-
@@ -129,3 +160,69 @@ jobs:
           STAGE: ${{ steps.parse.outputs.stage }}
           STAGE_SUITES_JSON: ${{ steps.parse.outputs.stage_suites_json }}
         run: python3 scripts/ci/slash_command_stage_dispatch.py
+
+      - name: List nightly cases
+        # `/run-nightly` (no arg) or `/run-nightly ?` → reply with the available
+        # case_keys. An on-demand answer (so a comment is fine, not noise),
+        # derived from the suite catalog so it can't drift.
+        if: >-
+          steps.parse.outputs.valid == 'true' &&
+          steps.parse.outputs.permitted == 'true' &&
+          steps.parse.outputs.action == 'list_nightly'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          body=$(python3 -c "import sys; sys.path.insert(0, 'scripts/ci'); from slash_command_parse import format_nightly_list; print(format_nightly_list())")
+          gh pr comment "$PR_NUMBER" --body "$body"
+
+      - name: React rocket on run-nightly
+        # 🚀 = the nightly started; it comments PASS/FAIL back when done. The actual
+        # run is the run-nightly job below (a reusable workflow). Bad keys got 😕 above.
+        if: >-
+          steps.parse.outputs.valid == 'true' &&
+          steps.parse.outputs.permitted == 'true' &&
+          steps.parse.outputs.action == 'run_nightly'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api repos/"$REPO"/issues/comments/"$COMMENT_ID"/reactions \
+            -f content='rocket' --silent
+
+  run-nightly:
+    # One nightly case on the PR HEAD, run as a reusable workflow so it stays part of
+    # this run — no standalone "Nightly Test Daily" run for the notifier/auto-bisect to
+    # mistake for the scheduled nightly. Comments PASS/FAIL back via pr_number.
+    needs: handle-command
+    if: needs.handle-command.outputs.action == 'run_nightly'
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/nightly-test-daily.yml
+    with:
+      ref: ${{ needs.handle-command.outputs.pull_ref }}
+      job_filter: ${{ needs.handle-command.outputs.nightly_job }}
+      cases: ${{ needs.handle-command.outputs.nightly_cases }}
+      pr_number: ${{ github.event.issue.number }}
+    secrets: inherit
+
+  bisect-on-nightly-failure:
+    # On a failed /run-nightly, dispatch ci-auto-bisect to analyze this run and comment
+    # the root cause on the PR. issue_number is explicit (this run's head_branch=main).
+    needs: run-nightly
+    if: always() && needs.run-nightly.result == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Trigger AI bisect on the failed nightly run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run ci-auto-bisect.yml \
+            -f run_id=${{ github.run_id }} \
+            -f issue_number=${{ github.event.issue.number }}

--- a/docs/developer_guide/ci_architecture.md
+++ b/docs/developer_guide/ci_architecture.md
@@ -60,6 +60,13 @@ re-running the entire workflow.
 - `OWNER`, `MEMBER`, `COLLABORATOR` — allowed
 - All other associations — rejected with a reply comment
 
+> **Fork-PR safety:** these commands run the PR HEAD code on a runner with elevated
+> permissions (`pull-requests: write`, GKE/GCP OIDC, inherited secrets). The only
+> gate is the permission model above — same trust model as `/rerun-group` /
+> `/rerun-stage`. **Review a fork PR's diff before commenting `/run-nightly` (or any
+> rerun command) on it**, since you are authorizing untrusted code to run with those
+> permissions.
+
 *Supported Commands:*
 
 | Command | Description |
@@ -68,6 +75,16 @@ re-running the entire workflow.
 | `/test perf` | Add the `test:perf` label — the label event triggers CI with perf tests enabled |
 | `/rerun-group <suite>` | Run a specific test suite on the matching runner via `rerun-test.yml`. Suite names from `test/srt/run_suite.py`; runner derived from suffix (`-v6e-1`, `-v6e-4`, `-cpu`) |
 | `/rerun-stage <stage>` | Dispatch all suites in a stage independently via `rerun-test.yml`. Stage: `1`/`fast` (unit), `2`/`medium` (e2e+accuracy), `3`/`heavy` (performance) |
+| `/run-nightly <case_key>` | Run a single nightly case against the PR HEAD via `nightly-test-daily.yml` (`job_filter` + `--cases`); the result is posted back on the PR. `<case_key>` is a case name (e.g. `qwen3-8b-fa`). A 🚀 reaction marks the nightly as started (it comments PASS/FAIL back); an invalid key gets 😕 plus the valid list; a failed case also gets an AI bisect comment |
+| `/run-nightly` or `/run-nightly ?` | List the available `case_key`s (grouped by job). Use this to discover what you can run |
+
+*Where the case_keys come from:* not a hand-maintained list — the slash parser enumerates the single-host suite runner's catalog by invoking its `--caselist` (`test/srt/nightly/single_host/suite_runner.py`, a subprocess; the case list is dependency-light and needs no jax, so it runs on the CPU runner), so **adding a case to a suite makes it runnable via `/run-nightly` with nothing else to update**. It exposes all accuracy cases plus each perf model's representative point (`PerfCase.capture_trace`), since the sweep's other points only make sense as a set. Multi-host is not wired into `/run-nightly` — its nightly job stays `if: false` until CI has 4-node v6e capacity. The parser holds only a single-host suite→job map; any suite the runner exposes but the map doesn't name is silently skipped.
+
+*Using `/run-nightly` (maintainers):*
+- **Discover:** comment `/run-nightly ?` (or bare `/run-nightly`) → it replies with the runnable `case_key`s, grouped by job.
+- **Run one case:** comment `/run-nightly <case_key>` — e.g. `/run-nightly qwen3-8b-fa` (an accuracy case) or `/run-nightly qwen3-32b-c32-i4096-o1024` (a perf representative point). It runs that one case against the PR HEAD.
+- **Who can trigger:** `OWNER` / `MEMBER` / `COLLABORATOR` only (the shared slash-command permission gate); anyone else is rejected. Review a fork PR's diff first — this runs PR-HEAD code with elevated permissions.
+- **What you get:** a 🚀 reaction when the run starts, then a `PASS`/`FAIL` comment (with a run link) when it finishes. An invalid `case_key` gets a 😕 reaction plus the list of valid keys; a failed case also gets an AI root-cause (`ci-auto-bisect`) comment.
 
 *Architecture:*
 - `scripts/ci/slash_command_parse.py` — pure-Python parser (stdlib only), reads
@@ -77,7 +94,15 @@ re-running the entire workflow.
   loops through each suite in the stage and dispatches `rerun-test.yml` independently
 - `rerun-test.yml` — `workflow_dispatch` workflow for `/rerun-group` and `/rerun-stage`,
   accepts suite name, runner label, and git ref as inputs
-- The handler workflow reacts with thumbs-up and posts result comments on the PR
+- `nightly-test-daily.yml` — exposes `workflow_call`; `/run-nightly` invokes it as a
+  reusable workflow (`uses:` from slash-command.yml) with `ref=refs/pull/<N>/head`
+  (resolves for fork PRs too), `job_filter`, `cases`, and `pr_number`. Running it via
+  `uses:` keeps the nightly part of the Slash Command Handler run, so it never appears
+  as a standalone "Nightly Test Daily" run for the notifier / auto-bisect to mistake
+  for the scheduled nightly. The run job (read-only, no write token) executes the case; a separate clean job posts PASS/FAIL back to the PR
+- Most commands react 👍 and post result comments; `/run-nightly` instead reacts
+  🚀 when the nightly starts / 😕 on an invalid key, to keep the PR thread quiet — only
+  the final PASS/FAIL (and the on-demand case list) are comments
 
 ### PR Review (pr-review.yml)
 

--- a/scripts/ci/slash_command_parse.py
+++ b/scripts/ci/slash_command_parse.py
@@ -8,13 +8,111 @@ and writes results to $GITHUB_OUTPUT.
 import json
 import os
 import re
+import subprocess
 import sys
 
 ALLOWED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 
-VALID_COMMANDS = {"rerun-failed-ci", "test", "rerun-group", "rerun-stage"}
+VALID_COMMANDS = {
+    "rerun-failed-ci",
+    "test",
+    "rerun-group",
+    "rerun-stage",
+    "run-nightly",
+}
 
 _SAFE_ARG_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+# case_key = a real case name (lowercase, e.g. "qwen3-8b-fa" or
+# "qwen3-32b-c32-i4096-o1024"), so the charset includes hyphens.
+_CASE_KEY_RE = re.compile(r"[^a-z0-9_.-]")
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Single-host suite -> its nightly-test-daily.yml job (job_filter value). case_keys
+# aren't listed here — they're derived from the catalog (single source of truth),
+# so adding a case to a suite needs no change here.
+_SINGLE_HOST_SUITE_JOBS = {
+    "accuracy-text-models-v6e-4": "nightly-test-accuracy-text-models-4-tpu-daily",
+    "perf-text-models-v6e-4": "nightly-test-perf-text-models-4-tpu-daily",
+}
+# Multi-host (the mimo-flash suite) is intentionally NOT wired into /run-nightly: its
+# nightly job stays `if: false` until multi-host CI has 4-node v6e capacity. To enable
+# later, add a suite->job map here and enumerate it in nightly_index().
+
+
+class NightlyEnumerationError(RuntimeError):
+    """Raised when a suite runner's --caselist can't be enumerated."""
+
+
+def _run_caselist(runner_relpath: str) -> list[dict]:
+    """Enumerate a runner's cases via its --caselist CLI (a subprocess).
+
+    Mirrors pytest's `--collect-only`: the suite runner owns its case list and
+    prints it as JSON; we don't import it (it's stdlib-only for --caselist, but a
+    subprocess keeps the parser's import space clean and isolates failures). Runs
+    on a plain CPU runner — --caselist needs no jax. The timeout guards the slash
+    handler against a catalog that hangs at import. Raises on non-zero exit.
+    """
+    path = os.path.join(_REPO_ROOT, "test", "srt", "nightly", runner_relpath)
+    try:
+        proc = subprocess.run(
+            [sys.executable, path, "--caselist"], capture_output=True, text=True, timeout=60
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise NightlyEnumerationError(
+            f"{runner_relpath} --caselist timed out after {exc.timeout:.0f}s"
+        ) from exc
+    if proc.returncode != 0:
+        raise NightlyEnumerationError(
+            f"{runner_relpath} --caselist failed (exit {proc.returncode}): "
+            f"{proc.stderr.strip()[:300]}"
+        )
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise NightlyEnumerationError(f"{runner_relpath} --caselist bad JSON: {exc}") from exc
+    if not isinstance(data, list) or not all(isinstance(entry, dict) for entry in data):
+        raise NightlyEnumerationError(f"{runner_relpath} --caselist must be a JSON list of objects")
+    return data
+
+
+def nightly_index() -> dict[str, tuple[str, str]]:
+    """Map each runnable case_key -> (job, cases-arg for suite_runner --cases).
+
+    The single-host runner self-enumerates via --caselist; this maps the suites it
+    exposes to a job name, one key per case (cases=case). Multi-host is not wired in
+    (see _SINGLE_HOST_SUITE_JOBS note above).
+    """
+    index: dict[str, tuple[str, str]] = {}
+    for entry in _run_caselist("single_host/suite_runner.py"):
+        suite, case = entry.get("suite"), entry.get("case")
+        if suite is None or case is None:
+            continue
+        job = _SINGLE_HOST_SUITE_JOBS.get(suite)
+        if job is None:
+            continue
+        index[case] = (job, case)
+    return index
+
+
+def format_nightly_list():
+    """Render the runnable /run-nightly case_keys, grouped by job."""
+    try:
+        index = nightly_index()
+    except NightlyEnumerationError as exc:
+        return f"Could not list nightly cases: {exc}"
+    by_job: dict[str, list[str]] = {}
+    for key, (job, _cases) in index.items():
+        by_job.setdefault(job, []).append(key)
+    lines = ["**Available `/run-nightly` cases:**", ""]
+    for job in sorted(by_job):
+        names = ", ".join(f"`{k}`" for k in sorted(by_job[job]))
+        lines.append(f"- `{job}`: {names}")
+    lines.append("")
+    lines.append("Usage: `/run-nightly <case_key>` — e.g. `/run-nightly qwen3-8b-fa`")
+    return "\n".join(lines)
+
 
 RUNNER_SUFFIXES = [
     ("-cpu", "arc-runner-cpu"),
@@ -101,11 +199,13 @@ def resolve_jobs(command, args):
 
     Keys:
         action     — "rerun_failed" | "add_label" | "rerun_group" | "rerun_stage"
+                     | "run_nightly"
         suite      — test suite name (for rerun-group)
         runner     — runner label (for rerun-group)
         labels     — labels to add to the PR
         stage      — canonical stage name (for rerun-stage)
         jobs       — list of pr-test.yml job names (for rerun-stage)
+        nightly_*  — job / cases / case_key (for run-nightly)
         error      — non-empty string on invalid input
     """
     result = {
@@ -116,6 +216,9 @@ def resolve_jobs(command, args):
         "error": "",
         "stage": "",
         "jobs": [],
+        "nightly_job": "",
+        "nightly_cases": "",
+        "nightly_case_key": "",
     }
 
     if command == "rerun-failed-ci":
@@ -164,6 +267,37 @@ def resolve_jobs(command, args):
         result["action"] = "rerun_stage"
         result["stage"] = stage
         result["jobs"] = STAGE_JOBS[stage]
+        return result
+
+    if command == "run-nightly":
+        # No arg or "?" → list cases instead of erroring ("?" mirrors Prow's
+        # /test ?, but a bare /run-nightly should be just as discoverable).
+        if not args or args[0] == "?":
+            result["action"] = "list_nightly"
+            return result
+        case_key = args[0].lower()
+        # Reject malformed keys (don't silently strip) so the error names what was
+        # typed. Echo with only illegal chars removed; the kept set is
+        # injection-safe, "<empty>" if every char was illegal.
+        if _CASE_KEY_RE.search(case_key):
+            safe = _CASE_KEY_RE.sub("", case_key)[:60] or "<empty>"
+            result["error"] = f"Invalid case_key '{safe}'. Allowed characters: [a-z0-9_.-]"
+            return result
+        try:
+            index = nightly_index()
+        except NightlyEnumerationError as exc:
+            result["error"] = f"Could not list nightly cases: {exc}"
+            return result
+        entry = index.get(case_key)
+        if entry is None:
+            valid = ", ".join(sorted(index))
+            result["error"] = f"Unknown case_key '{case_key}'. Valid: {valid}"
+            return result
+        job, cases = entry
+        result["action"] = "run_nightly"
+        result["nightly_job"] = job
+        result["nightly_cases"] = cases
+        result["nightly_case_key"] = case_key
         return result
 
     result["error"] = f"Unknown command '{command}'"
@@ -241,6 +375,10 @@ def main():
             suite_name, runner = JOB_TO_SUITE[job]
             suites.append({"suite": suite_name, "runner": runner})
         outputs["stage_suites_json"] = json.dumps(suites)
+    if job_info["action"] == "run_nightly":
+        outputs["nightly_job"] = job_info["nightly_job"]
+        outputs["nightly_cases"] = job_info["nightly_cases"]
+        outputs["nightly_case_key"] = job_info["nightly_case_key"]
 
     write_outputs(outputs)
 
@@ -258,6 +396,11 @@ def main():
     if job_info["stage"]:
         print(f"stage: {job_info['stage']}")
         print(f"jobs: {', '.join(job_info['jobs'])}")
+    if job_info["action"] == "run_nightly":
+        print(f"case_key: {job_info['nightly_case_key']}")
+        print(f"nightly_job: {job_info['nightly_job']}")
+        if job_info["nightly_cases"]:
+            print(f"nightly_cases: {job_info['nightly_cases']}")
 
 
 if __name__ == "__main__":

--- a/test/srt/nightly/cases.py
+++ b/test/srt/nightly/cases.py
@@ -10,6 +10,8 @@ Multi-host-only types (``RuntimeConfig``, ``ModelRun``, ``MultiHostSuite``, the
 launch-profile validators) stay in ``test/srt/nightly/multi_host/multi_host_suite.py``.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -155,3 +157,8 @@ class AccuracyCase:
     limit: int | None = None
     timeout: int | None = None
     score_threshold: float | None = None
+
+
+# Default gsm8k sampling (greedy). Lives here (host-neutral, stdlib-only) so the
+# suite catalog can build cases without importing the jax-backed case runners.
+GSM8K_GENERATION_CONFIG = {"temperature": 0.0, "max_tokens": 2048}

--- a/test/srt/nightly/multi_host/multi_host_suite.py
+++ b/test/srt/nightly/multi_host/multi_host_suite.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from dataclasses import dataclass
@@ -9,11 +11,10 @@ for _p in (_TEST_SRT, _NIGHTLY_DIR, _SELF_DIR):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
-# Host-neutral contracts live in test/srt/nightly/{cases,profiles}.py.
-# Re-exported here so existing `from multi_host_suite import ...` imports across
-# the multi_host package keep working unchanged.
+# Re-export the host-neutral case contracts from cases.py so `from multi_host_suite
+# import ...` keeps working. Kept stdlib-only (no profiles/pydantic) so suite_runner.py's
+# module import stays light (e.g. for --dry-run); RuntimeConfig comes from profiles where used.
 from cases import AccuracyCase, PerfCase, SuiteError  # noqa: E402,F401
-from profiles import RuntimeConfig  # noqa: E402,F401
 
 
 @dataclass(frozen=True)

--- a/test/srt/nightly/multi_host/suite_runner.py
+++ b/test/srt/nightly/multi_host/suite_runner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import dataclasses
 import json
@@ -19,24 +21,24 @@ for _p in (_TEST_SRT, _NIGHTLY_DIR, _SELF_DIR):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
-from accuracy_case_runner import run_accuracy_case
 from multi_host_suite import (
     AccuracyCase,
     ModelRun,
     MultiHostSuite,
     PerfCase,
-    RuntimeConfig,
     SuiteError,
     dry_run_suite,
 )
+
+# Case runners, sgl_jax, and the pydantic/yaml profile loader are imported lazily in
+# the functions that use them, keeping module import light and jax-free (e.g. --dry-run);
+# `from __future__ import annotations` keeps the deferred types usable in signatures.
 
 # Exit codes consumed by the multi-host CI workflow's Classify step.
 EXIT_OK = 0
 EXIT_INFRA = 10  # server / runtime infra failure → caller may retry
 EXIT_THRESHOLD = 20  # case finished but score below threshold → do not retry
 EXIT_CASE_CRASH = 30  # case raised unexpectedly → bug, do not retry
-from perf_case_runner import run_perf_case
-from profile_loader import LaunchProfile, build_other_server_args, load_profile
 
 _control_state = {"done": False, "exit_code": 0}
 
@@ -120,6 +122,8 @@ def wait_for_done(control_url: str, server_process, timeout_seconds: int = 3600)
 
 
 def build_runtime_config(node_rank: int | None = None) -> RuntimeConfig:
+    from profiles import RuntimeConfig
+
     workload_name = _get_env("WORKLOAD_NAME")
     headless_service_name = _get_env("HEADLESS_SERVICE_NAME")
     resolved_node_rank = int(_get_env("JOB_COMPLETION_INDEX") if node_rank is None else node_rank)
@@ -136,6 +140,10 @@ def build_runtime_config(node_rank: int | None = None) -> RuntimeConfig:
 
 
 def run_case(case: PerfCase | AccuracyCase, profile: LaunchProfile) -> None:
+    # Lazy: pull jax in only to actually run a case (module import stays jax-free).
+    from accuracy_case_runner import run_accuracy_case
+    from perf_case_runner import run_perf_case
+
     if isinstance(case, PerfCase):
         run_perf_case(case, profile)
         return
@@ -147,6 +155,8 @@ def run_case(case: PerfCase | AccuracyCase, profile: LaunchProfile) -> None:
 
 
 def run_model_run(model_run: ModelRun, runtime_cfg: RuntimeConfig) -> int:
+    from profile_loader import build_other_server_args, load_profile
+
     from sgl_jax.srt.utils import kill_process_tree
     from sgl_jax.test.test_utils import popen_launch_server
 
@@ -313,6 +323,8 @@ def parse_args() -> argparse.Namespace:
 
 
 def select_suites(suite_name: str | None, target: str | None) -> list[MultiHostSuite]:
+    from profile_loader import load_profile
+
     suites = get_suites()
     if suite_name is not None:
         return [suites[suite_name]]

--- a/test/srt/nightly/single_host/accuracy_case_runner.py
+++ b/test/srt/nightly/single_host/accuracy_case_runner.py
@@ -39,11 +39,6 @@ _LAUNCH_PROFILES_DIR = os.path.join(_NIGHTLY_DIR, "launch_profiles")
 # server's HTTP port.
 _DIST_INIT_PORT_OFFSET = 5000
 
-# Default gsm8k sampling for the 4-TPU accuracy gates: greedy decode.
-# Cases reference this so every AccuracyCase carries an explicit
-# generation_config, matching the per-case convention.
-GSM8K_GENERATION_CONFIG = {"temperature": 0.0, "max_tokens": 2048}
-
 
 def _fmt(value: float | None) -> str:
     return f"{value:.4f}" if isinstance(value, (int, float)) else "N/A"

--- a/test/srt/nightly/single_host/suite_runner.py
+++ b/test/srt/nightly/single_host/suite_runner.py
@@ -13,6 +13,8 @@ Pass/fail is conveyed through the process exit code (same tagged codes as the
 multi-host runner) so CI can classify the result.
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import os
@@ -26,26 +28,17 @@ for _p in (_TEST_SRT, _NIGHTLY_DIR, _SELF_DIR):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
-from accuracy_case_runner import (  # noqa: E402
-    GSM8K_GENERATION_CONFIG,
-    load_profile_file,
-    profile_server_spec,
-    run_accuracy_case,
-)
 from cases import (  # noqa: E402
+    GSM8K_GENERATION_CONFIG,
     AccuracyCase,
     PerfCase,
     PerfParams,
     SuiteError,
     perf_sweep_cases,
 )
-from perf_case_runner import run_perf_case  # noqa: E402
 
-from sgl_jax.srt.utils import kill_process_tree  # noqa: E402
-from sgl_jax.test.test_utils import (  # noqa: E402
-    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-    popen_launch_server,
-)
+# Case runners and sgl_jax are imported lazily in run_one(), not here, so
+# --caselist can enumerate cases without jax (it runs on a plain CPU runner).
 
 # Exit codes consumed by CI (same scheme as multi_host/suite_runner.py).
 EXIT_OK = 0
@@ -241,6 +234,20 @@ def run_one(run: SingleHostRun) -> None:
     load, server launch) propagate as-is. ``AccuracyCase`` and ``PerfCase`` are
     dispatched by type to their case runner.
     """
+    # Lazy: pull jax in only to actually run a case (keeps --caselist jax-free).
+    from accuracy_case_runner import (
+        load_profile_file,
+        profile_server_spec,
+        run_accuracy_case,
+    )
+    from perf_case_runner import run_perf_case
+
+    from sgl_jax.srt.utils import kill_process_tree
+    from sgl_jax.test.test_utils import (
+        DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+        popen_launch_server,
+    )
+
     profile = load_profile_file(run.launch_profile)
     spec = profile_server_spec(profile)
     _log(f"launching {profile.name} (model={spec['model']}, base_url={spec['base_url']})")
@@ -329,14 +336,37 @@ def _dry_run(suite: SingleHostSuite) -> dict:
     }
 
 
+def _caselist() -> list[dict]:
+    """Runnable /run-nightly cases across all suites, as [{"suite", "case"}].
+
+    Perf exposes only its representative point (PerfCase.capture_trace) — the
+    sweep's other points only make sense as a set; accuracy cases have no such
+    attr so all are listed. Touches only the stdlib `cases` catalog (no jax), so
+    the slash handler can call this on a plain CPU runner.
+    """
+    out: list[dict] = []
+    for suite_name, suite in SUITES.items():
+        for run in suite.runs:
+            for case in run.cases:
+                if getattr(case, "capture_trace", True) is False:
+                    continue
+                out.append({"suite": suite_name, "case": case.name})
+    return out
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run single-host SGL-JAX nightly suites")
-    parser.add_argument("--suite", required=True, choices=sorted(SUITES))
+    parser.add_argument("--suite", choices=sorted(SUITES))
     parser.add_argument(
         "--cases",
-        help="Comma-separated case_keys; run only these (e.g. for /run-nightly targeting).",
+        help="Comma-separated case names; run only these (e.g. for /run-nightly targeting).",
     )
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--caselist",
+        action="store_true",
+        help="Print runnable case_keys as JSON and exit (no jax needed).",
+    )
     return parser.parse_args()
 
 
@@ -358,6 +388,11 @@ def _select_cases(suite: SingleHostSuite, cases: str | None) -> SingleHostSuite:
 
 def main() -> int:
     args = parse_args()
+    if args.caselist:
+        print(json.dumps(_caselist(), indent=2, sort_keys=True))
+        return EXIT_OK
+    if not args.suite:
+        raise SystemExit("--suite is required (unless --caselist)")
     suite = _select_cases(SUITES[args.suite], args.cases)
     if args.dry_run:
         print(json.dumps(_dry_run(suite), indent=2, sort_keys=True))


### PR DESCRIPTION
## Summary

`/run-nightly <case_key>` on an open PR runs that single nightly case against the
PR HEAD and posts the result back. Non-collaborators are rejected by the existing
slash-command permission gate. `/run-nightly` (no arg, or `?`) lists the runnable
keys.

Based on `main` (the `test/srt/nightly/` single- and multi-host runners + suites,
incl. the #1245 perf sweeps, are already merged).

## Design

- **case_keys derive from the suite catalog — no hand-written list.** The single-host
  suite runner self-exposes a `--caselist` flag; the parser enumerates keys by running it
  as a subprocess (à la `pytest --collect-only`). Adding a case to a suite makes it
  runnable with no parser change. Glob/regex on source can't see perf points, which
  `perf_sweep_cases()` generates at runtime — enumeration is the only correct way.
- **`--caselist` is dependency-light.** The single-host runner exposes `--caselist`
  and imports its jax-backed case runners and the pydantic/yaml profile loader lazily,
  so the parser enumerates cases on the plain CPU runner the slash handler uses.
  `from __future__ import annotations` on the catalog + runner keeps that path
  importable on any Python (PEP-604 annotations stay un-evaluated, not pinned to ≥3.10).
  The shared gsm8k config moved to the host-neutral `cases.py`. (The multi-host runner
  keeps the same lazy-import structure for parity, though it's not wired into `/run-nightly`.)
- **Granularity.** Single-host exposes one key per case — all accuracy cases plus
  each perf model's representative point (`PerfCase.capture_trace`); a sweep's other
  points only make sense as a set. Multi-host is not wired into `/run-nightly` (its
  nightly job stays `if: false` until CI has 4-node v6e capacity). The parser
  keeps only a single-host suite→job map; any suite the runner exposes but the map doesn't
  name is silently skipped.
- **Invocation (reusable workflow).** `nightly-test-daily.yml` exposes `workflow_call`;
  `/run-nightly` invokes it via `uses:` (not `gh workflow run`), so a PR-triggered
  nightly is **part of the Slash Command Handler run** — it never appears as a
  standalone "Nightly Test Daily" run, so the nightly notifier / auto-bisect that watch
  that workflow don't fire on it. Per-job `job_filter` gating picks the one case; the
  job checks out PR HEAD and runs `--cases`; a separate clean job posts PASS/FAIL. Scheduled behavior is
  unchanged. `pr_number` gates out the publish-to-ci-data steps, so a PR's perf numbers
  never enter the trailing baseline.
- **Fork-safe + quiet.** The reusable workflow's `ref` input is `refs/pull/<N>/head`
  (a fork PR's branch isn't in the base repo). The job that runs PR-HEAD code is
  read-only with `persist-credentials: false` and gets no ci-data PAT; PASS/FAIL is
  posted from a separate clean job — so PR code never shares an environment with a
  write-capable token. Feedback is
  reactions on the comment — 🚀 started, 😕 invalid — and only the final PASS/FAIL
  (with run link) and the invalid-key reply (with the valid list) stay as comments. A
  failed case also dispatches `ci-auto-bisect` for an AI root-cause comment on the PR.

## Available case_keys

Generated on demand by `/run-nightly ?`; never hand-maintained. Currently:

- **accuracy** (`nightly-test-accuracy-text-models-4-tpu-daily`): `qwen3-8b-fa`,
  `qwen3-32b-fa`, `ds-v2-lite-mla`, `ds-v2-lite-fa-gqa`, `qwen3-moe-epmoe`,
  `qwen3-moe-fused`, `kimi-linear-hybrid`, `qwen3-moe-fp8-epmoe`, `qwen3-moe-fp8-fused`
- **perf** representative points (`nightly-test-perf-text-models-4-tpu-daily`):
  `qwen3-32b-c32-i4096-o1024`, `qwen3-moe-epmoe-c64-i4096-o1024`, `qwen3-moe-fused-c64-i4096-o1024`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
