### PR TITLE
test(ci): require pre-cached test models and enable HF Hub offline mode

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -15,6 +15,13 @@ concurrency:
   group: pr-test-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Force HuggingFace Hub into offline mode for the whole workflow: test models
+# must come from the pre-populated cache (SGLANG_JAX_MODEL_CACHE); an uncached
+# model fails fast instead of triggering an on-the-fly download that can exhaust
+# the runner's local disk.
+env:
+  HF_HUB_OFFLINE: "1"
+
 jobs:
   # =============================================== coordinator ====================================================
   coordinator:

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -26,6 +26,11 @@ permissions:
   contents: read
   pull-requests: write
 
+# Force HuggingFace Hub offline so uncached test models fail fast instead of
+# triggering an on-the-fly download (see pr-test.yml for rationale).
+env:
+  HF_HUB_OFFLINE: "1"
+
 jobs:
   rerun:
     runs-on: ${{ inputs.runner }}

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -125,6 +125,13 @@ def _local_or_hf(repo: str) -> str:
     local = Path(cache) / repo
     if _validate_local_snapshot(local):
         return str(local)
+    if is_in_ci():
+        raise RuntimeError(
+            f"[test_utils] model {repo!r} is not cached under {cache} "
+            f"(expected a valid snapshot at {local}). Pre-download it into the "
+            f"model cache before running this test in CI; falling back to an HF "
+            f"download can exhaust the runner's local disk."
+        )
     if repo not in _LOCAL_MODEL_LOG_ONCE:
         _LOCAL_MODEL_LOG_ONCE.add(repo)
         print(
@@ -135,32 +142,46 @@ def _local_or_hf(repo: str) -> str:
     return repo
 
 
-DEFAULT_MODEL_NAME_FOR_TEST = _local_or_hf("Qwen/Qwen3-8B")
-DEFAULT_SMALL_MODEL_NAME_FOR_TEST = _local_or_hf("Qwen/Qwen3-1.7B")
-QWEN3_8B = _local_or_hf("Qwen/Qwen3-8B")
-QWEN_7B = _local_or_hf("Qwen/Qwen-7B")
-QWEN3_4B = _local_or_hf("Qwen/Qwen3-4B")
+# Public model-name constants map to their HuggingFace repo ids and are resolved
+# lazily via the module-level __getattr__ below (PEP 562). Resolving lazily means
+# a model that is missing from the cache only fails the test that actually
+# requests it, instead of breaking import of this module for every test suite.
+_MODEL_REPOS: dict[str, str] = {
+    "DEFAULT_MODEL_NAME_FOR_TEST": "Qwen/Qwen3-8B",
+    "DEFAULT_SMALL_MODEL_NAME_FOR_TEST": "Qwen/Qwen3-1.7B",
+    "QWEN3_8B": "Qwen/Qwen3-8B",
+    "QWEN_7B": "Qwen/Qwen-7B",
+    "QWEN3_4B": "Qwen/Qwen3-4B",
+    "QWEN3_MOE_30B": "Qwen/Qwen3-30B-A3B",
+    "QWEN2_5_7B_INSTRUCT": "Qwen/Qwen2.5-7B-Instruct",
+    "QWEN3_CODER_30B_A3B_INSTRUCT": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+    "GEMMA2_2B_IT": "google/gemma-2-2b-it",
+    "BAILING_MOE": "inclusionAI/Ling-mini-2.0",
+    "DEEPSEEK_R1_DISTILL_QWEN_1_5B": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+    "DEEPSEEK_V2_LITE": "deepseek-ai/DeepSeek-V2-Lite",
+    "DEEPSEEK_CODER_V2_LITE_INSTRUCT": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
+    "QWEN3_32B": "Qwen/Qwen3-32B",
+    "QWEN3_32B_EAGLE3": "AngelSlim/Qwen3-32B_eagle3",
+    "WAN2_1_T2V_1_3B": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+    "WAN2_1_T2V_14B": "Wan-AI/Wan2.1-T2V-14B-Diffusers",
+    "MIMO_AUDIO_7B_INSTRUCT": "XiaomiMiMo/MiMo-Audio-7B-Instruct",
+    "UMT5_BASE": "google/umt5-base",
+    "QWEN3_OMNI_30B_A3B_INSTRUCT": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+}
+_RESOLVED_MODEL_PATHS: dict[str, str] = {}
 
-QWEN3_MOE_30B = _local_or_hf("Qwen/Qwen3-30B-A3B")
+# Hardcoded local-only path (no HF fallback); kept as an eager constant.
 QWEN3_5_35B_A3B = "/models/Qwen3.5-35B-A3B/"
-QWEN2_5_7B_INSTRUCT = _local_or_hf("Qwen/Qwen2.5-7B-Instruct")
-QWEN3_CODER_30B_A3B_INSTRUCT = _local_or_hf("Qwen/Qwen3-Coder-30B-A3B-Instruct")
-GEMMA2_2B_IT = _local_or_hf("google/gemma-2-2b-it")
 
-BAILING_MOE = _local_or_hf("inclusionAI/Ling-mini-2.0")
-DEEPSEEK_R1_DISTILL_QWEN_1_5B = _local_or_hf("deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B")
-DEEPSEEK_V2_LITE = _local_or_hf("deepseek-ai/DeepSeek-V2-Lite")
-DEEPSEEK_CODER_V2_LITE_INSTRUCT = _local_or_hf("deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct")
 
-QWEN3_32B = _local_or_hf("Qwen/Qwen3-32B")
-QWEN3_32B_EAGLE3 = _local_or_hf("AngelSlim/Qwen3-32B_eagle3")
+def __getattr__(name: str) -> str:
+    repo = _MODEL_REPOS.get(name)
+    if repo is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    if name not in _RESOLVED_MODEL_PATHS:
+        _RESOLVED_MODEL_PATHS[name] = _local_or_hf(repo)
+    return _RESOLVED_MODEL_PATHS[name]
 
-WAN2_1_T2V_1_3B = _local_or_hf("Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
-WAN2_1_T2V_14B = _local_or_hf("Wan-AI/Wan2.1-T2V-14B-Diffusers")
-
-MIMO_AUDIO_7B_INSTRUCT = _local_or_hf("XiaomiMiMo/MiMo-Audio-7B-Instruct")
-UMT5_BASE = _local_or_hf("google/umt5-base")
-QWEN3_OMNI_30B_A3B_INSTRUCT = _local_or_hf("Qwen/Qwen3-Omni-30B-A3B-Instruct")
 
 DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH = 600
 

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -118,14 +118,14 @@ def _validate_local_snapshot(d: Path) -> bool:
     return has_single_weight_file
 
 
-def _local_or_hf(repo: str) -> str:
+def _local_or_hf(repo: str, required: bool = True) -> str:
     cache = os.environ.get(_MODEL_CACHE_ENV)
     if not cache:
         return repo
     local = Path(cache) / repo
     if _validate_local_snapshot(local):
         return str(local)
-    if is_in_ci():
+    if required and is_in_ci():
         raise RuntimeError(
             f"[test_utils] model {repo!r} is not cached under {cache} "
             f"(expected a valid snapshot at {local}). Pre-download it into the "
@@ -170,6 +170,14 @@ _MODEL_REPOS: dict[str, str] = {
 }
 _RESOLVED_MODEL_PATHS: dict[str, str] = {}
 
+# Constants that are allowed to fall back to an HF download even in CI, instead
+# of hard-failing on a cache miss. EAGLE3 draft models ship without a tokenizer
+# (they reuse the target model's tokenizer), so they can never satisfy
+# _validate_local_snapshot; the speculative-decoding test also pins them to a
+# specific small revision fetched on the fly. Keep the pre-existing fallback for
+# these rather than forcing them into the cache.
+_CI_HF_FALLBACK_ALLOWED: set[str] = {"QWEN3_32B_EAGLE3"}
+
 # Hardcoded local-only path (no HF fallback); kept as an eager constant.
 QWEN3_5_35B_A3B = "/models/Qwen3.5-35B-A3B/"
 
@@ -179,7 +187,9 @@ def __getattr__(name: str) -> str:
     if repo is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     if name not in _RESOLVED_MODEL_PATHS:
-        _RESOLVED_MODEL_PATHS[name] = _local_or_hf(repo)
+        _RESOLVED_MODEL_PATHS[name] = _local_or_hf(
+            repo, required=name not in _CI_HF_FALLBACK_ALLOWED
+        )
     return _RESOLVED_MODEL_PATHS[name]
 
 

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -174,15 +174,23 @@ _MODEL_REPOS: dict[str, str] = {
     "MIMO_AUDIO_7B_INSTRUCT": "XiaomiMiMo/MiMo-Audio-7B-Instruct",
     "UMT5_BASE": "google/umt5-base",
     "QWEN3_OMNI_30B_A3B_INSTRUCT": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+    # LoRA adapters (no tokenizer/standard snapshot; see _SKIP_VALIDATION).
+    "QWEN3_4B_LORA_V2": "nissenj/Qwen3-4B-lora-v2",
+    "QWEN3_4B_LORA_MODEL": "y9760210/Qwen3-4B-lora_model",
 }
 _RESOLVED_MODEL_PATHS: dict[str, str] = {}
 
 # Constants whose cached snapshot is trusted as-is (no _validate_local_snapshot).
-# EAGLE3 draft models ship without a tokenizer, so they can never pass the normal
-# validation; cache them and skip the check instead. The cached directory must
-# contain the *.safetensors weights (the speculative-decoding test pins the draft
-# model to the revision that provides them).
-_SKIP_VALIDATION: set[str] = {"QWEN3_32B_EAGLE3"}
+# EAGLE3 draft models and LoRA adapters ship without a tokenizer, so they can
+# never pass the normal validation; cache them and skip the check instead. The
+# cached directory must contain the weights the loader expects (EAGLE3 draft:
+# *.safetensors at the pinned revision; LoRA: adapter_config.json + adapter
+# weights).
+_SKIP_VALIDATION: set[str] = {
+    "QWEN3_32B_EAGLE3",
+    "QWEN3_4B_LORA_V2",
+    "QWEN3_4B_LORA_MODEL",
+}
 
 # Hardcoded local-only path (no HF fallback); kept as an eager constant.
 QWEN3_5_35B_A3B = "/models/Qwen3.5-35B-A3B/"

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -118,12 +118,19 @@ def _validate_local_snapshot(d: Path) -> bool:
     return has_single_weight_file
 
 
-def _local_or_hf(repo: str, required: bool = True) -> str:
+def _local_or_hf(repo: str, required: bool = True, validate: bool = True) -> str:
     cache = os.environ.get(_MODEL_CACHE_ENV)
     if not cache:
         return repo
     local = Path(cache) / repo
-    if _validate_local_snapshot(local):
+    # validate=False trusts any non-empty cached directory without checking for a
+    # tokenizer or a complete weight set. It is used for EAGLE3 draft models, which
+    # ship without a tokenizer (they reuse the target model's) and therefore can
+    # never satisfy _validate_local_snapshot.
+    cached = (
+        _validate_local_snapshot(local) if validate else (local.is_dir() and any(local.iterdir()))
+    )
+    if cached:
         return str(local)
     if required and is_in_ci():
         raise RuntimeError(
@@ -170,13 +177,12 @@ _MODEL_REPOS: dict[str, str] = {
 }
 _RESOLVED_MODEL_PATHS: dict[str, str] = {}
 
-# Constants that are allowed to fall back to an HF download even in CI, instead
-# of hard-failing on a cache miss. EAGLE3 draft models ship without a tokenizer
-# (they reuse the target model's tokenizer), so they can never satisfy
-# _validate_local_snapshot; the speculative-decoding test also pins them to a
-# specific small revision fetched on the fly. Keep the pre-existing fallback for
-# these rather than forcing them into the cache.
-_CI_HF_FALLBACK_ALLOWED: set[str] = {"QWEN3_32B_EAGLE3"}
+# Constants whose cached snapshot is trusted as-is (no _validate_local_snapshot).
+# EAGLE3 draft models ship without a tokenizer, so they can never pass the normal
+# validation; cache them and skip the check instead. The cached directory must
+# contain the *.safetensors weights (the speculative-decoding test pins the draft
+# model to the revision that provides them).
+_SKIP_VALIDATION: set[str] = {"QWEN3_32B_EAGLE3"}
 
 # Hardcoded local-only path (no HF fallback); kept as an eager constant.
 QWEN3_5_35B_A3B = "/models/Qwen3.5-35B-A3B/"
@@ -187,9 +193,7 @@ def __getattr__(name: str) -> str:
     if repo is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     if name not in _RESOLVED_MODEL_PATHS:
-        _RESOLVED_MODEL_PATHS[name] = _local_or_hf(
-            repo, required=name not in _CI_HF_FALLBACK_ALLOWED
-        )
+        _RESOLVED_MODEL_PATHS[name] = _local_or_hf(repo, validate=name not in _SKIP_VALIDATION)
     return _RESOLVED_MODEL_PATHS[name]
 
 

--- a/test/srt/lora/test_align_lora_accuracy.py
+++ b/test/srt/lora/test_align_lora_accuracy.py
@@ -6,13 +6,13 @@ import unittest
 import numpy as np
 
 from sgl_jax.srt.entrypoints.engine import Engine
-from sgl_jax.test.test_utils import QWEN3_4B, CustomTestCase
+from sgl_jax.test.test_utils import QWEN3_4B, QWEN3_4B_LORA_MODEL, CustomTestCase
 
 LORA_SETS = [
     {
         "base": QWEN3_4B,
         "lora": [
-            "y9760210/Qwen3-4B-lora_model",
+            QWEN3_4B_LORA_MODEL,
         ],
     },
 ]

--- a/test/srt/lora/test_dynamic_lora.py
+++ b/test/srt/lora/test_dynamic_lora.py
@@ -30,6 +30,8 @@ from sgl_jax.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     QWEN3_4B,
+    QWEN3_4B_LORA_MODEL,
+    QWEN3_4B_LORA_V2,
     CustomTestCase,
     kill_process_tree,
     popen_launch_server,
@@ -39,8 +41,8 @@ LORA_SETS = [
     {
         "base": QWEN3_4B,
         "loras": [
-            "nissenj/Qwen3-4B-lora-v2",
-            "y9760210/Qwen3-4B-lora_model",
+            QWEN3_4B_LORA_V2,
+            QWEN3_4B_LORA_MODEL,
         ],
     },
 ]


### PR DESCRIPTION
## Motivation

CI run https://github.com/sgl-project/sglang-jax/actions/runs/27276793399 showed newly added tests referencing models that were never pre-downloaded into the CI model cache (`SGLANG_JAX_MODEL_CACHE`, e.g. `/models/model_scope`). The old behavior silently fell back to an on-the-fly HuggingFace download, which can exhaust the runner's local disk.

## What this PR does (4 commits)

1. **Fail fast on cache miss + lazy resolution.** `_local_or_hf` raises a clear `RuntimeError` in CI when a model is not cached, instead of falling back to an HF download. Model-name constants are resolved lazily via a module-level `__getattr__` (PEP 562), so a missing model only fails the test that actually requests it rather than breaking import of `test_utils` for every suite. Outside CI the HF-download fallback is unchanged.

2. **Cache the EAGLE3 draft model, skip its validation.** EAGLE3 draft models (`AngelSlim/Qwen3-32B_eagle3`) ship without a tokenizer, so they can never satisfy `_validate_local_snapshot`. Added a `validate` flag to `_local_or_hf`; the draft constant trusts a non-empty cached directory. The model loader resolves a local directory directly and globs `*.safetensors`, so the cache must hold the revision that provides them.

3. **Enable `HF_HUB_OFFLINE=1`** at the workflow level in `pr-test.yml` and `rerun-test.yml` as an infrastructure-level backstop: any uncached model fails fast instead of downloading, closing the gap where a bare HF id (not routed through `_local_or_hf`) would still download.

4. **Cache the two LoRA adapters** used by the LoRA accuracy tests and route them through `_local_or_hf` (instead of bare HF ids), so they resolve to the cached local dir under offline. The server derives the LoRA name from the path basename, identical for the repo id and the cached path, so request-side names are unchanged.

## Models pre-downloaded into the shared cache

`google/umt5-base`, `XiaomiMiMo/MiMo-Audio-7B-Instruct`, `Qwen/Qwen3-Omni-30B-A3B-Instruct`, `AngelSlim/Qwen3-32B_eagle3` (revision with `.safetensors`), `nissenj/Qwen3-4B-lora-v2`, `y9760210/Qwen3-4B-lora_model`.

## Offline audit

Audited every CI suite for runtime HF fetches before flipping offline:
- Models under test resolve to cached local paths (via `_local_or_hf`).
- Eval data (mmlu/gsm8k/mgsm/math/gpqa) comes from plain URLs (Azure blob / GitHub raw), not HF Hub — unaffected by offline.
- `test_qwen3_5` and `test_model_loader` already skip when the model is unreachable.
- HF-`load_dataset` evals (csimpleqa/aime26) are not invoked by any PR suite (nightly only).
- The two LoRA tests were the only offline breakages found; fixed by (4).

This PR's own CI run exercises offline mode and validates the audit.

## Verification

- `pre-commit run` passes (ruff, isort, black, mypy, codespell, check-yaml).
- Local logic checks: cache hit / miss-in-CI raise / non-CI fallback / `validate=False` for EAGLE3 + LoRA / LoRA basename stability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)