### PR TITLE
fix(kernels): three alignment/sharding fixes for FP8 block-quant models

### DIFF
--- a/python/sgl_jax/srt/kernels/quantized_matmul/blockwise_utils.py
+++ b/python/sgl_jax/srt/kernels/quantized_matmul/blockwise_utils.py
@@ -367,8 +367,14 @@ def get_safe_blockwise_tuned_value(
     n_lane_multiplier = max(1, int(tuned.n_lane_multiplier))
     compute_tile_n = 256 * n_lane_multiplier
 
-    # batch: simply cap to actual batch size.
-    batch_block_size = max(1, min(int(tuned.batch_block_size), int(n_batch)))
+    # batch: cap to actual batch size, then enforce the Pallas TPU block-shape
+    # constraint (block_m % 8 == 0 OR block_m == array_m). When Tier-1 fuzzy
+    # match returns a small batch_block_size (e.g. 1 from a #1191 entry) but
+    # n_batch is in (1, 8), the unaligned block triggers a lowering ValueError.
+    n_batch_i = int(n_batch)
+    batch_block_size = max(1, min(int(tuned.batch_block_size), n_batch_i))
+    if batch_block_size < n_batch_i and batch_block_size % 8 != 0:
+        batch_block_size = n_batch_i if n_batch_i <= 8 else max(8, batch_block_size & ~7)
 
     # out (N): round up to compute_tile_n, cap to matrix N, then snap to
     # nearest power-of-two multiple for TPU alignment.

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -196,6 +196,10 @@ class ModelWorker:
         if server_args.moe_backend == "fused" and server_args.ep_size > 1:
             from sgl_jax.srt.utils.common_utils import align_bs_for_fused_ep
 
+            assert server_args.ep_size % dp_size == 0, (
+                f"fused MoE requires ep_size ({server_args.ep_size}) to be a multiple "
+                f"of dp_size ({dp_size}) so the ep-aligned cap stays dp-aligned"
+            )
             aligned = align_bs_for_fused_ep(self.max_running_requests, server_args.ep_size)
             if aligned != self.max_running_requests:
                 logger.warning(

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -193,6 +193,20 @@ class ModelWorker:
                 dp_size,
             )
 
+        if server_args.moe_backend == "fused" and server_args.ep_size > 1:
+            from sgl_jax.srt.utils.common_utils import align_bs_for_fused_ep
+
+            aligned = align_bs_for_fused_ep(self.max_running_requests, server_args.ep_size)
+            if aligned != self.max_running_requests:
+                logger.warning(
+                    "Adjusted max_running_requests from %s to %s for fused MoE "
+                    "(ep_size=%s, bt must be in {2,4,8k})",
+                    self.max_running_requests,
+                    aligned,
+                    server_args.ep_size,
+                )
+                self.max_running_requests = aligned
+
         assert self.max_running_requests > 0, "max_running_request is zero"
 
         # A single request lives on one DP rank, so max_req_len is bounded

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -47,7 +47,6 @@ class CompilationManager:
         self.multimodal = multimodal
         self.has_recurrent_state = has_recurrent_state
         self.moe_backend = server_args.moe_backend
-        self.ep_size = server_args.ep_size
         self.enable_static_lora = server_args.enable_static_lora
 
         self.token_buckets = self._compute_token_buckets(server_args.precompile_token_paddings)
@@ -90,18 +89,7 @@ class CompilationManager:
                 buckets.append(bs)
         buckets.sort()
         if len(buckets) == 0 or buckets[-1] < self.max_padded_batch_size:
-            cap = self.max_padded_batch_size
-            if self.moe_backend == "fused" and self.ep_size > 1:
-                # fused_ep_moe requires global num_tokens % ep_size == 0 AND the
-                # derived per-ep bt (= num_tokens // ep_size) to be in {2, 4, 8k}.
-                # max_padded_batch_size comes from min(attn_backend_limit, ...)
-                # which is not ep-aware (e.g. 408 on v7x-16 ep=32); down-align so
-                # the auto-appended bucket is always launchable.
-                local = cap // self.ep_size
-                local = (local // 8) * 8 if local >= 8 else (4 if local >= 4 else 2)
-                cap = local * self.ep_size
-            if len(buckets) == 0 or cap > buckets[-1]:
-                buckets.append(cap)
+            buckets.append(self.max_padded_batch_size)
         return buckets
 
     def _compute_cache_loc_buckets(self) -> list[int]:

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -47,6 +47,7 @@ class CompilationManager:
         self.multimodal = multimodal
         self.has_recurrent_state = has_recurrent_state
         self.moe_backend = server_args.moe_backend
+        self.ep_size = server_args.ep_size
         self.enable_static_lora = server_args.enable_static_lora
 
         self.token_buckets = self._compute_token_buckets(server_args.precompile_token_paddings)
@@ -89,7 +90,18 @@ class CompilationManager:
                 buckets.append(bs)
         buckets.sort()
         if len(buckets) == 0 or buckets[-1] < self.max_padded_batch_size:
-            buckets.append(self.max_padded_batch_size)
+            cap = self.max_padded_batch_size
+            if self.moe_backend == "fused" and self.ep_size > 1:
+                # fused_ep_moe requires global num_tokens % ep_size == 0 AND the
+                # derived per-ep bt (= num_tokens // ep_size) to be in {2, 4, 8k}.
+                # max_padded_batch_size comes from min(attn_backend_limit, ...)
+                # which is not ep-aware (e.g. 408 on v7x-16 ep=32); down-align so
+                # the auto-appended bucket is always launchable.
+                local = cap // self.ep_size
+                local = (local // 8) * 8 if local >= 8 else (4 if local >= 4 else 2)
+                cap = local * self.ep_size
+            if len(buckets) == 0 or cap > buckets[-1]:
+                buckets.append(cap)
         return buckets
 
     def _compute_cache_loc_buckets(self) -> list[int]:

--- a/python/sgl_jax/srt/utils/common_utils.py
+++ b/python/sgl_jax/srt/utils/common_utils.py
@@ -39,6 +39,22 @@ PRECOMPILE_DEFAULT_TOKEN_PADDINGS = [1 << i for i in range(6, 14)]
 PRECOMPILE_DEFAULT_BS_PADDINGS = [1 << i for i in range(0, 9)]
 
 
+def align_bs_for_fused_ep(bs: int, ep_size: int) -> int:
+    """Down-align a global batch size so it is launchable by fused_ep_moe.
+
+    The fused MoE kernel requires ``bs % ep_size == 0`` and the per-EP local
+    batch ``bs // ep_size`` to be in ``{2, 4}`` or a multiple of 8. The
+    attention-backend / pool-derived ``max_running_requests`` is not ep-aware
+    (e.g. 408 on v7x-16 with ep=32), so callers must align it before it flows
+    into the scheduler and the precompile bucket list.
+    """
+    if ep_size <= 1:
+        return bs
+    local = bs // ep_size
+    local = (local // 8) * 8 if local >= 8 else (4 if local >= 4 else 2)
+    return local * ep_size
+
+
 def pad_to_bucket(value: int, buckets: list[int]) -> tuple[int, int]:
     """Return the smallest bucket >= value and its index.
 

--- a/python/sgl_jax/srt/utils/common_utils.py
+++ b/python/sgl_jax/srt/utils/common_utils.py
@@ -51,6 +51,11 @@ def align_bs_for_fused_ep(bs: int, ep_size: int) -> int:
     if ep_size <= 1:
         return bs
     local = bs // ep_size
+    if local < 2:
+        raise ValueError(
+            f"max_running_requests={bs} is below the fused-MoE minimum "
+            f"(2 * ep_size = {2 * ep_size}); reduce ep_size or increase capacity."
+        )
     local = (local // 8) * 8 if local >= 8 else (4 if local >= 4 else 2)
     return local * ep_size
 

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -883,8 +883,8 @@ class WeightLoader:
                     weight.shape,
                     model_param.value.shape,
                 )
-                weight = jnp.repeat(weight, block_size_out, axis=2)[..., :out_dim]
-                return weight[:, :, None, :]
+                idx = jnp.arange(out_dim) // block_size_out
+                return jnp.take(weight, idx, axis=2)[:, :, None, :]
             if weight.shape == (num_experts, expected_out_blocks, k_blocks):
                 logger.info(
                     "Transposing+expanding fused MoE 2D scale %s from %s to fast kernel layout %s",
@@ -893,8 +893,8 @@ class WeightLoader:
                     model_param.value.shape,
                 )
                 weight = jnp.transpose(weight, (0, 2, 1))
-                weight = jnp.repeat(weight, block_size_out, axis=2)[..., :out_dim]
-                return weight[:, :, None, :]
+                idx = jnp.arange(out_dim) // block_size_out
+                return jnp.take(weight, idx, axis=2)[:, :, None, :]
 
         if weight.shape == (num_experts, out_dim, k_blocks):
             return jnp.expand_dims(jnp.transpose(weight, (0, 2, 1)), axis=2)

--- a/python/sgl_jax/test/test_compilation_manager.py
+++ b/python/sgl_jax/test/test_compilation_manager.py
@@ -21,6 +21,12 @@ class TestAlignBsForFusedEp(unittest.TestCase):
         self.assertEqual(align_bs_for_fused_ep(100, 32), 64)  # local=3→2
         self.assertEqual(align_bs_for_fused_ep(200, 32), 128)  # local=6→4
 
+    def test_below_minimum_raises(self):
+        with self.assertRaises(ValueError):
+            align_bs_for_fused_ep(10, 32)  # local=0, would up-align past bs
+        with self.assertRaises(ValueError):
+            align_bs_for_fused_ep(63, 32)  # local=1
+
     def test_ep_le_1_passthrough(self):
         self.assertEqual(align_bs_for_fused_ep(408, 1), 408)
         self.assertEqual(align_bs_for_fused_ep(408, 0), 408)

--- a/python/sgl_jax/test/test_compilation_manager.py
+++ b/python/sgl_jax/test/test_compilation_manager.py
@@ -3,7 +3,27 @@ from unittest.mock import MagicMock
 
 from sgl_jax.srt.model_executor.compilation_manager import CompilationManager
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
-from sgl_jax.srt.utils.common_utils import pad_to_bucket
+from sgl_jax.srt.utils.common_utils import align_bs_for_fused_ep, pad_to_bucket
+
+
+class TestAlignBsForFusedEp(unittest.TestCase):
+    def test_v7x16_dsv3_408_to_256(self):
+        # DeepSeek-V3 v7x-16: attn_limit 102×dp4=408, ep=32 → local=12 invalid
+        self.assertEqual(align_bs_for_fused_ep(408, 32), 256)
+
+    def test_already_aligned_noop(self):
+        self.assertEqual(align_bs_for_fused_ep(512, 32), 512)  # local=16=8k
+        self.assertEqual(align_bs_for_fused_ep(512, 64), 512)  # local=8
+        self.assertEqual(align_bs_for_fused_ep(128, 32), 128)  # local=4
+        self.assertEqual(align_bs_for_fused_ep(64, 32), 64)  # local=2
+
+    def test_small_local_snaps_to_2_or_4(self):
+        self.assertEqual(align_bs_for_fused_ep(100, 32), 64)  # local=3→2
+        self.assertEqual(align_bs_for_fused_ep(200, 32), 128)  # local=6→4
+
+    def test_ep_le_1_passthrough(self):
+        self.assertEqual(align_bs_for_fused_ep(408, 1), 408)
+        self.assertEqual(align_bs_for_fused_ep(408, 0), 408)
 
 
 def _make_server_args(**overrides):


### PR DESCRIPTION
## Motivation

Three independent issues block FP8 block-quant models (DeepSeek-V3, GLM-5.1) from running on certain (dp, ep, batch) configs. All reproduce on `main@8abb3317`.

## Changes

### 1. `blockwise_utils.py` — Pallas 8-align after Tier-1 clamp

Tier-1 fuzzy match (post-#1191) can return `batch_block_size=1`. The existing `min(tuned, n_batch)` clamp leaves it at 1 even when `n_batch∈(2,7)`, which violates the Pallas TPU constraint `block_m % 8 == 0 OR block_m == array_m`:

    ValueError: block shape (1, 1024) ... array (4, 7168)

Fix: after clamping, if `block_m < n_batch and block_m % 8 != 0`, snap to `n_batch` (≤8) or down-align to 8.

### 2. `weight_utils.py` — keep expert sharding in scale convert

`_maybe_convert_epmoe_scale_for_kernel` uses `jnp.repeat` on the block-scale which loses the `("expert", …)` sharding and materializes a fully-replicated intermediate (117 MB × 6 × 58 layers) → HBM OOM on the fused load path. Replace with `jnp.take(weight, jnp.arange(out_dim)//block, axis=2)` which preserves sharding.

### 3. `tp_worker.py` / `common_utils.py` — ep-align `max_running_requests` for fused MoE

The attention-backend / pool cap on `max_running_requests` is not ep-aware (observed 408 on v7x-16 with ep=32). With `--moe-backend fused` this flows into the precompile bs-bucket list and hits `fused_moe.get_simplified_key`:

    ValueError: Expected num_tokens=408 to be aligned to ep_size=32

Fix: new helper `common_utils.align_bs_for_fused_ep(bs, ep)` down-aligns so that `bs // ep ∈ {2, 4, 8k}`; `tp_worker` calls it right after the existing dp-align so both the scheduler cap and `max_padded_batch_size` stay consistent. Guards added per review: raise when `bs < 2*ep` (no valid down-align), assert `ep_size % dp_size == 0`.

## Testing

- Unit: `test_compilation_manager.py::TestAlignBsForFusedEp` (5 cases: 408/32→256, no-op, 2/4-snap, below-minimum raises, ep≤1 passthrough)
- e2e: DeepSeek-V3 v6e-64 (dp=8/ep=64) + v7x-16 (dp=4/ep=32), server boots clean on default `--precompile-bs-paddings`, GSM8K 0.965–0.985

Part of #1318.
