### PR TITLE
feat: Add Stage 1 Qwen-VL multimodal preprocessing path

### DIFF
--- a/docs/architecture/12-multimodal.md
+++ b/docs/architecture/12-multimodal.md
@@ -6,7 +6,7 @@ sglang-jax's multimodal subsystem is an independent parallel architecture suppor
 
 Multimodal mode automatically disables the radix cache because the prefix-sharing rate of multimodal requests is extremely low — each image/video's visual token sequence is highly unlikely to overlap with another request's, so the maintenance overhead of the radix tree (LRU tracking, refcounts, eviction logic) yields no payoff in prefix reuse.
 
-**`Modality` enum** (`multimodal/common/modality_enum.py`): `IMAGE`, `MULTI_IMAGES`, `VIDEO`, `AUDIO`
+**`Modality` enum** (`multimodal/common/modality_enum.py`): `IMAGE`, `VIDEO`, `AUDIO` (multi-image requests are represented as multiple `IMAGE` items)
 
 ![Multimodal request processing flow](images/12-multimodal-request-flow.svg)
 
@@ -344,7 +344,7 @@ Auto-behaviors when `multimodal` is enabled:
 | `Stage` | `multimodal/manager/stage.py` | Pipeline stage definition |
 | `DeviceManager` | `multimodal/manager/device_manager.py` | Device mesh allocation (greedy in-order) |
 | `StageConfigRegistry` | `multimodal/models/static_configs/` | Mapping from model name → stage config YAML |
-| `Modality` | `multimodal/common/modality_enum.py` | Modality enum (IMAGE/MULTI_IMAGES/VIDEO/AUDIO) |
+| `Modality` | `multimodal/common/modality_enum.py` | Modality enum (IMAGE/VIDEO/AUDIO) |
 | `DataType` | `multimodal/manager/io_struct.py` | Request data-type enum (IMAGE/VIDEO/AUDIO) |
 | `GenerateMMReqInput` | `multimodal/manager/io_struct.py` | Image/video generation request |
 | `TokenizedGenerateMMReqInput` | `multimodal/manager/io_struct.py` | Tokenized image/video generation request (ZMQ transport) |

--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -196,7 +196,9 @@ class ModelConfig:
                 self.quantization_config.ignored_layers = ignored
         # Check model type
         self.is_generation = is_generation_model(self.hf_config.architectures, is_embedding)
-        self.is_multimodal = False
+        self.is_multimodal = any(
+            architecture in multimodal_model_archs for architecture in self.hf_config.architectures
+        )
         self.dtype = _get_and_verify_dtype(self.hf_text_config, dtype)
 
         if not isinstance(dtype_config, DtypeConfig):

--- a/python/sgl_jax/srt/hf_transformers_utils.py
+++ b/python/sgl_jax/srt/hf_transformers_utils.py
@@ -482,7 +482,7 @@ def get_processor(
     tokenizer_mode: str = "auto",
     trust_remote_code: bool = False,
     tokenizer_revision: str | None = None,
-    use_fast: bool | None = True,
+    use_fast: bool | None = False,
     **kwargs,
 ):
     # pop 'revision' from kwargs if present.

--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from sgl_jax.srt.managers.schedule_batch import BaseFinishReason
-from sgl_jax.srt.multimodal.common.modality_enum import flatten_nested_list
+from sgl_jax.srt.multimodal.common.modality_enum import (
+    MultimodalInputs,
+    flatten_nested_list,
+)
 
 # Handle serialization of Image for pydantic
 if TYPE_CHECKING:
@@ -164,7 +167,7 @@ class TokenizedGenerateReqInput:
     # whether to return hidden states
     return_hidden_states: bool = False
     # multimodal inputs (e.g., mrope positions, embeddings)
-    mm_inputs: dict | None = None
+    mm_inputs: MultimodalInputs | dict | None = None
     # The data parallel rank for this request
     dp_rank: int | None = None
     # PD disaggregation routing keys.

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1063,17 +1063,20 @@ class Scheduler(
         req.disagg_transfer_id = recv_req.disagg_transfer_id or req.rid
         if hasattr(recv_req, "mm_inputs") and recv_req.mm_inputs:
             req.mm_inputs = recv_req.mm_inputs
-            multimodal_embedding = recv_req.mm_inputs.get("multimodal_embedding")
+            get_mm_value = (
+                recv_req.mm_inputs.get
+                if isinstance(recv_req.mm_inputs, dict)
+                else lambda key: getattr(recv_req.mm_inputs, key, None)
+            )
+            multimodal_embedding = get_mm_value("multimodal_embedding")
             req.multimodal_embedding = multimodal_embedding
             if (
-                recv_req.mm_inputs.get("deepstack_visual_pos_mask") is not None
-                and recv_req.mm_inputs.get("deepstack_visual_embedding") is not None
+                get_mm_value("deepstack_visual_pos_mask") is not None
+                and get_mm_value("deepstack_visual_embedding") is not None
             ):
                 req.apply_for_deepstack = True
-                req.deepstack_visual_pos_mask = recv_req.mm_inputs.get("deepstack_visual_pos_mask")
-                req.deepstack_visual_embedding = recv_req.mm_inputs.get(
-                    "deepstack_visual_embedding"
-                )
+                req.deepstack_visual_pos_mask = get_mm_value("deepstack_visual_pos_mask")
+                req.deepstack_visual_embedding = get_mm_value("deepstack_visual_embedding")
         # Validate prompt length
         error_msg = validate_input_length(
             req,

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -30,7 +30,11 @@ import zmq.asyncio
 from fastapi import BackgroundTasks
 
 from sgl_jax.srt.configs.model_config import ModelConfig
-from sgl_jax.srt.hf_transformers_utils import get_tokenizer
+from sgl_jax.srt.hf_transformers_utils import (
+    get_processor,
+    get_tokenizer,
+    get_tokenizer_from_processor,
+)
 from sgl_jax.srt.lora.lora_registry import LoRARegistry
 from sgl_jax.srt.managers.io_struct import (
     AbortReq,
@@ -61,6 +65,10 @@ from sgl_jax.srt.managers.io_struct import (
     SetInternalStateReqOutput,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
+)
+from sgl_jax.srt.multimodal.manager.multimodal_processor import (
+    get_mm_processor_cls,
+    import_processors,
 )
 from sgl_jax.srt.multimodal.tokenizer_utils import resolve_tokenizer_subdir
 from sgl_jax.srt.sampling.sampling_params import SamplingParams
@@ -161,24 +169,53 @@ class TokenizerManager:
         self._cond = asyncio.Condition()
 
         self.mm_processor = None
+        self.processor = None
 
         if server_args.skip_tokenizer_init:
-            self.tokenizer = self.processor = None
+            self.tokenizer = None
         else:
             tokenizer_subdir = ""
             if server_args.multimodal:
                 tokenizer_subdir = resolve_tokenizer_subdir(
                     server_args.model_path, server_args.tokenizer_path
                 )
-            self.tokenizer = get_tokenizer(
-                server_args.tokenizer_path,
-                tokenizer_mode=server_args.tokenizer_mode,
-                trust_remote_code=server_args.trust_remote_code,
-                revision=server_args.revision,
-                tokenizer_backend=server_args.tokenizer_backend,
-                sub_dir=tokenizer_subdir,
-                download_dir=server_args.download_dir,
-            )
+
+            if self.model_config is not None and self.model_config.is_multimodal:
+                import_processors("sgl_jax.srt.multimodal.processors")
+                mm_processor_cls = get_mm_processor_cls(self.model_config.hf_config)
+            else:
+                mm_processor_cls = None
+
+            if mm_processor_cls is not None:
+                tokenizer_path = server_args.tokenizer_path
+                if tokenizer_subdir:
+                    tokenizer_path = os.path.join(tokenizer_path, tokenizer_subdir)
+                self.processor = get_processor(
+                    tokenizer_path,
+                    tokenizer_mode=server_args.tokenizer_mode,
+                    trust_remote_code=server_args.trust_remote_code,
+                    revision=server_args.revision,
+                )
+                self.mm_processor = mm_processor_cls(
+                    self.model_config.hf_config, server_args, self.processor
+                )
+                self.tokenizer = get_tokenizer_from_processor(self.processor)
+            else:
+                if self.model_config is not None and self.model_config.is_multimodal:
+                    logger.info(
+                        "No SGL-JAX multimodal processor registered for architectures %s; "
+                        "falling back to text tokenizer.",
+                        self.model_config.hf_config.architectures,
+                    )
+                self.tokenizer = get_tokenizer(
+                    server_args.tokenizer_path,
+                    tokenizer_mode=server_args.tokenizer_mode,
+                    trust_remote_code=server_args.trust_remote_code,
+                    revision=server_args.revision,
+                    tokenizer_backend=server_args.tokenizer_backend,
+                    sub_dir=tokenizer_subdir,
+                    download_dir=server_args.download_dir,
+                )
 
         # Store states
         self.no_create_loop = False
@@ -299,7 +336,27 @@ class TokenizerManager:
         # Tokenize
         input_text = obj.text
         input_ids = obj.input_ids
-        if input_ids is None and input_text is not None:
+        mm_inputs = None
+        if isinstance(obj, GenerateReqInput) and obj.contains_mm_input():
+            if self.mm_processor is None:
+                raise ValueError(
+                    "Multimodal input was provided, but the model has no multimodal processor."
+                )
+            if obj.video_data is not None or obj.audio_data is not None:
+                raise ValueError(
+                    "Only image input is supported by the current multimodal processor."
+                )
+            self._validate_mm_limits(obj)
+            mm_inputs = await self.mm_processor.process_mm_data_async(
+                image_data=obj.image_data,
+                input_text=input_text or input_ids,
+                request_obj=obj,
+            )
+            if mm_inputs is None:
+                raise ValueError("The multimodal processor produced no output.")
+            if mm_inputs.input_ids is not None:
+                input_ids = mm_inputs.input_ids
+        elif input_ids is None and input_text is not None:
             if self.tokenizer is None:
                 raise ValueError(
                     "Tokenizer is not initialized but input_text requires tokenization"
@@ -308,7 +365,7 @@ class TokenizerManager:
             input_ids = encoded["input_ids"]
 
         self._validate_one_request(obj, input_ids)
-        return self._create_tokenized_object(obj, input_text, input_ids)
+        return self._create_tokenized_object(obj, input_text, input_ids, mm_inputs)
 
     def _validate_one_request(
         self, obj: GenerateReqInput | EmbeddingReqInput, input_ids: list[int]
@@ -336,6 +393,18 @@ class TokenizerManager:
             )
             raise ValueError(error_msg)
 
+    def _validate_mm_limits(self, obj: GenerateReqInput | EmbeddingReqInput) -> None:
+        if not self.server_args.limit_mm_data_per_request:
+            return
+        for modality, limit in self.server_args.limit_mm_data_per_request.items():
+            data = getattr(obj, f"{modality}_data", None)
+            if data:
+                count = len(data) if isinstance(data, list) else 1
+                if count > limit:
+                    raise ValueError(
+                        f"{modality.capitalize()} count {count} exceeds limit {limit} per request."
+                    )
+
     def _validate_input_ids_in_vocab(self, input_ids: list[int], vocab_size: int) -> None:
         if any(id >= vocab_size for id in input_ids):
             raise ValueError(
@@ -347,6 +416,7 @@ class TokenizerManager:
         obj: GenerateReqInput,
         input_text: str,
         input_ids: list[int],
+        mm_inputs: object | None = None,
     ) -> TokenizedGenerateReqInput:
         """Create a tokenized request object from common parameters."""
         # Parse sampling parameters
@@ -363,19 +433,20 @@ class TokenizerManager:
         # Build return object
 
         tokenized_obj = TokenizedGenerateReqInput(
-            obj.rid,
-            input_text,
-            input_ids,
-            sampling_params,
-            obj.return_logprob,
-            obj.return_output_logprob_only,
-            obj.logprob_start_len,
-            obj.top_logprobs_num,
-            obj.token_ids_logprob,
-            obj.stream,
-            obj.lora_id,
-            obj.extra_key,
-            obj.return_routed_experts,
+            rid=obj.rid,
+            text=input_text,
+            input_ids=input_ids,
+            sampling_params=sampling_params,
+            return_logprob=obj.return_logprob,
+            return_output_logprob_only=obj.return_output_logprob_only,
+            logprob_start_len=obj.logprob_start_len,
+            top_logprobs_num=obj.top_logprobs_num,
+            token_ids_logprob=obj.token_ids_logprob,
+            stream=obj.stream,
+            lora_id=obj.lora_id,
+            extra_key=obj.extra_key,
+            return_routed_experts=obj.return_routed_experts,
+            mm_inputs=mm_inputs,
         )
 
         # PD disaggregation passthrough. When the engine is

--- a/python/sgl_jax/srt/multimodal/common/modality_enum.py
+++ b/python/sgl_jax/srt/multimodal/common/modality_enum.py
@@ -284,6 +284,7 @@ class MultimodalInputs:
 
     # List of data items
     mm_items: list[MultimodalDataItem]
+    input_ids: list[int] | None = None
     image_pad_len: list | None = None
     num_image_tokens: int | None = None
 

--- a/python/sgl_jax/srt/multimodal/manager/multimodal_processor.py
+++ b/python/sgl_jax/srt/multimodal/manager/multimodal_processor.py
@@ -1,0 +1,48 @@
+import importlib
+import inspect
+import logging
+import pkgutil
+
+from sgl_jax.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+
+logger = logging.getLogger(__name__)
+
+PROCESSOR_MAPPING: dict[str, type[BaseMultimodalProcessor]] = {}
+
+
+def import_processors(package_name: str) -> None:
+    package = importlib.import_module(package_name)
+    for _, name, ispkg in pkgutil.iter_modules(package.__path__, package_name + "."):
+        if ispkg:
+            continue
+        try:
+            module = importlib.import_module(name)
+        except Exception as e:
+            logger.warning("Ignore import error when loading %s: %s", name, e)
+            continue
+        for _, cls in inspect.getmembers(module, inspect.isclass):
+            if cls.__module__ != module.__name__:
+                continue
+            if not issubclass(cls, BaseMultimodalProcessor) or cls is BaseMultimodalProcessor:
+                continue
+            for arch in getattr(cls, "models", ()):
+                PROCESSOR_MAPPING[arch] = cls
+
+
+def get_mm_processor_cls(hf_config) -> type[BaseMultimodalProcessor] | None:
+    for arch in hf_config.architectures:
+        processor_cls = PROCESSOR_MAPPING.get(arch)
+        if processor_cls is not None:
+            return processor_cls
+    return None
+
+
+def get_mm_processor(hf_config, server_args, processor) -> BaseMultimodalProcessor:
+    processor_cls = get_mm_processor_cls(hf_config)
+    if processor_cls is not None:
+        return processor_cls(hf_config, server_args, processor)
+
+    raise ValueError(
+        f"No multimodal processor registered for architecture: {hf_config.architectures}.\n"
+        f"Registered architectures: {sorted(PROCESSOR_MAPPING)}"
+    )

--- a/python/sgl_jax/srt/multimodal/processors/base_processor.py
+++ b/python/sgl_jax/srt/multimodal/processors/base_processor.py
@@ -1,0 +1,107 @@
+import base64
+import io
+import os
+from abc import ABC, abstractmethod
+from urllib.parse import unquote, urlparse
+
+import numpy as np
+import requests
+from PIL import Image
+
+from sgl_jax.srt.multimodal.common.modality_enum import MultimodalInputs
+
+# Stage 1 safety limits for fetching remote multimodal payloads. These are
+# intentionally conservative; future stages should make them configurable via
+# ServerArgs and add proper async fetching.
+DEFAULT_HTTP_TIMEOUT_SECS = 30
+MAX_REMOTE_BYTES = 64 * 1024 * 1024  # 64 MiB hard cap per asset
+
+
+def _fetch_url(url: str) -> bytes:
+    with requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT_SECS, stream=True) as response:
+        response.raise_for_status()
+        content_length = response.headers.get("Content-Length")
+        if content_length is not None and int(content_length) > MAX_REMOTE_BYTES:
+            raise ValueError(
+                f"Remote asset at {url} reports {content_length} bytes, "
+                f"exceeds limit of {MAX_REMOTE_BYTES} bytes."
+            )
+        buffer = bytearray()
+        for chunk in response.iter_content(chunk_size=1 << 20):
+            buffer.extend(chunk)
+            if len(buffer) > MAX_REMOTE_BYTES:
+                raise ValueError(
+                    f"Remote asset at {url} exceeds limit of {MAX_REMOTE_BYTES} bytes."
+                )
+        return bytes(buffer)
+
+
+def _normalize_image_source(source) -> bytes | str:
+    """Normalize an image source into raw bytes or a local file path.
+
+    Accepts: bytes, http(s) URL, file:// URI, data: URI, local file path,
+    or a bare base64 string.
+    """
+    if isinstance(source, bytes):
+        return source
+    if not isinstance(source, str):
+        raise ValueError(f"Unsupported image source: {type(source)}")
+    if source.startswith(("http://", "https://")):
+        return _fetch_url(source)
+    if source.startswith("file://"):
+        return unquote(urlparse(source).path)
+    if source.startswith("data:"):
+        return base64.b64decode(source.split(",", 1)[1], validate=True)
+    if os.path.isfile(source):
+        return source
+    return base64.b64decode(source, validate=True)
+
+
+class BaseMultimodalProcessor(ABC):
+    models: tuple[str, ...] = ()
+
+    def __init__(self, hf_config, server_args, processor):
+        self.hf_config = hf_config
+        self.server_args = server_args
+        self.processor = processor
+
+    def apply_chat_template(self, *args, **kwargs):
+        return self.processor.apply_chat_template(*args, **kwargs)
+
+    @abstractmethod
+    async def process_mm_data_async(
+        self,
+        image_data,
+        input_text,
+        request_obj,
+        **kwargs,
+    ) -> MultimodalInputs:
+        """Process multimodal payload and return a ``MultimodalInputs``."""
+        pass
+
+    @staticmethod
+    def normalize_data(data) -> list:
+        if data is None:
+            return []
+        return data if isinstance(data, list) else [data]
+
+    @staticmethod
+    def unwrap_source(source):
+        if isinstance(source, dict) and "url" in source:
+            return source["url"]
+        if hasattr(source, "url"):
+            return source.url
+        return source
+
+    @classmethod
+    def load_image(cls, source) -> Image.Image:
+        source = cls.unwrap_source(source)
+        if isinstance(source, Image.Image):
+            return source.convert("RGB")
+        if isinstance(source, np.ndarray):
+            return Image.fromarray(source).convert("RGB")
+
+        payload = _normalize_image_source(source)
+        if isinstance(payload, bytes):
+            return Image.open(io.BytesIO(payload)).convert("RGB")
+        return Image.open(payload).convert("RGB")

--- a/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
+++ b/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
@@ -1,0 +1,111 @@
+import numpy as np
+
+from sgl_jax.srt.multimodal.common.modality_enum import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sgl_jax.srt.multimodal.manager.mrope_utils import compute_mrope_positions
+from sgl_jax.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+
+
+class QwenVLProcessor(BaseMultimodalProcessor):
+    models = (
+        "Qwen2VLForConditionalGeneration",
+        "Qwen2_5_VLForConditionalGeneration",
+    )
+
+    async def process_mm_data_async(
+        self,
+        image_data,
+        input_text,
+        request_obj,
+        **kwargs,
+    ):
+        images = [self.load_image(item) for item in self.normalize_data(image_data)]
+        if not images:
+            return None
+
+        if isinstance(input_text, list):
+            input_text = self.processor.tokenizer.decode(input_text)
+
+        processor_output = self.processor(
+            text=[input_text],
+            images=images,
+            padding=True,
+            return_tensors="np",
+        )
+
+        input_ids_array = self._to_numpy(processor_output.get("input_ids"))
+        if input_ids_array is None:
+            raise ValueError("HF multimodal processor did not return input_ids.")
+        input_ids = input_ids_array.reshape(-1).tolist()
+        pixel_values = self._to_numpy(processor_output.get("pixel_values"))
+        image_grid_thw = self._to_grid_list(processor_output.get("image_grid_thw"))
+
+        mm_items = self._build_items(pixel_values, image_grid_thw)
+        for item in mm_items:
+            item.set_pad_value()
+
+        vision_config = self.hf_config.vision_config
+        mrope_positions, mrope_position_delta = compute_mrope_positions(
+            input_ids=input_ids,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=None,
+            second_per_grid_ts=None,
+            vision_start_token_id=self.hf_config.vision_start_token_id,
+            image_token_id=self.hf_config.image_token_id,
+            video_token_id=None,
+            spatial_merge_size=vision_config.spatial_merge_size,
+            tokens_per_second=None,
+        )
+
+        return MultimodalInputs(
+            mm_items=mm_items,
+            input_ids=input_ids,
+            im_start_id=self.hf_config.vision_start_token_id,
+            im_end_id=getattr(self.hf_config, "vision_end_token_id", None),
+            im_token_id=self.hf_config.image_token_id,
+            mrope_positions=mrope_positions,
+            mrope_position_delta=mrope_position_delta,
+        )
+
+    @staticmethod
+    def _build_items(features, grids):
+        if features is None:
+            return []
+        if not grids:
+            raise ValueError("Missing image_grid_thw metadata for IMAGE inputs.")
+
+        feature_counts = [int(np.prod(grid)) for grid in grids]
+        if sum(feature_counts) != len(features):
+            raise ValueError(
+                f"IMAGE feature count does not match grid metadata: "
+                f"{len(features)} != {sum(feature_counts)}."
+            )
+
+        items = []
+        offset = 0
+        for count, grid in zip(feature_counts, grids):
+            item = MultimodalDataItem(
+                modality=Modality.IMAGE,
+                feature=features[offset : offset + count],
+            )
+            item.set("image_grid_thw", np.asarray([grid], dtype=np.int32))
+            items.append(item)
+            offset += count
+        return items
+
+    @staticmethod
+    def _to_numpy(value):
+        if value is None:
+            return None
+        if hasattr(value, "detach"):
+            value = value.detach().cpu().numpy()
+        return np.asarray(value)
+
+    @classmethod
+    def _to_grid_list(cls, value):
+        if value is None:
+            return None
+        return [tuple(int(item) for item in row) for row in cls._to_numpy(value).tolist()]

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -206,6 +206,7 @@ class ServerArgs:
 
     # Multimodal
     multimodal: bool = False
+    limit_mm_data_per_request: dict[str, int] | None = None
 
     enable_return_routed_experts: bool = False
     enable_expert_balance_debug: bool = False
@@ -366,6 +367,8 @@ class ServerArgs:
             self.device_indexes = None
         if self.multimodal:
             self.model_path = download_from_hf(self.model_path, allow_patterns=None)
+            if self.limit_mm_data_per_request is None:
+                self.limit_mm_data_per_request = {"image": 16}
 
         if self.ep_num_redundant_experts < 0:
             raise ValueError("ep_num_redundant_experts must be non-negative")


### PR DESCRIPTION
## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR adds the Stage 1 multimodal preprocessing path for Qwen-VL models in the regular SGL-JAX serving flow.

The goal is to support tokenizer-time Qwen-VL image preprocessing without requiring the legacy `--multimodal` serving path, while keeping non-multimodal models on the existing text tokenizer path.

The following examples use `Qwen/Qwen2.5-VL-3B-Instruct` with prompt `Describe the image.`. Offsets are inclusive `[start, end]` spans in the expanded `input_ids`.

| Image size | `image_grid_thw` | `item.offsets` | Image token count | `input_ids` length | `pixel_values.shape` | `mrope_positions.shape` |
|---|---:|---:|---:|---:|---:|---:|
| 224x224 | `[(1, 16, 16)]` | `[(15, 78)]` | 64 | 89 | `(256, 1176)` | `(3, 89)` |
| 448x448 | `[(1, 32, 32)]` | `[(15, 270)]` | 256 | 281 | `(1024, 1176)` | `(3, 281)` |

This shows that the image placeholder span is dynamic and derived from `image_grid_thw // spatial_merge_size^2`. The processor writes this span to `MultimodalDataItem.offsets` so scheduler/forward can identify the image token region directly.

## Modifications

<!-- Detail the changes made in this pull request. -->
- Added a base multimodal processor interface and a Qwen-VL processor implementation.
- Updated tokenizer initialization to load a multimodal processor only when the model is multimodal and a registered processor exists.
- Added fallback behavior so multimodal model configs without a registered processor still use the regular tokenizer.
- Wired tokenizer-time multimodal processing to produce request `input_ids`, image features, image grid metadata, and M-RoPE metadata.
- Passed `MultimodalInputs` through tokenizer and scheduler request plumbing.

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
