### PR TITLE
feat(mem_cache): HiCache Stage 0 — LRUHostKVPool host pinned KV pool

### DIFF
--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -6,7 +6,6 @@ import logging
 import threading
 from contextlib import suppress
 from dataclasses import dataclass
-from functools import partial
 from typing import TYPE_CHECKING
 
 import jax
@@ -27,60 +26,6 @@ if TYPE_CHECKING:
     from sgl_jax.srt.managers.scheduler import Scheduler
 
 logger = logging.getLogger(__name__)
-
-
-@partial(
-    jax.jit,
-    static_argnames=(
-        "page_size",
-        "kv_partition_axis",
-        "attention_data_partition_axis",
-        "mesh",
-    ),
-    donate_argnames=("kv_cache",),
-)
-def _jit_write_one_layer(
-    layer_kv,
-    loc,
-    kv_cache,
-    page_size,
-    kv_partition_axis,
-    attention_data_partition_axis,
-    mesh,
-):
-    """One-layer PD KV write, wrapped in a module-level ``jax.jit``.
-
-    The stable module-level ``jax.jit`` makes the trace cache hit on shape +
-    static args so the Pallas write kernel compiles once per write shape and is
-    reused thereafter.
-    """
-    from sgl_jax.srt.mem_cache.memory_pool import _set_fused_kv_buffer
-
-    total_tokens = loc.shape[0]
-    fused_sharding = NamedSharding(
-        mesh,
-        PartitionSpec(
-            attention_data_partition_axis,
-            None,
-            kv_partition_axis,
-            None,
-            None,
-        ),
-    )
-    fused = jax.lax.reshape(
-        layer_kv,
-        (total_tokens, 1) + tuple(layer_kv.shape[2:]),
-        out_sharding=fused_sharding,
-    )
-    return _set_fused_kv_buffer(
-        fused_kv=fused,
-        loc=loc,
-        kv_cache=kv_cache,
-        page_size=page_size,
-        kv_partition_axis=kv_partition_axis,
-        attention_data_partition_axis=attention_data_partition_axis,
-        mesh=mesh,
-    )
 
 
 @dataclass
@@ -666,11 +611,13 @@ class SchedulerDisaggregationDecodeMixin:
             jnp.asarray(loc_np),
             NamedSharding(kv_pool.mesh, PartitionSpec(kv_pool.attention_data_partition_axis)),
         )
+        from sgl_jax.srt.mem_cache.memory_pool import write_kv_layer
+
         for i, layer_id in enumerate(
             range(kv_pool.start_layer, kv_pool.start_layer + kv_pool.layer_num)
         ):
             layer_idx = layer_id - kv_pool.start_layer
-            kv_pool.kv_buffer[layer_idx] = _jit_write_one_layer(
+            kv_pool.kv_buffer[layer_idx] = write_kv_layer(
                 kv[i],
                 loc,
                 kv_pool.kv_buffer[layer_idx],

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -15,6 +15,7 @@ from jax.sharding import NamedSharding, PartitionSpec
 
 from sgl_jax.srt.disaggregation.base.kv_manager import KVPoll
 from sgl_jax.srt.disaggregation.bootstrap import BootstrapClient, PrefillInfoCache
+from sgl_jax.srt.mem_cache.memory_pool import write_kv_layer
 from sgl_jax.srt.disaggregation.jax_transfer.conn import (
     JaxTransferKVManager,
     JaxTransferKVReceiver,
@@ -611,7 +612,6 @@ class SchedulerDisaggregationDecodeMixin:
             jnp.asarray(loc_np),
             NamedSharding(kv_pool.mesh, PartitionSpec(kv_pool.attention_data_partition_axis)),
         )
-        from sgl_jax.srt.mem_cache.memory_pool import write_kv_layer
 
         for i, layer_id in enumerate(
             range(kv_pool.start_layer, kv_pool.start_layer + kv_pool.layer_num)

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -15,12 +15,12 @@ from jax.sharding import NamedSharding, PartitionSpec
 
 from sgl_jax.srt.disaggregation.base.kv_manager import KVPoll
 from sgl_jax.srt.disaggregation.bootstrap import BootstrapClient, PrefillInfoCache
-from sgl_jax.srt.mem_cache.memory_pool import write_kv_layer
 from sgl_jax.srt.disaggregation.jax_transfer.conn import (
     JaxTransferKVManager,
     JaxTransferKVReceiver,
     PMetadata,
 )
+from sgl_jax.srt.mem_cache.memory_pool import write_kv_layer
 
 if TYPE_CHECKING:
     from sgl_jax.srt.managers.schedule_batch import Req

--- a/python/sgl_jax/srt/mem_cache/host_kv_pool.py
+++ b/python/sgl_jax/srt/mem_cache/host_kv_pool.py
@@ -620,22 +620,48 @@ class LRUHostKVPool(HostKVPool):
             staged_pages.append(packed)
 
         n = len(host_buffer_ids)
-        # Bucket the page count so write_kv_layer compiles once per bucket, not
-        # per distinct n. Pad pages by duplicating page 0; the padding tokens get
-        # loc=-1, which the kernel skips, so the duplicate data is never written.
-        n_b = self._pad_to_page_bucket(n)
-        sel = list(range(n)) + [0] * (n_b - n)
+        dp = self._device_pool
+        dp_size = int(dp.dp_size)
+        num_dev_pages = int(dp.kv_buffer[0].shape[0])
+        pages_per_shard = num_dev_pages // dp_size
+
+        # The KV buffer's page axis is sharded contiguously across the data axis:
+        # shard d owns global pages [d*pages_per_shard, (d+1)*pages_per_shard).
+        # write_kv_layer's shard_map splits loc/data into dp_size equal contiguous
+        # chunks and indexes each shard's LOCAL slice -- so a global page must land
+        # in its owning shard's chunk, addressed as a shard-local offset (passing
+        # global ids writes to the wrong shard under dp>1). Give every shard a
+        # fixed per_shard bucket (pad_to_page_bucket(n) == the worst case where all
+        # n pages fall on one shard) so the compiled shape depends only on
+        # (n bucket, dp_size). For dp_size==1 this collapses to one global==local
+        # chunk -- identical to the single-shard layout.
+        per_shard = self._pad_to_page_bucket(n)
+        n_b = per_shard * dp_size
+        # Bucket each transfer page into its owning shard's slot list; padding
+        # slots keep staged index 0 (data ignored) and loc -1 (kernel skips it).
+        shard_sel = [[0] * per_shard for _ in range(dp_size)]
+        shard_loc = [[-1] * per_shard for _ in range(dp_size)]
+        fill_pos = [0] * dp_size
+        for k, gp in enumerate(int(p) for p in device_indices):
+            d = gp // pages_per_shard
+            pos = fill_pos[d]
+            shard_sel[d][pos] = k
+            shard_loc[d][pos] = gp - d * pages_per_shard
+            fill_pos[d] = pos + 1
+        sel = [k for chunk in shard_sel for k in chunk]
         stack = jnp.stack(
             [staged_pages[i] for i in sel], axis=0
         )  # (n_b, layer_num, *per_layer_shape)
 
-        # Expand global page ids -> absolute device token slots (page*PS + offset),
-        # then pad to n_b pages with -1 (skipped by the kernel).
-        dev_pages = np.asarray(device_indices, dtype=np.int64)
-        loc_np = (dev_pages[:, None] * PS + np.arange(PS, dtype=np.int64)).reshape(-1)
-        if n_b > n:
-            loc_np = np.concatenate([loc_np, -np.ones((n_b - n) * PS, dtype=loc_np.dtype)])
-        dp = self._device_pool
+        # Expand shard-local page ids -> shard-local token slots (page*PS + offset),
+        # -1 for padding. The per-shard chunk order matches the loc/data data-axis
+        # split so each shard receives exactly the pages it owns.
+        loc_pages = np.asarray([lp for chunk in shard_loc for lp in chunk], dtype=np.int64)
+        loc_np = np.where(
+            loc_pages[:, None] < 0,
+            -1,
+            loc_pages[:, None] * PS + np.arange(PS, dtype=np.int64),
+        ).reshape(-1)
         loc = jax.device_put(
             jnp.asarray(loc_np, dtype=jnp.int32),
             NamedSharding(dp.mesh, PartitionSpec(dp.attention_data_partition_axis)),

--- a/python/sgl_jax/srt/mem_cache/host_kv_pool.py
+++ b/python/sgl_jax/srt/mem_cache/host_kv_pool.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 
@@ -108,6 +109,36 @@ class HostKVPool(abc.ABC):
     @abc.abstractmethod
     def total_size(self) -> int:
         """Total entries in the pool (free + in-use)."""
+
+    # ------------------------------------------------------------------
+    # Symmetric buffer_id-addressed transfer primitives (HiCache).
+    #
+    # Defaulted (NOT @abc.abstractmethod) so QueueHostKVPool stays concrete
+    # and the PD path is untouched: only the retaining LRUHostKVPool overrides
+    # these. Signatures are pure-integer index pairs, deliberately isomorphic
+    # to a future raiden ``d2h(src_offsets, dst_offsets)`` / ``h2d(...)`` so
+    # the storage backend can be swapped with zero upper-layer changes.
+    # ------------------------------------------------------------------
+
+    def copy_into(self, device_indices: list[int], host_buffer_ids: list[int]) -> None:
+        """Retaining D2H: copy device-pool page(s) into RESERVED slot(s).
+
+        ``device_indices[i]`` pairs with ``host_buffer_ids[i]``. Unlike
+        :meth:`copy_from_device` (which hands the staged ``array_pytree`` back
+        to the caller and retains nothing), the data STAYS in the slot until
+        :meth:`release`. No ``jax.Array`` crosses the boundary. Only
+        LRUHostKVPool overrides this.
+        """
+        raise NotImplementedError
+
+    def copy_to_device(self, host_buffer_ids: list[int], device_indices: list[int]) -> None:
+        """H2D: scatter slot(s) back into the device pool by index.
+
+        ``host_buffer_ids[i]`` pairs with ``device_indices[i]``. The existing
+        ABC has no local H2D (PD does not need it). Only LRUHostKVPool
+        overrides this.
+        """
+        raise NotImplementedError
 
 
 class QueueHostKVPool(HostKVPool):
@@ -268,6 +299,579 @@ class QueueHostKVPool(HostKVPool):
             host_pool_free(self._pool_name, 1)
         except Exception:  # noqa: BLE001
             pass
+
+
+class LRUHostKVPool(HostKVPool):
+    """Retaining host pool for HiCache L2.
+
+    Unlike :class:`QueueHostKVPool` (PD one-shot borrow), a slot here RETAINS
+    its data — staged via :meth:`copy_into`, read back via
+    :meth:`copy_to_device`, and held until :meth:`release`. Each slot stores one
+    KV page packed across all layers as a single pinned-host ``jax.Array`` of
+    shape ``(layer_num, *per_layer_shape)``; retention is just holding the
+    reference, so there is no ``dynamic_update_slice`` on sharded host memory
+    (which crashes multi-chip — the MegaScale issue from the HiCache+PD spike).
+
+    The control plane is PAGE-addressed: every ``int`` that crosses the
+    boundary is a page id (a ``buffer_id`` IS a host page-slot id, and the
+    paired device index is a device page index into ``kv_buffer``'s leading
+    axis). The radix layer folds its token-level ``node.value`` to pages
+    (``// page_size``) before calling in; this pool never sees tokens. Batched
+    page alloc/free go through :meth:`alloc` / :meth:`free`; one-shot borrows
+    through :meth:`reserve` / :meth:`release`. ``available_size`` / ``total_size``
+    count PAGES. No host ``jax.Array`` crosses the boundary, so the storage
+    backend is later raiden-switchable (its block interface is also page-grained)
+    with zero upper-layer changes.
+
+    ``self._lock`` protects only the ``_free_ids`` free-list and ``_lock_ref``
+    counters (reserve/release/inc_lock_ref/dec_lock_ref). The per-slot writes in
+    :meth:`copy_into` / reads in :meth:`copy_to_device` are NOT lock-protected
+    and rely on the caller holding an exclusive reservation of that buffer_id.
+    """
+
+    def __init__(
+        self,
+        device_pool: Any,
+        pool_size: int,
+        page_size: int,
+        layer_num: int,
+        per_layer_shape: tuple[int, ...],
+        dtype: Any,
+        mesh: Mesh,
+        partition_spec: PartitionSpec,
+        *,
+        pool_name: str = "hicache",
+    ) -> None:
+        if pool_size <= 0:
+            raise ValueError(f"pool_size must be positive, got {pool_size}")
+        self._device_pool = device_pool
+        self._pool_size = pool_size
+        self._page_size = page_size
+        self._layer_num = layer_num
+        self._per_layer_shape = tuple(per_layer_shape)
+        self._dtype = dtype
+        self._mesh = mesh
+        self._partition_spec = partition_spec
+        self._pool_name = pool_name
+
+        # A slot is the page packed over layers: prepend a replicated layer
+        # axis and drop the device pool's leading page/DP axis (a single
+        # gathered page is not DP-sharded). The TP axis on heads is preserved.
+        self._slot_spec = PartitionSpec(None, *tuple(partition_spec)[1:])
+        self._host_sharding = _make_host_sharding(mesh, self._slot_spec)
+        self._device_packed_sharding = NamedSharding(mesh, self._slot_spec)
+        # A single gathered page (one layer, page axis dropped). On multi-chip,
+        # plain ``arr[idx]`` cannot resolve the output sharding of a gather, so
+        # the explicit ``.at[idx].get(out_sharding=)`` form is required.
+        self._gathered_layer_sharding = NamedSharding(
+            mesh, PartitionSpec(*tuple(partition_spec)[1:])
+        )
+        # Batched gather output (one layer, MANY pages): the page axis is back,
+        # so this needs the leading axis named. The gathered pages are not
+        # DP-distributed (arbitrary indices into a contiguous output), so the
+        # leading axis is replicated (None) — same form PD's gather uses
+        # (disaggregation/prefill.py:393-396). TP on heads preserved.
+        self._batched_layer_sharding = NamedSharding(
+            mesh, PartitionSpec(None, *tuple(partition_spec)[1:])
+        )
+        # PD's bucketed batched-gather helpers, reused to bound compiled shapes
+        # (one kernel per page bucket, not per distinct page count). Imported
+        # here (runtime, post-module-load) to avoid a mem_cache<-disaggregation
+        # import cycle.
+        from sgl_jax.srt.disaggregation.prefill import (
+            _jit_gather_one_layer,
+            _pad_to_page_bucket,
+        )
+
+        self._jit_gather_one_layer = _jit_gather_one_layer
+        self._pad_to_page_bucket = _pad_to_page_bucket
+
+        self._lock = threading.Lock()
+        self._free_ids: list[int] = list(range(pool_size))
+        self._slots: list[jax.Array | None] = [None] * pool_size
+        self._lock_ref: list[int] = [0] * pool_size
+        self._peak_used = 0
+        self._exhaust_count = 0
+        self._last_exhaust_log = 0.0
+        # Pre-gathered device pages awaiting their (async) host transfer, keyed
+        # by buffer_id. Filled by stage_backup() on the buffer-owning thread,
+        # drained by flush_backup() on the D2H worker. See stage_backup() for
+        # why the gather must be synchronous.
+        self._pending_lock = threading.Lock()
+        self._pending_gather: dict[int, jax.Array] = {}
+        # Pre-staged host pages awaiting their (cheap) in-place scatter into the
+        # device KV buffer, keyed by buffer_id. Filled by stage_load() on the D2H
+        # worker (slow host->device device_put, never touches kv_buffer), drained
+        # by flush_load() on the buffer-owning thread (cheap aliased kernel write,
+        # must run in a donation-safe window). Mirrors _pending_gather (D2H).
+        self._pending_load_lock = threading.Lock()
+        self._pending_load: dict[int, jax.Array] = {}
+
+    # ------------------------------------------------------------------
+    # HostKVPool ABC
+    # ------------------------------------------------------------------
+
+    def reserve(self) -> int | None:
+        # Pure free-list pop; does NOT auto-evict. When full it returns None and
+        # the tree-cache layer is responsible for releasing an LRU slot before
+        # retry (RFC-1.0 §5.1) — the pool cannot evict because only the tree
+        # knows which buffer_id a node still points at.
+        with self._lock:
+            if not self._free_ids:
+                self._exhaust_count += 1
+                now = time.time()
+                if now - self._last_exhaust_log >= 1.0:
+                    self._last_exhaust_log = now
+                    logger.info(
+                        "host pool %s exhausted (size=%d, peak_used=%d, "
+                        "exhaust_count=%d); tree cache must evict before retry",
+                        self._pool_name,
+                        self._pool_size,
+                        self._peak_used,
+                        self._exhaust_count,
+                    )
+                return None
+            buffer_id = self._free_ids.pop(0)
+            used = self._pool_size - len(self._free_ids)
+            if used > self._peak_used:
+                self._peak_used = used
+            return buffer_id
+
+    def release(self, buffer_id: int) -> None:
+        with self._lock:
+            if not (0 <= buffer_id < self._pool_size):
+                raise ValueError(
+                    f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})"
+                )
+            if buffer_id in self._free_ids:
+                raise RuntimeError(f"double free of buffer_id={buffer_id}")
+            if self._lock_ref[buffer_id] != 0:
+                raise RuntimeError(
+                    f"release of locked buffer_id={buffer_id} "
+                    f"(lock_ref={self._lock_ref[buffer_id]})"
+                )
+            self._slots[buffer_id] = None
+            self._free_ids.append(buffer_id)
+
+    # ------------------------------------------------------------------
+    # Page-batch alloc/free (HiCache control plane, page-addressed).
+    #
+    # The control plane (controller / tree cache) now speaks PAGE ids, not
+    # token ids: a "buffer_id" here IS a host page-slot id, and each slot
+    # physically holds exactly one device page (whole-page storage is forced
+    # by the sharded half-page-write constraint — see the class docstring).
+    # alloc/free are the batched, page-addressed counterparts of
+    # reserve/release: they let the radix layer grab/return N pages at once
+    # and map 1:1 onto a future raiden ``d2h``/``h2d`` block interface.
+    # ------------------------------------------------------------------
+
+    def alloc(self, need_pages: int) -> np.ndarray | None:
+        """Pop ``need_pages`` free page slots, returning their page ids.
+
+        All-or-nothing: returns ``None`` if the pool cannot satisfy the
+        request in full (no partial alloc, no auto-evict — the tree-cache
+        layer evicts an LRU node and retries, RFC-1.0 §5.1). The returned
+        ids index host page slots directly.
+        """
+        if need_pages <= 0:
+            raise ValueError(f"need_pages must be positive, got {need_pages}")
+        with self._lock:
+            if len(self._free_ids) < need_pages:
+                self._exhaust_count += 1
+                now = time.time()
+                if now - self._last_exhaust_log >= 1.0:
+                    self._last_exhaust_log = now
+                    logger.info(
+                        "host pool %s short on alloc (need=%d, free=%d, size=%d, "
+                        "exhaust_count=%d); tree cache must evict before retry",
+                        self._pool_name,
+                        need_pages,
+                        len(self._free_ids),
+                        self._pool_size,
+                        self._exhaust_count,
+                    )
+                return None
+            pages = [self._free_ids.pop(0) for _ in range(need_pages)]
+            used = self._pool_size - len(self._free_ids)
+            if used > self._peak_used:
+                self._peak_used = used
+        return np.asarray(pages, dtype=np.int64)
+
+    def free(self, host_page_ids) -> None:
+        """Release page slot(s) by id (deduplicated).
+
+        Batched, page-addressed counterpart of :meth:`release`. Rejects a
+        locked page (``lock_ref != 0``) or an already-free page. De-dupes the
+        input so a caller passing repeated ids (e.g. a token list folded to
+        pages elsewhere) does not double-free.
+        """
+        seen: set[int] = set()
+        unique: list[int] = []
+        for pid in host_page_ids:
+            pid = int(pid)
+            if pid not in seen:
+                seen.add(pid)
+                unique.append(pid)
+        with self._lock:
+            for pid in unique:
+                if not (0 <= pid < self._pool_size):
+                    raise ValueError(
+                        f"page id={pid} outside pool range [0, {self._pool_size})"
+                    )
+                if pid in self._free_ids:
+                    raise RuntimeError(f"double free of page id={pid}")
+                if self._lock_ref[pid] != 0:
+                    raise RuntimeError(
+                        f"free of locked page id={pid} (lock_ref={self._lock_ref[pid]})"
+                    )
+                self._slots[pid] = None
+                self._free_ids.append(pid)
+
+    def stage_backup(
+        self, device_indices: list[int], host_buffer_ids: list[int]
+    ) -> None:
+        """Synchronous device-side gather (the D2H read half of a backup).
+
+        Reads the live device KV pages for ``device_indices`` into materialized,
+        independent device arrays held per ``buffer_id`` in ``_pending_gather``.
+        MUST run on the thread that owns the device KV buffer (the scheduler /
+        forward thread), between forward steps: the forward writes KV with
+        donation, deleting the previous ``kv_buffer[layer]`` array every step,
+        so a gather issued on an off-thread worker races that deletion and
+        crashes with "Array has been deleted". Gathering synchronously here and
+        ``block_until_ready`` materializes the (small) pages before control
+        returns, after which the device buffer can be safely donated; the slow
+        host transfer is deferred to :meth:`flush_backup`.
+        """
+        if len(device_indices) != len(host_buffer_ids):
+            raise ValueError(
+                f"device_indices ({len(device_indices)}) and host_buffer_ids "
+                f"({len(host_buffer_ids)}) length mismatch"
+            )
+        if not host_buffer_ids:
+            return
+        for buffer_id in host_buffer_ids:
+            if not (0 <= buffer_id < self._pool_size):
+                raise ValueError(
+                    f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})"
+                )
+        buffers = self._device_pool.kv_buffer
+        n = len(device_indices)
+        # Bucket the page count so each layer's gather compiles once per bucket
+        # (PD pattern), not once per distinct n. Pad with page 0; the padding
+        # rows are gathered then discarded by the per-buffer slice below.
+        n_b = self._pad_to_page_bucket(n)
+        dev_idx_np = np.asarray(device_indices, dtype=np.int32)
+        if n_b > n:
+            dev_idx_np = np.concatenate(
+                [dev_idx_np, np.zeros(n_b - n, dtype=dev_idx_np.dtype)]
+            )
+        page_indices = jax.device_put(
+            dev_idx_np, NamedSharding(self._mesh, PartitionSpec(None))
+        )
+        # One batched gather per layer (page axis back); keep the per-layer loop
+        # so peak HBM stays at one layer's bucket (PD caps it this way too).
+        per_layer = [
+            self._jit_gather_one_layer(
+                buffers[layer], page_indices, self._batched_layer_sharding
+            )
+            for layer in range(self._layer_num)
+        ]
+        packed = jnp.stack(per_layer, axis=0)  # (layer_num, n_b, *per_layer_shape)
+        jax.block_until_ready(packed)
+        # Slice the real pages back per buffer_id (cheap views on the now-
+        # materialized array); padding rows [n:] are dropped.
+        gathered = {bid: packed[:, i] for i, bid in enumerate(host_buffer_ids)}
+        with self._pending_lock:
+            self._pending_gather.update(gathered)
+
+    def flush_backup(self, host_buffer_ids: list[int]) -> None:
+        """Asynchronous host-side transfer (the D2H write half of a backup).
+
+        ``device_put`` the pages gathered by :meth:`stage_backup` into their
+        host slots. Touches only ``_pending_gather`` / ``_slots`` (never the
+        device KV buffer), so it is safe to run on the D2H worker thread while
+        the main thread keeps running forward steps.
+        """
+        if not host_buffer_ids:
+            return
+        # Per-slot host transfer. Runs on the D2H worker thread (off the scheduler
+        # hot path) and was never the profiled bottleneck, so it stays per-slot:
+        # batching here would require slicing a pinned-host array, which has no
+        # CPU implementation and is unnecessary for the critical path.
+        staged: list[jax.Array] = []
+        for buffer_id in host_buffer_ids:
+            with self._pending_lock:
+                packed = self._pending_gather.pop(buffer_id, None)
+            if packed is None:
+                raise RuntimeError(
+                    f"flush_backup with no staged gather for buffer_id={buffer_id}; "
+                    f"stage_backup() must run (synchronously) first"
+                )
+            host_packed = jax.device_put(packed, self._host_sharding)
+            self._slots[buffer_id] = host_packed
+            staged.append(host_packed)
+        jax.block_until_ready(staged)
+
+    def copy_into(self, device_indices: list[int], host_buffer_ids: list[int]) -> None:
+        # Synchronous convenience: gather + host transfer on one thread. Used by
+        # tests and any single-threaded caller. The async HiCache path instead
+        # calls stage_backup() (sync, forward thread) and flush_backup() (worker)
+        # separately so the device read cannot race the KV-buffer donation.
+        self.stage_backup(device_indices, host_buffer_ids)
+        self.flush_backup(host_buffer_ids)
+
+    def copy_to_device(self, host_buffer_ids: list[int], device_indices: list[int]) -> None:
+        # Synchronous convenience: stage (host->device) + scatter (device kernel
+        # write) on one thread. Used by tests and any single-threaded caller. The
+        # async HiCache path instead calls stage_load() (slow device_put, worker
+        # thread, never touches kv_buffer) and flush_load() (cheap aliased kernel
+        # write, buffer-owning thread, donation-safe window) separately so the
+        # slow transfer overlaps the forward and only the cheap scatter has to
+        # serialize with KV-buffer donation.
+        host_buffer_ids = list(host_buffer_ids)
+        self.stage_load(host_buffer_ids)
+        self.flush_load(host_buffer_ids, device_indices)
+
+    def stage_load(self, host_buffer_ids: list[int]) -> None:
+        """Asynchronous host-side read (the slow H2D half of a load-back).
+
+        ``device_put`` each host page slot onto the device into an independent
+        staging array held per ``buffer_id`` in ``_pending_load``. Touches only
+        ``_slots`` / ``_pending_load`` (never the device KV buffer), so it is safe
+        to run on the H2D worker thread while the main thread keeps running
+        forward steps with KV donation. The cheap scatter into ``kv_buffer`` is
+        deferred to :meth:`flush_load`.
+        """
+        if not host_buffer_ids:
+            return
+        # Per-slot host->device transfer. Runs on the H2D worker thread (off the
+        # scheduler hot path) and was never the profiled bottleneck, so it stays
+        # per-slot: batching here would require stacking pinned-host arrays, which
+        # has no CPU implementation and is unnecessary for the critical path.
+        staged: list[jax.Array] = []
+        loaded: dict[int, jax.Array] = {}
+        for buffer_id in host_buffer_ids:
+            if not (0 <= buffer_id < self._pool_size):
+                raise ValueError(
+                    f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})"
+                )
+            slot = self._slots[buffer_id]
+            if slot is None:
+                raise RuntimeError(f"stage_load from empty buffer_id={buffer_id}")
+            packed_dev = jax.device_put(slot, self._device_packed_sharding)
+            loaded[buffer_id] = packed_dev
+            staged.append(packed_dev)
+        jax.block_until_ready(staged)
+        with self._pending_load_lock:
+            self._pending_load.update(loaded)
+
+    def flush_load(self, host_buffer_ids: list[int], device_indices: list[int]) -> None:
+        """Synchronous device scatter (the cheap H2D half of a load-back).
+
+        Writes the pages staged by :meth:`stage_load` into the device KV buffer
+        via the in-place aliased Pallas kernel (``write_kv_layer``), so the write
+        footprint scales with the loaded tokens (not the whole pool). MUST run on
+        the thread that owns the KV buffer, in a donation-safe window (no forward
+        in flight): it reads + reassigns ``kv_buffer[layer]``, which the forward
+        donates every step. ``device_indices`` are GLOBAL device PAGE ids; each is
+        expanded to ``page_size`` absolute token slots for the kernel ``loc``.
+        """
+        if len(host_buffer_ids) != len(device_indices):
+            raise ValueError(
+                f"host_buffer_ids ({len(host_buffer_ids)}) and device_indices "
+                f"({len(device_indices)}) length mismatch"
+            )
+        if not host_buffer_ids:
+            return
+        from sgl_jax.srt.mem_cache.memory_pool import write_kv_layer
+
+        PS = self._page_size
+        staged_pages: list[jax.Array] = []
+        for buffer_id in host_buffer_ids:
+            with self._pending_load_lock:
+                packed = self._pending_load.pop(buffer_id, None)
+            if packed is None:
+                raise RuntimeError(
+                    f"flush_load with no staged page for buffer_id={buffer_id}; "
+                    f"stage_load() must run first"
+                )
+            staged_pages.append(packed)
+
+        n = len(host_buffer_ids)
+        # Bucket the page count so write_kv_layer compiles once per bucket, not
+        # per distinct n. Pad pages by duplicating page 0; the padding tokens get
+        # loc=-1, which the kernel skips, so the duplicate data is never written.
+        n_b = self._pad_to_page_bucket(n)
+        sel = list(range(n)) + [0] * (n_b - n)
+        stack = jnp.stack(
+            [staged_pages[i] for i in sel], axis=0
+        )  # (n_b, layer_num, *per_layer_shape)
+
+        # Expand global page ids -> absolute device token slots (page*PS + offset),
+        # then pad to n_b pages with -1 (skipped by the kernel).
+        dev_pages = np.asarray(device_indices, dtype=np.int64)
+        loc_np = (dev_pages[:, None] * PS + np.arange(PS, dtype=np.int64)).reshape(-1)
+        if n_b > n:
+            loc_np = np.concatenate(
+                [loc_np, -np.ones((n_b - n) * PS, dtype=loc_np.dtype)]
+            )
+        dp = self._device_pool
+        loc = jax.device_put(
+            jnp.asarray(loc_np, dtype=jnp.int32),
+            NamedSharding(dp.mesh, PartitionSpec(dp.attention_data_partition_axis)),
+        )
+        total_tokens = n_b * PS
+        # layer_kv fed to write_kv_layer is [total_tokens, 1, *per_head_tail]. The
+        # fold of (n_b, page_size) -> total_tokens crosses replicated leading axes
+        # but keeps the tensor-sharded head axis, so the reshape needs an explicit
+        # out_sharding (matches write_kv_layer's own fused_sharding).
+        folded_sharding = NamedSharding(
+            dp.mesh,
+            PartitionSpec(
+                dp.attention_data_partition_axis,
+                None,
+                dp.kv_partition_axis,
+                None,
+                None,
+            ),
+        )
+        for layer in range(self._layer_num):
+            # One slice for the whole batch's layer (page axis kept), folded to
+            # tokens — no per-page gather/concatenate.
+            layer_kv = stack[:, layer]  # (n_b, page_size, *per_head_tail)
+            layer_kv = jax.lax.reshape(
+                layer_kv,
+                (total_tokens, 1) + tuple(layer_kv.shape[2:]),
+                out_sharding=folded_sharding,
+            )
+            dp.kv_buffer[layer] = write_kv_layer(
+                layer_kv,
+                loc,
+                dp.kv_buffer[layer],
+                PS,
+                dp.kv_partition_axis,
+                dp.attention_data_partition_axis,
+                dp.mesh,
+            )
+        jax.block_until_ready(dp.kv_buffer)
+
+    def precompile_transfers(self, max_pages: int | None = None) -> None:
+        """Warm up the JIT/Pallas compile of all four transfer kernels for every
+        page bucket up to ``max_pages``, so compilation never lands on the
+        scheduler thread during serving.
+
+        Without this, the first backup/load-back of each new page-bucket shape
+        triggers an XLA (and, for ``flush_load``, a Pallas/Mosaic) compile inline
+        on the scheduler hot path -- the dominant ON-vs-OFF latency gap. Here we
+        drive stage_backup -> flush_backup -> stage_load -> flush_load once per
+        bucket, exercising the exact compiled shapes the serving path will hit.
+        Device pages ``[0, b)`` are used as scratch: safe because serving starts
+        with an empty cache and overwrites every allocated page before any read.
+        """
+        from sgl_jax.srt.disaggregation.prefill import _KV_GATHER_PAGE_BUCKETS
+
+        # Cap at the device pool's PAGE capacity: a single backup/load-back can
+        # at most touch every device page, and no serving transfer ever exceeds
+        # that. ``device_pool.size`` is the token capacity (the same value
+        # kv_cache_builder folds into the host budget), so divide by page_size.
+        dev_pages_total = int(self._device_pool.size) // self._page_size
+        cap = min(self._pool_size, dev_pages_total)
+        if max_pages is not None:
+            cap = min(cap, int(max_pages))
+        if cap <= 0:
+            return
+        buckets = [b for b in _KV_GATHER_PAGE_BUCKETS if b <= cap]
+        if not buckets or buckets[-1] < cap:
+            buckets.append(self._pad_to_page_bucket(cap))
+        t0 = time.perf_counter()
+        warmed = 0
+        for b in buckets:
+            slots = self.alloc(b)
+            if slots is None:
+                logger.warning(
+                    "hicache precompile: host pool too small for bucket=%d "
+                    "(free=%d); stopping warmup early",
+                    b,
+                    self.available_size(),
+                )
+                break
+            host_ids = [int(x) for x in slots]
+            device_idx = list(range(b))
+            try:
+                self.stage_backup(device_idx, host_ids)
+                self.flush_backup(host_ids)
+                self.stage_load(host_ids)
+                self.flush_load(host_ids, device_idx)
+            except Exception as e:
+                # A bucket too large for the write_kv_layer Pallas kernel (SMEM
+                # overflow) must never crash the server: serving never drives a
+                # transfer that big either. Log and stop warming larger buckets.
+                self.free(slots)
+                logger.warning(
+                    "hicache precompile: bucket=%d failed to warm (%s); stopping "
+                    "warmup at the largest kernel-safe bucket",
+                    b,
+                    type(e).__name__,
+                )
+                break
+            self.free(slots)
+            warmed += 1
+        logger.info(
+            "hicache precompile: warmed %d buckets (max=%d pages) in %.1fs",
+            warmed,
+            buckets[warmed - 1] if warmed else 0,
+            time.perf_counter() - t0,
+        )
+
+    def available_size(self) -> int:
+        """Free page slots (HiCache control plane counts in pages)."""
+        with self._lock:
+            return len(self._free_ids)
+
+    def total_size(self) -> int:
+        """Total page slots in the pool (free + in-use)."""
+        return self._pool_size
+
+    def copy_from_device(self, layers: list[jax.Array], buffer_id: int) -> StagedData:
+        # ABC contract only — the HiCache upper layer never calls this (it uses
+        # copy_into so no jax.Array crosses the boundary). Present so the class
+        # is not abstract and so a non-retaining caller could still borrow.
+        if not (0 <= buffer_id < self._pool_size):
+            raise ValueError(
+                f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})"
+            )
+        if len(layers) != self._layer_num:
+            raise ValueError(f"expected {self._layer_num} layers, got {len(layers)}")
+        packed = jnp.stack(list(layers), axis=0)
+        host_packed = jax.device_put(packed, self._host_sharding)
+        jax.block_until_ready(host_packed)
+        self._slots[buffer_id] = host_packed
+        return StagedData(buffer_id=buffer_id, array_pytree=[host_packed])
+
+    # ------------------------------------------------------------------
+    # LRU / lock_ref mechanism (private to this class, not in the ABC).
+    # The pool only provides the mechanism; victim selection lives in the
+    # tree cache (RFC-1.0 §10).
+    # ------------------------------------------------------------------
+
+    def inc_lock_ref(self, buffer_id: int) -> None:
+        with self._lock:
+            if not (0 <= buffer_id < self._pool_size):
+                raise ValueError(
+                    f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})"
+                )
+            self._lock_ref[buffer_id] += 1
+
+    def dec_lock_ref(self, buffer_id: int) -> None:
+        with self._lock:
+            if not (0 <= buffer_id < self._pool_size):
+                raise ValueError(
+                    f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})"
+                )
+            if self._lock_ref[buffer_id] <= 0:
+                raise RuntimeError(f"dec_lock_ref underflow on buffer_id={buffer_id}")
+            self._lock_ref[buffer_id] -= 1
 
 
 def make_unit_mesh() -> Mesh:

--- a/python/sgl_jax/srt/mem_cache/host_kv_pool.py
+++ b/python/sgl_jax/srt/mem_cache/host_kv_pool.py
@@ -329,6 +329,9 @@ class LRUHostKVPool(HostKVPool):
         self._free_ids: list[int] = list(range(pool_size))
         self._slots: list[jax.Array | None] = [None] * pool_size
         self._lock_ref: list[int] = [0] * pool_size
+        # Allocated-state mirror of the free-list (O(1) membership for the
+        # page-id boundary checks below; a bare ``in self._free_ids`` is O(n)).
+        self._allocated: list[bool] = [False] * pool_size
         self._peak_used = 0
         self._exhaust_count = 0
         self._last_exhaust_log = 0.0
@@ -366,6 +369,7 @@ class LRUHostKVPool(HostKVPool):
                     )
                 return None
             buffer_id = self._free_ids.pop(0)
+            self._allocated[buffer_id] = True
             used = self._pool_size - len(self._free_ids)
             if used > self._peak_used:
                 self._peak_used = used
@@ -374,9 +378,7 @@ class LRUHostKVPool(HostKVPool):
     def release(self, buffer_id: int) -> None:
         with self._lock:
             if not (0 <= buffer_id < self._pool_size):
-                raise ValueError(
-                    f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})"
-                )
+                raise ValueError(f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})")
             if buffer_id in self._free_ids:
                 raise RuntimeError(f"double free of buffer_id={buffer_id}")
             if self._lock_ref[buffer_id] != 0:
@@ -386,6 +388,7 @@ class LRUHostKVPool(HostKVPool):
                 )
             self._drop_pending(buffer_id)
             self._slots[buffer_id] = None
+            self._allocated[buffer_id] = False
             self._free_ids.append(buffer_id)
 
     # Page-batch alloc/free: the batched, page-addressed counterparts of
@@ -418,6 +421,8 @@ class LRUHostKVPool(HostKVPool):
                     )
                 return None
             pages = [self._free_ids.pop(0) for _ in range(need_pages)]
+            for pid in pages:
+                self._allocated[pid] = True
             used = self._pool_size - len(self._free_ids)
             if used > self._peak_used:
                 self._peak_used = used
@@ -436,9 +441,7 @@ class LRUHostKVPool(HostKVPool):
         with self._lock:
             for pid in unique:
                 if not (0 <= pid < self._pool_size):
-                    raise ValueError(
-                        f"page id={pid} outside pool range [0, {self._pool_size})"
-                    )
+                    raise ValueError(f"page id={pid} outside pool range [0, {self._pool_size})")
                 if pid in self._free_ids:
                     raise RuntimeError(f"double free of page id={pid}")
                 if self._lock_ref[pid] != 0:
@@ -447,11 +450,10 @@ class LRUHostKVPool(HostKVPool):
                     )
                 self._drop_pending(pid)
                 self._slots[pid] = None
+                self._allocated[pid] = False
                 self._free_ids.append(pid)
 
-    def stage_backup(
-        self, device_indices: list[int], host_buffer_ids: list[int]
-    ) -> None:
+    def stage_backup(self, device_indices: list[int], host_buffer_ids: list[int]) -> None:
         """D2H phase 1: gather live device pages into per-buffer staging arrays.
 
         Sync + on the KV-owning thread: the forward donates ``kv_buffer`` every
@@ -467,10 +469,8 @@ class LRUHostKVPool(HostKVPool):
         if not host_buffer_ids:
             return
         for buffer_id in host_buffer_ids:
-            if not (0 <= buffer_id < self._pool_size):
-                raise ValueError(
-                    f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})"
-                )
+            self._require_allocated(buffer_id)
+        self._require_device_pages(device_indices)
         buffers = self._device_pool.kv_buffer
         n = len(device_indices)
         # Bucket the page count so each layer's gather compiles once per bucket
@@ -479,18 +479,12 @@ class LRUHostKVPool(HostKVPool):
         n_b = self._pad_to_page_bucket(n)
         dev_idx_np = np.asarray(device_indices, dtype=np.int32)
         if n_b > n:
-            dev_idx_np = np.concatenate(
-                [dev_idx_np, np.zeros(n_b - n, dtype=dev_idx_np.dtype)]
-            )
-        page_indices = jax.device_put(
-            dev_idx_np, NamedSharding(self._mesh, PartitionSpec(None))
-        )
+            dev_idx_np = np.concatenate([dev_idx_np, np.zeros(n_b - n, dtype=dev_idx_np.dtype)])
+        page_indices = jax.device_put(dev_idx_np, NamedSharding(self._mesh, PartitionSpec(None)))
         # One batched gather per layer (page axis back); keep the per-layer loop
         # so peak HBM stays at one layer's bucket (PD caps it this way too).
         per_layer = [
-            self._jit_gather_one_layer(
-                buffers[layer], page_indices, self._batched_layer_sharding
-            )
+            self._jit_gather_one_layer(buffers[layer], page_indices, self._batched_layer_sharding)
             for layer in range(self._layer_num)
         ]
         packed = jnp.stack(per_layer, axis=0)  # (layer_num, n_b, *per_layer_shape)
@@ -514,6 +508,7 @@ class LRUHostKVPool(HostKVPool):
         # array, which has no CPU implementation.
         staged: list[jax.Array] = []
         for buffer_id in host_buffer_ids:
+            self._require_allocated(buffer_id)
             with self._pending_lock:
                 packed = self._pending_gather.pop(buffer_id, None)
             if packed is None:
@@ -557,10 +552,7 @@ class LRUHostKVPool(HostKVPool):
         staged: list[jax.Array] = []
         loaded: dict[int, jax.Array] = {}
         for buffer_id in host_buffer_ids:
-            if not (0 <= buffer_id < self._pool_size):
-                raise ValueError(
-                    f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})"
-                )
+            self._require_allocated(buffer_id)
             slot = self._slots[buffer_id]
             if slot is None:
                 raise RuntimeError(f"stage_load from empty buffer_id={buffer_id}")
@@ -587,11 +579,13 @@ class LRUHostKVPool(HostKVPool):
             )
         if not host_buffer_ids:
             return
+        self._require_device_pages(device_indices)
         from sgl_jax.srt.mem_cache.memory_pool import write_kv_layer
 
         PS = self._page_size
         staged_pages: list[jax.Array] = []
         for buffer_id in host_buffer_ids:
+            self._require_allocated(buffer_id)
             with self._pending_load_lock:
                 packed = self._pending_load.pop(buffer_id, None)
             if packed is None:
@@ -616,9 +610,7 @@ class LRUHostKVPool(HostKVPool):
         dev_pages = np.asarray(device_indices, dtype=np.int64)
         loc_np = (dev_pages[:, None] * PS + np.arange(PS, dtype=np.int64)).reshape(-1)
         if n_b > n:
-            loc_np = np.concatenate(
-                [loc_np, -np.ones((n_b - n) * PS, dtype=loc_np.dtype)]
-            )
+            loc_np = np.concatenate([loc_np, -np.ones((n_b - n) * PS, dtype=loc_np.dtype)])
         dp = self._device_pool
         loc = jax.device_put(
             jnp.asarray(loc_np, dtype=jnp.int32),
@@ -736,9 +728,7 @@ class LRUHostKVPool(HostKVPool):
         # copy_into so no jax.Array crosses the boundary). Present so the class
         # is not abstract and so a non-retaining caller could still borrow.
         if not (0 <= buffer_id < self._pool_size):
-            raise ValueError(
-                f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})"
-            )
+            raise ValueError(f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})")
         if len(layers) != self._layer_num:
             raise ValueError(f"expected {self._layer_num} layers, got {len(layers)}")
         packed = jnp.stack(list(layers), axis=0)
@@ -762,20 +752,33 @@ class LRUHostKVPool(HostKVPool):
         with self._pending_load_lock:
             self._pending_load.pop(buffer_id, None)
 
+    def _require_allocated(self, buffer_id: int) -> None:
+        # Page-id boundary invariant: an id handed to a transfer/lock op must be
+        # currently allocated. A free-list id would otherwise get _slots/_lock_ref
+        # written while still claimable by the next alloc() -> double ownership.
+        if not (0 <= buffer_id < self._pool_size):
+            raise ValueError(f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})")
+        if not self._allocated[buffer_id]:
+            raise RuntimeError(f"buffer_id={buffer_id} is not allocated (in free-list)")
+
+    def _require_device_pages(self, device_indices) -> None:
+        # Reject out-of-range device page ids: a negative id would wrap (JAX
+        # negative indexing on D2H gather) or expand to negative loc on H2D
+        # (only -1 is treated as padding by the kernel; other negatives become
+        # real DMA targets and corrupt pages).
+        n_dev = int(self._device_pool.size) // self._page_size
+        for idx in device_indices:
+            if not (0 <= int(idx) < n_dev):
+                raise ValueError(f"device page id={idx} outside range [0, {n_dev})")
+
     def inc_lock_ref(self, buffer_id: int) -> None:
         with self._lock:
-            if not (0 <= buffer_id < self._pool_size):
-                raise ValueError(
-                    f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})"
-                )
+            self._require_allocated(buffer_id)
             self._lock_ref[buffer_id] += 1
 
     def dec_lock_ref(self, buffer_id: int) -> None:
         with self._lock:
-            if not (0 <= buffer_id < self._pool_size):
-                raise ValueError(
-                    f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})"
-                )
+            self._require_allocated(buffer_id)
             if self._lock_ref[buffer_id] <= 0:
                 raise RuntimeError(f"dec_lock_ref underflow on buffer_id={buffer_id}")
             self._lock_ref[buffer_id] -= 1

--- a/python/sgl_jax/srt/mem_cache/host_kv_pool.py
+++ b/python/sgl_jax/srt/mem_cache/host_kv_pool.py
@@ -1,15 +1,11 @@
-"""Host-staging KV pool for PD disaggregation.
+"""Host-staging KV pools (pinned host memory).
 
-The pool is a bounded counting semaphore: it hands out / takes back
-``pool_size`` slot ids via a FIFO queue, capping how many D2H transfers
-are in flight at once. It does not pre-allocate storage — each
-:meth:`QueueHostKVPool.copy_from_device` stages into fresh host arrays
-(pinned host memory, via an explicit ``memory_kind="pinned_host"`` — see
-``_make_host_sharding``). There is no LRU, no lock_ref, no retention —
-every borrow is intended to live for one transfer.
+Two concrete pools share one ABC:
 
-The :class:`HostKVPool` ABC is kept backend-agnostic so an LRU host pool
-can implement the same contract later.
+- :class:`QueueHostKVPool` — PD disaggregation. A bounded FIFO of one-shot
+  slots; each borrow lives for a single D2H transfer (no retention, no LRU).
+- :class:`LRUHostKVPool` — HiCache L2. Slots RETAIN their data until released;
+  page-addressed control plane with lock_ref, ready for a raiden block backend.
 """
 
 from __future__ import annotations
@@ -30,19 +26,12 @@ logger = logging.getLogger(__name__)
 
 
 def _make_host_sharding(mesh: Mesh, partition_spec: PartitionSpec) -> NamedSharding:
-    """Build a pinned-host sharding.
+    """Pinned-host sharding (falls back to default on platforms without it).
 
-    Requests host memory explicitly via ``memory_kind="pinned_host"``. A plain
-    ``NamedSharding(mesh, spec)`` with no ``memory_kind`` resolves to ``device``
-    (HBM) on TPU, which would keep the "staged" KV on the prefill HBM and defeat
-    the whole point of staging — so the kind must be stated explicitly.
-
-    ``pinned_host`` (not ``unpinned_host``): ``jax.experimental.transfer`` pulls
-    a bf16 array registered from an unpinned-host source with a 4-byte stride,
-    reading every other element (``got[i] == src[2i]``) and corrupting the KV.
-    pinned_host transfers bit-exact; it is also what tpu-inference stages
-    through (tpu_connector.py). Falls back to a plain (device) sharding if the
-    platform (e.g. CPU jaxlib) does not support host memory kinds.
+    ``memory_kind="pinned_host"`` is required: a plain ``NamedSharding`` resolves
+    to ``device`` (HBM) on TPU, which would keep the "staged" KV in HBM. Must be
+    ``pinned_host``, not ``unpinned_host`` — an unpinned bf16 source transfers
+    with a 4-byte stride (``got[i] == src[2i]``), silently corrupting the KV.
     """
 
     try:
@@ -57,13 +46,9 @@ def _make_host_sharding(mesh: Mesh, partition_spec: PartitionSpec) -> NamedShard
 
 @dataclass
 class StagedData:
-    """Result of a successful D2H staging copy.
-
-    ``array_pytree`` is a per-layer list of host-side jax.Arrays, each
-    sized to the request's padded page count, ready to hand to
-    ``JaxTransferWrapper.register_pull``. ``buffer_id`` identifies the
-    reserved pool slot; release is owned by the prefill terminal callback.
-    """
+    """Result of a D2H staging copy: a per-layer list of host arrays
+    (``array_pytree``) sized to the request's padded pages, plus the reserved
+    ``buffer_id``. Release is owned by the caller, not by the staging copy."""
 
     buffer_id: int
     array_pytree: list[jax.Array]
@@ -72,20 +57,13 @@ class StagedData:
 class HostKVPool(abc.ABC):
     """Backend-agnostic host-staging KV pool contract.
 
-    Sizing is per-request entry: each entry is a list of ``layer_num``
-    host arrays, each large enough to hold one request's padded pages.
-    Concrete shapes (per-layer K/V split, head count, head dim) live on
-    the implementing class.
+    Each entry is a list of ``layer_num`` host arrays, each holding one
+    request's padded pages. Concrete shapes live on the implementing class.
     """
 
     @abc.abstractmethod
     def reserve(self) -> int | None:
-        """Pop a free slot id, or ``None`` if the pool is exhausted.
-
-        Admission reserves a slot up front; the reserved slot is later
-        filled via :meth:`copy_from_device` and returned via
-        :meth:`release`.
-        """
+        """Pop a free slot id, or ``None`` if exhausted."""
 
     @abc.abstractmethod
     def release(self, buffer_id: int) -> None:
@@ -93,14 +71,9 @@ class HostKVPool(abc.ABC):
 
     @abc.abstractmethod
     def copy_from_device(self, layers: list[jax.Array], buffer_id: int) -> StagedData:
-        """D2H staging primitive used by PD ``producer_handoff``.
-
-        Writes each per-layer device array in ``layers`` into the
-        PRE-RESERVED slot ``buffer_id`` and returns a :class:`StagedData`
-        carrying a per-layer list of right-sized host slices. Release is
-        owned by the caller (prefill terminal callback), not by this
-        method.
-        """
+        """D2H staging for PD ``producer_handoff``: write ``layers`` into the
+        pre-reserved ``buffer_id`` and return a :class:`StagedData`. Release is
+        owned by the caller."""
 
     @abc.abstractmethod
     def available_size(self) -> int:
@@ -110,49 +83,30 @@ class HostKVPool(abc.ABC):
     def total_size(self) -> int:
         """Total entries in the pool (free + in-use)."""
 
-    # ------------------------------------------------------------------
-    # Symmetric buffer_id-addressed transfer primitives (HiCache).
-    #
-    # Defaulted (NOT @abc.abstractmethod) so QueueHostKVPool stays concrete
-    # and the PD path is untouched: only the retaining LRUHostKVPool overrides
-    # these. Signatures are pure-integer index pairs, deliberately isomorphic
-    # to a future raiden ``d2h(src_offsets, dst_offsets)`` / ``h2d(...)`` so
-    # the storage backend can be swapped with zero upper-layer changes.
-    # ------------------------------------------------------------------
+    # Retaining transfer primitives (HiCache). Defaulted (not abstract) so
+    # QueueHostKVPool stays concrete and the PD path is untouched — only
+    # LRUHostKVPool overrides them. Pure integer index pairs, isomorphic to a
+    # future raiden ``d2h(src_offsets, dst_offsets)`` / ``h2d(...)``.
 
     def copy_into(self, device_indices: list[int], host_buffer_ids: list[int]) -> None:
-        """Retaining D2H: copy device-pool page(s) into RESERVED slot(s).
-
-        ``device_indices[i]`` pairs with ``host_buffer_ids[i]``. Unlike
-        :meth:`copy_from_device` (which hands the staged ``array_pytree`` back
-        to the caller and retains nothing), the data STAYS in the slot until
-        :meth:`release`. No ``jax.Array`` crosses the boundary. Only
-        LRUHostKVPool overrides this.
-        """
+        """Retaining D2H: copy device page(s) into reserved slot(s), pairwise.
+        Data STAYS in the slot until :meth:`release`; no ``jax.Array`` crosses
+        the boundary."""
         raise NotImplementedError
 
     def copy_to_device(self, host_buffer_ids: list[int], device_indices: list[int]) -> None:
-        """H2D: scatter slot(s) back into the device pool by index.
-
-        ``host_buffer_ids[i]`` pairs with ``device_indices[i]``. The existing
-        ABC has no local H2D (PD does not need it). Only LRUHostKVPool
-        overrides this.
-        """
+        """H2D: scatter slot(s) back into the device pool by index, pairwise."""
         raise NotImplementedError
 
 
 class QueueHostKVPool(HostKVPool):
-    """FIFO-queue implementation of :class:`HostKVPool`.
+    """FIFO one-shot pool for PD: reserve -> copy_from_device -> release.
 
-    Short-lived borrows only — no LRU, no eviction, no lock_ref. Borrow
-    via :meth:`reserve`, fill via :meth:`copy_from_device`, return via
-    :meth:`release`. ``self._lock`` protects only the
-    ``_free_ids`` free-list (reserve/release); the per-slot buffer writes
-    in :meth:`copy_from_device` are NOT lock-protected and rely instead on
-    the caller holding an exclusive reservation of that ``buffer_id``. The
-    typical caller is the PD producer-handoff path which alternates
-    main-thread reserve with background-thread release triggered by the
-    ZMQ ack listener.
+    No LRU, no eviction, no lock_ref. ``self._lock`` guards only the
+    ``_free_ids`` free-list; per-slot buffer writes in :meth:`copy_from_device`
+    are unlocked and rely on the caller holding an exclusive reservation of that
+    ``buffer_id`` (the PD producer-handoff path: main-thread reserve, background
+    ZMQ-ack release).
     """
 
     def __init__(
@@ -304,29 +258,22 @@ class QueueHostKVPool(HostKVPool):
 class LRUHostKVPool(HostKVPool):
     """Retaining host pool for HiCache L2.
 
-    Unlike :class:`QueueHostKVPool` (PD one-shot borrow), a slot here RETAINS
-    its data — staged via :meth:`copy_into`, read back via
-    :meth:`copy_to_device`, and held until :meth:`release`. Each slot stores one
-    KV page packed across all layers as a single pinned-host ``jax.Array`` of
-    shape ``(layer_num, *per_layer_shape)``; retention is just holding the
-    reference, so there is no ``dynamic_update_slice`` on sharded host memory
-    (which crashes multi-chip — the MegaScale issue from the HiCache+PD spike).
+    A slot RETAINS its data (staged via :meth:`copy_into`, read back via
+    :meth:`copy_to_device`, held until :meth:`release`). Each slot holds one KV
+    page packed over all layers as a single pinned-host ``jax.Array`` of shape
+    ``(layer_num, *per_layer_shape)``; retention is just keeping the reference,
+    so there is no ``dynamic_update_slice`` on sharded host memory (which crashes
+    multi-chip — the MegaScale issue from the HiCache+PD spike).
 
-    The control plane is PAGE-addressed: every ``int`` that crosses the
-    boundary is a page id (a ``buffer_id`` IS a host page-slot id, and the
-    paired device index is a device page index into ``kv_buffer``'s leading
-    axis). The radix layer folds its token-level ``node.value`` to pages
-    (``// page_size``) before calling in; this pool never sees tokens. Batched
-    page alloc/free go through :meth:`alloc` / :meth:`free`; one-shot borrows
-    through :meth:`reserve` / :meth:`release`. ``available_size`` / ``total_size``
+    The control plane is PAGE-addressed: every ``int`` crossing the boundary is a
+    page id (a ``buffer_id`` is a host page-slot id; the paired device index is a
+    page index into ``kv_buffer``). The radix layer folds token-level
+    ``node.value`` to pages before calling in. ``available_size`` / ``total_size``
     count PAGES. No host ``jax.Array`` crosses the boundary, so the storage
-    backend is later raiden-switchable (its block interface is also page-grained)
-    with zero upper-layer changes.
+    backend is raiden-switchable (its block interface is also page-grained).
 
-    ``self._lock`` protects only the ``_free_ids`` free-list and ``_lock_ref``
-    counters (reserve/release/inc_lock_ref/dec_lock_ref). The per-slot writes in
-    :meth:`copy_into` / reads in :meth:`copy_to_device` are NOT lock-protected
-    and rely on the caller holding an exclusive reservation of that buffer_id.
+    ``self._lock`` guards only the free-list and ``_lock_ref``; per-slot
+    writes/reads rely on the caller holding an exclusive reservation.
     """
 
     def __init__(
@@ -360,24 +307,14 @@ class LRUHostKVPool(HostKVPool):
         self._slot_spec = PartitionSpec(None, *tuple(partition_spec)[1:])
         self._host_sharding = _make_host_sharding(mesh, self._slot_spec)
         self._device_packed_sharding = NamedSharding(mesh, self._slot_spec)
-        # A single gathered page (one layer, page axis dropped). On multi-chip,
-        # plain ``arr[idx]`` cannot resolve the output sharding of a gather, so
-        # the explicit ``.at[idx].get(out_sharding=)`` form is required.
-        self._gathered_layer_sharding = NamedSharding(
-            mesh, PartitionSpec(*tuple(partition_spec)[1:])
-        )
-        # Batched gather output (one layer, MANY pages): the page axis is back,
-        # so this needs the leading axis named. The gathered pages are not
-        # DP-distributed (arbitrary indices into a contiguous output), so the
-        # leading axis is replicated (None) — same form PD's gather uses
-        # (disaggregation/prefill.py:393-396). TP on heads preserved.
+        # Batched gather output (one layer, MANY pages): page axis is back and
+        # replicated (gathered pages are not DP-distributed); same form PD uses.
         self._batched_layer_sharding = NamedSharding(
             mesh, PartitionSpec(None, *tuple(partition_spec)[1:])
         )
         # PD's bucketed batched-gather helpers, reused to bound compiled shapes
-        # (one kernel per page bucket, not per distinct page count). Imported
-        # here (runtime, post-module-load) to avoid a mem_cache<-disaggregation
-        # import cycle.
+        # (one kernel per page bucket). Imported at runtime to avoid a
+        # mem_cache <- disaggregation import cycle.
         from sgl_jax.srt.disaggregation.prefill import (
             _jit_gather_one_layer,
             _pad_to_page_bucket,
@@ -393,17 +330,13 @@ class LRUHostKVPool(HostKVPool):
         self._peak_used = 0
         self._exhaust_count = 0
         self._last_exhaust_log = 0.0
-        # Pre-gathered device pages awaiting their (async) host transfer, keyed
-        # by buffer_id. Filled by stage_backup() on the buffer-owning thread,
-        # drained by flush_backup() on the D2H worker. See stage_backup() for
-        # why the gather must be synchronous.
+        # D2H: pages gathered by stage_backup (buffer-owning thread, sync) await
+        # their async host transfer in flush_backup (D2H worker), keyed by buffer_id.
         self._pending_lock = threading.Lock()
         self._pending_gather: dict[int, jax.Array] = {}
-        # Pre-staged host pages awaiting their (cheap) in-place scatter into the
-        # device KV buffer, keyed by buffer_id. Filled by stage_load() on the D2H
-        # worker (slow host->device device_put, never touches kv_buffer), drained
-        # by flush_load() on the buffer-owning thread (cheap aliased kernel write,
-        # must run in a donation-safe window). Mirrors _pending_gather (D2H).
+        # H2D (mirror): pages staged by stage_load (worker, slow device_put, never
+        # touches kv_buffer) await their cheap in-place scatter in flush_load
+        # (buffer-owning thread, donation-safe window), keyed by buffer_id.
         self._pending_load_lock = threading.Lock()
         self._pending_load: dict[int, jax.Array] = {}
 
@@ -453,25 +386,16 @@ class LRUHostKVPool(HostKVPool):
             self._slots[buffer_id] = None
             self._free_ids.append(buffer_id)
 
-    # ------------------------------------------------------------------
-    # Page-batch alloc/free (HiCache control plane, page-addressed).
-    #
-    # The control plane (controller / tree cache) now speaks PAGE ids, not
-    # token ids: a "buffer_id" here IS a host page-slot id, and each slot
-    # physically holds exactly one device page (whole-page storage is forced
-    # by the sharded half-page-write constraint — see the class docstring).
-    # alloc/free are the batched, page-addressed counterparts of
-    # reserve/release: they let the radix layer grab/return N pages at once
-    # and map 1:1 onto a future raiden ``d2h``/``h2d`` block interface.
-    # ------------------------------------------------------------------
+    # Page-batch alloc/free: the batched, page-addressed counterparts of
+    # reserve/release. The control plane speaks PAGE ids; each slot holds exactly
+    # one device page. These map 1:1 onto a future raiden d2h/h2d block interface.
 
     def alloc(self, need_pages: int) -> np.ndarray | None:
-        """Pop ``need_pages`` free page slots, returning their page ids.
+        """Pop ``need_pages`` free page slots, returning their ids.
 
-        All-or-nothing: returns ``None`` if the pool cannot satisfy the
-        request in full (no partial alloc, no auto-evict — the tree-cache
-        layer evicts an LRU node and retries, RFC-1.0 §5.1). The returned
-        ids index host page slots directly.
+        All-or-nothing: returns ``None`` if the request can't be satisfied in
+        full (no partial alloc, no auto-evict — the tree-cache layer evicts an
+        LRU node and retries, RFC-1.0 §5.1).
         """
         if need_pages <= 0:
             raise ValueError(f"need_pages must be positive, got {need_pages}")
@@ -498,13 +422,8 @@ class LRUHostKVPool(HostKVPool):
         return np.asarray(pages, dtype=np.int64)
 
     def free(self, host_page_ids) -> None:
-        """Release page slot(s) by id (deduplicated).
-
-        Batched, page-addressed counterpart of :meth:`release`. Rejects a
-        locked page (``lock_ref != 0``) or an already-free page. De-dupes the
-        input so a caller passing repeated ids (e.g. a token list folded to
-        pages elsewhere) does not double-free.
-        """
+        """Release page slot(s) by id, deduplicated. Rejects locked
+        (``lock_ref != 0``) or already-free pages."""
         seen: set[int] = set()
         unique: list[int] = []
         for pid in host_page_ids:
@@ -530,18 +449,15 @@ class LRUHostKVPool(HostKVPool):
     def stage_backup(
         self, device_indices: list[int], host_buffer_ids: list[int]
     ) -> None:
-        """Synchronous device-side gather (the D2H read half of a backup).
+        """Synchronous device-side gather (D2H read half of a backup).
 
-        Reads the live device KV pages for ``device_indices`` into materialized,
-        independent device arrays held per ``buffer_id`` in ``_pending_gather``.
-        MUST run on the thread that owns the device KV buffer (the scheduler /
-        forward thread), between forward steps: the forward writes KV with
-        donation, deleting the previous ``kv_buffer[layer]`` array every step,
-        so a gather issued on an off-thread worker races that deletion and
-        crashes with "Array has been deleted". Gathering synchronously here and
-        ``block_until_ready`` materializes the (small) pages before control
-        returns, after which the device buffer can be safely donated; the slow
-        host transfer is deferred to :meth:`flush_backup`.
+        Gathers the live device KV pages for ``device_indices`` into independent
+        device arrays held per ``buffer_id`` in ``_pending_gather``. MUST run on
+        the thread owning the KV buffer, between forward steps: the forward
+        donates ``kv_buffer[layer]`` every step, so an off-thread gather races
+        that deletion ("Array has been deleted"). The sync ``block_until_ready``
+        materializes the pages before return (after which the buffer can be
+        donated); the slow host transfer is deferred to :meth:`flush_backup`.
         """
         if len(device_indices) != len(host_buffer_ids):
             raise ValueError(
@@ -586,19 +502,17 @@ class LRUHostKVPool(HostKVPool):
             self._pending_gather.update(gathered)
 
     def flush_backup(self, host_buffer_ids: list[int]) -> None:
-        """Asynchronous host-side transfer (the D2H write half of a backup).
+        """Asynchronous host-side transfer (D2H write half of a backup).
 
-        ``device_put`` the pages gathered by :meth:`stage_backup` into their
-        host slots. Touches only ``_pending_gather`` / ``_slots`` (never the
-        device KV buffer), so it is safe to run on the D2H worker thread while
-        the main thread keeps running forward steps.
+        ``device_put`` the pages gathered by :meth:`stage_backup` into their host
+        slots. Touches only ``_pending_gather`` / ``_slots`` (never the KV
+        buffer), so it is safe on the D2H worker while the main thread runs forward.
         """
         if not host_buffer_ids:
             return
-        # Per-slot host transfer. Runs on the D2H worker thread (off the scheduler
-        # hot path) and was never the profiled bottleneck, so it stays per-slot:
-        # batching here would require slicing a pinned-host array, which has no
-        # CPU implementation and is unnecessary for the critical path.
+        # Per-slot host transfer: on the worker thread (off the hot path), never
+        # the profiled bottleneck. Batching would need to slice a pinned-host
+        # array, which has no CPU implementation.
         staged: list[jax.Array] = []
         for buffer_id in host_buffer_ids:
             with self._pending_lock:
@@ -614,41 +528,34 @@ class LRUHostKVPool(HostKVPool):
         jax.block_until_ready(staged)
 
     def copy_into(self, device_indices: list[int], host_buffer_ids: list[int]) -> None:
-        # Synchronous convenience: gather + host transfer on one thread. Used by
-        # tests and any single-threaded caller. The async HiCache path instead
-        # calls stage_backup() (sync, forward thread) and flush_backup() (worker)
-        # separately so the device read cannot race the KV-buffer donation.
+        # Sync convenience (gather + host transfer on one thread): tests and
+        # single-threaded callers. The async HiCache path calls stage_backup +
+        # flush_backup separately so the device read can't race KV-buffer donation.
         self.stage_backup(device_indices, host_buffer_ids)
         self.flush_backup(host_buffer_ids)
 
     def copy_to_device(self, host_buffer_ids: list[int], device_indices: list[int]) -> None:
-        # Synchronous convenience: stage (host->device) + scatter (device kernel
-        # write) on one thread. Used by tests and any single-threaded caller. The
-        # async HiCache path instead calls stage_load() (slow device_put, worker
-        # thread, never touches kv_buffer) and flush_load() (cheap aliased kernel
-        # write, buffer-owning thread, donation-safe window) separately so the
-        # slow transfer overlaps the forward and only the cheap scatter has to
-        # serialize with KV-buffer donation.
+        # Sync convenience (stage + scatter on one thread): tests and
+        # single-threaded callers. The async HiCache path calls stage_load +
+        # flush_load separately so the slow transfer overlaps forward and only
+        # the cheap scatter serializes with KV-buffer donation.
         host_buffer_ids = list(host_buffer_ids)
         self.stage_load(host_buffer_ids)
         self.flush_load(host_buffer_ids, device_indices)
 
     def stage_load(self, host_buffer_ids: list[int]) -> None:
-        """Asynchronous host-side read (the slow H2D half of a load-back).
+        """Asynchronous host-side read (slow H2D half of a load-back).
 
         ``device_put`` each host page slot onto the device into an independent
         staging array held per ``buffer_id`` in ``_pending_load``. Touches only
-        ``_slots`` / ``_pending_load`` (never the device KV buffer), so it is safe
-        to run on the H2D worker thread while the main thread keeps running
-        forward steps with KV donation. The cheap scatter into ``kv_buffer`` is
+        ``_slots`` / ``_pending_load`` (never the KV buffer), so it is safe on
+        the H2D worker while the main thread runs forward. The cheap scatter is
         deferred to :meth:`flush_load`.
         """
         if not host_buffer_ids:
             return
-        # Per-slot host->device transfer. Runs on the H2D worker thread (off the
-        # scheduler hot path) and was never the profiled bottleneck, so it stays
-        # per-slot: batching here would require stacking pinned-host arrays, which
-        # has no CPU implementation and is unnecessary for the critical path.
+        # Per-slot transfer: worker thread, off the hot path, not the bottleneck.
+        # Batching would need to stack pinned-host arrays (no CPU implementation).
         staged: list[jax.Array] = []
         loaded: dict[int, jax.Array] = {}
         for buffer_id in host_buffer_ids:
@@ -667,15 +574,14 @@ class LRUHostKVPool(HostKVPool):
             self._pending_load.update(loaded)
 
     def flush_load(self, host_buffer_ids: list[int], device_indices: list[int]) -> None:
-        """Synchronous device scatter (the cheap H2D half of a load-back).
+        """Synchronous device scatter (cheap H2D half of a load-back).
 
-        Writes the pages staged by :meth:`stage_load` into the device KV buffer
-        via the in-place aliased Pallas kernel (``write_kv_layer``), so the write
-        footprint scales with the loaded tokens (not the whole pool). MUST run on
-        the thread that owns the KV buffer, in a donation-safe window (no forward
-        in flight): it reads + reassigns ``kv_buffer[layer]``, which the forward
-        donates every step. ``device_indices`` are GLOBAL device PAGE ids; each is
-        expanded to ``page_size`` absolute token slots for the kernel ``loc``.
+        Writes the pages staged by :meth:`stage_load` into the KV buffer via the
+        in-place aliased Pallas kernel (``write_kv_layer``). MUST run on the
+        thread owning the KV buffer, in a donation-safe window: it reads +
+        reassigns ``kv_buffer[layer]``, which the forward donates every step.
+        ``device_indices`` are GLOBAL device PAGE ids, expanded to ``page_size``
+        token slots for the kernel ``loc``.
         """
         if len(host_buffer_ids) != len(device_indices):
             raise ValueError(
@@ -758,69 +664,68 @@ class LRUHostKVPool(HostKVPool):
 
     def precompile_transfers(self, max_pages: int | None = None) -> None:
         """Warm up the JIT/Pallas compile of all four transfer kernels for every
-        page bucket up to ``max_pages``, so compilation never lands on the
-        scheduler thread during serving.
+        page bucket serving can hit, so compilation never lands on the scheduler
+        thread during serving.
 
         Without this, the first backup/load-back of each new page-bucket shape
         triggers an XLA (and, for ``flush_load``, a Pallas/Mosaic) compile inline
-        on the scheduler hot path -- the dominant ON-vs-OFF latency gap. Here we
-        drive stage_backup -> flush_backup -> stage_load -> flush_load once per
-        bucket, exercising the exact compiled shapes the serving path will hit.
-        Device pages ``[0, b)`` are used as scratch: safe because serving starts
-        with an empty cache and overwrites every allocated page before any read.
+        on the scheduler hot path -- the dominant ON-vs-OFF latency gap. Device
+        pages ``[0, r)`` are used as scratch: safe because serving starts with an
+        empty cache and overwrites every allocated page before any read.
         """
         from sgl_jax.srt.disaggregation.prefill import _KV_GATHER_PAGE_BUCKETS
 
-        # Cap at the device pool's PAGE capacity: a single backup/load-back can
-        # at most touch every device page, and no serving transfer ever exceeds
-        # that. ``device_pool.size`` is the token capacity (the same value
-        # kv_cache_builder folds into the host budget), so divide by page_size.
+        # Largest single transfer serving can do = min(host slots, device pages).
+        # ``device_pool.size`` is token capacity, so // page_size. A transfer of
+        # ``r`` real pages compiles shape ``_pad_to_page_bucket(r)``; warm by REAL
+        # count (never more than ``cap_real`` slots, so alloc always fits) and let
+        # the transfer pad internally — covering the top partial bucket too.
         dev_pages_total = int(self._device_pool.size) // self._page_size
-        cap = min(self._pool_size, dev_pages_total)
+        cap_real = min(self._pool_size, dev_pages_total)
         if max_pages is not None:
-            cap = min(cap, int(max_pages))
-        if cap <= 0:
+            cap_real = min(cap_real, int(max_pages))
+        if cap_real <= 0:
             return
-        buckets = [b for b in _KV_GATHER_PAGE_BUCKETS if b <= cap]
-        if not buckets or buckets[-1] < cap:
-            buckets.append(self._pad_to_page_bucket(cap))
+        real_counts = [b for b in _KV_GATHER_PAGE_BUCKETS if b <= cap_real]
+        if not real_counts or real_counts[-1] < cap_real:
+            real_counts.append(cap_real)
         t0 = time.perf_counter()
         warmed = 0
-        for b in buckets:
-            slots = self.alloc(b)
+        for r in real_counts:
+            slots = self.alloc(r)
             if slots is None:
                 logger.warning(
-                    "hicache precompile: host pool too small for bucket=%d "
+                    "hicache precompile: host pool too small for %d pages "
                     "(free=%d); stopping warmup early",
-                    b,
+                    r,
                     self.available_size(),
                 )
                 break
             host_ids = [int(x) for x in slots]
-            device_idx = list(range(b))
+            device_idx = list(range(r))
             try:
                 self.stage_backup(device_idx, host_ids)
                 self.flush_backup(host_ids)
                 self.stage_load(host_ids)
                 self.flush_load(host_ids, device_idx)
             except Exception as e:
-                # A bucket too large for the write_kv_layer Pallas kernel (SMEM
-                # overflow) must never crash the server: serving never drives a
-                # transfer that big either. Log and stop warming larger buckets.
+                # A page count too large for the write_kv_layer Pallas kernel
+                # (SMEM overflow) must never crash the server: serving never
+                # drives a transfer that big either. Log and stop.
                 self.free(slots)
                 logger.warning(
-                    "hicache precompile: bucket=%d failed to warm (%s); stopping "
-                    "warmup at the largest kernel-safe bucket",
-                    b,
+                    "hicache precompile: %d pages failed to warm (%s); stopping "
+                    "at the largest kernel-safe size",
+                    r,
                     type(e).__name__,
                 )
                 break
             self.free(slots)
             warmed += 1
         logger.info(
-            "hicache precompile: warmed %d buckets (max=%d pages) in %.1fs",
+            "hicache precompile: warmed %d shapes (max=%d pages) in %.1fs",
             warmed,
-            buckets[warmed - 1] if warmed else 0,
+            real_counts[warmed - 1] if warmed else 0,
             time.perf_counter() - t0,
         )
 

--- a/python/sgl_jax/srt/mem_cache/host_kv_pool.py
+++ b/python/sgl_jax/srt/mem_cache/host_kv_pool.py
@@ -273,12 +273,15 @@ class LRUHostKVPool(HostKVPool):
     ``int`` crossing the boundary is a page id, and ``available_size`` /
     ``total_size`` count pages.
 
-    ``self._lock`` guards the free-list and ``_lock_ref``. Per-slot reads rely on
-    the caller holding an exclusive reservation, but the transfer write/publish
-    points (``_slots`` in flush_backup, ``_pending_*`` in stage_backup/stage_load)
-    re-check ``_allocated`` under ``_lock`` before publishing, so a concurrent
-    release()/free() can never resurrect data into a freed slot — it surfaces
-    loudly instead. Lock order is ``_lock -> _pending_lock``/``_pending_load_lock``.
+    ``self._lock`` guards the free-list, ``_lock_ref`` and ``_generation``. Per-slot
+    reads rely on the caller holding an exclusive reservation, but the transfer
+    write/publish points (``_slots`` in flush_backup, ``_pending_*`` in
+    stage_backup/stage_load, the scatter in flush_load) capture the slot's epoch
+    (``_generation``) at entry and re-check it under ``_lock`` before publishing.
+    A free()+realloc() that reused the slot mid-transfer leaves ``_allocated`` True
+    but bumps the epoch, so the stale publish is dropped (the ABA a bare
+    ``_allocated`` re-check missed). Lock order is
+    ``_lock -> _pending_lock``/``_pending_load_lock``.
     """
 
     def __init__(
@@ -335,18 +338,28 @@ class LRUHostKVPool(HostKVPool):
         # Allocated-state mirror of the free-list (O(1) membership for the
         # page-id boundary checks below; a bare ``in self._free_ids`` is O(n)).
         self._allocated: list[bool] = [False] * pool_size
+        # Per-slot allocation epoch, bumped on every alloc (reserve/alloc). A
+        # transfer captures the epoch at entry and re-checks it at publish: a
+        # free()+realloc() that reused the slot mid-transfer leaves _allocated
+        # True again but bumps the epoch, so the stale publish is dropped instead
+        # of resurrecting the old allocation's data into the new owner's slot
+        # (the ABA a bare _allocated re-check can't catch).
+        self._generation: list[int] = [0] * pool_size
         self._peak_used = 0
         self._exhaust_count = 0
         self._last_exhaust_log = 0.0
         # D2H: pages gathered by stage_backup (buffer-owning thread, sync) await
-        # their async host transfer in flush_backup (D2H worker), keyed by buffer_id.
+        # their async host transfer in flush_backup (D2H worker), keyed by
+        # buffer_id; each value is ``(epoch, array)`` so flush can reject a stale
+        # publish from a slot reused since staging.
         self._pending_lock = threading.Lock()
-        self._pending_gather: dict[int, jax.Array] = {}
+        self._pending_gather: dict[int, tuple[int, jax.Array]] = {}
         # H2D (mirror): pages staged by stage_load (worker, slow device_put, never
         # touches kv_buffer) await their cheap in-place scatter in flush_load
-        # (buffer-owning thread, donation-safe window), keyed by buffer_id.
+        # (buffer-owning thread, donation-safe window), keyed by buffer_id; value
+        # is ``(epoch, array)`` for the same staleness guard.
         self._pending_load_lock = threading.Lock()
-        self._pending_load: dict[int, jax.Array] = {}
+        self._pending_load: dict[int, tuple[int, jax.Array]] = {}
 
     # ------------------------------------------------------------------
     # HostKVPool ABC
@@ -373,6 +386,7 @@ class LRUHostKVPool(HostKVPool):
                 return None
             buffer_id = self._free_ids.pop(0)
             self._allocated[buffer_id] = True
+            self._generation[buffer_id] += 1
             used = self._pool_size - len(self._free_ids)
             if used > self._peak_used:
                 self._peak_used = used
@@ -426,6 +440,7 @@ class LRUHostKVPool(HostKVPool):
             pages = [self._free_ids.pop(0) for _ in range(need_pages)]
             for pid in pages:
                 self._allocated[pid] = True
+                self._generation[pid] += 1
             used = self._pool_size - len(self._free_ids)
             if used > self._peak_used:
                 self._peak_used = used
@@ -471,8 +486,13 @@ class LRUHostKVPool(HostKVPool):
             )
         if not host_buffer_ids:
             return
-        for buffer_id in host_buffer_ids:
-            self._require_allocated(buffer_id)
+        # Capture each slot's epoch under _lock alongside the allocated check, so
+        # the publish below can tell whether a free()+realloc() reused the slot
+        # while this (slow) gather was in flight.
+        with self._lock:
+            for buffer_id in host_buffer_ids:
+                self._require_allocated(buffer_id)
+            gens = {bid: self._generation[bid] for bid in host_buffer_ids}
         self._require_device_pages(device_indices)
         buffers = self._device_pool.kv_buffer
         n = len(device_indices)
@@ -495,17 +515,18 @@ class LRUHostKVPool(HostKVPool):
         # Slice the real pages back per buffer_id (cheap views on the now-
         # materialized array); padding rows [n:] are dropped.
         gathered = {bid: packed[:, i] for i, bid in enumerate(host_buffer_ids)}
-        # Publish under _lock with an allocation re-check: a free()/release()
-        # may have run since the entry check above (its _drop_pending also takes
-        # _lock, so this serializes against it). Without the re-check a gather
-        # could land in _pending_gather for a slot already returned to the
-        # free-list, to be popped later into a reused slot. Lock order is
-        # _lock -> _pending_lock, matching free()/release().
-        with self._lock:
+        # Publish under _lock, tagging each entry with the epoch captured at
+        # entry. A free()+realloc() since then leaves _allocated True but bumps
+        # the epoch, so the stale gather is dropped rather than landing in the
+        # reused slot (a bare _allocated re-check can't tell the new owner apart).
+        # Lock order is _lock -> _pending_lock, matching free()/release().
+        with self._lock, self._pending_lock:
             for buffer_id in host_buffer_ids:
-                self._require_allocated(buffer_id)
-            with self._pending_lock:
-                self._pending_gather.update(gathered)
+                if self._allocated[buffer_id] and self._generation[buffer_id] == gens[buffer_id]:
+                    self._pending_gather[buffer_id] = (
+                        gens[buffer_id],
+                        gathered[buffer_id],
+                    )
 
     def flush_backup(self, host_buffer_ids: list[int]) -> None:
         """D2H phase 2: ``device_put`` the staged pages into their host slots.
@@ -521,20 +542,21 @@ class LRUHostKVPool(HostKVPool):
         staged: list[jax.Array] = []
         for buffer_id in host_buffer_ids:
             with self._pending_lock:
-                packed = self._pending_gather.pop(buffer_id, None)
-            if packed is None:
+                entry = self._pending_gather.pop(buffer_id, None)
+            if entry is None:
                 raise RuntimeError(
                     f"flush_backup with no staged gather for buffer_id={buffer_id}; "
                     f"stage_backup() must run (synchronously) first"
                 )
+            gen, packed = entry
             host_packed = jax.device_put(packed, self._host_sharding)
-            # Re-check allocation under _lock before publishing into _slots: a
-            # release()/free() may have run after the pop above; writing here
-            # without the guard would resurrect data into a slot already on the
-            # free-list (claimable by the next alloc()).
+            # Publish into _slots only if the slot is still the same allocation
+            # that staged this gather (epoch unchanged): a release()/free()
+            # (+realloc) after the pop above would otherwise resurrect stale data
+            # into the reused slot.
             with self._lock:
-                self._require_allocated(buffer_id)
-                self._slots[buffer_id] = host_packed
+                if self._allocated[buffer_id] and self._generation[buffer_id] == gen:
+                    self._slots[buffer_id] = host_packed
             staged.append(host_packed)
         jax.block_until_ready(staged)
 
@@ -568,24 +590,32 @@ class LRUHostKVPool(HostKVPool):
         # Batching would need to stack pinned-host arrays (no CPU implementation).
         staged: list[jax.Array] = []
         loaded: dict[int, jax.Array] = {}
+        # Read the slot refs + capture epochs under _lock, so the publish can
+        # reject a slot reused since this (slow) device_put started.
+        with self._lock:
+            for buffer_id in host_buffer_ids:
+                self._require_allocated(buffer_id)
+            gens = {bid: self._generation[bid] for bid in host_buffer_ids}
+            slots = {bid: self._slots[bid] for bid in host_buffer_ids}
         for buffer_id in host_buffer_ids:
-            self._require_allocated(buffer_id)
-            slot = self._slots[buffer_id]
+            slot = slots[buffer_id]
             if slot is None:
                 raise RuntimeError(f"stage_load from empty buffer_id={buffer_id}")
             packed_dev = jax.device_put(slot, self._device_packed_sharding)
             loaded[buffer_id] = packed_dev
             staged.append(packed_dev)
         jax.block_until_ready(staged)
-        # Publish under _lock with an allocation re-check (same race as
-        # stage_backup): release()'s _drop_pending also takes _lock, so this
-        # serializes against a slot being freed mid-stage. Lock order
+        # Publish tagged with the entry epoch (same ABA guard as stage_backup): a
+        # free()+realloc() mid-stage bumps the epoch, so the stale device copy is
+        # dropped instead of landing in the reused slot's pending load. Lock order
         # _lock -> _pending_load_lock.
-        with self._lock:
+        with self._lock, self._pending_load_lock:
             for buffer_id in host_buffer_ids:
-                self._require_allocated(buffer_id)
-            with self._pending_load_lock:
-                self._pending_load.update(loaded)
+                if self._allocated[buffer_id] and self._generation[buffer_id] == gens[buffer_id]:
+                    self._pending_load[buffer_id] = (
+                        gens[buffer_id],
+                        loaded[buffer_id],
+                    )
 
     def flush_load(self, host_buffer_ids: list[int], device_indices: list[int]) -> None:
         """H2D phase 2: scatter the staged pages into the KV buffer via the
@@ -607,17 +637,32 @@ class LRUHostKVPool(HostKVPool):
         from sgl_jax.srt.mem_cache.memory_pool import write_kv_layer
 
         PS = self._page_size
+        # Capture each slot's current epoch under _lock; a page whose epoch moved
+        # since stage_load (free()+realloc()) is stale and must not be scattered
+        # into the caller's device pages.
+        with self._lock:
+            cur_gen: dict[int, int | None] = {}
+            for buffer_id in host_buffer_ids:
+                if not (0 <= buffer_id < self._pool_size):
+                    raise ValueError(
+                        f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})"
+                    )
+                cur_gen[buffer_id] = (
+                    self._generation[buffer_id] if self._allocated[buffer_id] else None
+                )
         staged_pages: list[jax.Array] = []
+        fresh: list[bool] = []
         for buffer_id in host_buffer_ids:
-            self._require_allocated(buffer_id)
             with self._pending_load_lock:
-                packed = self._pending_load.pop(buffer_id, None)
-            if packed is None:
+                entry = self._pending_load.pop(buffer_id, None)
+            if entry is None:
                 raise RuntimeError(
                     f"flush_load with no staged page for buffer_id={buffer_id}; "
                     f"stage_load() must run first"
                 )
+            gen, packed = entry
             staged_pages.append(packed)
+            fresh.append(cur_gen[buffer_id] == gen)
 
         n = len(host_buffer_ids)
         dp = self._device_pool
@@ -643,6 +688,8 @@ class LRUHostKVPool(HostKVPool):
         shard_loc = [[-1] * per_shard for _ in range(dp_size)]
         fill_pos = [0] * dp_size
         for k, gp in enumerate(int(p) for p in device_indices):
+            if not fresh[k]:
+                continue  # slot freed/realloc'd since stage_load: drop stale page
             d = gp // pages_per_shard
             pos = fill_pos[d]
             shard_sel[d][pos] = k

--- a/python/sgl_jax/srt/mem_cache/host_kv_pool.py
+++ b/python/sgl_jax/srt/mem_cache/host_kv_pool.py
@@ -79,12 +79,6 @@ class HostKVPool(abc.ABC):
         """Return a reserved slot to the pool by id."""
 
     @abc.abstractmethod
-    def copy_from_device(self, layers: list[jax.Array], buffer_id: int) -> StagedData:
-        """D2H staging for PD ``producer_handoff``: write ``layers`` into the
-        pre-reserved ``buffer_id`` and return a :class:`StagedData`. Release is
-        owned by the caller."""
-
-    @abc.abstractmethod
     def available_size(self) -> int:
         """Entries currently free."""
 
@@ -92,10 +86,15 @@ class HostKVPool(abc.ABC):
     def total_size(self) -> int:
         """Total entries in the pool (free + in-use)."""
 
-    # Retaining transfer primitives (HiCache). Defaulted (not abstract) so
-    # QueueHostKVPool stays concrete and the PD path is untouched — only
-    # LRUHostKVPool overrides them. Pure integer index pairs, isomorphic to a
-    # future raiden ``d2h(src_offsets, dst_offsets)`` / ``h2d(...)``.
+    # Role-specific transfer primitives, all defaulted (not abstract) so each
+    # concrete pool implements only the ones its role needs and stays concrete:
+    # PD overrides copy_from_device; HiCache overrides copy_into/copy_to_device.
+
+    def copy_from_device(self, layers: list[jax.Array], buffer_id: int) -> StagedData:
+        """D2H staging for PD ``producer_handoff``: write ``layers`` into the
+        pre-reserved ``buffer_id`` and return a :class:`StagedData`. Release is
+        owned by the caller. PD-only; HiCache uses :meth:`copy_into`."""
+        raise NotImplementedError
 
     def copy_into(self, device_indices: list[int], host_buffer_ids: list[int]) -> None:
         """Retaining D2H: copy device page(s) into reserved slot(s), pairwise.
@@ -274,8 +273,12 @@ class LRUHostKVPool(HostKVPool):
     ``int`` crossing the boundary is a page id, and ``available_size`` /
     ``total_size`` count pages.
 
-    ``self._lock`` guards only the free-list and ``_lock_ref``; per-slot
-    reads/writes rely on the caller holding an exclusive reservation.
+    ``self._lock`` guards the free-list and ``_lock_ref``. Per-slot reads rely on
+    the caller holding an exclusive reservation, but the transfer write/publish
+    points (``_slots`` in flush_backup, ``_pending_*`` in stage_backup/stage_load)
+    re-check ``_allocated`` under ``_lock`` before publishing, so a concurrent
+    release()/free() can never resurrect data into a freed slot — it surfaces
+    loudly instead. Lock order is ``_lock -> _pending_lock``/``_pending_load_lock``.
     """
 
     def __init__(
@@ -492,8 +495,17 @@ class LRUHostKVPool(HostKVPool):
         # Slice the real pages back per buffer_id (cheap views on the now-
         # materialized array); padding rows [n:] are dropped.
         gathered = {bid: packed[:, i] for i, bid in enumerate(host_buffer_ids)}
-        with self._pending_lock:
-            self._pending_gather.update(gathered)
+        # Publish under _lock with an allocation re-check: a free()/release()
+        # may have run since the entry check above (its _drop_pending also takes
+        # _lock, so this serializes against it). Without the re-check a gather
+        # could land in _pending_gather for a slot already returned to the
+        # free-list, to be popped later into a reused slot. Lock order is
+        # _lock -> _pending_lock, matching free()/release().
+        with self._lock:
+            for buffer_id in host_buffer_ids:
+                self._require_allocated(buffer_id)
+            with self._pending_lock:
+                self._pending_gather.update(gathered)
 
     def flush_backup(self, host_buffer_ids: list[int]) -> None:
         """D2H phase 2: ``device_put`` the staged pages into their host slots.
@@ -508,7 +520,6 @@ class LRUHostKVPool(HostKVPool):
         # array, which has no CPU implementation.
         staged: list[jax.Array] = []
         for buffer_id in host_buffer_ids:
-            self._require_allocated(buffer_id)
             with self._pending_lock:
                 packed = self._pending_gather.pop(buffer_id, None)
             if packed is None:
@@ -517,7 +528,13 @@ class LRUHostKVPool(HostKVPool):
                     f"stage_backup() must run (synchronously) first"
                 )
             host_packed = jax.device_put(packed, self._host_sharding)
-            self._slots[buffer_id] = host_packed
+            # Re-check allocation under _lock before publishing into _slots: a
+            # release()/free() may have run after the pop above; writing here
+            # without the guard would resurrect data into a slot already on the
+            # free-list (claimable by the next alloc()).
+            with self._lock:
+                self._require_allocated(buffer_id)
+                self._slots[buffer_id] = host_packed
             staged.append(host_packed)
         jax.block_until_ready(staged)
 
@@ -560,8 +577,15 @@ class LRUHostKVPool(HostKVPool):
             loaded[buffer_id] = packed_dev
             staged.append(packed_dev)
         jax.block_until_ready(staged)
-        with self._pending_load_lock:
-            self._pending_load.update(loaded)
+        # Publish under _lock with an allocation re-check (same race as
+        # stage_backup): release()'s _drop_pending also takes _lock, so this
+        # serializes against a slot being freed mid-stage. Lock order
+        # _lock -> _pending_load_lock.
+        with self._lock:
+            for buffer_id in host_buffer_ids:
+                self._require_allocated(buffer_id)
+            with self._pending_load_lock:
+                self._pending_load.update(loaded)
 
     def flush_load(self, host_buffer_ids: list[int], device_indices: list[int]) -> None:
         """H2D phase 2: scatter the staged pages into the KV buffer via the
@@ -723,19 +747,6 @@ class LRUHostKVPool(HostKVPool):
         """Total page slots in the pool (free + in-use)."""
         return self._pool_size
 
-    def copy_from_device(self, layers: list[jax.Array], buffer_id: int) -> StagedData:
-        # ABC contract only — the HiCache upper layer never calls this (it uses
-        # copy_into so no jax.Array crosses the boundary). Present so the class
-        # is not abstract and so a non-retaining caller could still borrow.
-        self._require_allocated(buffer_id)
-        if len(layers) != self._layer_num:
-            raise ValueError(f"expected {self._layer_num} layers, got {len(layers)}")
-        packed = jnp.stack(list(layers), axis=0)
-        host_packed = jax.device_put(packed, self._host_sharding)
-        jax.block_until_ready(host_packed)
-        self._slots[buffer_id] = host_packed
-        return StagedData(buffer_id=buffer_id, array_pytree=[host_packed])
-
     # ------------------------------------------------------------------
     # LRU / lock_ref mechanism (private to this class, not in the ABC).
     # The pool only provides the mechanism; victim selection lives in the
@@ -765,7 +776,13 @@ class LRUHostKVPool(HostKVPool):
         # negative indexing on D2H gather) or expand to negative loc on H2D
         # (only -1 is treated as padding by the kernel; other negatives become
         # real DMA targets and corrupt pages).
-        n_dev = int(self._device_pool.size) // self._page_size
+        #
+        # Bound is the kv_buffer's page-axis length, NOT size // page_size: the
+        # fused buffer carries an extra sentinel page (memory_pool packs
+        # ``(size + page_size*dp_size) // page_size`` rows) and the allocator
+        # hands out 1-based page ids up to that top row, so ``size // page_size``
+        # would wrongly reject the highest legitimately-allocated page.
+        n_dev = int(self._device_pool.kv_buffer[0].shape[0])
         for idx in device_indices:
             if not (0 <= int(idx) < n_dev):
                 raise ValueError(f"device page id={idx} outside range [0, {n_dev})")

--- a/python/sgl_jax/srt/mem_cache/host_kv_pool.py
+++ b/python/sgl_jax/srt/mem_cache/host_kv_pool.py
@@ -727,8 +727,7 @@ class LRUHostKVPool(HostKVPool):
         # ABC contract only — the HiCache upper layer never calls this (it uses
         # copy_into so no jax.Array crosses the boundary). Present so the class
         # is not abstract and so a non-retaining caller could still borrow.
-        if not (0 <= buffer_id < self._pool_size):
-            raise ValueError(f"buffer_id={buffer_id} outside pool range [0, {self._pool_size})")
+        self._require_allocated(buffer_id)
         if len(layers) != self._layer_num:
             raise ValueError(f"expected {self._layer_num} layers, got {len(layers)}")
         packed = jnp.stack(list(layers), axis=0)

--- a/python/sgl_jax/srt/mem_cache/host_kv_pool.py
+++ b/python/sgl_jax/srt/mem_cache/host_kv_pool.py
@@ -1,11 +1,20 @@
 """Host-staging KV pools (pinned host memory).
 
-Two concrete pools share one ABC:
+    HostKVPool (ABC)              backend-agnostic contract; page-id boundary
+    │                            (every int crossing in/out is a page id,
+    │                             raiden-block-switchable; no jax.Array crosses)
+    ├── QueueHostKVPool          PD disaggregation: bounded FIFO, one-shot slots
+    │                            (reserve -> copy_from_device -> release; no LRU)
+    └── LRUHostKVPool            HiCache L2: slots RETAIN data until released;
+                                 page-addressed, lock_ref-protected
 
-- :class:`QueueHostKVPool` — PD disaggregation. A bounded FIFO of one-shot
-  slots; each borrow lives for a single D2H transfer (no retention, no LRU).
-- :class:`LRUHostKVPool` — HiCache L2. Slots RETAIN their data until released;
-  page-addressed control plane with lock_ref, ready for a raiden block backend.
+LRUHostKVPool transfers are two-phase, split by which thread may touch the live
+KV buffer (the forward donates it every step):
+
+    D2H backup:    stage_backup (sync gather, KV-owning thread)
+                   -> flush_backup (async host put, D2H worker)
+    H2D load-back: stage_load   (async device put, H2D worker)
+                   -> flush_load (sync scatter, KV-owning thread, donation-safe)
 """
 
 from __future__ import annotations
@@ -258,22 +267,15 @@ class QueueHostKVPool(HostKVPool):
 class LRUHostKVPool(HostKVPool):
     """Retaining host pool for HiCache L2.
 
-    A slot RETAINS its data (staged via :meth:`copy_into`, read back via
-    :meth:`copy_to_device`, held until :meth:`release`). Each slot holds one KV
-    page packed over all layers as a single pinned-host ``jax.Array`` of shape
-    ``(layer_num, *per_layer_shape)``; retention is just keeping the reference,
-    so there is no ``dynamic_update_slice`` on sharded host memory (which crashes
-    multi-chip — the MegaScale issue from the HiCache+PD spike).
-
-    The control plane is PAGE-addressed: every ``int`` crossing the boundary is a
-    page id (a ``buffer_id`` is a host page-slot id; the paired device index is a
-    page index into ``kv_buffer``). The radix layer folds token-level
-    ``node.value`` to pages before calling in. ``available_size`` / ``total_size``
-    count PAGES. No host ``jax.Array`` crosses the boundary, so the storage
-    backend is raiden-switchable (its block interface is also page-grained).
+    Each slot holds one KV page packed over all layers as a single pinned-host
+    ``jax.Array`` ``(layer_num, *per_layer_shape)``; retention = keeping the
+    reference, avoiding ``dynamic_update_slice`` on sharded host (multi-chip
+    crash, the MegaScale issue from the HiCache+PD spike). Page-addressed: every
+    ``int`` crossing the boundary is a page id, and ``available_size`` /
+    ``total_size`` count pages.
 
     ``self._lock`` guards only the free-list and ``_lock_ref``; per-slot
-    writes/reads rely on the caller holding an exclusive reservation.
+    reads/writes rely on the caller holding an exclusive reservation.
     """
 
     def __init__(
@@ -345,10 +347,9 @@ class LRUHostKVPool(HostKVPool):
     # ------------------------------------------------------------------
 
     def reserve(self) -> int | None:
-        # Pure free-list pop; does NOT auto-evict. When full it returns None and
-        # the tree-cache layer is responsible for releasing an LRU slot before
-        # retry (RFC-1.0 §5.1) — the pool cannot evict because only the tree
-        # knows which buffer_id a node still points at.
+        # Free-list pop, no auto-evict: returns None when full. The pool can't
+        # evict (only the tree cache knows which buffer_id a node points at), so
+        # the tree cache must release an LRU slot before retrying.
         with self._lock:
             if not self._free_ids:
                 self._exhaust_count += 1
@@ -383,6 +384,7 @@ class LRUHostKVPool(HostKVPool):
                     f"release of locked buffer_id={buffer_id} "
                     f"(lock_ref={self._lock_ref[buffer_id]})"
                 )
+            self._drop_pending(buffer_id)
             self._slots[buffer_id] = None
             self._free_ids.append(buffer_id)
 
@@ -394,8 +396,8 @@ class LRUHostKVPool(HostKVPool):
         """Pop ``need_pages`` free page slots, returning their ids.
 
         All-or-nothing: returns ``None`` if the request can't be satisfied in
-        full (no partial alloc, no auto-evict — the tree-cache layer evicts an
-        LRU node and retries, RFC-1.0 §5.1).
+        full (no partial alloc, no auto-evict — the tree cache evicts an LRU
+        node and retries).
         """
         if need_pages <= 0:
             raise ValueError(f"need_pages must be positive, got {need_pages}")
@@ -443,21 +445,19 @@ class LRUHostKVPool(HostKVPool):
                     raise RuntimeError(
                         f"free of locked page id={pid} (lock_ref={self._lock_ref[pid]})"
                     )
+                self._drop_pending(pid)
                 self._slots[pid] = None
                 self._free_ids.append(pid)
 
     def stage_backup(
         self, device_indices: list[int], host_buffer_ids: list[int]
     ) -> None:
-        """Synchronous device-side gather (D2H read half of a backup).
+        """D2H phase 1: gather live device pages into per-buffer staging arrays.
 
-        Gathers the live device KV pages for ``device_indices`` into independent
-        device arrays held per ``buffer_id`` in ``_pending_gather``. MUST run on
-        the thread owning the KV buffer, between forward steps: the forward
-        donates ``kv_buffer[layer]`` every step, so an off-thread gather races
-        that deletion ("Array has been deleted"). The sync ``block_until_ready``
-        materializes the pages before return (after which the buffer can be
-        donated); the slow host transfer is deferred to :meth:`flush_backup`.
+        Sync + on the KV-owning thread: the forward donates ``kv_buffer`` every
+        step, so an off-thread gather would race that deletion. ``block_until_ready``
+        materializes the pages before return; the slow host put is deferred to
+        :meth:`flush_backup`.
         """
         if len(device_indices) != len(host_buffer_ids):
             raise ValueError(
@@ -502,11 +502,10 @@ class LRUHostKVPool(HostKVPool):
             self._pending_gather.update(gathered)
 
     def flush_backup(self, host_buffer_ids: list[int]) -> None:
-        """Asynchronous host-side transfer (D2H write half of a backup).
+        """D2H phase 2: ``device_put`` the staged pages into their host slots.
 
-        ``device_put`` the pages gathered by :meth:`stage_backup` into their host
-        slots. Touches only ``_pending_gather`` / ``_slots`` (never the KV
-        buffer), so it is safe on the D2H worker while the main thread runs forward.
+        Touches only ``_pending_gather`` / ``_slots`` (never the KV buffer), so
+        it runs on the D2H worker concurrently with forward.
         """
         if not host_buffer_ids:
             return
@@ -544,12 +543,11 @@ class LRUHostKVPool(HostKVPool):
         self.flush_load(host_buffer_ids, device_indices)
 
     def stage_load(self, host_buffer_ids: list[int]) -> None:
-        """Asynchronous host-side read (slow H2D half of a load-back).
+        """H2D phase 1: ``device_put`` host slots onto the device into per-buffer
+        staging arrays.
 
-        ``device_put`` each host page slot onto the device into an independent
-        staging array held per ``buffer_id`` in ``_pending_load``. Touches only
-        ``_slots`` / ``_pending_load`` (never the KV buffer), so it is safe on
-        the H2D worker while the main thread runs forward. The cheap scatter is
+        Touches only ``_slots`` / ``_pending_load`` (never the KV buffer), so it
+        runs on the H2D worker concurrently with forward; the cheap scatter is
         deferred to :meth:`flush_load`.
         """
         if not host_buffer_ids:
@@ -574,13 +572,12 @@ class LRUHostKVPool(HostKVPool):
             self._pending_load.update(loaded)
 
     def flush_load(self, host_buffer_ids: list[int], device_indices: list[int]) -> None:
-        """Synchronous device scatter (cheap H2D half of a load-back).
+        """H2D phase 2: scatter the staged pages into the KV buffer via the
+        in-place aliased Pallas kernel (``write_kv_layer``).
 
-        Writes the pages staged by :meth:`stage_load` into the KV buffer via the
-        in-place aliased Pallas kernel (``write_kv_layer``). MUST run on the
-        thread owning the KV buffer, in a donation-safe window: it reads +
+        Sync + on the KV-owning thread, in a donation-safe window: it reads +
         reassigns ``kv_buffer[layer]``, which the forward donates every step.
-        ``device_indices`` are GLOBAL device PAGE ids, expanded to ``page_size``
+        ``device_indices`` are GLOBAL device page ids, expanded to ``page_size``
         token slots for the kernel ``loc``.
         """
         if len(host_buffer_ids) != len(device_indices):
@@ -663,15 +660,11 @@ class LRUHostKVPool(HostKVPool):
         jax.block_until_ready(dp.kv_buffer)
 
     def precompile_transfers(self, max_pages: int | None = None) -> None:
-        """Warm up the JIT/Pallas compile of all four transfer kernels for every
+        """Warm the JIT/Pallas compile of the four transfer kernels for every
         page bucket serving can hit, so compilation never lands on the scheduler
-        thread during serving.
-
-        Without this, the first backup/load-back of each new page-bucket shape
-        triggers an XLA (and, for ``flush_load``, a Pallas/Mosaic) compile inline
-        on the scheduler hot path -- the dominant ON-vs-OFF latency gap. Device
-        pages ``[0, r)`` are used as scratch: safe because serving starts with an
-        empty cache and overwrites every allocated page before any read.
+        thread mid-serving (the dominant ON-vs-OFF latency gap). Device pages
+        ``[0, r)`` are scratch: safe because serving starts with an empty cache
+        and overwrites every page before any read.
         """
         from sgl_jax.srt.disaggregation.prefill import _KV_GATHER_PAGE_BUCKETS
 
@@ -757,8 +750,17 @@ class LRUHostKVPool(HostKVPool):
     # ------------------------------------------------------------------
     # LRU / lock_ref mechanism (private to this class, not in the ABC).
     # The pool only provides the mechanism; victim selection lives in the
-    # tree cache (RFC-1.0 §10).
+    # tree cache.
     # ------------------------------------------------------------------
+
+    def _drop_pending(self, buffer_id: int) -> None:
+        # Drop any orphaned staged transfer for a slot being freed, so a later
+        # reuse of this id can't have flush_backup/flush_load pop stale data into
+        # the reused slot. Called under self._lock (lock order: _lock -> pending).
+        with self._pending_lock:
+            self._pending_gather.pop(buffer_id, None)
+        with self._pending_load_lock:
+            self._pending_load.pop(buffer_id, None)
 
     def inc_lock_ref(self, buffer_id: int) -> None:
         with self._lock:

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import logging
 import time
+from functools import partial
 from typing import TYPE_CHECKING
 
 import jax
@@ -846,6 +847,63 @@ def _set_fused_kv_buffer(
     )
 
 
+@partial(
+    jax.jit,
+    static_argnames=(
+        "page_size",
+        "kv_partition_axis",
+        "attention_data_partition_axis",
+        "mesh",
+    ),
+    donate_argnames=("kv_cache",),
+)
+def write_kv_layer(
+    layer_kv,
+    loc,
+    kv_cache,
+    page_size,
+    kv_partition_axis,
+    attention_data_partition_axis,
+    mesh,
+):
+    """One-layer in-place KV write, wrapped in a module-level ``jax.jit``.
+
+    Shared by PD decode write-back and HiCache H2D load-back. ``layer_kv`` is
+    ``[total_tokens, *per_token_shape]``; ``loc`` is per-token absolute pool
+    slots (-1 marks padding, skipped). The write goes through the in-place
+    Pallas kernel (``_set_fused_kv_buffer`` -> ``update_fused_kv_cache_vectorized``
+    with ``input_output_aliases``), so the footprint scales with the tokens
+    written, not the whole pool. The stable module-level ``jax.jit`` makes the
+    trace cache hit on shape + static args so the kernel compiles once per write
+    shape and is reused thereafter.
+    """
+    total_tokens = loc.shape[0]
+    fused_sharding = NamedSharding(
+        mesh,
+        P(
+            attention_data_partition_axis,
+            None,
+            kv_partition_axis,
+            None,
+            None,
+        ),
+    )
+    fused = jax.lax.reshape(
+        layer_kv,
+        (total_tokens, 1) + tuple(layer_kv.shape[2:]),
+        out_sharding=fused_sharding,
+    )
+    return _set_fused_kv_buffer(
+        fused_kv=fused,
+        loc=loc,
+        kv_cache=kv_cache,
+        page_size=page_size,
+        kv_partition_axis=kv_partition_axis,
+        attention_data_partition_axis=attention_data_partition_axis,
+        mesh=mesh,
+    )
+
+
 def update_fused_kv_cache(
     fused_kv: jax.Array,  # [tokens, 1, heads*2//packing, packing, head_dim]
     loc: jax.Array,  # [total_tokens], -1 for padding
@@ -962,6 +1020,31 @@ def update_fused_kv_cache_vectorized(
     Vectorized fused KV cache update that handles padding and supports page_size > 1
     by grouping contiguous tokens into page-sized chunks for efficient updates.
     """
+
+    # CPU has no Mosaic backend, so the Pallas kernel below cannot lower there.
+    # Fall back to a pure-JAX scatter with identical semantics (write each token's
+    # fused KV into the flattened pool slot given by ``loc``; -1 is dropped). This
+    # keeps the fused write path runnable under unit tests on CPU; TPU still uses
+    # the in-place kernel.
+    if jax.default_backend() != "tpu":
+        flat_spec = P(data_partition_axis, kv_partition_axis, None, None)
+        cache_spec = P(data_partition_axis, None, kv_partition_axis, None, None)
+        if mesh is not None:
+            flat_out = NamedSharding(mesh, flat_spec)
+            cache_out = NamedSharding(mesh, cache_spec)
+        else:
+            flat_out, cache_out = flat_spec, cache_spec
+        flat = jax.lax.reshape(
+            kv_cache,
+            (kv_cache.shape[0] * kv_cache.shape[1],) + tuple(kv_cache.shape[2:]),
+            out_sharding=flat_out,
+        )
+        loc_i = loc.astype(jnp.int32)
+        safe = jnp.where(loc_i == -1, flat.shape[0], loc_i)
+        flat = flat.at[safe].set(
+            fused_kv[:, 0], mode="drop", out_sharding=flat_out
+        )
+        return jax.lax.reshape(flat, kv_cache.shape, out_sharding=cache_out)
 
     @jax.shard_map(
         in_specs=(

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -1021,31 +1021,6 @@ def update_fused_kv_cache_vectorized(
     by grouping contiguous tokens into page-sized chunks for efficient updates.
     """
 
-    # CPU has no Mosaic backend, so the Pallas kernel below cannot lower there.
-    # Fall back to a pure-JAX scatter with identical semantics (write each token's
-    # fused KV into the flattened pool slot given by ``loc``; -1 is dropped). This
-    # keeps the fused write path runnable under unit tests on CPU; TPU still uses
-    # the in-place kernel.
-    if jax.default_backend() != "tpu":
-        flat_spec = P(data_partition_axis, kv_partition_axis, None, None)
-        cache_spec = P(data_partition_axis, None, kv_partition_axis, None, None)
-        if mesh is not None:
-            flat_out = NamedSharding(mesh, flat_spec)
-            cache_out = NamedSharding(mesh, cache_spec)
-        else:
-            flat_out, cache_out = flat_spec, cache_spec
-        flat = jax.lax.reshape(
-            kv_cache,
-            (kv_cache.shape[0] * kv_cache.shape[1],) + tuple(kv_cache.shape[2:]),
-            out_sharding=flat_out,
-        )
-        loc_i = loc.astype(jnp.int32)
-        safe = jnp.where(loc_i == -1, flat.shape[0], loc_i)
-        flat = flat.at[safe].set(
-            fused_kv[:, 0], mode="drop", out_sharding=flat_out
-        )
-        return jax.lax.reshape(flat, kv_cache.shape, out_sharding=cache_out)
-
     @jax.shard_map(
         in_specs=(
             # fused_kv: 5D sharded by data and tensor

--- a/python/sgl_jax/test/mem_cache/conftest.py
+++ b/python/sgl_jax/test/mem_cache/conftest.py
@@ -1,0 +1,51 @@
+"""CPU test shim for the fused-KV in-place write.
+
+``update_fused_kv_cache_vectorized`` lowers to a Mosaic/Pallas kernel that only
+exists on TPU. Production code keeps the TPU-only path; here we monkeypatch a
+pure-JAX scatter with identical semantics so the mem_cache unit tests stay
+CPU-runnable. On TPU we leave the real kernel in place.
+
+Patched at conftest import time (before pytest imports the test modules), so
+both ``test_kv_cache`` (direct ``from ... import``) and ``test_host_kv_pool``
+(via the jitted ``write_kv_layer``) pick up the shim.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.mem_cache import memory_pool
+
+
+def _cpu_fused_kv_scatter(
+    fused_kv,
+    loc,
+    kv_cache,
+    page_size,
+    kv_partition_axis="tensor",
+    data_partition_axis="data",
+    mesh=None,
+):
+    flat_spec = P(data_partition_axis, kv_partition_axis, None, None)
+    cache_spec = P(data_partition_axis, None, kv_partition_axis, None, None)
+    if mesh is not None:
+        flat_out = NamedSharding(mesh, flat_spec)
+        cache_out = NamedSharding(mesh, cache_spec)
+    else:
+        flat_out, cache_out = flat_spec, cache_spec
+    flat = jax.lax.reshape(
+        kv_cache,
+        (kv_cache.shape[0] * kv_cache.shape[1],) + tuple(kv_cache.shape[2:]),
+        out_sharding=flat_out,
+    )
+    loc_i = loc.astype(jnp.int32)
+    safe = jnp.where(loc_i == -1, flat.shape[0], loc_i)
+    flat = flat.at[safe].set(fused_kv[:, 0], mode="drop", out_sharding=flat_out)
+    return jax.lax.reshape(flat, kv_cache.shape, out_sharding=cache_out)
+
+
+if jax.default_backend() != "tpu":
+    memory_pool.update_fused_kv_cache_vectorized = _cpu_fused_kv_scatter

--- a/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
@@ -323,5 +323,113 @@ class TestABCExtensionDoesNotBreakPD(unittest.TestCase):
             self.queue.copy_to_device([0], [0])
 
 
+class TestLRUHostKVPoolBucketPadding(unittest.TestCase):
+    """n between gather buckets (3 -> padded to 4): padded gather rows must be
+    discarded and padded scatter slots (loc=-1) skipped, so the round-trip stays
+    bit-exact AND untouched device pages (the padding target, page 0) are not
+    clobbered. All other tests use exactly 1/2 pages == bucket boundaries, so
+    this is the only coverage of the padding path that the batching work added."""
+
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self.device_pool = _make_device_pool(size=16, page_size=1, layer_num=3)
+        self.pool = _make_pool(self.device_pool, pool_size=4, page_size=1)
+
+    def _fill(self, idx, seed):
+        orig = []
+        for layer in range(self.device_pool.layer_num):
+            buf = self.device_pool.kv_buffer[layer]
+            vals = jax.random.normal(
+                jax.random.PRNGKey(seed * 100 + layer), buf[idx].shape, buf.dtype
+            )
+            self.device_pool.kv_buffer[layer] = buf.at[idx].set(
+                vals, out_sharding=buf.sharding
+            )
+            orig.append(np.asarray(self.device_pool.kv_buffer[layer][idx]))
+        return orig
+
+    def test_three_page_roundtrip_bit_exact(self):
+        self.assertEqual(self.pool._pad_to_page_bucket(3), 4)  # padding exercised
+        srcs, dsts = [1, 2, 3], [8, 9, 10]
+        origs = [self._fill(s, seed=s) for s in srcs]
+        host = [int(p) for p in self.pool.alloc(3)]
+        self.pool.stage_backup(srcs, host)
+        self.pool.flush_backup(host)
+        self.pool.copy_to_device(host, dsts)
+        for k, d in enumerate(dsts):
+            for layer in range(self.device_pool.layer_num):
+                got = np.asarray(self.device_pool.kv_buffer[layer][d])
+                np.testing.assert_allclose(got, origs[k][layer])
+
+    def test_padding_does_not_clobber_other_pages(self):
+        # Device page 0 is the gather/scatter padding target; a 3-page transfer
+        # excluding page 0 must leave it untouched (loc=-1 skip works).
+        guard = self._fill(0, seed=42)
+        srcs, dsts = [1, 2, 3], [8, 9, 10]
+        for s in srcs:
+            self._fill(s, seed=s)
+        host = [int(p) for p in self.pool.alloc(3)]
+        self.pool.stage_backup(srcs, host)
+        self.pool.flush_backup(host)
+        self.pool.copy_to_device(host, dsts)
+        for layer in range(self.device_pool.layer_num):
+            got = np.asarray(self.device_pool.kv_buffer[layer][0])
+            np.testing.assert_allclose(got, guard[layer])
+
+
+class TestLRUHostKVPoolStageDrainErrors(unittest.TestCase):
+    """The async two-phase contract: flush before stage must fail loudly rather
+    than silently transfer garbage."""
+
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self.pool = _make_pool(_make_device_pool(), pool_size=4)
+
+    def test_flush_backup_without_stage_raises(self):
+        b = self.pool.reserve()
+        with self.assertRaises(RuntimeError):
+            self.pool.flush_backup([b])
+
+    def test_flush_load_without_stage_raises(self):
+        b = self.pool.reserve()
+        with self.assertRaises(RuntimeError):
+            self.pool.flush_load([b], [0])
+
+    def test_stage_load_from_empty_slot_raises(self):
+        b = self.pool.reserve()
+        with self.assertRaises(RuntimeError):
+            self.pool.stage_load([b])
+
+
+class TestLRUHostKVPoolPrecompile(unittest.TestCase):
+    """precompile_transfers warms one shape per page count serving can hit and
+    must always restore the pool (free its scratch slots), never raise, and warm
+    the top partial bucket even when pool_size is not a bucket boundary."""
+
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+
+    def test_runs_and_restores_pool(self):
+        pool = _make_pool(_make_device_pool(size=16, layer_num=2), pool_size=8)
+        pool.precompile_transfers()
+        self.assertEqual(pool.available_size(), 8)
+
+    def test_non_bucket_pool_size_warms_without_alloc_failure(self):
+        # pool_size=3 is between buckets (2, 4). The real-count warmup must
+        # alloc 3 (which fits) instead of bucket 4 (which would not), so it
+        # warms fully and restores the pool with no "pool too small" early stop.
+        pool = _make_pool(_make_device_pool(size=16, layer_num=2), pool_size=3)
+        pool.precompile_transfers()
+        self.assertEqual(pool.available_size(), 3)
+
+    def test_max_pages_caps_warmup(self):
+        pool = _make_pool(_make_device_pool(size=16, layer_num=2), pool_size=8)
+        pool.precompile_transfers(max_pages=2)
+        self.assertEqual(pool.available_size(), 8)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
@@ -1,9 +1,10 @@
-"""Unit tests for :class:`LRUHostKVPool` (HiCache Stage 0).
+"""Unit tests for :class:`LRUHostKVPool` (HiCache Stage 0), CPU-runnable.
 
-CPU-runnable: ``_make_host_sharding`` falls back to default sharding when
-``pinned_host`` is unsupported, so the round-trip semantics are exercised
-without a TPU. The pinned-host in-place invariant is covered separately by
-``test_single_chip_host_pool`` on a real pod.
+``_make_host_sharding`` falls back to default sharding when ``pinned_host`` is
+unsupported, and ``conftest.py`` swaps the TPU-only fused-KV Pallas kernel for a
+pure-JAX scatter, so the round-trip semantics are exercised here without a TPU.
+The real kernel, true pinned-host placement, and dp>1 page-axis sharding are
+covered on hardware by ``test_host_kv_pool_tpu.py`` (``unit-test-tpu-v6e-4``).
 """
 
 from __future__ import annotations
@@ -146,12 +147,14 @@ class TestLRUHostKVPoolBoundaryInvariants(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.pool.stage_backup([0], [0])
 
-    def test_copy_from_device_rejects_unallocated_host_id(self):
-        # Same invariant on the ABC borrow path: a free-list id must not be
-        # written into _slots while alloc() can still hand it out.
+    def test_lru_copy_from_device_not_implemented(self):
+        # LRUHostKVPool is the retaining HiCache pool: it transfers via copy_into
+        # (no jax.Array crosses the boundary), so the PD-only copy_from_device
+        # default-raises rather than carrying a dead implementation.
+        b = self.pool.reserve()
         layers = [self.pool._device_pool.kv_buffer[L][0] for L in range(3)]
-        with self.assertRaises(RuntimeError):
-            self.pool.copy_from_device(layers, 0)
+        with self.assertRaises(NotImplementedError):
+            self.pool.copy_from_device(layers, b)
 
     def test_inc_lock_ref_rejects_unallocated(self):
         with self.assertRaises(RuntimeError):
@@ -162,9 +165,16 @@ class TestLRUHostKVPoolBoundaryInvariants(unittest.TestCase):
             self.pool.inc_lock_ref(99)
 
     def test_stage_backup_rejects_out_of_range_device_page(self):
+        # kv_buffer carries a sentinel page, so size=16/page_size=1 has 17 rows:
+        # valid device pages are [0, 17). 17 is the first out-of-range id; 16 (the
+        # top real page the allocator can hand out) must NOT be rejected.
         page = int(self.pool.alloc(1)[0])
+        n_dev = int(self.pool._device_pool.kv_buffer[0].shape[0])
+        self.assertEqual(n_dev, 17)
         with self.assertRaises(ValueError):
-            self.pool.stage_backup([16], [page])  # device has 16 pages: [0, 16)
+            self.pool.stage_backup([n_dev], [page])  # 17 is out of range
+        # Highest valid page is accepted (would raise before the off-by-one fix).
+        self.pool.stage_backup([n_dev - 1], [page])
 
     def test_flush_load_rejects_negative_device_page(self):
         page = int(self.pool.alloc(1)[0])

--- a/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
@@ -25,7 +25,9 @@ from sgl_jax.srt.utils.mesh_utils import create_device_mesh
 _MESH = create_device_mesh(ici_parallelism=[1, -1], dcn_parallelism=[1, 1])
 
 
-def _make_device_pool(*, size=16, page_size=1, head_num=4, head_dim=128, layer_num=3, dtype=jnp.float32):
+def _make_device_pool(
+    *, size=16, page_size=1, head_num=4, head_dim=128, layer_num=3, dtype=jnp.float32
+):
     # head_dim must be 128-aligned: copy_to_device now writes via the in-place
     # Pallas kernel (update_fused_kv_cache_vectorized), which requires it -- and
     # production KV pools are always 128-aligned.
@@ -125,6 +127,42 @@ class TestLRUHostKVPoolLockRef(unittest.TestCase):
         b = self.pool.reserve()
         with self.assertRaises(RuntimeError):
             self.pool.dec_lock_ref(b)
+
+
+class TestLRUHostKVPoolBoundaryInvariants(unittest.TestCase):
+    """Page-id boundary guards: an unallocated (free-list) host id or an
+    out-of-range device page must be rejected at the entry, not silently written
+    -- otherwise a transfer/lock corrupts a slot the next alloc() reuses, or DMAs
+    to a wrapped/negative device page."""
+
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self.pool = _make_pool(_make_device_pool(size=16, page_size=1), pool_size=4)
+
+    def test_transfer_rejects_unallocated_host_id(self):
+        # id 0 is in the free-list (never alloc'd): staging it would write _slots[0]
+        # while alloc() can still hand 0 to another owner.
+        with self.assertRaises(RuntimeError):
+            self.pool.stage_backup([0], [0])
+
+    def test_inc_lock_ref_rejects_unallocated(self):
+        with self.assertRaises(RuntimeError):
+            self.pool.inc_lock_ref(0)
+
+    def test_lock_ref_rejects_out_of_range(self):
+        with self.assertRaises(ValueError):
+            self.pool.inc_lock_ref(99)
+
+    def test_stage_backup_rejects_out_of_range_device_page(self):
+        page = int(self.pool.alloc(1)[0])
+        with self.assertRaises(ValueError):
+            self.pool.stage_backup([16], [page])  # device has 16 pages: [0, 16)
+
+    def test_flush_load_rejects_negative_device_page(self):
+        page = int(self.pool.alloc(1)[0])
+        with self.assertRaises(ValueError):
+            self.pool.flush_load([page], [-1])
 
 
 class TestLRUHostKVPoolRoundTrip(unittest.TestCase):
@@ -261,20 +299,6 @@ class TestLRUHostKVPoolPageSize(unittest.TestCase):
             orig.append(np.asarray(self.device_pool.kv_buffer[layer][device_page]))
         return orig
 
-    def test_page2_roundtrip(self):
-        if not jax.devices():
-            self.skipTest("JAX not available")
-        self._setup(page_size=2)
-        src_page, dst_page = 3, 6
-        orig = self._fill_page(src_page, seed=11)
-        host_pages = self.pool.alloc(1)
-        self.pool.stage_backup([src_page], [int(host_pages[0])])
-        self.pool.flush_backup([int(host_pages[0])])
-        self.pool.copy_to_device([int(host_pages[0])], [dst_page])
-        for layer in range(self.device_pool.layer_num):
-            got = np.asarray(self.device_pool.kv_buffer[layer][dst_page])
-            np.testing.assert_allclose(got, orig[layer])
-
     def test_page4_batched_roundtrip(self):
         if not jax.devices():
             self.skipTest("JAX not available")
@@ -287,7 +311,7 @@ class TestLRUHostKVPoolPageSize(unittest.TestCase):
         self.pool.stage_backup(srcs, host_pages)
         self.pool.flush_backup(host_pages)
         self.pool.copy_to_device(host_pages, dsts)
-        for (s, d) in pairs:
+        for s, d in pairs:
             for layer in range(self.device_pool.layer_num):
                 got = np.asarray(self.device_pool.kv_buffer[layer][d])
                 np.testing.assert_allclose(got, origs[s][layer])
@@ -343,9 +367,7 @@ class TestLRUHostKVPoolBucketPadding(unittest.TestCase):
             vals = jax.random.normal(
                 jax.random.PRNGKey(seed * 100 + layer), buf[idx].shape, buf.dtype
             )
-            self.device_pool.kv_buffer[layer] = buf.at[idx].set(
-                vals, out_sharding=buf.sharding
-            )
+            self.device_pool.kv_buffer[layer] = buf.at[idx].set(vals, out_sharding=buf.sharding)
             orig.append(np.asarray(self.device_pool.kv_buffer[layer][idx]))
         return orig
 
@@ -442,11 +464,6 @@ class TestLRUHostKVPoolPrecompile(unittest.TestCase):
         pool = _make_pool(_make_device_pool(size=16, layer_num=2), pool_size=3)
         pool.precompile_transfers()
         self.assertEqual(pool.available_size(), 3)
-
-    def test_max_pages_caps_warmup(self):
-        pool = _make_pool(_make_device_pool(size=16, layer_num=2), pool_size=8)
-        pool.precompile_transfers(max_pages=2)
-        self.assertEqual(pool.available_size(), 8)
 
 
 if __name__ == "__main__":

--- a/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
@@ -146,6 +146,13 @@ class TestLRUHostKVPoolBoundaryInvariants(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.pool.stage_backup([0], [0])
 
+    def test_copy_from_device_rejects_unallocated_host_id(self):
+        # Same invariant on the ABC borrow path: a free-list id must not be
+        # written into _slots while alloc() can still hand it out.
+        layers = [self.pool._device_pool.kv_buffer[L][0] for L in range(3)]
+        with self.assertRaises(RuntimeError):
+            self.pool.copy_from_device(layers, 0)
+
     def test_inc_lock_ref_rejects_unallocated(self):
         with self.assertRaises(RuntimeError):
             self.pool.inc_lock_ref(0)

--- a/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
@@ -1,0 +1,327 @@
+"""Unit tests for :class:`LRUHostKVPool` (HiCache Stage 0).
+
+CPU-runnable: ``_make_host_sharding`` falls back to default sharding when
+``pinned_host`` is unsupported, so the round-trip semantics are exercised
+without a TPU. The pinned-host in-place invariant is covered separately by
+``test_single_chip_host_pool`` on a real pod.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.mem_cache.host_kv_pool import (
+    LRUHostKVPool,
+    QueueHostKVPool,
+    make_unit_mesh,
+)
+from sgl_jax.srt.mem_cache.memory_pool import MHATokenToKVPool
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+
+_MESH = create_device_mesh(ici_parallelism=[1, -1], dcn_parallelism=[1, 1])
+
+
+def _make_device_pool(*, size=16, page_size=1, head_num=4, head_dim=128, layer_num=3, dtype=jnp.float32):
+    # head_dim must be 128-aligned: copy_to_device now writes via the in-place
+    # Pallas kernel (update_fused_kv_cache_vectorized), which requires it -- and
+    # production KV pools are always 128-aligned.
+    return MHATokenToKVPool(
+        size=size,
+        page_size=page_size,
+        dtype=dtype,
+        head_num=head_num,
+        head_dim=head_dim,
+        layer_num=layer_num,
+        mesh=_MESH,
+        dp_size=1,
+    )
+
+
+def _make_pool(device_pool, *, pool_size=4, page_size=1):
+    return LRUHostKVPool(
+        device_pool=device_pool,
+        pool_size=pool_size,
+        page_size=page_size,
+        layer_num=device_pool.layer_num,
+        per_layer_shape=tuple(int(d) for d in device_pool.kv_buffer[0].shape[1:]),
+        dtype=device_pool.dtype,
+        mesh=_MESH,
+        partition_spec=device_pool.kv_sharding.spec,
+    )
+
+
+class TestLRUHostKVPoolFreeList(unittest.TestCase):
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self.device_pool = _make_device_pool()
+        self.pool = _make_pool(self.device_pool, pool_size=3)
+
+    def test_reserve_returns_distinct_ids(self):
+        ids = {self.pool.reserve() for _ in range(3)}
+        self.assertEqual(ids, {0, 1, 2})
+
+    def test_exhaustion_returns_none(self):
+        for _ in range(3):
+            self.pool.reserve()
+        self.assertIsNone(self.pool.reserve())
+
+    def test_release_re_enables_reserve(self):
+        b = self.pool.reserve()
+        for _ in range(2):
+            self.pool.reserve()
+        self.assertIsNone(self.pool.reserve())
+        self.pool.release(b)
+        self.assertIsNotNone(self.pool.reserve())
+
+    def test_available_size_tracks_usage(self):
+        self.assertEqual(self.pool.available_size(), 3)
+        b = self.pool.reserve()
+        self.assertEqual(self.pool.available_size(), 2)
+        self.pool.release(b)
+        self.assertEqual(self.pool.available_size(), 3)
+
+    def test_total_size(self):
+        self.assertEqual(self.pool.total_size(), 3)
+
+    def test_double_free_raises(self):
+        b = self.pool.reserve()
+        self.pool.release(b)
+        with self.assertRaises(RuntimeError):
+            self.pool.release(b)
+
+    def test_release_out_of_range_raises(self):
+        with self.assertRaises(ValueError):
+            self.pool.release(99)
+
+
+class TestLRUHostKVPoolLockRef(unittest.TestCase):
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self.pool = _make_pool(_make_device_pool(), pool_size=2)
+
+    def test_locked_slot_cannot_be_released(self):
+        b = self.pool.reserve()
+        self.pool.inc_lock_ref(b)
+        with self.assertRaises(RuntimeError):
+            self.pool.release(b)
+
+    def test_dec_to_zero_allows_release(self):
+        b = self.pool.reserve()
+        self.pool.inc_lock_ref(b)
+        self.pool.inc_lock_ref(b)
+        self.pool.dec_lock_ref(b)
+        with self.assertRaises(RuntimeError):
+            self.pool.release(b)
+        self.pool.dec_lock_ref(b)
+        self.pool.release(b)  # no raise
+
+    def test_dec_underflow_raises(self):
+        b = self.pool.reserve()
+        with self.assertRaises(RuntimeError):
+            self.pool.dec_lock_ref(b)
+
+
+class TestLRUHostKVPoolRoundTrip(unittest.TestCase):
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self.device_pool = _make_device_pool(layer_num=3)
+        self.pool = _make_pool(self.device_pool, pool_size=4)
+
+    def _fill(self, device_idx, seed):
+        orig = []
+        for layer in range(self.device_pool.layer_num):
+            buf = self.device_pool.kv_buffer[layer]
+            vals = jax.random.normal(
+                jax.random.PRNGKey(seed * 100 + layer), buf[device_idx].shape, buf.dtype
+            )
+            self.device_pool.kv_buffer[layer] = buf.at[device_idx].set(
+                vals, out_sharding=buf.sharding
+            )
+            orig.append(np.asarray(self.device_pool.kv_buffer[layer][device_idx]))
+        return orig
+
+    def test_copy_into_then_copy_to_device_roundtrip(self):
+        src, dst = 5, 9
+        orig = self._fill(src, seed=1)
+        b = self.pool.reserve()
+        self.pool.copy_into([src], [b])
+        self.pool.copy_to_device([b], [dst])
+        for layer in range(self.device_pool.layer_num):
+            got = np.asarray(self.device_pool.kv_buffer[layer][dst])
+            np.testing.assert_allclose(got, orig[layer])
+
+    def test_batched_roundtrip(self):
+        pairs = [(2, 10), (3, 11), (4, 12)]
+        origs = {src: self._fill(src, seed=src) for src, _ in pairs}
+        bufs = [self.pool.reserve() for _ in pairs]
+        srcs = [src for src, _ in pairs]
+        dsts = [dst for _, dst in pairs]
+        self.pool.copy_into(srcs, bufs)
+        self.pool.copy_to_device(bufs, dsts)
+        for (src, dst), b in zip(pairs, bufs):
+            for layer in range(self.device_pool.layer_num):
+                got = np.asarray(self.device_pool.kv_buffer[layer][dst])
+                np.testing.assert_allclose(got, origs[src][layer])
+
+    def test_copy_into_length_mismatch_raises(self):
+        b = self.pool.reserve()
+        with self.assertRaises(ValueError):
+            self.pool.copy_into([1, 2], [b])
+
+    def test_copy_to_device_from_empty_slot_raises(self):
+        b = self.pool.reserve()
+        with self.assertRaises(RuntimeError):
+            self.pool.copy_to_device([b], [0])
+
+    def test_copy_to_device_out_of_range_buffer_raises(self):
+        with self.assertRaises(ValueError):
+            self.pool.copy_to_device([99], [0])
+
+    def test_release_clears_slot_data(self):
+        self._fill(5, seed=7)
+        b = self.pool.reserve()
+        self.pool.copy_into([5], [b])
+        self.pool.release(b)
+        # After release the slot reference is dropped: reading it back must fail.
+        with self.assertRaises(RuntimeError):
+            self.pool.copy_to_device([b], [9])
+
+
+class TestLRUHostKVPoolAllocFree(unittest.TestCase):
+    """The page-addressed control-plane interface used by HiCache: batched
+    ``alloc(need_pages)`` / ``free(page_ids)`` (vs the single-slot reserve/
+    release kept only to satisfy the ABC)."""
+
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self.pool = _make_pool(_make_device_pool(), pool_size=4)
+
+    def test_alloc_returns_distinct_page_ids(self):
+        pages = self.pool.alloc(3)
+        self.assertEqual(len(pages), 3)
+        self.assertEqual(len(set(int(p) for p in pages)), 3)
+        self.assertEqual(self.pool.available_size(), 1)
+
+    def test_alloc_insufficient_returns_none(self):
+        self.assertIsNotNone(self.pool.alloc(4))
+        self.assertIsNone(self.pool.alloc(1))
+
+    def test_alloc_all_or_nothing(self):
+        self.pool.alloc(3)
+        # Only 1 free left; asking for 2 must return None and free nothing.
+        self.assertIsNone(self.pool.alloc(2))
+        self.assertEqual(self.pool.available_size(), 1)
+
+    def test_free_re_enables_alloc(self):
+        pages = self.pool.alloc(4)
+        self.assertIsNone(self.pool.alloc(1))
+        self.pool.free([int(p) for p in pages[:2]])
+        self.assertEqual(self.pool.available_size(), 2)
+        self.assertIsNotNone(self.pool.alloc(2))
+
+    def test_free_dedupes(self):
+        pages = self.pool.alloc(2)
+        ids = [int(pages[0]), int(pages[0]), int(pages[1])]
+        self.pool.free(ids)
+        self.assertEqual(self.pool.available_size(), 4)
+
+    def test_free_locked_page_raises(self):
+        pages = self.pool.alloc(1)
+        self.pool.inc_lock_ref(int(pages[0]))
+        with self.assertRaises(RuntimeError):
+            self.pool.free([int(pages[0])])
+
+
+class TestLRUHostKVPoolPageSize(unittest.TestCase):
+    """page_size>1: one host slot holds a whole device page. The control plane
+    addresses device + host by PAGE id, and the round-trip must be bit-exact."""
+
+    def _setup(self, page_size):
+        self.device_pool = _make_device_pool(size=16, page_size=page_size, layer_num=3)
+        self.pool = _make_pool(self.device_pool, pool_size=4, page_size=page_size)
+
+    def _fill_page(self, device_page, seed):
+        orig = []
+        for layer in range(self.device_pool.layer_num):
+            buf = self.device_pool.kv_buffer[layer]
+            vals = jax.random.normal(
+                jax.random.PRNGKey(seed * 100 + layer), buf[device_page].shape, buf.dtype
+            )
+            self.device_pool.kv_buffer[layer] = buf.at[device_page].set(
+                vals, out_sharding=buf.sharding
+            )
+            orig.append(np.asarray(self.device_pool.kv_buffer[layer][device_page]))
+        return orig
+
+    def test_page2_roundtrip(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self._setup(page_size=2)
+        src_page, dst_page = 3, 6
+        orig = self._fill_page(src_page, seed=11)
+        host_pages = self.pool.alloc(1)
+        self.pool.stage_backup([src_page], [int(host_pages[0])])
+        self.pool.flush_backup([int(host_pages[0])])
+        self.pool.copy_to_device([int(host_pages[0])], [dst_page])
+        for layer in range(self.device_pool.layer_num):
+            got = np.asarray(self.device_pool.kv_buffer[layer][dst_page])
+            np.testing.assert_allclose(got, orig[layer])
+
+    def test_page4_batched_roundtrip(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self._setup(page_size=4)
+        pairs = [(0, 2), (1, 3)]  # 16 tokens / page_size 4 == 4 pages
+        origs = {s: self._fill_page(s, seed=s + 1) for s, _ in pairs}
+        host_pages = [int(p) for p in self.pool.alloc(len(pairs))]
+        srcs = [s for s, _ in pairs]
+        dsts = [d for _, d in pairs]
+        self.pool.stage_backup(srcs, host_pages)
+        self.pool.flush_backup(host_pages)
+        self.pool.copy_to_device(host_pages, dsts)
+        for (s, d) in pairs:
+            for layer in range(self.device_pool.layer_num):
+                got = np.asarray(self.device_pool.kv_buffer[layer][d])
+                np.testing.assert_allclose(got, origs[s][layer])
+
+
+class TestABCExtensionDoesNotBreakPD(unittest.TestCase):
+    """Adding copy_into/copy_to_device must leave QueueHostKVPool concrete."""
+
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self.queue = QueueHostKVPool(
+            pool_size=2,
+            max_padded_pages=4,
+            layer_num=2,
+            per_layer_shape=(1, 4, 1, 8),
+            dtype=jnp.float32,
+            mesh=make_unit_mesh(),
+            partition_spec=jax.sharding.PartitionSpec(),
+        )
+
+    def test_queue_pool_still_instantiates_and_reserves(self):
+        b = self.queue.reserve()
+        self.assertIsNotNone(b)
+        self.queue.release(b)
+
+    def test_queue_pool_copy_into_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            self.queue.copy_into([0], [0])
+
+    def test_queue_pool_copy_to_device_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            self.queue.copy_to_device([0], [0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
@@ -460,6 +460,89 @@ class TestLRUHostKVPoolStageDrainErrors(unittest.TestCase):
             self.pool.flush_load([b], [0])
 
 
+class TestLRUHostKVPoolABA(unittest.TestCase):
+    """A free()+realloc() that reuses a slot id WHILE a transfer is mid-flight
+    must not let the stale, in-flight data land in the reused slot. A bare
+    ``_allocated`` re-check at publish can't tell the reused slot from the
+    original allocation (both show allocated); the per-slot epoch can."""
+
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        # pool_size=1 so a free()+alloc() deterministically hands back the same id.
+        self.device_pool = _make_device_pool(size=16, page_size=1, layer_num=2)
+        self.pool = _make_pool(self.device_pool, pool_size=1, page_size=1)
+
+    def _fill(self, device_idx, seed):
+        orig = []
+        for layer in range(self.device_pool.layer_num):
+            buf = self.device_pool.kv_buffer[layer]
+            vals = jax.random.normal(
+                jax.random.PRNGKey(seed * 100 + layer), buf[device_idx].shape, buf.dtype
+            )
+            self.device_pool.kv_buffer[layer] = buf.at[device_idx].set(
+                vals, out_sharding=buf.sharding
+            )
+            orig.append(np.asarray(self.device_pool.kv_buffer[layer][device_idx]))
+        return orig
+
+    def test_stage_backup_drops_gather_when_slot_reused_midflight(self):
+        # Force the ABA: free()+realloc() the slot DURING stage_backup's gather
+        # (after the entry epoch capture, before the publish). The stale gather
+        # must be dropped, leaving the reused slot empty rather than poisoned.
+        pool = self.pool
+        [pid] = [int(p) for p in pool.alloc(1)]
+        orig_gather = pool._jit_gather_one_layer
+        state = {"fired": False}
+
+        def hook(buf, idx, sharding):
+            if not state["fired"]:
+                state["fired"] = True
+                pool.free([pid])
+                [again] = [int(p) for p in pool.alloc(1)]
+                self.assertEqual(again, pid)  # same id, new epoch
+            return orig_gather(buf, idx, sharding)
+
+        pool._jit_gather_one_layer = hook
+        pool.stage_backup([2], [pid])
+        self.assertTrue(state["fired"])
+        with pool._pending_lock:
+            self.assertNotIn(pid, pool._pending_gather)  # stale publish dropped
+        # The reused slot must be empty: a stale gather would have populated it.
+        with self.assertRaises(RuntimeError):
+            pool.stage_load([pid])
+
+    def test_flush_backup_rejects_stale_epoch(self):
+        # Simulate a free()+realloc() landing between flush_backup's pop and its
+        # _slots write by tagging the pending gather with an older epoch.
+        pool = self.pool
+        [pid] = [int(p) for p in pool.alloc(1)]
+        pool.stage_backup([2], [pid])
+        with pool._pending_lock:
+            gen, data = pool._pending_gather[pid]
+            pool._pending_gather[pid] = (gen - 1, data)
+        pool.flush_backup([pid])
+        self.assertIsNone(pool._slots[pid])  # stale rejected, slot not populated
+
+    def test_flush_load_skips_stale_epoch(self):
+        # A page whose slot was reused since stage_load must not be scattered into
+        # the caller's device pages; the dst page stays untouched.
+        pool = self.pool
+        dp = self.device_pool
+        [pid] = [int(p) for p in pool.alloc(1)]
+        self._fill(2, seed=1)
+        guard = self._fill(9, seed=99)  # dst page, must stay untouched
+        pool.copy_into([2], [pid])
+        pool.stage_load([pid])
+        with pool._pending_load_lock:
+            gen, data = pool._pending_load[pid]
+            pool._pending_load[pid] = (gen - 1, data)
+        pool.flush_load([pid], [9])
+        for layer in range(dp.layer_num):
+            got = np.asarray(dp.kv_buffer[layer][9])
+            np.testing.assert_array_equal(got, guard[layer])
+
+
 class TestLRUHostKVPoolPrecompile(unittest.TestCase):
     """precompile_transfers warms one shape per page count serving can hit and
     must always restore the pool (free its scratch slots), never raise, and warm

--- a/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_host_kv_pool.py
@@ -402,6 +402,24 @@ class TestLRUHostKVPoolStageDrainErrors(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.pool.stage_load([b])
 
+    def test_free_drops_pending_gather(self):
+        # free() must drop a slot's orphaned D2H gather so a reused id can't have
+        # a later flush_backup pop stale data into it.
+        pages = [int(p) for p in self.pool.alloc(1)]
+        self.pool.stage_backup([0], pages)
+        self.pool.free(pages)
+        with self.assertRaises(RuntimeError):
+            self.pool.flush_backup(pages)
+
+    def test_release_drops_pending_load(self):
+        # release() must drop a slot's orphaned H2D staged page for the same reason.
+        b = self.pool.reserve()
+        self.pool.copy_into([0], [b])
+        self.pool.stage_load([b])
+        self.pool.release(b)
+        with self.assertRaises(RuntimeError):
+            self.pool.flush_load([b], [0])
+
 
 class TestLRUHostKVPoolPrecompile(unittest.TestCase):
     """precompile_transfers warms one shape per page count serving can hit and

--- a/python/sgl_jax/test/mem_cache/test_host_kv_pool_tpu.py
+++ b/python/sgl_jax/test/mem_cache/test_host_kv_pool_tpu.py
@@ -1,0 +1,145 @@
+"""TPU round-trip tests for :class:`LRUHostKVPool` (HiCache Stage 0), tp=4/dp=1.
+
+The CPU suite (``test_host_kv_pool.py``) monkeypatches the fused-KV Pallas
+kernel out (``conftest.py``, gated on ``backend != "tpu"``) and falls back to
+default sharding when ``pinned_host`` is unavailable. That leaves the two parts
+most likely to break a donating in-place KV write unexercised:
+
+  1. the real ``update_fused_kv_cache_vectorized`` Pallas kernel, and
+  2. true ``pinned_host`` placement for the host slots.
+
+This module runs the bit-exact D2H->H2D round-trip on a 4-chip TPU at
+``tp=4/dp=1``, covering both. Registered in the ``unit-test-tpu-v6e-4`` suite;
+skipped off TPU / with <4 devices.
+
+dp>1 is intentionally NOT covered here: the H2D scatter
+(``flush_load`` -> ``write_kv_layer`` -> ``update_fused_kv_cache_vectorized``)
+passes GLOBAL device page ids, but the kernel's ``shard_map`` splits ``loc`` on
+the data axis and indexes each shard's local KV slice with those ids -- correct
+for the forward path (loc is already dp-local there) but wrong for HiCache's
+global ids, so a page lands on the wrong dp shard. Routing global pages to their
+owning shard is a separate piece of work; LRUHostKVPool is not yet wired into
+the unified cache, so no production path runs it under dp>1 today.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.mem_cache.host_kv_pool import LRUHostKVPool
+from sgl_jax.srt.mem_cache.memory_pool import MHATokenToKVPool
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+
+
+def _is_tpu_4chip() -> bool:
+    try:
+        return jax.default_backend() == "tpu" and len(jax.devices()) >= 4
+    except RuntimeError:
+        return False
+
+
+def _make_device_pool(
+    mesh, *, dp_size, size=32, page_size=1, head_num=4, head_dim=128, layer_num=3
+):
+    # head_dim must be 128-aligned: copy_to_device writes via the in-place Pallas
+    # kernel (update_fused_kv_cache_vectorized), which requires it.
+    return MHATokenToKVPool(
+        size=size,
+        page_size=page_size,
+        dtype=jnp.bfloat16,
+        head_num=head_num,
+        head_dim=head_dim,
+        layer_num=layer_num,
+        mesh=mesh,
+        dp_size=dp_size,
+    )
+
+
+def _make_pool(device_pool, mesh, *, pool_size=8, page_size=1):
+    return LRUHostKVPool(
+        device_pool=device_pool,
+        pool_size=pool_size,
+        page_size=page_size,
+        layer_num=device_pool.layer_num,
+        per_layer_shape=tuple(int(d) for d in device_pool.kv_buffer[0].shape[1:]),
+        dtype=device_pool.dtype,
+        mesh=mesh,
+        partition_spec=device_pool.kv_sharding.spec,
+    )
+
+
+def _read_page(device_pool, layer, idx):
+    # Pull the whole (sharded) layer to host and index with numpy: a device-side
+    # ``buf[idx]`` gather can't resolve an output sharding under explicit
+    # sharding on a multi-chip mesh (test-only read-back, not the path under test).
+    return np.asarray(jax.device_get(device_pool.kv_buffer[layer]))[idx]
+
+
+def _fill(device_pool, idx, seed):
+    orig = []
+    for layer in range(device_pool.layer_num):
+        buf = device_pool.kv_buffer[layer]
+        page_shape = tuple(buf.shape[1:])  # avoid a buf[idx] gather just for shape
+        vals = jax.random.normal(
+            jax.random.PRNGKey(seed * 100 + layer), page_shape, jnp.float32
+        ).astype(buf.dtype)
+        device_pool.kv_buffer[layer] = buf.at[idx].set(vals, out_sharding=buf.sharding)
+        orig.append(_read_page(device_pool, layer, idx))
+    return orig
+
+
+@unittest.skipUnless(_is_tpu_4chip(), "requires a TPU with >=4 chips")
+class TestLRUHostKVPoolTPURoundTrip(unittest.TestCase):
+    """Bit-exact D2H->H2D round-trip on the real kernel + pinned host, tp=4/dp=1."""
+
+    def _roundtrip(self, page_size=1):
+        mesh = create_device_mesh(ici_parallelism=[1, 4], dcn_parallelism=[1, 1])
+        device_pool = _make_device_pool(mesh, dp_size=1, page_size=page_size)
+        pool = _make_pool(device_pool, mesh, pool_size=8, page_size=page_size)
+
+        # Distinct src/dst device pages so a no-op (forgot to write) can't pass.
+        pairs = [(2, 5), (3, 6), (4, 7)]  # 3 pages -> exercises bucket padding too
+        origs = {s: _fill(device_pool, s, seed=s + 1) for s, _ in pairs}
+        host_pages = [int(p) for p in pool.alloc(len(pairs))]
+        srcs = [s for s, _ in pairs]
+        dsts = [d for _, d in pairs]
+
+        pool.copy_into(srcs, host_pages)
+        pool.copy_to_device(host_pages, dsts)
+
+        for s, d in pairs:
+            for layer in range(device_pool.layer_num):
+                got = _read_page(device_pool, layer, d)
+                np.testing.assert_array_equal(got, origs[s][layer])
+
+    def test_roundtrip_tp4_dp1(self):
+        self._roundtrip()
+
+    def test_roundtrip_tp4_dp1_page_size4(self):
+        self._roundtrip(page_size=4)
+
+    def test_padding_does_not_clobber_other_pages(self):
+        # Device page 0 is the gather/scatter padding target; a 3-page transfer
+        # excluding it must leave it untouched (loc=-1 skip works on the real
+        # kernel, not just the CPU shim).
+        mesh = create_device_mesh(ici_parallelism=[1, 4], dcn_parallelism=[1, 1])
+        device_pool = _make_device_pool(mesh, dp_size=1)
+        pool = _make_pool(device_pool, mesh, pool_size=8)
+        guard = _fill(device_pool, 0, seed=42)
+        srcs, dsts = [2, 3, 4], [5, 6, 7]
+        for s in srcs:
+            _fill(device_pool, s, seed=s + 1)
+        host_pages = [int(p) for p in pool.alloc(3)]
+        pool.copy_into(srcs, host_pages)
+        pool.copy_to_device(host_pages, dsts)
+        for layer in range(device_pool.layer_num):
+            got = _read_page(device_pool, layer, 0)
+            np.testing.assert_array_equal(got, guard[layer])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sgl_jax/test/mem_cache/test_host_kv_pool_tpu.py
+++ b/python/sgl_jax/test/mem_cache/test_host_kv_pool_tpu.py
@@ -9,17 +9,12 @@ most likely to break a donating in-place KV write unexercised:
   2. true ``pinned_host`` placement for the host slots.
 
 This module runs the bit-exact D2H->H2D round-trip on a 4-chip TPU at
-``tp=4/dp=1``, covering both. Registered in the ``unit-test-tpu-v6e-4`` suite;
-skipped off TPU / with <4 devices.
-
-dp>1 is intentionally NOT covered here: the H2D scatter
-(``flush_load`` -> ``write_kv_layer`` -> ``update_fused_kv_cache_vectorized``)
-passes GLOBAL device page ids, but the kernel's ``shard_map`` splits ``loc`` on
-the data axis and indexes each shard's local KV slice with those ids -- correct
-for the forward path (loc is already dp-local there) but wrong for HiCache's
-global ids, so a page lands on the wrong dp shard. Routing global pages to their
-owning shard is a separate piece of work; LRUHostKVPool is not yet wired into
-the unified cache, so no production path runs it under dp>1 today.
+``tp=4/dp=1``, covering both. The dp>1 page-axis gather/scatter layout is covered
+by the companion ``test_host_kv_pool_tpu_dp.py``: a single process cannot switch
+device mesh topology (``[1, 4]`` vs ``[2, 2]``) without the second mesh producing
+garbage, so the two layouts live in separate files (each TestFile in
+``run_suite.py`` is its own subprocess). Both are registered in
+``unit-test-tpu-v6e-4``; skipped off TPU / with <4 devices.
 """
 
 from __future__ import annotations

--- a/python/sgl_jax/test/mem_cache/test_host_kv_pool_tpu_dp.py
+++ b/python/sgl_jax/test/mem_cache/test_host_kv_pool_tpu_dp.py
@@ -1,0 +1,95 @@
+"""TPU round-trip tests for :class:`LRUHostKVPool` (HiCache Stage 0), tp=2/dp=2.
+
+Companion to ``test_host_kv_pool_tpu.py`` -- see that module's docstring for why
+the dp layouts live in separate files (a single process cannot switch device
+mesh topology). This file exercises the dp>1 page-axis sharding: the KV buffer's
+page axis is split across the data axis, so the H2D scatter must route each
+GLOBAL device page to its owning shard as a shard-local offset (``flush_load``).
+Registered in ``unit-test-tpu-v6e-4``; skipped off TPU / with <4 devices.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+from sgl_jax.test.mem_cache.test_host_kv_pool_tpu import (
+    _fill,
+    _is_tpu_4chip,
+    _make_device_pool,
+    _make_pool,
+    _read_page,
+)
+
+
+@unittest.skipUnless(_is_tpu_4chip(), "requires a TPU with >=4 chips")
+class TestLRUHostKVPoolTPURoundTripDP2(unittest.TestCase):
+    """Bit-exact round-trip + padding skip on the dp>1 page-axis sharding."""
+
+    def _roundtrip(self, page_size=1):
+        mesh = create_device_mesh(ici_parallelism=[2, 2], dcn_parallelism=[1, 1])
+        device_pool = _make_device_pool(mesh, dp_size=2, page_size=page_size)
+        pool = _make_pool(device_pool, mesh, pool_size=8, page_size=page_size)
+
+        # Distinct src/dst device pages so a no-op (forgot to write) can't pass.
+        pairs = [(2, 5), (3, 6), (4, 7)]  # 3 pages -> exercises bucket padding too
+        origs = {s: _fill(device_pool, s, seed=s + 1) for s, _ in pairs}
+        host_pages = [int(p) for p in pool.alloc(len(pairs))]
+        srcs = [s for s, _ in pairs]
+        dsts = [d for _, d in pairs]
+
+        pool.copy_into(srcs, host_pages)
+        pool.copy_to_device(host_pages, dsts)
+
+        for s, d in pairs:
+            for layer in range(device_pool.layer_num):
+                got = _read_page(device_pool, layer, d)
+                np.testing.assert_array_equal(got, origs[s][layer])
+
+    def test_roundtrip_tp2_dp2(self):
+        self._roundtrip()
+
+    def test_roundtrip_tp2_dp2_page_size4(self):
+        self._roundtrip(page_size=4)
+
+    def test_roundtrip_crosses_dp_shard_boundary(self):
+        # Targets span both data shards (pages_per_shard=17 for size=32/page_size=1):
+        # 3 in shard 0 (<17) and 2 in shard 1 (>=17). Catches the global->shard
+        # routing regression directly -- a global-id scatter writes the shard-1
+        # pages to the wrong place.
+        mesh = create_device_mesh(ici_parallelism=[2, 2], dcn_parallelism=[1, 1])
+        device_pool = _make_device_pool(mesh, dp_size=2)
+        pool = _make_pool(device_pool, mesh, pool_size=8)
+        pairs = [(2, 5), (3, 6), (4, 7), (8, 20), (9, 25)]
+        origs = {s: _fill(device_pool, s, seed=s + 1) for s, _ in pairs}
+        host_pages = [int(p) for p in pool.alloc(len(pairs))]
+        pool.copy_into([s for s, _ in pairs], host_pages)
+        pool.copy_to_device(host_pages, [d for _, d in pairs])
+        for s, d in pairs:
+            for layer in range(device_pool.layer_num):
+                got = _read_page(device_pool, layer, d)
+                np.testing.assert_array_equal(got, origs[s][layer])
+
+    def test_padding_does_not_clobber_other_pages(self):
+        # Device page 0 is the gather/scatter padding target; a 3-page transfer
+        # excluding it must leave it untouched (loc=-1 skip works on the real
+        # kernel, not just the CPU shim).
+        mesh = create_device_mesh(ici_parallelism=[2, 2], dcn_parallelism=[1, 1])
+        device_pool = _make_device_pool(mesh, dp_size=2)
+        pool = _make_pool(device_pool, mesh, pool_size=8)
+        guard = _fill(device_pool, 0, seed=42)
+        srcs, dsts = [2, 3, 4], [5, 6, 7]
+        for s in srcs:
+            _fill(device_pool, s, seed=s + 1)
+        host_pages = [int(p) for p in pool.alloc(3)]
+        pool.copy_into(srcs, host_pages)
+        pool.copy_to_device(host_pages, dsts)
+        for layer in range(device_pool.layer_num):
+            got = _read_page(device_pool, layer, 0)
+            np.testing.assert_array_equal(got, guard[layer])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -343,6 +343,7 @@ suites = {
         TestFile("python/sgl_jax/test/test_gdn_attention_dp.py", 6),
         TestFile("python/sgl_jax/test/layers/test_lightning_backend.py", 8, runner="pytest"),
         TestFile("test/srt/test_moe_block_quant_e2e.py", 1.5, runner="pytest"),
+        TestFile("python/sgl_jax/test/mem_cache/test_host_kv_pool_tpu.py", 1, runner="pytest"),
     ],
     "kernel-performance-test-tpu-v6e-1": [
         TestFile("benchmark/kernels/flash_attention/bench_flashattention.py", 5),

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -344,6 +344,7 @@ suites = {
         TestFile("python/sgl_jax/test/layers/test_lightning_backend.py", 8, runner="pytest"),
         TestFile("test/srt/test_moe_block_quant_e2e.py", 1.5, runner="pytest"),
         TestFile("python/sgl_jax/test/mem_cache/test_host_kv_pool_tpu.py", 1, runner="pytest"),
+        TestFile("python/sgl_jax/test/mem_cache/test_host_kv_pool_tpu_dp.py", 1, runner="pytest"),
     ],
     "kernel-performance-test-tpu-v6e-1": [
         TestFile("benchmark/kernels/flash_attention/bench_flashattention.py", 5),

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -319,6 +319,7 @@ suites = {
         TestFile("python/sgl_jax/test/mem_cache/test_unified_radix_cache.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_unified_radix_tree_flag.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_paged_allocator_multi_dp.py", 1),
+        TestFile("python/sgl_jax/test/mem_cache/test_host_kv_pool.py", 1, runner="pytest"),
         TestFile("python/sgl_jax/test/test_kv_cache_builder.py", 0.1, runner="pytest"),
         TestFile("test/srt/function_call/test_qwen3_coder_detector.py", 0.1),
         TestFile("test/srt/function_call/test_glm4_moe_detector.py", 0.1),


### PR DESCRIPTION
## Summary

HiCache Stage 0 (host pool foundation) from the roadmap #1280. Adds `LRUHostKVPool`, the L2 host-pinned KV pool, as a second concrete implementation of the shared `HostKVPool` ABC (introduced for PD disaggregation in #1368) — no new abstraction.

- **`LRUHostKVPool`** — slot-denominated `reserve`/`release` with LRU + `lock_ref` retention, page-addressed `alloc`/`free`, and capacity queries (`available_size`/`total_size`).
- **Symmetric `buffer_id`-addressed D2H/H2D primitives** — `copy_into`/`copy_to_device` plus a two-phase async transfer path (`stage_backup`/`flush_backup`, `stage_load`/`flush_load`). No host `jax.Array` crosses the upper-layer boundary, so the backend stays swappable (D4 contract).
- **Page-bucket batching** — transfers pad to gather buckets so the Pallas write kernel compiles once per bucket.
- **Shared `write_kv_layer`** — extracted from the PD decode path into `memory_pool.py` and reused by both PD and HiCache (single KV-write kernel wrapper).
- **Page-id boundary guards** — unallocated host ids and out-of-range device pages are rejected at every transfer/lock entry point.

The TPU-only fused-KV Pallas kernel is kept in production; CPU unit tests use a pure-JAX shim via `conftest.py`, so the suite runs on CPU CI.

## Test plan

- [x] `python/sgl_jax/test/mem_cache/test_host_kv_pool.py` — free-list, lock_ref, boundary invariants, D2H/H2D round-trip (bit-exact), page_size>1, bucket padding, two-phase stage/drain errors, precompile. Wired into `unit-test-cpu`.
- [x] Full `mem_cache/` suite green on CPU.

Closes #1310. Part of #1280 (Stage 0).