### PR TITLE
feat(scheduler): cache-aware DP routing policy

### DIFF
--- a/benchmark/hicache/bench_unified_radix_ab.py
+++ b/benchmark/hicache/bench_unified_radix_ab.py
@@ -80,7 +80,14 @@ def parse_args():
         choices=["random", "gsp"],
         default=["random", "gsp"],
     )
-    p.add_argument("--max-concurrency", type=int, default=64)
+    p.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=64,
+        help="Client-side in-flight request load (NOT a server capacity knob; the "
+        "server cap is --max-running-requests). With cache_aware DP routing, keep "
+        ">= dp_size so all ranks receive load.",
+    )
     p.add_argument("--num-prompts", type=int, default=256)
     p.add_argument("--random-input-len", type=int, default=1024)
     p.add_argument("--random-output-len", type=int, default=128)
@@ -125,7 +132,24 @@ def parse_args():
             "ids) when the host has no ShareGPT access."
         ),
     )
+    p.add_argument(
+        "--compare",
+        nargs="+",
+        default=None,
+        metavar="RESULT_JSON",
+        help=(
+            "Offline A/B gate: merge the 'aggregates' from two or more "
+            "--output-json files (each a single-config run) and run the soft-target "
+            "gate across them, no serving. This lets runs that produce one config "
+            "at a time form an A/B gate. Combine with --strict to fail on a missed "
+            "target."
+        ),
+    )
     args = p.parse_args()
+    if args.compare:
+        # Offline merge of prior results: no server is launched, so the
+        # server-shape validations below do not apply.
+        return args
     assert args.page_size >= 128, f"--page-size must be >= 128, got {args.page_size}"
     if args.tp_size > 1:
         bad = [b for b in args.precompile_bs_paddings if b % args.tp_size != 0]
@@ -371,9 +395,16 @@ def check_sweep_complete(args, raw):
 
 
 def soft_targets(args, agg):
-    """Print PASS/WARN per check. Returns True if all checks passed."""
+    """Print PASS/WARN per check. Returns ``(all_pass, n_gates_fired)``.
+
+    ``n_gates_fired`` counts the A/B comparison checks that actually ran (both
+    sides present). A run where no gate fired (e.g. only one config supplied)
+    must not be mistaken for a pass; callers using ``--strict`` should fail when
+    it is zero.
+    """
     print("\n--- soft-target report ---")
     all_pass = True
+    fired = 0
 
     def have(config, workload):
         return agg.get(config, {}).get(workload) is not None
@@ -384,6 +415,7 @@ def soft_targets(args, agg):
         r = agg["radix"]["random"]["total_tok_s_mean"]
         ok = u >= 0.95 * r
         all_pass = all_pass and ok
+        fired += 1
         print(
             f"[{'PASS' if ok else 'WARN'}] random: unified.total_tok/s ({u:.1f}) "
             f">= 0.95 * radix.total_tok/s ({0.95 * r:.1f})"
@@ -395,6 +427,7 @@ def soft_targets(args, agg):
         r = agg["radix"]["gsp"]["hit_rate_mean"]
         ok = u >= r
         all_pass = all_pass and ok
+        fired += 1
         print(
             f"[{'PASS' if ok else 'WARN'}] gsp: unified.hit_rate ({u:.4f}) "
             f">= radix.hit_rate ({r:.4f})"
@@ -407,16 +440,61 @@ def soft_targets(args, agg):
         ratio = u / nc if nc else float("nan")
         ok = ratio < 0.9
         all_pass = all_pass and ok
+        fired += 1
         print(
             f"[{'PASS' if ok else 'WARN'}] gsp: unified.p50_ttft ({u:.2f}) "
             f"vs no-cache.p50_ttft ({nc:.2f}), ratio={ratio:.3f} (want < 0.9)"
         )
 
-    return all_pass
+    return all_pass, fired
+
+
+def compare_mode(args) -> tuple[bool, int]:
+    """Merge the aggregates from multiple result JSONs and run the A/B gate.
+
+    Each input is one single-config run; together they form the A/B that a
+    single run constrained to one config cannot. Reuses ``print_table`` /
+    ``soft_targets`` on the union of configs+workloads. Returns
+    ``(all_pass, n_gates_fired)``; a single-file compare fires no gate.
+    """
+    merged: dict = {}
+    workloads: list[str] = []
+    for path in args.compare:
+        with open(path) as f:
+            payload = json.load(f)
+        for config, by_workload in (payload.get("aggregates") or {}).items():
+            dst = merged.setdefault(config, {})
+            for workload, cell in by_workload.items():
+                dst[workload] = cell
+                if workload not in workloads:
+                    workloads.append(workload)
+    if not merged:
+        raise SystemExit(f"--compare: no 'aggregates' found in {args.compare}")
+    # print_table / soft_targets iterate these; drive them off the merged keys.
+    args.configs = list(merged.keys())
+    args.workloads = workloads
+    print(
+        f"compare: merged {len(args.compare)} file(s) -> "
+        f"configs={args.configs} workloads={workloads}\n"
+    )
+    print_table(args, merged)
+    return soft_targets(args, merged)
 
 
 def main():
     args = parse_args()
+    if args.compare:
+        ok, fired = compare_mode(args)
+        if fired == 0:
+            print(
+                "\nNOTE: no A/B gate fired — compare needs both sides of a pair "
+                "for the same workload (e.g. no-cache/gsp + unified/gsp, or "
+                "radix/* + unified/*). Supply both result JSONs."
+            )
+        if args.strict and (not ok or fired == 0):
+            raise SystemExit(1)
+        return
+
     print(f"args={args}\n", flush=True)
 
     raw = {}
@@ -426,7 +504,7 @@ def main():
     agg = aggregate(args, raw)
     print_table(args, agg)
     complete = check_sweep_complete(args, raw)
-    targets_pass = soft_targets(args, agg)
+    targets_pass, _fired = soft_targets(args, agg)
     all_pass = complete and targets_pass
 
     if args.output_json:

--- a/python/sgl_jax/srt/managers/dp_schedule_policy.py
+++ b/python/sgl_jax/srt/managers/dp_schedule_policy.py
@@ -1,0 +1,100 @@
+"""Pure DP scheduling-policy decisions.
+
+Kept dependency-free (no JAX / model imports) so the policy logic can be unit
+tested without constructing a Scheduler. The Scheduler imports these and supplies
+the live tree / load state; these functions hold only the decision math.
+"""
+
+from __future__ import annotations
+
+# Soft affinity-vs-load thresholds (upstream sgl-router defaults). When the load
+# skew across eligible ranks is large, ignore cache affinity and balance; else
+# route a request to the least-loaded rank that holds a substantial cached prefix
+# (match_rate > CACHE_THRESHOLD), so a hot prefix spreads across its holders
+# instead of concentrating on the single longest-match rank.
+BALANCE_ABS = 32
+BALANCE_REL = 1.1
+CACHE_THRESHOLD = 0.5
+
+
+def req_prefix_match_key(req) -> tuple[list[int] | None, str | None]:
+    """Effective ``(token_ids, extra_key)`` for a cache-affinity prefix probe.
+
+    Mirrors the key the request will use for its *real* radix lookup, so the
+    probe routes on a match the request can actually reuse (and the holder
+    denominator is the real probe length):
+
+    - ``lora_id`` is concatenated into ``extra_key`` for cache namespace
+      isolation, exactly as ``Req.__init__`` does.
+    - The probe length is the *reusable* prefix, not the full prompt: a request
+      must keep at least one token to generate, so the lookup uses ``len - 1``
+      (``Req.adjust_max_prefix_ids``), further clamped by ``logprob_start_len``
+      when ``return_logprob`` is set. Using ``len - 1`` also stops page-aligned
+      ``match_prefix`` from reporting a phantom final-page hit the request drops.
+
+    Returns ``(None, None)`` when there is no usable single-sequence reusable
+    prefix (an unexpanded batch, an empty/one-token prompt, or a request whose
+    reusable prefix clamps to zero), so the caller falls back to load balancing.
+    """
+    input_ids = req.input_ids
+    if not isinstance(input_ids, list) or not input_ids or not isinstance(input_ids[0], int):
+        return None, None
+
+    extra_key = req.extra_key
+    lora_id = getattr(req, "lora_id", None)
+    if lora_id is not None:
+        extra_key = (extra_key or "") + lora_id
+
+    max_prefix_len = len(input_ids) - 1
+    if getattr(req, "return_logprob", False):
+        logprob_start_len = getattr(req, "logprob_start_len", -1)
+        if logprob_start_len is None or logprob_start_len == -1:
+            # Scheduler.handle_generate_request normalizes the -1 sentinel to
+            # input_len - 1, so a default logprob request still reuses the prefix;
+            # only an explicit start length clamps it shorter.
+            logprob_start_len = len(input_ids) - 1
+        max_prefix_len = min(max_prefix_len, logprob_start_len)
+    max_prefix_len = max(max_prefix_len, 0)
+    if max_prefix_len == 0:
+        return None, None
+
+    return input_ids[:max_prefix_len], extra_key
+
+
+def pick_cache_aware_dp(
+    eligible: list[int],
+    counts: list[int],
+    token_counts: list[int],
+    matches: dict[int, int],
+    prompt_len: int,
+) -> int | None:
+    """Cache-affinity DP policy with soft load balancing.
+
+    1. If the load skew across eligible ranks is large
+       (``max-min > BALANCE_ABS`` and ``max > min*BALANCE_REL``), ignore cache
+       affinity and pick the least-loaded rank.
+    2. Otherwise route to the least-loaded rank among the *holders* -- ranks whose
+       cached prefix covers more than ``CACHE_THRESHOLD`` of the prompt -- so a hot
+       prefix spreads across all its holders by load.
+    3. No holders (or no usable ``prompt_len``) -> least-loaded rank.
+
+    Load order is ``(running, tokens, rank)``. Eligibility (the per-rank admission
+    cap) is decided by the caller; this only chooses among eligible ranks.
+    """
+    if not eligible:
+        return None
+
+    def least_loaded(ranks: list[int]) -> int:
+        return min(ranks, key=lambda r: (counts[r], token_counts[r], r))
+
+    loads = [counts[r] for r in eligible]
+    max_load, min_load = max(loads), min(loads)
+    if max_load - min_load > BALANCE_ABS and max_load > min_load * BALANCE_REL:
+        return least_loaded(eligible)
+
+    if prompt_len > 0:
+        holders = [r for r in eligible if matches.get(r, 0) / prompt_len > CACHE_THRESHOLD]
+        if holders:
+            return least_loaded(holders)
+
+    return least_loaded(eligible)

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -34,6 +34,10 @@ from sgl_jax.srt.disaggregation.runtime import install_disaggregation_wiring
 from sgl_jax.srt.hf_transformers_utils import get_tokenizer
 from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
 from sgl_jax.srt.managers.communication import CommunicationBackend
+from sgl_jax.srt.managers.dp_schedule_policy import (
+    pick_cache_aware_dp,
+    req_prefix_match_key,
+)
 from sgl_jax.srt.managers.io_struct import (
     AbortReq,
     ContinueGenerationReqInput,
@@ -69,8 +73,10 @@ from sgl_jax.srt.managers.scheduler_profiler_mixing import SchedulerProfilerMixi
 from sgl_jax.srt.managers.tp_worker import ModelWorker
 from sgl_jax.srt.managers.tp_worker_overlap_thread import ModelWorkerClient
 from sgl_jax.srt.managers.utils import validate_input_length
+from sgl_jax.srt.mem_cache.base_prefix_cache import MatchPrefixParams
 from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
 from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
+from sgl_jax.srt.mem_cache.radix_cache import RadixKey
 from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
 from sgl_jax.srt.multimodal.tokenizer_utils import resolve_tokenizer_subdir
@@ -755,6 +761,27 @@ class Scheduler(
 
         return req_counts, token_counts
 
+    def _dp_load_and_eligible(
+        self, extra_counts: list[int], extra_token_counts: list[int]
+    ) -> tuple[list[int], list[int], list[int]]:
+        """Per-DP (running + pending) load and the ranks that can accept a request.
+
+        A rank is eligible when its batch is not full and it is under the
+        per-rank running cap. Returns ``(eligible_ranks, counts, token_counts)``.
+        """
+        running_counts, running_token_counts = self._get_dp_load_snapshot()
+        counts = [running_counts[i] + extra_counts[i] for i in range(self.dp_size)]
+        token_counts = [
+            running_token_counts[i] + extra_token_counts[i] for i in range(self.dp_size)
+        ]
+        eligible = [
+            dp_rank
+            for dp_rank in range(self.dp_size)
+            if not self.running_batch.reqs_info[dp_rank].batch_is_full
+            and counts[dp_rank] < self.per_dp_max_running_requests
+        ]
+        return eligible, counts, token_counts
+
     def _select_min_running_dp(
         self,
         extra_counts: list[int] | None = None,
@@ -772,24 +799,58 @@ class Scheduler(
         if extra_token_counts is None:
             extra_token_counts = [0] * self.dp_size
 
-        running_counts, running_token_counts = self._get_dp_load_snapshot()
-        counts = [running_counts[i] + extra_counts[i] for i in range(self.dp_size)]
-        token_counts = [
-            running_token_counts[i] + extra_token_counts[i] for i in range(self.dp_size)
-        ]
-
-        eligible = []
-        for dp_rank in range(self.dp_size):
-            if self.running_batch.reqs_info[dp_rank].batch_is_full:
-                continue
-            if counts[dp_rank] >= self.per_dp_max_running_requests:
-                continue
-            eligible.append(dp_rank)
-
+        eligible, counts, token_counts = self._dp_load_and_eligible(
+            extra_counts, extra_token_counts
+        )
         if not eligible:
             return None
 
         return min(eligible, key=lambda dp_rank: (counts[dp_rank], token_counts[dp_rank], dp_rank))
+
+    def _cached_prefix_len(self, token_ids: list[int], extra_key: str | None, dp_rank: int) -> int:
+        """Length of the longest cached prefix for ``token_ids`` on ``dp_rank``.
+
+        Probes the dp-keyed tree (no alloc, no CoW), but incurs the normal
+        ``match_prefix`` side effects (LRU refresh, possible node split). Returns
+        0 for non-radix caches (ChunkCache returns an empty match).
+        """
+        if self.tree_cache is None:
+            return 0
+        result = self.tree_cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(token_ids, extra_key, dp_rank))
+        )
+        return len(result.device_indices)
+
+    def _select_cache_aware_dp(
+        self,
+        req: TokenizedGenerateReqInput,
+        extra_counts: list[int],
+        extra_token_counts: list[int],
+    ) -> int | None:
+        """Route ``req`` by cache affinity with soft load balancing.
+
+        Probes each eligible rank's cached prefix length, then defers to
+        ``pick_cache_aware_dp``: balance on large load skew, else least-loaded
+        among the ranks holding a substantial cached prefix. Returns None if all
+        DP ranks are full.
+        """
+        if self.dp_size == 1:
+            return 0
+
+        eligible, counts, token_counts = self._dp_load_and_eligible(
+            extra_counts, extra_token_counts
+        )
+        if not eligible:
+            return None
+
+        token_ids, extra_key = req_prefix_match_key(req)
+        matches: dict[int, int] = {}
+        prompt_len = len(token_ids) if token_ids else 0
+        if token_ids:
+            for dp_rank in eligible:
+                matches[dp_rank] = self._cached_prefix_len(token_ids, extra_key, dp_rank)
+
+        return pick_cache_aware_dp(eligible, counts, token_counts, matches, prompt_len)
 
     def select_dp_for_request(self, recv_reqs: list[Req]) -> list[Req]:
         """Assign dp_rank to incoming requests using the configured DP policy.
@@ -838,10 +899,17 @@ class Scheduler(
                 ready_reqs.append(req)
                 continue
 
-            dp_rank = self._select_min_running_dp(
-                extra_counts=pending_counts,
-                extra_token_counts=pending_token_counts,
-            )
+            if self.dp_schedule_policy == "cache_aware":
+                dp_rank = self._select_cache_aware_dp(
+                    req,
+                    extra_counts=pending_counts,
+                    extra_token_counts=pending_token_counts,
+                )
+            else:
+                dp_rank = self._select_min_running_dp(
+                    extra_counts=pending_counts,
+                    extra_token_counts=pending_token_counts,
+                )
             if dp_rank is None:
                 # All DP ranks are full; keep the request pending.
                 self.pending_dp_reqs.append(req)

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -997,9 +997,15 @@ class ServerArgs:
         parser.add_argument(
             "--dp-schedule-policy",
             type=str,
-            choices=["round_robin", "min_running_queue"],
+            choices=["round_robin", "min_running_queue", "cache_aware"],
             default=ServerArgs.dp_schedule_policy,
-            help="DP scheduling policy for assigning dp_rank to new requests.",
+            help=(
+                "DP scheduling policy for assigning dp_rank to new requests. "
+                "'cache_aware' routes by cache affinity with soft load balancing: "
+                "it balances on large load skew, else picks the least-loaded rank "
+                "among those holding a substantial cached prefix, so a hot prefix "
+                "spreads across its holders. Improves prefix reuse under DP."
+            ),
         )
 
         # Multi-node distributed serving

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -322,6 +322,7 @@ suites = {
         TestFile("python/sgl_jax/test/mem_cache/test_unified_radix_tree_flag.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_paged_allocator_multi_dp.py", 1),
         TestFile("python/sgl_jax/test/test_kv_cache_builder.py", 0.1, runner="pytest"),
+        TestFile("test/srt/test_dp_schedule_policy.py", 0.2, runner="pytest"),
         TestFile("test/srt/function_call/test_qwen3_coder_detector.py", 0.1),
         TestFile("test/srt/function_call/test_glm4_moe_detector.py", 0.1),
         TestFile("test/srt/function_call/test_qwen25_detector.py", 0.1),

--- a/test/srt/test_dp_schedule_policy.py
+++ b/test/srt/test_dp_schedule_policy.py
@@ -1,0 +1,162 @@
+"""Unit tests for the cache-aware DP scheduling policy decision logic.
+
+Covers the pure ``pick_cache_aware_dp`` policy (soft affinity-vs-load) and
+``req_prefix_match_key`` probe-key extraction. These live in a dependency-free
+helper module, so the test imports neither Scheduler nor JAX. The end-to-end
+reuse improvement is validated separately by a full-KV ``cache_aware`` vs
+``min_running_queue`` A/B (see the PR description).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sgl_jax.srt.managers.dp_schedule_policy import pick_cache_aware_dp as pick
+from sgl_jax.srt.managers.dp_schedule_policy import req_prefix_match_key as match_key
+
+
+def test_holder_wins_when_loads_equal():
+    counts = [0, 0, 0, 0]
+    tokens = [0, 0, 0, 0]
+    matches = {0: 0, 1: 512, 2: 0, 3: 0}
+    assert pick([0, 1, 2, 3], counts, tokens, matches, prompt_len=512) == 1
+
+
+def test_least_loaded_among_holders():
+    # Both 0 and 1 hold a substantial prefix; rank 1 is less loaded. The longer
+    # match (rank 0, 600) does NOT win -- the hot prefix spreads to the lighter holder.
+    counts = [3, 1, 0, 0]
+    tokens = [30, 10, 0, 0]
+    matches = {0: 600, 1: 400}
+    assert pick([0, 1, 2, 3], counts, tokens, matches, prompt_len=512) == 1
+
+
+def test_no_cached_match_falls_back_to_least_load():
+    counts = [3, 1, 2, 4]
+    tokens = [30, 10, 20, 40]
+    matches = {0: 0, 1: 0, 2: 0, 3: 0}
+    assert pick([0, 1, 2, 3], counts, tokens, matches, prompt_len=512) == 1
+
+
+def test_below_threshold_match_is_not_a_holder():
+    # 100/512 < 0.5 -> rank 0 is not a holder; route by load to the idle rank 1.
+    counts = [5, 0]
+    tokens = [50, 0]
+    matches = {0: 100}
+    assert pick([0, 1], counts, tokens, matches, prompt_len=512) == 1
+
+
+def test_large_load_skew_overrides_cache_affinity():
+    # Rank 0 holds the full prefix but is overloaded; the skew (40-0 > 32) forces
+    # load balancing to the idle rank 1.
+    counts = [40, 0]
+    tokens = [400, 0]
+    matches = {0: 512}
+    assert pick([0, 1], counts, tokens, matches, prompt_len=512) == 1
+
+
+def test_small_load_skew_keeps_affinity():
+    # Skew 5-0 <= 32: affinity holds, route to the holder rank 0.
+    counts = [5, 0]
+    tokens = [50, 0]
+    matches = {0: 512}
+    assert pick([0, 1], counts, tokens, matches, prompt_len=512) == 0
+
+
+def test_hot_prefix_spills_when_owning_rank_is_full():
+    # Rank 0 holds the prefix but is full (not eligible): route by load among the
+    # eligible ranks (none of which hold it).
+    counts = [0, 5, 1, 9]
+    tokens = [0, 50, 10, 90]
+    matches = {0: 512}
+    assert pick([1, 2, 3], counts, tokens, matches, prompt_len=512) == 2
+
+
+def test_holder_and_load_tie_breaks_by_lowest_rank():
+    counts = [2, 2, 2, 2]
+    tokens = [20, 20, 20, 20]
+    matches = {0: 256, 1: 256, 2: 0, 3: 0}
+    assert pick([0, 1, 2, 3], counts, tokens, matches, prompt_len=256) == 0
+
+
+def test_prompt_len_zero_falls_back_to_least_load():
+    # No usable prompt_len -> skip the holder math (no zero-division), least-load wins.
+    counts = [5, 0]
+    tokens = [50, 0]
+    matches = {0: 512}
+    assert pick([0, 1], counts, tokens, matches, prompt_len=0) == 1
+
+
+def test_all_full_returns_none():
+    assert pick([], [0, 0], [0, 0], {}, prompt_len=4) is None
+
+
+def _req(input_ids, extra_key=None, lora_id=None, return_logprob=False, logprob_start_len=-1):
+    return SimpleNamespace(
+        input_ids=input_ids,
+        extra_key=extra_key,
+        lora_id=lora_id,
+        return_logprob=return_logprob,
+        logprob_start_len=logprob_start_len,
+    )
+
+
+def test_match_key_uses_reusable_prefix_not_full():
+    # The real radix lookup keeps >=1 token to generate, so the probe uses the
+    # reusable prefix (input_len - 1), not the full prompt.
+    assert match_key(_req([1, 2, 3, 4], extra_key="lora-a")) == ([1, 2, 3], "lora-a")
+
+
+def test_match_key_appends_lora_id():
+    # Matches Req.__init__: lora_id is concatenated into extra_key.
+    assert match_key(_req([1, 2, 3, 4], extra_key="salt:", lora_id="adapter")) == (
+        [1, 2, 3],
+        "salt:adapter",
+    )
+
+
+def test_match_key_lora_id_without_extra_key():
+    assert match_key(_req([1, 2, 3, 4], lora_id="adapter")) == ([1, 2, 3], "adapter")
+
+
+def test_match_key_return_logprob_clamps_to_start_len():
+    # return_logprob clamps the reusable prefix to logprob_start_len.
+    assert match_key(_req([1, 2, 3, 4, 5], return_logprob=True, logprob_start_len=2)) == (
+        [1, 2],
+        None,
+    )
+
+
+def test_match_key_return_logprob_default_start_len_uses_reusable_prefix():
+    # logprob_start_len=-1 is normalized to input_len-1 by the scheduler, so a
+    # default logprob request still probes the reusable prefix (not None).
+    assert match_key(_req([1, 2, 3, 4], return_logprob=True, logprob_start_len=-1)) == (
+        [1, 2, 3],
+        None,
+    )
+    # None on the wire behaves like the -1 sentinel.
+    assert match_key(_req([1, 2, 3, 4], return_logprob=True, logprob_start_len=None)) == (
+        [1, 2, 3],
+        None,
+    )
+
+
+def test_match_key_single_token_has_no_reusable_prefix():
+    assert match_key(_req([7])) == (None, None)
+
+
+def test_match_key_none_and_empty_are_skipped():
+    assert match_key(_req(None)) == (None, None)
+    assert match_key(_req([])) == (None, None)
+
+
+def test_match_key_batched_input_is_skipped():
+    assert match_key(_req([[1, 2], [3, 4]])) == (None, None)
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Adds an opt-in `--dp-schedule-policy cache_aware`. Under data parallelism,
load-only DP routing caps cross-request prefix reuse at ~`1/dp_size`: a prefix
cached on one rank is invisible to the others, so a shared system prompt is
re-cached on every rank it lands on. `cache_aware` routes each request to the
rank that already holds its cached prefix, with soft load balancing, lifting
reuse without overloading a hot rank.

This is a general full-KV `cache_aware` semantics change, **not**
recurrent-specific — it works for any radix-backed dp-keyed cache. Default stays
`min_running_queue`; `round_robin` and all flag-off paths are unchanged.

## What Changed

Paths under `python/sgl_jax/srt/` unless noted.

| File | Change |
|---|---|
| `managers/dp_schedule_policy.py` *(new)* | Dependency-free policy module (no JAX / Scheduler imports, so it unit-tests standalone): `pick_cache_aware_dp` (soft affinity-vs-load) and `req_prefix_match_key` (effective probe key). |
| `managers/scheduler.py` | `_select_cache_aware_dp` probes each eligible rank's dp-keyed radix tree via `match_prefix` and routes by the policy; `_dp_load_and_eligible` factored out of `_select_min_running_dp`; `cache_aware` branch added to `select_dp_for_request`. |
| `server_args.py` | Add `cache_aware` to `--dp-schedule-policy` choices + help. |
| `test/srt/test_dp_schedule_policy.py` *(new)* | 18 unit cases over the pure policy + effective-key extraction; registered in `test/srt/run_suite.py` (`unit-test-cpu`). |
| `benchmark/hicache/bench_unified_radix_ab.py` | Offline `--compare` gate: merge the `aggregates` from separate single-config result JSONs and run the soft-target A/B with no serving. |

**Policy.** Balance on large load skew (`max-min > 32` and `max > 1.1*min`,
upstream sgl-router defaults); else route to the least-loaded rank among the
*holders* — ranks whose cached prefix covers > 50% of the probe length — so a hot
prefix spreads across its holders instead of piling on the single longest match;
else least-loaded. Load order `(running, tokens, rank)`. The per-rank admission
cap stays the eligibility bound, so a hot prefix whose rank is full spills to the
next-best rank.

**Why the effective probe key.** The probe derives the same key the request's
real radix lookup will use, so it routes on a match the request can actually
reuse: `lora_id` is folded into `extra_key` (as `Req.__init__` does), and the
length is the reusable prefix `input_len - 1` (clamped by `logprob_start_len`
under `return_logprob`, as `Req.adjust_max_prefix_ids` does). Using `input_len-1`
also stops page-aligned `match_prefix` from reporting a phantom final-page hit
the request drops, and it is the holder denominator.

## Live Validation

| Area | Result |
|---|---|
| `test_dp_schedule_policy.py` (18 cases) | **pass** |
| `unit-test-cpu` full suite (39 files) | **pass** (pinned env, jax 0.8.1 / transformers 4.57) |
| pinned pre-commit (isort / ruff / black / codespell / mypy) | **pass** |
| Full-KV A/B (Qwen3-30B-A3B, tp4/dp2/ep4) | cache_aware **> min_running** |

### Full-KV A/B (Qwen3-30B-A3B, tp4/dp2/ep4, unified radix on, gsp shared-prefix)

Pure full-attention MoE, one v6e-4. Two server launches differing **only** in
`--dp-schedule-policy`; gsp = 16 groups × 8 prompts, 2048-token shared prefix;
mean of 2 post-warmup reps:

| metric | min_running_queue | cache_aware | delta |
|---|---|---|---|
| cache hit rate | 0.676 | 0.698 | +0.022 |
| p50 TTFT | 1177 ms | 874 ms | **−25.8%** |
| throughput | 32635 tok/s | 34780 tok/s | **+6.6%** |

The hit-rate headroom is bounded at dp2 (the ~`1/dp_size` floor is already ~0.5);
the user-visible win is the **−25.8% p50 TTFT** from better prefill cache
locality.

Reproduce (run the launch + client once per policy, identical otherwise):

```bash
# POLICY in {min_running_queue, cache_aware}
python -m sgl_jax.launch_server --model-path <model> --port 30000 \
  --tp-size 4 --dp-size 2 --ep-size 4 --attention-backend fa \
  --enable-unified-radix-tree --enable-cache-report --page-size 128 \
  --context-length 8192 --chunked-prefill-size 512 --mem-fraction-static 0.8 \
  --max-running-requests 64 --dtype bfloat16 --random-seed 3 \
  --skip-server-warmup --trust-remote-code \
  --precompile-bs-paddings 8 16 32 64 --precompile-token-paddings 2048 4096 \
  --dp-schedule-policy $POLICY

python -m sgl_jax.bench_serving --backend sgl-jax --base-url http://127.0.0.1:30000 \
  --model <model> --dataset-name generated-shared-prefix \
  --gsp-num-groups 16 --gsp-prompts-per-group 8 --gsp-system-prompt-len 2048 \
  --gsp-question-len 128 --gsp-output-len 128 --num-prompts 128 --max-concurrency 64
```

The committed `bench_unified_radix_ab.py` benchmarks **cache configs**
(no-cache / radix / unified), not DP policies; the policy A/B above is the two
launch commands, and the new offline `--compare` gate merges the two result
JSONs into one A/B report.

### Downstream (validated once the recurrent path lands) — related context only

- Recurrent shared-prefix A/B at dp4: hit 0.51 → 0.76, p50 TTFT −59%, tput +36%.
- Real eval (token-weighted cache-hit): 0.289 → 0.444.

## Known Limitations

- The probe uses `match_prefix`, which is **not read-only**: it refreshes the
  matched path's LRU and may split a node on a partial match. In the common case
  a prefix lives on one rank, so only the rank the probe routes to is touched. A
  non-mutating `peek_prefix_len` would remove the cross-rank touch (Next Work).
- Recurrent / hybrid models still require `--disable-radix-cache` on this branch,
  so `cache_aware` applies to full-KV radix paths only here; recurrent reuse is
  gated on the recurrent-radix path.

## Next Work

1. Non-mutating `peek_prefix_len` probe to drop the LRU-refresh / node-split side
   effect.
