### PR TITLE
refactor(scheduler): extract DP rank assignment

### DIFF
--- a/python/sgl_jax/srt/managers/dp_rank_assignment.py
+++ b/python/sgl_jax/srt/managers/dp_rank_assignment.py
@@ -1,0 +1,100 @@
+"""Scheduler-level DP rank assignment for incoming requests."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from sgl_jax.srt.managers.io_struct import TokenizedGenerateReqInput
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DpRankAssignmentResult:
+    ready_reqs: list[Any]
+    pending_reqs: list[TokenizedGenerateReqInput]
+
+
+def _valid_dp_rank(dp_rank: int | None, dp_size: int) -> bool:
+    return dp_rank is not None and 0 <= dp_rank < dp_size
+
+
+def assign_dp_ranks(
+    *,
+    recv_reqs: list[Any] | None,
+    pending_dp_reqs: list[TokenizedGenerateReqInput],
+    dp_size: int,
+    dp_schedule_policy: str,
+    select_round_robin_dp: Callable[[], int],
+    select_cache_aware_dp: Callable[[TokenizedGenerateReqInput, list[int], list[int]], int | None],
+    select_min_running_dp: Callable[[list[int], list[int]], int | None],
+    estimate_req_tokens: Callable[[TokenizedGenerateReqInput], int],
+) -> DpRankAssignmentResult:
+    """Assign or defer DP ranks for incoming generate requests.
+
+    This keeps request-intake ordering and mutation rules together while the
+    Scheduler remains the owner of live load snapshots and cache probing.
+    """
+    if recv_reqs is None:
+        recv_reqs = []
+
+    combined_reqs: list[Any] = []
+    if pending_dp_reqs:
+        combined_reqs.extend(pending_dp_reqs)
+    if recv_reqs:
+        combined_reqs.extend(recv_reqs)
+
+    if dp_size == 1:
+        for req in combined_reqs:
+            if isinstance(req, TokenizedGenerateReqInput):
+                req.dp_rank = 0
+        return DpRankAssignmentResult(ready_reqs=combined_reqs, pending_reqs=[])
+
+    pending_counts = [0] * dp_size
+    pending_token_counts = [0] * dp_size
+    ready_reqs: list[Any] = []
+    deferred_reqs: list[TokenizedGenerateReqInput] = []
+
+    for req in combined_reqs:
+        if not isinstance(req, TokenizedGenerateReqInput):
+            ready_reqs.append(req)
+            continue
+
+        if req.dp_rank is not None:
+            if _valid_dp_rank(req.dp_rank, dp_size):
+                pending_counts[req.dp_rank] += 1
+                pending_token_counts[req.dp_rank] += estimate_req_tokens(req)
+                ready_reqs.append(req)
+                continue
+
+            logger.warning(
+                "Ignoring invalid dp_rank=%s for request %s; reassigning with %s policy",
+                req.dp_rank,
+                getattr(req, "rid", None),
+                dp_schedule_policy,
+            )
+            req.dp_rank = None
+
+        if dp_schedule_policy == "round_robin":
+            req.dp_rank = select_round_robin_dp()
+            ready_reqs.append(req)
+            continue
+
+        if dp_schedule_policy == "cache_aware":
+            dp_rank = select_cache_aware_dp(req, pending_counts, pending_token_counts)
+        else:
+            dp_rank = select_min_running_dp(pending_counts, pending_token_counts)
+
+        if dp_rank is None:
+            deferred_reqs.append(req)
+            continue
+
+        req.dp_rank = dp_rank
+        pending_counts[dp_rank] += 1
+        pending_token_counts[dp_rank] += estimate_req_tokens(req)
+        ready_reqs.append(req)
+
+    return DpRankAssignmentResult(ready_reqs=ready_reqs, pending_reqs=deferred_reqs)

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -34,6 +34,7 @@ from sgl_jax.srt.disaggregation.runtime import install_disaggregation_wiring
 from sgl_jax.srt.hf_transformers_utils import get_tokenizer
 from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
 from sgl_jax.srt.managers.communication import CommunicationBackend
+from sgl_jax.srt.managers.dp_rank_assignment import assign_dp_ranks
 from sgl_jax.srt.managers.dp_schedule_policy import (
     pick_cache_aware_dp,
     req_prefix_match_key,
@@ -858,69 +859,18 @@ class Scheduler(
         Requests without a dp assignment (min-running + all full) are queued and
         retried in the next loop to keep ordering deterministic across nodes.
         """
-        if recv_reqs is None:
-            recv_reqs = []
-
-        # Preserve FIFO order: older pending requests first, then new arrivals.
-        combined_reqs = []
-        if self.pending_dp_reqs:
-            combined_reqs.extend(self.pending_dp_reqs)
-            self.pending_dp_reqs = []
-        if recv_reqs:
-            combined_reqs.extend(recv_reqs)
-
-        if self.dp_size == 1:
-            for req in combined_reqs:
-                # Only assign dp_rank to TokenizedGenerateReqInput
-                if isinstance(req, TokenizedGenerateReqInput):
-                    req.dp_rank = 0
-            return combined_reqs
-
-        pending_counts = [0] * self.dp_size
-        pending_token_counts = [0] * self.dp_size
-        ready_reqs: list[Req] = []
-
-        for req in combined_reqs:
-            # Only assign dp_rank to TokenizedGenerateReqInput
-            if not isinstance(req, TokenizedGenerateReqInput):
-                ready_reqs.append(req)
-                continue
-
-            # Skip if dp_rank already set (e.g., sticky sessions)
-            if req.dp_rank is not None:
-                if 0 <= req.dp_rank < self.dp_size:
-                    pending_counts[req.dp_rank] += 1
-                    pending_token_counts[req.dp_rank] += self._estimate_req_tokens(req)
-                ready_reqs.append(req)
-                continue
-
-            if self.dp_schedule_policy == "round_robin":
-                req.dp_rank = self._select_round_robin_dp()
-                ready_reqs.append(req)
-                continue
-
-            if self.dp_schedule_policy == "cache_aware":
-                dp_rank = self._select_cache_aware_dp(
-                    req,
-                    extra_counts=pending_counts,
-                    extra_token_counts=pending_token_counts,
-                )
-            else:
-                dp_rank = self._select_min_running_dp(
-                    extra_counts=pending_counts,
-                    extra_token_counts=pending_token_counts,
-                )
-            if dp_rank is None:
-                # All DP ranks are full; keep the request pending.
-                self.pending_dp_reqs.append(req)
-                continue
-
-            req.dp_rank = dp_rank
-            pending_counts[dp_rank] += 1
-            pending_token_counts[dp_rank] += self._estimate_req_tokens(req)
-            ready_reqs.append(req)
-
-        return ready_reqs
+        result = assign_dp_ranks(
+            recv_reqs=recv_reqs,
+            pending_dp_reqs=self.pending_dp_reqs,
+            dp_size=self.dp_size,
+            dp_schedule_policy=self.dp_schedule_policy,
+            select_round_robin_dp=self._select_round_robin_dp,
+            select_cache_aware_dp=self._select_cache_aware_dp,
+            select_min_running_dp=self._select_min_running_dp,
+            estimate_req_tokens=self._estimate_req_tokens,
+        )
+        self.pending_dp_reqs = result.pending_reqs
+        return result.ready_reqs
 
     def event_loop_normal(self):
         """A normal scheduler loop."""

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -324,6 +324,7 @@ suites = {
         TestFile("python/sgl_jax/test/mem_cache/test_host_kv_pool.py", 1, runner="pytest"),
         TestFile("python/sgl_jax/test/test_kv_cache_builder.py", 0.1, runner="pytest"),
         TestFile("test/srt/test_dp_schedule_policy.py", 0.2, runner="pytest"),
+        TestFile("test/srt/test_dp_rank_assignment.py", 0.2, runner="pytest"),
         TestFile("test/srt/function_call/test_qwen3_coder_detector.py", 0.1),
         TestFile("test/srt/function_call/test_glm4_moe_detector.py", 0.1),
         TestFile("test/srt/function_call/test_qwen25_detector.py", 0.1),

--- a/test/srt/test_dp_rank_assignment.py
+++ b/test/srt/test_dp_rank_assignment.py
@@ -1,0 +1,203 @@
+"""Characterization tests for scheduler-level DP rank assignment."""
+
+from __future__ import annotations
+
+from sgl_jax.srt.managers.dp_rank_assignment import assign_dp_ranks
+from sgl_jax.srt.managers.io_struct import TokenizedGenerateReqInput
+
+
+def _req(
+    rid: str,
+    *,
+    dp_rank: int | None = None,
+    input_len: int = 4,
+    max_new_tokens: int = 4,
+) -> TokenizedGenerateReqInput:
+    return TokenizedGenerateReqInput(
+        rid=rid,
+        input_ids=list(range(input_len)),
+        sampling_params={"max_new_tokens": max_new_tokens},
+        dp_rank=dp_rank,
+    )
+
+
+class _DpAssignmentHarness:
+    def __init__(
+        self,
+        *,
+        dp_size: int = 2,
+        running_counts: list[int] | None = None,
+        running_token_counts: list[int] | None = None,
+        full_ranks: set[int] | None = None,
+        per_dp_max_running_requests: int = 8,
+    ):
+        self.dp_size = dp_size
+        self.running_counts = running_counts or [0] * dp_size
+        self.running_token_counts = running_token_counts or [0] * dp_size
+        self.full_ranks = full_ranks or set()
+        self.per_dp_max_running_requests = per_dp_max_running_requests
+        self.round_robin_counter = 0
+        self.cache_aware_calls: list[tuple[str | list[str] | None, list[int], list[int]]] = []
+
+    def select_round_robin_dp(self) -> int:
+        dp_rank = self.round_robin_counter % self.dp_size
+        self.round_robin_counter += 1
+        return dp_rank
+
+    def select_min_running_dp(
+        self,
+        extra_counts: list[int],
+        extra_token_counts: list[int],
+    ) -> int | None:
+        eligible = self._eligible(extra_counts)
+        if not eligible:
+            return None
+
+        return min(
+            eligible,
+            key=lambda dp_rank: (
+                self.running_counts[dp_rank] + extra_counts[dp_rank],
+                self.running_token_counts[dp_rank] + extra_token_counts[dp_rank],
+                dp_rank,
+            ),
+        )
+
+    def select_cache_aware_dp(
+        self,
+        req: TokenizedGenerateReqInput,
+        extra_counts: list[int],
+        extra_token_counts: list[int],
+    ) -> int | None:
+        self.cache_aware_calls.append((req.rid, list(extra_counts), list(extra_token_counts)))
+        return self.select_min_running_dp(extra_counts, extra_token_counts)
+
+    @staticmethod
+    def estimate_req_tokens(req: TokenizedGenerateReqInput) -> int:
+        max_new_tokens = req.sampling_params.get("max_new_tokens", 0)
+        return len(req.input_ids or []) + max_new_tokens
+
+    def _eligible(self, extra_counts: list[int]) -> list[int]:
+        return [
+            dp_rank
+            for dp_rank in range(self.dp_size)
+            if dp_rank not in self.full_ranks
+            and self.running_counts[dp_rank] + extra_counts[dp_rank]
+            < self.per_dp_max_running_requests
+        ]
+
+
+def _assign(
+    *,
+    recv_reqs: list[object] | None,
+    pending_dp_reqs: list[TokenizedGenerateReqInput] | None = None,
+    dp_size: int = 2,
+    policy: str = "min_running_queue",
+    harness: _DpAssignmentHarness | None = None,
+):
+    harness = harness or _DpAssignmentHarness(dp_size=dp_size)
+    return assign_dp_ranks(
+        recv_reqs=recv_reqs,
+        pending_dp_reqs=pending_dp_reqs or [],
+        dp_size=dp_size,
+        dp_schedule_policy=policy,
+        select_round_robin_dp=harness.select_round_robin_dp,
+        select_cache_aware_dp=harness.select_cache_aware_dp,
+        select_min_running_dp=harness.select_min_running_dp,
+        estimate_req_tokens=harness.estimate_req_tokens,
+    )
+
+
+def test_min_running_defers_when_all_dp_ranks_are_full():
+    harness = _DpAssignmentHarness(
+        running_counts=[1, 1],
+        full_ranks={0, 1},
+        per_dp_max_running_requests=1,
+    )
+    req = _req("new")
+
+    result = _assign(recv_reqs=[req], harness=harness)
+
+    assert result.ready_reqs == []
+    assert result.pending_reqs == [req]
+    assert req.dp_rank is None
+
+
+def test_pending_requests_are_assigned_before_new_arrivals():
+    old = _req("old")
+    new = _req("new")
+
+    result = _assign(recv_reqs=[new], pending_dp_reqs=[old])
+
+    assert result.ready_reqs == [old, new]
+    assert result.pending_reqs == []
+    assert [old.dp_rank, new.dp_rank] == [0, 1]
+
+
+def test_existing_valid_dp_rank_counts_toward_following_assignment():
+    sticky = _req("sticky", dp_rank=0)
+    new = _req("new")
+
+    result = _assign(recv_reqs=[sticky, new])
+
+    assert result.ready_reqs == [sticky, new]
+    assert result.pending_reqs == []
+    assert sticky.dp_rank == 0
+    assert new.dp_rank == 1
+
+
+def test_round_robin_preserves_current_no_defer_behavior_for_full_ranks():
+    harness = _DpAssignmentHarness(
+        running_counts=[1, 1],
+        full_ranks={0, 1},
+        per_dp_max_running_requests=1,
+    )
+    req = _req("new")
+
+    result = _assign(recv_reqs=[req], policy="round_robin", harness=harness)
+
+    assert result.ready_reqs == [req]
+    assert result.pending_reqs == []
+    assert req.dp_rank == 0
+
+
+def test_invalid_existing_dp_rank_is_reassigned_by_policy(caplog):
+    req = _req("bad-rank", dp_rank=-1)
+
+    result = _assign(recv_reqs=[req])
+
+    assert result.ready_reqs == [req]
+    assert result.pending_reqs == []
+    assert req.dp_rank == 0
+    assert "invalid dp_rank" in caplog.text
+
+
+def test_cache_aware_receives_pending_load_from_prior_requests():
+    harness = _DpAssignmentHarness()
+    sticky = _req("sticky", dp_rank=0)
+    new = _req("new")
+
+    result = _assign(recv_reqs=[sticky, new], policy="cache_aware", harness=harness)
+
+    assert result.ready_reqs == [sticky, new]
+    assert result.pending_reqs == []
+    assert new.dp_rank == 1
+    assert harness.cache_aware_calls == [("new", [1, 0], [8, 0])]
+
+
+def test_dp_size_one_assigns_generate_reqs_and_preserves_control_reqs():
+    control_req = object()
+    req = _req("new", dp_rank=7)
+
+    result = _assign(recv_reqs=[control_req, req], dp_size=1)
+
+    assert result.ready_reqs == [control_req, req]
+    assert result.pending_reqs == []
+    assert req.dp_rank == 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
- Extract scheduler DP rank assignment into `dp_rank_assignment.py` so request-ordering, sticky-rank accounting, fallback reassignment, and deferral live in one small module.
- Keep `dp_schedule_policy.py` focused on policy math while `Scheduler` continues to own live load snapshots and cache probing callbacks.
- Add a defensive fallback for invalid pre-set `dp_rank` values: warn, clear the bad rank, and reassign through the active policy instead of letting invalid state crash indexing.
- Add characterization tests for pending FIFO, sticky rank accounting, invalid-rank fallback, round-robin behavior, cache-aware callback load propagation, and `dp_size == 1`.

## Validation
- `PYTHONPATH=python pytest test/srt/test_dp_schedule_policy.py test/srt/test_dp_rank_assignment.py -q`
- `PYTHONPATH=python ruff check python/sgl_jax/srt/managers/dp_rank_assignment.py python/sgl_jax/srt/managers/scheduler.py test/srt/test_dp_rank_assignment.py test/srt/run_suite.py`
- `PYTHONPATH=python python -m py_compile python/sgl_jax/srt/managers/dp_rank_assignment.py test/srt/test_dp_rank_assignment.py`
- `git diff --check`
- pre-commit hooks during commit: isort, ruff, mypy, codespell, and standard hygiene checks passed
