### PR TITLE
fix(schedule): chunked prefill serialized to one DP rank when radix enabled

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -582,7 +582,15 @@ class PrefillAdder:
                 return AddReqResult.NO_TOKEN
 
         total_can_run = sum(len(v) for v in self.can_run_list.values())
-        if real_input_tokens >= self.rem_input_tokens and total_can_run != 0:
+        if (
+            self.rem_chunk_tokens_list is None
+            and real_input_tokens >= self.rem_input_tokens
+            and total_can_run != 0
+        ):
+            # Without chunked prefill, the full extend_input_len is committed this round,
+            # so gate on the global rem_input_tokens. With chunked prefill the per-round
+            # footprint is bounded by rem_chunk_tokens_list[dp_rank]; comparing the
+            # untruncated length here would serialize admission to one DP rank.
             return AddReqResult.OTHER
 
         with self._lock_node(req.last_node):
@@ -598,7 +606,11 @@ class PrefillAdder:
             input_tokens = self.ceil_paged_tokens(req.extend_input_len)
 
             total_can_run = sum(len(v) for v in self.can_run_list.values())
-            if input_tokens >= self.rem_input_tokens and total_can_run != 0:
+            if (
+                self.rem_chunk_tokens_list is None
+                and input_tokens >= self.rem_input_tokens
+                and total_can_run != 0
+            ):
                 return AddReqResult.OTHER
 
             if (

--- a/python/sgl_jax/test/test_mixed_chunk_dp.py
+++ b/python/sgl_jax/test/test_mixed_chunk_dp.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import numpy as np
 
 from sgl_jax.srt.managers.schedule_batch import Req, ScheduleBatch
-from sgl_jax.srt.managers.schedule_policy import PrefillAdder
+from sgl_jax.srt.managers.schedule_policy import AddReqResult, PrefillAdder
 from sgl_jax.srt.sampling.sampling_params import SamplingParams
 
 
@@ -16,6 +16,21 @@ class _DummyAllocator:
 class _DummyTreeCache:
     def evictable_size(self, dp_rank: int = 0):
         return 0
+
+
+class _DummyRadixCache:
+    """Tree cache with disable=False so add_one_req takes the radix path."""
+
+    disable = False
+
+    def evictable_size(self, dp_rank: int = 0):
+        return 0
+
+    def inc_lock_ref(self, node):
+        return None
+
+    def dec_lock_ref(self, node, swa_uuid_for_lock=None):
+        pass
 
 
 def _make_req(rid: str, dp_rank: int, input_len: int = 4, output_len: int = 2) -> Req:
@@ -163,6 +178,41 @@ class TestMixedChunkDP(unittest.TestCase):
         self.assertEqual(adder.cur_rem_token_offset, [3, 1])
         self.assertEqual(adder.rem_input_tokens, 96)
         self.assertEqual(adder.rem_chunk_tokens_list, [17, 19])
+
+    def test_add_one_req_chunked_admits_all_dp_ranks_with_radix(self):
+        # Regression for #1239: with radix enabled (tree_cache.disable=False) +
+        # chunked prefill + dp>1 + extend_input_len >= max_prefill_tokens, the
+        # untruncated rem_input_tokens gate would return OTHER on the second
+        # rank, serializing prefill to one DP rank per round.
+        dp_size = 4
+        adder = PrefillAdder(
+            page_size=256,
+            tree_cache=_DummyRadixCache(),
+            token_to_kv_pool_allocator=_DummyAllocator(),
+            running_batch=None,
+            new_token_ratio=1.0,
+            rem_input_tokens=16384,
+            rem_chunk_tokens=2048,
+            dp_size=dp_size,
+        )
+        for dp in range(dp_size):
+            req = _make_req(f"r{dp}", dp_rank=dp, input_len=16384)
+            req.sampling_params.ignore_eos = True
+            req.fill_ids = req.origin_input_ids
+            req.extend_input_len = len(req.fill_ids)
+            req.prefix_indices = []
+            req.host_hit_length = 0
+            req.last_node = object()
+            res = adder.add_one_req(req)
+            self.assertEqual(
+                res,
+                AddReqResult.CONTINUE,
+                f"dp_rank={dp} got {res}; chunked admission must not serialize across DP ranks",
+            )
+        for dp in range(dp_size):
+            self.assertEqual(len(adder.can_run_list[dp]), 1)
+            self.assertIs(adder.new_chunked_reqs[dp], adder.can_run_list[dp][0])
+            self.assertEqual(adder.can_run_list[dp][0].extend_input_len, 2048)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

Fixes #1239.

## Root cause

Not radix-tree CPU overhead. Instrumented all `SWARadixCache` public methods on the #1239 repro — total wall time across 200 `cache_unfinished_req` calls is **0.09s**, nowhere near the 50s TTFT gap.

The actual cause is `PrefillAdder.add_one_req` returning `OTHER` on the second DP rank:

```python
total_can_run = sum(len(v) for v in self.can_run_list.values())
if real_input_tokens >= self.rem_input_tokens and total_can_run != 0:
    return AddReqResult.OTHER
```

`real_input_tokens` is the **untruncated** extend length (16384), `rem_input_tokens` is the **global** `max_prefill_tokens` budget. After dp_rank=0's 2048-token chunk is admitted, `rem_input_tokens` drops to 14336; dp_rank=1's req sees `16384 >= 14336 and 1 != 0` → `OTHER` → scheduler treats as global stop → break. So **only one DP rank prefills per round**:

| | `#prefill per DP` distribution (n=64) |
|---|---|
| `--disable-radix-cache` | `[1,1,1,1]` ×110, `[1,1,1,0]`-ish ×17, `[1,0,0,0]` ×25 |
| radix enabled (before) | **`[1,0,0,0]`/`[0,1,0,0]`/... ×257** |
| radix enabled (after) | `[1,1,1,1]` ×59, `[0,1,1,1]` ×8, `[1,0,0,0]` ×10 |

The `--disable-radix-cache` path goes through `add_one_req_ignore_eos` instead (because `getattr(ChunkCache, "disable", True)` defaults `True`), which has no such gate — so it looked like radix was 3× slower when it was purely a scheduling difference.

This also affects `ignore_eos=False` traffic with **either** cache impl (both reach `add_one_req`), so production long-context + dp>1 + chunked prefill is serialized regardless of the radix flag — bench_serving's default `ignore_eos=True` just masked that side.

## Fix

Match GPU sglang ([schedule_policy.py:908](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/schedule_policy.py)): only apply this gate when chunked prefill is **disabled** (`rem_chunk_tokens_list is None`). With chunked prefill the per-round footprint is bounded by `rem_chunk_tokens_list[dp_rank]`, so comparing the untruncated length against the global budget is over-rejection.

## Result (v6e-64 dp=4, MiMo-V2-Flash, random 16K/1K n=64 conc=32, main@4d02695f)

| | Output tok/s | Median TTFT | Median TPOT | Median ITL |
|---|---|---|---|---|
| radix off | 534.71 | 15.7 s | 44.54 ms | 21.57 ms |
| radix on (before) | 207.32 | 65.2 s | 90.96 ms | — |
| **radix on (after)** | **545.48** | 20.7 s | **38.17 ms** | **18.31 ms** |

Output/TPOT/ITL now at parity or better. The remaining ~5s TTFT delta is a one-off XLA compile for the cache-hit prefill shape (`#new-token: 256`) under `--disable-precompile`; radix-off never hits cache so never compiles that shape.

## Test

`test_mixed_chunk_dp.py::test_add_one_req_chunked_admits_all_dp_ranks_with_radix` — dp=4, chunked=2048, max_prefill=16384, four 16K reqs on the radix path. RED on main (`dp_rank=1` returns `OTHER`), GREEN with fix.

cc @pengchengneo @cjx0709