### PR TITLE
feat(model): Gemma4 vision encoder + multimodal integration

### DIFF
--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -279,6 +279,10 @@ class GenerateReqInput:
     input_ids: list[list[int]] | list[int] | None = None
     # The embeddings for input_ids; one can specify either text or input_ids or input_embeds.
     input_embeds: list[list[list[float]]] | list[list[float]] | None = None
+    # Pre-computed multimodal inputs, e.g. {"multimodal_embedding": [[...]]} for
+    # vision embeddings produced offline. Forwarded to the scheduler, which wires
+    # them onto Req.multimodal_embedding -> ForwardBatch.input_embedding.
+    mm_inputs: dict | None = None
     # The image input. It can be an image instance, file name, URL, or base64 encoded string.
     # Can be formatted as:
     # - Single image for a single request

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -306,6 +306,11 @@ class TokenizerManager:
                 )
             encoded = self.tokenizer(input_text)
             input_ids = encoded["input_ids"]
+        if input_ids is None and getattr(obj, "input_embeds", None) is not None:
+            # Pure input_embeds request: synthesize placeholder ids so the
+            # length-based scheduling/validation works; the decoder uses
+            # forward_batch.input_embedding instead of these ids.
+            input_ids = [0] * len(obj.input_embeds)
 
         self._validate_one_request(obj, input_ids)
         return self._create_tokenized_object(obj, input_text, input_ids)
@@ -377,6 +382,12 @@ class TokenizerManager:
             obj.extra_key,
             obj.return_routed_experts,
         )
+
+        # Forward pre-computed multimodal inputs (e.g. vision embeddings passed
+        # as {"multimodal_embedding": [[...]]}) to the scheduler, which wires
+        # them onto Req.multimodal_embedding -> ForwardBatch.input_embedding.
+        if getattr(obj, "mm_inputs", None) is not None:
+            tokenized_obj.mm_inputs = obj.mm_inputs
 
         # PD disaggregation passthrough. When the engine is
         # running in disaggregation_mode=decode, the request body MUST

--- a/python/sgl_jax/srt/models/gemma4.py
+++ b/python/sgl_jax/srt/models/gemma4.py
@@ -953,9 +953,7 @@ class Gemma4ForConditionalGeneration(Gemma4ForCausalLM):
 
         vision_config = getattr(config, "vision_config", None)
         if vision_config is None:
-            raise ValueError(
-                "Gemma4ForConditionalGeneration requires config.vision_config"
-            )
+            raise ValueError("Gemma4ForConditionalGeneration requires config.vision_config")
         self.vision_config = vision_config
         self.vision_tower = Gemma4VisionEncoder(vision_config, dtype=dtype)
         self.embed_vision = Gemma4MultimodalEmbedder(

--- a/python/sgl_jax/srt/models/gemma4.py
+++ b/python/sgl_jax/srt/models/gemma4.py
@@ -930,7 +930,116 @@ class Gemma4ForCausalLM(nnx.Module):
 
 
 class Gemma4ForConditionalGeneration(Gemma4ForCausalLM):
-    pass
+    """Gemma4 multimodal: text decoder + vision tower.
+
+    The text decode/prefill path is inherited unchanged — it reads
+    ``forward_batch.input_embedding`` for multimodal prefill (already wired in
+    ``Gemma4Model``). Image embeddings are produced by ``get_image_feature``
+    (vision encoder → ``embed_vision`` projection) and merged into the input
+    embedding stream via the ``mm_inputs.multimodal_embedding`` scheduler path.
+    """
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        super().__init__(config, mesh=mesh, dtype=dtype)
+        from sgl_jax.srt.multimodal.models.gemma4.vision_encoder import (
+            Gemma4MultimodalEmbedder,
+            Gemma4VisionEncoder,
+        )
+
+        vision_config = getattr(config, "vision_config", None)
+        if vision_config is None:
+            raise ValueError(
+                "Gemma4ForConditionalGeneration requires config.vision_config"
+            )
+        self.vision_config = vision_config
+        self.vision_tower = Gemma4VisionEncoder(vision_config, dtype=dtype)
+        self.embed_vision = Gemma4MultimodalEmbedder(
+            vision_config.hidden_size,
+            self.config.hidden_size,
+            getattr(vision_config, "rms_norm_eps", 1e-6),
+            dtype=dtype,
+        )
+
+    def get_image_feature(
+        self, pixel_values: jax.Array, pixel_position_ids: jax.Array
+    ) -> jax.Array:
+        """Encode pre-patchified images into text-space embeddings.
+
+        Args:
+          pixel_values: ``[B, num_patches, 768]`` (HF Gemma4ImageProcessor output).
+          pixel_position_ids: ``[B, num_patches, 2]`` (x, y), -1 for padding.
+        Returns:
+          ``[B, out_len, text_hidden]`` soft-token embeddings (caller drops
+          padded rows using the encoder's valid mask if needed).
+        """
+        soft_tokens, valid_mask = self.vision_tower(pixel_values, pixel_position_ids)
+        return self.embed_vision(soft_tokens), valid_mask
+
+    def load_weights(self, model_config: ModelConfig):
+        super().load_weights(model_config)
+        self._load_vision_weights(model_config)
+
+    def _load_vision_weights(self, model_config: ModelConfig):
+        """Load ``model.vision_tower.*`` + ``model.embed_vision.*`` directly from
+        safetensors into the nnx tree (separate from the text WeightLoader, whose
+        QKV/transpose semantics don't apply to the standalone vision encoder)."""
+        import json
+        import os
+
+        from sgl_jax.srt.multimodal.models.gemma4.vision_encoder import (
+            vision_weight_mappings,
+        )
+
+        model_path = model_config.model_path
+        index_path = os.path.join(model_path, "model.safetensors.index.json")
+        if not os.path.exists(index_path):
+            logger.warning("vision: no safetensors index at %s, skipping", index_path)
+            return
+        with open(index_path) as f:
+            weight_map = json.load(f)["weight_map"]
+
+        enc_mappings = vision_weight_mappings(self.vision_config.num_hidden_layers)
+        proj_key = "model.embed_vision.embedding_projection.weight"
+
+        wanted = {k: v for k, v in enc_mappings.items() if k in weight_map}
+        by_file: dict[str, list[str]] = {}
+        for hf_key in list(wanted) + ([proj_key] if proj_key in weight_map else []):
+            by_file.setdefault(weight_map[hf_key], []).append(hf_key)
+
+        enc_state = nnx.state(self.vision_tower)
+        for fname, keys in by_file.items():
+            with safetensors.safe_open(
+                os.path.join(model_path, fname), framework="np", device="cpu"
+            ) as f:
+                for hf_key in keys:
+                    w = f.get_tensor(hf_key)
+                    if hf_key == proj_key:
+                        self.embed_vision.embedding_projection.kernel.value = jnp.asarray(
+                            w.T, dtype=self.dtype
+                        )
+                        continue
+                    dst = enc_mappings[hf_key]
+                    if dst.endswith(".kernel"):
+                        w = w.T
+                    _set_nnx_path(enc_state, dst, jnp.asarray(w))
+        nnx.update(self.vision_tower, enc_state)
+        logger.info("Gemma4 vision tower + embed_vision weights loaded.")
+
+
+def _set_nnx_path(state, path: str, value):
+    """Set a leaf in an nnx State tree by dotted path (ints index lists)."""
+    parts = path.split(".")
+    node = state
+    for p in parts[:-1]:
+        node = node[int(p)] if p.isdigit() else node[p]
+    leaf = parts[-1]
+    cur = node[int(leaf)] if leaf.isdigit() else node[leaf]
+    cur.value = value.astype(cur.value.dtype)
 
 
 EntryClass = [Gemma4ForCausalLM, Gemma4ForConditionalGeneration]

--- a/python/sgl_jax/srt/multimodal/models/gemma4/vision_encoder.py
+++ b/python/sgl_jax/srt/multimodal/models/gemma4/vision_encoder.py
@@ -1,0 +1,325 @@
+"""Gemma4 vision encoder for sglang-jax.
+
+Ported from MaxText ``gemma4_vision.py`` and HF ``Gemma4VisionModel``. Expects
+pre-patchified inputs (HF ``Gemma4ImageProcessor`` output) so the encoder itself
+is shape-static for a fixed token budget. P0 supports the default 280-token
+budget only (2520 patches → 3×3 pool).
+
+No KV cache, no paging — plain bidirectional self-attention. Runs on a single
+device by default; sharding annotations are deferred to P2.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+PATCH_DIM = 16 * 16 * 3  # 768
+
+# Gemma4 supported token budgets → required input patch count (= budget × pool_k²).
+TOKEN_BUDGETS = (70, 140, 280, 560, 1120)
+
+
+def patches_for_budget(budget: int, pool_k: int = 3) -> int:
+    return budget * pool_k * pool_k
+
+
+def select_budget(num_patches: int, pool_k: int = 3) -> int:
+    """Smallest budget whose patch capacity ≥ num_patches (pad up)."""
+    for b in TOKEN_BUDGETS:
+        if patches_for_budget(b, pool_k) >= num_patches:
+            return b
+    return TOKEN_BUDGETS[-1]
+
+
+class RMSNorm(nnx.Module):
+    """Standard RMSNorm (x * w), matching HF Gemma4RMSNorm. Mesh-free."""
+
+    def __init__(self, dim: int, epsilon: float = 1e-6, use_scale: bool = True, dtype=jnp.bfloat16):
+        self.eps = epsilon
+        self.dtype = dtype
+        self.scale = nnx.Param(jnp.ones((dim,), dtype=dtype)) if use_scale else None
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        x32 = x.astype(jnp.float32)
+        normed = x32 * jax.lax.rsqrt(jnp.mean(x32 * x32, axis=-1, keepdims=True) + self.eps)
+        if self.scale is not None:
+            normed = normed * self.scale.value.astype(jnp.float32)
+        return normed.astype(self.dtype)
+
+
+# --------------------------------------------------------------------------- #
+# 2-D multidimensional RoPE
+# --------------------------------------------------------------------------- #
+def _rotate_half(x: jax.Array) -> jax.Array:
+    x1, x2 = jnp.split(x, 2, axis=-1)
+    return jnp.concatenate((-x2, x1), axis=-1)
+
+
+def _apply_rope_1d(x: jax.Array, pos: jax.Array, base_freq: float) -> jax.Array:
+    """x: [..., L, H, D_part], pos: [..., L]."""
+    dim = x.shape[-1]
+    half = dim // 2
+    timescale = base_freq ** (jnp.arange(0, dim, 2, dtype=jnp.float32) / dim)
+    sinusoid = pos[..., None, None].astype(jnp.float32) / timescale
+    sin = jnp.sin(sinusoid).astype(x.dtype)
+    cos = jnp.cos(sinusoid).astype(x.dtype)
+    sin = jnp.concatenate([sin, sin], axis=-1)
+    cos = jnp.concatenate([cos, cos], axis=-1)
+    _ = half  # half computed for clarity; concat above doubles to full dim
+    return x * cos + _rotate_half(x) * sin
+
+
+def apply_2d_rope(x: jax.Array, positions_xy: jax.Array, base_freq: float) -> jax.Array:
+    """Split head_dim in two and apply RoPE per spatial axis (x then y).
+
+    x: [..., L, H, D], positions_xy: [..., L, 2].
+    """
+    d = x.shape[-1]
+    x0, x1 = jnp.split(x, 2, axis=-1)
+    y0 = _apply_rope_1d(x0, positions_xy[..., 0], base_freq)
+    y1 = _apply_rope_1d(x1, positions_xy[..., 1], base_freq)
+    out = jnp.concatenate([y0, y1], axis=-1)
+    assert out.shape[-1] == d
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Building blocks
+# --------------------------------------------------------------------------- #
+class Gemma4VisionMLP(nnx.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int, dtype: jnp.dtype, rngs: nnx.Rngs):
+        self.gate_proj = nnx.Linear(
+            hidden_size, intermediate_size, use_bias=False, param_dtype=dtype, rngs=rngs
+        )
+        self.up_proj = nnx.Linear(
+            hidden_size, intermediate_size, use_bias=False, param_dtype=dtype, rngs=rngs
+        )
+        self.down_proj = nnx.Linear(
+            intermediate_size, hidden_size, use_bias=False, param_dtype=dtype, rngs=rngs
+        )
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        return self.down_proj(jax.nn.gelu(self.gate_proj(x), approximate=True) * self.up_proj(x))
+
+
+class Gemma4VisionAttention(nnx.Module):
+    def __init__(self, cfg, dtype: jnp.dtype, rngs: nnx.Rngs):
+        self.num_heads = cfg.num_attention_heads
+        self.head_dim = cfg.head_dim
+        self.rope_theta = cfg.rope_parameters["rope_theta"]
+        hidden = cfg.hidden_size
+        proj_dim = self.num_heads * self.head_dim
+
+        self.q_proj = nnx.Linear(hidden, proj_dim, use_bias=False, param_dtype=dtype, rngs=rngs)
+        self.k_proj = nnx.Linear(hidden, proj_dim, use_bias=False, param_dtype=dtype, rngs=rngs)
+        self.v_proj = nnx.Linear(hidden, proj_dim, use_bias=False, param_dtype=dtype, rngs=rngs)
+        self.o_proj = nnx.Linear(proj_dim, hidden, use_bias=False, param_dtype=dtype, rngs=rngs)
+
+        self.q_norm = RMSNorm(self.head_dim, epsilon=cfg.rms_norm_eps, dtype=dtype)
+        self.k_norm = RMSNorm(self.head_dim, epsilon=cfg.rms_norm_eps, dtype=dtype)
+        self.v_norm = RMSNorm(self.head_dim, epsilon=cfg.rms_norm_eps, use_scale=False, dtype=dtype)
+
+    def __call__(self, x: jax.Array, positions_xy: jax.Array, padding_mask: jax.Array) -> jax.Array:
+        b, n, _ = x.shape
+        h, d = self.num_heads, self.head_dim
+
+        q = self.q_norm(self.q_proj(x).reshape(b, n, h, d))
+        k = self.k_norm(self.k_proj(x).reshape(b, n, h, d))
+        v = self.v_norm(self.v_proj(x).reshape(b, n, h, d))
+
+        q = apply_2d_rope(q, positions_xy, self.rope_theta)
+        k = apply_2d_rope(k, positions_xy, self.rope_theta)
+
+        # [B,H,N,D]
+        q = q.transpose(0, 2, 1, 3)
+        k = k.transpose(0, 2, 1, 3)
+        v = v.transpose(0, 2, 1, 3)
+
+        scores = jnp.einsum("bhnd,bhmd->bhnm", q, k).astype(jnp.float32)
+        mask = padding_mask[:, None, None, :]  # [B,1,1,N] mask out padded keys
+        scores = jnp.where(mask, scores, jnp.finfo(jnp.float32).min)
+        weights = jax.nn.softmax(scores, axis=-1).astype(x.dtype)
+
+        out = jnp.einsum("bhnm,bhmd->bhnd", weights, v)
+        out = out.transpose(0, 2, 1, 3).reshape(b, n, h * d)
+        return self.o_proj(out)
+
+
+class Gemma4VisionBlock(nnx.Module):
+    def __init__(self, cfg, dtype: jnp.dtype, rngs: nnx.Rngs):
+        eps = cfg.rms_norm_eps
+        self.input_layernorm = RMSNorm(cfg.hidden_size, epsilon=eps, dtype=dtype)
+        self.post_attention_layernorm = RMSNorm(cfg.hidden_size, epsilon=eps, dtype=dtype)
+        self.pre_feedforward_layernorm = RMSNorm(cfg.hidden_size, epsilon=eps, dtype=dtype)
+        self.post_feedforward_layernorm = RMSNorm(cfg.hidden_size, epsilon=eps, dtype=dtype)
+        self.self_attn = Gemma4VisionAttention(cfg, dtype, rngs)
+        self.mlp = Gemma4VisionMLP(cfg.hidden_size, cfg.intermediate_size, dtype, rngs)
+
+    def __call__(self, x: jax.Array, positions_xy: jax.Array, padding_mask: jax.Array) -> jax.Array:
+        h = self.input_layernorm(x)
+        h = self.self_attn(h, positions_xy, padding_mask)
+        x = x + self.post_attention_layernorm(h)
+
+        h = self.pre_feedforward_layernorm(x)
+        h = self.mlp(h)
+        x = x + self.post_feedforward_layernorm(h)
+        return x
+
+
+class Gemma4VisionPatchEmbedder(nnx.Module):
+    """Linear patch projection + learned 2D factorized position embedding."""
+
+    def __init__(self, cfg, dtype: jnp.dtype, rngs: nnx.Rngs):
+        self.input_proj = nnx.Linear(
+            PATCH_DIM, cfg.hidden_size, use_bias=False, param_dtype=dtype, rngs=rngs
+        )
+        self.position_embedding_table = nnx.Param(
+            jnp.zeros((2, cfg.position_embedding_size, cfg.hidden_size), dtype=dtype)
+        )
+
+    def __call__(
+        self, patches: jax.Array, positions_xy: jax.Array, padding_mask: jax.Array
+    ) -> jax.Array:
+        x = self.input_proj(patches)
+        # Gather per-axis position embeddings then sum. Clamp -1 padding to 0
+        # and zero it via padding_mask afterwards.
+        clamped = jnp.maximum(positions_xy, 0)
+        pe_x = self.position_embedding_table[0][clamped[..., 0]]
+        pe_y = self.position_embedding_table[1][clamped[..., 1]]
+        pe = (pe_x + pe_y) * padding_mask[..., None].astype(x.dtype)
+        return x + pe.astype(x.dtype)
+
+
+def avg_pool_by_positions(
+    x: jax.Array, positions_xy: jax.Array, kernel: int, out_len: int
+) -> tuple[jax.Array, jax.Array]:
+    """3×3 average pool grouping patches by floor(pos/k). Matches HF Gemma4VisionPooler."""
+    max_x = positions_xy[..., 0].max(axis=-1, keepdims=True) + 1
+    kidx = jnp.floor_divide(positions_xy, kernel)
+    flat = kidx[..., 0] + (max_x // kernel) * kidx[..., 1]
+    weights = jax.nn.one_hot(flat, out_len, dtype=x.dtype) / (kernel * kernel)
+    out = jnp.einsum("bnl,bnd->bld", weights, x)
+    mask = jnp.any(weights != 0, axis=1)
+    return out, mask
+
+
+class Gemma4VisionEncoder(nnx.Module):
+    """Vision tower: patch embed → N encoder blocks → pool → √d scale → standardize."""
+
+    def __init__(self, cfg, dtype: jnp.dtype = jnp.bfloat16, rngs: nnx.Rngs | None = None):
+        rngs = rngs or nnx.Rngs(0)
+        self.cfg = cfg
+        self.dtype = dtype
+        self.out_len = cfg.default_output_length
+        self.pool_k = cfg.pooling_kernel_size
+
+        self.patch_embedder = Gemma4VisionPatchEmbedder(cfg, dtype, rngs)
+        self.layers = nnx.data(
+            [Gemma4VisionBlock(cfg, dtype, rngs) for _ in range(cfg.num_hidden_layers)]
+        )
+        self.std_bias = nnx.Param(jnp.zeros((cfg.hidden_size,), dtype=dtype))
+        self.std_scale = nnx.Param(jnp.ones((cfg.hidden_size,), dtype=dtype))
+
+    def __call__(
+        self,
+        pixel_values: jax.Array,
+        pixel_position_ids: jax.Array,
+        out_len: int | None = None,
+    ) -> tuple[jax.Array, jax.Array]:
+        """
+        Args:
+          pixel_values: [B, num_patches, 768] pre-patchified, range [0, 1].
+            num_patches must equal out_len × pool_k² (caller pads with pos=-1).
+          pixel_position_ids: [B, num_patches, 2] (x, y), -1 for padding.
+          out_len: token budget (70/140/280/560/1120); defaults to config.
+        Returns:
+          (soft_tokens [B, out_len, hidden], valid_mask [B, out_len]).
+        """
+        out_len = out_len or self.out_len
+        padding_mask = jnp.all(pixel_position_ids != -1, axis=-1)  # [B, N]
+        # HF Gemma4 normalizes [0,1] → [-1,1] inside the patch embedder.
+        patches = (2.0 * pixel_values - 1.0).astype(self.dtype)
+
+        x = self.patch_embedder(patches, pixel_position_ids, padding_mask)
+        for layer in self.layers:
+            x = layer(x, pixel_position_ids, padding_mask)
+
+        x, valid_mask = avg_pool_by_positions(x, pixel_position_ids, self.pool_k, out_len)
+        x = x * jnp.sqrt(jnp.asarray(self.cfg.hidden_size, x.dtype))
+        x = (x - self.std_bias.value.astype(x.dtype)) * self.std_scale.value.astype(x.dtype)
+        return x, valid_mask
+
+    def encode_bucketed(
+        self, pixel_values: jax.Array, pixel_position_ids: jax.Array
+    ) -> tuple[jax.Array, jax.Array, int]:
+        """Auto-select token budget and pad patches to the bucket boundary.
+
+        For TPU jit, wrap ``__call__`` with ``jax.jit(static_argnames=['out_len'])``
+        so each budget compiles once.
+        """
+        b, n, _ = pixel_values.shape
+        budget = select_budget(n, self.pool_k)
+        target_n = patches_for_budget(budget, self.pool_k)
+        if n < target_n:
+            pad_n = target_n - n
+            pixel_values = jnp.pad(pixel_values, ((0, 0), (0, pad_n), (0, 0)))
+            pixel_position_ids = jnp.pad(
+                pixel_position_ids, ((0, 0), (0, pad_n), (0, 0)), constant_values=-1
+            )
+        soft, mask = self(pixel_values, pixel_position_ids, out_len=budget)
+        return soft, mask, budget
+
+
+class Gemma4MultimodalEmbedder(nnx.Module):
+    """Project pooled vision features into the text embedding space."""
+
+    def __init__(
+        self,
+        vision_hidden: int,
+        text_hidden: int,
+        eps: float,
+        dtype: jnp.dtype = jnp.bfloat16,
+        rngs: nnx.Rngs | None = None,
+    ):
+        rngs = rngs or nnx.Rngs(0)
+        self.norm = RMSNorm(vision_hidden, epsilon=eps, use_scale=False, dtype=dtype)
+        self.embedding_projection = nnx.Linear(
+            vision_hidden, text_hidden, use_bias=False, param_dtype=dtype, rngs=rngs
+        )
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        return self.embedding_projection(self.norm(x))
+
+
+# --------------------------------------------------------------------------- #
+# HF safetensors → nnx weight mapping (target_path is the nnx attribute path)
+# --------------------------------------------------------------------------- #
+def vision_weight_mappings(num_layers: int) -> dict[str, str]:
+    """HF key → dotted nnx path. nnx.Linear stores weight as ``kernel`` (in_dim, out_dim)
+    so all HF Linear weights need transpose; caller is responsible for that.
+    """
+    m: dict[str, str] = {
+        "model.vision_tower.patch_embedder.input_proj.weight": "patch_embedder.input_proj.kernel",
+        "model.vision_tower.patch_embedder.position_embedding_table": "patch_embedder.position_embedding_table",
+        "model.vision_tower.std_bias": "std_bias",
+        "model.vision_tower.std_scale": "std_scale",
+    }
+    for i in range(num_layers):
+        src = f"model.vision_tower.encoder.layers.{i}"
+        dst = f"layers.{i}"
+        for ln in (
+            "input_layernorm",
+            "post_attention_layernorm",
+            "pre_feedforward_layernorm",
+            "post_feedforward_layernorm",
+        ):
+            m[f"{src}.{ln}.weight"] = f"{dst}.{ln}.scale"
+        m[f"{src}.self_attn.q_norm.weight"] = f"{dst}.self_attn.q_norm.scale"
+        m[f"{src}.self_attn.k_norm.weight"] = f"{dst}.self_attn.k_norm.scale"
+        for p in ("q_proj", "k_proj", "v_proj", "o_proj"):
+            m[f"{src}.self_attn.{p}.linear.weight"] = f"{dst}.self_attn.{p}.kernel"
+        for p in ("gate_proj", "up_proj", "down_proj"):
+            m[f"{src}.mlp.{p}.linear.weight"] = f"{dst}.mlp.{p}.kernel"
+    return m

--- a/test/srt/test_gemma4_vision_alignment.py
+++ b/test/srt/test_gemma4_vision_alignment.py
@@ -1,0 +1,103 @@
+"""Alignment test: JAX Gemma4VisionEncoder vs HF Gemma4VisionModel.
+
+CPU-only (vision tower ~570M). Fixed 280-token budget (2520 patches).
+"""
+
+import json
+import os
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+import torch
+from flax import nnx
+from safetensors import safe_open
+from transformers import AutoConfig, Gemma4VisionModel
+
+from sgl_jax.srt.multimodal.models.gemma4.vision_encoder import (
+    Gemma4VisionEncoder,
+    vision_weight_mappings,
+)
+from sgl_jax.test.test_utils import GEMMA4_31B_IT, CustomTestCase
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+
+def _set_by_path(state, path, value):
+    parts = path.split(".")
+    node = state
+    for p in parts[:-1]:
+        node = node[int(p)] if p.isdigit() else node[p]
+    leaf = parts[-1]
+    cur = node[int(leaf)] if leaf.isdigit() else node[leaf]
+    cur.value = value.astype(cur.value.dtype)
+
+
+def _load_vision_weights(model_dir, num_layers):
+    with open(f"{model_dir}/model.safetensors.index.json") as f:
+        index = json.load(f)["weight_map"]
+    mappings = vision_weight_mappings(num_layers)
+    by_file: dict[str, list[str]] = {}
+    for k in mappings:
+        by_file.setdefault(index[k], []).append(k)
+    tensors = {}
+    for fname, keys in by_file.items():
+        with safe_open(f"{model_dir}/{fname}", framework="np") as f:
+            for k in keys:
+                tensors[k] = f.get_tensor(k)
+    return tensors, mappings
+
+
+class TestGemma4VisionAlignment(CustomTestCase):
+    COS_THRESHOLD = 0.999
+
+    def test_vision_encoder_vs_hf(self):
+        cfg = AutoConfig.from_pretrained(GEMMA4_31B_IT)
+        vcfg = cfg.vision_config
+
+        # 672x960 → 42x60 patches = 2520 → pool 3x3 → 280
+        rng = np.random.default_rng(42)
+        pv = rng.uniform(0, 1, size=(1, 2520, 768)).astype(np.float32)
+        yy, xx = np.meshgrid(np.arange(42), np.arange(60), indexing="ij")
+        pos = np.stack([xx.ravel(), yy.ravel()], axis=-1)[None].astype(np.int32)
+
+        # HF reference
+        hf = Gemma4VisionModel(vcfg).to(torch.bfloat16).eval()
+        tensors, mappings = _load_vision_weights(GEMMA4_31B_IT, vcfg.num_hidden_layers)
+        sd = {
+            k.removeprefix("model.vision_tower."): torch.from_numpy(v) for k, v in tensors.items()
+        }
+        hf.load_state_dict(sd, strict=True)
+        with torch.no_grad():
+            hf_out = (
+                hf(
+                    pixel_values=torch.from_numpy(pv).to(torch.bfloat16),
+                    pixel_position_ids=torch.from_numpy(pos).long(),
+                )
+                .last_hidden_state.float()
+                .numpy()
+            )
+
+        # JAX
+        enc = Gemma4VisionEncoder(vcfg, dtype=jnp.bfloat16)
+        state = nnx.state(enc)
+        for k, dst in mappings.items():
+            w = tensors[k]
+            if dst.endswith(".kernel"):
+                w = w.T
+            _set_by_path(state, dst, jnp.asarray(w))
+        nnx.update(enc, state)
+        jax_out, _ = enc(jnp.asarray(pv), jnp.asarray(pos))
+        jax_out = np.asarray(jax_out.astype(jnp.float32))[0]
+
+        self.assertEqual(hf_out.shape, jax_out.shape)
+        cos = float(
+            (hf_out * jax_out).sum() / (np.linalg.norm(hf_out) * np.linalg.norm(jax_out) + 1e-8)
+        )
+        mae = float(np.abs(hf_out - jax_out).mean())
+        print(f"cos={cos:.6f} mae={mae:.5f}")
+        self.assertGreater(cos, self.COS_THRESHOLD)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_gemma4_vision_alignment.py
+++ b/test/srt/test_gemma4_vision_alignment.py
@@ -42,7 +42,9 @@ def _load_vision_weights(model_dir, num_layers):
         by_file.setdefault(index[k], []).append(k)
     tensors = {}
     for fname, keys in by_file.items():
-        with safe_open(f"{model_dir}/{fname}", framework="np") as f:
+        # framework="pt": HF state_dict consumes torch tensors directly; the
+        # JAX side converts via .float().numpy() (np can't hold bf16 -> torch).
+        with safe_open(f"{model_dir}/{fname}", framework="pt") as f:
             for k in keys:
                 tensors[k] = f.get_tensor(k)
     return tensors, mappings
@@ -64,9 +66,7 @@ class TestGemma4VisionAlignment(CustomTestCase):
         # HF reference
         hf = Gemma4VisionModel(vcfg).to(torch.bfloat16).eval()
         tensors, mappings = _load_vision_weights(GEMMA4_31B_IT, vcfg.num_hidden_layers)
-        sd = {
-            k.removeprefix("model.vision_tower."): torch.from_numpy(v) for k, v in tensors.items()
-        }
+        sd = {k.removeprefix("model.vision_tower."): v for k, v in tensors.items()}
         hf.load_state_dict(sd, strict=True)
         with torch.no_grad():
             hf_out = (
@@ -82,7 +82,7 @@ class TestGemma4VisionAlignment(CustomTestCase):
         enc = Gemma4VisionEncoder(vcfg, dtype=jnp.bfloat16)
         state = nnx.state(enc)
         for k, dst in mappings.items():
-            w = tensors[k]
+            w = tensors[k].float().numpy()
             if dst.endswith(".kernel"):
                 w = w.T
             _set_by_path(state, dst, jnp.asarray(w))


### PR DESCRIPTION
## Summary

Follow-up to #1323 (Gemma4 text decoder), adding the vision tower so Gemma4-31B can do image understanding. Per the collaboration agreed in #1301, this layers on top of @hks-9697-v2's merged decoder; bidirectional sliding-window mask is left for a later PR.

4 commits:
1. **vision encoder + integration** — `multimodal/models/gemma4/vision_encoder.py` (27-layer ViT, 2D RoPE, learned 2D pos table, 3×3 pool, Gemma4MultimodalEmbedder); wires `Gemma4ForConditionalGeneration` with vision_tower + embed_vision + get_image_feature + vision weight loading.
2. **fix(multimodal)** — forward `mm_inputs` through tokenizer_manager (the GenerateReqInput.mm_inputs field + scheduler wiring landed in #1323 but the tokenizer_manager hop was missing, so image embeddings were silently dropped).
3. **fix(multimodal)** — add `mm_inputs` field to GenerateReqInput (FastAPI drops unknown JSON keys without it).
4. **test** — vision encoder alignment vs HF.

## How it works

Clients pass pre-computed vision embeddings via `{"input_ids": [...], "mm_inputs": {"multimodal_embedding": [[...]]}}`. The chain: GenerateReqInput.mm_inputs → tokenizer_manager → scheduler → Req.multimodal_embedding → ForwardBatch.input_embedding (already consumed by Gemma4Model from #1323).

## Validation (v6e-4 TP=4)

| Check | Result |
|---|---|
| Vision encoder vs HF Gemma4VisionModel | cos=0.9993 (280-token input) |
| E2E single image via /generate + mm_inputs | "A red rectangle is centered on a white background." (HF: "A solid red rectangle...", 1-token bf16 diff) |
| Text-only regression | unaffected ("...the capital of France is Paris.") |

## Not in scope
- Bidirectional sliding-window attention for vision tokens (@hks-9697-v2 to add on top)
- Server-side image intake (raw `image_data` → vision encode); current path is pre-computed embeddings via mm_inputs
- E2B/E4B audio, variable aspect ratio bucketing

cc @hks-9697-v2 (collaboration per #1301) — @cjx0709 could you review? (you reviewed the SWA/heterogeneous-head_dim infra on #1301)