### PR TITLE
fix(vlm): restore Qwen2.5-VL encode bugfixes

### DIFF
--- a/python/sgl_jax/srt/managers/mm_utils.py
+++ b/python/sgl_jax/srt/managers/mm_utils.py
@@ -2,35 +2,36 @@
 
 Vision uses owning-rank data-parallel: each DP rank encodes its own images and
 merges into its own token slice on the ``data`` mesh axis. This module provides
-the vision encode, token merge, and host loop used before the language backbone
-forward.
+the token merge and host loop that call model-specific encoders before the
+language backbone forward.
 """
 
 import functools
 
 import jax
 import jax.numpy as jnp
-from flax import nnx
-from jax.sharding import NamedSharding, PartitionSpec
+from jax.sharding import PartitionSpec
 
 _MERGE_IN_SPECS = (
     PartitionSpec("data", None),  # running   [total_tok, H]
-    PartitionSpec("data", None),  # features  [dp*out_rows, H]
+    PartitionSpec("data", None, None),  # features  [dp, out_rows, H]
     PartitionSpec("data"),  # src_idx   [total_tok]
     PartitionSpec("data"),  # mask      [total_tok]
 )
 
 
 @functools.partial(jax.jit, static_argnames=("mesh",))
-def jitted_mm_merge(mesh, running, features, src_idx, mask):
+def merge_jit(mesh, running, features, src_idx, mask):
     """Merge encoded multimodal rows into the token embedding stream.
 
-    ``running``/``features`` are ``P("data", None)``; ``src_idx``/``mask`` are
-    ``P("data")``. Returns ``P("data", None)``.
+    ``running`` is ``P("data", None)``; ``features`` is
+    ``P("data", None, None)``. ``src_idx``/``mask`` are ``P("data")``. Returns
+    ``P("data", None)``.
     """
 
     def merge_local(running, features, src_idx, mask):
-        return jnp.where(mask[:, None], features[src_idx], running)
+        rank_features = features[0]
+        return jnp.where(mask[:, None], rank_features[src_idx], running)
 
     return jax.shard_map(
         merge_local,
@@ -39,23 +40,6 @@ def jitted_mm_merge(mesh, running, features, src_idx, mask):
         out_specs=PartitionSpec("data", None),
         check_vma=False,
     )(running, features, src_idx, mask)
-
-
-@functools.partial(jax.jit, static_argnames=("mesh", "graphdef"))
-def jitted_mm_encode(mesh, graphdef, state, pixels, meta, valid):
-    """Run the dp-leading vision encode.
-
-    ``pixels`` and ``meta`` are already placed on ``P("data", ...)``. The visual
-    module returns ``[dp, out_rows, H]``; this function flattens it to
-    ``[dp * out_rows, H]`` and pins the result to the merge sharding.
-    """
-    visual = nnx.merge(graphdef, state)
-    features = visual(pixels, meta, valid)  # [dp, out_rows, H]
-    dp, out_rows, h = features.shape
-    features = features.reshape(dp * out_rows, h)  # [dp*out_rows, H]
-    return jax.lax.with_sharding_constraint(
-        features, NamedSharding(mesh, PartitionSpec("data", None))
-    )
 
 
 def embed_mm_inputs(
@@ -78,7 +62,7 @@ def embed_mm_inputs(
         assert embedder is not None, f"no embedding method for {modality}"
         for rnd in rounds:
             features = embedder(rnd.encode_inputs)
-            running = jitted_mm_merge(mesh, running, features, rnd.src_idx, rnd.mask)
+            running = merge_jit(mesh, running, features, rnd.src_idx, rnd.mask)
     return running
 
 

--- a/python/sgl_jax/srt/models/qwen2_5_vl.py
+++ b/python/sgl_jax/srt/models/qwen2_5_vl.py
@@ -7,14 +7,13 @@ from types import SimpleNamespace
 import jax
 import jax.numpy as jnp
 from flax import nnx
-from jax.sharding import Mesh
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from transformers import modeling_flax_utils
 
 from sgl_jax.srt.configs.model_config import ModelConfig
 from sgl_jax.srt.hf_transformers_utils import get_hf_text_config
 from sgl_jax.srt.layers.embeddings import ParallelLMHead
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
-from sgl_jax.srt.managers.mm_utils import jitted_mm_encode
 from sgl_jax.srt.mem_cache.memory_pool import MemoryPools
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
 from sgl_jax.srt.models.qwen2 import Qwen2Model, create_qwen2_weight_mappings
@@ -34,6 +33,13 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 init_fn = nnx.initializers.uniform()
+
+
+def _apply_data_sharding(x: jax.Array, mesh: Mesh, spec: PartitionSpec) -> jax.Array:
+    sharding = NamedSharding(mesh, spec)
+    if "data" in mesh.abstract_mesh.explicit_axes:
+        return jax.sharding.reshard(x, sharding)
+    return jax.lax.with_sharding_constraint(x, sharding)
 
 
 def _apply_rotary_pos_emb_vision(x: jax.Array, rotary_pos_emb: jax.Array) -> jax.Array:
@@ -99,10 +105,12 @@ class Qwen2_5_VisionPatchEmbed(nnx.Module):
         in_channels: int = 3,
         hidden_size: int = 1152,
         dtype: jnp.dtype = jnp.bfloat16,
+        mesh: Mesh = None,
     ) -> None:
         self.patch_size = patch_size
         self.temporal_patch_size = temporal_patch_size
         self.hidden_size = hidden_size
+        self.mesh = mesh
         kernel_size = (temporal_patch_size, patch_size, patch_size)
 
         self.proj = nnx.Conv(
@@ -120,15 +128,31 @@ class Qwen2_5_VisionPatchEmbed(nnx.Module):
         # seq_len == the per-image patch count (== patch_k in the plan).
         dp, seq_len, dim = x.shape
         C = dim // (self.temporal_patch_size * self.patch_size * self.patch_size)
-        # Fold [dp, seq_len] into one conv batch axis: conv is per-element over
-        # the batch, so dp*seq_len patches together == per-image (no cross-image
-        # mixing).
-        x = x.reshape(dp * seq_len, C, self.temporal_patch_size, self.patch_size, self.patch_size)
-        # (dp*seq_len), T, H, W, C
-        x = jnp.transpose(x, (0, 2, 3, 4, 1))
+        x = x.reshape(
+            dp,
+            seq_len,
+            C,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        )
+        if self.mesh is not None:
+            x = _apply_data_sharding(
+                x,
+                self.mesh,
+                PartitionSpec("data", None, None, None, None, None),
+            )
+        # [dp, seq, C, T, H, W] -> [dp, seq, T, H, W, C]
+        x = jnp.transpose(x, (0, 1, 3, 4, 5, 2))
         x = self.proj(x)
-        # After conv (stride=kernel_size): (dp*seq_len, 1, 1, 1, hidden_size)
-        x = x.reshape(dp, seq_len, self.hidden_size)  # unfold dp
+        # After conv: [dp, seq, 1, 1, 1, hidden_size].
+        x = jnp.squeeze(x, axis=(2, 3, 4))
+        if self.mesh is not None:
+            x = _apply_data_sharding(
+                x,
+                self.mesh,
+                PartitionSpec("data", None, None),
+            )
         return x
 
 
@@ -183,6 +207,7 @@ class Qwen2_5_VisionAttention(nnx.Module):
         self.num_heads = config.num_heads
         self.head_dim = self.hidden_size // self.num_heads
         self.scale = 1.0 / math.sqrt(self.head_dim)
+        self.mesh = mesh
 
         # Use dummy rngs if None (for eval_shape)
         _rngs = rngs or nnx.Rngs(0)
@@ -226,12 +251,17 @@ class Qwen2_5_VisionAttention(nnx.Module):
         """Run one dp-leading ViT attention block."""
         dp, T, D = x.shape
 
-        positions = jnp.arange(T)
-        seg = jax.vmap(lambda row: jnp.searchsorted(row, positions, side="right"))(
-            cu_window_seqlens
+        positions = jnp.arange(T, dtype=cu_window_seqlens.dtype)
+        seg = jnp.sum(
+            cu_window_seqlens[:, :, None] <= positions[None, None, :],
+            axis=1,
         ).astype(jnp.int32)
+        if self.mesh is not None:
+            seg = _apply_data_sharding(seg, self.mesh, PartitionSpec("data", None))
         if valid is not None:
             is_real = positions[None, :] < jnp.reshape(valid, (dp, 1))
+            if self.mesh is not None:
+                is_real = _apply_data_sharding(is_real, self.mesh, PartitionSpec("data", None))
             seg = jnp.where(is_real, seg, jnp.full_like(seg, -1))
 
         # Project to Q, K, V
@@ -264,11 +294,12 @@ class Qwen2_5_VisionBlock(nnx.Module):
         dtype: jnp.dtype,
         rngs: nnx.Rngs = None,
         mesh: Mesh = None,
+        norm_eps: float = 1e-6,
     ):
         dim = config.hidden_size
         norm_layer = partial(
             nnx.RMSNorm,
-            epsilon=config.rms_norm_eps,
+            epsilon=norm_eps,
             scale_init=nnx.with_partitioning(init_fn, (None,)),
         )
 
@@ -301,8 +332,10 @@ class Qwen2_5_VisionPatchMerger(nnx.Module):
         spatial_merge_size: int,
         dtype: jnp.dtype,
         rngs: nnx.Rngs = None,
+        mesh: Mesh = None,
     ):
         self.hidden_size = context_dim * (spatial_merge_size**2)
+        self.mesh = mesh
 
         # Use dummy rngs if None (for eval_shape)
         _rngs = rngs or nnx.Rngs(0)
@@ -333,7 +366,17 @@ class Qwen2_5_VisionPatchMerger(nnx.Module):
         # Keep dp on axis 0: the sms² spatial-merge stays WITHIN each image.
         # ``reshape(-1, ...)`` here would interleave T and dp and silently mix
         # across images.
-        x = x.reshape(dp, -1, self.hidden_size)  # [dp, T/sms², ctx*sms²]
+        out_sharding = None
+        if self.mesh is not None and "data" in self.mesh.abstract_mesh.explicit_axes:
+            out_sharding = NamedSharding(self.mesh, PartitionSpec("data", None, None))
+        x = x.reshape(
+            dp,
+            -1,
+            self.hidden_size,
+            out_sharding=out_sharding,
+        )  # [dp, T/sms², ctx*sms²]
+        if self.mesh is not None and out_sharding is None:
+            x = _apply_data_sharding(x, self.mesh, PartitionSpec("data", None, None))
         x = self.mlp_fc1(x)
         x = self.mlp_act(x)
         x = self.mlp_fc2(x)
@@ -352,6 +395,7 @@ class Qwen2_5_VisionTransformer(nnx.Module):
     ):
         self.config = config
         self.dtype = dtype
+        self.mesh = mesh
 
         self.patch_embed = Qwen2_5_VisionPatchEmbed(
             patch_size=config.patch_size,
@@ -360,6 +404,7 @@ class Qwen2_5_VisionTransformer(nnx.Module):
             hidden_size=config.hidden_size,
             dtype=dtype,
             rngs=rngs,
+            mesh=mesh,
         )
 
         self.blocks = nnx.List(
@@ -369,6 +414,7 @@ class Qwen2_5_VisionTransformer(nnx.Module):
                     dtype=dtype,
                     rngs=rngs,
                     mesh=mesh,
+                    norm_eps=norm_eps,
                 )
                 for _ in range(config.depth)
             ]
@@ -381,6 +427,7 @@ class Qwen2_5_VisionTransformer(nnx.Module):
             spatial_merge_size=config.spatial_merge_size,
             dtype=dtype,
             rngs=rngs,
+            mesh=mesh,
         )
 
         self.spatial_merge_size = config.spatial_merge_size
@@ -448,6 +495,30 @@ class Qwen2_5_VisionTransformer(nnx.Module):
         hidden_states = jnp.take_along_axis(hidden_states, rev_idx, axis=1)
         return hidden_states  # [dp, out_rows, H]
 
+    def encode(self, pixels: jax.Array, meta, valid: jax.Array | None = None) -> jax.Array:
+        if self.mesh is None:
+            return self.encode_jit(pixels, meta, valid)
+        try:
+            ctx = jax.sharding.use_mesh(self.mesh)
+        except AttributeError:
+            try:
+                ctx = jax.set_mesh(self.mesh)
+            except AttributeError:
+                ctx = self.mesh
+        with ctx:
+            return self.encode_jit(pixels, meta, valid)
+
+    @jax.jit
+    def encode_jit(self, pixels: jax.Array, meta, valid: jax.Array | None = None) -> jax.Array:
+        features = self(pixels, meta, valid)  # [dp, out_rows, H]
+        if self.mesh is None:
+            return features
+        return _apply_data_sharding(
+            features,
+            self.mesh,
+            PartitionSpec("data", None, None),
+        )
+
 
 class Qwen2_5_VLForConditionalGeneration(nnx.Module):
     """In-model Qwen2.5-VL (single-file): vision tower + Qwen2 backbone (+ MRoPE)
@@ -496,10 +567,9 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
 
         ``enc.meta`` carries scheduler-built ViT aux
         (``window_index`` / ``cu_window_seqlens`` / ``rotary_pos_emb``).
-        Returns flattened image features with shape ``[dp * out_rows, H]``.
+        Returns dp-leading image features with shape ``[dp, out_rows, H]``.
         """
-        graphdef, state = nnx.split(self.visual)
-        return jitted_mm_encode(self.mesh, graphdef, state, enc.pixels, enc.meta, enc.valid)
+        return self.visual.encode(enc.pixels, enc.meta, enc.valid)
 
     def load_weights(self, model_config: ModelConfig):
         # Load text backbone and lm_head weights.

--- a/python/sgl_jax/srt/models/qwen2_5_vl.py
+++ b/python/sgl_jax/srt/models/qwen2_5_vl.py
@@ -144,7 +144,31 @@ class Qwen2_5_VisionPatchEmbed(nnx.Module):
             )
         # [dp, seq, C, T, H, W] -> [dp, seq, T, H, W, C]
         x = jnp.transpose(x, (0, 1, 3, 4, 5, 2))
-        x = self.proj(x)
+        flat_sharding = out_sharding = None
+        if self.mesh is not None and "data" in self.mesh.abstract_mesh.explicit_axes:
+            flat_sharding = NamedSharding(self.mesh, PartitionSpec("data", None, None, None, None))
+            out_sharding = NamedSharding(
+                self.mesh,
+                PartitionSpec("data", None, None, None, None, None),
+            )
+        x = x.reshape(
+            dp * seq_len,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+            C,
+            out_sharding=flat_sharding,
+        )
+        x = self.proj(x, out_sharding=flat_sharding)
+        x = x.reshape(
+            dp,
+            seq_len,
+            1,
+            1,
+            1,
+            self.hidden_size,
+            out_sharding=out_sharding,
+        )
         # After conv: [dp, seq, 1, 1, 1, hidden_size].
         x = jnp.squeeze(x, axis=(2, 3, 4))
         if self.mesh is not None:

--- a/python/sgl_jax/test/test_vlm_stage1_framework.py
+++ b/python/sgl_jax/test/test_vlm_stage1_framework.py
@@ -5,7 +5,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from jax.sharding import AxisType, Mesh, PartitionSpec
+from flax import nnx
+from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec
 
 from sgl_jax.srt.managers.io_struct import GenerateReqInput
 from sgl_jax.srt.managers.mm_utils import merge_jit
@@ -40,6 +41,13 @@ from sgl_jax.srt.multimodal.common.modality_enum import (
 )
 from sgl_jax.srt.multimodal.processors.qwen_vl import QwenVLProcessor
 from sgl_jax.srt.server_args import apply_multimodal_model_defaults
+
+
+def _two_data_devices():
+    devices = jax.devices()
+    if len(devices) < 2:
+        pytest.skip("requires at least two devices for real data-axis sharding")
+    return np.array(devices[:2])
 
 
 def test_vision_transformer_uses_default_norm_eps_when_hf_vision_config_omits_it():
@@ -225,6 +233,115 @@ def test_vision_transformer_encode_binds_mesh_for_sharded_inputs_without_callsit
     assert features.shape == (1, 1, 4)
 
 
+def test_vision_patch_embed_calls_conv_with_single_batch_dim(monkeypatch):
+    vision_config = SimpleNamespace(
+        patch_size=1,
+        temporal_patch_size=1,
+        in_channels=1,
+        hidden_size=4,
+        depth=0,
+        intermediate_size=8,
+        hidden_act="silu",
+        num_heads=1,
+        out_hidden_size=4,
+        spatial_merge_size=1,
+        fullatt_block_indexes=[],
+    )
+    mesh = Mesh(np.array(jax.devices()[:1]), ("data",), axis_types=(AxisType.Explicit,))
+    meta = Qwen25VLVisionMetadata(
+        window_index=jnp.tile(jnp.arange(3, dtype=jnp.int32)[None, :], (2, 1)),
+        cu_window_seqlens=jnp.array([[3], [3]], dtype=jnp.int32),
+        rotary_pos_emb=jnp.zeros((2, 3, 2), dtype=jnp.float32),
+    )
+
+    seen_input_shapes = []
+    original_call = nnx.Conv.__call__
+
+    def record_conv_input_shape(self, inputs, *args, **kwargs):
+        seen_input_shapes.append(inputs.shape)
+        return original_call(self, inputs, *args, **kwargs)
+
+    monkeypatch.setattr(nnx.Conv, "__call__", record_conv_input_shape)
+
+    with jax.set_mesh(mesh):
+        visual = Qwen2_5_VisionTransformer(
+            config=vision_config,
+            dtype=jnp.float32,
+            mesh=mesh,
+            norm_eps=1e-6,
+        )
+        features = visual.encode_jit(
+            jnp.ones((2, 3, 1), dtype=jnp.float32),
+            meta,
+            jnp.array([3, 3], dtype=jnp.int32),
+        )
+
+    assert features.shape == (2, 3, 4)
+    assert seen_input_shapes == [(6, 1, 1, 1, 1)]
+
+
+def test_vision_encode_runs_on_real_dp2_data_mesh(monkeypatch):
+    mesh = Mesh(_two_data_devices(), ("data",), axis_types=(AxisType.Explicit,))
+    vision_config = SimpleNamespace(
+        patch_size=1,
+        temporal_patch_size=1,
+        in_channels=1,
+        hidden_size=4,
+        depth=2,
+        intermediate_size=16,
+        hidden_act="silu",
+        num_heads=1,
+        out_hidden_size=4,
+        spatial_merge_size=2,
+        fullatt_block_indexes=[1],
+    )
+
+    def fake_vision_attention(backend, q, k, v, seg):
+        return jnp.zeros_like(q)
+
+    monkeypatch.setattr(
+        "sgl_jax.srt.models.qwen2_5_vl._vision_attention",
+        fake_vision_attention,
+    )
+
+    with jax.set_mesh(mesh):
+        visual = Qwen2_5_VisionTransformer(
+            config=vision_config,
+            dtype=jnp.float32,
+            mesh=mesh,
+            norm_eps=1e-6,
+        )
+        for block in visual.blocks:
+            block.attn.attn_backend = None
+
+    plan = MultimodalEmbedPlan(
+        rounds_by_modality={
+            Modality.IMAGE: [
+                EmbedRound(
+                    encode_inputs=VisionEncodeInputs(
+                        pixels=np.ones((2, 8, 1), dtype=np.float32),
+                        valid=np.array([8, 4], dtype=np.int32),
+                        meta=Qwen25VLVisionMetadata(
+                            window_index=np.array([[1, 0], [0, 1]], dtype=np.int32),
+                            cu_window_seqlens=np.array([[8], [4]], dtype=np.int32),
+                            rotary_pos_emb=np.zeros((2, 8, 2), dtype=np.float32),
+                        ),
+                    ),
+                    src_idx=np.zeros((8,), dtype=np.int32),
+                    mask=np.zeros((8,), dtype=np.bool_),
+                )
+            ]
+        }
+    )
+    _device_put_embed_plan(plan, mesh)
+    enc = plan.rounds_by_modality[Modality.IMAGE][0].encode_inputs
+
+    features = visual.encode(enc.pixels, enc.meta, enc.valid)
+
+    assert features.shape == (2, 2, 4)
+    assert tuple(features.sharding.spec) == ("data", None, None)
+
+
 def test_merge_jit_consumes_dp_leading_features():
     mesh = Mesh(np.array(jax.devices()[:1]), ("data",))
     running = jnp.zeros((2, 3), dtype=jnp.float32)
@@ -235,6 +352,69 @@ def test_merge_jit_consumes_dp_leading_features():
     out = merge_jit(mesh, running, features, src_idx, mask)
 
     np.testing.assert_array_equal(np.asarray(out), np.asarray(features[0]))
+
+
+def test_merge_jit_uses_rank_local_features_on_real_dp2_mesh():
+    mesh = Mesh(_two_data_devices(), ("data",), axis_types=(AxisType.Explicit,))
+    running = np.arange(12, dtype=np.float32).reshape(6, 2)
+    features = np.array(
+        [
+            [[10.0, 11.0], [20.0, 21.0]],
+            [[100.0, 101.0], [200.0, 201.0]],
+        ],
+        dtype=np.float32,
+    )
+    src_idx = np.array([1, 0, 0, 0, 0, 1], dtype=np.int32)
+    mask = np.array([True, True, False, True, False, True])
+
+    running_d = jax.device_put(running, NamedSharding(mesh, PartitionSpec("data", None)))
+    features_d = jax.device_put(features, NamedSharding(mesh, PartitionSpec("data", None, None)))
+    src_idx_d = jax.device_put(src_idx, NamedSharding(mesh, PartitionSpec("data")))
+    mask_d = jax.device_put(mask, NamedSharding(mesh, PartitionSpec("data")))
+
+    out = merge_jit(mesh, running_d, features_d, src_idx_d, mask_d)
+
+    expected = running.copy()
+    expected[0] = features[0, 1]
+    expected[1] = features[0, 0]
+    expected[3] = features[1, 0]
+    expected[5] = features[1, 1]
+    np.testing.assert_array_equal(np.asarray(out), expected)
+
+
+def test_device_put_embed_plan_places_qwen_metadata_data_leading():
+    mesh = Mesh(np.array(jax.devices()[:1]), ("data",), axis_types=(AxisType.Explicit,))
+    plan = MultimodalEmbedPlan(
+        rounds_by_modality={
+            Modality.IMAGE: [
+                EmbedRound(
+                    encode_inputs=VisionEncodeInputs(
+                        pixels=np.ones((1, 4, 1), dtype=np.float32),
+                        valid=np.array([4], dtype=np.int32),
+                        meta=Qwen25VLVisionMetadata(
+                            window_index=np.array([[0]], dtype=np.int32),
+                            cu_window_seqlens=np.array([[4]], dtype=np.int32),
+                            rotary_pos_emb=np.zeros((1, 4, 2), dtype=np.float32),
+                        ),
+                    ),
+                    src_idx=np.zeros((2,), dtype=np.int32),
+                    mask=np.zeros((2,), dtype=np.bool_),
+                )
+            ]
+        }
+    )
+
+    _device_put_embed_plan(plan, mesh)
+    rnd = plan.rounds_by_modality[Modality.IMAGE][0]
+    enc = rnd.encode_inputs
+
+    assert tuple(enc.pixels.sharding.spec) == ("data", None, None)
+    assert tuple(enc.valid.sharding.spec) == ("data",)
+    assert tuple(enc.meta.window_index.sharding.spec) == ("data", None)
+    assert tuple(enc.meta.cu_window_seqlens.sharding.spec) == ("data", None)
+    assert tuple(enc.meta.rotary_pos_emb.sharding.spec) == ("data", None, None)
+    assert tuple(rnd.src_idx.sharding.spec) == ("data",)
+    assert tuple(rnd.mask.sharding.spec) == ("data",)
 
 
 def test_multimodal_model_defaults_disable_unsupported_scheduler_features():

--- a/python/sgl_jax/test/test_vlm_stage1_framework.py
+++ b/python/sgl_jax/test/test_vlm_stage1_framework.py
@@ -2,11 +2,13 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
-from jax.sharding import Mesh, PartitionSpec
+from jax.sharding import AxisType, Mesh, PartitionSpec
 
 from sgl_jax.srt.managers.io_struct import GenerateReqInput
+from sgl_jax.srt.managers.mm_utils import merge_jit
 from sgl_jax.srt.managers.schedule_batch import (
     ModelWorkerBatch,
     ScheduleBatch,
@@ -18,6 +20,7 @@ from sgl_jax.srt.model_executor.forward_batch_info import (
     ForwardMode,
     _device_put_embed_plan,
 )
+from sgl_jax.srt.models.qwen2_5_vl import Qwen2_5_VisionTransformer
 from sgl_jax.srt.models.vision_metadata import (  # noqa: F401
     qwen2_5_vl as _qwen25vl_vision_metadata,
 )
@@ -37,6 +40,201 @@ from sgl_jax.srt.multimodal.common.modality_enum import (
 )
 from sgl_jax.srt.multimodal.processors.qwen_vl import QwenVLProcessor
 from sgl_jax.srt.server_args import apply_multimodal_model_defaults
+
+
+def test_vision_transformer_uses_default_norm_eps_when_hf_vision_config_omits_it():
+    vision_config = SimpleNamespace(
+        patch_size=1,
+        temporal_patch_size=1,
+        in_channels=3,
+        hidden_size=4,
+        depth=1,
+        intermediate_size=8,
+        hidden_act="silu",
+        num_heads=1,
+        out_hidden_size=4,
+        spatial_merge_size=1,
+        fullatt_block_indexes=[],
+    )
+
+    mesh = Mesh(np.array(jax.devices()[:1]), ("data",))
+    with jax.set_mesh(mesh):
+        Qwen2_5_VisionTransformer(
+            config=vision_config,
+            dtype=jnp.float32,
+            mesh=None,
+            norm_eps=1e-6,
+        )
+
+
+def test_vision_transformer_encode_jit_accepts_unhashable_vision_config():
+    class UnhashableVisionConfig(SimpleNamespace):
+        __hash__ = None
+
+    vision_config = UnhashableVisionConfig(
+        patch_size=1,
+        temporal_patch_size=1,
+        in_channels=1,
+        hidden_size=4,
+        depth=0,
+        intermediate_size=8,
+        hidden_act="silu",
+        num_heads=1,
+        out_hidden_size=4,
+        spatial_merge_size=1,
+        fullatt_block_indexes=[],
+    )
+    mesh = Mesh(np.array(jax.devices()[:1]), ("data",))
+    meta = Qwen25VLVisionMetadata(
+        window_index=jnp.zeros((1, 2), dtype=jnp.int32),
+        cu_window_seqlens=jnp.array([[2]], dtype=jnp.int32),
+        rotary_pos_emb=jnp.zeros((1, 2, 2), dtype=jnp.float32),
+    )
+
+    with jax.set_mesh(mesh):
+        visual = Qwen2_5_VisionTransformer(
+            config=vision_config,
+            dtype=jnp.float32,
+            mesh=mesh,
+            norm_eps=1e-6,
+        )
+        features = visual.encode_jit(
+            jnp.ones((1, 2, 1), dtype=jnp.float32),
+            meta,
+            jnp.array([2], dtype=jnp.int32),
+        )
+
+    assert features.shape == (1, 2, 4)
+
+
+def test_vision_transformer_encode_jit_uses_reshard_for_explicit_mesh(monkeypatch):
+    vision_config = SimpleNamespace(
+        patch_size=1,
+        temporal_patch_size=1,
+        in_channels=1,
+        hidden_size=4,
+        depth=0,
+        intermediate_size=8,
+        hidden_act="silu",
+        num_heads=1,
+        out_hidden_size=4,
+        spatial_merge_size=1,
+        fullatt_block_indexes=[],
+    )
+    mesh = Mesh(np.array(jax.devices()[:1]), ("data",), axis_types=(AxisType.Explicit,))
+    meta = Qwen25VLVisionMetadata(
+        window_index=jnp.zeros((1, 2), dtype=jnp.int32),
+        cu_window_seqlens=jnp.array([[2]], dtype=jnp.int32),
+        rotary_pos_emb=jnp.zeros((1, 2, 2), dtype=jnp.float32),
+    )
+
+    with jax.set_mesh(mesh):
+        visual = Qwen2_5_VisionTransformer(
+            config=vision_config,
+            dtype=jnp.float32,
+            mesh=mesh,
+            norm_eps=1e-6,
+        )
+
+        def fail_with_sharding_constraint(*args, **kwargs):
+            raise AssertionError("with_sharding_constraint must not be used in Qwen vision encode")
+
+        reshard_specs = []
+        original_reshard = jax.sharding.reshard
+
+        def record_reshard(x, out_sharding):
+            reshard_specs.append(tuple(out_sharding.spec))
+            return original_reshard(x, out_sharding)
+
+        monkeypatch.setattr(jax.lax, "with_sharding_constraint", fail_with_sharding_constraint)
+        monkeypatch.setattr(jax.sharding, "reshard", record_reshard)
+
+        features = visual.encode_jit(
+            jnp.ones((1, 2, 1), dtype=jnp.float32),
+            meta,
+            jnp.array([2], dtype=jnp.int32),
+        )
+
+    assert features.shape == (1, 2, 4)
+    assert reshard_specs == [
+        ("data", None, None, None, None, None),
+        ("data", None, None),
+        ("data", None, None),
+    ]
+
+
+def test_vision_transformer_encode_binds_mesh_for_sharded_inputs_without_callsite_context(
+    monkeypatch,
+):
+    vision_config = SimpleNamespace(
+        patch_size=1,
+        temporal_patch_size=1,
+        in_channels=1,
+        hidden_size=4,
+        depth=2,
+        intermediate_size=16,
+        hidden_act="silu",
+        num_heads=1,
+        out_hidden_size=4,
+        spatial_merge_size=2,
+        fullatt_block_indexes=[1],
+    )
+    mesh = Mesh(np.array(jax.devices()[:1]), ("data",), axis_types=(AxisType.Explicit,))
+    with jax.set_mesh(mesh):
+        visual = Qwen2_5_VisionTransformer(
+            config=vision_config,
+            dtype=jnp.float32,
+            mesh=mesh,
+            norm_eps=1e-6,
+        )
+        for block in visual.blocks:
+            block.attn.attn_backend = None
+
+    def fake_vision_attention(backend, q, k, v, seg):
+        return jnp.zeros_like(q)
+
+    monkeypatch.setattr(
+        "sgl_jax.srt.models.qwen2_5_vl._vision_attention",
+        fake_vision_attention,
+    )
+
+    plan = MultimodalEmbedPlan(
+        rounds_by_modality={
+            Modality.IMAGE: [
+                EmbedRound(
+                    encode_inputs=VisionEncodeInputs(
+                        pixels=np.ones((1, 4, 1), dtype=np.float32),
+                        valid=np.array([4], dtype=np.int32),
+                        meta=Qwen25VLVisionMetadata(
+                            window_index=np.array([[0]], dtype=np.int32),
+                            cu_window_seqlens=np.array([[4]], dtype=np.int32),
+                            rotary_pos_emb=np.zeros((1, 4, 2), dtype=np.float32),
+                        ),
+                    ),
+                    src_idx=np.zeros((1,), dtype=np.int32),
+                    mask=np.zeros((1,), dtype=np.bool_),
+                )
+            ]
+        }
+    )
+    _device_put_embed_plan(plan, mesh)
+    enc = plan.rounds_by_modality[Modality.IMAGE][0].encode_inputs
+
+    features = visual.encode(enc.pixels, enc.meta, enc.valid)
+
+    assert features.shape == (1, 1, 4)
+
+
+def test_merge_jit_consumes_dp_leading_features():
+    mesh = Mesh(np.array(jax.devices()[:1]), ("data",))
+    running = jnp.zeros((2, 3), dtype=jnp.float32)
+    features = jnp.array([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]], dtype=jnp.float32)
+    src_idx = jnp.array([0, 1], dtype=jnp.int32)
+    mask = jnp.array([True, True])
+
+    out = merge_jit(mesh, running, features, src_idx, mask)
+
+    np.testing.assert_array_equal(np.asarray(out), np.asarray(features[0]))
 
 
 def test_multimodal_model_defaults_disable_unsupported_scheduler_features():


### PR DESCRIPTION
## Summary

This PR restores the two Qwen2.5-VL bugfixes that were intentionally split out after the Stage 1 VLM landing:

- restore Qwen vision encode sharding stabilization
- restore DP sharding handling in Qwen patch embed
- restore focused VLM Stage 1 regression coverage for the encode / merge / DP-sharding paths

The branch is based on `epic/vlm` after PR #1399 was merged.

## What This Fixes

The merge evidence in `/Users/lianfang/primatrix/tmp/qwen2.5vl/MERGE_EVIDENCE_vlm_stage1.md` records the validation issues found while testing Qwen2.5-VL on `vlm/stage1`. This PR restores the final two fixes needed for the tested configuration:

| Area | Problem | Fix |
|---|---|---|
| Vision encode sharding | The previous common `jitted_mm_encode` lived in `mm_utils.py`, flattened `[dp, out_rows, H]` into `[dp * out_rows, H]`, and mixed model-specific NNX visual encode details into common orchestration. This was unstable with explicit meshes and did not match rank-local merge indexing. | Move encode ownership into `Qwen2_5_VisionTransformer.encode()/encode_jit()`, keep common `mm_utils.py` responsible for the host loop and merge only, and return dp-leading features `[dp, out_rows, H]`. |
| DP patch embed | In dp>1, Flax Conv folding/unfolding of the dp-leading patch tensor could lose or reject the data-axis sharding. | Fold `dp * seq` into the Conv batch with explicit guarded `out_sharding`, then unfold back to `[dp, seq, hidden]` with data-leading sharding. |
| Merge contract | Scheduler merge indices are rank-local, while flattened features imply global indexing. | `merge_jit` now consumes `features` as `P("data", None, None)` and each shard indexes its local `features[0]`. |

The PR also keeps the related regression tests for:

- default `norm_eps` when HF vision config omits `rms_norm_eps`
- unhashable HF vision config not entering the jitted visual graph
- explicit mesh using `jax.sharding.reshard` instead of `with_sharding_constraint`
- encode callable binding the mesh even when the callsite is not inside `set_mesh`
- dp2 feature merge using rank-local rows
- Qwen metadata device placement with data-leading sharding

## Test Configuration From Merge Evidence

Model:

- `Qwen/Qwen2.5-VL-7B-Instruct`
- in-model vision path, launched without `--multimodal`

Common runtime flags:

```bash
--page-size 128 --chunked-prefill-size -1 --disable-radix-cache \
--disable-overlap-schedule --mem-fraction-static 0.88
```

Deployment matrix:

| Scope | Hardware | Launch shape | Mesh |
|---|---|---|---|
| Single host dp1 | v6e-4 | `--tp-size 4 --dp-size 1` | `[data=1, tensor=4]` |
| Single host dp2 | v6e-4 | `--tp-size 4 --dp-size 2` | `[data=2, tensor=2]` |
| Multi-host | v6e-16, 4 hosts x 4 chips | `--tp-size 16 --dp-size 4 --nnodes 4` | `[data=4, tensor=4]` |

Runtime stack:

- image: `us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.8.1-rev1`
- JAX / jaxlib: `0.8.1`
- libtpu: `0.0.30`
- transformers: `4.57.1`

## Test Conclusions From Merge Evidence

Functional coverage:

- single-host dp1: text, single image, multi-image, OCR, chart, counting, and interleaved image/text requests passed
- single-host dp2: serial VLM requests passed; concurrent multi-image test passed `24/24`; scheduler logs showed requests distributed across both DP replicas
- multi-host v6e-16: distributed init and precompile passed; single-image request passed; synthetic concurrent multi-image test passed `32/32`; real COCO concurrent routing passed `32/32` with no image mix-up

HTTP assertion suite:

- `test_qwen_vl.py`: `8/9` passed on the multi-host service
- the only failed assertion was `count.seven_circles`, where the model consistently answered `8` for a 7-circle synthetic image
- this was classified as a model counting weakness rather than a service / DP / multi-host routing bug, because text, OCR, real image understanding, multi-image routing, and other counting cases passed

Non-determinism note:

- `real_conc_vl.py` reported exact string match `26/32`, but route correctness `32/32`
- the mismatches were semantic rephrasings caused by heterogeneous batch floating-point differences, not image routing mix-ups

## Local Validation For This PR

```bash
python3 -m py_compile \
  python/sgl_jax/srt/managers/mm_utils.py \
  python/sgl_jax/srt/models/qwen2_5_vl.py \
  python/sgl_jax/test/test_vlm_stage1_framework.py
```

```bash
uv run --project python --with pytest \
  python -m pytest python/sgl_jax/test/test_vlm_stage1_framework.py
```

Result:

```text
19 passed, 2 skipped
```

## Residual Risk

The focused local tests cover small/fake Qwen paths and real dp2 sharding behavior, but they do not replace the multi-host end-to-end validation recorded in the merge evidence. The multi-host evidence is included here as the merge support for the real Qwen2.5-VL service path.
