### PR TITLE
test(deepseek): relax gsm8k gate 0.85 -> 0.83 to fix flaky e2e

### DIFF
--- a/test/srt/test_deepseek_v2_lite_models.py
+++ b/test/srt/test_deepseek_v2_lite_models.py
@@ -59,8 +59,8 @@ class TestDeepSeekCoderV2LiteInstruct(CustomTestCase):
         kill_process_tree(cls.process.pid)
 
     def test_gsm8k(self):
-        # Matches sglang nightly threshold (test/manual/nightly/test_text_models_gsm8k_eval.py).
-        # Local 200-example smoke test landed at 0.88, so 0.85 is realistic.
+        # Loosened from 0.85, which flaked ~20% of CI runs; a 61-run sweep put
+        # the min at 0.84. See PR #1333 for the full distribution.
         args = SimpleNamespace(
             base_url=self.base_url,
             model=self.model,
@@ -70,7 +70,7 @@ class TestDeepSeekCoderV2LiteInstruct(CustomTestCase):
         )
 
         metrics = run_eval(args)
-        self.assertGreater(metrics["score"], 0.85)
+        self.assertGreater(metrics["score"], 0.83)
 
         if is_in_ci():
             write_github_step_summary(f"### test_gsm8k\n" f'{metrics["score"]=:.4f}\n')


### PR DESCRIPTION
## Problem

`test/srt/test_deepseek_v2_lite_models.py::test_gsm8k` is flaky. The accuracy gate `assertGreater(score, 0.85)` trips intermittently in CI (most recently PR #1328 post-merge `e2e-test-4-tpu`). The gsm8k score on this DeepSeek-Coder-V2-Lite config naturally straddles 0.85.

## Stress test

61 consecutive runs on **TPU v6e-4**, `main @ 35dc929`, using the **identical** server args from the test (`tp=4`, `page-size=128`, `context-length=8192`, `max-prefill-tokens=8192`, `mem-fraction-static=0.8`, `random-seed=3`) and the identical eval args (`eval_name=gsm8k`, `num_examples=200`, `num_threads=32`, greedy / `temperature=0`):

| metric | value |
|---|---|
| n | 61 |
| min | **0.840** |
| mean | 0.860 |
| max | 0.880 |
| std | 0.009 |

Score distribution (count per bucket):

| score | 0.840 | 0.845 | 0.850 | 0.855 | 0.860 | 0.865 | 0.870 | 0.875 | 0.880 |
|------:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| count | 2 | 3 | 7 | 13 | 12 | 10 | 7 | 5 | 2 |

Failure rate by threshold (`assertGreater` is strict `>`):

| threshold | failures | rate |
|---|---|---|
| `> 0.85` (old) | 12/61 | **~20%** |
| `> 0.84` | 2/61 | 3.3% |
| `> 0.83` (new) | 0/61 | **0%** |
| `> 0.82` | 0/61 | 0% |

## This is test brittleness, not an accuracy regression

DeepSeek-Coder-V2-Lite-Instruct's published **GSM8K score is 86.4%** ([DeepSeek-Coder-V2 repo](https://github.com/deepseek-ai/DeepSeek-Coder-V2) / [paper](https://arxiv.org/html/2406.11931v1)). Our 61-run **mean is 86.0%** — within one question (0.5% at num_examples=200) of the published number, so there is no systematic precision loss in the JAX implementation.

The root cause of the flakiness is that the `0.85` value was borrowed from sglang's nightly `MODEL_SCORE_THRESHOLDS` — but upstream that threshold is a *floor* for **`mgsm_en` on the full set** (`num_examples=None`), where the large sample size keeps variance tiny. Reusing the same `0.85` floor with only **200 questions** (1σ ≈ 0.9%) places it just ~1.5σ below the model's true ~86% ability, which is why ~20% of runs dip under it. The run-to-run spread (84–88% under greedy decoding on the **same** 200 questions) comes from inference numerical non-determinism (batch-composition-dependent reduction order / chunked-prefill chunk boundaries, which #1328 perturbs), not from prompt or sampling randomness.

Caveat: this compares our fixed first-200 GSM8K subset against the published full-set number and does not replicate the exact upstream prompt / few-shot / parsing setup, so it is a strong sanity check rather than an exact reproduction.

## Fix

Lower the gate to `> 0.83`: **0/61** observed failures with ~3σ of headroom above the measured min (0.840), while still flagging a real accuracy regression that drops the score meaningfully below the published ~86%. `num_examples` stays at 200.

The relaxed chunked-prefill admission introduced in #1328 is correct (the throughput win stands) and is **not** reverted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)