### PR TITLE
perf(mem_cache): cache jitted KV zero-allocator to avoid per-layer retrace

### DIFF
--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -24,6 +24,34 @@ from sgl_jax.srt.kernels.update_kv_cache.update_kv_cache import (
     kv_cache_update_impl,
 )
 
+# Module-level cache for jitted zero-allocators.
+# Keyed by (mesh_id, shape, dtype, sharding_spec, memory_kind).
+# Caches the FUNCTION (not the tensor) — each call returns fresh zeros.
+_KV_ZERO_ALLOCATOR_CACHE: dict = {}
+
+
+def _get_kv_zero_allocator(shape, dtype, sharding):
+    """Return a cached jax.jit(jnp.zeros) allocator for the given spec.
+
+    Avoids repeated JAX trace/compile overhead when _create_buffers()
+    allocates N identical layers. The allocator function is cached;
+    each call to the returned function still produces a fresh
+    zero-initialised tensor.
+    """
+    key = (
+        id(sharding.mesh),
+        tuple(shape),
+        str(jnp.dtype(dtype)),
+        repr(sharding.spec),
+        getattr(sharding, "memory_kind", None),
+    )
+    if key not in _KV_ZERO_ALLOCATOR_CACHE:
+        _KV_ZERO_ALLOCATOR_CACHE[key] = jax.jit(
+            partial(jnp.zeros, shape=tuple(shape), dtype=dtype),
+            out_shardings=sharding,
+        )
+    return _KV_ZERO_ALLOCATOR_CACHE[key]
+
 
 def merge_kv(k: jax.Array, v: jax.Array) -> jax.Array:
     """Merge 3D k/v into 5D fused format matching KV cache shape.
@@ -571,16 +599,9 @@ class MHATokenToKVPool(KVCache):
         )
         with self.mesh:
             self.kv_buffer = []
+            allocate = _get_kv_zero_allocator(fused_buffer_shape, self.dtype, self.kv_sharding)
             for _ in range(self.layer_num):
-                kv_buf = jax.jit(
-                    lambda: jnp.zeros(
-                        shape=fused_buffer_shape,
-                        dtype=self.dtype,
-                    ),
-                    out_shardings=self.kv_sharding,
-                )()
-
-                self.kv_buffer.append(kv_buf)
+                self.kv_buffer.append(allocate())
 
         end_time = time.time()
         logger.info(
@@ -1324,12 +1345,9 @@ class MLATokenToKVPool(KVCache):
 
         with self.mesh:
             self.kv_buffer = []
+            allocate = _get_kv_zero_allocator(buffer_shape, self.dtype, self.kv_sharding)
             for _ in range(self.layer_num):
-                kv_buf = jax.jit(
-                    lambda: jnp.zeros(shape=buffer_shape, dtype=self.dtype),
-                    out_shardings=self.kv_sharding,
-                )()
-                self.kv_buffer.append(kv_buf)
+                self.kv_buffer.append(allocate())
 
     def _calculate_memory_usage(self):
         """Calculate memory usage for the 4D paged MLA cache."""

--- a/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
+++ b/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
@@ -4,12 +4,34 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from functools import partial
 
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jax.tree_util import register_pytree_node_class
+
+# Module-level cache for jitted zero-allocators (recurrent/conv buffers).
+_RECURRENT_ZERO_ALLOCATOR_CACHE: dict = {}
+
+
+def _get_recurrent_zero_allocator(shape, dtype, sharding):
+    """Return a cached jax.jit(jnp.zeros) allocator for recurrent/conv buffers."""
+    key = (
+        id(sharding.mesh),
+        tuple(shape),
+        str(jnp.dtype(dtype)),
+        repr(sharding.spec),
+        getattr(sharding, "memory_kind", None),
+    )
+    if key not in _RECURRENT_ZERO_ALLOCATOR_CACHE:
+        _RECURRENT_ZERO_ALLOCATOR_CACHE[key] = jax.jit(
+            partial(jnp.zeros, shape=tuple(shape), dtype=dtype),
+            out_shardings=sharding,
+        )
+    return _RECURRENT_ZERO_ALLOCATOR_CACHE[key]
+
 
 _DTYPE_MAP = {
     "float32": jnp.float32,
@@ -152,23 +174,19 @@ class RecurrentStatePool:
         temporal_dtype = self.temporal_dtype
         conv_dtype = self.conv_dtype
 
+        alloc_recurrent = _get_recurrent_zero_allocator(
+            recurrent_shape, temporal_dtype, self.recurrent_sharding
+        )
+        alloc_conv = _get_recurrent_zero_allocator(conv_shape, conv_dtype, self.conv_sharding)
         with self.mesh:
             recurrent_buffers = []
             for _ in range(self.num_linear_recurrent_layers):
-                buf = jax.jit(
-                    lambda: jnp.zeros(shape=recurrent_shape, dtype=temporal_dtype),
-                    out_shardings=self.recurrent_sharding,
-                )()
-                recurrent_buffers.append(buf)
+                recurrent_buffers.append(alloc_recurrent())
 
             conv_buffers = []
             for _ in range(self.num_linear_recurrent_layers):
                 inner = []
-                buf = jax.jit(
-                    lambda: jnp.zeros(shape=conv_shape, dtype=conv_dtype),
-                    out_shardings=self.conv_sharding,
-                )()
-                inner.append(buf)
+                inner.append(alloc_conv())
                 conv_buffers.append(inner)
 
         return recurrent_buffers, conv_buffers


### PR DESCRIPTION
## Motivation

Repeated `jax.jit(lambda: jnp.zeros(...))` per layer causes JAX to re-trace
on every iteration, wasting significant time at pool construction.

`MHATokenToKVPool._create_buffers()`, `MLATokenToKVPool._create_buffers()`, and
`RecurrentStatePool._create_buffers()` each call `jax.jit(lambda: jnp.zeros(...))`
once per layer in a loop. JAX sees a new Python function object each iteration
and re-traces every time — even when XLA reuses a cached executable, the trace
+ dispatch/re-compile overhead is paid for every layer, on every pool construction.

## Modifications

Add a module-level allocator cache keyed by `(mesh_id, shape, dtype,
sharding_spec, memory_kind)`. The jitted `jnp.zeros` allocator is compiled once
and reused for all N layers. Each call still returns fresh zero-initialized
tensors — only the compiled function is cached.

- `memory_pool.py`: `_KV_ZERO_ALLOCATOR_CACHE` + `_get_kv_zero_allocator()`
- `recurrent_state_pool.py`: `_RECURRENT_ZERO_ALLOCATOR_CACHE` +
  `_get_recurrent_zero_allocator()`

## Benchmarking and Profiling

Each of the 6 test methods in `test_paged_allocator_multi_dp.py` constructs a
fresh `MHATokenToKVPool`, which calls `_create_buffers()` and logs `"Total time
to create N buffers"` at INFO level. The command:

  pytest python/sgl_jax/test/mem_cache/test_paged_allocator_multi_dp.py \
      -v -s --log-cli-level=INFO

produces 6 log lines — one per pool construction:

  Before (fresh jit per layer):
    Pool 1: 0.20s    Pool 2: 0.08s    Pool 3: 0.08s
    Pool 4: 0.08s    Pool 5: 0.08s    Pool 6: 0.08s

  After (cached allocator):
    Pool 1: 0.14s    Pool 2: 0.00s    Pool 3: 0.00s
    Pool 4: 0.00s    Pool 5: 0.00s    Pool 6: 0.00s

Even Pool 1 is faster (0.20s → 0.14s): with 2 layers, the old code traces
twice (two new lambdas), while the cached allocator traces only once then
dispatches twice.

On TPU the per-layer overhead is ~2-3s (ref: [vllm-project/tpu-inference#3180](https://github.com/vllm-project/tpu-inference/pull/3180)),
so a 36-layer model saves ~100s at startup.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.