### PR TITLE
[Feat] Support simulated acceptance across speculative verify paths

### DIFF
--- a/docs/architecture/13-configuration-reference.md
+++ b/docs/architecture/13-configuration-reference.md
@@ -522,8 +522,9 @@ See [11-quantization](11-quantization.md#112-quantizationconfig).
 
 | Env var | Default | Description |
 |----------|--------|------|
-| `SIMULATE_ACC_LEN` | — | Simulate accept length (testing) |
-| `SIMULATE_ACC_METHOD` | `"multinomial"` | Simulated acceptance method |
+| `SIMULATE_ACC_LEN` | `-1` | Simulated total accept length, including the bonus token; values greater than 0 enable simulation |
+| `SIMULATE_ACC_METHOD` | `"match-expected"` | Acceptance-length sampling method (`match-expected` / `multinomial`) |
+| `SIMULATE_ACC_TOKEN_MODE` | `"fixed"` | Simulated token source (`fixed` / `real-draft-token`); real draft tokens require top-k 1 |
 | `RETURN_ORIGINAL_LOGPROB` | `"false"` | Return original log probability |
 
 ### Data Dump

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/bench_v2.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/bench_v2.py
@@ -5,6 +5,8 @@ Supports config sweeping via comma-separated env vars.
 
 Env vars:
   BENCH_TOKENS  — comma-separated token counts (default: 4096)
+  BENCH_VALID_TOKENS — valid tokens within a single static token shape
+  BENCH_DP      — logical data-axis size (default: 1)
   BENCH_BT      — comma-separated bt candidates (default: 128)
   BENCH_BF      — comma-separated bf candidates (default: 256)
   BENCH_BTC     — comma-separated btc candidates (default: 128)
@@ -18,6 +20,8 @@ Env vars:
   BENCH_WARMUP  — warmup iterations (default: 2)
   BENCH_ITERS   — timed iterations (default: 5)
   BENCH_CHECK   — 1 to run correctness check (single-host only)
+  BENCH_OUTPUT  — optional rank-0 metrics JSONL output path
+  BENCH_VARIANT — variant label written to BENCH_OUTPUT
   BENCH_SWIGLU_LIMIT — SwiGLU clamp limit for routed experts (default: off)
   BENCH_SHARED_SWIGLU_LIMIT — SwiGLU clamp limit for the shared expert (default: off)
   BENCH_D/F/E/TOPK — model dims (default: MiMo V2 Pro)
@@ -255,11 +259,17 @@ from sgl_jax.srt.kernels.fused_moe.v2.tuned_block_configs import (
     DEFAULT_V2_BLOCK_CONFIG,
     get_tuned_fused_moe_v2_block_config,
 )
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
 
 P = jax.sharding.PartitionSpec
 num_devices = jax.device_count()
-devices = np.array(jax.devices()).reshape(1, num_devices)
-mesh = jax.sharding.Mesh(devices, ("data", "tensor"))
+bench_dp_size = int(os.environ.get("BENCH_DP", "1"))
+if bench_dp_size <= 0 or num_devices % bench_dp_size != 0:
+    raise ValueError(f"BENCH_DP must be a positive divisor of {num_devices=}, got {bench_dp_size}.")
+mesh = create_device_mesh(
+    ici_parallelism=[bench_dp_size, num_devices // bench_dp_size],
+    dcn_parallelism=[1, 1],
+)
 ep_size = num_devices
 
 d = int(os.environ.get("BENCH_D", "6144"))
@@ -330,6 +340,21 @@ bf_candidates = parse_csv_int("BENCH_BF", [256])
 btc_candidates = parse_csv_int("BENCH_BTC", [128])
 bts_candidates = parse_csv_int_or_none("BENCH_BTS")
 token_candidates = parse_csv_int("BENCH_TOKENS", [4096])
+valid_tokens_env = os.environ.get("BENCH_VALID_TOKENS")
+if len(token_candidates) != 1 and valid_tokens_env is not None:
+    raise ValueError("BENCH_VALID_TOKENS requires exactly one BENCH_TOKENS value.")
+requested_valid_tokens = int(valid_tokens_env) if valid_tokens_env is not None else None
+if requested_valid_tokens is not None and (
+    requested_valid_tokens <= 0 or requested_valid_tokens > token_candidates[0]
+):
+    raise ValueError(
+        f"BENCH_VALID_TOKENS must be in [1, {token_candidates[0]}], got {requested_valid_tokens}."
+    )
+if requested_valid_tokens is not None and requested_valid_tokens % bench_dp_size != 0:
+    raise ValueError(
+        f"BENCH_VALID_TOKENS={requested_valid_tokens} must be divisible by "
+        f"BENCH_DP={bench_dp_size}."
+    )
 
 # Tuned-first defaulting: when the user did NOT explicitly pin any block-shape
 # param (BT/BF/BTC/BTS) and we're not sweeping (BENCH_TUNE), look the shape up in
@@ -564,15 +589,10 @@ def generate_tune_candidates(
         )
     )
 
-    bt_list = []
+    bt_list = _aligned_divisors(local_num_tokens, 8)
     for p_val in [2, 4]:
         if local_num_tokens == p_val:
             bt_list.append(p_val)
-    p = 8
-    while p <= local_num_tokens:
-        if local_num_tokens % p == 0:
-            bt_list.append(p)
-        p *= 2
     if not bt_list:
         bt_list = [local_num_tokens]
     bt_list = sorted(set(bt_list))
@@ -720,7 +740,14 @@ if tune_mode:
 
 ep_sharding = jax.sharding.NamedSharding(mesh, P(("data", "tensor")))
 
-log(f"model: E={E} d={d} f={f} k={top_k} ep={ep_size} fp8={use_fp8}")
+log(
+    f"model: E={E} d={d} f={f} k={top_k} ep={ep_size} "
+    f"mesh=({bench_dp_size},{num_devices // bench_dp_size}) fp8={use_fp8}"
+)
+log(
+    f"tokens: static={token_candidates} "
+    f"valid={requested_valid_tokens if requested_valid_tokens is not None else 'all'}"
+)
 if routing_mode != "random":
     log(f"routing_mode={routing_mode}")
 log(
@@ -909,6 +936,7 @@ results: list[tuple[int, str, float, list[float]]] = []
 
 for num_tokens in token_candidates:
     log(f"--- tokens={num_tokens} ---")
+    valid_tokens = requested_valid_tokens if requested_valid_tokens is not None else num_tokens
 
     if tune_mode:
         local_nt = num_tokens // ep_size
@@ -998,6 +1026,15 @@ for num_tokens in token_candidates:
         _, topk_idx = lax.top_k(gating, top_k)
         topk_logits = jnp.take_along_axis(gating, topk_idx, axis=-1)
         topk_wts = jax.nn.softmax(topk_logits, axis=-1)
+
+    if valid_tokens < num_tokens:
+        per_dp_tokens = num_tokens // bench_dp_size
+        valid_tokens_per_dp = valid_tokens // bench_dp_size
+        valid_mask = (
+            jnp.arange(num_tokens, dtype=jnp.int32).reshape(bench_dp_size, per_dp_tokens)
+            < valid_tokens_per_dp
+        ).reshape(-1)
+        topk_idx = jnp.where(valid_mask[:, None], topk_idx, -1)
 
     configs_to_try = [
         (bc_raw, *flags)
@@ -1135,6 +1172,34 @@ if jax.process_index() == 0 and results:
         if len(entries) > 1:
             for tag, avg, _ in entries[1:]:
                 log(f"    {avg:.3f}ms [{tag}]")
+
+    output_path = os.environ.get("BENCH_OUTPUT")
+    if output_path:
+        output = pathlib.Path(output_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        variant = os.environ.get("BENCH_VARIANT", "tune")
+        with output.open("w") as f_out:
+            for num_tokens, tag, avg, times in results:
+                row_valid_tokens = (
+                    requested_valid_tokens if requested_valid_tokens is not None else num_tokens
+                )
+                f_out.write(
+                    json.dumps(
+                        {
+                            "variant": variant,
+                            "tokens": num_tokens,
+                            "valid_tokens": row_valid_tokens,
+                            "dp_size": bench_dp_size,
+                            "tp_size": num_devices // bench_dp_size,
+                            "ep_size": ep_size,
+                            "config": tag,
+                            "latency_ms": float(avg),
+                            "samples_ms": [float(t) for t in times],
+                        }
+                    )
+                    + "\n"
+                )
+        log(f"wrote metrics: {output}")
 
 # --- Correctness check (optional, single-host only) ---
 if check_correctness:

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/bench_v2.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/bench_v2.py
@@ -5,8 +5,6 @@ Supports config sweeping via comma-separated env vars.
 
 Env vars:
   BENCH_TOKENS  — comma-separated token counts (default: 4096)
-  BENCH_VALID_TOKENS — valid tokens within a single static token shape
-  BENCH_DP      — logical data-axis size (default: 1)
   BENCH_BT      — comma-separated bt candidates (default: 128)
   BENCH_BF      — comma-separated bf candidates (default: 256)
   BENCH_BTC     — comma-separated btc candidates (default: 128)
@@ -20,8 +18,6 @@ Env vars:
   BENCH_WARMUP  — warmup iterations (default: 2)
   BENCH_ITERS   — timed iterations (default: 5)
   BENCH_CHECK   — 1 to run correctness check (single-host only)
-  BENCH_OUTPUT  — optional rank-0 metrics JSONL output path
-  BENCH_VARIANT — variant label written to BENCH_OUTPUT
   BENCH_SWIGLU_LIMIT — SwiGLU clamp limit for routed experts (default: off)
   BENCH_SHARED_SWIGLU_LIMIT — SwiGLU clamp limit for the shared expert (default: off)
   BENCH_D/F/E/TOPK — model dims (default: MiMo V2 Pro)
@@ -259,17 +255,11 @@ from sgl_jax.srt.kernels.fused_moe.v2.tuned_block_configs import (
     DEFAULT_V2_BLOCK_CONFIG,
     get_tuned_fused_moe_v2_block_config,
 )
-from sgl_jax.srt.utils.mesh_utils import create_device_mesh
 
 P = jax.sharding.PartitionSpec
 num_devices = jax.device_count()
-bench_dp_size = int(os.environ.get("BENCH_DP", "1"))
-if bench_dp_size <= 0 or num_devices % bench_dp_size != 0:
-    raise ValueError(f"BENCH_DP must be a positive divisor of {num_devices=}, got {bench_dp_size}.")
-mesh = create_device_mesh(
-    ici_parallelism=[bench_dp_size, num_devices // bench_dp_size],
-    dcn_parallelism=[1, 1],
-)
+devices = np.array(jax.devices()).reshape(1, num_devices)
+mesh = jax.sharding.Mesh(devices, ("data", "tensor"))
 ep_size = num_devices
 
 d = int(os.environ.get("BENCH_D", "6144"))
@@ -340,21 +330,6 @@ bf_candidates = parse_csv_int("BENCH_BF", [256])
 btc_candidates = parse_csv_int("BENCH_BTC", [128])
 bts_candidates = parse_csv_int_or_none("BENCH_BTS")
 token_candidates = parse_csv_int("BENCH_TOKENS", [4096])
-valid_tokens_env = os.environ.get("BENCH_VALID_TOKENS")
-if len(token_candidates) != 1 and valid_tokens_env is not None:
-    raise ValueError("BENCH_VALID_TOKENS requires exactly one BENCH_TOKENS value.")
-requested_valid_tokens = int(valid_tokens_env) if valid_tokens_env is not None else None
-if requested_valid_tokens is not None and (
-    requested_valid_tokens <= 0 or requested_valid_tokens > token_candidates[0]
-):
-    raise ValueError(
-        f"BENCH_VALID_TOKENS must be in [1, {token_candidates[0]}], got {requested_valid_tokens}."
-    )
-if requested_valid_tokens is not None and requested_valid_tokens % bench_dp_size != 0:
-    raise ValueError(
-        f"BENCH_VALID_TOKENS={requested_valid_tokens} must be divisible by "
-        f"BENCH_DP={bench_dp_size}."
-    )
 
 # Tuned-first defaulting: when the user did NOT explicitly pin any block-shape
 # param (BT/BF/BTC/BTS) and we're not sweeping (BENCH_TUNE), look the shape up in
@@ -589,10 +564,15 @@ def generate_tune_candidates(
         )
     )
 
-    bt_list = _aligned_divisors(local_num_tokens, 8)
+    bt_list = []
     for p_val in [2, 4]:
         if local_num_tokens == p_val:
             bt_list.append(p_val)
+    p = 8
+    while p <= local_num_tokens:
+        if local_num_tokens % p == 0:
+            bt_list.append(p)
+        p *= 2
     if not bt_list:
         bt_list = [local_num_tokens]
     bt_list = sorted(set(bt_list))
@@ -740,14 +720,7 @@ if tune_mode:
 
 ep_sharding = jax.sharding.NamedSharding(mesh, P(("data", "tensor")))
 
-log(
-    f"model: E={E} d={d} f={f} k={top_k} ep={ep_size} "
-    f"mesh=({bench_dp_size},{num_devices // bench_dp_size}) fp8={use_fp8}"
-)
-log(
-    f"tokens: static={token_candidates} "
-    f"valid={requested_valid_tokens if requested_valid_tokens is not None else 'all'}"
-)
+log(f"model: E={E} d={d} f={f} k={top_k} ep={ep_size} fp8={use_fp8}")
 if routing_mode != "random":
     log(f"routing_mode={routing_mode}")
 log(
@@ -936,7 +909,6 @@ results: list[tuple[int, str, float, list[float]]] = []
 
 for num_tokens in token_candidates:
     log(f"--- tokens={num_tokens} ---")
-    valid_tokens = requested_valid_tokens if requested_valid_tokens is not None else num_tokens
 
     if tune_mode:
         local_nt = num_tokens // ep_size
@@ -1026,15 +998,6 @@ for num_tokens in token_candidates:
         _, topk_idx = lax.top_k(gating, top_k)
         topk_logits = jnp.take_along_axis(gating, topk_idx, axis=-1)
         topk_wts = jax.nn.softmax(topk_logits, axis=-1)
-
-    if valid_tokens < num_tokens:
-        per_dp_tokens = num_tokens // bench_dp_size
-        valid_tokens_per_dp = valid_tokens // bench_dp_size
-        valid_mask = (
-            jnp.arange(num_tokens, dtype=jnp.int32).reshape(bench_dp_size, per_dp_tokens)
-            < valid_tokens_per_dp
-        ).reshape(-1)
-        topk_idx = jnp.where(valid_mask[:, None], topk_idx, -1)
 
     configs_to_try = [
         (bc_raw, *flags)
@@ -1172,34 +1135,6 @@ if jax.process_index() == 0 and results:
         if len(entries) > 1:
             for tag, avg, _ in entries[1:]:
                 log(f"    {avg:.3f}ms [{tag}]")
-
-    output_path = os.environ.get("BENCH_OUTPUT")
-    if output_path:
-        output = pathlib.Path(output_path)
-        output.parent.mkdir(parents=True, exist_ok=True)
-        variant = os.environ.get("BENCH_VARIANT", "tune")
-        with output.open("w") as f_out:
-            for num_tokens, tag, avg, times in results:
-                row_valid_tokens = (
-                    requested_valid_tokens if requested_valid_tokens is not None else num_tokens
-                )
-                f_out.write(
-                    json.dumps(
-                        {
-                            "variant": variant,
-                            "tokens": num_tokens,
-                            "valid_tokens": row_valid_tokens,
-                            "dp_size": bench_dp_size,
-                            "tp_size": num_devices // bench_dp_size,
-                            "ep_size": ep_size,
-                            "config": tag,
-                            "latency_ms": float(avg),
-                            "samples_ms": [float(t) for t in times],
-                        }
-                    )
-                    + "\n"
-                )
-        log(f"wrote metrics: {output}")
 
 # --- Correctness check (optional, single-host only) ---
 if check_correctness:

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
@@ -36,8 +36,8 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         ('bfloat16', 'float8_e4m3fn', 128, 384, 8, 6144, 2048, 32, False, False): (8, 512, 8, 256, 8),
         ('bfloat16', 'float8_e4m3fn', 256, 384, 8, 6144, 2048, 32, False, False): (8, 512, 16, 256, 16),
         ('bfloat16', 'float8_e4m3fn', 512, 384, 8, 6144, 2048, 32, False, False): (16, 1024, 32, 256, 32),
-        # Tuned on a (dp=4, tp=8) mesh with 768 valid tokens (2026-07-28).
-        ('bfloat16', 'float8_e4m3fn', 1024, 384, 8, 6144, 2048, 32, False, False): (32, 512, 24, 256, 24),
+        # Tuned on a (dp=4, tp=8) mesh for the BS=192 decode bucket (2026-07-28).
+        ('bfloat16', 'float8_e4m3fn', 768, 384, 8, 6144, 2048, 32, False, False): (24, 1024, 32, 256, 32),
         # Prefill configs
         ('bfloat16', 'float8_e4m3fn', 2048, 384, 8, 6144, 2048, 32, False, False): (128, 512, 128, 256, None),
         ('bfloat16', 'float8_e4m3fn', 4096, 384, 8, 6144, 2048, 32, False, False): (128, 512, 128, 256, None),

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
@@ -45,7 +45,7 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         # MiMo V2 Pro with activation quantization, ep=128
         ('bfloat16', 'float8_e4m3fn', 512, 384, 8, 6144, 2048, 128, False, False, True): (8, 1024, 32, 256, 32),
         ('bfloat16', 'float8_e4m3fn', 768, 384, 8, 6144, 2048, 128, False, False, True): (8, 1024, 32, 256, 32),
-        ('bfloat16', 'float8_e4m3fn', 2048, 384, 8, 6144, 2048, 128, False, False, True): (16, 1024, 8, 256, 56),
+        ('bfloat16', 'float8_e4m3fn', 2048, 384, 8, 6144, 2048, 128, False, False, True): (16, 1024, 56, 256, 56),
         ('bfloat16', 'float8_e4m3fn', 3072, 384, 8, 6144, 2048, 128, False, False, True): (24, 1024, 16, 256, 80),
         ('bfloat16', 'float8_e4m3fn', 4096, 384, 8, 6144, 2048, 128, False, False, True): (32, 1024, 112, 256, 112),
         ('bfloat16', 'float8_e4m3fn', 65536, 384, 8, 6144, 2048, 128, False, False, True): (256, 128, 8, 256, 856),

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
@@ -43,12 +43,12 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         ('bfloat16', 'float8_e4m3fn', 8192, 384, 8, 6144, 2048, 32, False, False): (128, 1024, 56, 256, 112),
         ('bfloat16', 'float8_e4m3fn', 16384, 384, 8, 6144, 2048, 32, False, False): (256, 1024, 72, 256, 216),
         # MiMo V2 Pro with activation quantization, ep=128
-        ('bfloat16', 'float8_e4m3fn', 512, 384, 8, 6144, 2048, 128, False, False, True): (8, 1024, 32, 256, 32),
+        ('bfloat16', 'float8_e4m3fn', 512, 384, 8, 6144, 2048, 128, False, False, True): (8, 1024, 24, 256, 24),
         ('bfloat16', 'float8_e4m3fn', 768, 384, 8, 6144, 2048, 128, False, False, True): (8, 1024, 32, 256, 32),
         ('bfloat16', 'float8_e4m3fn', 2048, 384, 8, 6144, 2048, 128, False, False, True): (16, 1024, 56, 256, 56),
-        ('bfloat16', 'float8_e4m3fn', 3072, 384, 8, 6144, 2048, 128, False, False, True): (24, 1024, 16, 256, 80),
+        ('bfloat16', 'float8_e4m3fn', 3072, 384, 8, 6144, 2048, 128, False, False, True): (24, 1024, 32, 256, 96),
         ('bfloat16', 'float8_e4m3fn', 4096, 384, 8, 6144, 2048, 128, False, False, True): (32, 1024, 112, 256, 112),
-        ('bfloat16', 'float8_e4m3fn', 65536, 384, 8, 6144, 2048, 128, False, False, True): (256, 128, 8, 256, 856),
+        ('bfloat16', 'float8_e4m3fn', 65536, 384, 8, 6144, 2048, 128, False, False, True): (256, 256, 8, 256, 856),
         # MiMo V2 Pro: E=384, H=6144, I=2048, top_k=8, fp8 e4m3, ep=8
         # Decode configs (tuned on bench-4 single-host v7x-16, 2026-05-21)
         ('bfloat16', 'float8_e4m3fn', 512, 384, 8, 6144, 2048, 8, False, False): (64, 1024, 32, 256, 32),

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
@@ -42,6 +42,11 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         ('bfloat16', 'float8_e4m3fn', 4096, 384, 8, 6144, 2048, 32, False, False): (128, 512, 128, 256, None),
         ('bfloat16', 'float8_e4m3fn', 8192, 384, 8, 6144, 2048, 32, False, False): (128, 1024, 56, 256, 112),
         ('bfloat16', 'float8_e4m3fn', 16384, 384, 8, 6144, 2048, 32, False, False): (256, 1024, 72, 256, 216),
+        # MiMo V2 Pro with activation quantization, ep=128
+        ('bfloat16', 'float8_e4m3fn', 512, 384, 8, 6144, 2048, 128, False, False, True): (8, 1024, 32, 256, 32),
+        ('bfloat16', 'float8_e4m3fn', 768, 384, 8, 6144, 2048, 128, False, False, True): (8, 1024, 32, 256, 32),
+        ('bfloat16', 'float8_e4m3fn', 4096, 384, 8, 6144, 2048, 128, False, False, True): (32, 1024, 112, 256, 112),
+        ('bfloat16', 'float8_e4m3fn', 65536, 384, 8, 6144, 2048, 128, False, False, True): (256, 128, 8, 256, 856),
         # MiMo V2 Pro: E=384, H=6144, I=2048, top_k=8, fp8 e4m3, ep=8
         # Decode configs (tuned on bench-4 single-host v7x-16, 2026-05-21)
         ('bfloat16', 'float8_e4m3fn', 512, 384, 8, 6144, 2048, 8, False, False): (64, 1024, 32, 256, 32),

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
@@ -36,6 +36,8 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         ('bfloat16', 'float8_e4m3fn', 128, 384, 8, 6144, 2048, 32, False, False): (8, 512, 8, 256, 8),
         ('bfloat16', 'float8_e4m3fn', 256, 384, 8, 6144, 2048, 32, False, False): (8, 512, 16, 256, 16),
         ('bfloat16', 'float8_e4m3fn', 512, 384, 8, 6144, 2048, 32, False, False): (16, 1024, 32, 256, 32),
+        # Tuned on a (dp=4, tp=8) mesh with 768 valid tokens (2026-07-28).
+        ('bfloat16', 'float8_e4m3fn', 1024, 384, 8, 6144, 2048, 32, False, False): (32, 512, 24, 256, 24),
         # Prefill configs
         ('bfloat16', 'float8_e4m3fn', 2048, 384, 8, 6144, 2048, 32, False, False): (128, 512, 128, 256, None),
         ('bfloat16', 'float8_e4m3fn', 4096, 384, 8, 6144, 2048, 32, False, False): (128, 512, 128, 256, None),

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
@@ -36,7 +36,6 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         ('bfloat16', 'float8_e4m3fn', 128, 384, 8, 6144, 2048, 32, False, False): (8, 512, 8, 256, 8),
         ('bfloat16', 'float8_e4m3fn', 256, 384, 8, 6144, 2048, 32, False, False): (8, 512, 16, 256, 16),
         ('bfloat16', 'float8_e4m3fn', 512, 384, 8, 6144, 2048, 32, False, False): (16, 1024, 32, 256, 32),
-        # Tuned on a (dp=4, tp=8) mesh for the BS=192 decode bucket (2026-07-28).
         ('bfloat16', 'float8_e4m3fn', 768, 384, 8, 6144, 2048, 32, False, False): (24, 1024, 32, 256, 32),
         # Prefill configs
         ('bfloat16', 'float8_e4m3fn', 2048, 384, 8, 6144, 2048, 32, False, False): (128, 512, 128, 256, None),

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
@@ -43,11 +43,11 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         ('bfloat16', 'float8_e4m3fn', 8192, 384, 8, 6144, 2048, 32, False, False): (128, 1024, 56, 256, 112),
         ('bfloat16', 'float8_e4m3fn', 16384, 384, 8, 6144, 2048, 32, False, False): (256, 1024, 72, 256, 216),
         # MiMo V2 Pro with activation quantization, ep=128
-        ('bfloat16', 'float8_e4m3fn', 512, 384, 8, 6144, 2048, 128, False, False, True): (8, 1024, 24, 256, 24),
-        ('bfloat16', 'float8_e4m3fn', 768, 384, 8, 6144, 2048, 128, False, False, True): (8, 1024, 32, 256, 32),
-        ('bfloat16', 'float8_e4m3fn', 2048, 384, 8, 6144, 2048, 128, False, False, True): (16, 1024, 56, 256, 56),
-        ('bfloat16', 'float8_e4m3fn', 3072, 384, 8, 6144, 2048, 128, False, False, True): (24, 1024, 32, 256, 96),
-        ('bfloat16', 'float8_e4m3fn', 4096, 384, 8, 6144, 2048, 128, False, False, True): (32, 1024, 112, 256, 112),
+        ('bfloat16', 'float8_e4m3fn', 512, 384, 8, 6144, 2048, 128, False, False, True): (8, 1024, 32, 256, 32),
+        ('bfloat16', 'float8_e4m3fn', 768, 384, 8, 6144, 2048, 128, False, False, True): (8, 1024, 48, 256, 48),
+        ('bfloat16', 'float8_e4m3fn', 2048, 384, 8, 6144, 2048, 128, False, False, True): (16, 1024, 64, 256, 64),
+        ('bfloat16', 'float8_e4m3fn', 3072, 384, 8, 6144, 2048, 128, False, False, True): (24, 1024, 96, 256, 96),
+        ('bfloat16', 'float8_e4m3fn', 4096, 384, 8, 6144, 2048, 128, False, False, True): (32, 1024, 64, 256, 128),
         ('bfloat16', 'float8_e4m3fn', 65536, 384, 8, 6144, 2048, 128, False, False, True): (256, 256, 8, 256, 856),
         # MiMo V2 Pro: E=384, H=6144, I=2048, top_k=8, fp8 e4m3, ep=8
         # Decode configs (tuned on bench-4 single-host v7x-16, 2026-05-21)

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
@@ -45,6 +45,8 @@ TUNED_BLOCK_CONFIGS: dict[str, dict[tuple, tuple[int, ...]]] = {
         # MiMo V2 Pro with activation quantization, ep=128
         ('bfloat16', 'float8_e4m3fn', 512, 384, 8, 6144, 2048, 128, False, False, True): (8, 1024, 32, 256, 32),
         ('bfloat16', 'float8_e4m3fn', 768, 384, 8, 6144, 2048, 128, False, False, True): (8, 1024, 32, 256, 32),
+        ('bfloat16', 'float8_e4m3fn', 2048, 384, 8, 6144, 2048, 128, False, False, True): (16, 1024, 8, 256, 56),
+        ('bfloat16', 'float8_e4m3fn', 3072, 384, 8, 6144, 2048, 128, False, False, True): (24, 1024, 16, 256, 80),
         ('bfloat16', 'float8_e4m3fn', 4096, 384, 8, 6144, 2048, 128, False, False, True): (32, 1024, 112, 256, 112),
         ('bfloat16', 'float8_e4m3fn', 65536, 384, 8, 6144, 2048, 128, False, False, True): (256, 128, 8, 256, 856),
         # MiMo V2 Pro: E=384, H=6144, I=2048, top_k=8, fp8 e4m3, ep=8

--- a/python/sgl_jax/srt/layers/logits_processor.py
+++ b/python/sgl_jax/srt/layers/logits_processor.py
@@ -255,6 +255,13 @@ class LogitsProcessor(nnx.Module):
         self.mesh = mesh
 
     def _select_hidden_states(self, hidden_states: jax.Array, indices: jax.Array) -> jax.Array:
+        # Sequence parallelism may shard the token axis over both data and
+        # tensor. Gather indices are DP-local, so restore the full token rows
+        # within each data shard before entering shard_map.
+        hidden_states = jax.sharding.reshard(
+            hidden_states, NamedSharding(self.mesh, P("data", None))
+        )
+
         def select_local_fn(local_states, local_indices):
             return local_states[local_indices]
 

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -20,6 +20,10 @@ from sgl_jax.srt.speculative.relay_buffer import (
     make_dp_valid_mask,
     update_spec_relay_buffers,
 )
+from sgl_jax.srt.speculative.spec_utils import (
+    SIMULATED_ACCEPTANCE_CONFIG,
+    apply_simulated_acceptance,
+)
 
 
 class GreedyDraftInputs(NamedTuple):
@@ -160,10 +164,13 @@ def _prepare_draft_inputs(
         gathered_positions = positions.at[safe_index].get(out_sharding=positions_sharding)
     else:
         gathered_positions = positions[safe_index]
+    new_seq_lens = seq_lens + accept_length + 1
+    if SIMULATED_ACCEPTANCE_CONFIG.enabled:
+        new_seq_lens = jnp.where(seq_lens > 0, new_seq_lens, 0)
     return GreedyDraftInputs(
         hidden_states=gathered_hidden,
         positions=gathered_positions,
-        new_seq_lens=seq_lens + accept_length + 1,
+        new_seq_lens=new_seq_lens,
         select_index=select_index,
         verified_id=verified_id,
         accept_lens=accept_length,
@@ -180,6 +187,7 @@ def _verify_greedy(
     target_predict,
     speculative_num_steps,
     speculative_num_draft_tokens,
+    simulation_rng=None,
 ):
     bs = seq_lens.shape[0]
     n = speculative_num_draft_tokens
@@ -200,9 +208,20 @@ def _verify_greedy(
     accept_index_children = jnp.where(accepted_children, base + child_offsets, -1)
     accept_index_2d = jnp.concatenate([base, accept_index_children], axis=1)
     accept_index_2d = jnp.where(is_padding[:, None], -1, accept_index_2d)
-    accept_index = accept_index_2d.reshape(-1)
 
     predict = target_predict.astype(jnp.int32).reshape(-1)
+    accept_index_2d, predict, accept_length = apply_simulated_acceptance(
+        accept_index=accept_index_2d,
+        predict=predict,
+        accept_lens=accept_length,
+        candidates=draft_2d,
+        target_predict=target_predict_2d,
+        valid_mask=~is_padding,
+        spec_steps=speculative_num_steps,
+        topk=1,
+        rng=simulation_rng,
+    )
+    accept_index = accept_index_2d.reshape(-1)
     accept_width = speculative_num_steps + 1
     req_ids = (
         jnp.zeros_like(accept_index)
@@ -253,6 +272,7 @@ def _verify_rejection_sampling(
     enable_top_p,
     speculative_num_steps,
     speculative_num_draft_tokens,
+    simulation_rng=None,
 ):
     """Non-greedy counterpart of the greedy chain verify.
 
@@ -336,6 +356,18 @@ def _verify_rejection_sampling(
     accept_index_children = jnp.where(accepted_children, base + child_offsets, -1)
     accept_index_2d = jnp.concatenate([base, accept_index_children], axis=1)
     accept_index_2d = jnp.where(is_padding[:, None], -1, accept_index_2d)
+    target_predict_2d = jnp.argmax(tl, axis=-1).astype(jnp.int32).reshape(bs, n)
+    accept_index_2d, predict, accept_length = apply_simulated_acceptance(
+        accept_index=accept_index_2d,
+        predict=predict,
+        accept_lens=accept_length,
+        candidates=draft_2d,
+        target_predict=target_predict_2d,
+        valid_mask=~is_padding,
+        spec_steps=speculative_num_steps,
+        topk=1,
+        rng=simulation_rng,
+    )
     accept_index = accept_index_2d.reshape(-1)
 
     accept_width = speculative_num_steps + 1
@@ -895,6 +927,8 @@ def _build_verify(topk: int):
         mesh = sh.mesh if isinstance(sh, NamedSharding) else None
         target_logits = target_output.next_token_logits
         target_hidden = target_output.hidden_states
+        sampling_rng = jax.random.fold_in(sampling_base_rng, sampling_step)
+        simulation_rng = jax.random.fold_in(sampling_rng, 1)
         if is_greedy:
             target_predict = jnp.argmax(target_logits, axis=-1).astype(jnp.int32).reshape(-1)
             prepared = _verify_greedy(
@@ -903,6 +937,7 @@ def _build_verify(topk: int):
                 seq_lens=target_forward_batch.seq_lens,
                 draft_tokens=draft_tokens,
                 target_predict=target_predict,
+                simulation_rng=simulation_rng,
                 speculative_num_steps=speculative_num_steps,
                 speculative_num_draft_tokens=speculative_num_draft_tokens,
             )
@@ -912,7 +947,6 @@ def _build_verify(topk: int):
             # the threefry/uniform ops fused into this module instead of becoming
             # standalone eager dispatches (the reason the earlier host-side jax.random
             # attempt was reverted).
-            sampling_rng = jax.random.fold_in(sampling_base_rng, sampling_step)
             coins_key, coin_f_key = jax.random.split(sampling_rng)
             coins = jax.random.uniform(
                 coins_key,
@@ -931,6 +965,7 @@ def _build_verify(topk: int):
                 top_ps=top_ps,
                 coins=coins,
                 coin_f=coin_f,
+                simulation_rng=simulation_rng,
                 threshold_single=threshold_single,
                 threshold_acc=threshold_acc,
                 enable_top_k=enable_top_k,

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -663,9 +663,7 @@ def _repack_page_indices(
     offset_deltas = src_offsets - dst_offsets
     offsets_sharding = jax.typeof(offset_deltas).sharding
     offsets_out_sharding = offsets_sharding if isinstance(offsets_sharding, NamedSharding) else None
-    slot_offset_deltas = offset_deltas.at[dp_ids, slot_ids].get(
-        out_sharding=offsets_out_sharding
-    )
+    slot_offset_deltas = offset_deltas.at[dp_ids, slot_ids].get(out_sharding=offsets_out_sharding)
     gather_src = (
         dp_ids * pages_per_dp
         + slot_offset_deltas

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -660,14 +660,16 @@ def _repack_page_indices(
     valid = jnp.any(in_req, axis=2)
 
     dp_ids = jnp.arange(dp_size, dtype=jnp.int32)[:, None]
-    offsets_sharding = jax.typeof(src_offsets).sharding
+    offset_deltas = src_offsets - dst_offsets
+    offsets_sharding = jax.typeof(offset_deltas).sharding
     offsets_out_sharding = offsets_sharding if isinstance(offsets_sharding, NamedSharding) else None
-    src_slot_offsets = src_offsets.at[dp_ids, slot_ids].get(out_sharding=offsets_out_sharding)
-    dst_slot_offsets = dst_offsets.at[dp_ids, slot_ids].get(out_sharding=offsets_out_sharding)
+    slot_offset_deltas = offset_deltas.at[dp_ids, slot_ids].get(
+        out_sharding=offsets_out_sharding
+    )
     gather_src = (
         dp_ids * pages_per_dp
-        + src_slot_offsets
-        + (jnp.arange(pages_per_dp, dtype=jnp.int32)[None, :] - dst_slot_offsets)
+        + slot_offset_deltas
+        + jnp.arange(pages_per_dp, dtype=jnp.int32)[None, :]
     )
     page_sharding = jax.typeof(page_indices).sharding
     out_sharding = page_sharding if isinstance(page_sharding, NamedSharding) else None

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import functools
-import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -43,9 +42,10 @@ from sgl_jax.srt.mem_cache.common import (
 )
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
 from sgl_jax.srt.speculative.overlap_utils import use_legacy_eagle3_non_overlap
-
-SIMULATE_ACC_LEN = os.environ.get("SIMULATE_ACC_LEN")
-SIMULATE_ACC_METHOD = os.environ.get("SIMULATE_ACC_METHOD", "multinomial")
+from sgl_jax.srt.speculative.spec_utils import (
+    SIMULATED_ACCEPTANCE_CONFIG,
+    apply_simulated_acceptance,
+)
 
 
 def _is_jax_leaf(value: Any) -> bool:
@@ -1107,6 +1107,7 @@ class EagleVerifyInput:
         #     pass
 
         is_all_greedy = sampling_info.is_all_greedy
+        candidates = self.draft_token.reshape(bs, self.draft_token_num)
 
         if is_all_greedy:
             with jax.set_mesh(mesh):
@@ -1121,7 +1122,6 @@ class EagleVerifyInput:
                 )
         else:
             bs = self.retrive_index.shape[0]
-            candidates = self.draft_token.reshape(bs, self.draft_token_num)
             predict_shape = list(logits_output.next_token_logits.shape)[:-1]
             predict_shape[-1] += 1
             predict = jnp.zeros(predict_shape, dtype=jnp.int32)
@@ -1170,17 +1170,25 @@ class EagleVerifyInput:
                 threshold_acc=global_server_args_dict["speculative_accept_threshold_acc"],
                 deterministic=True,
             )
-        if SIMULATE_ACC_LEN:
-            # Do simulation
-            _, rng = jax.random.split(rng.params())
-            accept_index, accept_length, predict = _generate_simulated_accept_index(
+
+        accept_length = accept_length + 1
+        if SIMULATED_ACCEPTANCE_CONFIG.enabled:
+            target_predict = None
+            if SIMULATED_ACCEPTANCE_CONFIG.token_mode == "real-draft-token":
+                target_predict = jnp.argmax(logits_output.next_token_logits, axis=-1).reshape(
+                    bs, self.draft_token_num
+                )
+            simulation_rng = jax.random.split(rng.params())[1]
+            accept_index, predict, accept_length = apply_simulated_acceptance(
                 accept_index=accept_index,
                 predict=predict,
-                accept_length=accept_length,
-                simulate_acc_len=SIMULATE_ACC_LEN,
-                bs=bs,
+                accept_lens=accept_length,
+                candidates=candidates,
+                target_predict=target_predict,
+                valid_mask=accept_index[:, 0] >= 0,
                 spec_steps=self.spec_steps,
-                rng=rng,
+                topk=self.topk,
+                rng=simulation_rng,
             )
 
         for arr in (predict, accept_index, accept_length):
@@ -1190,62 +1198,10 @@ class EagleVerifyInput:
         accept_index = np.asarray(accept_index)
         accept_length = np.asarray(accept_length)
 
-        accept_length = accept_length + 1
         accept_index = accept_index.flatten()
         verified_id = np.zeros_like(accept_index, dtype=predict.dtype)
         verified_id[accept_index != -1] = predict[accept_index[accept_index != -1]]
         return predict, verified_id, accept_length, accept_index
-
-
-def _generate_simulated_accept_index(
-    accept_index: jax.Array,
-    predict,
-    accept_length,
-    simulate_acc_len,
-    bs,
-    spec_steps,
-    rng: nnx.Rngs,
-):
-    simulate_acc_len_float = float(simulate_acc_len)
-    if SIMULATE_ACC_METHOD == "multinomial":
-        # here data is on cpu
-        simulated_values = numpy.random.normal(
-            loc=simulate_acc_len_float,
-            scale=1.0,
-            size=(1,),
-        )
-        # clamp simulated values to be between 1 and self.spec_steps
-        simulated_values = jnp.clip(simulated_values, min=1.0, max=spec_steps + 1)
-        simulate_acc_len = int(simulated_values.round().item())
-    elif SIMULATE_ACC_METHOD == "match-expected":
-        # multinomial sampling does not match the expected length
-        # we keep it for the sake of compatibility of existing tests
-        # but it's better to use "match-expected" for the cases that need to
-        # match the expected length, One caveat is that this will only sample
-        # either round down or round up of the expected length
-        simulate_acc_len_float = max(1.0, min(spec_steps + 1, simulate_acc_len_float))
-        lower = int(simulate_acc_len_float // 1)
-        upper = lower + 1 if lower < spec_steps + 1 else lower
-        if lower == upper:
-            simulate_acc_len = lower
-        else:
-            weight_upper = simulate_acc_len_float - lower
-            weight_lower = 1.0 - weight_upper
-            # here, data is on cpu
-            probs = jnp.array([weight_lower, weight_upper])
-            sampled_index = jax.random.categorical(rng, jnp.log(probs))
-            simulate_acc_len = lower if sampled_index == 0 else upper
-    else:
-        raise ValueError(f"Invalid simulate_acc_method: {SIMULATE_ACC_METHOD}")
-
-    accept_indx_first_col = accept_index[:, 0].reshape(-1, 1)
-    sim_accept_index = jnp.full((bs, spec_steps + 1), -1, dtype=jnp.int32)
-    sim_accept_index = sim_accept_index.at[:, :simulate_acc_len].set(
-        accept_indx_first_col + jnp.arange(simulate_acc_len)
-    )
-    accept_length = accept_length.at[:].set(simulate_acc_len - 1)
-    predict = predict.at[:].set(100)  # some legit token id
-    return sim_accept_index, accept_length, predict
 
 
 def assign_req_to_token_pool(

--- a/python/sgl_jax/srt/speculative/spec_utils.py
+++ b/python/sgl_jax/srt/speculative/spec_utils.py
@@ -1,0 +1,140 @@
+"""Shared utilities for speculative decoding."""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+
+
+@dataclass(frozen=True)
+class SimulatedAcceptanceConfig:
+    accept_len: float
+    method: str
+    token_mode: str
+    enabled: bool
+
+
+def _load_config() -> SimulatedAcceptanceConfig:
+    raw_len = os.environ.get("SIMULATE_ACC_LEN")
+
+    try:
+        accept_len = float(raw_len) if raw_len is not None else -1.0
+    except ValueError as exc:
+        raise ValueError(f"SIMULATE_ACC_LEN must be a float, got {raw_len!r}.") from exc
+
+    method = os.environ.get("SIMULATE_ACC_METHOD", "match-expected")
+    token_mode = os.environ.get("SIMULATE_ACC_TOKEN_MODE", "fixed")
+    enabled = accept_len > 0
+    if enabled and method not in ("match-expected", "multinomial"):
+        raise ValueError(
+            f"Invalid SIMULATE_ACC_METHOD {method!r}; expected 'match-expected' or 'multinomial'."
+        )
+    if enabled and token_mode not in ("fixed", "real-draft-token"):
+        raise ValueError(
+            f"Invalid SIMULATE_ACC_TOKEN_MODE {token_mode!r}; expected "
+            "'fixed' or 'real-draft-token'."
+        )
+
+    return SimulatedAcceptanceConfig(
+        accept_len=accept_len,
+        method=method,
+        token_mode=token_mode,
+        enabled=enabled,
+    )
+
+
+SIMULATED_ACCEPTANCE_CONFIG = _load_config()
+
+
+def _sample_accept_len(rng: jax.Array, max_len: int) -> jax.Array:
+    config = SIMULATED_ACCEPTANCE_CONFIG
+    clamped_len = max(1.0, min(float(max_len), config.accept_len))
+
+    if config.method == "multinomial":
+        sampled = jnp.rint(
+            jax.random.normal(rng, shape=(), dtype=jnp.float32) + clamped_len
+        ).astype(jnp.int32)
+        return jnp.clip(sampled, 1, max_len)
+
+    lower = math.floor(clamped_len)
+    upper = min(lower + 1, max_len)
+    if lower == upper:
+        return jnp.asarray(lower, dtype=jnp.int32)
+
+    use_upper = jax.random.uniform(rng, shape=(), dtype=jnp.float32) < (clamped_len - lower)
+    return jnp.where(use_upper, upper, lower).astype(jnp.int32)
+
+
+def apply_simulated_acceptance(
+    *,
+    accept_index: jax.Array,
+    predict: jax.Array,
+    accept_lens: jax.Array,
+    candidates: jax.Array,
+    target_predict: jax.Array | None,
+    valid_mask: jax.Array,
+    spec_steps: int,
+    topk: int,
+    rng: jax.Array | None,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Replace real verify results with a fixed-shape simulated result."""
+    config = SIMULATED_ACCEPTANCE_CONFIG
+    if not config.enabled:
+        return accept_index, predict, accept_lens
+
+    if config.token_mode == "real-draft-token" and topk != 1:
+        raise ValueError(
+            "SIMULATE_ACC_TOKEN_MODE='real-draft-token' requires speculative_eagle_topk=1."
+        )
+    if rng is None:
+        raise ValueError("An RNG key is required when simulated acceptance is enabled.")
+
+    width = spec_steps + 1
+    if accept_index.ndim != 2 or accept_index.shape[1] != width:
+        raise ValueError(
+            f"accept_index must have shape (batch_size, {width}), got {accept_index.shape}."
+        )
+
+    simulated_len = _sample_accept_len(rng, width)
+    offsets = jnp.arange(width, dtype=jnp.int32)
+    accepted_mask = offsets[None, :] < simulated_len
+    valid_mask = valid_mask.astype(jnp.bool_)
+
+    base = accept_index[:, :1]
+    simulated_index = jnp.where(accepted_mask, base + offsets[None, :], -1)
+    simulated_index = jnp.where(valid_mask[:, None], simulated_index, -1)
+    simulated_lens = jnp.where(valid_mask, simulated_len, 0).astype(jnp.int32)
+
+    if config.token_mode == "fixed":
+        return simulated_index, jnp.full_like(predict, 100), simulated_lens
+
+    if target_predict is None:
+        raise ValueError(
+            "target_predict is required when SIMULATE_ACC_TOKEN_MODE='real-draft-token'."
+        )
+    if candidates.shape[1] < width or target_predict.shape[1] < width:
+        raise ValueError(
+            f"candidates and target_predict must contain at least {width} tokens per request."
+        )
+
+    draft_columns = jnp.minimum(offsets + 1, candidates.shape[1] - 1)
+    draft_values = jnp.take(candidates, draft_columns, axis=1)
+    target_values = target_predict[:, :width]
+    simulated_values = jnp.where(
+        offsets[None, :] == simulated_len - 1,
+        target_values,
+        draft_values,
+    ).astype(predict.dtype)
+
+    write_mask = accepted_mask & valid_mask[:, None]
+    scatter_index = jnp.where(write_mask, simulated_index, predict.size)
+    predict = predict.at[scatter_index.reshape(-1)].set(
+        simulated_values.reshape(-1),
+        mode="drop",
+        out_sharding=jax.typeof(predict).sharding,
+    )
+    return simulated_index, predict, simulated_lens

--- a/python/sgl_jax/srt/speculative/spec_utils.py
+++ b/python/sgl_jax/srt/speculative/spec_utils.py
@@ -110,7 +110,7 @@ def apply_simulated_acceptance(
     simulated_lens = jnp.where(valid_mask, simulated_len, 0).astype(jnp.int32)
 
     if config.token_mode == "fixed":
-        return simulated_index, jnp.full_like(predict, 100), simulated_lens
+        return simulated_index, jnp.full_like(predict, 32), simulated_lens
 
     if target_predict is None:
         raise ValueError(


### PR DESCRIPTION
## Motivation
This feature makes it possible to benchmark speculative decoding throughput at controlled acceptance lengths without modifying the model or acceptance thresholds.Token ID 32 is used in fixed mode instead of token ID 100 because MiMo decodes token 100 as an incomplete UTF-8 replacement character. That behavior delays detokenizer progress and can distort serving benchmarks by reducing average throughput and producing bursty peak throughput.

## Summary
This PR adds configurable speculative acceptance-length simulation for benchmarking in SGLang-JAX. The implementation is shared by fused NEXTN and non-fused EAGLE verification paths, including both greedy and rejection sampling.
  
## Changes

- Add `SIMULATE_ACC_LEN` to control the expected total accepted length.
- Add two sampling methods through `SIMULATE_ACC_METHOD`:
  - `match-expected`: deterministically uses integer values and probabilistically samples between adjacent integers for fractional values.
  - `multinomial`: samples around the configured acceptance length with a standard deviation of 1.0.
- Add two token reconstruction modes through `SIMULATE_ACC_TOKEN_MODE`:
  - `fixed`: fills simulated output with token ID 32, a printable and non-special token for the MiMo tokenizer.
  - `real-draft-token`: preserves accepted draft tokens and uses the target token at the rejection boundary.
- Apply the simulated verification result consistently to fused greedy, fused rejection, and non-fused speculative decoding paths.
- Keep behavior unchanged when `SIMULATE_ACC_LEN` is unset or non-positive.

## Testing

### Status
- Model path: /models/MiMo-V2.5-Pro
- Radix cache: disabled
- Hardware:
    - TPU type: tpu-v7x
    - Topology: 2x2x4 replicas
    - Chips: 16 physical chips / 32 JAX devices
- Versions:
    - engine: sglang-jax 0.0.0.dev595+ga79b31669 @ a79b31669 (haifeng/feat/spec-SIMULATE_ACC_LEN)
    - jax: 0.10.2
    - jaxlib: 0.10.2
    - libtpu: 0.0.42.1

### Result

SIMULATE_ACC_TOKEN_MODE=real-draft-token、acc=3/4（16K input、1K output）

| Concurrency | No-MTP Peak tok/s | real-draft-token acc=3 Peak tok/s | real-draft-token acc=4 Peak tok/s |
|---:|---:|---:|---:|
| 32 | 1,824 | 3,033 | 4,062 |
| 64 | 3,072 | 7,129 | 9,392 |
| 128 | 4,864 | 11,103 | 14,736 |
| 192 | 6,144 | 13,440 | 17,632 |


SIMULATE_ACC_TOKEN_MODE=fixed、acc=3/4（16K input、1K output）


| Concurrency | No-MTP Peak tok/s | fixed acc=3 Peak tok/s | fixed acc=4 Peak tok/s |
|---:|---:|---:|---:|
| 32 | 1,824 | 3,136 | 4,178 |
| 64 | 3,072 | 6,332 | 8,439 |
| 128 | 4,864 | 9,842 | 13,169 |
| 192 | 6,144 | 11,208 | 15,074 |

### Command
```bash
LIBTPU_INIT_ARGS="\
--xla_tpu_dvfs_p_state=7 \
--xla_tpu_enable_sparse_core_collective_offload_all_gather=false \
--xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=false \
--xla_tpu_enable_sparse_core_collective_offload_all_reduce=false" \
SIMULATE_ACC_LEN=4 \
SIMULATE_ACC_METHOD=match-expected \
SIMULATE_ACC_TOKEN_MODE=real-draft-token \
uv run python3 -m sgl_jax.launch_server \
  --model-path /models/MiMo-V2.5-Pro \
  --trust-remote-code \
  --enable-sequence-parallel \
  --tp-size 32 \
  --dp-size 4 \
  --ep-size 32 \
  --moe-backend fused_v2 \
  --nnodes "$NNODES" \
  --node-rank "$NODE_RANK" \
  --dist-init-addr "$DIST_ADDR" \
  --host 0.0.0.0 \
  --port 30271 \
  --page-size 256 \
  --context-length 262144 \
  --disable-radix-cache \
  --chunked-prefill-size 4096 \
  --dtype bfloat16 \
  --mem-fraction-static 0.84 \
  --swa-full-tokens-ratio 0.3 \
  --skip-server-warmup \
  --log-level info \
  --decode-log-interval 1 \
  --max-running-requests 256 \
  --dp-schedule-policy round_robin \
  --precompile-bs-paddings 1 4 8 16 32 64 128 192 256 \
  --precompile-token-paddings 4096 \
  --speculative-algorithm NEXTN \
  --speculative-num-steps 3 \
  --speculative-num-draft-tokens 4 \
  --speculative-eagle-topk 1 \
  --speculative-accept-threshold-single 1.0 \
  --speculative-accept-threshold-acc 1.0
```

```bash
for bs in 32 64 128 192; do
num_prompts=$((bs * 3))
mkdir -p "$out/bs_${bs}"

uv run python3 -m sgl_jax.bench_serving \
  --backend sgl-jax \
  --base-url http://127.0.0.1:30271 \
  --model /models/MiMo-V2.5-Pro \
  --dataset-name random \
  --random-input-len 16384 \
  --random-output-len 1024 \
  --random-range-ratio 1 \
  --max-concurrency "$bs" \
  --num-prompts "$num_prompts" \
  --warmup-requests 0 \
  --flush-cache \
  --output-file "$out/bs_${bs}/result.jsonl"
done

```

