### PR TITLE
Fix chunked-prefill request ownership lifecycle

### DIFF
--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -231,6 +231,8 @@ class SchedulerDisaggregationPrefillMixin:
                 # Still mid-chunk: KV is incomplete, and releasing the
                 # req_pool_idx here would leak the slot the next chunk
                 # round re-allocates. Extract on the final chunk.
+                assert req.is_chunked > 0
+                req.is_chunked -= 1
                 continue
             req_id = req.rid
             if req_id in self.disagg_prefill_queue._entries:

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -78,6 +78,7 @@ from sgl_jax.srt.managers.tp_worker_overlap_thread import ModelWorkerClient
 from sgl_jax.srt.managers.utils import validate_input_length
 from sgl_jax.srt.mem_cache.base_prefix_cache import MatchPrefixParams
 from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
+from sgl_jax.srt.mem_cache.common import release_kv_cache
 from sgl_jax.srt.mem_cache.kv_cache_builder import build_kv_cache
 from sgl_jax.srt.mem_cache.radix_cache import RadixKey
 from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
@@ -449,6 +450,7 @@ class Scheduler(
         if self.chunked_prefill_size <= 0:  # -1 means disable
             self.chunked_prefill_size = None
         self.chunked_reqs = [None] * self.dp_size  # Per-DP chunked requests
+        self._pending_chunked_abort_reqs = [None] * self.dp_size
         self.is_mixed_chunk = (
             self.chunked_prefill_size is not None and server_args.enable_mixed_chunk
         )
@@ -1053,10 +1055,7 @@ class Scheduler(
                         sum(len(i.reqs) for i in self.running_batch.reqs_info),
                     )
             else:
-                # When the server is idle, do self-check and re-init some states
-                self.check_memory()
-                self.check_tree_cache()
-                self.new_token_ratio = self.init_new_token_ratio
+                self.on_idle()
 
                 # Elegant wait if idle
                 if self._comm_backend is not None:
@@ -1149,10 +1148,7 @@ class Scheduler(
                     tmp_batch, tmp_result, batch.launch_done if batch else None
                 )
             elif batch is None:
-                # When the server is idle, do self-check and re-init some states
-                self.check_memory()
-                self.check_tree_cache()
-                self.new_token_ratio = self.init_new_token_ratio
+                self.on_idle()
 
             self.last_batch = batch
             if _pd_iter_trace:
@@ -1426,6 +1422,7 @@ class Scheduler(
         # state for pause/continue generation
         ret["engine_paused"] = self._engine_paused
         ret["waiting_queue_size"] = len(self.waiting_queue)
+        ret["pending_dp_reqs_size"] = len(self.pending_dp_reqs)
         ret["running_batch_size"] = (
             0 if self.running_batch.is_empty() else self.running_batch.batch_size()
         )
@@ -1438,6 +1435,7 @@ class Scheduler(
         ret["cur_batch_is_none"] = self.cur_batch is None
         ret["last_batch_is_none"] = self.last_batch is None
         ret["chunked_req_is_none"] = all(r is None for r in self.chunked_reqs)
+        ret["chunked_req_rids"] = [r.rid if r is not None else None for r in self.chunked_reqs]
 
         # request cache stat
         if isinstance(self.tree_cache, ChunkCache):
@@ -1459,6 +1457,10 @@ class Scheduler(
 
         # physical kv cache stat
         ret["available_kv_tokens"] = self.token_to_kv_pool_allocator.available_size()
+        ret["available_kv_tokens_per_dp"] = [
+            self.token_to_kv_pool_allocator.available_size(dp_rank)
+            for dp_rank in range(self.dp_size)
+        ]
 
         # counters
         ret["num_generated_tokens"] = self.num_generated_tokens
@@ -1551,6 +1553,7 @@ class Scheduler(
             return 0 if batch.is_empty() else batch.batch_size()
 
         waiting_reqs = len(self.waiting_queue)
+        grammar_reqs = len(self.grammar_queue)
         pending_dp_reqs = len(self.pending_dp_reqs)
         running_reqs = _batch_size(self.running_batch)
         current_batch_reqs = _batch_size(self.cur_batch)
@@ -1560,6 +1563,7 @@ class Scheduler(
 
         has_pending = (
             waiting_reqs > 0
+            or grammar_reqs > 0
             or pending_dp_reqs > 0
             or running_reqs > 0
             or current_batch_reqs > 0
@@ -1571,19 +1575,35 @@ class Scheduler(
         pd_prefill = len(self.disagg_prefill_queue or ())
         pd_prealloc = len(self.disagg_prealloc_queue or ())
         pd_transfer = len(self.disagg_transfer_queue or ())
-        has_pending = has_pending or pd_prefill > 0 or pd_prealloc > 0 or pd_transfer > 0
+        pd_bootstrap = len(self._pd_pending_bootstrap)
+        has_pending = (
+            has_pending or pd_prefill > 0 or pd_prealloc > 0 or pd_transfer > 0 or pd_bootstrap > 0
+        )
 
         if has_pending:
             msg = (
                 "Cache not flushed because there are pending requests. "
-                f"waiting={waiting_reqs}, pending_dp={pending_dp_reqs}, running={running_reqs}, "
+                f"waiting={waiting_reqs}, grammar={grammar_reqs}, "
+                f"pending_dp={pending_dp_reqs}, running={running_reqs}, "
                 f"cur_batch={current_batch_reqs}, last_batch={last_batch_reqs}, "
                 f"chunked={chunked_pending}, pending_results={pending_results}, "
-                f"pd_prefill={pd_prefill}, pd_prealloc={pd_prealloc}, pd_transfer={pd_transfer}"
+                f"pd_prefill={pd_prefill}, pd_prealloc={pd_prealloc}, "
+                f"pd_transfer={pd_transfer}, pd_bootstrap={pd_bootstrap}"
             )
             return False, msg
 
         return True, ""
+
+    def is_fully_idle(self) -> bool:
+        can_flush, _ = self._can_flush_cache()
+        return can_flush
+
+    def on_idle(self):
+        if not self.is_fully_idle():
+            return
+        self.check_memory()
+        self.check_tree_cache()
+        self.new_token_ratio = self.init_new_token_ratio
 
     def flush_cache(self) -> tuple[bool, str, int]:
         can_flush, message = self._can_flush_cache()
@@ -1607,6 +1627,7 @@ class Scheduler(
         )
         self.pending_dp_reqs = []
         self.chunked_reqs = [None] * self.dp_size
+        self._pending_chunked_abort_reqs = [None] * self.dp_size
         if self.enable_overlap:
             self.result_queue = deque()
 
@@ -1742,6 +1763,103 @@ class Scheduler(
             swa_evictable_size,
         )
 
+    def _sync_chunked_req_owners(self) -> None:
+        if self.last_batch and self.last_batch.forward_mode.is_extend():
+            for dp_rank, info in enumerate(self.last_batch.reqs_info):
+                if info.chunked_req is None:
+                    continue
+                active_req = self.chunked_reqs[dp_rank]
+                if active_req is None:
+                    self.chunked_reqs[dp_rank] = info.chunked_req
+                else:
+                    assert (
+                        active_req is info.chunked_req
+                    ), f"Chunked request mismatch for DP rank {dp_rank}"
+
+    def _prepare_chunked_reqs_to_exclude(self) -> dict[int, Req]:
+        """Retain scheduler ownership before removing chunked requests from a batch."""
+        self._sync_chunked_req_owners()
+
+        chunked_req_to_exclude: dict[int, Req] = {}
+        for dp_rank, req in enumerate(self.chunked_reqs):
+            if req is None:
+                continue
+            chunked_req_to_exclude[dp_rank] = req
+            if self._pending_chunked_abort_reqs[dp_rank] is None and len(req.fill_ids) > len(
+                req.prefix_indices
+            ):
+                self.tree_cache.cache_unfinished_req(req)
+        return chunked_req_to_exclude
+
+    def _mark_pending_chunked_aborts(self, recv_req: AbortReq) -> None:
+        if self.pd == "pathways":
+            return
+        for dp_rank, req in enumerate(self.chunked_reqs):
+            if req is None or (not recv_req.abort_all and not req.rid.startswith(recv_req.rid)):
+                continue
+            pending_req = self._pending_chunked_abort_reqs[dp_rank]
+            assert pending_req is None or pending_req is req
+            self._pending_chunked_abort_reqs[dp_rank] = req
+            req.to_finish = FINISH_ABORT()
+
+    def _process_pending_chunked_aborts(self) -> dict[int, Req]:
+        consumed: dict[int, Req] = {}
+        if self.pd == "pathways":
+            return consumed
+        for dp_rank, req in enumerate(self._pending_chunked_abort_reqs):
+            if req is None:
+                continue
+            assert self.chunked_reqs[dp_rank] is req
+            if req.is_chunked > 0:
+                continue
+
+            self._finalize_chunked_abort(req, dp_rank)
+            abort_out = AbortReq(rid=req.rid)
+            if self._comm_backend is not None:
+                self._comm_backend.send_pyobj(abort_out)
+            else:
+                self.send_to_tokenizer.send_pyobj(abort_out)
+            consumed[dp_rank] = req
+        return consumed
+
+    def _retire_chunked_req_batch_owners(self, consumed: dict[int, Req]) -> None:
+        if not consumed or self.last_batch is None or not self.last_batch.forward_mode.is_extend():
+            return
+
+        self.last_batch.filter_batch(chunked_req_to_exclude=consumed)
+        for dp_rank, req in consumed.items():
+            info = self.last_batch.reqs_info[dp_rank]
+            if info.chunked_req is None:
+                continue
+            assert info.chunked_req is req
+            info.chunked_req = None
+
+    def _retract_parked_chunked_reqs(self, retracted_reqs: list[Req]) -> None:
+        if self.pd == "pathways":
+            return
+        retracted_request_ids = {id(req) for req in retracted_reqs}
+        for dp_rank, req in enumerate(self.chunked_reqs):
+            if req is None:
+                continue
+            if id(req) in retracted_request_ids:
+                assert self._pending_chunked_abort_reqs[dp_rank] is None
+                self.chunked_reqs[dp_rank] = None
+                continue
+            assert self._pending_chunked_abort_reqs[dp_rank] is None
+            assert req.is_chunked == 0
+            self._release_prefill_host_buffer(req)
+            release_kv_cache(
+                req,
+                self.tree_cache,
+                is_insert=False,
+                allow_overallocated=(
+                    self.spec_algorithm is not None and not self.spec_algorithm.is_none()
+                ),
+            )
+            self.chunked_reqs[dp_rank] = None
+            req.reset_for_retract()
+            self._add_request_to_queue(req)
+
     def get_next_batch_to_run(self) -> ScheduleBatch | None:
         if self.pd == "pathways":
             return self._pd_get_next_batch_async()
@@ -1755,15 +1873,8 @@ class Scheduler(
                     self.running_batch.merge_batch(self._pd_pending_migrate)
                 self._pd_pending_migrate = None
 
-        # Process chunked requests for each DP rank
-        chunked_req_to_exclude = {}
-        _chunk_tree = self.p_tree if self.pd else self.tree_cache
-        for dp_rank in range(self.dp_size):
-            if self.chunked_reqs[dp_rank] is not None:
-                # Move the chunked request out of the batch so that we can merge
-                # only finished requests to running_batch.
-                chunked_req_to_exclude[dp_rank] = self.chunked_reqs[dp_rank]
-                _chunk_tree.cache_unfinished_req(self.chunked_reqs[dp_rank])
+        chunked_req_to_exclude = self._prepare_chunked_reqs_to_exclude()
+        self._process_pending_chunked_aborts()
 
         # Merge the prefill batch into the running batch
         if self.last_batch and self.last_batch.forward_mode.is_extend():
@@ -1772,14 +1883,9 @@ class Scheduler(
             for dp_rank in range(self.dp_size):
                 info = self.last_batch.reqs_info[dp_rank]
                 if info.chunked_req is not None:
-                    # Verify consistency: info.chunked_req should match self.chunked_reqs[dp_rank]
-                    if dp_rank in chunked_req_to_exclude:
-                        assert (
-                            chunked_req_to_exclude[dp_rank] is info.chunked_req
-                        ), f"Chunked request mismatch for DP rank {dp_rank}"
-                    else:
-                        # This shouldn't happen, but handle it gracefully
-                        chunked_req_to_exclude[dp_rank] = info.chunked_req
+                    assert (
+                        chunked_req_to_exclude.get(dp_rank) is info.chunked_req
+                    ), f"Chunked request owner missing for DP rank {dp_rank}"
 
             # Filter batch
             # Track per-DP batch sizes before filtering
@@ -1914,9 +2020,10 @@ class Scheduler(
 
         # Process existing chunked requests for each DP rank
         for dp_rank in range(self.dp_size):
-            if self.chunked_reqs[dp_rank] is not None:
-                self.chunked_reqs[dp_rank].init_next_round_input()
-                self.chunked_reqs[dp_rank] = adder.add_chunked_req(self.chunked_reqs[dp_rank])
+            req = self.chunked_reqs[dp_rank]
+            if req is not None and self._pending_chunked_abort_reqs[dp_rank] is None:
+                req.init_next_round_input()
+                self.chunked_reqs[dp_rank] = adder.add_chunked_req(req)
 
         # Collect existing LoRA IDs in the running batch if LoRA is enabled
         if self.lora_paths is not None:
@@ -2516,6 +2623,9 @@ class Scheduler(
         self.parent_process.send_signal(signal.SIGQUIT)
 
     def abort_request(self, recv_req: AbortReq):
+        self._sync_chunked_req_owners()
+        self._mark_pending_chunked_aborts(recv_req)
+
         # Delete requests in the waiting queue
         to_del = []
         for i, req in enumerate(self.waiting_queue):
@@ -2611,28 +2721,39 @@ class Scheduler(
                     survivors.append(req)
             self._pd_pending_bootstrap = survivors
 
+        if self._engine_paused:
+            consumed = self._process_pending_chunked_aborts()
+            self._retire_chunked_req_batch_owners(consumed)
+
     def pause_generation(self, recv_req: PauseGenerationReqInput):
         self._engine_paused = True
 
         # finish all in-flight request; in overlap mode, last_batch is running
+        self._sync_chunked_req_owners()
         if self.enable_overlap and self.last_batch:
             tmp_batch, tmp_result = self.result_queue.popleft()
             self.process_batch_result(tmp_batch, tmp_result)
             self.last_batch = None
             self.cur_batch = None
 
+        consumed = self._process_pending_chunked_aborts()
+        self._retire_chunked_req_batch_owners(consumed)
+
         if recv_req.mode == "retract":
             self.running_batch.filter_batch()
             all_reqs = [
                 req for info in self.running_batch.reqs_info for req in info.reqs if info.reqs
             ]
+            retracted_reqs = []
             if len(all_reqs) != 0:
                 # clear the kv cache
                 retracted_reqs = self.running_batch.retract_all(self.server_args)
                 for req in retracted_reqs:
                     self._add_request_to_queue(req)
 
-            self.chunked_reqs = [None] * self.dp_size
+            self._retract_parked_chunked_reqs(retracted_reqs)
+            self.last_batch = None
+            self.cur_batch = None
             logger.info("Paused generation retracted")
         elif recv_req.mode == "in_place":
             logger.info("Paused generation in place")

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -31,6 +31,33 @@ logger = logging.getLogger(__name__)
 DEFAULT_FORCE_STREAM_INTERVAL = 50
 
 
+def _complete_precision_trace(req: Req) -> None:
+    if not precision_tracer.get_trace_active():
+        return
+
+    precision_tracer.set_request_status_to_completed(req.rid)
+    precision_tracer.add_completed_requests_count()
+    precision_tracer.set_end_time_and_duration(req.rid)
+    logger.info(
+        "Request trace completed (%d/%d): %s",
+        precision_tracer.get_completed_requests_count(),
+        precision_tracer.get_max_requests(),
+        req.rid,
+    )
+    if precision_tracer.get_completed_requests_count() >= precision_tracer.get_max_requests():
+        precision_tracer.stop_trace()
+
+
+def _num_input_logprobs(
+    req_idx: int,
+    extend_input_len_per_req: list[int] | None,
+    extend_logprob_start_len_per_req: list[int] | None,
+) -> int:
+    assert extend_input_len_per_req is not None
+    assert extend_logprob_start_len_per_req is not None
+    return extend_input_len_per_req[req_idx] - extend_logprob_start_len_per_req[req_idx]
+
+
 def _input_logprob_lens_per_dp(batch: ScheduleBatch) -> list[int] | None:
     if not batch.forward_mode.is_extend():
         return None
@@ -77,6 +104,25 @@ class SchedulerOutputProcessorMixin:
     This class implements the output processing logic for Scheduler.
     We put them into a separate file to make the `scheduler.py` shorter.
     """
+
+    def _finalize_chunked_abort(self: Scheduler, req: Req, dp_rank: int) -> None:
+        assert self.chunked_reqs[dp_rank] is req
+        assert self._pending_chunked_abort_reqs[dp_rank] is req
+        assert req.is_chunked == 0
+        req.check_finished()
+        assert req.finished(), f"Chunked abort did not finish request {req.rid}"
+        _complete_precision_trace(req)
+        self._release_prefill_host_buffer(req)
+        release_kv_cache(
+            req,
+            self.tree_cache,
+            is_insert=False,
+            allow_overallocated=(
+                self.spec_algorithm is not None and not self.spec_algorithm.is_none()
+            ),
+        )
+        self.chunked_reqs[dp_rank] = None
+        self._pending_chunked_abort_reqs[dp_rank] = None
 
     def maybe_collect_routed_experts(self: Scheduler, req: Req):
         """Collect routed experts for a finished request."""
@@ -183,21 +229,7 @@ class SchedulerOutputProcessorMixin:
                     req.check_finished()
                     if req.finished():
                         self.maybe_collect_routed_experts(req)
-                        if precision_tracer.get_trace_active():
-                            precision_tracer.set_request_status_to_completed(req.rid)
-                            precision_tracer.add_completed_requests_count()
-                            precision_tracer.set_end_time_and_duration(req.rid)
-                            logger.info(
-                                "Request trace completed (%d/%d): %s",
-                                precision_tracer.get_completed_requests_count(),
-                                precision_tracer.get_max_requests(),
-                                req.rid,
-                            )
-                            if (
-                                precision_tracer.get_completed_requests_count()
-                                >= precision_tracer.get_max_requests()
-                            ):
-                                precision_tracer.stop_trace()
+                        _complete_precision_trace(req)
                         release_kv_cache(
                             req,
                             self.tree_cache,
@@ -217,11 +249,11 @@ class SchedulerOutputProcessorMixin:
                         req.output_token_logprobs_idx.append(next_token_id)
 
                     if req.return_logprob:
-                        assert extend_logprob_start_len_per_req is not None
-                        assert extend_input_len_per_req is not None
-                        extend_logprob_start_len = extend_logprob_start_len_per_req[req_idx]
-                        extend_input_len = extend_input_len_per_req[req_idx]
-                        num_input_logprobs = extend_input_len - extend_logprob_start_len
+                        num_input_logprobs = _num_input_logprobs(
+                            req_idx,
+                            extend_input_len_per_req,
+                            extend_logprob_start_len_per_req,
+                        )
                         self.add_logprob_return_values(
                             req_idx,
                             req,
@@ -264,26 +296,42 @@ class SchedulerOutputProcessorMixin:
                 else:
                     # being chunked reqs' prefill is not finished
                     req.is_chunked -= 1
-                    # On dp>1, multiple reqs (one per dp rank) can be chunked
-                    # in the same batch; collect all so stream_output skips them.
-                    skip_stream_reqs.add(id(req))
-
-                    # Incrementally update input logprobs.
-                    if req.return_logprob:
-                        extend_logprob_start_len = extend_logprob_start_len_per_req[req_idx]
-                        extend_input_len = extend_input_len_per_req[req_idx]
-                        if extend_logprob_start_len < extend_input_len:
-                            # Update input logprobs.
-                            num_input_logprobs = extend_input_len - extend_logprob_start_len
-                            self.add_input_logprob_return_values(
+                    if self._pending_chunked_abort_reqs[dp_rank] is req:
+                        assert req.to_finish is not None
+                        if req.return_logprob:
+                            # An aborted partial prefill has no complete prompt logprobs to emit.
+                            req.input_logprob_sent = True
+                            num_input_logprobs = _num_input_logprobs(
                                 req_idx,
-                                req,
-                                logits_output,
-                                logprob_pt,
-                                num_input_logprobs,
-                                last_prefill_chunk=False,
+                                extend_input_len_per_req,
+                                extend_logprob_start_len_per_req,
                             )
-                            logprob_pt += num_input_logprobs
+                            if num_input_logprobs > 0:
+                                logprob_pt += num_input_logprobs
+                        self._finalize_chunked_abort(req, dp_rank)
+                    else:
+                        # On dp>1, multiple reqs (one per dp rank) can be chunked
+                        # in the same batch; collect all so stream_output skips them.
+                        skip_stream_reqs.add(id(req))
+
+                        # Incrementally update input logprobs.
+                        if req.return_logprob:
+                            num_input_logprobs = _num_input_logprobs(
+                                req_idx,
+                                extend_input_len_per_req,
+                                extend_logprob_start_len_per_req,
+                            )
+                            if num_input_logprobs > 0:
+                                # Update input logprobs.
+                                self.add_input_logprob_return_values(
+                                    req_idx,
+                                    req,
+                                    logits_output,
+                                    logprob_pt,
+                                    num_input_logprobs,
+                                    last_prefill_chunk=False,
+                                )
+                                logprob_pt += num_input_logprobs
                 req_idx += 1
 
         batch.cache_miss_count = cache_miss_count
@@ -461,22 +509,7 @@ class SchedulerOutputProcessorMixin:
                         # kv_allocated_len as the allocation upper bound and let
                         # release_kv_cache free the overallocated tail.
                         req.kv_committed_len -= 1
-                    # End trace for finished request
-                    if precision_tracer.get_trace_active():
-                        precision_tracer.set_request_status_to_completed(req.rid)
-                        precision_tracer.add_completed_requests_count()
-                        precision_tracer.set_end_time_and_duration(req.rid)
-                        logger.info(
-                            "Request trace completed (%d/%d): %s",
-                            precision_tracer.get_completed_requests_count(),
-                            precision_tracer.get_max_requests(),
-                            req.rid,
-                        )
-                        if (
-                            precision_tracer.get_completed_requests_count()
-                            >= precision_tracer.get_max_requests()
-                        ):
-                            precision_tracer.stop_trace()
+                    _complete_precision_trace(req)
                     release_kv_cache(
                         req,
                         self.tree_cache,

--- a/python/sgl_jax/test/test_scheduler_chunked_ownership.py
+++ b/python/sgl_jax/test/test_scheduler_chunked_ownership.py
@@ -1,0 +1,386 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from sgl_jax.srt.managers.io_struct import AbortReq, PauseGenerationReqInput
+from sgl_jax.srt.managers.schedule_batch import FINISH_ABORT, Req, ScheduleBatch
+from sgl_jax.srt.managers.scheduler import GenerationBatchResult, Scheduler
+from sgl_jax.srt.managers.scheduler_output_processor_mixin import (
+    SchedulerOutputProcessorMixin,
+)
+from sgl_jax.srt.sampling.sampling_params import SamplingParams
+
+
+class TestSchedulerChunkedOwnership(unittest.TestCase):
+    def _make_req(self, rid, fill_ids, prefix_indices, dp_rank=0, return_logprob=False):
+        req = Req(
+            rid=rid,
+            origin_input_text="",
+            origin_input_ids=fill_ids,
+            sampling_params=SamplingParams(max_new_tokens=8),
+            dp_rank=dp_rank,
+            eos_token_ids={2},
+            vocab_size=100,
+            return_logprob=return_logprob,
+        )
+        req.fill_ids = fill_ids
+        req.prefix_indices = prefix_indices
+        req.req_pool_idx = 6
+        return req
+
+    def _make_batch(self, reqs, chunked_reqs):
+        batch = ScheduleBatch.init_new(
+            reqs=reqs,
+            req_to_token_pool=None,
+            token_to_kv_pool_allocator=None,
+            tree_cache=None,
+            model_config=SimpleNamespace(vocab_size=100),
+            enable_overlap=False,
+            dp_size=len(reqs),
+            chunked_reqs=chunked_reqs,
+            mesh=None,
+            spec_algorithm=None,
+        )
+        batch.forward_mode = SimpleNamespace(is_extend=lambda: True)
+        batch.per_dp_bs_size = max((len(rank_reqs) for rank_reqs in reqs), default=0)
+        return batch
+
+    def _make_scheduler(self, reqs, active_reqs=None, batch_owners=None):
+        if isinstance(reqs, Req):
+            reqs = [[reqs]]
+        dp_size = len(reqs)
+        if active_reqs is None:
+            active_reqs = [None] * dp_size
+        elif isinstance(active_reqs, Req):
+            active_reqs = [active_reqs]
+        if batch_owners is None:
+            batch_owners = [rank_reqs[0] if rank_reqs else None for rank_reqs in reqs]
+
+        cached = []
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.dp_size = dp_size
+        scheduler.pd = ""
+        scheduler._engine_paused = False
+        scheduler.enable_overlap = False
+        scheduler.chunked_reqs = active_reqs
+        scheduler._pending_chunked_abort_reqs = [None] * dp_size
+        scheduler.last_batch = self._make_batch(reqs, batch_owners)
+        scheduler.cur_batch = scheduler.last_batch
+        scheduler.running_batch = self._make_batch([[] for _ in range(dp_size)], [None] * dp_size)
+        scheduler.tree_cache = SimpleNamespace(
+            cache_unfinished_req=lambda cached_req: cached.append(cached_req)
+        )
+        scheduler.spec_algorithm = None
+        scheduler.is_generation = True
+        scheduler.is_hybrid = False
+        scheduler.is_mixed_chunk = False
+        scheduler.waiting_queue = []
+        scheduler.grammar_queue = []
+        scheduler.disagg_prefill_queue = None
+        scheduler.disagg_prealloc_queue = None
+        scheduler.disagg_transfer_queue = None
+        scheduler._pd_pending_bootstrap = []
+        scheduler._pending_h2d = []
+        scheduler._comm_backend = None
+        scheduler.policy = SimpleNamespace(calc_priority=Mock())
+        scheduler.page_size = 1
+        scheduler.token_to_kv_pool_allocator = object()
+        scheduler.new_token_ratio = 0.5
+        scheduler.max_prefill_tokens = 8
+        scheduler.chunked_prefill_size = 2
+        scheduler.lora_paths = None
+        scheduler.send_to_tokenizer = SimpleNamespace(send_pyobj=Mock())
+        scheduler.send_to_detokenizer = SimpleNamespace(send_pyobj=Mock())
+        scheduler._release_prefill_host_buffer = Mock()
+        scheduler.set_next_batch_sampling_info_done = Mock()
+        scheduler.stream_output = Mock()
+        scheduler.skip_tokenizer_init = False
+        scheduler.stream_interval = 1
+        return scheduler, cached
+
+    def _make_prefill_result(self, next_token_ids, input_token_logprobs=None):
+        logits_output = SimpleNamespace(
+            next_token_logprobs=None,
+            input_token_logprobs=input_token_logprobs,
+            hidden_states=None,
+        )
+        batch_size = len(next_token_ids)
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=next_token_ids,
+            extend_input_len_per_req=[2] * batch_size,
+            extend_logprob_start_len_per_req=[0] * batch_size,
+            cache_miss_count=0,
+            bid=1,
+        )
+
+    def test_parked_chunk_without_new_kv_is_not_cached_again(self):
+        req = self._make_req("parked", [1, 2], [10, 11])
+        scheduler, cached = self._make_scheduler(req, active_reqs=req)
+
+        excluded = scheduler._prepare_chunked_reqs_to_exclude()
+
+        self.assertIs(excluded[0], req)
+        self.assertEqual(cached, [])
+
+    def test_conflicting_chunked_owner_is_rejected(self):
+        batch_req = self._make_req("batch", [1, 2, 3], [10, 11])
+        active_req = self._make_req("active", [4, 5, 6], [12, 13])
+        scheduler, _ = self._make_scheduler(batch_req, active_reqs=active_req)
+
+        with self.assertRaisesRegex(AssertionError, "Chunked request mismatch"):
+            scheduler._prepare_chunked_reqs_to_exclude()
+
+    def test_restoring_one_dp_rank_preserves_the_other_rank_owner(self):
+        req0 = self._make_req("rank-0", [1, 2, 3], [10, 11], dp_rank=0)
+        req1 = self._make_req("rank-1", [4, 5, 6], [12, 13], dp_rank=1)
+        scheduler, cached = self._make_scheduler([[req0], [req1]], active_reqs=[None, req1])
+
+        excluded = scheduler._prepare_chunked_reqs_to_exclude()
+        scheduler.last_batch.filter_batch(chunked_req_to_exclude=excluded)
+
+        self.assertEqual(scheduler.chunked_reqs, [req0, req1])
+        self.assertEqual(scheduler._pending_chunked_abort_reqs, [None, None])
+        self.assertIs(excluded[0], req0)
+        self.assertIs(excluded[1], req1)
+        self.assertTrue(scheduler.last_batch.is_empty())
+        self.assertEqual(req0.req_pool_idx, 6)
+        self.assertEqual(req1.req_pool_idx, 6)
+        self.assertEqual(cached, [req0, req1])
+
+    def test_final_chunk_stays_in_batch_without_creating_an_owner(self):
+        req = self._make_req("final", [1, 2, 3], [10, 11])
+        scheduler, cached = self._make_scheduler(req, batch_owners=[None])
+
+        excluded = scheduler._prepare_chunked_reqs_to_exclude()
+        scheduler.last_batch.filter_batch(chunked_req_to_exclude=excluded)
+
+        self.assertEqual(excluded, {})
+        self.assertEqual(scheduler.chunked_reqs, [None])
+        self.assertEqual(scheduler.last_batch.reqs_info[0].reqs, [req])
+        self.assertEqual(cached, [])
+
+    def test_abort_releases_parked_chunk_and_clears_owner(self):
+        req = self._make_req("parked", [1, 2, 3], [10, 11])
+        scheduler, cached = self._make_scheduler(req)
+
+        with patch(
+            "sgl_jax.srt.managers.scheduler_output_processor_mixin.release_kv_cache"
+        ) as release:
+            scheduler.abort_request(AbortReq(rid=req.rid))
+            self.assertIs(scheduler.chunked_reqs[0], req)
+            self.assertIs(scheduler._pending_chunked_abort_reqs[0], req)
+            release.assert_not_called()
+
+            excluded = scheduler._prepare_chunked_reqs_to_exclude()
+            self.assertIs(scheduler._pending_chunked_abort_reqs[0], req)
+            self.assertEqual(cached, [])
+            scheduler._process_pending_chunked_aborts()
+            scheduler.last_batch.filter_batch(chunked_req_to_exclude=excluded)
+
+        release.assert_called_once_with(
+            req,
+            scheduler.tree_cache,
+            is_insert=False,
+            allow_overallocated=False,
+        )
+        scheduler._release_prefill_host_buffer.assert_called_once_with(req)
+        sent = scheduler.send_to_tokenizer.send_pyobj.call_args.args[0]
+        self.assertEqual(sent.rid, req.rid)
+        self.assertEqual(scheduler.chunked_reqs, [None])
+        self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
+        self.assertEqual(scheduler.last_batch.reqs_info[0].reqs, [])
+
+    def test_pause_retires_consumed_chunk_owner_from_batch(self):
+        req = self._make_req("parked", [1, 2, 3], [10, 11])
+        scheduler, _ = self._make_scheduler(req, active_reqs=req)
+        scheduler.abort_request(AbortReq(rid=req.rid))
+
+        with patch("sgl_jax.srt.managers.scheduler_output_processor_mixin.release_kv_cache"):
+            scheduler.pause_generation(PauseGenerationReqInput(mode="in_place"))
+
+        self.assertEqual(scheduler.chunked_reqs, [None])
+        self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
+        self.assertEqual(scheduler.last_batch.reqs_info[0].reqs, [])
+        self.assertIsNone(scheduler.last_batch.reqs_info[0].chunked_req)
+        scheduler._sync_chunked_req_owners()
+        self.assertEqual(scheduler.chunked_reqs, [None])
+
+    def test_abort_consumes_parked_chunk_while_engine_is_paused(self):
+        req = self._make_req("parked", [1, 2, 3], [10, 11])
+        scheduler, _ = self._make_scheduler(req, active_reqs=req)
+        scheduler.pause_generation(PauseGenerationReqInput(mode="in_place"))
+
+        with patch(
+            "sgl_jax.srt.managers.scheduler_output_processor_mixin.release_kv_cache"
+        ) as release:
+            scheduler.abort_request(AbortReq(rid=req.rid))
+
+        release.assert_called_once()
+        scheduler._release_prefill_host_buffer.assert_called_once_with(req)
+        self.assertTrue(req.finished())
+        self.assertEqual(scheduler.chunked_reqs, [None])
+        self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
+        self.assertEqual(scheduler.last_batch.reqs_info[0].reqs, [])
+        self.assertIsNone(scheduler.last_batch.reqs_info[0].chunked_req)
+        self.assertEqual(scheduler.send_to_tokenizer.send_pyobj.call_count, 1)
+
+    def test_pending_abort_chunk_is_not_rescheduled(self):
+        req = self._make_req("inflight", [1, 2], [10, 11])
+        scheduler, _ = self._make_scheduler(req, active_reqs=req)
+        req.to_finish = FINISH_ABORT()
+        scheduler._pending_chunked_abort_reqs[0] = req
+        req.init_next_round_input = Mock()
+        adder = SimpleNamespace(
+            can_run_list={0: []},
+            pending_h2d=[],
+            new_chunked_reqs=[None],
+            add_chunked_req=Mock(),
+        )
+
+        with patch("sgl_jax.srt.managers.scheduler.PrefillAdder", return_value=adder):
+            self.assertIsNone(scheduler.get_new_batch_prefill())
+
+        req.init_next_round_input.assert_not_called()
+        adder.add_chunked_req.assert_not_called()
+        self.assertIs(scheduler.chunked_reqs[0], req)
+
+    def test_abort_finalizes_when_inflight_overlap_chunk_returns(self):
+        req = self._make_req("inflight", [1, 2], [10, 11], return_logprob=True)
+        scheduler, _ = self._make_scheduler(req, active_reqs=req)
+        scheduler.last_batch.return_logprob = True
+        scheduler.enable_overlap = True
+        req.is_chunked = 1
+        result = self._make_prefill_result([3])
+        scheduler.tp_worker = SimpleNamespace(
+            resolve_last_batch_result=Mock(return_value=(result.logits_output, [3], 0))
+        )
+
+        with (
+            patch(
+                "sgl_jax.srt.managers.scheduler_output_processor_mixin.release_kv_cache"
+            ) as release,
+            patch(
+                "sgl_jax.srt.managers.scheduler_output_processor_mixin._complete_precision_trace"
+            ) as complete_trace,
+        ):
+            scheduler.abort_request(AbortReq(rid=req.rid))
+            self.assertIsNotNone(req.to_finish)
+            self.assertIs(scheduler._pending_chunked_abort_reqs[0], req)
+            release.assert_not_called()
+            complete_trace.assert_not_called()
+
+            scheduler._process_pending_chunked_aborts()
+            release.assert_not_called()
+
+            SchedulerOutputProcessorMixin.process_batch_result_prefill(
+                scheduler, scheduler.last_batch, result
+            )
+
+        self.assertTrue(req.finished())
+        self.assertIsNone(req.to_finish)
+        self.assertEqual(req.is_chunked, 0)
+        release.assert_called_once_with(
+            req,
+            scheduler.tree_cache,
+            is_insert=False,
+            allow_overallocated=False,
+        )
+        scheduler._release_prefill_host_buffer.assert_called_once_with(req)
+        self.assertEqual(scheduler.chunked_reqs, [None])
+        self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
+        skip_reqs = scheduler.stream_output.call_args.args[3]
+        self.assertNotIn(id(req), skip_reqs)
+        self.assertTrue(req.input_logprob_sent)
+
+        SchedulerOutputProcessorMixin.stream_output_generation(
+            scheduler,
+            [req],
+            return_logprob=True,
+            return_output_logprob_only=False,
+        )
+
+        sent = scheduler.send_to_detokenizer.send_pyobj.call_args.args[0]
+        self.assertEqual(sent.rids, [req.rid])
+        self.assertEqual(sent.input_token_logprobs_val, [[]])
+        self.assertEqual(sent.input_token_logprobs_idx, [[]])
+        complete_trace.assert_called_once_with(req)
+
+    def test_aborted_dp_chunk_advances_logprob_cursor_for_later_rank(self):
+        aborted_req = self._make_req("aborted", [1, 2], [10], dp_rank=0, return_logprob=True)
+        live_req = self._make_req("live", [3, 4], [11], dp_rank=1, return_logprob=True)
+        batch = self._make_batch([[aborted_req], [live_req]], [aborted_req, live_req])
+        for info in batch.reqs_info:
+            info.extend_lens = [2]
+            info.extend_logprob_start_lens = [0]
+
+        scheduler, _ = self._make_scheduler(
+            [[aborted_req], [live_req]], active_reqs=[aborted_req, live_req]
+        )
+        aborted_req.is_chunked = 1
+        aborted_req.to_finish = FINISH_ABORT()
+        scheduler._pending_chunked_abort_reqs[0] = aborted_req
+        live_req.is_chunked = 1
+        result = self._make_prefill_result([5, 6], input_token_logprobs=(0.1, 0.2, 0.3, 0.4))
+
+        with patch("sgl_jax.srt.managers.scheduler_output_processor_mixin.release_kv_cache"):
+            SchedulerOutputProcessorMixin.process_batch_result_prefill(scheduler, batch, result)
+
+        self.assertEqual(live_req.input_token_logprobs, [0.3, 0.4])
+
+    def test_pd_prefill_result_makes_middle_chunk_abort_releasable(self):
+        req = self._make_req("pd-inflight", [1, 2], [10], return_logprob=False)
+        req.bootstrap_room = 0
+        req.is_chunked = 1
+        scheduler, _ = self._make_scheduler(req, active_reqs=req)
+        scheduler.pd = "prefill"
+        scheduler.server_args = SimpleNamespace(enable_request_time_stats_logging=False)
+
+        scheduler.process_prefill_chunk(scheduler.last_batch, SimpleNamespace())
+
+        self.assertEqual(req.is_chunked, 0)
+        scheduler.abort_request(AbortReq(rid=req.rid))
+        with patch(
+            "sgl_jax.srt.managers.scheduler_output_processor_mixin.release_kv_cache"
+        ) as release:
+            scheduler._process_pending_chunked_aborts()
+
+        release.assert_called_once()
+        self.assertTrue(req.finished())
+        self.assertEqual(scheduler.chunked_reqs, [None])
+        self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
+
+    def test_retract_requeues_parked_chunk_after_releasing_allocation(self):
+        req = self._make_req("parked", [1, 2], [10, 11])
+        scheduler, _ = self._make_scheduler(req, active_reqs=req)
+
+        with patch("sgl_jax.srt.managers.scheduler.release_kv_cache") as release:
+            scheduler._retract_parked_chunked_reqs([])
+
+        release.assert_called_once_with(
+            req,
+            scheduler.tree_cache,
+            is_insert=False,
+            allow_overallocated=False,
+        )
+        scheduler._release_prefill_host_buffer.assert_called_once_with(req)
+        self.assertEqual(scheduler.waiting_queue, [req])
+        self.assertTrue(req.is_retracted)
+        self.assertEqual(scheduler.chunked_reqs, [None])
+        self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
+
+    def test_retract_does_not_release_batch_owned_chunk_twice(self):
+        req = self._make_req("active", [1, 2], [10, 11])
+        scheduler, _ = self._make_scheduler(req, active_reqs=req)
+
+        with patch("sgl_jax.srt.managers.scheduler.release_kv_cache") as release:
+            scheduler._retract_parked_chunked_reqs([req])
+
+        release.assert_not_called()
+        self.assertEqual(scheduler.waiting_queue, [])
+        self.assertEqual(scheduler.chunked_reqs, [None])
+        self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sgl_jax/test/test_scheduler_idle_check.py
+++ b/python/sgl_jax/test/test_scheduler_idle_check.py
@@ -1,0 +1,84 @@
+import unittest
+
+from sgl_jax.srt.managers.scheduler import Scheduler
+
+
+class _Batch:
+    reqs_info = []
+
+    def __init__(self, empty):
+        self.empty = empty
+
+    def is_empty(self):
+        return self.empty
+
+    def batch_size(self):
+        return 0 if self.empty else 1
+
+
+class TestSchedulerIdleCheck(unittest.TestCase):
+    def _make_scheduler(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.waiting_queue = []
+        scheduler.grammar_queue = []
+        scheduler.pending_dp_reqs = []
+        scheduler.running_batch = _Batch(empty=True)
+        scheduler.cur_batch = None
+        scheduler.last_batch = None
+        scheduler.chunked_reqs = [None, None]
+        scheduler.enable_overlap = False
+        scheduler.disagg_prefill_queue = None
+        scheduler.disagg_prealloc_queue = None
+        scheduler.disagg_transfer_queue = None
+        scheduler._pd_pending_bootstrap = []
+        scheduler.pd = ""
+        scheduler.init_new_token_ratio = 0.75
+        scheduler.new_token_ratio = 0.25
+        scheduler.calls = []
+        scheduler.check_memory = lambda: scheduler.calls.append("memory")
+        scheduler.check_tree_cache = lambda: scheduler.calls.append("tree")
+        return scheduler
+
+    def test_idle_check_skips_pending_work(self):
+        cases = [
+            ("waiting_queue", lambda s: s.waiting_queue.append(object())),
+            ("grammar_queue", lambda s: s.grammar_queue.append(object())),
+            ("pending_dp_reqs", lambda s: s.pending_dp_reqs.append(object())),
+            ("running_batch", lambda s: setattr(s, "running_batch", _Batch(empty=False))),
+            ("cur_batch", lambda s: setattr(s, "cur_batch", _Batch(empty=False))),
+            ("last_batch", lambda s: setattr(s, "last_batch", _Batch(empty=False))),
+            ("chunked_reqs", lambda s: s.chunked_reqs.__setitem__(1, object())),
+            (
+                "result_queue",
+                lambda s: (
+                    setattr(s, "enable_overlap", True),
+                    setattr(s, "result_queue", [object()]),
+                ),
+            ),
+            ("disagg_prefill_queue", lambda s: setattr(s, "disagg_prefill_queue", [object()])),
+            ("disagg_prealloc_queue", lambda s: setattr(s, "disagg_prealloc_queue", [object()])),
+            ("disagg_transfer_queue", lambda s: setattr(s, "disagg_transfer_queue", [object()])),
+            ("pd_pending_bootstrap", lambda s: s._pd_pending_bootstrap.append(object())),
+        ]
+
+        for name, setup in cases:
+            with self.subTest(name=name):
+                scheduler = self._make_scheduler()
+                setup(scheduler)
+
+                scheduler.on_idle()
+
+                self.assertEqual(scheduler.calls, [])
+                self.assertEqual(scheduler.new_token_ratio, 0.25)
+
+    def test_idle_check_runs_when_fully_idle(self):
+        scheduler = self._make_scheduler()
+
+        scheduler.on_idle()
+
+        self.assertEqual(scheduler.calls, ["memory", "tree"])
+        self.assertEqual(scheduler.new_token_ratio, scheduler.init_new_token_ratio)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -306,6 +306,8 @@ suites = {
             0.2,
             runner="pytest",
         ),
+        TestFile("python/sgl_jax/test/test_scheduler_idle_check.py", 0.1),
+        TestFile("python/sgl_jax/test/test_scheduler_chunked_ownership.py", 0.1),
         TestFile("test/srt/test_dtype_config_llama.py", 1),
         TestFile("test/srt/test_dtype_config_consistency.py", 10),
         TestFile("python/sgl_jax/test/test_compilation_manager.py", 1),
@@ -424,7 +426,7 @@ suites = {
     "e2e-test-tpu-v6e-4": [
         TestFile("test/srt/openai_server/basic/test_tool_calls.py", 2),
         TestFile("test/srt/test_features.py", 3),
-        TestFile("test/srt/test_chunked_prefill_size.py", 2),
+        TestFile("test/srt/test_chunked_prefill_size.py", 6),
         # TestFile("test/srt/test_sliding_window_attention.py", 30), # add after gpt-oss supported
         TestFile("test/srt/test_logprobs_dp.py", 3),
         TestFile("test/srt/test_model_loader.py", 1),

--- a/test/srt/test_chunked_prefill_size.py
+++ b/test/srt/test_chunked_prefill_size.py
@@ -1,6 +1,9 @@
+import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
+import requests
 from run_eval import run_eval
 
 from sgl_jax.srt.utils import kill_process_tree
@@ -63,6 +66,162 @@ class TestChunkedPrefillSize(CustomTestCase):
 
         metrics = run_eval(args)
         self.assertGreater(metrics["score"], 0.5)
+
+
+class TestChunkedPrefillAbortPressure(CustomTestCase):
+    output_tokens = 8
+    page_size = 64
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            device="tpu",
+            check_cache_miss=False,
+            other_args=[
+                "--trust-remote-code",
+                "--skip-server-warmup",
+                "--tp",
+                "4",
+                "--dp-size",
+                "2",
+                "--random-seed",
+                "3",
+                "--mem-fraction-static",
+                "0.8",
+                "--download-dir",
+                "/dev/shm",
+                "--dtype",
+                "bfloat16",
+                "--max-running-requests",
+                "8",
+                "--max-total-tokens",
+                "4096",
+                "--chunked-prefill-size",
+                "128",
+                "--page-size",
+                str(cls.page_size),
+                "--disable-radix-cache",
+                "--enable-mixed-chunk",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _state(self):
+        response = requests.get(self.base_url + "/get_server_info", timeout=10)
+        response.raise_for_status()
+        return response.json()["internal_states"][0]
+
+    def _generate(self, rid, input_ids):
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "rid": rid,
+                "input_ids": input_ids,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": self.output_tokens,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=180,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _wait_for_state(self, predicate, timeout):
+        deadline = time.monotonic() + timeout
+        state = None
+        while time.monotonic() < deadline:
+            try:
+                state = self._state()
+            except requests.RequestException:
+                time.sleep(0.05)
+                continue
+            if predicate(state):
+                return state
+            time.sleep(0.05)
+        self.fail(f"scheduler did not reach the expected state: {state}")
+
+    def test_stress_abort_recovers_chunked_owners_and_capacity(self):
+        initial = self._wait_for_state(
+            lambda state: state["waiting_queue_size"] == 0
+            and state["pending_dp_reqs_size"] == 0
+            and state["running_batch_size"] == 0
+            and state["chunked_req_is_none"]
+            and state["req_to_token_pool_available"] == state["req_to_token_pool_total"],
+            timeout=30,
+        )
+        token_capacity = initial["available_kv_tokens_per_dp"]
+        paged_prompt_len = (min(token_capacity) // self.page_size - 3) * self.page_size
+        prompt_len = paged_prompt_len - self.page_size // 2
+        self.assertGreater(prompt_len, 128)
+        base = [151646, 151644, 30021, 19131, 6133, 151645, 151648, 198]
+        prompt = (base * ((prompt_len + len(base) - 1) // len(base)))[:prompt_len]
+
+        warm_up = self._generate("chunked-pressure-warm-up", prompt)
+        self.assertEqual(warm_up["meta_info"]["finish_reason"]["type"], "length")
+        self._wait_for_state(
+            lambda state: state["req_to_token_pool_available"] == state["req_to_token_pool_total"]
+            and state["available_kv_tokens_per_dp"] == token_capacity,
+            timeout=30,
+        )
+
+        req_capacity = initial["req_to_token_pool_total"]
+        rids = [f"chunked-pressure-{i:02d}" for i in range(12)]
+
+        with ThreadPoolExecutor(max_workers=len(rids)) as executor:
+            futures = {rid: executor.submit(self._generate, rid, prompt) for rid in rids}
+            pressure_state = self._wait_for_state(
+                lambda state: sum(rid is not None for rid in state["chunked_req_rids"]) == 2
+                and state["waiting_queue_size"] + state["pending_dp_reqs_size"] > 0
+                and all(
+                    available <= capacity // 2
+                    for available, capacity in zip(
+                        state["available_kv_tokens_per_dp"], token_capacity
+                    )
+                ),
+                timeout=120,
+            )
+            aborted_rids = [rid for rid in pressure_state["chunked_req_rids"] if rid is not None]
+            for rid in aborted_rids:
+                response = requests.post(
+                    self.base_url + "/abort_request", json={"rid": rid}, timeout=10
+                )
+                response.raise_for_status()
+
+            outputs = {rid: future.result(timeout=180) for rid, future in futures.items()}
+
+        for rid in aborted_rids:
+            self.assertEqual(outputs[rid]["meta_info"]["finish_reason"]["type"], "abort")
+            self.assertEqual(outputs[rid]["output_ids"], [])
+
+        live_outputs = [outputs[rid] for rid in rids if rid not in aborted_rids]
+        self.assertTrue(live_outputs)
+        for output in live_outputs:
+            self.assertEqual(output["meta_info"]["finish_reason"]["type"], "length")
+            self.assertEqual(len(output["output_ids"]), self.output_tokens)
+
+        self._wait_for_state(
+            lambda state: state["waiting_queue_size"] == 0
+            and state["pending_dp_reqs_size"] == 0
+            and state["running_batch_size"] == 0
+            and state["chunked_req_is_none"]
+            and state["req_to_token_pool_available"] == req_capacity
+            and state["available_kv_tokens_per_dp"] == token_capacity,
+            timeout=30,
+        )
+
+        follow_up = self._generate("chunked-pressure-follow-up", prompt)
+        self.assertEqual(follow_up["meta_info"]["finish_reason"]["type"], "length")
+        self.assertEqual(len(follow_up["output_ids"]), self.output_tokens)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fix chunked-prefill requests losing their scheduler owner when an intermediate extend batch is filtered.

- Restore one canonical owner per DP rank before filtering.
- Track pending aborts with the owned request and stop scheduling further chunks.
- Let the consumer of an in-flight result finish logprob and trace bookkeeping before releasing host, KV, and request-pool resources.
- Keep parked abort and retract cleanup explicit, while preserving normal intermediate and final chunk behavior.

Addresses Problem 2 in #1400.

This covers the standard scheduler and multi-process PD paths. `pd == "pathways"` keeps its separate per-P lifecycle and event loop and is intentionally not covered by this change.

## Lifecycle

Before:

1. An intermediate chunk returned with KV and a request slot still allocated.
2. `filter_batch()` excluded it from the completed extend batch.
3. If `scheduler.chunked_reqs` had lost the pointer, the live request became unreachable: no next chunk could be scheduled and abort or retract could not release it.

After:

1. Before filtering, the scheduler restores `last_batch.reqs_info[dp_rank].chunked_req` as the canonical per-DP owner.
2. A non-aborted owner is cached only when it has new KV beyond its matched prefix and remains eligible for its next chunk.
3. A parked abort is released at the scheduler boundary. An overlap in-flight abort is marked pending and is not rescheduled; its result consumer drains the chunk, advances the shared logprob cursor, completes tracing, and then releases the PD host buffer, KV cache, request slot, and owner exactly once.
4. Standard PD-prefill decrements the existing `req.is_chunked` in-flight state in its own result path, so a pending abort is finalized only after that consumer returns.

## Validation

- Focused ownership, overlap-abort, idle-state, and mixed-DP tests: 15 passed plus 12 subtests.
- Standard PD-prefill unit tests: 64 passed.
- Added a registered DP=2 overlap stress test that drives both DP KV pools past 50% utilization under concurrent chunked requests, aborts both active owners, verifies terminal results and full resource recovery, and then sends a follow-up chunked request.
- Falcon `exp-h6189qgrzb` compared the exact PR base `91399b4` and head `be3652f` sequentially on the same v6e-4 worker with TP=4, DP=2, overlap enabled, chunk size 128, and 12 concurrent 3,872-token prompts. Across three post-warmup runs, median input throughput was 20,707 versus 20,579 tokens/s (-0.62%), and median batch time was 2.244 versus 2.258 seconds (+0.62%); no material performance regression was observed.
- In three current-head abort-pressure runs from the same experiment, both active owners returned terminal abort results, all KV and request slots were restored, and the follow-up request completed every time. Median/max terminal abort latency was 17.0/17.1 ms, median full workload-drain and recovery time was 1.929 seconds, and median follow-up latency was 317.4 ms.
- `pre-commit run --all-files` passed.
