### PR TITLE
perf(scheduler): env-gated per-step phase timing + #293 masking guard

### DIFF
--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -114,6 +114,16 @@ TEST_RETRACT = get_bool_env_var("SGLANG_TEST_RETRACT")
 TEST_RETRACT_INTERVAL = int(os.environ.get("SGLANG_TEST_RETRACT_INTERVAL", "3"))
 TEST_RETRACT_NO_PREFILL_BS = int(os.environ.get("SGLANG_TEST_RETRACT_NO_PREFILL_BS", str(2**31)))
 RECORD_STEP_TIME = get_bool_env_var("SGLANG_RECORD_STEP_TIME")
+# Debug: log per-phase scheduler-loop timing (recv / schedule / launch / result)
+# as running averages, to see what fraction of the step the scheduler thread
+# actually spends where. Off by default (zero prod overhead).
+SCHED_PHASE_TIME = get_bool_env_var("SGLANG_SCHED_PHASE_TIME")
+SCHED_PHASE_INTERVAL = int(os.environ.get("SGLANG_SCHED_PHASE_INTERVAL", "200"))
+# Optional: dump one row per forward step (step,bs,recv,sched,build,result in ms)
+# to this CSV path, so the host/forward ratio distribution (mean + percentiles)
+# can be computed offline. Implies phase timing. Off by default.
+SCHED_PHASE_CSV = os.environ.get("SGLANG_SCHED_PHASE_CSV")
+SCHED_PHASE_TIME = SCHED_PHASE_TIME or bool(SCHED_PHASE_CSV)
 GRAMMAR_TIMEOUT = float(os.environ.get("SGLANG_GRAMMAR_TIMEOUT", 300))
 
 
@@ -1081,13 +1091,23 @@ class Scheduler(
                 _gc.get_threshold(),
             )
 
+        _pt_acc = [0.0, 0.0, 0.0, 0.0]  # recv, schedule, build(run_batch), result
+        _pt_steps = 0  # forward steps only (batch non-None; run_batch fired)
+        _pt_iters = 0  # total loop iterations (spin ratio = iters/steps)
+        _pt_step_ct = 0  # monotonic step counter for the CSV
+        _pt_csv_rows = []  # buffered per-step rows, flushed every interval
+        if SCHED_PHASE_CSV:
+            with open(SCHED_PHASE_CSV, "w") as _f:
+                _f.write("step,bs,recv_ms,sched_ms,build_ms,result_ms\n")
         while True:
+            _pt0 = time.perf_counter() if SCHED_PHASE_TIME else 0.0
             _it0 = time.perf_counter() if _pd_iter_trace else 0.0
             recv_reqs = (
                 self._comm_backend.recv_requests()
                 if self._comm_backend is not None
                 else self.recv_requests()
             )
+            _pt_recv = time.perf_counter() if SCHED_PHASE_TIME else 0.0
             # Assign DP rank to incoming requests
             recv_reqs = self.select_dp_for_request(recv_reqs)
             self.process_input_requests(recv_reqs)
@@ -1099,6 +1119,7 @@ class Scheduler(
 
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
+            _pt_sched = time.perf_counter() if SCHED_PHASE_TIME else 0.0
             _it2 = time.perf_counter() if _pd_iter_trace else 0.0
 
             # HiCache: stage_load was issued during last round; flush must wait
@@ -1138,6 +1159,7 @@ class Scheduler(
                     with jax.profiler.TraceAnnotation("process_batch_result"):
                         self.process_batch_result(tmp_batch, None, batch.launch_done)
 
+            _pt_launch = time.perf_counter() if SCHED_PHASE_TIME else 0.0
             if self.last_batch:
                 # Process the results of the last batch
                 tmp_batch, tmp_result = self.result_queue.popleft()
@@ -1154,6 +1176,54 @@ class Scheduler(
                 self.check_tree_cache()
                 self.new_token_ratio = self.init_new_token_ratio
 
+            if SCHED_PHASE_TIME:
+                _pt_iters += 1
+                # Only count iterations that actually launched a forward (run_batch
+                # fired). The loop spins with batch=None while a forward is in flight;
+                # averaging over those spins dilutes the real per-step host cost.
+                if batch is not None:
+                    _pt_proc = time.perf_counter()
+                    _pt_acc[0] += _pt_recv - _pt0          # recv
+                    _pt_acc[1] += _pt_sched - _pt_recv     # schedule
+                    _pt_acc[2] += _pt_launch - _pt_sched   # build = run_batch (get_model_worker_batch + dispatch)
+                    _pt_acc[3] += _pt_proc - _pt_launch    # result = process_batch_result (forward-wait + D2H)
+                    _pt_steps += 1
+                    if SCHED_PHASE_CSV:
+                        _pt_step_ct += 1
+                        _pt_csv_rows.append(
+                            "%d,%d,%.4f,%.4f,%.4f,%.4f"
+                            % (
+                                _pt_step_ct,
+                                len(batch.reqs),
+                                (_pt_recv - _pt0) * 1e3,
+                                (_pt_sched - _pt_recv) * 1e3,
+                                (_pt_launch - _pt_sched) * 1e3,
+                                (_pt_proc - _pt_launch) * 1e3,
+                            )
+                        )
+                        if len(_pt_csv_rows) >= SCHED_PHASE_INTERVAL:
+                            with open(SCHED_PHASE_CSV, "a") as _f:
+                                _f.write("\n".join(_pt_csv_rows) + "\n")
+                            _pt_csv_rows = []
+                    if _pt_steps % SCHED_PHASE_INTERVAL == 0:
+                        _host = _pt_acc[0] + _pt_acc[1] + _pt_acc[2]  # recv+sched+build
+                        _fwdwait = _pt_acc[3]                          # result (mostly forward wait)
+                        logger.info(
+                            "[sched/fwd-step avg/%d steps, spin=%.0fx] HOST(recv+sched+build)=%.2fms "
+                            "[recv=%.2f sched=%.2f build=%.2f] | result(fwd-wait+D2H)=%.2fms  "
+                            "-> host %s forward",
+                            _pt_steps,
+                            _pt_iters / max(1, _pt_steps),
+                            _host / _pt_steps * 1e3,
+                            _pt_acc[0] / _pt_steps * 1e3,
+                            _pt_acc[1] / _pt_steps * 1e3,
+                            _pt_acc[2] / _pt_steps * 1e3,
+                            _fwdwait / _pt_steps * 1e3,
+                            "<" if _host < _fwdwait else ">=",
+                        )
+                        _pt_acc = [0.0, 0.0, 0.0, 0.0]
+                        _pt_steps = 0
+                        _pt_iters = 0
             self.last_batch = batch
             if _pd_iter_trace:
                 _it3 = time.perf_counter()

--- a/scripts/check_sched_masked.sh
+++ b/scripts/check_sched_masked.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Regression guard for issue #293: verify the scheduler's per-forward-step HOST
+# work (recv + schedule + build=get_model_worker_batch + dispatch) stays MASKED
+# under the TPU forward, so overlap hides it and the scheduler is not the
+# throughput bottleneck.
+#
+# Requires the env-gated SGLANG_SCHED_PHASE_TIME instrumentation in the server
+# (scheduler.event_loop_overlap logs "[sched/fwd-step ...]"). Run on a TPU host
+# (e.g. v6e-4). Exits 0 if masked (with margin), 1 if the scheduler is the
+# bottleneck (regression), 2 on parse/setup failure.
+#
+#   MARGIN=0.85 bash scripts/check_sched_masked.sh
+set -uo pipefail
+
+MODEL="${MODEL:-Qwen/Qwen3-8B}"
+# Pass if HOST < MARGIN * forward  (forward = HOST + result). 0.85 => require
+# >=15% headroom below the point where the scheduler stops being masked.
+MARGIN="${MARGIN:-0.85}"
+PORT="${PORT:-30000}"
+LOG="${LOG:-/tmp/sched_masked_server.log}"
+
+SGLANG_SCHED_PHASE_TIME=1 SGLANG_SCHED_PHASE_INTERVAL=100 \
+python -m sgl_jax.launch_server --model-path "$MODEL" --trust-remote-code \
+  --device tpu --dtype bfloat16 --tp-size 4 --mem-fraction-static 0.8 \
+  --page-size 64 --attention-backend fa --chunked-prefill-size 8192 \
+  --download-dir /dev/shm/ --host 127.0.0.1 --port "$PORT" > "$LOG" 2>&1 &
+SRV=$!
+trap 'kill "$SRV" 2>/dev/null || true' EXIT
+for _ in $(seq 1 120); do
+  curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && break; sleep 5
+done
+
+_bench() {  # in out nprompts conc
+  python -m sgl_jax.bench_serving --backend sgl-jax --model "$MODEL" \
+    --base-url "http://127.0.0.1:$PORT" --dataset-name random --num-prompts "$3" \
+    --random-input-len "$1" --random-output-len "$2" --random-range-ratio 1 \
+    --max-concurrency "$4" --warmup-requests 0 >/dev/null 2>&1
+}
+_bench 1024 64   8   8    # warmup / precompile
+_bench 1024 1024 200 16   # steady-state decode at the #293 config
+
+# Use a steady-state line (drop the last, which may catch tail/drain).
+line=$(grep "sched/fwd-step" "$LOG" | tail -5 | head -1)
+host=$(echo "$line" | sed -n 's/.*HOST(recv+sched+build)=\([0-9.]*\)ms.*/\1/p')
+res=$(echo "$line"  | sed -n 's/.*result(fwd-wait+D2H)=\([0-9.]*\)ms.*/\1/p')
+
+awk -v h="$host" -v r="$res" -v m="$MARGIN" 'BEGIN{
+  if (h=="" || r==""){ print "PARSE FAIL: no [sched/fwd-step] line (instrumentation missing?)"; exit 2 }
+  fwd = h + r;                 # forward = host overlap + remaining wait
+  ratio = h / fwd;
+  printf "sched HOST=%.2fms  forward=%.2fms  host/forward=%.2f  (margin=%.2f)\n", h, fwd, ratio, m;
+  if (ratio < m){ print "PASS: scheduler masked under the forward"; exit 0 }
+  else { print "FAIL: scheduler host >= "m"x forward -- #293 regression (not masked)"; exit 1 }
+}'

--- a/scripts/eval_scheduler_masking.sky.yaml
+++ b/scripts/eval_scheduler_masking.sky.yaml
@@ -1,0 +1,70 @@
+# Managed spot v6e-4 job for #293: masking-ratio DISTRIBUTION + GUARD in one run.
+# Runs random prompts with length variance (--random-range-ratio 0.5 => lengths
+# in [0.5L, L]) so batch shapes vary, dumps one row per forward step to a CSV
+# (SGLANG_SCHED_PHASE_CSV), then reports the mean AND distribution (p50/p90/p99 +
+# histogram) of host/forward AND exits non-zero if p99 >= margin (regression).
+#   sky jobs launch scripts/eval_scheduler_masking.sky.yaml -y   # job status = verdict
+name: scheduler-masking
+
+resources:
+  accelerators: tpu-v6e-4
+  accelerator_args:
+    tpu_vm: True
+    runtime_version: v2-alpha-tpuv6e
+  use_spot: True
+
+file_mounts:
+  /tmp/overlay_scheduler.py: ./python/sgl_jax/srt/managers/scheduler.py
+  /tmp/overlay_scripts: ./scripts
+
+setup: |
+  if [ -d "sglang-jax" ]; then pip uninstall -y sgl-jax || true && rm -rf sglang-jax; fi
+  git clone https://github.com/sgl-project/sglang-jax.git
+  cd sglang-jax   # main
+  echo "cloned main @ $(git rev-parse --short HEAD)"
+  cp -f /tmp/overlay_scheduler.py python/sgl_jax/srt/managers/scheduler.py
+  cp -f /tmp/overlay_scripts/*.sh scripts/ 2>/dev/null || true
+  cp -f /tmp/overlay_scripts/*.py scripts/ 2>/dev/null || true
+  uv venv --python 3.12
+  source .venv/bin/activate
+  uv pip install -e "python[all]"
+  bash scripts/killall_sglang.sh || true
+
+run: |
+  cd sglang-jax
+  source .venv/bin/activate
+  CSV=/tmp/phase.csv
+
+  echo "########## LAUNCH SERVER (per-step CSV on) ##########"
+  SGLANG_SCHED_PHASE_CSV=$CSV SGLANG_SCHED_PHASE_INTERVAL=50 \
+  python -m sgl_jax.launch_server --model-path Qwen/Qwen3-8B --trust-remote-code \
+    --device tpu --dtype bfloat16 --tp-size 4 \
+    --mem-fraction-static 0.8 --page-size 64 --attention-backend fa \
+    --chunked-prefill-size 8192 --download-dir /dev/shm/ \
+    --host 127.0.0.1 --port 30000 > /tmp/server.log 2>&1 &
+  for _ in $(seq 1 120); do curl -sf http://127.0.0.1:30000/health >/dev/null 2>&1 && break; sleep 5; done
+  echo "  server ready"
+
+  echo "########## WARMUP (precompile) ##########"
+  python -m sgl_jax.bench_serving --backend sgl-jax --model Qwen/Qwen3-8B \
+    --base-url http://127.0.0.1:30000 --dataset-name random --num-prompts 8 \
+    --random-input-len 1024 --random-output-len 64 --random-range-ratio 1 \
+    --max-concurrency 8 --warmup-requests 0 > /tmp/warmup.log 2>&1 || true
+
+  # Drop warmup steps so the distribution reflects only the varied load.
+  rm -f $CSV
+
+  echo "########## VARIED LOAD: 200 random prompts, lengths in [0.5x,1x], conc=16 ##########"
+  python -m sgl_jax.bench_serving --backend sgl-jax --model Qwen/Qwen3-8B \
+    --base-url http://127.0.0.1:30000 --dataset-name random --num-prompts 200 \
+    --random-input-len 1024 --random-output-len 1024 --random-range-ratio 0.5 \
+    --max-concurrency 16 --warmup-requests 0 > /tmp/bench.log 2>&1 || true
+
+  echo "########## MASKING RATIO DISTRIBUTION + GUARD ##########"
+  python scripts/summarize_phase.py $CSV --margin 0.85
+  rc=$?   # 0 = masked (p99 < margin), 1 = #293 regression -> job status = verdict
+  echo "########## bench summary ##########"
+  grep -iE "throughput|concurrency|latency|Successful" /tmp/bench.log | head -15
+  echo "########## rows: $(wc -l < $CSV) (incl header), GUARD rc=$rc ##########"
+  bash scripts/killall_sglang.sh >/dev/null 2>&1 || true
+  exit $rc

--- a/scripts/summarize_phase.py
+++ b/scripts/summarize_phase.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Summarize the scheduler per-step phase CSV (SGLANG_SCHED_PHASE_CSV).
+
+Reads step,bs,recv_ms,sched_ms,build_ms,result_ms and reports the distribution
+(mean + percentiles) of the host work, the forward step, and the masking ratio
+host/forward -- so we can see not just the average but the tail, over a varied
+workload. Pure stdlib, no numpy.
+
+  python scripts/summarize_phase.py /tmp/phase.csv [--margin 0.85]
+"""
+import argparse
+import csv
+
+
+def pct(xs, p):
+    if not xs:
+        return float("nan")
+    xs = sorted(xs)
+    k = (len(xs) - 1) * (p / 100.0)
+    lo = int(k)
+    hi = min(lo + 1, len(xs) - 1)
+    return xs[lo] + (xs[hi] - xs[lo]) * (k - lo)
+
+
+def stats_line(name, xs, unit="ms"):
+    if not xs:
+        return f"{name:<14} (no samples)"
+    mean = sum(xs) / len(xs)
+    return (
+        f"{name:<14} mean={mean:7.3f}  p50={pct(xs,50):7.3f}  p90={pct(xs,90):7.3f}  "
+        f"p99={pct(xs,99):7.3f}  max={max(xs):7.3f}  min={min(xs):7.3f} {unit}"
+    )
+
+
+def histogram(xs, lo, hi, nbins=20, width=50):
+    if not xs:
+        return
+    step = (hi - lo) / nbins
+    counts = [0] * nbins
+    for x in xs:
+        b = int((x - lo) / step) if step > 0 else 0
+        b = max(0, min(nbins - 1, b))
+        counts[b] += 1
+    peak = max(counts) or 1
+    for i, c in enumerate(counts):
+        edge = lo + i * step
+        bar = "#" * int(width * c / peak)
+        print(f"  [{edge:5.2f},{edge+step:5.2f})  {c:6d} |{bar}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("csv")
+    ap.add_argument("--margin", type=float, default=0.85,
+                    help="ratio below this = masked-with-headroom")
+    args = ap.parse_args()
+
+    host, fwd, ratio, res, build = [], [], [], [], []
+    bs = []
+    cols = ["step", "bs", "recv_ms", "sched_ms", "build_ms", "result_ms"]
+    with open(args.csv) as f:
+        first = f.readline()
+        f.seek(0)
+        # Tolerate a headerless CSV (e.g. if the header row was rotated away):
+        # if the first line isn't the header, supply the fixed field names.
+        has_header = first.startswith("step,")
+        reader = csv.DictReader(f) if has_header else csv.DictReader(f, fieldnames=cols)
+        for row in reader:
+            h = float(row["recv_ms"]) + float(row["sched_ms"]) + float(row["build_ms"])
+            r = float(row["result_ms"])
+            step = h + r
+            if step <= 0:
+                continue
+            host.append(h)
+            res.append(r)
+            build.append(float(row["build_ms"]))
+            fwd.append(step)
+            ratio.append(h / step)
+            bs.append(int(row["bs"]))
+
+    n = len(host)
+    print(f"\n===== scheduler phase distribution ({n} forward steps) =====")
+    print(stats_line("HOST", host))
+    print(stats_line("  build", build))
+    print(stats_line("result(fwd)", res))
+    print(stats_line("step=H+R", fwd))
+    print(stats_line("batch size", bs, unit=""))
+    print()
+    print(stats_line("host/forward", ratio, unit=""))
+
+    masked = sum(1 for x in ratio if x < 1.0)
+    headroom = sum(1 for x in ratio if x < args.margin)
+    print(
+        f"\nmasked (ratio<1.00): {masked}/{n} = {100*masked/max(1,n):.1f}%"
+        f"   |   with headroom (ratio<{args.margin:.2f}): {headroom}/{n} = {100*headroom/max(1,n):.1f}%"
+    )
+    worst = max(ratio) if ratio else float("nan")
+    print(f"worst-case ratio (p100/max): {worst:.3f}  -> "
+          f"{'PASS (all masked)' if worst < 1.0 else 'FAIL (some steps host-bound)'}")
+
+    print("\nhost/forward histogram:")
+    histogram(ratio, 0.0, 1.0)
+
+    # Verdict (also usable as a CI guard): gate on p99, not max -- a lone drain
+    # step (result~=0 => ratio 1.0) is a batch-boundary artifact, not un-masking.
+    p99 = pct(ratio, 99)
+    ok = p99 < args.margin
+    print(f"\nGUARD: p99 host/forward = {p99:.3f} {'<' if ok else '>='} margin {args.margin:.2f}"
+          f"  -> {'PASS (masked)' if ok else 'FAIL (#293 regression)'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())


### PR DESCRIPTION
## What
Adds env-gated per-forward-step timing of the scheduler overlap loop, split into `recv / schedule / build (get_model_worker_batch + dispatch) / result (forward-wait + D2H)`, plus a distribution analyzer and a masking regression guard.

- `SGLANG_SCHED_PHASE_TIME=1` → logs a running-average `[sched/fwd-step]` breakdown.
- `SGLANG_SCHED_PHASE_CSV=<path>` → also dumps one row per forward step for offline distribution analysis.

**Off by default** — when unset it's a couple of branch checks per loop, no syscalls, zero measurable overhead.

## Why (relates to #293)
#293 asked whether the scheduler thread is the throughput bottleneck. This makes it **measurable**. On current `main` (Qwen3-8B, tp=4, v6e-4):

- Single point (conc 16, 1024/1024): HOST ≈ **2.6–2.9 ms** (dominated by `build` ≈ 2.5 ms) vs forward ≈ **5.7–5.9 ms** → `host/forward ≈ 0.46`, **masked**. Throughput ≈ 2,450 tok/s confirms step ≈ forward, not host+forward.
- Distribution over a **varied** workload (`--random-range-ratio 0.5`, 10,350 forward steps): `host/forward` mean **0.449**, p90 0.486, **p99 0.523**, **100% of steps masked**.

So the scheduler is masked under the forward with ~2× headroom. Contributes a concrete performance check toward #1118.

## Files
| File | Purpose |
|------|---------|
| `python/sgl_jax/srt/managers/scheduler.py` | the env-gated instrumentation (only prod change) |
| `scripts/summarize_phase.py` | distribution (mean/p50/p90/p99 + histogram) **and** guard — exits non-zero if `p99 ≥ margin` |
| `scripts/eval_scheduler_masking.sky.yaml` | managed-spot v6e-4 job: varied workload → CSV → summarize; job status = verdict |
| `scripts/check_sched_masked.sh` | self-contained bash guard (no SkyPilot; runs directly on a TPU host) |

## Testing
Verified end-to-end on v6e-4 (SkyPilot managed spot): guard PASS, distribution as above. The guard gates on `p99 < margin` (default 0.85), robust to the lone batch-drain step where `result ≈ 0`.

Relates to #293, #1118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
