### PR TITLE
feat(scheduler): add shape_aware DP scheduling policy

### DIFF
--- a/python/sgl_jax/srt/managers/dp_rank_assignment.py
+++ b/python/sgl_jax/srt/managers/dp_rank_assignment.py
@@ -31,7 +31,11 @@ def assign_dp_ranks(
     select_round_robin_dp: Callable[[], int],
     select_cache_aware_dp: Callable[[TokenizedGenerateReqInput, list[int], list[int]], int | None],
     select_min_running_dp: Callable[[list[int], list[int]], int | None],
+    select_shape_aware_dp: Callable[
+        [int, int, list[int], list[int], list[int], list[int]], int | None
+    ],
     estimate_req_tokens: Callable[[TokenizedGenerateReqInput], int],
+    estimate_req_io_tokens: Callable[[TokenizedGenerateReqInput], tuple[int, int]],
 ) -> DpRankAssignmentResult:
     """Assign or defer DP ranks for incoming generate requests.
 
@@ -55,8 +59,23 @@ def assign_dp_ranks(
 
     pending_counts = [0] * dp_size
     pending_token_counts = [0] * dp_size
+    # shape_aware balances prefill (input) and decode (output) separately, so it
+    # also needs the input/output split of requests assigned earlier in this same
+    # intake tick -- otherwise a burst routes against a stale snapshot and
+    # mis-balances. Only tracked for that policy to avoid overhead elsewhere.
+    is_shape_aware = dp_schedule_policy == "shape_aware"
+    pending_input_counts = [0] * dp_size
+    pending_output_counts = [0] * dp_size
     ready_reqs: list[Any] = []
     deferred_reqs: list[TokenizedGenerateReqInput] = []
+
+    def track(req, dp_rank):
+        pending_counts[dp_rank] += 1
+        pending_token_counts[dp_rank] += estimate_req_tokens(req)
+        if is_shape_aware:
+            in_tok, out_tok = estimate_req_io_tokens(req)
+            pending_input_counts[dp_rank] += in_tok
+            pending_output_counts[dp_rank] += out_tok
 
     for req in combined_reqs:
         if not isinstance(req, TokenizedGenerateReqInput):
@@ -65,8 +84,7 @@ def assign_dp_ranks(
 
         if req.dp_rank is not None:
             if _valid_dp_rank(req.dp_rank, dp_size):
-                pending_counts[req.dp_rank] += 1
-                pending_token_counts[req.dp_rank] += estimate_req_tokens(req)
+                track(req, req.dp_rank)
                 ready_reqs.append(req)
                 continue
 
@@ -85,6 +103,16 @@ def assign_dp_ranks(
 
         if dp_schedule_policy == "cache_aware":
             dp_rank = select_cache_aware_dp(req, pending_counts, pending_token_counts)
+        elif is_shape_aware:
+            item_in, item_out = estimate_req_io_tokens(req)
+            dp_rank = select_shape_aware_dp(
+                item_in,
+                item_out,
+                pending_counts,
+                pending_token_counts,
+                pending_input_counts,
+                pending_output_counts,
+            )
         else:
             dp_rank = select_min_running_dp(pending_counts, pending_token_counts)
 
@@ -93,8 +121,7 @@ def assign_dp_ranks(
             continue
 
         req.dp_rank = dp_rank
-        pending_counts[dp_rank] += 1
-        pending_token_counts[dp_rank] += estimate_req_tokens(req)
+        track(req, dp_rank)
         ready_reqs.append(req)
 
     return DpRankAssignmentResult(ready_reqs=ready_reqs, pending_reqs=deferred_reqs)

--- a/python/sgl_jax/srt/managers/dp_schedule_policy.py
+++ b/python/sgl_jax/srt/managers/dp_schedule_policy.py
@@ -98,3 +98,36 @@ def pick_cache_aware_dp(
             return least_loaded(holders)
 
     return least_loaded(eligible)
+
+
+def pick_shape_aware_dp(
+    eligible: list[int],
+    input_counts: list[int],
+    output_counts: list[int],
+    item_input: int = 0,
+    item_output: int = 0,
+) -> int | None:
+    """Shape-aware DP policy: joint prefill/decode load balancing.
+
+    Balance prefill (input) and decode (output) token load jointly: route to the
+    eligible rank whose *bottleneck* dimension stays smallest after admitting the
+    request::
+
+        score(r) = max(input_counts[r] + item_input, output_counts[r] + item_output)
+
+    The ``max`` keeps whichever resource is the bottleneck on each rank (prefill
+    FLOPs vs. decode/KV HBM) lowest, so a prefill-heavy request is drawn toward a
+    decode-heavy rank and vice versa, co-locating complementary shapes rather than
+    piling like-shaped work onto one rank. Ties are broken by total load then rank
+    index. ``input_counts`` / ``output_counts`` are the per-rank running+pending
+    token sums; eligibility (the admission cap) is decided by the caller.
+    """
+    if not eligible:
+        return None
+
+    def score(r: int) -> tuple[int, int, int]:
+        after_in = input_counts[r] + item_input
+        after_out = output_counts[r] + item_output
+        return (max(after_in, after_out), after_in + after_out, r)
+
+    return min(eligible, key=score)

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -37,6 +37,7 @@ from sgl_jax.srt.managers.communication import CommunicationBackend
 from sgl_jax.srt.managers.dp_rank_assignment import assign_dp_ranks
 from sgl_jax.srt.managers.dp_schedule_policy import (
     pick_cache_aware_dp,
+    pick_shape_aware_dp,
     req_prefix_match_key,
 )
 from sgl_jax.srt.managers.io_struct import (
@@ -701,8 +702,15 @@ class Scheduler(
             return bool(sampling_params.get("ignore_eos", False))
         return bool(getattr(sampling_params, "ignore_eos", False))
 
-    def _estimate_req_tokens(self, req: Req | TokenizedGenerateReqInput) -> int:
-        """Estimate per-request token load as input + expected output."""
+    def _estimate_req_input_output_tokens(
+        self, req: Req | TokenizedGenerateReqInput
+    ) -> tuple[int, int]:
+        """Estimate per-request (input_tokens, estimated_output_tokens).
+
+        The prefill (input) and decode (output) loads are kept separate here so
+        the ``shape_aware`` policy can balance them independently;
+        ``_estimate_req_tokens`` sums them for the load-total policies.
+        """
         input_token_len = self._get_input_token_len(req)
         sampling_params = getattr(req, "sampling_params", None)
         est_max_new_tokens = self._extract_max_new_tokens(sampling_params)
@@ -724,10 +732,11 @@ class Scheduler(
             ) * self.page_size
             est_output_tokens += IGNORE_EOS_RESERVE_TOKENS
 
-        if isinstance(req, Req):
-            # For running requests, scheduler load should reflect total reserved footprint.
-            return input_token_len + est_output_tokens
+        return input_token_len, est_output_tokens
 
+    def _estimate_req_tokens(self, req: Req | TokenizedGenerateReqInput) -> int:
+        """Estimate per-request token load as input + expected output."""
+        input_token_len, est_output_tokens = self._estimate_req_input_output_tokens(req)
         return input_token_len + est_output_tokens
 
     def _get_dp_load_snapshot(self) -> tuple[list[int], list[int]]:
@@ -856,6 +865,84 @@ class Scheduler(
 
         return pick_cache_aware_dp(eligible, counts, token_counts, matches, prompt_len)
 
+    def _get_dp_io_snapshot(self) -> tuple[list[int], list[int]]:
+        """Return per-DP (input_tokens, output_tokens) for in-flight scheduled work.
+
+        Mirrors ``_get_dp_load_snapshot`` but keeps prefill (input) and decode
+        (output) token loads separate, for the ``shape_aware`` policy.
+        """
+        input_counts = [0] * self.dp_size
+        output_counts = [0] * self.dp_size
+
+        def add(req, dp_rank):
+            in_tok, out_tok = self._estimate_req_input_output_tokens(req)
+            input_counts[dp_rank] += in_tok
+            output_counts[dp_rank] += out_tok
+
+        for dp_rank, info in enumerate(self.running_batch.reqs_info):
+            if not info.reqs:
+                continue
+            for req in info.reqs:
+                add(req, dp_rank)
+
+        # In overlap mode, last_batch can still be in-flight (extend) but not yet
+        # merged into running_batch. Include it, mirroring _get_dp_load_snapshot.
+        if self.last_batch and self.last_batch.forward_mode.is_extend():
+            for dp_rank, info in enumerate(self.last_batch.reqs_info):
+                if not info.reqs and info.chunked_req is None:
+                    continue
+                running_ids = set()
+                running_info = self.running_batch.reqs_info[dp_rank]
+                if running_info.reqs:
+                    running_ids = {req.rid for req in running_info.reqs}
+                for req in info.reqs or []:
+                    if req.rid in running_ids:
+                        continue
+                    add(req, dp_rank)
+                if info.chunked_req is not None and info.chunked_req.rid not in running_ids:
+                    add(info.chunked_req, dp_rank)
+
+        return input_counts, output_counts
+
+    def _select_shape_aware_dp(
+        self,
+        item_input_tokens: int,
+        item_output_tokens: int,
+        extra_counts: list[int],
+        extra_token_counts: list[int],
+        extra_input_counts: list[int],
+        extra_output_counts: list[int],
+    ) -> int | None:
+        """Route a request by balancing prefill (input) and decode (output) load jointly.
+
+        Defers to ``pick_shape_aware_dp``: among eligible ranks, pick the one
+        whose bottleneck dimension stays smallest after admitting this request,
+        ``max(input + input_r, output + output_r)``. This draws a prefill-heavy
+        request toward a decode-heavy rank and vice versa, co-locating
+        complementary shapes.
+
+        Per-rank load = live running snapshot + ``extra_*`` (requests assigned
+        earlier in this intake tick). Folding in the per-tick pending input/output
+        split is load-bearing at low concurrency: without it a burst routes
+        against a stale snapshot and mis-balances. Eligibility (admission cap)
+        matches min_running. Returns None if all DP ranks are full.
+        """
+        if self.dp_size == 1:
+            return 0
+
+        eligible, _counts, _token_counts = self._dp_load_and_eligible(
+            extra_counts, extra_token_counts
+        )
+        if not eligible:
+            return None
+
+        running_input, running_output = self._get_dp_io_snapshot()
+        input_counts = [running_input[i] + extra_input_counts[i] for i in range(self.dp_size)]
+        output_counts = [running_output[i] + extra_output_counts[i] for i in range(self.dp_size)]
+        return pick_shape_aware_dp(
+            eligible, input_counts, output_counts, item_input_tokens, item_output_tokens
+        )
+
     def select_dp_for_request(self, recv_reqs: list[Req]) -> list[Req]:
         """Assign dp_rank to incoming requests using the configured DP policy.
 
@@ -870,7 +957,9 @@ class Scheduler(
             select_round_robin_dp=self._select_round_robin_dp,
             select_cache_aware_dp=self._select_cache_aware_dp,
             select_min_running_dp=self._select_min_running_dp,
+            select_shape_aware_dp=self._select_shape_aware_dp,
             estimate_req_tokens=self._estimate_req_tokens,
+            estimate_req_io_tokens=self._estimate_req_input_output_tokens,
         )
         self.pending_dp_reqs = result.pending_reqs
         return result.ready_reqs

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -997,14 +997,17 @@ class ServerArgs:
         parser.add_argument(
             "--dp-schedule-policy",
             type=str,
-            choices=["round_robin", "min_running_queue", "cache_aware"],
+            choices=["round_robin", "min_running_queue", "cache_aware", "shape_aware"],
             default=ServerArgs.dp_schedule_policy,
             help=(
                 "DP scheduling policy for assigning dp_rank to new requests. "
                 "'cache_aware' routes by cache affinity with soft load balancing: "
                 "it balances on large load skew, else picks the least-loaded rank "
                 "among those holding a substantial cached prefix, so a hot prefix "
-                "spreads across its holders. Improves prefix reuse under DP."
+                "spreads across its holders. Improves prefix reuse under DP. "
+                "'shape_aware' balances input (prefill) and output (decode) "
+                "token load jointly, routing to the replica whose bottleneck "
+                "dimension stays smallest: score = max(sum_input, sum_output)."
             ),
         )
 

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -324,6 +324,7 @@ suites = {
         TestFile("python/sgl_jax/test/mem_cache/test_host_kv_pool.py", 1, runner="pytest"),
         TestFile("python/sgl_jax/test/test_kv_cache_builder.py", 0.1, runner="pytest"),
         TestFile("test/srt/test_dp_schedule_policy.py", 0.2, runner="pytest"),
+        TestFile("test/srt/test_dp_schedule_shape_aware.py", 0.2, runner="pytest"),
         TestFile("test/srt/test_dp_rank_assignment.py", 0.2, runner="pytest"),
         TestFile("test/srt/function_call/test_qwen3_coder_detector.py", 0.1),
         TestFile("test/srt/function_call/test_glm4_moe_detector.py", 0.1),

--- a/test/srt/test_dp_rank_assignment.py
+++ b/test/srt/test_dp_rank_assignment.py
@@ -38,6 +38,9 @@ class _DpAssignmentHarness:
         self.per_dp_max_running_requests = per_dp_max_running_requests
         self.round_robin_counter = 0
         self.cache_aware_calls: list[tuple[str | list[str] | None, list[int], list[int]]] = []
+        # Records (item_input, item_output, extra_input_counts, extra_output_counts)
+        # per shape_aware dispatch, so tests can assert the same-tick pending-IO split.
+        self.shape_aware_calls: list[tuple[int, int, list[int], list[int]]] = []
 
     def select_round_robin_dp(self) -> int:
         dp_rank = self.round_robin_counter % self.dp_size
@@ -80,8 +83,12 @@ class _DpAssignmentHarness:
         extra_input_counts: list[int],
         extra_output_counts: list[int],
     ) -> int | None:
-        # These characterization tests exercise the dispatcher, not the shape-aware
-        # math (covered by test_dp_schedule_shape_aware.py); reuse min-running here.
+        # Record the IO-specific args so the dispatcher's same-tick pending-IO
+        # tracking is under test; the routing decision itself (shape-aware math)
+        # is covered by test_dp_schedule_shape_aware.py, so reuse min-running here.
+        self.shape_aware_calls.append(
+            (item_input, item_output, list(extra_input_counts), list(extra_output_counts))
+        )
         return self.select_min_running_dp(extra_counts, extra_token_counts)
 
     @staticmethod
@@ -201,6 +208,25 @@ def test_cache_aware_receives_pending_load_from_prior_requests():
     assert result.pending_reqs == []
     assert new.dp_rank == 1
     assert harness.cache_aware_calls == [("new", [1, 0], [8, 0])]
+
+
+def test_shape_aware_receives_pending_io_split_from_prior_requests():
+    # Guards the load-bearing same-tick pending-IO tracking: a request assigned
+    # earlier in this intake tick (the sticky request on rank 0) must be reflected
+    # in the input/output split passed to select_shape_aware_dp for the next
+    # request -- distinct input/output values here catch a swapped or dropped axis.
+    harness = _DpAssignmentHarness()
+    sticky = _req("sticky", dp_rank=0, input_len=10, max_new_tokens=3)  # io = (10, 3)
+    new = _req("new", input_len=5, max_new_tokens=7)  # item io = (5, 7)
+
+    result = _assign(recv_reqs=[sticky, new], policy="shape_aware", harness=harness)
+
+    assert result.ready_reqs == [sticky, new]
+    assert result.pending_reqs == []
+    # select_shape_aware_dp was called once (for `new`), seeing the incoming item's
+    # (input, output) = (5, 7) and the sticky request's IO accumulated on rank 0:
+    # per-rank pending input = [10, 0], pending output = [3, 0].
+    assert harness.shape_aware_calls == [(5, 7, [10, 0], [3, 0])]
 
 
 def test_dp_size_one_assigns_generate_reqs_and_preserves_control_reqs():

--- a/test/srt/test_dp_rank_assignment.py
+++ b/test/srt/test_dp_rank_assignment.py
@@ -71,10 +71,27 @@ class _DpAssignmentHarness:
         self.cache_aware_calls.append((req.rid, list(extra_counts), list(extra_token_counts)))
         return self.select_min_running_dp(extra_counts, extra_token_counts)
 
+    def select_shape_aware_dp(
+        self,
+        item_input: int,
+        item_output: int,
+        extra_counts: list[int],
+        extra_token_counts: list[int],
+        extra_input_counts: list[int],
+        extra_output_counts: list[int],
+    ) -> int | None:
+        # These characterization tests exercise the dispatcher, not the shape-aware
+        # math (covered by test_dp_schedule_shape_aware.py); reuse min-running here.
+        return self.select_min_running_dp(extra_counts, extra_token_counts)
+
     @staticmethod
     def estimate_req_tokens(req: TokenizedGenerateReqInput) -> int:
         max_new_tokens = req.sampling_params.get("max_new_tokens", 0)
         return len(req.input_ids or []) + max_new_tokens
+
+    @staticmethod
+    def estimate_req_io_tokens(req: TokenizedGenerateReqInput) -> tuple[int, int]:
+        return len(req.input_ids or []), req.sampling_params.get("max_new_tokens", 0)
 
     def _eligible(self, extra_counts: list[int]) -> list[int]:
         return [
@@ -103,7 +120,9 @@ def _assign(
         select_round_robin_dp=harness.select_round_robin_dp,
         select_cache_aware_dp=harness.select_cache_aware_dp,
         select_min_running_dp=harness.select_min_running_dp,
+        select_shape_aware_dp=harness.select_shape_aware_dp,
         estimate_req_tokens=harness.estimate_req_tokens,
+        estimate_req_io_tokens=harness.estimate_req_io_tokens,
     )
 
 

--- a/test/srt/test_dp_schedule_shape_aware.py
+++ b/test/srt/test_dp_schedule_shape_aware.py
@@ -1,0 +1,84 @@
+"""Unit tests for the ``shape_aware`` DP scheduling decision logic.
+
+Covers the pure ``pick_shape_aware_dp`` policy, which balances prefill
+(input) and decode (output) token load jointly:
+
+    score(rank) = max(input_counts[rank] + item_input,
+                      output_counts[rank] + item_output)
+
+Route to the eligible rank minimizing that bottleneck dimension. Like the
+other policies this lives in the dependency-free helper module, so the test
+imports neither Scheduler nor JAX. The end-to-end throughput/latency
+improvement is validated separately by a bimodal A/B (see the PR description).
+"""
+
+from __future__ import annotations
+
+from sgl_jax.srt.managers.dp_schedule_policy import pick_shape_aware_dp as pick
+
+
+def test_routes_to_min_bottleneck_when_item_is_small():
+    # rank0 output-heavy, rank1 input-heavy, rank2 balanced-low.
+    inp = [100, 900, 50]
+    out = [900, 100, 50]
+    # A tiny request lands on rank2 (lowest max dimension = 50).
+    assert pick([0, 1, 2], inp, out, item_input=10, item_output=10) == 2
+
+
+def test_input_heavy_request_drawn_to_output_heavy_rank():
+    # rank0: heavy output, light input. rank1: heavy input, light output.
+    inp = [50, 800]
+    out = [800, 50]
+    # A prefill-heavy request (big input) goes to rank0 (light input), co-locating
+    # with its heavy output: rank0 max(50+700,800)=800 < rank1 max(800+700,50)=1500.
+    assert pick([0, 1], inp, out, item_input=700, item_output=0) == 0
+
+
+def test_output_heavy_request_drawn_to_input_heavy_rank():
+    inp = [50, 800]
+    out = [800, 50]
+    # A decode-heavy request (big output) goes to rank1 (light output):
+    # rank0 max(50,800+700)=1500 > rank1 max(800,50+700)=800.
+    assert pick([0, 1], inp, out, item_input=0, item_output=700) == 1
+
+
+def test_tiebreak_prefers_lower_total_then_rank():
+    # Equal bottleneck (max=100) on both; rank1 has the lower total sum (110<200).
+    inp = [100, 100]
+    out = [100, 10]
+    assert pick([0, 1], inp, out) == 1
+
+
+def test_full_ranks_excluded_by_caller_eligibility():
+    # rank0 would be ideal (empty) but the caller left it out of `eligible`.
+    inp = [0, 500]
+    out = [0, 500]
+    assert pick([1], inp, out, item_input=10, item_output=10) == 1
+
+
+def test_no_eligible_ranks_returns_none():
+    assert pick([], [0, 0], [0, 0], item_input=10, item_output=10) is None
+
+
+def test_item_shape_changes_the_choice():
+    # Same rank state, opposite request shapes route to opposite ranks.
+    inp = [0, 600]
+    out = [600, 0]
+    assert pick([0, 1], inp, out, item_input=500, item_output=0) == 0
+    assert pick([0, 1], inp, out, item_input=0, item_output=500) == 1
+
+
+def test_zero_item_defaults_balance_existing_load():
+    # With no item load, pick the rank with the smallest current bottleneck.
+    inp = [300, 100]
+    out = [100, 250]
+    # rank0 max=300, rank1 max=250 -> rank1.
+    assert pick([0, 1], inp, out) == 1
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Adds a shape-aware data-parallel routing policy, `shape_aware`, alongside `round_robin`, `min_running_queue`, and `cache_aware`. It balances prefill (input) and decode (output) token load **jointly** across DP replicas, routing each request to the replica whose *bottleneck* dimension stays smallest after admission:

```
score(rank) = max( Σinput + input_r,  Σoutput + output_r )   →  argmin
```

The `max` keeps whichever resource is binding on each rank (prefill/FLOPs vs. decode/KV-HBM) lowest, so a prefill-heavy request is drawn toward a decode-heavy rank and vice versa, co-locating complementary shapes rather than piling like-shaped work onto one rank.

Per-rank load includes the input/output split of requests assigned earlier in the **same intake tick** (pending-io tracking). This is load-bearing at low concurrency: without it, a burst routes against a stale snapshot and mis-balances (see the ablation below). It plugs into `assign_dp_ranks` the same way `cache_aware` does; the decision math is a pure, dependency-free function in `dp_schedule_policy.py`. Routing is `O(replicas)` plain arithmetic on the CPU scheduler thread, off the accelerator critical path.

## Why this score

Currently, we don't distinguish FLOP-bound and HBM-bound requests when scheduling DP. This is inspired by a cluster (k8s) scheduling score to balance CPU and RAM pressure per device

```
max(FLOPs Util, HBM Util)
```

Here, we simply use input token to represent FLOPs pressure, and use output token to represent HBM pressure. Ideally, we need normalization or weight to apply to input and output. 

```
max(input token / prefill capacity, output token / decode capacity)
```

Here we simply assume prefill and decode capacity are the same. We can fine tune the weights in the future, using cost factor or real FLOPs / HBM GB estimations.


## When it helps

Shape-aware routing matters only when compute is **stranded** — long outputs + low concurrency + a saturated KV pool, where a small decode batch is memory-bandwidth-bound and FLOPs sit idle (the operating point for long-generation / reasoning serving). On ordinary high-concurrency traffic there is no imbalance to exploit and it is within noise of `min_running_queue` (no regression).

## Experiment results

Single-node **TPU v6e-4**, **Qwen3-8B** bf16, `dp=4`. Bimodal workload: compute-heavy stream A (`in=2000/out=32 ×60`) + memory-heavy stream B (`in=64/out=20000 ×16`), stranded config (`CONC=8`, `RATE=2`, `mem-fraction-static=0.50`), averaged over 2 seeds. Metrics are for stream B (the memory-heavy stream that dominates makespan). Δ is vs `min_running_queue` (the stronger baseline):

| Metric (stream B) | round_robin | min_running_queue | **shape_aware** | Δ vs mrq |
|---|---|---|---|---|
| Throughput (tok/s) ↑ | 228 | 227 | **280** | **+23%** |
| P90 E2E latency ↓ | 104.7 s | 96.7 s | **71.6 s** | **−26%** |
| P99 E2E latency ↓ | 105.5 s | 107.1 s | **84.0 s** | **−22%** |

The gain is consistent across both seeds (throughput 277.6 / 281.6 tok/s). On compute-bound / unimodal workloads all policies are within noise (no regression).

### Ablation: pending-io tracking is required

Same config, comparing the policy **with vs. without** the per-tick pending-io split:

| Variant | B throughput | B P90 | Notes |
|---|---|---|---|
| **with** pending-io (this PR) | **280 tok/s (+23%)** | **71.6 s** | stable across seeds |
| without pending-io | 225 tok/s (~tie) | 121.5 s | unstable: 164 vs 287 tok/s by seed |

Without pending-io, a low-concurrency burst routes against a stale snapshot and mis-balances — throughput collapses to a wash and swings wildly by arrival order. This is why the per-tick split is included.

## Reproduce

On a TPU v6e-4 host. Start the server (swap `--dp-schedule-policy` between `min_running_queue` and `shape_aware`):

```bash
python -m sgl_jax.launch_server --model-path Qwen/Qwen3-8B --trust-remote-code \
  --device tpu --dtype bfloat16 --tp-size 4 --dp-size 4 \
  --dp-schedule-policy shape_aware \
  --mem-fraction-static 0.50 --chunked-prefill-size 2048 --page-size 128 \
  --host 127.0.0.1 --port 30000
```

Drive the two streams **concurrently** (compute-heavy A + memory-heavy B), then compare stream B's `output_throughput` / P90 / P99 across policies:

```bash
# Stream A (compute-heavy: long input, short output)
python -m sgl_jax.bench_serving --backend sglang --model Qwen/Qwen3-8B \
  --base-url http://127.0.0.1:30000 --dataset-name random \
  --num-prompts 60 --request-rate 2 --max-concurrency 8 \
  --random-input-len 2000 --random-output-len 32 --random-range-ratio 0.6 --seed 1 &

# Stream B (memory-heavy: short input, long output) -- the reported metrics
python -m sgl_jax.bench_serving --backend sglang --model Qwen/Qwen3-8B \
  --base-url http://127.0.0.1:30000 --dataset-name random \
  --num-prompts 16 --request-rate 2 --max-concurrency 8 \
  --random-input-len 64 --random-output-len 20000 --random-range-ratio 0.6 --seed 1 &
wait
```

The effect appears only in this stranded regime (small saturated KV pool + low concurrency + long outputs); on compute-bound traffic the policies tie.

## Testing

- `test/srt/test_dp_schedule_shape_aware.py` — 8 pure-function unit tests for `pick_shape_aware_dp` (no JAX dependency; run with `PYTHONPATH=python pytest`).
- `test/srt/test_dp_rank_assignment.py` — dispatcher characterization for the new policy path.
- Full CPU unit suite green (`python test/srt/run_suite.py --suite unit-test-cpu`): **33 passed** on the v6e-4 CI image. Server boots and routes cleanly under `--dp-schedule-policy shape_aware`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)