### PR TITLE
fix(loader): materialize all fused dummy-weight targets

### DIFF
--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -2284,6 +2284,46 @@ class WeightLoader:
         nnx.update(self.model, params)
         logger.info("All weights loaded successfully.")
 
+    @staticmethod
+    def _make_dummy_shard(indices, shape, dtype, seed):
+        """Build one shard of a dummy weight for the slice described by
+        ``indices`` (as passed by ``jax.make_array_from_callback``)."""
+        shard_shape = []
+        for dim_size, idx in zip(shape, indices):
+            if isinstance(idx, slice):
+                start, stop, step = idx.indices(dim_size)
+                assert step == 1, f"Non-unit step not supported: {idx}"
+                shard_shape.append(stop - start)
+            else:
+                shard_shape.append(1)
+        shard_shape = tuple(shard_shape)
+
+        rng = np.random.default_rng(seed)
+        if jnp.issubdtype(dtype, jnp.floating):
+            gen_dtype: np.dtype[Any] = (
+                np.dtype(np.float32) if dtype == jnp.bfloat16 else np.dtype(dtype)
+            )
+            arr_np = rng.uniform(-1e-3, 1e-3, size=shard_shape).astype(gen_dtype)
+            return jnp.asarray(arr_np, dtype=dtype)
+        return jnp.zeros(shard_shape, dtype=dtype)
+
+    def _assign_dummy_param(self, params, target_path, sharding_tuple, seed):
+        """Materialize a single dummy parameter at ``target_path`` in-place."""
+        try:
+            model_param = self._get_param(params, target_path)
+        except (KeyError, AttributeError, ValueError):
+            logger.debug("Skip dummy weight for %s (parameter not found)", target_path)
+            return
+        shape = model_param.value.shape
+        dtype = model_param.value.dtype
+        sharding = jax.sharding.NamedSharding(
+            self.mesh, P(*sharding_tuple) if sharding_tuple else P()
+        )
+        model_param.value = jax.make_array_from_callback(
+            shape, sharding, lambda idx: self._make_dummy_shard(idx, shape, dtype, seed)
+        )
+        logger.debug("Generated dummy weight for %s, shape=%s", target_path, shape)
+
     def _load_dummy_weights(
         self,
         params: nnx.State,
@@ -2307,61 +2347,13 @@ class WeightLoader:
             elif not isinstance(mapping, WeightMapping):
                 raise TypeError("Unsupported mapping type:", type(mapping))
 
-            target_path = (
-                mapping.target_path
-                if isinstance(mapping.target_path, str)
-                else mapping.target_path[0]
-            )
-
-            try:
-                model_param = self._get_param(params, target_path)
-            except (KeyError, AttributeError, ValueError):
-                logger.debug("Skip dummy weight for %s (parameter not found)", target_path)
-                continue
-
-            shape = model_param.value.shape
-            dtype = model_param.value.dtype
-
-            sharding_spec = P(*mapping.sharding) if mapping.sharding else P()
-            sharding = jax.sharding.NamedSharding(self.mesh, sharding_spec)
-
-            def make_shard(indices, shape=shape, dtype=dtype):
-                shard_shape = []
-                for dim_size, idx in zip(shape, indices):
-                    if isinstance(idx, slice):
-                        start, stop, step = idx.indices(dim_size)
-                        assert step == 1, f"Non-unit step not supported: {idx}"
-                        shard_shape.append(stop - start)
-                    else:
-                        shard_shape.append(1)
-                shard_shape = tuple(shard_shape)
-
-                rng = np.random.default_rng(seed)
-                if jnp.issubdtype(dtype, jnp.floating):
-                    gen_dtype: np.dtype[Any]
-                    if dtype == jnp.bfloat16:
-                        gen_dtype = np.dtype(np.float32)
-                    else:
-                        gen_dtype = np.dtype(
-                            {
-                                jnp.float16: np.float16,
-                                jnp.float32: np.float32,
-                                jnp.float64: np.float64,
-                            }.get(dtype, np.float32)
-                        )
-                    arr_np = rng.uniform(-1e-3, 1e-3, size=shard_shape).astype(gen_dtype)
-                    return jnp.asarray(arr_np, dtype=dtype)
-                else:
-                    return jnp.zeros(shard_shape, dtype=dtype)
-
-            dummy_weight = jax.make_array_from_callback(shape, sharding, make_shard)
-            model_param.value = dummy_weight
-            logger.debug(
-                "Generated dummy weight for %s, shape=%s, sharding=%s",
-                target_path,
-                shape,
-                sharding_spec,
-            )
+            # A fused HF weight may map to several model params (e.g. a fused
+            # query_key_value -> q/k/v_proj). Materialize EVERY target, not just
+            # the first one, otherwise the un-filled params stay abstract
+            # (ShapeDtypeStruct from eval_shape) and crash at forward time.
+            tp = mapping.target_path
+            for target_path in tp if isinstance(tp, list) else [tp]:
+                self._assign_dummy_param(params, target_path, mapping.sharding, seed)
 
         for moe_key, mapping in moe_mappings.items():
             if isinstance(mapping, str | list):
@@ -2394,25 +2386,9 @@ class WeightLoader:
                 expert_sharding = jax.sharding.NamedSharding(self.mesh, expert_sharding_spec)
 
                 def make_expert_shard(
-                    indices, weight_shape=expert_weight_shape, weight_dtype=dtype, idx=expert_idx
+                    indices, shape=expert_weight_shape, dtype=dtype, idx=expert_idx
                 ):
-                    shard_shape = []
-                    for dim_size, idx_val in zip(weight_shape, indices):
-                        if isinstance(idx_val, slice):
-                            start, stop, step = idx_val.indices(dim_size)
-                            assert step == 1, f"Non-unit step not supported: {idx_val}"
-                            shard_shape.append(stop - start)
-                        else:
-                            shard_shape.append(1)
-                    shard_shape = tuple(shard_shape)
-
-                    rng = np.random.default_rng(seed + idx)
-                    if jnp.issubdtype(weight_dtype, jnp.floating):
-                        gen_dtype = np.float32 if weight_dtype == jnp.bfloat16 else weight_dtype
-                        arr_np = rng.uniform(-1e-3, 1e-3, size=shard_shape).astype(gen_dtype)
-                        return jnp.asarray(arr_np, dtype=weight_dtype)
-                    else:
-                        return jnp.zeros(shard_shape, dtype=weight_dtype)
+                    return self._make_dummy_shard(indices, shape, dtype, seed + idx)
 
                 expert_weight = jax.make_array_from_callback(
                     expert_weight_shape, expert_sharding, make_expert_shard

--- a/python/sgl_jax/test/test_weight_loader_dummy.py
+++ b/python/sgl_jax/test/test_weight_loader_dummy.py
@@ -1,0 +1,125 @@
+"""Unit tests for WeightLoader._load_dummy_weights fused-target handling.
+
+Regression for the bug where dummy mode only materialized `target_path[0]` of a
+list-valued regular mapping (fused `c_attn` -> q/k/v_proj, `gate_up` -> w1/w3),
+leaving the remaining split params as abstract `ShapeDtypeStruct` from
+`eval_shape` and crashing the first forward with "is not a valid JAX type".
+
+These run on CPU without a model/checkpoint: WeightLoader is built via
+`object.__new__` with just enough state to drive `_load_dummy_weights`, and
+`_get_param` is mocked to hand back capture params whose `.value` starts as the
+abstract placeholder and should be replaced with a concrete array.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.sharding import Mesh
+
+from sgl_jax.srt.utils import weight_utils
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+
+
+class _CaptureParam:
+    """Stand-in for nnx.Param: `.value` starts abstract (as after eval_shape) and
+    the loader's `model_param.value = ...` assignment lands here for read-back."""
+
+    def __init__(self, shape, dtype=jnp.float32):
+        self._v = jax.ShapeDtypeStruct(shape, dtype)
+
+    @property
+    def value(self):
+        return self._v
+
+    @value.setter
+    def value(self, v):
+        self._v = v
+
+
+def _make_loader(captured, monkeypatch):
+    """WeightLoader with only the state _load_dummy_weights needs; `_get_param`
+    resolves against `captured` and raises (→ skipped) for anything else. The
+    trailing `nnx.update(self.model, params)` is stubbed out."""
+    loader = object.__new__(WeightLoader)
+    loader.mesh = Mesh(np.array(jax.devices()[:1]).reshape(1, 1), ("data", "tensor"))
+    loader.model = object()
+
+    def _get_param(_params, path):
+        if path in captured:
+            return captured[path]
+        raise KeyError(path)
+
+    loader._get_param = _get_param
+    monkeypatch.setattr(weight_utils.nnx, "update", lambda *a, **k: None)
+    return loader
+
+
+def _concrete(param):
+    return isinstance(param.value, jax.Array)
+
+
+def test_fused_mapping_materializes_every_target(monkeypatch):
+    """The bug: a fused mapping (one HF key -> [q, k, v]) must fill ALL targets,
+    not just target_path[0]. Pre-fix, k_proj/v_proj stayed abstract."""
+    shape = (16, 16)
+    captured = {
+        "model.layers.0.self_attn.q_proj.weight": _CaptureParam(shape),
+        "model.layers.0.self_attn.k_proj.weight": _CaptureParam(shape),
+        "model.layers.0.self_attn.v_proj.weight": _CaptureParam(shape),
+    }
+    loader = _make_loader(captured, monkeypatch)
+    mappings = {
+        "transformer.h.0.attn.c_attn.weight": WeightMapping(
+            target_path=list(captured), sharding=(None, None)
+        )
+    }
+
+    loader._load_dummy_weights(params=None, weight_mappings=mappings)
+
+    for path, param in captured.items():
+        assert _concrete(param), f"{path} left abstract ({type(param.value).__name__})"
+
+
+def test_str_mapping_still_materializes_single_target(monkeypatch):
+    """Guard: the common non-fused case (target_path is a str) keeps working."""
+    captured = {"model.embed_tokens.embedding": _CaptureParam((32, 16))}
+    loader = _make_loader(captured, monkeypatch)
+    mappings = {
+        "transformer.wte.weight": WeightMapping(
+            target_path="model.embed_tokens.embedding", sharding=(None, None)
+        )
+    }
+
+    loader._load_dummy_weights(params=None, weight_mappings=mappings)
+
+    assert _concrete(captured["model.embed_tokens.embedding"])
+
+
+def test_missing_target_is_skipped(monkeypatch):
+    """Guard: a target absent from the model is skipped, not fatal, and does not
+    stop the remaining targets of the same mapping from being filled."""
+    captured = {
+        "model.layers.0.self_attn.q_proj.weight": _CaptureParam((16, 16)),
+        "model.layers.0.self_attn.v_proj.weight": _CaptureParam((16, 16)),
+    }
+    loader = _make_loader(captured, monkeypatch)
+    mappings = {
+        "transformer.h.0.attn.c_attn.weight": WeightMapping(
+            target_path=[
+                "model.layers.0.self_attn.q_proj.weight",
+                "model.layers.0.self_attn.k_proj.weight",  # not in captured -> skipped
+                "model.layers.0.self_attn.v_proj.weight",
+            ],
+            sharding=(None, None),
+        )
+    }
+
+    loader._load_dummy_weights(params=None, weight_mappings=mappings)
+
+    assert _concrete(captured["model.layers.0.self_attn.q_proj.weight"])
+    assert _concrete(captured["model.layers.0.self_attn.v_proj.weight"])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-xvs"])


### PR DESCRIPTION
## Motivation

Fixes #1437. In dummy mode (`--load-format dummy` / `_dummy_mode`),`WeightLoader._load_dummy_weights` only materialized `target_path[0]` for list-valued regular mappings. A fused HF weight that splits into several model
params (e.g. `c_attn` → `q/k/v_proj`, `gate_up` → `w1/w3`) therefore left every target except the first as an abstract `ShapeDtypeStruct` from `eval_shape`, and the first forward crashed with `... is not a valid JAX type`.

## Modifications

- **`_load_dummy_weights` (regular branch)**: iterate over every target of a mapping instead of only `target_path[0]`, so each split param is filled.
- **`_assign_dummy_param` / `_make_dummy_shard`**: extracted helpers (param lookup + shard generation) to keep the loop small and reusable.
- **`_load_dummy_weights` (MoE branch)**: unchanged behavior; now reuses `_make_dummy_shard`. It still uses `target_path[0]` on purpose — there the list is `[dest, *source_keys]` (`target_path[1:]` are checkpoint keys), so `[0]` is the only model param.

## Accuracy Tests

Deterministic CPU repro via the real dummy path (`nnx.eval_shape` → `model.load_weights(_dummy_mode=True)`) on the real `QWenLMHeadModel` (fuses q/k/v into `c_attn`). Run with `PYTHONPATH=python JAX_PLATFORMS=cpu python repro.py`:

```python
from types import SimpleNamespace
import jax, jax.numpy as jnp
from flax import nnx
from sgl_jax.srt.models.qwen import QWenLMHeadModel
from sgl_jax.srt.utils.mesh_utils import create_device_mesh
from sgl_jax.srt.utils.weight_utils import WeightLoader

CFG = SimpleNamespace(hidden_size=64, num_attention_heads=4, num_hidden_layers=2,
                      intermediate_size=128, max_position_embeddings=128, vocab_size=128,
                      layer_norm_epsilon=1e-6, tie_word_embeddings=False)
mesh = create_device_mesh([1, 1], [1, 1])
with jax.set_mesh(mesh):
    model = nnx.eval_shape(lambda: QWenLMHeadModel(CFG, mesh, dtype=jnp.float32))
    model.load_weights(SimpleNamespace(_dummy_mode=True))
    mappings, state = model._create_qwen_weight_mappings(), nnx.state(model)
    insp = WeightLoader(model, SimpleNamespace(), mesh, dtype=jnp.float32)
for k, m in mappings.items():
    if isinstance(m.target_path, list) and "c_attn.weight" in k:
        for t in m.target_path:
            v = insp._get_param(state, t).value
            print(t, "concrete" if isinstance(v, jax.Array) else f"ABSTRACT {type(v).__name__}")
        break
```

Before (on `main`): `q_proj` concrete, `k_proj`/`v_proj` abstract — 19/27 targets
filled. After this PR: 27/27.

## Benchmarking and Profiling

N/A (dummy-weight generation only; no change to model forward or kernels).

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve. (#1437)
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.