### PR TITLE
fix(qwen3.5): use make_array_from_callback in _put for multi-host loading

### DIFF
--- a/python/sgl_jax/srt/models/qwen3_5.py
+++ b/python/sgl_jax/srt/models/qwen3_5.py
@@ -619,9 +619,18 @@ class Qwen3_5MoeForConditionalGeneration(nnx.Module):
     # Weight loading
     # ------------------------------------------------------------------
     def _put(self, arr, spec):
-        """Host array -> sharded bf16 device array under the model mesh."""
-        return jax.device_put(
-            jnp.asarray(arr, dtype=self.dtype), NamedSharding(self.mesh, P(*spec))
+        """Host array -> sharded device array under the model mesh.
+
+        Uses make_array_from_callback so each host uploads only its local
+        shard; jax.device_put on a host-replicated array triggers a
+        multihost assert_equal -> process_allgather (16 hosts * 1.5G MoE
+        gate_up = 24G per device -> OOM on 122B/v6e-64). Matches the
+        pattern in weight_utils.py (see comment at :678).
+        """
+        sharding = NamedSharding(self.mesh, P(*spec))
+        arr = np.asarray(arr)
+        return jax.make_array_from_callback(arr.shape, sharding, lambda idx: arr[idx]).astype(
+            self.dtype
         )
 
     @staticmethod


### PR DESCRIPTION
Toward #1419 — unblocks multi-host loading for the larger Qwen3.5 MoE sizes. Scoped to the loader fix only; not claiming the full #1419 accuracy acceptance.

## Summary

`models/qwen3_5.py:_put` (the special-path loader for GDN fused projections and MoE `gate_up_proj`) used `jax.device_put(jnp.asarray(arr), NamedSharding)`. On multi-host that triggers `multihost_utils.assert_equal → process_allgather`, which materializes N_hosts copies per device. On 122B-A10B / v6e 8×8 (16 hosts) the MoE `gate_up` w1 tensor (~1.5G) becomes ~24G/device and OOMs after regular weights are already resident (~28G, 3.74G free). 35B-A3B on 2 hosts (2×0.5G) fit under the bar so this wasn't visible in M1.

Switch `_put` to `jax.make_array_from_callback` so each host uploads only its addressable shard — same pattern the regular `WeightLoader` path in `weight_utils.py` already uses (see comment at :678).

## Checkpoint-format note (both #1419 sizes)

Both 122B-A10B and 397B-A17B ship the pre-fused `experts.gate_up_proj`/`down_proj` layout under `model.language_model.*`, matching 35B (the per-expert `experts.N.{gate,up,down}_proj` keys in the index are all under `mtp.*`, which the loader skips). No non-pre-fused loader path needed.

## Test plan

- [x] `pytest python/sgl_jax/test/models/test_qwen3_5.py` — 18/18
- [x] pre-commit
- [x] 122B-A10B v6e 8×8 `--tp-size 64 --dp-size 4`: fired_up (was OOM before), loader-assert 831 loaded / 1118 skipped (333 visual + 785 mtp), no `[missing]`/`[unexpected]`
- [x] 122B-A10B v7x 2×2×2 `--tp-size 16 --dp-size 1`: fired_up, same loader-assert, GSM8K sanity 5/5
- [x] GPQA-Diamond full (198, §4.3 protocol, `max_tokens=30720`): **0.864** on v6e (target ≥85.1; official 86.6) — correctness holds after the loader change