### PR TITLE
fix(disaggregation): support multi-host TP processes in PD KV transfer

### DIFF
--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -311,9 +311,17 @@ class SchedulerDisaggregationDecodeMixin:
         padded_pages = _pad_to_page_bucket(num_pages)
         per_layer_tail = kv_pool.kv_buffer[0].shape[1:]
         shape = (kv_pool.layer_num, padded_pages) + per_layer_tail
-        base_spec = kv_pool.kv_sharding.spec
-        stacked_spec = PartitionSpec(None, *base_spec)
-        sharding = NamedSharding(kv_pool.kv_sharding.mesh, stacked_spec)
+        if jax.process_count() > 1:
+            # P registers a single fully-addressable buffer per host (see
+            # prefill._extract_req_kv); pull onto one local device and
+            # let _write_kv_to_pool reshard onto the pool mesh.
+            from jax.sharding import SingleDeviceSharding
+
+            sharding = SingleDeviceSharding(jax.local_devices()[0])
+        else:
+            base_spec = kv_pool.kv_sharding.spec
+            stacked_spec = PartitionSpec(None, *base_spec)
+            sharding = NamedSharding(kv_pool.kv_sharding.mesh, stacked_spec)
         return jax.ShapeDtypeStruct(shape, kv_pool.dtype, sharding=sharding)
 
     def _write_kv_to_pool(self: Scheduler, req: Req, kv_indices, kv: jax.Array) -> None:
@@ -328,6 +336,14 @@ class SchedulerDisaggregationDecodeMixin:
         from jax.sharding import NamedSharding, PartitionSpec
 
         kv_pool = self.token_to_kv_pool_allocator.get_kvcache()
+        if jax.process_count() > 1 and kv.is_fully_addressable:
+            # Each decode host pulled the same single-device buffer; lift
+            # it onto the pool mesh as replicated so the per-layer scatter
+            # below can reshard via out_sharding without cross-host gaps.
+            kv = jax.make_array_from_process_local_data(
+                NamedSharding(kv_pool.mesh, PartitionSpec()),
+                np.asarray(kv),
+            )
         page_size = kv_pool.page_size
         seqlen = len(req.origin_input_ids)
         num_pages = (seqlen + page_size - 1) // page_size

--- a/python/sgl_jax/srt/disaggregation/jax_transfer/wrapper.py
+++ b/python/sgl_jax/srt/disaggregation/jax_transfer/wrapper.py
@@ -154,6 +154,18 @@ class JaxTransferWrapper:
             raise RuntimeError(
                 "JaxTransferWrapper.start() must be called before " "register_pull()"
             )
+        sharding = getattr(data, "sharding", None)
+        if sharding is not None and not data.is_fully_addressable:
+            raise ValueError(
+                f"register_pull: array is sharded across "
+                f"{len(sharding.device_set)} devices but only "
+                f"{jax.local_device_count()} are local to this process. "
+                f"jax.experimental.transfer.await_pull only registers "
+                f"process-local shards, so a remote pull would receive "
+                f"partial/misaligned data. All-gather to a fully-"
+                f"addressable sharding first (see issue #1240 for the "
+                f"per-host coordination plan)."
+            )
         with self._pending_lock:
             if uuid in self._pending:
                 raise RuntimeError(

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -252,10 +252,18 @@ class SchedulerDisaggregationPrefillMixin:
             _np.asarray(page_id_source) // page_size,
             idx_sharding,
         )
-        # out_sharding describes the gather output, not the pool.
+        # out_sharding describes the gather output, not the pool. On a
+        # multi-host process the gather output MUST be fully addressable
+        # because jax.experimental.transfer only registers process-local
+        # shards (see wrapper.register_pull). All-gathering to replicated
+        # here is the cheapest correct path until per-host coordination
+        # (#1240) lands; the ICI all-gather is sub-millisecond at typical
+        # KV sizes.
         pool_pspec = kv_pool.kv_sharding.spec
-        gather_pspec = _P(None, *pool_pspec[1:])
-        gather_out_sharding = _NamedSharding(kv_pool.mesh, gather_pspec)
+        if jax.process_count() > 1:
+            gather_out_sharding = _NamedSharding(kv_pool.mesh, _P())
+        else:
+            gather_out_sharding = _NamedSharding(kv_pool.mesh, _P(None, *pool_pspec[1:]))
         layer_buffers = [
             kv_pool.get_kv_buffer(layer_id)
             for layer_id in range(
@@ -264,7 +272,11 @@ class SchedulerDisaggregationPrefillMixin:
             )
         ]
         layer_kvs = _jit_gather_all_layers(layer_buffers, page_indices, gather_out_sharding)
-        return jnp.stack(layer_kvs, axis=0)
+        stacked = jnp.stack(layer_kvs, axis=0)
+        if jax.process_count() > 1:
+            stacked.block_until_ready()
+            return stacked.addressable_data(0)
+        return stacked
 
     def _release_prefill_req_resources(self: Scheduler, req: Req) -> None:
         """Release prefill-side KV and request-pool resources."""

--- a/test/srt/disaggregation/test_wrapper.py
+++ b/test/srt/disaggregation/test_wrapper.py
@@ -163,6 +163,23 @@ def test_register_pull_rejects_duplicate_uuid():
     assert fake_server.await_pull.call_count == 2
 
 
+def test_register_pull_rejects_non_fully_addressable():
+    fake_server = mock.MagicMock()
+    with (
+        _shim_transfer_module(fake_server),
+        mock.patch.object(jtw_mod.jax, "local_devices", return_value=[mock.MagicMock()]),
+    ):
+        wrapper = JaxTransferWrapper("127.0.0.1", 31007)
+        wrapper.start()
+
+    arr = mock.MagicMock()
+    arr.is_fully_addressable = False
+    arr.sharding.device_set = {mock.MagicMock() for _ in range(8)}
+    with pytest.raises(ValueError, match="only registers process-local shards"):
+        wrapper.register_pull("mh", arr)
+    assert fake_server.await_pull.call_count == 0
+
+
 def test_singleton_rejects_rebinding():
     w1 = get_or_create_wrapper("10.0.0.1", 31010, channel_number=1)
     w2 = get_or_create_wrapper("10.0.0.1", 31010, channel_number=1)


### PR DESCRIPTION
# fix(disaggregation): support multi-host TP processes in PD KV transfer

Closes #1364

## Summary

`jax.experimental.transfer.await_pull` only registers process-local PJRT buffers. When the prefill process spans multiple hosts (`jax.process_count() > 1`), `_extract_req_kv` currently returns an array sharded on the full mesh, so each host's transfer server exposes only `1/N` of the KV and the decode pull either fails (`Async transfer object was deleted before transfers completed`) or — when shard counts happen to line up — returns misaligned data with no error.

This PR makes the existing single-endpoint transfer path correct on multi-host processes by:

1. **`jax_transfer/wrapper.py`** — `register_pull` raises with an actionable message when given a non-fully-addressable array, instead of letting the transfer layer fail opaquely.
2. **`prefill.py`** — on multi-host, `_extract_req_kv` gathers with `out_sharding=PartitionSpec()` (replicated) and returns `addressable_data(0)`, i.e. one fully-addressable buffer per host. Single-host behaviour is unchanged.
3. **`decode.py`** — on multi-host, `_build_kv_spec_for_req` pulls onto a single local device (matching the 1-buffer registration), and `_write_kv_to_pool` lifts the per-host single-device result onto the pool mesh as replicated before the existing per-layer scatter. Single-host behaviour is unchanged.

This is the minimal-change unblock; #1240 (per-host shard-aligned pull) remains the bandwidth-optimal follow-up.

## Cost

| step | multi-host added cost | measured (v7x, 320 MB bf16, 4-host P → 2-host D) |
|---|---|---|
| P ICI all-gather to replicated | `O(KV_bytes)` over ICI | 121–408 ms cold (jit compile); warm ≪ 1 ms |
| P→D DCN (unchanged, 1 host pair) | — | 62.3 ms = 5.1 GB/s |
| D `np.asarray` + `make_array_from_process_local_data` | one D2H + H2D of `KV_bytes` | not isolated; bounded by PCIe (~tens of ms at this size) |

For a 16K-token request on a 78-layer MLA model (~312 MB KV) the added cost is ≪ prefill time. The D-side D2H can be removed in a follow-up by assembling the global replicated array from device buffers directly; kept simple here.

## Testing

- [x] `pytest python/sgl_jax/test/disaggregation/ -v` (CPU, single-process — guard path not triggered)
- [x] Cross-process probe on 2 independent v7x slices (4-host P, 2-host D): without patch `Async transfer object was deleted`; with all-gather path **byte-equal** at 8 MB int32 and 320 MB bf16
- [ ] Multi-host `--disaggregation-mode prefill` + `--disaggregation-mode decode` end-to-end on a TP>local_device_count model (pending reviewer access to 2× multi-host slices; probe yaml attached in issue)

## Notes

- `is_fully_addressable` is used as the guard rather than `process_count() > 1` in `wrapper.py` so that future callers passing an already-gathered array on a multi-host process are not blocked.
- The prefill/decode branches key on `process_count() > 1` because the all-gather is unnecessary overhead on single-host and the existing behaviour there is already validated by #1299's L4.
