### PR TITLE
fix(ci): correct pallas_kernel path filter (sgl_jax/kernels → sgl_jax/srt/kernels)

### DIFF
--- a/.github/workflows/coordinator.yml
+++ b/.github/workflows/coordinator.yml
@@ -52,7 +52,7 @@ jobs:
               - ".github/workflows/coordinator.yml"
               - ".github/actions/**"
             pallas_kernel:
-              - "python/sgl_jax/kernels/**"
+              - "python/sgl_jax/srt/kernels/**"
               - "benchmark/kernels/**"
               - ".github/workflows/pr-test.yml"
               - ".github/workflows/coordinator.yml"


### PR DESCRIPTION
## Problem

The `pallas_kernel` paths-filter in `coordinator.yml` matches `python/sgl_jax/kernels/**`, but kernel source actually lives under `python/sgl_jax/srt/kernels/**` (`fused_moe` / `gdn` / `gmm` / `kda` / `mla`). The written path does not exist on `main`, so it is a dead entry.

## Effect

`run_pallas_bench` is decided solely by this filter (`coordinator_decide.py`: `run_pallas_bench = pallas_kernel == "true"`). Because the filter never matches kernel source, editing kernel source sets `pallas_kernel=false`, so `pallas-kernel-benchmark` never runs for kernel-source changes — kernel perf regressions are not caught at PR time. The benchmark only fires on edits under `benchmark/kernels/**` (or the CI files themselves), never on the actual kernel source.

## Fix

Point the filter at the real source path `python/sgl_jax/srt/kernels/**`.

## Verify

- A PR touching a file under `python/sgl_jax/srt/kernels/` should now produce coordinator output `run_pallas_bench=true` and trigger `pallas-kernel-benchmark`.
- Edits under `benchmark/kernels/**` keep triggering it as before.