### PR TITLE
fix(quant): make qwen3_moe weight mapping quantization-aware for static FP8 (#1287)

### DIFF
--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -286,7 +286,15 @@ class ModelConfig:
                     moe_activation_dtype=None,
                     ignored_layers=ignored_layers,
                     weight_block_size=weight_block_size,
+                    # Static block scales are correct; the narrow-N guard targets
+                    # the dynamic online-quant path (computed at load time).
+                    allow_narrow_n_blockwise=weight_block_size is not None,
                 )
+                if weight_block_size is not None:
+                    logger.info(
+                        "Static block-wise FP8 (block=%s): enabling allow_narrow_n_blockwise.",
+                        weight_block_size,
+                    )
                 return quant_config
 
             elif quant_method == "compressed-tensors":

--- a/python/sgl_jax/srt/kernels/quantized_matmul/blockwise_utils.py
+++ b/python/sgl_jax/srt/kernels/quantized_matmul/blockwise_utils.py
@@ -224,7 +224,10 @@ def should_use_blockwise_kernel(
 
     When a tensor-parallel column shard collapses to a single output block
     (for example local N=128 with block_size_out=128), the TPU blockwise
-    kernel can produce NaNs on Qwen3-MoE k/v projections.
+    kernel can produce NaNs on Qwen3-MoE k/v projections. This is specific to
+    the dynamic online-quant path (scales computed at load time); static FP8
+    checkpoints ship correct offline block scales and opt past this guard via
+    ``allow_narrow_n_blockwise``.
     """
     return out_dim > block_size_out
 

--- a/python/sgl_jax/srt/kernels/quantized_matmul/kernel.py
+++ b/python/sgl_jax/srt/kernels/quantized_matmul/kernel.py
@@ -71,12 +71,11 @@ def xla_quantized_matmul_local(
                 "Block-wise quantized matmul requires the blockwise kernel, "
                 "but it failed to load. Please check your installation."
             )
-        # TODO: Investigate root cause of accuracy collapse for narrow-N TP-sharded
-        # layers with block-wise quant (e.g. Qwen3-30B-A3B k/v projections at TP=4
-        # achieve GSM8K 0.489 vs 0.938 for per-channel). Either fix the blockwise
-        # kernel for out_dim <= block_size_out, or fall back to per-channel for those
-        # layers. Models known to be unaffected (e.g. DeepSeek V3/R1) can set
-        # allow_narrow_n_blockwise=True to bypass this guard. The guard on the quant config is temporary
+        # Narrow-N TP-sharded block-wise quant (out_dim <= block_size_out) can
+        # collapse accuracy on the dynamic online-quant path (e.g. Qwen3-MoE k/v
+        # at TP=4) because the load-time scales are wrong there. Static FP8
+        # checkpoints ship correct offline scales and set
+        # allow_narrow_n_blockwise=True to bypass this guard.
         if not allow_narrow_n_blockwise and not should_use_blockwise_kernel(
             out_dim=int(out_dim),
             block_size_out=int(block_size_out),

--- a/python/sgl_jax/srt/models/qwen3_moe.py
+++ b/python/sgl_jax/srt/models/qwen3_moe.py
@@ -440,65 +440,99 @@ class Qwen3MoeForCausalLM(nnx.Module):
                 target_path="lm_head.embedding", sharding=("tensor", None), transpose=False
             )
 
+        quant_config = getattr(self.config, "quantization_config", None)
+        is_static_quant = quant_config is not None and getattr(
+            quant_config, "is_static_checkpoint", False
+        )
+
         num_layers = self.config.num_hidden_layers
         mlp_only_layers = getattr(self.config, "mlp_only_layers", [])
 
         for layer_idx in range(num_layers):
             layer_mappings = self._create_moe_layer_mappings(
-                layer_idx, layer_idx in mlp_only_layers
+                layer_idx, layer_idx in mlp_only_layers, is_static_quant
             )
             mappings.update(layer_mappings)
 
         return mappings
 
-    def _create_moe_layer_mappings(self, layer_idx: int, is_mlp_layer: bool) -> dict:
+    def _create_moe_layer_mappings(
+        self, layer_idx: int, is_mlp_layer: bool, is_static_quant: bool = False
+    ) -> dict:
         prefix = f"model.layers.{layer_idx}"
         target_prefix = f"model.layers.{layer_idx}"
 
-        mappings = {
-            f"{prefix}.input_layernorm.weight": WeightMapping(
-                target_path=f"{target_prefix}.input_layernorm.scale",
-                sharding=(None,),
+        mappings: dict = {}
+
+        def add_linear(hf_prefix, target_prefix, sharding_std, kv_head_padding=False):
+            # Static FP8 loads QuantizedLinear.weight_q `[out, in]` directly
+            # (transpose off, kernel axes swapped) + weight_scale_inv sidecar.
+            if not is_static_quant:
+                mappings[f"{hf_prefix}.weight"] = WeightMapping(
+                    target_path=f"{target_prefix}.weight",
+                    sharding=sharding_std,
+                    transpose=True,
+                    kv_head_padding=kv_head_padding,
+                )
+                return
+            sharding_quant = (sharding_std[1], sharding_std[0])
+            mappings[f"{hf_prefix}.weight"] = WeightMapping(
+                target_path=f"{target_prefix}.weight_q",
+                sharding=sharding_quant,
                 transpose=False,
-            ),
-            f"{prefix}.post_attention_layernorm.weight": WeightMapping(
-                target_path=f"{target_prefix}.post_attention_layernorm.scale",
-                sharding=(None,),
+                kv_head_padding=kv_head_padding,
+            )
+            # No kv_head_padding on the scale: expand handles the un-replicated n_out.
+            mappings[f"{hf_prefix}.weight_scale_inv"] = WeightMapping(
+                target_path=f"{target_prefix}.weight_scale",
+                sharding=sharding_quant,
                 transpose=False,
-            ),
-            f"{prefix}.self_attn.q_proj.weight": WeightMapping(
-                target_path=f"{target_prefix}.self_attn.q_proj.weight",
-                sharding=(None, "tensor"),
-                transpose=True,
-            ),
-            f"{prefix}.self_attn.k_proj.weight": WeightMapping(
-                target_path=f"{target_prefix}.self_attn.k_proj.weight",
-                sharding=(None, "tensor"),
-                transpose=True,
-                kv_head_padding=True,
-            ),
-            f"{prefix}.self_attn.v_proj.weight": WeightMapping(
-                target_path=f"{target_prefix}.self_attn.v_proj.weight",
-                sharding=(None, "tensor"),
-                transpose=True,
-                kv_head_padding=True,
-            ),
-            f"{prefix}.self_attn.o_proj.weight": WeightMapping(
-                target_path=f"{target_prefix}.self_attn.c_proj.weight",
-                sharding=("tensor", None),
-                transpose=True,
-            ),
-            f"{prefix}.self_attn.q_norm.weight": WeightMapping(
-                target_path=f"{target_prefix}.self_attn.q_norm.scale",
-                sharding=(None,),
-                transpose=False,
-            ),
-            f"{prefix}.self_attn.k_norm.weight": WeightMapping(
-                target_path=f"{target_prefix}.self_attn.k_norm.scale",
-                sharding=(None,),
-                transpose=False,
-            ),
-        }
+            )
+
+        mappings.update(
+            {
+                f"{prefix}.input_layernorm.weight": WeightMapping(
+                    target_path=f"{target_prefix}.input_layernorm.scale",
+                    sharding=(None,),
+                    transpose=False,
+                ),
+                f"{prefix}.post_attention_layernorm.weight": WeightMapping(
+                    target_path=f"{target_prefix}.post_attention_layernorm.scale",
+                    sharding=(None,),
+                    transpose=False,
+                ),
+                f"{prefix}.self_attn.q_norm.weight": WeightMapping(
+                    target_path=f"{target_prefix}.self_attn.q_norm.scale",
+                    sharding=(None,),
+                    transpose=False,
+                ),
+                f"{prefix}.self_attn.k_norm.weight": WeightMapping(
+                    target_path=f"{target_prefix}.self_attn.k_norm.scale",
+                    sharding=(None,),
+                    transpose=False,
+                ),
+            }
+        )
+
+        # k/v carry kv_head_padding for GQA; o_proj keeps the o_proj -> c_proj rename.
+        add_linear(
+            f"{prefix}.self_attn.q_proj", f"{target_prefix}.self_attn.q_proj", (None, "tensor")
+        )
+        add_linear(
+            f"{prefix}.self_attn.k_proj",
+            f"{target_prefix}.self_attn.k_proj",
+            (None, "tensor"),
+            kv_head_padding=True,
+        )
+        add_linear(
+            f"{prefix}.self_attn.v_proj",
+            f"{target_prefix}.self_attn.v_proj",
+            (None, "tensor"),
+            kv_head_padding=True,
+        )
+        add_linear(
+            f"{prefix}.self_attn.o_proj", f"{target_prefix}.self_attn.c_proj", ("tensor", None)
+        )
 
         if getattr(self.config, "attention_bias", False):
             bias_mappings = {
@@ -528,24 +562,13 @@ class Qwen3MoeForCausalLM(nnx.Module):
             mappings.update(bias_mappings)
 
         if is_mlp_layer:
-            mlp_mappings = {
-                f"{prefix}.mlp.gate_proj.weight": WeightMapping(
-                    target_path=f"{target_prefix}.mlp.gate_proj.weight",
-                    sharding=(None, "tensor"),
-                    transpose=True,
-                ),
-                f"{prefix}.mlp.up_proj.weight": WeightMapping(
-                    target_path=f"{target_prefix}.mlp.up_proj.weight",
-                    sharding=(None, "tensor"),
-                    transpose=True,
-                ),
-                f"{prefix}.mlp.down_proj.weight": WeightMapping(
-                    target_path=f"{target_prefix}.mlp.down_proj.weight",
-                    sharding=("tensor", None),
-                    transpose=True,
-                ),
-            }
-            mappings.update(mlp_mappings)
+            add_linear(
+                f"{prefix}.mlp.gate_proj", f"{target_prefix}.mlp.gate_proj", (None, "tensor")
+            )
+            add_linear(f"{prefix}.mlp.up_proj", f"{target_prefix}.mlp.up_proj", (None, "tensor"))
+            add_linear(
+                f"{prefix}.mlp.down_proj", f"{target_prefix}.mlp.down_proj", ("tensor", None)
+            )
         else:
             mappings[f"{prefix}.mlp.gate.weight"] = WeightMapping(
                 target_path=f"{target_prefix}.moe_gate.kernel",
@@ -554,6 +577,7 @@ class Qwen3MoeForCausalLM(nnx.Module):
             )
 
             moe_backend = getattr(self.config, "moe_backend", "epmoe")
+            use_fused = moe_backend == "fused"
             num_experts = getattr(self.config, "num_experts", 128)
 
             # Get physical to logical mapping for redundant experts
@@ -595,6 +619,29 @@ class Qwen3MoeForCausalLM(nnx.Module):
                 physical_to_logical_map=phy_to_log,
             )
             mappings.update(moe_mappings)
+
+            # Routed-expert weight_scale_inv sidecars. fused needs the scale on
+            # the model mesh (data, tensor) + transpose to match its expert
+            # weights; epmoe keeps it on the expert mesh.
+            if is_static_quant:
+                for moe_key, wm in list(moe_mappings.items()):
+                    if not moe_key.startswith("__MOE_EXPERTS__"):
+                        continue
+                    target_base = wm.target_path[0]
+                    expert_scale_keys = [
+                        k.replace(".weight", ".weight_scale_inv") for k in wm.target_path[1:]
+                    ]
+                    scale_target = f"{target_base}_scale"
+                    scale_sharding = (
+                        (("data", "tensor"), None, None) if use_fused else ("expert", None, None)
+                    )
+                    mappings[f"__MOE_EXPERTS__{scale_target}"] = WeightMapping(
+                        target_path=[scale_target] + expert_scale_keys,
+                        sharding=scale_sharding,
+                        transpose=use_fused,
+                        concat_axis=wm.concat_axis,
+                        physical_to_logical_map=wm.physical_to_logical_map,
+                    )
 
         return mappings
 


### PR DESCRIPTION
## Motivation

Closes #1287. Loading a static block-wise FP8 Qwen3-MoE checkpoint (`Qwen/Qwen3-30B-A3B-FP8`) crashes during weight loading.

The static-FP8 structure prep swaps every `LinearBase` for a `QuantizedLinear` (params `weight_q` + `weight_scale`) **before** `load_weights` runs, but `qwen3_moe`'s weight mapping still targeted the now-removed `*.weight`, so `_get_param` raised `... is not a valid param path` at layer 0 (3/435 weights loaded).

## Modifications

- **`models/qwen3_moe.py`** — make `_create_moe_layer_mappings` quantization-aware, mirroring DeepSeek-V3: for static-quant linears emit `*.weight_q` plus a `weight_scale_inv -> weight_scale` sidecar (sharding axes swapped, `transpose=False`), and register per-expert MoE scale sidecars for **both `epmoe` and `fused`** backends (fused puts the scale on the model mesh with transpose, following `mimo_v2_flash`). `weight_q` keeps `kv_head_padding` for GQA; the linear scale sidecar does not. Layernorms, q/k norms and the router gate stay bf16.
- **`configs/model_config.py`** — set `allow_narrow_n_blockwise` on the auto-detected static block-wise FP8 config, and update the narrow-N guard notes (`should_use_blockwise_kernel` / `kernel.py`): the collapse/NaNs are specific to the **dynamic online-quant** path (scales computed at load time); loaded static checkpoints ship correct block scales and pass through. Dynamic quant uses a separate config path and stays guarded.

## Accuracy (v6e-4, TP4/EP4, `Qwen3-30B-A3B-FP8`, full GSM8K 1319)

| backend | GSM8K |
| --- | --- |
| epmoe | **0.931** |
| fused | **0.935** |
| bf16 baseline | 0.938 |

All 435 weights load; no NaNs. FP8 static ≈ bf16 on both backends. Unblocks the `qwen3-moe-fp8` nightly accuracy gate (#1200 §1.1.5 / PR #1246).

### Launch config used (pure auto-detect, no `--quantization-config-path`)

```
python -m sgl_jax.launch_server --trust-remote-code --device tpu \
  --model-path Qwen/Qwen3-30B-A3B-FP8 --download-dir /dev/shm/ \
  --tp-size 4 --ep-size 4 --moe-backend {epmoe|fused} \
  --dtype bfloat16 --attention-backend fa --page-size 64 \
  --skip-server-warmup --random-seed 3 \
  --mem-fraction-static 0.9 --max-prefill-tokens 8192 \
  --max-running-requests 128 --precompile-bs-paddings 128 --precompile-token-paddings 8192
```

`fused` requires `--max-running-requests` and `--precompile-bs-paddings` to be multiples of `ep_size` (the fused MoE kernel asserts `num_tokens % ep_size == 0`); `epmoe` has no such constraint. Concurrency/`mem-fraction-static` follow Brian's #1246 review suggestions and are perf knobs (no effect on the score).

## Scope

`qwen2_moe` and the `qwen3_omni` thinker share the same latent mapping gap, but neither has an official FP8 checkpoint to validate against, so they are out of scope.

Refs #1200 #1246

🤖 Generated with [Claude Code](https://claude.com/claude-code)