### PR TITLE
fix(disaggregation): support chunked prefill for PD reqs

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -427,11 +427,16 @@ class Req:
             self.extend_input_len = len(self.fill_ids) - len(self.prefix_indices)
             return
         # PD req with empty output_ids: skip match_prefix to avoid
-        # stale radix cache hits.
+        # stale radix cache hits, but preserve prefix_indices set by
+        # cache_unfinished_req for chunked-prefill continuation rounds
+        # (otherwise extend_input_len never shrinks and a req longer than
+        # chunked-prefill-size loops forever, and a budget-chunked short
+        # req leaks its first round's pages).
         if getattr(self, "bootstrap_room", None) is not None and not self.output_ids:
-            self.prefix_indices = []
-            self.last_matched_prefix_len = 0
-            self.extend_input_len = len(self.fill_ids)
+            if getattr(self, "is_chunked", 0) == 0:
+                self.prefix_indices = []
+                self.last_matched_prefix_len = 0
+            self.extend_input_len = len(self.fill_ids) - len(self.prefix_indices)
             root = getattr(tree_cache, "root_node", None) if tree_cache is not None else None
             self.last_node = root
             self.last_host_node = root

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -68,10 +68,7 @@ from sgl_jax.srt.managers.scheduler_output_processor_mixin import (
 from sgl_jax.srt.managers.scheduler_profiler_mixing import SchedulerProfilerMixin
 from sgl_jax.srt.managers.tp_worker import ModelWorker
 from sgl_jax.srt.managers.tp_worker_overlap_thread import ModelWorkerClient
-from sgl_jax.srt.managers.utils import (
-    validate_input_length,
-    validate_pd_no_chunked_prefill,
-)
+from sgl_jax.srt.managers.utils import validate_input_length
 from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
 from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
 from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
@@ -1068,17 +1065,6 @@ class Scheduler(
             req,
             self.max_req_input_len,
             self.server_args.allow_auto_truncate,
-        )
-        if error_msg:
-            req.set_finish_with_abort(error_msg)
-            self._add_request_to_queue(req)
-            return
-
-        # PD disaggregation does not support chunked prefill yet.
-        error_msg = validate_pd_no_chunked_prefill(
-            req,
-            self.server_args.disaggregation_mode,
-            self.server_args.chunked_prefill_size,
         )
         if error_msg:
             req.set_finish_with_abort(error_msg)

--- a/python/sgl_jax/srt/managers/utils.py
+++ b/python/sgl_jax/srt/managers/utils.py
@@ -43,32 +43,6 @@ def validate_input_length(
     return None
 
 
-def validate_pd_no_chunked_prefill(
-    req: Req, disaggregation_mode: str, chunked_prefill_size: int | None
-) -> str | None:
-    """Reject PD requests whose prompt would be chunked.
-
-    PD disaggregation does not support chunked prefill: process_prefill_chunk
-    replaces process_batch_result for PD batches, so a chunked req never
-    advances past its first chunk and leaks KV until OOM. Guard against it
-    until chunk-prefill-transfer lands.
-
-    Returns an error message if the request must be rejected, else None.
-    """
-    if disaggregation_mode == "null":
-        return None
-    if not chunked_prefill_size or chunked_prefill_size <= 0:
-        return None
-    if len(req.origin_input_ids) > chunked_prefill_size:
-        return (
-            f"Input length ({len(req.origin_input_ids)} tokens) exceeds "
-            f"chunked_prefill_size ({chunked_prefill_size} tokens). PD "
-            f"disaggregation does not support chunked prefill; raise "
-            f"--chunked-prefill-size or use a shorter input."
-        )
-    return None
-
-
 @jax.jit(static_argnames=("mesh"))
 def resolve_future_token_ids(input_ids, future_token_ids_map, mesh):
     input_ids_global = jax.sharding.reshard(input_ids, NamedSharding(mesh, P()))

--- a/test/srt/disaggregation/test_pd_prefill.py
+++ b/test/srt/disaggregation/test_pd_prefill.py
@@ -1,4 +1,4 @@
-"""Tests for PD prefill side: sender release, prefill info validation/cache, host KV pool, jax transfer wrapper, KV gather, payload roundtrip, no-chunked-prefill guard."""
+"""Tests for PD prefill side: sender release, prefill info validation/cache, host KV pool, jax transfer wrapper, KV gather, payload roundtrip."""
 
 from __future__ import annotations
 
@@ -31,7 +31,6 @@ from sgl_jax.srt.disaggregation.prefill import (
     _jit_gather_one_layer,
     _pad_to_page_bucket,
 )
-from sgl_jax.srt.managers.utils import validate_pd_no_chunked_prefill
 from sgl_jax.srt.mem_cache.host_kv_pool import QueueHostKVPool, StagedData
 
 # ---- from test_pd_prefill_sender_release.py ----
@@ -722,37 +721,3 @@ def test_path_a_rollback_releases_only_registered_sub_uuids_no_double_free():
     assert w.released == ["uuid-1:a"]
     # pool slot was NEVER released (scheduler prefill-terminal callback owns it)
     assert pool.released == []
-
-
-# ---- from test_pd_no_chunked_prefill_guard.py ----
-
-
-def _req(seqlen: int) -> SimpleNamespace:
-    return SimpleNamespace(origin_input_ids=list(range(seqlen)))
-
-
-def test_non_pd_mode_never_rejects():
-    err = validate_pd_no_chunked_prefill(_req(100000), "null", 4096)
-    assert err is None
-
-
-def test_pd_under_limit_passes():
-    err = validate_pd_no_chunked_prefill(_req(4096), "prefill", 4096)
-    assert err is None
-
-
-def test_pd_over_limit_rejected():
-    err = validate_pd_no_chunked_prefill(_req(4097), "prefill", 4096)
-    assert err is not None
-    assert "chunked_prefill_size" in err
-
-
-def test_pd_decode_mode_over_limit_rejected():
-    err = validate_pd_no_chunked_prefill(_req(5000), "decode", 4096)
-    assert err is not None
-
-
-def test_disabled_chunked_prefill_never_rejects():
-    assert validate_pd_no_chunked_prefill(_req(100000), "prefill", None) is None
-    assert validate_pd_no_chunked_prefill(_req(100000), "prefill", 0) is None
-    assert validate_pd_no_chunked_prefill(_req(100000), "prefill", -1) is None


### PR DESCRIPTION
Addresses the chunked-prefill review comment on #1368.

`Req.init_next_round_input` resets `prefix_indices=[]` for PD reqs every round, so a chunked PD req's `extend_input_len` never shrinks below the full input length. Two failure modes:

- a req longer than `chunked-prefill-size` loops forever (P fills the KV pool to OOM, D gets the first chunk's partial KV and produces garbage);
- a short req truncated by the per-batch budget re-allocs round-1's pages on round 2 and leaks them (observed on this branch: c=64 IL=1024 leaves P `token usage` at 0.08 after all senders ack).

## Change

- `schedule_batch.py`: keep `prefix_indices` on chunked-continuation rounds (`is_chunked > 0`); only reset on the first round. `get_next_batch_to_run` already calls `cache_unfinished_req` on the chunked req, so the next round's `extend_input_len` is `full_IL - committed`.
- drop `validate_pd_no_chunked_prefill` (function + callsite + tests) since long prompts now converge instead of being rejected.

## Testing

`pytest test/srt/disaggregation/` — 329 passed (9 pre-existing py3.11 `class X[T]` env failures, same as the base branch).

Multi-host PD on this branch + this commit (2× 4-host v6e-16, P TP=16 ↔ D TP=16, Qwen3-8B, no D2H):

| | base (78bfc67) | this PR |
|---|---|---|
| IL=5601 (> chunk_size 2048) | rejected by guard | P 3 chunks (2048+2048+1536), D output `' The capital of France is Paris. ...'` ✓ |
| c=64 IL=1024 n=128 | 128/128, P token usage stays at **0.08** after | 128/128, P token usage returns to **0.00** |
| c=64 throughput / p99 | 196.4 tok/s / 68.5s | 198.7 tok/s / 49.3s |
| 8-host server fail-lines | 0 | 0 |

The design doc's `Chunked prefill under PD | ❌` row can flip to ✓ (left that to you since it's your doc).
