### PR TITLE
feat(qwen3.5): add dense Qwen3.5 (0.8B-27B), validated on 27B

### DIFF
--- a/python/sgl_jax/srt/configs/qwen3_5.py
+++ b/python/sgl_jax/srt/configs/qwen3_5.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from transformers.configuration_utils import PretrainedConfig
 
-__all__ = ["Qwen3_5HybridConfig", "get_qwen3_5_hybrid_config"]
+__all__ = ["Qwen3_5HybridConfig", "Qwen3_5DenseConfig", "get_qwen3_5_hybrid_config"]
 
 
 class _Qwen3_5TextConfig(PretrainedConfig):
@@ -64,11 +64,13 @@ class _Qwen3_5TextConfig(PretrainedConfig):
         linear_value_head_dim: int = 128,
         linear_num_key_heads: int = 16,
         linear_num_value_heads: int = 32,
-        # MoE fields.
-        moe_intermediate_size: int = 512,
-        shared_expert_intermediate_size: int = 512,
-        num_experts_per_tok: int = 8,
-        num_experts: int = 256,
+        # FFN: dense ships ``intermediate_size``; MoE ships the ``moe_*`` /
+        # ``num_experts*`` block. Both default to ``None`` so ``is_moe`` is unambiguous.
+        intermediate_size: int | None = None,
+        moe_intermediate_size: int | None = None,
+        shared_expert_intermediate_size: int | None = None,
+        num_experts_per_tok: int | None = None,
+        num_experts: int | None = None,
         router_aux_loss_coef: float = 0.001,
         mlp_only_layers: list[int] | None = None,
         # MTP (multi-token prediction) — not used by base inference but
@@ -131,7 +133,8 @@ class _Qwen3_5TextConfig(PretrainedConfig):
         self.linear_num_key_heads = linear_num_key_heads
         self.linear_num_value_heads = linear_num_value_heads
 
-        # MoE.
+        # FFN.
+        self.intermediate_size = intermediate_size
         self.moe_intermediate_size = moe_intermediate_size
         self.shared_expert_intermediate_size = shared_expert_intermediate_size
         self.num_experts_per_tok = num_experts_per_tok
@@ -148,6 +151,12 @@ class _Qwen3_5TextConfig(PretrainedConfig):
             eos_token_id=eos_token_id,
             **kwargs,
         )
+
+    @property
+    def is_moe(self) -> bool:
+        """Single dense/MoE discriminator. MoE configs always declare
+        ``num_experts``; dense configs omit it (defaults to ``None``)."""
+        return self.num_experts is not None
 
     @property
     def full_attention_layer_ids(self) -> list[int]:
@@ -231,12 +240,23 @@ class Qwen3_5HybridConfig(PretrainedConfig):
         super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
 
 
+class Qwen3_5DenseConfig(Qwen3_5HybridConfig):
+    """Dense Qwen3.5 (0.8B–27B): identical to ``Qwen3_5HybridConfig`` but for
+    ``model_type``. Dense/MoE share the backbone; only the FFN differs, keyed off
+    ``text_config.is_moe``. The text sub-config is reused as-is (its own
+    ``model_type`` string is never read).
+    """
+
+    model_type = "qwen3_5"
+
+
 def get_qwen3_5_hybrid_config(hf_config: Any) -> Qwen3_5HybridConfig | None:
     """Return the hf_config cast to ``Qwen3_5HybridConfig``, else ``None``.
 
     Mirrors ``get_kimi_linear_config`` / ``get_bailing_hybrid_config`` so
-    the runner can dispatch via duck-typing.
+    the runner can dispatch via duck-typing. Matches both the MoE
+    (``qwen3_5_moe``) and dense (``qwen3_5``) root model types.
     """
-    if getattr(hf_config, "model_type", None) == "qwen3_5_moe":
+    if getattr(hf_config, "model_type", None) in {"qwen3_5_moe", "qwen3_5"}:
         return hf_config
     return None

--- a/python/sgl_jax/srt/hf_transformers_utils.py
+++ b/python/sgl_jax/srt/hf_transformers_utils.py
@@ -24,7 +24,7 @@ from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_N
 from sgl_jax.srt.configs.bailing_hybrid import BailingHybridConfig
 from sgl_jax.srt.configs.gemma4 import Gemma4Config
 from sgl_jax.srt.configs.kimi_linear import KimiLinearConfig
-from sgl_jax.srt.configs.qwen3_5 import Qwen3_5HybridConfig
+from sgl_jax.srt.configs.qwen3_5 import Qwen3_5DenseConfig, Qwen3_5HybridConfig
 from sgl_jax.srt.managers.tiktoken_tokenizer import TiktokenTokenizer
 from sgl_jax.srt.utils.common_utils import is_remote_url, lru_cache_frozenset
 
@@ -44,6 +44,7 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = {
         KimiLinearConfig,
         GlmMoeDsaConfig,
         Qwen3_5HybridConfig,
+        Qwen3_5DenseConfig,
         Gemma4Config,
     ]
 }
@@ -60,10 +61,12 @@ for name, cls in _CONFIG_REGISTRY.items():
     with contextlib.suppress(ValueError):
         AutoConfig.register(name, cls)
 
-# Qwen3.5 is the exception: stock transformers >=5.3 owns ``qwen3_5_moe`` so the
-# loop skips ours, but ours isn't interchangeable (flattens rope_parameters +
-# exposes the hybrid/GDN interface the runner needs). Force ours to win.
+# Qwen3.5 is the exception: stock transformers >=5.3 owns ``qwen3_5_moe`` /
+# ``qwen3_5`` so the loop skips ours, but ours isn't interchangeable (flattens
+# rope_parameters + exposes the hybrid/GDN interface the runner needs). Force
+# ours to win for both the MoE and dense root model types.
 AutoConfig.register("qwen3_5_moe", Qwen3_5HybridConfig, exist_ok=True)
+AutoConfig.register("qwen3_5", Qwen3_5DenseConfig, exist_ok=True)
 
 
 _UNSET = object()

--- a/python/sgl_jax/srt/layers/routed_experts_capturer.py
+++ b/python/sgl_jax/srt/layers/routed_experts_capturer.py
@@ -31,6 +31,44 @@ def get_array_size_bytes(t: np.ndarray):
     return np.prod(t.shape) * t.dtype.itemsize
 
 
+# Routed-expert metadata field names vary across HF model families, and may live
+# on the root config or a nested text config. Total experts: ``num_experts``
+# (Qwen), ``n_routed_experts`` (GLM/DeepSeek/MiMo), ``num_local_experts``
+# (MiniMax/Grok). Routing top-k: ``num_experts_per_tok``, ``num_experts_per_token``
+# (Kimi), or ``top_k_experts`` (Gemma4). Plain ``top_k`` is sampling top-k, not
+# routing — never use it here.
+_TOTAL_EXPERT_FIELDS = ("num_experts", "n_routed_experts", "num_local_experts")
+_TOPK_EXPERT_FIELDS = ("num_experts_per_tok", "num_experts_per_token", "top_k_experts")
+
+
+def _first_present_attr(configs, names):
+    for cfg in configs:
+        if cfg is None:
+            continue
+        for name in names:
+            value = getattr(cfg, name, None)
+            if value is not None:
+                return value
+    return None
+
+
+def get_routed_expert_count(model_config):
+    """Total routed experts across name aliases and root/text config; ``None`` if
+    the model is router-less (dense)."""
+    return _first_present_attr(
+        (getattr(model_config, "hf_text_config", None), getattr(model_config, "hf_config", None)),
+        _TOTAL_EXPERT_FIELDS,
+    )
+
+
+def get_routed_experts_per_token(model_config):
+    """Routing top-k across name aliases and root/text config; ``None`` if router-less."""
+    return _first_present_attr(
+        (getattr(model_config, "hf_text_config", None), getattr(model_config, "hf_config", None)),
+        _TOPK_EXPERT_FIELDS,
+    )
+
+
 class RoutedExpertsCapturer(ABC):
     @staticmethod
     def create(
@@ -50,6 +88,16 @@ class RoutedExpertsCapturer(ABC):
         physical_expert_counts: int = 256,
     ):
         if enable or enable_balance_debug or enable_dist_recorder:
+            # Router-less (dense) models expose no expert-count field under any
+            # known alias; the real capturer would size buffers from a None
+            # top-k and crash. Fail clearly instead.
+            if get_routed_expert_count(model_config) is None:
+                raise ValueError(
+                    "Routed-experts capture flags (--enable-return-routed-experts / "
+                    "--enable-expert-balance-debug / --enable-expert-distribution-recorder) "
+                    "require a MoE model; this model is router-less (no num_experts / "
+                    "n_routed_experts / num_local_experts)."
+                )
             return _RoutedExpertsCapturerReal(
                 model_config,
                 mesh=mesh,
@@ -118,7 +166,7 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         self.mesh = mesh
         self.enable_host_buffer = enable_host_buffer
         self.num_hidden_layers = model_config.hf_text_config.num_hidden_layers
-        self.num_experts_per_tok = model_config.hf_text_config.num_experts_per_tok
+        self.num_experts_per_tok = get_routed_experts_per_token(model_config)
         self.num_tokens = num_tokens
         self.max_padding = max_padding
 

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -18,6 +18,7 @@ from sgl_jax.srt.eplb.expert_location import (
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessorOutput
 from sgl_jax.srt.layers.routed_experts_capturer import (
     RoutedExpertsCapturer,
+    get_routed_expert_count,
     set_global_experts_capturer,
 )
 from sgl_jax.srt.layers.sampler import Sampler, compute_logprobs
@@ -179,7 +180,7 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                 dist_recorder_buffer_size=self.server_args.expert_distribution_recorder_buffer_size,
                 dist_recorder_output_file=self.server_args.expert_distribution_recorder_output_file,
                 physical_expert_counts=self.server_args.ep_num_redundant_experts
-                + getattr(self.model_config.hf_config, "num_experts", 0),
+                + (get_routed_expert_count(self.model_config) or 0),
             )
         )
 

--- a/python/sgl_jax/srt/models/qwen3_5.py
+++ b/python/sgl_jax/srt/models/qwen3_5.py
@@ -424,13 +424,25 @@ class Qwen3_5DecoderLayer(nnx.Module):
     ):
         text_cfg = config.text_config
         self.is_full_attn = layer_id in text_cfg.full_attention_layer_ids
+        self.is_moe = text_cfg.is_moe
 
         if self.is_full_attn:
             self.self_attn = Qwen3_5Attention(config, mesh, layer_id, dtype=dtype)
         else:
             self.self_attn = Qwen3_5GatedDeltaNet(config, mesh, layer_id, dtype=dtype)
 
-        self.mlp = Qwen3_5MoeBlock(config, mesh, layer_id, dtype=dtype)
+        if self.is_moe:
+            self.mlp = Qwen3_5MoeBlock(config, mesh, layer_id, dtype=dtype)
+        else:
+            # Dense: plain SwiGLU (Qwen2MoeMLP doubles as the column/row-parallel MLP).
+            self.mlp = Qwen2MoeMLP(
+                hidden_size=text_cfg.hidden_size,
+                intermediate_size=text_cfg.intermediate_size,
+                mesh=mesh,
+                layer_id=layer_id,
+                dtype=dtype,
+                gate_up_down_bias=False,
+            )
         self.input_layernorm = GemmaRMSNorm(text_cfg.hidden_size, epsilon=text_cfg.rms_norm_eps)
         self.post_attention_layernorm = GemmaRMSNorm(
             text_cfg.hidden_size, epsilon=text_cfg.rms_norm_eps
@@ -464,7 +476,12 @@ class Qwen3_5DecoderLayer(nnx.Module):
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
 
-        hidden_states, topk_ids = self.mlp(hidden_states, forward_batch, dispatch_info)
+        # MoE MLP consumes routing info and returns topk_ids; dense takes only hidden.
+        if self.is_moe:
+            hidden_states, topk_ids = self.mlp(hidden_states, forward_batch, dispatch_info)
+        else:
+            hidden_states = self.mlp(hidden_states)
+            topk_ids = None
         return hidden_states, residual, attn_state, topk_ids
 
 
@@ -518,7 +535,9 @@ class Qwen3_5MoeModel(nnx.Module):
                 rec_buf, conv_buf_list = attn_state
                 layers_rec_buffers.append(rec_buf)
                 layers_conv_buffers.append(conv_buf_list)
-            layers_topk_ids.append(topk_ids)
+            # Dense yields topk_ids=None; keep the list MoE-only (no-op EPLB for dense).
+            if topk_ids is not None:
+                layers_topk_ids.append(topk_ids)
 
         if residual is not None:
             hidden_states = hidden_states + residual
@@ -679,6 +698,7 @@ class Qwen3_5MoeForConditionalGeneration(nnx.Module):
         tc = hf_config.text_config
         num_layers = int(tc.num_hidden_layers)
         gdn_layers = list(tc.linear_layer_ids)
+        is_moe = tc.is_moe
 
         mappings, visual_skip, mtp_skip = _create_qwen3_5_weight_mappings(hf_config)
 
@@ -696,8 +716,11 @@ class Qwen3_5MoeForConditionalGeneration(nnx.Module):
                     f"{s}.conv1d.weight",
                 }
             )
-        for i in range(num_layers):
-            special.add(f"model.language_model.layers.{i}.mlp.experts.gate_up_proj")
+        # Pre-fused experts exist only in MoE variants; dense FFN weights are
+        # simple column/row-parallel and go through the shared loader.
+        if is_moe:
+            for i in range(num_layers):
+                special.add(f"model.language_model.layers.{i}.mlp.experts.gate_up_proj")
 
         simple = {k: v for k, v in mappings.items() if k not in special}
 
@@ -709,8 +732,9 @@ class Qwen3_5MoeForConditionalGeneration(nnx.Module):
         with SequentialSafetensorManager() as fm:
             for i in gdn_layers:
                 self._load_gdn_layer(fm, weight_info, i, tp)
-            for i in range(num_layers):
-                self._load_moe_gate_up(fm, weight_info, i)
+            if is_moe:
+                for i in range(num_layers):
+                    self._load_moe_gate_up(fm, weight_info, i)
 
         self._log_load_summary(mappings, weight_info, visual_skip, mtp_skip)
 
@@ -759,6 +783,8 @@ def _create_qwen3_5_weight_mappings(hf_config):
     tc = hf_config.text_config
     num_layers = int(tc.num_hidden_layers)
     full_attn_ids = set(tc.full_attention_layer_ids)
+    is_moe = tc.is_moe
+    tie_word_embeddings = bool(getattr(hf_config, "tie_word_embeddings", False))
     key_dim = tc.linear_num_key_heads * tc.linear_key_head_dim
     value_dim = tc.linear_num_value_heads * tc.linear_value_head_dim
     conv_dim = 2 * key_dim + value_dim
@@ -777,11 +803,14 @@ def _create_qwen3_5_weight_mappings(hf_config):
         sharding=(None,),
         transpose=False,
     )
-    mappings["lm_head.weight"] = WeightMapping(
-        target_path="lm_head.embedding",
-        sharding=("tensor", None),
-        transpose=False,
-    )
+    # Tied variants (0.8B / 2B / 4B) ship no ``lm_head.weight`` and reuse the
+    # embedding; the wrapper omits the lm_head module, so omit its mapping too.
+    if not tie_word_embeddings:
+        mappings["lm_head.weight"] = WeightMapping(
+            target_path="lm_head.embedding",
+            sharding=("tensor", None),
+            transpose=False,
+        )
 
     for i in range(num_layers):
         is_full = i in full_attn_ids
@@ -861,7 +890,27 @@ def _create_qwen3_5_weight_mappings(hf_config):
                 transpose=True,
             )
 
-        # MoE (all 40 layers). Experts are pre-fused on disk.
+        # FFN. Dense layers carry a plain SwiGLU (mlp.{gate,up,down}_proj); MoE
+        # layers carry the pre-fused routed experts + sigmoid-gated shared expert.
+        if not is_moe:
+            mappings[f"{src}.mlp.gate_proj.weight"] = WeightMapping(
+                target_path=f"{dst}.mlp.gate_proj.weight",
+                sharding=(None, "tensor"),
+                transpose=True,
+            )
+            mappings[f"{src}.mlp.up_proj.weight"] = WeightMapping(
+                target_path=f"{dst}.mlp.up_proj.weight",
+                sharding=(None, "tensor"),
+                transpose=True,
+            )
+            mappings[f"{src}.mlp.down_proj.weight"] = WeightMapping(
+                target_path=f"{dst}.mlp.down_proj.weight",
+                sharding=("tensor", None),
+                transpose=True,
+            )
+            continue
+
+        # MoE (all layers when is_moe). Experts are pre-fused on disk.
         mappings[f"{src}.mlp.gate.weight"] = WeightMapping(
             target_path=f"{dst}.mlp.moe_gate.kernel", sharding=(None, None), transpose=True
         )
@@ -901,4 +950,12 @@ def _create_qwen3_5_weight_mappings(hf_config):
     return mappings, _VISUAL_SKIP_PATTERNS, _MTP_SKIP_PATTERNS
 
 
-EntryClass = Qwen3_5MoeForConditionalGeneration
+class Qwen3_5ForConditionalGeneration(Qwen3_5MoeForConditionalGeneration):
+    """Dense Qwen3.5 (0.8B–27B). Behavior is fully config-driven in the base
+    class (MLP + weight loader branch on ``text_config.is_moe``); this subclass
+    exists only so the dense ``architectures`` name resolves via the
+    ``__name__``-keyed model registry.
+    """
+
+
+EntryClass = [Qwen3_5MoeForConditionalGeneration, Qwen3_5ForConditionalGeneration]

--- a/python/sgl_jax/test/models/test_qwen3_5.py
+++ b/python/sgl_jax/test/models/test_qwen3_5.py
@@ -1,37 +1,39 @@
-"""Qwen3.5-35B-A3B consolidated CPU test (RFC §4.2).
+"""Qwen3.5 (MoE 35B-A3B + dense 27B/2B) CPU component tests.
 
-Default fixture is the public HF Hub repo ``Qwen/Qwen3.5-35B-A3B`` — only
-``config.json`` and ``model.safetensors.index.json`` are downloaded (~190 KB,
-no weight blobs). Set ``QWEN3_5_FIXTURE`` to a local directory to override, or
-``QWEN3_5_REVISION`` to pin a commit; if the Hub is unreachable and no local
-fixture is set, the test skips instead of failing.
-CPU-only: validates config aliasing, layer schedule, module wiring/shapes,
-partial M-RoPE construction, and weight-mapping coverage against the real
-safetensors key set. Full numerical correctness is validated by the TPU smoke
-(``test/srt/test_qwen3_5_models.py``), not here — the fused MoE / GDN kernels
-do not run on CPU.
+Runs in the ``unit-test-cpu`` suite (``run_suite.py``). Hub-free, mirroring
+``test_mimo_v2_nextn`` / ``test_kimi_k25_weight_mapping``: configs are built
+in-process from the real ``config.json`` scalars + RoPE block, and weight-mapping
+coverage is checked against the checkpoint key set *reconstructed* from per-layer
+templates snapshotted from the real ``model.safetensors.index.json`` (no
+``from_pretrained`` / ``hf_hub_download``, so it never skips on an offline runner).
+Dims are shrunk to keep module construction cheap on CPU.
+
+The fused GDN/MoE kernels and numerical accuracy are gated separately by the TPU
+smoke (``test/srt/test_qwen3_5_models.py``) + the e2e MMLU-Pro / GPQA evals.
+
+Snapshots derive from Qwen3.5-{35B-A3B, 27B, 2B}; the per-layer block layout is
+identical across the family. Re-snapshot from the index if a future revision adds
+or renames tensors.
+
+Run:
+    python -m pytest python/sgl_jax/test/models/test_qwen3_5.py -q
 """
 
 from __future__ import annotations
 
-import json
 import os
 import re
 import unittest
-from pathlib import Path
+from types import SimpleNamespace
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
 
 import jax
 import jax.numpy as jnp
 import numpy as np
-from huggingface_hub import hf_hub_download
-from transformers import AutoConfig
 
-import sgl_jax.srt.hf_transformers_utils  # noqa: F401  (registers Qwen3_5HybridConfig)
+from sgl_jax.srt.configs.qwen3_5 import Qwen3_5DenseConfig, Qwen3_5HybridConfig
 from sgl_jax.srt.utils.mesh_utils import create_device_mesh
-
-CKPT_FIXTURE = os.environ.get("QWEN3_5_FIXTURE", "Qwen/Qwen3.5-35B-A3B")
-# Pin a commit for reproducible / offline-cached CI runs (None = latest).
-CKPT_REVISION = os.environ.get("QWEN3_5_REVISION") or None
 
 _mesh = create_device_mesh(
     ici_parallelism=[1, 1], dcn_parallelism=[1, 1], devices=[jax.devices()[0]]
@@ -39,43 +41,144 @@ _mesh = create_device_mesh(
 jax.sharding.set_mesh(_mesh)
 
 
+# RoPE block as the real config.json ships it (nested ``rope_parameters``, HF 5.x);
+# values shrunk but structurally identical so the config class's flatten path runs.
+_ROPE_PARAMETERS = {
+    "rope_type": "default",
+    "mrope_section": [6, 5, 5],  # sums to rotary_dim // 2 = (head_dim * partial) // 2
+    "mrope_interleaved": True,
+    "rope_theta": 12345,
+    "partial_rotary_factor": 0.5,
+}
+
+
+def _make_config(*, num_layers: int, is_moe: bool, tie: bool = False):
+    """Build a Qwen3.5 config with the real layout but small dims.
+
+    ``full_attention_interval=4`` (real schedule) and ``num_layers`` drive the
+    weight-mapping coverage; the small head/expert dims keep module construction
+    cheap. MoE vs dense is keyed off ``num_experts`` (the ``is_moe`` discriminator).
+    """
+    text = dict(
+        vocab_size=256,
+        hidden_size=256,
+        num_hidden_layers=num_layers,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=64,
+        full_attention_interval=4,
+        rms_norm_eps=1e-6,
+        rope_parameters=dict(_ROPE_PARAMETERS),
+        linear_num_key_heads=2,
+        linear_num_value_heads=4,
+        linear_key_head_dim=32,
+        linear_value_head_dim=32,
+        linear_conv_kernel_dim=4,
+    )
+    if is_moe:
+        text.update(
+            num_experts=8,
+            num_experts_per_tok=2,
+            moe_intermediate_size=128,
+            shared_expert_intermediate_size=128,
+        )
+        return Qwen3_5HybridConfig(tie_word_embeddings=tie, text_config=text)
+    text.update(intermediate_size=128)
+    return Qwen3_5DenseConfig(tie_word_embeddings=tie, text_config=text)
+
+
+# Per-layer HF safetensors key suffixes, snapshotted from the real
+# model.safetensors.index.json (verified: the reconstruction below reproduces the
+# real text-key set exactly — 693 for 35B-A3B, 851 for 27B, 320 for 2B).
+_NORM_KEYS = ("input_layernorm.weight", "post_attention_layernorm.weight")
+_GDN_KEYS = (
+    "linear_attn.in_proj_qkv.weight",
+    "linear_attn.in_proj_z.weight",
+    "linear_attn.in_proj_b.weight",
+    "linear_attn.in_proj_a.weight",
+    "linear_attn.conv1d.weight",
+    "linear_attn.A_log",
+    "linear_attn.dt_bias",
+    "linear_attn.norm.weight",
+    "linear_attn.out_proj.weight",
+)
+_FULL_ATTN_KEYS = (
+    "self_attn.q_proj.weight",
+    "self_attn.k_proj.weight",
+    "self_attn.v_proj.weight",
+    "self_attn.o_proj.weight",
+    "self_attn.q_norm.weight",
+    "self_attn.k_norm.weight",
+)
+_DENSE_FFN_KEYS = ("mlp.gate_proj.weight", "mlp.up_proj.weight", "mlp.down_proj.weight")
+_MOE_FFN_KEYS = (
+    "mlp.gate.weight",
+    "mlp.experts.gate_up_proj",
+    "mlp.experts.down_proj",
+    "mlp.shared_expert.gate_proj.weight",
+    "mlp.shared_expert.up_proj.weight",
+    "mlp.shared_expert.down_proj.weight",
+    "mlp.shared_expert_gate.weight",
+)
+
+
+def _expected_ckpt_keys(num_layers: int, is_moe: bool, tie: bool):
+    """Reconstruct the HF source-key set the checkpoint ships (= the keys the
+    weight mapping must cover). Independent of the production mapping code, so
+    comparing the two is a real bidirectional coverage check."""
+    keys = {
+        "model.language_model.embed_tokens.weight",
+        "model.language_model.norm.weight",
+    }
+    if not tie:  # tied variants reuse the embedding; no lm_head.weight on disk
+        keys.add("lm_head.weight")
+    ffn = _MOE_FFN_KEYS if is_moe else _DENSE_FFN_KEYS
+    for i in range(num_layers):
+        attn = _FULL_ATTN_KEYS if (i + 1) % 4 == 0 else _GDN_KEYS
+        for suffix in _NORM_KEYS + attn + ffn:
+            keys.add(f"model.language_model.layers.{i}.{suffix}")
+    return keys
+
+
 class TestQwen3_5(unittest.TestCase):
+    """MoE 35B-A3B backbone: config plumbing, module wiring/shapes, mapping coverage."""
+
     @classmethod
     def setUpClass(cls):
-        # Default fixture is a live HF Hub repo (config + index only). If it is
-        # unreachable (offline CI, no cache) and no local QWEN3_5_FIXTURE is set,
-        # skip rather than error -- matches the repo's skipTest idiom for
-        # unavailable resources. OSError is what transformers raises for an
-        # unreachable repo; a real config bug raises ValueError and still fails.
-        try:
-            cls.cfg = AutoConfig.from_pretrained(
-                CKPT_FIXTURE, revision=CKPT_REVISION, trust_remote_code=False
-            )
-        except OSError as e:
-            if os.path.isdir(CKPT_FIXTURE):
-                raise
-            raise unittest.SkipTest(f"Qwen3.5 fixture {CKPT_FIXTURE!r} unavailable: {e}") from e
         cls.mesh = _mesh
+        cls.cfg = _make_config(num_layers=4, is_moe=True)
 
-    # --- 1: config RoPE alias ---
-    def test_config_alias_surfaces_rope_fields(self):
+    # --- config: nested rope_parameters flattened to rope_scaling/theta/partial ---
+    def test_config_flattens_rope_parameters(self):
         tc = self.cfg.text_config
         self.assertEqual(type(self.cfg).__name__, "Qwen3_5HybridConfig")
         self.assertEqual(self.cfg.model_type, "qwen3_5_moe")
         # Subset-only: newer transformers versions inject extra fields
-        # (rope_theta, partial_rotary_factor) into rope_scaling. We only assert
-        # the fields the model actually consumes.
+        # (rope_theta, partial_rotary_factor) into rope_scaling. Assert just the
+        # fields the model actually consumes.
         keys = ("rope_type", "mrope_section", "mrope_interleaved")
         self.assertEqual(
             {k: tc.rope_scaling[k] for k in keys},
-            {"rope_type": "default", "mrope_section": [11, 11, 10], "mrope_interleaved": True},
+            {"rope_type": "default", "mrope_section": [6, 5, 5], "mrope_interleaved": True},
         )
-        self.assertEqual(tc.rope_theta, 10000000)
-        self.assertEqual(tc.partial_rotary_factor, 0.25)
+        self.assertEqual(tc.rope_theta, 12345)
+        self.assertEqual(tc.partial_rotary_factor, 0.5)
         self.assertFalse(self.cfg.tie_word_embeddings)
-        self.assertEqual(tc.head_dim, 256)
 
-    # --- 2: layer schedule ---
+    # --- config: is_moe discriminator + FFN field exclusivity ---
+    def test_is_moe_discriminator(self):
+        moe = _make_config(num_layers=4, is_moe=True).text_config
+        self.assertTrue(moe.is_moe)
+        self.assertIsNotNone(moe.num_experts)
+        self.assertIsNone(moe.intermediate_size)
+
+        dense = _make_config(num_layers=4, is_moe=False).text_config
+        self.assertFalse(dense.is_moe)
+        self.assertIsNone(dense.num_experts)
+        self.assertIsNone(dense.num_experts_per_tok)
+        self.assertIsNotNone(dense.intermediate_size)
+
+    # --- layer schedule derives from full_attention_interval ---
     def test_layer_types_matches_full_attention_interval(self):
         tc = self.cfg.text_config
         interval = int(tc.full_attention_interval)
@@ -85,12 +188,8 @@ class TestQwen3_5(unittest.TestCase):
         ]
         self.assertEqual(derived, list(tc.layer_types))
 
-    # --- 2b: decoder layer picks attention type from layer_types ---
+    # --- decoder layer picks full vs GDN attention from layer_types ---
     def test_decoder_layer_attention_type_from_layer_types(self):
-        """Qwen3_5DecoderLayer selects full vs GDN attention via
-        full_attention_layer_ids (layer_types), not a hard-coded interval.
-        Exercises the path the dropped runtime assert used to guard.
-        """
         from sgl_jax.srt.models.qwen3_5 import (
             Qwen3_5Attention,
             Qwen3_5DecoderLayer,
@@ -108,7 +207,7 @@ class TestQwen3_5(unittest.TestCase):
         self.assertFalse(gdn_layer.is_full_attn)
         self.assertIsInstance(gdn_layer.self_attn, Qwen3_5GatedDeltaNet)
 
-    # --- 3: full-attn output-gate layout ---
+    # --- full-attn output-gate layout: q_proj emits [q | gate] per head ---
     def test_q_proj_output_gate_layout(self):
         from sgl_jax.srt.models.qwen3_5 import Qwen3_5Attention
 
@@ -118,23 +217,23 @@ class TestQwen3_5(unittest.TestCase):
         x = jnp.zeros((T, self.cfg.text_config.hidden_size), dtype=jnp.bfloat16)
         q_raw, _ = attn.q_proj(x)
         self.assertEqual(q_raw.shape, (T, attn.num_heads * 2 * attn.head_dim))
-        # per-head [q | gate] split
         q_gate = q_raw.reshape(T, attn.num_heads, 2 * attn.head_dim)
         self.assertEqual(q_gate[..., : attn.head_dim].shape, (T, attn.num_heads, attn.head_dim))
         self.assertEqual(q_gate[..., attn.head_dim :].shape, (T, attn.num_heads, attn.head_dim))
 
-    # --- 4: partial M-RoPE wiring ---
+    # --- partial M-RoPE wiring: module reads mrope_section/rotary_dim from config ---
     def test_rope_wiring(self):
         from sgl_jax.srt.layers.embeddings import MRotaryEmbedding
         from sgl_jax.srt.models.qwen3_5 import Qwen3_5Attention
 
         attn = Qwen3_5Attention(self.cfg, self.mesh, layer_id=3)
+        tc = self.cfg.text_config
         self.assertIsInstance(attn.rotary_emb, MRotaryEmbedding)
-        self.assertEqual(list(attn.rotary_emb.mrope_section), [11, 11, 10])
-        self.assertEqual(attn.rotary_emb.rotary_dim, 64)
-        self.assertEqual(attn.rotary_emb.base, 10000000)
+        self.assertEqual(list(attn.rotary_emb.mrope_section), [6, 5, 5])
+        self.assertEqual(attn.rotary_emb.rotary_dim, int(tc.head_dim * tc.partial_rotary_factor))
+        self.assertEqual(attn.rotary_emb.base, tc.rope_theta)
 
-    # --- 5: GDN fused-projection shapes ---
+    # --- GDN fused-projection shapes ---
     def test_gdn_projection_shapes(self):
         from sgl_jax.srt.models.qwen3_5 import Qwen3_5GatedDeltaNet
 
@@ -154,12 +253,11 @@ class TestQwen3_5(unittest.TestCase):
         self.assertEqual(gdn.A_log.value.shape, (tc.linear_num_value_heads,))
         self.assertEqual(gdn.dt_bias.value.shape, (tc.linear_num_value_heads,))
 
-    # --- 5b: GDN output gate is norm-before-gate SILU (not sigmoid) ---
+    # --- GDN output gate is norm-before-gate SILU (not sigmoid) ---
     def test_gdn_output_norm_gate_is_silu(self):
         """GDN output gate is RMSNorm(core) * silu(z) — silu, NOT sigmoid.
 
-        Re-adds the deleted RmsGateTest; a silu->sigmoid swap passes shape tests
-        but tanks accuracy. CPU-safe (no fused kernel).
+        A silu->sigmoid swap passes shape tests but tanks accuracy. CPU-safe.
         """
         from sgl_jax.srt.models.qwen3_5 import Qwen3_5GatedDeltaNet
 
@@ -193,57 +291,12 @@ class TestQwen3_5(unittest.TestCase):
             )
         )
 
-    # --- 6: weight-mapping coverage vs the real safetensors index ---
-    def test_weight_mapping_covers_ckpt_keys(self):
-        from sgl_jax.srt.models.qwen3_5 import _create_qwen3_5_weight_mappings
-
-        # Resolve from local fixture dir if set; otherwise pull just the index
-        # file from the HF Hub repo (no weight blobs).
-        if os.path.isdir(CKPT_FIXTURE):
-            idx_path = Path(CKPT_FIXTURE) / "model.safetensors.index.json"
-        else:
-            idx_path = Path(
-                hf_hub_download(
-                    repo_id=CKPT_FIXTURE,
-                    filename="model.safetensors.index.json",
-                    revision=CKPT_REVISION,
-                )
-            )
-        with open(idx_path) as f:
-            ckpt_keys = set(json.load(f)["weight_map"].keys())
-
-        mapping, visual_skip, mtp_skip = _create_qwen3_5_weight_mappings(self.cfg)
-
-        text_keys = {k for k in ckpt_keys if k.startswith("model.language_model.")}
-        self.assertEqual(len(text_keys), 692)
-        for k in text_keys:
-            self.assertIn(k, mapping, f"unmapped text key: {k}")
-        self.assertIn("lm_head.weight", mapping)
-
-        visual_keys = {k for k in ckpt_keys if k.startswith("model.visual.")}
-        self.assertEqual(len(visual_keys), 333)
-        for k in visual_keys:
-            self.assertTrue(
-                any(re.match(p, k) for p in visual_skip), f"visual key not skipped: {k}"
-            )
-
-        mtp_keys = {k for k in ckpt_keys if k.startswith("mtp.")}
-        self.assertEqual(len(mtp_keys), 785)
-        for k in mtp_keys:
-            self.assertTrue(any(re.match(p, k) for p in mtp_skip), f"mtp key not skipped: {k}")
-
-        # No mapping key should reference a non-existent ckpt key (apart from the
-        # synthetic lm_head/embeds, which are real).
-        for src in mapping:
-            self.assertIn(src, ckpt_keys, f"mapping references missing ckpt key: {src}")
-
-    # --- 7: MoE block wiring + sigmoid-gated shared expert ---
+    # --- MoE block wiring + sigmoid-gated shared expert ---
     def test_moe_block_shared_expert_gate(self):
         from sgl_jax.srt.models.qwen3_5 import Qwen3_5MoeBlock
 
         tc = self.cfg.text_config
         block = Qwen3_5MoeBlock(self.cfg, self.mesh, layer_id=0)
-        # Routed expert param shapes (FusedEPMoE w1/w3 = [E, hidden, inter], w2 = [E, inter, hidden]).
         self.assertEqual(
             block.experts.w1.value.shape, (tc.num_experts, tc.hidden_size, tc.moe_intermediate_size)
         )
@@ -253,7 +306,6 @@ class TestQwen3_5(unittest.TestCase):
         self.assertEqual(
             block.experts.w2.value.shape, (tc.num_experts, tc.moe_intermediate_size, tc.hidden_size)
         )
-        # Shared path (plain matmuls — CPU-safe). sigmoid(gate)*shared_expert(x).
         T = 4
         x = jax.random.normal(jax.random.key(0), (T, tc.hidden_size), dtype=jnp.bfloat16)
         gate_logit, _ = block.shared_expert_gate(x)
@@ -262,6 +314,173 @@ class TestQwen3_5(unittest.TestCase):
         self.assertEqual(shared.shape, (T, tc.hidden_size))
         gated = jax.nn.sigmoid(gate_logit) * shared
         self.assertEqual(gated.shape, (T, tc.hidden_size))
+
+    # --- weight-mapping coverage vs the reconstructed 35B-A3B (MoE) key set ---
+    def test_weight_mapping_covers_moe_keys(self):
+        from sgl_jax.srt.models.qwen3_5 import _create_qwen3_5_weight_mappings
+
+        cfg = _make_config(num_layers=40, is_moe=True)  # 35B-A3B layer count
+        mapping, _, _ = _create_qwen3_5_weight_mappings(cfg)
+        expected = _expected_ckpt_keys(num_layers=40, is_moe=True, tie=False)
+        self.assertEqual(len(expected), 693)  # 692 text keys + lm_head.weight
+        self.assertEqual(set(mapping), expected)
+
+    # --- vision tower + MTP head are skipped by prefix, LM keys are not ---
+    def test_visual_and_mtp_keys_are_skipped(self):
+        from sgl_jax.srt.models.qwen3_5 import _create_qwen3_5_weight_mappings
+
+        _, visual_skip, mtp_skip = _create_qwen3_5_weight_mappings(self.cfg)
+        self.assertTrue(
+            any(re.match(p, "model.visual.blocks.0.attn.qkv.weight") for p in visual_skip)
+        )
+        self.assertTrue(any(re.match(p, "mtp.layers.0.input_layernorm.weight") for p in mtp_skip))
+        lm_key = "model.language_model.layers.0.input_layernorm.weight"
+        self.assertFalse(any(re.match(p, lm_key) for p in visual_skip + mtp_skip))
+
+    # --- expert capture builds the real capturer for MoE (counterpart to the
+    #     dense router-less guard in TestQwen3_5Dense) ---
+    def test_routed_experts_capturer_builds_for_moe(self):
+        from sgl_jax.srt.layers.routed_experts_capturer import (
+            RoutedExpertsCapturer,
+            _RoutedExpertsCapturerReal,
+        )
+
+        # Qwen3.5 MoE keeps num_experts / top-k under text_config (the nested-config
+        # path the helper must read). Enabling capture builds the real capturer and
+        # sizes the per-layer host buffer from the resolved top-k.
+        tc = self.cfg.text_config
+        moe_mc = SimpleNamespace(hf_config=self.cfg, hf_text_config=tc)
+        cap = RoutedExpertsCapturer.create(
+            mesh=self.mesh,
+            enable=True,
+            model_config=moe_mc,
+            num_tokens=1,
+            max_padding=1,
+            ep_size=1,
+        )
+        self.assertIsInstance(cap, _RoutedExpertsCapturerReal)
+        self.assertEqual(cap.num_experts_per_tok, tc.num_experts_per_tok)
+        self.assertEqual(cap.host_buffer.shape, (tc.num_hidden_layers, 1, tc.num_experts_per_tok))
+
+        # A MoE model that instead exposes the count on the ROOT config under an
+        # alias (n_routed_experts / num_local_experts) must still build the real
+        # capturer via the helper's root fallback, not trip the router-less guard.
+        # (Qwen3.5 itself uses text_config, above.)
+        for total_alias in ("n_routed_experts", "num_local_experts"):
+            root_mc = SimpleNamespace(
+                hf_text_config=SimpleNamespace(num_hidden_layers=2),
+                hf_config=SimpleNamespace(**{total_alias: 64, "num_experts_per_tok": 4}),
+            )
+            cap = RoutedExpertsCapturer.create(
+                mesh=self.mesh,
+                enable=True,
+                model_config=root_mc,
+                num_tokens=1,
+                max_padding=1,
+                ep_size=1,
+            )
+            self.assertIsInstance(cap, _RoutedExpertsCapturerReal)
+            self.assertEqual(cap.host_buffer.shape, (2, 1, 4))
+
+
+class TestQwen3_5Dense(unittest.TestCase):
+    """Dense 27B/2B: SwiGLU FFN dispatch, mapping coverage, tied-embedding variant."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mesh = _mesh
+        cls.cfg = _make_config(num_layers=4, is_moe=False)
+
+    # --- dense config: router-less, model_type/class, FFN field ---
+    def test_dense_config(self):
+        tc = self.cfg.text_config
+        self.assertEqual(type(self.cfg).__name__, "Qwen3_5DenseConfig")
+        self.assertEqual(self.cfg.model_type, "qwen3_5")
+        self.assertFalse(tc.is_moe)
+        self.assertIsNone(tc.num_experts)
+        self.assertIsNone(tc.num_experts_per_tok)
+        self.assertIsNotNone(tc.intermediate_size)
+        self.assertFalse(self.cfg.tie_word_embeddings)
+
+    # --- decoder layer dispatches the dense SwiGLU MLP ---
+    def test_decoder_dispatches_dense_mlp(self):
+        from sgl_jax.srt.models.qwen2_moe import Qwen2MoeMLP
+        from sgl_jax.srt.models.qwen3_5 import Qwen3_5DecoderLayer
+
+        layer = Qwen3_5DecoderLayer(self.cfg, self.mesh, layer_id=0)  # GDN layer
+        self.assertFalse(layer.is_moe)
+        self.assertIsInstance(layer.mlp, Qwen2MoeMLP)
+
+    # --- dense MLP forward (the only dense forward exercised on CPU) ---
+    def test_dense_mlp_shape(self):
+        from sgl_jax.srt.models.qwen2_moe import Qwen2MoeMLP
+
+        hidden, inter, T = 32, 64, 4
+        mlp = Qwen2MoeMLP(hidden_size=hidden, intermediate_size=inter, mesh=self.mesh)
+        x = jax.random.normal(jax.random.key(0), (T, hidden), dtype=jnp.bfloat16)
+        out = mlp(x)
+        self.assertEqual(out.shape, (T, hidden))
+
+    # --- weight mapping: reconstructed 27B (dense) key set; no expert keys ---
+    def test_weight_mapping_covers_dense_keys(self):
+        from sgl_jax.srt.models.qwen3_5 import _create_qwen3_5_weight_mappings
+
+        cfg = _make_config(num_layers=64, is_moe=False)  # 27B layer count
+        mapping, _, _ = _create_qwen3_5_weight_mappings(cfg)
+        expected = _expected_ckpt_keys(num_layers=64, is_moe=False, tie=False)
+        self.assertEqual(len(expected), 851)  # 850 text keys + lm_head.weight
+        self.assertEqual(set(mapping), expected)
+        self.assertIn("lm_head.weight", mapping)  # 27B is untied
+        self.assertFalse(
+            any("experts" in k or "shared_expert" in k for k in mapping),
+            "dense mapping must not reference MoE expert keys",
+        )
+
+    # --- tied variant (2B) omits the lm_head.weight mapping ---
+    def test_tied_variant_omits_lm_head_mapping(self):
+        from sgl_jax.srt.models.qwen3_5 import _create_qwen3_5_weight_mappings
+
+        cfg = _make_config(num_layers=24, is_moe=False, tie=True)  # 2B layer count
+        self.assertTrue(cfg.tie_word_embeddings)
+        mapping, _, _ = _create_qwen3_5_weight_mappings(cfg)
+        self.assertNotIn("lm_head.weight", mapping)
+        self.assertEqual(set(mapping), _expected_ckpt_keys(num_layers=24, is_moe=False, tie=True))
+
+    # --- router-less capturer guard (shared infra; dense regression scenario) ---
+    def test_dense_routed_experts_guard(self):
+        from sgl_jax.srt.layers.routed_experts_capturer import (
+            RoutedExpertsCapturer,
+            _RoutedExpertsCapturerNoop,
+        )
+
+        router_less = SimpleNamespace(
+            hf_text_config=SimpleNamespace(
+                num_experts=None, num_experts_per_tok=None, num_hidden_layers=4
+            )
+        )
+        # Flags off -> noop capturer, no allocation.
+        cap = RoutedExpertsCapturer.create(
+            mesh=self.mesh,
+            enable=False,
+            model_config=router_less,
+            num_tokens=1,
+            max_padding=1,
+            ep_size=1,
+        )
+        self.assertIsInstance(cap, _RoutedExpertsCapturerNoop)
+        # Any capture flag on -> clear error before NumPy shape allocation.
+        for flag in ("enable", "enable_balance_debug", "enable_dist_recorder"):
+            kwargs = dict(enable=False, enable_balance_debug=False, enable_dist_recorder=False)
+            kwargs[flag] = True
+            with self.assertRaises(ValueError):
+                RoutedExpertsCapturer.create(
+                    mesh=self.mesh,
+                    model_config=router_less,
+                    num_tokens=1,
+                    max_padding=1,
+                    ep_size=1,
+                    **kwargs,
+                )
 
 
 if __name__ == "__main__":

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -143,6 +143,7 @@ QWEN3_4B = _local_or_hf("Qwen/Qwen3-4B")
 
 QWEN3_MOE_30B = _local_or_hf("Qwen/Qwen3-30B-A3B")
 QWEN3_5_35B_A3B = "/models/Qwen3.5-35B-A3B/"
+QWEN3_5_27B = "/models/Qwen3.5-27B/"
 QWEN2_5_7B_INSTRUCT = _local_or_hf("Qwen/Qwen2.5-7B-Instruct")
 QWEN3_CODER_30B_A3B_INSTRUCT = _local_or_hf("Qwen/Qwen3-Coder-30B-A3B-Instruct")
 GEMMA2_2B_IT = _local_or_hf("google/gemma-2-2b-it")

--- a/test/srt/test_qwen3_5_models.py
+++ b/test/srt/test_qwen3_5_models.py
@@ -7,10 +7,34 @@ from sgl_jax.srt.utils import kill_process_tree
 from sgl_jax.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
+    QWEN3_5_27B,
     QWEN3_5_35B_A3B,
     CustomTestCase,
     popen_launch_server,
 )
+
+
+def _run_mmlu_smoke(test, base_url, model):
+    # Thinking mode + Qwen3 card sampling.
+    # enable_thinking must be explicit (qwen3 parser defaults it ON).
+    args = SimpleNamespace(
+        base_url=base_url,
+        model=model,
+        eval_name="mmlu",
+        num_examples=100,
+        num_threads=16,
+        max_tokens=32768,
+        temperature=0.6,
+        top_p=0.95,
+        top_k=20,
+        min_p=0.0,
+        presence_penalty=1.5,
+        repetition_penalty=1.0,
+        seed=17,
+        chat_template_kwargs={"enable_thinking": True},
+    )
+    metrics = run_eval(args)
+    test.assertGreater(metrics["score"], 0.70)
 
 
 class TestQwen35MoeModel(CustomTestCase):
@@ -63,26 +87,64 @@ class TestQwen35MoeModel(CustomTestCase):
         kill_process_tree(cls.process.pid)
 
     def test_mmlu_smoke(self):
-        # Thinking mode + Qwen3 card sampling
-        # enable_thinking must be explicit (qwen3 parser defaults it ON).
-        args = SimpleNamespace(
-            base_url=self.base_url,
-            model=self.model,
-            eval_name="mmlu",
-            num_examples=40,
-            num_threads=16,
-            max_tokens=32768,
-            temperature=0.6,
-            top_p=0.95,
-            top_k=20,
-            min_p=0.0,
-            presence_penalty=1.5,
-            repetition_penalty=1.0,
-            seed=17,
-            chat_template_kwargs={"enable_thinking": True},
+        _run_mmlu_smoke(self, self.base_url, self.model)
+
+
+class TestQwen35DenseModel(CustomTestCase):
+    """Dense Qwen3.5 (validated on 27B). Same hybrid backbone as the MoE class,
+    but a plain SwiGLU FFN, so no expert-parallel args: drop ``--ep-size`` (no
+    experts) and ``--moe-backend`` (never exercised). tp4 puts ~13.5 GB/chip of
+    weights on a single 4-chip host; mem-fraction 0.8 leaves ample headroom
+    (the tp16/dp4 e2e needed 0.90 only because dp replicates the weights)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN3_5_27B
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            device="tpu",
+            other_args=[
+                "--trust-remote-code",
+                "--skip-server-warmup",
+                "--random-seed",
+                "3",
+                "--dtype",
+                "bfloat16",
+                "--tp-size",
+                "4",
+                "--nnodes",
+                "1",
+                "--dist-init-addr",
+                "0.0.0.0:10011",
+                "--mem-fraction-static",
+                "0.8",
+                "--chunked-prefill-size",
+                "512",
+                "--page-size",
+                "64",
+                "--max-running-requests",
+                "16",
+                "--disable-radix-cache",
+                "--disable-overlap-schedule",
+                "--precompile-bs-paddings",
+                "16",
+                "--precompile-token-paddings",
+                "16",
+                "512",
+                "1024",
+            ],
+            env={"JAX_COMPILATION_CACHE_DIR": "/tmp/jax_compilation_cache"},
         )
-        metrics = run_eval(args)
-        self.assertGreater(metrics["score"], 0.70)
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu_smoke(self):
+        _run_mmlu_smoke(self, self.base_url, self.model)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Generalize the merged Qwen3.5-35B-A3B MoE path (#1267) to also serve the **dense** `Qwen3_5ForConditionalGeneration` family (0.8B / 2B / 4B / 9B / 27B). Dense and MoE variants share the hybrid backbone (full-attention + Gated DeltaNet, `full_attention_interval=4`), partial M-RoPE, and config layout — only the FFN differs (plain SwiGLU vs 256-expert MoE). Validated end-to-end on 27B.

Follows RFC #1251 / PR #1267.

## Modifications

- **Config** (`srt/configs/qwen3_5.py`): add `intermediate_size`; default all MoE-only fields (`num_experts` / `num_experts_per_tok` / `moe_intermediate_size` / `shared_expert_intermediate_size`) to `None`; add an `is_moe` discriminator (`num_experts is not None`); add `Qwen3_5DenseConfig` (`model_type="qwen3_5"`); widen `get_qwen3_5_hybrid_config` to both root types.
- **Model** (`srt/models/qwen3_5.py`): `Qwen3_5DecoderLayer` builds a plain SwiGLU MLP (`Qwen2MoeMLP`) when `not is_moe` and branches the call site (the two MLPs have different signatures; dense yields `topk_ids=None`, kept out of the EPLB / return-routed-experts list). Add the `Qwen3_5ForConditionalGeneration` entry class. GDN + full-attention paths unchanged.
- **Weight loader** (same file): dense `mlp.{gate,up,down}_proj` mappings; `lm_head.weight` mapping conditioned on `tie_word_embeddings` (tied 0.8B/2B/4B reuse the embedding); skip the pre-fused expert path when dense. 27B bring-up: consumed=851 / skipped=348 (vision+MTP) / missing=0 / unexpected=0.
- **Registration** (`srt/hf_transformers_utils.py`): register `Qwen3_5DenseConfig` for `qwen3_5`.
- **Routed-experts infra** (`srt/layers/routed_experts_capturer.py`, `srt/model_executor/model_runner.py`): alias-aware `get_routed_expert_count` / `get_routed_experts_per_token` helpers resolve the expert count (`num_experts` / `n_routed_experts` / `num_local_experts`) and routing top-k across name aliases and root-vs-text config. `create()` raises a clear error for router-less (dense) models when a capture flag is set; physical-expert count and buffer sizing go through the helpers so non-Qwen MoE configs aren't broken by the `hf_text_config` lookup.
- **Tests**: rework the CPU component tests to be Hub-free (synthetic configs + mapping coverage from per-layer templates snapshotted from the real index), covering MoE + dense (config / MLP dispatch / weight-mapping / tied-variant / capturer guard + build); add a dense class to the TPU smoke.

## Tests

- **Unit (CPU)**: `test_qwen3_5.py` 18/18 — Hub-free, runs in the `unit-test-cpu` CI suite.
- **Smoke (TPU, single-host v6e-4, TP=4)**: `test_qwen3_5_models.py`, MMLU 100-Q thinking mode (asserts > 0.70) — MoE 35B-A3B = **0.920**, dense 27B = **0.910**.
- **Full e2e** (v6e 4×4 16-chip, TP=16/DP=4, thinking: temp=0.6/top-p=0.95/top-k=20/min-p=0/presence=1.5/max-tokens=32768):

  | Benchmark | n | dense 27B | published | delta |
  |---|---|---:|---:|---:|
  | MMLU-Pro | 12,032 | **0.8671** / parsed 0.999 | 0.861 | +0.0061 |
  | GPQA-Diamond | 198 ×5 (median) | **0.8636** (0.848–0.889) | 0.855 | +0.0086 |

  GPQA-Diamond = median of 5 seeds (high-variance in thinking mode + non-deterministic TPU sampling); MMLU-Pro is a single run (large enough to be stable). Dense at TP=16/DP=4 needs `--mem-fraction-static 0.90` (weights replicate across the DP groups) and no `--moe-backend` (no experts).

## Benchmarking and Profiling

Out of scope for this PR (correctness-first); perf follow-up.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.

