### PR TITLE
fix(glm5): fp32 accumulate on absorbed-MLA W_UK/W_UV fold for v7x

### DIFF
--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -343,12 +343,17 @@ class Glm5Attention(nnx.Module):
         forward_batch: ForwardBatch,
         token_to_kv_pool: KVCache,
     ) -> tuple[jax.Array, jax.Array]:
-        # "thd,rhd->thr"
+        # "thd,rhd->thr" — fp32 accumulate: on v7x the default bf16
+        # accumulator drops enough precision on this small batched dot
+        # (per-device [T, H/tp, 128]) that decode drifts into repetition
+        # over 78 layers; v6e's default happens to be tighter. Cost is
+        # negligible vs q/o_proj.
         ql_nope = jax.lax.dot_general(
             q_nope,
             self.w_uk.value,
             (((2,), (2,)), ((1,), (1,))),
-        )
+            preferred_element_type=jnp.float32,
+        ).astype(q_nope.dtype)
         ql_nope = ql_nope.transpose(1, 0, 2)
 
         c_kv_3d = compressed[:, None, :]
@@ -361,12 +366,13 @@ class Glm5Attention(nnx.Module):
             q_rope=q_rope,
             k_rope=k_rope,
         )
-        # "thr,rhd->thd"
+        # "thr,rhd->thd" — fp32 accumulate; see ql_nope above.
         o_v = jax.lax.dot_general(
             attn_output,
             self.w_uv.value,
             (((2,), (0,)), ((1,), (1,))),
-        )
+            preferred_element_type=jnp.float32,
+        ).astype(attn_output.dtype)
         o_v = o_v.transpose(1, 0, 2)
         attn_output = o_v.reshape(-1, self.num_heads * self.v_head_dim)
         return attn_output, kv_fused


### PR DESCRIPTION
## Summary

GLM-5.x on TPU v7x produces degenerate repetition (`"1. The number of people is 20. 2. The number of people is 20..."`) on any `--attention-backend`, any tp size, with or without overlap scheduling. Same config on v6e is correct.

Root cause: the two `jax.lax.dot_general` calls in `Glm5Attention._forward_mqa` (absorbed-MLA W_UK/W_UV fold) don't specify `preferred_element_type`, so they use the hardware-default bf16 accumulator. On v7x the default bf16 dot-general on this batched shape (per-device `[T, H/tp, 128] × [512, H/tp, 128]`) loses enough precision that decode drifts into repetition over 78 layers. v6e's default happens to be tighter.

Fix: `preferred_element_type=jnp.float32` on both. Cost is negligible (contract dim 128/512, dwarfed by q/o_proj and MoE gmm).

## Before / after (v7x 2x2x2 tp=16, W8A8, `--attention-backend fa`)

| test | before | after |
|---|---|---|
| `Count from 1 to 20:` (60 tok) | `" 1. The number of people is 20.2. The number of people is 20..."` | `" 1. one 2. two 3. three ... 15. fifteen"` (matches v6e) |
| `first 200 natural numbers:` (400 tok) | `"...50, 60, 61, ...106, 106, 106, 106..."` | `" 1, 2, 3, ..., 200. If we remove all the numbers divisible by 2, 3, or 5..."` (matches v6e) |
| GSM8K chat 5Q | 2/5 (repetition tails) | **5/5** |
| pos=9 logits[15:24] (digit tokens) | `[3.5, 4.1, 6.1, ...]` (all positive) | `[-8.6, -5.5, -3.3, ...]` (all negative, matches v6e) |

Also verified on v7x 2x2x4 tp=32 with `--disable-overlap-schedule` (previously reported as a separate bug — same root cause).

## Test plan

- [x] v7x tp=16 fa: Count ×3 deterministic, long-seq 400 tok no repetition, GSM8K 5/5
- [x] v7x tp=32 fa `--disable-overlap-schedule`: Count ×3, long-seq no repetition
- [x] v6e tp=64 fa: unchanged (default was already sufficient)
- [x] Standalone `dot_general` precision probe: v7x bf16-default err=0.127 vs f32-accum err=0.0000 (ref_absmax=40.7)
