### PR TITLE
[SpecDecode] overlap scheduler + device-chain for fused spec decode

### DIFF
--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -150,6 +150,18 @@ class ModelConfig:
             # Each draft runner is a single SWA layer; without this the KV pool
             # sizes for all 70 target layers and OOMs.
             self.hf_config.num_hidden_layers = 1
+            # MTP uses SWA attention; override KV head count and head dims so
+            # the KV cache shape matches the SWA layer output, not the full-
+            # attention target config.
+            self.hf_config.num_key_value_heads = getattr(
+                self.hf_config, "swa_num_key_value_heads", self.hf_config.num_key_value_heads
+            )
+            self.hf_config.num_attention_heads = getattr(
+                self.hf_config, "swa_num_attention_heads", self.hf_config.num_attention_heads
+            )
+            self.hf_config.head_dim = getattr(
+                self.hf_config, "swa_head_dim", self.hf_config.head_dim
+            )
             if self.quantization_config is not None:
                 # eh_proj / o_proj are BF16 in model_mtp.safetensors (no
                 # weight_scale_inv); keep them as plain LinearBase so mappings

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -212,16 +212,7 @@ class FlashAttention(AttentionBackend):
         page_indices = (selected_cache_locs // self.page_size).astype(np.int32)
 
         if batch.forward_mode == ForwardMode.TARGET_VERIFY:
-            # convert custom_mask from bool to int32, because dma not support bool type
-            if batch.spec_info_padded.custom_mask.dtype == jnp.bool:
-                # FIXME(pc) rm this dtype convert
-                logger.warning(
-                    "batch.spec_info_padded.custom_mask type is  %s, it may make performance very low",
-                    batch.spec_info_padded.custom_mask.dtype,
-                )
-                metadata.custom_mask = batch.spec_info_padded.custom_mask.astype(jnp.int32)
-            else:
-                metadata.custom_mask = batch.spec_info_padded.custom_mask
+            metadata.custom_mask = batch.spec_info_padded.custom_mask
         else:
             metadata.custom_mask = None
 

--- a/python/sgl_jax/srt/managers/detokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/detokenizer_manager.py
@@ -299,6 +299,8 @@ class DetokenizerManager:
             output_hidden_states=recv_obj.output_hidden_states,
             cache_miss_count=recv_obj.cache_miss_count,
             output_routed_experts=output_routed_experts,
+            spec_verify_ct=recv_obj.spec_verify_ct,
+            spec_accepted_tokens=recv_obj.spec_accepted_tokens,
         )
 
 

--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -85,6 +85,10 @@ class BatchStrOut:
     # The routed experts for each output token
     output_routed_experts: list[str | None] = None
 
+    # Speculative decoding per-request stats (parity with sglang GPU meta_info)
+    spec_verify_ct: list[int] | None = None
+    spec_accepted_tokens: list[int] | None = None
+
 
 @dataclass
 class BatchTokenIDOut:
@@ -130,6 +134,10 @@ class BatchTokenIDOut:
 
     # The routed experts for each output token
     output_routed_experts: list[np.ndarray] = None
+
+    # Speculative decoding per-request stats (parity with sglang GPU meta_info)
+    spec_verify_ct: list[int] | None = None
+    spec_accepted_tokens: list[int] | None = None
 
 
 @dataclass

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2511,7 +2511,10 @@ class ScheduleBatch:
         for info in self.reqs_info:
             # Create a new ScheduleReqsInfo with shallow copies of necessary fields
             new_info = ScheduleReqsInfo()
-            new_info.reqs = info.reqs  # Shallow copy (list reference)
+            # Snapshot the reqs list: merge_batch does in-place .extend() on
+            # running_batch.reqs_info[r].reqs, which would otherwise mutate this
+            # copy under overlap (process_batch_result(N) runs after prep(N+1)).
+            new_info.reqs = list(info.reqs) if info.reqs else info.reqs
             new_info.out_cache_loc = info.out_cache_loc
             new_info.decoding_reqs = info.decoding_reqs
             copied_reqs_info.append(new_info)

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2526,6 +2526,7 @@ class ScheduleBatch:
             bid=self.bid,
             dp_size=self.dp_size,
             per_dp_bs_size=self.per_dp_bs_size,
+            spec_algorithm=self.spec_algorithm,
         )
 
     def _evict_tree_cache_if_needed(self, num_tokens_per_dp: dict[int, int]) -> None:
@@ -2967,6 +2968,10 @@ class ModelWorkerBatch:
 
     # Whether each request has prior recurrent state (lazy zero-on-read)
     has_initial_state: np.ndarray | None = None
+
+    # When True, fused spec_decode returns a SpecDecodePending (device handles)
+    # instead of blocking on d2h; the scheduler finalizes it next iteration.
+    defer_spec_materialize: bool = False
 
     def get_original_input_len(self):
         """

--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -582,7 +582,15 @@ class PrefillAdder:
                 return AddReqResult.NO_TOKEN
 
         total_can_run = sum(len(v) for v in self.can_run_list.values())
-        if real_input_tokens >= self.rem_input_tokens and total_can_run != 0:
+        if (
+            self.rem_chunk_tokens_list is None
+            and real_input_tokens >= self.rem_input_tokens
+            and total_can_run != 0
+        ):
+            # Without chunked prefill, the full extend_input_len is committed this round,
+            # so gate on the global rem_input_tokens. With chunked prefill the per-round
+            # footprint is bounded by rem_chunk_tokens_list[dp_rank]; comparing the
+            # untruncated length here would serialize admission to one DP rank.
             return AddReqResult.OTHER
 
         with self._lock_node(req.last_node):
@@ -598,7 +606,11 @@ class PrefillAdder:
             input_tokens = self.ceil_paged_tokens(req.extend_input_len)
 
             total_can_run = sum(len(v) for v in self.can_run_list.values())
-            if input_tokens >= self.rem_input_tokens and total_can_run != 0:
+            if (
+                self.rem_chunk_tokens_list is None
+                and input_tokens >= self.rem_input_tokens
+                and total_can_run != 0
+            ):
                 return AddReqResult.OTHER
 
             if (

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1059,7 +1059,8 @@ class Scheduler(
                 )
                 if _chain_relax:
                     _all_full = all(
-                        i.batch_is_full for i in self.running_batch.reqs_info
+                        len(i.reqs or []) >= self.per_dp_max_running_requests
+                        for i in self.running_batch.reqs_info
                     )
                     will_reshape = (
                         _has_chunked

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -122,6 +122,7 @@ class GenerationBatchResult:
     allocate_lens: np.ndarray | None = None
     num_accepted_tokens: int | None = None
     accept_lens: np.ndarray | None = None
+    spec_pending: object | None = None
 
 
 class Scheduler(
@@ -311,7 +312,13 @@ class Scheduler(
                     server_args.tp_size,
                 )
 
-        TpWorkerClass = ModelWorkerClient if self.enable_overlap else ModelWorker
+        # Spec decode handles its own overlap (defer materialize in event_loop_overlap)
+        # without the tp_worker thread; ModelWorkerClient's output_queue would deadlock
+        # since spec extend/decode never enqueue to it.
+        self._overlap_via_tp_thread = self.enable_overlap and (
+            self.spec_algorithm is None or self.spec_algorithm.is_none()
+        )
+        TpWorkerClass = ModelWorkerClient if self._overlap_via_tp_thread else ModelWorker
 
         self.tp_worker = TpWorkerClass(
             server_args=server_args,
@@ -329,7 +336,12 @@ class Scheduler(
             # DeepSeek-style configs expose num_nextn_predict_layers; MiMo-style
             # configs don't, so fall back to --speculative-num-steps under NEXTN
             # (one MTP weight set per step).
-            n_mtp = getattr(self.tp_worker.model_config.hf_config, "num_nextn_predict_layers", None)
+            spec_target_worker = (
+                self.tp_worker.worker if self._overlap_via_tp_thread else self.tp_worker
+            )
+            n_mtp = getattr(
+                spec_target_worker.model_config.hf_config, "num_nextn_predict_layers", None
+            )
             if n_mtp is None and self.spec_algorithm.is_nextn():
                 n_mtp = server_args.speculative_num_steps
             self._spec_multi_layer = n_mtp is not None and n_mtp > 1
@@ -344,7 +356,7 @@ class Scheduler(
 
             self.draft_worker = _SpecWorkerCls(
                 server_args=server_args,
-                target_worker=self.tp_worker,
+                target_worker=spec_target_worker,
             )
 
         # Get token and memory info from the model worker
@@ -856,6 +868,7 @@ class Scheduler(
     def event_loop_overlap(self):
         """A scheduler loop that overlaps the CPU processing and Accelerator computation."""
         self.result_queue = deque()
+        self._spec_pending = None
 
         while True:
             recv_reqs = (
@@ -871,6 +884,7 @@ class Scheduler(
             if self._engine_paused:
                 continue
 
+            self._finalize_pending_spec()
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
 
@@ -878,7 +892,10 @@ class Scheduler(
                 batch.launch_done = threading.Event()
                 with jax.profiler.TraceAnnotation("run_batch"):
                     result = self.run_batch(batch)
-                self.result_queue.append((batch.copy(), result))
+                batch_copy = batch.copy()
+                self.result_queue.append((batch_copy, result))
+                if getattr(result, "spec_pending", None) is not None:
+                    self._spec_pending = (batch, batch_copy, result)
 
                 if self.last_batch is None:
                     # Create a dummy first batch to start the pipeline for overlap schedule.
@@ -895,7 +912,7 @@ class Scheduler(
                         mesh=self.mesh,
                     )
                     tmp_batch.forward_mode = ForwardMode.DUMMY_FIRST
-                    tmp_batch.next_batch_sampling_info = self.tp_worker.cur_sampling_info
+                    tmp_batch.next_batch_sampling_info = getattr(self.tp_worker, "cur_sampling_info", None)
                     with jax.profiler.TraceAnnotation("process_batch_result"):
                         self.process_batch_result(tmp_batch, None, batch.launch_done)
 
@@ -903,7 +920,7 @@ class Scheduler(
                 # Process the results of the last batch
                 tmp_batch, tmp_result = self.result_queue.popleft()
                 tmp_batch.next_batch_sampling_info = (
-                    self.tp_worker.cur_sampling_info if batch else None
+                    getattr(self.tp_worker, "cur_sampling_info", None) if batch else None
                 )
                 # NOTE: we should use current launched batch's launch_done event Instead of the last batch's
                 self.process_batch_result(
@@ -1816,6 +1833,49 @@ class Scheduler(
                     dp_rank * per_dp_bs_size : dp_rank * per_dp_bs_size + num_real_reqs
                 ]
 
+    def _apply_spec_decode_result(self, batch, batch_output, per_dp_bs):
+        per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
+            batch_output.next_draft_input, [len(i.reqs) for i in batch.reqs_info]
+        )
+        for r, s in enumerate(per_rank_spec):
+            batch.reqs_info[r].spec_info = s
+        accept = batch_output.accept_lens
+        if accept is not None:
+            accept = np.asarray(accept)
+        for dp_rank, info in enumerate(batch.reqs_info):
+            if info.seq_lens is None or len(info.seq_lens) == 0:
+                continue
+            if accept is not None:
+                off = dp_rank * per_dp_bs
+                info.seq_lens = info.seq_lens + accept[off : off + len(info.seq_lens)]
+            else:
+                info.seq_lens = info.seq_lens + 1
+
+    def _finalize_pending_spec(self):
+        """Materialize the deferred spec-decode round before next-round prep.
+
+        Called at the top of event_loop_overlap, after process_batch_result(N-1)
+        has run concurrently with device JIT(N). Blocks on JIT(N) d2h, then
+        writes seq_lens/spec_info/output_ids back to batch(N) so
+        get_next_batch_to_run(N+1) sees consistent state.
+        """
+        if self._spec_pending is None:
+            return
+        batch, batch_copy, ret = self._spec_pending
+        self._spec_pending = None
+        pending = ret.spec_pending
+        with jax.profiler.TraceAnnotation("spec_finalize_pending"):
+            batch_output = pending.finalize()
+        self._apply_spec_decode_result(batch, batch_output, pending.per_dp_bs)
+        for r in range(self.dp_size):
+            batch_copy.reqs_info[r].spec_info = batch.reqs_info[r].spec_info
+        ret.next_token_ids = np.asarray(batch_output.next_token_ids).tolist()
+        ret.logits_output = batch_output.logits_output
+        ret.next_draft_input = batch_output.next_draft_input
+        ret.accept_lens = batch_output.accept_lens
+        ret.allocate_lens = batch_output.allocate_lens
+        ret.spec_pending = None
+
     def run_batch(self, batch: ScheduleBatch) -> GenerationBatchResult:
         """Run a batch."""
         self.forward_ct += 1
@@ -1885,26 +1945,33 @@ class Scheduler(
                     self.server_args.enable_static_lora,
                     draft_token_num=self.draft_worker.speculative_num_draft_tokens,
                 )
+            model_worker_batch.defer_spec_materialize = (
+                self.enable_overlap
+                and batch.forward_mode.is_decode()
+                and getattr(self.draft_worker, "_can_use_fused_spec_decode", False)
+                and model_worker_batch.sampling_info.is_all_greedy
+            )
             batch_output = self.draft_worker.forward_batch_speculative_generation(
                 model_worker_batch
             )
-            per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
-                batch_output.next_draft_input, model_worker_batch.real_bs_per_dp
-            )
-            for r, s in enumerate(per_rank_spec):
-                batch.reqs_info[r].spec_info = s
-            accept = batch_output.accept_lens
-            if accept is not None:
-                accept = np.asarray(jax.device_get(accept))
-            per_dp_bs = model_worker_batch.per_dp_bs_size
-            for dp_rank, info in enumerate(batch.reqs_info):
-                if info.seq_lens is None or len(info.seq_lens) == 0:
-                    continue
-                if accept is not None:
-                    off = dp_rank * per_dp_bs
-                    info.seq_lens = info.seq_lens + accept[off : off + len(info.seq_lens)]
-                else:
-                    info.seq_lens = info.seq_lens + 1
+            if model_worker_batch.defer_spec_materialize:
+                # Fused JIT dispatched; d2h + seq_lens/spec_info writeback are
+                # deferred to _finalize_pending_spec at the start of the next
+                # event_loop_overlap iteration so process_batch_result(N-1)
+                # overlaps device compute(N).
+                ret = GenerationBatchResult(
+                    logits_output=None,
+                    next_token_ids=None,
+                    extend_input_len_per_req=None,
+                    extend_logprob_start_len_per_req=None,
+                    bid=model_worker_batch.bid,
+                    cache_miss_count=0,
+                )
+                ret.spec_pending = batch_output
+                if hasattr(batch, "launch_done"):
+                    batch.launch_done.set()
+                return ret
+            self._apply_spec_decode_result(batch, batch_output, model_worker_batch.per_dp_bs_size)
             next_token_ids = np.asarray(jax.device_get(batch_output.next_token_ids))
             self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
             logits_output = batch_output.logits_output
@@ -1959,7 +2026,7 @@ class Scheduler(
         elif batch.forward_mode.is_extend():
             self.process_batch_result_prefill(batch, result, launch_done)
         elif batch.forward_mode.is_idle():
-            if self.enable_overlap:
+            if self._overlap_via_tp_thread:
                 self.tp_worker.resolve_last_batch_result(launch_done)
                 self.set_next_batch_sampling_info_done(batch)
         elif batch.forward_mode.is_dummy_first():

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1059,16 +1059,18 @@ class Scheduler(
                     )
                 )
                 if not will_reshape:
-                    # Optimistic bump for in-flight round k (CPU mock test
-                    # verified ext=accept when bump is BEFORE prepare_for_decode).
+                    # Optimistic bump for in-flight round k. Must stay bumped
+                    # through BOTH prepare_for_decode (allocate_lens) AND
+                    # run_batch (mwb.seq_lens → cu_kv_lens), so cache_loc stride
+                    # (aligned(allocate_lens)) == cu_kv_lens stride
+                    # (aligned(seq_lens+ndt)). Unbumping before run_batch (v2
+                    # bug) desyncs them by ndt → per_dp>1 page-index drift.
                     bumped = []
                     for info in self.running_batch.reqs_info:
                         if info.seq_lens is not None and len(info.seq_lens) > 0:
                             info.seq_lens = info.seq_lens + ndt
                             bumped.append(info)
                     next_batch = self.get_next_batch_to_run()
-                    for info in bumped:
-                        info.seq_lens = info.seq_lens - ndt
                     if (
                         next_batch is not None
                         and next_batch.forward_mode.is_decode()
@@ -1080,6 +1082,8 @@ class Scheduler(
                     elif next_batch is not None:
                         # will_reshape mispredicted (rare): hand to fallback.
                         fallback_batch = next_batch
+                    for info in bumped:
+                        info.seq_lens = info.seq_lens - ndt
 
     def run_publisher(self, recv_reqs):
         retry_count = 0

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1954,6 +1954,21 @@ class Scheduler(
             retracted_reqs, new_token_ratio, reqs_to_abort = batch.retract_decode(self.server_args)
             num_retracted_reqs = len(retracted_reqs)
             self.new_token_ratio = new_token_ratio
+            if (
+                self.enable_overlap
+                and self.spec_algorithm is not None
+                and not self.spec_algorithm.is_none()
+            ):
+                # KNOWN ISSUE: spec+overlap retract can deadlock device
+                # collectives on multi-host (fused spec-decode JIT → next
+                # extend). Not a host-timing bug (barrier+sync doesn't help).
+                # Production should size swa-full-tokens-ratio to avoid
+                # retract. Tracked for root-cause via xprof (follow-up).
+                logger.error(
+                    "retract under spec+overlap may deadlock on multi-host; "
+                    "increase --swa-full-tokens-ratio or --mem-fraction-static "
+                    "to avoid KV retract in production"
+                )
 
             # Send abort responses so clients get an error instead of a hung connection
             for req in reqs_to_abort:

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -959,6 +959,8 @@ class Scheduler(
         ndt = self.draft_worker.speculative_num_draft_tokens
         prepped = None  # (batch, copy, result, real_bs_per_dp)
         fallback_batch = None  # get_next_batch() result carried to next loop's fallback path
+        _chain_stat = {"hit": 0, "miss_reshape": 0, "miss_mismatch": 0, "n": 0}
+        _chain_relax = os.path.exists("/tmp/p2a-chain-relax")
 
         def _real_bs(b):
             return tuple(len(i.reqs) if i.reqs else 0 for i in b.reqs_info)
@@ -1049,15 +1051,36 @@ class Scheduler(
                 and batch.forward_mode.is_decode()
                 and getattr(result, "spec_pending", None) is not None
             ):
-                will_reshape = (
-                    len(self.waiting_queue) > 0
-                    or any(c is not None for c in self.chunked_reqs)
-                    or any(
-                        r.finished()
-                        for info in self.running_batch.reqs_info
-                        for r in (info.reqs or [])
-                    )
+                _has_chunked = any(c is not None for c in self.chunked_reqs)
+                _has_finished = any(
+                    r.finished()
+                    for info in self.running_batch.reqs_info
+                    for r in (info.reqs or [])
                 )
+                if _chain_relax:
+                    _all_full = all(
+                        i.batch_is_full for i in self.running_batch.reqs_info
+                    )
+                    will_reshape = (
+                        _has_chunked
+                        or _has_finished
+                        or (len(self.waiting_queue) > 0 and not _all_full)
+                    )
+                else:
+                    will_reshape = (
+                        len(self.waiting_queue) > 0 or _has_chunked or _has_finished
+                    )
+                _chain_stat["n"] += 1
+                if will_reshape:
+                    _chain_stat["miss_reshape"] += 1
+                if _chain_stat["n"] % 200 == 0:
+                    logger.info(
+                        "chain-stat n=%d hit=%d miss_reshape=%d miss_mismatch=%d",
+                        _chain_stat["n"],
+                        _chain_stat["hit"],
+                        _chain_stat["miss_reshape"],
+                        _chain_stat["miss_mismatch"],
+                    )
                 if not will_reshape:
                     # Optimistic bump for in-flight round k. Must stay bumped
                     # through BOTH prepare_for_decode (allocate_lens) AND
@@ -1079,9 +1102,11 @@ class Scheduler(
                         next_batch.launch_done = threading.Event()
                         next_result = self.run_batch(next_batch)
                         prepped = (next_batch, next_batch.copy(), next_result, bs_k)
+                        _chain_stat["hit"] += 1
                     elif next_batch is not None:
                         # will_reshape mispredicted (rare): hand to fallback.
                         fallback_batch = next_batch
+                        _chain_stat["miss_mismatch"] += 1
                     for info in bumped:
                         info.seq_lens = info.seq_lens - ndt
 

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -919,7 +919,9 @@ class Scheduler(
                         mesh=self.mesh,
                     )
                     tmp_batch.forward_mode = ForwardMode.DUMMY_FIRST
-                    tmp_batch.next_batch_sampling_info = getattr(self.tp_worker, "cur_sampling_info", None)
+                    tmp_batch.next_batch_sampling_info = getattr(
+                        self.tp_worker, "cur_sampling_info", None
+                    )
                     with jax.profiler.TraceAnnotation("process_batch_result"):
                         self.process_batch_result(tmp_batch, None, batch.launch_done)
 
@@ -1052,18 +1054,14 @@ class Scheduler(
             ):
                 _has_chunked = any(c is not None for c in self.chunked_reqs)
                 _has_finished = any(
-                    r.finished()
-                    for info in self.running_batch.reqs_info
-                    for r in (info.reqs or [])
+                    r.finished() for info in self.running_batch.reqs_info for r in (info.reqs or [])
                 )
                 _all_full = all(
                     len(i.reqs or []) >= self.per_dp_max_running_requests
                     for i in self.running_batch.reqs_info
                 )
                 will_reshape = (
-                    _has_chunked
-                    or _has_finished
-                    or (len(self.waiting_queue) > 0 and not _all_full)
+                    _has_chunked or _has_finished or (len(self.waiting_queue) > 0 and not _all_full)
                 )
                 _chain_stat["n"] += 1
                 if will_reshape:
@@ -2078,7 +2076,7 @@ class Scheduler(
         """Release finished spec reqs whose KV release was deferred under overlap.
 
         process_batch_result_decode marks a req finished one round after it was
-        already re-dispatched (or skipped, if a prefill batch pre-empted decode
+        already re-dispatched (or skipped, if a prefill batch preempted decode
         that round). The req is then dropped by filter_batch and never revisited
         by process_batch_result. Sweep running_batch here — before filter_batch —
         and release any finished req still holding req_pool_idx.

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -875,6 +875,17 @@ class Scheduler(
             return self._event_loop_overlap_chain()
         self.result_queue = deque()
         self._spec_pending = None
+        _DBG = os.path.exists("/tmp/p2a-dbg-retract")
+
+        def _D(tag, b=None):
+            if not _DBG:
+                return
+            sh = (
+                f"mode={b.forward_mode.name} bs={[len(i.reqs or []) for i in b.reqs_info]}"
+                if b
+                else ""
+            )
+            logger.info("DBGRT %s %s", tag, sh)
 
         while True:
             recv_reqs = (
@@ -890,15 +901,20 @@ class Scheduler(
             if self._engine_paused:
                 continue
 
+            _D("finalize.pre")
             self._finalize_pending_spec()
+            _D("finalize.post")
             self._drain_deferred_spec_release()
             batch = self.get_next_batch_to_run()
+            _D("get_batch.post", batch)
             self.cur_batch = batch
 
             if batch:
                 batch.launch_done = threading.Event()
                 with jax.profiler.TraceAnnotation("run_batch"):
+                    _D("run_batch.pre", batch)
                     result = self.run_batch(batch)
+                    _D("run_batch.post", batch)
                 batch_copy = batch.copy()
                 self.result_queue.append((batch_copy, result))
                 if getattr(result, "spec_pending", None) is not None:
@@ -930,9 +946,11 @@ class Scheduler(
                     getattr(self.tp_worker, "cur_sampling_info", None) if batch else None
                 )
                 # NOTE: we should use current launched batch's launch_done event Instead of the last batch's
+                _D("proc.pre", tmp_batch)
                 self.process_batch_result(
                     tmp_batch, tmp_result, batch.launch_done if batch else None
                 )
+                _D("proc.post")
             elif batch is None:
                 # When the server is idle, do self-check and re-init some states
                 self.check_memory()

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1834,9 +1834,17 @@ class Scheduler(
                     dp_rank * per_dp_bs_size : dp_rank * per_dp_bs_size + num_real_reqs
                 ]
 
-    def _apply_spec_decode_result(self, batch, batch_output, per_dp_bs):
+    def _apply_spec_decode_result(self, batch, batch_output, per_dp_bs, real_bs_per_dp=None):
+        cur_bs = [len(i.reqs) if i.reqs else 0 for i in batch.reqs_info]
+        if real_bs_per_dp is None:
+            real_bs_per_dp = cur_bs
+        elif os.path.exists("/tmp/p2a-kvdbg"):
+            assert list(real_bs_per_dp) == cur_bs, (
+                f"reqs drift between dispatch and finalize: "
+                f"dispatch={list(real_bs_per_dp)} now={cur_bs}"
+            )
         per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
-            batch_output.next_draft_input, [len(i.reqs) for i in batch.reqs_info]
+            batch_output.next_draft_input, real_bs_per_dp
         )
         for r, s in enumerate(per_rank_spec):
             batch.reqs_info[r].spec_info = s
@@ -1867,7 +1875,9 @@ class Scheduler(
         pending = ret.spec_pending
         with jax.profiler.TraceAnnotation("spec_finalize_pending"):
             batch_output = pending.finalize()
-        self._apply_spec_decode_result(batch, batch_output, pending.per_dp_bs)
+        self._apply_spec_decode_result(
+            batch, batch_output, pending.per_dp_bs, real_bs_per_dp=pending.real_bs_per_dp
+        )
         for r in range(self.dp_size):
             batch_copy.reqs_info[r].spec_info = batch.reqs_info[r].spec_info
         ret.next_token_ids = np.asarray(batch_output.next_token_ids).tolist()

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -868,24 +868,13 @@ class Scheduler(
     def event_loop_overlap(self):
         """A scheduler loop that overlaps the CPU processing and Accelerator computation."""
         if (
-            os.path.exists("/tmp/p2a-chain")
+            self.server_args.enable_spec_device_chain
             and self.spec_algorithm is not None
             and self.spec_algorithm.is_eagle()
         ):
             return self._event_loop_overlap_chain()
         self.result_queue = deque()
         self._spec_pending = None
-        _DBG = os.path.exists("/tmp/p2a-dbg-retract")
-
-        def _D(tag, b=None):
-            if not _DBG:
-                return
-            sh = (
-                f"mode={b.forward_mode.name} bs={[len(i.reqs or []) for i in b.reqs_info]}"
-                if b
-                else ""
-            )
-            logger.info("DBGRT %s %s", tag, sh)
 
         while True:
             recv_reqs = (
@@ -901,21 +890,15 @@ class Scheduler(
             if self._engine_paused:
                 continue
 
-            if self._spec_pending is not None:
-                _D("finalize.pre")
             self._finalize_pending_spec()
             self._drain_deferred_spec_release()
             batch = self.get_next_batch_to_run()
-            if batch is not None:
-                _D("get_batch.post", batch)
             self.cur_batch = batch
 
             if batch:
                 batch.launch_done = threading.Event()
                 with jax.profiler.TraceAnnotation("run_batch"):
-                    _D("run_batch.pre", batch)
                     result = self.run_batch(batch)
-                    _D("run_batch.post", batch)
                 batch_copy = batch.copy()
                 self.result_queue.append((batch_copy, result))
                 if getattr(result, "spec_pending", None) is not None:
@@ -947,11 +930,9 @@ class Scheduler(
                     getattr(self.tp_worker, "cur_sampling_info", None) if batch else None
                 )
                 # NOTE: we should use current launched batch's launch_done event Instead of the last batch's
-                _D("proc.pre", tmp_batch)
                 self.process_batch_result(
                     tmp_batch, tmp_result, batch.launch_done if batch else None
                 )
-                _D("proc.post")
             elif batch is None:
                 # When the server is idle, do self-check and re-init some states
                 self.check_memory()
@@ -979,7 +960,6 @@ class Scheduler(
         prepped = None  # (batch, copy, result, real_bs_per_dp)
         fallback_batch = None  # get_next_batch() result carried to next loop's fallback path
         _chain_stat = {"hit": 0, "miss_reshape": 0, "miss_mismatch": 0, "n": 0}
-        _chain_relax = os.path.exists("/tmp/p2a-chain-relax")
 
         def _real_bs(b):
             return tuple(len(i.reqs) if i.reqs else 0 for i in b.reqs_info)
@@ -1076,20 +1056,15 @@ class Scheduler(
                     for info in self.running_batch.reqs_info
                     for r in (info.reqs or [])
                 )
-                if _chain_relax:
-                    _all_full = all(
-                        len(i.reqs or []) >= self.per_dp_max_running_requests
-                        for i in self.running_batch.reqs_info
-                    )
-                    will_reshape = (
-                        _has_chunked
-                        or _has_finished
-                        or (len(self.waiting_queue) > 0 and not _all_full)
-                    )
-                else:
-                    will_reshape = (
-                        len(self.waiting_queue) > 0 or _has_chunked or _has_finished
-                    )
+                _all_full = all(
+                    len(i.reqs or []) >= self.per_dp_max_running_requests
+                    for i in self.running_batch.reqs_info
+                )
+                will_reshape = (
+                    _has_chunked
+                    or _has_finished
+                    or (len(self.waiting_queue) > 0 and not _all_full)
+                )
                 _chain_stat["n"] += 1
                 if will_reshape:
                     _chain_stat["miss_reshape"] += 1
@@ -2050,11 +2025,6 @@ class Scheduler(
         cur_bs = [len(i.reqs) if i.reqs else 0 for i in batch.reqs_info]
         if real_bs_per_dp is None:
             real_bs_per_dp = cur_bs
-        elif os.path.exists("/tmp/p2a-kvdbg"):
-            assert list(real_bs_per_dp) == cur_bs, (
-                f"reqs drift between dispatch and finalize: "
-                f"dispatch={list(real_bs_per_dp)} now={cur_bs}"
-            )
         if not skip_spec_info:
             per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
                 batch_output.next_draft_input, real_bs_per_dp

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -885,6 +885,7 @@ class Scheduler(
                 continue
 
             self._finalize_pending_spec()
+            self._drain_deferred_spec_release()
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
 
@@ -1875,6 +1876,24 @@ class Scheduler(
         ret.accept_lens = batch_output.accept_lens
         ret.allocate_lens = batch_output.allocate_lens
         ret.spec_pending = None
+
+    def _drain_deferred_spec_release(self):
+        """Release finished spec reqs whose KV release was deferred under overlap.
+
+        process_batch_result_decode marks a req finished one round after it was
+        already re-dispatched (or skipped, if a prefill batch pre-empted decode
+        that round). The req is then dropped by filter_batch and never revisited
+        by process_batch_result. Sweep running_batch here — before filter_batch —
+        and release any finished req still holding req_pool_idx.
+        """
+        if self.spec_algorithm is None or self.spec_algorithm.is_none():
+            return
+        if self.running_batch is None or self.running_batch.is_empty():
+            return
+        for dp_rank, info in enumerate(self.running_batch.reqs_info):
+            for req in info.reqs or ():
+                if req.finished() and req.req_pool_idx is not None:
+                    self._free_spec_overalloc_and_release(req, dp_rank)
 
     def run_batch(self, batch: ScheduleBatch) -> GenerationBatchResult:
         """Run a batch."""

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -901,12 +901,13 @@ class Scheduler(
             if self._engine_paused:
                 continue
 
-            _D("finalize.pre")
+            if self._spec_pending is not None:
+                _D("finalize.pre")
             self._finalize_pending_spec()
-            _D("finalize.post")
             self._drain_deferred_spec_release()
             batch = self.get_next_batch_to_run()
-            _D("get_batch.post", batch)
+            if batch is not None:
+                _D("get_batch.post", batch)
             self.cur_batch = batch
 
             if batch:

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -867,6 +867,12 @@ class Scheduler(
 
     def event_loop_overlap(self):
         """A scheduler loop that overlaps the CPU processing and Accelerator computation."""
+        if (
+            os.path.exists("/tmp/p2a-chain")
+            and self.spec_algorithm is not None
+            and self.spec_algorithm.is_eagle()
+        ):
+            return self._event_loop_overlap_chain()
         self.result_queue = deque()
         self._spec_pending = None
 
@@ -934,6 +940,146 @@ class Scheduler(
                 self.new_token_ratio = self.init_new_token_ratio
 
             self.last_batch = batch
+
+    def _event_loop_overlap_chain(self):
+        """Spec-decode chain variant: prep_{k+1}+dispatch_{k+1} runs ∥ jit_k.
+
+        Two paths per iteration:
+        - chain: prepped_k was dispatched at loop k-1 end. finalize_{k-1}
+          (skip_spec_info=True so prep_k's allocate_lens isn't overwritten),
+          then prep_{k+1} with optimistic seq_lens (+ndt) ∥ jit_k.
+        - fallback (first round / batch reshape): standard finalize → get_batch
+          → run_batch → proc_res. Host spec_info written normally so
+          use_chain=False has real hidden/topk.
+        Batch reshape detection: per-rank reqs count changed OR last_batch was
+        extend (merge) → fallback next round (one ~7ms idle, amortized).
+        """
+        self.result_queue = deque()
+        self._spec_pending = None
+        ndt = self.draft_worker.speculative_num_draft_tokens
+        prepped = None  # (batch, copy, result, real_bs_per_dp)
+        fallback_batch = None  # get_next_batch() result carried to next loop's fallback path
+
+        def _real_bs(b):
+            return tuple(len(i.reqs) if i.reqs else 0 for i in b.reqs_info)
+
+        while True:
+            recv_reqs = (
+                self._comm_backend.recv_requests()
+                if self._comm_backend is not None
+                else self.recv_requests()
+            )
+            recv_reqs = self.select_dp_for_request(recv_reqs)
+            self.process_input_requests(recv_reqs)
+            if self._engine_paused:
+                continue
+
+            on_chain = prepped is not None
+            if on_chain:
+                batch, batch_copy, result, bs_k = prepped
+                self.result_queue.append((batch_copy, result))
+                self.cur_batch = batch
+                # finalize_{k-1}: skip_spec_info so prep_k's allocate_lens
+                # (written at loop k-1 end) survives for prep_{k+1}'s old_r.
+                self._finalize_pending_spec(skip_spec_info=True)
+                self._drain_deferred_spec_release()
+                if getattr(result, "spec_pending", None) is not None:
+                    self._spec_pending = (batch, batch_copy, result)
+            else:
+                # Fallback / first round: standard order.
+                self._finalize_pending_spec(skip_spec_info=False)
+                self._drain_deferred_spec_release()
+                if fallback_batch is not None:
+                    batch = fallback_batch
+                    fallback_batch = None
+                else:
+                    batch = self.get_next_batch_to_run()
+                self.cur_batch = batch
+                if batch:
+                    batch.launch_done = threading.Event()
+                    result = self.run_batch(batch)
+                    batch_copy = batch.copy()
+                    self.result_queue.append((batch_copy, result))
+                    if getattr(result, "spec_pending", None) is not None:
+                        self._spec_pending = (batch, batch_copy, result)
+                    bs_k = _real_bs(batch)
+                else:
+                    result = batch_copy = bs_k = None
+                if self.last_batch is None and batch:
+                    tmp = ScheduleBatch.init_new(
+                        reqs=[[] for _ in range(self.dp_size)],
+                        req_to_token_pool=self.req_to_token_pool,
+                        token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                        tree_cache=self.tree_cache,
+                        model_config=self.model_config,
+                        enable_overlap=self.enable_overlap,
+                        dp_size=self.dp_size,
+                        spec_algorithm=self.spec_algorithm,
+                        mesh=self.mesh,
+                    )
+                    tmp.forward_mode = ForwardMode.DUMMY_FIRST
+                    tmp.next_batch_sampling_info = getattr(
+                        self.tp_worker, "cur_sampling_info", None
+                    )
+                    self.process_batch_result(tmp, None, batch.launch_done)
+
+            if self.last_batch:
+                tmp_batch, tmp_result = self.result_queue.popleft()
+                tmp_batch.next_batch_sampling_info = (
+                    getattr(self.tp_worker, "cur_sampling_info", None) if batch else None
+                )
+                self.process_batch_result(
+                    tmp_batch, tmp_result, batch.launch_done if batch else None
+                )
+            elif batch is None:
+                self.check_memory()
+                self.check_tree_cache()
+                self.new_token_ratio = self.init_new_token_ratio
+
+            self.last_batch = batch
+            prepped = None
+
+            # prep_{k+1} (∥ jit_k) — only if batch_k is spec decode AND next
+            # round won't reshape. Reshape prediction (BEFORE get_next_batch,
+            # so no alloc to roll back): any finished req still in running
+            # (proc_res_{k-1} just marked) OR pending prefill in waiting_queue
+            # OR chunked req. If reshape → fallback next loop (one ~7ms idle).
+            if (
+                batch is not None
+                and batch.forward_mode.is_decode()
+                and getattr(result, "spec_pending", None) is not None
+            ):
+                will_reshape = (
+                    len(self.waiting_queue) > 0
+                    or any(c is not None for c in self.chunked_reqs)
+                    or any(
+                        r.finished()
+                        for info in self.running_batch.reqs_info
+                        for r in (info.reqs or [])
+                    )
+                )
+                if not will_reshape:
+                    # Optimistic bump for in-flight round k (CPU mock test
+                    # verified ext=accept when bump is BEFORE prepare_for_decode).
+                    bumped = []
+                    for info in self.running_batch.reqs_info:
+                        if info.seq_lens is not None and len(info.seq_lens) > 0:
+                            info.seq_lens = info.seq_lens + ndt
+                            bumped.append(info)
+                    next_batch = self.get_next_batch_to_run()
+                    for info in bumped:
+                        info.seq_lens = info.seq_lens - ndt
+                    if (
+                        next_batch is not None
+                        and next_batch.forward_mode.is_decode()
+                        and _real_bs(next_batch) == bs_k
+                    ):
+                        next_batch.launch_done = threading.Event()
+                        next_result = self.run_batch(next_batch)
+                        prepped = (next_batch, next_batch.copy(), next_result, bs_k)
+                    elif next_batch is not None:
+                        # will_reshape mispredicted (rare): hand to fallback.
+                        fallback_batch = next_batch
 
     def run_publisher(self, recv_reqs):
         retry_count = 0
@@ -1834,7 +1980,9 @@ class Scheduler(
                     dp_rank * per_dp_bs_size : dp_rank * per_dp_bs_size + num_real_reqs
                 ]
 
-    def _apply_spec_decode_result(self, batch, batch_output, per_dp_bs, real_bs_per_dp=None):
+    def _apply_spec_decode_result(
+        self, batch, batch_output, per_dp_bs, real_bs_per_dp=None, skip_spec_info=False
+    ):
         cur_bs = [len(i.reqs) if i.reqs else 0 for i in batch.reqs_info]
         if real_bs_per_dp is None:
             real_bs_per_dp = cur_bs
@@ -1843,11 +1991,12 @@ class Scheduler(
                 f"reqs drift between dispatch and finalize: "
                 f"dispatch={list(real_bs_per_dp)} now={cur_bs}"
             )
-        per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
-            batch_output.next_draft_input, real_bs_per_dp
-        )
-        for r, s in enumerate(per_rank_spec):
-            batch.reqs_info[r].spec_info = s
+        if not skip_spec_info:
+            per_rank_spec = ScheduleBatch._split_spec_info_per_rank(
+                batch_output.next_draft_input, real_bs_per_dp
+            )
+            for r, s in enumerate(per_rank_spec):
+                batch.reqs_info[r].spec_info = s
         accept = batch_output.accept_lens
         if accept is not None:
             accept = np.asarray(accept)
@@ -1860,7 +2009,7 @@ class Scheduler(
             else:
                 info.seq_lens = info.seq_lens + 1
 
-    def _finalize_pending_spec(self):
+    def _finalize_pending_spec(self, skip_spec_info=False):
         """Materialize the deferred spec-decode round before next-round prep.
 
         Called at the top of event_loop_overlap, after process_batch_result(N-1)
@@ -1876,7 +2025,11 @@ class Scheduler(
         with jax.profiler.TraceAnnotation("spec_finalize_pending"):
             batch_output = pending.finalize()
         self._apply_spec_decode_result(
-            batch, batch_output, pending.per_dp_bs, real_bs_per_dp=pending.real_bs_per_dp
+            batch,
+            batch_output,
+            pending.per_dp_bs,
+            real_bs_per_dp=pending.real_bs_per_dp,
+            skip_spec_info=skip_spec_info,
         )
         for r in range(self.dp_size):
             batch_copy.reqs_info[r].spec_info = batch.reqs_info[r].spec_info

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -260,8 +260,12 @@ class SchedulerOutputProcessorMixin:
         with ``[]`` at padding slots, so the per-rank slice in
         ``process_batch_result_decode`` works for any ``dp_size``.
         """
-        next_token_ids = np.asarray(jax.device_get(result.next_token_ids))
-        accept_lens = np.asarray(jax.device_get(result.accept_lens)).tolist()
+        if hasattr(result.next_token_ids, "copy_to_host_async"):
+            result.next_token_ids.copy_to_host_async()
+        if hasattr(result.accept_lens, "copy_to_host_async"):
+            result.accept_lens.copy_to_host_async()
+        next_token_ids = np.asarray(result.next_token_ids)
+        accept_lens = np.asarray(result.accept_lens).tolist()
         stride = self.draft_worker.speculative_num_draft_tokens
         per_dp_bs = batch.per_dp_bs_size
         total_bs = per_dp_bs * batch.dp_size

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import threading
 from typing import TYPE_CHECKING
 
@@ -321,11 +320,6 @@ class SchedulerOutputProcessorMixin:
         ]
         kv_indices = kv_indices[kv_indices != 0]
         self.token_to_kv_pool_allocator.free(kv_indices, dp_rank)
-        if os.path.exists("/tmp/p2a-kvdbg"):
-            logger.info(
-                "[kvdbg] release rid=%s dp=%d committed=%d alloc=%d freed=%d",
-                req.rid[:8], dp_rank, req.kv_committed_len, req.kv_allocated_len, len(kv_indices),
-            )
         req.kv_allocated_len = req.kv_committed_len
         release_kv_cache(req, self.tree_cache)
 

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from typing import TYPE_CHECKING
 
@@ -114,7 +115,16 @@ class SchedulerOutputProcessorMixin:
             # Check finish conditions for each request in this DP rank
             for i, (req, next_token_id) in enumerate(zip(reqs, dp_output_ids)):
                 if req.finished() or req.is_retracted:
-                    # release_kv_cache owns over-allocated KV; freeing here would double-free.
+                    if (
+                        self.enable_overlap
+                        and batch.spec_algorithm is not None
+                        and batch.spec_algorithm.is_eagle()
+                        and req.finished()
+                        and req.req_pool_idx is not None
+                    ):
+                        # Deferred from process_batch_result_decode under overlap;
+                        # this round was mixed (decode+prefill) so we land here.
+                        self._free_spec_overalloc_and_release(req, dp_rank)
                     req_idx += 1
                     continue
 
@@ -285,16 +295,27 @@ class SchedulerOutputProcessorMixin:
         result.num_accepted_tokens = total_accepted - n_real
         return predict_tokens
 
-    def _free_spec_overalloc_and_release(self, req, cur_allocate_len: int, dp_rank: int):
-        """Free spec-decode over-allocated KV slots beyond committed length, then release."""
+    def _free_spec_overalloc_and_release(self, req, dp_rank: int):
+        """Free spec-decode over-allocated KV slots beyond committed length, then release.
+
+        Uses req.kv_allocated_len (bumped per-round in EagleDraftInput.prepare_for_decode)
+        as the upper bound, so this works regardless of which process_batch_result path
+        (decode/prefill/mixed) the deferred release lands in under overlap.
+        """
         all_token_len = req.kv_committed_len
         if self.page_size > 1:
             all_token_len = cdiv(all_token_len, self.page_size) * self.page_size
         kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, all_token_len:cur_allocate_len
+            req.req_pool_idx, all_token_len : req.kv_allocated_len
         ]
         kv_indices = kv_indices[kv_indices != 0]
         self.token_to_kv_pool_allocator.free(kv_indices, dp_rank)
+        if os.path.exists("/tmp/p2a-kvdbg"):
+            logger.info(
+                "[kvdbg] release rid=%s dp=%d committed=%d alloc=%d freed=%d",
+                req.rid[:8], dp_rank, req.kv_committed_len, req.kv_allocated_len, len(kv_indices),
+            )
+        req.kv_allocated_len = req.kv_committed_len
         release_kv_cache(req, self.tree_cache)
 
     def process_batch_result_decode(
@@ -372,11 +393,9 @@ class SchedulerOutputProcessorMixin:
                         # Under overlap, this req was marked finished in
                         # process_result(k) but already dispatched in round k+1
                         # before that. Its over-alloc free + req_pool release
-                        # were deferred there; do them now using round k+1's
-                        # allocate_lens (covers both round k and k+1 over-alloc).
-                        self._free_spec_overalloc_and_release(
-                            req, int(result.allocate_lens[req_idx]), dp_rank
-                        )
+                        # were deferred there; do them now (kv_allocated_len was
+                        # bumped to round k+1's alloc by prepare_for_decode).
+                        self._free_spec_overalloc_and_release(req, dp_rank)
                     req_idx += 1
                     continue
 
@@ -400,14 +419,13 @@ class SchedulerOutputProcessorMixin:
                     is_spec = batch.spec_algorithm is not None and batch.spec_algorithm.is_eagle()
                     if is_spec:
                         # Spec decode allocates via EagleDraftInput.prepare_for_decode
-                        # so kv_committed_len was never bumped past prefill; align to
-                        # the *unaligned* actual token count so cache_finished_req
-                        # frees decode pages without touching the page-0 sentinel.
-                        actual_token_len = len(req.origin_input_ids) + max(
+                        # (which bumps req.kv_allocated_len) but kv_committed_len was
+                        # never bumped past prefill; align to the *unaligned* actual
+                        # token count so cache_finished_req frees decode pages without
+                        # touching the page-0 sentinel.
+                        req.kv_committed_len = len(req.origin_input_ids) + max(
                             len(req.output_ids) - 1, 0
                         )
-                        req.kv_committed_len = actual_token_len
-                        req.kv_allocated_len = actual_token_len
                     # End trace for finished request
                     if precision_tracer.get_trace_active():
                         precision_tracer.set_request_status_to_completed(req.rid)
@@ -426,16 +444,14 @@ class SchedulerOutputProcessorMixin:
                             precision_tracer.stop_trace()
                     if is_spec and self.enable_overlap:
                         # Req is already in-flight on device for round k+1
-                        # (dispatched before this process_result(k) ran). Defer
-                        # over-alloc free + req_pool release to the finished
-                        # branch above on the next round, using round k+1's
-                        # allocate_lens, so req_pool_idx isn't recycled
-                        # mid-flight and both rounds' over-alloc are freed.
+                        # (dispatched before this process_result(k) ran).
+                        # prepare_for_decode(k+1) already bumped kv_allocated_len
+                        # to round k+1's alloc; defer free+release to next round's
+                        # already-finished branch (decode L353 or prefill L116) so
+                        # req_pool_idx isn't recycled mid-flight.
                         pass
                     elif is_spec:
-                        self._free_spec_overalloc_and_release(
-                            req, int(result.allocate_lens[req_idx]), dp_rank
-                        )
+                        self._free_spec_overalloc_and_release(req, dp_rank)
                     else:
                         release_kv_cache(req, self.tree_cache)
 

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -285,6 +285,18 @@ class SchedulerOutputProcessorMixin:
         result.num_accepted_tokens = total_accepted - n_real
         return predict_tokens
 
+    def _free_spec_overalloc_and_release(self, req, cur_allocate_len: int, dp_rank: int):
+        """Free spec-decode over-allocated KV slots beyond committed length, then release."""
+        all_token_len = req.kv_committed_len
+        if self.page_size > 1:
+            all_token_len = cdiv(all_token_len, self.page_size) * self.page_size
+        kv_indices = self.req_to_token_pool.req_to_token[
+            req.req_pool_idx, all_token_len:cur_allocate_len
+        ]
+        kv_indices = kv_indices[kv_indices != 0]
+        self.token_to_kv_pool_allocator.free(kv_indices, dp_rank)
+        release_kv_cache(req, self.tree_cache)
+
     def process_batch_result_decode(
         self: Scheduler,
         batch: ScheduleBatch,
@@ -351,7 +363,20 @@ class SchedulerOutputProcessorMixin:
             for i, (req, next_token_id) in enumerate(zip(reqs, dp_output_ids)):
                 req: Req
                 if self.enable_overlap and (req.finished() or req.is_retracted):
-                    # release_kv_cache owns over-allocated KV; freeing here would double-free.
+                    if (
+                        batch.spec_algorithm is not None
+                        and batch.spec_algorithm.is_eagle()
+                        and req.finished()
+                        and req.req_pool_idx is not None
+                    ):
+                        # Under overlap, this req was marked finished in
+                        # process_result(k) but already dispatched in round k+1
+                        # before that. Its over-alloc free + req_pool release
+                        # were deferred there; do them now using round k+1's
+                        # allocate_lens (covers both round k and k+1 over-alloc).
+                        self._free_spec_overalloc_and_release(
+                            req, int(result.allocate_lens[req_idx]), dp_rank
+                        )
                     req_idx += 1
                     continue
 
@@ -372,34 +397,15 @@ class SchedulerOutputProcessorMixin:
 
                 if req.finished():
                     self.maybe_collect_routed_experts(req)
-                    if batch.spec_algorithm is not None and batch.spec_algorithm.is_eagle():
-                        cur_allocate_len = int(info.spec_info.allocate_lens[i])
+                    is_spec = batch.spec_algorithm is not None and batch.spec_algorithm.is_eagle()
+                    if is_spec:
+                        # Spec decode allocates via EagleDraftInput.prepare_for_decode
+                        # so kv_committed_len was never bumped past prefill; align to
+                        # the *unaligned* actual token count so cache_finished_req
+                        # frees decode pages without touching the page-0 sentinel.
                         actual_token_len = len(req.origin_input_ids) + max(
                             len(req.output_ids) - 1, 0
                         )
-                        all_token_len = actual_token_len
-                        if self.page_size > 1:
-                            all_token_len = cdiv(all_token_len, self.page_size) * self.page_size
-                        kv_indices = self.req_to_token_pool.req_to_token[
-                            req.req_pool_idx,
-                            all_token_len:cur_allocate_len,
-                        ]
-                        kv_indices = kv_indices[kv_indices != 0]
-                        from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
-
-                        assert (
-                            len(kv_indices) <= EagleDraftInput.ALLOC_LEN_PER_DECODE
-                        ), f"redundant kv indices {len(kv_indices)=} should less than {EagleDraftInput.ALLOC_LEN_PER_DECODE=}"
-
-                        self.token_to_kv_pool_allocator.free(kv_indices, dp_rank)
-                        # Spec decode allocates via EagleDraftInput.prepare_for_decode,
-                        # not ScheduleBatch.prepare_for_decode, so kv_committed_len is
-                        # never bumped past prefill. cache_finished_req would then
-                        # free only the prefill page and leak every decode-allocated
-                        # page (visible on idle check_memory at bs=1). Use the
-                        # *unaligned* actual token count: ChunkCache.cache_finished_req
-                        # does NOT filter 0-valued req_to_token entries, so a
-                        # page-aligned length would free the page-0 sentinel.
                         req.kv_committed_len = actual_token_len
                         req.kv_allocated_len = actual_token_len
                     # End trace for finished request
@@ -418,7 +424,20 @@ class SchedulerOutputProcessorMixin:
                             >= precision_tracer.get_max_requests()
                         ):
                             precision_tracer.stop_trace()
-                    release_kv_cache(req, self.tree_cache)
+                    if is_spec and self.enable_overlap:
+                        # Req is already in-flight on device for round k+1
+                        # (dispatched before this process_result(k) ran). Defer
+                        # over-alloc free + req_pool release to the finished
+                        # branch above on the next round, using round k+1's
+                        # allocate_lens, so req_pool_idx isn't recycled
+                        # mid-flight and both rounds' over-alloc are freed.
+                        pass
+                    elif is_spec:
+                        self._free_spec_overalloc_and_release(
+                            req, int(result.allocate_lens[req_idx]), dp_rank
+                        )
+                    else:
+                        release_kv_cache(req, self.tree_cache)
 
                 if req.return_output_logprob_only:
                     req.output_token_logprobs_val.append(next_token_logprobs[req_idx])

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -873,6 +873,8 @@ class SchedulerOutputProcessorMixin:
                 output_hidden_states_for_mm,
                 cache_miss_count,
                 output_routed_experts,
+                spec_verify_ct=spec_verify_ct or None,
+                spec_accepted_tokens=spec_accepted_tokens or None,
             )
             if self._comm_backend is not None:
                 self._comm_backend.send_pyobj(out)

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -150,7 +150,18 @@ class SchedulerOutputProcessorMixin:
                                 >= precision_tracer.get_max_requests()
                             ):
                                 precision_tracer.stop_trace()
-                        release_kv_cache(req, self.tree_cache)
+                        if (
+                            self.enable_overlap
+                            and self.spec_algorithm is not None
+                            and self.spec_algorithm.is_eagle()
+                        ):
+                            # Round k+1 prepare_for_decode already bumped
+                            # kv_allocated_len; release_kv_cache would assert
+                            # committed==allocated. Defer to drain (req is in
+                            # running_batch after last_batch merge at k+1).
+                            pass
+                        else:
+                            release_kv_cache(req, self.tree_cache)
                     elif not info.decoding_reqs or req not in info.decoding_reqs:
                         # This updates radix so others can match
                         self.tree_cache.cache_unfinished_req(req)

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -68,7 +68,7 @@ class SchedulerOutputProcessorMixin:
             result.extend_logprob_start_len_per_req,
             result.cache_miss_count,
         )
-        if self.enable_overlap:
+        if self._overlap_via_tp_thread:
             logits_output, next_token_ids, cache_miss_count = (
                 self.tp_worker.resolve_last_batch_result(launch_done)
             )
@@ -313,7 +313,7 @@ class SchedulerOutputProcessorMixin:
             self.draft_token += batch.batch_size() * self.draft_worker.speculative_num_draft_tokens
         # FIXME(pc) add spec decode metrics
 
-        if self.enable_overlap:
+        if self._overlap_via_tp_thread:
             logits_output, next_token_ids, cache_miss_count = (
                 self.tp_worker.resolve_last_batch_result(launch_done)
             )

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -1007,6 +1007,12 @@ class TokenizerManager:
                         "cached_tokens": recv_obj.cached_tokens[i],
                     }
                 )
+                if getattr(recv_obj, "spec_verify_ct", None):
+                    vct = recv_obj.spec_verify_ct[i]
+                    meta_info["spec_verify_ct"] = vct
+                    meta_info["spec_accept_length"] = (
+                        recv_obj.spec_accepted_tokens[i] / vct if vct else 0.0
+                    )
 
             if getattr(recv_obj, "output_hidden_states", None):
                 meta_info["hidden_states"] = recv_obj.output_hidden_states[i]

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -187,6 +187,8 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         model_def, model_state = nnx.split(self.model)
         # note export for external modification
         self.model_state_leaves, model_state_def = jax.tree_util.tree_flatten(model_state)
+        self._model_def = model_def
+        self._model_state_def = model_state_def
         sampler_def, sampler_state = nnx.split(self.sampler)
         sampler_state_leaves, sampler_state_def = jax.tree_util.tree_flatten(sampler_state)
 

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -1194,13 +1194,6 @@ class ServerArgs:
         # Check LoRA configuration
         self.check_lora_server_args()
 
-        # Disallow overlap scheduler when speculative decoding is enabled
-        if self.speculative_algorithm is not None and not self.disable_overlap_schedule:
-            raise ValueError(
-                "Speculative decoding does not support overlap scheduler. "
-                "Please pass --disable-overlap-schedule when using --speculative-algorithm."
-            )
-
     def check_lora_server_args(self):
         """Validate and normalize LoRA-related server arguments."""
         # Import LoRARef here to avoid circular imports

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -156,6 +156,7 @@ class ServerArgs:
     speculative_num_draft_tokens: int = 4
     speculative_accept_threshold_single: float = 1.0
     speculative_accept_threshold_acc: float = 1.0
+    enable_spec_device_chain: bool = False
 
     # For deterministic sampling
     enable_deterministic_sampling: bool = False
@@ -1033,6 +1034,16 @@ class ServerArgs:
             type=float,
             help="The accept probability of a draft token is raised from its target probability p to min(1, p / threshold_acc).",
             default=ServerArgs.speculative_accept_threshold_acc,
+        )
+        parser.add_argument(
+            "--enable-spec-device-chain",
+            action="store_true",
+            help=(
+                "Under overlap scheduler with speculative decoding, keep verify "
+                "results on device and resolve them inside the next round's fused "
+                "JIT (avoids the d2h→h2d round-trip between rounds). Requires "
+                "--speculative-algorithm and overlap scheduler enabled."
+            ),
         )
 
         # For deterministic sampling

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -78,6 +78,12 @@ class BaseSpecWorker:
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
+        self._can_use_fused_spec_decode = (
+            self.speculative_algorithm.is_nextn()
+            and self.topk == 1
+            and self.speculative_num_steps > 1
+            and self.speculative_num_draft_tokens == self.speculative_num_steps + 1
+        )
 
         self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
 
@@ -139,6 +145,12 @@ class BaseSpecWorker:
         # to global-flat (real_bs,) so reqs_info[0].spec_info stays flat-ordered.
         sel = model_worker_batch.logits_indices_selector
         cur_allocate_lens = np.asarray(model_worker_batch.spec_info_padded.allocate_lens)[sel]
+        if self._can_use_fused_spec_decode and model_worker_batch.sampling_info.is_all_greedy:
+            # Current fused route covers greedy NEXTN decode; more speculative
+            # decode paths can be folded into this entry point over time.
+            from sgl_jax.srt.speculative.draft_extend_fused import spec_decode
+
+            return spec_decode(self, model_worker_batch, cur_allocate_lens)
         self.draft_worker.draft(model_worker_batch)
         batch_output = self.verify(model_worker_batch, cur_allocate_lens)
         self.draft_worker.draft_extend_for_decode(model_worker_batch, batch_output)
@@ -179,6 +191,7 @@ class BaseSpecWorker:
             self.mesh, logits_output.next_token_logits, logits_output.hidden_states
         )
         spec_info.hidden_states = logits_output.hidden_states
+
         (
             predict,
             verified_id,

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 import jax
+
+logger = logging.getLogger(__name__)
 import numpy as np
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
@@ -108,6 +111,9 @@ class BaseSpecWorker:
         from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
 
         if model_worker_batch.forward_mode.is_extend():
+            import os as _os
+
+            _DBG = _os.path.exists("/tmp/p2a-dbg-retract")
             if model_worker_batch.sampling_info.temperatures.ndim == 1:
                 model_worker_batch.sampling_info.temperatures = (
                     model_worker_batch.sampling_info.temperatures[:, None]
@@ -118,16 +124,41 @@ class BaseSpecWorker:
                 self.mesh,
                 vocab_size=self.target_worker.model_config.vocab_size,
             )
+            if _DBG:
+                logger.info(
+                    "DBGRT spec_ext.target_fwd.pre padded_bs=%d real_bs=%d",
+                    len(model_worker_batch.seq_lens),
+                    model_worker_batch.real_bs,
+                )
             logits_output, next_token_ids, cache_miss_count, bid, _seq_lens = (
                 self.forward_target_extend(model_worker_batch, sampling_metadata)
             )
+            if _DBG:
+                logger.info(
+                    "DBGRT spec_ext.target_fwd.post nti.shape=%s",
+                    getattr(next_token_ids, "shape", None),
+                )
             if model_worker_batch.dp_size > 1:
                 from jax.experimental.multihost_utils import process_allgather
 
+                if _DBG:
+                    logger.info(
+                        "DBGRT spec_ext.block_ready.pre sharding=%s",
+                        getattr(next_token_ids, "sharding", None),
+                    )
+                    jax.block_until_ready(next_token_ids)
+                    logger.info("DBGRT spec_ext.block_ready.post")
+                    logger.info("DBGRT spec_ext.allgather.pre")
                 next_token_ids = process_allgather(next_token_ids, tiled=True)
+                if _DBG:
+                    logger.info("DBGRT spec_ext.allgather.post")
+            if _DBG:
+                logger.info("DBGRT spec_ext.draft_ext.pre")
             self.draft_worker.draft_extend_for_prefill(
                 model_worker_batch, logits_output.hidden_states, next_token_ids
             )
+            if _DBG:
+                logger.info("DBGRT spec_ext.draft_ext.post")
             return GenerationBatchResult(
                 logits_output=logits_output,
                 next_token_ids=next_token_ids,

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 import jax
-
-logger = logging.getLogger(__name__)
 import numpy as np
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
@@ -111,9 +108,6 @@ class BaseSpecWorker:
         from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
 
         if model_worker_batch.forward_mode.is_extend():
-            import os as _os
-
-            _DBG = _os.path.exists("/tmp/p2a-dbg-retract")
             if model_worker_batch.sampling_info.temperatures.ndim == 1:
                 model_worker_batch.sampling_info.temperatures = (
                     model_worker_batch.sampling_info.temperatures[:, None]
@@ -124,41 +118,16 @@ class BaseSpecWorker:
                 self.mesh,
                 vocab_size=self.target_worker.model_config.vocab_size,
             )
-            if _DBG:
-                logger.info(
-                    "DBGRT spec_ext.target_fwd.pre padded_bs=%d real_bs=%d",
-                    len(model_worker_batch.seq_lens),
-                    model_worker_batch.real_bs,
-                )
             logits_output, next_token_ids, cache_miss_count, bid, _seq_lens = (
                 self.forward_target_extend(model_worker_batch, sampling_metadata)
             )
-            if _DBG:
-                logger.info(
-                    "DBGRT spec_ext.target_fwd.post nti.shape=%s",
-                    getattr(next_token_ids, "shape", None),
-                )
             if model_worker_batch.dp_size > 1:
                 from jax.experimental.multihost_utils import process_allgather
 
-                if _DBG:
-                    logger.info(
-                        "DBGRT spec_ext.block_ready.pre sharding=%s",
-                        getattr(next_token_ids, "sharding", None),
-                    )
-                    jax.block_until_ready(next_token_ids)
-                    logger.info("DBGRT spec_ext.block_ready.post")
-                    logger.info("DBGRT spec_ext.allgather.pre")
                 next_token_ids = process_allgather(next_token_ids, tiled=True)
-                if _DBG:
-                    logger.info("DBGRT spec_ext.allgather.post")
-            if _DBG:
-                logger.info("DBGRT spec_ext.draft_ext.pre")
             self.draft_worker.draft_extend_for_prefill(
                 model_worker_batch, logits_output.hidden_states, next_token_ids
             )
-            if _DBG:
-                logger.info("DBGRT spec_ext.draft_ext.post")
             return GenerationBatchResult(
                 logits_output=logits_output,
                 next_token_ids=next_token_ids,

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -1,0 +1,243 @@
+"""Fused single-JIT for N-layer MTP draft extend decode.
+
+Merges all N model forward calls into one @jax.jit, eliminating:
+- Per-layer host dispatch overhead (~N jit calls → 1)
+- Per-layer device_get for rotate_ids (device .at[].set for topk=1)
+- Per-layer replicate_to_mesh boundary (with_sharding_constraint inside jit)
+
+Constraints:
+- topk=1 only (rotate_ids = .at[sel_pos].set)
+- All MTP layers share same model class (same model_def / model_state_def)
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+logger = logging.getLogger(__name__)
+
+
+def _device_rotate_input_ids(input_ids, ext_lens, sel_pos, new_tokens):
+    """Device-side per-req rotate for topk=1, exact mirror of the host
+    ``MultiLayerDraftWorker._rotate_ids``:
+
+      seg[:-1] = seg[1:]      # left-shift, KEEP last column (= prev last token)
+      seg[sel_pos] = new_token
+      padding reqs (ext_lens == 0) are left untouched
+
+    input_ids is the flat (bs * tokens_per_req,) buffer; every req occupies a
+    fixed ``tokens_per_req`` segment (real reqs have extend_seq_lens ==
+    tokens_per_req, padding reqs have 0). The last column is the captured-logit
+    position, so it must be copy-last (NOT jnp.roll, which wraps the first token
+    into the last column and diverges on partial accept).
+    """
+    bs = ext_lens.shape[0]
+    tokens_per_req = input_ids.shape[0] // bs
+    ids_2d = input_ids.reshape(bs, tokens_per_req)
+    shifted_2d = jnp.concatenate([ids_2d[:, 1:], ids_2d[:, -1:]], axis=1)
+    shifted_2d = shifted_2d.at[jnp.arange(bs), sel_pos].set(
+        new_tokens,
+        out_sharding=jax.typeof(shifted_2d).sharding,
+    )
+    pad_mask = (ext_lens == 0)[:, None]
+    shifted_2d = jnp.where(pad_mask, ids_2d, shifted_2d)
+    return shifted_2d.reshape(-1)
+
+
+def _build_fused_draft_extend_jit(num_layers: int, topk: int):
+    """Build the fused JIT. Called once, result cached on draft_worker."""
+    assert topk == 1, "Fused draft extend only supports topk=1"
+
+    @partial(
+        jax.jit,
+        donate_argnames=["all_memory_pools"],
+        static_argnames=["model_state_def", "num_layers"],
+    )
+    def fused_draft_extend(
+        model_def,
+        model_state_def,
+        all_leaves,  # tuple of N tuples-of-arrays
+        forward_batch,  # single ForwardBatch (shared across layers)
+        all_memory_pools,  # tuple of N MemoryPools pytrees
+        logits_metadata,  # LogitsMetadata pytree
+        target_hidden,  # (tokens, hidden_dim) replicated
+        sel_pos,  # (bs,) device array — rotate position
+        *,
+        num_layers,
+    ):
+        all_topk_p = []
+        all_topk_index = []
+        all_pool_updates = []
+        layer0_hidden = None
+        mesh = None
+        input_ids = forward_batch.input_ids
+
+        for i in range(num_layers):
+            state = jax.tree_util.tree_unflatten(model_state_def, all_leaves[i])
+            model = nnx.merge(model_def, state)
+
+            # shared forward_batch: only hidden_states and input_ids change per layer;
+            # model() must not mutate other fields (positions, attn metadata, etc.)
+            forward_batch.spec_info.hidden_states = target_hidden
+            forward_batch.input_ids = input_ids
+
+            output, pool_updates, _, _ = model(forward_batch, all_memory_pools[i], logits_metadata)
+            all_pool_updates.append(pool_updates)
+
+            # Replicate logits + hidden to P() (all-gather)
+            sh = jax.typeof(output.next_token_logits).sharding
+            mesh = sh.mesh if isinstance(sh, NamedSharding) else None
+            if mesh is not None:
+                rep_logits = jax.sharding.reshard(
+                    output.next_token_logits, NamedSharding(mesh, P())
+                )
+                rep_hidden = jax.sharding.reshard(output.hidden_states, NamedSharding(mesh, P()))
+            else:
+                rep_logits = output.next_token_logits
+                rep_hidden = output.hidden_states
+
+            if i == 0:
+                layer0_hidden = rep_hidden
+
+            # topk (inline, not separate jit)
+            topk_logits, topk_idx = jax.lax.top_k(rep_logits, topk)
+            logsumexp = jax.nn.logsumexp(rep_logits, axis=-1, keepdims=True)
+            topk_p = jnp.exp(topk_logits - logsumexp).astype(rep_logits.dtype)
+
+            all_topk_p.append(topk_p)
+            all_topk_index.append(topk_idx)
+
+            # Device-side rotate for topk=1 (shared with offline equivalence
+            # test; exact mirror of host _rotate_ids).
+            if i < num_layers - 1:
+                ext_lens = forward_batch.extend_seq_lens
+                input_ids = _device_rotate_input_ids(input_ids, ext_lens, sel_pos, topk_idx[:, 0])
+
+        # Force P() replicated sharding on outputs that must be cross-process
+        # consistent. Without this, donate_argnames may let XLA alias output
+        # buffers with donated P("data")-sharded pool buffers, silently making
+        # np.asarray() return per-process-different values.
+        stacked_p = jnp.stack(all_topk_p, axis=1)
+        stacked_idx = jnp.stack(all_topk_index, axis=1)
+        if mesh is not None:
+            rep = NamedSharding(mesh, P())
+            layer0_hidden = jax.lax.with_sharding_constraint(layer0_hidden, rep)
+            stacked_p = jax.lax.with_sharding_constraint(stacked_p, rep)
+            stacked_idx = jax.lax.with_sharding_constraint(stacked_idx, rep)
+
+        return (
+            layer0_hidden,
+            stacked_p,
+            stacked_idx,
+            tuple(all_pool_updates),
+        )
+
+    return fused_draft_extend
+
+
+def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output):
+    """Drop-in replacement for MultiLayerDraftWorker.draft_extend_for_decode.
+
+    Fuses all N MTP layer forwards into a single jit call.
+    """
+    from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+    from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
+
+    if batch_output.next_draft_input.verified_id.shape[0] <= 0:
+        return
+    target_hidden = batch_output.logits_output.hidden_states
+
+    draft_input = EagleDraftInput(
+        hidden_states=target_hidden, allocate_lens=batch_output.allocate_lens
+    )
+    mwb, logits_metadata = draft_input.prepare_for_extend_after_verify(
+        model_worker_batch,
+        draft_worker.draft_model_runner,
+        batch_output,
+        draft_worker.speculative_num_draft_tokens,
+    )
+    if mwb.input_ids.shape[0] <= 0:
+        return
+
+    sel = np.asarray(model_worker_batch.logits_indices_selector)
+    accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
+    assert (accept_host[sel] >= 1).all(), f"accept_length < 1: {accept_host[sel]}"
+    sel_pos = np.clip(accept_host - 1, 0, None).astype(np.int32)
+
+    # --- Host preparation (all done before single jit call) ---
+
+    # Build ONE ForwardBatch and reuse for all layers. All workers share the
+    # same mwb so forward_metadata is identical; only memory_pools/weights differ.
+    mr0 = draft_worker._workers[0].model_runner
+    mwb.spec_info_padded.hidden_states = target_hidden
+    mr0.attn_backend.forward_metadata = mr0.attn_backend.get_eagle_forward_metadata(mwb)
+    shared_fb = ForwardBatch.init_new(mwb, mr0)
+    shared_fb.bid = model_worker_batch.bid
+
+    all_memory_pools = []
+    all_leaves = []
+    for w in draft_worker._workers:
+        mr = w.model_runner
+        all_memory_pools.append(mr.memory_pools)
+        all_leaves.append(tuple(mr.model_state_leaves))
+
+    sel_pos_device = jax.device_put(sel_pos, NamedSharding(draft_worker.mesh, P("data")))
+
+    # --- Build / get cached fused jit ---
+    if not hasattr(draft_worker, "_fused_jit_fn"):
+        draft_worker._fused_jit_fn = _build_fused_draft_extend_jit(
+            num_layers=draft_worker.speculative_num_steps,
+            topk=draft_worker.topk,
+        )
+
+    # --- Single jit call: all N layers fused ---
+    # Model internals use P() with implicit mesh; need use_mesh context
+    try:
+        ctx = jax.sharding.use_mesh(draft_worker.mesh)
+    except AttributeError:
+        try:
+            ctx = jax.set_mesh(draft_worker.mesh)
+        except AttributeError:
+            ctx = draft_worker.mesh
+    with ctx:
+        layer0_hidden, topk_p_stacked, topk_index_stacked, all_pool_updates = (
+            draft_worker._fused_jit_fn(
+                mr0._model_def,
+                mr0._model_state_def,
+                tuple(all_leaves),
+                shared_fb,
+                tuple(all_memory_pools),
+                logits_metadata,
+                target_hidden,
+                sel_pos_device,
+                num_layers=draft_worker.speculative_num_steps,
+            )
+        )
+
+    # --- Host post-processing: replace memory pools + assemble outputs ---
+    for i, w in enumerate(draft_worker._workers):
+        w.model_runner.memory_pools.replace_all(all_pool_updates[i])
+
+    select_index = sel * (draft_worker.speculative_num_steps + 1) + accept_host[sel] - 1
+    verified_id_arr = batch_output.next_draft_input.verified_id
+    if hasattr(verified_id_arr, "copy_to_host_async"):
+        jax.copy_to_host_async(verified_id_arr)
+
+    jax.copy_to_host_async(layer0_hidden)
+    jax.copy_to_host_async(topk_p_stacked)
+    jax.copy_to_host_async(topk_index_stacked)
+
+    batch_output.next_draft_input.hidden_states = np.asarray(layer0_hidden)[select_index]
+    batch_output.next_draft_input.topk_p = np.asarray(topk_p_stacked)[sel]
+    batch_output.next_draft_input.topk_index = np.asarray(topk_index_stacked)[sel]
+    batch_output.next_draft_input.verified_id = np.asarray(verified_id_arr)[select_index]
+    batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
+    batch_output.accept_lens = accept_host

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -910,36 +910,59 @@ def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
     for i, w in enumerate(draft_worker._workers):
         w.model_runner.memory_pools.replace_all(all_pool_updates[i])
 
+    jax.copy_to_host_async(layer0_hidden)
+    jax.copy_to_host_async(topk_index_stacked)
+    jax.copy_to_host_async(accept_lens_device)
+    jax.copy_to_host_async(predict_device)
+
     selector = np.asarray(model_worker_batch.logits_indices_selector)
-    result = _materialize_fused_greedy_batch_output_for_scheduler(
-        batch_output=batch_output,
+    seq_lens_host = model_worker_batch.seq_lens.copy()
+    real_bs = model_worker_batch.real_bs
+    n_draft = draft_worker.speculative_num_draft_tokens
+
+    def _finalize():
+        result = _materialize_fused_greedy_batch_output_for_scheduler(
+            batch_output=batch_output,
+            selector=selector,
+            real_bs=real_bs,
+            seq_lens_host=seq_lens_host,
+            layer0_hidden=layer0_hidden,
+            topk_index_stacked=topk_index_stacked,
+            accept_lens_device=accept_lens_device,
+            predict_device=predict_device,
+            speculative_num_draft_tokens=n_draft,
+            target_logits=target_logits,
+            target_hidden=target_hidden,
+        )
+        if _SH["on"]:
+            padded_bs = result.accept_lens.shape[0]
+            prev_vid = np.asarray(previous_verified_id, dtype=np.int32).reshape(padded_bs, 1)
+            prev_tl = np.asarray(previous_token_list, dtype=np.int32)[:, : n_draft - 1]
+            draft_2d = np.concatenate([prev_vid, prev_tl], axis=1)
+            predict_2d = np.asarray(result.next_token_ids).reshape(padded_bs, n_draft)
+            _log_step_hit(draft_2d, predict_2d, selector)
+        return result
+
+    pending = SpecDecodePending(
+        finalize=_finalize,
         selector=selector,
-        real_bs=model_worker_batch.real_bs,
-        seq_lens_host=model_worker_batch.seq_lens,
-        layer0_hidden=layer0_hidden,
-        topk_index_stacked=topk_index_stacked,
-        accept_lens_device=accept_lens_device,
-        predict_device=predict_device,
-        speculative_num_draft_tokens=draft_worker.speculative_num_draft_tokens,
-        target_logits=target_logits,
-        target_hidden=target_hidden,
+        per_dp_bs=model_worker_batch.per_dp_bs_size,
+        real_bs_per_dp=list(model_worker_batch.real_bs_per_dp),
     )
-    if _SH["on"] or _DUMP["on"]:
-        n = draft_worker.speculative_num_draft_tokens
-        padded_bs = result.accept_lens.shape[0]
-        prev_vid = np.asarray(previous_verified_id, dtype=np.int32).reshape(padded_bs, 1)
-        prev_tl = np.asarray(previous_token_list, dtype=np.int32)[:, : n - 1]
-        draft_2d = np.concatenate([prev_vid, prev_tl], axis=1)
-        predict_2d = np.asarray(result.next_token_ids).reshape(padded_bs, n)
-        _log_step_hit(draft_2d, predict_2d, selector)
-        if _DUMP["on"]:
-            _dump_dext_round(
-                "spec",
-                draft=draft_2d[selector],
-                predict=predict_2d[selector],
-                accept=result.accept_lens[selector],
-                topk_next=result.next_draft_input.topk_index,  # (real_bs, num_layers, 1)
-                verified_next=result.next_draft_input.verified_id,
-                l0_hidden8=result.next_draft_input.hidden_states[:, :8],
-            )
-    return result
+    if model_worker_batch.defer_spec_materialize:
+        return pending
+    return pending.finalize()
+
+
+class SpecDecodePending(NamedTuple):
+    """Deferred materialization handle for one fused spec-decode round.
+
+    Under overlap, the scheduler calls ``finalize()`` at the start of the
+    *next* iteration (before ``get_next_batch_to_run``), so the d2h sync and
+    host bookkeeping run while the device was busy with this round's JIT.
+    """
+
+    finalize: Any
+    selector: np.ndarray
+    per_dp_bs: int
+    real_bs_per_dp: list

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -361,28 +361,25 @@ def _build_fused_greedy_decode_jit(num_layers: int, topk: int):
         if use_chain:
             d1 = jax.typeof(target_forward_batch.seq_lens).sharding
             mesh_ = d1.mesh if isinstance(d1, NamedSharding) else None
-            d2 = NamedSharding(mesh_, P("data", None)) if mesh_ else d1
             d3 = NamedSharding(mesh_, P("data", None, None)) if mesh_ else d1
-            seq_lens_real = jax.sharding.reshard(
-                prev_chain.new_seq_lens.astype(jnp.int32), d1
-            )
+            seq_lens_real = jax.sharding.reshard(prev_chain.new_seq_lens.astype(jnp.int32), d1)
             prev_acc = jax.sharding.reshard(prev_chain.accept_lens.astype(jnp.int32), d1)
             prev_pred = jax.sharding.reshard(prev_chain.predict.astype(jnp.int32), d1)
             prev_last = jnp.clip(prev_acc - 1, 0, ndt - 1)
             verified_id_real = jnp.take_along_axis(
                 prev_pred.reshape(target_bs, ndt), prev_last[:, None], axis=1
             ).squeeze(1)
-            token_list_real = jax.sharding.reshard(
-                prev_chain.stacked_idx.astype(jnp.int32), d3
-            )[:, :, 0]
+            token_list_real = jax.sharding.reshard(prev_chain.stacked_idx.astype(jnp.int32), d3)[
+                :, :, 0
+            ]
             is_real = (seq_lens_real > 0).astype(jnp.int32)
             target_forward_batch.seq_lens = seq_lens_real
             target_forward_batch.attn_backend.forward_metadata.seq_lens = (
                 seq_lens_real + is_real * ndt
             )
             draft_forward_batch.seq_lens = seq_lens_real + is_real * (ndt - 1)
-            draft_forward_batch.attn_backend.forward_metadata.seq_lens = (
-                seq_lens_real + is_real * (ndt - 1)
+            draft_forward_batch.attn_backend.forward_metadata.seq_lens = seq_lens_real + is_real * (
+                ndt - 1
             )
         else:
             verified_id_real = previous_verified_id
@@ -923,9 +920,7 @@ def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
     rpi_host = np.asarray(model_worker_batch.req_pool_indices)
     prev = getattr(spec_worker, "_chain_state", None)
     use_chain = bool(
-        prev is not None
-        and prev[0].shape == rpi_host.shape
-        and np.array_equal(prev[0], rpi_host)
+        prev is not None and prev[0].shape == rpi_host.shape and np.array_equal(prev[0], rpi_host)
     )
     if use_chain:
         prev_chain = prev[1]

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -55,6 +55,35 @@ def _dump_dext_round(tag, **arrays):
     _DUMP["k"] += 1
 
 
+class SpecChainState(NamedTuple):
+    """Device-resident outputs of round k passed as round k+1 inputs.
+
+    Stored with whatever sharding the fused JIT produced (NOT resharded —
+    that cost ~1.5ms/round in v1). Round k+1 reshards in-JIT to the target
+    sharding (rep→P("data") = split, no cross-host comm).
+    """
+
+    new_seq_lens: jax.Array  # (padded_bs,) — seq_lens + accept (post-verify)
+    stacked_idx: jax.Array  # (padded_bs, num_steps, 1) — draft topk_index
+    predict: jax.Array  # (padded_bs * ndt,) — verify argmax
+    accept_lens: jax.Array  # (padded_bs,)
+
+
+def _zeros_chain_state(padded_bs, num_steps, ndt, mesh):
+    from sgl_jax.srt.utils.jax_utils import device_array
+
+    d1 = NamedSharding(mesh, P("data"))
+    return SpecChainState(
+        new_seq_lens=device_array(np.zeros((padded_bs,), np.int32), sharding=d1),
+        stacked_idx=device_array(
+            np.zeros((padded_bs, num_steps, 1), np.int32),
+            sharding=NamedSharding(mesh, P("data", None, None)),
+        ),
+        predict=device_array(np.zeros((padded_bs * ndt,), np.int32), sharding=d1),
+        accept_lens=device_array(np.zeros((padded_bs,), np.int32), sharding=d1),
+    )
+
+
 class GreedyDraftInputs(NamedTuple):
     hidden_states: jax.Array
     positions: jax.Array
@@ -334,6 +363,7 @@ def _build_fused_greedy_decode_jit(num_layers: int, topk: int):
             "speculative_num_draft_tokens",
             "return_target_logits",
             "return_target_hidden",
+            "use_chain",
         ],
     )
     def fused_greedy_decode(
@@ -351,7 +381,9 @@ def _build_fused_greedy_decode_jit(num_layers: int, topk: int):
         draft_logits_metadata,
         previous_verified_id,
         previous_token_list,
+        prev_chain,
         *,
+        use_chain,
         num_layers,
         speculative_num_steps,
         speculative_num_draft_tokens,
@@ -359,6 +391,46 @@ def _build_fused_greedy_decode_jit(num_layers: int, topk: int):
         return_target_hidden,
     ):
         target_bs = target_forward_batch.seq_lens.shape[0]
+        ndt = speculative_num_draft_tokens
+        # Device-chain resolve: when batch layout is unchanged from prev round
+        # (use_chain static), derive verified_id/token_list/seq_lens from
+        # prev_chain (jit_{k-1} device outputs) instead of host-uploaded values.
+        # Reshard prev_chain in-JIT to match host-value shardings (rep→P("data")
+        # is a per-host split, no cross-host comm; P("data")→P("data") is no-op).
+        # Host metadata (cu_kv_lens/page_indices/out_cache_loc) used optimistic
+        # seq_lens (+ndt); kernel masks via kv_lens (overridden below) so the
+        # ≤ndt-token over-fetch (= 0 pages at page_size=256) is harmless.
+        if use_chain:
+            d1 = jax.typeof(target_forward_batch.seq_lens).sharding
+            mesh_ = d1.mesh if isinstance(d1, NamedSharding) else None
+            d2 = NamedSharding(mesh_, P("data", None)) if mesh_ else d1
+            d3 = NamedSharding(mesh_, P("data", None, None)) if mesh_ else d1
+            seq_lens_real = jax.sharding.reshard(
+                prev_chain.new_seq_lens.astype(jnp.int32), d1
+            )
+            prev_acc = jax.sharding.reshard(prev_chain.accept_lens.astype(jnp.int32), d1)
+            prev_pred = jax.sharding.reshard(prev_chain.predict.astype(jnp.int32), d1)
+            prev_last = jnp.clip(prev_acc - 1, 0, ndt - 1)
+            verified_id_real = jnp.take_along_axis(
+                prev_pred.reshape(target_bs, ndt), prev_last[:, None], axis=1
+            ).squeeze(1)
+            token_list_real = jax.sharding.reshard(
+                prev_chain.stacked_idx.astype(jnp.int32), d3
+            )[:, :, 0]
+            is_real = (seq_lens_real > 0).astype(jnp.int32)
+            target_forward_batch.seq_lens = seq_lens_real
+            target_forward_batch.attn_backend.forward_metadata.seq_lens = (
+                seq_lens_real + is_real * ndt
+            )
+            draft_forward_batch.seq_lens = seq_lens_real + is_real * (ndt - 1)
+            draft_forward_batch.attn_backend.forward_metadata.seq_lens = (
+                seq_lens_real + is_real * (ndt - 1)
+            )
+        else:
+            verified_id_real = previous_verified_id
+            token_list_real = previous_token_list
+            seq_lens_real = target_forward_batch.seq_lens
+
         (
             draft_tokens,
             positions,
@@ -366,9 +438,9 @@ def _build_fused_greedy_decode_jit(num_layers: int, topk: int):
             retrive_next_token_flat,
             retrive_next_sibling_flat,
         ) = _build_topk1_chain_verify_inputs_device_tuple(
-            verified_id=previous_verified_id,
-            token_list=previous_token_list,
-            seq_lens=target_forward_batch.seq_lens,
+            verified_id=verified_id_real,
+            token_list=token_list_real,
+            seq_lens=seq_lens_real,
             num_verify_tokens=speculative_num_draft_tokens,
             batch_size=target_bs,
         )
@@ -458,6 +530,14 @@ def _build_fused_greedy_decode_jit(num_layers: int, topk: int):
         )
         target_logits_for_host = target_logits if return_target_logits else None
         target_hidden_for_host = target_hidden if return_target_hidden else None
+        # chain_out: capture BEFORE host-facing reshard-to-rep so next round's
+        # in-JIT reshard is split/no-op (no cross-host all-gather).
+        chain_out = SpecChainState(
+            new_seq_lens=prepared.new_seq_lens,
+            stacked_idx=stacked_idx,
+            predict=prepared.predict,
+            accept_lens=prepared.accept_lens,
+        )
         if mesh is not None:
             rep = NamedSharding(mesh, P())
             selected_layer0_hidden = jax.sharding.reshard(selected_layer0_hidden, rep)
@@ -481,6 +561,7 @@ def _build_fused_greedy_decode_jit(num_layers: int, topk: int):
             prepared_predict,
             target_logits_for_host,
             target_hidden_for_host,
+            chain_out,
         )
 
     return fused_greedy_decode
@@ -874,6 +955,30 @@ def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
             topk=draft_worker.topk,
         )
 
+    # Device-chain: when batch padded layout is unchanged from prev round
+    # (same req_pool_indices), pass prev round's device outputs so the JIT
+    # resolves verified_id/token_list/seq_lens device-side. use_chain is a
+    # python bool → static arg → 2 compiled variants (no jnp.where sharding
+    # mismatch). Step1: event_loop not reordered yet, so host seq_lens ==
+    # prev_chain.new_seq_lens (correctness check only, no perf gain).
+    padded_bs = int(model_worker_batch.seq_lens.shape[0])
+    rpi_host = np.asarray(model_worker_batch.req_pool_indices)
+    prev = getattr(spec_worker, "_chain_state", None)
+    use_chain = bool(
+        prev is not None
+        and prev[0].shape == rpi_host.shape
+        and np.array_equal(prev[0], rpi_host)
+    )
+    if use_chain:
+        prev_chain = prev[1]
+    else:
+        prev_chain = _zeros_chain_state(
+            padded_bs,
+            draft_worker.speculative_num_steps,
+            draft_worker.speculative_num_draft_tokens,
+            spec_worker.mesh,
+        )
+
     with jax.set_mesh(draft_worker.mesh):
         (
             layer0_hidden,
@@ -884,6 +989,7 @@ def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
             predict_device,
             target_logits,
             target_hidden,
+            chain_out,
         ) = draft_worker._fused_greedy_decode_jit_fn(
             target_mr._model_def,
             target_mr._model_state_def,
@@ -899,6 +1005,8 @@ def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
             draft_logits_metadata,
             previous_verified_id,
             previous_token_list,
+            prev_chain,
+            use_chain=use_chain,
             num_layers=draft_worker.speculative_num_steps,
             speculative_num_steps=draft_worker.speculative_num_steps,
             speculative_num_draft_tokens=draft_worker.speculative_num_draft_tokens,
@@ -906,6 +1014,7 @@ def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
             return_target_hidden=return_target_hidden,
         )
 
+    spec_worker._chain_state = (rpi_host, chain_out)
     target_mr.memory_pools.replace_all(target_pool_updates)
     for i, w in enumerate(draft_worker._workers):
         w.model_runner.memory_pools.replace_all(all_pool_updates[i])

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -1,19 +1,9 @@
-"""Fused single-JIT for N-layer MTP draft extend decode.
-
-Merges all N model forward calls into one @jax.jit, eliminating:
-- Per-layer host dispatch overhead (~N jit calls → 1)
-- Per-layer device_get for rotate_ids (device .at[].set for topk=1)
-- Per-layer replicate_to_mesh boundary (with_sharding_constraint inside jit)
-
-Constraints:
-- topk=1 only (rotate_ids = .at[sel_pos].set)
-- All MTP layers share same model class (same model_def / model_state_def)
-"""
+"""Fused greedy speculative decode and MTP draft extend."""
 
 from __future__ import annotations
 
-import logging
 from functools import partial
+from typing import NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -22,23 +12,175 @@ from flax import nnx
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
-logger = logging.getLogger(__name__)
+
+class GreedyDraftInputs(NamedTuple):
+    hidden_states: jax.Array
+    positions: jax.Array
+    new_seq_lens: jax.Array
+    select_index: jax.Array
+    verified_id: jax.Array
+    accept_lens: jax.Array
+    sel_pos: jax.Array
+
+
+class GreedySampleAndPrepareOutput(NamedTuple):
+    hidden_states: jax.Array
+    positions: jax.Array
+    new_seq_lens: jax.Array
+    select_index: jax.Array
+    verified_id: jax.Array
+    accept_lens: jax.Array
+    sel_pos: jax.Array
+    predict: jax.Array
+
+
+def _take_with_index_sharding(values, index):
+    index_sharding = jax.typeof(index).sharding
+    if isinstance(index_sharding, NamedSharding):
+        return values.reshape(-1).at[index].get(out_sharding=index_sharding)
+    return jnp.take(values.reshape(-1), index)
+
+
+def _greedy_prepare_draft_inputs(
+    hidden_states,
+    positions,
+    seq_lens,
+    accept_index,
+    accept_length,
+    verified_id,
+    *,
+    speculative_num_steps,
+    speculative_num_draft_tokens,
+):
+    accept_width = speculative_num_steps + 1
+    req_ids = (
+        jnp.zeros_like(accept_index)
+        + jnp.arange(accept_index.shape[0], dtype=jnp.int32) // accept_width
+    )
+    per_req_last = req_ids * speculative_num_draft_tokens + speculative_num_draft_tokens - 1
+    safe_index = jnp.where(accept_index >= 0, accept_index, per_req_last)
+    safe_accept_length = jnp.clip(accept_length, 1, None)
+    select_index = (
+        jnp.arange(accept_length.shape[0], dtype=jnp.int32) * accept_width + safe_accept_length - 1
+    )
+    hidden_sharding = jax.typeof(hidden_states).sharding
+    positions_sharding = jax.typeof(positions).sharding
+    if isinstance(hidden_sharding, NamedSharding):
+        gathered_hidden = hidden_states.at[safe_index, :].get(out_sharding=hidden_sharding)
+    else:
+        gathered_hidden = hidden_states[safe_index, :]
+    if isinstance(positions_sharding, NamedSharding):
+        gathered_positions = positions.at[safe_index].get(out_sharding=positions_sharding)
+    else:
+        gathered_positions = positions[safe_index]
+    return GreedyDraftInputs(
+        hidden_states=gathered_hidden,
+        positions=gathered_positions,
+        new_seq_lens=seq_lens + accept_length,
+        select_index=select_index,
+        verified_id=verified_id,
+        accept_lens=accept_length,
+        sel_pos=jnp.clip(accept_length - 1, 0, None).astype(jnp.int32),
+    )
+
+
+def _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
+    *,
+    target_hidden,
+    positions,
+    seq_lens,
+    draft_tokens,
+    target_predict,
+    speculative_num_steps,
+    speculative_num_draft_tokens,
+):
+    bs = seq_lens.shape[0]
+    n = speculative_num_draft_tokens
+    width = speculative_num_steps + 1
+    draft_2d = draft_tokens.reshape(bs, n)
+    target_predict_2d = target_predict.reshape(bs, n)
+
+    child_matches = draft_2d[:, 1:] == target_predict_2d[:, :-1]
+    is_padding = seq_lens == 0
+    accepted_children = jnp.cumprod(child_matches.astype(jnp.int32), axis=1).astype(jnp.bool_)
+    accepted_children = jnp.where(is_padding[:, None], False, accepted_children)
+    accept_length_raw = jnp.sum(accepted_children.astype(jnp.int32), axis=1)
+    accept_length = jnp.where(is_padding, 0, accept_length_raw + 1)
+
+    row_ids = jnp.zeros_like(accept_length_raw) + jnp.arange(bs, dtype=jnp.int32)
+    base = row_ids[:, None] * n
+    child_offsets = jnp.arange(1, width, dtype=jnp.int32)[None, :]
+    accept_index_children = jnp.where(accepted_children, base + child_offsets, -1)
+    accept_index_2d = jnp.concatenate([base, accept_index_children], axis=1)
+    accept_index_2d = jnp.where(is_padding[:, None], -1, accept_index_2d)
+    accept_index = accept_index_2d.reshape(-1)
+
+    predict = target_predict.astype(jnp.int32).reshape(-1)
+    accept_width = speculative_num_steps + 1
+    req_ids = (
+        jnp.zeros_like(accept_index)
+        + jnp.arange(accept_index.shape[0], dtype=jnp.int32) // accept_width
+    )
+    per_req_last = req_ids * speculative_num_draft_tokens + speculative_num_draft_tokens - 1
+    safe_index = jnp.where(accept_index >= 0, accept_index, per_req_last)
+    safe_predict = _take_with_index_sharding(predict, safe_index)
+    verified_id = jnp.where(accept_index >= 0, safe_predict, jnp.zeros_like(safe_predict))
+    prepared = _greedy_prepare_draft_inputs(
+        target_hidden,
+        positions,
+        seq_lens,
+        accept_index,
+        accept_length,
+        verified_id,
+        speculative_num_steps=speculative_num_steps,
+        speculative_num_draft_tokens=speculative_num_draft_tokens,
+    )
+    return GreedySampleAndPrepareOutput(
+        hidden_states=prepared.hidden_states,
+        positions=prepared.positions,
+        new_seq_lens=prepared.new_seq_lens,
+        select_index=prepared.select_index,
+        verified_id=prepared.verified_id,
+        accept_lens=prepared.accept_lens,
+        sel_pos=prepared.sel_pos,
+        predict=predict,
+    )
+
+
+def _build_topk1_chain_verify_inputs_device_tuple(
+    *,
+    verified_id,
+    token_list,
+    seq_lens,
+    num_verify_tokens,
+    batch_size,
+):
+    """Build topk=1 linear-chain verify inputs in-JIT without stacking shardings."""
+    n = num_verify_tokens
+    bs = batch_size
+    tid_range = jnp.arange(n, dtype=jnp.int32)
+    draft_tokens = jnp.concatenate(
+        [verified_id.astype(jnp.int32)[:, None], token_list[:, : n - 1].astype(jnp.int32)],
+        axis=1,
+    ).reshape(bs * n)
+    positions = (seq_lens.astype(jnp.int32)[:, None] + tid_range[None, :]).reshape(bs * n)
+    retrive_index = jnp.arange(bs * n, dtype=jnp.int32)
+    retrive_next_token = jnp.broadcast_to(
+        jnp.concatenate([jnp.arange(1, n, dtype=jnp.int32), jnp.array([-1], dtype=jnp.int32)]),
+        (bs, n),
+    ).reshape(bs * n)
+    retrive_next_sibling = jnp.full((bs * n,), -1, dtype=jnp.int32)
+    return (
+        draft_tokens,
+        positions,
+        retrive_index,
+        retrive_next_token,
+        retrive_next_sibling,
+    )
 
 
 def _device_rotate_input_ids(input_ids, ext_lens, sel_pos, new_tokens):
-    """Device-side per-req rotate for topk=1, exact mirror of the host
-    ``MultiLayerDraftWorker._rotate_ids``:
-
-      seg[:-1] = seg[1:]      # left-shift, KEEP last column (= prev last token)
-      seg[sel_pos] = new_token
-      padding reqs (ext_lens == 0) are left untouched
-
-    input_ids is the flat (bs * tokens_per_req,) buffer; every req occupies a
-    fixed ``tokens_per_req`` segment (real reqs have extend_seq_lens ==
-    tokens_per_req, padding reqs have 0). The last column is the captured-logit
-    position, so it must be copy-last (NOT jnp.roll, which wraps the first token
-    into the last column and diverges on partial accept).
-    """
+    """Mirror MultiLayerDraftWorker._rotate_ids on device for topk=1."""
     bs = ext_lens.shape[0]
     tokens_per_req = input_ids.shape[0] // bs
     ids_2d = input_ids.reshape(bs, tokens_per_req)
@@ -50,6 +192,18 @@ def _device_rotate_input_ids(input_ids, ext_lens, sel_pos, new_tokens):
     pad_mask = (ext_lens == 0)[:, None]
     shifted_2d = jnp.where(pad_mask, ids_2d, shifted_2d)
     return shifted_2d.reshape(-1)
+
+
+def _gather_rows_preserve_sharding(values, index):
+    sharding = jax.typeof(values).sharding
+    if isinstance(sharding, NamedSharding):
+        return values.at[index, :].get(out_sharding=sharding)
+    return values[index, :]
+
+
+def _topk1_index_from_logits(logits):
+    topk_idx = jnp.argmax(logits, axis=-1).astype(jnp.int32)[:, None]
+    return topk_idx
 
 
 def _build_fused_draft_extend_jit(num_layers: int, topk: int):
@@ -64,16 +218,15 @@ def _build_fused_draft_extend_jit(num_layers: int, topk: int):
     def fused_draft_extend(
         model_def,
         model_state_def,
-        all_leaves,  # tuple of N tuples-of-arrays
-        forward_batch,  # single ForwardBatch (shared across layers)
-        all_memory_pools,  # tuple of N MemoryPools pytrees
-        logits_metadata,  # LogitsMetadata pytree
-        target_hidden,  # (tokens, hidden_dim) replicated
-        sel_pos,  # (bs,) device array — rotate position
+        all_leaves,
+        forward_batch,
+        all_memory_pools,
+        logits_metadata,
+        target_hidden,
+        sel_pos,
         *,
         num_layers,
     ):
-        all_topk_p = []
         all_topk_index = []
         all_pool_updates = []
         layer0_hidden = None
@@ -84,63 +237,347 @@ def _build_fused_draft_extend_jit(num_layers: int, topk: int):
             state = jax.tree_util.tree_unflatten(model_state_def, all_leaves[i])
             model = nnx.merge(model_def, state)
 
-            # shared forward_batch: only hidden_states and input_ids change per layer;
-            # model() must not mutate other fields (positions, attn metadata, etc.)
             forward_batch.spec_info.hidden_states = target_hidden
             forward_batch.input_ids = input_ids
 
             output, pool_updates, _, _ = model(forward_batch, all_memory_pools[i], logits_metadata)
             all_pool_updates.append(pool_updates)
 
-            # Replicate logits + hidden to P() (all-gather)
             sh = jax.typeof(output.next_token_logits).sharding
             mesh = sh.mesh if isinstance(sh, NamedSharding) else None
-            if mesh is not None:
-                rep_logits = jax.sharding.reshard(
-                    output.next_token_logits, NamedSharding(mesh, P())
-                )
-                rep_hidden = jax.sharding.reshard(output.hidden_states, NamedSharding(mesh, P()))
-            else:
-                rep_logits = output.next_token_logits
-                rep_hidden = output.hidden_states
 
             if i == 0:
-                layer0_hidden = rep_hidden
+                layer0_hidden = output.hidden_states
 
-            # topk (inline, not separate jit)
-            topk_logits, topk_idx = jax.lax.top_k(rep_logits, topk)
-            logsumexp = jax.nn.logsumexp(rep_logits, axis=-1, keepdims=True)
-            topk_p = jnp.exp(topk_logits - logsumexp).astype(rep_logits.dtype)
-
-            all_topk_p.append(topk_p)
+            topk_idx = _topk1_index_from_logits(output.next_token_logits)
             all_topk_index.append(topk_idx)
 
-            # Device-side rotate for topk=1 (shared with offline equivalence
-            # test; exact mirror of host _rotate_ids).
             if i < num_layers - 1:
                 ext_lens = forward_batch.extend_seq_lens
                 input_ids = _device_rotate_input_ids(input_ids, ext_lens, sel_pos, topk_idx[:, 0])
 
+        select_index = jnp.arange(sel_pos.shape[0], dtype=jnp.int32) * (num_layers + 1) + sel_pos
+        selected_layer0_hidden = _gather_rows_preserve_sharding(layer0_hidden, select_index)
         # Force P() replicated sharding on outputs that must be cross-process
         # consistent. Without this, donate_argnames may let XLA alias output
         # buffers with donated P("data")-sharded pool buffers, silently making
         # np.asarray() return per-process-different values.
-        stacked_p = jnp.stack(all_topk_p, axis=1)
         stacked_idx = jnp.stack(all_topk_index, axis=1)
         if mesh is not None:
             rep = NamedSharding(mesh, P())
-            layer0_hidden = jax.lax.with_sharding_constraint(layer0_hidden, rep)
-            stacked_p = jax.lax.with_sharding_constraint(stacked_p, rep)
-            stacked_idx = jax.lax.with_sharding_constraint(stacked_idx, rep)
+            selected_layer0_hidden = jax.sharding.reshard(selected_layer0_hidden, rep)
+            stacked_idx = jax.sharding.reshard(stacked_idx, rep)
 
         return (
-            layer0_hidden,
-            stacked_p,
+            selected_layer0_hidden,
             stacked_idx,
             tuple(all_pool_updates),
         )
 
     return fused_draft_extend
+
+
+def _build_fused_greedy_decode_jit(num_layers: int, topk: int):
+    """Build fused JIT: target verify forward + greedy sample + MTP extend."""
+    assert topk == 1, "Fused greedy decode only supports topk=1"
+
+    @partial(
+        jax.jit,
+        donate_argnames=["target_memory_pools", "all_memory_pools"],
+        static_argnames=[
+            "target_model_state_def",
+            "draft_model_state_def",
+            "num_layers",
+            "speculative_num_steps",
+            "speculative_num_draft_tokens",
+            "return_target_logits",
+            "return_target_hidden",
+        ],
+    )
+    def fused_greedy_decode(
+        target_model_def,
+        target_model_state_def,
+        target_leaves,
+        target_forward_batch,
+        target_memory_pools,
+        target_logits_metadata,
+        draft_model_def,
+        draft_model_state_def,
+        draft_all_leaves,
+        draft_forward_batch,
+        all_memory_pools,
+        draft_logits_metadata,
+        previous_verified_id,
+        previous_token_list,
+        *,
+        num_layers,
+        speculative_num_steps,
+        speculative_num_draft_tokens,
+        return_target_logits,
+        return_target_hidden,
+    ):
+        target_bs = target_forward_batch.seq_lens.shape[0]
+        (
+            draft_tokens,
+            positions,
+            retrive_index_flat,
+            retrive_next_token_flat,
+            retrive_next_sibling_flat,
+        ) = _build_topk1_chain_verify_inputs_device_tuple(
+            verified_id=previous_verified_id,
+            token_list=previous_token_list,
+            seq_lens=target_forward_batch.seq_lens,
+            num_verify_tokens=speculative_num_draft_tokens,
+            batch_size=target_bs,
+        )
+        retrive_index = retrive_index_flat.reshape(target_bs, speculative_num_draft_tokens)
+        retrive_next_token = retrive_next_token_flat.reshape(
+            target_bs, speculative_num_draft_tokens
+        )
+        retrive_next_sibling = retrive_next_sibling_flat.reshape(
+            target_bs, speculative_num_draft_tokens
+        )
+
+        target_forward_batch.input_ids = draft_tokens
+        target_forward_batch.positions = positions
+        target_forward_batch.spec_info.draft_token = draft_tokens
+        target_forward_batch.spec_info.positions = positions
+        target_forward_batch.spec_info.retrive_index = retrive_index
+        target_forward_batch.spec_info.retrive_next_token = retrive_next_token
+        target_forward_batch.spec_info.retrive_next_sibling = retrive_next_sibling
+
+        target_state = jax.tree_util.tree_unflatten(target_model_state_def, target_leaves)
+        target_model = nnx.merge(target_model_def, target_state)
+        target_output, target_pool_updates, _, _ = target_model(
+            target_forward_batch,
+            target_memory_pools,
+            target_logits_metadata,
+        )
+
+        sh = jax.typeof(target_output.next_token_logits).sharding
+        mesh = sh.mesh if isinstance(sh, NamedSharding) else None
+        target_logits = target_output.next_token_logits
+        target_hidden = target_output.hidden_states
+        target_predict = jnp.argmax(target_logits, axis=-1).astype(jnp.int32).reshape(-1)
+
+        prepared = _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
+            target_hidden=target_hidden,
+            positions=target_forward_batch.positions,
+            seq_lens=target_forward_batch.seq_lens,
+            draft_tokens=draft_tokens,
+            target_predict=target_predict,
+            speculative_num_steps=speculative_num_steps,
+            speculative_num_draft_tokens=speculative_num_draft_tokens,
+        )
+
+        all_topk_index = []
+        all_pool_updates = []
+        layer0_hidden = None
+        input_ids = prepared.verified_id
+
+        draft_forward_batch.positions = prepared.positions
+        draft_forward_batch.spec_info.hidden_states = prepared.hidden_states
+        draft_forward_batch.spec_info.accept_length = prepared.accept_lens
+        draft_logits_metadata.accept_lens = prepared.accept_lens
+
+        for i in range(num_layers):
+            state = jax.tree_util.tree_unflatten(draft_model_state_def, draft_all_leaves[i])
+            model = nnx.merge(draft_model_def, state)
+
+            draft_forward_batch.spec_info.hidden_states = prepared.hidden_states
+            draft_forward_batch.input_ids = input_ids
+
+            output, pool_updates, _, _ = model(
+                draft_forward_batch, all_memory_pools[i], draft_logits_metadata
+            )
+            all_pool_updates.append(pool_updates)
+
+            sh = jax.typeof(output.next_token_logits).sharding
+            mesh = sh.mesh if isinstance(sh, NamedSharding) else mesh
+            topk_idx = _topk1_index_from_logits(output.next_token_logits)
+            rep_hidden = output.hidden_states
+
+            if i == 0:
+                layer0_hidden = rep_hidden
+
+            all_topk_index.append(topk_idx)
+
+            if i < num_layers - 1:
+                input_ids = _device_rotate_input_ids(
+                    input_ids,
+                    draft_forward_batch.extend_seq_lens,
+                    prepared.sel_pos,
+                    topk_idx[:, 0],
+                )
+
+        stacked_idx = jnp.stack(all_topk_index, axis=1)
+        selected_layer0_hidden = _gather_rows_preserve_sharding(
+            layer0_hidden, prepared.select_index
+        )
+        target_logits_for_host = target_logits if return_target_logits else None
+        target_hidden_for_host = target_hidden if return_target_hidden else None
+        if mesh is not None:
+            rep = NamedSharding(mesh, P())
+            selected_layer0_hidden = jax.sharding.reshard(selected_layer0_hidden, rep)
+            stacked_idx = jax.sharding.reshard(stacked_idx, rep)
+            prepared_accept_lens = jax.sharding.reshard(prepared.accept_lens, rep)
+            prepared_predict = jax.sharding.reshard(prepared.predict, rep)
+            if return_target_logits:
+                target_logits_for_host = jax.sharding.reshard(target_logits, rep)
+            if return_target_hidden:
+                target_hidden_for_host = jax.sharding.reshard(target_hidden, rep)
+        else:
+            prepared_accept_lens = prepared.accept_lens
+            prepared_predict = prepared.predict
+
+        return (
+            selected_layer0_hidden,
+            stacked_idx,
+            target_pool_updates,
+            tuple(all_pool_updates),
+            prepared_accept_lens,
+            prepared_predict,
+            target_logits_for_host,
+            target_hidden_for_host,
+        )
+
+    return fused_greedy_decode
+
+
+def _prepare_topk1_verify_placeholders_from_draft_state(draft_worker, model_worker_batch):
+    """Prepare fixed-shape verify placeholders while keeping chain build inside JIT."""
+    from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode
+    from sgl_jax.srt.speculative.eagle_util import EagleVerifyInput
+
+    draft_worker.padding_for_decode(model_worker_batch)
+    draft_input = model_worker_batch.spec_info_padded
+    previous_verified_id = draft_input.verified_id
+    if isinstance(previous_verified_id, np.ndarray):
+        previous_verified_id = np.asarray(previous_verified_id, dtype=np.int32)
+    previous_token_list = draft_input.topk_index[:, :, 0]
+    if isinstance(previous_token_list, np.ndarray):
+        previous_token_list = np.asarray(previous_token_list, dtype=np.int32)
+    else:
+        previous_token_list = previous_token_list.astype(jnp.int32)
+
+    bs = model_worker_batch.seq_lens.shape[0]
+    n = draft_worker.speculative_num_draft_tokens
+    flat = bs * n
+    model_worker_batch.spec_info_padded = EagleVerifyInput(
+        draft_token=np.zeros((flat,), dtype=np.int32),
+        custom_mask=None,
+        positions=np.zeros((flat,), dtype=np.int32),
+        retrive_index=np.zeros((bs, n), dtype=np.int32),
+        retrive_next_token=np.zeros((bs, n), dtype=np.int32),
+        retrive_next_sibling=np.zeros((bs, n), dtype=np.int32),
+        retrive_cum_len=None,
+        spec_steps=draft_worker.speculative_num_steps,
+        topk=draft_worker.topk,
+        draft_token_num=draft_worker.speculative_num_draft_tokens,
+        capture_hidden_mode=CaptureHiddenMode.LAST,
+        seq_lens_sum=model_worker_batch.seq_lens_sum,
+        seq_lens_cpu=model_worker_batch.seq_lens,
+    )
+    return previous_verified_id, previous_token_list
+
+
+def _device_array_preserve_device(value, sharding):
+    from sgl_jax.srt.utils.jax_utils import device_array
+
+    if value is None:
+        return None
+    if isinstance(value, jax.Array):
+        return jax.device_put(value, sharding)
+    return device_array(value, sharding=sharding)
+
+
+def _logits_metadata_from_model_worker_batch_preserve_device(
+    batch, mesh, *, include_accept_lens: bool = True
+):
+    from sgl_jax.srt.layers.logits_processor import LogitsMetadata
+
+    sharding = NamedSharding(mesh, P("data"))
+    spec_info = batch.spec_info_padded
+    accept_lens = (
+        getattr(spec_info, "accept_length", None)
+        if include_accept_lens and batch.forward_mode.is_draft_extend() and spec_info is not None
+        else None
+    )
+    return LogitsMetadata(
+        forward_mode=batch.forward_mode,
+        capture_hidden_mode=batch.capture_hidden_mode,
+        extend_return_logprob=False,
+        extend_return_top_logprob=False,
+        extend_token_ids_logprob=False,
+        extend_seq_lens=_device_array_preserve_device(batch.extend_seq_lens, sharding),
+        logits_indices=_device_array_preserve_device(batch.logits_indices, sharding),
+        accept_lens=_device_array_preserve_device(accept_lens, sharding),
+        extend_seq_lens_cpu=None,
+        extend_logprob_start_lens_cpu=None,
+        extend_logprob_pruned_lens_cpu=None,
+        top_logprobs_nums=getattr(batch, "top_logprobs_nums", None),
+        token_ids_logprobs=getattr(batch, "token_ids_logprobs", None),
+        extend_input_logprob_token_ids_device=_device_array_preserve_device(
+            getattr(batch, "extend_input_logprob_token_ids", None), sharding
+        ),
+    )
+
+
+def _forward_batch_init_new_preserve_device(batch, model_runner):
+    from sgl_jax.srt.eplb.expert_location import get_global_expert_location_metadata
+    from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+
+    data_sharding = NamedSharding(model_runner.mesh, P("data"))
+    replicated_2d = NamedSharding(model_runner.mesh, P(None, None))
+
+    input_embedding = _device_array_preserve_device(batch.input_embedding, replicated_2d)
+    if input_embedding is not None:
+        input_embedding = input_embedding.astype(jnp.bfloat16)
+
+    deepstack_visual_embedding = None
+    if getattr(batch, "apply_for_deepstack", False):
+        deepstack_visual_embedding = _device_array_preserve_device(
+            batch.deepstack_visual_embedding, replicated_2d
+        )
+        if deepstack_visual_embedding is not None:
+            deepstack_visual_embedding = deepstack_visual_embedding.astype(jnp.bfloat16)
+
+    if batch.lora_scalings is not None:
+        lora_scalings = _device_array_preserve_device(batch.lora_scalings, data_sharding)
+        lora_token_indices = _device_array_preserve_device(batch.lora_token_indices, data_sharding)
+        lora_ranks = _device_array_preserve_device(batch.lora_ranks, data_sharding)
+    else:
+        lora_scalings = batch.lora_scalings
+        lora_token_indices = batch.lora_token_indices
+        lora_ranks = batch.lora_ranks
+
+    return ForwardBatch(
+        bid=batch.bid,
+        forward_mode=batch.forward_mode,
+        batch_size=len(batch.seq_lens),
+        input_ids=_device_array_preserve_device(batch.input_ids, data_sharding),
+        seq_lens=_device_array_preserve_device(batch.seq_lens, data_sharding),
+        out_cache_loc=_device_array_preserve_device(batch.out_cache_loc, data_sharding),
+        positions=_device_array_preserve_device(batch.positions, data_sharding),
+        mrope_positions=_device_array_preserve_device(batch.mrope_positions, replicated_2d),
+        req_pool_indices=_device_array_preserve_device(batch.req_pool_indices, data_sharding),
+        cache_loc=_device_array_preserve_device(batch.cache_loc, data_sharding),
+        extend_prefix_lens=_device_array_preserve_device(batch.extend_prefix_lens, data_sharding),
+        extend_seq_lens=_device_array_preserve_device(batch.extend_seq_lens, data_sharding),
+        lora_ids=batch.lora_ids,
+        lora_scalings=lora_scalings,
+        lora_token_indices=lora_token_indices,
+        lora_ranks=lora_ranks,
+        attn_backend=model_runner.attn_backend,
+        spec_info=batch.spec_info_padded,
+        spec_algorithm=batch.spec_algorithm,
+        capture_hidden_mode=batch.capture_hidden_mode,
+        input_embedding=input_embedding,
+        apply_for_deepstack=batch.apply_for_deepstack,
+        deepstack_visual_embedding=deepstack_visual_embedding,
+        expert_location_metadata=get_global_expert_location_metadata(),
+        recurrent_indices=_device_array_preserve_device(batch.recurrent_indices, data_sharding),
+    )
 
 
 def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output):
@@ -172,10 +609,6 @@ def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output
     assert (accept_host[sel] >= 1).all(), f"accept_length < 1: {accept_host[sel]}"
     sel_pos = np.clip(accept_host - 1, 0, None).astype(np.int32)
 
-    # --- Host preparation (all done before single jit call) ---
-
-    # Build ONE ForwardBatch and reuse for all layers. All workers share the
-    # same mwb so forward_metadata is identical; only memory_pools/weights differ.
     mr0 = draft_worker._workers[0].model_runner
     mwb.spec_info_padded.hidden_states = target_hidden
     mr0.attn_backend.forward_metadata = mr0.attn_backend.get_eagle_forward_metadata(mwb)
@@ -191,53 +624,260 @@ def draft_extend_for_decode_fused(draft_worker, model_worker_batch, batch_output
 
     sel_pos_device = jax.device_put(sel_pos, NamedSharding(draft_worker.mesh, P("data")))
 
-    # --- Build / get cached fused jit ---
     if not hasattr(draft_worker, "_fused_jit_fn"):
         draft_worker._fused_jit_fn = _build_fused_draft_extend_jit(
             num_layers=draft_worker.speculative_num_steps,
             topk=draft_worker.topk,
         )
 
-    # --- Single jit call: all N layers fused ---
-    # Model internals use P() with implicit mesh; need use_mesh context
-    try:
-        ctx = jax.sharding.use_mesh(draft_worker.mesh)
-    except AttributeError:
-        try:
-            ctx = jax.set_mesh(draft_worker.mesh)
-        except AttributeError:
-            ctx = draft_worker.mesh
-    with ctx:
-        layer0_hidden, topk_p_stacked, topk_index_stacked, all_pool_updates = (
-            draft_worker._fused_jit_fn(
-                mr0._model_def,
-                mr0._model_state_def,
-                tuple(all_leaves),
-                shared_fb,
-                tuple(all_memory_pools),
-                logits_metadata,
-                target_hidden,
-                sel_pos_device,
-                num_layers=draft_worker.speculative_num_steps,
-            )
+    with jax.set_mesh(draft_worker.mesh):
+        selected_layer0_hidden, topk_index_stacked, all_pool_updates = draft_worker._fused_jit_fn(
+            mr0._model_def,
+            mr0._model_state_def,
+            tuple(all_leaves),
+            shared_fb,
+            tuple(all_memory_pools),
+            logits_metadata,
+            target_hidden,
+            sel_pos_device,
+            num_layers=draft_worker.speculative_num_steps,
         )
 
-    # --- Host post-processing: replace memory pools + assemble outputs ---
     for i, w in enumerate(draft_worker._workers):
         w.model_runner.memory_pools.replace_all(all_pool_updates[i])
 
-    select_index = sel * (draft_worker.speculative_num_steps + 1) + accept_host[sel] - 1
     verified_id_arr = batch_output.next_draft_input.verified_id
     if hasattr(verified_id_arr, "copy_to_host_async"):
         jax.copy_to_host_async(verified_id_arr)
 
-    jax.copy_to_host_async(layer0_hidden)
-    jax.copy_to_host_async(topk_p_stacked)
+    jax.copy_to_host_async(selected_layer0_hidden)
     jax.copy_to_host_async(topk_index_stacked)
 
-    batch_output.next_draft_input.hidden_states = np.asarray(layer0_hidden)[select_index]
-    batch_output.next_draft_input.topk_p = np.asarray(topk_p_stacked)[sel]
-    batch_output.next_draft_input.topk_index = np.asarray(topk_index_stacked)[sel]
+    batch_output.next_draft_input.hidden_states = np.asarray(selected_layer0_hidden)[sel]
+    topk_index = np.asarray(topk_index_stacked)[sel]
+    batch_output.next_draft_input.topk_p = np.ones(topk_index.shape, dtype=np.float32)
+    batch_output.next_draft_input.topk_index = topk_index
+    select_index = sel * (draft_worker.speculative_num_steps + 1) + accept_host[sel] - 1
     batch_output.next_draft_input.verified_id = np.asarray(verified_id_arr)[select_index]
     batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
     batch_output.accept_lens = accept_host
+
+
+def _prepare_model_worker_batch_for_draft_extend(draft_worker, model_worker_batch, batch_output):
+    from sgl_jax.srt.model_executor.forward_batch_info import (
+        CaptureHiddenMode,
+        ForwardMode,
+    )
+
+    model_worker_batch.spec_info_padded = batch_output.next_draft_input
+    sel = model_worker_batch.logits_indices_selector
+    model_worker_batch.seq_lens[sel] = (
+        model_worker_batch.seq_lens[sel] + draft_worker.speculative_num_draft_tokens - 1
+    )
+
+    bs = batch_output.accept_lens.shape[0]
+    step_plus_1 = batch_output.next_draft_input.verified_id.shape[0] // bs
+    model_worker_batch.extend_seq_lens = np.zeros((bs,), dtype=np.int32)
+    model_worker_batch.extend_seq_lens[sel] = step_plus_1
+
+    dp = model_worker_batch.dp_size
+    per_dp = model_worker_batch.per_dp_bs_size if dp > 1 else bs
+    model_worker_batch.logits_indices = (
+        model_worker_batch.extend_seq_lens.reshape(dp, per_dp)
+        .cumsum(axis=1, dtype=np.int32)
+        .ravel()
+        - 1
+    )
+    model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
+    model_worker_batch.spec_info_padded.capture_hidden_mode = CaptureHiddenMode.FULL
+    model_worker_batch.forward_mode = ForwardMode.DRAFT_EXTEND
+    model_worker_batch.spec_info_padded.hidden_states = batch_output.logits_output.hidden_states
+    model_worker_batch.spec_info_padded.accept_length = None
+    model_worker_batch.input_ids = batch_output.next_draft_input.verified_id
+
+    forward_metadata = draft_worker.draft_model_runner.attn_backend.get_eagle_forward_metadata(
+        model_worker_batch
+    )
+    draft_worker.draft_model_runner.attn_backend.forward_metadata = forward_metadata
+    logits_metadata = _logits_metadata_from_model_worker_batch_preserve_device(
+        model_worker_batch, draft_worker.mesh, include_accept_lens=False
+    )
+    return model_worker_batch, logits_metadata
+
+
+def _materialize_fused_greedy_batch_output_for_scheduler(
+    *,
+    batch_output,
+    selector,
+    real_bs,
+    seq_lens_host,
+    layer0_hidden,
+    topk_index_stacked,
+    accept_lens_device,
+    predict_device,
+    speculative_num_draft_tokens,
+    target_logits,
+    target_hidden,
+):
+    """Materialize the scheduler-facing fields after the single fused decode JIT."""
+    from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
+
+    with jax.profiler.TraceAnnotation("fused_greedy_batch_output_d2h"):
+        jax.copy_to_host_async(layer0_hidden)
+        jax.copy_to_host_async(topk_index_stacked)
+        jax.copy_to_host_async(accept_lens_device)
+        jax.copy_to_host_async(predict_device)
+
+        batch_output.logits_output = LogitsProcessorOutput(
+            next_token_logits=target_logits,
+            hidden_states=target_hidden,
+        )
+        batch_output.next_draft_input.hidden_states = np.asarray(layer0_hidden)[selector]
+        topk_index = np.asarray(topk_index_stacked)[selector]
+        batch_output.next_draft_input.topk_p = np.ones(topk_index.shape, dtype=np.float32)
+        batch_output.next_draft_input.topk_index = topk_index
+        accept_lens = np.asarray(accept_lens_device)
+        predict = np.asarray(predict_device)
+        seq_lens_host = np.asarray(seq_lens_host)
+        verified_pos = selector * speculative_num_draft_tokens + accept_lens[selector] - 1
+        batch_output.next_draft_input.verified_id = predict[verified_pos]
+        original_seq_lens = seq_lens_host[selector] - speculative_num_draft_tokens + 1
+        batch_output.next_draft_input.new_seq_lens = original_seq_lens + accept_lens[selector]
+        batch_output.allocate_lens = batch_output.allocate_lens[:real_bs]
+        batch_output.accept_lens = accept_lens
+        batch_output.next_token_ids = predict
+        return batch_output
+
+
+def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
+    """Run one fused speculative decode round."""
+    from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
+    from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+    from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
+
+    draft_worker = spec_worker.draft_worker
+    target_worker = spec_worker.target_worker
+    target_mr = target_worker.model_runner
+    previous_verified_id, previous_token_list = _prepare_topk1_verify_placeholders_from_draft_state(
+        draft_worker, model_worker_batch
+    )
+    spec_info = model_worker_batch.spec_info_padded
+    return_target_logits = bool(
+        getattr(model_worker_batch, "return_logprob", False)
+        or getattr(model_worker_batch, "return_output_logprob_only", False)
+    )
+    return_target_hidden = bool(getattr(model_worker_batch, "return_hidden_states", False))
+
+    spec_info.allocate_lens = cur_allocate_lens
+    spec_info.prepare_for_verify(model_worker_batch, spec_worker.page_size, target_worker)
+    target_mr.attn_backend.forward_metadata = target_mr.attn_backend.get_eagle_forward_metadata(
+        model_worker_batch
+    )
+    target_forward_batch = _forward_batch_init_new_preserve_device(model_worker_batch, target_mr)
+    target_forward_batch.bid = model_worker_batch.bid
+    target_logits_metadata = _logits_metadata_from_model_worker_batch_preserve_device(
+        model_worker_batch, spec_worker.mesh
+    )
+
+    hidden_size = target_worker.model_config.hidden_size
+    placeholder_hidden = np.zeros((spec_info.draft_token.shape[0], hidden_size), dtype=np.float32)
+    placeholder_logits = np.zeros((spec_info.draft_token.shape[0], 1), dtype=np.float32)
+
+    next_draft_input = EagleDraftInput(
+        verified_id=spec_info.draft_token,
+        new_seq_lens=model_worker_batch.seq_lens,
+        allocate_lens=cur_allocate_lens,
+        hidden_states=placeholder_hidden,
+    )
+    next_draft_input.draft_token = spec_info.draft_token
+    next_draft_input.retrive_index = spec_info.retrive_index
+    next_draft_input.retrive_next_token = spec_info.retrive_next_token
+    next_draft_input.retrive_next_sibling = spec_info.retrive_next_sibling
+    batch_output = GenerationBatchResult(
+        logits_output=LogitsProcessorOutput(
+            next_token_logits=placeholder_logits,
+            hidden_states=placeholder_hidden,
+        ),
+        next_token_ids=spec_info.draft_token,
+        next_draft_input=next_draft_input,
+        accept_lens=np.ones(model_worker_batch.seq_lens.shape, dtype=np.int32),
+        allocate_lens=cur_allocate_lens,
+        bid=model_worker_batch.bid,
+        cache_miss_count=0,
+        extend_input_len_per_req=None,
+        extend_logprob_start_len_per_req=None,
+    )
+    model_worker_batch.spec_info_padded = next_draft_input
+
+    draft_mwb, draft_logits_metadata = _prepare_model_worker_batch_for_draft_extend(
+        draft_worker, model_worker_batch, batch_output
+    )
+    if draft_mwb.input_ids.shape[0] <= 0:
+        return batch_output
+
+    draft_mr0 = draft_worker._workers[0].model_runner
+    draft_forward_batch = _forward_batch_init_new_preserve_device(draft_mwb, draft_mr0)
+    draft_forward_batch.bid = model_worker_batch.bid
+
+    all_memory_pools = []
+    all_leaves = []
+    for w in draft_worker._workers:
+        mr = w.model_runner
+        all_memory_pools.append(mr.memory_pools)
+        all_leaves.append(tuple(mr.model_state_leaves))
+
+    if not hasattr(draft_worker, "_fused_greedy_decode_jit_fn"):
+        draft_worker._fused_greedy_decode_jit_fn = _build_fused_greedy_decode_jit(
+            num_layers=draft_worker.speculative_num_steps,
+            topk=draft_worker.topk,
+        )
+
+    with jax.set_mesh(draft_worker.mesh):
+        (
+            layer0_hidden,
+            topk_index_stacked,
+            target_pool_updates,
+            all_pool_updates,
+            accept_lens_device,
+            predict_device,
+            target_logits,
+            target_hidden,
+        ) = draft_worker._fused_greedy_decode_jit_fn(
+            target_mr._model_def,
+            target_mr._model_state_def,
+            tuple(target_mr.model_state_leaves),
+            target_forward_batch,
+            target_mr.memory_pools,
+            target_logits_metadata,
+            draft_mr0._model_def,
+            draft_mr0._model_state_def,
+            tuple(all_leaves),
+            draft_forward_batch,
+            tuple(all_memory_pools),
+            draft_logits_metadata,
+            previous_verified_id,
+            previous_token_list,
+            num_layers=draft_worker.speculative_num_steps,
+            speculative_num_steps=draft_worker.speculative_num_steps,
+            speculative_num_draft_tokens=draft_worker.speculative_num_draft_tokens,
+            return_target_logits=return_target_logits,
+            return_target_hidden=return_target_hidden,
+        )
+
+    target_mr.memory_pools.replace_all(target_pool_updates)
+    for i, w in enumerate(draft_worker._workers):
+        w.model_runner.memory_pools.replace_all(all_pool_updates[i])
+
+    return _materialize_fused_greedy_batch_output_for_scheduler(
+        batch_output=batch_output,
+        selector=np.asarray(model_worker_batch.logits_indices_selector),
+        real_bs=model_worker_batch.real_bs,
+        seq_lens_host=model_worker_batch.seq_lens,
+        layer0_hidden=layer0_hidden,
+        topk_index_stacked=topk_index_stacked,
+        accept_lens_device=accept_lens_device,
+        predict_device=predict_device,
+        speculative_num_draft_tokens=draft_worker.speculative_num_draft_tokens,
+        target_logits=target_logits,
+        target_hidden=target_hidden,
+    )

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-import os
 from functools import partial
 from typing import NamedTuple
 
@@ -13,46 +11,6 @@ import numpy as np
 from flax import nnx
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
-
-# step0-gap instrument: per-step conditional hit accumulator (gated)
-_SH = {"uncond": None, "cond": None, "n": 0, "on": os.path.exists("/tmp/p2a-stephit")}
-_DUMP = {
-    "on": os.path.exists("/tmp/p2a-dext-dump"),
-    "dir": "/tmp/dext-dump",
-    "k": 0,
-}
-
-
-def _log_step_hit(draft_2d, predict_2d, sel):
-    """draft_2d/predict_2d: (padded_bs, n) host int32; sel: real-req indices."""
-    if not _SH["on"]:
-        return
-    d, t = draft_2d[sel], predict_2d[sel]
-    hit = d[:, 1:] == t[:, :-1]
-    cond = np.cumprod(hit, axis=1)
-    if _SH["uncond"] is None:
-        _SH["uncond"] = np.zeros(hit.shape[1], dtype=np.int64)
-        _SH["cond"] = np.zeros(hit.shape[1], dtype=np.int64)
-    _SH["uncond"] += hit.sum(0)
-    _SH["cond"] += cond.sum(0)
-    _SH["n"] += len(sel)
-    if _SH["n"] % 200 < len(sel):
-        n = _SH["n"]
-        logging.getLogger(__name__).info(
-            "[stephit] n=%d uncond=%s cond=%s E[accept]=%.3f",
-            n,
-            (_SH["uncond"] / n).round(3).tolist(),
-            (_SH["cond"] / n).round(3).tolist(),
-            1.0 + (_SH["cond"] / n).sum(),
-        )
-
-
-def _dump_dext_round(tag, **arrays):
-    if not _DUMP["on"]:
-        return
-    os.makedirs(_DUMP["dir"], exist_ok=True)
-    np.savez(f"{_DUMP['dir']}/{tag}-r{_DUMP['k']:04d}.npz", **arrays)
-    _DUMP["k"] += 1
 
 
 class SpecChainState(NamedTuple):
@@ -845,9 +803,6 @@ def _materialize_fused_greedy_batch_output_for_scheduler(
     """Materialize the scheduler-facing fields after the single fused decode JIT."""
     from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
 
-    import os as _os
-
-    _DBG = _os.path.exists("/tmp/p2a-dbg-retract")
     with jax.profiler.TraceAnnotation("fused_greedy_batch_output_d2h"):
         jax.copy_to_host_async(layer0_hidden)
         jax.copy_to_host_async(topk_index_stacked)
@@ -858,17 +813,7 @@ def _materialize_fused_greedy_batch_output_for_scheduler(
             next_token_logits=target_logits,
             hidden_states=target_hidden,
         )
-        if _DBG:
-            _lg = logging.getLogger(__name__)
-            _lg.info(
-                "DBGRT mat.d2h.pre l0h.sh=%s acc.sh=%s pred.sh=%s",
-                getattr(layer0_hidden, "sharding", None),
-                getattr(accept_lens_device, "sharding", None),
-                getattr(predict_device, "sharding", None),
-            )
         batch_output.next_draft_input.hidden_states = np.asarray(layer0_hidden)[selector]
-        if _DBG:
-            _lg.info("DBGRT mat.d2h.post")
         topk_index = np.asarray(topk_index_stacked)[selector]
         batch_output.next_draft_input.topk_p = np.ones(topk_index.shape, dtype=np.float32)
         batch_output.next_draft_input.topk_index = topk_index
@@ -1056,13 +1001,6 @@ def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
             target_logits=target_logits,
             target_hidden=target_hidden,
         )
-        if _SH["on"]:
-            padded_bs = result.accept_lens.shape[0]
-            prev_vid = np.asarray(previous_verified_id, dtype=np.int32).reshape(padded_bs, 1)
-            prev_tl = np.asarray(previous_token_list, dtype=np.int32)[:, : n_draft - 1]
-            draft_2d = np.concatenate([prev_vid, prev_tl], axis=1)
-            predict_2d = np.asarray(result.next_token_ids).reshape(padded_bs, n_draft)
-            _log_step_hit(draft_2d, predict_2d, selector)
         return result
 
     pending = SpecDecodePending(

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from functools import partial
 from typing import NamedTuple
 
@@ -11,6 +13,46 @@ import numpy as np
 from flax import nnx
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
+
+# step0-gap instrument: per-step conditional hit accumulator (gated)
+_SH = {"uncond": None, "cond": None, "n": 0, "on": os.path.exists("/tmp/p2a-stephit")}
+_DUMP = {
+    "on": os.path.exists("/tmp/p2a-dext-dump"),
+    "dir": "/tmp/dext-dump",
+    "k": 0,
+}
+
+
+def _log_step_hit(draft_2d, predict_2d, sel):
+    """draft_2d/predict_2d: (padded_bs, n) host int32; sel: real-req indices."""
+    if not _SH["on"]:
+        return
+    d, t = draft_2d[sel], predict_2d[sel]
+    hit = d[:, 1:] == t[:, :-1]
+    cond = np.cumprod(hit, axis=1)
+    if _SH["uncond"] is None:
+        _SH["uncond"] = np.zeros(hit.shape[1], dtype=np.int64)
+        _SH["cond"] = np.zeros(hit.shape[1], dtype=np.int64)
+    _SH["uncond"] += hit.sum(0)
+    _SH["cond"] += cond.sum(0)
+    _SH["n"] += len(sel)
+    if _SH["n"] % 200 < len(sel):
+        n = _SH["n"]
+        logging.getLogger(__name__).info(
+            "[stephit] n=%d uncond=%s cond=%s E[accept]=%.3f",
+            n,
+            (_SH["uncond"] / n).round(3).tolist(),
+            (_SH["cond"] / n).round(3).tolist(),
+            1.0 + (_SH["cond"] / n).sum(),
+        )
+
+
+def _dump_dext_round(tag, **arrays):
+    if not _DUMP["on"]:
+        return
+    os.makedirs(_DUMP["dir"], exist_ok=True)
+    np.savez(f"{_DUMP['dir']}/{tag}-r{_DUMP['k']:04d}.npz", **arrays)
+    _DUMP["k"] += 1
 
 
 class GreedyDraftInputs(NamedTuple):
@@ -868,9 +910,10 @@ def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
     for i, w in enumerate(draft_worker._workers):
         w.model_runner.memory_pools.replace_all(all_pool_updates[i])
 
-    return _materialize_fused_greedy_batch_output_for_scheduler(
+    selector = np.asarray(model_worker_batch.logits_indices_selector)
+    result = _materialize_fused_greedy_batch_output_for_scheduler(
         batch_output=batch_output,
-        selector=np.asarray(model_worker_batch.logits_indices_selector),
+        selector=selector,
         real_bs=model_worker_batch.real_bs,
         seq_lens_host=model_worker_batch.seq_lens,
         layer0_hidden=layer0_hidden,
@@ -881,3 +924,22 @@ def spec_decode(spec_worker, model_worker_batch, cur_allocate_lens):
         target_logits=target_logits,
         target_hidden=target_hidden,
     )
+    if _SH["on"] or _DUMP["on"]:
+        n = draft_worker.speculative_num_draft_tokens
+        padded_bs = result.accept_lens.shape[0]
+        prev_vid = np.asarray(previous_verified_id, dtype=np.int32).reshape(padded_bs, 1)
+        prev_tl = np.asarray(previous_token_list, dtype=np.int32)[:, : n - 1]
+        draft_2d = np.concatenate([prev_vid, prev_tl], axis=1)
+        predict_2d = np.asarray(result.next_token_ids).reshape(padded_bs, n)
+        _log_step_hit(draft_2d, predict_2d, selector)
+        if _DUMP["on"]:
+            _dump_dext_round(
+                "spec",
+                draft=draft_2d[selector],
+                predict=predict_2d[selector],
+                accept=result.accept_lens[selector],
+                topk_next=result.next_draft_input.topk_index,  # (real_bs, num_layers, 1)
+                verified_next=result.next_draft_input.verified_id,
+                l0_hidden8=result.next_draft_input.hidden_states[:, :8],
+            )
+    return result

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -845,6 +845,9 @@ def _materialize_fused_greedy_batch_output_for_scheduler(
     """Materialize the scheduler-facing fields after the single fused decode JIT."""
     from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
 
+    import os as _os
+
+    _DBG = _os.path.exists("/tmp/p2a-dbg-retract")
     with jax.profiler.TraceAnnotation("fused_greedy_batch_output_d2h"):
         jax.copy_to_host_async(layer0_hidden)
         jax.copy_to_host_async(topk_index_stacked)
@@ -855,7 +858,17 @@ def _materialize_fused_greedy_batch_output_for_scheduler(
             next_token_logits=target_logits,
             hidden_states=target_hidden,
         )
+        if _DBG:
+            _lg = logging.getLogger(__name__)
+            _lg.info(
+                "DBGRT mat.d2h.pre l0h.sh=%s acc.sh=%s pred.sh=%s",
+                getattr(layer0_hidden, "sharding", None),
+                getattr(accept_lens_device, "sharding", None),
+                getattr(predict_device, "sharding", None),
+            )
         batch_output.next_draft_input.hidden_states = np.asarray(layer0_hidden)[selector]
+        if _DBG:
+            _lg.info("DBGRT mat.d2h.post")
         topk_index = np.asarray(topk_index_stacked)[selector]
         batch_output.next_draft_input.topk_p = np.ones(topk_index.shape, dtype=np.float32)
         batch_output.next_draft_input.topk_index = topk_index

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -21,6 +21,7 @@ from sgl_jax.srt.speculative.eagle_util import (
     EagleDraftInput,
     EagleVerifyInput,
     build_chain_verify_inputs,
+    build_chain_verify_inputs_device,
     build_tree_kernel_efficient,
     build_tree_mask_for_draft_decode,
 )
@@ -140,18 +141,33 @@ class EagleDraftWorker(BaseDraftWorker):
         bs = model_worker_batch.seq_lens.shape[0]
 
         if self.topk == 1:
-            token_list_cpu = np.asarray(jax.device_get(token_list))
-            verified_id_cpu = np.asarray(
-                jax.device_get(model_worker_batch.spec_info_padded.verified_id)
-            )
-            seq_lens_cpu = np.asarray(verified_seq_lens)
             n = self.speculative_num_draft_tokens
-            packed_np = build_chain_verify_inputs(
-                verified_id_cpu, token_list_cpu, seq_lens_cpu, n, bs
-            )
-            # One allgather instead of five: pack into a single (5, bs*n) buffer,
-            # device_put once, then slice on device (replicated views are free).
-            packed = jax.device_put(packed_np, NamedSharding(self.mesh, P()))
+            verified_id = model_worker_batch.spec_info_padded.verified_id
+            if any(isinstance(x, jax.Array) for x in (verified_id, token_list, verified_seq_lens)):
+                rep = NamedSharding(self.mesh, P())
+                verified_id, token_list, verified_seq_lens = jax.device_put(
+                    (verified_id, token_list, verified_seq_lens),
+                    rep,
+                )
+                packed = build_chain_verify_inputs_device(
+                    verified_id, token_list, verified_seq_lens, n, bs
+                )
+                packed = jax.device_put(packed, rep)
+            else:
+                packed_np = build_chain_verify_inputs(
+                    np.asarray(verified_id, dtype=np.int32),
+                    np.asarray(token_list, dtype=np.int32),
+                    np.asarray(verified_seq_lens, dtype=np.int32),
+                    n,
+                    bs,
+                )
+                # One allgather instead of five: pack into a single (5, bs*n)
+                # buffer, device_put once, then slice on device.
+                packed = (
+                    jax.device_put(packed_np, NamedSharding(self.mesh, P()))
+                    if self.mesh is not None
+                    else packed_np
+                )
             draft_tokens = packed[0]
             position = packed[1]
             retrive_index = packed[2].reshape(bs, n)

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -20,6 +20,7 @@ from sgl_jax.srt.speculative.base_worker import BaseDraftWorker, replicate_to_me
 from sgl_jax.srt.speculative.eagle_util import (
     EagleDraftInput,
     EagleVerifyInput,
+    build_chain_verify_inputs,
     build_tree_kernel_efficient,
     build_tree_mask_for_draft_decode,
 )
@@ -136,29 +137,52 @@ class EagleDraftWorker(BaseDraftWorker):
         self.padding_for_decode(model_worker_batch)
         score_list, token_list, parents_list = self.draft_forward(model_worker_batch)
         verified_seq_lens = model_worker_batch.seq_lens - 1
-        max_seq_len = int(np.max(verified_seq_lens)) if verified_seq_lens.size > 0 else 1
-        max_context_len = self._pick_context_len(max_seq_len)
-        (
-            tree_mask,
-            position,
-            retrive_index,
-            retrive_next_token,
-            retrive_next_sibling,
-            draft_tokens,
-        ) = build_tree_kernel_efficient(
-            model_worker_batch.spec_info_padded.verified_id,
-            score_list,
-            token_list,
-            parents_list,
-            verified_seq_lens,
-            np.sum(verified_seq_lens),
-            self.topk,
-            self.speculative_num_draft_tokens,
-            max_context_len,
-            model_worker_batch.seq_lens.shape[0],
-            model_worker_batch.speculative_num_steps,
-            self.mesh,
-        )
+        bs = model_worker_batch.seq_lens.shape[0]
+
+        if self.topk == 1:
+            token_list_cpu = np.asarray(jax.device_get(token_list))
+            verified_id_cpu = np.asarray(
+                jax.device_get(model_worker_batch.spec_info_padded.verified_id)
+            )
+            seq_lens_cpu = np.asarray(verified_seq_lens)
+            n = self.speculative_num_draft_tokens
+            packed_np = build_chain_verify_inputs(
+                verified_id_cpu, token_list_cpu, seq_lens_cpu, n, bs
+            )
+            # One allgather instead of five: pack into a single (5, bs*n) buffer,
+            # device_put once, then slice on device (replicated views are free).
+            packed = jax.device_put(packed_np, NamedSharding(self.mesh, P()))
+            draft_tokens = packed[0]
+            position = packed[1]
+            retrive_index = packed[2].reshape(bs, n)
+            retrive_next_token = packed[3].reshape(bs, n)
+            retrive_next_sibling = packed[4].reshape(bs, n)
+            tree_mask = None
+        else:
+            max_seq_len = int(np.max(verified_seq_lens)) if verified_seq_lens.size > 0 else 1
+            max_context_len = self._pick_context_len(max_seq_len)
+            (
+                tree_mask,
+                position,
+                retrive_index,
+                retrive_next_token,
+                retrive_next_sibling,
+                draft_tokens,
+            ) = build_tree_kernel_efficient(
+                model_worker_batch.spec_info_padded.verified_id,
+                score_list,
+                token_list,
+                parents_list,
+                verified_seq_lens,
+                np.sum(verified_seq_lens),
+                self.topk,
+                self.speculative_num_draft_tokens,
+                max_context_len,
+                bs,
+                model_worker_batch.speculative_num_steps,
+                self.mesh,
+            )
+
         model_worker_batch.spec_info_padded = EagleVerifyInput(
             draft_token=draft_tokens,
             custom_mask=tree_mask,
@@ -255,7 +279,9 @@ class EagleDraftWorker(BaseDraftWorker):
             logits_metadata=logits_metadata,
         )
         sel = np.asarray(model_worker_batch.logits_indices_selector)
-        accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
+        if hasattr(batch_output.accept_lens, "copy_to_host_async"):
+            batch_output.accept_lens.copy_to_host_async()
+        accept_host = np.asarray(batch_output.accept_lens)
         select_index = sel * (self.speculative_num_steps + 1) + accept_host[sel] - 1
         rep_logits, rep_hidden = replicate_to_mesh(
             self.mesh, draft_logits_output.next_token_logits, draft_logits_output.hidden_states
@@ -478,42 +504,33 @@ class EagleDraftWorker(BaseDraftWorker):
         return 1 << (max_seq_len - 1).bit_length()
 
     def copy_model_worker_batch_to_cpu(self, model_worker_batch: ModelWorkerBatch):
-        model_worker_batch.input_ids = np.array(
-            jax.device_get(model_worker_batch.input_ids), dtype=model_worker_batch.input_ids.dtype
-        )
-        model_worker_batch.seq_lens = np.array(
-            jax.device_get(model_worker_batch.seq_lens), dtype=model_worker_batch.seq_lens.dtype
-        )
-        model_worker_batch.out_cache_loc = np.array(
-            jax.device_get(model_worker_batch.out_cache_loc),
-            dtype=model_worker_batch.out_cache_loc.dtype,
-        )
-        model_worker_batch.positions = np.array(
-            jax.device_get(model_worker_batch.positions), dtype=model_worker_batch.positions.dtype
-        )
-        model_worker_batch.req_pool_indices = np.array(
-            jax.device_get(model_worker_batch.req_pool_indices),
-            dtype=model_worker_batch.req_pool_indices.dtype,
-        )
-        model_worker_batch.cache_loc = np.array(
-            jax.device_get(model_worker_batch.cache_loc), dtype=model_worker_batch.cache_loc.dtype
-        )
-        model_worker_batch.extend_prefix_lens = (
-            np.array(
-                jax.device_get(model_worker_batch.extend_prefix_lens),
-                dtype=model_worker_batch.extend_prefix_lens.dtype,
-            )
-            if model_worker_batch.extend_prefix_lens is not None
-            else None
-        )
-        model_worker_batch.extend_seq_lens = (
-            np.array(
-                jax.device_get(model_worker_batch.extend_seq_lens),
-                dtype=model_worker_batch.extend_seq_lens.dtype,
-            )
-            if model_worker_batch.extend_seq_lens is not None
-            else None
-        )
+        mwb = model_worker_batch
+        fields = [
+            "input_ids",
+            "seq_lens",
+            "out_cache_loc",
+            "positions",
+            "req_pool_indices",
+            "cache_loc",
+        ]
+        optional = ["extend_prefix_lens", "extend_seq_lens"]
+
+        for name in fields:
+            arr = getattr(mwb, name)
+            if hasattr(arr, "copy_to_host_async"):
+                arr.copy_to_host_async()
+        for name in optional:
+            arr = getattr(mwb, name)
+            if arr is not None and hasattr(arr, "copy_to_host_async"):
+                arr.copy_to_host_async()
+
+        for name in fields:
+            arr = getattr(mwb, name)
+            setattr(mwb, name, np.asarray(arr))
+        for name in optional:
+            arr = getattr(mwb, name)
+            if arr is not None:
+                setattr(mwb, name, np.asarray(arr))
 
     def get_padding_bs(self, real_bs: int) -> int:
         self.precompile_bs_paddings.sort()

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -665,8 +665,11 @@ class EagleDraftInput:
                 continue
             bs_r = len(info.seq_lens)
             seq_r = np.asarray(info.seq_lens)
-            new_r = seq_r + self.ALLOC_LEN_PER_DECODE - 1
             old_r = self.allocate_lens[flat_off : flat_off + bs_r]
+            # Chain → fallback transition: chain prep used optimistic seq (+ndt)
+            # so old_r may already exceed seq+ndt-1. Clamp new_r ≥ old_r so
+            # ext_r ≥ 0 (already-allocated slots cover this round's verify).
+            new_r = np.maximum(seq_r + self.ALLOC_LEN_PER_DECODE - 1, old_r)
             ext_r = int((new_r - old_r).sum())
             if page_size == 1:
                 ocl_r = alloc_token_slots(schedule_batch.tree_cache, ext_r, dp_rank=dp_rank)

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -295,6 +295,51 @@ def build_tree_mask_for_draft_decode(
     return jnp.asarray(concatenated, dtype=jnp.int32)
 
 
+def build_chain_verify_inputs(
+    verified_id: np.ndarray,
+    token_list: np.ndarray,
+    seq_lens: np.ndarray,
+    num_verify_tokens: int,
+    batch_size: int,
+) -> np.ndarray:
+    """Build verify inputs for topk=1 (linear chain) without tree mask.
+
+    Returns a single ``(5, bs*n)`` int32 buffer packing all 5 outputs
+    [draft_tokens, positions, retrive_index, retrive_next_token,
+    retrive_next_sibling] so the caller can do **one** ``device_put``
+    instead of five — under multi-host setup each independent P() replicated
+    output triggers a separate allgather (~1.5ms each).
+
+    When topk=1 the draft tree is a simple chain, so causal attention is
+    equivalent to the tree mask.
+    """
+    n = num_verify_tokens
+    bs = batch_size
+    out = np.empty((5, bs * n), dtype=np.int32)
+
+    # row 0: draft_tokens (bs*n,)
+    out[0].reshape(bs, n)[:, 0] = verified_id
+    out[0].reshape(bs, n)[:, 1:] = token_list[:, : n - 1]
+
+    # row 1: positions (bs*n,) = seq_lens[bid] + tid
+    tid_range = np.arange(n, dtype=np.int32)
+    out[1] = (seq_lens.astype(np.int32)[:, None] + tid_range[None, :]).reshape(-1)
+
+    # row 2: retrive_index (bs, n) flattened: bid*n + tid
+    out[2] = np.arange(bs * n, dtype=np.int32)
+
+    # row 3: retrive_next_token (bs, n) flattened: chain → tid+1, last is -1
+    next_token_row = np.empty(n, dtype=np.int32)
+    next_token_row[: n - 1] = np.arange(1, n, dtype=np.int32)
+    next_token_row[n - 1] = -1
+    out[3] = np.broadcast_to(next_token_row, (bs, n)).reshape(-1)
+
+    # row 4: retrive_next_sibling: chain has no siblings, all -1
+    out[4].fill(-1)
+
+    return out
+
+
 def build_tree_kernel_efficient(
     verified_id: jax.Array,
     score_list: jax.Array,
@@ -649,12 +694,14 @@ class EagleDraftInput:
         dtype: np.dtype,
         topk: int,
         capture_hidden_mode: CaptureHiddenMode,
+        num_steps: int = 1,
     ):
+        topk_shape = (0, num_steps, topk) if num_steps > 1 else (0, topk)
         return cls(
             verified_id=np.empty((0,), dtype=np.int32),
             hidden_states=np.empty((0, hidden_size), dtype=dtype),
-            topk_p=np.empty((0, topk), dtype=np.float32),
-            topk_index=np.empty((0, topk), dtype=np.int32),
+            topk_p=np.empty(topk_shape, dtype=np.float32),
+            topk_index=np.empty(topk_shape, dtype=np.int32),
             capture_hidden_mode=capture_hidden_mode,
             accept_length=np.empty((0,), dtype=np.int32),
             accept_length_cpu=np.empty((0,), dtype=np.int32),
@@ -744,8 +791,8 @@ class EagleVerifyInput:
     #: device ``(b*draft_token_num,)`` — flattened draft tokens to verify.
     draft_token: jax.Array
     #: device ``(sum(q_i*kv_i),)`` — tree attention mask; shape participates
-    #: in the JIT cache key.
-    custom_mask: jax.Array
+    #: in the JIT cache key.  ``None`` when topk=1 (chain mode uses causal).
+    custom_mask: jax.Array | None
     #: device ``(b*draft_token_num,)`` — verify positions (follows
     #: ``ForwardBatch`` host/device convention).
     positions: jax.Array
@@ -996,9 +1043,12 @@ class EagleVerifyInput:
                 rng=rng,
             )
 
-        predict = np.asarray(jax.device_get(predict))
-        accept_index = np.asarray(jax.device_get(accept_index))
-        accept_length = np.asarray(jax.device_get(accept_length))
+        for arr in (predict, accept_index, accept_length):
+            if hasattr(arr, "copy_to_host_async"):
+                arr.copy_to_host_async()
+        predict = np.asarray(predict)
+        accept_index = np.asarray(accept_index)
+        accept_length = np.asarray(accept_length)
 
         accept_length = accept_length + 1
         accept_index = accept_index.flatten()

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -687,6 +687,8 @@ class EagleDraftInput:
             assign_req_to_token_pool(
                 info.req_pool_indices, schedule_batch.req_to_token_pool, old_r, new_r, ocl_r
             )
+            for j, req in enumerate(info.reqs):
+                req.kv_allocated_len = int(new_r[j])
             new_alloc_chunks.append(new_r)
             # Per-rank store (matches nospec extend); _get_spec_decode_mwb_dp
             # DP-segments these so each rank's P("data") shard = its own slots.

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -56,22 +56,22 @@ def _is_jax_leaf(value: Any) -> bool:
     return cls.__name__ == "Leaf" and cls.__module__.startswith("jax.")
 
 
-def _as_int32_array(value: Any, *, fallback: int = -1) -> jax.Array:
-    """Convert scalar-like inputs into scalar int32 JAX arrays."""
+def _as_int32_array(value: Any, *, fallback: int = -1) -> Any:
+    """Convert scalar-like metadata into int32 arrays without forcing device work."""
     if value is None:
         return None
     if isinstance(value, jax.Array):
         return value
     if isinstance(value, numpy.ndarray):
-        return jnp.asarray(value, dtype=jnp.int32)
+        return np.asarray(value, dtype=np.int32)
     if isinstance(value, (int, numpy.integer)):
-        return jnp.asarray(int(value), dtype=jnp.int32)
+        return np.asarray(int(value), dtype=np.int32)
     if isinstance(value, (list, tuple)):
-        return jnp.asarray(value, dtype=jnp.int32)
+        return np.asarray(value, dtype=np.int32)
     if _is_jax_leaf(value):
-        return jnp.asarray(fallback, dtype=jnp.int32)
+        return np.asarray(fallback, dtype=np.int32)
     try:
-        return jnp.asarray(value, dtype=jnp.int32)
+        return np.asarray(value, dtype=np.int32)
     except (TypeError, ValueError) as exc:
         raise TypeError(
             f"Unable to convert value of type {type(value)} into int32 metadata array."
@@ -340,6 +340,35 @@ def build_chain_verify_inputs(
     return out
 
 
+@functools.partial(jax.jit, static_argnames=["num_verify_tokens", "batch_size"])
+def build_chain_verify_inputs_device(
+    verified_id: jax.Array,
+    token_list: jax.Array,
+    seq_lens: jax.Array,
+    num_verify_tokens: int,
+    batch_size: int,
+) -> jax.Array:
+    """Build verify inputs for topk=1 linear chains on device."""
+    n = num_verify_tokens
+    bs = batch_size
+    tid_range = jnp.arange(n, dtype=jnp.int32)
+    draft_tokens = jnp.concatenate(
+        [verified_id.astype(jnp.int32)[:, None], token_list[:, : n - 1].astype(jnp.int32)],
+        axis=1,
+    ).reshape(bs * n)
+    positions = (seq_lens.astype(jnp.int32)[:, None] + tid_range[None, :]).reshape(bs * n)
+    retrive_index = jnp.arange(bs * n, dtype=jnp.int32)
+    retrive_next_token = jnp.broadcast_to(
+        jnp.concatenate([jnp.arange(1, n, dtype=jnp.int32), jnp.array([-1], dtype=jnp.int32)]),
+        (bs, n),
+    ).reshape(bs * n)
+    retrive_next_sibling = jnp.full((bs * n,), -1, dtype=jnp.int32)
+    return jnp.stack(
+        [draft_tokens, positions, retrive_index, retrive_next_token, retrive_next_sibling],
+        axis=0,
+    )
+
+
 def build_tree_kernel_efficient(
     verified_id: jax.Array,
     score_list: jax.Array,
@@ -385,18 +414,7 @@ def build_tree_kernel_efficient(
         speculative_num_steps,
     )
 
-    # Get batch size
-    # for compatibility, 0.6.3 need to use use_mesh. set_mesh is not have __entry__ attribute.
-    # on jax >=0.7.1, we need to use set_mesh.
-    try:
-        ctx = jax.sharding.use_mesh(mesh)
-    except AttributeError:
-        try:
-            ctx = jax.set_mesh(mesh)
-        except AttributeError:
-            ctx = mesh
-    with ctx:
-
+    with jax.set_mesh(mesh):
         tree_mask, positions, retrive_index, retrive_next_token, retrive_next_sibling = (
             build_eagle_tree_structure(
                 parent_list=parent_list,
@@ -495,7 +513,7 @@ class EagleDraftInput:
 
     def tree_flatten(self):
         accept_length_cpu_arr = (
-            jnp.empty((0,), dtype=jnp.int32)
+            np.empty((0,), dtype=np.int32)
             if self.accept_length_cpu is None
             else _as_int32_array(self.accept_length_cpu, fallback=0)
         )
@@ -960,16 +978,7 @@ class EagleVerifyInput:
         is_all_greedy = sampling_info.is_all_greedy
 
         if is_all_greedy:
-            # # for compatibility, 0.6.3 need to use use_mesh. set_mesh is not have __entry__ attribute.
-            # # on jax >=0.7.1, we need to use set_mesh.
-            try:
-                ctx = jax.sharding.use_mesh(mesh)
-            except AttributeError:
-                try:
-                    ctx = jax.set_mesh(mesh)
-                except AttributeError:
-                    ctx = mesh
-            with ctx:
+            with jax.set_mesh(mesh):
                 accept_index, accept_length, predict = verify_tree_greedy(
                     speculative_num_steps=self.spec_steps,
                     num_draft_tokens=self.draft_token_num,

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -190,13 +190,19 @@ class EAGLEWorker(BaseSpecWorker):
                     dp_size=dp_size,
                     per_dp_bs_size=per_dp_bs,
                 )
+                num_steps = self.speculative_num_steps
+                from sgl_jax.srt.speculative.multi_layer_draft_worker import (
+                    MultiLayerDraftWorker,
+                )
+
+                is_multi_layer = isinstance(self.draft_worker, MultiLayerDraftWorker)
+                topk_shape = (bs, num_steps, self.topk) if is_multi_layer else (bs, self.topk)
                 spec_info = EagleDraftInput(
-                    # FIXME(pc) dtype should according to serverargs
                     topk_p=jnp.ones(
-                        (bs, self.topk),
+                        topk_shape,
                         dtype=jnp.bfloat16 if self.server_args.dtype == "bfloat16" else jnp.float32,
                     ),
-                    topk_index=jnp.ones((bs, self.topk), dtype=jnp.int32),
+                    topk_index=jnp.ones(topk_shape, dtype=jnp.int32),
                     hidden_states=jnp.ones(
                         (bs, self.draft_worker.model_config.hidden_size),
                         dtype=jnp.bfloat16 if self.server_args.dtype == "bfloat16" else jnp.float32,

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -1,11 +1,15 @@
-"""MiMo-V2.5-Pro multi-layer MTP draft worker (#1053 P1-4).
+"""Multi-layer NEXTN/MTP draft worker (#1053 P1-4).
 
-Differs from ``EagleDraftWorker`` in that the N draft steps each use a
-*different* draft model runner (one per ``mtp_layer_idx``), with hidden
-states flowing layer→layer (layer i's output hidden becomes layer i+1's
-``spec_info.hidden_states``). Everything else — padding, tree build,
-verify-input construction, replicate helpers — is reused from
-``EagleDraftWorker``.
+The N draft steps each use a *different* draft model runner (one per
+``mtp_layer_idx``). Per the NEXTN training recipe (DeepSeek/MiMo), every
+layer i takes ``(embed(tok_{t+i}), target_hidden_t)`` — i.e. each layer
+sees the **target** model's hidden, not the previous MTP layer's output.
+So ``draft_extend`` forwards each layer once with the same target hidden
+and a per-layer rotated ``input_ids`` (shift+append previous topk), and
+``draft_forward`` does no model forward — it just reads the per-layer
+topk that ``draft_extend`` already stored. Chain-style hidden passing
+(layer i+1 ← layer i output) is only correct for archs like Step3p5MTP;
+see GPU sglang ``multi_layer_eagle_worker_v2.chain_mtp_hidden_states``.
 """
 
 from __future__ import annotations
@@ -17,8 +21,6 @@ import logging
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax.sharding import NamedSharding
-from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata
 from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
@@ -35,10 +37,8 @@ from sgl_jax.srt.speculative.eagle_draft_worker import (
     select_top_k_tokens,
     topk_probs_from_logits,
     update_eagle_lists,
-    update_forward_batch_info,
 )
 from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
-from sgl_jax.srt.utils.jax_utils import device_array
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +132,10 @@ class MultiLayerDraftWorker(EagleDraftWorker):
     # ---- per-layer overrides ------------------------------------------------
 
     def draft_forward(self, model_worker_batch: ModelWorkerBatch):
+        # dext already forwarded each MTP layer once and stored per-layer topk
+        # in spec_info.topk_{p,index} with shape (bs, num_steps, topk). We only
+        # feed those through select_top_k_tokens to assemble the tree lists —
+        # no model forward here (mirrors GPU multi_layer_eagle_worker_v2).
         topk_p = model_worker_batch.spec_info_padded.topk_p
         topk_index = model_worker_batch.spec_info_padded.topk_index
         hidden_states = model_worker_batch.spec_info_padded.hidden_states
@@ -143,51 +147,34 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         )
         parents_list = jnp.empty((bs, self.topk + 1 + step_min_1 * self.topk))
         scores = None
-        positions_base = device_array(
-            np.repeat(model_worker_batch.seq_lens, self.topk),
-            sharding=NamedSharding(self.mesh, P()),
-        )
-        logits_metadata = LogitsMetadata.from_model_worker_batch(model_worker_batch, self.mesh)
-
-        # Per-layer attention metadata: each layer has its own KV pool, so
-        # page_indices differ; positions/seq_lens are shared so we only need
-        # the i-th step's metadata from layer i.
-        metadata_per_layer = [
-            w.model_runner.attn_backend.get_eagle_multi_step_metadata(model_worker_batch)
-            for w in self._workers
-        ]
-
-        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
-        forward_batch.out_cache_loc = np.empty((1,))
-        forward_batch.cache_loc = np.empty((1,))
-        forward_batch.spec_info = EagleDraftInput()
-        forward_batch.spec_info.hidden_states = jnp.empty((bs * self.topk, hidden_states.shape[1]))
-
         for i in range(self.speculative_num_steps):
-            input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
-                i, topk_p, topk_index, hidden_states, scores, self.topk
+            _, hidden_states, scores, tree_info = select_top_k_tokens(
+                i, topk_p[:, i], topk_index[:, i], hidden_states, scores, self.topk
             )
             score_list, token_list, parents_list = update_eagle_lists(
                 i, score_list, token_list, parents_list, tree_info, self.topk
             )
-            if i == self.speculative_num_steps - 1:
-                break
-
-            forward_batch = update_forward_batch_info(
-                forward_batch, i, input_ids, hidden_states, positions_base
-            )
-            mr = self.runner(i)
-            mr.attn_backend.forward_metadata = metadata_per_layer[i][i]
-            forward_batch.attn_backend = mr.attn_backend
-            forward_batch.bid = model_worker_batch.bid
-            logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)
-
-            topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
-            if self.hot_token_ids is not None:
-                topk_index = self.hot_token_ids[topk_index]
-            hidden_states = replicate_to_mesh(self.mesh, logits_output.hidden_states)
-
         return score_list, token_list, parents_list
+
+    @staticmethod
+    def _rotate_ids(mwb: ModelWorkerBatch, last_tok: np.ndarray, sel_pos: np.ndarray) -> None:
+        """In-place left-shift each req's input_ids by 1, then write last_tok[slot]
+        at position sel_pos[slot]. Mirrors GPU rotate_input_ids_triton."""
+        dp = mwb.dp_size
+        per_dp_bs = mwb.per_dp_bs_size
+        per_dp_tok = len(mwb.input_ids) // dp
+        ext = mwb.extend_seq_lens
+        for r in range(dp):
+            pt = r * per_dp_tok
+            for j in range(per_dp_bs):
+                s = r * per_dp_bs + j
+                el = int(ext[s])
+                if el == 0:
+                    continue
+                seg = mwb.input_ids[pt : pt + el]
+                seg[:-1] = seg[1:]
+                seg[int(sel_pos[s])] = last_tok[s]
+                pt += el
 
     def draft_extend_for_prefill(
         self,
@@ -197,10 +184,15 @@ class MultiLayerDraftWorker(EagleDraftWorker):
     ) -> None:
         """Prefill-extend across all MTP layers.
 
-        Layer 0 consumes the target's full-prefix hidden_states; layer i>0
-        consumes layer i-1's output hidden. Each layer writes its own
-        prefix KV. Only layer 0's topk/hidden are kept as the next-round
-        draft state (draft step 0 starts from layer 0).
+        NEXTN (DeepSeek/MiMo) trains each MTP layer i with input
+        ``(embed(tok_{t+i}), target_hidden_t)`` — every layer sees the *target*
+        hidden, not the previous MTP layer's output. So per layer we keep
+        ``hidden = target_hidden_states`` and only rotate ``input_ids`` (shift
+        by 1, append previous layer's topk) so layer i's last-logit position is
+        ``(topk_{i-1}, target_hidden_{last})``. Each layer's topk goes into
+        ``spec_info.topk_index[:, i]`` and ``draft_forward`` does no model
+        forward. Mirrors GPU sglang ``multi_layer_eagle_worker_v2`` for
+        non-chain archs (chain is only for Step3p5MTP).
         """
         sel = np.asarray(model_worker_batch.logits_indices_selector)
         verified_id_np = np.asarray(jax.device_get(next_token_ids))[sel]
@@ -232,10 +224,12 @@ class MultiLayerDraftWorker(EagleDraftWorker):
             )
 
         layer0_out = None
-        cur_hidden = hidden_states
+        all_topk_p, all_topk_index = [], []
+        ext = model_worker_batch.extend_seq_lens
+        sel_pos = np.clip(ext - 1, 0, None).astype(np.int64)
         for i, w in enumerate(self._workers):
             mr = w.model_runner
-            model_worker_batch.spec_info_padded.hidden_states = cur_hidden
+            model_worker_batch.spec_info_padded.hidden_states = hidden_states
             forward_batch = ForwardBatch.init_new(model_worker_batch, mr)
             forward_batch.return_logprob = False
             mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(
@@ -248,17 +242,19 @@ class MultiLayerDraftWorker(EagleDraftWorker):
                     model_worker_batch, self.mesh
                 ),
             )
-            cur_hidden = logits_output.hidden_states
             if i == 0:
                 layer0_out = logits_output
+            tp, ti = topk_probs_from_logits(
+                replicate_to_mesh(self.mesh, logits_output.next_token_logits), self.topk
+            )
+            all_topk_p.append(np.asarray(jax.device_get(tp)))
+            all_topk_index.append(np.asarray(jax.device_get(ti)))
+            if i < len(self._workers) - 1:
+                self._rotate_ids(model_worker_batch, all_topk_index[-1][:, 0], sel_pos)
 
-        # Next-round draft state = layer 0's last-token hidden + topk (draft step 0
-        # starts from layer 0 with target's last hidden, so we cache layer 0's
-        # output here so step 0 can be skipped).
-        rep_logits, rep_hidden = replicate_to_mesh(
-            self.mesh, layer0_out.next_token_logits, layer0_out.hidden_states
-        )
-        layer0_out.next_token_logits = rep_logits
+        # spec_info.hidden_states is only consumed by select_top_k_tokens (shape
+        # bookkeeping at topk=1); keep layer0's last-token hidden for that.
+        rep_hidden = replicate_to_mesh(self.mesh, layer0_out.hidden_states)
         dp_size = model_worker_batch.dp_size
         if dp_size > 1:
             per_dp_tokens = rep_hidden.shape[0] // dp_size
@@ -266,33 +262,21 @@ class MultiLayerDraftWorker(EagleDraftWorker):
             last_idx = last_idx.copy()
             for k in range(1, dp_size):
                 last_idx[k * per_dp_bs : (k + 1) * per_dp_bs] += k * per_dp_tokens
-        layer0_out.hidden_states = rep_hidden[last_idx]
-        model_worker_batch.spec_info_padded.hidden_states = hidden_states
-        model_worker_batch.spec_info_padded.allocate_lens = np.asarray(model_worker_batch.seq_lens)[
-            sel
-        ]
-        # Restore real_bs verified_id so split_spec_info_per_rank can cut on
-        # real_bs_per_dp without slicing past the valid region.
-        model_worker_batch.spec_info_padded.verified_id = verified_id_np
-        self.capture_for_decode(layer0_out, model_worker_batch.spec_info_padded, sel=sel)
+        si = model_worker_batch.spec_info_padded
+        si.hidden_states = np.asarray(jax.device_get(rep_hidden))[last_idx][sel]
+        si.topk_p = np.stack(all_topk_p, axis=1)[sel]
+        si.topk_index = np.stack(all_topk_index, axis=1)[sel]
+        si.allocate_lens = np.asarray(model_worker_batch.seq_lens)[sel]
+        si.verified_id = verified_id_np
 
     def draft_extend_for_decode(
         self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
     ) -> None:
-        """Decode-extend across all MTP layers (each updates its own KV).
-
-        Same chaining as prefill: layer 0 consumes target verify hidden,
-        layer i>0 consumes layer i-1's output. Only layer 0's topk/hidden
-        become the next-round draft state.
-        """
+        """Decode-extend across all MTP layers; see draft_extend_for_prefill."""
         if batch_output.next_draft_input.verified_id.shape[0] <= 0:
             return
         target_hidden = batch_output.logits_output.hidden_states
 
-        # prepare_for_extend_after_verify mutates mwb.seq_lens / input_ids /
-        # spec_info in place — call it once (semantics are layer-independent),
-        # then per layer only swap hidden_states + recompute forward_metadata
-        # against that layer's KV pool.
         draft_input = EagleDraftInput(
             hidden_states=target_hidden, allocate_lens=batch_output.allocate_lens
         )
@@ -305,46 +289,39 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         if mwb.input_ids.shape[0] <= 0:
             return
 
-        layer0_logits = None
-        cur_hidden = target_hidden
+        sel = np.asarray(model_worker_batch.logits_indices_selector)
+        accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
+        assert (accept_host[sel] >= 1).all(), f"accept_length < 1: {accept_host[sel]}"
+        sel_pos = np.clip(accept_host - 1, 0, None).astype(np.int64)
+        mwb.input_ids = np.asarray(jax.device_get(mwb.input_ids)).copy()
+
+        layer0_hidden = None
+        all_topk_p, all_topk_index = [], []
         for i, w in enumerate(self._workers):
             mr = w.model_runner
-            mwb.spec_info_padded.hidden_states = cur_hidden
+            mwb.spec_info_padded.hidden_states = target_hidden
             mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(mwb)
             forward_batch = ForwardBatch.init_new(mwb, mr)
             logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)
             if i == 0:
-                layer0_logits = logits_output
-            cur_hidden = logits_output.hidden_states
+                layer0_hidden = replicate_to_mesh(self.mesh, logits_output.hidden_states)
+            tp, ti = topk_probs_from_logits(
+                replicate_to_mesh(self.mesh, logits_output.next_token_logits), self.topk
+            )
+            all_topk_p.append(np.asarray(jax.device_get(tp)))
+            all_topk_index.append(np.asarray(jax.device_get(ti)))
+            if i < len(self._workers) - 1:
+                self._rotate_ids(mwb, all_topk_index[-1][:, 0], sel_pos)
 
-        # logits_indices_selector maps global-flat req k → DP-padded slot s_k.
-        # rep_logits/rep_hidden are DP-padded (total_bs, …)/(total_bs*(steps+1), …);
-        # keep topk_probs_from_logits running on device with the padded shape
-        # (varying real_bs gather on device would generate a fresh trace per
-        # warmup batch size — see #1090). Gather to real_bs on host.
-        sel = np.asarray(model_worker_batch.logits_indices_selector)
-        accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
-        assert (accept_host[sel] >= 1).all(), f"accept_length < 1: {accept_host[sel]}"
         select_index = sel * (self.speculative_num_steps + 1) + accept_host[sel] - 1
-        rep_logits, rep_hidden = replicate_to_mesh(
-            self.mesh, layer0_logits.next_token_logits, layer0_logits.hidden_states
-        )
-        topk_p, topk_index = topk_probs_from_logits(rep_logits, self.topk)
-        jax.copy_to_host_async(topk_p)
-        jax.copy_to_host_async(topk_index)
-        jax.copy_to_host_async(rep_hidden)
         verified_id_arr = batch_output.next_draft_input.verified_id
         if hasattr(verified_id_arr, "copy_to_host_async"):
             jax.copy_to_host_async(verified_id_arr)
-        topk_p = np.asarray(topk_p)[sel]
-        topk_index = np.asarray(topk_index)[sel]
-        hidden = np.asarray(rep_hidden)[select_index]
-        verified_id = np.asarray(verified_id_arr)[select_index]
-        batch_output.next_draft_input.hidden_states = hidden
-        batch_output.next_draft_input.topk_p = topk_p
-        batch_output.next_draft_input.topk_index = topk_index
-        batch_output.next_draft_input.verified_id = verified_id
+        batch_output.next_draft_input.hidden_states = np.asarray(jax.device_get(layer0_hidden))[
+            select_index
+        ]
+        batch_output.next_draft_input.topk_p = np.stack(all_topk_p, axis=1)[sel]
+        batch_output.next_draft_input.topk_index = np.stack(all_topk_index, axis=1)[sel]
+        batch_output.next_draft_input.verified_id = np.asarray(verified_id_arr)[select_index]
         batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
-        # accept_lens stays DP-padded (total_bs,) — scheduler per-rank seq_lens
-        # update and _resolve_spec_decode_token_ids both index by DP slot.
         batch_output.accept_lens = accept_host

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -7,9 +7,8 @@ sees the **target** model's hidden, not the previous MTP layer's output.
 So ``draft_extend`` forwards each layer once with the same target hidden
 and a per-layer rotated ``input_ids`` (shift+append previous topk), and
 ``draft_forward`` does no model forward — it just reads the per-layer
-topk that ``draft_extend`` already stored. Chain-style hidden passing
-(layer i+1 ← layer i output) is only correct for archs like Step3p5MTP;
-see GPU sglang ``multi_layer_eagle_worker_v2.chain_mtp_hidden_states``.
+topk that ``draft_extend`` already stored. Chain-style hidden passing is
+only correct for architectures that explicitly chain MTP hidden states.
 """
 
 from __future__ import annotations
@@ -155,6 +154,11 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         topk_p = model_worker_batch.spec_info_padded.topk_p
         topk_index = model_worker_batch.spec_info_padded.topk_index
         hidden_states = model_worker_batch.spec_info_padded.hidden_states
+        if self.topk == 1:
+            if isinstance(topk_index, np.ndarray):
+                return None, np.asarray(topk_index[:, :, 0], dtype=np.int32), None
+            return None, topk_index[:, :, 0].astype(jnp.int32), None
+
         bs = model_worker_batch.seq_lens.shape[0]
         step_min_1 = self.speculative_num_steps - 1
         score_list = jnp.zeros((bs, 1 + step_min_1 * self.topk, self.topk))
@@ -208,7 +212,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         ``(topk_{i-1}, target_hidden_{last})``. Each layer's topk goes into
         ``spec_info.topk_index[:, i]`` and ``draft_forward`` does no model
         forward. Mirrors GPU sglang ``multi_layer_eagle_worker_v2`` for
-        non-chain archs (chain is only for Step3p5MTP).
+        non-chain architectures.
         """
         sel = np.asarray(model_worker_batch.logits_indices_selector)
         verified_id_np = np.asarray(jax.device_get(next_token_ids))[sel]
@@ -288,7 +292,7 @@ class MultiLayerDraftWorker(EagleDraftWorker):
     def draft_extend_for_decode(
         self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
     ) -> None:
-        """Decode-extend across all MTP layers — fused single JIT."""
+        """Decode-extend across all MTP layers."""
         from sgl_jax.srt.speculative.draft_extend_fused import (
             draft_extend_for_decode_fused,
         )

--- a/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/multi_layer_draft_worker.py
@@ -76,6 +76,9 @@ class MultiLayerDraftWorker(EagleDraftWorker):
 
         self.num_mtp_layers = self.speculative_num_steps
         assert self.num_mtp_layers > 1
+        assert (
+            self.topk == 1
+        ), f"MultiLayerDraftWorker fused decode requires topk=1, got {self.topk}"
         cfg_mtp = getattr(target_worker.model_config.hf_config, "num_nextn_predict_layers", None)
         # MiMo-style configs omit num_nextn_predict_layers; only enforce equality
         # when the field exists (scheduler routes here iff n_mtp>1 either way).
@@ -107,6 +110,19 @@ class MultiLayerDraftWorker(EagleDraftWorker):
 
         for i, w in enumerate(self._workers):
             w.model_runner.initialize_jit()
+
+        # Share target's SWA index mapping with draft workers. The scheduler
+        # allocates KV pages via the target's SWATokenToKVPoolAllocator which
+        # maintains full_to_swa_index_mapping. Draft workers have independent
+        # allocators whose mappings stay at zero. Without this, draft SWA
+        # attention remaps all page indices to 0 → reads wrong KV data.
+        target_allocator = target_worker.model_runner.token_to_kv_pool_allocator
+        target_swa_mapping = getattr(target_allocator, "full_to_swa_index_mapping", None)
+        if target_swa_mapping is not None:
+            for w in self._workers:
+                object.__setattr__(
+                    w.model_runner.attn_backend, "swa_index_mapping", target_swa_mapping
+                )
 
         (
             self.precompile_token_paddings,
@@ -141,11 +157,11 @@ class MultiLayerDraftWorker(EagleDraftWorker):
         hidden_states = model_worker_batch.spec_info_padded.hidden_states
         bs = model_worker_batch.seq_lens.shape[0]
         step_min_1 = self.speculative_num_steps - 1
-        score_list = jnp.empty((bs, 1 + step_min_1 * self.topk, self.topk))
-        token_list = jnp.empty(
+        score_list = jnp.zeros((bs, 1 + step_min_1 * self.topk, self.topk))
+        token_list = jnp.zeros(
             (bs, self.topk + step_min_1 * self.topk * self.topk), dtype=jnp.int32
         )
-        parents_list = jnp.empty((bs, self.topk + 1 + step_min_1 * self.topk))
+        parents_list = jnp.zeros((bs, self.topk + 1 + step_min_1 * self.topk))
         scores = None
         for i in range(self.speculative_num_steps):
             _, hidden_states, scores, tree_info = select_top_k_tokens(
@@ -272,56 +288,9 @@ class MultiLayerDraftWorker(EagleDraftWorker):
     def draft_extend_for_decode(
         self, model_worker_batch: ModelWorkerBatch, batch_output: GenerationBatchResult
     ) -> None:
-        """Decode-extend across all MTP layers; see draft_extend_for_prefill."""
-        if batch_output.next_draft_input.verified_id.shape[0] <= 0:
-            return
-        target_hidden = batch_output.logits_output.hidden_states
-
-        draft_input = EagleDraftInput(
-            hidden_states=target_hidden, allocate_lens=batch_output.allocate_lens
+        """Decode-extend across all MTP layers — fused single JIT."""
+        from sgl_jax.srt.speculative.draft_extend_fused import (
+            draft_extend_for_decode_fused,
         )
-        mwb, logits_metadata = draft_input.prepare_for_extend_after_verify(
-            model_worker_batch,
-            self.draft_model_runner,
-            batch_output,
-            self.speculative_num_draft_tokens,
-        )
-        if mwb.input_ids.shape[0] <= 0:
-            return
 
-        sel = np.asarray(model_worker_batch.logits_indices_selector)
-        accept_host = np.asarray(jax.device_get(batch_output.accept_lens))
-        assert (accept_host[sel] >= 1).all(), f"accept_length < 1: {accept_host[sel]}"
-        sel_pos = np.clip(accept_host - 1, 0, None).astype(np.int64)
-        mwb.input_ids = np.asarray(jax.device_get(mwb.input_ids)).copy()
-
-        layer0_hidden = None
-        all_topk_p, all_topk_index = [], []
-        for i, w in enumerate(self._workers):
-            mr = w.model_runner
-            mwb.spec_info_padded.hidden_states = target_hidden
-            mr.attn_backend.forward_metadata = mr.attn_backend.get_eagle_forward_metadata(mwb)
-            forward_batch = ForwardBatch.init_new(mwb, mr)
-            logits_output, _, _ = mr.forward(forward_batch, logits_metadata=logits_metadata)
-            if i == 0:
-                layer0_hidden = replicate_to_mesh(self.mesh, logits_output.hidden_states)
-            tp, ti = topk_probs_from_logits(
-                replicate_to_mesh(self.mesh, logits_output.next_token_logits), self.topk
-            )
-            all_topk_p.append(np.asarray(jax.device_get(tp)))
-            all_topk_index.append(np.asarray(jax.device_get(ti)))
-            if i < len(self._workers) - 1:
-                self._rotate_ids(mwb, all_topk_index[-1][:, 0], sel_pos)
-
-        select_index = sel * (self.speculative_num_steps + 1) + accept_host[sel] - 1
-        verified_id_arr = batch_output.next_draft_input.verified_id
-        if hasattr(verified_id_arr, "copy_to_host_async"):
-            jax.copy_to_host_async(verified_id_arr)
-        batch_output.next_draft_input.hidden_states = np.asarray(jax.device_get(layer0_hidden))[
-            select_index
-        ]
-        batch_output.next_draft_input.topk_p = np.stack(all_topk_p, axis=1)[sel]
-        batch_output.next_draft_input.topk_index = np.stack(all_topk_index, axis=1)[sel]
-        batch_output.next_draft_input.verified_id = np.asarray(verified_id_arr)[select_index]
-        batch_output.allocate_lens = batch_output.allocate_lens[: model_worker_batch.real_bs]
-        batch_output.accept_lens = accept_host
+        return draft_extend_for_decode_fused(self, model_worker_batch, batch_output)

--- a/python/sgl_jax/test/speculative/test_eagle_utils.py
+++ b/python/sgl_jax/test/speculative/test_eagle_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 
 import jax
 import jax.numpy as jnp
@@ -14,6 +15,202 @@ from sgl_jax.test.test_utils import CustomTestCase
 
 
 class TestVerifyTree(CustomTestCase):
+    def test_as_int32_array_keeps_host_metadata_on_host(self):
+        from sgl_jax.srt.speculative import eagle_util
+
+        original_jnp_asarray = eagle_util.jnp.asarray
+        original_jnp_empty = eagle_util.jnp.empty
+
+        def fail_jnp_asarray(*args, **kwargs):
+            raise AssertionError("host metadata conversion must not call jnp.asarray")
+
+        def fail_jnp_empty(*args, **kwargs):
+            raise AssertionError("host metadata placeholder must not call jnp.empty")
+
+        try:
+            eagle_util.jnp.asarray = fail_jnp_asarray
+            eagle_util.jnp.empty = fail_jnp_empty
+            arr = eagle_util._as_int32_array(np.array([1, 2], dtype=np.int64))
+            scalar = eagle_util._as_int32_array(3)
+            listed = eagle_util._as_int32_array([4, 5])
+            children, _ = eagle_util.EagleDraftInput().tree_flatten()
+        finally:
+            eagle_util.jnp.asarray = original_jnp_asarray
+            eagle_util.jnp.empty = original_jnp_empty
+
+        self.assertIsInstance(arr, np.ndarray)
+        self.assertEqual(arr.dtype, np.int32)
+        np.testing.assert_array_equal(arr, np.array([1, 2], dtype=np.int32))
+        self.assertIsInstance(scalar, np.ndarray)
+        self.assertEqual(scalar.dtype, np.int32)
+        np.testing.assert_array_equal(listed, np.array([4, 5], dtype=np.int32))
+        self.assertIsInstance(children[9], np.ndarray)
+        self.assertEqual(children[9].dtype, np.int32)
+        self.assertEqual(children[9].shape, (0,))
+
+        device_arr = jnp.array([6], dtype=jnp.int32)
+        self.assertIs(eagle_util._as_int32_array(device_arr), device_arr)
+
+    def test_build_chain_verify_inputs_device_matches_linear_chain_layout(self):
+        from sgl_jax.srt.speculative.eagle_util import build_chain_verify_inputs_device
+
+        verified_id = jnp.array([101, 201], dtype=jnp.int32)
+        token_list = jnp.array(
+            [
+                [102, 103, 104],
+                [202, 203, 204],
+            ],
+            dtype=jnp.int32,
+        )
+        seq_lens = jnp.array([7, 11], dtype=jnp.int32)
+
+        packed = build_chain_verify_inputs_device(
+            verified_id=verified_id,
+            token_list=token_list,
+            seq_lens=seq_lens,
+            num_verify_tokens=4,
+            batch_size=2,
+        )
+
+        expected = np.array(
+            [
+                [101, 102, 103, 104, 201, 202, 203, 204],
+                [7, 8, 9, 10, 11, 12, 13, 14],
+                [0, 1, 2, 3, 4, 5, 6, 7],
+                [1, 2, 3, -1, 1, 2, 3, -1],
+                [-1, -1, -1, -1, -1, -1, -1, -1],
+            ],
+            dtype=np.int32,
+        )
+        np.testing.assert_array_equal(np.asarray(packed), expected)
+
+    def test_fused_chain_verify_matches_topk1_linear_reference(self):
+        from sgl_jax.srt.speculative.draft_extend_fused import (
+            _greedy_sample_and_prepare_draft_inputs_chain_from_predict,
+        )
+
+        speculative_num_steps = 3
+        num_draft_tokens = 4
+        bs = 4
+        draft_tokens = jnp.array(
+            [
+                10,
+                11,
+                12,
+                13,
+                20,
+                21,
+                22,
+                23,
+                30,
+                31,
+                32,
+                33,
+                40,
+                41,
+                42,
+                43,
+            ],
+            dtype=jnp.int32,
+        )
+        target_predict = np.array(
+            [
+                99,
+                12,
+                13,
+                14,
+                21,
+                99,
+                23,
+                24,
+                31,
+                32,
+                99,
+                34,
+                41,
+                42,
+                43,
+                44,
+            ],
+            dtype=np.int32,
+        )
+        chain = _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
+            target_hidden=jnp.arange(bs * num_draft_tokens * 2, dtype=jnp.float32).reshape(
+                bs * num_draft_tokens, 2
+            ),
+            positions=jnp.arange(bs * num_draft_tokens, dtype=jnp.int32),
+            seq_lens=jnp.array([100, 200, 300, 400], dtype=jnp.int32),
+            draft_tokens=draft_tokens,
+            target_predict=jnp.asarray(target_predict),
+            speculative_num_steps=speculative_num_steps,
+            speculative_num_draft_tokens=num_draft_tokens,
+        )
+
+        np.testing.assert_array_equal(np.asarray(chain.accept_lens), np.array([1, 2, 3, 4]))
+        np.testing.assert_array_equal(
+            np.asarray(chain.select_index),
+            np.arange(bs, dtype=np.int32) * (speculative_num_steps + 1)
+            + np.asarray(chain.accept_lens)
+            - 1,
+        )
+        select_index = np.asarray(chain.select_index)
+        np.testing.assert_array_equal(
+            np.asarray(chain.verified_id)[select_index],
+            np.array([99, 99, 99, 44], dtype=np.int32),
+        )
+
+    def test_fused_chain_verify_zeroes_padding_accept_length(self):
+        from sgl_jax.srt.speculative.draft_extend_fused import (
+            _greedy_sample_and_prepare_draft_inputs_chain_from_predict,
+        )
+
+        out = _greedy_sample_and_prepare_draft_inputs_chain_from_predict(
+            target_hidden=jnp.arange(8 * 2, dtype=jnp.float32).reshape(8, 2),
+            positions=jnp.arange(8, dtype=jnp.int32),
+            seq_lens=jnp.array([0, 10], dtype=jnp.int32),
+            draft_tokens=jnp.array([0, 0, 0, 0, 20, 21, 22, 23], dtype=jnp.int32),
+            target_predict=jnp.array([0, 0, 0, 0, 21, 22, 99, 24], dtype=jnp.int32),
+            speculative_num_steps=3,
+            speculative_num_draft_tokens=4,
+        )
+
+        np.testing.assert_array_equal(np.asarray(out.accept_lens), np.array([0, 3]))
+        np.testing.assert_array_equal(np.asarray(out.new_seq_lens), np.array([0, 13]))
+        np.testing.assert_array_equal(np.asarray(out.sel_pos), np.array([0, 2]))
+
+    def test_fused_materialize_uses_original_seq_lens_for_new_seq_lens(self):
+        from sgl_jax.srt.speculative.draft_extend_fused import (
+            _materialize_fused_greedy_batch_output_for_scheduler,
+        )
+
+        batch_output = SimpleNamespace(
+            logits_output=None,
+            next_draft_input=SimpleNamespace(),
+            allocate_lens=np.array([9, 8, 7], dtype=np.int32),
+            accept_lens=None,
+            next_token_ids=None,
+        )
+        out = _materialize_fused_greedy_batch_output_for_scheduler(
+            batch_output=batch_output,
+            selector=np.array([0, 2], dtype=np.int32),
+            real_bs=2,
+            seq_lens_host=np.array([103, 203, 303], dtype=np.int32),
+            layer0_hidden=jnp.arange(12 * 2, dtype=jnp.float32).reshape(12, 2),
+            topk_index_stacked=jnp.array(
+                [[[11], [12], [13]], [[21], [22], [23]], [[31], [32], [33]]]
+            ),
+            accept_lens_device=jnp.array([1, 2, 4], dtype=jnp.int32),
+            predict_device=jnp.arange(12, dtype=jnp.int32),
+            speculative_num_draft_tokens=4,
+            target_logits=None,
+            target_hidden=None,
+        )
+
+        np.testing.assert_array_equal(
+            out.next_draft_input.new_seq_lens,
+            np.array([101, 304], dtype=np.int32),
+        )
+
     def test_verify_tree_greedy(self):
         candidates = jnp.array(
             [
@@ -65,19 +262,10 @@ class TestVerifyTree(CustomTestCase):
         accept_index = jnp.full((bs, num_spec_step), -1, dtype=jnp.int32)  # mutable
         accept_token_num = jnp.full((bs,), 0, dtype=jnp.int32)  # mutable
 
-        # # for compatibility, 0.6.3 need to use use_mesh. set_mesh is not have __entry__ attribute.
-        # # on jax >=0.7.1, we need to use set_mesh.
         from sgl_jax.srt.utils.mesh_utils import create_device_mesh
 
         mesh = create_device_mesh(ici_parallelism=[-1, 1], dcn_parallelism=[1, 1])
-        try:
-            ctx = jax.sharding.use_mesh(mesh)
-        except AttributeError:
-            try:
-                ctx = jax.set_mesh(mesh)
-            except AttributeError:
-                ctx = mesh
-        with ctx:
+        with jax.set_mesh(mesh):
             accept_index, accept_token_num, predicts = verify_tree_greedy(
                 speculative_num_steps=4,
                 num_draft_tokens=6,

--- a/python/sgl_jax/test/speculative/test_spec_chain_state.py
+++ b/python/sgl_jax/test/speculative/test_spec_chain_state.py
@@ -6,9 +6,9 @@ produces correct per-round ext (= accept, no cumulative drift) and that
 the optimistic alloc upper bound covers the real verify KV-write range.
 Does NOT exercise the fused JIT (device-only); that's TPU-gated.
 """
+
 import numpy as np
 import pytest
-
 
 NDT = 4
 
@@ -65,13 +65,13 @@ def test_chain_ext_equals_accept_no_drift():
         # ext must equal accept (no drift)
         np.testing.assert_array_equal(ext, acc), f"round {k}: ext={ext} != accept={acc}"
         # alloc upper bound must cover verify write range [real:real+ndt]
-        assert np.all(verify_hi - 1 <= new_r), (
-            f"round {k}: verify_hi-1={verify_hi-1} > alloc new_r={new_r} (under-alloc)"
-        )
+        assert np.all(
+            verify_hi - 1 <= new_r
+        ), f"round {k}: verify_hi-1={verify_hi-1} > alloc new_r={new_r} (under-alloc)"
         # alloc must not over-shoot by more than ndt (bounded over-alloc)
-        assert np.all(new_r - (verify_hi - 1) <= NDT), (
-            f"round {k}: over-alloc {new_r - (verify_hi-1)} > ndt"
-        )
+        assert np.all(
+            new_r - (verify_hi - 1) <= NDT
+        ), f"round {k}: over-alloc {new_r - (verify_hi-1)} > ndt"
 
 
 def test_chain_first_round_from_prefill():

--- a/python/sgl_jax/test/speculative/test_spec_chain_state.py
+++ b/python/sgl_jax/test/speculative/test_spec_chain_state.py
@@ -1,0 +1,144 @@
+"""CPU mock test for device-chain state timing (Wave 3d v2).
+
+Verifies the host-side allocate_lens / seq_lens bookkeeping under the
+chain event_loop ordering (bump → prepare_for_decode → unbump → finalize)
+produces correct per-round ext (= accept, no cumulative drift) and that
+the optimistic alloc upper bound covers the real verify KV-write range.
+Does NOT exercise the fused JIT (device-only); that's TPU-gated.
+"""
+import numpy as np
+import pytest
+
+
+NDT = 4
+
+
+class MockReqInfo:
+    def __init__(self, seq_lens, alloc_lens):
+        self.seq_lens = np.asarray(seq_lens, dtype=np.int64)
+        self.allocate_lens = np.asarray(alloc_lens, dtype=np.int64)
+        self.reqs = list(range(len(seq_lens)))
+
+
+def chain_round(info: MockReqInfo, accept_prev: np.ndarray):
+    """One chain loop iteration: finalize_{k-1} → bump → prep_k → unbump.
+
+    Returns (ext_allocated, new_r_optimistic, verify_write_range_real).
+    """
+    # finalize_{k-1}: seq_lens += accept (real)
+    info.seq_lens = info.seq_lens + accept_prev  # real_{k-1}
+    real_seq = info.seq_lens.copy()
+
+    # bump (optimistic for in-flight round k)
+    info.seq_lens = info.seq_lens + NDT
+
+    # prepare_for_decode (uses bumped seq_lens)
+    old_r = info.allocate_lens
+    new_r = info.seq_lens + NDT - 1
+    ext = new_r - old_r
+    info.allocate_lens = new_r
+
+    # unbump
+    info.seq_lens = info.seq_lens - NDT
+
+    # round k verify writes [real_seq : real_seq+ndt] (device-side, real seq_lens)
+    verify_hi = real_seq + NDT
+    return ext, new_r, verify_hi
+
+
+def test_chain_ext_equals_accept_no_drift():
+    """ext_r per round must equal accept_{k-1} (real), not cumulative."""
+    # initial: post-prefill, first decode round already prepped (alloc_0 optimistic)
+    seq0 = np.array([512, 600, 700, 512])  # real_{-1} (post-prefill)
+    # first prep (round 0) used bump: alloc_0 = seq0 + 2*ndt - 1
+    alloc0 = seq0 + 2 * NDT - 1
+    info = MockReqInfo(seq0, alloc0)
+
+    accepts = [
+        np.array([3, 4, 1, 2]),
+        np.array([4, 2, 3, 4]),
+        np.array([1, 1, 4, 3]),
+        np.array([2, 3, 2, 1]),
+    ]
+    for k, acc in enumerate(accepts):
+        ext, new_r, verify_hi = chain_round(info, acc)
+        # ext must equal accept (no drift)
+        np.testing.assert_array_equal(ext, acc), f"round {k}: ext={ext} != accept={acc}"
+        # alloc upper bound must cover verify write range [real:real+ndt]
+        assert np.all(verify_hi - 1 <= new_r), (
+            f"round {k}: verify_hi-1={verify_hi-1} > alloc new_r={new_r} (under-alloc)"
+        )
+        # alloc must not over-shoot by more than ndt (bounded over-alloc)
+        assert np.all(new_r - (verify_hi - 1) <= NDT), (
+            f"round {k}: over-alloc {new_r - (verify_hi-1)} > ndt"
+        )
+
+
+def test_chain_first_round_from_prefill():
+    """First decode round (no prev chain): alloc_0 from non-optimistic old_r.
+
+    Prefill sets allocate_lens = prefill_len (not optimistic). First chain
+    prep bumps seq_lens but old_r = prefill_len → ext = 2*ndt-1 (one-time
+    over-alloc), covered by drain release.
+    """
+    seq0 = np.array([512, 600])
+    alloc_prefill = seq0.copy()  # prefill: allocate_lens = prefill_len
+    info = MockReqInfo(seq0, alloc_prefill)
+
+    # first chain round: accept_prev = 1 (prefill output 1 token, but seq_lens
+    # already includes it? assume seq0 is post-prefill-output, accept_prev=0 here)
+    # Actually finalize for prefill round writes seq_lens += 1 (extend output).
+    ext, new_r, verify_hi = chain_round(info, np.array([1, 1]))
+    # ext = (seq0+1+2ndt-1) - seq0 = 2ndt → one-time over-alloc of (2ndt - accept)
+    assert np.all(ext == 2 * NDT), f"first-round ext={ext}"
+    assert np.all(verify_hi - 1 <= new_r)
+
+    # second round onwards: ext = accept
+    ext2, new_r2, _ = chain_round(info, np.array([3, 2]))
+    np.testing.assert_array_equal(ext2, [3, 2])
+
+
+def test_chain_batch_shrink_shape_consistent():
+    """After a req finishes (filter), spec_info.allocate_lens shape must match reqs.
+
+    chain mode: finalize does NOT write spec_info; prep maintains it. filter_batch
+    must shrink both reqs and allocate_lens consistently.
+    """
+    info = MockReqInfo([512, 600, 700], np.array([512, 600, 700]) + 2 * NDT - 1)
+    chain_round(info, np.array([3, 4, 2]))
+    # req[1] finishes → filter
+    keep = [0, 2]
+    info.seq_lens = info.seq_lens[keep]
+    info.allocate_lens = info.allocate_lens[keep]
+    info.reqs = [info.reqs[i] for i in keep]
+    # next round must not assert shape mismatch
+    assert info.allocate_lens.shape[0] == len(info.reqs) == 2
+    ext, _, _ = chain_round(info, np.array([2, 3]))
+    np.testing.assert_array_equal(ext, [2, 3])
+
+
+def test_chain_finalize_must_not_overwrite_alloc():
+    """Regression for step2 crash: if finalize writes spec_info (with stale
+    allocate_lens from round k-1), next prep's old_r is wrong → ext drifts.
+    This test documents why finalize must skip spec_info under chain.
+    """
+    info = MockReqInfo([512], [512 + 2 * NDT - 1])
+    chain_round(info, np.array([3]))  # alloc_1 = 512+3 + 2ndt-1
+    alloc_1 = info.allocate_lens.copy()
+
+    # WRONG: finalize overwrites with stale alloc_0
+    stale_alloc_0 = np.array([512 + 2 * NDT - 1])
+    info.allocate_lens = stale_alloc_0  # ← what step2 did
+
+    # next prep: old_r = stale_alloc_0, new_r = (512+3+4 +ndt) + ndt-1
+    info.seq_lens = info.seq_lens + 4  # finalize accept=4
+    info.seq_lens = info.seq_lens + NDT  # bump
+    new_r = info.seq_lens + NDT - 1
+    ext_wrong = new_r - stale_alloc_0
+    ext_right = new_r - alloc_1
+    # wrong ext = accept_0 + accept_1 = 7 (cumulative); right = accept_1 = 4
+    assert ext_wrong[0] == 7 and ext_right[0] == 4, (ext_wrong, ext_right)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/sgl_jax/test/test_mixed_chunk_dp.py
+++ b/python/sgl_jax/test/test_mixed_chunk_dp.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import numpy as np
 
 from sgl_jax.srt.managers.schedule_batch import Req, ScheduleBatch
-from sgl_jax.srt.managers.schedule_policy import PrefillAdder
+from sgl_jax.srt.managers.schedule_policy import AddReqResult, PrefillAdder
 from sgl_jax.srt.sampling.sampling_params import SamplingParams
 
 
@@ -16,6 +16,21 @@ class _DummyAllocator:
 class _DummyTreeCache:
     def evictable_size(self, dp_rank: int = 0):
         return 0
+
+
+class _DummyRadixCache:
+    """Tree cache with disable=False so add_one_req takes the radix path."""
+
+    disable = False
+
+    def evictable_size(self, dp_rank: int = 0):
+        return 0
+
+    def inc_lock_ref(self, node):
+        return None
+
+    def dec_lock_ref(self, node, swa_uuid_for_lock=None):
+        pass
 
 
 def _make_req(rid: str, dp_rank: int, input_len: int = 4, output_len: int = 2) -> Req:
@@ -163,6 +178,41 @@ class TestMixedChunkDP(unittest.TestCase):
         self.assertEqual(adder.cur_rem_token_offset, [3, 1])
         self.assertEqual(adder.rem_input_tokens, 96)
         self.assertEqual(adder.rem_chunk_tokens_list, [17, 19])
+
+    def test_add_one_req_chunked_admits_all_dp_ranks_with_radix(self):
+        # Regression for #1239: with radix enabled (tree_cache.disable=False) +
+        # chunked prefill + dp>1 + extend_input_len >= max_prefill_tokens, the
+        # untruncated rem_input_tokens gate would return OTHER on the second
+        # rank, serializing prefill to one DP rank per round.
+        dp_size = 4
+        adder = PrefillAdder(
+            page_size=256,
+            tree_cache=_DummyRadixCache(),
+            token_to_kv_pool_allocator=_DummyAllocator(),
+            running_batch=None,
+            new_token_ratio=1.0,
+            rem_input_tokens=16384,
+            rem_chunk_tokens=2048,
+            dp_size=dp_size,
+        )
+        for dp in range(dp_size):
+            req = _make_req(f"r{dp}", dp_rank=dp, input_len=16384)
+            req.sampling_params.ignore_eos = True
+            req.fill_ids = req.origin_input_ids
+            req.extend_input_len = len(req.fill_ids)
+            req.prefix_indices = []
+            req.host_hit_length = 0
+            req.last_node = object()
+            res = adder.add_one_req(req)
+            self.assertEqual(
+                res,
+                AddReqResult.CONTINUE,
+                f"dp_rank={dp} got {res}; chunked admission must not serialize across DP ranks",
+            )
+        for dp in range(dp_size):
+            self.assertEqual(len(adder.can_run_list[dp]), 1)
+            self.assertIs(adder.new_chunked_reqs[dp], adder.can_run_list[dp][0])
+            self.assertEqual(adder.can_run_list[dp][0].extend_input_len, 2048)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# [SpecDecode] overlap scheduler + device-chain for fused spec decode

Target: `epic/mtp-phase2-performance`
Branch: `zorrofox:feat/overlap-fused` @ `00110585`
Diff: 12 files, +788/-86

## Summary

Enables `--speculative-algorithm` to run with the overlap scheduler (previously hard-disabled), and adds an opt-in device-chain mode (`--enable-spec-device-chain`) that keeps verify results on-device between spec-decode rounds.

Builds on the no-chain overlap direction from #1324 (credit @pengchengneo). This PR takes a different mechanism: instead of splitting the fused JIT into verify/draft phases, it keeps #1292's single fused JIT and (a) defers its host-side materialization to the next loop iteration, and (b) optionally chains rounds device-to-device by passing the previous round's `(accept_lens, seq_lens, predict, topk_idx)` as a side-input to the next JIT call.

## Performance (V2-Flash, dp=4, decode steady-state tput rr≥24 p50)

| HW | Workload | nospec | spec+disable-overlap | spec+device-chain | vs nospec | vs disable-overlap | chain hit |
|---|---|---|---|---|---|---|---|
| v6e-64 | 16K/1K conc=32 | 1509 | — | **4127** | **+173% / ITL 2.89×** | — | 93.9% |
| v6e-16 | 16K/1K conc=32 | — | 1094 | **1575** | — | **+44.0%** | 87.2% |
| v6e-16 | 512/256 conc=32 | — | 2640 | **3554** | — | **+34.6%** | — |
| **v7x-16** | 16K/1K conc=32 | 1414 | 2974 | **4560** | **+222% / ITL 2.46×** | **+53.3%** | 95.7% |
| **v7x-16** | 512/256 conc=32 | — | 2585 | **3744** | — | **+44.8%** | 78.8% |

For reference: GPU H100 8× 16K MTP ITL speedup 2.53×; H200 8× +89~172%. v6e-64 and v7x-16 both reach or exceed the GPU range.

vs #1324 no-chain overlap (v6e-16, +11.6%): device-chain reaches +35~44% on the same hardware (3-4×).

## Design

### 1. Defer materialize (no-chain overlap, always on)

`run_batch` for spec-decode dispatches the fused JIT and returns a `SpecDecodePending` handle (no d2h). The d2h + `seq_lens`/`spec_info` writeback happens in `_finalize_pending_spec()` at the *start of the next* `event_loop_overlap` iteration, so `process_batch_result(k-1)` runs concurrently with device JIT(k).

KV lifecycle under overlap: a finished req's over-allocated draft slots are released one round late (`_drain_deferred_spec_release` at loop top), since the req was already re-dispatched before `process_batch_result` marked it finished. `req.kv_allocated_len` tracks the per-req over-alloc independent of which batch the result lands in.

`ScheduleBatch.copy()` snapshots `reqs_info[r].reqs` (was a shared list reference; `merge_batch`'s in-place `.extend()` could resize the copy's view → token-index drift in `_resolve_spec_decode_token_ids`).

### 2. Device-chain (`--enable-spec-device-chain`, opt-in)

`_event_loop_overlap_chain`: after dispatching round k, the host immediately preps round k+1 (with optimistically-bumped `seq_lens += ndt`) and dispatches it — *while* JIT(k) is still in flight. The fused JIT takes a `prev_chain: SpecChainState` side-input plus a static `use_chain: bool`; when `use_chain=True` it derives the real `seq_lens`/`verified_id`/`topk_index` for round k+1 from `prev_chain` (round k's device outputs) instead of the host-uploaded placeholders.

`SpecChainState` is *not* resharded on output (keeps the JIT's natural sharding); the next round reshards it in-JIT (rep→P("data") = split, no cross-host comm). Resharding on output cost ~1.5ms/round in an earlier attempt.

The host falls back to the no-chain path when the next round's batch shape will change (`will_reshape`): any req finished, a chunked prefill is pending, or `waiting_queue > 0 ∧ not all DP ranks at max-running`. The last clause is what gets the 16K continuous-queue case from ~7% chain hit to ~90%.

Bump/unbump invariant: optimistic `seq_lens` must stay bumped through *both* `prepare_for_decode` (so `allocate_lens` advances) *and* `run_batch` (so `cu_kv_lens` stride matches `cache_loc` stride). Unbumping early desyncs them by `ndt` → per-DP cumsum drift.

### 3. Misc

- Removed the hard `speculative_algorithm + overlap` rejection in `server_args`.
- Cherry-picked #1328 (chunked-prefill DP serialization) which the 16K+radix tests depend on; will drop on rebase if epic picks it up.
- `c1ef03f0` exposes per-request `spec_accept_length` in `/generate` `meta_info` (used for accept-len measurement; small standalone change, can split out if preferred).

## Correctness (v6e-16 dp=4)

| Test | Result |
|---|---|
| GSM8K-200 (5-shot, greedy) | 0.875 (baseline disable-overlap: 0.860) |
| det4 (4 prompts, serial DP=[1,1,1,1], 64 tok) device-chain vs disable-overlap | byte-identical |
| staggered 4+3 (merge_batch path) device-chain vs disable-overlap | 5/7 identical; 2/7 differ = #1090 (disable-overlap r1 vs r2 also differs on the same 2 prompts; disable-overlap r2 == device-chain) |
| radix-on + device-chain | no crash (chain hit 76%) |
| accept-len | 3.85 (== disable-overlap, no drift) |
| KV leak (`check_memory`) / Traceback | 0 |

## Known issues

- **#1266 — hybrid-SWA retract deadlock (pre-existing on epic, introduced by #1234, unrelated to this PR)**. Reproduces with or without spec/overlap when the SWA sub-pool retracts on multi-host. We hit it on v6e-16 with `swa-full-tokens-ratio=0.15`; v6e-64/v7x-16 with ≥0.30 don't retract. We spent several rounds verifying this PR's defer/chain path is *not* the cause (disabling defer + `effects_barrier` + `sync_global_devices` between rounds still hangs; the hang is in device collectives, not host timing). A `logger.error` warning is added on retract under spec+overlap pointing at the workaround.
- #1090 per-DP-rank cross-batch nondeterminism (pre-existing on epic).
- dp=1 fused spec_decode sharding crash (pre-existing on epic; dp≥2 unaffected).

## Commit groups (20 commits, not squashed for review; happy to squash before merge)

| Group | Commits |
|---|---|
| prereq | `c1ef03f0` (spec_accept_length meta), `07ee3f04` (#1328 cherry-pick), `1683195e` (instrument, removed in cleanup) |
| defer materialize | `a2c5a933` |
| KV lifecycle | `1bc8709d` `b2bd93fe` `a0ae2f03` `971f639c` `88df582b` |
| device-chain | `51a62359` `6b2ea24a` `a6377c13` `10e6188a` `1e89d886` `e5a2b657` |
| retract known-issue | `5ebd9ee9` `8f789fbe` `52c36aeb` (instruments removed in cleanup) |
| cleanup + server_arg | `968f2623` `00110585` |

## Test plan

- [x] CPU: `test_spec_chain_state.py` (4 tests: chain alloc/seq_lens drift, first-round, batch shrink, finalize-overwrite regression)
- [x] v6e-16 dp=4: GSM8K + det4 + staggered + radix-on + 16K
- [x] v6e-64 dp=4: 16K nospec/chain
- [x] v7x-16 dp=4: 16K nospec/spec-off/chain + short-ctx
- [ ] CI green
