### PR TITLE
feat(fused_moe): static block-wise scale wiring for DeepSeek-V3

### DIFF
--- a/python/sgl_jax/srt/layers/fused_moe.py
+++ b/python/sgl_jax/srt/layers/fused_moe.py
@@ -260,30 +260,31 @@ class FusedEPMoE(nnx.Module):
                 )
 
                 if self.num_shared_experts > 0:
-                    # fused kernel expects per-channel shared scale (1, 1, se_inter)
-                    # — see _validate_fused_ep_moe_args / kernel.py:455-470
-                    shared_scale_sharding = P(None, None, None)
+                    # Static block-wise checkpoints: store the raw HF 2D block
+                    # scale [out_blocks, in_blocks]; __call__ dequants the fp8
+                    # shared weight to bf16 before the kernel call so the
+                    # Pallas kernel keeps its per-channel-only shared path.
+                    bn = self.quant_block_n or wsz
                     se_inter = self.moe_shared_expert_intermediate_size * self.num_shared_experts
+                    se13_shape = (-(-se_inter // bn), -(-self.hidden_size // wsz))
+                    se2_shape = (-(-self.hidden_size // bn), -(-se_inter // wsz))
 
                     if hasattr(self, "w1_shared_scale"):
                         del self.w1_shared_scale
                     self.w1_shared_scale = nnx.Param(
-                        jnp.zeros((1, 1, se_inter), dtype=jnp.float32),
-                        out_sharding=shared_scale_sharding,
+                        jnp.zeros(se13_shape, dtype=jnp.float32), out_sharding=P(None, None)
                     )
 
                     if hasattr(self, "w3_shared_scale"):
                         del self.w3_shared_scale
                     self.w3_shared_scale = nnx.Param(
-                        jnp.zeros((1, 1, se_inter), dtype=jnp.float32),
-                        out_sharding=shared_scale_sharding,
+                        jnp.zeros(se13_shape, dtype=jnp.float32), out_sharding=P(None, None)
                     )
 
                     if hasattr(self, "w2_shared_scale"):
                         del self.w2_shared_scale
                     self.w2_shared_scale = nnx.Param(
-                        jnp.zeros((1, 1, self.hidden_size), dtype=jnp.float32),
-                        out_sharding=shared_scale_sharding,
+                        jnp.zeros(se2_shape, dtype=jnp.float32), out_sharding=P(None, None)
                     )
 
                 return
@@ -458,6 +459,29 @@ class FusedEPMoE(nnx.Module):
         w3_shared_scale = self.w3_shared_scale.value if self.w3_shared_scale is not None else None
         w2_shared_scale = self.w2_shared_scale.value if self.w2_shared_scale is not None else None
 
+        # Static block-wise shared scale (HF 2D [out_blocks, in_blocks]): the
+        # Pallas kernel's shared-expert VMEM buffers are hard-typed to the
+        # routed weight dtype (fp8) and only accept per-channel (1,1,N) scale,
+        # so compute the shared-expert contribution here in jnp (dequant fp8
+        # weight to bf16) and disable the kernel's shared path.
+        def _dequant(w, s):
+            in_dim, out_dim = w.shape
+            ob, ib = s.shape
+            bk, bn = -(-in_dim // ib), -(-out_dim // ob)
+            full = jnp.repeat(jnp.repeat(s, bn, axis=0)[:out_dim], bk, axis=1)[:, :in_dim].T
+            return (w.astype(jnp.float32) * full).astype(self.dtype)
+
+        external_shared_out = None
+        if w1_shared_val is not None and w1_shared_scale is not None and w1_shared_scale.ndim == 2:
+            w1d = _dequant(w1_shared_val, w1_shared_scale)
+            w3d = _dequant(w3_shared_val, w3_shared_scale)
+            w2d = _dequant(w2_shared_val, w2_shared_scale)
+            x = hidden_states.astype(self.dtype)
+            gate = jax.nn.silu(x @ w1d)
+            external_shared_out = ((gate * (x @ w3d)) @ w2d).astype(hidden_states.dtype)
+            w1_shared_val = w3_shared_val = w2_shared_val = None
+            w1_shared_scale = w3_shared_scale = w2_shared_scale = None
+
         quant_block_k = self.quant_block_k if self.quant_block_k is not None else None
 
         output = fused_ep_moe(
@@ -506,5 +530,8 @@ class FusedEPMoE(nnx.Module):
 
         if out_sharding is None:
             out_sharding = jax.sharding.NamedSharding(self.mesh, P(*([None] * output.ndim)))
+        if external_shared_out is not None:
+            ep_spec = jax.sharding.NamedSharding(self.mesh, P(("data", "tensor"), None))
+            output = output + jax.sharding.reshard(external_shared_out, ep_spec)
         output = jax.sharding.reshard(output, out_sharding)
         return output

--- a/python/sgl_jax/srt/models/deepseek_v3.py
+++ b/python/sgl_jax/srt/models/deepseek_v3.py
@@ -928,18 +928,17 @@ class DeepseekV3ForCausalLM(nnx.Module):
         )
         mappings.update(moe_mappings)
 
-        # Routed expert weight-scale sidecars (static FP8, non-fused only).
-        # Fused MoE static-FP8 placeholder shapes are (1,) today — loading
-        # block scales would need a dedicated fix in fused_moe.py. Skip.
-        #
-        # For each expert weight group (emitted by create_moe_weights_mapping
-        # as `__MOE_EXPERTS__<target_base>`) register a parallel scale group
-        # whose HF keys are the per-expert `*.weight_scale_inv` tensors and
-        # whose target is `<target_base>_scale` (e.g. `wi_0_scale`). After
-        # stacking, WeightLoader's _maybe_convert_epmoe_scale_for_kernel
-        # converts the `[E, out_blocks, in_blocks]` layout into the
-        # kernel-ready `[E, k_blocks, 1, n_out]` expected by GMM.
-        if is_static_quant and not use_fused:
+        # Routed expert weight-scale sidecars (static FP8). For each expert
+        # weight group register a parallel `*_scale` group. WeightLoader's
+        # _maybe_convert_epmoe_scale_for_kernel converts `[E, out_blocks,
+        # in_blocks]` → kernel-ready `[E, k_blocks, 1, n_out]` (works for both
+        # epmoe targets `wi_*_scale` and fused targets `w[123]_scale`).
+        if is_static_quant:
+            # Match the weight mapping's mesh: epmoe uses moe_mesh ("expert"
+            # axis), fused uses the original mesh ("data","tensor" product).
+            scale_load_sharding = (
+                ("expert", None, None) if not use_fused else (("data", "tensor"), None, None)
+            )
             for moe_key, wm in moe_mappings.items():
                 if not moe_key.startswith("__MOE_EXPERTS__"):
                     continue
@@ -948,14 +947,9 @@ class DeepseekV3ForCausalLM(nnx.Module):
                     k.replace(".weight", ".weight_scale_inv") for k in wm.target_path[1:]
                 ]
                 scale_target = f"{target_base}_scale"
-                # Stacked checkpoint scale is `[E, out_blocks, in_blocks]`. Load
-                # replicated on the block dims; _maybe_convert_epmoe_scale_for_kernel
-                # expands via jnp.take, which fails if the gathered axis is
-                # tensor-sharded (ambiguous output sharding). The converter reshards
-                # to model_param.value.sharding at the end.
                 mappings[f"__MOE_EXPERTS__{scale_target}"] = WeightMapping(
                     target_path=[scale_target] + expert_scale_keys,
-                    sharding=("expert", None, None),
+                    sharding=scale_load_sharding,
                     transpose=False,
                     physical_to_logical_map=wm.physical_to_logical_map,
                 )
@@ -964,10 +958,10 @@ class DeepseekV3ForCausalLM(nnx.Module):
         n_shared_experts = getattr(self.config, "n_shared_experts", None)
         if n_shared_experts and n_shared_experts > 0:
             if use_fused:
-                # Fused backend stores shared-expert weights as bare nnx.Param
-                # (no QuantizedLinear swap). Static-FP8 scale mappings for the
-                # fused path are TODO (requires fixed placeholder shapes in
-                # FusedEPMoE.quantize_weights(is_static=True)).
+                # Fused backend stores shared-expert weights as bare nnx.Param.
+                # For static FP8 also load the 2D HF block scale_inv directly
+                # into the matching placeholder; FusedEPMoE.__call__ dequants
+                # the weight to bf16 before the kernel call.
                 for hf_name, target_name in [
                     ("gate_proj", "w1_shared"),
                     ("up_proj", "w3_shared"),
@@ -978,6 +972,14 @@ class DeepseekV3ForCausalLM(nnx.Module):
                         sharding=(None, None),
                         transpose=True,
                     )
+                    if is_static_quant:
+                        mappings[f"{prefix}.mlp.shared_experts.{hf_name}.weight_scale_inv"] = (
+                            WeightMapping(
+                                target_path=f"{target}.mlp.{target_name}_scale",
+                                sharding=(None, None),
+                                transpose=False,
+                            )
+                        )
             else:
                 for proj, sharding in [
                     ("gate_proj", (None, "tensor")),


### PR DESCRIPTION
## Motivation

`FusedEPMoE` only supports dynamic per-tensor scales; static block-wise FP8 checkpoints (DeepSeek-V3) are forced onto `EPMoE`, whose replicate-then-mask `reshard(P(None))` all-gather dominates EXTEND (40% of step, xprof attached).

## Changes

### `deepseek_v3.py` weight mapping
- Drop the `not use_fused` guard on `is_static_quant` routed-expert scale mapping; for fused, load with `(("data","tensor"), None, None)` to match the fused weight mesh (epmoe uses `("expert", …)` via `moe_mesh`).
- Add shared-expert `weight_scale_inv` mappings (2D HF layout, replicated).

### `fused_moe.py`
- `quantize_weights(is_static=True)`: shared scale placeholders → 2D `(out_blocks, in_blocks)` to receive HF `weight_scale_inv` directly.
- `__call__`: when shared scales are 2D block-wise, dequant shared w1/w2/w3 to bf16 and compute the shared-expert SwiGLU with plain `jnp` (3 small GEMMs), pass `None` to the Pallas kernel for shared, and add the result back after resharding to `P(("data","tensor"), None)`. Rationale: the v1 Pallas kernel's shared-expert path assumes the same dtype/VMEM layout as routed; mixing fp8 routed + per-call-dequant'd bf16 shared in-kernel triggers a DMA dtype mismatch. The shared expert is tiny (`inter=2048` vs hidden=7168) so the out-of-kernel cost is negligible (<1% of step).

Routed experts use the existing block-scale path added in #1259 (gmm_v2) — no kernel change needed; only the scale *loading* was missing.

## Benchmark (v6e-64, `bench_serving 1K/1K --random-range-ratio 1.0`)

| | epmoe (with #1320 tune) | fused (this PR + #1322) | Δ |
|---|---|---|---|
| cc=420 | 2958 | **5299** | **+79%** |
| cc=512 | 3291 | **5315** | **+62%** |
| ITL P50 @512 | 87.2 ms | **57.5 ms** | −34% |
| GSM8K 200 | — | 0.96 | ✅ |

## xprof (v6e-64, cc=512 load, single TPU:0)

| op | epmoe EXTEND 1075 ms | **fused EXTEND 895 ms** | epmoe DECODE 69 ms | **fused DECODE 56 ms** |
|---|---|---|---|---|
| all-gather (reshard P(None)) | **424 (40%)** | 76 (8%) | 12 | **0** |
| MoE gmm / fused-moe Pallas | 366 | 544¹ | 30 | 18 |
| all-reduce | 202 | 3 | 8 | 8 |
| mla | 10 | 132 | 10 | 12 |
| quantized_mm (dense) | 57 | 25 | 7 | 4 |

¹ EXTEND uses DEFAULT config; tuned in #1322.

Part of #1318.

> Runtime depends on #1319 (the `weight_utils` `jnp.take` fix — without it the fused weight-load path OOMs). Diff here is independent (2 files, no overlap with #1319).

