### PR TITLE
fix(glm5): disable fused MLP for static FP8 checkpoint (#1403)

### DIFF
--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -509,6 +509,12 @@ class Glm5MLP(nnx.Module):
     def post_load_weights(self):
         if not self.use_fused:
             return
+        if not hasattr(self.gate_proj, "weight"):
+            # static fp8 checkpoint: gate_proj is already QuantizedLinear
+            # (weight_q/weight_scale), fused-merge path from #1344 only
+            # handles bf16 LinearBase. Fall back to unfused (forward checks
+            # hasattr(self, "w_gu")).
+            return
 
         wg = self.gate_proj.weight.value
         wu = self.up_proj.weight.value
@@ -1108,9 +1114,11 @@ class GlmMoeDsaForCausalLM(Glm5ForCausalLM):
         # runs, so the fused weights bypass quantization and regress decode
         # TPOT on HBM-bound hardware (#1378). Keep the unfused path there so
         # the LinearBase modules get quantized as before.
-        mc.hf_config._sgl_use_fused_mlp = (
-            mc.quantization_config is None or mc.quantization_config.is_static_checkpoint
-        )
+        # Static fp8 checkpoint also breaks fused: gate_proj/up_proj/down_proj
+        # become QuantizedLinear (no .weight), so post_load_weights cannot
+        # populate w_gu/w_d and the abstract ShapeDtypeStruct placeholders
+        # leak into jit inputs. Keep fused for bf16-only.
+        mc.hf_config._sgl_use_fused_mlp = mc.quantization_config is None
 
 
 EntryClass = [Glm5ForCausalLM, GlmMoeDsaForCausalLM]


### PR DESCRIPTION
## Motivation

Fixes #1403. #1378 kept `_sgl_use_fused_mlp=True` for static FP8 checkpoints, but the loader replaces `gate_proj`/`up_proj`/`down_proj` with `QuantizedLinear` (which has `weight_q`/`weight_scale`, not `.weight`) **before** `post_load_weights` runs. So the fused-merge path crashes with `AttributeError: 'QuantizedLinear' object has no attribute 'weight'`. Even guarding with `hasattr` is insufficient — the `w_gu`/`w_d` placeholders allocated in `__init__` stay as `ShapeDtypeStruct` and leak into `jitted_run_model` inputs.

## Modifications

- `patch_model_config`: `_sgl_use_fused_mlp = quantization_config is None` (was `... or is_static_checkpoint`). Static FP8 now also takes the unfused path, same as dynamic quant.
- `Glm5MLP.post_load_weights`: add a `hasattr(self.gate_proj, "weight")` guard as defense-in-depth.

This drops the #1344 fused-MLP speedup for static FP8 checkpoints. A follow-up could teach the fused path to consume `weight_q`/`weight_scale`, but that's a larger change.

## Verification

GLM-5.1 static FP8 checkpoint, TPU v7x 2x2x2, tp=16:
- Before: `AttributeError` at `post_load_weights` (or `TypeError: ShapeDtypeStruct ... not a valid JAX type` if guarded)
- After: loads + serves; greedy "The capital of France is" → "Paris..."; bench rate=0.19 IL=4096 OL=1024 ×2 runs σ<1%

BF16 path unchanged (`quantization_config is None` → still `use_fused=True`).

## Checklist

- [x] `pre-commit run --all-files`
- [x] e2e on v7x static FP8 (sanity + bench ×2)
- [x] BF16 path unchanged (logic verified)
