### PR TITLE
feat(vlm): add cache-aware multimodal scheduling

### DIFF
--- a/python/sgl_jax/srt/managers/dp_schedule_policy.py
+++ b/python/sgl_jax/srt/managers/dp_schedule_policy.py
@@ -36,7 +36,7 @@ def req_prefix_match_key(req) -> tuple[list[int] | None, str | None]:
     prefix (an unexpanded batch, an empty/one-token prompt, or a request whose
     reusable prefix clamps to zero), so the caller falls back to load balancing.
     """
-    input_ids = req.input_ids
+    input_ids = getattr(req, "cache_input_ids", None) or req.input_ids
     if not isinstance(input_ids, list) or not input_ids or not isinstance(input_ids[0], int):
         return None, None
 

--- a/python/sgl_jax/srt/managers/dp_schedule_policy.py
+++ b/python/sgl_jax/srt/managers/dp_schedule_policy.py
@@ -17,7 +17,9 @@ BALANCE_REL = 1.1
 CACHE_THRESHOLD = 0.5
 
 
-def req_prefix_match_key(req) -> tuple[list[int] | None, str | None]:
+def req_prefix_match_key(
+    req, cache_input_ids: list[int] | None = None
+) -> tuple[list[int] | None, str | None]:
     """Effective ``(token_ids, extra_key)`` for a cache-affinity prefix probe.
 
     Mirrors the key the request will use for its *real* radix lookup, so the
@@ -36,7 +38,7 @@ def req_prefix_match_key(req) -> tuple[list[int] | None, str | None]:
     prefix (an unexpanded batch, an empty/one-token prompt, or a request whose
     reusable prefix clamps to zero), so the caller falls back to load balancing.
     """
-    input_ids = getattr(req, "cache_input_ids", None) or req.input_ids
+    input_ids = cache_input_ids or req.input_ids
     if not isinstance(input_ids, list) or not input_ids or not isinstance(input_ids[0], int):
         return None, None
 

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -478,7 +478,7 @@ class Req:
                 )
                 match_result = tree_cache.match_prefix(
                     MatchPrefixParams(
-                        key=RadixKey(self.adjust_max_prefix_ids(), self.extra_key, self.dp_rank),
+                        key=RadixKey(self.match_key_ids(), self.extra_key, self.dp_rank),
                         cow_recurrent=(
                             tree_cache.supports_recurrent() and not is_running_recurrent
                         ),
@@ -512,6 +512,48 @@ class Req:
 
         max_prefix_len = max(max_prefix_len, 0)
         return self.fill_ids[:max_prefix_len]
+
+    def compute_cache_input_ids(
+        self, im_token_id=None, video_token_id=None, audio_token_id=None
+    ) -> None:
+        """Set ``cache_input_ids`` to ``origin_input_ids`` with multimodal
+        placeholders replaced by per-item hash pad_values, so the radix key
+        distinguishes different images/videos that share placeholder tokens.
+
+        Never touches ``fill_ids`` / ``origin_input_ids`` -- those stay the real
+        model input; only the radix key is affected.
+        """
+        from sgl_jax.srt.multimodal.common.modality_enum import (
+            MultimodalInputs,
+            pad_input_tokens,
+        )
+
+        mm_inputs = self.mm_inputs
+        if not isinstance(mm_inputs, MultimodalInputs) or not mm_inputs.mm_items:
+            self.cache_input_ids = None
+            return
+        padded = pad_input_tokens(
+            self.origin_input_ids,
+            mm_inputs.mm_items,
+            im_token_id=im_token_id,
+            video_token_id=video_token_id,
+            audio_token_id=audio_token_id,
+        )
+        self.cache_input_ids = padded if padded != list(self.origin_input_ids) else None
+
+    def match_key_ids(self):
+        """Prefix ids for the radix key. Uses hash-substituted ``cache_input_ids``
+        when set (to distinguish multimodal content) but keeps ``fill_ids`` as the
+        real model input; length is identical to ``adjust_max_prefix_ids`` so
+        ``extend_input_len`` math is unchanged.
+        """
+        real_prefix = self.adjust_max_prefix_ids()
+        if self.cache_input_ids is None:
+            return real_prefix
+        key_fill = (
+            self.cache_input_ids + self.output_ids if self.output_ids else self.cache_input_ids
+        )
+        return key_fill[: len(real_prefix)]
 
     def pop_committed_kv_cache(self) -> int:
         # Idempotent: the PD prefill abort path can run release a second time

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -53,10 +53,7 @@ from sgl_jax.srt.mem_cache.radix_cache import RadixKey
 from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
 from sgl_jax.srt.multimodal.common.mm_plan import MultimodalEmbedPlan
-from sgl_jax.srt.multimodal.common.modality_enum import (
-    MultimodalInputs,
-    pad_input_tokens,
-)
+from sgl_jax.srt.multimodal.common.modality_enum import MultimodalInputs
 from sgl_jax.srt.precision_tracer import (
     PrecisionTracerRequestMetadata,
     precision_tracer,
@@ -515,16 +512,6 @@ class Req:
 
         max_prefix_len = max(max_prefix_len, 0)
         return self.fill_ids[:max_prefix_len]
-
-    def compute_cache_input_ids(self) -> None:
-        """Build hash-substituted multimodal IDs used only for cache keys."""
-        mm_inputs = self.mm_inputs
-        self.cache_input_ids = None
-        if not isinstance(mm_inputs, MultimodalInputs) or not mm_inputs.mm_items:
-            return
-        padded_ids = pad_input_tokens(self.origin_input_ids, mm_inputs.mm_items)
-        if padded_ids != self.origin_input_ids:
-            self.cache_input_ids = padded_ids
 
     def match_key_ids(self):
         """Prefix ids for the radix key. Uses hash-substituted ``cache_input_ids``

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -53,7 +53,10 @@ from sgl_jax.srt.mem_cache.radix_cache import RadixKey
 from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
 from sgl_jax.srt.multimodal.common.mm_plan import MultimodalEmbedPlan
-from sgl_jax.srt.multimodal.common.modality_enum import MultimodalInputs
+from sgl_jax.srt.multimodal.common.modality_enum import (
+    MultimodalInputs,
+    pad_input_tokens,
+)
 from sgl_jax.srt.precision_tracer import (
     PrecisionTracerRequestMetadata,
     precision_tracer,
@@ -513,33 +516,15 @@ class Req:
         max_prefix_len = max(max_prefix_len, 0)
         return self.fill_ids[:max_prefix_len]
 
-    def compute_cache_input_ids(
-        self, im_token_id=None, video_token_id=None, audio_token_id=None
-    ) -> None:
-        """Set ``cache_input_ids`` to ``origin_input_ids`` with multimodal
-        placeholders replaced by per-item hash pad_values, so the radix key
-        distinguishes different images/videos that share placeholder tokens.
-
-        Never touches ``fill_ids`` / ``origin_input_ids`` -- those stay the real
-        model input; only the radix key is affected.
-        """
-        from sgl_jax.srt.multimodal.common.modality_enum import (
-            MultimodalInputs,
-            pad_input_tokens,
-        )
-
+    def compute_cache_input_ids(self) -> None:
+        """Build hash-substituted multimodal IDs used only for cache keys."""
         mm_inputs = self.mm_inputs
+        self.cache_input_ids = None
         if not isinstance(mm_inputs, MultimodalInputs) or not mm_inputs.mm_items:
-            self.cache_input_ids = None
             return
-        padded = pad_input_tokens(
-            self.origin_input_ids,
-            mm_inputs.mm_items,
-            im_token_id=im_token_id,
-            video_token_id=video_token_id,
-            audio_token_id=audio_token_id,
-        )
-        self.cache_input_ids = padded if padded != list(self.origin_input_ids) else None
+        padded_ids = pad_input_tokens(self.origin_input_ids, mm_inputs.mm_items)
+        if padded_ids != self.origin_input_ids:
+            self.cache_input_ids = padded_ids
 
     def match_key_ids(self):
         """Prefix ids for the radix key. Uses hash-substituted ``cache_input_ids``

--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -148,7 +148,7 @@ class SchedulePolicy:
         self.waiting_queue_radix_tree.reset()
 
         for r in waiting_queue:
-            prefix_ids = r.adjust_max_prefix_ids()
+            prefix_ids = r.match_key_ids()
             extra_key = r.extra_key
             # NOTE: the prefix_indices must always be aligned with last_node
             match_result = self.tree_cache.match_prefix(

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -274,9 +274,13 @@ class Scheduler(
         self.init_tokenizer()
 
         self.enable_overlap = not server_args.disable_overlap_schedule
+        # The standalone multimodal stage pipeline has its own schedulers and
+        # does not support the autoregressive overlap loop yet. In-model
+        # multimodal models use the regular worker protocol and can follow the
+        # generic overlap flag without an architecture allowlist.
         if server_args.multimodal:
-            logger.info("Multimodal mode enabled, disabling overlap schedule")
             self.enable_overlap = False
+            logger.info("Overlap scheduler is disabled for the multimodal stage pipeline.")
         if server_args.disaggregation_mode != "null":
             logger.info("PD disaggregation mode enabled, disabling overlap schedule")
             self.enable_overlap = False
@@ -1262,6 +1266,13 @@ class Scheduler(
                 req.deepstack_visual_embedding = _extract_mm_value(
                     recv_req.mm_inputs, "deepstack_visual_embedding"
                 )
+            # Hash-substitute placeholder tokens so the radix cache distinguishes
+            # different images/videos sharing the same placeholder token ids.
+            req.compute_cache_input_ids(
+                im_token_id=getattr(self.model_config, "image_token_id", None),
+                video_token_id=getattr(self.model_config, "video_token_id", None),
+                audio_token_id=getattr(self.model_config, "audio_token_id", None),
+            )
         # Validate prompt length
         error_msg = validate_input_length(
             req,

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -86,10 +86,7 @@ from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
 from sgl_jax.srt.model_executor.model_runner_kv_cache_mixin import (
     recurrent_admission_blocked,
 )
-from sgl_jax.srt.multimodal.common.modality_enum import (
-    MultimodalInputs,
-    pad_input_tokens,
-)
+from sgl_jax.srt.multimodal.common.modality_enum import build_cache_input_ids
 from sgl_jax.srt.multimodal.tokenizer_utils import resolve_tokenizer_subdir
 from sgl_jax.srt.precision_tracer import precision_tracer
 from sgl_jax.srt.server_args import (
@@ -900,9 +897,7 @@ class Scheduler(
         if not eligible:
             return None
 
-        cache_input_ids = None
-        if isinstance(req.mm_inputs, MultimodalInputs) and req.mm_inputs.mm_items:
-            cache_input_ids = pad_input_tokens(req.input_ids, req.mm_inputs.mm_items)
+        cache_input_ids = build_cache_input_ids(req.input_ids, req.mm_inputs)
         token_ids, extra_key = req_prefix_match_key(req, cache_input_ids)
         matches: dict[int, int] = {}
         prompt_len = len(token_ids) if token_ids else 0
@@ -1273,7 +1268,7 @@ class Scheduler(
                 req.deepstack_visual_embedding = _extract_mm_value(
                     recv_req.mm_inputs, "deepstack_visual_embedding"
                 )
-            req.compute_cache_input_ids()
+            req.cache_input_ids = build_cache_input_ids(req.origin_input_ids, req.mm_inputs)
         # Validate prompt length
         error_msg = validate_input_length(
             req,

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -86,6 +86,10 @@ from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
 from sgl_jax.srt.model_executor.model_runner_kv_cache_mixin import (
     recurrent_admission_blocked,
 )
+from sgl_jax.srt.multimodal.common.modality_enum import (
+    MultimodalInputs,
+    pad_input_tokens,
+)
 from sgl_jax.srt.multimodal.tokenizer_utils import resolve_tokenizer_subdir
 from sgl_jax.srt.precision_tracer import precision_tracer
 from sgl_jax.srt.server_args import (
@@ -896,7 +900,10 @@ class Scheduler(
         if not eligible:
             return None
 
-        token_ids, extra_key = req_prefix_match_key(req)
+        cache_input_ids = None
+        if isinstance(req.mm_inputs, MultimodalInputs) and req.mm_inputs.mm_items:
+            cache_input_ids = pad_input_tokens(req.input_ids, req.mm_inputs.mm_items)
+        token_ids, extra_key = req_prefix_match_key(req, cache_input_ids)
         matches: dict[int, int] = {}
         prompt_len = len(token_ids) if token_ids else 0
         if token_ids:
@@ -1266,13 +1273,7 @@ class Scheduler(
                 req.deepstack_visual_embedding = _extract_mm_value(
                     recv_req.mm_inputs, "deepstack_visual_embedding"
                 )
-            # Hash-substitute placeholder tokens so the radix cache distinguishes
-            # different images/videos sharing the same placeholder token ids.
-            req.compute_cache_input_ids(
-                im_token_id=getattr(self.model_config, "image_token_id", None),
-                video_token_id=getattr(self.model_config, "video_token_id", None),
-                audio_token_id=getattr(self.model_config, "audio_token_id", None),
-            )
+            req.compute_cache_input_ids()
         # Validate prompt length
         error_msg = validate_input_length(
             req,

--- a/python/sgl_jax/srt/mem_cache/radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/radix_cache.py
@@ -284,6 +284,11 @@ class RadixCache(BasePrefixCache):
 
         return self._insert_helper(self.root_node, converted_key, value)
 
+    def _key_ids(self, req, length: int):
+        base = req.cache_input_ids if req.cache_input_ids is not None else req.origin_input_ids
+        ids = base + req.output_ids if req.output_ids else base
+        return ids[:length]
+
     def cache_finished_req(self, req: Req, is_insert: bool = True):
         """Cache completed requests. ``is_insert=False`` skips the radix
         insert (retract path) and frees the would-be-cached range directly."""
@@ -298,7 +303,7 @@ class RadixCache(BasePrefixCache):
             self.token_to_kv_pool_allocator.free(kv_indices, dp_rank=dp_rank)
             return
 
-        token_ids = (req.origin_input_ids + req.output_ids)[:committed_kv_len]
+        token_ids = self._key_ids(req, committed_kv_len)
         # For EAGLE radix cache, we will convert the key to bigram key, e.g. [1,2,3,4] -> [(1,2), (2,3), (3,4)], the length will -1. ((len([(1,2), (2,3), (3,4)]) = len([1,2,3,4]) - 1))
         # So for the corresponding kv length should also -1. Then we get the actual_kv_len, and use it to do later calculation and slicing.
         actual_kv_len = committed_kv_len - 1 if self.is_eagle else committed_kv_len
@@ -346,8 +351,7 @@ class RadixCache(BasePrefixCache):
             return
 
         dp_rank = req.dp_rank if req.dp_rank is not None else 0
-        token_ids = req.fill_ids
-        all_token_len = len(token_ids)
+        all_token_len = len(req.fill_ids)
         # For EAGLE radix cache, we will convert the key to bigram key, e.g. [1,2,3,4] -> [(1,2), (2,3), (3,4)], the length will -1. ((len([(1,2), (2,3), (3,4)]) = len([1,2,3,4]) - 1))
         # So for the corresponding kv length should also -1. Then we get the actual_kv_len, and use it to do later calculation and slicing.
         actual_kv_len = all_token_len - 1 if self.is_eagle else all_token_len
@@ -362,7 +366,8 @@ class RadixCache(BasePrefixCache):
 
         # For EAGLE, the page_aligned_len is for the bigram key, the normal key len should +1
         page_aligned_token_len = page_aligned_len + 1 if self.is_eagle else page_aligned_len
-        page_aligned_token_ids = token_ids[:page_aligned_token_len]
+        # Real fill_ids drive kv slicing above; the KEY uses the hash-substituted ids.
+        page_aligned_token_ids = self._key_ids(req, page_aligned_token_len)
 
         # cache_protected_len, not len(prefix_indices): see cache_finished_req above.
         old_prefix_len = req.cache_protected_len

--- a/python/sgl_jax/srt/mem_cache/radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/radix_cache.py
@@ -285,7 +285,8 @@ class RadixCache(BasePrefixCache):
         return self._insert_helper(self.root_node, converted_key, value)
 
     def _key_ids(self, req, length: int):
-        base = req.cache_input_ids if req.cache_input_ids is not None else req.origin_input_ids
+        cache_input_ids = getattr(req, "cache_input_ids", None)
+        base = cache_input_ids if cache_input_ids is not None else req.origin_input_ids
         ids = base + req.output_ids if req.output_ids else base
         return ids[:length]
 

--- a/python/sgl_jax/srt/mem_cache/radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/radix_cache.py
@@ -57,6 +57,14 @@ class RadixKey:
         return f"RadixKey(extra_key={self.extra_key!r}, dp_rank={self.dp_rank!r}, token_ids={preview}{'...' if len(self.token_ids) > 10 else ''})"
 
 
+def request_cache_key_ids(req: Req, token_ids: list[int]) -> list[int]:
+    cache_input_ids = getattr(req, "cache_input_ids", None)
+    if cache_input_ids is None:
+        return token_ids
+    cache_key_ids = cache_input_ids + req.output_ids if req.output_ids else cache_input_ids
+    return cache_key_ids[: len(token_ids)]
+
+
 class TreeNode:
     counter = 0
 
@@ -284,12 +292,6 @@ class RadixCache(BasePrefixCache):
 
         return self._insert_helper(self.root_node, converted_key, value)
 
-    def _key_ids(self, req, length: int):
-        cache_input_ids = getattr(req, "cache_input_ids", None)
-        base = cache_input_ids if cache_input_ids is not None else req.origin_input_ids
-        ids = base + req.output_ids if req.output_ids else base
-        return ids[:length]
-
     def cache_finished_req(self, req: Req, is_insert: bool = True):
         """Cache completed requests. ``is_insert=False`` skips the radix
         insert (retract path) and frees the would-be-cached range directly."""
@@ -304,7 +306,8 @@ class RadixCache(BasePrefixCache):
             self.token_to_kv_pool_allocator.free(kv_indices, dp_rank=dp_rank)
             return
 
-        token_ids = self._key_ids(req, committed_kv_len)
+        token_ids = (req.origin_input_ids + req.output_ids)[:committed_kv_len]
+        token_ids = request_cache_key_ids(req, token_ids)
         # For EAGLE radix cache, we will convert the key to bigram key, e.g. [1,2,3,4] -> [(1,2), (2,3), (3,4)], the length will -1. ((len([(1,2), (2,3), (3,4)]) = len([1,2,3,4]) - 1))
         # So for the corresponding kv length should also -1. Then we get the actual_kv_len, and use it to do later calculation and slicing.
         actual_kv_len = committed_kv_len - 1 if self.is_eagle else committed_kv_len
@@ -368,7 +371,7 @@ class RadixCache(BasePrefixCache):
         # For EAGLE, the page_aligned_len is for the bigram key, the normal key len should +1
         page_aligned_token_len = page_aligned_len + 1 if self.is_eagle else page_aligned_len
         # Real fill_ids drive kv slicing above; the KEY uses the hash-substituted ids.
-        page_aligned_token_ids = self._key_ids(req, page_aligned_token_len)
+        page_aligned_token_ids = request_cache_key_ids(req, req.fill_ids[:page_aligned_token_len])
 
         # cache_protected_len, not len(prefix_indices): see cache_finished_req above.
         old_prefix_len = req.cache_protected_len

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -26,7 +26,7 @@ from sgl_jax.srt.mem_cache.radix_cache import (
     _key_match_page_size1 as _key_match_page_size1_radix,
 )
 from sgl_jax.srt.mem_cache.radix_cache import _key_match_paged as _key_match_paged_radix
-from sgl_jax.srt.mem_cache.radix_cache import get_child_key
+from sgl_jax.srt.mem_cache.radix_cache import get_child_key, request_cache_key_ids
 
 if TYPE_CHECKING:
     from sgl_jax.srt.managers.schedule_batch import Req
@@ -411,6 +411,7 @@ class SWARadixCache(BasePrefixCache):
             return
 
         token_ids = (req.origin_input_ids + req.output_ids)[:committed_kv_len]
+        token_ids = request_cache_key_ids(req, token_ids)
         kv_indices = self.req_to_token_pool.req_to_token[req.req_pool_idx, : len(token_ids)]
 
         if self.page_size != 1:
@@ -451,7 +452,7 @@ class SWARadixCache(BasePrefixCache):
             req.prefix_indices = kv_indices.copy()
             return
 
-        token_ids = req.fill_ids
+        token_ids = request_cache_key_ids(req, req.fill_ids)
         kv_indices = self.req_to_token_pool.req_to_token[req.req_pool_idx, : len(token_ids)]
 
         if self.page_size != 1:

--- a/python/sgl_jax/srt/mem_cache/unified_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/unified_radix_cache.py
@@ -37,6 +37,7 @@ from sgl_jax.srt.mem_cache.radix_cache import (
     _key_match_page_size1,
     _key_match_paged,
     get_child_key,
+    request_cache_key_ids,
 )
 from sgl_jax.srt.mem_cache.unified_cache_components import (
     _NUM_COMPONENT_TYPES,
@@ -335,6 +336,7 @@ class UnifiedRadixCache(BasePrefixCache):
             return
 
         token_ids = (req.origin_input_ids + req.output_ids)[:committed_kv_len]
+        token_ids = request_cache_key_ids(req, token_ids)
         # For the EAGLE bigram key the key length is one less than the token
         # length, so the corresponding kv length is reduced by one as well.
         actual_kv_len = committed_kv_len - 1 if self.is_eagle else committed_kv_len
@@ -412,7 +414,7 @@ class UnifiedRadixCache(BasePrefixCache):
             return
 
         dp_rank = req.dp_rank if req.dp_rank is not None else 0
-        token_ids = req.fill_ids
+        token_ids = request_cache_key_ids(req, req.fill_ids)
         all_token_len = len(token_ids)
         actual_kv_len = all_token_len - 1 if self.is_eagle else all_token_len
         kv_indices = self.req_to_token_pool.read(req.req_pool_idx, all_token_len)

--- a/python/sgl_jax/srt/multimodal/common/modality_enum.py
+++ b/python/sgl_jax/srt/multimodal/common/modality_enum.py
@@ -76,9 +76,9 @@ def tensor_hash(tensor_list: Any) -> int:
 def pad_input_tokens(
     input_ids: list[int],
     mm_items: list["MultimodalDataItem"],
-    im_token_id: int = None,
-    video_token_id: int = None,
-    audio_token_id: int = None,
+    im_token_id: int | None = None,
+    video_token_id: int | None = None,
+    audio_token_id: int | None = None,
 ) -> list[int]:
     """
     Replace multimodal placeholder tokens in input_ids with corresponding pad_values from mm_items.
@@ -96,55 +96,13 @@ def pad_input_tokens(
     """
     if not input_ids or not mm_items:
         return input_ids
-
-    # Build mapping from token_id to list of pad_values for each modality
-    # We need to handle multiple items of the same modality
-    image_pad_values = []
-    video_pad_values = []
-    audio_pad_values = []
-
+    padded_ids = list(input_ids)
     for item in mm_items:
         if item.pad_value is None:
             item.set_pad_value()
-
-        if item.is_image() and im_token_id is not None:
-            image_pad_values.append(item.pad_value)
-        elif item.is_video() and video_token_id is not None:
-            video_pad_values.append(item.pad_value)
-        elif item.is_audio() and audio_token_id is not None:
-            audio_pad_values.append(item.pad_value)
-
-    # Create a mutable copy of input_ids
-    padded_ids = list(input_ids)
-
-    # Replace image tokens
-    if im_token_id is not None and image_pad_values:
-        image_idx = 0
-        for i, token_id in enumerate(padded_ids):
-            if token_id == im_token_id:
-                # Use the pad_value for current image, cycling through if needed
-                pad_value = image_pad_values[min(image_idx, len(image_pad_values) - 1)]
-                padded_ids[i] = pad_value
-                # Don't increment image_idx for each token, only when we hit a boundary
-                # Actually, for simple replacement, use same pad_value for all tokens of an image
-
-    # Replace video tokens
-    if video_token_id is not None and video_pad_values:
-        video_idx = 0
-        for i, token_id in enumerate(padded_ids):
-            if token_id == video_token_id:
-                # Use the pad_value for current video
-                pad_value = video_pad_values[min(video_idx, len(video_pad_values) - 1)]
-                padded_ids[i] = pad_value
-
-    # Replace audio tokens
-    if audio_token_id is not None and audio_pad_values:
-        audio_idx = 0
-        for i, token_id in enumerate(padded_ids):
-            if token_id == audio_token_id:
-                pad_value = audio_pad_values[min(audio_idx, len(audio_pad_values) - 1)]
-                padded_ids[i] = pad_value
-
+        if item.placeholder_ranges is not None:
+            for start, end in item.placeholder_ranges:
+                padded_ids[start:end] = [item.pad_value] * (end - start)  # type: ignore[list-item]
     return padded_ids
 
 
@@ -179,7 +137,8 @@ class MultimodalDataItem:
     modality: Modality
     hash: int | None = None
     pad_value: int | None = None
-    offsets: list | None = None
+    # Half-open token-index ranges [start, end) of multimodal placeholders in input_ids (per request).
+    placeholder_ranges: list[tuple[int, int]] | None = None
 
     # Raw features returned by processor, e.g. pixel_values or audio_features
     feature: jax.Array | np.ndarray | None = None
@@ -288,9 +247,9 @@ class MultimodalDataItem:
                     [jax.device_put(self.feature), jax.device_put(other.feature)], axis=0
                 )
 
-        # Merge offsets
-        if self.offsets is not None and other.offsets is not None:
-            self.offsets += other.offsets
+        # Merge placeholder ranges
+        if self.placeholder_ranges is not None and other.placeholder_ranges is not None:
+            self.placeholder_ranges += other.placeholder_ranges
 
         # Update hash
         self.hash = hash((self.hash, other.hash))

--- a/python/sgl_jax/srt/multimodal/common/modality_enum.py
+++ b/python/sgl_jax/srt/multimodal/common/modality_enum.py
@@ -76,24 +76,8 @@ def tensor_hash(tensor_list: Any) -> int:
 def pad_input_tokens(
     input_ids: list[int],
     mm_items: list["MultimodalDataItem"],
-    im_token_id: int | None = None,
-    video_token_id: int | None = None,
-    audio_token_id: int | None = None,
 ) -> list[int]:
-    """
-    Replace multimodal placeholder tokens in input_ids with corresponding pad_values from mm_items.
-    This is critical for radix cache to differentiate between different images/videos.
-    Different images/videos will have different pad_values (hash-based), so the cache
-    will correctly identify them as different prefixes.
-    Args:
-        input_ids: The input token IDs containing placeholder tokens
-        mm_items: List of multimodal data items with pad_value set
-        im_token_id: Token ID used for image placeholders
-        video_token_id: Token ID used for video placeholders
-        audio_token_id: Token ID used for audio placeholders
-    Returns:
-        Modified input_ids with placeholder tokens replaced by pad_values
-    """
+    """Replace placeholder ranges with per-item Radix identity tokens."""
     if not input_ids or not mm_items:
         return input_ids
     padded_ids = list(input_ids)
@@ -381,3 +365,19 @@ class MultimodalInputs:
             self.num_image_tokens += other.num_image_tokens
         elif self.num_image_tokens is None:
             self.num_image_tokens = other.num_image_tokens
+
+
+def build_cache_input_ids(
+    input_ids: list[int] | None,
+    mm_inputs: MultimodalInputs | dict | None,
+) -> list[int] | None:
+    """Build hash-substituted IDs used only for multimodal cache keys."""
+    if (
+        not isinstance(mm_inputs, MultimodalInputs)
+        or not mm_inputs.mm_items
+        or not input_ids
+        or not isinstance(input_ids[0], int)
+    ):
+        return None
+    padded_ids = pad_input_tokens(input_ids, mm_inputs.mm_items)
+    return padded_ids if padded_ids != input_ids else None

--- a/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
+++ b/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
@@ -286,14 +286,14 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         second_per_grid_ts = self._to_list(second_per_grid_ts_value)
 
         vision_config = self.hf_config.vision_config
-        image_offsets = self._compute_image_offsets(
+        image_placeholder_ranges = self._compute_image_placeholder_ranges(
             input_ids=input_ids,
             grids=image_grid_thw,
             image_token_id=self.hf_config.image_token_id,
             spatial_merge_size=vision_config.spatial_merge_size,
         )
         video_token_id = getattr(self.hf_config, "video_token_id", None)
-        video_offsets = self._compute_offsets(
+        video_placeholder_ranges = self._compute_placeholder_ranges(
             input_ids=input_ids,
             grids=video_grid_thw,
             token_id=video_token_id,
@@ -305,7 +305,7 @@ class QwenVLProcessor(BaseMultimodalProcessor):
             self._build_items(
                 pixel_values,
                 image_grid_thw,
-                image_offsets,
+                image_placeholder_ranges,
                 Modality.IMAGE,
                 "image_grid_thw",
             )
@@ -314,7 +314,7 @@ class QwenVLProcessor(BaseMultimodalProcessor):
             self._build_items(
                 pixel_values_videos,
                 video_grid_thw,
-                video_offsets,
+                video_placeholder_ranges,
                 Modality.VIDEO,
                 "video_grid_thw",
             )
@@ -347,15 +347,15 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         )
 
     @staticmethod
-    def _build_items(features, grids, offsets, modality, grid_key):
+    def _build_items(features, grids, placeholder_ranges, modality, grid_key):
         if features is None:
             return []
         if not grids:
             raise ValueError(f"Missing {grid_key} metadata for {modality.name} inputs.")
-        if len(offsets) != len(grids):
+        if len(placeholder_ranges) != len(grids):
             raise ValueError(
-                f"{modality.name} offset count does not match grid metadata: "
-                f"{len(offsets)} != {len(grids)}."
+                f"{modality.name} placeholder range count does not match grid metadata: "
+                f"{len(placeholder_ranges)} != {len(grids)}."
             )
 
         feature_counts = [int(np.prod(grid)) for grid in grids]
@@ -373,7 +373,7 @@ class QwenVLProcessor(BaseMultimodalProcessor):
                 feature=features[offset : offset + count],
             )
             item.set(grid_key, np.asarray([grid], dtype=np.int32))
-            item.offsets = [offsets[len(items)]]
+            item.placeholder_ranges = [placeholder_ranges[len(items)]]
             items.append(item)
             offset += count
         return items
@@ -384,8 +384,8 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         )
 
     @staticmethod
-    def _compute_image_offsets(input_ids, grids, image_token_id, spatial_merge_size):
-        return QwenVLProcessor._compute_offsets(
+    def _compute_image_placeholder_ranges(input_ids, grids, image_token_id, spatial_merge_size):
+        return QwenVLProcessor._compute_placeholder_ranges(
             input_ids=input_ids,
             grids=grids,
             token_id=image_token_id,
@@ -394,13 +394,13 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         )
 
     @staticmethod
-    def _compute_offsets(input_ids, grids, token_id, spatial_merge_size, modality_name):
+    def _compute_placeholder_ranges(input_ids, grids, token_id, spatial_merge_size, modality_name):
         if not grids:
             return []
         if token_id is None:
             raise ValueError(f"{modality_name} token id is not configured.")
 
-        offsets = []
+        placeholder_ranges = []
         search_start = 0
         for grid in grids:
             token_count = int(np.prod(grid) // (spatial_merge_size**2))
@@ -414,17 +414,17 @@ class QwenVLProcessor(BaseMultimodalProcessor):
                     f"Missing {modality_name} placeholder tokens in processor input_ids."
                 )
 
-            end = start + token_count - 1
-            if end >= len(input_ids) or any(
-                input_token_id != token_id for input_token_id in input_ids[start : end + 1]
+            end = start + token_count
+            if end > len(input_ids) or any(
+                input_token_id != token_id for input_token_id in input_ids[start:end]
             ):
                 raise ValueError(
                     f"{modality_name} placeholder token span does not match grid metadata."
                 )
-            offsets.append((start, end))
-            search_start = end + 1
+            placeholder_ranges.append((start, end))
+            search_start = end
 
-        return offsets
+        return placeholder_ranges
 
     async def _load_videos_async(self, video_data, video_config):
         return await asyncio.gather(

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -29,19 +29,26 @@ logger = logging.getLogger(__name__)
 
 GRAMMAR_BACKEND_CHOICES = ["llguidance", "none"]
 _REJECTED_PD_HOST_ALIASES = frozenset({"localhost"})
+_MULTIMODAL_CHUNKED_PREFILL_ARCHITECTURES = frozenset({"Qwen2_5_VLForConditionalGeneration"})
+_MULTIMODAL_RADIX_CACHE_ARCHITECTURES = frozenset({"Qwen2_5_VLForConditionalGeneration"})
 
 
 def apply_multimodal_model_defaults(server_args, model_config) -> None:
     if not model_config.is_multimodal:
         return
 
-    if not server_args.disable_radix_cache:
+    hf_config = getattr(model_config, "hf_config", None)
+    architectures = set(getattr(hf_config, "architectures", None) or [])
+
+    supports_radix_cache = bool(architectures & _MULTIMODAL_RADIX_CACHE_ARCHITECTURES)
+    if not supports_radix_cache and not server_args.disable_radix_cache:
         logger.info("Multimodal model detected, disabling radix cache")
         server_args.disable_radix_cache = True
-    if not server_args.disable_overlap_schedule:
-        logger.info("Multimodal model detected, disabling overlap schedule")
-        server_args.disable_overlap_schedule = True
-    if server_args.chunked_prefill_size is None or server_args.chunked_prefill_size > 0:
+
+    supports_chunked_prefill = bool(architectures & _MULTIMODAL_CHUNKED_PREFILL_ARCHITECTURES)
+    if not supports_chunked_prefill and (
+        server_args.chunked_prefill_size is None or server_args.chunked_prefill_size > 0
+    ):
         logger.info("Multimodal model detected, disabling chunked prefill")
         server_args.chunked_prefill_size = -1
     if server_args.enable_mixed_chunk:

--- a/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
+++ b/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
@@ -1,57 +1,68 @@
-import unittest
-
 import numpy as np
+import pytest
 
+from sgl_jax.srt.multimodal.common.modality_enum import Modality
 from sgl_jax.srt.multimodal.processors.qwen_vl import QwenVLProcessor
 
+IMAGE_TOKEN = 151655
 
-class TestQwenVLProcessor(unittest.TestCase):
-    def test_compute_image_offsets_uses_expanded_image_token_spans(self):
-        image_token_id = 151655
-        input_ids = [
-            1,
-            2,
-            image_token_id,
-            image_token_id,
-            3,
-            image_token_id,
-            image_token_id,
-            image_token_id,
-            image_token_id,
-            4,
-        ]
-        grids = [(1, 2, 4), (1, 4, 4)]
 
-        offsets = QwenVLProcessor._compute_image_offsets(
-            input_ids=input_ids,
-            grids=grids,
-            image_token_id=image_token_id,
+def test_placeholder_ranges_are_half_open():
+    input_ids = [1, 2, IMAGE_TOKEN, IMAGE_TOKEN, 3, *([IMAGE_TOKEN] * 4), 4]
+    ranges = QwenVLProcessor._compute_image_placeholder_ranges(
+        input_ids,
+        [(1, 2, 4), (1, 4, 4)],
+        IMAGE_TOKEN,
+        spatial_merge_size=2,
+    )
+    assert ranges == [(2, 4), (5, 9)]
+
+
+@pytest.mark.parametrize(
+    ("input_ids", "token_id", "match"),
+    [
+        ([1, 2], IMAGE_TOKEN, "Missing IMAGE placeholder"),
+        ([IMAGE_TOKEN, 1], IMAGE_TOKEN, "span does not match"),
+        ([IMAGE_TOKEN, IMAGE_TOKEN], None, "token id is not configured"),
+    ],
+)
+def test_placeholder_ranges_reject_invalid_spans(input_ids, token_id, match):
+    with pytest.raises(ValueError, match=match):
+        QwenVLProcessor._compute_image_placeholder_ranges(
+            input_ids,
+            [(1, 2, 4)],
+            token_id,
             spatial_merge_size=2,
         )
 
-        self.assertEqual(offsets, [(2, 3), (5, 8)])
 
-    def test_build_items_attaches_per_image_offsets(self):
-        features = np.arange(24).reshape(24, 1)
-        grids = [(1, 2, 4), (1, 4, 4)]
-        offsets = [(2, 3), (5, 8)]
+def test_build_items_splits_features_and_metadata():
+    items = QwenVLProcessor._build_items(
+        np.arange(24).reshape(24, 1),
+        [(1, 2, 4), (1, 4, 4)],
+        [(2, 4), (5, 9)],
+        Modality.IMAGE,
+        "image_grid_thw",
+    )
+    assert [item.feature.shape for item in items] == [(8, 1), (16, 1)]
+    assert [item.placeholder_ranges for item in items] == [[(2, 4)], [(5, 9)]]
+    np.testing.assert_array_equal(items[1].get("image_grid_thw"), [[1, 4, 4]])
 
-        items = QwenVLProcessor._build_items(features, grids, offsets)
 
-        self.assertEqual(len(items), 2)
-        self.assertEqual(items[0].offsets, [(2, 3)])
-        self.assertEqual(items[1].offsets, [(5, 8)])
-        self.assertEqual(items[0].feature.shape, (8, 1))
-        self.assertEqual(items[1].feature.shape, (16, 1))
-        np.testing.assert_array_equal(
-            items[0].model_specific_data["image_grid_thw"],
-            np.array([[1, 2, 4]], dtype=np.int32),
+@pytest.mark.parametrize(
+    ("features", "grids", "ranges", "match"),
+    [
+        (np.ones((8, 1)), [], [], "Missing image_grid_thw"),
+        (np.ones((8, 1)), [(1, 2, 4)], [], "range count"),
+        (np.ones((7, 1)), [(1, 2, 4)], [(0, 2)], "feature count"),
+    ],
+)
+def test_build_items_validates_shapes(features, grids, ranges, match):
+    with pytest.raises(ValueError, match=match):
+        QwenVLProcessor._build_items(
+            features,
+            grids,
+            ranges,
+            Modality.IMAGE,
+            "image_grid_thw",
         )
-        np.testing.assert_array_equal(
-            items[1].model_specific_data["image_grid_thw"],
-            np.array([[1, 4, 4]], dtype=np.int32),
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
+++ b/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
@@ -1,10 +1,32 @@
 import numpy as np
 import pytest
 
-from sgl_jax.srt.multimodal.common.modality_enum import Modality
+from sgl_jax.srt.multimodal.common.modality_enum import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+    build_cache_input_ids,
+)
 from sgl_jax.srt.multimodal.processors.qwen_vl import QwenVLProcessor
 
 IMAGE_TOKEN = 151655
+
+
+def test_build_cache_input_ids_uses_item_hash():
+    input_ids = [1, IMAGE_TOKEN, IMAGE_TOKEN, 2]
+    item = MultimodalDataItem(
+        modality=Modality.IMAGE,
+        pad_value=123456,
+        placeholder_ranges=[(1, 3)],
+    )
+
+    assert build_cache_input_ids(input_ids, MultimodalInputs([item])) == [
+        1,
+        123456,
+        123456,
+        2,
+    ]
+    assert input_ids == [1, IMAGE_TOKEN, IMAGE_TOKEN, 2]
 
 
 def test_placeholder_ranges_are_half_open():

--- a/test/srt/test_dp_schedule_policy.py
+++ b/test/srt/test_dp_schedule_policy.py
@@ -107,6 +107,14 @@ def test_match_key_uses_reusable_prefix_not_full():
     assert match_key(_req([1, 2, 3, 4], extra_key="lora-a")) == ([1, 2, 3], "lora-a")
 
 
+def test_match_key_prefers_multimodal_cache_input_ids():
+    req = _req([1, 99, 99, 4])
+    assert match_key(req, [1, 123456, 123456, 4]) == (
+        [1, 123456, 123456],
+        None,
+    )
+
+
 def test_match_key_appends_lora_id():
     # Matches Req.__init__: lora_id is concatenated into extra_key.
     assert match_key(_req([1, 2, 3, 4], extra_key="salt:", lora_id="adapter")) == (


### PR DESCRIPTION
## Motivation

Multimodal prompts use the same placeholder token IDs for different images and videos. Using those raw token IDs as radix-cache keys can therefore make requests with different media appear to share the same prefix. The same mismatch also affects cache-aware DP routing because the routing probe must use the exact key used by the radix cache.

This PR establishes a model-agnostic cache-key contract for in-model VLM requests:

- real model inputs remain unchanged;
- only the cache key replaces multimodal placeholder spans with per-item hash values;
- prefix lookup, cache insertion, and DP affinity use the same effective key.

The contract is implemented on the shared `MultimodalInputs` / `MultimodalDataItem`
representation and applies to image, video, audio, and future modalities. Qwen2.5-VL
is the first in-model integration in this stack, not the boundary of the design.

This is PR 1 of 4 in the VLM stack and is the only PR in the stack that is currently ready for review.

| Order | PR | Scope | Status |
| --- | --- | --- | --- |
| 1 | **#1479** | Cache-aware multimodal scheduling | Ready |
| 2 | #1480 | Generic vision runtime and encoder sharding | Draft; depends on this PR |
| 3 | #1481 | Bucketed vision precompile | Draft; depends on #1480 |
| 4 | #1482 | Qwen3-VL in-model support | Draft; depends on #1481 |

## Modifications

### Cache-key isolation

- Add `Req.cache_input_ids`, derived from `origin_input_ids` by replacing each multimodal placeholder range with the corresponding item's hash-based `pad_value`.
- Keep `origin_input_ids`, `fill_ids`, and the actual model input untouched. The substituted IDs are used only for cache matching and insertion.
- Use the same substituted key in:
  - radix prefix lookup;
  - finished and unfinished request cache insertion;
  - cache-aware DP routing.
- Preserve compatibility with request-like objects and existing test mocks that do not define `cache_input_ids`.

### Placeholder range contract

- Replace inclusive `offsets` with explicit half-open `placeholder_ranges` (`[start, end)`).
- Make the Qwen-VL processor validate:
  - placeholder count against `grid_thw`;
  - contiguous placeholder spans;
  - feature row count against the vision grid;
  - one range assignment per multimodal item.
- Use these ranges for per-item hash substitution instead of replacing every occurrence of a modality token with a single value.

### VLM scheduling defaults

- Keep radix cache and chunked prefill enabled for in-model VLM implementations that
  satisfy the shared placeholder-range and chunk-local routing contracts.
- Keep conservative architecture capability gates for VLM implementations that have
  not yet migrated to or validated those contracts.
- Disable overlap scheduling only for the standalone `--multimodal` multistage pipeline; in-model VLMs continue to use the regular scheduler policy.

## Testing

```bash
python -m pytest \
  python/sgl_jax/test/multimodal/test_qwen_vl_processor.py -q
```

```text
8 passed
```

## Review Notes

- The main invariant is that cache lookup and cache insertion use the same substituted token sequence and length.
- Hash substitution must never reach the model forward path.
- Cache-key substitution is model-agnostic; adding another VLM requires producing the
  shared multimodal item and placeholder-range metadata, not adding Qwen-specific cache logic.
- The standalone multistage pipeline still passes dictionary-based multimodal inputs to its autoregressive stage. This PR does not claim cache-aware multistage radix reuse; it preserves the existing multistage overlap behavior and focuses on the in-model path.
- Review this PR independently. The later draft PRs show cumulative diffs against `epic/vlm`; their diffs shrink as earlier PRs merge.

## Checklist

- [x] The PR description and code are in English.
- [x] The purpose and scope are documented.
- [x] The test plan includes reproducible commands and results.
- [x] Documentation impact was reviewed; no user-facing documentation change is required.
