### PR TITLE
test(eval): add sampler params + reasoning-trace stripping to simple-evals

### DIFF
--- a/test/srt/eval/simple_eval_common.py
+++ b/test/srt/eval/simple_eval_common.py
@@ -1,6 +1,7 @@
 # Adapted from https://github.com/openai/simple-evals/
 
 import os
+import re
 import resource
 import time
 from collections import defaultdict
@@ -175,6 +176,27 @@ D) {D}
 
 ANSWER_PATTERN_MULTICHOICE = r"(?i)Answer\s*:\s*([A-D])"
 ANSWER_PATTERN = r"(?i)Answer\s*:\s*([^\n]+)"
+
+_REASONING_RE_BOTH = re.compile(r"<think>.*?</think>", flags=re.DOTALL)
+_REASONING_RE_CLOSE_ONLY = re.compile(r"^.*?</think>", flags=re.DOTALL)
+
+
+def strip_reasoning(text: str) -> str:
+    """Drop the reasoning span before multichoice answer extraction.
+
+    Handles both shapes:
+    - Full ``<think>...</think>`` block in the response (some templates).
+    - Bare ``</think>`` only (Qwen-style: the opening ``<think>\\n`` is
+      injected by the chat template into the prompt, so the server's
+      content field starts directly with reasoning text and only emits
+      the closing tag).
+    """
+    if not text:
+        return text
+    text = _REASONING_RE_BOTH.sub("", text)
+    if "</think>" in text:
+        text = _REASONING_RE_CLOSE_ONLY.sub("", text, count=1)
+    return text.strip()
 
 
 EQUALITY_TEMPLATE = r"""

--- a/test/srt/eval/simple_eval_gpqa.py
+++ b/test/srt/eval/simple_eval_gpqa.py
@@ -19,6 +19,7 @@ from eval.simple_eval_common import (
     SamplerBase,
     SingleEvalResult,
     format_multichoice_question,
+    strip_reasoning,
 )
 
 
@@ -66,7 +67,7 @@ class GPQAEval(Eval):
                 )
             ]
             response_text = sampler(prompt_messages)
-            match = re.search(ANSWER_PATTERN_MULTICHOICE, response_text)
+            match = re.search(ANSWER_PATTERN_MULTICHOICE, strip_reasoning(response_text))
             extracted_answer = match.group(1) if match else None
             score = 1.0 if extracted_answer == correct_answer else 0.0
             html = common.jinja_env.from_string(HTML_JINJA).render(

--- a/test/srt/eval/simple_eval_mmlu.py
+++ b/test/srt/eval/simple_eval_mmlu.py
@@ -19,6 +19,7 @@ from eval.simple_eval_common import (
     SamplerBase,
     SingleEvalResult,
     format_multichoice_question,
+    strip_reasoning,
 )
 
 subject2category = {
@@ -97,7 +98,7 @@ class MMLUEval(Eval):
                 sampler._pack_message(content=format_multichoice_question(row), role="user")
             ]
             response_text = sampler(prompt_messages)
-            match = re.search(ANSWER_PATTERN_MULTICHOICE, response_text)
+            match = re.search(ANSWER_PATTERN_MULTICHOICE, strip_reasoning(response_text))
             extracted_answer = match.group(1) if match else None
             score = 1.0 if extracted_answer == row["Answer"] else 0.0
             html = common.jinja_env.from_string(HTML_JINJA).render(

--- a/test/srt/eval/test_simple_eval_common.py
+++ b/test/srt/eval/test_simple_eval_common.py
@@ -1,0 +1,100 @@
+# ruff: noqa: E402
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from eval.simple_eval_common import ANSWER_PATTERN_MULTICHOICE, strip_reasoning
+from run_eval import build_extra_body
+
+
+def _extract_answer(response_text: str, *, strip: bool) -> str | None:
+    # Mirror exactly what simple_eval_{gpqa,mmlu} do at answer-extraction time.
+    text = strip_reasoning(response_text) if strip else response_text
+    match = re.search(ANSWER_PATTERN_MULTICHOICE, text)
+    return match.group(1) if match else None
+
+
+class TestSimpleEvalCommon(unittest.TestCase):
+    def test_full_think_block_must_be_stripped_before_extraction(self):
+        # A reasoning model writes a mid-thought guess inside <think> and the
+        # real answer after it. ANSWER_PATTERN_MULTICHOICE + re.search take the
+        # FIRST "Answer: X", so without stripping the trace the scratch-work
+        # letter ("A") wins and a correct ("C") response is scored wrong.
+        response = (
+            "<think>\n"
+            "First glance suggests Answer: A from the surface reading.\n"
+            "Reconsidering the kinetics, that is wrong - it must be C.\n"
+            "</think>\n"
+            "Answer: C"
+        )
+        self.assertEqual(_extract_answer(response, strip=False), "A")
+        self.assertEqual(_extract_answer(response, strip=True), "C")
+
+    def test_bare_closing_think_trace_must_be_stripped_before_extraction(self):
+        # When the opening <think> is dropped (tokenizer/template), everything
+        # up to </think> is reasoning; the only "Answer:" before it is the
+        # scratch guess ("B"), not the final answer ("D").
+        response = "Working it out, Answer: B seems plausible.</think>\nAnswer: D"
+        self.assertEqual(_extract_answer(response, strip=False), "B")
+        self.assertEqual(_extract_answer(response, strip=True), "D")
+
+    def test_extraction_unaffected_when_no_reasoning_tags_present(self):
+        # Most eval outputs have no <think> tag; stripping must not touch them.
+        self.assertEqual(strip_reasoning("Answer: D"), "Answer: D")
+        self.assertEqual(strip_reasoning(""), "")
+        self.assertEqual(_extract_answer("Answer: D", strip=True), "D")
+
+    def test_build_extra_body_routes_sglang_params_and_chat_template(self):
+        # SGLang-only sampling params + chat_template_kwargs ride in extra_body;
+        # the OpenAI client merges them into the request body top level. top_p is
+        # a native kwarg handled by the sampler, so it must NOT leak into here.
+        args = SimpleNamespace(
+            top_p=0.95,
+            top_k=20,
+            min_p=0.0,
+            presence_penalty=1.5,
+            frequency_penalty=0.5,
+            repetition_penalty=1.0,
+            seed=17,
+            chat_template_kwargs={"enable_thinking": True},
+        )
+
+        extra_body = build_extra_body(args)
+
+        self.assertEqual(
+            extra_body,
+            {
+                "chat_template_kwargs": {"enable_thinking": True},
+                "top_k": 20,
+                "min_p": 0.0,
+                "presence_penalty": 1.5,
+                "repetition_penalty": 1.0,
+                "frequency_penalty": 0.5,
+                "seed": 17,
+            },
+        )
+        self.assertNotIn("top_p", extra_body)
+
+    def test_build_extra_body_is_none_when_nothing_set(self):
+        self.assertIsNone(build_extra_body(SimpleNamespace()))
+        self.assertIsNone(
+            build_extra_body(SimpleNamespace(top_p=0.9, temperature=0.7, max_tokens=64))
+        )
+
+    def test_build_extra_body_keeps_chat_template_only(self):
+        args = SimpleNamespace(chat_template_kwargs={"enable_thinking": False})
+
+        self.assertEqual(
+            build_extra_body(args),
+            {"chat_template_kwargs": {"enable_thinking": False}},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/nightly/multi_host/accuracy_case_runner.py
+++ b/test/srt/nightly/multi_host/accuracy_case_runner.py
@@ -30,7 +30,11 @@ def run_accuracy_case(case: AccuracyCase, profile: LaunchProfile) -> None:
         f"name={case.name}, dataset={case.dataset}, "
         f"num_threads={case.eval_batch_size}, "
         f"temperature={gen.get('temperature', 0.0)}, max_tokens={gen.get('max_tokens', 2048)}, "
-        f"top_p={gen.get('top_p')}, chat_template_kwargs={gen.get('chat_template_kwargs')}, "
+        f"top_p={gen.get('top_p')}, top_k={gen.get('top_k')}, min_p={gen.get('min_p')}, "
+        f"presence_penalty={gen.get('presence_penalty')}, "
+        f"repetition_penalty={gen.get('repetition_penalty')}, "
+        f"frequency_penalty={gen.get('frequency_penalty')}, seed={gen.get('seed')}, "
+        f"chat_template_kwargs={gen.get('chat_template_kwargs')}, "
         f"limit={case.limit}",
         flush=True,
     )

--- a/test/srt/nightly/results.py
+++ b/test/srt/nightly/results.py
@@ -137,6 +137,10 @@ def run_eval_for_case(case: AccuracyCase, base_url: str):
     from run_eval import run_eval
 
     gen = case.generation_config or {}
+    # Forward the full sampler config. run_eval routes the SGLang-only params
+    # (SGLANG_EXTRA_SAMPLING_PARAMS) into extra_body; cherry-picking a subset
+    # here would let a case set e.g. top_k in generation_config, record it in
+    # the summary, yet silently drop it before it reaches the sampler.
     args = SimpleNamespace(
         base_url=base_url,
         host=None,
@@ -148,6 +152,12 @@ def run_eval_for_case(case: AccuracyCase, base_url: str):
         temperature=gen.get("temperature", 0.0),
         max_tokens=gen.get("max_tokens", 2048),
         top_p=gen.get("top_p"),
+        top_k=gen.get("top_k"),
+        min_p=gen.get("min_p"),
+        presence_penalty=gen.get("presence_penalty"),
+        repetition_penalty=gen.get("repetition_penalty"),
+        frequency_penalty=gen.get("frequency_penalty"),
+        seed=gen.get("seed"),
         chat_template_kwargs=gen.get("chat_template_kwargs"),
     )
     started_at = time.time()

--- a/test/srt/run_eval.py
+++ b/test/srt/run_eval.py
@@ -10,6 +10,38 @@ import time
 
 from eval.simple_eval_common import ChatCompletionSampler, make_report, set_ulimit
 
+# Sampling params the SGLang server accepts but the OpenAI chat-completion API
+# does not expose as native kwargs. They ride in `extra_body`, which the OpenAI
+# client merges into the request body so the server reads them at the JSON top
+# level. Keeping the OpenAI-vs-SGLang split here (rather than inside the sampler)
+# means callers forward a flat generation config and routing lives in one place.
+SGLANG_EXTRA_SAMPLING_PARAMS = (
+    "top_k",
+    "min_p",
+    "presence_penalty",
+    "repetition_penalty",
+    "frequency_penalty",
+    "seed",
+)
+
+
+def build_extra_body(args) -> dict | None:
+    """Assemble the OpenAI ``extra_body`` from a flat generation config.
+
+    Collects the SGLang-only sampling params plus ``chat_template_kwargs``
+    (e.g. thinking-mode toggles). Returns ``None`` when nothing is set so the
+    sampler omits ``extra_body`` entirely.
+    """
+    extra_body: dict = {}
+    chat_template_kwargs = getattr(args, "chat_template_kwargs", None)
+    if chat_template_kwargs:
+        extra_body["chat_template_kwargs"] = chat_template_kwargs
+    for name in SGLANG_EXTRA_SAMPLING_PARAMS:
+        value = getattr(args, name, None)
+        if value is not None:
+            extra_body[name] = value
+    return extra_body or None
+
 
 def run_eval(args):
     set_ulimit()
@@ -86,8 +118,7 @@ def run_eval(args):
         max_tokens = 2048
 
     top_p = getattr(args, "top_p", None)
-    chat_template_kwargs = getattr(args, "chat_template_kwargs", None)
-    extra_body = {"chat_template_kwargs": chat_template_kwargs} if chat_template_kwargs else None
+    extra_body = build_extra_body(args)
 
     sampler = ChatCompletionSampler(
         model=args.model,
@@ -148,6 +179,12 @@ if __name__ == "__main__":
     parser.add_argument("--num-threads", type=int, default=512)
     parser.add_argument("--temperature", type=float, default=0.0)
     parser.add_argument("--max-tokens", type=int, default=2048)
+    parser.add_argument("--top-k", type=int, default=None)
+    parser.add_argument("--min-p", type=float, default=None)
+    parser.add_argument("--presence-penalty", type=float, default=None)
+    parser.add_argument("--repetition-penalty", type=float, default=None)
+    parser.add_argument("--frequency-penalty", type=float, default=None)
+    parser.add_argument("--seed", type=int, default=None)
     args = parser.parse_args()
 
     run_eval(args)

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -310,6 +310,7 @@ suites = {
         TestFile("test/srt/openai_server/basic/test_serving_chat.py", 0.1),
         TestFile("test/srt/openai_server/basic/test_serving_completions.py", 0.1),
         TestFile("test/srt/test_reasoning_parser.py", 0.1),
+        TestFile("test/srt/eval/test_simple_eval_common.py", 0.1, runner="pytest"),
         TestFile("test/srt/test_server_info.py", 0.1),
     ],
     "unit-test-tpu-v6e-4": [


### PR DESCRIPTION
## Motivation

The Qwen3.5 thinking-mode evaluation in `test/srt/test_qwen3_5_models.py` needs to specify its intended generation configuration, but the existing `ChatCompletionSampler` does not expose the full set of required sampling parameters. Its `<think>` reasoning trace can also be mistaken for the final answer during multichoice answer extraction.

Although motivated by Qwen3.5, the implementation is model-agnostic: it lets simple-evals pass backend-supported generation settings for any model and improves answer extraction for reasoning models that emit `<think>` traces.

## Summary

Model-agnostic additions to the simple-evals harness:

- **`run_eval.build_extra_body`**: routes generation params in one place at the harness layer (not inside the sampler). OpenAI-native params (`top_p`) stay top-level; SGLang-only params (`top_k`, `min_p`, `presence_penalty`, `repetition_penalty`, `frequency_penalty`, `seed`) ride in `extra_body`, alongside any `chat_template_kwargs` (e.g. thinking mode). `ChatCompletionSampler` stays minimal — no per-param routing layer. CLI gains opt-in flags for the new params.
- **`strip_reasoning()`**: drops the `<think>...</think>` reasoning span before multichoice answer extraction (handles both a full block and a bare `</think>` close-tag). Applied **only** to the copy fed to the answer regex in GPQA/MMLU — the raw response is preserved for the html/convo report and the `chars` metric. Note this will flip the benchmark result, evidence: https://github.com/sgl-project/sglang-jax/pull/1306#issuecomment-4621957669
- **`accuracy_case_runner`**: forwards the complete `generation_config` to `run_eval` (previously only `temperature`/`max_tokens`/`top_p`/`chat_template_kwargs`), so suite-level params actually reach the sampler instead of being recorded in the summary but silently dropped.

All params default to `None`, so existing invocations are byte-for-byte unchanged. No model-specific coupling.

## Testing

`test/srt/eval/test_simple_eval_common.py` (pure CPU, registered in `unit-test-cpu`): `build_extra_body` param routing (OpenAI-native vs `extra_body`, `chat_template_kwargs` preserved, `None` when unset) and `strip_reasoning` across full-block / bare-close / no-tag passthrough.
