### PR TITLE
docs(cookbook): drop per-recipe Troubleshooting sections

### DIFF
--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-R1.md
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-R1.md
@@ -279,21 +279,6 @@ Max ITL (ms):                            2518.61
 
 > R1's throughput on this workload reflects MoE + MLA + FP8 block-quant on the validated `dp=8` mesh; future PRs can add reasoning-typical workloads (OSL=4096+) for trace-heavy scenarios.
 
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| Response contains raw `<think>` text instead of `reasoning_content` | `--reasoning-parser` not set | Add `--reasoning-parser deepseek-r1` to the launch command. |
-| Truncated thinking trace at low `max_tokens` | R1 thinking budgets are 2k-3k tokens before the final answer; client requests with `max_tokens=512` get cut off mid-trace | Set client `max_tokens >= 4096`. For accuracy benchmarks (AIME / MATH / GPQA), use `max_tokens >= 8192`. |
-| `ValueError: dimension 0 must be divisible by tensor=64` during `_shard_weight` on `model.layers.0.mlp.gate_proj.weight_scale_inv (144, 56)` | Tensor axis too large for the dense MLP block-quant scale grid. 144 = `intermediate_size(18432) / block_size(128)`. | Add `--dp-size 8` (or another `dp` that makes `tp_size/dp_size` a divisor of 144). |
-| Server up but **all outputs are a single repeating token** (e.g., "爲了爲了爲了…") | Per-rank `out_dim` of the shared expert `gate_proj`/`up_proj` equals `block_size_out=128`, hitting the block-wise quant kernel's accuracy-collapse regime. At `dp=4` on v6e-64, `2048/16 = 128`. | Use `--dp-size 8` (gives `2048/8 = 256 > 128`). The `epmoe` path will assert explicitly; the `fused` path is silent — see §2.4 MoE Backend. |
-| `RuntimeError: Block-wise kernel does not support out_dim=128 with block_size_out=128 (known to cause accuracy collapse)` | Same as above, surfaced by the `epmoe` assertion. | Same fix: `--dp-size 8`. Do **not** set `allow_narrow_n_blockwise=True` — it suppresses the guard, not the bug. |
-| `RESOURCE_EXHAUSTED: Ran out of memory in memory space hbm. Used 31.68G of 31.25G hbm. Exceeded hbm capacity by ~440M.` during EXTEND precompile | At `dp=8`, the per-rank trace peak with `--chunked-prefill-size 2048` overshoots HBM. | Drop `--chunked-prefill-size` to 1024. Lowering `--max-running-requests` alone does not help — the peak is in prefill, not decode. |
-| `ValueError: Expected local_num_tokens=1 to be aligned to t_packing=2` | Using `--moe-backend fused` at low effective per-rank token count during decode precompile. | Switch to `--moe-backend epmoe` (current recommended default), or raise `--max-running-requests` until `(max / dp_size) / (ep_size / dp_size) >= t_packing`. |
-| Multi-node hang at init | `--dist-init-addr` unreachable from non-rank-0 nodes | Verify the rank-0 internal IP and that the chosen port (default 5000 in the cookbook manifest) is open between nodes. |
-| First request takes ~4 min per node | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR` on a shared PVC across all 16 nodes and across pod restarts (mesh-shape-keyed; safe across `backoffLimit` retries). |
-| GKE control-plane blip evicts all 16 pods mid-run (`kube-root-ca.crt not registered` / `gcsfuse.csi.storage.gke.io not found`) | Transient kube-system flap tainted nodes with NoExecute; default `backoffLimit: 0` collapsed the Job. | Set `backoffLimit: 16` (or higher) in the GKE Indexed Job manifest. Pods get replacements and the server comes back; JIT cache hit keeps recovery time short. |
-
 ## Additional Resources
 
 - [DeepSeek-R1 model card](https://huggingface.co/deepseek-ai/DeepSeek-R1)

--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V2.md
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V2.md
@@ -159,14 +159,6 @@ Mean TPOT (ms):                          7.41
 ==================================================
 ```
 
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| MoE throughput plateau | Wrong `--moe-backend` for EP size | V2-Lite uses `epmoe` at EP=4. |
-| OOM at startup (V2-Lite) | `--mem-fraction-static` too high | Lower from default 0.88 to 0.85. Verify `--tp-size 4` matches v6e-4 chip count. |
-| First request takes ~4 min | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR` across restarts. |
-
 ## Additional Resources
 
 - [DeepSeek-V2-Lite model card](https://huggingface.co/deepseek-ai/DeepSeek-V2-Lite)

--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.md
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.md
@@ -13,7 +13,7 @@ title: "DeepSeek V3"
 **Architectural notes**:
 
 - **MLA** — uses the FlashAttention Pallas MLA kernel by default; no extra flag needed.
-- **MoE with shared + routed experts** — see §2.4 for the backend choice (`epmoe` is the currently validated one at V3 scale on v6e-64; `fused` has known regression at this scale, see §5).
+- **MoE with shared + routed experts** — see §2.4 for the backend choice (`epmoe` is the currently validated one at V3 scale on v6e-64; `fused` has known regression at this scale).
 - **FP8 block-quant compatibility** — the per-rank `out_dim` of the shared expert `gate_proj` / `up_proj` must be **strictly greater than** `block_size_out=128`. This constraint forces the v6e-64 mesh shape and is why `--dp-size 8` (effective tensor axis 8) is recommended over `--dp-size 4` (tensor axis 16, which collides with the block size — see §2.4).
 - **DSA** (DeepSeek Sparse Attention) on V3.2 — activated by model config; no extra launch flag.
 
@@ -217,19 +217,6 @@ P99 ITL (ms):                            1256.43
 Max ITL (ms):                            2517.66
 ==================================================
 ```
-
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| `ValueError: dimension 0 must be divisible by tensor=64` during `_shard_weight` on `model.layers.0.mlp.gate_proj.weight_scale_inv (144, 56)` | Tensor axis too large for the dense MLP block-quant scale grid. 144 = `intermediate_size(18432) / block_size(128)`. | Add `--dp-size 8` (or another `dp` that makes `tp_size/dp_size` a divisor of 144). |
-| Server up but **all outputs are a single repeating token** (e.g., "爲了爲了爲了…") | Per-rank `out_dim` of the shared expert `gate_proj`/`up_proj` equals `block_size_out=128`, hitting the block-wise quant kernel's accuracy-collapse regime. At `dp=4` on v6e-64, `2048/16 = 128`. | Use `--dp-size 8` (gives `2048/8 = 256 > 128`). The `epmoe` path will assert explicitly; the `fused` path is silent — see §2.4 MoE Backend. |
-| `RuntimeError: Block-wise kernel does not support out_dim=128 with block_size_out=128 (known to cause accuracy collapse)` | Same as above, surfaced by the `epmoe` assertion. | Same fix: `--dp-size 8`. Do **not** set `allow_narrow_n_blockwise=True` — it suppresses the guard, not the bug. |
-| `RESOURCE_EXHAUSTED: Ran out of memory in memory space hbm. Used 31.68G of 31.25G hbm. Exceeded hbm capacity by ~440M.` during EXTEND precompile | At `dp=8`, the per-rank trace peak with `--chunked-prefill-size 2048` overshoots HBM. | Drop `--chunked-prefill-size` to 1024. Lowering `--max-running-requests` alone does not help — the peak is in prefill, not decode. |
-| `ValueError: Expected local_num_tokens=1 to be aligned to t_packing=2` | Using `--moe-backend fused` at low effective per-rank token count during decode precompile. | Switch to `--moe-backend epmoe` (current recommended default), or raise `--max-running-requests` until `(max / dp_size) / (ep_size / dp_size) >= t_packing`. |
-| Multi-node hang at init | `--dist-init-addr` unreachable from non-rank-0 nodes | Verify the rank-0 internal IP and that the chosen port (default 5000 in the cookbook manifest) is open between nodes. |
-| First request takes ~4 min per node | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR` on a shared PVC across all 16 nodes and across pod restarts (mesh-shape-keyed; safe across `backoffLimit` retries). |
-| GKE control-plane blip evicts all 16 pods mid-run (`kube-root-ca.crt not registered` / `gcsfuse.csi.storage.gke.io not found`) | Transient kube-system flap tainted nodes with NoExecute; default `backoffLimit: 0` collapsed the Job. | Set `backoffLimit: 16` (or higher) in the GKE Indexed Job manifest. Pods get replacements and the server comes back; JIT cache hit keeps recovery time short. |
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/GLM/GLM-4.5.md
+++ b/docs/cookbook/autoregressive/GLM/GLM-4.5.md
@@ -4,7 +4,7 @@ title: "GLM-4.5"
 
 # GLM-4.5 MoE on SGL-JAX
 
-> **Validated recipe** — GLM-4.5-Air (106B) validated on TPU v6e-32 with sglang-jax 0.1.0; sanity + GSM8K + bench all pass. If using a pre-0.1.0 build see §5 Troubleshooting.
+> **Validated recipe** — GLM-4.5-Air (106B) validated on TPU v6e-32 with sglang-jax 0.1.0; sanity + GSM8K + bench all pass. Pin to sglang-jax 0.1.0+ — earlier builds have a stale `q_proj` weight-transpose mapping that fails at first prefill.
 
 ## 1. Model Introduction
 
@@ -284,18 +284,6 @@ Mean TTFT (ms):           576.77
 Mean TPOT (ms):           13.35
 ==================================================
 ```
-
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| Startup assert `tile_n` divisibility failure (GLM-4.5-Air) | `--moe-backend fused` with `moe_intermediate_size=1408 % 512 ≠ 0` | Use `--moe-backend epmoe` for GLM-4.5-Air (mandatory). |
-| `dot_general` contracting shape mismatch in `q_proj` during first prefill | Pre-0.1.0 build with stale weight transpose mappings | Upgrade to sglang-jax 0.1.0; the transpose fix is merged. |
-| Tool calls return empty arguments | `--tool-call-parser` not set | Add `--tool-call-parser glm45` to the launch command. |
-| No `reasoning_content` in response | `--reasoning-parser` not set | Add `--reasoning-parser glm45` to launch. |
-| OOM at startup (GLM-4.5-Air) | `--mem-fraction-static 0.9` too high for this slice | Lower to 0.88. Verify `--tp-size 32` matches v6e-32 chip count (4 × 8 = 32). |
-| Multi-node hang at init | `--dist-init-addr` unreachable from non-rank-0 nodes | Verify the rank-0 internal IP and that the chosen port is open. |
-| First request takes ~4 min per node | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR`; mount a shared PVC across nodes for amortized compilation. |
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/Google/Gemma2.md
+++ b/docs/cookbook/autoregressive/Google/Gemma2.md
@@ -187,15 +187,6 @@ Mean ITL (ms):                           14.48
 ==================================================
 ```
 
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| Gemma 2 27B OOM at startup | `--mem-fraction-static 0.88` (default) too high for dual KV pools | Lower to 0.85 or 0.8. Verify `--tp-size 4` matches v6e-4 chip count. |
-| Output throughput stuck near single-stream (~150 tok/s); TTFT > 5 s under concurrent load | `--page-size` defaulted to 1 → scheduler logs `Final max_running_requests: 1` and serializes requests | Add `--page-size 128 --max-running-requests 64` (see §2.4 Paging / concurrency). |
-| Sliding-window pool exhaustion at high concurrency | `--swa-full-tokens-ratio` mismatches workload sequence-length distribution | Lower the ratio to give the sliding pool more capacity. See [troubleshooting §SWA pool exhaustion](../../troubleshooting.md#swa-pool-exhaustion-mimo-hybrid-attention-models). |
-| First request takes ~4 min | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR` across restarts. |
-
 ## Additional Resources
 
 - [Gemma 2 27B-it model card](https://huggingface.co/google/gemma-2-27b-it)

--- a/docs/cookbook/autoregressive/Grok/Grok2.md
+++ b/docs/cookbook/autoregressive/Grok/Grok2.md
@@ -4,7 +4,7 @@ title: "Grok-2"
 
 # Grok-2 on SGL-JAX
 
-> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, sanity output correct, `bench_serving` numbers in §4.1. **Accuracy intentionally omitted** — Grok-2 is a base model (no chat template; see §1) and the cookbook follows design §6.F: base model recipes skip §4.1 Accuracy (chat-format datasets via `/v1/chat/completions` mis-extract on base models — see §5 troubleshooting for the underlying chat-template + evalscope-extractor interaction). **Cookbook used `--moe-backend epmoe`** because the fused MoE backend fails to init on this small-EP large-mesh layout (8 experts on 64 chips) (see §5). **Grok-2 architecture**: `config.json` declares `num_local_experts=8 num_experts_per_tok=2` under `Grok1ForCausalLM` — i.e. **MoE with 8 experts, 2 active per token** (not dense). Launch flags below assume MoE (`--ep-size 8 --moe-backend epmoe`).
+> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, sanity output correct, `bench_serving` numbers in §4.1. **Accuracy intentionally omitted** — Grok-2 is a base model (no chat template; see §1) and the cookbook follows design §6.F: base model recipes skip §4.1 Accuracy (chat-format datasets via `/v1/chat/completions` mis-extract on base models — see §3.1 for the underlying chat-template + evalscope-extractor interaction). **Cookbook used `--moe-backend epmoe`** because the fused MoE backend fails to init on this small-EP large-mesh layout (8 experts on 64 chips) (see §2.4). **Grok-2 architecture**: `config.json` declares `num_local_experts=8 num_experts_per_tok=2` under `Grok1ForCausalLM` — i.e. **MoE with 8 experts, 2 active per token** (not dense). Launch flags below assume MoE (`--ep-size 8 --moe-backend epmoe`).
 
 ## 1. Model Introduction
 
@@ -137,7 +137,7 @@ resp = client.completions.create(
 print(resp.choices[0].text)
 ```
 
-> **Why not `/v1/chat/completions`?** Grok-2 has no chat template — sending `messages` either fails (no template registered) or wraps the prompt in a community-grafted template the model wasn't trained on. The community-template path looks superficially OK on single-turn sanity prompts but silently degrades accuracy on chat-format eval datasets: the model doesn't emit EOS at the end of a short answer and continues in-context with self-generated follow-ups (see §5 troubleshooting; per design §6.F base models skip §4 Accuracy entirely).
+> **Why not `/v1/chat/completions`?** Grok-2 has no chat template — sending `messages` either fails (no template registered) or wraps the prompt in a community-grafted template the model wasn't trained on. The community-template path looks superficially OK on single-turn sanity prompts but silently degrades accuracy on chat-format eval datasets: the model doesn't emit EOS at the end of a short answer and continues in-context with self-generated follow-ups (per design §6.F base models skip §4 Accuracy entirely).
 
 > Grok-2 has no hybrid reasoning or native tool-calling format. For those workloads, see the **Parser key reference** in [Parser key reference](../index.md#parser-key-reference) for the list of cookbook recipes with reasoning / tool-call parsers registered.
 
@@ -145,7 +145,7 @@ print(resp.choices[0].text)
 
 > Benchmark data below is a snapshot pinned to the `Tested build` listed in each Test Environment; not refreshed on every release.
 >
-> Accuracy section is omitted by design — see banner + §5 for why base models skip it (per design §6.F).
+> Accuracy section is omitted by design — see the banner + §1 for why base models skip it (per design §6.F).
 
 ### 4.1 Speed — single workload (low-concurrency latency baseline)
 
@@ -216,22 +216,7 @@ Max ITL (ms):                            1270.39
 ==================================================
 ```
 
-> Grok-2 throughput on this v6e-64 mesh is bottlenecked by small-EP MoE underutilization: with only 8 experts on 64 chips, the `--moe-backend epmoe` fallback (forced because `fused` crashes on this mesh, see §5) leaves most chips idle per token. This is a known limitation of the current fused MoE backend assumes large-EP; Grok-2's 8-expert layout sits below that assumption.
-
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| `--moe-backend fused` crashes at init with a sharding-spec `ValueError` on the (data, tensor) mesh | fused MoE backend assumes the expert axis aligns with the combined (data × tensor) mesh; this small-EP / large-mesh layout (8 experts on 64 chips) doesn't satisfy that | Use `--moe-backend epmoe` (current cookbook default) — slower than fused for large-EP models but is the only working choice on this slice. |
-| `/v1/chat/completions` returns empty / nonsense, or evalscope chat-format datasets (GSM8K few-shot / MT-Bench) score 10-30% despite sanity prompts working | Grok-2 is a base model — `tokenizer_config.json` has no `chat_template`. Sending `messages` either fails outright or wraps the prompt in a community-grafted template the model wasn't trained on; without that training the model fails to emit EOS at the "right" place and continues in-context with self-generated Q→A chains. evalscope's "last number in output" extractor then grabs a number from the model's self-generated follow-up question instead of the actual answer, marking correct cases as failed. | Use `/v1/completions` with raw prompts (see [§3.1](#31-basic-text-completion-base-model)) and **completion-style datasets** (MMLU / HellaSwag / BBH / ARC). For GSM8K specifically, use `python -m sglang.test.few_shot_gsm8k --num-questions 200` which constructs a raw 5-shot prompt and stops on `\nQuestion:`. **Never** run `evalscope ... --api-url http://.../v1/chat/completions` against a base model — full rule in [`cookbook-recipe-design.md` §6.F](../../cookbook-recipe-design.md). |
-| Server outputs garbage / silent accuracy collapse | `--ep-size` missing or wrong; Grok-2 is MoE (8 experts, 2 active), not dense. Without `--ep-size 8 --moe-backend epmoe` (or `fused` once the upstream fused crash is fixed) the loader will route experts incorrectly. | Always set `--ep-size 8 --moe-backend epmoe`. The cookbook §2.3 template is correct; reject any "dense Grok-2" recipe variant. |
-| Weight loader fails to align pre-sharded TP files | `--tp-size` not a multiple of 8. The checkpoint is pre-sharded `pytorch_model-NNNNN-TP-{000..007}.safetensors` so the loader expects to slice along 8 TP partitions. | Use `--tp-size` ∈ {8, 16, 24, 32, 40, ..., 64}. On v6e-64 use 64; on v6e-32 use 32; on v6e-16 (if attempted) needs dp to avoid breaking the constraint. |
-| Tokenizer load fails at startup | `--tokenizer-path` missing or unreachable | Add `--tokenizer-path alvarobartt/grok-2-tokenizer`; if HF rate-limited, set `HF_TOKEN` env. |
-| Multi-node hang at `jax.distributed.initialize` | `--dist-init-addr` unreachable from non-rank-0 nodes | Verify the rank-0 internal IP / pod DNS (`<JOB>-0.<JOB>-headless-svc:5000` on GKE) and that the chosen port is open between nodes. |
-| OOM at startup | `--mem-fraction-static` too high relative to available HBM | Drop to `0.85`. Verify `--tp-size` matches the chip count expected by the slice. |
-| MoE throughput plateau / very slow decode (~190 ms TPOT) | Inherent to small-EP MoE on large mesh. With 8 experts on 64 chips, only 16 chips fully utilized per token; epmoe path doesn't have a fused kernel. | This is a known limitation pending upstream fix for small-EP shapes. Until then, expect ~140 tok/s total throughput on v6e-64. |
-| Slow cold start (~5-10 min per node) on every launch | JIT cache empty (`JAX_COMPILATION_CACHE_DIR` not persisted across launches) | Mount a shared PVC at the cache directory across all nodes. Mesh shape is part of the cache key; changing `--tp-size`/`--ep-size` invalidates it. |
-| GKE control-plane blip evicts pods mid-run | Default `backoffLimit: 0` collapses the Job on transient node taint | Set `backoffLimit: 16` in the GKE Indexed Job manifest. Replacements pick up the warm JIT cache. |
+> Grok-2 throughput on this v6e-64 mesh is bottlenecked by small-EP MoE underutilization: with only 8 experts on 64 chips, the `--moe-backend epmoe` fallback (forced because `fused` crashes on this mesh, see §2.4) leaves most chips idle per token. This is a known limitation of the current fused MoE backend assumes large-EP; Grok-2's 8-expert layout sits below that assumption.
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/Llama/Llama3.1.md
+++ b/docs/cookbook/autoregressive/Llama/Llama3.1.md
@@ -174,14 +174,6 @@ Mean ITL (ms):                           9.87
 ==================================================
 ```
 
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| OOM at startup | Weights + KV exceed budget at chosen `--mem-fraction-static` | Lower to 0.85. Verify `--tp-size 4` matches v6e-4 chip count. |
-| First request takes ~4 min | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR` across restarts (host volume mount in Docker). |
-| Bench shows ~150 tok/s output and ~50s TTFT at concurrency=16 | `--page-size` defaulted to 1 → `Final max_running_requests: 1` (visible in launch log), requests serialize | Add `--page-size 128 --max-running-requests 64` to the launch command. See §2.4. |
-
 ## Additional Resources
 
 - [Llama 3.1 8B-Instruct model card](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct)

--- a/docs/cookbook/autoregressive/Llama/Llama3.3-70B.md
+++ b/docs/cookbook/autoregressive/Llama/Llama3.3-70B.md
@@ -72,6 +72,7 @@ For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](../.
 **Tensor Parallelism:**
 - `--tp-size 16` on v6e-16 fully shards Llama 3.3 70B's GQA `num_kv_heads=8` (tensor axis must be a divisor of 8 — 16 maps cleanly: 2 chips per KV head). All ranks must be in the same TPU slice; verify `--nnodes` matches the slice node count.
 - Multi-host coordination: every rank runs the same launch command; only `${NODE_RANK}` and `${MASTER_ADDR}` vary. Dispatch all ranks within seconds of each other (a >5-min stagger trips the JAX distributed RPC deadline).
+- Stale libtpu lock: if a prior multi-host launch on the same pod failed, run `rm -f /tmp/libtpu_lockfile` on every rank before relaunching — a leftover lock surfaces as `Internal error when accessing libtpu multi-process lockfile` on rank 0. Worth scripting into the launch wrapper.
 
 **Compilation Cache Hygiene:**
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min per node.
@@ -187,15 +188,6 @@ Median TPOT (ms):                        16.47
 Mean ITL (ms):                           16.30
 ==================================================
 ```
-
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| OOM at startup | Weights + KV exceed budget at chosen `--mem-fraction-static` | Lower to 0.85 (or 0.8). Verify `--tp-size` matches the chip count (v6e-16 → 16, v6e-32 → 32). |
-| `Internal error when accessing libtpu multi-process lockfile` on rank 0 | Stale `/tmp/libtpu_lockfile` from a prior failed launch on the same pod | `rm -f /tmp/libtpu_lockfile` on every rank before relaunching. Worth scripting into the launch wrapper since multi-host failures often leave stale locks. |
-| Multi-node hang at init | `--dist-init-addr` unreachable from non-rank-0 nodes | Verify the rank-0 internal IP and that the chosen port is open. |
-| First request takes ~4 min per node | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR`; mount a shared PVC across all 8 nodes for amortized compilation. |
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-Linear.md
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-Linear.md
@@ -101,6 +101,9 @@ For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](../.
 - `--page-size 128` reduces KV page-table overhead.
 - `--chunked-prefill-size 2048` bounds peak HBM during long-prompt prefill — Kimi-Linear's linear-attention benefit is most visible on long prompts.
 
+**Multi-host launch:**
+- Dispatch all ranks within seconds of each other — a >5-min stagger between ranks trips the JAX distributed service's RPC deadline (`RegisterTask DEADLINE_EXCEEDED`) on the early-arriving ranks. Fan the launch out (parallel `kubectl exec`) rather than starting ranks one by one.
+
 **Compilation Cache Hygiene:**
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min per node.
 - Mount a shared PVC across the cluster's 4 nodes to amortize compilation.
@@ -217,17 +220,6 @@ Within the ±2.3 pp sampling-noise band at limit=200; v6e-32 doubling TP does no
 | TPU v6e-32 | sglang-jax 0.1.0 | 140.55 | 1457.14 | 728.57 | 19.72 | 526.89 |
 
 v6e-32 delivers ~5% throughput / 13% TTFT improvement over v6e-16. Scaling is sublinear because Kimi-Linear's sparse 3B-activated MoE caps the per-token chip utilization — the larger slice's main win is HBM headroom for long-context recurrent state, not raw token throughput.
-
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| `AssertionError: Hybrid recurrent state models require --disable-radix-cache` at startup | Prefix / radix caching for hybrid recurrent models is planned but not yet shipped. | Pass `--disable-radix-cache` (mandatory for Kimi-Linear until the caching path lands) — see §2.4. |
-| `RegisterTask DEADLINE_EXCEEDED` (5 min) on multi-host launch | Ranks dispatched too far apart — the JAX distributed service has a 5-min RPC deadline | Dispatch all ranks within seconds of each other (parallel `kubectl exec`); a >5-min stagger between ranks fails registration on the early-arriving ranks. |
-| OOM at startup | Recurrent state + KV exceed budget | Lower `--recurrent-state-memory-ratio` (e.g. to 0.7) and/or `--mem-fraction-static` to 0.88. |
-| Long-prompt requests stall | KV cache exhausted before recurrent state | Lower `--recurrent-state-memory-ratio` to give the KV cache more headroom. |
-| Multi-node hang at init | `--dist-init-addr` unreachable from non-rank-0 nodes | Verify the rank-0 internal IP and that the chosen port is open. |
-| First request takes ~4 min per node | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR`; mount a shared PVC across nodes for amortized compilation. |
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/Qwen/Qwen.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen.md
@@ -203,14 +203,6 @@ Max ITL (ms):                            154.39
 ==================================================
 ```
 
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| OOM at startup | Weights + KV cache exceed budget | Lower `--max-prefill-tokens` to 4096, or `--mem-fraction-static` to 0.75. Verify `--tp-size 4` matches v6e-4 chip count. |
-| First request takes ~4 min | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR` across restarts (host volume mount in Docker). |
-| Low throughput at high concurrency | `--page-size 1` overhead dominates | Raise `--page-size` to 16 or 32 for long-sequence high-concurrency workloads. |
-
 ## Additional Resources
 
 - [Qwen Model Cards](https://huggingface.co/Qwen)

--- a/docs/cookbook/autoregressive/Qwen/Qwen2.5-VL.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen2.5-VL.md
@@ -93,6 +93,9 @@ For Qwen2.5-VL-3B or Qwen2.5-VL-7B, use the same command shape but set `--model-
 **Multimodal Attention Backend:**
 - The vision-language attention path runs on the default `--attention-backend fa` (FlashAttention on Pallas) — no override needed.
 
+**Remote media URLs:**
+- `image_url` / `video_url` inputs must be fetchable **from the TPU host** — a URL that loads in your browser can still fail server-side on auth / region / firewall. Stage the media on a mounted volume and pass `file:///path/to/media`, or use a publicly reachable URL.
+
 **Compilation Cache Hygiene:**
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min per stage while XLA/Pallas re-compiles every kernel (ViT and AR each compile independently).
 - The cache keys on full kernel shape: changing `--page-size`, `--tp-size`, image resolution buckets, or `--context-length` invalidates cached entries.
@@ -232,17 +235,6 @@ print(response.choices[0].message.content)
 > Benchmark section is intentionally omitted — Qwen2.5-VL is a Starter recipe (banner). All §4.1 Accuracy / §4.2 Speed cells are pending real PR-back measurements. When you run a numbered MMMU / MMMU Pro Vision / DocVQA / ChartQA eval against the model on TPU, file a PR adding the §4 block back with the actual numbers and upgrade the banner to Partially validated or Validated. For the canonical four-part §4 form (Test Environment / Deployment Command / Benchmark Command / Test Results) see any Validated recipe in [Autoregressive index](../index.md).
 >
 > Note: `bench_serving` does not have native multimodal input support today, so §4.2 Speed needs a custom OpenAI-client load test driving the §3.2 multi-image / video patterns; PR back full TTFT / ITL / output tok/s along with the image resolution and prompt template used.
-
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| Server rejects `image_url` / `video_url` content blocks | `--multimodal` not set | Add `--multimodal` to the launch command; the text-only server cannot parse vision content blocks. |
-| 72B multi-host launch fails or hangs | Current SGL-JAX staging and multimodal AR multi-host broadcast are not ready for a followable 72B recipe | Do not use 72B as a followable target until a 72B multi-host path and scheduler fix land. |
-| OOM at startup (32B) | Default `--mem-fraction-static` too high once ViT / AR weights load | Lower to 0.8, reduce `--max-running-requests`, and keep the recipe's `--tp-size 4`. |
-| OOM at request-time on multi-image input | Vision embeddings push KV demand past budget at chosen `--max-running-requests` | Lower `--max-running-requests` to 16 or 8; raise `--context-length` if available to spread KV per request. |
-| First request takes 6+ min (vs 4 min text-only) | Both ViT and AR stages JIT-compile separately on first request | Persist `JAX_COMPILATION_CACHE_DIR` across restarts — both stages share the same cache dir. |
-| Video URL works in browser but server rejects it | URL not directly fetchable from the TPU host (auth / region / firewall) | Stage the video on a mounted volume and pass `file:///path/to/video.mp4` instead, or use a publicly reachable URL. |
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/Qwen/Qwen3-MoE.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3-MoE.md
@@ -370,17 +370,6 @@ Mean ITL (ms):                           9.83
 ==================================================
 ```
 
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| `ValueError: Expected intermediate_size=768 to be aligned to bf=512` at startup (30B-A3B) | `--moe-backend fused` requires `moe_intermediate_size % 512 == 0`; Qwen3-30B-A3B has 768 | Switch to `--moe-backend epmoe`. See §2.4 MoE Backend. |
-| OOM at startup | `--mem-fraction-static` too high | Lower by 0.02. Verify `--tp-size 16` matches v6e-16 chip count (4 × 4 = 16). |
-| Tool calls return empty arguments | `--tool-call-parser` not set | Add `--tool-call-parser qwen25`. |
-| No `reasoning_content` in response | `--reasoning-parser` not set | Add `--reasoning-parser qwen3`. |
-| Multi-node hang at init | `--dist-init-addr` unreachable | Verify the rank-0 internal IP and that the chosen port is open. |
-| First request takes ~4 min per node | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR`; mount a shared PVC across nodes for amortized compilation. |
-
 ## Additional Resources
 
 - [Qwen3-30B-A3B model card](https://huggingface.co/Qwen/Qwen3-30B-A3B)

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.md
@@ -446,15 +446,6 @@ Mean E2E Latency (ms):                   8948.78
 
 Lower than the 1977 tok/s c=64 table cell because c=16 leaves the batch under-filled — included only to confirm the recipe still launches and decodes cleanly on the current build. The Sept-2025 sweep above remains the canonical SGL-JAX-vs-vLLM comparison.
 
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| OOM at startup with Qwen3-32B | `--mem-fraction-static 0.8` still too high for 32B + large `--max-running-requests` | Lower `--max-running-requests` to 128, or `--mem-fraction-static` to 0.75. Verify `--tp-size 4` matches v6e-4 chip count. |
-| First request takes ~4 min | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR` across restarts (host volume mount in Docker). |
-| Throughput plateaus below benchmark numbers | RadixAttention prefix caching helping (or not) | If reproducing the §4.2 vLLM comparison, ensure `--disable-radix-cache` is set. For production, leave it off — it's a free win on repeated prefixes. |
-| Tool calls return empty arguments | `--tool-call-parser` not set | Add `--tool-call-parser qwen25` to the launch command. |
-
 ## Additional Resources
 
 - [Qwen Model Cards](https://huggingface.co/Qwen)

--- a/docs/cookbook/autoregressive/Xiaomi/MiMo-7B.md
+++ b/docs/cookbook/autoregressive/Xiaomi/MiMo-7B.md
@@ -381,14 +381,6 @@ Max ITL (ms):                            38.99
 ==================================================
 ```
 
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| Tool calls return empty arguments | `--tool-call-parser` not set | Add `--tool-call-parser mimo` to the launch command. |
-| No `reasoning_content` in response | `--reasoning-parser` not set, or `enable_thinking` not passed | Add `--reasoning-parser mimo` to launch; pass `extra_body={"chat_template_kwargs":{"enable_thinking":true}}` per request. |
-| First request takes ~4 min | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR` across restarts. |
-
 ## Additional Resources
 
 - [MiMo-7B-RL model card](https://huggingface.co/XiaomiMiMo/MiMo-7B-RL)

--- a/docs/cookbook/autoregressive/Xiaomi/MiMo-V2-Flash.md
+++ b/docs/cookbook/autoregressive/Xiaomi/MiMo-V2-Flash.md
@@ -467,17 +467,6 @@ The fused MoE tuned-config table covers the EP=8 shapes (server logs report `Usi
 
 **Other workload cells**: _Pending_ — additional v6e-16 (ISL, OSL, concurrency) combinations not yet measured. PR the full `============ Serving Benchmark Result ============` block from `bench_serving` when measured.
 
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| OOM at startup | Weights don't fit | Lower `--mem-fraction-static` to 0.90; verify `--tp-size` matches device count (8 for v7x-8, 16 for v6e-16). |
-| SWA pool exhaustion at runtime | Too much concurrent decode demand on SWA layers | Lower `--max-running-requests`, or raise `--swa-full-tokens-ratio`. Observe `swa token usage` in server logs. |
-| Full-attention pool exhaustion | Long full-attention KV demand exceeds budget | Lower `--swa-full-tokens-ratio` (shifts pool toward full layers), or shorten `--context-length`. |
-| First request takes ~4 min | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR` across restarts (host volume mount in Docker; PVC in GKE). |
-| Multi-node hang at `jax.distributed.initialize` | `--dist-init-addr` unreachable | Verify rank-0 IP and port reachable from all nodes; check firewall on the JAX init port. |
-| `fused` MoE backend slower than `epmoe` on single-host v7x-8 | Expected — see §4.2 measurements | Use `--moe-backend epmoe` for EP ≤ 8; `fused` is the right pick at EP ≥ 16. |
-
 ## Additional Resources
 
 - [MiMo-V2-Flash Model Card](https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash)

--- a/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md
+++ b/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md
@@ -466,18 +466,6 @@ Max ITL (ms):                            1290.76
 ==================================================
 ```
 
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| OOM at startup on v6e-64 | `--mem-fraction-static 0.95` too aggressive for v6e's smaller per-chip HBM | Use `0.92` on v6e-64 (already the value in §2.3); also lower `--swa-full-tokens-ratio` to 0.15 to shift KV pool to full-attention layers. |
-| SWA pool exhaustion (`swa token usage` near 100%) | Long generation traffic outgrows SWA per-layer budget | Raise `--swa-full-tokens-ratio` to 0.30+ or lower `--max-running-requests`. |
-| Full-attention pool exhaustion (`full token usage` near 100%) | Long-context full-attention KV outgrows budget | Lower `--swa-full-tokens-ratio` (shifts pool toward full layers) or shorten `--context-length`. |
-| First request takes ~4 min on each new launch | JIT cache empty | Persist `JAX_COMPILATION_CACHE_DIR` across restarts (host volume mount in Docker; PVC in GKE). Don't share a cache dir across recipes with different `--page-size` / `--tp-size` / etc. |
-| Speculative decoding refuses to start | Overlap scheduler conflict | Add `--disable-overlap-schedule` — required whenever `--speculative-algorithm` is set. |
-| Multi-node hang at `jax.distributed.initialize` | `${MASTER_ADDR}` unreachable from non-rank-0 nodes | Verify rank-0 IP + port `5000` reachable from all nodes; check firewall and headless Service DNS resolution (GKE) or `sky status -a` (SkyPilot). |
-| `Mismatched TPU process count` at first step | `TPU_PROCESS_ADDRESSES` length ≠ `--nnodes` | `echo $TPU_PROCESS_ADDRESSES | tr ',' '\n' | wc -l` should equal `${NNODES}`. The v6e-64 manifest expects 16 entries — make sure the GKE Indexed Job manifest matches the slice. |
-
 ## Additional Resources
 
 - [MiMo-V2.5-Pro Model Card](https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro)

--- a/docs/cookbook/base/tpu-topology-reference.md
+++ b/docs/cookbook/base/tpu-topology-reference.md
@@ -139,7 +139,7 @@ Before you hit "go", verify against `python/sgl_jax/srt/configs/model_config.py`
 | 5 | Hybrid recurrent models (Ling-2.6, Kimi-Linear) require `--disable-radix-cache` | Server asserts on startup | Recipe §2.4 |
 | 6 | MLA models (DeepSeek family) require `--page-size >= 2` | MLA backend asserts on startup | Recipe §2.4 |
 
-The recipe's §5 Troubleshooting table will have a symptom row for each — start there if launch fails.
+The recipe's §2.4 Configuration Tips covers these constraints; see the [central Troubleshooting page](../troubleshooting.md) if launch still fails.
 
 ### Step 4 — If launch hits OOM
 

--- a/docs/cookbook/diffusion/Wan/Wan2.1.md
+++ b/docs/cookbook/diffusion/Wan/Wan2.1.md
@@ -17,7 +17,7 @@ title: "Wan 2.1 T2V"
 
 **Recommended Generation Parameters** (request body, not launch flags):
 
-- `size` - `720*1280` (default), `480*832` (lower-cost), or another precompiled bucket. **Format is `WIDTH*HEIGHT` (asterisk-separated), the same syntax as `--precompile-width-heights`.** Sending `WIDTHxHEIGHT` (lowercase `x`) raises `ValueError: invalid literal for int() with base 10: ...` and crashes the GlobalScheduler — see [§5 Troubleshooting](#5-troubleshooting). Must match a precompiled bucket; see [§2.4 Configuration Tips](#24-configuration-tips).
+- `size` - `720*1280` (default), `480*832` (lower-cost), or another precompiled bucket. **Format is `WIDTH*HEIGHT` (asterisk-separated), the same syntax as `--precompile-width-heights`.** Sending `WIDTHxHEIGHT` (lowercase `x`) raises `ValueError: invalid literal for int() with base 10: ...` and crashes the GlobalScheduler. Must match a precompiled bucket; see [§2.4 Configuration Tips](#24-configuration-tips).
 - `num_frames` - defaults to the model-card recommended count, commonly 41 for Wan 2.1.
 - `num_inference_steps` - defaults to the model-card recommended count.
 - `seconds` / `fps` - alternative way to specify frame count; the server resolves to `num_frames`.
@@ -212,19 +212,6 @@ Video diffusion latency is dominated by `num_inference_steps x DiT step time x n
 | sglang-jax 0.1.0 | Wan2.1-T2V-14B-Diffusers | TPU v6e-4 (TP=2) | `480*832` | 41 | default (50) | 1 | ~4 min 19 s |
 
 This is a single-shot smoke datapoint, not a throughput sweep. Throughput sweeps require the custom driver above.
-
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| `/api/v1/videos/generation` returns 404 | `--multimodal` not set at launch | Add `--multimodal` to the launch command. |
-| `ValueError: invalid literal for int() with base 10: '480x832'` and `GlobalScheduler hit an exception` (server crashes) | Request body used `WIDTHxHEIGHT` (lowercase `x`); server parses `size` as `WIDTH*HEIGHT` (asterisk-separated) | Send `"size": "480*832"` (asterisk-separated). Also restart the server — the GlobalScheduler exits on this exception. |
-| Response body is `{"success": true, "meta_info": {}}` with no `path`/`url` | Expected behavior — the videos / images endpoints persist the file to the server's `cwd` and only acknowledge success in the response | Locate the MP4 by the `Saved output to <uuid>.mp4` line in the server log, or run the server with a known `cwd` and mount that directory. |
-| First request blocks on every new resolution | Resolution not in `--precompile-width-heights` | Add the size you serve (`WIDTH*HEIGHT`) to `--precompile-width-heights` and relaunch. |
-| First request blocks on every new frame count | Frame count not in `--precompile-frame-paddings` | Add the frame count to `--precompile-frame-paddings` and relaunch. |
-| OOM during VAE decode at high resolution | Full VAE decode too large for HBM despite tiling | Lower the request `size` or split the request; VAE tiling is already on by default. |
-| Video response `path` not accessible to client | Server-written file lives on TPU host only | Mount a shared output volume and serve via a separate file server, or stream the file back from the TPU host. |
-| Slow throughput at moderate concurrency | DiT is the bottleneck | Lower request `num_inference_steps` to trade quality for throughput. |
 
 ## Additional Resources
 

--- a/docs/cookbook/diffusion/Wan/Wan2.2.md
+++ b/docs/cookbook/diffusion/Wan/Wan2.2.md
@@ -22,7 +22,7 @@ title: "Wan 2.2 T2V"
 
 **Recommended Generation Parameters** (request body, not launch flags):
 
-- `size` - `720*1280` (default), `480*832` (lower-cost), or another precompiled bucket. **Format is `WIDTH*HEIGHT` (asterisk-separated), the same syntax as `--precompile-width-heights`.** Sending `WIDTHxHEIGHT` (lowercase `x`) raises `ValueError: invalid literal for int() with base 10: ...` and crashes the GlobalScheduler — see [§5 Troubleshooting](#5-troubleshooting). Must match a precompiled bucket; see [§2.4 Configuration Tips](#24-configuration-tips).
+- `size` - `720*1280` (default), `480*832` (lower-cost), or another precompiled bucket. **Format is `WIDTH*HEIGHT` (asterisk-separated), the same syntax as `--precompile-width-heights`.** Sending `WIDTHxHEIGHT` (lowercase `x`) raises `ValueError: invalid literal for int() with base 10: ...` and crashes the GlobalScheduler. Must match a precompiled bucket; see [§2.4 Configuration Tips](#24-configuration-tips).
 - `num_frames` - choose a value you also pass through `--precompile-frame-paddings`.
 - `num_inference_steps` - defaults to the model-card recommended count.
 - `seconds` / `fps` - alternative way to specify frame count; the server resolves to `num_frames`.
@@ -217,20 +217,6 @@ Video diffusion latency is dominated by `num_inference_steps x DiT step time x n
 | sglang-jax 0.1.0 | Wan2.2-T2V-A14B-Diffusers | TPU v6e-4 (TP=1, CPU text encoder) | `480*832` | 41 | default (50) | 1 | ~2 min 43 s |
 
 This is a single-shot smoke datapoint, not a throughput sweep. Throughput sweeps require the custom driver above.
-
-## 5. Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| `/api/v1/videos/generation` returns 404 | `--multimodal` not set at launch | Add `--multimodal` to the launch command. |
-| `ValueError: invalid literal for int() with base 10: '480x832'` and `GlobalScheduler hit an exception` (server crashes) | Request body used `WIDTHxHEIGHT` (lowercase `x`); server parses `size` as `WIDTH*HEIGHT` (asterisk-separated) | Send `"size": "480*832"` (asterisk-separated). Also restart the server — the GlobalScheduler exits on this exception. |
-| Response body is `{"success": true, "meta_info": {}}` with no `path`/`url` | Expected behavior — the videos / images endpoints persist the file to the server's `cwd` and only acknowledge success in the response | Locate the MP4 by the `Saved output to <uuid>.mp4` line in the server log, or run the server with a known `cwd` and mount that directory. |
-| First request blocks on every new resolution | Resolution not in `--precompile-width-heights` | Add the size you serve (`WIDTH*HEIGHT`) to `--precompile-width-heights` and relaunch. |
-| First request blocks on every new frame count | Frame count not in `--precompile-frame-paddings` | Add the frame count to `--precompile-frame-paddings` and relaunch. |
-| OOM during VAE decode at high resolution | Full VAE decode too large for HBM despite tiling | Lower the request `size` or split the request; VAE tiling is already on by default. |
-| Wan 2.2 A14B OOM at startup on v6e-4 | Dual transformer doubles the DiT footprint | Lower `--mem-fraction-static` first. Moving to v6e-8 only helps after SGL-JAX provides a matching larger-stage placement. |
-| Video response `path` not accessible to client | Server-written file lives on TPU host only | Mount a shared output volume and serve via a separate file server, or stream the file back from the TPU host. |
-| Slow throughput at moderate concurrency | DiT is the bottleneck | Lower request `num_inference_steps` to trade quality for throughput. |
 
 ## Additional Resources
 

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -20,13 +20,14 @@ End-to-end recipes for serving specific models on specific TPU (or GPU) topologi
 
 ## Conventions
 
-Every recipe follows the **same five-section template** so you can scan any page the same way:
+Every recipe follows the **same four-section template** so you can scan any page the same way:
 
 1. **Model Introduction** — variants, parameter sizes, HuggingFace links, license, recommended sampling params.
 2. **Deployment** — 2.1 Hardware Matrix · 2.2 Environment · 2.3 Launch (single-host + multi-host) · 2.4 Configuration Tips.
 3. **Invocation** — basic `curl` / OpenAI-compatible request examples; reasoning / tool-call patterns where applicable.
 4. **Benchmark** — accuracy (`evalscope`) and throughput (`bench_serving`) commands with reference numbers.
-5. **Troubleshooting** — model-specific symptom → cause → fix table. Generic issues go to [`troubleshooting.md`](troubleshooting.md).
+
+Model-specific constraints are documented inline in each recipe's §2.4 Configuration Tips; cross-cutting startup / multi-node / runtime failures live in [`troubleshooting.md`](troubleshooting.md).
 
 Recipes carry one of five status banners at the top:
 
@@ -79,7 +80,7 @@ Vision-language and diffusion rows are constrained by SGL-JAX's built-in staged 
    - Validated multi-host reference: [`autoregressive/Moonshotai/Kimi-Linear.md`](autoregressive/Moonshotai/Kimi-Linear.md) shows the complete multi-host benchmark / accuracy structure.
    - Partially validated large-MoE pattern: [`autoregressive/Xiaomi/MiMo-V2.5-Pro.md`](autoregressive/Xiaomi/MiMo-V2.5-Pro.md) is the broadest GKE / multi-host reference, with some benchmark cells still pending.
    - Starter pattern: [`autoregressive/Llama/Llama3.1.md`](autoregressive/Llama/Llama3.1.md) is the smallest skeleton.
-2. Copy its five-section structure.
+2. Copy its four-section structure.
 3. Place the new file under `autoregressive/<Vendor>/` (PascalCase, matching upstream [sgl-cookbook](https://github.com/sgl-project/sgl-cookbook/tree/main/docs/autoregressive) naming). Create a new vendor subdir if needed.
 4. Mark the top banner **Starter** until you have measured numbers; then upgrade to **Partially validated** or **Validated** based on the status legend.
 5. Fill in real `evalscope` and `bench_serving` outputs — do not leave `_Pending_` cells in a Validated recipe's claimed primary path.

--- a/docs/cookbook/troubleshooting.md
+++ b/docs/cookbook/troubleshooting.md
@@ -4,7 +4,7 @@ title: "Troubleshooting"
 
 # Troubleshooting
 
-Common failure modes across all SGL-JAX cookbook recipes, with the fix and what to grep in logs to confirm. Model-specific gotchas live in each recipe's §7; this page covers everything else.
+Common failure modes across all SGL-JAX cookbook recipes, with the fix and what to grep in logs to confirm. Model-specific constraints live in each recipe's §2 Deployment / Configuration Tips; this page covers everything else.
 
 ## Startup
 


### PR DESCRIPTION
## What

Removes the boilerplate **`## 5. Troubleshooting`** section from all 18 autoregressive + diffusion cookbook recipes.

## Why

Auditing the sections showed they were almost entirely either:
1. **Generic failure modes** (cold compile, multi-host hang, OOM→lower `--mem-fraction-static`, `--page-size`→`max_running_requests`, `backoffLimit`) — already covered by the central [`docs/cookbook/troubleshooting.md`](https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/troubleshooting.md); or
2. **Symptom→fix restatements** of constraints already documented in each recipe's **§2.4 Configuration Tips** (`--dp-size 8`, `--moe-backend` choice, `--disable-radix-cache`, `--disable-overlap-schedule`, etc.).

A per-recipe troubleshooting table that duplicates §2.4 and the central page is maintenance overhead and drifts out of sync. Model-specific constraints belong up front in the recipe's config/deployment section; cross-recipe failures belong in the central page.

## Changes

- **Delete `## 5. Troubleshooting`** from 18 recipes (17 autoregressive + 2 diffusion).
- **Migrate the few genuinely-unique gotchas** that were *not* already in §2.4 into the recipe's §2 Configuration Tips:
  - **Llama3.3-70B** — stale `/tmp/libtpu_lockfile` cleanup before relaunch.
  - **Kimi-Linear** — multi-host RPC deadline (`RegisterTask DEADLINE_EXCEEDED`); dispatch all ranks within seconds.
  - **Qwen2.5-VL** — remote `image_url`/`video_url` must be reachable from the TPU host.
- **Fold** the GLM-4.5 pre-0.1.0 `q_proj` weight-transpose note into its validated-recipe banner.
- **Fix dangling `§5` references** in Grok2 (×5), GLM-4.5, DeepSeek-V3, Wan2.1, Wan2.2.
- **Update** `base/tpu-topology-reference.md` and the central `troubleshooting.md`, both of which previously pointed readers at each recipe's `§5` / `§7` troubleshooting section.

Net: **+17 / −207**. No model-specific knowledge lost — everything unique is now in §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)