### PR TITLE
fix(multimodal): make EncoderScheduler kwargs explicit and fail-fast (#1326)

### DIFF
--- a/python/sgl_jax/srt/multimodal/manager/scheduler/encoder_scheduler.py
+++ b/python/sgl_jax/srt/multimodal/manager/scheduler/encoder_scheduler.py
@@ -23,7 +23,8 @@ class EncoderScheduler(SchedulerProfilerMixin):
         communication_backend: CommunicationBackend,
         model_class: str | list[str] = None,
         stage_sub_dir: str | None = None,
-        **kwargs,
+        tokenizers: str = "tokenizer",
+        precompile_params: dict | None = None,
     ):
         """Initialize the EncoderScheduler.
 
@@ -33,7 +34,18 @@ class EncoderScheduler(SchedulerProfilerMixin):
             communication_backend: backend implementing
                 `recv_requests()` and `send_pyobj()`.
             model_class: encoder model class passed to the worker.
+            stage_sub_dir: optional stage sub-directory for the worker.
+            tokenizers: tokenizer path/name forwarded to the worker.
+            precompile_params: uniformly forwarded to every scheduler by
+                `stage.py` but unused here; ``None``/empty is accepted and a
+                non-empty value is rejected (issue #1326).
         """
+        if precompile_params:
+            raise ValueError(
+                f"EncoderScheduler does not support precompile_params "
+                f"({precompile_params!r}); precompilation is controlled by "
+                "server_args.disable_precompile."
+            )
 
         self.communication_backend = communication_backend
         self.mesh = mesh
@@ -42,7 +54,7 @@ class EncoderScheduler(SchedulerProfilerMixin):
             mesh=mesh,
             model_class=model_class,
             stage_sub_dir=stage_sub_dir,
-            tokenizer=kwargs.get("tokenizers", "tokenizer"),
+            tokenizer=tokenizers,
         )
         self.forward_ct = 0
         self.init_profier()

--- a/python/sgl_jax/test/multimodal/test_encoder_scheduler_kwargs.py
+++ b/python/sgl_jax/test/multimodal/test_encoder_scheduler_kwargs.py
@@ -1,0 +1,63 @@
+import unittest
+from unittest import mock
+
+from sgl_jax.srt.multimodal.manager.scheduler.encoder_scheduler import EncoderScheduler
+
+WORKER = "sgl_jax.srt.multimodal.manager.scheduler.encoder_scheduler.EncoderModelWorker"
+
+
+class _FakeServerArgs:
+    disable_precompile = True
+
+
+class TestEncoderSchedulerConstructorContract(unittest.TestCase):
+    """EncoderScheduler.__init__ contract after removing **kwargs (issue #1326).
+
+    The failure cases raise during argument binding / at the top of __init__,
+    before the (heavy) EncoderModelWorker is built, so they run on CPU without
+    devices or model weights. The accepted cases mock the worker and profiler
+    init to keep construction on CPU.
+    """
+
+    def test_tokenizer_typo_fails_at_construction(self):
+        # `tokenizer` (singular) is the classic YAML typo for `tokenizers`; it must
+        # now fail instead of being silently swallowed and defaulted.
+        with self.assertRaises(TypeError):
+            EncoderScheduler(None, None, None, tokenizer="/tok")
+
+    def test_unknown_scheduler_param_fails_at_construction(self):
+        with self.assertRaises(TypeError):
+            EncoderScheduler(None, None, None, some_unsupported_param=1)
+
+    def test_non_empty_precompile_params_is_rejected(self):
+        with self.assertRaises(ValueError):
+            EncoderScheduler(None, None, None, precompile_params={"mode": "eager"})
+
+    @mock.patch.object(EncoderScheduler, "init_profier")
+    @mock.patch(WORKER)
+    def test_none_precompile_params_accepted_and_tokenizers_forwarded(
+        self, mock_worker, _mock_init_profier
+    ):
+        # None is the uniform forward from stage.py and must be accepted; the
+        # tokenizers value must reach the worker.
+        scheduler = EncoderScheduler(
+            _FakeServerArgs(),
+            mesh=None,
+            communication_backend="backend",
+            model_class="EncoderModel",
+            stage_sub_dir="sub",
+            tokenizers="/path/to/tok",
+            precompile_params=None,
+        )
+        self.assertIs(scheduler.encoder_worker, mock_worker.return_value)
+        self.assertEqual(mock_worker.call_args.kwargs["tokenizer"], "/path/to/tok")
+
+    @mock.patch.object(EncoderScheduler, "init_profier")
+    @mock.patch(WORKER)
+    def test_empty_precompile_params_is_accepted(self, _mock_worker, _mock_init_profier):
+        # Empty means "nothing configured" -> must not raise.
+        EncoderScheduler(_FakeServerArgs(), None, "backend", precompile_params={})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -370,6 +370,7 @@ suites = {
             0.2,
             runner="pytest",
         ),
+        TestFile("python/sgl_jax/test/multimodal/test_encoder_scheduler_kwargs.py", 0.1),
         TestFile("python/sgl_jax/test/models/test_qwen3_5.py", 2, runner="pytest"),
         TestFile(
             "python/sgl_jax/test/kernels/test_gdn_fused_chunk_parallel_provenance.py",

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -324,6 +324,7 @@ suites = {
             0.2,
             runner="pytest",
         ),
+        TestFile("python/sgl_jax/test/multimodal/test_encoder_scheduler_kwargs.py", 0.1),
         TestFile("python/sgl_jax/test/models/test_qwen3_5.py", 2, runner="pytest"),
         TestFile("python/sgl_jax/test/mem_cache/test_req_to_token_pool.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_hybrid_req_to_token_pool.py", 1),


### PR DESCRIPTION
## Motivation

`EncoderScheduler.__init__` accepted `**kwargs` but only read
`kwargs.get("tokenizers", ...)`, silently dropping every other key. Because
`stage.py` forwards `precompile_params=..., **scheduler_params` to every
scheduler, a misconfigured `text_encoder` stage failed **silently**:

- a YAML typo (`tokenizer` vs `tokenizers`) fell back to the default with no signal;
- any other unsupported `scheduler_params` key was swallowed by `**kwargs`;
- a uniformly-forwarded non-empty `precompile_params` (which `EncoderScheduler`
  does not consume) was silently ignored.

The stage then looked like it honored the config when it did not.

Closes #1326

## Modifications

Fix the constructor contract itself instead of warning about the symptom:

- Make `tokenizers` an explicit `EncoderScheduler.__init__` parameter and **remove
  `**kwargs`**, so a typo or any unsupported `scheduler_params` key now fails at
  construction (`TypeError`) instead of being silently dropped.
- Make `precompile_params` an explicit parameter: accept the uniformly-forwarded
  `None`/empty, and reject a non-empty value with a `ValueError` — `EncoderScheduler`
  does not consume it (precompilation is controlled by `server_args.disable_precompile`).
- Add CPU unit tests that exercise the real `EncoderScheduler` construction path
  (typo → `TypeError`, unknown param → `TypeError`, non-empty `precompile_params`
  → `ValueError`, and the accepted `None`/empty cases with the worker mocked),
  registered in the `unit-test-cpu` suite.

**Scope**

- Only `EncoderScheduler` is tightened. The other schedulers (`auto_regressive`,
  `diffusion`, `vae`) still accept `precompile_params`/`**kwargs` as before — this
  PR does not change them.
- All current `text_encoder` stage configs (`flux1_dev`, and `wan2_1`/`wan2_2`
  after #1316) pass only `{"tokenizers": ...}` with `precompile_params=None`, so the
  stricter contract is a no-op for valid configs and only surfaces misconfigurations.

## Accuracy Tests

N/A — host-side constructor/config validation only; no change to model / kernel /
forward code or model outputs.

## Benchmarking and Profiling

N/A — no change to the inference path; no performance impact.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve. (Closes #1326)
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.

### Test plan

    pytest python/sgl_jax/test/multimodal/test_encoder_scheduler_kwargs.py -v
    pre-commit run --all-files