### PR TITLE
feat(pd): Pathways PD follow-ups — D-side KV admission reservation + logprob on the async prefill path

### DIFF
--- a/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
+++ b/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
@@ -227,6 +227,11 @@ class PathwaysPDSchedulerMixin:
         # reqs pushed to prefill_q but not yet drained into running_batch;
         # tracked by rid so a chunked req counts once, not once-per-chunk.
         self._pd_inflight_rids: set[str] = set()
+        # D-pool tokens the inflight rids will need at migrate time (page-
+        # padded full IL per req) -- the admission-side reservation ledger.
+        self._pd_inflight_tokens = 0
+        self._pd_gate_ticks = 0
+        self._pd_defer_ticks = 0
         self._pd_reserved_per = server_args.disaggregation_num_reserved_decode_tokens
         self._pd_sliding_window = self.tp_workers_p[0].sliding_window_size or 0
         self._pd_next_p = 0
@@ -647,7 +652,7 @@ class PathwaysPDSchedulerMixin:
                     if r.req_pool_idx is not None:
                         p_tree.cache_finished_req(r)
                         p_r2t.free_slots.append(r.req_pool_idx)
-                    self._pd_inflight_rids.discard(r.rid)
+                    self._pd_untrack_inflight(r)
                     all_reqs.append(r)
             self.stream_output(all_reqs, False, False)
             for dp in chunked_excl:
@@ -671,7 +676,22 @@ class PathwaysPDSchedulerMixin:
                 for rk, nd in need_by_rank.items()
             ):
                 self._pd_defer.append(item)
+                # Starvation diagnostic: defer is silent by design (retried
+                # every drain tick); if it stays wedged (e.g. a single item
+                # whose need can never fit next to the reserve) surface the
+                # numbers instead of hanging mutely. ~30s at a ~29ms tick.
+                self._pd_defer_ticks += 1
+                if self._pd_defer_ticks % 1024 == 0:
+                    logger.warning(
+                        "[pd-backpressure] ready item deferred x%d: need=%s "
+                        "reserved/rank=%d avail=%s",
+                        self._pd_defer_ticks,
+                        dict(need_by_rank),
+                        reserved_per_rank,
+                        {rk: allocator.available_size(dp_rank=rk) for rk in need_by_rank},
+                    )
                 return
+            self._pd_defer_ticks = 0
         d_pages_all = []
         for r, p_slots, p_pages in done_per_req:
             seq_len = len(r.fill_ids)
@@ -773,7 +793,7 @@ class PathwaysPDSchedulerMixin:
                 (time.perf_counter() - t_dequeue_ready) * 1e3,
             )
         for r, _, _ in done_per_req:
-            self._pd_inflight_rids.discard(r.rid)
+            self._pd_untrack_inflight(r)
         if _PD_DBG and done_per_req and hasattr(p_alloc, "swa_available_size"):
             logger.info(
                 "[pd-diag] after free %d done: P full_avail=%d swa_avail=%d",
@@ -827,6 +847,65 @@ class PathwaysPDSchedulerMixin:
                 break
         return n_calls
 
+    def _pd_req_kv_tokens(self, r) -> int:
+        """Page-padded D-pool token footprint a req needs at migrate time
+        (migrate allocs len(p_pages) * page_size for the full input)."""
+        n = len(r.origin_input_ids)
+        return -(-n // self.page_size) * self.page_size
+
+    def _pd_track_inflight(self, r) -> None:
+        """Reserve r's D-pool footprint at admission. Idempotent per rid so
+        a chunked req's chunk-2..N batches don't double-count."""
+        if r.rid not in self._pd_inflight_rids:
+            self._pd_inflight_rids.add(r.rid)
+            self._pd_inflight_tokens += self._pd_req_kv_tokens(r)
+
+    def _pd_untrack_inflight(self, r) -> None:
+        """Release r's reservation (migrated into D, or prefill failed)."""
+        if r.rid in self._pd_inflight_rids:
+            self._pd_inflight_rids.discard(r.rid)
+            self._pd_inflight_tokens = max(0, self._pd_inflight_tokens - self._pd_req_kv_tokens(r))
+
+    def _pd_token_gate_closed(self) -> bool:
+        """D-side token-level admission reservation (#1427 follow-up).
+
+        Closed when the inflight reqs' migrate-time footprint plus the
+        decode-growth reserve already covers the D pools' free space --
+        admitting more would just burn P compute on prefills that pile up
+        in _pd_defer holding P KV. Totals across D targets and dp ranks
+        (per-rank exact fit is enforced by the drain-time gate + defer);
+        check-then-build, so one build of overshoot is possible -- also
+        absorbed by the drain gate. On SWA allocators gate on the FULL
+        pool: the swa pool's transient full-seq occupancy during migrate
+        recovers via free_swa, and min()-gating on it would wedge
+        admission for models whose swa pool is window-sized.
+        """
+        if os.environ.get("SGLANG_PD_NO_TOKEN_GATE"):
+            return False
+        avail = 0
+        for alloc in self.d_allocs:
+            f = getattr(alloc, "full_available_size", alloc.available_size)
+            avail += sum(f(dp_rank=rk) for rk in range(self.dp_size))
+        reserved = self._pd_reserved_per * (
+            self._pd_total_d_running() + len(self._pd_inflight_rids)
+        )
+        closed = self._pd_inflight_tokens + reserved >= avail
+        if closed:
+            self._pd_gate_ticks += 1
+            if self._pd_gate_ticks % 512 == 1:
+                logger.info(
+                    "[pd-backpressure] admission paused x%d: inflight=%d reqs "
+                    "%d tok + reserved %d >= D avail %d",
+                    self._pd_gate_ticks,
+                    len(self._pd_inflight_rids),
+                    self._pd_inflight_tokens,
+                    reserved,
+                    avail,
+                )
+        else:
+            self._pd_gate_ticks = 0
+        return closed
+
     def _pd_maybe_push_prefill(self) -> None:
         """Build at most one P batch (round-robin across P slices) and push to
         its prefill_q. Extracted so both the n_decode==1 path
@@ -857,11 +936,19 @@ class PathwaysPDSchedulerMixin:
         # up in the same tick -> observed 2P1D-only correctness bug on the
         # first attempt. D tick ~29ms << P cycle ~330ms so 1 build/tick is
         # plenty to keep both P threads fed.
+        gate_closed = self._pd_token_gate_closed()
         for _off in range(n_p):
             i = (self._pd_next_p + _off) % n_p
             if self._pd_chunk_pending[i]:
                 continue
             if self._pd_prefill_qs[i].full():
+                continue
+            # Token gate blocks NEW admissions only; a P slice with a pending
+            # chunked req still builds so chunk-N+1 can complete and migrate
+            # (its footprint is already in the ledger from chunk-1). The
+            # builder may admit new reqs alongside a continuation -- bounded
+            # overshoot, see _pd_token_gate_closed docstring.
+            if gate_closed and not any(r is not None for r in self.p_chunked_reqs[i]):
                 continue
             self._pd_next_p = (i + 1) % n_p
             saved = self.per_dp_max_running_requests
@@ -907,7 +994,7 @@ class PathwaysPDSchedulerMixin:
             ), "[pd_async] return_logprob / hidden_states not yet supported (async prefill drops logits_output)"
             for info in new_batch.reqs_info:
                 for r in info.reqs or ():
-                    self._pd_inflight_rids.add(r.rid)
+                    self._pd_track_inflight(r)
             # Set pending only when this batch has a mid-chunk req (whose next
             # chunk depends on this one draining). Final-chunk / non-chunked
             # batches leave pending untouched so the main loop can immediately

--- a/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
+++ b/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
@@ -961,9 +961,7 @@ class PathwaysPDSchedulerMixin:
                 continue
             # Token gate blocks NEW admissions only; a P slice with a pending
             # chunked req still builds so chunk-N+1 can complete and migrate
-            # (its footprint is already in the ledger from chunk-1). The
-            # builder may admit new reqs alongside a continuation -- bounded
-            # overshoot, see _pd_token_gate_closed docstring.
+            # (its footprint is already in the ledger from chunk-1).
             if gate_closed and not any(r is not None for r in self.p_chunked_reqs[i]):
                 continue
             self._pd_next_p = (i + 1) % n_p
@@ -986,7 +984,20 @@ class PathwaysPDSchedulerMixin:
             )
             try:
                 with self._pd_swap_p_pool(i):
-                    new_batch = self.get_new_batch_prefill()
+                    if gate_closed:
+                        # Chunk-continuation only: hide the waiting queue so
+                        # the builder cannot admit new reqs from ANY dp rank
+                        # while the gate is closed (with dp>1, ranks without a
+                        # chunk would otherwise fill their slots from the
+                        # queue, leaking admissions past the gate).
+                        _saved_q = self.waiting_queue
+                        self.waiting_queue = []
+                        try:
+                            new_batch = self.get_new_batch_prefill()
+                        finally:
+                            self.waiting_queue = _saved_q
+                    else:
+                        new_batch = self.get_new_batch_prefill()
             finally:
                 self.per_dp_max_running_requests = saved
             if new_batch is None:

--- a/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
+++ b/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
@@ -375,8 +375,12 @@ class PathwaysPDSchedulerMixin:
             _mwb = b.get_model_worker_batch(
                 *paddings, self.page_size, self.server_args.enable_static_lora
             )
-            _, _ntok, _ = worker.forward_batch_generation(_mwb, sampling_metadata=None)
-            return _mwb, _ntok, _t0, time.perf_counter()
+            # logprob batches take the unfused path inside
+            # forward_batch_generation, which host-materializes all logprob
+            # fields of logits_output before returning -- so keeping it here
+            # (P thread) costs nothing on the main-thread drain.
+            _lo, _ntok, _ = worker.forward_batch_generation(_mwb, sampling_metadata=None)
+            return _mwb, _lo, _ntok, _t0, time.perf_counter()
 
         def _is_mid_only(b):
             return all(
@@ -385,16 +389,16 @@ class PathwaysPDSchedulerMixin:
                 if info.reqs
             )
 
-        _stash = None  # pre-dispatched (batch, mwb, ntok_dev, t0, t_disp)
+        _stash = None  # pre-dispatched (batch, mwb, lo, ntok_dev, t0, t_disp)
         while True:
             if _stash is not None:
-                batch, mwb, ntok_dev, t0, t_disp = _stash
+                batch, mwb, lo, ntok_dev, t0, t_disp = _stash
                 _stash = None
             else:
                 batch = q.get()
                 if batch is None:
                     return
-                mwb, ntok_dev, t0, t_disp = _disp(batch)
+                mwb, lo, ntok_dev, t0, t_disp = _disp(batch)
             t_enq_p = getattr(batch, "_pd_t_enqueue_prefill", None)
             try:
                 # depth-1 pipeline: mid-only chunk clears pending right after
@@ -475,11 +479,32 @@ class PathwaysPDSchedulerMixin:
                         ],
                     )
                 self._extract_dp_output_ids(ntok, mwb, batch)
+                if batch.return_logprob or batch.return_output_logprob_only:
+                    # Mirrors run_batch: snapshot per-req lens NOW -- chunked
+                    # bookkeeping mutates them before the main-thread drain
+                    # consumes this result. logits_output's logprob fields are
+                    # already host arrays (materialized on this P thread).
+                    extend_input_lens = [
+                        req.extend_input_len
+                        for info in batch.reqs_info
+                        if info.reqs
+                        for req in info.reqs
+                    ]
+                    extend_logprob_start_lens = [
+                        req.extend_logprob_start_len
+                        for info in batch.reqs_info
+                        if info.reqs
+                        for req in info.reqs
+                    ]
+                else:
+                    lo = None  # drop device logits promptly on non-logprob batches
+                    extend_input_lens = None
+                    extend_logprob_start_lens = None
                 result = GenerationBatchResult(
-                    logits_output=None,
+                    logits_output=lo,
                     next_token_ids=ntok.tolist(),
-                    extend_input_len_per_req=None,
-                    extend_logprob_start_len_per_req=None,
+                    extend_input_len_per_req=extend_input_lens,
+                    extend_logprob_start_len_per_req=extend_logprob_start_lens,
                     bid=mwb.bid,
                     cache_miss_count=0,
                 )
@@ -987,11 +1012,11 @@ class PathwaysPDSchedulerMixin:
                 break
             self._pd_chunk_stall = 0
             assert not any(
-                r.return_logprob or r.return_hidden_states
+                r.return_hidden_states
                 for info in new_batch.reqs_info
                 if info.reqs
                 for r in info.reqs
-            ), "[pd_async] return_logprob / hidden_states not yet supported (async prefill drops logits_output)"
+            ), "[pd_async] return_hidden_states not yet supported on the async prefill path"
             for info in new_batch.reqs_info:
                 for r in info.reqs or ():
                     self._pd_track_inflight(r)

--- a/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
+++ b/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
@@ -480,22 +480,13 @@ class PathwaysPDSchedulerMixin:
                     )
                 self._extract_dp_output_ids(ntok, mwb, batch)
                 if batch.return_logprob or batch.return_output_logprob_only:
-                    # Mirrors run_batch: snapshot per-req lens NOW -- chunked
-                    # bookkeeping mutates them before the main-thread drain
-                    # consumes this result. logits_output's logprob fields are
-                    # already host arrays (materialized on this P thread).
-                    extend_input_lens = [
-                        req.extend_input_len
-                        for info in batch.reqs_info
-                        if info.reqs
-                        for req in info.reqs
-                    ]
-                    extend_logprob_start_lens = [
-                        req.extend_logprob_start_len
-                        for info in batch.reqs_info
-                        if info.reqs
-                        for req in info.reqs
-                    ]
+                    # Per-req lens were snapshotted on the main thread at
+                    # build time (_pd_maybe_push_prefill) -- the live req
+                    # fields may already belong to chunk N+1 by now.
+                    # logits_output's logprob fields are already host arrays
+                    # (materialized on this P thread).
+                    extend_input_lens = batch._pd_extend_input_lens
+                    extend_logprob_start_lens = batch._pd_extend_logprob_start_lens
                 else:
                     lo = None  # drop device logits promptly on non-logprob batches
                     extend_input_lens = None
@@ -1027,6 +1018,26 @@ class PathwaysPDSchedulerMixin:
             # (depth=2 overlap). Drain only clears pending on a mid-chunk item.
             if any(info.chunked_req is not None for info in new_batch.reqs_info):
                 self._pd_chunk_pending[i] = True
+            # Snapshot per-req logprob lens NOW, on the main thread: once this
+            # batch is queued, the depth-1 pipeline lets the main loop build
+            # chunk N+1 (init_next_round_input mutates extend_input_len /
+            # extend_logprob_start_len) while the P thread is still between
+            # forward and result construction -- reading the live fields there
+            # races and breaks chunked input-logprob accounting. Mirrors the
+            # copy run_batch does for the same reason.
+            if new_batch.return_logprob or new_batch.return_output_logprob_only:
+                new_batch._pd_extend_input_lens = [
+                    req.extend_input_len
+                    for info in new_batch.reqs_info
+                    if info.reqs
+                    for req in info.reqs
+                ]
+                new_batch._pd_extend_logprob_start_lens = [
+                    req.extend_logprob_start_len
+                    for info in new_batch.reqs_info
+                    if info.reqs
+                    for req in info.reqs
+                ]
             new_batch._pd_t_enqueue_prefill = time.perf_counter()
             self._pd_prefill_qs[i].put_nowait(new_batch)
             break

--- a/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
+++ b/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
@@ -985,17 +985,17 @@ class PathwaysPDSchedulerMixin:
             try:
                 with self._pd_swap_p_pool(i):
                     if gate_closed:
-                        # Chunk-continuation only: hide the waiting queue so
-                        # the builder cannot admit new reqs from ANY dp rank
-                        # while the gate is closed (with dp>1, ranks without a
-                        # chunk would otherwise fill their slots from the
-                        # queue, leaking admissions past the gate).
-                        _saved_q = self.waiting_queue
-                        self.waiting_queue = []
+                        # Chunk-continuation only: pause admissions explicitly
+                        # so the builder advances existing chunks without
+                        # scanning the waiting queue on ANY dp rank and without
+                        # the grammar-queue move (swapping the queue out
+                        # instead would strand grammar reqs moved into the
+                        # temporary list -- review on #1469).
+                        self._pd_admission_paused = True
                         try:
                             new_batch = self.get_new_batch_prefill()
                         finally:
-                            self.waiting_queue = _saved_q
+                            self._pd_admission_paused = False
                     else:
                         new_batch = self.get_new_batch_prefill()
             finally:

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1864,7 +1864,13 @@ class Scheduler(
         return ret
 
     def get_new_batch_prefill(self) -> ScheduleBatch | None:
-        if self.grammar_queue:
+        # Pathways-PD sets _pd_admission_paused while its D-pool token gate is
+        # closed: existing chunked requests still advance, but nothing new is
+        # admitted -- neither from the waiting queue nor via the grammar-queue
+        # move (which would strand or leak requests past the gate). Absent /
+        # False everywhere else, so the native path is unchanged.
+        admissions_paused = getattr(self, "_pd_admission_paused", False)
+        if self.grammar_queue and not admissions_paused:
             self.move_ready_grammar_requests()
 
         # Settle completed async D2H backups before scheduling.
@@ -1927,7 +1933,7 @@ class Scheduler(
                         lora_set.update([req.lora_id for req in info.reqs])
 
         # Get requests from the waiting queue to a new prefill batch
-        for req in self.waiting_queue:
+        for req in () if admissions_paused else self.waiting_queue:
             # Get DP rank for this request
             dp_rank = req.dp_rank
             assert (

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -1216,7 +1216,11 @@ class TokenizerManager:
             ]
         else:
             assert self.tokenizer is not None
-            token_texts = self.tokenizer.batch_decode(token_logprobs_idx)
+            # Wrap each id as its own sequence: transformers>=5 batch_decode
+            # treats a flat int list as ONE sequence, returning a single
+            # string -- zip would then truncate to one (logprob, id, text)
+            # triple. Nested lists decode per-token on both v4 and v5.
+            token_texts = self.tokenizer.batch_decode([[t] for t in token_logprobs_idx])
             return list(zip(token_logprobs_val, token_logprobs_idx, token_texts))
 
     def detokenize_top_logprobs_tokens(

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -475,9 +475,12 @@ class ModelWorker:
 
         # Pathways-PD: fuse run_model+sampler+resolve/set into one jit so a
         # decode tick is a single Execute through the ordered dispatch queue.
+        # Any logprob batch falls through to the unfused path below, which is
+        # the only one that computes/materializes logprob fields.
         if (
             self._pd_fuse_sample
             and not skip_sample
+            and not model_worker_batch.return_logprob
             and not model_worker_batch.return_output_logprob_only
         ):
             if model_worker_batch.sampling_info:

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -437,6 +437,25 @@ class ModelWorker:
             sampling_metadata.apply_vocab_mask = True
             sampling_metadata.vocab_mask = batch.sampling_info.vocab_mask
 
+    def _pd_fuse_for_batch(self, model_worker_batch: ModelWorkerBatch) -> bool:
+        """Batch-level fused-sample eligibility. The single source of truth
+        for every fused-vs-regular branch choice (worker AND overlap client):
+        the two paths return different tuple arities, so a caller keying on
+        the worker-level flag alone would mis-unpack whenever an ineligible
+        batch falls through to the regular path.
+
+        Decode-only: the fused jit exists to collapse a decode tick into one
+        Execute; the Pathways-PD prefill thread's EXTEND batches crash inside
+        its future-token resolve (and prefill was never the fusion target).
+        Logprob batches take the regular path -- the only one that computes/
+        materializes logprob fields."""
+        return (
+            self._pd_fuse_sample
+            and model_worker_batch.forward_mode.is_decode()
+            and not model_worker_batch.return_logprob
+            and not model_worker_batch.return_output_logprob_only
+        )
+
     def forward_batch_generation(
         self,
         model_worker_batch: ModelWorkerBatch,
@@ -477,12 +496,7 @@ class ModelWorker:
         # decode tick is a single Execute through the ordered dispatch queue.
         # Any logprob batch falls through to the unfused path below, which is
         # the only one that computes/materializes logprob fields.
-        if (
-            self._pd_fuse_sample
-            and not skip_sample
-            and not model_worker_batch.return_logprob
-            and not model_worker_batch.return_output_logprob_only
-        ):
+        if self._pd_fuse_for_batch(model_worker_batch) and not skip_sample:
             if model_worker_batch.sampling_info:
                 self._update_grammar_vocab_mask(model_worker_batch, sampling_metadata)
             fmap = future_map if future_map is not None else self._pd_dummy_future_map

--- a/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
@@ -116,8 +116,11 @@ class ModelWorkerClient:
             if not model_worker_batch:
                 break
 
-            if self.worker._pd_fuse_sample:
+            if self.worker._pd_fuse_for_batch(model_worker_batch):
                 # Fused path: resolve/set_future are inlined into the single jit.
+                # Batch-level check (not the worker flag): logprob batches take
+                # the regular 3-tuple path inside forward_batch_generation, so
+                # selecting the fused 4-tuple unpack here would crash on them.
                 with jax.profiler.TraceAnnotation(
                     f"forward_batch_generation {model_worker_batch.bid}"
                 ):

--- a/test/srt/disaggregation/test_pathways_pd.py
+++ b/test/srt/disaggregation/test_pathways_pd.py
@@ -586,3 +586,122 @@ def test_drain_multi_mixed_backlog_then_stuck_defer():
     assert fake._pd_ready_q.empty()
     assert n_calls == 4  # 3 ready items + 1 no-progress defer call before exit
     assert fake._pd_defer == ["stuck-req"]
+
+
+# ---------------------------------------------------------------------------
+# D-side token-level admission reservation (#1427 follow-up: KV backpressure)
+# ---------------------------------------------------------------------------
+
+
+class _FakeReq:
+    def __init__(self, rid: str, n_tokens: int):
+        self.rid = rid
+        self.origin_input_ids = [0] * n_tokens
+
+
+class _FakeFullAlloc:
+    """SWA-style allocator: full_available_size differs from (min-based)
+    available_size, so the gate must read the full pool, not the min."""
+
+    def __init__(self, full_by_rank, min_by_rank=None):
+        self._full = full_by_rank
+        self._min = min_by_rank or full_by_rank
+
+    def full_available_size(self, dp_rank: int = 0) -> int:
+        return self._full[dp_rank]
+
+    def available_size(self, dp_rank: int = 0) -> int:
+        return self._min[dp_rank]
+
+
+class _FakeMinOnlyAlloc:
+    """Non-SWA allocator: only available_size exists (getattr fallback)."""
+
+    def __init__(self, by_rank):
+        self._by_rank = by_rank
+
+    def available_size(self, dp_rank: int = 0) -> int:
+        return self._by_rank[dp_rank]
+
+
+class _FakeGateSelf(PathwaysPDSchedulerMixin):
+    """Subclasses the mixin so the gate/ledger helpers under test can call
+    each other through self, with only the state they touch defined here."""
+
+    page_size = PAGE_SIZE
+
+    def __init__(self, d_allocs, dp_size=1, reserved_per=0, d_running=0):
+        self.d_allocs = d_allocs
+        self.dp_size = dp_size
+        self._pd_reserved_per = reserved_per
+        self._d_running = d_running
+        self._pd_inflight_rids = set()
+        self._pd_inflight_tokens = 0
+        self._pd_gate_ticks = 0
+
+    def _pd_total_d_running(self) -> int:
+        return self._d_running
+
+
+def test_pd_req_kv_tokens_page_padded():
+    fake = _FakeGateSelf(d_allocs=[])
+    f = PathwaysPDSchedulerMixin._pd_req_kv_tokens
+    assert f(fake, _FakeReq("a", 1)) == PAGE_SIZE
+    assert f(fake, _FakeReq("b", PAGE_SIZE)) == PAGE_SIZE
+    assert f(fake, _FakeReq("c", PAGE_SIZE + 1)) == 2 * PAGE_SIZE
+
+
+def test_track_untrack_inflight_idempotent():
+    fake = _FakeGateSelf(d_allocs=[])
+    r = _FakeReq("r1", 5)  # pads to 8
+    PathwaysPDSchedulerMixin._pd_track_inflight(fake, r)
+    assert fake._pd_inflight_tokens == 8
+    # chunked req: chunk-2..N re-track the same rid -> counted once
+    PathwaysPDSchedulerMixin._pd_track_inflight(fake, r)
+    assert fake._pd_inflight_tokens == 8
+    PathwaysPDSchedulerMixin._pd_untrack_inflight(fake, r)
+    assert fake._pd_inflight_tokens == 0
+    assert not fake._pd_inflight_rids
+    # double-untrack (failure path after success path) must not go negative
+    PathwaysPDSchedulerMixin._pd_untrack_inflight(fake, r)
+    assert fake._pd_inflight_tokens == 0
+
+
+def test_token_gate_open_under_capacity():
+    fake = _FakeGateSelf(d_allocs=[_FakeMinOnlyAlloc({0: 100})])
+    PathwaysPDSchedulerMixin._pd_track_inflight(fake, _FakeReq("r1", 40))
+    assert not PathwaysPDSchedulerMixin._pd_token_gate_closed(fake)
+
+
+def test_token_gate_closes_on_projected_exhaustion():
+    # inflight 40 + reserved 2*(running 20 + inflight 1) = 82 >= avail 80
+    fake = _FakeGateSelf(d_allocs=[_FakeMinOnlyAlloc({0: 80})], reserved_per=2, d_running=20)
+    PathwaysPDSchedulerMixin._pd_track_inflight(fake, _FakeReq("r1", 40))
+    assert PathwaysPDSchedulerMixin._pd_token_gate_closed(fake)
+
+
+def test_token_gate_sums_across_d_and_ranks():
+    # 2 D targets x 2 ranks x 30 = 120 total; inflight 100 < 120 -> open
+    allocs = [_FakeMinOnlyAlloc({0: 30, 1: 30}), _FakeMinOnlyAlloc({0: 30, 1: 30})]
+    fake = _FakeGateSelf(d_allocs=allocs, dp_size=2)
+    PathwaysPDSchedulerMixin._pd_track_inflight(fake, _FakeReq("r1", 100))
+    assert not PathwaysPDSchedulerMixin._pd_token_gate_closed(fake)
+    PathwaysPDSchedulerMixin._pd_track_inflight(fake, _FakeReq("r2", 100))
+    assert PathwaysPDSchedulerMixin._pd_token_gate_closed(fake)
+
+
+def test_token_gate_reads_full_pool_not_min_for_swa():
+    # swa side transiently tiny (min=4) but full pool has room (100): the
+    # IL projection must gate on the full pool -- the swa transient is
+    # handled exactly by the drain-time gate + defer. min() here would
+    # wedge admission for SWA models whose swa pool is window-sized.
+    fake = _FakeGateSelf(d_allocs=[_FakeFullAlloc({0: 100}, min_by_rank={0: 4})])
+    PathwaysPDSchedulerMixin._pd_track_inflight(fake, _FakeReq("r1", 40))
+    assert not PathwaysPDSchedulerMixin._pd_token_gate_closed(fake)
+
+
+def test_token_gate_env_escape(monkeypatch):
+    monkeypatch.setenv("SGLANG_PD_NO_TOKEN_GATE", "1")
+    fake = _FakeGateSelf(d_allocs=[_FakeMinOnlyAlloc({0: 0})])
+    PathwaysPDSchedulerMixin._pd_track_inflight(fake, _FakeReq("r1", 400))
+    assert not PathwaysPDSchedulerMixin._pd_token_gate_closed(fake)

--- a/test/srt/disaggregation/test_pathways_pd.py
+++ b/test/srt/disaggregation/test_pathways_pd.py
@@ -705,3 +705,28 @@ def test_token_gate_env_escape(monkeypatch):
     fake = _FakeGateSelf(d_allocs=[_FakeMinOnlyAlloc({0: 0})])
     PathwaysPDSchedulerMixin._pd_track_inflight(fake, _FakeReq("r1", 400))
     assert not PathwaysPDSchedulerMixin._pd_token_gate_closed(fake)
+
+
+def test_fuse_for_batch_is_batch_level():
+    """Fused-sample eligibility must consider the batch's logprob flags, not
+    just the worker flag -- the overlap client picks its unpack arity from
+    this predicate (#1469 review)."""
+    from types import SimpleNamespace as _NS
+
+    from sgl_jax.srt.managers.tp_worker import ModelWorker
+
+    w = ModelWorker.__new__(ModelWorker)
+    w._pd_fuse_sample = True
+    dec = _NS(is_decode=lambda: True)
+    ext = _NS(is_decode=lambda: False)
+    plain = _NS(return_logprob=False, return_output_logprob_only=False, forward_mode=dec)
+    lp = _NS(return_logprob=True, return_output_logprob_only=False, forward_mode=dec)
+    olp = _NS(return_logprob=False, return_output_logprob_only=True, forward_mode=dec)
+    prefill = _NS(return_logprob=False, return_output_logprob_only=False, forward_mode=ext)
+    assert w._pd_fuse_for_batch(plain)
+    assert not w._pd_fuse_for_batch(lp)
+    assert not w._pd_fuse_for_batch(olp)
+    # the PD prefill thread's EXTEND batches must never take the fused path
+    assert not w._pd_fuse_for_batch(prefill)
+    w._pd_fuse_sample = False
+    assert not w._pd_fuse_for_batch(plain)


### PR DESCRIPTION

Implements two follow-ups tracked in #1427 (promised in the #1428 review), plus one general tokenizer fix found while validating them.

Related but orthogonal to #1410 (multi-host DP logprob host transfer): that PR makes `_materialize_logprobs_to_host` sharding-aware for data-sharded tables across hosts; this one carries the (already host-materialized) logprobs through the Pathways single-controller async prefill path, where all arrays are locally addressable. The only shared file is `tp_worker.py` in adjacent, non-overlapping hunks — either PR rebases cleanly over the other.

## 1. D-side KV reservation / backpressure

The drain-time capacity gate + defer (pending-ready path) landed in #1453; this adds the admission-side reservation half:

- **Token ledger** (`_pd_inflight_tokens`): every admitted-but-not-yet-migrated req reserves its page-padded full-input footprint; released at migrate or on prefill failure. Idempotent per rid, so chunked re-admissions don't double-count.
- **Admission gate** (`_pd_token_gate_closed`): NEW admissions pause when `inflight footprint + decode-growth reserve (disaggregation_num_reserved_decode_tokens × (running + inflight)) >= total D free space` — instead of burning P compute on prefills that pile up in `_pd_defer` holding P KV. Chunked continuations still build. On SWA allocators the gate reads the FULL pool (the swa pool's transient full-seq occupancy during migrate recovers via `free_swa`; min()-gating would wedge admission for window-sized swa pools).
- **Starvation diagnostics**: a periodic warning with need/reserved/avail when a deferred ready item stays wedged, and an admission-paused counter log. `SGLANG_PD_NO_TOKEN_GATE=1` reverts to pre-gate behavior.

No new CLI flags; reuses `disaggregation_num_reserved_decode_tokens`.

## 2. logprob on the async prefill path

The async prefill result previously dropped `logits_output` and the per-req extend lens, so `return_logprob` was rejected at admission. The P-thread forward already computes and host-materializes every logprob field for logprob batches (they bypass the fused-sample jit), so:

- Keep `logits_output` in the async `GenerationBatchResult`; the shared prefill output processor consumes it unchanged, including chunked-prefill input-logprob accumulation.
- Snapshot `extend_input_len` / `extend_logprob_start_len` on the main thread at batch-build time: the depth-1 pipeline builds chunk N+1 (mutating those fields) while the P thread is still between forward and result construction — same reason `run_batch` copies them before overlap dispatch.
- Gate the Pathways fused-sample jit on `return_logprob` too (it only checked `return_output_logprob_only`), so a decode batch carrying a full-logprob req falls back to the unfused path instead of silently dropping `next_token_logprobs`. Unreachable outside Pathways PD.
- `return_hidden_states` remains rejected at admission.

## 3. fix(tokenizer): per-token batch_decode for logprob text under transformers>=5

Independent of PD (found while validating the logprob change in section 2 above, needed to observe it end-to-end). `detokenize_logprob_tokens` passes a flat list of ints to `batch_decode`. Under the pinned `transformers~=4.57.1` that already decodes per-token, so **this change is a byte-identical no-op on the pinned env**. Under transformers >= 5, `batch_decode` treats a flat int list as ONE sequence and returns a single string — the zip then silently truncates every `meta_info` output/input/top logprob list to one entry. This is reachable today: GLM-5 tokenizers don't load under transformers 4.x (`TokenizersBackend does not exist`), so any GLM-5 deployment already runs transformers 5 and gets truncated logprobs. Wrapping each id as its own sequence decodes per-token on both. Verified on 4.57.6 / 5.3.0 / 5.14.1 with two tokenizers: v4 flat == v4 wrapped == v5 wrapped == per-token; v5 flat == one concatenated string. The existing `test_logprobs.py` asserts values, not list length vs token count, so it doesn't catch the truncation on a v5 env. Happy to split this into a small prerequisite PR if preferred.

## Test plan

Environment: TPU v7x via Pathways single-controller, MiMo-V2-Flash, tp8 ep8 dp2, 2P1D (3 slices), 16K/4K, same config as the #1453 test plan.

**Standard regression** (`--pd-decode-max-tokens 800000`, pool not saturated — gate never fires):

| item | this branch | #1453 baseline | delta |
|---|---|---|---|
| correctness SHORT/MID/LONG × C4/8/16 | 336/336 | 336/336 | — |
| C128 r2 tok/s (Med ITL) | 15411 (32.52ms) | 15493 (32.3-32.5ms) | −0.53% (within node-to-node variance) |
| C128 r3 tok/s (Med ITL) | 15378 (32.69ms) | 15426 | −0.31% |
| gsm8k 200q | 0.890, Invalid 0 | 0.865–0.885 | — |
| `[pd-backpressure]` lines during bench | 0 | — | zero perturbation at standard load |

**Backpressure stress** (`--pd-decode-max-tokens 300000` → full pool 2,120,192 tok; C128 × (16K+4K) ≈ 2.6M demand → genuinely saturated; 256 prompts, single round each arm):

| metric | gate ON | gate OFF (`SGLANG_PD_NO_TOKEN_GATE=1`, = pre-PR behavior) |
|---|---|---|
| completed | 256/256 | 256/256 |
| crashes | 0 | 0 |
| total tok/s | 14117 | 14301 (−1.3%, single round; per-run variance 0.4–0.7%) |
| Median / P99 ITL | 30.54 / 123.4ms | 30.72 / 121.8ms |
| admission-paused episodes | 32 (opens/closes with pool availability) | 0 |
| ledger leak check | single request served immediately after the run | n/a |

The small gate-ON deficit at saturation is the expected trade: reqs wait in the waiting queue instead of pre-prefilled in the defer list; at standard load there is no cost.

**GLM-5.2-FP8 (MLA, non-SWA KV pool) — the gate's real-world engagement case** (tp16 ep16 dp1, 1P1D, 2 slices, 16K/4K C64, 192 prompts, 2 warm rounds each arm; this config's D pool is HBM-capped so it saturates at standard load and the gate genuinely engages, unlike the MiMo rows where it never fires):

| item | gate ON | gate OFF | #1453 baseline |
|---|---|---|---|
| correctness 336 | 336/336 | 336/336 | 336/336 |
| gsm8k 200q | 0.950 | 0.965 | 0.955 (±1-2 questions run-to-run) |
| C64 tok/s, 2-round mean | 1067.6 (r1/r2 1068.5/1066.6) | 1076.6 (1076.5/1076.7) | 1078 |
| Median / P99 ITL | 88.9–89.2 / 94.1–94.2ms | 89.3 / 93.6ms | — |
| admission-paused | 154+ episodes | 0 | — |
| crashes | 0 | 0 | — |

Gate ON costs a reproducible **−0.83%** at this saturated operating point (ITL unchanged): with the gate off, deferred pre-prefilled requests refill a freed D slot one admission→prefill cycle sooner. We think the trade is worth it (bounded defer, P KV not held hostage, requests remain abortable in the waiting queue), and `SGLANG_PD_NO_TOKEN_GATE=1` restores the old behavior — but happy to discuss adding a pre-staging slack or flipping the default if preferred.

**logprob e2e** (async prefill path, both models):

| test | result |
|---|---|
| short prompt, `return_logprob` + `top_logprobs_num=5`, temperature=0 (MiMo + GLM) | per-token logprobs == completion length; 5 candidates per position; sampled token == top-1 with equal logprob |
| MiMo: 8001-token prompt (4 × 2048 chunks), `logprob_start_len=0` | 8001 input logprob entries (first `None` by convention), all finite ≤ 0, no crash |
| GLM: 5001-token prompt (2 × 4096 chunks), `logprob_start_len=0` | 5001 input logprob entries, all finite ≤ 0; output logprobs == completion length under `ignore_eos` |
| mixed concurrency: 2 logprob + 2 plain | all 4 outputs byte-equal to a plain reference run |

- CPU unit tests: 7 new (ledger idempotence, gate projection math, multi-D/rank summing, SWA full-pool semantics, env escape); `test_pathways_pd.py` 28 pass
- Known not-covered: the `return_output_logprob_only`-only path (bare `return_logprob` requests are converted to it by the tokenizer manager) shares the same `next_token_logprobs` production but has no dedicated assertion in the e2e above.
