### PR TITLE
Qwen2.5-VL per-request encode plan

### DIFF
--- a/python/sgl_jax/srt/managers/mm_utils.py
+++ b/python/sgl_jax/srt/managers/mm_utils.py
@@ -6,11 +6,26 @@ the token merge and host loop that call model-specific encoders before the
 language backbone forward.
 """
 
+import dataclasses
 import functools
+from typing import Any
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax.sharding import PartitionSpec
+
+from sgl_jax.srt.multimodal.common.mm_plan import (
+    EmbedRound,
+    MultimodalEmbedPlan,
+    VisionEncodeInputs,
+)
+from sgl_jax.srt.multimodal.common.modality_enum import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sgl_jax.srt.multimodal.common.vision_metadata import VisionMetadataBuilderProtocol
 
 _MERGE_IN_SPECS = (
     PartitionSpec("data", None),  # running   [total_tok, H]
@@ -18,6 +33,184 @@ _MERGE_IN_SPECS = (
     PartitionSpec("data"),  # src_idx   [total_tok]
     PartitionSpec("data"),  # mask      [total_tok]
 )
+
+
+@dataclasses.dataclass(frozen=True)
+class ReqEncodeUnit:
+    """One request's vision payload owned by one DP rank for one encode round."""
+
+    images: list[MultimodalDataItem]
+    req_base: int
+
+
+def _collect_image_requests(
+    reqs_info: list[Any] | None,
+    dp_size: int,
+) -> list[list[ReqEncodeUnit]]:
+    """Collect vision-bearing requests as per-rank encode units."""
+    per_rank_units: list[list[ReqEncodeUnit]] = [[] for _ in range(dp_size)]
+    for dp_rank in range(dp_size):
+        if not reqs_info or dp_rank >= len(reqs_info):
+            continue
+        info = reqs_info[dp_rank]
+        if not info.reqs:
+            continue
+        req_base = 0
+        for req in info.reqs:
+            if req.mm_inputs is None:
+                mm_items = []
+            elif isinstance(req.mm_inputs, MultimodalInputs):
+                mm_items = req.mm_inputs.mm_items
+            elif isinstance(req.mm_inputs, dict) and "mm_items" not in req.mm_inputs:
+                mm_items = []
+            else:
+                raise TypeError(
+                    "build_mm_embed_plan expects req.mm_inputs to be MultimodalInputs, "
+                    f"got {type(req.mm_inputs).__name__}."
+                )
+            image_items = []
+            for item in mm_items:
+                if not isinstance(item, MultimodalDataItem):
+                    raise TypeError(
+                        "build_mm_embed_plan expects mm_items to contain "
+                        f"MultimodalDataItem, got {type(item).__name__}."
+                    )
+                if item.is_image() or item.is_video():
+                    image_items.append(item)
+            if image_items:
+                per_rank_units[dp_rank].append(ReqEncodeUnit(images=image_items, req_base=req_base))
+            req_base += int(getattr(req, "extend_input_len", 0) or 0)
+    return per_rank_units
+
+
+def _build_embed_round(
+    round_units: list[ReqEncodeUnit | None],
+    builder: VisionMetadataBuilderProtocol,
+    dp_size: int,
+    per_dp_token: int,
+) -> EmbedRound:
+    """Build one DP encode round from a single image order source.
+
+    ``unit.images`` is the only ordering source for this round. The raw patch
+    concat order, request-metadata pack order, and rank-local ``src_idx`` rows
+    must all be derived from this same traversal; splitting those traversals can
+    silently scatter the wrong vision row into a placeholder token.
+    """
+    total_token = dp_size * per_dp_token
+    src_idx = np.zeros(total_token, dtype=np.int32)
+    mask = np.zeros(total_token, dtype=np.bool_)
+    patch_features_by_rank = [None] * dp_size
+    metas = [None] * dp_size
+
+    real_lane = False
+    for dp_rank in range(dp_size):
+        unit = round_units[dp_rank] if dp_rank < len(round_units) else None
+        if unit is None:
+            continue
+        real_lane = True
+        rank_base = dp_rank * per_dp_token
+        merge_row = 0
+        patch_features = []
+        for item in unit.images:
+            feat = item.feature
+            if feat is None:
+                raise ValueError(f"IMAGE item in dp_rank {dp_rank} is missing feature.")
+            feat = np.asarray(feat)
+            if feat.ndim != 2 or feat.shape[0] <= 0:
+                raise ValueError(
+                    "IMAGE item feature must be a non-empty 2D patch array, "
+                    f"got shape={feat.shape} in dp_rank {dp_rank}."
+                )
+
+            patch_features.append(feat)
+            for start, end in item.offsets or []:
+                for o in range(int(start), int(end) + 1):
+                    tok = rank_base + unit.req_base + o
+                    if tok < rank_base or tok >= rank_base + per_dp_token:
+                        raise ValueError(
+                            "IMAGE placeholder offset is outside its packed rank slot: "
+                            f"dp_rank={dp_rank}, req_base={unit.req_base}, offset={o}, "
+                            f"per_dp_token={per_dp_token}."
+                        )
+                    if mask[tok]:
+                        raise ValueError(
+                            "IMAGE placeholder token is assigned more than once: "
+                            f"dp_rank={dp_rank}, token={tok}, offset={o}."
+                        )
+                    src_idx[tok] = merge_row
+                    mask[tok] = True
+                    merge_row += 1
+
+        actual_rows = int(mask[rank_base : rank_base + per_dp_token].sum())
+        if actual_rows != merge_row:
+            raise ValueError(
+                "IMAGE placeholder mask rows must match emitted merge rows: "
+                f"dp_rank={dp_rank}, mask rows={actual_rows}, expected={merge_row}."
+            )
+        patch_cat = np.concatenate(patch_features, axis=0)
+        patch_features_by_rank[dp_rank] = patch_cat
+        metas[dp_rank] = builder.get_metadata(unit.images)
+
+    if not real_lane:
+        raise ValueError("Multimodal embed round requires at least one real image lane.")
+
+    present = [f for f in patch_features_by_rank if f is not None]
+    patch_k = max(int(f.shape[0]) for f in present)
+    patch_dim = int(present[0].shape[1])
+    pixels = np.zeros((dp_size, patch_k, patch_dim), dtype=np.float32)
+    valid = np.zeros((dp_size,), dtype=np.int32)
+    for dp_rank, feat in enumerate(patch_features_by_rank):
+        if feat is None:
+            continue
+        rows = int(feat.shape[0])
+        pixels[dp_rank, :rows, :] = feat
+        valid[dp_rank] = rows
+
+    meta = builder.stack_metadata(metas, patch_k)
+    return EmbedRound(
+        encode_inputs=VisionEncodeInputs(pixels=pixels, valid=valid, meta=meta),
+        src_idx=src_idx,
+        mask=mask,
+    )
+
+
+def build_mm_embed_plan(
+    reqs_info: list[Any] | None,
+    dp_size: int,
+    model_config: Any,
+    per_dp_token: int,
+) -> MultimodalEmbedPlan | None:
+    """Build the owning-rank DP multimodal embed plan (host-side, numpy).
+
+    Round-loop: process one request's images per rank per round. ``n_rounds`` =
+    max over ranks of (#image-bearing requests that rank owns). Ranks with fewer
+    requests use a dummy lane that contributes nothing (grid/pixels zero, mask
+    all False).
+
+    Returns ``None`` for batches with no image items.
+    """
+    per_rank_units = _collect_image_requests(reqs_info, dp_size)
+    n_rounds = max((len(units) for units in per_rank_units), default=0)
+    if n_rounds == 0:
+        return None
+
+    # Resolve the per-arch metadata builder only after confirming this batch has
+    # image items, so non-image multimodal batches do not require a vision builder.
+    from sgl_jax.srt.multimodal.common.vision_metadata import (
+        resolve_vision_metadata_builder,
+    )
+
+    builder = resolve_vision_metadata_builder(model_config)
+
+    rounds = []
+    for round_idx in range(n_rounds):
+        round_units = [
+            per_rank_units[rank][round_idx] if round_idx < len(per_rank_units[rank]) else None
+            for rank in range(dp_size)
+        ]
+        rounds.append(_build_embed_round(round_units, builder, dp_size, per_dp_token))
+
+    return MultimodalEmbedPlan(rounds_by_modality={Modality.IMAGE: rounds})
 
 
 @functools.partial(jax.jit, static_argnames=("mesh",))
@@ -51,9 +244,9 @@ def embed_mm_inputs(
     """Encode each multimodal round and merge it into token embeddings.
 
     ``running`` starts as the plain text embedding (``embed_tokens`` once); each
-    round encodes one image per rank via the model's ``get_{modality}_feature``
-    embedder, which consumes scheduler-built ``enc.meta``. Returns the merged
-    embedding ``[total_token, H]``.
+    round encodes the image-bearing requests assigned to one DP rank via the
+    model's ``get_{modality}_feature`` embedder, which consumes scheduler-built
+    ``enc.meta``. Returns the merged embedding ``[total_token, H]``.
     """
     mesh = multimodal_model.mesh
     running = input_embedding(input_ids)

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -31,6 +31,7 @@ from jax._src import mesh as mesh_lib
 
 from sgl_jax.global_config import global_config
 from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.managers.mm_utils import build_mm_embed_plan
 from sgl_jax.srt.mem_cache.allocator import (
     BaseTokenToKVPoolAllocator,
     SWATokenToKVPoolAllocator,
@@ -51,16 +52,8 @@ from sgl_jax.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPo
 from sgl_jax.srt.mem_cache.radix_cache import RadixKey
 from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
-from sgl_jax.srt.multimodal.common.mm_plan import (
-    EmbedRound,
-    MultimodalEmbedPlan,
-    VisionEncodeInputs,
-)
-from sgl_jax.srt.multimodal.common.modality_enum import (
-    Modality,
-    MultimodalDataItem,
-    MultimodalInputs,
-)
+from sgl_jax.srt.multimodal.common.mm_plan import MultimodalEmbedPlan
+from sgl_jax.srt.multimodal.common.modality_enum import MultimodalInputs
 from sgl_jax.srt.precision_tracer import (
     PrecisionTracerRequestMetadata,
     precision_tracer,
@@ -2983,180 +2976,6 @@ def _extract_mm_value(mm_inputs: Any, key: str):
     if isinstance(mm_inputs, dict):
         return mm_inputs.get(key)
     return getattr(mm_inputs, key, None)
-
-
-def _as_mm_item(item: Any) -> MultimodalDataItem:
-    if isinstance(item, MultimodalDataItem):
-        return item
-    if isinstance(item, dict):
-        return MultimodalDataItem.from_dict(item)
-    raise TypeError(f"mm_items must contain MultimodalDataItem, got {type(item).__name__}.")
-
-
-def _build_merge_idx(
-    rank_entries: list,
-    dp_size: int,
-    per_dp_token: int,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Build ``src_idx``/``mask`` for one vision round.
-
-    Token layout mirrors ``_merge_input_and_positions``: rank ``r`` owns the
-    contiguous slot ``[r * per_dp_token : (r + 1) * per_dp_token]``; within that
-    slot, requests are concatenated in prefill order. ``item.offsets`` are
-    request-local inclusive placeholder spans, and ``req_base`` translates them
-    into the rank-local packed slot.
-
-    ``src_idx`` values are rank-local feature rows because the merge shard only
-    sees its own rank's encoded features. ``mask`` marks the global token
-    positions that should be replaced by vision rows.
-    """
-    total_token = dp_size * per_dp_token
-    src_idx = np.zeros(total_token, dtype=np.int32)
-    mask = np.zeros(total_token, dtype=np.bool_)
-
-    for dp_rank in range(dp_size):
-        entry = rank_entries[dp_rank] if dp_rank < len(rank_entries) else None
-        if entry is None:
-            continue  # dummy lane: contributes nothing (mask stays False)
-        item, req_base = entry
-        rank_base = dp_rank * per_dp_token
-        feat_row = 0
-        for start, end in item.offsets or []:
-            for o in range(int(start), int(end) + 1):
-                tok = rank_base + req_base + o
-                if tok >= rank_base + per_dp_token:
-                    raise ValueError(
-                        "Vision placeholder offset is outside its packed rank slot: "
-                        f"dp_rank={dp_rank}, req_base={req_base}, offset={o}, "
-                        f"per_dp_token={per_dp_token}."
-                    )
-                # rank-local feature row (merge gathers within this shard's own
-                # features); a plain running counter, NOT base_feat + feat_row.
-                src_idx[tok] = feat_row
-                mask[tok] = True
-                feat_row += 1
-    return src_idx, mask
-
-
-def build_mm_embed_plan(
-    reqs_info: list[ScheduleReqsInfo] | None,
-    dp_size: int,
-    model_config: Any,
-    per_dp_token: int,
-) -> MultimodalEmbedPlan | None:
-    """Build the owning-rank DP multimodal embed plan (host-side, numpy).
-
-    Round-loop: process vision items one-per-rank-per-round. ``n_rounds`` = max over
-    ranks of (#vision items that rank owns). Ranks with fewer items use a dummy lane
-    that contributes nothing (grid/pixels zero, mask all False). Each round runs
-    ONE single-item ViT per rank.
-
-    Returns ``None`` for batches with no vision items.
-
-    # TODO: bucket the vision patch and per-arch metadata axes; this
-    #   uses the per-forward cross-rank max for stable shapes within one call.
-    """
-    # Keep each vision item bound to its request's packed-slot offset. The merge
-    # builder translates item-local offsets with that req_base, so request
-    # boundaries must be preserved here.
-    items_by_rank: list[list[tuple[Any, int]]] = [[] for _ in range(dp_size)]
-    for dp_rank in range(dp_size):
-        if not reqs_info or dp_rank >= len(reqs_info):
-            continue
-        info = reqs_info[dp_rank]
-        if not info.reqs:
-            continue
-        req_base = 0  # running slot offset of the current req within this rank
-        for req in info.reqs:
-            mm_items = _extract_mm_value(req.mm_inputs, "mm_items") or []
-            for raw_item in mm_items:
-                item = _as_mm_item(raw_item)
-                if item.is_image() or item.is_video():
-                    items_by_rank[dp_rank].append((item, req_base))
-            # Advance by how many tokens this req contributes to the slot (the
-            # extend window, == len(fill_ids) - len(prefix_indices)).
-            req_base += int(getattr(req, "extend_input_len", 0) or 0)
-
-    n_rounds = max((len(items) for items in items_by_rank), default=0)
-    if n_rounds == 0:
-        return None
-
-    # Resolve the per-arch metadata builder only after confirming this batch has
-    # vision items, so non-vision multimodal batches do not require a vision builder.
-    from sgl_jax.srt.multimodal.common.vision_metadata import (
-        resolve_vision_metadata_builder,
-    )
-
-    builder = resolve_vision_metadata_builder(model_config)
-
-    rounds: list[EmbedRound] = []
-    for k in range(n_rounds):
-        # The round-k entry per rank: an ``(item, req_base)`` tuple, or
-        # None => dummy lane for ranks with < k+1 imgs.
-        rank_entries_k = [
-            items_by_rank[r][k] if k < len(items_by_rank[r]) else None for r in range(dp_size)
-        ]
-        # Bare items (without req_base) for grid/feature/meta sizing, which is
-        # per-image and does not need the slot translation.
-        rank_items_k = [None if e is None else e[0] for e in rank_entries_k]
-
-        # Per-rank grid for the per-arch metadata builder only; patch bucket
-        # sizing comes from feature rows.
-        patch_rows = [0] * dp_size
-        features = [None] * dp_size
-        metas = [None] * dp_size  # per-rank native VisionMetadata (None => dummy)
-        for r, item in enumerate(rank_items_k):
-            if item is None:
-                continue
-            feat = item.feature
-            if feat is None:
-                raise ValueError(f"Vision item in round {k}, dp_rank {r} is missing feature.")
-            feat = np.asarray(feat)
-            if feat.ndim != 2 or feat.shape[0] <= 0:
-                raise ValueError(
-                    "Vision item feature must be a non-empty 2D patch array, "
-                    f"got shape={feat.shape} in round {k}, dp_rank {r}."
-                )
-            features[r] = feat
-            patch_rows[r] = int(feat.shape[0])
-            # The builder constructs native-size per-image metadata and keeps its
-            # concrete fields opaque to the scheduler.
-            metas[r] = builder.get_metadata(item)
-
-        patch_k = max(patch_rows) if any(patch_rows) else 0
-        present = next(f for f in features if f is not None)
-        patch_dim = int(present.shape[1])
-
-        # pixels_k [dp, patch_k, dim]: pad+stack each rank's feature (pure numpy).
-        pixels_k = np.zeros((dp_size, patch_k, patch_dim), dtype=np.float32)
-        valid_k = np.zeros((dp_size,), dtype=np.int32)
-        for r, feat in enumerate(features):
-            if feat is None:
-                continue
-            rows = int(feat.shape[0])
-            pixels_k[r, :rows, :] = feat
-            valid_k[r] = rows
-
-        # The builder owns role-specific cross-rank metadata padding; the
-        # scheduler only supplies native metas and the round's patch bucket.
-        meta_k = builder.stack_metadata(metas, patch_k)
-
-        src_idx_k, mask_k = _build_merge_idx(rank_entries_k, dp_size, per_dp_token)
-
-        encode_inputs = VisionEncodeInputs(
-            pixels=pixels_k,
-            valid=valid_k,
-            meta=meta_k,
-        )
-        rounds.append(
-            EmbedRound(
-                encode_inputs=encode_inputs,
-                src_idx=src_idx_k,
-                mask=mask_k,
-            )
-        )
-
-    return MultimodalEmbedPlan(rounds_by_modality={Modality.IMAGE: rounds})
 
 
 def _as_int_scalar(value: Any, default: int = 0) -> int:

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -515,17 +515,9 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         self.forward_pass_id += 1
         precision_tracer.start_batch_trace(forward_batch.bid)
         precision_tracer.set_current_forward_pass_id(self.forward_pass_id)
-        # In-model VLM path (active): run the host embed routine (per-round JIT
-        # vision-encode -> JIT merge; aux precomputed host-side by the scheduler
-        # and carried in the plan), storing the merged embedding on
-        # forward_batch.input_embedding before the backbone JIT. `language_model`
-        # is the Qwen2Model backbone (`self.model.model`) -- it provides
-        # `get_input_embeddings` (embed module) to seed `running`;
-        # `multimodal_model` is the VL wrapper (`self.model`) -- it provides
-        # `get_image_feature`. The forward_mode gate lives ONLY in the scheduler
-        # (plan built iff forward_mode == EXTEND), so a non-None plan already means
-        # "this batch runs vision" -- here we just test `mm_embed_plan is not None`
-        # (decode / target_verify / mixed / draft_extend all carry a None plan).
+        # In-model VLM path: a non-None mm_embed_plan means the scheduler chose
+        # the normal prefill vision path; here we just fuse embeddings before the
+        # backbone JIT.
         if forward_batch.mm_embed_plan is not None:
             general_mm_embed_routine(
                 input_ids=forward_batch.input_ids,

--- a/python/sgl_jax/srt/models/qwen2_5_vl.py
+++ b/python/sgl_jax/srt/models/qwen2_5_vl.py
@@ -125,7 +125,7 @@ class Qwen2_5_VisionPatchEmbed(nnx.Module):
 
     def __call__(self, x: jax.Array) -> jax.Array:
         # x is (dp, seq_len, C * T * H * W) -- dp-leading batched;
-        # seq_len == the per-image patch count (== patch_k in the plan).
+        # seq_len == the per-request packed patch count (== patch_k in the plan).
         dp, seq_len, dim = x.shape
         C = dim // (self.temporal_patch_size * self.patch_size * self.patch_size)
         x = x.reshape(
@@ -469,6 +469,7 @@ class Qwen2_5_VisionTransformer(nnx.Module):
             meta.window_index,
             meta.cu_window_seqlens,
             meta.rotary_pos_emb,
+            meta.cu_image_seqlens,
             valid,
         )
 
@@ -478,6 +479,7 @@ class Qwen2_5_VisionTransformer(nnx.Module):
         window_index: jax.Array,
         cu_window_seqlens: jax.Array,
         rotary_pos_emb: jax.Array,
+        cu_image_seqlens: jax.Array,
         valid: jax.Array | None = None,
     ) -> jax.Array:
         """Run the dp-leading ViT encode body."""
@@ -493,21 +495,17 @@ class Qwen2_5_VisionTransformer(nnx.Module):
         hidden_states = jnp.take_along_axis(hidden_states, gather_idx, axis=1)
         hidden_states = hidden_states.reshape(dp, seq_len, -1)  # [dp, T, D]
 
-        # Full-att blocks use one segment per image; windowed blocks use window boundaries.
-        if valid is None:
-            full_cu_window_seqlens = jnp.full((dp, 1), seq_len, dtype=cu_window_seqlens.dtype)
-        else:
-            full_cu_window_seqlens = jnp.reshape(valid, (dp, 1)).astype(cu_window_seqlens.dtype)
-
         for layer_num, blk in enumerate(self.blocks):
+            # Full-attention blocks must segment by image, not by the packed
+            # request length, otherwise later images can leak into earlier image
+            # outputs. Windowed blocks keep the Qwen window boundaries.
+            cu_seqlens = (
+                cu_image_seqlens if layer_num in self.fullatt_block_indexes else cu_window_seqlens
+            )
             hidden_states = blk(
                 hidden_states,
                 rotary_pos_emb,
-                (
-                    full_cu_window_seqlens
-                    if layer_num in self.fullatt_block_indexes
-                    else cu_window_seqlens
-                ),
+                cu_seqlens,
                 valid,
             )
 
@@ -590,7 +588,8 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module):
         """Encode one DP round of images.
 
         ``enc.meta`` carries scheduler-built ViT aux
-        (``window_index`` / ``cu_window_seqlens`` / ``rotary_pos_emb``).
+        (``window_index`` / ``cu_window_seqlens`` / ``cu_image_seqlens`` /
+        ``rotary_pos_emb``).
         Returns dp-leading image features with shape ``[dp, out_rows, H]``.
         """
         return self.visual.encode(enc.pixels, enc.meta, enc.valid)

--- a/python/sgl_jax/srt/models/vision_metadata/qwen2_5_vl.py
+++ b/python/sgl_jax/srt/models/vision_metadata/qwen2_5_vl.py
@@ -26,15 +26,22 @@ class Qwen25VLVisionMetadata:
 
     Common code treats this as an opaque pytree. The Qwen ViT encode body reads
     the concrete fields, in flatten order:
-    ``window_index`` / ``cu_window_seqlens`` / ``rotary_pos_emb``.
+    ``window_index`` / ``cu_window_seqlens`` / ``rotary_pos_emb`` /
+    ``cu_image_seqlens``.
     """
 
     window_index: Any
     cu_window_seqlens: Any
     rotary_pos_emb: Any
+    cu_image_seqlens: Any
 
     def tree_flatten(self):
-        children = (self.window_index, self.cu_window_seqlens, self.rotary_pos_emb)
+        children = (
+            self.window_index,
+            self.cu_window_seqlens,
+            self.rotary_pos_emb,
+            self.cu_image_seqlens,
+        )
         aux_data = {}  # static sizes/roles may live here; runtime does not depend on it
         return (children, aux_data)
 
@@ -46,8 +53,8 @@ class Qwen25VLVisionMetadata:
 def _item_grid_thw(item: MultimodalDataItem) -> tuple:
     """First ``(t, h, w)`` of this vision item's grid metadata as a python-int tuple.
 
-    The builder pulls its geometry from the item here, so the common
-    ``get_metadata(item)`` interface stays arch-agnostic.
+    Qwen-specific: the builder pulls its geometry from the item here, so the
+    common ``get_metadata(items)`` interface stays arch-agnostic.
     """
     grid = item.get("image_grid_thw")
     grid_key = "image_grid_thw"
@@ -78,8 +85,8 @@ class Qwen25VLVisionMetadataBuilder:
     """Host-side builder for Qwen2.5-VL ViT aux.
 
     Contract:
-    - ``get_metadata(item)`` consumes one image item carrying ``image_grid_thw``
-      and returns native-size metadata for that image.
+    - ``get_metadata(items)`` consumes one request's image items and
+      returns request-level metadata without a DP axis.
     - ``stack_metadata(metas, patch_k)`` consumes one native metadata object per
       DP rank (or ``None`` for a dummy lane) and returns a pad-stacked metadata
       pytree for one encode round.
@@ -174,15 +181,21 @@ class Qwen25VLVisionMetadataBuilder:
         cu_seqlens_window = cu_seqlens_window.astype(np.int32)
         return index_new.astype(np.int32), cu_seqlens_window
 
-    def get_metadata(self, item) -> Qwen25VLVisionMetadata:
+    def get_metadata(self, items) -> Qwen25VLVisionMetadata:
+        """Build request-level Qwen metadata for image items in concat order."""
+        per_img_metas = [self._get_image_metadata(item) for item in items]
+        return self._pack_request_metadata(per_img_metas)
+
+    def _get_image_metadata(self, item) -> Qwen25VLVisionMetadata:
         """Build native-size Qwen metadata for one image item.
 
         Input contract: ``item`` must provide exactly one ``image_grid_thw`` row.
         Output contract: all fields are native-size numpy arrays for this image:
         ``window_index`` is a spatial-merge-unit permutation,
-        ``cu_window_seqlens`` is cumulative window boundaries, and
+        ``cu_window_seqlens`` is cumulative window boundaries,
+        ``cu_image_seqlens`` is this image's cumulative patch-row boundary, and
         ``rotary_pos_emb`` is per-patch 2D rope already gathered into window
-        order. Full-attention boundaries are derived later from ``valid``.
+        order.
         """
         t, h, w = _item_grid_thw(item)
         sms = self.spatial_merge_size
@@ -223,6 +236,51 @@ class Qwen25VLVisionMetadataBuilder:
             window_index=window_index.astype(np.int32),
             cu_window_seqlens=cu_window_seqlens.astype(np.int32),
             rotary_pos_emb=rope,
+            cu_image_seqlens=np.asarray([expected_patch_rows], dtype=np.int32),
+        )
+
+    def _pack_request_metadata(self, per_img_metas) -> Qwen25VLVisionMetadata:
+        """Pack one request's per-image metadata into one encode sequence.
+
+        Args:
+            per_img_metas: Native per-image metadata from ``_get_image_metadata(item)``,
+                in the same order as the request's concatenated patch features.
+
+        Returns:
+            Request-level metadata without a DP axis. Shapes are
+            ``window_index=[sum_units]``, ``cu_window_seqlens=[sum_windows]``,
+            ``rotary_pos_emb=[sum_patches, rot_dim]``, and
+            ``cu_image_seqlens=[num_images]``.
+
+        Globalization rules:
+        - ``window_index`` is offset by prior images' spatial-merge units.
+        - ``cu_window_seqlens`` is offset by prior images' patch rows.
+        - ``cu_image_seqlens`` records image-end patch rows for full attention.
+        """
+        if not per_img_metas:
+            raise ValueError("Qwen2.5-VL request metadata requires at least one image.")
+
+        unit_off = 0
+        patch_off = 0
+        window_indices = []
+        cu_window_seqlens = []
+        rotary_rows = []
+        cu_image_seqlens = []
+        for meta in per_img_metas:
+            n_units = int(meta.window_index.shape[0])
+            n_patches = n_units * self.spatial_merge_unit
+            window_indices.append(np.asarray(meta.window_index, dtype=np.int32) + unit_off)
+            cu_window_seqlens.append(np.asarray(meta.cu_window_seqlens, dtype=np.int32) + patch_off)
+            rotary_rows.append(np.asarray(meta.rotary_pos_emb, dtype=np.float32))
+            patch_off += n_patches
+            unit_off += n_units
+            cu_image_seqlens.append(patch_off)
+
+        return Qwen25VLVisionMetadata(
+            window_index=np.concatenate(window_indices).astype(np.int32),
+            cu_window_seqlens=np.concatenate(cu_window_seqlens).astype(np.int32),
+            rotary_pos_emb=np.concatenate(rotary_rows, axis=0).astype(np.float32),
+            cu_image_seqlens=np.asarray(cu_image_seqlens, dtype=np.int32),
         )
 
     def stack_metadata(self, metas, patch_k):
@@ -237,21 +295,39 @@ class Qwen25VLVisionMetadataBuilder:
         - ``window_index`` stays a valid permutation via identity tail padding.
         - ``cu_window_seqlens`` uses ``patch_k`` sentinel tail padding.
         - ``rotary_pos_emb`` uses zero row padding to ``patch_k``.
+        - ``cu_image_seqlens`` uses ``patch_k`` sentinel tail padding.
         """
+        if patch_k % self.spatial_merge_unit != 0:
+            raise ValueError(
+                "Qwen2.5-VL metadata patch bucket must be divisible by "
+                f"spatial_merge_unit={self.spatial_merge_unit}, got patch_k={patch_k}."
+            )
+
         present = [m for m in metas if m is not None]
-        units_k = max(int(m.window_index.shape[0]) for m in present)
+        if not present:
+            raise ValueError("Qwen2.5-VL stack_metadata requires at least one real metadata lane.")
+        units_k = patch_k // self.spatial_merge_unit
         win_k = max(int(m.cu_window_seqlens.shape[0]) for m in present)
+        img_k = max(int(m.cu_image_seqlens.shape[0]) for m in present)
         rot_dim = int(present[0].rotary_pos_emb.shape[-1])
-        window_indices, cu_window_seqlens_rows, rotary_rows = [], [], []
+        window_indices, cu_window_seqlens_rows, rotary_rows, cu_image_rows = [], [], [], []
         for m in metas:
             if m is None:  # dummy lane
                 window_indices.append(np.arange(units_k, dtype=np.int32))  # identity perm
                 cu_window_seqlens_rows.append(np.full(win_k, patch_k, dtype=np.int32))
                 rotary_rows.append(np.zeros((patch_k, rot_dim), dtype=np.float32))
+                cu_image_rows.append(np.full(img_k, patch_k, dtype=np.int32))
             else:
                 # window_index: true values + arange continuation for the pad tail.
                 w = np.arange(units_k, dtype=np.int32)
                 n_units = int(m.window_index.shape[0])
+                # Defensive for direct calls with undersized patch_k; scheduler
+                # normally derives patch_k from the same round's patch features.
+                if n_units > units_k:
+                    raise ValueError(
+                        "Qwen2.5-VL window_index exceeds patch bucket: "
+                        f"n_units={n_units}, units_k={units_k}."
+                    )
                 w[:n_units] = np.asarray(m.window_index, dtype=np.int32)
                 # cu_window_seqlens: true values + patch_k sentinel tail.
                 c = np.full(win_k, patch_k, dtype=np.int32)
@@ -260,14 +336,27 @@ class Qwen25VLVisionMetadataBuilder:
                 # rotary_pos_emb: true rows + zero pad to patch_k.
                 r = np.zeros((patch_k, rot_dim), dtype=np.float32)
                 rp = np.asarray(m.rotary_pos_emb, dtype=np.float32)
+                # Defensive for direct calls with undersized patch_k; scheduler
+                # normally derives patch_k from the same round's patch features.
+                if int(rp.shape[0]) > patch_k:
+                    raise ValueError(
+                        "Qwen2.5-VL rotary rows exceed patch bucket: "
+                        f"rows={int(rp.shape[0])}, patch_k={patch_k}."
+                    )
                 r[: int(rp.shape[0])] = rp
+                # cu_image_seqlens: true per-image ends + patch_k sentinel tail.
+                ci = np.full(img_k, patch_k, dtype=np.int32)
+                n_img = int(m.cu_image_seqlens.shape[0])
+                ci[:n_img] = np.asarray(m.cu_image_seqlens, dtype=np.int32)
                 window_indices.append(w)
                 cu_window_seqlens_rows.append(c)
                 rotary_rows.append(r)
+                cu_image_rows.append(ci)
         return Qwen25VLVisionMetadata(
             np.stack(window_indices),
             np.stack(cu_window_seqlens_rows),
             np.stack(rotary_rows),
+            np.stack(cu_image_rows),
         )
 
 

--- a/python/sgl_jax/srt/multimodal/common/mm_plan.py
+++ b/python/sgl_jax/srt/multimodal/common/mm_plan.py
@@ -26,9 +26,9 @@ class VisionEncodeInputs:
 
     Two-state array fields (``np.ndarray`` host -> ``jax.Array`` device):
 
-    - ``pixels``: ``[dp, patch_k, dim]`` -- per-rank round-k image patches.
+    - ``pixels``: ``[dp, patch_k, dim]`` -- per-rank round-k request image patches.
     - ``valid``:  ``[dp]``               -- real patch-row count per rank's
-      round-k image.
+      round-k image-bearing request.
     - ``meta``:   per-arch ViT-aux registered pytree (opaque to common; see
       :class:`VisionMetadataPytree`). Crosses the encode JIT.
     """
@@ -40,7 +40,7 @@ class VisionEncodeInputs:
 
 @dataclass
 class EmbedRound:
-    """One owning-rank DP round: one single-image ViT per rank, then merge.
+    """One owning-rank DP round: one request's images per rank, then merge.
 
     ``src_idx``/``mask`` are integer/bool arrays produced by the scheduler that
     drive the ``where(mask, features[src_idx], running)`` merge -- no device

--- a/python/sgl_jax/srt/multimodal/common/vision_metadata.py
+++ b/python/sgl_jax/srt/multimodal/common/vision_metadata.py
@@ -18,8 +18,8 @@ class VisionMetadataBuilderProtocol(Protocol):
 
     def __init__(self, model_config) -> None: ...
 
-    def get_metadata(self, item) -> VisionMetadataPytree:
-        """Build native-size metadata for one multimodal item."""
+    def get_metadata(self, items) -> VisionMetadataPytree:
+        """Build request-level metadata for one rank's encode unit."""
         ...
 
     def stack_metadata(self, metas, patch_k) -> VisionMetadataPytree:

--- a/python/sgl_jax/test/test_vlm_stage1_framework.py
+++ b/python/sgl_jax/test/test_vlm_stage1_framework.py
@@ -9,12 +9,16 @@ from flax import nnx
 from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec
 
 from sgl_jax.srt.managers.io_struct import GenerateReqInput
-from sgl_jax.srt.managers.mm_utils import merge_jit
+from sgl_jax.srt.managers.mm_utils import (
+    _build_embed_round,
+    _collect_image_requests,
+    build_mm_embed_plan,
+    merge_jit,
+)
 from sgl_jax.srt.managers.schedule_batch import (
     ModelWorkerBatch,
     ScheduleBatch,
     ScheduleReqsInfo,
-    build_mm_embed_plan,
 )
 from sgl_jax.srt.model_executor.forward_batch_info import (
     ForwardBatch,
@@ -41,6 +45,29 @@ from sgl_jax.srt.multimodal.common.modality_enum import (
 )
 from sgl_jax.srt.multimodal.processors.qwen_vl import QwenVLProcessor
 from sgl_jax.srt.server_args import apply_multimodal_model_defaults
+
+
+def _build_image_items(features, grids, offsets):
+    return QwenVLProcessor._build_items(
+        features,
+        grids,
+        offsets,
+        Modality.IMAGE,
+        "image_grid_thw",
+    )
+
+
+class _NaiveSegmentAttentionBackend:
+    def __call__(self, q, k, v, segment_ids):
+        q_seg = segment_ids.q
+        kv_seg = segment_ids.kv
+        scores = jnp.einsum("dnth,dnsh->dnts", q, k)
+        mask = (q_seg[:, None, :, None] == kv_seg[:, None, None, :]) & (
+            q_seg[:, None, :, None] >= 0
+        )
+        scores = jnp.where(mask, scores, jnp.asarray(-1e9, dtype=scores.dtype))
+        probs = jax.nn.softmax(scores, axis=-1)
+        return jnp.einsum("dnts,dnsh->dnth", probs, v)
 
 
 def _two_data_devices():
@@ -97,6 +124,7 @@ def test_vision_transformer_encode_jit_accepts_unhashable_vision_config():
         window_index=jnp.zeros((1, 2), dtype=jnp.int32),
         cu_window_seqlens=jnp.array([[2]], dtype=jnp.int32),
         rotary_pos_emb=jnp.zeros((1, 2, 2), dtype=jnp.float32),
+        cu_image_seqlens=jnp.array([[2]], dtype=jnp.int32),
     )
 
     with jax.set_mesh(mesh):
@@ -134,6 +162,7 @@ def test_vision_transformer_encode_jit_uses_reshard_for_explicit_mesh(monkeypatc
         window_index=jnp.zeros((1, 2), dtype=jnp.int32),
         cu_window_seqlens=jnp.array([[2]], dtype=jnp.int32),
         rotary_pos_emb=jnp.zeros((1, 2, 2), dtype=jnp.float32),
+        cu_image_seqlens=jnp.array([[2]], dtype=jnp.int32),
     )
 
     with jax.set_mesh(mesh):
@@ -217,6 +246,7 @@ def test_vision_transformer_encode_binds_mesh_for_sharded_inputs_without_callsit
                             window_index=np.array([[0]], dtype=np.int32),
                             cu_window_seqlens=np.array([[4]], dtype=np.int32),
                             rotary_pos_emb=np.zeros((1, 4, 2), dtype=np.float32),
+                            cu_image_seqlens=np.array([[4]], dtype=np.int32),
                         ),
                     ),
                     src_idx=np.zeros((1,), dtype=np.int32),
@@ -252,6 +282,7 @@ def test_vision_patch_embed_calls_conv_with_single_batch_dim(monkeypatch):
         window_index=jnp.tile(jnp.arange(3, dtype=jnp.int32)[None, :], (2, 1)),
         cu_window_seqlens=jnp.array([[3], [3]], dtype=jnp.int32),
         rotary_pos_emb=jnp.zeros((2, 3, 2), dtype=jnp.float32),
+        cu_image_seqlens=jnp.array([[3], [3]], dtype=jnp.int32),
     )
 
     seen_input_shapes = []
@@ -278,6 +309,142 @@ def test_vision_patch_embed_calls_conv_with_single_batch_dim(monkeypatch):
 
     assert features.shape == (2, 3, 4)
     assert seen_input_shapes == [(6, 1, 1, 1, 1)]
+
+
+def test_vision_full_attention_keeps_packed_images_block_diagonal_on_cpu():
+    vision_config = SimpleNamespace(
+        patch_size=1,
+        temporal_patch_size=1,
+        in_channels=1,
+        hidden_size=4,
+        depth=1,
+        intermediate_size=8,
+        hidden_act="silu",
+        num_heads=1,
+        out_hidden_size=4,
+        spatial_merge_size=1,
+        fullatt_block_indexes=[0],
+        window_size=1,
+        rope_theta=10000.0,
+    )
+    mesh = Mesh(np.array(jax.devices()[:1]), ("data",))
+    with jax.set_mesh(mesh):
+        visual = Qwen2_5_VisionTransformer(
+            config=vision_config,
+            dtype=jnp.float32,
+            mesh=None,
+            norm_eps=1e-6,
+        )
+    visual.blocks[0].attn.attn_backend = _NaiveSegmentAttentionBackend()
+    builder = Qwen25VLVisionMetadataBuilder(
+        SimpleNamespace(hf_config=SimpleNamespace(vision_config=vision_config))
+    )
+
+    packed_features = np.arange(1, 8, dtype=np.float32).reshape(7, 1)
+    packed_items = _build_image_items(
+        packed_features,
+        [(1, 2, 2), (1, 1, 3)],
+        [(0, 3), (4, 6)],
+    )
+    packed_meta = builder.stack_metadata(
+        [builder.get_metadata(packed_items)],
+        patch_k=7,
+    )
+
+    single_item = _build_image_items(
+        packed_features[:4],
+        [(1, 2, 2)],
+        [(0, 3)],
+    )[0]
+    single_meta = builder.stack_metadata(
+        [builder.get_metadata([single_item])],
+        patch_k=4,
+    )
+
+    packed_out = visual.compute_hidden_states(
+        jnp.asarray(packed_features[None, :, :]),
+        jnp.asarray(packed_meta.window_index),
+        jnp.asarray(packed_meta.cu_window_seqlens),
+        jnp.asarray(packed_meta.rotary_pos_emb),
+        jnp.asarray(packed_meta.cu_image_seqlens),
+        jnp.array([7], dtype=jnp.int32),
+    )
+    single_out = visual.compute_hidden_states(
+        jnp.asarray(packed_features[None, :4, :]),
+        jnp.asarray(single_meta.window_index),
+        jnp.asarray(single_meta.cu_window_seqlens),
+        jnp.asarray(single_meta.rotary_pos_emb),
+        jnp.asarray(single_meta.cu_image_seqlens),
+        jnp.array([4], dtype=jnp.int32),
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(packed_out[:, :4, :]),
+        np.asarray(single_out),
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
+
+def test_vision_single_image_request_matches_single_image_encode_on_cpu():
+    vision_config = SimpleNamespace(
+        patch_size=1,
+        temporal_patch_size=1,
+        in_channels=1,
+        hidden_size=4,
+        depth=1,
+        intermediate_size=8,
+        hidden_act="silu",
+        num_heads=1,
+        out_hidden_size=4,
+        spatial_merge_size=1,
+        fullatt_block_indexes=[0],
+        window_size=1,
+        rope_theta=10000.0,
+    )
+    mesh = Mesh(np.array(jax.devices()[:1]), ("data",))
+    with jax.set_mesh(mesh):
+        visual = Qwen2_5_VisionTransformer(
+            config=vision_config,
+            dtype=jnp.float32,
+            mesh=None,
+            norm_eps=1e-6,
+        )
+    visual.blocks[0].attn.attn_backend = _NaiveSegmentAttentionBackend()
+    builder = Qwen25VLVisionMetadataBuilder(
+        SimpleNamespace(hf_config=SimpleNamespace(vision_config=vision_config))
+    )
+
+    patch_features = np.arange(1, 5, dtype=np.float32).reshape(4, 1)
+    item = _build_image_items(
+        patch_features,
+        [(1, 2, 2)],
+        [(0, 3)],
+    )[0]
+    native_meta = builder.stack_metadata([builder._get_image_metadata(item)], patch_k=4)
+    packed_meta = builder.stack_metadata(
+        [builder._pack_request_metadata([builder._get_image_metadata(item)])],
+        patch_k=4,
+    )
+
+    native_out = visual.compute_hidden_states(
+        jnp.asarray(patch_features[None, :, :]),
+        jnp.asarray(native_meta.window_index),
+        jnp.asarray(native_meta.cu_window_seqlens),
+        jnp.asarray(native_meta.rotary_pos_emb),
+        jnp.asarray(native_meta.cu_image_seqlens),
+        jnp.array([4], dtype=jnp.int32),
+    )
+    packed_out = visual.compute_hidden_states(
+        jnp.asarray(patch_features[None, :, :]),
+        jnp.asarray(packed_meta.window_index),
+        jnp.asarray(packed_meta.cu_window_seqlens),
+        jnp.asarray(packed_meta.rotary_pos_emb),
+        jnp.asarray(packed_meta.cu_image_seqlens),
+        jnp.array([4], dtype=jnp.int32),
+    )
+
+    np.testing.assert_allclose(np.asarray(packed_out), np.asarray(native_out), rtol=1e-5, atol=1e-5)
 
 
 def test_vision_encode_runs_on_real_dp2_data_mesh(monkeypatch):
@@ -325,6 +492,7 @@ def test_vision_encode_runs_on_real_dp2_data_mesh(monkeypatch):
                             window_index=np.array([[1, 0], [0, 1]], dtype=np.int32),
                             cu_window_seqlens=np.array([[8], [4]], dtype=np.int32),
                             rotary_pos_emb=np.zeros((2, 8, 2), dtype=np.float32),
+                            cu_image_seqlens=np.array([[8], [4]], dtype=np.int32),
                         ),
                     ),
                     src_idx=np.zeros((8,), dtype=np.int32),
@@ -395,6 +563,7 @@ def test_device_put_embed_plan_places_qwen_metadata_data_leading():
                             window_index=np.array([[0]], dtype=np.int32),
                             cu_window_seqlens=np.array([[4]], dtype=np.int32),
                             rotary_pos_emb=np.zeros((1, 4, 2), dtype=np.float32),
+                            cu_image_seqlens=np.array([[4]], dtype=np.int32),
                         ),
                     ),
                     src_idx=np.zeros((2,), dtype=np.int32),
@@ -413,6 +582,7 @@ def test_device_put_embed_plan_places_qwen_metadata_data_leading():
     assert tuple(enc.meta.window_index.sharding.spec) == ("data", None)
     assert tuple(enc.meta.cu_window_seqlens.sharding.spec) == ("data", None)
     assert tuple(enc.meta.rotary_pos_emb.sharding.spec) == ("data", None, None)
+    assert tuple(enc.meta.cu_image_seqlens.sharding.spec) == ("data", None)
     assert tuple(rnd.src_idx.sharding.spec) == ("data",)
     assert tuple(rnd.mask.sharding.spec) == ("data",)
 
@@ -524,6 +694,7 @@ def test_mm_embed_plan_device_put_uses_data_leading_sharding():
                             window_index=np.zeros((1, 1), dtype=np.int32),
                             cu_window_seqlens=np.ones((1, 1), dtype=np.int32),
                             rotary_pos_emb=np.ones((1, 4, 2), dtype=np.float32),
+                            cu_image_seqlens=np.array([[4]], dtype=np.int32),
                         ),
                     ),
                     src_idx=np.zeros((4,), dtype=np.int32),
@@ -550,6 +721,7 @@ def test_mm_embed_plan_device_put_uses_data_leading_sharding():
         PartitionSpec("data", None),
         PartitionSpec("data", None),
         PartitionSpec("data", None, None),
+        PartitionSpec("data", None),
         PartitionSpec("data"),
         PartitionSpec("data"),
     ]
@@ -621,11 +793,288 @@ def test_multimodal_data_item_get_reads_common_and_model_specific_fields():
     assert item.get("missing", "fallback") == "fallback"
 
 
+def test_qwen_metadata_builder_packs_request_metadata_with_image_boundaries():
+    vision_config = SimpleNamespace(
+        patch_size=14,
+        window_size=112,
+        spatial_merge_size=2,
+        num_heads=16,
+        hidden_size=1280,
+        rope_theta=10000.0,
+    )
+    builder = Qwen25VLVisionMetadataBuilder(
+        SimpleNamespace(hf_config=SimpleNamespace(vision_config=vision_config))
+    )
+    features = np.arange(272, dtype=np.float32).reshape(272, 1)
+    items = _build_image_items(
+        features,
+        [(1, 16, 16), (1, 4, 4)],
+        [(0, 63), (64, 67)],
+    )
+
+    packed = builder.get_metadata(items)
+
+    np.testing.assert_array_equal(
+        packed.cu_window_seqlens,
+        np.array([64, 128, 192, 256, 272], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        packed.cu_image_seqlens,
+        np.array([256, 272], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        np.sort(packed.window_index),
+        np.arange(68, dtype=np.int32),
+    )
+    assert packed.rotary_pos_emb.shape[0] == 272
+
+
+def test_qwen_metadata_builder_single_image_request_metadata_degenerates_to_native():
+    vision_config = SimpleNamespace(
+        patch_size=14,
+        window_size=112,
+        spatial_merge_size=2,
+        num_heads=16,
+        hidden_size=1280,
+        rope_theta=10000.0,
+    )
+    builder = Qwen25VLVisionMetadataBuilder(
+        SimpleNamespace(hf_config=SimpleNamespace(vision_config=vision_config))
+    )
+    item = _build_image_items(
+        np.arange(8, dtype=np.float32).reshape(8, 1),
+        [(1, 2, 4)],
+        [(0, 1)],
+    )[0]
+
+    native = builder._get_image_metadata(item)
+    packed = builder._pack_request_metadata([native])
+
+    np.testing.assert_array_equal(packed.window_index, native.window_index)
+    np.testing.assert_array_equal(packed.cu_window_seqlens, native.cu_window_seqlens)
+    np.testing.assert_array_equal(packed.rotary_pos_emb, native.rotary_pos_emb)
+    np.testing.assert_array_equal(packed.cu_image_seqlens, np.array([8], dtype=np.int32))
+
+
+def test_qwen_metadata_builder_stack_metadata_pads_multi_image_and_dummy_rank():
+    vision_config = SimpleNamespace(
+        patch_size=14,
+        window_size=112,
+        spatial_merge_size=2,
+        num_heads=16,
+        hidden_size=1280,
+        rope_theta=10000.0,
+    )
+    builder = Qwen25VLVisionMetadataBuilder(
+        SimpleNamespace(hf_config=SimpleNamespace(vision_config=vision_config))
+    )
+    items = _build_image_items(
+        np.arange(24, dtype=np.float32).reshape(24, 1),
+        [(1, 2, 4), (1, 4, 4)],
+        [(0, 1), (2, 5)],
+    )
+    meta = builder.get_metadata(items)
+
+    stacked = builder.stack_metadata([meta, None], patch_k=24)
+
+    assert stacked.window_index.shape == (2, 6)
+    assert stacked.cu_window_seqlens.shape == (2, 2)
+    assert stacked.rotary_pos_emb.shape == (2, 24, 40)
+    assert stacked.cu_image_seqlens.shape == (2, 2)
+    np.testing.assert_array_equal(stacked.cu_image_seqlens[0], np.array([8, 24], dtype=np.int32))
+    np.testing.assert_array_equal(stacked.cu_image_seqlens[1], np.array([24, 24], dtype=np.int32))
+    np.testing.assert_array_equal(stacked.window_index[1], np.arange(6, dtype=np.int32))
+
+
+def test_qwen_metadata_builder_stack_metadata_fails_fast_on_all_dummy_lanes():
+    vision_config = SimpleNamespace(
+        patch_size=14,
+        window_size=112,
+        spatial_merge_size=2,
+        num_heads=16,
+        hidden_size=1280,
+        rope_theta=10000.0,
+    )
+    builder = Qwen25VLVisionMetadataBuilder(
+        SimpleNamespace(hf_config=SimpleNamespace(vision_config=vision_config))
+    )
+
+    with pytest.raises(ValueError, match="at least one real"):
+        builder.stack_metadata([None, None], patch_k=0)
+
+
+def test_qwen_metadata_builder_stack_metadata_checks_patch_bucket_divisibility():
+    vision_config = SimpleNamespace(
+        patch_size=14,
+        window_size=112,
+        spatial_merge_size=2,
+        num_heads=16,
+        hidden_size=1280,
+        rope_theta=10000.0,
+    )
+    builder = Qwen25VLVisionMetadataBuilder(
+        SimpleNamespace(hf_config=SimpleNamespace(vision_config=vision_config))
+    )
+    item = _build_image_items(
+        np.arange(8, dtype=np.float32).reshape(8, 1),
+        [(1, 2, 4)],
+        [(0, 1)],
+    )[0]
+    meta = builder._get_image_metadata(item)
+
+    with pytest.raises(ValueError, match="divisible"):
+        builder.stack_metadata([meta], patch_k=10)
+
+
+def test_collect_image_requests_preserves_owner_rank_request_base():
+    feature = np.arange(8, dtype=np.float32).reshape(8, 1)
+    rank0_req0 = SimpleNamespace(
+        mm_inputs=MultimodalInputs(
+            mm_items=[
+                MultimodalDataItem(
+                    modality=Modality.AUDIO,
+                    feature=np.ones((1, 1), dtype=np.float32),
+                )
+            ]
+        ),
+        extend_input_len=3,
+    )
+    rank0_req1 = SimpleNamespace(
+        mm_inputs=MultimodalInputs(
+            mm_items=_build_image_items(
+                feature,
+                [(1, 2, 4)],
+                [(1, 2)],
+            )
+        ),
+        extend_input_len=4,
+    )
+    rank1_req0 = SimpleNamespace(
+        mm_inputs=MultimodalInputs(
+            mm_items=_build_image_items(
+                feature,
+                [(1, 2, 4)],
+                [(0, 1)],
+            )
+        ),
+        extend_input_len=2,
+    )
+
+    per_rank_units = _collect_image_requests(
+        [ScheduleReqsInfo(reqs=[rank0_req0, rank0_req1]), ScheduleReqsInfo(reqs=[rank1_req0])],
+        dp_size=2,
+    )
+
+    assert len(per_rank_units) == 2
+    assert len(per_rank_units[0]) == 1
+    assert per_rank_units[0][0].req_base == 3
+    assert len(per_rank_units[0][0].images) == 1
+    assert per_rank_units[0][0].images[0].is_image()
+    assert len(per_rank_units[1]) == 1
+    assert per_rank_units[1][0].req_base == 0
+
+
+def test_build_embed_round_derives_pixels_metadata_and_merge_idx_from_one_unit_order():
+    vision_config = SimpleNamespace(
+        patch_size=14,
+        window_size=112,
+        spatial_merge_size=2,
+        fullatt_block_indexes=[],
+        num_heads=16,
+        hidden_size=1280,
+        rope_theta=10000.0,
+    )
+    builder = Qwen25VLVisionMetadataBuilder(
+        SimpleNamespace(hf_config=SimpleNamespace(vision_config=vision_config))
+    )
+    items = _build_image_items(
+        np.arange(24, dtype=np.float32).reshape(24, 1),
+        [(1, 2, 4), (1, 4, 4)],
+        [(2, 3), (5, 8)],
+    )
+
+    rnd = _build_embed_round(
+        [SimpleNamespace(images=items, req_base=0)],
+        builder=builder,
+        dp_size=1,
+        per_dp_token=10,
+    )
+
+    np.testing.assert_array_equal(rnd.encode_inputs.valid, np.array([24], dtype=np.int32))
+    np.testing.assert_array_equal(rnd.encode_inputs.pixels[0, :, 0], np.arange(24))
+    np.testing.assert_array_equal(
+        rnd.encode_inputs.meta.cu_image_seqlens,
+        np.array([[8, 24]], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(np.flatnonzero(rnd.mask), np.array([2, 3, 5, 6, 7, 8]))
+    np.testing.assert_array_equal(rnd.src_idx[[2, 3, 5, 6, 7, 8]], np.arange(6))
+
+
+def test_build_embed_round_keeps_merge_row_contiguous_across_multi_placeholder_images():
+    vision_config = SimpleNamespace(
+        patch_size=14,
+        window_size=112,
+        spatial_merge_size=2,
+        fullatt_block_indexes=[],
+        num_heads=16,
+        hidden_size=1280,
+        rope_theta=10000.0,
+    )
+    builder = Qwen25VLVisionMetadataBuilder(
+        SimpleNamespace(hf_config=SimpleNamespace(vision_config=vision_config))
+    )
+    items = _build_image_items(
+        np.arange(32, dtype=np.float32).reshape(32, 1),
+        [(1, 2, 4), (1, 4, 6)],
+        [(0, 1), (4, 9)],
+    )
+
+    rnd = _build_embed_round(
+        [SimpleNamespace(images=items, req_base=0)],
+        builder=builder,
+        dp_size=1,
+        per_dp_token=12,
+    )
+
+    np.testing.assert_array_equal(rnd.src_idx[[0, 1]], np.array([0, 1], dtype=np.int32))
+    assert rnd.src_idx[4] == 2
+    np.testing.assert_array_equal(rnd.src_idx[[4, 5, 6, 7, 8, 9]], np.arange(2, 8))
+
+
+def test_build_embed_round_fails_fast_on_placeholder_token_out_of_rank_slot():
+    vision_config = SimpleNamespace(
+        patch_size=14,
+        window_size=112,
+        spatial_merge_size=1,
+        fullatt_block_indexes=[],
+        num_heads=16,
+        hidden_size=1280,
+        rope_theta=10000.0,
+    )
+    builder = Qwen25VLVisionMetadataBuilder(
+        SimpleNamespace(hf_config=SimpleNamespace(vision_config=vision_config))
+    )
+    item = MultimodalDataItem(
+        modality=Modality.IMAGE,
+        feature=np.ones((3, 1), dtype=np.float32),
+        offsets=[(0, 2)],
+        model_specific_data={"image_grid_thw": np.array([[1, 1, 3]], dtype=np.int32)},
+    )
+
+    with pytest.raises(ValueError, match="outside its packed rank slot"):
+        _build_embed_round(
+            [SimpleNamespace(images=[item], req_base=2)],
+            builder=builder,
+            dp_size=1,
+            per_dp_token=4,
+        )
+
+
 def test_mm_embed_plan_keeps_placeholder_count_separate_from_encode_rows():
     features = np.arange(24, dtype=np.float32).reshape(24, 1)
     grids = [(1, 2, 4), (1, 4, 4)]
     offsets = [(2, 3), (5, 8)]
-    items = QwenVLProcessor._build_items(features, grids, offsets)
+    items = _build_image_items(features, grids, offsets)
     req = SimpleNamespace(
         mm_inputs=MultimodalInputs(mm_items=items),
         extend_input_len=10,
@@ -655,16 +1104,179 @@ def test_mm_embed_plan_keeps_placeholder_count_separate_from_encode_rows():
     )
 
     rounds = plan.rounds_by_modality[items[0].modality]
+    assert len(rounds) == 1
+
+    np.testing.assert_array_equal(rounds[0].encode_inputs.valid, np.array([24], dtype=np.int32))
+
+    np.testing.assert_array_equal(np.flatnonzero(rounds[0].mask), np.array([2, 3, 5, 6, 7, 8]))
+    np.testing.assert_array_equal(rounds[0].src_idx[[2, 3, 5, 6, 7, 8]], np.arange(6))
+
+
+def test_mm_embed_plan_fails_fast_on_overlapping_placeholder_offsets():
+    features = np.arange(3, dtype=np.float32).reshape(3, 1)
+    item = MultimodalDataItem(
+        modality=Modality.IMAGE,
+        feature=features,
+        offsets=[(0, 1), (1, 1)],
+        model_specific_data={"image_grid_thw": np.array([[1, 1, 3]], dtype=np.int32)},
+    )
+    req = SimpleNamespace(
+        mm_inputs=MultimodalInputs(mm_items=[item]),
+        extend_input_len=3,
+    )
+    vision_config = SimpleNamespace(
+        patch_size=14,
+        window_size=112,
+        spatial_merge_size=1,
+        fullatt_block_indexes=[],
+        num_heads=16,
+        hidden_size=1280,
+        rope_theta=10000.0,
+    )
+    model_config = SimpleNamespace(
+        is_multimodal=True,
+        hf_config=SimpleNamespace(
+            architectures=["Qwen2_5_VLForConditionalGeneration"],
+            vision_config=vision_config,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="assigned more than once"):
+        build_mm_embed_plan(
+            reqs_info=[ScheduleReqsInfo(reqs=[req])],
+            dp_size=1,
+            model_config=model_config,
+            per_dp_token=3,
+        )
+
+
+def test_mm_embed_plan_packs_per_request_with_dp_dummy_lane():
+    vision_config = SimpleNamespace(
+        patch_size=14,
+        window_size=112,
+        spatial_merge_size=2,
+        fullatt_block_indexes=[],
+        num_heads=16,
+        hidden_size=1280,
+        rope_theta=10000.0,
+    )
+    model_config = SimpleNamespace(
+        is_multimodal=True,
+        hf_config=SimpleNamespace(
+            architectures=["Qwen2_5_VLForConditionalGeneration"],
+            vision_config=vision_config,
+        ),
+    )
+    rank0_req0 = SimpleNamespace(
+        mm_inputs=MultimodalInputs(
+            mm_items=_build_image_items(
+                np.arange(8, dtype=np.float32).reshape(8, 1),
+                [(1, 2, 4)],
+                [(1, 2)],
+            )
+        ),
+        extend_input_len=4,
+    )
+    rank0_req1 = SimpleNamespace(
+        mm_inputs=MultimodalInputs(
+            mm_items=_build_image_items(
+                np.arange(16, dtype=np.float32).reshape(16, 1),
+                [(1, 4, 4)],
+                [(0, 3)],
+            )
+        ),
+        extend_input_len=5,
+    )
+    rank1_req0 = SimpleNamespace(
+        mm_inputs=MultimodalInputs(
+            mm_items=_build_image_items(
+                np.arange(8, dtype=np.float32).reshape(8, 1),
+                [(1, 2, 4)],
+                [(2, 3)],
+            )
+        ),
+        extend_input_len=4,
+    )
+
+    plan = build_mm_embed_plan(
+        reqs_info=[
+            ScheduleReqsInfo(reqs=[rank0_req0, rank0_req1]),
+            ScheduleReqsInfo(reqs=[rank1_req0]),
+        ],
+        dp_size=2,
+        model_config=model_config,
+        per_dp_token=10,
+    )
+
+    rounds = plan.rounds_by_modality[Modality.IMAGE]
     assert len(rounds) == 2
+    np.testing.assert_array_equal(rounds[0].encode_inputs.valid, np.array([8, 8], dtype=np.int32))
+    np.testing.assert_array_equal(rounds[1].encode_inputs.valid, np.array([16, 0], dtype=np.int32))
+    np.testing.assert_array_equal(np.flatnonzero(rounds[0].mask), np.array([1, 2, 12, 13]))
+    np.testing.assert_array_equal(np.flatnonzero(rounds[1].mask), np.array([4, 5, 6, 7]))
+    np.testing.assert_array_equal(
+        rounds[1].encode_inputs.meta.cu_image_seqlens,
+        np.array([[16], [16]], dtype=np.int32),
+    )
 
-    np.testing.assert_array_equal(rounds[0].encode_inputs.valid, np.array([8], dtype=np.int32))
-    np.testing.assert_array_equal(rounds[1].encode_inputs.valid, np.array([16], dtype=np.int32))
 
-    np.testing.assert_array_equal(np.flatnonzero(rounds[0].mask), np.array([2, 3]))
-    np.testing.assert_array_equal(rounds[0].src_idx[2:4], np.array([0, 1], dtype=np.int32))
+def test_mm_embed_plan_pads_dp_ranks_with_uneven_multi_image_requests():
+    vision_config = SimpleNamespace(
+        patch_size=14,
+        window_size=112,
+        spatial_merge_size=2,
+        fullatt_block_indexes=[],
+        num_heads=16,
+        hidden_size=1280,
+        rope_theta=10000.0,
+    )
+    model_config = SimpleNamespace(
+        is_multimodal=True,
+        hf_config=SimpleNamespace(
+            architectures=["Qwen2_5_VLForConditionalGeneration"],
+            vision_config=vision_config,
+        ),
+    )
+    rank0_items = _build_image_items(
+        np.arange(24, dtype=np.float32).reshape(24, 1),
+        [(1, 2, 4), (1, 4, 4)],
+        [(0, 1), (3, 6)],
+    )
+    rank1_items = _build_image_items(
+        np.arange(32, dtype=np.float32).reshape(32, 1),
+        [(1, 2, 4), (1, 2, 4), (1, 4, 4)],
+        [(1, 2), (4, 5), (7, 10)],
+    )
+    rank0_req = SimpleNamespace(
+        mm_inputs=MultimodalInputs(mm_items=rank0_items),
+        extend_input_len=8,
+    )
+    rank1_req = SimpleNamespace(
+        mm_inputs=MultimodalInputs(mm_items=rank1_items),
+        extend_input_len=12,
+    )
 
-    np.testing.assert_array_equal(np.flatnonzero(rounds[1].mask), np.array([5, 6, 7, 8]))
-    np.testing.assert_array_equal(rounds[1].src_idx[5:9], np.array([0, 1, 2, 3], dtype=np.int32))
+    plan = build_mm_embed_plan(
+        reqs_info=[ScheduleReqsInfo(reqs=[rank0_req]), ScheduleReqsInfo(reqs=[rank1_req])],
+        dp_size=2,
+        model_config=model_config,
+        per_dp_token=12,
+    )
+
+    rounds = plan.rounds_by_modality[Modality.IMAGE]
+    assert len(rounds) == 1
+    rnd = rounds[0]
+    np.testing.assert_array_equal(rnd.encode_inputs.valid, np.array([24, 32], dtype=np.int32))
+    assert rnd.encode_inputs.pixels.shape == (2, 32, 1)
+    np.testing.assert_array_equal(
+        rnd.encode_inputs.meta.cu_image_seqlens,
+        np.array([[8, 24, 32], [8, 16, 32]], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        np.flatnonzero(rnd.mask), np.array([0, 1, 3, 4, 5, 6, 13, 14, 16, 17, 19, 20, 21, 22])
+    )
+    np.testing.assert_array_equal(rnd.src_idx[[0, 1, 3, 4, 5, 6]], np.arange(6))
+    np.testing.assert_array_equal(rnd.src_idx[[13, 14, 16, 17, 19, 20, 21, 22]], np.arange(8))
 
 
 def test_qwen_metadata_builder_checks_feature_rows_match_grid():
@@ -687,7 +1299,7 @@ def test_qwen_metadata_builder_checks_feature_rows_match_grid():
     )
 
     with pytest.raises(ValueError, match="feature rows"):
-        builder.get_metadata(item)
+        builder._get_image_metadata(item)
 
 
 def test_qwen_metadata_builder_checks_placeholder_rows_match_grid():
@@ -710,10 +1322,10 @@ def test_qwen_metadata_builder_checks_placeholder_rows_match_grid():
     )
 
     with pytest.raises(ValueError, match="placeholder rows"):
-        builder.get_metadata(item)
+        builder._get_image_metadata(item)
 
 
-def test_mm_embed_plan_normalizes_dict_mm_items():
+def test_mm_embed_plan_rejects_dict_mm_inputs():
     feature = np.arange(8, dtype=np.float32).reshape(8, 1)
     req = SimpleNamespace(
         mm_inputs={
@@ -745,17 +1357,13 @@ def test_mm_embed_plan_normalizes_dict_mm_items():
         ),
     )
 
-    plan = build_mm_embed_plan(
-        reqs_info=[ScheduleReqsInfo(reqs=[req])],
-        dp_size=1,
-        model_config=model_config,
-        per_dp_token=2,
-    )
-
-    rounds = plan.rounds_by_modality[Modality.IMAGE]
-    assert len(rounds) == 1
-    np.testing.assert_array_equal(rounds[0].encode_inputs.valid, np.array([8], dtype=np.int32))
-    np.testing.assert_array_equal(np.flatnonzero(rounds[0].mask), np.array([0, 1]))
+    with pytest.raises(TypeError, match="MultimodalInputs"):
+        build_mm_embed_plan(
+            reqs_info=[ScheduleReqsInfo(reqs=[req])],
+            dp_size=1,
+            model_config=model_config,
+            per_dp_token=2,
+        )
 
 
 def test_mm_embed_plan_returns_none_before_resolving_builder_without_images():
@@ -790,7 +1398,7 @@ def test_mm_embed_plan_returns_none_before_resolving_builder_without_images():
 
 def test_mm_embed_plan_fails_fast_when_qwen_vision_config_missing():
     features = np.arange(8, dtype=np.float32).reshape(8, 1)
-    items = QwenVLProcessor._build_items(features, [(1, 2, 4)], [(0, 1)])
+    items = _build_image_items(features, [(1, 2, 4)], [(0, 1)])
     req = SimpleNamespace(
         mm_inputs=MultimodalInputs(mm_items=items),
         extend_input_len=2,


### PR DESCRIPTION
## Summary

This PR changes Qwen2.5-VL vision encode scheduling from per-image rounds to per-request rounds.

For a single request with multiple images, the scheduler now packs all vision patch rows for that request into one ViT encode round on the owning DP rank, then merges the encoded rows back into the request's placeholder positions. This reduces multi-image requests from N vision encode calls to 1 while preserving the existing owning-rank DP merge path.

## Implementation Details

- `ScheduleBatch.get_model_worker_batch` keeps the existing multimodal merge fields (`input_embedding`, mRoPE positions, deepstack inputs) and only builds an embed plan for normal prefill batches with multimodal inputs.
- `mm_utils.build_mm_embed_plan` collects request-level encode units per DP rank. Each unit owns all Qwen vision items for one request, along with the request's rank-local token base.
- Each embed round derives patch concat order, request-level metadata, `src_idx`, and `mask` from the same `unit.images` traversal. This is the core invariant: the encoded feature row order must match the placeholder scatter order.
- Qwen2.5-VL metadata is packed at request granularity. Windowed ViT blocks continue to use `cu_window_seqlens`; full-attention blocks use `cu_image_seqlens` so packed images remain attention-isolated.
- `_device_put_embed_plan` keeps embed-plan leaves data-leading for DP execution. Forward then loops over embed rounds, runs `get_image_feature`, applies `merge_jit`, and passes the fused embedding into the existing Qwen2 backbone path.
- `merge_jit`, `embed_mm_inputs`, and the language backbone JIT remain structurally unchanged.

## End-to-End Flow

```mermaid
flowchart TD
    A["ScheduleBatch.get_model_worker_batch"] --> B["_merge_multimodal<br/>input_embedding / mRoPE / deepstack"]
    A --> C{"contains_mm_inputs<br/>and ForwardMode.EXTEND"}
    C -- no --> Z["mm_embed_plan = None"]
    C -- yes --> D["mm_utils.build_mm_embed_plan<br/>reqs_info, dp_size, model_config, per_dp_token"]

    D --> E["Collect request-level encode units per DP rank<br/>ReqEncodeUnit(images, req_base)"]
    E --> F["n_rounds = max request units across ranks<br/>missing ranks use dummy lanes"]
    F --> G["_build_embed_round"]

    G --> H["Single traversal of unit.images"]
    H --> H1["concat patch rows<br/>pixels"]
    H --> H2["builder.get_metadata(images)<br/>request-level Qwen metadata"]
    H --> H3["item.offsets -> src_idx / mask<br/>merge_row increments across images"]

    H1 --> I["pad and stack pixels<br/>[dp, patch_k, dim]"]
    H2 --> J["builder.stack_metadata<br/>request metadata padded by patch_k"]
    H3 --> K["data-leading src_idx / mask"]
    I --> L["MultimodalEmbedPlan<br/>IMAGE: EmbedRound[]"]
    J --> L
    K --> L

    L --> M["ForwardBatch.init_new<br/>_device_put_embed_plan"]
    M --> N["model_runner.forward"]
    N --> O["general_mm_embed_routine<br/>embed_mm_inputs loop"]
    O --> P["Qwen2.5-VL get_image_feature<br/>encode_jit"]
    P --> Q["ViT attention<br/>windowed: cu_window_seqlens<br/>full-attention: cu_image_seqlens"]
    Q --> R["merge_jit<br/>scatter encoded rows into placeholders"]
    R --> S["Qwen2 backbone JIT<br/>consumes fused input embedding"]
```

## Validation

Validated feature branch: `feat/qwen25vl-per-request-encode@db64b6b7`  
Baseline: `epic/vlm@3e0b4a54`

### CPU Unit Tests

`test_vlm_stage1_framework.py`: `33 passed, 2 skipped`.

This suite directly tests the local plan/metadata/merge invariants:

- request-level metadata packing for multi-image inputs
- single-image degeneration to the old behavior
- block-diagonal attention semantics on a small CPU ViT
- per-request embed plan construction
- placeholder row count vs encoded feature row count checks
- DP dummy lane padding
- uneven multi-image requests across DP ranks
- encode/merge sharding paths

### TPU Functional Tests

All TPU validation phases passed.

| Area | What was tested | Result |
| --- | --- | --- |
| Single-image E2E regression | Sent the existing Qwen-VL request matrix through the server: text-only, real image QA, OCR, counting, chart understanding, multi-image prompts, and interleaved text/image prompts. This checks that the per-request encode change does not regress existing single-image and mixed multimodal behavior. | 9/9 passed. |
| Multi-image E2E routing | Sent concurrent real-image requests where each request contains two images and expects an answer tied to its own images. This detects cross-request contamination and cross-image routing mistakes after packing. | N=16, CONC=8, `correct_routed=16/16`. |
| Multi-image ViT parity vs HF | Compared packed sglang-jax ViT output against HF Qwen2.5-VL multi-image ViT output on the same multi-image input. Outputs were split back per image and compared numerically. | gcos small/mid/large = `0.99993 / 0.99954 / 0.99986`. |
| Cross-image leakage | Re-encoded the same target image while changing or clearing neighboring images in the same packed request. If full-attention boundaries leaked across images, the target image output would change. | Target image output unchanged, `max_abs=0`. |
| Multi-image logprobs parity | Sent 2-image and 3-image requests with `return_logprob`, then compared tokenization alignment, image placeholder counts, greedy first token, argmax agreement, and input-token logprobs against sglang/HF references. | Text input ids matched 22/22; image pad counts matched 256/688; first greedy token matched across sglang-jax / sglang / HF; sglang-jax vs HF itlp Pearson `0.99983`. |
| DP1 concurrent serving | Ran concurrent mixed single-image and multi-image requests on dp1. This checks batching, per-request packing, and merge routing under concurrent load. | conc 24/24; real-image concurrent routing `correct_routed=32/32`. |
| DP2 concurrent serving | Ran the same concurrent mixed workload on dp2. This checks owning-rank assignment, dummy lanes, per-DP request grouping, and merge isolation across DP ranks. | conc 24/24; real-image concurrent routing `correct_routed=32/32`; per-DP distribution `[4,4]/[4,3]`. |
| High-concurrency soak | Ran a larger concurrent multi-image workload to check stability under longer packed ViT sequences and repeated batching. This targets OOM, request retraction, and server crashes. | N=64, CONC=32, `correct_routed=64/64`; no OOM/retract/crash; server stayed alive; 5.45 req/s. |
| Multi-host tp16×dp4 | Ran multi-image smoke and concurrent real-image routing on 4-host TPU with tp16×dp4. This checks the same packing/merge behavior across host boundaries and DP replicas. | real_conc 32/16, `correct_routed=32/32`; per-DP distribution `[2,2,2,2]/[5,4,3,3]`; no OOM/crash. |
| Performance A/B | Compared `epic/vlm` per-image encode vs this PR's per-request encode on N=1/2/3 image requests. Checked ViT call count, latency, and memory. | ViT calls confirmed N→1. Small-N E2E latency was noise-level comparable: baseline `33 / 71 / 166 ms`, feature `33 / 74 / 165 ms`; no single-image or memory regression. |

## Performance Notes

The structural optimization is confirmed: a multi-image request now performs one ViT encode instead of one encode per image.

In the measured N=1/2/3 setup, E2E latency is roughly flat versus `epic/vlm` because LLM prefill dominates this configuration. The main expected win is reduced vision scheduling/encode overhead for larger multi-image or higher-concurrency workloads.
