### PR TITLE
fix(multimodal): route Wan text encoder through encoder pipeline

### DIFF
--- a/docs/architecture/12-multimodal.md
+++ b/docs/architecture/12-multimodal.md
@@ -238,9 +238,9 @@ HTTP Request (text prompt + params)
   → GlobalScheduler
     → TypeBasedDispatcher → Wan Pipeline
 
-  → Stage 0 (Embed)
-    → EmbedScheduler → EmbedModelExecutor
-    → Text → CLIP/T5 embedding
+  → Stage 0 (Text Encoder)
+    → EncoderScheduler → EncoderModelWorker → EncoderModelRunner
+    → Text → UMT5 embeddings
 
   → Stage 1 (Diffusion)
     → DiffusionScheduler → DiffusionModelExecutor

--- a/docs/architecture/12-multimodal.md
+++ b/docs/architecture/12-multimodal.md
@@ -141,7 +141,7 @@ The `auto_regressive` Scheduler type in the YAML config reuses the text engine's
 
 | Directory | Model | Pipeline stages |
 |------|------|--------------|
-| `wan/` | Wan 2.1/2.2 | Embed → Diffusion → VAE |
+| `wan/` | Wan 2.1/2.2 | Text Encoder → Diffusion → VAE |
 | `qwen2_5VL/` | Qwen2.5-VL | ViT → AutoRegressive |
 | `qwen3_omni_moe/` | Qwen3-Omni-MoE | ViT → AutoRegressive → Audio |
 | `mimo_audio/` | MiMo Audio | Audio → AutoRegressive |
@@ -154,8 +154,8 @@ Each model has a corresponding YAML config under `multimodal/models/static_confi
 **Wan 2.1 example** (3-stage pipeline, `wan2_1_stage_config.yaml`):
 
 ```text
-Stage 0: scheduler=auto_regressive, model_class=UMT5EncoderModel
-  → Text encoding (reuses the text engine's Scheduler)
+Stage 0: scheduler=text_encoder, model_class=UMT5EncoderModel
+  → UMT5 text encoding through the dedicated encoder scheduler
 
 Stage 1: scheduler=diffusion, model_class=WanTransformer3DModel
   → N-step diffusion denoising

--- a/docs/architecture/12-multimodal.md
+++ b/docs/architecture/12-multimodal.md
@@ -119,7 +119,8 @@ Each stage contains:
 | `DiffusionScheduler` | Text-to-image / video | Manages diffusion-step iteration |
 | `VaeScheduler` | VAE decoding | Latent → pixel decoding scheduling |
 | `VitScheduler` | Vision Transformer | Image patch encoding |
-| `EmbedScheduler` | Text embedding | Text encoder feature extraction |
+| `EncoderScheduler` | Text encoding | Runs dedicated text encoders such as CLIP, T5, and UMT5 |
+| `EmbedScheduler` | Text embedding | Produces embedding-model outputs |
 | `AudioScheduler` | Audio | Audio feature extraction/generation |
 | `AudioBackboneScheduler` | Audio backbone | Audio model backbone network |
 
@@ -212,7 +213,8 @@ Each stage's YAML definition contains:
 |------|------|--------|
 | `audio/` | Audio processing | Audio encoding/decoding execution |
 | `diffusion/` | Diffusion model execution | Manages denoising steps, invokes UNet/DiT |
-| `embed/` | Embedding extraction | Text encoder forward |
+| `embed/` | Embedding extraction | Produces embedding-model outputs |
+| `encoder/` | Text encoding | Tokenization and dedicated text encoder forward |
 | `vae/` | VAE encode/decode | Latent ↔ pixel conversion |
 | `vit/` | Vision Transformer | Image patch encoding |
 

--- a/python/sgl_jax/srt/multimodal/manager/stage.py
+++ b/python/sgl_jax/srt/multimodal/manager/stage.py
@@ -10,7 +10,6 @@ import psutil
 from sgl_jax.srt.managers.communication import QueueBackend
 from sgl_jax.srt.managers.scheduler import Scheduler as AutoRegressiveScheduler
 from sgl_jax.srt.models.qwen2 import Qwen2ForCausalLM
-from sgl_jax.srt.models.umt5 import UMT5EncoderModel
 from sgl_jax.srt.multimodal.manager.device_manager import DeviceManager
 from sgl_jax.srt.multimodal.manager.scheduler.audio_backbone_scheduler import (
     AudioBackboneScheduler,
@@ -26,6 +25,9 @@ from sgl_jax.srt.multimodal.manager.scheduler.vit_scheduler import VitScheduler
 from sgl_jax.srt.multimodal.models.dits.flux import FluxTransformer2DModel
 from sgl_jax.srt.multimodal.models.encoders.clip import CLIPTextModel
 from sgl_jax.srt.multimodal.models.encoders.t5 import T5EncoderModel
+from sgl_jax.srt.multimodal.models.encoders.t5 import (
+    UMT5EncoderModel as MultimodalUMT5EncoderModel,
+)
 from sgl_jax.srt.multimodal.models.mimo_audio.mimo_audio_backbone import (
     MiMoAudioForCausalLM,
 )
@@ -239,7 +241,7 @@ def get_scheduler_class(name: str):
 def get_model_class(name: str) -> type | list[type]:
     model_classes = {
         "AutoencoderKLWan": AutoencoderKLWan,
-        "UMT5EncoderModel": UMT5EncoderModel,
+        "UMT5EncoderModel": MultimodalUMT5EncoderModel,
         "WanTransformer3DModel": WanTransformer3DModel,
         "WanDualTransformer3DModel": WanDualTransformer3DModel,
         "Qwen2_5_VL_Generation": Qwen2_5_VL_Generation,

--- a/python/sgl_jax/srt/multimodal/model_executor/encoder/encoder_model_runner.py
+++ b/python/sgl_jax/srt/multimodal/model_executor/encoder/encoder_model_runner.py
@@ -20,6 +20,8 @@ from sgl_jax.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
 
+ENCODER_TOKEN_BUCKETS = (16, 32, 64, 128, 256, 512, 1024)
+
 
 @dataclass
 class _EncoderSpec:
@@ -363,11 +365,21 @@ class EncoderModelRunner(BaseModelRunner):
         actual_length: int,
         encoder_max_length: int,
     ) -> int:
-        token_buckets = [16, 32, 64, 128, 256, 512, 1024]
-        for size in token_buckets:
+        for size in ENCODER_TOKEN_BUCKETS:
             if actual_length <= size <= encoder_max_length:
                 return size
         return encoder_max_length
+
+    def get_precompile_lengths(self, spec: _EncoderSpec, encoder_idx: int) -> list[int]:
+        if spec.max_length is None:
+            raise ValueError(f"Encoder max_length is not initialized for {spec.model_class}.")
+        if self.is_flux_t5(spec, encoder_idx):
+            return [spec.max_length]
+
+        lengths = [size for size in ENCODER_TOKEN_BUCKETS if size <= spec.max_length]
+        if not lengths or lengths[-1] != spec.max_length:
+            lengths.append(spec.max_length)
+        return lengths
 
     def _get_model_attention_mask(
         self,

--- a/python/sgl_jax/srt/multimodal/model_executor/encoder/encoder_model_runner.py
+++ b/python/sgl_jax/srt/multimodal/model_executor/encoder/encoder_model_runner.py
@@ -231,7 +231,7 @@ class EncoderModelRunner(BaseModelRunner):
             processed_output, output_kind = self._postprocess_encoder_outputs(
                 spec,
                 outputs,
-                tokenized,
+                model_attention_mask,
             )
             if processed_output is None:
                 continue
@@ -286,14 +286,14 @@ class EncoderModelRunner(BaseModelRunner):
         self,
         spec: _EncoderSpec,
         outputs: dict[str, jax.Array],
-        text_inputs: dict[str, jax.Array],
+        attention_mask: jax.Array,
     ) -> tuple[jax.Array | None, str]:
         model_class_name = getattr(spec.model_class, "__name__", str(spec.model_class))
 
         if "T5" in model_class_name:
-            return self.t5_postprocess_text(outputs, text_inputs), "hidden_states"
+            return self.t5_postprocess_text(outputs, attention_mask), "hidden_states"
         if "CLIP" in model_class_name:
-            return self.clip_postprocess_text(outputs, text_inputs), "pooler"
+            return self.clip_postprocess_text(outputs, attention_mask), "pooler"
 
         if outputs["last_hidden_state"] is not None:
             return outputs["last_hidden_state"], "hidden_states"
@@ -304,16 +304,17 @@ class EncoderModelRunner(BaseModelRunner):
     @staticmethod
     def t5_postprocess_text(
         outputs: dict[str, jax.Array],
-        _text_inputs: dict[str, jax.Array],
+        attention_mask: jax.Array,
     ) -> jax.Array:
         if outputs["last_hidden_state"] is None:
             raise ValueError("T5 encoder output does not contain last_hidden_state.")
-        return outputs["last_hidden_state"]
+        hidden_states = outputs["last_hidden_state"]
+        return hidden_states * attention_mask[..., None].astype(hidden_states.dtype)
 
     @staticmethod
     def clip_postprocess_text(
         outputs: dict[str, jax.Array],
-        _text_inputs: dict[str, jax.Array],
+        _attention_mask: jax.Array,
     ) -> jax.Array:
         if outputs["pooler_output"] is None:
             raise ValueError("CLIP encoder output does not contain pooler_output.")

--- a/python/sgl_jax/srt/multimodal/model_executor/encoder/encoder_model_worker.py
+++ b/python/sgl_jax/srt/multimodal/model_executor/encoder/encoder_model_worker.py
@@ -35,17 +35,18 @@ class EncoderModelWorker:
 
         start_time = time.perf_counter()
         for i, spec in enumerate(self.model_runner.encoder_specs):
-            max_length = spec.max_length or 512
-            logger.info(
-                "[ENCODER] Precompiling encoder %d/%d (%s), max_length=%d",
-                i + 1,
-                len(self.model_runner.encoder_specs),
-                spec.model_class.__name__,
-                max_length,
-            )
-            dummy_input_ids = jnp.ones((1, max_length), dtype=jnp.int32)
-            dummy_attention_mask = jnp.ones((1, max_length), dtype=jnp.int32)
-            spec.jitted_forward(dummy_input_ids, dummy_attention_mask)
+            precompile_lengths = self.model_runner.get_precompile_lengths(spec, i)
+            for length in precompile_lengths:
+                logger.info(
+                    "[ENCODER] Precompiling encoder %d/%d (%s), length=%d",
+                    i + 1,
+                    len(self.model_runner.encoder_specs),
+                    spec.model_class.__name__,
+                    length,
+                )
+                dummy_input_ids = jnp.ones((1, length), dtype=jnp.int32)
+                dummy_attention_mask = jnp.ones((1, length), dtype=jnp.int32)
+                spec.jitted_forward(dummy_input_ids, dummy_attention_mask)
         elapsed = time.perf_counter() - start_time
         logger.info("[ENCODER] Precompile finished in %.0f secs", elapsed)
 

--- a/python/sgl_jax/srt/multimodal/models/static_configs/wan2_1_stage_config.yaml
+++ b/python/sgl_jax/srt/multimodal/models/static_configs/wan2_1_stage_config.yaml
@@ -6,10 +6,9 @@ stage_args:
    runtime:
      num_tpus: 2
      max_batch_size: 1
-   scheduler: auto_regressive
+   scheduler: text_encoder
    final_output: false
-   scheduler_params: {}
-   precompile_params: {"capture_hidden_mode": 2}
+   scheduler_params: {"tokenizers": "tokenizer"}
    model_class: UMT5EncoderModel
 
  - stage_id: 1

--- a/python/sgl_jax/srt/multimodal/models/static_configs/wan2_2_stage_config.yaml
+++ b/python/sgl_jax/srt/multimodal/models/static_configs/wan2_2_stage_config.yaml
@@ -7,10 +7,9 @@ stage_args:
      num_tpus: 1
      device_kind: cpu
      max_batch_size: 1
-   scheduler: auto_regressive
+   scheduler: text_encoder
    final_output: false
-   scheduler_params: {}
-   precompile_params: {"capture_hidden_mode": 2}
+   scheduler_params: {"tokenizers": "tokenizer"}
    model_class: UMT5EncoderModel
 
  - stage_id: 1

--- a/python/sgl_jax/test/multimodal/test_stage_config_routing.py
+++ b/python/sgl_jax/test/multimodal/test_stage_config_routing.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import jax.numpy as jnp
 import numpy as np
@@ -10,7 +11,9 @@ from sgl_jax.srt.multimodal.manager.utils import load_stage_configs_from_yaml
 from sgl_jax.srt.multimodal.model_executor.encoder.encoder_model_runner import (
     EncoderModelRunner,
 )
-from sgl_jax.srt.multimodal.models.encoders.clip import CLIPTextModel
+from sgl_jax.srt.multimodal.model_executor.encoder.encoder_model_worker import (
+    EncoderModelWorker,
+)
 from sgl_jax.srt.multimodal.models.encoders.t5 import T5EncoderModel, UMT5EncoderModel
 from sgl_jax.srt.multimodal.models.static_configs import get_stage_config_path
 
@@ -25,20 +28,50 @@ from sgl_jax.srt.multimodal.models.static_configs import get_stage_config_path
 def test_wan_text_encoder_uses_encoder_pipeline(model_path):
     stage = load_stage_configs_from_yaml(get_stage_config_path(model_path))[0]
 
-    assert stage.scheduler == "text_encoder"
-    assert stage.scheduler_params == {"tokenizers": "tokenizer"}
-    assert "precompile_params" not in stage
     assert get_scheduler_class(stage.scheduler) is EncoderScheduler
     assert get_model_class(stage.model_class) is UMT5EncoderModel
 
 
-def test_flux_text_encoder_routing_is_unchanged():
-    stage = load_stage_configs_from_yaml(get_stage_config_path("black-forest-labs/FLUX.1-dev"))[0]
+@pytest.mark.parametrize("max_length", [8, 226, 512, 768, 2048])
+def test_encoder_precompile_covers_every_runtime_length(max_length):
+    runner = object.__new__(EncoderModelRunner)
+    runner.server_args = SimpleNamespace(model_path="Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
+    spec = SimpleNamespace(model_class=UMT5EncoderModel, max_length=max_length)
 
-    assert stage.scheduler == "text_encoder"
-    assert stage.scheduler_params == {"tokenizers": "tokenizer,tokenizer_2"}
-    assert get_scheduler_class(stage.scheduler) is EncoderScheduler
-    assert get_model_class(stage.model_class) == [CLIPTextModel, T5EncoderModel]
+    precompile_lengths = runner.get_precompile_lengths(spec, encoder_idx=0)
+
+    assert precompile_lengths == sorted(set(precompile_lengths))
+    assert all(
+        runner._select_precompiled_max_length(actual_length, max_length) in precompile_lengths
+        for actual_length in range(1, max_length + 1)
+    )
+
+
+def test_flux_t5_precompiles_only_its_fixed_runtime_length():
+    runner = object.__new__(EncoderModelRunner)
+    runner.server_args = SimpleNamespace(model_path="black-forest-labs/FLUX.1-dev")
+    spec = SimpleNamespace(model_class=T5EncoderModel, max_length=512)
+
+    assert runner.get_precompile_lengths(spec, encoder_idx=1) == [512]
+
+
+def test_encoder_worker_precompiles_every_runtime_bucket():
+    runner = object.__new__(EncoderModelRunner)
+    runner.server_args = SimpleNamespace(model_path="Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
+    spec = SimpleNamespace(
+        model_class=UMT5EncoderModel,
+        max_length=512,
+        jitted_forward=Mock(),
+    )
+    runner.encoder_specs = [spec]
+    worker = object.__new__(EncoderModelWorker)
+    worker.model_runner = runner
+
+    worker.run_precompile()
+
+    expected_lengths = runner.get_precompile_lengths(spec, encoder_idx=0)
+    actual_lengths = [call.args[0].shape[1] for call in spec.jitted_forward.call_args_list]
+    assert actual_lengths == expected_lengths
 
 
 def test_wan_t5_bucket_padding_is_zeroed():

--- a/python/sgl_jax/test/multimodal/test_stage_config_routing.py
+++ b/python/sgl_jax/test/multimodal/test_stage_config_routing.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from sgl_jax.srt.multimodal.manager.scheduler.encoder_scheduler import EncoderScheduler
+from sgl_jax.srt.multimodal.manager.stage import get_model_class, get_scheduler_class
+from sgl_jax.srt.multimodal.manager.utils import load_stage_configs_from_yaml
+from sgl_jax.srt.multimodal.model_executor.encoder.encoder_model_runner import (
+    EncoderModelRunner,
+)
+from sgl_jax.srt.multimodal.models.encoders.clip import CLIPTextModel
+from sgl_jax.srt.multimodal.models.encoders.t5 import T5EncoderModel, UMT5EncoderModel
+from sgl_jax.srt.multimodal.models.static_configs import get_stage_config_path
+
+
+@pytest.mark.parametrize(
+    "model_path",
+    [
+        "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+    ],
+)
+def test_wan_text_encoder_uses_encoder_pipeline(model_path):
+    stage = load_stage_configs_from_yaml(get_stage_config_path(model_path))[0]
+
+    assert stage.scheduler == "text_encoder"
+    assert stage.scheduler_params == {"tokenizers": "tokenizer"}
+    assert "precompile_params" not in stage
+    assert get_scheduler_class(stage.scheduler) is EncoderScheduler
+    assert get_model_class(stage.model_class) is UMT5EncoderModel
+
+
+def test_flux_text_encoder_routing_is_unchanged():
+    stage = load_stage_configs_from_yaml(get_stage_config_path("black-forest-labs/FLUX.1-dev"))[0]
+
+    assert stage.scheduler == "text_encoder"
+    assert stage.scheduler_params == {"tokenizers": "tokenizer,tokenizer_2"}
+    assert get_scheduler_class(stage.scheduler) is EncoderScheduler
+    assert get_model_class(stage.model_class) == [CLIPTextModel, T5EncoderModel]
+
+
+def test_wan_t5_bucket_padding_is_zeroed():
+    runner = object.__new__(EncoderModelRunner)
+    runner.server_args = SimpleNamespace(model_path="Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
+    spec = SimpleNamespace(model_class=UMT5EncoderModel)
+    hidden_states = jnp.arange(1, 17, dtype=jnp.float32).reshape(1, 4, 4)
+    tokenizer_mask = jnp.array([[1, 1, 0, 0]], dtype=jnp.int32)
+
+    model_mask = runner._get_model_attention_mask(spec, tokenizer_mask, encoder_idx=0)
+    result = runner.t5_postprocess_text({"last_hidden_state": hidden_states}, model_mask)
+
+    np.testing.assert_array_equal(result[:, :2], hidden_states[:, :2])
+    np.testing.assert_array_equal(result[:, 2:], jnp.zeros_like(hidden_states[:, 2:]))
+
+
+def test_flux_t5_effective_mask_preserves_padded_outputs():
+    runner = object.__new__(EncoderModelRunner)
+    runner.server_args = SimpleNamespace(model_path="black-forest-labs/FLUX.1-dev")
+    spec = SimpleNamespace(model_class=T5EncoderModel)
+    hidden_states = jnp.arange(1, 17, dtype=jnp.float32).reshape(1, 4, 4)
+    tokenizer_mask = jnp.array([[1, 1, 0, 0]], dtype=jnp.int32)
+
+    model_mask = runner._get_model_attention_mask(spec, tokenizer_mask, encoder_idx=1)
+    result = runner.t5_postprocess_text({"last_hidden_state": hidden_states}, model_mask)
+
+    np.testing.assert_array_equal(model_mask, jnp.ones_like(tokenizer_mask))
+    np.testing.assert_array_equal(result, hidden_states)

--- a/test/srt/multimodal/test_wan2_1_models.py
+++ b/test/srt/multimodal/test_wan2_1_models.py
@@ -29,27 +29,30 @@ class TestWan2_1Model(CustomTestCase):
                 "--random-seed",
                 "3",
                 "--multimodal",
-                "--disable-precompile",
             ],
             multimodal=True,
         )
-        data = {
-            "prompt": "A curious raccoon",
-            "size": "480*832",
-            "num_frames": 41,
-            "num_inference_steps": 5,
-        }
-        response = requests.post(
-            DEFAULT_URL_FOR_TEST + "/api/v1/videos/generation",
-            headers=headers,
-            json=data,
-            timeout=1200,
-        )
-        response.raise_for_status()
-        result = response.json()
-        print("success！")
-        print(json.dumps(result, indent=4, ensure_ascii=False))
-        process.kill()
+        try:
+            data = {
+                "prompt": "A curious raccoon",
+                "size": "480*832",
+                "num_frames": 41,
+                "num_inference_steps": 5,
+            }
+            response = requests.post(
+                DEFAULT_URL_FOR_TEST + "/api/v1/videos/generation",
+                headers=headers,
+                json=data,
+                timeout=1200,
+            )
+            response.raise_for_status()
+            result = response.json()
+            self.assertTrue(result.get("success"), msg=f"generation not successful: {result}")
+            self.assertIn("meta_info", result)
+            print("success！")
+            print(json.dumps(result, indent=4, ensure_ascii=False))
+        finally:
+            kill_process_tree(process.pid)
 
     def test_wan2_1_14b(self):
         process = popen_launch_server(
@@ -63,22 +66,25 @@ class TestWan2_1Model(CustomTestCase):
                 "--random-seed",
                 "3",
                 "--multimodal",
-                "--disable-precompile",
             ],
             multimodal=True,
         )
-        data = {"prompt": "A curious raccoon", "size": "480*832", "num_frames": 5}
-        response = requests.post(
-            DEFAULT_URL_FOR_TEST + "/api/v1/videos/generation",
-            headers=headers,
-            json=data,
-            timeout=1200,
-        )
-        response.raise_for_status()
-        result = response.json()
-        print("success！")
-        print(json.dumps(result, indent=4, ensure_ascii=False))
-        process.kill()
+        try:
+            data = {"prompt": "A curious raccoon", "size": "480*832", "num_frames": 5}
+            response = requests.post(
+                DEFAULT_URL_FOR_TEST + "/api/v1/videos/generation",
+                headers=headers,
+                json=data,
+                timeout=1200,
+            )
+            response.raise_for_status()
+            result = response.json()
+            self.assertTrue(result.get("success"), msg=f"generation not successful: {result}")
+            self.assertIn("meta_info", result)
+            print("success！")
+            print(json.dumps(result, indent=4, ensure_ascii=False))
+        finally:
+            kill_process_tree(process.pid)
 
 
 if __name__ == "__main__":

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -314,6 +314,9 @@ suites = {
         TestFile(
             "python/sgl_jax/test/multimodal/test_kimi_k25_weight_mapping.py", 0.2, runner="pytest"
         ),
+        TestFile(
+            "python/sgl_jax/test/multimodal/test_stage_config_routing.py", 0.1, runner="pytest"
+        ),
         TestFile("python/sgl_jax/test/models/test_qwen3_5.py", 2, runner="pytest"),
         TestFile("python/sgl_jax/test/mem_cache/test_req_to_token_pool.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py", 1),


### PR DESCRIPTION
## Summary

The Wan2.1 and Wan2.2 stage-0 UMT5 text encoder is configured with the
`auto_regressive` scheduler. This selects the LLM-serving scheduler and the
LLM-path UMT5 implementation, so startup precompile follows the autoregressive
path and can run an unnecessarily large prefill that exhausts device memory.

This PR routes the Wan text encoder through the dedicated encoder pipeline.
Runtime token-bucket selection and startup precompile now share the same bucket
definition, so precompile covers every input shape that the request path can
select. UMT5 outputs at bucket-padding positions are zeroed with the effective
model attention mask before they reach Wan cross-attention, matching the
reference Wan padding contract while preserving FLUX T5's fixed-length,
all-ones-mask behavior.

Fixes #1315.

## Changes

- Bind the multimodal encoder-path `UMT5EncoderModel` in the stage model registry.
- Change the Wan2.1 and Wan2.2 text-encoder stages from `auto_regressive` to
  `text_encoder`, pass the tokenizer explicitly, and remove the autoregressive
  `precompile_params`.
- Use one shared encoder token-bucket definition for runtime padding and
  precompile every reachable input length. FLUX T5 remains fixed at its maximum
  sequence length.
- Re-enable precompile in the Wan2.1 E2E cases so the original startup path is
  covered.
- Mask T5 bucket-padding hidden states at the encoder output boundary using the
  effective model attention mask.
- Add CPU regression tests for Wan scheduler/model resolution, runtime-to-
  precompile bucket coverage, worker precompile calls, Wan padding semantics,
  and unchanged FLUX T5 behavior, registered in `unit-test-cpu`.
- Update the multimodal architecture documentation and make the Wan E2E server
  cleanup reliable when an assertion fails.

## Validation

- `python -m pytest python/sgl_jax/test/multimodal/test_stage_config_routing.py -q`
  - 11 passed
- `pre-commit run --all-files`
  - passed
- The previous CI attempt passed CPU, all 1-TPU unit partitions, 1-TPU E2E,
  1-TPU accuracy, and one 4-TPU unit partition. The remaining 4-TPU runners
  lost communication with GitHub before producing test results.
- Wan TPU E2E has not completed against the current head. Prior TPU and
  numerical validation is documented in #1315.

## Accuracy Tests

The CPU regression tests verify that Wan real-token embeddings are preserved,
Wan bucket-padding embeddings are zeroed, every runtime-selectable encoder
shape is precompiled, and FLUX T5 keeps its fixed-length behavior. The
model-path rewire was previously validated against Hugging Face and with Wan
end-to-end generation as documented in #1315; that TPU validation has not yet
completed against the current head.

## Benchmarking and Profiling

N/A. This PR fixes stage routing and precompile coverage; no throughput or
latency benchmark was run for the current head.

## Checklist

- [x] The PR and public artifacts are in English.
- [x] The PR links the issue it resolves.
- [x] The test plan and current validation status are documented.
