### PR TITLE
fix(multimodal): restore multimodal data-flow dropped by the DP refactor (input_embedding / mrope / deepstack)

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2390,7 +2390,48 @@ class ScheduleBatch:
             # Pad to total_bs
             lora_ids = lora_ids + ["0"] * (total_bs - real_bs)
 
-        # input_embedding = None
+        # Reassemble multimodal input_embedding (DP-aware).
+        #
+        # Mirrors the per-req slice/concat/pad logic from 785f3806 but scatters
+        # into the DP-interleaved padded token layout produced by
+        # _merge_input_and_positions: per-DP-rank slot stride is
+        # per_dp_token_padding, and within a rank the per-req EXTEND window is
+        # [prefix_len, seq_len) -- the same zip(info.seq_lens, info.prefix_lens)
+        # order used to build positions. The result aligns 1:1 with
+        # input_ids_cpu so forward_batch.input_embedding[k] matches
+        # input_ids[k]; trailing padding rows stay zero.
+        input_embedding = None
+        if self.forward_mode.is_extend() and any(
+            getattr(req, "multimodal_embedding", None) is not None
+            for info in self.reqs_info
+            if info.reqs
+            for req in info.reqs
+        ):
+            emb = None
+            offset = 0
+            for dp_rank in range(self.dp_size):
+                info = self.reqs_info[dp_rank]
+                if not info.reqs or info.seq_lens is None or len(info.seq_lens) == 0:
+                    offset += per_dp_token_padding
+                    continue
+                local = 0
+                for req, seq_len, prefix_len in zip(info.reqs, info.seq_lens, info.prefix_lens):
+                    ext_len = int(seq_len) - int(prefix_len)
+                    mm = getattr(req, "multimodal_embedding", None)
+                    if mm is not None and ext_len > 0:
+                        mm_full = np.asarray(mm)
+                        start = int(prefix_len or 0)
+                        end = start + ext_len
+                        chunk = mm_full[start:end]
+                        if emb is None:
+                            emb = np.zeros(
+                                (total_token_size, mm_full.shape[1]),
+                                dtype=mm_full.dtype,
+                            )
+                        emb[offset + local : offset + local + chunk.shape[0]] = chunk
+                    local += ext_len
+                offset += per_dp_token_padding
+            input_embedding = emb
 
         # Merge per-DP top_logprobs_nums / token_ids_logprobs with the same
         # offset_bs += per_dp_bs_padding padding scheme used in _merge_batch_metadata.
@@ -2496,7 +2537,7 @@ class ScheduleBatch:
             dp_size=self.dp_size,
             per_dp_bs_size=per_dp_bs_padding,
             launch_done=self.launch_done,
-            input_embedding=None,
+            input_embedding=input_embedding,
             apply_for_deepstack=False,
             deepstack_visual_embedding=None,
             recurrent_indices=recurrent_indices_cpu,

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1823,25 +1823,35 @@ class ScheduleBatch:
 
         return input_ids_cpu, positions_cpu, out_cache_loc_cpu, real_input_ids_len
 
-    def _merge_mrope_positions(
+    def _merge_multimodal(
         self,
         per_dp_token_size: int,
         total_token_size: int,
-    ) -> np.ndarray | None:
-        """Merge 3-D mrope_positions from all DP ranks, aligned with input_ids.
+    ) -> dict:
+        """Assemble all per-token multimodal tensors in one DP-interleaved pass.
 
-        Mirrors the DP-interleaved rank-offset layout of
-        ``_merge_input_and_positions``: each DP rank occupies a
-        ``per_dp_token_size`` slot (offset advances per rank, padding columns
-        stay zero), and within a rank per-req positions are written in the same
-        ``[prefix_len, seq_len)`` extend-window order used to build input_ids,
-        so ``out[:, k]`` lines up with ``input_ids[k]``.
+        Single traversal of ``reqs_info[*].reqs`` that produces, on the same
+        rank-offset layout as ``_merge_input_and_positions`` (per-rank slot
+        stride ``per_dp_token_size``; within a rank the per-req EXTEND window
+        ``[prefix_len, seq_len)``), all three multimodal tensors at once:
 
-        Absorbs the per-req slice / delta / fallback logic of the former
-        single-rank ``_compute_mrope_positions_for_batch`` (orphaned by the DP
-        refactor de5287ed). Returns ``None`` when no request carries mrope data
-        so the model keeps its 1-D positions path (pure-text 0-diff).
+        - ``input_embedding`` ``[total_token_size, hidden]`` -- per-req merged
+          embedding sliced to its extend window.
+        - ``mrope_positions`` ``[3, total_token_size]`` -- 3-D mRoPE positions;
+          extend slices ``mm_positions[:, prefix:prefix+ext]`` (delta / arange
+          fallback), decode advances ``seq_len-1 (+delta)``.
+        - ``deepstack_visual_embedding`` ``[num_layers, total_token_size,
+          hidden]`` -- sparse visual rows densified into the batched layout with
+          non-visual rows zero, plus the derived ``apply_for_deepstack``.
+
+        Data stays on ``Req`` (no new ScheduleReqsInfo fields); this only reads it. Collapses the
+        three previously separate rank-offset loops so the layout logic lives in
+        exactly one place. Each field is ``None`` / ``False`` when no request
+        carries it, keeping pure-text / non-multimodal paths unchanged (0-diff).
         """
+        is_extend = self.forward_mode.is_extend()
+        is_decode = self.forward_mode.is_decode()
+
         has_mrope = any(
             _extract_mm_value(getattr(req, "mm_inputs", None), "mrope_positions") is not None
             or _extract_mm_value(getattr(req, "mm_inputs", None), "mrope_position_delta")
@@ -1850,11 +1860,20 @@ class ScheduleBatch:
             if info.reqs
             for req in info.reqs
         )
-        if not has_mrope:
-            return None
 
-        is_decode = self.forward_mode.is_decode()
-        out = np.zeros((3, total_token_size), dtype=np.int32)
+        # input_embedding / deepstack are extend-only; mrope also refreshes on
+        # decode. Nothing to assemble otherwise -> all None/False (0-diff).
+        emb = None
+        mrope = np.zeros((3, total_token_size), dtype=np.int32) if has_mrope else None
+        dense = None
+        if not is_extend and mrope is None:
+            return {
+                "input_embedding": None,
+                "mrope_positions": None,
+                "apply_for_deepstack": False,
+                "deepstack_visual_embedding": None,
+            }
+
         offset = 0
         for dp_rank in range(self.dp_size):
             info = self.reqs_info[dp_rank]
@@ -1862,42 +1881,99 @@ class ScheduleBatch:
                 offset += per_dp_token_size
                 continue
             local = 0
+
             if is_decode:
-                # One token per request; mrope advances by the cached delta.
-                for req, seq_len in zip(info.reqs, info.seq_lens):
-                    mm_inputs = getattr(req, "mm_inputs", None)
-                    base_pos = int(seq_len) - 1
-                    delta = _extract_mm_value(mm_inputs, "mrope_position_delta")
-                    if delta is not None:
-                        base_pos += _as_int_scalar(delta)
-                    out[:, offset + local] = base_pos
-                    local += 1
-            else:
-                for req, seq_len, prefix_len in zip(info.reqs, info.seq_lens, info.prefix_lens):
-                    ext_len = int(seq_len) - int(prefix_len)
-                    if ext_len <= 0:
-                        continue
-                    start = int(prefix_len or 0)
-                    mm_inputs = getattr(req, "mm_inputs", None)
-                    mm_positions = _extract_mm_value(mm_inputs, "mrope_positions")
+                # Decode: one token per request; only mrope advances (embedding
+                # and deepstack are extend-only and stay None/False).
+                if mrope is not None:
+                    for req, seq_len in zip(info.reqs, info.seq_lens):
+                        base_pos = int(seq_len) - 1
+                        delta = _extract_mm_value(
+                            getattr(req, "mm_inputs", None), "mrope_position_delta"
+                        )
+                        if delta is not None:
+                            base_pos += _as_int_scalar(delta)
+                        mrope[:, offset + local] = base_pos
+                        local += 1
+                offset += per_dp_token_size
+                continue
+
+            # Extend: write each req's [prefix_len, seq_len) window.
+            for req, seq_len, prefix_len in zip(info.reqs, info.seq_lens, info.prefix_lens):
+                ext_len = int(seq_len) - int(prefix_len)
+                if ext_len <= 0:
+                    continue
+                start = int(prefix_len or 0)
+                end = start + ext_len
+
+                # input_embedding: per-req merged embedding, extend window.
+                mm_emb = getattr(req, "multimodal_embedding", None)
+                if mm_emb is not None:
+                    mm_full = np.asarray(mm_emb)
+                    chunk = mm_full[start:end]
+                    if emb is None:
+                        emb = np.zeros((total_token_size, mm_full.shape[1]), dtype=mm_full.dtype)
+                    emb[offset + local : offset + local + chunk.shape[0]] = chunk
+
+                # mrope_positions: 3-D positions, slice with fallback.
+                if mrope is not None:
+                    mm_positions = _extract_mm_value(
+                        getattr(req, "mm_inputs", None), "mrope_positions"
+                    )
                     if mm_positions is None:
                         # Text-only req in a mixed mrope batch: 1-D positions
                         # broadcast to 3 rows (T==H==W), matching the model's
                         # non-mrope fallback for these tokens.
                         base = np.arange(start, start + ext_len, dtype=np.int32)
-                        chunk = np.broadcast_to(base.reshape(1, -1), (3, ext_len))
+                        mchunk = np.broadcast_to(base.reshape(1, -1), (3, ext_len))
                     else:
-                        chunk = np.asarray(mm_positions)[:, start : start + ext_len]
-                        if chunk.size == 0:
-                            delta = _extract_mm_value(mm_inputs, "mrope_position_delta")
+                        mchunk = np.asarray(mm_positions)[:, start : start + ext_len]
+                        if mchunk.size == 0:
+                            delta = _extract_mm_value(
+                                getattr(req, "mm_inputs", None), "mrope_position_delta"
+                            )
                             base = np.arange(start, start + ext_len, dtype=np.int32)
                             if delta is not None:
                                 base = base + _as_int_scalar(delta)
-                            chunk = np.broadcast_to(base.reshape(1, -1), (3, ext_len))
-                    out[:, offset + local : offset + local + ext_len] = chunk
-                    local += ext_len
+                            mchunk = np.broadcast_to(base.reshape(1, -1), (3, ext_len))
+                    mrope[:, offset + local : offset + local + ext_len] = mchunk
+
+                # deepstack: densify sparse visual rows into batched layout,
+                # non-visual rows stay zero (so the model can add to all tokens).
+                ds_emb = getattr(req, "deepstack_visual_embedding", None)
+                ds_mask = getattr(req, "deepstack_visual_pos_mask", None)
+                if (
+                    getattr(req, "apply_for_deepstack", False)
+                    and ds_emb is not None
+                    and ds_mask is not None
+                ):
+                    full_mask = np.asarray(ds_mask).astype(bool)
+                    emb_arr = np.asarray(ds_emb)  # (num_layers, num_visual, hidden)
+                    # Only valid when the per-req mask spans the full prompt
+                    # (skips the audio-only dummy [1]-length fallback).
+                    if full_mask.shape[0] >= end and emb_arr.ndim == 3:
+                        window_mask = full_mask[start:end]
+                        nvis = int(window_mask.sum())
+                        if nvis > 0:
+                            vstart = int(full_mask[:start].sum())
+                            window_emb = emb_arr[:, vstart : vstart + nvis, :]
+                            if dense is None:
+                                dense = np.zeros(
+                                    (emb_arr.shape[0], total_token_size, emb_arr.shape[2]),
+                                    dtype=emb_arr.dtype,
+                                )
+                            vis_pos = offset + local + np.nonzero(window_mask)[0]
+                            dense[:, vis_pos, :] = window_emb
+
+                local += ext_len
             offset += per_dp_token_size
-        return out
+
+        return {
+            "input_embedding": emb,
+            "mrope_positions": mrope,
+            "apply_for_deepstack": dense is not None,
+            "deepstack_visual_embedding": dense,
+        }
 
     def _merge_batch_metadata(
         self,
@@ -2466,110 +2542,16 @@ class ScheduleBatch:
             # Pad to total_bs
             lora_ids = lora_ids + ["0"] * (total_bs - real_bs)
 
-        # Reassemble multimodal input_embedding (DP-aware).
-        #
-        # Mirrors the per-req slice/concat/pad logic from 785f3806 but scatters
-        # into the DP-interleaved padded token layout produced by
-        # _merge_input_and_positions: per-DP-rank slot stride is
-        # per_dp_token_padding, and within a rank the per-req EXTEND window is
-        # [prefix_len, seq_len) -- the same zip(info.seq_lens, info.prefix_lens)
-        # order used to build positions. The result aligns 1:1 with
-        # input_ids_cpu so forward_batch.input_embedding[k] matches
-        # input_ids[k]; trailing padding rows stay zero.
-        input_embedding = None
-        if self.forward_mode.is_extend() and any(
-            getattr(req, "multimodal_embedding", None) is not None
-            for info in self.reqs_info
-            if info.reqs
-            for req in info.reqs
-        ):
-            emb = None
-            offset = 0
-            for dp_rank in range(self.dp_size):
-                info = self.reqs_info[dp_rank]
-                if not info.reqs or info.seq_lens is None or len(info.seq_lens) == 0:
-                    offset += per_dp_token_padding
-                    continue
-                local = 0
-                for req, seq_len, prefix_len in zip(info.reqs, info.seq_lens, info.prefix_lens):
-                    ext_len = int(seq_len) - int(prefix_len)
-                    mm = getattr(req, "multimodal_embedding", None)
-                    if mm is not None and ext_len > 0:
-                        mm_full = np.asarray(mm)
-                        start = int(prefix_len or 0)
-                        end = start + ext_len
-                        chunk = mm_full[start:end]
-                        if emb is None:
-                            emb = np.zeros(
-                                (total_token_size, mm_full.shape[1]),
-                                dtype=mm_full.dtype,
-                            )
-                        emb[offset + local : offset + local + chunk.shape[0]] = chunk
-                    local += ext_len
-                offset += per_dp_token_padding
-            input_embedding = emb
-
-        # Reassemble deepstack visual embeddings (DP-aware), densified to the
-        # batched token layout. Each req carries a sparse (num_layers, num_visual,
-        # hidden) embedding plus a per-prompt boolean pos-mask; we scatter the
-        # visual rows of the EXTEND window into a dense
-        # (num_layers, total_token_size, hidden) tensor at the matching token
-        # positions (same DP offset/stride as input_embedding above). Non-visual
-        # rows stay zero, so the model can add deepstack[layer] to all tokens
-        # (Qwen3-Omni thinker) without a separate position mask. Mirrors the
-        # pre-DP densification dropped by de5287ed.
-        apply_for_deepstack = False
-        deepstack_visual_embedding = None
-        if self.forward_mode.is_extend():
-            dense = None
-            num_layers = None
-            offset = 0
-            for dp_rank in range(self.dp_size):
-                info = self.reqs_info[dp_rank]
-                if not info.reqs or info.seq_lens is None or len(info.seq_lens) == 0:
-                    offset += per_dp_token_padding
-                    continue
-                local = 0
-                for req, seq_len, prefix_len in zip(info.reqs, info.seq_lens, info.prefix_lens):
-                    ext_len = int(seq_len) - int(prefix_len)
-                    ds_emb = getattr(req, "deepstack_visual_embedding", None)
-                    ds_mask = getattr(req, "deepstack_visual_pos_mask", None)
-                    if (
-                        getattr(req, "apply_for_deepstack", False)
-                        and ds_emb is not None
-                        and ds_mask is not None
-                        and ext_len > 0
-                    ):
-                        full_mask = np.asarray(ds_mask).astype(bool)
-                        emb_arr = np.asarray(ds_emb)  # (num_layers, num_visual, hidden)
-                        start = int(prefix_len or 0)
-                        end = start + ext_len
-                        # Only valid when the per-req mask spans the full prompt
-                        # (skips the audio-only dummy [1]-length fallback).
-                        if full_mask.shape[0] >= end and emb_arr.ndim == 3:
-                            window_mask = full_mask[start:end]
-                            nvis = int(window_mask.sum())
-                            if nvis > 0:
-                                vstart = int(full_mask[:start].sum())
-                                window_emb = emb_arr[:, vstart : vstart + nvis, :]
-                                if dense is None:
-                                    num_layers = emb_arr.shape[0]
-                                    dense = np.zeros(
-                                        (num_layers, total_token_size, emb_arr.shape[2]),
-                                        dtype=emb_arr.dtype,
-                                    )
-                                vis_pos = offset + local + np.nonzero(window_mask)[0]
-                                dense[:, vis_pos, :] = window_emb
-                    local += ext_len
-                offset += per_dp_token_padding
-            if dense is not None:
-                apply_for_deepstack = True
-                deepstack_visual_embedding = dense
-
-        # Reassemble 3-D mrope_positions (DP-aware), aligned column-for-column
-        # with input_ids_cpu. Returns None for pure-text batches so the model
-        # keeps its 1-D positions path. Restores wiring dropped by de5287ed.
-        mrope_positions = self._merge_mrope_positions(per_dp_token_padding, total_token_size)
+        # Assemble all per-token multimodal tensors (input_embedding,
+        # mrope_positions, deepstack) in a single DP-interleaved pass over
+        # reqs_info[*].reqs; see ScheduleBatch._merge_multimodal. Each is
+        # None/False for pure-text batches, so non-multimodal paths stay
+        # unchanged.
+        _mm = self._merge_multimodal(per_dp_token_padding, total_token_size)
+        input_embedding = _mm["input_embedding"]
+        mrope_positions = _mm["mrope_positions"]
+        apply_for_deepstack = _mm["apply_for_deepstack"]
+        deepstack_visual_embedding = _mm["deepstack_visual_embedding"]
 
         # Merge per-DP top_logprobs_nums / token_ids_logprobs with the same
         # offset_bs += per_dp_bs_padding padding scheme used in _merge_batch_metadata.

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2433,6 +2433,63 @@ class ScheduleBatch:
                 offset += per_dp_token_padding
             input_embedding = emb
 
+        # Reassemble deepstack visual embeddings (DP-aware), densified to the
+        # batched token layout. Each req carries a sparse (num_layers, num_visual,
+        # hidden) embedding plus a per-prompt boolean pos-mask; we scatter the
+        # visual rows of the EXTEND window into a dense
+        # (num_layers, total_token_size, hidden) tensor at the matching token
+        # positions (same DP offset/stride as input_embedding above). Non-visual
+        # rows stay zero, so the model can add deepstack[layer] to all tokens
+        # (Qwen3-Omni thinker) without a separate position mask. Mirrors the
+        # pre-DP densification dropped by de5287ed.
+        apply_for_deepstack = False
+        deepstack_visual_embedding = None
+        if self.forward_mode.is_extend():
+            dense = None
+            num_layers = None
+            offset = 0
+            for dp_rank in range(self.dp_size):
+                info = self.reqs_info[dp_rank]
+                if not info.reqs or info.seq_lens is None or len(info.seq_lens) == 0:
+                    offset += per_dp_token_padding
+                    continue
+                local = 0
+                for req, seq_len, prefix_len in zip(info.reqs, info.seq_lens, info.prefix_lens):
+                    ext_len = int(seq_len) - int(prefix_len)
+                    ds_emb = getattr(req, "deepstack_visual_embedding", None)
+                    ds_mask = getattr(req, "deepstack_visual_pos_mask", None)
+                    if (
+                        getattr(req, "apply_for_deepstack", False)
+                        and ds_emb is not None
+                        and ds_mask is not None
+                        and ext_len > 0
+                    ):
+                        full_mask = np.asarray(ds_mask).astype(bool)
+                        emb_arr = np.asarray(ds_emb)  # (num_layers, num_visual, hidden)
+                        start = int(prefix_len or 0)
+                        end = start + ext_len
+                        # Only valid when the per-req mask spans the full prompt
+                        # (skips the audio-only dummy [1]-length fallback).
+                        if full_mask.shape[0] >= end and emb_arr.ndim == 3:
+                            window_mask = full_mask[start:end]
+                            nvis = int(window_mask.sum())
+                            if nvis > 0:
+                                vstart = int(full_mask[:start].sum())
+                                window_emb = emb_arr[:, vstart : vstart + nvis, :]
+                                if dense is None:
+                                    num_layers = emb_arr.shape[0]
+                                    dense = np.zeros(
+                                        (num_layers, total_token_size, emb_arr.shape[2]),
+                                        dtype=emb_arr.dtype,
+                                    )
+                                vis_pos = offset + local + np.nonzero(window_mask)[0]
+                                dense[:, vis_pos, :] = window_emb
+                    local += ext_len
+                offset += per_dp_token_padding
+            if dense is not None:
+                apply_for_deepstack = True
+                deepstack_visual_embedding = dense
+
         # Merge per-DP top_logprobs_nums / token_ids_logprobs with the same
         # offset_bs += per_dp_bs_padding padding scheme used in _merge_batch_metadata.
         if self.return_logprob:
@@ -2538,8 +2595,8 @@ class ScheduleBatch:
             per_dp_bs_size=per_dp_bs_padding,
             launch_done=self.launch_done,
             input_embedding=input_embedding,
-            apply_for_deepstack=False,
-            deepstack_visual_embedding=None,
+            apply_for_deepstack=apply_for_deepstack,
+            deepstack_visual_embedding=deepstack_visual_embedding,
             recurrent_indices=recurrent_indices_cpu,
             has_initial_state=has_initial_state_cpu,
             spec_algorithm=self.spec_algorithm,

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1823,6 +1823,82 @@ class ScheduleBatch:
 
         return input_ids_cpu, positions_cpu, out_cache_loc_cpu, real_input_ids_len
 
+    def _merge_mrope_positions(
+        self,
+        per_dp_token_size: int,
+        total_token_size: int,
+    ) -> np.ndarray | None:
+        """Merge 3-D mrope_positions from all DP ranks, aligned with input_ids.
+
+        Mirrors the DP-interleaved rank-offset layout of
+        ``_merge_input_and_positions``: each DP rank occupies a
+        ``per_dp_token_size`` slot (offset advances per rank, padding columns
+        stay zero), and within a rank per-req positions are written in the same
+        ``[prefix_len, seq_len)`` extend-window order used to build input_ids,
+        so ``out[:, k]`` lines up with ``input_ids[k]``.
+
+        Absorbs the per-req slice / delta / fallback logic of the former
+        single-rank ``_compute_mrope_positions_for_batch`` (orphaned by the DP
+        refactor de5287ed). Returns ``None`` when no request carries mrope data
+        so the model keeps its 1-D positions path (pure-text 0-diff).
+        """
+        has_mrope = any(
+            _extract_mm_value(getattr(req, "mm_inputs", None), "mrope_positions") is not None
+            or _extract_mm_value(getattr(req, "mm_inputs", None), "mrope_position_delta")
+            is not None
+            for info in self.reqs_info
+            if info.reqs
+            for req in info.reqs
+        )
+        if not has_mrope:
+            return None
+
+        is_decode = self.forward_mode.is_decode()
+        out = np.zeros((3, total_token_size), dtype=np.int32)
+        offset = 0
+        for dp_rank in range(self.dp_size):
+            info = self.reqs_info[dp_rank]
+            if not info.reqs or info.seq_lens is None or len(info.seq_lens) == 0:
+                offset += per_dp_token_size
+                continue
+            local = 0
+            if is_decode:
+                # One token per request; mrope advances by the cached delta.
+                for req, seq_len in zip(info.reqs, info.seq_lens):
+                    mm_inputs = getattr(req, "mm_inputs", None)
+                    base_pos = int(seq_len) - 1
+                    delta = _extract_mm_value(mm_inputs, "mrope_position_delta")
+                    if delta is not None:
+                        base_pos += _as_int_scalar(delta)
+                    out[:, offset + local] = base_pos
+                    local += 1
+            else:
+                for req, seq_len, prefix_len in zip(info.reqs, info.seq_lens, info.prefix_lens):
+                    ext_len = int(seq_len) - int(prefix_len)
+                    if ext_len <= 0:
+                        continue
+                    start = int(prefix_len or 0)
+                    mm_inputs = getattr(req, "mm_inputs", None)
+                    mm_positions = _extract_mm_value(mm_inputs, "mrope_positions")
+                    if mm_positions is None:
+                        # Text-only req in a mixed mrope batch: 1-D positions
+                        # broadcast to 3 rows (T==H==W), matching the model's
+                        # non-mrope fallback for these tokens.
+                        base = np.arange(start, start + ext_len, dtype=np.int32)
+                        chunk = np.broadcast_to(base.reshape(1, -1), (3, ext_len))
+                    else:
+                        chunk = np.asarray(mm_positions)[:, start : start + ext_len]
+                        if chunk.size == 0:
+                            delta = _extract_mm_value(mm_inputs, "mrope_position_delta")
+                            base = np.arange(start, start + ext_len, dtype=np.int32)
+                            if delta is not None:
+                                base = base + _as_int_scalar(delta)
+                            chunk = np.broadcast_to(base.reshape(1, -1), (3, ext_len))
+                    out[:, offset + local : offset + local + ext_len] = chunk
+                    local += ext_len
+            offset += per_dp_token_size
+        return out
+
     def _merge_batch_metadata(
         self,
         per_dp_bs_size: int,
@@ -2490,6 +2566,11 @@ class ScheduleBatch:
                 apply_for_deepstack = True
                 deepstack_visual_embedding = dense
 
+        # Reassemble 3-D mrope_positions (DP-aware), aligned column-for-column
+        # with input_ids_cpu. Returns None for pure-text batches so the model
+        # keeps its 1-D positions path. Restores wiring dropped by de5287ed.
+        mrope_positions = self._merge_mrope_positions(per_dp_token_padding, total_token_size)
+
         # Merge per-DP top_logprobs_nums / token_ids_logprobs with the same
         # offset_bs += per_dp_bs_padding padding scheme used in _merge_batch_metadata.
         if self.return_logprob:
@@ -2573,7 +2654,7 @@ class ScheduleBatch:
             token_ids_logprobs=token_ids_logprobs,
             sampling_info=sampling_info,
             positions=positions_cpu,
-            mrope_positions=None,
+            mrope_positions=mrope_positions,
             cache_loc=cache_loc_cpu,
             extend_prefix_lens=extend_prefix_lens,
             extend_seq_lens=extend_seq_lens,
@@ -2798,84 +2879,6 @@ def _as_int_scalar(value: Any, default: int = 0) -> int:
             return default
         return int(arr.reshape(-1)[0])
     return int(value)
-
-
-def _compute_mrope_positions_for_batch(
-    reqs: list[Req],
-    forward_mode: ForwardMode,
-    seq_lens_cpu: np.ndarray,
-    input_ids_len: int,
-    extend_prefix_lens: np.ndarray | None,
-    extend_seq_lens: np.ndarray | None,
-) -> np.ndarray | None:
-    mm_inputs_list = [getattr(req, "mm_inputs", None) for req in reqs]
-    has_mrope = any(
-        _extract_mm_value(mm, "mrope_positions") is not None
-        or _extract_mm_value(mm, "mrope_position_delta") is not None
-        for mm in mm_inputs_list
-    )
-    if not has_mrope:
-        return None
-
-    if forward_mode.is_decode():
-        mrope_positions_list = []
-        for batch_idx, mm_inputs in enumerate(mm_inputs_list):
-            base_pos = int(seq_lens_cpu[batch_idx]) - 1
-            delta = _extract_mm_value(mm_inputs, "mrope_position_delta")
-            if delta is not None:
-                base_pos += _as_int_scalar(delta)
-            mrope_positions_list.append(
-                np.full((3, 1), base_pos, dtype=np.int32),
-            )
-        mrope_positions = (
-            np.concatenate(mrope_positions_list, axis=1)
-            if mrope_positions_list
-            else np.zeros((3, 0), dtype=np.int32)
-        )
-    else:
-        if extend_prefix_lens is None or extend_seq_lens is None:
-            return None
-        mrope_positions_list = []
-        for batch_idx, mm_inputs in enumerate(mm_inputs_list):
-            extend_len = int(extend_seq_lens[batch_idx])
-            prefix_len = int(extend_prefix_lens[batch_idx])
-            if extend_len <= 0:
-                mrope_positions_list.append(np.zeros((3, 0), dtype=np.int32))
-                continue
-
-            mm_positions = _extract_mm_value(mm_inputs, "mrope_positions")
-            if mm_positions is None:
-                positions = np.arange(prefix_len, prefix_len + extend_len, dtype=np.int32)
-                mrope_positions_list.append(
-                    np.broadcast_to(positions.reshape(1, -1), (3, extend_len))
-                )
-                continue
-
-            mm_positions = np.asarray(mm_positions)
-            chunk = mm_positions[:, prefix_len : prefix_len + extend_len]
-            if chunk.size == 0:
-                delta = _extract_mm_value(mm_inputs, "mrope_position_delta")
-                if delta is not None:
-                    delta_val = _as_int_scalar(delta)
-                    positions = (
-                        np.arange(prefix_len, prefix_len + extend_len, dtype=np.int32) + delta_val
-                    )
-                else:
-                    positions = np.arange(prefix_len, prefix_len + extend_len, dtype=np.int32)
-                chunk = np.broadcast_to(positions.reshape(1, -1), (3, extend_len))
-            mrope_positions_list.append(chunk.astype(np.int32, copy=False))
-
-        mrope_positions = (
-            np.concatenate(mrope_positions_list, axis=1)
-            if mrope_positions_list
-            else np.zeros((3, 0), dtype=np.int32)
-        )
-
-    pad_len = input_ids_len - mrope_positions.shape[1]
-    if pad_len > 0:
-        pad = np.zeros((3, pad_len), dtype=mrope_positions.dtype)
-        mrope_positions = np.concatenate([mrope_positions, pad], axis=1)
-    return mrope_positions
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Summary

The DP-support refactor (`de5287ed`, "dp support (#939)") rewrote `get_model_worker_batch` into the per-DP `reqs_info` / DP-interleaved layout and, in doing so, **deleted the multimodal batch-assembly logic instead of migrating it**. The data sources (`Req` fields, tokenizer output) and the final consumers (`ForwardBatch`, the model forwards) are intact — only the *mid-pipeline plumbing* in `schedule_batch.py` was severed: `get_model_worker_batch` hardcodes every multimodal tensor to `None` / `False`. Multimodal understanding "looks like it runs" but silently ignores or corrupts the media.

This PR restores all of it (DP-aware) and consolidates the assembly into one helper. Each item below is a separate commit.

## What broke

All in `schedule_batch.py :: get_model_worker_batch`, hardcoded since `de5287ed`:

| Field | Hardcoded value | Symptom |
|---|---|---|
| `input_embedding` | `= None` | image/video/audio never reach the LM → output is effectively text-only, silently |
| `mrope_positions` | `= None` (main + spec path) | 3-D mRoPE degrades to 1-D → image-patch H/W spatial positions wrong on every VL request |
| deepstack | `apply_for_deepstack=False`, `deepstack_visual_embedding=None` | Qwen3-Omni visual deepstack enhancement never runs |

Once restored, each of those three would otherwise re-implement the same DP rank-offset loop, so they are consolidated into one helper (final commit).

Supporting facts: the per-DP container `ScheduleReqsInfo` has no multimodal fields, and `_compute_mrope_positions_for_batch` became dead code (zero callers). The pre-DP parent had all of these wired (`input_embedding=...`, `mrope_positions=...`, `apply_for_deepstack=...`). The scheduler ingest that fills `Req` is unchanged, so the data is still available — only the assembly into `ModelWorkerBatch` is missing.

The shared assembly layout is the same one `_merge_input_and_positions` uses: token slots are laid out `[dp0 | pad | dp1 | pad | ...]` with per-rank stride `per_dp_token_padding`; within a rank each req contributes its `[prefix_len, seq_len)` extend window. Every restored tensor is written on this layout so it aligns 1:1 with `input_ids`.

## Data flow: before vs. after

**Before** — `de5287ed` lets the data reach `Req`, then drops it at the batch-assembly boundary:

```
producer (vit / embed runner)      get_model_worker_batch          model forward

req.multimodal_embedding  -->  input_embedding     = None   -->  embed_tokens(input_ids)  [text-only]
req.mm_inputs[mrope_*]    -->  mrope_positions     = None   -->  1-D positions            [3-D mRoPE lost]
req.deepstack_*           -->  apply_for_deepstack = False  -->  deepstack skipped
                               ^ data is on Req, but hardcoded away here
```

**After** — one DP-interleaved pass re-assembles all three, aligned 1:1 with `input_ids`:

```
producer (vit / embed runner)      get_model_worker_batch          model forward

req.multimodal_embedding  --+
req.mm_inputs[mrope_*]      +-->  _merge_multimodal()  -->  input_embedding  -->  hidden states
req.deepstack_*           --+     single DP-interleaved      mrope_positions  -->  3-D mRoPE positions
                                  pass over reqs_info         deepstack + flag -->  injected at visual pos
```

---

### input_embedding

**Problem.** `req.multimodal_embedding` (the per-token text+visual merged embedding produced by the ViT / embed runner) is never copied into `ModelWorkerBatch.input_embedding`, so `forward_batch.input_embedding` is always `None` and the LM falls back to `embed_tokens(input_ids)` on prefill — silently text-only.

**Fix.** Slice each req's `[prefix:seq]` window into the DP-interleaved buffer aligned with `input_ids`. Returns `None` for pure-text batches (0-diff: the consumer keeps its `embed_tokens` path).

### mrope_positions

**Problem.** Both the main and spec paths hardcode `mrope_positions=None`, and the only assembler (`_compute_mrope_positions_for_batch`) is dead code. The consumer falls back to 1-D positions, so 3-D mRoPE degenerates to standard RoPE — not just the video time axis, but image-patch H/W spatial positions are wrong on every Qwen2.5-VL / Qwen3-Omni request.

**Fix.** Assemble `[3, total_tokens]` on the same layout: extend slices `mm_positions[:, prefix:prefix+ext]` (delta / arange fallback when absent); decode advances `seq_len-1 (+mrope_position_delta)`. **Main path only.** The spec path's `input_ids`/`positions`/`cache_loc` are empty placeholders rebuilt later by `EagleDraftWorker.padding_for_decode`, so its `None` is intentional and spec+mrope is a separate follow-up.

### deepstack (Qwen3-Omni)

**Problem.** `apply_for_deepstack` / `deepstack_visual_embedding` are hardcoded off and the pre-DP densification scatter was deleted. Naively flipping the flag back on (passing the sparse `(num_layers, num_visual, hidden)` tensor through) would make the thinker add visual features to **all** tokens — turning "missing feature" into "corrupts every token".

**Fix.** DP-aware densification: scatter the sparse visual rows into a dense `(num_layers, total_tokens, hidden)` buffer with non-visual rows left zero. Then the thinker's "add `deepstack[layer]` to all tokens" is mathematically equivalent to "add at visual positions only" — so no separate `deepstack_visual_pos_mask` carrier field is needed on `ForwardBatch`. `vstart` (= #visual-before-prefix) keeps chunked prefill correct.

### Consolidation — `_merge_multimodal`

**Problem.** The three restored paths above each carried an identical copy of the DP rank-offset loop. Three copies of one layout is a drift hazard: if any one drops the offset advance or miscounts `local`, that tensor silently misaligns with `input_ids`.

**Fix.** Collapse them into a single `_merge_multimodal(per_dp_token_size, total_token_size)` that traverses `reqs_info[*].reqs` once and emits all three tensors on one shared `offset`/`local` cursor. Data stays on `Req` (no new `ScheduleReqsInfo` fields); the helper only reads it. The dead `_compute_mrope_positions_for_batch` is folded in and removed.

## Not addressed here (dp>1 follow-ups)

- **Sharding**: `input_embedding` / `mrope_positions` / `deepstack` use `PartitionSpec(None, None)` (full replication) in `forward_batch_info.py`, while `positions` / `hidden_states` use `P("data")`. Harmless at `dp_size=1` (the current multimodal deployment — LM stage `max_batch_size:1`); at `dp_size>1` the replicated tensors fed into a `P("data","tensor")` attention may reshard / trip `.at[].set()` under jax 0.8.x explicit sharding.
- `_forward_mrope` uses a global `num_tokens` slice; correct as long as `mrope_positions` is assembled in DP-interleaved order (it is), but worth revisiting for `dp>1`.

### TPU e2e validation (Qwen2.5-VL-7B-Instruct, v6e-4)

Ran on a single-host **v6e-4** GKE node pool: this PR vs `main`, same pod / model / request — only the sglang-jax commit changed.

- Image `jax-ai-image/tpu:jax0.8.1-rev1` (jax 0.8.1), launched `--multimodal --trust-remote-code`, `temperature=0`.
- Env note: the image ships no `torch`; HF `AutoProcessor` for Qwen2.5-VL pulls in `AutoVideoProcessor` (hard-requires PyTorch), the exception is swallowed → `mm_processor=None` → every image request 400s (`"processor/config is not available"`) and the default warmup failure kills the process. `pip install torch torchvision` (CPU; preprocessing only, model still runs on JAX/TPU) resolves it — possibly worth documenting.

**Probe 1** — COCO `000000039769.jpg` (two cats sleeping on a couch) + *"How many cats are in this image, and what are they doing? Answer briefly."*

| Branch | Output |
|---|---|
| **This PR** (`1cb8f0a`) | "There are two cats in the image, and they are sleeping." ✅ |
| `main` (`1c38158`) | "There are no cats in this image. The image shows a group of people standing in a line, with some holding signs..." ❌ |

**Probe 2** — SGLang logo image, *"describe this image in one sentence."*

| Branch | Output |
|---|---|
| **This PR** | correctly describes the logo (letters + figure with code/book) ✅ |
| `main` | "a person riding a bicycle on a paved path in a park" ❌ |

**Key signal:** `prompt_tokens` is **429 on both branches** — the image placeholder tokens are present, but on `main` the visual embeddings are never merged into `input_embedding` (exactly the data-flow this PR restores). So placeholder positions get empty embeddings and the model generates from text only → consistent hallucination on both probes. With this PR the embeddings are injected and outputs are correct, confirming the `input_embedding` fix end-to-end on real hardware.

Isolation: `main` here is 4 commits behind this PR and 1 ahead of the merge-base (`6495488`); that extra commit is an unrelated quant change (#1259), orthogonal to the multimodal data-flow — merge-base gives identical results. `dp_size=1`, so the dp>1 sharding follow-ups noted above are not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

