### PR TITLE
fix(glm5): disable fused MLP under dynamic quant (#1378)

### DIFF
--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -612,6 +612,7 @@ class Glm5DecoderLayer(nnx.Module):
         )
 
         first_k_dense_replace = getattr(config, "first_k_dense_replace", 0)
+        use_fused_mlp = getattr(config, "_sgl_use_fused_mlp", True)
 
         if layer_id < first_k_dense_replace:
             self.mlp = Glm5MLP(
@@ -620,6 +621,7 @@ class Glm5DecoderLayer(nnx.Module):
                 layer_id=layer_id,
                 dtype=dtype,
                 mesh=mesh,
+                use_fused=use_fused_mlp,
             )
             self.is_moe_layer = False
             self.moe_gate = None
@@ -687,6 +689,7 @@ class Glm5DecoderLayer(nnx.Module):
                     layer_id=layer_id,
                     dtype=dtype,
                     mesh=mesh,
+                    use_fused=use_fused_mlp,
                 )
             else:
                 self.shared_experts = None
@@ -1100,6 +1103,14 @@ class GlmMoeDsaForCausalLM(Glm5ForCausalLM):
             # narrow-N guard would reject it but the indexer output is currently
             # discarded so accuracy is unaffected. Match deepseek_v3 config.
             mc.quantization_config.allow_narrow_n_blockwise = True
+        # Under dynamic (in-framework) quant, Glm5MLP.post_load_weights merges
+        # BF16 w_gu/w_d and nulls gate/up/down_proj *before* quantize_model
+        # runs, so the fused weights bypass quantization and regress decode
+        # TPOT on HBM-bound hardware (#1378). Keep the unfused path there so
+        # the LinearBase modules get quantized as before.
+        mc.hf_config._sgl_use_fused_mlp = (
+            mc.quantization_config is None or mc.quantization_config.is_static_checkpoint
+        )
 
 
 EntryClass = [Glm5ForCausalLM, GlmMoeDsaForCausalLM]


### PR DESCRIPTION

## Motivation

Fixes #1378. `Glm5MLP.post_load_weights` (added in #1344) merges `gate/up/down_proj` into BF16 `w_gu`/`w_d` `nnx.Param`s and nulls the originals. This runs inside `model.load_weights()`, i.e. **before** dynamic quantization iterates `LinearBase` modules — so the fused weights bypass quant entirely.

## Modifications

`patch_model_config` writes `hf_config._sgl_use_fused_mlp = (quant_config is None or quant_config.is_static_checkpoint)`; `Glm5DecoderLayer` reads it and passes `use_fused=` to both `Glm5MLP` instantiations (dense + shared_experts). Under dynamic quant, `use_fused=False` → no `w_gu`/`w_d` allocation, `post_load_weights` early-returns, `__call__` uses the original `LinearBase` path → `gate/up/down_proj` get quantized as before #1344.

BF16 and static-FP8 checkpoints keep `use_fused=True` (the #1344 optimization is unchanged there).

## Verification

GLM-5.1, TPU v6e-64, W8A8 (`fp8_w8a8.yaml`), tp64/dp8/ep64, 1K/1K cc=460 ratio=1, ×2:

| commit | output tok/s | Median TPOT | KV pool tokens |
|---|---|---|---|
| `2396c98e` (pre-#1344) | 2809 | 130 ms | 976384 |
| `9c130712` (post-#1344) | 2187 | 145.9 ms | 941568 |
| `9c130712` + this PR | **2744** (σ=0.09%) | **133.3 ms** | **976384** |

KV pool fully recovers to pre-#1344 (no `w_gu`/`w_d` BF16 placeholder). TPOT recovers ~90% of the regression; the remaining ~3 ms vs `2396c98e` is from other #1344 changes (`_forward_mqa` einsum→dot_general, mla/gmm `ref[...].reshape()`) and/or intermediate commits, not the fused MLP.

Sanity (Paris) + pre-commit pass. BF16/static-FP8 paths verified to still hit `use_fused=True` (logic check).

## Checklist

- [x] `pre-commit run --all-files`
- [x] e2e on v6e-64 W8A8 dp8 (sanity + cc=460 ×2)
- [x] BF16 / static-FP8 path unchanged (logic verified)
