### PR TITLE
fix(spec): non-overlap multi-host crash + false-positive KV leak

### DIFF
--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -876,6 +876,16 @@ class Scheduler(
             if batch:
                 result = self.run_batch(batch)
                 self.process_batch_result(batch, result)
+            elif any(r is not None for r in self.chunked_reqs):
+                # Spec non-overlap blocks prefill while running_batch is non-empty
+                # (get_new_batch_prefill early-return). When the last running req
+                # finishes, the same call still sees the finished req in
+                # running_batch, returns None, and update_running_batch then
+                # filters it to empty -> batch=None for one iteration. Chunked
+                # reqs on other DP ranks still hold KV at that moment, so
+                # check_memory() would raise a false-positive leak. Skip the
+                # idle bookkeeping; next iteration prefill will resume chunk2.
+                pass
             else:
                 # When the server is idle, do self-check and re-init some states
                 self.check_memory()

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -810,6 +810,18 @@ class EagleDraftInput:
         for f in device_fields:
             v = getattr(self, f, None)
             if v is not None and hasattr(v, "copy_to_host_async"):
+                sh = getattr(v, "sharding", None)
+                if sh is not None and not getattr(sh, "is_fully_replicated", True):
+                    # Non-overlap multi-host path: spec_decode_verify leaves
+                    # accept_length (and potentially others) as P("data")
+                    # device arrays. np.asarray on a cross-host array raises
+                    # "spans non-addressable devices". Gather to replicated
+                    # first; this path is SPMD across hosts so the collective
+                    # is safe.
+                    from jax.experimental.multihost_utils import process_allgather
+
+                    v = process_allgather(v, tiled=True)
+                    setattr(self, f, v)
                 jax.copy_to_host_async(v)
                 to_copy.append(f)
         for f in to_copy:


### PR DESCRIPTION

Fixes #1405.

Two regressions on the `--speculative-algorithm` + `--disable-overlap-schedule` + multi-host (`dp>1`) path after #1293. Both are unreachable from single-host CI and from the (default) overlap path.

## 1. `_ensure_host` crash on cross-host `accept_length`

`spec_decode_verify` now populates `next_draft_input.accept_length` with a `P("data")`-sharded device array. Non-overlap `spec_decode` does not set `future_indices`, so `_split_spec_info_per_rank` calls `_ensure_host()`, which does `np.asarray` on a cross-host array → `RuntimeError: spans non-addressable devices` on the first decode batch.

`restore_draft_extend_result` already converts `topk_p/topk_index/hidden_states/verified_id` to host numpy but does not touch `accept_length`. Rather than special-casing one field, `_ensure_host` now `process_allgather`s any non-replicated field before the host copy. The non-overlap path is SPMD across hosts so the collective is safe.

## 2. False-positive `check_memory` leak with chunked prefill

`get_new_batch_prefill` early-returns when `running_batch` is non-empty (spec non-overlap cannot mix prefill+decode). After the last running req finishes, the finished req is still present in `running_batch` for one more `get_next_batch_to_run` call, so the early-return fires again, the decode branch filters running to empty, and `batch=None` for exactly one iteration. `event_loop_normal` then calls `check_memory()` while `chunked_reqs` on other DP ranks still hold their chunk1 KV (chunk2 pending) → false-positive `memory leak detected` raise (leak amount = `chunked_prefill_size` per pending rank, `dp` of the just-finished req is clean).

Next iteration would resume chunk2 normally; this is purely a transient one-loop gap, not an actual leak. Fix: skip the idle bookkeeping (`check_memory`/`check_tree_cache`/ratio reset) when `chunked_reqs` is pending — the server is not actually idle.

## Testing

TPU v6e-16, 4 hosts, `dp=4 tp=16`, MiMo-V2-Flash, `cps=2048 swa=0.3`:

| case | before | after |
|---|---|---|
| 1 req, 256 in / 64 out (non-chunked) | crash @ first decode | ✓ |
| 16 × 4K in / 128 out, conc=8 | crash → leak crash | ✓ 16/16 |
| 64 × 4K in / 256 out, conc=32 (run1) | leak crash | ✓ 64/64 |
| 64 × 4K in / 256 out, conc=32 (run2, seed=43) | — | ✓ 64/64 |
| `check_memory()` after all reqs drain | — | ✓ pass |

Decode `accept-len` reads 1.0–4.0 across rounds as expected (server log). Neither change touches verify/draft compute, only host-copy of `accept_length` (lossless `process_allgather`) and idle-branch bookkeeping.