### PR TITLE
[Draft] fix(multimodal): block-diagonal attention masks for Qwen2.5-VL ViT and Qwen3-Omni audio

### DIFF
--- a/python/sgl_jax/srt/multimodal/layers/attention/layer.py
+++ b/python/sgl_jax/srt/multimodal/layers/attention/layer.py
@@ -15,7 +15,7 @@ def align_to(x, a):
     return pl.cdiv(x, a) * a
 
 
-def simple_attention(query, key, value, scale=None, causal=False):
+def simple_attention(query, key, value, scale=None, causal=False, attn_mask=None):
     """Simple dot-product attention for diffusion models (no KV cache).
 
     Args:
@@ -24,6 +24,9 @@ def simple_attention(query, key, value, scale=None, causal=False):
         value: [B, S, H, D]
         scale: softmax scale, default 1/sqrt(D)
         causal: whether to apply causal mask
+        attn_mask: optional additive mask broadcastable to [B, H, S, S]
+            (0 where attention is allowed, large negative where masked). Used
+            for block-diagonal attention (e.g. per-window audio encoding).
     Returns:
         output: [B, S, H, D]
     """
@@ -37,6 +40,9 @@ def simple_attention(query, key, value, scale=None, causal=False):
 
     # [B, H, S, S]
     attn_weights = jnp.einsum("bhsd,bhtd->bhst", q, k) * scale
+
+    if attn_mask is not None:
+        attn_weights = attn_weights + attn_mask.astype(attn_weights.dtype)
 
     if causal:
         seq_len = query.shape[1]

--- a/python/sgl_jax/srt/multimodal/models/qwen2_5VL/qwen2_5_vit.py
+++ b/python/sgl_jax/srt/multimodal/models/qwen2_5VL/qwen2_5_vit.py
@@ -72,7 +72,7 @@ def vision_attention(
     k: jax.Array,
     v: jax.Array,
     scale: float,
-    window_size: int = -1,
+    attn_mask: jax.Array | None = None,
 ) -> jax.Array:
     """
     Compute vision attention using flash attention on GPU or native attention on TPU.
@@ -82,13 +82,16 @@ def vision_attention(
     Args:
         q, k, v: Input tensors of shape [B, T, N, H] (batch, seq_len, num_heads, head_dim)
         scale: Attention scale factor (1/sqrt(head_dim))
-        window_size: Window size for local attention. -1 means full attention.
+        attn_mask: Optional [T, T] boolean mask where True marks an allowed
+            (query, key) pair. Used to implement Qwen2.5-VL's block-diagonal
+            attention (within a single image for full-attention layers, within a
+            single window for windowed layers). None means unmasked full attention.
 
     Returns:
         Output tensor of shape [B, T, N, H]
     """
-    if not is_tpu_runtime():
-        # GPU: use flash_mha
+    if not is_tpu_runtime() and attn_mask is None:
+        # GPU fast path: unmasked full attention via flash_mha.
         flash_mha = _get_flash_mha()
         original_dtype = q.dtype
         if q.dtype not in [jnp.bfloat16, jnp.float16]:
@@ -96,23 +99,15 @@ def vision_attention(
             k = k.astype(jnp.bfloat16)
             v = v.astype(jnp.bfloat16)
 
-        if window_size > 0:
-            output = flash_mha(
-                q,
-                k,
-                v,
-                softmax_scale=scale,
-                is_causal=False,
-                window_size=(window_size, window_size),
-            )
-        else:
-            output = flash_mha(q, k, v, softmax_scale=scale, is_causal=False)
+        output = flash_mha(q, k, v, softmax_scale=scale, is_causal=False)
 
         if output.dtype != original_dtype:
             output = output.astype(original_dtype)
         return output
     else:
-        # TPU: native attention
+        # Native attention (TPU, or GPU when a block-diagonal mask is required).
+        # flash_mha cannot express the per-image / per-window block-diagonal
+        # mask, so masked attention always runs natively here.
         B, T, N, H = q.shape
         q = jnp.transpose(q, (0, 2, 1, 3))  # [B, N, T, H]
         k = jnp.transpose(k, (0, 2, 1, 3))
@@ -120,13 +115,10 @@ def vision_attention(
 
         attn_weights = jnp.einsum("bnth,bnsh->bnts", q, k) * scale
 
-        if window_size > 0:
-            # Create window mask for local attention
-            positions = jnp.arange(T)
-            distance = jnp.abs(positions[:, None] - positions[None, :])
-            window_mask = distance > window_size
+        if attn_mask is not None:
+            # attn_mask[i, j] == True  -> keep; False -> mask out.
             attn_weights = jnp.where(
-                window_mask[None, None, :, :], jnp.finfo(attn_weights.dtype).min, attn_weights
+                attn_mask[None, None, :, :], attn_weights, jnp.finfo(attn_weights.dtype).min
             )
 
         attn_weights = jax.nn.softmax(attn_weights, axis=-1)
@@ -265,8 +257,7 @@ class Qwen2_5_VisionAttention(nnx.Module):
         self,
         x: jax.Array,
         rotary_pos_emb: jax.Array,
-        cu_window_seqlens: jax.Array | None = None,
-        use_fullattn: bool = True,
+        cu_seqlens: jax.Array | None = None,
     ) -> jax.Array:
         T, B, D = x.shape
         assert B == 1, "Vision attention currently only supports batch size 1"
@@ -284,13 +275,22 @@ class Qwen2_5_VisionAttention(nnx.Module):
         q = apply_rotary_pos_emb_vision(q, rotary_pos_emb)
         k = apply_rotary_pos_emb_vision(k, rotary_pos_emb)
 
-        # Use static window size derived from config for JIT compatibility.
-        window_size = -1
-        if not use_fullattn and cu_window_seqlens is not None:
-            window_size = self._window_token_size
+        # Build a block-diagonal attention mask from the cumulative sequence
+        # lengths. `cu_seqlens` is [0, b1, b2, ..., T]; for full-attention layers
+        # the blocks are per-image frames, for windowed layers they are per
+        # window. Token p belongs to segment seg[p] = number of boundaries in
+        # cu_seqlens[1:] that p has reached; two tokens may attend iff they share
+        # a segment. This replaces the previous (incorrect) 1-D sliding-distance
+        # window mask and the unmasked full attention. Robust to zero-width
+        # segments (duplicate boundaries) produced by window padding.
+        attn_mask = None
+        if cu_seqlens is not None:
+            pos = jnp.arange(T)
+            seg = jnp.sum(pos[:, None] >= cu_seqlens[None, 1:], axis=1)
+            attn_mask = seg[:, None] == seg[None, :]
 
         # Compute attention using the backend function
-        output = vision_attention(q, k, v, self.scale, window_size)
+        output = vision_attention(q, k, v, self.scale, attn_mask)
 
         # Reshape back: [B, T, N, H] -> [T, B, D]
         output = output.transpose(1, 0, 2, 3).reshape(T, B, D)
@@ -325,10 +325,9 @@ class Qwen2_5_VisionBlock(nnx.Module):
         self,
         x: jax.Array,
         rotary_pos_emb: jax.Array,
-        cu_window_seqlens: jax.Array | None = None,
-        use_fullattn: bool = True,
+        cu_seqlens: jax.Array | None = None,
     ) -> jax.Array:
-        x = x + self.attn(self.norm1(x), rotary_pos_emb, cu_window_seqlens, use_fullattn)
+        x = x + self.attn(self.norm1(x), rotary_pos_emb, cu_seqlens)
         x = x + self.mlp(self.norm2(x))
         return x
 
@@ -580,15 +579,13 @@ class Qwen2_5_VL_VisionTransformer(nnx.Module):
                 hidden_states = blk(
                     hidden_states,
                     rotary_pos_emb=rotary_pos_emb,
-                    cu_window_seqlens=cu_seqlens,
-                    use_fullattn=True,
+                    cu_seqlens=cu_seqlens,
                 )
             else:
                 hidden_states = blk(
                     hidden_states,
                     rotary_pos_emb=rotary_pos_emb,
-                    cu_window_seqlens=cu_window_seqlens,
-                    use_fullattn=False,
+                    cu_seqlens=cu_window_seqlens,
                 )
 
         # adapter

--- a/python/sgl_jax/srt/multimodal/models/qwen3_omni_moe/audio_encoder.py
+++ b/python/sgl_jax/srt/multimodal/models/qwen3_omni_moe/audio_encoder.py
@@ -75,6 +75,7 @@ class Qwen3OmniMoeAudioAttention(nnx.Module):
     def __call__(
         self,
         hidden_states: jax.Array,
+        attn_mask: jax.Array | None = None,
     ) -> tuple[jax.Array, jax.Array | None, tuple[jax.Array] | None]:
         seq_length, _ = hidden_states.shape
 
@@ -88,6 +89,7 @@ class Qwen3OmniMoeAudioAttention(nnx.Module):
             value_states,
             scale=self.scaling,
             causal=False,
+            attn_mask=attn_mask,
         )
 
         attn_output = attn_output.reshape(seq_length, -1)
@@ -133,10 +135,11 @@ class Qwen3OmniMoeAudioEncoderLayer(nnx.Module):
     def __call__(
         self,
         hidden_states: jax.Array,
+        attn_mask: jax.Array | None = None,
     ) -> jax.Array:
         residual = hidden_states
         hidden_states = self.self_attn_layer_norm(hidden_states)
-        hidden_states = self.self_attn(hidden_states)
+        hidden_states = self.self_attn(hidden_states, attn_mask)
         hidden_states = residual + hidden_states
         residual = hidden_states
         hidden_states = self.final_layer_norm(hidden_states)
@@ -277,9 +280,37 @@ class Qwen3OmniMoeAudioEncoder(nnx.Module):
         padded_embed = padded_embed + positional_embedding
         hidden_states = padded_embed[padded_mask_after_cnn]
 
+        # Build a block-diagonal attention mask so each audio window attends only
+        # within itself (mirrors HF Qwen3-Omni: attention is restricted to
+        # cu_seqlens blocks). Without this the encoder ran global bidirectional
+        # attention over the whole concatenated audio, which diverges for any
+        # audio spanning more than one window.
+        aftercnn_lens = self._get_feat_extract_output_lengths(feature_lens)
+        window_aftercnn = int(jnp.max(feature_lens_after_cnn)) * (
+            self.n_window_infer // (self.n_window * 2)
+        )
+        cu_chunk_lens = [0]
+        for cnn_len in aftercnn_lens.tolist():
+            cnn_len = int(cnn_len)
+            cu_chunk_lens += [window_aftercnn] * (cnn_len // window_aftercnn)
+            remainder = cnn_len % window_aftercnn
+            if remainder != 0:
+                cu_chunk_lens += [remainder]
+        cu_seqlens = jnp.cumsum(jnp.asarray(cu_chunk_lens, dtype=jnp.int32))
+
+        total_tokens = hidden_states.shape[0]
+        pos = jnp.arange(total_tokens)
+        # seg[p] = index of the cu_seqlens block that token p belongs to; tokens
+        # may attend iff they share a block. Robust to zero-width blocks.
+        seg = jnp.sum(pos[:, None] >= cu_seqlens[None, 1:], axis=1)
+        attn_mask = jnp.where(seg[:, None] == seg[None, :], 0.0, jnp.finfo(self.dtype).min).astype(
+            self.dtype
+        )
+
         for encoder_layer in self.layers:
             layer_outputs = encoder_layer(
                 hidden_states,
+                attn_mask,
             )
 
             hidden_states = layer_outputs


### PR DESCRIPTION
## Summary

Two block-diagonal attention-mask fixes for the vision/audio encoders. Both are **silent correctness bugs** — no crash, no error, just quietly degraded image/audio understanding: the already-computed `cu_seqlens` / `cu_window_seqlens` boundaries were never actually used as a mask.

## Qwen2.5-VL ViT block-diagonal attention

The ViT interleaves two attention layer types and got both wrong for every image:

| Layer type | Intended attention | Before this fix |
|---|---|---|
| Full-attention (`fullatt_block_indexes`) | block-diagonal per **frame** (`cu_seqlens = repeat_interleave(h*w, t).cumsum()`) | **no mask at all** — patches from different images/frames attend to each other |
| Windowed (28 of 32 layers) | block-diagonal per **window** (tokens reordered by `window_index` + `cu_window_seqlens`) | a 1-D sliding-distance mask `abs(i-j) > window` |

That 1-D distance mask is wrong both ways: it lets tokens across window boundaries attend, and wrongly blocks same-window tokens farther apart than `window`. `cu_seqlens` / `cu_window_seqlens` were already computed and threaded into the attention call, **but only used as a truthiness flag, never as a mask** — so even a single normal-sized image is encoded incorrectly because it spans multiple windows.

**Fix (segment-id block-diagonal mask):**

```python
pos = jnp.arange(T)
seg = jnp.sum(pos[:, None] >= cu_seqlens[None, 1:], axis=1)  # segment id = #boundaries crossed
attn_mask = seg[:, None] == seg[None, :]                      # True = allowed
```

- Full-attention layers pass `cu_seqlens` (per-frame blocks); windowed layers pass `cu_window_seqlens` (per-window blocks) — the only difference between the two is now which cumulative array is passed. The `use_fullattn` / `window_size` dead plumbing is removed.
- `vision_attention` now takes a `[T, T]` bool mask instead of a scalar `window_size`.
- JIT-friendly (static shapes) and robust to zero-width segments: when a grid dim is an exact multiple of the window size, window padding produces duplicate boundaries (zero-width segments) that merely skip a segment id without affecting grouping.

**Why the reorder stays consistent:** `hidden_states` and `rotary_pos_emb` are reordered by `window_index` exactly once, and windows never cross frames — so the per-frame blocks of full-attention layers remain contiguous after the reorder, and the block-diagonal construction holds for both layer types. Semantics match the HuggingFace reference.

## Qwen3-Omni audio encoder per-window cu_seqlens mask

The audio encoder ran global bidirectional attention over the entire concatenated audio: `cu_seqlens` was never built and no mask was passed. HF Qwen3-Omni restricts attention to per-window blocks via `cu_seqlens`. Any audio spanning more than one window (the common case for real speech) therefore diverges from the reference → wrong audio embeddings, silently.

Fix: reconstruct `cu_seqlens` in the encoder forward exactly as HF (per-audio length split into `window_aftercnn`-sized blocks plus a remainder), build the same segment-id block-diagonal additive mask as the ViT fix, and thread it through `encoder_layer → attention → simple_attention` (`simple_attention` gains an optional `attn_mask`; its only caller is this encoder, so it is backward compatible).

## Known trade-off (GPU, not yet addressed)

The ViT fix loses flash attention on GPU: `flash_mha` cannot express the per-image / per-window block-diagonal mask, so once a mask is supplied (always, for this model) attention runs the **native** path — materializing an `[B, N, T, T]` score matrix, O(T²) time and memory.

- The flash fast path is kept only for the unmasked case, which this model no longer hits.
- Rationale: vision encoding runs once at prefill, not on the decode hot path.
- **Risk:** for high-resolution / multi-image prefill the materialized O(T²) buffer may **OOM** where flash attention would not — the first thing to watch when serving large images on GPU. Follow-up: a varlen / block-diagonal flash kernel that consumes `cu_seqlens` directly.

## Scope: only Qwen2.5-VL / Qwen3-Omni audio

Other vision/multimodal encoders were checked and are unaffected: `qwen3_omni_moe/vision_encoder.py` (`_create_attention_mask` already builds a correct per-frame block-diagonal mask, and has no windowed layers); `encoders/clip.py` (single-image full/causal, no multi-image concat or windows); `t5` / `wan` / `dits` / `vaes` (text / diffusion, different attention semantics).

## Testing

- `py_compile` / ast pass; pre-commit (black/ruff/isort/mypy) all green
- numpy checks: ViT segment-mask block-diagonal grouping, robustness to duplicate (zero-width) boundaries, single-block degenerate case; audio length invariant `sum(feature_lens_after_cnn) == cu_seqlens[-1]`, cu_seqlens construction, and the block-diagonal mask matching HF `_prepare_attention_mask`
- ⚠️ **No jax / real-model e2e** (no local jax). Attention numerical correctness should be validated on TPU against a real model.

## Follow-ups

- Reviewer check for future VL ViTs: confirm boundaries like `cu_seqlens` are actually used as a mask (per-frame block-diagonal for full layers; per-window for windowed layers), not just as a truthiness flag.
- If serving large images on GPU becomes a target, revisit the O(T²) path with a block-diagonal flash kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
