### PR TITLE
fix(recurrent): stabilize CoW and Track JIT structure

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -740,20 +740,17 @@ class ScheduleReqsInfo:
     # Recurrent state indices for hybrid recurrent models (per DP)
     recurrent_indices: np.ndarray | None = None
 
-    # Recurrent CoW src slot per req (0 = no clone), per DP
+    # Recurrent CoW src slot per req (0 = no clone), per DP.
     recurrent_cow_src_indices: np.ndarray | None = None
 
-    # Recurrent track metadata per DP (extra-buffer; set only on a track boundary).
+    # Recurrent track metadata per DP (extra-buffer; mask 0 = no boundary).
     recurrent_track_indices: np.ndarray | None = None
     recurrent_track_mask: np.ndarray | None = None
 
 
-def _build_recurrent_cow_src_indices(reqs: list[Req]) -> np.ndarray | None:
-    """None when no clone is pending, so cold extends skip the donated-buffer
-    CoW scatter in _maybe_apply_recurrent_cow."""
+def _build_recurrent_cow_src_indices(reqs: list[Req]) -> np.ndarray:
+    """Build fixed-shape CoW metadata; zero means no clone for that request."""
     vals = [r.recurrent_cow_src_index or 0 for r in reqs]
-    if not any(vals):
-        return None
     return np.asarray(vals, dtype=np.int32)
 
 
@@ -787,10 +784,7 @@ def _recurrent_track_entry(
 def _build_recurrent_track_entries(
     reqs: list[Req], final_seq_lens: list[int], *, interval: int, pool, is_extend: bool
 ):
-    """Two np.int32 arrays (indices, mask as 0/1) aligned with ``reqs``, or
-    ``(None, None)`` when no req hits a boundary -- mirroring
-    ``_build_recurrent_cow_src_indices``'s one-shot None return so the backend
-    skips the snapshot path entirely on a boundary-free batch."""
+    """Build fixed-shape track indices and a 0/1 boundary mask."""
     indices: list[int] = []
     mask: list[int] = []
     for req, final_seq_len in zip(reqs, final_seq_lens):
@@ -799,8 +793,6 @@ def _build_recurrent_track_entries(
         )
         indices.append(entry.track_index)
         mask.append(1 if entry.track_mask else 0)
-    if not any(mask):
-        return None, None
     return (
         np.asarray(indices, dtype=np.int32),
         np.asarray(mask, dtype=np.int32),
@@ -2969,12 +2961,6 @@ class ScheduleBatch:
                 info.recurrent_cow_src_indices = None
                 for r in info.reqs or []:
                     r.recurrent_cow_src_index = None
-            if (
-                recurrent_cow_src_indices_cpu is not None
-                and not recurrent_cow_src_indices_cpu.any()
-            ):
-                recurrent_cow_src_indices_cpu = None
-
         # Merge recurrent track metadata (extra-buffer; see ScheduleReqsInfo).
         recurrent_track_indices_cpu = None
         recurrent_track_mask_cpu = None
@@ -2998,11 +2984,6 @@ class ScheduleBatch:
             for info in self.reqs_info:
                 info.recurrent_track_indices = None
                 info.recurrent_track_mask = None
-            # No boundary this batch: None skips the snapshot path entirely.
-            if not recurrent_track_mask_cpu.any():
-                recurrent_track_indices_cpu = None
-                recurrent_track_mask_cpu = None
-
         # has_initial_state[i] = True iff slot i already holds
         # prior KV/recurrent state (extend with prefix, or any decode slot).
         has_initial_state_cpu = np.ones(total_bs, dtype=np.bool_)

--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -260,6 +260,7 @@ class ModelWorker:
         # precompile
         from sgl_jax.srt.model_executor.compilation_manager import CompilationManager
 
+        has_recurrent_state = self.model_runner.linear_recurrent_config is not None
         self.compilation_manager = CompilationManager(
             server_args=server_args,
             max_padded_batch_size=self.max_padded_batch_size,
@@ -278,7 +279,15 @@ class ModelWorker:
                 self.max_total_num_tokens if os.getenv("JAX_PLATFORMS") == "proxy" else 0
             ),
             multimodal=server_args.multimodal,
-            has_recurrent_state=self.model_runner.linear_recurrent_config is not None,
+            has_recurrent_state=has_recurrent_state,
+            supports_recurrent_cow=(
+                has_recurrent_state
+                and server_args.enable_unified_radix_tree
+                and not server_args.disable_radix_cache
+            ),
+            supports_recurrent_track=(
+                has_recurrent_state and server_args.enable_recurrent_extra_buffer
+            ),
             moe_backend=effective_moe_backend,
         )
 

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -37,6 +37,8 @@ class CompilationManager:
         max_total_num_tokens: int = 0,
         multimodal: bool = False,
         has_recurrent_state: bool = False,
+        supports_recurrent_cow: bool = False,
+        supports_recurrent_track: bool = False,
         moe_backend: str | None = None,
     ):
         self.dp_size = dp_size
@@ -49,6 +51,8 @@ class CompilationManager:
         self.vocab_size = vocab_size
         self.multimodal = multimodal
         self.has_recurrent_state = has_recurrent_state
+        self.supports_recurrent_cow = supports_recurrent_cow
+        self.supports_recurrent_track = supports_recurrent_track
         # Callers pass the *effective* backend (ModelConfig.moe_backend), which
         # resolves architectures that hard-code FusedEPMoE (e.g. Qwen3.5) to
         # "fused" so the bs-bucket filter below applies. Fall back to the raw
@@ -349,6 +353,17 @@ class CompilationManager:
             # non-recurrent backends are unaffected.
             recurrent_indices=(np.zeros(bs, dtype=np.int32) if self.has_recurrent_state else None),
             has_initial_state=(np.zeros(bs, dtype=np.bool_) if self.has_recurrent_state else None),
+            recurrent_cow_src_indices=(
+                np.zeros(bs, dtype=np.int32)
+                if self.supports_recurrent_cow and mode == ForwardMode.EXTEND
+                else None
+            ),
+            recurrent_track_indices=(
+                np.zeros(bs, dtype=np.int32) if self.supports_recurrent_track else None
+            ),
+            recurrent_track_mask=(
+                np.zeros(bs, dtype=np.int32) if self.supports_recurrent_track else None
+            ),
         )
 
     # ---- Lazy compilation tracking ----

--- a/python/sgl_jax/test/test_compilation_manager.py
+++ b/python/sgl_jax/test/test_compilation_manager.py
@@ -1,5 +1,7 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import numpy as np
 
 from sgl_jax.srt.model_executor.compilation_manager import CompilationManager
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
@@ -42,6 +44,55 @@ def _make_server_args(**overrides):
     for k, v in overrides.items():
         setattr(args, k, v)
     return args
+
+
+def _make_precompile_manager(
+    *,
+    page_size=128,
+    has_recurrent_state=False,
+    supports_recurrent_cow=False,
+    supports_recurrent_track=False,
+):
+    return CompilationManager(
+        server_args=_make_server_args(
+            precompile_token_paddings=[4, 8],
+            precompile_bs_paddings=[2, 4],
+        ),
+        max_padded_batch_size=4,
+        max_padded_num_tokens=8,
+        dp_size=1,
+        tp_size=1,
+        page_size=page_size,
+        max_req_len=8,
+        vocab_size=32,
+        has_recurrent_state=has_recurrent_state,
+        supports_recurrent_cow=supports_recurrent_cow,
+        supports_recurrent_track=supports_recurrent_track,
+    )
+
+
+def _collect_precompile_batches(cm, mode):
+    batches = []
+
+    def forward_fn(batch, **_kwargs):
+        batches.append(batch)
+
+    with (
+        patch(
+            "sgl_jax.srt.model_executor.forward_batch_info.ForwardBatch.init_new",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "sgl_jax.srt.sampling.sampling_batch_info." "SamplingMetadata.from_model_worker_batch",
+            return_value=MagicMock(),
+        ),
+    ):
+        if mode == ForwardMode.EXTEND:
+            cm._precompile_extend(forward_fn, MagicMock(), MagicMock(), None, None)
+        else:
+            cm._precompile_decode(forward_fn, MagicMock(), MagicMock(), None, None)
+
+    return batches
 
 
 class TestBucketComputation(unittest.TestCase):
@@ -207,6 +258,81 @@ class TestLazyCompilation(unittest.TestCase):
         assert cm.register_variant_if_new(key1) is True
         assert cm.register_variant_if_new(key2) is True
         assert cm.register_variant_if_new(key1) is False
+
+
+class TestRecurrentPrecompileStructure(unittest.TestCase):
+    @staticmethod
+    def _presence(batch):
+        return (
+            batch.recurrent_cow_src_indices is not None,
+            batch.recurrent_track_indices is not None,
+        )
+
+    def test_non_recurrent_preserves_original_structure(self):
+        cm = _make_precompile_manager()
+
+        extend_batches = _collect_precompile_batches(cm, ForwardMode.EXTEND)
+        decode_batches = _collect_precompile_batches(cm, ForwardMode.DECODE)
+
+        assert len(extend_batches) == len(cm.token_buckets)
+        assert len(decode_batches) == len(cm.bs_buckets)
+        assert all(self._presence(batch) == (False, False) for batch in extend_batches)
+        assert all(self._presence(batch) == (False, False) for batch in decode_batches)
+
+    def test_recurrent_without_capabilities_preserves_original_structure(self):
+        cm = _make_precompile_manager(has_recurrent_state=True)
+
+        extend_batches = _collect_precompile_batches(cm, ForwardMode.EXTEND)
+        decode_batches = _collect_precompile_batches(cm, ForwardMode.DECODE)
+
+        assert len(extend_batches) == len(cm.token_buckets)
+        assert len(decode_batches) == len(cm.bs_buckets)
+        assert all(self._presence(batch) == (False, False) for batch in extend_batches)
+        assert all(self._presence(batch) == (False, False) for batch in decode_batches)
+
+    def test_page_size_one_recurrent_uses_fixed_extend_cow_structure(self):
+        cm = _make_precompile_manager(
+            page_size=1,
+            has_recurrent_state=True,
+            supports_recurrent_cow=True,
+        )
+
+        extend_batches = _collect_precompile_batches(cm, ForwardMode.EXTEND)
+        decode_batches = _collect_precompile_batches(cm, ForwardMode.DECODE)
+
+        assert len(extend_batches) == len(cm.token_buckets)
+        assert len(decode_batches) == len(cm.bs_buckets)
+        assert all(self._presence(batch) == (True, False) for batch in extend_batches)
+        assert all(self._presence(batch) == (False, False) for batch in decode_batches)
+
+    def test_extra_buffer_uses_one_fixed_structure_per_mode(self):
+        cm = _make_precompile_manager(
+            has_recurrent_state=True,
+            supports_recurrent_cow=True,
+            supports_recurrent_track=True,
+        )
+
+        extend_batches = _collect_precompile_batches(cm, ForwardMode.EXTEND)
+        decode_batches = _collect_precompile_batches(cm, ForwardMode.DECODE)
+
+        assert len(extend_batches) == len(cm.token_buckets)
+        assert len(decode_batches) == len(cm.bs_buckets)
+        assert all(self._presence(batch) == (True, True) for batch in extend_batches)
+        assert all(self._presence(batch) == (False, True) for batch in decode_batches)
+
+        for batch in extend_batches + decode_batches:
+            for value in (
+                batch.recurrent_cow_src_indices,
+                batch.recurrent_track_indices,
+                batch.recurrent_track_mask,
+            ):
+                if value is not None:
+                    assert value.shape == (batch.real_bs,)
+                    assert value.dtype == np.int32
+            assert (batch.recurrent_track_indices is None) == (batch.recurrent_track_mask is None)
+
+        assert all(batch.recurrent_cow_src_indices is None for batch in decode_batches)
+        assert all(len(key) == 4 for key in cm._compiled_variants)
 
 
 class TestDummyBatch(unittest.TestCase):

--- a/test/srt/test_recurrent_cow_metadata.py
+++ b/test/srt/test_recurrent_cow_metadata.py
@@ -1,5 +1,4 @@
-"""_build_recurrent_cow_src_indices must return None (not an all-zero array)
-when no clone is pending, so cold extends skip the donated-buffer CoW scatter."""
+"""CoW metadata keeps a stable array structure while zero remains the no-op sentinel."""
 
 import unittest
 from unittest.mock import MagicMock
@@ -17,11 +16,13 @@ def _req(rid, cow_src=None):
 
 
 class TestBuildRecurrentCowSrcIndices(unittest.TestCase):
-    def test_all_zero_returns_none(self):
-        self.assertIsNone(_build_recurrent_cow_src_indices([_req(0), _req(1)]))
+    def test_all_zero_returns_array(self):
+        out = _build_recurrent_cow_src_indices([_req(0), _req(1)])
+        np.testing.assert_array_equal(out, np.zeros(2, dtype=np.int32))
 
-    def test_empty_returns_none(self):
-        self.assertIsNone(_build_recurrent_cow_src_indices([]))
+    def test_empty_returns_array(self):
+        out = _build_recurrent_cow_src_indices([])
+        np.testing.assert_array_equal(out, np.empty(0, dtype=np.int32))
 
     def test_mixed_returns_array(self):
         out = _build_recurrent_cow_src_indices([_req(0, 0), _req(1, 7)])

--- a/test/srt/test_recurrent_track_metadata.py
+++ b/test/srt/test_recurrent_track_metadata.py
@@ -1,7 +1,6 @@
 """recurrent_track_indices / recurrent_track_mask must ride the same plumbing as
 recurrent_cow_src_indices (scheduler -> ModelWorkerBatch -> ForwardBatch -> backend
-metadata) in lockstep: populated only on a track boundary, distinct sentinels catch
-swapped fields, None round-trips to None."""
+metadata) in lockstep; distinct sentinels catch swapped fields."""
 
 import unittest
 
@@ -158,15 +157,16 @@ class TestRecurrentTrackEntryBuilder(unittest.TestCase):
         self.assertEqual(req.recurrent_next_track_idx, 0)
         self.assertEqual(req.recurrent_last_track_seqlen, 128)
 
-    def test_builder_none_when_no_boundary(self):
+    def test_builder_returns_zero_arrays_when_no_boundary(self):
         reqs = [
             _FakeReq(extend_input_len=100, buffer=[40, 41]),
             _FakeReq(extend_input_len=50, buffer=[42, 43]),
         ]
-        out = _build_recurrent_track_entries(
+        indices, mask = _build_recurrent_track_entries(
             reqs, [200, 150], interval=128, pool=_PingPongPool(), is_extend=True
         )
-        self.assertEqual(out, (None, None))
+        np.testing.assert_array_equal(indices, np.zeros(2, dtype=np.int32))
+        np.testing.assert_array_equal(mask, np.zeros(2, dtype=np.int32))
         # No req mutated when nothing hit a boundary.
         self.assertTrue(all(r.recurrent_last_track_seqlen is None for r in reqs))
 


### PR DESCRIPTION
Fixes serving-time JIT misses caused by recurrent CoW/Track metadata changing between `None` and arrays. This is the JIT-structure prerequisite for the performance coverage in #1477 and the performance portion of #1425.

## Problem

Three recurrent metadata fields are optional:

- `recurrent_cow_src_indices`
- `recurrent_track_indices`
- `recurrent_track_mask`

Previously, a batch without CoW or a Track boundary used `None`, while a batch performing the operation used arrays. `None` and arrays are different JAX PyTree structures, so the first real cache hit or Track boundary compiled a new executable on the serving path. This added a 30–32 second request-latency spike and failed the cache-miss check.

Precompiling every presence/absence combination removes the serving miss, but increases this profile from 3 executables to 8 and substantially delays server readiness.

## Approach

Whether a server supports recurrent CoW or Track is already known at startup, so the metadata structure is decided once per server:

```text
capability disabled -> None for the server lifetime
capability enabled  -> fixed int32 arrays; zero values mean no-op
```

Concretely:

- CoW-enabled EXTEND batches always carry a source-index array; `0` means no clone.
- Track-enabled EXTEND and DECODE batches always carry index and mask arrays; a zero mask means no boundary.
- Real CoW/Track work changes only array values, not the PyTree structure.
- `CompilationManager` creates dummy batches with the same capability-derived structure as runtime batches.
- Each existing shape bucket is compiled once; no presence/absence matrix is added.

This keeps non-recurrent and capability-disabled servers unchanged.

## Result

The same Qwen3.5-35B-A3B TP4 extra-buffer profile was used throughout.

| Implementation | Executables | Cold startup | Warm startup | First CoW/Track request |
|---|---:|---:|---:|---:|
| all-`None` precompile | 3 | 106.86 s | 53.93 s | 30–32 s JIT miss |
| presence matrix | 8 | 237.77 s | 85.53 s | no miss |
| fixed metadata | 3 | 112.0 s | 54.6 s | no miss |

Real shared-prefix requests reported 2048/4096 cached tokens, confirming that the CoW path was exercised without a serving-time JIT miss.

Fixed metadata restores the original executable count and startup cost. The trade-off is a small steady-state cost from carrying the masked no-op path on enabled servers: approximately 1.6% GSP throughput and 0.9% random-workload throughput versus the presence-matrix revision. Both remain within the 2% nightly gates in #1477.

## Tests

- recurrent compilation/metadata tests: 42 passed locally and on TPU
- repo-pinned pre-commit hooks passed
- full PR CI passed

No user-visible flag, recurrent cache semantics, or memory sizing is changed.
