### PR TITLE
fix(mem_cache): freeze unified device match on BASE misses only

### DIFF
--- a/python/sgl_jax/srt/mem_cache/unified_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/unified_radix_cache.py
@@ -570,15 +570,19 @@ class UnifiedRadixCache(BasePrefixCache):
         best_host_node = node
         best_host_tokens = 0
         cur_tokens = 0
-        # Device coverage must stay a contiguous prefix from root. Once a
-        # tombstone breaks the chain, device-best freezes — otherwise a deeper
-        # still-resident node under an evicted ancestor breaks inc_lock_ref.
+        # Device coverage must stay a contiguous BASE prefix from root: past a
+        # tombstone (FULL KV evicted), a deeper still-resident node would break
+        # inc_lock_ref, so only a BASE miss freezes device-best. Auxiliary
+        # components hold no value on interior nodes by design (leaf-only
+        # recurrent snapshots), so their misses skip the node — a deeper
+        # fully-valid node can still win.
         device_broken = False
 
+        base_device_validator = self.components[BASE_COMPONENT_TYPE].create_match_validator(
+            match_device_only=True
+        )
         if full_only:
-            device_validators = (
-                self.components[BASE_COMPONENT_TYPE].create_match_validator(match_device_only=True),
-            )
+            device_validators = (base_device_validator,)
             host_validators = ()
         else:
             device_validators = tuple(
@@ -593,12 +597,12 @@ class UnifiedRadixCache(BasePrefixCache):
         def _update_best_if_valid(candidate: UnifiedTreeNode):
             nonlocal best_device_node, best_value_len, best_device_tokens
             nonlocal best_host_node, best_host_tokens, device_broken
+            if not base_device_validator(candidate):
+                device_broken = True
             if not device_broken and all(v(candidate) for v in device_validators):
                 best_device_node = candidate
                 best_value_len = len(value)
                 best_device_tokens = cur_tokens
-            else:
-                device_broken = True
             if all(v(candidate) for v in host_validators):
                 best_host_node = candidate
                 best_host_tokens = cur_tokens

--- a/python/sgl_jax/test/mem_cache/test_unified_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_unified_radix_cache.py
@@ -1209,6 +1209,27 @@ class TestUnifiedRadixCacheRecurrent(CustomTestCase):
         self.assertEqual(pool.recurrent_available_size(0), slots)
         self.assertEqual(cache.assert_recurrent_slot_ledger(0), 0)
 
+    def test_match_reaches_snapshot_past_snapshotless_interior_node(self):
+        """The device walk must skip interior nodes without a recurrent snapshot
+        (leaf-only invariant frees them) and match the deeper snapshot leaf."""
+        _, pool, _, cache = self._create_recurrent_setup()
+
+        key = [1, 2, 3, 4, 5, 6, 7, 8]
+        full_value = np.arange(100, 108, dtype=np.int32)
+        self._commit(cache, pool, key[:4], full_value[:4])
+        slot2, second = self._commit(cache, pool, key, full_value)
+        self.assertTrue(second.recurrent_committed)
+        # The first boundary node turned interior; its snapshot was freed.
+        self.assertEqual(cache.component_evictable_size_[ComponentType.RECURRENT][0], 1)
+
+        # Cross-request share: same 8-token prefix, diverging tail.
+        req = _CowReq(dp_rank=0)
+        match = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(key + [99], None, 0), cow_recurrent=True, req=req)
+        )
+        self.assertTrue(np.array_equal(match.device_indices, full_value))
+        self.assertEqual(req.recurrent_cow_src_index, slot2)
+
     def test_abort_and_retract_release_recurrent_slots(self):
         """Abort and retract must return request-owned recurrent slots to the free list."""
         state_pool, pool, allocator, cache = self._create_recurrent_setup()


### PR DESCRIPTION
Fixes #1456.

The `device_broken` freeze in `_match_prefix_helper` (#1411) keyed on all device validators, but auxiliary components legitimately hold no value on interior nodes (leaf-only recurrent snapshots), so any recurrent prompt spanning >=2 track intervals froze at the first interior node and matched nothing. Key the freeze to the BASE validator — the actual `inc_lock_ref` contiguity invariant; auxiliary misses skip the node so a deeper valid node still wins. Tombstone semantics with hicache on are unchanged.

## Tests

- New `test_match_reaches_snapshot_past_snapshotless_interior_node`: builds a 2-segment chain (interior snapshot freed by the leaf-only invariant) and asserts the device match reaches the deeper snapshot leaf. Fails on main at the device-match assert; passes with the fix.
- Full `python/sgl_jax/test/mem_cache/` battery green (325 pass; `test_copy_slots_multi_dp_locality` passes with the forced 4-device flag as usual).
- TPU A/B (nightly `recurrent-ab-perf-v6e-4` suite, Qwen3.5-35B-A3B tp4/page128/track512, v6e-4): gsp hit_rate 0.0000 → **0.8021**, p50 TTFT ratio 0.725 → **0.099** (1554 ms vs 15641 ms no-cache); random workload gate unchanged (1746 vs 1513 tok/s, >=0.95x PASS).
