### PR TITLE
fix(kda): bound Stage 1 gate cumsum residency

### DIFF
--- a/python/sgl_jax/srt/kernels/kda/kda.py
+++ b/python/sgl_jax/srt/kernels/kda/kda.py
@@ -137,48 +137,34 @@ _VMEM_HW_LIMIT_BYTES = 30 * 1024 * 1024
 
 
 def _chunk_cumsum_kernel(
-    cu_seqlens_ref,
-    chunk_indices_ref,
     s_ref,
     o_ref,
     *,
     BT: int,
-    NT: int,
     REVERSE: bool,
     HAS_SCALE: bool,
     scale: float,
 ):
     num_steps = int(math.log2(BT))
+    s = s_ref[:, 0, :, :].astype(jnp.float32)
 
-    def body(i_t, _):
-        i_n = chunk_indices_ref[i_t, 0]
-        local_i_t = chunk_indices_ref[i_t, 1]
-        bos = cu_seqlens_ref[i_n]
-        start_t = bos + local_i_t * BT
-        start_t = pl.multiple_of(start_t, BT)
+    if REVERSE:
+        for d in range(num_steps):
+            stride = 1 << d
+            top = s[:, : BT - stride, :] + s[:, stride:, :]
+            bot = s[:, BT - stride :, :]
+            s = jnp.concatenate([top, bot], axis=1)
+    else:
+        for d in range(num_steps):
+            stride = 1 << d
+            top = s[:, :stride, :]
+            bot = s[:, stride:, :] + s[:, :-stride, :]
+            s = jnp.concatenate([top, bot], axis=1)
 
-        s = s_ref[:, dslice(start_t, BT), :].astype(jnp.float32)
+    if HAS_SCALE:
+        s = s * scale
 
-        if REVERSE:
-            for d in range(num_steps):
-                stride = 1 << d
-                top = s[:, : BT - stride, :] + s[:, stride:, :]
-                bot = s[:, BT - stride :, :]
-                s = jnp.concatenate([top, bot], axis=1)
-        else:
-            for d in range(num_steps):
-                stride = 1 << d
-                top = s[:, :stride, :]
-                bot = s[:, stride:, :] + s[:, :-stride, :]
-                s = jnp.concatenate([top, bot], axis=1)
-
-        if HAS_SCALE:
-            s = s * scale
-
-        o_ref[:, dslice(start_t, BT), :] = s.astype(o_ref.dtype)
-        return 0
-
-    jax.lax.fori_loop(0, NT, body, 0)
+    o_ref[:, 0, dslice(0, BT), :] = s.astype(o_ref.dtype)
 
 
 def chunk_local_cumsum_vector(
@@ -226,41 +212,82 @@ def chunk_local_cumsum_vector(
 
     if chunk_indices is None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
-    NT = len(chunk_indices)
+    NC_max = len(chunk_indices)
 
     g_flat = jnp.pad(g_flat, ((0, 0), (0, BT), (0, 0)))
     T_alloc = T + BT
 
+    cu_i32 = cu_seqlens.astype(jnp.int32)
+    chunk_indices_i32 = chunk_indices.astype(jnp.int32)
+    N = cu_i32.shape[0] - 1
+    chunks_per_seq = (jnp.diff(cu_i32) + BT - 1) // BT
+
+    seq_id = chunk_indices_i32[:, 0]
+    local_ci = chunk_indices_i32[:, 1]
+    safe_seq_id = jnp.clip(seq_id, 0, N - 1)
+    chunk_valid = (
+        (seq_id == safe_seq_id)
+        & (local_ci >= 0)
+        & (local_ci < chunks_per_seq[safe_seq_id])
+    )
+
+    bos = cu_i32[safe_seq_id]
+    eos = cu_i32[safe_seq_id + 1]
+    chunk_starts = jnp.where(chunk_valid, bos + local_ci * BT, 0)
+    positions = chunk_starts[:, None] + jnp.arange(BT, dtype=jnp.int32)[None, :]
+    token_valid = chunk_valid[:, None] & (positions < eos[:, None]) & (positions < T)
+
+    def _gather_chunk(start):
+        return jax.lax.dynamic_slice(
+            g_flat,
+            (0, start, 0),
+            (BH_padded, BT, S_padded),
+        )
+
+    g_chunks = jax.vmap(_gather_chunk)(chunk_starts).transpose(1, 0, 2, 3)
+    g_chunks = jnp.where(token_valid[None, :, :, None], g_chunks, 0)
+
     elem_bytes = 4
-    while BB > 1 and 4 * BB * T_alloc * BS * elem_bytes > _VMEM_HW_LIMIT_BYTES:
+    while BB > 1 and 4 * BB * BT * BS * elem_bytes > _VMEM_HW_LIMIT_BYTES:
         BB //= 2
     NBH = BH_padded // BB
 
-    grid = (NS, NBH)
+    grid = (NS, NBH, NC_max)
     kernel = functools.partial(
         _chunk_cumsum_kernel,
         BT=BT,
-        NT=NT,
         REVERSE=reverse,
         HAS_SCALE=HAS_SCALE,
         scale=scale_val,
     )
 
-    def _index_map(i_s, i_bb, *_):
-        return (i_bb, 0, i_s)
+    def _index_map(i_s, i_bb, i_t):
+        return (i_bb, i_t, 0, i_s)
 
-    o_flat = pl.pallas_call(
+    block_shape = (BB, 1, BT, BS)
+
+    o_chunks = pl.pallas_call(
         kernel,
         grid_spec=pltpu.PrefetchScalarGridSpec(
-            num_scalar_prefetch=2,
+            num_scalar_prefetch=0,
             grid=grid,
-            in_specs=[pl.BlockSpec(block_shape=(BB, T_alloc, BS), index_map=_index_map)],
-            out_specs=pl.BlockSpec(block_shape=(BB, T_alloc, BS), index_map=_index_map),
+            in_specs=[pl.BlockSpec(block_shape=block_shape, index_map=_index_map)],
+            out_specs=pl.BlockSpec(block_shape=block_shape, index_map=_index_map),
         ),
-        out_shape=jax.ShapeDtypeStruct(g_flat.shape, out_dtype),
+        out_shape=jax.ShapeDtypeStruct(g_chunks.shape, out_dtype),
         interpret=interpret,
-        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "parallel")),
-    )(cu_seqlens, chunk_indices, g_flat)
+        compiler_params=pltpu.CompilerParams(
+            dimension_semantics=("parallel", "parallel", "parallel")
+        ),
+    )(g_chunks)
+
+    o_chunks = jnp.where(token_valid[None, :, :, None], o_chunks, 0)
+    sentinel = jnp.minimum(cu_i32[-1], T)
+    scatter_positions = jnp.where(token_valid, positions, sentinel).reshape(-1)
+    scatter_values = o_chunks.reshape(BH_padded, NC_max * BT, S_padded)
+
+    o_flat = jnp.zeros((BH_padded, T_alloc, S_padded), dtype=o_chunks.dtype)
+    o_flat = o_flat.at[:, scatter_positions, :].add(scatter_values)
 
     o_flat = o_flat[:BH, :T, :S]
 

--- a/python/sgl_jax/srt/kernels/kda/kda.py
+++ b/python/sgl_jax/srt/kernels/kda/kda.py
@@ -226,9 +226,7 @@ def chunk_local_cumsum_vector(
     local_ci = chunk_indices_i32[:, 1]
     safe_seq_id = jnp.clip(seq_id, 0, N - 1)
     chunk_valid = (
-        (seq_id == safe_seq_id)
-        & (local_ci >= 0)
-        & (local_ci < chunks_per_seq[safe_seq_id])
+        (seq_id == safe_seq_id) & (local_ci >= 0) & (local_ci < chunks_per_seq[safe_seq_id])
     )
 
     bos = cu_i32[safe_seq_id]

--- a/python/sgl_jax/test/kernels/kda_test.py
+++ b/python/sgl_jax/test/kernels/kda_test.py
@@ -15,6 +15,8 @@ Run the exact acceptance nodes on TPU with::
     uv run --with pytest python -m pytest -q \
       python/sgl_jax/test/kernels/kda_test.py::test_chunk_kda_32k_varlen_output_and_final_state_match_naive_recurrent_kda -vv
     uv run --with pytest python -m pytest -q \
+      python/sgl_jax/test/kernels/kda_test.py::test_chunk_kda_32k_no_zero_length_output_and_final_state_match_naive_recurrent_kda -vv
+    uv run --with pytest python -m pytest -q \
       python/sgl_jax/test/kernels/kda_test.py::test_chunk_local_cumsum_preserves_custom_chunk_order_and_masks_invalid_chunks -vv
 """
 
@@ -207,10 +209,11 @@ def test_kda_gate_chunk_cumsum_32k_tpu_regression():
     )
 
 
-def _make_full_32k_case():
-    seq_lens = [0, 1023, 1025] + [1024] * 30
+def _make_full_32k_case(*, include_zero_length: bool = True):
+    base_seq_lens = [0, 1023, 1025] + [1024] * 30
+    seq_lens = base_seq_lens if include_zero_length else base_seq_lens[1:]
     logical_t = sum(seq_lens)
-    assert len(seq_lens) == 33
+    assert len(seq_lens) == (33 if include_zero_length else 32)
     assert logical_t == 32_768
     cu_seqlens = jnp.asarray(
         np.concatenate([[0], np.cumsum(seq_lens, dtype=np.int32)]), dtype=jnp.int32
@@ -227,9 +230,12 @@ def _make_full_32k_case():
     )
     A_log = -1.5 + 0.1 * jax.random.normal(keys[5], (_H,), dtype=jnp.float32)
     dt_bias = 0.1 + 0.2 * jax.random.normal(keys[6], (_H, _K), dtype=jnp.float32)
-    initial_state = 0.01 * jax.random.normal(
-        keys[7], (len(seq_lens), _H, _K, _V), dtype=jnp.float32
+    base_initial_state = 0.01 * jax.random.normal(
+        keys[7], (len(base_seq_lens), _H, _K, _V), dtype=jnp.float32
     )
+    # Generate the 33-row base first so removing the zero-length request keeps
+    # every remaining request's initial state bit-for-bit identical.
+    initial_state = base_initial_state if include_zero_length else base_initial_state[1:]
 
     assert q.dtype == k.dtype == v.dtype == raw_g.dtype == jnp.bfloat16
     assert q.shape == k.shape == v.shape == raw_g.shape == shape
@@ -303,13 +309,12 @@ def _full_naive_reference(
         outputs.append(output_i)
         final_states.append(final_state_i[0])
 
-    assert call_count == len(seq_lens) == 33
-    assert set(callable_by_length) == {0, 1023, 1024, 1025}
+    assert call_count == len(seq_lens)
+    assert set(callable_by_length) == set(seq_lens)
     return jnp.concatenate(outputs, axis=1), jnp.stack(final_states, axis=0)
 
 
-def test_chunk_kda_32k_varlen_output_and_final_state_match_naive_recurrent_kda():
-    """Full path covers duplicate, BT-1, BT+1, and 30 aligned requests."""
+def _run_full_32k_case(*, include_zero_length: bool):
     (
         seq_lens,
         cu_seqlens,
@@ -321,7 +326,7 @@ def test_chunk_kda_32k_varlen_output_and_final_state_match_naive_recurrent_kda()
         A_log,
         dt_bias,
         initial_state,
-    ) = _make_full_32k_case()
+    ) = _make_full_32k_case(include_zero_length=include_zero_length)
 
     scale = _K**-0.5
     optimized_output, optimized_final_state, *_ = chunk_kda(
@@ -359,30 +364,68 @@ def test_chunk_kda_32k_varlen_output_and_final_state_match_naive_recurrent_kda()
     )
 
     # _align_seqs allocates its static worst-case packed shape rather than only
-    # padded_cu_seqlens[-1]: logical/aligned/Stage-1 allocated = 32768/34880/34944.
+    # padded_cu_seqlens[-1]. Keep logical, aligned, and Stage-1 allocated T
+    # separate because the zero-length request changes only the latter two.
     aligned_t = align_up(len(seq_lens) * (_BT - 1) + q.shape[1], _BT)
+    expected_aligned_t = 34_880 if include_zero_length else 34_816
+    expected_allocated_t = expected_aligned_t + _BT
     assert q.shape[1] == 32_768
-    assert aligned_t == 34_880
-    assert aligned_t + _BT == 34_944
+    assert aligned_t == expected_aligned_t
+    assert aligned_t + _BT == expected_allocated_t
     assert optimized_output.shape == reference_output.shape == (1, 32_768, _H, _V)
     assert (
         optimized_final_state.shape
         == reference_final_state.shape
         == (
-            33,
+            len(seq_lens),
             _H,
             _K,
             _V,
         )
     )
     assert np.isfinite(np.asarray(optimized_output)).all()
+    assert np.isfinite(np.asarray(reference_output)).all()
     assert np.isfinite(np.asarray(optimized_final_state)).all()
+    assert np.isfinite(np.asarray(reference_final_state)).all()
     np.testing.assert_allclose(
         np.asarray(optimized_output),
         np.asarray(reference_output),
         rtol=2e-2,
         atol=1e-2,
     )
+    return seq_lens, optimized_final_state, reference_final_state
+
+
+def test_chunk_kda_32k_varlen_output_and_final_state_match_naive_recurrent_kda():
+    """Zero-length full path: logical/aligned/allocated T = 32768/34880/34944."""
+    seq_lens, optimized_final_state, reference_final_state = _run_full_32k_case(
+        include_zero_length=True
+    )
+
+    nonempty_mask = np.asarray(seq_lens, dtype=np.int32) > 0
+    assert nonempty_mask.shape == (33,)
+    assert np.count_nonzero(nonempty_mask) == 32
+    # Zero-length optimized final-state semantics are tracked by #326:
+    # https://github.com/primatrix/projects/issues/326
+    # All logical output remains checked above; only the explicitly nonempty
+    # requests participate in this final-state acceptance boundary.
+    np.testing.assert_allclose(
+        np.asarray(optimized_final_state)[nonempty_mask],
+        np.asarray(reference_final_state)[nonempty_mask],
+        rtol=2e-2,
+        atol=1e-2,
+    )
+
+
+def test_chunk_kda_32k_no_zero_length_output_and_final_state_match_naive_recurrent_kda():
+    """No-zero full path: logical/aligned/allocated T = 32768/34816/34880."""
+    seq_lens, optimized_final_state, reference_final_state = _run_full_32k_case(
+        include_zero_length=False
+    )
+
+    nonempty_mask = np.asarray(seq_lens, dtype=np.int32) > 0
+    assert nonempty_mask.shape == (32,)
+    assert nonempty_mask.all()
     np.testing.assert_allclose(
         np.asarray(optimized_final_state),
         np.asarray(reference_final_state),
@@ -395,7 +438,11 @@ def test_chunk_local_cumsum_preserves_custom_chunk_order_and_masks_invalid_chunk
     """Characterize caller mapping, both scan directions, dtype/layout, and masks."""
     chunk_size = 4
     total_t = 12
+    # The duplicate boundary at 3 is a zero-length request. Keep this fixed-seed
+    # fixture as the direct caller-mapping/mask characterization for #325.
     cu_seqlens = jnp.asarray([0, 3, 3, 8], dtype=jnp.int32)
+    # [2, 1] is partial, the middle rows are deliberately reordered, and
+    # [2, 2] is invalid; production must consume these caller-provided rows.
     chunk_indices = jnp.asarray([[2, 1], [0, 0], [2, 0], [2, 2]], dtype=jnp.int32)
     key = jax.random.PRNGKey(325)
     g = 0.25 + 0.2 * jax.random.normal(key, (1, total_t, _H, 7), dtype=jnp.float32)
@@ -451,6 +498,10 @@ def test_chunk_local_cumsum_preserves_custom_chunk_order_and_masks_invalid_chunk
 
         padding_slice = [slice(None)] * optimized.ndim
         padding_slice[time_axis] = slice(8, total_t)
+        np.testing.assert_array_equal(
+            np.asarray(reference[tuple(padding_slice)]),
+            np.zeros_like(np.asarray(reference[tuple(padding_slice)])),
+        )
         np.testing.assert_array_equal(
             np.asarray(optimized[tuple(padding_slice)]),
             np.zeros_like(np.asarray(optimized[tuple(padding_slice)])),

--- a/python/sgl_jax/test/kernels/kda_test.py
+++ b/python/sgl_jax/test/kernels/kda_test.py
@@ -438,11 +438,17 @@ def test_chunk_local_cumsum_preserves_custom_chunk_order_and_masks_invalid_chunk
         assert optimized.shape == reference.shape == case_g.shape
         assert optimized.dtype == reference.dtype == output_dtype
         assert np.isfinite(np.asarray(optimized)).all()
-        np.testing.assert_allclose(
-            np.asarray(optimized), np.asarray(reference), rtol=rtol, atol=atol
-        )
 
         time_axis = 2 if head_first else 1
+        logical_slice = [slice(None)] * optimized.ndim
+        logical_slice[time_axis] = slice(0, 8)
+        np.testing.assert_allclose(
+            np.asarray(optimized[tuple(logical_slice)]),
+            np.asarray(reference[tuple(logical_slice)]),
+            rtol=rtol,
+            atol=atol,
+        )
+
         padding_slice = [slice(None)] * optimized.ndim
         padding_slice[time_axis] = slice(8, total_t)
         np.testing.assert_array_equal(

--- a/python/sgl_jax/test/kernels/kda_test.py
+++ b/python/sgl_jax/test/kernels/kda_test.py
@@ -141,16 +141,18 @@ def _make_direct_case(length: int):
 
 def _run_direct_case(length: int):
     raw_g, A_log, dt_bias, cu_seqlens, chunk_indices, aligned_t = _make_direct_case(length)
-    optimized = kda_gate_chunk_cumsum(
-        raw_g,
-        A_log,
-        chunk_size=_BT,
-        scale=_GATE_SCALE,
-        dt_bias=dt_bias,
-        cu_seqlens=cu_seqlens,
-        output_dtype=jnp.float32,
-        chunk_indices=chunk_indices,
-    )
+    optimized = jax.jit(
+        lambda dynamic_raw_g: kda_gate_chunk_cumsum(
+            dynamic_raw_g,
+            A_log,
+            chunk_size=_BT,
+            scale=_GATE_SCALE,
+            dt_bias=dt_bias,
+            cu_seqlens=cu_seqlens,
+            output_dtype=jnp.float32,
+            chunk_indices=chunk_indices,
+        )
+    )(raw_g)
     # The 32K RED must surface at the optimized Stage 1 compile before the
     # independent eager reference performs one update per logical chunk.
     jax.block_until_ready(optimized)

--- a/python/sgl_jax/test/kernels/kda_test.py
+++ b/python/sgl_jax/test/kernels/kda_test.py
@@ -1,0 +1,490 @@
+"""TPU regressions for KDA Stage 1 chunk-local gate cumsum.
+
+The 16K node is the compile/control case: it checks shape, finiteness, and all
+logical tokens.  The 32K direct node additionally owns the direct-path
+padding, invalid-chunk, and sentinel-zero contract because its baseline RED is
+expected to occur first at Stage 1 Pallas VMEM allocation.  The custom-mapping
+node independently characterizes those masking semantics at a small shape.
+
+Run the exact acceptance nodes on TPU with::
+
+    uv run --with pytest python -m pytest -q \
+      python/sgl_jax/test/kernels/kda_test.py::test_kda_gate_chunk_cumsum_16k_tpu_control -vv
+    uv run --with pytest python -m pytest -q \
+      python/sgl_jax/test/kernels/kda_test.py::test_kda_gate_chunk_cumsum_32k_tpu_regression -vv
+    uv run --with pytest python -m pytest -q \
+      python/sgl_jax/test/kernels/kda_test.py::test_chunk_kda_32k_varlen_output_and_final_state_match_naive_recurrent_kda -vv
+    uv run --with pytest python -m pytest -q \
+      python/sgl_jax/test/kernels/kda_test.py::test_chunk_local_cumsum_preserves_custom_chunk_order_and_masks_invalid_chunks -vv
+"""
+
+from __future__ import annotations
+
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.kernels.kda import chunk_kda, naive_recurrent_kda
+from sgl_jax.srt.kernels.kda.kda import (
+    align_up,
+    chunk_local_cumsum_vector,
+    kda_gate_chunk_cumsum,
+    prepare_chunk_indices,
+)
+
+_BT = 64
+_H = 2
+_K = 128
+_V = 128
+_GATE_SCALE = 1.0 / math.log(2)
+
+
+def reference_kda_gate_chunk_cumsum(
+    raw_g,
+    A_log,
+    dt_bias,
+    cu_seqlens,
+    chunk_size=64,
+    scale=1.0 / math.log(2),
+):
+    """Independent JAX reference; deliberately does not call production cumsum."""
+    activated = -jnp.exp(A_log.astype(jnp.float32))[None, None, :, None] * (
+        jax.nn.softplus(raw_g.astype(jnp.float32) + dt_bias.astype(jnp.float32)[None, None, :, :])
+    )
+    out = jnp.zeros_like(activated, dtype=jnp.float32)
+    boundaries = np.asarray(cu_seqlens)
+    for request in range(len(boundaries) - 1):
+        begin, end = int(boundaries[request]), int(boundaries[request + 1])
+        for start in range(begin, end, chunk_size):
+            stop = min(start + chunk_size, end)
+            out = out.at[:, start:stop].set(jnp.cumsum(activated[:, start:stop], axis=1) * scale)
+    return out
+
+
+def _reference_chunk_local_cumsum(
+    g: jax.Array,
+    *,
+    chunk_size: int,
+    reverse: bool,
+    scale: float | None,
+    cu_seqlens: jax.Array,
+    head_first: bool,
+    output_dtype,
+    chunk_indices: jax.Array,
+) -> jax.Array:
+    """Independent mapping-aware reference for the characterization node."""
+    if head_first:
+        batch, heads, total_t, width = g.shape
+        flat = g.reshape(batch * heads, total_t, width).astype(jnp.float32)
+    else:
+        batch, total_t, heads, width = g.shape
+        flat = (
+            jnp.transpose(g, (0, 2, 1, 3))
+            .reshape(batch * heads, total_t, width)
+            .astype(jnp.float32)
+        )
+
+    out = jnp.zeros_like(flat, dtype=jnp.float32)
+    boundaries = np.asarray(cu_seqlens)
+    mapping = np.asarray(chunk_indices)
+    for seq_id_raw, local_chunk_raw in mapping:
+        seq_id = int(seq_id_raw)
+        local_chunk = int(local_chunk_raw)
+        if seq_id < 0 or seq_id >= len(boundaries) - 1 or local_chunk < 0:
+            continue
+        begin, end = int(boundaries[seq_id]), int(boundaries[seq_id + 1])
+        start = begin + local_chunk * chunk_size
+        if start >= end or start >= total_t:
+            continue
+        stop = min(start + chunk_size, end, total_t)
+        values = flat[:, start:stop]
+        if reverse:
+            values = jnp.flip(jnp.cumsum(jnp.flip(values, axis=1), axis=1), axis=1)
+        else:
+            values = jnp.cumsum(values, axis=1)
+        if scale is not None:
+            values = values * scale
+        out = out.at[:, start:stop].set(values)
+
+    out_dtype = output_dtype or g.dtype
+    out = out.astype(out_dtype)
+    if head_first:
+        return out.reshape(batch, heads, total_t, width)
+    return jnp.transpose(out.reshape(batch, heads, total_t, width), (0, 2, 1, 3))
+
+
+def _make_direct_case(length: int):
+    aligned_t = align_up(length + _BT - 1, _BT)
+    raw_key, a_key, bias_key = jax.random.split(jax.random.PRNGKey(325), 3)
+    raw_g = 0.25 + 0.2 * jax.random.normal(raw_key, (1, aligned_t, _H, _K), dtype=jnp.float32)
+    A_log = -1.5 + 0.1 * jax.random.normal(a_key, (_H,), dtype=jnp.float32)
+    dt_bias = 0.1 + 0.2 * jax.random.normal(bias_key, (_H, _K), dtype=jnp.float32)
+    cu_seqlens = jnp.asarray([0, length], dtype=jnp.int32)
+    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=_BT, max_T=aligned_t)
+
+    assert raw_g.shape == (1, aligned_t, _H, _K)
+    assert raw_g.dtype == jnp.float32
+    assert np.count_nonzero(np.asarray(A_log)) > 0
+    assert np.ptp(np.asarray(A_log)) > 0
+    assert np.count_nonzero(np.asarray(dt_bias)) > 0
+    assert np.ptp(np.asarray(dt_bias)) > 0
+    np.testing.assert_array_equal(
+        np.asarray(chunk_indices[-1]), np.asarray([0, length // _BT], dtype=np.int32)
+    )
+    # The invalid row gathers deliberately non-zero data unless production masks it.
+    assert np.count_nonzero(np.asarray(raw_g[:, length:aligned_t])) > 0
+    assert np.ptp(np.asarray(raw_g[:, length:aligned_t])) > 0
+    return raw_g, A_log, dt_bias, cu_seqlens, chunk_indices, aligned_t
+
+
+def _run_direct_case(length: int):
+    raw_g, A_log, dt_bias, cu_seqlens, chunk_indices, aligned_t = _make_direct_case(length)
+    optimized = kda_gate_chunk_cumsum(
+        raw_g,
+        A_log,
+        chunk_size=_BT,
+        scale=_GATE_SCALE,
+        dt_bias=dt_bias,
+        cu_seqlens=cu_seqlens,
+        output_dtype=jnp.float32,
+        chunk_indices=chunk_indices,
+    )
+    # The 32K RED must surface at the optimized Stage 1 compile before the
+    # independent eager reference performs one update per logical chunk.
+    jax.block_until_ready(optimized)
+    reference = reference_kda_gate_chunk_cumsum(
+        raw_g, A_log, dt_bias, cu_seqlens, chunk_size=_BT, scale=_GATE_SCALE
+    )
+    assert optimized.shape == reference.shape == (1, aligned_t, _H, _K)
+    assert np.isfinite(np.asarray(optimized)).all()
+    assert np.isfinite(np.asarray(reference)).all()
+    np.testing.assert_allclose(
+        np.asarray(optimized[:, :length]),
+        np.asarray(reference[:, :length]),
+        rtol=1e-5,
+        atol=1e-5,
+    )
+    return optimized, reference, aligned_t
+
+
+def test_kda_gate_chunk_cumsum_16k_tpu_control():
+    """16K control: logical/aligned/Stage-1 allocated T = 16384/16448/16512."""
+    length = 16_384
+    optimized, reference, aligned_t = _run_direct_case(length)
+    assert aligned_t == 16_448
+    assert aligned_t + _BT == 16_512
+    # Materialize both results before the test returns so asynchronous TPU errors surface here.
+    jax.block_until_ready((optimized, reference))
+
+
+def test_kda_gate_chunk_cumsum_32k_tpu_regression():
+    """32K blocker: logical/aligned/Stage-1 allocated T = 32768/32832/32896."""
+    length = 32_768
+    optimized, reference, aligned_t = _run_direct_case(length)
+    assert aligned_t == 32_832
+    assert aligned_t + _BT == 32_896
+
+    np.testing.assert_array_equal(
+        np.asarray(reference[:, length:aligned_t]),
+        np.zeros((1, aligned_t - length, _H, _K), dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        np.asarray(optimized[:, length:aligned_t]),
+        np.zeros((1, aligned_t - length, _H, _K), dtype=np.float32),
+    )
+    # The sole extra mapping row is invalid.  Its gather and all partial lanes
+    # map to sentinel=cu_seqlens[-1]=length and must contribute exactly zero.
+    np.testing.assert_array_equal(
+        np.asarray(optimized[:, length : length + _BT]),
+        np.zeros((1, _BT, _H, _K), dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        np.asarray(optimized[:, length]), np.zeros((1, _H, _K), dtype=np.float32)
+    )
+
+
+def _make_full_32k_case():
+    seq_lens = [0, 1023, 1025] + [1024] * 30
+    logical_t = sum(seq_lens)
+    assert len(seq_lens) == 33
+    assert logical_t == 32_768
+    cu_seqlens = jnp.asarray(
+        np.concatenate([[0], np.cumsum(seq_lens, dtype=np.int32)]), dtype=jnp.int32
+    )
+
+    keys = jax.random.split(jax.random.PRNGKey(325), 8)
+    shape = (1, logical_t, _H, _K)
+    q = (0.1 * jax.random.normal(keys[0], shape, dtype=jnp.float32)).astype(jnp.bfloat16)
+    k = (0.1 * jax.random.normal(keys[1], shape, dtype=jnp.float32)).astype(jnp.bfloat16)
+    v = (0.1 * jax.random.normal(keys[2], shape, dtype=jnp.float32)).astype(jnp.bfloat16)
+    raw_g = (0.25 + 0.2 * jax.random.normal(keys[3], shape, dtype=jnp.float32)).astype(jnp.bfloat16)
+    beta = jax.nn.sigmoid(jax.random.normal(keys[4], (1, logical_t, _H), dtype=jnp.float32)).astype(
+        jnp.bfloat16
+    )
+    A_log = -1.5 + 0.1 * jax.random.normal(keys[5], (_H,), dtype=jnp.float32)
+    dt_bias = 0.1 + 0.2 * jax.random.normal(keys[6], (_H, _K), dtype=jnp.float32)
+    initial_state = 0.01 * jax.random.normal(
+        keys[7], (len(seq_lens), _H, _K, _V), dtype=jnp.float32
+    )
+
+    assert q.dtype == k.dtype == v.dtype == raw_g.dtype == jnp.bfloat16
+    assert q.shape == k.shape == v.shape == raw_g.shape == shape
+    assert np.count_nonzero(np.asarray(raw_g)) > 0
+    assert np.ptp(np.asarray(raw_g, dtype=np.float32)) > 0
+    assert initial_state.dtype == jnp.float32
+    assert np.count_nonzero(np.asarray(initial_state)) > 0
+    assert np.ptp(np.asarray(initial_state)) > 0
+    return (
+        seq_lens,
+        cu_seqlens,
+        q,
+        k,
+        v,
+        raw_g,
+        beta,
+        A_log,
+        dt_bias,
+        initial_state,
+    )
+
+
+def _full_naive_reference(
+    seq_lens,
+    cu_seqlens,
+    q,
+    k,
+    v,
+    activated_g,
+    beta,
+    initial_state,
+    scale,
+):
+    """Call ``naive_recurrent_kda`` exactly once for each logical request."""
+    callable_by_length = {}
+    outputs = []
+    final_states = []
+    call_count = 0
+    boundaries = np.asarray(cu_seqlens)
+
+    def build_callable():
+        def run(q_i, k_i, v_i, g_i, beta_i, state_i):
+            return naive_recurrent_kda(
+                q_i,
+                k_i,
+                v_i,
+                g_i,
+                beta_i,
+                scale=scale,
+                initial_state=state_i,
+                output_final_state=True,
+            )
+
+        return jax.jit(run)
+
+    for request, expected_length in enumerate(seq_lens):
+        begin, end = int(boundaries[request]), int(boundaries[request + 1])
+        assert end - begin == expected_length
+        if expected_length not in callable_by_length:
+            callable_by_length[expected_length] = build_callable()
+        run = callable_by_length[expected_length]
+        output_i, final_state_i = run(
+            q[:, begin:end],
+            k[:, begin:end],
+            v[:, begin:end],
+            activated_g[:, begin:end],
+            beta[:, begin:end],
+            initial_state[request : request + 1],
+        )
+        call_count += 1
+        outputs.append(output_i)
+        final_states.append(final_state_i[0])
+
+    assert call_count == len(seq_lens) == 33
+    assert set(callable_by_length) == {0, 1023, 1024, 1025}
+    return jnp.concatenate(outputs, axis=1), jnp.stack(final_states, axis=0)
+
+
+def test_chunk_kda_32k_varlen_output_and_final_state_match_naive_recurrent_kda():
+    """Full path covers duplicate, BT-1, BT+1, and 30 aligned requests."""
+    (
+        seq_lens,
+        cu_seqlens,
+        q,
+        k,
+        v,
+        raw_g,
+        beta,
+        A_log,
+        dt_bias,
+        initial_state,
+    ) = _make_full_32k_case()
+
+    scale = _K**-0.5
+    optimized_output, optimized_final_state, *_ = chunk_kda(
+        q,
+        k,
+        v,
+        raw_g,
+        beta,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        chunk_size=_BT,
+        use_gate_in_kernel=True,
+        A_log=A_log,
+        dt_bias=dt_bias,
+    )
+    # Materialize the optimized pipeline first so a baseline failure is
+    # unambiguously Stage 1 VMEM, not naive-reference compile or host memory.
+    jax.block_until_ready((optimized_output, optimized_final_state))
+
+    activated_g = -jnp.exp(A_log.astype(jnp.float32))[None, None, :, None] * (
+        jax.nn.softplus(raw_g.astype(jnp.float32) + dt_bias.astype(jnp.float32)[None, None, :, :])
+    )
+    reference_output, reference_final_state = _full_naive_reference(
+        seq_lens,
+        cu_seqlens,
+        q,
+        k,
+        v,
+        activated_g,
+        beta,
+        initial_state,
+        scale,
+    )
+
+    # _align_seqs allocates its static worst-case packed shape rather than only
+    # padded_cu_seqlens[-1]: logical/aligned/Stage-1 allocated = 32768/34880/34944.
+    aligned_t = align_up(len(seq_lens) * (_BT - 1) + q.shape[1], _BT)
+    assert q.shape[1] == 32_768
+    assert aligned_t == 34_880
+    assert aligned_t + _BT == 34_944
+    assert optimized_output.shape == reference_output.shape == (1, 32_768, _H, _V)
+    assert (
+        optimized_final_state.shape
+        == reference_final_state.shape
+        == (
+            33,
+            _H,
+            _K,
+            _V,
+        )
+    )
+    assert np.isfinite(np.asarray(optimized_output)).all()
+    assert np.isfinite(np.asarray(optimized_final_state)).all()
+    np.testing.assert_allclose(
+        np.asarray(optimized_output),
+        np.asarray(reference_output),
+        rtol=2e-2,
+        atol=1e-2,
+    )
+    np.testing.assert_allclose(
+        np.asarray(optimized_final_state),
+        np.asarray(reference_final_state),
+        rtol=2e-2,
+        atol=1e-2,
+    )
+
+
+def test_chunk_local_cumsum_preserves_custom_chunk_order_and_masks_invalid_chunks():
+    """Characterize caller mapping, both scan directions, dtype/layout, and masks."""
+    chunk_size = 4
+    total_t = 12
+    cu_seqlens = jnp.asarray([0, 3, 3, 8], dtype=jnp.int32)
+    chunk_indices = jnp.asarray([[2, 1], [0, 0], [2, 0], [2, 2]], dtype=jnp.int32)
+    key = jax.random.PRNGKey(325)
+    g = 0.25 + 0.2 * jax.random.normal(key, (1, total_t, _H, 7), dtype=jnp.float32)
+    assert np.count_nonzero(np.asarray(g[:, 8:])) > 0
+    assert np.ptp(np.asarray(g[:, 8:])) > 0
+
+    cases = (
+        (False, False, jnp.float32, 0.75, g, 2e-5, 2e-5),
+        (
+            True,
+            True,
+            jnp.bfloat16,
+            1.25,
+            jnp.transpose(g, (0, 2, 1, 3)),
+            2e-2,
+            2e-2,
+        ),
+    )
+    for reverse, head_first, output_dtype, scale, case_g, rtol, atol in cases:
+        optimized = chunk_local_cumsum_vector(
+            case_g,
+            chunk_size=chunk_size,
+            reverse=reverse,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            head_first=head_first,
+            output_dtype=output_dtype,
+            chunk_indices=chunk_indices,
+        )
+        reference = _reference_chunk_local_cumsum(
+            case_g,
+            chunk_size=chunk_size,
+            reverse=reverse,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            head_first=head_first,
+            output_dtype=output_dtype,
+            chunk_indices=chunk_indices,
+        )
+        assert optimized.shape == reference.shape == case_g.shape
+        assert optimized.dtype == reference.dtype == output_dtype
+        assert np.isfinite(np.asarray(optimized)).all()
+        np.testing.assert_allclose(
+            np.asarray(optimized), np.asarray(reference), rtol=rtol, atol=atol
+        )
+
+        time_axis = 2 if head_first else 1
+        padding_slice = [slice(None)] * optimized.ndim
+        padding_slice[time_axis] = slice(8, total_t)
+        np.testing.assert_array_equal(
+            np.asarray(optimized[tuple(padding_slice)]),
+            np.zeros_like(np.asarray(optimized[tuple(padding_slice)])),
+        )
+        sentinel_slice = [slice(None)] * optimized.ndim
+        sentinel_slice[time_axis] = 8
+        np.testing.assert_array_equal(
+            np.asarray(optimized[tuple(sentinel_slice)]),
+            np.zeros_like(np.asarray(optimized[tuple(sentinel_slice)])),
+        )
+
+    # Mapping-sensitive omission probe: keep the approved mapping above as the
+    # primary characterization, then omit [2, 0] here.  A kernel that silently
+    # rebuilds canonical rows would populate positions 3:7 and fail this check.
+    omission_mapping = jnp.asarray([[2, 1], [0, 0], [2, 2], [2, 3]], dtype=jnp.int32)
+    omission_optimized = chunk_local_cumsum_vector(
+        g,
+        chunk_size=chunk_size,
+        reverse=False,
+        scale=0.75,
+        cu_seqlens=cu_seqlens,
+        head_first=False,
+        output_dtype=jnp.float32,
+        chunk_indices=omission_mapping,
+    )
+    omission_reference = _reference_chunk_local_cumsum(
+        g,
+        chunk_size=chunk_size,
+        reverse=False,
+        scale=0.75,
+        cu_seqlens=cu_seqlens,
+        head_first=False,
+        output_dtype=jnp.float32,
+        chunk_indices=omission_mapping,
+    )
+    np.testing.assert_allclose(
+        np.asarray(omission_optimized),
+        np.asarray(omission_reference),
+        rtol=2e-5,
+        atol=2e-5,
+    )
+    np.testing.assert_array_equal(
+        np.asarray(omission_optimized[:, 3:7]),
+        np.zeros((1, 4, _H, 7), dtype=np.float32),
+    )

--- a/python/sgl_jax/test/kernels/kda_test.py
+++ b/python/sgl_jax/test/kernels/kda_test.py
@@ -385,8 +385,9 @@ def _run_full_32k_case(*, include_zero_length: bool):
     )
     assert np.isfinite(np.asarray(optimized_output)).all()
     assert np.isfinite(np.asarray(reference_output)).all()
-    assert np.isfinite(np.asarray(optimized_final_state)).all()
-    assert np.isfinite(np.asarray(reference_final_state)).all()
+    nonempty_mask = np.asarray(seq_lens, dtype=np.int32) > 0
+    assert np.isfinite(np.asarray(optimized_final_state)[nonempty_mask]).all()
+    assert np.isfinite(np.asarray(reference_final_state)[nonempty_mask]).all()
     np.testing.assert_allclose(
         np.asarray(optimized_output),
         np.asarray(reference_output),

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -254,6 +254,7 @@ suites = {
     "unit-test-tpu-v6e-1": [
         TestFile("python/sgl_jax/test/kernels/quantized_linear_test.py", 0.3, runner="pytest"),
         TestFile("python/sgl_jax/test/kernels/moe_block_quant_test.py", 0.2, runner="pytest"),
+        TestFile("python/sgl_jax/test/kernels/kda_test.py", 10, runner="pytest"),
         TestFile("python/sgl_jax/test/test_flashattention_mha.py", 11),
         TestFile("python/sgl_jax/test/test_flashattention_gqa.py", 11),
         TestFile("python/sgl_jax/test/test_flashattention_misc.py", 7),


### PR DESCRIPTION
## Motivation

### Problem

KDA Stage 1 gate cumsum used a full-`T` Pallas `BlockSpec`. At the 32K direct shape, that creates a 64.25 MiB scoped-VMEM allocation, exceeding the 32 MiB TPU VMEM limit and failing compilation before the reference path can run.

This PR unblocks `primatrix/projects#324`.

## Modifications

### Solution

- Gather caller-selected chunks into a chunk-major HBM tensor with static capacity `O(NC_max * BT)`, where `NC_max = len(chunk_indices)`.
- Run one Pallas program per chunk with a fixed `BT=64` temporal window.
- Mask invalid and partial-token lanes before and after the scan, then scatter valid results back into the packed layout through a zero sentinel.
- Keep per-program VMEM independent of complete logical/aligned `T`.

### Semantics

The implementation preserves:

- caller-provided `chunk_indices` ordering and omission semantics;
- varlen and zero-length request boundaries;
- invalid-chunk, partial-tail, padding, and sentinel-zero behavior;
- forward/reverse scans;
- optional scale;
- head-first/non-head-first layouts and output dtype.

## Accuracy Tests

All functional acceptance and profiling commands used functional HEAD `52463e38df8e84ad5b52004bc21c354d8ddab4d5`. Current HEAD `9d792f4b5ca0fcd85c3be491f81a64ba349f5ab3` adds only the Black 24.10.0 line folding required by CI in `kda.py`; no logic or tests changed. The exact `git diff -w 52463e3..HEAD` hunk contains only that line regrouping, `git diff -w --word-diff=porcelain` has no token additions/deletions, and old/new Python ASTs are identical.

Five exact nodes passed on all four TPU ranks:

- custom caller mapping/mask: 4/4 PASS;
- direct 16K control: 4/4 PASS;
- direct 32K regression: 4/4 PASS, with no scoped-VMEM OOM;
- zero-length full 32K: 4/4 PASS for all logical output and all 32 nonempty final states;
- no-zero full 32K: 4/4 PASS for all output and final states.

Adjacent regressions on the functional-HEAD source overlay:

- KDA single: 11/11 PASS;
- KDA DP/sharded: 9/9 PASS;
- GDN single: 11/11 PASS;
- GDN DP/sharded: 10/10 PASS;
- Qwen3.5 CPU: 18/18 PASS.

The raw KDA Stage 3 zero-length final-state contract is a pre-existing bug reproduced both before and after this Stage 1 change. It is tracked separately by [primatrix/projects#326](https://github.com/primatrix/projects/issues/326). This PR does not fix or close #326. The #324 GDN adapter already uses a `nonempty` mask to preserve the original state for zero-length requests, so #326 does not block #324.

## Benchmarking and Profiling

Four-rank compiler/profile captures were refreshed on functional HEAD `52463e38df8e84ad5b52004bc21c354d8ddab4d5` for both 16K and 32K:

| Field | 16K | 32K |
|---|---:|---:|
| `NC_max` | 257 | 513 |
| Pallas grid | `[1,1,257]` | `[1,1,513]` |
| VMEM memref/window | `[8,1,64,128]` | `[8,1,64,128]` |
| Per-program input | 262,144 bytes | 262,144 bytes |
| Source VMEM guard | 1,048,576 bytes | 1,048,576 bytes |

The finalized LLO changes only the number of fixed-size programs (`iteration_bounds` 257 to 513); its temporal VMEM window remains fixed. Launcher-level chunk-major HBM capacity grows as `O(NC_max * BT)`, not `O(num_sequences * total_T)`.

Evidence:

- Pod-local: `/tmp/beaver-325/final-green-52463e3/`
- Team archive: `/data/user/dongbohao/beaver-325/evidence/52463e3/`
- Manifest: `/data/user/dongbohao/beaver-325/evidence/52463e3/evidence-manifest.md`
- Report: `/data/user/dongbohao/beaver-325/evidence/52463e3/final-green-report.md`

## Checklist

- [x] PR description is in English.
- [x] Purpose and linked project issues are included.
- [x] Test, accuracy, regression, and profiling evidence is included.
- [x] TPU CI registration includes `python/sgl_jax/test/kernels/kda_test.py`.
- [x] No Stage 2-4, GDN adapter, or #324 experiment files are changed.

Closes primatrix/projects#325

Unblocks primatrix/projects#324

## Post-merge Stage 1 runtime benchmark (2026-07-20)

This benchmark isolates `kda_gate_chunk_cumsum` (Stage 1); it is not a full-model or #324 GDN end-to-end benchmark.

- Baseline: `main@03931b0fbc2816da7fee823abaab7176fff5f173`
- Optimized: merged commit `13fc48de4e00635262765b296a7a53c76616b88d`
- Source identity: baseline `kda.py` SHA256 `340ba3d8...`; merged/PR-head `kda.py` SHA256 `52eb27d5...`
- Hardware: TPU v6e-16, four hosts × four chips (2×2 per host)
- Shape: `B=1, H=2, K=128, BT=64, fp32`; seed 325
- Method: per-rank wall time with `block_until_ready`, 3 warmups + 30 measured samples, two independent rounds per successful configuration, empty compilation cache per case/rank, and strict pre/post process + coordinator-port barriers
- Aggregation: 240 measured samples per successful configuration (4 ranks × 2 rounds × 30)

| Logical T | Baseline pooled median | Merged pooled median | Median of merged rank medians | Result |
|---|---:|---:|---:|---|
| 16K | 0.371555 ms | 1.791589 ms | 1.789322 ms | +382.187% latency; 0.207× baseline throughput |
| 32K | compile-time VMEM OOM on 4/4 ranks | 4.975394 ms | 4.970399 ms | 4/4 ranks complete; no VMEM OOM |

Per-rank pooled medians (two rounds / 60 samples per rank):

- Baseline 16K: `[0.379900, 0.376594, 0.354365, 0.370565] ms`
- Merged 16K: `[1.797105, 1.784739, 1.792919, 1.785725] ms`
- Merged 32K: `[4.980875, 4.973967, 4.966832, 4.965875] ms`

Capacity and correctness gates:

- Baseline 32K reproduced the exact failure on all ranks: `f32[8,32896,128]`, scoped allocation 64.25 MiB, limit 32 MiB.
- Merged 32K completed 240/240 measured samples with no VMEM OOM.
- All 720 successful measured samples were finite; logical outputs matched the independent reference; optimized padding remained zero.
- The 28 rank JSON files used independent per-case/per-rank compilation caches.

Interpretation: the change achieves its bounded-residency/capacity objective and makes the 32K shape runnable, but it does **not** improve isolated Stage 1 latency. At 16K, the chunk-major multi-program execution is about 4.82× slower than the old full-`T` program. This tradeoff is recorded explicitly for follow-up tuning; no end-to-end performance claim is made from this kernel-only benchmark.

Evidence:

- Team path: `/data/user/dongbohao/beaver-325/performance/pr1465-kda-ab-20260720T151507Z/`
- Cross-rank summary SHA256: `37103b97883b32378f03a900182070ba0b4a9d1b41c8c26fa6ee1b915afdc833`
- Cross-rank manifest SHA256 / `.complete`: `e46b75b8bc0ef27c05da77f6129307a9734c0074111e1c34b53c2d7e532834b3`
- Rank manifest SHA256: `2ae7bbb7...`, `ad8ce0da...`, `e57709de...`, `bc829347...`
- Runner SHA256: `e3c208aa...`; rank aggregator SHA256: `02646da0...`; cross-rank validator SHA256: `804c044a...`

The earlier incomplete orchestration attempt under `/tmp/beaver-325/pr1465-kda-runtime-20260720T143755Z/` was excluded from these statistics and is not a formal evidence source.