### PR TITLE
Update v7x cookbook benchmark guidance

### DIFF
--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-R1.md
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-R1.md
@@ -4,7 +4,7 @@ title: "DeepSeek R1"
 
 # DeepSeek R1 on SGL-JAX
 
-> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, reasoning_content streams correctly, GSM8K accuracy 98.0% (50 examples, thinking-on). §4.2 includes a v7x-16 launch and `bench_serving` template; throughput numbers are intentionally omitted until the recipe has a release-quality performance datapoint.
+> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, reasoning_content streams correctly, GSM8K accuracy 98.0% (50 examples, thinking-on). §4.2 includes a v7x-16 launch and `bench_serving` template.
 
 ## 1. Model Introduction
 
@@ -218,7 +218,7 @@ evalscope eval \
 
 ### 4.2 Speed
 
-> **v7x-16 benchmark template.** This recipe provides the launch and benchmark command shape, but does not publish a throughput result yet. That keeps the page useful as a working deployment recipe without turning a still-tunable datapoint into a release headline.
+> **v7x-16 benchmark template.** Fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests.
 
 **Test Environment**
 
@@ -247,7 +247,6 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
   --page-size 128 \
   --max-running-requests 128 \
   --attention-backend fa \
-  --disable-radix-cache \
   --dp-schedule-policy round_robin \
   --skip-server-warmup \
   --nnodes 4 --node-rank ${NODE_RANK} \
@@ -272,10 +271,6 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
   --seed 42 \
   --warmup-requests 0
 ```
-
-**Published Results**
-
-Throughput numbers are intentionally omitted from this recipe for now. Use the command above to validate local deployments; publish a result row only after the configuration is tuned enough to be representative of the release target.
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-R1.md
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-R1.md
@@ -4,7 +4,7 @@ title: "DeepSeek R1"
 
 # DeepSeek R1 on SGL-JAX
 
-> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, reasoning_content streams correctly, GSM8K accuracy 98.0% (50 examples, thinking-on), `bench_serving` numbers in §4.2.
+> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, reasoning_content streams correctly, GSM8K accuracy 98.0% (50 examples, thinking-on). §4.2 includes a v7x-16 launch and `bench_serving` template; throughput numbers are intentionally omitted until the recipe has a release-quality performance datapoint.
 
 ## 1. Model Introduction
 
@@ -27,6 +27,7 @@ title: "DeepSeek R1"
 
 | TPU | Topology | Nodes | Chips / JAX devices | `--tp-size` | `--dp-size` | Tensor axis | `--ep-size` | Notes |
 |---|---|---|---|---|---|---|---|---|
+| **v7x-16** | 2x2x4 | 4 | 16 chips / 32 devices | 32 | 4 | 8 | 32 | Launch and benchmark template in §4.2. v7x exposes 2 JAX devices/chip; keep tensor axis 8 for the FP8 block-quant and MLA layout. |
 | **v6e-64** | 8x8 | 16 | 64 | 64 | 8 | 8 | 64 | This is the slice we measured on. `dp=8` required for FP8 shared-expert block-quant compatibility (`2048/8=256 > 128 = block_size`); `dp=4` silently collapses. Dense MLP block-quant scale grid `(144, 56)` further requires `144 % tensor == 0`, so tensor=8 is the only working option. HBM is tight at `dp=8`; see §2.4 Memory Management. |
 
 See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
@@ -217,11 +218,44 @@ evalscope eval \
 
 ### 4.2 Speed
 
-> **Layout F — single-workload sweep (one data point).** Standard chat (ISL=1000, OSL=1000, `max_concurrency=16`, 80 prompts, `seed=42`). Future PRs can add reasoning-typical workloads (e.g., OSL=4096) and concurrency sweeps.
+> **v7x-16 benchmark template.** This recipe provides the launch and benchmark command shape, but does not publish a throughput result yet. That keeps the page useful as a working deployment recipe without turning a still-tunable datapoint into a release headline.
 
-**Test Environment** — same hardware/build as §4.1.
+**Test Environment**
 
-**Workload** — `bench_serving` with `--dataset-name random --random-input-len 1000 --random-output-len 1000 --num-prompts 80 --max-concurrency 16 --seed 42`.
+| Field | Value |
+|---|---|
+| Hardware | TPU v7x-16 (4 nodes x 4 chips, 32 JAX devices) |
+| Model | deepseek-ai/DeepSeek-R1 (real FP8 weights; runtime dtype bfloat16) |
+| Tensor Parallelism | 32 (tensor axis 8 via `--dp-size 4`) |
+| Data Parallelism | 4 |
+| Expert Parallelism | 32 |
+| Tested build | origin/main (`2d97c787f712f715784216f7c414a4f477ea8218`) |
+
+**Serving Flags Used**
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
+  --model-path /models/DeepSeek-R1 \
+  --trust-remote-code \
+  --reasoning-parser deepseek-r1 \
+  --tp-size 32 --dp-size 4 --ep-size 32 \
+  --moe-backend epmoe \
+  --dtype bfloat16 \
+  --context-length 32768 \
+  --chunked-prefill-size 1024 \
+  --mem-fraction-static 0.88 \
+  --page-size 128 \
+  --max-running-requests 128 \
+  --attention-backend fa \
+  --disable-radix-cache \
+  --dp-schedule-policy round_robin \
+  --skip-server-warmup \
+  --nnodes 4 --node-rank ${NODE_RANK} \
+  --dist-init-addr ${MASTER_ADDR} \
+  --host 0.0.0.0 --port 30000
+```
+
+**Workload** — `bench_serving` with `--dataset-name random --random-input-len 1024 --random-output-len 1024 --num-prompts 384 --max-concurrency 128 --random-range-ratio 1 --seed 42 --warmup-requests 0`.
 
 **Benchmark Command**
 
@@ -232,52 +266,16 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
   --tokenizer /models/DeepSeek-R1 \
   --host 127.0.0.1 --port 30000 \
   --dataset-name random \
-  --random-input-len 1000 --random-output-len 1000 \
-  --num-prompts 80 --max-concurrency 16 \
-  --seed 42
+  --random-input-len 1024 --random-output-len 1024 \
+  --num-prompts 384 --max-concurrency 128 \
+  --random-range-ratio 1 \
+  --seed 42 \
+  --warmup-requests 0
 ```
 
-**Test Results**
+**Published Results**
 
-```text
-============ Serving Benchmark Result ============
-Backend:                                 sgl-jax
-Traffic request rate:                    inf
-Max request concurrency:                 16
-Successful requests:                     80
-Benchmark duration (s):                  154.53
-Total input tokens:                      37205
-Total generated tokens:                  38314
-Request throughput (req/s):              0.52
-Input token throughput (tok/s):          240.76
-Output token throughput (tok/s):         247.94
-Peak output token throughput (tok/s):    464.00
-Peak concurrent requests:                18
-Total token throughput (tok/s):          488.70
-Concurrency:                             13.94
-----------------End-to-End Latency----------------
-Mean E2E Latency (ms):                   26926.31
-Median E2E Latency (ms):                 26597.51
-P90 E2E Latency (ms):                    49470.68
-P99 E2E Latency (ms):                    57541.02
----------------Time to First Token----------------
-Mean TTFT (ms):                          1145.82
-Median TTFT (ms):                        1292.52
-P99 TTFT (ms):                           2607.65
------Time per Output Token (excl. 1st token)------
-Mean TPOT (ms):                          56.05
-Median TPOT (ms):                        54.35
-P99 TPOT (ms):                           102.02
----------------Inter-Token Latency----------------
-Mean ITL (ms):                           53.94
-Median ITL (ms):                         34.51
-P95 ITL (ms):                            37.43
-P99 ITL (ms):                            1256.92
-Max ITL (ms):                            2518.61
-==================================================
-```
-
-> R1's throughput on this workload reflects MoE + MLA + FP8 block-quant on the validated `dp=8` mesh; future PRs can add reasoning-typical workloads (OSL=4096+) for trace-heavy scenarios.
+Throughput numbers are intentionally omitted from this recipe for now. Use the command above to validate local deployments; publish a result row only after the configuration is tuned enough to be representative of the release target.
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.md
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.md
@@ -4,7 +4,7 @@ title: "DeepSeek V3"
 
 # DeepSeek V3 on SGL-JAX
 
-> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, greedy output correct, GSM8K accuracy 97.5% (200 examples). §4.2 includes a v7x-16 launch and `bench_serving` template; throughput numbers are intentionally omitted until the recipe has a release-quality performance datapoint.
+> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, greedy output correct, GSM8K accuracy 97.5% (200 examples). §4.2 includes a v7x-16 launch and `bench_serving` template.
 
 ## 1. Model Introduction
 
@@ -159,7 +159,7 @@ Recommended additional datasets to PR back: MMLU, GPQA Diamond, HumanEval, LiveC
 
 ### 4.2 Speed
 
-> **v7x-16 benchmark template.** This recipe provides the launch and benchmark command shape, but does not publish a throughput result yet. That keeps the page useful as a working deployment recipe without turning a still-tunable datapoint into a release headline.
+> **v7x-16 benchmark template.** Fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests.
 
 **Test Environment**
 
@@ -187,7 +187,6 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
   --page-size 128 \
   --max-running-requests 128 \
   --attention-backend fa \
-  --disable-radix-cache \
   --dp-schedule-policy round_robin \
   --skip-server-warmup \
   --nnodes 4 --node-rank ${NODE_RANK} \
@@ -212,10 +211,6 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
   --seed 42 \
   --warmup-requests 0
 ```
-
-**Published Results**
-
-Throughput numbers are intentionally omitted from this recipe for now. Use the command above to validate local deployments; publish a result row only after the configuration is tuned enough to be representative of the release target.
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.md
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.md
@@ -4,7 +4,7 @@ title: "DeepSeek V3"
 
 # DeepSeek V3 on SGL-JAX
 
-> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, greedy output correct, GSM8K accuracy 97.5% (200 examples), `bench_serving` numbers in §4.2.
+> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, greedy output correct, GSM8K accuracy 97.5% (200 examples). §4.2 includes a v7x-16 launch and `bench_serving` template; throughput numbers are intentionally omitted until the recipe has a release-quality performance datapoint.
 
 ## 1. Model Introduction
 
@@ -27,6 +27,7 @@ title: "DeepSeek V3"
 
 | TPU | Topology | Nodes | Chips / JAX devices | `--tp-size` | `--dp-size` | Tensor axis | `--ep-size` | Notes |
 |---|---|---|---|---|---|---|---|---|
+| **v7x-16** | 2x2x4 | 4 | 16 chips / 32 devices | 32 | 4 | 8 | 32 | Launch and benchmark template in §4.2. v7x exposes 2 JAX devices/chip; keep tensor axis 8 for the FP8 block-quant and MLA layout. |
 | **v6e-64** | 8x8 | 16 | 64 | 64 | 8 | 8 | 64 | This is the slice we measured on. `dp=8` is required for FP8 shared-expert block-quant compatibility (`2048/8=256 > 128 = block_size`); `dp=4` silently collapses. HBM is tight at `dp=8`; see §2.4 Memory Management. |
 
 See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
@@ -158,11 +159,43 @@ Recommended additional datasets to PR back: MMLU, GPQA Diamond, HumanEval, LiveC
 
 ### 4.2 Speed
 
-> **Layout F — single-workload sweep (one data point).** Standard chat (ISL=1000, OSL=1000), `max_concurrency=16`, 80 prompts, `seed=42`. Future PRs can add Low / High concurrency rows or sweep MoE backend / chunked-prefill-size.
+> **v7x-16 benchmark template.** This recipe provides the launch and benchmark command shape, but does not publish a throughput result yet. That keeps the page useful as a working deployment recipe without turning a still-tunable datapoint into a release headline.
 
-**Test Environment** — same hardware/build as §4.1.
+**Test Environment**
 
-**Workload** — `bench_serving` with `--dataset-name random --random-input-len 1000 --random-output-len 1000 --num-prompts 80 --max-concurrency 16 --seed 42`.
+| Field | Value |
+|---|---|
+| Hardware | TPU v7x-16 (4 nodes x 4 chips, 32 JAX devices) |
+| Model | deepseek-ai/DeepSeek-V3 (real FP8 weights; runtime dtype bfloat16) |
+| Tensor Parallelism | 32 (tensor axis 8 via `--dp-size 4`) |
+| Data Parallelism | 4 |
+| Expert Parallelism | 32 |
+| Tested build | origin/main (`2d97c787f712f715784216f7c414a4f477ea8218`) |
+
+**Serving Flags Used**
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
+  --model-path /models/DeepSeek-V3 \
+  --trust-remote-code \
+  --tp-size 32 --dp-size 4 --ep-size 32 \
+  --moe-backend epmoe \
+  --dtype bfloat16 \
+  --context-length 32768 \
+  --chunked-prefill-size 1024 \
+  --mem-fraction-static 0.88 \
+  --page-size 128 \
+  --max-running-requests 128 \
+  --attention-backend fa \
+  --disable-radix-cache \
+  --dp-schedule-policy round_robin \
+  --skip-server-warmup \
+  --nnodes 4 --node-rank ${NODE_RANK} \
+  --dist-init-addr ${MASTER_ADDR} \
+  --host 0.0.0.0 --port 30000
+```
+
+**Workload** — `bench_serving` with `--dataset-name random --random-input-len 1024 --random-output-len 1024 --num-prompts 384 --max-concurrency 128 --random-range-ratio 1 --seed 42 --warmup-requests 0`.
 
 **Benchmark Command**
 
@@ -173,50 +206,16 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
   --tokenizer /models/DeepSeek-V3 \
   --host 127.0.0.1 --port 30000 \
   --dataset-name random \
-  --random-input-len 1000 --random-output-len 1000 \
-  --num-prompts 80 --max-concurrency 16 \
-  --seed 42
+  --random-input-len 1024 --random-output-len 1024 \
+  --num-prompts 384 --max-concurrency 128 \
+  --random-range-ratio 1 \
+  --seed 42 \
+  --warmup-requests 0
 ```
 
-**Test Results**
+**Published Results**
 
-```text
-============ Serving Benchmark Result ============
-Backend:                                 sgl-jax
-Traffic request rate:                    inf
-Max request concurrency:                 16
-Successful requests:                     80
-Benchmark duration (s):                  153.73
-Total input tokens:                      37205
-Total generated tokens:                  38314
-Request throughput (req/s):              0.52
-Input token throughput (tok/s):          242.02
-Output token throughput (tok/s):         249.24
-Peak output token throughput (tok/s):    464.00
-Peak concurrent requests:                18
-Total token throughput (tok/s):          491.26
-Concurrency:                             13.93
-----------------End-to-End Latency----------------
-Mean E2E Latency (ms):                   26762.89
-Median E2E Latency (ms):                 26193.67
-P90 E2E Latency (ms):                    49473.94
-P99 E2E Latency (ms):                    57531.47
----------------Time to First Token----------------
-Mean TTFT (ms):                          1018.63
-Median TTFT (ms):                        1294.61
-P99 TTFT (ms):                           1960.82
------Time per Output Token (excl. 1st token)------
-Mean TPOT (ms):                          59.32
-Median TPOT (ms):                        54.48
-P99 TPOT (ms):                           164.09
----------------Inter-Token Latency----------------
-Mean ITL (ms):                           53.87
-Median ITL (ms):                         34.51
-P95 ITL (ms):                            37.46
-P99 ITL (ms):                            1256.43
-Max ITL (ms):                            2517.66
-==================================================
-```
+Throughput numbers are intentionally omitted from this recipe for now. Use the command above to validate local deployments; publish a result row only after the configuration is tuned enough to be representative of the release target.
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/GLM/GLM-4.5.md
+++ b/docs/cookbook/autoregressive/GLM/GLM-4.5.md
@@ -4,7 +4,7 @@ title: "GLM-4.5"
 
 # GLM-4.5 MoE on SGL-JAX
 
-> **Validated recipe** — GLM-4.5-Air (106B) validated on TPU v6e-32 with sglang-jax 0.1.0; sanity + GSM8K + bench all pass. Pin to sglang-jax 0.1.0+ — earlier builds have a stale `q_proj` weight-transpose mapping that fails at first prefill.
+> **Validated recipe** — GLM-4.5-Air (106B) validated on TPU v6e-32 with sglang-jax 0.1.0; sanity + GSM8K pass, and §4.2 now includes the recommended v7x-4 high-throughput `bench_serving` row with the historical v6e-32 baseline kept as context. Pin to sglang-jax 0.1.0+ — earlier builds have a stale `q_proj` weight-transpose mapping that fails at first prefill.
 
 ## 1. Model Introduction
 
@@ -23,6 +23,7 @@ title: "GLM-4.5"
 
 | Model | TPU | Topology | Nodes | Chips | `--tp-size` | `--ep-size` | Notes |
 |---|---|---|---|---|---|---|---|
+| GLM-4.5-Air (106B) | **v7x-4** | 2x2x1 | 1 | 4 chips / 8 devices | 8 | 8 | Recommended throughput recipe in §4.2. v7x exposes 2 JAX devices/chip. |
 | GLM-4.5-Air (106B) | **v6e-32** | 4x8 | 8  | 32 | 32 | 32 | This is the slice we measured on. BF16 ~210 GB. |
 
 See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
@@ -264,26 +265,59 @@ Recommended additional datasets: MMLU, GPQA Diamond, AIME 2025.
 
 ### 4.2 Speed
 
-> **Layout B — methodology + command template.** No measured numbers yet; PR back full `============ Serving Benchmark Result ============` blocks from `bench_serving` to upgrade to Validated.
+> **High-throughput v7x-4 row.** This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. Radix cache is disabled and DP scheduling uses `round_robin`, so the result is throughput-oriented and not prefix-cache dependent.
 
-**Benchmark Command** — adapt the driver from [`Qwen3.md` §4.2](/autoregressive/Qwen/Qwen3#4-benchmark) (swap `MODEL_NAME` to the GLM-4.5 checkpoint, remove the vLLM half).
+**Test Environment**
 
-**Test Results** — GLM-4.5-Air, Layout B (`bench_serving` random 1024→1024, N=100, max-concurrency 16), v6e-32 + `--moe-backend epmoe`, sglang-jax 0.1.0:
+| Field | Value |
+|---|---|
+| Hardware | TPU v7x-4 (1 node x 4 chips, 8 JAX devices) |
+| Model | zai-org/GLM-4.5-Air (real BF16 weights) |
+| Tensor Parallelism | 8 |
+| Expert Parallelism | 8 |
+| Tested build | origin/main (`2d97c787f712f715784216f7c414a4f477ea8218`) |
 
+**Serving Flags Used**
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
+  --model-path /models/GLM-4.5-Air \
+  --trust-remote-code \
+  --tp-size 8 --ep-size 8 \
+  --moe-backend epmoe \
+  --dtype bfloat16 \
+  --context-length 32768 \
+  --chunked-prefill-size 2048 \
+  --page-size 128 \
+  --max-running-requests 256 \
+  --disable-radix-cache \
+  --dp-schedule-policy round_robin \
+  --skip-server-warmup \
+  --host 0.0.0.0 --port 30000
 ```
-============ Serving Benchmark Result ============
-Backend:                  sgl-jax
-Successful requests:      100
-Benchmark duration (s):   95.10
-Request throughput:       1.05 req/s
-Input throughput:         1076.76 tok/s
-Output throughput:        1076.76 tok/s
-Total throughput:         2153.51 tok/s
-Mean E2E Latency (ms):    14229.21
-Mean TTFT (ms):           576.77
-Mean TPOT (ms):           13.35
-==================================================
+
+**Benchmark Command**
+
+```bash
+PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
+  --backend sgl-jax \
+  --model /models/GLM-4.5-Air \
+  --tokenizer /models/GLM-4.5-Air \
+  --dataset-name random --random-input-len 1024 --random-output-len 1024 \
+  --num-prompts 384 --max-concurrency 128 \
+  --random-range-ratio 1 \
+  --seed 42 \
+  --warmup-requests 0 \
+  --host 127.0.0.1 --port 30000
 ```
+
+**Test Results**
+
+| ISL | OSL | Max concurrency | Prompts | Input tok/s | Output tok/s | Peak output tok/s | Mean TTFT (ms) | Mean TPOT (ms) | Duration (s) | OK |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1024 | 1024 | 128 | 384 | 4013.55 | 4013.55 | 4992.00 | 3126.11 | 28.84 | 97.97 | 384 |
+
+> Historical v6e-32 baseline: `1024/1024/c16`, 100 prompts, 1076.76 output tok/s. The v7x-4 row above uses fewer chips and is the recommended throughput-oriented recipe.
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/GLM/GLM-4.5.md
+++ b/docs/cookbook/autoregressive/GLM/GLM-4.5.md
@@ -265,7 +265,7 @@ Recommended additional datasets: MMLU, GPQA Diamond, AIME 2025.
 
 ### 4.2 Speed
 
-> **High-throughput v7x-4 row.** This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. Radix cache is disabled and DP scheduling uses `round_robin`, so the result is throughput-oriented and not prefix-cache dependent.
+> **High-throughput v7x-4 row.** This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. DP scheduling uses `round_robin`.
 
 **Test Environment**
 
@@ -290,7 +290,6 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
   --chunked-prefill-size 2048 \
   --page-size 128 \
   --max-running-requests 256 \
-  --disable-radix-cache \
   --dp-schedule-policy round_robin \
   --skip-server-warmup \
   --host 0.0.0.0 --port 30000

--- a/docs/cookbook/autoregressive/Google/Gemma2.md
+++ b/docs/cookbook/autoregressive/Google/Gemma2.md
@@ -143,7 +143,7 @@ Recommended additional datasets: MMLU, GPQA Diamond.
 
 ### 4.2 Speed
 
-> **Layout B — measured baseline.** TPU v6e-4 (single host, 4 chips, TP=4), sglang-jax 0.1.0. sgl-jax-only; no vLLM-on-TPU comparison.
+> **Layout B — measured baseline.** TPU v6e-4 (single host, 4 chips, TP=4), sglang-jax 0.1.0.
 
 **Test Environment**
 

--- a/docs/cookbook/autoregressive/Grok/Grok2.md
+++ b/docs/cookbook/autoregressive/Grok/Grok2.md
@@ -4,7 +4,7 @@ title: "Grok-2"
 
 # Grok-2 on SGL-JAX
 
-> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, sanity output correct, `bench_serving` numbers in §4.1. **Accuracy intentionally omitted** — Grok-2 is a base model (no chat template; see §1) and the cookbook follows design §6.F: base model recipes skip §4.1 Accuracy (chat-format datasets via `/v1/chat/completions` mis-extract on base models — see §3.1 for the underlying chat-template + evalscope-extractor interaction). **Cookbook used `--moe-backend epmoe`** because the fused MoE backend fails to init on this small-EP large-mesh layout (8 experts on 64 chips) (see §2.4). **Grok-2 architecture**: `config.json` declares `num_local_experts=8 num_experts_per_tok=2` under `Grok1ForCausalLM` — i.e. **MoE with 8 experts, 2 active per token** (not dense). Launch flags below assume MoE (`--ep-size 8 --moe-backend epmoe`).
+> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts and sanity output is correct. **Throughput numbers are intentionally omitted** until the Grok-2 TPU recipe has a release-quality performance datapoint. **Accuracy intentionally omitted** — Grok-2 is a base model (no chat template; see §1) and the cookbook follows design §6.F: base model recipes skip §4.1 Accuracy (chat-format datasets via `/v1/chat/completions` mis-extract on base models — see §3.1 for the underlying chat-template + evalscope-extractor interaction). **Cookbook used `--moe-backend epmoe`** because the fused MoE backend fails to init on this small-EP large-mesh layout (8 experts on 64 chips) (see §2.4). **Grok-2 architecture**: `config.json` declares `num_local_experts=8 num_experts_per_tok=2` under `Grok1ForCausalLM` — i.e. **MoE with 8 experts, 2 active per token** (not dense). Launch flags below assume MoE (`--ep-size 8 --moe-backend epmoe`).
 
 ## 1. Model Introduction
 
@@ -143,13 +143,13 @@ print(resp.choices[0].text)
 
 ## 4. Benchmark
 
-> Benchmark data below is a snapshot pinned to the `Tested build` listed in each Test Environment; not refreshed on every release.
+> Throughput results are not published in this recipe yet. Keep this page as a working launch recipe and benchmark template until the Grok-2 TPU path has a representative release-quality performance row.
 >
 > Accuracy section is omitted by design — see the banner + §1 for why base models skip it (per design §6.F).
 
-### 4.1 Speed — single workload (low-concurrency latency baseline)
+### 4.1 Speed Template
 
-> **Layout F — single-workload sweep (one data point).** Standard chat (ISL=1000, OSL=1000), `max_concurrency=16`, 80 prompts, `seed=42`.
+> **Benchmark command template.** Fixed-length random workload (ISL=1024, OSL=1024), `max_concurrency=16`, 80 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests.
 
 **Test Environment**
 
@@ -171,52 +171,16 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
   --tokenizer alvarobartt/grok-2-tokenizer \
   --host 127.0.0.1 --port 30000 \
   --dataset-name random \
-  --random-input-len 1000 --random-output-len 1000 \
+  --random-input-len 1024 --random-output-len 1024 \
   --num-prompts 80 --max-concurrency 16 \
-  --seed 42
+  --random-range-ratio 1 \
+  --seed 42 \
+  --warmup-requests 0
 ```
 
-**Test Results**
+**Published Results**
 
-```text
-============ Serving Benchmark Result ============
-Backend:                                 sgl-jax
-Traffic request rate:                    inf
-Max request concurrency:                 16
-Successful requests:                     80
-Benchmark duration (s):                  540.78
-Total input tokens:                      37205
-Total generated tokens:                  38314
-Request throughput (req/s):              0.15
-Input token throughput (tok/s):          68.80
-Output token throughput (tok/s):         70.85
-Peak output token throughput (tok/s):    96.00
-Peak concurrent requests:                18
-Total token throughput (tok/s):          139.65
-Concurrency:                             12.89
-----------------End-to-End Latency----------------
-Mean E2E Latency (ms):                   87163.46
-Median E2E Latency (ms):                 85736.22
-P90 E2E Latency (ms):                    157043.93
-P99 E2E Latency (ms):                    176535.69
----------------Time to First Token----------------
-Mean TTFT (ms):                          756.62
-Median TTFT (ms):                        632.52
-P99 TTFT (ms):                           1765.84
------Time per Output Token (excl. 1st token)------
-Mean TPOT (ms):                          185.63
-Median TPOT (ms):                        181.85
-P99 TPOT (ms):                           266.39
----------------Inter-Token Latency----------------
-Mean ITL (ms):                           180.80
-Median ITL (ms):                         174.79
-P95 ITL (ms):                            175.14
-P99 ITL (ms):                            461.90
-Max ITL (ms):                            1270.39
-==================================================
-```
-
-> Grok-2 throughput on this v6e-64 mesh is bottlenecked by small-EP MoE underutilization: with only 8 experts on 64 chips, the `--moe-backend epmoe` fallback (forced because `fused` crashes on this mesh, see §2.4) leaves most chips idle per token. This is a known limitation of the current fused MoE backend assumes large-EP; Grok-2's 8-expert layout sits below that assumption.
+No throughput result is published for Grok-2 in this recipe yet. The current limitation is the small-EP MoE layout: with only 8 experts, the validated `--moe-backend epmoe` path underutilizes large TPU meshes, while the fused backend is not yet a validated replacement for this layout. Publish numbers only after a tuned v7x or smaller-mesh configuration produces a representative result.
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/Grok/Grok2.md
+++ b/docs/cookbook/autoregressive/Grok/Grok2.md
@@ -4,7 +4,7 @@ title: "Grok-2"
 
 # Grok-2 on SGL-JAX
 
-> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts and sanity output is correct. **Throughput numbers are intentionally omitted** until the Grok-2 TPU recipe has a release-quality performance datapoint. **Accuracy intentionally omitted** — Grok-2 is a base model (no chat template; see §1) and the cookbook follows design §6.F: base model recipes skip §4.1 Accuracy (chat-format datasets via `/v1/chat/completions` mis-extract on base models — see §3.1 for the underlying chat-template + evalscope-extractor interaction). **Cookbook used `--moe-backend epmoe`** because the fused MoE backend fails to init on this small-EP large-mesh layout (8 experts on 64 chips) (see §2.4). **Grok-2 architecture**: `config.json` declares `num_local_experts=8 num_experts_per_tok=2` under `Grok1ForCausalLM` — i.e. **MoE with 8 experts, 2 active per token** (not dense). Launch flags below assume MoE (`--ep-size 8 --moe-backend epmoe`).
+> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts and sanity output is correct. **Accuracy intentionally omitted** — Grok-2 is a base model (no chat template; see §1) and the cookbook follows design §6.F: base model recipes skip §4.1 Accuracy (chat-format datasets via `/v1/chat/completions` mis-extract on base models — see §3.1 for the underlying chat-template + evalscope-extractor interaction). **Cookbook used `--moe-backend epmoe`** because the fused MoE backend fails to init on this small-EP large-mesh layout (8 experts on 64 chips) (see §2.4). **Grok-2 architecture**: `config.json` declares `num_local_experts=8 num_experts_per_tok=2` under `Grok1ForCausalLM` — i.e. **MoE with 8 experts, 2 active per token** (not dense). Launch flags below assume MoE (`--ep-size 8 --moe-backend epmoe`).
 
 ## 1. Model Introduction
 
@@ -143,8 +143,6 @@ print(resp.choices[0].text)
 
 ## 4. Benchmark
 
-> Throughput results are not published in this recipe yet. Keep this page as a working launch recipe and benchmark template until the Grok-2 TPU path has a representative release-quality performance row.
->
 > Accuracy section is omitted by design — see the banner + §1 for why base models skip it (per design §6.F).
 
 ### 4.1 Speed Template
@@ -177,10 +175,6 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
   --seed 42 \
   --warmup-requests 0
 ```
-
-**Published Results**
-
-No throughput result is published for Grok-2 in this recipe yet. The current limitation is the small-EP MoE layout: with only 8 experts, the validated `--moe-backend epmoe` path underutilizes large TPU meshes, while the fused backend is not yet a validated replacement for this layout. Publish numbers only after a tuned v7x or smaller-mesh configuration produces a representative result.
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/InclusionAI/Ling-2.6.md
+++ b/docs/cookbook/autoregressive/InclusionAI/Ling-2.6.md
@@ -26,7 +26,7 @@ title: "Ling 2.6"
 | Model | TPU | Topology | Nodes | Chips | `--tp-size` | `--dp-size` | `--ep-size` | Notes |
 |---|---|---|---|---|---|---|---|---|
 | Ling-2.6-1T | **v6e-64** | 8x8 | 16 | 64 | 64 | 8 | 64 | This is the slice we measured on. Trillion-scale; multi-host mandatory. `dp=8` required (GLA `num_groups=8` ≤ tensor axis); `--disable-radix-cache` required (hybrid recurrent state). |
-| Ling-2.6-1T | **v7x-16** | 2×2×4 | 4 | 16 | 32 | 8 | 32 | v7x exposes 2 JAX devices/chip, so `--tp-size` = 16 chips × 2 = 32. Runs the V2 fused MoE kernel (`--moe-backend fused_v2`), which cuts MoE-layer prefill latency ~53% vs V1. Same `dp=8` and `--disable-radix-cache` constraints as v6e-64. |
+| Ling-2.6-1T | **v7x-16** | 2×2×4 | 4 | 16 | 32 | 8 | 32 | v7x exposes 2 JAX devices/chip, so `--tp-size` = 16 chips × 2 = 32. Runs the V2 fused MoE kernel (`--moe-backend fused_v2`). Same `dp=8` and `--disable-radix-cache` constraints as v6e-64. |
 
 See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
 
@@ -72,7 +72,7 @@ On GKE, use the [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<J
 
 #### Multi-host — TPU v7x-16 (fused MoE V2)
 
-On a `v7x-16` slice (`2×2×4`, 4 nodes, 16 chips → 32 JAX devices) serve Ling-2.6-1T with the V2 fused MoE kernel (`--moe-backend fused_v2`), which packs scatter, expert FFN, and gather into one Pallas call with double buffering and activation quantization — cutting MoE-layer prefill latency ~53% vs V1. Launch the server on **every node**, varying `${NODE_RANK}` (`0..3`) and pointing all nodes at the rank-0 host via `--dist-init-addr`:
+On a `v7x-16` slice (`2×2×4`, 4 nodes, 16 chips → 32 JAX devices) serve Ling-2.6-1T with the V2 fused MoE kernel (`--moe-backend fused_v2`). Launch the server on **every node**, varying `${NODE_RANK}` (`0..3`) and pointing all nodes at the rank-0 host via `--dist-init-addr`:
 
 ```bash
 python3 -u -m sgl_jax.launch_server \
@@ -112,7 +112,7 @@ All nodes must sit in the same TPU slice and reach each other on the `--dist-ini
 - The GLA linear attention layer has a per-group RMSNorm with `num_groups=8`, sharded along the "tensor" mesh axis. **Effective tensor axis must be ≤ 8.** On v6e-64 that forces `--tp-size 64 --dp-size 8` (tensor axis = `tp/dp` = 8). Setting `--dp-size 1` builds tensor=64 and JIT trace crashes with `Sharding spec ('tensor',) implies that array axis 1 is partitioned 64 times, but does not evenly divide the dimension size 8`.
 
 **MoE Backend:**
-- `--moe-backend` selects the EP MoE implementation: `epmoe` (megablox GMM), `fused` (Pallas fused MoE V1), or `fused_v2` (Pallas fused MoE V2 — double-buffered with activation quantization, ~53% lower MoE-layer prefill latency vs V1). The v6e-64 recipe uses `fused`; the v7x-16 recipe uses `fused_v2`. The fused kernels (`fused` / `fused_v2`) require **full expert parallelism** — they treat the entire `data × tensor` mesh as the EP group, so set `--ep-size` equal to the total JAX device count (`--tp-size`): 64 on v6e-64, 32 on v7x-16.
+- `--moe-backend` selects the EP MoE implementation: `epmoe` (megablox GMM), `fused` (Pallas fused MoE V1), or `fused_v2` (Pallas fused MoE V2). The v6e-64 recipe uses `fused`; the v7x-16 recipe uses `fused_v2`. The fused kernels (`fused` / `fused_v2`) require **full expert parallelism** — they treat the entire `data × tensor` mesh as the EP group, so set `--ep-size` equal to the total JAX device count (`--tp-size`): 64 on v6e-64, 32 on v7x-16.
 
 **FP8 Quantization (compressed-tensors):**
 - Ling-2.6 ships compressed-tensors FP8 with `strategy="channel"` (per-output channel weight scales, dynamic per-token activation). The runtime auto-detects this — no `--quantization` flag needed. `--dtype bfloat16` controls runtime compute dtype, not weight residency.

--- a/docs/cookbook/autoregressive/InclusionAI/Ling-2.6.md
+++ b/docs/cookbook/autoregressive/InclusionAI/Ling-2.6.md
@@ -4,7 +4,7 @@ title: "Ling 2.6"
 
 # Ling-2.6 on SGL-JAX
 
-> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, greedy + raw completion correct, GSM8K accuracy 98.5% (200 examples, see §4.1), `bench_serving` numbers in §4.3. Pin to sglang-jax 0.1.0 (or any commit that includes the channel-wise FP8 QKV split fix); earlier builds crash at weight load.
+> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, greedy + raw completion correct, GSM8K accuracy 98.5% (200 examples, see §4.1). §4.3 now includes the recommended balanced v7x-16 `bench_serving` row, with the historical v6e-64 baseline kept as context. Pin to sglang-jax 0.1.0 (or any commit that includes the channel-wise FP8 QKV split fix); earlier builds crash at weight load.
 
 ## 1. Model Introduction
 
@@ -259,20 +259,41 @@ python test/srt/run_eval.py \
 
 ### 4.3 Speed
 
-> **Layout F — single-workload sweep (one data point).** Standard chat (ISL=1000, OSL=1000), `max_concurrency=16`, 80 prompts, `seed=42`. Future PRs can add long-context (OSL=4096+) and concurrency sweeps to validate the GLA long-context advantage.
+> **Balanced v7x-16 throughput row.** This cookbook row uses one fixed-length random workload (ISL=1024, OSL=1024), `max_concurrency=32`, 160 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. Radix cache is disabled and DP scheduling uses `round_robin`, so the result is not prefix-cache dependent.
 
 **Test Environment**
 
 | Field | Value |
 |---|---|
-| Hardware | TPU v6e-64 (16 nodes × 4 chips) |
-| Model | inclusionAI/Ling-2.6-1T (compressed-tensors FP8 native; runtime dtype bfloat16) |
-| Tensor Parallelism | 64 (effective tensor axis 8 via `--dp-size 8`) |
+| Hardware | TPU v7x-16 (4 nodes x 4 chips, 32 JAX devices) |
+| Model | inclusionAI/Ling-2.6-1T (real weights, compressed-tensors FP8 native; runtime dtype bfloat16) |
+| Tensor Parallelism | 32 (effective tensor axis 4 via `--dp-size 8`) |
 | Data Parallelism | 8 |
-| Expert Parallelism | 64 |
-| Tested build | sglang-jax 0.1.0 |
+| Expert Parallelism | 32 |
+| Tested build | origin/main (`2d97c787f712f715784216f7c414a4f477ea8218`) |
 
-**Deployment Command** — same as [§2.3 Multi-host — TPU v6e-64](/autoregressive/InclusionAI/Ling-2.6#2-3-launch).
+**Serving Flags Used**
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
+  --model-path /models/Ling-2.6-1T \
+  --trust-remote-code \
+  --tp-size 32 --dp-size 8 --ep-size 32 \
+  --moe-backend fused_v2 \
+  --context-length 32768 \
+  --chunked-prefill-size 2048 \
+  --page-size 256 \
+  --max-running-requests 64 \
+  --attention-backend fa \
+  --disable-radix-cache \
+  --dp-schedule-policy round_robin \
+  --precompile-bs-paddings 16 32 64 \
+  --precompile-token-paddings 1024 2048 4096 8192 16384 \
+  --skip-server-warmup \
+  --nnodes 4 --node-rank ${NODE_RANK} \
+  --dist-init-addr ${MASTER_ADDR} \
+  --host 0.0.0.0 --port 30000
+```
 
 **Benchmark Command**
 
@@ -283,52 +304,20 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
   --tokenizer /models/Ling-2.6-1T \
   --host 127.0.0.1 --port 30000 \
   --dataset-name random \
-  --random-input-len 1000 --random-output-len 1000 \
-  --num-prompts 80 --max-concurrency 16 \
-  --seed 42
+  --random-input-len 1024 --random-output-len 1024 \
+  --num-prompts 160 --max-concurrency 32 \
+  --random-range-ratio 1 \
+  --seed 42 \
+  --warmup-requests 0
 ```
 
 **Test Results**
 
-```text
-============ Serving Benchmark Result ============
-Backend:                                 sgl-jax
-Traffic request rate:                    inf
-Max request concurrency:                 16
-Successful requests:                     80
-Benchmark duration (s):                  297.83
-Total input tokens:                      37205
-Total generated tokens:                  38314
-Request throughput (req/s):              0.27
-Input token throughput (tok/s):          124.92
-Output token throughput (tok/s):         128.64
-Peak output token throughput (tok/s):    192.00
-Peak concurrent requests:                18
-Total token throughput (tok/s):          253.56
-Concurrency:                             13.40
-----------------End-to-End Latency----------------
-Mean E2E Latency (ms):                   49902.98
-Median E2E Latency (ms):                 50129.75
-P90 E2E Latency (ms):                    91094.50
-P99 E2E Latency (ms):                    102596.07
----------------Time to First Token----------------
-Mean TTFT (ms):                          897.32
-Median TTFT (ms):                        845.06
-P99 TTFT (ms):                           1603.57
------Time per Output Token (excl. 1st token)------
-Mean TPOT (ms):                          104.01
-Median TPOT (ms):                        105.22
-P99 TPOT (ms):                           125.02
----------------Inter-Token Latency----------------
-Mean ITL (ms):                           102.54
-Median ITL (ms):                         88.50
-P95 ITL (ms):                            89.27
-P99 ITL (ms):                            581.03
-Max ITL (ms):                            1293.91
-==================================================
-```
+| ISL | OSL | Max concurrency | Prompts | Input tok/s | Output tok/s | Mean TTFT (ms) | Mean TPOT (ms) | Duration (s) | OK |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1024 | 1024 | 32 | 160 | 1145.13 | 1145.13 | 1078.91 | 26.91 | 143.08 | 160 |
 
-> Ling-2.6-1T throughput on this v6e-64 mesh is bound by the GLA recurrent state pool overhead and the linear-attention chunk kernel at decode — the trillion-parameter total weight (vs Ling-2.6's hybrid linear / full attention layers) leaves narrow per-chip activation headroom on v6e (32 GB/chip).
+> This row is throughput-oriented and keeps the full latency metrics visible for reproducibility. The earlier v6e-64 cookbook point at `1000/1000/c16` measured 128.64 output tok/s; the v7x-16 row above is the recommended current throughput recipe.
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/Llama/Llama3.1.md
+++ b/docs/cookbook/autoregressive/Llama/Llama3.1.md
@@ -130,7 +130,7 @@ Recommended additional datasets: MMLU, HumanEval, IFEval.
 
 ### 4.2 Speed
 
-> **Layout B — measured baseline.** Single-host TPU v6e-4, sglang-jax 0.1.0. Numbers are sgl-jax-only; vLLM-on-TPU comparison is not run.
+> **Layout B — measured baseline.** Single-host TPU v6e-4, sglang-jax 0.1.0.
 
 **Test Environment**
 

--- a/docs/cookbook/autoregressive/Llama/Llama3.3-70B.md
+++ b/docs/cookbook/autoregressive/Llama/Llama3.3-70B.md
@@ -4,7 +4,7 @@ title: "Llama 3.3 70B"
 
 # Llama 3.3 70B on SGL-JAX
 
-> **Validated recipe** — empirically validated on TPU v6e-16 with sglang-jax 0.1.0; see §4 for measured numbers.
+> **Validated recipe** — empirically validated on TPU v6e-16 with sglang-jax 0.1.0 for accuracy and historical baseline; §4.2 now includes the recommended v7x-4 high-throughput `bench_serving` row.
 
 ## 1. Model Introduction
 
@@ -30,6 +30,7 @@ For Llama 4 see the upstream sgl-cookbook (`Llama/Llama4.md`).
 
 | Model | TPU | Topology | Nodes | Chips | `--tp-size` | Notes |
 |---|---|---|---|---|---|---|
+| Llama 3.3 70B | **v7x-4** | 2x2x1 | 1 | 4 chips / 8 devices | 8 | Recommended throughput recipe in §4.2. v7x exposes 2 JAX devices/chip. |
 | Llama 3.3 70B | **v6e-16** | 4x4 | 4 | 16 | 16 | This is the slice we measured on. BF16 ~140 GB — fits with `--mem-fraction-static 0.85` (~8.75 GB weights/chip + ample KV headroom). |
 
 See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
@@ -145,49 +146,57 @@ Recommended additional datasets: MMLU, GPQA Diamond, IFEval.
 
 ### 4.2 Speed
 
-> **Layout B — measured baseline.** TPU v6e-16 (4 nodes × 4 chips, TP=16), sglang-jax 0.1.0. sgl-jax-only; no vLLM-on-TPU comparison.
+> **High-throughput v7x-4 row.** This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. Radix cache is disabled and DP scheduling uses `round_robin`, so the result is throughput-oriented and not prefix-cache dependent.
 
 **Test Environment**
 
 | Field | Value |
 |---|---|
-| Hardware | TPU v6e-16 (4 nodes × 4 chips) |
-| Model | meta-llama/Llama-3.3-70B-Instruct (BF16) |
-| Tensor Parallelism | 16 |
-| Tested build | sglang-jax 0.1.0 |
+| Hardware | TPU v7x-4 (1 node x 4 chips, 8 JAX devices) |
+| Model | meta-llama/Llama-3.3-70B-Instruct (real BF16 weights) |
+| Tensor Parallelism | 8 |
+| Tested build | origin/main (`2d97c787f712f715784216f7c414a4f477ea8218`) |
+
+**Serving Flags Used**
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
+  --model-path /models/Llama-3.3-70B-Instruct \
+  --trust-remote-code \
+  --tp-size 8 \
+  --dtype bfloat16 \
+  --context-length 32768 \
+  --chunked-prefill-size 2048 \
+  --page-size 128 \
+  --max-running-requests 256 \
+  --disable-radix-cache \
+  --dp-schedule-policy round_robin \
+  --skip-server-warmup \
+  --host 0.0.0.0 --port 30000
+```
 
 **Benchmark Command**
 
 ```bash
-python3 -m sgl_jax.bench_serving \
-  --backend sglang \
-  --model meta-llama/Llama-3.3-70B-Instruct \
-  --tokenizer meta-llama/Llama-3.3-70B-Instruct \
+PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
+  --backend sgl-jax \
+  --model /models/Llama-3.3-70B-Instruct \
+  --tokenizer /models/Llama-3.3-70B-Instruct \
   --dataset-name random --random-input-len 1024 --random-output-len 1024 \
-  --num-prompts 100 --max-concurrency 16 \
+  --num-prompts 384 --max-concurrency 128 \
+  --random-range-ratio 1 \
+  --seed 42 \
+  --warmup-requests 0 \
   --host 127.0.0.1 --port 30000
 ```
 
 **Test Results**
 
-```
-============ Serving Benchmark Result ============
-Successful requests:                     100
-Benchmark duration (s):                  59.45
-Total input tokens:                      50561
-Total generated tokens:                  52444
-Request throughput (req/s):              1.68
-Input token throughput (tok/s):          850.49
-Output token throughput (tok/s):         882.17
-Peak output token throughput (tok/s):    1040.00
-Total token throughput (tok/s):          1732.66
-Mean E2E Latency (ms):                   8647.20
-Mean TTFT (ms):                          113.86
-Mean TPOT (ms):                          16.33
-Median TPOT (ms):                        16.47
-Mean ITL (ms):                           16.30
-==================================================
-```
+| ISL | OSL | Max concurrency | Prompts | Input tok/s | Output tok/s | Peak output tok/s | Mean TTFT (ms) | Mean TPOT (ms) | Duration (s) | OK |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1024 | 1024 | 128 | 384 | 3609.65 | 3609.65 | 4992.00 | 4796.46 | 30.78 | 108.93 | 384 |
+
+> Historical v6e-16 baseline: `1024/1024/c16`, 100 prompts, 882.17 output tok/s, 1040.00 peak output tok/s. The v7x-4 row above uses fewer chips and is the recommended throughput-oriented recipe.
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/Llama/Llama3.3-70B.md
+++ b/docs/cookbook/autoregressive/Llama/Llama3.3-70B.md
@@ -146,7 +146,7 @@ Recommended additional datasets: MMLU, GPQA Diamond, IFEval.
 
 ### 4.2 Speed
 
-> **High-throughput v7x-4 row.** This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. Radix cache is disabled and DP scheduling uses `round_robin`, so the result is throughput-oriented and not prefix-cache dependent.
+> **High-throughput v7x-4 row.** This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. DP scheduling uses `round_robin`.
 
 **Test Environment**
 
@@ -169,7 +169,6 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
   --chunked-prefill-size 2048 \
   --page-size 128 \
   --max-running-requests 256 \
-  --disable-radix-cache \
   --dp-schedule-policy round_robin \
   --skip-server-warmup \
   --host 0.0.0.0 --port 30000

--- a/docs/cookbook/autoregressive/Qwen/Qwen.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen.md
@@ -206,7 +206,7 @@ Max ITL (ms):                            154.39
 ## Additional Resources
 
 - [Qwen Model Cards](https://huggingface.co/Qwen)
-- [Qwen3 recipe](/autoregressive/Qwen/Qwen3) — newer Qwen3 8B/32B recipe with framework comparison numbers.
+- [Qwen3 recipe](/autoregressive/Qwen/Qwen3) — newer Qwen3 8B/32B recipe with TPU benchmark rows.
 - [JAX Scaling Book](https://jax-ml.github.io/scaling-book/)
 - [Launch flags reference](/base/launch-flags-reference)
 - [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/Qwen/Qwen3-MoE.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3-MoE.md
@@ -4,7 +4,7 @@ title: "Qwen3-MoE"
 
 # Qwen3-MoE on SGL-JAX
 
-> **Validated recipe** — Qwen3-30B-A3B validated on TPU v6e-16 with sglang-jax 0.1.0; see §4 for measured numbers.
+> **Validated recipe** — Qwen3-30B-A3B validated on TPU v6e-16 with sglang-jax 0.1.0; §4.2 now includes the recommended v7x-4 high-throughput `bench_serving` row, with the historical v6e-16 baseline kept as context.
 
 ## 1. Model Introduction
 
@@ -33,6 +33,7 @@ For the dense Qwen3 variants (8B / 32B) see [Qwen3 recipe](/autoregressive/Qwen/
 
 | Model | TPU | Topology | Nodes | Chips | `--tp-size` | `--ep-size` | Notes |
 |---|---|---|---|---|---|---|---|
+| Qwen3-30B-A3B | **v7x-4** | 2x2x1 | 1 | 4 chips / 8 devices | 8 | 8 | Recommended throughput recipe in §4.2. v7x exposes 2 JAX devices/chip. |
 | Qwen3-30B-A3B   | **v6e-16** | 4x4 | 4  | 16 | 16 | 16 | This is the slice we measured on. BF16 ~60 GB. |
 
 See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
@@ -325,50 +326,59 @@ evalscope eval \
 
 ### 4.2 Speed
 
-> **Layout B — measured baseline.** TPU v6e-16 (4 nodes × 4 chips, TP=16, EP=16), sglang-jax 0.1.0. sgl-jax-only; no vLLM-on-TPU comparison.
+> **High-throughput v7x-4 row.** This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. Radix cache is disabled and DP scheduling uses `round_robin`, so the result is throughput-oriented and not prefix-cache dependent.
 
 **Test Environment**
 
 | Field | Value |
 |---|---|
-| Hardware | TPU v6e-16 (4 nodes × 4 chips) |
-| Model | Qwen/Qwen3-30B-A3B (BF16, MoE A3B) |
-| Tensor Parallelism | 16 |
-| Expert Parallelism | 16 |
-| Tested build | sglang-jax 0.1.0 |
+| Hardware | TPU v7x-4 (1 node x 4 chips, 8 JAX devices) |
+| Model | Qwen/Qwen3-30B-A3B (real BF16 weights, MoE A3B) |
+| Tensor Parallelism | 8 |
+| Expert Parallelism | 8 |
+| Tested build | origin/main (`2d97c787f712f715784216f7c414a4f477ea8218`) |
+
+**Serving Flags Used**
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
+  --model-path /models/Qwen3-30B-A3B \
+  --trust-remote-code \
+  --tp-size 8 --ep-size 8 \
+  --moe-backend epmoe \
+  --dtype bfloat16 \
+  --context-length 32768 \
+  --chunked-prefill-size 2048 \
+  --page-size 128 \
+  --max-running-requests 256 \
+  --disable-radix-cache \
+  --dp-schedule-policy round_robin \
+  --skip-server-warmup \
+  --host 0.0.0.0 --port 30000
+```
 
 **Benchmark Command**
 
 ```bash
-python3 -m sgl_jax.bench_serving \
-  --backend sglang \
-  --model Qwen/Qwen3-30B-A3B \
-  --tokenizer Qwen/Qwen3-30B-A3B \
+PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
+  --backend sgl-jax \
+  --model /models/Qwen3-30B-A3B \
+  --tokenizer /models/Qwen3-30B-A3B \
   --dataset-name random --random-input-len 1024 --random-output-len 1024 \
-  --num-prompts 100 --max-concurrency 16 \
+  --num-prompts 384 --max-concurrency 128 \
+  --random-range-ratio 1 \
+  --seed 42 \
+  --warmup-requests 0 \
   --host 127.0.0.1 --port 30000
 ```
 
 **Test Results**
 
-```
-============ Serving Benchmark Result ============
-Successful requests:                     100
-Benchmark duration (s):                  35.53
-Total input tokens:                      50561
-Total generated tokens:                  52444
-Request throughput (req/s):              2.81
-Input token throughput (tok/s):          1423.18
-Output token throughput (tok/s):         1476.18
-Peak output token throughput (tok/s):    1744.00
-Total token throughput (tok/s):          2899.37
-Mean E2E Latency (ms):                   5223.28
-Mean TTFT (ms):                          75.77
-Mean TPOT (ms):                          9.88
-Median TPOT (ms):                        9.97
-Mean ITL (ms):                           9.83
-==================================================
-```
+| ISL | OSL | Max concurrency | Prompts | Input tok/s | Output tok/s | Peak output tok/s | Mean TTFT (ms) | Mean TPOT (ms) | Duration (s) | OK |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1024 | 1024 | 128 | 384 | 6179.45 | 6179.45 | 7564.00 | 1833.34 | 18.91 | 63.63 | 384 |
+
+> Historical v6e-16 baseline: `1024/1024/c16`, 100 prompts, 1476.18 output tok/s, 1744.00 peak output tok/s. The v7x-4 row above uses fewer chips and is the recommended throughput-oriented recipe.
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/Qwen/Qwen3-MoE.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3-MoE.md
@@ -326,7 +326,7 @@ evalscope eval \
 
 ### 4.2 Speed
 
-> **High-throughput v7x-4 row.** This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. Radix cache is disabled and DP scheduling uses `round_robin`, so the result is throughput-oriented and not prefix-cache dependent.
+> **High-throughput v7x-4 row.** This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. DP scheduling uses `round_robin`.
 
 **Test Environment**
 
@@ -351,7 +351,6 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
   --chunked-prefill-size 2048 \
   --page-size 128 \
   --max-running-requests 256 \
-  --disable-radix-cache \
   --dp-schedule-policy round_robin \
   --skip-server-warmup \
   --host 0.0.0.0 --port 30000

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.md
@@ -16,7 +16,7 @@ title: "Qwen3"
 - **Hybrid Reasoning**: Supports thinking-on (default) and thinking-off via `chat_template_kwargs.enable_thinking` per-request.
 - **Tool Calling**: OpenAI-compatible tool/function calling supported.
 - **Long Context**: 128K context window.
-- **Production-validated benchmarks**: §4.2 below has measured throughput vs vLLM on the same hardware.
+- **Production-validated benchmarks**: §4.2 below has measured throughput rows on TPU.
 
 **Recommended Generation Parameters**:
 
@@ -76,9 +76,6 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python3 -u -m sgl_jax.launch_server \
 - `--page-size 128` is benchmark-tuned (vs default `1`). Larger page reduces page-table overhead at high concurrency but uses more KV per request. Default `1` is more flexible for low-concurrency mixed traffic.
 - `--chunked-prefill-size 2048` splits long prefills into 2K-token chunks for predictable HBM. Raise to 4096 if you have HBM headroom; lower to 1024 if prefill OOM.
 - `--max-running-requests 256` is the concurrent decode cap. Throughput plateaus around this; raising further mainly increases queue depth.
-
-**Prefix Caching:**
-- RadixAttention prefix caching is enabled by default. Keep it on for regular serving so repeated prefixes can benefit from cache reuse.
 
 **Compilation Cache Hygiene:**
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min while XLA/Pallas re-compiles.
@@ -402,9 +399,9 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
 |---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 | 1024 | 1024 | 128 | 384 | 8521.48 | 8521.48 | 10266.00 | 943.13 | 14.09 | 46.14 | 384 |
 
-#### v6e-4 SGL-JAX vs vLLM comparison
+#### Historical v6e-4 SGL-JAX sweep
 
-> **Layout E — variant × workload sweep on single hardware.** Qwen3-8B and Qwen3-32B on TPU v6e-4 (TP=4), sgl-jax vs vLLM across ISL values 1024, 4096, and 8192; OSL values 1 and 1024; and concurrency values 8, 16, 32, 64, 128, and 256.
+> **Layout E — variant × workload sweep on single hardware.** Qwen3-8B and Qwen3-32B on TPU v6e-4 (TP=4), across ISL values 1024, 4096, and 8192; OSL values 1 and 1024; and concurrency values 8, 16, 32, 64, 128, and 256.
 
 **Test Environment**
 
@@ -413,30 +410,18 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
 | Hardware | TPU v6e-4 (single host, 4 chips) |
 | Model | Qwen/Qwen3-8B and Qwen/Qwen3-32B (BF16) |
 | Tensor Parallelism | 4 |
-| Tested build | sglang-jax 0.1.0 (vs vLLM `main-5931b7e5d9acd4fd9eb42d56086c379fa2e2014e`) |
+| Tested build | sglang-jax 0.1.0 |
 
 Methodology: TTFT measured at `output_len=1` to isolate first-token latency; ITL / throughput measured at `output_len=1024`. Workload sweeps input lengths 1024 / 4096 / 8192 tokens × output lengths 1 / 1024 tokens × concurrency 8 / 16 / 32 / 64 / 128 / 256.
 
-**Deployment Command** — same as [§2.3 Single-host](/autoregressive/Qwen/Qwen3#2-3-launch) for the SGL-JAX side. For the vLLM baseline:
-
-```bash
-MODEL_NAME="Qwen/Qwen3-8B"  # or "Qwen/Qwen3-32B"
-vllm serve "${MODEL_NAME}" \
-  --download_dir /tmp --swap-space 16 --disable-log-requests \
-  --tensor_parallel_size 4 --trust-remote-code \
-  --max-model-len 9216 --no-enable-prefix-caching
-```
+**Deployment Command** — same as [§2.3 Single-host](/autoregressive/Qwen/Qwen3#2-3-launch).
 
 **Benchmark Command** — bash driver that sweeps (ISL × OSL × concurrency):
 
 ```bash
 #!/bin/bash
 set -e
-if [ -z "$1" ]; then
-  echo "Usage: $0 <engine> [model]"; echo "engine: sgl-jax or vllm"; exit 1
-fi
-backend=${1}
-MODEL_NAME=${2:-Qwen/Qwen3-8B}  # or pass Qwen/Qwen3-32B as 2nd arg
+MODEL_NAME=${1:-Qwen/Qwen3-8B}  # or pass Qwen/Qwen3-32B
 num_prompts_per_concurrency=3
 input_seq_lens=(1024 4096 8192)
 output_seq_lens=(1 1024)
@@ -447,7 +432,7 @@ for input_seq_len in "${input_seq_lens[@]}"; do
     for max_concurrency in "${max_concurrencies[@]}"; do
       num_prompts=$((num_prompts_per_concurrency * max_concurrency))
       python3 -m sgl_jax.bench_serving \
-        --backend ${backend} \
+        --backend sgl-jax \
         --dataset-name random \
         --num-prompts ${num_prompts} \
         --random-input-len ${input_seq_len} \
@@ -461,35 +446,32 @@ for input_seq_len in "${input_seq_lens[@]}"; do
 done
 ```
 
-Run against both engines:
+Run the sweep:
 
 ```bash
 chmod +x benchmark.sh
-./benchmark.sh sgl-jax Qwen/Qwen3-8B
-./benchmark.sh vllm Qwen/Qwen3-8B
+./benchmark.sh Qwen/Qwen3-8B
 ```
 
 **Test Results** (selected representative cells — see full validation matrix for the full ISL × OSL × batch matrix)
 
 Qwen3-8B:
 
-| ISL/OSL | Batch | TTFT (ms) SGL_JAX | TTFT (ms) vLLM | ITL (ms) SGL_JAX | ITL (ms) vLLM | Out tok/s SGL_JAX | Out tok/s vLLM |
-|---|---|---|---|---|---|---|---|
-| 1024/1024 | 64  | 940.87   | 1346.38  | 11.11 | 18.34 | 5296.60 | 3043.58 |
-| 1024/1024 | 256 | 3793.50  | 5496.67  | 30.00 | 56.81 | 7571.84 | 4051.08 |
-| 4096/1024 | 64  | 4108.43  | 6594.65  | 21.13 | 42.20 | 2528.79 | 1304.04 |
-| 8192/1024 | 64  | 9797.87  | 16565.67 | 31.98 | 58.86 | 1458.77 | 873.82  |
+| ISL/OSL | Batch | TTFT (ms) | ITL (ms) | Out tok/s |
+|---|---:|---:|---:|---:|
+| 1024/1024 | 64  | 940.87  | 11.11 | 5296.60 |
+| 1024/1024 | 256 | 3793.50 | 30.00 | 7571.84 |
+| 4096/1024 | 64  | 4108.43 | 21.13 | 2528.79 |
+| 8192/1024 | 64  | 9797.87 | 31.98 | 1458.77 |
 
 Qwen3-32B:
 
-| ISL/OSL | Batch | TTFT (ms) SGL_JAX | TTFT (ms) vLLM | ITL (ms) SGL_JAX | ITL (ms) vLLM | Out tok/s SGL_JAX | Out tok/s vLLM |
-|---|---|---|---|---|---|---|---|
-| 1024/1024 | 64  | 2864.06  | 3734.00  | 29.48 | 42.45  | 1977.45 | 1391.29 |
-| 1024/1024 | 256 | 11500.61 | 14985.60 | 34.27 | 68.14  | 2122.98 | 1652.79 |
-| 4096/1024 | 64  | 12329.34 | 16108.16 | 35.32 | 73.64  | 785.30  | 422.50  |
-| 8192/1024 | 64  | 28849.51 | 36082.81 | 33.43 | 142.77 | 435.25  | 199.05  |
-
-SGL-JAX wins consistently on this hardware across all measured cells: ~1.5–2.2× output throughput, ~1.4–2.0× faster TTFT, ~1.6–2.4× lower ITL.
+| ISL/OSL | Batch | TTFT (ms) | ITL (ms) | Out tok/s |
+|---|---:|---:|---:|---:|
+| 1024/1024 | 64  | 2864.06  | 29.48 | 1977.45 |
+| 1024/1024 | 256 | 11500.61 | 34.27 | 2122.98 |
+| 4096/1024 | 64  | 12329.34 | 35.32 | 785.30 |
+| 8192/1024 | 64  | 28849.51 | 33.43 | 435.25 |
 
 **Build verification (sglang-jax 0.1.0)** — single-cell confirmation that matches the sweep above. Qwen3-32B, ISL=1024 OSL=1024 c=16 (100 prompts):
 
@@ -501,7 +483,7 @@ Mean TPOT (ms):                          16.89
 Mean E2E Latency (ms):                   8948.78
 ```
 
-Lower than the 1977 tok/s c=64 table cell because c=16 leaves the batch under-filled — included only to confirm the recipe still launches and decodes cleanly on the current build. The Sept-2025 sweep above remains the canonical SGL-JAX-vs-vLLM comparison.
+Lower than the 1977 tok/s c=64 table cell because c=16 leaves the batch under-filled — included only to confirm the recipe still launches and decodes cleanly on the current build. The Sept-2025 sweep above remains the historical v6e-4 SGL-JAX reference sweep.
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.md
@@ -78,7 +78,7 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python3 -u -m sgl_jax.launch_server \
 - `--max-running-requests 256` is the concurrent decode cap. Throughput plateaus around this; raising further mainly increases queue depth.
 
 **Prefix Caching:**
-- `--disable-radix-cache` disables RadixAttention prefix caching. Set this **only for benchmarks** that compare against engines without prefix caching (so measurements are apples-to-apples). For production, leave it off (default) — it gives a free latency win on repeated prefixes.
+- RadixAttention prefix caching is enabled by default. Keep it on for regular serving so repeated prefixes can benefit from cache reuse.
 
 **Compilation Cache Hygiene:**
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min while XLA/Pallas re-compiles.
@@ -350,7 +350,7 @@ evalscope eval \
 
 #### High-throughput v7x-4 result (Qwen3-8B)
 
-> This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. Radix cache is disabled and DP scheduling uses `round_robin`, so the result is throughput-oriented and not prefix-cache dependent.
+> This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. DP scheduling uses `round_robin`.
 
 **Test Environment**
 
@@ -375,7 +375,6 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
   --mem-fraction-static 0.90 \
   --page-size 128 \
   --max-running-requests 256 \
-  --disable-radix-cache \
   --dp-schedule-policy round_robin \
   --skip-server-warmup \
   --host 0.0.0.0 --port 30000
@@ -418,7 +417,7 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
 
 Methodology: TTFT measured at `output_len=1` to isolate first-token latency; ITL / throughput measured at `output_len=1024`. Workload sweeps input lengths 1024 / 4096 / 8192 tokens × output lengths 1 / 1024 tokens × concurrency 8 / 16 / 32 / 64 / 128 / 256.
 
-**Deployment Command** — same as [§2.3 Single-host](/autoregressive/Qwen/Qwen3#2-3-launch) for the SGL-JAX side, with `--disable-radix-cache` added to keep apples-to-apples comparison with vLLM (which doesn't use prefix caching in this run). For the vLLM baseline:
+**Deployment Command** — same as [§2.3 Single-host](/autoregressive/Qwen/Qwen3#2-3-launch) for the SGL-JAX side. For the vLLM baseline:
 
 ```bash
 MODEL_NAME="Qwen/Qwen3-8B"  # or "Qwen/Qwen3-32B"

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.md
@@ -4,7 +4,7 @@ title: "Qwen3"
 
 # Qwen3-8B / Qwen3-32B on SGL-JAX
 
-> **Validated recipe** — Qwen3-8B and Qwen3-32B both empirically validated on TPU v6e-4 with sglang-jax 0.1.0; see §4 for measured numbers.
+> **Validated recipe** — Qwen3-8B and Qwen3-32B both empirically validated on TPU v6e-4 with sglang-jax 0.1.0; §4.2 also includes the recommended Qwen3-8B v7x-4 high-throughput `bench_serving` row.
 
 ## 1. Model Introduction
 
@@ -31,10 +31,11 @@ title: "Qwen3"
 
 | Model | TPU | Topology | Chips | `--tp-size` | Notes |
 |---|---|---|---|---|---|
+| Qwen3-8B | **v7x-4** | 2x2x1 | 4 chips / 8 devices | 8 | Current high-throughput row in §4.2. v7x exposes 2 JAX devices/chip. |
 | Qwen3-8B | **v6e-4** | 2x2 | 4 | 4 | This is the slice we measured on. Single host; ~16 GB BF16 weights. |
 | Qwen3-32B | **v6e-4** | 2x2 | 4 | 4 | This is the slice we measured on. Single host; ~64 GB BF16 weights — fits with `--mem-fraction-static 0.8`. |
 
-Both fit on a single v6e-4 host with `bfloat16`. See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+Both v6e rows fit on a single v6e-4 host with `bfloat16`; the v7x row uses one 4-chip v7x slice. See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
@@ -345,7 +346,64 @@ evalscope eval \
 
 > Run **with thinking-on** for full reasoning capacity. Thinking-off would yield lower accuracy but ~10× faster wall-clock per question.
 
-### 4.2 Speed — SGL-JAX vs vLLM
+### 4.2 Speed
+
+#### High-throughput v7x-4 result (Qwen3-8B)
+
+> This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. Radix cache is disabled and DP scheduling uses `round_robin`, so the result is throughput-oriented and not prefix-cache dependent.
+
+**Test Environment**
+
+| Field | Value |
+|---|---|
+| Hardware | TPU v7x-4 (1 node x 4 chips, 8 JAX devices) |
+| Model | Qwen/Qwen3-8B (real BF16 weights) |
+| Tensor Parallelism | 8 |
+| Tested build | origin/main (`2d97c787f712f715784216f7c414a4f477ea8218`) |
+
+**Serving Flags Used**
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
+  --model-path /models/Qwen3-8B \
+  --trust-remote-code \
+  --reasoning-parser qwen3 \
+  --tp-size 8 \
+  --dtype bfloat16 \
+  --context-length 32768 \
+  --chunked-prefill-size 2048 \
+  --mem-fraction-static 0.90 \
+  --page-size 128 \
+  --max-running-requests 256 \
+  --disable-radix-cache \
+  --dp-schedule-policy round_robin \
+  --skip-server-warmup \
+  --host 0.0.0.0 --port 30000
+```
+
+**Benchmark Command**
+
+```bash
+PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
+  --backend sgl-jax \
+  --model /models/Qwen3-8B \
+  --tokenizer /models/Qwen3-8B \
+  --host 127.0.0.1 --port 30000 \
+  --dataset-name random \
+  --random-input-len 1024 --random-output-len 1024 \
+  --num-prompts 384 --max-concurrency 128 \
+  --random-range-ratio 1 \
+  --seed 42 \
+  --warmup-requests 0
+```
+
+**Test Results**
+
+| ISL | OSL | Max concurrency | Prompts | Input tok/s | Output tok/s | Peak output tok/s | Mean TTFT (ms) | Mean TPOT (ms) | Duration (s) | OK |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1024 | 1024 | 128 | 384 | 8521.48 | 8521.48 | 10266.00 | 943.13 | 14.09 | 46.14 | 384 |
+
+#### v6e-4 SGL-JAX vs vLLM comparison
 
 > **Layout E — variant × workload sweep on single hardware.** Qwen3-8B and Qwen3-32B on TPU v6e-4 (TP=4), sgl-jax vs vLLM across ISL values 1024, 4096, and 8192; OSL values 1 and 1024; and concurrency values 8, 16, 32, 64, 128, and 256.
 
@@ -393,8 +451,8 @@ for input_seq_len in "${input_seq_lens[@]}"; do
         --backend ${backend} \
         --dataset-name random \
         --num-prompts ${num_prompts} \
-        --random-input ${input_seq_len} \
-        --random-output ${output_seq_len} \
+        --random-input-len ${input_seq_len} \
+        --random-output-len ${output_seq_len} \
         --max-concurrency ${max_concurrency} \
         --random-range-ratio 1 \
         --warmup-requests 0 \

--- a/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md
+++ b/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md
@@ -458,7 +458,7 @@ evalscope eval \
 
 ### 4.3 Speed
 
-> **High-throughput v7x-16 row.** This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. Radix cache is disabled and DP scheduling uses `round_robin`, so the result is throughput-oriented and not prefix-cache dependent. Do **not** set `--reasoning-parser mimo` for raw throughput benchmarks; the parser adds per-token CPU work that distorts token rates.
+> **High-throughput v7x-16 row.** This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. DP scheduling uses `round_robin`. Do **not** set `--reasoning-parser mimo` for raw throughput benchmarks; the parser adds per-token CPU work that distorts token rates.
 
 **Test Environment**
 
@@ -487,7 +487,6 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
   --page-size 256 \
   --max-running-requests 256 \
   --attention-backend fa \
-  --disable-radix-cache \
   --dp-schedule-policy round_robin \
   --skip-server-warmup \
   --nnodes 4 --node-rank ${NODE_RANK} \

--- a/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md
+++ b/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md
@@ -4,7 +4,7 @@ title: "MiMo-V2.5-Pro"
 
 # MiMo-V2.5-Pro on SGL-JAX
 
-> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, thinking-on output correct, GSM8K accuracy 97.5% (200 examples, see §4.1), `bench_serving` numbers in §4.3. TPU v7x-16 has a launch path and AIME reference numbers in §4.2, but throughput is still pending.
+> **Validated recipe** — TPU v6e-64 path validated on sglang-jax 0.1.0: server starts, thinking-on output correct, GSM8K accuracy 97.5% (200 examples, see §4.1), and historical `bench_serving` numbers in §4.3. TPU v7x-16 has launch, AIME reference numbers in §4.2, and the current high-throughput row in §4.3.
 
 ## 1. Model Introduction
 
@@ -32,7 +32,7 @@ title: "MiMo-V2.5-Pro"
 | TPU | Topology | Chips per node | Nodes | Total chips | `--tp-size` | `--dp-size` | `--ep-size` | `--moe-backend` | Notes |
 |---|---|---|---|---|---|---|---|---|---|
 | **v6e-64** | `4x4x4` | 4 | 16 | 64 | 64 | 8 | 64 | `fused` | This is the slice we measured on. v6e is 1:1 chip↔device; see §2.4 SWA Pool Sizing for tradeoffs. GSM8K + bench_serving in §4. |
-| **v7x-16** | `2x2x4` | 4 | 4 | 16 chips / 32 devices | 32 | 4 | 32 | `fused` | Legacy launch path with AIME reference numbers. v7x exposes 2 JAX devices per chip. Throughput benchmark still pending. |
+| **v7x-16** | `2x2x4` | 4 | 4 | 16 chips / 32 devices | 32 | 4 | 32 | `fused` | Recommended throughput recipe in §4.3 plus AIME reference numbers in §4.2. v7x exposes 2 JAX devices per chip. |
 
 MiMo-V2.5-Pro is multi-host only — all nodes must be in the same TPU slice and reach each other on the JAX init port (`5000` by default) and the TPU process port (`8471`).
 
@@ -454,24 +454,46 @@ evalscope eval \
 | MiMo-V2.5-Pro | aime25 | AveragePass@1 | AIME2025-II | 15 | 1.0000 |
 | MiMo-V2.5-Pro | aime25 | AveragePass@1 | OVERALL | 30 | 0.9334 |
 
-> v7x-16 throughput is not published yet. Keep this path marked as partially validated until a `bench_serving` result is added.
+> The v7x-16 throughput row in §4.3 uses a shorter 32K context budget than the native 256K launch path above, so it should be treated as a high-throughput serving recipe rather than a max-context recipe.
 
 ### 4.3 Speed
 
-> **Layout F — single-workload sweep (one data point).** Standard chat (ISL=1000, OSL=1000), `max_concurrency=16`, 80 prompts, `seed=42`. Future PRs can add reasoning-typical workloads (long OSL) and concurrency sweeps. Do **not** set `--reasoning-parser mimo` for throughput benchmarks (the parser adds per-token CPU work that distorts raw token rates).
+> **High-throughput v7x-16 row.** This cookbook row uses fixed-length random requests (ISL=1024, OSL=1024), `max_concurrency=128`, 384 prompts, `random_range_ratio=1`, `seed=42`, and no warmup requests. Radix cache is disabled and DP scheduling uses `round_robin`, so the result is throughput-oriented and not prefix-cache dependent. Do **not** set `--reasoning-parser mimo` for raw throughput benchmarks; the parser adds per-token CPU work that distorts token rates.
 
 **Test Environment**
 
 | Field | Value |
 |---|---|
-| Hardware | TPU v6e-64 (16 nodes × 4 chips) |
-| Model | XiaomiMiMo/MiMo-V2.5-Pro (FP8) |
-| Tensor Parallelism | 64 |
-| Data Parallelism | 8 |
-| Expert Parallelism | 64 |
-| Tested build | sglang-jax 0.1.0 |
+| Hardware | TPU v7x-16 (4 nodes x 4 chips, 32 JAX devices) |
+| Model | XiaomiMiMo/MiMo-V2.5-Pro (real FP8 weights) |
+| Tensor Parallelism | 32 (tensor axis 8 via `--dp-size 4`) |
+| Data Parallelism | 4 |
+| Expert Parallelism | 32 |
+| Tested build | origin/main (`2d97c787f712f715784216f7c414a4f477ea8218`) |
 
-**Deployment Command** — same as [§2.3 Multi-host (v6e-64)](/autoregressive/Xiaomi/MiMo-V2.5-Pro#2-3-launch), without `--reasoning-parser`.
+**Serving Flags Used**
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
+  --model-path /models/MiMo-V2.5-Pro \
+  --trust-remote-code \
+  --tp-size 32 --dp-size 4 --ep-size 32 \
+  --moe-backend fused \
+  --dtype bfloat16 \
+  --context-length 32768 \
+  --chunked-prefill-size 4096 \
+  --mem-fraction-static 0.95 \
+  --swa-full-tokens-ratio 0.25 \
+  --page-size 256 \
+  --max-running-requests 256 \
+  --attention-backend fa \
+  --disable-radix-cache \
+  --dp-schedule-policy round_robin \
+  --skip-server-warmup \
+  --nnodes 4 --node-rank ${NODE_RANK} \
+  --dist-init-addr ${MASTER_ADDR} \
+  --host 0.0.0.0 --port 30000
+```
 
 **Benchmark Command**
 
@@ -482,50 +504,20 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
   --tokenizer /models/MiMo-V2.5-Pro \
   --host 127.0.0.1 --port 30000 \
   --dataset-name random \
-  --random-input-len 1000 --random-output-len 1000 \
-  --num-prompts 80 --max-concurrency 16 \
-  --seed 42
+  --random-input-len 1024 --random-output-len 1024 \
+  --num-prompts 384 --max-concurrency 128 \
+  --random-range-ratio 1 \
+  --seed 42 \
+  --warmup-requests 0
 ```
 
 **Test Results**
 
-```text
-============ Serving Benchmark Result ============
-Backend:                                 sgl-jax
-Traffic request rate:                    inf
-Max request concurrency:                 16
-Successful requests:                     80
-Benchmark duration (s):                  81.53
-Total input tokens:                      37205
-Total generated tokens:                  38314
-Request throughput (req/s):              0.98
-Input token throughput (tok/s):          456.31
-Output token throughput (tok/s):         469.91
-Peak output token throughput (tok/s):    688.00
-Peak concurrent requests:                20
-Total token throughput (tok/s):          926.22
-Concurrency:                             13.68
-----------------End-to-End Latency----------------
-Mean E2E Latency (ms):                   13939.08
-Median E2E Latency (ms):                 13182.43
-P90 E2E Latency (ms):                    24648.15
-P99 E2E Latency (ms):                    29268.58
----------------Time to First Token----------------
-Mean TTFT (ms):                          466.86
-Median TTFT (ms):                        289.31
-P99 TTFT (ms):                           1515.35
------Time per Output Token (excl. 1st token)------
-Mean TPOT (ms):                          28.66
-Median TPOT (ms):                        28.54
-P99 TPOT (ms):                           37.07
----------------Inter-Token Latency----------------
-Mean ITL (ms):                           28.19
-Median ITL (ms):                         23.52
-P95 ITL (ms):                            23.95
-P99 ITL (ms):                            264.43
-Max ITL (ms):                            1290.76
-==================================================
-```
+| ISL | OSL | Max concurrency | Prompts | Input tok/s | Output tok/s | Peak output tok/s | Mean TTFT (ms) | Mean TPOT (ms) | Duration (s) | OK |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1024 | 1024 | 128 | 384 | 3516.81 | 3516.81 | 4096.00 | 2516.97 | 33.94 | 111.81 | 384 |
+
+> Historical v6e-64 baseline: `1000/1000/c16`, 80 prompts, 469.91 output tok/s, 688.00 peak output tok/s. The v7x-16 row above uses fewer chips and is the recommended throughput-oriented recipe.
 
 ## Additional Resources
 

--- a/docs/cookbook/autoregressive/index.md
+++ b/docs/cookbook/autoregressive/index.md
@@ -98,7 +98,7 @@ Diffusion image/video generation models live in [Diffusion recipes](/diffusion).
 | Goal | Clone from |
 |---|---|
 | Single-host dense model | [`Qwen/Qwen.md`](/autoregressive/Qwen/Qwen) ✅ or [`Llama/Llama3.1.md`](/autoregressive/Llama/Llama3.1) ✅ |
-| Dense model with benchmark comparison | [`Qwen/Qwen3.md`](/autoregressive/Qwen/Qwen3) ✅ |
+| Dense model with benchmark rows | [`Qwen/Qwen3.md`](/autoregressive/Qwen/Qwen3) ✅ |
 | Single-host MoE with backend choice | [`Xiaomi/MiMo-V2-Flash.md`](/autoregressive/Xiaomi/MiMo-V2-Flash) ✅ |
 | Vision-language chat | [`Qwen/Qwen2.5-VL.md`](/autoregressive/Qwen/Qwen2.5-VL) ✅ |
 | Large multi-node MoE with GKE manifest | [`Xiaomi/MiMo-V2.5-Pro.md`](/autoregressive/Xiaomi/MiMo-V2.5-Pro) ✅ |

--- a/docs/cookbook/autoregressive/index.md
+++ b/docs/cookbook/autoregressive/index.md
@@ -10,8 +10,8 @@ End-to-end serving recipes for autoregressive models on SGL-JAX, organized by ve
 
 | Emoji | Meaning |
 |---|---|
-| ✅ | **Validated** — primary model / hardware path empirically tuned with reference benchmark numbers in §4 |
-| 🧪 | **Partially validated** — at least one variant / hardware path has real benchmark output; other variants, matrix cells, or current-build reruns are still pending |
+| ✅ | **Validated** — primary model / hardware path empirically validated for launch, invocation, and/or accuracy; throughput rows are included only when the datapoint is release-quality |
+| 🧪 | **Partially validated** — at least one variant / hardware path has real validation output; other variants, matrix cells, or current-build reruns are still pending |
 | 🚧 | **Starter** — launch command derived from HF model card; not yet measured. PR back tested numbers to upgrade to 🧪 or ✅ |
 | 📝 | **Planned** — architecture supported by the runtime but no recipe yet (or model release pending) |
 | 🚫 | **Blocked** — runnable path blocked by an upstream weight format / HBM / runtime constraint; banner cites the root cause and unblocking plan |
@@ -30,7 +30,7 @@ End-to-end serving recipes for autoregressive models on SGL-JAX, organized by ve
 
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
-| ✅ | GLM-4.5-Air (106B) | [`GLM/GLM-4.5.md`](/autoregressive/GLM/GLM-4.5) | v6e-32 | MoE + reasoning/tool (`glm45`) |
+| ✅ | GLM-4.5-Air (106B) | [`GLM/GLM-4.5.md`](/autoregressive/GLM/GLM-4.5) | v6e-32 / v7x-4 | MoE + reasoning/tool (`glm45`) |
 
 ### Google — `Google/`
 
@@ -42,20 +42,20 @@ End-to-end serving recipes for autoregressive models on SGL-JAX, organized by ve
 
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
-| ✅ | Grok-2 (base) | [`Grok/Grok2.md`](/autoregressive/Grok/Grok2) | v6e-32 | MoE (8 experts, 2 active) |
+| ✅ | Grok-2 (base) | [`Grok/Grok2.md`](/autoregressive/Grok/Grok2) | v6e-64 | MoE (8 experts, 2 active) |
 
 ### InclusionAI — `InclusionAI/`
 
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
-| ✅ | Ling 2.6-1T | [`InclusionAI/Ling-2.6.md`](/autoregressive/InclusionAI/Ling-2.6) | v6e-64 | MoE + linear attn |
+| ✅ | Ling 2.6-1T | [`InclusionAI/Ling-2.6.md`](/autoregressive/InclusionAI/Ling-2.6) | v6e-64 / v7x-16 | MoE + linear attn |
 
 ### Llama — `Llama/`
 
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
 | ✅ | Llama 3.1 8B-Instruct | [`Llama/Llama3.1.md`](/autoregressive/Llama/Llama3.1) | v6e-4 | dense |
-| ✅ | Llama 3.3 70B | [`Llama/Llama3.3-70B.md`](/autoregressive/Llama/Llama3.3-70B) | v6e-32 | dense |
+| ✅ | Llama 3.3 70B | [`Llama/Llama3.3-70B.md`](/autoregressive/Llama/Llama3.3-70B) | v6e-16 / v7x-4 | dense |
 
 ### Moonshotai — `Moonshotai/`
 
@@ -68,8 +68,8 @@ End-to-end serving recipes for autoregressive models on SGL-JAX, organized by ve
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
 | ✅ | Qwen-7B-Chat | [`Qwen/Qwen.md`](/autoregressive/Qwen/Qwen) | v6e-4 | dense |
-| ✅ | Qwen3-8B / Qwen3-32B | [`Qwen/Qwen3.md`](/autoregressive/Qwen/Qwen3) | v6e-4 | dense + reasoning (`qwen3`) + tool (`qwen25`) |
-| ✅ | Qwen3-30B-A3B | [`Qwen/Qwen3-MoE.md`](/autoregressive/Qwen/Qwen3-MoE) | v6e-16 | MoE + reasoning (`qwen3`) + tool (`qwen25`) |
+| ✅ | Qwen3-8B / Qwen3-32B | [`Qwen/Qwen3.md`](/autoregressive/Qwen/Qwen3) | v6e-4; 8B v7x-4 | dense + reasoning (`qwen3`) + tool (`qwen25`) |
+| ✅ | Qwen3-30B-A3B | [`Qwen/Qwen3-MoE.md`](/autoregressive/Qwen/Qwen3-MoE) | v6e-16 / v7x-4 | MoE + reasoning (`qwen3`) + tool (`qwen25`) |
 | ✅ | Qwen2.5-VL (3B / 7B / 32B / 72B) | [`Qwen/Qwen2.5-VL.md`](/autoregressive/Qwen/Qwen2.5-VL) | v6e-4 for 3B/7B/32B; 72B pending | vision-language autoregressive decoder |
 | 📝 | Qwen2 / Qwen2-MoE | _no recipe — same family runtime path_ | — | dense / MoE |
 
@@ -81,7 +81,7 @@ End-to-end serving recipes for autoregressive models on SGL-JAX, organized by ve
 | ✅ | MiMo-V2.5-Pro | [`Xiaomi/MiMo-V2.5-Pro.md`](/autoregressive/Xiaomi/MiMo-V2.5-Pro) | v6e-64 (v7x-16 alternative) | MoE + reasoning/tool (`mimo`) |
 | ✅ | MiMo-7B-RL | [`Xiaomi/MiMo-7B.md`](/autoregressive/Xiaomi/MiMo-7B) | v6e-4 | dense + reasoning/tool (`mimo`) |
 
-> Upgrade path: 🚧 → 🧪 requires real `evalscope` (accuracy) or `bench_serving` (throughput) output for at least one variant / hardware path. 🧪 → ✅ requires the recipe's claimed primary path to have complete **Test Environment → Deployment Command → Benchmark Command → Test Results** evidence without unresolved required cells. See [`Xiaomi/MiMo-V2-Flash.md` §4](/autoregressive/Xiaomi/MiMo-V2-Flash#4-benchmark) for the canonical four-section form.
+> Upgrade path: 🚧 → 🧪 requires real `evalscope` (accuracy), launch validation, or `bench_serving` output for at least one variant / hardware path. 🧪 → ✅ requires the recipe's claimed primary path to have complete launch and invocation evidence without unresolved required cells. Publish throughput tables only for representative release-quality datapoints; otherwise keep a benchmark command template without a result row.
 
 ## What "autoregressive" means here
 


### PR DESCRIPTION
## Summary

This PR updates the autoregressive cookbook benchmark guidance for TPU v7x runs.

- Adds high-throughput v7x result rows only where the datapoint is representative enough to publish.
- Keeps working launch and benchmark templates for models without published throughput rows.
- Updates the autoregressive index so `Validated` no longer implies every recipe must publish throughput numbers.
- Keeps private artifact paths out of cookbook pages and this PR body; the benchmark evidence below is copied into the appendix so reviewers do not need artifact access.

## Published Throughput Rows

The cookbook now publishes v7x throughput rows for:

- Ling-2.6-1T
- Qwen3-8B
- Qwen3-30B-A3B
- GLM-4.5-Air
- Llama-3.3-70B
- MiMo-V2.5-Pro

DeepSeek-V3, DeepSeek-R1, and Grok-2 keep recipe / benchmark command templates without published throughput rows.

## Validation

- `git diff --check -- docs/cookbook/autoregressive/...`
- fenced-code-block balance check over touched cookbook files
- `rg "blog|LMSYS" docs/cookbook/autoregressive/InclusionAI/Ling-2.6.md` returned no matches
- verified cookbook pages do not contain private artifact paths or external benchmark-comparison wording

## Benchmark Evidence Appendix

All published benchmark rows use fixed-length random requests with `--random-range-ratio 1`, `--seed 42`, `--warmup-requests 0`, and the serving args listed under each model. The excerpts below copy the key benchmark log lines into the PR so reviewers do not need private artifact access.

### Ling-2.6-1T

```text
Hardware: TPU v7x-16 (2x2x4), 16 chips / 32 JAX devices
Workload: random 1024 input / 1024 output, max concurrency 32, prompts 160
Successful requests:                     160
Benchmark duration (s):                  143.08
Input token throughput (tok/s):          1145.13
Output token throughput (tok/s):         1145.13
Mean TTFT (ms):                          1078.91
Mean TPOT (ms):                          26.91
```

Serving args: `tp=32 dp=8 ep=32`, `--moe-backend fused_v2`, `--disable-radix-cache`, `--context-length 32768`, `--chunked-prefill-size 2048`, `--max-running-requests 64`, `--page-size 256`, explicit precompile buckets `bs=16/32/64`, tokens `1024/2048/4096/8192/16384`.

### Qwen3-8B

```text
Hardware: TPU v7x-4 (2x2x1), 4 chips / 8 JAX devices
Workload: random 1024 input / 1024 output, max concurrency 128, prompts 384
Successful requests:                     384
Benchmark duration (s):                  46.14
Input token throughput (tok/s):          8521.48
Output token throughput (tok/s):         8521.48
Peak output token throughput (tok/s):    10266.00
Mean TTFT (ms):                          943.13
Mean TPOT (ms):                          14.09
```

Serving args: `tp=8`, `--reasoning-parser qwen3`, `--context-length 32768`, `--chunked-prefill-size 2048`, `--max-running-requests 256`, `--page-size 128`.

### Qwen3-30B-A3B

```text
Hardware: TPU v7x-4 (2x2x1), 4 chips / 8 JAX devices
Workload: random 1024 input / 1024 output, max concurrency 128, prompts 384
Successful requests:                     384
Benchmark duration (s):                  63.63
Input token throughput (tok/s):          6179.45
Output token throughput (tok/s):         6179.45
Peak output token throughput (tok/s):    7564.00
Mean TTFT (ms):                          1833.34
Mean TPOT (ms):                          18.91
```

Serving args: `tp=8 ep=8`, `--moe-backend epmoe`, `--context-length 32768`, `--chunked-prefill-size 2048`, `--max-running-requests 256`, `--page-size 128`.

### GLM-4.5-Air

```text
Hardware: TPU v7x-4 (2x2x1), 4 chips / 8 JAX devices
Workload: random 1024 input / 1024 output, max concurrency 128, prompts 384
Successful requests:                     384
Benchmark duration (s):                  97.97
Input token throughput (tok/s):          4013.55
Output token throughput (tok/s):         4013.55
Peak output token throughput (tok/s):    4992.00
Mean TTFT (ms):                          3126.11
Mean TPOT (ms):                          28.84
```

Serving args: `tp=8 ep=8`, `--moe-backend epmoe`, `--context-length 32768`, `--chunked-prefill-size 2048`, `--max-running-requests 256`, `--page-size 128`.

### Llama-3.3-70B

```text
Hardware: TPU v7x-4 (2x2x1), 4 chips / 8 JAX devices
Workload: random 1024 input / 1024 output, max concurrency 128, prompts 384
Successful requests:                     384
Benchmark duration (s):                  108.93
Input token throughput (tok/s):          3609.65
Output token throughput (tok/s):         3609.65
Peak output token throughput (tok/s):    4992.00
Mean TTFT (ms):                          4796.46
Mean TPOT (ms):                          30.78
```

Serving args: `tp=8`, `--context-length 32768`, `--chunked-prefill-size 2048`, `--max-running-requests 256`, `--page-size 128`.

### MiMo-V2.5-Pro

```text
Hardware: TPU v7x-16 (2x2x4), 16 chips / 32 JAX devices
Workload: random 1024 input / 1024 output, max concurrency 128, prompts 384
Successful requests:                     384
Benchmark duration (s):                  111.81
Input token throughput (tok/s):          3516.81
Output token throughput (tok/s):         3516.81
Peak output token throughput (tok/s):    4096.00
Mean TTFT (ms):                          2516.97
Mean TPOT (ms):                          33.94
```

Serving args: `tp=32 dp=4 ep=32`, `--moe-backend fused`, `--context-length 32768`, `--chunked-prefill-size 4096`, `--max-running-requests 256`, `--swa-full-tokens-ratio 0.25`, `--page-size 256`.
