### PR TITLE
fix(ci): lower ds-v2-lite-mla gsm8k threshold 0.86→0.855

### DIFF
--- a/test/srt/nightly/single_host/suite_runner.py
+++ b/test/srt/nightly/single_host/suite_runner.py
@@ -104,7 +104,7 @@ SUITES: dict[str, SingleHostSuite] = {
                 launch_profile="ds-v2-lite-mla-v6e-4.yaml",
                 cases=[
                     _gsm8k_case(
-                        "ds-v2-lite-mla", "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct", 0.86, 128
+                        "ds-v2-lite-mla", "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct", 0.855, 128
                     )
                 ],
             ),


### PR DESCRIPTION
## Summary
- Lower the `ds-v2-lite-mla` gsm8k accuracy threshold from 0.86 to 0.855 to eliminate false CI failures from normal sampling noise.

## Context
The nightly test failed on 6/20 with score=0.859 (threshold=0.86), filed as #1381. A 50-run stress test on v6e-4 (tp=4, dp=4, greedy decoding) confirmed this is noise, not regression:

| Metric | Value |
|--------|-------|
| Mean | 0.86810 |
| Std (σ) | 0.003658 |
| Min / Max | 0.85671 / 0.87945 |
| p05 / p95 | 0.86353 / 0.87263 |

The old threshold 0.86 sits at mean−2σ (~2% false failure rate). The new threshold 0.855 (≈mean−3.5σ) covers the full observed range while still catching genuine regressions (a score below 0.855 implies the mean has dropped by >1.3pp).

Cross-version validation: commit `33e9eb1` (12 runs) averaged 0.8684, matching the latest main — no accuracy drift from recent changes.

## Test plan
- [x] 50-run stress test validates the new threshold covers all observed scores
- [ ] Next nightly run passes with the updated threshold

Closes #1381