### PR TITLE
feat(model): Gemma4-31B text decoder + vision encoder

### DIFF
--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -603,9 +603,9 @@ class FlashAttention(AttentionBackend):
             out_specs=out_specs,
             check_vma=False,
         )(
-            q.reshape(q.shape[0], -1, self.head_dim),
-            k.reshape(k.shape[0], -1, self.head_dim),
-            v.reshape(v.shape[0], -1, self.head_dim),
+            q.reshape(q.shape[0], -1, layer.head_dim if layer else self.head_dim),
+            k.reshape(k.shape[0], -1, layer.head_dim if layer else self.head_dim),
+            v.reshape(v.shape[0], -1, layer.v_head_dim if layer else self.head_dim),
             kv_cache_fused,
             self.forward_metadata.seq_lens,
             page_indices_arg,

--- a/python/sgl_jax/srt/layers/embeddings.py
+++ b/python/sgl_jax/srt/layers/embeddings.py
@@ -486,9 +486,7 @@ class ProportionalRotaryEmbedding(RotaryEmbedding):
             base ** (np.arange(0, 2 * rope_angles, 2, dtype=np.float32) / head_size)
         )
         if nope_angles > 0:
-            inv_freq = np.concatenate(
-                [inv_freq_rotated, np.zeros(nope_angles, dtype=np.float32)]
-            )
+            inv_freq = np.concatenate([inv_freq_rotated, np.zeros(nope_angles, dtype=np.float32)])
         else:
             inv_freq = inv_freq_rotated
         self._inv_freq_np = inv_freq / factor

--- a/python/sgl_jax/srt/layers/embeddings.py
+++ b/python/sgl_jax/srt/layers/embeddings.py
@@ -453,6 +453,47 @@ class MRotaryEmbedding(RotaryEmbedding):
         return query, key
 
 
+class ProportionalRotaryEmbedding(RotaryEmbedding):
+    """Proportional RoPE (Gemma4 full-attention layers).
+
+    Unlike standard partial-rotary which scales inv_freq by ``rotary_dim``,
+    proportional keeps the inv_freq denominator as the full ``head_size`` and
+    zero-pads the tail so the unrotated dims see cos=1/sin=0.
+    Matches HF ``_compute_proportional_rope_parameters``.
+    """
+
+    def __init__(
+        self,
+        head_size: int,
+        max_position_embeddings: int,
+        base: float,
+        is_neox_style: bool,
+        dtype: jnp.dtype,
+        partial_rotary_factor: float = 1.0,
+        factor: float = 1.0,
+    ):
+        super().__init__(
+            head_size=head_size,
+            rotary_dim=head_size,
+            max_position_embeddings=max_position_embeddings,
+            base=base,
+            is_neox_style=is_neox_style,
+            dtype=dtype,
+        )
+        rope_angles = int(partial_rotary_factor * head_size // 2)
+        nope_angles = head_size // 2 - rope_angles
+        inv_freq_rotated = 1.0 / (
+            base ** (np.arange(0, 2 * rope_angles, 2, dtype=np.float32) / head_size)
+        )
+        if nope_angles > 0:
+            inv_freq = np.concatenate(
+                [inv_freq_rotated, np.zeros(nope_angles, dtype=np.float32)]
+            )
+        else:
+            inv_freq = inv_freq_rotated
+        self._inv_freq_np = inv_freq / factor
+
+
 class Llama3RotaryEmbedding(RotaryEmbedding):
     def __init__(
         self,
@@ -625,6 +666,18 @@ def get_rope(
             # equivalent to rope_scaling=None.  Fall back to plain RotaryEmbedding.
             rotary_emb = RotaryEmbedding(
                 head_size, rotary_dim, max_position, base, is_neox_style, dtype
+            )
+        elif scaling_type == "proportional":
+            rotary_emb = ProportionalRotaryEmbedding(
+                head_size,
+                max_position,
+                base,
+                is_neox_style,
+                dtype,
+                partial_rotary_factor=rope_scaling.get(
+                    "partial_rotary_factor", partial_rotary_factor
+                ),
+                factor=rope_scaling.get("factor", 1.0),
             )
         elif scaling_type == "llama3":
             scaling_factor = rope_scaling["factor"]

--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -271,6 +271,9 @@ class GenerateReqInput:
     input_ids: list[list[int]] | list[int] | None = None
     # The embeddings for input_ids; one can specify either text or input_ids or input_embeds.
     input_embeds: list[list[list[float]]] | list[list[float]] | None = None
+    # Pre-computed multimodal inputs (e.g. {"multimodal_embedding": [[...], ...]}) to
+    # bypass server-side encoding. Passed through to scheduler unchanged.
+    mm_inputs: dict | None = None
     # The image input. It can be an image instance, file name, URL, or base64 encoded string.
     # Can be formatted as:
     # - Single image for a single request
@@ -332,8 +335,13 @@ class GenerateReqInput:
             raise ValueError("The rid should be a string or a list of strings.")
 
     def normalize_batch_and_arguments(self):
-        # at least one of text, input_ids, or image should be provided
-        if self.text is None and self.input_ids is None and self.image_data is None:
+        # at least one of text, input_ids, input_embeds, or image should be provided
+        if (
+            self.text is None
+            and self.input_ids is None
+            and self.input_embeds is None
+            and self.image_data is None
+        ):
             raise ValueError("At least one of text, input_ids, or image should be provided")
 
         # text and input_ids cannot be provided at the same time

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -21,8 +21,8 @@ from typing import Any
 
 import fastapi
 import jax
-import numpy as np
 import jax.numpy as jnp
+import numpy as np
 import uvloop
 import zmq
 import zmq.asyncio

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import fastapi
 import jax
+import numpy as np
 import jax.numpy as jnp
 import uvloop
 import zmq
@@ -303,6 +304,8 @@ class TokenizerManager:
                 )
             encoded = self.tokenizer(input_text)
             input_ids = encoded["input_ids"]
+        if input_ids is None and getattr(obj, "input_embeds", None) is not None:
+            input_ids = [0] * len(obj.input_embeds)
         self._validate_one_request(obj, input_ids)
         return self._create_tokenized_object(obj, input_text, input_ids)
 
@@ -373,6 +376,12 @@ class TokenizerManager:
             obj.extra_key,
             obj.return_routed_experts,
         )
+        if getattr(obj, "mm_inputs", None) is not None:
+            tokenized_obj.mm_inputs = obj.mm_inputs
+        elif getattr(obj, "input_embeds", None) is not None:
+            tokenized_obj.mm_inputs = {
+                "multimodal_embedding": np.asarray(obj.input_embeds, dtype=np.float32)
+            }
         # note: When only `return_logprob` is specified, we assume that only the output probability is required.
         if (
             tokenized_obj.return_logprob

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -626,6 +626,7 @@ class SWAKVPool(KVCache):
         full_attention_layer_ids: list[int],
         token_to_kv_pool_class: KVCache = MHATokenToKVPool,
         swa_head_num: int | None = None,
+        swa_head_dim: int | None = None,
         **kwargs,
     ):
         self.size = size
@@ -638,12 +639,14 @@ class SWAKVPool(KVCache):
         self.kv_partition_axis = "tensor"
         kwargs["page_size"] = page_size
 
-        # If SWA layers have different KV head count, create separate kwargs
+        # If SWA layers have different KV head count/dim, create separate kwargs
+        swa_kwargs = kwargs
         if swa_head_num is not None and swa_head_num != kwargs.get("head_num"):
-            swa_kwargs = dict(kwargs)
+            swa_kwargs = dict(swa_kwargs)
             swa_kwargs["head_num"] = swa_head_num
-        else:
-            swa_kwargs = kwargs
+        if swa_head_dim is not None and swa_head_dim != kwargs.get("head_dim"):
+            swa_kwargs = dict(swa_kwargs) if swa_kwargs is kwargs else swa_kwargs
+            swa_kwargs["head_dim"] = swa_head_dim
 
         self.swa_kv_pool = token_to_kv_pool_class(
             size=size_swa,

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -460,6 +460,16 @@ class ModelRunnerKVCacheMixin:
                 ),
                 head_dim=(self.model_config.head_dim + 127) // 128 * 128,
                 swa_head_num=swa_head_num,
+                swa_head_dim=(
+                    (
+                        getattr(self.model_config.hf_text_config, "swa_head_dim", None)
+                        + 127
+                    )
+                    // 128
+                    * 128
+                    if getattr(self.model_config.hf_text_config, "swa_head_dim", None)
+                    else None
+                ),
                 mesh=self.mesh,
                 dp_size=dp_size,
             )

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -461,10 +461,7 @@ class ModelRunnerKVCacheMixin:
                 head_dim=(self.model_config.head_dim + 127) // 128 * 128,
                 swa_head_num=swa_head_num,
                 swa_head_dim=(
-                    (
-                        getattr(self.model_config.hf_text_config, "swa_head_dim", None)
-                        + 127
-                    )
+                    (getattr(self.model_config.hf_text_config, "swa_head_dim", None) + 127)
                     // 128
                     * 128
                     if getattr(self.model_config.hf_text_config, "swa_head_dim", None)

--- a/python/sgl_jax/srt/models/gemma4.py
+++ b/python/sgl_jax/srt/models/gemma4.py
@@ -381,11 +381,7 @@ class Gemma4ForConditionalGeneration(nnx.Module):
     def _k_eq_v_layers(self) -> set[int]:
         if not getattr(self.text_config, "attention_k_eq_v", False):
             return set()
-        return {
-            i
-            for i, t in enumerate(self.text_config.layer_types)
-            if t == _FULL
-        }
+        return {i for i, t in enumerate(self.text_config.layer_types) if t == _FULL}
 
     def _create_weight_mappings(self) -> dict[str, WeightMapping]:
         mappings: dict[str, WeightMapping] = {

--- a/python/sgl_jax/srt/models/gemma4.py
+++ b/python/sgl_jax/srt/models/gemma4.py
@@ -1,0 +1,474 @@
+"""Gemma4 text decoder for sglang-jax.
+
+31B dense variant only (no PLE / no Shared-KV / no MoE). Multimodal vision
+encoder lives separately under ``srt/multimodal/models/gemma4/``; this file
+loads ``model.language_model.*`` weights from the
+``Gemma4ForConditionalGeneration`` checkpoint and ignores the rest.
+
+Key deltas vs Gemma2:
+- Heterogeneous attention: full layers use ``global_head_dim`` /
+  ``num_global_key_value_heads`` and proportional RoPE; sliding layers use the
+  base ``head_dim`` / ``num_key_value_heads`` with default RoPE.
+- ``attention_k_eq_v``: full layers ship no ``v_proj`` checkpoint; we alias
+  ``k_proj`` weights into ``v_proj`` at load time.
+- Q/K RMSNorm + scale-free V RMSNorm; attention scaling is 1.0.
+- Standard RMSNorm (``x * w``) everywhere, not Gemma2's ``x * (1 + w)``.
+- Per-layer learned scalar multiplied onto the residual sum.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from transformers import PretrainedConfig
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.layers.embeddings import Embed, get_rope
+from sgl_jax.srt.layers.layernorm import RMSNorm
+from sgl_jax.srt.layers.linear import LinearBase
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
+from sgl_jax.srt.layers.radix_attention import RadixAttention
+from sgl_jax.srt.mem_cache.memory_pool import KVCache, MemoryPools
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+
+logger = logging.getLogger(__name__)
+
+_SLIDING = "sliding_attention"
+_FULL = "full_attention"
+_HF_PREFIX = "model.language_model"
+
+
+def _layer_type(config: PretrainedConfig, layer_id: int) -> str:
+    return config.layer_types[layer_id]
+
+
+class Gemma4MLP(nnx.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        mesh: jax.sharding.Mesh,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.gate_proj = LinearBase(
+            input_size=hidden_size,
+            output_size=intermediate_size,
+            kernel_axes=(None, "tensor"),
+            use_bias=False,
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+        self.up_proj = LinearBase(
+            input_size=hidden_size,
+            output_size=intermediate_size,
+            kernel_axes=(None, "tensor"),
+            use_bias=False,
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+        self.down_proj = LinearBase(
+            input_size=intermediate_size,
+            output_size=hidden_size,
+            kernel_axes=("tensor", None),
+            use_bias=False,
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+
+    def __call__(self, hidden_states: jax.Array) -> jax.Array:
+        a1, _ = self.gate_proj(hidden_states)
+        a2, _ = self.up_proj(hidden_states)
+        intermediate = a2 * jax.nn.gelu(a1, approximate=True)
+        output, _ = self.down_proj(intermediate)
+        return output
+
+
+class Gemma4Attention(nnx.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        layer_id: int,
+        mesh: jax.sharding.Mesh,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        layer_type = _layer_type(config, layer_id)
+        is_sliding = layer_type == _SLIDING
+
+        self.layer_id = layer_id
+        self.num_heads = config.num_attention_heads
+        self.head_dim = (
+            getattr(config, "swa_head_dim", config.head_dim) if is_sliding else config.head_dim
+        )
+        self.num_kv_heads = (
+            getattr(config, "swa_num_key_value_heads", config.num_key_value_heads)
+            if is_sliding
+            else config.num_key_value_heads
+        )
+        hidden_size = config.hidden_size
+
+        self.q_proj = LinearBase(
+            input_size=hidden_size,
+            output_size=self.num_heads * self.head_dim,
+            kernel_axes=(None, "tensor"),
+            use_bias=config.attention_bias,
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+        self.k_proj = LinearBase(
+            input_size=hidden_size,
+            output_size=self.num_kv_heads * self.head_dim,
+            kernel_axes=(None, "tensor"),
+            use_bias=config.attention_bias,
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+        self.k_eq_v = not is_sliding and getattr(config, "attention_k_eq_v", False)
+        if not self.k_eq_v:
+            self.v_proj = LinearBase(
+                input_size=hidden_size,
+                output_size=self.num_kv_heads * self.head_dim,
+                kernel_axes=(None, "tensor"),
+                use_bias=config.attention_bias,
+                params_dtype=dtype,
+                mesh=mesh,
+            )
+        self.o_proj = LinearBase(
+            input_size=self.num_heads * self.head_dim,
+            output_size=hidden_size,
+            kernel_axes=("tensor", None),
+            use_bias=config.attention_bias,
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+
+        self.q_norm = RMSNorm(self.head_dim, epsilon=config.rms_norm_eps, dtype=dtype)
+        self.k_norm = RMSNorm(self.head_dim, epsilon=config.rms_norm_eps, dtype=dtype)
+        self.v_norm = RMSNorm(
+            self.head_dim, epsilon=config.rms_norm_eps, use_scale=False, dtype=dtype
+        )
+
+        rope_params = dict(config.rope_parameters.get(layer_type, {"rope_type": "default"}))
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=config.max_position_embeddings,
+            base=rope_params.get("rope_theta", 10000.0),
+            rope_scaling=rope_params,
+            is_neox_style=True,
+            dtype=dtype,
+        )
+
+        self.attn = RadixAttention(
+            num_heads=self.num_heads,
+            head_dim=self.head_dim,
+            scaling=1.0,
+            num_kv_heads=self.num_kv_heads,
+            layer_id=layer_id,
+            sliding_window_size=config.sliding_window if is_sliding else 0,
+            logit_cap=0.0,
+        )
+
+    def __call__(
+        self,
+        hidden_states: jax.Array,
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: KVCache,
+    ) -> tuple[jax.Array, jax.Array]:
+        q, _ = self.q_proj(hidden_states)
+        k, _ = self.k_proj(hidden_states)
+        v = k if self.k_eq_v else self.v_proj(hidden_states)[0]
+
+        q = q.reshape(-1, self.num_heads, self.head_dim)
+        k = k.reshape(-1, self.num_kv_heads, self.head_dim)
+        v = v.reshape(-1, self.num_kv_heads, self.head_dim)
+
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+        v = self.v_norm(v)
+
+        q, k = self.rotary_emb(forward_batch.positions, q, k)
+
+        attn_output, kv_fused = self.attn(
+            q, k, v, forward_batch=forward_batch, token_to_kv_pool=token_to_kv_pool
+        )
+        output, _ = self.o_proj(attn_output)
+        return output, kv_fused
+
+
+class Gemma4DecoderLayer(nnx.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        layer_id: int = 0,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.layer_id = layer_id
+        eps = config.rms_norm_eps
+
+        self.self_attn = Gemma4Attention(config, layer_id, mesh=mesh, dtype=dtype)
+        self.mlp = Gemma4MLP(config.hidden_size, config.intermediate_size, mesh=mesh, dtype=dtype)
+
+        self.input_layernorm = RMSNorm(config.hidden_size, epsilon=eps, dtype=dtype)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, epsilon=eps, dtype=dtype)
+        self.pre_feedforward_layernorm = RMSNorm(config.hidden_size, epsilon=eps, dtype=dtype)
+        self.post_feedforward_layernorm = RMSNorm(config.hidden_size, epsilon=eps, dtype=dtype)
+
+        self.layer_scalar = nnx.Param(jnp.ones((1,), dtype=dtype))
+
+    def __call__(
+        self,
+        hidden_states: jax.Array,
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: KVCache,
+    ) -> tuple[jax.Array, jax.Array]:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, kv_fused = self.self_attn(hidden_states, forward_batch, token_to_kv_pool)
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.pre_feedforward_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.post_feedforward_layernorm(hidden_states)
+        hidden_states = (residual + hidden_states) * jnp.asarray(
+            self.layer_scalar, hidden_states.dtype
+        )
+        return hidden_states, kv_fused
+
+
+class Gemma4TextModel(nnx.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.hidden_size = config.hidden_size
+        self.embed_tokens = Embed(
+            config.vocab_size,
+            config.hidden_size,
+            dtype=dtype,
+            param_dtype=dtype,
+            kernel_axes=("tensor", None),
+            mesh=mesh,
+        )
+        self.layers = nnx.data(
+            [
+                Gemma4DecoderLayer(config, layer_id=i, dtype=dtype, mesh=mesh)
+                for i in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = RMSNorm(config.hidden_size, epsilon=config.rms_norm_eps, dtype=dtype)
+
+    def __call__(
+        self,
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: KVCache,
+    ) -> tuple[jax.Array, list[jax.Array]]:
+        if (
+            forward_batch.input_embedding is not None
+            and forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
+        ):
+            hidden_states = forward_batch.input_embedding
+        else:
+            hidden_states = self.embed_tokens(forward_batch.input_ids)
+            hidden_states *= jnp.array([self.hidden_size**0.5], dtype=hidden_states.dtype)
+
+        layers_kv_fused: list[jax.Array] = []
+        for layer in self.layers:
+            hidden_states, kv_fused = layer(hidden_states, forward_batch, token_to_kv_pool)
+            layers_kv_fused.append(kv_fused)
+
+        hidden_states = self.norm(hidden_states)
+        return hidden_states, layers_kv_fused
+
+
+class Gemma4ForConditionalGeneration(nnx.Module):
+    """Phase-1 text-only entry. Vision tower added in Phase 2."""
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.mesh = mesh
+        self.config = config
+        self.dtype = dtype
+        text_config = getattr(config, "text_config", config)
+        self.text_config = text_config
+        self.language_model = Gemma4TextModel(text_config, dtype=dtype, mesh=mesh)
+        self.logits_processor = LogitsProcessor(
+            text_config.vocab_size,
+            soft_cap=getattr(text_config, "final_logit_softcapping", None),
+            mesh=mesh,
+        )
+
+    # Expose ``model.layers`` so model_runner's hybrid-SWA layer scan works.
+    @property
+    def model(self):
+        return self.language_model
+
+    @classmethod
+    def patch_model_config(cls, model_config: ModelConfig) -> None:
+        """Remap HF Gemma4 attention dims to sglang's swa_* / base convention.
+
+        HF: base attrs describe sliding layers, ``global_*`` describe full layers.
+        sglang: base attrs describe full layers, ``swa_*`` describe sliding layers.
+
+        Mutates ``hf_text_config`` in place (matching the existing sglang pattern
+        in ``model_config.get_total_num_kv_heads_with_replication``). The
+        ``_gemma4_patched`` guard makes this idempotent across the multiple
+        ``ModelConfig`` constructions that share one ``hf_config`` object.
+        """
+        text_cfg = model_config.hf_text_config
+        global_head_dim = getattr(text_cfg, "global_head_dim", None)
+        global_kv = getattr(text_cfg, "num_global_key_value_heads", None)
+        if global_head_dim is None and global_kv is None:
+            return
+        if getattr(text_cfg, "_gemma4_patched", False):
+            # ModelConfig is constructed multiple times per process sharing the
+            # same hf_config; the remap below is not idempotent.
+            model_config.head_dim = text_cfg.head_dim
+            return
+        text_cfg._gemma4_patched = True
+
+        text_cfg.swa_head_dim = text_cfg.head_dim
+        text_cfg.swa_num_key_value_heads = text_cfg.num_key_value_heads
+        if global_head_dim is not None:
+            text_cfg.head_dim = global_head_dim
+        if global_kv is not None:
+            text_cfg.num_key_value_heads = global_kv
+
+        # Mirror onto top-level hf_config for callers that read it directly
+        # (e.g. model_runner_kv_cache_mixin reads swa_num_key_value_heads there).
+        for attr in ("swa_head_dim", "swa_num_key_value_heads", "head_dim", "num_key_value_heads"):
+            setattr(model_config.hf_config, attr, getattr(text_cfg, attr))
+
+        model_config.head_dim = text_cfg.head_dim
+
+    def __call__(
+        self,
+        forward_batch: ForwardBatch,
+        memory_pools: MemoryPools,
+        logits_metadata: LogitsMetadata,
+    ):
+        kv_pool = memory_pools.token_to_kv_pool
+        hidden_states, layers_kv_fused = self.language_model(forward_batch, kv_pool)
+        output = self.logits_processor(
+            hidden_states, self.language_model.embed_tokens, logits_metadata
+        )
+        return output, {"token_to_kv_pool": layers_kv_fused}, True, None
+
+    # ------------------------------------------------------------------ #
+    # Weight loading
+    # ------------------------------------------------------------------ #
+
+    def load_weights(self, model_config: ModelConfig) -> None:
+        loader = WeightLoader(
+            model=self, model_config=model_config, mesh=self.mesh, dtype=self.dtype
+        )
+        mappings = self._create_weight_mappings()
+        loader.load_weights_from_safetensors(mappings)
+        logger.info("Gemma4 language_model weights loaded (vision tower skipped).")
+
+    def _k_eq_v_layers(self) -> set[int]:
+        if not getattr(self.text_config, "attention_k_eq_v", False):
+            return set()
+        return {
+            i
+            for i, t in enumerate(self.text_config.layer_types)
+            if t == _FULL
+        }
+
+    def _create_weight_mappings(self) -> dict[str, WeightMapping]:
+        mappings: dict[str, WeightMapping] = {
+            f"{_HF_PREFIX}.embed_tokens.weight": WeightMapping(
+                target_path="language_model.embed_tokens.embedding",
+                sharding=("tensor", None),
+                transpose=False,
+            ),
+            f"{_HF_PREFIX}.norm.weight": WeightMapping(
+                target_path="language_model.norm.scale",
+                sharding=(None,),
+                transpose=False,
+            ),
+        }
+        k_eq_v = self._k_eq_v_layers()
+        for layer_id in range(self.text_config.num_hidden_layers):
+            mappings.update(self._create_layer_mappings(layer_id, layer_id in k_eq_v))
+        return mappings
+
+    def _create_layer_mappings(self, layer_id: int, k_eq_v: bool) -> dict[str, WeightMapping]:
+        src = f"{_HF_PREFIX}.layers.{layer_id}"
+        dst = f"language_model.layers.{layer_id}"
+
+        m: dict[str, WeightMapping] = {
+            f"{src}.layer_scalar": WeightMapping(
+                target_path=f"{dst}.layer_scalar", sharding=(None,), transpose=False
+            ),
+        }
+        for ln in (
+            "input_layernorm",
+            "post_attention_layernorm",
+            "pre_feedforward_layernorm",
+            "post_feedforward_layernorm",
+        ):
+            m[f"{src}.{ln}.weight"] = WeightMapping(
+                target_path=f"{dst}.{ln}.scale", sharding=(None,), transpose=False
+            )
+
+        m[f"{src}.self_attn.q_norm.weight"] = WeightMapping(
+            target_path=f"{dst}.self_attn.q_norm.scale", sharding=(None,), transpose=False
+        )
+        m[f"{src}.self_attn.k_norm.weight"] = WeightMapping(
+            target_path=f"{dst}.self_attn.k_norm.scale", sharding=(None,), transpose=False
+        )
+
+        m[f"{src}.self_attn.q_proj.weight"] = WeightMapping(
+            target_path=f"{dst}.self_attn.q_proj.weight",
+            sharding=(None, "tensor"),
+            transpose=True,
+        )
+        m[f"{src}.self_attn.o_proj.weight"] = WeightMapping(
+            target_path=f"{dst}.self_attn.o_proj.weight",
+            sharding=("tensor", None),
+            transpose=True,
+        )
+        # Only full-attention layers need kv_head_padding (4 heads < TP=8).
+        # Sliding layers have 16 heads ≥ any practical TP. WeightLoader's
+        # padding uses model_config.head_dim (= full head_dim after patch),
+        # so applying it to sliding (head_dim=256) would mis-reshape.
+        m[f"{src}.self_attn.k_proj.weight"] = WeightMapping(
+            target_path=f"{dst}.self_attn.k_proj.weight",
+            sharding=(None, "tensor"),
+            transpose=True,
+            kv_head_padding=k_eq_v,
+        )
+        if not k_eq_v:
+            m[f"{src}.self_attn.v_proj.weight"] = WeightMapping(
+                target_path=f"{dst}.self_attn.v_proj.weight",
+                sharding=(None, "tensor"),
+                transpose=True,
+            )
+
+        for proj, axes in (
+            ("gate_proj", (None, "tensor")),
+            ("up_proj", (None, "tensor")),
+            ("down_proj", ("tensor", None)),
+        ):
+            m[f"{src}.mlp.{proj}.weight"] = WeightMapping(
+                target_path=f"{dst}.mlp.{proj}.weight",
+                sharding=axes,
+                transpose=True,
+            )
+        return m
+
+
+EntryClass = Gemma4ForConditionalGeneration

--- a/python/sgl_jax/srt/multimodal/models/gemma4/vision_encoder.py
+++ b/python/sgl_jax/srt/multimodal/models/gemma4/vision_encoder.py
@@ -1,0 +1,335 @@
+"""Gemma4 vision encoder for sglang-jax.
+
+Ported from MaxText ``gemma4_vision.py`` and HF ``Gemma4VisionModel``. Expects
+pre-patchified inputs (HF ``Gemma4ImageProcessor`` output) so the encoder itself
+is shape-static for a fixed token budget. P0 supports the default 280-token
+budget only (2520 patches → 3×3 pool).
+
+No KV cache, no paging — plain bidirectional self-attention. Runs on a single
+device by default; sharding annotations are deferred to P2.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+PATCH_DIM = 16 * 16 * 3  # 768
+
+# Gemma4 supported token budgets → required input patch count (= budget × pool_k²).
+TOKEN_BUDGETS = (70, 140, 280, 560, 1120)
+
+
+def patches_for_budget(budget: int, pool_k: int = 3) -> int:
+    return budget * pool_k * pool_k
+
+
+def select_budget(num_patches: int, pool_k: int = 3) -> int:
+    """Smallest budget whose patch capacity ≥ num_patches (pad up)."""
+    for b in TOKEN_BUDGETS:
+        if patches_for_budget(b, pool_k) >= num_patches:
+            return b
+    return TOKEN_BUDGETS[-1]
+
+
+class RMSNorm(nnx.Module):
+    """Standard RMSNorm (x * w), matching HF Gemma4RMSNorm. Mesh-free."""
+
+    def __init__(
+        self, dim: int, epsilon: float = 1e-6, use_scale: bool = True, dtype=jnp.bfloat16
+    ):
+        self.eps = epsilon
+        self.dtype = dtype
+        self.scale = nnx.Param(jnp.ones((dim,), dtype=dtype)) if use_scale else None
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        x32 = x.astype(jnp.float32)
+        normed = x32 * jax.lax.rsqrt(jnp.mean(x32 * x32, axis=-1, keepdims=True) + self.eps)
+        if self.scale is not None:
+            normed = normed * self.scale.value.astype(jnp.float32)
+        return normed.astype(self.dtype)
+
+
+# --------------------------------------------------------------------------- #
+# 2-D multidimensional RoPE
+# --------------------------------------------------------------------------- #
+def _rotate_half(x: jax.Array) -> jax.Array:
+    x1, x2 = jnp.split(x, 2, axis=-1)
+    return jnp.concatenate((-x2, x1), axis=-1)
+
+
+def _apply_rope_1d(x: jax.Array, pos: jax.Array, base_freq: float) -> jax.Array:
+    """x: [..., L, H, D_part], pos: [..., L]."""
+    dim = x.shape[-1]
+    half = dim // 2
+    timescale = base_freq ** (jnp.arange(0, dim, 2, dtype=jnp.float32) / dim)
+    sinusoid = pos[..., None, None].astype(jnp.float32) / timescale
+    sin = jnp.sin(sinusoid).astype(x.dtype)
+    cos = jnp.cos(sinusoid).astype(x.dtype)
+    sin = jnp.concatenate([sin, sin], axis=-1)
+    cos = jnp.concatenate([cos, cos], axis=-1)
+    _ = half  # half computed for clarity; concat above doubles to full dim
+    return x * cos + _rotate_half(x) * sin
+
+
+def apply_2d_rope(x: jax.Array, positions_xy: jax.Array, base_freq: float) -> jax.Array:
+    """Split head_dim in two and apply RoPE per spatial axis (x then y).
+
+    x: [..., L, H, D], positions_xy: [..., L, 2].
+    """
+    d = x.shape[-1]
+    x0, x1 = jnp.split(x, 2, axis=-1)
+    y0 = _apply_rope_1d(x0, positions_xy[..., 0], base_freq)
+    y1 = _apply_rope_1d(x1, positions_xy[..., 1], base_freq)
+    out = jnp.concatenate([y0, y1], axis=-1)
+    assert out.shape[-1] == d
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Building blocks
+# --------------------------------------------------------------------------- #
+class Gemma4VisionMLP(nnx.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int, dtype: jnp.dtype, rngs: nnx.Rngs):
+        self.gate_proj = nnx.Linear(
+            hidden_size, intermediate_size, use_bias=False, param_dtype=dtype, rngs=rngs
+        )
+        self.up_proj = nnx.Linear(
+            hidden_size, intermediate_size, use_bias=False, param_dtype=dtype, rngs=rngs
+        )
+        self.down_proj = nnx.Linear(
+            intermediate_size, hidden_size, use_bias=False, param_dtype=dtype, rngs=rngs
+        )
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        return self.down_proj(jax.nn.gelu(self.gate_proj(x), approximate=True) * self.up_proj(x))
+
+
+class Gemma4VisionAttention(nnx.Module):
+    def __init__(self, cfg, dtype: jnp.dtype, rngs: nnx.Rngs):
+        self.num_heads = cfg.num_attention_heads
+        self.head_dim = cfg.head_dim
+        self.rope_theta = cfg.rope_parameters["rope_theta"]
+        hidden = cfg.hidden_size
+        proj_dim = self.num_heads * self.head_dim
+
+        self.q_proj = nnx.Linear(hidden, proj_dim, use_bias=False, param_dtype=dtype, rngs=rngs)
+        self.k_proj = nnx.Linear(hidden, proj_dim, use_bias=False, param_dtype=dtype, rngs=rngs)
+        self.v_proj = nnx.Linear(hidden, proj_dim, use_bias=False, param_dtype=dtype, rngs=rngs)
+        self.o_proj = nnx.Linear(proj_dim, hidden, use_bias=False, param_dtype=dtype, rngs=rngs)
+
+        self.q_norm = RMSNorm(self.head_dim, epsilon=cfg.rms_norm_eps, dtype=dtype)
+        self.k_norm = RMSNorm(self.head_dim, epsilon=cfg.rms_norm_eps, dtype=dtype)
+        self.v_norm = RMSNorm(
+            self.head_dim, epsilon=cfg.rms_norm_eps, use_scale=False, dtype=dtype
+        )
+
+    def __call__(
+        self, x: jax.Array, positions_xy: jax.Array, padding_mask: jax.Array
+    ) -> jax.Array:
+        b, n, _ = x.shape
+        h, d = self.num_heads, self.head_dim
+
+        q = self.q_norm(self.q_proj(x).reshape(b, n, h, d))
+        k = self.k_norm(self.k_proj(x).reshape(b, n, h, d))
+        v = self.v_norm(self.v_proj(x).reshape(b, n, h, d))
+
+        q = apply_2d_rope(q, positions_xy, self.rope_theta)
+        k = apply_2d_rope(k, positions_xy, self.rope_theta)
+
+        # [B,H,N,D]
+        q = q.transpose(0, 2, 1, 3)
+        k = k.transpose(0, 2, 1, 3)
+        v = v.transpose(0, 2, 1, 3)
+
+        scores = jnp.einsum("bhnd,bhmd->bhnm", q, k).astype(jnp.float32)
+        mask = padding_mask[:, None, None, :]  # [B,1,1,N] mask out padded keys
+        scores = jnp.where(mask, scores, jnp.finfo(jnp.float32).min)
+        weights = jax.nn.softmax(scores, axis=-1).astype(x.dtype)
+
+        out = jnp.einsum("bhnm,bhmd->bhnd", weights, v)
+        out = out.transpose(0, 2, 1, 3).reshape(b, n, h * d)
+        return self.o_proj(out)
+
+
+class Gemma4VisionBlock(nnx.Module):
+    def __init__(self, cfg, dtype: jnp.dtype, rngs: nnx.Rngs):
+        eps = cfg.rms_norm_eps
+        self.input_layernorm = RMSNorm(cfg.hidden_size, epsilon=eps, dtype=dtype)
+        self.post_attention_layernorm = RMSNorm(cfg.hidden_size, epsilon=eps, dtype=dtype)
+        self.pre_feedforward_layernorm = RMSNorm(cfg.hidden_size, epsilon=eps, dtype=dtype)
+        self.post_feedforward_layernorm = RMSNorm(cfg.hidden_size, epsilon=eps, dtype=dtype)
+        self.self_attn = Gemma4VisionAttention(cfg, dtype, rngs)
+        self.mlp = Gemma4VisionMLP(cfg.hidden_size, cfg.intermediate_size, dtype, rngs)
+
+    def __call__(
+        self, x: jax.Array, positions_xy: jax.Array, padding_mask: jax.Array
+    ) -> jax.Array:
+        h = self.input_layernorm(x)
+        h = self.self_attn(h, positions_xy, padding_mask)
+        x = x + self.post_attention_layernorm(h)
+
+        h = self.pre_feedforward_layernorm(x)
+        h = self.mlp(h)
+        x = x + self.post_feedforward_layernorm(h)
+        return x
+
+
+class Gemma4VisionPatchEmbedder(nnx.Module):
+    """Linear patch projection + learned 2D factorized position embedding."""
+
+    def __init__(self, cfg, dtype: jnp.dtype, rngs: nnx.Rngs):
+        self.input_proj = nnx.Linear(
+            PATCH_DIM, cfg.hidden_size, use_bias=False, param_dtype=dtype, rngs=rngs
+        )
+        self.position_embedding_table = nnx.Param(
+            jnp.zeros((2, cfg.position_embedding_size, cfg.hidden_size), dtype=dtype)
+        )
+
+    def __call__(
+        self, patches: jax.Array, positions_xy: jax.Array, padding_mask: jax.Array
+    ) -> jax.Array:
+        x = self.input_proj(patches)
+        # Gather per-axis position embeddings then sum. Clamp -1 padding to 0
+        # and zero it via padding_mask afterwards.
+        clamped = jnp.maximum(positions_xy, 0)
+        pe_x = self.position_embedding_table[0][clamped[..., 0]]
+        pe_y = self.position_embedding_table[1][clamped[..., 1]]
+        pe = (pe_x + pe_y) * padding_mask[..., None].astype(x.dtype)
+        return x + pe.astype(x.dtype)
+
+
+def avg_pool_by_positions(
+    x: jax.Array, positions_xy: jax.Array, kernel: int, out_len: int
+) -> tuple[jax.Array, jax.Array]:
+    """3×3 average pool grouping patches by floor(pos/k). Matches HF Gemma4VisionPooler."""
+    max_x = positions_xy[..., 0].max(axis=-1, keepdims=True) + 1
+    kidx = jnp.floor_divide(positions_xy, kernel)
+    flat = kidx[..., 0] + (max_x // kernel) * kidx[..., 1]
+    weights = jax.nn.one_hot(flat, out_len, dtype=x.dtype) / (kernel * kernel)
+    out = jnp.einsum("bnl,bnd->bld", weights, x)
+    mask = jnp.any(weights != 0, axis=1)
+    return out, mask
+
+
+class Gemma4VisionEncoder(nnx.Module):
+    """Vision tower: patch embed → N encoder blocks → pool → √d scale → standardize."""
+
+    def __init__(self, cfg, dtype: jnp.dtype = jnp.bfloat16, rngs: nnx.Rngs | None = None):
+        rngs = rngs or nnx.Rngs(0)
+        self.cfg = cfg
+        self.dtype = dtype
+        self.out_len = cfg.default_output_length
+        self.pool_k = cfg.pooling_kernel_size
+
+        self.patch_embedder = Gemma4VisionPatchEmbedder(cfg, dtype, rngs)
+        self.layers = nnx.data(
+            [Gemma4VisionBlock(cfg, dtype, rngs) for _ in range(cfg.num_hidden_layers)]
+        )
+        self.std_bias = nnx.Param(jnp.zeros((cfg.hidden_size,), dtype=dtype))
+        self.std_scale = nnx.Param(jnp.ones((cfg.hidden_size,), dtype=dtype))
+
+    def __call__(
+        self,
+        pixel_values: jax.Array,
+        pixel_position_ids: jax.Array,
+        out_len: int | None = None,
+    ) -> tuple[jax.Array, jax.Array]:
+        """
+        Args:
+          pixel_values: [B, num_patches, 768] pre-patchified, range [0, 1].
+            num_patches must equal out_len × pool_k² (caller pads with pos=-1).
+          pixel_position_ids: [B, num_patches, 2] (x, y), -1 for padding.
+          out_len: token budget (70/140/280/560/1120); defaults to config.
+        Returns:
+          (soft_tokens [B, out_len, hidden], valid_mask [B, out_len]).
+        """
+        out_len = out_len or self.out_len
+        padding_mask = jnp.all(pixel_position_ids != -1, axis=-1)  # [B, N]
+        # HF Gemma4 normalizes [0,1] → [-1,1] inside the patch embedder.
+        patches = (2.0 * pixel_values - 1.0).astype(self.dtype)
+
+        x = self.patch_embedder(patches, pixel_position_ids, padding_mask)
+        for layer in self.layers:
+            x = layer(x, pixel_position_ids, padding_mask)
+
+        x, valid_mask = avg_pool_by_positions(
+            x, pixel_position_ids, self.pool_k, out_len
+        )
+        x = x * jnp.sqrt(jnp.asarray(self.cfg.hidden_size, x.dtype))
+        x = (x - self.std_bias.value.astype(x.dtype)) * self.std_scale.value.astype(x.dtype)
+        return x, valid_mask
+
+    def encode_bucketed(
+        self, pixel_values: jax.Array, pixel_position_ids: jax.Array
+    ) -> tuple[jax.Array, jax.Array, int]:
+        """Auto-select token budget and pad patches to the bucket boundary.
+
+        For TPU jit, wrap ``__call__`` with ``jax.jit(static_argnames=['out_len'])``
+        so each budget compiles once.
+        """
+        b, n, _ = pixel_values.shape
+        budget = select_budget(n, self.pool_k)
+        target_n = patches_for_budget(budget, self.pool_k)
+        if n < target_n:
+            pad_n = target_n - n
+            pixel_values = jnp.pad(pixel_values, ((0, 0), (0, pad_n), (0, 0)))
+            pixel_position_ids = jnp.pad(
+                pixel_position_ids, ((0, 0), (0, pad_n), (0, 0)), constant_values=-1
+            )
+        soft, mask = self(pixel_values, pixel_position_ids, out_len=budget)
+        return soft, mask, budget
+
+
+class Gemma4MultimodalEmbedder(nnx.Module):
+    """Project pooled vision features into the text embedding space."""
+
+    def __init__(
+        self,
+        vision_hidden: int,
+        text_hidden: int,
+        eps: float,
+        dtype: jnp.dtype = jnp.bfloat16,
+        rngs: nnx.Rngs | None = None,
+    ):
+        rngs = rngs or nnx.Rngs(0)
+        self.norm = RMSNorm(vision_hidden, epsilon=eps, use_scale=False, dtype=dtype)
+        self.embedding_projection = nnx.Linear(
+            vision_hidden, text_hidden, use_bias=False, param_dtype=dtype, rngs=rngs
+        )
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        return self.embedding_projection(self.norm(x))
+
+
+# --------------------------------------------------------------------------- #
+# HF safetensors → nnx weight mapping (target_path is the nnx attribute path)
+# --------------------------------------------------------------------------- #
+def vision_weight_mappings(num_layers: int) -> dict[str, str]:
+    """HF key → dotted nnx path. nnx.Linear stores weight as ``kernel`` (in_dim, out_dim)
+    so all HF Linear weights need transpose; caller is responsible for that.
+    """
+    m: dict[str, str] = {
+        "model.vision_tower.patch_embedder.input_proj.weight": "patch_embedder.input_proj.kernel",
+        "model.vision_tower.patch_embedder.position_embedding_table": "patch_embedder.position_embedding_table",
+        "model.vision_tower.std_bias": "std_bias",
+        "model.vision_tower.std_scale": "std_scale",
+    }
+    for i in range(num_layers):
+        src = f"model.vision_tower.encoder.layers.{i}"
+        dst = f"layers.{i}"
+        for ln in (
+            "input_layernorm",
+            "post_attention_layernorm",
+            "pre_feedforward_layernorm",
+            "post_feedforward_layernorm",
+        ):
+            m[f"{src}.{ln}.weight"] = f"{dst}.{ln}.scale"
+        m[f"{src}.self_attn.q_norm.weight"] = f"{dst}.self_attn.q_norm.scale"
+        m[f"{src}.self_attn.k_norm.weight"] = f"{dst}.self_attn.k_norm.scale"
+        for p in ("q_proj", "k_proj", "v_proj", "o_proj"):
+            m[f"{src}.self_attn.{p}.linear.weight"] = f"{dst}.self_attn.{p}.kernel"
+        for p in ("gate_proj", "up_proj", "down_proj"):
+            m[f"{src}.mlp.{p}.linear.weight"] = f"{dst}.mlp.{p}.kernel"
+    return m

--- a/python/sgl_jax/srt/multimodal/models/gemma4/vision_encoder.py
+++ b/python/sgl_jax/srt/multimodal/models/gemma4/vision_encoder.py
@@ -36,9 +36,7 @@ def select_budget(num_patches: int, pool_k: int = 3) -> int:
 class RMSNorm(nnx.Module):
     """Standard RMSNorm (x * w), matching HF Gemma4RMSNorm. Mesh-free."""
 
-    def __init__(
-        self, dim: int, epsilon: float = 1e-6, use_scale: bool = True, dtype=jnp.bfloat16
-    ):
+    def __init__(self, dim: int, epsilon: float = 1e-6, use_scale: bool = True, dtype=jnp.bfloat16):
         self.eps = epsilon
         self.dtype = dtype
         self.scale = nnx.Param(jnp.ones((dim,), dtype=dtype)) if use_scale else None
@@ -121,13 +119,9 @@ class Gemma4VisionAttention(nnx.Module):
 
         self.q_norm = RMSNorm(self.head_dim, epsilon=cfg.rms_norm_eps, dtype=dtype)
         self.k_norm = RMSNorm(self.head_dim, epsilon=cfg.rms_norm_eps, dtype=dtype)
-        self.v_norm = RMSNorm(
-            self.head_dim, epsilon=cfg.rms_norm_eps, use_scale=False, dtype=dtype
-        )
+        self.v_norm = RMSNorm(self.head_dim, epsilon=cfg.rms_norm_eps, use_scale=False, dtype=dtype)
 
-    def __call__(
-        self, x: jax.Array, positions_xy: jax.Array, padding_mask: jax.Array
-    ) -> jax.Array:
+    def __call__(self, x: jax.Array, positions_xy: jax.Array, padding_mask: jax.Array) -> jax.Array:
         b, n, _ = x.shape
         h, d = self.num_heads, self.head_dim
 
@@ -163,9 +157,7 @@ class Gemma4VisionBlock(nnx.Module):
         self.self_attn = Gemma4VisionAttention(cfg, dtype, rngs)
         self.mlp = Gemma4VisionMLP(cfg.hidden_size, cfg.intermediate_size, dtype, rngs)
 
-    def __call__(
-        self, x: jax.Array, positions_xy: jax.Array, padding_mask: jax.Array
-    ) -> jax.Array:
+    def __call__(self, x: jax.Array, positions_xy: jax.Array, padding_mask: jax.Array) -> jax.Array:
         h = self.input_layernorm(x)
         h = self.self_attn(h, positions_xy, padding_mask)
         x = x + self.post_attention_layernorm(h)
@@ -254,9 +246,7 @@ class Gemma4VisionEncoder(nnx.Module):
         for layer in self.layers:
             x = layer(x, pixel_position_ids, padding_mask)
 
-        x, valid_mask = avg_pool_by_positions(
-            x, pixel_position_ids, self.pool_k, out_len
-        )
+        x, valid_mask = avg_pool_by_positions(x, pixel_position_ids, self.pool_k, out_len)
         x = x * jnp.sqrt(jnp.asarray(self.cfg.hidden_size, x.dtype))
         x = (x - self.std_bias.value.astype(x.dtype)) * self.std_scale.value.astype(x.dtype)
         return x, valid_mask

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -145,6 +145,7 @@ QWEN3_MOE_30B = _local_or_hf("Qwen/Qwen3-30B-A3B")
 QWEN2_5_7B_INSTRUCT = _local_or_hf("Qwen/Qwen2.5-7B-Instruct")
 QWEN3_CODER_30B_A3B_INSTRUCT = _local_or_hf("Qwen/Qwen3-Coder-30B-A3B-Instruct")
 GEMMA2_2B_IT = _local_or_hf("google/gemma-2-2b-it")
+GEMMA4_31B_IT = _local_or_hf("google/gemma-4-31B-it")
 
 BAILING_MOE = _local_or_hf("inclusionAI/Ling-mini-2.0")
 DEEPSEEK_R1_DISTILL_QWEN_1_5B = _local_or_hf("deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B")

--- a/test/srt/test_gemma4_models.py
+++ b/test/srt/test_gemma4_models.py
@@ -1,0 +1,78 @@
+import unittest
+from types import SimpleNamespace
+
+from run_eval import run_eval
+
+from sgl_jax.srt.utils import kill_process_tree
+from sgl_jax.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    GEMMA4_31B_IT,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+class TestGemma4Model(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = GEMMA4_31B_IT
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            device="tpu",
+            other_args=[
+                "--trust-remote-code",
+                "--skip-server-warmup",
+                "--random-seed",
+                "3",
+                "--tp-size",
+                "4",
+                "--max-prefill-tokens",
+                "16384",
+                "--download-dir",
+                "/dev/shm/",
+                "--dtype",
+                "bfloat16",
+                "--attention-backend",
+                "fa",
+                "--page-size",
+                "64",
+                "--max-running-requests",
+                "32",
+                "--chunked-prefill-size",
+                "2048",
+                "--swa-full-tokens-ratio",
+                "0.1",
+                "--disable-radix-cache",
+                "--precompile-bs-paddings",
+                "32",
+                "--precompile-token-paddings",
+                "2048",
+            ],
+            env={
+                "JAX_COMPILATION_CACHE_DIR": "/tmp/jax_compilation_cache",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="mmlu",
+            num_examples=64,
+            num_threads=32,
+            max_tokens=1024,
+        )
+        metrics = run_eval(args)
+        self.assertGreater(metrics["score"], 0.70)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_gemma4_vision_alignment.py
+++ b/test/srt/test_gemma4_vision_alignment.py
@@ -65,8 +65,7 @@ class TestGemma4VisionAlignment(CustomTestCase):
         hf = Gemma4VisionModel(vcfg).to(torch.bfloat16).eval()
         tensors, mappings = _load_vision_weights(GEMMA4_31B_IT, vcfg.num_hidden_layers)
         sd = {
-            k.removeprefix("model.vision_tower."): torch.from_numpy(v)
-            for k, v in tensors.items()
+            k.removeprefix("model.vision_tower."): torch.from_numpy(v) for k, v in tensors.items()
         }
         hf.load_state_dict(sd, strict=True)
         with torch.no_grad():
@@ -93,8 +92,7 @@ class TestGemma4VisionAlignment(CustomTestCase):
 
         self.assertEqual(hf_out.shape, jax_out.shape)
         cos = float(
-            (hf_out * jax_out).sum()
-            / (np.linalg.norm(hf_out) * np.linalg.norm(jax_out) + 1e-8)
+            (hf_out * jax_out).sum() / (np.linalg.norm(hf_out) * np.linalg.norm(jax_out) + 1e-8)
         )
         mae = float(np.abs(hf_out - jax_out).mean())
         print(f"cos={cos:.6f} mae={mae:.5f}")

--- a/test/srt/test_gemma4_vision_alignment.py
+++ b/test/srt/test_gemma4_vision_alignment.py
@@ -1,0 +1,105 @@
+"""Alignment test: JAX Gemma4VisionEncoder vs HF Gemma4VisionModel.
+
+CPU-only (vision tower ~570M). Fixed 280-token budget (2520 patches).
+"""
+
+import json
+import os
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+import torch
+from flax import nnx
+from safetensors import safe_open
+from transformers import AutoConfig, Gemma4VisionModel
+
+from sgl_jax.srt.multimodal.models.gemma4.vision_encoder import (
+    Gemma4VisionEncoder,
+    vision_weight_mappings,
+)
+from sgl_jax.test.test_utils import GEMMA4_31B_IT, CustomTestCase
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+
+def _set_by_path(state, path, value):
+    parts = path.split(".")
+    node = state
+    for p in parts[:-1]:
+        node = node[int(p)] if p.isdigit() else node[p]
+    leaf = parts[-1]
+    cur = node[int(leaf)] if leaf.isdigit() else node[leaf]
+    cur.value = value.astype(cur.value.dtype)
+
+
+def _load_vision_weights(model_dir, num_layers):
+    with open(f"{model_dir}/model.safetensors.index.json") as f:
+        index = json.load(f)["weight_map"]
+    mappings = vision_weight_mappings(num_layers)
+    by_file: dict[str, list[str]] = {}
+    for k in mappings:
+        by_file.setdefault(index[k], []).append(k)
+    tensors = {}
+    for fname, keys in by_file.items():
+        with safe_open(f"{model_dir}/{fname}", framework="np") as f:
+            for k in keys:
+                tensors[k] = f.get_tensor(k)
+    return tensors, mappings
+
+
+class TestGemma4VisionAlignment(CustomTestCase):
+    COS_THRESHOLD = 0.999
+
+    def test_vision_encoder_vs_hf(self):
+        cfg = AutoConfig.from_pretrained(GEMMA4_31B_IT)
+        vcfg = cfg.vision_config
+
+        # 672x960 → 42x60 patches = 2520 → pool 3x3 → 280
+        rng = np.random.default_rng(42)
+        pv = rng.uniform(0, 1, size=(1, 2520, 768)).astype(np.float32)
+        yy, xx = np.meshgrid(np.arange(42), np.arange(60), indexing="ij")
+        pos = np.stack([xx.ravel(), yy.ravel()], axis=-1)[None].astype(np.int32)
+
+        # HF reference
+        hf = Gemma4VisionModel(vcfg).to(torch.bfloat16).eval()
+        tensors, mappings = _load_vision_weights(GEMMA4_31B_IT, vcfg.num_hidden_layers)
+        sd = {
+            k.removeprefix("model.vision_tower."): torch.from_numpy(v)
+            for k, v in tensors.items()
+        }
+        hf.load_state_dict(sd, strict=True)
+        with torch.no_grad():
+            hf_out = (
+                hf(
+                    pixel_values=torch.from_numpy(pv).to(torch.bfloat16),
+                    pixel_position_ids=torch.from_numpy(pos).long(),
+                )
+                .last_hidden_state.float()
+                .numpy()
+            )
+
+        # JAX
+        enc = Gemma4VisionEncoder(vcfg, dtype=jnp.bfloat16)
+        state = nnx.state(enc)
+        for k, dst in mappings.items():
+            w = tensors[k]
+            if dst.endswith(".kernel"):
+                w = w.T
+            _set_by_path(state, dst, jnp.asarray(w))
+        nnx.update(enc, state)
+        jax_out, _ = enc(jnp.asarray(pv), jnp.asarray(pos))
+        jax_out = np.asarray(jax_out.astype(jnp.float32))[0]
+
+        self.assertEqual(hf_out.shape, jax_out.shape)
+        cos = float(
+            (hf_out * jax_out).sum()
+            / (np.linalg.norm(hf_out) * np.linalg.norm(jax_out) + 1e-8)
+        )
+        mae = float(np.abs(hf_out - jax_out).mean())
+        print(f"cos={cos:.6f} mae={mae:.5f}")
+        self.assertGreater(cos, self.COS_THRESHOLD)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds Gemma4-31B-it support (text + image). 31B is the dense variant — no PLE, no shared-KV, no MoE — so the text decoder is a moderate extension of gemma2.py. Vision encoder is ported from MaxText/deepmind-gemma official Flax implementations.

Four commits, splittable into separate PRs if preferred:
1. **infra**: heterogeneous head_dim support (SWAKVPool `swa_head_dim`, FA backend `layer.head_dim`) + `ProportionalRotaryEmbedding`
2. **scheduler fix**: wire `input_embeds` / `mm_inputs` through to `ForwardBatch.input_embedding` (existing API field that was disconnected)
3. **model**: `gemma4.py` + `multimodal/models/gemma4/vision_encoder.py`
4. **test**: model MMLU test + vision encoder alignment test

## Architecture notes (31B specifics)

- **Heterogeneous attention**: 50 sliding layers (head_dim=256, kv_heads=16, rope_theta=10k) + 10 full layers (head_dim=512, kv_heads=4, proportional RoPE @ 1M, partial_rotary=0.25)
- **attention_k_eq_v**: full layers have no `v_proj` in checkpoint; K projection output is reused as V (matching deepmind/gemma reference)
- **Standard RMSNorm** (`x*w`), not Gemma2's `x*(1+w)`
- **`patch_model_config`** remaps HF's `global_*` ↔ sglang's `swa_*` naming convention; idempotent guard handles multiple `ModelConfig` constructions sharing one `hf_config`
- **Vision**: 27-layer ViT, 2D RoPE (head_dim split per x/y axis), learned 2D pos table (gather), 3×3 position-based pool, 5 token budgets (70-1120)

## Validation (v6e-4 TP=4 / v6e-8 TP=8)

| Benchmark | Result | Reference |
|---|---|---|
| GSM8K (1319, 0-shot) | 90.5% | — |
| MMLU (500, shuffled, 0-shot) | 85.0% | official MMLU Pro 85.2% |
| MMMU val (50, 10 subjects) | 62.0% | official MMMU Pro 76.9% — **HF reference under identical prompt produces identical answers (8/8 match)**, so the gap is eval-protocol (prompt/CoT) not implementation |
| Vision encoder vs HF | cos=0.9993 | bf16, 27 layers |
| E2E inputs_embeds vs HF | cos=0.9982 | — |
| Single-image server output | "A red rectangle is centered on a white background." | HF: "A **solid** red rectangle..." (1-token diff) |
| Throughput cc=32 | v6e-4: 1359 tok/s, v6e-8: 2904 tok/s | — |

Token-level parity with HF verified (no-BOS prompt produces identical repetition on both; MMMU 8-sample side-by-side: 0 mismatch).

## Known limitations

- `mm_inputs.multimodal_embedding` path supports bs=1 only (assert in `schedule_batch.py`)
- Vision encoder runs on CPU (client-side); TPU jit + sharding deferred
- Bidirectional attention mask for vision tokens in sliding layers not implemented (HF side-by-side shows 0 mismatch on MMMU, so not the cause of accuracy gap)
- E2B/E4B (PLE + shared-KV + audio) and 26B-A4B (MoE) not in scope

## Test plan

- [x] gsm8k 1319 on v6e-4 TP=4
- [x] MMLU 500 shuffled
- [x] Vision encoder unit test vs HF `Gemma4VisionModel`
- [x] E2E single-image via `/generate` + `mm_inputs`
- [x] v6e-8 TP=8 with kv_head_padding (full-layer 4 heads × 2 replication)
- [x] MMMU HF side-by-side parity check (8/8 match)
- [ ] CI lint/format