### PR TITLE
test(recurrent): add nightly performance coverage

### DIFF
--- a/test/srt/nightly/cases.py
+++ b/test/srt/nightly/cases.py
@@ -13,7 +13,7 @@ launch-profile validators) stay in ``test/srt/nightly/multi_host/multi_host_suit
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 
 class SuiteError(Exception):
@@ -25,12 +25,30 @@ class SuiteError(Exception):
 
 
 @dataclass(frozen=True)
+class GeneratedSharedPrefixParams:
+    num_groups: int
+    prompts_per_group: int
+    shared_prefix_len: int
+    question_len: int
+    range_ratio: float = 1.0
+
+    def __post_init__(self):
+        for name in ("num_groups", "prompts_per_group", "shared_prefix_len", "question_len"):
+            if getattr(self, name) <= 0:
+                raise ValueError(f"{name} must be positive, got {getattr(self, name)}")
+        if not 0 < self.range_ratio <= 1:
+            raise ValueError(f"range_ratio must be in (0, 1], got {self.range_ratio}")
+
+
+@dataclass(frozen=True)
 class PerfCase:
     name: str
     input_len: int
     output_len: int
     num_prompts: int
     max_concurrency: int
+    workload: Literal["random", "generated-shared-prefix"] = "random"
+    gsp_params: GeneratedSharedPrefixParams | None = None
     request_rate: float = float("inf")
     seed: int = 42
     flush_cache: bool = False
@@ -40,6 +58,28 @@ class PerfCase:
     # Set on the one representative point that captures an xprof trace.
     capture_trace: bool = False
     profile_num_steps: int | None = None
+
+    def __post_init__(self):
+        if self.workload == "random":
+            if self.gsp_params is not None:
+                raise ValueError(f"{self.name}: random workload cannot set gsp_params")
+            return
+        if self.workload != "generated-shared-prefix":
+            raise ValueError(f"{self.name}: unknown workload {self.workload!r}")
+        if self.gsp_params is None:
+            raise ValueError(f"{self.name}: generated-shared-prefix requires gsp_params")
+        expected_prompts = self.gsp_params.num_groups * self.gsp_params.prompts_per_group
+        if self.num_prompts != expected_prompts:
+            raise ValueError(
+                f"{self.name}: num_prompts={self.num_prompts} must equal "
+                f"num_groups*prompts_per_group={expected_prompts}"
+            )
+        expected_input = self.gsp_params.shared_prefix_len + self.gsp_params.question_len
+        if self.input_len != expected_input:
+            raise ValueError(
+                f"{self.name}: input_len={self.input_len} must equal "
+                f"shared_prefix_len+question_len={expected_input}"
+            )
 
 
 @dataclass(frozen=True)
@@ -94,6 +134,7 @@ class PerfParams:
     # (trace stays on profile_point/decode). Set per model at registration.
     prefill_floor_point: tuple[int, int, int] | None = None
     prefill_floors: dict[str, float] | None = None
+    flush_cache: bool = False
 
 
 def _perf_num_prompts(concurrency: int, output_len: int) -> int:
@@ -139,6 +180,7 @@ def perf_sweep_cases(prefix: str, params: PerfParams | None = None) -> list["Per
                 output_len=output_len,
                 num_prompts=_perf_num_prompts(concurrency, output_len),
                 max_concurrency=concurrency,
+                flush_cache=p.flush_cache,
                 floors=point_floors,
                 capture_trace=is_repr,  # trace only at decode repr
                 profile_num_steps=p.profile_num_steps if is_repr else None,

--- a/test/srt/nightly/drivers.py
+++ b/test/srt/nightly/drivers.py
@@ -75,9 +75,9 @@ def run_benchmark_for_case(
     from sgl_jax.bench_serving import run_benchmark
     from sgl_jax.test.test_utils import get_benchmark_args
 
-    args = get_benchmark_args(
+    benchmark_kwargs = dict(
         base_url=base_url,
-        dataset_name="random",
+        dataset_name=case.workload,
         device="tpu",
         tokenizer=tokenizer,
         num_prompts=case.num_prompts,
@@ -89,6 +89,16 @@ def run_benchmark_for_case(
         seed=case.seed,
         warmup_requests=0,
     )
+    if case.gsp_params is not None:
+        benchmark_kwargs.update(
+            gsp_num_groups=case.gsp_params.num_groups,
+            gsp_prompts_per_group=case.gsp_params.prompts_per_group,
+            gsp_system_prompt_len=case.gsp_params.shared_prefix_len,
+            gsp_question_len=case.gsp_params.question_len,
+            gsp_output_len=case.output_len,
+            gsp_range_ratio=case.gsp_params.range_ratio,
+        )
+    args = get_benchmark_args(**benchmark_kwargs)
     args.output_file = "/dev/null"
     args.flush_cache = case.flush_cache
     args.profile = True if profile else None

--- a/test/srt/nightly/launch_profiles/recurrent-qwen35-perf-v6e-4.yaml
+++ b/test/srt/nightly/launch_profiles/recurrent-qwen35-perf-v6e-4.yaml
@@ -1,0 +1,46 @@
+name: qwen3_5_a3b-recurrent-perf-tp4
+target: v6e-4
+model_path: Qwen/Qwen3.5-35B-A3B
+tp_size: 4
+dp_size: 1
+port: 30063
+server_args:
+  - --trust-remote-code
+  - --skip-server-warmup
+  - --random-seed
+  - "3"
+  - --dtype
+  - bfloat16
+  - --mem-fraction-static
+  - "0.9"
+  - --attention-backend
+  - fa
+  - --download-dir
+  - /dev/shm/
+  - --page-size
+  - "128"
+  - --context-length
+  - "16384"
+  - --max-running-requests
+  - "32"
+  - --max-prefill-tokens
+  - "8192"
+  - --chunked-prefill-size
+  - "4096"
+  - --recurrent-track-interval
+  - "4096"
+  - --max-recurrent-state-size
+  - "128"
+  - --disable-overlap-schedule
+  - --disable-topk-kernel
+  - --enable-unified-radix-tree
+  - --enable-recurrent-extra-buffer
+  - --precompile-bs-paddings
+  - "8"
+  - "16"
+  - "32"
+  - --precompile-token-paddings
+  - "512"
+  - "1024"
+  - "2048"
+  - "4096"

--- a/test/srt/nightly/multi_host/perf_case_runner.py
+++ b/test/srt/nightly/multi_host/perf_case_runner.py
@@ -6,6 +6,11 @@ from results import write_perf_json
 
 
 def run_perf_case(case: PerfCase, profile: LaunchProfile) -> None:
+    if case.workload != "random":
+        raise NotImplementedError(
+            f"Multi-host perf only supports random workloads, got {case.workload!r}"
+        )
+
     from sgl_jax.bench_serving import run_benchmark
     from sgl_jax.test.test_utils import get_benchmark_args
 

--- a/test/srt/nightly/perf_baseline.py
+++ b/test/srt/nightly/perf_baseline.py
@@ -35,6 +35,7 @@ TRAILING_MIN_NIGHTS = 5
 # (results.gate_perf_result), so a floor on a latency metric is checked the
 # right way round.
 METRIC_DIRECTION: dict[str, str] = {
+    "cache_hit_rate": "higher",
     "in_tps": "higher",
     "out_tps": "higher",
     "ttft_ms": "lower",

--- a/test/srt/nightly/results.py
+++ b/test/srt/nightly/results.py
@@ -159,6 +159,7 @@ def build_perf_result(
         "itl_ms": _f("median_itl_ms"),
         "in_tps": _f("input_throughput"),
         "out_tps": _f("output_throughput"),
+        "cache_hit_rate": _f("cache_hit_rate"),
         # Gate-helper fields (not written to CSV).
         "case": case.name,
         "completed": completed,
@@ -293,9 +294,7 @@ def gate_perf_result(case: PerfCase, result: dict) -> tuple[str, str] | None:
 
     # 2. absolute floor — per-metric hard minimum/maximum, by metric direction
     # (higher-is-better → fail under floor; lower-is-better latency → fail over
-    # floor). Today's registered floors are all out_tps (higher), so this is the
-    # same `value < floor` as before; the direction split only matters if a
-    # latency floor (e.g. ttft_ms) is ever registered.
+    # floor).
     floor_failures: list[str] = []
     for metric, floor in floors.items():
         if floor is None:
@@ -308,6 +307,7 @@ def gate_perf_result(case: PerfCase, result: dict) -> tuple[str, str] | None:
                 floor_failures.append(f"{metric}={value:.1f} > floor {floor:.1f}")
         elif value < floor:
             floor_failures.append(f"{metric}={value:.1f} < floor {floor:.1f}")
+
     result["absolute_floor_passed"] = not floor_failures
 
     # 3. trailing baseline (best-effort; skipped when history < min nights).

--- a/test/srt/nightly/single_host/suite_runner.py
+++ b/test/srt/nightly/single_host/suite_runner.py
@@ -31,6 +31,7 @@ for _p in (_TEST_SRT, _NIGHTLY_DIR, _SELF_DIR):
 from cases import (  # noqa: E402
     GSM8K_GENERATION_CONFIG,
     AccuracyCase,
+    GeneratedSharedPrefixParams,
     PerfCase,
     PerfParams,
     SuiteError,
@@ -200,6 +201,44 @@ SUITES: dict[str, SingleHostSuite] = {
                         prefill_floors={"in_tps": 31954.6},
                     ),
                 ),
+            ),
+            SingleHostRun(
+                launch_profile="recurrent-qwen35-perf-v6e-4.yaml",
+                cases=[
+                    *perf_sweep_cases(
+                        "recurrent-qwen35",
+                        PerfParams(
+                            decode_concurrencies=(16, 32),
+                            profile_point=(32, 4096, 1024),
+                            floors={"out_tps": 268.2},
+                            prefill_floor_point=(32, 4096, 1),
+                            prefill_floors={"in_tps": 1954.4},
+                            flush_cache=True,
+                        ),
+                    ),
+                    PerfCase(
+                        name="recurrent-qwen35-gsp-c16-i8704-o1",
+                        workload="generated-shared-prefix",
+                        input_len=8704,
+                        output_len=1,
+                        num_prompts=128,
+                        max_concurrency=16,
+                        flush_cache=True,
+                        gsp_params=GeneratedSharedPrefixParams(
+                            num_groups=16,
+                            prompts_per_group=8,
+                            shared_prefix_len=8192,
+                            question_len=512,
+                        ),
+                        floors={
+                            "cache_hit_rate": 0.75,
+                            "in_tps": 5769.3,
+                            "ttft_ms": 6049.6,
+                        },
+                        capture_trace=True,
+                        profile_num_steps=10,
+                    ),
+                ],
             ),
         ],
     ),


### PR DESCRIPTION
Implements the performance-nightly portion of #1425 for the recurrent radix cache introduced by #1401 and extended to the production `page_size >= 128` path by #1408. #1476 is merged, and this PR is rebased on current `main`.

## Coverage intent

This PR protects two properties of the Qwen3.5-35B-A3B unified recurrent-cache production configuration:

1. Standard no-reuse prefill and decode performance must not regress.
2. A representative long shared prefix must produce real recurrent-cache reuse, and its cache-on prefill performance must not regress.

Cache-on/cache-off benefit remains an on-demand A/B benchmark. Daily nightly measures one cache-enabled production profile with absolute floors and the existing trailing baseline.

## What this adds

One `SingleHostRun` in the existing `nightly-test-perf-text-models-4-tpu-daily` job, with one server launch and seven standard `PerfCase` points:

| Coverage | Points | Signals |
|---|---|---|
| Random prefill | `c={8,32} × input={4096,8192} × output=1` | `in_tps`, TTFT, completion; cache hit must remain zero during calibration |
| Random decode | `c={16,32} × input=4096 × output=1024` | `out_tps`, `in_tps`, ITL, TTFT, completion |
| Shared-prefix prefill | 16 groups × 8 prompts, `8192` shared + `512` unique tokens, output 1, concurrency 16 | cache-hit rate, `in_tps`, TTFT, completion |

Every point flushes the cache before measurement. The random points reuse `perf_sweep_cases`, `PerfParams`, CSV/JSON output, absolute floors, and the five-night trailing baseline. The GSP point only adds typed generated-shared-prefix parameters and maps the benchmark's existing `cache_hit_rate` into the existing floor gate. Its unique `input=8704` key does not collide with the random 4K/8K trailing history.

The final diff does not add a custom baseline type, `total_tps`, bespoke JSON gate schema, special caselist behavior, a CPU configuration test, or workflow changes.

## Production profile

The profile uses TP4/DP1, 16K context, `max-running-requests=32`, `max-prefill-tokens=8192`, `page-size=128`, overlap off, and:

- `chunked-prefill-size=4096`
- `recurrent-track-interval=4096`
- `max-recurrent-state-size=128`

The server and existing performance nightlies use a 4K production chunk by default. Keeping `track == chunk` places snapshots on existing forward boundaries and avoids force-splitting each 4K prefill into smaller forwards. The 8K shared prefix therefore lands on exactly two reusable snapshot boundaries.

`state=128` was selected after four complete sweeps for both 128 and 160:

| Metric | state 128 | state 160 |
|---|---:|---:|
| KV token capacity | 1,046,656 | 996,352 |
| Representative prefill `in_tps` mean | 2,318.1 | 2,293.9 |
| Representative decode `out_tps` mean | 316.5 | 314.6 |
| GSP cache-hit mean | 0.7929 | 0.7994 |
| GSP `in_tps` mean | 6,812.2 | 6,736.6 |
| GSP median TTFT mean | 5,237.8 ms | 5,339.6 ms |

The extra 32 state slots improved mean hit rate by only 0.0065 while reducing KV capacity by 50,304 tokens (4.8%) and slightly regressing every representative performance signal. The smaller stable pool is therefore used.

## Absolute-floor calibration

Four independent complete state-128 sweeps produced:

| Gate | Four runs | Tolerance Rule | Tolerance Floor |
|---|---|---|---:|
| Prefill `in_tps` at `c32,i4096,o1` | 2322.1 / 2329.4 / 2321.7 / 2299.3 | `min × 0.85` | 1954.4 |
| Decode `out_tps` at `c32,i4096,o1024` | 317.1 / 316.7 / 316.9 / 315.5 | `min × 0.85` | 268.2 |
| GSP cache-hit rate | 0.8041 / 0.7820 / 0.7893 / 0.7961 | safe lower bound below the observed range | 0.75 |
| GSP `in_tps` | 6826.9 / 6816.9 / 6817.5 / 6787.4 | `min × 0.85` | 5769.3 |
| GSP median TTFT | 5215.3 / 5258.4 / 5216.9 / 5260.5 ms | `max × 1.15` | 6049.6 ms |

`cache_hit_rate` uses the absolute floor only. GSP `in_tps` and TTFT, like the random points, automatically gain the existing five-night trailing gate after enough history is available.

## Validation

- 4 complete seven-point sweeps with `state=128`: all cases passed
- 4 complete seven-point sweeps with `state=160`: all cases passed
- every request completed; random cache-hit rate was zero and GSP reuse was positive in every run
- steady-state decode reached `running=32`, `queue=0`
- no OOM, preemption, dropped request, or request-time JIT miss
- selected-case dry run contains exactly the intended seven points
- absolute-floor positive and negative checks passed
- Python compilation, `git diff --check`, and repo-pinned pre-commit hooks passed

Post-push nightlies on `e3560e2b`:

- [`recurrent-qwen35-c32-i4096-o1024`](https://github.com/sgl-project/sglang-jax/actions/runs/30511635379): **PASS** — 128/128 completed, `running=32`, `queue=0`, `out_tps=311.4`
- [`recurrent-qwen35-gsp-c16-i8704-o1`](https://github.com/sgl-project/sglang-jax/actions/runs/30511636899): **PASS** — 128/128 completed, cache-hit rate `0.7960`, `in_tps=5912.9`, median TTFT `5288.5 ms`

## Files

- `test/srt/nightly/launch_profiles/recurrent-qwen35-perf-v6e-4.yaml` — production recurrent performance profile
- `test/srt/nightly/single_host/suite_runner.py` — standard random sweep, GSP point, and calibrated floors
- `test/srt/nightly/cases.py`, `test/srt/nightly/drivers.py` — typed GSP routing and per-point cache flush
- `test/srt/nightly/perf_baseline.py`, `test/srt/nightly/results.py` — `cache_hit_rate` direction and metric mapping

## Notes

- GSP uses output 1 intentionally: shared-prefix reuse is a prefill signal; long decode would dilute it with decode-kernel and scheduler behavior already covered by the standard decode sweep.
- The representative decode and GSP points remain available through the existing `/run-nightly` caselist routing.
- No concurrency/DP/EP ablation, multi-host benchmark, or A/B ratio gate is included.