### PR TITLE
chore(skills): add profiling-capture skill

### DIFF
--- a/.claude/skills/profiling-capture/SKILL.md
+++ b/.claude/skills/profiling-capture/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: profiling-capture
+description: "Use when you need to CAPTURE / PRODUCE XProf (jax.profiler) profiling artifacts from sgl-jax (SGLang on JAX/TPU) for later performance analysis: driving a live server (/start_profile, stage-separated prefill/decode), offline bench_one_batch --profile, or kernel microbench. This skill produces the trace files; it does not analyze them."
+---
+
+# XProf Profiling Capture
+
+Produce XProf profiling files from sgl-jax for later analysis. sgl-jax is **JAX/TPU**, so the
+profiler is `jax.profiler` and it emits **XProf/TensorBoard** artifacts (`*.xplane.pb` +
+`trace.json.gz` under `plugins/profile/`), not `torch.profiler`. Scope is **capture only** —
+producing the trace, not reading it. Analysis belongs to a separate skill.
+
+## Workflow
+
+1. Pick a capture path (A/B/C) from the table below by your situation.
+2. Warm up before tracing so JIT/autotune is excluded — **never trace a cold run**. Path A
+   uses `--warmup-requests`; Path B auto-warms.
+3. Default to **one non-stage trace**; prefill/decode are separated at analysis time (out of
+   scope here). Add `--profile-by-stage` only when you need pre-split dirs.
+4. For prefill, force cache-missing prompts (`--dataset-name random` / `--disable-radix-cache`)
+   plus `--flush-cache` — unless the change under test is cache-related.
+5. Run the capture. The trace dir is **server-side** — confirm it is writable on the host.
+6. Wait for flush: confirm `*.xplane.pb` exists and `profile_status == idle`. Whether the
+   needed device compute actually landed is confirmed at analysis time, not here.
+7. Prefer a **single-rank** trace when TP emits one per rank.
+8. Hand off (see Handoff) — do **not** analyze; analysis is a separate skill.
+
+## Pick a capture path
+
+| Situation | Path |
+| --- | --- |
+| running HTTP server | **A** — live capture (non-stage default) |
+| one batch shape, no server | **B** — `bench_one_batch --profile` |
+| one kernel | **C** — kernel microbench |
+
+## A — live server
+
+`bench_serving --profile` is the recommended default: it warms up, arms the profiler, drives
+a real dataset workload, then stops — **one trace over the whole run**. A single window
+reliably captures device ops for **both** stages; separating prefill from decode is an
+analysis-time step (out of scope here).
+
+Default command:
+
+```bash
+python -m sgl_jax.bench_serving \
+  --backend sgl-jax --base-url http://127.0.0.1:30000 \
+  --dataset-name random --num-prompts 8 \
+  --random-input-len 4096 --random-output-len 128 --warmup-requests 10 \
+  --flush-cache --profile --profile-num-steps 5
+```
+
+Key flags:
+
+| Flag | Effect |
+| --- | --- |
+| `--profile` | arm the profiler for this run |
+| `--profile-num-steps` | number of steps to trace after warmup |
+| `--warmup-requests` | untraced requests first, so JIT/autotune is excluded |
+| `--flush-cache` | clear the radix cache once before the run (see Capture quality) |
+| `--profile-by-stage` | write pre-split `prefill/` + `decode/` dirs (prefill unreliable) |
+| `--profile-stages prefill decode` | with `--profile-by-stage`, which stages to profile |
+
+**Need pre-split `prefill/` + `decode/` dirs** to compare the stages directly? Add
+`--profile-by-stage`, optionally with `--profile-stages prefill decode` — pass one stage to
+profile only that stage, omit for both.
+
+**Manual path:** `POST /start_profile` (body = `ProfileReqInput`, may include `output_dir`) →
+send requests → `POST /stop_profile` → `GET /profile_status` until `message == "idle"` (else
+`"in_progress"`).
+
+**Traces are written server-side**, into `SGLANG_JAX_PROFILER_DIR` (default `/tmp`), read from
+the server process's environment. To steer `bench_serving` output, export it **at server
+launch** — a running process cannot be changed. The manual `/start_profile` path can pass
+`output_dir` per request instead. Either way the dir must be writable on the host.
+
+## B — offline batch
+
+`bench_one_batch` takes the **same server args as `launch_server`**, so fill the model and
+parallelism from your own deployment context, then add the batch shape and `--profile`:
+
+```bash
+python -m sgl_jax.bench_one_batch \
+  --model-path <model> --tp-size <n> --device tpu ... \  # your launch_server config
+  --batch-size 1 --input-len 4096 --output-len 128 --profile   # -> *.tb/
+```
+
+- **Match your server config.** Pass the same parallelism/model flags you launch with
+  (`--tp-size`, `--dp-size`, `--trust-remote-code`, `--dtype`, …); mismatched config profiles a
+  different program than you run in production.
+- **Auto-warms up** first (a full untraced run), so JIT/autotune is already excluded — do not
+  add warmup here.
+- The trace covers prefill **plus all decode steps mixed in one `*.tb/` dir**, with no stage
+  separation.
+- Only **tp_rank 0** writes the trace.
+- Dir name pattern: `<prefix>_batch<bs>_input<il>_output<ol>.tb` (`--profile-filename-prefix`).
+
+## C — kernel microbench
+
+`jax.profiler.trace(dir)` around a warmed-up `run_kernel()`. Produces Pallas/Mosaic LLO
+detail. For LLO / custom-call / perf-counter detail, set the dump flags **before `import jax`**
+and pin libtpu ≥ 0.0.39. Full recipe — region vs counter mode, flags, verification, delivery,
+existing harnesses — in [references/pallas-kernel-profiling.md](references/pallas-kernel-profiling.md).
+
+## Capture quality
+
+Details in [references/capture-recipes.md](references/capture-recipes.md). Musts:
+
+- **Warm up** (`--warmup-requests 5`) so JIT/autotune is excluded (a *step* = one forward over
+  the batch; decode step = one token, prefill step ≈ one prompt batch).
+- **Capture both stages in one non-stage trace**; splitting prefill from decode is done at
+  analysis time. Reach for `--profile-by-stage` only when you need pre-split dirs, knowing its
+  prefill trace is unreliable.
+- **Avoid the prefix-cache shortcut for prefill.** `--dataset-name random` gives unique
+  (cache-missing) prompts, or run with `--disable-radix-cache`. Add `--flush-cache` too —
+  warmup populates the radix cache, so `random` alone still traces *hits* where run prompts
+  overlap warmup; flush clears that once before the run. Decode is unaffected. Exception: when
+  profiling a KV/radix/prefix/HiCache change, do **not** flush — you want controlled cache
+  state, and flushing turns a reuse trace into miss-then-hit.
+- **Wait for flush, then confirm the capture.** `*.xplane.pb` exists and
+  `profile_status == idle` are necessary but not sufficient — a truncated window still writes a
+  valid-but-empty file. Whether the device compute you need actually landed is confirmed when
+  the trace is opened for analysis (the device/TensorCore track is non-empty over the stage of
+  interest), not from the file itself. A stage file orders of magnitude smaller than its sibling
+  is under-capture, not success.
+- **Prefer a single-rank trace** when TP emits one per rank.
+
+## Output layout
+
+```
+$SGLANG_JAX_PROFILER_DIR/            # server-side; default /tmp
+    plugins/profile/<run>/<host>.xplane.pb           # default: single tree (+ .trace.json.gz)
+# with --profile-by-stage: split into prefill/ and decode/ subtrees instead
+    prefill/plugins/profile/<run>/<host>.xplane.pb
+    decode/plugins/profile/<run>/<host>.xplane.pb
+```
+
+## Handoff
+
+Do not analyze — hand the trace to the analysis skill. The dir containing `plugins/profile` is
+what an analysis tool consumes. Always report:
+
+- **Trace dir(s)** and the stage(s) captured.
+- **Workload shape** — dataset, input/output len, warmup / `--profile-num-steps`.
+- **Server config** — `GET /get_server_info`.
+- **Verification** — `*.xplane.pb` present and `profile_status == idle`.

--- a/.claude/skills/profiling-capture/SKILL.md
+++ b/.claude/skills/profiling-capture/SKILL.md
@@ -85,7 +85,7 @@ until [ "$(curl -s http://127.0.0.1:30000/profile_status | jq -r .status)" = idl
 
 `start_profile` / `stop_profile` also accept `GET`; `start_profile` with no body uses server
 defaults. Key `ProfileReqInput` fields: `output_dir`, `num_steps`, `start_step`,
-`profile_by_stage`, `profile_stages` (e.g. `["prefill","decode"]`). 
+`profile_by_stage`, `profile_stages` (e.g. `["prefill","decode"]`).
 
 **Traces are written server-side**, into `SGLANG_JAX_PROFILER_DIR` (default `/tmp`), read from
 the server process's environment. To steer `bench_serving` output, export it **at server

--- a/.claude/skills/profiling-capture/SKILL.md
+++ b/.claude/skills/profiling-capture/SKILL.md
@@ -40,6 +40,9 @@ a real dataset workload, then stops — **one trace over the whole run**. A sing
 reliably captures device ops for **both** stages; separating prefill from decode is an
 analysis-time step (out of scope here).
 
+Keep startup precompilation enabled on the live server (the default): **do not pass
+`--disable-precompile`** when launching `sgl_jax.launch_server`.
+
 Default command:
 
 ```bash
@@ -117,10 +120,11 @@ python -m sgl_jax.bench_one_batch \
 
 ## C — kernel microbench
 
-`jax.profiler.trace(dir)` around a warmed-up `run_kernel()`. Produces Pallas/Mosaic LLO
-detail. For LLO / custom-call / perf-counter detail, set the dump flags **before `import jax`**
-and pin libtpu ≥ 0.0.39. Full recipe — region vs counter mode, flags, verification, delivery,
-existing harnesses — in [references/pallas-kernel-profiling.md](references/pallas-kernel-profiling.md).
+Use `jax.profiler.trace(dir)` around a warmed-up `run_kernel()` as the low-overhead default.
+Add LLO utilization, compiler dumps, or Ironwood/v7x periodic counters only when the profiling
+question needs that evidence. The modes are composable but add compilation, profile-size, or
+runtime overhead. Full selection guide, flags, verification, and delivery details are in
+[references/pallas-kernel-profiling.md](references/pallas-kernel-profiling.md).
 
 ## Capture quality
 
@@ -160,17 +164,23 @@ $SGLANG_JAX_PROFILER_DIR/            # server-side; default /tmp
 Do not analyze here — this skill is capture-only. Hand the trace to a companion
 analysis skill if one is installed in your environment, else open it manually:
 
-- Point TensorBoard's profile plugin at the dir that *contains* `plugins/profile` (not the
-  `.xplane.pb` file itself):
+- **Prefer standalone [XProf](https://openxla.org/xprof/jax_profiling).** Pass the complete
+  logdir that *contains* `plugins/profile` (not `plugins/profile` or the `.xplane.pb` file):
 
   ```bash
-  pip install tensorboard tensorboard-plugin-profile
-  tensorboard --logdir /tmp/myprofile   # open http://localhost:6006 → PROFILE tab
+  pip install -U xprof
+  xprof --logdir=/tmp/myprofile --port=8791   # open http://localhost:8791
   ```
 
-- Or load the `*.xplane.pb` directly in the standalone [XProf](https://github.com/openxla/xprof) viewer.
+- TensorBoard remains a fallback; install `xprof`, which now provides its Profile tab and
+  supersedes the formerly recommended `tensorboard-plugin-profile` package:
 
-Either way, the dir containing `plugins/profile` is what the tool consumes. Always report:
+  ```bash
+  pip install -U tensorboard xprof
+  tensorboard --logdir=/tmp/myprofile   # open http://localhost:6006 → Profile tab
+  ```
+
+Both commands consume the full logdir containing `plugins/profile`. Always report:
 
 - **Trace dir(s)** and the stage(s) captured.
 - **Workload shape** — dataset, input/output len, warmup / `--profile-num-steps`.

--- a/.claude/skills/profiling-capture/SKILL.md
+++ b/.claude/skills/profiling-capture/SKILL.md
@@ -66,8 +66,26 @@ Key flags:
 profile only that stage, omit for both.
 
 **Manual path:** `POST /start_profile` (body = `ProfileReqInput`, may include `output_dir`) →
-send requests → `POST /stop_profile` → `GET /profile_status` until `message == "idle"` (else
-`"in_progress"`).
+send requests → `POST /stop_profile` → `GET /profile_status` until `status == "idle"` (else
+`"in_progress"`):
+
+```bash
+# 1. arm the profiler (body = ProfileReqInput; all fields optional).
+#    Omit num_steps so the window runs until you call stop_profile below.
+curl -s -X POST http://127.0.0.1:30000/start_profile \
+  -H 'Content-Type: application/json' \
+  -d '{"output_dir": "/tmp/myprofile"}'
+
+# 2. send your requests here (bench_serving, curl /generate, real traffic, …)
+
+# 3. stop, then poll status until it flushes to idle
+curl -s -X POST http://127.0.0.1:30000/stop_profile
+until [ "$(curl -s http://127.0.0.1:30000/profile_status | jq -r .status)" = idle ]; do sleep 1; done
+```
+
+`start_profile` / `stop_profile` also accept `GET`; `start_profile` with no body uses server
+defaults. Key `ProfileReqInput` fields: `output_dir`, `num_steps`, `start_step`,
+`profile_by_stage`, `profile_stages` (e.g. `["prefill","decode"]`). 
 
 **Traces are written server-side**, into `SGLANG_JAX_PROFILER_DIR` (default `/tmp`), read from
 the server process's environment. To steer `bench_serving` output, export it **at server
@@ -79,10 +97,12 @@ launch** — a running process cannot be changed. The manual `/start_profile` pa
 `bench_one_batch` takes the **same server args as `launch_server`**, so fill the model and
 parallelism from your own deployment context, then add the batch shape and `--profile`:
 
+Replace `...` with your launch_server config; writes to `*.tb/`.
+
 ```bash
 python -m sgl_jax.bench_one_batch \
-  --model-path <model> --tp-size <n> --device tpu ... \  # your launch_server config
-  --batch-size 1 --input-len 4096 --output-len 128 --profile   # -> *.tb/
+  --model-path <model> --tp-size <n> --device tpu ... \
+  --batch-size 1 --input-len 4096 --output-len 128 --profile
 ```
 
 - **Match your server config.** Pass the same parallelism/model flags you launch with
@@ -137,8 +157,20 @@ $SGLANG_JAX_PROFILER_DIR/            # server-side; default /tmp
 
 ## Handoff
 
-Do not analyze — hand the trace to the analysis skill. The dir containing `plugins/profile` is
-what an analysis tool consumes. Always report:
+Do not analyze here — this skill is capture-only. Hand the trace to a companion
+analysis skill if one is installed in your environment, else open it manually:
+
+- Point TensorBoard's profile plugin at the dir that *contains* `plugins/profile` (not the
+  `.xplane.pb` file itself):
+
+  ```bash
+  pip install tensorboard tensorboard-plugin-profile
+  tensorboard --logdir /tmp/myprofile   # open http://localhost:6006 → PROFILE tab
+  ```
+
+- Or load the `*.xplane.pb` directly in the standalone [XProf](https://github.com/openxla/xprof) viewer.
+
+Either way, the dir containing `plugins/profile` is what the tool consumes. Always report:
 
 - **Trace dir(s)** and the stage(s) captured.
 - **Workload shape** — dataset, input/output len, warmup / `--profile-num-steps`.

--- a/.claude/skills/profiling-capture/references/capture-recipes.md
+++ b/.claude/skills/profiling-capture/references/capture-recipes.md
@@ -1,0 +1,45 @@
+# Capture Recipes
+
+Details behind the SKILL.md "Capture quality" musts — read when tuning a capture.
+Driving tool is `sgl_jax.bench_serving --profile` (Path A).
+
+## Step definition
+
+A **step** = one model forward over the batch (`forward_ct`), not a request or a token.
+So `--profile-num-steps 5` on decode needs requests generating ≥5 tokens; 5 prefill steps
+needs several prefill requests (`--num-prompts` covers this).
+
+## Shaping the load
+
+Split prefill vs decode by annotation in analysis, since prefill forwards carry `extend`.
+Shape the workload with `bench_serving` dataset flags:
+
+- `--random-input-len` — larger stresses prefill
+- `--random-output-len` — larger produces more decode steps
+- `--num-prompts` — how many requests; does **not** fix stage-separated prefill, which is a
+  transition race, not a volume problem
+
+To match production, use a real `--dataset-name` or set the random lengths to your p50/p95 and
+note them in the handoff.
+
+## Prefix-cache: hand-crafted prompts
+
+SKILL.md covers the `--dataset-name random` + `--flush-cache` musts. The extra trap: if you
+ever hand-craft **fixed** prompts instead, vary **content at a fixed token length**. Varying by
+*appending* grows the token count across a `precompile_token_paddings` bucket and changes the
+padded shape — that, not the content, is what destabilizes the trace. Decode is unaffected
+(`ignore_eos` + fixed output len is deterministic).
+
+## Tracer levels
+
+`host_tracer_level` (0 off · 1 TraceMe default · 2 +expensive XLA · 3 +cheap XLA)
+and `python_tracer_level` (0 off · 1 default) on `ProfileReqInput`. Raise only
+when you need host/python detail — higher levels perturb timing and bloat the file.
+
+## Annotations & multi-host
+
+- Scheduler always emits `run_batch`, `process_batch_result`, and
+  `forward_batch_generation {bid}` annotations — no flags needed.
+- Each host writes its own trace under `plugins/profile`; collect from all hosts
+  for the full picture. PD-disaggregated: profile prefill and decode workers
+  separately (`--profile-prefill-url` / `--profile-decode-url`) and label which is which.

--- a/.claude/skills/profiling-capture/references/pallas-kernel-profiling.md
+++ b/.claude/skills/profiling-capture/references/pallas-kernel-profiling.md
@@ -51,14 +51,22 @@ export XLA_FLAGS="${XLA_FLAGS:+$XLA_FLAGS }\
 ```python
 import os  # flags BEFORE import jax (see above)
 import jax
+OUT = "/tmp/pallas-profile"                   # same dir as the flags block above
 for _ in range(3):                            # warm up so compile/autotune is outside the trace
     jax.block_until_ready(run_kernel())
-with jax.profiler.trace("/tmp/pallas-profile/xprof"):
-    jax.block_until_ready(run_kernel())       # block_until_ready MUST be inside the block
+with jax.profiler.trace(f"{OUT}/xprof"):      # trace lands beside the LLO/HLO dumps under $OUT
+    for _ in range(100):                      # a ns-scale kernel needs many iters or the window is ~empty
+        r = run_kernel()
+    jax.block_until_ready(r)                  # block_until_ready MUST be inside the block
 ```
 
+Loop count: one call of a fast (single-digit-ns) kernel leaves too little in the window — a
+valid-but-empty trap. Loop until the region is milliseconds of device work (hundreds–thousands
+of iters for a tiny kernel); block **once at the end, still inside the block**.
+
 Name the phases with `jax.named_scope("w1_load" / "gemm" / "store_output")` so
-Trace Viewer maps LLO/MXU activity to your code (business-stage names, not `scope1`).
+Trace Viewer maps LLO/MXU activity to your code. Those names are illustrative — use **your
+kernel's** real phases (a VPU/sort kernel has no `gemm`), business-stage names not `scope1`.
 
 Output: `<logdir>/plugins/profile/<ts>/<host>.xplane.pb` (+ `.trace.json.gz`).
 
@@ -86,6 +94,7 @@ same `compiler/llo/` or trace dir.
 | `NO_LLO` | wrong dump path → `compiler/llo/` or `rank-*/compiler/llo/` |
 | job SUCCEEDED, no trace | benchmark swallowed a compile/runtime error → check logs + `.xplane.pb` |
 | LLO/HLO but no xplane | kernel didn't run / `block_until_ready` outside trace block |
+| stale or empty `compiler/llo/` on a fresh `$OUT` | a persistent compile cache skipped recompile → no new Mosaic dump; unset/clear `JAX_COMPILATION_CACHE_DIR` (or use a fresh cache dir) so the kernel recompiles |
 | VMEM OOM | shrink tile / `pltpu.CompilerParams(vmem_limit_bytes=...)` |
 
 ## References

--- a/.claude/skills/profiling-capture/references/pallas-kernel-profiling.md
+++ b/.claude/skills/profiling-capture/references/pallas-kernel-profiling.md
@@ -56,6 +56,8 @@ Illustrative skeleton (placeholders — substitute your kernel). Name each phase
 # so they take effect before the first `import jax` below.
 import jax
 
+OUT = "tmp/pallas-profile"
+
 @jax.jit
 def run_kernel():
     # wrap each phase in its own named_scope context manager
@@ -70,7 +72,7 @@ def run_kernel():
 opts = jax.profiler.ProfileOptions()          # add counter config only for counters mode
 for _ in range(3):                            # warm up so compile/autotune is outside the trace
     jax.block_until_ready(run_kernel())
-with jax.profiler.trace(f"{OUT}/xprof"):      # trace lands beside the LLO/HLO dumps under $OUT
+with jax.profiler.trace(f"{OUT}/xprof", profiler_options=opts):
     for _ in range(100):                      # a ns-scale kernel needs many iters or the window is ~empty
         r = run_kernel()
     jax.block_until_ready(r)                  # block_until_ready MUST be inside the block

--- a/.claude/skills/profiling-capture/references/pallas-kernel-profiling.md
+++ b/.claude/skills/profiling-capture/references/pallas-kernel-profiling.md
@@ -1,0 +1,95 @@
+# Pallas Kernel Profiling
+
+Producing LLO + HLO + XProf artifacts for a **Pallas/Mosaic kernel** (Path C).
+
+## Three artifact types
+
+| Artifact | When | Path |
+| --- | --- | --- |
+| Mosaic **LLO** dump | compile time | `compiler/llo/` |
+| HLO / MLIR dump | compile time | `compiler/hlo/` |
+| **XProf** trace / xplane | run time | `plugins/profile/<ts>/` |
+
+Having an LLO dump does **not** mean you captured a runtime trace — a failed
+compile can still leave LLO/HLO but no valid `.xplane.pb`.
+
+## Prerequisites
+
+- **libtpu ≥ 0.0.39** (or a pinned recent nightly). On older libtpu the LLO debug
+  flags may not exist: some are silently ignored (flags set, no LLO utilization in
+  the trace), others are rejected outright — libtpu aborts at startup with
+  `Unknown command line flag '<flag>'` (seen with `--xla_enable_custom_call_region_trace`
+  on libtpu 0.0.30). Pin a recent libtpu before setting them.
+- **Set flags before `import jax`.** `LIBTPU_INIT_ARGS` / `XLA_FLAGS` must be
+  exported in the shell or set via `os.environ` at the very top, before any JAX /
+  libtpu init. Setting them late = silent no-op.
+- Periodic perf counters are mainly **v7/Ironwood+**; on v6e expect custom-call /
+  LLO region info but not the fine-grained counters.
+
+## Dump flags
+
+```bash
+OUT=/tmp/pallas-profile      # any writable dir
+mkdir -p "$OUT/compiler/llo" "$OUT/compiler/hlo"
+export LIBTPU_INIT_ARGS="${LIBTPU_INIT_ARGS:+$LIBTPU_INIT_ARGS }\
+--xla_enable_custom_call_region_trace=true \
+--xla_xprof_register_llo_debug_info=true \
+--xla_mosaic_dump_to=$OUT/compiler/llo"
+export XLA_FLAGS="${XLA_FLAGS:+$XLA_FLAGS }\
+--xla_dump_to=$OUT/compiler/hlo --xla_dump_hlo_as_text --xla_dump_hlo_as_proto"
+```
+
+- `--xla_mosaic_dump_to` → Pallas/Mosaic LLO
+- `--xla_enable_custom_call_region_trace=true` → custom-call regions enter the trace
+- `--xla_xprof_register_llo_debug_info=true` → XProf can align custom-call ↔ LLO
+- `--xla_dump_hlo_as_text` → human-readable `*.txt` HLO; `--xla_dump_hlo_as_proto` → `*.pb` for tooling
+- LLO **must** land in `compiler/llo/` (or `rank-*/compiler/llo/`) — analysis
+  tooling scans that path; dumping elsewhere reads as `NO_LLO`.
+
+## Capture skeleton
+
+```python
+import os  # flags BEFORE import jax (see above)
+import jax
+for _ in range(3):                            # warm up so compile/autotune is outside the trace
+    jax.block_until_ready(run_kernel())
+with jax.profiler.trace("/tmp/pallas-profile/xprof"):
+    jax.block_until_ready(run_kernel())       # block_until_ready MUST be inside the block
+```
+
+Name the phases with `jax.named_scope("w1_load" / "gemm" / "store_output")` so
+Trace Viewer maps LLO/MXU activity to your code (business-stage names, not `scope1`).
+
+Output: `<logdir>/plugins/profile/<ts>/<host>.xplane.pb` (+ `.trace.json.gz`).
+
+## Verify the capture is valid
+
+```bash
+find "$OUT" -name '*.xplane.pb' -o -name '*.trace.json.gz'
+find "$OUT" -name '*.xplane.pb' -print0 | xargs -0 \
+  grep -aE 'MXU|tpu_custom_call|bundle\.|gemm|matmul' | head
+```
+Good signals: `MXU`, `Vector Load/Store/Fills/Spills`, `Scalar ALU`, `XLU`,
+`bundle.*`, `tpu_custom_call`, your `named_scope` names.
+
+## Delivery layout
+
+Keep the full `plugins/profile/<ts>/` tree — `xprof --logdir` / TensorBoard need it.
+Multi-host: each rank writes its own `rank-N/...` — never let two ranks write the
+same `compiler/llo/` or trace dir.
+
+## Common pitfalls
+
+| Symptom | Cause → fix |
+| --- | --- |
+| no LLO utilization | old libtpu / flags set late → pin libtpu, set flags before `import jax` |
+| `NO_LLO` | wrong dump path → `compiler/llo/` or `rank-*/compiler/llo/` |
+| job SUCCEEDED, no trace | benchmark swallowed a compile/runtime error → check logs + `.xplane.pb` |
+| LLO/HLO but no xplane | kernel didn't run / `block_until_ready` outside trace block |
+| VMEM OOM | shrink tile / `pltpu.CompilerParams(vmem_limit_bytes=...)` |
+
+## References
+
+OpenXLA custom-call profiling: https://openxla.org/xprof/custom_call_profiling ·
+XProf kernel guide: https://openxla.org/xprof/kernel-profiling ·
+Mosaic dump errors: https://openxla.org/xla/errors/error_3000

--- a/.claude/skills/profiling-capture/references/pallas-kernel-profiling.md
+++ b/.claude/skills/profiling-capture/references/pallas-kernel-profiling.md
@@ -1,66 +1,49 @@
 # Pallas Kernel Profiling
 
-Producing LLO + HLO + XProf artifacts for a **Pallas/Mosaic kernel** (Path C).
+Collect profiling evidence for a **Pallas/Mosaic kernel** (Path C). Start with a plain XProf
+trace, then add only the evidence modes required by the profiling question.
 
-## Three artifact types
+## Four composable capture modes
 
-| Artifact | When | Path |
-| --- | --- | --- |
-| Mosaic **LLO** dump | compile time | `compiler/llo/` |
-| HLO / MLIR dump | compile time | `compiler/hlo/` |
-| **XProf** trace / xplane | run time | `plugins/profile/<ts>/` |
+| Mode | What it provides | How to enable it | Best suited for |
+| --- | --- | --- | --- |
+| Plain trace | JAX/TPU runtime timeline, kernel duration, named scopes | `jax.profiler.trace(...)` | Which kernel is slow, and how long does it take? |
+| LLO utilization | LLO bundle utilization aligned to a Pallas custom call | Add two custom-call flags to `LIBTPU_INIT_ARGS` | How are MXU, DMA, and wait time distributed inside the kernel? |
+| Compiler dump | Compile-time HLO, MLIR, and Mosaic LLO files | Set `--xla_mosaic_dump_to` and `--xla_dump_to` | What instructions and layouts did the compiler generate? |
+| Periodic counters | Fine-grained, time-series hardware counters | Set `ProfileOptions.advanced_configuration` | Why is the MXU idle? Are spills or hardware bottlenecks occurring? |
 
-Having an LLO dump does **not** mean you captured a runtime trace — a failed
-compile can still leave LLO/HLO but no valid `.xplane.pb`.
+The modes are composable, but none of the three advanced modes is a default. Select each
+additional mode explicitly. Enabling all modes can substantially increase compilation time,
+profile size, and runtime collection overhead.
+
+Having an LLO or HLO dump does **not** mean you captured a runtime trace: a failed compile can
+leave compiler artifacts but no valid `.xplane.pb`.
 
 ## Prerequisites
 
-- **libtpu ≥ 0.0.39** (or a pinned recent nightly). On older libtpu the LLO debug
-  flags may not exist: some are silently ignored (flags set, no LLO utilization in
-  the trace), others are rejected outright — libtpu aborts at startup with
-  `Unknown command line flag '<flag>'` (seen with `--xla_enable_custom_call_region_trace`
-  on libtpu 0.0.30). Pin a recent libtpu before setting them.
-- **Set flags before `import jax`.** `LIBTPU_INIT_ARGS` / `XLA_FLAGS` must be
-  exported in the shell or set via `os.environ` at the very top, before any JAX /
-  libtpu init. Setting them late = silent no-op.
-- Periodic perf counters are mainly **v7/Ironwood+**; on v6e expect custom-call /
-  LLO region info but not the fine-grained counters.
+- Warm up before tracing so compilation and autotuning stay outside the runtime trace.
+- Set `LIBTPU_INIT_ARGS` / `XLA_FLAGS` before `import jax` when enabling LLO utilization or
+  compiler dumps. Setting them after JAX/libtpu initialization is a silent no-op.
+- Use **libtpu ≥ 0.0.39** (or a pinned recent nightly) for LLO utilization. Older versions may
+  ignore or reject the custom-call flags with `Unknown command line flag '<flag>'`.
+- Use periodic counters only on **Ironwood (TPU v7x) or later** with **JAX ≥0.9** and a
+  compatible runtime/libtpu. This repository pins JAX 0.8.1 by default, so counter mode needs
+  a separate compatible environment.
 
-## Dump flags
+## Mode 1 — plain trace (default)
 
-```bash
-OUT=/tmp/pallas-profile      # any writable dir
-mkdir -p "$OUT/compiler/llo" "$OUT/compiler/hlo"
-export LIBTPU_INIT_ARGS="${LIBTPU_INIT_ARGS:+$LIBTPU_INIT_ARGS }\
---xla_enable_custom_call_region_trace=true \
---xla_xprof_register_llo_debug_info=true \
---xla_mosaic_dump_to=$OUT/compiler/llo"
-export XLA_FLAGS="${XLA_FLAGS:+$XLA_FLAGS }\
---xla_dump_to=$OUT/compiler/hlo --xla_dump_hlo_as_text --xla_dump_hlo_as_proto"
-```
-
-- `--xla_mosaic_dump_to` → Pallas/Mosaic LLO
-- `--xla_enable_custom_call_region_trace=true` → custom-call regions enter the trace
-- `--xla_xprof_register_llo_debug_info=true` → XProf can align custom-call ↔ LLO
-- `--xla_dump_hlo_as_text` → human-readable `*.txt` HLO; `--xla_dump_hlo_as_proto` → `*.pb` for tooling
-- LLO **must** land in `compiler/llo/` (or `rank-*/compiler/llo/`) — analysis
-  tooling scans that path; dumping elsewhere reads as `NO_LLO`.
-
-## Capture skeleton
-
-Illustrative skeleton (placeholders — substitute your kernel). Name each phase with
-`jax.named_scope` so Trace Viewer shows business-stage names, then warm up and record:
+Use no dump flags, custom-call profiling flags, or `ProfileOptions` for the first pass. Name
+each phase so Trace Viewer identifies the work, warm up, then capture enough iterations to make
+short kernels visible:
 
 ```python
-# Run with the LIBTPU_INIT_ARGS / XLA_FLAGS from "Dump flags" already exported,
-# so they take effect before the first `import jax` below.
 import jax
 
-OUT = "tmp/pallas-profile"
+OUT = "/tmp/pallas-profile"
+
 
 @jax.jit
 def run_kernel():
-    # wrap each phase in its own named_scope context manager
     with jax.named_scope("w1_load"):
         w1 = load_weights()
     with jax.named_scope("gemm"):
@@ -69,47 +52,134 @@ def run_kernel():
         store(acc)
     return acc
 
-opts = jax.profiler.ProfileOptions()          # add counter config only for counters mode
-for _ in range(3):                            # warm up so compile/autotune is outside the trace
+
+for _ in range(3):
     jax.block_until_ready(run_kernel())
-with jax.profiler.trace(f"{OUT}/xprof", profiler_options=opts):
-    for _ in range(100):                      # a ns-scale kernel needs many iters or the window is ~empty
-        r = run_kernel()
-    jax.block_until_ready(r)                  # block_until_ready MUST be inside the block
+
+with jax.profiler.trace(f"{OUT}/xprof"):
+    for _ in range(100):
+        result = run_kernel()
+    jax.block_until_ready(result)
 ```
 
-Output lands under the logdir passed to `jax.profiler.trace` — here
-`$OUT/xprof/plugins/profile/<ts>/<host>.xplane.pb` (+ `.trace.json.gz`).
+Keep the final `block_until_ready` inside the trace block. Output lands under
+`$OUT/xprof/plugins/profile/<ts>/<host>.xplane.pb` plus `.trace.json.gz`.
 
-## Verify the capture is valid
+## Mode 2 — add LLO utilization
+
+Use this layer only when you need custom-call region visibility or custom-call ↔ LLO
+utilization correlation. Set both flags before `import jax`, then run the same plain trace:
 
 ```bash
-find "$OUT" -name '*.xplane.pb' -o -name '*.trace.json.gz'
-find "$OUT" -name '*.xplane.pb' -print0 | xargs -0 \
-  grep -aE 'MXU|tpu_custom_call|bundle\.|gemm|matmul' | head
+export LIBTPU_INIT_ARGS="${LIBTPU_INIT_ARGS:+$LIBTPU_INIT_ARGS }\
+--xla_enable_custom_call_region_trace=true \
+--xla_xprof_register_llo_debug_info=true"
 ```
-Good signals: `MXU`, `Vector Load/Store/Fills/Spills`, `Scalar ALU`, `XLU`,
-`bundle.*`, `tpu_custom_call`, your `named_scope` names.
+
+- `--xla_enable_custom_call_region_trace=true` exposes custom-call regions in the trace.
+- `--xla_xprof_register_llo_debug_info=true` lets XProf align a custom call with LLO bundles.
+
+These flags increase captured profile size and collection overhead. Leave them unset for
+routine timing traces. See the OpenXLA
+[custom-call profiling guide](https://openxla.org/xprof/custom_call_profiling).
+
+## Mode 3 — add compiler dumps
+
+Use this layer only when investigating lowering, layouts, or generated instructions. Set the
+flags before `import jax`; they take effect when the kernel compiles:
+
+```bash
+OUT=/tmp/pallas-profile
+mkdir -p "$OUT/compiler/llo" "$OUT/compiler/hlo"
+export LIBTPU_INIT_ARGS="${LIBTPU_INIT_ARGS:+$LIBTPU_INIT_ARGS }\
+--xla_mosaic_dump_to=$OUT/compiler/llo"
+export XLA_FLAGS="${XLA_FLAGS:+$XLA_FLAGS }\
+--xla_dump_to=$OUT/compiler/hlo --xla_dump_hlo_as_text --xla_dump_hlo_as_proto"
+```
+
+- Mosaic IR/LLO artifacts land in `compiler/llo/`.
+- Human-readable HLO and HLO proto files land in `compiler/hlo/`.
+- A persistent compilation-cache hit may skip compilation and produce no fresh dumps. Use a
+  fresh `JAX_COMPILATION_CACHE_DIR` or clear it when new artifacts are required.
+
+Compiler dumps add compile-time work and disk output; they do not replace the runtime trace.
+See the OpenXLA [HLO dump guide](https://openxla.org/xla/hlo_dumps).
+
+## Mode 4 — add periodic counters (Ironwood/v7x+)
+
+Use this layer only for a focused hardware-bottleneck question in a compatible JAX ≥0.9
+environment. Periodic counters are independent of the LLO utilization and compiler-dump flags.
+This official TC example samples five counter indices; replace the set with counters selected
+for the question in XProf's Perf Counters tool:
+
+```python
+opts = jax.profiler.ProfileOptions()
+opts.advanced_configuration = {
+    "tpu_enable_periodic_counter_sampling": True,
+    "tpu_tc_perf_counter_sampling_options": (
+        "interval_us:1 scaling:0 counter_size_bits:1 "
+        "indices:10 indices:11 indices:56 indices:57 indices:58"
+    ),
+}
+
+with jax.profiler.trace(f"{OUT}/xprof", profiler_options=opts):
+    for _ in range(100):
+        result = run_kernel()
+    jax.block_until_ready(result)
+```
+
+The example uses the minimum 1 μs interval and 16-bit packed counters (`counter_size_bits:1`),
+so treat it as an aggressive illustrative configuration. For another TPU component, change
+both the `tpu_<component>_perf_counter_sampling_options` key and its component-specific indices.
+Sample only the components, indices, and frequency needed: more counters and shorter intervals
+increase payload size and runtime collection overhead and can cause trace drops. See the
+[XProf Kernel guide](https://openxla.org/xprof/kernel-profiling).
+
+## Verify the selected evidence
+
+```bash
+OUT=/tmp/pallas-profile
+find "$OUT/xprof" -name '*.xplane.pb' -o -name '*.trace.json.gz'
+find "$OUT/compiler" -type f 2>/dev/null | head
+```
+
+- **Plain trace:** confirm `*.xplane.pb` exists, then check kernel durations and named scopes.
+- **LLO utilization:** also confirm the LLO Utilization line, `bundle.*`, and custom-call regions.
+- **Compiler dumps:** also confirm fresh files exist under `compiler/llo/` and `compiler/hlo/`.
+- **Periodic counters:** also confirm the selected counter lines contain time-series points.
+
+Do not expect LLO utilization, compiler files, or periodic-counter lines from a plain trace.
 
 ## Delivery layout
 
-Keep the full `plugins/profile/<ts>/` tree — `xprof --logdir` / TensorBoard need it.
-Multi-host: each rank writes its own `rank-N/...` — never let two ranks write the
-same `compiler/llo/` or trace dir.
+Keep the full `plugins/profile/<ts>/` tree; `xprof --logdir` and TensorBoard consume the logdir
+that contains `plugins/profile`.
+
+```text
+$OUT/
+├── xprof/plugins/profile/<ts>/<host>.xplane.pb
+├── compiler/llo/       # only with compiler-dump mode
+└── compiler/hlo/       # only with compiler-dump mode
+```
+
+For multi-host captures, write each rank to its own `rank-N/` tree. Never let two ranks share a
+compiler-dump or trace directory.
 
 ## Common pitfalls
 
 | Symptom | Cause → fix |
 | --- | --- |
-| no LLO utilization | old libtpu / flags set late → pin libtpu, set flags before `import jax` |
-| `NO_LLO` | wrong dump path → `compiler/llo/` or `rank-*/compiler/llo/` |
-| job SUCCEEDED, no trace | benchmark swallowed a compile/runtime error → check logs + `.xplane.pb` |
-| LLO/HLO but no xplane | kernel didn't run / `block_until_ready` outside trace block |
-| stale or empty `compiler/llo/` on a fresh `$OUT` | a persistent compile cache skipped recompile → no new Mosaic dump; unset/clear `JAX_COMPILATION_CACHE_DIR` (or use a fresh cache dir) so the kernel recompiles |
-| VMEM OOM | shrink tile / `pltpu.CompilerParams(vmem_limit_bytes=...)` |
+| no runtime trace | kernel did not run, or `block_until_ready` was outside the trace block |
+| no LLO utilization | mode not selected, old libtpu, or flags set after `import jax` |
+| no compiler dumps | mode not selected, flags set late, or persistent cache skipped compilation |
+| LLO/HLO but no xplane | compiler dumps are compile-time evidence, not a runtime capture |
+| no periodic counter lines | unsupported TPU generation or incomplete counter configuration |
+| trace is unexpectedly large | too many modes, counters, or short sampling intervals enabled |
+| VMEM OOM | shrink the tile or set `pltpu.CompilerParams(vmem_limit_bytes=...)` |
 
 ## References
 
-OpenXLA custom-call profiling: https://openxla.org/xprof/custom_call_profiling ·
-XProf kernel guide: https://openxla.org/xprof/kernel-profiling ·
-Mosaic dump errors: https://openxla.org/xla/errors/error_3000
+- [JAX `profiler.trace`](https://docs.jax.dev/en/latest/_autosummary/jax.profiler.trace.html)
+- [OpenXLA custom-call profiling](https://openxla.org/xprof/custom_call_profiling)
+- [OpenXLA HLO dumps](https://openxla.org/xla/hlo_dumps)
+- [XProf Kernel guide](https://openxla.org/xprof/kernel-profiling)

--- a/.claude/skills/profiling-capture/references/pallas-kernel-profiling.md
+++ b/.claude/skills/profiling-capture/references/pallas-kernel-profiling.md
@@ -48,10 +48,26 @@ export XLA_FLAGS="${XLA_FLAGS:+$XLA_FLAGS }\
 
 ## Capture skeleton
 
+Illustrative skeleton (placeholders — substitute your kernel). Name each phase with
+`jax.named_scope` so Trace Viewer shows business-stage names, then warm up and record:
+
 ```python
-import os  # flags BEFORE import jax (see above)
+# Run with the LIBTPU_INIT_ARGS / XLA_FLAGS from "Dump flags" already exported,
+# so they take effect before the first `import jax` below.
 import jax
-OUT = "/tmp/pallas-profile"                   # same dir as the flags block above
+
+@jax.jit
+def run_kernel():
+    # wrap each phase in its own named_scope context manager
+    with jax.named_scope("w1_load"):
+        w1 = load_weights()
+    with jax.named_scope("gemm"):
+        acc = matmul(x, w1)
+    with jax.named_scope("store_output"):
+        store(acc)
+    return acc
+
+opts = jax.profiler.ProfileOptions()          # add counter config only for counters mode
 for _ in range(3):                            # warm up so compile/autotune is outside the trace
     jax.block_until_ready(run_kernel())
 with jax.profiler.trace(f"{OUT}/xprof"):      # trace lands beside the LLO/HLO dumps under $OUT
@@ -60,15 +76,8 @@ with jax.profiler.trace(f"{OUT}/xprof"):      # trace lands beside the LLO/HLO d
     jax.block_until_ready(r)                  # block_until_ready MUST be inside the block
 ```
 
-Loop count: one call of a fast (single-digit-ns) kernel leaves too little in the window — a
-valid-but-empty trap. Loop until the region is milliseconds of device work (hundreds–thousands
-of iters for a tiny kernel); block **once at the end, still inside the block**.
-
-Name the phases with `jax.named_scope("w1_load" / "gemm" / "store_output")` so
-Trace Viewer maps LLO/MXU activity to your code. Those names are illustrative — use **your
-kernel's** real phases (a VPU/sort kernel has no `gemm`), business-stage names not `scope1`.
-
-Output: `<logdir>/plugins/profile/<ts>/<host>.xplane.pb` (+ `.trace.json.gz`).
+Output lands under the logdir passed to `jax.profiler.trace` — here
+`$OUT/xprof/plugins/profile/<ts>/<host>.xplane.pb` (+ `.trace.json.gz`).
 
 ## Verify the capture is valid
 


### PR DESCRIPTION
## Motivation

Add a **capture-only** XProf profiling skill for sgl-jax (JAX/TPU) under `.claude/skills/profiling-capture/`. It documents how to reliably *produce* trace artifacts (`*.xplane.pb` + `trace.json.gz`) for later analysis, avoiding common silent failures (cold runs, prefix-cache hits faking prefill, truncated/empty windows, LLO dump flags set after `import jax`). Analysis is out of scope.

## Modifications

Docs only — no runtime code changed. Adds three files:

- `SKILL.md` — path A/B/C selection (live server / offline batch / kernel microbench),
  capture-quality musts, handoff contract.
- `references/capture-recipes.md` — step definition, load shaping.
- `references/pallas-kernel-profiling.md` — Pallas/Mosaic LLO/HLO/XProf recipe + pitfalls.

## Accuracy Tests

N/A — documentation only, no model output changes.

## Benchmarking and Profiling

N/A — documentation only, no inference-speed impact.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.