### PR TITLE
[SpecDecode] phase2 performance tuning, compatible with scheduler overlap

### DIFF
--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -173,6 +173,18 @@ class ModelConfig:
             # Each draft runner is a single SWA layer; without this the KV pool
             # sizes for all 70 target layers and OOMs.
             self.hf_config.num_hidden_layers = 1
+            # MTP uses SWA attention; override KV head count and head dims so
+            # the KV cache shape matches the SWA layer output, not the full-
+            # attention target config.
+            self.hf_config.num_key_value_heads = getattr(
+                self.hf_config, "swa_num_key_value_heads", self.hf_config.num_key_value_heads
+            )
+            self.hf_config.num_attention_heads = getattr(
+                self.hf_config, "swa_num_attention_heads", self.hf_config.num_attention_heads
+            )
+            self.hf_config.head_dim = getattr(
+                self.hf_config, "swa_head_dim", self.hf_config.head_dim
+            )
             if self.quantization_config is not None:
                 # eh_proj / o_proj are BF16 in model_mtp.safetensors (no
                 # weight_scale_inv); keep them as plain LinearBase so mappings

--- a/python/sgl_jax/srt/kernels/speculative/kernel.py
+++ b/python/sgl_jax/srt/kernels/speculative/kernel.py
@@ -1,6 +1,8 @@
 import jax
 import jax.numpy as jnp
 
+from sgl_jax.srt.layers.binary_search import float32_bsearch, topk_mask
+
 
 def create_extend_after_decode_spec_info(
     verified_id,
@@ -90,6 +92,14 @@ def verify_tree_greedy(
     return accept_index, accept_token_num, predicts
 
 
+# top-k / top-p renorm only need an inclusion *threshold* (keep every prob >= t),
+# not a sorted order -- and on TPU a sort / large-k top_k over the vocab dominated
+# device time (~29ms, ~48% of the verify step). We reuse the shared, TPU-tuned
+# bit-exact binary search from layers/binary_search.py (the same primitive the
+# regular sampler's mask path uses): mass/count above t is monotone in t, so the
+# threshold is found with a fixed bit-search and no sort.
+
+
 def top_k_renorm_prob(probs, top_k_values):
     """Renormalizing probabilities by top-k thresholding.
 
@@ -105,14 +115,10 @@ def top_k_renorm_prob(probs, top_k_values):
         probs.shape[0] == top_k_values.shape[0]
     ), f"probs.shape[0]: {probs.shape[0]} should equal to top_k_values.shape[0]: {top_k_values.shape}"
 
-    # TODO: optimize alg of top_k by avoiding sort
-    def process_single_sample(prob_row, k):
-        ranks = jnp.argsort(jnp.argsort(prob_row)[::-1])
-        mask = ranks < k
-        masked_probs = jnp.where(mask, prob_row, 0.0)
-        return masked_probs / jnp.sum(masked_probs)
-
-    return jax.vmap(process_single_sample, in_axes=(0, 0))(probs, top_k_values)
+    # topk_mask keeps the largest k values per row (ties may keep >k) and zeros the
+    # rest; k covering the whole vocabulary (TOP_K_ALL) keeps everything.
+    masked_probs = topk_mask(probs, top_k_values.reshape(-1), replace_val=0.0)
+    return masked_probs / jnp.sum(masked_probs, axis=-1, keepdims=True)
 
 
 def top_p_renorm_prob(probs, top_p_values):
@@ -130,22 +136,21 @@ def top_p_renorm_prob(probs, top_p_values):
         probs.shape[0] == top_p_values.shape[0]
     ), f"probs.shape[0]: {probs.shape[0]} should equal to top_k_values.shape[0]: {top_p_values.shape}"
 
-    # TODO: optimize alg of top_p by avoiding sort
-    def process_single_sample(prob_row, top_p):
-        sorted_indices = jnp.argsort(prob_row)[::-1]
-        sorted_probs = prob_row[sorted_indices]
+    # Largest threshold whose kept probability mass is still >= top_p, via the shared
+    # bit-exact float32 binary search. The vocab axis is moved to second-to-last so
+    # the per-step reductions don't run across vector lanes (slow on TPU) -- the same
+    # layout trick as binary_search.topp_mask.
+    p = top_p_values.reshape(-1)
+    probs_t = jnp.swapaxes(probs, -1, -2)
 
-        cumsum_probs = jnp.cumsum(sorted_probs)
-        cutoff_idx = jnp.argmax(cumsum_probs >= top_p)
+    def predicate(threshold):
+        threshold = jax.lax.expand_dims(threshold, (0,))
+        mass = jnp.sum(jnp.where(probs_t >= threshold, probs_t, 0.0), axis=0)
+        return mass < p
 
-        ranks = jnp.argsort(jnp.argsort(prob_row)[::-1])
-
-        mask = ranks <= cutoff_idx
-
-        masked_probs = jnp.where(mask, prob_row, 0.0)
-        return masked_probs / jnp.sum(masked_probs)
-
-    return jax.vmap(process_single_sample, in_axes=(0, 0))(probs, top_p_values)
+    threshold = float32_bsearch((probs.shape[0],), predicate)
+    masked_probs = jnp.where(probs >= threshold[:, None], probs, 0.0)
+    return masked_probs / jnp.sum(masked_probs, axis=-1, keepdims=True)
 
 
 def _sampling_from_prob(probs: jax.Array, threshold: jax.Array):

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -281,7 +281,9 @@ class FlashAttention(AttentionBackend):
             ) * self.page_size
         cu_kv_lens = _per_dp_cumsum(aligned_seq_lens, dp_size, per_dp_bs)
 
-        if batch.forward_mode == ForwardMode.DRAFT_EXTEND:
+        if batch.forward_mode == ForwardMode.DRAFT_EXTEND and not getattr(
+            batch.spec_info_padded, "device_seq_lens_for_draft_extend", False
+        ):
             # Truncate each req's page list from allocate_len → seq_len, keeping
             # the DP-segmented layout from padding_for_decode (rank r's pages
             # at [r*per_dp_pg : ...]). page_indices (line 212) is already

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -212,16 +212,7 @@ class FlashAttention(AttentionBackend):
         page_indices = (selected_cache_locs // self.page_size).astype(np.int32)
 
         if batch.forward_mode == ForwardMode.TARGET_VERIFY:
-            # convert custom_mask from bool to int32, because dma not support bool type
-            if batch.spec_info_padded.custom_mask.dtype == jnp.bool:
-                # FIXME(pc) rm this dtype convert
-                logger.warning(
-                    "batch.spec_info_padded.custom_mask type is  %s, it may make performance very low",
-                    batch.spec_info_padded.custom_mask.dtype,
-                )
-                metadata.custom_mask = batch.spec_info_padded.custom_mask.astype(jnp.int32)
-            else:
-                metadata.custom_mask = batch.spec_info_padded.custom_mask
+            metadata.custom_mask = batch.spec_info_padded.custom_mask
         else:
             metadata.custom_mask = None
 

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -213,6 +213,10 @@ class FlashAttention(AttentionBackend):
 
         if batch.forward_mode == ForwardMode.TARGET_VERIFY:
             metadata.custom_mask = batch.spec_info_padded.custom_mask
+            if metadata.custom_mask is not None:
+                assert (
+                    metadata.custom_mask.dtype != jnp.bool_
+                ), "custom_mask bool dtype is not supported; use int32 instead."
         else:
             metadata.custom_mask = None
 

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -71,6 +71,7 @@ GLOBAL_SERVER_ARGS_KEYS = [
     "device",
     "chunked_prefill_size",
     "disable_radix_cache",
+    "speculative_algorithm",
     "speculative_accept_threshold_single",
     "speculative_accept_threshold_acc",
     "enable_deterministic_sampling",
@@ -1221,6 +1222,10 @@ class ScheduleBatch:
             info.reqs if selected_indices is None else [info.reqs[i] for i in selected_indices]
         )
 
+        spec_info = getattr(info, "spec_info", None)
+        if spec_info is not None and hasattr(spec_info, "new_tokens_required_next_decode"):
+            return spec_info.new_tokens_required_next_decode(requests, page_size)
+
         new_pages = sum(1 for r in requests if r.kv_committed_len % page_size == 0)
         return new_pages * page_size
 
@@ -1514,7 +1519,16 @@ class ScheduleBatch:
                     info.seq_lens = None
                     info.out_cache_loc = None
                     info.seq_lens_sum = 0
+                    info.spec_info = None
+                elif (
+                    info.spec_info is not None
+                    and getattr(info.spec_info, "allocate_lens", None) is not None
+                    and len(info.spec_info.allocate_lens) != len(info.reqs)
+                ):
+                    info.spec_info.trim_to_length(len(info.reqs))
             flat_spec = self._concat_spec_info_per_rank([info.spec_info for info in self.reqs_info])
+            if getattr(flat_spec, "pending_draft_extend_result", None) is not None:
+                flat_spec.resolve_pending_draft_extend_result()
             flat_spec.prepare_for_decode(self)
             real_bs_per_dp = [len(info.reqs) if info.reqs else 0 for info in self.reqs_info]
             per_rank_spec = self._split_spec_info_per_rank(flat_spec, real_bs_per_dp)
@@ -1660,6 +1674,14 @@ class ScheduleBatch:
 
             # Early exit: No filtering needed if all requests kept
             if len(keep_indices_dp) == len(info.reqs):
+                spec_info_len = (
+                    None
+                    if info.spec_info is None
+                    or getattr(info.spec_info, "allocate_lens", None) is None
+                    else len(info.spec_info.allocate_lens)
+                )
+                if spec_info_len is not None and spec_info_len != len(info.reqs):
+                    info.spec_info.trim_to_length(len(info.reqs))
                 continue
 
             # Filter reqs list
@@ -1792,7 +1814,8 @@ class ScheduleBatch:
                     and other_info.top_logprobs_nums is not None
                 ):
                     self_info.top_logprobs_nums.extend(other_info.top_logprobs_nums)
-                    self_info.token_ids_logprobs.extend(other_info.token_ids_logprobs)
+                self_info.token_ids_logprobs.extend(other_info.token_ids_logprobs)
+
             elif self.return_logprob and self_info.top_logprobs_nums is not None:
                 self_info.top_logprobs_nums.extend([0] * len(other_info.reqs))
                 self_info.token_ids_logprobs.extend([None] * len(other_info.reqs))
@@ -2360,13 +2383,25 @@ class ScheduleBatch:
             logits_indices_selector,
         ) = self._merge_batch_metadata(per_dp_bs, total_bs)
         sampling_info = self._merge_sampling_info(per_dp_bs, total_bs)
+        for dp_rank, info in enumerate(self.reqs_info):
+            spec_info_dp = info.spec_info
+            future_indices = getattr(spec_info_dp, "future_indices", None)
+            if future_indices is None:
+                continue
+            num_reqs = len(info.reqs) if info.reqs is not None else 0
+            assert len(future_indices) == num_reqs, (
+                f"future_indices length mismatch on dp_rank={dp_rank}: "
+                f"{len(future_indices)=}, {num_reqs=}"
+            )
         # Concat per-rank spec_info into a cross-rank-flat EagleDraftInput,
         # then scatter into DP-padded (total_bs, ...) slots so spec_info[i]
         # aligns with seq_lens[i]. Returns a new object — does not mutate
         # the per-rank cross-round state on reqs_info[r].spec_info.
         flat_spec = self._concat_spec_info_per_rank([info.spec_info for info in self.reqs_info])
+        if getattr(flat_spec, "pending_draft_extend_result", None) is not None:
+            flat_spec.resolve_pending_draft_extend_result()
         spec_info = self._scatter_spec_info_to_dp_slots(
-            flat_spec, logits_indices_selector, total_bs
+            flat_spec, logits_indices_selector, total_bs, mesh=self.mesh
         )
         # Per-rank out_cache_loc chunks (set in spec prepare_for_decode) have
         # variable length (∝ accept_len). DP-segment: pad each to max_len with
@@ -2380,10 +2415,18 @@ class ScheduleBatch:
             )
             for i in self.reqs_info
         ]
-        # Pad each rank's out_cache_loc to per_dp_bs * draft_token_num so the
-        # merged shape is stable across runtime bs. max_chunk_len defensive.
+        # Spec prepare_for_decode conservatively reserves up to
+        # 2 * ALLOC_LEN_PER_DECODE tokens per request. Keep the JIT-visible
+        # out_cache_loc shape on that same conservative bucket instead of the
+        # smaller draft-token count, otherwise high-running batches can escape
+        # precompile with shapes like 656/928/1024.
         max_chunk_len = max((len(c) for c in ocl_chunks), default=0)
-        target_per_rank_ocl = max(per_dp_bs * draft_token_num, max_chunk_len)
+        target_per_rank_ocl = per_dp_bs * draft_token_num * 2
+        assert max_chunk_len <= target_per_rank_ocl, (
+            "spec decode out_cache_loc escaped precompile bucket: "
+            f"max_chunk_len={max_chunk_len}, bucket_per_rank={target_per_rank_ocl}, "
+            f"per_dp_bs={per_dp_bs}, draft_token_num={draft_token_num}"
+        )
         out_cache_loc = (
             np.concatenate(
                 [
@@ -2394,7 +2437,7 @@ class ScheduleBatch:
             if target_per_rank_ocl > 0
             else np.empty(0, dtype=np.int32)
         )
-        return ModelWorkerBatch(
+        model_worker_batch = ModelWorkerBatch(
             bid=acc_global_bid(),
             forward_mode=self.forward_mode,
             input_ids=np.empty(0, dtype=np.int32),
@@ -2432,9 +2475,12 @@ class ScheduleBatch:
             tree_cache=self.tree_cache,
             mrope_positions=None,
         )
+        return model_worker_batch
 
     @staticmethod
-    def _scatter_spec_info_to_dp_slots(flat, selector: np.ndarray, total_bs: int):
+    def _scatter_spec_info_to_dp_slots(
+        flat, selector: np.ndarray, total_bs: int, mesh: mesh_lib.Mesh = None
+    ):
         """Scatter global-flat spec_info arrays into DP-padded ``(total_bs, …)``.
 
         ``selector[k]`` is the DP-padded slot of the k-th global-flat req
@@ -2442,23 +2488,32 @@ class ScheduleBatch:
         the cross-round flat state on ``reqs_info[r].spec_info`` is unchanged.
         """
 
-        def _scatter1(arr):
+        def _scatter1(arr, *, require_selector_len: bool = True, data_sharded: bool = False):
             if arr is None:
                 return None
             a = np.asarray(arr)
+            if require_selector_len and a.shape[0] != len(selector):
+                return None
             out = np.zeros((total_bs,) + a.shape[1:], dtype=a.dtype)
             out[selector] = a
+            if data_sharded and mesh is not None:
+                from jax.sharding import NamedSharding
+                from jax.sharding import PartitionSpec as P
+
+                return jax.device_put(out, NamedSharding(mesh, P("data")))
             return out
 
         return type(flat)(
-            topk_p=_scatter1(flat.topk_p),
-            topk_index=_scatter1(flat.topk_index),
+            topk_p=_scatter1(flat.topk_p, data_sharded=True),
+            topk_index=_scatter1(flat.topk_index, data_sharded=True),
             hidden_states=_scatter1(flat.hidden_states),
-            verified_id=_scatter1(flat.verified_id),
+            verified_id=_scatter1(flat.verified_id, data_sharded=True),
             allocate_lens=_scatter1(flat.allocate_lens),
             capture_hidden_mode=flat.capture_hidden_mode,
-            accept_length=flat.accept_length,
-            accept_length_cpu=flat.accept_length_cpu,
+            accept_length=_scatter1(flat.accept_length),
+            accept_length_cpu=_scatter1(flat.accept_length_cpu),
+            new_seq_lens=_scatter1(flat.new_seq_lens),
+            future_indices=_scatter1(flat.future_indices),
         )
 
     @staticmethod
@@ -2472,7 +2527,42 @@ class ScheduleBatch:
         if flat is None:
             return [None] * len(real_bs_per_dp)
 
-        flat._ensure_host()
+        has_future_indices = getattr(flat, "future_indices", None) is not None
+        if getattr(flat, "pending_draft_extend_result", None) is not None:
+            flat.resolve_pending_draft_extend_result()
+        if not has_future_indices:
+            flat._ensure_host()
+            required_fields = ("topk_p", "topk_index", "hidden_states", "verified_id")
+            missing = [f for f in required_fields if getattr(flat, f, None) is None]
+            if missing:
+
+                def _field_state(v):
+                    if v is None:
+                        return None
+                    shape = getattr(v, "shape", None)
+                    if shape is not None:
+                        return shape
+                    return len(v)
+
+                field_states = {
+                    f: _field_state(getattr(flat, f, None))
+                    for f in (
+                        "topk_p",
+                        "topk_index",
+                        "hidden_states",
+                        "verified_id",
+                        "allocate_lens",
+                        "accept_length",
+                        "accept_length_cpu",
+                        "new_seq_lens",
+                        "future_indices",
+                    )
+                }
+                raise RuntimeError(
+                    "_split_spec_info_per_rank got incomplete EagleDraftInput "
+                    f"without pending_draft_extend_result; missing={missing}, "
+                    f"field_states={field_states}, real_bs_per_dp={real_bs_per_dp}"
+                )
 
         per_req_fields = (
             "topk_p",
@@ -2482,6 +2572,8 @@ class ScheduleBatch:
             "allocate_lens",
             "accept_length",
             "accept_length_cpu",
+            "new_seq_lens",
+            "future_indices",
         )
 
         out = []
@@ -2493,7 +2585,15 @@ class ScheduleBatch:
             kwargs = {"capture_hidden_mode": flat.capture_hidden_mode}
             for f in per_req_fields:
                 v = getattr(flat, f, None)
-                kwargs[f] = None if v is None else v[offset : offset + n]
+                if has_future_indices and f not in (
+                    "allocate_lens",
+                    "new_seq_lens",
+                    "accept_length_cpu",
+                    "future_indices",
+                ):
+                    kwargs[f] = None
+                else:
+                    kwargs[f] = None if v is None else v[offset : offset + n]
             out.append(type(flat)(**kwargs))
             offset += n
         return out
@@ -2510,6 +2610,19 @@ class ScheduleBatch:
         if not nonempty:
             return None
 
+        has_future_indices = any(getattr(s, "future_indices", None) is not None for s in nonempty)
+        if has_future_indices:
+            assert all(getattr(s, "future_indices", None) is not None for s in nonempty), (
+                "_concat_spec_info_per_rank requires every nonempty rank to carry "
+                "future_indices on the relay-buffer path"
+            )
+        elif any(getattr(s, "pending_draft_extend_result", None) is not None for s in nonempty):
+            for spec_info in nonempty:
+                spec_info.resolve_pending_draft_extend_result()
+        else:
+            for spec_info in nonempty:
+                spec_info.resolve_pending_draft_extend_result()
+
         per_req_fields = (
             "topk_p",
             "topk_index",
@@ -2518,13 +2631,20 @@ class ScheduleBatch:
             "allocate_lens",
             "accept_length",
             "accept_length_cpu",
+            "new_seq_lens",
+            "future_indices",
         )
 
-        kwargs = {"capture_hidden_mode": nonempty[0].capture_hidden_mode}
+        kwargs = {
+            "capture_hidden_mode": nonempty[0].capture_hidden_mode,
+        }
         for f in per_req_fields:
             vals = [getattr(s, f, None) for s in nonempty]
             nonnull = [v for v in vals if v is not None]
             if not nonnull:
+                kwargs[f] = None
+                continue
+            if f in ("accept_length", "accept_length_cpu") and len(nonnull) != len(nonempty):
                 kwargs[f] = None
                 continue
             # All nonempty ranks should agree on which optional fields they
@@ -2827,6 +2947,7 @@ class ScheduleBatch:
             # _input_logprob_lens_per_dp, which reads these.
             new_info.extend_lens = info.extend_lens
             new_info.extend_logprob_start_lens = info.extend_logprob_start_lens
+            new_info.spec_info = info.spec_info
             copied_reqs_info.append(new_info)
 
         return ScheduleBatch(

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -58,6 +58,7 @@ from sgl_jax.srt.precision_tracer import (
 from sgl_jax.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sgl_jax.srt.sampling.sampling_params import DEFAULT_SAMPLING_SEED, SamplingParams
 from sgl_jax.srt.server_args import ServerArgs
+from sgl_jax.srt.speculative.overlap_utils import use_legacy_eagle3_non_overlap
 from sgl_jax.srt.utils.common_utils import get_bool_env_var, pad_to_bucket
 
 if TYPE_CHECKING:
@@ -2400,8 +2401,15 @@ class ScheduleBatch:
         flat_spec = self._concat_spec_info_per_rank([info.spec_info for info in self.reqs_info])
         if getattr(flat_spec, "pending_draft_extend_result", None) is not None:
             flat_spec.resolve_pending_draft_extend_result()
+        legacy_eagle3_non_overlap = use_legacy_eagle3_non_overlap(
+            self.enable_overlap, self.spec_algorithm
+        )
         spec_info = self._scatter_spec_info_to_dp_slots(
-            flat_spec, logits_indices_selector, total_bs, mesh=self.mesh
+            flat_spec,
+            logits_indices_selector,
+            total_bs,
+            mesh=self.mesh,
+            legacy_host_scatter=legacy_eagle3_non_overlap,
         )
         # Per-rank out_cache_loc chunks (set in spec prepare_for_decode) have
         # variable length (∝ accept_len). DP-segment: pad each to max_len with
@@ -2421,12 +2429,15 @@ class ScheduleBatch:
         # smaller draft-token count, otherwise high-running batches can escape
         # precompile with shapes like 656/928/1024.
         max_chunk_len = max((len(c) for c in ocl_chunks), default=0)
-        target_per_rank_ocl = per_dp_bs * draft_token_num * 2
-        assert max_chunk_len <= target_per_rank_ocl, (
-            "spec decode out_cache_loc escaped precompile bucket: "
-            f"max_chunk_len={max_chunk_len}, bucket_per_rank={target_per_rank_ocl}, "
-            f"per_dp_bs={per_dp_bs}, draft_token_num={draft_token_num}"
-        )
+        if use_legacy_eagle3_non_overlap(self.enable_overlap, self.spec_algorithm):
+            target_per_rank_ocl = max(per_dp_bs * draft_token_num, max_chunk_len)
+        else:
+            target_per_rank_ocl = per_dp_bs * draft_token_num * 2
+            assert max_chunk_len <= target_per_rank_ocl, (
+                "spec decode out_cache_loc escaped precompile bucket: "
+                f"max_chunk_len={max_chunk_len}, bucket_per_rank={target_per_rank_ocl}, "
+                f"per_dp_bs={per_dp_bs}, draft_token_num={draft_token_num}"
+            )
         out_cache_loc = (
             np.concatenate(
                 [
@@ -2479,7 +2490,11 @@ class ScheduleBatch:
 
     @staticmethod
     def _scatter_spec_info_to_dp_slots(
-        flat, selector: np.ndarray, total_bs: int, mesh: mesh_lib.Mesh = None
+        flat,
+        selector: np.ndarray,
+        total_bs: int,
+        mesh: mesh_lib.Mesh = None,
+        legacy_host_scatter: bool = False,
     ):
         """Scatter global-flat spec_info arrays into DP-padded ``(total_bs, …)``.
 
@@ -2502,6 +2517,20 @@ class ScheduleBatch:
 
                 return jax.device_put(out, NamedSharding(mesh, P("data")))
             return out
+
+        if legacy_host_scatter:
+            return type(flat)(
+                topk_p=_scatter1(flat.topk_p),
+                topk_index=_scatter1(flat.topk_index),
+                hidden_states=_scatter1(flat.hidden_states),
+                verified_id=_scatter1(flat.verified_id),
+                allocate_lens=_scatter1(flat.allocate_lens),
+                capture_hidden_mode=flat.capture_hidden_mode,
+                accept_length=flat.accept_length,
+                accept_length_cpu=flat.accept_length_cpu,
+                new_seq_lens=_scatter1(flat.new_seq_lens),
+                future_indices=_scatter1(flat.future_indices),
+            )
 
         return type(flat)(
             topk_p=_scatter1(flat.topk_p, data_sharded=True),

--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -442,6 +442,15 @@ class PrefillAdder:
             )
         if _rem_tokens <= 0:
             if self.is_hybrid:
+                # Caller already ran init_next_round_input(), which reset
+                # fill_ids to the full input. If we return here without
+                # scheduling, the next round's cache_unfinished_req() will
+                # treat that full length as committed prefix, then compute
+                # extend_input_len==0 and schedule a zero-extend chunked req.
+                # A q_len==0 seq inside the RPA kernel's [start_seq, end_seq)
+                # range deadlocks the DMA pipeline (#1266). Restore fill_ids
+                # to the actually-committed prefix before bailing.
+                req.fill_ids = req.fill_ids[: len(req.prefix_indices)]
                 return req
             _rem_tokens = self.rem_chunk_tokens_list[dp_rank]
         truncated = req.extend_input_len > _rem_tokens

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1926,84 +1926,20 @@ class Scheduler(
                 next_token_ids = np.array(jax.device_get(next_token_ids_device))
                 self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
         else:
-            if batch.forward_mode.is_extend():
-                # Spec extend always uses the padded mwb so target and draft
-                # see identical shapes regardless of dp_size / multi-layer
-                # (#1090 + #1053 P1-5b assert dp>1 spec extend must go here).
-                model_worker_batch = batch.get_model_worker_batch(
-                    precompile_token_paddings,
-                    precompile_bs_paddings,
-                    precompile_cache_loc_paddings,
-                    self.page_size,
-                    self.server_args.enable_static_lora,
-                )
-            else:
-                model_worker_batch = batch.get_spec_model_worker_batch(
-                    precompile_token_paddings,
-                    precompile_bs_paddings,
-                    precompile_cache_loc_paddings,
-                    self.page_size,
-                    self.server_args.enable_static_lora,
-                    draft_token_num=self.draft_worker.speculative_num_draft_tokens,
-                )
-            use_spec_decode_overlap = can_use_spec_decode_overlap(
-                self.enable_overlap, self.spec_algorithm, batch
+            (
+                model_worker_batch,
+                batch_output,
+                next_token_ids,
+                logits_output,
+                cache_miss_count,
+                defer_spec_output,
+                defer_spec_prefill_output,
+            ) = self._run_speculative_batch(
+                batch,
+                precompile_token_paddings,
+                precompile_bs_paddings,
+                precompile_cache_loc_paddings,
             )
-            use_spec_prefill_overlap = can_use_spec_prefill_overlap(
-                self.enable_overlap, self.spec_algorithm, batch
-            )
-            if use_spec_decode_overlap:
-                batch_output, published_new_seq_lens = (
-                    self.draft_worker.forward_batch_speculative_decode_overlap(model_worker_batch)
-                )
-            elif use_spec_prefill_overlap:
-                batch_output = self.draft_worker.forward_batch_speculative_prefill_overlap(
-                    model_worker_batch
-                )
-                published_new_seq_lens = None
-            else:
-                batch_output = self.draft_worker.forward_batch_speculative_generation(
-                    model_worker_batch
-                )
-                published_new_seq_lens = (
-                    publish_spec_decode_new_seq_lens(batch_output)
-                    if batch.forward_mode.is_decode()
-                    else None
-                )
-            if batch_output.next_draft_input is not None:
-                per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
-                    batch_output.next_draft_input, model_worker_batch.real_bs_per_dp
-                )
-                for r, s in enumerate(per_rank_spec):
-                    batch.reqs_info[r].spec_info = s
-            if not use_spec_decode_overlap:
-                new_seq_lens = (
-                    np.asarray(jax.device_get(published_new_seq_lens))
-                    if published_new_seq_lens is not None
-                    else None
-                )
-                per_dp_bs = model_worker_batch.per_dp_bs_size
-                for dp_rank, info in enumerate(batch.reqs_info):
-                    if info.seq_lens is None or len(info.seq_lens) == 0:
-                        continue
-                    if new_seq_lens is not None:
-                        off = dp_rank * per_dp_bs
-                        info.seq_lens = new_seq_lens[off : off + len(info.seq_lens)]
-                    else:
-                        info.seq_lens = info.seq_lens + 1
-            defer_spec_decode_output = (
-                self.enable_overlap
-                and batch.forward_mode.is_decode()
-                and self.spec_algorithm is not None
-                and not self.spec_algorithm.is_none()
-            )
-            defer_spec_prefill_output = use_spec_prefill_overlap
-            defer_spec_output = defer_spec_decode_output or defer_spec_prefill_output
-            if not defer_spec_output:
-                next_token_ids = np.asarray(jax.device_get(batch_output.next_token_ids))
-                self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
-            logits_output = batch_output.logits_output
-            cache_miss_count = batch_output.cache_miss_count
         bid = model_worker_batch.bid
 
         # These 2 values are needed for processing the output, but the values can be
@@ -2081,26 +2017,6 @@ class Scheduler(
         elif batch.forward_mode.is_dummy_first():
             self.set_next_batch_sampling_info_done(batch)
 
-    def get_idle_batch(self):
-        # Create empty request lists for each DP rank
-        reqs_per_dp = [[] for _ in range(self.dp_size)]
-
-        idle_batch = ScheduleBatch.init_new(
-            reqs_per_dp,
-            self.req_to_token_pool,
-            self.token_to_kv_pool_allocator,
-            self.tree_cache,
-            self.model_config,
-            self.enable_overlap,
-            self.dp_size,
-            spec_algorithm=self.spec_algorithm,
-            enable_custom_logit_processor=self.server_args.enable_custom_logit_processor,
-            chunked_reqs=None,
-            mesh=self.mesh,
-        )
-        idle_batch.prepare_for_idle()
-        return idle_batch
-
     def set_next_batch_sampling_info_done(self, batch: ScheduleBatch):
         if batch.next_batch_sampling_info:
             # Update grammar vocab masks for next batch in overlap mode
@@ -2112,6 +2028,98 @@ class Scheduler(
         if self.spec_algorithm is not None and not self.spec_algorithm.is_none():
             return self.draft_worker
         return self.tp_worker
+
+    def _run_speculative_batch(
+        self,
+        batch: ScheduleBatch,
+        precompile_token_paddings,
+        precompile_bs_paddings,
+        precompile_cache_loc_paddings,
+    ):
+        if batch.forward_mode.is_extend():
+            # Spec extend always uses the padded mwb so target and draft
+            # see identical shapes regardless of dp_size / multi-layer
+            # (#1090 + #1053 P1-5b assert dp>1 spec extend must go here).
+            model_worker_batch = batch.get_model_worker_batch(
+                precompile_token_paddings,
+                precompile_bs_paddings,
+                precompile_cache_loc_paddings,
+                self.page_size,
+                self.server_args.enable_static_lora,
+            )
+        else:
+            model_worker_batch = batch.get_spec_model_worker_batch(
+                precompile_token_paddings,
+                precompile_bs_paddings,
+                precompile_cache_loc_paddings,
+                self.page_size,
+                self.server_args.enable_static_lora,
+                draft_token_num=self.draft_worker.speculative_num_draft_tokens,
+            )
+
+        use_spec_decode_overlap = can_use_spec_decode_overlap(
+            self.enable_overlap, self.spec_algorithm, batch
+        )
+        use_spec_prefill_overlap = can_use_spec_prefill_overlap(
+            self.enable_overlap, self.spec_algorithm, batch
+        )
+        if use_spec_decode_overlap:
+            batch_output, published_new_seq_lens = (
+                self.draft_worker.forward_batch_speculative_decode_overlap(model_worker_batch)
+            )
+        elif use_spec_prefill_overlap:
+            batch_output = self.draft_worker.forward_batch_speculative_prefill_overlap(
+                model_worker_batch
+            )
+            published_new_seq_lens = None
+        else:
+            batch_output = self.draft_worker.forward_batch_speculative_generation(
+                model_worker_batch
+            )
+            published_new_seq_lens = (
+                publish_spec_decode_new_seq_lens(batch_output)
+                if batch.forward_mode.is_decode()
+                else None
+            )
+
+        if batch_output.next_draft_input is not None:
+            per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
+                batch_output.next_draft_input, model_worker_batch.real_bs_per_dp
+            )
+            for r, s in enumerate(per_rank_spec):
+                batch.reqs_info[r].spec_info = s
+
+        if not use_spec_decode_overlap:
+            new_seq_lens = (
+                np.asarray(jax.device_get(published_new_seq_lens))
+                if published_new_seq_lens is not None
+                else None
+            )
+            per_dp_bs = model_worker_batch.per_dp_bs_size
+            for dp_rank, info in enumerate(batch.reqs_info):
+                if info.seq_lens is None or len(info.seq_lens) == 0:
+                    continue
+                if new_seq_lens is not None:
+                    off = dp_rank * per_dp_bs
+                    info.seq_lens = new_seq_lens[off : off + len(info.seq_lens)]
+                else:
+                    info.seq_lens = info.seq_lens + 1
+
+        defer_spec_output = use_spec_decode_overlap or use_spec_prefill_overlap
+        next_token_ids = None
+        if not defer_spec_output:
+            next_token_ids = np.asarray(jax.device_get(batch_output.next_token_ids))
+            self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
+
+        return (
+            model_worker_batch,
+            batch_output,
+            next_token_ids,
+            batch_output.logits_output,
+            batch_output.cache_miss_count,
+            defer_spec_output,
+            use_spec_prefill_overlap,
+        )
 
     def watchdog_thread(self):
         """A watch dog thread that will try to kill the server itself if one forward batch takes too long."""

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -2068,7 +2068,7 @@ class Scheduler(
         )
         use_spec_prefill_overlap = can_use_spec_prefill_overlap(
             self.enable_overlap, self.spec_algorithm, batch
-        )
+        ) and self.draft_worker._can_use_fused_spec_prefill(model_worker_batch)
         use_legacy_eagle3_decode = batch.forward_mode.is_decode() and use_legacy_eagle3_non_overlap(
             self.enable_overlap, self.spec_algorithm
         )

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -81,6 +81,7 @@ from sgl_jax.srt.speculative.overlap_utils import (
     can_use_spec_decode_overlap,
     can_use_spec_prefill_overlap,
     publish_spec_decode_new_seq_lens,
+    use_legacy_eagle3_non_overlap,
 )
 from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
 from sgl_jax.srt.utils.common_utils import (
@@ -1565,7 +1566,11 @@ class Scheduler(
             if not self.last_batch.is_empty() and not self.last_batch.is_prefill_only:
                 if self.running_batch.is_empty():
                     self.running_batch = self.last_batch
-                elif not self._is_spec_decode_enabled() or self.enable_overlap:
+                elif (
+                    not self._is_spec_decode_enabled()
+                    or self.enable_overlap
+                    or use_legacy_eagle3_non_overlap(self.enable_overlap, self.spec_algorithm)
+                ):
                     # Spec overlap keeps prefill and decode as separate forwards, but
                     # once prefill has produced req-granular relay state it can join
                     # the next decode batch through the normal batch merge.
@@ -1607,6 +1612,7 @@ class Scheduler(
         if (
             self._is_spec_decode_enabled()
             and not self.enable_overlap
+            and not use_legacy_eagle3_non_overlap(self.enable_overlap, self.spec_algorithm)
             and not self.running_batch.is_empty()
         ):
             return None
@@ -2063,6 +2069,9 @@ class Scheduler(
         use_spec_prefill_overlap = can_use_spec_prefill_overlap(
             self.enable_overlap, self.spec_algorithm, batch
         )
+        use_legacy_eagle3_decode = batch.forward_mode.is_decode() and use_legacy_eagle3_non_overlap(
+            self.enable_overlap, self.spec_algorithm
+        )
         if use_spec_decode_overlap:
             batch_output, published_new_seq_lens = (
                 self.draft_worker.forward_batch_speculative_decode_overlap(model_worker_batch)
@@ -2076,11 +2085,14 @@ class Scheduler(
             batch_output = self.draft_worker.forward_batch_speculative_generation(
                 model_worker_batch
             )
-            published_new_seq_lens = (
-                publish_spec_decode_new_seq_lens(batch_output)
-                if batch.forward_mode.is_decode()
-                else None
-            )
+            if use_legacy_eagle3_decode:
+                published_new_seq_lens = None
+            else:
+                published_new_seq_lens = (
+                    publish_spec_decode_new_seq_lens(batch_output)
+                    if batch.forward_mode.is_decode()
+                    else None
+                )
 
         if batch_output.next_draft_input is not None:
             per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
@@ -2090,18 +2102,27 @@ class Scheduler(
                 batch.reqs_info[r].spec_info = s
 
         if not use_spec_decode_overlap:
-            new_seq_lens = (
-                np.asarray(jax.device_get(published_new_seq_lens))
-                if published_new_seq_lens is not None
-                else None
-            )
+            if use_legacy_eagle3_decode and batch_output.accept_lens is not None:
+                new_seq_lens = np.asarray(jax.device_get(batch_output.accept_lens))
+                advance_from_accept_lens = True
+            else:
+                new_seq_lens = (
+                    np.asarray(jax.device_get(published_new_seq_lens))
+                    if published_new_seq_lens is not None
+                    else None
+                )
+                advance_from_accept_lens = False
             per_dp_bs = model_worker_batch.per_dp_bs_size
             for dp_rank, info in enumerate(batch.reqs_info):
                 if info.seq_lens is None or len(info.seq_lens) == 0:
                     continue
                 if new_seq_lens is not None:
                     off = dp_rank * per_dp_bs
-                    info.seq_lens = new_seq_lens[off : off + len(info.seq_lens)]
+                    delta = new_seq_lens[off : off + len(info.seq_lens)]
+                    if advance_from_accept_lens:
+                        info.seq_lens = info.seq_lens + delta
+                    else:
+                        info.seq_lens = delta
                 else:
                     info.seq_lens = info.seq_lens + 1
 

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -77,6 +77,11 @@ from sgl_jax.srt.multimodal.tokenizer_utils import resolve_tokenizer_subdir
 from sgl_jax.srt.precision_tracer import precision_tracer
 from sgl_jax.srt.server_args import PortArgs, ServerArgs
 from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
+from sgl_jax.srt.speculative.overlap_utils import (
+    can_use_spec_decode_overlap,
+    can_use_spec_prefill_overlap,
+    publish_spec_decode_new_seq_lens,
+)
 from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
 from sgl_jax.srt.utils.common_utils import (
     configure_logger,
@@ -114,15 +119,16 @@ class ReceiveDataError(Exception):
 @dataclass
 class GenerationBatchResult:
     logits_output: LogitsProcessorOutput | None
-    next_token_ids: list[int] | None
+    next_token_ids: object | None
     extend_input_len_per_req: list[int]
     extend_logprob_start_len_per_req: list[int]
     bid: int
     cache_miss_count: int
     # relay path: forward stream -> next step forward
     next_draft_input: EagleDraftInput | None = None
+    spec_relay_buffers: object | None = None
+    prefill_relay_future_indices: object | None = None
 
-    allocate_lens: np.ndarray | None = None
     num_accepted_tokens: int | None = None
     accept_lens: np.ndarray | None = None
 
@@ -335,6 +341,8 @@ class Scheduler(
                 server_args=server_args,
                 target_worker=self.tp_worker,
             )
+            if self.enable_overlap and hasattr(self.draft_worker, "init_spec_relay_buffers"):
+                self.draft_worker.init_spec_relay_buffers()
 
         # Get token and memory info from the model worker
         (
@@ -522,6 +530,9 @@ class Scheduler(
         if cache_status is None:
             cache_status = "not configured (JAX_COMPILATION_CACHE_DIR unset)"
         logger.info("XLA persistent compilation cache: %s", cache_status)
+
+    def _is_spec_decode_enabled(self) -> bool:
+        return self.spec_algorithm is not None and not self.spec_algorithm.is_none()
 
     def sync_pub(self):
         logger.info(
@@ -913,7 +924,9 @@ class Scheduler(
                         mesh=self.mesh,
                     )
                     tmp_batch.forward_mode = ForwardMode.DUMMY_FIRST
-                    tmp_batch.next_batch_sampling_info = self.tp_worker.cur_sampling_info
+                    tmp_batch.next_batch_sampling_info = (
+                        self._current_sampling_info_owner().cur_sampling_info
+                    )
                     with jax.profiler.TraceAnnotation("process_batch_result"):
                         self.process_batch_result(tmp_batch, None, batch.launch_done)
 
@@ -921,7 +934,7 @@ class Scheduler(
                 # Process the results of the last batch
                 tmp_batch, tmp_result = self.result_queue.popleft()
                 tmp_batch.next_batch_sampling_info = (
-                    self.tp_worker.cur_sampling_info if batch else None
+                    self._current_sampling_info_owner().cur_sampling_info if batch else None
                 )
                 # NOTE: we should use current launched batch's launch_done event Instead of the last batch's
                 self.process_batch_result(
@@ -1552,8 +1565,10 @@ class Scheduler(
             if not self.last_batch.is_empty() and not self.last_batch.is_prefill_only:
                 if self.running_batch.is_empty():
                     self.running_batch = self.last_batch
-                else:
-                    # Merge running_batch with prefill batch
+                elif not self._is_spec_decode_enabled() or self.enable_overlap:
+                    # Spec overlap keeps prefill and decode as separate forwards, but
+                    # once prefill has produced req-granular relay state it can join
+                    # the next decode batch through the normal batch merge.
                     self.running_batch.merge_batch(self.last_batch)
 
         # For prefill-only batch, filter out finished requests since they
@@ -1585,6 +1600,16 @@ class Scheduler(
 
         # Handle the cases where prefill is not allowed
         has_chunked_reqs = any(req is not None for req in self.chunked_reqs)
+        if self.is_hybrid:
+            for info in self.running_batch.reqs_info:
+                info.batch_is_full = False
+
+        if (
+            self._is_spec_decode_enabled()
+            and not self.enable_overlap
+            and not self.running_batch.is_empty()
+        ):
+            return None
         if (
             self.running_batch.batch_is_full or len(self.waiting_queue) == 0
         ) and not has_chunked_reqs:
@@ -1727,6 +1752,7 @@ class Scheduler(
         # Mixed-style chunked prefill
         if (
             self.is_mixed_chunk
+            and not self._is_spec_decode_enabled()
             and not self.running_batch.is_empty()
             and not (new_batch.return_logprob or self.running_batch.return_logprob)
         ):
@@ -1920,28 +1946,62 @@ class Scheduler(
                     self.server_args.enable_static_lora,
                     draft_token_num=self.draft_worker.speculative_num_draft_tokens,
                 )
-            batch_output = self.draft_worker.forward_batch_speculative_generation(
-                model_worker_batch
+            use_spec_decode_overlap = can_use_spec_decode_overlap(
+                self.enable_overlap, self.spec_algorithm, batch
             )
-            per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
-                batch_output.next_draft_input, model_worker_batch.real_bs_per_dp
+            use_spec_prefill_overlap = can_use_spec_prefill_overlap(
+                self.enable_overlap, self.spec_algorithm, batch
             )
-            for r, s in enumerate(per_rank_spec):
-                batch.reqs_info[r].spec_info = s
-            accept = batch_output.accept_lens
-            if accept is not None:
-                accept = np.asarray(jax.device_get(accept))
-            per_dp_bs = model_worker_batch.per_dp_bs_size
-            for dp_rank, info in enumerate(batch.reqs_info):
-                if info.seq_lens is None or len(info.seq_lens) == 0:
-                    continue
-                if accept is not None:
-                    off = dp_rank * per_dp_bs
-                    info.seq_lens = info.seq_lens + accept[off : off + len(info.seq_lens)]
-                else:
-                    info.seq_lens = info.seq_lens + 1
-            next_token_ids = np.asarray(jax.device_get(batch_output.next_token_ids))
-            self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
+            if use_spec_decode_overlap:
+                batch_output, published_new_seq_lens = (
+                    self.draft_worker.forward_batch_speculative_decode_overlap(model_worker_batch)
+                )
+            elif use_spec_prefill_overlap:
+                batch_output = self.draft_worker.forward_batch_speculative_prefill_overlap(
+                    model_worker_batch
+                )
+                published_new_seq_lens = None
+            else:
+                batch_output = self.draft_worker.forward_batch_speculative_generation(
+                    model_worker_batch
+                )
+                published_new_seq_lens = (
+                    publish_spec_decode_new_seq_lens(batch_output)
+                    if batch.forward_mode.is_decode()
+                    else None
+                )
+            if batch_output.next_draft_input is not None:
+                per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
+                    batch_output.next_draft_input, model_worker_batch.real_bs_per_dp
+                )
+                for r, s in enumerate(per_rank_spec):
+                    batch.reqs_info[r].spec_info = s
+            if not use_spec_decode_overlap:
+                new_seq_lens = (
+                    np.asarray(jax.device_get(published_new_seq_lens))
+                    if published_new_seq_lens is not None
+                    else None
+                )
+                per_dp_bs = model_worker_batch.per_dp_bs_size
+                for dp_rank, info in enumerate(batch.reqs_info):
+                    if info.seq_lens is None or len(info.seq_lens) == 0:
+                        continue
+                    if new_seq_lens is not None:
+                        off = dp_rank * per_dp_bs
+                        info.seq_lens = new_seq_lens[off : off + len(info.seq_lens)]
+                    else:
+                        info.seq_lens = info.seq_lens + 1
+            defer_spec_decode_output = (
+                self.enable_overlap
+                and batch.forward_mode.is_decode()
+                and self.spec_algorithm is not None
+                and not self.spec_algorithm.is_none()
+            )
+            defer_spec_prefill_output = use_spec_prefill_overlap
+            defer_spec_output = defer_spec_decode_output or defer_spec_prefill_output
+            if not defer_spec_output:
+                next_token_ids = np.asarray(jax.device_get(batch_output.next_token_ids))
+                self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
             logits_output = batch_output.logits_output
             cache_miss_count = batch_output.cache_miss_count
         bid = model_worker_batch.bid
@@ -1967,20 +2027,41 @@ class Scheduler(
                     )
         else:
             extend_logprob_start_len_per_req = None
+        spec_relay_buffers = None
+        prefill_relay_future_indices = None
+        if self.spec_algorithm is not None and not self.spec_algorithm.is_none():
+            spec_relay_buffers = getattr(batch_output, "spec_relay_buffers", None)
+            prefill_relay_future_indices = getattr(
+                batch_output, "prefill_relay_future_indices", None
+            )
 
         ret = GenerationBatchResult(
             logits_output=logits_output,
-            next_token_ids=next_token_ids.tolist(),
+            next_token_ids=(
+                batch_output.next_token_ids
+                if (
+                    self.spec_algorithm is not None
+                    and self.spec_algorithm.is_eagle()
+                    and (batch.forward_mode.is_decode() or defer_spec_prefill_output)
+                    and self.enable_overlap
+                )
+                else next_token_ids.tolist()
+            ),
             extend_input_len_per_req=extend_input_len_per_req,
             extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
             bid=bid,
             cache_miss_count=cache_miss_count,
+            spec_relay_buffers=spec_relay_buffers,
+            prefill_relay_future_indices=prefill_relay_future_indices,
         )
-        if self.spec_algorithm is not None and self.spec_algorithm.is_eagle():
+        if (
+            self.spec_algorithm is not None
+            and self.spec_algorithm.is_eagle()
+            and batch_output.next_draft_input is not None
+        ):
             assert isinstance(batch_output.next_draft_input, EagleDraftInput)
             ret.next_draft_input = batch_output.next_draft_input
             ret.accept_lens = batch_output.accept_lens
-            ret.allocate_lens = batch_output.allocate_lens
         return ret
 
     def process_batch_result(
@@ -2026,6 +2107,11 @@ class Scheduler(
             if batch.next_batch_sampling_info.grammars is not None:
                 batch.next_batch_sampling_info.update_grammar_vocab_mask()
             batch.next_batch_sampling_info.sampling_info_done.set()
+
+    def _current_sampling_info_owner(self):
+        if self.spec_algorithm is not None and not self.spec_algorithm.is_none():
+            return self.draft_worker
+        return self.tp_worker
 
     def watchdog_thread(self):
         """A watch dog thread that will try to kill the server itself if one forward batch takes too long."""

--- a/python/sgl_jax/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_metrics_mixin.py
@@ -128,7 +128,12 @@ class SchedulerMetricsMixin:
             per_dp_running = [len(info.reqs) if info.reqs else 0 for info in batch.reqs_info]
             msg += f"#running-req per DP: {per_dp_running}, "
 
-        if running_batch.spec_algorithm is not None and not running_batch.spec_algorithm.is_none():
+        if (
+            self.spec_algorithm is not None
+            and not self.spec_algorithm.is_none()
+            and self.draft_token > 0
+            and self.spec_num_forward_ct > 0
+        ):
             accept_ratio = self.accept_token / self.draft_token
             accept_len = self.accept_token / self.spec_num_forward_ct
             self.accept_token = 0

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -116,12 +116,7 @@ class SchedulerOutputProcessorMixin:
         )
         if self.enable_overlap:
             if self.spec_algorithm is not None and not self.spec_algorithm.is_none():
-                next_token_ids = resolve_spec_prefill_token_ids(
-                    result,
-                    batch,
-                    getattr(result, "spec_relay_buffers", None),
-                    getattr(self.draft_worker, "mesh", None),
-                )
+                next_token_ids = resolve_spec_prefill_token_ids(result)
                 if launch_done is not None:
                     launch_done.wait()
             else:

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from typing import TYPE_CHECKING
 
@@ -13,7 +14,7 @@ from sgl_jax.srt.managers.io_struct import AbortReq, BatchTokenIDOut
 from sgl_jax.srt.managers.schedule_batch import BaseFinishReason, Req, ScheduleBatch
 from sgl_jax.srt.mem_cache.common import release_kv_cache
 from sgl_jax.srt.precision_tracer import precision_tracer
-from sgl_jax.srt.utils.common_utils import cdiv
+from sgl_jax.srt.speculative.overlap_utils import resolve_spec_prefill_token_ids
 
 if TYPE_CHECKING:
     from sgl_jax.srt.managers.scheduler import (
@@ -114,9 +115,19 @@ class SchedulerOutputProcessorMixin:
             result.cache_miss_count,
         )
         if self.enable_overlap:
-            logits_output, next_token_ids, cache_miss_count = (
-                self.tp_worker.resolve_last_batch_result(launch_done)
-            )
+            if self.spec_algorithm is not None and not self.spec_algorithm.is_none():
+                next_token_ids = resolve_spec_prefill_token_ids(
+                    result,
+                    batch,
+                    getattr(result, "spec_relay_buffers", None),
+                    getattr(self.draft_worker, "mesh", None),
+                )
+                if launch_done is not None:
+                    launch_done.wait()
+            else:
+                logits_output, next_token_ids, cache_miss_count = (
+                    self.tp_worker.resolve_last_batch_result(launch_done)
+                )
         else:
             # Move next_token_ids and logprobs to cpu
             if batch.return_output_logprob_only and logits_output.next_token_logprobs is not None:
@@ -189,7 +200,14 @@ class SchedulerOutputProcessorMixin:
                                 >= precision_tracer.get_max_requests()
                             ):
                                 precision_tracer.stop_trace()
-                        release_kv_cache(req, self.tree_cache)
+                        release_kv_cache(
+                            req,
+                            self.tree_cache,
+                            allow_overallocated=(
+                                self.spec_algorithm is not None
+                                and not self.spec_algorithm.is_none()
+                            ),
+                        )
                     elif not info.decoding_reqs or req not in info.decoding_reqs:
                         # This updates radix so others can match
                         self.tree_cache.cache_unfinished_req(req)
@@ -298,40 +316,13 @@ class SchedulerOutputProcessorMixin:
             )
             for r, s in enumerate(per_rank_spec):
                 batch.reqs_info[r].spec_info = s
-
-    def _resolve_spec_decode_token_ids(
-        self: Scheduler, result: GenerationBatchResult, batch: ScheduleBatch
-    ) -> list[list[int]]:
-        """Resolve per-req accepted token lists from the verify output.
-
-        Returns a list of length ``per_dp_bs * dp_size`` (DP-padded order),
-        with ``[]`` at padding slots, so the per-rank slice in
-        ``process_batch_result_decode`` works for any ``dp_size``.
-        """
-        if hasattr(result.next_token_ids, "copy_to_host_async"):
-            result.next_token_ids.copy_to_host_async()
-        if hasattr(result.accept_lens, "copy_to_host_async"):
-            result.accept_lens.copy_to_host_async()
-        next_token_ids = np.asarray(result.next_token_ids)
-        accept_lens = np.asarray(result.accept_lens).tolist()
-        stride = self.draft_worker.speculative_num_draft_tokens
-        per_dp_bs = batch.per_dp_bs_size
-        total_bs = per_dp_bs * batch.dp_size
-        predict_tokens: list[list[int]] = [[] for _ in range(total_bs)]
-        n_real = 0
-        total_accepted = 0
-        for dp_rank, info in enumerate(batch.reqs_info):
-            base = dp_rank * per_dp_bs
-            for j, req in enumerate(info.reqs or []):
-                i = base + j
-                a = accept_lens[i]
-                predict_tokens[i] = next_token_ids[i * stride : i * stride + a].tolist()
-                req.spec_verify_ct += 1
-                req.spec_accepted_tokens += a
-                total_accepted += a
-                n_real += 1
-        result.num_accepted_tokens = total_accepted - n_real
-        return predict_tokens
+            if os.getenv("SGL_JAX_SPEC_RELAY_DEBUG_ASSERT") == "1":
+                for info in batch.reqs_info:
+                    if info.reqs:
+                        assert (
+                            info.spec_info is not None
+                            and getattr(info.spec_info, "future_indices", None) is not None
+                        ), "spec relay prefill output must carry future_indices"
 
     def process_batch_result_decode(
         self: Scheduler,
@@ -344,28 +335,67 @@ class SchedulerOutputProcessorMixin:
             result.next_token_ids,
             result.cache_miss_count,
         )
-        if self.spec_algorithm is not None and not self.spec_algorithm.is_none():
-            next_token_ids = self._resolve_spec_decode_token_ids(result=result, batch=batch)
+        is_spec_decode = self.spec_algorithm is not None and not self.spec_algorithm.is_none()
+        if is_spec_decode:
+            from sgl_jax.srt.speculative.overlap_utils import (
+                resolve_spec_decode_token_ids,
+            )
 
-            # allocate_lens_list = result.allocate_lens.tolist()
+            next_token_ids, accept_lens = resolve_spec_decode_token_ids(
+                result,
+                batch,
+                self.draft_worker.speculative_num_draft_tokens,
+            )
+            if self.enable_overlap and launch_done is not None:
+                launch_done.wait()
+            n_real = 0
+            total_accepted = 0
+            per_dp_bs = batch.per_dp_bs_size
+            for dp_rank, info in enumerate(batch.reqs_info):
+                base = dp_rank * per_dp_bs
+                for j, req in enumerate(info.reqs or []):
+                    if self.enable_overlap and (req.finished() or req.is_retracted):
+                        continue
+                    if req.is_retracted:
+                        continue
+                    a = accept_lens[base + j]
+                    req.spec_verify_ct += 1
+                    req.spec_accepted_tokens += a
+                    total_accepted += a
+                    n_real += 1
+            result.num_accepted_tokens = total_accepted - n_real
+
             # accept_lens_list = result.accept_lens.tolist()
 
         # TODO: Speculative decoding support for DP
-        if self.spec_algorithm is None or self.spec_algorithm.is_none():
+        if not is_spec_decode:
             self.num_generated_tokens += batch.batch_size()
         else:
-            for next_token_id in next_token_ids:
-                self.num_generated_tokens += len(next_token_id)
-                self.accept_token += len(next_token_id)
-            self.spec_num_forward_ct += batch.batch_size()
-            self.draft_token += batch.batch_size() * self.draft_worker.speculative_num_draft_tokens
+            active_spec_reqs = 0
+            per_dp_bs = batch.per_dp_bs_size
+            for dp_rank, info in enumerate(batch.reqs_info):
+                base = dp_rank * per_dp_bs
+                for j, req in enumerate(info.reqs or []):
+                    if self.enable_overlap and (req.finished() or req.is_retracted):
+                        continue
+                    if req.is_retracted:
+                        continue
+                    accepted = len(next_token_ids[base + j])
+                    self.num_generated_tokens += accepted
+                    self.accept_token += accepted
+                    active_spec_reqs += 1
+            self.spec_num_forward_ct += active_spec_reqs
+            self.draft_token += active_spec_reqs * self.draft_worker.speculative_num_draft_tokens
         # FIXME(pc) add spec decode metrics
 
         if self.enable_overlap:
-            logits_output, next_token_ids, cache_miss_count = (
-                self.tp_worker.resolve_last_batch_result(launch_done)
-            )
-            next_token_logprobs = logits_output.next_token_logprobs
+            if is_spec_decode:
+                next_token_logprobs = None
+            else:
+                logits_output, next_token_ids, cache_miss_count = (
+                    self.tp_worker.resolve_last_batch_result(launch_done)
+                )
+                next_token_logprobs = logits_output.next_token_logprobs
         else:
             # spec decoding handles output logprobs inside verify process.
             if batch.return_logprob or batch.return_output_logprob_only:
@@ -410,7 +440,7 @@ class SchedulerOutputProcessorMixin:
                 req.latest_bid = result.bid
 
                 new_accepted_len = 1
-                if batch.spec_algorithm is None or batch.spec_algorithm.is_none():
+                if not is_spec_decode:
                     req.output_ids.append(next_token_id)
                 elif self.spec_algorithm.is_eagle():
                     req.output_ids.extend([int(t) for t in next_token_id])
@@ -420,36 +450,11 @@ class SchedulerOutputProcessorMixin:
 
                 if req.finished():
                     self.maybe_collect_routed_experts(req)
-                    if batch.spec_algorithm is not None and batch.spec_algorithm.is_eagle():
-                        cur_allocate_len = int(info.spec_info.allocate_lens[i])
-                        actual_token_len = len(req.origin_input_ids) + max(
-                            len(req.output_ids) - 1, 0
-                        )
-                        all_token_len = actual_token_len
-                        if self.page_size > 1:
-                            all_token_len = cdiv(all_token_len, self.page_size) * self.page_size
-                        kv_indices = self.req_to_token_pool.req_to_token[
-                            req.req_pool_idx,
-                            all_token_len:cur_allocate_len,
-                        ]
-                        kv_indices = kv_indices[kv_indices != 0]
-                        from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
-
-                        assert (
-                            len(kv_indices) <= EagleDraftInput.ALLOC_LEN_PER_DECODE
-                        ), f"redundant kv indices {len(kv_indices)=} should less than {EagleDraftInput.ALLOC_LEN_PER_DECODE=}"
-
-                        self.token_to_kv_pool_allocator.free(kv_indices, dp_rank)
-                        # Spec decode allocates via EagleDraftInput.prepare_for_decode,
-                        # not ScheduleBatch.prepare_for_decode, so kv_committed_len is
-                        # never bumped past prefill. cache_finished_req would then
-                        # free only the prefill page and leak every decode-allocated
-                        # page (visible on idle check_memory at bs=1). Use the
-                        # *unaligned* actual token count: ChunkCache.cache_finished_req
-                        # does NOT filter 0-valued req_to_token entries, so a
-                        # page-aligned length would free the page-0 sentinel.
-                        req.kv_committed_len = actual_token_len
-                        req.kv_allocated_len = actual_token_len
+                    if is_spec_decode and self.spec_algorithm.is_eagle():
+                        # prepare_for_decode pre-claims one bonus slot. Keep
+                        # kv_allocated_len as the allocation upper bound and let
+                        # release_kv_cache free the overallocated tail.
+                        req.kv_committed_len -= 1
                     # End trace for finished request
                     if precision_tracer.get_trace_active():
                         precision_tracer.set_request_status_to_completed(req.rid)
@@ -466,15 +471,19 @@ class SchedulerOutputProcessorMixin:
                             >= precision_tracer.get_max_requests()
                         ):
                             precision_tracer.stop_trace()
-                    release_kv_cache(req, self.tree_cache)
+                    release_kv_cache(
+                        req,
+                        self.tree_cache,
+                        allow_overallocated=is_spec_decode,
+                    )
+                elif is_spec_decode and self.spec_algorithm.is_eagle():
+                    req.kv_committed_len += new_accepted_len - 1
 
                 if req.return_output_logprob_only:
                     req.output_token_logprobs_val.append(next_token_logprobs[req_idx])
                     req.output_token_logprobs_idx.append(next_token_id)
 
-                if req.return_logprob and (
-                    batch.spec_algorithm is None or batch.spec_algorithm.is_none()
-                ):
+                if req.return_logprob and not is_spec_decode:
                     # speculative worker handles logprob in speculative decoding
                     req.output_token_logprobs_val.append(next_token_logprobs[req_idx])
                     req.output_token_logprobs_idx.append(next_token_id)

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -14,7 +14,10 @@ from sgl_jax.srt.managers.io_struct import AbortReq, BatchTokenIDOut
 from sgl_jax.srt.managers.schedule_batch import BaseFinishReason, Req, ScheduleBatch
 from sgl_jax.srt.mem_cache.common import release_kv_cache
 from sgl_jax.srt.precision_tracer import precision_tracer
-from sgl_jax.srt.speculative.overlap_utils import resolve_spec_prefill_token_ids
+from sgl_jax.srt.speculative.overlap_utils import (
+    resolve_spec_prefill_token_ids,
+    use_legacy_eagle3_non_overlap,
+)
 
 if TYPE_CHECKING:
     from sgl_jax.srt.managers.scheduler import (
@@ -331,6 +334,9 @@ class SchedulerOutputProcessorMixin:
             result.cache_miss_count,
         )
         is_spec_decode = self.spec_algorithm is not None and not self.spec_algorithm.is_none()
+        legacy_eagle3_non_overlap = use_legacy_eagle3_non_overlap(
+            self.enable_overlap, self.spec_algorithm
+        )
         if is_spec_decode:
             from sgl_jax.srt.speculative.overlap_utils import (
                 resolve_spec_decode_token_ids,
@@ -445,7 +451,12 @@ class SchedulerOutputProcessorMixin:
 
                 if req.finished():
                     self.maybe_collect_routed_experts(req)
-                    if is_spec_decode and self.spec_algorithm.is_eagle():
+                    if legacy_eagle3_non_overlap:
+                        actual_token_len = len(req.origin_input_ids) + max(
+                            len(req.output_ids) - 1, 0
+                        )
+                        req.kv_committed_len = actual_token_len
+                    elif is_spec_decode and self.spec_algorithm.is_eagle():
                         # prepare_for_decode pre-claims one bonus slot. Keep
                         # kv_allocated_len as the allocation upper bound and let
                         # release_kv_cache free the overallocated tail.
@@ -471,7 +482,11 @@ class SchedulerOutputProcessorMixin:
                         self.tree_cache,
                         allow_overallocated=is_spec_decode,
                     )
-                elif is_spec_decode and self.spec_algorithm.is_eagle():
+                elif (
+                    is_spec_decode
+                    and self.spec_algorithm.is_eagle()
+                    and not legacy_eagle3_non_overlap
+                ):
                     req.kv_committed_len += new_accepted_len - 1
 
                 if req.return_output_logprob_only:

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -308,8 +308,12 @@ class SchedulerOutputProcessorMixin:
         with ``[]`` at padding slots, so the per-rank slice in
         ``process_batch_result_decode`` works for any ``dp_size``.
         """
-        next_token_ids = np.asarray(jax.device_get(result.next_token_ids))
-        accept_lens = np.asarray(jax.device_get(result.accept_lens)).tolist()
+        if hasattr(result.next_token_ids, "copy_to_host_async"):
+            result.next_token_ids.copy_to_host_async()
+        if hasattr(result.accept_lens, "copy_to_host_async"):
+            result.accept_lens.copy_to_host_async()
+        next_token_ids = np.asarray(result.next_token_ids)
+        accept_lens = np.asarray(result.accept_lens).tolist()
         stride = self.draft_worker.speculative_num_draft_tokens
         per_dp_bs = batch.per_dp_bs_size
         total_bs = per_dp_bs * batch.dp_size

--- a/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
@@ -64,6 +64,14 @@ class ModelWorkerClient:
     def get_model_runner(self):
         return self.worker.get_model_runner()
 
+    @property
+    def model_config(self):
+        return self.worker.model_config
+
+    @property
+    def model_runner(self):
+        return self.worker.model_runner
+
     def get_worker_info(self):
         return self.worker.get_worker_info()
 

--- a/python/sgl_jax/srt/mem_cache/common.py
+++ b/python/sgl_jax/srt/mem_cache/common.py
@@ -121,6 +121,7 @@ def release_kv_cache(
     req,
     tree_cache: BasePrefixCache,
     is_insert: bool = True,
+    allow_overallocated: bool = False,
 ) -> None:
     """Single entry point for releasing a request's KV cache (sglang #12224)."""
     if req.req_pool_idx is None:
@@ -131,9 +132,16 @@ def release_kv_cache(
     tree_cache.cache_finished_req(req, is_insert=is_insert)
 
     start_p, end_p = req.pop_overallocated_kv_cache()
-    assert (
-        start_p == end_p
-    ), f"Unexpected overallocated KV cache, {req.kv_committed_len=}, {req.kv_allocated_len=}"
+    if not allow_overallocated:
+        from sgl_jax.srt.managers.schedule_batch import global_server_args_dict
+
+        spec_algorithm = global_server_args_dict.get("speculative_algorithm")
+        allow_overallocated = spec_algorithm is not None
+
+    if not allow_overallocated:
+        assert (
+            start_p == end_p
+        ), f"Unexpected overallocated KV cache, {req.kv_committed_len=}, {req.kv_allocated_len=}"
 
     page_size = tree_cache.page_size
     if page_size > 1:
@@ -141,6 +149,7 @@ def release_kv_cache(
 
     if start_p < end_p:
         indices_to_free = tree_cache.req_to_token_pool.req_to_token[req.req_pool_idx, start_p:end_p]
+        indices_to_free = indices_to_free[indices_to_free != 0]
         tree_cache.token_to_kv_pool_allocator.free(indices_to_free, dp_rank=dp_rank)
 
     tree_cache.req_to_token_pool.free(req)

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -286,10 +286,13 @@ class CompilationManager:
 
         if speculative_algorithm is None:
             sampling_info = ModelWorkerSamplingInfo.generate_for_precompile(bs, self.vocab_size)
+            return_output_logprob_only = True
         else:
             sampling_info = ModelWorkerSamplingInfo.generate_for_precompile_all_greedy(
                 bs, self.vocab_size
             )
+            sampling_info.vocab_mask = None
+            return_output_logprob_only = False
 
         return ModelWorkerBatch(
             bid=1,
@@ -301,7 +304,7 @@ class CompilationManager:
             seq_lens=np.array([1] * bs, dtype=np.int32),
             out_cache_loc=np.concat([valid_out_cache_loc, invalid_out_cache_loc], axis=0),
             return_logprob=False,
-            return_output_logprob_only=True,
+            return_output_logprob_only=return_output_logprob_only,
             sampling_info=sampling_info,
             extend_input_logprob_token_ids=None,
             positions=np.concat([valid_positions, invalid_positions], axis=0),

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -187,6 +187,8 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         model_def, model_state = nnx.split(self.model)
         # note export for external modification
         self.model_state_leaves, model_state_def = jax.tree_util.tree_flatten(model_state)
+        self._model_def = model_def
+        self._model_state_def = model_state_def
         sampler_def, sampler_state = nnx.split(self.sampler)
         sampler_state_leaves, sampler_state_def = jax.tree_util.tree_flatten(sampler_state)
 

--- a/python/sgl_jax/srt/model_loader/loader.py
+++ b/python/sgl_jax/srt/model_loader/loader.py
@@ -3,8 +3,10 @@ import dataclasses
 import glob
 import logging
 import os
+import time
 from abc import ABC, abstractmethod
 from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import huggingface_hub
@@ -186,6 +188,55 @@ class JAXModelLoader(DefaultModelLoader):
         hf_folder = self._prepare_weights(source.model_or_path, source.revision)
         return hf_folder
 
+    @staticmethod
+    def _warmup_safetensors_cache(model_config: ModelConfig):
+        """Pre-read safetensors files to warm GCSFuse cache."""
+        model_path = model_config.model_path
+        try:
+            with open("/proc/mounts") as fp:
+                mounts = [line.split() for line in fp]
+            mount = max(
+                (
+                    mount
+                    for mount in mounts
+                    if model_path == mount[1] or model_path.startswith(mount[1].rstrip("/") + "/")
+                ),
+                key=lambda mount: len(mount[1]),
+            )
+            if "fuse" not in mount[2]:
+                logger.info("model_path on %s mount, skipping GCSFuse warm-up", mount[2])
+                return
+        except Exception:
+            logger.warning("Failed to detect model_path mount type; skipping GCSFuse warm-up")
+            return
+
+        st_files = sorted(glob.glob(os.path.join(model_path, "*.safetensors")))
+        if not st_files:
+            return
+
+        total_size = sum(os.path.getsize(path) for path in st_files)
+        logger.info(
+            "Warming up GCSFuse cache: %d files, %.1f GB",
+            len(st_files),
+            total_size / 1024**3,
+        )
+
+        def _read_file(path):
+            buf = bytearray(4 * 1024 * 1024)
+            with open(path, "rb") as fp:
+                while fp.readinto(buf):
+                    pass
+
+        t0 = time.time()
+        with ThreadPoolExecutor(max_workers=min(8, len(st_files))) as executor:
+            list(executor.map(_read_file, st_files))
+        t1 = time.time()
+        logger.info(
+            "GCSFuse cache warm-up done: %.1fs (%.0f MB/s)",
+            t1 - t0,
+            total_size / 1024**2 / (t1 - t0) if t1 > t0 else 0,
+        )
+
     def load_model(
         self,
         model_config: ModelConfig,
@@ -199,6 +250,7 @@ class JAXModelLoader(DefaultModelLoader):
             model_config = copy.copy(model_config)
 
         model_config.model_path = hf_folder
+        self._warmup_safetensors_cache(model_config)
         # Initialize JAX model
         model = self._initialize_model(model_config)
 

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -173,7 +173,8 @@ class MiMoV2Moe(nnx.Module):
                 hidden_states.shape[0],
                 out_sharding=NamedSharding(self.mesh, P(out_sharding.spec[0])),
             )
-            topk_ids = jnp.where(token_valid_mask[:, None], topk_ids, -1)
+            if token_valid_mask is not None:
+                topk_ids = jnp.where(token_valid_mask[:, None], topk_ids, -1)
             mlp_output = self.experts(
                 hidden_states,
                 topk_weights,

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -1460,12 +1460,21 @@ class ServerArgs:
         # Check LoRA configuration
         self.check_lora_server_args()
 
-        # Disallow overlap scheduler when speculative decoding is enabled
+        # Speculative overlap is currently implemented for the fused NEXTN
+        # topk=1 path only.
         if self.speculative_algorithm is not None and not self.disable_overlap_schedule:
-            raise ValueError(
-                "Speculative decoding does not support overlap scheduler. "
-                "Please pass --disable-overlap-schedule when using --speculative-algorithm."
+            supports_spec_overlap = (
+                self.speculative_algorithm == "NEXTN"
+                and self.speculative_eagle_topk == 1
+                and self.speculative_num_draft_tokens == self.speculative_num_steps + 1
             )
+            if not supports_spec_overlap:
+                raise ValueError(
+                    "Speculative overlap scheduler only supports NEXTN with "
+                    "--speculative-eagle-topk=1 and "
+                    "--speculative-num-draft-tokens == --speculative-num-steps + 1. "
+                    "Please pass --disable-overlap-schedule for other speculative configs."
+                )
 
     def check_lora_server_args(self):
         """Validate and normalize LoRA-related server arguments."""

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -131,7 +131,6 @@ class BaseSpecWorker:
         )
         return (
             self._can_use_fused_spec_decode
-            and sampling_info.is_all_greedy
             and not has_penalty
             and getattr(sampling_info, "vocab_mask", None) is None
             and not getattr(model_worker_batch, "return_logprob", False)
@@ -155,8 +154,8 @@ class BaseSpecWorker:
                 "Spec decode-overlap entry only supports decode batches; "
                 "prefill overlap uses forward_batch_speculative_generation()."
             )
-        if not (self._can_use_fused_spec_decode and model_worker_batch.sampling_info.is_all_greedy):
-            raise NotImplementedError("Spec overlap entry only supports fused greedy decode.")
+        if not self._can_use_fused_spec_decode:
+            raise NotImplementedError("Spec overlap entry only supports fused NEXTN topk=1 decode.")
 
         self.init_spec_relay_buffers()
         self._prepare_overlap_sampling_info(model_worker_batch)
@@ -181,12 +180,12 @@ class BaseSpecWorker:
         self._prepare_overlap_sampling_info(model_worker_batch)
 
         from sgl_jax.srt.speculative.draft_extend_fused import (
-            prepare_spec_prefill_forward_batch,
+            prepare_forward_batch_for_prefill,
             spec_prefill_overlap,
         )
 
         if getattr(model_worker_batch, "forward_batch", None) is None:
-            prepare_spec_prefill_forward_batch(self, model_worker_batch)
+            prepare_forward_batch_for_prefill(self, model_worker_batch)
         result = spec_prefill_overlap(self, model_worker_batch)
         launch_done = getattr(model_worker_batch, "launch_done", None)
         if launch_done is not None:
@@ -205,12 +204,12 @@ class BaseSpecWorker:
         if model_worker_batch.forward_mode.is_extend():
             if self._can_use_fused_spec_prefill(model_worker_batch):
                 from sgl_jax.srt.speculative.draft_extend_fused import (
-                    prepare_spec_prefill_forward_batch,
+                    prepare_forward_batch_for_prefill,
                     spec_prefill,
                 )
 
                 if getattr(model_worker_batch, "forward_batch", None) is None:
-                    prepare_spec_prefill_forward_batch(self, model_worker_batch)
+                    prepare_forward_batch_for_prefill(self, model_worker_batch)
                 return spec_prefill(self, model_worker_batch, launch_done=launch_done)
 
             if model_worker_batch.sampling_info.temperatures.ndim == 1:

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import dataclasses
+import os
+import threading
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
@@ -92,6 +96,7 @@ class BaseSpecWorker:
             self.precompile_bs_paddings,
             self.precompile_cache_loc_paddings,
         ) = target_worker.get_precompile_paddings()
+        self.spec_relay_buffers = None
 
     @property
     def target_worker(self) -> ModelWorker:
@@ -101,13 +106,113 @@ class BaseSpecWorker:
     def draft_worker(self) -> BaseDraftWorker:
         return self._draft_worker
 
+    def init_spec_relay_buffers(self):
+        if self.spec_relay_buffers is not None:
+            return
+        from sgl_jax.srt.speculative.relay_buffer import create_spec_relay_buffers
+
+        hidden_dtype = jnp.bfloat16 if self.server_args.dtype == "bfloat16" else jnp.float32
+        self.spec_relay_buffers = create_spec_relay_buffers(
+            self.mesh,
+            self.req_to_token_pool,
+            dp_size=self.server_args.dp_size,
+            num_steps=self.speculative_num_steps,
+            hidden_size=self.target_worker.model_config.hidden_size,
+            hidden_dtype=hidden_dtype,
+        )
+
+    def _can_use_fused_spec_prefill(self, model_worker_batch: ModelWorkerBatch) -> bool:
+        if os.getenv("SGL_JAX_DISABLE_FUSED_SPEC_PREFILL") == "1":
+            return False
+        sampling_info = model_worker_batch.sampling_info
+        penalizer = getattr(sampling_info, "penalizer_orchestrator", None)
+        has_penalty = getattr(sampling_info, "linear_penalty", None) is not None or bool(
+            getattr(penalizer, "is_required", False)
+        )
+        return (
+            self._can_use_fused_spec_decode
+            and sampling_info.is_all_greedy
+            and not has_penalty
+            and getattr(sampling_info, "vocab_mask", None) is None
+            and not getattr(model_worker_batch, "return_logprob", False)
+            and not getattr(model_worker_batch, "return_output_logprob_only", False)
+        )
+
     # -- Main entry point --
 
-    def forward_batch_speculative_generation(self, model_worker_batch: ModelWorkerBatch):
+    def _prepare_overlap_sampling_info(self, model_worker_batch: ModelWorkerBatch):
+        sampling_info = model_worker_batch.sampling_info
+        sampling_info.update_penalties()
+        model_worker_batch.sampling_info = self.cur_sampling_info = dataclasses.replace(
+            sampling_info,
+            sampling_info_done=threading.Event(),
+            penalizer_orchestrator=None,
+        )
+
+    def forward_batch_speculative_decode_overlap(self, model_worker_batch: ModelWorkerBatch):
+        if not model_worker_batch.forward_mode.is_decode():
+            raise NotImplementedError(
+                "Spec decode-overlap entry only supports decode batches; "
+                "prefill overlap uses forward_batch_speculative_generation()."
+            )
+        if not (self._can_use_fused_spec_decode and model_worker_batch.sampling_info.is_all_greedy):
+            raise NotImplementedError("Spec overlap entry only supports fused greedy decode.")
+
+        self.init_spec_relay_buffers()
+        self._prepare_overlap_sampling_info(model_worker_batch)
+        sel = model_worker_batch.logits_indices_selector
+        cur_allocate_lens = np.asarray(model_worker_batch.spec_info_padded.allocate_lens)[sel]
+
+        from sgl_jax.srt.speculative.draft_extend_fused import spec_decode_overlap
+
+        result = spec_decode_overlap(self, model_worker_batch, cur_allocate_lens)
+        launch_done = getattr(model_worker_batch, "launch_done", None)
+        if launch_done is not None:
+            launch_done.set()
+        return result
+
+    def forward_batch_speculative_prefill_overlap(self, model_worker_batch: ModelWorkerBatch):
+        if not model_worker_batch.forward_mode.is_extend():
+            raise NotImplementedError("Spec prefill-overlap entry only supports extend batches.")
+        if not self._can_use_fused_spec_prefill(model_worker_batch):
+            raise NotImplementedError("Spec prefill overlap only supports fused greedy prefill.")
+
+        self.init_spec_relay_buffers()
+        self._prepare_overlap_sampling_info(model_worker_batch)
+
+        from sgl_jax.srt.speculative.draft_extend_fused import (
+            prepare_spec_prefill_forward_batch,
+            spec_prefill_overlap,
+        )
+
+        if getattr(model_worker_batch, "forward_batch", None) is None:
+            prepare_spec_prefill_forward_batch(self, model_worker_batch)
+        result = spec_prefill_overlap(self, model_worker_batch)
+        launch_done = getattr(model_worker_batch, "launch_done", None)
+        if launch_done is not None:
+            launch_done.set()
+        return result
+
+    def forward_batch_speculative_generation(
+        self, model_worker_batch: ModelWorkerBatch, launch_done=None
+    ):
         from sgl_jax.srt.managers.scheduler import GenerationBatchResult
         from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
 
+        if launch_done is None:
+            self._prepare_overlap_sampling_info(model_worker_batch)
+
         if model_worker_batch.forward_mode.is_extend():
+            if self._can_use_fused_spec_prefill(model_worker_batch):
+                from sgl_jax.srt.speculative.draft_extend_fused import (
+                    prepare_spec_prefill_forward_batch,
+                    spec_prefill,
+                )
+
+                if getattr(model_worker_batch, "forward_batch", None) is None:
+                    prepare_spec_prefill_forward_batch(self, model_worker_batch)
+                return spec_prefill(self, model_worker_batch, launch_done=launch_done)
+
             if model_worker_batch.sampling_info.temperatures.ndim == 1:
                 model_worker_batch.sampling_info.temperatures = (
                     model_worker_batch.sampling_info.temperatures[:, None]
@@ -118,9 +223,19 @@ class BaseSpecWorker:
                 self.mesh,
                 vocab_size=self.target_worker.model_config.vocab_size,
             )
-            logits_output, next_token_ids, cache_miss_count, bid, _seq_lens = (
-                self.forward_target_extend(model_worker_batch, sampling_metadata)
-            )
+            if model_worker_batch.sampling_info.is_all_greedy:
+                logits_output, _, cache_miss_count, bid, _seq_lens = self.forward_target_extend(
+                    model_worker_batch,
+                    sampling_metadata,
+                    skip_sample=True,
+                )
+                next_token_ids = jnp.argmax(logits_output.next_token_logits, axis=-1).astype(
+                    jnp.int32
+                )
+            else:
+                logits_output, next_token_ids, cache_miss_count, bid, _seq_lens = (
+                    self.forward_target_extend(model_worker_batch, sampling_metadata)
+                )
             if model_worker_batch.dp_size > 1:
                 from jax.experimental.multihost_utils import process_allgather
 
@@ -132,9 +247,6 @@ class BaseSpecWorker:
                 logits_output=logits_output,
                 next_token_ids=next_token_ids,
                 next_draft_input=model_worker_batch.spec_info_padded,
-                allocate_lens=np.asarray(model_worker_batch.seq_lens)[
-                    model_worker_batch.logits_indices_selector
-                ],
                 bid=bid,
                 cache_miss_count=cache_miss_count,
                 extend_input_len_per_req=None,
@@ -150,20 +262,34 @@ class BaseSpecWorker:
             # decode paths can be folded into this entry point over time.
             from sgl_jax.srt.speculative.draft_extend_fused import spec_decode
 
-            return spec_decode(self, model_worker_batch, cur_allocate_lens)
+            batch_output = spec_decode(self, model_worker_batch, cur_allocate_lens)
+            launch_done = getattr(model_worker_batch, "launch_done", None)
+            if launch_done is not None:
+                launch_done.set()
+            return batch_output
         self.draft_worker.draft(model_worker_batch)
         batch_output = self.verify(model_worker_batch, cur_allocate_lens)
         self.draft_worker.draft_extend_for_decode(model_worker_batch, batch_output)
+        launch_done = getattr(model_worker_batch, "launch_done", None)
+        if launch_done is not None:
+            launch_done.set()
         return batch_output
 
-    def forward_target_extend(self, model_worker_batch: ModelWorkerBatch, sampling_metadata):
+    def forward_target_extend(
+        self,
+        model_worker_batch: ModelWorkerBatch,
+        sampling_metadata,
+        *,
+        skip_sample: bool = False,
+    ):
         from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode
 
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
-        logits_output, next_token_ids, cache_miss_count = (
-            self.target_worker.forward_batch_generation(
-                model_worker_batch, sampling_metadata=sampling_metadata
-            )
+        target_worker = getattr(self.target_worker, "worker", self.target_worker)
+        logits_output, next_token_ids, cache_miss_count = target_worker.forward_batch_generation(
+            model_worker_batch,
+            sampling_metadata=sampling_metadata,
+            skip_sample=skip_sample,
         )
         return (
             logits_output,
@@ -217,7 +343,7 @@ class BaseSpecWorker:
         logits_output.next_token_logits = logits_output.next_token_logits[safe_index, :]
         logits_output.hidden_states = logits_output.hidden_states[safe_index, :]
         model_worker_batch.positions = model_worker_batch.positions[safe_index]
-        new_seq_lens = model_worker_batch.seq_lens + accept_length
+        new_seq_lens = model_worker_batch.seq_lens + accept_length + 1
         next_draft_input = EagleDraftInput(
             verified_id=verified_id,
             new_seq_lens=new_seq_lens,
@@ -231,8 +357,6 @@ class BaseSpecWorker:
             next_token_ids=predict,
             next_draft_input=next_draft_input,
             accept_lens=accept_length,
-            # FIXME(pc) this field is for overlap
-            allocate_lens=cur_allocate_lens,
             bid=model_worker_batch.bid,
             cache_miss_count=cache_miss_count,
             extend_input_len_per_req=None,

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -78,6 +78,12 @@ class BaseSpecWorker:
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
+        self._can_use_fused_spec_decode = (
+            self.speculative_algorithm.is_nextn()
+            and self.topk == 1
+            and self.speculative_num_steps > 1
+            and self.speculative_num_draft_tokens == self.speculative_num_steps + 1
+        )
 
         self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
 
@@ -139,6 +145,12 @@ class BaseSpecWorker:
         # to global-flat (real_bs,) so reqs_info[0].spec_info stays flat-ordered.
         sel = model_worker_batch.logits_indices_selector
         cur_allocate_lens = np.asarray(model_worker_batch.spec_info_padded.allocate_lens)[sel]
+        if self._can_use_fused_spec_decode and model_worker_batch.sampling_info.is_all_greedy:
+            # Current fused route covers greedy NEXTN decode; more speculative
+            # decode paths can be folded into this entry point over time.
+            from sgl_jax.srt.speculative.draft_extend_fused import spec_decode
+
+            return spec_decode(self, model_worker_batch, cur_allocate_lens)
         self.draft_worker.draft(model_worker_batch)
         batch_output = self.verify(model_worker_batch, cur_allocate_lens)
         self.draft_worker.draft_extend_for_decode(model_worker_batch, batch_output)
@@ -179,6 +191,7 @@ class BaseSpecWorker:
             self.mesh, logits_output.next_token_logits, logits_output.hidden_states
         )
         spec_info.hidden_states = logits_output.hidden_states
+
         (
             predict,
             verified_id,

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -12,6 +12,8 @@ import numpy as np
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
+from sgl_jax.srt.speculative.overlap_utils import use_legacy_eagle3_non_overlap
+
 if TYPE_CHECKING:
     from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
     from sgl_jax.srt.managers.tp_worker import ModelWorker
@@ -198,7 +200,11 @@ class BaseSpecWorker:
         from sgl_jax.srt.managers.scheduler import GenerationBatchResult
         from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
 
-        if launch_done is None:
+        legacy_non_overlap = use_legacy_eagle3_non_overlap(
+            not self.server_args.disable_overlap_schedule,
+            getattr(model_worker_batch, "spec_algorithm", None),
+        )
+        if launch_done is None and not legacy_non_overlap:
             self._prepare_overlap_sampling_info(model_worker_batch)
 
         if model_worker_batch.forward_mode.is_extend():
@@ -222,7 +228,7 @@ class BaseSpecWorker:
                 self.mesh,
                 vocab_size=self.target_worker.model_config.vocab_size,
             )
-            if model_worker_batch.sampling_info.is_all_greedy:
+            if model_worker_batch.sampling_info.is_all_greedy and not legacy_non_overlap:
                 logits_output, _, cache_miss_count, bid, _seq_lens = self.forward_target_extend(
                     model_worker_batch,
                     sampling_metadata,
@@ -328,21 +334,36 @@ class BaseSpecWorker:
             self.draft_worker.draft_model_runner.rngs,
             self.mesh,
         )
-        # accept_index uses -1 for rejected slots; gathering with -1 picks the
-        # global last element, so dext later writes rejected tokens' draft-KV at
-        # a foreign position inside each req's page (corrupts prefix KV for all
-        # but the last req at bs>1). Redirect -1 to each req's own last slot.
-        # accept_index has length bs*(spec_steps+1); the gathered tensors have
-        # length bs*draft_token_num — equal at topk=1, distinct at topk>1.
-        draft_n = self.speculative_num_draft_tokens
-        accept_width = self.speculative_num_steps + 1
-        req_ids = np.arange(len(accept_index)) // accept_width
-        per_req_last = req_ids * draft_n + draft_n - 1
-        safe_index = np.where(accept_index >= 0, accept_index, per_req_last)
+        legacy_non_overlap = use_legacy_eagle3_non_overlap(
+            not self.server_args.disable_overlap_schedule,
+            getattr(model_worker_batch, "spec_algorithm", None),
+        )
+        if legacy_non_overlap:
+            safe_index = accept_index
+        else:
+            # accept_index uses -1 for rejected slots; gathering with -1 picks the
+            # global last element, so dext later writes rejected tokens' draft-KV at
+            # a foreign position inside each req's page (corrupts prefix KV for all
+            # but the last req at bs>1). Redirect -1 to each req's own last slot.
+            # accept_index has length bs*(spec_steps+1); the gathered tensors have
+            # length bs*draft_token_num — equal at topk=1, distinct at topk>1.
+            draft_n = self.speculative_num_draft_tokens
+            accept_width = self.speculative_num_steps + 1
+            req_ids = np.arange(len(accept_index)) // accept_width
+            per_req_last = req_ids * draft_n + draft_n - 1
+            safe_index = np.where(accept_index >= 0, accept_index, per_req_last)
         logits_output.next_token_logits = logits_output.next_token_logits[safe_index, :]
         logits_output.hidden_states = logits_output.hidden_states[safe_index, :]
         model_worker_batch.positions = model_worker_batch.positions[safe_index]
-        new_seq_lens = model_worker_batch.seq_lens + accept_length + 1
+        if legacy_non_overlap:
+            # The legacy scheduler path advances seq_lens from accept_lens, as
+            # it did before the relay-buffer/new_seq_lens path was introduced.
+            new_seq_lens = None
+        else:
+            # prepare_for_verify decrements seq_lens before target verify.  The
+            # scheduler-visible length must advance from the original length by the
+            # accepted tokens, so add that slot back when publishing new_seq_lens.
+            new_seq_lens = model_worker_batch.seq_lens + accept_length + 1
         next_draft_input = EagleDraftInput(
             verified_id=verified_id,
             new_seq_lens=new_seq_lens,

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -1,0 +1,243 @@
+"""Fused single-JIT for N-layer MTP draft extend decode.
+
+Merges all N model forward calls into one @jax.jit, eliminating:
+- Per-layer host dispatch overhead (~N jit calls → 1)
+- Per-layer device_get for rotate_ids (device .at[].set for topk=1)
+- Per-layer replicate_to_mesh boundary (with_sharding_constraint inside jit)
+
+Constraints:
+- topk=1 only (rotate_ids = .at[sel_pos].set)
+- All MTP layers share same model class (same model_def / model_state_def)
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+logger = logging.getLogger(__name__)
+
+
+def _device_rotate_input_ids(input_ids, ext_lens, sel_pos, new_tokens):
+    """Device-side per-req rotate for topk=1, exact mirror of the host
+    ``MultiLayerDraftWorker._rotate_ids``:
+
+      seg[:-1] = seg[1:]      # left-shift, KEEP last column (= prev last token)
+      seg[sel_pos] = new_token
+      padding reqs (ext_lens == 0) are left untouched
+
+    input_ids is the flat (bs * tokens_per_req,) buffer; every req occupies a
+    fixed ``tokens_per_req`` segment (real reqs have extend_seq_lens ==
+    tokens_per_req, padding reqs have 0). The last column is the captured-logit
+    position, so it must be copy-last (NOT jnp.roll, which wraps the first token
+    into the last column and diverges on partial accept).
+    """
+    bs = ext_lens.shape[0]
+    tokens_per_req = input_ids.shape[0] // bs
+    ids_2d = input_ids.reshape(bs, tokens_per_req)
+    shifted_2d = jnp.concatenate([ids_2d[:, 1:], ids_2d[:, -1:]], axis=1)
+    shifted_2d = shifted_2d.at[jnp.arange(bs), sel_pos].set(
+        new_tokens,
+        out_sharding=jax.typeof(shifted_2d).sharding,
+    )
+    pad_mask = (ext_lens == 0)[:, None]
+    shifted_2d = jnp.where(pad_mask, ids_2d, shifted_2d)
+    return shifted_2d.reshape(-1)
+
+
+def _build_fused_draft_extend_jit(num_layers: int, topk: int):
+    """Build the fused JIT. Called once, result cached on draft_worker."""
+    assert topk == 1, "Fused draft extend only supports topk=1"
+
+    @partial(
+        jax.jit,
+        donate_argnames=["all_memory_pools"],
+        static_argnames=["model_state_def", "num_layers"],
+    )
+    def fused_draft_extend(
+        model_def,
+        model_state_def,
+        all_leaves,  # tuple of N tuples-of-arrays
+        forward_batch,  # single ForwardBatch (shared across layers)
+        all_memory_pools,  # tuple of N MemoryPools pytrees
+        logits_metadata,  # LogitsMetadata pytree
+        target_hidden,  # (tokens, hidden_dim) replicated
+        sel_pos,  # (bs,) device array — rotate position
+        *,
+        num_layers,
+    ):
+        all_topk_p = []
+        all_topk_index = []
+        all_pool_updates = []
+        layer0_hidden = None
+        mesh = None
+        input_ids = forward_batch.input_ids
+
+        for i in range(num_layers):
+            state = jax.tree_util.tree_unflatten(model_state_def, all_leaves[i])
+            model = nnx.merge(model_def, state)
+
+            # shared forward_batch: only hidden_states and input_ids change per layer;
+            # model() must not mutate other fields (positions, attn metadata, etc.)
+            forward_batch.spec_info.hidden_states = target_hidden
+            forward_batch.input_ids = input_ids
+
+            output, pool_updates, _, _ = model(forward_batch, all_memory_pools[i], logits_metadata)
+            all_pool_updates.append(pool_updates)
+
+            # Replicate logits + hidden to P() (all-gather)
+            sh = jax.typeof(output.next_token_logits).sharding
+            mesh = sh.mesh if isinstance(sh, NamedSharding) else None
+            if mesh is not None:
+                rep_logits = jax.sharding.reshard(
+                    output.next_token_logits, NamedSharding(mesh, P())
+                )
+                rep_hidden = jax.sharding.reshard(output.hidden_states, NamedSharding(mesh, P()))
+            else:
+                rep_logits = output.next_token_logits
+                rep_hidden = output.hidden_states
+
+            if i == 0:
+                layer0_hidden = rep_hidden
+
+            # topk (inline, not separate jit)
+            topk_logits, topk_idx = jax.lax.top_k(rep_logits, topk)
+            logsumexp = jax.nn.logsumexp(rep_logits, axis=-1, keepdims=True)
+            topk_p = jnp.exp(topk_logits - logsumexp).astype(rep_logits.dtype)
+
+            all_topk_p.append(topk_p)
+            all_topk_index.append(topk_idx)
+
+            # Device-side rotate for topk=1 (shared with offline equivalence
+            # test; exact mirror of host _rotate_ids).
+            if i < num_layers - 1:
+                ext_lens = forward_batch.extend_seq_lens
+                input_ids = _device_rotate_input_ids(input_ids, ext_lens, sel_pos, topk_idx[:, 0])
+
+        # Force P() replicated sharding on outputs that must be cross-process
+        # consistent. Without this, donate_argnames may let XLA alias output
+        # buffers with donated P("data")-sharded pool buffers, silently making
+        # np.asarray() return per-process-different values.
+        stacked_p = jnp.stack(all_topk_p, axis=1)
+        stacked_idx = jnp.stack(all_topk_index, axis=1)
+        if mesh is not None:
+            rep = NamedSharding(mesh, P())
+            layer0_hidden = jax.lax.with_sharding_constraint(layer0_hidden, rep)
+            stacked_p = jax.lax.with_sharding_constraint(stacked_p, rep)
+            stacked_idx = jax.lax.with_sharding_constraint(stacked_idx, rep)
+
+        return (
+            layer0_hidden,
+            stacked_p,
+            stacked_idx,
+            tuple(all_pool_updates),
+        )
+
+    return fused_draft_extend
+
+
+def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output):
+    """Drop-in replacement for MultiLayerDraftWorker.draft_extend_for_decode.
+
+    Fuses all N MTP layer forwards into a single jit call.
+    """
+    from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+    from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
+
+    if batch_output.next_draft_input.verified_id.shape[0] <= 0:
+        return
+    target_hidden = batch_output.logits_output.hidden_states
+
+    draft_input = EagleDraftInput(
+        hidden_states=target_hidden, allocate_lens=batch_output.allocate_lens
+    )
+    mwb, logits_metadata = draft_input.prepare_for_extend_after_verify(
+        model_worker_batch,
+        draft_worker.draft_model_runner,
+        batch_output,
+        draft_worker.speculative_num_draft_tokens,
+    )
+    if mwb.input_ids.shape[0] <= 0:
+        return
+
+    sel = np.asarray(model_worker_batch.logits_indices_selector)
+    accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
+    assert (accept_host[sel] >= 1).all(), f"accept_length < 1: {accept_host[sel]}"
+    sel_pos = np.clip(accept_host - 1, 0, None).astype(np.int32)
+
+    # --- Host preparation (all done before single jit call) ---
+
+    # Build ONE ForwardBatch and reuse for all layers. All workers share the
+    # same mwb so forward_metadata is identical; only memory_pools/weights differ.
+    mr0 = draft_worker._workers[0].model_runner
+    mwb.spec_info_padded.hidden_states = target_hidden
+    mr0.attn_backend.forward_metadata = mr0.attn_backend.get_eagle_forward_metadata(mwb)
+    shared_fb = ForwardBatch.init_new(mwb, mr0)
+    shared_fb.bid = model_worker_batch.bid
+
+    all_memory_pools = []
+    all_leaves = []
+    for w in draft_worker._workers:
+        mr = w.model_runner
+        all_memory_pools.append(mr.memory_pools)
+        all_leaves.append(tuple(mr.model_state_leaves))
+
+    sel_pos_device = jax.device_put(sel_pos, NamedSharding(draft_worker.mesh, P("data")))
+
+    # --- Build / get cached fused jit ---
+    if not hasattr(draft_worker, "_fused_jit_fn"):
+        draft_worker._fused_jit_fn = _build_fused_draft_extend_jit(
+            num_layers=draft_worker.speculative_num_steps,
+            topk=draft_worker.topk,
+        )
+
+    # --- Single jit call: all N layers fused ---
+    # Model internals use P() with implicit mesh; need use_mesh context
+    try:
+        ctx = jax.sharding.use_mesh(draft_worker.mesh)
+    except AttributeError:
+        try:
+            ctx = jax.set_mesh(draft_worker.mesh)
+        except AttributeError:
+            ctx = draft_worker.mesh
+    with ctx:
+        layer0_hidden, topk_p_stacked, topk_index_stacked, all_pool_updates = (
+            draft_worker._fused_jit_fn(
+                mr0._model_def,
+                mr0._model_state_def,
+                tuple(all_leaves),
+                shared_fb,
+                tuple(all_memory_pools),
+                logits_metadata,
+                target_hidden,
+                sel_pos_device,
+                num_layers=draft_worker.speculative_num_steps,
+            )
+        )
+
+    # --- Host post-processing: replace memory pools + assemble outputs ---
+    for i, w in enumerate(draft_worker._workers):
+        w.model_runner.memory_pools.replace_all(all_pool_updates[i])
+
+    select_index = sel * (draft_worker.speculative_num_steps + 1) + accept_host[sel] - 1
+    verified_id_arr = batch_output.next_draft_input.verified_id
+    if hasattr(verified_id_arr, "copy_to_host_async"):
+        jax.copy_to_host_async(verified_id_arr)
+
+    jax.copy_to_host_async(layer0_hidden)
+    jax.copy_to_host_async(topk_p_stacked)
+    jax.copy_to_host_async(topk_index_stacked)
+
+    batch_output.next_draft_input.hidden_states = np.asarray(layer0_hidden)[select_index]
+    batch_output.next_draft_input.topk_p = np.asarray(topk_p_stacked)[sel]
+    batch_output.next_draft_input.topk_index = np.asarray(topk_index_stacked)[sel]
+    batch_output.next_draft_input.verified_id = np.asarray(verified_id_arr)[select_index]
+    batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
+    batch_output.accept_lens = accept_host

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -2,17 +2,18 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from functools import partial
 from typing import NamedTuple
 
 import jax
-import jax._src.test_util as jtu
 import jax.numpy as jnp
 import numpy as np
 from flax import nnx
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
+from sgl_jax.srt.kernels.speculative.kernel import top_k_renorm_prob, top_p_renorm_prob
 from sgl_jax.srt.speculative.relay_buffer import (
     gather_spec_relay_buffers,
     make_dp_valid_mask,
@@ -52,6 +53,17 @@ class FusedDraftExtendPendingResult(NamedTuple):
     updated_relay_buffers: object | None
 
 
+@contextmanager
+def _count_pjit_cpp_cache_miss():
+    try:
+        import jax._src.test_util as jtu
+    except (ImportError, ModuleNotFoundError):
+        yield lambda: 0
+        return
+    with jtu.count_pjit_cpp_cache_miss() as count:
+        yield count
+
+
 def _prepare_spec_prefill_output_token_ids(draft_worker, next_token_ids):
     if draft_worker.mesh is None:
         return next_token_ids
@@ -71,7 +83,7 @@ def _take_with_index_sharding(values, index):
     return jnp.take(values.reshape(-1), index)
 
 
-def _greedy_prepare_draft_inputs(
+def _prepare_draft_inputs(
     hidden_states,
     positions,
     seq_lens,
@@ -114,7 +126,7 @@ def _greedy_prepare_draft_inputs(
     )
 
 
-def _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
+def _verify_greedy(
     *,
     target_hidden,
     positions,
@@ -155,7 +167,7 @@ def _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
     safe_index = jnp.where(accept_index >= 0, accept_index, per_req_last)
     safe_predict = _take_with_index_sharding(predict, safe_index)
     verified_id = jnp.where(accept_index >= 0, safe_predict, jnp.zeros_like(safe_predict))
-    prepared = _greedy_prepare_draft_inputs(
+    prepared = _prepare_draft_inputs(
         target_hidden,
         positions,
         seq_lens,
@@ -178,7 +190,139 @@ def _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
     )
 
 
-def _build_topk1_chain_verify_inputs_device_tuple(
+def _verify_rejection_sampling(
+    *,
+    target_hidden,
+    positions,
+    seq_lens,
+    draft_tokens,
+    target_logits,
+    temperatures,
+    top_ks,
+    top_ps,
+    coins,
+    coin_f,
+    threshold_single,
+    threshold_acc,
+    enable_top_k,
+    enable_top_p,
+    speculative_num_steps,
+    speculative_num_draft_tokens,
+):
+    """Non-greedy counterpart of the greedy chain verify.
+
+    Mirrors `tree_speculative_sampling_target_only` (eagle_util.py) for the
+    pure topk=1 chain: target-only typical acceptance. Accepted slots emit the
+    accepted draft token; the first rejected slot samples from the residual
+    target distribution, while the all-accepted bonus slot samples from the
+    full target distribution.
+    """
+    bs = seq_lens.shape[0]
+    n = speculative_num_draft_tokens
+    width = speculative_num_steps + 1
+    vocab = target_logits.shape[-1]
+
+    # v1: replicate the working set so explicit-sharding never has to resolve
+    # gather/cumsum shardings. Correctness over speed for now. top_k/top_p TODO.
+    sh = jax.typeof(target_logits).sharding
+    mesh = sh.mesh if isinstance(sh, NamedSharding) else None
+
+    def _rep(x):
+        return jax.sharding.reshard(x, NamedSharding(mesh, P())) if mesh is not None else x
+
+    tl = _rep(target_logits.astype(jnp.float32))
+    draft_2d = _rep(draft_tokens.reshape(bs, n).astype(jnp.int32))
+    seq_lens_r = _rep(seq_lens.astype(jnp.int32))
+    temp = _rep(temperatures.reshape(bs, 1).astype(jnp.float32))
+    coins_r = _rep(coins.astype(jnp.float32))
+    coin_f_r = _rep(coin_f.astype(jnp.float32))
+
+    # target probs: temperature scale, then optional top_k/top_p renorm.
+    # Everything is replicated here, so the renorm kernels behave exactly like
+    # the non-overlap reference path (eagle_util.sample) when enabled.
+    probs_3d = jax.nn.softmax(tl.reshape(bs, n, vocab) / temp[:, :, None], axis=-1)
+    probs_2d = probs_3d.reshape(bs * n, vocab)
+    if enable_top_k:
+        tk = _rep(top_ks.astype(jnp.int32))
+        tk_flat = jnp.broadcast_to(tk[:, None], (bs, n)).reshape(bs * n)
+        probs_2d = top_k_renorm_prob(probs_2d, tk_flat)
+    if enable_top_p:
+        tp = _rep(top_ps.astype(jnp.float32))
+        tp_flat = jnp.broadcast_to(tp[:, None], (bs, n)).reshape(bs * n)
+        probs_2d = top_p_renorm_prob(probs_2d, tp_flat)
+    probs_3d = probs_2d.reshape(bs, n, vocab)
+
+    cand = draft_2d[:, 1:]  # (bs, n-1) candidate tokens d1..d_{n-1}
+    p_cand = jnp.take_along_axis(probs_3d[:, : n - 1, :], cand[:, :, None], axis=-1)[:, :, 0]
+
+    accept_mask = (coins_r <= p_cand / threshold_acc) | (p_cand >= threshold_single)
+
+    is_padding = seq_lens_r == 0
+    accepted_children = jnp.cumprod(accept_mask.astype(jnp.int32), axis=1).astype(jnp.bool_)
+    accepted_children = jnp.where(is_padding[:, None], False, accepted_children)
+    accept_length_raw = jnp.sum(accepted_children.astype(jnp.int32), axis=1)
+    accept_length = jnp.where(is_padding, 0, accept_length_raw + 1)
+
+    # residual / bonus sampling at emit position = accept_length_raw
+    emit_pos = accept_length_raw.astype(jnp.int32)  # (bs,) in [0, n-1]
+    p_emit = jnp.take_along_axis(probs_3d, emit_pos[:, None, None], axis=1)[:, 0, :]  # (bs, vocab)
+    has_rejected_child = emit_pos < (n - 1)
+    safe_reject_pos = jnp.minimum(emit_pos, n - 2)
+    rejected_token = jnp.take_along_axis(cand, safe_reject_pos[:, None], axis=1)[:, 0]
+    vocab_ids = jnp.arange(vocab, dtype=jnp.int32)[None, :]
+    residual_probs = jnp.where(vocab_ids == rejected_token[:, None], 0.0, p_emit)
+    final_probs = jnp.where(has_rejected_child[:, None], residual_probs, p_emit)
+    cdf = jnp.cumsum(final_probs, axis=-1)
+    u = coin_f_r * cdf[:, -1]
+    sampled = jnp.sum((cdf <= u[:, None]).astype(jnp.int32), axis=-1).astype(jnp.int32)
+    sampled = jnp.minimum(sampled, jnp.int32(vocab - 1))  # (bs,)
+
+    # predict_2d[:, k] = cand[:, k] (=d_{k+1}); override emit_pos slot with sampled
+    predict_2d = jnp.concatenate([cand, jnp.zeros((bs, 1), dtype=jnp.int32)], axis=1).astype(
+        jnp.int32
+    )
+    predict_2d = predict_2d.at[jnp.arange(bs), emit_pos].set(sampled)
+    predict = predict_2d.reshape(-1)
+
+    # --- accept_index machinery (identical to greedy path) ---
+    row_ids = jnp.arange(bs, dtype=jnp.int32)
+    base = row_ids[:, None] * n
+    child_offsets = jnp.arange(1, width, dtype=jnp.int32)[None, :]
+    accept_index_children = jnp.where(accepted_children, base + child_offsets, -1)
+    accept_index_2d = jnp.concatenate([base, accept_index_children], axis=1)
+    accept_index_2d = jnp.where(is_padding[:, None], -1, accept_index_2d)
+    accept_index = accept_index_2d.reshape(-1)
+
+    accept_width = speculative_num_steps + 1
+    req_ids = jnp.arange(accept_index.shape[0], dtype=jnp.int32) // accept_width
+    per_req_last = req_ids * speculative_num_draft_tokens + speculative_num_draft_tokens - 1
+    safe_index = jnp.where(accept_index >= 0, accept_index, per_req_last)
+    safe_predict = _take_with_index_sharding(predict, safe_index)
+    verified_id = jnp.where(accept_index >= 0, safe_predict, jnp.zeros_like(safe_predict))
+    prepared = _prepare_draft_inputs(
+        target_hidden,
+        positions,
+        seq_lens,
+        accept_index,
+        accept_length,
+        verified_id,
+        speculative_num_steps=speculative_num_steps,
+        speculative_num_draft_tokens=speculative_num_draft_tokens,
+    )
+    return GreedySampleAndPrepareOutput(
+        hidden_states=prepared.hidden_states,
+        positions=prepared.positions,
+        new_seq_lens=prepared.new_seq_lens,
+        select_index=prepared.select_index,
+        safe_index=safe_index,
+        verified_id=prepared.verified_id,
+        accept_lens=prepared.accept_lens,
+        sel_pos=prepared.sel_pos,
+        predict=predict,
+    )
+
+
+def _build_chain_verify_arrays(
     *,
     verified_id,
     token_list,
@@ -210,7 +354,7 @@ def _build_topk1_chain_verify_inputs_device_tuple(
     )
 
 
-def _device_rotate_input_ids(input_ids, ext_lens, sel_pos, new_tokens):
+def _rotate_input_ids(input_ids, ext_lens, sel_pos, new_tokens):
     """Mirror MultiLayerDraftWorker._rotate_ids on device for topk=1."""
     bs = ext_lens.shape[0]
     tokens_per_req = input_ids.shape[0] // bs
@@ -225,7 +369,7 @@ def _device_rotate_input_ids(input_ids, ext_lens, sel_pos, new_tokens):
     return shifted_2d.reshape(-1)
 
 
-def _device_rotate_prefill_input_ids(input_ids, extend_seq_lens, verified_id, dp_size, per_dp_bs):
+def _rotate_prefill_input_ids(input_ids, extend_seq_lens, verified_id, dp_size, per_dp_bs):
     per_dp_tokens = input_ids.shape[0] // dp_size
     ids = input_ids.reshape(dp_size, per_dp_tokens)
     ext = extend_seq_lens.reshape(dp_size, per_dp_bs)
@@ -257,12 +401,16 @@ def _gather_rows_preserve_sharding(values, index):
     return values[index, :]
 
 
+def _reshard_values(sharding, *values):
+    return tuple(jax.sharding.reshard(value, sharding) for value in values)
+
+
 def _topk1_index_from_logits(logits):
     topk_idx = jnp.argmax(logits, axis=-1).astype(jnp.int32)[:, None]
     return topk_idx
 
 
-def _build_fused_draft_extend_jit(num_layers: int, topk: int):
+def _build_draft_extend(num_layers: int, topk: int):
     """Build the fused JIT. Called once, result cached on draft_worker."""
     assert topk == 1, "Fused draft extend only supports topk=1"
 
@@ -305,14 +453,12 @@ def _build_fused_draft_extend_jit(num_layers: int, topk: int):
                 draft_verify_seq_lens + num_layers,
                 jnp.zeros_like(draft_verify_seq_lens),
             )
-            forward_batch.attn_backend.forward_metadata = (
-                _make_draft_extend_metadata_from_device_seq_lens(
-                    forward_batch.attn_backend.forward_metadata,
-                    forward_batch.seq_lens,
-                    draft_allocate_lens,
-                    page_size=forward_batch.attn_backend.page_size,
-                    dp_size=dp_size,
-                )
+            forward_batch.attn_backend.forward_metadata = _make_draft_extend_metadata(
+                forward_batch.attn_backend.forward_metadata,
+                forward_batch.seq_lens,
+                draft_allocate_lens,
+                page_size=forward_batch.attn_backend.page_size,
+                dp_size=dp_size,
             )
 
         for i in range(num_layers):
@@ -336,7 +482,7 @@ def _build_fused_draft_extend_jit(num_layers: int, topk: int):
 
             if i < num_layers - 1:
                 ext_lens = forward_batch.extend_seq_lens
-                input_ids = _device_rotate_input_ids(input_ids, ext_lens, sel_pos, topk_idx[:, 0])
+                input_ids = _rotate_input_ids(input_ids, ext_lens, sel_pos, topk_idx[:, 0])
 
         last_idx = draft_logits_indices
         if logits_metadata.accept_lens is not None:
@@ -391,13 +537,13 @@ def _build_fused_draft_extend_jit(num_layers: int, topk: int):
 def _per_dp_cumsum_device(lens, dp_size: int):
     per_dp_bs = lens.shape[0] // dp_size
     lens_2d = lens.reshape((dp_size, per_dp_bs))
-    zeros = jnp.zeros((dp_size, 1), dtype=jnp.int32)
+    zeros = jnp.zeros_like(lens_2d[:, :1], dtype=jnp.int32)
     return jnp.concatenate([zeros, jnp.cumsum(lens_2d, axis=1, dtype=jnp.int32)], axis=1).reshape(
         (dp_size * (per_dp_bs + 1),)
     )
 
 
-def _repack_page_indices_from_allocated_lens(
+def _repack_page_indices(
     page_indices,
     allocated_lens,
     metadata_seq_lens,
@@ -448,7 +594,7 @@ def _repack_page_indices_from_allocated_lens(
     return jnp.where(valid, gathered, jnp.zeros_like(gathered)).reshape(page_indices.shape)
 
 
-def _make_target_verify_metadata_from_device_seq_lens(
+def _make_target_verify_metadata(
     old_metadata,
     verify_seq_lens,
     allocated_lens,
@@ -471,7 +617,7 @@ def _make_target_verify_metadata_from_device_seq_lens(
     metadata_seq_lens = verify_seq_lens + extend_seq_lens
     aligned_seq_lens = ((metadata_seq_lens + page_size - 1) // page_size) * page_size
     cu_kv_lens = _per_dp_cumsum_device(aligned_seq_lens, dp_size)
-    page_indices = _repack_page_indices_from_allocated_lens(
+    page_indices = _repack_page_indices(
         old_metadata.page_indices,
         allocated_lens,
         metadata_seq_lens,
@@ -480,7 +626,7 @@ def _make_target_verify_metadata_from_device_seq_lens(
     )
     swa_page_indices = None
     if old_metadata.swa_page_indices is not None:
-        swa_page_indices = _repack_page_indices_from_allocated_lens(
+        swa_page_indices = _repack_page_indices(
             old_metadata.swa_page_indices,
             allocated_lens,
             metadata_seq_lens,
@@ -506,7 +652,7 @@ def _make_target_verify_metadata_from_device_seq_lens(
     )
 
 
-def _make_draft_extend_metadata_from_device_seq_lens(
+def _make_draft_extend_metadata(
     old_metadata,
     draft_seq_lens,
     allocated_lens,
@@ -525,7 +671,7 @@ def _make_draft_extend_metadata_from_device_seq_lens(
     cu_q_lens = old_metadata.cu_q_lens
     aligned_seq_lens = ((draft_seq_lens + page_size - 1) // page_size) * page_size
     cu_kv_lens = _per_dp_cumsum_device(aligned_seq_lens, dp_size)
-    page_indices = _repack_page_indices_from_allocated_lens(
+    page_indices = _repack_page_indices(
         old_metadata.page_indices,
         allocated_lens,
         draft_seq_lens,
@@ -534,7 +680,7 @@ def _make_draft_extend_metadata_from_device_seq_lens(
     )
     swa_page_indices = None
     if old_metadata.swa_page_indices is not None:
-        swa_page_indices = _repack_page_indices_from_allocated_lens(
+        swa_page_indices = _repack_page_indices(
             old_metadata.swa_page_indices,
             allocated_lens,
             draft_seq_lens,
@@ -560,7 +706,7 @@ def _make_draft_extend_metadata_from_device_seq_lens(
     )
 
 
-def _build_fused_greedy_verify_jit(topk: int):
+def _build_verify(topk: int):
     """Build target verify JIT for greedy NEXTN decode."""
     assert topk == 1, "Fused greedy verify only supports topk=1"
 
@@ -574,9 +720,14 @@ def _build_fused_greedy_verify_jit(topk: int):
             "return_target_logits",
             "use_relay_state",
             "dp_size",
+            "is_greedy",
+            "threshold_single",
+            "threshold_acc",
+            "enable_top_k",
+            "enable_top_p",
         ],
     )
-    def fused_greedy_verify(
+    def fused_verify(
         target_model_def,
         target_model_state_def,
         target_leaves,
@@ -588,12 +739,22 @@ def _build_fused_greedy_verify_jit(topk: int):
         relay_buffers,
         relay_future_indices,
         verify_allocate_lens,
+        sampling_base_rng,
+        sampling_step,
+        temperatures,
+        top_ks,
+        top_ps,
         *,
         speculative_num_steps,
         speculative_num_draft_tokens,
         return_target_logits,
         use_relay_state,
         dp_size,
+        is_greedy=True,
+        threshold_single=1.0,
+        threshold_acc=1.0,
+        enable_top_k=False,
+        enable_top_p=False,
     ):
         if use_relay_state:
             relay_topk_index, _, relay_verified_id, relay_new_seq_lens = gather_spec_relay_buffers(
@@ -607,15 +768,13 @@ def _build_fused_greedy_verify_jit(topk: int):
                 relay_new_seq_lens - 1,
                 jnp.zeros_like(target_forward_batch.seq_lens),
             )
-            target_forward_batch.attn_backend.forward_metadata = (
-                _make_target_verify_metadata_from_device_seq_lens(
-                    target_forward_batch.attn_backend.forward_metadata,
-                    target_forward_batch.seq_lens,
-                    verify_allocate_lens,
-                    speculative_num_draft_tokens=speculative_num_draft_tokens,
-                    page_size=target_forward_batch.attn_backend.page_size,
-                    dp_size=dp_size,
-                )
+            target_forward_batch.attn_backend.forward_metadata = _make_target_verify_metadata(
+                target_forward_batch.attn_backend.forward_metadata,
+                target_forward_batch.seq_lens,
+                verify_allocate_lens,
+                speculative_num_draft_tokens=speculative_num_draft_tokens,
+                page_size=target_forward_batch.attn_backend.page_size,
+                dp_size=dp_size,
             )
             previous_verified_id = relay_verified_id
             previous_token_list = relay_topk_index
@@ -627,7 +786,7 @@ def _build_fused_greedy_verify_jit(topk: int):
             retrive_index_flat,
             retrive_next_token_flat,
             retrive_next_sibling_flat,
-        ) = _build_topk1_chain_verify_inputs_device_tuple(
+        ) = _build_chain_verify_arrays(
             verified_id=previous_verified_id,
             token_list=previous_token_list,
             seq_lens=target_forward_batch.seq_lens,
@@ -662,17 +821,49 @@ def _build_fused_greedy_verify_jit(topk: int):
         mesh = sh.mesh if isinstance(sh, NamedSharding) else None
         target_logits = target_output.next_token_logits
         target_hidden = target_output.hidden_states
-        target_predict = jnp.argmax(target_logits, axis=-1).astype(jnp.int32).reshape(-1)
-
-        prepared = _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
-            target_hidden=target_hidden,
-            positions=target_forward_batch.positions,
-            seq_lens=target_forward_batch.seq_lens,
-            draft_tokens=draft_tokens,
-            target_predict=target_predict,
-            speculative_num_steps=speculative_num_steps,
-            speculative_num_draft_tokens=speculative_num_draft_tokens,
-        )
+        if is_greedy:
+            target_predict = jnp.argmax(target_logits, axis=-1).astype(jnp.int32).reshape(-1)
+            prepared = _verify_greedy(
+                target_hidden=target_hidden,
+                positions=target_forward_batch.positions,
+                seq_lens=target_forward_batch.seq_lens,
+                draft_tokens=draft_tokens,
+                target_predict=target_predict,
+                speculative_num_steps=speculative_num_steps,
+                speculative_num_draft_tokens=speculative_num_draft_tokens,
+            )
+        else:
+            # Generate rejection-sampling coins inside the JIT: avoids building them
+            # on host and copying (tbs, n-1)+(tbs,) arrays in every step, and keeps
+            # the threefry/uniform ops fused into this module instead of becoming
+            # standalone eager dispatches (the reason the earlier host-side jax.random
+            # attempt was reverted).
+            sampling_rng = jax.random.fold_in(sampling_base_rng, sampling_step)
+            coins_key, coin_f_key = jax.random.split(sampling_rng)
+            coins = jax.random.uniform(
+                coins_key,
+                (target_bs, speculative_num_draft_tokens - 1),
+                dtype=jnp.float32,
+            )
+            coin_f = jax.random.uniform(coin_f_key, (target_bs,), dtype=jnp.float32)
+            prepared = _verify_rejection_sampling(
+                target_hidden=target_hidden,
+                positions=target_forward_batch.positions,
+                seq_lens=target_forward_batch.seq_lens,
+                draft_tokens=draft_tokens,
+                target_logits=target_logits,
+                temperatures=temperatures,
+                top_ks=top_ks,
+                top_ps=top_ps,
+                coins=coins,
+                coin_f=coin_f,
+                threshold_single=threshold_single,
+                threshold_acc=threshold_acc,
+                enable_top_k=enable_top_k,
+                enable_top_p=enable_top_p,
+                speculative_num_steps=speculative_num_steps,
+                speculative_num_draft_tokens=speculative_num_draft_tokens,
+            )
 
         target_logits_for_host = (
             _gather_rows_preserve_sharding(target_logits, prepared.safe_index)
@@ -681,27 +872,74 @@ def _build_fused_greedy_verify_jit(topk: int):
         )
         prepared_hidden = prepared.hidden_states
         prepared_verified_id = prepared.verified_id
+        prepared_verified_id_data = prepared.verified_id
         prepared_next_verified_id = _take_with_index_sharding(
             prepared.verified_id, prepared.select_index
         )
         prepared_new_seq_lens = prepared.new_seq_lens
-        prepared_accept_lens = prepared.accept_lens
+        prepared_accept_lens_host = prepared.accept_lens
+        prepared_accept_lens_data = prepared.accept_lens
+        prepared_extend_seq_lens = jnp.where(
+            target_forward_batch.seq_lens > 0,
+            jnp.full_like(target_forward_batch.seq_lens, speculative_num_draft_tokens),
+            jnp.zeros_like(target_forward_batch.seq_lens),
+        ).astype(jnp.int32)
+        prepared_logits_indices = (
+            jnp.cumsum(
+                prepared_extend_seq_lens.reshape(dp_size, target_bs // dp_size),
+                axis=1,
+            ).reshape(-1)
+            - 1
+        ).astype(jnp.int32)
         prepared_sel_pos = prepared.sel_pos
+        prepared_sel_pos_data = prepared.sel_pos
         prepared_predict = prepared.predict
         prepared_positions = prepared.positions
+        prepared_positions_data = prepared.positions
         prepared_verify_seq_lens = target_forward_batch.seq_lens
+        prepared_allocate_lens_data = verify_allocate_lens
 
         if mesh is not None:
             rep = NamedSharding(mesh, P())
             data = NamedSharding(mesh, P("data"))
-            prepared_hidden = jax.sharding.reshard(prepared_hidden, rep)
-            prepared_verified_id = jax.sharding.reshard(prepared_verified_id, rep)
-            prepared_next_verified_id = jax.sharding.reshard(prepared_next_verified_id, data)
-            prepared_new_seq_lens = jax.sharding.reshard(prepared_new_seq_lens, rep)
-            prepared_accept_lens = jax.sharding.reshard(prepared_accept_lens, rep)
-            prepared_sel_pos = jax.sharding.reshard(prepared_sel_pos, rep)
-            prepared_predict = jax.sharding.reshard(prepared_predict, rep)
-            prepared_positions = jax.sharding.reshard(prepared_positions, rep)
+            (
+                prepared_hidden,
+                prepared_verified_id,
+                prepared_new_seq_lens,
+                prepared_accept_lens_host,
+                prepared_sel_pos,
+                prepared_predict,
+                prepared_positions,
+            ) = _reshard_values(
+                rep,
+                prepared_hidden,
+                prepared_verified_id,
+                prepared_new_seq_lens,
+                prepared_accept_lens_host,
+                prepared_sel_pos,
+                prepared_predict,
+                prepared_positions,
+            )
+            (
+                prepared_verified_id_data,
+                prepared_next_verified_id,
+                prepared_accept_lens_data,
+                prepared_extend_seq_lens,
+                prepared_logits_indices,
+                prepared_sel_pos_data,
+                prepared_positions_data,
+                prepared_allocate_lens_data,
+            ) = _reshard_values(
+                data,
+                prepared_verified_id_data,
+                prepared_next_verified_id,
+                prepared_accept_lens_data,
+                prepared_extend_seq_lens,
+                prepared_logits_indices,
+                prepared_sel_pos_data,
+                prepared_positions_data,
+                prepared_allocate_lens_data,
+            )
             if return_target_logits:
                 target_logits_for_host = jax.sharding.reshard(target_logits_for_host, rep)
 
@@ -709,20 +947,27 @@ def _build_fused_greedy_verify_jit(topk: int):
             target_pool_updates,
             prepared_hidden,
             prepared_verified_id,
+            prepared_verified_id_data,
             prepared_next_verified_id,
             prepared_new_seq_lens,
-            prepared_accept_lens,
+            prepared_accept_lens_host,
+            prepared_accept_lens_data,
+            prepared_extend_seq_lens,
+            prepared_logits_indices,
             prepared_sel_pos,
+            prepared_sel_pos_data,
             prepared_predict,
             prepared_positions,
+            prepared_positions_data,
             prepared_verify_seq_lens,
+            prepared_allocate_lens_data,
             target_logits_for_host,
         )
 
-    return fused_greedy_verify
+    return fused_verify
 
 
-def _build_fused_greedy_prefill_jit(num_layers: int, topk: int):
+def _build_prefill(num_layers: int, topk: int):
     """Build prefill JIT: target extend + all MTP draft-extend layers."""
     assert topk == 1, "Fused greedy prefill only supports topk=1"
 
@@ -738,7 +983,7 @@ def _build_fused_greedy_prefill_jit(num_layers: int, topk: int):
             "update_relay",
         ],
     )
-    def fused_greedy_prefill(
+    def fused_prefill(
         target_model_def,
         target_model_state_def,
         target_leaves,
@@ -772,7 +1017,7 @@ def _build_fused_greedy_prefill_jit(num_layers: int, topk: int):
         target_logits = target_output.next_token_logits
         target_hidden = target_output.hidden_states
         next_token_ids = jnp.argmax(target_logits, axis=-1).astype(jnp.int32)
-        input_ids = _device_rotate_prefill_input_ids(
+        input_ids = _rotate_prefill_input_ids(
             draft_forward_batch.input_ids,
             draft_forward_batch.extend_seq_lens,
             next_token_ids,
@@ -804,7 +1049,7 @@ def _build_fused_greedy_prefill_jit(num_layers: int, topk: int):
             if i == 0:
                 layer0_hidden = output.hidden_states
             if i < num_layers - 1:
-                input_ids = _device_rotate_prefill_input_ids(
+                input_ids = _rotate_prefill_input_ids(
                     input_ids,
                     draft_forward_batch.extend_seq_lens,
                     topk_idx[:, 0],
@@ -856,10 +1101,10 @@ def _build_fused_greedy_prefill_jit(num_layers: int, topk: int):
             updated_relay_buffers,
         )
 
-    return fused_greedy_prefill
+    return fused_prefill
 
 
-def _prepare_topk1_verify_placeholders_from_draft_state(draft_worker, model_worker_batch):
+def _prepare_verify(draft_worker, model_worker_batch):
     """Prepare fixed-shape verify placeholders while keeping chain build inside JIT."""
     from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode
     from sgl_jax.srt.speculative.eagle_util import EagleVerifyInput
@@ -927,19 +1172,19 @@ def _prepare_topk1_verify_placeholders_from_draft_state(draft_worker, model_work
     return previous_verified_id, previous_token_list
 
 
-def _device_array_preserve_device(value, sharding):
+def _prepare_device_array(value, sharding, name: str | None = None):
     from sgl_jax.srt.utils.jax_utils import device_array
 
     if value is None:
         return None
     if isinstance(value, jax.Array):
+        if value.sharding == sharding:
+            return value
         return jax.device_put(value, sharding)
     return device_array(value, sharding=sharding)
 
 
-def _logits_metadata_from_model_worker_batch_preserve_device(
-    batch, mesh, *, include_accept_lens: bool = True
-):
+def _prepare_logits_metadata(batch, mesh, *, include_accept_lens: bool = True):
     from sgl_jax.srt.layers.logits_processor import LogitsMetadata
 
     sharding = NamedSharding(mesh, P("data"))
@@ -955,43 +1200,75 @@ def _logits_metadata_from_model_worker_batch_preserve_device(
         extend_return_logprob=False,
         extend_return_top_logprob=False,
         extend_token_ids_logprob=False,
-        extend_seq_lens=_device_array_preserve_device(batch.extend_seq_lens, sharding),
-        logits_indices=_device_array_preserve_device(batch.logits_indices, sharding),
-        accept_lens=_device_array_preserve_device(accept_lens, sharding),
+        extend_seq_lens=_prepare_device_array(
+            batch.extend_seq_lens, sharding, "logits.extend_seq_lens"
+        ),
+        logits_indices=_prepare_device_array(
+            batch.logits_indices, sharding, "logits.logits_indices"
+        ),
+        accept_lens=_prepare_device_array(accept_lens, sharding, "logits.accept_lens"),
         extend_seq_lens_cpu=None,
         extend_logprob_start_lens_cpu=None,
         extend_logprob_pruned_lens_cpu=None,
         top_logprobs_nums=getattr(batch, "top_logprobs_nums", None),
         token_ids_logprobs=getattr(batch, "token_ids_logprobs", None),
-        extend_input_logprob_token_ids_device=_device_array_preserve_device(
-            getattr(batch, "extend_input_logprob_token_ids", None), sharding
+        extend_input_logprob_token_ids_device=_prepare_device_array(
+            getattr(batch, "extend_input_logprob_token_ids", None),
+            sharding,
+            "logits.extend_input_logprob_token_ids",
         ),
     )
 
 
-def _forward_batch_init_new_preserve_device(batch, model_runner):
+def _make_forward_batch(batch, model_runner):
     from sgl_jax.srt.eplb.expert_location import get_global_expert_location_metadata
     from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
 
     data_sharding = NamedSharding(model_runner.mesh, P("data"))
     replicated_2d = NamedSharding(model_runner.mesh, P(None, None))
+    spec_info = getattr(batch, "spec_info_padded", None)
+    input_ids = (
+        getattr(spec_info, "verified_id_for_draft_extend", None) if spec_info is not None else None
+    )
+    if input_ids is None:
+        input_ids = batch.input_ids
+    positions = (
+        getattr(spec_info, "positions_for_draft_extend", None) if spec_info is not None else None
+    )
+    if positions is None:
+        positions = batch.positions
+    extend_seq_lens = (
+        getattr(spec_info, "extend_seq_lens_for_draft_extend", None)
+        if spec_info is not None
+        else None
+    )
+    if extend_seq_lens is None:
+        extend_seq_lens = batch.extend_seq_lens
 
-    input_embedding = _device_array_preserve_device(batch.input_embedding, replicated_2d)
+    input_embedding = _prepare_device_array(
+        batch.input_embedding, replicated_2d, "forward.input_embedding"
+    )
     if input_embedding is not None:
         input_embedding = input_embedding.astype(jnp.bfloat16)
 
     deepstack_visual_embedding = None
     if getattr(batch, "apply_for_deepstack", False):
-        deepstack_visual_embedding = _device_array_preserve_device(
-            batch.deepstack_visual_embedding, replicated_2d
+        deepstack_visual_embedding = _prepare_device_array(
+            batch.deepstack_visual_embedding,
+            replicated_2d,
+            "forward.deepstack_visual_embedding",
         )
         if deepstack_visual_embedding is not None:
             deepstack_visual_embedding = deepstack_visual_embedding.astype(jnp.bfloat16)
 
     if batch.lora_scalings is not None:
-        lora_scalings = _device_array_preserve_device(batch.lora_scalings, data_sharding)
-        lora_token_indices = _device_array_preserve_device(batch.lora_token_indices, data_sharding)
-        lora_ranks = _device_array_preserve_device(batch.lora_ranks, data_sharding)
+        lora_scalings = _prepare_device_array(
+            batch.lora_scalings, data_sharding, "forward.lora_scalings"
+        )
+        lora_token_indices = _prepare_device_array(
+            batch.lora_token_indices, data_sharding, "forward.lora_token_indices"
+        )
+        lora_ranks = _prepare_device_array(batch.lora_ranks, data_sharding, "forward.lora_ranks")
     else:
         lora_scalings = batch.lora_scalings
         lora_token_indices = batch.lora_token_indices
@@ -1001,15 +1278,25 @@ def _forward_batch_init_new_preserve_device(batch, model_runner):
         bid=batch.bid,
         forward_mode=batch.forward_mode,
         batch_size=len(batch.seq_lens),
-        input_ids=_device_array_preserve_device(batch.input_ids, data_sharding),
-        seq_lens=_device_array_preserve_device(batch.seq_lens, data_sharding),
-        out_cache_loc=_device_array_preserve_device(batch.out_cache_loc, data_sharding),
-        positions=_device_array_preserve_device(batch.positions, data_sharding),
-        mrope_positions=_device_array_preserve_device(batch.mrope_positions, replicated_2d),
-        req_pool_indices=_device_array_preserve_device(batch.req_pool_indices, data_sharding),
-        cache_loc=_device_array_preserve_device(batch.cache_loc, data_sharding),
-        extend_prefix_lens=_device_array_preserve_device(batch.extend_prefix_lens, data_sharding),
-        extend_seq_lens=_device_array_preserve_device(batch.extend_seq_lens, data_sharding),
+        input_ids=_prepare_device_array(input_ids, data_sharding, "forward.input_ids"),
+        seq_lens=_prepare_device_array(batch.seq_lens, data_sharding, "forward.seq_lens"),
+        out_cache_loc=_prepare_device_array(
+            batch.out_cache_loc, data_sharding, "forward.out_cache_loc"
+        ),
+        positions=_prepare_device_array(positions, data_sharding, "forward.positions"),
+        mrope_positions=_prepare_device_array(
+            batch.mrope_positions, replicated_2d, "forward.mrope_positions"
+        ),
+        req_pool_indices=_prepare_device_array(
+            batch.req_pool_indices, data_sharding, "forward.req_pool_indices"
+        ),
+        cache_loc=_prepare_device_array(batch.cache_loc, data_sharding, "forward.cache_loc"),
+        extend_prefix_lens=_prepare_device_array(
+            batch.extend_prefix_lens, data_sharding, "forward.extend_prefix_lens"
+        ),
+        extend_seq_lens=_prepare_device_array(
+            extend_seq_lens, data_sharding, "forward.extend_seq_lens"
+        ),
         lora_ids=batch.lora_ids,
         lora_scalings=lora_scalings,
         lora_token_indices=lora_token_indices,
@@ -1022,11 +1309,13 @@ def _forward_batch_init_new_preserve_device(batch, model_runner):
         apply_for_deepstack=batch.apply_for_deepstack,
         deepstack_visual_embedding=deepstack_visual_embedding,
         expert_location_metadata=get_global_expert_location_metadata(),
-        recurrent_indices=_device_array_preserve_device(batch.recurrent_indices, data_sharding),
+        recurrent_indices=_prepare_device_array(
+            batch.recurrent_indices, data_sharding, "forward.recurrent_indices"
+        ),
     )
 
 
-def prepare_spec_prefill_forward_batch(spec_worker, model_worker_batch):
+def prepare_forward_batch_for_prefill(spec_worker, model_worker_batch):
     """Prepare the target ForwardBatch before speculative prefill is queued."""
     from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode
 
@@ -1035,9 +1324,7 @@ def prepare_spec_prefill_forward_batch(spec_worker, model_worker_batch):
     target_mr.attn_backend.forward_metadata = target_mr.attn_backend.get_forward_metadata(
         model_worker_batch
     )
-    model_worker_batch.forward_batch = _forward_batch_init_new_preserve_device(
-        model_worker_batch, target_mr
-    )
+    model_worker_batch.forward_batch = _make_forward_batch(model_worker_batch, target_mr)
     model_worker_batch.forward_batch.bid = model_worker_batch.bid
     return model_worker_batch.forward_batch
 
@@ -1062,6 +1349,25 @@ def launch_fused_draft_extend_for_decode(
     draft_input = EagleDraftInput(
         hidden_states=target_hidden,
         allocate_lens=batch_output.next_draft_input.allocate_lens,
+        accept_length=getattr(batch_output.next_draft_input, "accept_length", None),
+    )
+    draft_input.verified_id_for_draft_extend = getattr(
+        batch_output.next_draft_input, "verified_id_for_draft_extend", None
+    )
+    draft_input.extend_seq_lens_for_draft_extend = getattr(
+        batch_output.next_draft_input, "extend_seq_lens_for_draft_extend", None
+    )
+    draft_input.logits_indices_for_draft_extend = getattr(
+        batch_output.next_draft_input, "logits_indices_for_draft_extend", None
+    )
+    draft_input.positions_for_draft_extend = getattr(
+        batch_output.next_draft_input, "positions_for_draft_extend", None
+    )
+    draft_input.sel_pos_for_draft_extend = getattr(
+        batch_output.next_draft_input, "sel_pos_for_draft_extend", None
+    )
+    draft_input.allocate_lens_for_draft_extend = getattr(
+        batch_output.next_draft_input, "allocate_lens_for_draft_extend", None
     )
     if getattr(batch_output.next_draft_input, "verify_seq_lens", None) is not None:
         draft_input.device_seq_lens_for_draft_extend = True
@@ -1075,14 +1381,19 @@ def launch_fused_draft_extend_for_decode(
         return None
 
     sel = np.asarray(model_worker_batch.logits_indices_selector)
-    if hasattr(batch_output.next_draft_input, "sel_pos"):
+    sel_pos_for_draft_extend = getattr(
+        batch_output.next_draft_input, "sel_pos_for_draft_extend", None
+    )
+    if sel_pos_for_draft_extend is not None:
+        sel_pos = sel_pos_for_draft_extend
+    elif hasattr(batch_output.next_draft_input, "sel_pos"):
         sel_pos = batch_output.next_draft_input.sel_pos
     else:
         sel_pos = jnp.clip(batch_output.accept_lens - 1, 0, None).astype(jnp.int32)
 
     mr0 = draft_worker._workers[0].model_runner
     mwb.spec_info_padded.hidden_states = target_hidden
-    shared_fb = _forward_batch_init_new_preserve_device(mwb, mr0)
+    shared_fb = _make_forward_batch(mwb, mr0)
     shared_fb.bid = model_worker_batch.bid
 
     all_memory_pools = []
@@ -1093,21 +1404,41 @@ def launch_fused_draft_extend_for_decode(
         all_leaves.append(tuple(mr.model_state_leaves))
 
     data_sharding = NamedSharding(draft_worker.mesh, P("data"))
-    sel_pos_device = _device_array_preserve_device(sel_pos, data_sharding)
-    draft_logits_indices = _device_array_preserve_device(mwb.logits_indices, data_sharding)
-    draft_allocate_lens = np.zeros_like(model_worker_batch.seq_lens, dtype=np.int32)
-    draft_allocate_lens[sel] = np.asarray(batch_output.next_draft_input.allocate_lens)
-    draft_allocate_lens = _device_array_preserve_device(draft_allocate_lens, data_sharding)
+    sel_pos_device = _prepare_device_array(sel_pos, data_sharding, "draft_extend.sel_pos")
+    draft_logits_indices = _prepare_device_array(
+        (
+            getattr(mwb.spec_info_padded, "logits_indices_for_draft_extend", None)
+            if getattr(mwb.spec_info_padded, "logits_indices_for_draft_extend", None) is not None
+            else mwb.logits_indices
+        ),
+        data_sharding,
+        "draft_extend.logits_indices",
+    )
+    draft_allocate_lens = getattr(
+        batch_output.next_draft_input, "allocate_lens_for_draft_extend", None
+    )
+    if draft_allocate_lens is None:
+        draft_allocate_lens = np.zeros_like(model_worker_batch.seq_lens, dtype=np.int32)
+        draft_allocate_lens[sel] = np.asarray(batch_output.next_draft_input.allocate_lens)
+    draft_allocate_lens = _prepare_device_array(
+        draft_allocate_lens, data_sharding, "draft_extend.allocate_lens"
+    )
     draft_verify_seq_lens = getattr(batch_output.next_draft_input, "verify_seq_lens", None)
-    draft_verify_seq_lens = _device_array_preserve_device(draft_verify_seq_lens, data_sharding)
+    draft_verify_seq_lens = _prepare_device_array(
+        draft_verify_seq_lens, data_sharding, "draft_extend.verify_seq_lens"
+    )
     if relay_future_indices is None:
         relay_future_indices = np.zeros(model_worker_batch.req_pool_indices.shape, dtype=np.int32)
     if relay_valid_mask is None:
         relay_valid_mask = np.zeros(model_worker_batch.req_pool_indices.shape, dtype=np.bool_)
-    relay_future_indices = _device_array_preserve_device(relay_future_indices, data_sharding)
-    relay_valid_mask = _device_array_preserve_device(relay_valid_mask, data_sharding)
+    relay_future_indices = _prepare_device_array(
+        relay_future_indices, data_sharding, "draft_extend.relay_future_indices"
+    )
+    relay_valid_mask = _prepare_device_array(
+        relay_valid_mask, data_sharding, "draft_extend.relay_valid_mask"
+    )
     if not hasattr(draft_worker, "_fused_jit_fn"):
-        draft_worker._fused_jit_fn = _build_fused_draft_extend_jit(
+        draft_worker._fused_jit_fn = _build_draft_extend(
             num_layers=draft_worker.speculative_num_steps,
             topk=draft_worker.topk,
         )
@@ -1154,7 +1485,7 @@ def launch_fused_draft_extend_for_decode(
     )
 
 
-def restore_fused_draft_extend_result(draft_worker, model_worker_batch, pending_result):
+def restore_draft_extend_result(draft_worker, model_worker_batch, pending_result):
     if pending_result is None:
         return
 
@@ -1184,7 +1515,7 @@ def restore_fused_draft_extend_result(draft_worker, model_worker_batch, pending_
     batch_output.accept_lens = accept_host
 
 
-def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output):
+def draft_extend_for_decode(draft_worker, model_worker_batch, batch_output):
     """Drop-in replacement for MultiLayerDraftWorker.draft_extend_for_decode.
 
     Fuses all N MTP layer forwards into a single jit call.
@@ -1192,7 +1523,7 @@ def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output
     pending_result = launch_fused_draft_extend_for_decode(
         draft_worker, model_worker_batch, batch_output
     )
-    restore_fused_draft_extend_result(draft_worker, model_worker_batch, pending_result)
+    restore_draft_extend_result(draft_worker, model_worker_batch, pending_result)
 
 
 def spec_prefill(spec_worker, model_worker_batch, launch_done=None, *, update_relay=False):
@@ -1209,7 +1540,7 @@ def spec_prefill(spec_worker, model_worker_batch, launch_done=None, *, update_re
     target_mr = target_worker.model_runner
 
     if getattr(model_worker_batch, "forward_batch", None) is None:
-        target_forward_batch = prepare_spec_prefill_forward_batch(spec_worker, model_worker_batch)
+        target_forward_batch = prepare_forward_batch_for_prefill(spec_worker, model_worker_batch)
     else:
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
         target_mr.attn_backend.forward_metadata = target_mr.attn_backend.get_forward_metadata(
@@ -1217,9 +1548,7 @@ def spec_prefill(spec_worker, model_worker_batch, launch_done=None, *, update_re
         )
         target_forward_batch = model_worker_batch.forward_batch
         target_forward_batch.bid = model_worker_batch.bid
-    target_logits_metadata = _logits_metadata_from_model_worker_batch_preserve_device(
-        model_worker_batch, spec_worker.mesh
-    )
+    target_logits_metadata = _prepare_logits_metadata(model_worker_batch, spec_worker.mesh)
 
     hidden_size = target_worker.model_config.hidden_size
     model_worker_batch.spec_info_padded = EagleDraftInput(
@@ -1240,13 +1569,12 @@ def spec_prefill(spec_worker, model_worker_batch, launch_done=None, *, update_re
     draft_forward_batch = ForwardBatch.init_new(model_worker_batch, draft_mr0)
     draft_forward_batch.input_ids = target_forward_batch.input_ids
     draft_forward_batch.bid = model_worker_batch.bid
-    draft_logits_indices = _device_array_preserve_device(
+    draft_logits_indices = _prepare_device_array(
         model_worker_batch.logits_indices,
         NamedSharding(draft_worker.mesh, P("data")),
+        "prefill.logits_indices",
     )
-    draft_logits_metadata = _logits_metadata_from_model_worker_batch_preserve_device(
-        model_worker_batch, draft_worker.mesh
-    )
+    draft_logits_metadata = _prepare_logits_metadata(model_worker_batch, draft_worker.mesh)
 
     all_memory_pools = []
     all_leaves = []
@@ -1256,7 +1584,7 @@ def spec_prefill(spec_worker, model_worker_batch, launch_done=None, *, update_re
         all_leaves.append(tuple(mr.model_state_leaves))
 
     if not hasattr(draft_worker, "_fused_greedy_prefill_jit_fn"):
-        draft_worker._fused_greedy_prefill_jit_fn = _build_fused_greedy_prefill_jit(
+        draft_worker._fused_greedy_prefill_jit_fn = _build_prefill(
             num_layers=draft_worker.speculative_num_steps,
             topk=draft_worker.topk,
         )
@@ -1273,10 +1601,12 @@ def spec_prefill(spec_worker, model_worker_batch, launch_done=None, *, update_re
         np.asarray(model_worker_batch.req_pool_indices, dtype=np.int32),
         0,
     )
-    relay_future_indices = _device_array_preserve_device(safe_indices, data_sharding)
-    relay_valid_mask = _device_array_preserve_device(valid_mask, data_sharding)
+    relay_future_indices = _prepare_device_array(
+        safe_indices, data_sharding, "prefill.relay_future_indices"
+    )
+    relay_valid_mask = _prepare_device_array(valid_mask, data_sharding, "prefill.relay_valid_mask")
 
-    with jax.set_mesh(draft_worker.mesh), jtu.count_pjit_cpp_cache_miss() as count:
+    with jax.set_mesh(draft_worker.mesh), _count_pjit_cpp_cache_miss() as count:
         (
             logits_output,
             next_token_ids,
@@ -1383,7 +1713,7 @@ def spec_prefill_overlap(spec_worker, model_worker_batch):
     return spec_prefill(spec_worker, model_worker_batch, update_relay=True)
 
 
-def spec_decode_verify_phase(spec_worker, model_worker_batch, cur_allocate_lens):
+def spec_decode_verify(spec_worker, model_worker_batch, cur_allocate_lens):
     """Run target verify as the first speculative decode JIT."""
     from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
     from sgl_jax.srt.managers.scheduler import GenerationBatchResult
@@ -1401,9 +1731,7 @@ def spec_decode_verify_phase(spec_worker, model_worker_batch, cur_allocate_lens)
     if use_relay_state:
         relay_future_indices = np.asarray(draft_input.future_indices, dtype=np.int32)
         relay_future_indices = np.where(relay_future_indices >= 0, relay_future_indices, 0)
-    previous_verified_id, previous_token_list = _prepare_topk1_verify_placeholders_from_draft_state(
-        draft_worker, model_worker_batch
-    )
+    previous_verified_id, previous_token_list = _prepare_verify(draft_worker, model_worker_batch)
     spec_info = model_worker_batch.spec_info_padded
     return_target_logits = bool(
         getattr(model_worker_batch, "return_logprob", False)
@@ -1417,36 +1745,99 @@ def spec_decode_verify_phase(spec_worker, model_worker_batch, cur_allocate_lens)
     )
     if use_relay_state and target_mr.attn_backend.forward_metadata.custom_mask is not None:
         raise NotImplementedError("Spec decode overlap relay path does not support custom_mask.")
-    target_forward_batch = _forward_batch_init_new_preserve_device(model_worker_batch, target_mr)
+    target_forward_batch = _make_forward_batch(model_worker_batch, target_mr)
     target_forward_batch.bid = model_worker_batch.bid
-    target_logits_metadata = _logits_metadata_from_model_worker_batch_preserve_device(
-        model_worker_batch, spec_worker.mesh
-    )
+    target_logits_metadata = _prepare_logits_metadata(model_worker_batch, spec_worker.mesh)
     data_sharding = NamedSharding(spec_worker.mesh, P("data"))
     if relay_future_indices is None:
         relay_future_indices = np.zeros(model_worker_batch.seq_lens.shape, dtype=np.int32)
-    relay_future_indices = _device_array_preserve_device(relay_future_indices, data_sharding)
+    relay_future_indices = _prepare_device_array(
+        relay_future_indices, data_sharding, "verify.relay_future_indices"
+    )
     verify_allocate_lens = np.zeros_like(model_worker_batch.seq_lens, dtype=np.int32)
     verify_allocate_lens[model_worker_batch.logits_indices_selector] = cur_allocate_lens
-    verify_allocate_lens = _device_array_preserve_device(verify_allocate_lens, data_sharding)
+    verify_allocate_lens = _prepare_device_array(
+        verify_allocate_lens, data_sharding, "verify.allocate_lens"
+    )
 
     if not hasattr(draft_worker, "_fused_greedy_verify_jit_fn"):
-        draft_worker._fused_greedy_verify_jit_fn = _build_fused_greedy_verify_jit(
+        draft_worker._fused_greedy_verify_jit_fn = _build_verify(
             topk=draft_worker.topk,
         )
 
-    with jax.set_mesh(draft_worker.mesh), jtu.count_pjit_cpp_cache_miss() as count:
+    si = model_worker_batch.sampling_info
+    _sv_is_greedy = bool(getattr(si, "is_all_greedy", True))
+    _sv_tbs = target_forward_batch.seq_lens.shape[0]
+    _sv_enable_top_k = False
+    _sv_enable_top_p = False
+    if _sv_is_greedy:
+        _sv_temps = _prepare_device_array(np.ones((_sv_tbs, 1), np.float32), data_sharding)
+        _sv_topks = _prepare_device_array(np.zeros((_sv_tbs,), np.int32), data_sharding)
+        _sv_topps = _prepare_device_array(np.ones((_sv_tbs,), np.float32), data_sharding)
+    else:
+        _t = np.asarray(si.temperatures, np.float32).reshape(-1)
+        _k = (
+            np.asarray(getattr(si, "top_ks", None)).reshape(-1)
+            if getattr(si, "top_ks", None) is not None
+            else None
+        )
+        _p = (
+            np.asarray(getattr(si, "top_ps", None), np.float32).reshape(-1)
+            if getattr(si, "top_ps", None) is not None
+            else None
+        )
+        _tv = float(_t[0]) if _t.size else 1.0
+        _kv = int(_k[0]) if (_k is not None and _k.size) else 0
+        _pv = float(_p[0]) if (_p is not None and _p.size) else 1.0
+        _sv_vocab = int(target_worker.model_config.vocab_size)
+        _sv_enable_top_k = 0 < _kv < _sv_vocab
+        _sv_enable_top_p = _pv < 1.0
+        # temps/topks/topps are constant across decode steps for a given batch
+        # (they only depend on tbs and the per-batch sampling scalars), so building
+        # + transferring them every step is wasted H2D dispatch. Cache the device
+        # arrays keyed by (tbs, temp, top_k, top_p) and reuse until the batch changes.
+        _const_sig = (_sv_tbs, _tv, _kv, _pv)
+        _const_cache = getattr(target_mr, "_sv_sampling_const_cache", None)
+        if _const_cache is None or _const_cache[0] != _const_sig:
+            _sv_temps = _prepare_device_array(np.full((_sv_tbs, 1), _tv, np.float32), data_sharding)
+            _sv_topks = _prepare_device_array(np.full((_sv_tbs,), _kv, np.int32), data_sharding)
+            _sv_topps = _prepare_device_array(np.full((_sv_tbs,), _pv, np.float32), data_sharding)
+            target_mr._sv_sampling_const_cache = (
+                _const_sig,
+                _sv_temps,
+                _sv_topks,
+                _sv_topps,
+            )
+        else:
+            _, _sv_temps, _sv_topks, _sv_topps = _const_cache
+    _sv_thr_single = float(
+        getattr(spec_worker.server_args, "speculative_accept_threshold_single", 1.0)
+    )
+    _sv_thr_acc = float(getattr(spec_worker.server_args, "speculative_accept_threshold_acc", 1.0))
+
+    # Advance the per-step sampling RNG; coins are generated inside the verify JIT
+    # from (base_rng, step), so only this small int crosses the host->device boundary.
+    target_mr._sampler_step += 1
+
+    with jax.set_mesh(draft_worker.mesh), _count_pjit_cpp_cache_miss() as count:
         (
             target_pool_updates,
             prepared_hidden,
             prepared_verified_id,
+            prepared_verified_id_data,
             prepared_next_verified_id,
             prepared_new_seq_lens,
-            prepared_accept_lens,
+            prepared_accept_lens_host,
+            prepared_accept_lens_data,
+            prepared_extend_seq_lens,
+            prepared_logits_indices,
             prepared_sel_pos,
+            prepared_sel_pos_data,
             prepared_predict,
             prepared_positions,
+            prepared_positions_data,
             prepared_verify_seq_lens,
+            prepared_allocate_lens_data,
             target_logits,
         ) = draft_worker._fused_greedy_verify_jit_fn(
             target_mr._model_def,
@@ -1460,11 +1851,21 @@ def spec_decode_verify_phase(spec_worker, model_worker_batch, cur_allocate_lens)
             getattr(spec_worker, "spec_relay_buffers", None),
             relay_future_indices,
             verify_allocate_lens,
+            target_mr._sampler_base_rng,
+            target_mr._sampler_step,
+            _sv_temps,
+            _sv_topks,
+            _sv_topps,
             speculative_num_steps=draft_worker.speculative_num_steps,
             speculative_num_draft_tokens=draft_worker.speculative_num_draft_tokens,
             return_target_logits=return_target_logits,
             use_relay_state=use_relay_state,
             dp_size=model_worker_batch.dp_size,
+            is_greedy=_sv_is_greedy,
+            threshold_single=_sv_thr_single,
+            threshold_acc=_sv_thr_acc,
+            enable_top_k=_sv_enable_top_k,
+            enable_top_p=_sv_enable_top_p,
         )
         cache_miss_count = count()
 
@@ -1475,7 +1876,14 @@ def spec_decode_verify_phase(spec_worker, model_worker_batch, cur_allocate_lens)
         new_seq_lens=prepared_new_seq_lens,
         allocate_lens=cur_allocate_lens,
         hidden_states=prepared_hidden,
+        accept_length=prepared_accept_lens_data,
     )
+    next_draft_input.verified_id_for_draft_extend = prepared_verified_id_data
+    next_draft_input.extend_seq_lens_for_draft_extend = prepared_extend_seq_lens
+    next_draft_input.logits_indices_for_draft_extend = prepared_logits_indices
+    next_draft_input.positions_for_draft_extend = prepared_positions_data
+    next_draft_input.sel_pos_for_draft_extend = prepared_sel_pos_data
+    next_draft_input.allocate_lens_for_draft_extend = prepared_allocate_lens_data
     next_draft_input.next_verified_id = prepared_next_verified_id
     next_draft_input.sel_pos = prepared_sel_pos
     next_draft_input.positions = prepared_positions
@@ -1487,7 +1895,7 @@ def spec_decode_verify_phase(spec_worker, model_worker_batch, cur_allocate_lens)
         ),
         next_token_ids=prepared_predict,
         next_draft_input=next_draft_input,
-        accept_lens=prepared_accept_lens,
+        accept_lens=prepared_accept_lens_host,
         bid=model_worker_batch.bid,
         cache_miss_count=cache_miss_count,
         extend_input_len_per_req=None,
@@ -1497,7 +1905,7 @@ def spec_decode_verify_phase(spec_worker, model_worker_batch, cur_allocate_lens)
     return batch_output
 
 
-def spec_decode_draft_extend_phase(spec_worker, model_worker_batch, batch_output):
+def spec_decode_draft_extend(spec_worker, model_worker_batch, batch_output):
     """Run MTP draft extend as the second speculative decode JIT."""
     spec_worker.draft_worker.draft_extend_for_decode(model_worker_batch, batch_output)
     return batch_output
@@ -1505,13 +1913,13 @@ def spec_decode_draft_extend_phase(spec_worker, model_worker_batch, batch_output
 
 def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
     """Run speculative decode as verify JIT followed by draft-extend JIT."""
-    batch_output = spec_decode_verify_phase(spec_worker, model_worker_batch, cur_allocate_lens)
-    return spec_decode_draft_extend_phase(spec_worker, model_worker_batch, batch_output)
+    batch_output = spec_decode_verify(spec_worker, model_worker_batch, cur_allocate_lens)
+    return spec_decode_draft_extend(spec_worker, model_worker_batch, batch_output)
 
 
 def spec_decode_overlap(spec_worker, model_worker_batch, cur_allocate_lens):
     """Launch decode verify and draft-extend without restoring draft results inline."""
-    batch_output = spec_decode_verify_phase(spec_worker, model_worker_batch, cur_allocate_lens)
+    batch_output = spec_decode_verify(spec_worker, model_worker_batch, cur_allocate_lens)
     sel = np.asarray(model_worker_batch.logits_indices_selector)
     batch_output.next_draft_input.future_indices = np.asarray(model_worker_batch.req_pool_indices)[
         sel

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -1,19 +1,9 @@
-"""Fused single-JIT for N-layer MTP draft extend decode.
-
-Merges all N model forward calls into one @jax.jit, eliminating:
-- Per-layer host dispatch overhead (~N jit calls → 1)
-- Per-layer device_get for rotate_ids (device .at[].set for topk=1)
-- Per-layer replicate_to_mesh boundary (with_sharding_constraint inside jit)
-
-Constraints:
-- topk=1 only (rotate_ids = .at[sel_pos].set)
-- All MTP layers share same model class (same model_def / model_state_def)
-"""
+"""Fused greedy speculative decode and MTP draft extend."""
 
 from __future__ import annotations
 
-import logging
 from functools import partial
+from typing import NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -22,23 +12,175 @@ from flax import nnx
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
-logger = logging.getLogger(__name__)
+
+class GreedyDraftInputs(NamedTuple):
+    hidden_states: jax.Array
+    positions: jax.Array
+    new_seq_lens: jax.Array
+    select_index: jax.Array
+    verified_id: jax.Array
+    accept_lens: jax.Array
+    sel_pos: jax.Array
+
+
+class GreedySampleAndPrepareOutput(NamedTuple):
+    hidden_states: jax.Array
+    positions: jax.Array
+    new_seq_lens: jax.Array
+    select_index: jax.Array
+    verified_id: jax.Array
+    accept_lens: jax.Array
+    sel_pos: jax.Array
+    predict: jax.Array
+
+
+def _take_with_index_sharding(values, index):
+    index_sharding = jax.typeof(index).sharding
+    if isinstance(index_sharding, NamedSharding):
+        return values.reshape(-1).at[index].get(out_sharding=index_sharding)
+    return jnp.take(values.reshape(-1), index)
+
+
+def _greedy_prepare_draft_inputs(
+    hidden_states,
+    positions,
+    seq_lens,
+    accept_index,
+    accept_length,
+    verified_id,
+    *,
+    speculative_num_steps,
+    speculative_num_draft_tokens,
+):
+    accept_width = speculative_num_steps + 1
+    req_ids = (
+        jnp.zeros_like(accept_index)
+        + jnp.arange(accept_index.shape[0], dtype=jnp.int32) // accept_width
+    )
+    per_req_last = req_ids * speculative_num_draft_tokens + speculative_num_draft_tokens - 1
+    safe_index = jnp.where(accept_index >= 0, accept_index, per_req_last)
+    safe_accept_length = jnp.clip(accept_length, 1, None)
+    select_index = (
+        jnp.arange(accept_length.shape[0], dtype=jnp.int32) * accept_width + safe_accept_length - 1
+    )
+    hidden_sharding = jax.typeof(hidden_states).sharding
+    positions_sharding = jax.typeof(positions).sharding
+    if isinstance(hidden_sharding, NamedSharding):
+        gathered_hidden = hidden_states.at[safe_index, :].get(out_sharding=hidden_sharding)
+    else:
+        gathered_hidden = hidden_states[safe_index, :]
+    if isinstance(positions_sharding, NamedSharding):
+        gathered_positions = positions.at[safe_index].get(out_sharding=positions_sharding)
+    else:
+        gathered_positions = positions[safe_index]
+    return GreedyDraftInputs(
+        hidden_states=gathered_hidden,
+        positions=gathered_positions,
+        new_seq_lens=seq_lens + accept_length,
+        select_index=select_index,
+        verified_id=verified_id,
+        accept_lens=accept_length,
+        sel_pos=jnp.clip(accept_length - 1, 0, None).astype(jnp.int32),
+    )
+
+
+def _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
+    *,
+    target_hidden,
+    positions,
+    seq_lens,
+    draft_tokens,
+    target_predict,
+    speculative_num_steps,
+    speculative_num_draft_tokens,
+):
+    bs = seq_lens.shape[0]
+    n = speculative_num_draft_tokens
+    width = speculative_num_steps + 1
+    draft_2d = draft_tokens.reshape(bs, n)
+    target_predict_2d = target_predict.reshape(bs, n)
+
+    child_matches = draft_2d[:, 1:] == target_predict_2d[:, :-1]
+    is_padding = seq_lens == 0
+    accepted_children = jnp.cumprod(child_matches.astype(jnp.int32), axis=1).astype(jnp.bool_)
+    accepted_children = jnp.where(is_padding[:, None], False, accepted_children)
+    accept_length_raw = jnp.sum(accepted_children.astype(jnp.int32), axis=1)
+    accept_length = jnp.where(is_padding, 0, accept_length_raw + 1)
+
+    row_ids = jnp.zeros_like(accept_length_raw) + jnp.arange(bs, dtype=jnp.int32)
+    base = row_ids[:, None] * n
+    child_offsets = jnp.arange(1, width, dtype=jnp.int32)[None, :]
+    accept_index_children = jnp.where(accepted_children, base + child_offsets, -1)
+    accept_index_2d = jnp.concatenate([base, accept_index_children], axis=1)
+    accept_index_2d = jnp.where(is_padding[:, None], -1, accept_index_2d)
+    accept_index = accept_index_2d.reshape(-1)
+
+    predict = target_predict.astype(jnp.int32).reshape(-1)
+    accept_width = speculative_num_steps + 1
+    req_ids = (
+        jnp.zeros_like(accept_index)
+        + jnp.arange(accept_index.shape[0], dtype=jnp.int32) // accept_width
+    )
+    per_req_last = req_ids * speculative_num_draft_tokens + speculative_num_draft_tokens - 1
+    safe_index = jnp.where(accept_index >= 0, accept_index, per_req_last)
+    safe_predict = _take_with_index_sharding(predict, safe_index)
+    verified_id = jnp.where(accept_index >= 0, safe_predict, jnp.zeros_like(safe_predict))
+    prepared = _greedy_prepare_draft_inputs(
+        target_hidden,
+        positions,
+        seq_lens,
+        accept_index,
+        accept_length,
+        verified_id,
+        speculative_num_steps=speculative_num_steps,
+        speculative_num_draft_tokens=speculative_num_draft_tokens,
+    )
+    return GreedySampleAndPrepareOutput(
+        hidden_states=prepared.hidden_states,
+        positions=prepared.positions,
+        new_seq_lens=prepared.new_seq_lens,
+        select_index=prepared.select_index,
+        verified_id=prepared.verified_id,
+        accept_lens=prepared.accept_lens,
+        sel_pos=prepared.sel_pos,
+        predict=predict,
+    )
+
+
+def _build_topk1_chain_verify_inputs_device_tuple(
+    *,
+    verified_id,
+    token_list,
+    seq_lens,
+    num_verify_tokens,
+    batch_size,
+):
+    """Build topk=1 linear-chain verify inputs in-JIT without stacking shardings."""
+    n = num_verify_tokens
+    bs = batch_size
+    tid_range = jnp.arange(n, dtype=jnp.int32)
+    draft_tokens = jnp.concatenate(
+        [verified_id.astype(jnp.int32)[:, None], token_list[:, : n - 1].astype(jnp.int32)],
+        axis=1,
+    ).reshape(bs * n)
+    positions = (seq_lens.astype(jnp.int32)[:, None] + tid_range[None, :]).reshape(bs * n)
+    retrive_index = jnp.arange(bs * n, dtype=jnp.int32)
+    retrive_next_token = jnp.broadcast_to(
+        jnp.concatenate([jnp.arange(1, n, dtype=jnp.int32), jnp.array([-1], dtype=jnp.int32)]),
+        (bs, n),
+    ).reshape(bs * n)
+    retrive_next_sibling = jnp.full((bs * n,), -1, dtype=jnp.int32)
+    return (
+        draft_tokens,
+        positions,
+        retrive_index,
+        retrive_next_token,
+        retrive_next_sibling,
+    )
 
 
 def _device_rotate_input_ids(input_ids, ext_lens, sel_pos, new_tokens):
-    """Device-side per-req rotate for topk=1, exact mirror of the host
-    ``MultiLayerDraftWorker._rotate_ids``:
-
-      seg[:-1] = seg[1:]      # left-shift, KEEP last column (= prev last token)
-      seg[sel_pos] = new_token
-      padding reqs (ext_lens == 0) are left untouched
-
-    input_ids is the flat (bs * tokens_per_req,) buffer; every req occupies a
-    fixed ``tokens_per_req`` segment (real reqs have extend_seq_lens ==
-    tokens_per_req, padding reqs have 0). The last column is the captured-logit
-    position, so it must be copy-last (NOT jnp.roll, which wraps the first token
-    into the last column and diverges on partial accept).
-    """
+    """Mirror MultiLayerDraftWorker._rotate_ids on device for topk=1."""
     bs = ext_lens.shape[0]
     tokens_per_req = input_ids.shape[0] // bs
     ids_2d = input_ids.reshape(bs, tokens_per_req)
@@ -50,6 +192,18 @@ def _device_rotate_input_ids(input_ids, ext_lens, sel_pos, new_tokens):
     pad_mask = (ext_lens == 0)[:, None]
     shifted_2d = jnp.where(pad_mask, ids_2d, shifted_2d)
     return shifted_2d.reshape(-1)
+
+
+def _gather_rows_preserve_sharding(values, index):
+    sharding = jax.typeof(values).sharding
+    if isinstance(sharding, NamedSharding):
+        return values.at[index, :].get(out_sharding=sharding)
+    return values[index, :]
+
+
+def _topk1_index_from_logits(logits):
+    topk_idx = jnp.argmax(logits, axis=-1).astype(jnp.int32)[:, None]
+    return topk_idx
 
 
 def _build_fused_draft_extend_jit(num_layers: int, topk: int):
@@ -64,16 +218,15 @@ def _build_fused_draft_extend_jit(num_layers: int, topk: int):
     def fused_draft_extend(
         model_def,
         model_state_def,
-        all_leaves,  # tuple of N tuples-of-arrays
-        forward_batch,  # single ForwardBatch (shared across layers)
-        all_memory_pools,  # tuple of N MemoryPools pytrees
-        logits_metadata,  # LogitsMetadata pytree
-        target_hidden,  # (tokens, hidden_dim) replicated
-        sel_pos,  # (bs,) device array — rotate position
+        all_leaves,
+        forward_batch,
+        all_memory_pools,
+        logits_metadata,
+        target_hidden,
+        sel_pos,
         *,
         num_layers,
     ):
-        all_topk_p = []
         all_topk_index = []
         all_pool_updates = []
         layer0_hidden = None
@@ -84,63 +237,347 @@ def _build_fused_draft_extend_jit(num_layers: int, topk: int):
             state = jax.tree_util.tree_unflatten(model_state_def, all_leaves[i])
             model = nnx.merge(model_def, state)
 
-            # shared forward_batch: only hidden_states and input_ids change per layer;
-            # model() must not mutate other fields (positions, attn metadata, etc.)
             forward_batch.spec_info.hidden_states = target_hidden
             forward_batch.input_ids = input_ids
 
             output, pool_updates, _, _ = model(forward_batch, all_memory_pools[i], logits_metadata)
             all_pool_updates.append(pool_updates)
 
-            # Replicate logits + hidden to P() (all-gather)
             sh = jax.typeof(output.next_token_logits).sharding
             mesh = sh.mesh if isinstance(sh, NamedSharding) else None
-            if mesh is not None:
-                rep_logits = jax.sharding.reshard(
-                    output.next_token_logits, NamedSharding(mesh, P())
-                )
-                rep_hidden = jax.sharding.reshard(output.hidden_states, NamedSharding(mesh, P()))
-            else:
-                rep_logits = output.next_token_logits
-                rep_hidden = output.hidden_states
 
             if i == 0:
-                layer0_hidden = rep_hidden
+                layer0_hidden = output.hidden_states
 
-            # topk (inline, not separate jit)
-            topk_logits, topk_idx = jax.lax.top_k(rep_logits, topk)
-            logsumexp = jax.nn.logsumexp(rep_logits, axis=-1, keepdims=True)
-            topk_p = jnp.exp(topk_logits - logsumexp).astype(rep_logits.dtype)
-
-            all_topk_p.append(topk_p)
+            topk_idx = _topk1_index_from_logits(output.next_token_logits)
             all_topk_index.append(topk_idx)
 
-            # Device-side rotate for topk=1 (shared with offline equivalence
-            # test; exact mirror of host _rotate_ids).
             if i < num_layers - 1:
                 ext_lens = forward_batch.extend_seq_lens
                 input_ids = _device_rotate_input_ids(input_ids, ext_lens, sel_pos, topk_idx[:, 0])
 
+        select_index = jnp.arange(sel_pos.shape[0], dtype=jnp.int32) * (num_layers + 1) + sel_pos
+        selected_layer0_hidden = _gather_rows_preserve_sharding(layer0_hidden, select_index)
         # Force P() replicated sharding on outputs that must be cross-process
         # consistent. Without this, donate_argnames may let XLA alias output
         # buffers with donated P("data")-sharded pool buffers, silently making
         # np.asarray() return per-process-different values.
-        stacked_p = jnp.stack(all_topk_p, axis=1)
         stacked_idx = jnp.stack(all_topk_index, axis=1)
         if mesh is not None:
             rep = NamedSharding(mesh, P())
-            layer0_hidden = jax.lax.with_sharding_constraint(layer0_hidden, rep)
-            stacked_p = jax.lax.with_sharding_constraint(stacked_p, rep)
-            stacked_idx = jax.lax.with_sharding_constraint(stacked_idx, rep)
+            selected_layer0_hidden = jax.sharding.reshard(selected_layer0_hidden, rep)
+            stacked_idx = jax.sharding.reshard(stacked_idx, rep)
 
         return (
-            layer0_hidden,
-            stacked_p,
+            selected_layer0_hidden,
             stacked_idx,
             tuple(all_pool_updates),
         )
 
     return fused_draft_extend
+
+
+def _build_fused_greedy_decode_jit(num_layers: int, topk: int):
+    """Build fused JIT: target verify forward + greedy sample + MTP extend."""
+    assert topk == 1, "Fused greedy decode only supports topk=1"
+
+    @partial(
+        jax.jit,
+        donate_argnames=["target_memory_pools", "all_memory_pools"],
+        static_argnames=[
+            "target_model_state_def",
+            "draft_model_state_def",
+            "num_layers",
+            "speculative_num_steps",
+            "speculative_num_draft_tokens",
+            "return_target_logits",
+            "return_target_hidden",
+        ],
+    )
+    def fused_greedy_decode(
+        target_model_def,
+        target_model_state_def,
+        target_leaves,
+        target_forward_batch,
+        target_memory_pools,
+        target_logits_metadata,
+        draft_model_def,
+        draft_model_state_def,
+        draft_all_leaves,
+        draft_forward_batch,
+        all_memory_pools,
+        draft_logits_metadata,
+        previous_verified_id,
+        previous_token_list,
+        *,
+        num_layers,
+        speculative_num_steps,
+        speculative_num_draft_tokens,
+        return_target_logits,
+        return_target_hidden,
+    ):
+        target_bs = target_forward_batch.seq_lens.shape[0]
+        (
+            draft_tokens,
+            positions,
+            retrive_index_flat,
+            retrive_next_token_flat,
+            retrive_next_sibling_flat,
+        ) = _build_topk1_chain_verify_inputs_device_tuple(
+            verified_id=previous_verified_id,
+            token_list=previous_token_list,
+            seq_lens=target_forward_batch.seq_lens,
+            num_verify_tokens=speculative_num_draft_tokens,
+            batch_size=target_bs,
+        )
+        retrive_index = retrive_index_flat.reshape(target_bs, speculative_num_draft_tokens)
+        retrive_next_token = retrive_next_token_flat.reshape(
+            target_bs, speculative_num_draft_tokens
+        )
+        retrive_next_sibling = retrive_next_sibling_flat.reshape(
+            target_bs, speculative_num_draft_tokens
+        )
+
+        target_forward_batch.input_ids = draft_tokens
+        target_forward_batch.positions = positions
+        target_forward_batch.spec_info.draft_token = draft_tokens
+        target_forward_batch.spec_info.positions = positions
+        target_forward_batch.spec_info.retrive_index = retrive_index
+        target_forward_batch.spec_info.retrive_next_token = retrive_next_token
+        target_forward_batch.spec_info.retrive_next_sibling = retrive_next_sibling
+
+        target_state = jax.tree_util.tree_unflatten(target_model_state_def, target_leaves)
+        target_model = nnx.merge(target_model_def, target_state)
+        target_output, target_pool_updates, _, _ = target_model(
+            target_forward_batch,
+            target_memory_pools,
+            target_logits_metadata,
+        )
+
+        sh = jax.typeof(target_output.next_token_logits).sharding
+        mesh = sh.mesh if isinstance(sh, NamedSharding) else None
+        target_logits = target_output.next_token_logits
+        target_hidden = target_output.hidden_states
+        target_predict = jnp.argmax(target_logits, axis=-1).astype(jnp.int32).reshape(-1)
+
+        prepared = _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
+            target_hidden=target_hidden,
+            positions=target_forward_batch.positions,
+            seq_lens=target_forward_batch.seq_lens,
+            draft_tokens=draft_tokens,
+            target_predict=target_predict,
+            speculative_num_steps=speculative_num_steps,
+            speculative_num_draft_tokens=speculative_num_draft_tokens,
+        )
+
+        all_topk_index = []
+        all_pool_updates = []
+        layer0_hidden = None
+        input_ids = prepared.verified_id
+
+        draft_forward_batch.positions = prepared.positions
+        draft_forward_batch.spec_info.hidden_states = prepared.hidden_states
+        draft_forward_batch.spec_info.accept_length = prepared.accept_lens
+        draft_logits_metadata.accept_lens = prepared.accept_lens
+
+        for i in range(num_layers):
+            state = jax.tree_util.tree_unflatten(draft_model_state_def, draft_all_leaves[i])
+            model = nnx.merge(draft_model_def, state)
+
+            draft_forward_batch.spec_info.hidden_states = prepared.hidden_states
+            draft_forward_batch.input_ids = input_ids
+
+            output, pool_updates, _, _ = model(
+                draft_forward_batch, all_memory_pools[i], draft_logits_metadata
+            )
+            all_pool_updates.append(pool_updates)
+
+            sh = jax.typeof(output.next_token_logits).sharding
+            mesh = sh.mesh if isinstance(sh, NamedSharding) else mesh
+            topk_idx = _topk1_index_from_logits(output.next_token_logits)
+            rep_hidden = output.hidden_states
+
+            if i == 0:
+                layer0_hidden = rep_hidden
+
+            all_topk_index.append(topk_idx)
+
+            if i < num_layers - 1:
+                input_ids = _device_rotate_input_ids(
+                    input_ids,
+                    draft_forward_batch.extend_seq_lens,
+                    prepared.sel_pos,
+                    topk_idx[:, 0],
+                )
+
+        stacked_idx = jnp.stack(all_topk_index, axis=1)
+        selected_layer0_hidden = _gather_rows_preserve_sharding(
+            layer0_hidden, prepared.select_index
+        )
+        target_logits_for_host = target_logits if return_target_logits else None
+        target_hidden_for_host = target_hidden if return_target_hidden else None
+        if mesh is not None:
+            rep = NamedSharding(mesh, P())
+            selected_layer0_hidden = jax.sharding.reshard(selected_layer0_hidden, rep)
+            stacked_idx = jax.sharding.reshard(stacked_idx, rep)
+            prepared_accept_lens = jax.sharding.reshard(prepared.accept_lens, rep)
+            prepared_predict = jax.sharding.reshard(prepared.predict, rep)
+            if return_target_logits:
+                target_logits_for_host = jax.sharding.reshard(target_logits, rep)
+            if return_target_hidden:
+                target_hidden_for_host = jax.sharding.reshard(target_hidden, rep)
+        else:
+            prepared_accept_lens = prepared.accept_lens
+            prepared_predict = prepared.predict
+
+        return (
+            selected_layer0_hidden,
+            stacked_idx,
+            target_pool_updates,
+            tuple(all_pool_updates),
+            prepared_accept_lens,
+            prepared_predict,
+            target_logits_for_host,
+            target_hidden_for_host,
+        )
+
+    return fused_greedy_decode
+
+
+def _prepare_topk1_verify_placeholders_from_draft_state(draft_worker, model_worker_batch):
+    """Prepare fixed-shape verify placeholders while keeping chain build inside JIT."""
+    from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode
+    from sgl_jax.srt.speculative.eagle_util import EagleVerifyInput
+
+    draft_worker.padding_for_decode(model_worker_batch)
+    draft_input = model_worker_batch.spec_info_padded
+    previous_verified_id = draft_input.verified_id
+    if isinstance(previous_verified_id, np.ndarray):
+        previous_verified_id = np.asarray(previous_verified_id, dtype=np.int32)
+    previous_token_list = draft_input.topk_index[:, :, 0]
+    if isinstance(previous_token_list, np.ndarray):
+        previous_token_list = np.asarray(previous_token_list, dtype=np.int32)
+    else:
+        previous_token_list = previous_token_list.astype(jnp.int32)
+
+    bs = model_worker_batch.seq_lens.shape[0]
+    n = draft_worker.speculative_num_draft_tokens
+    flat = bs * n
+    model_worker_batch.spec_info_padded = EagleVerifyInput(
+        draft_token=np.zeros((flat,), dtype=np.int32),
+        custom_mask=None,
+        positions=np.zeros((flat,), dtype=np.int32),
+        retrive_index=np.zeros((bs, n), dtype=np.int32),
+        retrive_next_token=np.zeros((bs, n), dtype=np.int32),
+        retrive_next_sibling=np.zeros((bs, n), dtype=np.int32),
+        retrive_cum_len=None,
+        spec_steps=draft_worker.speculative_num_steps,
+        topk=draft_worker.topk,
+        draft_token_num=draft_worker.speculative_num_draft_tokens,
+        capture_hidden_mode=CaptureHiddenMode.LAST,
+        seq_lens_sum=model_worker_batch.seq_lens_sum,
+        seq_lens_cpu=model_worker_batch.seq_lens,
+    )
+    return previous_verified_id, previous_token_list
+
+
+def _device_array_preserve_device(value, sharding):
+    from sgl_jax.srt.utils.jax_utils import device_array
+
+    if value is None:
+        return None
+    if isinstance(value, jax.Array):
+        return jax.device_put(value, sharding)
+    return device_array(value, sharding=sharding)
+
+
+def _logits_metadata_from_model_worker_batch_preserve_device(
+    batch, mesh, *, include_accept_lens: bool = True
+):
+    from sgl_jax.srt.layers.logits_processor import LogitsMetadata
+
+    sharding = NamedSharding(mesh, P("data"))
+    spec_info = batch.spec_info_padded
+    accept_lens = (
+        getattr(spec_info, "accept_length", None)
+        if include_accept_lens and batch.forward_mode.is_draft_extend() and spec_info is not None
+        else None
+    )
+    return LogitsMetadata(
+        forward_mode=batch.forward_mode,
+        capture_hidden_mode=batch.capture_hidden_mode,
+        extend_return_logprob=False,
+        extend_return_top_logprob=False,
+        extend_token_ids_logprob=False,
+        extend_seq_lens=_device_array_preserve_device(batch.extend_seq_lens, sharding),
+        logits_indices=_device_array_preserve_device(batch.logits_indices, sharding),
+        accept_lens=_device_array_preserve_device(accept_lens, sharding),
+        extend_seq_lens_cpu=None,
+        extend_logprob_start_lens_cpu=None,
+        extend_logprob_pruned_lens_cpu=None,
+        top_logprobs_nums=getattr(batch, "top_logprobs_nums", None),
+        token_ids_logprobs=getattr(batch, "token_ids_logprobs", None),
+        extend_input_logprob_token_ids_device=_device_array_preserve_device(
+            getattr(batch, "extend_input_logprob_token_ids", None), sharding
+        ),
+    )
+
+
+def _forward_batch_init_new_preserve_device(batch, model_runner):
+    from sgl_jax.srt.eplb.expert_location import get_global_expert_location_metadata
+    from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+
+    data_sharding = NamedSharding(model_runner.mesh, P("data"))
+    replicated_2d = NamedSharding(model_runner.mesh, P(None, None))
+
+    input_embedding = _device_array_preserve_device(batch.input_embedding, replicated_2d)
+    if input_embedding is not None:
+        input_embedding = input_embedding.astype(jnp.bfloat16)
+
+    deepstack_visual_embedding = None
+    if getattr(batch, "apply_for_deepstack", False):
+        deepstack_visual_embedding = _device_array_preserve_device(
+            batch.deepstack_visual_embedding, replicated_2d
+        )
+        if deepstack_visual_embedding is not None:
+            deepstack_visual_embedding = deepstack_visual_embedding.astype(jnp.bfloat16)
+
+    if batch.lora_scalings is not None:
+        lora_scalings = _device_array_preserve_device(batch.lora_scalings, data_sharding)
+        lora_token_indices = _device_array_preserve_device(batch.lora_token_indices, data_sharding)
+        lora_ranks = _device_array_preserve_device(batch.lora_ranks, data_sharding)
+    else:
+        lora_scalings = batch.lora_scalings
+        lora_token_indices = batch.lora_token_indices
+        lora_ranks = batch.lora_ranks
+
+    return ForwardBatch(
+        bid=batch.bid,
+        forward_mode=batch.forward_mode,
+        batch_size=len(batch.seq_lens),
+        input_ids=_device_array_preserve_device(batch.input_ids, data_sharding),
+        seq_lens=_device_array_preserve_device(batch.seq_lens, data_sharding),
+        out_cache_loc=_device_array_preserve_device(batch.out_cache_loc, data_sharding),
+        positions=_device_array_preserve_device(batch.positions, data_sharding),
+        mrope_positions=_device_array_preserve_device(batch.mrope_positions, replicated_2d),
+        req_pool_indices=_device_array_preserve_device(batch.req_pool_indices, data_sharding),
+        cache_loc=_device_array_preserve_device(batch.cache_loc, data_sharding),
+        extend_prefix_lens=_device_array_preserve_device(batch.extend_prefix_lens, data_sharding),
+        extend_seq_lens=_device_array_preserve_device(batch.extend_seq_lens, data_sharding),
+        lora_ids=batch.lora_ids,
+        lora_scalings=lora_scalings,
+        lora_token_indices=lora_token_indices,
+        lora_ranks=lora_ranks,
+        attn_backend=model_runner.attn_backend,
+        spec_info=batch.spec_info_padded,
+        spec_algorithm=batch.spec_algorithm,
+        capture_hidden_mode=batch.capture_hidden_mode,
+        input_embedding=input_embedding,
+        apply_for_deepstack=batch.apply_for_deepstack,
+        deepstack_visual_embedding=deepstack_visual_embedding,
+        expert_location_metadata=get_global_expert_location_metadata(),
+        recurrent_indices=_device_array_preserve_device(batch.recurrent_indices, data_sharding),
+    )
 
 
 def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output):
@@ -172,10 +609,6 @@ def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output
     assert (accept_host[sel] >= 1).all(), f"accept_length < 1: {accept_host[sel]}"
     sel_pos = np.clip(accept_host - 1, 0, None).astype(np.int32)
 
-    # --- Host preparation (all done before single jit call) ---
-
-    # Build ONE ForwardBatch and reuse for all layers. All workers share the
-    # same mwb so forward_metadata is identical; only memory_pools/weights differ.
     mr0 = draft_worker._workers[0].model_runner
     mwb.spec_info_padded.hidden_states = target_hidden
     mr0.attn_backend.forward_metadata = mr0.attn_backend.get_eagle_forward_metadata(mwb)
@@ -191,53 +624,260 @@ def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output
 
     sel_pos_device = jax.device_put(sel_pos, NamedSharding(draft_worker.mesh, P("data")))
 
-    # --- Build / get cached fused jit ---
     if not hasattr(draft_worker, "_fused_jit_fn"):
         draft_worker._fused_jit_fn = _build_fused_draft_extend_jit(
             num_layers=draft_worker.speculative_num_steps,
             topk=draft_worker.topk,
         )
 
-    # --- Single jit call: all N layers fused ---
-    # Model internals use P() with implicit mesh; need use_mesh context
-    try:
-        ctx = jax.sharding.use_mesh(draft_worker.mesh)
-    except AttributeError:
-        try:
-            ctx = jax.set_mesh(draft_worker.mesh)
-        except AttributeError:
-            ctx = draft_worker.mesh
-    with ctx:
-        layer0_hidden, topk_p_stacked, topk_index_stacked, all_pool_updates = (
-            draft_worker._fused_jit_fn(
-                mr0._model_def,
-                mr0._model_state_def,
-                tuple(all_leaves),
-                shared_fb,
-                tuple(all_memory_pools),
-                logits_metadata,
-                target_hidden,
-                sel_pos_device,
-                num_layers=draft_worker.speculative_num_steps,
-            )
+    with jax.set_mesh(draft_worker.mesh):
+        selected_layer0_hidden, topk_index_stacked, all_pool_updates = draft_worker._fused_jit_fn(
+            mr0._model_def,
+            mr0._model_state_def,
+            tuple(all_leaves),
+            shared_fb,
+            tuple(all_memory_pools),
+            logits_metadata,
+            target_hidden,
+            sel_pos_device,
+            num_layers=draft_worker.speculative_num_steps,
         )
 
-    # --- Host post-processing: replace memory pools + assemble outputs ---
     for i, w in enumerate(draft_worker._workers):
         w.model_runner.memory_pools.replace_all(all_pool_updates[i])
 
-    select_index = sel * (draft_worker.speculative_num_steps + 1) + accept_host[sel] - 1
     verified_id_arr = batch_output.next_draft_input.verified_id
     if hasattr(verified_id_arr, "copy_to_host_async"):
         jax.copy_to_host_async(verified_id_arr)
 
-    jax.copy_to_host_async(layer0_hidden)
-    jax.copy_to_host_async(topk_p_stacked)
+    jax.copy_to_host_async(selected_layer0_hidden)
     jax.copy_to_host_async(topk_index_stacked)
 
-    batch_output.next_draft_input.hidden_states = np.asarray(layer0_hidden)[select_index]
-    batch_output.next_draft_input.topk_p = np.asarray(topk_p_stacked)[sel]
-    batch_output.next_draft_input.topk_index = np.asarray(topk_index_stacked)[sel]
+    batch_output.next_draft_input.hidden_states = np.asarray(selected_layer0_hidden)[sel]
+    topk_index = np.asarray(topk_index_stacked)[sel]
+    batch_output.next_draft_input.topk_p = np.ones(topk_index.shape, dtype=np.float32)
+    batch_output.next_draft_input.topk_index = topk_index
+    select_index = sel * (draft_worker.speculative_num_steps + 1) + accept_host[sel] - 1
     batch_output.next_draft_input.verified_id = np.asarray(verified_id_arr)[select_index]
     batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
     batch_output.accept_lens = accept_host
+
+
+def _prepare_model_worker_batch_for_draft_extend(draft_worker, model_worker_batch, batch_output):
+    from sgl_jax.srt.model_executor.forward_batch_info import (
+        CaptureHiddenMode,
+        ForwardMode,
+    )
+
+    model_worker_batch.spec_info_padded = batch_output.next_draft_input
+    sel = model_worker_batch.logits_indices_selector
+    model_worker_batch.seq_lens[sel] = (
+        model_worker_batch.seq_lens[sel] + draft_worker.speculative_num_draft_tokens - 1
+    )
+
+    bs = batch_output.accept_lens.shape[0]
+    step_plus_1 = batch_output.next_draft_input.verified_id.shape[0] // bs
+    model_worker_batch.extend_seq_lens = np.zeros((bs,), dtype=np.int32)
+    model_worker_batch.extend_seq_lens[sel] = step_plus_1
+
+    dp = model_worker_batch.dp_size
+    per_dp = model_worker_batch.per_dp_bs_size if dp > 1 else bs
+    model_worker_batch.logits_indices = (
+        model_worker_batch.extend_seq_lens.reshape(dp, per_dp)
+        .cumsum(axis=1, dtype=np.int32)
+        .ravel()
+        - 1
+    )
+    model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
+    model_worker_batch.spec_info_padded.capture_hidden_mode = CaptureHiddenMode.FULL
+    model_worker_batch.forward_mode = ForwardMode.DRAFT_EXTEND
+    model_worker_batch.spec_info_padded.hidden_states = batch_output.logits_output.hidden_states
+    model_worker_batch.spec_info_padded.accept_length = None
+    model_worker_batch.input_ids = batch_output.next_draft_input.verified_id
+
+    forward_metadata = draft_worker.draft_model_runner.attn_backend.get_eagle_forward_metadata(
+        model_worker_batch
+    )
+    draft_worker.draft_model_runner.attn_backend.forward_metadata = forward_metadata
+    logits_metadata = _logits_metadata_from_model_worker_batch_preserve_device(
+        model_worker_batch, draft_worker.mesh, include_accept_lens=False
+    )
+    return model_worker_batch, logits_metadata
+
+
+def _materialize_fused_greedy_batch_output_for_scheduler(
+    *,
+    batch_output,
+    selector,
+    real_bs,
+    seq_lens_host,
+    layer0_hidden,
+    topk_index_stacked,
+    accept_lens_device,
+    predict_device,
+    speculative_num_draft_tokens,
+    target_logits,
+    target_hidden,
+):
+    """Materialize the scheduler-facing fields after the single fused decode JIT."""
+    from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
+
+    with jax.profiler.TraceAnnotation("fused_greedy_batch_output_d2h"):
+        jax.copy_to_host_async(layer0_hidden)
+        jax.copy_to_host_async(topk_index_stacked)
+        jax.copy_to_host_async(accept_lens_device)
+        jax.copy_to_host_async(predict_device)
+
+        batch_output.logits_output = LogitsProcessorOutput(
+            next_token_logits=target_logits,
+            hidden_states=target_hidden,
+        )
+        batch_output.next_draft_input.hidden_states = np.asarray(layer0_hidden)[selector]
+        topk_index = np.asarray(topk_index_stacked)[selector]
+        batch_output.next_draft_input.topk_p = np.ones(topk_index.shape, dtype=np.float32)
+        batch_output.next_draft_input.topk_index = topk_index
+        accept_lens = np.asarray(accept_lens_device)
+        predict = np.asarray(predict_device)
+        seq_lens_host = np.asarray(seq_lens_host)
+        verified_pos = selector * speculative_num_draft_tokens + accept_lens[selector] - 1
+        batch_output.next_draft_input.verified_id = predict[verified_pos]
+        original_seq_lens = seq_lens_host[selector] - speculative_num_draft_tokens + 1
+        batch_output.next_draft_input.new_seq_lens = original_seq_lens + accept_lens[selector]
+        batch_output.allocate_lens = batch_output.allocate_lens[:real_bs]
+        batch_output.accept_lens = accept_lens
+        batch_output.next_token_ids = predict
+        return batch_output
+
+
+def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
+    """Run one fused speculative decode round."""
+    from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
+    from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+    from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
+
+    draft_worker = spec_worker.draft_worker
+    target_worker = spec_worker.target_worker
+    target_mr = target_worker.model_runner
+    previous_verified_id, previous_token_list = _prepare_topk1_verify_placeholders_from_draft_state(
+        draft_worker, model_worker_batch
+    )
+    spec_info = model_worker_batch.spec_info_padded
+    return_target_logits = bool(
+        getattr(model_worker_batch, "return_logprob", False)
+        or getattr(model_worker_batch, "return_output_logprob_only", False)
+    )
+    return_target_hidden = bool(getattr(model_worker_batch, "return_hidden_states", False))
+
+    spec_info.allocate_lens = cur_allocate_lens
+    spec_info.prepare_for_verify(model_worker_batch, spec_worker.page_size, target_worker)
+    target_mr.attn_backend.forward_metadata = target_mr.attn_backend.get_eagle_forward_metadata(
+        model_worker_batch
+    )
+    target_forward_batch = _forward_batch_init_new_preserve_device(model_worker_batch, target_mr)
+    target_forward_batch.bid = model_worker_batch.bid
+    target_logits_metadata = _logits_metadata_from_model_worker_batch_preserve_device(
+        model_worker_batch, spec_worker.mesh
+    )
+
+    hidden_size = target_worker.model_config.hidden_size
+    placeholder_hidden = np.zeros((spec_info.draft_token.shape[0], hidden_size), dtype=np.float32)
+    placeholder_logits = np.zeros((spec_info.draft_token.shape[0], 1), dtype=np.float32)
+
+    next_draft_input = EagleDraftInput(
+        verified_id=spec_info.draft_token,
+        new_seq_lens=model_worker_batch.seq_lens,
+        allocate_lens=cur_allocate_lens,
+        hidden_states=placeholder_hidden,
+    )
+    next_draft_input.draft_token = spec_info.draft_token
+    next_draft_input.retrive_index = spec_info.retrive_index
+    next_draft_input.retrive_next_token = spec_info.retrive_next_token
+    next_draft_input.retrive_next_sibling = spec_info.retrive_next_sibling
+    batch_output = GenerationBatchResult(
+        logits_output=LogitsProcessorOutput(
+            next_token_logits=placeholder_logits,
+            hidden_states=placeholder_hidden,
+        ),
+        next_token_ids=spec_info.draft_token,
+        next_draft_input=next_draft_input,
+        accept_lens=np.ones(model_worker_batch.seq_lens.shape, dtype=np.int32),
+        allocate_lens=cur_allocate_lens,
+        bid=model_worker_batch.bid,
+        cache_miss_count=0,
+        extend_input_len_per_req=None,
+        extend_logprob_start_len_per_req=None,
+    )
+    model_worker_batch.spec_info_padded = next_draft_input
+
+    draft_mwb, draft_logits_metadata = _prepare_model_worker_batch_for_draft_extend(
+        draft_worker, model_worker_batch, batch_output
+    )
+    if draft_mwb.input_ids.shape[0] <= 0:
+        return batch_output
+
+    draft_mr0 = draft_worker._workers[0].model_runner
+    draft_forward_batch = _forward_batch_init_new_preserve_device(draft_mwb, draft_mr0)
+    draft_forward_batch.bid = model_worker_batch.bid
+
+    all_memory_pools = []
+    all_leaves = []
+    for w in draft_worker._workers:
+        mr = w.model_runner
+        all_memory_pools.append(mr.memory_pools)
+        all_leaves.append(tuple(mr.model_state_leaves))
+
+    if not hasattr(draft_worker, "_fused_greedy_decode_jit_fn"):
+        draft_worker._fused_greedy_decode_jit_fn = _build_fused_greedy_decode_jit(
+            num_layers=draft_worker.speculative_num_steps,
+            topk=draft_worker.topk,
+        )
+
+    with jax.set_mesh(draft_worker.mesh):
+        (
+            layer0_hidden,
+            topk_index_stacked,
+            target_pool_updates,
+            all_pool_updates,
+            accept_lens_device,
+            predict_device,
+            target_logits,
+            target_hidden,
+        ) = draft_worker._fused_greedy_decode_jit_fn(
+            target_mr._model_def,
+            target_mr._model_state_def,
+            tuple(target_mr.model_state_leaves),
+            target_forward_batch,
+            target_mr.memory_pools,
+            target_logits_metadata,
+            draft_mr0._model_def,
+            draft_mr0._model_state_def,
+            tuple(all_leaves),
+            draft_forward_batch,
+            tuple(all_memory_pools),
+            draft_logits_metadata,
+            previous_verified_id,
+            previous_token_list,
+            num_layers=draft_worker.speculative_num_steps,
+            speculative_num_steps=draft_worker.speculative_num_steps,
+            speculative_num_draft_tokens=draft_worker.speculative_num_draft_tokens,
+            return_target_logits=return_target_logits,
+            return_target_hidden=return_target_hidden,
+        )
+
+    target_mr.memory_pools.replace_all(target_pool_updates)
+    for i, w in enumerate(draft_worker._workers):
+        w.model_runner.memory_pools.replace_all(all_pool_updates[i])
+
+    return _materialize_fused_greedy_batch_output_for_scheduler(
+        batch_output=batch_output,
+        selector=np.asarray(model_worker_batch.logits_indices_selector),
+        real_bs=model_worker_batch.real_bs,
+        seq_lens_host=model_worker_batch.seq_lens,
+        layer0_hidden=layer0_hidden,
+        topk_index_stacked=topk_index_stacked,
+        accept_lens_device=accept_lens_device,
+        predict_device=predict_device,
+        speculative_num_draft_tokens=draft_worker.speculative_num_draft_tokens,
+        target_logits=target_logits,
+        target_hidden=target_hidden,
+    )

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -14,6 +14,7 @@ from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.kernels.speculative.kernel import top_k_renorm_prob, top_p_renorm_prob
+from sgl_jax.srt.sampling.sampling_params import TOP_K_ALL
 from sgl_jax.srt.speculative.relay_buffer import (
     gather_spec_relay_buffers,
     make_dp_valid_mask,
@@ -62,6 +63,50 @@ def _count_pjit_cpp_cache_miss():
         return
     with jtu.count_pjit_cpp_cache_miss() as count:
         yield count
+
+
+def _active_dp_slot_mask(batch, total_bs: int) -> np.ndarray:
+    mask = np.zeros(total_bs, dtype=bool)
+    per_dp_bs = int(getattr(batch, "per_dp_bs_size", total_bs))
+    real_bs_per_dp = getattr(batch, "real_bs_per_dp", None)
+    if real_bs_per_dp is None:
+        mask[: int(getattr(batch, "real_bs", total_bs))] = True
+        return mask
+    for dp_rank, real_bs in enumerate(real_bs_per_dp):
+        start = dp_rank * per_dp_bs
+        mask[start : start + int(real_bs)] = True
+    return mask
+
+
+def _prepare_rejection_sampling(sampling_info, batch, total_bs: int, vocab_size: int):
+    temperatures = np.asarray(sampling_info.temperatures, dtype=np.float32).reshape(total_bs, 1)
+    top_ks_src = getattr(sampling_info, "top_ks", None)
+    top_ps_src = getattr(sampling_info, "top_ps", None)
+    top_ks = (
+        np.asarray(top_ks_src, dtype=np.int32).reshape(total_bs)
+        if top_ks_src is not None
+        else np.full(total_bs, TOP_K_ALL, dtype=np.int32)
+    )
+    top_ps = (
+        np.asarray(top_ps_src, dtype=np.float32).reshape(total_bs)
+        if top_ps_src is not None
+        else np.ones(total_bs, dtype=np.float32)
+    )
+
+    active = _active_dp_slot_mask(batch, total_bs)
+    temperatures = temperatures.copy()
+    top_ks = top_ks.copy()
+    top_ps = top_ps.copy()
+    temperatures[~active] = 1.0
+    top_ks[~active] = TOP_K_ALL
+    top_ks[top_ks <= 0] = TOP_K_ALL
+    top_ps[~active] = 1.0
+
+    active_top_ks = top_ks[active]
+    active_top_ps = top_ps[active]
+    enable_top_k = bool(np.any((active_top_ks > 0) & (active_top_ks < vocab_size)))
+    enable_top_p = bool(np.any(active_top_ps < 1.0))
+    return temperatures, top_ks, top_ps, enable_top_k, enable_top_p
 
 
 def _prepare_spec_prefill_output_token_ids(draft_worker, next_token_ids):
@@ -223,7 +268,7 @@ def _verify_rejection_sampling(
     vocab = target_logits.shape[-1]
 
     # v1: replicate the working set so explicit-sharding never has to resolve
-    # gather/cumsum shardings. Correctness over speed for now. top_k/top_p TODO.
+    # gather/cumsum shardings. Correctness over speed for now.
     sh = jax.typeof(target_logits).sharding
     mesh = sh.mesh if isinstance(sh, NamedSharding) else None
 
@@ -1772,44 +1817,24 @@ def spec_decode_verify(spec_worker, model_worker_batch, cur_allocate_lens):
     _sv_enable_top_p = False
     if _sv_is_greedy:
         _sv_temps = _prepare_device_array(np.ones((_sv_tbs, 1), np.float32), data_sharding)
-        _sv_topks = _prepare_device_array(np.zeros((_sv_tbs,), np.int32), data_sharding)
+        _sv_topks = _prepare_device_array(np.full((_sv_tbs,), TOP_K_ALL, np.int32), data_sharding)
         _sv_topps = _prepare_device_array(np.ones((_sv_tbs,), np.float32), data_sharding)
     else:
-        _t = np.asarray(si.temperatures, np.float32).reshape(-1)
-        _k = (
-            np.asarray(getattr(si, "top_ks", None)).reshape(-1)
-            if getattr(si, "top_ks", None) is not None
-            else None
+        (
+            _sv_temps_host,
+            _sv_topks_host,
+            _sv_topps_host,
+            _sv_enable_top_k,
+            _sv_enable_top_p,
+        ) = _prepare_rejection_sampling(
+            si,
+            model_worker_batch,
+            _sv_tbs,
+            int(target_worker.model_config.vocab_size),
         )
-        _p = (
-            np.asarray(getattr(si, "top_ps", None), np.float32).reshape(-1)
-            if getattr(si, "top_ps", None) is not None
-            else None
-        )
-        _tv = float(_t[0]) if _t.size else 1.0
-        _kv = int(_k[0]) if (_k is not None and _k.size) else 0
-        _pv = float(_p[0]) if (_p is not None and _p.size) else 1.0
-        _sv_vocab = int(target_worker.model_config.vocab_size)
-        _sv_enable_top_k = 0 < _kv < _sv_vocab
-        _sv_enable_top_p = _pv < 1.0
-        # temps/topks/topps are constant across decode steps for a given batch
-        # (they only depend on tbs and the per-batch sampling scalars), so building
-        # + transferring them every step is wasted H2D dispatch. Cache the device
-        # arrays keyed by (tbs, temp, top_k, top_p) and reuse until the batch changes.
-        _const_sig = (_sv_tbs, _tv, _kv, _pv)
-        _const_cache = getattr(target_mr, "_sv_sampling_const_cache", None)
-        if _const_cache is None or _const_cache[0] != _const_sig:
-            _sv_temps = _prepare_device_array(np.full((_sv_tbs, 1), _tv, np.float32), data_sharding)
-            _sv_topks = _prepare_device_array(np.full((_sv_tbs,), _kv, np.int32), data_sharding)
-            _sv_topps = _prepare_device_array(np.full((_sv_tbs,), _pv, np.float32), data_sharding)
-            target_mr._sv_sampling_const_cache = (
-                _const_sig,
-                _sv_temps,
-                _sv_topks,
-                _sv_topps,
-            )
-        else:
-            _, _sv_temps, _sv_topks, _sv_topps = _const_cache
+        _sv_temps = _prepare_device_array(_sv_temps_host, data_sharding)
+        _sv_topks = _prepare_device_array(_sv_topks_host, data_sharding)
+        _sv_topps = _prepare_device_array(_sv_topps_host, data_sharding)
     _sv_thr_single = float(
         getattr(spec_worker.server_args, "speculative_accept_threshold_single", 1.0)
     )

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -6,11 +6,18 @@ from functools import partial
 from typing import NamedTuple
 
 import jax
+import jax._src.test_util as jtu
 import jax.numpy as jnp
 import numpy as np
 from flax import nnx
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.speculative.relay_buffer import (
+    gather_spec_relay_buffers,
+    make_dp_valid_mask,
+    update_spec_relay_buffers,
+)
 
 
 class GreedyDraftInputs(NamedTuple):
@@ -28,10 +35,33 @@ class GreedySampleAndPrepareOutput(NamedTuple):
     positions: jax.Array
     new_seq_lens: jax.Array
     select_index: jax.Array
+    safe_index: jax.Array
     verified_id: jax.Array
     accept_lens: jax.Array
     sel_pos: jax.Array
     predict: jax.Array
+
+
+class FusedDraftExtendPendingResult(NamedTuple):
+    batch_output: object
+    selected_layer0_hidden: object
+    topk_index_stacked: object
+    next_verified_id: object
+    accept_lens: object
+    sel: np.ndarray
+    updated_relay_buffers: object | None
+
+
+def _prepare_spec_prefill_output_token_ids(draft_worker, next_token_ids):
+    if draft_worker.mesh is None:
+        return next_token_ids
+    if not hasattr(draft_worker, "_spec_prefill_output_gather_fn"):
+        replicated_sharding = NamedSharding(draft_worker.mesh, P())
+        draft_worker._spec_prefill_output_gather_fn = jax.jit(
+            lambda x: x,
+            out_shardings=replicated_sharding,
+        )
+    return draft_worker._spec_prefill_output_gather_fn(next_token_ids)
 
 
 def _take_with_index_sharding(values, index):
@@ -76,7 +106,7 @@ def _greedy_prepare_draft_inputs(
     return GreedyDraftInputs(
         hidden_states=gathered_hidden,
         positions=gathered_positions,
-        new_seq_lens=seq_lens + accept_length,
+        new_seq_lens=seq_lens + accept_length + 1,
         select_index=select_index,
         verified_id=verified_id,
         accept_lens=accept_length,
@@ -140,6 +170,7 @@ def _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
         positions=prepared.positions,
         new_seq_lens=prepared.new_seq_lens,
         select_index=prepared.select_index,
+        safe_index=safe_index,
         verified_id=prepared.verified_id,
         accept_lens=prepared.accept_lens,
         sel_pos=prepared.sel_pos,
@@ -194,6 +225,31 @@ def _device_rotate_input_ids(input_ids, ext_lens, sel_pos, new_tokens):
     return shifted_2d.reshape(-1)
 
 
+def _device_rotate_prefill_input_ids(input_ids, extend_seq_lens, verified_id, dp_size, per_dp_bs):
+    per_dp_tokens = input_ids.shape[0] // dp_size
+    ids = input_ids.reshape(dp_size, per_dp_tokens)
+    ext = extend_seq_lens.reshape(dp_size, per_dp_bs)
+    verified = verified_id.reshape(dp_size, per_dp_bs)
+    tok = jnp.arange(per_dp_tokens, dtype=jnp.int32)
+
+    def rotate_rank(ids_rank, ext_rank, verified_rank):
+        starts = jnp.cumsum(ext_rank, axis=0) - ext_rank
+        ends = starts + ext_rank
+        in_req = (tok[None, :] >= starts[:, None]) & (tok[None, :] < ends[:, None])
+        has_req = jnp.any(in_req, axis=0)
+        slot = jnp.argmax(in_req.astype(jnp.int32), axis=0)
+        req_starts = starts.at[slot].get()
+        req_lens = ext_rank.at[slot].get()
+        req_verified = verified_rank.at[slot].get()
+        shifted_index = jnp.minimum(tok + 1, per_dp_tokens - 1)
+        shifted = ids_rank.at[shifted_index].get()
+        is_last = has_req & ((tok - req_starts) == (req_lens - 1))
+        rotated = jnp.where(is_last, req_verified, shifted)
+        return jnp.where(has_req, rotated, ids_rank)
+
+    return jax.vmap(rotate_rank)(ids, ext, verified).reshape(input_ids.shape)
+
+
 def _gather_rows_preserve_sharding(values, index):
     sharding = jax.typeof(values).sharding
     if isinstance(sharding, NamedSharding):
@@ -213,7 +269,7 @@ def _build_fused_draft_extend_jit(num_layers: int, topk: int):
     @partial(
         jax.jit,
         donate_argnames=["all_memory_pools"],
-        static_argnames=["model_state_def", "num_layers"],
+        static_argnames=["model_state_def", "num_layers", "update_relay", "dp_size"],
     )
     def fused_draft_extend(
         model_def,
@@ -224,14 +280,40 @@ def _build_fused_draft_extend_jit(num_layers: int, topk: int):
         logits_metadata,
         target_hidden,
         sel_pos,
+        draft_logits_indices,
+        relay_buffers,
+        relay_future_indices,
+        relay_valid_mask,
+        relay_verified_id,
+        relay_new_seq_lens,
+        draft_verify_seq_lens,
+        draft_allocate_lens,
         *,
         num_layers,
+        update_relay,
+        dp_size,
     ):
         all_topk_index = []
         all_pool_updates = []
         layer0_hidden = None
         mesh = None
         input_ids = forward_batch.input_ids
+        if draft_verify_seq_lens is not None:
+            valid_draft_slots = draft_verify_seq_lens > 0
+            forward_batch.seq_lens = jnp.where(
+                valid_draft_slots,
+                draft_verify_seq_lens + num_layers,
+                jnp.zeros_like(draft_verify_seq_lens),
+            )
+            forward_batch.attn_backend.forward_metadata = (
+                _make_draft_extend_metadata_from_device_seq_lens(
+                    forward_batch.attn_backend.forward_metadata,
+                    forward_batch.seq_lens,
+                    draft_allocate_lens,
+                    page_size=forward_batch.attn_backend.page_size,
+                    dp_size=dp_size,
+                )
+            )
 
         for i in range(num_layers):
             state = jax.tree_util.tree_unflatten(model_state_def, all_leaves[i])
@@ -256,66 +338,288 @@ def _build_fused_draft_extend_jit(num_layers: int, topk: int):
                 ext_lens = forward_batch.extend_seq_lens
                 input_ids = _device_rotate_input_ids(input_ids, ext_lens, sel_pos, topk_idx[:, 0])
 
-        select_index = jnp.arange(sel_pos.shape[0], dtype=jnp.int32) * (num_layers + 1) + sel_pos
-        selected_layer0_hidden = _gather_rows_preserve_sharding(layer0_hidden, select_index)
-        # Force P() replicated sharding on outputs that must be cross-process
-        # consistent. Without this, donate_argnames may let XLA alias output
-        # buffers with donated P("data")-sharded pool buffers, silently making
-        # np.asarray() return per-process-different values.
-        stacked_idx = jnp.stack(all_topk_index, axis=1)
+        last_idx = draft_logits_indices
+        if logits_metadata.accept_lens is not None:
+            last_idx = last_idx - (forward_batch.extend_seq_lens - logits_metadata.accept_lens)
+            last_idx = jnp.where(forward_batch.extend_seq_lens > 0, last_idx, 0)
+        if dp_size > 1:
+            per_dp_tokens = layer0_hidden.shape[0] // dp_size
+            per_dp_bs = last_idx.shape[0] // dp_size
+            rank_ids = jnp.arange(last_idx.shape[0], dtype=jnp.int32) // per_dp_bs
+            last_idx = last_idx + rank_ids * per_dp_tokens
+        selected_layer0_hidden = _gather_rows_preserve_sharding(layer0_hidden, last_idx)
+        if topk == 1:
+            stacked_idx = jnp.stack([idx[:, 0] for idx in all_topk_index], axis=1)
+        else:
+            stacked_idx = jnp.stack(all_topk_index, axis=1)
+
+        relay_hidden = selected_layer0_hidden
+        relay_topk_index = stacked_idx
+        relay_verified_id_for_update = relay_verified_id
+
+        # Force P() replicated sharding only on outputs that may still be
+        # materialized on host by the debug/legacy restore path. Relay buffers
+        # are DP-local and must be updated with the original data-sharded values.
         if mesh is not None:
             rep = NamedSharding(mesh, P())
             selected_layer0_hidden = jax.sharding.reshard(selected_layer0_hidden, rep)
             stacked_idx = jax.sharding.reshard(stacked_idx, rep)
 
+        updated_relay_buffers = relay_buffers
+        if update_relay:
+            updated_relay_buffers = update_spec_relay_buffers(
+                relay_buffers,
+                relay_future_indices,
+                relay_valid_mask,
+                relay_topk_index,
+                relay_hidden,
+                relay_verified_id_for_update,
+                relay_new_seq_lens,
+                dp_size=dp_size,
+            )
+
         return (
             selected_layer0_hidden,
             stacked_idx,
             tuple(all_pool_updates),
+            updated_relay_buffers,
         )
 
     return fused_draft_extend
 
 
-def _build_fused_greedy_decode_jit(num_layers: int, topk: int):
-    """Build fused JIT: target verify forward + greedy sample + MTP extend."""
-    assert topk == 1, "Fused greedy decode only supports topk=1"
+def _per_dp_cumsum_device(lens, dp_size: int):
+    per_dp_bs = lens.shape[0] // dp_size
+    lens_2d = lens.reshape((dp_size, per_dp_bs))
+    zeros = jnp.zeros((dp_size, 1), dtype=jnp.int32)
+    return jnp.concatenate([zeros, jnp.cumsum(lens_2d, axis=1, dtype=jnp.int32)], axis=1).reshape(
+        (dp_size * (per_dp_bs + 1),)
+    )
+
+
+def _repack_page_indices_from_allocated_lens(
+    page_indices,
+    allocated_lens,
+    metadata_seq_lens,
+    *,
+    page_size: int,
+    dp_size: int,
+):
+    total_bs = metadata_seq_lens.shape[0]
+    per_dp_bs = total_bs // dp_size
+    pages_per_dp = page_indices.shape[0] // dp_size
+
+    allocated_pages = ((allocated_lens + page_size - 1) // page_size).astype(jnp.int32)
+    needed_pages = ((metadata_seq_lens + page_size - 1) // page_size).astype(jnp.int32)
+    allocated_pages = allocated_pages.reshape((dp_size, per_dp_bs))
+    needed_pages = needed_pages.reshape((dp_size, per_dp_bs))
+
+    src_offsets = jnp.cumsum(allocated_pages, axis=1, dtype=jnp.int32) - allocated_pages
+    dst_offsets = jnp.cumsum(needed_pages, axis=1, dtype=jnp.int32) - needed_pages
+
+    local_page_ids = jnp.arange(pages_per_dp, dtype=jnp.int32)[None, :, None]
+    in_req = (local_page_ids >= dst_offsets[:, None, :]) & (
+        local_page_ids < (dst_offsets + needed_pages)[:, None, :]
+    )
+    slot_ids = jnp.argmax(in_req.astype(jnp.int32), axis=2).astype(jnp.int32)
+    valid = jnp.any(in_req, axis=2)
+
+    dp_ids = jnp.arange(dp_size, dtype=jnp.int32)[:, None]
+    offsets_sharding = jax.typeof(src_offsets).sharding
+    offsets_out_sharding = offsets_sharding if isinstance(offsets_sharding, NamedSharding) else None
+    src_slot_offsets = src_offsets.at[dp_ids, slot_ids].get(out_sharding=offsets_out_sharding)
+    dst_slot_offsets = dst_offsets.at[dp_ids, slot_ids].get(out_sharding=offsets_out_sharding)
+    gather_src = (
+        dp_ids * pages_per_dp
+        + src_slot_offsets
+        + (jnp.arange(pages_per_dp, dtype=jnp.int32)[None, :] - dst_slot_offsets)
+    )
+    page_sharding = jax.typeof(page_indices).sharding
+    out_sharding = page_sharding if isinstance(page_sharding, NamedSharding) else None
+    gathered = (
+        page_indices.at[gather_src.reshape(-1)]
+        .get(
+            mode="fill",
+            fill_value=0,
+            out_sharding=out_sharding,
+        )
+        .reshape((dp_size, pages_per_dp))
+    )
+    return jnp.where(valid, gathered, jnp.zeros_like(gathered)).reshape(page_indices.shape)
+
+
+def _make_target_verify_metadata_from_device_seq_lens(
+    old_metadata,
+    verify_seq_lens,
+    allocated_lens,
+    *,
+    speculative_num_draft_tokens: int,
+    page_size: int,
+    dp_size: int,
+):
+    from sgl_jax.srt.layers.attention.flashattention_backend import (
+        FlashAttentionMetadata,
+    )
+
+    valid = verify_seq_lens > 0
+    extend_seq_lens = jnp.where(
+        valid,
+        jnp.full_like(verify_seq_lens, speculative_num_draft_tokens),
+        jnp.zeros_like(verify_seq_lens),
+    )
+    cu_q_lens = _per_dp_cumsum_device(extend_seq_lens, dp_size)
+    metadata_seq_lens = verify_seq_lens + extend_seq_lens
+    aligned_seq_lens = ((metadata_seq_lens + page_size - 1) // page_size) * page_size
+    cu_kv_lens = _per_dp_cumsum_device(aligned_seq_lens, dp_size)
+    page_indices = _repack_page_indices_from_allocated_lens(
+        old_metadata.page_indices,
+        allocated_lens,
+        metadata_seq_lens,
+        page_size=page_size,
+        dp_size=dp_size,
+    )
+    swa_page_indices = None
+    if old_metadata.swa_page_indices is not None:
+        swa_page_indices = _repack_page_indices_from_allocated_lens(
+            old_metadata.swa_page_indices,
+            allocated_lens,
+            metadata_seq_lens,
+            page_size=page_size,
+            dp_size=dp_size,
+        )
+
+    per_dp_bs = verify_seq_lens.shape[0] // dp_size
+    local_num_seqs = jnp.sum(valid.reshape((dp_size, per_dp_bs)).astype(jnp.int32), axis=1)
+    distribution = jnp.stack(
+        [jnp.zeros_like(local_num_seqs), local_num_seqs, local_num_seqs],
+        axis=1,
+    ).reshape((dp_size * 3,))
+
+    return FlashAttentionMetadata(
+        cu_q_lens=cu_q_lens,
+        cu_kv_lens=cu_kv_lens,
+        page_indices=page_indices,
+        swa_page_indices=swa_page_indices,
+        seq_lens=metadata_seq_lens,
+        distribution=distribution,
+        custom_mask=old_metadata.custom_mask,
+    )
+
+
+def _make_draft_extend_metadata_from_device_seq_lens(
+    old_metadata,
+    draft_seq_lens,
+    allocated_lens,
+    *,
+    page_size: int,
+    dp_size: int,
+):
+    from sgl_jax.srt.layers.attention.flashattention_backend import (
+        FlashAttentionMetadata,
+    )
+
+    valid = draft_seq_lens > 0
+    # DRAFT_EXTEND always runs a fixed number of query tokens per request. The
+    # host metadata already has the correct DP-padded query cumsum shape; only
+    # seq_lens/page_indices need to be rebuilt from the actual verify base.
+    cu_q_lens = old_metadata.cu_q_lens
+    aligned_seq_lens = ((draft_seq_lens + page_size - 1) // page_size) * page_size
+    cu_kv_lens = _per_dp_cumsum_device(aligned_seq_lens, dp_size)
+    page_indices = _repack_page_indices_from_allocated_lens(
+        old_metadata.page_indices,
+        allocated_lens,
+        draft_seq_lens,
+        page_size=page_size,
+        dp_size=dp_size,
+    )
+    swa_page_indices = None
+    if old_metadata.swa_page_indices is not None:
+        swa_page_indices = _repack_page_indices_from_allocated_lens(
+            old_metadata.swa_page_indices,
+            allocated_lens,
+            draft_seq_lens,
+            page_size=page_size,
+            dp_size=dp_size,
+        )
+
+    per_dp_bs = draft_seq_lens.shape[0] // dp_size
+    local_num_seqs = jnp.sum(valid.reshape((dp_size, per_dp_bs)).astype(jnp.int32), axis=1)
+    distribution = jnp.stack(
+        [jnp.zeros_like(local_num_seqs), local_num_seqs, local_num_seqs],
+        axis=1,
+    ).reshape((dp_size * 3,))
+
+    return FlashAttentionMetadata(
+        cu_q_lens=cu_q_lens,
+        cu_kv_lens=cu_kv_lens,
+        page_indices=page_indices,
+        swa_page_indices=swa_page_indices,
+        seq_lens=draft_seq_lens,
+        distribution=distribution,
+        custom_mask=old_metadata.custom_mask,
+    )
+
+
+def _build_fused_greedy_verify_jit(topk: int):
+    """Build target verify JIT for greedy NEXTN decode."""
+    assert topk == 1, "Fused greedy verify only supports topk=1"
 
     @partial(
         jax.jit,
-        donate_argnames=["target_memory_pools", "all_memory_pools"],
+        donate_argnames=["target_memory_pools"],
         static_argnames=[
             "target_model_state_def",
-            "draft_model_state_def",
-            "num_layers",
             "speculative_num_steps",
             "speculative_num_draft_tokens",
             "return_target_logits",
-            "return_target_hidden",
+            "use_relay_state",
+            "dp_size",
         ],
     )
-    def fused_greedy_decode(
+    def fused_greedy_verify(
         target_model_def,
         target_model_state_def,
         target_leaves,
         target_forward_batch,
         target_memory_pools,
         target_logits_metadata,
-        draft_model_def,
-        draft_model_state_def,
-        draft_all_leaves,
-        draft_forward_batch,
-        all_memory_pools,
-        draft_logits_metadata,
         previous_verified_id,
         previous_token_list,
+        relay_buffers,
+        relay_future_indices,
+        verify_allocate_lens,
         *,
-        num_layers,
         speculative_num_steps,
         speculative_num_draft_tokens,
         return_target_logits,
-        return_target_hidden,
+        use_relay_state,
+        dp_size,
     ):
+        if use_relay_state:
+            relay_topk_index, _, relay_verified_id, relay_new_seq_lens = gather_spec_relay_buffers(
+                relay_buffers,
+                relay_future_indices,
+                dp_size=dp_size,
+            )
+            valid_seq_lens = target_forward_batch.seq_lens > 0
+            target_forward_batch.seq_lens = jnp.where(
+                valid_seq_lens,
+                relay_new_seq_lens - 1,
+                jnp.zeros_like(target_forward_batch.seq_lens),
+            )
+            target_forward_batch.attn_backend.forward_metadata = (
+                _make_target_verify_metadata_from_device_seq_lens(
+                    target_forward_batch.attn_backend.forward_metadata,
+                    target_forward_batch.seq_lens,
+                    verify_allocate_lens,
+                    speculative_num_draft_tokens=speculative_num_draft_tokens,
+                    page_size=target_forward_batch.attn_backend.page_size,
+                    dp_size=dp_size,
+                )
+            )
+            previous_verified_id = relay_verified_id
+            previous_token_list = relay_topk_index
+
         target_bs = target_forward_batch.seq_lens.shape[0]
         (
             draft_tokens,
@@ -370,23 +674,124 @@ def _build_fused_greedy_decode_jit(num_layers: int, topk: int):
             speculative_num_draft_tokens=speculative_num_draft_tokens,
         )
 
+        target_logits_for_host = (
+            _gather_rows_preserve_sharding(target_logits, prepared.safe_index)
+            if return_target_logits
+            else None
+        )
+        prepared_hidden = prepared.hidden_states
+        prepared_verified_id = prepared.verified_id
+        prepared_next_verified_id = _take_with_index_sharding(
+            prepared.verified_id, prepared.select_index
+        )
+        prepared_new_seq_lens = prepared.new_seq_lens
+        prepared_accept_lens = prepared.accept_lens
+        prepared_sel_pos = prepared.sel_pos
+        prepared_predict = prepared.predict
+        prepared_positions = prepared.positions
+        prepared_verify_seq_lens = target_forward_batch.seq_lens
+
+        if mesh is not None:
+            rep = NamedSharding(mesh, P())
+            data = NamedSharding(mesh, P("data"))
+            prepared_hidden = jax.sharding.reshard(prepared_hidden, rep)
+            prepared_verified_id = jax.sharding.reshard(prepared_verified_id, rep)
+            prepared_next_verified_id = jax.sharding.reshard(prepared_next_verified_id, data)
+            prepared_new_seq_lens = jax.sharding.reshard(prepared_new_seq_lens, rep)
+            prepared_accept_lens = jax.sharding.reshard(prepared_accept_lens, rep)
+            prepared_sel_pos = jax.sharding.reshard(prepared_sel_pos, rep)
+            prepared_predict = jax.sharding.reshard(prepared_predict, rep)
+            prepared_positions = jax.sharding.reshard(prepared_positions, rep)
+            if return_target_logits:
+                target_logits_for_host = jax.sharding.reshard(target_logits_for_host, rep)
+
+        return (
+            target_pool_updates,
+            prepared_hidden,
+            prepared_verified_id,
+            prepared_next_verified_id,
+            prepared_new_seq_lens,
+            prepared_accept_lens,
+            prepared_sel_pos,
+            prepared_predict,
+            prepared_positions,
+            prepared_verify_seq_lens,
+            target_logits_for_host,
+        )
+
+    return fused_greedy_verify
+
+
+def _build_fused_greedy_prefill_jit(num_layers: int, topk: int):
+    """Build prefill JIT: target extend + all MTP draft-extend layers."""
+    assert topk == 1, "Fused greedy prefill only supports topk=1"
+
+    @partial(
+        jax.jit,
+        donate_argnames=["target_memory_pools", "all_memory_pools"],
+        static_argnames=[
+            "target_model_state_def",
+            "draft_model_state_def",
+            "num_layers",
+            "dp_size",
+            "per_dp_bs",
+            "update_relay",
+        ],
+    )
+    def fused_greedy_prefill(
+        target_model_def,
+        target_model_state_def,
+        target_leaves,
+        target_forward_batch,
+        target_memory_pools,
+        target_logits_metadata,
+        draft_model_def,
+        draft_model_state_def,
+        draft_all_leaves,
+        draft_forward_batch,
+        draft_logits_indices,
+        all_memory_pools,
+        draft_logits_metadata,
+        relay_buffers,
+        relay_future_indices,
+        relay_valid_mask,
+        *,
+        num_layers,
+        dp_size,
+        per_dp_bs,
+        update_relay,
+    ):
+        target_state = jax.tree_util.tree_unflatten(target_model_state_def, target_leaves)
+        target_model = nnx.merge(target_model_def, target_state)
+        target_output, target_pool_updates, _, _ = target_model(
+            target_forward_batch,
+            target_memory_pools,
+            target_logits_metadata,
+        )
+
+        target_logits = target_output.next_token_logits
+        target_hidden = target_output.hidden_states
+        next_token_ids = jnp.argmax(target_logits, axis=-1).astype(jnp.int32)
+        input_ids = _device_rotate_prefill_input_ids(
+            draft_forward_batch.input_ids,
+            draft_forward_batch.extend_seq_lens,
+            next_token_ids,
+            dp_size,
+            per_dp_bs,
+        )
+
         all_topk_index = []
         all_pool_updates = []
         layer0_hidden = None
-        input_ids = prepared.verified_id
+        mesh = None
 
-        draft_forward_batch.positions = prepared.positions
-        draft_forward_batch.spec_info.hidden_states = prepared.hidden_states
-        draft_forward_batch.spec_info.accept_length = prepared.accept_lens
-        draft_logits_metadata.accept_lens = prepared.accept_lens
-
+        draft_forward_batch.spec_info.hidden_states = target_hidden
         for i in range(num_layers):
             state = jax.tree_util.tree_unflatten(draft_model_state_def, draft_all_leaves[i])
             model = nnx.merge(draft_model_def, state)
 
-            draft_forward_batch.spec_info.hidden_states = prepared.hidden_states
             draft_forward_batch.input_ids = input_ids
-
+            draft_forward_batch.spec_info.hidden_states = target_hidden
             output, pool_updates, _, _ = model(
                 draft_forward_batch, all_memory_pools[i], draft_logits_metadata
             )
@@ -395,53 +800,63 @@ def _build_fused_greedy_decode_jit(num_layers: int, topk: int):
             sh = jax.typeof(output.next_token_logits).sharding
             mesh = sh.mesh if isinstance(sh, NamedSharding) else mesh
             topk_idx = _topk1_index_from_logits(output.next_token_logits)
-            rep_hidden = output.hidden_states
-
-            if i == 0:
-                layer0_hidden = rep_hidden
-
             all_topk_index.append(topk_idx)
-
+            if i == 0:
+                layer0_hidden = output.hidden_states
             if i < num_layers - 1:
-                input_ids = _device_rotate_input_ids(
+                input_ids = _device_rotate_prefill_input_ids(
                     input_ids,
                     draft_forward_batch.extend_seq_lens,
-                    prepared.sel_pos,
                     topk_idx[:, 0],
+                    dp_size,
+                    per_dp_bs,
                 )
 
-        stacked_idx = jnp.stack(all_topk_index, axis=1)
-        selected_layer0_hidden = _gather_rows_preserve_sharding(
-            layer0_hidden, prepared.select_index
-        )
-        target_logits_for_host = target_logits if return_target_logits else None
-        target_hidden_for_host = target_hidden if return_target_hidden else None
-        if mesh is not None:
+        last_idx = draft_logits_indices
+        if dp_size > 1:
+            per_dp_tokens = layer0_hidden.shape[0] // dp_size
+            rank_ids = jnp.arange(last_idx.shape[0], dtype=jnp.int32) // per_dp_bs
+            last_idx = last_idx + rank_ids * per_dp_tokens
+
+        selected_layer0_hidden = _gather_rows_preserve_sharding(layer0_hidden, last_idx)
+        if topk == 1:
+            stacked_idx = jnp.stack([idx[:, 0] for idx in all_topk_index], axis=1)
+        else:
+            stacked_idx = jnp.stack(all_topk_index, axis=1)
+        relay_hidden = selected_layer0_hidden
+        relay_topk_index = stacked_idx
+        relay_verified_id = next_token_ids
+        relay_new_seq_lens = target_forward_batch.seq_lens + 1
+        if mesh is not None and not update_relay:
             rep = NamedSharding(mesh, P())
+            next_token_ids = jax.sharding.reshard(jnp.copy(next_token_ids), rep)
             selected_layer0_hidden = jax.sharding.reshard(selected_layer0_hidden, rep)
             stacked_idx = jax.sharding.reshard(stacked_idx, rep)
-            prepared_accept_lens = jax.sharding.reshard(prepared.accept_lens, rep)
-            prepared_predict = jax.sharding.reshard(prepared.predict, rep)
-            if return_target_logits:
-                target_logits_for_host = jax.sharding.reshard(target_logits, rep)
-            if return_target_hidden:
-                target_hidden_for_host = jax.sharding.reshard(target_hidden, rep)
-        else:
-            prepared_accept_lens = prepared.accept_lens
-            prepared_predict = prepared.predict
+
+        updated_relay_buffers = relay_buffers
+        if update_relay:
+            updated_relay_buffers = update_spec_relay_buffers(
+                relay_buffers,
+                relay_future_indices,
+                relay_valid_mask,
+                relay_topk_index,
+                relay_hidden,
+                relay_verified_id,
+                relay_new_seq_lens,
+                dp_size=dp_size,
+            )
 
         return (
-            selected_layer0_hidden,
-            stacked_idx,
+            target_output,
+            next_token_ids,
             target_pool_updates,
             tuple(all_pool_updates),
-            prepared_accept_lens,
-            prepared_predict,
-            target_logits_for_host,
-            target_hidden_for_host,
+            selected_layer0_hidden,
+            stacked_idx,
+            updated_relay_buffers,
         )
 
-    return fused_greedy_decode
+    return fused_greedy_prefill
 
 
 def _prepare_topk1_verify_placeholders_from_draft_state(draft_worker, model_worker_batch):
@@ -449,12 +864,43 @@ def _prepare_topk1_verify_placeholders_from_draft_state(draft_worker, model_work
     from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode
     from sgl_jax.srt.speculative.eagle_util import EagleVerifyInput
 
+    draft_input = model_worker_batch.spec_info_padded
+    use_relay_state = (
+        getattr(draft_input, "future_indices", None) is not None
+        and getattr(draft_input, "topk_index", None) is None
+    )
+    if use_relay_state:
+        bs = len(model_worker_batch.seq_lens)
+        draft_input.verified_id = np.zeros((bs,), dtype=np.int32)
+        draft_input.topk_p = np.ones(
+            (bs, draft_worker.speculative_num_steps),
+            dtype=np.float32,
+        )
+        draft_input.topk_index = np.zeros(
+            (bs, draft_worker.speculative_num_steps),
+            dtype=np.int32,
+        )
+        draft_input.hidden_states = np.zeros(
+            (bs, draft_worker.model_config.hidden_size),
+            dtype=np.float32,
+        )
+
     draft_worker.padding_for_decode(model_worker_batch)
     draft_input = model_worker_batch.spec_info_padded
     previous_verified_id = draft_input.verified_id
     if isinstance(previous_verified_id, np.ndarray):
         previous_verified_id = np.asarray(previous_verified_id, dtype=np.int32)
-    previous_token_list = draft_input.topk_index[:, :, 0]
+    topk_index = draft_input.topk_index
+    if len(topk_index.shape) == 2:
+        previous_token_list = topk_index
+    elif len(topk_index.shape) == 3 and topk_index.shape[-1] == 1:
+        previous_token_list = (
+            np.squeeze(topk_index, axis=-1)
+            if isinstance(topk_index, np.ndarray)
+            else jnp.squeeze(topk_index, axis=-1)
+        )
+    else:
+        previous_token_list = topk_index[:, :, 0]
     if isinstance(previous_token_list, np.ndarray):
         previous_token_list = np.asarray(previous_token_list, dtype=np.int32)
     else:
@@ -580,21 +1026,45 @@ def _forward_batch_init_new_preserve_device(batch, model_runner):
     )
 
 
-def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output):
-    """Drop-in replacement for MultiLayerDraftWorker.draft_extend_for_decode.
+def prepare_spec_prefill_forward_batch(spec_worker, model_worker_batch):
+    """Prepare the target ForwardBatch before speculative prefill is queued."""
+    from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode
 
-    Fuses all N MTP layer forwards into a single jit call.
-    """
-    from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+    target_mr = spec_worker.target_worker.model_runner
+    model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
+    target_mr.attn_backend.forward_metadata = target_mr.attn_backend.get_forward_metadata(
+        model_worker_batch
+    )
+    model_worker_batch.forward_batch = _forward_batch_init_new_preserve_device(
+        model_worker_batch, target_mr
+    )
+    model_worker_batch.forward_batch.bid = model_worker_batch.bid
+    return model_worker_batch.forward_batch
+
+
+def launch_fused_draft_extend_for_decode(
+    draft_worker,
+    model_worker_batch,
+    batch_output,
+    *,
+    relay_buffers=None,
+    relay_future_indices=None,
+    relay_valid_mask=None,
+):
+    """Launch fused MTP draft extend and return deferred host restore state."""
     from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
 
     if batch_output.next_draft_input.verified_id.shape[0] <= 0:
-        return
+        return None
     target_hidden = batch_output.logits_output.hidden_states
+    update_relay = relay_buffers is not None
 
     draft_input = EagleDraftInput(
-        hidden_states=target_hidden, allocate_lens=batch_output.allocate_lens
+        hidden_states=target_hidden,
+        allocate_lens=batch_output.next_draft_input.allocate_lens,
     )
+    if getattr(batch_output.next_draft_input, "verify_seq_lens", None) is not None:
+        draft_input.device_seq_lens_for_draft_extend = True
     mwb, logits_metadata = draft_input.prepare_for_extend_after_verify(
         model_worker_batch,
         draft_worker.draft_model_runner,
@@ -602,17 +1072,17 @@ def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output
         draft_worker.speculative_num_draft_tokens,
     )
     if mwb.input_ids.shape[0] <= 0:
-        return
+        return None
 
     sel = np.asarray(model_worker_batch.logits_indices_selector)
-    accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
-    assert (accept_host[sel] >= 1).all(), f"accept_length < 1: {accept_host[sel]}"
-    sel_pos = np.clip(accept_host - 1, 0, None).astype(np.int32)
+    if hasattr(batch_output.next_draft_input, "sel_pos"):
+        sel_pos = batch_output.next_draft_input.sel_pos
+    else:
+        sel_pos = jnp.clip(batch_output.accept_lens - 1, 0, None).astype(jnp.int32)
 
     mr0 = draft_worker._workers[0].model_runner
     mwb.spec_info_padded.hidden_states = target_hidden
-    mr0.attn_backend.forward_metadata = mr0.attn_backend.get_eagle_forward_metadata(mwb)
-    shared_fb = ForwardBatch.init_new(mwb, mr0)
+    shared_fb = _forward_batch_init_new_preserve_device(mwb, mr0)
     shared_fb.bid = model_worker_batch.bid
 
     all_memory_pools = []
@@ -622,8 +1092,20 @@ def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output
         all_memory_pools.append(mr.memory_pools)
         all_leaves.append(tuple(mr.model_state_leaves))
 
-    sel_pos_device = jax.device_put(sel_pos, NamedSharding(draft_worker.mesh, P("data")))
-
+    data_sharding = NamedSharding(draft_worker.mesh, P("data"))
+    sel_pos_device = _device_array_preserve_device(sel_pos, data_sharding)
+    draft_logits_indices = _device_array_preserve_device(mwb.logits_indices, data_sharding)
+    draft_allocate_lens = np.zeros_like(model_worker_batch.seq_lens, dtype=np.int32)
+    draft_allocate_lens[sel] = np.asarray(batch_output.next_draft_input.allocate_lens)
+    draft_allocate_lens = _device_array_preserve_device(draft_allocate_lens, data_sharding)
+    draft_verify_seq_lens = getattr(batch_output.next_draft_input, "verify_seq_lens", None)
+    draft_verify_seq_lens = _device_array_preserve_device(draft_verify_seq_lens, data_sharding)
+    if relay_future_indices is None:
+        relay_future_indices = np.zeros(model_worker_batch.req_pool_indices.shape, dtype=np.int32)
+    if relay_valid_mask is None:
+        relay_valid_mask = np.zeros(model_worker_batch.req_pool_indices.shape, dtype=np.bool_)
+    relay_future_indices = _device_array_preserve_device(relay_future_indices, data_sharding)
+    relay_valid_mask = _device_array_preserve_device(relay_valid_mask, data_sharding)
     if not hasattr(draft_worker, "_fused_jit_fn"):
         draft_worker._fused_jit_fn = _build_fused_draft_extend_jit(
             num_layers=draft_worker.speculative_num_steps,
@@ -631,7 +1113,12 @@ def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output
         )
 
     with jax.set_mesh(draft_worker.mesh):
-        selected_layer0_hidden, topk_index_stacked, all_pool_updates = draft_worker._fused_jit_fn(
+        (
+            selected_layer0_hidden,
+            topk_index_stacked,
+            all_pool_updates,
+            updated_relay_buffers,
+        ) = draft_worker._fused_jit_fn(
             mr0._model_def,
             mr0._model_state_def,
             tuple(all_leaves),
@@ -640,184 +1127,126 @@ def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output
             logits_metadata,
             target_hidden,
             sel_pos_device,
+            draft_logits_indices,
+            relay_buffers,
+            relay_future_indices,
+            relay_valid_mask,
+            batch_output.next_draft_input.next_verified_id,
+            batch_output.next_draft_input.new_seq_lens,
+            draft_verify_seq_lens,
+            draft_allocate_lens,
             num_layers=draft_worker.speculative_num_steps,
+            update_relay=update_relay,
+            dp_size=model_worker_batch.dp_size,
         )
 
     for i, w in enumerate(draft_worker._workers):
         w.model_runner.memory_pools.replace_all(all_pool_updates[i])
 
-    verified_id_arr = batch_output.next_draft_input.verified_id
-    if hasattr(verified_id_arr, "copy_to_host_async"):
-        jax.copy_to_host_async(verified_id_arr)
+    return FusedDraftExtendPendingResult(
+        batch_output=batch_output,
+        selected_layer0_hidden=selected_layer0_hidden,
+        topk_index_stacked=topk_index_stacked,
+        next_verified_id=batch_output.next_draft_input.next_verified_id,
+        accept_lens=batch_output.accept_lens,
+        sel=sel,
+        updated_relay_buffers=updated_relay_buffers,
+    )
+
+
+def restore_fused_draft_extend_result(draft_worker, model_worker_batch, pending_result):
+    if pending_result is None:
+        return
+
+    batch_output = pending_result.batch_output
+    selected_layer0_hidden = pending_result.selected_layer0_hidden
+    topk_index_stacked = pending_result.topk_index_stacked
+    next_verified_id = pending_result.next_verified_id
+    accept_host = np.asarray(jax.device_get(pending_result.accept_lens))
+    sel = pending_result.sel
 
     jax.copy_to_host_async(selected_layer0_hidden)
     jax.copy_to_host_async(topk_index_stacked)
+    if model_worker_batch.dp_size > 1:
+        from jax.experimental.multihost_utils import process_allgather
+
+        next_verified_id = process_allgather(next_verified_id, tiled=True)
+    jax.copy_to_host_async(next_verified_id)
 
     batch_output.next_draft_input.hidden_states = np.asarray(selected_layer0_hidden)[sel]
     topk_index = np.asarray(topk_index_stacked)[sel]
     batch_output.next_draft_input.topk_p = np.ones(topk_index.shape, dtype=np.float32)
     batch_output.next_draft_input.topk_index = topk_index
-    select_index = sel * (draft_worker.speculative_num_steps + 1) + accept_host[sel] - 1
-    batch_output.next_draft_input.verified_id = np.asarray(verified_id_arr)[select_index]
-    batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
+    batch_output.next_draft_input.verified_id = np.asarray(next_verified_id)[sel]
+    batch_output.next_draft_input.allocate_lens = batch_output.next_draft_input.allocate_lens[
+        : model_worker_batch.real_bs
+    ]
     batch_output.accept_lens = accept_host
 
 
-def _prepare_model_worker_batch_for_draft_extend(draft_worker, model_worker_batch, batch_output):
+def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output):
+    """Drop-in replacement for MultiLayerDraftWorker.draft_extend_for_decode.
+
+    Fuses all N MTP layer forwards into a single jit call.
+    """
+    pending_result = launch_fused_draft_extend_for_decode(
+        draft_worker, model_worker_batch, batch_output
+    )
+    restore_fused_draft_extend_result(draft_worker, model_worker_batch, pending_result)
+
+
+def spec_prefill(spec_worker, model_worker_batch, launch_done=None, *, update_relay=False):
+    """Run greedy prefill target forward and MTP draft-extend in one JIT."""
+    from sgl_jax.srt.managers.scheduler import GenerationBatchResult
     from sgl_jax.srt.model_executor.forward_batch_info import (
         CaptureHiddenMode,
-        ForwardMode,
+        ForwardBatch,
     )
-
-    model_worker_batch.spec_info_padded = batch_output.next_draft_input
-    sel = model_worker_batch.logits_indices_selector
-    model_worker_batch.seq_lens[sel] = (
-        model_worker_batch.seq_lens[sel] + draft_worker.speculative_num_draft_tokens - 1
-    )
-
-    bs = batch_output.accept_lens.shape[0]
-    step_plus_1 = batch_output.next_draft_input.verified_id.shape[0] // bs
-    model_worker_batch.extend_seq_lens = np.zeros((bs,), dtype=np.int32)
-    model_worker_batch.extend_seq_lens[sel] = step_plus_1
-
-    dp = model_worker_batch.dp_size
-    per_dp = model_worker_batch.per_dp_bs_size if dp > 1 else bs
-    model_worker_batch.logits_indices = (
-        model_worker_batch.extend_seq_lens.reshape(dp, per_dp)
-        .cumsum(axis=1, dtype=np.int32)
-        .ravel()
-        - 1
-    )
-    model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
-    model_worker_batch.spec_info_padded.capture_hidden_mode = CaptureHiddenMode.FULL
-    model_worker_batch.forward_mode = ForwardMode.DRAFT_EXTEND
-    model_worker_batch.spec_info_padded.hidden_states = batch_output.logits_output.hidden_states
-    model_worker_batch.spec_info_padded.accept_length = None
-    model_worker_batch.input_ids = batch_output.next_draft_input.verified_id
-
-    forward_metadata = draft_worker.draft_model_runner.attn_backend.get_eagle_forward_metadata(
-        model_worker_batch
-    )
-    draft_worker.draft_model_runner.attn_backend.forward_metadata = forward_metadata
-    logits_metadata = _logits_metadata_from_model_worker_batch_preserve_device(
-        model_worker_batch, draft_worker.mesh, include_accept_lens=False
-    )
-    return model_worker_batch, logits_metadata
-
-
-def _materialize_fused_greedy_batch_output_for_scheduler(
-    *,
-    batch_output,
-    selector,
-    real_bs,
-    seq_lens_host,
-    layer0_hidden,
-    topk_index_stacked,
-    accept_lens_device,
-    predict_device,
-    speculative_num_draft_tokens,
-    target_logits,
-    target_hidden,
-):
-    """Materialize the scheduler-facing fields after the single fused decode JIT."""
-    from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
-
-    with jax.profiler.TraceAnnotation("fused_greedy_batch_output_d2h"):
-        jax.copy_to_host_async(layer0_hidden)
-        jax.copy_to_host_async(topk_index_stacked)
-        jax.copy_to_host_async(accept_lens_device)
-        jax.copy_to_host_async(predict_device)
-
-        batch_output.logits_output = LogitsProcessorOutput(
-            next_token_logits=target_logits,
-            hidden_states=target_hidden,
-        )
-        batch_output.next_draft_input.hidden_states = np.asarray(layer0_hidden)[selector]
-        topk_index = np.asarray(topk_index_stacked)[selector]
-        batch_output.next_draft_input.topk_p = np.ones(topk_index.shape, dtype=np.float32)
-        batch_output.next_draft_input.topk_index = topk_index
-        accept_lens = np.asarray(accept_lens_device)
-        predict = np.asarray(predict_device)
-        seq_lens_host = np.asarray(seq_lens_host)
-        verified_pos = selector * speculative_num_draft_tokens + accept_lens[selector] - 1
-        batch_output.next_draft_input.verified_id = predict[verified_pos]
-        original_seq_lens = seq_lens_host[selector] - speculative_num_draft_tokens + 1
-        batch_output.next_draft_input.new_seq_lens = original_seq_lens + accept_lens[selector]
-        batch_output.allocate_lens = batch_output.allocate_lens[:real_bs]
-        batch_output.accept_lens = accept_lens
-        batch_output.next_token_ids = predict
-        return batch_output
-
-
-def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
-    """Run one fused speculative decode round."""
-    from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
-    from sgl_jax.srt.managers.scheduler import GenerationBatchResult
     from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
 
     draft_worker = spec_worker.draft_worker
     target_worker = spec_worker.target_worker
     target_mr = target_worker.model_runner
-    previous_verified_id, previous_token_list = _prepare_topk1_verify_placeholders_from_draft_state(
-        draft_worker, model_worker_batch
-    )
-    spec_info = model_worker_batch.spec_info_padded
-    return_target_logits = bool(
-        getattr(model_worker_batch, "return_logprob", False)
-        or getattr(model_worker_batch, "return_output_logprob_only", False)
-    )
-    return_target_hidden = bool(getattr(model_worker_batch, "return_hidden_states", False))
 
-    spec_info.allocate_lens = cur_allocate_lens
-    spec_info.prepare_for_verify(model_worker_batch, spec_worker.page_size, target_worker)
-    target_mr.attn_backend.forward_metadata = target_mr.attn_backend.get_eagle_forward_metadata(
-        model_worker_batch
-    )
-    target_forward_batch = _forward_batch_init_new_preserve_device(model_worker_batch, target_mr)
-    target_forward_batch.bid = model_worker_batch.bid
+    if getattr(model_worker_batch, "forward_batch", None) is None:
+        target_forward_batch = prepare_spec_prefill_forward_batch(spec_worker, model_worker_batch)
+    else:
+        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
+        target_mr.attn_backend.forward_metadata = target_mr.attn_backend.get_forward_metadata(
+            model_worker_batch
+        )
+        target_forward_batch = model_worker_batch.forward_batch
+        target_forward_batch.bid = model_worker_batch.bid
     target_logits_metadata = _logits_metadata_from_model_worker_batch_preserve_device(
         model_worker_batch, spec_worker.mesh
     )
 
     hidden_size = target_worker.model_config.hidden_size
-    placeholder_hidden = np.zeros((spec_info.draft_token.shape[0], hidden_size), dtype=np.float32)
-    placeholder_logits = np.zeros((spec_info.draft_token.shape[0], 1), dtype=np.float32)
-
-    next_draft_input = EagleDraftInput(
-        verified_id=spec_info.draft_token,
-        new_seq_lens=model_worker_batch.seq_lens,
-        allocate_lens=cur_allocate_lens,
-        hidden_states=placeholder_hidden,
+    model_worker_batch.spec_info_padded = EagleDraftInput(
+        hidden_states=np.zeros((len(model_worker_batch.input_ids), hidden_size), dtype=np.float32),
+        verified_id=np.zeros((len(model_worker_batch.seq_lens),), dtype=np.int32),
+        num_tokens_per_batch=np.asarray(1, dtype=np.int32),
+        num_tokens_for_logprob_per_batch=np.asarray(1, dtype=np.int32),
+        allocate_lens=model_worker_batch.seq_lens,
     )
-    next_draft_input.draft_token = spec_info.draft_token
-    next_draft_input.retrive_index = spec_info.retrive_index
-    next_draft_input.retrive_next_token = spec_info.retrive_next_token
-    next_draft_input.retrive_next_sibling = spec_info.retrive_next_sibling
-    batch_output = GenerationBatchResult(
-        logits_output=LogitsProcessorOutput(
-            next_token_logits=placeholder_logits,
-            hidden_states=placeholder_hidden,
-        ),
-        next_token_ids=spec_info.draft_token,
-        next_draft_input=next_draft_input,
-        accept_lens=np.ones(model_worker_batch.seq_lens.shape, dtype=np.int32),
-        allocate_lens=cur_allocate_lens,
-        bid=model_worker_batch.bid,
-        cache_miss_count=0,
-        extend_input_len_per_req=None,
-        extend_logprob_start_len_per_req=None,
-    )
-    model_worker_batch.spec_info_padded = next_draft_input
-
-    draft_mwb, draft_logits_metadata = _prepare_model_worker_batch_for_draft_extend(
-        draft_worker, model_worker_batch, batch_output
-    )
-    if draft_mwb.input_ids.shape[0] <= 0:
-        return batch_output
+    model_worker_batch.return_hidden_states = False
+    model_worker_batch.spec_info_padded.capture_hidden_mode = CaptureHiddenMode.FULL
+    model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
 
     draft_mr0 = draft_worker._workers[0].model_runner
-    draft_forward_batch = _forward_batch_init_new_preserve_device(draft_mwb, draft_mr0)
+    draft_mr0.attn_backend.forward_metadata = draft_mr0.attn_backend.get_eagle_forward_metadata(
+        model_worker_batch
+    )
+    draft_forward_batch = ForwardBatch.init_new(model_worker_batch, draft_mr0)
+    draft_forward_batch.input_ids = target_forward_batch.input_ids
     draft_forward_batch.bid = model_worker_batch.bid
+    draft_logits_indices = _device_array_preserve_device(
+        model_worker_batch.logits_indices,
+        NamedSharding(draft_worker.mesh, P("data")),
+    )
+    draft_logits_metadata = _logits_metadata_from_model_worker_batch_preserve_device(
+        model_worker_batch, draft_worker.mesh
+    )
 
     all_memory_pools = []
     all_leaves = []
@@ -826,23 +1255,37 @@ def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
         all_memory_pools.append(mr.memory_pools)
         all_leaves.append(tuple(mr.model_state_leaves))
 
-    if not hasattr(draft_worker, "_fused_greedy_decode_jit_fn"):
-        draft_worker._fused_greedy_decode_jit_fn = _build_fused_greedy_decode_jit(
+    if not hasattr(draft_worker, "_fused_greedy_prefill_jit_fn"):
+        draft_worker._fused_greedy_prefill_jit_fn = _build_fused_greedy_prefill_jit(
             num_layers=draft_worker.speculative_num_steps,
             topk=draft_worker.topk,
         )
 
-    with jax.set_mesh(draft_worker.mesh):
+    data_sharding = NamedSharding(draft_worker.mesh, P("data"))
+    relay_buffers = getattr(spec_worker, "spec_relay_buffers", None)
+    valid_mask = make_dp_valid_mask(
+        model_worker_batch.real_bs_per_dp,
+        total_bs=model_worker_batch.req_pool_indices.shape[0],
+        per_dp_bs=model_worker_batch.per_dp_bs_size,
+    )
+    safe_indices = np.where(
+        valid_mask,
+        np.asarray(model_worker_batch.req_pool_indices, dtype=np.int32),
+        0,
+    )
+    relay_future_indices = _device_array_preserve_device(safe_indices, data_sharding)
+    relay_valid_mask = _device_array_preserve_device(valid_mask, data_sharding)
+
+    with jax.set_mesh(draft_worker.mesh), jtu.count_pjit_cpp_cache_miss() as count:
         (
-            layer0_hidden,
-            topk_index_stacked,
+            logits_output,
+            next_token_ids,
             target_pool_updates,
             all_pool_updates,
-            accept_lens_device,
-            predict_device,
-            target_logits,
-            target_hidden,
-        ) = draft_worker._fused_greedy_decode_jit_fn(
+            layer0_hidden,
+            topk_index_stacked,
+            updated_relay_buffers,
+        ) = draft_worker._fused_greedy_prefill_jit_fn(
             target_mr._model_def,
             target_mr._model_state_def,
             tuple(target_mr.model_state_leaves),
@@ -853,31 +1296,250 @@ def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
             draft_mr0._model_state_def,
             tuple(all_leaves),
             draft_forward_batch,
+            draft_logits_indices,
             tuple(all_memory_pools),
             draft_logits_metadata,
-            previous_verified_id,
-            previous_token_list,
+            relay_buffers,
+            relay_future_indices,
+            relay_valid_mask,
             num_layers=draft_worker.speculative_num_steps,
-            speculative_num_steps=draft_worker.speculative_num_steps,
-            speculative_num_draft_tokens=draft_worker.speculative_num_draft_tokens,
-            return_target_logits=return_target_logits,
-            return_target_hidden=return_target_hidden,
+            dp_size=model_worker_batch.dp_size,
+            per_dp_bs=model_worker_batch.per_dp_bs_size,
+            update_relay=update_relay,
         )
+        cache_miss_count = count()
+    prefill_output_token_ids = None
+    if update_relay:
+        prefill_output_token_ids = _prepare_spec_prefill_output_token_ids(
+            draft_worker,
+            next_token_ids,
+        )
+        if hasattr(prefill_output_token_ids, "copy_to_host_async"):
+            prefill_output_token_ids.copy_to_host_async()
+
+    if launch_done is not None:
+        launch_done.set()
 
     target_mr.memory_pools.replace_all(target_pool_updates)
     for i, w in enumerate(draft_worker._workers):
         w.model_runner.memory_pools.replace_all(all_pool_updates[i])
+    if update_relay:
+        spec_worker.spec_relay_buffers = updated_relay_buffers
 
-    return _materialize_fused_greedy_batch_output_for_scheduler(
-        batch_output=batch_output,
-        selector=np.asarray(model_worker_batch.logits_indices_selector),
-        real_bs=model_worker_batch.real_bs,
-        seq_lens_host=model_worker_batch.seq_lens,
-        layer0_hidden=layer0_hidden,
-        topk_index_stacked=topk_index_stacked,
-        accept_lens_device=accept_lens_device,
-        predict_device=predict_device,
-        speculative_num_draft_tokens=draft_worker.speculative_num_draft_tokens,
-        target_logits=target_logits,
-        target_hidden=target_hidden,
+    sel = np.asarray(model_worker_batch.logits_indices_selector)
+    if update_relay:
+        from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
+
+        future_indices = np.asarray(model_worker_batch.req_pool_indices, dtype=np.int32)[sel]
+        model_worker_batch.spec_info_padded = EagleDraftInput(
+            future_indices=future_indices,
+            allocate_lens=np.asarray(model_worker_batch.seq_lens, dtype=np.int32)[sel],
+            capture_hidden_mode=CaptureHiddenMode.FULL,
+            num_tokens_per_batch=np.asarray(1, dtype=np.int32),
+            num_tokens_for_logprob_per_batch=np.asarray(1, dtype=np.int32),
+        )
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=prefill_output_token_ids,
+            next_draft_input=model_worker_batch.spec_info_padded,
+            spec_relay_buffers=updated_relay_buffers,
+            prefill_relay_future_indices=relay_future_indices,
+            bid=model_worker_batch.bid,
+            cache_miss_count=cache_miss_count,
+            extend_input_len_per_req=None,
+            extend_logprob_start_len_per_req=None,
+        )
+
+    relay_next_token_ids = next_token_ids
+    host_next_token_ids = next_token_ids
+    if model_worker_batch.dp_size > 1:
+        from jax.experimental.multihost_utils import process_allgather
+
+        host_next_token_ids = process_allgather(host_next_token_ids, tiled=True)
+
+    jax.copy_to_host_async(host_next_token_ids)
+    jax.copy_to_host_async(layer0_hidden)
+    jax.copy_to_host_async(topk_index_stacked)
+
+    topk_index = np.asarray(topk_index_stacked)[sel]
+    model_worker_batch.spec_info_padded.hidden_states = np.asarray(layer0_hidden)[sel]
+    model_worker_batch.spec_info_padded.topk_p = np.ones(topk_index.shape, dtype=np.float32)
+    model_worker_batch.spec_info_padded.topk_index = topk_index
+    model_worker_batch.spec_info_padded.allocate_lens = np.asarray(model_worker_batch.seq_lens)[sel]
+    model_worker_batch.spec_info_padded.verified_id = np.asarray(host_next_token_ids)[sel]
+
+    return GenerationBatchResult(
+        logits_output=logits_output,
+        next_token_ids=relay_next_token_ids if launch_done is not None else host_next_token_ids,
+        next_draft_input=model_worker_batch.spec_info_padded,
+        bid=model_worker_batch.bid,
+        cache_miss_count=cache_miss_count,
+        extend_input_len_per_req=None,
+        extend_logprob_start_len_per_req=None,
     )
+
+
+def spec_prefill_overlap(spec_worker, model_worker_batch):
+    return spec_prefill(spec_worker, model_worker_batch, update_relay=True)
+
+
+def spec_decode_verify_phase(spec_worker, model_worker_batch, cur_allocate_lens):
+    """Run target verify as the first speculative decode JIT."""
+    from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
+    from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+    from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
+
+    draft_worker = spec_worker.draft_worker
+    target_worker = spec_worker.target_worker
+    target_mr = target_worker.model_runner
+    draft_input = model_worker_batch.spec_info_padded
+    use_relay_state = (
+        getattr(draft_input, "future_indices", None) is not None
+        and getattr(draft_input, "topk_index", None) is None
+    )
+    relay_future_indices = None
+    if use_relay_state:
+        relay_future_indices = np.asarray(draft_input.future_indices, dtype=np.int32)
+        relay_future_indices = np.where(relay_future_indices >= 0, relay_future_indices, 0)
+    previous_verified_id, previous_token_list = _prepare_topk1_verify_placeholders_from_draft_state(
+        draft_worker, model_worker_batch
+    )
+    spec_info = model_worker_batch.spec_info_padded
+    return_target_logits = bool(
+        getattr(model_worker_batch, "return_logprob", False)
+        or getattr(model_worker_batch, "return_output_logprob_only", False)
+    )
+
+    spec_info.allocate_lens = cur_allocate_lens
+    spec_info.prepare_for_verify(model_worker_batch, spec_worker.page_size, target_worker)
+    target_mr.attn_backend.forward_metadata = target_mr.attn_backend.get_eagle_forward_metadata(
+        model_worker_batch
+    )
+    if use_relay_state and target_mr.attn_backend.forward_metadata.custom_mask is not None:
+        raise NotImplementedError("Spec decode overlap relay path does not support custom_mask.")
+    target_forward_batch = _forward_batch_init_new_preserve_device(model_worker_batch, target_mr)
+    target_forward_batch.bid = model_worker_batch.bid
+    target_logits_metadata = _logits_metadata_from_model_worker_batch_preserve_device(
+        model_worker_batch, spec_worker.mesh
+    )
+    data_sharding = NamedSharding(spec_worker.mesh, P("data"))
+    if relay_future_indices is None:
+        relay_future_indices = np.zeros(model_worker_batch.seq_lens.shape, dtype=np.int32)
+    relay_future_indices = _device_array_preserve_device(relay_future_indices, data_sharding)
+    verify_allocate_lens = np.zeros_like(model_worker_batch.seq_lens, dtype=np.int32)
+    verify_allocate_lens[model_worker_batch.logits_indices_selector] = cur_allocate_lens
+    verify_allocate_lens = _device_array_preserve_device(verify_allocate_lens, data_sharding)
+
+    if not hasattr(draft_worker, "_fused_greedy_verify_jit_fn"):
+        draft_worker._fused_greedy_verify_jit_fn = _build_fused_greedy_verify_jit(
+            topk=draft_worker.topk,
+        )
+
+    with jax.set_mesh(draft_worker.mesh), jtu.count_pjit_cpp_cache_miss() as count:
+        (
+            target_pool_updates,
+            prepared_hidden,
+            prepared_verified_id,
+            prepared_next_verified_id,
+            prepared_new_seq_lens,
+            prepared_accept_lens,
+            prepared_sel_pos,
+            prepared_predict,
+            prepared_positions,
+            prepared_verify_seq_lens,
+            target_logits,
+        ) = draft_worker._fused_greedy_verify_jit_fn(
+            target_mr._model_def,
+            target_mr._model_state_def,
+            tuple(target_mr.model_state_leaves),
+            target_forward_batch,
+            target_mr.memory_pools,
+            target_logits_metadata,
+            previous_verified_id,
+            previous_token_list,
+            getattr(spec_worker, "spec_relay_buffers", None),
+            relay_future_indices,
+            verify_allocate_lens,
+            speculative_num_steps=draft_worker.speculative_num_steps,
+            speculative_num_draft_tokens=draft_worker.speculative_num_draft_tokens,
+            return_target_logits=return_target_logits,
+            use_relay_state=use_relay_state,
+            dp_size=model_worker_batch.dp_size,
+        )
+        cache_miss_count = count()
+
+    target_mr.memory_pools.replace_all(target_pool_updates)
+
+    next_draft_input = EagleDraftInput(
+        verified_id=prepared_verified_id,
+        new_seq_lens=prepared_new_seq_lens,
+        allocate_lens=cur_allocate_lens,
+        hidden_states=prepared_hidden,
+    )
+    next_draft_input.next_verified_id = prepared_next_verified_id
+    next_draft_input.sel_pos = prepared_sel_pos
+    next_draft_input.positions = prepared_positions
+    next_draft_input.verify_seq_lens = prepared_verify_seq_lens
+    batch_output = GenerationBatchResult(
+        logits_output=LogitsProcessorOutput(
+            next_token_logits=target_logits,
+            hidden_states=prepared_hidden,
+        ),
+        next_token_ids=prepared_predict,
+        next_draft_input=next_draft_input,
+        accept_lens=prepared_accept_lens,
+        bid=model_worker_batch.bid,
+        cache_miss_count=cache_miss_count,
+        extend_input_len_per_req=None,
+        extend_logprob_start_len_per_req=None,
+    )
+    model_worker_batch.spec_info_padded = next_draft_input
+    return batch_output
+
+
+def spec_decode_draft_extend_phase(spec_worker, model_worker_batch, batch_output):
+    """Run MTP draft extend as the second speculative decode JIT."""
+    spec_worker.draft_worker.draft_extend_for_decode(model_worker_batch, batch_output)
+    return batch_output
+
+
+def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
+    """Run speculative decode as verify JIT followed by draft-extend JIT."""
+    batch_output = spec_decode_verify_phase(spec_worker, model_worker_batch, cur_allocate_lens)
+    return spec_decode_draft_extend_phase(spec_worker, model_worker_batch, batch_output)
+
+
+def spec_decode_overlap(spec_worker, model_worker_batch, cur_allocate_lens):
+    """Launch decode verify and draft-extend without restoring draft results inline."""
+    batch_output = spec_decode_verify_phase(spec_worker, model_worker_batch, cur_allocate_lens)
+    sel = np.asarray(model_worker_batch.logits_indices_selector)
+    batch_output.next_draft_input.future_indices = np.asarray(model_worker_batch.req_pool_indices)[
+        sel
+    ]
+
+    from sgl_jax.srt.speculative.overlap_utils import publish_spec_decode_new_seq_lens
+    from sgl_jax.srt.speculative.relay_buffer import make_dp_valid_mask
+
+    published_new_seq_lens = publish_spec_decode_new_seq_lens(batch_output)
+    valid_mask = make_dp_valid_mask(
+        model_worker_batch.real_bs_per_dp,
+        total_bs=model_worker_batch.req_pool_indices.shape[0],
+        per_dp_bs=model_worker_batch.per_dp_bs_size,
+    )
+    safe_indices = np.where(
+        valid_mask,
+        np.asarray(model_worker_batch.req_pool_indices, dtype=np.int32),
+        0,
+    )
+    pending_result = launch_fused_draft_extend_for_decode(
+        spec_worker.draft_worker,
+        model_worker_batch,
+        batch_output,
+        relay_buffers=spec_worker.spec_relay_buffers,
+        relay_future_indices=safe_indices,
+        relay_valid_mask=valid_mask,
+    )
+    if pending_result is not None:
+        spec_worker.spec_relay_buffers = pending_result.updated_relay_buffers
+    batch_output.next_draft_input.new_seq_lens = None
+    return batch_output, published_new_seq_lens

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -21,6 +21,7 @@ from sgl_jax.srt.speculative.eagle_util import (
     EagleDraftInput,
     EagleVerifyInput,
     build_chain_verify_inputs,
+    build_chain_verify_inputs_device,
     build_tree_kernel_efficient,
     build_tree_mask_for_draft_decode,
 )
@@ -140,18 +141,33 @@ class EagleDraftWorker(BaseDraftWorker):
         bs = model_worker_batch.seq_lens.shape[0]
 
         if self.topk == 1:
-            token_list_cpu = np.asarray(jax.device_get(token_list))
-            verified_id_cpu = np.asarray(
-                jax.device_get(model_worker_batch.spec_info_padded.verified_id)
-            )
-            seq_lens_cpu = np.asarray(verified_seq_lens)
             n = self.speculative_num_draft_tokens
-            packed_np = build_chain_verify_inputs(
-                verified_id_cpu, token_list_cpu, seq_lens_cpu, n, bs
-            )
-            # One allgather instead of five: pack into a single (5, bs*n) buffer,
-            # device_put once, then slice on device (replicated views are free).
-            packed = jax.device_put(packed_np, NamedSharding(self.mesh, P()))
+            verified_id = model_worker_batch.spec_info_padded.verified_id
+            if any(isinstance(x, jax.Array) for x in (verified_id, token_list, verified_seq_lens)):
+                rep = NamedSharding(self.mesh, P())
+                verified_id, token_list, verified_seq_lens = jax.device_put(
+                    (verified_id, token_list, verified_seq_lens),
+                    rep,
+                )
+                packed = build_chain_verify_inputs_device(
+                    verified_id, token_list, verified_seq_lens, n, bs
+                )
+                packed = jax.device_put(packed, rep)
+            else:
+                packed_np = build_chain_verify_inputs(
+                    np.asarray(verified_id, dtype=np.int32),
+                    np.asarray(token_list, dtype=np.int32),
+                    np.asarray(verified_seq_lens, dtype=np.int32),
+                    n,
+                    bs,
+                )
+                # One allgather instead of five: pack into a single (5, bs*n)
+                # buffer, device_put once, then slice on device.
+                packed = (
+                    jax.device_put(packed_np, NamedSharding(self.mesh, P()))
+                    if self.mesh is not None
+                    else packed_np
+                )
             draft_tokens = packed[0]
             position = packed[1]
             retrive_index = packed[2].reshape(bs, n)

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -278,7 +278,7 @@ class EagleDraftWorker(BaseDraftWorker):
             return
         draft_input = EagleDraftInput(
             hidden_states=batch_output.logits_output.hidden_states,
-            allocate_lens=batch_output.allocate_lens,
+            allocate_lens=batch_output.next_draft_input.allocate_lens,
         )
         model_worker_batch, logits_metadata = draft_input.prepare_for_extend_after_verify(
             model_worker_batch,
@@ -321,7 +321,9 @@ class EagleDraftWorker(BaseDraftWorker):
         batch_output.next_draft_input.topk_p = topk_p
         batch_output.next_draft_input.topk_index = topk_index
         batch_output.next_draft_input.verified_id = verified_id
-        batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
+        batch_output.next_draft_input.allocate_lens = batch_output.next_draft_input.allocate_lens[
+            : model_worker_batch.real_bs
+        ]
         batch_output.accept_lens = accept_host
 
     # -- Internal draft helpers --
@@ -357,9 +359,6 @@ class EagleDraftWorker(BaseDraftWorker):
         seq_lens_cpu = model_worker_batch.seq_lens
         page_size = self.page_size
         req_to_token_pool, _ = self.target_worker_ref.get_memory_pool()
-        token_indices_with_all_reqs = req_to_token_pool.req_to_token[
-            model_worker_batch.req_pool_indices
-        ]
         spec_info = model_worker_batch.spec_info_padded
         assert isinstance(spec_info, EagleDraftInput)
         # At dp>1 spec_info arrays arrive at (real_bs,) but seq_lens_cpu is
@@ -393,8 +392,9 @@ class EagleDraftWorker(BaseDraftWorker):
                 assert (
                     base + aligned_len <= (r + 1) * per_dp_cache_len
                 ), f"rank {r} cache_loc overflow: {intra_rank_off[r]+aligned_len} > {per_dp_cache_len}"
-                cache_loc_cpu[base : base + allocate_len] = token_indices_with_all_reqs[
-                    seq_idx, :allocate_len
+                page_offsets = np.arange(0, aligned_len, page_size)
+                cache_loc_cpu[base + page_offsets] = req_to_token_pool.req_to_token[
+                    model_worker_batch.req_pool_indices[seq_idx], page_offsets
                 ]
                 intra_rank_off[r] += aligned_len
 
@@ -403,7 +403,7 @@ class EagleDraftWorker(BaseDraftWorker):
 
         topk_index = spec_info.topk_index
         if self.hot_token_ids is not None:
-            model_worker_batch.spec_info_padded.topk_index = self.hot_token_ids[topk_index]
+            model_worker_batch.spec_info_padded.topk_index = self._map_hot_token_ids(topk_index)
         if self.topk > 1:
             self.draft_model_runner.attn_backend.forward_metadata.custom_mask = (
                 build_tree_mask_for_draft_decode(
@@ -508,10 +508,14 @@ class EagleDraftWorker(BaseDraftWorker):
             topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
 
             if self.hot_token_ids is not None:
-                topk_index = self.hot_token_ids[topk_index]
+                topk_index = self._map_hot_token_ids(topk_index)
             hidden_states = replicate_to_mesh(self.mesh, logits_output.hidden_states)
 
         return score_list, token_list, parents_list
+
+    def _map_hot_token_ids(self, topk_index):
+        out_sharding = jax.typeof(topk_index).sharding
+        return self.hot_token_ids.at[topk_index].get(out_sharding=out_sharding)
 
     def _pick_context_len(self, max_seq_len: int) -> int:
         if self.precompile_token_paddings:
@@ -611,21 +615,28 @@ def update_eagle_lists(
 ):
     bs = score_list.shape[0]
     scores_update, tokens_update, parents_update = tree_info
+    score_sharding = jax.typeof(scores_update).sharding
+    token_sharding = jax.typeof(tokens_update).sharding
+    parent_sharding = jax.typeof(parents_update).sharding
     if i == 0:
-        score_list = score_list.at[:bs, :1, :].set(scores_update[:bs])
-        token_list = token_list.at[:bs, :topk].set(tokens_update[:bs])
-        parents_list = parents_list.at[:bs, : topk + 1].set(parents_update[:bs])
+        score_list = score_list.at[:bs, :1, :].set(scores_update[:bs], out_sharding=score_sharding)
+        token_list = token_list.at[:bs, :topk].set(tokens_update[:bs], out_sharding=token_sharding)
+        parents_list = parents_list.at[:bs, : topk + 1].set(
+            parents_update[:bs], out_sharding=parent_sharding
+        )
     else:
         score_start = 1 + (i - 1) * topk
         token_start = topk + (i - 1) * topk * topk
         parent_start = topk + 1 + (i - 1) * topk
 
-        score_list = score_list.at[:bs, score_start : score_start + topk, :].set(scores_update[:bs])
+        score_list = score_list.at[:bs, score_start : score_start + topk, :].set(
+            scores_update[:bs], out_sharding=score_sharding
+        )
         token_list = token_list.at[:bs, token_start : token_start + topk * topk].set(
-            tokens_update[:bs]
+            tokens_update[:bs], out_sharding=token_sharding
         )
         parents_list = parents_list.at[:bs, parent_start : parent_start + topk].set(
-            parents_update[:bs]
+            parents_update[:bs], out_sharding=parent_sharding
         )
     return score_list, token_list, parents_list
 
@@ -708,7 +719,9 @@ def select_top_k_tokens_step_greater_0(
         selected_input_index = topk_cs_index.flatten() // topk + jnp.repeat(
             jnp.arange(0, hidden_states.shape[0], topk), topk
         )
-        hidden_states = hidden_states[selected_input_index, :]
+        hidden_states = hidden_states.at[selected_input_index, :].get(
+            out_sharding=jax.typeof(hidden_states).sharding
+        )
     tree_info = (
         expand_scores,
         topk_index,

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -25,6 +25,7 @@ from sgl_jax.srt.speculative.eagle_util import (
     build_tree_kernel_efficient,
     build_tree_mask_for_draft_decode,
 )
+from sgl_jax.srt.speculative.overlap_utils import use_legacy_eagle3_non_overlap
 from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
 from sgl_jax.srt.utils.common_utils import get_bool_env_var
 from sgl_jax.srt.utils.jax_utils import device_array
@@ -359,6 +360,13 @@ class EagleDraftWorker(BaseDraftWorker):
         seq_lens_cpu = model_worker_batch.seq_lens
         page_size = self.page_size
         req_to_token_pool, _ = self.target_worker_ref.get_memory_pool()
+        legacy_non_overlap = use_legacy_eagle3_non_overlap(
+            not self.server_args.disable_overlap_schedule, self.speculative_algorithm
+        )
+        if legacy_non_overlap:
+            token_indices_with_all_reqs = req_to_token_pool.req_to_token[
+                model_worker_batch.req_pool_indices
+            ]
         spec_info = model_worker_batch.spec_info_padded
         assert isinstance(spec_info, EagleDraftInput)
         # At dp>1 spec_info arrays arrive at (real_bs,) but seq_lens_cpu is
@@ -392,10 +400,15 @@ class EagleDraftWorker(BaseDraftWorker):
                 assert (
                     base + aligned_len <= (r + 1) * per_dp_cache_len
                 ), f"rank {r} cache_loc overflow: {intra_rank_off[r]+aligned_len} > {per_dp_cache_len}"
-                page_offsets = np.arange(0, aligned_len, page_size)
-                cache_loc_cpu[base + page_offsets] = req_to_token_pool.req_to_token[
-                    model_worker_batch.req_pool_indices[seq_idx], page_offsets
-                ]
+                if legacy_non_overlap:
+                    cache_loc_cpu[base : base + allocate_len] = token_indices_with_all_reqs[
+                        seq_idx, :allocate_len
+                    ]
+                else:
+                    page_offsets = np.arange(0, aligned_len, page_size)
+                    cache_loc_cpu[base + page_offsets] = req_to_token_pool.req_to_token[
+                        model_worker_batch.req_pool_indices[seq_idx], page_offsets
+                    ]
                 intra_rank_off[r] += aligned_len
 
         model_worker_batch.cache_loc = cache_loc_cpu

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -20,6 +20,7 @@ from sgl_jax.srt.speculative.base_worker import BaseDraftWorker, replicate_to_me
 from sgl_jax.srt.speculative.eagle_util import (
     EagleDraftInput,
     EagleVerifyInput,
+    build_chain_verify_inputs,
     build_tree_kernel_efficient,
     build_tree_mask_for_draft_decode,
 )
@@ -136,29 +137,52 @@ class EagleDraftWorker(BaseDraftWorker):
         self.padding_for_decode(model_worker_batch)
         score_list, token_list, parents_list = self.draft_forward(model_worker_batch)
         verified_seq_lens = model_worker_batch.seq_lens - 1
-        max_seq_len = int(np.max(verified_seq_lens)) if verified_seq_lens.size > 0 else 1
-        max_context_len = self._pick_context_len(max_seq_len)
-        (
-            tree_mask,
-            position,
-            retrive_index,
-            retrive_next_token,
-            retrive_next_sibling,
-            draft_tokens,
-        ) = build_tree_kernel_efficient(
-            model_worker_batch.spec_info_padded.verified_id,
-            score_list,
-            token_list,
-            parents_list,
-            verified_seq_lens,
-            np.sum(verified_seq_lens),
-            self.topk,
-            self.speculative_num_draft_tokens,
-            max_context_len,
-            model_worker_batch.seq_lens.shape[0],
-            model_worker_batch.speculative_num_steps,
-            self.mesh,
-        )
+        bs = model_worker_batch.seq_lens.shape[0]
+
+        if self.topk == 1:
+            token_list_cpu = np.asarray(jax.device_get(token_list))
+            verified_id_cpu = np.asarray(
+                jax.device_get(model_worker_batch.spec_info_padded.verified_id)
+            )
+            seq_lens_cpu = np.asarray(verified_seq_lens)
+            n = self.speculative_num_draft_tokens
+            packed_np = build_chain_verify_inputs(
+                verified_id_cpu, token_list_cpu, seq_lens_cpu, n, bs
+            )
+            # One allgather instead of five: pack into a single (5, bs*n) buffer,
+            # device_put once, then slice on device (replicated views are free).
+            packed = jax.device_put(packed_np, NamedSharding(self.mesh, P()))
+            draft_tokens = packed[0]
+            position = packed[1]
+            retrive_index = packed[2].reshape(bs, n)
+            retrive_next_token = packed[3].reshape(bs, n)
+            retrive_next_sibling = packed[4].reshape(bs, n)
+            tree_mask = None
+        else:
+            max_seq_len = int(np.max(verified_seq_lens)) if verified_seq_lens.size > 0 else 1
+            max_context_len = self._pick_context_len(max_seq_len)
+            (
+                tree_mask,
+                position,
+                retrive_index,
+                retrive_next_token,
+                retrive_next_sibling,
+                draft_tokens,
+            ) = build_tree_kernel_efficient(
+                model_worker_batch.spec_info_padded.verified_id,
+                score_list,
+                token_list,
+                parents_list,
+                verified_seq_lens,
+                np.sum(verified_seq_lens),
+                self.topk,
+                self.speculative_num_draft_tokens,
+                max_context_len,
+                bs,
+                model_worker_batch.speculative_num_steps,
+                self.mesh,
+            )
+
         model_worker_batch.spec_info_padded = EagleVerifyInput(
             draft_token=draft_tokens,
             custom_mask=tree_mask,
@@ -255,7 +279,9 @@ class EagleDraftWorker(BaseDraftWorker):
             logits_metadata=logits_metadata,
         )
         sel = np.asarray(model_worker_batch.logits_indices_selector)
-        accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
+        if hasattr(batch_output.accept_lens, "copy_to_host_async"):
+            batch_output.accept_lens.copy_to_host_async()
+        accept_host = np.asarray(batch_output.accept_lens)
         select_index = sel * (self.speculative_num_steps + 1) + accept_host[sel] - 1
         rep_logits, rep_hidden = replicate_to_mesh(
             self.mesh, draft_logits_output.next_token_logits, draft_logits_output.hidden_states
@@ -478,42 +504,33 @@ class EagleDraftWorker(BaseDraftWorker):
         return 1 << (max_seq_len - 1).bit_length()
 
     def copy_model_worker_batch_to_cpu(self, model_worker_batch: ModelWorkerBatch):
-        model_worker_batch.input_ids = np.array(
-            jax.device_get(model_worker_batch.input_ids), dtype=model_worker_batch.input_ids.dtype
-        )
-        model_worker_batch.seq_lens = np.array(
-            jax.device_get(model_worker_batch.seq_lens), dtype=model_worker_batch.seq_lens.dtype
-        )
-        model_worker_batch.out_cache_loc = np.array(
-            jax.device_get(model_worker_batch.out_cache_loc),
-            dtype=model_worker_batch.out_cache_loc.dtype,
-        )
-        model_worker_batch.positions = np.array(
-            jax.device_get(model_worker_batch.positions), dtype=model_worker_batch.positions.dtype
-        )
-        model_worker_batch.req_pool_indices = np.array(
-            jax.device_get(model_worker_batch.req_pool_indices),
-            dtype=model_worker_batch.req_pool_indices.dtype,
-        )
-        model_worker_batch.cache_loc = np.array(
-            jax.device_get(model_worker_batch.cache_loc), dtype=model_worker_batch.cache_loc.dtype
-        )
-        model_worker_batch.extend_prefix_lens = (
-            np.array(
-                jax.device_get(model_worker_batch.extend_prefix_lens),
-                dtype=model_worker_batch.extend_prefix_lens.dtype,
-            )
-            if model_worker_batch.extend_prefix_lens is not None
-            else None
-        )
-        model_worker_batch.extend_seq_lens = (
-            np.array(
-                jax.device_get(model_worker_batch.extend_seq_lens),
-                dtype=model_worker_batch.extend_seq_lens.dtype,
-            )
-            if model_worker_batch.extend_seq_lens is not None
-            else None
-        )
+        mwb = model_worker_batch
+        fields = [
+            "input_ids",
+            "seq_lens",
+            "out_cache_loc",
+            "positions",
+            "req_pool_indices",
+            "cache_loc",
+        ]
+        optional = ["extend_prefix_lens", "extend_seq_lens"]
+
+        for name in fields:
+            arr = getattr(mwb, name)
+            if hasattr(arr, "copy_to_host_async"):
+                arr.copy_to_host_async()
+        for name in optional:
+            arr = getattr(mwb, name)
+            if arr is not None and hasattr(arr, "copy_to_host_async"):
+                arr.copy_to_host_async()
+
+        for name in fields:
+            arr = getattr(mwb, name)
+            setattr(mwb, name, np.asarray(arr))
+        for name in optional:
+            arr = getattr(mwb, name)
+            if arr is not None:
+                setattr(mwb, name, np.asarray(arr))
 
     def get_padding_bs(self, real_bs: int) -> int:
         self.precompile_bs_paddings.sort()

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -295,6 +295,51 @@ def build_tree_mask_for_draft_decode(
     return jnp.asarray(concatenated, dtype=jnp.int32)
 
 
+def build_chain_verify_inputs(
+    verified_id: np.ndarray,
+    token_list: np.ndarray,
+    seq_lens: np.ndarray,
+    num_verify_tokens: int,
+    batch_size: int,
+) -> np.ndarray:
+    """Build verify inputs for topk=1 (linear chain) without tree mask.
+
+    Returns a single ``(5, bs*n)`` int32 buffer packing all 5 outputs
+    [draft_tokens, positions, retrive_index, retrive_next_token,
+    retrive_next_sibling] so the caller can do **one** ``device_put``
+    instead of five — under multi-host setup each independent P() replicated
+    output triggers a separate allgather (~1.5ms each).
+
+    When topk=1 the draft tree is a simple chain, so causal attention is
+    equivalent to the tree mask.
+    """
+    n = num_verify_tokens
+    bs = batch_size
+    out = np.empty((5, bs * n), dtype=np.int32)
+
+    # row 0: draft_tokens (bs*n,)
+    out[0].reshape(bs, n)[:, 0] = verified_id
+    out[0].reshape(bs, n)[:, 1:] = token_list[:, : n - 1]
+
+    # row 1: positions (bs*n,) = seq_lens[bid] + tid
+    tid_range = np.arange(n, dtype=np.int32)
+    out[1] = (seq_lens.astype(np.int32)[:, None] + tid_range[None, :]).reshape(-1)
+
+    # row 2: retrive_index (bs, n) flattened: bid*n + tid
+    out[2] = np.arange(bs * n, dtype=np.int32)
+
+    # row 3: retrive_next_token (bs, n) flattened: chain → tid+1, last is -1
+    next_token_row = np.empty(n, dtype=np.int32)
+    next_token_row[: n - 1] = np.arange(1, n, dtype=np.int32)
+    next_token_row[n - 1] = -1
+    out[3] = np.broadcast_to(next_token_row, (bs, n)).reshape(-1)
+
+    # row 4: retrive_next_sibling: chain has no siblings, all -1
+    out[4].fill(-1)
+
+    return out
+
+
 def build_tree_kernel_efficient(
     verified_id: jax.Array,
     score_list: jax.Array,
@@ -649,12 +694,14 @@ class EagleDraftInput:
         dtype: np.dtype,
         topk: int,
         capture_hidden_mode: CaptureHiddenMode,
+        num_steps: int = 1,
     ):
+        topk_shape = (0, num_steps, topk) if num_steps > 1 else (0, topk)
         return cls(
             verified_id=np.empty((0,), dtype=np.int32),
             hidden_states=np.empty((0, hidden_size), dtype=dtype),
-            topk_p=np.empty((0, topk), dtype=np.float32),
-            topk_index=np.empty((0, topk), dtype=np.int32),
+            topk_p=np.empty(topk_shape, dtype=np.float32),
+            topk_index=np.empty(topk_shape, dtype=np.int32),
             capture_hidden_mode=capture_hidden_mode,
             accept_length=np.empty((0,), dtype=np.int32),
             accept_length_cpu=np.empty((0,), dtype=np.int32),
@@ -744,8 +791,8 @@ class EagleVerifyInput:
     #: device ``(b*draft_token_num,)`` — flattened draft tokens to verify.
     draft_token: jax.Array
     #: device ``(sum(q_i*kv_i),)`` — tree attention mask; shape participates
-    #: in the JIT cache key.
-    custom_mask: jax.Array
+    #: in the JIT cache key.  ``None`` when topk=1 (chain mode uses causal).
+    custom_mask: jax.Array | None
     #: device ``(b*draft_token_num,)`` — verify positions (follows
     #: ``ForwardBatch`` host/device convention).
     positions: jax.Array
@@ -996,9 +1043,12 @@ class EagleVerifyInput:
                 rng=rng,
             )
 
-        predict = np.asarray(jax.device_get(predict))
-        accept_index = np.asarray(jax.device_get(accept_index))
-        accept_length = np.asarray(jax.device_get(accept_length))
+        for arr in (predict, accept_index, accept_length):
+            if hasattr(arr, "copy_to_host_async"):
+                arr.copy_to_host_async()
+        predict = np.asarray(predict)
+        accept_index = np.asarray(accept_index)
+        accept_length = np.asarray(accept_length)
 
         accept_length = accept_length + 1
         accept_index = accept_index.flatten()

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -42,6 +42,7 @@ from sgl_jax.srt.mem_cache.common import (
     alloc_token_slots,
 )
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
+from sgl_jax.srt.speculative.overlap_utils import use_legacy_eagle3_non_overlap
 
 SIMULATE_ACC_LEN = os.environ.get("SIMULATE_ACC_LEN")
 SIMULATE_ACC_METHOD = os.environ.get("SIMULATE_ACC_METHOD", "multinomial")
@@ -621,6 +622,11 @@ class EagleDraftInput:
         batch_output: GenerationBatchResult,
         speculative_num_draft_tokens: int,
     ):
+        legacy_non_overlap = (
+            model_worker_batch.spec_algorithm is not None
+            and model_worker_batch.spec_algorithm.is_eagle3()
+            and getattr(batch_output.next_draft_input, "future_indices", None) is None
+        )
         model_worker_batch.spec_info_padded = self
         sel = model_worker_batch.logits_indices_selector
         model_worker_batch.seq_lens[sel] = (
@@ -629,7 +635,7 @@ class EagleDraftInput:
         bs = batch_output.accept_lens.shape[0]
         step_plus_1 = model_worker_batch.input_ids.shape[0] // bs
         positions = getattr(batch_output.next_draft_input, "positions", None)
-        if positions is not None:
+        if positions is not None and not legacy_non_overlap:
             model_worker_batch.positions = positions
         model_worker_batch.extend_seq_lens = np.zeros((bs,), dtype=np.int32)
         model_worker_batch.extend_seq_lens[sel] = step_plus_1
@@ -649,7 +655,7 @@ class EagleDraftInput:
         model_worker_batch.spec_info_padded.hidden_states = (
             batch_output.next_draft_input.hidden_states
         )
-        if model_worker_batch.spec_info_padded.accept_length is None:
+        if legacy_non_overlap or model_worker_batch.spec_info_padded.accept_length is None:
             model_worker_batch.spec_info_padded.accept_length = batch_output.accept_lens
         model_worker_batch.input_ids = batch_output.next_draft_input.verified_id
         forward_metadata = draft_model_runner.attn_backend.get_eagle_forward_metadata(
@@ -660,7 +666,7 @@ class EagleDraftInput:
         from sgl_jax.srt.layers.logits_processor import LogitsMetadata
         from sgl_jax.srt.utils.jax_utils import device_array
 
-        if model_worker_batch.return_logprob:
+        if legacy_non_overlap or model_worker_batch.return_logprob:
             logits_metadata = LogitsMetadata.from_model_worker_batch(
                 model_worker_batch, draft_model_runner.mesh
             )
@@ -727,13 +733,23 @@ class EagleDraftInput:
         page_size = schedule_batch.token_to_kv_pool_allocator.page_size
         new_alloc_chunks = []
         flat_off = 0
+        legacy_non_overlap = use_legacy_eagle3_non_overlap(
+            schedule_batch.enable_overlap, schedule_batch.spec_algorithm
+        )
         for dp_rank, info in enumerate(schedule_batch.reqs_info):
             if info.seq_lens is None or len(info.seq_lens) == 0:
                 continue
             bs_r = len(info.seq_lens)
-            old_r = np.asarray([req.kv_allocated_len for req in info.reqs], dtype=np.int32)
-            committed_r = np.asarray([req.kv_committed_len for req in info.reqs], dtype=np.int32)
-            new_r = np.maximum(old_r, committed_r + 2 * self.ALLOC_LEN_PER_DECODE)
+            if legacy_non_overlap:
+                seq_r = np.asarray(info.seq_lens)
+                new_r = seq_r + self.ALLOC_LEN_PER_DECODE - 1
+                old_r = self.allocate_lens[flat_off : flat_off + bs_r]
+            else:
+                old_r = np.asarray([req.kv_allocated_len for req in info.reqs], dtype=np.int32)
+                committed_r = np.asarray(
+                    [req.kv_committed_len for req in info.reqs], dtype=np.int32
+                )
+                new_r = np.maximum(old_r, committed_r + 2 * self.ALLOC_LEN_PER_DECODE)
             ext_r = int((new_r - old_r).sum())
             if page_size == 1:
                 ocl_r = alloc_token_slots(schedule_batch.tree_cache, ext_r, dp_rank=dp_rank)
@@ -761,7 +777,8 @@ class EagleDraftInput:
             for req, allocated_len in zip(info.reqs, new_r):
                 req.decode_batch_idx += 1
                 req.kv_allocated_len = int(allocated_len)
-                req.kv_committed_len += 1
+                if not legacy_non_overlap:
+                    req.kv_committed_len += 1
             flat_off += bs_r
             info.seq_lens_sum = np.sum(info.seq_lens).item()
 

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -576,10 +576,6 @@ class EagleDraftInput:
         return obj
 
     def prepare_for_extend_after_target_prefill(self, model_worker_batch: ModelWorkerBatch):
-
-        if model_worker_batch.forward_mode.is_idle():
-            return
-
         # Prefill only generate 1 token.
         assert (
             self.verified_id.shape[0] == model_worker_batch.real_bs
@@ -799,26 +795,6 @@ class EagleDraftInput:
 
         self.pending_draft_extend_result = None
         raise RuntimeError("Spec overlap relay path must not carry pending_draft_extend_result.")
-
-    @classmethod
-    def create_idle_input(
-        cls,
-        hidden_size: int,
-        dtype: np.dtype,
-        topk: int,
-        capture_hidden_mode: CaptureHiddenMode,
-        num_steps: int = 1,
-    ):
-        topk_shape = (0, num_steps, topk) if num_steps > 1 else (0, topk)
-        return cls(
-            verified_id=np.empty((0,), dtype=np.int32),
-            hidden_states=np.empty((0, hidden_size), dtype=dtype),
-            topk_p=np.empty(topk_shape, dtype=np.float32),
-            topk_index=np.empty(topk_shape, dtype=np.int32),
-            capture_hidden_mode=capture_hidden_mode,
-            accept_length=np.empty((0,), dtype=np.int32),
-            accept_length_cpu=np.empty((0,), dtype=np.int32),
-        )
 
     def _ensure_host(self):
         """Move device arrays to host (numpy) to avoid variable-shape device ops.
@@ -1079,9 +1055,6 @@ class EagleVerifyInput:
     def prepare_for_verify(
         self, model_worker_batch: ModelWorkerBatch, page_size: int, target_worker: ModelWorker
     ):
-        if model_worker_batch.forward_mode.is_idle():
-            return
-
         sel = model_worker_batch.logits_indices_selector
         model_worker_batch.seq_lens[sel] = model_worker_batch.seq_lens[sel] - 1
         model_worker_batch.input_ids = self.draft_token
@@ -1115,24 +1088,6 @@ class EagleVerifyInput:
         tokens. I.e., logits_output.next_token_logits only contains
         accepted token logits.
         """
-        if model_worker_batch.forward_mode.is_idle():
-            return EagleVerifyOutput(
-                draft_input=EagleDraftInput.create_idle_input(
-                    hidden_size=model_worker_batch.model_config.hidden_size,
-                    dtype=model_worker_batch.model_config.dtype,
-                    topk=self.topk,
-                    capture_hidden_mode=CaptureHiddenMode.LAST,
-                ),
-                logits_output=logits_output,
-                verified_id=jnp.empty(0, dtype=jnp.int32),
-                accept_length_per_req_cpu=[],
-                accepted_indices=jnp.full(
-                    (0, self.spec_steps + 1),
-                    -1,
-                    dtype=jnp.int32,
-                ),
-            )
-
         sampling_info = model_worker_batch.sampling_info
         bs = self.retrive_index.shape[0]
         if bs != len(sampling_info):

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -489,6 +489,9 @@ class EagleDraftInput:
     #: host ``(b,)`` — scheduler-visible logical length after verify. May be
     #: derived from ``old_seq_lens + accept_length`` if not stored.
     new_seq_lens: np.ndarray | None = None
+    #: host ``(b,)`` — req_pool_indices used to gather relay-buffer state.
+    future_indices: np.ndarray | None = None
+    pending_draft_extend_result: object | None = None
 
     # ---- SpecInput protocol -------------------------------------------------
     def is_draft_input(self) -> bool:
@@ -511,6 +514,17 @@ class EagleDraftInput:
     def get_verify_token_num(self, bs: int) -> int:
         return 0
 
+    def new_tokens_required_next_decode(self, requests, page_size: int) -> int:
+        target_alloc = self.ALLOC_LEN_PER_DECODE * 2
+        total = 0
+        for req in requests:
+            cur = req.kv_allocated_len
+            nxt = max(cur, req.kv_committed_len + target_alloc)
+            total += ((nxt + page_size - 1) // page_size) * page_size - (
+                (cur + page_size - 1) // page_size
+            ) * page_size
+        return total
+
     def tree_flatten(self):
         accept_length_cpu_arr = (
             np.empty((0,), dtype=np.int32)
@@ -531,6 +545,7 @@ class EagleDraftInput:
             self.kv_indices,
             self.seq_lens_for_draft_extend,
             self.req_pool_indices_for_draft_extend,
+            self.future_indices,
             accept_length_cpu_arr,
             num_tokens_per_batch_arr,
             num_tokens_for_logprob_arr,
@@ -554,10 +569,11 @@ class EagleDraftInput:
         obj.kv_indices = children[6]
         obj.seq_lens_for_draft_extend = children[7]
         obj.req_pool_indices_for_draft_extend = children[8]
+        obj.future_indices = children[9]
 
-        obj.accept_length_cpu = children[9]
-        obj.num_tokens_per_batch = children[10]
-        obj.num_tokens_for_logprob_per_batch = children[11]
+        obj.accept_length_cpu = children[10]
+        obj.num_tokens_per_batch = children[11]
+        obj.num_tokens_for_logprob_per_batch = children[12]
 
         return obj
 
@@ -615,7 +631,9 @@ class EagleDraftInput:
         )
         bs = batch_output.accept_lens.shape[0]
         step_plus_1 = model_worker_batch.input_ids.shape[0] // bs
-        model_worker_batch.positions = model_worker_batch.positions
+        positions = getattr(batch_output.next_draft_input, "positions", None)
+        if positions is not None:
+            model_worker_batch.positions = positions
         model_worker_batch.extend_seq_lens = np.zeros((bs,), dtype=np.int32)
         model_worker_batch.extend_seq_lens[sel] = step_plus_1
         # Per-rank-local cumsum: _select_hidden_states is a shard_map rank-local
@@ -642,10 +660,40 @@ class EagleDraftInput:
 
         draft_model_runner.attn_backend.forward_metadata = forward_metadata
         from sgl_jax.srt.layers.logits_processor import LogitsMetadata
+        from sgl_jax.srt.utils.jax_utils import device_array
 
-        logits_metadata = LogitsMetadata.from_model_worker_batch(
-            model_worker_batch, draft_model_runner.mesh
-        )
+        if model_worker_batch.return_logprob:
+            logits_metadata = LogitsMetadata.from_model_worker_batch(
+                model_worker_batch, draft_model_runner.mesh
+            )
+        else:
+            sharding = NamedSharding(draft_model_runner.mesh, P("data"))
+
+            def _to_device(value):
+                if value is None:
+                    return None
+                if isinstance(value, jax.Array):
+                    return jax.device_put(value, sharding)
+                return device_array(value, sharding=sharding)
+
+            logits_metadata = LogitsMetadata(
+                forward_mode=model_worker_batch.forward_mode,
+                capture_hidden_mode=model_worker_batch.capture_hidden_mode,
+                extend_return_logprob=False,
+                extend_return_top_logprob=False,
+                extend_token_ids_logprob=False,
+                extend_seq_lens=_to_device(model_worker_batch.extend_seq_lens),
+                logits_indices=_to_device(model_worker_batch.logits_indices),
+                accept_lens=_to_device(model_worker_batch.spec_info_padded.accept_length),
+                extend_seq_lens_cpu=None,
+                extend_logprob_start_lens_cpu=None,
+                extend_logprob_pruned_lens_cpu=None,
+                top_logprobs_nums=model_worker_batch.top_logprobs_nums,
+                token_ids_logprobs=model_worker_batch.token_ids_logprobs,
+                extend_input_logprob_token_ids_device=_to_device(
+                    model_worker_batch.extend_input_logprob_token_ids
+                ),
+            )
         return model_worker_batch, logits_metadata
 
     def prepare_for_decode(self, schedule_batch: ScheduleBatch):
@@ -664,9 +712,9 @@ class EagleDraftInput:
             if info.seq_lens is None or len(info.seq_lens) == 0:
                 continue
             bs_r = len(info.seq_lens)
-            seq_r = np.asarray(info.seq_lens)
-            new_r = seq_r + self.ALLOC_LEN_PER_DECODE - 1
-            old_r = self.allocate_lens[flat_off : flat_off + bs_r]
+            old_r = np.asarray([req.kv_allocated_len for req in info.reqs], dtype=np.int32)
+            committed_r = np.asarray([req.kv_committed_len for req in info.reqs], dtype=np.int32)
+            new_r = np.maximum(old_r, committed_r + 2 * self.ALLOC_LEN_PER_DECODE)
             ext_r = int((new_r - old_r).sum())
             if page_size == 1:
                 ocl_r = alloc_token_slots(schedule_batch.tree_cache, ext_r, dp_rank=dp_rank)
@@ -691,6 +739,10 @@ class EagleDraftInput:
             # Per-rank store (matches nospec extend); _get_spec_decode_mwb_dp
             # DP-segments these so each rank's P("data") shard = its own slots.
             info.out_cache_loc = np.asarray(ocl_r, dtype=np.int32)
+            for req, allocated_len in zip(info.reqs, new_r):
+                req.decode_batch_idx += 1
+                req.kv_allocated_len = int(allocated_len)
+                req.kv_committed_len += 1
             flat_off += bs_r
             info.seq_lens_sum = np.sum(info.seq_lens).item()
 
@@ -704,6 +756,13 @@ class EagleDraftInput:
         self.num_tokens_for_logprob_per_batch = topk
         model_worker_batch.return_hidden_states = False
         model_worker_batch.seq_lens_sum = np.sum(model_worker_batch.seq_lens)
+
+    def resolve_pending_draft_extend_result(self):
+        if self.pending_draft_extend_result is None:
+            return
+
+        self.pending_draft_extend_result = None
+        raise RuntimeError("Spec overlap relay path must not carry pending_draft_extend_result.")
 
     @classmethod
     def create_idle_input(
@@ -746,6 +805,23 @@ class EagleDraftInput:
 
     def filter_batch(self, new_indices: np.ndarray, has_been_filtered: bool = True):
         new_indices = np.asarray(new_indices)
+        if self.future_indices is not None:
+            src = np.asarray(self.future_indices)
+            idx = (
+                slice(0, len(new_indices))
+                if has_been_filtered and len(new_indices) == len(src)
+                else new_indices
+            )
+            self.future_indices = src[idx]
+            if self.allocate_lens is not None:
+                self.allocate_lens = np.asarray(self.allocate_lens)[idx]
+            if self.new_seq_lens is not None:
+                self.new_seq_lens = np.asarray(self.new_seq_lens)[idx]
+            if self.accept_length_cpu is not None:
+                self.accept_length_cpu = np.asarray(self.accept_length_cpu)[idx]
+            return
+
+        self.resolve_pending_draft_extend_result()
         self._ensure_host()
         if has_been_filtered and len(new_indices) == len(self.topk_p):
             self.topk_p = self.topk_p[: len(new_indices)]
@@ -754,6 +830,8 @@ class EagleDraftInput:
             self.verified_id = self.verified_id[: len(new_indices)]
             if self.allocate_lens is not None:
                 self.allocate_lens = np.asarray(self.allocate_lens)[: len(new_indices)]
+            if self.new_seq_lens is not None:
+                self.new_seq_lens = np.asarray(self.new_seq_lens)[: len(new_indices)]
         else:
             self.topk_p = self.topk_p[new_indices]
             self.topk_index = self.topk_index[new_indices]
@@ -761,13 +839,69 @@ class EagleDraftInput:
             self.verified_id = self.verified_id[new_indices]
             if self.allocate_lens is not None:
                 self.allocate_lens = np.asarray(self.allocate_lens)[new_indices]
+            if self.new_seq_lens is not None:
+                self.new_seq_lens = np.asarray(self.new_seq_lens)[new_indices]
+
+    def trim_to_length(self, n: int):
+        self.resolve_pending_draft_extend_result()
+        self._ensure_host()
+        for f in (
+            "topk_p",
+            "topk_index",
+            "hidden_states",
+            "verified_id",
+            "allocate_lens",
+            "new_seq_lens",
+            "accept_length",
+            "accept_length_cpu",
+            "future_indices",
+        ):
+            v = getattr(self, f, None)
+            if v is not None and len(v) != n:
+                setattr(self, f, np.asarray(v)[:n])
 
     def merge_batch(self, spec_info: EagleDraftInput):
+        if self.future_indices is not None or spec_info.future_indices is not None:
+            assert self.future_indices is not None and spec_info.future_indices is not None, (
+                "merge_batch requires both EagleDraftInput objects to carry future_indices "
+                "on the relay-buffer path"
+            )
+            self.future_indices = np.concatenate(
+                [np.asarray(self.future_indices), np.asarray(spec_info.future_indices)],
+                axis=0,
+            )
+            if self.allocate_lens is not None and spec_info.allocate_lens is not None:
+                self.allocate_lens = np.concatenate(
+                    [np.asarray(self.allocate_lens), np.asarray(spec_info.allocate_lens)],
+                    axis=0,
+                )
+            else:
+                self.allocate_lens = None
+            if self.new_seq_lens is not None and spec_info.new_seq_lens is not None:
+                self.new_seq_lens = np.concatenate(
+                    [np.asarray(self.new_seq_lens), np.asarray(spec_info.new_seq_lens)],
+                    axis=0,
+                )
+            else:
+                self.new_seq_lens = None
+            if self.accept_length_cpu is not None and spec_info.accept_length_cpu is not None:
+                self.accept_length_cpu = np.concatenate(
+                    [np.asarray(self.accept_length_cpu), np.asarray(spec_info.accept_length_cpu)],
+                    axis=0,
+                )
+            else:
+                self.accept_length_cpu = None
+            return
+
+        self.resolve_pending_draft_extend_result()
+        spec_info.resolve_pending_draft_extend_result()
         if self.hidden_states is None:
             self.hidden_states = spec_info.hidden_states
             self.verified_id = spec_info.verified_id
             self.topk_p = spec_info.topk_p
             self.topk_index = spec_info.topk_index
+            self.allocate_lens = spec_info.allocate_lens
+            self.new_seq_lens = spec_info.new_seq_lens
             return
         if spec_info.hidden_states is None:
             return
@@ -778,6 +912,12 @@ class EagleDraftInput:
         self.topk_p = np.concatenate([self.topk_p, spec_info.topk_p])
         self.topk_index = np.concatenate([self.topk_index, spec_info.topk_index])
         self.allocate_lens = np.concatenate([self.allocate_lens, spec_info.allocate_lens])
+        if self.new_seq_lens is not None and spec_info.new_seq_lens is not None:
+            self.new_seq_lens = np.concatenate(
+                [np.asarray(self.new_seq_lens), np.asarray(spec_info.new_seq_lens)]
+            )
+        else:
+            self.new_seq_lens = None
 
 
 @dataclass

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -56,22 +56,22 @@ def _is_jax_leaf(value: Any) -> bool:
     return cls.__name__ == "Leaf" and cls.__module__.startswith("jax.")
 
 
-def _as_int32_array(value: Any, *, fallback: int = -1) -> jax.Array:
-    """Convert scalar-like inputs into scalar int32 JAX arrays."""
+def _as_int32_array(value: Any, *, fallback: int = -1) -> Any:
+    """Convert scalar-like metadata into int32 arrays without forcing device work."""
     if value is None:
         return None
     if isinstance(value, jax.Array):
         return value
     if isinstance(value, numpy.ndarray):
-        return jnp.asarray(value, dtype=jnp.int32)
+        return np.asarray(value, dtype=np.int32)
     if isinstance(value, (int, numpy.integer)):
-        return jnp.asarray(int(value), dtype=jnp.int32)
+        return np.asarray(int(value), dtype=np.int32)
     if isinstance(value, (list, tuple)):
-        return jnp.asarray(value, dtype=jnp.int32)
+        return np.asarray(value, dtype=np.int32)
     if _is_jax_leaf(value):
-        return jnp.asarray(fallback, dtype=jnp.int32)
+        return np.asarray(fallback, dtype=np.int32)
     try:
-        return jnp.asarray(value, dtype=jnp.int32)
+        return np.asarray(value, dtype=np.int32)
     except (TypeError, ValueError) as exc:
         raise TypeError(
             f"Unable to convert value of type {type(value)} into int32 metadata array."
@@ -340,6 +340,35 @@ def build_chain_verify_inputs(
     return out
 
 
+@functools.partial(jax.jit, static_argnames=["num_verify_tokens", "batch_size"])
+def build_chain_verify_inputs_device(
+    verified_id: jax.Array,
+    token_list: jax.Array,
+    seq_lens: jax.Array,
+    num_verify_tokens: int,
+    batch_size: int,
+) -> jax.Array:
+    """Build verify inputs for topk=1 linear chains on device."""
+    n = num_verify_tokens
+    bs = batch_size
+    tid_range = jnp.arange(n, dtype=jnp.int32)
+    draft_tokens = jnp.concatenate(
+        [verified_id.astype(jnp.int32)[:, None], token_list[:, : n - 1].astype(jnp.int32)],
+        axis=1,
+    ).reshape(bs * n)
+    positions = (seq_lens.astype(jnp.int32)[:, None] + tid_range[None, :]).reshape(bs * n)
+    retrive_index = jnp.arange(bs * n, dtype=jnp.int32)
+    retrive_next_token = jnp.broadcast_to(
+        jnp.concatenate([jnp.arange(1, n, dtype=jnp.int32), jnp.array([-1], dtype=jnp.int32)]),
+        (bs, n),
+    ).reshape(bs * n)
+    retrive_next_sibling = jnp.full((bs * n,), -1, dtype=jnp.int32)
+    return jnp.stack(
+        [draft_tokens, positions, retrive_index, retrive_next_token, retrive_next_sibling],
+        axis=0,
+    )
+
+
 def build_tree_kernel_efficient(
     verified_id: jax.Array,
     score_list: jax.Array,
@@ -385,18 +414,7 @@ def build_tree_kernel_efficient(
         speculative_num_steps,
     )
 
-    # Get batch size
-    # for compatibility, 0.6.3 need to use use_mesh. set_mesh is not have __entry__ attribute.
-    # on jax >=0.7.1, we need to use set_mesh.
-    try:
-        ctx = jax.sharding.use_mesh(mesh)
-    except AttributeError:
-        try:
-            ctx = jax.set_mesh(mesh)
-        except AttributeError:
-            ctx = mesh
-    with ctx:
-
+    with jax.set_mesh(mesh):
         tree_mask, positions, retrive_index, retrive_next_token, retrive_next_sibling = (
             build_eagle_tree_structure(
                 parent_list=parent_list,
@@ -495,7 +513,7 @@ class EagleDraftInput:
 
     def tree_flatten(self):
         accept_length_cpu_arr = (
-            jnp.empty((0,), dtype=jnp.int32)
+            np.empty((0,), dtype=np.int32)
             if self.accept_length_cpu is None
             else _as_int32_array(self.accept_length_cpu, fallback=0)
         )
@@ -960,16 +978,7 @@ class EagleVerifyInput:
         is_all_greedy = sampling_info.is_all_greedy
 
         if is_all_greedy:
-            # # for compatibility, 0.6.3 need to use use_mesh. set_mesh is not have __entry__ attribute.
-            # # on jax >=0.7.1, we need to use set_mesh.
-            try:
-                ctx = jax.sharding.use_mesh(mesh)
-            except AttributeError:
-                try:
-                    ctx = jax.set_mesh(mesh)
-                except AttributeError:
-                    ctx = mesh
-            with ctx:
+            with jax.set_mesh(mesh):
                 accept_index, accept_length, predict = verify_tree_greedy(
                     speculative_num_steps=self.spec_steps,
                     num_draft_tokens=self.draft_token_num,

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import functools
-import logging
 import os
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -43,8 +42,6 @@ from sgl_jax.srt.mem_cache.common import (
     alloc_token_slots,
 )
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
-
-logger = logging.getLogger(__name__)
 
 SIMULATE_ACC_LEN = os.environ.get("SIMULATE_ACC_LEN")
 SIMULATE_ACC_METHOD = os.environ.get("SIMULATE_ACC_METHOD", "multinomial")
@@ -652,7 +649,8 @@ class EagleDraftInput:
         model_worker_batch.spec_info_padded.hidden_states = (
             batch_output.next_draft_input.hidden_states
         )
-        model_worker_batch.spec_info_padded.accept_length = batch_output.accept_lens
+        if model_worker_batch.spec_info_padded.accept_length is None:
+            model_worker_batch.spec_info_padded.accept_length = batch_output.accept_lens
         model_worker_batch.input_ids = batch_output.next_draft_input.verified_id
         forward_metadata = draft_model_runner.attn_backend.get_eagle_forward_metadata(
             model_worker_batch
@@ -669,12 +667,30 @@ class EagleDraftInput:
         else:
             sharding = NamedSharding(draft_model_runner.mesh, P("data"))
 
-            def _to_device(value):
+            def _to_device(name, value):
                 if value is None:
                     return None
                 if isinstance(value, jax.Array):
+                    current_sharding = value.sharding
+                    if current_sharding == sharding:
+                        return value
                     return jax.device_put(value, sharding)
                 return device_array(value, sharding=sharding)
+
+            extend_seq_lens_for_logits = getattr(
+                model_worker_batch.spec_info_padded,
+                "extend_seq_lens_for_draft_extend",
+                None,
+            )
+            if extend_seq_lens_for_logits is None:
+                extend_seq_lens_for_logits = model_worker_batch.extend_seq_lens
+            logits_indices_for_logits = getattr(
+                model_worker_batch.spec_info_padded,
+                "logits_indices_for_draft_extend",
+                None,
+            )
+            if logits_indices_for_logits is None:
+                logits_indices_for_logits = model_worker_batch.logits_indices
 
             logits_metadata = LogitsMetadata(
                 forward_mode=model_worker_batch.forward_mode,
@@ -682,16 +698,19 @@ class EagleDraftInput:
                 extend_return_logprob=False,
                 extend_return_top_logprob=False,
                 extend_token_ids_logprob=False,
-                extend_seq_lens=_to_device(model_worker_batch.extend_seq_lens),
-                logits_indices=_to_device(model_worker_batch.logits_indices),
-                accept_lens=_to_device(model_worker_batch.spec_info_padded.accept_length),
+                extend_seq_lens=_to_device("extend_seq_lens", extend_seq_lens_for_logits),
+                logits_indices=_to_device("logits_indices", logits_indices_for_logits),
+                accept_lens=_to_device(
+                    "accept_lens", model_worker_batch.spec_info_padded.accept_length
+                ),
                 extend_seq_lens_cpu=None,
                 extend_logprob_start_lens_cpu=None,
                 extend_logprob_pruned_lens_cpu=None,
                 top_logprobs_nums=model_worker_batch.top_logprobs_nums,
                 token_ids_logprobs=model_worker_batch.token_ids_logprobs,
                 extend_input_logprob_token_ids_device=_to_device(
-                    model_worker_batch.extend_input_logprob_token_ids
+                    "extend_input_logprob_token_ids",
+                    model_worker_batch.extend_input_logprob_token_ids,
                 ),
             )
         return model_worker_batch, logits_metadata
@@ -1255,35 +1274,6 @@ def _generate_simulated_accept_index(
     accept_length = accept_length.at[:].set(simulate_acc_len - 1)
     predict = predict.at[:].set(100)  # some legit token id
     return sim_accept_index, accept_length, predict
-
-
-def get_src_tgt_cache_loc(
-    seq_lens: np.ndarray,
-    out_cache_loc: np.ndarray,
-    accept_index: np.ndarray,
-    accept_length: np.ndarray,
-    draft_token_num: int,
-    page_size: int,
-):
-    src_cache_loc = out_cache_loc[accept_index]
-    extended_len = seq_lens + draft_token_num
-    keep_len = np.minimum(
-        (seq_lens + accept_length + 1 + page_size - 1) // page_size * page_size,
-        extended_len,
-    )
-    to_free_num_slots = extended_len - keep_len
-    return src_cache_loc, to_free_num_slots
-
-
-def create_accept_length_filter(
-    accept_length: np.ndarray,
-    unfinished_index_device: np.ndarray,
-    seq_lens: np.ndarray,
-):
-    accept_length_filter = jnp.zeros_like(accept_length)
-    accept_length_filter[unfinished_index_device] = accept_length[unfinished_index_device] + 1
-    seq_lens.add_(accept_length + 1)
-    return accept_length_filter
 
 
 def assign_req_to_token_pool(

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -5,6 +5,8 @@ import time
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 from tqdm import tqdm
 
 from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
@@ -112,6 +114,8 @@ class EAGLEWorker(BaseSpecWorker):
     # -- Precompilation --
 
     def run_spec_decode_precompile(self):
+        if not self.server_args.disable_overlap_schedule:
+            self.init_spec_relay_buffers()
         self.precompile_spec_extend()
         self.precompile_spec_decode()
         # FIXME precompile some kernel
@@ -152,7 +156,16 @@ class EAGLEWorker(BaseSpecWorker):
                     dp_size=dp_size,
                     per_dp_bs_size=per_dp_bs,
                 )
-                self.forward_batch_speculative_generation(model_worker_batch)
+                if not self._can_use_fused_spec_prefill(model_worker_batch):
+                    logger.warning(
+                        "[SPEC_EXTEND] skip fused precompile because fused spec prefill is disabled"
+                    )
+                    continue
+                if self.spec_relay_buffers is not None:
+                    self.forward_batch_speculative_prefill_overlap(model_worker_batch)
+                    jax.block_until_ready(self.spec_relay_buffers)
+                else:
+                    self.forward_batch_speculative_generation(model_worker_batch)
         end_time = time.perf_counter()
         logger.info("[SPEC_EXTEND] Precompile finished in %.0f secs", end_time - start_time)
 
@@ -181,55 +194,98 @@ class EAGLEWorker(BaseSpecWorker):
                     // self.page_size
                     * self.page_size
                 )
-                model_worker_batch = self.draft_worker.compilation_manager._make_dummy_batch(
-                    bs,
-                    bs,
-                    ForwardMode.DECODE,
-                    aligned_cache_loc_size,
-                    speculative_algorithm=self.speculative_algorithm,
-                    dp_size=dp_size,
-                    per_dp_bs_size=per_dp_bs,
-                )
+
+                def _make_decode_batch(
+                    *,
+                    bs=bs,
+                    per_dp_bs=per_dp_bs,
+                    aligned_cache_loc_size=aligned_cache_loc_size,
+                ):
+                    batch = self.draft_worker.compilation_manager._make_dummy_batch(
+                        bs,
+                        bs,
+                        ForwardMode.DECODE,
+                        aligned_cache_loc_size,
+                        speculative_algorithm=self.speculative_algorithm,
+                        dp_size=dp_size,
+                        per_dp_bs_size=per_dp_bs,
+                    )
+                    # Pad out_cache_loc to the conservative decode allocation
+                    # bucket used by runtime _get_spec_decode_mwb_dp.
+                    ocl_target = bs * self.speculative_num_draft_tokens * 2
+                    if batch.out_cache_loc.shape[0] < ocl_target:
+                        pad_len = ocl_target - batch.out_cache_loc.shape[0]
+                        batch.out_cache_loc = np.concatenate(
+                            [
+                                np.asarray(batch.out_cache_loc, dtype=np.int32),
+                                np.full(pad_len, -1, dtype=np.int32),
+                            ]
+                        )
+                    return batch
+
+                model_worker_batch = _make_decode_batch()
+                assert not model_worker_batch.return_logprob
+                assert not model_worker_batch.return_output_logprob_only
+                assert model_worker_batch.sampling_info.is_all_greedy
                 num_steps = self.speculative_num_steps
                 from sgl_jax.srt.speculative.multi_layer_draft_worker import (
                     MultiLayerDraftWorker,
                 )
 
                 is_multi_layer = isinstance(self.draft_worker, MultiLayerDraftWorker)
-                topk_shape = (bs, num_steps, self.topk) if is_multi_layer else (bs, self.topk)
+                if is_multi_layer and self.topk == 1:
+                    topk_shape = (bs, num_steps)
+                else:
+                    topk_shape = (bs, num_steps, self.topk) if is_multi_layer else (bs, self.topk)
+                data_sharding = NamedSharding(self.mesh, P("data"))
                 spec_info = EagleDraftInput(
-                    topk_p=jnp.ones(
-                        topk_shape,
-                        dtype=jnp.bfloat16 if self.server_args.dtype == "bfloat16" else jnp.float32,
-                    ),
-                    topk_index=jnp.ones(topk_shape, dtype=jnp.int32),
-                    hidden_states=jnp.ones(
+                    topk_p=jax.device_put(np.ones(topk_shape, dtype=np.float32), data_sharding),
+                    topk_index=jax.device_put(np.ones(topk_shape, dtype=np.int32), data_sharding),
+                    hidden_states=np.ones(
                         (bs, self.draft_worker.model_config.hidden_size),
-                        dtype=jnp.bfloat16 if self.server_args.dtype == "bfloat16" else jnp.float32,
+                        dtype=(
+                            jnp.bfloat16 if self.server_args.dtype == "bfloat16" else np.float32
+                        ),
                     ),
-                    verified_id=jnp.ones((bs,), dtype=jnp.int32),
-                    accept_length=jnp.ones((bs,), dtype=jnp.int32),
-                    capture_hidden_mode=CaptureHiddenMode.LAST,
+                    verified_id=jax.device_put(np.ones((bs,), dtype=np.int32), data_sharding),
+                    capture_hidden_mode=CaptureHiddenMode.FULL,
+                    num_tokens_per_batch=np.asarray(1, dtype=np.int32),
+                    num_tokens_for_logprob_per_batch=np.asarray(1, dtype=np.int32),
                     allocate_lens=model_worker_batch.seq_lens
                     + EagleDraftInput.ALLOC_LEN_PER_DECODE,
                 )
+                if self.spec_relay_buffers is not None:
+                    model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
+                    model_worker_batch.spec_info_padded = spec_info
+                    model_worker_batch.speculative_eagle_topk = self.topk
+                    model_worker_batch.speculative_num_draft_tokens = (
+                        self.speculative_num_draft_tokens
+                    )
+                    model_worker_batch.speculative_num_steps = self.speculative_num_steps
+                    self.forward_batch_speculative_decode_overlap(model_worker_batch)
+                    jax.block_until_ready(self.spec_relay_buffers)
+
+                    model_worker_batch = _make_decode_batch()
+                    spec_info = EagleDraftInput(
+                        future_indices=np.asarray(
+                            model_worker_batch.req_pool_indices, dtype=np.int32
+                        ),
+                        capture_hidden_mode=CaptureHiddenMode.FULL,
+                        num_tokens_per_batch=np.asarray(1, dtype=np.int32),
+                        num_tokens_for_logprob_per_batch=np.asarray(1, dtype=np.int32),
+                        allocate_lens=model_worker_batch.seq_lens
+                        + EagleDraftInput.ALLOC_LEN_PER_DECODE,
+                    )
                 model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
                 model_worker_batch.spec_info_padded = spec_info
                 model_worker_batch.speculative_eagle_topk = self.topk
                 model_worker_batch.speculative_num_draft_tokens = self.speculative_num_draft_tokens
                 model_worker_batch.speculative_num_steps = self.speculative_num_steps
-                # Pad out_cache_loc to bs * draft_token_num so verify/draft_extend
-                # forward see the same shape runtime _get_spec_decode_mwb_dp emits.
-                ocl_target = bs * self.speculative_num_draft_tokens
-                if model_worker_batch.out_cache_loc.shape[0] < ocl_target:
-                    pad_len = ocl_target - model_worker_batch.out_cache_loc.shape[0]
-                    model_worker_batch.out_cache_loc = np.concatenate(
-                        [
-                            np.asarray(model_worker_batch.out_cache_loc, dtype=np.int32),
-                            np.full(pad_len, -1, dtype=np.int32),
-                        ]
-                    )
-                self.forward_batch_speculative_generation(model_worker_batch)
+                if self.spec_relay_buffers is not None:
+                    self.forward_batch_speculative_decode_overlap(model_worker_batch)
+                    jax.block_until_ready(self.spec_relay_buffers)
+                else:
+                    self.forward_batch_speculative_generation(model_worker_batch)
 
         end_time = time.perf_counter()
         logger.info("[SPEC_DECODE] Precompile finished in %.0f secs", end_time - start_time)

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -190,13 +190,19 @@ class EAGLEWorker(BaseSpecWorker):
                     dp_size=dp_size,
                     per_dp_bs_size=per_dp_bs,
                 )
+                num_steps = self.speculative_num_steps
+                from sgl_jax.srt.speculative.multi_layer_draft_worker import (
+                    MultiLayerDraftWorker,
+                )
+
+                is_multi_layer = isinstance(self.draft_worker, MultiLayerDraftWorker)
+                topk_shape = (bs, num_steps, self.topk) if is_multi_layer else (bs, self.topk)
                 spec_info = EagleDraftInput(
-                    # FIXME(pc) dtype should according to serverargs
                     topk_p=jnp.ones(
-                        (bs, self.topk),
+                        topk_shape,
                         dtype=jnp.bfloat16 if self.server_args.dtype == "bfloat16" else jnp.float32,
                     ),
-                    topk_index=jnp.ones((bs, self.topk), dtype=jnp.int32),
+                    topk_index=jnp.ones(topk_shape, dtype=jnp.int32),
                     hidden_states=jnp.ones(
                         (bs, self.draft_worker.model_config.hidden_size),
                         dtype=jnp.bfloat16 if self.server_args.dtype == "bfloat16" else jnp.float32,

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -155,9 +155,15 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         topk_index = model_worker_batch.spec_info_padded.topk_index
         hidden_states = model_worker_batch.spec_info_padded.hidden_states
         if self.topk == 1:
+            if len(topk_index.shape) == 2:
+                token_list = topk_index
+            elif isinstance(topk_index, np.ndarray):
+                token_list = np.asarray(topk_index[:, :, 0], dtype=np.int32)
+            else:
+                token_list = topk_index[:, :, 0].astype(jnp.int32)
             if isinstance(topk_index, np.ndarray):
-                return None, np.asarray(topk_index[:, :, 0], dtype=np.int32), None
-            return None, topk_index[:, :, 0].astype(jnp.int32), None
+                token_list = np.asarray(token_list, dtype=np.int32)
+            return None, token_list, None
 
         bs = model_worker_batch.seq_lens.shape[0]
         step_min_1 = self.speculative_num_steps - 1

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -1,11 +1,15 @@
-"""MiMo-V2.5-Pro multi-layer MTP draft worker (#1053 P1-4).
+"""Multi-layer NEXTN/MTP draft worker (#1053 P1-4).
 
-Differs from ``EagleDraftWorker`` in that the N draft steps each use a
-*different* draft model runner (one per ``mtp_layer_idx``), with hidden
-states flowing layer→layer (layer i's output hidden becomes layer i+1's
-``spec_info.hidden_states``). Everything else — padding, tree build,
-verify-input construction, replicate helpers — is reused from
-``EagleDraftWorker``.
+The N draft steps each use a *different* draft model runner (one per
+``mtp_layer_idx``). Per the NEXTN training recipe (DeepSeek/MiMo), every
+layer i takes ``(embed(tok_{t+i}), target_hidden_t)`` — i.e. each layer
+sees the **target** model's hidden, not the previous MTP layer's output.
+So ``draft_extend`` forwards each layer once with the same target hidden
+and a per-layer rotated ``input_ids`` (shift+append previous topk), and
+``draft_forward`` does no model forward — it just reads the per-layer
+topk that ``draft_extend`` already stored. Chain-style hidden passing
+(layer i+1 ← layer i output) is only correct for archs like Step3p5MTP;
+see GPU sglang ``multi_layer_eagle_worker_v2.chain_mtp_hidden_states``.
 """
 
 from __future__ import annotations
@@ -17,8 +21,6 @@ import logging
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax.sharding import NamedSharding
-from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata
 from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
@@ -35,10 +37,8 @@ from sgl_jax.srt.speculative.eagle_draft_worker import (
     select_top_k_tokens,
     topk_probs_from_logits,
     update_eagle_lists,
-    update_forward_batch_info,
 )
 from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
-from sgl_jax.srt.utils.jax_utils import device_array
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +132,10 @@ class MultiLayerDraftWorker(EagleDraftWorker):
     # ---- per-layer overrides ------------------------------------------------
 
     def draft_forward(self, model_worker_batch: ModelWorkerBatch):
+        # dext already forwarded each MTP layer once and stored per-layer topk
+        # in spec_info.topk_{p,index} with shape (bs, num_steps, topk). We only
+        # feed those through select_top_k_tokens to assemble the tree lists —
+        # no model forward here (mirrors GPU multi_layer_eagle_worker_v2).
         topk_p = model_worker_batch.spec_info_padded.topk_p
         topk_index = model_worker_batch.spec_info_padded.topk_index
         hidden_states = model_worker_batch.spec_info_padded.hidden_states
@@ -143,51 +147,34 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         )
         parents_list = jnp.empty((bs, self.topk + 1 + step_min_1 * self.topk))
         scores = None
-        positions_base = device_array(
-            np.repeat(model_worker_batch.seq_lens, self.topk),
-            sharding=NamedSharding(self.mesh, P()),
-        )
-        logits_metadata = LogitsMetadata.from_model_worker_batch(model_worker_batch, self.mesh)
-
-        # Per-layer attention metadata: each layer has its own KV pool, so
-        # page_indices differ; positions/seq_lens are shared so we only need
-        # the i-th step's metadata from layer i.
-        metadata_per_layer = [
-            w.model_runner.attn_backend.get_eagle_multi_step_metadata(model_worker_batch)
-            for w in self._workers
-        ]
-
-        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
-        forward_batch.out_cache_loc = np.empty((1,))
-        forward_batch.cache_loc = np.empty((1,))
-        forward_batch.spec_info = EagleDraftInput()
-        forward_batch.spec_info.hidden_states = jnp.empty((bs * self.topk, hidden_states.shape[1]))
-
         for i in range(self.speculative_num_steps):
-            input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
-                i, topk_p, topk_index, hidden_states, scores, self.topk
+            _, hidden_states, scores, tree_info = select_top_k_tokens(
+                i, topk_p[:, i], topk_index[:, i], hidden_states, scores, self.topk
             )
             score_list, token_list, parents_list = update_eagle_lists(
                 i, score_list, token_list, parents_list, tree_info, self.topk
             )
-            if i == self.speculative_num_steps - 1:
-                break
-
-            forward_batch = update_forward_batch_info(
-                forward_batch, i, input_ids, hidden_states, positions_base
-            )
-            mr = self.runner(i)
-            mr.attn_backend.forward_metadata = metadata_per_layer[i][i]
-            forward_batch.attn_backend = mr.attn_backend
-            forward_batch.bid = model_worker_batch.bid
-            logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)
-
-            topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
-            if self.hot_token_ids is not None:
-                topk_index = self.hot_token_ids[topk_index]
-            hidden_states = replicate_to_mesh(self.mesh, logits_output.hidden_states)
-
         return score_list, token_list, parents_list
+
+    @staticmethod
+    def _rotate_ids(mwb: ModelWorkerBatch, last_tok: np.ndarray, sel_pos: np.ndarray) -> None:
+        """In-place left-shift each req's input_ids by 1, then write last_tok[slot]
+        at position sel_pos[slot]. Mirrors GPU rotate_input_ids_triton."""
+        dp = mwb.dp_size
+        per_dp_bs = mwb.per_dp_bs_size
+        per_dp_tok = len(mwb.input_ids) // dp
+        ext = mwb.extend_seq_lens
+        for r in range(dp):
+            pt = r * per_dp_tok
+            for j in range(per_dp_bs):
+                s = r * per_dp_bs + j
+                el = int(ext[s])
+                if el == 0:
+                    continue
+                seg = mwb.input_ids[pt : pt + el]
+                seg[:-1] = seg[1:]
+                seg[int(sel_pos[s])] = last_tok[s]
+                pt += el
 
     def draft_extend_for_prefill(
         self,
@@ -197,10 +184,15 @@ class MultiLayerDraftWorker(EagleDraftWorker):
     ) -> None:
         """Prefill-extend across all MTP layers.
 
-        Layer 0 consumes the target's full-prefix hidden_states; layer i>0
-        consumes layer i-1's output hidden. Each layer writes its own
-        prefix KV. Only layer 0's topk/hidden are kept as the next-round
-        draft state (draft step 0 starts from layer 0).
+        NEXTN (DeepSeek/MiMo) trains each MTP layer i with input
+        ``(embed(tok_{t+i}), target_hidden_t)`` — every layer sees the *target*
+        hidden, not the previous MTP layer's output. So per layer we keep
+        ``hidden = target_hidden_states`` and only rotate ``input_ids`` (shift
+        by 1, append previous layer's topk) so layer i's last-logit position is
+        ``(topk_{i-1}, target_hidden_{last})``. Each layer's topk goes into
+        ``spec_info.topk_index[:, i]`` and ``draft_forward`` does no model
+        forward. Mirrors GPU sglang ``multi_layer_eagle_worker_v2`` for
+        non-chain archs (chain is only for Step3p5MTP).
         """
         sel = np.asarray(model_worker_batch.logits_indices_selector)
         verified_id_np = np.asarray(jax.device_get(next_token_ids))[sel]
@@ -232,10 +224,12 @@ class MultiLayerDraftWorker(EagleDraftWorker):
             )
 
         layer0_out = None
-        cur_hidden = hidden_states
+        all_topk_p, all_topk_index = [], []
+        ext = model_worker_batch.extend_seq_lens
+        sel_pos = np.clip(ext - 1, 0, None).astype(np.int64)
         for i, w in enumerate(self._workers):
             mr = w.model_runner
-            model_worker_batch.spec_info_padded.hidden_states = cur_hidden
+            model_worker_batch.spec_info_padded.hidden_states = hidden_states
             forward_batch = ForwardBatch.init_new(model_worker_batch, mr)
             forward_batch.return_logprob = False
             mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(
@@ -248,17 +242,19 @@ class MultiLayerDraftWorker(EagleDraftWorker):
                     model_worker_batch, self.mesh
                 ),
             )
-            cur_hidden = logits_output.hidden_states
             if i == 0:
                 layer0_out = logits_output
+            tp, ti = topk_probs_from_logits(
+                replicate_to_mesh(self.mesh, logits_output.next_token_logits), self.topk
+            )
+            all_topk_p.append(np.asarray(jax.device_get(tp)))
+            all_topk_index.append(np.asarray(jax.device_get(ti)))
+            if i < len(self._workers) - 1:
+                self._rotate_ids(model_worker_batch, all_topk_index[-1][:, 0], sel_pos)
 
-        # Next-round draft state = layer 0's last-token hidden + topk (draft step 0
-        # starts from layer 0 with target's last hidden, so we cache layer 0's
-        # output here so step 0 can be skipped).
-        rep_logits, rep_hidden = replicate_to_mesh(
-            self.mesh, layer0_out.next_token_logits, layer0_out.hidden_states
-        )
-        layer0_out.next_token_logits = rep_logits
+        # spec_info.hidden_states is only consumed by select_top_k_tokens (shape
+        # bookkeeping at topk=1); keep layer0's last-token hidden for that.
+        rep_hidden = replicate_to_mesh(self.mesh, layer0_out.hidden_states)
         dp_size = model_worker_batch.dp_size
         if dp_size > 1:
             per_dp_tokens = rep_hidden.shape[0] // dp_size
@@ -266,33 +262,21 @@ class MultiLayerDraftWorker(EagleDraftWorker):
             last_idx = last_idx.copy()
             for k in range(1, dp_size):
                 last_idx[k * per_dp_bs : (k + 1) * per_dp_bs] += k * per_dp_tokens
-        layer0_out.hidden_states = rep_hidden[last_idx]
-        model_worker_batch.spec_info_padded.hidden_states = hidden_states
-        model_worker_batch.spec_info_padded.allocate_lens = np.asarray(model_worker_batch.seq_lens)[
-            sel
-        ]
-        # Restore real_bs verified_id so split_spec_info_per_rank can cut on
-        # real_bs_per_dp without slicing past the valid region.
-        model_worker_batch.spec_info_padded.verified_id = verified_id_np
-        self.capture_for_decode(layer0_out, model_worker_batch.spec_info_padded, sel=sel)
+        si = model_worker_batch.spec_info_padded
+        si.hidden_states = np.asarray(jax.device_get(rep_hidden))[last_idx][sel]
+        si.topk_p = np.stack(all_topk_p, axis=1)[sel]
+        si.topk_index = np.stack(all_topk_index, axis=1)[sel]
+        si.allocate_lens = np.asarray(model_worker_batch.seq_lens)[sel]
+        si.verified_id = verified_id_np
 
     def draft_extend_for_decode(
         self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
     ) -> None:
-        """Decode-extend across all MTP layers (each updates its own KV).
-
-        Same chaining as prefill: layer 0 consumes target verify hidden,
-        layer i>0 consumes layer i-1's output. Only layer 0's topk/hidden
-        become the next-round draft state.
-        """
+        """Decode-extend across all MTP layers; see draft_extend_for_prefill."""
         if batch_output.next_draft_input.verified_id.shape[0] <= 0:
             return
         target_hidden = batch_output.logits_output.hidden_states
 
-        # prepare_for_extend_after_verify mutates mwb.seq_lens / input_ids /
-        # spec_info in place — call it once (semantics are layer-independent),
-        # then per layer only swap hidden_states + recompute forward_metadata
-        # against that layer's KV pool.
         draft_input = EagleDraftInput(
             hidden_states=target_hidden, allocate_lens=batch_output.allocate_lens
         )
@@ -305,46 +289,39 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         if mwb.input_ids.shape[0] <= 0:
             return
 
-        layer0_logits = None
-        cur_hidden = target_hidden
+        sel = np.asarray(model_worker_batch.logits_indices_selector)
+        accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
+        assert (accept_host[sel] >= 1).all(), f"accept_length < 1: {accept_host[sel]}"
+        sel_pos = np.clip(accept_host - 1, 0, None).astype(np.int64)
+        mwb.input_ids = np.asarray(jax.device_get(mwb.input_ids)).copy()
+
+        layer0_hidden = None
+        all_topk_p, all_topk_index = [], []
         for i, w in enumerate(self._workers):
             mr = w.model_runner
-            mwb.spec_info_padded.hidden_states = cur_hidden
+            mwb.spec_info_padded.hidden_states = target_hidden
             mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(mwb)
             forward_batch = ForwardBatch.init_new(mwb, mr)
             logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)
             if i == 0:
-                layer0_logits = logits_output
-            cur_hidden = logits_output.hidden_states
+                layer0_hidden = replicate_to_mesh(self.mesh, logits_output.hidden_states)
+            tp, ti = topk_probs_from_logits(
+                replicate_to_mesh(self.mesh, logits_output.next_token_logits), self.topk
+            )
+            all_topk_p.append(np.asarray(jax.device_get(tp)))
+            all_topk_index.append(np.asarray(jax.device_get(ti)))
+            if i < len(self._workers) - 1:
+                self._rotate_ids(mwb, all_topk_index[-1][:, 0], sel_pos)
 
-        # logits_indices_selector maps global-flat req k → DP-padded slot s_k.
-        # rep_logits/rep_hidden are DP-padded (total_bs, …)/(total_bs*(steps+1), …);
-        # keep topk_probs_from_logits running on device with the padded shape
-        # (varying real_bs gather on device would generate a fresh trace per
-        # warmup batch size — see #1090). Gather to real_bs on host.
-        sel = np.asarray(model_worker_batch.logits_indices_selector)
-        accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
-        assert (accept_host[sel] >= 1).all(), f"accept_length < 1: {accept_host[sel]}"
         select_index = sel * (self.speculative_num_steps + 1) + accept_host[sel] - 1
-        rep_logits, rep_hidden = replicate_to_mesh(
-            self.mesh, layer0_logits.next_token_logits, layer0_logits.hidden_states
-        )
-        topk_p, topk_index = topk_probs_from_logits(rep_logits, self.topk)
-        jax.copy_to_host_async(topk_p)
-        jax.copy_to_host_async(topk_index)
-        jax.copy_to_host_async(rep_hidden)
         verified_id_arr = batch_output.next_draft_input.verified_id
         if hasattr(verified_id_arr, "copy_to_host_async"):
             jax.copy_to_host_async(verified_id_arr)
-        topk_p = np.asarray(topk_p)[sel]
-        topk_index = np.asarray(topk_index)[sel]
-        hidden = np.asarray(rep_hidden)[select_index]
-        verified_id = np.asarray(verified_id_arr)[select_index]
-        batch_output.next_draft_input.hidden_states = hidden
-        batch_output.next_draft_input.topk_p = topk_p
-        batch_output.next_draft_input.topk_index = topk_index
-        batch_output.next_draft_input.verified_id = verified_id
+        batch_output.next_draft_input.hidden_states = np.asarray(jax.device_get(layer0_hidden))[
+            select_index
+        ]
+        batch_output.next_draft_input.topk_p = np.stack(all_topk_p, axis=1)[sel]
+        batch_output.next_draft_input.topk_index = np.stack(all_topk_index, axis=1)[sel]
+        batch_output.next_draft_input.verified_id = np.asarray(verified_id_arr)[select_index]
         batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
-        # accept_lens stays DP-padded (total_bs,) — scheduler per-rank seq_lens
-        # update and _resolve_spec_decode_token_ids both index by DP slot.
         batch_output.accept_lens = accept_host

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -299,8 +299,6 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
     ) -> None:
         """Decode-extend across all MTP layers."""
-        from sgl_jax.srt.speculative.draft_extend_fused import (
-            draft_extend_for_decode_fused,
-        )
+        from sgl_jax.srt.speculative.draft_extend_fused import draft_extend_for_decode
 
-        return draft_extend_for_decode_fused(self, model_worker_batch, batch_output)
+        return draft_extend_for_decode(self, model_worker_batch, batch_output)

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -7,9 +7,8 @@ sees the **target** model's hidden, not the previous MTP layer's output.
 So ``draft_extend`` forwards each layer once with the same target hidden
 and a per-layer rotated ``input_ids`` (shift+append previous topk), and
 ``draft_forward`` does no model forward — it just reads the per-layer
-topk that ``draft_extend`` already stored. Chain-style hidden passing
-(layer i+1 ← layer i output) is only correct for archs like Step3p5MTP;
-see GPU sglang ``multi_layer_eagle_worker_v2.chain_mtp_hidden_states``.
+topk that ``draft_extend`` already stored. Chain-style hidden passing is
+only correct for architectures that explicitly chain MTP hidden states.
 """
 
 from __future__ import annotations
@@ -155,6 +154,11 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         topk_p = model_worker_batch.spec_info_padded.topk_p
         topk_index = model_worker_batch.spec_info_padded.topk_index
         hidden_states = model_worker_batch.spec_info_padded.hidden_states
+        if self.topk == 1:
+            if isinstance(topk_index, np.ndarray):
+                return None, np.asarray(topk_index[:, :, 0], dtype=np.int32), None
+            return None, topk_index[:, :, 0].astype(jnp.int32), None
+
         bs = model_worker_batch.seq_lens.shape[0]
         step_min_1 = self.speculative_num_steps - 1
         score_list = jnp.zeros((bs, 1 + step_min_1 * self.topk, self.topk))
@@ -208,7 +212,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         ``(topk_{i-1}, target_hidden_{last})``. Each layer's topk goes into
         ``spec_info.topk_index[:, i]`` and ``draft_forward`` does no model
         forward. Mirrors GPU sglang ``multi_layer_eagle_worker_v2`` for
-        non-chain archs (chain is only for Step3p5MTP).
+        non-chain architectures.
         """
         sel = np.asarray(model_worker_batch.logits_indices_selector)
         verified_id_np = np.asarray(jax.device_get(next_token_ids))[sel]
@@ -288,7 +292,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
     def draft_extend_for_decode(
         self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
     ) -> None:
-        """Decode-extend across all MTP layers — fused single JIT."""
+        """Decode-extend across all MTP layers."""
         from sgl_jax.srt.speculative.draft_extend_fused import (
             draft_extend_for_decode_fused,
         )

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -76,6 +76,9 @@ class MultiLayerDraftWorker(EagleDraftWorker):
 
         self.num_mtp_layers = self.speculative_num_steps
         assert self.num_mtp_layers > 1
+        assert (
+            self.topk == 1
+        ), f"MultiLayerDraftWorker fused decode requires topk=1, got {self.topk}"
         cfg_mtp = getattr(target_worker.model_config.hf_config, "num_nextn_predict_layers", None)
         # MiMo-style configs omit num_nextn_predict_layers; only enforce equality
         # when the field exists (scheduler routes here iff n_mtp>1 either way).
@@ -107,6 +110,19 @@ class MultiLayerDraftWorker(EagleDraftWorker):
 
         for i, w in enumerate(self._workers):
             w.model_runner.initialize_jit()
+
+        # Share target's SWA index mapping with draft workers. The scheduler
+        # allocates KV pages via the target's SWATokenToKVPoolAllocator which
+        # maintains full_to_swa_index_mapping. Draft workers have independent
+        # allocators whose mappings stay at zero. Without this, draft SWA
+        # attention remaps all page indices to 0 → reads wrong KV data.
+        target_allocator = target_worker.model_runner.token_to_kv_pool_allocator
+        target_swa_mapping = getattr(target_allocator, "full_to_swa_index_mapping", None)
+        if target_swa_mapping is not None:
+            for w in self._workers:
+                object.__setattr__(
+                    w.model_runner.attn_backend, "swa_index_mapping", target_swa_mapping
+                )
 
         (
             self.precompile_token_paddings,
@@ -141,11 +157,11 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         hidden_states = model_worker_batch.spec_info_padded.hidden_states
         bs = model_worker_batch.seq_lens.shape[0]
         step_min_1 = self.speculative_num_steps - 1
-        score_list = jnp.empty((bs, 1 + step_min_1 * self.topk, self.topk))
-        token_list = jnp.empty(
+        score_list = jnp.zeros((bs, 1 + step_min_1 * self.topk, self.topk))
+        token_list = jnp.zeros(
             (bs, self.topk + step_min_1 * self.topk * self.topk), dtype=jnp.int32
         )
-        parents_list = jnp.empty((bs, self.topk + 1 + step_min_1 * self.topk))
+        parents_list = jnp.zeros((bs, self.topk + 1 + step_min_1 * self.topk))
         scores = None
         for i in range(self.speculative_num_steps):
             _, hidden_states, scores, tree_info = select_top_k_tokens(
@@ -272,56 +288,9 @@ class MultiLayerDraftWorker(EagleDraftWorker):
     def draft_extend_for_decode(
         self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
     ) -> None:
-        """Decode-extend across all MTP layers; see draft_extend_for_prefill."""
-        if batch_output.next_draft_input.verified_id.shape[0] <= 0:
-            return
-        target_hidden = batch_output.logits_output.hidden_states
-
-        draft_input = EagleDraftInput(
-            hidden_states=target_hidden, allocate_lens=batch_output.allocate_lens
+        """Decode-extend across all MTP layers — fused single JIT."""
+        from sgl_jax.srt.speculative.draft_extend_fused import (
+            draft_extend_for_decode_fused,
         )
-        mwb, logits_metadata = draft_input.prepare_for_extend_after_verify(
-            model_worker_batch,
-            self.draft_model_runner,
-            batch_output,
-            self.speculative_num_draft_tokens,
-        )
-        if mwb.input_ids.shape[0] <= 0:
-            return
 
-        sel = np.asarray(model_worker_batch.logits_indices_selector)
-        accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
-        assert (accept_host[sel] >= 1).all(), f"accept_length < 1: {accept_host[sel]}"
-        sel_pos = np.clip(accept_host - 1, 0, None).astype(np.int64)
-        mwb.input_ids = np.asarray(jax.device_get(mwb.input_ids)).copy()
-
-        layer0_hidden = None
-        all_topk_p, all_topk_index = [], []
-        for i, w in enumerate(self._workers):
-            mr = w.model_runner
-            mwb.spec_info_padded.hidden_states = target_hidden
-            mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(mwb)
-            forward_batch = ForwardBatch.init_new(mwb, mr)
-            logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)
-            if i == 0:
-                layer0_hidden = replicate_to_mesh(self.mesh, logits_output.hidden_states)
-            tp, ti = topk_probs_from_logits(
-                replicate_to_mesh(self.mesh, logits_output.next_token_logits), self.topk
-            )
-            all_topk_p.append(np.asarray(jax.device_get(tp)))
-            all_topk_index.append(np.asarray(jax.device_get(ti)))
-            if i < len(self._workers) - 1:
-                self._rotate_ids(mwb, all_topk_index[-1][:, 0], sel_pos)
-
-        select_index = sel * (self.speculative_num_steps + 1) + accept_host[sel] - 1
-        verified_id_arr = batch_output.next_draft_input.verified_id
-        if hasattr(verified_id_arr, "copy_to_host_async"):
-            jax.copy_to_host_async(verified_id_arr)
-        batch_output.next_draft_input.hidden_states = np.asarray(jax.device_get(layer0_hidden))[
-            select_index
-        ]
-        batch_output.next_draft_input.topk_p = np.stack(all_topk_p, axis=1)[sel]
-        batch_output.next_draft_input.topk_index = np.stack(all_topk_index, axis=1)[sel]
-        batch_output.next_draft_input.verified_id = np.asarray(verified_id_arr)[select_index]
-        batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
-        batch_output.accept_lens = accept_host
+        return draft_extend_for_decode_fused(self, model_worker_batch, batch_output)

--- a/python/sgl_jax/srt/speculative/overlap_utils.py
+++ b/python/sgl_jax/srt/speculative/overlap_utils.py
@@ -1,0 +1,67 @@
+import numpy as np
+
+
+def resolve_spec_prefill_token_ids(result, batch, relay_buffers, mesh):
+    """Resolve prefill next-token ids prepared by the producer path."""
+    token_ids_arr = result.next_token_ids
+    if token_ids_arr is None:
+        raise RuntimeError(
+            "Spec prefill overlap result is missing prepared next_token_ids "
+            f"for bid={getattr(result, 'bid', None)}"
+        )
+    if hasattr(token_ids_arr, "copy_to_host_async"):
+        token_ids_arr.copy_to_host_async()
+    return np.asarray(token_ids_arr).tolist()
+
+
+def publish_spec_decode_new_seq_lens(batch_output):
+    new_seq_lens = batch_output.next_draft_input.new_seq_lens
+    if new_seq_lens is not None and hasattr(new_seq_lens, "copy_to_host_async"):
+        new_seq_lens.copy_to_host_async()
+    return new_seq_lens
+
+
+def can_use_spec_decode_overlap(enable_overlap, spec_algorithm, batch) -> bool:
+    if not enable_overlap:
+        return False
+    if spec_algorithm is None or spec_algorithm.is_none():
+        return False
+    if batch.forward_mode.is_mixed():
+        return False
+    if not batch.forward_mode.is_decode():
+        return False
+    if any(info.decoding_reqs for info in batch.reqs_info):
+        return False
+    return not (batch.return_logprob or batch.return_output_logprob_only)
+
+
+def can_use_spec_prefill_overlap(enable_overlap, spec_algorithm, batch) -> bool:
+    if not enable_overlap:
+        return False
+    if spec_algorithm is None or spec_algorithm.is_none():
+        return False
+    if not batch.forward_mode.is_extend():
+        return False
+    return not (batch.return_logprob or batch.return_output_logprob_only)
+
+
+def resolve_spec_decode_token_ids(result, batch, draft_token_num: int):
+    """Resolve per-request accepted token ids from a speculative verify result."""
+    if hasattr(result.next_token_ids, "copy_to_host_async"):
+        result.next_token_ids.copy_to_host_async()
+    if hasattr(result.accept_lens, "copy_to_host_async"):
+        result.accept_lens.copy_to_host_async()
+    next_token_ids = np.asarray(result.next_token_ids)
+    accept_lens = np.asarray(result.accept_lens).tolist()
+    per_dp_bs = batch.per_dp_bs_size
+    total_bs = per_dp_bs * batch.dp_size
+    predict_tokens: list[list[int]] = [[] for _ in range(total_bs)]
+    for dp_rank, info in enumerate(batch.reqs_info):
+        base = dp_rank * per_dp_bs
+        for j, _req in enumerate(info.reqs or []):
+            i = base + j
+            a = accept_lens[i]
+            predict_tokens[i] = next_token_ids[
+                i * draft_token_num : i * draft_token_num + a
+            ].tolist()
+    return predict_tokens, accept_lens

--- a/python/sgl_jax/srt/speculative/overlap_utils.py
+++ b/python/sgl_jax/srt/speculative/overlap_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def resolve_spec_prefill_token_ids(result, batch, relay_buffers, mesh):
+def resolve_spec_prefill_token_ids(result):
     """Resolve prefill next-token ids prepared by the producer path."""
     token_ids_arr = result.next_token_ids
     if token_ids_arr is None:

--- a/python/sgl_jax/srt/speculative/overlap_utils.py
+++ b/python/sgl_jax/srt/speculative/overlap_utils.py
@@ -32,10 +32,24 @@ def can_use_spec_decode_overlap(enable_overlap, spec_algorithm, batch) -> bool:
         return False
     if any(info.decoding_reqs for info in batch.reqs_info):
         return False
+    # TODO(spec-overlap): neither the fused overlap verify kernel
+    # (draft_extend_fused.spec_decode_verify) nor the non-overlap verify path
+    # currently applies grammar / vocab_mask / penalty constraints during
+    # speculative verification. Batches carrying these constraints will have
+    # them silently ignored on the spec decode path. We do NOT exclude them in
+    # this gate because the non-overlap fallback has the same gap, so routing
+    # them off the overlap path would not make them correct. Revisit once
+    # constrained speculative verify is implemented.
     return not (batch.return_logprob or batch.return_output_logprob_only)
 
 
 def can_use_spec_prefill_overlap(enable_overlap, spec_algorithm, batch) -> bool:
+    # Cheap pre-filter only. The authoritative check is
+    # EAGLEWorker._can_use_fused_spec_prefill(model_worker_batch), which the
+    # scheduler ANDs in before dispatching to the fused prefill overlap entry
+    # (it needs the merged model_worker_batch sampling_info plus the worker's
+    # NEXTN/topk/num_steps config). Keep this gate to the conditions decidable
+    # from the ScheduleBatch alone so the two never drift.
     if not enable_overlap:
         return False
     if spec_algorithm is None or spec_algorithm.is_none():

--- a/python/sgl_jax/srt/speculative/overlap_utils.py
+++ b/python/sgl_jax/srt/speculative/overlap_utils.py
@@ -45,6 +45,15 @@ def can_use_spec_prefill_overlap(enable_overlap, spec_algorithm, batch) -> bool:
     return not (batch.return_logprob or batch.return_output_logprob_only)
 
 
+def use_legacy_eagle3_non_overlap(enable_overlap, spec_algorithm) -> bool:
+    return (
+        not enable_overlap
+        and spec_algorithm is not None
+        and not spec_algorithm.is_none()
+        and spec_algorithm.is_eagle3()
+    )
+
+
 def resolve_spec_decode_token_ids(result, batch, draft_token_num: int):
     """Resolve per-request accepted token ids from a speculative verify result."""
     if hasattr(result.next_token_ids, "copy_to_host_async"):

--- a/python/sgl_jax/srt/speculative/relay_buffer.py
+++ b/python/sgl_jax/srt/speculative/relay_buffer.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+RELAY_STATE_SPEC = P("data", None, None)
+RELAY_ID_SPEC = P("data", None)
+
+
+class SpecRelayBuffers(NamedTuple):
+    topk_index: jax.Array
+    hidden_states: jax.Array
+    verified_id: jax.Array
+    new_seq_lens: jax.Array
+
+
+def create_spec_relay_buffers(
+    mesh,
+    req_to_token_pool,
+    *,
+    dp_size: int,
+    num_steps: int,
+    hidden_size: int,
+    hidden_dtype,
+) -> SpecRelayBuffers:
+    """Create DP-local req-indexed buffers for cross-batch draft state relay."""
+    capacity = int(req_to_token_pool.req_to_token.shape[0])
+    token_sharding = NamedSharding(mesh, RELAY_STATE_SPEC)
+    hidden_sharding = NamedSharding(mesh, RELAY_STATE_SPEC)
+    id_sharding = NamedSharding(mesh, RELAY_ID_SPEC)
+    return SpecRelayBuffers(
+        topk_index=jax.device_put(
+            jnp.zeros((dp_size, capacity, num_steps), dtype=jnp.int32),
+            token_sharding,
+        ),
+        hidden_states=jax.device_put(
+            jnp.zeros((dp_size, capacity, hidden_size), dtype=hidden_dtype),
+            hidden_sharding,
+        ),
+        verified_id=jax.device_put(
+            jnp.zeros((dp_size, capacity), dtype=jnp.int32),
+            id_sharding,
+        ),
+        new_seq_lens=jax.device_put(
+            jnp.zeros((dp_size, capacity), dtype=jnp.int32),
+            id_sharding,
+        ),
+    )
+
+
+def update_spec_relay_buffers(
+    buffers: SpecRelayBuffers,
+    future_indices,
+    valid_mask,
+    topk_index,
+    hidden_states,
+    verified_id,
+    new_seq_lens,
+    *,
+    dp_size: int,
+) -> SpecRelayBuffers:
+    """Write DP-padded draft state into relay buffers without touching padded rows."""
+    per_dp_bs = future_indices.shape[0] // dp_size
+    indices = future_indices.reshape((dp_size, per_dp_bs))
+    valid = valid_mask.reshape((dp_size, per_dp_bs))
+    dp_indices = jnp.arange(dp_size, dtype=jnp.int32)[:, None]
+    scatter_indices = jnp.where(
+        valid,
+        indices,
+        jnp.full_like(indices, buffers.topk_index.shape[1]),
+    )
+
+    topk_index = topk_index.reshape((dp_size, per_dp_bs) + topk_index.shape[1:])
+    hidden_states = hidden_states.reshape((dp_size, per_dp_bs) + hidden_states.shape[1:])
+    verified_id = verified_id.reshape((dp_size, per_dp_bs))
+    new_seq_lens = new_seq_lens.reshape((dp_size, per_dp_bs))
+
+    return SpecRelayBuffers(
+        topk_index=buffers.topk_index.at[dp_indices, scatter_indices].set(
+            topk_index,
+            mode="drop",
+            out_sharding=RELAY_STATE_SPEC,
+        ),
+        hidden_states=buffers.hidden_states.at[dp_indices, scatter_indices].set(
+            hidden_states,
+            mode="drop",
+            out_sharding=RELAY_STATE_SPEC,
+        ),
+        verified_id=buffers.verified_id.at[dp_indices, scatter_indices].set(
+            verified_id,
+            mode="drop",
+            out_sharding=RELAY_ID_SPEC,
+        ),
+        new_seq_lens=buffers.new_seq_lens.at[dp_indices, scatter_indices].set(
+            new_seq_lens,
+            mode="drop",
+            out_sharding=RELAY_ID_SPEC,
+        ),
+    )
+
+
+def gather_spec_relay_buffers(
+    buffers: SpecRelayBuffers,
+    future_indices,
+    *,
+    dp_size: int,
+):
+    """Gather DP-padded draft state for the next batch."""
+    per_dp_bs = future_indices.shape[0] // dp_size
+    indices = future_indices.reshape((dp_size, per_dp_bs))
+    dp_indices = jnp.arange(dp_size, dtype=jnp.int32)[:, None]
+
+    return (
+        buffers.topk_index.at[dp_indices, indices]
+        .get(out_sharding=RELAY_STATE_SPEC)
+        .reshape(future_indices.shape + buffers.topk_index.shape[2:]),
+        buffers.hidden_states.at[dp_indices, indices]
+        .get(out_sharding=RELAY_STATE_SPEC)
+        .reshape(future_indices.shape + buffers.hidden_states.shape[2:]),
+        buffers.verified_id.at[dp_indices, indices]
+        .get(out_sharding=RELAY_ID_SPEC)
+        .reshape(future_indices.shape),
+        buffers.new_seq_lens.at[dp_indices, indices]
+        .get(out_sharding=RELAY_ID_SPEC)
+        .reshape(future_indices.shape),
+    )
+
+
+def gather_spec_relay_verified_id(
+    buffers: SpecRelayBuffers,
+    future_indices,
+    *,
+    dp_size: int,
+):
+    """Gather DP-padded verified ids from the relay buffer."""
+    per_dp_bs = future_indices.shape[0] // dp_size
+    indices = future_indices.reshape((dp_size, per_dp_bs))
+    dp_indices = jnp.arange(dp_size, dtype=jnp.int32)[:, None]
+    return (
+        buffers.verified_id.at[dp_indices, indices]
+        .get(out_sharding=RELAY_ID_SPEC)
+        .reshape(future_indices.shape)
+    )
+
+
+def scatter_future_indices_to_dp_slots(
+    per_dp_indices,
+    *,
+    total_bs: int,
+    per_dp_bs: int,
+) -> np.ndarray:
+    out = np.zeros((total_bs,), dtype=np.int32)
+    for dp_rank, indices in enumerate(per_dp_indices):
+        start = dp_rank * per_dp_bs
+        n = len(indices)
+        if n:
+            out[start : start + n] = np.asarray(indices, dtype=np.int32)
+    return out
+
+
+def make_dp_valid_mask(real_bs_per_dp, *, total_bs: int, per_dp_bs: int) -> np.ndarray:
+    mask = np.zeros((total_bs,), dtype=np.bool_)
+    for dp_rank, real_bs in enumerate(real_bs_per_dp):
+        if real_bs:
+            start = dp_rank * per_dp_bs
+            mask[start : start + int(real_bs)] = True
+    return mask

--- a/python/sgl_jax/srt/speculative/relay_buffer.py
+++ b/python/sgl_jax/srt/speculative/relay_buffer.py
@@ -131,38 +131,6 @@ def gather_spec_relay_buffers(
     )
 
 
-def gather_spec_relay_verified_id(
-    buffers: SpecRelayBuffers,
-    future_indices,
-    *,
-    dp_size: int,
-):
-    """Gather DP-padded verified ids from the relay buffer."""
-    per_dp_bs = future_indices.shape[0] // dp_size
-    indices = future_indices.reshape((dp_size, per_dp_bs))
-    dp_indices = jnp.arange(dp_size, dtype=jnp.int32)[:, None]
-    return (
-        buffers.verified_id.at[dp_indices, indices]
-        .get(out_sharding=RELAY_ID_SPEC)
-        .reshape(future_indices.shape)
-    )
-
-
-def scatter_future_indices_to_dp_slots(
-    per_dp_indices,
-    *,
-    total_bs: int,
-    per_dp_bs: int,
-) -> np.ndarray:
-    out = np.zeros((total_bs,), dtype=np.int32)
-    for dp_rank, indices in enumerate(per_dp_indices):
-        start = dp_rank * per_dp_bs
-        n = len(indices)
-        if n:
-            out[start : start + n] = np.asarray(indices, dtype=np.int32)
-    return out
-
-
 def make_dp_valid_mask(real_bs_per_dp, *, total_bs: int, per_dp_bs: int) -> np.ndarray:
     mask = np.zeros((total_bs,), dtype=np.bool_)
     for dp_rank, real_bs in enumerate(real_bs_per_dp):

--- a/python/sgl_jax/test/speculative/test_eagle_utils.py
+++ b/python/sgl_jax/test/speculative/test_eagle_utils.py
@@ -1,5 +1,4 @@
 import unittest
-from types import SimpleNamespace
 
 import jax
 import jax.numpy as jnp
@@ -44,9 +43,10 @@ class TestVerifyTree(CustomTestCase):
         self.assertIsInstance(scalar, np.ndarray)
         self.assertEqual(scalar.dtype, np.int32)
         np.testing.assert_array_equal(listed, np.array([4, 5], dtype=np.int32))
-        self.assertIsInstance(children[9], np.ndarray)
-        self.assertEqual(children[9].dtype, np.int32)
-        self.assertEqual(children[9].shape, (0,))
+        self.assertIsNone(children[9])
+        self.assertIsInstance(children[10], np.ndarray)
+        self.assertEqual(children[10].dtype, np.int32)
+        self.assertEqual(children[10].shape, (0,))
 
         device_arr = jnp.array([6], dtype=jnp.int32)
         self.assertIs(eagle_util._as_int32_array(device_arr), device_arr)
@@ -175,40 +175,28 @@ class TestVerifyTree(CustomTestCase):
         )
 
         np.testing.assert_array_equal(np.asarray(out.accept_lens), np.array([0, 3]))
-        np.testing.assert_array_equal(np.asarray(out.new_seq_lens), np.array([0, 13]))
+        np.testing.assert_array_equal(np.asarray(out.new_seq_lens), np.array([1, 14]))
         np.testing.assert_array_equal(np.asarray(out.sel_pos), np.array([0, 2]))
 
-    def test_fused_materialize_uses_original_seq_lens_for_new_seq_lens(self):
+    def test_greedy_prepare_uses_original_seq_lens_for_new_seq_lens(self):
         from sgl_jax.srt.speculative.draft_extend_fused import (
-            _materialize_fused_greedy_batch_output_for_scheduler,
+            _greedy_prepare_draft_inputs,
         )
 
-        batch_output = SimpleNamespace(
-            logits_output=None,
-            next_draft_input=SimpleNamespace(),
-            allocate_lens=np.array([9, 8, 7], dtype=np.int32),
-            accept_lens=None,
-            next_token_ids=None,
-        )
-        out = _materialize_fused_greedy_batch_output_for_scheduler(
-            batch_output=batch_output,
-            selector=np.array([0, 2], dtype=np.int32),
-            real_bs=2,
-            seq_lens_host=np.array([103, 203, 303], dtype=np.int32),
-            layer0_hidden=jnp.arange(12 * 2, dtype=jnp.float32).reshape(12, 2),
-            topk_index_stacked=jnp.array(
-                [[[11], [12], [13]], [[21], [22], [23]], [[31], [32], [33]]]
-            ),
-            accept_lens_device=jnp.array([1, 2, 4], dtype=jnp.int32),
-            predict_device=jnp.arange(12, dtype=jnp.int32),
+        out = _greedy_prepare_draft_inputs(
+            hidden_states=jnp.arange(12 * 2, dtype=jnp.float32).reshape(12, 2),
+            positions=jnp.arange(12, dtype=jnp.int32),
+            seq_lens=jnp.array([103, 303], dtype=jnp.int32),
+            accept_index=jnp.array([0, -1, -1, -1, 8, 9, 10, 11], dtype=jnp.int32),
+            accept_length=jnp.array([1, 4], dtype=jnp.int32),
+            verified_id=jnp.arange(8, dtype=jnp.int32),
+            speculative_num_steps=3,
             speculative_num_draft_tokens=4,
-            target_logits=None,
-            target_hidden=None,
         )
 
         np.testing.assert_array_equal(
-            out.next_draft_input.new_seq_lens,
-            np.array([101, 304], dtype=np.int32),
+            np.asarray(out.new_seq_lens),
+            np.array([105, 308], dtype=np.int32),
         )
 
     def test_verify_tree_greedy(self):

--- a/python/sgl_jax/test/speculative/test_eagle_utils.py
+++ b/python/sgl_jax/test/speculative/test_eagle_utils.py
@@ -85,9 +85,7 @@ class TestVerifyTree(CustomTestCase):
         np.testing.assert_array_equal(np.asarray(packed), expected)
 
     def test_fused_chain_verify_matches_topk1_linear_reference(self):
-        from sgl_jax.srt.speculative.draft_extend_fused import (
-            _greedy_sample_and_prepare_draft_inputs_chain_from_predict,
-        )
+        from sgl_jax.srt.speculative.draft_extend_fused import _verify_greedy
 
         speculative_num_steps = 3
         num_draft_tokens = 4
@@ -134,7 +132,7 @@ class TestVerifyTree(CustomTestCase):
             ],
             dtype=np.int32,
         )
-        chain = _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
+        chain = _verify_greedy(
             target_hidden=jnp.arange(bs * num_draft_tokens * 2, dtype=jnp.float32).reshape(
                 bs * num_draft_tokens, 2
             ),
@@ -160,11 +158,9 @@ class TestVerifyTree(CustomTestCase):
         )
 
     def test_fused_chain_verify_zeroes_padding_accept_length(self):
-        from sgl_jax.srt.speculative.draft_extend_fused import (
-            _greedy_sample_and_prepare_draft_inputs_chain_from_predict,
-        )
+        from sgl_jax.srt.speculative.draft_extend_fused import _verify_greedy
 
-        out = _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
+        out = _verify_greedy(
             target_hidden=jnp.arange(8 * 2, dtype=jnp.float32).reshape(8, 2),
             positions=jnp.arange(8, dtype=jnp.int32),
             seq_lens=jnp.array([0, 10], dtype=jnp.int32),
@@ -179,11 +175,9 @@ class TestVerifyTree(CustomTestCase):
         np.testing.assert_array_equal(np.asarray(out.sel_pos), np.array([0, 2]))
 
     def test_greedy_prepare_uses_original_seq_lens_for_new_seq_lens(self):
-        from sgl_jax.srt.speculative.draft_extend_fused import (
-            _greedy_prepare_draft_inputs,
-        )
+        from sgl_jax.srt.speculative.draft_extend_fused import _prepare_draft_inputs
 
-        out = _greedy_prepare_draft_inputs(
+        out = _prepare_draft_inputs(
             hidden_states=jnp.arange(12 * 2, dtype=jnp.float32).reshape(12, 2),
             positions=jnp.arange(12, dtype=jnp.int32),
             seq_lens=jnp.array([103, 303], dtype=jnp.int32),

--- a/python/sgl_jax/test/speculative/test_eagle_utils.py
+++ b/python/sgl_jax/test/speculative/test_eagle_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 
 import jax
 import jax.numpy as jnp
@@ -14,6 +15,202 @@ from sgl_jax.test.test_utils import CustomTestCase
 
 
 class TestVerifyTree(CustomTestCase):
+    def test_as_int32_array_keeps_host_metadata_on_host(self):
+        from sgl_jax.srt.speculative import eagle_util
+
+        original_jnp_asarray = eagle_util.jnp.asarray
+        original_jnp_empty = eagle_util.jnp.empty
+
+        def fail_jnp_asarray(*args, **kwargs):
+            raise AssertionError("host metadata conversion must not call jnp.asarray")
+
+        def fail_jnp_empty(*args, **kwargs):
+            raise AssertionError("host metadata placeholder must not call jnp.empty")
+
+        try:
+            eagle_util.jnp.asarray = fail_jnp_asarray
+            eagle_util.jnp.empty = fail_jnp_empty
+            arr = eagle_util._as_int32_array(np.array([1, 2], dtype=np.int64))
+            scalar = eagle_util._as_int32_array(3)
+            listed = eagle_util._as_int32_array([4, 5])
+            children, _ = eagle_util.EagleDraftInput().tree_flatten()
+        finally:
+            eagle_util.jnp.asarray = original_jnp_asarray
+            eagle_util.jnp.empty = original_jnp_empty
+
+        self.assertIsInstance(arr, np.ndarray)
+        self.assertEqual(arr.dtype, np.int32)
+        np.testing.assert_array_equal(arr, np.array([1, 2], dtype=np.int32))
+        self.assertIsInstance(scalar, np.ndarray)
+        self.assertEqual(scalar.dtype, np.int32)
+        np.testing.assert_array_equal(listed, np.array([4, 5], dtype=np.int32))
+        self.assertIsInstance(children[9], np.ndarray)
+        self.assertEqual(children[9].dtype, np.int32)
+        self.assertEqual(children[9].shape, (0,))
+
+        device_arr = jnp.array([6], dtype=jnp.int32)
+        self.assertIs(eagle_util._as_int32_array(device_arr), device_arr)
+
+    def test_build_chain_verify_inputs_device_matches_linear_chain_layout(self):
+        from sgl_jax.srt.speculative.eagle_util import build_chain_verify_inputs_device
+
+        verified_id = jnp.array([101, 201], dtype=jnp.int32)
+        token_list = jnp.array(
+            [
+                [102, 103, 104],
+                [202, 203, 204],
+            ],
+            dtype=jnp.int32,
+        )
+        seq_lens = jnp.array([7, 11], dtype=jnp.int32)
+
+        packed = build_chain_verify_inputs_device(
+            verified_id=verified_id,
+            token_list=token_list,
+            seq_lens=seq_lens,
+            num_verify_tokens=4,
+            batch_size=2,
+        )
+
+        expected = np.array(
+            [
+                [101, 102, 103, 104, 201, 202, 203, 204],
+                [7, 8, 9, 10, 11, 12, 13, 14],
+                [0, 1, 2, 3, 4, 5, 6, 7],
+                [1, 2, 3, -1, 1, 2, 3, -1],
+                [-1, -1, -1, -1, -1, -1, -1, -1],
+            ],
+            dtype=np.int32,
+        )
+        np.testing.assert_array_equal(np.asarray(packed), expected)
+
+    def test_fused_chain_verify_matches_topk1_linear_reference(self):
+        from sgl_jax.srt.speculative.draft_extend_fused import (
+            _greedy_sample_and_prepare_draft_inputs_chain_from_predict,
+        )
+
+        speculative_num_steps = 3
+        num_draft_tokens = 4
+        bs = 4
+        draft_tokens = jnp.array(
+            [
+                10,
+                11,
+                12,
+                13,
+                20,
+                21,
+                22,
+                23,
+                30,
+                31,
+                32,
+                33,
+                40,
+                41,
+                42,
+                43,
+            ],
+            dtype=jnp.int32,
+        )
+        target_predict = np.array(
+            [
+                99,
+                12,
+                13,
+                14,
+                21,
+                99,
+                23,
+                24,
+                31,
+                32,
+                99,
+                34,
+                41,
+                42,
+                43,
+                44,
+            ],
+            dtype=np.int32,
+        )
+        chain = _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
+            target_hidden=jnp.arange(bs * num_draft_tokens * 2, dtype=jnp.float32).reshape(
+                bs * num_draft_tokens, 2
+            ),
+            positions=jnp.arange(bs * num_draft_tokens, dtype=jnp.int32),
+            seq_lens=jnp.array([100, 200, 300, 400], dtype=jnp.int32),
+            draft_tokens=draft_tokens,
+            target_predict=jnp.asarray(target_predict),
+            speculative_num_steps=speculative_num_steps,
+            speculative_num_draft_tokens=num_draft_tokens,
+        )
+
+        np.testing.assert_array_equal(np.asarray(chain.accept_lens), np.array([1, 2, 3, 4]))
+        np.testing.assert_array_equal(
+            np.asarray(chain.select_index),
+            np.arange(bs, dtype=np.int32) * (speculative_num_steps + 1)
+            + np.asarray(chain.accept_lens)
+            - 1,
+        )
+        select_index = np.asarray(chain.select_index)
+        np.testing.assert_array_equal(
+            np.asarray(chain.verified_id)[select_index],
+            np.array([99, 99, 99, 44], dtype=np.int32),
+        )
+
+    def test_fused_chain_verify_zeroes_padding_accept_length(self):
+        from sgl_jax.srt.speculative.draft_extend_fused import (
+            _greedy_sample_and_prepare_draft_inputs_chain_from_predict,
+        )
+
+        out = _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
+            target_hidden=jnp.arange(8 * 2, dtype=jnp.float32).reshape(8, 2),
+            positions=jnp.arange(8, dtype=jnp.int32),
+            seq_lens=jnp.array([0, 10], dtype=jnp.int32),
+            draft_tokens=jnp.array([0, 0, 0, 0, 20, 21, 22, 23], dtype=jnp.int32),
+            target_predict=jnp.array([0, 0, 0, 0, 21, 22, 99, 24], dtype=jnp.int32),
+            speculative_num_steps=3,
+            speculative_num_draft_tokens=4,
+        )
+
+        np.testing.assert_array_equal(np.asarray(out.accept_lens), np.array([0, 3]))
+        np.testing.assert_array_equal(np.asarray(out.new_seq_lens), np.array([0, 13]))
+        np.testing.assert_array_equal(np.asarray(out.sel_pos), np.array([0, 2]))
+
+    def test_fused_materialize_uses_original_seq_lens_for_new_seq_lens(self):
+        from sgl_jax.srt.speculative.draft_extend_fused import (
+            _materialize_fused_greedy_batch_output_for_scheduler,
+        )
+
+        batch_output = SimpleNamespace(
+            logits_output=None,
+            next_draft_input=SimpleNamespace(),
+            allocate_lens=np.array([9, 8, 7], dtype=np.int32),
+            accept_lens=None,
+            next_token_ids=None,
+        )
+        out = _materialize_fused_greedy_batch_output_for_scheduler(
+            batch_output=batch_output,
+            selector=np.array([0, 2], dtype=np.int32),
+            real_bs=2,
+            seq_lens_host=np.array([103, 203, 303], dtype=np.int32),
+            layer0_hidden=jnp.arange(12 * 2, dtype=jnp.float32).reshape(12, 2),
+            topk_index_stacked=jnp.array(
+                [[[11], [12], [13]], [[21], [22], [23]], [[31], [32], [33]]]
+            ),
+            accept_lens_device=jnp.array([1, 2, 4], dtype=jnp.int32),
+            predict_device=jnp.arange(12, dtype=jnp.int32),
+            speculative_num_draft_tokens=4,
+            target_logits=None,
+            target_hidden=None,
+        )
+
+        np.testing.assert_array_equal(
+            out.next_draft_input.new_seq_lens,
+            np.array([101, 304], dtype=np.int32),
+        )
+
     def test_verify_tree_greedy(self):
         candidates = jnp.array(
             [
@@ -65,19 +262,10 @@ class TestVerifyTree(CustomTestCase):
         accept_index = jnp.full((bs, num_spec_step), -1, dtype=jnp.int32)  # mutable
         accept_token_num = jnp.full((bs,), 0, dtype=jnp.int32)  # mutable
 
-        # # for compatibility, 0.6.3 need to use use_mesh. set_mesh is not have __entry__ attribute.
-        # # on jax >=0.7.1, we need to use set_mesh.
         from sgl_jax.srt.utils.mesh_utils import create_device_mesh
 
         mesh = create_device_mesh(ici_parallelism=[-1, 1], dcn_parallelism=[1, 1])
-        try:
-            ctx = jax.sharding.use_mesh(mesh)
-        except AttributeError:
-            try:
-                ctx = jax.set_mesh(mesh)
-            except AttributeError:
-                ctx = mesh
-        with ctx:
+        with jax.set_mesh(mesh):
             accept_index, accept_token_num, predicts = verify_tree_greedy(
                 speculative_num_steps=4,
                 num_draft_tokens=6,

--- a/test/srt/test_speculative_decoding.py
+++ b/test/srt/test_speculative_decoding.py
@@ -89,7 +89,7 @@ class TestSpeculativeDecoding(CustomTestCase):
         )
 
         metrics = run_eval(args)
-        print(f"mmlu metrics {metrics}")
+        self.assertGreater(metrics["score"], 0.45)
 
 
 @unittest.skipUnless(

--- a/test/srt/test_speculative_decoding.py
+++ b/test/srt/test_speculative_decoding.py
@@ -89,7 +89,7 @@ class TestSpeculativeDecoding(CustomTestCase):
         )
 
         metrics = run_eval(args)
-        self.assertGreater(metrics["score"], 0.45)
+        print(f"mmlu metrics {metrics}")
 
 
 @unittest.skipUnless(


### PR DESCRIPTION
<img width="1376" height="746" alt="image" src="https://github.com/user-attachments/assets/d8b3126d-416d-4449-85f1-b9a97d964332" />

## 4k input / 1k output benchserving logs and results

Raw logs/results bundle: https://gist.github.com/pengchengneo/328518a93ecd11366e5bea09f605d189

The gist contains:
- rank0 raw server logs for spec and no-spec
- benchserving `run.log` and `result.jsonl` for bsz 4/8/16/32/64
- parsed TTFT/ITL CSV
- parsed rank0 steady decode gen-throughput CSV



## Spec server launch command, rank0 shown

```bash
python3 -m sgl_jax.launch_server \
  --model-path /data/pc \
  --trust-remote-code \
  --tp-size 16 \
  --dp-size 4 \
  --ep-size 16 \
  --moe-backend epmoe \
  --nnodes 4 \
  --node-rank 0 \
  --dist-init-addr 10.16.2.6:30042 \
  --host 0.0.0.0 \
  --port 30271 \
  --page-size 256 \
  --context-length 262144 \
  --disable-radix-cache \
  --chunked-prefill-size 2048 \
  --dtype bfloat16 \
  --mem-fraction-static 0.84 \
  --swa-full-tokens-ratio 0.2 \
  --skip-server-warmup \
  --log-level info \
  --decode-log-interval 1 \
  --max-running-requests 128 \
  --dp-schedule-policy round_robin \
  --max-seq-len 4096 \
  --precompile-bs-paddings 1 4 8 16 32 64 128 \
  --precompile-token-paddings 4096 \
  --speculative-algorithm NEXTN \
  --speculative-num-steps 3 \
  --speculative-num-draft-tokens 4 \
  --speculative-eagle-topk 1 \
  --speculative-accept-threshold-single 1.0 \
  --speculative-accept-threshold-acc 1.0
```

## No-spec server launch command, rank0 shown

```bash
python3 -m sgl_jax.launch_server \
  --model-path /data/pc \
  --trust-remote-code \
  --tp-size 16 \
  --dp-size 4 \
  --ep-size 16 \
  --moe-backend epmoe \
  --nnodes 4 \
  --node-rank 0 \
  --dist-init-addr 10.16.2.6:30042 \
  --host 0.0.0.0 \
  --port 30271 \
  --page-size 256 \
  --context-length 262144 \
  --disable-radix-cache \
  --chunked-prefill-size 2048 \
  --dtype bfloat16 \
  --mem-fraction-static 0.84 \
  --swa-full-tokens-ratio 0.2 \
  --skip-server-warmup \
  --log-level info \
  --decode-log-interval 1 \
  --max-running-requests 128 \
  --dp-schedule-policy round_robin \
  --max-seq-len 4096 \
  --precompile-bs-paddings 1 4 8 16 32 64 128 \
  --precompile-token-paddings 4096
```

For ranks 1/2/3, only `--node-rank` and pod/log filename differ.

## Benchserving command template

```bash
for bs in 4 8 16 32 64; do
  num_prompts=$((bs * 3))
  python3 -m sgl_jax.bench_serving \
    --backend sgl-jax \
    --base-url http://127.0.0.1:30271 \
    --model /data/pc \
    --dataset-name random \
    --random-input-len 4096 \
    --random-output-len 1024 \
    --random-range-ratio 1 \
    --max-concurrency "$bs" \
    --num-prompts "$num_prompts" \
    --warmup-requests 0 \
    --output-file "$out/bs_${bs}/result.jsonl" \
    2>&1 | tee "$out/bs_${bs}/run.log"
done
```

## Benchserving results

| bsz | spec out tok/s | no-spec out tok/s | speedup | spec TTFT ms | no-spec TTFT ms | spec ITL ms | no-spec ITL ms |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 4 | 457.90 | 326.17 | 1.404x | 1865.45 | 2091.70 | 6.42 | 10.23 |
| 8 | 711.06 | 519.27 | 1.369x | 2173.81 | 2668.22 | 8.77 | 12.81 |
| 16 | 817.10 | 761.33 | 1.073x | 2691.87 | 3832.60 | 16.21 | 17.28 |
| 32 | 1168.70 | 1103.83 | 1.059x | 4072.27 | 6124.56 | 22.87 | 23.02 |
| 64 | 1162.40 | 1418.37 | 0.820x | 6989.83 | 10875.96 | 46.98 | 34.52 |

## Rank0 server-log steady decode gen throughput

| bsz | spec steady decode gen tok/s | no-spec steady decode gen tok/s | speedup |
| --- | --- | --- | --- |
| 4 | 1024.64 | 402.51 | 2.546x |
| 8 | 1681.14 | 669.43 | 2.511x |
| 16 | 2503.09 | 1046.65 | 2.392x |
| 32 | 4076.77 | 1711.67 | 2.382x |
| 64 | 5025.27 | 2629.48 | 1.911x |

Notes:
- TTFT/ITL are benchserving streaming-client metrics. TTFT includes scheduling and queueing under load, not only first-token compute.
- ITL is inter-stream-chunk latency for `sgl-jax`; it is not retokenized by accepted-token count for speculative decoding in this backend.

## Throughput comparison plot

![Spec vs no-spec steady decode throughput comparison](https://gist.githubusercontent.com/pengchengneo/328518a93ecd11366e5bea09f605d189/raw/c5a482cad0e96546f69bd6148291939308967d1e/spec-vs-nospec-steady-decode-throughput.svg)

