### PR TITLE
Add sort-free top-k Pallas kernels

### DIFF
--- a/benchmark/kernels/biased_topk/bench_biased_topk.py
+++ b/benchmark/kernels/biased_topk/bench_biased_topk.py
@@ -1,0 +1,228 @@
+"""Profile gate-fed JAX top-k against the biased top-k Pallas kernel on TPU.
+
+The gate matmul and sigmoid stay outside the measured scopes so both routing
+paths receive the layout produced by the real MiMo gate.
+"""
+
+import argparse
+import functools
+import glob
+import gzip
+import json
+import os
+import re
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.kernels.biased_topk import biased_topk_pallas
+
+TRACE_ROOT = os.environ.get("TOPK_TRACE_ROOT", "/tmp/tpu_logs/biased_topk_bench")
+HIDDEN_SIZE = 6144
+EXPERTS = 384
+TOPK = 8
+SCOPE_JAX = "BIASED_TOPK_JAX"
+SCOPE_PALLAS = "BIASED_TOPK_PALLAS"
+
+
+def reference_biased_topk(router_logits, correction_bias, *, topk):
+    scores = router_logits.astype(jnp.float32) + correction_bias.astype(jnp.float32)
+    ids = jax.lax.top_k(scores, topk)[1]
+    weights = jnp.take_along_axis(router_logits.astype(jnp.float32), ids, axis=1)
+    return weights, ids
+
+
+def make_router_logits(gate_weight):
+    def prepare(hidden_states):
+        return jax.nn.sigmoid(
+            jnp.dot(hidden_states, gate_weight, precision=jax.lax.Precision.HIGHEST)
+        )
+
+    return prepare
+
+
+def make_jax_route(correction_bias):
+    def route(router_logits):
+        with jax.named_scope(SCOPE_JAX):
+            return reference_biased_topk(
+                router_logits,
+                correction_bias,
+                topk=TOPK,
+            )
+
+    return route
+
+
+def make_pallas_route(correction_bias, block_tokens):
+    def route(router_logits):
+        with jax.named_scope(SCOPE_PALLAS):
+            return biased_topk_pallas(
+                router_logits,
+                correction_bias,
+                topk=TOPK,
+                block_tokens=block_tokens,
+                interpret=False,
+            )
+
+    return route
+
+
+def _scope_device_us(run_fn, scope, tag, *, warmup=5, iters=20):
+    for _ in range(warmup):
+        jax.block_until_ready(run_fn())
+    trace_root = os.path.join(
+        TRACE_ROOT,
+        f"{re.sub(r'[^A-Za-z0-9]', '_', tag)}_{os.getpid()}_{int(time.time() * 1000)}",
+    )
+    os.makedirs(trace_root, exist_ok=True)
+    with jax.profiler.trace(trace_root):
+        for step in range(iters):
+            with jax.profiler.StepTraceAnnotation("biased_topk", step_num=step):
+                jax.block_until_ready(run_fn())
+
+    profile_dirs = glob.glob(os.path.join(trace_root, "plugins", "profile", "*"))
+    if not profile_dirs:
+        return float("nan"), trace_root
+    latest = max(profile_dirs, key=os.path.getmtime)
+    events = []
+    for trace_file in sorted(glob.glob(os.path.join(latest, "*.trace.json.gz"))):
+        with gzip.open(trace_file) as file:
+            events.extend(json.load(file).get("traceEvents", []))
+
+    process_names = {}
+    thread_names = {}
+    for event in events:
+        if event.get("ph") != "M":
+            continue
+        args = event.get("args", {})
+        if event["name"] == "process_name":
+            process_names[event["pid"]] = args.get("name", "")
+        elif event["name"] == "thread_name":
+            thread_names[(event["pid"], event["tid"])] = args.get("name", "")
+
+    module_count = 0
+    scope_total_us = 0.0
+    for event in events:
+        if event.get("ph") != "X":
+            continue
+        if process_names.get(event["pid"]) != "/device:TPU:0":
+            continue
+        thread = thread_names.get((event["pid"], event["tid"]), "")
+        if thread == "XLA Modules":
+            module_count += 1
+            continue
+        if thread != "XLA Ops":
+            continue
+        blob = event["name"] + " " + json.dumps(event.get("args", {}))
+        if scope not in blob:
+            continue
+        duration_ps = event.get("args", {}).get("device_duration_ps")
+        if duration_ps is not None:
+            scope_total_us += float(duration_ps) / 1e6
+    if module_count == 0:
+        return float("nan"), trace_root
+    return scope_total_us / module_count, trace_root
+
+
+def benchmark_one(tokens, block_tokens):
+    gate_weight = jax.random.normal(
+        jax.random.key(0),
+        (HIDDEN_SIZE, EXPERTS),
+        dtype=jnp.float32,
+    )
+    correction_bias = (
+        jax.random.normal(
+            jax.random.key(1),
+            (EXPERTS,),
+            dtype=jnp.float32,
+        )
+        * 0.1
+    )
+    hidden_states = jax.random.normal(
+        jax.random.key(2),
+        (tokens, HIDDEN_SIZE),
+        dtype=jnp.bfloat16,
+    )
+    prepare_router_logits = jax.jit(make_router_logits(gate_weight))
+    router_logits = prepare_router_logits(hidden_states)
+    jax.block_until_ready(router_logits)
+    jax_fn = jax.jit(make_jax_route(correction_bias))
+    pallas_fn = jax.jit(make_pallas_route(correction_bias, block_tokens))
+
+    expected_weights, expected_ids = jax_fn(router_logits)
+    actual_weights, actual_ids = pallas_fn(router_logits)
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_array_equal(
+        np.asarray(actual_weights),
+        np.asarray(expected_weights),
+    )
+
+    jax_us, jax_trace = _scope_device_us(
+        functools.partial(jax_fn, router_logits),
+        SCOPE_JAX,
+        f"jax_t{tokens}",
+    )
+    pallas_us, pallas_trace = _scope_device_us(
+        functools.partial(pallas_fn, router_logits),
+        SCOPE_PALLAS,
+        f"pallas_t{tokens}",
+    )
+    return jax_us, pallas_us, jax_trace, pallas_trace
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tokens",
+        default="64,128,256,512,1024,2048,4096,8192,16384,32768",
+    )
+    parser.add_argument("--block-tokens", default="auto")
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    block_tokens = args.block_tokens if args.block_tokens == "auto" else int(args.block_tokens)
+    print(f"JAX {jax.__version__} | {jax.devices()[0].device_kind}")
+    print("MiMo gate-fed routing: H=6144 E=384 k=8; exact device_duration_ps")
+    print(f"{'T':>7} {'jax_us':>10} {'pallas_us':>10} {'speedup':>9}")
+    measurements = []
+    for tokens in (int(value) for value in args.tokens.split(",")):
+        jax_us, pallas_us, jax_trace, pallas_trace = benchmark_one(
+            tokens,
+            block_tokens,
+        )
+        speedup = jax_us / pallas_us if pallas_us > 0 else float("nan")
+        print(f"{tokens:7d} {jax_us:10.2f} {pallas_us:10.2f} {speedup:8.2f}x")
+        print(f"  traces: {jax_trace} {pallas_trace}")
+        common = {
+            "phase": "benchmark",
+            "tokens": tokens,
+            "experts": EXPERTS,
+            "topk": TOPK,
+            "block_tokens": block_tokens,
+        }
+        measurements.extend(
+            [
+                {
+                    **common,
+                    "variant": "jax",
+                    "device_duration_us": jax_us,
+                    "latency_ms": jax_us / 1000.0,
+                },
+                {
+                    **common,
+                    "variant": "pallas",
+                    "device_duration_us": pallas_us,
+                    "latency_ms": pallas_us / 1000.0,
+                    "speedup_vs_jax": speedup,
+                },
+            ]
+        )
+    if args.output:
+        with open(args.output, "w") as output:
+            output.writelines(json.dumps(row, sort_keys=True) + "\n" for row in measurements)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/biased_topk/tune_biased_topk_bt.py
+++ b/benchmark/kernels/biased_topk/tune_biased_topk_bt.py
@@ -1,0 +1,151 @@
+"""Sweep biased-topk token block sizes on TPU v7."""
+
+import argparse
+import functools
+import json
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from benchmark.kernels.biased_topk.bench_biased_topk import (
+    _scope_device_us,
+    reference_biased_topk,
+)
+from sgl_jax.srt.kernels.biased_topk import biased_topk_pallas
+
+EXPERTS = 384
+TOPK = 8
+
+
+def _candidates(tokens):
+    candidates = {
+        value
+        for value in (64, 128, 256, 512, 1024, 2048, 4096)
+        if value <= tokens and tokens % value == 0
+    }
+    if tokens <= 2048:
+        candidates.add(tokens)
+    return sorted(candidates)
+
+
+def tune_one(tokens, *, interpret):
+    logits = jax.nn.sigmoid(
+        jax.random.normal(
+            jax.random.key(tokens),
+            (tokens, EXPERTS),
+            dtype=jnp.float32,
+        )
+    )
+    bias = (
+        jax.random.normal(
+            jax.random.key(tokens + 1),
+            (EXPERTS,),
+            dtype=jnp.float32,
+        )
+        * 0.1
+    )
+    expected_weights, expected_ids = reference_biased_topk(
+        logits,
+        bias,
+        topk=TOPK,
+    )
+    rows = []
+    measurements = []
+    print(f"\nT={tokens}")
+    print(f"{'BT':>6} {'status':>12} {'device_us':>12}")
+    for block_tokens in _candidates(tokens):
+        fn = jax.jit(
+            functools.partial(
+                biased_topk_pallas,
+                topk=TOPK,
+                block_tokens=block_tokens,
+                interpret=interpret,
+            )
+        )
+        try:
+            actual_weights, actual_ids = fn(logits, bias)
+            jax.block_until_ready((actual_weights, actual_ids))
+            np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+            np.testing.assert_array_equal(
+                np.asarray(actual_weights),
+                np.asarray(expected_weights),
+            )
+            if interpret:
+                device_us = float("nan")
+            else:
+                device_us, _ = _scope_device_us(
+                    functools.partial(fn, logits, bias),
+                    "biased-topk",
+                    f"tune_t{tokens}_bt{block_tokens}",
+                )
+        except Exception as exc:  # noqa: BLE001
+            message = f"{type(exc).__name__}: {exc}"
+            status = (
+                "OOM" if "vmem" in message.lower() or "RESOURCE_EXHAUSTED" in message else "FAIL"
+            )
+            print(f"{block_tokens:6d} {status:>12} {'-':>12}")
+            measurements.append(
+                {
+                    "phase": "tune",
+                    "variant": "pallas",
+                    "tokens": tokens,
+                    "experts": EXPERTS,
+                    "topk": TOPK,
+                    "block_tokens": block_tokens,
+                    "status": status.lower(),
+                    "error": message,
+                }
+            )
+            continue
+        print(f"{block_tokens:6d} {'ok':>12} {device_us:12.2f}")
+        rows.append((block_tokens, device_us))
+        measurements.append(
+            {
+                "phase": "tune",
+                "variant": "pallas",
+                "tokens": tokens,
+                "experts": EXPERTS,
+                "topk": TOPK,
+                "block_tokens": block_tokens,
+                "status": "ok",
+                "device_duration_us": device_us,
+                "latency_ms": device_us / 1000.0,
+            }
+        )
+    if not rows:
+        return None, measurements
+    if interpret:
+        return rows[-1][0], measurements
+    return min(rows, key=lambda row: row[1])[0], measurements
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tokens",
+        default="64,128,256,512,1024,2048,4096,8192,16384,32768",
+    )
+    parser.add_argument("--interpret", action="store_true")
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    print(f"JAX {jax.__version__} | {jax.devices()[0].device_kind}")
+    best = {}
+    measurements = []
+    for tokens in (int(value) for value in args.tokens.split(",")):
+        block_tokens, token_measurements = tune_one(tokens, interpret=args.interpret)
+        measurements.extend(token_measurements)
+        if block_tokens is not None:
+            best[(tokens, EXPERTS, TOPK)] = block_tokens
+
+    print("\n# paste into TUNED_BT['TPU v7']")
+    for key, block_tokens in best.items():
+        print(f"{key!r}: {block_tokens},")
+    if args.output:
+        with open(args.output, "w") as output:
+            output.writelines(json.dumps(row, sort_keys=True) + "\n" for row in measurements)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/biased_topk/tune_biased_topk_bt.py
+++ b/benchmark/kernels/biased_topk/tune_biased_topk_bt.py
@@ -1,4 +1,4 @@
-"""Sweep biased-topk token block sizes on TPU v7."""
+"""Sweep biased-topk token block sizes on TPU."""
 
 import argparse
 import functools
@@ -13,6 +13,7 @@ from benchmark.kernels.biased_topk.bench_biased_topk import (
     reference_biased_topk,
 )
 from sgl_jax.srt.kernels.biased_topk import biased_topk_pallas
+from sgl_jax.srt.kernels.biased_topk.tuned_block_sizes import _device_name
 
 EXPERTS = 384
 TOPK = 8
@@ -139,7 +140,7 @@ def main():
         if block_tokens is not None:
             best[(tokens, EXPERTS, TOPK)] = block_tokens
 
-    print("\n# paste into TUNED_BT['TPU v7']")
+    print(f"\n# paste into TUNED_BT[{_device_name()!r}]")
     for key, block_tokens in best.items():
         print(f"{key!r}: {block_tokens},")
     if args.output:

--- a/python/sgl_jax/srt/kernels/biased_topk/__init__.py
+++ b/python/sgl_jax/srt/kernels/biased_topk/__init__.py
@@ -1,5 +1,5 @@
-"""Biased top-k Pallas kernels."""
+"""Sort-free top-k Pallas kernels."""
 
-from sgl_jax.srt.kernels.biased_topk.v1 import biased_topk_pallas
+from sgl_jax.srt.kernels.biased_topk.v1 import biased_topk_pallas, topk_pallas
 
-__all__ = ["biased_topk_pallas"]
+__all__ = ["biased_topk_pallas", "topk_pallas"]

--- a/python/sgl_jax/srt/kernels/biased_topk/__init__.py
+++ b/python/sgl_jax/srt/kernels/biased_topk/__init__.py
@@ -1,0 +1,5 @@
+"""Biased top-k Pallas kernels."""
+
+from sgl_jax.srt.kernels.biased_topk.v1 import biased_topk_pallas
+
+__all__ = ["biased_topk_pallas"]

--- a/python/sgl_jax/srt/kernels/biased_topk/tuned_block_sizes.py
+++ b/python/sgl_jax/srt/kernels/biased_topk/tuned_block_sizes.py
@@ -1,0 +1,41 @@
+"""Tuned token block sizes for the biased top-k Pallas kernel."""
+
+import jax
+
+
+def _device_name() -> str:
+    kind = jax.devices()[0].device_kind
+    if "TPU" not in kind:
+        raise RuntimeError("not a TPU device")
+    if kind.endswith(" lite"):
+        return kind[: -len(" lite")] + "e"
+    if kind == "TPU7x":
+        return "TPU v7"
+    return kind
+
+
+# device_name -> {(T, E, k): block_tokens}
+# TPU v7 E=384/k=8 entries are populated from the real-device tuner.
+TUNED_BT: dict[str, dict[tuple[int, int, int], int]] = {
+    "TPU v7": {
+        (64, 384, 8): 64,
+        (128, 384, 8): 128,
+        (256, 384, 8): 256,
+        (512, 384, 8): 512,
+        (1024, 384, 8): 512,
+        (2048, 384, 8): 512,
+        (4096, 384, 8): 1024,
+        (8192, 384, 8): 1024,
+        (16384, 384, 8): 1024,
+        (32768, 384, 8): 1024,
+    },
+}
+
+
+def get_tuned_bt(tokens: int, experts: int, topk: int) -> int | None:
+    """Return a measured block size for this exact routing shape."""
+    try:
+        device = _device_name()
+    except Exception:  # noqa: BLE001
+        return None
+    return TUNED_BT.get(device, {}).get((tokens, experts, topk))

--- a/python/sgl_jax/srt/kernels/biased_topk/tuned_block_sizes.py
+++ b/python/sgl_jax/srt/kernels/biased_topk/tuned_block_sizes.py
@@ -17,6 +17,18 @@ def _device_name() -> str:
 # device_name -> {(T, E, k): block_tokens}
 # TPU v7 E=384/k=8 entries are populated from the real-device tuner.
 TUNED_BT: dict[str, dict[tuple[int, int, int], int]] = {
+    "TPU v6e": {
+        (64, 384, 8): 64,
+        (128, 384, 8): 128,
+        (256, 384, 8): 256,
+        (512, 384, 8): 256,
+        (1024, 384, 8): 256,
+        (2048, 384, 8): 1024,
+        (4096, 384, 8): 1024,
+        (8192, 384, 8): 1024,
+        (16384, 384, 8): 1024,
+        (32768, 384, 8): 1024,
+    },
     "TPU v7": {
         (64, 384, 8): 64,
         (128, 384, 8): 128,

--- a/python/sgl_jax/srt/kernels/biased_topk/v1/__init__.py
+++ b/python/sgl_jax/srt/kernels/biased_topk/v1/__init__.py
@@ -1,0 +1,5 @@
+"""Official sort-free biased top-k Pallas kernel."""
+
+from sgl_jax.srt.kernels.biased_topk.v1.kernel import biased_topk_pallas
+
+__all__ = ["biased_topk_pallas"]

--- a/python/sgl_jax/srt/kernels/biased_topk/v1/__init__.py
+++ b/python/sgl_jax/srt/kernels/biased_topk/v1/__init__.py
@@ -1,5 +1,5 @@
-"""Official sort-free biased top-k Pallas kernel."""
+"""Official sort-free top-k Pallas kernels."""
 
-from sgl_jax.srt.kernels.biased_topk.v1.kernel import biased_topk_pallas
+from sgl_jax.srt.kernels.biased_topk.v1.kernel import biased_topk_pallas, topk_pallas
 
-__all__ = ["biased_topk_pallas"]
+__all__ = ["biased_topk_pallas", "topk_pallas"]

--- a/python/sgl_jax/srt/kernels/biased_topk/v1/kernel.py
+++ b/python/sgl_jax/srt/kernels/biased_topk/v1/kernel.py
@@ -1,0 +1,155 @@
+"""Sort-free biased top-k routing for TPU.
+
+Selection uses ``router_logits + correction_bias`` while returned weights come
+from the pre-bias ``router_logits``. Tokens occupy the TPU lane dimension in the
+VMEM compute layout so the expert reductions avoid cross-lane permutation.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+
+import jax
+import jax.experimental.pallas as pl
+import jax.numpy as jnp
+
+from sgl_jax.srt.kernels.biased_topk.tuned_block_sizes import get_tuned_bt
+
+NEG_INF = -jnp.inf
+SAFE_AUTO_BT = 2048
+
+
+def get_interpret() -> bool:
+    return os.environ.get("PALLAS_INTERPRET", "").strip().lower() in ("1", "true")
+
+
+def _safe_auto_block_tokens(batch_size: int) -> int | None:
+    if batch_size <= SAFE_AUTO_BT:
+        return batch_size
+    for candidate in range(SAFE_AUTO_BT, 0, -128):
+        if batch_size % candidate == 0:
+            return candidate
+    return None
+
+
+def _biased_topk_kernel(
+    logits_ref,  # [BT, E] f32, pre-bias
+    bias_ref,  # [E] f32
+    weights_ref,  # [topk, BT] f32
+    ids_ref,  # [topk, BT] i32
+    *,
+    topk: int,
+    num_experts: int,
+):
+    logits = logits_ref[...].astype(jnp.float32).T  # [E, BT]
+    scores = logits + bias_ref[...].astype(jnp.float32)[:, None]
+    block_tokens = logits.shape[1]
+
+    expert_iota = jax.lax.broadcasted_iota(
+        jnp.int32,
+        (num_experts, block_tokens),
+        0,
+    )
+    row_iota = jax.lax.broadcasted_iota(jnp.int32, (topk, block_tokens), 0)
+    ids_init = jnp.full((topk, block_tokens), -1, dtype=jnp.int32)
+    weights_init = jnp.zeros((topk, block_tokens), dtype=jnp.float32)
+
+    def select_one(k, carry):
+        current_scores, ids, weights = carry
+        max_score = jnp.max(current_scores, axis=0, keepdims=True)
+        selected_id = jnp.min(
+            jnp.where(current_scores == max_score, expert_iota, num_experts),
+            axis=0,
+            keepdims=True,
+        )
+        selected = expert_iota == selected_id
+        selected_weight = jnp.sum(
+            jnp.where(selected, logits, 0.0),
+            axis=0,
+            keepdims=True,
+        )
+        write_row = row_iota == k
+        ids = jnp.where(write_row, selected_id.astype(jnp.int32), ids)
+        weights = jnp.where(write_row, selected_weight.astype(jnp.float32), weights)
+        current_scores = jnp.where(selected, NEG_INF, current_scores)
+        return current_scores, ids, weights
+
+    _, ids, weights = jax.lax.fori_loop(
+        0,
+        topk,
+        select_one,
+        (scores, ids_init, weights_init),
+        unroll=True,
+    )
+    weights_ref[...] = weights
+    ids_ref[...] = ids
+
+
+def biased_topk_pallas(
+    router_logits: jax.Array,
+    correction_bias: jax.Array,
+    *,
+    topk: int,
+    block_tokens: int | str = "auto",
+    interpret: bool | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    """Select biased top-k expert ids and return their pre-bias weights."""
+    if router_logits.ndim != 2:
+        raise ValueError(f"router_logits must be rank 2, got shape={router_logits.shape}")
+    batch_size, num_experts = router_logits.shape
+    if correction_bias.shape != (num_experts,):
+        raise ValueError(
+            "correction_bias must have shape "
+            f"({num_experts},), got shape={correction_bias.shape}"
+        )
+    if num_experts % 128 != 0:
+        raise ValueError(f"num_experts must be divisible by 128, got {num_experts}")
+    if not 1 <= topk <= num_experts:
+        raise ValueError(f"topk must be in [1, {num_experts}], got {topk}")
+    if block_tokens == "auto":
+        block_tokens = get_tuned_bt(batch_size, num_experts, topk)
+        if block_tokens is None:
+            block_tokens = _safe_auto_block_tokens(batch_size)
+        if block_tokens is None:
+            raise ValueError(
+                f"no VMEM-safe block_tokens for batch_size={batch_size}; "
+                "fall back to jax.lax.top_k"
+            )
+    block_tokens = int(block_tokens)
+    if not 1 <= block_tokens <= batch_size:
+        raise ValueError(f"block_tokens must be in [1, {batch_size}], got {block_tokens}")
+    if batch_size % block_tokens != 0:
+        raise ValueError(
+            f"batch_size={batch_size} must be divisible by block_tokens={block_tokens}"
+        )
+    if interpret is None:
+        interpret = get_interpret()
+
+    kernel = functools.partial(
+        _biased_topk_kernel,
+        topk=topk,
+        num_experts=num_experts,
+    )
+    weights_t, ids_t = pl.pallas_call(
+        kernel,
+        grid=(batch_size // block_tokens,),
+        in_specs=[
+            pl.BlockSpec((block_tokens, num_experts), lambda i: (i, 0)),
+            pl.BlockSpec((num_experts,), lambda i: (0,)),
+        ],
+        out_specs=[
+            pl.BlockSpec((topk, block_tokens), lambda i: (0, i)),
+            pl.BlockSpec((topk, block_tokens), lambda i: (0, i)),
+        ],
+        out_shape=[
+            jax.ShapeDtypeStruct((topk, batch_size), jnp.float32),
+            jax.ShapeDtypeStruct((topk, batch_size), jnp.int32),
+        ],
+        interpret=interpret,
+        name="biased-topk",
+    )(
+        router_logits.astype(jnp.float32),
+        correction_bias.astype(jnp.float32),
+    )
+    return weights_t.T, ids_t.T

--- a/python/sgl_jax/srt/kernels/biased_topk/v1/kernel.py
+++ b/python/sgl_jax/srt/kernels/biased_topk/v1/kernel.py
@@ -1,8 +1,10 @@
-"""Sort-free biased top-k routing for TPU.
+"""Sort-free top-k routing for TPU.
 
-Selection uses ``router_logits + correction_bias`` while returned weights come
-from the pre-bias ``router_logits``. Tokens occupy the TPU lane dimension in the
-VMEM compute layout so the expert reductions avoid cross-lane permutation.
+The plain path returns the same values and ids as ``jax.lax.top_k`` for finite
+f32 router scores. The biased path selects with
+``router_logits + correction_bias`` while returning pre-bias weights. Tokens
+occupy the TPU lane dimension in the VMEM compute layout so expert reductions
+avoid cross-lane permutation.
 """
 
 from __future__ import annotations
@@ -33,17 +35,15 @@ def _safe_auto_block_tokens(batch_size: int) -> int | None:
     return None
 
 
-def _biased_topk_kernel(
-    logits_ref,  # [BT, E] f32, pre-bias
-    bias_ref,  # [E] f32
+def _select_topk(
+    logits,  # [E, BT] f32, values returned to the caller
+    scores,  # [E, BT] f32, values used for selection
     weights_ref,  # [topk, BT] f32
     ids_ref,  # [topk, BT] i32
     *,
     topk: int,
     num_experts: int,
 ):
-    logits = logits_ref[...].astype(jnp.float32).T  # [E, BT]
-    scores = logits + bias_ref[...].astype(jnp.float32)[:, None]
     block_tokens = logits.shape[1]
 
     expert_iota = jax.lax.broadcasted_iota(
@@ -86,23 +86,55 @@ def _biased_topk_kernel(
     ids_ref[...] = ids
 
 
-def biased_topk_pallas(
-    router_logits: jax.Array,
-    correction_bias: jax.Array,
+def _biased_topk_kernel(
+    logits_ref,  # [BT, E] f32, pre-bias
+    bias_ref,  # [E] f32
+    weights_ref,  # [topk, BT] f32
+    ids_ref,  # [topk, BT] i32
     *,
     topk: int,
-    block_tokens: int | str = "auto",
-    interpret: bool | None = None,
-) -> tuple[jax.Array, jax.Array]:
-    """Select biased top-k expert ids and return their pre-bias weights."""
+    num_experts: int,
+):
+    logits = logits_ref[...].astype(jnp.float32).T  # [E, BT]
+    scores = logits + bias_ref[...].astype(jnp.float32)[:, None]
+    _select_topk(
+        logits,
+        scores,
+        weights_ref,
+        ids_ref,
+        topk=topk,
+        num_experts=num_experts,
+    )
+
+
+def _topk_kernel(
+    logits_ref,  # [BT, E] f32
+    weights_ref,  # [topk, BT] f32
+    ids_ref,  # [topk, BT] i32
+    *,
+    topk: int,
+    num_experts: int,
+):
+    logits = logits_ref[...].astype(jnp.float32).T  # [E, BT]
+    _select_topk(
+        logits,
+        logits,
+        weights_ref,
+        ids_ref,
+        topk=topk,
+        num_experts=num_experts,
+    )
+
+
+def _resolve_block_tokens(
+    router_logits: jax.Array,
+    *,
+    topk: int,
+    block_tokens: int | str,
+) -> tuple[int, int, int]:
     if router_logits.ndim != 2:
         raise ValueError(f"router_logits must be rank 2, got shape={router_logits.shape}")
     batch_size, num_experts = router_logits.shape
-    if correction_bias.shape != (num_experts,):
-        raise ValueError(
-            "correction_bias must have shape "
-            f"({num_experts},), got shape={correction_bias.shape}"
-        )
     if num_experts % 128 != 0:
         raise ValueError(f"num_experts must be divisible by 128, got {num_experts}")
     if not 1 <= topk <= num_experts:
@@ -122,6 +154,28 @@ def biased_topk_pallas(
     if batch_size % block_tokens != 0:
         raise ValueError(
             f"batch_size={batch_size} must be divisible by block_tokens={block_tokens}"
+        )
+    return batch_size, num_experts, block_tokens
+
+
+def biased_topk_pallas(
+    router_logits: jax.Array,
+    correction_bias: jax.Array,
+    *,
+    topk: int,
+    block_tokens: int | str = "auto",
+    interpret: bool | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    """Select biased top-k expert ids and return their pre-bias weights."""
+    batch_size, num_experts, block_tokens = _resolve_block_tokens(
+        router_logits,
+        topk=topk,
+        block_tokens=block_tokens,
+    )
+    if correction_bias.shape != (num_experts,):
+        raise ValueError(
+            "correction_bias must have shape "
+            f"({num_experts},), got shape={correction_bias.shape}"
         )
     if interpret is None:
         interpret = get_interpret()
@@ -152,4 +206,45 @@ def biased_topk_pallas(
         router_logits.astype(jnp.float32),
         correction_bias.astype(jnp.float32),
     )
+    return weights_t.T, ids_t.T
+
+
+def topk_pallas(
+    router_logits: jax.Array,
+    *,
+    topk: int,
+    block_tokens: int | str = "auto",
+    interpret: bool | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    """Return the top-k values and ids of a finite f32 routing matrix."""
+    batch_size, num_experts, block_tokens = _resolve_block_tokens(
+        router_logits,
+        topk=topk,
+        block_tokens=block_tokens,
+    )
+    if interpret is None:
+        interpret = get_interpret()
+
+    kernel = functools.partial(
+        _topk_kernel,
+        topk=topk,
+        num_experts=num_experts,
+    )
+    weights_t, ids_t = pl.pallas_call(
+        kernel,
+        grid=(batch_size // block_tokens,),
+        in_specs=[
+            pl.BlockSpec((block_tokens, num_experts), lambda i: (i, 0)),
+        ],
+        out_specs=[
+            pl.BlockSpec((topk, block_tokens), lambda i: (0, i)),
+            pl.BlockSpec((topk, block_tokens), lambda i: (0, i)),
+        ],
+        out_shape=[
+            jax.ShapeDtypeStruct((topk, batch_size), jnp.float32),
+            jax.ShapeDtypeStruct((topk, batch_size), jnp.int32),
+        ],
+        interpret=interpret,
+        name="topk",
+    )(router_logits.astype(jnp.float32))
     return weights_t.T, ids_t.T

--- a/python/sgl_jax/srt/layers/gate.py
+++ b/python/sgl_jax/srt/layers/gate.py
@@ -12,7 +12,7 @@ from sgl_jax.srt.eplb.expert_location import (
     get_global_server_args,
     topk_ids_logical_to_physical,
 )
-from sgl_jax.srt.kernels.biased_topk import biased_topk_pallas
+from sgl_jax.srt.kernels.biased_topk import biased_topk_pallas, topk_pallas
 from sgl_jax.srt.kernels.grouped_topk.v1.kernel import grouped_topk_pallas
 from sgl_jax.srt.utils.profiling_utils import named_scope
 
@@ -20,9 +20,7 @@ from sgl_jax.srt.utils.profiling_utils import named_scope
 def _topk_kernel_enabled() -> bool:
     server_args = get_global_server_args()
     return (
-        server_args is not None
-        and server_args.enable_grouped_topk_kernel
-        and server_args.device == "tpu"
+        server_args is not None and server_args.enable_topk_kernel and server_args.device == "tpu"
     )
 
 
@@ -130,7 +128,26 @@ class TopK(nnx.Module):
         return topk_weights, topk_ids
 
     def _topk(self, router_logits):
-        return jax.lax.top_k(router_logits, self.topk)
+        if not _topk_kernel_enabled() or router_logits.shape[-1] % 128 != 0:
+            return jax.lax.top_k(router_logits, self.topk)
+        fn = functools.partial(
+            topk_pallas,
+            topk=self.topk,
+        )
+        if self.mesh is not None:
+            fn = jax.shard_map(
+                fn,
+                mesh=self.mesh,
+                in_specs=(P("data", None),),
+                out_specs=(P("data", None), P("data", None)),
+                check_vma=False,
+            )
+        try:
+            return fn(router_logits)
+        except ValueError as exc:
+            if "no VMEM-safe block_tokens" not in str(exc):
+                raise
+            return jax.lax.top_k(router_logits, self.topk)
 
     def _biased_topk(self, router_logits, correction_bias):
         if not _topk_kernel_enabled() or router_logits.shape[-1] % 128 != 0:

--- a/python/sgl_jax/srt/layers/gate.py
+++ b/python/sgl_jax/srt/layers/gate.py
@@ -12,11 +12,12 @@ from sgl_jax.srt.eplb.expert_location import (
     get_global_server_args,
     topk_ids_logical_to_physical,
 )
+from sgl_jax.srt.kernels.biased_topk import biased_topk_pallas
 from sgl_jax.srt.kernels.grouped_topk.v1.kernel import grouped_topk_pallas
 from sgl_jax.srt.utils.profiling_utils import named_scope
 
 
-def _grouped_topk_kernel_enabled() -> bool:
+def _topk_kernel_enabled() -> bool:
     server_args = get_global_server_args()
     return (
         server_args is not None
@@ -132,6 +133,30 @@ class TopK(nnx.Module):
         return jax.lax.top_k(router_logits, self.topk)
 
     def _biased_topk(self, router_logits, correction_bias):
+        if not _topk_kernel_enabled() or router_logits.shape[-1] % 128 != 0:
+            return self._biased_topk_jax(router_logits, correction_bias)
+        fn = functools.partial(
+            biased_topk_pallas,
+            topk=self.topk,
+        )
+        # Mosaic/Pallas kernels cannot be auto-partitioned by JAX's SPMD compiler;
+        # wrap in shard_map so each device runs the kernel on its local token slice.
+        if self.mesh is not None:
+            fn = jax.shard_map(
+                fn,
+                mesh=self.mesh,
+                in_specs=(P("data", None), P(None)),
+                out_specs=(P("data", None), P("data", None)),
+                check_vma=False,
+            )
+        try:
+            return fn(router_logits, correction_bias)
+        except ValueError as exc:
+            if "no VMEM-safe block_tokens" not in str(exc):
+                raise
+            return self._biased_topk_jax(router_logits, correction_bias)
+
+    def _biased_topk_jax(self, router_logits, correction_bias):
         n_routed_experts = router_logits.shape[-1]
         scores_for_choice = router_logits.reshape(-1, n_routed_experts) + jnp.expand_dims(
             correction_bias, axis=0
@@ -179,7 +204,7 @@ class TopK(nnx.Module):
         correction_bias: jax.Array = None,
         packed: bool = False,
     ):
-        if not _grouped_topk_kernel_enabled():
+        if not _topk_kernel_enabled():
             return self._biased_grouped_topk_jax(router_logits, correction_bias)
         fn = functools.partial(
             grouped_topk_pallas,

--- a/python/sgl_jax/srt/layers/gate.py
+++ b/python/sgl_jax/srt/layers/gate.py
@@ -24,6 +24,14 @@ def _topk_kernel_enabled() -> bool:
     )
 
 
+def _routing_partition_spec(routing_sharding: jax.sharding.Sharding | None) -> P:
+    """Translate an explicit router sharding into a shard_map partition spec."""
+    spec = getattr(routing_sharding, "spec", None)
+    if spec is None or len(spec) != 2 or spec[1] is not None:
+        return P("data", None)
+    return P(spec[0], None)
+
+
 class GateLogit(nnx.Module):
     def __init__(
         self,
@@ -99,21 +107,33 @@ class TopK(nnx.Module):
         router_logits: jax.Array,
         correction_bias: jax.Array = None,
         dispatch_info: ExpertLocationMetadata | None = None,
+        routing_sharding: jax.sharding.Sharding | None = None,
     ):
         router_logits = router_logits.astype(jnp.float32)
+        routing_spec = _routing_partition_spec(routing_sharding)
 
         if self.num_expert_group > 0 or self.topk_group > 0:
             if correction_bias is not None:
                 topk_weights, topk_ids = self._biased_grouped_topk(
-                    router_logits, correction_bias, packed=router_logits.dtype == jnp.bfloat16
+                    router_logits,
+                    correction_bias,
+                    packed=router_logits.dtype == jnp.bfloat16,
+                    routing_spec=routing_spec,
                 )
             else:
                 topk_weights, topk_ids = self._grouped_topk(router_logits)
         else:
             if correction_bias is not None:
-                topk_weights, topk_ids = self._biased_topk(router_logits, correction_bias)
+                topk_weights, topk_ids = self._biased_topk(
+                    router_logits,
+                    correction_bias,
+                    routing_spec=routing_spec,
+                )
             else:
-                topk_weights, topk_ids = self._topk(router_logits)
+                topk_weights, topk_ids = self._topk(
+                    router_logits,
+                    routing_spec=routing_spec,
+                )
 
         if dispatch_info is not None:
             topk_ids = topk_ids_logical_to_physical(topk_ids, dispatch_info, self.layer_id)
@@ -127,7 +147,9 @@ class TopK(nnx.Module):
 
         return topk_weights, topk_ids
 
-    def _topk(self, router_logits):
+    def _topk(self, router_logits, *, routing_spec=None):
+        if routing_spec is None:
+            routing_spec = P("data", None)
         if not _topk_kernel_enabled() or router_logits.shape[-1] % 128 != 0:
             return jax.lax.top_k(router_logits, self.topk)
         fn = functools.partial(
@@ -138,8 +160,8 @@ class TopK(nnx.Module):
             fn = jax.shard_map(
                 fn,
                 mesh=self.mesh,
-                in_specs=(P("data", None),),
-                out_specs=(P("data", None), P("data", None)),
+                in_specs=(routing_spec,),
+                out_specs=(routing_spec, routing_spec),
                 check_vma=False,
             )
         try:
@@ -149,7 +171,15 @@ class TopK(nnx.Module):
                 raise
             return jax.lax.top_k(router_logits, self.topk)
 
-    def _biased_topk(self, router_logits, correction_bias):
+    def _biased_topk(
+        self,
+        router_logits,
+        correction_bias,
+        *,
+        routing_spec=None,
+    ):
+        if routing_spec is None:
+            routing_spec = P("data", None)
         if not _topk_kernel_enabled() or router_logits.shape[-1] % 128 != 0:
             return self._biased_topk_jax(router_logits, correction_bias)
         fn = functools.partial(
@@ -162,8 +192,8 @@ class TopK(nnx.Module):
             fn = jax.shard_map(
                 fn,
                 mesh=self.mesh,
-                in_specs=(P("data", None), P(None)),
-                out_specs=(P("data", None), P("data", None)),
+                in_specs=(routing_spec, P(None)),
+                out_specs=(routing_spec, routing_spec),
                 check_vma=False,
             )
         try:
@@ -220,7 +250,10 @@ class TopK(nnx.Module):
         router_logits: jax.Array,
         correction_bias: jax.Array = None,
         packed: bool = False,
+        routing_spec=None,
     ):
+        if routing_spec is None:
+            routing_spec = P("data", None)
         if not _topk_kernel_enabled():
             return self._biased_grouped_topk_jax(router_logits, correction_bias)
         fn = functools.partial(
@@ -236,8 +269,8 @@ class TopK(nnx.Module):
             fn = jax.shard_map(
                 fn,
                 mesh=self.mesh,
-                in_specs=(P("data", None), P(None)),
-                out_specs=(P("data", None), P("data", None)),
+                in_specs=(routing_spec, P(None)),
+                out_specs=(routing_spec, routing_spec),
                 check_vma=False,
             )
         return fn(router_logits, correction_bias)

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -168,7 +168,11 @@ class MiMoV2Moe(nnx.Module):
     ):
         router_logits = self.moe_gate(hidden_states)
         correction_bias = self.correction_bias.value if self.correction_bias is not None else None
-        topk_weights, topk_ids = self.topk(router_logits, correction_bias=correction_bias)
+        topk_weights, topk_ids = self.topk(
+            router_logits,
+            correction_bias=correction_bias,
+            routing_sharding=out_sharding,
+        )
         if self.use_fused:
             token_valid_mask = forward_batch.get_token_valid_mask(
                 hidden_states.shape[0],

--- a/python/sgl_jax/srt/models/qwen3_moe.py
+++ b/python/sgl_jax/srt/models/qwen3_moe.py
@@ -294,7 +294,11 @@ class QWen3MoeDecoderLayer(nnx.Module):
         topk_ids = None
         if self.is_moe_layer:
             router_logits = self.moe_gate(hidden_states)
-            topk_weights, topk_ids = self.topk(router_logits, dispatch_info=dispatch_info)
+            topk_weights, topk_ids = self.topk(
+                router_logits,
+                dispatch_info=dispatch_info,
+                routing_sharding=reduce_sharding,
+            )
             if self.use_fused:
                 token_valid_mask = forward_batch.get_token_valid_mask(
                     hidden_states.shape[0],

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -184,7 +184,7 @@ class ServerArgs:
     attention_backend: str | None = "fa"
     moe_backend: str = "epmoe"
     disable_jax_allreduce_metadata: bool = False
-    enable_grouped_topk_kernel: bool = False
+    enable_topk_kernel: bool = True
 
     grammar_backend: str | None = None
 
@@ -1411,12 +1411,14 @@ class ServerArgs:
             ),
         )
         parser.add_argument(
-            "--enable-grouped-topk-kernel",
-            action="store_true",
-            default=ServerArgs.enable_grouped_topk_kernel,
+            "--disable-topk-kernel",
+            dest="enable_topk_kernel",
+            action="store_false",
+            default=ServerArgs.enable_topk_kernel,
             help=(
-                "Enable Pallas kernels for biased top-k routing, including grouped "
-                "and non-grouped paths (TPU only). Default off, using pure JAX."
+                "Disable Pallas kernels for top-k routing, including grouped, biased, "
+                "and plain paths (TPU only), and use pure JAX instead. "
+                "The kernels are enabled by default."
             ),
         )
 

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -1415,8 +1415,8 @@ class ServerArgs:
             action="store_true",
             default=ServerArgs.enable_grouped_topk_kernel,
             help=(
-                "Enable the Pallas grouped-topk kernel for biased grouped top-k "
-                "routing (TPU only). Default off, using the pure JAX implementation."
+                "Enable Pallas kernels for biased top-k routing, including grouped "
+                "and non-grouped paths (TPU only). Default off, using pure JAX."
             ),
         )
 

--- a/python/sgl_jax/test/kernels/biased_topk_test.py
+++ b/python/sgl_jax/test/kernels/biased_topk_test.py
@@ -383,6 +383,28 @@ def test_v7_tuned_block_sizes_cover_mimo_sweep(monkeypatch):
     assert tuned_block_sizes.get_tuned_bt(1024, 256, 8) is None
 
 
+def test_v6e_tuned_block_sizes_cover_mimo_sweep(monkeypatch):
+    from sgl_jax.srt.kernels.biased_topk import tuned_block_sizes
+
+    monkeypatch.setattr(tuned_block_sizes, "_device_name", lambda: "TPU v6e")
+    expected = {
+        64: 64,
+        128: 128,
+        256: 256,
+        512: 256,
+        1024: 256,
+        2048: 1024,
+        4096: 1024,
+        8192: 1024,
+        16384: 1024,
+        32768: 1024,
+    }
+
+    for tokens, block_tokens in expected.items():
+        assert tuned_block_sizes.get_tuned_bt(tokens, 384, 8) == block_tokens
+    assert tuned_block_sizes.get_tuned_bt(1024, 256, 8) is None
+
+
 def test_topk_kernel_path_preserves_logical_to_physical_mapping(monkeypatch):
     from sgl_jax.srt.eplb.expert_location import (
         ExpertLocationMetadata,

--- a/python/sgl_jax/test/kernels/biased_topk_test.py
+++ b/python/sgl_jax/test/kernels/biased_topk_test.py
@@ -1,5 +1,6 @@
-"""Equivalence tests for the sort-free biased top-k Pallas kernel."""
+"""Equivalence tests for the sort-free top-k Pallas kernels."""
 
+import argparse
 from types import SimpleNamespace
 
 import jax
@@ -40,6 +41,41 @@ def test_mimo_shape_matches_reference():
         rtol=0,
         atol=1e-6,
     )
+
+
+def test_unbiased_topk_matches_lax_top_k():
+    from sgl_jax.srt.kernels.biased_topk import topk_pallas
+
+    tokens, experts, topk = 128, 384, 8
+    logits = jax.random.normal(jax.random.key(15), (tokens, experts), dtype=jnp.float32)
+    expected_weights, expected_ids = jax.lax.top_k(logits, topk)
+
+    actual_weights, actual_ids = topk_pallas(
+        logits,
+        topk=topk,
+        block_tokens=tokens,
+        interpret=True,
+    )
+
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_array_equal(np.asarray(actual_weights), np.asarray(expected_weights))
+
+
+def test_unbiased_topk_flat_ties_choose_lowest_expert_ids():
+    from sgl_jax.srt.kernels.biased_topk import topk_pallas
+
+    tokens, experts, topk = 64, 384, 8
+    logits = jnp.ones((tokens, experts), dtype=jnp.float32)
+    actual_weights, actual_ids = topk_pallas(
+        logits,
+        topk=topk,
+        block_tokens=tokens,
+        interpret=True,
+    )
+
+    expected_weights, expected_ids = jax.lax.top_k(logits, topk)
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_array_equal(np.asarray(actual_weights), np.asarray(expected_weights))
 
 
 def test_auto_block_tokens_rejects_unsafe_large_token_shape():
@@ -205,7 +241,7 @@ def test_topk_shared_flag_dispatches_plain_biased_routing(monkeypatch):
 
     monkeypatch.setattr(gate, "biased_topk_pallas", fake_biased_topk)
     previous_server_args = get_global_server_args()
-    set_global_server_args(SimpleNamespace(enable_grouped_topk_kernel=True, device="tpu"))
+    set_global_server_args(SimpleNamespace(enable_topk_kernel=True, device="tpu"))
     try:
         actual_weights, actual_ids = gate.TopK(
             topk=topk,
@@ -222,6 +258,52 @@ def test_topk_shared_flag_dispatches_plain_biased_routing(monkeypatch):
         rtol=0,
         atol=0,
     )
+
+
+def test_topk_shared_flag_dispatches_unbiased_routing(monkeypatch):
+    from sgl_jax.srt.eplb.expert_location import (
+        get_global_server_args,
+        set_global_server_args,
+    )
+    from sgl_jax.srt.layers import gate
+
+    tokens, experts, topk = 128, 128, 8
+    logits = jax.random.normal(jax.random.key(16), (tokens, experts), dtype=jnp.float32)
+    expected_weights, expected_ids = jax.lax.top_k(logits, topk)
+    called = False
+
+    def fake_topk(router_logits, *, topk, **_):
+        nonlocal called
+        called = True
+        return jax.lax.top_k(router_logits, topk)
+
+    monkeypatch.setattr(gate, "topk_pallas", fake_topk)
+    previous_server_args = get_global_server_args()
+    set_global_server_args(SimpleNamespace(enable_topk_kernel=True, device="tpu"))
+    try:
+        actual_weights, actual_ids = gate.TopK(
+            topk=topk,
+            renormalize=False,
+        )(logits)
+    finally:
+        set_global_server_args(previous_server_args)
+
+    assert called
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_array_equal(np.asarray(actual_weights), np.asarray(expected_weights))
+
+
+def test_topk_kernel_cli_is_enabled_by_default_and_can_be_disabled():
+    from sgl_jax.srt.server_args import ServerArgs
+
+    parser = argparse.ArgumentParser()
+    ServerArgs.add_cli_args(parser)
+
+    default_args = parser.parse_args(["--model-path", "dummy-model"])
+    disabled_args = parser.parse_args(["--model-path", "dummy-model", "--disable-topk-kernel"])
+
+    assert default_args.enable_topk_kernel is True
+    assert disabled_args.enable_topk_kernel is False
 
 
 def test_topk_shared_flag_dispatches_grouped_biased_routing(monkeypatch):
@@ -252,7 +334,7 @@ def test_topk_shared_flag_dispatches_grouped_biased_routing(monkeypatch):
 
     monkeypatch.setattr(gate, "grouped_topk_pallas", fake_grouped_topk)
     previous_server_args = get_global_server_args()
-    set_global_server_args(SimpleNamespace(enable_grouped_topk_kernel=True, device="tpu"))
+    set_global_server_args(SimpleNamespace(enable_topk_kernel=True, device="tpu"))
     try:
         actual_weights, actual_ids = module(logits, correction_bias=bias)
     finally:
@@ -283,7 +365,7 @@ def test_topk_flag_off_keeps_jax_path(monkeypatch):
 
     monkeypatch.setattr(gate, "biased_topk_pallas", fail_if_called)
     previous_server_args = get_global_server_args()
-    set_global_server_args(SimpleNamespace(enable_grouped_topk_kernel=False, device="tpu"))
+    set_global_server_args(SimpleNamespace(enable_topk_kernel=False, device="tpu"))
     try:
         actual_weights, actual_ids = gate.TopK(
             topk=8,
@@ -293,6 +375,34 @@ def test_topk_flag_off_keeps_jax_path(monkeypatch):
         set_global_server_args(previous_server_args)
 
     expected_weights, expected_ids = _reference(logits, bias, topk=8)
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_array_equal(np.asarray(actual_weights), np.asarray(expected_weights))
+
+
+def test_topk_flag_off_keeps_unbiased_jax_path(monkeypatch):
+    from sgl_jax.srt.eplb.expert_location import (
+        get_global_server_args,
+        set_global_server_args,
+    )
+    from sgl_jax.srt.layers import gate
+
+    logits = jnp.arange(128, dtype=jnp.float32)[None, :]
+
+    def fail_if_called(*_, **__):
+        raise AssertionError("Pallas kernel must not run when the flag is disabled")
+
+    monkeypatch.setattr(gate, "topk_pallas", fail_if_called)
+    previous_server_args = get_global_server_args()
+    set_global_server_args(SimpleNamespace(enable_topk_kernel=False, device="tpu"))
+    try:
+        actual_weights, actual_ids = gate.TopK(
+            topk=8,
+            renormalize=False,
+        )(logits)
+    finally:
+        set_global_server_args(previous_server_args)
+
+    expected_weights, expected_ids = jax.lax.top_k(logits, 8)
     np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
     np.testing.assert_array_equal(np.asarray(actual_weights), np.asarray(expected_weights))
 
@@ -314,7 +424,7 @@ def test_topk_kernel_path_preserves_normalization_and_scaling(monkeypatch):
     expected_weights = raw_weights / raw_weights.sum(axis=-1, keepdims=True) * 1.75
 
     previous_server_args = get_global_server_args()
-    set_global_server_args(SimpleNamespace(enable_grouped_topk_kernel=True, device="tpu"))
+    set_global_server_args(SimpleNamespace(enable_topk_kernel=True, device="tpu"))
     try:
         actual_weights, actual_ids = TopK(
             topk=topk,
@@ -348,7 +458,7 @@ def test_topk_unsafe_large_token_shape_falls_back_to_jax():
     expected_weights, expected_ids = _reference(logits, bias, topk=topk)
 
     previous_server_args = get_global_server_args()
-    set_global_server_args(SimpleNamespace(enable_grouped_topk_kernel=True, device="tpu"))
+    set_global_server_args(SimpleNamespace(enable_topk_kernel=True, device="tpu"))
     try:
         actual_weights, actual_ids = TopK(
             topk=topk,
@@ -429,7 +539,7 @@ def test_topk_kernel_path_preserves_logical_to_physical_mapping(monkeypatch):
     )
 
     previous_server_args = get_global_server_args()
-    set_global_server_args(SimpleNamespace(enable_grouped_topk_kernel=True, device="tpu"))
+    set_global_server_args(SimpleNamespace(enable_topk_kernel=True, device="tpu"))
     try:
         _, physical_ids = TopK(
             topk=topk,

--- a/python/sgl_jax/test/kernels/biased_topk_test.py
+++ b/python/sgl_jax/test/kernels/biased_topk_test.py
@@ -7,6 +7,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
 
 
 def _reference(router_logits, correction_bias, *, topk):
@@ -347,6 +349,79 @@ def test_topk_shared_flag_dispatches_grouped_biased_routing(monkeypatch):
         np.asarray(expected_weights),
         rtol=0,
         atol=0,
+    )
+
+
+@pytest.mark.parametrize("token_axis", ["data", ("data", "tensor")])
+@pytest.mark.parametrize("mode", ["plain", "biased", "grouped"])
+def test_topk_kernel_preserves_router_token_sharding(monkeypatch, token_axis, mode):
+    from sgl_jax.srt.eplb.expert_location import (
+        get_global_server_args,
+        set_global_server_args,
+    )
+    from sgl_jax.srt.layers.gate import TopK, _routing_partition_spec
+
+    monkeypatch.setenv("PALLAS_INTERPRET", "1")
+    devices = np.asarray(jax.devices())
+    mesh_shape = (len(devices), 1) if token_axis == "data" else (1, len(devices))
+    mesh = Mesh(devices.reshape(mesh_shape), ("data", "tensor"))
+    tokens = 256 * len(devices)
+    experts = 256 if mode == "grouped" else 128
+    routing_sharding = NamedSharding(mesh, P(token_axis, None))
+    logits = jax.device_put(
+        jax.nn.sigmoid(
+            jax.random.normal(
+                jax.random.key(experts),
+                (tokens, experts),
+                dtype=jnp.float32,
+            )
+        ),
+        routing_sharding,
+    )
+    bias = jax.device_put(
+        jax.random.normal(jax.random.key(17), (experts,), dtype=jnp.float32) * 0.1,
+        NamedSharding(mesh, P(None)),
+    )
+    module = TopK(
+        topk=8,
+        renormalize=False,
+        num_expert_group=8 if mode == "grouped" else 0,
+        topk_group=4 if mode == "grouped" else 0,
+        mesh=mesh,
+    )
+
+    if mode == "plain":
+        expected_weights, expected_ids = jax.lax.top_k(logits, 8)
+        correction_bias = None
+    elif mode == "biased":
+        expected_weights, expected_ids = module._biased_topk_jax(logits, bias)
+        correction_bias = bias
+    else:
+        expected_weights, expected_ids = module._biased_grouped_topk_jax(logits, bias)
+        correction_bias = bias
+
+    previous_server_args = get_global_server_args()
+    set_global_server_args(SimpleNamespace(enable_topk_kernel=True, device="tpu"))
+    try:
+        actual_weights, actual_ids = module(
+            logits,
+            correction_bias=correction_bias,
+            routing_sharding=routing_sharding,
+        )
+    finally:
+        set_global_server_args(previous_server_args)
+
+    expected_spec = P(token_axis, None)
+    assert _routing_partition_spec(routing_sharding) == expected_spec
+    if len(devices) > 1:
+        assert actual_weights.sharding.spec == expected_spec
+        assert actual_ids.sharding.spec == expected_spec
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_allclose(
+        np.asarray(actual_weights),
+        np.asarray(expected_weights),
+        rtol=0,
+        atol=1e-6,
     )
 
 

--- a/python/sgl_jax/test/kernels/biased_topk_test.py
+++ b/python/sgl_jax/test/kernels/biased_topk_test.py
@@ -1,0 +1,423 @@
+"""Equivalence tests for the sort-free biased top-k Pallas kernel."""
+
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+
+def _reference(router_logits, correction_bias, *, topk):
+    scores_for_choice = router_logits.astype(jnp.float32) + correction_bias.astype(jnp.float32)
+    topk_ids = jax.lax.top_k(scores_for_choice, topk)[1]
+    topk_weights = jnp.take_along_axis(router_logits.astype(jnp.float32), topk_ids, axis=1)
+    return topk_weights, topk_ids
+
+
+def test_mimo_shape_matches_reference():
+    from sgl_jax.srt.kernels.biased_topk import biased_topk_pallas
+
+    tokens, experts, topk = 256, 384, 8
+    logits = jax.nn.sigmoid(
+        jax.random.normal(jax.random.key(0), (tokens, experts), dtype=jnp.float32)
+    )
+    bias = jax.random.normal(jax.random.key(1), (experts,), dtype=jnp.float32) * 0.1
+
+    expected_weights, expected_ids = _reference(logits, bias, topk=topk)
+    actual_weights, actual_ids = biased_topk_pallas(
+        logits,
+        bias,
+        topk=topk,
+        block_tokens=256,
+        interpret=True,
+    )
+
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_allclose(
+        np.asarray(actual_weights),
+        np.asarray(expected_weights),
+        rtol=0,
+        atol=1e-6,
+    )
+
+
+def test_auto_block_tokens_rejects_unsafe_large_token_shape():
+    from sgl_jax.srt.kernels.biased_topk import biased_topk_pallas
+
+    tokens, experts = 2050, 128
+    logits = jnp.zeros((tokens, experts), dtype=jnp.float32)
+    bias = jnp.zeros((experts,), dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="no VMEM-safe block_tokens"):
+        biased_topk_pallas(
+            logits,
+            bias,
+            topk=8,
+            block_tokens="auto",
+            interpret=True,
+        )
+
+
+@pytest.mark.parametrize("experts", [128, 256, 384, 512])
+@pytest.mark.parametrize("topk", [1, 2, 8, 16])
+def test_generic_static_shapes_match_reference(experts, topk):
+    from sgl_jax.srt.kernels.biased_topk import biased_topk_pallas
+
+    tokens = 128
+    logits = jax.nn.sigmoid(
+        jax.random.normal(jax.random.key(experts + topk), (tokens, experts), dtype=jnp.float32)
+    )
+    bias = jax.random.normal(jax.random.key(topk), (experts,), dtype=jnp.float32) * 0.25
+
+    expected_weights, expected_ids = _reference(logits, bias, topk=topk)
+    actual_weights, actual_ids = biased_topk_pallas(
+        logits,
+        bias,
+        topk=topk,
+        block_tokens=tokens,
+        interpret=True,
+    )
+
+    assert actual_weights.shape == (tokens, topk)
+    assert actual_ids.shape == (tokens, topk)
+    assert actual_weights.dtype == jnp.float32
+    assert actual_ids.dtype == jnp.int32
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_allclose(
+        np.asarray(actual_weights),
+        np.asarray(expected_weights),
+        rtol=0,
+        atol=1e-6,
+    )
+
+
+def test_flat_ties_choose_lowest_expert_ids():
+    from sgl_jax.srt.kernels.biased_topk import biased_topk_pallas
+
+    tokens, experts, topk = 64, 384, 8
+    logits = jnp.full((tokens, experts), 0.5, dtype=jnp.float32)
+    bias = jnp.zeros((experts,), dtype=jnp.float32)
+
+    actual_weights, actual_ids = biased_topk_pallas(
+        logits,
+        bias,
+        topk=topk,
+        block_tokens=tokens,
+        interpret=True,
+    )
+
+    np.testing.assert_array_equal(
+        np.asarray(actual_ids),
+        np.tile(np.arange(topk, dtype=np.int32), (tokens, 1)),
+    )
+    np.testing.assert_array_equal(
+        np.asarray(actual_weights),
+        np.full((tokens, topk), 0.5, dtype=np.float32),
+    )
+
+
+def test_post_bias_tie_returns_pre_bias_weights_in_stable_order():
+    from sgl_jax.srt.kernels.biased_topk import biased_topk_pallas
+
+    tokens, experts = 64, 128
+    logits = jnp.zeros((tokens, experts), dtype=jnp.float32)
+    logits = logits.at[:, 3].set(0.4)
+    logits = logits.at[:, 5].set(0.3)
+    bias = jnp.full((experts,), -1.0, dtype=jnp.float32)
+    bias = bias.at[3].set(0.1)
+    bias = bias.at[5].set(0.2)
+
+    actual_weights, actual_ids = biased_topk_pallas(
+        logits,
+        bias,
+        topk=2,
+        block_tokens=tokens,
+        interpret=True,
+    )
+
+    np.testing.assert_array_equal(
+        np.asarray(actual_ids),
+        np.tile(np.array([3, 5], dtype=np.int32), (tokens, 1)),
+    )
+    np.testing.assert_allclose(
+        np.asarray(actual_weights),
+        np.tile(np.array([0.4, 0.3], dtype=np.float32), (tokens, 1)),
+        rtol=0,
+        atol=1e-6,
+    )
+
+
+@pytest.mark.parametrize("bias_mode", ["zero", "negative"])
+def test_zero_and_negative_bias_match_reference(bias_mode):
+    from sgl_jax.srt.kernels.biased_topk import biased_topk_pallas
+
+    tokens, experts, topk = 256, 384, 8
+    logits = jax.nn.sigmoid(
+        jax.random.normal(jax.random.key(21), (tokens, experts), dtype=jnp.float32)
+    )
+    if bias_mode == "zero":
+        bias = jnp.zeros((experts,), dtype=jnp.float32)
+    else:
+        bias = -jax.random.uniform(
+            jax.random.key(22),
+            (experts,),
+            dtype=jnp.float32,
+        )
+
+    expected_weights, expected_ids = _reference(logits, bias, topk=topk)
+    actual_weights, actual_ids = biased_topk_pallas(
+        logits,
+        bias,
+        topk=topk,
+        block_tokens=128,
+        interpret=True,
+    )
+
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_allclose(
+        np.asarray(actual_weights),
+        np.asarray(expected_weights),
+        rtol=0,
+        atol=1e-6,
+    )
+
+
+def test_topk_shared_flag_dispatches_plain_biased_routing(monkeypatch):
+    from sgl_jax.srt.eplb.expert_location import (
+        get_global_server_args,
+        set_global_server_args,
+    )
+    from sgl_jax.srt.layers import gate
+
+    tokens, experts, topk = 128, 128, 8
+    logits = jax.nn.sigmoid(
+        jax.random.normal(jax.random.key(7), (tokens, experts), dtype=jnp.float32)
+    )
+    bias = jax.random.normal(jax.random.key(8), (experts,), dtype=jnp.float32) * 0.1
+    expected_weights, expected_ids = _reference(logits, bias, topk=topk)
+    called = False
+
+    def fake_biased_topk(router_logits, correction_bias, *, topk, **_):
+        nonlocal called
+        called = True
+        return _reference(router_logits, correction_bias, topk=topk)
+
+    monkeypatch.setattr(gate, "biased_topk_pallas", fake_biased_topk)
+    previous_server_args = get_global_server_args()
+    set_global_server_args(SimpleNamespace(enable_grouped_topk_kernel=True, device="tpu"))
+    try:
+        actual_weights, actual_ids = gate.TopK(
+            topk=topk,
+            renormalize=False,
+        )(logits, correction_bias=bias)
+    finally:
+        set_global_server_args(previous_server_args)
+
+    assert called
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_allclose(
+        np.asarray(actual_weights),
+        np.asarray(expected_weights),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_topk_shared_flag_dispatches_grouped_biased_routing(monkeypatch):
+    from sgl_jax.srt.eplb.expert_location import (
+        get_global_server_args,
+        set_global_server_args,
+    )
+    from sgl_jax.srt.layers import gate
+
+    tokens, experts, topk = 128, 128, 8
+    logits = jax.nn.sigmoid(
+        jax.random.normal(jax.random.key(9), (tokens, experts), dtype=jnp.float32)
+    )
+    bias = jax.random.normal(jax.random.key(10), (experts,), dtype=jnp.float32) * 0.1
+    module = gate.TopK(
+        topk=topk,
+        renormalize=False,
+        num_expert_group=8,
+        topk_group=4,
+    )
+    expected_weights, expected_ids = module._biased_grouped_topk_jax(logits, bias)
+    called = False
+
+    def fake_grouped_topk(router_logits, correction_bias, **_):
+        nonlocal called
+        called = True
+        return module._biased_grouped_topk_jax(router_logits, correction_bias)
+
+    monkeypatch.setattr(gate, "grouped_topk_pallas", fake_grouped_topk)
+    previous_server_args = get_global_server_args()
+    set_global_server_args(SimpleNamespace(enable_grouped_topk_kernel=True, device="tpu"))
+    try:
+        actual_weights, actual_ids = module(logits, correction_bias=bias)
+    finally:
+        set_global_server_args(previous_server_args)
+
+    assert called
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_allclose(
+        np.asarray(actual_weights),
+        np.asarray(expected_weights),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_topk_flag_off_keeps_jax_path(monkeypatch):
+    from sgl_jax.srt.eplb.expert_location import (
+        get_global_server_args,
+        set_global_server_args,
+    )
+    from sgl_jax.srt.layers import gate
+
+    logits = jnp.arange(128, dtype=jnp.float32)[None, :]
+    bias = jnp.zeros((128,), dtype=jnp.float32)
+
+    def fail_if_called(*_, **__):
+        raise AssertionError("Pallas kernel must not run when the flag is disabled")
+
+    monkeypatch.setattr(gate, "biased_topk_pallas", fail_if_called)
+    previous_server_args = get_global_server_args()
+    set_global_server_args(SimpleNamespace(enable_grouped_topk_kernel=False, device="tpu"))
+    try:
+        actual_weights, actual_ids = gate.TopK(
+            topk=8,
+            renormalize=False,
+        )(logits, correction_bias=bias)
+    finally:
+        set_global_server_args(previous_server_args)
+
+    expected_weights, expected_ids = _reference(logits, bias, topk=8)
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_array_equal(np.asarray(actual_weights), np.asarray(expected_weights))
+
+
+def test_topk_kernel_path_preserves_normalization_and_scaling(monkeypatch):
+    from sgl_jax.srt.eplb.expert_location import (
+        get_global_server_args,
+        set_global_server_args,
+    )
+    from sgl_jax.srt.layers.gate import TopK
+
+    monkeypatch.setenv("PALLAS_INTERPRET", "1")
+    tokens, experts, topk = 64, 128, 8
+    logits = jax.nn.sigmoid(
+        jax.random.normal(jax.random.key(11), (tokens, experts), dtype=jnp.float32)
+    )
+    bias = jax.random.normal(jax.random.key(12), (experts,), dtype=jnp.float32) * 0.1
+    raw_weights, expected_ids = _reference(logits, bias, topk=topk)
+    expected_weights = raw_weights / raw_weights.sum(axis=-1, keepdims=True) * 1.75
+
+    previous_server_args = get_global_server_args()
+    set_global_server_args(SimpleNamespace(enable_grouped_topk_kernel=True, device="tpu"))
+    try:
+        actual_weights, actual_ids = TopK(
+            topk=topk,
+            renormalize=True,
+            routed_scaling_factor=1.75,
+        )(logits, correction_bias=bias)
+    finally:
+        set_global_server_args(previous_server_args)
+
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_allclose(
+        np.asarray(actual_weights),
+        np.asarray(expected_weights),
+        rtol=0,
+        atol=1e-6,
+    )
+
+
+def test_topk_unsafe_large_token_shape_falls_back_to_jax():
+    from sgl_jax.srt.eplb.expert_location import (
+        get_global_server_args,
+        set_global_server_args,
+    )
+    from sgl_jax.srt.layers.gate import TopK
+
+    tokens, experts, topk = 2050, 128, 8
+    logits = jax.nn.sigmoid(
+        jax.random.normal(jax.random.key(13), (tokens, experts), dtype=jnp.float32)
+    )
+    bias = jax.random.normal(jax.random.key(14), (experts,), dtype=jnp.float32) * 0.1
+    expected_weights, expected_ids = _reference(logits, bias, topk=topk)
+
+    previous_server_args = get_global_server_args()
+    set_global_server_args(SimpleNamespace(enable_grouped_topk_kernel=True, device="tpu"))
+    try:
+        actual_weights, actual_ids = TopK(
+            topk=topk,
+            renormalize=False,
+        )(logits, correction_bias=bias)
+    finally:
+        set_global_server_args(previous_server_args)
+
+    np.testing.assert_array_equal(np.asarray(actual_ids), np.asarray(expected_ids))
+    np.testing.assert_array_equal(np.asarray(actual_weights), np.asarray(expected_weights))
+
+
+def test_v7_tuned_block_sizes_cover_mimo_sweep(monkeypatch):
+    from sgl_jax.srt.kernels.biased_topk import tuned_block_sizes
+
+    monkeypatch.setattr(tuned_block_sizes, "_device_name", lambda: "TPU v7")
+    expected = {
+        64: 64,
+        128: 128,
+        256: 256,
+        512: 512,
+        1024: 512,
+        2048: 512,
+        4096: 1024,
+        8192: 1024,
+        16384: 1024,
+        32768: 1024,
+    }
+
+    for tokens, block_tokens in expected.items():
+        assert tuned_block_sizes.get_tuned_bt(tokens, 384, 8) == block_tokens
+    assert tuned_block_sizes.get_tuned_bt(1024, 256, 8) is None
+
+
+def test_topk_kernel_path_preserves_logical_to_physical_mapping(monkeypatch):
+    from sgl_jax.srt.eplb.expert_location import (
+        ExpertLocationMetadata,
+        get_global_server_args,
+        set_global_server_args,
+    )
+    from sgl_jax.srt.layers.gate import TopK
+
+    monkeypatch.setenv("PALLAS_INTERPRET", "1")
+    tokens, experts, topk = 64, 128, 8
+    logits = jnp.tile(jnp.arange(experts, dtype=jnp.float32), (tokens, 1))
+    bias = jnp.zeros((experts,), dtype=jnp.float32)
+    _, logical_ids = _reference(logits, bias, topk=topk)
+    logical_to_physical = np.arange(experts - 1, -1, -1, dtype=np.int32)[None, :]
+    dispatch_info = ExpertLocationMetadata(
+        ep_dispatch_algorithm="static",
+        logical_to_rank_dispatch_physical_map=logical_to_physical,
+        logical_to_all_physical_map=logical_to_physical[..., None],
+        logical_to_all_physical_map_num_valid=np.ones((1, experts), dtype=np.int32),
+        physical_to_logical_map=logical_to_physical,
+        num_physical_experts=experts,
+    )
+
+    previous_server_args = get_global_server_args()
+    set_global_server_args(SimpleNamespace(enable_grouped_topk_kernel=True, device="tpu"))
+    try:
+        _, physical_ids = TopK(
+            topk=topk,
+            renormalize=False,
+        )(logits, correction_bias=bias, dispatch_info=dispatch_info)
+    finally:
+        set_global_server_args(previous_server_args)
+
+    expected_physical_ids = logical_to_physical[0][np.asarray(logical_ids)]
+    np.testing.assert_array_equal(
+        np.asarray(physical_ids),
+        expected_physical_ids,
+    )

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -263,6 +263,7 @@ suites = {
         TestFile("python/sgl_jax/test/test_moe_topk.py", 0.3),
         TestFile("python/sgl_jax/test/kernels/fused_moe_v1_test.py", 9),
         TestFile("python/sgl_jax/test/kernels/fused_moe_v2_test.py", 3),
+        TestFile("python/sgl_jax/test/kernels/biased_topk_test.py", 1, runner="pytest"),
         TestFile("python/sgl_jax/test/kernels/grouped_topk_test.py", 1, runner="pytest"),
         TestFile("python/sgl_jax/test/test_sampler.py", 0.2),
         TestFile("python/sgl_jax/test/test_sampler_deterministic_cond.py", 0.3),


### PR DESCRIPTION
## Summary

- add sort-free Pallas kernels for plain and non-grouped biased top-k routing
- enable plain, biased, and grouped top-k kernels by default, with
  `--disable-topk-kernel` as the unified JAX fallback
- preserve DP/SP token-axis sharding for plain, biased, and grouped kernel dispatch
- preserve f32 post-bias selection, stable lowest-index ties, and pre-bias weights
- add TPU shard-map dispatch, safe JAX fallback, tuned block-size lookup, tests, and benchmarks

## Validation

- `63 passed, 12 skipped` across plain/biased/grouped top-k CPU interpret tests
- 8-device CPU simulation passed for DP/SP sharding preservation across all three paths
- pre-commit hooks passed
- TPU v7x-8 real-kernel correctness passed for `E=384, k=8`, including bitwise-equal pre-bias weights
- biased-routing exact-scope speedup over `jax.lax.top_k`: 4.56x at T=64 through 11.38x at T=32768
- TPU v6e-4 real-kernel correctness passed for `E=384, k=8`, including bitwise-equal pre-bias weights
- biased-routing v6e exact-scope speedup: 5.17x at T=64 through 25.06x at T=32768

## TPU tuning

- v7 tuned entries are included for T=64 through T=32768
- v6e tuned entries are included for the same sweep; its measured BT choices differ at T=512, 1024, and 2048
