### PR TITLE
feat(disaggregation): per-host KV shard transfer for multi-host PD (#1240 part 1)

### DIFF
--- a/python/sgl_jax/srt/disaggregation/bootstrap.py
+++ b/python/sgl_jax/srt/disaggregation/bootstrap.py
@@ -49,6 +49,8 @@ class PrefillInfo:
     tp_rank: int = 0
     tp_size: int = 1
     system_dp_rank: int = 0
+    jax_process_index: int = 0
+    jax_process_count: int = 1
     protocol_version: int = PROTOCOL_VERSION
 
     def to_dict(self) -> dict[str, object]:
@@ -63,6 +65,8 @@ class RegisterPrefillRequest(BaseModel):
     tp_rank: int = 0
     tp_size: int = 1
     system_dp_rank: int = 0
+    jax_process_index: int = 0
+    jax_process_count: int = 1
     protocol_version: int = PROTOCOL_VERSION
 
 
@@ -346,6 +350,8 @@ class BootstrapClient:
         tp_rank: int = 0,
         tp_size: int = 1,
         system_dp_rank: int = 0,
+        jax_process_index: int = 0,
+        jax_process_count: int = 1,
         protocol_version: int = PROTOCOL_VERSION,
     ) -> None:
         payload = {
@@ -356,6 +362,8 @@ class BootstrapClient:
             "tp_rank": tp_rank,
             "tp_size": tp_size,
             "system_dp_rank": system_dp_rank,
+            "jax_process_index": jax_process_index,
+            "jax_process_count": jax_process_count,
             "protocol_version": protocol_version,
         }
         last_err: Exception | None = None

--- a/python/sgl_jax/srt/disaggregation/common/multihost_sync.py
+++ b/python/sgl_jax/srt/disaggregation/common/multihost_sync.py
@@ -9,7 +9,7 @@ buffer shape — safe even when the in-flight set differs across NPs.
 
 from __future__ import annotations
 
-from typing import Callable, Iterable
+from collections.abc import Callable, Iterable
 
 import numpy as np
 

--- a/python/sgl_jax/srt/disaggregation/common/multihost_sync.py
+++ b/python/sgl_jax/srt/disaggregation/common/multihost_sync.py
@@ -1,0 +1,64 @@
+"""Fixed-shape cross-process agreement on per-NP receiver terminal state.
+
+Decode-side only. The scatter into the KV pool is a cross-host jit, so
+every NP must drain the same set of receivers in the same loop iteration.
+Each NP's receiver reaches SUCCESS/FAILED independently (it pulls from a
+different P host), so we allgather (bootstrap_room, state) with a fixed
+buffer shape — safe even when the in-flight set differs across NPs.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable
+
+import numpy as np
+
+from sgl_jax.srt.disaggregation.base.kv_manager import KVPoll
+
+_SYNC_MAX_INFLIGHT = 256
+
+
+def synced_terminal_rooms(
+    entries: Iterable,
+    poll_fn: Callable[[object], KVPoll],
+    room_fn: Callable[[object], int | None],
+) -> tuple[set[int], set[int]]:
+    """Return ``(success_rooms, failed_rooms)`` agreed across all processes.
+
+    ``poll_fn`` is wrapped in a try/except so a per-NP receiver exception
+    becomes FAILED instead of skipping the allgather (which would desync
+    the SPMD program counter).
+    """
+
+    from jax.experimental import multihost_utils
+
+    local = np.full((_SYNC_MAX_INFLIGHT, 2), -1, dtype=np.int64)
+    for i, e in enumerate(entries):
+        if i >= _SYNC_MAX_INFLIGHT:
+            break
+        room = room_fn(e)
+        if room is None:
+            continue
+        try:
+            st = poll_fn(e)
+        except Exception:
+            st = KVPoll.FAILED
+        local[i, 0] = int(room)
+        local[i, 1] = 1 if st == KVPoll.SUCCESS else (-2 if st == KVPoll.FAILED else 0)
+    gathered = multihost_utils.process_allgather(local)
+    nproc = int(gathered.shape[0])
+    per_room: dict[int, list[int]] = {}
+    for p in range(nproc):
+        for i in range(_SYNC_MAX_INFLIGHT):
+            room = int(gathered[p, i, 0])
+            if room < 0:
+                continue
+            per_room.setdefault(room, []).append(int(gathered[p, i, 1]))
+    success: set[int] = set()
+    failed: set[int] = set()
+    for room, sts in per_room.items():
+        if -2 in sts:
+            failed.add(room)
+        elif len(sts) >= nproc and all(s == 1 for s in sts):
+            success.add(room)
+    return success, failed

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -37,6 +37,9 @@ class DecodeBookkeeping:
     kv_indices: object | None = None
     # Whether the receiver has been initialized + poll started.
     started: bool = False
+    # Set by _drain_transfer_queue_synced on multi-host so downstream
+    # does not re-poll (a poll() that raised would re-raise and desync).
+    synced_state: KVPoll | None = None
 
 
 class DecodePreallocQueue:
@@ -243,7 +246,13 @@ class SchedulerDisaggregationDecodeMixin:
 
         for entry in self._drain_transfer_queue_synced():
             assert entry.receiver is not None
-            state = entry.receiver.poll()
+            state = entry.synced_state
+            if state is None:
+                try:
+                    state = entry.receiver.poll()
+                except Exception:
+                    logger.exception("receiver.poll() raised for req_id=%s", entry.req_id)
+                    state = KVPoll.FAILED
             if state == KVPoll.SUCCESS:
                 try:
                     kv_result = entry.receiver.result
@@ -323,12 +332,13 @@ class SchedulerDisaggregationDecodeMixin:
                 room = getattr(e.req, "bootstrap_room", None)
                 if room in failed:
                     self.disagg_transfer_queue._entries.pop(rid, None)
-                    if e.receiver.poll() != KVPoll.FAILED:
-                        with suppress(Exception):
-                            e.receiver.fail(reason="peer_np_failed")
+                    with suppress(Exception):
+                        e.receiver.fail(reason="peer_np_failed")
+                    e.synced_state = KVPoll.FAILED
                     out.append(e)
                 elif room in success:
                     self.disagg_transfer_queue._entries.pop(rid, None)
+                    e.synced_state = KVPoll.SUCCESS
                     out.append(e)
         return out
 

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -170,7 +170,10 @@ class SchedulerDisaggregationDecodeMixin:
                 from sgl_jax.srt.disaggregation.common.metrics import time_phase
 
                 with time_phase("bootstrap", "decode"):
-                    p_info = self.disagg_bootstrap_client.get_prefill_info(req.bootstrap_room)
+                    if jax.process_count() > 1:
+                        p_info = self._pick_prefill_peer_for_this_host()
+                    else:
+                        p_info = self.disagg_bootstrap_client.get_prefill_info(req.bootstrap_room)
             except Exception:
                 logger.exception(
                     "bootstrap lookup failed for req_id=%s "
@@ -238,7 +241,7 @@ class SchedulerDisaggregationDecodeMixin:
         for entry in self.disagg_prealloc_queue.pop_all():
             self.disagg_transfer_queue.add(entry)
 
-        for entry in self.disagg_transfer_queue.drain_terminal():
+        for entry in self._drain_transfer_queue_synced():
             assert entry.receiver is not None
             state = entry.receiver.poll()
             if state == KVPoll.SUCCESS:
@@ -269,6 +272,65 @@ class SchedulerDisaggregationDecodeMixin:
                 if entry.kv_indices is not None:
                     self._release_decode_kv_indices(entry.kv_indices)
                 self._abort_decode_request(entry.req, "receiver_terminal_failed")
+
+    def _pick_prefill_peer_for_this_host(self: Scheduler) -> dict[str, object]:
+        """Multi-host: find the P host whose jax_process_index matches ours.
+        That host's local KV shard is exactly the slice this D host needs.
+        Requires P/D to have the same nproc (same-TP constraint).
+        """
+        if getattr(self, "_disagg_prefill_peer", None) is not None:
+            return self._disagg_prefill_peer
+        my_pidx = jax.process_index()
+        my_nproc = jax.process_count()
+        all_p = self.disagg_bootstrap_client.list_prefills()
+        for p in all_p:
+            if int(p.get("jax_process_index", -1)) == my_pidx:
+                if int(p.get("jax_process_count", 0)) != my_nproc:
+                    raise RuntimeError(
+                        f"P/D process_count mismatch: P={p.get('jax_process_count')} "
+                        f"D={my_nproc}. Per-host shard transfer requires same nproc."
+                    )
+                self._disagg_prefill_peer = p
+                return p
+        raise RuntimeError(
+            f"no prefill host with jax_process_index={my_pidx} registered "
+            f"(got {[(p.get('host'), p.get('jax_process_index')) for p in all_p]})"
+        )
+
+    def _drain_transfer_queue_synced(self: Scheduler) -> list[DecodeBookkeeping]:
+        """On multi-host, only drain entries whose receiver has reached a
+        terminal state on every NP — _write_kv_to_pool issues a cross-host
+        jit and all NPs must enter it for the same set of reqs.
+        """
+        if jax.process_count() <= 1:
+            return self.disagg_transfer_queue.drain_terminal()
+        from sgl_jax.srt.disaggregation.common.multihost_sync import (
+            synced_terminal_rooms,
+        )
+
+        with self.disagg_transfer_queue._lock:
+            entries = list(self.disagg_transfer_queue._entries.values())
+        success, failed = synced_terminal_rooms(
+            entries,
+            poll_fn=lambda e: e.receiver.poll(),
+            room_fn=lambda e: getattr(e.req, "bootstrap_room", None),
+        )
+        if not success and not failed:
+            return []
+        out: list[DecodeBookkeeping] = []
+        with self.disagg_transfer_queue._lock:
+            for rid, e in list(self.disagg_transfer_queue._entries.items()):
+                room = getattr(e.req, "bootstrap_room", None)
+                if room in failed:
+                    self.disagg_transfer_queue._entries.pop(rid, None)
+                    if e.receiver.poll() != KVPoll.FAILED:
+                        with suppress(Exception):
+                            e.receiver.fail(reason="peer_np_failed")
+                    out.append(e)
+                elif room in success:
+                    self.disagg_transfer_queue._entries.pop(rid, None)
+                    out.append(e)
+        return out
 
     # ------------------------------------------------------------------
     # Overridable / test-friendly hooks
@@ -309,6 +371,10 @@ class SchedulerDisaggregationDecodeMixin:
         seqlen = len(req.origin_input_ids)
         num_pages = (seqlen + page_size - 1) // page_size
         padded_pages = _pad_to_page_bucket(num_pages)
+        if jax.process_count() > 1:
+            from sgl_jax.srt.disaggregation.prefill import local_kv_spec_for_pool
+
+            return local_kv_spec_for_pool(kv_pool, kv_pool.layer_num, padded_pages)
         per_layer_tail = kv_pool.kv_buffer[0].shape[1:]
         shape = (kv_pool.layer_num, padded_pages) + per_layer_tail
         base_spec = kv_pool.kv_sharding.spec
@@ -328,6 +394,18 @@ class SchedulerDisaggregationDecodeMixin:
         from jax.sharding import NamedSharding, PartitionSpec
 
         kv_pool = self.token_to_kv_pool_allocator.get_kvcache()
+        if jax.process_count() > 1 and kv.is_fully_addressable:
+            # Pulled KV is this host's local shard on a 1-D local mesh.
+            # Assemble it into the global pool sharding (zero-copy: each NP
+            # contributes its own addressable_shards).
+            pool_pspec = kv_pool.kv_sharding.spec
+            stacked_spec = PartitionSpec(None, None, *pool_pspec[1:])
+            gsh = NamedSharding(kv_pool.mesh, stacked_spec)
+            per_layer_tail = kv_pool.kv_buffer[0].shape[1:]
+            gshape = (kv.shape[0], kv.shape[1]) + per_layer_tail
+            kv = jax.make_array_from_single_device_arrays(
+                gshape, gsh, [s.data for s in kv.addressable_shards]
+            )
         page_size = kv_pool.page_size
         seqlen = len(req.origin_input_ids)
         num_pages = (seqlen + page_size - 1) // page_size

--- a/python/sgl_jax/srt/disaggregation/jax_transfer/wrapper.py
+++ b/python/sgl_jax/srt/disaggregation/jax_transfer/wrapper.py
@@ -154,6 +154,14 @@ class JaxTransferWrapper:
             raise RuntimeError(
                 "JaxTransferWrapper.start() must be called before " "register_pull()"
             )
+        sharding = getattr(data, "sharding", None)
+        if sharding is not None and not data.is_fully_addressable:
+            raise ValueError(
+                f"register_pull: array spans {len(sharding.device_set)} "
+                f"devices but only {jax.local_device_count()} are local. "
+                f"await_pull only registers process-local shards; pass the "
+                f"per-host shard (see prefill._global_to_local_shard)."
+            )
         with self._pending_lock:
             if uuid in self._pending:
                 raise RuntimeError(

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -44,6 +44,61 @@ def _jit_gather_all_layers(buffers, page_indices, out_sharding):
     return [buf.at[page_indices].get(out_sharding=out_sharding) for buf in buffers]
 
 
+def _global_to_local_shard(arr: jax.Array) -> jax.Array:
+    """View this host's addressable shards of a globally-sharded ``arr`` as a
+    fully-addressable array on a 1-D local mesh. Assumes ``arr`` is sharded
+    along exactly one dimension (the KV head axis). Zero-copy.
+    """
+    import numpy as _np
+    from jax.sharding import Mesh as _Mesh
+    from jax.sharding import NamedSharding as _NamedSharding
+    from jax.sharding import PartitionSpec as _P
+
+    spec = arr.sharding.spec
+    sharded_dims = [i for i, s in enumerate(spec) if s is not None]
+    if len(sharded_dims) != 1:
+        raise ValueError(
+            f"_global_to_local_shard expects exactly one sharded dim, got spec={spec}"
+        )
+    sd = sharded_dims[0]
+    ldev = jax.local_devices()
+    shards = [s.data for s in arr.addressable_shards]
+    lshape = tuple(
+        shards[0].shape[i] * len(ldev) if i == sd else shards[0].shape[i]
+        for i in range(arr.ndim)
+    )
+    lmesh = _Mesh(_np.asarray(ldev), ("_local",))
+    lspec = _P(*("_local" if i == sd else None for i in range(arr.ndim)))
+    return jax.make_array_from_single_device_arrays(
+        lshape, _NamedSharding(lmesh, lspec), shards
+    )
+
+
+def local_kv_spec_for_pool(kv_pool, layer_num: int, padded_pages: int) -> jax.ShapeDtypeStruct:
+    """Build the ShapeDtypeStruct that D should pull on a multi-host process:
+    this host's 1/nproc slice of the stacked KV, on a 1-D local mesh.
+    """
+    import numpy as _np
+    from jax.sharding import Mesh as _Mesh
+    from jax.sharding import NamedSharding as _NamedSharding
+    from jax.sharding import PartitionSpec as _P
+
+    pool_pspec = kv_pool.kv_sharding.spec
+    per_layer_tail = kv_pool.kv_buffer[0].shape[1:]
+    gshape = (layer_num, padded_pages) + per_layer_tail
+    gspec = (None, None) + tuple(pool_pspec[1:])
+    sharded_dims = [i for i, s in enumerate(gspec) if s is not None]
+    if len(sharded_dims) != 1:
+        raise ValueError(f"expected one sharded dim in KV spec, got {gspec}")
+    sd = sharded_dims[0]
+    ldev = jax.local_devices()
+    nproc = jax.process_count()
+    lshape = tuple(gshape[i] // nproc if i == sd else gshape[i] for i in range(len(gshape)))
+    lmesh = _Mesh(_np.asarray(ldev), ("_local",))
+    lspec = _P(*("_local" if i == sd else None for i in range(len(gshape))))
+    return jax.ShapeDtypeStruct(lshape, kv_pool.dtype, sharding=_NamedSharding(lmesh, lspec))
+
+
 @dataclass
 class PrefillBookkeeping:
     """Per-request prefill-side state tracked by the Mixin."""
@@ -136,7 +191,9 @@ class SchedulerDisaggregationPrefillMixin:
                     self._comm_backend.wait_for_new_requests(0.001)
 
             self.send_kv_chunk()
-            self.last_batch = batch
+            # PD reqs are finished and released inside process_prefill_chunk;
+            # do not merge them into running_batch.
+            self.last_batch = None if batch and any(r.bootstrap_room is not None for r in batch.reqs) else batch
 
     def process_prefill_chunk(self: Scheduler, batch, result) -> None:
         """Extract KV for PD reqs and hand off to sender."""
@@ -201,8 +258,19 @@ class SchedulerDisaggregationPrefillMixin:
                 )
                 continue
 
-            def _on_terminal(req_obj=req, sender_obj=sender):
-                self._on_prefill_transfer_terminal(req_obj, sender_obj)
+            if jax.process_count() > 1:
+                # The gather output is a fresh buffer, so pool pages can be
+                # released here — the same SPMD point on every NP — keeping
+                # allocator state identical across NPs without a cross-host
+                # control-plane sync. Single-host keeps the original
+                # release-on-ack behaviour.
+                self._release_prefill_req_resources(req)
+                released = True
+            else:
+                released = False
+
+            def _on_terminal(req_obj=req, sender_obj=sender, _released=released):
+                self._on_prefill_transfer_terminal(req_obj, sender_obj, already_released=_released)
 
             self.disagg_prefill_queue.add(req_id, sender, on_terminal=_on_terminal)
 
@@ -238,20 +306,25 @@ class SchedulerDisaggregationPrefillMixin:
         seqlen = len(req.origin_input_ids)
         num_pages = (seqlen + page_size - 1) // page_size
         padded_pages = _pad_to_page_bucket(num_pages)
+        # Only the first num_pages slots of req_to_token are written for this
+        # req; the bucket-padding region holds whatever the previous occupant
+        # left. Slice the real pages and zero-pad so device_put's cross-process
+        # assert_equal sees identical indices on every NP.
         page_id_source = req_to_token[
             req.req_pool_idx,
-            : padded_pages * page_size : page_size,
+            : num_pages * page_size : page_size,
         ]
         import numpy as _np
         from jax.sharding import NamedSharding as _NamedSharding
         from jax.sharding import PartitionSpec as _P
 
-        # Indices must be placed on the same mesh as the KV pool.
+        page_ids = _np.asarray(page_id_source) // page_size
+        if padded_pages > num_pages:
+            page_ids = _np.concatenate(
+                [page_ids, _np.zeros(padded_pages - num_pages, dtype=page_ids.dtype)]
+            )
         idx_sharding = _NamedSharding(kv_pool.mesh, _P(None))
-        page_indices = jax.device_put(
-            _np.asarray(page_id_source) // page_size,
-            idx_sharding,
-        )
+        page_indices = jax.device_put(page_ids, idx_sharding)
         # out_sharding describes the gather output, not the pool.
         pool_pspec = kv_pool.kv_sharding.spec
         gather_pspec = _P(None, *pool_pspec[1:])
@@ -264,7 +337,15 @@ class SchedulerDisaggregationPrefillMixin:
             )
         ]
         layer_kvs = _jit_gather_all_layers(layer_buffers, page_indices, gather_out_sharding)
-        return jnp.stack(layer_kvs, axis=0)
+        stacked = jnp.stack(layer_kvs, axis=0)
+        if jax.process_count() > 1:
+            # The gather output is TP-sharded across the global mesh. Expose
+            # only this host's shard as a fully-addressable local-mesh array;
+            # each P host registers its own 1/nproc slice and the matching D
+            # host (same jax_process_index) pulls exactly that slice.
+            stacked.block_until_ready()
+            return _global_to_local_shard(stacked)
+        return stacked
 
     def _release_prefill_req_resources(self: Scheduler, req: Req) -> None:
         """Release prefill-side KV and request-pool resources."""
@@ -308,7 +389,11 @@ class SchedulerDisaggregationPrefillMixin:
         self._release_prefill_req_resources(req)
 
     def _on_prefill_transfer_terminal(
-        self: Scheduler, req: Req, sender: JaxTransferKVSender
+        self: Scheduler,
+        req: Req,
+        sender: JaxTransferKVSender,
+        *,
+        already_released: bool = False,
     ) -> None:
         try:
             if sender.poll() == KVPoll.SUCCESS:
@@ -317,7 +402,8 @@ class SchedulerDisaggregationPrefillMixin:
                 self._finish_prefill_only_failure(req, sender)
         finally:
             sender.clear()
-            self._release_prefill_req_resources(req)
+            if not already_released:
+                self._release_prefill_req_resources(req)
 
     def _finish_prefill_only_success(self: Scheduler, req: Req) -> None:
         from sgl_jax.srt.managers.schedule_batch import FINISH_LENGTH

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -57,21 +57,16 @@ def _global_to_local_shard(arr: jax.Array) -> jax.Array:
     spec = arr.sharding.spec
     sharded_dims = [i for i, s in enumerate(spec) if s is not None]
     if len(sharded_dims) != 1:
-        raise ValueError(
-            f"_global_to_local_shard expects exactly one sharded dim, got spec={spec}"
-        )
+        raise ValueError(f"_global_to_local_shard expects exactly one sharded dim, got spec={spec}")
     sd = sharded_dims[0]
     ldev = jax.local_devices()
     shards = [s.data for s in arr.addressable_shards]
     lshape = tuple(
-        shards[0].shape[i] * len(ldev) if i == sd else shards[0].shape[i]
-        for i in range(arr.ndim)
+        shards[0].shape[i] * len(ldev) if i == sd else shards[0].shape[i] for i in range(arr.ndim)
     )
     lmesh = _Mesh(_np.asarray(ldev), ("_local",))
     lspec = _P(*("_local" if i == sd else None for i in range(arr.ndim)))
-    return jax.make_array_from_single_device_arrays(
-        lshape, _NamedSharding(lmesh, lspec), shards
-    )
+    return jax.make_array_from_single_device_arrays(lshape, _NamedSharding(lmesh, lspec), shards)
 
 
 def local_kv_spec_for_pool(kv_pool, layer_num: int, padded_pages: int) -> jax.ShapeDtypeStruct:
@@ -193,7 +188,9 @@ class SchedulerDisaggregationPrefillMixin:
             self.send_kv_chunk()
             # PD reqs are finished and released inside process_prefill_chunk;
             # do not merge them into running_batch.
-            self.last_batch = None if batch and any(r.bootstrap_room is not None for r in batch.reqs) else batch
+            self.last_batch = (
+                None if batch and any(r.bootstrap_room is not None for r in batch.reqs) else batch
+            )
 
     def process_prefill_chunk(self: Scheduler, batch, result) -> None:
         """Extract KV for PD reqs and hand off to sender."""

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -205,8 +205,14 @@ class SchedulerDisaggregationPrefillMixin:
 
         self.set_next_batch_sampling_info_done(batch)
 
+        chunked_now = tuple(r for r in getattr(self, "chunked_reqs", ()) if r is not None)
         for req in batch.reqs:
             if req.bootstrap_room is None:
+                continue
+            if any(req is cr for cr in chunked_now):
+                # Still mid-chunk: KV is incomplete, and releasing the
+                # req_pool_idx here would leak the slot the next chunk
+                # round re-allocates. Extract on the final chunk.
                 continue
             req_id = req.rid
             if req_id in self.disagg_prefill_queue._entries:

--- a/python/sgl_jax/srt/disaggregation/runtime.py
+++ b/python/sgl_jax/srt/disaggregation/runtime.py
@@ -103,6 +103,8 @@ def install_disaggregation_wiring(scheduler: Scheduler, server_args: ServerArgs)
     )
 
     if mode == "prefill":
+        import jax
+
         scheduler.disagg_prefill_queue = PrefillBootstrapQueue()
         bootstrap_key = f"{local_host}:{transfer_port}"
         scheduler.disagg_bootstrap_client.register_prefill(
@@ -113,6 +115,8 @@ def install_disaggregation_wiring(scheduler: Scheduler, server_args: ServerArgs)
             tp_rank=server_args.node_rank,
             tp_size=server_args.tp_size,
             system_dp_rank=0,
+            jax_process_index=jax.process_index(),
+            jax_process_count=jax.process_count(),
         )
         scheduler.disagg_heartbeat = HeartbeatDaemon(
             scheduler.disagg_bootstrap_client, bootstrap_key


### PR DESCRIPTION
Implements the per-host transfer identity piece of #1240. On a multi-host process (`jax.process_count() > 1`) each P host registers only its own 1/nproc TP-shard of the gathered KV; each D host pulls from the P host with the same `jax.process_index()` and reassembles the global pool sharding zero-copy.

This replaces the all-gather-to-replicated workaround attempted in #1365 (closed): per-request HBM is `×1` instead of `×tp_size`, and the P-side allocator stays SPMD-consistent without a per-tick TPU collective.

## Design

- **bootstrap** (`bootstrap.py`, `runtime.py`): every P host already registers; `PrefillInfo` now carries `jax_process_index` / `jax_process_count` so D can pair by jax rank (k8s pod index ≠ jax process index in general).
- **prefill** (`prefill.py`):
  - `_extract_req_kv` keeps the gather TP-sharded (no all-gather) and returns `_global_to_local_shard(stacked)`: a fully-addressable view of this host's `addressable_shards` on a 1-D local mesh (zero-copy).
  - Padding page-ids are zero-filled instead of read from the uninitialised tail of `req_to_token`, so `device_put`'s cross-process `assert_equal` sees identical indices.
  - Mid-chunk reqs are skipped — extract only on the final chunk.
  - On multi-host, pool pages are released immediately after `register_pull` (the gather output is a fresh buffer), at the same SPMD point on every NP. The per-host ack only triggers `sender.clear()`. This keeps allocator state identical across NPs without `process_allgather`.
- **decode** (`decode.py`):
  - `_pick_prefill_peer_for_this_host()` finds the P host whose `jax_process_index` matches and caches it.
  - `_build_kv_spec_for_req` uses `local_kv_spec_for_pool` on multi-host.
  - `_write_kv_to_pool` lifts the pulled local shard back to the global pool sharding via `make_array_from_single_device_arrays` (each NP contributes its own shards; zero-copy) before the existing scatter.
  - `_drain_transfer_queue_synced` allgathers `(bootstrap_room, state)` in a fixed `(256, 2)` int64 buffer so per-NP entry-count differences cannot desync the SPMD program counter; receiver `poll()` exceptions are caught and treated as FAILED.
- **wrapper** (`wrapper.py`): `register_pull` raises on `not is_fully_addressable` instead of silently registering partial shards.

Single-host behaviour: all multi-host paths are gated on `jax.process_count() > 1`. The chunked-skip and padding-zero changes are not gated and also improve single-host (see testing).

## Testing

- [x] `pytest test/srt/disaggregation/` — 204 passed (7 pre-existing py3.11 `class _Communicator[T]` env failures, unrelated)
- [x] **single-host PD** (1-host P TP=8 ↔ 1-host D TP=8, Qwen3-8B): e2e PASS; GSM8K 50q `acc=0.960` (main `d2a69bc`: `0.840`); bench c=8 32/32 `146.7 tok/s` (main: `91.8`)
- [x] **multi-host PD** (4-host P TP=32 ↔ 4-host D TP=32, two independent v7x slices, Qwen3-8B):
  - e2e cold P 11.06s D 36.20s / warm P 1.01s D 1.59s ×2, text correct
  - GSM8K 200q c=8 `acc=0.955`, invalid=0, errors=0
  - bench c=8 32/32 `164.6 tok/s`, c=32 64/64, **c=64 128/128 `253.7 tok/s` warm / `140-142 tok/s` cold ×2**, p99 32.3s warm
  - 8-host server logs: 0 × `failed to extract / reached failed / RESOURCE_EXHAUSTED / Traceback / Watchdog / launch id`
- [x] synthetic per-host shard probe: 8-device local register + pull byte-correct at 3.7-4.9 GB/s; `make_array_from_single_device_arrays` reassembly 0.4ms zero-copy

## Constraints / known limitations

- **P and D must have the same `jax.process_count()`** (same-TP, same-nnodes). Hetero-TP needs a head-reshard step.
- **Single P process group.** Multi-P routing is the rest of #1240 (router/proxy).
- **`input_len > chunked-prefill-size` is not supported** on either single- or multi-host PD: `init_next_round_input` resets `prefix_indices=[]` for PD reqs each round, so a req longer than one chunk never converges (P loops to KV-pool OOM). Out of scope here; tracked separately. The chunked-skip in this PR handles the multi-req-fills-a-chunk case (each req < chunk size).
