### PR TITLE
perf(scheduler): cut per-step host overhead — cache_loc buffer reuse, sync next_token_ids

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1937,7 +1937,16 @@ class ScheduleBatch:
             total_cache_loc_size = cache_loc_paddings[bs_index]
 
         per_dp_cache_loc_size = total_cache_loc_size // self.dp_size
-        cache_loc_cpu = np.zeros(total_cache_loc_size, dtype=np.int32)
+        # View into the persistent buffer; intentionally NOT re-zeroed per step.
+        # Safe because:
+        #  - padding slots are never read on-device: attention kernels (RPA v3 /
+        #    MLA v2 / native) bound page reads by cu_kv_lens / seq_lens, and every
+        #    real-request page slot lands on a written position.
+        #  - every buffer value is a valid in-bounds KV slot index (init is
+        #    np.zeros + only valid slots are ever written), so even SWA's
+        #    host-side mapping[cache_loc] lookup (flashattention_backend) can't go
+        #    OOB. This REQUIRES the init buffer to be np.zeros, not np.empty.
+        cache_loc_cpu = self.req_to_token_pool.cache_loc_host_buf[:total_cache_loc_size]
 
         offset_bs = 0
         req_to_token = self.req_to_token_pool.req_to_token

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1946,7 +1946,15 @@ class ScheduleBatch:
         #    np.zeros + only valid slots are ever written), so even SWA's
         #    host-side mapping[cache_loc] lookup (flashattention_backend) can't go
         #    OOB. This REQUIRES the init buffer to be np.zeros, not np.empty.
-        cache_loc_cpu = self.req_to_token_pool.cache_loc_host_buf[:total_cache_loc_size]
+        cache_loc_host_buf = self.req_to_token_pool.cache_loc_host_buf
+        assert (
+            cache_loc_host_buf is not None and cache_loc_host_buf.shape[0] >= total_cache_loc_size
+        ), (
+            "cache_loc_host_buf is not initialized or too small: "
+            f"capacity={0 if cache_loc_host_buf is None else cache_loc_host_buf.shape[0]}, "
+            f"required={total_cache_loc_size}"
+        )
+        cache_loc_cpu = cache_loc_host_buf[:total_cache_loc_size]
 
         offset_bs = 0
         req_to_token = self.req_to_token_pool.req_to_token

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -234,6 +234,12 @@ class ModelWorker:
             has_recurrent_state=self.model_runner.linear_recurrent_config is not None,
         )
 
+        # Allocate the persistent cache_loc host buffer once (reused every step
+        # by ScheduleBatch._merge_cache_loc), sized to the largest cache_loc bucket.
+        self.model_runner.req_to_token_pool.init_cache_loc_host_buffer(
+            self.compilation_manager.cache_loc_buckets[-1]
+        )
+
         self.parent_process = psutil.Process().parent()
         self.sync_queue = Queue()
         self.sync_expert_ids_d2h_thread = threading.Thread(

--- a/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
@@ -157,7 +157,7 @@ class ModelWorkerClient:
             if logits_output.hidden_states is not None
             else None
         )
-        async_next_tokens = jax.copy_to_host_async(next_token_ids)
+        next_token_ids = jax.device_get(next_token_ids).tolist()
 
         # Step 2: materialize. The first np.asarray waits for that array's
         # copy; the others have been making progress in parallel.
@@ -167,7 +167,6 @@ class ModelWorkerClient:
             logits_output.input_token_logprobs = np.asarray(async_input_logprobs).tolist()
         if async_hidden_states is not None:
             logits_output.hidden_states = np.asarray(async_hidden_states)
-        next_token_ids = np.asarray(async_next_tokens).tolist()
 
         if launch_done is not None:
             launch_done.wait()

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -85,6 +85,17 @@ class ReqToTokenPool:
         # Use simple list to manage free slots
         self.free_slots = list(range(size))
 
+        # Persistent host scratch buffer reused by
+        # ScheduleBatch._merge_cache_loc to avoid a fresh np.zeros every step.
+        # Allocated once at startup via init_cache_loc_host_buffer (its size is
+        # only known after the precompile cache_loc buckets are computed).
+        self.cache_loc_host_buf = None
+
+    def init_cache_loc_host_buffer(self, size: int):
+        """Pre-allocate the persistent cache_loc host buffer (called once at
+        init by tp_worker with the largest cache_loc precompile bucket)."""
+        self.cache_loc_host_buf = np.zeros(size, dtype=np.int32)
+
     def tree_flatten(self):
         children = (self.req_to_token,)
         aux_data = {
@@ -105,6 +116,10 @@ class ReqToTokenPool:
         obj.free_slots = aux_data["free_slots"]
 
         obj.req_to_token = children[0]
+        # Host scratch buffer is transient host memory, not model state, so it
+        # is not carried through the pytree. The live serving pool keeps its
+        # init-time buffer; _merge_cache_loc never runs on a reconstructed pool.
+        obj.cache_loc_host_buf = None
 
         return obj
 

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -92,9 +92,9 @@ class ReqToTokenPool:
         self.cache_loc_host_buf = None
 
     def init_cache_loc_host_buffer(self, size: int):
-        """Pre-allocate the persistent cache_loc host buffer (called once at
-        init by tp_worker with the largest cache_loc precompile bucket)."""
-        self.cache_loc_host_buf = np.zeros(size, dtype=np.int32)
+        """Ensure the persistent cache_loc host buffer has enough capacity."""
+        if self.cache_loc_host_buf is None or self.cache_loc_host_buf.shape[0] < size:
+            self.cache_loc_host_buf = np.zeros(size, dtype=np.int32)
 
     def tree_flatten(self):
         children = (self.req_to_token,)

--- a/python/sgl_jax/test/mem_cache/test_req_to_token_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_req_to_token_pool.py
@@ -115,6 +115,30 @@ class TestReqToTokenPoolFree(CustomTestCase):
         self.assertEqual(self.pool.free_slots, free_slots_before)
 
 
+class TestReqToTokenPoolCacheLocHostBuffer(CustomTestCase):
+    def setUp(self):
+        self.pool = ReqToTokenPool(size=4, max_context_len=16, dtype=np.int32)
+
+    def test_cache_loc_host_buffer_never_shrinks(self):
+        self.pool.init_cache_loc_host_buffer(16)
+        original = self.pool.cache_loc_host_buf
+        original[:] = 7
+
+        self.pool.init_cache_loc_host_buffer(8)
+
+        self.assertIs(self.pool.cache_loc_host_buf, original)
+        self.assertEqual(self.pool.cache_loc_host_buf.shape[0], 16)
+        np.testing.assert_array_equal(self.pool.cache_loc_host_buf, np.full(16, 7, dtype=np.int32))
+
+    def test_cache_loc_host_buffer_grows_when_needed(self):
+        self.pool.init_cache_loc_host_buffer(8)
+
+        self.pool.init_cache_loc_host_buffer(16)
+
+        self.assertEqual(self.pool.cache_loc_host_buf.shape[0], 16)
+        np.testing.assert_array_equal(self.pool.cache_loc_host_buf, np.zeros(16, dtype=np.int32))
+
+
 class TestReqToTokenPoolChunkedReqLifecycle(CustomTestCase):
     """End-to-end lock-in for chunked-req slot ownership across batches."""
 


### PR DESCRIPTION
## What

Two scheduler-side perf changes that reduce per-step host (CPU) overhead on the
single scheduler thread. Cherry-picked from #1264 to land independently of the
fused-moe-v2 work in that PR.

> The incremental-detokenize change originally on this branch has been dropped —
> it is already covered by #1295.

### Commits

1. **`overlap`: materialize `next_token_ids` synchronously via `device_get`**
   Replaces the async `copy_to_host` of `next_token_ids` with a blocking
   `jax.device_get(next_token_ids).tolist()` in `ModelWorkerClient`'s resolve
   path. logprobs / input_logprobs / hidden_states keep the async `copy_to_host`
   pipeline.

2. **`perf(schedule)`: reuse a persistent host buffer for `cache_loc` (no per-step `np.zeros`)**
   `_merge_cache_loc` allocated a fresh `np.zeros(total_cache_loc_size)` every
   step, paying malloc/munmap churn + first-touch page faults on every written
   page; on long-context / high-concurrency decode the padded `cache_loc` table
   is multi-MB. Now `ReqToTokenPool` owns a `cache_loc_host_buf` that `tp_worker`
   allocates **once at startup**, sized to the largest cache_loc precompile
   bucket (`cache_loc_buckets[-1]`, the earliest point that size is known).
   `_merge_cache_loc` just slices `buf[:total]` — no per-step allocation, and no
   per-step zeroing: padding slots are never read on-device (attention kernels
   truncate KV via `seq_lens` / `cu_kv_lens`), and real-request slots are
   overwritten by the scatter loop. The per-req page-aligned scatter is unchanged.
   Reuse is safe: `ForwardBatch.init_new`'s H2D copy runs synchronously on the
   scheduler thread before the next step rebuilds the buffer, and the resulting
   device array does not alias the host buffer.

## Test

- `python -m py_compile` clean on all changed files; `mypy` pre-commit passes.

### Accuracy validation (MiMo-V2-Flash)

Ran this branch (clean, off `main`) on **MiMo-V2-Flash** (fp8 block-128) on a v7x
32-device pod (`--moe-backend epmoe`, tp=32 / dp=8 / ep=32) and measured GSM8K
accuracy (thinking mode, chat template, `temperature=0.6 top_p=0.95`,
`max_new_tokens=6144`):

| concurrency | GSM8K accuracy |
|---|---|
| parallel=1 (single-stream) | 1.00 (12/12) |
| parallel=64 (batched) | 0.95 (95/100) |

Batched ≈ single-stream — no degeneration under concurrency, and consistent with
MiMo-V2-Flash's known GSM8K level (~0.96). The per-step `cache_loc` buffer reuse
and synchronous `next_token_ids` materialization do not change output correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
