### PR TITLE
feat(glm5): support GLM-5.2 config (indexer_types + rope_parameters)

### DIFF
--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -164,6 +164,7 @@ class Glm5Attention(nnx.Module):
         attention_bias: bool = False,
         dtype: jnp.dtype = jnp.bfloat16,
         use_absorbed: bool = True,
+        has_indexer: bool = True,
     ):
         super().__init__()
         self.layer_id = layer_id
@@ -243,15 +244,18 @@ class Glm5Attention(nnx.Module):
             scope_name="o_proj",
         )
 
-        self.indexer = GlmDsaIndexer(
-            hidden_size=hidden_size,
-            q_lora_rank=self.q_lora_rank,
-            index_head_dim=128,
-            index_n_heads=32,
-            mesh=mesh,
-            dtype=dtype,
-            scope_name="indexer",
-        )
+        if has_indexer:
+            self.indexer = GlmDsaIndexer(
+                hidden_size=hidden_size,
+                q_lora_rank=self.q_lora_rank,
+                index_head_dim=128,
+                index_n_heads=32,
+                mesh=mesh,
+                dtype=dtype,
+                scope_name="indexer",
+            )
+        else:
+            self.indexer = None
         self.rotary_emb = RotaryEmbedding(
             head_size=self.qk_rope_head_dim,
             rotary_dim=self.qk_rope_head_dim,
@@ -407,7 +411,8 @@ class Glm5Attention(nnx.Module):
         q, _ = self.q_b_proj(q_compressed)
         q = q.reshape(-1, self.num_heads, self.qk_head_dim)
 
-        _ = self.indexer(hidden_states, q_compressed, positions, self.rotary_emb)
+        if self.indexer is not None:
+            _ = self.indexer(hidden_states, q_compressed, positions, self.rotary_emb)
 
         q_nope = q[:, :, : self.qk_nope_head_dim]
         q_rope = q[:, :, self.qk_nope_head_dim :]
@@ -584,7 +589,8 @@ class Glm5DecoderLayer(nnx.Module):
     ):
         self.layer_id = layer_id
         self.hidden_size = config.hidden_size
-        rope_theta = getattr(config, "rope_theta", 1000000)
+        rope_params = getattr(config, "rope_parameters", None) or {}
+        rope_theta = getattr(config, "rope_theta", None) or rope_params.get("rope_theta", 1000000)
         rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings", 131072)
         self.head_dim = getattr(config, "head_dim", None) or 128
@@ -592,6 +598,12 @@ class Glm5DecoderLayer(nnx.Module):
 
         partial_rotary_factor = getattr(config, "partial_rotary_factor", 0.5)
         rotary_dim = int(self.head_dim * partial_rotary_factor)
+
+        # GLM-5.2 IndexShare: layers tagged "shared" reuse the previous "full"
+        # layer's top-k and ship no indexer weights. Dense MLA discards indexer
+        # output anyway, so just skip building the module on shared layers.
+        indexer_types = getattr(config, "indexer_types", None)
+        has_indexer = indexer_types is None or indexer_types[layer_id] == "full"
 
         self.self_attn = Glm5Attention(
             hidden_size=config.hidden_size,
@@ -609,6 +621,7 @@ class Glm5DecoderLayer(nnx.Module):
             dtype=dtype,
             mesh=mesh,
             use_absorbed=True,
+            has_indexer=has_indexer,
         )
 
         first_k_dense_replace = getattr(config, "first_k_dense_replace", 0)
@@ -912,6 +925,7 @@ class Glm5ForCausalLM(nnx.Module):
 
         num_layers = self.config.num_hidden_layers
         first_k_dense_replace = getattr(self.config, "first_k_dense_replace", 0)
+        indexer_types = getattr(self.config, "indexer_types", None)
 
         quant_config = getattr(model_config, "quantization_config", None)
         is_static_quant = quant_config is not None and quant_config.is_static_checkpoint
@@ -924,13 +938,19 @@ class Glm5ForCausalLM(nnx.Module):
                 target_idx,
                 target_idx < first_k_dense_replace,
                 is_static_quant=is_static_quant,
+                has_indexer=indexer_types is None or indexer_types[target_idx] == "full",
             )
             mappings.update(layer_mappings)
 
         return mappings
 
     def _create_moe_layer_mappings(
-        self, layer_idx: int, target_idx: int, is_mlp_layer: bool, is_static_quant: bool = False
+        self,
+        layer_idx: int,
+        target_idx: int,
+        is_mlp_layer: bool,
+        is_static_quant: bool = False,
+        has_indexer: bool = True,
     ) -> dict:
         prefix = f"model.layers.{target_idx}"
         target_prefix = f"model.layers.{layer_idx}"
@@ -989,21 +1009,22 @@ class Glm5ForCausalLM(nnx.Module):
         add_linear(f"{ap}.kv_b_proj", f"{tp}.kv_b_proj", (None, "tensor"))
         add_linear(f"{ap}.o_proj", f"{tp}.o_proj", ("tensor", None))
 
-        add_linear(f"{ap}.indexer.wq_b", f"{tp}.indexer.wq_b", (None, None))
-        add_linear(f"{ap}.indexer.wk", f"{tp}.indexer.wk", (None, None))
-        # weights_proj is in modules_to_not_convert (HF: indexers_proj) → unquantized.
-        add_linear(
-            f"{ap}.indexer.weights_proj",
-            f"{tp}.indexer.weights_proj",
-            (None, None),
-            force_unquant=True,
-        )
-        mappings[f"{ap}.indexer.k_norm.weight"] = WeightMapping(
-            target_path=f"{tp}.indexer.k_norm.weight", sharding=(None,)
-        )
-        mappings[f"{ap}.indexer.k_norm.bias"] = WeightMapping(
-            target_path=f"{tp}.indexer.k_norm.bias", sharding=(None,)
-        )
+        if has_indexer:
+            add_linear(f"{ap}.indexer.wq_b", f"{tp}.indexer.wq_b", (None, None))
+            add_linear(f"{ap}.indexer.wk", f"{tp}.indexer.wk", (None, None))
+            # weights_proj is in modules_to_not_convert (HF: indexers_proj) → unquantized.
+            add_linear(
+                f"{ap}.indexer.weights_proj",
+                f"{tp}.indexer.weights_proj",
+                (None, None),
+                force_unquant=True,
+            )
+            mappings[f"{ap}.indexer.k_norm.weight"] = WeightMapping(
+                target_path=f"{tp}.indexer.k_norm.weight", sharding=(None,)
+            )
+            mappings[f"{ap}.indexer.k_norm.bias"] = WeightMapping(
+                target_path=f"{tp}.indexer.k_norm.bias", sharding=(None,)
+            )
 
         if is_mlp_layer:
             add_linear(


### PR DESCRIPTION
Fixes #1383.


## Motivation

GLM-5.2 ([HF](https://huggingface.co/zai-org/GLM-5.2)) reuses `GlmMoeDsaForCausalLM` with identical core architecture (78 layers, 6144 hidden, MLA, 256-expert MoE), but two config additions break loading on the existing 5.1 path:

1. **`indexer_types`** (IndexShare): 57/78 layers are tagged `"shared"` and ship **no indexer weights** in the checkpoint. The current code builds an indexer per layer unconditionally → weight loading fails with unexpected params.
2. **`rope_parameters.rope_theta`**: GLM-5.x nests `rope_theta` under `rope_parameters`. 5.1 happened to match the `1e6` fallback; 5.2 uses `8e6` and would silently mis-RoPE.

## Modifications

`python/sgl_jax/srt/models/glm5_moe.py` (+48/-27):
- `Glm5Attention.__init__`: add `has_indexer: bool = True`, conditionally build `self.indexer`
- `Glm5Attention.__call__`: guard `self.indexer(...)` with `is not None`
- `Glm5DecoderLayer.__init__`: read `rope_theta` from `rope_parameters` fallback; derive `has_indexer` from `config.indexer_types[layer_id] == "full"`
- `_create_glm5_weight_mappings` / `_create_moe_layer_mappings`: skip indexer key mappings on shared layers

Both changes are **no-ops for GLM-5.1** (`indexer_types` absent → all `"full"`; flat `rope_theta` still wins over nested).

Note: this does **not** implement IndexShare semantics (cross-layer top-k reuse). Since the dense MLA path already discards indexer output (`_ = self.indexer(...)`), skipping the module on shared layers is lossless and saves 57 layers of unused indexer forward.

## Verification

TPU v6e-64, W8A8 in-framework (`fp8_w8a8.yaml`), tp64/dp8/ep64, 1K/1K cc=460 ratio=1, ×2, main `0498a2e7`:

| | GLM-5.1 | **GLM-5.2 (this PR)** | Δ |
|---|---|---|---|
| sanity / GSM8K | 3/3 / 5/5 | **3/3 / 5/5** ✅ | — |
| output tok/s | 2744 | **2801** (σ=1.2%) | **+2.1%** |
| Median TPOT | 133.3 ms | **130.4 ms** | -2.2% |
| KV pool tokens (dp8) | 976384 | **1019392** | +4.4% |

The +2.1% throughput / +4.4% KV are consistent with skipping 57 layers of indexer params/forward.

## Checklist

- [x] `pre-commit run --all-files`
- [x] Backward-compat with GLM-5.1 verified (config parsing + e2e on same image)
- [x] e2e sanity + GSM8K on v6e-64 W8A8 dp1/dp8
- [x] Rebased onto `0498a2e7` (post-#1344/#1379)
