### PR TITLE
feat(hicache): implement HostKVPool slot-based host pool (RFC-1.0)

### DIFF
--- a/python/sgl_jax/srt/disaggregation/jax_transfer/conn.py
+++ b/python/sgl_jax/srt/disaggregation/jax_transfer/conn.py
@@ -37,7 +37,7 @@ from sgl_jax.srt.disaggregation.common.metrics import (
 )
 from sgl_jax.srt.disaggregation.common.zmq_notifier import ZmqPullNotifier
 from sgl_jax.srt.disaggregation.jax_transfer.wrapper import JaxTransferWrapper
-from sgl_jax.srt.mem_cache.host_kv_pool import HostKVPool, StagedData
+from sgl_jax.srt.mem_cache.queue_host_kv_pool import HostKVPool, StagedData
 
 __all__ = [
     "JaxTransferKVManager",

--- a/python/sgl_jax/srt/mem_cache/host_kv_pool.py
+++ b/python/sgl_jax/srt/mem_cache/host_kv_pool.py
@@ -1,300 +1,73 @@
-"""Pinned-host KV pool for PD disaggregation.
+"""HiCache L2 pinned-host KV slot pool (RFC-1.0).
 
-The pool predefines ``pool_size`` independent host arrays (``memory_kind=
-"pinned_host"`` on TPU; on CPU the kind falls back to the default since
-``pinned_host`` is TPU-only) and hands them out / takes them back via a
-FIFO queue. There is no LRU, no lock_ref, no retention — every borrow is
-intended to live for one transfer.
-
-The :class:`HostKVPool` ABC is the surface that HiCache's
-``LRUHostKVPool`` will also implement in its own RFC; keeping the ABC
-backend-agnostic now means HiCache can drop in without re-shaping the
-contract.
+Manages slot ID allocation and jax.Array reference storage for the
+HiCache host tier. No pre-allocation — each slot holds a reference
+to a pinned-host jax.Array produced by jax.device_put with
+memory_kind='pinned_host'.
 """
 
 from __future__ import annotations
 
-import abc
 import logging
-import threading
-from dataclasses import dataclass
-from typing import Any
+from typing import Sequence
 
 import jax
-import jax.numpy as jnp
-import numpy as np
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
 logger = logging.getLogger(__name__)
 
 
-def _make_host_sharding(mesh: Mesh, partition_spec: PartitionSpec) -> NamedSharding:
-    """Build a host-side sharding.
+def make_host_sharding(mesh: Mesh, partition_spec: PartitionSpec) -> NamedSharding:
+    """Build a host-side NamedSharding with pinned_host memory kind.
 
-    Tries ``memory_kind="pinned_host"`` first (TPU-only); falls back to
-    the default memory kind so unit tests can construct the pool on
-    CPU. The fallback path is purely a CPU-test affordance — production
-    PD always runs on TPU and uses pinned_host.
+    Falls back to default memory kind on platforms without pinned_host
+    support (e.g. CPU-only JAX) so unit tests can run anywhere.
     """
-
     try:
         return NamedSharding(mesh, partition_spec, memory_kind="pinned_host")
     except (TypeError, ValueError):
         logger.warning(
-            "pinned_host memory_kind unavailable on this platform; "
-            "falling back to default. This is expected on CPU-only "
-            "jaxlib and will hurt H2D throughput on TPU."
+            "pinned_host memory_kind unavailable; falling back to default."
         )
         return NamedSharding(mesh, partition_spec)
 
 
-@dataclass
-class HostBufferHandle:
-    """Handle for an in-use host buffer.
+class HostKVPool:
+    """Pinned-host KV slot pool for HiCache L2.
 
-    ``buffer`` is the current ``jax.Array``; it may be replaced after
-    each :meth:`HostKVPool.copy_from_device` because ``.at[].set()`` is
-    a functional update. **Do not cache** ``handle.buffer`` across
-    multiple ``copy_from_device`` calls on the same handle.
+    Provides slot ID allocation/free and jax.Array reference storage.
+    Eviction is NOT handled here — it's driven by the tree cache layer
+    (RFC-1.1) which atomically calls pool.free() + clears node.host_value.
     """
 
-    buffer_id: int
-    num_tokens: int
-    buffer: jax.Array
+    def __init__(self, capacity: int, host_sharding: NamedSharding):
+        self.capacity = capacity
+        self.host_sharding = host_sharding
+        self.slot_table: dict[int, jax.Array] = {}
+        self.free_list: list[int] = list(range(capacity))
 
-
-@dataclass
-class StagedData:
-    """Result of a successful D2H staging copy.
-
-    ``array`` is the host-side jax.Array ready to hand to
-    ``JaxTransferWrapper.register_pull``. ``buffer_id`` lets the
-    transfer-completion callback return the buffer to the pool via
-    :meth:`HostKVPool.put_buffer`.
-    """
-
-    buffer_id: int
-    array: jax.Array
-
-
-class HostKVPool(abc.ABC):
-    """Backend-agnostic pinned-host KV pool contract.
-
-    All sizing is in tokens. Concrete shapes (per-layer K/V split, head
-    count, head dim) live on the implementing class. The ABC keeps the
-    surface small so HiCache's LRU variant can implement the same
-    contract without inheriting Queue semantics.
-    """
-
-    @abc.abstractmethod
-    def alloc(self, num_tokens: int) -> HostBufferHandle | None:
-        """Reserve a buffer big enough for ``num_tokens`` tokens.
-
-        Returns ``None`` if the pool is empty or if ``num_tokens``
-        exceeds the per-buffer capacity. The returned handle's
-        ``buffer`` field is the un-modified pre-allocated array; use
-        :meth:`copy_from_device` if you want it filled.
-        """
-
-    @abc.abstractmethod
-    def free(self, handle: HostBufferHandle) -> None:
-        """Return ``handle``'s buffer to the pool."""
-
-    @abc.abstractmethod
-    def get_buffer(self) -> tuple[int, HostBufferHandle]:
-        """Low-level: pull one buffer regardless of token count."""
-
-    @abc.abstractmethod
-    def put_buffer(self, buffer_id: int) -> None:
-        """Low-level: return a buffer by id."""
-
-    @abc.abstractmethod
-    def copy_from_device(self, device_kv: jax.Array) -> StagedData:
-        """D2H staging primitive used by PD ``producer_handoff``.
-
-        Allocates one buffer, copies ``device_kv`` (which lives on
-        TPU/device memory) into the host-side buffer, and returns a
-        :class:`StagedData` carrying the staged array + the buffer id
-        for later release. ``device_kv.shape[0]`` is treated as the
-        token count.
-        """
-
-    @abc.abstractmethod
-    def available_size(self) -> int:
-        """Buffers currently free."""
-
-    @abc.abstractmethod
-    def total_size(self) -> int:
-        """Total buffers in the pool (free + in-use)."""
-
-
-class QueueHostKVPool(HostKVPool):
-    """FIFO-queue implementation of :class:`HostKVPool`.
-
-    Short-lived borrows only — no LRU, no eviction, no lock_ref. Borrow
-    via :meth:`alloc` or :meth:`copy_from_device`, return via
-    :meth:`free` or :meth:`put_buffer`. Concurrent access is allowed
-    (the queue is protected by a lock); the typical caller is the PD
-    producer-handoff path which alternates main-thread alloc with
-    background-thread free triggered by the ZMQ ack listener.
-    """
-
-    def __init__(
-        self,
-        pool_size: int,
-        max_tokens_per_buffer: int,
-        layer_num: int,
-        kv_head_per_rank: int,
-        head_dim: int,
-        dtype: Any,
-        mesh: Mesh,
-        partition_spec: PartitionSpec,
-        *,
-        pool_name: str = "default",
-    ) -> None:
-        if pool_size <= 0:
-            raise ValueError(f"pool_size must be positive, got {pool_size}")
-        if max_tokens_per_buffer <= 0:
-            raise ValueError(
-                f"max_tokens_per_buffer must be positive, " f"got {max_tokens_per_buffer}"
-            )
-        self._pool_size = pool_size
-        self._max_tokens_per_buffer = max_tokens_per_buffer
-        self._layer_num = layer_num
-        self._kv_head_per_rank = kv_head_per_rank
-        self._head_dim = head_dim
-        self._dtype = dtype
-        self._mesh = mesh
-        self._partition_spec = partition_spec
-        self._pool_name = pool_name
-        self._host_sharding = _make_host_sharding(mesh, partition_spec)
-
-        self._buffer_shape = (
-            max_tokens_per_buffer,
-            layer_num,
-            kv_head_per_rank,
-            head_dim,
-        )
-
-        self._lock = threading.Lock()
-        self._buffers: list[jax.Array] = self._allocate_buffers()
-        self._free_ids: list[int] = list(range(pool_size))
-
-    def _allocate_buffers(self) -> list[jax.Array]:
-        buffers: list[jax.Array] = []
-        zeros = jnp.zeros(self._buffer_shape, dtype=self._dtype)
-        for _ in range(self._pool_size):
-            buffers.append(jax.device_put(zeros, self._host_sharding))
-        for b in buffers:
-            b.block_until_ready()
-        return buffers
-
-    # ------------------------------------------------------------------
-    # HostKVPool ABC
-    # ------------------------------------------------------------------
-
-    def alloc(self, num_tokens: int) -> HostBufferHandle | None:
-        if num_tokens > self._max_tokens_per_buffer:
+    def alloc(self, n: int = 1) -> list[int] | None:
+        """Allocate n slot IDs. Returns None if insufficient space."""
+        if len(self.free_list) < n:
             return None
-        if num_tokens <= 0:
-            raise ValueError(f"num_tokens must be positive, got {num_tokens}")
-        with self._lock:
-            if not self._free_ids:
-                return None
-            buffer_id = self._free_ids.pop(0)
-        try:
-            from sgl_jax.srt.disaggregation.common.metrics import host_pool_alloc
+        allocated = self.free_list[:n]
+        self.free_list = self.free_list[n:]
+        return allocated
 
-            host_pool_alloc(self._pool_name, 1)
-        except Exception:  # noqa: BLE001
-            pass
-        return HostBufferHandle(
-            buffer_id=buffer_id,
-            num_tokens=num_tokens,
-            buffer=self._buffers[buffer_id],
-        )
+    def free(self, indices: list[int] | Sequence[int]) -> None:
+        """Free slots: delete array references, return IDs to free_list."""
+        for idx in indices:
+            self.slot_table.pop(idx, None)
+            self.free_list.append(idx)
 
-    def free(self, handle: HostBufferHandle) -> None:
-        self._release(handle.buffer_id)
+    def put(self, slot_id: int, data: jax.Array) -> None:
+        """Store a pinned-host jax.Array reference at slot_id."""
+        self.slot_table[slot_id] = data
 
-    def get_buffer(self) -> tuple[int, HostBufferHandle]:
-        with self._lock:
-            if not self._free_ids:
-                raise RuntimeError(
-                    "QueueHostKVPool is empty; caller should have " "checked available_size() first"
-                )
-            buffer_id = self._free_ids.pop(0)
-        try:
-            from sgl_jax.srt.disaggregation.common.metrics import host_pool_alloc
-
-            host_pool_alloc(self._pool_name, 1)
-        except Exception:  # noqa: BLE001
-            pass
-        return buffer_id, HostBufferHandle(
-            buffer_id=buffer_id,
-            num_tokens=self._max_tokens_per_buffer,
-            buffer=self._buffers[buffer_id],
-        )
-
-    def put_buffer(self, buffer_id: int) -> None:
-        self._release(buffer_id)
-
-    def copy_from_device(self, device_kv: jax.Array) -> StagedData:
-        num_tokens = device_kv.shape[0]
-        if num_tokens > self._max_tokens_per_buffer:
-            raise ValueError(
-                f"device_kv has {num_tokens} tokens > pool's "
-                f"max_tokens_per_buffer={self._max_tokens_per_buffer}"
-            )
-        handle = self.alloc(num_tokens)
-        if handle is None:
-            raise RuntimeError("QueueHostKVPool exhausted; alloc returned None")
-        staged_device = jax.device_put(device_kv, self._host_sharding)
-        updated = handle.buffer.at[:num_tokens].set(staged_device)
-        updated.block_until_ready()
-        # Replace the pool's slot so subsequent reads of self._buffers
-        # see the latest content; .at[].set() returns a new array.
-        self._buffers[handle.buffer_id] = updated
-        try:
-            from sgl_jax.srt.disaggregation.common.metrics import (
-                PD_TRANSFER_BYTES_TOTAL,
-            )
-
-            PD_TRANSFER_BYTES_TOTAL.labels(direction="d2h", role="prefill").inc(
-                int(device_kv.nbytes)
-            )
-        except Exception:  # noqa: BLE001
-            pass
-        return StagedData(buffer_id=handle.buffer_id, array=updated)
+    def get(self, slot_id: int) -> jax.Array:
+        """Retrieve the pinned-host jax.Array at slot_id."""
+        return self.slot_table[slot_id]
 
     def available_size(self) -> int:
-        with self._lock:
-            return len(self._free_ids)
-
-    def total_size(self) -> int:
-        return self._pool_size
-
-    # ------------------------------------------------------------------
-
-    def _release(self, buffer_id: int) -> None:
-        with self._lock:
-            if buffer_id in self._free_ids:
-                raise RuntimeError(f"double free of buffer_id={buffer_id}")
-            if not (0 <= buffer_id < self._pool_size):
-                raise ValueError(
-                    f"buffer_id={buffer_id} outside pool range " f"[0, {self._pool_size})"
-                )
-            self._free_ids.append(buffer_id)
-        try:
-            from sgl_jax.srt.disaggregation.common.metrics import host_pool_free
-
-            host_pool_free(self._pool_name, 1)
-        except Exception:  # noqa: BLE001
-            pass
-
-
-def make_unit_mesh() -> Mesh:
-    """Convenience for tests: a single-device mesh with axis ``x``."""
-
-    devices = jax.local_devices()
-    return Mesh(np.asarray(devices[:1]).reshape(1), axis_names=("x",))
+        """Number of free slots."""
+        return len(self.free_list)

--- a/python/sgl_jax/srt/mem_cache/host_kv_pool.py
+++ b/python/sgl_jax/srt/mem_cache/host_kv_pool.py
@@ -9,7 +9,7 @@ memory_kind='pinned_host'.
 from __future__ import annotations
 
 import logging
-from typing import Sequence
+from collections.abc import Sequence
 
 import jax
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
@@ -26,9 +26,7 @@ def make_host_sharding(mesh: Mesh, partition_spec: PartitionSpec) -> NamedShardi
     try:
         return NamedSharding(mesh, partition_spec, memory_kind="pinned_host")
     except (TypeError, ValueError):
-        logger.warning(
-            "pinned_host memory_kind unavailable; falling back to default."
-        )
+        logger.warning("pinned_host memory_kind unavailable; falling back to default.")
         return NamedSharding(mesh, partition_spec)
 
 

--- a/python/sgl_jax/srt/mem_cache/queue_host_kv_pool.py
+++ b/python/sgl_jax/srt/mem_cache/queue_host_kv_pool.py
@@ -1,0 +1,300 @@
+"""Pinned-host KV pool for PD disaggregation.
+
+The pool predefines ``pool_size`` independent host arrays (``memory_kind=
+"pinned_host"`` on TPU; on CPU the kind falls back to the default since
+``pinned_host`` is TPU-only) and hands them out / takes them back via a
+FIFO queue. There is no LRU, no lock_ref, no retention — every borrow is
+intended to live for one transfer.
+
+The :class:`HostKVPool` ABC is the surface that HiCache's
+``LRUHostKVPool`` will also implement in its own RFC; keeping the ABC
+backend-agnostic now means HiCache can drop in without re-shaping the
+contract.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+
+logger = logging.getLogger(__name__)
+
+
+def _make_host_sharding(mesh: Mesh, partition_spec: PartitionSpec) -> NamedSharding:
+    """Build a host-side sharding.
+
+    Tries ``memory_kind="pinned_host"`` first (TPU-only); falls back to
+    the default memory kind so unit tests can construct the pool on
+    CPU. The fallback path is purely a CPU-test affordance — production
+    PD always runs on TPU and uses pinned_host.
+    """
+
+    try:
+        return NamedSharding(mesh, partition_spec, memory_kind="pinned_host")
+    except (TypeError, ValueError):
+        logger.warning(
+            "pinned_host memory_kind unavailable on this platform; "
+            "falling back to default. This is expected on CPU-only "
+            "jaxlib and will hurt H2D throughput on TPU."
+        )
+        return NamedSharding(mesh, partition_spec)
+
+
+@dataclass
+class HostBufferHandle:
+    """Handle for an in-use host buffer.
+
+    ``buffer`` is the current ``jax.Array``; it may be replaced after
+    each :meth:`HostKVPool.copy_from_device` because ``.at[].set()`` is
+    a functional update. **Do not cache** ``handle.buffer`` across
+    multiple ``copy_from_device`` calls on the same handle.
+    """
+
+    buffer_id: int
+    num_tokens: int
+    buffer: jax.Array
+
+
+@dataclass
+class StagedData:
+    """Result of a successful D2H staging copy.
+
+    ``array`` is the host-side jax.Array ready to hand to
+    ``JaxTransferWrapper.register_pull``. ``buffer_id`` lets the
+    transfer-completion callback return the buffer to the pool via
+    :meth:`HostKVPool.put_buffer`.
+    """
+
+    buffer_id: int
+    array: jax.Array
+
+
+class HostKVPool(abc.ABC):
+    """Backend-agnostic pinned-host KV pool contract.
+
+    All sizing is in tokens. Concrete shapes (per-layer K/V split, head
+    count, head dim) live on the implementing class. The ABC keeps the
+    surface small so HiCache's LRU variant can implement the same
+    contract without inheriting Queue semantics.
+    """
+
+    @abc.abstractmethod
+    def alloc(self, num_tokens: int) -> HostBufferHandle | None:
+        """Reserve a buffer big enough for ``num_tokens`` tokens.
+
+        Returns ``None`` if the pool is empty or if ``num_tokens``
+        exceeds the per-buffer capacity. The returned handle's
+        ``buffer`` field is the un-modified pre-allocated array; use
+        :meth:`copy_from_device` if you want it filled.
+        """
+
+    @abc.abstractmethod
+    def free(self, handle: HostBufferHandle) -> None:
+        """Return ``handle``'s buffer to the pool."""
+
+    @abc.abstractmethod
+    def get_buffer(self) -> tuple[int, HostBufferHandle]:
+        """Low-level: pull one buffer regardless of token count."""
+
+    @abc.abstractmethod
+    def put_buffer(self, buffer_id: int) -> None:
+        """Low-level: return a buffer by id."""
+
+    @abc.abstractmethod
+    def copy_from_device(self, device_kv: jax.Array) -> StagedData:
+        """D2H staging primitive used by PD ``producer_handoff``.
+
+        Allocates one buffer, copies ``device_kv`` (which lives on
+        TPU/device memory) into the host-side buffer, and returns a
+        :class:`StagedData` carrying the staged array + the buffer id
+        for later release. ``device_kv.shape[0]`` is treated as the
+        token count.
+        """
+
+    @abc.abstractmethod
+    def available_size(self) -> int:
+        """Buffers currently free."""
+
+    @abc.abstractmethod
+    def total_size(self) -> int:
+        """Total buffers in the pool (free + in-use)."""
+
+
+class QueueHostKVPool(HostKVPool):
+    """FIFO-queue implementation of :class:`HostKVPool`.
+
+    Short-lived borrows only — no LRU, no eviction, no lock_ref. Borrow
+    via :meth:`alloc` or :meth:`copy_from_device`, return via
+    :meth:`free` or :meth:`put_buffer`. Concurrent access is allowed
+    (the queue is protected by a lock); the typical caller is the PD
+    producer-handoff path which alternates main-thread alloc with
+    background-thread free triggered by the ZMQ ack listener.
+    """
+
+    def __init__(
+        self,
+        pool_size: int,
+        max_tokens_per_buffer: int,
+        layer_num: int,
+        kv_head_per_rank: int,
+        head_dim: int,
+        dtype: Any,
+        mesh: Mesh,
+        partition_spec: PartitionSpec,
+        *,
+        pool_name: str = "default",
+    ) -> None:
+        if pool_size <= 0:
+            raise ValueError(f"pool_size must be positive, got {pool_size}")
+        if max_tokens_per_buffer <= 0:
+            raise ValueError(
+                f"max_tokens_per_buffer must be positive, " f"got {max_tokens_per_buffer}"
+            )
+        self._pool_size = pool_size
+        self._max_tokens_per_buffer = max_tokens_per_buffer
+        self._layer_num = layer_num
+        self._kv_head_per_rank = kv_head_per_rank
+        self._head_dim = head_dim
+        self._dtype = dtype
+        self._mesh = mesh
+        self._partition_spec = partition_spec
+        self._pool_name = pool_name
+        self._host_sharding = _make_host_sharding(mesh, partition_spec)
+
+        self._buffer_shape = (
+            max_tokens_per_buffer,
+            layer_num,
+            kv_head_per_rank,
+            head_dim,
+        )
+
+        self._lock = threading.Lock()
+        self._buffers: list[jax.Array] = self._allocate_buffers()
+        self._free_ids: list[int] = list(range(pool_size))
+
+    def _allocate_buffers(self) -> list[jax.Array]:
+        buffers: list[jax.Array] = []
+        zeros = jnp.zeros(self._buffer_shape, dtype=self._dtype)
+        for _ in range(self._pool_size):
+            buffers.append(jax.device_put(zeros, self._host_sharding))
+        for b in buffers:
+            b.block_until_ready()
+        return buffers
+
+    # ------------------------------------------------------------------
+    # HostKVPool ABC
+    # ------------------------------------------------------------------
+
+    def alloc(self, num_tokens: int) -> HostBufferHandle | None:
+        if num_tokens > self._max_tokens_per_buffer:
+            return None
+        if num_tokens <= 0:
+            raise ValueError(f"num_tokens must be positive, got {num_tokens}")
+        with self._lock:
+            if not self._free_ids:
+                return None
+            buffer_id = self._free_ids.pop(0)
+        try:
+            from sgl_jax.srt.disaggregation.common.metrics import host_pool_alloc
+
+            host_pool_alloc(self._pool_name, 1)
+        except Exception:  # noqa: BLE001
+            pass
+        return HostBufferHandle(
+            buffer_id=buffer_id,
+            num_tokens=num_tokens,
+            buffer=self._buffers[buffer_id],
+        )
+
+    def free(self, handle: HostBufferHandle) -> None:
+        self._release(handle.buffer_id)
+
+    def get_buffer(self) -> tuple[int, HostBufferHandle]:
+        with self._lock:
+            if not self._free_ids:
+                raise RuntimeError(
+                    "QueueHostKVPool is empty; caller should have " "checked available_size() first"
+                )
+            buffer_id = self._free_ids.pop(0)
+        try:
+            from sgl_jax.srt.disaggregation.common.metrics import host_pool_alloc
+
+            host_pool_alloc(self._pool_name, 1)
+        except Exception:  # noqa: BLE001
+            pass
+        return buffer_id, HostBufferHandle(
+            buffer_id=buffer_id,
+            num_tokens=self._max_tokens_per_buffer,
+            buffer=self._buffers[buffer_id],
+        )
+
+    def put_buffer(self, buffer_id: int) -> None:
+        self._release(buffer_id)
+
+    def copy_from_device(self, device_kv: jax.Array) -> StagedData:
+        num_tokens = device_kv.shape[0]
+        if num_tokens > self._max_tokens_per_buffer:
+            raise ValueError(
+                f"device_kv has {num_tokens} tokens > pool's "
+                f"max_tokens_per_buffer={self._max_tokens_per_buffer}"
+            )
+        handle = self.alloc(num_tokens)
+        if handle is None:
+            raise RuntimeError("QueueHostKVPool exhausted; alloc returned None")
+        staged_device = jax.device_put(device_kv, self._host_sharding)
+        updated = handle.buffer.at[:num_tokens].set(staged_device)
+        updated.block_until_ready()
+        # Replace the pool's slot so subsequent reads of self._buffers
+        # see the latest content; .at[].set() returns a new array.
+        self._buffers[handle.buffer_id] = updated
+        try:
+            from sgl_jax.srt.disaggregation.common.metrics import (
+                PD_TRANSFER_BYTES_TOTAL,
+            )
+
+            PD_TRANSFER_BYTES_TOTAL.labels(direction="d2h", role="prefill").inc(
+                int(device_kv.nbytes)
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        return StagedData(buffer_id=handle.buffer_id, array=updated)
+
+    def available_size(self) -> int:
+        with self._lock:
+            return len(self._free_ids)
+
+    def total_size(self) -> int:
+        return self._pool_size
+
+    # ------------------------------------------------------------------
+
+    def _release(self, buffer_id: int) -> None:
+        with self._lock:
+            if buffer_id in self._free_ids:
+                raise RuntimeError(f"double free of buffer_id={buffer_id}")
+            if not (0 <= buffer_id < self._pool_size):
+                raise ValueError(
+                    f"buffer_id={buffer_id} outside pool range " f"[0, {self._pool_size})"
+                )
+            self._free_ids.append(buffer_id)
+        try:
+            from sgl_jax.srt.disaggregation.common.metrics import host_pool_free
+
+            host_pool_free(self._pool_name, 1)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def make_unit_mesh() -> Mesh:
+    """Convenience for tests: a single-device mesh with axis ``x``."""
+
+    devices = jax.local_devices()
+    return Mesh(np.asarray(devices[:1]).reshape(1), axis_names=("x",))

--- a/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
@@ -1,0 +1,113 @@
+"""Tests for RFC-1.0 HostKVPool (HiCache L2 pinned-host slot pool)."""
+
+from __future__ import annotations
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
+
+from sgl_jax.srt.mem_cache.host_kv_pool import HostKVPool, make_host_sharding
+
+
+def _make_mesh() -> Mesh:
+    devices = jax.local_devices()
+    return Mesh(np.asarray(devices[:1]).reshape(1), axis_names=("x",))
+
+
+def _make_pool(capacity: int = 8) -> tuple[HostKVPool, NamedSharding]:
+    mesh = _make_mesh()
+    sharding = make_host_sharding(mesh, P("x"))
+    pool = HostKVPool(capacity=capacity, host_sharding=sharding)
+    return pool, sharding
+
+
+class TestAllocFree(unittest.TestCase):
+    def test_alloc_returns_unique_ids(self):
+        pool, _ = _make_pool(capacity=4)
+        ids = pool.alloc(3)
+        self.assertEqual(len(ids), 3)
+        self.assertEqual(len(set(ids)), 3)
+
+    def test_alloc_returns_none_when_full(self):
+        pool, _ = _make_pool(capacity=2)
+        pool.alloc(2)
+        self.assertIsNone(pool.alloc(1))
+
+    def test_free_then_realloc(self):
+        pool, _ = _make_pool(capacity=2)
+        ids = pool.alloc(2)
+        self.assertIsNone(pool.alloc(1))
+        pool.free(ids[:1])
+        new_ids = pool.alloc(1)
+        self.assertIsNotNone(new_ids)
+        self.assertEqual(len(new_ids), 1)
+
+    def test_available_size_tracks_alloc_free(self):
+        pool, _ = _make_pool(capacity=4)
+        self.assertEqual(pool.available_size(), 4)
+        ids = pool.alloc(2)
+        self.assertEqual(pool.available_size(), 2)
+        pool.free(ids)
+        self.assertEqual(pool.available_size(), 4)
+
+
+class TestPutGet(unittest.TestCase):
+    def test_put_then_get_returns_same_reference(self):
+        pool, sharding = _make_pool(capacity=4)
+        ids = pool.alloc(1)
+        data = jax.device_put(jnp.ones((2, 3)), sharding)
+        pool.put(ids[0], data)
+        retrieved = pool.get(ids[0])
+        self.assertIs(retrieved, data)
+
+    def test_free_removes_reference(self):
+        pool, sharding = _make_pool(capacity=4)
+        ids = pool.alloc(1)
+        data = jax.device_put(jnp.ones((2, 3)), sharding)
+        pool.put(ids[0], data)
+        pool.free(ids)
+        self.assertNotIn(ids[0], pool.slot_table)
+
+    def test_get_missing_slot_raises(self):
+        pool, _ = _make_pool(capacity=4)
+        ids = pool.alloc(1)
+        with self.assertRaises(KeyError):
+            pool.get(ids[0])
+
+
+class TestD2HRoundTrip(unittest.TestCase):
+    def test_device_to_host_to_device_roundtrip(self):
+        """D2H -> put -> get -> H2D produces data matching the original."""
+        mesh = _make_mesh()
+        device_sharding = NamedSharding(mesh, P("x"))
+        host_sharding = make_host_sharding(mesh, P("x"))
+        pool = HostKVPool(capacity=4, host_sharding=host_sharding)
+
+        original = jax.device_put(
+            jnp.arange(12, dtype=jnp.float32).reshape(3, 4),
+            device_sharding,
+        )
+
+        ids = pool.alloc(1)
+        host_array = jax.device_put(original, host_sharding)
+        pool.put(ids[0], host_array)
+
+        retrieved = pool.get(ids[0])
+        restored = jax.device_put(retrieved, device_sharding)
+
+        np.testing.assert_allclose(
+            np.asarray(restored), np.asarray(original), rtol=0, atol=0
+        )
+
+
+class TestHostSharding(unittest.TestCase):
+    def test_host_sharding_stored_on_pool(self):
+        pool, sharding = _make_pool()
+        self.assertIs(pool.host_sharding, sharding)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
@@ -7,7 +7,8 @@ import unittest
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.mem_cache.host_kv_pool import HostKVPool, make_host_sharding
 
@@ -98,9 +99,7 @@ class TestD2HRoundTrip(unittest.TestCase):
         retrieved = pool.get(ids[0])
         restored = jax.device_put(retrieved, device_sharding)
 
-        np.testing.assert_allclose(
-            np.asarray(restored), np.asarray(original), rtol=0, atol=0
-        )
+        np.testing.assert_allclose(np.asarray(restored), np.asarray(original), rtol=0, atol=0)
 
 
 class TestHostSharding(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Implement RFC-1.0 `HostKVPool` — pinned-host KV slot pool for HiCache L2 tier
- Move existing PD disaggregation pool (`QueueHostKVPool`) to `queue_host_kv_pool.py` to resolve naming conflict
- Add unit tests covering all 6 RFC acceptance criteria (alloc/free, put/get reference identity, D2H round-trip, available_size tracking)

Closes #1310

## Test plan
- [x] `python -m pytest python/sgl_jax/test/mem_cache/test_host_kv_pool.py -v` — 9 tests pass
- [ ] Verify PD disaggregation import path still works on TPU pod
- [ ] TPU integration: `jax.device_put(data, host_sharding)` with `memory_kind='pinned_host'`