### PR TITLE
feat(mem_cache): HiCache Stage 1 — UnifiedRadixCache core, FullComponent, serving tests

### DIFF
--- a/benchmark/hicache/bench_unified_radix_ab.py
+++ b/benchmark/hicache/bench_unified_radix_ab.py
@@ -1,0 +1,447 @@
+"""Standalone A/B serving benchmark for HiCache Stage 1 (S1c).
+
+Compares three cache configurations on a single TPU pod:
+  - ``no-cache``  (``--disable-radix-cache``): no prefix reuse, the floor.
+  - ``radix``     (default RadixCache): the current production baseline.
+  - ``unified``   (``--enable-unified-radix-tree``): the S1c UnifiedRadixCache.
+
+For each (config x workload) it launches one server, runs ``bench_serving``
+``--repeats`` times (cold each rep via ``/flush_cache``), drops the first
+``--drop-first`` warmup reps, then reports pooled TTFT percentiles, mean+/-std
+throughput, and mean cache-hit-rate, plus a few soft acceptance checks.
+
+This is M1 throughput/TTFT evidence for S1c. It is run MANUALLY on a v6e-4
+host (e.g. sky-yh-v6e4); it is NOT registered in CI. Servers are launched
+sequentially -- one TPU pod, never two servers at once.
+
+Usage (on the TPU host, from the repo root)::
+
+    python benchmark/hicache/bench_unified_radix_ab.py \
+        --model Qwen/Qwen3-8B --tp-size 4 --page-size 128 --port 20000 \
+        --configs no-cache radix unified --workloads random gsp \
+        --output-json /tmp/s1c_ab.json
+
+MoE usage (Qwen3-MoE under tp/ep/dp)::
+
+    python benchmark/hicache/bench_unified_radix_ab.py \
+        --model /models/Qwen3-30B-A3B --tp-size 4 --ep-size 4 --moe-backend epmoe \
+        --page-size 256 --configs radix unified --output-json /tmp/moe_ab.json
+
+Multi-chip note:
+    --tp-size is the TOTAL chip count; --dp-size sub-partitions it (attention runs
+    at tp_size // dp_size). At --tp-size > 1, --precompile-bs-paddings values must be
+    divisible by --tp-size (validated at startup): a decode batch not divisible by the
+    device count hits a pre-existing tp>1 sampler lax.cond sharding bug. Widen the set
+    to cover higher --max-concurrency.
+
+GSP disk-cache warning:
+    The generated-shared-prefix dataset is pickled under ``~/.cache/sglang``
+    keyed by the GSP shape, ``--seed``, and tokenizer *class* (not the model), so
+    switching models with the same tokenizer class reuses stale prompts -- use a
+    fresh ``--seed`` or cache dir.
+"""
+
+import argparse
+import json
+import time
+
+import numpy as np
+
+CONFIG_ARGS = {
+    "no-cache": ["--disable-radix-cache"],
+    "radix": [],
+    "unified": ["--enable-unified-radix-tree"],
+}
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="A/B serving benchmark: no-cache / RadixCache / UnifiedRadixCache (S1c).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--model", default="Qwen/Qwen3-8B")
+    p.add_argument("--tp-size", type=int, default=4)
+    p.add_argument("--ep-size", type=int, default=1)
+    p.add_argument("--dp-size", type=int, default=1)
+    p.add_argument("--moe-backend", default=None, help="e.g. epmoe; emitted only when set")
+    p.add_argument("--page-size", type=int, default=128)
+    p.add_argument("--port", type=int, default=20000)
+    p.add_argument("--repeats", type=int, default=5)
+    p.add_argument("--drop-first", type=int, default=2)
+    p.add_argument(
+        "--configs",
+        nargs="+",
+        choices=["no-cache", "radix", "unified"],
+        default=["no-cache", "radix", "unified"],
+    )
+    p.add_argument(
+        "--workloads",
+        nargs="+",
+        choices=["random", "gsp"],
+        default=["random", "gsp"],
+    )
+    p.add_argument("--max-concurrency", type=int, default=64)
+    p.add_argument("--num-prompts", type=int, default=256)
+    p.add_argument("--random-input-len", type=int, default=1024)
+    p.add_argument("--random-output-len", type=int, default=128)
+    p.add_argument("--gsp-num-groups", type=int, default=16)
+    p.add_argument("--gsp-prompts-per-group", type=int, default=8)
+    p.add_argument("--gsp-system-prompt-len", type=int, default=2048)
+    p.add_argument("--gsp-question-len", type=int, default=128)
+    p.add_argument("--gsp-output-len", type=int, default=128)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--mem-fraction-static", type=float, default=0.8)
+    p.add_argument("--attention-backend", default="fa")
+    p.add_argument(
+        "--precompile-bs-paddings",
+        nargs="+",
+        type=int,
+        default=[8, 16, 32, 64],
+        help=(
+            "Decode batch buckets the running batch pads up to. At --tp-size > 1 "
+            "every value must be divisible by --tp-size (a non-divisible decode "
+            "batch hits a pre-existing tp>1 sampler sharding bug); cover the "
+            "concurrency range."
+        ),
+    )
+    p.add_argument(
+        "--precompile-token-paddings",
+        nargs="+",
+        type=int,
+        default=[2048],
+        help="Prefill token buckets to precompile (off-bucket shapes JIT on demand).",
+    )
+    p.add_argument("--output-json", default=None)
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if any soft-target check fails.",
+    )
+    p.add_argument(
+        "--dataset-random-ids",
+        action="store_true",
+        help=(
+            "Use dataset_name 'random-ids' instead of 'random' (synthetic token "
+            "ids) when the host has no ShareGPT access."
+        ),
+    )
+    args = p.parse_args()
+    assert args.page_size >= 128, f"--page-size must be >= 128, got {args.page_size}"
+    if args.tp_size > 1:
+        bad = [b for b in args.precompile_bs_paddings if b % args.tp_size != 0]
+        assert not bad, (
+            f"--precompile-bs-paddings {bad} not divisible by --tp-size "
+            f"{args.tp_size} (hits the tp>1 sampler sharding bug)"
+        )
+    return args
+
+
+def _per_run_args(args, base_url, workload):
+    """Build a per-run bench_serving SimpleNamespace via get_benchmark_args."""
+    from sgl_jax.test.test_utils import get_benchmark_args
+
+    if workload == "random":
+        run_args = get_benchmark_args(
+            base_url=base_url,
+            dataset_name="random-ids" if args.dataset_random_ids else "random",
+            device="tpu",
+            tokenizer=args.model,
+            num_prompts=args.num_prompts,
+            random_input_len=args.random_input_len,
+            random_output_len=args.random_output_len,
+            random_range_ratio=1.0,
+            max_concurrency=args.max_concurrency,
+            seed=args.seed,
+            warmup_requests=1,
+        )
+    elif workload == "gsp":
+        num_prompts = args.gsp_num_groups * args.gsp_prompts_per_group
+        run_args = get_benchmark_args(
+            base_url=base_url,
+            dataset_name="generated-shared-prefix",
+            device="tpu",
+            tokenizer=args.model,
+            num_prompts=num_prompts,
+            max_concurrency=args.max_concurrency,
+            seed=args.seed,
+            warmup_requests=1,
+            gsp_num_groups=args.gsp_num_groups,
+            gsp_prompts_per_group=args.gsp_prompts_per_group,
+            gsp_system_prompt_len=args.gsp_system_prompt_len,
+            gsp_question_len=args.gsp_question_len,
+            gsp_output_len=args.gsp_output_len,
+            gsp_range_ratio=1.0,
+        )
+    else:
+        raise ValueError(f"unknown workload {workload!r}")
+
+    # run_benchmark always appends a per-run JSONL; metrics come from its return
+    # value, so /dev/null avoids stray files without losing data.
+    run_args.output_file = "/dev/null"
+    run_args.flush_cache = True  # flush after warmup -> each rep starts cold
+    return run_args
+
+
+def run_config(args, config):
+    """Launch one server for ``config`` and run all workloads x repeats."""
+    from sgl_jax.bench_serving import run_benchmark
+    from sgl_jax.srt.utils import kill_process_tree
+    from sgl_jax.test.test_utils import popen_launch_server
+
+    base_url = f"http://127.0.0.1:{args.port}"
+    common = [
+        "--trust-remote-code",
+        "--skip-server-warmup",
+        "--dtype",
+        "bfloat16",
+        "--random-seed",
+        "3",
+        "--mem-fraction-static",
+        str(args.mem_fraction_static),
+        "--max-running-requests",
+        "256",
+        "--page-size",
+        str(args.page_size),
+        "--tp-size",
+        str(args.tp_size),
+        "--attention-backend",
+        args.attention_backend,
+        "--download-dir",
+        "/dev/shm/",
+    ]
+    common += ["--precompile-bs-paddings", *[str(b) for b in args.precompile_bs_paddings]]
+    common += ["--precompile-token-paddings", *[str(t) for t in args.precompile_token_paddings]]
+    # Emit parallelism/MoE flags only when set, so the default dense command stays
+    # byte-identical and main-compatible. --tp-size is the TOTAL chip count;
+    # --dp-size sub-partitions it (attention runs at tp_size // dp_size).
+    if args.dp_size > 1:
+        common += ["--dp-size", str(args.dp_size)]
+    if args.ep_size > 1:
+        common += ["--ep-size", str(args.ep_size)]
+    if args.moe_backend:
+        common += ["--moe-backend", args.moe_backend]
+
+    # config -> {workload -> [res dict per rep]}
+    results = {w: [] for w in args.workloads}
+
+    process = popen_launch_server(
+        args.model,
+        base_url=base_url,
+        timeout=1800,
+        other_args=common + CONFIG_ARGS[config],
+        check_cache_miss=False,
+        # A stray SGLANG_JAX_ENABLE_UNIFIED_RADIX_TREE=1 in the caller's env
+        # would silently turn the baselines into unified (env can only force
+        # the flag ON); pin it off -- "unified" gets the flag via CLI.
+        env={"SGLANG_JAX_ENABLE_UNIFIED_RADIX_TREE": "0"},
+    )
+    try:
+        for workload in args.workloads:
+            for rep in range(args.repeats):
+                print(
+                    f"\n=== config={config} workload={workload} "
+                    f"rep={rep + 1}/{args.repeats} ===",
+                    flush=True,
+                )
+                run_args = _per_run_args(args, base_url, workload)
+                try:
+                    res = run_benchmark(run_args)
+                except Exception as e:  # noqa: BLE001
+                    # Don't let one failed rep (OOM, transient hiccup, or
+                    # run_benchmark's NameError on zero completions) abort the sweep.
+                    print(
+                        f"!!! rep failed (config={config} workload={workload} "
+                        f"rep={rep + 1}): {e!r}; skipping this rep",
+                        flush=True,
+                    )
+                    continue
+                # A partially-failed rep would skew stats (failed requests carry
+                # ttft=0.0 and missing tokens); count it as failed instead.
+                completed = res.get("completed", 0)
+                if completed != run_args.num_prompts:
+                    print(
+                        f"!!! rep incomplete (config={config} workload={workload} "
+                        f"rep={rep + 1}): completed={completed}/{run_args.num_prompts}; "
+                        "skipping this rep",
+                        flush=True,
+                    )
+                    continue
+                results[workload].append(res)
+    finally:
+        kill_process_tree(process.pid)
+        process.wait()
+        time.sleep(10)  # let the TPU free before the next config
+
+    return results
+
+
+def _sample_std(x):
+    """Sample std (ddof=1); 0.0 for a single kept rep (ddof=1 would be nan)."""
+    return float(x.std(ddof=1)) if len(x) > 1 else 0.0
+
+
+def aggregate(args, raw):
+    """Aggregate raw[config][workload] = [res, ...] into per-cell stats."""
+    agg = {}
+    for config, by_workload in raw.items():
+        agg[config] = {}
+        for workload, reps in by_workload.items():
+            kept = reps[args.drop_first :]
+            if not kept:
+                continue
+            pooled_ttft = []
+            for res in kept:
+                # bench_serving's per-request ttfts are unfiltered: failed
+                # requests carry the 0.0 default, which would fake-improve
+                # percentiles. Reps are already completeness-checked; this
+                # guards the per-request layer.
+                pooled_ttft.extend(t for t in (res.get("ttfts") or []) if t > 0)
+            if pooled_ttft:
+                p50, p95, p99 = np.percentile(pooled_ttft, [50, 95, 99]) * 1000.0
+            else:
+                p50 = p95 = p99 = float("nan")
+
+            out_tps = np.array([res["output_throughput"] for res in kept], dtype=float)
+            total_tps = np.array([res["total_throughput"] for res in kept], dtype=float)
+            hit_rate = np.array([res.get("cache_hit_rate", 0.0) for res in kept], dtype=float)
+
+            agg[config][workload] = {
+                "p50_ttft_ms": float(p50),
+                "p95_ttft_ms": float(p95),
+                "p99_ttft_ms": float(p99),
+                "out_tok_s_mean": float(out_tps.mean()),
+                "out_tok_s_std": _sample_std(out_tps),
+                "total_tok_s_mean": float(total_tps.mean()),
+                "total_tok_s_std": _sample_std(total_tps),
+                "hit_rate_mean": float(hit_rate.mean()),
+                "kept_reps": len(kept),
+            }
+    return agg
+
+
+def print_table(args, agg):
+    header = (
+        f"{'workload':<10} {'config':<10} {'p50_ttft':>10} {'p95_ttft':>10} "
+        f"{'p99_ttft':>10} {'out_tok/s':>20} {'total_tok/s':>20} {'hit_rate':>9}"
+    )
+    print("\n" + "=" * len(header))
+    print(header)
+    print("-" * len(header))
+    for workload in args.workloads:
+        for config in args.configs:
+            cell = agg.get(config, {}).get(workload)
+            if cell is None:
+                continue
+            out_str = f"{cell['out_tok_s_mean']:.1f}+/-{cell['out_tok_s_std']:.1f}"
+            total_str = f"{cell['total_tok_s_mean']:.1f}+/-{cell['total_tok_s_std']:.1f}"
+            print(
+                f"{workload:<10} {config:<10} "
+                f"{cell['p50_ttft_ms']:>10.2f} {cell['p95_ttft_ms']:>10.2f} "
+                f"{cell['p99_ttft_ms']:>10.2f} {out_str:>20} "
+                f"{total_str:>20} {cell['hit_rate_mean']:>9.4f}"
+            )
+    print("=" * len(header))
+
+
+def check_sweep_complete(args, raw):
+    """Fail loudly if any requested (config, workload) cell lacks enough reps.
+
+    Failed reps are skipped, and empty cells drop out of the table + soft-target
+    checks -- so without this an all-failed cell would look like a clean pass.
+    Every requested cell needs >= drop_first + 1 successful reps (>= 1 survives
+    the warmup drop); fewer is a sweep failure.
+    """
+    print("\n--- sweep completeness ---")
+    min_required = args.drop_first + 1
+    complete = True
+    for config in args.configs:
+        for workload in args.workloads:
+            n = len(raw.get(config, {}).get(workload, []))
+            if n < min_required:
+                complete = False
+                tag = "FAIL"
+            elif n < args.repeats:
+                tag = "WARN"
+            else:
+                tag = "PASS"
+            print(
+                f"[{tag}] {config}/{workload}: {n}/{args.repeats} reps ok (need >= {min_required})"
+            )
+    return complete
+
+
+def soft_targets(args, agg):
+    """Print PASS/WARN per check. Returns True if all checks passed."""
+    print("\n--- soft-target report ---")
+    all_pass = True
+
+    def have(config, workload):
+        return agg.get(config, {}).get(workload) is not None
+
+    # 1. random: unified degradation < 5% vs radix total throughput.
+    if "random" in args.workloads and have("unified", "random") and have("radix", "random"):
+        u = agg["unified"]["random"]["total_tok_s_mean"]
+        r = agg["radix"]["random"]["total_tok_s_mean"]
+        ok = u >= 0.95 * r
+        all_pass = all_pass and ok
+        print(
+            f"[{'PASS' if ok else 'WARN'}] random: unified.total_tok/s ({u:.1f}) "
+            f">= 0.95 * radix.total_tok/s ({0.95 * r:.1f})"
+        )
+
+    # 2. gsp: unified hit-rate >= radix hit-rate.
+    if "gsp" in args.workloads and have("unified", "gsp") and have("radix", "gsp"):
+        u = agg["unified"]["gsp"]["hit_rate_mean"]
+        r = agg["radix"]["gsp"]["hit_rate_mean"]
+        ok = u >= r
+        all_pass = all_pass and ok
+        print(
+            f"[{'PASS' if ok else 'WARN'}] gsp: unified.hit_rate ({u:.4f}) "
+            f">= radix.hit_rate ({r:.4f})"
+        )
+
+    # 3. gsp: unified p50 TTFT < no-cache p50 TTFT (warn if ratio >= 0.9).
+    if "gsp" in args.workloads and have("unified", "gsp") and have("no-cache", "gsp"):
+        u = agg["unified"]["gsp"]["p50_ttft_ms"]
+        nc = agg["no-cache"]["gsp"]["p50_ttft_ms"]
+        ratio = u / nc if nc else float("nan")
+        ok = ratio < 0.9
+        all_pass = all_pass and ok
+        print(
+            f"[{'PASS' if ok else 'WARN'}] gsp: unified.p50_ttft ({u:.2f}) "
+            f"vs no-cache.p50_ttft ({nc:.2f}), ratio={ratio:.3f} (want < 0.9)"
+        )
+
+    return all_pass
+
+
+def main():
+    args = parse_args()
+    print(f"args={args}\n", flush=True)
+
+    raw = {}
+    for config in args.configs:
+        raw[config] = run_config(args, config)
+
+    agg = aggregate(args, raw)
+    print_table(args, agg)
+    complete = check_sweep_complete(args, raw)
+    targets_pass = soft_targets(args, agg)
+    all_pass = complete and targets_pass
+
+    if args.output_json:
+        payload = {
+            "args": vars(args),
+            "raw": raw,
+            "aggregates": agg,
+        }
+        with open(args.output_json, "w") as f:
+            json.dump(payload, f, indent=2, default=str)
+        print(f"\nWrote results to {args.output_json}")
+
+    if args.strict and not all_pass:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sgl_jax/bench_serving.py
+++ b/python/sgl_jax/bench_serving.py
@@ -105,6 +105,7 @@ class RequestFuncOutput:
     prompt_len: int = 0
     error: str = ""
     output_len: int = 0
+    cached_tokens: int = 0
     start_time: float = 0.0
 
     @staticmethod
@@ -608,6 +609,7 @@ async def async_request_sglang_generate(
                                 timestamp = time.perf_counter()
                                 generated_text = data["text"]
                                 output_len = data["meta_info"]["completion_tokens"]
+                                output.cached_tokens = data["meta_info"].get("cached_tokens", 0)
 
                                 # First token
                                 if ttft == 0.0:
@@ -915,6 +917,8 @@ class BenchmarkMetrics:
     concurrency: float
     max_output_tokens_per_s: float = 0.0
     max_concurrent_requests: int = 0
+    total_cached_tokens: int = 0
+    cache_hit_rate: float = 0.0
 
 
 SHAREGPT_REPO_ID = "anon8231489123/ShareGPT_Vicuna_unfiltered"
@@ -1943,6 +1947,8 @@ def calculate_metrics(
     total_input = 0
     total_input_text = 0
     total_input_vision = 0
+    total_cached = 0
+    total_prompt_tokens = 0
     completed = 0
     itls: list[float] = []
     tpots: list[float] = []
@@ -1964,6 +1970,8 @@ def calculate_metrics(
                 tokenizer.encode(outputs[i].generated_text, add_special_tokens=False)
             )
             retokenized_output_lens.append(retokenized_output_len)
+            total_cached += outputs[i].cached_tokens
+            total_prompt_tokens += outputs[i].prompt_len
             if input_requests is not None:
                 total_input += input_requests[i].prompt_len
                 total_input_text += input_requests[i].text_prompt_len
@@ -2092,6 +2100,8 @@ def calculate_metrics(
         concurrency=np.sum(e2e_latencies) / dur_s,
         max_output_tokens_per_s=max_output_tokens_per_s,
         max_concurrent_requests=max_concurrent_requests,
+        total_cached_tokens=total_cached,
+        cache_hit_rate=total_cached / total_prompt_tokens if total_prompt_tokens > 0 else 0.0,
     )
 
     return metrics, output_lens
@@ -2401,6 +2411,8 @@ async def benchmark(
             "Total generated tokens (retokenized):", metrics.total_output_retokenized
         )
     )
+    print("{:<40} {:<10}".format("Total cached tokens:", metrics.total_cached_tokens))
+    print("{:<40} {:<10.4f}".format("Cache hit rate:", metrics.cache_hit_rate))
     print("{:<40} {:<10.2f}".format("Request throughput (req/s):", metrics.request_throughput))
     print("{:<40} {:<10.2f}".format("Input token throughput (tok/s):", metrics.input_throughput))
     print("{:<40} {:<10.2f}".format("Output token throughput (tok/s):", metrics.output_throughput))
@@ -2464,6 +2476,8 @@ async def benchmark(
             "total_input_vision_tokens": metrics.total_input_vision,
             "total_output_tokens": metrics.total_output,
             "total_output_tokens_retokenized": metrics.total_output_retokenized,
+            "total_cached_tokens": metrics.total_cached_tokens,
+            "cache_hit_rate": metrics.cache_hit_rate,
             "request_throughput": metrics.request_throughput,
             "input_throughput": metrics.input_throughput,
             "output_throughput": metrics.output_throughput,
@@ -2514,6 +2528,7 @@ async def benchmark(
     result_details = {
         "input_lens": [output.prompt_len for output in outputs],
         "output_lens": output_lens,
+        "cached_tokens": [output.cached_tokens for output in outputs],
         "ttfts": [output.ttft for output in outputs],
         "itls": [output.itl for output in outputs],
         "generated_texts": [output.generated_text for output in outputs],

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -35,7 +35,11 @@ from sgl_jax.srt.mem_cache.allocator import (
     BaseTokenToKVPoolAllocator,
     SWATokenToKVPoolAllocator,
 )
-from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache
+from sgl_jax.srt.mem_cache.base_prefix_cache import (
+    BasePrefixCache,
+    EvictParams,
+    MatchPrefixParams,
+)
 from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
 from sgl_jax.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
@@ -435,14 +439,15 @@ class Req:
                 self.last_host_node = tree_cache.root_node
                 self.host_hit_length = 0
             else:
-                (
-                    self.prefix_indices,
-                    self.last_node,
-                    self.last_host_node,
-                    self.host_hit_length,
-                ) = tree_cache.match_prefix(
-                    key=RadixKey(self.adjust_max_prefix_ids(), self.extra_key, self.dp_rank),
+                match_result = tree_cache.match_prefix(
+                    MatchPrefixParams(
+                        key=RadixKey(self.adjust_max_prefix_ids(), self.extra_key, self.dp_rank)
+                    )
                 )
+                self.prefix_indices = match_result.device_indices
+                self.last_node = match_result.last_device_node
+                self.last_host_node = match_result.last_host_node
+                self.host_hit_length = match_result.host_hit_length
             self.last_matched_prefix_len = len(self.prefix_indices)
         self.extend_input_len = len(self.fill_ids) - len(self.prefix_indices)
 
@@ -2858,11 +2863,13 @@ class ScheduleBatch:
                 if (full_available < num_tokens or swa_available < num_tokens) and self.tree_cache:
                     full_num = max(0, num_tokens - full_available)
                     swa_num = max(0, num_tokens - swa_available)
-                    self.tree_cache.evict(full_num, swa_num, dp_rank=dp_rank)
+                    self.tree_cache.evict(
+                        EvictParams(num_tokens=full_num, swa_num_tokens=swa_num, dp_rank=dp_rank)
+                    )
             else:
                 available = self.token_to_kv_pool_allocator.available_size(dp_rank=dp_rank)
                 if available < num_tokens and self.tree_cache:
-                    self.tree_cache.evict(num_tokens, dp_rank=dp_rank)
+                    self.tree_cache.evict(EvictParams(num_tokens=num_tokens, dp_rank=dp_rank))
 
     def _is_available_size_sufficient(self, num_tokens_per_dp: dict[int, int]) -> bool:
         """Check if sufficient memory available across all DP ranks.

--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -11,7 +11,11 @@ import numpy as np
 
 from sgl_jax.srt.managers.schedule_batch import Req, ScheduleBatch
 from sgl_jax.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
-from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache
+from sgl_jax.srt.mem_cache.base_prefix_cache import (
+    BasePrefixCache,
+    InsertParams,
+    MatchPrefixParams,
+)
 from sgl_jax.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
 
 if TYPE_CHECKING:
@@ -147,12 +151,15 @@ class SchedulePolicy:
             prefix_ids = r.adjust_max_prefix_ids()
             extra_key = r.extra_key
             # NOTE: the prefix_indices must always be aligned with last_node
-            r.prefix_indices, r.last_node, r.last_host_node, r.host_hit_length = (
-                self.tree_cache.match_prefix(
-                    rid=r.rid,
-                    key=RadixKey(token_ids=prefix_ids, extra_key=extra_key, dp_rank=r.dp_rank),
+            match_result = self.tree_cache.match_prefix(
+                MatchPrefixParams(
+                    key=RadixKey(token_ids=prefix_ids, extra_key=extra_key, dp_rank=r.dp_rank)
                 )
             )
+            r.prefix_indices = match_result.device_indices
+            r.last_node = match_result.last_device_node
+            r.last_host_node = match_result.last_host_node
+            r.host_hit_length = match_result.host_hit_length
 
             # NOTE(sang): This logic is for in-batch prefix caching;
             # If there are more than 1 request that have small matching prefix from
@@ -162,10 +169,12 @@ class SchedulePolicy:
             # threshold means we cannot use in-batch prefix caching for short prefixes.
             # It is kind of common when the engine is long running (e.g., imagine the prefix "the").
             if len(r.prefix_indices) <= IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD:
-                in_batch_matching_prefixes, _, _, _ = self.waiting_queue_radix_tree.match_prefix(
-                    rid=r.rid,
-                    key=RadixKey(token_ids=prefix_ids, extra_key=extra_key, dp_rank=r.dp_rank),
+                in_batch_match = self.waiting_queue_radix_tree.match_prefix(
+                    MatchPrefixParams(
+                        key=RadixKey(token_ids=prefix_ids, extra_key=extra_key, dp_rank=r.dp_rank)
+                    )
                 )
+                in_batch_matching_prefixes = in_batch_match.device_indices
                 if (
                     len(in_batch_matching_prefixes)
                     >= IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD
@@ -174,8 +183,12 @@ class SchedulePolicy:
                 else:
                     # Insert with a dummy key
                     self.waiting_queue_radix_tree.insert(
-                        RadixKey(token_ids=prefix_ids, extra_key=extra_key, dp_rank=r.dp_rank),
-                        np.empty(len(prefix_ids), dtype=np.bool_),
+                        InsertParams(
+                            key=RadixKey(
+                                token_ids=prefix_ids, extra_key=extra_key, dp_rank=r.dp_rank
+                            ),
+                            value=np.empty(len(prefix_ids), dtype=np.bool_),
+                        )
                     )
         return temporary_deprioritized
 
@@ -470,18 +483,11 @@ class PrefillAdder:
 
     @contextmanager
     def _lock_node(self, last_node: TreeNode):
-        if self.is_hybrid:
-            try:
-                swa_uuid_for_lock = self.tree_cache.inc_lock_ref(last_node)
-                yield None
-            finally:
-                self.tree_cache.dec_lock_ref(last_node, swa_uuid_for_lock)
-        else:
-            try:
-                self.tree_cache.inc_lock_ref(last_node)
-                yield None
-            finally:
-                self.tree_cache.dec_lock_ref(last_node)
+        res = self.tree_cache.inc_lock_ref(last_node)
+        try:
+            yield None
+        finally:
+            self.tree_cache.dec_lock_ref(last_node, res.to_dec_params())
 
     def add_one_req_ignore_eos(self, req: Req):
         dp_rank = req.dp_rank if req.dp_rank is not None else 0
@@ -630,11 +636,8 @@ class PrefillAdder:
             ):
                 # Non-chunked prefill
                 self.can_run_list[dp_rank].append(req)
-                if self.is_hybrid:
-                    swa_uuid_for_lock = self.tree_cache.inc_lock_ref(req.last_node)
-                    req.swa_uuid_for_lock = swa_uuid_for_lock
-                else:
-                    self.tree_cache.inc_lock_ref(req.last_node)
+                res = self.tree_cache.inc_lock_ref(req.last_node)
+                req.swa_uuid_for_lock = res.swa_uuid_for_lock
                 self._update_prefill_budget(
                     prefix_len,
                     input_tokens,
@@ -656,11 +659,8 @@ class PrefillAdder:
 
                 self.can_run_list[dp_rank].append(req)
                 self.new_chunked_reqs[dp_rank] = req
-                if self.is_hybrid:
-                    swa_uuid_for_lock = self.tree_cache.inc_lock_ref(req.last_node)
-                    req.swa_uuid_for_lock = swa_uuid_for_lock
-                else:
-                    self.tree_cache.inc_lock_ref(req.last_node)
+                res = self.tree_cache.inc_lock_ref(req.last_node)
+                req.swa_uuid_for_lock = res.swa_uuid_for_lock
                 self._update_prefill_budget(prefix_len, trunc_len, 0, dp_rank)
 
         return self._budget_state_after_add(dp_rank)

--- a/python/sgl_jax/srt/mem_cache/base_prefix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/base_prefix_cache.py
@@ -1,12 +1,68 @@
+from __future__ import annotations
+
 import abc
+import dataclasses
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 import jax
 
 if TYPE_CHECKING:
-    from sgl_jax.srt.mem_cache.radix_cache import TreeNode
+    from sgl_jax.srt.mem_cache.radix_cache import RadixKey, TreeNode
 else:
-    TreeNode = Any  # Placeholder for TreeNode type when not type checking
+    TreeNode = Any
+
+
+@dataclasses.dataclass
+class MatchPrefixParams:
+    """Unified parameters for match_prefix across cache types."""
+
+    key: RadixKey
+
+
+@dataclasses.dataclass
+class InsertParams:
+    """Unified parameters for insert across cache types."""
+
+    key: RadixKey | None = None
+    value: Any = None
+    # SWA-specific: consumed by SWARadixCache, ignored by RadixCache.
+    prev_prefix_len: int = 0
+    swa_evicted_seqlen: int = 0
+
+
+@dataclasses.dataclass
+class EvictParams:
+    """Unified parameters for evict across cache types."""
+
+    num_tokens: int = 0
+    swa_num_tokens: int = 0
+    dp_rank: int | None = None
+
+
+@dataclasses.dataclass
+class EvictResult:
+    """Result of an evict operation."""
+
+    num_tokens_evicted: int = 0
+    swa_num_tokens_evicted: int = 0
+
+
+@dataclasses.dataclass
+class DecLockRefParams:
+    """Parameters for dec_lock_ref."""
+
+    swa_uuid_for_lock: int | None = None
+
+
+@dataclasses.dataclass
+class IncLockRefResult:
+    """Result of inc_lock_ref."""
+
+    delta: int | None = None
+    swa_uuid_for_lock: int | None = None
+
+    def to_dec_params(self) -> DecLockRefParams:
+        return DecLockRefParams(swa_uuid_for_lock=self.swa_uuid_for_lock)
 
 
 class MatchResult(NamedTuple):
@@ -18,6 +74,8 @@ class MatchResult(NamedTuple):
         last_host_node  :   The last TreeNode on the host that was matched.
                             Note that if HiCache is not enabled,
                             this **must** be the same as `last_device_node`.
+        best_match_node :   Deepest node accepted by the match;
+                            equals last_device_node when HiCache is off.
         host_hit_length :   Length of the KV cache hit on the host, if applicable.
                             0 if HiCache is not enabled.
     """
@@ -25,6 +83,7 @@ class MatchResult(NamedTuple):
     device_indices: jax.Array
     last_device_node: TreeNode | None
     last_host_node: TreeNode | None
+    best_match_node: TreeNode | None
     host_hit_length: int = 0
 
 
@@ -36,7 +95,7 @@ class BasePrefixCache(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def match_prefix(self, key: list[int], **kwargs) -> MatchResult:
+    def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
         pass
 
     @abc.abstractmethod
@@ -48,15 +107,15 @@ class BasePrefixCache(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def evict(self, num_tokens: int, dp_rank: int | None = None):
+    def evict(self, params: EvictParams) -> EvictResult:
         pass
 
     @abc.abstractmethod
-    def inc_lock_ref(self, node: Any):
+    def inc_lock_ref(self, node: Any) -> IncLockRefResult:
         pass
 
     @abc.abstractmethod
-    def dec_lock_ref(self, node: Any, swa_uuid_for_lock: str | None = None):
+    def dec_lock_ref(self, node: Any, params: DecLockRefParams | None = None):
         pass
 
     def evictable_size(self, dp_rank: int = 0):

--- a/python/sgl_jax/srt/mem_cache/chunk_cache.py
+++ b/python/sgl_jax/srt/mem_cache/chunk_cache.py
@@ -8,7 +8,15 @@ from sgl_jax.srt.mem_cache.allocator import (
     BaseTokenToKVPoolAllocator,
     SWATokenToKVPoolAllocator,
 )
-from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache, MatchResult
+from sgl_jax.srt.mem_cache.base_prefix_cache import (
+    BasePrefixCache,
+    DecLockRefParams,
+    EvictParams,
+    EvictResult,
+    IncLockRefResult,
+    MatchPrefixParams,
+    MatchResult,
+)
 from sgl_jax.srt.mem_cache.memory_pool import ReqToTokenPool
 
 if TYPE_CHECKING:
@@ -29,11 +37,12 @@ class ChunkCache(BasePrefixCache):
     def reset(self):
         pass
 
-    def match_prefix(self, **unused_kwargs) -> MatchResult:
+    def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
         return MatchResult(
             device_indices=np.empty((0,), dtype=np.int32),
             last_device_node=None,
             last_host_node=None,
+            best_match_node=None,
         )
 
     def cache_finished_req(self, req: Req, is_insert: bool = True):
@@ -52,18 +61,13 @@ class ChunkCache(BasePrefixCache):
             req.req_pool_idx, : len(req.fill_ids)
         ].copy()
 
-    def evict(
-        self,
-        num_tokens: int,
-        swa_num_tokens: int = 0,
-        dp_rank: int | None = None,
-    ):
-        pass
+    def evict(self, params: EvictParams) -> EvictResult:
+        return EvictResult()
 
-    def inc_lock_ref(self, node: Any):
-        return 0
+    def inc_lock_ref(self, node: Any) -> IncLockRefResult:
+        return IncLockRefResult(delta=0)
 
-    def dec_lock_ref(self, node: Any, swa_uuid_for_lock: str | None = None):
+    def dec_lock_ref(self, node: Any, params: DecLockRefParams | None = None):
         return 0
 
     def pretty_print(self):

--- a/python/sgl_jax/srt/mem_cache/common.py
+++ b/python/sgl_jax/srt/mem_cache/common.py
@@ -1,7 +1,7 @@
 import logging
 
 from sgl_jax.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
-from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache
+from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
 from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
 from sgl_jax.srt.utils.common_utils import cdiv
 
@@ -87,11 +87,17 @@ def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int, d
         if full_available_size < num_tokens or swa_available_size < num_tokens:
             full_num_tokens = max(0, num_tokens - full_available_size)
             swa_num_tokens = max(0, num_tokens - swa_available_size)
-            tree_cache.evict(full_num_tokens, swa_num_tokens, dp_rank=dp_rank)
+            tree_cache.evict(
+                EvictParams(
+                    num_tokens=full_num_tokens,
+                    swa_num_tokens=swa_num_tokens,
+                    dp_rank=dp_rank,
+                )
+            )
     else:
         # Standard allocator
         if allocator.available_size(dp_rank=dp_rank) < num_tokens:
-            tree_cache.evict(num_tokens, dp_rank=dp_rank)
+            tree_cache.evict(EvictParams(num_tokens=num_tokens, dp_rank=dp_rank))
 
 
 def available_and_evictable_str(tree_cache, dp_rank: int = 0) -> str:

--- a/python/sgl_jax/srt/mem_cache/radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/radix_cache.py
@@ -12,7 +12,16 @@ import jax.numpy as jnp
 import numpy as np
 
 from sgl_jax.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
-from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache, MatchResult
+from sgl_jax.srt.mem_cache.base_prefix_cache import (
+    BasePrefixCache,
+    DecLockRefParams,
+    EvictParams,
+    EvictResult,
+    IncLockRefResult,
+    InsertParams,
+    MatchPrefixParams,
+    MatchResult,
+)
 from sgl_jax.srt.mem_cache.memory_pool import ReqToTokenPool
 
 if TYPE_CHECKING:
@@ -203,12 +212,8 @@ class RadixCache(BasePrefixCache):
         self.evictable_size_ = defaultdict(int)
         self.protected_size_ = defaultdict(int)
 
-    def match_prefix(self, key: RadixKey | list[int], **kwargs) -> MatchResult:
-        # Support both RadixKey and plain list for backward compatibility
-        if not isinstance(key, RadixKey):
-            extra_key = kwargs.get("extra_key")
-            dp_rank = kwargs.get("dp_rank")
-            key = RadixKey(key, extra_key, dp_rank)
+    def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
+        key = params.key
 
         if self.disable or len(key) == 0:
             empty_array = np.empty((0,), dtype=np.int32)
@@ -217,6 +222,7 @@ class RadixCache(BasePrefixCache):
                 device_indices=empty_array,
                 last_device_node=self.root_node,
                 last_host_node=self.root_node,
+                best_match_node=self.root_node,
                 host_hit_length=0,
             )
 
@@ -249,10 +255,14 @@ class RadixCache(BasePrefixCache):
             device_indices=matched_tokens,
             last_device_node=last_node,
             last_host_node=last_node,
+            best_match_node=last_node,
             host_hit_length=0,
         )
 
-    def insert(self, key: RadixKey | list, value=None):
+    def insert(self, params: InsertParams) -> int:
+        key = params.key
+        value = params.value
+
         if self.disable:
             return 0
 
@@ -315,8 +325,10 @@ class RadixCache(BasePrefixCache):
         if is_insert:
             # Radix Cache takes over one reference from memory pool
             new_prefix_len = self.insert(
-                RadixKey(token_ids[:page_aligned_token_len], req.extra_key, req.dp_rank),
-                page_aligned_kv_indices,
+                InsertParams(
+                    key=RadixKey(token_ids[:page_aligned_token_len], req.extra_key, req.dp_rank),
+                    value=page_aligned_kv_indices,
+                )
             )
             self.token_to_kv_pool_allocator.free(
                 kv_indices[old_prefix_len:new_prefix_len], dp_rank=dp_rank
@@ -361,13 +373,13 @@ class RadixCache(BasePrefixCache):
 
         # Radix Cache takes over one reference from memory pool
         radix_key = RadixKey(page_aligned_token_ids, req.extra_key, req.dp_rank)
-        new_prefix_len = self.insert(radix_key, page_aligned_kv_indices)
+        new_prefix_len = self.insert(InsertParams(key=radix_key, value=page_aligned_kv_indices))
         self.token_to_kv_pool_allocator.free(
             kv_indices[old_prefix_len:new_prefix_len], dp_rank=dp_rank
         )
 
         # Prefix indices may have been updated, reuse them
-        new_match_result = self.match_prefix(radix_key)
+        new_match_result = self.match_prefix(MatchPrefixParams(key=radix_key))
         new_indices = new_match_result.device_indices  # cpu
         new_last_node = new_match_result.last_device_node
 
@@ -403,9 +415,12 @@ class RadixCache(BasePrefixCache):
     def total_size(self):
         return self._total_size_helper()
 
-    def evict(self, num_tokens: int, dp_rank: int | None = None):
+    def evict(self, params: EvictParams) -> EvictResult:
+        num_tokens = params.num_tokens
+        dp_rank = params.dp_rank
+
         if self.disable:
-            return
+            return EvictResult()
 
         leaves = self._collect_leaves()
         heapq.heapify(leaves)
@@ -433,9 +448,11 @@ class RadixCache(BasePrefixCache):
             if len(x.parent.children) == 0:
                 heapq.heappush(leaves, x.parent)
 
-    def inc_lock_ref(self, node: TreeNode):
+        return EvictResult(num_tokens_evicted=num_evicted)
+
+    def inc_lock_ref(self, node: TreeNode) -> IncLockRefResult:
         if self.disable:
-            return 0
+            return IncLockRefResult(delta=0)
 
         delta = 0
         while node != self.root_node:
@@ -447,9 +464,9 @@ class RadixCache(BasePrefixCache):
                 delta -= len(node.value)
             node.lock_ref += 1
             node = node.parent
-        return delta
+        return IncLockRefResult(delta=delta)
 
-    def dec_lock_ref(self, node: TreeNode, swa_uuid_for_lock: str | None = None):
+    def dec_lock_ref(self, node: TreeNode, params: DecLockRefParams | None = None):
         if self.disable:
             return 0
 

--- a/python/sgl_jax/srt/mem_cache/registry.py
+++ b/python/sgl_jax/srt/mem_cache/registry.py
@@ -58,6 +58,27 @@ def default_radix_cache_factory(ctx: TreeCacheBuildContext) -> BasePrefixCache:
             page_size=params.page_size,
         )
 
+    if (
+        ctx.server_args.enable_unified_radix_tree
+        and not ctx.is_hybrid_swa
+        and not ctx.disable_radix_cache
+    ):
+        from sgl_jax.srt.mem_cache.unified_cache_components import ComponentType
+        from sgl_jax.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+
+        return UnifiedRadixCache(
+            req_to_token_pool=params.req_to_token_pool,
+            token_to_kv_pool_allocator=params.token_to_kv_pool_allocator,
+            page_size=params.page_size,
+            disable=False,
+            kv_head_num=ctx.model_config.get_num_kv_heads(ctx.tp_size),
+            head_dim=ctx.model_config.head_dim,
+            layer_num=ctx.model_config.num_hidden_layers,
+            max_seq_len=ctx.server_args.max_seq_len,
+            is_eagle=params.is_eagle,
+            tree_components=(ComponentType.FULL,),
+        )
+
     from sgl_jax.srt.mem_cache.radix_cache import RadixCache
 
     return RadixCache(

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -10,7 +10,16 @@ import jax.numpy as jnp
 import numpy as np
 
 from sgl_jax.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
-from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache, MatchResult
+from sgl_jax.srt.mem_cache.base_prefix_cache import (
+    BasePrefixCache,
+    DecLockRefParams,
+    EvictParams,
+    EvictResult,
+    IncLockRefResult,
+    InsertParams,
+    MatchPrefixParams,
+    MatchResult,
+)
 from sgl_jax.srt.mem_cache.memory_pool import ReqToTokenPool
 from sgl_jax.srt.mem_cache.radix_cache import RadixKey
 from sgl_jax.srt.mem_cache.radix_cache import (
@@ -332,7 +341,7 @@ class SWARadixCache(BasePrefixCache):
         self.full_lru_list = LRUList(swa=False)
         self.swa_lru_list = LRUList(swa=True)
 
-    def match_prefix(self, key: RadixKey | list[int], **kwargs) -> MatchResult:
+    def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
         """Find the matching prefix from the radix tree.
         Args:
             key: A RadixKey or list of token IDs to find a matching prefix.
@@ -343,11 +352,7 @@ class SWARadixCache(BasePrefixCache):
             The last node create a new child if the prefix is shorter
             than the last node's value.
         """
-        # Support both RadixKey and plain list for backward compatibility
-        if not isinstance(key, RadixKey):
-            extra_key = kwargs.get("extra_key")
-            dp_rank = kwargs.get("dp_rank")
-            key = RadixKey(key, extra_key, dp_rank)
+        key = params.key
 
         if self.disable or len(key) == 0:
             return MatchResult(
@@ -357,6 +362,7 @@ class SWARadixCache(BasePrefixCache):
                 ),
                 last_device_node=self.root_node,
                 last_host_node=self.root_node,
+                best_match_node=self.root_node,
             )
 
         if self.page_size != 1:
@@ -369,15 +375,15 @@ class SWARadixCache(BasePrefixCache):
             device_indices=value,
             last_device_node=last_node,
             last_host_node=last_node,
+            best_match_node=last_node,
         )
 
-    def insert(
-        self,
-        key: RadixKey | list,
-        value=None,
-        prev_prefix_len: int = 0,
-        swa_evicted_seqlen: int = 0,
-    ) -> int:
+    def insert(self, params: InsertParams) -> int:
+        key = params.key
+        value = params.value
+        prev_prefix_len = params.prev_prefix_len
+        swa_evicted_seqlen = params.swa_evicted_seqlen
+
         if self.disable:
             return 0
 
@@ -420,10 +426,12 @@ class SWARadixCache(BasePrefixCache):
             # Radix Cache takes one ref in memory pool
             # Note: the insert function already frees the overlapped kv_indices
             self.insert(
-                RadixKey(token_ids[:page_aligned_len], req.extra_key, req.dp_rank),
-                page_aligned_kv_indices,
-                req.cache_protected_len,
-                swa_evicted_seqlen=req.swa_evicted_seqlen,
+                InsertParams(
+                    key=RadixKey(token_ids[:page_aligned_len], req.extra_key, req.dp_rank),
+                    value=page_aligned_kv_indices,
+                    prev_prefix_len=req.cache_protected_len,
+                    swa_evicted_seqlen=req.swa_evicted_seqlen,
+                )
             )
         else:
             # cache_protected_len, not len(prefix_indices); see RadixCache.cache_finished_req.
@@ -433,7 +441,7 @@ class SWARadixCache(BasePrefixCache):
                     kv_indices[old_prefix_len:page_aligned_len], dp_rank=dp_rank
                 )
 
-        self.dec_lock_ref(req.last_node, req.swa_uuid_for_lock)
+        self.dec_lock_ref(req.last_node, DecLockRefParams(swa_uuid_for_lock=req.swa_uuid_for_lock))
 
     def cache_unfinished_req(self, req: Req, chunked=False) -> None:
         """Cache request when it is unfinished."""
@@ -458,14 +466,16 @@ class SWARadixCache(BasePrefixCache):
         # Note: the insert function already frees the overlapped kv_indices
         old_prefix_len = req.cache_protected_len
         new_prefix_len = self.insert(
-            RadixKey(page_aligned_token_ids, req.extra_key, req.dp_rank),
-            page_aligned_kv_indices,
-            old_prefix_len,
-            swa_evicted_seqlen=req.swa_evicted_seqlen,
+            InsertParams(
+                key=RadixKey(page_aligned_token_ids, req.extra_key, req.dp_rank),
+                value=page_aligned_kv_indices,
+                prev_prefix_len=old_prefix_len,
+                swa_evicted_seqlen=req.swa_evicted_seqlen,
+            )
         )
 
         match_result = self.match_prefix(
-            RadixKey(page_aligned_token_ids, req.extra_key, req.dp_rank)
+            MatchPrefixParams(key=RadixKey(page_aligned_token_ids, req.extra_key, req.dp_rank))
         )
         new_indices = match_result.device_indices
         new_last_node = match_result.last_device_node
@@ -476,8 +486,8 @@ class SWARadixCache(BasePrefixCache):
             new_indices[old_prefix_len:],
         )
 
-        self.dec_lock_ref(req.last_node, req.swa_uuid_for_lock)
-        swa_uuid_for_lock = self.inc_lock_ref(new_last_node)
+        self.dec_lock_ref(req.last_node, DecLockRefParams(swa_uuid_for_lock=req.swa_uuid_for_lock))
+        swa_uuid_for_lock = self.inc_lock_ref(new_last_node).swa_uuid_for_lock
 
         if self.page_size != 1:
             req.prefix_indices = np.concatenate([new_indices, kv_indices[len(new_indices) :]])
@@ -496,11 +506,13 @@ class SWARadixCache(BasePrefixCache):
     def total_size(self) -> tuple[int, int]:
         return self._total_size_helper()
 
-    def evict(
-        self, full_num_tokens: int, swa_num_tokens: int = 0, dp_rank: int | None = None
-    ) -> None:
+    def evict(self, params: EvictParams) -> EvictResult:
+        full_num_tokens = params.num_tokens
+        swa_num_tokens = params.swa_num_tokens
+        dp_rank = params.dp_rank
+
         if self.disable:
-            return
+            return EvictResult()
 
         full_num_evicted = 0
         swa_num_evicted = 0
@@ -600,7 +612,11 @@ class SWARadixCache(BasePrefixCache):
 
                 x = x_next
 
-    def inc_lock_ref(self, node: TreeNode) -> int | None:
+        return EvictResult(
+            num_tokens_evicted=full_num_evicted, swa_num_tokens_evicted=swa_num_evicted
+        )
+
+    def inc_lock_ref(self, node: TreeNode) -> IncLockRefResult:
         """
         Increment the lock reference count for the node. Returns the swa_uuid_for_lock, which needs
         to be passed to dec_lock_ref.
@@ -608,7 +624,7 @@ class SWARadixCache(BasePrefixCache):
         It locks the swa_lock_ref for nodes between the [last node, swa_uuid_for_lock], inclusive.
         """
         if self.disable:
-            return None
+            return IncLockRefResult()
 
         swa_lock_size = 0
         swa_uuid_for_lock = None
@@ -642,15 +658,16 @@ class SWARadixCache(BasePrefixCache):
                         node.swa_uuid = gen_swa_uuid()
                     swa_uuid_for_lock = node.swa_uuid
             node = node.parent
-        return swa_uuid_for_lock
+        return IncLockRefResult(swa_uuid_for_lock=swa_uuid_for_lock)
 
-    def dec_lock_ref(self, node: TreeNode, swa_uuid_for_lock: int | None = None):
+    def dec_lock_ref(self, node: TreeNode, params: DecLockRefParams | None = None):
         """
         Decrement the lock reference count for the node.
         It unlocks the full_lock_ref for nodes between the [last node, root), exclusive.
         It unlocks the swa_lock_ref for nodes between the [last node, swa_uuid_for_lock], inclusive.
         If swa_uuid_for_lock is None, it unlocks to the root, exclusive.
         """
+        swa_uuid_for_lock = params.swa_uuid_for_lock if params is not None else None
         if self.disable:
             return
 

--- a/python/sgl_jax/srt/mem_cache/unified_cache_components/__init__.py
+++ b/python/sgl_jax/srt/mem_cache/unified_cache_components/__init__.py
@@ -1,0 +1,29 @@
+from sgl_jax.srt.mem_cache.unified_cache_components.full_component import FullComponent
+from sgl_jax.srt.mem_cache.unified_cache_components.tree_component import (
+    _NUM_COMPONENT_TYPES,
+    BASE_COMPONENT_TYPE,
+    CacheTransferPhase,
+    ComponentData,
+    ComponentType,
+    EvictLayer,
+    InsertResult,
+    LRURefreshPhase,
+    TreeComponent,
+    get_and_increase_time_counter,
+    next_component_uuid,
+)
+
+__all__ = [
+    "BASE_COMPONENT_TYPE",
+    "CacheTransferPhase",
+    "ComponentData",
+    "ComponentType",
+    "EvictLayer",
+    "FullComponent",
+    "InsertResult",
+    "LRURefreshPhase",
+    "TreeComponent",
+    "_NUM_COMPONENT_TYPES",
+    "get_and_increase_time_counter",
+    "next_component_uuid",
+]

--- a/python/sgl_jax/srt/mem_cache/unified_cache_components/full_component.py
+++ b/python/sgl_jax/srt/mem_cache/unified_cache_components/full_component.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import heapq
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from sgl_jax.srt.mem_cache.base_prefix_cache import (
+    DecLockRefParams,
+    EvictParams,
+    IncLockRefResult,
+)
+from sgl_jax.srt.mem_cache.unified_cache_components.tree_component import (
+    ComponentType,
+    EvictLayer,
+    TreeComponent,
+)
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.mem_cache.cache_init_params import CacheInitParams
+    from sgl_jax.srt.mem_cache.unified_radix_cache import (
+        UnifiedRadixCache,
+        UnifiedTreeNode,
+    )
+
+
+class FullComponent(TreeComponent):
+    component_type = ComponentType.FULL
+
+    def __init__(self, cache: UnifiedRadixCache, params: CacheInitParams | None = None):
+        super().__init__(cache, params)
+        self._free_full = cache.token_to_kv_pool_allocator.free
+        # HiCache state: set to host KV pool when HiCache enabled (not in stage 1)
+        self._full_kv_pool_host = None
+
+    def create_match_validator(
+        self, match_device_only: bool = False
+    ) -> Callable[[UnifiedTreeNode], bool]:
+        # Stage 1 has no host tier, so device-only and default matching coincide.
+        return lambda node: node.component_data[self.component_type].value is not None
+
+    def redistribute_on_node_split(self, new_parent: UnifiedTreeNode, child: UnifiedTreeNode):
+        ct = self.component_type
+        new_parent.component_data[ct].lock_ref = child.component_data[ct].lock_ref
+        child_cd = child.component_data[ct]
+        split_len = len(new_parent.key)
+        if child_cd.value is not None:
+            new_parent.component_data[ct].value = child_cd.value[:split_len].copy()
+            child_cd.value = child_cd.value[split_len:].copy()
+
+    def evict_component(
+        self,
+        node: UnifiedTreeNode,
+        target: EvictLayer = EvictLayer.DEVICE,
+    ) -> tuple[int, int]:
+        cd = node.component_data[self.component_type]
+        freed = 0
+
+        if EvictLayer.DEVICE in target and cd.value is not None:
+            node_dp_rank = node.key.dp_rank if node.key and node.key.dp_rank is not None else 0
+            freed = len(cd.value)
+            self._free_full(cd.value, dp_rank=node_dp_rank)
+            self.cache.component_evictable_size_[self.component_type][node_dp_rank] -= freed
+            # NOTE: cd.value = None is deferred to _cascade_evict (Full as trigger)
+            # because SWA's free_swa still needs to read Full.value.
+        return freed, 0
+
+    def eviction_priority(self, is_leaf: bool) -> int:
+        return 0 if is_leaf else 2
+
+    def drive_eviction(self, params: EvictParams, tracker: dict[ComponentType, int]) -> None:
+        request = params.num_tokens
+        dp_rank = params.dp_rank
+        # UnifiedTreeNode.__lt__ compares last_access_time, so heapifying the
+        # node objects directly yields LRU order.
+        heap = list(self.cache.evictable_device_leaves)
+        heapq.heapify(heap)
+        ct = self.component_type
+        while tracker[ct] < request and heap:
+            x = heapq.heappop(heap)
+            if x not in self.cache.evictable_device_leaves:
+                continue
+            node_dp_rank = x.key.dp_rank if x.key and x.key.dp_rank is not None else 0
+            if dp_rank is not None and node_dp_rank != dp_rank:
+                continue
+            self.cache._evict_device_leaf(x, tracker)
+            if x.parent is not None and x.parent in self.cache.evictable_device_leaves:
+                heapq.heappush(heap, x.parent)
+
+    def acquire_component_lock(
+        self,
+        node: UnifiedTreeNode,
+        result: IncLockRefResult,
+        lock_host: bool = False,
+    ) -> IncLockRefResult:
+        if lock_host:
+            # No host tier in stage 1.
+            return result
+
+        ct = self.component_type
+        root = self.cache.root_node
+        cur = node
+
+        # Stage 1 has no tombstones (device eviction deletes leaves), so a
+        # live node's FULL value is never None on a lock path.
+        delta = 0
+        while cur is not root:
+            cd = cur.component_data[ct]
+            assert (
+                cd.value is not None
+            ), f"FULL invariant broken: evicted node {cur.id} on lock path"
+            if cd.lock_ref == 0:
+                key_len = len(cd.value)
+                cur_dp_rank = cur.key.dp_rank if cur.key and cur.key.dp_rank is not None else 0
+                self.cache.component_evictable_size_[ct][cur_dp_rank] -= key_len
+                self.cache.component_protected_size_[ct][cur_dp_rank] += key_len
+                # This repo's convention (RadixCache.inc_lock_ref): delta is the
+                # evictable-size change, negative on acquire.
+                delta -= key_len
+            cd.lock_ref += 1
+            self.cache.evictable_device_leaves.discard(cur)
+            cur = cur.parent
+        result.delta = delta
+        return result
+
+    def release_component_lock(
+        self,
+        node: UnifiedTreeNode,
+        params: DecLockRefParams | None,
+        lock_host: bool = False,
+    ) -> None:
+        if lock_host:
+            # No host tier in stage 1.
+            return
+
+        ct = self.component_type
+        root = self.cache.root_node
+        cur = node
+        while cur is not root:
+            cd = cur.component_data[ct]
+            assert cd.value is not None
+            assert cd.lock_ref > 0
+
+            if cd.lock_ref == 1:
+                key_len = len(cd.value)
+                cur_dp_rank = cur.key.dp_rank if cur.key and cur.key.dp_rank is not None else 0
+                self.cache.component_evictable_size_[ct][cur_dp_rank] += key_len
+                self.cache.component_protected_size_[ct][cur_dp_rank] -= key_len
+            cd.lock_ref -= 1
+            if cd.lock_ref == 0:
+                self.cache._update_evictable_leaf_sets(cur)
+            cur = cur.parent

--- a/python/sgl_jax/srt/mem_cache/unified_cache_components/tree_component.py
+++ b/python/sgl_jax/srt/mem_cache/unified_cache_components/tree_component.py
@@ -1,0 +1,415 @@
+"""Component layer for UnifiedRadixCache.
+
+Stage 1 ships only the FULL (full-attention) component. The seam surface is
+deliberately wider than what stage 1 exercises: CacheTransferPhase /
+LRURefreshPhase / next_component_uuid / eviction_priority /
+recover_after_unevict / value_len / the ComponentType.is_* helpers and the
+unused ``params`` ctor arg exist so SWA / Mamba / HiCache components can land
+against a stable contract without re-touching this module.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Sequence
+from enum import IntEnum, IntFlag, StrEnum
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from sgl_jax.srt.mem_cache.base_prefix_cache import (
+    DecLockRefParams,
+    EvictParams,
+    IncLockRefResult,
+    InsertParams,
+    MatchPrefixParams,
+    MatchResult,
+)
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.managers.schedule_batch import Req
+    from sgl_jax.srt.mem_cache.cache_init_params import CacheInitParams
+    from sgl_jax.srt.mem_cache.unified_radix_cache import (
+        UnifiedRadixCache,
+        UnifiedTreeNode,
+    )
+
+
+class ComponentType(IntEnum):
+    """Integer enum so that per-node list/tuple storage can be indexed directly."""
+
+    FULL = 0
+    SWA = 1
+    MAMBA = 2
+
+    def __str__(self) -> str:  # keep human-readable logging
+        return self.name.lower()
+
+    @property
+    def is_full(self) -> bool:
+        return self == ComponentType.FULL
+
+    @property
+    def is_swa(self) -> bool:
+        return self == ComponentType.SWA
+
+    @property
+    def is_mamba(self) -> bool:
+        return self == ComponentType.MAMBA
+
+
+BASE_COMPONENT_TYPE = ComponentType.FULL
+_NUM_COMPONENT_TYPES = len(ComponentType)
+
+_LAST_ACCESS_TIME_COUNTER_FLOAT = np.float64(1.0)
+_COMPONENT_UUID_COUNTER = 1
+
+
+@dataclasses.dataclass
+class ComponentData:
+    value: np.ndarray | None = None
+    lock_ref: int = 0
+    host_value: np.ndarray | None = None
+    host_lock_ref: int = 0
+
+
+@dataclasses.dataclass
+class InsertResult:
+    """Result of an insert operation.
+
+    Lean stage-1 version (upstream keeps this in base_prefix_cache);
+    used only in component seam annotations."""
+
+    prefix_len: int = 0
+
+
+class EvictLayer(IntFlag):
+    """Which storage layer(s) to evict.  Combinable via bitwise OR."""
+
+    DEVICE = 1
+    HOST = 2
+    ALL = DEVICE | HOST
+
+
+class CacheTransferPhase(StrEnum):
+
+    BACKUP_HOST = "backup_host"  # D→H
+    LOAD_BACK = "load_back"  # H→D
+    BACKUP_STORAGE = "backup_storage"  # H→Storage
+    PREFETCH = "prefetch"  # Storage→H
+
+
+class LRURefreshPhase(StrEnum):
+
+    WALKDOWN = "walkdown"  # touching a node while walking through the tree
+    MATCH_END = "match_end"  # end of a successful prefix match
+    INSERT_END = "insert_end"  # after a new/updated leaf is committed
+
+
+def get_and_increase_time_counter() -> np.float64:
+    global _LAST_ACCESS_TIME_COUNTER_FLOAT
+    ret = _LAST_ACCESS_TIME_COUNTER_FLOAT
+    _LAST_ACCESS_TIME_COUNTER_FLOAT += 1.0
+    return ret
+
+
+def next_component_uuid() -> int:
+    global _COMPONENT_UUID_COUNTER
+    _COMPONENT_UUID_COUNTER += 1
+    return _COMPONENT_UUID_COUNTER
+
+
+class TreeComponent(ABC):
+    def __init__(self, cache: UnifiedRadixCache, params: CacheInitParams | None = None):
+        self.cache = cache
+
+    # Subclasses MUST set this as a class attribute (not @property)
+    component_type: ComponentType
+
+    def node_has_component_data(
+        self, node: UnifiedTreeNode, target: EvictLayer = EvictLayer.DEVICE
+    ) -> bool:
+        cd = node.component_data[self.component_type]
+        # EvictLayer is combinable: require data on every requested layer.
+        device_ok = EvictLayer.DEVICE not in target or cd.value is not None
+        host_ok = EvictLayer.HOST not in target or cd.host_value is not None
+        return device_ok and host_ok
+
+    def value_len(self, node: UnifiedTreeNode) -> int:
+        value = node.component_data[self.component_type].value
+        return len(value) if value is not None else 0
+
+    @abstractmethod
+    def create_match_validator(
+        self, match_device_only: bool = False
+    ) -> Callable[[UnifiedTreeNode], bool]:
+        """Return a per-match stateful predicate that decides whether a node
+        is a valid match boundary for this component.
+        Called once per match_prefix; the returned closure may carry state.
+        When match_device_only is true, host-backed nodes must not be accepted
+        as valid match boundaries.
+        - Full: returns True if the node has full component data.
+        - SWA: tracks accumulated length since last gap; returns True only
+          when the contiguous window reaches swa_sliding_window_size.
+        - Mamba: returns True iff the node has mamba component data."""
+        ...
+
+    def finalize_match_result(
+        self,
+        result: MatchResult,
+        params: MatchPrefixParams,
+        value_chunks: list[np.ndarray],
+        best_value_len: int,
+    ) -> MatchResult:
+        """Post-process the match result after prefix matching completes.
+        - Full & SWA: pass through unchanged.
+        - Mamba: performs copy-on-write — allocates a new mamba slot, copies
+          the matched node's mamba state into the request pool, and records
+          branching_seqlen in result."""
+        return result
+
+    def update_component_on_insert_overlap(
+        self,
+        node: UnifiedTreeNode,
+        prefix_len: int,
+        total_prefix_len: int,
+        value_slice: np.ndarray,
+        params: InsertParams,
+    ) -> int:
+        """Called per-node when an insert's key overlaps an existing node.
+        Returns the index within value_slice from which this component
+        consumed (took ownership of) the underlying KV pool slots.
+        Returns prefix_len if nothing was consumed (default).
+        In stage 1 the core discards the return value (request-caching
+        callers free the duplicate overlap instead); once aux components
+        land, _insert_helper will use it to free only the non-consumed
+        duplicate portion: value_slice[dup_start:consumed_from]."""
+        return prefix_len
+
+    def should_skip_leaf_creation(
+        self, total_prefix_len: int, key_len: int, params: InsertParams
+    ) -> bool:
+        """Return True to veto leaf creation when the entire new leaf would
+        be a tombstone for this component."""
+        return False
+
+    def recover_after_unevict(
+        self,
+        node: UnifiedTreeNode,
+        prefix_len: int,
+        total_prefix_len: int,
+        params: InsertParams,
+    ) -> None:
+        """Later-stage hook (no-op in stage 1, which has no tombstones):
+        called after the core restores the base (Full) value on an evicted
+        node during insert. Aux components (e.g. SWA) override this to
+        rebuild their own data from the freshly assigned base value when
+        their entry is still tombstoned. Default no-op."""
+        return None
+
+    def commit_insert_component_data(
+        self,
+        node: UnifiedTreeNode,
+        is_new_leaf: bool,
+        params: InsertParams,
+        result: InsertResult,
+    ) -> None:
+        """Finalize component data on the target (leaf) node after the insert
+        walk completes. Called once per insert.
+        - Full: no-op (full data is handled by _add_new_node).
+        - SWA: for new leaves, checks whether the node straddles the SWA
+          eviction boundary (swa_evicted_seqlen). If so, splits the node
+          via _split_node — the parent becomes a tombstone (no SWA) and the
+          child (the deeper portion) receives SWA data. If the entire node
+          is within the window, sets SWA directly. If entirely outside,
+          leaves SWA as None (tombstone).
+        - Mamba: sets the mamba component value from params and increments
+          evictable size."""
+        return None
+
+    @abstractmethod
+    def redistribute_on_node_split(self, new_parent: UnifiedTreeNode, child: UnifiedTreeNode):
+        """Redistribute component data between new_parent and child when a
+        node is split. new_parent is the newly created prefix node.
+        - Full: copies child's lock_ref to new_parent.
+        - SWA: slices (or copies) the swa value for new_parent, copies
+          lock_ref and the swa component_uuid, then syncs child's swa
+          value with its (now-trimmed) full_value.
+        - Mamba: sets new_parent's mamba value to None and lock_ref to 0
+          (mamba data stays on the original leaf, not on prefix nodes)."""
+        ...
+
+    @abstractmethod
+    def evict_component(
+        self,
+        node: UnifiedTreeNode,
+        target: EvictLayer = EvictLayer.DEVICE,
+    ) -> tuple[int, int]:
+        """Free this component's KV resources on a node being evicted.
+
+        *target* controls which layer(s) to evict:
+          - DEVICE: free device memory. Implementations may defer the
+                    tombstone (value = None) to the caller's cascade step
+                    (see FullComponent) — the caller owns setting
+                    value = None after all components have been driven.
+                    Host data is untouched.
+          - HOST:   free host memory (host_value = None).
+                    Device data is untouched.
+          - ALL:    free both device and host memory.
+                    No tombstone — caller will delete the node.
+
+        Returns (device_freed, host_freed) token counts."""
+        ...
+
+    def eviction_priority(self, is_leaf: bool) -> int:
+        """Eviction priority on this node type. Higher = evicted later.
+        When a component is evicted, all other components with equal or
+        lower priority on the same node are also cascade-evicted.
+
+        Leaf: all components equal (0) — evicting any cascades to all,
+        because the node will be deleted.
+
+        Internal: full=2 > swa=1 > mamba=0.
+        Why swa > mamba: SWA data on internal nodes is *path data* —
+        the sliding window needs continuous SWA coverage along the path
+        from root to the match boundary. E.g. A->B->C->D->E where C
+        and E both have mamba and the window covers C->E: if C's mamba
+        is evicted, C's SWA must stay so E remains reachable.
+        Mamba data, by contrast, is only meaningful at the match
+        boundary node; on internal nodes it
+        contributes nothing to the path. So SWA is more valuable to
+        keep and should be evicted later.
+
+        Cascade consequences:
+        - Mamba evict internal: no cascade.
+        - SWA evict internal: cascades to Mamba. SWA gone -> SWA
+          validator fails -> mamba data is useless (match requires all
+          validators to pass).
+        - Full evict internal: cascades to SWA + Mamba."""
+        return 0
+
+    @abstractmethod
+    def drive_eviction(self, params: EvictParams, tracker: dict[ComponentType, int]) -> None:
+        """Drive eviction for this component.
+        Each component extracts its own request from params, walks its own
+        candidate set (LRU order via last_access_time), evicts, and calls
+        cache._cascade_evict for priority cascade.
+        Updates the shared tracker with freed amounts for all components.
+        - Full: walks evictable device leaves, evicts full then cascades
+          the entire leaf.
+        - Mamba: walks internal/leaf candidates; tombstones internal nodes
+          (with cascade to equal-priority components like swa), cascades
+          leaves to all."""
+        ...
+
+    @abstractmethod
+    def acquire_component_lock(
+        self,
+        node: UnifiedTreeNode,
+        result: IncLockRefResult,
+        lock_host: bool = False,
+    ) -> IncLockRefResult:
+        """Increment component lock refs, protecting nodes from
+        eviction. Updates evictable → protected size on first lock.
+        - Full: path-lock — walks from node up to root, incrementing
+          lock_ref on every ancestor.
+        - SWA: path-lock — walks upward collecting swa values until the
+          sliding window is filled; records a component_uuid at the
+          boundary for release_component_lock to know where to stop.
+        - Mamba: single-node lock — only increments lock_ref on the
+          node itself (mamba state is per-leaf, not per-path).
+
+        When ``lock_host`` is True, the lock applies to host-side state:
+        - Full: single-node host lock.
+        - SWA: host window-lock with a dedicated host UUID boundary.
+        - Mamba: single-node host lock."""
+        ...
+
+    @abstractmethod
+    def release_component_lock(
+        self,
+        node: UnifiedTreeNode,
+        params: DecLockRefParams | None,
+        lock_host: bool = False,
+    ) -> None:
+        """Decrement component lock refs, un-protecting nodes.
+        Updates protected → evictable size when lock_ref drops to 0.
+        - Full: path-unlock — walks from node up to root, decrementing
+          lock_ref on every ancestor.
+        - SWA: path-unlock — walks upward, stopping at the node whose
+          component_uuid matches the one recorded during acquire.
+        - Mamba: single-node unlock — only decrements lock_ref on the
+          node itself.
+
+        When ``lock_host`` is True, the inverse host-side semantics apply."""
+        ...
+
+    def prepare_for_caching_req(
+        self,
+        req: Req,
+        insert_params: InsertParams,
+        token_ids_len: int,
+        is_finished: bool,
+    ) -> int | None:
+        """Prepare component-specific data before insert, fill component
+        fields in insert_params, return effective cache_len.
+        Return None for no truncation opinion (use full length);
+        return int >= 0 for effective cache length.
+        - Full: no-op, returns None.
+        - SWA: sets insert_params.swa_evicted_seqlen on finished; returns None.
+        - Mamba: prepares mamba_value (finished from ping-pong buffer,
+          unfinished fork from req); returns mamba_last_track_seqlen."""
+        return None
+
+    def cleanup_after_caching_req(
+        self,
+        req: Req,
+        is_finished: bool,
+        insert_result: InsertResult | None = None,
+        insert_params: InsertParams | None = None,
+    ) -> None:
+        """Post-cache cleanup for component-specific resources.
+
+        ``is_finished`` — whether the request has finished generation.
+        True means the request is complete and its resources can be released;
+        ``insert_result`` is None when insert was skipped (cache disabled
+        or the retract path); treat as "no insert happened".
+        ``insert_params`` is None when no insert flow ran (cache disabled,
+        or the finished-retract path); on other early-return paths it is
+        still provided so components can free their resources."""
+        return None
+
+    # ---- HiCache Hooks ----
+
+    def build_hicache_transfers(
+        self,
+        node: UnifiedTreeNode,
+        phase: CacheTransferPhase,
+        *,
+        req: Req | None = None,
+        token_ids: Sequence[int] | None = None,
+        prefetch_tokens: int = 0,
+        last_hash: str | None = None,
+    ) -> list | None:
+        """Build transfer descriptors for this component in the given phase.
+        Returns None if the component has nothing to transfer."""
+        return None
+
+    def commit_hicache_transfer(
+        self,
+        node: UnifiedTreeNode,
+        phase: CacheTransferPhase,
+        transfers: Sequence[Any] = (),
+        *,
+        insert_result: InsertResult | None = None,
+        pool_storage_result: Any = None,
+    ) -> None:
+        """Post-transfer bookkeeping: store host indices, update LRU, etc."""
+        return None
+
+    def drive_host_eviction(self, num_tokens: int, tracker: dict[ComponentType, int]) -> None:
+        """Evict from this component's host-side resources.
+        Called by the host pool owner when the host pool is full.
+        Default no-op for components without host storage."""
+        return None

--- a/python/sgl_jax/srt/mem_cache/unified_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/unified_radix_cache.py
@@ -1,0 +1,681 @@
+"""Unified radix cache: a component-based radix tree over the device KV cache.
+
+Stage 1 ports the FULL-attention subset of upstream sglang's UnifiedRadixCache.
+All per-component behavior (matching, locking, eviction, split redistribution)
+is delegated to TreeComponent implementations so that later stages (SWA, Mamba,
+HiCache) plug in without touching the core walk.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from functools import partial
+from typing import TYPE_CHECKING
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+from sgl_jax.srt.mem_cache.base_prefix_cache import (
+    BasePrefixCache,
+    DecLockRefParams,
+    EvictParams,
+    EvictResult,
+    IncLockRefResult,
+    InsertParams,
+    MatchPrefixParams,
+    MatchResult,
+)
+from sgl_jax.srt.mem_cache.memory_pool import ReqToTokenPool
+from sgl_jax.srt.mem_cache.radix_cache import (
+    RadixKey,
+    _convert_to_bigram_key,
+    _key_match_page_size1,
+    _key_match_paged,
+    get_child_key,
+)
+from sgl_jax.srt.mem_cache.unified_cache_components import (
+    _NUM_COMPONENT_TYPES,
+    BASE_COMPONENT_TYPE,
+    ComponentData,
+    ComponentType,
+    EvictLayer,
+    FullComponent,
+    InsertResult,
+    TreeComponent,
+    get_and_increase_time_counter,
+)
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.managers.schedule_batch import Req
+
+
+class UnifiedTreeNode:
+    counter = 0
+
+    def __init__(self, tree_components: tuple[ComponentType, ...]):
+        self.children: dict = defaultdict(partial(UnifiedTreeNode, tree_components))
+        self.parent: UnifiedTreeNode | None = None
+        self.key: RadixKey | None = None
+        self.tree_components = tree_components
+        # List indexed by ComponentType (int enum 0..N-1).
+        self.component_data: list[ComponentData] = [
+            ComponentData() for _ in range(_NUM_COMPONENT_TYPES)
+        ]
+        self.last_access_time = get_and_increase_time_counter()
+        self.id = UnifiedTreeNode.counter
+        UnifiedTreeNode.counter += 1
+
+    @property
+    def evicted(self) -> bool:
+        """Tree-level: FULL KV not on device (non-root with value=None)."""
+        return self.parent is not None and self.component_data[BASE_COMPONENT_TYPE].value is None
+
+    @property
+    def backuped(self) -> bool:
+        """Tree-level: FULL KV present on host."""
+        return self.component_data[BASE_COMPONENT_TYPE].host_value is not None
+
+    def __lt__(self, other: UnifiedTreeNode) -> bool:
+        return self.last_access_time < other.last_access_time
+
+
+COMPONENT_REGISTRY: dict[ComponentType, type[TreeComponent]] = {
+    ComponentType.FULL: FullComponent,
+}
+
+
+class UnifiedRadixCache(BasePrefixCache):
+    def __init__(
+        self,
+        req_to_token_pool: ReqToTokenPool,
+        token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
+        page_size: int = 1,
+        disable: bool = False,
+        kv_head_num: int = 32,
+        head_dim: int = 128,
+        layer_num: int = 32,
+        max_seq_len: int = 4096,
+        dtype: jnp.dtype = jnp.bfloat16,
+        enable_kv_cache_events: bool = False,
+        is_eagle: bool = False,
+        tree_components: tuple[ComponentType, ...] = (ComponentType.FULL,),
+    ):
+        self.req_to_token_pool = req_to_token_pool
+        self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
+        self.page_size = page_size
+        self.disable = disable
+        self.kv_head_num = kv_head_num
+        self.head_dim = head_dim
+        self.layer_num = layer_num
+        self.max_seq_len = max_seq_len
+        self.dtype = dtype
+        self.enable_kv_cache_events = enable_kv_cache_events
+        self.kv_event_queue: list = []
+
+        self.process_id = jax.process_index()
+
+        self.is_eagle = is_eagle
+        if is_eagle:
+            self.key_convert_fn = _convert_to_bigram_key
+        else:
+            self.key_convert_fn = lambda key: key
+
+        if self.page_size == 1:
+            self.key_match_fn = _key_match_page_size1
+            self.get_child_key_fn = get_child_key
+        else:
+            self.key_match_fn = partial(_key_match_paged, page_size=page_size)
+            self.get_child_key_fn = partial(get_child_key, page_size=page_size)
+
+        self.tree_components = tree_components
+        self.components: dict[ComponentType, TreeComponent] = {
+            ct: COMPONENT_REGISTRY[ct](self, None) for ct in tree_components
+        }
+        self._components_tuple: tuple[TreeComponent, ...] = tuple(self.components.values())
+
+        self.reset()
+
+    def reset(self):
+        self.root_node = UnifiedTreeNode(self.tree_components)
+        self.root_node.key = RadixKey(token_ids=[], extra_key=None, dp_rank=None)
+        self.root_node.component_data[BASE_COMPONENT_TYPE].value = []
+        for ct in self.tree_components:
+            self.root_node.component_data[ct].lock_ref = 1
+        # Per-component, per-dp_rank token counts.
+        self.component_evictable_size_: dict[ComponentType, defaultdict] = {
+            ct: defaultdict(int) for ct in self.tree_components
+        }
+        self.component_protected_size_: dict[ComponentType, defaultdict] = {
+            ct: defaultdict(int) for ct in self.tree_components
+        }
+        self.evictable_device_leaves: set[UnifiedTreeNode] = set()
+
+    def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
+        key = params.key
+
+        if self.disable or len(key) == 0:
+            return self._empty_match_result()
+
+        converted_key = RadixKey(self.key_convert_fn(key.token_ids), key.extra_key, key.dp_rank)
+        if self.page_size != 1:
+            page_aligned_len = len(converted_key) // self.page_size * self.page_size
+            converted_key = converted_key[:page_aligned_len]
+        if len(converted_key) == 0:
+            return self._empty_match_result()
+
+        value, best_match_node, best_value_len = self._match_prefix_helper(converted_key)
+        return self._match_post_processor(params, value, best_match_node, best_value_len)
+
+    def insert(self, params: InsertParams) -> int:
+        if self.disable:
+            return 0
+
+        key = params.key
+        value = params.value
+
+        # Support both RadixKey and plain list for backward compatibility.
+        if not isinstance(key, RadixKey):
+            key = RadixKey(key, None, None)
+
+        converted_key = RadixKey(self.key_convert_fn(key.token_ids), key.extra_key, key.dp_rank)
+
+        if value is None:
+            value = np.array(converted_key.token_ids, dtype=np.int32)
+        elif isinstance(value, list):
+            value = np.array(value, dtype=np.int32)
+
+        if self.is_eagle:
+            # Make sure the value len equals the EAGLE bigram key len.
+            value = value[: len(converted_key)]
+
+        # Page-align defensively (callers in this repo pre-align; upstream
+        # aligns here).
+        if self.page_size != 1:
+            page_aligned_len = len(converted_key) // self.page_size * self.page_size
+            converted_key = converted_key[:page_aligned_len]
+            value = value[:page_aligned_len]
+
+        return self._insert_helper(self.root_node, converted_key, value, params)
+
+    def evict(self, params: EvictParams) -> EvictResult:
+        if self.disable:
+            return EvictResult()
+
+        tracker = {ct: 0 for ct in self.tree_components}
+        for component in self._components_tuple:
+            component.drive_eviction(params=params, tracker=tracker)
+
+        return EvictResult(
+            num_tokens_evicted=tracker[BASE_COMPONENT_TYPE],
+            swa_num_tokens_evicted=tracker.get(ComponentType.SWA, 0),
+        )
+
+    def inc_lock_ref(self, node: UnifiedTreeNode) -> IncLockRefResult:
+        if self.disable:
+            return IncLockRefResult(delta=0)
+
+        result = IncLockRefResult()
+        for component in self._components_tuple:
+            result = component.acquire_component_lock(node=node, result=result)
+
+        self._update_evictable_leaf_sets(node)
+        return result
+
+    def dec_lock_ref(self, node: UnifiedTreeNode, params: DecLockRefParams | None = None):
+        if self.disable:
+            return 0
+
+        for component in self._components_tuple:
+            component.release_component_lock(node=node, params=params)
+
+        self._update_evictable_leaf_sets(node)
+        return 0
+
+    def cache_finished_req(self, req: Req, is_insert: bool = True, **kwargs):
+        """Cache completed requests. ``is_insert=False`` skips the radix
+        insert (retract path) and frees the would-be-cached range directly."""
+        committed_kv_len = req.pop_committed_kv_cache()
+        dp_rank = req.dp_rank if req.dp_rank is not None else 0
+        if self.disable:
+            kv_indices = self.req_to_token_pool.read(req.req_pool_idx, committed_kv_len)
+            kv_indices = kv_indices[kv_indices != 0]
+            self.token_to_kv_pool_allocator.free(kv_indices, dp_rank=dp_rank)
+            for component in self._components_tuple:
+                component.cleanup_after_caching_req(
+                    req, is_finished=True, insert_result=None, insert_params=None
+                )
+            return
+
+        token_ids = (req.origin_input_ids + req.output_ids)[:committed_kv_len]
+        # For the EAGLE bigram key the key length is one less than the token
+        # length, so the corresponding kv length is reduced by one as well.
+        actual_kv_len = committed_kv_len - 1 if self.is_eagle else committed_kv_len
+        kv_indices = self.req_to_token_pool.read(req.req_pool_idx, committed_kv_len)
+        kv_indices = kv_indices[kv_indices != 0]
+
+        if self.page_size != 1:
+            page_aligned_len = actual_kv_len // self.page_size * self.page_size
+            page_aligned_kv_indices = kv_indices[:page_aligned_len].copy()
+            self.token_to_kv_pool_allocator.free(kv_indices[page_aligned_len:], dp_rank=dp_rank)
+        else:
+            page_aligned_len = actual_kv_len
+            page_aligned_kv_indices = kv_indices[:page_aligned_len].copy()
+
+        page_aligned_token_len = page_aligned_len + 1 if self.is_eagle else page_aligned_len
+        # cache_protected_len, not len(prefix_indices): the latter may include
+        # an unaligned tail owned by the req but not by the tree.
+        old_prefix_len = req.cache_protected_len
+        if self.is_eagle and old_prefix_len > req.last_matched_prefix_len:
+            # In the EAGLE chunked prefill case the prefix indices include one
+            # unmatched token; -1 so its kv can be freed without leaking.
+            old_prefix_len -= 1
+
+        insert_params = None
+        insert_result = None
+        if is_insert:
+            insert_params = InsertParams(
+                key=RadixKey(token_ids[:page_aligned_token_len], req.extra_key, req.dp_rank),
+                value=page_aligned_kv_indices,
+            )
+            for component in self._components_tuple:
+                component.prepare_for_caching_req(
+                    req, insert_params, len(token_ids), is_finished=True
+                )
+            # Radix cache takes over one reference from the memory pool.
+            new_prefix_len = self.insert(insert_params)
+            insert_result = InsertResult(prefix_len=new_prefix_len)
+            self.token_to_kv_pool_allocator.free(
+                kv_indices[old_prefix_len:new_prefix_len], dp_rank=dp_rank
+            )
+        else:
+            self.token_to_kv_pool_allocator.free(
+                kv_indices[old_prefix_len:page_aligned_len], dp_rank=dp_rank
+            )
+
+        for component in self._components_tuple:
+            component.cleanup_after_caching_req(
+                req, is_finished=True, insert_result=insert_result, insert_params=insert_params
+            )
+
+        self.dec_lock_ref(req.last_node)
+
+    def cache_unfinished_req(self, req: Req, **kwargs):
+        """Cache incomplete requests."""
+        if self.disable:
+            for component in self._components_tuple:
+                component.cleanup_after_caching_req(
+                    req, is_finished=False, insert_result=None, insert_params=None
+                )
+            return
+
+        dp_rank = req.dp_rank if req.dp_rank is not None else 0
+        token_ids = req.fill_ids
+        all_token_len = len(token_ids)
+        actual_kv_len = all_token_len - 1 if self.is_eagle else all_token_len
+        kv_indices = self.req_to_token_pool.read(req.req_pool_idx, all_token_len)
+
+        if self.page_size != 1:
+            page_aligned_len = actual_kv_len // self.page_size * self.page_size
+            page_aligned_kv_indices = kv_indices[:page_aligned_len].copy()
+        else:
+            page_aligned_len = actual_kv_len
+            page_aligned_kv_indices = kv_indices
+
+        # For EAGLE, page_aligned_len is for the bigram key; the token len is +1.
+        page_aligned_token_len = page_aligned_len + 1 if self.is_eagle else page_aligned_len
+        page_aligned_token_ids = token_ids[:page_aligned_token_len]
+
+        # cache_protected_len, not len(prefix_indices): see cache_finished_req.
+        old_prefix_len = req.cache_protected_len
+        if self.is_eagle and old_prefix_len > req.last_matched_prefix_len:
+            old_prefix_len -= 1
+
+        radix_key = RadixKey(page_aligned_token_ids, req.extra_key, req.dp_rank)
+        insert_params = InsertParams(key=radix_key, value=page_aligned_kv_indices)
+        for component in self._components_tuple:
+            component.prepare_for_caching_req(req, insert_params, all_token_len, is_finished=False)
+        # Radix cache takes over one reference from the memory pool.
+        new_prefix_len = self.insert(insert_params)
+        insert_result = InsertResult(prefix_len=new_prefix_len)
+        self.token_to_kv_pool_allocator.free(
+            kv_indices[old_prefix_len:new_prefix_len], dp_rank=dp_rank
+        )
+
+        # Prefix indices may have been updated, reuse them.
+        new_match_result = self.match_prefix(MatchPrefixParams(key=radix_key))
+        new_indices = new_match_result.device_indices
+        new_last_node = new_match_result.last_device_node
+
+        self.req_to_token_pool.write(
+            (req.req_pool_idx, slice(old_prefix_len, len(new_indices))),
+            new_indices[old_prefix_len:],
+        )
+        req.last_matched_prefix_len = len(new_indices)
+        req.cache_protected_len = len(new_indices)
+        self.dec_lock_ref(req.last_node)
+        self.inc_lock_ref(new_last_node)
+
+        # `req.prefix_indices` is used later in `PrefillAdder::add_chunked_req`.
+        if self.page_size != 1:
+            req.prefix_indices = np.concatenate([new_indices, kv_indices[len(new_indices) :]])
+        elif self.is_eagle:
+            # Attach the kv index of the last token for EAGLE chunked prefill.
+            req.prefix_indices = np.concatenate([new_indices, kv_indices[actual_kv_len:]])
+        else:
+            req.prefix_indices = new_indices
+        req.last_node = new_last_node
+
+        for component in self._components_tuple:
+            component.cleanup_after_caching_req(
+                req, is_finished=False, insert_result=insert_result, insert_params=insert_params
+            )
+
+    ##### Size Accessors #####
+
+    def evictable_size(self, dp_rank: int = 0):
+        return self.component_evictable_size_[BASE_COMPONENT_TYPE][dp_rank]
+
+    def full_evictable_size(self, dp_rank: int = 0):
+        return self.evictable_size(dp_rank)
+
+    def protected_size(self, dp_rank: int = 0):
+        return self.component_protected_size_[BASE_COMPONENT_TYPE][dp_rank]
+
+    def full_protected_size(self, dp_rank: int = 0):
+        return self.protected_size(dp_rank)
+
+    def swa_evictable_size(self, dp_rank: int = 0):
+        return 0
+
+    def swa_protected_size(self):
+        return 0
+
+    def total_size(self):
+        total_size = 0
+        stack = [self.root_node]
+        while stack:
+            node = stack.pop()
+            full_value = node.component_data[BASE_COMPONENT_TYPE].value
+            if full_value is not None:
+                total_size += len(full_value)
+            stack.extend(node.children.values())
+        return total_size
+
+    def pretty_print(self):
+        print(f"\n[process {self.process_id}] Unified Radix Tree structure:")
+        self._print_helper(self.root_node, 0)
+        print(f"total tokens: {self.total_size()}")
+        evictable = dict(self.component_evictable_size_[BASE_COMPONENT_TYPE])
+        protected = dict(self.component_protected_size_[BASE_COMPONENT_TYPE])
+        print(f"evictable size per dp_rank: {evictable}")
+        print(f"protected size per dp_rank: {protected}")
+
+    def take_events(self):
+        """Atomically takes all events and clears the queue."""
+        if not self.enable_kv_cache_events:
+            return []
+        events = self.kv_event_queue
+        self.kv_event_queue = []
+        return events
+
+    ##### Internal Helper Functions #####
+
+    def _empty_match_result(self) -> MatchResult:
+        return MatchResult(
+            device_indices=np.empty((0,), dtype=np.int32),
+            last_device_node=self.root_node,
+            last_host_node=self.root_node,
+            best_match_node=self.root_node,
+            host_hit_length=0,
+        )
+
+    def _match_prefix_helper(self, key: RadixKey) -> tuple[list[np.ndarray], UnifiedTreeNode, int]:
+        node = self.root_node
+        node.last_access_time = get_and_increase_time_counter()
+        child_key = self.get_child_key_fn(key)
+
+        value: list[np.ndarray] = []
+        best_match_node = node
+        # Number of value CHUNKS accepted at the best match, not a token
+        # count (upstream seam name kept for port parity).
+        best_value_len = 0
+        # Stage 1 has no host tier: device-only matching is the only mode, so
+        # the best match and the best device match coincide.
+        validators = tuple(
+            comp.create_match_validator(match_device_only=True) for comp in self._components_tuple
+        )
+
+        def _update_best_if_valid(candidate: UnifiedTreeNode):
+            nonlocal best_match_node, best_value_len
+            if all(v(candidate) for v in validators):
+                best_match_node = candidate
+                best_value_len = len(value)
+
+        while len(key) > 0 and child_key in node.children:
+            child = node.children[child_key]
+
+            # Dead node (evicted and not backed up) ends the walk.
+            if child.evicted and not child.backuped:
+                break
+
+            child.last_access_time = get_and_increase_time_counter()
+            prefix_len = self.key_match_fn(child.key, key)
+            if prefix_len < len(child.key):
+                new_node = self._split_node(child.key, child, prefix_len)
+                if not new_node.evicted:
+                    value.append(new_node.component_data[BASE_COMPONENT_TYPE].value)
+                _update_best_if_valid(new_node)
+                node = new_node
+                break
+
+            if not child.evicted:
+                value.append(child.component_data[BASE_COMPONENT_TYPE].value)
+            node = child
+            _update_best_if_valid(node)
+            key = key[prefix_len:]
+            if len(key):
+                child_key = self.get_child_key_fn(key)
+
+        return value, best_match_node, best_value_len
+
+    def _match_post_processor(
+        self,
+        params: MatchPrefixParams,
+        value: list[np.ndarray],
+        best_match_node: UnifiedTreeNode,
+        best_value_len: int,
+    ) -> MatchResult:
+        # Refresh the matched path so deeper nodes look more recently used.
+        cur_time = get_and_increase_time_counter()
+        node_update: UnifiedTreeNode | None = best_match_node
+        while node_update is not None:
+            node_update.last_access_time = cur_time
+            cur_time -= 0.00001
+            node_update = node_update.parent
+
+        if best_value_len > 0:
+            device_indices = np.concatenate(value[:best_value_len])
+        else:
+            device_indices = np.empty((0,), dtype=np.int32)
+
+        result = MatchResult(
+            device_indices=device_indices,
+            last_device_node=best_match_node,
+            last_host_node=best_match_node,
+            best_match_node=best_match_node,
+            host_hit_length=0,
+        )
+        for component in self._components_tuple:
+            result = component.finalize_match_result(
+                result=result,
+                params=params,
+                value_chunks=value,
+                best_value_len=best_value_len,
+            )
+        return result
+
+    def _split_node(self, key: RadixKey, child: UnifiedTreeNode, split_len: int) -> UnifiedTreeNode:
+        new_node = UnifiedTreeNode(self.tree_components)
+        new_node.children = {self.get_child_key_fn(key[split_len:]): child}
+        new_node.parent = child.parent
+        new_node.key = child.key[:split_len]
+
+        child.parent = new_node
+        child.key = child.key[split_len:]
+        for component in self._components_tuple:
+            component.redistribute_on_node_split(new_parent=new_node, child=child)
+        new_node.parent.children[self.get_child_key_fn(key)] = new_node
+        child.last_access_time = get_and_increase_time_counter()
+
+        self._update_evictable_leaf_sets(new_node)
+        self._update_evictable_leaf_sets(child)
+        return new_node
+
+    def _add_new_node(
+        self, parent: UnifiedTreeNode, key: RadixKey, value: np.ndarray
+    ) -> UnifiedTreeNode:
+        new_node = UnifiedTreeNode(self.tree_components)
+        new_node.parent = parent
+        new_node.key = key
+        new_node.component_data[BASE_COMPONENT_TYPE].value = value.copy()
+        parent.children[self.get_child_key_fn(key)] = new_node
+        node_dp_rank = key.dp_rank if key.dp_rank is not None else 0
+        self.component_evictable_size_[BASE_COMPONENT_TYPE][node_dp_rank] += len(value)
+
+        self._update_evictable_leaf_sets(new_node)
+        self._update_evictable_leaf_sets(parent)
+        return new_node
+
+    def _insert_helper(
+        self,
+        node: UnifiedTreeNode,
+        key: RadixKey,
+        value: np.ndarray,
+        params: InsertParams,
+    ) -> int:
+        node.last_access_time = get_and_increase_time_counter()
+        if len(key) == 0:
+            return 0
+
+        child_key = self.get_child_key_fn(key)
+        total_prefix_length = 0
+        while len(key) > 0 and child_key in node.children:
+            node = node.children[child_key]
+            node.last_access_time = get_and_increase_time_counter()
+            prefix_len = self.key_match_fn(node.key, key)
+            if prefix_len < len(node.key):
+                node = self._split_node(node.key, node, prefix_len)
+
+            # Let each component claim ownership of overlapping KV slots.
+            # FULL never consumes; duplicate frees stay in cache_*_req (this
+            # repo's convention), so the returned index is unused in stage 1.
+            value_slice = value[:prefix_len]
+            for component in self._components_tuple:
+                component.update_component_on_insert_overlap(
+                    node=node,
+                    prefix_len=prefix_len,
+                    total_prefix_len=total_prefix_length,
+                    value_slice=value_slice,
+                    params=params,
+                )
+
+            total_prefix_length += prefix_len
+            key = key[prefix_len:]
+            value = value[prefix_len:]
+            if len(key):
+                child_key = self.get_child_key_fn(key)
+
+        is_new_leaf = False
+        target_node = node
+        if len(key):
+            if any(
+                comp.should_skip_leaf_creation(
+                    total_prefix_len=total_prefix_length,
+                    key_len=len(key),
+                    params=params,
+                )
+                for comp in self._components_tuple
+            ):
+                node_dp_rank = key.dp_rank if key.dp_rank is not None else 0
+                self.token_to_kv_pool_allocator.free(value, dp_rank=node_dp_rank)
+                return total_prefix_length
+            target_node = self._add_new_node(node, key, value)
+            is_new_leaf = True
+
+        # Finalize: let each component attach its data to the target node.
+        result = InsertResult(prefix_len=total_prefix_length)
+        for component in self._components_tuple:
+            component.commit_insert_component_data(
+                node=target_node,
+                is_new_leaf=is_new_leaf,
+                params=params,
+                result=result,
+            )
+
+        return total_prefix_length
+
+    ##### Evict Helpers #####
+
+    def _cascade_evict(self, node: UnifiedTreeNode) -> None:
+        """Tombstone the base value after all components have been driven.
+
+        Stage 1 collapses the upstream priority cascade: FULL is both the
+        trigger and the only component. The deferral contract puts
+        value = None here, not in FullComponent.evict_component."""
+        node.component_data[BASE_COMPONENT_TYPE].value = None
+        self._update_evictable_leaf_sets(node)
+
+    def _remove_leaf_from_parent(self, node: UnifiedTreeNode) -> None:
+        child_key = self.get_child_key_fn(node.key)
+        v = node.parent.children.pop(child_key, None)
+        assert v is node
+
+    def _evict_device_leaf(self, node: UnifiedTreeNode, tracker: dict[ComponentType, int]) -> None:
+        """Evict a device leaf: free all component device data, tombstone the
+        base value, and delete the node from the tree (no host tier yet)."""
+        assert self._is_device_leaf(node), f"node {node.id} is not a D-leaf"
+
+        for component in self._components_tuple:
+            if component.node_has_component_data(node, EvictLayer.DEVICE):
+                freed, _ = component.evict_component(node, EvictLayer.DEVICE)
+                tracker[component.component_type] += freed
+
+        self._cascade_evict(node)
+        self.evictable_device_leaves.discard(node)
+        parent = node.parent
+        self._remove_leaf_from_parent(node)
+        self._update_evictable_leaf_sets(parent)
+
+    def _is_device_leaf(self, node: UnifiedTreeNode) -> bool:
+        """D-leaf: FULL device value present, no child with FULL KV on device,
+        unlocked, not root. Auxiliary components are not required."""
+        ct = BASE_COMPONENT_TYPE
+        if node is self.root_node or node.evicted:
+            return False
+        if any(cd.lock_ref > 0 for cd in node.component_data):
+            return False
+        return not any(
+            child.component_data[ct].value is not None for child in node.children.values()
+        )
+
+    def _update_evictable_leaf_sets(self, node: UnifiedTreeNode) -> None:
+        if self._is_device_leaf(node):
+            self.evictable_device_leaves.add(node)
+        else:
+            self.evictable_device_leaves.discard(node)
+
+    def _print_helper(self, node: UnifiedTreeNode, indent: int) -> None:
+        cd = node.component_data[BASE_COMPONENT_TYPE]
+        value_info = f"len={len(cd.value)}" if cd.value is not None else "evicted"
+        print(
+            " " * indent,
+            len(node.key) if node.key else 0,
+            node.key.token_ids[:10] if node.key else [],
+            f"r={cd.lock_ref}",
+            f"extra_key={node.key.extra_key if node.key else None}",
+            value_info,
+        )
+        for child in node.children.values():
+            self._print_helper(child, indent + 2)

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -150,6 +150,7 @@ class ServerArgs:
 
     # Optimization/debug options
     disable_radix_cache: bool = False
+    enable_unified_radix_tree: bool = False
     allow_auto_truncate: bool = False
     enable_tokenizer_batch_encode: bool = False
     disable_overlap_schedule: bool = False
@@ -326,6 +327,9 @@ class ServerArgs:
         os.environ["SGLANG_ENABLE_DETERMINISTIC_SAMPLING"] = (
             "1" if self.enable_deterministic_sampling else "0"
         )
+
+        if os.getenv("SGLANG_JAX_ENABLE_UNIFIED_RADIX_TREE", "0") == "1":
+            self.enable_unified_radix_tree = True
 
         if self.nnodes > 1 and self.device_indexes is not None:
             logger.warning("In a multi-machine scenario, device_indexes will be set to None.")
@@ -993,6 +997,13 @@ class ServerArgs:
             "--disable-radix-cache",
             action="store_true",
             help="Disable RadixAttention for prefix caching.",
+        )
+        parser.add_argument(
+            "--enable-unified-radix-tree",
+            action="store_true",
+            help="Route non-hybrid (full-attention) models to UnifiedRadixCache "
+            "(component-agnostic prefix cache). Default off; hybrid models are "
+            "unaffected.",
         )
         parser.add_argument(
             "--allow-auto-truncate",

--- a/python/sgl_jax/test/kits/cache_hit_kit.py
+++ b/python/sgl_jax/test/kits/cache_hit_kit.py
@@ -1,0 +1,349 @@
+import asyncio
+import json
+import time
+
+import aiohttp
+import requests
+
+from sgl_jax.bench_serving import (
+    RequestFuncOutput,
+    get_tokenizer,
+    remove_prefix,
+    sample_random_requests,
+)
+
+AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=20 * 60 * 60)
+
+
+async def async_request_sglang_generate(
+    payload,
+    url,
+    pbar=None,
+):
+    """Send a streaming request to the server and collect cache metrics.
+
+    Returns a RequestFuncOutput with additional cached_tokens and output_ids attributes.
+    """
+    async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
+        headers = {}
+        generated_text = ""
+        all_output_ids = []
+        ttft = 0.0
+        st = time.perf_counter()
+        most_recent_timestamp = st
+        output = RequestFuncOutput()
+
+        try:
+            async with session.post(url=url, json=payload, headers=headers) as response:
+                if response.status == 200:
+                    prompt_tokens = 0
+                    cached_tokens = 0
+
+                    async for chunk_bytes in response.content:
+                        chunk_bytes = chunk_bytes.strip()
+                        if not chunk_bytes:
+                            continue
+
+                        chunk = remove_prefix(chunk_bytes.decode("utf-8"), "data: ")
+                        latency = time.perf_counter() - st
+
+                        if chunk == "[DONE]":
+                            pass
+                        else:
+                            data = json.loads(chunk)
+
+                            # output_ids and text are always returned together
+                            if data.get("output_ids"):
+                                all_output_ids = data["output_ids"]
+                                generated_text = data.get("text", "")
+                                timestamp = time.perf_counter()
+
+                                if ttft == 0.0:
+                                    ttft = time.perf_counter() - st
+                                    output.ttft = ttft
+                                    prompt_tokens = (data.get("meta_info") or {}).get(
+                                        "prompt_tokens", 0
+                                    )
+                                    cached_tokens = (data.get("meta_info") or {}).get(
+                                        "cached_tokens", 0
+                                    )
+                                else:
+                                    output.itl.append(timestamp - most_recent_timestamp)
+
+                                most_recent_timestamp = timestamp
+
+                    output.generated_text = generated_text
+                    output.output_ids = all_output_ids
+                    output.success = True
+                    output.latency = latency
+                    output.prompt_len = prompt_tokens
+                    output.cached_tokens = cached_tokens
+                    output.generated_len = len(output.itl) + 1
+                else:
+                    output.error = response.reason or ""
+                    output.success = False
+        except Exception as e:
+            output.success = False
+            output.error = str(e)
+            print(f"Request failed: {e}")
+
+    if pbar:
+        pbar.update(1)
+    return output
+
+
+def gen_payload(input_ids, output_len, lora_path=None):
+    payload = {
+        "input_ids": input_ids,
+        "sampling_params": {
+            "temperature": 0.0,
+            "max_new_tokens": output_len,
+            "ignore_eos": True,
+        },
+        "stream": True,
+        "return_logprob": False,
+        "logprob_start_len": -1,
+    }
+    if lora_path:
+        payload["lora_path"] = lora_path
+    return payload
+
+
+async def _send_round(
+    payloads,
+    url,
+    max_parallel,
+):
+    """Send a batch of payloads concurrently with concurrency limit."""
+    semaphore = asyncio.Semaphore(max_parallel)
+
+    async def _send_one(payload):
+        async with semaphore:
+            return await async_request_sglang_generate(payload, url)
+
+    tasks = [asyncio.create_task(_send_one(p)) for p in payloads]
+    return await asyncio.gather(*tasks)
+
+
+def _get_page_size(base_url: str) -> int:
+    """Query server for page_size used by radix cache."""
+    try:
+        resp = requests.get(f"{base_url}/get_server_info", timeout=10)
+        resp.raise_for_status()
+        info = resp.json()
+        return info.get("page_size", 1)
+    except Exception as e:
+        # Warn rather than silently return 1, which would weaken the
+        # page-aligned assertion and mask a real route failure.
+        print(
+            f"WARNING: failed to query page_size from {base_url}/get_server_info, "
+            f"falling back to 1: {e}"
+        )
+        return 1
+
+
+def flush_cache(base_url: str, retries: int = 10, delay: float = 1.0) -> None:
+    """POST /flush_cache, retrying until HTTP 200.
+
+    The scheduler returns 400 while a batch is still in flight (last_batch
+    lingers one loop iteration after the client sees its final chunk), so a
+    single fire-and-forget POST can race. Raise if it never succeeds.
+    """
+    last_status = None
+    last_text = ""
+    for _ in range(retries):
+        resp = requests.post(f"{base_url}/flush_cache", timeout=30)
+        if resp.status_code == 200:
+            return
+        last_status = resp.status_code
+        last_text = resp.text
+        time.sleep(delay)
+    raise RuntimeError(
+        f"flush_cache failed after {retries} retries: "
+        f"last status={last_status}, text={last_text}"
+    )
+
+
+def run_multiturn_cache_hit_test(
+    base_url: str,
+    model_path: str,
+    num_clients: int = 8,
+    num_rounds: int = 3,
+    request_length: int = 256,
+    output_length: int = 32,
+    miss_tolerance: int = 1,
+    sub_question_input_length: int = 0,
+    lora_path: str = "",
+    dataset_path: str = "",
+    max_parallel: int = 64,
+    seed: int = 1,
+) -> dict:
+    """Run a multi-turn workload and verify cache hit rate.
+
+    Sends requests in round-barrier mode: all clients complete round i
+    before round i+1 starts, ensuring deterministic cache state.
+
+    The expected cache hit rate is self-computed from the workload structure:
+    - Round 0: expected cached_tokens = 0 (cold start after flush)
+    - Round r (r >= 1): each client's prefix from round r-1 should be cached,
+      minus up to previous round's (prompt_len + decoding output - miss_tolerance) // page * page.
+
+    Returns metrics dict with per-round and overall cache_hit_rate.
+    """
+    import random
+
+    import numpy as np
+
+    random.seed(seed)
+    np.random.seed(seed)
+
+    generate_url = f"{base_url}/generate"
+    page_size = _get_page_size(base_url)
+
+    # Flush cache for clean state
+    flush_cache(base_url)
+
+    # Resolve sub-question length (0 means same as request_length)
+    effective_sub_len = (
+        sub_question_input_length if sub_question_input_length != 0 else request_length
+    )
+
+    # Sample initial prompts and sub-question prompts as token ids
+    tokenizer = get_tokenizer(model_path)
+
+    initial_inputs = sample_random_requests(
+        input_len=request_length,
+        output_len=output_length,
+        num_prompts=num_clients,
+        range_ratio=1.0,
+        tokenizer=tokenizer,
+        dataset_path=dataset_path,
+        random_sample=False,
+        return_text=False,
+    )
+    # sample_random_requests can silently drop samples (token_mismatch) and its
+    # own shortfall guard is a no-op; assert the count or a later round IndexErrors.
+    assert len(initial_inputs) == num_clients, (
+        f"sample_random_requests returned {len(initial_inputs)} initial prompts, "
+        f"expected {num_clients} (likely token_mismatch skips)"
+    )
+    # r.prompt is now List[int] when return_text=False
+    initial_token_ids = [list(r.prompt) for r in initial_inputs]
+
+    expected_sub_count = num_clients * max(num_rounds - 1, 1)
+    sub_question_inputs = sample_random_requests(
+        input_len=effective_sub_len,
+        output_len=output_length,
+        num_prompts=expected_sub_count,
+        range_ratio=1.0,
+        tokenizer=tokenizer,
+        dataset_path=dataset_path,
+        random_sample=False,
+        return_text=False,
+    )
+    assert len(sub_question_inputs) == expected_sub_count, (
+        f"sample_random_requests returned {len(sub_question_inputs)} sub-question "
+        f"prompts, expected {expected_sub_count} (likely token_mismatch skips)"
+    )
+    sub_question_token_ids = [list(r.prompt) for r in sub_question_inputs]
+
+    # Per-round metrics and per-client tracking for expected cache computation
+    round_metrics = {
+        i: {"prompt_len": [], "cached_tokens": [], "ttft": []} for i in range(num_rounds)
+    }
+    # Track the previous round's prompt_len per client to compute expected cache
+    prev_prompt_lens = [0] * num_clients
+    # histories now stores List[int] (token ids) for each client
+    histories = [list(ids) for ids in initial_token_ids]
+    sub_idx = 0
+
+    for round_num in range(num_rounds):
+        payloads = [gen_payload(h, output_length, lora_path) for h in histories]
+        responses = asyncio.run(_send_round(payloads, generate_url, max_parallel))
+
+        for i, resp in enumerate(responses):
+            assert resp.success, f"Round {round_num}, client {i} failed: {resp.error}"
+
+            round_metrics[round_num]["prompt_len"].append(resp.prompt_len)
+            round_metrics[round_num]["cached_tokens"].append(resp.cached_tokens)
+            round_metrics[round_num]["ttft"].append(resp.ttft)
+
+            # Verify cache hit against expected value
+            if round_num == 0:
+                # Cold start: no cache expected
+                expected_cached = 0
+            else:
+                # Previous round's prompt + output are in cache.
+                # Radix cache aligns to page_size, so the last partial page
+                # may not be cached.
+                cacheable = prev_prompt_lens[i] + output_length - miss_tolerance
+                expected_cached = (cacheable // page_size) * page_size
+
+            msg = (
+                f"Round {round_num}, client {i}: "
+                f"cached_tokens={resp.cached_tokens}, "
+                f"expected>={expected_cached} "
+                f"(prev_prompt={prev_prompt_lens[i]}, "
+                f"output={output_length}, page_size={page_size})"
+            )
+
+            print(msg)
+
+            assert resp.cached_tokens >= expected_cached
+            # Upper bound: cached tokens are a subset of the prompt, so they can
+            # never exceed prompt_len. In PD disaggregation with decode radix
+            # cache, the shared prefix was previously counted on both the prefill
+            # and the decode node, making cached_tokens exceed prompt_len.
+            assert resp.cached_tokens <= resp.prompt_len, (
+                f"Round {round_num}, client {i}: cached_tokens="
+                f"{resp.cached_tokens} exceeds prompt_len={resp.prompt_len} "
+                f"(double-counted prefix across prefill/decode)"
+            )
+
+            # Record this round's prompt_len for next round's expected calc
+            prev_prompt_lens[i] = resp.prompt_len
+
+            # Accumulate history for next round using output_ids (token ids)
+            histories[i].extend(resp.output_ids)
+            if round_num < num_rounds - 1:
+                histories[i].extend(sub_question_token_ids[sub_idx])
+                sub_idx += 1
+
+    # Compute per-round and overall cache hit rate
+    total_prompt = 0
+    total_cached = 0
+    result = {"rounds": {}, "overall": {}}
+
+    for r in range(num_rounds):
+        rm = round_metrics[r]
+        r_prompt = sum(rm["prompt_len"])
+        r_cached = sum(rm["cached_tokens"])
+        r_hit_rate = r_cached / r_prompt if r_prompt > 0 else 0.0
+        r_avg_ttft = sum(rm["ttft"]) / len(rm["ttft"]) if rm["ttft"] else 0.0
+
+        result["rounds"][f"round_{r}"] = {
+            "cache_hit_rate": r_hit_rate,
+            "average_ttft": r_avg_ttft,
+            "total_prompt_tokens": r_prompt,
+            "total_cached_tokens": r_cached,
+            "request_count": len(rm["ttft"]),
+        }
+
+        total_prompt += r_prompt
+        total_cached += r_cached
+
+        print(
+            f"  Round {r}: cache_hit_rate={r_hit_rate:.4f}, "
+            f"avg_ttft={r_avg_ttft:.4f}s, "
+            f"cached={r_cached}/{r_prompt} tokens"
+        )
+
+    overall_hit_rate = total_cached / total_prompt if total_prompt > 0 else 0.0
+    result["overall"] = {
+        "cache_hit_rate": overall_hit_rate,
+        "total_prompt_tokens": total_prompt,
+        "total_cached_tokens": total_cached,
+    }
+    print(f"  Overall cache_hit_rate={overall_hit_rate:.4f}")
+
+    return result

--- a/python/sgl_jax/test/mem_cache/test_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_radix_cache.py
@@ -16,6 +16,11 @@ import jax.numpy as jnp
 import numpy as np
 
 from sgl_jax.srt.mem_cache.allocator import TokenToKVPoolAllocator
+from sgl_jax.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    InsertParams,
+    MatchPrefixParams,
+)
 from sgl_jax.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
 from sgl_jax.srt.mem_cache.radix_cache import (
     RadixCache,
@@ -116,10 +121,10 @@ class TestRadixCache(CustomTestCase):
 
         # test disabled cache behavior
         key = [1, 2, 3, 4, 5]
-        match_result = cache.match_prefix(key)
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
         self.assertEqual(len(match_result.device_indices), 0)
 
-        insert_result = cache.insert(key)
+        insert_result = cache.insert(InsertParams(key=key))
         self.assertEqual(insert_result, 0)
 
     def test_basic_insert_and_match(self):
@@ -128,21 +133,24 @@ class TestRadixCache(CustomTestCase):
 
         # test insert
         key1 = [1, 2, 3, 4, 5]
-        prefix_len = cache.insert(key1)
+        prefix_len = cache.insert(InsertParams(key=key1))
         self.assertEqual(prefix_len, 0)  # new inserted, no prefix
 
         # test match
-        match_result = cache.match_prefix(key1)
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key1)))
         self.assertEqual(len(match_result.device_indices), len(key1))
+        # full hit: best_match_node is the last matched device node (HiCache off)
+        self.assertIs(match_result.best_match_node, match_result.last_device_node)
 
-        # test partial match
+        # test partial match (triggers a node split)
         key2 = [1, 2, 3]
-        match_result = cache.match_prefix(key2)
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key2)))
         self.assertEqual(len(match_result.device_indices), len(key2))
+        self.assertIs(match_result.best_match_node, match_result.last_device_node)
 
         # test no match
         key3 = [6, 7, 8]
-        match_result = cache.match_prefix(key3)
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key3)))
         self.assertEqual(len(match_result.device_indices), 0)
 
     def test_basic_insert_with_value(self):
@@ -151,11 +159,11 @@ class TestRadixCache(CustomTestCase):
 
         key = [1, 2, 3, 4, 5]
         value = [9, 8, 7, 6, 5]
-        prefix_len = cache.insert(key, value)
+        prefix_len = cache.insert(InsertParams(key=key, value=value))
         self.assertEqual(prefix_len, 0)
 
         key2 = [1, 2, 3]
-        match_result = cache.match_prefix(key2)
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key2)))
         self.assertEqual(len(match_result.device_indices), len(key2))
         value2 = match_result.device_indices
         self.assertEqual(value2.tolist(), value[: len(key2)])
@@ -166,18 +174,18 @@ class TestRadixCache(CustomTestCase):
 
         # insert short sequence
         key1 = [1, 2, 3]
-        cache.insert(key1)
+        cache.insert(InsertParams(key=key1))
 
         # insert long sequence (contains previous prefix)
         key2 = [1, 2, 3, 4, 5]
-        prefix_len = cache.insert(key2)
+        prefix_len = cache.insert(InsertParams(key=key2))
         self.assertEqual(prefix_len, 3)  # matched 3 tokens
 
         # verify both sequences can be correctly matched
-        match_result1 = cache.match_prefix(key1)
+        match_result1 = cache.match_prefix(MatchPrefixParams(key=RadixKey(key1)))
         self.assertEqual(len(match_result1.device_indices), len(key1))
 
-        match_result2 = cache.match_prefix(key2)
+        match_result2 = cache.match_prefix(MatchPrefixParams(key=RadixKey(key2)))
         self.assertEqual(len(match_result2.device_indices), len(key2))
 
     def test_lock_reference_counting(self):
@@ -186,10 +194,10 @@ class TestRadixCache(CustomTestCase):
 
         # insert data
         key = [1, 2, 3, 4, 5]
-        cache.insert(key)
+        cache.insert(InsertParams(key=key))
 
         # get leaf node
-        match_result = cache.match_prefix(key)
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
         last_node = match_result.last_device_node
 
         # test increase lock reference
@@ -215,14 +223,14 @@ class TestRadixCache(CustomTestCase):
 
         # test page aligned sequence
         key1 = [1, 2, 3, 4, 5, 6, 7, 8]  # 8 tokens, aligned to 8
-        cache.insert(key1)
+        cache.insert(InsertParams(key=key1))
 
-        match_result = cache.match_prefix(key1)
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key1)))
         self.assertEqual(len(match_result.device_indices), 8)
 
         # test non-page aligned sequence (should be truncated)
         key2 = [1, 2, 3, 4, 5, 6, 7]  # 7 tokens, should be truncated to 4
-        match_result = cache.match_prefix(key2)
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key2)))
         self.assertEqual(len(match_result.device_indices), 4)
 
     def test_eviction(self):
@@ -234,13 +242,13 @@ class TestRadixCache(CustomTestCase):
         keys = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
         for key in keys:
-            cache.insert(key)
+            cache.insert(InsertParams(key=key))
 
         initial_size = cache.total_size()
         self.assertGreater(initial_size, 0)
 
         # execute eviction
-        cache.evict(5)  # evict 5 tokens
+        cache.evict(EvictParams(num_tokens=5))  # evict 5 tokens
 
         # verify size reduced (possibly not reduced to 5, because of protected nodes)
         final_size = cache.total_size()
@@ -253,10 +261,10 @@ class TestRadixCache(CustomTestCase):
 
         # test empty key
         empty_key = []
-        match_result = cache.match_prefix(empty_key)
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(empty_key)))
         self.assertEqual(len(match_result.device_indices), 0)
 
-        insert_result = cache.insert(empty_key)
+        insert_result = cache.insert(InsertParams(key=empty_key))
         self.assertEqual(insert_result, 0)
 
     def test_pretty_print(self):
@@ -265,8 +273,8 @@ class TestRadixCache(CustomTestCase):
         cache = self._create_radix_cache(req_pool, allocator)
 
         # insert some data
-        cache.insert([1, 2, 3])
-        cache.insert([1, 2, 4])
+        cache.insert(InsertParams(key=[1, 2, 3]))
+        cache.insert(InsertParams(key=[1, 2, 4]))
 
         # test print (should not throw exception)
         try:
@@ -280,8 +288,8 @@ class TestRadixCache(CustomTestCase):
         cache = self._create_radix_cache(req_pool, allocator)
 
         # insert data
-        cache.insert([1, 2, 3])
-        cache.insert([4, 5, 6])
+        cache.insert(InsertParams(key=[1, 2, 3]))
+        cache.insert(InsertParams(key=[4, 5, 6]))
 
         self.assertGreater(cache.total_size(), 0)
 
@@ -300,22 +308,25 @@ class TestRadixCache(CustomTestCase):
 
         # test empty key matching
         empty_key = []
-        match_result = cache.match_prefix(empty_key)
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(empty_key)))
         device_indices = match_result.device_indices
 
         # verify empty array metadata
         self.assertIsInstance(device_indices, np.ndarray)
         self.assertEqual(device_indices.dtype, np.int32)
         self.assertEqual(len(device_indices), 0)
+        # empty hit: best_match_node anchors at the root
+        self.assertIs(match_result.best_match_node, cache.root_node)
 
         # test no match
         no_match_key = [999, 888, 777]
-        match_result = cache.match_prefix(no_match_key)
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(no_match_key)))
         device_indices = match_result.device_indices
 
         self.assertIsInstance(device_indices, np.ndarray)
         self.assertEqual(device_indices.dtype, np.int32)
         self.assertEqual(len(device_indices), 0)
+        self.assertIs(match_result.best_match_node, cache.root_node)
 
     def test_extra_key_namespace_isolation(self):
         """Test that same tokens with different extra_keys don't share cache"""
@@ -325,19 +336,19 @@ class TestRadixCache(CustomTestCase):
         # Insert same token sequence with extra_key="lora_a"
         key = [1, 2, 3, 4, 5]
         value_a = allocator.alloc(len(key))
-        cache.insert(RadixKey(key, "lora_a"), value_a)
+        cache.insert(InsertParams(key=RadixKey(key, "lora_a"), value=value_a))
 
         # Insert same token sequence with extra_key="lora_b"
         value_b = allocator.alloc(len(key))
-        cache.insert(RadixKey(key, "lora_b"), value_b)
+        cache.insert(InsertParams(key=RadixKey(key, "lora_b"), value=value_b))
 
         # Match with extra_key="lora_a" should return value_a
-        match_a = cache.match_prefix(RadixKey(key, "lora_a"))
+        match_a = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora_a")))
         self.assertEqual(len(match_a.device_indices), len(key))
         np.testing.assert_array_equal(match_a.device_indices, value_a)
 
         # Match with extra_key="lora_b" should return value_b
-        match_b = cache.match_prefix(RadixKey(key, "lora_b"))
+        match_b = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora_b")))
         self.assertEqual(len(match_b.device_indices), len(key))
         np.testing.assert_array_equal(match_b.device_indices, value_b)
 
@@ -351,15 +362,15 @@ class TestRadixCache(CustomTestCase):
 
         # Insert with extra_key="lora_x"
         key = [10, 20, 30]
-        cache.insert(RadixKey(key, "lora_x"))
+        cache.insert(InsertParams(key=RadixKey(key, "lora_x")))
 
         # Match with same extra_key should hit cache
-        match = cache.match_prefix(RadixKey(key, "lora_x"))
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora_x")))
         self.assertEqual(len(match.device_indices), len(key))
 
         # Insert longer sequence with same extra_key should reuse prefix
         longer_key = [10, 20, 30, 40, 50]
-        prefix_len = cache.insert(RadixKey(longer_key, "lora_x"))
+        prefix_len = cache.insert(InsertParams(key=RadixKey(longer_key, "lora_x")))
         self.assertEqual(prefix_len, 3)  # Reused 3 tokens from cache
 
     def test_extra_key_none_default_namespace(self):
@@ -370,18 +381,18 @@ class TestRadixCache(CustomTestCase):
         # Insert with extra_key=None
         key = [100, 200, 300]
         value_none = allocator.alloc(len(key))
-        cache.insert(RadixKey(key, None), value_none)
+        cache.insert(InsertParams(key=RadixKey(key, None), value=value_none))
 
         # Insert with extra_key="some_key"
         value_some = allocator.alloc(len(key))
-        cache.insert(RadixKey(key, "some_key"), value_some)
+        cache.insert(InsertParams(key=RadixKey(key, "some_key"), value=value_some))
 
         # Match with None should return value_none
-        match_none = cache.match_prefix(RadixKey(key, None))
+        match_none = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None)))
         np.testing.assert_array_equal(match_none.device_indices, value_none)
 
         # Match with "some_key" should return value_some
-        match_some = cache.match_prefix(RadixKey(key, "some_key"))
+        match_some = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "some_key")))
         np.testing.assert_array_equal(match_some.device_indices, value_some)
 
     def test_radix_key_backward_compatibility(self):
@@ -391,15 +402,15 @@ class TestRadixCache(CustomTestCase):
 
         # Insert with plain list (should use extra_key=None)
         key = [5, 10, 15]
-        prefix_len = cache.insert(key)
+        prefix_len = cache.insert(InsertParams(key=key))
         self.assertEqual(prefix_len, 0)
 
         # Match with plain list
-        match = cache.match_prefix(key)
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
         self.assertEqual(len(match.device_indices), len(key))
 
         # Match with RadixKey(key, None) should return same result
-        match_radix = cache.match_prefix(RadixKey(key, None))
+        match_radix = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None)))
         np.testing.assert_array_equal(match.device_indices, match_radix.device_indices)
 
     def test_radix_key_slicing(self):
@@ -424,19 +435,19 @@ class TestRadixCache(CustomTestCase):
         # Insert same token sequence with dp_rank=0
         key = [1, 2, 3, 4, 5]
         value_rank0 = allocator.alloc(len(key))
-        cache.insert(RadixKey(key, None, 0), value_rank0)
+        cache.insert(InsertParams(key=RadixKey(key, None, 0), value=value_rank0))
 
         # Insert same token sequence with dp_rank=1
         value_rank1 = allocator.alloc(len(key))
-        cache.insert(RadixKey(key, None, 1), value_rank1)
+        cache.insert(InsertParams(key=RadixKey(key, None, 1), value=value_rank1))
 
         # Match with dp_rank=0 should return value_rank0
-        match_rank0 = cache.match_prefix(RadixKey(key, None, 0))
+        match_rank0 = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, 0)))
         self.assertEqual(len(match_rank0.device_indices), len(key))
         np.testing.assert_array_equal(match_rank0.device_indices, value_rank0)
 
         # Match with dp_rank=1 should return value_rank1
-        match_rank1 = cache.match_prefix(RadixKey(key, None, 1))
+        match_rank1 = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, 1)))
         self.assertEqual(len(match_rank1.device_indices), len(key))
         np.testing.assert_array_equal(match_rank1.device_indices, value_rank1)
 
@@ -450,15 +461,15 @@ class TestRadixCache(CustomTestCase):
 
         # Insert with dp_rank=None
         key = [10, 20, 30]
-        cache.insert(RadixKey(key, None, None))
+        cache.insert(InsertParams(key=RadixKey(key, None, None)))
 
         # Match with dp_rank=None should hit cache
-        match = cache.match_prefix(RadixKey(key, None, None))
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, None)))
         self.assertEqual(len(match.device_indices), len(key))
 
         # Insert longer sequence with dp_rank=None should reuse prefix
         longer_key = [10, 20, 30, 40, 50]
-        prefix_len = cache.insert(RadixKey(longer_key, None, None))
+        prefix_len = cache.insert(InsertParams(key=RadixKey(longer_key, None, None)))
         self.assertEqual(prefix_len, 3)  # Reused 3 tokens from cache
 
     def test_dp_rank_none_vs_explicit_rank(self):
@@ -469,18 +480,18 @@ class TestRadixCache(CustomTestCase):
         # Insert with dp_rank=None
         key = [100, 200, 300]
         value_none = allocator.alloc(len(key))
-        cache.insert(RadixKey(key, None, None), value_none)
+        cache.insert(InsertParams(key=RadixKey(key, None, None), value=value_none))
 
         # Insert with dp_rank=0
         value_rank0 = allocator.alloc(len(key))
-        cache.insert(RadixKey(key, None, 0), value_rank0)
+        cache.insert(InsertParams(key=RadixKey(key, None, 0), value=value_rank0))
 
         # Match with None should return value_none
-        match_none = cache.match_prefix(RadixKey(key, None, None))
+        match_none = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, None)))
         np.testing.assert_array_equal(match_none.device_indices, value_none)
 
         # Match with 0 should return value_rank0
-        match_rank0 = cache.match_prefix(RadixKey(key, None, 0))
+        match_rank0 = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, 0)))
         np.testing.assert_array_equal(match_rank0.device_indices, value_rank0)
 
         # Verify they are different
@@ -495,28 +506,28 @@ class TestRadixCache(CustomTestCase):
 
         # Create 4 different cache namespaces
         value_lora_a_rank0 = allocator.alloc(len(key))
-        cache.insert(RadixKey(key, "lora_a", 0), value_lora_a_rank0)
+        cache.insert(InsertParams(key=RadixKey(key, "lora_a", 0), value=value_lora_a_rank0))
 
         value_lora_a_rank1 = allocator.alloc(len(key))
-        cache.insert(RadixKey(key, "lora_a", 1), value_lora_a_rank1)
+        cache.insert(InsertParams(key=RadixKey(key, "lora_a", 1), value=value_lora_a_rank1))
 
         value_lora_b_rank0 = allocator.alloc(len(key))
-        cache.insert(RadixKey(key, "lora_b", 0), value_lora_b_rank0)
+        cache.insert(InsertParams(key=RadixKey(key, "lora_b", 0), value=value_lora_b_rank0))
 
         value_lora_b_rank1 = allocator.alloc(len(key))
-        cache.insert(RadixKey(key, "lora_b", 1), value_lora_b_rank1)
+        cache.insert(InsertParams(key=RadixKey(key, "lora_b", 1), value=value_lora_b_rank1))
 
         # Verify each combination returns its own value
-        match = cache.match_prefix(RadixKey(key, "lora_a", 0))
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora_a", 0)))
         np.testing.assert_array_equal(match.device_indices, value_lora_a_rank0)
 
-        match = cache.match_prefix(RadixKey(key, "lora_a", 1))
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora_a", 1)))
         np.testing.assert_array_equal(match.device_indices, value_lora_a_rank1)
 
-        match = cache.match_prefix(RadixKey(key, "lora_b", 0))
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora_b", 0)))
         np.testing.assert_array_equal(match.device_indices, value_lora_b_rank0)
 
-        match = cache.match_prefix(RadixKey(key, "lora_b", 1))
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora_b", 1)))
         np.testing.assert_array_equal(match.device_indices, value_lora_b_rank1)
 
         # Verify all values are different

--- a/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
@@ -14,6 +14,12 @@ import numpy as np
 from jax.sharding import Mesh
 
 from sgl_jax.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
+from sgl_jax.srt.mem_cache.base_prefix_cache import (
+    DecLockRefParams,
+    EvictParams,
+    InsertParams,
+    MatchPrefixParams,
+)
 from sgl_jax.srt.mem_cache.memory_pool import (
     MHATokenToKVPool,
     ReqToTokenPool,
@@ -174,11 +180,11 @@ class TestSWARadixCache(CustomTestCase):
         val_a = self._alloc_indices(len(key_a))
         val_b = self._alloc_indices(len(key_b))
 
-        cache.insert(key_a, value=val_a, prev_prefix_len=0)
-        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+        cache.insert(InsertParams(key=key_a, value=val_a, prev_prefix_len=0))
+        cache.insert(InsertParams(key=key_b, value=val_b, prev_prefix_len=0))
 
         # SWA-evict: evict the shared internal node (LRU, oldest access)
-        cache.evict(full_num_tokens=0, swa_num_tokens=len(shared))
+        cache.evict(EvictParams(num_tokens=0, swa_num_tokens=len(shared)))
 
         return cache, key_a, val_a, key_b, val_b
 
@@ -191,24 +197,28 @@ class TestSWARadixCache(CustomTestCase):
         key = list(range(100, 110))
         value = self._alloc_indices(len(key))
 
-        prefix_len = self.cache.insert(key, value=value, prev_prefix_len=0)
+        prefix_len = self.cache.insert(InsertParams(key=key, value=value, prev_prefix_len=0))
         self.assertEqual(prefix_len, 0)
 
-        match = self.cache.match_prefix(key)
+        match = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
         np.testing.assert_array_equal(np.asarray(match.device_indices), value)
         self.assertEqual(len(match.device_indices), len(key))
         self.assertIs(match.last_device_node, match.last_host_node)
+        # full hit: best_match_node is the last matched device node (HiCache off)
+        self.assertIs(match.best_match_node, match.last_device_node)
 
     def test_insert_and_match_shorter_prefix(self):
         """Insert a sequence and match a shorter prefix."""
         key = list(range(200, 200 + 8))
         value = self._alloc_indices(len(key))
-        self.cache.insert(key, value=value, prev_prefix_len=0)
+        self.cache.insert(InsertParams(key=key, value=value, prev_prefix_len=0))
 
         prefix_key = key[:5]
-        match = self.cache.match_prefix(prefix_key)
+        match = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(prefix_key)))
         np.testing.assert_array_equal(np.asarray(match.device_indices), value[: len(prefix_key)])
         self.assertEqual(len(match.device_indices), len(prefix_key))
+        # partial match (node split): best_match_node is the last matched device node
+        self.assertIs(match.best_match_node, match.last_device_node)
 
     def test_evict_and_reset_basic(self):
         """Evict some tokens and then reset the cache."""
@@ -217,14 +227,14 @@ class TestSWARadixCache(CustomTestCase):
         val1 = self._alloc_indices(len(key1))
         val2 = self._alloc_indices(len(key2))
 
-        self.cache.insert(key1, value=val1, prev_prefix_len=0)
-        self.cache.insert(key2, value=val2, prev_prefix_len=0)
+        self.cache.insert(InsertParams(key=key1, value=val1, prev_prefix_len=0))
+        self.cache.insert(InsertParams(key=key2, value=val2, prev_prefix_len=0))
 
         total_before, swa_before = self.cache.total_size()
         self.assertGreater(total_before, 0)
         self.assertEqual(total_before, swa_before)
 
-        self.cache.evict(full_num_tokens=8, swa_num_tokens=0)
+        self.cache.evict(EvictParams(num_tokens=8, swa_num_tokens=0))
         total_after, swa_after = self.cache.total_size()
         self.assertLess(total_after, total_before)
         self.assertLessEqual(swa_after, total_after)
@@ -239,21 +249,21 @@ class TestSWARadixCache(CustomTestCase):
         # First sequence A
         key_A = list(range(1000, 1000 + 6))  # [1000..1005]
         val_A = self._alloc_indices(len(key_A))
-        self.cache.insert(key_A, value=val_A, prev_prefix_len=0)
+        self.cache.insert(InsertParams(key=key_A, value=val_A, prev_prefix_len=0))
 
         # Second sequence B shares first 4 tokens with A, then diverges
         shared = key_A[:4]
         suffix_B = list(range(2000, 2000 + 4))
         key_B = shared + suffix_B  # length 8
         val_B = self._alloc_indices(len(key_B))
-        self.cache.insert(key_B, value=val_B, prev_prefix_len=0)
+        self.cache.insert(InsertParams(key=key_B, value=val_B, prev_prefix_len=0))
 
         # Matching A should return exactly val_A
-        match_A = self.cache.match_prefix(key_A)
+        match_A = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key_A)))
         np.testing.assert_array_equal(np.asarray(match_A.device_indices), val_A)
 
         # Matching B should reuse A's prefix indices and use B's suffix indices
-        match_B = self.cache.match_prefix(key_B)
+        match_B = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key_B)))
         matched_B = np.asarray(match_B.device_indices)
         self.assertEqual(len(matched_B), len(key_B))
         np.testing.assert_array_equal(matched_B[: len(shared)], val_A[: len(shared)])
@@ -263,30 +273,30 @@ class TestSWARadixCache(CustomTestCase):
         """Lock a leaf node; eviction should skip it until unlocked."""
         key = list(range(500, 500 + 8))
         value = self._alloc_indices(len(key))
-        self.cache.insert(key, value=value, prev_prefix_len=0)
+        self.cache.insert(InsertParams(key=key, value=value, prev_prefix_len=0))
 
         total_before, _ = self.cache.total_size()
         self.assertEqual(total_before, len(key))
         self.assertEqual(self.cache.full_evictable_size(), len(key))
 
         # Lock the leaf node
-        match = self.cache.match_prefix(key)
+        match = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
         leaf = match.last_device_node
-        swa_uuid = self.cache.inc_lock_ref(leaf)
+        swa_uuid = self.cache.inc_lock_ref(leaf).swa_uuid_for_lock
         self.assertEqual(self.cache.full_protected_size(), len(key))
         self.assertEqual(self.cache.full_evictable_size(), 0)
 
         # Eviction should have no effect while locked
-        self.cache.evict(full_num_tokens=len(key), swa_num_tokens=0)
+        self.cache.evict(EvictParams(num_tokens=len(key), swa_num_tokens=0))
         total_after_lock_evict, _ = self.cache.total_size()
         self.assertEqual(total_after_lock_evict, total_before)
 
         # Unlock and then evict; tokens should be removed
-        self.cache.dec_lock_ref(leaf, swa_uuid)
+        self.cache.dec_lock_ref(leaf, DecLockRefParams(swa_uuid_for_lock=swa_uuid))
         self.assertEqual(self.cache.full_protected_size(), 0)
         self.assertEqual(self.cache.full_evictable_size(), len(key))
 
-        self.cache.evict(full_num_tokens=len(key), swa_num_tokens=0)
+        self.cache.evict(EvictParams(num_tokens=len(key), swa_num_tokens=0))
         total_after_unlock_evict, _ = self.cache.total_size()
         self.assertEqual(total_after_unlock_evict, 0)
 
@@ -303,15 +313,15 @@ class TestSWARadixCache(CustomTestCase):
 
         key = list(range(600, 600 + 8))  # length 8
         value = self._alloc_indices(len(key))
-        paged_cache.insert(key, value=value, prev_prefix_len=0)
+        paged_cache.insert(InsertParams(key=key, value=value, prev_prefix_len=0))
 
         # Exact match still returns full value
-        match_full = paged_cache.match_prefix(key)
+        match_full = paged_cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
         np.testing.assert_array_equal(np.asarray(match_full.device_indices), value)
 
         # Shorter key of length 6 should be truncated to 4 (page-aligned)
         partial_key = key[:6]
-        match_partial = paged_cache.match_prefix(partial_key)
+        match_partial = paged_cache.match_prefix(MatchPrefixParams(key=RadixKey(partial_key)))
         matched_partial = np.asarray(match_partial.device_indices)
         self.assertEqual(len(matched_partial), 4)
         np.testing.assert_array_equal(matched_partial, value[:4])
@@ -330,15 +340,17 @@ class TestSWARadixCache(CustomTestCase):
         value = self._alloc_indices(len(key))
 
         # Insert should report zero prefix and not change size
-        prefix_len = disabled_cache.insert(key, value=value, prev_prefix_len=0)
+        prefix_len = disabled_cache.insert(InsertParams(key=key, value=value, prev_prefix_len=0))
         self.assertEqual(prefix_len, 0)
         total_size, swa_size = disabled_cache.total_size()
         self.assertEqual(total_size, 0)
         self.assertEqual(swa_size, 0)
 
         # Match should always return empty
-        match = disabled_cache.match_prefix(key)
+        match = disabled_cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
         self.assertEqual(len(match.device_indices), 0)
+        # empty/disabled hit: best_match_node anchors at the root
+        self.assertIs(match.best_match_node, disabled_cache.root_node)
 
     def test_extra_key_namespace_isolation(self):
         """Test that same tokens with different extra_keys don't share cache in SWA"""
@@ -346,18 +358,22 @@ class TestSWARadixCache(CustomTestCase):
 
         # Insert with extra_key="adapter_a"
         value_a = self._alloc_indices(len(key))
-        self.cache.insert(RadixKey(key, "adapter_a"), value=value_a, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(key=RadixKey(key, "adapter_a"), value=value_a, prev_prefix_len=0)
+        )
 
         # Insert with extra_key="adapter_b"
         value_b = self._alloc_indices(len(key))
-        self.cache.insert(RadixKey(key, "adapter_b"), value=value_b, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(key=RadixKey(key, "adapter_b"), value=value_b, prev_prefix_len=0)
+        )
 
         # Match with "adapter_a" should return value_a
-        match_a = self.cache.match_prefix(RadixKey(key, "adapter_a"))
+        match_a = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "adapter_a")))
         np.testing.assert_array_equal(np.asarray(match_a.device_indices), value_a)
 
         # Match with "adapter_b" should return value_b
-        match_b = self.cache.match_prefix(RadixKey(key, "adapter_b"))
+        match_b = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "adapter_b")))
         np.testing.assert_array_equal(np.asarray(match_b.device_indices), value_b)
 
         # Verify they don't share cache (different values)
@@ -368,20 +384,26 @@ class TestSWARadixCache(CustomTestCase):
         # Insert short sequence with extra_key
         key_short = [10, 20, 30]
         value_short = self._alloc_indices(len(key_short))
-        self.cache.insert(RadixKey(key_short, "shared_key"), value=value_short, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(
+                key=RadixKey(key_short, "shared_key"), value=value_short, prev_prefix_len=0
+            )
+        )
 
         # Insert longer sequence with same extra_key should reuse prefix
         key_long = [10, 20, 30, 40, 50]
         value_long = self._alloc_indices(len(key_long))
         prefix_len = self.cache.insert(
-            RadixKey(key_long, "shared_key"), value=value_long, prev_prefix_len=0
+            InsertParams(key=RadixKey(key_long, "shared_key"), value=value_long, prev_prefix_len=0)
         )
 
         # Should have matched the first 3 tokens from cache
         self.assertGreater(prefix_len, 0)
 
         # Matching the short key should still work
-        match_short = self.cache.match_prefix(RadixKey(key_short, "shared_key"))
+        match_short = self.cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(key_short, "shared_key"))
+        )
         self.assertEqual(len(match_short.device_indices), len(key_short))
 
     def test_extra_key_none_vs_string(self):
@@ -390,18 +412,22 @@ class TestSWARadixCache(CustomTestCase):
 
         # Insert with extra_key=None
         value_none = self._alloc_indices(len(key))
-        self.cache.insert(RadixKey(key, None), value=value_none, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(key=RadixKey(key, None), value=value_none, prev_prefix_len=0)
+        )
 
         # Insert with extra_key="test"
         value_test = self._alloc_indices(len(key))
-        self.cache.insert(RadixKey(key, "test"), value=value_test, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(key=RadixKey(key, "test"), value=value_test, prev_prefix_len=0)
+        )
 
         # Match with None should return value_none
-        match_none = self.cache.match_prefix(RadixKey(key, None))
+        match_none = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None)))
         np.testing.assert_array_equal(np.asarray(match_none.device_indices), value_none)
 
         # Match with "test" should return value_test
-        match_test = self.cache.match_prefix(RadixKey(key, "test"))
+        match_test = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "test")))
         np.testing.assert_array_equal(np.asarray(match_test.device_indices), value_test)
 
         # They should be different
@@ -413,15 +439,15 @@ class TestSWARadixCache(CustomTestCase):
         value = self._alloc_indices(len(key))
 
         # Insert with plain list
-        prefix_len = self.cache.insert(key, value=value, prev_prefix_len=0)
+        prefix_len = self.cache.insert(InsertParams(key=key, value=value, prev_prefix_len=0))
         self.assertEqual(prefix_len, 0)
 
         # Match with plain list
-        match_plain = self.cache.match_prefix(key)
+        match_plain = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
         np.testing.assert_array_equal(np.asarray(match_plain.device_indices), value)
 
         # Match with RadixKey(key, None) should give same result
-        match_radix = self.cache.match_prefix(RadixKey(key, None))
+        match_radix = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None)))
         np.testing.assert_array_equal(
             np.asarray(match_plain.device_indices), np.asarray(match_radix.device_indices)
         )
@@ -432,18 +458,22 @@ class TestSWARadixCache(CustomTestCase):
 
         # Insert with dp_rank=0
         value_rank0 = self._alloc_indices(len(key))
-        self.cache.insert(RadixKey(key, None, 0), value=value_rank0, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(key=RadixKey(key, None, 0), value=value_rank0, prev_prefix_len=0)
+        )
 
         # Insert with dp_rank=1
         value_rank1 = self._alloc_indices(len(key))
-        self.cache.insert(RadixKey(key, None, 1), value=value_rank1, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(key=RadixKey(key, None, 1), value=value_rank1, prev_prefix_len=0)
+        )
 
         # Match with dp_rank=0 should return value_rank0
-        match_rank0 = self.cache.match_prefix(RadixKey(key, None, 0))
+        match_rank0 = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, 0)))
         np.testing.assert_array_equal(np.asarray(match_rank0.device_indices), value_rank0)
 
         # Match with dp_rank=1 should return value_rank1
-        match_rank1 = self.cache.match_prefix(RadixKey(key, None, 1))
+        match_rank1 = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, 1)))
         np.testing.assert_array_equal(np.asarray(match_rank1.device_indices), value_rank1)
 
         # Verify values are different (different cache namespaces)
@@ -455,17 +485,21 @@ class TestSWARadixCache(CustomTestCase):
 
         # Insert with dp_rank=None
         value_none = self._alloc_indices(len(key))
-        self.cache.insert(RadixKey(key, None, None), value=value_none, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(key=RadixKey(key, None, None), value=value_none, prev_prefix_len=0)
+        )
 
         # Match with dp_rank=None should hit cache
-        match = self.cache.match_prefix(RadixKey(key, None, None))
+        match = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, None)))
         np.testing.assert_array_equal(np.asarray(match.device_indices), value_none)
 
         # Insert longer sequence with dp_rank=None should reuse prefix
         longer_key = [10, 20, 30, 40, 50]
         longer_value = self._alloc_indices(len(longer_key))
         prefix_len = self.cache.insert(
-            RadixKey(longer_key, None, None), value=longer_value, prev_prefix_len=0
+            InsertParams(
+                key=RadixKey(longer_key, None, None), value=longer_value, prev_prefix_len=0
+            )
         )
         self.assertEqual(prefix_len, 3)  # Reused 3 tokens from cache
 
@@ -475,18 +509,22 @@ class TestSWARadixCache(CustomTestCase):
 
         # Insert with dp_rank=None
         value_none = self._alloc_indices(len(key))
-        self.cache.insert(RadixKey(key, None, None), value=value_none, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(key=RadixKey(key, None, None), value=value_none, prev_prefix_len=0)
+        )
 
         # Insert with dp_rank=0
         value_rank0 = self._alloc_indices(len(key))
-        self.cache.insert(RadixKey(key, None, 0), value=value_rank0, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(key=RadixKey(key, None, 0), value=value_rank0, prev_prefix_len=0)
+        )
 
         # Match with None should return value_none
-        match_none = self.cache.match_prefix(RadixKey(key, None, None))
+        match_none = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, None)))
         np.testing.assert_array_equal(np.asarray(match_none.device_indices), value_none)
 
         # Match with 0 should return value_rank0
-        match_rank0 = self.cache.match_prefix(RadixKey(key, None, 0))
+        match_rank0 = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, 0)))
         np.testing.assert_array_equal(np.asarray(match_rank0.device_indices), value_rank0)
 
         # Verify they are different
@@ -498,28 +536,44 @@ class TestSWARadixCache(CustomTestCase):
 
         # Create 4 different cache namespaces
         value_lora_a_rank0 = self._alloc_indices(len(key))
-        self.cache.insert(RadixKey(key, "lora_a", 0), value=value_lora_a_rank0, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(
+                key=RadixKey(key, "lora_a", 0), value=value_lora_a_rank0, prev_prefix_len=0
+            )
+        )
 
         value_lora_a_rank1 = self._alloc_indices(len(key))
-        self.cache.insert(RadixKey(key, "lora_a", 1), value=value_lora_a_rank1, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(
+                key=RadixKey(key, "lora_a", 1), value=value_lora_a_rank1, prev_prefix_len=0
+            )
+        )
 
         value_lora_b_rank0 = self._alloc_indices(len(key))
-        self.cache.insert(RadixKey(key, "lora_b", 0), value=value_lora_b_rank0, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(
+                key=RadixKey(key, "lora_b", 0), value=value_lora_b_rank0, prev_prefix_len=0
+            )
+        )
 
         value_lora_b_rank1 = self._alloc_indices(len(key))
-        self.cache.insert(RadixKey(key, "lora_b", 1), value=value_lora_b_rank1, prev_prefix_len=0)
+        self.cache.insert(
+            InsertParams(
+                key=RadixKey(key, "lora_b", 1), value=value_lora_b_rank1, prev_prefix_len=0
+            )
+        )
 
         # Verify each combination returns its own value
-        match = self.cache.match_prefix(RadixKey(key, "lora_a", 0))
+        match = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora_a", 0)))
         np.testing.assert_array_equal(np.asarray(match.device_indices), value_lora_a_rank0)
 
-        match = self.cache.match_prefix(RadixKey(key, "lora_a", 1))
+        match = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora_a", 1)))
         np.testing.assert_array_equal(np.asarray(match.device_indices), value_lora_a_rank1)
 
-        match = self.cache.match_prefix(RadixKey(key, "lora_b", 0))
+        match = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora_b", 0)))
         np.testing.assert_array_equal(np.asarray(match.device_indices), value_lora_b_rank0)
 
-        match = self.cache.match_prefix(RadixKey(key, "lora_b", 1))
+        match = self.cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora_b", 1)))
         np.testing.assert_array_equal(np.asarray(match.device_indices), value_lora_b_rank1)
 
         # Verify all values are different
@@ -581,7 +635,7 @@ class TestSWARadixCache(CustomTestCase):
     def test_evictable_size_returns_min(self):
         cache = self.cache
         indices = self._alloc_indices(10)
-        cache.insert(RadixKey(list(range(10)), None), indices)
+        cache.insert(InsertParams(key=RadixKey(list(range(10)), None), value=indices))
         self.assertEqual(cache.evictable_size(), 10)
 
     # ------------------------------------------------------------------ #
@@ -598,15 +652,15 @@ class TestSWARadixCache(CustomTestCase):
         val_a = self._alloc_indices(len(key_a))
         val_b = self._alloc_indices(len(key_b))
 
-        cache.insert(key_a, value=val_a, prev_prefix_len=0)
-        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+        cache.insert(InsertParams(key=key_a, value=val_a, prev_prefix_len=0))
+        cache.insert(InsertParams(key=key_b, value=val_b, prev_prefix_len=0))
 
         full_before, swa_before = cache.total_size()
         self.assertEqual(full_before, swa_before)  # no tombstones yet
         swa_evictable_before = cache.swa_evictable_size()
 
         # SWA evict the shared prefix
-        cache.evict(full_num_tokens=0, swa_num_tokens=len(shared))
+        cache.evict(EvictParams(num_tokens=0, swa_num_tokens=len(shared)))
 
         full_after, swa_after = cache.total_size()
         # Full tokens unchanged (tombstone keeps full), SWA tokens decreased
@@ -630,10 +684,10 @@ class TestSWARadixCache(CustomTestCase):
         cache, key_a, val_a, key_b, val_b = self._make_tree_with_tombstone()
 
         # With sliding_window_size=4 and suffix length=5 (>4), matching should still work
-        match_a = cache.match_prefix(key_a)
+        match_a = cache.match_prefix(MatchPrefixParams(key=RadixKey(key_a)))
         self.assertEqual(len(match_a.device_indices), len(key_a))
 
-        match_b = cache.match_prefix(key_b)
+        match_b = cache.match_prefix(MatchPrefixParams(key=RadixKey(key_b)))
         self.assertEqual(len(match_b.device_indices), len(key_b))
 
     def test_tombstone_healing_branch1(self):
@@ -647,7 +701,9 @@ class TestSWARadixCache(CustomTestCase):
 
         # Re-insert key_a with swa_evicted_seqlen=0 (Branch 1: not evicted)
         new_val = self._alloc_indices(len(key_a))
-        cache.insert(key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=0)
+        cache.insert(
+            InsertParams(key=key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=0)
+        )
 
         # The tombstone should be healed (revived)
         healed_node = cache.root_node.children[child_key]
@@ -667,7 +723,9 @@ class TestSWARadixCache(CustomTestCase):
         # Re-insert with swa_evicted_seqlen=5 (in the middle of shared[0:10])
         # Branch 2: split at position 5, revive [5:10], keep [0:5] as tombstone
         new_val = self._alloc_indices(len(key_a))
-        cache.insert(key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=5)
+        cache.insert(
+            InsertParams(key=key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=5)
+        )
 
         # Walk tree: root → [0:5] (tombstone) → [5:10] (revived) → {[10:15], [20:24]}
         front_node = cache.root_node.children[child_key]
@@ -697,7 +755,9 @@ class TestSWARadixCache(CustomTestCase):
         # Re-insert with swa_evicted_seqlen=15 (>= node_end=10)
         # Branch 3: entire node already evicted → keep tombstone
         new_val = self._alloc_indices(len(key_a))
-        cache.insert(key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=15)
+        cache.insert(
+            InsertParams(key=key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=15)
+        )
 
         # The shared prefix should still be tombstone
         self.assertTrue(cache.root_node.children[child_key].swa_tombstone)
@@ -711,7 +771,7 @@ class TestSWARadixCache(CustomTestCase):
         full_before, _ = cache.total_size()
 
         # Evict enough full tokens to delete all leaves, which cascade to tombstone parent
-        cache.evict(full_num_tokens=full_before, swa_num_tokens=0)
+        cache.evict(EvictParams(num_tokens=full_before, swa_num_tokens=0))
 
         full_after, swa_after = cache.total_size()
         self.assertEqual(full_after, 0)
@@ -727,26 +787,26 @@ class TestSWARadixCache(CustomTestCase):
 
         # Insert all
         for k, v in zip(keys, vals):
-            cache.insert(k, value=v, prev_prefix_len=0)
+            cache.insert(InsertParams(key=k, value=v, prev_prefix_len=0))
             self._verify_size_consistency_for(cache, f"after insert {k[0]}")
 
         # SWA evict some
-        cache.evict(full_num_tokens=0, swa_num_tokens=20)
+        cache.evict(EvictParams(num_tokens=0, swa_num_tokens=20))
         self._verify_size_consistency_for(cache, "after swa evict 20")
 
         # Full evict some
-        cache.evict(full_num_tokens=20, swa_num_tokens=0)
+        cache.evict(EvictParams(num_tokens=20, swa_num_tokens=0))
         self._verify_size_consistency_for(cache, "after full evict 20")
 
         # Insert more (reuse prefix)
         new_key = keys[0] + [999, 998, 997]
         new_val = self._alloc_indices(len(new_key))
-        cache.insert(new_key, value=new_val, prev_prefix_len=0)
+        cache.insert(InsertParams(key=new_key, value=new_val, prev_prefix_len=0))
         self._verify_size_consistency_for(cache, "after re-insert with extension")
 
         # Evict everything
         full_total, _ = cache.total_size()
-        cache.evict(full_num_tokens=full_total, swa_num_tokens=0)
+        cache.evict(EvictParams(num_tokens=full_total, swa_num_tokens=0))
         self._verify_size_consistency_for(cache, "after evict all")
 
     def test_protected_prefix_basic(self):
@@ -756,22 +816,24 @@ class TestSWARadixCache(CustomTestCase):
         val_first = self._alloc_indices(len(key))
 
         # First insert: puts everything into tree
-        cache.insert(key, value=val_first, prev_prefix_len=0)
+        cache.insert(InsertParams(key=key, value=val_first, prev_prefix_len=0))
 
         # Match to confirm
-        match = cache.match_prefix(key)
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
         self.assertEqual(len(match.device_indices), 20)
 
         # SWA-evict to create tombstone
-        cache.evict(full_num_tokens=0, swa_num_tokens=20)
+        cache.evict(EvictParams(num_tokens=0, swa_num_tokens=20))
 
         # Second insert with protected_prefix_len=10 (prev_prefix_len) and swa_evicted_seqlen=5
         # Branch 2 applies: swa_evicted_seqlen(5) < node_end(20), split at 5, revive [5:20]
         val_second = self._alloc_indices(len(key))
-        cache.insert(key, value=val_second, prev_prefix_len=10, swa_evicted_seqlen=5)
+        cache.insert(
+            InsertParams(key=key, value=val_second, prev_prefix_len=10, swa_evicted_seqlen=5)
+        )
 
         # Match should still return 20 tokens (sliding_window=4, suffix > 4)
-        match2 = cache.match_prefix(key)
+        match2 = cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
         self.assertEqual(len(match2.device_indices), 20)
 
         self._verify_size_consistency_for(cache, "after protected prefix insert")
@@ -784,7 +846,7 @@ class TestSWARadixCache(CustomTestCase):
 
         # Insert with swa_evicted_seqlen=10 → new node should be split:
         # [0:10] as tombstone + [10:20] as non-tombstone
-        cache.insert(key, value=val, prev_prefix_len=0, swa_evicted_seqlen=10)
+        cache.insert(InsertParams(key=key, value=val, prev_prefix_len=0, swa_evicted_seqlen=10))
 
         full_total, swa_total = cache.total_size()
         self.assertEqual(full_total, 20)
@@ -806,7 +868,7 @@ class TestSWARadixCache(CustomTestCase):
         self.assertEqual(len(leaf_node.value), 10)
 
         # Match should return all 20 tokens (sliding_window=4, non-tombstone suffix=10 > 4)
-        match = cache.match_prefix(key)
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
         self.assertEqual(len(match.device_indices), 20)
 
         self._verify_size_consistency_for(cache, "after new node tombstone split")
@@ -820,21 +882,21 @@ class TestSWARadixCache(CustomTestCase):
         val_a = self._alloc_indices(len(key_a))
         val_b = self._alloc_indices(len(key_b))
 
-        cache.insert(key_a, value=val_a, prev_prefix_len=0)
-        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+        cache.insert(InsertParams(key=key_a, value=val_a, prev_prefix_len=0))
+        cache.insert(InsertParams(key=key_b, value=val_b, prev_prefix_len=0))
 
         full_before, swa_before = cache.total_size()
         self.assertEqual(full_before, swa_before)
 
         # Phase 2 SWA evict: should tombstone the shared prefix
-        cache.evict(full_num_tokens=0, swa_num_tokens=len(shared))
+        cache.evict(EvictParams(num_tokens=0, swa_num_tokens=len(shared)))
         full_mid, swa_mid = cache.total_size()
         self.assertEqual(full_mid, full_before)  # full unchanged
         self.assertLess(swa_mid, swa_before)  # SWA decreased
         self._verify_size_consistency_for(cache, "after phase 2 evict")
 
         # Phase 1 full evict: should delete leaf + cascade tombstone
-        cache.evict(full_num_tokens=8, swa_num_tokens=0)
+        cache.evict(EvictParams(num_tokens=8, swa_num_tokens=0))
         full_after, swa_after = cache.total_size()
         self.assertLess(full_after, full_mid)
         self._verify_size_consistency_for(cache, "after phase 1 evict")
@@ -846,21 +908,23 @@ class TestSWARadixCache(CustomTestCase):
         for cycle in range(5):
             key = list(range(cycle * 100, cycle * 100 + 16))
             val = self._alloc_indices(len(key))
-            cache.insert(key, value=val, prev_prefix_len=0)
+            cache.insert(InsertParams(key=key, value=val, prev_prefix_len=0))
             self._verify_size_consistency_for(cache, f"cycle {cycle} insert")
 
             # SWA evict some
-            cache.evict(full_num_tokens=0, swa_num_tokens=8)
+            cache.evict(EvictParams(num_tokens=0, swa_num_tokens=8))
             self._verify_size_consistency_for(cache, f"cycle {cycle} swa evict")
 
             # Re-insert with new values (simulating healing)
             new_val = self._alloc_indices(len(key))
-            cache.insert(key, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=0)
+            cache.insert(
+                InsertParams(key=key, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=0)
+            )
             self._verify_size_consistency_for(cache, f"cycle {cycle} re-insert")
 
         # Final full evict
         full_total, _ = cache.total_size()
-        cache.evict(full_num_tokens=full_total + 100, swa_num_tokens=0)
+        cache.evict(EvictParams(num_tokens=full_total + 100, swa_num_tokens=0))
         full_final, swa_final = cache.total_size()
         self.assertEqual(full_final, 0, "full size should be 0 after evict all")
         self.assertEqual(swa_final, 0, "swa size should be 0 after evict all")
@@ -882,17 +946,19 @@ class TestSWARadixCache(CustomTestCase):
                 val = self._alloc_indices(length)
                 swa_evicted = rng.choice([0, 0, 0, rng.randint(0, length)])
                 cache.insert(
-                    key,
-                    value=val,
-                    prev_prefix_len=0,
-                    swa_evicted_seqlen=swa_evicted,
+                    InsertParams(
+                        key=key,
+                        value=val,
+                        prev_prefix_len=0,
+                        swa_evicted_seqlen=swa_evicted,
+                    )
                 )
             elif op == "evict_swa":
                 amount = rng.randint(1, 16)
-                cache.evict(full_num_tokens=0, swa_num_tokens=amount)
+                cache.evict(EvictParams(num_tokens=0, swa_num_tokens=amount))
             else:
                 amount = rng.randint(1, 16)
-                cache.evict(full_num_tokens=amount, swa_num_tokens=0)
+                cache.evict(EvictParams(num_tokens=amount, swa_num_tokens=0))
 
             self._verify_size_consistency_for(cache, f"fuzz step {step} op={op}")
 
@@ -925,12 +991,12 @@ class TestSWARadixCache(CustomTestCase):
         val_a = self._alloc_indices(len(key_a))
         val_b = self._alloc_indices(len(key_b))
 
-        cache.insert(key_a, value=val_a, prev_prefix_len=0)
-        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+        cache.insert(InsertParams(key=key_a, value=val_a, prev_prefix_len=0))
+        cache.insert(InsertParams(key=key_b, value=val_b, prev_prefix_len=0))
 
         # SWA-evict both shared prefixes: first [0..4], then [5..9]
         # This creates two consecutive tombstone nodes
-        cache.evict(full_num_tokens=0, swa_num_tokens=10)
+        cache.evict(EvictParams(num_tokens=0, swa_num_tokens=10))
 
         # Walk tree to verify two tombstones
         child_key_0 = cache.get_child_key_fn(RadixKey([0], None))
@@ -938,7 +1004,7 @@ class TestSWARadixCache(CustomTestCase):
         self.assertTrue(node_0_4.swa_tombstone, "First shared prefix should be tombstone")
 
         # Match should still work: suffix (5 tokens) > sliding_window (4)
-        match_a = cache.match_prefix(key_a)
+        match_a = cache.match_prefix(MatchPrefixParams(key=RadixKey(key_a)))
         # Even with two consecutive tombstones, the suffix after the last tombstone
         # should be enough to match if it exceeds sliding_window_size
         self.assertGreater(len(match_a.device_indices), 0)
@@ -958,7 +1024,7 @@ class TestSWARadixCache(CustomTestCase):
 
         # Insert with swa_evicted_seqlen=20 (>> total_prefix_length + len(key) = 10)
         # Upstream behavior: free value, return early, no node created
-        cache.insert(key, value=val, prev_prefix_len=0, swa_evicted_seqlen=20)
+        cache.insert(InsertParams(key=key, value=val, prev_prefix_len=0, swa_evicted_seqlen=20))
 
         full_total, swa_total = cache.total_size()
         # No node created → tree is empty
@@ -981,7 +1047,7 @@ class TestSWARadixCache(CustomTestCase):
         val = self._alloc_indices(len(key))
 
         # swa_evicted_seqlen == total_prefix_length(0) + len(key)(10) = 10
-        cache.insert(key, value=val, prev_prefix_len=0, swa_evicted_seqlen=10)
+        cache.insert(InsertParams(key=key, value=val, prev_prefix_len=0, swa_evicted_seqlen=10))
 
         full_total, swa_total = cache.total_size()
         # No node created → tree is empty
@@ -1004,15 +1070,15 @@ class TestSWARadixCache(CustomTestCase):
         val_a = self._alloc_indices(len(key_a))
         val_b = self._alloc_indices(len(key_b))
 
-        cache.insert(key_a, value=val_a, prev_prefix_len=0)
-        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+        cache.insert(InsertParams(key=key_a, value=val_a, prev_prefix_len=0))
+        cache.insert(InsertParams(key=key_b, value=val_b, prev_prefix_len=0))
 
         full_before, swa_before = cache.total_size()
         self.assertEqual(full_before, 15)  # 5 shared + 5 suffix_a + 5 suffix_b
 
         # The tree has: root → [0..4] (internal) → {[10..14] (leaf A), [20..24] (leaf B)}
         # Evict one leaf by full eviction
-        cache.evict(full_num_tokens=5, swa_num_tokens=0)
+        cache.evict(EvictParams(num_tokens=5, swa_num_tokens=0))
 
         full_after, swa_after = cache.total_size()
         self.assertLess(full_after, full_before)
@@ -1028,7 +1094,7 @@ class TestSWARadixCache(CustomTestCase):
         full_before, _ = cache.total_size()
 
         # Full evict everything — should cascade delete tombstone parent via _delete_tombstone_leaf
-        cache.evict(full_num_tokens=full_before, swa_num_tokens=0)
+        cache.evict(EvictParams(num_tokens=full_before, swa_num_tokens=0))
 
         full_after, swa_after = cache.total_size()
         self.assertEqual(full_after, 0)
@@ -1043,8 +1109,8 @@ class TestSWARadixCache(CustomTestCase):
         cache = self._make_small_cache(sliding_window_size=4)
         key = list(range(0, 20))
         tree_indices = self._alloc_indices(len(key))
-        cache.insert(key, value=tree_indices, prev_prefix_len=0)
-        match = cache.match_prefix(key)
+        cache.insert(InsertParams(key=key, value=tree_indices, prev_prefix_len=0))
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
 
         tail_indices = self._alloc_indices(10)
         req_indices = np.concatenate([tree_indices, tail_indices])
@@ -1080,8 +1146,8 @@ class TestSWARadixCache(CustomTestCase):
 
         key = list(range(0, 8))
         tree_indices = self._alloc_indices(len(key))
-        paged_cache.insert(key, value=tree_indices, prev_prefix_len=0)
-        match = paged_cache.match_prefix(key)
+        paged_cache.insert(InsertParams(key=key, value=tree_indices, prev_prefix_len=0))
+        match = paged_cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
 
         tail_indices = self._alloc_indices(12)
         req_indices = np.concatenate([tree_indices, tail_indices])
@@ -1121,14 +1187,16 @@ class TestSWARadixCache(CustomTestCase):
         val_a = self._alloc_indices(len(key_a))
         val_b = self._alloc_indices(len(key_b))
 
-        paged_cache.insert(key_a, value=val_a, prev_prefix_len=0)
-        paged_cache.insert(key_b, value=val_b, prev_prefix_len=0)
-        paged_cache.evict(full_num_tokens=0, swa_num_tokens=8)
+        paged_cache.insert(InsertParams(key=key_a, value=val_a, prev_prefix_len=0))
+        paged_cache.insert(InsertParams(key=key_b, value=val_b, prev_prefix_len=0))
+        paged_cache.evict(EvictParams(num_tokens=0, swa_num_tokens=8))
 
         # Re-inserting with non-page-aligned swa_evicted_seqlen should assert
         new_val = self._alloc_indices(len(key_a))
         with self.assertRaises(AssertionError):
-            paged_cache.insert(key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=3)
+            paged_cache.insert(
+                InsertParams(key=key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=3)
+            )
 
     def test_cache_unfinished_req_writeback_range(self):
         """T22: cache_unfinished_req writes back from last_matched_prefix_len, not len(prefix_indices)."""
@@ -1137,19 +1205,21 @@ class TestSWARadixCache(CustomTestCase):
         # Simulate first insert (initial request)
         key_part1 = list(range(0, 10))
         val1 = self._alloc_indices(len(key_part1))
-        cache.insert(key_part1, value=val1, prev_prefix_len=0)
+        cache.insert(InsertParams(key=key_part1, value=val1, prev_prefix_len=0))
 
         # After first insert, match should return all 10 tokens
-        match1 = cache.match_prefix(key_part1)
+        match1 = cache.match_prefix(MatchPrefixParams(key=RadixKey(key_part1)))
         self.assertEqual(len(match1.device_indices), 10)
 
         # Insert extended sequence (simulating cache_unfinished_req)
         key_full = list(range(0, 20))
         val2 = self._alloc_indices(len(key_full))
-        cache.insert(key_full, value=val2, prev_prefix_len=10, swa_evicted_seqlen=0)
+        cache.insert(
+            InsertParams(key=key_full, value=val2, prev_prefix_len=10, swa_evicted_seqlen=0)
+        )
 
         # Match the full key
-        match2 = cache.match_prefix(key_full)
+        match2 = cache.match_prefix(MatchPrefixParams(key=RadixKey(key_full)))
         self.assertEqual(len(match2.device_indices), 20)
 
         # Verify old cached indices are preserved (not overwritten)

--- a/python/sgl_jax/test/mem_cache/test_unified_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_unified_radix_cache.py
@@ -1,0 +1,746 @@
+# cd python && USE_DEVICE_TYPE=cpu python -m pytest sgl_jax/test/mem_cache/test_unified_radix_cache.py -v
+# specific shard information can be appended -s
+
+import os
+
+# Set up multi-device simulation for tensor parallelism
+if os.environ.get("USE_DEVICE_TYPE") == "cpu":
+    os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
+    # Set JAX to use CPU for testing with simulated devices
+    os.environ["JAX_PLATFORMS"] = "cpu"
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.mem_cache.allocator import TokenToKVPoolAllocator
+from sgl_jax.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    InsertParams,
+    MatchPrefixParams,
+)
+from sgl_jax.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
+from sgl_jax.srt.mem_cache.radix_cache import RadixCache, RadixKey
+from sgl_jax.srt.mem_cache.unified_cache_components import ComponentType
+from sgl_jax.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+from sgl_jax.test.test_utils import CustomTestCase
+
+mesh = create_device_mesh(ici_parallelism=[1, -1], dcn_parallelism=[1, 1])
+jax.sharding.set_mesh(mesh)
+
+
+class TestUnifiedRadixCache(CustomTestCase):
+    def setUp(self):
+        self.devices = jax.devices()
+        # Small KV pool dims: the radix tree only exercises the allocator's
+        # index bookkeeping, so the actual KV buffers can stay tiny.
+        self.kv_head_num = 8
+        self.head_dim = 64
+        self.layer_num = 2
+        self.max_seq_len = 2048
+        self.dtype = jnp.bfloat16
+        self.pool_size = 8192
+
+    def _create_auto_device_setup(self, dp_size: int = 1):
+        # create memory pool
+        req_pool = ReqToTokenPool(
+            size=1024,
+            max_context_len=self.max_seq_len,
+            dtype=np.int32,
+        )
+
+        # create KV cache
+        kv_cache = MHATokenToKVPool(
+            size=self.pool_size,
+            page_size=1,
+            dtype=self.dtype,
+            head_num=self.kv_head_num,
+            head_dim=self.head_dim,
+            layer_num=self.layer_num,
+            mesh=mesh,
+            dp_size=dp_size,
+        )
+
+        # create allocator
+        allocator = TokenToKVPoolAllocator(
+            size=self.pool_size,
+            kvcache=kv_cache,
+            dp_size=dp_size,
+        )
+
+        return req_pool, allocator
+
+    def _create_unified_cache(self, req_pool, allocator, **kwargs):
+        cache = UnifiedRadixCache(
+            req_to_token_pool=req_pool,
+            token_to_kv_pool_allocator=allocator,
+            page_size=kwargs.get("page_size", 1),
+            disable=kwargs.get("disable", False),
+            enable_kv_cache_events=kwargs.get("enable_kv_cache_events", False),
+            kv_head_num=self.kv_head_num,
+            head_dim=self.head_dim,
+            layer_num=self.layer_num,
+            max_seq_len=self.max_seq_len,
+            dtype=self.dtype,
+        )
+        return cache
+
+    def _create_radix_cache(self, req_pool, allocator, **kwargs):
+        cache = RadixCache(
+            req_to_token_pool=req_pool,
+            token_to_kv_pool_allocator=allocator,
+            page_size=kwargs.get("page_size", 1),
+            disable=kwargs.get("disable", False),
+            enable_kv_cache_events=kwargs.get("enable_kv_cache_events", False),
+            kv_head_num=self.kv_head_num,
+            head_dim=self.head_dim,
+            layer_num=self.layer_num,
+            max_seq_len=self.max_seq_len,
+            dtype=self.dtype,
+        )
+        return cache
+
+    def _assert_sizes_equal(self, radix, unified, dp_rank: int = 0):
+        self.assertEqual(radix.evictable_size(dp_rank), unified.evictable_size(dp_rank))
+        self.assertEqual(radix.protected_size(dp_rank), unified.protected_size(dp_rank))
+        self.assertEqual(radix.total_size(), unified.total_size())
+
+    def test_basic_insert_and_match(self):
+        req_pool, allocator = self._create_auto_device_setup()
+        cache = self._create_unified_cache(req_pool, allocator)
+
+        key = [1, 2, 3, 4, 5, 6, 7, 8]
+        value = np.arange(100, 108, dtype=np.int32)
+        prefix_len = cache.insert(InsertParams(key=RadixKey(key), value=value))
+        self.assertEqual(prefix_len, 0)  # new inserted, no prefix
+
+        # full hit returns all 8 indices
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
+        self.assertTrue(np.array_equal(match_result.device_indices, value))
+        # full hit: best_match_node is the last matched device node (HiCache off)
+        self.assertIs(match_result.best_match_node, match_result.last_device_node)
+
+        # second insert of the same key matches the full prefix
+        prefix_len = cache.insert(InsertParams(key=RadixKey(key), value=value.copy()))
+        self.assertEqual(prefix_len, 8)
+        self.assertEqual(cache.total_size(), 8)
+
+    def test_partial_match_splits_node(self):
+        req_pool, allocator = self._create_auto_device_setup()
+        cache = self._create_unified_cache(req_pool, allocator)
+
+        key1 = [1, 2, 3, 4, 5, 6, 7, 8]
+        value1 = np.arange(100, 108, dtype=np.int32)
+        cache.insert(InsertParams(key=RadixKey(key1), value=value1))
+
+        # shares only the first 4 tokens, then diverges
+        key2 = [1, 2, 3, 4, 99, 98, 97, 96]
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key2)))
+        self.assertTrue(np.array_equal(match_result.device_indices, value1[:4]))
+        self.assertIs(match_result.best_match_node, match_result.last_device_node)
+        # the 8-token node was split: the matched node holds exactly 4 tokens
+        self.assertEqual(len(match_result.last_device_node.key), 4)
+
+        # inserting the diverging key reuses the 4-token shared prefix
+        value2 = np.arange(200, 208, dtype=np.int32)
+        prefix_len = cache.insert(InsertParams(key=RadixKey(key2), value=value2))
+        self.assertEqual(prefix_len, 4)
+        self.assertEqual(cache.total_size(), 12)
+
+    def test_empty_and_no_match(self):
+        req_pool, allocator = self._create_auto_device_setup()
+        cache = self._create_unified_cache(req_pool, allocator)
+
+        cache.insert(InsertParams(key=RadixKey([1, 2, 3, 4])))
+
+        # empty key
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey([])))
+        self.assertIsInstance(match_result.device_indices, np.ndarray)
+        self.assertEqual(match_result.device_indices.dtype, np.int32)
+        self.assertEqual(len(match_result.device_indices), 0)
+        self.assertIs(match_result.best_match_node, cache.root_node)
+
+        # completely disjoint key
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey([999, 888, 777])))
+        self.assertIsInstance(match_result.device_indices, np.ndarray)
+        self.assertEqual(len(match_result.device_indices), 0)
+        self.assertIs(match_result.best_match_node, cache.root_node)
+
+    def test_disabled_cache(self):
+        req_pool, allocator = self._create_auto_device_setup()
+        cache = self._create_unified_cache(req_pool, allocator, disable=True)
+
+        key = [1, 2, 3, 4, 5]
+        insert_result = cache.insert(InsertParams(key=RadixKey(key)))
+        self.assertEqual(insert_result, 0)
+
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
+        self.assertEqual(len(match_result.device_indices), 0)
+        self.assertIs(match_result.best_match_node, cache.root_node)
+
+        evict_result = cache.evict(EvictParams(num_tokens=100))
+        self.assertEqual(evict_result.num_tokens_evicted, 0)
+
+        lock_result = cache.inc_lock_ref(cache.root_node)
+        self.assertEqual(lock_result.delta, 0)
+
+    def test_lock_protects_from_eviction(self):
+        req_pool, allocator = self._create_auto_device_setup()
+        cache = self._create_unified_cache(req_pool, allocator)
+
+        key = [1, 2, 3, 4, 5, 6, 7, 8]
+        value = np.arange(100, 108, dtype=np.int32)
+        cache.insert(InsertParams(key=RadixKey(key), value=value))
+        self.assertEqual(cache.evictable_size(0), 8)
+
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
+        last_node = match_result.last_device_node
+
+        # lock: delta is the evictable-size change (negative on acquire)
+        lock_result = cache.inc_lock_ref(last_node)
+        self.assertEqual(lock_result.delta, -8)
+        self.assertEqual(cache.evictable_size(0), 0)
+        self.assertEqual(cache.protected_size(0), 8)
+
+        # locked node survives eviction
+        evict_result = cache.evict(EvictParams(num_tokens=100, dp_rank=0))
+        self.assertEqual(evict_result.num_tokens_evicted, 0)
+        self.assertEqual(cache.total_size(), 8)
+
+        # unlock restores the evictable/protected accounting
+        cache.dec_lock_ref(last_node, lock_result.to_dec_params())
+        self.assertEqual(cache.evictable_size(0), 8)
+        self.assertEqual(cache.protected_size(0), 0)
+
+        # now eviction frees the tokens
+        evict_result = cache.evict(EvictParams(num_tokens=100, dp_rank=0))
+        self.assertEqual(evict_result.num_tokens_evicted, 8)
+        self.assertEqual(cache.total_size(), 0)
+        self.assertEqual(cache.evictable_size(0), 0)
+
+    def test_lru_eviction_order(self):
+        req_pool, allocator = self._create_auto_device_setup()
+        cache = self._create_unified_cache(req_pool, allocator)
+
+        key_a = [1, 2, 3, 4, 5, 6, 7, 8]
+        value_a = np.arange(100, 108, dtype=np.int32)
+        cache.insert(InsertParams(key=RadixKey(key_a), value=value_a))
+
+        key_b = [101, 102, 103, 104, 105, 106, 107, 108]
+        value_b = np.arange(200, 208, dtype=np.int32)
+        cache.insert(InsertParams(key=RadixKey(key_b), value=value_b))
+
+        # touch A so B becomes the LRU leaf
+        cache.match_prefix(MatchPrefixParams(key=RadixKey(key_a)))
+
+        evict_result = cache.evict(EvictParams(num_tokens=len(key_b)))
+        self.assertEqual(evict_result.num_tokens_evicted, 8)
+        self.assertEqual(cache.total_size(), 8)
+
+        # B is gone, A is still fully matchable
+        match_b = cache.match_prefix(MatchPrefixParams(key=RadixKey(key_b)))
+        self.assertEqual(len(match_b.device_indices), 0)
+        self.assertIs(match_b.best_match_node, cache.root_node)
+
+        match_a = cache.match_prefix(MatchPrefixParams(key=RadixKey(key_a)))
+        self.assertTrue(np.array_equal(match_a.device_indices, value_a))
+
+    def test_equivalence_with_radix_cache_page1(self):
+        # fresh pools per cache so allocator state doesn't cross-contaminate
+        radix_pool, radix_alloc = self._create_auto_device_setup()
+        radix = self._create_radix_cache(radix_pool, radix_alloc, page_size=1)
+        unified_pool, unified_alloc = self._create_auto_device_setup()
+        unified = self._create_unified_cache(unified_pool, unified_alloc, page_size=1)
+
+        key_a = [1, 2, 3, 4, 5, 6, 7, 8]
+        value_a = np.arange(100, 108, dtype=np.int32)
+        # shares the first 4 tokens with A
+        key_b = [1, 2, 3, 4, 20, 21, 22, 23]
+        value_b = np.arange(200, 208, dtype=np.int32)
+        # disjoint
+        key_c = [50, 51, 52, 53, 54, 55, 56, 57]
+        value_c = np.arange(300, 308, dtype=np.int32)
+
+        for key, value, expected_prefix in (
+            (key_a, value_a, 0),
+            (key_b, value_b, 4),
+            (key_c, value_c, 0),
+        ):
+            radix_prefix = radix.insert(InsertParams(key=RadixKey(key), value=value.copy()))
+            unified_prefix = unified.insert(InsertParams(key=RadixKey(key), value=value.copy()))
+            self.assertEqual(radix_prefix, unified_prefix)
+            self.assertEqual(radix_prefix, expected_prefix)
+            self._assert_sizes_equal(radix, unified)
+
+        # matches return identical indices
+        radix_match_a = radix.match_prefix(MatchPrefixParams(key=RadixKey(key_a)))
+        unified_match_a = unified.match_prefix(MatchPrefixParams(key=RadixKey(key_a)))
+        self.assertTrue(np.array_equal(radix_match_a.device_indices, value_a))
+        self.assertTrue(
+            np.array_equal(radix_match_a.device_indices, unified_match_a.device_indices)
+        )
+        self._assert_sizes_equal(radix, unified)
+
+        # lock the matched node in both caches and compare the accounting
+        radix_lock = radix.inc_lock_ref(radix_match_a.last_device_node)
+        unified_lock = unified.inc_lock_ref(unified_match_a.last_device_node)
+        self.assertEqual(radix_lock.delta, unified_lock.delta)
+        self.assertEqual(radix_lock.delta, -8)
+        self._assert_sizes_equal(radix, unified)
+        radix.dec_lock_ref(radix_match_a.last_device_node, radix_lock.to_dec_params())
+        unified.dec_lock_ref(unified_match_a.last_device_node, unified_lock.to_dec_params())
+        self._assert_sizes_equal(radix, unified)
+
+        for key in ([1, 2, 3, 4], key_c):
+            radix_match = radix.match_prefix(MatchPrefixParams(key=RadixKey(key)))
+            unified_match = unified.match_prefix(MatchPrefixParams(key=RadixKey(key)))
+            self.assertEqual(len(radix_match.device_indices), len(key))
+            self.assertTrue(
+                np.array_equal(radix_match.device_indices, unified_match.device_indices)
+            )
+            self._assert_sizes_equal(radix, unified)
+
+        # B's tail is the LRU leaf: both caches evict the same 4 tokens
+        radix_evicted = radix.evict(EvictParams(num_tokens=4))
+        unified_evicted = unified.evict(EvictParams(num_tokens=4))
+        self.assertEqual(radix_evicted.num_tokens_evicted, unified_evicted.num_tokens_evicted)
+        self.assertEqual(radix_evicted.num_tokens_evicted, 4)
+        self._assert_sizes_equal(radix, unified)
+
+        radix_match_b = radix.match_prefix(MatchPrefixParams(key=RadixKey(key_b)))
+        unified_match_b = unified.match_prefix(MatchPrefixParams(key=RadixKey(key_b)))
+        self.assertEqual(len(radix_match_b.device_indices), 4)
+        self.assertTrue(
+            np.array_equal(radix_match_b.device_indices, unified_match_b.device_indices)
+        )
+
+        # evict everything remaining
+        radix_evicted = radix.evict(EvictParams(num_tokens=1000))
+        unified_evicted = unified.evict(EvictParams(num_tokens=1000))
+        self.assertEqual(radix_evicted.num_tokens_evicted, unified_evicted.num_tokens_evicted)
+        self.assertEqual(radix_evicted.num_tokens_evicted, 16)
+        self.assertEqual(unified.total_size(), 0)
+        self._assert_sizes_equal(radix, unified)
+
+    def test_equivalence_with_radix_cache_page128(self):
+        page_size = 128
+        radix_pool, radix_alloc = self._create_auto_device_setup()
+        radix = self._create_radix_cache(radix_pool, radix_alloc, page_size=page_size)
+        unified_pool, unified_alloc = self._create_auto_device_setup()
+        unified = self._create_unified_cache(unified_pool, unified_alloc, page_size=page_size)
+
+        # 300 tokens, page-aligned to 256
+        key_a = list(range(1000, 1300))
+        aligned_len = len(key_a) // page_size * page_size
+        self.assertEqual(aligned_len, 256)
+        value_a = np.arange(1, 1 + aligned_len, dtype=np.int32)
+
+        # RadixCache.insert does not page-align (its callers pre-align), so the
+        # reference gets the pre-aligned key; the unified cache gets the raw
+        # un-aligned key to exercise its internal page-align truncation.
+        radix_prefix = radix.insert(
+            InsertParams(key=RadixKey(key_a[:aligned_len]), value=value_a.copy())
+        )
+        unified_prefix = unified.insert(InsertParams(key=RadixKey(key_a), value=value_a.copy()))
+        self.assertEqual(radix_prefix, unified_prefix)
+        self.assertEqual(radix_prefix, 0)
+        self.assertEqual(unified.total_size(), 256)
+        self._assert_sizes_equal(radix, unified)
+
+        # match with a 270-token shared-prefix key: aligned down to 256
+        key_b = key_a[:270]
+        radix_match = radix.match_prefix(MatchPrefixParams(key=RadixKey(key_b)))
+        unified_match = unified.match_prefix(MatchPrefixParams(key=RadixKey(key_b)))
+        self.assertEqual(len(radix_match.device_indices), 256)
+        self.assertEqual(len(unified_match.device_indices), 256)
+        self.assertTrue(np.array_equal(radix_match.device_indices, value_a))
+        self.assertTrue(np.array_equal(radix_match.device_indices, unified_match.device_indices))
+        self.assertIs(unified_match.best_match_node, unified_match.last_device_node)
+        self._assert_sizes_equal(radix, unified)
+
+        # re-insert: the whole aligned prefix is matched
+        radix_prefix = radix.insert(
+            InsertParams(key=RadixKey(key_a[:aligned_len]), value=value_a.copy())
+        )
+        unified_prefix = unified.insert(InsertParams(key=RadixKey(key_a), value=value_a.copy()))
+        self.assertEqual(radix_prefix, unified_prefix)
+        self.assertEqual(radix_prefix, 256)
+        self._assert_sizes_equal(radix, unified)
+
+        # diverging key sharing exactly one 128-token page: splits the node
+        key_c = key_a[:128] + list(range(5000, 5172))
+        value_c = np.arange(301, 301 + aligned_len, dtype=np.int32)
+        radix_prefix = radix.insert(
+            InsertParams(key=RadixKey(key_c[:aligned_len]), value=value_c.copy())
+        )
+        unified_prefix = unified.insert(InsertParams(key=RadixKey(key_c), value=value_c.copy()))
+        self.assertEqual(radix_prefix, unified_prefix)
+        self.assertEqual(radix_prefix, 128)
+        self.assertEqual(unified.total_size(), 384)
+        self._assert_sizes_equal(radix, unified)
+
+        # touch A so C's tail becomes the LRU leaf, then evict one page
+        radix_match = radix.match_prefix(MatchPrefixParams(key=RadixKey(key_b)))
+        unified_match = unified.match_prefix(MatchPrefixParams(key=RadixKey(key_b)))
+        self.assertTrue(np.array_equal(radix_match.device_indices, unified_match.device_indices))
+
+        radix_evicted = radix.evict(EvictParams(num_tokens=128))
+        unified_evicted = unified.evict(EvictParams(num_tokens=128))
+        self.assertEqual(radix_evicted.num_tokens_evicted, unified_evicted.num_tokens_evicted)
+        self.assertEqual(radix_evicted.num_tokens_evicted, 128)
+        self._assert_sizes_equal(radix, unified)
+
+        # A is still fully matchable after C's tail eviction
+        radix_match = radix.match_prefix(MatchPrefixParams(key=RadixKey(key_b)))
+        unified_match = unified.match_prefix(MatchPrefixParams(key=RadixKey(key_b)))
+        self.assertTrue(np.array_equal(radix_match.device_indices, value_a))
+        self.assertTrue(np.array_equal(radix_match.device_indices, unified_match.device_indices))
+
+        radix_evicted = radix.evict(EvictParams(num_tokens=1000))
+        unified_evicted = unified.evict(EvictParams(num_tokens=1000))
+        self.assertEqual(radix_evicted.num_tokens_evicted, unified_evicted.num_tokens_evicted)
+        self.assertEqual(radix_evicted.num_tokens_evicted, 256)
+        self.assertEqual(unified.total_size(), 0)
+        self._assert_sizes_equal(radix, unified)
+
+    def test_dp_rank_isolation(self):
+        req_pool, allocator = self._create_auto_device_setup(dp_size=2)
+        cache = self._create_unified_cache(req_pool, allocator)
+
+        # same token ids on both ranks: dp_rank namespaces them
+        key = [1, 2, 3, 4, 5, 6, 7, 8]
+        value_rank0 = np.arange(10, 18, dtype=np.int32)
+        value_rank1 = np.arange(20, 28, dtype=np.int32)
+        cache.insert(InsertParams(key=RadixKey(key, None, 0), value=value_rank0))
+        cache.insert(InsertParams(key=RadixKey(key, None, 1), value=value_rank1))
+
+        self.assertEqual(cache.evictable_size(0), 8)
+        self.assertEqual(cache.evictable_size(1), 8)
+        self.assertEqual(cache.total_size(), 16)
+
+        match_rank0 = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, 0)))
+        self.assertTrue(np.array_equal(match_rank0.device_indices, value_rank0))
+        match_rank1 = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, 1)))
+        self.assertTrue(np.array_equal(match_rank1.device_indices, value_rank1))
+
+        # evicting rank 0 leaves rank 1 untouched
+        evict_result = cache.evict(EvictParams(num_tokens=100, dp_rank=0))
+        self.assertEqual(evict_result.num_tokens_evicted, 8)
+        self.assertEqual(cache.evictable_size(0), 0)
+        self.assertEqual(cache.evictable_size(1), 8)
+        self.assertEqual(cache.total_size(), 8)
+
+        match_rank0 = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, 0)))
+        self.assertEqual(len(match_rank0.device_indices), 0)
+        self.assertIs(match_rank0.best_match_node, cache.root_node)
+
+        match_rank1 = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, 1)))
+        self.assertTrue(np.array_equal(match_rank1.device_indices, value_rank1))
+
+    def test_extra_key_isolation(self):
+        req_pool, allocator = self._create_auto_device_setup()
+        cache = self._create_unified_cache(req_pool, allocator)
+
+        # same token ids under two extra_keys: extra_key namespaces them
+        key = [1, 2, 3, 4, 5, 6, 7, 8]
+        value_a = np.arange(10, 18, dtype=np.int32)
+        value_b = np.arange(20, 28, dtype=np.int32)
+        cache.insert(InsertParams(key=RadixKey(key, "lora-a"), value=value_a))
+        cache.insert(InsertParams(key=RadixKey(key, "lora-b"), value=value_b))
+        self.assertEqual(cache.total_size(), 16)
+
+        match_a = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora-a")))
+        self.assertTrue(np.array_equal(match_a.device_indices, value_a))
+        match_b = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora-b")))
+        self.assertTrue(np.array_equal(match_b.device_indices, value_b))
+
+        # an unknown extra_key matches nothing
+        match_c = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, "lora-c")))
+        self.assertEqual(len(match_c.device_indices), 0)
+        self.assertIs(match_c.best_match_node, cache.root_node)
+
+    def test_evict_device_leaf_tombstones_and_unlinks(self):
+        # Deliberate white-box coverage of the tombstone contract:
+        # _cascade_evict sets the FULL component value to None ("tombstone")
+        # after the component data is freed. In stage 1 the public API can
+        # never observe an evicted-but-alive node (eviction immediately
+        # unlinks the leaf), so this drives _evict_device_leaf directly until
+        # the host tier (HiCache) lands and makes tombstones reachable.
+        req_pool, allocator = self._create_auto_device_setup()
+        cache = self._create_unified_cache(req_pool, allocator)
+
+        key = [1, 2, 3, 4, 5, 6, 7, 8]
+        value = np.arange(100, 108, dtype=np.int32)
+        cache.insert(InsertParams(key=RadixKey(key), value=value))
+        leaf = cache.match_prefix(MatchPrefixParams(key=RadixKey(key))).last_device_node
+
+        # Precondition: the leaf is live and evictable.
+        self.assertIn(leaf, cache.evictable_device_leaves)
+        self.assertIs(leaf.evicted, False)
+
+        tracker = {ct: 0 for ct in cache.tree_components}
+        cache._evict_device_leaf(leaf, tracker)
+
+        self.assertEqual(tracker[ComponentType.FULL], 8)
+        # Tombstone: parent link kept, FULL value is None.
+        self.assertIs(leaf.evicted, True)
+        # The leaf is detached from the tree (key is a single chain off root).
+        self.assertNotIn(leaf, cache.root_node.children.values())
+        self.assertNotIn(leaf, cache.evictable_device_leaves)
+        self.assertEqual(cache.evictable_size(0), 0)
+        self.assertEqual(cache.total_size(), 0)
+
+        # A fresh match no longer sees the key.
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key)))
+        self.assertEqual(len(match_result.device_indices), 0)
+        self.assertIs(match_result.best_match_node, cache.root_node)
+
+    def test_reset(self):
+        req_pool, allocator = self._create_auto_device_setup()
+        cache = self._create_unified_cache(req_pool, allocator)
+
+        key1 = [1, 2, 3, 4, 5, 6, 7, 8]
+        cache.insert(InsertParams(key=RadixKey(key1), value=np.arange(100, 108, dtype=np.int32)))
+        cache.insert(
+            InsertParams(key=RadixKey([20, 21, 22]), value=np.arange(200, 203, dtype=np.int32))
+        )
+
+        # lock one path so both buckets are non-empty before the reset
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key1)))
+        cache.inc_lock_ref(match_result.last_device_node)
+        self.assertEqual(cache.protected_size(0), 8)
+        self.assertEqual(cache.evictable_size(0), 3)
+        self.assertEqual(cache.total_size(), 11)
+
+        cache.reset()
+
+        self.assertEqual(cache.evictable_size(0), 0)
+        self.assertEqual(cache.protected_size(0), 0)
+        self.assertEqual(cache.total_size(), 0)
+
+        match_result = cache.match_prefix(MatchPrefixParams(key=RadixKey(key1)))
+        self.assertEqual(len(match_result.device_indices), 0)
+        self.assertIs(match_result.best_match_node, cache.root_node)
+
+
+class MockRequest:
+    """mock request object for testing cache request functionality"""
+
+    def __init__(
+        self,
+        req_pool_idx,
+        origin_input_ids,
+        output_ids,
+        fill_ids,
+        prefix_indices,
+        last_node,
+        extra_key=None,
+        dp_rank=None,
+    ):
+        self.req_pool_idx = req_pool_idx
+        self.origin_input_ids = origin_input_ids
+        self.output_ids = output_ids
+        self.fill_ids = fill_ids
+        self.prefix_indices = prefix_indices
+        self.last_node = last_node
+        self.extra_key = extra_key
+        self.dp_rank = dp_rank
+        self.rid = "mock-req"
+        # Match legacy length formula so cache_finished_req frees the same range.
+        self.kv_committed_len = len(origin_input_ids) + max(len(output_ids) - 1, 0)
+        self.kv_allocated_len = self.kv_committed_len
+        self.kv_committed_freed = False
+        self.kv_overallocated_freed = False
+        # Mirrors prepare_for_extend: page-aligned matched-prefix length at
+        # extend time. Tests construct mock reqs without going through extend,
+        # so default to len(prefix_indices) (== matched prefix in the simple
+        # mock setup; no unaligned tail because tests use page_size=1).
+        self.cache_protected_len = len(prefix_indices)
+
+    def pop_committed_kv_cache(self) -> int:
+        assert not self.kv_committed_freed
+        self.kv_committed_freed = True
+        return self.kv_committed_len
+
+    def pop_overallocated_kv_cache(self):
+        assert not self.kv_overallocated_freed
+        self.kv_overallocated_freed = True
+        return self.kv_committed_len, self.kv_allocated_len
+
+
+class TestUnifiedRadixCacheWithRequests(CustomTestCase):
+    """Drive cache_unfinished_req / cache_finished_req through RadixCache and
+    UnifiedRadixCache with identical inputs and compare every observable."""
+
+    def setUp(self):
+        self.devices = jax.devices()
+        self.kv_head_num = 8
+        self.head_dim = 64
+        self.layer_num = 2
+        self.max_seq_len = 2048
+        self.dtype = jnp.bfloat16
+        self.pool_size = 8192
+
+    def _create_stack(self, cache_cls, disable: bool = False):
+        """One independent req-pool + allocator + cache stack (page_size=1)."""
+        req_pool = ReqToTokenPool(
+            size=1024,
+            max_context_len=self.max_seq_len,
+            dtype=np.int32,
+        )
+        kv_cache = MHATokenToKVPool(
+            size=self.pool_size,
+            page_size=1,
+            dtype=self.dtype,
+            head_num=self.kv_head_num,
+            head_dim=self.head_dim,
+            layer_num=self.layer_num,
+            mesh=mesh,
+        )
+        allocator = TokenToKVPoolAllocator(
+            size=self.pool_size,
+            kvcache=kv_cache,
+        )
+        cache = cache_cls(
+            req_to_token_pool=req_pool,
+            token_to_kv_pool_allocator=allocator,
+            page_size=1,
+            disable=disable,
+            kv_head_num=self.kv_head_num,
+            head_dim=self.head_dim,
+            layer_num=self.layer_num,
+            max_seq_len=self.max_seq_len,
+            dtype=self.dtype,
+        )
+        return req_pool, allocator, cache
+
+    def _assert_sizes_equal(self, radix, unified, dp_rank: int = 0):
+        self.assertEqual(radix.evictable_size(dp_rank), unified.evictable_size(dp_rank))
+        self.assertEqual(radix.protected_size(dp_rank), unified.protected_size(dp_rank))
+        self.assertEqual(radix.total_size(), unified.total_size())
+
+    def test_cache_unfinished_then_finished_equivalence(self):
+        radix_pool, radix_alloc, radix = self._create_stack(RadixCache)
+        unified_pool, unified_alloc, unified = self._create_stack(UnifiedRadixCache)
+        stacks = (
+            (radix, radix_pool, radix_alloc),
+            (unified, unified_pool, unified_alloc),
+        )
+
+        # --- chunked prefill: cache_unfinished_req ---
+        prefill_ids = list(range(1, 13))  # 12 tokens
+        reqs = []
+        for cache, pool, alloc in stacks:
+            kv_indices = alloc.alloc(len(prefill_ids), dp_rank=0)
+            self.assertIsNotNone(kv_indices)
+            pool.write((0, slice(0, len(prefill_ids))), kv_indices)
+            req = MockRequest(
+                req_pool_idx=0,
+                origin_input_ids=list(prefill_ids),
+                output_ids=[],
+                fill_ids=list(prefill_ids),
+                prefix_indices=np.empty((0,), dtype=np.int32),
+                last_node=cache.root_node,
+            )
+            req.last_matched_prefix_len = 0
+            cache.cache_unfinished_req(req)
+            reqs.append(req)
+        radix_req, unified_req = reqs
+
+        # Request observables match across implementations.
+        self.assertEqual(radix_req.cache_protected_len, unified_req.cache_protected_len)
+        self.assertEqual(radix_req.cache_protected_len, 12)
+        self.assertEqual(radix_req.last_matched_prefix_len, unified_req.last_matched_prefix_len)
+        self.assertEqual(radix_req.last_matched_prefix_len, 12)
+        self.assertEqual(len(radix_req.prefix_indices), len(unified_req.prefix_indices))
+        self.assertEqual(len(radix_req.prefix_indices), 12)
+        # Cache accounting matches: the cached prefix is locked for the
+        # still-running request.
+        self._assert_sizes_equal(radix, unified)
+        self.assertEqual(unified.evictable_size(0), 0)
+        self.assertEqual(unified.protected_size(0), 12)
+        self.assertEqual(unified.total_size(), 12)
+        # The unified req now points at the locked path, not root.
+        self.assertIsNot(unified_req.last_node, unified.root_node)
+
+        # --- completion: cache_finished_req on the same req objects ---
+        # Production flow: cache_unfinished during chunked prefill, then
+        # cache_finished at completion on the same req; pop_committed_kv_cache
+        # is called exactly once, at finish.
+        output_ids = [13, 14, 15, 16, 17]
+        # kv is committed for all but the last output token.
+        num_new_kv = len(output_ids) - 1
+        for (cache, pool, alloc), req in zip(stacks, reqs):
+            new_kv_indices = alloc.alloc(num_new_kv, dp_rank=0)
+            self.assertIsNotNone(new_kv_indices)
+            pool.write(
+                (0, slice(len(prefill_ids), len(prefill_ids) + num_new_kv)),
+                new_kv_indices,
+            )
+            req.output_ids = list(output_ids)
+            req.fill_ids = req.origin_input_ids + req.output_ids
+            # Keep the MockRequest committed-kv formula in sync after mutation.
+            req.kv_committed_len = len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
+            req.kv_allocated_len = req.kv_committed_len
+            cache.cache_finished_req(req)
+
+        # The lock is released and the full committed range is cached.
+        self._assert_sizes_equal(radix, unified)
+        self.assertEqual(unified.protected_size(0), 0)
+        self.assertEqual(unified.evictable_size(0), 16)
+        self.assertEqual(unified.total_size(), 16)
+
+        full_sequence = prefill_ids + output_ids
+        radix_match = radix.match_prefix(MatchPrefixParams(key=RadixKey(full_sequence)))
+        unified_match = unified.match_prefix(MatchPrefixParams(key=RadixKey(full_sequence)))
+        self.assertEqual(len(radix_match.device_indices), len(unified_match.device_indices))
+        self.assertEqual(len(unified_match.device_indices), 16)
+        self.assertIs(unified_match.best_match_node, unified_match.last_device_node)
+
+    def test_cache_finished_req_disabled_unified(self):
+        """test cache finished request disabled"""
+        _, _, disabled_cache = self._create_stack(UnifiedRadixCache, disable=True)
+
+        # create mock request
+        mock_req = MockRequest(
+            req_pool_idx=0,
+            origin_input_ids=[1, 2, 3],
+            output_ids=[4, 5],
+            fill_ids=[1, 2, 3, 4],
+            prefix_indices=jnp.array([1, 2, 3]),
+            last_node=disabled_cache.root_node,
+        )
+
+        # should execute normally without throwing exception
+        try:
+            disabled_cache.cache_finished_req(mock_req)
+        except Exception as e:
+            self.fail(f"cache_finished_req raised an exception: {e}")
+        # the committed kv range was popped (and freed) exactly once
+        self.assertTrue(mock_req.kv_committed_freed)
+
+    def test_cache_unfinished_req_disabled_unified(self):
+        _, _, disabled_cache = self._create_stack(UnifiedRadixCache, disable=True)
+
+        # create mock request
+        mock_req = MockRequest(
+            req_pool_idx=0,
+            origin_input_ids=[1, 2, 3],
+            output_ids=[4],
+            fill_ids=[1, 2, 3, 4],
+            prefix_indices=jnp.array([1, 2, 3]),
+            last_node=disabled_cache.root_node,
+        )
+
+        # should execute normally without throwing exception
+        try:
+            disabled_cache.cache_unfinished_req(mock_req)
+        except Exception as e:
+            self.fail(f"cache_unfinished_req raised an exception: {e}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sgl_jax/test/mem_cache/test_unified_radix_tree_flag.py
+++ b/python/sgl_jax/test/mem_cache/test_unified_radix_tree_flag.py
@@ -1,0 +1,297 @@
+# cd python && USE_DEVICE_TYPE=cpu python -m pytest sgl_jax/test/mem_cache/test_unified_radix_tree_flag.py -q
+
+import os
+
+# Set up multi-device simulation for tensor parallelism
+if os.environ.get("USE_DEVICE_TYPE") == "cpu":
+    os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
+    # Set JAX to use CPU for testing with simulated devices
+    os.environ["JAX_PLATFORMS"] = "cpu"
+
+import argparse
+import unittest
+from unittest import mock
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.mem_cache.allocator import (
+    SWATokenToKVPoolAllocator,
+    TokenToKVPoolAllocator,
+)
+from sgl_jax.srt.mem_cache.cache_init_params import CacheInitParams
+from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache, SWAChunkCache
+from sgl_jax.srt.mem_cache.memory_pool import (
+    MHATokenToKVPool,
+    ReqToTokenPool,
+    SWAKVPool,
+)
+from sgl_jax.srt.mem_cache.radix_cache import RadixCache
+from sgl_jax.srt.mem_cache.registry import (
+    TreeCacheBuildContext,
+    default_radix_cache_factory,
+)
+from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
+from sgl_jax.srt.mem_cache.unified_cache_components import ComponentType
+from sgl_jax.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sgl_jax.srt.server_args import ServerArgs
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+from sgl_jax.test.test_utils import CustomTestCase
+
+mesh = create_device_mesh(ici_parallelism=[1, -1], dcn_parallelism=[1, 1])
+jax.sharding.set_mesh(mesh)
+
+ENV_FLAG = "SGLANG_JAX_ENABLE_UNIFIED_RADIX_TREE"
+
+
+class _StubModelConfig:
+    """Exposes exactly what default_radix_cache_factory reads off ModelConfig."""
+
+    head_dim = 64
+    num_hidden_layers = 2
+
+    def get_num_kv_heads(self, tp_size: int) -> int:
+        return 8
+
+
+def _make_server_args(**kwargs) -> ServerArgs:
+    """Construct ServerArgs hermetically.
+
+    ``__post_init__`` reads and writes process env vars (e.g. it honors
+    SGLANG_JAX_ENABLE_UNIFIED_RADIX_TREE and sets
+    SGLANG_ENABLE_DETERMINISTIC_SAMPLING), so build inside a patched env with
+    the unified-radix override removed; tests that exercise the env override
+    set it explicitly themselves.
+    """
+    kwargs.setdefault("model_path", "dummy-model")
+    kwargs.setdefault("max_seq_len", 2048)
+    with mock.patch.dict(os.environ):
+        os.environ.pop(ENV_FLAG, None)
+        return ServerArgs(**kwargs)
+
+
+class TestUnifiedRadixTreeFlag(CustomTestCase):
+    def setUp(self):
+        # Small KV pool dims: routing only constructs the caches, so the
+        # actual KV buffers can stay tiny.
+        self.kv_head_num = 8
+        self.head_dim = 64
+        self.layer_num = 2
+        self.max_seq_len = 2048
+        self.dtype = jnp.bfloat16
+        self.pool_size = 8192
+
+    # ------------------------------------------------------------------ #
+    #  Pool helpers (fresh pools per test)                                 #
+    # ------------------------------------------------------------------ #
+
+    def _create_pools(self, dp_size: int = 1):
+        req_pool = ReqToTokenPool(
+            size=1024,
+            max_context_len=self.max_seq_len,
+            dtype=np.int32,
+        )
+        kv_cache = MHATokenToKVPool(
+            size=self.pool_size,
+            page_size=1,
+            dtype=self.dtype,
+            head_num=self.kv_head_num,
+            head_dim=self.head_dim,
+            layer_num=self.layer_num,
+            mesh=mesh,
+            dp_size=dp_size,
+        )
+        allocator = TokenToKVPoolAllocator(
+            size=self.pool_size,
+            kvcache=kv_cache,
+            dp_size=dp_size,
+        )
+        return req_pool, allocator
+
+    def _create_swa_pools(self):
+        req_pool = ReqToTokenPool(
+            size=64,
+            max_context_len=512,
+            dtype=np.int32,
+        )
+        kv_pool = SWAKVPool(
+            size=128,
+            size_swa=128,
+            page_size=1,
+            swa_attention_layer_ids=[0],
+            full_attention_layer_ids=[1],
+            token_to_kv_pool_class=MHATokenToKVPool,
+            dtype=self.dtype,
+            # head_num must stay divisible by the tensor-axis size of the
+            # module-level 8-device mesh.
+            head_num=self.kv_head_num,
+            head_dim=self.head_dim,
+            mesh=mesh,
+        )
+        allocator = SWATokenToKVPoolAllocator(
+            size=128,
+            size_swa=128,
+            kvcache=kv_pool,
+        )
+        return req_pool, allocator
+
+    def _build_ctx(
+        self,
+        server_args: ServerArgs,
+        req_pool,
+        allocator,
+        *,
+        is_hybrid_swa: bool = False,
+        disable_radix_cache: bool = False,
+        effective_chunked_prefill_size: int | None = None,
+        sliding_window_size: int | None = None,
+    ) -> TreeCacheBuildContext:
+        params = CacheInitParams(
+            req_to_token_pool=req_pool,
+            token_to_kv_pool_allocator=allocator,
+            page_size=1,
+            sliding_window_size=sliding_window_size,
+        )
+        return TreeCacheBuildContext(
+            server_args=server_args,
+            params=params,
+            is_hybrid_swa=is_hybrid_swa,
+            disable_radix_cache=disable_radix_cache,
+            effective_chunked_prefill_size=effective_chunked_prefill_size,
+            model_config=_StubModelConfig(),
+            tp_size=1,
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Flag parsing                                                        #
+    # ------------------------------------------------------------------ #
+
+    def test_flag_default_off(self):
+        server_args = _make_server_args()
+        self.assertIs(server_args.enable_unified_radix_tree, False)
+
+    def test_flag_cli_parse(self):
+        parser = argparse.ArgumentParser()
+        ServerArgs.add_cli_args(parser)
+
+        args_on = parser.parse_args(["--model-path", "dummy-model", "--enable-unified-radix-tree"])
+        self.assertTrue(args_on.enable_unified_radix_tree)
+
+        args_off = parser.parse_args(["--model-path", "dummy-model"])
+        self.assertFalse(args_off.enable_unified_radix_tree)
+
+        # round-trip through from_cli_args: the namespace attr lands on the field
+        with mock.patch.dict(os.environ):
+            os.environ.pop(ENV_FLAG, None)
+            server_args = ServerArgs.from_cli_args(args_on)
+            self.assertTrue(server_args.enable_unified_radix_tree)
+
+    def test_flag_env_honor(self):
+        with mock.patch.dict(os.environ, {ENV_FLAG: "1"}):
+            server_args = ServerArgs(model_path="dummy-model", max_seq_len=2048)
+            self.assertTrue(server_args.enable_unified_radix_tree)
+
+        with mock.patch.dict(os.environ, {ENV_FLAG: "0"}):
+            server_args = ServerArgs(model_path="dummy-model", max_seq_len=2048)
+            self.assertFalse(server_args.enable_unified_radix_tree)
+
+        # env var absent
+        server_args = _make_server_args()
+        self.assertFalse(server_args.enable_unified_radix_tree)
+
+    # ------------------------------------------------------------------ #
+    #  Factory routing                                                     #
+    # ------------------------------------------------------------------ #
+
+    def test_factory_flag_off_returns_radix_cache(self):
+        server_args = _make_server_args()
+        req_pool, allocator = self._create_pools()
+        ctx = self._build_ctx(server_args, req_pool, allocator)
+
+        cache = default_radix_cache_factory(ctx)
+
+        self.assertIsInstance(cache, RadixCache)
+        self.assertNotIsInstance(cache, UnifiedRadixCache)
+        self.assertFalse(cache.disable)
+
+    def test_factory_flag_on_returns_unified(self):
+        server_args = _make_server_args(enable_unified_radix_tree=True)
+        req_pool, allocator = self._create_pools()
+        ctx = self._build_ctx(server_args, req_pool, allocator)
+
+        cache = default_radix_cache_factory(ctx)
+
+        self.assertIsInstance(cache, UnifiedRadixCache)
+        self.assertEqual(cache.tree_components, (ComponentType.FULL,))
+        self.assertIs(cache.disable, False)
+
+    def test_factory_flag_on_hybrid_unaffected(self):
+        server_args = _make_server_args(enable_unified_radix_tree=True)
+        req_pool, allocator = self._create_swa_pools()
+        ctx = self._build_ctx(
+            server_args,
+            req_pool,
+            allocator,
+            is_hybrid_swa=True,
+            sliding_window_size=64,
+        )
+
+        cache = default_radix_cache_factory(ctx)
+
+        self.assertIsInstance(cache, SWARadixCache)
+        self.assertNotIsInstance(cache, UnifiedRadixCache)
+
+    def test_factory_flag_on_hybrid_disabled_returns_swa_chunk_cache(self):
+        # hybrid + disabled radix wins over the unified flag (registry checks
+        # is_hybrid_swa first, and its disable branch builds SWAChunkCache).
+        server_args = _make_server_args(enable_unified_radix_tree=True)
+        req_pool, allocator = self._create_swa_pools()
+        ctx = self._build_ctx(
+            server_args,
+            req_pool,
+            allocator,
+            is_hybrid_swa=True,
+            disable_radix_cache=True,
+            sliding_window_size=64,
+        )
+
+        cache = default_radix_cache_factory(ctx)
+
+        self.assertIsInstance(cache, SWAChunkCache)
+        self.assertNotIsInstance(cache, UnifiedRadixCache)
+
+    def test_factory_flag_on_disabled_radix_unaffected(self):
+        server_args = _make_server_args(enable_unified_radix_tree=True)
+
+        # disabled + chunked prefill set -> ChunkCache
+        req_pool, allocator = self._create_pools()
+        ctx = self._build_ctx(
+            server_args,
+            req_pool,
+            allocator,
+            disable_radix_cache=True,
+            effective_chunked_prefill_size=4096,
+        )
+        cache = default_radix_cache_factory(ctx)
+        self.assertIsInstance(cache, ChunkCache)
+        self.assertNotIsInstance(cache, UnifiedRadixCache)
+        self.assertNotIsInstance(cache, RadixCache)
+
+        # disabled + chunked prefill None -> disabled RadixCache
+        req_pool, allocator = self._create_pools()
+        ctx = self._build_ctx(
+            server_args,
+            req_pool,
+            allocator,
+            disable_radix_cache=True,
+            effective_chunked_prefill_size=None,
+        )
+        cache = default_radix_cache_factory(ctx)
+        self.assertIsInstance(cache, RadixCache)
+        self.assertNotIsInstance(cache, UnifiedRadixCache)
+        self.assertTrue(cache.disable)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sgl_jax/test/test_kv_cache_builder.py
+++ b/python/sgl_jax/test/test_kv_cache_builder.py
@@ -9,6 +9,7 @@ def _make_server_args(**overrides):
     args.disable_radix_cache = False
     args.chunked_prefill_size = None
     args.max_seq_len = 4096
+    args.enable_unified_radix_tree = False
     for k, v in overrides.items():
         setattr(args, k, v)
     return args
@@ -38,6 +39,22 @@ class TestBuildKVCache(unittest.TestCase):
         from sgl_jax.srt.mem_cache.radix_cache import RadixCache
 
         self.assertIsInstance(cache, RadixCache)
+
+    def test_enable_unified_radix_tree_returns_unified_radix_cache(self):
+        cache = build_kv_cache(
+            server_args=_make_server_args(enable_unified_radix_tree=True),
+            model_config=_make_model_config(),
+            req_to_token_pool=MagicMock(),
+            token_to_kv_pool_allocator=MagicMock(),
+            page_size=1,
+            is_hybrid=False,
+            sliding_window_size=None,
+            tp_size=1,
+            spec_algorithm=None,
+        )
+        from sgl_jax.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+
+        self.assertIsInstance(cache, UnifiedRadixCache)
 
     def test_disable_radix_no_chunked_prefill_returns_disabled_radix(self):
         cache = build_kv_cache(

--- a/python/sgl_jax/test/test_mixed_chunk_dp.py
+++ b/python/sgl_jax/test/test_mixed_chunk_dp.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from sgl_jax.srt.managers.schedule_batch import Req, ScheduleBatch
 from sgl_jax.srt.managers.schedule_policy import AddReqResult, PrefillAdder
+from sgl_jax.srt.mem_cache.base_prefix_cache import IncLockRefResult
 from sgl_jax.srt.sampling.sampling_params import SamplingParams
 
 
@@ -27,9 +28,9 @@ class _DummyRadixCache:
         return 0
 
     def inc_lock_ref(self, node):
-        return None
+        return IncLockRefResult(delta=0)
 
-    def dec_lock_ref(self, node, swa_uuid_for_lock=None):
+    def dec_lock_ref(self, node, params=None):
         pass
 
 

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -465,6 +465,13 @@ def get_benchmark_args(
     backend="sgl-jax",
     warmup_requests=1,
     return_routed_experts=False,
+    gsp_num_groups=64,
+    gsp_prompts_per_group=16,
+    gsp_system_prompt_len=2048,
+    gsp_question_len=128,
+    gsp_output_len=256,
+    gsp_range_ratio=1.0,
+    flush_cache=False,
 ):
     return SimpleNamespace(
         backend=backend,
@@ -501,6 +508,13 @@ def get_benchmark_args(
         pd_separated=pd_separated,
         warmup_requests=warmup_requests,
         return_routed_experts=return_routed_experts,
+        gsp_num_groups=gsp_num_groups,
+        gsp_prompts_per_group=gsp_prompts_per_group,
+        gsp_system_prompt_len=gsp_system_prompt_len,
+        gsp_question_len=gsp_question_len,
+        gsp_output_len=gsp_output_len,
+        gsp_range_ratio=gsp_range_ratio,
+        flush_cache=flush_cache,
     )
 
 

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -378,6 +378,7 @@ suites = {
         TestFile("test/srt/lora/test_bgmv_backend.py", 6),
         TestFile("test/srt/lora/test_dynamic_lora.py", 10),
         TestFile("test/srt/lora/test_static_lora.py", 10),
+        TestFile("test/srt/test_unified_radix_cache_serving.py", 8),
     ],
     "e2e-test-tpu-v6e-4": [
         TestFile("test/srt/openai_server/basic/test_tool_calls.py", 2),

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -307,6 +307,8 @@ suites = {
         TestFile("python/sgl_jax/test/mem_cache/test_swa_allocator.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_swa_radix_cache.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_radix_cache.py", 1),
+        TestFile("python/sgl_jax/test/mem_cache/test_unified_radix_cache.py", 1),
+        TestFile("python/sgl_jax/test/mem_cache/test_unified_radix_tree_flag.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_paged_allocator_multi_dp.py", 1),
         TestFile("python/sgl_jax/test/test_kv_cache_builder.py", 0.1, runner="pytest"),
         TestFile("test/srt/function_call/test_qwen3_coder_detector.py", 0.1),

--- a/test/srt/test_eval_accuracy_large_unified_radix.py
+++ b/test/srt/test_eval_accuracy_large_unified_radix.py
@@ -1,0 +1,99 @@
+"""MMLU sanity for --enable-unified-radix-tree (HiCache Stage 1, S1c / #1337).
+
+Mirrors test_eval_accuracy_large.py with the unified-radix-tree flag on, to
+confirm the UnifiedRadixCache serving path does not regress accuracy.
+
+NOTE: deliberately NOT registered in test/srt/run_suite.py. CI suite placement
+(accuracy-test-tpu-v6e-1 vs a nightly suite) is deferred pending team
+discussion; run it manually:
+
+    cd test/srt && python -m unittest \
+        test_eval_accuracy_large_unified_radix.TestEvalAccuracyLargeUnifiedRadix.test_mmlu
+
+Caveat: `python run_suite.py --suite all` globs test_*.py and WOULD pick this
+up; that is expected -- the deferral is about the named per-PR/nightly suites.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from run_eval import run_eval
+
+from sgl_jax.srt.utils import kill_process_tree
+from sgl_jax.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+
+
+class TestEvalAccuracyLargeUnifiedRadix(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--skip-server-warmup",
+                "--dist-init-addr",
+                "0.0.0.0:10011",
+                "--nnodes",
+                "1",
+                "--random-seed",
+                "3",
+                "--mem-fraction-static",
+                "0.8",
+                "--max-prefill-tokens",
+                "8192",
+                "--download-dir",
+                "/dev/shm/",
+                "--dtype",
+                "bfloat16",
+                "--attention-backend",
+                "fa",
+                "--precompile-bs-paddings",
+                "64",
+                "--precompile-token-paddings",
+                "8192",
+                "--chunked-prefill-size",
+                "-1",
+                "--max-running-requests",
+                "64",
+                "--page-size",
+                "64",
+                "--enable-unified-radix-tree",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="mmlu",
+            num_examples=200,
+            num_threads=32,
+        )
+
+        metrics = run_eval(args)
+
+        if is_in_ci():
+            write_github_step_summary(f'### test_mmlu\n{metrics["score"]=:.4f}\n')
+        print("mmlu metrics", metrics)
+
+        self.assertGreater(metrics["score"], 0.698)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_unified_radix_cache_serving.py
+++ b/test/srt/test_unified_radix_cache_serving.py
@@ -1,0 +1,165 @@
+"""Serving-level verification for ``--enable-unified-radix-tree``.
+
+HiCache Stage 1, S1c (#1337).
+
+Scope is intentionally flag-on only: this per-PR test proves the enabled
+UnifiedRadixCache serving path is active and correct. The Radix / no-cache /
+Unified comparison evidence (relative cache-hit and throughput numbers) is
+produced separately by a standalone A/B script, not by this file.
+
+Qwen3-1.7B is non-hybrid, so ``--enable-unified-radix-tree`` routes the cache
+to UnifiedRadixCache via the registry. The ``/get_server_info`` assertion in
+``setUpClass`` confirms the flag actually took effect before any cache
+behavior is checked.
+"""
+
+import unittest
+
+import requests
+
+from sgl_jax.srt.utils import kill_process_tree
+from sgl_jax.test.kits.cache_hit_kit import flush_cache, run_multiturn_cache_hit_test
+from sgl_jax.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+_PAGE_SIZE = 64
+
+# Do NOT add "--stream-output": the cache-hit kit assumes each chunk carries the
+# full accumulated output_ids (only true with the default stream_output=False).
+_SERVER_ARGS = [
+    "--skip-server-warmup",
+    "--dtype",
+    "bfloat16",
+    "--mem-fraction-static",
+    "0.8",
+    "--max-running-requests",
+    "16",
+    "--page-size",
+    "64",
+    "--random-seed",
+    "42",
+    "--enable-unified-radix-tree",
+]
+
+
+class TestUnifiedRadixCacheServing(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            base_url=cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=_SERVER_ARGS,
+            # Keep check_cache_miss=True: a compile-cache miss on the hit path is
+            # a regression signal. Drop to False if it trips on the first TPU run.
+        )
+
+        # Fail fast for the whole class if the flag didn't take effect.
+        # /get_server_info spreads dataclasses.asdict(server_args) at top level.
+        # A raise here aborts setUpClass and skips tearDownClass, so kill the
+        # server before re-raising to avoid leaking it on the TPU.
+        try:
+            resp = requests.get(f"{cls.base_url}/get_server_info", timeout=30)
+            resp.raise_for_status()
+            info = resp.json()
+            assert info["enable_unified_radix_tree"] is True, (
+                f"server did not enable unified radix tree: "
+                f"enable_unified_radix_tree={info.get('enable_unified_radix_tree')!r}"
+            )
+            assert (
+                info["page_size"] == _PAGE_SIZE
+            ), f"server page_size={info.get('page_size')!r}, expected {_PAGE_SIZE}"
+        except Exception:
+            kill_process_tree(cls.process.pid)
+            raise
+
+    @classmethod
+    def tearDownClass(cls):
+        proc = getattr(cls, "process", None)
+        if proc is not None:
+            kill_process_tree(proc.pid)
+            try:
+                proc.wait(timeout=30)
+            except Exception:
+                pass
+
+    def _generate(self, prompt):
+        resp = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": prompt,
+                "sampling_params": {"temperature": 0, "max_new_tokens": 80},
+            },
+            timeout=120,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def test_multiturn_cache_hit(self):
+        flush_cache(self.base_url)  # shared server: start from an empty tree
+        result = run_multiturn_cache_hit_test(
+            base_url=self.base_url,
+            model_path=self.model,
+            num_clients=4,
+            num_rounds=3,
+            request_length=256,
+            output_length=96,
+            miss_tolerance=1,
+            max_parallel=4,
+        )
+        # The kit asserts the exact per-request bound internally; assert the
+        # aggregate here so the coverage is visible in this file.
+        rounds = result["rounds"]
+        self.assertEqual(rounds["round_0"]["total_cached_tokens"], 0)  # cold start
+        # Round 1 re-sends each client's grown prefix -> >= one page cached each.
+        self.assertGreaterEqual(
+            rounds["round_1"]["total_cached_tokens"],
+            rounds["round_1"]["request_count"] * _PAGE_SIZE,
+        )
+        self.assertGreater(result["overall"]["cache_hit_rate"], 0.0)
+
+    def test_hit_flush_determinism(self):
+        # paragraph * 6 tokenizes to well over one page.
+        paragraph = (
+            "In the field of artificial intelligence, large language models have "
+            "shown remarkable capabilities in natural language processing. These "
+            "models can perform text generation, translation, summarization, and "
+            "question answering. "
+        )
+        prompt = paragraph * 6
+
+        # 1. Cold: empty tree -> nothing cached.
+        flush_cache(self.base_url)
+        cold = self._generate(prompt)
+        self.assertGreaterEqual(
+            cold["meta_info"]["prompt_tokens"],
+            2 * _PAGE_SIZE,
+            "fixture prompt must exceed one page to exercise page-aligned caching",
+        )
+        self.assertEqual(cold["meta_info"]["cached_tokens"], 0)
+
+        # 2. Hit: re-send -> prefix cached, output unchanged.
+        hit = self._generate(prompt)
+        prompt_tokens = hit["meta_info"]["prompt_tokens"]
+        self.assertLessEqual(_PAGE_SIZE, hit["meta_info"]["cached_tokens"])
+        self.assertLessEqual(hit["meta_info"]["cached_tokens"], prompt_tokens)
+        # Greedy determinism. The hit path has a different prefill shape than cold;
+        # if this flakes on TPU bit-exactness, keep only the step-3 comparison.
+        self.assertEqual(hit["text"], cold["text"])
+
+        # 3. Post-flush: tree emptied -> nothing cached; shape-identical to cold.
+        flush_cache(self.base_url)
+        post_flush = self._generate(prompt)
+        self.assertEqual(post_flush["meta_info"]["cached_tokens"], 0)
+        self.assertEqual(post_flush["text"], cold["text"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #1335, #1336, #1337
Refs #1311

This PR delivers **HiCache Stage 1**: a component-agnostic prefix cache (`UnifiedRadixCache` + `FullComponent`, ported from upstream `sglang`) behind a default-off `--enable-unified-radix-tree` flag, plus serving-level verification. Flag-off keeps the existing `RadixCache` path unchanged. Later stages hang SWA / recurrent / HiCache host-tier components off the same core without re-architecting.

One commit per sub-issue: S1a (typed params), S1b (core + flag), S1c (serving tests).

## What Changed

### S1a — typed cache interface (#1335)

| Area | Change |
|------|--------|
| `mem_cache/base_prefix_cache.py` | Evict/match/lock signatures converge on typed params (`EvictParams`, `MatchPrefixParams`, `InsertParams`, `IncLockRefResult`, `DecLockRefParams`, `EvictResult`); `MatchResult` gains `best_match_node`. Not behind the new flag — `RadixCache`/`SWARadixCache`/`ChunkCache` and all callers adapt. |
| `managers/{schedule_batch,schedule_policy}.py` | The 3 strict 4-tuple `MatchResult` unpacks switch to field-name access. |

### S1b — UnifiedRadixCache core + flag (#1336)

| Area | Change |
|------|--------|
| `mem_cache/unified_radix_cache.py` (new) | `UnifiedTreeNode` + `UnifiedRadixCache`: trie / ref-counting / eviction ported from upstream; component hooks at match/insert/evict/lock seams; `dp_rank`-aware size accounting (sgl-jax divergence). |
| `mem_cache/unified_cache_components/` (new) | `ComponentType`/`ComponentData`/`TreeComponent` ABC + `FullComponent` (full-attention). HiCache host-tier hooks are no-op stubs. |
| `server_args.py`, `mem_cache/registry.py` | `--enable-unified-radix-tree` (default off, env `SGLANG_JAX_ENABLE_UNIFIED_RADIX_TREE`); routes **non-hybrid models only** — hybrid SWA stays on `SWARadixCache`. |
| Unit tests (`unit-test-cpu`) | Core ops, `best_match_node`, equivalence-vs-`RadixCache` (page 1/128), dp_rank isolation, request-path equivalence via mock reqs, flag routing incl. hybrid/disabled branches. |

### S1c — serving tests (#1337)

| Area | Change |
|------|--------|
| `bench_serving.py`, `test/test_utils.py` | Aggregate per-request `cached_tokens` → `total_cached_tokens` + `cache_hit_rate` in metrics/result dict; `get_benchmark_args` gains `gsp_*`/`flush_cache` fields. Additive. |
| `test/kits/cache_hit_kit.py` (new) | Port of upstream cache-hit kit: round-barriered multiturn, per-request `cached_tokens` asserted against the analytic page-aligned expectation; retrying `flush_cache()` helper. |
| `test/srt/test_unified_radix_cache_serving.py` (new) | Per-PR flag-on serving test (Qwen3-1.7B): `/get_server_info` flag assert, multiturn cache-hit, cold → hit → flush → cold greedy determinism. Registered in `e2e-test-tpu-v6e-1`. |
| `benchmark/hicache/bench_unified_radix_ab.py` (new) | Standalone A/B benchmark (no-cache / radix / unified × random / shared-prefix): pooled TTFT p50/p95/p99, throughput mean±std, hit rate, sweep-completeness check, `--strict`. Manual tool, not in CI. |
| `test/srt/test_eval_accuracy_large_unified_radix.py` (new) | MMLU sanity with the flag on (threshold 0.698). Committed, not CI-registered (see deviations). |

## Live Validation

Committed tests run per-PR in CI (unit tests: CPU; serving test: Qwen3-1.7B, tp=1, v6e-1). The Qwen3-8B and Qwen3-30B-A3B sections below are a manual pass on a v6e-4 host; exact commands are in the reproduction [comment below](https://github.com/sgl-project/sglang-jax/pull/1347#issuecomment-4678396330).

**Small scale — Qwen3-1.7B / CPU (the CI targets).**
- CPU unit tests (`python/sgl_jax/test/mem_cache/test_unified_radix_cache.py`, `test_unified_radix_tree_flag.py`, `python/sgl_jax/test/test_kv_cache_builder.py`): core ops, equivalence vs `RadixCache` (page 1/128), `dp_rank` isolation, flag routing. Flag-off compatibility additionally has an engine smoke: flag-off vs flag-on byte-identical greedy outputs and identical `cached_tokens` on shared-prefix prompts.
- Serving test (`test/srt/test_unified_radix_cache_serving.py`): `/get_server_info` flag assert, multiturn cache-hit, hit/flush greedy determinism. Runs per-PR on the v6e-1 runner; the two sections below re-run this same file at larger scale.

**Qwen3-8B (dense, tp=4).**
- Serving test (re-run at Qwen3-8B / tp=4) passes; multiturn hit rate per round 0.0000 → 0.5263 → 0.7333, overall 0.5614.
- A/B sweep (`benchmark/hicache/bench_unified_radix_ab.py`), one session — three server configs: `no-cache` (`--disable-radix-cache`), `radix` (default `RadixCache`), `unified` (`--enable-unified-radix-tree`); random + generated-shared-prefix (gsp) workloads, 3 reps (drop first), page 128, all soft targets pass:

| workload | config | p50 TTFT (ms) | p99 TTFT (ms) | total tok/s | hit rate |
|----------|--------|--------------|--------------|-------------|----------|
| random | no-cache | 574.1 | 1071.7 | 33301 ± 362 | 0.0000 |
| random | radix | 574.2 | 1055.7 | 33380 ± 239 | 0.0000 |
| random | unified | 570.5 | 1046.9 | 33428 ± 292 | 0.0000 |
| gsp | no-cache | 1304.0 | 2468.5 | 42305 ± 7 | 0.0000 |
| gsp | radix | 495.7 | 1006.4 | 78604 ± 1181 | 0.7632 |
| gsp | unified | 497.4 | 1092.6 | 77628 ± 220 | 0.7632 |

- RadixCache unchanged vs `origin/main`: the same `radix`/random bench on a clean main tree gives 33266 ± 387 tok/s vs 33380 ± 239 above (+0.34%, within noise) — the S1a interface refactor does not change the existing radix path.
- MMLU with the flag on (`test/srt/test_eval_accuracy_large_unified_radix.py`): **0.755 > threshold 0.698**.

**Qwen3-30B-A3B (MoE, epmoe).**
- Serving test (re-run with the MoE model, `--moe-backend epmoe` + parallelism flags) passes at **tp=4/ep=4** and **tp=4/dp=2/ep=2** (attention_tp=2, exercises the `dp_rank`-aware accounting); per-round hit rate matches dense (overall 0.5438).
- A/B `radix` vs `unified` (same script: tp=4/ep=4, page 256): random throughput +0.2%; gsp hit rate **identical at 0.7641**, throughput within 1%.

## Deviations from issue text (deliberate)

- #1337 "flip `--disable-radix-cache` off in `test_bench_serving_*.py`" is **deferred**: radix-on perf coverage comes from the standalone A/B script; existing perf baselines and calibrated thresholds stay untouched. Flag-on perf CI coverage is follow-up, pending suite-placement discussion.
- #1337 "hit rate ≥ baseline" is replaced by a **stronger no-baseline assertion** (analytic page-aligned `cached_tokens` per request), so the per-PR test needs one server instead of an A/B pair.
- The MMLU test file is committed but **not registered** in `run_suite.py` (accuracy suite vs nightly placement to be decided); run manually per its docstring.

## Known Limitations

- Stage 1 populates only the FULL component; SWA / recurrent / HiCache host tier are later stages (hooks stubbed).
- The cache-hit kit assumes full accumulated `output_ids` per stream chunk (default `stream_output=False`).
- At `tp > 1` the A/B script requires `--precompile-bs-paddings` divisible by the tp size (asserted): a decode batch not divisible by the device count trips a pre-existing sampler `lax.cond` sharding mismatch, independent of this PR. The same sampler cond also rejects `--enable-deterministic-sampling` at any tp (seeded vs unseeded branch shardings differ), so the serving test relies on greedy + `--random-seed` instead of that flag.

## Next Work

- Decide CI placement for the MMLU test and flag-on perf coverage, then register them.
- Fix the sampler `lax.cond` sharding mismatch in a separate PR #1349
- Stage 5: SWA / recurrent components on this core (#1311 roadmap).
