### PR TITLE
Improve DP scheduling defaults for radix cache

### DIFF
--- a/docs/architecture/03-scheduler.md
+++ b/docs/architecture/03-scheduler.md
@@ -80,7 +80,7 @@ The `Scheduler` class inherits from three mixins:
 | `grammar_queue` | `list[Req]` | Asynchronous grammar compilation queue |
 | `aborted_reqs` | `dict[str, Req]` | Aborted requests (Request ID → Req mapping) |
 | `dp_size` | `int` | Number of Data Parallel ranks |
-| `dp_schedule_policy` | `str` | Policy for assigning new requests to DP ranks |
+| `dp_schedule_policy` | `str` | Policy for assigning new requests to DP ranks; auto-derived at startup when unset |
 
 ---
 
@@ -236,13 +236,14 @@ The `DFS_WEIGHT` policy traverses the Radix Tree, computing the number of waitin
 
 ### Data Parallel Request Assignment
 
-Data Parallel does not change the number of Scheduler processes. After receiving a new request, the Scheduler assigns `Req.dp_rank`, after which all batch construction, KV Cache allocation, and Attention Metadata are partitioned by DP rank. Three DP assignment policies are currently supported:
+Data Parallel does not change the number of Scheduler processes. After receiving a new request, the Scheduler assigns `Req.dp_rank`, after which all batch construction, KV Cache allocation, and Attention Metadata are partitioned by DP rank. If `--dp-schedule-policy` is unset, startup chooses `cache_aware` when radix cache is enabled and `min_running_queue` when `--disable-radix-cache` is set or Pathways PD is enabled. Explicit policy values remain available for tuning and debugging:
 
 | `dp_schedule_policy` | Description |
 |---|---|
-| `min_running_queue` | Picks the DP rank with the fewest currently running requests |
+| `cache_aware` | Prefers eligible DP ranks that hold a substantial reusable radix-cache prefix, preserves large-load-skew balancing, and uses shape-aware selection on cache misses |
+| `shape_aware` | Balances input/prefill and output/decode token load separately by minimizing the post-admission bottleneck dimension |
+| `min_running_queue` | Picks the DP rank with the fewest currently running requests, then scheduled tokens |
 | `round_robin` | Rotates new requests across ranks |
-| `cache_aware` | Prefer ranks with a substantial cached prefix while falling back to load balancing under skew |
 
 `waiting_queue` is still a Scheduler-level queue, but each `Req` already carries a target `dp_rank`. When constructing batches, `ScheduleBatch.reqs_info` keeps a `ScheduleReqsInfo` per rank, containing that rank's `reqs`, `chunked_req`, `input_ids`, `req_pool_indices`, `seq_lens`, and `out_cache_loc`; `per_dp_bs_size` records each rank's padded batch size, used by the execution side to construct DP-uniform inputs.
 

--- a/docs/architecture/13-configuration-reference.md
+++ b/docs/architecture/13-configuration-reference.md
@@ -131,7 +131,7 @@ The table below summarizes the most commonly used launch parameters, recommended
 | `device_indexes` | `list[int] \| None` | `None` | Device indices used by the mesh |
 | `tp_size` | `int` | `1` | Tensor parallelism degree |
 | `dp_size` | `int` | `1` | Data parallelism degree; the Scheduler partitions requests and batches by DP rank inside the same process |
-| `dp_schedule_policy` | `str` | `"min_running_queue"` | DP rank assignment policy (`min_running_queue` / `round_robin` / `cache_aware`) |
+| `dp_schedule_policy` | `str \| None` | `None` (auto) | DP rank assignment policy (`cache_aware` / `shape_aware` / `min_running_queue` / `round_robin`) |
 | `ep_size` | `int` | `1` | Expert parallelism degree |
 | `ep_num_redundant_experts` | `int` | `0` | Number of redundant experts for EP load balancing |
 | `ep_dispatch_algorithm` | `str \| None` | `None` | EP dispatch mode (`static` / `dynamic` / `fake`) |
@@ -148,7 +148,7 @@ The table below summarizes the most commonly used launch parameters, recommended
 
 **`tp_size` / `dp_size`**: `tp_size` denotes the model tensor-parallel configuration of the total parallel device count, and `dp_size` denotes the number of Data Parallel ranks partitioned within the same Scheduler. The execution-side mesh shape is `(dp_size, tp_size // dp_size)`, with axis names `(data, tensor)`. Therefore the actual TP width on the attention side is `tp_size // dp_size`.
 
-**`dp_schedule_policy`**: Controls which DP rank a new request is assigned to. `min_running_queue` selects the rank with the fewest currently running requests; `round_robin` cycles through ranks; `cache_aware` routes by prefix-cache affinity when the load is balanced enough, and falls back toward the least-loaded rank under large skew.
+**`dp_schedule_policy`**: Controls which DP rank a new request is assigned to. If unset, startup chooses `cache_aware` when radix cache is enabled and `min_running_queue` when `--disable-radix-cache` is set or Pathways PD is enabled. `cache_aware` keeps prefix affinity as the first-order signal, falls back to shape-aware routing on cache misses, and still overrides cache affinity under large request-count skew. `shape_aware` balances input/prefill and output/decode token load separately by minimizing the post-admission bottleneck dimension, and is available as an explicit tuning option. `min_running_queue` selects the rank with the fewest currently running requests, then scheduled tokens; `round_robin` cycles through ranks.
 
 **`enable_sequence_parallel`**: Defaults to `False`. When set to `True`, `srt/utils/parallel_utils.py::should_scatter()` decides whether a specific row-parallel Linear actually performs reduce-scatter — only when the layer explicitly declares `output_scatter_dimension`, the per-device slice is ≥ `global_config.tpu_scatter_min_local_size`, and divisibility holds, does it take effect; otherwise it falls back to the original partition spec automatically. Currently wired up in `models/grok.py`; other models will only be affected after explicitly setting `output_scatter_dimension` on their Linear layers.
 

--- a/docs/cookbook/base/launch-flags-reference.md
+++ b/docs/cookbook/base/launch-flags-reference.md
@@ -34,6 +34,7 @@ grep -n 'add_argument' python/sgl_jax/srt/server_args.py
 |---|---|---|
 | `--tensor-parallel-size` / `--tp-size` | `1` | Total JAX devices across all nodes. See [`tpu-topology-reference.md`](/base/tpu-topology-reference) for the v7x 2-devices-per-chip rule. |
 | `--data-parallel-size` / `--dp-size` | `1` | DP factor for the **attention** path only. Attention TP becomes `tp_size / dp_size`. MoE layers still run with full `ep_size`. |
+| `--dp-schedule-policy` | auto | DP rank assignment policy. If unset, radix-cache serving uses `cache_aware`; `--disable-radix-cache` and Pathways PD use `min_running_queue`. Explicit choices are `cache_aware`, `shape_aware`, `min_running_queue`, and `round_robin`; use non-default choices as workload-specific tuning overrides. |
 | `--ep-size` | `1` | Expert parallelism. Typically `--ep-size == --tp-size` for MoE models. |
 
 ## 3. KV cache & sequence length

--- a/docs/features/server_arguments.md
+++ b/docs/features/server_arguments.md
@@ -48,9 +48,18 @@ For reusable Docker, GKE, and SkyPilot launchers, see [Deployment](../deployment
 |---|---|
 | `--model-path`, `--model` | Local path or Hugging Face repo id for the model weights. |
 | `--tokenizer-path` | Override the tokenizer location when it differs from the model path. |
+| `--tokenizer-mode` | Select `auto` fast-tokenizer usage or force `slow` tokenization. |
+| `--tokenizer-backend` | Select the tokenizer implementation, such as Hugging Face or `fastokens`. |
+| `--skip-tokenizer-init` | Skip tokenizer initialization; requests must provide `input_ids`. |
+| `--load-format` | Select checkpoint loading format, such as `auto`, `safetensors`, `dummy`, `gguf`, or `layered`. |
+| `--model-loader-extra-config` | Pass load-format-specific JSON config through to the selected model loader. |
 | `--trust-remote-code` | Allow model-specific code from the model repository. Common for Qwen-derived and MiMo recipes. |
 | `--context-length` | Override the model context length from config. |
+| `--max-seq-len` | Alias for setting the maximum model sequence length. |
+| `--is-embedding` | Serve a CausalLM as an embedding model. |
 | `--revision` | Pin a branch, tag, or commit for model loading. |
+| `--model-impl` | Select SGLang-native, Transformers, or automatic model implementation. |
+| `--model-layer-nums` | Load only the first N model layers, mainly for profiling or bring-up. |
 | `--json-model-override-args` | Patch selected model config fields, such as `architectures`, before loading. |
 | `--multimodal` | Use the multimodal server argument class and multimodal HTTP entrypoint. |
 
@@ -65,6 +74,16 @@ For reusable Docker, GKE, and SkyPilot launchers, see [Deployment](../deployment
 | `--stream-interval` | Control token interval for streaming responses. |
 | `--stream-output` | Return output as disjoint streamed segments. |
 | `--grammar-backend` | Select the backend for structured output constraints. |
+| `--constrained-json-whitespace-pattern` | Customize allowed JSON whitespace for llguidance constrained decoding. |
+| `--constrained-json-disable-any-whitespace` | Force compact JSON output for llguidance constrained decoding. |
+| `--api-key` | Require an API key for the OpenAI-compatible server. |
+| `--served-model-name` | Override the model name returned by `/v1/models`. |
+| `--file-storage-path` | Backend storage path for uploaded files. |
+| `--reasoning-parser` | Parse reasoning-model outputs with a supported detector. |
+| `--tool-call-parser` | Parse tool-call outputs for OpenAI-compatible function/tool calling. |
+| `--preferred-sampling-params` | JSON sampling defaults returned by `/get_model_info`. |
+| `--allow-auto-truncate` | Truncate over-length requests instead of returning an error. |
+| `--enable-tokenizer-batch-encode` | Batch tokenization for multi-text requests when inputs are not multimodal or pre-tokenized. |
 
 ## Precision, Quantization, and Dtype
 
@@ -85,7 +104,9 @@ For reusable Docker, GKE, and SkyPilot launchers, see [Deployment](../deployment
 |---|---|
 | `--tensor-parallel-size`, `--tp-size` | Total tensor-parallel JAX devices. |
 | `--data-parallel-size`, `--dp-size` | Data parallelism factor for supported execution paths. |
+| `--dp-schedule-policy` | DP rank assignment policy. If unset, radix-cache serving uses `cache_aware`; `--disable-radix-cache` and Pathways PD use `min_running_queue`. Explicit choices are `cache_aware`, `shape_aware`, `min_running_queue`, and `round_robin`; use non-default choices as workload-specific tuning overrides. |
 | `--ep-size` | Expert parallelism size for MoE models. |
+| `--ep-num-redundant-experts` | Add redundant physical experts for EP load balancing. |
 | `--ep-dispatch-algorithm` | Expert dispatch algorithm: `static`, `dynamic`, or `fake`. |
 | `--enable-sequence-parallel` | Enable sequence parallelism. |
 | `--nnodes` | Number of serving nodes. |
@@ -103,16 +124,45 @@ For TPU topology math, see the cookbook `base/tpu-topology-reference.md` page.
 | `--max-running-requests` | Maximum number of active decode requests. |
 | `--max-total-tokens` | Explicit token pool size; normally derived from memory limits. |
 | `--chunked-prefill-size` | Prefill chunk size. `-1` disables chunked prefill. |
+| `--enable-mixed-chunk` | Allow prefill and decode requests to share a batch when chunked prefill is enabled. |
 | `--max-prefill-tokens` | Maximum prefill tokens admitted into a batch. |
 | `--disable-overlap-schedule` | Disable scheduler/model-worker overlap. |
 | `--schedule-policy` | Request scheduling policy. |
 | `--schedule-conservativeness` | How conservatively the scheduler admits requests. |
 | `--page-size` | KV page size. |
 | `--swa-full-tokens-ratio` | Sliding-window/full-attention KV token ratio for hybrid attention models. |
-| `--disable-radix-cache` | Disable prefix cache reuse. |
+| `--recurrent-state-memory-ratio` | Recurrent-state memory budget ratio for hybrid recurrent models such as Kimi-Linear. |
+| `--max-recurrent-state-size` | Explicit total recurrent-state slot count across DP ranks. |
+| `--disable-hybrid-swa-memory` | Disable the hybrid sliding-window/full-attention memory optimization. |
+| `--disable-radix-cache` | Disable prefix cache reuse. This also makes the unset DP schedule policy resolve to `min_running_queue`; Pathways PD follows the same default because it uses chunk cache internally. |
 | `--enable-unified-radix-tree` | Use unified radix tree mode. |
+| `--hicache-storage` | Enable HiCache host KV offload with `none`, keep it off with `disable`, or reserve `file` for future file-backed storage. |
+| `--hicache-ratio` | Size the HiCache host pool relative to the device KV pool. |
+| `--hicache-write-through-threshold` | Minimum prefix hit count before backing a node up to host memory. |
+| `--hicache-write-policy` | Select HiCache write-through, selective write-through, or write-back behavior. |
 
 For deeper scheduler behavior, see [Scheduler](../architecture/03-scheduler.md) and [KV Cache](../architecture/07-kv-cache.md).
+
+## Runtime, Logging, and Metrics
+
+| Argument | Purpose |
+|---|---|
+| `--device` | Select the serving device, or leave unset for auto-detection. |
+| `--device-indexes` | Restrict mesh construction to specific local device indexes. |
+| `--random-seed` | Seed used by server-side sampling paths. |
+| `--download-dir` | Hugging Face model download/cache directory. |
+| `--sleep-on-idle` | Lower CPU usage while the server is idle. |
+| `--watchdog-timeout` | Crash the server if a forward batch hangs beyond the timeout. |
+| `--log-level`, `--log-level-http` | Control application and HTTP server logging verbosity. |
+| `--log-requests`, `--log-requests-level` | Log request metadata and optionally sampling parameters or payloads. |
+| `--crash-dump-folder` | Dump recent requests to a directory before crash handling. |
+| `--enable-metrics` | Enable Prometheus metrics. |
+| `--enable-metrics-for-all-schedulers` | Record scheduler metrics for all TP ranks instead of TP rank 0 only. |
+| `--bucket-time-to-first-token`, `--bucket-inter-token-latency`, `--bucket-e2e-request-latency` | Customize latency histogram buckets for metrics. |
+| `--decode-log-interval` | Control the decode-batch logging interval. |
+| `--enable-request-time-stats-logging` | Emit per-request timing statistics in logs. |
+| `--kv-events-config` | Enable NVIDIA Dynamo KV event publishing from a JSON config. |
+| `--enable-cache-report` | Include cached-token counts in OpenAI-compatible usage details. |
 
 ## JIT and Kernel Backends
 

--- a/python/sgl_jax/srt/managers/dp_rank_assignment.py
+++ b/python/sgl_jax/srt/managers/dp_rank_assignment.py
@@ -29,7 +29,10 @@ def assign_dp_ranks(
     dp_size: int,
     dp_schedule_policy: str,
     select_round_robin_dp: Callable[[], int],
-    select_cache_aware_dp: Callable[[TokenizedGenerateReqInput, list[int], list[int]], int | None],
+    select_cache_aware_dp: Callable[
+        [TokenizedGenerateReqInput, list[int], list[int], list[int], list[int]],
+        int | None,
+    ],
     select_min_running_dp: Callable[[list[int], list[int]], int | None],
     select_shape_aware_dp: Callable[
         [int, int, list[int], list[int], list[int], list[int]], int | None
@@ -59,11 +62,11 @@ def assign_dp_ranks(
 
     pending_counts = [0] * dp_size
     pending_token_counts = [0] * dp_size
-    # shape_aware balances prefill (input) and decode (output) separately, so it
-    # also needs the input/output split of requests assigned earlier in this same
-    # intake tick -- otherwise a burst routes against a stale snapshot and
-    # mis-balances. Only tracked for that policy to avoid overhead elsewhere.
-    is_shape_aware = dp_schedule_policy == "shape_aware"
+    # shape_aware balances prefill (input) and decode (output) separately. cache_aware
+    # needs the same split for its no-holder/cache-miss shape-aware fallback. Include
+    # requests assigned earlier in this intake tick, otherwise bursts route against a
+    # stale snapshot and mis-balance.
+    tracks_pending_io = dp_schedule_policy in ("shape_aware", "cache_aware")
     pending_input_counts = [0] * dp_size
     pending_output_counts = [0] * dp_size
     ready_reqs: list[Any] = []
@@ -72,7 +75,7 @@ def assign_dp_ranks(
     def track(req, dp_rank):
         pending_counts[dp_rank] += 1
         pending_token_counts[dp_rank] += estimate_req_tokens(req)
-        if is_shape_aware:
+        if tracks_pending_io:
             in_tok, out_tok = estimate_req_io_tokens(req)
             pending_input_counts[dp_rank] += in_tok
             pending_output_counts[dp_rank] += out_tok
@@ -102,8 +105,14 @@ def assign_dp_ranks(
             continue
 
         if dp_schedule_policy == "cache_aware":
-            dp_rank = select_cache_aware_dp(req, pending_counts, pending_token_counts)
-        elif is_shape_aware:
+            dp_rank = select_cache_aware_dp(
+                req,
+                pending_counts,
+                pending_token_counts,
+                pending_input_counts,
+                pending_output_counts,
+            )
+        elif dp_schedule_policy == "shape_aware":
             item_in, item_out = estimate_req_io_tokens(req)
             dp_rank = select_shape_aware_dp(
                 item_in,

--- a/python/sgl_jax/srt/managers/dp_schedule_policy.py
+++ b/python/sgl_jax/srt/managers/dp_schedule_policy.py
@@ -67,8 +67,12 @@ def pick_cache_aware_dp(
     token_counts: list[int],
     matches: dict[int, int],
     prompt_len: int,
+    input_counts: list[int],
+    output_counts: list[int],
+    item_input: int = 0,
+    item_output: int = 0,
 ) -> int | None:
-    """Cache-affinity DP policy with soft load balancing.
+    """Cache-affinity DP policy with shape-aware miss fallback.
 
     1. If the load skew across eligible ranks is large
        (``max-min > BALANCE_ABS`` and ``max > min*BALANCE_REL``), ignore cache
@@ -76,10 +80,11 @@ def pick_cache_aware_dp(
     2. Otherwise route to the least-loaded rank among the *holders* -- ranks whose
        cached prefix covers more than ``CACHE_THRESHOLD`` of the prompt -- so a hot
        prefix spreads across all its holders by load.
-    3. No holders (or no usable ``prompt_len``) -> least-loaded rank.
+    3. No holders (or no usable ``prompt_len``) -> shape-aware fallback.
 
-    Load order is ``(running, tokens, rank)``. Eligibility (the per-rank admission
-    cap) is decided by the caller; this only chooses among eligible ranks.
+    Holder and large-skew load order is ``(running, tokens, rank)``. Eligibility
+    (the per-rank admission cap) is decided by the caller; this only chooses among
+    eligible ranks.
     """
     if not eligible:
         return None
@@ -97,7 +102,7 @@ def pick_cache_aware_dp(
         if holders:
             return least_loaded(holders)
 
-    return least_loaded(eligible)
+    return pick_shape_aware_dp(eligible, input_counts, output_counts, item_input, item_output)
 
 
 def pick_shape_aware_dp(

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -868,13 +868,15 @@ class Scheduler(
         req: TokenizedGenerateReqInput,
         extra_counts: list[int],
         extra_token_counts: list[int],
+        extra_input_counts: list[int],
+        extra_output_counts: list[int],
     ) -> int | None:
-        """Route ``req`` by cache affinity with soft load balancing.
+        """Route ``req`` by cache affinity with shape-aware miss fallback.
 
         Probes each eligible rank's cached prefix length, then defers to
         ``pick_cache_aware_dp``: balance on large load skew, else least-loaded
-        among the ranks holding a substantial cached prefix. Returns None if all
-        DP ranks are full.
+        among the ranks holding a substantial cached prefix, else shape-aware
+        selection. Returns None if all DP ranks are full.
         """
         if self.dp_size == 1:
             return 0
@@ -892,7 +894,22 @@ class Scheduler(
             for dp_rank in eligible:
                 matches[dp_rank] = self._cached_prefix_len(token_ids, extra_key, dp_rank)
 
-        return pick_cache_aware_dp(eligible, counts, token_counts, matches, prompt_len)
+        running_input, running_output = self._get_dp_io_snapshot()
+        input_counts = [running_input[i] + extra_input_counts[i] for i in range(self.dp_size)]
+        output_counts = [running_output[i] + extra_output_counts[i] for i in range(self.dp_size)]
+        item_input, item_output = self._estimate_req_input_output_tokens(req)
+
+        return pick_cache_aware_dp(
+            eligible,
+            counts,
+            token_counts,
+            matches,
+            prompt_len,
+            input_counts,
+            output_counts,
+            item_input,
+            item_output,
+        )
 
     def _get_dp_io_snapshot(self) -> tuple[list[int], list[int]]:
         """Return per-DP (input_tokens, output_tokens) for in-flight scheduled work.

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -123,7 +123,7 @@ class ServerArgs:
 
     # Data parallel
     dp_size: int = 1
-    dp_schedule_policy: str = "min_running_queue"
+    dp_schedule_policy: str | None = None
 
     # Logging
     log_level: str = "info"
@@ -478,6 +478,10 @@ class ServerArgs:
                     "hicache_write_policy must be one of write_through/"
                     f"write_through_selective/write_back, got {self.hicache_write_policy}"
                 )
+
+        if self.dp_schedule_policy is None:
+            use_no_radix_default = self.disable_radix_cache or bool(self.pd_disaggregation)
+            self.dp_schedule_policy = "min_running_queue" if use_no_radix_default else "cache_aware"
 
         if self.nnodes > 1 and self.device_indexes is not None:
             logger.warning("In a multi-machine scenario, device_indexes will be set to None.")
@@ -1175,6 +1179,8 @@ class ServerArgs:
             default=ServerArgs.dp_schedule_policy,
             help=(
                 "DP scheduling policy for assigning dp_rank to new requests. "
+                "When unset, defaults to 'cache_aware' with radix cache enabled "
+                "and 'min_running_queue' with radix cache disabled or Pathways PD. "
                 "'cache_aware' routes by cache affinity with soft load balancing: "
                 "it balances on large load skew, else picks the least-loaded rank "
                 "among those holding a substantial cached prefix, so a hot prefix "

--- a/test/srt/test_dp_rank_assignment.py
+++ b/test/srt/test_dp_rank_assignment.py
@@ -37,7 +37,19 @@ class _DpAssignmentHarness:
         self.full_ranks = full_ranks or set()
         self.per_dp_max_running_requests = per_dp_max_running_requests
         self.round_robin_counter = 0
-        self.cache_aware_calls: list[tuple[str | list[str] | None, list[int], list[int]]] = []
+        # Records (rid, extra_counts, extra_token_counts, item_input, item_output,
+        # extra_input_counts, extra_output_counts) per cache_aware dispatch.
+        self.cache_aware_calls: list[
+            tuple[
+                str | list[str] | None,
+                list[int],
+                list[int],
+                int,
+                int,
+                list[int],
+                list[int],
+            ]
+        ] = []
         # Records (item_input, item_output, extra_input_counts, extra_output_counts)
         # per shape_aware dispatch, so tests can assert the same-tick pending-IO split.
         self.shape_aware_calls: list[tuple[int, int, list[int], list[int]]] = []
@@ -70,8 +82,21 @@ class _DpAssignmentHarness:
         req: TokenizedGenerateReqInput,
         extra_counts: list[int],
         extra_token_counts: list[int],
+        extra_input_counts: list[int],
+        extra_output_counts: list[int],
     ) -> int | None:
-        self.cache_aware_calls.append((req.rid, list(extra_counts), list(extra_token_counts)))
+        item_input, item_output = self.estimate_req_io_tokens(req)
+        self.cache_aware_calls.append(
+            (
+                req.rid,
+                list(extra_counts),
+                list(extra_token_counts),
+                item_input,
+                item_output,
+                list(extra_input_counts),
+                list(extra_output_counts),
+            )
+        )
         return self.select_min_running_dp(extra_counts, extra_token_counts)
 
     def select_shape_aware_dp(
@@ -87,7 +112,12 @@ class _DpAssignmentHarness:
         # tracking is under test; the routing decision itself (shape-aware math)
         # is covered by test_dp_schedule_shape_aware.py, so reuse min-running here.
         self.shape_aware_calls.append(
-            (item_input, item_output, list(extra_input_counts), list(extra_output_counts))
+            (
+                item_input,
+                item_output,
+                list(extra_input_counts),
+                list(extra_output_counts),
+            )
         )
         return self.select_min_running_dp(extra_counts, extra_token_counts)
 
@@ -207,7 +237,26 @@ def test_cache_aware_receives_pending_load_from_prior_requests():
     assert result.ready_reqs == [sticky, new]
     assert result.pending_reqs == []
     assert new.dp_rank == 1
-    assert harness.cache_aware_calls == [("new", [1, 0], [8, 0])]
+    assert harness.cache_aware_calls == [("new", [1, 0], [8, 0], 4, 4, [4, 0], [4, 0])]
+
+
+def test_cache_aware_receives_pending_io_split_from_prior_same_tick_assignment():
+    # Guards cache_aware's shape-aware miss fallback: a request assigned earlier in
+    # the same intake tick must affect the input/output split seen by the next
+    # request, not only the aggregate pending token count.
+    harness = _DpAssignmentHarness()
+    first = _req("first", input_len=10, max_new_tokens=3)  # assigned to rank 0
+    second = _req("second", input_len=5, max_new_tokens=7)
+
+    result = _assign(recv_reqs=[first, second], policy="cache_aware", harness=harness)
+
+    assert result.ready_reqs == [first, second]
+    assert result.pending_reqs == []
+    assert [first.dp_rank, second.dp_rank] == [0, 1]
+    assert harness.cache_aware_calls == [
+        ("first", [0, 0], [0, 0], 10, 3, [0, 0], [0, 0]),
+        ("second", [1, 0], [13, 0], 5, 7, [10, 0], [3, 0]),
+    ]
 
 
 def test_shape_aware_receives_pending_io_split_from_prior_requests():

--- a/test/srt/test_dp_schedule_policy.py
+++ b/test/srt/test_dp_schedule_policy.py
@@ -1,25 +1,50 @@
-"""Unit tests for the cache-aware DP scheduling policy decision logic.
+"""Unit tests for DP scheduling policy selection.
 
-Covers the pure ``pick_cache_aware_dp`` policy (soft affinity-vs-load) and
-``req_prefix_match_key`` probe-key extraction. These live in a dependency-free
-helper module, so the test imports neither Scheduler nor JAX. The end-to-end
-reuse improvement is validated separately by a full-KV ``cache_aware`` vs
-``min_running_queue`` A/B (see the PR description).
+Covers the pure ``pick_cache_aware_dp`` decision logic,
+``req_prefix_match_key`` probe-key extraction, and ServerArgs default policy
+normalization.
 """
 
 from __future__ import annotations
 
+import argparse
 from types import SimpleNamespace
 
 from sgl_jax.srt.managers.dp_schedule_policy import pick_cache_aware_dp as pick
 from sgl_jax.srt.managers.dp_schedule_policy import req_prefix_match_key as match_key
+from sgl_jax.srt.server_args import ServerArgs
+
+
+def _pick(
+    eligible,
+    counts,
+    tokens,
+    matches,
+    prompt_len,
+    *,
+    input_counts=None,
+    output_counts=None,
+    item_input=0,
+    item_output=0,
+):
+    return pick(
+        eligible,
+        counts,
+        tokens,
+        matches,
+        prompt_len,
+        input_counts if input_counts is not None else counts,
+        output_counts if output_counts is not None else tokens,
+        item_input,
+        item_output,
+    )
 
 
 def test_holder_wins_when_loads_equal():
     counts = [0, 0, 0, 0]
     tokens = [0, 0, 0, 0]
     matches = {0: 0, 1: 512, 2: 0, 3: 0}
-    assert pick([0, 1, 2, 3], counts, tokens, matches, prompt_len=512) == 1
+    assert _pick([0, 1, 2, 3], counts, tokens, matches, prompt_len=512) == 1
 
 
 def test_least_loaded_among_holders():
@@ -28,14 +53,31 @@ def test_least_loaded_among_holders():
     counts = [3, 1, 0, 0]
     tokens = [30, 10, 0, 0]
     matches = {0: 600, 1: 400}
-    assert pick([0, 1, 2, 3], counts, tokens, matches, prompt_len=512) == 1
+    assert _pick([0, 1, 2, 3], counts, tokens, matches, prompt_len=512) == 1
 
 
-def test_no_cached_match_falls_back_to_least_load():
-    counts = [3, 1, 2, 4]
-    tokens = [30, 10, 20, 40]
-    matches = {0: 0, 1: 0, 2: 0, 3: 0}
-    assert pick([0, 1, 2, 3], counts, tokens, matches, prompt_len=512) == 1
+def test_no_cached_match_falls_back_to_shape_aware():
+    # Rank 0 has fewer requests, so the old least-loaded fallback would pick it.
+    # The output-heavy item should instead go to rank 1, whose output side is light.
+    counts = [0, 1]
+    tokens = [0, 1]
+    input_counts = [0, 900]
+    output_counts = [900, 0]
+    matches = {0: 0, 1: 0}
+    assert (
+        _pick(
+            [0, 1],
+            counts,
+            tokens,
+            matches,
+            prompt_len=512,
+            input_counts=input_counts,
+            output_counts=output_counts,
+            item_input=0,
+            item_output=700,
+        )
+        == 1
+    )
 
 
 def test_below_threshold_match_is_not_a_holder():
@@ -43,7 +85,7 @@ def test_below_threshold_match_is_not_a_holder():
     counts = [5, 0]
     tokens = [50, 0]
     matches = {0: 100}
-    assert pick([0, 1], counts, tokens, matches, prompt_len=512) == 1
+    assert _pick([0, 1], counts, tokens, matches, prompt_len=512) == 1
 
 
 def test_large_load_skew_overrides_cache_affinity():
@@ -52,7 +94,7 @@ def test_large_load_skew_overrides_cache_affinity():
     counts = [40, 0]
     tokens = [400, 0]
     matches = {0: 512}
-    assert pick([0, 1], counts, tokens, matches, prompt_len=512) == 1
+    assert _pick([0, 1], counts, tokens, matches, prompt_len=512) == 1
 
 
 def test_small_load_skew_keeps_affinity():
@@ -60,7 +102,7 @@ def test_small_load_skew_keeps_affinity():
     counts = [5, 0]
     tokens = [50, 0]
     matches = {0: 512}
-    assert pick([0, 1], counts, tokens, matches, prompt_len=512) == 0
+    assert _pick([0, 1], counts, tokens, matches, prompt_len=512) == 0
 
 
 def test_hot_prefix_spills_when_owning_rank_is_full():
@@ -69,26 +111,41 @@ def test_hot_prefix_spills_when_owning_rank_is_full():
     counts = [0, 5, 1, 9]
     tokens = [0, 50, 10, 90]
     matches = {0: 512}
-    assert pick([1, 2, 3], counts, tokens, matches, prompt_len=512) == 2
+    assert _pick([1, 2, 3], counts, tokens, matches, prompt_len=512) == 2
 
 
 def test_holder_and_load_tie_breaks_by_lowest_rank():
     counts = [2, 2, 2, 2]
     tokens = [20, 20, 20, 20]
     matches = {0: 256, 1: 256, 2: 0, 3: 0}
-    assert pick([0, 1, 2, 3], counts, tokens, matches, prompt_len=256) == 0
+    assert _pick([0, 1, 2, 3], counts, tokens, matches, prompt_len=256) == 0
 
 
-def test_prompt_len_zero_falls_back_to_least_load():
-    # No usable prompt_len -> skip the holder math (no zero-division), least-load wins.
-    counts = [5, 0]
-    tokens = [50, 0]
+def test_prompt_len_zero_falls_back_to_shape_aware():
+    # No usable prompt_len -> skip holder math (no zero-division) and use shape-aware fallback.
+    counts = [0, 1]
+    tokens = [0, 1]
+    input_counts = [0, 900]
+    output_counts = [900, 0]
     matches = {0: 512}
-    assert pick([0, 1], counts, tokens, matches, prompt_len=0) == 1
+    assert (
+        _pick(
+            [0, 1],
+            counts,
+            tokens,
+            matches,
+            prompt_len=0,
+            input_counts=input_counts,
+            output_counts=output_counts,
+            item_input=0,
+            item_output=700,
+        )
+        == 1
+    )
 
 
 def test_all_full_returns_none():
-    assert pick([], [0, 0], [0, 0], {}, prompt_len=4) is None
+    assert _pick([], [0, 0], [0, 0], {}, prompt_len=4) is None
 
 
 def _req(input_ids, extra_key=None, lora_id=None, return_logprob=False, logprob_start_len=-1):
@@ -152,6 +209,47 @@ def test_match_key_none_and_empty_are_skipped():
 
 def test_match_key_batched_input_is_skipped():
     assert match_key(_req([[1, 2], [3, 4]])) == (None, None)
+
+
+def _server_args(**kwargs) -> ServerArgs:
+    return ServerArgs(model_path="dummy", device="cpu", **kwargs)
+
+
+def test_unset_dp_schedule_policy_follows_normalized_radix_state():
+    assert _server_args().dp_schedule_policy == "cache_aware"
+    assert _server_args(disable_radix_cache=True).dp_schedule_policy == "min_running_queue"
+    assert _server_args(pd_disaggregation="pathways").dp_schedule_policy == "min_running_queue"
+
+    hicache_args = _server_args(disable_radix_cache=True, hicache_storage="none")
+    assert hicache_args.disable_radix_cache is False
+    assert hicache_args.dp_schedule_policy == "cache_aware"
+
+
+def test_explicit_dp_schedule_policy_is_preserved():
+    assert (
+        _server_args(dp_schedule_policy="min_running_queue").dp_schedule_policy
+        == "min_running_queue"
+    )
+    assert (
+        _server_args(
+            disable_radix_cache=True,
+            dp_schedule_policy="shape_aware",
+        ).dp_schedule_policy
+        == "shape_aware"
+    )
+
+
+def test_cli_default_keeps_unset_policy_distinct_from_explicit_min_running_queue():
+    parser = argparse.ArgumentParser()
+    ServerArgs.add_cli_args(parser)
+
+    unset = parser.parse_args(["--model-path", "dummy"])
+    explicit = parser.parse_args(
+        ["--model-path", "dummy", "--dp-schedule-policy", "min_running_queue"]
+    )
+
+    assert unset.dp_schedule_policy is None
+    assert explicit.dp_schedule_policy == "min_running_queue"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #1442.

- Make `--dp-schedule-policy` unset by default so startup can distinguish an omitted policy from an explicit user override.
- Default DP scheduling to `cache_aware` when radix cache is enabled and `min_running_queue` when radix cache is disabled or Pathways PD is enabled.
- Keep `shape_aware` and `round_robin` as explicit tuning policies, and make cache-aware cache misses fall back to shape-aware load balancing.
- Document the new DP policy behavior and refresh the top-level server arguments page with several missing common serve flags.

## Expected behavior

```python
# ServerArgs normalization, after radix/hicache args are normalized.
if dp_schedule_policy is None:
    if disable_radix_cache or pd_disaggregation:
        dp_schedule_policy = "min_running_queue"
    else:
        dp_schedule_policy = "cache_aware"

# Cache-aware DP assignment.
if policy == "cache_aware":
    if eligible_ranks is empty:
        return None
    if eligible load skew is large:
        return least_loaded(eligible_ranks)
    if radix prefix holders exist:
        return least_loaded(prefix_holders)
    return shape_aware_pick(eligible_ranks, pending_input, pending_output, req_shape)
```

Explicit `--dp-schedule-policy` values are preserved, so users can still force `min_running_queue`, `cache_aware`, `shape_aware`, or `round_robin` for workload-specific tuning.

## v6e-4 validation

Environment:

- GKE cluster: `tpu-service-473302/asia-northeast1-b/niu-v6e-4x4-asia`
- TPU: v6e-4 from node pool `tpu-v6e-2x2`
- Model: `Qwen/Qwen3-8B`
- Server: `tp=4`, `dp=2/4`, TPU, bf16, FA

### Radix enabled

Deltas are relative to `min_running_queue`; the proposed default is `cache_aware`.

| dp | scenario | cache-aware result |
|---:|---|---|
| 2 | gsp | hit +4.2pp, total +6.6%, p90 -21.2% |
| 2 | gsp_no_ignore_eos | hit +1.4pp, total -5.2%, output +3.2%, p90 +0.3% |
| 2 | mixed_gsp | hit +5.6pp, total +20.8%, p90 -4.9% |
| 2 | mixed_random | hit +0.0pp, total +9.5%, p90 +1.8% |
| 2 | random_no_share | hit +0.0pp, total +2.4%, p90 -1.3% |
| 4 | gsp | hit +16.9pp, total +12.5%, p90 -34.7% |
| 4 | gsp_no_ignore_eos | hit +17.0pp, total +26.4%, p90 -11.0% |
| 4 | mixed_gsp | hit +20.6pp, total +4.9%, p90 +74.0% |
| 4 | mixed_random | hit +0.0pp, total +1.6%, p90 -37.5% |
| 4 | random_no_share | hit +0.0pp, total +33.7%, p90 -9.7% |

Takeaways:

- `cache_aware` is positive on most radix/cache-reuse cases, especially dp=4 GSP cases.
- Cache-miss fallback to shape-aware was neutral to positive for no-share/random cases in this run.
- Caveat: dp=2 `gsp_no_ignore_eos` regressed total throughput by 5.2%, although output throughput improved by 3.2%.
- `shape_aware` is not a safe radix default in this matrix: dp=4 `mixed_gsp` regressed total throughput by 14.3% and p90 by 168.7%.
- `round_robin` can be strong on homogeneous random/mixed throughput but does not preserve the cache-hit objective, so it remains an explicit tuning policy.

### Radix disabled

The proposed default remains `min_running_queue` for no-radix serving.

| dp | scenario | shape-aware result vs min_running_queue |
|---:|---|---|
| 2 | random_no_share | total +1.4%, p90 -1.8%, TTFT -6.3% |
| 2 | shape_prefill | total +0.0%, p90 +0.0%, TTFT -0.4% |
| 2 | shape_decode | total +2.0%, p90 -0.2%, TTFT +1.5% |
| 4 | random_no_share | total -0.2%, p90 +0.2%, TTFT +5.0% |
| 4 | shape_prefill | total +0.1%, p90 +0.7%, TTFT -0.8% |
| 4 | shape_decode | total -5.0%, p90 -0.6%, TTFT +2.9% |

Takeaway: no-radix should not default to `shape_aware` yet; it is mostly neutral but has a dp=4 shape-decode total throughput regression. Keeping `min_running_queue` avoids making this path riskier by default.

## Test plan

- `UV_PROJECT_ENVIRONMENT=/tmp/sgl-jax-pr-venv uv run --project python --extra cpu --with pytest python -m pytest -q test/srt/test_dp_schedule_policy.py test/srt/test_dp_schedule_shape_aware.py test/srt/test_dp_rank_assignment.py python/sgl_jax/test/mem_cache/test_unified_radix_tree_flag.py`
  - `46 passed in 13.65s`
- `git diff --check`


