### PR TITLE
feat(mem_cache): page>=128 recurrent extra-buffer + pool sizing/admission

### DIFF
--- a/benchmark/hicache/bench_recurrent_reuse_sweep.py
+++ b/benchmark/hicache/bench_recurrent_reuse_sweep.py
@@ -1,0 +1,371 @@
+"""Recurrent-cache reuse-collapse K-sweep (one-time characterization).
+
+Characterizes how many distinct cached prefix snapshots the recurrent cache
+holds before reuse collapses, and asserts the empirical collapse "knee" falls
+in an analytically predicted range -- a sizing/eviction correctness check for
+the hybrid-recurrent cache.
+
+Recurrent state capacity is slot-count based (unlike token-scaled FULL KV), so
+a controlled one-snapshot-per-prefix workload shows a visible capacity knee at
+K* = dp_size * (S_rank - owned * C_rank), where S_rank = max_recurrent_state_size
+/ dp_size, owned = request_owned_slots a running req consumes (1 running + ping-pong
+track slots: 3 with overlap, 2 with --disable-overlap-schedule), and C_rank is the
+per-rank in-flight reservation derived from the ACTUAL run (--parallel spread
+over DP ranks), not a fixed constant.
+
+This script POINTS AT an already-running server (the operator launches it,
+multi-host for KDA); it does NOT launch a server. It talks HTTP only:
+``/get_server_info`` (sizing), ``/flush_cache`` (cold each K point), and
+``/generate`` with ``max_new_tokens=1`` reading ``meta_info.cached_tokens`` for
+reuse accounting -- the same primitives as the cache-hit probe.
+
+Per distinct-prefix count K::
+
+    flush_cache
+    WARM : send each of the K distinct prefixes once   -> populates the cache
+    PROBE: resend each prefix (in a shuffled order) + a short divergent suffix
+    record reuse_frac = sum(cached_tokens) / sum(prompt_tokens), probe TTFT, tput
+
+Prefixes are deterministic (per-index salt, no RNG/timestamps) so the sweep is
+reproducible; each crosses exactly one track boundary (length in [I, 2I), I =
+recurrent_track_interval) -> one reusable snapshot per prefix. The PROBE order is
+a fixed-seed shuffle, NOT the WARM order: replaying in the same order makes every
+probe miss once K exceeds capacity (each prefix is evicted just before its turn),
+which falsely reads as reuse=0; shuffling reflects the true retained fraction.
+
+Usage (client-only against a launched server)::
+
+    python benchmark/hicache/bench_recurrent_reuse_sweep.py \
+        --server-url http://<rank0>:30000 \
+        --k-list 8 16 32 64 96 128 160 192 256 \
+        --parallel 8 --output-json /tmp/recurrent_reuse_sweep.json
+
+The HTTP sweep path is exercised by the controller against a live server; the
+pure ``predict_knee`` math is covered by a CPU unittest (not in CI run_suite).
+"""
+
+import argparse
+import asyncio
+import json
+import random
+import statistics
+import time
+
+import requests
+
+from sgl_jax.test.kits.cache_hit_kit import (
+    async_request_sglang_generate,
+    flush_cache,
+    gen_payload,
+)
+
+
+def predict_knee(
+    max_recurrent_state_size: int,
+    dp_size: int,
+    C_rank: float,
+    request_owned_slots: int = 3,
+    snapshots_per_prefix: int = 1,
+) -> float:
+    """Analytic collapse knee K* = dp_size * (S_rank - owned*C_rank) / snapshots.
+
+    S_rank = max_recurrent_state_size / dp_size (slots per rank); request_owned_slots
+    is the slots a running req actually consumes (1 running + ping-pong track slots:
+    3 with overlap, 2 with --disable-overlap-schedule); C_rank is the per-rank
+    in-flight reservation. Example: size=192, dp=4, C_rank=4, owned=2 -> S_rank=48,
+    K* = 4 * (48 - 2*4) = 160.
+    """
+    s_rank = max_recurrent_state_size / dp_size
+    cap_rank = s_rank - request_owned_slots * C_rank
+    return dp_size * cap_rank / snapshots_per_prefix
+
+
+def derive_actual_C_rank(parallel: int, dp_size: int) -> float:
+    """Per-rank in-flight reservation from the actual run, not a constant.
+
+    The probe issues at most ``parallel`` requests concurrently; spread over
+    ``dp_size`` ranks (assume even routing) each rank carries about
+    ``parallel / dp_size`` concurrent requests, each reserving ``factor`` slots.
+    Non-uniform routing is absorbed by the widened knee range, not here.
+    """
+    return max(1.0, parallel / dp_size)
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Recurrent-cache reuse-collapse K-sweep (one-time characterization).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--server-url",
+        required=True,
+        help="Already-running server (operator launches; multi-host for KDA). Client-only.",
+    )
+    p.add_argument(
+        "--k-list",
+        nargs="+",
+        type=int,
+        default=[8, 16, 32, 64, 96, 128, 160, 192, 256],
+        help="Distinct-prefix counts K to sweep.",
+    )
+    p.add_argument(
+        "--parallel",
+        type=int,
+        default=8,
+        help="Client-side in-flight request load for WARM/PROBE (the production "
+        "analog is live serving concurrency; the server cap is --max-running-requests, "
+        "and the cache capacity that bounds K is --max-recurrent-state-size). Use "
+        ">= dp_size: predict_knee assumes every dp rank is populated, but WARM only "
+        "reaches ranks that carry an in-flight request, so parallel < dp_size "
+        "under-fills ranks and lowers the empirical knee below the prediction.",
+    )
+    p.add_argument(
+        "--suffix-tokens",
+        type=int,
+        default=8,
+        help="Short divergent suffix length (keeps the shared prefix the reusable snapshot).",
+    )
+    # Sizing fallbacks: used only if /get_server_info omits the field.
+    p.add_argument("--max-recurrent-state-size", type=int, default=None)
+    p.add_argument("--dp-size", type=int, default=None)
+    p.add_argument("--recurrent-track-interval", type=int, default=None)
+    p.add_argument(
+        "--request-owned-slots",
+        type=int,
+        default=None,
+        help="Per-req recurrent slots consumed (overrides server-info derivation: "
+        "3 overlap-on / 2 overlap-off extra-buffer, 1 otherwise).",
+    )
+    p.add_argument(
+        "--plateau-frac",
+        type=float,
+        default=0.9,
+        help="Knee = largest K with reuse_frac >= plateau-frac * max(reuse_frac).",
+    )
+    p.add_argument(
+        "--knee-range-frac",
+        type=float,
+        default=0.4,
+        help="Assertion half-width: knee must lie in [K*(1-f), K*(1+f)] (widened for DP routing).",
+    )
+    p.add_argument("--output-json", default=None)
+    p.add_argument(
+        "--no-assert",
+        action="store_true",
+        help="Report the knee-vs-K* verdict but skip the hard range assertion (curve-only run).",
+    )
+    return p.parse_args()
+
+
+def get_server_sizing(args):
+    """Read recurrent sizing from /get_server_info, falling back to CLI args."""
+    info = requests.get(f"{args.server_url}/get_server_info", timeout=30).json()
+
+    def pick(key, cli):
+        val = info.get(key)
+        return cli if val is None else val
+
+    size = pick("max_recurrent_state_size", args.max_recurrent_state_size)
+    dp_size = pick("dp_size", args.dp_size)
+    interval = pick("recurrent_track_interval", args.recurrent_track_interval)
+    tokenizer = info.get("tokenizer_path") or info.get("model_path")
+    assert size is not None and dp_size is not None and interval is not None, (
+        "missing recurrent sizing from /get_server_info; pass --max-recurrent-state-size, "
+        "--dp-size, --recurrent-track-interval explicitly "
+        f"(got size={size}, dp_size={dp_size}, interval={interval})"
+    )
+    # Actual per-req consumption: 1 running + ping-pong track slots (2 with overlap,
+    # 1 with --disable-overlap-schedule); 1 without extra-buffer.
+    if args.request_owned_slots is not None:
+        owned = args.request_owned_slots
+    elif info.get("enable_recurrent_extra_buffer"):
+        owned = 2 if info.get("disable_overlap_schedule") else 3
+    else:
+        owned = 1
+    return int(size), int(dp_size), int(interval), tokenizer, int(owned)
+
+
+def make_prefix_ids(tokenizer, index: int, target_tokens: int):
+    """Deterministic distinct prefix of ~target_tokens tokens (no RNG).
+
+    The per-index tag makes prefixes truly distinct so accidental sharing does
+    not blur the knee; padding words are index-seeded, never random.
+    """
+    head = f"Document {index} unique tag recurrent-reuse-sweep section. "
+    ids = tokenizer.encode(head)
+    filler = f"token{index}word "
+    while len(ids) < target_tokens:
+        ids = tokenizer.encode(head + filler * (target_tokens - len(ids) + 4))
+    return ids[:target_tokens]
+
+
+def make_suffix_ids(tokenizer, index: int, salt: int, n: int):
+    """Short divergent suffix; salt differs WARM (7) vs PROBE (13) per index."""
+    ids = tokenizer.encode(f" suffix{salt}-{index} end")
+    while len(ids) < n:
+        ids = ids + ids
+    return ids[:n]
+
+
+async def _send_round(payloads, url, parallel):
+    sem = asyncio.Semaphore(parallel)
+
+    async def one(payload):
+        async with sem:
+            return await async_request_sglang_generate(payload, url)
+
+    return await asyncio.gather(*[asyncio.create_task(one(p)) for p in payloads])
+
+
+def run_k_point(args, tokenizer, generate_url, K, interval):
+    """Run one K point: flush -> WARM -> PROBE; return per-point metrics."""
+    target_tokens = interval + interval // 2  # in [I, 2I) -> one track boundary
+    prefixes = [make_prefix_ids(tokenizer, i, target_tokens) for i in range(K)]
+
+    flush_cache(args.server_url)
+    warm = [
+        gen_payload(prefixes[i] + make_suffix_ids(tokenizer, i, 7, args.suffix_tokens), 1)
+        for i in range(K)
+    ]
+    asyncio.run(_send_round(warm, generate_url, args.parallel))
+
+    # Probe each prefix once, in a fixed-seed shuffled order (NOT the warm order).
+    # Same-order replay makes every probe miss once K exceeds capacity (each
+    # prefix is evicted just before its turn) -> false reuse=0; shuffling reflects
+    # the true retained fraction.
+    probe_order = list(range(K))
+    random.Random(1234).shuffle(probe_order)
+    probe = [
+        gen_payload(prefixes[i] + make_suffix_ids(tokenizer, i, 13, args.suffix_tokens), 1)
+        for i in probe_order
+    ]
+    t0 = time.perf_counter()
+    results = asyncio.run(_send_round(probe, generate_url, args.parallel))
+    wall = time.perf_counter() - t0
+
+    ok = [r for r in results if r.success]
+    assert ok, f"K={K}: all probe requests failed"
+    total_cached = sum(r.cached_tokens for r in ok)
+    total_prompt = sum(r.prompt_len for r in ok)
+    ttfts = sorted(r.ttft for r in ok)
+    return {
+        "K": K,
+        "reuse_frac": total_cached / total_prompt if total_prompt else 0.0,
+        "cached_tokens": total_cached,
+        "prompt_tokens": total_prompt,
+        "ttft_p50_ms": statistics.median(ttfts) * 1000.0,
+        "ttft_p90_ms": ttfts[min(len(ttfts) - 1, int(0.9 * len(ttfts)))] * 1000.0,
+        "throughput_req_s": len(ok) / wall if wall else 0.0,
+    }
+
+
+def detect_knee(curve, plateau_frac, eps=1e-9):
+    """Knee = largest K with reuse_frac >= plateau_frac * max(reuse_frac).
+
+    Returns None when no prefix was ever reused (peak reuse_frac ~ 0). There is
+    no knee to locate in that case, and returning the largest K would falsely
+    read as a full-capacity plateau -- the no-cache / broken-cache / all-miss
+    signature, not a sizing result.
+    """
+    fracs = {pt["K"]: pt["reuse_frac"] for pt in curve}
+    peak = max(fracs.values(), default=0.0)
+    if peak <= eps:
+        return None
+    return max(K for K, f in fracs.items() if f >= plateau_frac * peak)
+
+
+def main():
+    args = parse_args()
+    print(f"args={args}\n", flush=True)
+
+    from sgl_jax.bench_serving import get_tokenizer
+
+    size, dp_size, interval, tokenizer_path, owned = get_server_sizing(args)
+
+    if args.parallel < dp_size and not args.no_assert:
+        raise SystemExit(
+            f"--parallel ({args.parallel}) < dp_size ({dp_size}): WARM only fills "
+            f"ranks that carry an in-flight request, so the empirical knee falls "
+            f"below predict_knee and the gate falsely fails. Use --parallel >= "
+            f"{dp_size}, or pass --no-assert for a curve-only run."
+        )
+
+    tokenizer = get_tokenizer(tokenizer_path)
+    generate_url = f"{args.server_url}/generate"
+
+    curve = []
+    for K in sorted(args.k_list):
+        pt = run_k_point(args, tokenizer, generate_url, K, interval)
+        curve.append(pt)
+        print(
+            f"K={K:>5}  reuse_frac={pt['reuse_frac']:.4f}  "
+            f"cached={pt['cached_tokens']}/{pt['prompt_tokens']}  "
+            f"ttft_p50={pt['ttft_p50_ms']:.1f}ms  ttft_p90={pt['ttft_p90_ms']:.1f}ms  "
+            f"tput={pt['throughput_req_s']:.1f}req/s",
+            flush=True,
+        )
+
+    knee = detect_knee(curve, args.plateau_frac)
+    C_rank = derive_actual_C_rank(args.parallel, dp_size)
+    Kstar = predict_knee(
+        size, dp_size, C_rank=C_rank, request_owned_slots=owned, snapshots_per_prefix=1
+    )
+    Kstar_lo = Kstar * (1 - args.knee_range_frac)
+    Kstar_hi = Kstar * (1 + args.knee_range_frac)
+    no_reuse = knee is None
+    in_range = (not no_reuse) and (Kstar_lo <= knee <= Kstar_hi)
+
+    if no_reuse:
+        print(
+            "\nno reusable prefixes observed (peak reuse_frac ~ 0) -> no knee to "
+            "locate. Expected with caching disabled or unreachable; otherwise the "
+            "recurrent snapshot is not being cached/reused. -> FAIL",
+            flush=True,
+        )
+    else:
+        print(
+            f"\nsize={size} dp_size={dp_size} interval={interval} parallel={args.parallel} "
+            f"C_rank={C_rank:.2f}\n"
+            f"K*={Kstar:.1f}  range=[{Kstar_lo:.1f}, {Kstar_hi:.1f}]  "
+            f"empirical knee={knee}  -> {'PASS' if in_range else 'FAIL'}",
+            flush=True,
+        )
+
+    if args.output_json:
+        payload = {
+            "args": vars(args),
+            "sizing": {
+                "max_recurrent_state_size": size,
+                "dp_size": dp_size,
+                "recurrent_track_interval": interval,
+                "request_owned_slots": owned,
+                "C_rank": C_rank,
+            },
+            "curve": curve,
+            "knee": knee,
+            "no_reuse": no_reuse,
+            "Kstar": Kstar,
+            "Kstar_range": [Kstar_lo, Kstar_hi],
+            "in_range": in_range,
+        }
+        with open(args.output_json, "w") as f:
+            json.dump(payload, f, indent=2, default=str)
+        print(f"\nWrote results to {args.output_json}")
+
+    if no_reuse:
+        assert args.no_assert, (
+            "no reusable prefixes observed (peak reuse_frac ~ 0): caching is "
+            "disabled/unreachable or the recurrent snapshot is not cached/reused."
+        )
+    else:
+        assert in_range or args.no_assert, (
+            f"empirical knee {knee} outside predicted range "
+            f"[{Kstar_lo:.1f}, {Kstar_hi:.1f}] (K*={Kstar:.1f}): "
+            "knee << K* means parallel < dp_size (WARM under-fills ranks) or an "
+            "eviction/sizing/routing bug; knee >> K* means over-provisioning / "
+            "non-caching prefixes."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/hicache/bench_unified_radix_ab.py
+++ b/benchmark/hicache/bench_unified_radix_ab.py
@@ -1,31 +1,44 @@
-"""Standalone A/B serving benchmark for HiCache Stage 1 (S1c).
+"""Standalone A/B serving benchmark for the unified radix cache.
 
-Compares three cache configurations on a single TPU pod:
+Compares cache configurations on a single TPU pod:
   - ``no-cache``  (``--disable-radix-cache``): no prefix reuse, the floor.
   - ``radix``     (default RadixCache): the current production baseline.
-  - ``unified``   (``--enable-unified-radix-tree``): the S1c UnifiedRadixCache.
+  - ``unified``   (``--enable-unified-radix-tree``): the UnifiedRadixCache.
+  - ``unified-recurrent`` (``--enable-unified-radix-tree
+    --enable-recurrent-extra-buffer``): the hybrid-recurrent cache.
 
 For each (config x workload) it launches one server, runs ``bench_serving``
 ``--repeats`` times (cold each rep via ``/flush_cache``), drops the first
 ``--drop-first`` warmup reps, then reports pooled TTFT percentiles, mean+/-std
 throughput, and mean cache-hit-rate, plus a few soft acceptance checks.
 
-This is M1 throughput/TTFT evidence for S1c. It is run MANUALLY on a v6e-4
-host (e.g. sky-yh-v6e4); it is NOT registered in CI. Servers are launched
-sequentially -- one TPU pod, never two servers at once.
+This is throughput/TTFT evidence for the unified radix cache. It is run
+MANUALLY on a v6e-4 host (e.g. sky-yh-v6e4); it is NOT registered in CI.
+Servers are launched sequentially -- one TPU pod, never two servers at once.
 
 Usage (on the TPU host, from the repo root)::
 
     python benchmark/hicache/bench_unified_radix_ab.py \
         --model Qwen/Qwen3-8B --tp-size 4 --page-size 128 --port 20000 \
         --configs no-cache radix unified --workloads random gsp \
-        --output-json /tmp/s1c_ab.json
+        --output-json /tmp/radix_ab.json
 
 MoE usage (Qwen3-MoE under tp/ep/dp)::
 
     python benchmark/hicache/bench_unified_radix_ab.py \
         --model /models/Qwen3-30B-A3B --tp-size 4 --ep-size 4 --moe-backend epmoe \
         --page-size 256 --configs radix unified --output-json /tmp/moe_ab.json
+
+External-server / multi-host usage:
+    ``popen_launch_server`` is single-host and cannot start an ``nnodes>1``
+    server. For multi-host KDA the operator launches the 4-pod server manually,
+    then runs this harness client-only against rank0 with ``--server-url`` and a
+    single ``--configs`` entry (a result label). A/B = run twice (e.g. no-cache
+    and unified-recurrent) and merge the two ``--output-json`` files offline::
+
+        python benchmark/hicache/bench_unified_radix_ab.py \
+            --server-url http://<rank0>:30000 --configs unified-recurrent \
+            --disable-overlap-schedule --workloads gsp --output-json /tmp/rec.json
 
 Multi-chip note:
     --tp-size is the TOTAL chip count; --dp-size sub-partitions it (attention runs
@@ -51,12 +64,16 @@ CONFIG_ARGS = {
     "no-cache": ["--disable-radix-cache"],
     "radix": [],
     "unified": ["--enable-unified-radix-tree"],
+    "unified-recurrent": [
+        "--enable-unified-radix-tree",
+        "--enable-recurrent-extra-buffer",
+    ],
 }
 
 
 def parse_args():
     p = argparse.ArgumentParser(
-        description="A/B serving benchmark: no-cache / RadixCache / UnifiedRadixCache (S1c).",
+        description="A/B serving benchmark: no-cache / RadixCache / UnifiedRadixCache.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     p.add_argument("--model", default="Qwen/Qwen3-8B")
@@ -71,7 +88,7 @@ def parse_args():
     p.add_argument(
         "--configs",
         nargs="+",
-        choices=["no-cache", "radix", "unified"],
+        choices=["no-cache", "radix", "unified", "unified-recurrent"],
         default=["no-cache", "radix", "unified"],
     )
     p.add_argument(
@@ -99,6 +116,34 @@ def parse_args():
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--mem-fraction-static", type=float, default=0.8)
     p.add_argument("--attention-backend", default="fa")
+    p.add_argument(
+        "--chunked-prefill-size",
+        type=int,
+        default=512,
+        help=(
+            "Prefill chunk size. Emitted to the server command ONLY for the "
+            "unified-recurrent config (it also sets the recurrent track interval); "
+            "the dense configs use the server default to stay byte-identical."
+        ),
+    )
+    p.add_argument(
+        "--disable-overlap-schedule",
+        action="store_true",
+        help=(
+            "Pass --disable-overlap-schedule to the server (correctness-critical "
+            "for KDA/Kimi-Linear recurrent decode)."
+        ),
+    )
+    p.add_argument(
+        "--server-url",
+        default=None,
+        help=(
+            "Run client-only against an already-launched server at this URL "
+            "(e.g. a multi-host nnodes>1 server). When set, the harness does NOT "
+            "launch or kill a server; exactly one --configs entry is required "
+            "(it is only a result label)."
+        ),
+    )
     p.add_argument(
         "--precompile-bs-paddings",
         nargs="+",
@@ -157,6 +202,12 @@ def parse_args():
             f"--precompile-bs-paddings {bad} not divisible by --tp-size "
             f"{args.tp_size} (hits the tp>1 sampler sharding bug)"
         )
+    if args.server_url is not None:
+        assert len(args.configs) == 1, (
+            "--server-url runs client-only against one already-launched server, so "
+            f"exactly one --configs entry is required (got {args.configs}). The config "
+            "name is only a result label; run twice and merge the two JSON outputs for A/B."
+        )
     return args
 
 
@@ -207,59 +258,24 @@ def _per_run_args(args, base_url, workload):
 
 
 def run_config(args, config):
-    """Launch one server for ``config`` and run all workloads x repeats."""
+    """Run all workloads x repeats for ``config``.
+
+    Launches one server for ``config`` unless ``--server-url`` is set, in which
+    case it runs client-only against that already-launched server (no launch, no
+    kill) -- the path for multi-host nnodes>1 servers ``popen_launch_server``
+    cannot start.
+    """
     from sgl_jax.bench_serving import run_benchmark
     from sgl_jax.srt.utils import kill_process_tree
     from sgl_jax.test.test_utils import popen_launch_server
 
-    base_url = f"http://127.0.0.1:{args.port}"
-    common = [
-        "--trust-remote-code",
-        "--skip-server-warmup",
-        "--dtype",
-        "bfloat16",
-        "--random-seed",
-        "3",
-        "--mem-fraction-static",
-        str(args.mem_fraction_static),
-        "--max-running-requests",
-        "256",
-        "--page-size",
-        str(args.page_size),
-        "--tp-size",
-        str(args.tp_size),
-        "--attention-backend",
-        args.attention_backend,
-        "--download-dir",
-        "/dev/shm/",
-    ]
-    common += ["--precompile-bs-paddings", *[str(b) for b in args.precompile_bs_paddings]]
-    common += ["--precompile-token-paddings", *[str(t) for t in args.precompile_token_paddings]]
-    # Emit parallelism/MoE flags only when set, so the default dense command stays
-    # byte-identical and main-compatible. --tp-size is the TOTAL chip count;
-    # --dp-size sub-partitions it (attention runs at tp_size // dp_size).
-    if args.dp_size > 1:
-        common += ["--dp-size", str(args.dp_size)]
-    if args.ep_size > 1:
-        common += ["--ep-size", str(args.ep_size)]
-    if args.moe_backend:
-        common += ["--moe-backend", args.moe_backend]
+    external = args.server_url is not None
+    base_url = args.server_url if external else f"http://127.0.0.1:{args.port}"
 
     # config -> {workload -> [res dict per rep]}
     results = {w: [] for w in args.workloads}
 
-    process = popen_launch_server(
-        args.model,
-        base_url=base_url,
-        timeout=1800,
-        other_args=common + CONFIG_ARGS[config],
-        check_cache_miss=False,
-        # A stray SGLANG_JAX_ENABLE_UNIFIED_RADIX_TREE=1 in the caller's env
-        # would silently turn the baselines into unified (env can only force
-        # the flag ON); pin it off -- "unified" gets the flag via CLI.
-        env={"SGLANG_JAX_ENABLE_UNIFIED_RADIX_TREE": "0"},
-    )
-    try:
+    def run_reps():
         for workload in args.workloads:
             for rep in range(args.repeats):
                 print(
@@ -291,6 +307,65 @@ def run_config(args, config):
                     )
                     continue
                 results[workload].append(res)
+
+    if external:
+        # Operator already launched the matching server (e.g. multi-host KDA);
+        # just drive the client loop against it.
+        run_reps()
+        return results
+
+    common = [
+        "--trust-remote-code",
+        "--skip-server-warmup",
+        "--dtype",
+        "bfloat16",
+        "--random-seed",
+        "3",
+        "--mem-fraction-static",
+        str(args.mem_fraction_static),
+        "--max-running-requests",
+        "256",
+        "--page-size",
+        str(args.page_size),
+        "--tp-size",
+        str(args.tp_size),
+        "--attention-backend",
+        args.attention_backend,
+        "--download-dir",
+        "/dev/shm/",
+    ]
+    common += ["--precompile-bs-paddings", *[str(b) for b in args.precompile_bs_paddings]]
+    common += ["--precompile-token-paddings", *[str(t) for t in args.precompile_token_paddings]]
+    # Emit parallelism/MoE flags only when set, so the default dense command stays
+    # byte-identical and main-compatible. --tp-size is the TOTAL chip count;
+    # --dp-size sub-partitions it (attention runs at tp_size // dp_size).
+    if args.dp_size > 1:
+        common += ["--dp-size", str(args.dp_size)]
+    if args.ep_size > 1:
+        common += ["--ep-size", str(args.ep_size)]
+    if args.moe_backend:
+        common += ["--moe-backend", args.moe_backend]
+    # Recurrent flags. Emit --chunked-prefill-size only for the recurrent config
+    # (it also sets the recurrent track interval); the dense configs keep the
+    # server default (4096) so their launch command stays byte-identical.
+    if config == "unified-recurrent":
+        common += ["--chunked-prefill-size", str(args.chunked_prefill_size)]
+    if args.disable_overlap_schedule:
+        common += ["--disable-overlap-schedule"]
+
+    process = popen_launch_server(
+        args.model,
+        base_url=base_url,
+        timeout=1800,
+        other_args=common + CONFIG_ARGS[config],
+        check_cache_miss=False,
+        # A stray SGLANG_JAX_ENABLE_UNIFIED_RADIX_TREE=1 in the caller's env
+        # would silently turn the baselines into unified (env can only force
+        # the flag ON); pin it off -- "unified" gets the flag via CLI.
+        env={"SGLANG_JAX_ENABLE_UNIFIED_RADIX_TREE": "0"},
+    )
+    try:
+        run_reps()
     finally:
         kill_process_tree(process.pid)
         process.wait()
@@ -446,6 +521,38 @@ def soft_targets(args, agg):
             f"vs no-cache.p50_ttft ({nc:.2f}), ratio={ratio:.3f} (want < 0.9)"
         )
 
+    # Recurrent A/B {no-cache, unified-recurrent} (no radix baseline). The
+    # hit-rate band is calibrated by the controller after the first run, so
+    # gsp hit-rate is reported, not gated.
+    rc = "unified-recurrent"
+    if "gsp" in args.workloads and have(rc, "gsp"):
+        hr = agg[rc]["gsp"]["hit_rate_mean"]
+        print(f"[REPORT] gsp: {rc}.hit_rate = {hr:.4f}")
+        if have("no-cache", "gsp"):
+            u = agg[rc]["gsp"]["p50_ttft_ms"]
+            nc = agg["no-cache"]["gsp"]["p50_ttft_ms"]
+            ratio = u / nc if nc else float("nan")
+            ok = ratio < 0.9
+            all_pass = all_pass and ok
+            fired += 1
+            print(
+                f"[{'PASS' if ok else 'WARN'}] gsp: {rc}.p50_ttft ({u:.2f}) "
+                f"vs no-cache.p50_ttft ({nc:.2f}), ratio={ratio:.3f} (want < 0.9)"
+            )
+
+    # random (a.k.a. low-concurrency): recurrent throughput overhead <= 5% vs
+    # no-cache.
+    if "random" in args.workloads and have(rc, "random") and have("no-cache", "random"):
+        u = agg[rc]["random"]["total_tok_s_mean"]
+        nc = agg["no-cache"]["random"]["total_tok_s_mean"]
+        ok = u >= 0.95 * nc
+        all_pass = all_pass and ok
+        fired += 1
+        print(
+            f"[{'PASS' if ok else 'WARN'}] random: {rc}.total_tok/s ({u:.1f}) "
+            f">= 0.95 * no-cache.total_tok/s ({0.95 * nc:.1f})"
+        )
+
     return all_pass, fired
 
 
@@ -488,8 +595,8 @@ def main():
         if fired == 0:
             print(
                 "\nNOTE: no A/B gate fired — compare needs both sides of a pair "
-                "for the same workload (e.g. no-cache/gsp + unified/gsp, or "
-                "radix/* + unified/*). Supply both result JSONs."
+                "for the same workload (e.g. no-cache/gsp + unified-recurrent/gsp, "
+                "or radix/* + unified/*). Supply both result JSONs."
             )
         if args.strict and (not ok or fired == 0):
             raise SystemExit(1)
@@ -506,6 +613,15 @@ def main():
     complete = check_sweep_complete(args, raw)
     targets_pass, _fired = soft_targets(args, agg)
     all_pass = complete and targets_pass
+
+    if args.server_url is not None and args.strict:
+        # Single-config external run: the A/B targets compare two configs, so none
+        # of them fire here. Say so, so --strict is not mistaken for a passed gate.
+        print(
+            "\nNOTE: single-config external run — the A/B targets need two configs "
+            "and did not run. Run each config separately, then gate with "
+            "`--compare run_a.json run_b.json --strict`."
+        )
 
     if args.output_json:
         payload = {

--- a/python/sgl_jax/srt/kernels/gdn/gated_delta.py
+++ b/python/sgl_jax/srt/kernels/gdn/gated_delta.py
@@ -92,6 +92,27 @@ def _scatter_idx0_safe(buf: jax.Array, state_indices: jax.Array, val: jax.Array)
     return buf.at[state_indices].set(safe_val)
 
 
+def _scatter_track(
+    buf: jax.Array,
+    track_indices: jax.Array,
+    track_mask: jax.Array,
+    val: jax.Array,
+) -> jax.Array:
+    """Scatter ``val`` into the request track slots (extra-buffer path).
+
+    Operates on the buffer RETURNED by :func:`_scatter_idx0_safe` so the
+    running slot and the track slot both persist. Keep-mask preserves slots at
+    ``track_idx == 0`` (padding/dummy) and ``track_mask == 0`` (non-boundary
+    rows). The result is wrapped in ``optimization_barrier`` because the pool
+    buffer is donated under multi-host SPMD (donated-buffer aliasing guard).
+    """
+    val = val.astype(buf.dtype)
+    keep = ((track_indices == 0) | (track_mask == 0)).reshape((-1,) + (1,) * (buf.ndim - 1))
+    safe_val = jnp.where(keep, buf[track_indices], val)
+    new_buf = buf.at[track_indices].set(safe_val)
+    return jax.lax.optimization_barrier(new_buf)
+
+
 def jax_causal_conv1d_prefill(
     x: jax.Array,  # [D, T]  packed activations
     weight: jax.Array,  # [D, kernel_size]  depthwise weight
@@ -101,6 +122,8 @@ def jax_causal_conv1d_prefill(
     state_indices: jax.Array | None = None,  # [B] req → slot
     has_initial_state: jax.Array | None = None,  # [B] bool
     activation: str | None = None,
+    track_indices: jax.Array | None = None,  # [B] req → track slot (None = OFF)
+    track_mask: jax.Array | None = None,  # [B] bool boundary mask
 ) -> tuple[jax.Array, jax.Array]:
     """Depthwise causal conv1d over a ragged-batched packed sequence.
 
@@ -247,6 +270,8 @@ def jax_causal_conv1d_prefill(
     # slice as-is for tests that don't construct a pool.
     if conv_state is not None:
         new_conv_state = _scatter_idx0_safe(conv_state, state_indices, final_state)
+        if track_indices is not None:
+            new_conv_state = _scatter_track(new_conv_state, track_indices, track_mask, final_state)
     else:
         new_conv_state = final_state
     return y, new_conv_state
@@ -260,6 +285,8 @@ def jax_causal_conv1d_update(
     bias: jax.Array | None = None,  # [D]
     activation: str | None = None,
     has_initial_state: jax.Array | None = None,  # [B] bool
+    track_indices: jax.Array | None = None,  # [B] req → track slot (None = OFF)
+    track_mask: jax.Array | None = None,  # [B] bool boundary mask
 ) -> tuple[jax.Array, jax.Array]:
     """Single-token causal conv1d update.
 
@@ -314,6 +341,8 @@ def jax_causal_conv1d_update(
 
     # Scatter the per-request new state back into the full pool table.
     new_conv_state = _scatter_idx0_safe(conv_state, state_indices, new_state)
+    if track_indices is not None:
+        new_conv_state = _scatter_track(new_conv_state, track_indices, track_mask, new_state)
     # Pin the scatter result across the aliasing boundary (see entry barrier).
     new_conv_state, y = jax.lax.optimization_barrier((new_conv_state, y))
     return y, new_conv_state
@@ -339,6 +368,8 @@ def ragged_gated_delta_rule_ref(
     n_v: int,
     d_k: int,
     d_v: int,
+    track_indices: jax.Array | None = None,
+    track_mask: jax.Array | None = None,
 ) -> tuple[jax.Array, jax.Array]:
     """Ragged gated delta-rule forward (extend / chunked-prefill).
 
@@ -473,6 +504,10 @@ def ragged_gated_delta_rule_ref(
     # carries fp32; the pool is typically fp32 too, but
     # ``SGLANG_JAX_RECURRENT_STATE_DTYPE=bfloat16`` can override).
     new_recurrent_state = _scatter_idx0_safe(recurrent_state, state_indices, new_state_buf)
+    if track_indices is not None:
+        new_recurrent_state = _scatter_track(
+            new_recurrent_state, track_indices, track_mask, new_state_buf
+        )
     return new_recurrent_state, output
 
 
@@ -490,6 +525,8 @@ def decode_gated_delta_rule_ref(
     d_k: int,
     d_v: int,
     has_initial_state: jax.Array | None = None,
+    track_indices: jax.Array | None = None,
+    track_mask: jax.Array | None = None,
 ) -> tuple[jax.Array, jax.Array]:
     """Decode-only gated delta-rule (parallel single-step across the batch).
 
@@ -561,6 +598,10 @@ def decode_gated_delta_rule_ref(
 
     # Scatter the per-request new state back into the full pool table.
     new_recurrent_state = _scatter_idx0_safe(recurrent_state, state_indices, new_state)
+    if track_indices is not None:
+        new_recurrent_state = _scatter_track(
+            new_recurrent_state, track_indices, track_mask, new_state
+        )
     # Pin the scatter result across the aliasing boundary (see entry barrier).
     new_recurrent_state, out = jax.lax.optimization_barrier((new_recurrent_state, out))
     return new_recurrent_state, out.astype(mixed_qkv.dtype)

--- a/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sgl_jax/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -32,9 +32,19 @@ class LinearRecurrentAttnBackendMetadata:
     cu_q_lens: jax.Array = None
     recurrent_indices: jax.Array = None
     has_initial_state: jax.Array = None
+    # Recurrent track metadata (extra-buffer snapshot at track boundaries).
+    # Optional: None when the batch crosses no track boundary.
+    recurrent_track_indices: jax.Array = None
+    recurrent_track_mask: jax.Array = None
 
     def tree_flatten(self):
-        children = (self.cu_q_lens, self.recurrent_indices, self.has_initial_state)
+        children = (
+            self.cu_q_lens,
+            self.recurrent_indices,
+            self.has_initial_state,
+            self.recurrent_track_indices,
+            self.recurrent_track_mask,
+        )
         aux_data = {}
         return children, aux_data
 
@@ -44,12 +54,14 @@ class LinearRecurrentAttnBackendMetadata:
             cu_q_lens=children[0],
             recurrent_indices=children[1],
             has_initial_state=children[2],
+            recurrent_track_indices=children[3],
+            recurrent_track_mask=children[4],
         )
 
 
 @dataclass
 class LinearRecurrentAttnBackend(AttentionBackend):
-    """Base class for linear recurrent attention backends (KDA, GDN, Mamba2).
+    """Base class for linear recurrent attention backends (e.g. KDA, GDN).
 
     Provides metadata computation and pytree infrastructure.
     Subclasses implement ``__call__`` with model-specific forward logic.
@@ -95,6 +107,18 @@ class LinearRecurrentAttnBackend(AttentionBackend):
             (cu_q_lens, batch.recurrent_indices, batch.has_initial_state),
             sharding=NamedSharding(self.mesh, sharding_spec),
         )
+
+        # Track metadata may be None (no boundary): guard each device_array.
+        if batch.recurrent_track_indices is not None:
+            (metadata.recurrent_track_indices,) = device_array(
+                (batch.recurrent_track_indices,),
+                sharding=NamedSharding(self.mesh, sharding_spec),
+            )
+        if batch.recurrent_track_mask is not None:
+            (metadata.recurrent_track_mask,) = device_array(
+                (batch.recurrent_track_mask,),
+                sharding=NamedSharding(self.mesh, sharding_spec),
+            )
 
         return metadata
 

--- a/python/sgl_jax/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/gdn_backend.py
@@ -208,6 +208,8 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
         recurrence step across the batch, all inside a shard_map."""
         state_indices = self.forward_metadata.recurrent_indices
         has_initial_state = self.forward_metadata.has_initial_state
+        track_indices = self.forward_metadata.recurrent_track_indices
+        track_mask = self.forward_metadata.recurrent_track_mask
         tp = _mesh_tp_size(self.mesh)
         n_kq_tp = self.num_k_heads // tp
         n_v_tp = self.num_v_heads // tp
@@ -225,6 +227,8 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
             a_l,
             state_indices_l,
             has_initial_state_l,
+            track_indices_l=None,
+            track_mask_l=None,
         ):
             conv_out, new_conv = jax_causal_conv1d_update(
                 mixed_qkv_l,
@@ -234,6 +238,8 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
                 bias=None,
                 activation="silu",
                 has_initial_state=has_initial_state_l,
+                track_indices=track_indices_l,
+                track_mask=track_mask_l,
             )
             new_rec, out = decode_gated_delta_rule_ref(
                 conv_out,
@@ -248,31 +254,24 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
                 d_k=d_k,
                 d_v=d_v,
                 has_initial_state=has_initial_state_l,
+                track_indices=track_indices_l,
+                track_mask=track_mask_l,
             )
             return out, new_conv, new_rec
 
-        return jax.shard_map(
-            _decode_local,
-            mesh=self.mesh,
-            in_specs=(
-                P("data", "tensor"),  # mixed_qkv
-                P("data", "tensor", None),  # conv_state
-                P("data", "tensor", None, None),  # recurrent_state
-                P("tensor", None),  # conv1d weight
-                P("tensor"),  # A_log
-                P("tensor"),  # dt_bias
-                P("data", "tensor"),  # b
-                P("data", "tensor"),  # a
-                P("data"),  # state_indices (sharded by data — one slice per DP rank)
-                P("data"),  # has_initial_state (sharded by data)
-            ),
-            out_specs=(
-                P("data", "tensor", None),  # out [B, n_v, d_v]
-                P("data", "tensor", None),  # new_conv_state [num_blocks, conv_dim, K-1]
-                P("data", "tensor", None, None),  # new_rec_state [num_blocks, n_v, d_k, d_v]
-            ),
-            check_vma=False,
-        )(
+        in_specs = [
+            P("data", "tensor"),  # mixed_qkv
+            P("data", "tensor", None),  # conv_state
+            P("data", "tensor", None, None),  # recurrent_state
+            P("tensor", None),  # conv1d weight
+            P("tensor"),  # A_log
+            P("tensor"),  # dt_bias
+            P("data", "tensor"),  # b
+            P("data", "tensor"),  # a
+            P("data"),  # state_indices (sharded by data — one slice per DP rank)
+            P("data"),  # has_initial_state (sharded by data)
+        ]
+        args = [
             mixed_qkv,
             conv_state_in,
             recurrent_state_in,
@@ -283,7 +282,25 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
             a,
             state_indices,
             has_initial_state,
-        )
+        ]
+        # OFF/no-boundary: track_indices is None -> keep the original shard_map
+        # call (no track args), byte-identical to the no-track path. When a
+        # boundary lands in this batch, add two P("data") track slices.
+        if track_indices is not None:
+            in_specs += [P("data"), P("data")]  # track_indices, track_mask
+            args += [track_indices, track_mask]
+
+        return jax.shard_map(
+            _decode_local,
+            mesh=self.mesh,
+            in_specs=tuple(in_specs),
+            out_specs=(
+                P("data", "tensor", None),  # out [B, n_v, d_v]
+                P("data", "tensor", None),  # new_conv_state [num_blocks, conv_dim, K-1]
+                P("data", "tensor", None, None),  # new_rec_state [num_blocks, n_v, d_k, d_v]
+            ),
+            check_vma=False,
+        )(*args)
 
     # ------------------------------------------------------------------
     # Extend / chunked-prefill
@@ -305,6 +322,8 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
         cu_seqlens = meta.cu_q_lens
         state_indices = meta.recurrent_indices
         has_initial_state = meta.has_initial_state
+        track_indices = meta.recurrent_track_indices
+        track_mask = meta.recurrent_track_mask
         tp = _mesh_tp_size(self.mesh)
         n_kq_tp = self.num_k_heads // tp
         n_v_tp = self.num_v_heads // tp
@@ -323,6 +342,8 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
             cu_seqlens_l,
             state_indices_l,
             has_initial_state_l,
+            track_indices_l=None,
+            track_mask_l=None,
         ):
             # jax_causal_conv1d_prefill operates on [D, T] (channel-first).
             # Pass `has_initial_state` so brand-new prefills don't pick up
@@ -337,6 +358,8 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
                 state_indices=state_indices_l,
                 has_initial_state=has_initial_state_l,
                 activation="silu",
+                track_indices=track_indices_l,
+                track_mask=track_mask_l,
             )
             conv_out = conv_out_dt.T  # [T, D]
             new_rec, out = ragged_gated_delta_rule_ref(
@@ -353,32 +376,25 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
                 n_v=n_v_tp,
                 d_k=d_k,
                 d_v=d_v,
+                track_indices=track_indices_l,
+                track_mask=track_mask_l,
             )
             return out, new_conv, new_rec
 
-        return jax.shard_map(
-            _extend_local,
-            mesh=self.mesh,
-            in_specs=(
-                P("data", "tensor"),  # mixed_qkv
-                P("data", "tensor", None),  # conv_state
-                P("data", "tensor", None, None),  # recurrent_state
-                P("tensor", None),  # conv1d weight
-                P("tensor"),  # A_log
-                P("tensor"),  # dt_bias
-                P("data", "tensor"),  # b
-                P("data", "tensor"),  # a
-                P("data"),  # cu_seqlens (sharded by data — one slice per DP rank)
-                P("data"),  # state_indices (sharded by data)
-                P("data"),  # has_initial_state (sharded by data)
-            ),
-            out_specs=(
-                P("data", "tensor", None),  # out [T, n_v, d_v]
-                P("data", "tensor", None),  # new_conv_state [num_blocks, conv_dim, K-1]
-                P("data", "tensor", None, None),  # new_rec_state [num_blocks, n_v, d_k, d_v]
-            ),
-            check_vma=False,
-        )(
+        in_specs = [
+            P("data", "tensor"),  # mixed_qkv
+            P("data", "tensor", None),  # conv_state
+            P("data", "tensor", None, None),  # recurrent_state
+            P("tensor", None),  # conv1d weight
+            P("tensor"),  # A_log
+            P("tensor"),  # dt_bias
+            P("data", "tensor"),  # b
+            P("data", "tensor"),  # a
+            P("data"),  # cu_seqlens (sharded by data — one slice per DP rank)
+            P("data"),  # state_indices (sharded by data)
+            P("data"),  # has_initial_state (sharded by data)
+        ]
+        args = [
             mixed_qkv,
             conv_state_in,
             recurrent_state_in,
@@ -390,4 +406,19 @@ class GDNAttnBackend(LinearRecurrentAttnBackend):
             cu_seqlens,
             state_indices,
             has_initial_state,
-        )
+        ]
+        if track_indices is not None:
+            in_specs += [P("data"), P("data")]  # track_indices, track_mask
+            args += [track_indices, track_mask]
+
+        return jax.shard_map(
+            _extend_local,
+            mesh=self.mesh,
+            in_specs=tuple(in_specs),
+            out_specs=(
+                P("data", "tensor", None),  # out [T, n_v, d_v]
+                P("data", "tensor", None),  # new_conv_state [num_blocks, conv_dim, K-1]
+                P("data", "tensor", None, None),  # new_rec_state [num_blocks, n_v, d_k, d_v]
+            ),
+            check_vma=False,
+        )(*args)

--- a/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
@@ -141,6 +141,20 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         new_conv_full_list = self.set_conv_state(
             recurrent_state_pool, layer.layer_id, recurrent_indices, new_conv_packed
         )
+
+        # Track snapshot: boundaries are forced to forward ends, so the
+        # running-scatter value IS the boundary snapshot; scatter it into each
+        # request's track slot too. None -> byte-identical no-track path.
+        track_indices = self.forward_metadata.recurrent_track_indices
+        if track_indices is not None:
+            track_mask = self.forward_metadata.recurrent_track_mask
+            new_ssm_full = self.set_ssm_track_state(
+                new_ssm_full, track_indices, track_mask, new_recurrent
+            )
+            new_conv_full_list = self.set_conv_track_state(
+                new_conv_full_list, track_indices, track_mask, new_conv_packed
+            )
+
         return output.reshape(output.shape[0], -1), (new_ssm_full, new_conv_full_list)
 
     def get_state(self, recurrent_state_pool, layer_id, recurrent_indices):
@@ -226,6 +240,61 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
             check_vma=False,
         )(full_conv, recurrent_indices, new_conv_packed)
         return [new_conv_full]
+
+    def set_ssm_track_state(self, full_recurrent, track_indices, track_mask, new_recurrent):
+        """Scatter ``new_recurrent`` into the request track slots.
+
+        Operates on the buffer RETURNED by ``set_ssm_state`` so both the
+        running slot and the track slot persist. Keep-mask preserves slots at
+        ``track_idx == 0`` (padding/dummy) and ``track_mask == 0`` (non-boundary
+        rows). Wrapped in ``optimization_barrier`` because the buffer is donated
+        (donated-buffer multi-host aliasing guard).
+        """
+
+        def _scatter(buf, tidx, tmask, val):
+            keep = ((tidx == 0) | (tmask == 0)).reshape(-1, 1, 1, 1)
+            safe_val = jnp.where(keep, buf[tidx], val)
+            return buf.at[tidx].set(safe_val)
+
+        new_full = jax.shard_map(
+            _scatter,
+            mesh=self.mesh,
+            in_specs=(
+                P("data", "tensor", None, None),
+                P("data"),
+                P("data"),
+                P("data", "tensor", None, None),
+            ),
+            out_specs=P("data", "tensor", None, None),
+            check_vma=False,
+        )(full_recurrent, track_indices, track_mask, new_recurrent)
+        return jax.lax.optimization_barrier(new_full)
+
+    def set_conv_track_state(self, new_conv_full_list, track_indices, track_mask, new_conv_packed):
+        """Scatter ``new_conv_packed`` into the request track slots.
+
+        Conv variant of :meth:`set_ssm_track_state` (3D keep-mask reshape).
+        """
+        full_conv = new_conv_full_list[0]
+
+        def _scatter(buf, tidx, tmask, val):
+            keep = ((tidx == 0) | (tmask == 0)).reshape(-1, 1, 1)
+            safe_val = jnp.where(keep, buf[tidx], val)
+            return buf.at[tidx].set(safe_val)
+
+        new_full = jax.shard_map(
+            _scatter,
+            mesh=self.mesh,
+            in_specs=(
+                P("data", "tensor", None),
+                P("data"),
+                P("data"),
+                P("data", "tensor", None),
+            ),
+            out_specs=P("data", "tensor", None),
+            check_vma=False,
+        )(full_conv, track_indices, track_mask, new_conv_packed)
+        return [jax.lax.optimization_barrier(new_full)]
 
     # ------------------------------------------------------------------
     # Forward mode implementations

--- a/python/sgl_jax/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/lightning_backend.py
@@ -139,6 +139,15 @@ class LightningAttnBackend(LinearRecurrentAttnBackend):
         **kwargs,
     ) -> tuple[jax.Array, tuple]:
         md = self.forward_metadata
+        # GLA decode is a fused Pallas kernel (in-kernel DMA gather/scatter), so
+        # a masked recurrent track scatter cannot be added cleanly. The recurrent
+        # extra-buffer is gated OFF for GLA at startup; fail fast if a track
+        # boundary somehow reaches this backend.
+        if md.recurrent_track_indices is not None:
+            raise NotImplementedError(
+                "recurrent extra-buffer (--enable-recurrent-extra-buffer) is not "
+                "supported with the GLA/Lightning backend"
+            )
         recurrent_buffer, _ = self.get_layer_cache(recurrent_state_pool, layer.layer_id)
 
         try:

--- a/python/sgl_jax/srt/layers/attention/linear/short_convolution.py
+++ b/python/sgl_jax/srt/layers/attention/linear/short_convolution.py
@@ -10,7 +10,7 @@ and cache layouts. Two execution paths are provided:
 * ``extend`` — variable-length packed prefill that consumes ``cu_seqlens`` to
   build a per-token sliding window mixing prior cache and in-sequence tokens.
 
-State convention follows vLLM / Mamba: cache has width ``K-1`` and stores the
+State convention follows vLLM: cache has width ``K-1`` and stores the
 prior ``K-1`` tokens (the current token is supplied via ``x`` at call time).
 """
 

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -23,7 +23,7 @@ import logging
 import os
 import threading
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
 import jax
 import numpy as np
@@ -232,6 +232,13 @@ class Req:
         # One-shot recurrent CoW src slot: set on a fresh match, consumed at the
         # next extend forward, cleared everywhere else (re-match, merge, retract).
         self.recurrent_cow_src_index: int | None = None
+        # Extra-buffer ping-pong track slots holding materialized page-boundary
+        # snapshots (dormant unless enable_recurrent_extra_buffer).
+        self.recurrent_ping_pong_track_buffer: list[int] | None = None
+        self.recurrent_next_track_idx: int | None = None
+        # Watermark seqlen of the last materialized track slot; set ONLY by a real
+        # track scatter, never from a prefix match.
+        self.recurrent_last_track_seqlen: int | None = None
 
         # Check finish
         self.tokenizer = None
@@ -460,10 +467,19 @@ class Req:
                 self.last_host_node = tree_cache.root_node
                 self.host_hit_length = 0
             else:
+                # A running recurrent req already OWNS its state (running slot):
+                # no re-clone (cow_recurrent=False), FULL-only match -- its
+                # unfinished prefix is not gated on recurrent-tree validation.
+                is_running_recurrent = (
+                    tree_cache.supports_recurrent() and self.recurrent_pool_idx is not None
+                )
                 match_result = tree_cache.match_prefix(
                     MatchPrefixParams(
                         key=RadixKey(self.adjust_max_prefix_ids(), self.extra_key, self.dp_rank),
-                        cow_recurrent=tree_cache.supports_recurrent(),
+                        cow_recurrent=(
+                            tree_cache.supports_recurrent() and not is_running_recurrent
+                        ),
+                        full_only=is_running_recurrent,
                         req=self,
                     )
                 )
@@ -647,6 +663,9 @@ class Req:
         self.cache_protected_len = 0
         self.recurrent_pool_idx = None
         self.recurrent_cow_src_index = None
+        self.recurrent_ping_pong_track_buffer = None
+        self.recurrent_next_track_idx = None
+        self.recurrent_last_track_seqlen = None
 
     def set_finish_with_abort(self, error_msg: str):
         # set it to one token to skip the long prefill
@@ -723,6 +742,10 @@ class ScheduleReqsInfo:
     # Recurrent CoW src slot per req (0 = no clone), per DP
     recurrent_cow_src_indices: np.ndarray | None = None
 
+    # Recurrent track metadata per DP (extra-buffer; set only on a track boundary).
+    recurrent_track_indices: np.ndarray | None = None
+    recurrent_track_mask: np.ndarray | None = None
+
 
 def _build_recurrent_cow_src_indices(reqs: list[Req]) -> np.ndarray | None:
     """None when no clone is pending, so cold extends skip the donated-buffer
@@ -731,6 +754,56 @@ def _build_recurrent_cow_src_indices(reqs: list[Req]) -> np.ndarray | None:
     if not any(vals):
         return None
     return np.asarray(vals, dtype=np.int32)
+
+
+class _RecurrentTrackEntry(NamedTuple):
+    track_mask: bool
+    track_index: int
+
+
+def _recurrent_track_entry(
+    req: Req, final_seq_len: int, *, interval: int, pool, is_extend: bool
+) -> _RecurrentTrackEntry:
+    """Per-req extra-buffer track entry for the forward at ``final_seq_len``.
+
+    On a real track boundary, reads the ping-pong slot at ``recurrent_next_track_idx``
+    BEFORE flipping it (read-then-flip), records the watermark seqlen, and flips
+    the next-scatter target. Off a boundary, returns a dormant (0,) entry and
+    leaves the req's bookkeeping untouched."""
+    if is_extend:
+        track_mask = req.extend_input_len > 0 and final_seq_len % interval == 0
+    else:
+        track_mask = final_seq_len % interval == 0
+    if not track_mask:
+        return _RecurrentTrackEntry(False, 0)
+    idx = req.recurrent_next_track_idx
+    track_index = req.recurrent_ping_pong_track_buffer[idx]
+    req.recurrent_last_track_seqlen = final_seq_len
+    req.recurrent_next_track_idx = pool.get_recurrent_ping_pong_other_idx(idx)
+    return _RecurrentTrackEntry(True, track_index)
+
+
+def _build_recurrent_track_entries(
+    reqs: list[Req], final_seq_lens: list[int], *, interval: int, pool, is_extend: bool
+):
+    """Two np.int32 arrays (indices, mask as 0/1) aligned with ``reqs``, or
+    ``(None, None)`` when no req hits a boundary -- mirroring
+    ``_build_recurrent_cow_src_indices``'s one-shot None return so the backend
+    skips the snapshot path entirely on a boundary-free batch."""
+    indices: list[int] = []
+    mask: list[int] = []
+    for req, final_seq_len in zip(reqs, final_seq_lens):
+        entry = _recurrent_track_entry(
+            req, final_seq_len, interval=interval, pool=pool, is_extend=is_extend
+        )
+        indices.append(entry.track_index)
+        mask.append(1 if entry.track_mask else 0)
+    if not any(mask):
+        return None, None
+    return (
+        np.asarray(indices, dtype=np.int32),
+        np.asarray(mask, dtype=np.int32),
+    )
 
 
 @dataclasses.dataclass
@@ -923,7 +996,8 @@ class ScheduleBatch:
             and self.tree_cache.supports_recurrent()
         ):
             dp_rank = reqs[0].dp_rank if reqs and reqs[0].dp_rank is not None else 0
-            demand = sum(1 for r in reqs if r.recurrent_pool_idx is None)
+            per_req = self.req_to_token_pool.request_owned_slots
+            demand = per_req * sum(1 for r in reqs if r.recurrent_pool_idx is None)
             available = self.req_to_token_pool.recurrent_available_size(dp_rank)
             if available < demand:
                 self.tree_cache.evict(
@@ -931,11 +1005,22 @@ class ScheduleBatch:
                 )
         req_pool_indices = self.req_to_token_pool.alloc(reqs)
         if req_pool_indices is None:
+            detail = f"{self.req_to_token_pool.available_size()=}, {len(reqs)=}"
+            if (
+                self.is_hybrid_recurrent
+                and self.tree_cache is not None
+                and self.tree_cache.supports_recurrent()
+            ):
+                # Throttled upstream by admission backpressure, so unreachable for
+                # recurrent; report the recurrent pool (the constrained resource).
+                dp_rank = reqs[0].dp_rank if reqs and reqs[0].dp_rank is not None else 0
+                detail += (
+                    f", recurrent_available={self.req_to_token_pool.recurrent_available_size(dp_rank)}"
+                    f", request_owned_slots={self.req_to_token_pool.request_owned_slots}"
+                )
             raise RuntimeError(
                 "alloc_req_slots runs out of memory. "
-                "Please set a smaller number for `--max-running-requests`. "
-                f"{self.req_to_token_pool.available_size()=}, "
-                f"{len(reqs)=}, "
+                f"Please set a smaller number for `--max-running-requests`. {detail}"
             )
         return req_pool_indices
 
@@ -1231,6 +1316,21 @@ class ScheduleBatch:
                 )
                 if self.tree_cache is not None and self.tree_cache.supports_recurrent():
                     info.recurrent_cow_src_indices = _build_recurrent_cow_src_indices(reqs)
+                # Boundary splitting guarantees an EXTEND ends on a boundary or
+                # is a non-final chunk, so seq_len % interval == 0 iff the
+                # snapshot should be taken this round.
+                if self.tree_cache is not None and self.tree_cache.recurrent_extra_buffer_active():
+                    interval = self.tree_cache.recurrent_track_interval
+                    (
+                        info.recurrent_track_indices,
+                        info.recurrent_track_mask,
+                    ) = _build_recurrent_track_entries(
+                        reqs,
+                        seq_lens,
+                        interval=interval,
+                        pool=self.req_to_token_pool,
+                        is_extend=True,
+                    )
 
             # Write to req_to_token_pool
             pt = 0
@@ -1651,6 +1751,19 @@ class ScheduleBatch:
                     info.req_pool_indices
                 )
                 info.recurrent_cow_src_indices = None
+                if self.tree_cache is not None and self.tree_cache.recurrent_extra_buffer_active():
+                    interval = self.tree_cache.recurrent_track_interval
+                    new_seq_lens = [int(s) for s in info.seq_lens]
+                    (
+                        info.recurrent_track_indices,
+                        info.recurrent_track_mask,
+                    ) = _build_recurrent_track_entries(
+                        reqs,
+                        new_seq_lens,
+                        interval=interval,
+                        pool=self.req_to_token_pool,
+                        is_extend=False,
+                    )
 
             # Allocate memory for this DP rank
             if self.token_to_kv_pool_allocator.page_size == 1:
@@ -2842,7 +2955,35 @@ class ScheduleBatch:
             ):
                 recurrent_cow_src_indices_cpu = None
 
-        # Step 5.6: has_initial_state[i] = True iff slot i already holds
+        # Merge recurrent track metadata (extra-buffer; see ScheduleReqsInfo).
+        recurrent_track_indices_cpu = None
+        recurrent_track_mask_cpu = None
+        if any(info.recurrent_track_mask is not None for info in self.reqs_info):
+            recurrent_track_indices_cpu = np.zeros(total_bs, dtype=np.int32)
+            recurrent_track_mask_cpu = np.zeros(total_bs, dtype=np.int32)
+            offset_bs = 0
+            for dp_rank in range(self.dp_size):
+                info = self.reqs_info[dp_rank]
+                if info.seq_lens is not None and len(info.seq_lens) > 0:
+                    dp_bs = len(info.seq_lens)
+                    if info.recurrent_track_indices is not None:
+                        recurrent_track_indices_cpu[offset_bs : offset_bs + dp_bs] = (
+                            info.recurrent_track_indices
+                        )
+                    if info.recurrent_track_mask is not None:
+                        recurrent_track_mask_cpu[offset_bs : offset_bs + dp_bs] = (
+                            info.recurrent_track_mask
+                        )
+                offset_bs += per_dp_bs_padding
+            for info in self.reqs_info:
+                info.recurrent_track_indices = None
+                info.recurrent_track_mask = None
+            # No boundary this batch: None skips the snapshot path entirely.
+            if not recurrent_track_mask_cpu.any():
+                recurrent_track_indices_cpu = None
+                recurrent_track_mask_cpu = None
+
+        # has_initial_state[i] = True iff slot i already holds
         # prior KV/recurrent state (extend with prefix, or any decode slot).
         has_initial_state_cpu = np.ones(total_bs, dtype=np.bool_)
         if self.forward_mode.is_extend():
@@ -2990,6 +3131,8 @@ class ScheduleBatch:
             deepstack_visual_embedding=deepstack_visual_embedding,
             recurrent_indices=recurrent_indices_cpu,
             recurrent_cow_src_indices=recurrent_cow_src_indices_cpu,
+            recurrent_track_indices=recurrent_track_indices_cpu,
+            recurrent_track_mask=recurrent_track_mask_cpu,
             has_initial_state=has_initial_state_cpu,
             spec_algorithm=self.spec_algorithm,
         )
@@ -3441,6 +3584,10 @@ class ModelWorkerBatch:
 
     # Recurrent CoW src slot per req (0 = no clone); clone dst = recurrent_indices.
     recurrent_cow_src_indices: np.ndarray | None = None
+
+    # Recurrent track metadata (extra-buffer); padded to total_bs, P("data").
+    recurrent_track_indices: np.ndarray | None = None
+    recurrent_track_mask: np.ndarray | None = None
 
     # Whether each request has prior recurrent state (lazy zero-on-read)
     has_initial_state: np.ndarray | None = None

--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -405,6 +405,18 @@ class PrefillAdder:
     def ceil_paged_tokens(self, tokens: int) -> int:
         return -(-tokens // self.page_size) * self.page_size
 
+    def _recurrent_boundary_cap(self, prefix_len: int) -> int | None:
+        """Max EXTEND length that keeps a recurrent track from CROSSING a boundary.
+
+        Returns the distance from ``prefix_len`` to the first track boundary
+        strictly after it (in ``(0, interval]``), or None when extra-buffer
+        recurrent caching is inactive (no cap)."""
+        if not self.tree_cache.recurrent_extra_buffer_active():
+            return None
+        interval = self.tree_cache.recurrent_track_interval
+        first_boundary = (prefix_len // interval + 1) * interval
+        return first_boundary - prefix_len
+
     def align_page_size(self, size: int) -> int:
         return (size + self.page_size - 1) // self.page_size * self.page_size
 
@@ -455,6 +467,10 @@ class PrefillAdder:
                 req.fill_ids = req.fill_ids[: len(req.prefix_indices)]
                 return req
             _rem_tokens = self.rem_chunk_tokens_list[dp_rank]
+        boundary_cap = self._recurrent_boundary_cap(len(req.prefix_indices))
+        boundary_truncated = boundary_cap is not None and req.extend_input_len > boundary_cap
+        if boundary_cap is not None:
+            _rem_tokens = min(_rem_tokens, boundary_cap)
         truncated = req.extend_input_len > _rem_tokens
         req.extend_input_len = min(req.extend_input_len, _rem_tokens)
         req.fill_ids = req.fill_ids[: len(req.prefix_indices) + req.extend_input_len]
@@ -464,14 +480,13 @@ class PrefillAdder:
             req.extend_input_len,
             (
                 min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS_ESTIMATION)
-                if not truncated
+                if not (truncated or boundary_truncated)
                 else 0
             ),
             dp_rank,
         )
 
-        # Return if chunked prefill not finished
-        return req if truncated else None
+        return req if (truncated or boundary_truncated) else None
 
     def _update_prefill_budget(
         self, prefix_len: int, extend_input_len: int, max_new_tokens: int, dp_rank: int
@@ -664,6 +679,16 @@ class PrefillAdder:
             req.last_matched_prefix_len = prefix_len
             input_tokens = self.ceil_paged_tokens(req.extend_input_len)
 
+            # Recurrent track-boundary cap: never let a scheduled EXTEND cross a
+            # boundary. A boundary-only split (chunk budget had room) is still
+            # marked chunked so the next round continues from the protected prefix.
+            boundary_cap = self._recurrent_boundary_cap(prefix_len)
+            boundary_truncated = boundary_cap is not None and req.extend_input_len > boundary_cap
+            if boundary_truncated:
+                req.extend_input_len = boundary_cap
+                req.fill_ids = req.fill_ids[: prefix_len + boundary_cap]
+                input_tokens = self.ceil_paged_tokens(req.extend_input_len)
+
             total_can_run = sum(len(v) for v in self.can_run_list.values())
             if (
                 self.rem_chunk_tokens_list is None
@@ -672,10 +697,11 @@ class PrefillAdder:
             ):
                 return AddReqResult.OTHER
 
-            if (
+            chunk_budget_ok = (
                 self.rem_chunk_tokens_list is None
                 or input_tokens <= self.rem_chunk_tokens_list[dp_rank]
-            ):
+            )
+            if chunk_budget_ok and not boundary_truncated:
                 # Non-chunked prefill
                 self.can_run_list[dp_rank].append(req)
                 res = self.tree_cache.inc_lock_ref(req.last_node)
@@ -689,13 +715,19 @@ class PrefillAdder:
                     ),
                     dp_rank,
                 )
+            elif chunk_budget_ok and boundary_truncated:
+                self.can_run_list[dp_rank].append(req)
+                self.new_chunked_reqs[dp_rank] = req
+                res = self.tree_cache.inc_lock_ref(req.last_node)
+                req.swa_uuid_for_lock = res.swa_uuid_for_lock
+                self._update_prefill_budget(prefix_len, input_tokens, 0, dp_rank)
             else:
                 # Make sure at least one page is available
                 trunc_len = self.rem_chunk_tokens_list[dp_rank] // self.page_size * self.page_size
                 if trunc_len <= 0:
                     return AddReqResult.OTHER
 
-                # Chunked prefill
+                # Chunk budget tighter than the boundary cap: min of the two.
                 req.extend_input_len = trunc_len
                 req.fill_ids = req.fill_ids[: len(req.prefix_indices) + trunc_len]
 

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -82,6 +82,9 @@ from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
 from sgl_jax.srt.mem_cache.radix_cache import RadixKey
 from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+from sgl_jax.srt.model_executor.model_runner_kv_cache_mixin import (
+    recurrent_admission_blocked,
+)
 from sgl_jax.srt.multimodal.tokenizer_utils import resolve_tokenizer_subdir
 from sgl_jax.srt.precision_tracer import precision_tracer
 from sgl_jax.srt.server_args import PortArgs, ServerArgs
@@ -1902,9 +1905,26 @@ class Scheduler(
             ):
                 continue
 
-            # Skip DP ranks with an ongoing chunked request to avoid
-            # creating a second chunked req on the same rank.
-            if self.chunked_reqs[dp_rank] is not None:
+            # Recurrent backpressure: defer instead of letting alloc_req_slots
+            # raise (see recurrent_admission_blocked).
+            if self.tree_cache is not None and self.tree_cache.supports_recurrent():
+                per_req = self.req_to_token_pool.request_owned_slots
+                demand = per_req * (len(adder.can_run_list[dp_rank]) + 1)
+                free = self.req_to_token_pool.recurrent_available_size(dp_rank)
+                evictable = self.tree_cache.recurrent_evictable_size(dp_rank)
+                if recurrent_admission_blocked(free, evictable, demand):
+                    self.running_batch.reqs_info[dp_rank].batch_is_full = True
+                    if self.running_batch.batch_is_full:
+                        break
+                    continue
+
+            # Skip DP ranks with an ongoing chunked request (persistent or added
+            # this round: a boundary-only split leaves chunk budget, so a second
+            # req could otherwise truncate and overwrite new_chunked_reqs).
+            if (
+                self.chunked_reqs[dp_rank] is not None
+                or adder.new_chunked_reqs[dp_rank] is not None
+            ):
                 continue
 
             # Check LoRA constraint: ensure we don't exceed max_loras_per_batch
@@ -1929,6 +1949,27 @@ class Scheduler(
                 continue  # host pool full: leave req in waiting_queue, retry next round
 
             req.init_next_round_input(self.tree_cache)
+
+            # Post-match refinement: a prefix hit locks its matched snapshot
+            # (non-evictable for the req's lifetime); discount it so admission at
+            # exact capacity defers (see recurrent_admission_blocked keeps_locked).
+            if (
+                self.tree_cache is not None
+                and self.tree_cache.supports_recurrent()
+                and req.recurrent_cow_src_index is not None
+            ):
+                per_req = self.req_to_token_pool.request_owned_slots
+                demand = per_req * (len(adder.can_run_list[dp_rank]) + 1)
+                free = self.req_to_token_pool.recurrent_available_size(dp_rank)
+                evictable = self.tree_cache.recurrent_evictable_size(dp_rank)
+                if recurrent_admission_blocked(free, evictable, demand, keeps_locked=1):
+                    if _reserved_bid is not None and _host_pool is not None:
+                        _host_pool.release(_reserved_bid)
+                    self.running_batch.reqs_info[dp_rank].batch_is_full = True
+                    if self.running_batch.batch_is_full:
+                        break
+                    continue
+
             # H2D load-back happens inside add_one_req (after NO_TOKEN gate).
             res = adder.add_one_req(req)
 

--- a/python/sgl_jax/srt/mem_cache/base_prefix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/base_prefix_cache.py
@@ -145,6 +145,12 @@ class BasePrefixCache(abc.ABC):
     def supports_recurrent(self) -> bool:
         return False
 
+    def recurrent_extra_buffer_active(self) -> bool:
+        """True when this cache materializes page-boundary recurrent snapshots
+        (extra-buffer recurrent path). Drives scheduler boundary splitting and
+        track-entry computation; False keeps the path byte-identical to today."""
+        return False
+
     def full_evictable_size(self, dp_rank: int = 0):
         return 0
 

--- a/python/sgl_jax/srt/mem_cache/cache_init_params.py
+++ b/python/sgl_jax/srt/mem_cache/cache_init_params.py
@@ -17,3 +17,10 @@ class CacheInitParams:
     is_eagle: bool = False
 
     sliding_window_size: int | None = None
+
+    # Recurrent radix: page-aligned ping-pong track buffer for page>=128.
+    enable_recurrent_extra_buffer: bool = False
+
+    # Track-boundary interval (multiple of page_size) for extra-buffer snapshots;
+    # resolved to page_size by ServerArgs when extra-buffer is on.
+    recurrent_track_interval: int | None = None

--- a/python/sgl_jax/srt/mem_cache/kv_cache_builder.py
+++ b/python/sgl_jax/srt/mem_cache/kv_cache_builder.py
@@ -39,6 +39,8 @@ def build_kv_cache(
         page_size=page_size,
         is_eagle=spec_algorithm is not None and spec_algorithm.is_eagle(),
         sliding_window_size=sliding_window_size,
+        enable_recurrent_extra_buffer=server_args.enable_recurrent_extra_buffer,
+        recurrent_track_interval=server_args.recurrent_track_interval,
     )
 
     cache = create_tree_cache(

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -184,10 +184,18 @@ class HybridReqToTokenPool(ReqToTokenPool):
         dtype: np.dtype,
         recurrent_state_pool,
         dp_size: int = 1,
+        enable_recurrent_extra_buffer: bool = False,
+        ping_pong_slots: int = 2,
     ):
         super().__init__(size=size, max_context_len=max_context_len, dtype=dtype)
         self.recurrent_state_pool = recurrent_state_pool
         self.dp_size = dp_size
+        self.enable_recurrent_extra_buffer = enable_recurrent_extra_buffer
+        # Ping-pong track slots a req holds under extra-buffer: 2 with overlap
+        # scheduling (double-buffer across the overlap boundary), 1 without
+        # (--disable-overlap-schedule) -- the boundary state is committed before
+        # the next forward, so a single track slot suffices.
+        self.ping_pong_slots = ping_pong_slots
         # recurrent_state_pool.size is global (mirrors MHATokenToKVPool).
         # Divisibility is asserted inside RecurrentStatePool.__init__.
         self.slots_per_rank = recurrent_state_pool.size // dp_size
@@ -195,12 +203,25 @@ class HybridReqToTokenPool(ReqToTokenPool):
             list(range(1, self.slots_per_rank + 1)) for _ in range(dp_size)
         ]
         self.req_index_to_recurrent_index_mapping = np.zeros(size, dtype=np.int32)
+        # Extra-buffer ping-pong track slots: (req_pool_idx, ping_pong_slots),
+        # parallel to req_index_to_recurrent_index_mapping.
+        self.req_index_to_recurrent_ping_pong_track_buffer_mapping = np.zeros(
+            (size, ping_pong_slots), dtype=np.int32
+        )
+
+    @property
+    def request_owned_slots(self) -> int:
+        """Recurrent slots a running req actually consumes: 1 running plus the
+        ping-pong track slots under extra-buffer (1 otherwise). Distinct from the
+        sizing back-cap's reservation factor, whose surplus is snapshot headroom."""
+        return 1 + self.ping_pong_slots if self.enable_recurrent_extra_buffer else 1
 
     def alloc(self, reqs: list[Req]) -> list[int] | None:
         # dp_rank from reqs[0]: callers (prepare_for_extend/decode) iterate per-DP,
         # so all reqs in a single alloc() call share the same dp_rank.
         dp_rank = reqs[0].dp_rank if reqs and reqs[0].dp_rank is not None else 0
-        needed = sum(1 for r in reqs if r.recurrent_pool_idx is None)
+        per_req = self.request_owned_slots
+        needed = per_req * sum(1 for r in reqs if r.recurrent_pool_idx is None)
         if needed > len(self.recurrent_free_slots[dp_rank]):
             return None
 
@@ -213,6 +234,8 @@ class HybridReqToTokenPool(ReqToTokenPool):
                 slot = self.alloc_recurrent_slot(dp_rank)
                 r.recurrent_pool_idx = slot
                 self.req_index_to_recurrent_index_mapping[r.req_pool_idx] = slot
+                if self.enable_recurrent_extra_buffer:
+                    self._alloc_ping_pong_buffer(r, dp_rank)
 
         return result
 
@@ -229,6 +252,67 @@ class HybridReqToTokenPool(ReqToTokenPool):
     def recurrent_value_from_slot(slot: int) -> np.ndarray:
         return np.array([int(slot)], dtype=np.int32)
 
+    def _alloc_ping_pong_buffer(self, req: Req, dp_rank: int) -> list[int] | None:
+        """Pop ``ping_pong_slots`` free slots for a request's ping-pong track
+        buffer; store them in the req + mapping. Returns None (without partial
+        mutation) if fewer than ``ping_pong_slots`` free slots remain (caller
+        handles the shortfall)."""
+        slots = self.recurrent_free_slots[dp_rank]
+        n = self.ping_pong_slots
+        if len(slots) < n:
+            return None
+        buffer = [slots.pop(0) for _ in range(n)]
+        req.recurrent_ping_pong_track_buffer = buffer
+        req.recurrent_next_track_idx = 0
+        req.recurrent_last_track_seqlen = None
+        self.req_index_to_recurrent_ping_pong_track_buffer_mapping[req.req_pool_idx] = np.array(
+            buffer, dtype=np.int32
+        )
+        return buffer
+
+    def get_recurrent_ping_pong_other_idx(self, next_idx: int) -> int:
+        """The buffer index that is NOT the next-scatter target. With a single
+        track slot (overlap disabled) there is no other slot, so this returns 0
+        (keep == next == the sole slot)."""
+        return (next_idx + 1) % self.ping_pong_slots
+
+    def get_recurrent_ping_pong_keep_idx(self, req: Req) -> int:
+        """Buffer index holding the most-recently materialized boundary: the
+        slot the next scatter does NOT overwrite."""
+        return self.get_recurrent_ping_pong_other_idx(req.recurrent_next_track_idx)
+
+    def set_recurrent_ping_pong_slot(self, req: Req, idx: int, slot: int) -> None:
+        """Point buffer slot ``idx`` at ``slot`` in both the req and the mapping."""
+        req.recurrent_ping_pong_track_buffer[idx] = int(slot)
+        self.req_index_to_recurrent_ping_pong_track_buffer_mapping[req.req_pool_idx, idx] = int(
+            slot
+        )
+
+    def donate_recurrent_ping_pong_slot(self, req: Req, new_slot: int) -> np.ndarray:
+        """Donate the current KEEP slot to the tree: return its length-1 int32
+        tree value, then replace it in the buffer + mapping with ``new_slot``."""
+        keep_idx = self.get_recurrent_ping_pong_keep_idx(req)
+        keep_slot = req.recurrent_ping_pong_track_buffer[keep_idx]
+        value = self.recurrent_value_from_slot(keep_slot)
+        self.set_recurrent_ping_pong_slot(req, keep_idx, new_slot)
+        return value
+
+    def count_request_owned_recurrent_slots(self, live_reqs: list[Req], dp_rank: int = 0) -> int:
+        """Count request-owned recurrent slots (running + ping-pong track) held by
+        the live requests on ``dp_rank``. Lets the ledger check
+        ``owned + tree_owned + free == slots_per_rank`` catch a leaked slot."""
+        count = 0
+        for req in live_reqs:
+            req_rank = req.dp_rank if req.dp_rank is not None else 0
+            if req_rank != dp_rank:
+                continue
+            if req.recurrent_pool_idx is not None:
+                count += 1
+            track = getattr(req, "recurrent_ping_pong_track_buffer", None)
+            if track is not None:
+                count += sum(1 for s in track if s)
+        return count
+
     def commit_to_tree(self, req: Req) -> None:
         """Transfer running-slot ownership to the tree; the slot is not freed."""
         if req.recurrent_pool_idx is None:
@@ -244,12 +328,21 @@ class HybridReqToTokenPool(ReqToTokenPool):
 
     def free_recurrent_cache(self, req: Req):
         recurrent_idx = req.recurrent_pool_idx
-        if recurrent_idx is None:
-            return
         dp_rank = req.dp_rank if req.dp_rank is not None else 0
-        self.free_recurrent_slot(recurrent_idx, dp_rank)
-        self.req_index_to_recurrent_index_mapping[req.req_pool_idx] = 0
-        req.recurrent_pool_idx = None
+        if recurrent_idx is not None:
+            self.free_recurrent_slot(recurrent_idx, dp_rank)
+            self.req_index_to_recurrent_index_mapping[req.req_pool_idx] = 0
+            req.recurrent_pool_idx = None
+        # Return every request-owned track slot (slot 0/None are never owned).
+        track = getattr(req, "recurrent_ping_pong_track_buffer", None)
+        if track is not None:
+            for slot in track:
+                if slot:
+                    self.free_recurrent_slot(slot, dp_rank)
+            self.req_index_to_recurrent_ping_pong_track_buffer_mapping[req.req_pool_idx] = 0
+            req.recurrent_ping_pong_track_buffer = None
+            req.recurrent_next_track_idx = None
+            req.recurrent_last_track_seqlen = None
 
     def get_linear_recurrent_indices(self, req_pool_indices) -> np.ndarray:
         return self.req_index_to_recurrent_index_mapping[req_pool_indices]
@@ -263,6 +356,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         for rank in range(self.dp_size):
             self.recurrent_free_slots[rank] = list(range(1, self.slots_per_rank + 1))
         self.req_index_to_recurrent_index_mapping.fill(0)
+        self.req_index_to_recurrent_ping_pong_track_buffer_mapping.fill(0)
 
 
 @register_pytree_node_class

--- a/python/sgl_jax/srt/mem_cache/registry.py
+++ b/python/sgl_jax/srt/mem_cache/registry.py
@@ -78,6 +78,8 @@ def default_radix_cache_factory(ctx: TreeCacheBuildContext) -> BasePrefixCache:
             max_seq_len=ctx.server_args.max_seq_len,
             is_eagle=params.is_eagle,
             tree_components=(ComponentType.FULL, ComponentType.RECURRENT),
+            enable_recurrent_extra_buffer=params.enable_recurrent_extra_buffer,
+            recurrent_track_interval=params.recurrent_track_interval,
         )
 
     if (

--- a/python/sgl_jax/srt/mem_cache/unified_cache_components/full_component.py
+++ b/python/sgl_jax/srt/mem_cache/unified_cache_components/full_component.py
@@ -107,7 +107,7 @@ class FullComponent(TreeComponent):
         lock_host: bool = False,
     ) -> IncLockRefResult:
         if lock_host:
-            # No host tier in stage 1.
+            # No host tier.
             return result
 
         ct = self.component_type
@@ -140,7 +140,7 @@ class FullComponent(TreeComponent):
         lock_host: bool = False,
     ) -> None:
         if lock_host:
-            # No host tier in stage 1.
+            # No host tier.
             return
 
         ct = self.component_type

--- a/python/sgl_jax/srt/mem_cache/unified_cache_components/recurrent_component.py
+++ b/python/sgl_jax/srt/mem_cache/unified_cache_components/recurrent_component.py
@@ -1,7 +1,11 @@
-"""Recurrent-state (KDA/GDN/GLA) component for UnifiedRadixCache, page_size=1.
+"""Recurrent-state (KDA/GDN/GLA) component for UnifiedRadixCache.
 
 State is one RecurrentStatePool slot per leaf, so the component is leaf-only:
-it rides the core's ``evictable_device_leaves`` rather than an LRU list."""
+it rides the core's ``evictable_device_leaves`` rather than an LRU list.
+
+The base path (page_size=1): finished-request commit + prefix-hit
+copy-on-write clone. The extra-buffer path (page_size>=128) adds a
+page-aligned ping-pong extra buffer and unfinished/fork donation."""
 
 from __future__ import annotations
 
@@ -47,12 +51,15 @@ class RecurrentComponent(TreeComponent):
             f"RecurrentComponent requires HybridReqToTokenPool, "
             f"got {type(cache.req_to_token_pool)}"
         )
-        assert (
-            cache.page_size == 1
-        ), f"RecurrentComponent requires page_size=1, got {cache.page_size}"
+        if not getattr(cache, "enable_recurrent_extra_buffer", False):
+            assert cache.page_size == 1, (
+                f"RecurrentComponent requires page_size=1 when the extra buffer "
+                f"is off, got {cache.page_size}"
+            )
         super().__init__(cache, params)
         self.req_to_token_pool = cache.req_to_token_pool
         self.recurrent_state_pool = cache.req_to_token_pool.recurrent_state_pool
+        self.enable_recurrent_extra_buffer = getattr(cache, "enable_recurrent_extra_buffer", False)
 
     # ---- matching -----------------------------------------------------------
 
@@ -127,14 +134,50 @@ class RecurrentComponent(TreeComponent):
         token_ids_len: int,
         is_finished: bool,
     ) -> int | None:
-        # Finished-only donation: the running slot already holds the final state
-        # (no copy); donating unfinished would publish state not yet materialized.
-        if not is_finished or req.recurrent_pool_idx is None:
+        if not self.enable_recurrent_extra_buffer:
+            # Base path (page_size=1), finished-only donation: the running slot
+            # already holds the final state (no copy); donating unfinished would
+            # publish state not yet materialized.
+            if not is_finished or req.recurrent_pool_idx is None:
+                return None
+            insert_params.recurrent_value = self.req_to_token_pool.recurrent_value_from_slot(
+                req.recurrent_pool_idx
+            )
             return None
-        insert_params.recurrent_value = self.req_to_token_pool.recurrent_value_from_slot(
-            req.recurrent_pool_idx
+
+        # Extra-buffer (page>=128): donate the materialized page-boundary snapshot
+        # held by the KEEP ping-pong slot, capping the tree key at that boundary.
+        cache_len = req.recurrent_last_track_seqlen
+        if cache_len is None:
+            # No materialized boundary: nothing to donate; cleanup frees owned slots.
+            return 0
+
+        keep_idx = self.req_to_token_pool.get_recurrent_ping_pong_keep_idx(req)
+        keep_slot = req.recurrent_ping_pong_track_buffer[keep_idx]
+        if is_finished:
+            # The keep slot IS the final boundary state; donate it directly. Cleanup
+            # transfers ownership (do NOT remove it from the buffer here).
+            insert_params.recurrent_value = self.req_to_token_pool.recurrent_value_from_slot(
+                keep_slot
+            )
+            return cache_len
+
+        # Unfinished: secure a fresh REPLACEMENT track slot FIRST, then donate the
+        # keep slot. A mid-flight request must always retain two owned track slots,
+        # so never donate without a secured replacement.
+        dp = req.dp_rank if req.dp_rank is not None else 0
+        replacement_slot = self.req_to_token_pool.alloc_recurrent_slot(dp)
+        if replacement_slot is None:
+            self.cache.evict(EvictParams(recurrent_num=1, dp_rank=dp))
+            replacement_slot = self.req_to_token_pool.alloc_recurrent_slot(dp)
+        if replacement_slot is None:
+            # All candidates locked: skip donation (buffer + watermark intact).
+            insert_params.recurrent_value = None
+            return 0
+        insert_params.recurrent_value = self.req_to_token_pool.donate_recurrent_ping_pong_slot(
+            req, replacement_slot
         )
-        return None
+        return cache_len
 
     def cleanup_after_caching_req(
         self,
@@ -144,12 +187,47 @@ class RecurrentComponent(TreeComponent):
         insert_params: InsertParams | None = None,
     ) -> None:
         committed = insert_result.recurrent_committed if insert_result is not None else False
-        if not is_finished:
+        if not self.enable_recurrent_extra_buffer:
+            # Base path: sole owner of the finished donate-vs-free decision.
+            if not is_finished:
+                return
+            if committed:
+                # Tree owns the running slot now (its content is the final state).
+                self.req_to_token_pool.commit_to_tree(req)
+            # else: leave req.recurrent_pool_idx set so release frees it.
             return
+
+        # Extra-buffer: the donated value is the KEEP ping-pong slot, not the
+        # running slot. Do NOT use commit_to_tree (page=1 running-slot donation).
+        dp = req.dp_rank if req.dp_rank is not None else 0
+        if is_finished:
+            if committed:
+                # Tree now owns the keep slot. Zero the keep position so
+                # free_recurrent_cache skips it, then free running + the non-keep
+                # track slot. Net: 3 req-owned → 1 tree-owned + 2 free.
+                keep_idx = self.req_to_token_pool.get_recurrent_ping_pong_keep_idx(req)
+                self.req_to_token_pool.set_recurrent_ping_pong_slot(req, keep_idx, 0)
+                self.req_to_token_pool.free_recurrent_cache(req)
+            else:
+                # Nothing donated to the tree (duplicate/internal/no-insert): free
+                # running + BOTH track slots.
+                self.req_to_token_pool.free_recurrent_cache(req)
+            return
+
+        # Unfinished: the request stays live, keeping running + the other track
+        # slot in the buffer (free nothing here).
         if committed:
-            # Donate-vs-free: on commit the tree takes ownership of the running
-            # slot; otherwise req keeps recurrent_pool_idx and release frees it.
-            self.req_to_token_pool.commit_to_tree(req)
+            # Tree owns the donated slot; the buffer already holds the replacement.
+            # No request-owned track slot represents that boundary anymore.
+            req.recurrent_last_track_seqlen = None
+        elif insert_params is not None and insert_params.recurrent_value is not None:
+            # A donation was attempted but the tree rejected it: the donated slot
+            # was swapped OUT of the buffer (replacement took its place) and is now
+            # orphaned. Free it and invalidate the watermark.
+            self.req_to_token_pool.free_recurrent_slot(int(insert_params.recurrent_value[0]), dp)
+            req.recurrent_last_track_seqlen = None
+        # else: donation SKIPPED (replacement alloc failed) → buffer + watermark
+        # intact; the request keeps both track slots and may publish later.
 
     # ---- eviction -----------------------------------------------------------
 

--- a/python/sgl_jax/srt/mem_cache/unified_cache_components/tree_component.py
+++ b/python/sgl_jax/srt/mem_cache/unified_cache_components/tree_component.py
@@ -356,8 +356,8 @@ class TreeComponent(ABC):
         return int >= 0 for effective cache length.
         - Full: no-op, returns None.
         - SWA: sets insert_params.swa_evicted_seqlen on finished; returns None.
-        - Recurrent: on a finished request, donates the running slot as
-          recurrent_value; returns None (no truncation)."""
+        - Recurrent: prepares recurrent_value (finished from ping-pong buffer,
+          unfinished fork from req); returns recurrent_last_track_seqlen."""
         return None
 
     def cleanup_after_caching_req(

--- a/python/sgl_jax/srt/mem_cache/unified_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/unified_radix_cache.py
@@ -1,9 +1,10 @@
 """Unified radix cache: a component-based radix tree over the device KV cache.
 
-Stage 1 ports the FULL-attention subset of upstream sglang's UnifiedRadixCache.
-All per-component behavior (matching, locking, eviction, split redistribution)
-is delegated to TreeComponent implementations so that later stages (SWA, Mamba,
-HiCache) plug in without touching the core walk.
+Ports upstream sglang's UnifiedRadixCache. Per-component behavior (matching,
+locking, eviction, split redistribution) is delegated to TreeComponent
+implementations: a FULL-attention component plus a leaf-only recurrent
+component (KDA / GDN). SWA / HiCache components plug into the same contract
+without touching the core walk.
 """
 
 from __future__ import annotations
@@ -109,6 +110,8 @@ class UnifiedRadixCache(BasePrefixCache):
         enable_kv_cache_events: bool = False,
         is_eagle: bool = False,
         tree_components: tuple[ComponentType, ...] = (ComponentType.FULL,),
+        enable_recurrent_extra_buffer: bool = False,
+        recurrent_track_interval: int | None = None,
     ):
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
@@ -120,6 +123,8 @@ class UnifiedRadixCache(BasePrefixCache):
         self.max_seq_len = max_seq_len
         self.dtype = dtype
         self.enable_kv_cache_events = enable_kv_cache_events
+        self.enable_recurrent_extra_buffer = enable_recurrent_extra_buffer
+        self.recurrent_track_interval = recurrent_track_interval
         self.kv_event_queue: list = []
 
         self.process_id = jax.process_index()
@@ -250,8 +255,27 @@ class UnifiedRadixCache(BasePrefixCache):
     def supports_recurrent(self) -> bool:
         return ComponentType.RECURRENT in self.components
 
-    def assert_recurrent_slot_ledger(self, dp_rank: int = 0) -> int:
-        """Assert active + tree_owned + free == slots_per_rank; return active."""
+    def recurrent_extra_buffer_active(self) -> bool:
+        return (
+            self.supports_recurrent()
+            and self.enable_recurrent_extra_buffer
+            and self.recurrent_track_interval is not None
+        )
+
+    def recurrent_evictable_size(self, dp_rank: int = 0) -> int:
+        """Unlocked tree-owned recurrent slots on ``dp_rank`` — what ``evict``
+        can reclaim (protected/locked snapshots excluded)."""
+        return self.component_evictable_size_[ComponentType.RECURRENT][dp_rank]
+
+    def assert_recurrent_slot_ledger(self, dp_rank: int = 0, live_reqs: list | None = None) -> int:
+        """Per-rank invariant ``active + tree_owned + free == slots_per_rank``;
+        returns the derived ``active`` (request-owned) count. Tree-owned =
+        recurrent evictable + protected; free = recurrent free-list length.
+
+        When ``live_reqs`` is given, the structurally-derived ``active`` is
+        cross-checked against the slots those requests actually hold (running +
+        ping-pong track), so a leaked track slot is caught rather than silently
+        absorbed into the tautological subtraction."""
         ct = ComponentType.RECURRENT
         rtp = self.req_to_token_pool
         free = len(rtp.recurrent_free_slots[dp_rank])
@@ -265,6 +289,13 @@ class UnifiedRadixCache(BasePrefixCache):
             f"recurrent slot ledger broken (dp={dp_rank}): free={free} "
             f"tree_owned={tree_owned} > slots_per_rank={slots}"
         )
+        if live_reqs is not None:
+            owned = rtp.count_request_owned_recurrent_slots(live_reqs, dp_rank)
+            assert owned == active, (
+                f"recurrent slot leak (dp={dp_rank}): request-owned={owned} != "
+                f"active={active} (free={free} tree_owned={tree_owned} "
+                f"slots_per_rank={slots})"
+            )
         return active
 
     def inc_lock_ref(self, node: UnifiedTreeNode) -> IncLockRefResult:
@@ -898,9 +929,10 @@ class UnifiedRadixCache(BasePrefixCache):
     def _cascade_evict(self, node: UnifiedTreeNode) -> None:
         """Tombstone the base value after all components have been driven.
 
-        Stage 1 collapses the upstream priority cascade: FULL is both the
-        trigger and the only component. The deferral contract puts
-        value = None here, not in FullComponent.evict_component."""
+        FULL is the eviction trigger (device-leaf status keys off its value);
+        the base-value tombstone is deferred to here -- after every component's
+        evict_component has run -- rather than inside FullComponent, so an aux
+        component (e.g. recurrent) can still read FULL.value while evicting."""
         node.component_data[BASE_COMPONENT_TYPE].value = None
         self._update_evictable_leaf_sets(node)
 

--- a/python/sgl_jax/srt/model_executor/forward_batch_info.py
+++ b/python/sgl_jax/srt/model_executor/forward_batch_info.py
@@ -205,6 +205,11 @@ class ForwardBatch:
     recurrent_indices: jax.Array | None = None
     # Recurrent CoW src slots [batch_size] (0 = no clone)
     recurrent_cow_src_indices: jax.Array | None = None
+    # Recurrent track metadata [batch_size] (extra-buffer snapshot at track
+    # boundaries). Populated on extend batches that cross a track boundary; None
+    # otherwise.
+    recurrent_track_indices: jax.Array | None = None
+    recurrent_track_mask: jax.Array | None = None
 
     def tree_flatten(self):
         children = (
@@ -229,6 +234,8 @@ class ForwardBatch:
             self.deepstack_visual_embedding,
             self.recurrent_indices,
             self.recurrent_cow_src_indices,
+            self.recurrent_track_indices,
+            self.recurrent_track_mask,
         )
 
         aux_data = {
@@ -274,6 +281,8 @@ class ForwardBatch:
         obj.deepstack_visual_embedding = children[18]
         obj.recurrent_indices = children[19]
         obj.recurrent_cow_src_indices = children[20]
+        obj.recurrent_track_indices = children[21]
+        obj.recurrent_track_mask = children[22]
         return obj
 
     def __repr__(self) -> str:
@@ -419,6 +428,20 @@ class ForwardBatch:
                 sharding=(NamedSharding(model_runner.mesh, PartitionSpec("data"))),
             )
 
+        recurrent_track_indices = None
+        if batch.recurrent_track_indices is not None:
+            (recurrent_track_indices,) = device_array(
+                (batch.recurrent_track_indices,),
+                sharding=(NamedSharding(model_runner.mesh, PartitionSpec("data"))),
+            )
+
+        recurrent_track_mask = None
+        if batch.recurrent_track_mask is not None:
+            (recurrent_track_mask,) = device_array(
+                (batch.recurrent_track_mask,),
+                sharding=(NamedSharding(model_runner.mesh, PartitionSpec("data"))),
+            )
+
         obj = cls(
             bid=batch.bid,
             forward_mode=batch.forward_mode,
@@ -446,6 +469,8 @@ class ForwardBatch:
             expert_location_metadata=expert_location_metadata,
             recurrent_indices=recurrent_indices,
             recurrent_cow_src_indices=recurrent_cow_src_indices,
+            recurrent_track_indices=recurrent_track_indices,
+            recurrent_track_mask=recurrent_track_mask,
         )
 
         # Auto-generate attention mask for Encoder-only models (e.g. UMT5Encoder, BERT)

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -9,6 +9,7 @@ Aligns with upstream sglang model_runner_kv_cache_mixin.py:
 from __future__ import annotations
 
 import logging
+import math
 import os
 from typing import TYPE_CHECKING
 
@@ -110,23 +111,105 @@ def _per_req_state_bytes_from_config(cfg, tp_size: int) -> int:
     )
 
 
-def _enforce_recurrent_state_server_constraints(server_args) -> None:
+def _enforce_recurrent_state_server_constraints(server_args, is_lightning: bool = False) -> None:
     """Assert server constraints for hybrid recurrent state models."""
+    if server_args.enable_recurrent_extra_buffer:
+        # GLA/Lightning decode is a fused Pallas kernel that cannot add a masked
+        # recurrent track scatter, so the extra-buffer path is unsupported. Reject
+        # at init (the LightningAttnBackend assert is a mid-serving backstop).
+        assert not is_lightning, (
+            "--enable-recurrent-extra-buffer is not supported with the GLA/Lightning "
+            "(bailing_hybrid) architecture."
+        )
+        # The extra-buffer path needs the recurrent radix path; the legacy 1:1
+        # disable_radix_cache branch has no track slots. Check before the
+        # early return below so the combo fails loudly.
+        assert not server_args.disable_radix_cache, (
+            "--enable-recurrent-extra-buffer is incompatible with --disable-radix-cache "
+            "(the legacy 1:1 path has no recurrent track slots)."
+        )
+        assert server_args.enable_unified_radix_tree, (
+            "--enable-recurrent-extra-buffer requires --enable-unified-radix-tree "
+            "(recurrent radix caching)."
+        )
     if server_args.disable_radix_cache:
         return
     assert server_args.enable_unified_radix_tree, (
         "Hybrid recurrent state models require --disable-radix-cache (legacy) "
         "or --enable-unified-radix-tree (recurrent radix caching)."
     )
-    assert server_args.page_size == 1, "Recurrent radix caching requires --page-size 1."
+    # HiCache host offload is unsupported here: recurrent state is device-only
+    # (never backed up), the match validator stops at every tombstone, so the
+    # host tier can never serve a hit.
+    assert getattr(server_args, "hicache_storage", "disable") == "disable", (
+        "Recurrent radix caching does not support HiCache host offload "
+        "(--hicache-storage must be 'disable' for linear-recurrent models)."
+    )
+    if not server_args.enable_recurrent_extra_buffer:
+        assert server_args.page_size == 1, (
+            "Recurrent radix caching requires --page-size 1 unless "
+            "--enable-recurrent-extra-buffer."
+        )
 
 
-def _recurrent_slot_factor(server_args) -> int:
-    """Slots per concurrent request: 2 under radix caching (running slot +
-    tree-owned/clone headroom), 1 on the legacy 1:1 path."""
-    if server_args.enable_unified_radix_tree and not server_args.disable_radix_cache:
-        return 2
+# Fraction of a rank's recurrent slots reserved for cross-request snapshots when
+# the pool size is derived from --recurrent-state-memory-ratio (the auto path).
+# On the explicit --max-recurrent-state-size path this is not enforced (warn only).
+_RECURRENT_SNAPSHOT_HEADROOM_FRACTION = 0.25
+
+
+def _recurrent_ping_pong_slots(server_args) -> int:
+    """Ping-pong track slots per req under extra-buffer: 2 with overlap
+    scheduling (double-buffer across the overlap boundary), 1 without
+    (--disable-overlap-schedule)."""
+    return 1 if server_args.disable_overlap_schedule else 2
+
+
+def request_owned_slots(server_args) -> int:
+    """Recurrent slots a running req actually CONSUMES.
+
+    - extra-buffer: 1 running + ping-pong track slots (3 overlap-on / 2 overlap-off).
+    - 1 otherwise (unified-radix page=1, or legacy 1:1 path).
+
+    Used by alloc, admission backpressure, eviction demand, and the reuse K-sweep.
+    Distinct from ``reservation_slots_per_request`` (the back-cap factor)."""
+    if server_args.disable_radix_cache or not server_args.enable_unified_radix_tree:
+        return 1
+    if server_args.enable_recurrent_extra_buffer:
+        return 1 + _recurrent_ping_pong_slots(server_args)
     return 1
+
+
+def reservation_slots_per_request(server_args) -> int:
+    """Slots the sizing back-cap RESERVES per concurrent request. The surplus
+    over ``request_owned_slots`` is the implicit per-req snapshot headroom.
+
+    - 3 with extra-buffer (overlap-off consumes 2 -> 1 headroom slot/req).
+    - 2 for unified-radix recurrent without extra-buffer (consumes 1 -> 1 headroom).
+    - 1 otherwise (legacy 1:1 path; radix disabled).
+    """
+    if server_args.disable_radix_cache or not server_args.enable_unified_radix_tree:
+        return 1
+    if server_args.enable_recurrent_extra_buffer:
+        return 3
+    return 2
+
+
+def recurrent_admission_blocked(
+    free: int, evictable: int, demand: int, keeps_locked: int = 0
+) -> bool:
+    """Whether a rank's recurrent slots cannot cover ``demand`` fresh slots.
+
+    ``free`` = unused recurrent slots, ``evictable`` = unlocked tree-owned
+    snapshots reclaimable by eviction. ``keeps_locked`` discounts snapshots this
+    admission will keep protected: a cross-request prefix hit locks its matched
+    snapshot for the req's lifetime, so that slot leaves the evictable pool while
+    the req still needs ``request_owned_slots`` fresh slots. Pre-match callers
+    pass 0; a post-match caller that sees a recurrent prefix hit passes 1 so
+    admission at exact capacity defers instead of letting ``alloc_req_slots``
+    evict too few and raise.
+    """
+    return free + evictable - keeps_locked < demand
 
 
 def _build_hybrid_pools(
@@ -138,6 +221,8 @@ def _build_hybrid_pools(
     mesh,
     dp_size: int = 1,
     state_size: int | None = None,
+    enable_recurrent_extra_buffer: bool = False,
+    ping_pong_slots: int = 2,
 ) -> tuple:
     """Build RecurrentStatePool + HybridReqToTokenPool + MemoryPools.
 
@@ -175,6 +260,8 @@ def _build_hybrid_pools(
         dtype=np.int32,
         recurrent_state_pool=rsp,
         dp_size=dp_size,
+        enable_recurrent_extra_buffer=enable_recurrent_extra_buffer,
+        ping_pong_slots=ping_pong_slots,
     )
     mp = MemoryPools(
         token_to_kv_pool=token_to_kv_pool,
@@ -287,6 +374,9 @@ class ModelRunnerKVCacheMixin:
         sa = self.server_args
         dp_size = self.dp_size
         per_req_state = _per_req_state_bytes_from_config(cfg, self.attention_tp_size)
+        factor = reservation_slots_per_request(sa)
+        # Operator-set (priority 1/2) vs ratio-derived (priority 3) pool size.
+        self.recurrent_size_user_supplied = sa.max_recurrent_state_size is not None
 
         if sa.max_recurrent_state_size is not None:
             assert sa.max_recurrent_state_size % dp_size == 0, (
@@ -309,23 +399,25 @@ class ModelRunnerKVCacheMixin:
                     f"hybrid recurrent model; set --recurrent-state-memory-ratio > 0 "
                     f"(default 0.9)."
                 )
-            # _split_state_kv_budget runs against per-device memory, so its
-            # output is per-rank — multiply back to global.
-            state_max_reqs_per_rank, _ = _split_state_kv_budget(
+            # _split_state_kv_budget returns the per-rank SLOT count the state
+            # share affords (not a request count); the pool is exactly those slots.
+            state_slots_per_rank, _ = _split_state_kv_budget(
                 total_rest_memory, ratio, per_req_state
             )
-            sa.max_recurrent_state_size = state_max_reqs_per_rank * dp_size
+            sa.max_recurrent_state_size = state_slots_per_rank * dp_size
 
         state_memory_per_rank = (sa.max_recurrent_state_size // dp_size) * per_req_state
         kv_budget = total_rest_memory - state_memory_per_rank
 
         logger.info(
-            "Hybrid recurrent budget: per_req_state=%d bytes, "
+            "Hybrid recurrent budget: per_req_state=%d bytes, reservation_factor=%d, "
             "max_recurrent_state_size=%d (global) / %d per dp rank, "
-            "kv_budget=%.1f GB",
+            "reservation_cap=%d (global), kv_budget=%.1f GB",
             per_req_state,
+            factor,
             sa.max_recurrent_state_size,
             sa.max_recurrent_state_size // dp_size,
+            sa.max_recurrent_state_size // factor,
             kv_budget / (1024**3),
         )
 
@@ -411,17 +503,82 @@ class ModelRunnerKVCacheMixin:
         ):
             max_num_reqs = self.server_args.max_num_reqs
 
-        # Cap by recurrent state budget (global).
+        # Cap max_running by the recurrent state pool. max_recurrent_state_size is
+        # global (set by handle_recurrent_cache). Explicit sizing caps by the
+        # reservation factor (warn-only headroom); the auto path reserves explicit
+        # snapshot headroom and caps by actual per-req consumption.
         if (
             self.linear_recurrent_config is not None
             and self.server_args.max_recurrent_state_size is not None
         ):
-            factor = _recurrent_slot_factor(self.server_args)
-            budget_cap = self.server_args.max_recurrent_state_size // factor
-            # _build_hybrid_pools asserts max_num_reqs % dp_size == 0; round the
-            # budget cap down to stay dp-aligned.
-            budget_cap -= budget_cap % self.dp_size
-            max_num_reqs = min(max_num_reqs, budget_cap)
+            reservation = reservation_slots_per_request(self.server_args)
+            owned = request_owned_slots(self.server_args)
+            dp_size = self.dp_size
+            slots_per_rank = self.server_args.max_recurrent_state_size // dp_size
+            user_supplied = getattr(self, "recurrent_size_user_supplied", True)
+
+            # A pool with fewer slots/rank than one request consumes can never
+            # allocate; backpressure would mark every rank full forever. Fail
+            # fast with an actionable message instead of a stuck server.
+            if slots_per_rank < owned:
+                raise ValueError(
+                    f"Recurrent state pool too small: {slots_per_rank} slot(s) per dp rank "
+                    f"(max_recurrent_state_size={self.server_args.max_recurrent_state_size}, "
+                    f"dp_size={dp_size}) < request_owned_slots={owned} -- cannot fit even one "
+                    f"running request. Raise --max-recurrent-state-size to >= {reservation * dp_size} "
+                    f"(or raise --recurrent-state-memory-ratio for the auto-derived pool)."
+                )
+
+            if user_supplied:
+                # Warn using the REAL headroom (slots left after actual
+                # consumption), not the reservation factor.
+                budget_cap = slots_per_rank * dp_size // reservation
+                budget_cap -= budget_cap % dp_size
+                # The reservation divide + dp floor can land at 0 even past the
+                # per-slot guard above (owned < reservation): fail fast, a server
+                # with max_running=0 admits nothing and hangs silently.
+                if budget_cap < dp_size:
+                    raise ValueError(
+                        f"Recurrent state pool too small for one running request per dp rank: "
+                        f"max_recurrent_state_size={self.server_args.max_recurrent_state_size} "
+                        f"/ reservation_slots_per_request={reservation} / dp_size={dp_size} "
+                        f"caps max_running at {budget_cap}. Raise --max-recurrent-state-size "
+                        f"to >= {reservation * dp_size}."
+                    )
+                max_num_reqs = min(max_num_reqs, budget_cap)
+                snapshot_headroom = self.server_args.max_recurrent_state_size - max_num_reqs * owned
+                if snapshot_headroom < dp_size:
+                    logger.warning(
+                        "Recurrent pool has near-zero snapshot headroom "
+                        "(max_recurrent_state_size=%d, max_running=%d, "
+                        "request_owned_slots=%d -> %d slot(s) for cached "
+                        "snapshots). Cross-request reuse will be ~0 at saturation; "
+                        "raise --max-recurrent-state-size (e.g. > max_running*%d) "
+                        "to enable reuse.",
+                        self.server_args.max_recurrent_state_size,
+                        max_num_reqs,
+                        owned,
+                        snapshot_headroom,
+                        owned,
+                    )
+            else:
+                # Auto path: reserve snapshot headroom when capacity allows and
+                # back-cap running by actual consumption. The max(1, ...) floors
+                # keep one running req/rank on a tiny pool (liveness over headroom).
+                headroom_per_rank = max(
+                    1, math.ceil(_RECURRENT_SNAPSHOT_HEADROOM_FRACTION * slots_per_rank)
+                )
+                running_per_rank = max(1, (slots_per_rank - headroom_per_rank) // owned)
+                budget_cap = running_per_rank * dp_size
+                max_num_reqs = min(max_num_reqs, budget_cap)
+                logger.info(
+                    "Recurrent pool headroom: %d slot(s)/rank reserved for snapshots "
+                    "(slots/rank=%d, request_owned_slots=%d, max_running=%d global).",
+                    headroom_per_rank,
+                    slots_per_rank,
+                    owned,
+                    max_num_reqs,
+                )
 
         return max_num_reqs
 
@@ -556,6 +713,8 @@ class ModelRunnerKVCacheMixin:
                 mesh=self.mesh,
                 dp_size=dp_size,
                 state_size=state_size,
+                enable_recurrent_extra_buffer=self.server_args.enable_recurrent_extra_buffer,
+                ping_pong_slots=_recurrent_ping_pong_slots(self.server_args),
             )
         else:
             self.memory_pools = _build_non_hybrid_memory_pools(self.token_to_kv_pool)
@@ -598,7 +757,9 @@ class ModelRunnerKVCacheMixin:
 
         # 2. Enforce constraints for hybrid recurrent
         if self.linear_recurrent_config is not None:
-            _enforce_recurrent_state_server_constraints(self.server_args)
+            _enforce_recurrent_state_server_constraints(
+                self.server_args, is_lightning=self.lightning_config is not None
+            )
 
         # 3. Profile max tokens
         self.max_total_num_tokens = self.profile_max_num_token(total_device_memory)

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -94,6 +94,7 @@ class ServerArgs:
     swa_full_tokens_ratio: float = 0.8
     recurrent_state_memory_ratio: float = 0.9
     max_recurrent_state_size: int | None = None
+    recurrent_track_interval: int | None = None
     disable_hybrid_swa_memory: bool = False
 
     # Runtime options
@@ -170,6 +171,7 @@ class ServerArgs:
     #   write_through_selective  same path, just a higher threshold
     #   write_back               no backup on hit; back up only at device eviction
     hicache_write_policy: str = "write_through"
+    enable_recurrent_extra_buffer: bool = False
     allow_auto_truncate: bool = False
     enable_tokenizer_batch_encode: bool = False
     disable_overlap_schedule: bool = False
@@ -370,6 +372,83 @@ class ServerArgs:
         # Normalize speculative_algorithm: treat empty string as None
         if isinstance(self.speculative_algorithm, str) and self.speculative_algorithm.strip() == "":
             self.speculative_algorithm = None
+
+        # Recurrent extra-buffer static validation + track-interval
+        # normalization. Gated on the flag so non-recurrent / base-path launches
+        # are untouched. Model-dependent checks (radix routing) live in
+        # _enforce_recurrent_state_server_constraints.
+        if self.enable_recurrent_extra_buffer:
+            if self.page_size <= 1:
+                raise ValueError(
+                    "--enable-recurrent-extra-buffer requires --page-size > 1 "
+                    f"(recurrent radix caching uses page-boundary track slots); "
+                    f"got page_size={self.page_size}."
+                )
+            # Default to chunked_prefill_size so snapshots land on existing
+            # chunk boundaries and add no extra prefill splits.
+            if self.recurrent_track_interval is None:
+                if self.chunked_prefill_size and self.chunked_prefill_size > 0:
+                    # check_server_args() asserts chunk page-alignment later; check
+                    # here so the error blames the chunk, not the derived interval.
+                    if self.chunked_prefill_size % self.page_size != 0:
+                        raise ValueError(
+                            f"--chunked-prefill-size ({self.chunked_prefill_size}) must be a "
+                            f"multiple of --page-size ({self.page_size}) when "
+                            "--enable-recurrent-extra-buffer is set (the recurrent track "
+                            "interval defaults to it)."
+                        )
+                    self.recurrent_track_interval = self.chunked_prefill_size
+                else:
+                    self.recurrent_track_interval = self.page_size
+            if self.recurrent_track_interval <= 0:
+                raise ValueError(
+                    "--recurrent-track-interval must be > 0 when "
+                    f"--enable-recurrent-extra-buffer is set; got {self.recurrent_track_interval}."
+                )
+            if self.recurrent_track_interval % self.page_size != 0:
+                raise ValueError(
+                    f"--recurrent-track-interval ({self.recurrent_track_interval}) must be a "
+                    f"multiple of --page-size ({self.page_size})."
+                )
+            if self.chunked_prefill_size and self.chunked_prefill_size > 0:
+                if self.recurrent_track_interval > self.chunked_prefill_size:
+                    # Coarser than the chunk: short prompts cache nothing but do
+                    # not stall. Warn, don't reject -- a memory-for-hit-rate trade.
+                    logger.warning(
+                        "--recurrent-track-interval (%d) > --chunked-prefill-size (%d): recurrent "
+                        "snapshots are published only at interval boundaries, so any prompt shorter "
+                        "than the interval caches nothing and cross-request reuse is limited to "
+                        "prompts that cross a boundary. The request still progresses (no stall); "
+                        "this only lowers the recurrent-cache hit rate. Prefer the default "
+                        "(= chunked_prefill_size) unless you are deliberately trading hit rate for "
+                        "coarser, cheaper snapshots.",
+                        self.recurrent_track_interval,
+                        self.chunked_prefill_size,
+                    )
+                elif self.recurrent_track_interval < self.chunked_prefill_size:
+                    logger.warning(
+                        "--recurrent-track-interval (%d) < --chunked-prefill-size (%d): this "
+                        "force-splits prefill into %d-token sub-chunks so each forward ends on a "
+                        "snapshot boundary. Chunked prefill is chunk-size-sensitive in the "
+                        "full-attention/MoE path, so finer snapshots trade accuracy (~3.5pp on "
+                        "GPQA at interval=128 vs chunk=512) for recurrent-cache granularity. "
+                        "Prefer the default (= chunked_prefill_size).",
+                        self.recurrent_track_interval,
+                        self.chunked_prefill_size,
+                        self.recurrent_track_interval,
+                    )
+            if self.speculative_algorithm is not None:
+                raise ValueError(
+                    "--enable-recurrent-extra-buffer does not support speculative "
+                    f"decoding yet; got --speculative-algorithm={self.speculative_algorithm}. "
+                    "Disable one of them."
+                )
+            if self.enable_mixed_chunk:
+                raise ValueError(
+                    "--enable-recurrent-extra-buffer does not support mixed chunked "
+                    "prefill yet (the track snapshot is scoped to pure extend / "
+                    "pure decode forwards). Disable --enable-mixed-chunk."
+                )
 
         os.environ["SGLANG_ENABLE_DETERMINISTIC_SAMPLING"] = (
             "1" if self.enable_deterministic_sampling else "0"
@@ -797,6 +876,16 @@ class ServerArgs:
             "Must be divisible by dp_size when set explicitly.",
         )
         parser.add_argument(
+            "--recurrent-track-interval",
+            type=int,
+            default=ServerArgs.recurrent_track_interval,
+            help="Recurrent radix cache: page-boundary interval at which a "
+            "recurrent track state is committed. Requires --enable-recurrent-extra-buffer "
+            "and must be a positive multiple of --page-size. Defaults to "
+            "--chunked-prefill-size when extra-buffer is enabled (falls back to "
+            "--page-size if chunked prefill is off).",
+        )
+        parser.add_argument(
             "--disable-hybrid-swa-memory",
             action="store_true",
             help="Disable the hybrid SWA memory.",
@@ -1141,7 +1230,9 @@ class ServerArgs:
             choices=["disable", "none", "file"],
             default=ServerArgs.hicache_storage,
             help="HiCache KV offloading: 'disable' off, 'none' enables L1+L2 "
-            "(host pinned pool), 'file' reserved for L3(not support yet).",
+            "(host pinned pool), 'file' reserved for L3(not support yet). "
+            "Unsupported for linear-recurrent models under the unified radix "
+            "tree (rejected at init).",
         )
         parser.add_argument(
             "--hicache-ratio",
@@ -1164,6 +1255,13 @@ class ServerArgs:
             "(>= threshold); 'write_through_selective' is the same path with a "
             "higher threshold; 'write_back' skips hit-time backup and only backs "
             "up a node when its device KV is evicted (fewest D2H)",
+        )
+        parser.add_argument(
+            "--enable-recurrent-extra-buffer",
+            action="store_true",
+            help="Recurrent radix cache: use the page-aligned ping-pong track "
+            "buffer for page_size>=128. Off by default; the base path supports "
+            "page_size=1 only.",
         )
         parser.add_argument(
             "--allow-auto-truncate",

--- a/python/sgl_jax/test/layers/test_lightning_backend.py
+++ b/python/sgl_jax/test/layers/test_lightning_backend.py
@@ -178,6 +178,8 @@ def _run_backend_extend(lens, H, K, dtype, h0, rng_seed, layer_id=_LAYER_ID):
             input_ids=np.zeros(total_tokens, dtype=np.int32),
             recurrent_indices=rec_indices,
             has_initial_state=np.ones(B, dtype=np.bool_),
+            recurrent_track_indices=None,
+            recurrent_track_mask=None,
             dp_size=1,
             per_dp_bs_size=B,
         )
@@ -227,6 +229,8 @@ def _run_backend_extend_bucket_padded(lens, H, K, dtype, h0, rng_seed, layer_id=
             input_ids=input_ids,
             recurrent_indices=rec_indices,
             has_initial_state=np.ones(B_padded, dtype=np.bool_),
+            recurrent_track_indices=None,
+            recurrent_track_mask=None,
             dp_size=1,
             per_dp_bs_size=B_padded,
         )
@@ -285,6 +289,8 @@ def _run_backend_decode(B, H, K, dtype, h0, rng_seed, layer_id=_LAYER_ID):
             seq_lens=np.ones(B, dtype=np.int32),
             recurrent_indices=rec_indices,
             has_initial_state=np.ones(B, dtype=np.bool_),
+            recurrent_track_indices=None,
+            recurrent_track_mask=None,
             dp_size=1,
             per_dp_bs_size=B,
         )

--- a/python/sgl_jax/test/layers/test_lightning_backend_dp.py
+++ b/python/sgl_jax/test/layers/test_lightning_backend_dp.py
@@ -201,6 +201,8 @@ class TestDPMetadata:
                 seq_lens=np.array([10, 20, 15, 25], dtype=np.int32),
                 recurrent_indices=np.array([1, 2, 1, 2], dtype=np.int32),  # LOCAL indices per rank
                 has_initial_state=np.ones(4, dtype=np.bool_),
+                recurrent_track_indices=None,
+                recurrent_track_mask=None,
                 dp_size=2,
                 per_dp_bs_size=2,
             )
@@ -271,6 +273,8 @@ class TestDPDecode:
                 seq_lens=np.ones(B, dtype=np.int32),
                 recurrent_indices=rec_indices,
                 has_initial_state=np.ones(B, dtype=np.bool_),
+                recurrent_track_indices=None,
+                recurrent_track_mask=None,
                 dp_size=1,
                 per_dp_bs_size=B,
             )
@@ -311,6 +315,8 @@ class TestDPDecode:
                 seq_lens=np.ones(B, dtype=np.int32),
                 recurrent_indices=batch_rec_indices,
                 has_initial_state=np.ones(B, dtype=np.bool_),
+                recurrent_track_indices=None,
+                recurrent_track_mask=None,
                 dp_size=2,
                 per_dp_bs_size=B // 2,
             )
@@ -386,6 +392,8 @@ class TestDPDecode:
                 seq_lens=np.ones(B, dtype=np.int32),
                 recurrent_indices=batch_rec_indices,
                 has_initial_state=np.ones(B, dtype=np.bool_),
+                recurrent_track_indices=None,
+                recurrent_track_mask=None,
                 dp_size=2,
                 per_dp_bs_size=B // 2,
             )
@@ -459,6 +467,8 @@ class TestDPExtend:
                 input_ids=np.zeros(total_tokens, dtype=np.int32),
                 recurrent_indices=rec_indices,
                 has_initial_state=np.ones(B, dtype=np.bool_),
+                recurrent_track_indices=None,
+                recurrent_track_mask=None,
                 dp_size=1,
                 per_dp_bs_size=B,
             )
@@ -502,6 +512,8 @@ class TestDPExtend:
                 input_ids=np.zeros(total_tokens, dtype=np.int32),
                 recurrent_indices=batch_rec_indices,
                 has_initial_state=np.ones(B, dtype=np.bool_),
+                recurrent_track_indices=None,
+                recurrent_track_mask=None,
                 dp_size=2,
                 per_dp_bs_size=B // 2,
             )
@@ -631,6 +643,8 @@ class TestDPExtend:
                 input_ids=np.zeros(total_tokens, dtype=np.int32),
                 recurrent_indices=rec_indices,
                 has_initial_state=np.ones(B, dtype=np.bool_),
+                recurrent_track_indices=None,
+                recurrent_track_mask=None,
                 dp_size=2,
                 per_dp_bs_size=B // 2,
             )
@@ -721,6 +735,8 @@ class TestDPEndToEnd:
                 input_ids=np.zeros(total_tokens, dtype=np.int32),
                 recurrent_indices=batch_rec_indices,
                 has_initial_state=np.ones(B, dtype=np.bool_),
+                recurrent_track_indices=None,
+                recurrent_track_mask=None,
                 dp_size=2,
                 per_dp_bs_size=B // 2,
             )

--- a/python/sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py
+++ b/python/sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py
@@ -43,6 +43,17 @@ class FakeReq:
         self.kv_committed_len = kv_committed_len
         self.dp_rank = dp_rank
         self.recurrent_pool_idx = recurrent_pool_idx
+        # Extra-buffer ping-pong track fields.
+        self.recurrent_ping_pong_track_buffer = None
+        self.recurrent_next_track_idx = None
+        self.recurrent_last_track_seqlen = None
+
+    def reset_for_retract(self):
+        """Mirror Req.reset_for_retract clears for the ping-pong fields."""
+        self.recurrent_pool_idx = None
+        self.recurrent_ping_pong_track_buffer = None
+        self.recurrent_next_track_idx = None
+        self.recurrent_last_track_seqlen = None
 
 
 # ---------------------------------------------------------------------------
@@ -406,6 +417,366 @@ class TestHybridPoolRecurrentSlotAPI(CustomTestCase):
         self.pool.free(reqs[1])
         self.pool.free(reqs[2])
         self.assertEqual(self.pool.recurrent_available_size(0), slots)
+
+
+class TestHybridPoolExtraBufferAPI(CustomTestCase):
+    """Ping-pong track-slot API used by the extra-buffer recurrent path.
+
+    Dormant unless ``enable_recurrent_extra_buffer=True``: with it off the pool must
+    behave byte-identically to the base page=1 path (running slot only).
+    """
+
+    def _make_pool(self, enable_recurrent_extra_buffer, dp_size=1, size=16, ping_pong_slots=2):
+        state_pool = FakeRecurrentStatePool(size=size)
+        return HybridReqToTokenPool(
+            size=size,
+            max_context_len=32,
+            dtype=np.int32,
+            recurrent_state_pool=state_pool,
+            dp_size=dp_size,
+            enable_recurrent_extra_buffer=enable_recurrent_extra_buffer,
+            ping_pong_slots=ping_pong_slots,
+        )
+
+    # --- Case: extra-buffer OFF is a strict no-op (base page=1 path unchanged) ---
+
+    def test_extra_buffer_off_allocs_only_running_slot(self):
+        pool = self._make_pool(enable_recurrent_extra_buffer=False)
+        free_before = pool.recurrent_available_size(0)
+        req = FakeReq(dp_rank=0)
+
+        pool.alloc([req])
+
+        # Only the running slot is consumed; no track slots, no fields set.
+        self.assertIsNotNone(req.recurrent_pool_idx)
+        self.assertIsNone(req.recurrent_ping_pong_track_buffer)
+        self.assertIsNone(req.recurrent_next_track_idx)
+        self.assertIsNone(req.recurrent_last_track_seqlen)
+        self.assertEqual(pool.recurrent_available_size(0), free_before - 1)
+        # Track mapping row untouched (all zeros).
+        np.testing.assert_array_equal(
+            pool.req_index_to_recurrent_ping_pong_track_buffer_mapping[req.req_pool_idx],
+            np.zeros(2, dtype=np.int32),
+        )
+
+    # --- Case 1: alloc gives running + 2 track slots (3 total) ---
+
+    def test_alloc_allocates_running_plus_two_track(self):
+        pool = self._make_pool(enable_recurrent_extra_buffer=True)
+        free_before = pool.recurrent_available_size(0)
+        req = FakeReq(dp_rank=0)
+
+        pool.alloc([req])
+
+        self.assertIsNotNone(req.recurrent_pool_idx)
+        self.assertIsNotNone(req.recurrent_ping_pong_track_buffer)
+        self.assertEqual(len(req.recurrent_ping_pong_track_buffer), 2)
+        # Free list dropped by 3 (1 running + 2 track).
+        self.assertEqual(pool.recurrent_available_size(0), free_before - 3)
+        # next_track_idx starts at 0; last_track_seqlen stays None (no scatter yet).
+        self.assertEqual(req.recurrent_next_track_idx, 0)
+        self.assertIsNone(req.recurrent_last_track_seqlen)
+        # Three distinct non-null slots, none is slot 0.
+        used = {req.recurrent_pool_idx, *req.recurrent_ping_pong_track_buffer}
+        self.assertEqual(len(used), 3)
+        self.assertNotIn(0, used)
+        # Mapping row reflects the buffer.
+        np.testing.assert_array_equal(
+            pool.req_index_to_recurrent_ping_pong_track_buffer_mapping[req.req_pool_idx],
+            np.array(req.recurrent_ping_pong_track_buffer, dtype=np.int32),
+        )
+
+    def test_alloc_returns_none_when_below_three_free(self):
+        # 4 slots/rank; one req takes 3, leaving 1 < 3 for the next.
+        pool = self._make_pool(enable_recurrent_extra_buffer=True, size=4)
+        first = FakeReq(dp_rank=0)
+        self.assertIsNotNone(pool.alloc([first]))
+        self.assertEqual(pool.recurrent_available_size(0), 1)
+
+        overflow = FakeReq(dp_rank=0)
+        self.assertIsNone(pool.alloc([overflow]))
+        self.assertIsNone(overflow.req_pool_idx)
+        self.assertIsNone(overflow.recurrent_pool_idx)
+        self.assertIsNone(overflow.recurrent_ping_pong_track_buffer)
+
+    # --- Case 2: donate keep slot + keep/other index helpers ---
+
+    def test_donate_keep_slot_replaces_and_returns_value(self):
+        pool = self._make_pool(enable_recurrent_extra_buffer=True)
+        req = FakeReq(dp_rank=0)
+        pool.alloc([req])
+
+        # next=0 -> overwrite slot 0; keep slot is the other (index 1).
+        self.assertEqual(req.recurrent_next_track_idx, 0)
+        keep_idx = pool.get_recurrent_ping_pong_keep_idx(req)
+        self.assertEqual(keep_idx, 1)
+        self.assertEqual(pool.get_recurrent_ping_pong_other_idx(0), 1)
+        self.assertEqual(pool.get_recurrent_ping_pong_other_idx(1), 0)
+
+        keep_slot = req.recurrent_ping_pong_track_buffer[keep_idx]
+        new_slot = pool.alloc_recurrent_slot(0)
+
+        value = pool.donate_recurrent_ping_pong_slot(req, new_slot)
+
+        # Returned the keep slot's len-1 int32 value.
+        self.assertIsInstance(value, np.ndarray)
+        self.assertEqual(value.dtype, np.int32)
+        self.assertEqual(value.shape, (1,))
+        self.assertEqual(int(value[0]), keep_slot)
+        # Keep slot replaced by new slot in buffer + mapping.
+        self.assertEqual(req.recurrent_ping_pong_track_buffer[keep_idx], new_slot)
+        self.assertEqual(
+            pool.req_index_to_recurrent_ping_pong_track_buffer_mapping[req.req_pool_idx, keep_idx],
+            new_slot,
+        )
+
+    def test_set_recurrent_ping_pong_slot_updates_buffer_and_mapping(self):
+        pool = self._make_pool(enable_recurrent_extra_buffer=True)
+        req = FakeReq(dp_rank=0)
+        pool.alloc([req])
+        new_slot = pool.alloc_recurrent_slot(0)
+
+        pool.set_recurrent_ping_pong_slot(req, 1, new_slot)
+
+        self.assertEqual(req.recurrent_ping_pong_track_buffer[1], new_slot)
+        self.assertEqual(
+            pool.req_index_to_recurrent_ping_pong_track_buffer_mapping[req.req_pool_idx, 1],
+            new_slot,
+        )
+
+    # --- Case 3: free_recurrent_cache frees running + both track slots ---
+
+    def test_free_recurrent_cache_frees_running_and_track(self):
+        pool = self._make_pool(enable_recurrent_extra_buffer=True)
+        free_full = pool.recurrent_available_size(0)
+        req = FakeReq(dp_rank=0)
+        pool.alloc([req])
+        running = req.recurrent_pool_idx
+        track = list(req.recurrent_ping_pong_track_buffer)
+        req_pool_idx = req.req_pool_idx
+
+        pool.free_recurrent_cache(req)
+
+        # All 3 slots back; mapping rows zeroed; fields cleared.
+        self.assertEqual(pool.recurrent_available_size(0), free_full)
+        self.assertIn(running, pool.recurrent_free_slots[0])
+        for slot in track:
+            self.assertIn(slot, pool.recurrent_free_slots[0])
+        self.assertEqual(pool.req_index_to_recurrent_index_mapping[req_pool_idx], 0)
+        np.testing.assert_array_equal(
+            pool.req_index_to_recurrent_ping_pong_track_buffer_mapping[req_pool_idx],
+            np.zeros(2, dtype=np.int32),
+        )
+        self.assertIsNone(req.recurrent_pool_idx)
+        self.assertIsNone(req.recurrent_ping_pong_track_buffer)
+        self.assertIsNone(req.recurrent_next_track_idx)
+        self.assertIsNone(req.recurrent_last_track_seqlen)
+
+    # --- Case 4: retract clears the ping-pong fields after free ---
+
+    def test_retract_clears_ping_pong_fields_for_requeue(self):
+        pool = self._make_pool(enable_recurrent_extra_buffer=True)
+        req = FakeReq(dp_rank=0)
+        pool.alloc([req])
+
+        pool.free_recurrent_cache(req)
+        req.reset_for_retract()
+
+        self.assertIsNone(req.recurrent_pool_idx)
+        self.assertIsNone(req.recurrent_ping_pong_track_buffer)
+        self.assertIsNone(req.recurrent_next_track_idx)
+        self.assertIsNone(req.recurrent_last_track_seqlen)
+
+        # A requeued req reallocates fresh track slots.
+        requeued = FakeReq(dp_rank=0)
+        pool.alloc([requeued])
+        self.assertIsNotNone(requeued.recurrent_ping_pong_track_buffer)
+        self.assertEqual(len(requeued.recurrent_ping_pong_track_buffer), 2)
+
+    # --- Case 5: ledger counts request-owned running + track for dp1 and dp2 ---
+
+    def _assert_ledger(self, pool, live_reqs, dp_rank, tree_owned=0):
+        slots = pool.slots_per_rank
+        free = pool.recurrent_available_size(dp_rank)
+        owned = pool.count_request_owned_recurrent_slots(live_reqs, dp_rank)
+        # owned (request) + tree_owned (donated, off-pool) + free == slots.
+        self.assertEqual(owned + tree_owned + free, slots)
+
+    def test_ledger_invariant_dp1(self):
+        pool = self._make_pool(enable_recurrent_extra_buffer=True, dp_size=1, size=16)
+        reqs = [FakeReq(dp_rank=0), FakeReq(dp_rank=0)]
+        pool.alloc(reqs)
+        self._assert_ledger(pool, reqs, 0)
+
+        # donate moves the keep slot to the tree and consumes a fresh free slot
+        # for the buffer: request-owned count is unchanged, +1 tree-owned slot.
+        new_slot = pool.alloc_recurrent_slot(0)
+        donated = pool.donate_recurrent_ping_pong_slot(reqs[0], new_slot)
+        self._assert_ledger(pool, reqs, 0, tree_owned=1)
+
+        # Simulate tree eviction returning the donated slot.
+        pool.free_recurrent_slot(int(donated[0]), 0)
+        self._assert_ledger(pool, reqs, 0)
+
+        pool.free_recurrent_cache(reqs[0])
+        live = [reqs[1]]
+        self._assert_ledger(pool, live, 0)
+
+    def test_ledger_invariant_dp2(self):
+        pool = self._make_pool(enable_recurrent_extra_buffer=True, dp_size=2, size=16)
+        r0 = FakeReq(dp_rank=0)
+        r1 = FakeReq(dp_rank=1)
+        pool.alloc([r0])
+        pool.alloc([r1])
+
+        self._assert_ledger(pool, [r0], 0)
+        self._assert_ledger(pool, [r1], 1)
+
+        pool.free_recurrent_cache(r0)
+        self._assert_ledger(pool, [], 0)
+        self._assert_ledger(pool, [r1], 1)
+
+    def test_ledger_detects_leaked_track_slot(self):
+        """A track slot left allocated but not returned to the free list must make
+        owned + free != slots_per_rank (the leak is caught)."""
+        pool = self._make_pool(enable_recurrent_extra_buffer=True, dp_size=1, size=16)
+        req = FakeReq(dp_rank=0)
+        pool.alloc([req])
+
+        # Simulate a leak: free only the running slot, drop the req handle without
+        # returning its track slots.
+        pool.free_recurrent_slot(req.recurrent_pool_idx, 0)
+        leaked = list(req.recurrent_ping_pong_track_buffer)
+        live_reqs = []  # request gone, but its track slots never freed
+
+        slots = pool.slots_per_rank
+        free = pool.recurrent_available_size(0)
+        owned = pool.count_request_owned_recurrent_slots(live_reqs, 0)
+        self.assertEqual(len(leaked), 2)
+        self.assertNotEqual(owned + free, slots)
+
+
+class TestPingPongSingleSlot(unittest.TestCase):
+    """Overlap-off (--disable-overlap-schedule) uses 1 ping-pong track slot, so a
+    req consumes 2 (1 running + 1 track) instead of 3. The toggle collapses to a
+    no-op and donate/cleanup must stay ledger-consistent."""
+
+    def _make_pool(self, dp_size=1, size=16):
+        state_pool = FakeRecurrentStatePool(size=size)
+        return HybridReqToTokenPool(
+            size=size,
+            max_context_len=32,
+            dtype=np.int32,
+            recurrent_state_pool=state_pool,
+            dp_size=dp_size,
+            enable_recurrent_extra_buffer=True,
+            ping_pong_slots=1,
+        )
+
+    def test_request_owned_slots_is_two(self):
+        pool = self._make_pool()
+        self.assertEqual(pool.request_owned_slots, 2)
+
+    def test_alloc_allocates_running_plus_one_track(self):
+        pool = self._make_pool()
+        free_before = pool.recurrent_available_size(0)
+        req = FakeReq(dp_rank=0)
+
+        pool.alloc([req])
+
+        self.assertEqual(len(req.recurrent_ping_pong_track_buffer), 1)
+        # Free list dropped by 2 (1 running + 1 track).
+        self.assertEqual(pool.recurrent_available_size(0), free_before - 2)
+        used = {req.recurrent_pool_idx, *req.recurrent_ping_pong_track_buffer}
+        self.assertEqual(len(used), 2)
+        self.assertNotIn(0, used)
+        # Mapping row is width 1 and reflects the single track slot.
+        np.testing.assert_array_equal(
+            pool.req_index_to_recurrent_ping_pong_track_buffer_mapping[req.req_pool_idx],
+            np.array(req.recurrent_ping_pong_track_buffer, dtype=np.int32),
+        )
+
+    def test_toggle_is_noop_and_keep_equals_next(self):
+        pool = self._make_pool()
+        req = FakeReq(dp_rank=0)
+        pool.alloc([req])
+        # With one slot the next-scatter target never moves; keep == next == 0.
+        self.assertEqual(pool.get_recurrent_ping_pong_other_idx(0), 0)
+        self.assertEqual(req.recurrent_next_track_idx, 0)
+        self.assertEqual(pool.get_recurrent_ping_pong_keep_idx(req), 0)
+
+    def test_donate_replaces_the_sole_slot(self):
+        pool = self._make_pool()
+        req = FakeReq(dp_rank=0)
+        pool.alloc([req])
+        keep_slot = req.recurrent_ping_pong_track_buffer[0]
+        new_slot = pool.alloc_recurrent_slot(0)
+
+        value = pool.donate_recurrent_ping_pong_slot(req, new_slot)
+
+        self.assertEqual(int(value[0]), keep_slot)
+        self.assertEqual(req.recurrent_ping_pong_track_buffer[0], new_slot)
+        self.assertEqual(
+            pool.req_index_to_recurrent_ping_pong_track_buffer_mapping[req.req_pool_idx, 0],
+            new_slot,
+        )
+
+    def test_free_recurrent_cache_frees_running_and_single_track(self):
+        pool = self._make_pool()
+        free_full = pool.recurrent_available_size(0)
+        req = FakeReq(dp_rank=0)
+        pool.alloc([req])
+        running = req.recurrent_pool_idx
+        track = list(req.recurrent_ping_pong_track_buffer)
+
+        pool.free_recurrent_cache(req)
+
+        self.assertEqual(pool.recurrent_available_size(0), free_full)
+        self.assertIn(running, pool.recurrent_free_slots[0])
+        self.assertIn(track[0], pool.recurrent_free_slots[0])
+        np.testing.assert_array_equal(
+            pool.req_index_to_recurrent_ping_pong_track_buffer_mapping[req.req_pool_idx],
+            np.zeros(1, dtype=np.int32),
+        )
+        self.assertIsNone(req.recurrent_ping_pong_track_buffer)
+
+    def test_finished_committed_net_one_tree_one_free(self):
+        """Finished + committed: zero the keep slot (tree owns it), free running.
+        Net of the 2 owned slots: 1 tree-owned + 1 freed."""
+        pool = self._make_pool()
+        req = FakeReq(dp_rank=0)
+        pool.alloc([req])
+        free_after_alloc = pool.recurrent_available_size(0)
+        keep_idx = pool.get_recurrent_ping_pong_keep_idx(req)  # 0
+
+        # Tree takes the keep slot: zero it so free_recurrent_cache skips it.
+        pool.set_recurrent_ping_pong_slot(req, keep_idx, 0)
+        pool.free_recurrent_cache(req)
+
+        # Only the running slot returned (+1); the donated track slot stays
+        # tree-owned (off-pool).
+        self.assertEqual(pool.recurrent_available_size(0), free_after_alloc + 1)
+
+    def test_ledger_invariant_with_donation(self):
+        pool = self._make_pool(dp_size=1, size=16)
+        reqs = [FakeReq(dp_rank=0), FakeReq(dp_rank=0)]
+        pool.alloc(reqs)
+        slots = pool.slots_per_rank
+
+        def owned():
+            return pool.count_request_owned_recurrent_slots(reqs, 0)
+
+        self.assertEqual(owned() + pool.recurrent_available_size(0), slots)
+
+        # Unfinished donation: alloc replacement, donate the sole slot. Owned is
+        # unchanged (replacement swaps in); +1 tree-owned.
+        new_slot = pool.alloc_recurrent_slot(0)
+        donated = pool.donate_recurrent_ping_pong_slot(reqs[0], new_slot)
+        self.assertEqual(owned() + 1 + pool.recurrent_available_size(0), slots)
+
+        # Tree eviction returns the donated slot.
+        pool.free_recurrent_slot(int(donated[0]), 0)
+        self.assertEqual(owned() + pool.recurrent_available_size(0), slots)
 
 
 if __name__ == "__main__":

--- a/python/sgl_jax/test/mem_cache/test_unified_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_unified_radix_cache.py
@@ -1270,7 +1270,8 @@ class TestUnifiedRadixCacheRecurrent(CustomTestCase):
         pool.alloc([req])  # assigns req_pool_idx + a running recurrent slot
         self.assertIsNotNone(req.recurrent_pool_idx)
         running_slot = req.recurrent_pool_idx
-        self.assertEqual(cache.assert_recurrent_slot_ledger(0), 1)
+        # active=1 (this running req), tree_owned=0, free=slots-1.
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=[req]), 1)
 
         kv1 = allocator.alloc(len(chunk1), dp_rank=0)
         self.assertIsNotNone(kv1)
@@ -1284,7 +1285,7 @@ class TestUnifiedRadixCacheRecurrent(CustomTestCase):
         self.assertEqual(req.cache_protected_len, len(chunk1))
         self.assertEqual(len(req.prefix_indices), len(chunk1))
         self.assertEqual(cache.component_evictable_size_[ComponentType.RECURRENT][0], 0)
-        self.assertEqual(cache.assert_recurrent_slot_ledger(0), 1)
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=[req]), 1)
 
         prefix_key = RadixKey(chunk1, None, 0)
 
@@ -1319,7 +1320,7 @@ class TestUnifiedRadixCacheRecurrent(CustomTestCase):
         self.assertEqual(len(req.prefix_indices), len(chunk1) + len(chunk2))
         self.assertEqual(req.recurrent_pool_idx, running_slot)
         self.assertEqual(cache.component_evictable_size_[ComponentType.RECURRENT][0], 0)
-        self.assertEqual(cache.assert_recurrent_slot_ledger(0), 1)
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=[req]), 1)
 
         full_key = RadixKey(chunk1 + chunk2, None, 0)
         again = cache.match_prefix(MatchPrefixParams(key=full_key, full_only=True))
@@ -1340,6 +1341,41 @@ class TestUnifiedRadixCacheRecurrent(CustomTestCase):
         )
         self.assertEqual(len(match.device_indices), 0)
         self.assertIsNone(req.recurrent_cow_src_index)
+
+    def test_hicache_tombstone_blocks_recurrent_match(self):
+        """hicache x recurrent: a tombstone (FULL on host, recurrent state freed at
+        eviction) stops BOTH walks — no host hit, no CoW src — so the host tier
+        never serves a prefix whose recurrent state is gone."""
+        state_pool, pool, _, cache = self._create_recurrent_setup()
+        key = [1, 2, 3, 4]
+        value = np.arange(100, 104, dtype=np.int32)
+        slot, result = self._commit(cache, pool, key, value)
+        self.assertTrue(result.recurrent_committed)
+
+        probe = cache.match_prefix(MatchPrefixParams(key=RadixKey(key, None, 0)))
+        node = probe.last_device_node
+
+        # Minimal hicache wiring + the tombstone state _evict_device_leaf leaves
+        # behind after a D2H backup (host copy kept, device value + recurrent freed).
+        cache.hicache_enabled = True
+        cache.write_policy = "write_through"
+        node.component_data[ComponentType.FULL].host_value = np.arange(4, dtype=np.int32)
+        tracker = {ct: 0 for ct in cache.tree_components}
+        cache._evict_device_leaf(node, tracker)
+
+        self.assertIsNone(node.component_data[ComponentType.FULL].value)
+        self.assertIsNotNone(node.component_data[ComponentType.FULL].host_value)
+        self.assertIsNone(node.component_data[ComponentType.RECURRENT].value)
+        self.assertEqual(pool.recurrent_available_size(0), pool.slots_per_rank)
+
+        req = _CowReq(dp_rank=0)
+        match = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(key, None, 0), cow_recurrent=True, req=req)
+        )
+        self.assertEqual(len(match.device_indices), 0)
+        self.assertEqual(match.host_hit_length, 0)
+        self.assertIsNone(req.recurrent_cow_src_index)
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0), 0)
 
     def test_shorter_prefix_after_longer_skips_internal(self):
         """Committing on an internal node is skipped (leaf-only); the caller frees the slot."""
@@ -1493,6 +1529,546 @@ class TestUnifiedRadixCacheRecurrent(CustomTestCase):
         # Cross-rank leakage would make global row 3 read 7.0 (or vice versa).
         self.assertEqual(float(rec[3].reshape(-1)[0]), 2.0)
         self.assertEqual(float(rec[8].reshape(-1)[0]), 7.0)
+
+
+class _ExtraBufferReq:
+    """Req surrogate carrying the extra-buffer ping-pong fields, enough to drive
+    RecurrentComponent.prepare/cleanup directly (extra-buffer page>=128 path)."""
+
+    def __init__(self, dp_rank=0):
+        self.dp_rank = dp_rank
+        self.req_pool_idx = None
+        self.recurrent_pool_idx = None
+        self.recurrent_ping_pong_track_buffer = None
+        self.recurrent_next_track_idx = None
+        self.recurrent_last_track_seqlen = None
+        self.recurrent_cow_src_index = None
+
+
+class _AllocReq:
+    """Minimal Req surrogate for ScheduleBatch.alloc_req_slots demand counting
+    (carries the fields HybridReqToTokenPool.alloc reads)."""
+
+    def __init__(self, dp_rank=0, recurrent_pool_idx=None):
+        self.dp_rank = dp_rank
+        self.recurrent_pool_idx = recurrent_pool_idx
+        self.req_pool_idx = None
+        self.is_chunked = 0
+        self.kv_committed_len = 0
+        self.recurrent_ping_pong_track_buffer = None
+        self.recurrent_next_track_idx = None
+        self.recurrent_last_track_seqlen = None
+
+
+class TestUnifiedRadixCacheRecurrentExtraBuffer(CustomTestCase):
+    """Extra-buffer (page>=128) recurrent commit/donation: prepare caps the key at
+    the materialized boundary; cleanup commits the KEEP ping-pong slot (finished)
+    or donates it with a secured replacement (unfinished). Ledger balanced after
+    every transition. Slot-shortfall eviction reclaims 3x the new reqs."""
+
+    def setUp(self):
+        self.max_seq_len = 2048
+        self.dtype = jnp.bfloat16
+        self.pool_size = 8192
+        self.kv_head_num = 8
+        self.head_dim = 64
+        self.layer_num = 2
+        self.recurrent_size = 24  # global recurrent slots (3 per req leaves room)
+        self.rec_num_heads = 8
+        self.rec_head_dim = 16
+        self.conv_kernel_size = 4
+        self.track_interval = 128
+
+    def _create_setup(self, dp_size=1, recurrent_size=None, ping_pong_slots=2):
+        recurrent_size = recurrent_size or self.recurrent_size
+        state_pool = RecurrentStatePool(
+            linear_recurrent_layer_ids=[0, 1],
+            size=recurrent_size,
+            num_heads=self.rec_num_heads,
+            head_dim=self.rec_head_dim,
+            conv_kernel_size=self.conv_kernel_size,
+            mesh=mesh,
+            dp_size=dp_size,
+        )
+        hybrid_pool = HybridReqToTokenPool(
+            size=64,
+            max_context_len=self.max_seq_len,
+            dtype=np.int32,
+            recurrent_state_pool=state_pool,
+            dp_size=dp_size,
+            enable_recurrent_extra_buffer=True,
+            ping_pong_slots=ping_pong_slots,
+        )
+        kv_cache = MHATokenToKVPool(
+            size=self.pool_size,
+            page_size=1,
+            dtype=self.dtype,
+            head_num=self.kv_head_num,
+            head_dim=self.head_dim,
+            layer_num=self.layer_num,
+            mesh=mesh,
+            dp_size=dp_size,
+        )
+        allocator = TokenToKVPoolAllocator(size=self.pool_size, kvcache=kv_cache, dp_size=dp_size)
+        cache = UnifiedRadixCache(
+            req_to_token_pool=hybrid_pool,
+            token_to_kv_pool_allocator=allocator,
+            page_size=1,
+            disable=False,
+            kv_head_num=self.kv_head_num,
+            head_dim=self.head_dim,
+            layer_num=self.layer_num,
+            max_seq_len=self.max_seq_len,
+            dtype=self.dtype,
+            tree_components=(ComponentType.FULL, ComponentType.RECURRENT),
+            enable_recurrent_extra_buffer=True,
+            recurrent_track_interval=self.track_interval,
+        )
+        return state_pool, hybrid_pool, allocator, cache
+
+    @staticmethod
+    def _admit(pool, dp_rank=0):
+        """Allocate a req (running + 2 track slots under extra-buffer)."""
+        req = _ExtraBufferReq(dp_rank=dp_rank)
+        pool.alloc([req])
+        return req
+
+    @staticmethod
+    def _simulate_boundary_scatter(pool, req, final_seq_len):
+        """Mirror _recurrent_track_entry: the scatter writes the slot at
+        next_track_idx, sets the watermark, then flips next_track_idx. The keep
+        slot afterward is the one just written."""
+        idx = req.recurrent_next_track_idx
+        req.recurrent_last_track_seqlen = final_seq_len
+        req.recurrent_next_track_idx = pool.get_recurrent_ping_pong_other_idx(idx)
+        return req.recurrent_ping_pong_track_buffer[idx]
+
+    def _component(self, cache):
+        return cache.components[ComponentType.RECURRENT]
+
+    # --- Case 1: prepare caps the key at the materialized boundary ---
+
+    def test_prepare_returns_watermark_caps_inserted_key(self):
+        _, pool, _, cache = self._create_setup()
+        comp = self._component(cache)
+        req = self._admit(pool)
+        self._simulate_boundary_scatter(pool, req, final_seq_len=256)
+
+        params = InsertParams()
+        cap = comp.prepare_for_caching_req(req, params, token_ids_len=300, is_finished=True)
+        self.assertEqual(cap, 256)
+        self.assertIsNotNone(params.recurrent_value)
+
+    def test_prepare_returns_zero_when_no_boundary(self):
+        _, pool, _, cache = self._create_setup()
+        comp = self._component(cache)
+        req = self._admit(pool)  # recurrent_last_track_seqlen stays None
+        self.assertIsNone(req.recurrent_last_track_seqlen)
+
+        params = InsertParams()
+        cap = comp.prepare_for_caching_req(req, params, token_ids_len=100, is_finished=True)
+        self.assertEqual(cap, 0)
+        self.assertIsNone(params.recurrent_value)
+
+    # --- Case 2: finished commit uses the KEEP slot; cleanup balances ---
+
+    def test_finished_commit_uses_keep_slot_then_frees_running_and_other(self):
+        _, pool, _, cache = self._create_setup()
+        comp = self._component(cache)
+        slots = pool.slots_per_rank
+        req = self._admit(pool)
+        running = req.recurrent_pool_idx
+        keep_slot = self._simulate_boundary_scatter(pool, req, final_seq_len=128)
+        # 3 request-owned slots (running + 2 track), no tree-owned yet.
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=[req]), 3)
+
+        params = InsertParams(
+            key=RadixKey([1, 2, 3, 4], None, 0),
+            value=np.arange(10, 14, dtype=np.int32),
+        )
+        cap = comp.prepare_for_caching_req(req, params, token_ids_len=4, is_finished=True)
+        self.assertEqual(cap, 128)
+        # The donated value is the KEEP slot, NOT the running slot.
+        self.assertEqual(int(params.recurrent_value[0]), keep_slot)
+        self.assertNotEqual(int(params.recurrent_value[0]), running)
+
+        result = cache.insert(params)
+        self.assertTrue(result.recurrent_committed)
+        comp.cleanup_after_caching_req(
+            req, is_finished=True, insert_result=result, insert_params=params
+        )
+
+        # Tree owns the keep slot; running + other track slot freed. Net: 1 tree + 2 free.
+        self.assertIsNone(req.recurrent_pool_idx)
+        self.assertIsNone(req.recurrent_ping_pong_track_buffer)
+        self.assertEqual(cache.component_evictable_size_[ComponentType.RECURRENT][0], 1)
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=[req]), 0)
+        self.assertEqual(pool.recurrent_available_size(0), slots - 1)
+
+    def test_finished_not_committed_frees_running_and_both_track(self):
+        _, pool, _, cache = self._create_setup()
+        comp = self._component(cache)
+        slots = pool.slots_per_rank
+        # Pre-commit a leaf so the same key is a duplicate (recurrent_exist).
+        seed = self._admit(pool)
+        self._simulate_boundary_scatter(pool, seed, final_seq_len=128)
+        seed_params = InsertParams(
+            key=RadixKey([1, 2, 3, 4], None, 0), value=np.arange(10, 14, dtype=np.int32)
+        )
+        comp.prepare_for_caching_req(seed, seed_params, token_ids_len=4, is_finished=True)
+        seed_res = cache.insert(seed_params)
+        comp.cleanup_after_caching_req(
+            seed, is_finished=True, insert_result=seed_res, insert_params=seed_params
+        )
+        self.assertEqual(pool.recurrent_available_size(0), slots - 1)
+
+        req = self._admit(pool)
+        self._simulate_boundary_scatter(pool, req, final_seq_len=128)
+        params = InsertParams(
+            key=RadixKey([1, 2, 3, 4], None, 0), value=np.arange(10, 14, dtype=np.int32)
+        )
+        comp.prepare_for_caching_req(req, params, token_ids_len=4, is_finished=True)
+        result = cache.insert(params)
+        # Duplicate of the existing leaf: not re-committed.
+        self.assertFalse(result.recurrent_committed)
+        comp.cleanup_after_caching_req(
+            req, is_finished=True, insert_result=result, insert_params=params
+        )
+
+        # All 3 request-owned slots freed; only the seed leaf remains tree-owned.
+        self.assertIsNone(req.recurrent_ping_pong_track_buffer)
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=[req]), 0)
+        self.assertEqual(pool.recurrent_available_size(0), slots - 1)
+
+    # --- Case 3: unfinished donation keeps running live, allocates replacement ---
+
+    def test_unfinished_donation_secures_replacement_and_clears_watermark(self):
+        _, pool, _, cache = self._create_setup()
+        comp = self._component(cache)
+        slots = pool.slots_per_rank
+        req = self._admit(pool)
+        running = req.recurrent_pool_idx
+        keep_slot = self._simulate_boundary_scatter(pool, req, final_seq_len=128)
+        other_slot = next(s for s in req.recurrent_ping_pong_track_buffer if s != keep_slot)
+        free_before = pool.recurrent_available_size(0)
+
+        params = InsertParams(
+            key=RadixKey([5, 6, 7, 8], None, 0), value=np.arange(20, 24, dtype=np.int32)
+        )
+        cap = comp.prepare_for_caching_req(req, params, token_ids_len=4, is_finished=False)
+        self.assertEqual(cap, 128)
+        # Donated value is the keep slot; a fresh replacement took its buffer place.
+        self.assertEqual(int(params.recurrent_value[0]), keep_slot)
+        self.assertNotIn(keep_slot, req.recurrent_ping_pong_track_buffer)
+        self.assertIn(other_slot, req.recurrent_ping_pong_track_buffer)
+        # Replacement consumed one free slot; running slot untouched.
+        self.assertEqual(pool.recurrent_available_size(0), free_before - 1)
+        self.assertEqual(req.recurrent_pool_idx, running)
+
+        result = cache.insert(params)
+        self.assertTrue(result.recurrent_committed)
+        comp.cleanup_after_caching_req(
+            req, is_finished=False, insert_result=result, insert_params=params
+        )
+
+        # Tree owns the donated slot; the request keeps running + 2 track slots.
+        self.assertIsNone(req.recurrent_last_track_seqlen)
+        self.assertEqual(req.recurrent_pool_idx, running)
+        self.assertEqual(len([s for s in req.recurrent_ping_pong_track_buffer if s]), 2)
+        self.assertEqual(cache.component_evictable_size_[ComponentType.RECURRENT][0], 1)
+        # active = running(1) + 2 track = 3; tree_owned=1; free = slots - 4.
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=[req]), 3)
+        self.assertEqual(pool.recurrent_available_size(0), slots - 4)
+
+    # --- Case 4: unfinished donation NOT committed → free orphan, clear watermark ---
+
+    def test_unfinished_donation_not_committed_frees_orphan(self):
+        _, pool, _, cache = self._create_setup()
+        comp = self._component(cache)
+        slots = pool.slots_per_rank
+        # Pre-commit a leaf so the unfinished re-donation of the same key is a dup.
+        seed = self._admit(pool)
+        self._simulate_boundary_scatter(pool, seed, final_seq_len=128)
+        seed_params = InsertParams(
+            key=RadixKey([5, 6, 7, 8], None, 0), value=np.arange(20, 24, dtype=np.int32)
+        )
+        comp.prepare_for_caching_req(seed, seed_params, token_ids_len=4, is_finished=True)
+        seed_res = cache.insert(seed_params)
+        comp.cleanup_after_caching_req(
+            seed, is_finished=True, insert_result=seed_res, insert_params=seed_params
+        )
+
+        req = self._admit(pool)
+        running = req.recurrent_pool_idx
+        keep_slot = self._simulate_boundary_scatter(pool, req, final_seq_len=128)
+        params = InsertParams(
+            key=RadixKey([5, 6, 7, 8], None, 0), value=np.arange(20, 24, dtype=np.int32)
+        )
+        cap = comp.prepare_for_caching_req(req, params, token_ids_len=4, is_finished=False)
+        self.assertEqual(cap, 128)
+        donated = int(params.recurrent_value[0])
+        self.assertEqual(donated, keep_slot)
+        result = cache.insert(params)
+        self.assertFalse(result.recurrent_committed)  # duplicate of the seed leaf
+        free_before = pool.recurrent_available_size(0)
+        comp.cleanup_after_caching_req(
+            req, is_finished=False, insert_result=result, insert_params=params
+        )
+
+        # The orphaned donated slot is freed; watermark cleared; request keeps
+        # running + 2 (replacement + other) track slots.
+        self.assertEqual(pool.recurrent_available_size(0), free_before + 1)
+        self.assertIn(donated, pool.recurrent_free_slots[0])
+        self.assertIsNone(req.recurrent_last_track_seqlen)
+        self.assertEqual(req.recurrent_pool_idx, running)
+        self.assertEqual(len([s for s in req.recurrent_ping_pong_track_buffer if s]), 2)
+        # active = running + 2 track = 3; only the seed leaf is tree-owned.
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=[req]), 3)
+        _ = slots  # capacity sanity already covered by the ledger assertion
+
+    # --- Case 5: replacement alloc fails (all locked) → donation skipped ---
+
+    def test_unfinished_replacement_alloc_fails_skips_donation(self):
+        # Size 3: exactly one req's worth of slots, so after admission the free
+        # list is empty and there is no tree leaf to evict for a replacement.
+        _, pool, _, cache = self._create_setup(recurrent_size=3)
+        comp = self._component(cache)
+        req = self._admit(pool)
+        keep_slot = self._simulate_boundary_scatter(pool, req, final_seq_len=128)
+        self.assertEqual(pool.recurrent_available_size(0), 0)
+        buffer_before = list(req.recurrent_ping_pong_track_buffer)
+
+        params = InsertParams(
+            key=RadixKey([9, 10, 11, 12], None, 0), value=np.arange(30, 34, dtype=np.int32)
+        )
+        cap = comp.prepare_for_caching_req(req, params, token_ids_len=4, is_finished=False)
+        # Replacement unavailable → donation skipped: returns 0, buffer + watermark intact.
+        self.assertEqual(cap, 0)
+        self.assertIsNone(params.recurrent_value)
+        self.assertEqual(req.recurrent_ping_pong_track_buffer, buffer_before)
+        self.assertIn(keep_slot, req.recurrent_ping_pong_track_buffer)
+        self.assertEqual(req.recurrent_last_track_seqlen, 128)
+
+        # Cleanup with no commit + no donation: frees nothing, leaves req intact.
+        comp.cleanup_after_caching_req(
+            req, is_finished=False, insert_result=None, insert_params=params
+        )
+        self.assertEqual(req.recurrent_last_track_seqlen, 128)
+        self.assertEqual(req.recurrent_ping_pong_track_buffer, buffer_before)
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=[req]), 3)
+
+    # --- Case 6: alloc_req_slots evicts the exact 3x shortfall ---
+
+    def _seed_tree_leaves(self, comp, cache, pool, keys, dp_rank=0):
+        """Commit one finished extra-buffer req per key, leaving each as a
+        tree-owned leaf the eviction can reclaim."""
+        for i, key in enumerate(keys):
+            req = self._admit(pool, dp_rank=dp_rank)
+            self._simulate_boundary_scatter(pool, req, final_seq_len=128)
+            params = InsertParams(
+                key=RadixKey(list(key), None, dp_rank),
+                value=np.arange(100 + i * 10, 100 + i * 10 + len(key), dtype=np.int32),
+            )
+            comp.prepare_for_caching_req(req, params, token_ids_len=len(key), is_finished=True)
+            res = cache.insert(params)
+            comp.cleanup_after_caching_req(
+                req, is_finished=True, insert_result=res, insert_params=params
+            )
+
+    def _make_batch(self, cache, pool, allocator, reqs):
+        from sgl_jax.srt.managers.schedule_batch import ScheduleBatch
+
+        return ScheduleBatch(
+            reqs_info=[],
+            req_to_token_pool=pool,
+            token_to_kv_pool_allocator=allocator,
+            tree_cache=cache,
+            is_hybrid_recurrent=True,
+        )
+
+    def test_alloc_req_slots_evicts_exact_three_x_shortfall_dp1(self):
+        _, pool, allocator, cache = self._create_setup(recurrent_size=12)  # 12 slots/rank
+        comp = self._component(cache)
+        slots = pool.slots_per_rank
+        # Fill the free list with tree leaves: 4 leaves use 4 slots, leaving 8 free.
+        self._seed_tree_leaves(comp, cache, pool, [[1, 2], [3, 4], [5, 6], [7, 8]])
+        self.assertEqual(pool.recurrent_available_size(0), slots - 4)  # 8 free
+        self.assertEqual(cache.component_evictable_size_[ComponentType.RECURRENT][0], 4)
+
+        # 3 new reqs → demand = 9 > 8 free → evict exactly 1 leaf.
+        batch = self._make_batch(cache, pool, allocator, None)
+        reqs = [_AllocReq(dp_rank=0) for _ in range(3)]
+        batch.alloc_req_slots(reqs)
+
+        # Exactly one leaf evicted; the 3 reqs each got running + 2 track (9 slots).
+        self.assertEqual(cache.component_evictable_size_[ComponentType.RECURRENT][0], 3)
+        for r in reqs:
+            self.assertIsNotNone(r.recurrent_pool_idx)
+            self.assertEqual(len(r.recurrent_ping_pong_track_buffer), 2)
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=reqs), 9)
+
+    def test_alloc_req_slots_evicts_exact_three_x_shortfall_dp2(self):
+        _, pool, allocator, cache = self._create_setup(dp_size=2, recurrent_size=24)
+        comp = self._component(cache)
+        slots = pool.slots_per_rank  # 12 per rank
+        # Seed 4 leaves on rank 1 only (rank 0 stays empty).
+        self._seed_tree_leaves(comp, cache, pool, [[1, 2], [3, 4], [5, 6], [7, 8]], dp_rank=1)
+        self.assertEqual(pool.recurrent_available_size(1), slots - 4)
+        self.assertEqual(cache.component_evictable_size_[ComponentType.RECURRENT][1], 4)
+
+        batch = self._make_batch(cache, pool, allocator, None)
+        reqs = [_AllocReq(dp_rank=1) for _ in range(3)]  # demand 9 > 8 free → evict 1
+        batch.alloc_req_slots(reqs)
+
+        self.assertEqual(cache.component_evictable_size_[ComponentType.RECURRENT][1], 3)
+        self.assertEqual(cache.assert_recurrent_slot_ledger(1, live_reqs=reqs), 9)
+        # Rank 0 untouched.
+        self.assertEqual(pool.recurrent_available_size(0), slots)
+
+    def test_alloc_req_slots_no_evict_when_enough_free(self):
+        _, pool, allocator, cache = self._create_setup(recurrent_size=12)
+        comp = self._component(cache)
+        self._seed_tree_leaves(comp, cache, pool, [[1, 2]])  # 1 leaf, 11 free
+        leaves_before = cache.component_evictable_size_[ComponentType.RECURRENT][0]
+
+        batch = self._make_batch(cache, pool, allocator, None)
+        reqs = [_AllocReq(dp_rank=0) for _ in range(3)]  # demand 9 <= 11 free
+        batch.alloc_req_slots(reqs)
+
+        # No eviction: enough free slots already.
+        self.assertEqual(cache.component_evictable_size_[ComponentType.RECURRENT][0], leaves_before)
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=reqs), 9)
+
+    def test_alloc_req_slots_recurrent_oom_reports_recurrent_pool(self):
+        # Pool too small with nothing evictable: the recurrent pre-check fails and
+        # the raise must name the recurrent pool (not the base req-pool size).
+        _, pool, allocator, cache = self._create_setup(recurrent_size=4)  # 4 slots, per_req 3
+        batch = self._make_batch(cache, pool, allocator, None)
+        reqs = [_AllocReq(dp_rank=0) for _ in range(2)]  # demand 6 > 4, nothing to evict
+        with self.assertRaises(RuntimeError) as cm:
+            batch.alloc_req_slots(reqs)
+        self.assertIn("recurrent_available", str(cm.exception))
+        self.assertIn("request_owned_slots", str(cm.exception))
+
+    # --- Single-slot ping-pong (overlap-off): donate/cleanup orchestration when
+    #     the keep slot IS the only track slot (keep == next == 0) ---
+
+    def test_single_slot_admit_owns_running_plus_one_track(self):
+        _, pool, _, cache = self._create_setup(ping_pong_slots=1)
+        req = self._admit(pool)
+        self.assertEqual(len(req.recurrent_ping_pong_track_buffer), 1)
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=[req]), 2)
+
+    def test_single_slot_finished_committed_tree_owns_sole_slot(self):
+        _, pool, _, cache = self._create_setup(ping_pong_slots=1)
+        comp = self._component(cache)
+        slots = pool.slots_per_rank
+        req = self._admit(pool)
+        keep_slot = self._simulate_boundary_scatter(pool, req, final_seq_len=128)
+        params = InsertParams(
+            key=RadixKey([1, 2, 3, 4], None, 0), value=np.arange(10, 14, dtype=np.int32)
+        )
+        cap = comp.prepare_for_caching_req(req, params, token_ids_len=4, is_finished=True)
+        self.assertEqual(cap, 128)
+        self.assertEqual(int(params.recurrent_value[0]), keep_slot)
+        result = cache.insert(params)
+        self.assertTrue(result.recurrent_committed)
+        comp.cleanup_after_caching_req(
+            req, is_finished=True, insert_result=result, insert_params=params
+        )
+        # Net of the 2 owned slots: 1 tree-owned + 1 freed.
+        self.assertEqual(cache.component_evictable_size_[ComponentType.RECURRENT][0], 1)
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=[req]), 0)
+        self.assertEqual(pool.recurrent_available_size(0), slots - 1)
+
+    def test_single_slot_unfinished_committed_secures_replacement(self):
+        _, pool, _, cache = self._create_setup(ping_pong_slots=1)
+        comp = self._component(cache)
+        req = self._admit(pool)
+        running = req.recurrent_pool_idx
+        keep_slot = self._simulate_boundary_scatter(pool, req, final_seq_len=128)
+        free_before = pool.recurrent_available_size(0)
+        params = InsertParams(
+            key=RadixKey([5, 6, 7, 8], None, 0), value=np.arange(20, 24, dtype=np.int32)
+        )
+        cap = comp.prepare_for_caching_req(req, params, token_ids_len=4, is_finished=False)
+        self.assertEqual(cap, 128)
+        self.assertEqual(int(params.recurrent_value[0]), keep_slot)
+        # The donated slot left the buffer; a fresh replacement is the sole slot.
+        self.assertEqual(len(req.recurrent_ping_pong_track_buffer), 1)
+        self.assertNotIn(keep_slot, req.recurrent_ping_pong_track_buffer)
+        self.assertEqual(pool.recurrent_available_size(0), free_before - 1)
+        self.assertEqual(req.recurrent_pool_idx, running)
+        result = cache.insert(params)
+        self.assertTrue(result.recurrent_committed)
+        comp.cleanup_after_caching_req(
+            req, is_finished=False, insert_result=result, insert_params=params
+        )
+        self.assertIsNone(req.recurrent_last_track_seqlen)
+        self.assertEqual(req.recurrent_pool_idx, running)
+        # active = running + 1 track = 2; tree_owned = 1.
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=[req]), 2)
+
+    def test_single_slot_unfinished_not_committed_frees_orphan(self):
+        _, pool, _, cache = self._create_setup(ping_pong_slots=1)
+        comp = self._component(cache)
+        # Seed a leaf so the same key is a duplicate (not re-committed).
+        seed = self._admit(pool)
+        self._simulate_boundary_scatter(pool, seed, final_seq_len=128)
+        seed_params = InsertParams(
+            key=RadixKey([5, 6, 7, 8], None, 0), value=np.arange(20, 24, dtype=np.int32)
+        )
+        comp.prepare_for_caching_req(seed, seed_params, token_ids_len=4, is_finished=True)
+        seed_res = cache.insert(seed_params)
+        comp.cleanup_after_caching_req(
+            seed, is_finished=True, insert_result=seed_res, insert_params=seed_params
+        )
+
+        req = self._admit(pool)
+        running = req.recurrent_pool_idx
+        keep_slot = self._simulate_boundary_scatter(pool, req, final_seq_len=128)
+        params = InsertParams(
+            key=RadixKey([5, 6, 7, 8], None, 0), value=np.arange(20, 24, dtype=np.int32)
+        )
+        comp.prepare_for_caching_req(req, params, token_ids_len=4, is_finished=False)
+        donated = int(params.recurrent_value[0])
+        self.assertEqual(donated, keep_slot)
+        result = cache.insert(params)
+        self.assertFalse(result.recurrent_committed)  # duplicate of the seed leaf
+        free_before = pool.recurrent_available_size(0)
+        comp.cleanup_after_caching_req(
+            req, is_finished=False, insert_result=result, insert_params=params
+        )
+        # Orphaned donated slot freed; watermark cleared; req keeps running + 1 track.
+        self.assertEqual(pool.recurrent_available_size(0), free_before + 1)
+        self.assertIn(donated, pool.recurrent_free_slots[0])
+        self.assertIsNone(req.recurrent_last_track_seqlen)
+        self.assertEqual(req.recurrent_pool_idx, running)
+        self.assertEqual(cache.assert_recurrent_slot_ledger(0, live_reqs=[req]), 2)
+
+    def test_single_slot_replacement_alloc_fails_skips_donation(self):
+        # Size 2: exactly one req's worth (running + 1 track), so no free slot and
+        # no evictable leaf for a replacement.
+        _, pool, _, cache = self._create_setup(recurrent_size=2, ping_pong_slots=1)
+        comp = self._component(cache)
+        req = self._admit(pool)
+        keep_slot = self._simulate_boundary_scatter(pool, req, final_seq_len=128)
+        self.assertEqual(pool.recurrent_available_size(0), 0)
+        buffer_before = list(req.recurrent_ping_pong_track_buffer)
+        params = InsertParams(
+            key=RadixKey([9, 10, 11, 12], None, 0), value=np.arange(30, 34, dtype=np.int32)
+        )
+        cap = comp.prepare_for_caching_req(req, params, token_ids_len=4, is_finished=False)
+        # Replacement unavailable → donation skipped: buffer + watermark intact.
+        self.assertEqual(cap, 0)
+        self.assertIsNone(params.recurrent_value)
+        self.assertEqual(req.recurrent_ping_pong_track_buffer, buffer_before)
+        self.assertIn(keep_slot, req.recurrent_ping_pong_track_buffer)
+        self.assertEqual(req.recurrent_last_track_seqlen, 128)
+        comp.cleanup_after_caching_req(
+            req, is_finished=False, insert_result=None, insert_params=params
+        )
+        self.assertEqual(req.recurrent_ping_pong_track_buffer, buffer_before)
 
 
 if __name__ == "__main__":

--- a/python/sgl_jax/test/test_gdn_attention.py
+++ b/python/sgl_jax/test/test_gdn_attention.py
@@ -733,30 +733,85 @@ class TestGDNAttention(unittest.TestCase):
             )
             pool.replace_buffer(([recurrent_buffer], [conv_buffer_list]))
 
-    def test_recurrent_cow_copy_equivalence(self):
-        """copy_slots clones a prefilled recurrent+conv state bitwise into another slot."""
-        layer, pool, rec_idx, rec_buf, conv_buf_list = self.run_test("prefill", [128])
-        pool.replace_buffer(([rec_buf], [conv_buf_list]))
+    # NOTE: copy_slots equivalence is backend-agnostic; it is covered at the
+    # pool/cache level (test_unified_radix_cache.py::test_copy_slots_bitwise_clone_all_layers
+    # and ::test_copy_slots_multi_dp_locality) and via the KDA attention copy
+    # (test_kda_attention.py::test_recurrent_cow_copy_equivalence). The
+    # backend-specific track-scatter test below is kept.
 
-        src = int(np.asarray(rec_idx).reshape(-1)[0])
-        dst = src + 1 if src + 1 < pool.total_slots else 1
+    def test_track_scatter_equivalence(self):
+        """Recurrent track writeback: a prefill that lands on a track boundary
+        scatters the SAME final state into the request's track slot AND its
+        running slot. Assert the track slot equals the running slot bitwise
+        (synthetic weights, no checkpoint). Controller-validated on TPU.
+
+        Uses a pool sized larger than the batch so distinct free track slots
+        exist (``create_test_data`` ties pool size to batch size)."""
+        seq_lens = [64, 32]
+        batch_size = len(seq_lens)
+        (
+            forward_batch,
+            _pool,
+            layer,
+            q,
+            k,
+            v,
+            a,
+            b,
+            _initial_ssm_ref,
+            _initial_conv_ref,
+            recurrent_indices,
+        ) = create_test_data(
+            "prefill",
+            seq_lens,
+            self.NUM_K_HEADS,
+            self.NUM_V_HEADS,
+            self.HEAD_K_DIM,
+            self.HEAD_V_DIM,
+            self.CONV_KERNEL_SIZE,
+            self.DTYPE,
+            self.rng,
+        )
+        pool = RecurrentStatePool(
+            linear_recurrent_layer_ids=[layer.layer_id],
+            size=8,
+            num_heads=self.NUM_V_HEADS,
+            head_dim=self.HEAD_V_DIM,
+            conv_kernel_size=self.CONV_KERNEL_SIZE,
+            mesh=mesh,
+            dp_size=1,
+            recurrent_partition_axis="tensor",
+            conv_partition_axis="tensor",
+            data_partition_axis="data",
+            temporal_dtype=jnp.float32,
+            conv_dtype=self.DTYPE,
+            num_k_heads=self.NUM_K_HEADS,
+            head_k_dim=self.HEAD_K_DIM,
+        )
+        running = np.asarray(recurrent_indices)  # [1, 2]
+        track = running + batch_size  # [3, 4] (free slots)
         data_sh = NamedSharding(mesh, P("data"))
-        src_arr = jax.device_put(np.array([src], dtype=np.int32), data_sh)
-        dst_arr = jax.device_put(np.array([dst], dtype=np.int32), data_sh)
-        new_rec, new_conv = jax.jit(pool.copy_slots)(src_arr, dst_arr)
-        pool.replace_buffer((new_rec, new_conv))
+        md = forward_batch.attn_backend.forward_metadata
+        md.recurrent_track_indices = jax.device_put(track.astype(np.int32), data_sh)
+        md.recurrent_track_mask = jax.device_put(np.ones(batch_size, dtype=np.int32), data_sh)
 
-        src_idx = np.array([src], dtype=np.int32)
-        dst_idx = np.array([dst], dtype=np.int32)
-        for layer_idx in range(pool.num_linear_recurrent_layers):
-            np.testing.assert_array_equal(
-                np.asarray(gather_ssm(pool, pool.recurrent_buffers[layer_idx], dst_idx)),
-                np.asarray(gather_ssm(pool, pool.recurrent_buffers[layer_idx], src_idx)),
-            )
-            np.testing.assert_array_equal(
-                np.asarray(gather_conv(pool, pool.conv_buffers[layer_idx][0], dst_idx)),
-                np.asarray(gather_conv(pool, pool.conv_buffers[layer_idx][0], src_idx)),
-            )
+        key_sharding = NamedSharding(mesh, P("data", "tensor"))
+        head_sharding = NamedSharding(mesh, P("data", "tensor"))
+        _, (recurrent_buffer, conv_buffer_list) = layer(
+            forward_batch,
+            jax.device_put(q, key_sharding),
+            jax.device_put(k, key_sharding),
+            jax.device_put(v, key_sharding),
+            jax.device_put(a, head_sharding),
+            jax.device_put(b, head_sharding),
+            pool,
+        )
+        run_ssm = np.asarray(gather_ssm(pool, recurrent_buffer, running))
+        trk_ssm = np.asarray(gather_ssm(pool, recurrent_buffer, track))
+        run_conv = np.asarray(gather_conv(pool, conv_buffer_list[0], running))
+        trk_conv = np.asarray(gather_conv(pool, conv_buffer_list[0], track))
+        np.testing.assert_array_equal(trk_ssm, run_ssm)
+        np.testing.assert_array_equal(trk_conv, run_conv)
 
 
 if __name__ == "__main__":

--- a/python/sgl_jax/test/test_kda_attention.py
+++ b/python/sgl_jax/test/test_kda_attention.py
@@ -640,6 +640,85 @@ class TestKDAAttention(unittest.TestCase):
                 np.asarray(gather_conv(pool, pool.conv_buffers[layer_idx][0], src_idx)),
             )
 
+    def test_track_scatter_equivalence(self):
+        """Recurrent track writeback: a prefill that lands on a track boundary
+        scatters the SAME final state into the request's track slot AND its
+        running slot. Assert the track slot equals the running slot bitwise
+        (synthetic weights, no checkpoint). Controller-validated on TPU.
+
+        Uses a pool sized larger than the batch so distinct free track slots
+        exist (``create_test_data`` ties pool size to batch size, leaving no
+        spare slot)."""
+        # Pin the 4-device mesh for the whole test via jax.set_mesh (the
+        # codebase-standard context, see moe.py / weight_utils). This keeps the
+        # test correct even when another test module's import-time set_mesh has
+        # left a different global mesh active (e.g. test_gdn_attention sets a
+        # single-device mesh); CI already isolates files in separate subprocesses.
+        with jax.set_mesh(mesh):
+            seq_lens = [64, 32]
+            batch_size = len(seq_lens)
+            (
+                forward_batch,
+                _pool,
+                layer,
+                q,
+                k,
+                v,
+                a,
+                b,
+                _initial_ssm_ref,
+                _initial_conv_ref,
+                recurrent_indices,
+            ) = create_test_data(
+                "prefill",
+                seq_lens,
+                self.NUM_HEADS,
+                self.HEAD_DIM,
+                self.CONV_KERNEL_SIZE,
+                self.DTYPE,
+                self.rng,
+            )
+            # Fresh, larger pool so track slots are distinct free slots. Fresh
+            # prefill (has_initial_state=False) needs no initial-state write.
+            pool = RecurrentStatePool(
+                linear_recurrent_layer_ids=[layer.layer_id],
+                size=8,
+                num_heads=self.NUM_HEADS,
+                head_dim=self.HEAD_DIM,
+                conv_kernel_size=self.CONV_KERNEL_SIZE,
+                mesh=mesh,
+                dp_size=1,
+                recurrent_partition_axis="tensor",
+                conv_partition_axis="tensor",
+                data_partition_axis="data",
+                temporal_dtype=jnp.float32,
+                conv_dtype=self.DTYPE,
+            )
+            running = np.asarray(recurrent_indices)  # [1, 2]
+            track = running + batch_size  # [3, 4] (free slots)
+            data_sh = NamedSharding(mesh, P("data"))
+            md = forward_batch.attn_backend.forward_metadata
+            md.recurrent_track_indices = jax.device_put(track.astype(np.int32), data_sh)
+            md.recurrent_track_mask = jax.device_put(np.ones(batch_size, dtype=np.int32), data_sh)
+
+            hidden_sharding = NamedSharding(mesh, P("data", "tensor"))
+            head_sharding = NamedSharding(mesh, P("data", "tensor"))
+            _, (recurrent_buffer, conv_buffer_list) = layer(
+                forward_batch,
+                jax.device_put(q, hidden_sharding),
+                jax.device_put(k, hidden_sharding),
+                jax.device_put(v, hidden_sharding),
+                jax.device_put(a, hidden_sharding),
+                jax.device_put(b, head_sharding),
+                pool,
+            )
+            run_ssm = np.asarray(gather_ssm(pool, recurrent_buffer, running))
+            trk_ssm = np.asarray(gather_ssm(pool, recurrent_buffer, track))
+            run_conv = np.asarray(gather_conv(pool, conv_buffer_list[0], running))
+            trk_conv = np.asarray(gather_conv(pool, conv_buffer_list[0], track))
+        np.testing.assert_array_equal(trk_ssm, run_ssm)
+        np.testing.assert_array_equal(trk_conv, run_conv)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/sgl_jax/test/test_mixed_chunk_dp.py
+++ b/python/sgl_jax/test/test_mixed_chunk_dp.py
@@ -24,6 +24,9 @@ class _DummyRadixCache:
 
     disable = False
 
+    def recurrent_extra_buffer_active(self) -> bool:
+        return False
+
     def evictable_size(self, dp_rank: int = 0):
         return 0
 

--- a/python/sgl_jax/test/test_utils.py
+++ b/python/sgl_jax/test/test_utils.py
@@ -142,7 +142,7 @@ QWEN_7B = _local_or_hf("Qwen/Qwen-7B")
 QWEN3_4B = _local_or_hf("Qwen/Qwen3-4B")
 
 QWEN3_MOE_30B = _local_or_hf("Qwen/Qwen3-30B-A3B")
-QWEN3_5_35B_A3B = "/models/Qwen3.5-35B-A3B/"
+QWEN3_5_35B_A3B = _local_or_hf("Qwen/Qwen3.5-35B-A3B")
 QWEN3_5_27B = "/models/Qwen3.5-27B/"
 QWEN2_5_7B_INSTRUCT = _local_or_hf("Qwen/Qwen2.5-7B-Instruct")
 QWEN3_CODER_30B_A3B_INSTRUCT = _local_or_hf("Qwen/Qwen3-Coder-30B-A3B-Instruct")

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -329,6 +329,8 @@ suites = {
         TestFile("test/srt/test_dp_schedule_policy.py", 0.2, runner="pytest"),
         TestFile("test/srt/test_dp_schedule_shape_aware.py", 0.2, runner="pytest"),
         TestFile("test/srt/test_dp_rank_assignment.py", 0.2, runner="pytest"),
+        TestFile("test/srt/test_bench_recurrent_reuse_sweep.py", 0.2, runner="pytest"),
+        TestFile("python/sgl_jax/test/test_mixed_chunk_dp.py", 0.2),
         TestFile("test/srt/function_call/test_qwen3_coder_detector.py", 0.1),
         TestFile("test/srt/function_call/test_glm4_moe_detector.py", 0.1),
         TestFile("test/srt/function_call/test_qwen25_detector.py", 0.1),
@@ -341,6 +343,11 @@ suites = {
         TestFile("test/srt/eval/test_simple_eval_common.py", 0.1, runner="pytest"),
         TestFile("test/srt/test_server_info.py", 0.1),
         TestFile("test/srt/test_recurrent_cow_metadata.py", 0.2),
+        TestFile("test/srt/test_recurrent_track_metadata.py", 0.2),
+        TestFile("test/srt/test_recurrent_boundary_split.py", 0.2),
+        TestFile("test/srt/test_recurrent_state_sizing.py", 0.2),
+        TestFile("test/srt/test_recurrent_track_scatter.py", 0.3),
+        TestFile("test/srt/test_recurrent_split_equivalence.py", 0.3),
         TestFile("test/srt/test_prepare_for_extend_protected_len.py", 0.2),
     ],
     "unit-test-tpu-v6e-4": [
@@ -400,7 +407,14 @@ suites = {
         TestFile("test/srt/lora/test_bgmv_backend.py", 6),
         TestFile("test/srt/lora/test_dynamic_lora.py", 10),
         TestFile("test/srt/lora/test_static_lora.py", 10),
-        TestFile("test/srt/test_unified_radix_cache_serving.py", 8),
+        # Dense (non-hybrid) class only. The recurrent (GDN-hybrid) class is a
+        # heavy 4-chip / 35B determinism run kept out of per-PR CI (nightly
+        # recurrent gate: #1425).
+        TestFile(
+            "test/srt/test_unified_radix_cache_serving.py",
+            8,
+            ["TestUnifiedRadixCacheServing"],
+        ),
     ],
     "e2e-test-tpu-v6e-4": [
         TestFile("test/srt/openai_server/basic/test_tool_calls.py", 2),

--- a/test/srt/test_bench_recurrent_reuse_sweep.py
+++ b/test/srt/test_bench_recurrent_reuse_sweep.py
@@ -1,0 +1,80 @@
+"""CPU tests for the bench_recurrent_reuse_sweep knee math (predict_knee /
+derive_actual_C_rank / detect_knee); loaded by file path (benchmark/ is off the
+package path)."""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Make sgl_jax importable when the package is not installed (CPU dev box).
+_PKG_DIR = os.path.join(_REPO_ROOT, "python")
+if _PKG_DIR not in sys.path:
+    sys.path.insert(0, _PKG_DIR)
+
+_BENCH_PATH = os.path.join(_REPO_ROOT, "benchmark", "hicache", "bench_recurrent_reuse_sweep.py")
+
+
+def _load_bench_module():
+    spec = importlib.util.spec_from_file_location("bench_recurrent_reuse_sweep", _BENCH_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestPredictKnee(unittest.TestCase):
+    def setUp(self):
+        self.bench = _load_bench_module()
+
+    def test_spec_example(self):
+        """Doc example: size=192, dp=4, C_rank=4, owned=3 -> S_rank=48, 4*(48-12)=144."""
+        self.assertEqual(self.bench.predict_knee(192, dp_size=4, C_rank=4), 144.0)
+
+    def test_owned_slots_scale_reservation(self):
+        """request_owned_slots multiplies the per-rank consumption: overlap-off
+        (owned=2) raises the knee: 4*(48 - 2*4) = 160."""
+        self.assertEqual(self.bench.predict_knee(192, 4, C_rank=4, request_owned_slots=2), 160.0)
+
+    def test_snapshots_per_prefix_divides_knee(self):
+        """More snapshots per prefix -> fewer distinct prefixes fit -> lower K*."""
+        base = self.bench.predict_knee(192, 4, C_rank=4, snapshots_per_prefix=1)
+        self.assertEqual(
+            self.bench.predict_knee(192, 4, C_rank=4, snapshots_per_prefix=2), base / 2
+        )
+
+
+class TestDeriveActualCRank(unittest.TestCase):
+    def setUp(self):
+        self.bench = _load_bench_module()
+
+    def test_spread_over_dp(self):
+        """parallel spread over DP ranks: 16 / 4 = 4 concurrent per rank."""
+        self.assertEqual(self.bench.derive_actual_C_rank(parallel=16, dp_size=4), 4.0)
+
+    def test_floor_of_one(self):
+        """At least one in-flight request per rank is reserved (max(1, ...))."""
+        self.assertEqual(self.bench.derive_actual_C_rank(parallel=2, dp_size=8), 1.0)
+
+
+class TestDetectKnee(unittest.TestCase):
+    def setUp(self):
+        self.bench = _load_bench_module()
+
+    @staticmethod
+    def _curve(pairs):
+        return [{"K": k, "reuse_frac": f} for k, f in pairs]
+
+    def test_knee_at_plateau_edge(self):
+        """Largest K still within plateau_frac * peak is the knee."""
+        curve = self._curve([(8, 0.5), (16, 0.5), (32, 0.2), (64, 0.05)])
+        self.assertEqual(self.bench.detect_knee(curve, plateau_frac=0.9), 16)
+
+    def test_no_reuse_returns_none(self):
+        """Peak reuse ~0 (no-cache / broken / all-miss) has no knee, not max K."""
+        curve = self._curve([(8, 0.0), (16, 0.0), (32, 0.0)])
+        self.assertIsNone(self.bench.detect_knee(curve, plateau_frac=0.9))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_bench_unified_radix_ab_args.py
+++ b/test/srt/test_bench_unified_radix_ab_args.py
@@ -1,0 +1,108 @@
+"""CPU smoke tests for the bench_unified_radix_ab arg layer (parsing, external-server
+single-config assertion, dense default config) -- no server; loaded by file path.
+Manual-only: not registered in run_suite.py."""
+
+import importlib.util
+import os
+import sys
+import unittest
+from unittest import mock
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Make sgl_jax importable when the package is not installed (CPU dev box).
+_PKG_DIR = os.path.join(_REPO_ROOT, "python")
+if _PKG_DIR not in sys.path:
+    sys.path.insert(0, _PKG_DIR)
+
+_BENCH_PATH = os.path.join(_REPO_ROOT, "benchmark", "hicache", "bench_unified_radix_ab.py")
+
+
+def _load_bench_module():
+    spec = importlib.util.spec_from_file_location("bench_unified_radix_ab", _BENCH_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _parse(argv):
+    bench = _load_bench_module()
+    with mock.patch("sys.argv", ["bench_unified_radix_ab.py", *argv]):
+        return bench, bench.parse_args()
+
+
+class TestBenchUnifiedRadixABArgs(unittest.TestCase):
+    def test_config_args_dense_byte_identical(self):
+        """Dense CONFIG_ARGS entries are unchanged; recurrent is additive."""
+        bench = _load_bench_module()
+        self.assertEqual(bench.CONFIG_ARGS["no-cache"], ["--disable-radix-cache"])
+        self.assertEqual(bench.CONFIG_ARGS["radix"], [])
+        self.assertEqual(bench.CONFIG_ARGS["unified"], ["--enable-unified-radix-tree"])
+        self.assertEqual(
+            bench.CONFIG_ARGS["unified-recurrent"],
+            ["--enable-unified-radix-tree", "--enable-recurrent-extra-buffer"],
+        )
+
+    def test_default_args_dense_unchanged(self):
+        """No new flags -> dense defaults are exactly the original values."""
+        _, args = _parse([])
+        self.assertEqual(args.configs, ["no-cache", "radix", "unified"])
+        self.assertIsNone(args.server_url)
+        self.assertFalse(args.disable_overlap_schedule)
+        # chunked_prefill_size has a parser default but is NOT emitted for dense
+        # configs (see run_config), so the dense server command stays identical.
+        self.assertEqual(args.chunked_prefill_size, 512)
+
+    def test_new_flags_parse(self):
+        bench, args = _parse(
+            [
+                "--configs",
+                "unified-recurrent",
+                "--disable-overlap-schedule",
+                "--chunked-prefill-size",
+                "256",
+                "--server-url",
+                "http://10.0.0.1:30000",
+            ]
+        )
+        self.assertEqual(args.configs, ["unified-recurrent"])
+        self.assertTrue(args.disable_overlap_schedule)
+        self.assertEqual(args.chunked_prefill_size, 256)
+        self.assertEqual(args.server_url, "http://10.0.0.1:30000")
+
+    def test_server_url_requires_single_config(self):
+        with self.assertRaises(AssertionError) as ctx:
+            _parse(["--server-url", "http://10.0.0.1:30000", "--configs", "no-cache", "unified"])
+        self.assertIn("exactly one --configs entry", str(ctx.exception))
+
+    def test_server_url_single_config_ok(self):
+        _, args = _parse(
+            ["--server-url", "http://10.0.0.1:30000", "--configs", "unified-recurrent"]
+        )
+        self.assertEqual(args.configs, ["unified-recurrent"])
+
+    def test_recurrent_chunked_prefill_emitted_only_for_recurrent(self):
+        """run_config emits --chunked-prefill-size only for unified-recurrent."""
+        bench = _load_bench_module()
+
+        captured = {}
+
+        def fake_popen(model, **kwargs):
+            captured["other_args"] = kwargs["other_args"]
+            raise RuntimeError("stop after building the server command")
+
+        for config, expect_cps in (("radix", False), ("unified-recurrent", True)):
+            _, args = _parse(["--configs", config, "--tp-size", "1", "--workloads", "random"])
+            # Patch the lazily-imported launcher + run_benchmark inside run_config.
+            with (
+                mock.patch("sgl_jax.test.test_utils.popen_launch_server", side_effect=fake_popen),
+                mock.patch("sgl_jax.bench_serving.run_benchmark"),
+                mock.patch("sgl_jax.srt.utils.kill_process_tree"),
+            ):
+                with self.assertRaises(RuntimeError):
+                    bench.run_config(args, config)
+            has_cps = "--chunked-prefill-size" in captured["other_args"]
+            self.assertEqual(has_cps, expect_cps, f"config={config}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_eval_accuracy_large_unified_radix.py
+++ b/test/srt/test_eval_accuracy_large_unified_radix.py
@@ -1,4 +1,4 @@
-"""MMLU sanity for --enable-unified-radix-tree (HiCache Stage 1, S1c / #1337).
+"""MMLU sanity for --enable-unified-radix-tree (#1337).
 
 Mirrors test_eval_accuracy_large.py with the unified-radix-tree flag on, to
 confirm the UnifiedRadixCache serving path does not regress accuracy.

--- a/test/srt/test_recurrent_boundary_split.py
+++ b/test/srt/test_recurrent_boundary_split.py
@@ -1,0 +1,241 @@
+"""Scheduler must split prefill at recurrent track boundaries: a scheduled EXTEND
+ends on a boundary or is a non-final chunk. The cap composes with chunk-budget
+truncation (admitted length = min of the caps; chunked if either truncated);
+extra-buffer OFF is byte-identical to today."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sgl_jax.srt.managers.schedule_batch import Req
+from sgl_jax.srt.managers.schedule_policy import AddReqResult, PrefillAdder
+from sgl_jax.srt.mem_cache.base_prefix_cache import IncLockRefResult
+from sgl_jax.srt.sampling.sampling_params import SamplingParams
+
+
+class _DummyAllocator:
+    def available_size(self, dp_rank: int = 0):
+        return 1_000_000
+
+
+class _RecurrentRadixCache:
+    """Fake recurrent tree cache exposing the predicate PrefillAdder reads."""
+
+    disable = False
+
+    def __init__(self, extra_buffer: bool, interval: int | None):
+        self._extra_buffer = extra_buffer
+        self.recurrent_track_interval = interval
+        self.enable_recurrent_extra_buffer = extra_buffer
+
+    def supports_recurrent(self) -> bool:
+        return True
+
+    def recurrent_extra_buffer_active(self) -> bool:
+        return self._extra_buffer and self.recurrent_track_interval is not None
+
+    def evictable_size(self, dp_rank: int = 0):
+        return 0
+
+    def inc_lock_ref(self, node):
+        return IncLockRefResult(delta=0)
+
+    def dec_lock_ref(self, node, params=None):
+        pass
+
+
+def _make_req(rid, *, input_len, prefix_len=0, dp_rank=0):
+    req = Req(
+        rid=rid,
+        origin_input_text="",
+        origin_input_ids=list(range(input_len)),
+        sampling_params=SamplingParams(max_new_tokens=8),
+        dp_rank=dp_rank,
+        eos_token_ids={input_len + 1},
+        vocab_size=32000,
+    )
+    req.fill_ids = list(range(input_len))
+    req.prefix_indices = list(range(prefix_len))
+    req.extend_input_len = input_len - prefix_len
+    req.host_hit_length = 0
+    req.last_node = object()
+    return req
+
+
+def _adder(tree_cache, *, page_size=128, rem_chunk_tokens=100_000):
+    return PrefillAdder(
+        page_size=page_size,
+        tree_cache=tree_cache,
+        token_to_kv_pool_allocator=_DummyAllocator(),
+        running_batch=None,
+        new_token_ratio=1.0,
+        rem_input_tokens=1_000_000,
+        rem_chunk_tokens=rem_chunk_tokens,
+        dp_size=1,
+    )
+
+
+class TestBoundarySplitAddOneReq(unittest.TestCase):
+    def test_split_at_first_boundary_marks_chunked(self):
+        # prefix=0, interval=128, input=300 -> cap to 128, land on boundary.
+        cache = _RecurrentRadixCache(extra_buffer=True, interval=128)
+        adder = _adder(cache)
+        req = _make_req("r", input_len=300, prefix_len=0)
+        res = adder.add_one_req(req)
+        self.assertEqual(res, AddReqResult.CONTINUE)
+        self.assertEqual(req.extend_input_len, 128)
+        self.assertEqual(len(req.fill_ids), 128)
+        # Lands exactly on a boundary.
+        self.assertEqual((len(req.prefix_indices) + req.extend_input_len) % 128, 0)
+        # Marked chunked: more tokens next round from the protected prefix.
+        self.assertIs(adder.new_chunked_reqs[0], req)
+
+    def test_split_with_nonzero_prefix(self):
+        # prefix=200, interval=128 -> first boundary after 200 is 256.
+        cache = _RecurrentRadixCache(extra_buffer=True, interval=128)
+        adder = _adder(cache)
+        req = _make_req("r", input_len=400, prefix_len=200)
+        adder.add_one_req(req)
+        self.assertEqual(req.extend_input_len, 56)  # 256 - 200
+        self.assertEqual((200 + req.extend_input_len) % 128, 0)
+        self.assertIs(adder.new_chunked_reqs[0], req)
+
+    def test_no_split_when_already_within_first_interval(self):
+        # input lands before the first boundary -> final chunk, NOT marked chunked.
+        cache = _RecurrentRadixCache(extra_buffer=True, interval=128)
+        adder = _adder(cache)
+        req = _make_req("r", input_len=100, prefix_len=0)
+        adder.add_one_req(req)
+        self.assertEqual(req.extend_input_len, 100)
+        self.assertIsNone(adder.new_chunked_reqs[0])
+
+    def test_exact_boundary_input_is_final_chunk(self):
+        # input exactly = interval -> ends on boundary, final chunk (no more tokens).
+        cache = _RecurrentRadixCache(extra_buffer=True, interval=128)
+        adder = _adder(cache)
+        req = _make_req("r", input_len=128, prefix_len=0)
+        adder.add_one_req(req)
+        self.assertEqual(req.extend_input_len, 128)
+        self.assertEqual((0 + req.extend_input_len) % 128, 0)
+        self.assertIsNone(adder.new_chunked_reqs[0])
+
+    def test_chunk_budget_tighter_than_boundary(self):
+        # boundary cap = 128 but chunk budget = 64 -> min = 64, still chunked,
+        # mid-interval is allowed because it is not the final chunk.
+        cache = _RecurrentRadixCache(extra_buffer=True, interval=128)
+        adder = _adder(cache, page_size=64, rem_chunk_tokens=64)
+        req = _make_req("r", input_len=300, prefix_len=0)
+        adder.add_one_req(req)
+        self.assertEqual(req.extend_input_len, 64)
+        self.assertIs(adder.new_chunked_reqs[0], req)
+
+    def test_off_no_boundary_cap(self):
+        # extra-buffer OFF -> no cap, no forced chunked marking (regression).
+        cache = _RecurrentRadixCache(extra_buffer=False, interval=None)
+        adder = _adder(cache)
+        req = _make_req("r", input_len=300, prefix_len=0)
+        adder.add_one_req(req)
+        self.assertEqual(req.extend_input_len, 300)
+        self.assertIsNone(adder.new_chunked_reqs[0])
+
+
+class TestBoundarySplitAddChunkedReq(unittest.TestCase):
+    def test_chunked_req_capped_to_boundary(self):
+        cache = _RecurrentRadixCache(extra_buffer=True, interval=128)
+        adder = _adder(cache)
+        req = _make_req("r", input_len=300, prefix_len=0)
+        out = adder.add_chunked_req(req)
+        self.assertEqual(req.extend_input_len, 128)
+        self.assertEqual((len(req.prefix_indices) + req.extend_input_len) % 128, 0)
+        # boundary truncation -> chunked req returned (more tokens next round).
+        self.assertIs(out, req)
+
+    def test_chunked_req_final_chunk_within_interval(self):
+        cache = _RecurrentRadixCache(extra_buffer=True, interval=128)
+        adder = _adder(cache)
+        req = _make_req("r", input_len=100, prefix_len=0)
+        out = adder.add_chunked_req(req)
+        self.assertEqual(req.extend_input_len, 100)
+        self.assertIsNone(out)
+
+    def test_chunked_req_off_no_cap(self):
+        cache = _RecurrentRadixCache(extra_buffer=False, interval=None)
+        adder = _adder(cache)
+        req = _make_req("r", input_len=300, prefix_len=0)
+        out = adder.add_chunked_req(req)
+        self.assertEqual(req.extend_input_len, 300)
+        self.assertIsNone(out)
+
+
+class TestSchedulerSingleChunkedPerRankPerRound(unittest.TestCase):
+    """One chunked req per rank per round: a boundary-only split leaves chunk
+    budget, so without the rank-skip on new_chunked_reqs a second same-rank req
+    would truncate and silently overwrite the first."""
+
+    def test_second_boundary_split_req_stays_in_waiting_queue(self):
+        from sgl_jax.srt.managers import scheduler as scheduler_mod
+
+        cache = _RecurrentRadixCache(extra_buffer=True, interval=128)
+        cache.root_node = object()
+        cache.recurrent_evictable_size = lambda dp_rank=0: 0
+        cache.match_prefix = lambda params: SimpleNamespace(
+            device_indices=[],
+            last_device_node=cache.root_node,
+            last_host_node=cache.root_node,
+            host_hit_length=0,
+        )
+
+        req1 = _make_req("r1", input_len=300, prefix_len=0)
+        req2 = _make_req("r2", input_len=300, prefix_len=0)
+
+        rank_info = SimpleNamespace(reqs=[], batch_is_full=False)
+        fake = SimpleNamespace(
+            grammar_queue=[],
+            chunked_reqs=[None],
+            is_hybrid=False,
+            _is_spec_decode_enabled=lambda: False,
+            enable_overlap=False,
+            spec_algorithm=None,
+            running_batch=SimpleNamespace(
+                batch_is_full=False,
+                is_empty=lambda: True,
+                batch_size=lambda: 0,
+                reqs_info=[rank_info],
+            ),
+            waiting_queue=[req1, req2],
+            policy=SimpleNamespace(calc_priority=lambda q: None),
+            page_size=128,
+            tree_cache=cache,
+            token_to_kv_pool_allocator=_DummyAllocator(),
+            new_token_ratio=1.0,
+            max_prefill_tokens=1_000_000,
+            chunked_prefill_size=100_000,
+            is_mixed_chunk=False,
+            dp_size=1,
+            lora_paths=None,
+            per_dp_max_running_requests=1000,
+            req_to_token_pool=SimpleNamespace(
+                request_owned_slots=1,
+                recurrent_available_size=lambda dp_rank=0: 1_000_000,
+            ),
+            log_prefill_stats=lambda *a, **k: None,
+            model_config=None,
+            mesh=None,
+        )
+
+        with patch.object(scheduler_mod.ScheduleBatch, "init_new", return_value=MagicMock()):
+            batch = scheduler_mod.Scheduler.get_new_batch_prefill(fake)
+
+        self.assertIsNotNone(batch)
+        # req1 admitted as the rank's single chunked req; req2 deferred intact.
+        self.assertIs(fake.chunked_reqs[0], req1)
+        self.assertEqual(req1.is_chunked, 1)
+        self.assertEqual(req1.extend_input_len, 128)
+        self.assertIn(req2, fake.waiting_queue)
+        self.assertNotIn(req1, fake.waiting_queue)
+        self.assertEqual(req2.extend_input_len, 300)
+        self.assertEqual(req2.is_chunked, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_recurrent_split_equivalence.py
+++ b/test/srt/test_recurrent_split_equivalence.py
@@ -1,0 +1,232 @@
+"""Offline oracle: a single GDN forward == chained 128-token split (the extra-buffer
+boundary-split schedule), pure JAX on CPU -- the TPU-free check that splitting a
+prefill does not change model numerics. Pool-table dtypes mirror production
+(conv bf16, recurrent fp32): the carry dtype is set purely by the initial tables."""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+# Pure-JAX kernels run eager on one CPU device. Pin CPU before JAX initializes
+# (mirrors test_recurrent_track_scatter's preamble) but DO NOT set a module
+# mesh — these ops need none and a module mesh would pollute sibling files.
+if os.environ.get("USE_DEVICE_TYPE") == "cpu" or "XLA_FLAGS" not in os.environ:
+    os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
+    os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.kernels.gdn.gated_delta import (
+    jax_causal_conv1d_prefill,
+    ragged_gated_delta_rule_ref,
+)
+
+# Small CPU shapes (mirror test_gdn_attention). conv_dim = 2*n_kq*d_k + n_v*d_v.
+N_KQ, N_V, D_K, D_V, K = 4, 8, 32, 32, 4
+CONV_DIM = 2 * N_KQ * D_K + N_V * D_V  # 512
+NUM_BLOCKS = 4  # slot 0 = dummy, requests use slot 1
+T_MAX = 384
+
+# slot the single + split runs both target (slot 0 is the dummy).
+SLOT = 1
+
+# (length, chunk sizes) — model GPQA prompts crossing 128 boundaries. Two cases
+# cover the distinct splits: one clean boundary, and multi-boundary with a
+# partial final chunk. A multi-boundary all-clean case (e.g. 384) adds nothing:
+# the chunk-to-chunk carry is identical to the partial case minus the tail.
+PATTERNS = [
+    (256, [128, 128]),  # one boundary
+    (300, [128, 128, 44]),  # two boundaries + partial final chunk (realistic)
+]
+
+
+def _make_inputs(seed: int = 0):
+    """Generate the shared layer weights + input tokens ONCE (float32).
+
+    Same rationale as test_gdn_attention's ``_scaled_randn``: scale 0.1 for the
+    activations/gates keeps the recurrent state bounded so bf16 noise stays
+    inside the global atol; scale 1.0 for weight / A_log / dt_bias.
+    """
+    rng = np.random.default_rng(seed)
+
+    def scaled(shape, scale):
+        return (rng.standard_normal(shape) * scale).astype(np.float32)
+
+    return {
+        "mixed_raw": scaled((T_MAX, CONV_DIM), 0.1),
+        "b": scaled((T_MAX, N_V), 0.1),
+        "a": scaled((T_MAX, N_V), 0.1),
+        "weight": scaled((CONV_DIM, K), 1.0),
+        "A_log": scaled((N_V,), 1.0),
+        "dt_bias": scaled((N_V,), 1.0),
+    }
+
+
+def _run_chunks(inputs, chunk_sizes, *, conv_dtype, rec_dtype, io_dtype):
+    """Run the GDN forward as a chain of chunks, carrying the FULL pool tables.
+
+    The pool-table dtypes (conv_dtype / rec_dtype) drive the production
+    round-trip automatically (kernels cast on write-back; ragged reads the
+    recurrent table back as float32). io_dtype casts mixed_raw + weight.
+
+    Returns float32 numpy ``(output, final_rec, final_conv)``.
+    """
+    weight = jnp.asarray(inputs["weight"], dtype=io_dtype)
+    A_log = jnp.asarray(inputs["A_log"], dtype=jnp.float32)
+    dt_bias = jnp.asarray(inputs["dt_bias"], dtype=jnp.float32)
+    mixed_raw = jnp.asarray(inputs["mixed_raw"], dtype=io_dtype)
+    b = jnp.asarray(inputs["b"], dtype=jnp.float32)
+    a = jnp.asarray(inputs["a"], dtype=jnp.float32)
+
+    conv_table = jnp.zeros((NUM_BLOCKS, CONV_DIM, K - 1), dtype=conv_dtype)
+    rec_table = jnp.zeros((NUM_BLOCKS, N_V, D_K, D_V), dtype=rec_dtype)
+
+    state_idx = jnp.array([SLOT], dtype=jnp.int32)
+    outs = []
+    start = 0
+    for ci, csz in enumerate(chunk_sizes):
+        end = start + csz
+        T = end - start
+        cu = jnp.array([0, T], dtype=jnp.int32)
+        # First chunk is a brand-new prefill (no prior state); later chunks
+        # continue from the carried tables.
+        has_init = jnp.array([ci != 0], dtype=bool)
+
+        y, conv_table = jax_causal_conv1d_prefill(
+            mixed_raw[start:end].T,
+            weight,
+            None,
+            cu,
+            conv_table,
+            state_idx,
+            has_init,
+            "silu",
+        )
+        rec_table, out = ragged_gated_delta_rule_ref(
+            y.T,
+            b[start:end],
+            a[start:end],
+            rec_table,
+            A_log,
+            dt_bias,
+            cu,
+            state_idx,
+            has_init,
+            n_kq=N_KQ,
+            n_v=N_V,
+            d_k=D_K,
+            d_v=D_V,
+        )
+        outs.append(out)
+        start = end
+
+    output = jnp.concatenate(outs, axis=0)
+    final_conv = conv_table[SLOT]
+    final_rec = rec_table[SLOT]
+    return (
+        np.asarray(output, dtype=np.float32),
+        np.asarray(final_rec, dtype=np.float32),
+        np.asarray(final_conv, dtype=np.float32),
+    )
+
+
+def _metrics(single: np.ndarray, split: np.ndarray):
+    diff = np.abs(single - split)
+    max_abs = float(diff.max())
+    mean_abs = float(diff.mean())
+    denom = float(np.linalg.norm(single.reshape(-1))) + 1e-12
+    rel = float(np.linalg.norm((single - split).reshape(-1)) / denom)
+    return max_abs, mean_abs, rel
+
+
+class _SplitEquivalenceBase(unittest.TestCase):
+    """Compare a single forward over N tokens vs the chained 128-token split."""
+
+    # Subclasses set the variant name + the three dtypes + the bit-exact flag.
+    VARIANT = ""
+    CONV_DTYPE = jnp.float32
+    REC_DTYPE = jnp.float32
+    IO_DTYPE = jnp.float32
+    BITEXACT_REC = False
+
+    RTOL = 2e-2
+    ATOL = 1e-2
+
+    @classmethod
+    def setUpClass(cls):
+        # unittest/pytest collect any TestCase subclass regardless of the
+        # leading underscore, so skip the bare base (it would otherwise run a
+        # third, mislabeled all-fp32 variant). Mirrors test_retract_decode.py.
+        if cls is _SplitEquivalenceBase:
+            raise unittest.SkipTest("abstract base; variants run via subclasses")
+
+    def setUp(self):
+        self.inputs = _make_inputs(0)
+
+    def _check_pattern(self, length, chunk_sizes):
+        kw = dict(
+            conv_dtype=self.CONV_DTYPE,
+            rec_dtype=self.REC_DTYPE,
+            io_dtype=self.IO_DTYPE,
+        )
+        single = _run_chunks(self.inputs, [length], **kw)
+        split = _run_chunks(self.inputs, chunk_sizes, **kw)
+
+        names = ("output", "final_rec", "final_conv")
+        print(
+            f"\n[{self.VARIANT}] length={length} split={chunk_sizes}",
+            flush=True,
+        )
+        for name, s, sp in zip(names, single, split):
+            max_abs, mean_abs, rel = _metrics(s, sp)
+            print(
+                f"  {name:<10s} max_abs={max_abs:.3e} " f"mean_abs={mean_abs:.3e} rel={rel:.3e}",
+                flush=True,
+            )
+
+        # Established kernel-equivalence bar (same as test_gdn_attention).
+        for name, s, sp in zip(names, single, split):
+            np.testing.assert_allclose(
+                sp, s, rtol=self.RTOL, atol=self.ATOL, err_msg=f"{name} mismatch"
+            )
+
+        # fp32-only: with no bf16 and an fp32 sequential carry, the split must
+        # reproduce the single forward bit-exactly for the recurrent final
+        # state. Any diff there is a real split-mechanism bug. (conv/output may
+        # differ by ULPs from XLA op reordering — covered by assert_allclose.)
+        if self.BITEXACT_REC:
+            np.testing.assert_array_equal(
+                split[1], single[1], err_msg="final_rec not bit-exact (fp32 split)"
+            )
+
+    def test_len256_one_boundary(self):
+        self._check_pattern(256, [128, 128])
+
+    def test_len300_partial_final(self):
+        self._check_pattern(300, [128, 128, 44])
+
+
+class TestSplitEquivalenceProd(_SplitEquivalenceBase):
+    """Faithful production: conv pool bfloat16, recurrent pool float32."""
+
+    VARIANT = "V_prod"
+    CONV_DTYPE = jnp.bfloat16
+    REC_DTYPE = jnp.float32
+    IO_DTYPE = jnp.bfloat16
+    BITEXACT_REC = False
+
+
+class TestSplitEquivalenceFp32(_SplitEquivalenceBase):
+    """Isolates the split mechanism: no bf16 anywhere (all float32)."""
+
+    VARIANT = "V_fp32"
+    CONV_DTYPE = jnp.float32
+    REC_DTYPE = jnp.float32
+    IO_DTYPE = jnp.float32
+    BITEXACT_REC = True
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_recurrent_state_sizing.py
+++ b/test/srt/test_recurrent_state_sizing.py
@@ -1,0 +1,408 @@
+"""Pure sizing helpers (reservation_slots_per_request / request_owned_slots) and the
+ServerArgs validation for --recurrent-track-interval; no server launch."""
+
+import unittest
+from types import SimpleNamespace
+
+from sgl_jax.srt.model_executor.model_runner_kv_cache_mixin import (
+    ModelRunnerKVCacheMixin,
+    _enforce_recurrent_state_server_constraints,
+    recurrent_admission_blocked,
+    request_owned_slots,
+    reservation_slots_per_request,
+)
+from sgl_jax.srt.server_args import ServerArgs
+
+_MIXIN_LOGGER = "sgl_jax.srt.model_executor.model_runner_kv_cache_mixin"
+
+
+def _factor_args(
+    *,
+    disable_radix_cache=False,
+    enable_unified_radix_tree=False,
+    enable_recurrent_extra_buffer=False,
+    disable_overlap_schedule=False,
+):
+    return SimpleNamespace(
+        disable_radix_cache=disable_radix_cache,
+        enable_unified_radix_tree=enable_unified_radix_tree,
+        enable_recurrent_extra_buffer=enable_recurrent_extra_buffer,
+        disable_overlap_schedule=disable_overlap_schedule,
+    )
+
+
+class TestReservationSlotsPerRequest(unittest.TestCase):
+    """Back-cap reservation: 1 legacy, 2 radix, 3 extra-buffer. The surplus over
+    request_owned_slots is the implicit per-req snapshot headroom."""
+
+    def test_legacy_disabled_radix_is_one(self):
+        self.assertEqual(reservation_slots_per_request(_factor_args(disable_radix_cache=True)), 1)
+
+    def test_plain_no_radix_is_one(self):
+        self.assertEqual(reservation_slots_per_request(_factor_args()), 1)
+
+    def test_unified_radix_without_extra_buffer_is_two(self):
+        self.assertEqual(
+            reservation_slots_per_request(_factor_args(enable_unified_radix_tree=True)), 2
+        )
+
+    def test_extra_buffer_is_three(self):
+        self.assertEqual(
+            reservation_slots_per_request(
+                _factor_args(
+                    enable_unified_radix_tree=True,
+                    enable_recurrent_extra_buffer=True,
+                )
+            ),
+            3,
+        )
+
+    def test_extra_buffer_reservation_unaffected_by_overlap(self):
+        # The reservation factor stays 3 regardless of overlap; only consumption
+        # (request_owned_slots) drops to 2 overlap-off, leaving 1 headroom slot/req.
+        self.assertEqual(
+            reservation_slots_per_request(
+                _factor_args(
+                    enable_unified_radix_tree=True,
+                    enable_recurrent_extra_buffer=True,
+                    disable_overlap_schedule=True,
+                )
+            ),
+            3,
+        )
+
+    def test_extra_buffer_with_disabled_radix_is_one(self):
+        # disable_radix_cache wins (legacy 1:1 path); extra-buffer is invalid
+        # there and rejected by server_args / constraints elsewhere.
+        self.assertEqual(
+            reservation_slots_per_request(
+                _factor_args(disable_radix_cache=True, enable_recurrent_extra_buffer=True)
+            ),
+            1,
+        )
+
+
+class TestRequestOwnedSlots(unittest.TestCase):
+    """Actual per-req consumption: 1 running + ping-pong track slots."""
+
+    def test_legacy_disabled_radix_is_one(self):
+        self.assertEqual(request_owned_slots(_factor_args(disable_radix_cache=True)), 1)
+
+    def test_plain_no_radix_is_one(self):
+        self.assertEqual(request_owned_slots(_factor_args()), 1)
+
+    def test_unified_radix_without_extra_buffer_consumes_one(self):
+        # page=1 base path consumes a single running slot (reservation is 2 -> the
+        # surplus is headroom). Consumption != reservation here.
+        self.assertEqual(request_owned_slots(_factor_args(enable_unified_radix_tree=True)), 1)
+
+    def test_extra_buffer_overlap_on_is_three(self):
+        self.assertEqual(
+            request_owned_slots(
+                _factor_args(
+                    enable_unified_radix_tree=True,
+                    enable_recurrent_extra_buffer=True,
+                )
+            ),
+            3,
+        )
+
+    def test_extra_buffer_overlap_off_is_two(self):
+        # --disable-overlap-schedule needs only 1 ping-pong track slot.
+        self.assertEqual(
+            request_owned_slots(
+                _factor_args(
+                    enable_unified_radix_tree=True,
+                    enable_recurrent_extra_buffer=True,
+                    disable_overlap_schedule=True,
+                )
+            ),
+            2,
+        )
+
+
+def _server_args(**overrides):
+    kwargs = dict(
+        model_path="dummy",
+        enable_unified_radix_tree=True,
+        enable_recurrent_extra_buffer=True,
+        page_size=128,
+    )
+    kwargs.update(overrides)
+    return ServerArgs(**kwargs)
+
+
+class TestExtraBufferStaticValidation(unittest.TestCase):
+    """``__post_init__`` static checks gated by ``enable_recurrent_extra_buffer``."""
+
+    def test_extra_buffer_requires_page_size_gt_1(self):
+        with self.assertRaises((ValueError, AssertionError)):
+            _server_args(page_size=1)
+
+    def test_track_interval_none_defaults_to_chunked_prefill_size(self):
+        # Default snapshot interval = chunked_prefill_size (NOT page_size), so the
+        # recurrent feature never force-splits prefill below the chunk size (which
+        # would inherit the chunk-size-sensitive accuracy penalty).
+        sa = _server_args(recurrent_track_interval=None, page_size=256, chunked_prefill_size=512)
+        self.assertEqual(sa.recurrent_track_interval, 512)
+
+    def test_track_interval_none_falls_back_to_page_size_when_chunked_disabled(self):
+        sa = _server_args(recurrent_track_interval=None, page_size=256, chunked_prefill_size=-1)
+        self.assertEqual(sa.recurrent_track_interval, 256)
+
+    def test_track_interval_above_chunked_prefill_allowed(self):
+        # interval > chunk budget is ALLOWED (warns): a chunk never reaches a
+        # snapshot boundary, so sub-interval prompts cache nothing, but the
+        # request still progresses (the zero-cache-len chunk skip advances
+        # prefix_indices -- no stall). It must resolve to the requested value.
+        sa = _server_args(recurrent_track_interval=1024, chunked_prefill_size=512)
+        self.assertEqual(sa.recurrent_track_interval, 1024)
+
+    def test_track_interval_below_chunked_prefill_allowed(self):
+        # Smaller interval is allowed (finer cache granularity) but warns about
+        # the accuracy cost; it must still resolve to the requested value.
+        sa = _server_args(recurrent_track_interval=128, chunked_prefill_size=512)
+        self.assertEqual(sa.recurrent_track_interval, 128)
+
+    def test_track_interval_zero_rejected(self):
+        with self.assertRaises((ValueError, AssertionError)):
+            _server_args(recurrent_track_interval=0)
+
+    def test_track_interval_not_divisible_by_page_size_rejected(self):
+        with self.assertRaises((ValueError, AssertionError)):
+            _server_args(recurrent_track_interval=200, page_size=128)
+
+    def test_default_interval_rejects_non_page_aligned_chunk(self):
+        # The interval auto-derives from chunked_prefill_size, so a non-page-aligned
+        # chunk must fail with a message naming chunked_prefill_size (not the
+        # auto-derived interval), even though check_server_args runs later.
+        with self.assertRaises(ValueError) as cm:
+            _server_args(recurrent_track_interval=None, chunked_prefill_size=1000, page_size=128)
+        self.assertIn("chunked-prefill-size", str(cm.exception))
+
+    def test_extra_buffer_with_speculative_rejected(self):
+        with self.assertRaises((ValueError, AssertionError)):
+            _server_args(speculative_algorithm="EAGLE")
+
+    def test_extra_buffer_with_mixed_chunk_rejected(self):
+        with self.assertRaises((ValueError, AssertionError)):
+            _server_args(enable_mixed_chunk=True)
+
+    def test_no_extra_buffer_skips_static_checks(self):
+        # Page size 1 + speculative are fine when extra-buffer is off.
+        sa = ServerArgs(
+            model_path="dummy",
+            page_size=1,
+            enable_recurrent_extra_buffer=False,
+        )
+        self.assertIsNone(sa.recurrent_track_interval)
+
+
+class TestRecurrentStateConstraints(unittest.TestCase):
+    """``_enforce_recurrent_state_server_constraints`` model-dependent checks."""
+
+    def test_extra_buffer_incompatible_with_disable_radix_cache(self):
+        sa = _server_args(disable_radix_cache=True)
+        with self.assertRaises(AssertionError):
+            _enforce_recurrent_state_server_constraints(sa)
+
+    def test_extra_buffer_requires_unified_radix_tree(self):
+        sa = _server_args(enable_unified_radix_tree=False)
+        with self.assertRaises(AssertionError):
+            _enforce_recurrent_state_server_constraints(sa)
+
+    def test_extra_buffer_unified_radix_passes(self):
+        sa = _server_args()
+        _enforce_recurrent_state_server_constraints(sa)  # no raise
+
+    def test_extra_buffer_rejected_for_lightning(self):
+        # GLA/Lightning has no extra-buffer support; reject at init even though
+        # the radix/page constraints are otherwise satisfied.
+        sa = _server_args()
+        with self.assertRaises(AssertionError):
+            _enforce_recurrent_state_server_constraints(sa, is_lightning=True)
+
+    def test_lightning_without_extra_buffer_passes(self):
+        # A Lightning model on the non-extra-buffer recurrent radix path is fine.
+        sa = ServerArgs(
+            model_path="dummy",
+            enable_unified_radix_tree=True,
+            page_size=1,
+        )
+        _enforce_recurrent_state_server_constraints(sa, is_lightning=True)  # no raise
+
+    def test_unified_radix_without_extra_buffer_requires_page_size_1(self):
+        sa = ServerArgs(
+            model_path="dummy",
+            enable_unified_radix_tree=True,
+            enable_recurrent_extra_buffer=False,
+            page_size=128,
+        )
+        with self.assertRaises(AssertionError):
+            _enforce_recurrent_state_server_constraints(sa)
+
+    def test_unified_radix_without_extra_buffer_page_size_1_passes(self):
+        sa = ServerArgs(
+            model_path="dummy",
+            enable_unified_radix_tree=True,
+            page_size=1,
+        )
+        _enforce_recurrent_state_server_constraints(sa)  # no raise
+
+    def test_legacy_disable_radix_passes(self):
+        sa = ServerArgs(model_path="dummy", disable_radix_cache=True)
+        _enforce_recurrent_state_server_constraints(sa)  # early return, no raise
+
+    def test_hicache_rejected_on_recurrent_radix(self):
+        # Recurrent state is device-only (never backed up), so the host tier can
+        # never serve a hit on a recurrent tree; reject the combo at init.
+        sa = _server_args(hicache_storage="none")
+        with self.assertRaises(AssertionError):
+            _enforce_recurrent_state_server_constraints(sa)
+
+    def test_hicache_rejected_on_page1_recurrent_radix(self):
+        sa = ServerArgs(
+            model_path="dummy",
+            enable_unified_radix_tree=True,
+            page_size=1,
+            hicache_storage="none",
+        )
+        with self.assertRaises(AssertionError):
+            _enforce_recurrent_state_server_constraints(sa)
+
+    def test_hicache_disable_passes(self):
+        sa = _server_args(hicache_storage="disable")
+        _enforce_recurrent_state_server_constraints(sa)  # no raise
+
+
+class TestResolveMaxNumReqsHeadroom(unittest.TestCase):
+    """``_resolve_max_num_reqs`` back-cap: the auto/ratio path enforces snapshot
+    headroom; the explicit path keeps the operator's max_running and only warns."""
+
+    def _runner(self, *, max_recurrent_state_size, dp_size, user_supplied, **sa_over):
+        sa = SimpleNamespace(
+            disable_radix_cache=False,
+            enable_unified_radix_tree=True,
+            enable_recurrent_extra_buffer=True,
+            disable_overlap_schedule=True,
+            max_recurrent_state_size=max_recurrent_state_size,
+            max_num_reqs=None,
+        )
+        sa.__dict__.update(sa_over)
+        return SimpleNamespace(
+            is_draft_worker=False,
+            spec_algorithm=None,
+            server_args=sa,
+            linear_recurrent_config=object(),
+            dp_size=dp_size,
+            recurrent_size_user_supplied=user_supplied,
+        )
+
+    def _resolve(self, runner, requested):
+        return ModelRunnerKVCacheMixin._resolve_max_num_reqs(runner, requested)
+
+    def test_auto_path_reserves_headroom(self):
+        # size 192 / dp 4 -> 48 slots/rank; overlap-off consumes 2/req.
+        # headroom = ceil(0.25*48)=12; running/rank = (48-12)//2 = 18 -> 72 global.
+        runner = self._runner(max_recurrent_state_size=192, dp_size=4, user_supplied=False)
+        result = self._resolve(runner, 1000)
+        self.assertEqual(result, 72)
+        slots_per_rank = 192 // 4
+        owned = request_owned_slots(runner.server_args)
+        headroom = slots_per_rank - (result // 4) * owned
+        self.assertGreaterEqual(headroom, 12)
+
+    def test_auto_path_running_floor_is_at_least_dp(self):
+        # Tiny pool still yields >=1 running slot/rank (no zero/negative cap).
+        runner = self._runner(max_recurrent_state_size=8, dp_size=4, user_supplied=False)
+        result = self._resolve(runner, 1000)
+        self.assertGreaterEqual(result, 4)
+
+    def test_explicit_path_keeps_reservation_cap_no_warn(self):
+        # Explicit 192/dp4, overlap-off: cap = 192//3 = 64; owned 2 < reservation 3
+        # leaves real headroom 192 - 64*2 = 64 -> no warning.
+        runner = self._runner(max_recurrent_state_size=192, dp_size=4, user_supplied=True)
+        import logging
+
+        logger = logging.getLogger(_MIXIN_LOGGER)
+        with self.assertNoLogs(logger, level="WARNING"):
+            result = self._resolve(runner, 1000)
+        self.assertEqual(result, 64)
+
+    def test_explicit_path_overlap_on_zero_headroom_warns(self):
+        # Overlap-ON: owned == reservation == 3, so 192//3 = 64 running consumes the
+        # whole pool -> zero headroom -> warn (but max_running is NOT reduced).
+        runner = self._runner(
+            max_recurrent_state_size=192,
+            dp_size=4,
+            user_supplied=True,
+            disable_overlap_schedule=False,
+        )
+        with self.assertLogs(_MIXIN_LOGGER, level="WARNING"):
+            result = self._resolve(runner, 1000)
+        self.assertEqual(result, 64)
+
+    def test_undersized_pool_below_owned_fails_fast_auto(self):
+        # Overlap-ON extra-buffer: owned = 3. size 8 / dp 4 -> 2 slots/rank < 3 ->
+        # the pool cannot fit even one running request. Fail fast instead of
+        # advertising >=1 running/rank the pool can never allocate (which would
+        # leave the rank marked full forever).
+        runner = self._runner(
+            max_recurrent_state_size=8,
+            dp_size=4,
+            user_supplied=False,
+            disable_overlap_schedule=False,
+        )
+        with self.assertRaises(ValueError):
+            self._resolve(runner, 1000)
+
+    def test_undersized_pool_below_owned_fails_fast_explicit(self):
+        # Same fail-fast on the explicit --max-recurrent-state-size path.
+        runner = self._runner(
+            max_recurrent_state_size=8,
+            dp_size=4,
+            user_supplied=True,
+            disable_overlap_schedule=False,
+        )
+        with self.assertRaises(ValueError):
+            self._resolve(runner, 1000)
+
+    def test_explicit_reservation_cap_floored_to_zero_fails_fast(self):
+        # Overlap-off owned=2 passes the per-slot guard (slots/rank 2 >= 2), but
+        # the reservation divide + dp floor lands at 0 (8//3=2 -> 2-2%4=0):
+        # max_running=0 must fail fast, not start a server that admits nothing.
+        runner = self._runner(max_recurrent_state_size=8, dp_size=4, user_supplied=True)
+        with self.assertRaises(ValueError):
+            self._resolve(runner, 1000)
+
+    def test_slots_equal_owned_does_not_fail(self):
+        # Boundary: slots/rank == owned fits exactly one req/rank (zero snapshot
+        # headroom), so it must NOT fail fast. Overlap-off owned=2, size 8/dp4 -> 2.
+        runner = self._runner(max_recurrent_state_size=8, dp_size=4, user_supplied=False)
+        self.assertGreaterEqual(self._resolve(runner, 1000), 4)
+
+
+class TestRecurrentAdmissionBlocked(unittest.TestCase):
+    """The scheduler admission backpressure predicate. ``keeps_locked`` discounts
+    a snapshot a cross-request prefix hit will keep protected (locked, hence
+    non-evictable) while the req still needs request_owned_slots fresh slots."""
+
+    def test_cold_admission_at_exact_capacity_admits(self):
+        # No prefix hit (keeps_locked=0): free+evictable == demand -> admit.
+        self.assertFalse(recurrent_admission_blocked(free=0, evictable=3, demand=3))
+
+    def test_prefix_hit_at_exact_capacity_defers(self):
+        # Hit locks 1 of the 3 evictable snapshots -> only 2 reclaimable for 3
+        # fresh slots -> must defer (else alloc_req_slots evicts too few and raises).
+        self.assertTrue(recurrent_admission_blocked(free=0, evictable=3, demand=3, keeps_locked=1))
+
+    def test_prefix_hit_with_one_free_slot_admits(self):
+        # One free slot covers the locked snapshot's shortfall.
+        self.assertFalse(recurrent_admission_blocked(free=1, evictable=3, demand=3, keeps_locked=1))
+
+    def test_obvious_oversubscription_blocks(self):
+        self.assertTrue(recurrent_admission_blocked(free=0, evictable=1, demand=3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_recurrent_track_metadata.py
+++ b/test/srt/test_recurrent_track_metadata.py
@@ -1,0 +1,262 @@
+"""recurrent_track_indices / recurrent_track_mask must ride the same plumbing as
+recurrent_cow_src_indices (scheduler -> ModelWorkerBatch -> ForwardBatch -> backend
+metadata) in lockstep: populated only on a track boundary, distinct sentinels catch
+swapped fields, None round-trips to None."""
+
+import unittest
+
+import numpy as np
+
+from sgl_jax.srt.layers.attention.hybrid_linear_attn_backend import (
+    LinearRecurrentAttnBackendMetadata,
+)
+from sgl_jax.srt.managers.schedule_batch import (
+    Req,
+    _build_recurrent_track_entries,
+    _recurrent_track_entry,
+)
+from sgl_jax.srt.mem_cache.base_prefix_cache import MatchResult
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sgl_jax.srt.sampling.sampling_params import SamplingParams
+
+
+class TestLinearRecurrentAttnBackendMetadataTrack(unittest.TestCase):
+    def test_track_arrays_round_trip_distinct_sentinels(self):
+        # Distinct values per field so a swapped flatten/unflatten index is caught.
+        md = LinearRecurrentAttnBackendMetadata(
+            cu_q_lens=np.array([0, 1], dtype=np.int32),
+            recurrent_indices=np.array([10, 11], dtype=np.int32),
+            has_initial_state=np.array([1, 0], dtype=np.int32),
+            recurrent_track_indices=np.array([20, 21], dtype=np.int32),
+            recurrent_track_mask=np.array([1, 0], dtype=np.int32),
+        )
+
+        children, aux_data = md.tree_flatten()
+        rebuilt = LinearRecurrentAttnBackendMetadata.tree_unflatten(aux_data, children)
+
+        np.testing.assert_array_equal(rebuilt.cu_q_lens, md.cu_q_lens)
+        np.testing.assert_array_equal(rebuilt.recurrent_indices, md.recurrent_indices)
+        np.testing.assert_array_equal(rebuilt.has_initial_state, md.has_initial_state)
+        np.testing.assert_array_equal(
+            rebuilt.recurrent_track_indices, np.array([20, 21], dtype=np.int32)
+        )
+        np.testing.assert_array_equal(
+            rebuilt.recurrent_track_mask, np.array([1, 0], dtype=np.int32)
+        )
+
+    def test_track_arrays_none_round_trip(self):
+        md = LinearRecurrentAttnBackendMetadata()
+        rebuilt = LinearRecurrentAttnBackendMetadata.tree_unflatten(*reversed(md.tree_flatten()))
+
+        self.assertIsNone(rebuilt.recurrent_track_indices)
+        self.assertIsNone(rebuilt.recurrent_track_mask)
+
+
+def _minimal_forward_batch(**overrides):
+    kwargs = dict(
+        bid=0,
+        forward_mode=ForwardMode.DECODE,
+        batch_size=2,
+        input_ids=np.array([1, 2], dtype=np.int32),
+        req_pool_indices=np.array([0, 1], dtype=np.int32),
+        seq_lens=np.array([4, 5], dtype=np.int32),
+        out_cache_loc=np.array([0, 1], dtype=np.int32),
+    )
+    kwargs.update(overrides)
+    return ForwardBatch(**kwargs)
+
+
+class TestForwardBatchTrackPytree(unittest.TestCase):
+    def test_track_arrays_round_trip_distinct_sentinels(self):
+        fb = _minimal_forward_batch(
+            recurrent_indices=np.array([10, 11], dtype=np.int32),
+            recurrent_cow_src_indices=np.array([30, 31], dtype=np.int32),
+            recurrent_track_indices=np.array([20, 21], dtype=np.int32),
+            recurrent_track_mask=np.array([1, 0], dtype=np.int32),
+        )
+
+        children, aux_data = fb.tree_flatten()
+        rebuilt = ForwardBatch.tree_unflatten(aux_data, children)
+
+        # Existing recurrent fields stay aligned.
+        np.testing.assert_array_equal(rebuilt.recurrent_indices, np.array([10, 11]))
+        np.testing.assert_array_equal(rebuilt.recurrent_cow_src_indices, np.array([30, 31]))
+        # New track fields keep their distinct sentinels (no index swap).
+        np.testing.assert_array_equal(
+            rebuilt.recurrent_track_indices, np.array([20, 21], dtype=np.int32)
+        )
+        np.testing.assert_array_equal(
+            rebuilt.recurrent_track_mask, np.array([1, 0], dtype=np.int32)
+        )
+
+    def test_track_arrays_none_round_trip(self):
+        fb = _minimal_forward_batch()
+
+        children, aux_data = fb.tree_flatten()
+        rebuilt = ForwardBatch.tree_unflatten(aux_data, children)
+
+        self.assertIsNone(rebuilt.recurrent_track_indices)
+        self.assertIsNone(rebuilt.recurrent_track_mask)
+
+
+class _PingPongPool:
+    """Minimal pool exposing the ping-pong flip helper the track builder uses.
+    ``ping_pong_slots`` mirrors HybridReqToTokenPool: 2 with overlap (toggle),
+    1 without (the flip is a no-op, keep == next == 0)."""
+
+    def __init__(self, ping_pong_slots: int = 2):
+        self.ping_pong_slots = ping_pong_slots
+
+    def get_recurrent_ping_pong_other_idx(self, next_idx: int) -> int:
+        return (next_idx + 1) % self.ping_pong_slots
+
+
+class _FakeReq:
+    def __init__(self, *, extend_input_len, buffer, next_idx=0):
+        self.extend_input_len = extend_input_len
+        self.recurrent_ping_pong_track_buffer = list(buffer)
+        self.recurrent_next_track_idx = next_idx
+        self.recurrent_last_track_seqlen = None
+
+
+class TestRecurrentTrackEntryBuilder(unittest.TestCase):
+    """Per-req track entries with read-then-flip bookkeeping."""
+
+    def test_extend_on_boundary_reads_then_flips(self):
+        # next_idx=0 -> read slot buffer[0]=40, then flip to 1.
+        req = _FakeReq(extend_input_len=128, buffer=[40, 41], next_idx=0)
+        entry = _recurrent_track_entry(req, 256, interval=128, pool=_PingPongPool(), is_extend=True)
+        self.assertTrue(entry.track_mask)
+        self.assertEqual(entry.track_index, 40)  # slot BEFORE the flip
+        self.assertEqual(req.recurrent_last_track_seqlen, 256)
+        self.assertEqual(req.recurrent_next_track_idx, 1)  # flipped once
+
+    def test_extend_off_boundary_dormant_no_flip(self):
+        req = _FakeReq(extend_input_len=100, buffer=[40, 41], next_idx=0)
+        entry = _recurrent_track_entry(req, 200, interval=128, pool=_PingPongPool(), is_extend=True)
+        self.assertFalse(entry.track_mask)
+        self.assertEqual(entry.track_index, 0)
+        self.assertIsNone(req.recurrent_last_track_seqlen)
+        self.assertEqual(req.recurrent_next_track_idx, 0)  # untouched
+
+    def test_extend_zero_input_never_tracks(self):
+        # A zero-extend (e.g. already-committed prefix) must not snapshot even
+        # if the seqlen happens to land on a boundary.
+        req = _FakeReq(extend_input_len=0, buffer=[40, 41], next_idx=0)
+        entry = _recurrent_track_entry(req, 256, interval=128, pool=_PingPongPool(), is_extend=True)
+        self.assertFalse(entry.track_mask)
+        self.assertEqual(req.recurrent_next_track_idx, 0)
+
+    def test_decode_on_boundary_tracks(self):
+        # Decode advances by 1; mask is purely seqlen % interval == 0.
+        req = _FakeReq(extend_input_len=0, buffer=[40, 41], next_idx=1)
+        entry = _recurrent_track_entry(
+            req, 128, interval=128, pool=_PingPongPool(), is_extend=False
+        )
+        self.assertTrue(entry.track_mask)
+        self.assertEqual(entry.track_index, 41)  # buffer[next_idx=1] before flip
+        self.assertEqual(req.recurrent_next_track_idx, 0)
+        self.assertEqual(req.recurrent_last_track_seqlen, 128)
+
+    def test_builder_none_when_no_boundary(self):
+        reqs = [
+            _FakeReq(extend_input_len=100, buffer=[40, 41]),
+            _FakeReq(extend_input_len=50, buffer=[42, 43]),
+        ]
+        out = _build_recurrent_track_entries(
+            reqs, [200, 150], interval=128, pool=_PingPongPool(), is_extend=True
+        )
+        self.assertEqual(out, (None, None))
+        # No req mutated when nothing hit a boundary.
+        self.assertTrue(all(r.recurrent_last_track_seqlen is None for r in reqs))
+
+    def test_builder_padded_one_shot_on_boundary(self):
+        reqs = [
+            _FakeReq(extend_input_len=128, buffer=[40, 41], next_idx=0),  # hits 256
+            _FakeReq(extend_input_len=50, buffer=[42, 43], next_idx=0),  # misses
+        ]
+        indices, mask = _build_recurrent_track_entries(
+            reqs, [256, 150], interval=128, pool=_PingPongPool(), is_extend=True
+        )
+        np.testing.assert_array_equal(mask, np.array([1, 0], dtype=np.int32))
+        np.testing.assert_array_equal(indices, np.array([40, 0], dtype=np.int32))
+        # Only the hitting req flipped.
+        self.assertEqual(reqs[0].recurrent_next_track_idx, 1)
+        self.assertEqual(reqs[1].recurrent_next_track_idx, 0)
+
+    def test_single_slot_boundary_reads_then_stays(self):
+        # Overlap-off: one track slot. The read returns the sole slot and the
+        # "flip" keeps next_idx at 0 (no other slot to swap to).
+        pool = _PingPongPool(ping_pong_slots=1)
+        req = _FakeReq(extend_input_len=128, buffer=[40], next_idx=0)
+        entry = _recurrent_track_entry(req, 256, interval=128, pool=pool, is_extend=True)
+        self.assertTrue(entry.track_mask)
+        self.assertEqual(entry.track_index, 40)
+        self.assertEqual(req.recurrent_last_track_seqlen, 256)
+        self.assertEqual(req.recurrent_next_track_idx, 0)  # stays 0
+        # A second boundary reuses the same slot.
+        entry2 = _recurrent_track_entry(req, 384, interval=128, pool=pool, is_extend=True)
+        self.assertTrue(entry2.track_mask)
+        self.assertEqual(entry2.track_index, 40)
+        self.assertEqual(req.recurrent_next_track_idx, 0)
+
+
+class _CapturingTreeCache:
+    """Records the MatchPrefixParams init_next_round_input builds."""
+
+    disable = False
+
+    class _Root:
+        pass
+
+    def __init__(self):
+        self.root_node = self._Root()
+        self.last_params = None
+
+    def supports_recurrent(self) -> bool:
+        return True
+
+    def match_prefix(self, params):
+        self.last_params = params
+        return MatchResult(
+            device_indices=np.empty((0,), dtype=np.int32),
+            last_device_node=self.root_node,
+            last_host_node=self.root_node,
+            best_match_node=self.root_node,
+            host_hit_length=0,
+        )
+
+
+def _bare_req(rid):
+    return Req(
+        rid=rid,
+        origin_input_text="",
+        origin_input_ids=[1, 2, 3, 4],
+        sampling_params=SamplingParams(max_new_tokens=8),
+        eos_token_ids={9},
+        vocab_size=32000,
+    )
+
+
+class TestFullOnlyRematch(unittest.TestCase):
+    """A running recurrent req re-matches FULL-only, no re-clone."""
+
+    def test_running_recurrent_req_full_only_no_clone(self):
+        cache = _CapturingTreeCache()
+        req = _bare_req("running")
+        req.recurrent_pool_idx = 7  # already owns a running slot
+        req.init_next_round_input(cache)
+        self.assertTrue(cache.last_params.full_only)
+        self.assertFalse(cache.last_params.cow_recurrent)
+
+    def test_new_prefill_clones_and_matches_all_components(self):
+        cache = _CapturingTreeCache()
+        req = _bare_req("fresh")
+        req.recurrent_pool_idx = None  # no running slot yet
+        req.init_next_round_input(cache)
+        self.assertFalse(cache.last_params.full_only)
+        self.assertTrue(cache.last_params.cow_recurrent)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_recurrent_track_scatter.py
+++ b/test/srt/test_recurrent_track_scatter.py
@@ -1,0 +1,404 @@
+"""KDA / GDN backends must scatter the SAME final state written to the running slot
+ALSO into each request's track slot (gated on track_mask and the idx == 0 guard);
+with no track metadata the output is byte-identical to the no-track path, and
+Lightning/GLA fails fast. Pure-JAX scatters on a forced multi-device CPU mesh."""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+# Force a multi-device CPU mesh before JAX initializes. The CI cpu-test job sets
+# USE_DEVICE_TYPE=cpu; standalone runs (suite's unittest runner) need the same
+# pins so >=2 devices exist for the sharded track scatter.
+if os.environ.get("USE_DEVICE_TYPE") == "cpu" or "XLA_FLAGS" not in os.environ:
+    os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
+    os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.kernels.gdn.gated_delta import (
+    _scatter_idx0_safe,
+    _scatter_track,
+    decode_gated_delta_rule_ref,
+    jax_causal_conv1d_prefill,
+    jax_causal_conv1d_update,
+    ragged_gated_delta_rule_ref,
+)
+from sgl_jax.srt.layers.attention.hybrid_linear_attn_backend import (
+    LinearRecurrentAttnBackendMetadata,
+)
+from sgl_jax.srt.layers.attention.linear.kda_backend import KDAAttnBackend
+from sgl_jax.srt.layers.attention.linear.lightning_backend import LightningAttnBackend
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+
+# Forced multi-device CPU mesh (dp=1, tp=2) over a 2-device subset. The CPU
+# suite pins JAX_PLATFORMS=cpu + xla_force_host_platform_device_count=8. We put
+# both devices on the "tensor" axis so the FULL pool buffer is visible per DP
+# rank (absolute slot indices stay valid) while the head dim is sharded -- the
+# same shard_map the production scatter runs through. The track scatter is pure
+# JAX, so a 2-way tensor split exercises it.
+_DEVICES = jax.devices()[:2] if len(jax.devices()) >= 2 else jax.devices()
+mesh = create_device_mesh(
+    ici_parallelism=[1, len(_DEVICES)], dcn_parallelism=[1, 1], devices=_DEVICES
+)
+jax.sharding.set_mesh(mesh)
+
+
+def _data(arr) -> jax.Array:
+    return jax.device_put(np.asarray(arr), NamedSharding(mesh, P("data")))
+
+
+class TestKDATrackScatter(unittest.TestCase):
+    """KDA parallel track scatter onto the running-scatter result."""
+
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self.backend = KDAAttnBackend(mesh=mesh)
+        self.rng = np.random.default_rng(0)
+        # 4 slots: idx 0 = dummy. recurrent [N, H, K, V]; conv [N, D, K-1].
+        self.N, self.H, self.K, self.V = 4, 2, 8, 8
+        self.D, self.Km1 = 6, 3
+        self.ssm_buf = jnp.asarray(
+            self.rng.standard_normal((self.N, self.H, self.K, self.V)), jnp.float32
+        )
+        self.conv_buf = jnp.asarray(
+            self.rng.standard_normal((self.N, self.D, self.Km1)), jnp.float32
+        )
+
+    def test_ssm_track_mask_on_writes_slot(self):
+        # Two requests routed to running slots 1,2; track slots 3, 0 (dummy).
+        track_idx = _data(np.array([3, 1], dtype=np.int32))
+        track_mask = _data(np.array([1, 1], dtype=np.int32))
+        new_rec = jnp.asarray(self.rng.standard_normal((2, self.H, self.K, self.V)), jnp.float32)
+        new_rec = jax.device_put(new_rec, NamedSharding(mesh, P("data", "tensor", None, None)))
+        buf = jax.device_put(self.ssm_buf, NamedSharding(mesh, P("data", "tensor", None, None)))
+
+        out = self.backend.set_ssm_track_state(buf, track_idx, track_mask, new_rec)
+        out = np.asarray(out)
+        # track slot 3 (mask=1, idx!=0) takes new_rec[0]; slot 1 takes new_rec[1].
+        np.testing.assert_array_equal(out[3], np.asarray(new_rec)[0])
+        np.testing.assert_array_equal(out[1], np.asarray(new_rec)[1])
+        # untouched slot 2 unchanged.
+        np.testing.assert_array_equal(out[2], np.asarray(self.ssm_buf)[2])
+
+    def test_ssm_track_mask_off_preserves_slot(self):
+        track_idx = _data(np.array([3, 2], dtype=np.int32))
+        track_mask = _data(np.array([0, 0], dtype=np.int32))  # no boundary
+        new_rec = jnp.asarray(self.rng.standard_normal((2, self.H, self.K, self.V)), jnp.float32)
+        new_rec = jax.device_put(new_rec, NamedSharding(mesh, P("data", "tensor", None, None)))
+        buf = jax.device_put(self.ssm_buf, NamedSharding(mesh, P("data", "tensor", None, None)))
+
+        out = np.asarray(self.backend.set_ssm_track_state(buf, track_idx, track_mask, new_rec))
+        np.testing.assert_array_equal(out[3], np.asarray(self.ssm_buf)[3])
+        np.testing.assert_array_equal(out[2], np.asarray(self.ssm_buf)[2])
+
+    def test_ssm_track_idx0_is_noop(self):
+        track_idx = _data(np.array([0, 0], dtype=np.int32))  # dummy slot
+        track_mask = _data(np.array([1, 1], dtype=np.int32))  # mask on but idx==0
+        new_rec = jnp.asarray(self.rng.standard_normal((2, self.H, self.K, self.V)), jnp.float32)
+        new_rec = jax.device_put(new_rec, NamedSharding(mesh, P("data", "tensor", None, None)))
+        buf = jax.device_put(self.ssm_buf, NamedSharding(mesh, P("data", "tensor", None, None)))
+
+        out = np.asarray(self.backend.set_ssm_track_state(buf, track_idx, track_mask, new_rec))
+        np.testing.assert_array_equal(out[0], np.asarray(self.ssm_buf)[0])
+
+    def test_conv_track_mask_on_writes_slot(self):
+        track_idx = _data(np.array([3, 1], dtype=np.int32))
+        track_mask = _data(np.array([1, 0], dtype=np.int32))
+        new_conv = jnp.asarray(self.rng.standard_normal((2, self.D, self.Km1)), jnp.float32)
+        new_conv = jax.device_put(new_conv, NamedSharding(mesh, P("data", "tensor", None)))
+        buf = jax.device_put(self.conv_buf, NamedSharding(mesh, P("data", "tensor", None)))
+
+        out = np.asarray(
+            self.backend.set_conv_track_state([buf], track_idx, track_mask, new_conv)[0]
+        )
+        np.testing.assert_array_equal(out[3], np.asarray(new_conv)[0])  # mask on
+        np.testing.assert_array_equal(out[1], np.asarray(self.conv_buf)[1])  # mask off
+
+
+class TestGDNScatterTrack(unittest.TestCase):
+    """GDN ``_scatter_track`` helper + the 4 kernel-site track scatters."""
+
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self.rng = np.random.default_rng(1)
+
+    def test_scatter_track_mask_and_idx_guard(self):
+        buf = jnp.asarray(self.rng.standard_normal((4, 3, 5)), jnp.float32)
+        val = jnp.asarray(self.rng.standard_normal((3, 3, 5)), jnp.float32)
+        track_idx = jnp.array([2, 0, 3], dtype=np.int32)  # idx 0 = dummy
+        track_mask = jnp.array([1, 1, 0], dtype=np.int32)  # row2 mask off
+        out = np.asarray(_scatter_track(buf, track_idx, track_mask, val))
+        np.testing.assert_array_equal(out[2], np.asarray(val)[0])  # mask on, idx!=0
+        np.testing.assert_array_equal(out[0], np.asarray(buf)[0])  # idx==0 guard
+        np.testing.assert_array_equal(out[3], np.asarray(buf)[3])  # mask off
+
+    def test_conv_prefill_track_scatter(self):
+        D, K, B = 4, 3, 2
+        T = 6
+        x = jnp.asarray(self.rng.standard_normal((D, T)), jnp.float32)
+        weight = jnp.asarray(self.rng.standard_normal((D, K)), jnp.float32)
+        conv_state = jnp.asarray(self.rng.standard_normal((4, D, K - 1)), jnp.float32)
+        cu = jnp.array([0, 3, 6], dtype=np.int32)
+        state_idx = jnp.array([1, 2], dtype=np.int32)
+        has_init = jnp.array([True, True])
+        track_idx = jnp.array([3, 0], dtype=np.int32)
+        track_mask = jnp.array([1, 1], dtype=np.int32)
+
+        _, base = jax_causal_conv1d_prefill(
+            x, weight, None, cu, conv_state, state_idx, has_init, "silu"
+        )
+        _, tracked = jax_causal_conv1d_prefill(
+            x,
+            weight,
+            None,
+            cu,
+            conv_state,
+            state_idx,
+            has_init,
+            "silu",
+            track_indices=track_idx,
+            track_mask=track_mask,
+        )
+        base, tracked = np.asarray(base), np.asarray(tracked)
+        # track slot 3 (req 0, mask on) takes req 0's running-slot final state.
+        np.testing.assert_array_equal(tracked[3], base[1])
+        np.testing.assert_array_equal(tracked[0], base[0])  # idx==0 untouched
+        # running slots still match the no-track scatter.
+        np.testing.assert_array_equal(tracked[1], base[1])
+        np.testing.assert_array_equal(tracked[2], base[2])
+
+    def test_conv_update_track_scatter(self):
+        D, K, B = 4, 3, 2
+        x = jnp.asarray(self.rng.standard_normal((B, D)), jnp.float32)
+        weight = jnp.asarray(self.rng.standard_normal((D, K)), jnp.float32)
+        conv_state = jnp.asarray(self.rng.standard_normal((4, D, K - 1)), jnp.float32)
+        state_idx = jnp.array([1, 2], dtype=np.int32)
+        track_idx = jnp.array([3, 0], dtype=np.int32)
+        track_mask = jnp.array([1, 0], dtype=np.int32)
+
+        _, base = jax_causal_conv1d_update(
+            x, conv_state, state_idx, weight, None, "silu", jnp.array([True, True])
+        )
+        _, tracked = jax_causal_conv1d_update(
+            x,
+            conv_state,
+            state_idx,
+            weight,
+            None,
+            "silu",
+            jnp.array([True, True]),
+            track_indices=track_idx,
+            track_mask=track_mask,
+        )
+        base, tracked = np.asarray(base), np.asarray(tracked)
+        np.testing.assert_array_equal(tracked[3], base[1])  # req 0 -> track slot 3
+        np.testing.assert_array_equal(tracked[1], base[1])  # running preserved
+
+    def test_ragged_recurrent_track_scatter(self):
+        n_kq, n_v, d_k, d_v = 2, 2, 4, 4
+        conv_dim = 2 * n_kq * d_k + n_v * d_v
+        T = 6
+        mixed = jnp.asarray(self.rng.standard_normal((T, conv_dim)), jnp.float32)
+        b = jnp.asarray(self.rng.standard_normal((T, n_v)), jnp.float32)
+        a = jnp.asarray(self.rng.standard_normal((T, n_v)), jnp.float32)
+        rec = jnp.asarray(self.rng.standard_normal((4, n_v, d_k, d_v)), jnp.float32)
+        A_log = jnp.asarray(self.rng.standard_normal((n_v,)), jnp.float32)
+        dt_bias = jnp.asarray(self.rng.standard_normal((n_v,)), jnp.float32)
+        cu = jnp.array([0, 3, 6], dtype=np.int32)
+        state_idx = jnp.array([1, 2], dtype=np.int32)
+        has_init = jnp.array([True, True])
+        track_idx = jnp.array([3, 0], dtype=np.int32)
+        track_mask = jnp.array([1, 1], dtype=np.int32)
+
+        base, _ = ragged_gated_delta_rule_ref(
+            mixed,
+            b,
+            a,
+            rec,
+            A_log,
+            dt_bias,
+            cu,
+            state_idx,
+            has_init,
+            n_kq=n_kq,
+            n_v=n_v,
+            d_k=d_k,
+            d_v=d_v,
+        )
+        tracked, _ = ragged_gated_delta_rule_ref(
+            mixed,
+            b,
+            a,
+            rec,
+            A_log,
+            dt_bias,
+            cu,
+            state_idx,
+            has_init,
+            n_kq=n_kq,
+            n_v=n_v,
+            d_k=d_k,
+            d_v=d_v,
+            track_indices=track_idx,
+            track_mask=track_mask,
+        )
+        base, tracked = np.asarray(base), np.asarray(tracked)
+        np.testing.assert_array_equal(tracked[3], base[1])  # req 0 -> track slot 3
+        np.testing.assert_array_equal(tracked[0], base[0])  # idx==0 dummy untouched
+        np.testing.assert_array_equal(tracked[1], base[1])  # running preserved
+
+    def test_decode_recurrent_track_scatter(self):
+        n_kq, n_v, d_k, d_v = 2, 2, 4, 4
+        conv_dim = 2 * n_kq * d_k + n_v * d_v
+        B = 2
+        mixed = jnp.asarray(self.rng.standard_normal((B, conv_dim)), jnp.float32)
+        b = jnp.asarray(self.rng.standard_normal((B, n_v)), jnp.float32)
+        a = jnp.asarray(self.rng.standard_normal((B, n_v)), jnp.float32)
+        rec = jnp.asarray(self.rng.standard_normal((4, n_v, d_k, d_v)), jnp.float32)
+        A_log = jnp.asarray(self.rng.standard_normal((n_v,)), jnp.float32)
+        dt_bias = jnp.asarray(self.rng.standard_normal((n_v,)), jnp.float32)
+        state_idx = jnp.array([1, 2], dtype=np.int32)
+        track_idx = jnp.array([3, 0], dtype=np.int32)
+        track_mask = jnp.array([1, 1], dtype=np.int32)
+
+        base, _ = decode_gated_delta_rule_ref(
+            mixed,
+            b,
+            a,
+            rec,
+            A_log,
+            dt_bias,
+            state_idx,
+            n_kq=n_kq,
+            n_v=n_v,
+            d_k=d_k,
+            d_v=d_v,
+        )
+        tracked, _ = decode_gated_delta_rule_ref(
+            mixed,
+            b,
+            a,
+            rec,
+            A_log,
+            dt_bias,
+            state_idx,
+            n_kq=n_kq,
+            n_v=n_v,
+            d_k=d_k,
+            d_v=d_v,
+            track_indices=track_idx,
+            track_mask=track_mask,
+        )
+        base, tracked = np.asarray(base), np.asarray(tracked)
+        np.testing.assert_array_equal(tracked[3], base[1])  # req 0 -> track slot 3
+        np.testing.assert_array_equal(tracked[1], base[1])  # running preserved
+
+
+class TestTrackScatterOffByteIdentical(unittest.TestCase):
+    """track_indices=None -> identical scatter output to the no-track path."""
+
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+        self.rng = np.random.default_rng(2)
+
+    def test_decode_recurrent_none_equals_no_track(self):
+        n_kq, n_v, d_k, d_v = 2, 2, 4, 4
+        conv_dim = 2 * n_kq * d_k + n_v * d_v
+        B = 2
+        mixed = jnp.asarray(self.rng.standard_normal((B, conv_dim)), jnp.float32)
+        b = jnp.asarray(self.rng.standard_normal((B, n_v)), jnp.float32)
+        a = jnp.asarray(self.rng.standard_normal((B, n_v)), jnp.float32)
+        rec = jnp.asarray(self.rng.standard_normal((4, n_v, d_k, d_v)), jnp.float32)
+        A_log = jnp.asarray(self.rng.standard_normal((n_v,)), jnp.float32)
+        dt_bias = jnp.asarray(self.rng.standard_normal((n_v,)), jnp.float32)
+        state_idx = jnp.array([1, 2], dtype=np.int32)
+
+        no_arg, no_out = decode_gated_delta_rule_ref(
+            mixed,
+            b,
+            a,
+            rec,
+            A_log,
+            dt_bias,
+            state_idx,
+            n_kq=n_kq,
+            n_v=n_v,
+            d_k=d_k,
+            d_v=d_v,
+        )
+        none_arg, none_out = decode_gated_delta_rule_ref(
+            mixed,
+            b,
+            a,
+            rec,
+            A_log,
+            dt_bias,
+            state_idx,
+            n_kq=n_kq,
+            n_v=n_v,
+            d_k=d_k,
+            d_v=d_v,
+            track_indices=None,
+            track_mask=None,
+        )
+        np.testing.assert_array_equal(np.asarray(no_arg), np.asarray(none_arg))
+        np.testing.assert_array_equal(np.asarray(no_out), np.asarray(none_out))
+
+    def test_conv_prefill_none_equals_no_track(self):
+        D, K = 4, 3
+        T = 6
+        x = jnp.asarray(self.rng.standard_normal((D, T)), jnp.float32)
+        weight = jnp.asarray(self.rng.standard_normal((D, K)), jnp.float32)
+        conv_state = jnp.asarray(self.rng.standard_normal((4, D, K - 1)), jnp.float32)
+        cu = jnp.array([0, 3, 6], dtype=np.int32)
+        state_idx = jnp.array([1, 2], dtype=np.int32)
+        has_init = jnp.array([True, True])
+
+        _, no_arg = jax_causal_conv1d_prefill(
+            x, weight, None, cu, conv_state, state_idx, has_init, "silu"
+        )
+        _, none_arg = jax_causal_conv1d_prefill(
+            x,
+            weight,
+            None,
+            cu,
+            conv_state,
+            state_idx,
+            has_init,
+            "silu",
+            track_indices=None,
+            track_mask=None,
+        )
+        np.testing.assert_array_equal(np.asarray(no_arg), np.asarray(none_arg))
+
+
+class TestLightningTrackFailFast(unittest.TestCase):
+    """GLA/Lightning fails fast when track metadata reaches the backend."""
+
+    def setUp(self):
+        if not jax.devices():
+            self.skipTest("JAX not available")
+
+    def test_track_metadata_raises(self):
+        backend = LightningAttnBackend(mesh=mesh)
+        backend.forward_metadata = LinearRecurrentAttnBackendMetadata(
+            recurrent_track_indices=_data(np.array([1, 2], dtype=np.int32)),
+            recurrent_track_mask=_data(np.array([1, 1], dtype=np.int32)),
+        )
+        layer = type("L", (), {"layer_id": 0})()
+        fb = type("FB", (), {"forward_mode": None})()
+        with self.assertRaises(NotImplementedError):
+            backend(None, None, None, layer=layer, forward_batch=fb, recurrent_state_pool=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_unified_radix_cache_serving.py
+++ b/test/srt/test_unified_radix_cache_serving.py
@@ -1,6 +1,6 @@
 """Serving-level verification for ``--enable-unified-radix-tree``.
 
-HiCache Stage 1, S1c (#1337).
+unified radix tree (#1337); recurrent page=1 backfill (#1380).
 
 Scope is intentionally flag-on only: this per-PR test proves the enabled
 UnifiedRadixCache serving path is active and correct. The Radix / no-cache /
@@ -11,6 +11,14 @@ Qwen3-1.7B is non-hybrid, so ``--enable-unified-radix-tree`` routes the cache
 to UnifiedRadixCache via the registry. The ``/get_server_info`` assertion in
 ``setUpClass`` confirms the flag actually took effect before any cache
 behavior is checked.
+
+``TestUnifiedRadixCacheServingRecurrent`` covers the recurrent (GDN-hybrid)
+production path at ``--page-size 128 --enable-recurrent-extra-buffer``: a
+Qwen3.5-35B-A3B (qwen3_5_moe) model routes to UnifiedRadixCache with a recurrent
+component, and the cache-hit run must stay byte-identical to a
+``--disable-radix-cache`` baseline (the KL==0 guarantee for the extra-buffer
+path). It needs 4 chips and a ~72GB checkpoint, so it is kept out of per-PR CI
+(run manually / on GKE; nightly recurrent gate: #1425).
 """
 
 import unittest
@@ -23,11 +31,19 @@ from sgl_jax.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
+    QWEN3_5_35B_A3B,
     CustomTestCase,
     popen_launch_server,
 )
 
-_PAGE_SIZE = 64
+_PAGE_SIZE = 128
+
+# Recurrent (GDN-hybrid) checkpoint for the extra-buffer serving test. Resolved
+# under SGLANG_JAX_MODEL_CACHE like the other model constants (qwen3_5_moe, fits
+# 4 chips at tp=4).
+RECURRENT_MODEL_PATH = QWEN3_5_35B_A3B
+_RECURRENT_PAGE_SIZE = 128
+_RECURRENT_TP_SIZE = 4
 
 # Do NOT add "--stream-output": the cache-hit kit assumes each chunk carries the
 # full accumulated output_ids (only true with the default stream_output=False).
@@ -40,7 +56,7 @@ _SERVER_ARGS = [
     "--max-running-requests",
     "16",
     "--page-size",
-    "64",
+    str(_PAGE_SIZE),
     "--random-seed",
     "42",
     "--enable-unified-radix-tree",
@@ -126,14 +142,15 @@ class TestUnifiedRadixCacheServing(CustomTestCase):
         self.assertGreater(result["overall"]["cache_hit_rate"], 0.0)
 
     def test_hit_flush_determinism(self):
-        # paragraph * 6 tokenizes to well over one page.
+        # paragraph * 10 tokenizes to ~350 tokens, comfortably over two pages
+        # (page_size=128).
         paragraph = (
             "In the field of artificial intelligence, large language models have "
             "shown remarkable capabilities in natural language processing. These "
             "models can perform text generation, translation, summarization, and "
             "question answering. "
         )
-        prompt = paragraph * 6
+        prompt = paragraph * 10
 
         # 1. Cold: empty tree -> nothing cached.
         flush_cache(self.base_url)
@@ -159,6 +176,204 @@ class TestUnifiedRadixCacheServing(CustomTestCase):
         post_flush = self._generate(prompt)
         self.assertEqual(post_flush["meta_info"]["cached_tokens"], 0)
         self.assertEqual(post_flush["text"], cold["text"])
+
+
+class TestUnifiedRadixCacheServingRecurrent(CustomTestCase):
+    """Recurrent (GDN-hybrid) extra-buffer serving determinism.
+
+    A Qwen3.5-35B-A3B (qwen3_5_moe) model under ``--enable-unified-radix-tree
+    --enable-recurrent-extra-buffer --page-size 128`` routes to UnifiedRadixCache
+    with a recurrent component. The cache-hit run must be byte-identical to a
+    ``--disable-radix-cache`` baseline, proving the KL==0 guarantee holds for the
+    production extra-buffer recurrent path.
+
+    Sampler caveat: use greedy + ``--random-seed`` only; ``--precompile-bs-paddings``
+    pinned to multiples of tp_size*t_packing (=8) keeps the decode batch divisible
+    by the device count and satisfies the fused MoE alignment. Do NOT add
+    ``--enable-deterministic-sampling`` (it crashes on the sampler ``lax.cond``
+    divisibility bug).
+    """
+
+    # Shared launch args except the radix-cache toggle (cache vs baseline).
+    _COMMON_ARGS = [
+        "--trust-remote-code",
+        "--skip-server-warmup",
+        "--dtype",
+        "bfloat16",
+        "--tp-size",
+        str(_RECURRENT_TP_SIZE),
+        "--nnodes",
+        "1",
+        "--dist-init-addr",
+        "0.0.0.0:10011",
+        "--mem-fraction-static",
+        "0.8",
+        # Bound the context so the heavy recurrent model leaves room for
+        # running requests on 4 chips (its full context would force
+        # max_running_requests to 0). The test prompt is far under this.
+        "--context-length",
+        "8192",
+        "--chunked-prefill-size",
+        "512",
+        "--page-size",
+        str(_RECURRENT_PAGE_SIZE),
+        "--max-running-requests",
+        "16",
+        "--random-seed",
+        "42",
+        "--disable-overlap-schedule",
+        # bs paddings pinned to multiples of tp_size*t_packing (=8): keeps the
+        # decode batch divisible by the device count (sampler lax.cond) and gives
+        # each device >=2 tokens, satisfying the fused MoE t_packing=2 alignment
+        # for this qwen3_5_moe checkpoint at tp=4 (bs=4 -> 1 token/device fails).
+        "--precompile-bs-paddings",
+        "8",
+        "16",
+        "--precompile-token-paddings",
+        "512",
+        "1024",
+    ]
+    _ENV = {"JAX_COMPILATION_CACHE_DIR": "/tmp/jax_compilation_cache"}
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = RECURRENT_MODEL_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            base_url=cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls._COMMON_ARGS
+            + [
+                "--enable-unified-radix-tree",
+                "--enable-recurrent-extra-buffer",
+                # Cap the recurrent pool. The default ratio-based sizing reserves
+                # ~0.9 of HBM, which with the 35B weights on 4 chips leaves a
+                # negative KV budget. 96 slots (slot_factor=3 -> ~32 reqs) covers
+                # max_running_requests=16 and leaves ample KV. The baseline server
+                # uses --disable-radix-cache, which auto-sizes from max-running.
+                "--max-recurrent-state-size",
+                "96",
+            ],
+            env=cls._ENV,
+        )
+
+        # Fail fast for the whole class if the flag or page size didn't take.
+        try:
+            resp = requests.get(f"{cls.base_url}/get_server_info", timeout=30)
+            resp.raise_for_status()
+            info = resp.json()
+            assert info["enable_unified_radix_tree"] is True, (
+                f"server did not enable unified radix tree: "
+                f"enable_unified_radix_tree={info.get('enable_unified_radix_tree')!r}"
+            )
+            assert info["page_size"] == _RECURRENT_PAGE_SIZE, (
+                f"server page_size={info.get('page_size')!r}, " f"expected {_RECURRENT_PAGE_SIZE}"
+            )
+        except Exception:
+            kill_process_tree(cls.process.pid)
+            raise
+
+    @classmethod
+    def tearDownClass(cls):
+        proc = getattr(cls, "process", None)
+        if proc is not None:
+            kill_process_tree(proc.pid)
+            try:
+                proc.wait(timeout=30)
+            except Exception:
+                pass
+
+    def _generate(self, prompt):
+        resp = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": prompt,
+                "sampling_params": {"temperature": 0, "max_new_tokens": 80},
+            },
+            timeout=300,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    @classmethod
+    def _baseline_text(cls, prompt):
+        """Generate the same prompt on a fresh ``--disable-radix-cache`` server.
+
+        The recurrent hit run must reproduce this byte-for-byte. A separate
+        process avoids any cache state from the unified-tree server leaking in.
+        """
+        proc = popen_launch_server(
+            cls.model,
+            base_url=cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls._COMMON_ARGS + ["--disable-radix-cache"],
+            env=cls._ENV,
+        )
+        try:
+            resp = requests.post(
+                f"{cls.base_url}/generate",
+                json={
+                    "text": prompt,
+                    "sampling_params": {"temperature": 0, "max_new_tokens": 80},
+                },
+                timeout=300,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            assert data["meta_info"]["cached_tokens"] == 0, (
+                "baseline must run with radix cache disabled: "
+                f"cached_tokens={data['meta_info']['cached_tokens']}"
+            )
+            return data["text"]
+        finally:
+            kill_process_tree(proc.pid)
+            try:
+                proc.wait(timeout=30)
+            except Exception:
+                pass
+
+    def test_recurrent_hit_flush_determinism(self):
+        paragraph = (
+            "In the field of artificial intelligence, large language models have "
+            "shown remarkable capabilities in natural language processing. These "
+            "models can perform text generation, translation, summarization, and "
+            "question answering. "
+        )
+        # Long enough to cross a recurrent track boundary (track_interval
+        # defaults to chunked_prefill_size=512), so the recurrent snapshot is
+        # actually cached and reused on the hit -- not just the full-KV pages.
+        prompt = paragraph * 16
+
+        # 1. Cold: empty tree -> nothing cached.
+        flush_cache(self.base_url)
+        cold = self._generate(prompt)
+        self.assertEqual(cold["meta_info"]["cached_tokens"], 0)
+
+        # 2. Hit: re-send -> recurrent prefix cached, output unchanged.
+        hit = self._generate(prompt)
+        prompt_tokens = hit["meta_info"]["prompt_tokens"]
+        self.assertGreater(hit["meta_info"]["cached_tokens"], 0)
+        self.assertLessEqual(hit["meta_info"]["cached_tokens"], prompt_tokens)
+        self.assertEqual(hit["text"], cold["text"])
+
+        # 3. Post-flush: tree emptied -> nothing cached; shape-identical to cold.
+        flush_cache(self.base_url)
+        post_flush = self._generate(prompt)
+        self.assertEqual(post_flush["meta_info"]["cached_tokens"], 0)
+        self.assertEqual(post_flush["text"], cold["text"])
+
+        # 4. KL==0: the cache-hit output is byte-identical to a no-cache baseline.
+        # Restart on the same URL with radix cache disabled, so kill our server
+        # first to free the port.
+        kill_process_tree(type(self).process.pid)
+        try:
+            type(self).process.wait(timeout=30)
+        except Exception:
+            pass
+        type(self).process = None
+        baseline_text = self._baseline_text(prompt)
+        self.assertEqual(hit["text"], baseline_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## Summary

Adds the production **page>=128 recurrent radix cache** path behind
`--enable-recurrent-extra-buffer`, plus root-cause recurrent pool sizing and admission
backpressure. Builds on the page=1 recurrent base (#1401, merged). Off by default; flag-off and
non-recurrent paths are unchanged.

Tracked by #1424 (under #1339 / #1338). Builds on #1401 (merged).

## What changed

### Extra-buffer path (page>=128)
| Area | Change |
|---|---|
| `memory_pool.py` | Page-aligned ping-pong track slots (2 with overlap scheduling, 1 without) + request-owned-slot ledger and track-slot API. |
| `managers/schedule_batch.py`, `managers/schedule_policy.py` | Scheduler splits prefill at track-interval boundaries so the published snapshot is always the forward's final state (no mid-forward extraction). |
| `model_executor/forward_batch_info.py` | `recurrent_track_indices` / `recurrent_track_mask` metadata. |
| `kernels/gdn/gated_delta.py`, `attention/linear/{kda,gdn}_backend.py`, `attention/hybrid_linear_attn_backend.py`, `attention/linear/short_convolution.py` | Masked track scatter into the keep slot, wrapped in `optimization_barrier` (donated-buffer aliasing guard under multi-host SPMD). |
| `unified_cache_components/recurrent_component.py`, `unified_radix_cache.py` | Extra-buffer commit/donation + shortfall eviction. |
| `server_args.py`, `cache_init_params.py`, `kv_cache_builder.py`, `registry.py`, `base_prefix_cache.py` | `--enable-recurrent-extra-buffer` + `--recurrent-track-interval` (defaults to `chunked_prefill_size` to avoid the chunked-prefill chunk-size accuracy penalty); reject unsupported combinations at init (speculative decoding, mixed chunked prefill, GLA/Lightning, page<=1, disable-radix-cache). |

### Pool sizing / admission (over-subscription throttles instead of crashing)
| Area | Change |
|---|---|
| `model_executor/model_runner_kv_cache_mixin.py` | Split the back-cap reservation factor from actual per-request consumption; overlap-aware `request_owned_slots`; explicit snapshot-headroom contract (the auto/memory-ratio path reserves headroom and caps running by consumption; the explicit `--max-recurrent-state-size` path keeps the operator's max_running and warns on near-zero headroom). Fail-fast at startup when a rank has fewer recurrent slots than one request consumes. |
| `managers/scheduler.py` | Recurrent admission backpressure: defer a request when a rank's free + evictable recurrent slots cannot cover demand, instead of an `alloc_req_slots` crash. The check is match-aware — a cross-request prefix hit keeps its matched snapshot locked for the request's lifetime, so that slot is discounted from the evictable pool. Recurrent-aware diagnostic on the residual allocation error. |

### Benchmark
`benchmark/hicache/bench_recurrent_reuse_sweep.py` (reuse K-sweep + capacity model) and a
`unified-recurrent` A/B mode + external-server mode in `bench_unified_radix_ab.py`.

> The dense offline `--compare` gate is already on main via #1402; net-new in this PR is the recurrent A/B (`unified-recurrent`) and external-server modes of `bench_unified_radix_ab.py`.

## Live validation

| Area | Result |
|---|---|
| CPU `unit-test-cpu` (full suite) | **pass** — CI green on this head; 221 tests across the PR-touched files locally |
| Recurrent serving determinism (GDN single-host tp4/dp2; KDA multi-host tp16/dp4) | **bit-identical** — cache-ON == no-cache, byte-for-byte, under real boundary reuse (GDN 5120-tok / KDA 3584-tok warm hits) → cache reuse is logits-transparent; multi-host ep>1 caveat below |
| Reuse K-sweep + pool robustness (multi-host, size 192) | **no crash** — through K=256 (over-capacity throttles); predict_knee K\*=128 matches `size − request_owned_slots·parallel` |
| Admission backpressure / sizing | **throttles, never crashes** — over-subscription defers (no SIGQUIT); match-aware backpressure + fail-fast undersized-pool guard, unit-tested |
| Accuracy — gsm8k (GDN Qwen3.5-35B-A3B, 200q 5-shot greedy) | **0.865 == matched no-cache control 0.865, exactly equal** (no published reference — the model card reports HMMT/AIME, not gsm8k) |
| Accuracy — GPQA-Diamond (GDN Qwen3.5-35B-A3B, robust `simple_eval`, 5 seeds/arm) | **cache-ON median 0.8333 ≥ matched no-radix median 0.8283** (same seeds; per-seed spread 0.818–0.859; published 84.2) |
| Accuracy — MMLU-Pro (GDN Qwen3.5-35B-A3B, robust `simple_eval`, 4 shuffled seeds/arm) | **cache-ON 0.846 ± 0.009 == matched no-cache control 0.847 ± 0.007** (published 85.3; the ~0.7pp offset is harness-side and arm-symmetric), ~0% parse-failures |
| Accuracy — MMLU-Pro (KDA Kimi-Linear-48B-A3B, cache-ON full-set 12,032 q) | **0.6720 ≥ 0.6574 bring-up full-set baseline** (0.8% parse-failures; no protocol-comparable published number — the model card's 51.0 uses a 4k-ctx base-model protocol) |

The recurrent cache reuse is output-transparent by construction (greedy cache-ON == no-cache is byte-identical single-host and at ep=1 multi-host, and the CPU split-equivalence test proves the recurrent scan is chunk-invariant), so cache reuse does not change the model's logits. Matched no-radix controls (same seeds, same `simple_eval` harness) close the loop empirically: gsm8k is exactly equal, the GPQA cache-ON median sits above the control median, and the MMLU-Pro means are statistically identical — residual offsets vs the model-card numbers (85.3 MMLU-Pro / 84.2 GPQA for Qwen3.5-35B-A3B) are harness-side and affect both arms equally. The low readings seen during bring-up were eval-harness artifacts (max_tokens truncation of thinking-mode CoT + a strict `ANSWER:`-only extractor), not the cache; the extractor fragility is tracked in #1409. The `recurrent_track_interval = chunked_prefill_size` default removes the chunked-prefill chunk-size accuracy penalty (a smaller interval force-splits prefill and lowers GPQA ~3.5pp).

## Performance (A/B via this branch's `bench_unified_radix_ab.py`, single-host v6e-4, GDN Qwen3.5-35B-A3B tp4)

`--configs no-cache unified-recurrent --workloads gsp random --repeats 3` (gsp: 64 groups × 16 prompts sharing a 2048-token system prompt, max concurrency 64; random: 256 × 1024/128, no shared prefix; cache flushed between reps):

| workload | config | p50 TTFT (ms) | out tok/s | total tok/s | hit rate |
|---|---|---|---|---|---|
| gsp (shared prefix) | no-cache | 36811 | 111.7 | 2062 | — |
| gsp (shared prefix) | unified-recurrent | **8095 (0.22×)** | **409.5** | **7559 (+267%)** | 0.80 |
| random (no sharing) | no-cache | 17270 | 222.6 | 2004 | — |
| random (no sharing) | unified-recurrent | 17190 | 224.3 | 2019 (+0.7%) | 0 |

Shared-prefix traffic gets 4.5× lower p50 TTFT and +267% throughput at a 0.80 hit rate; traffic with no shared prefix is overhead-neutral. A lighter-load run through the nightly A/B suite (parallel 16) corroborates: p50 TTFT ratio 0.100, hit rate 0.8020, random throughput +14.4%.

## Known limitations / next work
- Multi-host `ep>1` (GDN tp16/dp4/ep4): cache resume is within-bf16-numerics of full recompute but not byte-identical (shape-dependent argmax flip; pre-existing — reproduced identically on the pre-PR tree via a flush cold-vs-warm test). Single-host and `ep=1` multi-host are byte-identical.
- Production recurrent cache path is page>=128 with `--enable-recurrent-extra-buffer`; the page=1
  base path (#1401) remains for single-tiling KL==0.
- An explicit `--max-recurrent-state-size` still needs headroom for reuse; oversubscription
  throttles rather than crashing.
- Cache-aware DP routing (the reuse-rate uplift) is a separate PR (#1402); with the default
  `min_running` policy the per-rank reuse plateau is the ~1/dp floor.
- The bring-up accuracy dip traced to MCQ answer-extraction, not the cache. The repo's `simple_eval` MCQ extractors for `gsm8k`/`mgsm`/`math` share a strict-`ANSWER:` fragility for reasoning models (no `strip_reasoning`); tracked separately in #1409.







