### PR TITLE
refactor(fused_mlp): remove unused variables/parameters

### DIFF
--- a/python/sgl_jax/srt/kernels/fused_mlp.py
+++ b/python/sgl_jax/srt/kernels/fused_mlp.py
@@ -23,9 +23,7 @@ def inner_mlp_kernel(
     y_tile,
     y_scratch,
     *,
-    b_seq: int,
     b_inter: int,
-    hidden_size: int,
     num_inter: int,
 ):
     i_i = pl.program_id(0)
@@ -108,9 +106,7 @@ def mlp_kernel_main(x_hbm, w_gu_hbm, wd_hbm, y_hbm, y_scratch, *, b_seq, b_inter
     pipeline_fn = pltpu.emit_pipeline(
         functools.partial(
             inner_mlp_kernel,
-            b_seq=b_seq,
             b_inter=b_inter,
-            hidden_size=hidden_size,
             num_inter=num_inter,
         ),
         grid=(num_inter,),
@@ -191,7 +187,7 @@ def apply_fused_mlp_with_padding(
     b_inter: int = 128,
 ) -> jax.Array:
     """Pads the input sequence length to be a multiple of b_seq if necessary."""
-    seq_len, hidden_size = x.shape
+    seq_len = x.shape[0]
     rem = seq_len % b_seq
     if rem == 0:
         return apply_fused_mlp_sharded(x, w_gu, wd, mesh, b_seq, b_inter)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

The purpose of this pull request is to clean up unused variables and parameters in the Gated MLP (SwiGLU) Pallas kernel (`fused_mlp.py`). This improves code readability and eliminates redundant parameter passing.

## Modifications

- **`inner_mlp_kernel`**: Removed unused `b_seq` and `hidden_size` keyword-only arguments from the function signature.
- **`mlp_kernel_main`**: Removed the redundant `b_seq` and `hidden_size` arguments from the `functools.partial` wrap of `inner_mlp_kernel`.
- **`apply_fused_mlp_with_padding`**: Removed the unused local variable `hidden_size` by replacing `seq_len, hidden_size = x.shape` with `seq_len = x.shape[0]`.

## Accuracy Tests

This is a clean-up refactor that only removes unused variables and parameters, without changing the execution logic or computation. Syntactic validation was verified using:
```bash
python3 -m py_compile python/sgl_jax/srt/kernels/fused_mlp.py
```

## Benchmarking and Profiling

N/A (No computational logic or memory layout has changed).

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.