### PR TITLE
feat(pd): Pathways single-controller PD Stage 2 — perf + multi-D + hetero-TP

### DIFF
--- a/python/sgl_jax/srt/disaggregation/pathways_pd.py
+++ b/python/sgl_jax/srt/disaggregation/pathways_pd.py
@@ -3,23 +3,25 @@
 Architecture: one Python process (Pathways head) sees all devices across
 N slices via IFRT proxy. Build prefill_mesh on slice 0, decode_mesh on
 slice 1, run two ModelRunners. KV transfer = jax.device_put across meshes
-(IFRT runtime handles per-host DCN fan-out, ~14 GB/s/host on v7x vs ~4.5
+(IFRT runtime handles per-host DCN fan-out, ~14 GB/s/host measured vs ~4.5
 for jax.experimental.transfer on the same hardware).
 """
 
 from __future__ import annotations
 
 import logging
+import os
+import time
 from collections import defaultdict
 
 import jax
-import jax.numpy as jnp
 import numpy as np
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
 __all__ = [
     "group_by_slice",
+    "group_pages_by_dp_rank",
     "make_slice_meshes",
     "PathwaysPDKVTransfer",
     "migrate_reqs_p_to_d",
@@ -27,12 +29,13 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
+_PD_DBG = bool(os.environ.get("SGLANG_PD_DBG"))
 
-_NPG_BUCKETS = (8, 16, 32, 64)
-# Upper bound on pages per stacked transfer. 64pg x 78L x 80KB ~= 0.39 GB
-# transient HBM (x2 with the recv-side donate buffer) — fits the smallest
-# headroom we measured (v6e fp8: ~1.3 GB free after weights + KV + jit exec).
-_NPG_BATCH_MAX = 64
+_NPG_BUCKETS = (8, 16, 32, 64, 128, 256)
+# Upper bound on pages per stacked transfer. 256pg x 78L x 80KB ~= 1.6 GB
+# transient on each side; mf=0.84 on 96GB devices leaves >8 GB headroom.
+# 16K/ps256 = 64pg fits one shot, 16K/ps128 = 128pg also one shot.
+_NPG_BATCH_MAX = 256
 
 
 def _bucket_npg(n: int) -> int:
@@ -52,6 +55,51 @@ def slots_to_ordered_pages(slots: np.ndarray, page_size: int) -> np.ndarray:
     pages = np.asarray(slots, np.int64) // page_size
     _, first_idx = np.unique(pages, return_index=True)
     return pages[np.sort(first_idx)].astype(np.int32)
+
+
+def group_pages_by_dp_rank(
+    pages_by_req: list[tuple[int, np.ndarray]], dp_size: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Group per-req (dp_rank, local_pages) pairs into the [dp_size, max_n]
+    layout the dp>1 shard_map kernels (_make_pool_jits' gather_jit /
+    scatter_one_jit) require -- each row must hold ONLY that rank's own
+    LOCAL page indices (allocator.py: indices aren't comparable across
+    ranks), never a flat cross-rank concat.
+
+    Returns (pages, valid) both shaped [dp_size, max_n]: `pages[i, j]` for
+    j >= real-count is padded by repeating rank i's own last real page
+    (harmless self-overwrite/re-gather, same scheme _bucket_npg already
+    uses within a single rank). `valid[i, j]` is False for those padding
+    slots -- callers MUST check it before trusting/using the corresponding
+    output.
+
+    KNOWN LIMITATION (not yet handled by any caller): a rank with ZERO real
+    pages this round has no "own last page" to repeat, so its row is left
+    as all-zero-index/all-invalid. Naively feeding that row into
+    scatter_one_jit would overwrite page 0 of THAT rank's D pool with
+    whatever stale P-side data rides along -- a real corruption, not a
+    harmless no-op (unlike the same-rank padding case). Callers must NOT
+    invoke the scatter kernel across a batch where any rank's row is
+    all-invalid; either defer that rank's migration to a round where it
+    has >=1 real req, or split into per-rank-populated sub-batches.
+    """
+    per_rank: list[list[int]] = [[] for _ in range(dp_size)]
+    for dp_rank, pages in pages_by_req:
+        per_rank[dp_rank].extend(int(p) for p in np.asarray(pages, np.int64))
+    max_n = max((len(p) for p in per_rank), default=0)
+    if max_n == 0:
+        return np.zeros((dp_size, 0), np.int32), np.zeros((dp_size, 0), bool)
+    pages_out = np.zeros((dp_size, max_n), np.int32)
+    valid_out = np.zeros((dp_size, max_n), bool)
+    for i, p in enumerate(per_rank):
+        if not p:
+            continue  # no real pages for this rank -- see KNOWN LIMITATION above
+        arr = np.asarray(p, np.int32)
+        valid_out[i, : len(arr)] = True
+        if len(arr) < max_n:
+            arr = np.concatenate([arr, np.full(max_n - len(arr), arr[-1], np.int32)])
+        pages_out[i] = arr
+    return pages_out, valid_out
 
 
 def migrate_reqs_p_to_d(
@@ -127,60 +175,202 @@ def group_by_slice(devs: list) -> dict[int, list]:
 
 
 def make_slice_meshes(
-    dp_size: int, tp_per_side: int, n_prefill: int = 1
-) -> tuple[list[Mesh], Mesh]:
-    """Build ([prefill_mesh_0..n_prefill-1], decode_mesh) from the first
-    n_prefill+1 slices. Multi-P: n_prefill>1 fans prefill across
-    slices to lift R_prefill (the bottleneck on device-bound models)."""
+    dp_size: int,
+    tp_per_side: int,
+    n_prefill: int = 1,
+    n_decode: int = 1,
+    tp_prefill: int = 0,
+) -> tuple[list[Mesh], list[Mesh]]:
+    """Build ([prefill_mesh_0..n_prefill-1], [decode_mesh_0..n_decode-1]) from
+    the first n_prefill+n_decode slices.
+
+    Multi-P (n_prefill>1) fans prefill across slices to lift R_prefill (the
+    bottleneck on P-bound workloads, short OL). Multi-D (n_decode>1) fans
+    decode across slices for D-bound workloads (long OL, e.g. 4K/16K where
+    R_p/R_d ~= 26x on MiMo-V2 tp16 -- one P slice can feed >>1 D slice).
+
+    Hetero-TP (Stage 6 P-D-different-tp): tp_prefill!=0 builds each P mesh
+    with tp_prefill devices instead of tp_per_side (D always tp_per_side).
+    Requires the underlying PathwaysJob to expose slices of BOTH sizes
+    (workers[] is a list -- e.g. one 2x2x4 entry for P + one 2x2x2 for D);
+    slices are then role-assigned by device count, not by slice_index order,
+    so tp_p<tp_d and tp_p>tp_d both work regardless of which topology the
+    RM enumerates first. dp_size is shared (attention_tp differs per side).
+    """
+    tp_d = tp_per_side
+    tp_p = tp_prefill or tp_per_side
     devs = jax.devices()
     groups = group_by_slice(devs)
     sids = sorted(groups)
-    need = n_prefill + 1
+    need = n_prefill + n_decode
     if len(sids) < need:
         raise RuntimeError(
-            f"pathways_pd n_prefill={n_prefill} requires >={need} slices, got {len(sids)} "
-            f"(devices={len(devs)}, backend={jax.default_backend()})"
+            f"pathways_pd n_prefill={n_prefill} n_decode={n_decode} requires >={need} "
+            f"slices, got {len(sids)} (devices={len(devs)}, backend={jax.default_backend()})"
         )
-    tp_axis = tp_per_side // dp_size
+    if tp_p != tp_d:
+        # Assign by slice size: n_prefill slices of size tp_p go to P,
+        # n_decode of size tp_d go to D. Fail loud if the PathwaysJob
+        # workers[] topologies don't match -- don't silently truncate a
+        # bigger slice (wastes chips + adds an untested code path).
+        p_sids = [s for s in sids if len(groups[s]) == tp_p][:n_prefill]
+        d_sids = [s for s in sids if len(groups[s]) == tp_d and s not in p_sids][:n_decode]
+        if len(p_sids) < n_prefill or len(d_sids) < n_decode:
+            raise RuntimeError(
+                f"[pathways_pd] hetero-tp needs {n_prefill} slice(s) of size {tp_p} (P) "
+                f"+ {n_decode} of size {tp_d} (D); got sizes={[len(groups[s]) for s in sids]}"
+            )
+    else:
+        p_sids = sids[:n_prefill]
+        d_sids = sids[n_prefill : n_prefill + n_decode]
     et = (jax.sharding.AxisType.Explicit,) * 2
 
-    def _mk(ds: list) -> Mesh:
-        if len(ds) != tp_per_side:
-            raise RuntimeError(f"slice size {len(ds)} != tp_per_side {tp_per_side}")
+    def _mk(ds: list, tp: int) -> Mesh:
+        if len(ds) != tp:
+            raise RuntimeError(f"slice size {len(ds)} != tp {tp}")
         return Mesh(
-            np.asarray(ds).reshape(dp_size, tp_axis),
+            np.asarray(ds).reshape(dp_size, tp // dp_size),
             axis_names=("data", "tensor"),
             axis_types=et,
         )
 
-    p_meshes = [_mk(groups[sids[i]]) for i in range(n_prefill)]
-    d_mesh = _mk(groups[sids[n_prefill]])
+    p_meshes = [_mk(groups[s], tp_p) for s in p_sids]
+    d_meshes = [_mk(groups[s], tp_d) for s in d_sids]
     logger.info(
-        "[pathways_pd] slices=%d n_prefill=%d p_slices=%s d_slice=%d shape=%s",
+        "[pathways_pd] slices=%d n_prefill=%d n_decode=%d tp_p=%d tp_d=%d "
+        "p_slices=%s d_slices=%s p_shape=%s d_shape=%s",
         len(sids),
         n_prefill,
-        sids[:n_prefill],
-        sids[n_prefill],
-        d_mesh.shape,
+        n_decode,
+        tp_p,
+        tp_d,
+        p_sids,
+        d_sids,
+        p_meshes[0].shape,
+        d_meshes[0].shape,
     )
-    return p_meshes, d_mesh
+    return p_meshes, d_meshes
 
 
 def _make_pool_jits(p_mesh: Mesh, d_mesh: Mesh, p_sub, d_sub):
-    """Build (gather_jit, scatter_jit, d_stack_shard) for one MHA-style sub-pool."""
+    """Build (gather_jit, scatter_one_jit, d_stack_shard) for one MHA-style sub-pool.
+
+    scatter is per-layer: one jit call per kv_buffer entry. Batching all
+    layers into a single jit made the XLA program's temp reservation scale
+    with the whole D pool (n_layers x pool_bytes), which OOMs the bottom-
+    of-HBM region once the pool is large (V2-Flash tp16 DPOOL=1310720 ->
+    32G reserve vs 15G free). Per-layer keeps the reservation at O(1 layer).
+
+    dp>1: kv_buffer's leading (token/page) axis is sharded by the mesh's
+    'data' axis, and page/token indices from the allocator are PER-RANK
+    LOCAL (allocator.py: "Each rank has independent [1, size_per_rank]
+    indices"). A plain jax.jit `.at[idx].get/set()` with a replicated idx
+    array would misinterpret rank>0's local index as a GLOBAL index (landing
+    on the wrong rank's physical data) -- this is exactly the pattern the
+    base (non-PD) KV-cache write path avoids by running under `jax.shard_map`
+    (see memory_pool.py update_fused_kv_cache_vectorized). gather_jit/
+    scatter_one_jit below do the same: `idx`/`page` carry an explicit
+    dp_size-sized leading axis sharded on 'data', so each rank's shard_map
+    instance only ever sees and applies its OWN local indices.
+
+    dp_size==1 fast path: shard_map's manual-sharding lowering is a
+    functional no-op here but was NOT compile/dispatch-free on real TPU --
+    a live 78-layer model showed gather (all layers in one XLA program,
+    unlike scatter's per-layer calls) climbing 18s->37s and NOT plateauing
+    across repeat calls, vs <1s before shard_map existed.
+    Since dp_size==1 is 100% of production traffic today (dp>1 scheduler-
+    side wiring isn't done yet), skip shard_map entirely for that case and
+    reuse the exact pre-shard_map plain-jit body -- callers still always
+    pass [dp_size, n]-shaped idx/page (this fn just unwraps dim 0).
+    """
     kv_spec = d_sub.kv_sharding.spec
-    page_spec = P(None, *kv_spec[1:])
-    stack_spec = P(None, *kv_spec)
-    gather_jit = jax.jit(
-        lambda bufs, idx: jnp.stack([b.at[idx].get(out_sharding=page_spec) for b in bufs])
+    dp_axis = kv_spec[0]  # mesh axis name the pool's token dim is sharded on
+    tail_spec = kv_spec[1:]
+    # gather returns a tuple of L per-layer arrays (NOT jnp.stack): stacking
+    # forced scatter to index the device Array with un-jitted __getitem__
+    # (~11ms Execute each x 48 layers).
+    stack_spec = P(None, *tail_spec)
+
+    if p_mesh.shape[dp_axis] == 1 and d_mesh.shape[dp_axis] == 1:
+        page_spec = P(None, *tail_spec)
+        gather_jit = jax.jit(
+            lambda bufs, idx: tuple(b.at[idx[0]].get(out_sharding=page_spec) for b in bufs)
+        )
+        scatter_one_jit = jax.jit(
+            lambda buf, idx, page: buf.at[idx[0]].set(page[0], out_sharding=kv_spec),
+            donate_argnums=(0,),
+        )
+        return gather_jit, scatter_one_jit, NamedSharding(d_mesh, stack_spec)
+
+    idx_spec = P(dp_axis, None)
+    page_batch_spec = P(dp_axis, None, *tail_spec)
+
+    # dp>1 gather: ALL layers in ONE jit (tuple bufs -> stacked output).
+    # Per-layer (48 separate gather_one_jit Executes) head-of-line-blocked
+    # D forward dispatch through Pathways' single ordered dispatch queue --
+    # measured 2x ~650ms burst per done (gather 48 + scatter 48), costing
+    # ~16% throughput. Precompile covers the first-compile cost of the
+    # all-layers form (previously 18-37s trace/lower on 78L models).
+    _gather_body = jax.shard_map(
+        lambda buf, idx: buf.at[idx[0]].get()[None, ...],
+        mesh=p_mesh,
+        in_specs=(kv_spec, idx_spec),
+        out_specs=P(dp_axis, None, *tail_spec),
+        check_vma=False,
     )
-    scatter_jit = jax.jit(
-        lambda bufs, idx, stacked: tuple(
-            b.at[idx].set(stacked[i], out_sharding=kv_spec) for i, b in enumerate(bufs)
-        ),
+    gather_jit = jax.jit(lambda bufs, idx: tuple(_gather_body(b, idx) for b in bufs))
+
+    # scatter: donate reserves the full D-pool slice per layer simultaneously
+    # (not sequentially) inside one jit -- all-39L=16.6G, 8L=14.7G both OOM'd
+    # (~1.84G/layer, 9.9G free). Batch of 4 (~7.4G) fits; 48 per-layer
+    # Executes -> ~13 (2 sub-pools x ceil(L/4)), cutting the dispatch-queue
+    # burst from ~500ms to ~130ms.
+    _scatter_body = jax.shard_map(
+        lambda buf, idx, page: buf.at[idx[0]].set(page[0]),
+        mesh=d_mesh,
+        in_specs=(kv_spec, idx_spec, page_batch_spec),
+        out_specs=kv_spec,
+        check_vma=False,
+    )
+    # donate through shard_map only aliases in-place when the outer jit's
+    # executable I/O has *explicitly identical* shardings on the donated input
+    # and its output. Without in/out_shardings the SPMDShardToFullShape custom-
+    # call at shard_map's exit is opaque to XLA buffer-assignment, so donation
+    # degrades to free-then-copy of the whole D-pool layer (~3GB x _SB per
+    # scatter, 30-150ms). Pinning both sides to d_sub.kv_sharding lets XLA set
+    # input_output_alias -> the inner .at[].set() lowers to in-place scatter.
+    d_kv_shard = d_sub.kv_sharding  # NamedSharding(d_mesh, kv_spec)
+    d_idx_shard = NamedSharding(d_mesh, idx_spec)
+    d_page_shard = NamedSharding(d_mesh, page_batch_spec)
+    scatter_one_jit = jax.jit(
+        _scatter_body,
+        in_shardings=(d_kv_shard, d_idx_shard, d_page_shard),
+        out_shardings=d_kv_shard,
         donate_argnums=(0,),
     )
-    return gather_jit, scatter_jit, NamedSharding(d_mesh, stack_spec)
+    _SB = 4
+    scatter_batch_jit = jax.jit(
+        lambda bufs, idx, pages: tuple(_scatter_body(bufs[i], idx, pages[i]) for i in range(_SB)),
+        in_shardings=((d_kv_shard,) * _SB, d_idx_shard, (d_page_shard,) * _SB),
+        out_shardings=(d_kv_shard,) * _SB,
+        donate_argnums=(0,),
+    )
+
+    def scatter_fn(bufs_list, idx, stacked):
+        i, n = 0, len(bufs_list)
+        while i + _SB <= n:
+            new = scatter_batch_jit(
+                tuple(bufs_list[i : i + _SB]), idx, tuple(stacked[i + j] for j in range(_SB))
+            )
+            for j in range(_SB):
+                bufs_list[i + j] = new[j]
+            i += _SB
+        while i < n:
+            bufs_list[i] = scatter_one_jit(bufs_list[i], idx, stacked[i])
+            i += 1
+
+    # dp>1 gather returns tuple of L [dp_size, n, *page_dims] arrays.
+    return gather_jit, scatter_fn, NamedSharding(d_mesh, P(dp_axis, None, *tail_spec))
 
 
 class PathwaysPDKVTransfer:
@@ -188,7 +378,7 @@ class PathwaysPDKVTransfer:
 
     gather(P pages) -> stack L layers -> device_put to d_mesh sharding
     -> scatter into D pool (donate). Single transfer per batch maximizes
-    payload (P0 measured 28.9 GB/s aggregate at 2048 MiB on 2x v7x-8).
+    payload (measured 28.9 GB/s aggregate at 2048 MiB on 2x 8-device slices).
 
     SWAKVPool: full + swa sub-pools transferred independently. Input/output
     pages are in the *full* index space; swa pages are derived per side via
@@ -200,24 +390,70 @@ class PathwaysPDKVTransfer:
         self.p_mesh = p_mesh
         self.d_mesh = d_mesh
         self.d_pool = d_pool
+        # gather_jit/scatter_one_jit run per-dp-rank via shard_map (see
+        # _make_pool_jits); the calling convention below still only feeds
+        # them a single rank's worth of pages (dp_size==1 wrapped as
+        # shape [1, n]) since the scheduler doesn't yet group migrated
+        # pages by req.dp_rank -- that's the remaining piece for dp>1.
+        self.p_dp_size = p_mesh.shape["data"]
+        self.d_dp_size = d_mesh.shape["data"]
         self.is_swa = hasattr(p_pool, "swa_kv_pool")
         if self.is_swa:
             self.page_size = kw["page_size"]
             self.p_mapping = kw["p_alloc"].full_to_swa_index_mapping
             self.d_mapping = kw["d_alloc"].full_to_swa_index_mapping
+            # swa layers only need the last sliding_window tokens on D. Gather
+            # was moving all seq_len pages (16K/256=64) x 39 swa layers ~=
+            # 2.6GB/done cross-slice; tail-only cuts that to ~40MB. D-side swa
+            # slots outside the tail stay garbage (decode swa attention never
+            # reads past the window) and get free_swa'd in _pd_drain_ready.
+            self._swa_tail_pages = kw.get("swa_tail_pages", 0)
             sub_pools = [
                 (p_pool.full_kv_pool, d_pool.full_kv_pool),
                 (p_pool.swa_kv_pool, d_pool.swa_kv_pool),
             ]
         else:
+            self._swa_tail_pages = 0
             sub_pools = [(p_pool, d_pool)]
+        # Hetero-TP guard: gather/scatter move whole pages (global shape),
+        # so P/D per-page shape must match. MLA pools are tensor-replicated
+        # (P("data",None,None,None)) -> always match. MHA pools shard on
+        # kv_heads: match iff kv_heads >= max(attention_tp_p, attention_tp_d)
+        # (else get_total_num_kv_heads_with_replication pads to attention_tp
+        # and the two sides' head axes differ). Fail here, not mid-transfer.
+        for p_sub, d_sub in sub_pools:
+            ps, ds = p_sub.kv_buffer[0].shape[1:], d_sub.kv_buffer[0].shape[1:]
+            if ps != ds:
+                raise RuntimeError(
+                    f"[pathways_pd] hetero-tp KV per-page shape mismatch P={ps} D={ds}; "
+                    f"model kv_heads must be >= max(attention_tp_p, attention_tp_d) "
+                    f"for MHA/GQA, or use an MLA model"
+                )
         # _jits[k] = (gather, scatter, d_stack_shard, p_sub_pool, d_sub_pool)
         self._jits = [
             (*_make_pool_jits(p_mesh, d_mesh, p_sub, d_sub), p_sub, d_sub)
             for p_sub, d_sub in sub_pools
         ]
-        self._p_idx_shard = NamedSharding(p_mesh, P(None))
-        self._d_idx_shard = NamedSharding(d_mesh, P(None))
+        self._p_idx_shard = NamedSharding(p_mesh, P("data", None))
+        self._d_idx_shard = NamedSharding(d_mesh, P("data", None))
+        # Hetero-tp: device_put(tuple-of-L-layers, d_shard) dispatches L
+        # separate ReshardOps through Pathways' dispatch queue (~4.5ms each on
+        # 32->16); GLM L=78 -> ~350ms/gather vs same-shape homo path ~5ms.
+        # Stack to one [L, ...] array on p_mesh (1 XLA prog), device_put once
+        # (1 ReshardOp), unstack on d_mesh (1 XLA prog). Homo path unchanged.
+        self._is_hetero = p_mesh.size != d_mesh.size
+        if self._is_hetero:
+            self._hetero_jits = []
+            for k, (_, _, d_stack_shard, p_sub, _) in enumerate(self._jits):
+                L = p_sub.layer_num
+                big_spec = P(None, *d_stack_shard.spec)
+                d_big_shard = NamedSharding(d_mesh, big_spec)
+                stack_j = jax.jit(lambda t: jax.numpy.stack(t, axis=0))
+                unstack_j = jax.jit(
+                    lambda x, _L=L: tuple(x[i] for i in range(_L)),
+                    out_shardings=d_stack_shard,
+                )
+                self._hetero_jits.append((stack_j, unstack_j, d_big_shard))
         logger.info(
             "[pathways_pd] kv_transfer is_swa=%s sub_pools=%d layers=%s",
             self.is_swa,
@@ -225,47 +461,216 @@ class PathwaysPDKVTransfer:
             [p.layer_num for p, _ in sub_pools],
         )
 
-    def _swa_pages(self, full_pages: np.ndarray, mapping) -> np.ndarray:
-        # PD currently runs dp=1 only; mapping is a single np.array.
-        m = mapping[0] if isinstance(mapping, list) else mapping
+    def precompile(self) -> None:
+        """Warm up gather/[stack/reshard/unstack]/scatter for all bucket shapes so
+        the first real request doesn't pay the ~minutes-long trace/lower cost
+        (dominant on hetero-tp where stack_j/unstack_j span L layers)."""
+        t0 = time.perf_counter()
+        # page 0 is the allocator sentinel (never handed out), safe to read/write.
+        for n in _NPG_BUCKETS:
+            _tb = time.perf_counter()
+            p_pages = np.zeros((self.p_dp_size, n), np.int32)
+            d_pages = np.zeros((self.d_dp_size, n), np.int32)
+            d_stacked, bucket = self.gather_to_dmesh(p_pages)
+            self.scatter_from_dmesh(d_pages, d_stacked, bucket)
+            for sk in d_stacked:
+                jax.block_until_ready(sk[-1] if isinstance(sk, tuple) else sk)
+            logger.info(
+                "[pathways_pd] precompile bucket=%d done in %.1fs", n, time.perf_counter() - _tb
+            )
+        logger.info(
+            "[pathways_pd] KV transfer precompile done in %.1fs (hetero=%s)",
+            time.perf_counter() - t0,
+            self._is_hetero,
+        )
+
+    def _swa_pages(self, full_pages: np.ndarray, mapping, dp_rank: int = 0) -> np.ndarray:
+        # `mapping` is a list of per-dp-rank arrays when dp_size>1 (each rank's
+        # full_to_swa_index_mapping uses that rank's own local index space --
+        # see allocator.py: "Each rank has independent [1, size_per_rank]
+        # indices"), or a single array when dp_size==1. `full_pages` must all
+        # belong to the SAME dp_rank (callers with a multi-rank batch must
+        # split by rank before calling, since indices aren't comparable
+        # across ranks) -- not yet done by any caller (dp=1 only today).
+        m = mapping[dp_rank] if isinstance(mapping, list) else mapping
         return (m[full_pages.astype(np.int64) * self.page_size] // self.page_size).astype(np.int32)
 
-    def gather_to_dmesh(self, p_pages: np.ndarray) -> tuple[jax.Array | tuple, int]:
+    def _prep_idx(self, pages: np.ndarray, dp_size: int, side: str) -> tuple[np.ndarray, int, int]:
+        """Normalize pages to [dp_size, bucket] with per-rank last-page padding.
+
+        dp_size==1: pages is a flat [n] array (old callers) -> wrap to [1, n].
+        dp_size>1: pages MUST already be [dp_size, n_per_rank] (caller used
+        group_pages_by_dp_rank); every rank must have >=1 real page (all-zero
+        rows corrupt that rank's page 0 -- see group_pages_by_dp_rank
+        docstring's KNOWN LIMITATION). We assert on that here so it fails
+        loudly instead of silently corrupting data.
+        """
+        pages = np.asarray(pages, np.int32)
+        if dp_size == 1:
+            pages = pages[None, :] if pages.ndim == 1 else pages
+        assert pages.ndim == 2 and pages.shape[0] == dp_size, (
+            f"[pathways_pd] {side} pages shape {pages.shape} vs dp_size={dp_size}: "
+            f"dp>1 callers must pre-group via group_pages_by_dp_rank"
+        )
+        n = pages.shape[1]
+        # Empty-rank rows (all-zero page indices) are harmless: allocator.py
+        # never hands out index 0 (arange(1, size+1)), so page 0 is a reserved
+        # sentinel on both sides -- gather reads it, scatter overwrites it,
+        # nothing that any req's slots point at is touched.
+        bucket = _bucket_npg(max(n, 1))
+        if bucket > n:
+            pad = np.repeat(pages[:, -1:], bucket - n, axis=1)
+            pages = np.concatenate([pages, pad], axis=1)
+        return pages, bucket, n
+
+    def gather_to_dmesh(
+        self, p_pages: np.ndarray, p_swa_pages=None
+    ) -> tuple[jax.Array | tuple, int]:
         """gather P pool pages -> stack -> device_put to D mesh.
 
         Runs in the prefill thread; the returned d_stacked is a future on the
         D mesh — main-thread scatter consumes it via data-dep so the cross-slice
         RecvRefs interleaves with decode instead of stalling here for ~250ms.
         """
-        p_pages = np.asarray(p_pages, np.int32)
-        npg = len(p_pages)
-        bucket = _bucket_npg(npg)
-        if bucket > npg:
-            p_pages = np.concatenate([p_pages, np.full(bucket - npg, p_pages[-1], np.int32)])
+        pp2, bucket, n_real = self._prep_idx(p_pages, self.p_dp_size, "P")
+        _no_tail = os.environ.get("SGLANG_PD_NO_SWA_TAIL")
         out = []
         for k, (gather_jit, _, d_stack_shard, p_sub, _) in enumerate(self._jits):
-            pp = p_pages if k == 0 else self._swa_pages(p_pages, self.p_mapping)
-            p_idx = jax.device_put(pp, self._p_idx_shard)
+            if k == 0:
+                pk = pp2
+            elif _no_tail:
+                pk = np.stack(
+                    [self._swa_pages(pp2[i], self.p_mapping, i) for i in range(self.p_dp_size)]
+                )
+            elif p_swa_pages is not None:
+                pt, _, _ = self._prep_idx(p_swa_pages, self.p_dp_size, "P")
+                pk = np.stack(
+                    [self._swa_pages(pt[i], self.p_mapping, i) for i in range(self.p_dp_size)]
+                )
+            else:
+                tail = self._swa_tail_pages
+                # slice tail from the REAL pages (before bucket padding), not
+                # from padded pp2 -- otherwise when bucket-n_real >= tail the
+                # tail is all-padding (last real page repeated) and swa gather
+                # misses page[n_real-tail:n_real-1].
+                _lo = max(0, n_real - tail) if tail else 0
+                pt = pp2[:, _lo:n_real] if tail and tail < n_real else pp2[:, :n_real]
+                pk = np.stack(
+                    [self._swa_pages(pt[i], self.p_mapping, i) for i in range(self.p_dp_size)]
+                )
+                if os.environ.get("SGLANG_PD_DBG_KV"):
+                    logger.info(
+                        "[pd-swa-dbg gather] slice=%s n_real=%d bucket=%d tail=%d "
+                        "pt=%s swa_pk=%s",
+                        self.p_mesh.devices.flat[0].slice_index,
+                        n_real,
+                        bucket,
+                        tail,
+                        pt.tolist(),
+                        pk.tolist(),
+                    )
+            p_idx = jax.device_put(pk, self._p_idx_shard)
             with jax.set_mesh(self.p_mesh):
                 p_stacked = gather_jit(tuple(p_sub.kv_buffer), p_idx)
-            out.append(jax.device_put(p_stacked, d_stack_shard))
-        return (out[0] if len(out) == 1 else tuple(out), bucket)
+            if self._is_hetero:
+                stack_j, unstack_j, d_big_shard = self._hetero_jits[k]
+                with jax.set_mesh(self.p_mesh):
+                    p_big = stack_j(p_stacked)
+                d_big = jax.device_put(p_big, d_big_shard)
+                with jax.set_mesh(self.d_mesh):
+                    _d = unstack_j(d_big)
+            else:
+                _d = jax.device_put(p_stacked, d_stack_shard)
+            if os.environ.get("SGLANG_PD_DBG_KV") and k == 0:
+                _sp = np.asarray(
+                    jax.device_get(p_stacked[0] if isinstance(p_stacked, tuple) else p_stacked)
+                ).astype(np.float32)
+                _sd = np.asarray(jax.device_get(_d[0] if isinstance(_d, tuple) else _d)).astype(
+                    np.float32
+                )
+                logger.info(
+                    "[pd-gather-dbg] slice=%s pk0=%s pk_last=%s p_sum=%.1f d_sum=%.1f "
+                    "p_last=%.1f d_last=%.1f MATCH=%s",
+                    self.p_mesh.devices.flat[0].slice_index,
+                    list(pk[0, :3]),
+                    list(pk[-1, :3]),
+                    float(_sp.sum()),
+                    float(_sd.sum()),
+                    float(_sp[-1].sum()),
+                    float(_sd[-1].sum()),
+                    bool(np.allclose(_sp, _sd)),
+                )
+            out.append(_d)
+        # Always tuple(out) even for single sub-pool: scatter_from_dmesh's
+        # `stacked[k]` indexes by sub-pool k, so out[0] (a per-layer tuple)
+        # unwrapped here would make stacked[0] = layer-0 not sub-pool-0.
+        return (tuple(out), bucket)
 
-    def scatter_from_dmesh(self, d_pages: np.ndarray, d_stacked, bucket: int) -> None:
+    def scatter_from_dmesh(
+        self, d_pages: np.ndarray, d_stacked, bucket: int, d_swa_pages=None
+    ) -> None:
         """scatter d_stacked into D pool. Called on the main thread so the
         donated kv_buffer reassignment is ordered before the next decode
         forward dispatch (data-dependency guarantees device-side ordering)."""
-        d_pages = np.asarray(d_pages, np.int32)
-        npg = len(d_pages)
-        if bucket > npg:
-            d_pages = np.concatenate([d_pages, np.full(bucket - npg, d_pages[-1], np.int32)])
+        dp2, _, d_n_real = self._prep_idx(d_pages, self.d_dp_size, "D")
+        # bucket comes from gather (P side) and MUST match dp2.shape[1] since
+        # both sides use the same n_per_rank -> _bucket_npg. If d_pages n
+        # differs from p_pages n (shouldn't: 1:1 page mapping) trust bucket.
+        assert dp2.shape[1] == bucket, f"D pages n={dp2.shape[1]} != gather bucket={bucket}"
         stacked = d_stacked if isinstance(d_stacked, tuple) else (d_stacked,)
+        # dp=1 fast-path gather output has NO leading dp dim ([L, n, ...]);
+        # dp>1 shard_map gather output has it ([L, dp_size, n, ...]).
+        wrap = self.d_dp_size == 1
+        _t_acq = time.perf_counter()
         with self.d_pool._donate_lock, jax.set_mesh(self.d_mesh):
-            for k, (_, scatter_jit, _, _, d_sub) in enumerate(self._jits):
-                dp = d_pages if k == 0 else self._swa_pages(d_pages, self.d_mapping)
-                d_idx = jax.device_put(dp, self._d_idx_shard)
-                new_bufs = scatter_jit(tuple(d_sub.kv_buffer), d_idx, stacked[k])
-                d_sub.kv_buffer = list(new_bufs)
+            _t_in = time.perf_counter()
+            for k, (_, scatter_fn, _, _, d_sub) in enumerate(self._jits):
+                if k == 0:
+                    dk = dp2
+                elif os.environ.get("SGLANG_PD_NO_SWA_TAIL"):
+                    dk = np.stack(
+                        [self._swa_pages(dp2[i], self.d_mapping, i) for i in range(self.d_dp_size)]
+                    )
+                elif d_swa_pages is not None:
+                    dt, _, _ = self._prep_idx(d_swa_pages, self.d_dp_size, "D")
+                    dk = np.stack(
+                        [self._swa_pages(dt[i], self.d_mapping, i) for i in range(self.d_dp_size)]
+                    )
+                else:
+                    tail = self._swa_tail_pages
+                    _lo = max(0, d_n_real - tail) if tail else 0
+                    dt = dp2[:, _lo:d_n_real] if tail and tail < d_n_real else dp2[:, :d_n_real]
+                    dk = np.stack(
+                        [self._swa_pages(dt[i], self.d_mapping, i) for i in range(self.d_dp_size)]
+                    )
+                    if os.environ.get("SGLANG_PD_DBG_KV"):
+                        _sk = stacked[k]
+                        _sk0 = _sk[0] if isinstance(_sk, tuple) else _sk
+                        _sksum = float(np.asarray(jax.device_get(_sk0)).astype(np.float32).sum())
+                        logger.info(
+                            "[pd-swa-dbg scatter] d_n_real=%d dt=%s swa_dk=%s "
+                            "stacked_k1_l0_sum=%.1f shape=%s",
+                            d_n_real,
+                            dt.tolist(),
+                            dk.tolist(),
+                            _sksum,
+                            np.asarray(jax.device_get(_sk0)).shape,
+                        )
+                d_idx = jax.device_put(dk, self._d_idx_shard)
+                if wrap:
+                    for i in range(d_sub.layer_num):
+                        d_sub.kv_buffer[i] = scatter_fn(
+                            d_sub.kv_buffer[i], d_idx, stacked[k][i][None, ...]
+                        )
+                else:
+                    scatter_fn(d_sub.kv_buffer, d_idx, stacked[k])
+        if _PD_DBG:
+            logger.info(
+                "[pd-lock] scatter wait=%.2fms hold=%.2fms n_sub=%d",
+                (_t_in - _t_acq) * 1e3,
+                (time.perf_counter() - _t_in) * 1e3,
+                len(self._jits),
+            )
 
     def transfer(self, p_page_indices: np.ndarray, d_page_indices: np.ndarray) -> None:
         p_page_indices = np.asarray(p_page_indices, np.int32)

--- a/python/sgl_jax/srt/disaggregation/pathways_pd.py
+++ b/python/sgl_jax/srt/disaggregation/pathways_pd.py
@@ -277,10 +277,8 @@ def _make_pool_jits(p_mesh: Mesh, d_mesh: Mesh, p_sub, d_sub):
     functional no-op here but was NOT compile/dispatch-free on real TPU --
     a live 78-layer model showed gather (all layers in one XLA program,
     unlike scatter's per-layer calls) climbing 18s->37s and NOT plateauing
-    across repeat calls, vs <1s before shard_map existed.
-    Since dp_size==1 is 100% of production traffic today (dp>1 scheduler-
-    side wiring isn't done yet), skip shard_map entirely for that case and
-    reuse the exact pre-shard_map plain-jit body -- callers still always
+    across repeat calls, vs <1s before shard_map existed. So skip shard_map
+    entirely when dp==1 and reuse the plain-jit body -- callers still always
     pass [dp_size, n]-shaped idx/page (this fn just unwraps dim 0).
     """
     kv_spec = d_sub.kv_sharding.spec

--- a/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
+++ b/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
@@ -367,7 +367,6 @@ class PathwaysPDSchedulerMixin:
             _mwb = b.get_model_worker_batch(
                 *paddings, self.page_size, self.server_args.enable_static_lora
             )
-            _mwb._pd_disp_t0 = time.perf_counter()
             _, _ntok, _ = worker.forward_batch_generation(_mwb, sampling_metadata=None)
             return _mwb, _ntok, _t0, time.perf_counter()
 

--- a/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
+++ b/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
@@ -89,9 +89,12 @@ class PathwaysPDSchedulerMixin:
             # both p_mesh world_size and num_experts; default = keep D's
             # ep/tp ratio (pure-EP stays pure-EP on the bigger P slice).
             p_args.tp_size = self._pd_tp_p
-            p_args.ep_size = server_args.pd_prefill_ep_size or (
-                server_args.ep_size * self._pd_tp_p // self.tp_size
+            p_args.ep_size = server_args.pd_prefill_ep_size or max(
+                1, server_args.ep_size * self._pd_tp_p // self.tp_size
             )
+            assert (
+                p_args.tp_size % p_args.ep_size == 0
+            ), f"derived P ep_size={p_args.ep_size} must divide P tp_size={p_args.tp_size}; set --pd-prefill-ep-size explicitly"
             logger.info(
                 "[pathways_pd] hetero-tp P: tp=%d ep=%d (D: tp=%d ep=%d)",
                 p_args.tp_size,

--- a/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
+++ b/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
@@ -9,19 +9,19 @@ from __future__ import annotations
 import copy
 import logging
 import os
-import signal
 import threading
 import time
+from collections import defaultdict
 from contextlib import contextmanager
 from queue import Empty as _QEmpty
 from queue import Queue as _Queue
 
 import jax
 import numpy as np
-import psutil
 
 from sgl_jax.srt.disaggregation.pathways_pd import (
     PathwaysPDKVTransfer,
+    group_pages_by_dp_rank,
     make_slice_meshes,
     migrate_reqs_p_to_d,
     slots_to_ordered_pages,
@@ -32,6 +32,8 @@ from sgl_jax.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
 from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache, SWAChunkCache
 
 logger = logging.getLogger(__name__)
+_PD_DBG = bool(os.environ.get("SGLANG_PD_DBG"))
+_PD_DBG_TIMING = bool(os.environ.get("SGLANG_PD_DBG_TIMING")) or _PD_DBG
 
 
 class PathwaysPDSchedulerMixin:
@@ -46,37 +48,64 @@ class PathwaysPDSchedulerMixin:
 
     def _pd_make_meshes(self, server_args) -> None:
         server_args.disable_radix_cache = True
-        # PD does not support chunked prefill; raise cps to the P-pool
-        # capacity so PrefillAdder never truncates a req mid-batch when
-        # packing many short reqs (e.g. 32-way GSM8K -> 6x~700 > 4096).
-        server_args.chunked_prefill_size = max(
-            server_args.chunked_prefill_size or 0, server_args.pd_prefill_max_tokens
-        )
         if not server_args.quantization_config_path:
             # Dynamic quant: cache holds BF16; after quant the fp8 model
-            # plus BF16 cache exceeds device HBM (139G>103G on v7x).
-            # setdefault so SGLANG_PD_WEIGHT_CACHE=0 can disable for >768G
-            # checkpoints that overflow the c4-192 head-node host RAM.
+            # plus BF16 cache can exceed device HBM. setdefault so
+            # SGLANG_PD_WEIGHT_CACHE=0 can disable for large checkpoints
+            # that overflow head-node host RAM.
             os.environ.setdefault("SGLANG_PD_WEIGHT_CACHE", "1")
         os.environ.setdefault("SGLANG_MOE_BULK_READ", "1")
         self._pd_n_prefill = max(1, server_args.pd_num_prefill)
-        self.p_meshes, self.mesh = make_slice_meshes(self.dp_size, self.tp_size, self._pd_n_prefill)
+        self._pd_n_decode = max(1, server_args.pd_num_decode)
+        # Hetero-TP: --tp-size is D (base Scheduler + main event loop run on
+        # d_mesh); --pd-prefill-tp-size overrides P only. 0 = homogeneous.
+        self._pd_tp_p = server_args.pd_prefill_tp_size or self.tp_size
+        if self._pd_tp_p != self.tp_size:
+            # weight_cache._pd_remap_sharding assumes P/D meshes are same size
+            # (1:1 dev id map); hetero-tp shardings differ so cache can't be
+            # reused across sides -- each loads its own (slower but correct).
+            os.environ["SGLANG_PD_WEIGHT_CACHE"] = "0"
+        self.p_meshes, self.d_meshes = make_slice_meshes(
+            self.dp_size,
+            self.tp_size,
+            self._pd_n_prefill,
+            self._pd_n_decode,
+            tp_prefill=self._pd_tp_p,
+        )
         self.p_mesh = self.p_meshes[0]
+        self.mesh = self.d_meshes[0]
 
     def _pd_init_workers(self, server_args, model_class, precompile_params, TpWorkerClass) -> None:
         assert self.spec_algorithm is None or self.spec_algorithm.is_none()
         assert not getattr(server_args, "enable_mixed_chunk", False)
-        d_mesh = self.mesh
         p_args = copy.deepcopy(server_args)
         p_args.mem_fraction_static = server_args.pd_prefill_mem_fraction
         p_args.disable_radix_cache = True
+        if self._pd_tp_p != self.tp_size:
+            # ModelWorker/ModelRunner read tp/ep from server_args (tp_worker.py
+            # :75/:130, moe.py:79 world_size from mesh); mesh alone isn't
+            # enough -- attention_tp = tp_size//dp_size drives kv_heads
+            # replication + validate_tensor_parallel_config. ep must divide
+            # both p_mesh world_size and num_experts; default = keep D's
+            # ep/tp ratio (pure-EP stays pure-EP on the bigger P slice).
+            p_args.tp_size = self._pd_tp_p
+            p_args.ep_size = server_args.pd_prefill_ep_size or (
+                server_args.ep_size * self._pd_tp_p // self.tp_size
+            )
+            logger.info(
+                "[pathways_pd] hetero-tp P: tp=%d ep=%d (D: tp=%d ep=%d)",
+                p_args.tp_size,
+                p_args.ep_size,
+                self.tp_size,
+                server_args.ep_size,
+            )
         d_args = copy.deepcopy(server_args)
         d_args.mem_fraction_static = server_args.pd_decode_mem_fraction
         d_args.disable_radix_cache = True
 
         n_p = self._pd_n_prefill
         p_meshes = self.p_meshes
-        os.environ["SGLANG_CI_SMALL_KV_SIZE"] = str(server_args.pd_prefill_max_tokens)
+        p_args.max_total_tokens = server_args.pd_prefill_max_tokens
         self.tp_workers_p = []
         self.p_r2ts, self.p_allocs, self.p_trees = [], [], []
         for i, pm in enumerate(p_meshes):
@@ -110,39 +139,84 @@ class PathwaysPDSchedulerMixin:
             self.p_allocs[0],
             self.p_trees[0],
         )
-        logger.info("[pathways_pd] loading D worker on %s", d_mesh.shape)
-        os.environ["SGLANG_CI_SMALL_KV_SIZE"] = str(server_args.pd_decode_max_tokens)
-        self.tp_worker = TpWorkerClass(
-            server_args=d_args,
-            mesh=d_mesh,
-            model_class=model_class,
-            precompile_params=precompile_params,
-        )
-        del os.environ["SGLANG_CI_SMALL_KV_SIZE"]
-        d_kv = self.tp_worker.model_runner.token_to_kv_pool
-        d_kv._donate_lock = threading.Lock()
-        d_alloc = self.tp_worker.model_runner.token_to_kv_pool_allocator
-        self.kv_transfers = [
-            PathwaysPDKVTransfer(
-                pm,
-                d_mesh,
-                w.model_runner.token_to_kv_pool,
-                d_kv,
-                p_alloc=self.p_allocs[i],
-                d_alloc=d_alloc,
-                page_size=server_args.page_size,
+        n_d = self._pd_n_decode
+        d_args.max_total_tokens = server_args.pd_decode_max_tokens
+        self.tp_workers_d = []
+        self.d_kvs, self.d_allocs = [], []
+        for j, dm in enumerate(self.d_meshes):
+            logger.info("[pathways_pd] loading D worker %d/%d on %s", j, n_d, dm.shape)
+            wd = TpWorkerClass(
+                server_args=d_args,
+                mesh=dm,
+                model_class=model_class,
+                precompile_params=precompile_params,
             )
+            self.tp_workers_d.append(wd)
+            d_kv = wd.model_runner.token_to_kv_pool
+            d_kv._donate_lock = threading.Lock()
+            self.d_kvs.append(d_kv)
+            self.d_allocs.append(wd.model_runner.token_to_kv_pool_allocator)
+        # Base Scheduler.__init__ reads self.tp_worker for D0 pool/tree/running_batch;
+        # D1.. get their own copies in _pd_init_decode_extras (called post-init).
+        self.tp_worker = self.tp_workers_d[0]
+        sw = getattr(self.tp_worker.worker.model_runner, "sliding_window_size", 0) or 0
+        swa_tail = -(-(sw + server_args.page_size) // server_args.page_size) if sw else 0
+        # kv_transfers[p_idx][d_idx]: each (P,D) pair needs its own gather/scatter
+        # jits (gather runs on P mesh, d_stack_shard + scatter on D mesh). A done
+        # batch goes to ONE D (batch-level RR via _pd_next_d), not broadcast --
+        # 1P-ND is fan-out routing, not replication.
+        self.kv_transfers = [
+            [
+                PathwaysPDKVTransfer(
+                    pm,
+                    dm,
+                    w.model_runner.token_to_kv_pool,
+                    self.d_kvs[j],
+                    p_alloc=self.p_allocs[i],
+                    d_alloc=self.d_allocs[j],
+                    page_size=server_args.page_size,
+                    swa_tail_pages=swa_tail,
+                )
+                for j, dm in enumerate(self.d_meshes)
+            ]
             for i, (pm, w) in enumerate(zip(p_meshes, self.tp_workers_p))
         ]
-        self.kv_transfer = self.kv_transfers[0]
+        self.kv_transfer = self.kv_transfers[0][0]
+        # Warm up gather/[stack/reshard/unstack]/scatter so the first real
+        # request doesn't pay the trace/lower cost (78-layer models: minutes).
+        for row in self.kv_transfers:
+            for kt in row:
+                kt.precompile()
+        # Per-dp RR counters: chunked prefill emits done batches of ~1 req in
+        # strict dp0,dp1,dp0,.. order (select_dp_for_request round_robin), so a
+        # single global RR counter phase-locks with dp -> dp0 all land on D0,
+        # dp1 all on D1 -> each D runs half its dp ranks empty. Per-dp counters
+        # give each dp its own D0->D1->D0 rotation, breaking the lock.
+        self._pd_next_d_per_dp = [0] * max(8, self.server_args.dp_size)
+        self._pd_next_d_lock = threading.Lock()
         self._pd_prefill_qs = [_Queue(maxsize=2) for _ in range(n_p)]
         self._pd_prefill_q = self._pd_prefill_qs[0]
-        self._pd_ready_q: _Queue = _Queue()
+        # cap ready_q so at most `max_inflight_transfers` gathered d_stacked
+        # buffers sit on D HBM waiting for scatter; prefill thread blocks on
+        # put() until the main loop drains one.
+        _max_inflight = max(1, server_args.disaggregation_max_inflight_transfers)
+        self._pd_ready_q: _Queue = _Queue(maxsize=_max_inflight)
         self._pd_qempty = _QEmpty
+        # a chunked req's chunk-N is in the prefill pipeline; main thread must
+        # drain it (updates prefix_indices) before building chunk-N+1. Per-P:
+        # each P slice has its own chunked_reqs (swapped in _pd_swap_p_pool) so
+        # req_A's chunk-2..N stay on the same P that holds chunk-1's KV.
+        self._pd_chunk_pending = [False] * n_p
+        self.p_chunked_reqs = [[None] * self.dp_size for _ in range(n_p)]
+        self._pd_t_pending_cleared = 0.0
+        self._pd_t_last_get_batch = 0.0
+        # ready_q items whose D-pool alloc was deferred (avail < need+reserved)
+        self._pd_defer: list = []
         # reqs pushed to prefill_q but not yet drained into running_batch;
-        # admission must reserve D r2t slots for them (single-item drain
-        # lets ready_q backlog while running_batch undercounts).
-        self._pd_inflight = 0
+        # tracked by rid so a chunked req counts once, not once-per-chunk.
+        self._pd_inflight_rids: set[str] = set()
+        self._pd_reserved_per = server_args.disaggregation_num_reserved_decode_tokens
+        self._pd_sliding_window = self.tp_workers_p[0].sliding_window_size or 0
         self._pd_next_p = 0
         self._pd_empty_running_p = [
             ScheduleBatch.init_new(
@@ -171,11 +245,88 @@ class PathwaysPDSchedulerMixin:
             t.start()
         self._pd_pending_migrate: ScheduleBatch | None = None
         logger.info(
-            "[pathways_pd] n_prefill=%d P pool=%d tok, D pool=%d tok",
+            "[pathways_pd] n_prefill=%d n_decode=%d P pool=%d tok, D pool=%d tok",
             n_p,
+            n_d,
             self.tp_worker_p.max_total_num_tokens,
             self.tp_worker.max_total_num_tokens,
         )
+
+    def _pd_init_decode_extras(self) -> None:
+        """Post base-__init__ setup for D1..N-1. Base __init__ already built
+        self.{req_to_token_pool, token_to_kv_pool_allocator, tree_cache,
+        running_batch} from tp_workers_d[0]; mirror those for the remaining
+        D workers so _pd_swap_d_pool can rotate the whole set."""
+        from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
+
+        self.d_r2ts = [self.req_to_token_pool]
+        self.d_trees = [self.tree_cache]
+        self.d_running_batches = [self.running_batch]
+        for j in range(1, self._pd_n_decode):
+            wd = self.tp_workers_d[j]
+            r2t, alloc = wd.get_memory_pool()
+            assert alloc is self.d_allocs[j]
+            self.d_r2ts.append(r2t)
+            tree = build_kv_cache(
+                server_args=self.server_args,
+                model_config=self.model_config,
+                req_to_token_pool=r2t,
+                token_to_kv_pool_allocator=alloc,
+                page_size=self.page_size,
+                is_hybrid=self.is_hybrid,
+                sliding_window_size=self.sliding_window_size,
+                tp_size=self.tp_size,
+                spec_algorithm=self.spec_algorithm,
+            )
+            self.d_trees.append(tree)
+            self.d_running_batches.append(
+                ScheduleBatch.init_new(
+                    reqs=[[] for _ in range(self.dp_size)],
+                    req_to_token_pool=r2t,
+                    token_to_kv_pool_allocator=alloc,
+                    tree_cache=tree,
+                    model_config=self.model_config,
+                    enable_overlap=self.enable_overlap,
+                    dp_size=self.dp_size,
+                    spec_algorithm=self.spec_algorithm,
+                    mesh=self.d_meshes[j],
+                )
+            )
+        # slot 0 aliases the base scheduler attrs; keep in sync at swap boundaries.
+        self.d_allocs[0] = self.token_to_kv_pool_allocator
+        self._pd_cur_d = 0
+
+    def _pd_set_d(self, d_idx: int) -> None:
+        """Point self.{tp_worker, tree_cache, req_to_token_pool,
+        token_to_kv_pool_allocator, mesh, running_batch} at D[d_idx].
+
+        Stateful (not a context manager): saves the CURRENT self.running_batch
+        back into d_running_batches[_pd_cur_d] first so any reassignment
+        (e.g. `self.running_batch = batch` in _pd_drain_ready) is captured.
+        _pd_swap_p_pool still layers on top via save/restore of whatever D
+        is loaded. n_decode==1: always d_idx==0 == cur_d, no-op."""
+        cur = self._pd_cur_d
+        if cur == d_idx:
+            return
+        self.d_running_batches[cur] = self.running_batch
+        self._pd_cur_d = d_idx
+        self.tp_worker = self.tp_workers_d[d_idx]
+        self.tree_cache = self.d_trees[d_idx]
+        self.req_to_token_pool = self.d_r2ts[d_idx]
+        self.token_to_kv_pool_allocator = self.d_allocs[d_idx]
+        self.mesh = self.d_meshes[d_idx]
+        self.running_batch = self.d_running_batches[d_idx]
+
+    def _pd_total_d_running(self) -> int:
+        if self._pd_n_decode == 1:
+            return sum(len(x.reqs) for x in self.running_batch.reqs_info if x.reqs)
+        # d_running_batches[cur_d] may be stale; self.running_batch is authoritative
+        tot = 0
+        for j, rb in enumerate(self.d_running_batches):
+            if j == self._pd_cur_d:
+                rb = self.running_batch
+            tot += sum(len(x.reqs) for x in rb.reqs_info if x.reqs)
+        return tot
 
     # ---- runtime helpers ----
 
@@ -183,28 +334,130 @@ class PathwaysPDSchedulerMixin:
         """Pathways-PD async prefill thread: P-slice forward + cross-slice KV
         gather/device_put run here so the main loop never blocks on P mesh.
         scatter into D pool stays on the main thread (see _pd_drain_ready).
-        Multi-P: one thread per P slice, each bound to its own
-        worker/pool/transfer; main thread round-robins batches across queues."""
+
+        chunked prefill: batch.reqs_info[dp].chunked_req marks the mid-chunk
+        req (still has more chunks queued on the main thread). Mid-chunk reqs
+        are NOT gathered — they stay in the P pool; only done reqs (final
+        chunk) are gathered + P-freed here. This thread updates the mid req's
+        prefix_indices (== ChunkCache.cache_unfinished_req, which neither
+        ChunkCache nor SWAChunkCache-derived state needs beyond this numpy
+        read) and clears _pd_chunk_pending itself, right after forward, so
+        the main loop can build chunk N+1 without waiting a full drain cycle
+        (was ~104ms/chunk of host round-trip; see [pd-chunk-cycle] log)."""
         from sgl_jax.srt.managers.scheduler import GenerationBatchResult
 
         worker = self.tp_workers_p[p_idx]
         p_r2t = self.p_r2ts[p_idx]
-        kv_transfer = self.kv_transfers[p_idx]
+        kv_transfers_d = self.kv_transfers[p_idx]  # [d_idx] -> transfer
+        n_d = self._pd_n_decode
         q = self._pd_prefill_qs[p_idx]
         paddings = worker.get_precompile_paddings()
+
+        def _disp(b):
+            _t0 = time.perf_counter()
+            _mwb = b.get_model_worker_batch(
+                *paddings, self.page_size, self.server_args.enable_static_lora
+            )
+            _mwb._pd_disp_t0 = time.perf_counter()
+            _, _ntok, _ = worker.forward_batch_generation(_mwb, sampling_metadata=None)
+            return _mwb, _ntok, _t0, time.perf_counter()
+
+        def _is_mid_only(b):
+            return all(
+                info.chunked_req is not None and len(info.reqs or ()) <= 1
+                for info in b.reqs_info
+                if info.reqs
+            )
+
+        _stash = None  # pre-dispatched (batch, mwb, ntok_dev, t0, t_disp)
         while True:
-            batch = q.get()
-            if batch is None:
-                return
+            if _stash is not None:
+                batch, mwb, ntok_dev, t0, t_disp = _stash
+                _stash = None
+            else:
+                batch = q.get()
+                if batch is None:
+                    return
+                mwb, ntok_dev, t0, t_disp = _disp(batch)
+            t_enq_p = getattr(batch, "_pd_t_enqueue_prefill", None)
             try:
-                t0 = time.perf_counter()
-                mwb = batch.get_model_worker_batch(
-                    *paddings, self.page_size, self.server_args.enable_static_lora
-                )
-                _, ntok_dev, _ = worker.forward_batch_generation(mwb, sampling_metadata=None)
-                t_disp = time.perf_counter()
+                # depth-1 pipeline: mid-only chunk clears pending right after
+                # dispatch (prefix_indices readable now — prepare_for_extend
+                # wrote P r2t pre-dispatch), then eagerly pull+dispatch N+1 so
+                # its mwb+disp hides under N's device wait. Mirrors the
+                # multi-process PD prefill overlap loop. done-chunk keeps late clear
+                # to guard gather-abort slot double-use. Stash chunks ALSO
+                # eager-dispatch (unbounded depth is safe: _stash is scalar so
+                # depth stays 1; _pd_eager_cleared prevents double-build).
+                if _is_mid_only(batch):
+                    for info in batch.reqs_info:
+                        r = info.chunked_req
+                        if r is not None:
+                            r.prefix_indices = p_r2t.req_to_token[
+                                r.req_pool_idx, : len(r.fill_ids)
+                            ].copy()
+                    self._pd_chunk_pending[p_idx] = False
+                    self._pd_t_pending_cleared = t_disp
+                    batch._pd_eager_cleared = True
+                    try:
+                        nxt = q.get(timeout=0.04)
+                    except _QEmpty:
+                        nxt = None
+                    if nxt is None:
+                        pass  # timeout or sentinel; sentinel re-read next iter via q.put below
+                    else:
+                        try:
+                            _stash = (nxt, *_disp(nxt))
+                        except Exception as _e:
+                            logger.exception("[pd_prefill %d] eager-stash dispatch failed", p_idx)
+                            for info in nxt.reqs_info:
+                                for r in info.reqs or ():
+                                    r.set_finish_with_abort(f"PD eager-stash error: {_e}")
+                            _tn = time.perf_counter()
+                            self._pd_ready_q.put((p_idx, 0, nxt, None, [], None, None, 0, _tn, _tn))
                 ntok = np.asarray(jax.device_get(ntok_dev))
+                if os.environ.get("SGLANG_PD_DBG_NTOK"):
+                    try:
+                        _sh = [
+                            (
+                                s.device.slice_index,
+                                str(s.index),
+                                np.asarray(s.data).flatten()[:4].tolist(),
+                            )
+                            for s in ntok_dev.addressable_shards
+                        ]
+                    except Exception as _e:
+                        _sh = f"err:{_e}"
+                    logger.info(
+                        "[ntok-shard p%d] shape=%s spec=%s full=%s shards=%s",
+                        p_idx,
+                        ntok.shape,
+                        getattr(ntok_dev.sharding, "spec", "?"),
+                        ntok.flatten().tolist()[:16],
+                        _sh,
+                    )
                 t_fwd = time.perf_counter()
+                _rids = [r.rid[:8] for info in batch.reqs_info if info.reqs for r in info.reqs]
+                _plens = [
+                    len(r.prefix_indices)
+                    for info in batch.reqs_info
+                    if info.reqs
+                    for r in info.reqs
+                ]
+                if _PD_DBG:
+                    logger.info(
+                        "[pd-dbg p%d] rids=%s prefix_lens=%s ntok=%s pool_idx=%s",
+                        p_idx,
+                        _rids,
+                        _plens,
+                        ntok.flatten()[:4].tolist(),
+                        [
+                            r.req_pool_idx
+                            for info in batch.reqs_info
+                            if info.reqs
+                            for r in info.reqs
+                        ],
+                    )
                 self._extract_dp_output_ids(ntok, mwb, batch)
                 result = GenerationBatchResult(
                     logits_output=None,
@@ -214,53 +467,207 @@ class PathwaysPDSchedulerMixin:
                     bid=mwb.bid,
                     cache_miss_count=0,
                 )
+                mid_reqs = [
+                    info.chunked_req for info in batch.reqs_info if info.chunked_req is not None
+                ]
+                mid_set = {id(r) for r in mid_reqs}
                 all_reqs = [r for info in batch.reqs_info if info.reqs for r in info.reqs]
-                p_pages_per_req = []
+                done_per_req = []
                 for r in all_reqs:
+                    if id(r) in mid_set:
+                        continue
                     seq_len = len(r.fill_ids)
                     p_slots = p_r2t.req_to_token[r.req_pool_idx, :seq_len].copy()
-                    p_pages_per_req.append(
+                    if _PD_DBG:
+                        logger.info(
+                            "[pd-done-dbg p%d] rid=%s seq_len=%d n_pages=%d pool_idx=%d prefix=%d",
+                            p_idx,
+                            r.rid[:8],
+                            seq_len,
+                            (seq_len + self.page_size - 1) // self.page_size,
+                            r.req_pool_idx,
+                            len(r.prefix_indices),
+                        )
+                    done_per_req.append(
                         (r, p_slots, slots_to_ordered_pages(p_slots, self.page_size))
                     )
-                p_pages_all = np.concatenate([p for _, _, p in p_pages_per_req])
-                d_stacked, bucket = kv_transfer.gather_to_dmesh(p_pages_all)
+                # prefix_indices is a pure read of the P r2t table (already
+                # written by this batch's prepare_for_extend before dispatch)
+                # -- safe to update regardless of what happens below.
+                for r in mid_reqs:
+                    r.prefix_indices = p_r2t.req_to_token[r.req_pool_idx, : len(r.fill_ids)].copy()
+                if done_per_req:
+                    # Batch-level RR to a single D target: gather once on P mesh
+                    # then device_put to d_meshes[d_idx]. done batches are small
+                    # (chunked prefill -> done=0~2) so batch-RR ~= req-RR for
+                    # load balance without splitting one gather across D targets.
+                    # RR counter is per-dp so dp-alternating done order doesn't
+                    # phase-lock dp<->D (see _pd_next_d_per_dp init comment).
+                    lead_dp = done_per_req[0][0].dp_rank or 0
+                    with self._pd_next_d_lock:
+                        d_idx = self._pd_next_d_per_dp[lead_dp] % n_d
+                        self._pd_next_d_per_dp[lead_dp] += 1
+                    kv_transfer = kv_transfers_d[d_idx]
+                    _dpl = [(r.dp_rank or 0, p) for r, _, p in done_per_req]
+                    p_pages_all = self._pd_group(_dpl, kv_transfer.p_dp_size)
+                    _tail = kv_transfer._swa_tail_pages
+                    p_swa_all = (
+                        self._pd_group([(dr, p[-_tail:]) for dr, p in _dpl], kv_transfer.p_dp_size)
+                        if _tail
+                        else None
+                    )
+                    d_stacked, bucket = kv_transfer.gather_to_dmesh(p_pages_all, p_swa_all)
+                else:
+                    d_idx, p_pages_all, d_stacked, bucket = 0, None, None, 0
                 t_gather = time.perf_counter()
-                logger.info(
-                    "[pd-timing] P fwd disp=%.0fms wait=%.0fms gather=%.0fms reqs=%d",
-                    (t_disp - t0) * 1e3,
-                    (t_fwd - t_disp) * 1e3,
-                    (t_gather - t_fwd) * 1e3,
-                    len(all_reqs),
-                )
+                # Only now -- after gather_to_dmesh succeeded for any done_per_req
+                # in this SAME batch -- is it safe to let the main loop build
+                # chunk N+1 reusing this req's req_pool_idx. Clearing pending
+                # any earlier (e.g. right after the prefix_indices update above)
+                # would let chunk N+1 be built+queued before we know whether a
+                # gather failure below is about to abort this whole batch
+                # (including mid_reqs) and free that same req_pool_idx out from
+                # under the newly-queued chunk N+1 -- a slot double-use.
+                if mid_reqs and not getattr(batch, "_pd_eager_cleared", False):
+                    self._pd_chunk_pending[p_idx] = False
+                    self._pd_t_pending_cleared = time.perf_counter()
+                if _PD_DBG_TIMING:
+                    logger.info(
+                        "[pd-timing] P fwd pq_wait=%.0fms disp=%.0fms wait=%.0fms gather=%.0fms "
+                        "done=%d mid=%d",
+                        (t0 - t_enq_p) * 1e3 if t_enq_p else -1.0,
+                        (t_disp - t0) * 1e3,
+                        (t_fwd - t_disp) * 1e3,
+                        (t_gather - t_fwd) * 1e3,
+                        len(done_per_req),
+                        len(mid_set),
+                    )
+                _t_put0 = time.perf_counter()
                 self._pd_ready_q.put(
-                    (p_idx, batch, result, p_pages_per_req, p_pages_all, d_stacked, bucket, t0)
+                    (
+                        p_idx,
+                        d_idx,
+                        batch,
+                        result,
+                        done_per_req,
+                        p_pages_all,
+                        d_stacked,
+                        bucket,
+                        t0,
+                        t_gather,
+                    )
                 )
-            except Exception:
-                logger.exception("[pd_prefill %d] thread error", p_idx)
-                psutil.Process().parent().send_signal(signal.SIGQUIT)
-                return
+                _put_ms = (time.perf_counter() - _t_put0) * 1e3
+                if _PD_DBG_TIMING and _put_ms > 10:
+                    logger.info(
+                        "[pd-put-block] ready_q.put blocked=%.0fms qsize=%d",
+                        _put_ms,
+                        self._pd_ready_q.qsize(),
+                    )
+            except Exception as e:
+                logger.exception("[pd_prefill %d] batch failed, aborting reqs", p_idx)
+                for info in batch.reqs_info:
+                    for r in info.reqs or ():
+                        r.set_finish_with_abort(f"PD prefill error: {e}")
+                _tnow = time.perf_counter()
+                self._pd_ready_q.put((p_idx, 0, batch, None, [], None, None, 0, _tnow, _tnow))
+
+    @staticmethod
+    def _pd_group(rank_pages: list[tuple[int, np.ndarray]], dp_size: int) -> np.ndarray:
+        """(dp_rank, pages)[] -> flat concat (dp==1) or [dp_size, n] (dp>1).
+
+        dp>1 empty-rank rows are left as page-index 0 (see
+        group_pages_by_dp_rank). This is SAFE: allocator.py never hands out
+        index 0 (`arange(1, size+1)`), so page 0 on both P and D pools is a
+        reserved sentinel no req's slots ever point at -- gather reads
+        uninitialised-zero and scatter overwrites the same never-read slot.
+        """
+        if dp_size == 1:
+            return np.concatenate([p for _, p in rank_pages])
+        pages, valid = group_pages_by_dp_rank(rank_pages, dp_size)
+        _prr = valid.sum(axis=1).tolist()
+        if _PD_DBG and (len(set(_prr)) > 1 or 0 in _prr):
+            logger.info(
+                "[pd-group-dbg] UNBALANCED per_rank_real=%s max_n=%d in=%s",
+                _prr,
+                pages.shape[1],
+                [(dr, len(p)) for dr, p in rank_pages],
+            )
+        return pages
 
     def _pd_drain_ready(self) -> None:
-        """Main-thread side of async PD: pop ONE ready item per call (avoid
-        burst stalling decode), rewrite req state to D side, scatter, then
-        process_prefill under D context so finished reqs release D pool."""
-        try:
-            item = self._pd_ready_q.get_nowait()
-        except self._pd_qempty:
+        """Main-thread side of async PD: pop ONE ready item, migrate done reqs
+        to D pool (capacity-gated: defer when avail < need+reserved instead of
+        raising), scatter, process_prefill, then merge into running_batch.
+        Mid-chunk reqs stay on P — cache_unfinished_req updates their
+        prefix_indices so the next get_new_batch_prefill builds chunk N+1."""
+        if self._pd_defer:
+            item = self._pd_defer.pop(0)
+        else:
+            try:
+                item = self._pd_ready_q.get_nowait()
+            except self._pd_qempty:
+                return
+        t_dequeue_ready = time.perf_counter()
+        (
+            p_idx,
+            d_idx,
+            batch,
+            result,
+            done_per_req,
+            p_pages_all,
+            d_stacked,
+            bucket,
+            t0,
+            t_enq_ready,
+        ) = item
+        p_alloc, p_r2t, p_tree = self.p_allocs[p_idx], self.p_r2ts[p_idx], self.p_trees[p_idx]
+        chunked_excl = {
+            dp: info.chunked_req
+            for dp, info in enumerate(batch.reqs_info)
+            if info.chunked_req is not None
+        }
+        if result is None:
+            # prefill thread reported failure; free P, clear inflight/chunked.
+            # TODO: proper stream-abort to client (currently client times out).
+            all_reqs = []
+            for info in batch.reqs_info:
+                for r in info.reqs or ():
+                    if r.req_pool_idx is not None:
+                        p_tree.cache_finished_req(r)
+                        p_r2t.free_slots.append(r.req_pool_idx)
+                    self._pd_inflight_rids.discard(r.rid)
+                    all_reqs.append(r)
+            self.stream_output(all_reqs, False, False)
+            for dp in chunked_excl:
+                self.p_chunked_reqs[p_idx][dp] = None
+            self._pd_chunk_pending[p_idx] = False
             return
-        p_idx, batch, result, p_pages_per_req, p_pages_all, d_stacked, bucket, t0 = item
-        p_alloc, p_r2t = self.p_allocs[p_idx], self.p_r2ts[p_idx]
+
+        # Load D[d_idx] state so allocator/r2t/tree_cache/running_batch below all
+        # point at the target D. n_decode==1: no-op (d_idx==_pd_cur_d==0).
+        self._pd_set_d(d_idx)
+        allocator = self.token_to_kv_pool_allocator
+        if done_per_req:
+            n_running = sum(len(x.reqs) for x in self.running_batch.reqs_info if x.reqs)
+            reserved = self._pd_reserved_per * (n_running + len(self._pd_inflight_rids))
+            reserved_per_rank = reserved // max(1, self.dp_size)
+            need_by_rank = defaultdict(int)
+            for r, _, p in done_per_req:
+                need_by_rank[r.dp_rank or 0] += len(p) * self.page_size
+            if any(
+                nd + reserved_per_rank > allocator.available_size(dp_rank=rk)
+                for rk, nd in need_by_rank.items()
+            ):
+                self._pd_defer.append(item)
+                return
         d_pages_all = []
-        _ann = jax.profiler.TraceAnnotation("pd_drain_ready")
-        _ann.__enter__()
-        for r, p_slots, p_pages in p_pages_per_req:
+        for r, p_slots, p_pages in done_per_req:
             seq_len = len(r.fill_ids)
             n_pages = len(p_pages)
-            d_slots = self.token_to_kv_pool_allocator.alloc(
-                n_pages * self.page_size, dp_rank=r.dp_rank or 0
-            )
+            d_slots = allocator.alloc(n_pages * self.page_size, dp_rank=r.dp_rank or 0)
             if d_slots is None:
-                raise RuntimeError("[pd_async] D pool OOM during insert")
+                raise RuntimeError("[pd_async] D pool OOM after capacity gate")
             d_pages = slots_to_ordered_pages(d_slots, self.page_size)
             p_slots64 = np.asarray(p_slots, np.int64)
             offsets = p_slots64 % self.page_size
@@ -279,21 +686,55 @@ class PathwaysPDSchedulerMixin:
             r.cache_protected_len = 0
             r.kv_committed_len = seq_len
             r.kv_allocated_len = seq_len
-            d_pages_all.append(d_pages)
-        _ts0 = time.perf_counter()
-        with jax.profiler.TraceAnnotation("pd_scatter"):
-            self.kv_transfers[p_idx].scatter_from_dmesh(
-                np.concatenate(d_pages_all), d_stacked, bucket
+            d_pages_all.append((r.dp_rank or 0, d_pages))
+        if d_pages_all:
+            _ts0 = time.perf_counter()
+            kt = self.kv_transfers[p_idx][d_idx]
+            _dpg = self._pd_group(d_pages_all, kt.d_dp_size)
+            _tail = kt._swa_tail_pages
+            _dsw = (
+                self._pd_group([(dr, p[-_tail:]) for dr, p in d_pages_all], kt.d_dp_size)
+                if _tail
+                else None
             )
-        _ts = (time.perf_counter() - _ts0) * 1e3
-        _tq = (time.perf_counter() - t0) * 1e3
-        if _ts > 100 or _tq > 3000:
-            logger.info(
-                "[pd-timing] scatter=%.0fms P->drain=%.0fms reqs=%d",
-                _ts,
-                _tq,
-                len(p_pages_per_req),
-            )
+            if _PD_DBG:
+                logger.info(
+                    "[pd-scatter-dbg p%d] dpg=%s rids=%s",
+                    p_idx,
+                    np.asarray(_dpg).reshape(kt.d_dp_size, -1)[:, :3].tolist(),
+                    [(r.rid[:8], r.dp_rank) for r, _, _ in done_per_req],
+                )
+            with jax.profiler.TraceAnnotation("pd_scatter"):
+                kt.scatter_from_dmesh(_dpg, d_stacked, bucket, _dsw)
+            # PD migrate hands D the full seq_len of swa slots (P kept them all
+            # for chunked prefill), but decode only needs the last sliding
+            # window. Without this immediate evict the D swa pool fills at
+            # ~seq_len/req (MiMo 16K/4K: 12.5K/req vs window=128) and caps
+            # running at ~56 (swa usage 0.91 never dropped -- the standard
+            # maybe_evict_swa path didn't fire on migrated reqs). Mirrors
+            # multi-process PD which only pulls the window-tail swa pages. Must
+            # run AFTER scatter (freed slots could otherwise be re-alloc'd by
+            # a later req in this same done_per_req loop and then overwritten
+            # by scatter).
+            if self._pd_sliding_window and hasattr(allocator, "free_swa"):
+                for r, _, _ in done_per_req:
+                    seq_len = len(r.fill_ids)
+                    tail = (
+                        (seq_len - self._pd_sliding_window - self.page_size) // self.page_size
+                    ) * self.page_size
+                    if tail > r.swa_evicted_seqlen:
+                        allocator.free_swa(
+                            self.req_to_token_pool.req_to_token[r.req_pool_idx, :tail],
+                            dp_rank=r.dp_rank or 0,
+                        )
+                        r.swa_evicted_seqlen = tail
+            if _PD_DBG_TIMING:
+                logger.info(
+                    "[pd-timing] scatter_disp=%.0fms P->drain=%.0fms reqs=%d",
+                    (time.perf_counter() - _ts0) * 1e3,
+                    (time.perf_counter() - t0) * 1e3,
+                    len(done_per_req),
+                )
         batch.req_to_token_pool = self.req_to_token_pool
         batch.token_to_kv_pool_allocator = self.token_to_kv_pool_allocator
         batch.tree_cache = self.tree_cache
@@ -302,13 +743,34 @@ class PathwaysPDSchedulerMixin:
                 info.req_pool_indices = np.array(
                     [r.req_pool_idx for r in info.reqs], dtype=np.int64
                 )
-        # process_prefill AFTER reqs are on D side: finished reqs (EOS on first
-        # token) release_kv_cache against D pool here, not leak.
         with jax.profiler.TraceAnnotation("pd_process_prefill"):
             self.process_batch_result_prefill(batch, result, None)
-        self._pd_inflight -= len(p_pages_per_req)
-        _ann.__exit__(None, None, None)
-        batch.filter_batch()
+        for r in chunked_excl.values():
+            # Redundant with the prefill thread's own update (same numpy read,
+            # done right after forward — see _pd_prefill_loop) but harmless
+            # and kept as a safety net. _pd_chunk_pending is NOT touched here:
+            # the prefill thread is now the sole authority for clearing it
+            # (success path), right after forward completes, so the main loop
+            # doesn't have to wait for this drain cycle to build chunk N+1.
+            # Only the error path (result is None, above) still clears it —
+            # that's a distinct failure recovery, not this normal-path drain.
+            p_tree.cache_unfinished_req(r)
+        if _PD_DBG_TIMING and chunked_excl:
+            logger.info(
+                "[pd-chunk-cycle] rq_wait=%.0fms drain=%.0fms (fwd_done->dequeue->drain_done)",
+                (t_dequeue_ready - t_enq_ready) * 1e3,
+                (time.perf_counter() - t_dequeue_ready) * 1e3,
+            )
+        for r, _, _ in done_per_req:
+            self._pd_inflight_rids.discard(r.rid)
+        if _PD_DBG and done_per_req and hasattr(p_alloc, "swa_available_size"):
+            logger.info(
+                "[pd-diag] after free %d done: P full_avail=%d swa_avail=%d",
+                len(done_per_req),
+                p_alloc.full_available_size(),
+                p_alloc.swa_available_size(),
+            )
+        batch.filter_batch(chunked_req_to_exclude=chunked_excl)
         if not batch.is_empty():
             if self.running_batch.is_empty():
                 self.running_batch = batch
@@ -316,50 +778,264 @@ class PathwaysPDSchedulerMixin:
                 self.running_batch.merge_batch(batch)
         if self.forward_ct % 20 == 0:
             logger.info(
-                "[pd_async] insert %d reqs e2e=%.1fms (D avail=%d)",
-                len(p_pages_per_req),
+                "[pd_async] drain done=%d mid=%d e2e=%.1fms (D avail=%d)",
+                len(done_per_req),
+                len(chunked_excl),
                 (time.perf_counter() - t0) * 1e3,
-                self.token_to_kv_pool_allocator.available_size(),
+                allocator.available_size(),
             )
 
-    def _pd_get_next_batch_async(self):
-        """Pathways-PD async scheduling: main loop only ever returns decode
-        batches; prefill batches are pushed to _pd_prefill_qs[i] (round-robin
-        across P slices) and run on prefill threads concurrently with D decode."""
-        self._pd_drain_ready()
+    def _pd_drain_ready_multi(self) -> int:
+        """Drain up to `ready_q.maxsize + 1` items per call instead of one.
+
+        At concurrency (many reqs each producing a ready_q item near-
+        simultaneously at their own chunk boundaries), a 1-pop-per-tick drain
+        falls behind the arrival rate and ready_q backlogs for seconds
+        (measured rq_wait 2.4-4.8s at C32, feeding directly into decode ITL
+        spikes since draining also merges finished reqs into running_batch).
+        Draining up to the full ready_q capacity per tick keeps the backlog
+        from compounding; each item is cheap (~2ms observed, including
+        done-item scatter, at this workload) so this doesn't itself stall
+        decode.
+
+        Stops early if a call makes no progress (ready_q size and defer-list
+        length both unchanged): a single D-pool-full item at the head of
+        _pd_defer gets re-popped and re-appended every call, so without this
+        guard the loop would burn its full budget retrying the same stuck
+        item instead of exiting once nothing more can be drained this tick.
+
+        Returns the number of `_pd_drain_ready()` calls made (test hook)."""
+        n_calls = 0
+        for _ in range(self._pd_ready_q.maxsize + 1):
+            if not self._pd_defer and self._pd_ready_q.empty():
+                break
+            n_defer_before, n_ready_before = len(self._pd_defer), self._pd_ready_q.qsize()
+            self._pd_drain_ready()
+            n_calls += 1
+            if len(self._pd_defer) == n_defer_before and self._pd_ready_q.qsize() == n_ready_before:
+                break
+        return n_calls
+
+    def _pd_maybe_push_prefill(self) -> None:
+        """Build at most one P batch (round-robin across P slices) and push to
+        its prefill_q. Extracted so both the n_decode==1 path
+        (_pd_get_next_batch_async via base event_loop_overlap) and the
+        n_decode>1 path (event_loop_overlap_pd_nd) share the same P admission.
+
+        Chunked prefill: while a chunked req's chunk-N is in-flight
+        (_pd_chunk_pending), skip building chunk-N+1. The prefill thread
+        clears pending itself right after chunk-N's forward (prefix_indices
+        updated there too), so this only blocks for actual forward latency,
+        not a full drain-cycle round-trip."""
+        _tnow = time.perf_counter()
+        if (
+            _PD_DBG_TIMING
+            and self._pd_t_last_get_batch > 0
+            and _tnow - self._pd_t_last_get_batch > 0.3
+        ):
+            logger.info(
+                "[pd-tick-gap] %.0fms since last get_batch (D running=%d)",
+                (_tnow - self._pd_t_last_get_batch) * 1e3,
+                sum(len(x.reqs) for x in self.running_batch.reqs_info if x.reqs),
+            )
+        self._pd_t_last_get_batch = _tnow
         n_p = self._pd_n_prefill
-        for _ in range(n_p):
-            i = self._pd_next_p
-            self._pd_next_p = (i + 1) % n_p
+        # One P build per tick (round-robin). Building for BOTH P in the same
+        # tick has get_new_batch_prefill(P0) walk waiting_queue and mutate
+        # reqs (init_next_round_input/add_one_req truncate) that P1 will pick
+        # up in the same tick -> observed 2P1D-only correctness bug on the
+        # first attempt. D tick ~29ms << P cycle ~330ms so 1 build/tick is
+        # plenty to keep both P threads fed.
+        for _off in range(n_p):
+            i = (self._pd_next_p + _off) % n_p
+            if self._pd_chunk_pending[i]:
+                continue
             if self._pd_prefill_qs[i].full():
                 continue
+            self._pd_next_p = (i + 1) % n_p
             saved = self.per_dp_max_running_requests
-            d_running = sum(len(x.reqs) for x in self.running_batch.reqs_info if x.reqs)
+            d_running = self._pd_total_d_running()
             # swap_p_pool replaces running_batch with an empty one so PrefillAdder
             # stops mixing D-side future-token reservation into the P pool budget;
-            # the D r2t slot constraint moves here explicitly (was implicit via
-            # get_new_batch_prefill's len(running_batch.reqs) check).
-            self.per_dp_max_running_requests = max(0, saved - self._pd_inflight - d_running)
+            # the D r2t slot constraint moves here explicitly. `saved` is per-dp
+            # but inflight/d_running are TOTAL across all dp ranks (single-process
+            # dp>1) — divide by dp_size so the subtraction is unit-consistent.
+            # (Previously subtracted totals directly: dp4 saved=64 hit 0 once
+            # d_running reached 64, freezing P admission for ~2min bursts and
+            # capping C128 D running at 64.)
+            # n_decode>1: total D r2t slots = n_d * saved * dp_size, and
+            # d_running/_pd_inflight_rids are already summed across all D.
+            self.per_dp_max_running_requests = max(
+                0,
+                saved * self._pd_n_decode
+                - (len(self._pd_inflight_rids) + d_running + self.dp_size - 1) // self.dp_size,
+            )
             try:
                 with self._pd_swap_p_pool(i):
                     new_batch = self.get_new_batch_prefill()
             finally:
                 self.per_dp_max_running_requests = saved
             if new_batch is None:
+                if any(r is not None for r in self.p_chunked_reqs[i]):
+                    self._pd_chunk_stall = getattr(self, "_pd_chunk_stall", 0) + 1
+                    if self._pd_chunk_stall % 500 == 1:
+                        pa = self.p_allocs[i]
+                        logger.warning(
+                            "[pd-diag] chunked stall x%d: P full=%d swa=%d",
+                            self._pd_chunk_stall,
+                            getattr(pa, "full_available_size", pa.available_size)(),
+                            pa.swa_available_size() if hasattr(pa, "swa_available_size") else -1,
+                        )
                 break
-            assert all(
-                r is None for r in self.chunked_reqs
-            ), "[pd_async] chunked prefill not supported (single-req IL exceeds pd_prefill_max_tokens)"
+            self._pd_chunk_stall = 0
             assert not any(
-                r.return_logprob for info in new_batch.reqs_info if info.reqs for r in info.reqs
+                r.return_logprob or r.return_hidden_states
+                for info in new_batch.reqs_info
+                if info.reqs
+                for r in info.reqs
             ), "[pd_async] return_logprob / hidden_states not yet supported (async prefill drops logits_output)"
-            self._pd_inflight += sum(len(info.reqs) for info in new_batch.reqs_info if info.reqs)
+            for info in new_batch.reqs_info:
+                for r in info.reqs or ():
+                    self._pd_inflight_rids.add(r.rid)
+            # Set pending only when this batch has a mid-chunk req (whose next
+            # chunk depends on this one draining). Final-chunk / non-chunked
+            # batches leave pending untouched so the main loop can immediately
+            # build the next req's chunk-1 while this one is still forwarding
+            # (depth=2 overlap). Drain only clears pending on a mid-chunk item.
+            if any(info.chunked_req is not None for info in new_batch.reqs_info):
+                self._pd_chunk_pending[i] = True
+            new_batch._pd_t_enqueue_prefill = time.perf_counter()
             self._pd_prefill_qs[i].put_nowait(new_batch)
             break
+
+    def _pd_get_next_batch_async(self):
+        """n_decode==1 entry point (called from base event_loop_overlap via
+        get_next_batch_to_run): push P, drain, return the D0 decode batch."""
+        self._pd_maybe_push_prefill()
+        # drain AFTER pushing next P batch so P thread's pq_wait doesn't
+        # include the ~130ms migrate of done reqs (drain overlaps P forward).
+        # chunked req's prefix_indices are already updated by P thread (:269),
+        # and new-req chunk-1 only needs waiting_queue (not drain), so build-
+        # before-drain is safe. done reqs merge into running_batch one tick
+        # later, harmless.
+        self._pd_drain_ready_multi()
         if not self.running_batch.is_empty() and not self.running_batch.is_prefill_only:
             self.running_batch = self.update_running_batch(self.running_batch)
             return self.running_batch if not self.running_batch.is_empty() else None
         return None
+
+    def event_loop_overlap_pd_nd(self):
+        """n_decode>1 event loop: one main-thread tick dispatches ALL D slices.
+
+        Each D has its own overlap ModelWorkerClient (own forward thread), so
+        dispatch is just N x input_queue.put (~7ms python each). Device-side
+        forwards run physically parallel on disjoint slices; the Pathways
+        dispatch queue serializes DISPATCH but each Execute is ~7ms so
+        N=2 dispatch (~14ms) < D forward (~24ms). resolve_last_batch_result
+        per D waits on that D's own output_queue -- by the time we resolve,
+        the previous tick's forward is already done, so it's D2H (~2ms) +
+        process_batch_result_decode (~3ms) per D. N=2 total main-thread
+        ~24ms ~= device 24.7ms (feasibility gate). N>=3 likely main-thread
+        bound; would need per-D sub-loop threads (not done here)."""
+        import gc as _gc
+        from collections import deque
+
+        from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+
+        assert self.enable_overlap, "pd_num_decode>1 requires --enable-overlap-schedule"
+        _gc.collect()
+        _gc.freeze()
+        _gc.set_threshold(700, 10, 10000)
+        n_d = self._pd_n_decode
+        self.result_queue = deque()
+        d_result_queues = [deque() for _ in range(n_d)]
+        d_last_batch: list = [None] * n_d
+        d_cur_batch: list = [None] * n_d
+        logger.info("[pathways_pd] entering event_loop_overlap_pd_nd n_decode=%d", n_d)
+
+        while True:
+            _it0 = time.perf_counter()
+            recv_reqs = (
+                self._comm_backend.recv_requests()
+                if self._comm_backend is not None
+                else self.recv_requests()
+            )
+            recv_reqs = self.select_dp_for_request(recv_reqs)
+            self.process_input_requests(recv_reqs)
+            if self._engine_paused:
+                continue
+
+            self._pd_maybe_push_prefill()
+            self._pd_drain_ready_multi()
+            _it1 = time.perf_counter()
+
+            any_batch = False
+            for j in range(n_d):
+                self._pd_set_d(j)
+                rb = self.running_batch
+                if not rb.is_empty() and not rb.is_prefill_only:
+                    self.running_batch = self.update_running_batch(rb)
+                    batch = self.running_batch if not self.running_batch.is_empty() else None
+                else:
+                    batch = None
+                d_cur_batch[j] = batch
+                self.cur_batch = batch
+                if batch:
+                    any_batch = True
+                    batch.launch_done = threading.Event()
+                    result = self.run_batch(batch)
+                    d_result_queues[j].append((batch.copy(), result))
+                    if d_last_batch[j] is None:
+                        tmp = ScheduleBatch.init_new(
+                            reqs=[[] for _ in range(self.dp_size)],
+                            req_to_token_pool=self.req_to_token_pool,
+                            token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                            tree_cache=self.tree_cache,
+                            model_config=self.model_config,
+                            enable_overlap=self.enable_overlap,
+                            dp_size=self.dp_size,
+                            spec_algorithm=self.spec_algorithm,
+                            mesh=self.mesh,
+                        )
+                        tmp.forward_mode = ForwardMode.DUMMY_FIRST
+                        tmp.next_batch_sampling_info = self.tp_worker.cur_sampling_info
+                        self.process_batch_result(tmp, None, batch.launch_done)
+            _it2 = time.perf_counter()
+
+            for j in range(n_d):
+                self._pd_set_d(j)
+                if d_last_batch[j]:
+                    tmp_b, tmp_r = d_result_queues[j].popleft()
+                    tmp_b.next_batch_sampling_info = (
+                        self.tp_worker.cur_sampling_info if d_cur_batch[j] else None
+                    )
+                    self.process_batch_result(
+                        tmp_b, tmp_r, d_cur_batch[j].launch_done if d_cur_batch[j] else None
+                    )
+                d_last_batch[j] = d_cur_batch[j]
+                self.last_batch = d_cur_batch[j]
+
+            if not any_batch and all(b is None for b in d_last_batch):
+                self.check_memory()
+                self.new_token_ratio = self.init_new_token_ratio
+
+            _it3 = time.perf_counter()
+            self.d_running_batches[self._pd_cur_d] = self.running_batch
+            if _PD_DBG_TIMING and (self.forward_ct % 40 == 0 or _it3 - _it0 > 0.3):
+                _runs = [
+                    sum(len(x.reqs) for x in rb.reqs_info if x.reqs)
+                    for rb in self.d_running_batches
+                ]
+                logger.info(
+                    "[pd-iter-nd] total=%.0fms push+drain=%.0f dispatch=%.0f resolve=%.0f "
+                    "running=%s inflight=%d",
+                    (_it3 - _it0) * 1e3,
+                    (_it1 - _it0) * 1e3,
+                    (_it2 - _it1) * 1e3,
+                    (_it3 - _it2) * 1e3,
+                    _runs,
+                    len(self._pd_inflight_rids),
+                )
 
     def _pd_gather_output(self, arr, is_prefill: bool) -> np.ndarray:
         """Sub-mesh forward output (addressable on one side only) -> full numpy."""
@@ -378,7 +1054,9 @@ class PathwaysPDSchedulerMixin:
             self.mesh,
             self.running_batch,
             self.max_total_num_tokens,
+            self.chunked_reqs,
         )
+        self.chunked_reqs = self.p_chunked_reqs[p_idx]
         self.tree_cache = self.p_trees[p_idx]
         self.req_to_token_pool = self.p_r2ts[p_idx]
         self.token_to_kv_pool_allocator = self.p_allocs[p_idx]
@@ -403,6 +1081,7 @@ class PathwaysPDSchedulerMixin:
                 self.mesh,
                 self.running_batch,
                 self.max_total_num_tokens,
+                self.chunked_reqs,
             ) = saved
 
     def _pd_migrate(self, batch: ScheduleBatch) -> bool:

--- a/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
+++ b/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
@@ -182,11 +182,20 @@ class PathwaysPDSchedulerMixin:
             for i, (pm, w) in enumerate(zip(p_meshes, self.tp_workers_p))
         ]
         self.kv_transfer = self.kv_transfers[0][0]
-        # Warm up gather/[stack/reshard/unstack]/scatter so the first real
-        # request doesn't pay the trace/lower cost (78-layer models: minutes).
-        for row in self.kv_transfers:
-            for kt in row:
-                kt.precompile()
+        # Base Scheduler skips run_precompile under PD (`and not self.pd` in
+        # scheduler.py), so P/D workers would first-compile on the first real
+        # request (~minutes on 78L models). Precompile all of them here, plus
+        # the KV-transfer gather/[stack/reshard/unstack]/scatter per bucket.
+        if not server_args.disable_precompile:
+            for i, w in enumerate(self.tp_workers_p):
+                logger.info("[pathways_pd] precompiling P worker %d forward (extend only)", i)
+                w.run_precompile(only="extend")
+            for j, w in enumerate(self.tp_workers_d):
+                logger.info("[pathways_pd] precompiling D worker %d forward (decode only)", j)
+                w.run_precompile(only="decode")
+            for row in self.kv_transfers:
+                for kt in row:
+                    kt.precompile()
         # Per-dp RR counters: chunked prefill emits done batches of ~1 req in
         # strict dp0,dp1,dp0,.. order (select_dp_for_request round_robin), so a
         # single global RR counter phase-locks with dp -> dp0 all land on D0,

--- a/python/sgl_jax/srt/layers/fused_moe.py
+++ b/python/sgl_jax/srt/layers/fused_moe.py
@@ -600,6 +600,10 @@ class FusedEPMoEV2(FusedEPMoE):
             )
 
         direct_scaled_dot = w1_scale is not None
+        kernel_sharding = jax.sharding.NamedSharding(self.mesh, P(("data", "tensor"), None))
+        hidden_states = jax.sharding.reshard(hidden_states, kernel_sharding)
+        topk_weights = jax.sharding.reshard(topk_weights, kernel_sharding)
+        topk_ids = jax.sharding.reshard(topk_ids, kernel_sharding)
 
         output = fused_ep_moe_v2(
             self.mesh,

--- a/python/sgl_jax/srt/layers/logits_processor.py
+++ b/python/sgl_jax/srt/layers/logits_processor.py
@@ -258,6 +258,10 @@ class LogitsProcessor(nnx.Module):
         def select_local_fn(local_states, local_indices):
             return local_states[local_indices]
 
+        hidden_states = jax.sharding.reshard(
+            hidden_states,
+            NamedSharding(self.mesh, P("data", None)),
+        )
         return jax.shard_map(
             select_local_fn,
             mesh=self.mesh,

--- a/python/sgl_jax/srt/layers/logits_processor.py
+++ b/python/sgl_jax/srt/layers/logits_processor.py
@@ -258,10 +258,6 @@ class LogitsProcessor(nnx.Module):
         def select_local_fn(local_states, local_indices):
             return local_states[local_indices]
 
-        hidden_states = jax.sharding.reshard(
-            hidden_states,
-            NamedSharding(self.mesh, P("data", None)),
-        )
         return jax.shard_map(
             select_local_fn,
             mesh=self.mesh,

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -82,6 +82,7 @@ PADDING_BUCKETS = [1 << i for i in range(6, 21)]
 
 # Put some global args for easy access
 global_server_args_dict = {k: getattr(ServerArgs, k) for k in GLOBAL_SERVER_ARGS_KEYS}
+_PD_PROXY = os.getenv("JAX_PLATFORMS") == "proxy"
 
 logger = logging.getLogger(__name__)
 
@@ -2463,14 +2464,14 @@ class ScheduleBatch:
             # Move to next DP rank's section (fixed stride)
             offset_bs += per_dp_cache_loc_size
 
-        # copy(): cache_loc_cpu is a VIEW into the per-r2t reusable
-        # cache_loc_host_buf. Pathways-PD eager-stash calls _disp(nxt)
+        # copy() only under Pathways-PD: cache_loc_cpu is a VIEW into the
+        # per-r2t reusable cache_loc_host_buf. PD eager-stash calls _disp(nxt)
         # (which re-enters this path on the SAME r2t and overwrites host_buf)
         # before batch N's make_array_from_callback H2D has necessarily
         # consumed the view -> batch N forward reads nxt's cache_loc and
-        # writes KV to wrong slots. n_prefill>1 also races across P threads
-        # if they somehow shared a host_buf (they don't today, per-r2t).
-        return cache_loc_cpu.copy()
+        # writes KV to wrong slots. Native/colocated has no concurrent stash
+        # so the view is consumed before any overwrite.
+        return cache_loc_cpu.copy() if _PD_PROXY else cache_loc_cpu
 
     def _merge_sampling_info(
         self,

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1177,8 +1177,14 @@ class ScheduleBatch:
 
             # Init arrays
             seq_lens = [len(r.fill_ids) for r in reqs]
-            prefix_lens = [len(r.prefix_indices) for r in reqs]
             extend_lens = [r.extend_input_len for r in reqs]
+            # PD: P thread may concurrently reassign r.prefix_indices (stash
+            # eager path, pathways_scheduler:_pd_prefill_loop). fill_ids and
+            # extend_input_len are only set by this (main) thread in
+            # init_next_round_input/add_one_req, so derive prefix_lens from
+            # those instead of re-reading len(r.prefix_indices) which can race
+            # ahead -> fill_ids[pre_len:] empty -> np.fromiter count mismatch.
+            prefix_lens = [s - e for s, e in zip(seq_lens, extend_lens)]
             extend_num_tokens = sum(extend_lens)
 
             req_pool_indices_cpu = np.array(req_pool_indices, dtype=np.int32)
@@ -1206,11 +1212,12 @@ class ScheduleBatch:
                 # tree-protected and leak it on finish.
                 req.cache_protected_len = req.last_matched_prefix_len
 
-                prefix_indices = req.prefix_indices
                 if pre_len > 0:
-                    # note: prefix_indices has to locate on device, or will meet Received incompatible devices for jitted computation
+                    # req.prefix_indices may have been reassigned to a longer
+                    # array by the P thread (same race as prefix_lens above);
+                    # pre_len is the main-thread snapshot, so slice to match.
                     self.req_to_token_pool.write(
-                        (req.req_pool_idx, slice(0, pre_len)), prefix_indices
+                        (req.req_pool_idx, slice(0, pre_len)), req.prefix_indices[:pre_len]
                     )
 
                 req.cached_tokens += pre_len - req.already_computed
@@ -1241,10 +1248,7 @@ class ScheduleBatch:
                     # input_logprobs = [1, 2, 3, 4]
                     # fill_ids = [3, 4]
                     # extend_input_logprob_token_id = [4, 0]
-                    global_start_idx, global_end_idx = (
-                        len(req.prefix_indices),
-                        len(req.fill_ids),
-                    )
+                    global_start_idx, global_end_idx = (pre_len, seq_len)
                     # Apply logprob_start_len
                     if global_start_idx < req.logprob_start_len:
                         global_start_idx = req.logprob_start_len
@@ -2386,6 +2390,9 @@ class ScheduleBatch:
 
         offset_bs = 0
         req_to_token = self.req_to_token_pool.req_to_token
+        max_context_len = req_to_token.shape[1]
+        req_to_token_flat = req_to_token.reshape(-1)
+        page_ramp = np.arange(page_size, dtype=req_to_token.dtype) if page_size > 1 else None
 
         for dp_rank in range(self.dp_size):
             info = self.reqs_info[dp_rank]
@@ -2394,27 +2401,58 @@ class ScheduleBatch:
                 offset_bs += per_dp_cache_loc_size
                 continue
 
-            seq_lens = info.seq_lens
-            req_pool_indices = info.req_pool_indices
+            seq_lens = np.asarray(info.seq_lens)
+            req_pool_indices = np.asarray(info.req_pool_indices)
 
             n_reqs = len(seq_lens)
-            if n_reqs > 0:
-                # Page-aligned offsets per request
-                aligned_lens = ((seq_lens + page_size - 1) // page_size) * page_size
-                offsets = np.empty(n_reqs, dtype=np.int64)
-                offsets[0] = 0
-                np.cumsum(aligned_lens[:-1], out=offsets[1:])
+            # Page-aligned offsets per request
+            aligned_lens = ((seq_lens + page_size - 1) // page_size) * page_size
+            offsets = np.empty(n_reqs, dtype=np.int64)
+            offsets[0] = 0
+            np.cumsum(aligned_lens[:-1], out=offsets[1:])
 
-                # Per-req contiguous slice copy from req_to_token directly.
-                # Avoids:
-                #  - the 8MB-per-DP intermediate `req_to_token[req_pool_indices]`
-                #    full-row gather (only first seq_len of each row is used)
-                #  - the 1M-element fancy-index scatter, which numpy serialises
-                #    at Python level rather than as a contiguous memcpy.
-                # Measured ~40x speedup at BSZ=64 OSL=16K decode vs the
-                # vectorised fancy-index version (~12ms -> ~0.3ms).
-                # Byte-for-byte identical output (verified with 14 edge cases
-                # incl. BSZ in {1,8,32,64,512}, empty DPs, page boundaries).
+            if page_size > 1:
+                # PagedTokenToKVPoolAllocator (allocator.py alloc/_alloc_extend_impl/
+                # _alloc_decode_impl) always writes page-contiguous slot indices:
+                #   req_to_token[idx, p*page_size + j] == req_to_token[idx, p*page_size] + j
+                # so the full token-level cache_loc can be reconstructed from
+                # page-start values alone. This turns the O(bs) Python loop of
+                # ~seq_len memcpys into a single vectorised gather of
+                # sum(n_pages) ints (page_size x fewer reads from the large
+                # req_to_token array) plus one broadcast-add write. Under
+                # Pathways-head GIL contention the loop dominated run_batch
+                # (profiled 12.4ms@bs=64 -> 24.8ms@bs=128, MiMo 16K/4K page=256).
+                # Real-token positions are byte-identical to the loop; padding
+                # tail [seq_len:aligned] gets page_start+j (a valid in-bounds
+                # slot in the same allocated page) instead of stale buffer
+                # residue, which is still safe per the persistent-buffer note
+                # above.
+                n_pages = aligned_lens // page_size
+                total_pages = int(n_pages.sum())
+                if total_pages > 0:
+                    total_aligned = total_pages * page_size
+                    # Ragged flat indices of page-start slots in req_to_token:
+                    #   flat_src[g] = idx[r]*W + p*page_size
+                    # where g is the global page index and (r, p) its req/local-page.
+                    # Since dest is contiguous (offsets = cumsum(aligned)), g runs
+                    # 0..total_pages-1 and p = g - page_cum[r], so
+                    #   flat_src[g] = (idx[r]*W - page_cum[r]*page_size) + g*page_size.
+                    page_cum = offsets // page_size
+                    row_base = req_pool_indices.astype(np.int64) * max_context_len
+                    flat_src = np.repeat(row_base - page_cum * page_size, n_pages)
+                    flat_src += np.arange(total_pages, dtype=np.int64) * page_size
+                    page_starts = req_to_token_flat[flat_src]
+                    dest = cache_loc_cpu[offset_bs : offset_bs + total_aligned]
+                    np.add(
+                        page_starts.reshape(total_pages, 1),
+                        page_ramp.reshape(1, page_size),
+                        out=dest.reshape(total_pages, page_size),
+                    )
+            else:
+                # page_size == 1: non-paged TokenToKVPoolAllocator has no
+                # contiguity guarantee; keep the per-req contiguous slice copy
+                # (still avoids the full-row gather + fancy scatter, ~40x faster
+                # than that at BSZ=64 OSL=16K decode).
                 for r in range(n_reqs):
                     sl = int(seq_lens[r])
                     dest_start = int(offsets[r]) + offset_bs
@@ -2425,7 +2463,14 @@ class ScheduleBatch:
             # Move to next DP rank's section (fixed stride)
             offset_bs += per_dp_cache_loc_size
 
-        return cache_loc_cpu
+        # copy(): cache_loc_cpu is a VIEW into the per-r2t reusable
+        # cache_loc_host_buf. Pathways-PD eager-stash calls _disp(nxt)
+        # (which re-enters this path on the SAME r2t and overwrites host_buf)
+        # before batch N's make_array_from_callback H2D has necessarily
+        # consumed the view -> batch N forward reads nxt's cache_loc and
+        # writes KV to wrong slots. n_prefill>1 also races across P threads
+        # if they somehow shared a host_buf (they don't today, per-r2t).
+        return cache_loc_cpu.copy()
 
     def _merge_sampling_info(
         self,
@@ -3195,13 +3240,19 @@ class ScheduleBatch:
         for info in self.reqs_info:
             # Create a new ScheduleReqsInfo with shallow copies of necessary fields
             new_info = ScheduleReqsInfo()
-            new_info.reqs = info.reqs  # Shallow copy (list reference)
+            new_info.reqs = list(info.reqs) if info.reqs else info.reqs
             new_info.out_cache_loc = info.out_cache_loc
-            new_info.decoding_reqs = info.decoding_reqs
+            new_info.decoding_reqs = (
+                list(info.decoding_reqs) if info.decoding_reqs else info.decoding_reqs
+            )
             # process_batch_result compacts per-DP padded input logprobs via
             # _input_logprob_lens_per_dp, which reads these.
-            new_info.extend_lens = info.extend_lens
-            new_info.extend_logprob_start_lens = info.extend_logprob_start_lens
+            new_info.extend_lens = list(info.extend_lens) if info.extend_lens else info.extend_lens
+            new_info.extend_logprob_start_lens = (
+                list(info.extend_logprob_start_lens)
+                if info.extend_logprob_start_lens
+                else info.extend_logprob_start_lens
+            )
             new_info.spec_info = info.spec_info
             copied_reqs_info.append(new_info)
 

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1179,12 +1179,8 @@ class ScheduleBatch:
             # Init arrays
             seq_lens = [len(r.fill_ids) for r in reqs]
             extend_lens = [r.extend_input_len for r in reqs]
-            # PD: P thread may concurrently reassign r.prefix_indices (stash
-            # eager path, pathways_scheduler:_pd_prefill_loop). fill_ids and
-            # extend_input_len are only set by this (main) thread in
-            # init_next_round_input/add_one_req, so derive prefix_lens from
-            # those instead of re-reading len(r.prefix_indices) which can race
-            # ahead -> fill_ids[pre_len:] empty -> np.fromiter count mismatch.
+            # Derive from main-thread-owned fields: r.prefix_indices can be
+            # concurrently reassigned by the PD P-thread eager-stash path.
             prefix_lens = [s - e for s, e in zip(seq_lens, extend_lens)]
             extend_num_tokens = sum(extend_lens)
 
@@ -1214,9 +1210,7 @@ class ScheduleBatch:
                 req.cache_protected_len = req.last_matched_prefix_len
 
                 if pre_len > 0:
-                    # req.prefix_indices may have been reassigned to a longer
-                    # array by the P thread (same race as prefix_lens above);
-                    # pre_len is the main-thread snapshot, so slice to match.
+                    # Slice: same P-thread race on prefix_indices as above.
                     self.req_to_token_pool.write(
                         (req.req_pool_idx, slice(0, pre_len)), req.prefix_indices[:pre_len]
                     )
@@ -2413,31 +2407,16 @@ class ScheduleBatch:
             np.cumsum(aligned_lens[:-1], out=offsets[1:])
 
             if page_size > 1:
-                # PagedTokenToKVPoolAllocator (allocator.py alloc/_alloc_extend_impl/
-                # _alloc_decode_impl) always writes page-contiguous slot indices:
-                #   req_to_token[idx, p*page_size + j] == req_to_token[idx, p*page_size] + j
-                # so the full token-level cache_loc can be reconstructed from
-                # page-start values alone. This turns the O(bs) Python loop of
-                # ~seq_len memcpys into a single vectorised gather of
-                # sum(n_pages) ints (page_size x fewer reads from the large
-                # req_to_token array) plus one broadcast-add write. Under
-                # Pathways-head GIL contention the loop dominated run_batch
-                # (profiled 12.4ms@bs=64 -> 24.8ms@bs=128, MiMo 16K/4K page=256).
-                # Real-token positions are byte-identical to the loop; padding
-                # tail [seq_len:aligned] gets page_start+j (a valid in-bounds
-                # slot in the same allocated page) instead of stale buffer
-                # residue, which is still safe per the persistent-buffer note
-                # above.
+                # PagedTokenToKVPoolAllocator writes page-contiguous slot indices
+                # (req_to_token[i, p*ps+j] == req_to_token[i, p*ps] + j), so the
+                # per-req loop can be replaced by one gather of page-start values
+                # plus a broadcast-add. Padding tail [seq_len:aligned] lands in
+                # the same allocated page so remains safe.
                 n_pages = aligned_lens // page_size
                 total_pages = int(n_pages.sum())
                 if total_pages > 0:
                     total_aligned = total_pages * page_size
-                    # Ragged flat indices of page-start slots in req_to_token:
-                    #   flat_src[g] = idx[r]*W + p*page_size
-                    # where g is the global page index and (r, p) its req/local-page.
-                    # Since dest is contiguous (offsets = cumsum(aligned)), g runs
-                    # 0..total_pages-1 and p = g - page_cum[r], so
-                    #   flat_src[g] = (idx[r]*W - page_cum[r]*page_size) + g*page_size.
+                    # flat_src[g] = idx[r]*W + p*ps = (idx[r]*W - page_cum[r]*ps) + g*ps
                     page_cum = offsets // page_size
                     row_base = req_pool_indices.astype(np.int64) * max_context_len
                     flat_src = np.repeat(row_base - page_cum * page_size, n_pages)
@@ -2450,10 +2429,7 @@ class ScheduleBatch:
                         out=dest.reshape(total_pages, page_size),
                     )
             else:
-                # page_size == 1: non-paged TokenToKVPoolAllocator has no
-                # contiguity guarantee; keep the per-req contiguous slice copy
-                # (still avoids the full-row gather + fancy scatter, ~40x faster
-                # than that at BSZ=64 OSL=16K decode).
+                # Non-paged allocator has no page-contiguity guarantee.
                 for r in range(n_reqs):
                     sl = int(seq_lens[r])
                     dest_start = int(offsets[r]) + offset_bs
@@ -2464,13 +2440,9 @@ class ScheduleBatch:
             # Move to next DP rank's section (fixed stride)
             offset_bs += per_dp_cache_loc_size
 
-        # copy() only under Pathways-PD: cache_loc_cpu is a VIEW into the
-        # per-r2t reusable cache_loc_host_buf. PD eager-stash calls _disp(nxt)
-        # (which re-enters this path on the SAME r2t and overwrites host_buf)
-        # before batch N's make_array_from_callback H2D has necessarily
-        # consumed the view -> batch N forward reads nxt's cache_loc and
-        # writes KV to wrong slots. Native/colocated (single scheduler thread,
-        # no concurrent stash) consume the view before any overwrite.
+        # cache_loc_cpu is a view into the reusable host_buf; PD eager-stash
+        # can overwrite it via _disp(nxt) before this batch's H2D consumes the
+        # view. Single-threaded (native/colocated) callers don't need the copy.
         if global_server_args_dict.get("pd_disaggregation") == "pathways":
             return cache_loc_cpu.copy()
         return cache_loc_cpu

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -76,13 +76,13 @@ GLOBAL_SERVER_ARGS_KEYS = [
     "speculative_accept_threshold_single",
     "speculative_accept_threshold_acc",
     "enable_deterministic_sampling",
+    "pd_disaggregation",
 ]
 
 PADDING_BUCKETS = [1 << i for i in range(6, 21)]
 
 # Put some global args for easy access
 global_server_args_dict = {k: getattr(ServerArgs, k) for k in GLOBAL_SERVER_ARGS_KEYS}
-_PD_PROXY = os.getenv("JAX_PLATFORMS") == "proxy"
 
 logger = logging.getLogger(__name__)
 
@@ -2469,9 +2469,11 @@ class ScheduleBatch:
         # (which re-enters this path on the SAME r2t and overwrites host_buf)
         # before batch N's make_array_from_callback H2D has necessarily
         # consumed the view -> batch N forward reads nxt's cache_loc and
-        # writes KV to wrong slots. Native/colocated has no concurrent stash
-        # so the view is consumed before any overwrite.
-        return cache_loc_cpu.copy() if _PD_PROXY else cache_loc_cpu
+        # writes KV to wrong slots. Native/colocated (single scheduler thread,
+        # no concurrent stash) consume the view before any overwrite.
+        if global_server_args_dict.get("pd_disaggregation") == "pathways":
+            return cache_loc_cpu.copy()
+        return cache_loc_cpu
 
     def _merge_sampling_info(
         self,

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -425,6 +425,8 @@ class Scheduler(
             spec_algorithm=self.spec_algorithm,
             mesh=self.mesh,
         )
+        if self.pd == "pathways":
+            self._pd_init_decode_extras()
         # The current forward batch
         self.cur_batch: ScheduleBatch | None = None
         # The last forward batch
@@ -1009,13 +1011,30 @@ class Scheduler(
             if self._engine_paused:
                 continue
 
+            _it1 = time.perf_counter() if self.pd == "pathways" else 0.0
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
             self._flush_pending_h2d()
+            _it2 = time.perf_counter() if self.pd == "pathways" else 0.0
 
             if batch:
                 result = self.run_batch(batch)
+                _it3 = time.perf_counter() if self.pd == "pathways" else 0.0
                 self.process_batch_result(batch, result)
+                if (
+                    self.pd == "pathways"
+                    and os.environ.get("SGLANG_PD_DBG")
+                    and self.forward_ct % 50 == 0
+                ):
+                    _it4 = time.perf_counter()
+                    logger.info(
+                        "[pd-iter-n] get_batch=%.1f run=%.1f proc=%.1f tot=%.1f running=%d",
+                        (_it2 - _it1) * 1e3,
+                        (_it3 - _it2) * 1e3,
+                        (_it4 - _it3) * 1e3,
+                        (_it4 - _it1) * 1e3,
+                        sum(len(i.reqs) for i in self.running_batch.reqs_info),
+                    )
             else:
                 # When the server is idle, do self-check and re-init some states
                 self.check_memory()
@@ -1031,7 +1050,7 @@ class Scheduler(
     def event_loop_overlap(self):
         """A scheduler loop that overlaps the CPU processing and Accelerator computation."""
         self.result_queue = deque()
-        _pd_iter_trace = self.pd == "pathways"
+        _pd_iter_trace = self.pd == "pathways" and os.environ.get("SGLANG_PD_DBG")
 
         if self.pd == "pathways":
             import gc as _gc
@@ -1130,7 +1149,7 @@ class Scheduler(
                         (_it2 - _it1) * 1e3,
                         (_it3 - _it2) * 1e3,
                         sum(len(i.reqs) for i in self.running_batch.reqs_info),
-                        getattr(self, "_pd_inflight", 0),
+                        len(getattr(self, "_pd_inflight_rids", ())),
                     )
 
     def run_publisher(self, recv_reqs):
@@ -2635,6 +2654,8 @@ def dispatch_scheduler_event_loop(scheduler: Scheduler, server_args: ServerArgs)
         scheduler.event_loop_normal_disagg_prefill()
     elif mode == "decode":
         scheduler.event_loop_normal_disagg_decode()
+    elif scheduler.pd == "pathways" and getattr(scheduler, "_pd_n_decode", 1) > 1:
+        scheduler.event_loop_overlap_pd_nd()
     elif scheduler.enable_overlap:
         scheduler.event_loop_overlap()
     else:

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -226,10 +226,8 @@ class ModelWorker:
 
         assert self.max_running_requests > 0, "max_running_request is zero"
 
-        # Fused resolve/set path needs a future_token_ids_map array of the same
-        # shape as ModelWorkerClient.future_token_ids_map for callers that don't
-        # supply one (precompile, non-overlap). Real ids are always >=0 there so
-        # resolve is a no-op and the returned map is discarded.
+        # Same-shape dummy for callers without a real future map (precompile,
+        # non-overlap) so the fused jit variant matches the overlap-thread shape.
         if self._pd_fuse_sample:
             self._pd_dummy_future_map = jax.device_put(
                 jnp.zeros((self.max_running_requests * 5,), dtype=jnp.int32),
@@ -475,10 +473,8 @@ class ModelWorker:
         self.model_runner.attn_backend.forward_metadata = forward_metadata
         logits_metadata = LogitsMetadata.from_model_worker_batch(model_worker_batch, self.mesh)
 
-        # Pathways: fuse run_model+sampler into one jit to drop one Execute
-        # round-trip (~10ms/tick through the dispatch queue). Skips the debug-only
-        # DUMP_LAST_LAYER_LOGITS path and per-token logprob path (both add
-        # extra device_get anyway). Gated by env so CO/native path unchanged.
+        # Pathways-PD: fuse run_model+sampler+resolve/set into one jit so a
+        # decode tick is a single Execute through the ordered dispatch queue.
         if (
             self._pd_fuse_sample
             and not skip_sample
@@ -486,9 +482,6 @@ class ModelWorker:
         ):
             if model_worker_batch.sampling_info:
                 self._update_grammar_vocab_mask(model_worker_batch, sampling_metadata)
-            # Precompile / non-overlap callers don't have a future map; feed the
-            # same-shape dummy so the compiled variant matches the overlap
-            # thread's runtime shape (resolve/set are semantic no-ops there).
             fmap = future_map if future_map is not None else self._pd_dummy_future_map
             fct = future_ct if future_ct is not None else 0
             (

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -4,6 +4,7 @@ import logging
 import os
 import signal
 import threading
+import time
 from queue import Queue
 
 import jax
@@ -12,6 +13,8 @@ import numpy as np
 import psutil
 from flax import nnx
 from jax.experimental.multihost_utils import broadcast_one_to_all
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.configs.model_config import ModelConfig
 from sgl_jax.srt.constrained.bitmask_ops import allocate_token_bitmask
@@ -71,6 +74,7 @@ class ModelWorker:
         # Parse args
         self.tp_size = server_args.tp_size
         self.dp_size = server_args.dp_size
+        self._pd_fuse_sample = os.getenv("SGLANG_PD_FUSE_SAMPLE") == "1"
         from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
 
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
@@ -220,6 +224,16 @@ class ModelWorker:
 
         assert self.max_running_requests > 0, "max_running_request is zero"
 
+        # Fused resolve/set path needs a future_token_ids_map array of the same
+        # shape as ModelWorkerClient.future_token_ids_map for callers that don't
+        # supply one (precompile, non-overlap). Real ids are always >=0 there so
+        # resolve is a no-op and the returned map is discarded.
+        if self._pd_fuse_sample:
+            self._pd_dummy_future_map = jax.device_put(
+                jnp.zeros((self.max_running_requests * 5,), dtype=jnp.int32),
+                NamedSharding(self.mesh, P(None)),
+            )
+
         # A single request lives on one DP rank, so max_req_len is bounded
         # by per-rank pool size, not the global (dp-scaled) pool size.
         per_rank_tokens = (
@@ -255,6 +269,7 @@ class ModelWorker:
             page_size=self.page_size,
             max_req_len=self.max_req_len,
             vocab_size=self.model_config.vocab_size,
+            max_total_num_tokens=self.max_total_num_tokens,
             multimodal=server_args.multimodal,
             has_recurrent_state=self.model_runner.linear_recurrent_config is not None,
             moe_backend=effective_moe_backend,
@@ -416,21 +431,26 @@ class ModelWorker:
         skip_sample: bool = False,
         sampling_metadata: SamplingMetadata = None,
         forward_metadata=None,
+        future_map=None,
+        future_ct=None,
     ) -> tuple[LogitsProcessorOutput, jax.Array | None, int]:
         # Prepare LoRA batch if LoRA is enabled
         if self.worker.server_args.enable_lora and self.need_prepare_lora_batch:
             self.prepare_lora_batch(model_worker_batch)
 
+        _pd_t = getattr(model_worker_batch, "_pd_disp_t0", None)
         # Use pre-initialized ForwardBatch if available (for overlap scheduling optimization)
         if model_worker_batch.forward_batch is not None:
             forward_batch = model_worker_batch.forward_batch
         else:
             forward_batch = ForwardBatch.init_new(model_worker_batch, self.model_runner)
+        _pd_t1 = time.perf_counter()
 
         if forward_metadata is None:
             forward_metadata = self.model_runner.attn_backend.get_forward_metadata(
                 model_worker_batch
             )
+        _pd_t2 = time.perf_counter()
 
         if sampling_metadata is None:
             sampling_metadata = SamplingMetadata.from_model_worker_batch(
@@ -439,9 +459,54 @@ class ModelWorker:
                 self.mesh,
                 self.model_config.vocab_size,
             )
+        _pd_t3 = time.perf_counter()
 
         self.model_runner.attn_backend.forward_metadata = forward_metadata
         logits_metadata = LogitsMetadata.from_model_worker_batch(model_worker_batch, self.mesh)
+        if _pd_t is not None and os.environ.get("SGLANG_PD_DBG"):
+            _pd_t4 = time.perf_counter()
+            logger.info(
+                "[pd-disp] fb=%.1f attn=%.1f smp=%.1f lm=%.1f",
+                (_pd_t1 - _pd_t) * 1e3,
+                (_pd_t2 - _pd_t1) * 1e3,
+                (_pd_t3 - _pd_t2) * 1e3,
+                (_pd_t4 - _pd_t3) * 1e3,
+            )
+
+        # Pathways: fuse run_model+sampler into one jit to drop one Execute
+        # round-trip (~10ms/tick through the dispatch queue). Skips the debug-only
+        # DUMP_LAST_LAYER_LOGITS path and per-token logprob path (both add
+        # extra device_get anyway). Gated by env so CO/native path unchanged.
+        if (
+            self._pd_fuse_sample
+            and not skip_sample
+            and not model_worker_batch.return_output_logprob_only
+        ):
+            if model_worker_batch.sampling_info:
+                self._update_grammar_vocab_mask(model_worker_batch, sampling_metadata)
+            # Precompile / non-overlap callers don't have a future map; feed the
+            # same-shape dummy so the compiled variant matches the overlap
+            # thread's runtime shape (resolve/set are semantic no-ops there).
+            fmap = future_map if future_map is not None else self._pd_dummy_future_map
+            fct = future_ct if future_ct is not None else 0
+            (
+                next_token_ids_device,
+                logits_output,
+                _,
+                cache_miss_count,
+                layers_topk_ids,
+                new_future_map,
+            ) = self.model_runner.forward_and_sample(
+                forward_batch, logits_metadata, sampling_metadata, fmap, fct
+            )
+            self.dump_topk_ids(layers_topk_ids, model_worker_batch)
+            if launch_done is not None:
+                launch_done.set()
+            self.sync_queue.put((layers_topk_ids, model_worker_batch))
+            if future_map is not None:
+                return (logits_output, next_token_ids_device, cache_miss_count, new_future_map)
+            return (logits_output, next_token_ids_device, cache_miss_count)
+
         logits_output, cache_miss_count, layers_topk_ids = self.model_runner.forward(
             forward_batch,
             logits_metadata=logits_metadata,

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -73,7 +73,10 @@ class ModelWorker:
         # Parse args
         self.tp_size = server_args.tp_size
         self.dp_size = server_args.dp_size
-        self._pd_fuse_sample = os.getenv("SGLANG_PD_FUSE_SAMPLE") == "1"
+        self._pd_fuse_sample = (
+            server_args.pd_disaggregation == "pathways"
+            and os.getenv("SGLANG_PD_FUSE_SAMPLE") == "1"
+        )
         from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
 
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
@@ -268,11 +271,11 @@ class ModelWorker:
             page_size=self.page_size,
             max_req_len=self.max_req_len,
             vocab_size=self.model_config.vocab_size,
-            # cache_loc bucket cap only under Pathways proxy: it saves ~25ms/tick
-            # gRPC H2D there, but on native TPU the smaller/odd bucket shape
-            # (page_indices ~554 vs 81920) yields a slower Pallas ragged-attention
-            # kernel (-6% input_throughput on v6e-1 CI). Native H2D is fast enough
-            # that the uncapped bucket is not on the critical path.
+            # cache_loc bucket cap under Pathways proxy backend (PD or colocated
+            # alike -- both do H2D over gRPC where the smaller bucket helps). On
+            # native TPU the smaller/odd bucket shape yields a slower Pallas
+            # ragged-attention kernel and native H2D is fast enough that the
+            # uncapped bucket is not on the critical path.
             max_total_num_tokens=(
                 self.max_total_num_tokens if os.getenv("JAX_PLATFORMS") == "proxy" else 0
             ),

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -4,7 +4,6 @@ import logging
 import os
 import signal
 import threading
-import time
 from queue import Queue
 
 import jax
@@ -451,19 +450,16 @@ class ModelWorker:
         if self.worker.server_args.enable_lora and self.need_prepare_lora_batch:
             self.prepare_lora_batch(model_worker_batch)
 
-        _pd_t = getattr(model_worker_batch, "_pd_disp_t0", None)
         # Use pre-initialized ForwardBatch if available (for overlap scheduling optimization)
         if model_worker_batch.forward_batch is not None:
             forward_batch = model_worker_batch.forward_batch
         else:
             forward_batch = ForwardBatch.init_new(model_worker_batch, self.model_runner)
-        _pd_t1 = time.perf_counter()
 
         if forward_metadata is None:
             forward_metadata = self.model_runner.attn_backend.get_forward_metadata(
                 model_worker_batch
             )
-        _pd_t2 = time.perf_counter()
 
         if sampling_metadata is None:
             sampling_metadata = SamplingMetadata.from_model_worker_batch(
@@ -472,19 +468,9 @@ class ModelWorker:
                 self.mesh,
                 self.model_config.vocab_size,
             )
-        _pd_t3 = time.perf_counter()
 
         self.model_runner.attn_backend.forward_metadata = forward_metadata
         logits_metadata = LogitsMetadata.from_model_worker_batch(model_worker_batch, self.mesh)
-        if _pd_t is not None and os.environ.get("SGLANG_PD_DBG"):
-            _pd_t4 = time.perf_counter()
-            logger.info(
-                "[pd-disp] fb=%.1f attn=%.1f smp=%.1f lm=%.1f",
-                (_pd_t1 - _pd_t) * 1e3,
-                (_pd_t2 - _pd_t1) * 1e3,
-                (_pd_t3 - _pd_t2) * 1e3,
-                (_pd_t4 - _pd_t3) * 1e3,
-            )
 
         # Pathways: fuse run_model+sampler into one jit to drop one Execute
         # round-trip (~10ms/tick through the dispatch queue). Skips the debug-only

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -269,7 +269,14 @@ class ModelWorker:
             page_size=self.page_size,
             max_req_len=self.max_req_len,
             vocab_size=self.model_config.vocab_size,
-            max_total_num_tokens=self.max_total_num_tokens,
+            # cache_loc bucket cap only under Pathways proxy: it saves ~25ms/tick
+            # gRPC H2D there, but on native TPU the smaller/odd bucket shape
+            # (page_indices ~554 vs 81920) yields a slower Pallas ragged-attention
+            # kernel (-6% input_throughput on v6e-1 CI). Native H2D is fast enough
+            # that the uncapped bucket is not on the critical path.
+            max_total_num_tokens=(
+                self.max_total_num_tokens if os.getenv("JAX_PLATFORMS") == "proxy" else 0
+            ),
             multimodal=server_args.multimodal,
             has_recurrent_state=self.model_runner.linear_recurrent_config is not None,
             moe_backend=effective_moe_backend,

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -302,15 +302,21 @@ class ModelWorker:
             layers_topk_ids, model_worker_batch = self.sync_queue.get()
             get_global_experts_capturer().on_forward_end(layers_topk_ids, model_worker_batch)
 
-    def run_precompile(self, future_token_ids_map=None):
+    def run_precompile(self, future_token_ids_map=None, only: str | None = None):
         prepare_lora = self.prepare_lora_batch if self.server_args.enable_lora else None
-        self.compilation_manager.precompile_all(
-            forward_fn=self.forward_batch_generation,
-            model_runner=self.model_runner,
-            mesh=self.mesh,
-            prepare_lora_fn=prepare_lora,
-            future_token_ids_map=future_token_ids_map,
+        args = (
+            self.forward_batch_generation,
+            self.model_runner,
+            self.mesh,
+            prepare_lora,
+            future_token_ids_map,
         )
+        if only == "extend":
+            self.compilation_manager._precompile_extend(*args)
+        elif only == "decode":
+            self.compilation_manager._precompile_decode(*args)
+        else:
+            self.compilation_manager.precompile_all(*args)
 
     def set_forward_metadata(self, model_worker_batch: ModelWorkerBatch):
         self.model_runner.attn_backend.forward_metadata = (

--- a/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
@@ -155,14 +155,18 @@ class ModelWorkerClient:
                         forward_metadata=forward_metadata,
                     )
                 )
-            next_token_ids = self.async_gather_fn(next_token_ids)
-            # Update the future token ids map
+            # Update the future token ids map. next_token_ids here is the raw
+            # sampler output (stable P('data') sharding); feeding it directly
+            # avoids the tracing/cpp-fastpath cache miss that async_gather_fn's
+            # dp=1-no-op-optimized output type otherwise causes. async_gather
+            # runs afterwards purely to prep the replicated D2H copy.
             self.future_token_ids_map = set_future_token_ids(
                 self.future_token_ids_map,
                 future_token_ids_ct,
                 next_token_ids,
                 self.mesh,
             )
+            next_token_ids = self.async_gather_fn(next_token_ids)
             self.output_queue.put(
                 (None, logits_output, next_token_ids, cache_miss_count, time.perf_counter())
             )
@@ -313,8 +317,8 @@ class ModelWorkerClient:
         self.future_token_ids_ct = (self.future_token_ids_ct + bs) % self.future_token_ids_limit
         return None, future_next_token_ids, 0
 
-    def run_precompile(self):
-        self.worker.run_precompile(self.future_token_ids_map)
+    def run_precompile(self, only: str | None = None):
+        self.worker.run_precompile(self.future_token_ids_map, only=only)
 
     @property
     def page_size(self) -> int:

--- a/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
@@ -117,9 +117,7 @@ class ModelWorkerClient:
                 break
 
             if self.worker._pd_fuse_sample:
-                # Fused path: resolve/set_future are inlined into the single
-                # jitted_run_and_sample; feed raw (possibly negative) input_ids
-                # straight through and take the updated future map back out.
+                # Fused path: resolve/set_future are inlined into the single jit.
                 with jax.profiler.TraceAnnotation(
                     f"forward_batch_generation {model_worker_batch.bid}"
                 ):
@@ -153,11 +151,8 @@ class ModelWorkerClient:
                         forward_metadata=forward_metadata,
                     )
                 )
-            # Update the future token ids map. next_token_ids here is the raw
-            # sampler output (stable P('data') sharding); feeding it directly
-            # avoids the tracing/cpp-fastpath cache miss that async_gather_fn's
-            # dp=1-no-op-optimized output type otherwise causes. async_gather
-            # runs afterwards purely to prep the replicated D2H copy.
+            # Feed the raw sampler output (stable P('data') sharding) so
+            # set_future's cpp-fastpath cache hits; async_gather afterwards.
             self.future_token_ids_map = set_future_token_ids(
                 self.future_token_ids_map,
                 future_token_ids_ct,

--- a/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
@@ -134,9 +134,7 @@ class ModelWorkerClient:
                         )
                     )
                 self.future_token_ids_map = new_future_map
-                self.output_queue.put(
-                    (None, logits_output, next_token_ids, cache_miss_count, time.perf_counter())
-                )
+                self.output_queue.put((None, logits_output, next_token_ids, cache_miss_count))
                 continue
 
             # Resolve future tokens in the input
@@ -167,9 +165,7 @@ class ModelWorkerClient:
                 self.mesh,
             )
             next_token_ids = self.async_gather_fn(next_token_ids)
-            self.output_queue.put(
-                (None, logits_output, next_token_ids, cache_miss_count, time.perf_counter())
-            )
+            self.output_queue.put((None, logits_output, next_token_ids, cache_miss_count))
 
     def resolve_last_batch_result(self, launch_done: threading.Event | None = None):
         """
@@ -182,7 +178,7 @@ class ModelWorkerClient:
         jax.device_get does.
         """
         _r0 = time.perf_counter()
-        _, logits_output, next_token_ids, cache_miss_count, _fwd_done = self.output_queue.get()
+        _, logits_output, next_token_ids, cache_miss_count = self.output_queue.get()
         _r1 = time.perf_counter()
         # Step 1: kick off async D2H copies for everything we need
         async_next_logprobs = (
@@ -221,11 +217,6 @@ class ModelWorkerClient:
                 _sh,
             )
         next_token_ids = jax.device_get(next_token_ids).tolist()
-        _r2 = time.perf_counter()
-        if os.environ.get("SGLANG_PD_DBG") and _r2 - _r0 > 0.15:
-            logger.info(
-                "[pd-resolve] q_wait=%.0fms d2h=%.0fms", (_r1 - _r0) * 1e3, (_r2 - _r1) * 1e3
-            )
 
         # Step 2: materialize. The first np.asarray waits for that array's
         # copy; the others have been making progress in parallel.

--- a/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import logging
+import os
 import signal
 import threading
 import time
@@ -63,11 +64,6 @@ class ModelWorkerClient:
         self.parent_process = psutil.Process().parent()
         replicated_sharding = NamedSharding(mesh, PartitionSpec())
         self.async_gather_fn = jax.jit(lambda x: x, out_shardings=replicated_sharding)
-        logger.info(
-            "[pd-debug] overlap mesh=%s replicated_devices=%s",
-            mesh.shape,
-            sorted(d.id for d in replicated_sharding.device_set),
-        )
 
     @property
     def model_runner(self):
@@ -120,6 +116,29 @@ class ModelWorkerClient:
             if not model_worker_batch:
                 break
 
+            if self.worker._pd_fuse_sample:
+                # Fused path: resolve/set_future are inlined into the single
+                # jitted_run_and_sample; feed raw (possibly negative) input_ids
+                # straight through and take the updated future map back out.
+                with jax.profiler.TraceAnnotation(
+                    f"forward_batch_generation {model_worker_batch.bid}"
+                ):
+                    logits_output, next_token_ids, cache_miss_count, new_future_map = (
+                        self.worker.forward_batch_generation(
+                            model_worker_batch,
+                            model_worker_batch.launch_done,
+                            sampling_metadata=sampling_metadata,
+                            forward_metadata=forward_metadata,
+                            future_map=self.future_token_ids_map,
+                            future_ct=future_token_ids_ct,
+                        )
+                    )
+                self.future_token_ids_map = new_future_map
+                self.output_queue.put(
+                    (None, logits_output, next_token_ids, cache_miss_count, time.perf_counter())
+                )
+                continue
+
             # Resolve future tokens in the input
             input_ids = model_worker_batch.forward_batch.input_ids
             model_worker_batch.forward_batch.input_ids = resolve_future_token_ids(
@@ -144,7 +163,9 @@ class ModelWorkerClient:
                 next_token_ids,
                 self.mesh,
             )
-            self.output_queue.put((None, logits_output, next_token_ids, cache_miss_count))
+            self.output_queue.put(
+                (None, logits_output, next_token_ids, cache_miss_count, time.perf_counter())
+            )
 
     def resolve_last_batch_result(self, launch_done: threading.Event | None = None):
         """
@@ -157,7 +178,7 @@ class ModelWorkerClient:
         jax.device_get does.
         """
         _r0 = time.perf_counter()
-        _, logits_output, next_token_ids, cache_miss_count = self.output_queue.get()
+        _, logits_output, next_token_ids, cache_miss_count, _fwd_done = self.output_queue.get()
         _r1 = time.perf_counter()
         # Step 1: kick off async D2H copies for everything we need
         async_next_logprobs = (
@@ -175,7 +196,32 @@ class ModelWorkerClient:
             if logits_output.hidden_states is not None
             else None
         )
+        if os.environ.get("SGLANG_PD_DBG_NTOK"):
+            try:
+                _all = next_token_ids.addressable_shards
+                _sh = [
+                    (s.device.id, np.asarray(s.data).flatten()[:4].tolist())
+                    for s in (_all[:2] + _all[len(_all) // 2 : len(_all) // 2 + 2])
+                ]
+                _sp = getattr(next_token_ids.sharding, "spec", "?")
+            except Exception as _e:
+                _sh, _sp = f"err:{_e}", "?"
+            _full = np.asarray(jax.device_get(next_token_ids)).flatten()
+            _n = len(_full)
+            logger.info(
+                "[D-ntok] shape=%s spec=%s dp0[:4]=%s dp1[:4]=%s shards=%s",
+                _full.shape,
+                _sp,
+                _full[: min(4, _n // 2)].tolist(),
+                _full[_n // 2 : _n // 2 + 4].tolist(),
+                _sh,
+            )
         next_token_ids = jax.device_get(next_token_ids).tolist()
+        _r2 = time.perf_counter()
+        if os.environ.get("SGLANG_PD_DBG") and _r2 - _r0 > 0.15:
+            logger.info(
+                "[pd-resolve] q_wait=%.0fms d2h=%.0fms", (_r1 - _r0) * 1e3, (_r2 - _r1) * 1e3
+            )
 
         # Step 2: materialize. The first np.asarray waits for that array's
         # copy; the others have been making progress in parallel.
@@ -190,7 +236,7 @@ class ModelWorkerClient:
         if launch_done is not None:
             launch_done.wait()
         _r4 = time.perf_counter()
-        if _r4 - _r0 > 0.5:
+        if os.environ.get("SGLANG_PD_DBG") and _r4 - _r0 > 0.5:
             import gc as _gc
 
             import jax as _jax

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -34,6 +34,7 @@ class CompilationManager:
         page_size: int,
         max_req_len: int,
         vocab_size: int,
+        max_total_num_tokens: int = 0,
         multimodal: bool = False,
         has_recurrent_state: bool = False,
         moe_backend: str | None = None,
@@ -42,6 +43,7 @@ class CompilationManager:
         self.tp_size = tp_size
         self.page_size = page_size
         self.max_req_len = max_req_len
+        self.max_total_num_tokens = max_total_num_tokens
         self.max_padded_batch_size = max_padded_batch_size
         self.max_padded_num_tokens = max_padded_num_tokens
         self.vocab_size = vocab_size
@@ -98,8 +100,20 @@ class CompilationManager:
         return buckets
 
     def _compute_cache_loc_buckets(self) -> list[int]:
+        # bs*max_req_len over-provisions: at bs=128 ctx=262K that's 134MB H2D
+        # per tick, but bs reqs together can never exceed max_total_num_tokens
+        # (the pool). Cap per-bs at the pool size -- shrinks 134MB->~15MB, a
+        # ~25ms/tick save on Pathways gRPC H2D (~5GB/s vs native PCIe 16GB/s).
         pages_per_req = (self.max_req_len + self.page_size - 1) // self.page_size * self.page_size
-        return [bs * pages_per_req for bs in self.bs_buckets]
+        pool_aligned = (
+            (self.max_total_num_tokens + self.page_size - 1) // self.page_size * self.page_size
+            if self.max_total_num_tokens
+            else None
+        )
+        return [
+            min(bs * pages_per_req, pool_aligned) if pool_aligned else bs * pages_per_req
+            for bs in self.bs_buckets
+        ]
 
     # ---- Pre-compilation ----
 

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -100,10 +100,9 @@ class CompilationManager:
         return buckets
 
     def _compute_cache_loc_buckets(self) -> list[int]:
-        # bs*max_req_len over-provisions: at bs=128 ctx=262K that's 134MB H2D
-        # per tick, but bs reqs together can never exceed max_total_num_tokens
-        # (the pool). Cap per-bs at the pool size -- shrinks 134MB->~15MB, a
-        # ~25ms/tick save on Pathways gRPC H2D (~5GB/s vs native PCIe 16GB/s).
+        # bs reqs together can never exceed max_total_num_tokens, so cap the
+        # per-bs bucket at the pool size (helps Pathways gRPC H2D; see tp_worker
+        # for why the cap is proxy-only).
         pages_per_req = (self.max_req_len + self.page_size - 1) // self.page_size * self.page_size
         pool_aligned = (
             (self.max_total_num_tokens + self.page_size - 1) // self.page_size * self.page_size

--- a/python/sgl_jax/srt/model_executor/forward_batch_info.py
+++ b/python/sgl_jax/srt/model_executor/forward_batch_info.py
@@ -251,6 +251,10 @@ class ForwardBatch:
     def tree_unflatten(cls, aux_data, children):
         obj = cls.__new__(cls)
 
+        # bid is intentionally not in aux_data (would break jit cache); only
+        # used by precision_tracer outside jit, so a sentinel is fine after a
+        # pytree round-trip (e.g. compilation_manager padding path).
+        obj.bid = 0
         obj.forward_mode = aux_data["forward_mode"]
         obj.batch_size = aux_data["batch_size"]
         obj.spec_algorithm = aux_data["spec_algorithm"]

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -1,6 +1,7 @@
 """ModelRunner runs the forward passes of the models."""
 
 import contextlib
+import dataclasses
 import logging
 from functools import partial
 
@@ -9,6 +10,8 @@ import jax.numpy as jnp
 import numpy as np
 from flax import nnx
 from jax._src import mesh as mesh_lib
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.configs.load_config import LoadConfig
 from sgl_jax.srt.configs.model_config import AttentionArch, MockModelConfig, ModelConfig
@@ -245,6 +248,7 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         # fold_in(constant, dynamic_step) is computed inside JIT, avoiding
         # the eager jax.random.split that would serialize the host-device pipeline.
         base_rng_key = self._sampler_base_rng
+        _fused_mesh = self.mesh
 
         @partial(jax.jit, static_argnames=["sampler_state_def", "use_sort_for_toppk_minp"])
         def jitted_sampler(
@@ -288,6 +292,109 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         )
 
         self.jitted_compute_logprobs = partial(jitted_compute_logprobs, self.mesh)
+
+        # Pathways: single-controller dispatch pays ~10ms per independent jit
+        # through the ordered dispatch queue. Fusing the
+        # full forward_thread tick body -- resolve_future_token_ids +
+        # run_model + sampler + async_gather + set_future_token_ids -- into
+        # one jit drops it from 3 Executes to 1 per decode tick. Only used
+        # when SGLANG_PD_FUSE_SAMPLE=1 and no grammar mask update is needed
+        # between forward and sample.
+        @partial(
+            jax.jit,
+            donate_argnames=["memory_pools"],
+            static_argnames=["model_state_def", "sampler_state_def", "use_sort_for_toppk_minp"],
+            compiler_options=jit_compiler_options,
+        )
+        def jitted_run_and_sample(
+            model_def,
+            model_state_def,
+            model_state_leaves,
+            forward_batch,
+            memory_pools,
+            logits_metadata,
+            sampler_def,
+            sampler_state_def,
+            sampler_state_leaves,
+            use_sort_for_toppk_minp,
+            rng_step,
+            sampling_metadata,
+            future_token_ids_map,
+            future_token_ids_ct,
+        ):
+            # resolve_future_token_ids inlined (utils.py:47-54): overlap thread
+            # feeds raw input_ids that may still hold negative future-id
+            # placeholders; look them up in the (replicated) future map here.
+            ids = forward_batch.input_ids
+            ids_g = jax.lax.with_sharding_constraint(ids, NamedSharding(_fused_mesh, P()))
+            resolved = jnp.where(
+                ids_g < 0,
+                future_token_ids_map.at[jnp.clip(-ids_g, min=0)].get(
+                    out_sharding=NamedSharding(_fused_mesh, P())
+                ),
+                ids_g,
+            )
+            resolved = jax.lax.with_sharding_constraint(
+                resolved, NamedSharding(_fused_mesh, P("data"))
+            )
+            forward_batch = dataclasses.replace(forward_batch, input_ids=resolved)
+
+            model_state = jax.tree_util.tree_unflatten(model_state_def, model_state_leaves)
+            model = nnx.merge(model_def, model_state)
+            with LoraBatchContext.set_batch(forward_batch):
+                output, pool_updates, aux, layers_topk_ids = model(
+                    forward_batch, memory_pools, logits_metadata
+                )
+            s_state = jax.tree_util.tree_unflatten(sampler_state_def, sampler_state_leaves)
+            sampler = nnx.merge(sampler_def, s_state)
+            rng_key = jax.random.fold_in(base_rng_key, rng_step)
+            next_ids, token_logprobs, _new_output = sampler(
+                output,
+                sampling_metadata,
+                use_sort_for_toppk_minp=use_sort_for_toppk_minp,
+                rng_override=rng_key,
+            )
+            # Fold async_gather_fn's replicated reshard into this jit so the
+            # overlap thread can skip that separate Execute.
+            next_ids = jax.lax.with_sharding_constraint(next_ids, NamedSharding(_fused_mesh, P()))
+            # set_future_token_ids inlined (utils.py:58-61): next_ids is already
+            # replicated above, so dynamic_update_slice on the replicated map
+            # needs no extra reshard.
+            new_future_map = jax.lax.dynamic_update_slice(
+                future_token_ids_map, next_ids, (future_token_ids_ct + 1,)
+            )
+            return (
+                next_ids,
+                output,
+                pool_updates,
+                aux,
+                layers_topk_ids,
+                token_logprobs,
+                new_future_map,
+            )
+
+        def run_and_sample_wrapper(
+            forward_batch, logits_metadata, sampling_metadata, future_map, future_ct
+        ):
+            self._sampler_step += 1
+            return jitted_run_and_sample(
+                model_def,
+                model_state_def,
+                self.model_state_leaves,
+                forward_batch,
+                self.memory_pools,
+                logits_metadata,
+                sampler_def,
+                sampler_state_def,
+                sampler_state_leaves,
+                self.use_sort_for_toppk_minp,
+                self._sampler_step,
+                sampling_metadata,
+                future_map,
+                jnp.asarray(future_ct, dtype=jnp.int32),
+            )
+
+        self.jitted_run_and_sample = run_and_sample_wrapper
 
     def get_available_device_memory(self):
         distributed = jax.process_count() != 1
@@ -520,9 +627,9 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
 
         # _donate_lock (set by PD scheduler init) serializes the donate-dispatch
         # → replace_all window against the main-thread scatter_from_dmesh which
-        # also donates the same kv_buffer list. ifrt_proxy/client/array.cc:382
-        # marks the input deleted the instant kDonateInput dispatches, so a GIL
-        # switch in this window lets scatter read a deleted array.
+        # also donates the same kv_buffer list. IFRT marks the input deleted the
+        # instant kDonateInput dispatches, so a GIL switch in this window lets
+        # scatter read a deleted array.
         _kv_lock = getattr(self.token_to_kv_pool, "_donate_lock", None)
         with _kv_lock if _kv_lock is not None else contextlib.nullcontext():
             with jtu.count_pjit_cpp_cache_miss() as count:
@@ -540,6 +647,36 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
 
         # layers_topk_ids required real_bs and original_input_len which could not be stored in ForwardBatch
         return output, cache_miss_count, layers_topk_ids
+
+    def forward_and_sample(
+        self, forward_batch, logits_metadata, sampling_metadata, future_map, future_ct
+    ):
+        import jax._src.test_util as jtu
+
+        self.forward_pass_id += 1
+        # NOTE: no use_mesh here (unlike _forward_raw): wrapping sampler in the
+        # Explicit mesh context makes binary_search.py:148 select fail on
+        # mismatched shardings. Model shard_maps carry mesh explicitly.
+        _kv_lock = getattr(self.token_to_kv_pool, "_donate_lock", None)
+        with _kv_lock if _kv_lock is not None else contextlib.nullcontext():
+            with jtu.count_pjit_cpp_cache_miss() as count:
+                (
+                    next_ids,
+                    output,
+                    pool_updates,
+                    _,
+                    layers_topk_ids,
+                    token_logprobs,
+                    new_future_map,
+                ) = self.jitted_run_and_sample(
+                    forward_batch, logits_metadata, sampling_metadata, future_map, future_ct
+                )
+                cache_miss_count = count()
+            if self.tp_size == 1 and isinstance(pool_updates, list):
+                target_sharding = self.token_to_kv_pool.kv_sharding
+                pool_updates = [jax.device_put(kv, target_sharding) for kv in pool_updates]
+            self.memory_pools.replace_all(pool_updates)
+        return next_ids, output, token_logprobs, cache_miss_count, layers_topk_ids, new_future_map
 
     def forward_idle(
         self,

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -293,13 +293,9 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
 
         self.jitted_compute_logprobs = partial(jitted_compute_logprobs, self.mesh)
 
-        # Pathways: single-controller dispatch pays ~10ms per independent jit
-        # through the ordered dispatch queue. Fusing the
-        # full forward_thread tick body -- resolve_future_token_ids +
-        # run_model + sampler + async_gather + set_future_token_ids -- into
-        # one jit drops it from 3 Executes to 1 per decode tick. Only used
-        # when SGLANG_PD_FUSE_SAMPLE=1 and no grammar mask update is needed
-        # between forward and sample.
+        # Pathways-PD: fuse resolve_future_token_ids + run_model + sampler +
+        # async_gather + set_future_token_ids into one jit so a decode tick is
+        # a single Execute through the ordered dispatch queue.
         @partial(
             jax.jit,
             donate_argnames=["memory_pools"],
@@ -322,9 +318,7 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
             future_token_ids_map,
             future_token_ids_ct,
         ):
-            # resolve_future_token_ids inlined (utils.py:47-54): overlap thread
-            # feeds raw input_ids that may still hold negative future-id
-            # placeholders; look them up in the (replicated) future map here.
+            # resolve_future_token_ids inlined: negative ids are future placeholders.
             ids = forward_batch.input_ids
             ids_g = jax.lax.with_sharding_constraint(ids, NamedSharding(_fused_mesh, P()))
             resolved = jnp.where(
@@ -354,12 +348,8 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                 use_sort_for_toppk_minp=use_sort_for_toppk_minp,
                 rng_override=rng_key,
             )
-            # Fold async_gather_fn's replicated reshard into this jit so the
-            # overlap thread can skip that separate Execute.
+            # async_gather + set_future_token_ids inlined.
             next_ids = jax.lax.with_sharding_constraint(next_ids, NamedSharding(_fused_mesh, P()))
-            # set_future_token_ids inlined (utils.py:58-61): next_ids is already
-            # replicated above, so dynamic_update_slice on the replicated map
-            # needs no extra reshard.
             new_future_map = jax.lax.dynamic_update_slice(
                 future_token_ids_map, next_ids, (future_token_ids_ct + 1,)
             )

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -106,6 +106,9 @@ class ServerArgs:
     pd_prefill_max_tokens: int = 20480
     pd_decode_max_tokens: int = 25600
     pd_num_prefill: int = 1
+    pd_num_decode: int = 1
+    pd_prefill_tp_size: int = 0
+    pd_prefill_ep_size: int = 0
     tp_size: int = 1
     ep_size: int = 1
     ep_num_redundant_experts: int = 0
@@ -945,6 +948,29 @@ class ServerArgs:
             type=int,
             default=ServerArgs.pd_num_prefill,
             help="Number of prefill slices for pathways PD (Stage 6 multi-P).",
+        )
+        parser.add_argument(
+            "--pd-num-decode",
+            dest="pd_num_decode",
+            type=int,
+            default=ServerArgs.pd_num_decode,
+            help="Number of decode slices for pathways PD (1P-ND fan-out).",
+        )
+        parser.add_argument(
+            "--pd-prefill-tp-size",
+            dest="pd_prefill_tp_size",
+            type=int,
+            default=ServerArgs.pd_prefill_tp_size,
+            help="Prefill-side tp_size for pathways PD hetero-TP (Stage 6 "
+            "P-D-different-tp). 0 = same as --tp-size (D side).",
+        )
+        parser.add_argument(
+            "--pd-prefill-ep-size",
+            dest="pd_prefill_ep_size",
+            type=int,
+            default=ServerArgs.pd_prefill_ep_size,
+            help="Prefill-side ep_size for pathways PD hetero-TP. "
+            "0 = scale ep_size by tp_p/tp_d.",
         )
 
         parser.add_argument(

--- a/test/srt/disaggregation/test_pathways_pd.py
+++ b/test/srt/disaggregation/test_pathways_pd.py
@@ -6,6 +6,7 @@ Run: XLA_FLAGS=--xla_force_host_platform_device_count=8 JAX_PLATFORMS=cpu \
 
 from __future__ import annotations
 
+import queue
 import threading
 from types import SimpleNamespace
 
@@ -19,10 +20,12 @@ from jax.sharding import PartitionSpec as P
 from sgl_jax.srt.disaggregation.pathways_pd import (
     PathwaysPDKVTransfer,
     group_by_slice,
+    group_pages_by_dp_rank,
     make_slice_meshes,
     migrate_reqs_p_to_d,
     slots_to_ordered_pages,
 )
+from sgl_jax.srt.disaggregation.pathways_scheduler import PathwaysPDSchedulerMixin
 
 NUM_PAGES = 16
 PAGE_SIZE = 4
@@ -35,9 +38,10 @@ def meshes():
     devs = jax.devices()
     if len(devs) < 8:
         pytest.skip(f"need >=8 devices, got {len(devs)}")
-    p_meshes, d_mesh = make_slice_meshes(dp_size=1, tp_per_side=len(devs) // 2)
+    p_meshes, d_meshes = make_slice_meshes(dp_size=1, tp_per_side=len(devs) // 2)
     assert isinstance(p_meshes, list) and len(p_meshes) == 1
-    return p_meshes[0], d_mesh
+    assert isinstance(d_meshes, list) and len(d_meshes) == 1
+    return p_meshes[0], d_meshes[0]
 
 
 def _make_pool(mesh, fill: str):
@@ -81,6 +85,71 @@ def test_make_slice_meshes(meshes):
 
 
 @pytest.mark.unit
+def test_make_slice_meshes_hetero_tp():
+    """tp_prefill != tp_per_side: P/D meshes have different tensor-axis size,
+    slices assigned by device count. group_by_slice fallback splits 8 CPU
+    devs into 2 groups of 4, so tp_p=tp_d=4 is the only combo we can test on
+    CPU without slice_index; the by-size assignment is unit-tested via a
+    monkeypatched group_by_slice returning unequal groups."""
+    devs = jax.devices()
+    if len(devs) < 6:
+        pytest.skip("need >=6 devices")
+    import sgl_jax.srt.disaggregation.pathways_pd as pd
+
+    orig = pd.group_by_slice
+    # fake: slice 0 = 4 dev (P tp4), slice 1 = 2 dev (D tp2)
+    pd.group_by_slice = lambda ds: {0: list(ds)[:4], 1: list(ds)[4:6]}
+    try:
+        p_meshes, d_meshes = make_slice_meshes(dp_size=1, tp_per_side=2, tp_prefill=4)
+        d_mesh = d_meshes[0]
+        assert p_meshes[0].devices.size == 4
+        assert d_mesh.devices.size == 2
+        assert p_meshes[0].shape["tensor"] == 4
+        assert d_mesh.shape["tensor"] == 2
+        p_ids = {d.id for d in p_meshes[0].devices.flatten()}
+        d_ids = {d.id for d in d_mesh.devices.flatten()}
+        assert p_ids.isdisjoint(d_ids)
+        # reversed roles: tp_p=2 (small P) tp_d=4 (big D) also assigns by size
+        p2, d2 = make_slice_meshes(dp_size=1, tp_per_side=4, tp_prefill=2)
+        assert p2[0].devices.size == 2 and d2[0].devices.size == 4
+        # mismatch: request tp_p=8 but no size-8 slice -> loud fail
+        with pytest.raises(RuntimeError, match="hetero-tp needs"):
+            make_slice_meshes(dp_size=1, tp_per_side=2, tp_prefill=8)
+    finally:
+        pd.group_by_slice = orig
+
+
+@pytest.mark.unit
+def test_transfer_byte_equal_hetero_tp():
+    """MLA-style pool (tensor-replicated P("data",None,None,None)) transfers
+    byte-equal across meshes of DIFFERENT tensor-axis size. This is the
+    GLM-5.2 hetero-TP path: device_put reshard is replicated->replicated
+    (change device set only), no shape change, no explicit reshape."""
+    devs = jax.devices()
+    if len(devs) < 6:
+        pytest.skip("need >=6 devices")
+    import sgl_jax.srt.disaggregation.pathways_pd as pd
+
+    orig = pd.group_by_slice
+    pd.group_by_slice = lambda ds: {0: list(ds)[:4], 1: list(ds)[4:6]}
+    try:
+        p_meshes, d_meshes = make_slice_meshes(dp_size=1, tp_per_side=2, tp_prefill=4)
+    finally:
+        pd.group_by_slice = orig
+    p_mesh, d_mesh = p_meshes[0], d_meshes[0]
+    p_pool = _make_pool(p_mesh, fill="seq")
+    d_pool = _make_pool(d_mesh, fill="zero")
+    xfer = PathwaysPDKVTransfer(p_mesh, d_mesh, p_pool, d_pool)
+    p_pages = np.array([1, 3, 5], np.int32)
+    d_pages = np.array([0, 2, 4], np.int32)
+    xfer.transfer(p_pages, d_pages)
+    for layer in range(N_LAYERS):
+        d_host = np.asarray(d_pool.kv_buffer[layer])
+        p_host = np.asarray(p_pool.kv_buffer[layer])
+        np.testing.assert_array_equal(d_host[d_pages], p_host[p_pages])
+
+
+@pytest.mark.unit
 def test_transfer_byte_equal(meshes):
     p_mesh, d_mesh = meshes
     p_pool = _make_pool(p_mesh, fill="seq")
@@ -97,6 +166,79 @@ def test_transfer_byte_equal(meshes):
         np.testing.assert_array_equal(d_host[d_pages], p_host[p_pages])
         untouched = np.array([1, 3, 5, 7, 8, 9], np.int32)
         np.testing.assert_array_equal(d_host[untouched], np.zeros_like(d_host[untouched]))
+
+
+@pytest.mark.unit
+def test_gather_scatter_jits_dp2_no_cross_rank_leakage():
+    """dp>1 kernel-level check (PathwaysPDKVTransfer's public API still
+    raises NotImplementedError for dp>1 pending scheduler-side per-req
+    dp_rank page grouping -- this test calls _make_pool_jits' gather_jit/
+    scatter_one_jit directly to prove the underlying shard_map kernel
+    itself is already dp>1-correct: each rank's local index only ever
+    touches that SAME rank's physical shard, never another rank's."""
+    from sgl_jax.srt.disaggregation.pathways_pd import _make_pool_jits
+
+    devs = jax.devices()
+    if len(devs) < 8:
+        pytest.skip(f"need >=8 devices, got {len(devs)}")
+    dp_size, tp_per_side = 2, 4
+    p_meshes, d_meshes = make_slice_meshes(dp_size=dp_size, tp_per_side=tp_per_side)
+    p_mesh, d_mesh = p_meshes[0], d_meshes[0]
+
+    p_pool = _make_pool(p_mesh, fill="seq")  # NUM_PAGES=16 total, 8 pages/rank
+    d_pool = _make_pool(d_mesh, fill="zero")
+    gather_jit, scatter_one_jit, d_stack_shard = _make_pool_jits(p_mesh, d_mesh, p_pool, d_pool)
+
+    pages_per_rank = NUM_PAGES // dp_size  # 8
+    # rank0 gathers its local pages [0,2]; rank1 gathers its local pages [1,3]
+    # (deliberately different per rank, so cross-rank leakage would be caught)
+    local_idx = np.array([[0, 2], [1, 3]], dtype=np.int32)
+    idx_dev = jax.device_put(local_idx, NamedSharding(p_mesh, P("data", None)))
+
+    stacked = gather_jit(tuple(p_pool.kv_buffer), idx_dev)
+    stacked_host = np.asarray(jax.device_put(stacked, d_stack_shard))
+
+    # gather output shape now [L, dp_size, n, page_size, 1, head_dim] (per-layer
+    # shard_map keeps the leading dp dim explicit instead of concatenating).
+    assert stacked_host.shape[:3] == (N_LAYERS, dp_size, 2)
+    p_host_full = [np.asarray(p_pool.kv_buffer[layer]) for layer in range(N_LAYERS)]
+    for layer in range(N_LAYERS):
+        # rank0's local page k lives at global page k; rank1's local page k
+        # lives at global page (pages_per_rank + k) -- per-rank contiguous shard.
+        expected_r0 = p_host_full[layer][[0, 2]]
+        expected_r1 = p_host_full[layer][[pages_per_rank + 1, pages_per_rank + 3]]
+        np.testing.assert_array_equal(stacked_host[layer, 0], expected_r0)
+        np.testing.assert_array_equal(stacked_host[layer, 1], expected_r1)
+
+    # scatter: write the gathered payload into DIFFERENT D-side local pages
+    # per rank, verify each rank's write lands only in its own shard.
+    scatter_idx = np.array([[5], [6]], dtype=np.int32)
+    scatter_idx_dev = jax.device_put(scatter_idx, NamedSharding(d_mesh, P("data", None)))
+    for layer in range(N_LAYERS):
+        # build payload on host (numpy) to avoid ad-hoc eager JAX indexing on
+        # an Explicit-sharded array, then device_put with the right sharding.
+        payload_host = np.stack(
+            [stacked_host[layer, 0, 0:1], stacked_host[layer, 1, 0:1]], axis=0
+        )  # [dp_size=2, n=1, page_size, 1, head_dim]
+        payload = jax.device_put(
+            payload_host, NamedSharding(d_mesh, P("data", None, None, None, None))
+        )
+        d_pool.kv_buffer[layer] = scatter_one_jit(d_pool.kv_buffer[layer], scatter_idx_dev, payload)
+
+    d_host_full = [np.asarray(d_pool.kv_buffer[layer]) for layer in range(N_LAYERS)]
+    for layer in range(N_LAYERS):
+        # rank0 wrote to its local page 5 (global page 5); rank1 wrote to its
+        # local page 6 (global page pages_per_rank+6).
+        np.testing.assert_array_equal(d_host_full[layer][5], p_host_full[layer][0])
+        np.testing.assert_array_equal(
+            d_host_full[layer][pages_per_rank + 6], p_host_full[layer][pages_per_rank + 1]
+        )
+        # everything else stays zero -- no cross-rank / off-target writes
+        untouched_mask = np.ones(NUM_PAGES, dtype=bool)
+        untouched_mask[[5, pages_per_rank + 6]] = False
+        np.testing.assert_array_equal(
+            d_host_full[layer][untouched_mask], np.zeros_like(d_host_full[layer][untouched_mask])
+        )
 
 
 @pytest.mark.unit
@@ -137,6 +279,49 @@ def test_slots_to_ordered_pages():
     np.testing.assert_array_equal(
         slots_to_ordered_pages(np.array([6, 7, 8, 9, 10], np.int32), 4), [1, 2]
     )
+
+
+def test_group_pages_by_dp_rank_balanced():
+    # rank0 req has 2 pages, rank1 req has 3 pages -> max_n=3, rank0 padded
+    # by repeating its own last page (7), never rank1's data.
+    pages_by_req = [(0, np.array([5, 7], np.int32)), (1, np.array([1, 2, 9], np.int32))]
+    pages, valid = group_pages_by_dp_rank(pages_by_req, dp_size=2)
+    np.testing.assert_array_equal(pages[0], [5, 7, 7])
+    np.testing.assert_array_equal(valid[0], [True, True, False])
+    np.testing.assert_array_equal(pages[1], [1, 2, 9])
+    np.testing.assert_array_equal(valid[1], [True, True, True])
+
+
+def test_group_pages_by_dp_rank_multi_req_same_rank():
+    # two reqs on the same rank get concatenated in order, not interleaved.
+    pages_by_req = [
+        (0, np.array([3], np.int32)),
+        (1, np.array([4, 5], np.int32)),
+        (0, np.array([6, 8], np.int32)),
+    ]
+    pages, valid = group_pages_by_dp_rank(pages_by_req, dp_size=2)
+    np.testing.assert_array_equal(pages[0], [3, 6, 8])
+    np.testing.assert_array_equal(valid[0], [True, True, True])
+    np.testing.assert_array_equal(pages[1], [4, 5, 5])
+    np.testing.assert_array_equal(valid[1], [True, True, False])
+
+
+def test_group_pages_by_dp_rank_empty_rank_marked_invalid():
+    # KNOWN LIMITATION case: rank1 has zero reqs this round. Its row must
+    # come back all-invalid (not silently defaulted to a "safe" real page --
+    # there isn't one), so a caller that forgets to check `valid` can't
+    # mistake page-index 0 for a real transfer.
+    pages_by_req = [(0, np.array([2, 4], np.int32))]
+    pages, valid = group_pages_by_dp_rank(pages_by_req, dp_size=2)
+    np.testing.assert_array_equal(pages[0], [2, 4])
+    np.testing.assert_array_equal(valid[0], [True, True])
+    np.testing.assert_array_equal(valid[1], [False, False])
+
+
+def test_group_pages_by_dp_rank_no_reqs():
+    pages, valid = group_pages_by_dp_rank([], dp_size=2)
+    assert pages.shape == (2, 0)
+    assert valid.shape == (2, 0)
 
 
 def _make_swa_pool(mesh, fill: str, n_swa_layers: int = 2):
@@ -212,6 +397,31 @@ def test_swa_page_mapping(meshes):
     full_pages = np.array([0, 1, 5], np.int32)
     np.testing.assert_array_equal(xfer._swa_pages(full_pages, xfer.p_mapping), [2, 3, 7])
     np.testing.assert_array_equal(xfer._swa_pages(full_pages, xfer.d_mapping), full_pages)
+
+
+def test_swa_pages_dp_rank_indexing():
+    """dp>1 building block: _swa_pages must select the CALLER-specified
+    dp_rank's mapping array, not always rank 0 -- each rank's mapping uses
+    that rank's own local index space (allocator.py: "Each rank has
+    independent [1, size_per_rank] indices"), so mixing ranks is wrong.
+    Default dp_rank=0 preserves today's dp=1-only behavior exactly."""
+    fake = SimpleNamespace(page_size=PAGE_SIZE, _swa_pages=PathwaysPDKVTransfer._swa_pages)
+    full_pages = np.array([0, 1, 2], np.int32)
+    # rank 0: full page k -> swa page k (identity)
+    map_r0 = np.arange(NUM_PAGES * PAGE_SIZE, dtype=np.int64)
+    # rank 1: full page k -> swa page (k+1) mod NUM_PAGES (shifted by one page)
+    map_r1 = ((map_r0 // PAGE_SIZE + 1) % NUM_PAGES) * PAGE_SIZE + map_r0 % PAGE_SIZE
+    mapping = [map_r0, map_r1]
+
+    # default dp_rank=0 (unchanged call signature still works)
+    np.testing.assert_array_equal(fake._swa_pages(fake, full_pages, mapping), full_pages)
+    np.testing.assert_array_equal(fake._swa_pages(fake, full_pages, mapping, dp_rank=0), full_pages)
+    # dp_rank=1 must use map_r1, NOT silently fall back to map_r0
+    np.testing.assert_array_equal(
+        fake._swa_pages(fake, full_pages, mapping, dp_rank=1), full_pages + 1
+    )
+    # non-list mapping (dp_size==1 real-world case): dp_rank is ignored, same array used
+    np.testing.assert_array_equal(fake._swa_pages(fake, full_pages, map_r0, dp_rank=1), full_pages)
 
 
 # ---- e2e: full migrate_reqs_p_to_d path on CPU mock pools ----
@@ -299,3 +509,80 @@ def test_migrate_reqs_e2e(meshes):
             p_host = np.asarray(p_pool.kv_buffer[layer]).reshape(-1, HEAD_DIM)
             d_host = np.asarray(d_pool.kv_buffer[layer]).reshape(-1, HEAD_DIM)
             np.testing.assert_array_equal(d_host[d_slots], p_host[p_slots])
+
+
+class _FakeDrainSelf:
+    """Minimal stand-in for `Scheduler` exposing only what
+    `_pd_drain_ready_multi` touches, so the multi-item drain loop can be
+    tested without booting a real scheduler/mesh/allocator stack."""
+
+    def __init__(self, ready_items=(), defer_items=(), drain_fn=None, ready_maxsize=8):
+        self._pd_ready_q = queue.Queue(maxsize=ready_maxsize)
+        for it in ready_items:
+            self._pd_ready_q.put_nowait(it)
+        self._pd_defer = list(defer_items)
+        self._drain_fn = drain_fn
+        self.drain_calls = 0
+
+    def _pd_drain_ready(self):
+        self.drain_calls += 1
+        self._drain_fn(self)
+
+
+def _drain_one_ready(fake: _FakeDrainSelf) -> None:
+    """Simulates a successful (non-deferred) drain: pop one ready_q item."""
+    try:
+        fake._pd_ready_q.get_nowait()
+    except queue.Empty:
+        pass
+
+
+def _drain_stuck_defer(fake: _FakeDrainSelf) -> None:
+    """Simulates a D-pool-full item that never fits: pop + re-append,
+    leaving both ready_q and defer-list lengths unchanged."""
+    item = fake._pd_defer.pop(0)
+    fake._pd_defer.append(item)
+
+
+def test_drain_multi_clears_backlog():
+    """A full ready_q backlog drains in a single tick, not one-per-tick."""
+    fake = _FakeDrainSelf(ready_items=list(range(5)), drain_fn=_drain_one_ready)
+    n_calls = PathwaysPDSchedulerMixin._pd_drain_ready_multi(fake)
+    assert fake._pd_ready_q.empty()
+    assert n_calls == 5
+    assert fake.drain_calls == 5
+
+
+def test_drain_multi_empty_makes_no_calls():
+    """Nothing to drain -> the loop must not call _pd_drain_ready at all."""
+    fake = _FakeDrainSelf(drain_fn=_drain_one_ready)
+    n_calls = PathwaysPDSchedulerMixin._pd_drain_ready_multi(fake)
+    assert n_calls == 0
+    assert fake.drain_calls == 0
+
+
+def test_drain_multi_stops_on_no_progress():
+    """A permanently-stuck deferred item (D pool never frees up) must not
+    burn the full maxsize+1 retry budget -- one no-op call, then exit."""
+    fake = _FakeDrainSelf(defer_items=["stuck-req"], drain_fn=_drain_stuck_defer)
+    n_calls = PathwaysPDSchedulerMixin._pd_drain_ready_multi(fake)
+    assert n_calls == 1
+    assert fake._pd_defer == ["stuck-req"]  # still stuck, untouched otherwise
+
+
+def test_drain_multi_mixed_backlog_then_stuck_defer():
+    """Ready_q items drain first (each shrinks the queue -> progress), then
+    a stuck defer item causes exit on the next no-progress call."""
+    fake = _FakeDrainSelf(ready_items=[1, 2, 3], defer_items=["stuck-req"])
+
+    def drain(f: _FakeDrainSelf) -> None:
+        if not f._pd_ready_q.empty():
+            _drain_one_ready(f)
+        else:
+            _drain_stuck_defer(f)
+
+    fake._drain_fn = drain
+    n_calls = PathwaysPDSchedulerMixin._pd_drain_ready_multi(fake)
+    assert fake._pd_ready_q.empty()
+    assert n_calls == 4  # 3 ready items + 1 no-progress defer call before exit
+    assert fake._pd_defer == ["stuck-req"]

--- a/test/srt/test_merge_cache_loc.py
+++ b/test/srt/test_merge_cache_loc.py
@@ -1,0 +1,175 @@
+"""Correctness tests for the vectorized ScheduleBatch._merge_cache_loc.
+
+The paged fast path (page_size > 1) reconstructs token-level slot indices from
+page-start values instead of memcpy-ing every token from req_to_token. These
+tests verify byte-identity against the reference per-req-loop implementation
+at every real-token position, plus the page-start slice that FA/MLA backends
+actually consume (cache_loc.reshape(dp, -1)[:, ::page_size]).
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from sgl_jax.srt.managers.schedule_batch import ScheduleBatch, ScheduleReqsInfo
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+
+
+def _make_paged_req_to_token(pool_size, max_ctx, page_size, seed=0):
+    """Build a req_to_token with the same page-contiguous layout the
+    PagedTokenToKVPoolAllocator produces: within each page, slot indices are
+    consecutive integers starting at page_id * page_size."""
+    rng = np.random.default_rng(seed)
+    n_pages = pool_size * (max_ctx // page_size)
+    page_ids = rng.permutation(n_pages).astype(np.int32).reshape(pool_size, -1)
+    return (page_ids[:, :, None] * page_size + np.arange(page_size, dtype=np.int32)).reshape(
+        pool_size, max_ctx
+    )
+
+
+def _reference_loop(req_to_token, reqs_info, dp_size, per_dp_size, page_size, total_size):
+    """The pre-vectorization per-req loop (kept as ground truth)."""
+    out = np.zeros(total_size, dtype=np.int32)
+    offset_bs = 0
+    for dp_rank in range(dp_size):
+        info = reqs_info[dp_rank]
+        if info.seq_lens is None or len(info.seq_lens) == 0:
+            offset_bs += per_dp_size
+            continue
+        seq_lens = info.seq_lens
+        aligned = ((seq_lens + page_size - 1) // page_size) * page_size
+        offsets = np.concatenate([[0], np.cumsum(aligned[:-1])]).astype(np.int64)
+        for r in range(len(seq_lens)):
+            sl = int(seq_lens[r])
+            d0 = int(offsets[r]) + offset_bs
+            out[d0 : d0 + sl] = req_to_token[int(info.req_pool_indices[r]), :sl]
+        offset_bs += per_dp_size
+    return out
+
+
+class TestMergeCacheLoc(unittest.TestCase):
+    def _run_merge(self, reqs_info, dp_size, req_to_token, page_size, total_cache_loc_size):
+        pool = MagicMock()
+        pool.req_to_token = req_to_token
+        pool.cache_loc_host_buf = np.zeros(total_cache_loc_size, dtype=np.int32)
+        batch = ScheduleBatch(
+            reqs_info=reqs_info,
+            dp_size=dp_size,
+            req_to_token_pool=pool,
+            forward_mode=ForwardMode.EXTEND,  # extend picks cache_loc_paddings[-1]
+        )
+        return batch._merge_cache_loc(
+            bs_paddings=[dp_size * 128],
+            cache_loc_paddings=[total_cache_loc_size],
+            page_size=page_size,
+            per_dp_bs_size=128,
+        )
+
+    def _assert_real_tokens_match(self, got, ref, reqs_info, dp_size, per_dp, page_size, msg=""):
+        offset_bs = 0
+        for dp_rank in range(dp_size):
+            info = reqs_info[dp_rank]
+            if info.seq_lens is None or len(info.seq_lens) == 0:
+                offset_bs += per_dp
+                continue
+            aligned = ((info.seq_lens + page_size - 1) // page_size) * page_size
+            offsets = np.concatenate([[0], np.cumsum(aligned[:-1])]).astype(np.int64)
+            for r in range(len(info.seq_lens)):
+                sl = int(info.seq_lens[r])
+                d0 = int(offsets[r]) + offset_bs
+                np.testing.assert_array_equal(
+                    got[d0 : d0 + sl],
+                    ref[d0 : d0 + sl],
+                    err_msg=f"{msg} dp={dp_rank} req={r} sl={sl}",
+                )
+            offset_bs += per_dp
+
+    def test_paged_matches_reference(self):
+        """Vectorized paged path must be byte-identical to the loop at every
+        real-token position, across page sizes / dp / boundary alignments."""
+        pool_size, max_ctx = 64, 4096
+        rng = np.random.default_rng(123)
+        for page_size in (16, 64, 256):
+            req_to_token = _make_paged_req_to_token(pool_size, max_ctx, page_size)
+            for dp_size in (1, 2, 4):
+                for _ in range(3):
+                    reqs_info = []
+                    for _dp in range(dp_size):
+                        n = int(rng.integers(0, 9))  # includes empty-DP case
+                        if n == 0:
+                            reqs_info.append(ScheduleReqsInfo(reqs=[], seq_lens=None))
+                            continue
+                        # Mix of page-boundary-exact and off-boundary seq_lens
+                        seq = rng.integers(1, max_ctx, size=n).astype(np.int32)
+                        seq[::3] = (seq[::3] // page_size) * page_size
+                        seq = np.maximum(seq, 1)
+                        idx = rng.choice(pool_size, size=n, replace=False).astype(np.int32)
+                        reqs_info.append(
+                            ScheduleReqsInfo(reqs=[], seq_lens=seq, req_pool_indices=idx)
+                        )
+                    per_dp = ((max_ctx * 8 + page_size - 1) // page_size) * page_size
+                    total = per_dp * dp_size
+                    got = self._run_merge(reqs_info, dp_size, req_to_token, page_size, total)
+                    ref = _reference_loop(
+                        req_to_token, reqs_info, dp_size, per_dp, page_size, total
+                    )
+                    self._assert_real_tokens_match(
+                        got,
+                        ref,
+                        reqs_info,
+                        dp_size,
+                        per_dp,
+                        page_size,
+                        msg=f"page={page_size} dp={dp_size}",
+                    )
+                    # Page-start slice (what FA/MLA backends read) must match
+                    # exactly — this is the correctness-critical view.
+                    np.testing.assert_array_equal(
+                        got.reshape(dp_size, per_dp)[:, ::page_size],
+                        ref.reshape(dp_size, per_dp)[:, ::page_size],
+                    )
+
+    def test_page_size_1_full_identity(self):
+        """page_size==1 keeps the per-req loop; must be fully byte-identical
+        even without the page-contiguous invariant."""
+        pool_size, max_ctx = 32, 512
+        rng = np.random.default_rng(7)
+        req_to_token = rng.integers(0, 1 << 20, size=(pool_size, max_ctx), dtype=np.int32)
+        seq = np.array([5, 128, 1, 511, 42], dtype=np.int32)
+        idx = np.array([3, 0, 17, 9, 22], dtype=np.int32)
+        reqs_info = [ScheduleReqsInfo(reqs=[], seq_lens=seq, req_pool_indices=idx)]
+        total = 4096
+        got = self._run_merge(reqs_info, 1, req_to_token, 1, total)
+        ref = _reference_loop(req_to_token, reqs_info, 1, total, 1, total)
+        np.testing.assert_array_equal(got, ref)
+
+    def test_all_empty_dp(self):
+        """All-empty batch must not crash and returns the buffer view."""
+        req_to_token = np.zeros((8, 256), dtype=np.int32)
+        reqs_info = [
+            ScheduleReqsInfo(reqs=[], seq_lens=None),
+            ScheduleReqsInfo(reqs=[], seq_lens=np.empty(0, dtype=np.int32)),
+        ]
+        got = self._run_merge(reqs_info, 2, req_to_token, 64, 1024)
+        self.assertEqual(got.shape, (1024,))
+        np.testing.assert_array_equal(got, np.zeros(1024, dtype=np.int32))
+
+    def test_single_req_single_token(self):
+        """Minimal edge: bs=1, seq_len=1 (one page)."""
+        req_to_token = _make_paged_req_to_token(4, 256, 64)
+        reqs_info = [
+            ScheduleReqsInfo(
+                reqs=[],
+                seq_lens=np.array([1], dtype=np.int32),
+                req_pool_indices=np.array([2], dtype=np.int32),
+            )
+        ]
+        got = self._run_merge(reqs_info, 1, req_to_token, 64, 256)
+        ref = _reference_loop(req_to_token, reqs_info, 1, 256, 64, 256)
+        np.testing.assert_array_equal(got[:1], ref[:1])
+        self.assertEqual(got[0], req_to_token[2, 0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Pathways single-controller PD Stage 2: perf + multi-D + hetero-TP

## Summary

Follow-up to #1428 (Stage 1 base). Adds:

**Performance (single-controller dispatch overhead)**
- Fuse `run_model + sampler + resolve/set_future` into one jit → 3 Executes/tick to 1 on the D path
- Fold dp>1 gather/scatter into single jit (per-layer 48 Executes → 1 gather + ~13 batched scatter)
- SWA models: gather/scatter only the sliding-window tail pages instead of full seq_len (16K/256 → ~2.6GB/done cross-slice down to ~40MB)
- P-thread depth-1 overlap pipeline: eager-dispatch chunk N+1 under N's device wait
- Vectorize `_merge_cache_loc` (O(bs) loop → single gather); cap `cache_loc` bucket at pool size
- Pin scatter jit in/out shardings so donate aliases in-place (avoid full-pool copy)

**`--pd-num-decode` (1 prefill → N decode fan-out)**
- Batch-level round-robin routing across N decode meshes; each done batch goes to one D
- Per-D `running_batch`/`tp_worker`/allocator state, switched via `_pd_set_d`
- Dedicated `event_loop_overlap_pd_nd` when N>1

**Startup precompile (fixes first-request cold-compile timeout)**
- Base scheduler skips `run_precompile()` under PD; this PR precompiles P workers (extend-only) + all D workers (decode-only) + KV-transfer gather/scatter for every `_NPG_BUCKETS` shape at init
- GLM-5.2 78L: correctness first-request goes from 180s+ timeout (8-16 failed) to immediate PASS (336/336); startup +~16min (P extend 220s + D decode 680s + KV 50s)

**`--pd-prefill-tp-size` (heterogeneous P/D tensor parallelism)**
- Build P mesh with `tp_prefill` devices, D mesh with `--tp-size`; slices assigned by device count
- Currently supports MLA models (KV pool tensor-replicated so per-page shape matches across tp); MHA/GQA requires `kv_heads >= max(attention_tp_p, attention_tp_d)`
- Hetero-tp gather: stack L layers → 1 device_put → unstack (L ReshardOps → 1; ~350ms → ~3ms on 78L 32→16)
- Requires a hand-written JobSet to expose slices of both topologies (PathwaysJob CRD supports one `workers[]` entry only) — sample YAML below

**Correctness fixes** (found during Stage 2 development, all covered by the test matrix)
- `copy()` must not share `reqs` list with `running_batch` (tp16 CONC≥3 overlap corruption)
- `prefix_indices[:pre_len]` snapshot for P-thread race in `prepare_for_extend`
- SWA-tail slice from real pages (not bucket-padded); per-req default; `_swa_tail_pages=0` for non-SWA pools
- dp>1 admission per-dp/total unit consistency; per-rank D-pool capacity gate
- 1P-ND per-dp RR to break dp↔D phase lock

## Test plan

All runs on TPU via Pathways single-controller. Debug logs (`[pd-*]`) gated behind `SGLANG_PD_DBG` / `SGLANG_PD_DBG_TIMING`.

| model | KV pool | tp | dp | nP-nD | IL/OL | conc | correctness | tok/s (r2/r3) | gsm8k |
|---|---|---|---|---|---|---|---|---|---|
| MiMo-V2-Flash | SWA | 8 | 2 | 2P1D | 16K/4K | 128 | 336/336 | 15439 / 15341 | 0.885 |
| MiMo-V2-Flash | SWA | 16 | 2 | 2P1D | 16K/4K | 128 | 336/336 | 16102 / 16070 | 0.865 |
| MiMo-V2-Flash | SWA | 8 | 2 | 1P2D | 4K/16K | 128 | 336/336 | 3866 / — | 0.895 |
| MiMo-V2.5-Pro | SWA | 16 | 2 | 1P1D | 16K/4K | 64 | 336/336 | 7293 / 7282 | 0.980 |
| MiMo-V2.5-Pro | SWA | 16 | 2 | 2P1D | 16K/4K | 64 | 336/336 | 7391 / 7388 | 0.980 |
| GLM-5.2-FP8 | MLA | 16 | 1 | 1P1D | 16K/4K | 64 | 336/336 | 1078³ | 0.955 |
| GLM-5.2-FP8 | MLA | 32→16 | 1 | 1P1D-hetero | 16K/4K | 64 | 336/336 | 936³ | 0.965 |

³ GLM tp16 D-pool is HBM-capped at ~397K tokens (MLA KV ~88KB/token × 78L ≈ 35GB/device tensor-replicated); at 16K IL that bounds `#running` to ~20 (vs conc 64), so throughput is D-pool-bound. The MiMo rows above (SWA pool, `#running`=128) are the P-bound throughput measurements. MiMo-V2.5-Pro rows use `pd_decode_mem_fraction=0.75` / `max_running=64` (963G weights leave ~36G/device HBM headroom).

- Correctness: 336 requests × {SHORT/MID/LONG input} × {CONC 4/8/16}, greedy `max_new_tokens=8`, byte-equal per CONC group
- Throughput: `bench_serving --num-prompts 512 --request-rate inf`, 3 rounds, r2/r3 warm
- gsm8k: 200q, `max_new_tokens=1024`
- CPU unit tests: `pytest test/srt/disaggregation/test_pathways_pd.py` (11 pass, 10 skip on CPU)

### vs Stage 1 (#1428)

Stage 1 established functional parity (rate-limited MedITL Δ+0.6% vs colocated on GLM-5.2 tp16). Stage 2 adds the throughput-oriented optimizations above; the MiMo tp8/tp16 2P1D rows are the first `request-rate inf` measurements on this path (Stage 1 did not include a saturated-throughput test plan).

GLM-5.2 gsm8k is unchanged Stage 1 → Stage 2 (0.955), confirming the perf commits do not touch model forward/sampling.

MiMo-V2.5-Pro at the Stage-1 rate-limited operating point (4K/1K, rate=0.19/0.28, same hardware):

| rate | Stage 1 PD MedITL | Stage 2 1P1D | Stage 2 2P1D |
|---|---|---|---|
| 0.19 | 57.80ms | **16.19ms** (-72%) | 16.33ms |
| 0.28 | 75.07ms | **17.28ms** (-77%) | 17.36ms |

Primary contributors are the fused D-tick (3 Executes → 1) and SWA-tail-only KV transfer (Stage 1 sent full 4K seq to D swa pool). 2P1D ≈ 1P1D at these rates (P is not the bottleneck). Config note: Stage 1 was dp=1 `fused`; Stage 2 uses dp=2 `fused_v2` — not a strict apples-to-apples on the moe backend axis.

### Shared-code perf notes

The two shared-file changes that touch the compiled path:

- **`compilation_manager` cache_loc bucket cap** (`tp_worker.py:277`): capping the per-bs bucket at pool size shrinks the largest H2D array (e.g. 134MB → ~15MB at bs=128 ctx=262K), saving ~25ms/tick on Pathways gRPC H2D. On native TPU the smaller/odd bucket shape yields a slower Pallas ragged-attention kernel (v6e-1 CI `test_bench_serving_dense` input_throughput 28285 → 26557, -6.1%), so the cap is gated on `JAX_PLATFORMS=="proxy"` (e72e96ca). Applies to Pathways colocated too (same gRPC H2D).
- **`FusedEPMoEV2` explicit reshard** (`fused_moe.py:603`): under jax 0.8.1 the `shard_map` `in_specs` already declares `P((dp,tp))`, but a same-node A/B (v7x tp8 dp2 2P1D fused_v2 16K/4K C128) shows the explicit reshard still helps the compiled path — with reshard r2/r3 = 15493/15426 tok/s vs without 15313/15245 (-1.16%/-1.17%, per-run variance 0.4–0.7%). XLA appears to place the collective differently when the sharding is asserted before the shard_map boundary. The eager-mode overhead is Python-level and does not survive jit. The analogous `logits_processor` reshard was reverted (0bbf6e4e) since it showed no e2e delta. Only reachable via `moe_backend=fused_v2`.

### Reproducing the tp8 dp2 2P1D run

<details>
<summary>PathwaysJob + launch + benchmark commands (v7x, MiMo tp8 dp2 2P1D 16K/4K C128)</summary>

**1. PathwaysJob** (3×2x2x1 slices + CPU head; requires the PathwaysJob CRD and pre-created v7x nodepools):

```yaml
apiVersion: pathways-job.pathways.domain/v1
kind: PathwaysJob
metadata:
  name: pathways-pd-b5
spec:
  maxRestarts: 20
  pathwaysVersion: jax-0.8.1
  pathwaysDir: gs://<YOUR_BUCKET>/pathways-staging
  customComponents:
    - componentType: proxy_server
      customFlags:
        - --temporary_flags_for_debugging=temporary_flag_for_debugging_disable_concurrent_dispatch=false
    - componentType: pathways_server
      customFlags:
        - --temporary_flags_for_debugging=temporary_flag_for_debugging_persistent_compilation_cache=false
  workers:
    - type: tpu7x-standard-4t
      topology: 2x2x1
      numSlices: 3
  controller:
    deploymentMode: default
    mainContainerName: main
    template:
      spec:
        nodeSelector:
          cloud.google.com/gke-nodepool: <CPU_NODEPOOL>
        containers:
          - name: main
            image: <YOUR_SGLANG_JAX_IMAGE>
            ports: [{ containerPort: 30000 }]
            env: [{ name: HF_HOME, value: /tmp/hf }]
            command: ["/bin/bash","-c","sleep infinity"]
```

For models >700G, raise the `pathways-proxy` initContainer memory limit after the head pod is running (see Known issues #6):

```bash
kubectl patch pod <HEAD_POD> --subresource resize --type=strategic \
  -p '{"spec":{"initContainers":[{"name":"pathways-proxy","resources":{"limits":{"memory":"150Gi"}}}]}}'
```

**2. Launch server** (exec into the head pod's `main` container):

```bash
env SGLANG_MOE_BULK_READ=1 SGLANG_MOE_BULK_BLOCK=1 SGLANG_PD_WEIGHT_CACHE=1 \
python3 -m sgl_jax.launch_server \
  --model-path <MODEL_PATH> --trust-remote-code --dtype=bfloat16 \
  --tp-size 8 --ep-size 8 --dp-size 2 --dp-schedule-policy round_robin --moe-backend fused_v2 \
  --page-size 256 --swa-full-tokens-ratio 0.2 --context-length 262144 \
  --chunked-prefill-size 2048 --max-prefill-tokens 16384 --max-running-requests 256 \
  --precompile-bs-paddings 1 4 8 16 32 64 128 256 --precompile-token-paddings 4096 \
  --disable-radix-cache --attention-backend fa --skip-server-warmup --random-seed 3 \
  --pd-disaggregation pathways --pd-num-prefill 2 --pd-num-decode 1 \
  --pd-prefill-max-tokens 32768 --pd-decode-max-tokens 800000 \
  --pd-prefill-mem-fraction 0.84 --pd-decode-mem-fraction 0.84 \
  --disaggregation-max-inflight-transfers 32 \
  --host 0.0.0.0 --port 30000
```

**3. Benchmark** (after `fired up`, from the same container):

```bash
# throughput (r1/r2/r3 rows in the test-plan table)
python3 -m sgl_jax.bench_serving --backend sgl-jax --host 127.0.0.1 --port 30000 \
  --dataset-name random --num-prompts 384 --request-rate inf --max-concurrency 128 \
  --random-input 16384 --random-output 4096 --random-range-ratio 1.0 --seed 12345 \
  --extra-request-body '{"sampling_params":{"temperature":0.1,"top_p":0.95,"max_new_tokens":4096,"ignore_eos":true}}'

# gsm8k
python3 benchmark/gsm8k/bench_sglang_jax.py --base-url http://localhost:30000 \
  --num-questions 200 --num-shots 5 --max-new-tokens 1024 --temperature 0 --parallel 32
```

`<MODEL_PATH>` in the reported runs is a local checkpoint of MiMo-V2-Flash mounted via PVC; a HuggingFace path with `--download-dir` also works if the head pod has enough ephemeral storage.

</details>

## Known issues

1. `schedule_policy.py:453/458/600/667` potential `prefix_indices` race under radix-cache (PD forces `--disable-radix-cache` so not triggered on this path)
2. 1P-ND N≥2 tp16: main-thread bound (~50ms/tick vs device 25ms) — throughput does not scale linearly with N
3. dp=1 + Pathways proxy backend: `jitted_run_model` cpp fastpath miss every step (~<1ms/step overhead; dp>1 unaffected). Also present on colocated — pre-existing on main, tracked in #1452.
4. Hetero-TP requires a hand-written JobSet (PathwaysJob CRD does not support multiple `workers[]` entries)
5. `kv_cache_dtype=fp8` not supported (`_init_kv_cache_dtype` handles auto/bf16 only)
6. Large models (>700G) need `pathways-proxy` initContainer memory limit raised from the CRD default 100G (peak proxy rss ≈10% of model bytes during load; e.g. `kubectl patch pod <head> --subresource resize -p '{"spec":{"initContainers":[{"name":"pathways-proxy","resources":{"limits":{"memory":"400Gi"}}}]}}'`)

## Hetero-TP JobSet sample

```yaml
apiVersion: jobset.x-k8s.io/v1alpha2
kind: JobSet
metadata: { name: <NAME> }
spec:
  replicatedJobs:
    - name: pathways-head
      template:
        spec:
          template:
            spec:
              containers:
                - name: pathways-rm
                  image: <PATHWAYS_SERVER_IMAGE>
                  args:
                    - --server_port=29001
                    - --expected_instances=<TPU_TYPE>:<P_TOPOLOGY>,<TPU_TYPE>:<D_TOPOLOGY>
                    - --instance_count=2
                # ... proxy + main containers (see PathwaysJob-generated head pod for full spec)
    - name: worker-0  # P slice, larger topology
      template:
        spec:
          parallelism: <P_HOSTS>
          template:
            spec:
              nodeSelector: { cloud.google.com/gke-tpu-topology: <P_TOPOLOGY> }
              containers:
                - name: worker
                  env:
                    - { name: MEGASCALE_SLICE_ID, value: "0" }
    - name: worker-1  # D slice, smaller topology
      # ... same, MEGASCALE_SLICE_ID=1, <D_TOPOLOGY>
```

Server args: `--pd-disaggregation pathways --tp-size <D_TP> --pd-prefill-tp-size <P_TP> --pd-prefill-ep-size <P_EP>`


