### PR TITLE
fix(bench): align speculative accept metrics with upstream(SGLang)

### DIFF
--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1452,6 +1452,11 @@ class Scheduler(
         ret["disagg_prealloc_queue_size"] = len(self.disagg_prealloc_queue or ())
         ret["disagg_transfer_queue_size"] = len(self.disagg_transfer_queue or ())
 
+        if self.spec_num_total_forward_ct > 0:
+            ret["avg_spec_accept_length"] = (
+                self.spec_num_total_accepted_tokens / self.spec_num_total_forward_ct
+            )
+
         return GetInternalStateReqOutput(internal_state=ret)
 
     def set_internal_state(self, recv_req: SetInternalStateReq):

--- a/python/sgl_jax/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_metrics_mixin.py
@@ -134,8 +134,13 @@ class SchedulerMetricsMixin:
             and self.draft_token > 0
             and self.spec_num_forward_ct > 0
         ):
-            accept_ratio = self.accept_token / self.draft_token
             accept_len = self.accept_token / self.spec_num_forward_ct
+            num_draft_tokens = self.draft_token / self.spec_num_forward_ct
+            accept_ratio = (
+                (accept_len - 1) / (num_draft_tokens - 1) if num_draft_tokens > 1 else 0.0
+            )
+            self.spec_num_total_accepted_tokens += self.accept_token
+            self.spec_num_total_forward_ct += self.spec_num_forward_ct
             self.accept_token = 0
             self.draft_token = 0
             self.spec_num_forward_ct = 0


### PR DESCRIPTION
## Content
- Change the cal of accept rate the same to sglang
<img width="1531" height="148" alt="image" src="https://github.com/user-attachments/assets/344435a8-18b3-413a-8038-aec32bc62b50" />

- Add accept length statistics

## Test

```bash
python3 -m sgl_jax.bench_serving \
    --backend sgl-jax \
    --host 127.0.0.1 --port 8000 \
    --dataset-name random \
    --num-prompts 3 \
    --random-input 1024 \
    --random-output 1024 \
    --max-concurrency 1 \
    --random-range-ratio 1 \
    --warmup-requests 0
```
<img width="1462" height="153" alt="image" src="https://github.com/user-attachments/assets/d4f08391-f3ba-46a4-bf2c-a6fb3ea517bd" />


And show accept len in the final output

<img width="471" height="438" alt="image" src="https://github.com/user-attachments/assets/b289bca9-ef65-4fe5-ac8f-4eb59ee377e5" />
