### PR TITLE
fix(ci): gate TPU stages on unit-test-cpu for fail-fast

### DIFF
--- a/.github/workflows/coordinator.yml
+++ b/.github/workflows/coordinator.yml
@@ -22,6 +22,9 @@ on:
         description: "Run Pallas kernel benchmark (requires secrets)"
         value: ${{ jobs.decide.outputs.run_pallas_bench }}
 
+permissions:
+  contents: read
+
 jobs:
   decide:
     runs-on: ubuntu-latest
@@ -34,13 +37,13 @@ jobs:
       run_pallas_bench: ${{ steps.decide.outputs.run_pallas_bench }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Detect file changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             main_package:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -47,7 +47,7 @@ jobs:
 
   # =============================================== Stage 2: multi-chip + e2e + accuracy ============================
   unit-test-4-tpu:
-    needs: [coordinator, unit-test-1-tpu]
+    needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
     runs-on: arc-runner-v6e-4
     strategy:
@@ -92,7 +92,7 @@ jobs:
           python test/srt/run_suite.py --suite unit-test-cpu
 
   e2e-test-1-tpu:
-    needs: [coordinator, unit-test-1-tpu]
+    needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
     runs-on: arc-runner-v6e-1
     strategy:
@@ -120,7 +120,7 @@ jobs:
 
 
   e2e-test-4-tpu:
-    needs: [coordinator, unit-test-1-tpu]
+    needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
     runs-on: arc-runner-v6e-4
     strategy:
@@ -149,7 +149,7 @@ jobs:
           python test/srt/run_suite.py --suite e2e-test-tpu-v6e-4 --auto-partition-id ${{ matrix.part }} --auto-partition-size 3
 
   accuracy-test-1-tpu:
-    needs: [coordinator, unit-test-1-tpu]
+    needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
     runs-on: arc-runner-v6e-1
     strategy:
@@ -177,7 +177,7 @@ jobs:
           python test/srt/run_suite.py --suite accuracy-test-tpu-v6e-1 --auto-partition-id ${{ matrix.part }} --auto-partition-size 1
 
   accuracy-test-4-tpu:
-    needs: [coordinator, unit-test-1-tpu]
+    needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
 
     runs-on: arc-runner-v6e-4
@@ -207,7 +207,7 @@ jobs:
 
   # ---- Stage 2 optional: multi-chip-extra (label test:multi-chip or test:full) ----
   multi-chip-extra-test-4-tpu:
-    needs: [coordinator, unit-test-1-tpu]
+    needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: >-
       needs.coordinator.outputs.run_main_test == 'true' &&
       (needs.coordinator.outputs.requires_4tpu == 'true' || needs.coordinator.outputs.run_full == 'true')
@@ -235,7 +235,7 @@ jobs:
 
   # ---- Stage 2 optional: accuracy-extra (label test:accuracy-extra or test:full) ----
   accuracy-extra-test-1-tpu:
-    needs: [coordinator, unit-test-1-tpu]
+    needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: >-
       needs.coordinator.outputs.run_main_test == 'true' &&
       (needs.coordinator.outputs.run_accuracy_extra == 'true' || needs.coordinator.outputs.run_full == 'true')

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -15,6 +15,9 @@ concurrency:
   group: pr-test-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   # =============================================== coordinator ====================================================
   coordinator:
@@ -158,7 +161,7 @@ jobs:
         part: [0]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
@@ -187,7 +190,7 @@ jobs:
         part: [0]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
@@ -272,7 +275,7 @@ jobs:
         part: [0]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
@@ -300,7 +303,7 @@ jobs:
         part: [0, 1]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv


### PR DESCRIPTION
## Problem

`unit-test-cpu` runs in parallel with `unit-test-1-tpu`, but it gates nothing: no downstream job lists it in `needs` — only the final `pr-test-finish` summary does. The whole TPU chain (Stage 2: `unit-test-4-tpu` / `e2e-*` / `accuracy-*` / extras; Stage 3: `performance-*`) is gated on `unit-test-1-tpu`, never on `unit-test-cpu`.

So CPU test has two roles, and only one works:

| Layer | Status |
|-------|--------|
| **Admission gate** (can the PR merge?) | ✅ `unit-test-cpu` is in `finish_check.py` `MANDATORY_JOBS`, so a CPU failure blocks merge. |
| **Fail-fast gate** (does a CPU failure save downstream cost?) | ❌ No TPU stage depends on it. When CPU fails, every Stage 2/3 TPU job still runs to completion; the failure only surfaces at the finish gate. |

CPU unit tests are the cheapest, fastest signal (`arc-runner-cpu`, 30 min, no `HF_TOKEN`, no model download), so they are exactly what should fail fast before expensive v6e-1 / v6e-4 jobs spend machine time.

## Fix

Add `unit-test-cpu` to the `needs` of the seven Stage 2 entry jobs (`unit-test-4-tpu`, `e2e-test-1-tpu`, `e2e-test-4-tpu`, `accuracy-test-1-tpu`, `accuracy-test-4-tpu`, `multi-chip-extra-test-4-tpu`, `accuracy-extra-test-1-tpu`). Stage 3 (`performance-*`) inherits the gate transitively through its Stage 2 dependencies, so it needs no change.

## Behavior after the change

- CPU fails → Stage 2 jobs skip (failed `needs`) → Stage 3 skips → `finish_check.py` sees those mandatory jobs as non-`success` → finish gate fails. TPU machine time is saved and merge is still blocked.
- `unit-test-cpu` itself is unchanged (`needs: [coordinator]`), so no dependency cycle.

## Trade-off

Stage 2 now waits for both `unit-test-cpu` and `unit-test-1-tpu` before starting. If the CPU runner queues slower than the v6e-1 runner, Stage 2 start is slightly delayed — trading a little serial latency for fail-fast machine-time savings. Finish-gate semantics are unchanged.