### PR TITLE
Kimi K2.5 INT4 support

### DIFF
--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -311,38 +311,118 @@ class EPMoE(nnx.Module):
                 wi_scale_sharding = P("expert", None, None, "tensor")
                 wo_scale_sharding = P("expert", None, None, None)
 
-                if hasattr(self, "wi_0_scale"):
-                    del self.wi_0_scale
-                self.wi_0_scale = nnx.Param(
-                    jnp.zeros(
-                        (num_experts, k_blocks_wi, 1, intermediate_dim),
-                        dtype=jnp.float32,
-                        out_sharding=wi_scale_sharding,
-                    ),
-                    out_sharding=wi_scale_sharding,
-                )
+                wi_sharding = P("expert", None, "tensor")
+                wo_sharding = P("expert", "tensor", None)
 
-                if hasattr(self, "wi_1_scale"):
-                    del self.wi_1_scale
-                self.wi_1_scale = nnx.Param(
-                    jnp.zeros(
-                        (num_experts, k_blocks_wi, 1, intermediate_dim),
-                        dtype=jnp.float32,
-                        out_sharding=wi_scale_sharding,
-                    ),
-                    out_sharding=wi_scale_sharding,
-                )
+                is_abstract = isinstance(self.wi_0.value, jax.ShapeDtypeStruct)
 
-                if hasattr(self, "wo_scale"):
-                    del self.wo_scale
-                self.wo_scale = nnx.Param(
-                    jnp.zeros(
-                        (num_experts, k_blocks_wo, 1, hidden_size),
-                        dtype=jnp.float32,
+                if is_abstract:
+                    if hasattr(self, "wi_0_scale"):
+                        del self.wi_0_scale
+                    self.wi_0_scale = nnx.Param(
+                        jax.ShapeDtypeStruct(
+                            (num_experts, k_blocks_wi, 1, intermediate_dim),
+                            dtype=jnp.float32,
+                            sharding=jax.sharding.NamedSharding(self.moe_mesh, wi_scale_sharding),
+                        )
+                    )
+
+                    if hasattr(self, "wi_1_scale"):
+                        del self.wi_1_scale
+                    self.wi_1_scale = nnx.Param(
+                        jax.ShapeDtypeStruct(
+                            (num_experts, k_blocks_wi, 1, intermediate_dim),
+                            dtype=jnp.float32,
+                            sharding=jax.sharding.NamedSharding(self.moe_mesh, wi_scale_sharding),
+                        )
+                    )
+
+                    if hasattr(self, "wo_scale"):
+                        del self.wo_scale
+                    self.wo_scale = nnx.Param(
+                        jax.ShapeDtypeStruct(
+                            (num_experts, k_blocks_wo, 1, hidden_size),
+                            dtype=jnp.float32,
+                            sharding=jax.sharding.NamedSharding(self.moe_mesh, wo_scale_sharding),
+                        )
+                    )
+
+                    self.wi_0 = nnx.Param(
+                        jax.ShapeDtypeStruct(
+                            (num_experts, hidden_size, intermediate_dim),
+                            dtype=self.quantized_dtype,
+                            sharding=jax.sharding.NamedSharding(self.moe_mesh, wi_sharding),
+                        )
+                    )
+                    self.wi_1 = nnx.Param(
+                        jax.ShapeDtypeStruct(
+                            (num_experts, hidden_size, intermediate_dim),
+                            dtype=self.quantized_dtype,
+                            sharding=jax.sharding.NamedSharding(self.moe_mesh, wi_sharding),
+                        )
+                    )
+                    self.wo = nnx.Param(
+                        jax.ShapeDtypeStruct(
+                            (num_experts, intermediate_dim, hidden_size),
+                            dtype=self.quantized_dtype,
+                            sharding=jax.sharding.NamedSharding(self.moe_mesh, wo_sharding),
+                        )
+                    )
+                else:
+                    if hasattr(self, "wi_0_scale"):
+                        del self.wi_0_scale
+                    self.wi_0_scale = nnx.Param(
+                        jnp.zeros(
+                            (num_experts, k_blocks_wi, 1, intermediate_dim),
+                            dtype=jnp.float32,
+                            out_sharding=wi_scale_sharding,
+                        ),
+                        out_sharding=wi_scale_sharding,
+                    )
+
+                    if hasattr(self, "wi_1_scale"):
+                        del self.wi_1_scale
+                    self.wi_1_scale = nnx.Param(
+                        jnp.zeros(
+                            (num_experts, k_blocks_wi, 1, intermediate_dim),
+                            dtype=jnp.float32,
+                            out_sharding=wi_scale_sharding,
+                        ),
+                        out_sharding=wi_scale_sharding,
+                    )
+
+                    if hasattr(self, "wo_scale"):
+                        del self.wo_scale
+                    self.wo_scale = nnx.Param(
+                        jnp.zeros(
+                            (num_experts, k_blocks_wo, 1, hidden_size),
+                            dtype=jnp.float32,
+                            out_sharding=wo_scale_sharding,
+                        ),
                         out_sharding=wo_scale_sharding,
-                    ),
-                    out_sharding=wo_scale_sharding,
-                )
+                    )
+
+                    self.wi_0 = nnx.Param(
+                        jnp.zeros(
+                            (num_experts, hidden_size, intermediate_dim),
+                            dtype=self.quantized_dtype,
+                        ),
+                        out_sharding=wi_sharding,
+                    )
+                    self.wi_1 = nnx.Param(
+                        jnp.zeros(
+                            (num_experts, hidden_size, intermediate_dim),
+                            dtype=self.quantized_dtype,
+                        ),
+                        out_sharding=wi_sharding,
+                    )
+                    self.wo = nnx.Param(
+                        jnp.zeros(
+                            (num_experts, intermediate_dim, hidden_size),
+                            dtype=self.quantized_dtype,
+                        ),
+                        out_sharding=wo_sharding,
+                    )
                 return
 
             # Quantize weights along k-dim (axis=1 in [g, k, n] layout)
@@ -586,6 +666,13 @@ class EPMoE(nnx.Module):
         if token_indices.shape[0] == 0:
             return jnp.zeros((0, wo_kernel.shape[-1]), dtype=inputs_2d.dtype)
 
+        if w0_kernel.dtype in [jnp.int4, jnp.uint4]:
+            w0_kernel = w0_kernel.astype(jnp.int8)
+        if w1_kernel.dtype in [jnp.int4, jnp.uint4]:
+            w1_kernel = w1_kernel.astype(jnp.int8)
+        if wo_kernel.dtype in [jnp.int4, jnp.uint4]:
+            wo_kernel = wo_kernel.astype(jnp.int8)
+
         # indexed_gmm: gather sorted_inputs here instead of in _permute,
         # so XLA can fuse the gather with the matmul and avoid materializing
         # the full [M*top_k, D] sorted_inputs tensor at peak memory.
@@ -609,6 +696,20 @@ class EPMoE(nnx.Module):
         # (m=64 -> 128) and triggered an on-device SparseCore halt.
         group_sizes = group_sizes.astype(jnp.int32)
         act_q_dtype = self.activation_quantized_dtype
+
+        # 1. JAX Compilation/Tracing Stage Logger (fires during XLA compile)
+        import logging
+        moe_logger = logging.getLogger("sgl_jax.srt.layers.moe")
+        moe_logger.info(
+            "JAX Compile Tracing GMM Stage - "
+            "LHS activation shape: %s, dtype: %s | "
+            "RHS weight shape: %s, dtype: %s | "
+            "RHS scale shape: %s, dtype: %s",
+            x.shape, x.dtype,
+            w0_kernel.shape, w0_kernel.dtype,
+            w0_kernel_scale.shape if w0_kernel_scale is not None else "None",
+            w0_kernel_scale.dtype if w0_kernel_scale is not None else "None"
+        )
 
         gmm_kwargs = dict(
             group_sizes=group_sizes,
@@ -771,6 +872,7 @@ def create_moe_weights_mapping(
     moe_path: str = "mlp",
     source_expert_pattern: str = "experts.{i}",
     physical_to_logical_map=None,  # np.ndarray shape (num_physical,) or None
+    weight_suffix: str = "weight",
 ) -> dict:
     """Generate a unified mapping dictionary for MoE layer expert weights."""
     if moe_backend == "epmoe":
@@ -798,7 +900,7 @@ def create_moe_weights_mapping(
 
         # Source weight paths for logical experts only
         expert_keys = [
-            f"{prefix}.{moe_path}.{source_expert_pattern.format(i=i)}.{source_name}.weight"
+            f"{prefix}.{moe_path}.{source_expert_pattern.format(i=i)}.{source_name}.{weight_suffix}"
             for i in range(num_experts)
         ]
 

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -62,6 +62,8 @@ def _reinterpret_dtype_if_needed(data: np.ndarray, target_dtype: jnp.dtype) -> n
     return data
 
 def unpack_4bit_jax(lazy_weight: jax.Array, target_dtype: jnp.dtype) -> jax.Array:
+    import logging
+    logging.info(f"Trace unpack_4bit_jax (before): JAX TPU array lazy_weight dtype={lazy_weight.dtype}, target={target_dtype}")
     if lazy_weight.dtype in [jnp.int32, jnp.uint32]:
         shifts = jnp.arange(0, 32, 4, dtype=jnp.int32)
         unpacked = (lazy_weight[..., None] >> shifts) & 0x0F
@@ -73,8 +75,12 @@ def unpack_4bit_jax(lazy_weight: jax.Array, target_dtype: jnp.dtype) -> jax.Arra
     if target_dtype == jnp.int4:
         unpacked = unpacked.astype(jnp.int8)
         unpacked = jnp.where(unpacked >= 8, unpacked - 16, unpacked)
-        return unpacked.astype(jnp.int4)
-    return unpacked.astype(target_dtype)
+        final_array = unpacked.astype(jnp.int4)
+        logging.info(f"Trace unpack_4bit_jax (after): JAX TPU array casted to final dtype={final_array.dtype}")
+        return final_array
+    final_array = unpacked.astype(target_dtype)
+    logging.info(f"Trace unpack_4bit_jax (after): JAX TPU array casted to final dtype={final_array.dtype}")
+    return final_array
 
 
 
@@ -1256,7 +1262,6 @@ class WeightLoader:
         do_transpose: bool = False,
         target_sharding: jax.sharding.NamedSharding = None,
         physical_to_logical_map: np.ndarray | None = None,
-        param_dtype: jnp.dtype = None,
     ) -> jax.Array:
         """
         Lazy loader for TP-Split MOE weights (e.g., Grok MOE).
@@ -1383,14 +1388,13 @@ class WeightLoader:
             if remaining_logical:
                 with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
                     list(executor.map(load_and_fill_expert, remaining_logical))
-
+            
+            import logging
+            logging.info(f"Trace CPU Safetensor Read: out_array loaded into CPU RAM with dtype={out_array.dtype}")
             return out_array
 
         result = jax.make_array_from_callback(stacked_shape, sharding, _load_stacked_slice)
-        
-        if param_dtype in [jnp.int4, jnp.uint4, jnp.float4_e2m1fn] and result.dtype in [jnp.int32, jnp.uint32, jnp.int8, jnp.uint8]:
-            result = unpack_4bit_jax(result, param_dtype)
-        elif result.dtype != target_dtype:
+        if result.dtype != target_dtype:
             result = result.astype(target_dtype)
         if do_transpose and result.ndim >= 3:
             result = jnp.transpose(result, (0, 2, 1))
@@ -1404,7 +1408,6 @@ class WeightLoader:
         do_transpose: bool = False,
         target_sharding: jax.sharding.NamedSharding = None,
         physical_to_logical_map: np.ndarray | None = None,
-        param_dtype: jnp.dtype = None,
     ) -> jax.Array:
         first_key = expected_hf_keys[0]
         info = weight_info[first_key][0]
@@ -1972,6 +1975,8 @@ class WeightLoader:
                             )
                             lazy_weight = lazy_arrays[0]
 
+                        target_path = mapping.target_path
+                        model_param = self._get_param(params, target_path)
 
                         if model_param.value.dtype in [jnp.int4, jnp.uint4, jnp.float4_e2m1fn] and lazy_weight.dtype in [jnp.int32, jnp.uint32, jnp.int8, jnp.uint8]:
                             lazy_weight = unpack_4bit_jax(lazy_weight, model_param.value.dtype)
@@ -1989,9 +1994,6 @@ class WeightLoader:
                                 lazy_weight.astype(jnp.float32)
                                 * self.model_config.hf_config.output_multiplier_scale
                             )
-
-                        target_path = mapping.target_path
-                        model_param = self._get_param(params, target_path)
 
                         # Expand 2D block-quant scale to 3D kernel-ready layout.
                         lazy_weight = self._maybe_expand_linear_block_scale(
@@ -2102,13 +2104,20 @@ class WeightLoader:
                         # Standard Sharding
                         final_sharding = jax.sharding.NamedSharding(self.mesh, P(*mapping.sharding))
 
+                    target_path = mapping.target_path[0]
+                    model_param = self._get_param(params, target_path)
+
+                    is_int4_weight = model_param.value.dtype in [
+                        getattr(jnp, t) for t in ["int4", "uint4", "float4_e2m1fn"] if hasattr(jnp, t)
+                    ]
+
                     # 2. Call creator
                     _t_load_start = time.monotonic()
                     stacked_weight = self._create_stacked_moe_lazy_tensor(
                         expected_hf_keys,
                         weight_info,
                         file_manager,
-                        do_transpose=mapping.transpose,  # CPU transpose
+                        do_transpose=mapping.transpose if not is_int4_weight else False,
                         target_sharding=final_sharding,  # Global loading
                         physical_to_logical_map=mapping.physical_to_logical_map,
                     )
@@ -2122,9 +2131,14 @@ class WeightLoader:
                         axis, times = mapping.repeat
                         stacked_weight = jnp.repeat(stacked_weight, times, axis=axis)
 
+                    # Unpack 4-bit weights if needed (e.g. MoE int4)
+                    if is_int4_weight and stacked_weight.dtype in [jnp.int32, jnp.uint32, jnp.int8, jnp.uint8]:
+                        stacked_weight = unpack_4bit_jax(stacked_weight, model_param.value.dtype)
+                        # Perform the deferred transpose on TPU after unpacking
+                        if mapping.transpose:
+                            stacked_weight = jnp.transpose(stacked_weight, (0, 2, 1))
+
                     # 3. Direct assignment
-                    target_path = mapping.target_path[0]
-                    model_param = self._get_param(params, target_path)
                     stacked_weight = self._maybe_convert_epmoe_scale_for_kernel(
                         stacked_weight,
                         model_param,

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -61,6 +61,22 @@ def _reinterpret_dtype_if_needed(data: np.ndarray, target_dtype: jnp.dtype) -> n
         return data.view(ml_dtypes.bfloat16)
     return data
 
+def unpack_4bit_jax(lazy_weight: jax.Array, target_dtype: jnp.dtype) -> jax.Array:
+    if lazy_weight.dtype in [jnp.int32, jnp.uint32]:
+        shifts = jnp.arange(0, 32, 4, dtype=jnp.int32)
+        unpacked = (lazy_weight[..., None] >> shifts) & 0x0F
+        unpacked = jnp.reshape(unpacked, lazy_weight.shape[:-1] + (lazy_weight.shape[-1] * 8,))
+    else:
+        unpacked = jnp.stack([lazy_weight & 0x0F, lazy_weight >> 4], axis=-1)
+        unpacked = jnp.reshape(unpacked, lazy_weight.shape[:-1] + (lazy_weight.shape[-1] * 2,))
+
+    if target_dtype == jnp.int4:
+        unpacked = unpacked.astype(jnp.int8)
+        unpacked = jnp.where(unpacked >= 8, unpacked - 16, unpacked)
+        return unpacked.astype(jnp.int4)
+    return unpacked.astype(target_dtype)
+
+
 
 @dataclass
 class WeightMapping:
@@ -1240,6 +1256,7 @@ class WeightLoader:
         do_transpose: bool = False,
         target_sharding: jax.sharding.NamedSharding = None,
         physical_to_logical_map: np.ndarray | None = None,
+        param_dtype: jnp.dtype = None,
     ) -> jax.Array:
         """
         Lazy loader for TP-Split MOE weights (e.g., Grok MOE).
@@ -1370,7 +1387,10 @@ class WeightLoader:
             return out_array
 
         result = jax.make_array_from_callback(stacked_shape, sharding, _load_stacked_slice)
-        if result.dtype != target_dtype:
+        
+        if param_dtype in [jnp.int4, jnp.uint4, jnp.float4_e2m1fn] and result.dtype in [jnp.int32, jnp.uint32, jnp.int8, jnp.uint8]:
+            result = unpack_4bit_jax(result, param_dtype)
+        elif result.dtype != target_dtype:
             result = result.astype(target_dtype)
         if do_transpose and result.ndim >= 3:
             result = jnp.transpose(result, (0, 2, 1))
@@ -1384,6 +1404,7 @@ class WeightLoader:
         do_transpose: bool = False,
         target_sharding: jax.sharding.NamedSharding = None,
         physical_to_logical_map: np.ndarray | None = None,
+        param_dtype: jnp.dtype = None,
     ) -> jax.Array:
         first_key = expected_hf_keys[0]
         info = weight_info[first_key][0]
@@ -1950,6 +1971,10 @@ class WeightLoader:
                                 target_sharding=final_sharding,
                             )
                             lazy_weight = lazy_arrays[0]
+
+
+                        if model_param.value.dtype in [jnp.int4, jnp.uint4, jnp.float4_e2m1fn] and lazy_weight.dtype in [jnp.int32, jnp.uint32, jnp.int8, jnp.uint8]:
+                            lazy_weight = unpack_4bit_jax(lazy_weight, model_param.value.dtype)
 
                         # Handle multi-dimensional transpose (transpose_axes) or 2D transpose
                         if mapping.transpose_axes is not None:

--- a/python/sgl_jax/test/kernels/run_multihost_test.sh
+++ b/python/sgl_jax/test/kernels/run_multihost_test.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-
-echo "Running multi-host test..."
-python3 python/sgl_jax/test/kernels/test_kimi_int4_loading.py

--- a/python/sgl_jax/test/kernels/run_multihost_test.sh
+++ b/python/sgl_jax/test/kernels/run_multihost_test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+echo "Running multi-host test..."
+export JAX_COORDINATOR_ADDRESS="gke-tpu-4a99f854-2zmz:9915"
+export NUM_LAYERS=2
+python3 python/sgl_jax/test/kernels/test_kimi_int4_loading.py

--- a/python/sgl_jax/test/kernels/run_multihost_test.sh
+++ b/python/sgl_jax/test/kernels/run_multihost_test.sh
@@ -2,6 +2,4 @@
 set -e
 
 echo "Running multi-host test..."
-export JAX_COORDINATOR_ADDRESS="gke-tpu-4a99f854-2zmz:9915"
-export NUM_LAYERS=2
 python3 python/sgl_jax/test/kernels/test_kimi_int4_loading.py

--- a/python/sgl_jax/test/kernels/test_kimi_int4_loading.py
+++ b/python/sgl_jax/test/kernels/test_kimi_int4_loading.py
@@ -1,5 +1,11 @@
 import logging
 import os
+
+host0 = "grok2-multi-grok-worker-0-0-0.grok2-multi"
+host1 = "grok2-multi-grok-worker-1-0-0.grok2-multi"
+os.environ["TPU_WORKER_HOSTNAMES"] = f"{host0},{host1}"
+os.environ["TPU_PROCESS_ADDRESSES"] = f"{host0}:8471,{host1}:8471"
+
 import jax
 
 # Set up logging immediately

--- a/python/sgl_jax/test/kernels/test_kimi_int4_loading.py
+++ b/python/sgl_jax/test/kernels/test_kimi_int4_loading.py
@@ -1,0 +1,145 @@
+import logging
+import os
+import jax
+
+# Set up logging immediately
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("test_kimi_int4_loading")
+
+# Initialize JAX distributed as early as possible to avoid backend init issues
+if "JAX_COORDINATOR_ADDRESS" in os.environ:
+    logger.info("Initializing JAX distributed at startup...")
+    try:
+        jax.distributed.initialize()
+        logger.info("JAX Distributed Initialized successfully at startup.")
+        
+        # Set TPU overrides after JAX init but before backend init
+        process_id = int(os.environ.get("JAX_PROCESS_ID", 0))
+        host0_name = "gke-tpu-4a99f854-2zmz"
+        host1_name = "gke-tpu-4a99f854-ptwl"
+        
+        if process_id == 0:
+            os.environ["TPU_WORKER_HOSTNAMES"] = host0_name
+            os.environ["TPU_PROCESS_ADDRESSES"] = f"{host0_name}:8471"
+            os.environ["TPU_HOSTNAME_OVERRIDE"] = host0_name
+            os.environ["MEGASCALE_SLICE_ID"] = "0"
+        elif process_id == 1:
+            os.environ["TPU_WORKER_HOSTNAMES"] = host1_name
+            os.environ["TPU_PROCESS_ADDRESSES"] = f"{host1_name}:8471"
+            os.environ["TPU_HOSTNAME_OVERRIDE"] = host1_name
+            os.environ["MEGASCALE_SLICE_ID"] = "1"
+            
+        os.environ["TPU_HOST_BOUNDS"] = "1,1,1"
+        os.environ["MEGASCALE_NUM_SLICES"] = "2"
+        os.environ["MEGASCALE_COORDINATOR_ADDRESS"] = f"{host0_name}:9915"
+        
+        logger.info("TPU overrides set in Python: TPU_WORKER_HOSTNAMES=%s, TPU_HOSTNAME_OVERRIDE=%s, MEGASCALE_SLICE_ID=%s, TPU_HOST_BOUNDS=%s", 
+                    os.environ["TPU_WORKER_HOSTNAMES"], os.environ["TPU_HOSTNAME_OVERRIDE"], os.environ["MEGASCALE_SLICE_ID"], os.environ["TPU_HOST_BOUNDS"])
+    except Exception as e:
+        logger.info(f"JAX distributed init failed or already initialized: {e}")
+
+import numpy as np
+import jax.numpy as jnp
+from flax import nnx
+from jax.sharding import Mesh, AxisType
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.multimodal.models.kimi_k25.kimi_k25_vl_generation import KimiK25ForConditionalGeneration
+from sgl_jax.srt.utils.quantization.quantization_utils import apply_linear_quantization, apply_moe_quantization
+
+def main():
+    model_path = "/dsk/models/kimi_original_new"
+    
+    # 1. Build TPU Mesh
+    devices = jax.devices()
+    logger.info("Available JAX devices: %d (%s)", len(devices), [d.platform for d in devices])
+    mesh = Mesh(
+        np.array(devices).reshape(2, 8),
+        axis_names=("data", "tensor"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit),
+    )
+
+    # 2. Create ModelConfig
+    logger.info("Creating ModelConfig for: %s", model_path)
+    model_config = ModelConfig(
+        model_path=model_path,
+        trust_remote_code=True,
+        dtype="bfloat16"
+    )
+    
+    # Configure ideal sharding for 16 devices (EP=2, TP=8)
+    model_config.ep_size = 2
+    if hasattr(model_config, "hf_config"):
+        model_config.hf_config.ep_size = 2
+        if hasattr(model_config.hf_config, "text_config") and model_config.hf_config.text_config is not None:
+            model_config.hf_config.text_config.ep_size = 2
+            model_config.hf_config.text_config.moe_intermediate_size = 2048
+            model_config.hf_config.text_config.n_routed_experts = 16
+    if hasattr(model_config, "hf_text_config") and model_config.hf_text_config is not None:
+        model_config.hf_text_config.ep_size = 2
+        model_config.hf_text_config.moe_intermediate_size = 2048
+        model_config.hf_text_config.n_routed_experts = 16
+    
+    num_layers_env = os.environ.get("NUM_LAYERS")
+    if num_layers_env is not None:
+        num_layers = int(num_layers_env)
+        logger.info("Patching ModelConfig to %d layers for custom verification...", num_layers)
+        model_config.hf_text_config.num_hidden_layers = num_layers
+        model_config.num_hidden_layers = num_layers
+        if hasattr(model_config.hf_config, "text_config") and model_config.hf_config.text_config is not None:
+            model_config.hf_config.text_config.num_hidden_layers = num_layers
+        
+    # 3. Instantiate ABSTRACT model under nnx.eval_shape to avoid HBM out-of-memory
+    logger.info("Instantiating abstract KimiK25ForConditionalGeneration under nnx.eval_shape...")
+    with jax.set_mesh(mesh):
+        model = nnx.eval_shape(
+            lambda: KimiK25ForConditionalGeneration(
+                model_config.hf_config,
+                dtype=model_config.dtype,
+                mesh=mesh
+            )
+        )
+    
+    # 4. Apply Selective Quantization structure modifications on the abstract model
+    logger.info("Applying selective linear quantization (is_static_input=True) on abstract model...")
+    model = apply_linear_quantization(model_config, model, is_static_input=True)
+    
+    logger.info("Applying MoE quantization (is_static_input=True) on abstract model...")
+    model = apply_moe_quantization(model_config, model, is_static_input=True)
+
+    layers = model.model.layers
+    moe_layer = layers[1]
+    
+    # 5. Load weights via WeightLoader
+    logger.info("Loading weights from safetensors onto TPU...")
+    model.load_weights(model_config)
+    
+    # 6. Verify loaded parameters are materialized and in JAX-native int4
+    if hasattr(moe_layer.mlp, "wi_0"):
+        param_after = moe_layer.mlp.wi_0.value
+        logger.info("Parameter type after loading: %s", type(param_after))
+        logger.info("Loaded Parameter shape: %s, dtype: %s", param_after.shape, param_after.dtype)
+        
+        assert not isinstance(param_after, jax.ShapeDtypeStruct), "Weight is still abstract after loading!"
+        assert param_after.dtype == jnp.int4, f"Weight dtype is {param_after.dtype}, expected jnp.int4!"
+        
+    # 7. Run a dummy forward pass on EPMoE to verify dynamic compilation & device execution dtypes
+    logger.info("Constructing dummy inputs to trigger GMM TPU computation kernel...")
+    batch_seq = 16
+    hidden_size = moe_layer.mlp.hidden_size
+    num_experts_per_tok = moe_layer.mlp.num_experts_per_tok
+
+    dummy_hidden_states = jax.random.normal(jax.random.PRNGKey(42), (batch_seq, hidden_size), dtype=jnp.bfloat16)
+    dummy_topk_weights = jax.random.uniform(jax.random.key(43), (batch_seq, num_experts_per_tok), dtype=jnp.bfloat16)
+    dummy_topk_ids = jax.random.randint(jax.random.key(44), (batch_seq, num_experts_per_tok), 0, moe_layer.mlp.num_experts)
+
+    logger.info("Executing EPMoE forward pass (GMM Kernel on TPU)...")
+    with jax.set_mesh(mesh):
+        output = moe_layer.mlp(dummy_hidden_states, dummy_topk_weights, dummy_topk_ids)
+        output.block_until_ready()
+    logger.info("EPMoE Output successfully materialized on TPU - shape: %s, dtype: %s", output.shape, output.dtype)
+        
+    logger.info("SUCCESS: Kimi K2.5 Raw INT4 Weights Successfully Unpacked, Loaded and Verified!")
+
+if __name__ == "__main__":
+    main()

--- a/python/sgl_jax/test/kernels/test_kimi_int4_loading_single.py
+++ b/python/sgl_jax/test/kernels/test_kimi_int4_loading_single.py
@@ -1,52 +1,11 @@
 import logging
 import os
 
-host0 = "10.128.0.2"
-host1 = "10.128.0.4"
-os.environ["TPU_WORKER_HOSTNAMES"] = f"{host0},{host1}"
-os.environ["TPU_PROCESS_ADDRESSES"] = f"{host0}:8471,{host1}:8471"
-
-# Override coordinator port to avoid "newer incarnation" crashes
-if "JAX_COORDINATOR_ADDRESS" in os.environ:
-    os.environ["JAX_COORDINATOR_ADDRESS"] = os.environ["JAX_COORDINATOR_ADDRESS"].rsplit(":", 1)[0] + ":10025"
-if "MEGASCALE_COORDINATOR_ADDRESS" in os.environ:
-    os.environ["MEGASCALE_COORDINATOR_ADDRESS"] = os.environ["MEGASCALE_COORDINATOR_ADDRESS"].rsplit(":", 1)[0] + ":10026"
-
 import jax
 
 # Set up logging immediately
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("test_kimi_int4_loading")
-
-# Set TPU overrides before JAX init and backend init
-process_id = int(os.environ.get("JAX_PROCESS_ID", 0))
-
-if process_id == 0:
-    os.environ["TPU_WORKER_HOSTNAMES"] = host0
-    os.environ["TPU_PROCESS_ADDRESSES"] = f"{host0}:8471"
-    os.environ["TPU_HOSTNAME_OVERRIDE"] = host0
-    os.environ["MEGASCALE_SLICE_ID"] = "0"
-elif process_id == 1:
-    os.environ["TPU_WORKER_HOSTNAMES"] = host1
-    os.environ["TPU_PROCESS_ADDRESSES"] = f"{host1}:8471"
-    os.environ["TPU_HOSTNAME_OVERRIDE"] = host1
-    os.environ["MEGASCALE_SLICE_ID"] = "1"
-    
-os.environ["TPU_HOST_BOUNDS"] = "1,1,1"
-os.environ["MEGASCALE_NUM_SLICES"] = "2"
-os.environ["MEGASCALE_COORDINATOR_ADDRESS"] = f"{host0}:9915"
-
-logger.info("TPU overrides set in Python: TPU_WORKER_HOSTNAMES=%s, TPU_HOSTNAME_OVERRIDE=%s, MEGASCALE_SLICE_ID=%s, TPU_HOST_BOUNDS=%s", 
-            os.environ["TPU_WORKER_HOSTNAMES"], os.environ["TPU_HOSTNAME_OVERRIDE"], os.environ["MEGASCALE_SLICE_ID"], os.environ["TPU_HOST_BOUNDS"])
-
-# Initialize JAX distributed as early as possible to avoid backend init issues
-if "JAX_COORDINATOR_ADDRESS" in os.environ:
-    logger.info("Initializing JAX distributed at startup...")
-    try:
-        jax.distributed.initialize()
-        logger.info("JAX Distributed Initialized successfully at startup.")
-    except Exception as e:
-        logger.info(f"JAX distributed init failed or already initialized: {e}")
 
 import numpy as np
 import jax.numpy as jnp
@@ -64,7 +23,7 @@ def main():
     devices = jax.devices()
     logger.info("Available JAX devices: %d (%s)", len(devices), [d.platform for d in devices])
     mesh = Mesh(
-        np.array(devices).reshape(1, 16),
+        np.array(devices).reshape(1, 8),
         axis_names=("data", "tensor"),
         axis_types=(AxisType.Explicit, AxisType.Explicit),
     )
@@ -77,14 +36,16 @@ def main():
         dtype="bfloat16"
     )
     
-    # Configure ideal sharding for 16 devices (EP=16, TP=16)
-    model_config.ep_size = 16
+    # Configure ideal sharding for 8 devices (EP=1, TP=8)
+    model_config.ep_size = 1
     if hasattr(model_config, "hf_config"):
-        model_config.hf_config.ep_size = 16
+        model_config.hf_config.ep_size = 1
         if hasattr(model_config.hf_config, "text_config") and model_config.hf_config.text_config is not None:
-            model_config.hf_config.text_config.ep_size = 16
+            model_config.hf_config.text_config.ep_size = 1
+            model_config.hf_config.text_config.n_routed_experts = 16
     if hasattr(model_config, "hf_text_config") and model_config.hf_text_config is not None:
-        model_config.hf_text_config.ep_size = 16
+        model_config.hf_text_config.ep_size = 1
+        model_config.hf_text_config.n_routed_experts = 16
     
     num_layers_env = os.environ.get("NUM_LAYERS")
     if num_layers_env is not None:


### PR DESCRIPTION
## Motivation

The goal of this Pull Request is to support loading and running inference on the original **Kimi 2.5 INT4 quantized weights** in both single-host and multi-host TPU environments.

Previously, there was no pipeline to unpack packed 4-bit weights dynamically on TPUs, this PR introduces an optimized loader that performs dynamic bit-unpacking on TPU and defers transpositions to post-unpacking, enabling clean compilation and execution using the Megablox GMM TPU kernels.

---

## Modifications

*   **`python/sgl_jax/srt/utils/weight_utils.py`**:
    *   Added `unpack_4bit_jax` to unpack raw `int32`/`int8` weights to `int4` on TPU.
    *   Deferred transposition of `int4` weights to TPU post-unpacking to avoid bit corruption.
*   **`python/sgl_jax/srt/layers/moe.py`**:
    *   Casts unpacked `int4` weights to `int8` right before Megablox GMM kernel compilation/execution.
    *   Fixed expert-sharded scale placeholders for static model initialization (`is_static=True`).
*   **`python/sgl_jax/test/kernels/`**:
    *   Added `test_kimi_int4_loading.py` (multi-host TP=16/EP=16) and `test_kimi_int4_loading_single.py` (TP=8/EP=1) verification tests.
    *   Added wrapper execution script `run_multihost_test.sh`.

---

## Accuracy Tests

We verified that the JAX/XLA graph compiles and executes successfully on TPU. 

*   **Test Environment**: 16 TPU devices of v7x / Ironwood (2 nodes of 4 chips each, where each chip has 2 devices).
*   **Execution Verification**: Both Dense (Layer 0 MLP) and Sparse MoE (Layer 1 EPMoE) compiled and materialized outputs successfully on TPU:
    *   **Dense FFN output shape**: `(16, 7168)`, dtype: `bfloat16`.
    *   **EPMoE GMM output shape**: `(16, 7168)`, dtype: `bfloat16`.
    *   **GMM Compiled shapes**: LHS `(128, 7168)`, RHS `(24, 7168, 2048)` (EP=16 Expert-sharded layout), scale `(24, 224, 1, 2048)`.

### Weight Loader Datatype Lifecycle Logs

Below are the trace logs verifying the correct datatype transitions from host loading to TPU compilation:

1.  **JAX TPU Bit-Unpacking**: Unpacks raw `int32` elements loaded from safetensors into JAX `int4` weights:
    ```
    INFO:root:Trace unpack_4bit_jax (before): JAX TPU array lazy_weight dtype=int32, target=int4
    INFO:root:Trace unpack_4bit_jax (after): JAX TPU array casted to final dtype=int4
    ```
2.  **Model Parameter Shape & Dtype**: After loading has finished, parameters are correctly stored in HBM with `int4` dtype:
    ```
    INFO:test_kimi_int4_loading:Parameter type after loading: <class 'jaxlib._jax.ArrayImpl'>
    INFO:test_kimi_int4_loading:Loaded Parameter shape: (384, 7168, 2048), dtype: int4
    ```
3.  **Megablox GMM Compilation Casting**: Unpacked `int4` weights are cast to `int8` container variables at compiling stage to run via GMM:
    ```
    INFO:sgl_jax.srt.layers.moe:JAX Compile Tracing GMM Stage - LHS activation shape: (128, 7168), dtype: bfloat16 | RHS weight shape: (24, 7168, 2048), dtype: int8 | RHS scale shape: (24, 224, 1, 2048), dtype: float32
    ```

For the full execution logs of the multi-host validation run, see [this GitHub Gist](https://gist.github.com/chaitanyapk/6d01a829d26e5f1404419e428b8883f6).

---

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.

### Test Plan

#### 1. Single-Node Verification (TP=8, EP=1)
Run the single-host mock test:
```bash
python3 python/sgl_jax/test/kernels/test_kimi_int4_loading_single.py
```

#### 2. Distributed Multi-Host Verification (TP=16, EP=16 on 16 TPUs)
Trigger the following commands in parallel on the coordinator and worker nodes respectively:

*   **Coordinator Node (Host 0)**:
    ```bash
    rm -f /tmp/libtpu_lockfile && PYTHONPATH=python JAX_PROCESS_ID=0 JAX_COORDINATOR_ADDRESS=10.128.0.2:10025 MEGASCALE_COORDINATOR_ADDRESS=10.128.0.2:10026 python3 python/sgl_jax/test/kernels/test_kimi_int4_loading.py
    ```

*   **Worker Node (Host 1)**:
    ```bash
    rm -f /tmp/libtpu_lockfile && PYTHONPATH=python JAX_PROCESS_ID=1 JAX_COORDINATOR_ADDRESS=10.128.0.2:10025 MEGASCALE_COORDINATOR_ADDRESS=10.128.0.2:10026 python3 python/sgl_jax/test/kernels/test_kimi_int4_loading.py
    ```
