### PR TITLE
Optimize scheduler host-side batching overhead

### DIFF
--- a/docs/architecture/03-scheduler.md
+++ b/docs/architecture/03-scheduler.md
@@ -164,7 +164,7 @@ Waiting ──(picked by PrefillAdder)──→ Prefilling ──(prefill done)�
    └─────────────────────────(OOM Retract)────────────────────────────┘
 ```
 
-**Waiting** — The request sits in `waiting_queue` waiting to be scheduled. `init_next_round_input()` computes prefix matching (`tree_cache.match_prefix()`) to determine `prefix_indices` and `extend_input_len`.
+**Waiting** — The request sits in `waiting_queue` waiting to be scheduled. `init_next_round_input()` builds `fill_ids`, then determines `prefix_indices` and `extend_input_len`. When Tree Cache is enabled, it computes prefix matching via `tree_cache.match_prefix()`; when Tree Cache is disabled, it uses an empty prefix and the cache root node.
 
 **Prefilling** — The request is selected into a Prefill batch by `PrefillAdder`. `prepare_for_extend()` allocates KV Cache, and the model forward inference processes the input token sequence.
 
@@ -266,17 +266,24 @@ Data Parallel does not change the number of Scheduler processes. After receiving
 
 **Request admission logic** (`add_one_req()`):
 
-1. Compute `total_tokens = extend_input_len + min(max_new_tokens, 4096)`
-2. Check whether `total_tokens` exceeds `rem_total_tokens` and `rem_input_tokens`
-3. Lock the Radix Tree node to prevent the prefix from being evicted during admission
-4. If Chunked Prefill is needed, truncate `extend_input_len` to `rem_chunk_tokens` (aligned to `page_size`)
-5. Update each budget dimension
+1. Resolve the request's target `dp_rank`
+2. Compute `total_tokens = extend_input_len + min(max_new_tokens, 4096)`
+3. Check whether the request fits within that DP rank's remaining full-KV budget
+4. For hybrid SWA models, check whether the request also fits within that DP rank's SWA budget
+5. Check the global prefill input-token budget, using paged input length and accounting for host prefix hits
+6. Lock the Radix Tree node to prevent the prefix from being evicted during admission
+7. If Chunked Prefill is needed, truncate `extend_input_len` to the target rank's remaining chunk budget, aligned to `page_size`
+8. Update the relevant global and per-rank budget counters
 
-**Budget state** (`budget_state()`):
+**Budget state** (`budget_state()` / `_budget_state_after_add()`):
 
-- `NO_TOKEN` — Total or current tokens exhausted; stop admitting
-- `OTHER` — Input/chunk budget exhausted; stop admitting
-- `CONTINUE` — Continue admitting
+`PrefillAdder` reports whether request admission should continue after each attempted add:
+
+- `NO_TOKEN` — Token capacity is exhausted for the relevant DP rank. The Scheduler marks that rank as full and continues scanning `waiting_queue` for requests assigned to other ranks. For hybrid SWA models, this can happen when the target rank's SWA budget is exhausted.
+- `OTHER` — A global prefill limit is exhausted, such as `rem_input_tokens` or the chunked-prefill token budget. The Scheduler stops building the current Prefill batch.
+- `CONTINUE` — Continue admitting requests.
+
+The general `budget_state()` view uses the minimum remaining full-KV budget across DP ranks for compatibility. After a request is admitted, `add_one_req()` uses a rank-aware post-add check so one exhausted DP rank does not unnecessarily stop admission on other ranks.
 
 ### Prefill Batch Construction Flow (`get_new_batch_prefill()`)
 
@@ -286,8 +293,7 @@ Data Parallel does not change the number of Scheduler processes. After receiving
 4. Create a `PrefillAdder`, set the token budget
 5. Iterate over the sorted `waiting_queue`:
    - `req.init_next_round_input(tree_cache)` — Compute prefix match
-   - `adder.add_one_req(req)` — Try to admit
-   - Stop if budget is exhausted
+   - `adder.add_one_req(req)` — Try to admit; `NO_TOKEN` only marks the request's DP rank full, while `OTHER` stops the Prefill batch construction loop
 6. `ScheduleBatch.init_new()` → `prepare_for_extend()` — Allocate KV Cache per DP rank, build per-DP batch arrays
 
 ### Decode Batch Update (`update_running_batch()`)

--- a/python/sgl_jax/srt/layers/logits_processor.py
+++ b/python/sgl_jax/srt/layers/logits_processor.py
@@ -201,6 +201,20 @@ class LogitsMetadata:
             extend_logprob_pruned_lens_cpu = extend_seq_lens_cpu = None
 
         sharding = NamedSharding(mesh, P("data"))
+        (
+            extend_seq_lens_device,
+            logits_indices_device,
+            extend_input_logprob_token_ids_device,
+            input_logprob_indices_device,
+        ) = device_array(
+            (
+                batch.extend_seq_lens,
+                batch.logits_indices,
+                batch.extend_input_logprob_token_ids,
+                batch.input_logprob_indices,
+            ),
+            sharding=sharding,
+        )
 
         return cls(
             forward_mode=batch.forward_mode,
@@ -208,8 +222,8 @@ class LogitsMetadata:
             extend_return_logprob=extend_return_logprob,
             extend_return_top_logprob=extend_return_top_logprob,
             extend_token_ids_logprob=extend_token_ids_logprob,
-            extend_seq_lens=device_array(batch.extend_seq_lens, sharding=sharding),
-            logits_indices=device_array(batch.logits_indices, sharding=sharding),
+            extend_seq_lens=extend_seq_lens_device,
+            logits_indices=logits_indices_device,
             accept_lens=(
                 device_array(batch.spec_info_padded.accept_length, sharding=sharding)
                 if batch.forward_mode.is_draft_extend()
@@ -227,12 +241,8 @@ class LogitsMetadata:
             extend_logprob_pruned_lens_cpu=extend_logprob_pruned_lens_cpu,
             top_logprobs_nums=batch.top_logprobs_nums,
             token_ids_logprobs=batch.token_ids_logprobs,
-            extend_input_logprob_token_ids_device=device_array(
-                batch.extend_input_logprob_token_ids, sharding=sharding
-            ),
-            input_logprob_indices_device=device_array(
-                batch.input_logprob_indices, sharding=sharding
-            ),
+            extend_input_logprob_token_ids_device=extend_input_logprob_token_ids_device,
+            input_logprob_indices_device=input_logprob_indices_device,
         )
 
 

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -18,6 +18,7 @@ ScheduleBatch -> ModelWorkerBatch -> ForwardBatch
 """
 
 import dataclasses
+import itertools
 import logging
 import os
 import threading
@@ -396,21 +397,31 @@ class Req:
         self,
         tree_cache: BasePrefixCache | None = None,
     ):
-        self.fill_ids = self.origin_input_ids + self.output_ids
+        self.fill_ids = (
+            self.origin_input_ids + self.output_ids if self.output_ids else self.origin_input_ids
+        )
         if tree_cache is not None:
-            (
-                self.prefix_indices,
-                self.last_node,
-                self.last_host_node,
-                self.host_hit_length,
-            ) = tree_cache.match_prefix(
-                key=RadixKey(self.adjust_max_prefix_ids(), self.extra_key, self.dp_rank),
-            )
+            if getattr(tree_cache, "disable", False):
+                self.prefix_indices = np.empty((0,), dtype=np.int32)
+                self.last_node = tree_cache.root_node
+                self.last_host_node = tree_cache.root_node
+                self.host_hit_length = 0
+            else:
+                (
+                    self.prefix_indices,
+                    self.last_node,
+                    self.last_host_node,
+                    self.host_hit_length,
+                ) = tree_cache.match_prefix(
+                    key=RadixKey(self.adjust_max_prefix_ids(), self.extra_key, self.dp_rank),
+                )
             self.last_matched_prefix_len = len(self.prefix_indices)
         self.extend_input_len = len(self.fill_ids) - len(self.prefix_indices)
 
     def adjust_max_prefix_ids(self):
-        self.fill_ids = self.origin_input_ids + self.output_ids
+        self.fill_ids = (
+            self.origin_input_ids + self.output_ids if self.output_ids else self.origin_input_ids
+        )
         input_len = len(self.fill_ids)
 
         # FIXME: To work around some bugs in logprob computation, we need to ensure each
@@ -996,14 +1007,19 @@ class ScheduleBatch:
             req_pool_indices = self.alloc_req_slots(reqs)
 
             # Init arrays
-            input_ids = [r.fill_ids[len(r.prefix_indices) :] for r in reqs]
-            extend_num_tokens = sum(len(ids) for ids in input_ids)
             seq_lens = [len(r.fill_ids) for r in reqs]
             prefix_lens = [len(r.prefix_indices) for r in reqs]
             extend_lens = [r.extend_input_len for r in reqs]
+            extend_num_tokens = sum(extend_lens)
 
             req_pool_indices_cpu = np.array(req_pool_indices, dtype=np.int32)
-            input_ids_cpu = np.array(sum(input_ids, []), dtype=np.int32)
+            input_ids_cpu = np.fromiter(
+                itertools.chain.from_iterable(
+                    r.fill_ids[pre_len:] for r, pre_len in zip(reqs, prefix_lens)
+                ),
+                dtype=np.int32,
+                count=extend_num_tokens,
+            )
             seq_lens_cpu = np.array(seq_lens, dtype=np.int32)
             prefix_lens_cpu = np.array(prefix_lens, dtype=np.int32)
 
@@ -1836,10 +1852,11 @@ class ScheduleBatch:
             # Build positions for this DP rank
             if self.forward_mode.is_extend():
                 # For extend: positions are [prefix_len, prefix_len+1, ..., seq_len-1] for each request
-                dp_positions = []
+                pt = offset
                 for seq_len, prefix_len in zip(info.seq_lens, info.prefix_lens):
-                    dp_positions.extend(range(prefix_len, seq_len))
-                positions_cpu[offset : offset + len(dp_positions)] = dp_positions
+                    next_pt = pt + (seq_len - prefix_len)
+                    positions_cpu[pt:next_pt] = np.arange(prefix_len, seq_len, dtype=np.int32)
+                    pt = next_pt
             else:
                 # For decode: positions are [seq_len-1] for each request
                 dp_positions = info.seq_lens - 1

--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -407,6 +407,17 @@ class PrefillAdder:
 
         return AddReqResult.CONTINUE
 
+    def _budget_state_after_add(self, dp_rank: int):
+        if self.rem_input_tokens <= 0 or (
+            self.rem_chunk_tokens is not None and self.rem_chunk_tokens <= 0
+        ):
+            return AddReqResult.OTHER
+
+        if self.is_hybrid and self.rem_swa_tokens_for_dp(dp_rank) <= 0:
+            return AddReqResult.NO_TOKEN
+
+        return AddReqResult.CONTINUE
+
     def add_chunked_req(self, req: Req):
         dp_rank = req.dp_rank if req.dp_rank is not None else 0
         _rem_tokens = min(
@@ -557,7 +568,7 @@ class PrefillAdder:
             self.new_chunked_reqs[dp_rank] = req
             self._update_prefill_budget(0, trunc_len, 0, dp_rank)
 
-        return self.budget_state()
+        return self._budget_state_after_add(dp_rank)
 
     def add_one_req(self, req: Req):
         if req.sampling_params.ignore_eos and getattr(self.tree_cache, "disable", True):
@@ -640,4 +651,4 @@ class PrefillAdder:
                     self.tree_cache.inc_lock_ref(req.last_node)
                 self._update_prefill_budget(prefix_len, trunc_len, 0, dp_rank)
 
-        return self.budget_state()
+        return self._budget_state_after_add(dp_rank)

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1646,7 +1646,8 @@ class Scheduler(
         if len(all_can_run_reqs) == 0:
             return None
 
-        self.waiting_queue = [x for x in self.waiting_queue if x not in set(all_can_run_reqs)]
+        can_run_set = set(all_can_run_reqs)
+        self.waiting_queue = [x for x in self.waiting_queue if x not in can_run_set]
 
         # Update chunked requests for each DP rank
         for dp_rank in range(self.dp_size):


### PR DESCRIPTION
## Motivation
Reduce host-side scheduler overhead in the prefill path, especially in `Scheduler.get_next_batch_to_run()`.

This addresses the scheduler overhead discussed in https://github.com/sgl-project/sglang-jax/issues/293.

The goal is behavior parity with lower Python/Numpy overhead during request admission and batch preparation.

## Modifications
- Avoid unnecessary `fill_ids` copies when a request has no generated output yet.
- Skip radix-prefix matching work when the prefix cache is disabled.
- Replace Python list flattening via `sum(..., [])` with `np.fromiter`.
- Avoid rebuilding `set(all_can_run_reqs)` for every waiting-queue element.
- Use a narrower post-admission budget check in `PrefillAdder`.
- Batch several logits metadata host-to-device transfers through one `device_array` call.
- Fill extend positions directly into the target numpy array.

## Benchmarking and Profiling
I created a small micro-benchmark for `Scheduler.get_next_batch_to_run()` in isolation. I link the gist: https://gist.github.com/AmedeoBiolatti/a4d04e53b3e0640fb1a98b00ae8056eb

Command used locally:
`python bench_get_next_batch_to_run.py --iterations 300 --warmup 30 --queue-size 512 --dp-size 4 --max-running-requests 512`

Results:
| main | this |
|--|--|
| 1.776 ms | 1.122 ms |

Improvement: ~36.8%.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.