### PR TITLE
fix(swa): restore chunked req fill_ids on hybrid no-budget early-return

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -429,6 +429,15 @@ class PrefillAdder:
             )
         if _rem_tokens <= 0:
             if self.is_hybrid:
+                # Caller already ran init_next_round_input(), which reset
+                # fill_ids to the full input. If we return here without
+                # scheduling, the next round's cache_unfinished_req() will
+                # treat that full length as committed prefix, then compute
+                # extend_input_len==0 and schedule a zero-extend chunked req.
+                # A q_len==0 seq inside the RPA kernel's [start_seq, end_seq)
+                # range deadlocks the DMA pipeline (#1266). Restore fill_ids
+                # to the actually-committed prefix before bailing.
+                req.fill_ids = req.fill_ids[: len(req.prefix_indices)]
                 return req
             _rem_tokens = self.rem_chunk_tokens_list[dp_rank]
         truncated = req.extend_input_len > _rem_tokens


### PR DESCRIPTION
Fixes #1266 — hybrid-SWA models deadlock the TPU on multi-host after a KV-full retract.

cc @pengchengneo (this is a 1-line fix to the `add_chunked_req` early-return path you added in #1234)

## Root cause

#1234 added an early-return in `add_chunked_req` when the hybrid SWA budget is exhausted (`_rem_tokens <= 0 → return req`), but the caller (`scheduler.py:1619`) has already run `init_next_round_input()` which resets `req.fill_ids` to the full input length. The early-return leaves `fill_ids` at full length, so:

| round | what happens | chunked req state |
|---|---|---|
| N | SWA full → `add_chunked_req` early-returns; **`fill_ids` left at 8192** (full input) | prefix=4352, fill_ids=8192 |
| N+1 | `cache_unfinished_req()` sets `prefix = req_to_token[:8192]` (includes 4352–8192 **stale** slots). `init_next_round_input()` → **`extend = 8192 − 8192 = 0`**. SWA now freed (post-retract) → `add_chunked_req` appends with `extend_input_len=0` | seq=8192, **extend=0** in EXTEND batch |

The resulting batch has per-DP `seq_lens=[8192, 4096]`, `extend_seq_lens=[0, 4096]`, `cu_q_lens=[0, 0, 4096, …]`, `distribution=[0, 2, 2]`.

A `q_len==0` seq inside the RPA kernel's `[start_seq_idx, end_seq_idx)` range deadlocks the kernel: the prologue prefetches bq/bkv for seq 0, but `process()` runs **zero** `bq` iterations (so it never advances the double-buffer `sem_ids` or prefetches seq 1's first block), leaving seq 1's `wait_fetch_*` waiting on a mismatched semaphore — all 16 chips wedge in `Execute` ("Slow PjRt TPU operation").

## Fix

Restore `fill_ids` to the actually-committed prefix length before bailing on `_rem_tokens <= 0`.

## Verification (v6e-16, dp=4/tp=16/ep=16, #1266 repro config)

`--disable-radix-cache --swa-full-tokens-ratio 0.15 --max-running-requests 128`, overlap, 256 × (8192 in / 1024 out), conc=128:

| | retract count | result |
|---|---|---|
| main@a98e2931 | 1 | **deadlock** at first post-retract EXTEND (`cu_q=[0,0,4096]`) |
| + this fix | 19 | **PASS** 256/256, 313 tok/s, median ITL 23 ms |

After the fix, the post-retract EXTEND has `cu_q=[0,4096,8192]` (chunked req correctly extends 4096 instead of 0).

## Out of scope (follow-ups)

- RPA kernel robustness to `q_len==0` seqs in the active range — worth hardening so future scheduler bugs degrade to wrong output instead of a TPU wedge.
- `swa-full-tokens-ratio=0.15` + `bs=128` retracts ~19× per 256 reqs (the #1234 throttle doesn't fully cap admission under overlap) — separate tuning issue, not a deadlock.