### PR TITLE
fix(sampling): rebind penalizer weakref when merging into empty DP rank

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1671,6 +1671,14 @@ class ScheduleBatch:
                 # Copy everything from other_info
                 self_info.reqs = other_info.reqs.copy()
                 self_info.sampling_info = other_info.sampling_info
+                # reqs_info is a weakref (orchestrator.py) still pointing at the
+                # transient other_info; rebind to the surviving self_info so
+                # reqs() stays live, else penalizers desync -> IndexError crash.
+                if (
+                    self_info.sampling_info is not None
+                    and self_info.sampling_info.penalizer_orchestrator is not None
+                ):
+                    self_info.sampling_info.penalizer_orchestrator.reqs_info = self_info
                 self_info.req_pool_indices = other_info.req_pool_indices
                 self_info.seq_lens = other_info.seq_lens
                 self_info.out_cache_loc = other_info.out_cache_loc


### PR DESCRIPTION
## Problem

`BatchedPenalizerOrchestrator` tracks sampling penalty state and reads the current per-DP-rank requests through a weak reference to `ScheduleReqsInfo`.

When a non-empty per-DP request group is merged into an empty destination DP rank, its `sampling_info` is transferred to `self_info`, but the orchestrator's weak reference still points to the transient `other_info`. After `other_info` is released, the orchestrator sees an empty request list while the merged batch tensors still contain requests, desynchronizing penalty state and causing an `IndexError` on the next decode step.

This only affects this merge path when a penalizer is active, such as a non-zero presence or frequency penalty. The issue is model-agnostic.

## Fix

Rebind the orchestrator's `reqs_info` weak reference to the surviving `self_info` after transferring `sampling_info`. This preserves the accumulated penalty state while keeping its request view live.

## Testing

Reproduced the `IndexError` with an active penalizer and confirmed that the rebind resolves it. No unit test is added because no CI-registered test currently exercises the active-penalizer merge into an empty DP rank, and the change is a localized weak-reference rebind.