### PR TITLE
fix(sharding): derive FlashAttention shard_map in_specs from actual sharding

### DIFF
--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -534,9 +534,10 @@ class FlashAttention(AttentionBackend):
         elif hasattr(token_to_kv_pool, "remap_cache_loc") and self.page_size == 1:
             page_indices_arg = token_to_kv_pool.remap_cache_loc(page_indices_arg, layer.layer_id)
 
-        q_arg = q.reshape(q.shape[0], -1, self.head_dim)
-        k_arg = k.reshape(k.shape[0], -1, self.head_dim)
-        v_arg = v.reshape(v.shape[0], -1, self.head_dim)
+        head_dim = getattr(layer, "head_dim", self.head_dim)
+        q_arg = q.reshape(q.shape[0], -1, head_dim)
+        k_arg = k.reshape(k.shape[0], -1, head_dim)
+        v_arg = v.reshape(v.shape[0], -1, head_dim)
 
         # JAX 0.9.1+ enforces shard_map in_specs match actual input sharding.
         # Derive effective axes from the actual array sharding rather than

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -19,7 +19,7 @@ from sgl_jax.srt.mem_cache.memory_pool import KVCache
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
 from sgl_jax.srt.utils import cdiv
-from sgl_jax.srt.utils.jax_utils import device_array
+from sgl_jax.srt.utils.jax_utils import device_array, effective_axis
 from sgl_jax.srt.utils.profiling_utils import named_scope
 
 logger = logging.getLogger(__name__)
@@ -534,33 +534,65 @@ class FlashAttention(AttentionBackend):
         elif hasattr(token_to_kv_pool, "remap_cache_loc") and self.page_size == 1:
             page_indices_arg = token_to_kv_pool.remap_cache_loc(page_indices_arg, layer.layer_id)
 
+        q_arg = q.reshape(q.shape[0], -1, self.head_dim)
+        k_arg = k.reshape(k.shape[0], -1, self.head_dim)
+        v_arg = v.reshape(v.shape[0], -1, self.head_dim)
+
+        # JAX 0.9.1+ enforces shard_map in_specs match actual input sharding.
+        # Derive effective axes from the actual array sharding rather than
+        # divisibility, so specs always match what JAX assigned.
+        axis = self.kv_partition_axis
+        dpa = self.attention_data_partition_axis
+
+        # q and kv may have different head counts (GQA), so compute axes
+        # independently from the actual array sharding.
+        q_data = effective_axis(q_arg, 0, dpa)
+        q_axis = effective_axis(q_arg, 1, axis)
+        kv_data = effective_axis(k_arg, 0, dpa)
+        kv_axis = effective_axis(k_arg, 1, axis)
+        v_data = effective_axis(v_arg, 0, dpa)
+        v_axis = effective_axis(v_arg, 1, axis)
+
+        # kv_cache: [pages, page_size, heads*2//packing, packing, head_dim]
+        cache_data = effective_axis(kv_cache_fused, 0, dpa)
+        cache_axis = effective_axis(kv_cache_fused, 2, axis)
+
+        # attention_sink: [num_q_heads] — derive from actual sharding
+        sink_axis = effective_axis(attention_sink, 0, axis) if attention_sink is not None else None
+
+        # Metadata arrays: derive from actual sharding
+        kv_lens_dpa = effective_axis(self.forward_metadata.seq_lens, 0, dpa)
+        page_idx_dpa = effective_axis(page_indices_arg, 0, dpa)
+        cu_q_dpa = effective_axis(self.forward_metadata.cu_q_lens, 0, dpa)
+        cu_kv_dpa = effective_axis(self.forward_metadata.cu_kv_lens, 0, dpa)
+        dist_dpa = effective_axis(self.forward_metadata.distribution, 0, dpa)
+        custom_mask_dpa = (
+            effective_axis(self.forward_metadata.custom_mask, 0, dpa)
+            if self.forward_metadata.custom_mask is not None
+            else None
+        )
+
         in_specs = (
-            P(self.attention_data_partition_axis, self.kv_partition_axis),  # queries
-            P(self.attention_data_partition_axis, self.kv_partition_axis),  # keys (new tokens)
-            P(self.attention_data_partition_axis, self.kv_partition_axis),  # values (new tokens)
-            P(
-                self.attention_data_partition_axis, None, self.kv_partition_axis, None, None
-            ),  # kv_cache_fused (head interleaved)
-            P(self.attention_data_partition_axis),  # kv_lens
-            P(self.attention_data_partition_axis),  # page_indices
-            P(self.attention_data_partition_axis),  # cu_q_lens
-            P(self.attention_data_partition_axis),  # cu_kv_lens
-            P(self.attention_data_partition_axis),  # distribution
+            P(q_data, q_axis),  # queries
+            P(kv_data, kv_axis),  # keys (new tokens)
+            P(v_data, v_axis),  # values (new tokens)
+            P(cache_data, None, cache_axis, None, None),  # kv_cache_fused
+            P(kv_lens_dpa),  # kv_lens
+            P(page_idx_dpa),  # page_indices
+            P(cu_q_dpa),  # cu_q_lens
+            P(cu_kv_dpa),  # cu_kv_lens
+            P(dist_dpa),  # distribution
             (
-                P(self.attention_data_partition_axis)
+                P(custom_mask_dpa)
                 if self.forward_metadata.custom_mask is not None
                 else P()
-            ),  # custom_mask: DP-segmented per-rank (cu_seq_mask_lens is rank-local)
-            (
-                P(self.kv_partition_axis) if attention_sink is not None else P()
-            ),  # attention sink: (num_q_heads,), sharded by heads
+            ),  # custom_mask: DP-segmented per-rank when present
+            P(sink_axis) if attention_sink is not None else P(),  # attention sink
         )
 
         out_specs = (
-            P(self.attention_data_partition_axis, self.kv_partition_axis),  # attention output
-            P(
-                self.attention_data_partition_axis, None, self.kv_partition_axis, None, None
-            ),  # updated kv_cache_fused (head interleaved) - 3D: [total_tokens, num_kv_heads*2, head_dim]
+            P(q_data, q_axis),  # attention output
+            P(cache_data, None, cache_axis, None, None),  # updated kv_cache_fused
         )
 
         mask_aligned_to_cu_kv = (
@@ -568,9 +600,12 @@ class FlashAttention(AttentionBackend):
             and forward_batch.forward_mode.is_target_verify()
         )
 
+        # args layout follows in_specs order: q, k, v, kv_cache, ...,
+        # attention_sink (always last, may be None with P() spec).
         def _ragged_paged_attention_with_fused_kv(*args):
             queries, keys, values, kv_cache_fused = args[:4]
-            other_args = args[4:]
+            other_args = args[4:-1]
+            local_attention_sink = args[-1]
 
             # Call fused KV kernel with head interleaving
             result, updated_kv_cache_fused = ragged_paged_attention_v3(
@@ -579,6 +614,7 @@ class FlashAttention(AttentionBackend):
                 values,
                 kv_cache_fused,
                 *other_args,
+                attention_sink=local_attention_sink,
                 causal=causal,
                 sm_scale=scale,
                 sliding_window=layer.sliding_window_size,
@@ -601,9 +637,9 @@ class FlashAttention(AttentionBackend):
             out_specs=out_specs,
             check_vma=False,
         )(
-            q.reshape(q.shape[0], -1, getattr(layer, "head_dim", self.head_dim)),
-            k.reshape(k.shape[0], -1, getattr(layer, "head_dim", self.head_dim)),
-            v.reshape(v.shape[0], -1, getattr(layer, "head_dim", self.head_dim)),
+            q_arg,
+            k_arg,
+            v_arg,
             kv_cache_fused,
             self.forward_metadata.seq_lens,
             page_indices_arg,
@@ -615,7 +651,7 @@ class FlashAttention(AttentionBackend):
         )
 
         return (
-            attn_output.reshape(q.shape[0], -1),
+            attn_output.reshape(q_arg.shape[0], -1),
             updated_kv_cache_fused,
         )
 

--- a/python/sgl_jax/srt/utils/jax_utils.py
+++ b/python/sgl_jax/srt/utils/jax_utils.py
@@ -210,6 +210,24 @@ def device_array(data, sharding=None, **kwargs) -> jax.Array:
     return jax.tree.map(_to_device, data)
 
 
+def effective_axis(x, dim: int, expected: str):
+    """Return ``expected`` only when an array is exactly sharded that way.
+
+    Inside jax.jit the concrete Array sharding may be carried by the tracer
+    aval instead of x.sharding; shard_map still validates against that aval
+    sharding. This helper intentionally does not infer or simplify composite
+    axes; it only mirrors exact per-dimension axis matches for shard_map specs.
+    """
+    for sharding in (
+        getattr(x, "sharding", None),
+        getattr(getattr(x, "aval", None), "sharding", None),
+    ):
+        spec = getattr(sharding, "spec", None)
+        if spec is not None and len(spec) > dim:
+            return expected if spec[dim] == expected else None
+    return None
+
+
 _IS_TPU_RUNTIME_CACHED: bool | None = None
 
 

--- a/python/sgl_jax/test/test_jax_utils.py
+++ b/python/sgl_jax/test/test_jax_utils.py
@@ -2,7 +2,6 @@ import unittest
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 

--- a/python/sgl_jax/test/test_jax_utils.py
+++ b/python/sgl_jax/test/test_jax_utils.py
@@ -1,0 +1,42 @@
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.utils.jax_utils import effective_axis
+
+
+class TestEffectiveAxis(unittest.TestCase):
+    """Unit tests for the effective_axis sharding helper."""
+
+    def test_concrete_named_sharding_match(self):
+        mesh = jax.sharding.Mesh(jax.devices()[:1], ("data",))
+        x = jax.device_put(jnp.ones((4, 8)), NamedSharding(mesh, P("data", None)))
+        self.assertEqual(effective_axis(x, 0, "data"), "data")
+        self.assertIsNone(effective_axis(x, 0, "tensor"))
+        self.assertIsNone(effective_axis(x, 1, "data"))
+
+    def test_concrete_named_sharding_mismatch(self):
+        mesh = jax.sharding.Mesh(jax.devices()[:1], ("tensor",))
+        x = jax.device_put(jnp.ones((4, 8)), NamedSharding(mesh, P(None, "tensor")))
+        self.assertIsNone(effective_axis(x, 0, "tensor"))
+        self.assertEqual(effective_axis(x, 1, "tensor"), "tensor")
+
+    def test_replicated_returns_none(self):
+        x = jnp.ones((4, 8))
+        self.assertIsNone(effective_axis(x, 0, "data"))
+        self.assertIsNone(effective_axis(x, 1, "tensor"))
+
+    def test_dim_out_of_range(self):
+        x = jax.device_put(
+            jnp.ones((4,)),
+            NamedSharding(jax.sharding.Mesh(jax.devices()[:1], ("data",)), P("data")),
+        )
+        self.assertIsNone(effective_axis(x, 1, "data"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Derive the FlashAttention `shard_map` `in_specs` / `out_specs` from the **actual** input
  sharding instead of hard-coded `P("data", "tensor", ...)`, so they satisfy the stricter
  `shard_map` `in_specs` enforcement introduced in JAX 0.9.1+.
- Add a small `effective_axis(x, dim, expected)` helper that reads an array's real
  `NamedSharding` (including tracer `aval.sharding` inside `jax.jit`).
- Keep the dependency pinned at `jax[tpu]==0.8.1`; this change is **dual-version compatible**
  (no behavior change on 0.8.1, satisfies the strict check on 0.9.2).

This is the first minimal, real call-site fix from the JAX 0.8.1 → 0.9.2 upgrade
(splitting #1057 into small, reviewable PRs). It is intentionally scoped to the single
concrete 0.9.2 `in_specs` incompatibility — multi-chip `num_kv_heads < tp_size` robustness
is deliberately **not** included (see Scope).

## Motivation

JAX 0.9.1+ makes `shard_map` enforce that `in_specs` match the actual sharding of each
input; the previous silent resharding of mismatched inputs is gone. FlashAttention hard-codes
`P("data", "tensor", ...)` for every argument, but the replicated 1-D auxiliary arrays —
`attention_sink` (`float32[num_heads]`) and `custom_mask` (`bool[...]`) — are actually
`P(None)`. On JAX 0.9.2 this raises:

```
ValueError: in_specs passed to shard_map: P('tensor',) does not match the specs of the
input: P(None,) for arg: float32[32]. `in_specs` is an optional argument ... If you want
to reshard your inputs, you can use `jax.reshard` on the arguments and then pass those args
to shard_map.
```

This is **not** a multi-device-only problem: it reproduces on a single chip, because even
with a tensor-axis size of 1 JAX 0.9.2 treats `P('tensor') != P(None)`. The fix follows the
direction agreed in the #1286 review thread: land one concrete, dual-version-compatible
call-site fix while keeping the runtime JAX pinned at 0.8.1.

## Modifications

**FlashAttention (`srt/layers/attention/flashattention_backend.py`)**
- In `FlashAttention._paged_attention`, derive `in_specs` / `out_specs` for `q/k/v`,
  `kv_cache_fused`, the metadata arrays (`kv_lens`, `page_indices`, `cu_q_lens`,
  `cu_kv_lens`, `distribution`, `custom_mask`), and `attention_sink` from each input's
  actual sharding via `effective_axis`, instead of hard-coded axis names.
- Replicated aux arrays now correctly get `P(None)`; tensor/DP-sharded arrays keep their
  axes. No production tensor is resharded.

**Sharding helper (`srt/utils/jax_utils.py`)**
- Add `effective_axis(x, dim, expected)`: returns `expected` only when `x` is exactly
  sharded that way on `dim` (reading `x.sharding` or, inside `jit`, `x.aval.sharding`);
  otherwise `None`. It does not infer or simplify composite axes.

**Tests (`test/test_jax_utils.py`)**
- Unit tests for `effective_axis`: concrete `NamedSharding` match / mismatch, replicated
  fallback to `None`, dim out of range.

## Accuracy Tests

Representative end-to-end model, before/after the change, on the same hardware and JAX
version (the dependency is pinned at 0.8.1). Dense MMLU via the maintained server path
(`fa` backend), `Qwen/Qwen3-8B`, `num_examples=200`, single chip, JAX 0.8.1:

```
cd test/srt && python -m unittest test_eval_accuracy_large.TestEvalAccuracyLarge.test_mmlu
```

| Run | MMLU score | stem / humanities / social / other | Test time |
| --- | --- | --- | --- |
| `main` (before) | **0.725** | 0.786 / 0.629 / 0.714 / 0.809 | 256.16 s |
| this PR (after) | **0.725** | 0.786 / 0.629 / 0.714 / 0.809 | 245.92 s |

The MMLU score is **identical** overall and per-category, confirming the in_specs derivation
is a semantic no-op on JAX 0.8.1 (no correctness regression on a real 8B model). End-to-end
latency is within run-to-run noise (no throughput regression / no added communication); no
production tensor is resharded on the common path.

JAX 0.9.2 forward-compatibility for this path is covered by the single-chip unit-test matrix
below (this PR is green on 0.9.2 where `main` fails) and by the full upgrade in #1057.

## Test Plan

### FlashAttention unit tests — single-chip dual-version matrix

Run `python python/sgl_jax/test/test_flashattention_{mha,gqa,misc}.py` on TPU v6e restricted
to a single chip (`TPU_CHIPS_PER_HOST_BOUNDS=1,1,1 TPU_HOST_BOUNDS=1,1,1 TPU_VISIBLE_CHIPS=0`),
across three JAX versions in separate venvs on the same hardware:

| Code | JAX 0.8.1 | JAX 0.9.2 | JAX 0.10.2 |
| --- | --- | --- | --- |
| `main` (hard-coded specs) | PASS | **FAIL** — `in_specs` on attention_sink / custom_mask | PASS |
| **this PR** (derived specs) | PASS | **PASS** | PASS |

(PASS = mha 10/10, gqa 10/10, misc 6/6.) `main` fails only inside the strict `in_specs`
window: JAX 0.9.1 introduced the Explicit-mode assertion, and JAX 0.10.x no longer raises it
for a size-1 mesh axis. Deriving the specs from the actual sharding is **version-agnostic** —
green on 0.8.1, on the strict 0.9.x window, and on 0.10.x — so the fix is the robust choice
regardless of which JAX version the gray period and the eventual bump land on. The full
upgrade (dependency bump + end-to-end model runs) is exercised in #1057.

### Helper unit tests

```bash
python python/sgl_jax/test/test_jax_utils.py   # effective_axis: 4 tests, PASS
```

## Benchmarking and Profiling

Throughput/latency are reported via the Accuracy Tests table above (MMLU total latency on
`main` vs this branch). No separate serving benchmark is included: on JAX 0.8.1 the derived
specs are identical to the previous hard-coded specs on the common path, and no production
tensor is resharded, so no hot path changes behavior.

## Scope (explicitly deferred to a follow-up PR)

These are **multi-chip-only** and unrelated to the 0.9.2 `in_specs` strictness; they are
no-ops on a single chip and are validated separately on multi-chip hardware:

- `num_kv_heads < tp_size` divisibility fallback in `MHATokenToKVPool`
  (`effective_kv_partition_axis`).
- GQA head-ratio / v-axis / attention_sink resharding in the kernel call path.
- Reference-path host-side gather metadata in `ref_ragged_paged_attention` (test-only).

## References

- Part of [#1025](https://github.com/sgl-project/sglang-jax/issues/1025): the JAX upgrade
  tracking issue. This PR does not close it — it lands one dual-version-compatible call-site
  fix during the gray period while the dependency stays pinned at 0.8.1. (Per the discussion
  on that issue, the eventual runtime target may advance to 0.10.2; the `in_specs` strictness
  this PR addresses was introduced in 0.9.1 and still applies on 0.10.x, so the fix remains
  forward-compatible.)
- Relates to [#1057](https://github.com/sgl-project/sglang-jax/pull/1057): the full JAX
  0.8.1 → 0.9.2 upgrade; this PR is the first call-site fix split out of it, and #1057 also
  provides the 0.9.2 runtime + end-to-end model validation.
- Supersedes [#1286](https://github.com/sgl-project/sglang-jax/pull/1286): the helper-only
  foundation PR; per that review thread, this PR lands the helper together with a real,
  dual-version-compatible call-site fix instead of in isolation.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
