### PR TITLE
ci: bump Node 20 actions to Node 24 versions

### DIFF
--- a/.github/workflows/ci-auto-bisect.yml
+++ b/.github/workflows/ci-auto-bisect.yml
@@ -253,7 +253,7 @@ jobs:
           CLAUDE_CODE_LOG_LEVEL: debug
 
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ci-auto-bisect-${{ github.run_number }}
           path: analysis_result.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: arc-runner-cpu
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install pre-commit hook
         run: |
           python3.12 -m venv .venv

--- a/.github/workflows/nightly-slack-notify.yml
+++ b/.github/workflows/nightly-slack-notify.yml
@@ -255,7 +255,7 @@ jobs:
 
       - name: Upload classification artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: nightly-failure-classification-${{ github.run_number }}
           path: |

--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -83,7 +83,7 @@ jobs:
       SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
       - name: Setup Python environment
@@ -104,7 +104,7 @@ jobs:
       SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
       - name: Setup Python environment
@@ -125,7 +125,7 @@ jobs:
       SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
       - name: Setup Python environment
@@ -155,7 +155,7 @@ jobs:
       SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
       - name: Setup Python environment
@@ -180,7 +180,7 @@ jobs:
       RESULTS_DIR: ${{ github.workspace }}/test/nightly_test_output/accuracy
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
@@ -253,7 +253,7 @@ jobs:
       RESULTS_DIR: ${{ github.workspace }}/test/nightly_test_output/perf
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
@@ -326,7 +326,7 @@ jobs:
           fi
       - name: Upload perf results (per-model CSV + xprof traces)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: perf-results-v6e-4-${{ github.run_id }}
           path: ${{ github.workspace }}/test/nightly_test_output/perf
@@ -372,7 +372,7 @@ jobs:
       TZ: Asia/Shanghai
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Detect trend drift
         # stdlib-only on purpose — no setup-venv. A 3rd-party import would
         # ImportError here, silently swallowed by continue-on-error.
@@ -385,7 +385,7 @@ jobs:
               --data-dir /observability-storage --output drift.json
           fi
       - name: Upload drift report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: trend-drift-${{ github.run_id }}
           path: drift.json
@@ -404,9 +404,9 @@ jobs:
       TZ: Asia/Shanghai
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Download drift report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         # Tolerate a missing artifact (monitor crash) so the next step still
         # runs and warns, instead of the job silently vanishing.
         continue-on-error: true

--- a/.github/workflows/nightly-test-summize.yml
+++ b/.github/workflows/nightly-test-summize.yml
@@ -26,7 +26,7 @@ jobs:
       TZ: Asia/Shanghai
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
 
       - name: Set current date
@@ -119,7 +119,7 @@ jobs:
           '
 
       - name: Upload Trend Images Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: trend-charts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,10 +67,10 @@ jobs:
       dry_run: ${{ steps.compute.outputs.dry_run }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -136,14 +136,14 @@ jobs:
     environment: prod
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ needs.metadata.outputs.dry_run == 'true' && github.ref || needs.metadata.outputs.tag }}
 
       - name: Create GitHub Release
         if: ${{ needs.metadata.outputs.dry_run != 'true' }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.metadata.outputs.tag }}
           name: sglang-jax ${{ needs.metadata.outputs.tag }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -30,17 +30,17 @@ jobs:
     environment: prod
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ inputs.dry_run && github.ref || inputs.tag }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
         if: ${{ ! inputs.dry_run }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -80,7 +80,7 @@ jobs:
 
       - name: Push image
         if: ${{ ! inputs.dry_run }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -123,13 +123,13 @@ jobs:
     environment: prod
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ inputs.dry_run && github.ref || inputs.tag }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -25,10 +25,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -44,12 +44,12 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -33,7 +33,7 @@ jobs:
       SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
         with:
@@ -98,7 +98,7 @@ jobs:
       SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
         with:
@@ -137,7 +137,7 @@ jobs:
       SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
       - name: Run performance test for text models
@@ -181,7 +181,7 @@ jobs:
       SGLANG_JAX_MODEL_CACHE: /models/model_scope
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
@@ -247,7 +247,7 @@ jobs:
         SGLANG_JAX_MODEL_CACHE: /models/model_scope
       steps:
         - name: Checkout code
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
 
         - name: Setup Python environment
           uses: ./.github/actions/setup-venv
@@ -291,7 +291,7 @@ jobs:
           SGLANG_JAX_MODEL_CACHE: /models/model_scope
         steps:
           - name: Checkout code
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
 
           - name: Setup Python environment
             uses: ./.github/actions/setup-venv


### PR DESCRIPTION
## Why

GitHub forces Node 24 for JavaScript actions starting **2026-06-16** and removes Node 20 in **fall 2026** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This bumps all remaining Node 20 JS actions across the repo to their Node 24 releases. (`pr-test.yml` / `coordinator.yml` were already done in #1354.)

## Upgrades

| Action | From | To | Notes |
|--------|------|----|-------|
| `actions/checkout` | v4 | v5 | runtime; already validated on self-hosted runners in #1354 |
| `actions/setup-python` | v5 | v6 | runtime |
| `actions/upload-artifact` | v4 | v5 | runtime (low risk; the hard break was v3→v4, already past) |
| `actions/download-artifact` | v4 | v5 | runtime + by-ID extract path change (we use by-name, unaffected) |
| `docker/build-push-action` | v6 | v7 | runtime; removed `DOCKER_BUILD_*` env vars not used here |
| `docker/login-action` | v3 | v4 | runtime only |
| `docker/setup-buildx-action` | v3 | v4 | runtime; no deprecated inputs passed |
| `softprops/action-gh-release` | v2 | v3 | runtime only |

Each target version was confirmed to run on Node 24 via its `action.yml`. Breaking changes beyond the runtime bump were checked against actual usage — **none apply**.

## Left unchanged (intentionally)

- `google-github-actions/{auth,setup-gcloud,get-gke-credentials}@v3` — already Node 24
- `anthropics/claude-code-action@v1`, `pypa/gh-action-pypi-publish@release/v1` — composite actions, not affected by the Node 20 deprecation
- `permissions` hardening is **out of scope** here (separate concern; several release/auth workflows need write scopes)

## Verification scope

Most changed workflows (release / publish / docker / pypi / nightly / weekly) are **not triggered by PR CI** — they run on tags / schedule / dispatch — so this PR's checks won't exercise them. The changes are version-number-only bumps with per-action breaking-change review done above; watch the next real run of the release/nightly workflows. `lint.yml` does run on this PR and exercises `checkout@v5`.