### PR TITLE
perf(fused_moe): v6e/v7x DECODE block-config entries for DeepSeek-V3

### DIFF
--- a/python/sgl_jax/srt/kernels/fused_moe/v1/tuned_block_configs.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v1/tuned_block_configs.py
@@ -126,6 +126,12 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         ('bfloat16', 'float8_e4m3fn', 8192, 384, 8, 6144, 2048, 32, False, False): (64, 1024, 2048, 2048, 64, 64, 1024, 2048, 2048, 1024),
         ('bfloat16', 'float8_e4m3fn', 16384, 384, 8, 6144, 2048, 32, False, False): (64, 1024, 2048, 2048, 64, 64, 1024, 2048, 2048, 1024),
 
+        # DeepSeek-V3 671B (hidden=7168, ep=32) — shared expert computed
+        # out-of-kernel (use_shared=False). bd1/bd2=1024 (must divide 7168).
+        # T=512 (bt=16) verified on v7x-16; T<512 entries pending verification.
+        ('bfloat16', 'float8_e4m3fn', 512, 256, 8, 7168, 2048, 32, False, False): (16, 2048, 1024, 1024, 64, 16, 2048, 1024, 1024, 256),
+        ('bfloat16', 'float8_e4m3fn', 512, 256, 8, 7168, 2048, 32, False, True): (16, 2048, 1024, 1024, 64, 16, 2048, 1024, 1024, 256),
+
         ('bfloat16', 'float8_e4m3fn', 64, 256, 8, 8192, 2048, 32, True, True): (2, 2048, 4096, 4096, 4, 4, 256, 512, 4096, 512),
         ('bfloat16', 'float8_e4m3fn', 128, 256, 8, 8192, 2048, 32, True, True): (4, 2048, 4096, 4096, 8, 8, 256, 512, 4096, 256),
         ('bfloat16', 'float8_e4m3fn', 256, 256, 8, 8192, 2048, 32, True, True): (8, 2048, 2048, 2048, 16, 16, 256, 512, 2048, 2048),
@@ -219,6 +225,16 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         ('bfloat16', 'bfloat16', 2048, 128, 8, 2048, 768, 4, False, False): (512, 768, 2048, 2048, 128, 128, 768, 2048, 2048, 768),
         ('bfloat16', 'bfloat16', 4096, 128, 8, 2048, 768, 4, False, False): (512, 768, 2048, 2048, 128, 128, 768, 2048, 2048, 768),
         ('bfloat16', 'bfloat16', 8192, 128, 8, 2048, 768, 4, False, False): (512, 768, 2048, 2048, 128, 128, 768, 2048, 2048, 768),
+        # DeepSeek-V3: 256 experts, top_k=8, H=7168, I=2048, ep=64. Shared expert
+        # computed out-of-kernel → use_shared=False. DECODE only (T≤512): raise
+        # bts from DEFAULT bts=bt (2/4/8, MXU-underutilized) to 64; bd=1024
+        # (must divide 7168). EXTEND (T≥1024) uses DEFAULT (large bts → VMEM OOM).
+        ('bfloat16', 'float8_e4m3fn', 128, 256, 8, 7168, 2048, 64, False, False): (2, 2048, 1024, 1024, 64, 2, 2048, 1024, 1024, 256),
+        ('bfloat16', 'float8_e4m3fn', 256, 256, 8, 7168, 2048, 64, False, False): (4, 2048, 1024, 1024, 64, 4, 2048, 1024, 1024, 256),
+        ('bfloat16', 'float8_e4m3fn', 512, 256, 8, 7168, 2048, 64, False, False): (8, 2048, 1024, 1024, 64, 8, 2048, 1024, 1024, 256),
+        ('bfloat16', 'float8_e4m3fn', 128, 256, 8, 7168, 2048, 64, False, True): (2, 2048, 1024, 1024, 64, 2, 2048, 1024, 1024, 256),
+        ('bfloat16', 'float8_e4m3fn', 256, 256, 8, 7168, 2048, 64, False, True): (4, 2048, 1024, 1024, 64, 4, 2048, 1024, 1024, 256),
+        ('bfloat16', 'float8_e4m3fn', 512, 256, 8, 7168, 2048, 64, False, True): (8, 2048, 1024, 1024, 64, 8, 2048, 1024, 1024, 256),
     },
     # Fallback for any device kind.
     "*": {},


### PR DESCRIPTION
## Motivation

After the fused block-scale wiring PR, DeepSeek-V3 fused falls back to `DEFAULT_BLOCK_CONFIG` which sets `bts = bt`. At decode `bt ∈ {2,4,8,16}` → per-expert GEMM M-tile = 2/4/8/16, severely under-utilizing the MXU.

## Changes

`(bf16, fp8_e4m3fn, n_exp=256, topk=8, hidden=7168, moe_inter=2048, use_shared=False)`:

| device | ep | T | entries |
|---|---|---|---|
| TPU v6e | 64 | 128/256/512 | 6 (× grouped∈{F,T}) |
| TPU v7 | 32 | 512 | 2 (× grouped∈{F,T}); T<512 pending verify |

- `bts`: bt → **64** (per-expert GEMM M-tile)
- `bf`: 512 → **2048** (= moe_inter)
- `bd1/bd2`: **1024** (must divide hidden=7168; 7168/7=1024)

EXTEND (T≥1024) intentionally **not** added — large `bts` overflows v6e VMEM (`f32[2, 8192, 1, 2048] = 128 MB > 96 MB`); DEFAULT is fine there since `bt=local_T` is already large.

## Benchmark (`bench_serving 1K/1K --random-range-ratio 1.0`)

| | v6e-64 cc=512 | v7x-16 cc=512 |
|---|---|---|
| fused, DEFAULT config | — ² | 2442 |
| **fused, this PR** | **5315** | **3696** |
| ITL P50 | **57.5 ms** | **79.6 ms** |
| GSM8K 200 | 0.96 ✅ | 0.965 ✅ |

² v6e fused-DEFAULT not separately measured at ratio=1.0; epmoe→fused combined gain (incl. #1321) is +62% (3291→5315). v7x "this PR" includes #1320 MLA/QM entries (measured together).

Part of #1318.

> Entries are inert without #1321 (nothing hits the `hidden=7168` keys until DeepSeek-V3 can run fused), but safe to review/merge independently — pure dict additions.

