### PR TITLE
perf: tune RPA v3 for speculative target verify

### DIFF
--- a/benchmark/kernels/flash_attention/tune_target_verify_matrix_v3.py
+++ b/benchmark/kernels/flash_attention/tune_target_verify_matrix_v3.py
@@ -1,0 +1,115 @@
+"""Run a representative target-verify RPA v3 tuning matrix."""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+FULL_CASES = (
+    # q4 production buckets.
+    ("full-q4-bs4-p16k", 4, 4, 16384),
+    ("full-q4-bs8-p16k", 8, 4, 16384),
+    ("full-q4-bs16-p16k", 16, 4, 16384),
+    ("full-q4-bs32-p16k", 32, 4, 16384),
+    ("full-q4-bs64-p16k", 64, 4, 16384),
+    # Other speculative lengths at the same total-Q=128 bucket.
+    ("full-q2-bs64-p16k", 64, 2, 16384),
+    ("full-q8-bs16-p16k", 16, 8, 16384),
+    # Context sensitivity for the production q4/bs32 bucket.
+    ("full-q4-bs32-p4k", 32, 4, 4096),
+    ("full-q4-bs32-p8k", 32, 4, 8192),
+    ("full-q4-bs32-p17k", 32, 4, 17408),
+    ("full-q4-bs32-p32k", 32, 4, 32768),
+)
+
+FULL_CONTEXT_CASES = FULL_CASES[-4:]
+
+SWA_CASES = (
+    ("swa128-q4-bs4-p16k", 4, 4, 16384),
+    ("swa128-q4-bs8-p16k", 8, 4, 16384),
+    ("swa128-q4-bs16-p16k", 16, 4, 16384),
+    ("swa128-q4-bs32-p16k", 32, 4, 16384),
+    ("swa128-q4-bs64-p16k", 64, 4, 16384),
+    ("swa128-q2-bs64-p16k", 64, 2, 16384),
+    ("swa128-q8-bs16-p16k", 16, 8, 16384),
+)
+
+SWA_CONTEXT_CASES = (
+    ("swa128-q4-bs32-p4k", 32, 4, 4096),
+    ("swa128-q4-bs32-p8k", 32, 4, 8192),
+    ("swa128-q4-bs32-p17k", 32, 4, 17408),
+    ("swa128-q4-bs32-p32k", 32, 4, 32768),
+)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--suite",
+        choices=(
+            "full",
+            "swa",
+            "tokens16-full",
+            "tokens16-swa",
+            "context-full",
+            "context-swa",
+            "all",
+        ),
+        default="all",
+    )
+    parser.add_argument("--tries", type=int, default=3)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    cases = []
+    if args.suite in ("full", "all"):
+        cases.extend((name, bs, q, prefix, 0) for name, bs, q, prefix in FULL_CASES)
+    if args.suite in ("swa", "all"):
+        cases.extend((name, bs, q, prefix, 128) for name, bs, q, prefix in SWA_CASES)
+    if args.suite == "tokens16-full":
+        name, bs, q, prefix = FULL_CASES[0]
+        cases.append((name, bs, q, prefix, 0))
+    if args.suite == "tokens16-swa":
+        name, bs, q, prefix = SWA_CASES[0]
+        cases.append((name, bs, q, prefix, 128))
+    if args.suite == "context-full":
+        cases.extend((name, bs, q, prefix, 0) for name, bs, q, prefix in FULL_CONTEXT_CASES)
+    if args.suite == "context-swa":
+        cases.extend((name, bs, q, prefix, 128) for name, bs, q, prefix in SWA_CONTEXT_CASES)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    tuner = Path(__file__).with_name("tune_target_verify_v3.py")
+    aggregate_path = args.output_dir / "metrics.jsonl"
+    with aggregate_path.open("w") as aggregate:
+        for name, batch_size, draft_token_num, prefix_len, sliding_window in cases:
+            case_path = args.output_dir / f"{name}.jsonl"
+            command = [
+                sys.executable,
+                str(tuner),
+                "--batch-size",
+                str(batch_size),
+                "--draft-token-num",
+                str(draft_token_num),
+                "--prefix-len",
+                str(prefix_len),
+                "--tries",
+                str(args.tries),
+                "--grid",
+                "focused",
+                "--output",
+                str(case_path),
+            ]
+            if sliding_window:
+                command.extend(["--sliding-window", str(sliding_window)])
+            print(f"\n## CASE {name}", flush=True)
+            subprocess.run(command, check=True)
+            for line in case_path.read_text().splitlines():
+                record = json.loads(line)
+                record["case"] = name
+                aggregate.write(json.dumps(record) + "\n")
+                aggregate.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/flash_attention/tune_target_verify_v3.py
+++ b/benchmark/kernels/flash_attention/tune_target_verify_v3.py
@@ -1,0 +1,318 @@
+"""Tune RPA v3 MIXED blocks for batched speculative target verification.
+
+This intentionally has a separate entry point from the generic MIXED tuner:
+``mnt=128`` there means one 128-token prefill, while the production workload
+here is 32 sequences x 4 draft tokens, each attending to a long KV prefix.
+
+Example matching the MiMo-V2-Pro 16K-input target-verify HLO::
+
+    python benchmark/kernels/flash_attention/tune_target_verify_v3.py \
+      --batch-size 32 --draft-token-num 4 --prefix-len 16384 \
+      --page-size 256 --page-indices-capacity 32768 \
+      --max-kv-cache-tokens 1655296 --q-head-num 16 \
+      --kv-head-num 1 --head-dim 256 --tries 5
+"""
+
+import argparse
+import functools
+import json
+import math
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from utils import create_target_verify_uniform_data
+
+from sgl_jax.srt.kernels.ragged_paged_attention.ragged_paged_attention_v3 import (
+    get_vmem_estimate_bytes,
+    get_vmem_limit,
+    ragged_paged_attention,
+)
+from sgl_jax.srt.kernels.utils.perf import multiple_iteration_timeit_from_trace
+from sgl_jax.srt.utils.jax_utils import get_device_name
+
+_DEFAULT_CANDIDATES = (
+    (32, 256, 32, 256),  # current production table hit
+    (1, 1024, 1, 512),
+    (2, 1024, 2, 512),
+    (4, 1024, 4, 512),
+    (8, 1024, 8, 512),
+    (4, 1024, 4, 1024),
+    (1, 2048, 1, 512),
+    (2, 2048, 2, 512),
+    (4, 2048, 4, 512),
+    (8, 2048, 8, 512),
+    (4, 2048, 4, 1024),
+    (4, 2048, 4, 2048),
+    (4, 4096, 4, 1024),
+)
+
+
+def _focused_candidates(
+    draft_token_num: int,
+    sliding_window: int | None,
+) -> list[tuple[int, int, int, int]]:
+    q = draft_token_num
+    q_lo = max(1, q // 2)
+    q_hi = min(32, q * 2)
+    if sliding_window is not None:
+        return [
+            (32, 256, 32, 256),
+            (q_lo, 256, q_lo, 256),
+            (q, 256, q, 256),
+            (q_hi, 256, q_hi, 256),
+            (q, 512, q, 256),
+            (q, 512, q, 512),
+            (q, 1024, q, 256),
+            (q, 1024, q, 512),
+            (q, 1024, q, 1024),
+        ]
+    return [
+        (32, 256, 32, 256),
+        (q_lo, 2048, q_lo, 2048),
+        (q, 1024, q, 1024),
+        (q, 2048, q, 1024),
+        (q, 2048, q, 2048),
+        (q_hi, 2048, q_hi, 2048),
+        (q, 4096, q, 1024),
+    ]
+
+
+def _parse_candidate(value: str) -> tuple[int, int, int, int]:
+    parts = tuple(int(item) for item in value.split(","))
+    if len(parts) != 4:
+        raise argparse.ArgumentTypeError("candidate must be bq_sz,bkv_sz,bq_csz,bkv_csz")
+    return parts
+
+
+def _benchmark_one(
+    inputs,
+    block_sizes,
+    head_dim: int,
+    tries: int,
+    sliding_window: int | None,
+) -> float:
+    @functools.partial(
+        jax.jit,
+        static_argnames=("sm_scale", "m_block_sizes"),
+    )
+    def attn(
+        q,
+        k,
+        v,
+        kv_cache,
+        kv_lens,
+        page_indices,
+        cu_q_lens,
+        cu_kv_lens,
+        distribution,
+        sm_scale,
+        m_block_sizes,
+    ):
+        return ragged_paged_attention(
+            q,
+            k,
+            v,
+            kv_cache,
+            kv_lens,
+            page_indices,
+            cu_q_lens,
+            cu_kv_lens,
+            distribution,
+            custom_mask=None,
+            causal=1,
+            sm_scale=sm_scale,
+            sliding_window=sliding_window,
+            chunk_prefill_size=None,
+            m_block_sizes=m_block_sizes,
+            vmem_limit_bytes=get_vmem_limit(),
+        )
+
+    bound = functools.partial(
+        attn,
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["kv_cache"],
+        inputs["kv_lens"],
+        inputs["page_indices"],
+        inputs["cu_q_lens"],
+        inputs["cu_kv_lens"],
+        inputs["distribution"],
+        head_dim**-0.5,
+        block_sizes,
+    )
+    out = bound()
+    jax.block_until_ready(out)
+    scope = (
+        f"RPAm-p_{inputs['page_size']}"
+        f"-bq_{block_sizes[0]}_{block_sizes[2]}"
+        f"-bkv_{block_sizes[1]}_{block_sizes[3]}"
+    )
+    times = multiple_iteration_timeit_from_trace(
+        compute_func=bound,
+        data_generator=lambda: (),
+        task=scope,
+        tries=tries,
+    )
+    return float(np.mean(times)) if times else math.nan
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--draft-token-num", type=int, default=4)
+    parser.add_argument("--prefix-len", type=int, default=16384)
+    parser.add_argument("--page-size", type=int, default=256)
+    parser.add_argument("--page-indices-capacity", type=int, default=32768)
+    parser.add_argument("--max-kv-cache-tokens", type=int, default=1655296)
+    parser.add_argument("--q-head-num", type=int, default=16)
+    parser.add_argument("--kv-head-num", type=int, default=1)
+    parser.add_argument("--head-dim", type=int, default=256)
+    parser.add_argument("--tries", type=int, default=5)
+    parser.add_argument(
+        "--sliding-window",
+        type=int,
+        default=0,
+        help="0 for full attention; positive values tune an SWA target-verify layer",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="optional JSONL path for Falcon operator-analysis",
+    )
+    parser.add_argument(
+        "--candidate",
+        action="append",
+        type=_parse_candidate,
+        dest="candidates",
+        help="repeatable bq_sz,bkv_sz,bq_csz,bkv_csz; defaults to focused grid",
+    )
+    parser.add_argument(
+        "--grid",
+        choices=("broad", "focused"),
+        default="broad",
+        help="broad reproduces the original q4 sweep; focused scales with q_len",
+    )
+    args = parser.parse_args()
+
+    values = create_target_verify_uniform_data(
+        batch_size=args.batch_size,
+        draft_token_num=args.draft_token_num,
+        prefix_len=args.prefix_len,
+        page_indices_capacity=args.page_indices_capacity,
+        max_kv_cache_tokens=args.max_kv_cache_tokens,
+        q_head_num=args.q_head_num,
+        kv_head_num=args.kv_head_num,
+        head_dim=args.head_dim,
+        page_size=args.page_size,
+    )
+    inputs = dict(
+        zip(
+            (
+                "q",
+                "k",
+                "v",
+                "kv_cache",
+                "kv_lens",
+                "page_indices",
+                "cu_q_lens",
+                "cu_kv_lens",
+            ),
+            values[:8],
+            strict=True,
+        )
+    )
+    inputs["distribution"] = values[-1]
+    inputs["page_size"] = args.page_size
+
+    candidates = args.candidates or (
+        _focused_candidates(args.draft_token_num, args.sliding_window or None)
+        if args.grid == "focused"
+        else list(_DEFAULT_CANDIDATES)
+    )
+    vmem_limit = get_vmem_limit()
+    print(f"# device={get_device_name()} devices={jax.devices()}")
+    print(
+        "# workload="
+        f"bs{args.batch_size}xq{args.draft_token_num} "
+        f"prefix={args.prefix_len} page={args.page_size} "
+        f"q_heads={args.q_head_num} kv_heads={args.kv_head_num} hd={args.head_dim} "
+        f"sliding_window={args.sliding_window or None}"
+    )
+    print(
+        f"# shapes q={inputs['q'].shape} kv_cache={inputs['kv_cache'].shape} "
+        f"page_indices={inputs['page_indices'].shape}"
+    )
+
+    rows = []
+    for block_sizes in candidates:
+        est = get_vmem_estimate_bytes(
+            args.kv_head_num,
+            args.q_head_num // args.kv_head_num,
+            args.head_dim,
+            block_sizes[0],
+            block_sizes[1],
+            jnp.bfloat16,
+            jnp.bfloat16,
+            use_custom_mask=False,
+            bkv_csz=block_sizes[3],
+        )
+        if est > vmem_limit:
+            print(
+                f"# SKIP {block_sizes}: estimated VMEM {est / 2**20:.2f}MiB "
+                f"> limit {vmem_limit / 2**20:.2f}MiB"
+            )
+            continue
+        try:
+            elapsed = _benchmark_one(
+                inputs,
+                block_sizes,
+                args.head_dim,
+                args.tries,
+                args.sliding_window or None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(f"# FAIL {block_sizes}: {type(exc).__name__}: {exc}")
+            continue
+        rows.append((elapsed, block_sizes, est))
+        print(f"# MEASURED {block_sizes}: {elapsed:.4f}ms vmem={est / 2**20:.2f}MiB")
+
+    if not rows:
+        raise SystemExit("no candidate completed")
+    rows.sort()
+    best_time, best, _ = rows[0]
+    baseline = next((time for time, bs, _ in rows if bs == (32, 256, 32, 256)), math.nan)
+    speedup = baseline / best_time if math.isfinite(baseline) else math.nan
+    print(f"RESULT best={best} time_ms={best_time:.4f}")
+    print(f"RESULT baseline_ms={baseline:.4f} speedup={speedup:.3f}x")
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("w") as output:
+            for elapsed, block_sizes, est in rows:
+                output.write(
+                    json.dumps(
+                        {
+                            "variant": "target_verify",
+                            "batch_size": args.batch_size,
+                            "draft_token_num": args.draft_token_num,
+                            "prefix_len": args.prefix_len,
+                            "page_size": args.page_size,
+                            "q_head_num": args.q_head_num,
+                            "kv_head_num": args.kv_head_num,
+                            "head_dim": args.head_dim,
+                            "sliding_window": args.sliding_window or None,
+                            "block_sizes": list(block_sizes),
+                            "latency_ms": elapsed,
+                            "estimated_vmem_mib": est / 2**20,
+                            "is_baseline": block_sizes == (32, 256, 32, 256),
+                            "is_best": block_sizes == best,
+                        }
+                    )
+                    + "\n"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/flash_attention/utils.py
+++ b/benchmark/kernels/flash_attention/utils.py
@@ -1,8 +1,7 @@
 import jax
 import jax.numpy as jnp
 
-from sgl_jax.srt.kernels.ragged_paged_attention.util import get_dtype_packing
-from sgl_jax.srt.utils import cdiv
+from sgl_jax.srt.kernels.ragged_paged_attention.util import cdiv, get_dtype_packing
 
 
 def create_kv_cache_data(
@@ -164,6 +163,109 @@ def create_decode_uniform_data(
         v,
         kv_cache,
         seq_lens,
+        page_indices,
+        cu_q_lens,
+        cu_kv_lens,
+        num_seqs,
+        seq_lens,
+        cache_loc,
+        distribution,
+    )
+
+
+def create_target_verify_uniform_data(
+    *,
+    batch_size: int,
+    draft_token_num: int,
+    prefix_len: int,
+    page_indices_capacity: int,
+    max_kv_cache_tokens: int,
+    q_head_num: int,
+    kv_head_num: int,
+    head_dim: int,
+    page_size: int = 128,
+    dtype=jnp.bfloat16,
+    seed: int = 42,
+):
+    """Create the padded MIXED workload used by batched target verification.
+
+    Unlike ``create_prefill_uniform_data``, this models many short query
+    segments attending to long existing prefixes. ``cu_kv_lens`` follows the
+    production target-verify path and advances by page-aligned KV lengths,
+    while ``kv_lens`` retains the actual (prefix + draft) length.
+    """
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}")
+    if draft_token_num <= 0:
+        raise ValueError(f"draft_token_num must be positive, got {draft_token_num}")
+    if prefix_len < 0:
+        raise ValueError(f"prefix_len must be non-negative, got {prefix_len}")
+
+    total_q_tokens = batch_size * draft_token_num
+    kv_len = prefix_len + draft_token_num
+    aligned_kv_len = cdiv(kv_len, page_size) * page_size
+    pages_per_seq = cdiv(kv_len, page_size)
+    required_page_indices = batch_size * pages_per_seq
+    if page_indices_capacity < required_page_indices:
+        raise ValueError(
+            "page_indices_capacity is too small: "
+            f"required={required_page_indices}, got={page_indices_capacity}"
+        )
+
+    q, k, v = create_qkv_data(
+        total_q_tokens,
+        q_head_num,
+        kv_head_num,
+        head_dim,
+        dtype,
+        seed,
+    )
+    packing = get_dtype_packing(dtype)
+    total_num_pages = cdiv(max_kv_cache_tokens, page_size)
+    if total_num_pages < required_page_indices:
+        raise ValueError(
+            "max_kv_cache_tokens is too small: "
+            f"required_pages={required_page_indices}, got_pages={total_num_pages}"
+        )
+    # Cache contents do not affect kernel timing. Avoid allocating random
+    # generation intermediates for the multi-GB production-shaped cache.
+    kv_cache = jnp.zeros(
+        (total_num_pages, page_size, kv_head_num * 2 // packing, packing, head_dim),
+        dtype=dtype,
+    )
+
+    kv_lens = jnp.full((batch_size,), kv_len, dtype=jnp.int32)
+    cu_q_lens = jnp.arange(
+        0,
+        total_q_tokens + 1,
+        draft_token_num,
+        dtype=jnp.int32,
+    )
+    cu_kv_lens = jnp.arange(
+        0,
+        batch_size * aligned_kv_len + 1,
+        aligned_kv_len,
+        dtype=jnp.int32,
+    )
+
+    page_indices = jnp.pad(
+        jnp.arange(required_page_indices, dtype=jnp.int32),
+        (0, page_indices_capacity - required_page_indices),
+        constant_values=0,
+    )
+    num_seqs = jnp.array([batch_size], dtype=jnp.int32)
+    seq_lens = kv_lens
+    cache_loc = jnp.arange(total_q_tokens, dtype=jnp.int32)
+    # TARGET_VERIFY metadata starts as [0, N, N]. RPA remaps the middle
+    # boundary to zero when chunk_prefill_size=None, so all rows execute in
+    # the MIXED pallas_call.
+    distribution = jnp.array([0, batch_size, batch_size], dtype=jnp.int32)
+    return (
+        q,
+        k,
+        v,
+        kv_cache,
+        kv_lens,
         page_indices,
         cu_q_lens,
         cu_kv_lens,

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/tuned_block_sizes_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/tuned_block_sizes_v3.py
@@ -1,14 +1,18 @@
 """Auto-tuned block sizes for ragged paged attention v3.
 
 The v3 kernel splits into three pallas_calls (DECODE / PREFILL / MIXED), each
-with its own (bq_sz, bkv_sz, bq_csz, bkv_csz) 4-tuple. This table is keyed by
-device + stage + sliding-window bucket + the same workload signature used by v2.
+with its own (bq_sz, bkv_sz, bq_csz, bkv_csz) 4-tuple. Batched target
+verification still executes the MIXED pallas_call, but uses lookup stage
+``"v"`` because its many short queries over long KV prefixes need different
+tiling from ordinary mixed/prefill traffic.
 
 Schema:
     TUNED_BLOCK_SIZES_V3[device_name][key] = (bq_sz, bkv_sz, bq_csz, bkv_csz)
-    key = (stage, sliding_window, q_dtype, kv_dtype, q_heads, kv_heads,
+    key = (stage, sliding_window, ..., q_dtype, kv_dtype, q_heads, kv_heads,
            head_dim, page_size, max_num_tokens)
-    stage in {"d", "p", "m"}
+    stage in {"d", "p", "m", "v"}
+    stage "v" inserts tokens_per_seq after sliding_window and is lookup-only;
+    the selected tuple is passed to the MIXED pallas_call.
     sliding_window: None for full-attention layers; int for SWA layers
                     (a different sliding_window value is a different entry —
                     e.g., bkv ~= sliding_window is usually optimal so SWA must
@@ -1002,6 +1006,25 @@ TUNED_BLOCK_SIZES_V3: dict[str, dict[tuple, tuple[int, int, int, int]]] = {
         ("m", None, "bfloat16", "bfloat16", 64, 16, 128, 256, 2048): (32, 256, 32, 256),
     },
     "TPU v7": {
+        # Target verify on MiMo v2.5 Pro: short per-request query segments over
+        # a long prefix. Lookup stage "v" still executes the MIXED pallas_call.
+        # Full attention was stable at bkv=2048 across 4K--32K contexts.
+        ("v", None, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 16): (4, 2048, 4, 2048),
+        ("v", None, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 32): (4, 2048, 4, 2048),
+        ("v", None, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 64): (4, 2048, 4, 2048),
+        ("v", None, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (4, 2048, 4, 2048),
+        ("v", None, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 256): (4, 2048, 4, 2048),
+        ("v", None, 2, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (2, 2048, 2, 2048),
+        ("v", None, 8, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (8, 2048, 8, 2048),
+        # SWA128 only reads a 128-token window. One 256-token page/block is
+        # consistently faster than carrying the full-attention bkv=2048.
+        ("v", 128, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 16): (4, 256, 4, 256),
+        ("v", 128, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 32): (4, 256, 4, 256),
+        ("v", 128, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 64): (4, 256, 4, 256),
+        ("v", 128, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (4, 256, 4, 256),
+        ("v", 128, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 256): (4, 256, 4, 256),
+        ("v", 128, 2, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (2, 256, 2, 256),
+        ("v", 128, 8, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (8, 256, 8, 256),
         ("d", 128, "bfloat16", "bfloat16", 16, 1, 256, 128, 1): (1, 256, 1, 256),
         ("d", 128, "bfloat16", "bfloat16", 16, 1, 256, 128, 2): (1, 256, 1, 256),
         ("d", 128, "bfloat16", "bfloat16", 16, 1, 256, 128, 4): (1, 256, 1, 256),
@@ -2150,6 +2173,7 @@ def get_tuned_block_sizes_v3(
     page_size: int,
     max_num_tokens: int,
     sliding_window: int | None = None,
+    tokens_per_seq: int | None = None,
 ) -> tuple[int, int, int, int] | None:
     """Look up (bq_sz, bkv_sz, bq_csz, bkv_csz) from the v3 tuned table.
 
@@ -2160,8 +2184,10 @@ def get_tuned_block_sizes_v3(
     Returns None if no entry matches; caller should fall back to the heuristic
     in ragged_paged_attention_v3.get_default_block_sizes.
     """
-    if stage not in ("d", "p", "m"):
-        raise ValueError(f"stage must be one of d/p/m, got {stage!r}")
+    if stage not in ("d", "p", "m", "v"):
+        raise ValueError(f"stage must be one of d/p/m/v, got {stage!r}")
+    if stage == "v" and tokens_per_seq is None:
+        raise ValueError("tokens_per_seq is required for target-verify stage v")
 
     tpu_version = get_tpu_version()
     if tpu_version < 5:
@@ -2181,7 +2207,11 @@ def get_tuned_block_sizes_v3(
     if not table:
         return None
 
-    key = (stage, sliding_window, *signature)
+    key = (
+        (stage, sliding_window, tokens_per_seq, *signature)
+        if stage == "v"
+        else (stage, sliding_window, *signature)
+    )
     hit = table.get(key)
     if hit is None and key not in _WARNED_MISSES:
         _WARNED_MISSES.add(key)

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/tuned_block_sizes_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/tuned_block_sizes_v3.py
@@ -11,8 +11,9 @@ Schema:
     key = (stage, sliding_window, ..., q_dtype, kv_dtype, q_heads, kv_heads,
            head_dim, page_size, max_num_tokens)
     stage in {"d", "p", "m", "v"}
-    stage "v" inserts tokens_per_seq after sliding_window and is lookup-only;
-    the selected tuple is passed to the MIXED pallas_call.
+    stage "v" is lookup-only; the selected tuple is passed to the MIXED
+    pallas_call. Its bq fields are caps that are clamped to tokens_per_seq at
+    trace time.
     sliding_window: None for full-attention layers; int for SWA layers
                     (a different sliding_window value is a different entry —
                     e.g., bkv ~= sliding_window is usually optimal so SWA must
@@ -1009,22 +1010,18 @@ TUNED_BLOCK_SIZES_V3: dict[str, dict[tuple, tuple[int, int, int, int]]] = {
         # Target verify on MiMo v2.5 Pro: short per-request query segments over
         # a long prefix. Lookup stage "v" still executes the MIXED pallas_call.
         # Full attention was stable at bkv=2048 across 4K--32K contexts.
-        ("v", None, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 16): (4, 2048, 4, 2048),
-        ("v", None, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 32): (4, 2048, 4, 2048),
-        ("v", None, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 64): (4, 2048, 4, 2048),
-        ("v", None, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (4, 2048, 4, 2048),
-        ("v", None, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 256): (4, 2048, 4, 2048),
-        ("v", None, 2, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (2, 2048, 2, 2048),
-        ("v", None, 8, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (8, 2048, 8, 2048),
+        ("v", None, "bfloat16", "bfloat16", 16, 1, 256, 256, 16): (32, 2048, 32, 2048),
+        ("v", None, "bfloat16", "bfloat16", 16, 1, 256, 256, 32): (32, 2048, 32, 2048),
+        ("v", None, "bfloat16", "bfloat16", 16, 1, 256, 256, 64): (32, 2048, 32, 2048),
+        ("v", None, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (32, 2048, 32, 2048),
+        ("v", None, "bfloat16", "bfloat16", 16, 1, 256, 256, 256): (32, 2048, 32, 2048),
         # SWA128 only reads a 128-token window. One 256-token page/block is
         # consistently faster than carrying the full-attention bkv=2048.
-        ("v", 128, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 16): (4, 256, 4, 256),
-        ("v", 128, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 32): (4, 256, 4, 256),
-        ("v", 128, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 64): (4, 256, 4, 256),
-        ("v", 128, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (4, 256, 4, 256),
-        ("v", 128, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 256): (4, 256, 4, 256),
-        ("v", 128, 2, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (2, 256, 2, 256),
-        ("v", 128, 8, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (8, 256, 8, 256),
+        ("v", 128, "bfloat16", "bfloat16", 16, 1, 256, 256, 16): (32, 256, 32, 256),
+        ("v", 128, "bfloat16", "bfloat16", 16, 1, 256, 256, 32): (32, 256, 32, 256),
+        ("v", 128, "bfloat16", "bfloat16", 16, 1, 256, 256, 64): (32, 256, 32, 256),
+        ("v", 128, "bfloat16", "bfloat16", 16, 1, 256, 256, 128): (32, 256, 32, 256),
+        ("v", 128, "bfloat16", "bfloat16", 16, 1, 256, 256, 256): (32, 256, 32, 256),
         ("d", 128, "bfloat16", "bfloat16", 16, 1, 256, 128, 1): (1, 256, 1, 256),
         ("d", 128, "bfloat16", "bfloat16", 16, 1, 256, 128, 2): (1, 256, 1, 256),
         ("d", 128, "bfloat16", "bfloat16", 16, 1, 256, 128, 4): (1, 256, 1, 256),
@@ -2207,11 +2204,7 @@ def get_tuned_block_sizes_v3(
     if not table:
         return None
 
-    key = (
-        (stage, sliding_window, tokens_per_seq, *signature)
-        if stage == "v"
-        else (stage, sliding_window, *signature)
-    )
+    key = (stage, sliding_window, *signature)
     hit = table.get(key)
     if hit is None and key not in _WARNED_MISSES:
         _WARNED_MISSES.add(key)
@@ -2221,5 +2214,16 @@ def get_tuned_block_sizes_v3(
             "to enable tuning for this shape.",
             device_name,
             key,
+        )
+    if hit is not None and stage == "v":
+        # Verify has many static q_len-sized query segments. The table stores a
+        # reusable query-tile cap, while draft_token_num specializes bq at trace
+        # time without adding a one-off key dimension.
+        assert tokens_per_seq is not None
+        return (
+            min(hit[0], tokens_per_seq),
+            hit[1],
+            min(hit[2], tokens_per_seq),
+            hit[3],
         )
     return hit

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -12,6 +12,9 @@ from jax.tree_util import register_pytree_node_class
 from sgl_jax.srt.kernels.ragged_paged_attention.ragged_paged_attention_v3 import (
     ragged_paged_attention as ragged_paged_attention_v3,
 )
+from sgl_jax.srt.kernels.ragged_paged_attention.tuned_block_sizes_v3 import (
+    get_tuned_block_sizes_v3,
+)
 from sgl_jax.srt.layers.attention.base_attn_backend import AttentionBackend
 from sgl_jax.srt.layers.radix_attention import RadixAttention
 from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
@@ -430,7 +433,6 @@ class FlashAttention(AttentionBackend):
         return metadata
 
     def get_eagle_multi_step_metadata(self, batch: ModelWorkerBatch):
-
         indices = np.arange(0, len(batch.cache_loc), self.page_size)
         # NOTE: Use original_selected_cache_locs as the source of truth for all steps
         # to avoid the bug where selected_cache_locs is overwritten by truncated data in loops.
@@ -646,10 +648,37 @@ class FlashAttention(AttentionBackend):
             self.forward_metadata.custom_mask is not None
             and forward_batch.forward_mode.is_target_verify()
         )
+        target_verify_tokens_per_seq = (
+            getattr(forward_batch.spec_info, "draft_token_num", None)
+            if forward_batch.forward_mode.is_target_verify()
+            else None
+        )
 
         def _ragged_paged_attention_with_fused_kv(*args):
             queries, keys, values, kv_cache_fused = args[:4]
             other_args = args[4:]
+            # Target verify is semantically many short decode-like query
+            # segments over long prefixes, although it must execute in the
+            # MIXED kernel for q_len > 1. Keep its tuning namespace separate
+            # from ordinary mixed/prefill. The current table is for causal
+            # chain verification; custom tree masks retain the generic path.
+            target_verify_m_block_sizes = (
+                get_tuned_block_sizes_v3(
+                    "v",
+                    queries.dtype,
+                    kv_cache_fused.dtype,
+                    queries.shape[1],
+                    keys.shape[1],
+                    queries.shape[2],
+                    kv_cache_fused.shape[1],
+                    queries.shape[0],
+                    sliding_window=layer.sliding_window_size,
+                    tokens_per_seq=target_verify_tokens_per_seq,
+                )
+                if target_verify_tokens_per_seq is not None
+                and self.forward_metadata.custom_mask is None
+                else None
+            )
 
             # Call fused KV kernel with head interleaving
             result, updated_kv_cache_fused = ragged_paged_attention_v3(
@@ -667,6 +696,7 @@ class FlashAttention(AttentionBackend):
                 ),
                 softmax_dtype=layer.softmax_dtype,
                 mask_aligned_to_cu_kv=mask_aligned_to_cu_kv,
+                m_block_sizes=target_verify_m_block_sizes,
             )
 
             return result, updated_kv_cache_fused

--- a/python/sgl_jax/test/test_tuned_block_sizes_v3.py
+++ b/python/sgl_jax/test/test_tuned_block_sizes_v3.py
@@ -108,8 +108,8 @@ def test_sliding_window_separates_buckets(monkeypatch):
     ) == (1, 256, 1, 256)
 
 
-def test_target_verify_uses_tokens_per_seq_bucket(monkeypatch):
-    """Target verify must not share a key with ordinary MIXED traffic."""
+def test_target_verify_clamps_query_tile_without_extra_key_dimension(monkeypatch):
+    """Target verify uses the common key schema and specializes bq at trace time."""
     from sgl_jax.srt.kernels.ragged_paged_attention import tuned_block_sizes_v3 as mod
 
     monkeypatch.setattr(mod, "get_tpu_version", lambda: 7)
@@ -129,8 +129,8 @@ def test_target_verify_uses_tokens_per_seq_bucket(monkeypatch):
     )
     mod.TUNED_BLOCK_SIZES_V3["TPU v7"].clear()
     mod.TUNED_BLOCK_SIZES_V3["TPU v7"][
-        ("v", None, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 128)
-    ] = (4, 2048, 4, 2048)
+        ("v", None, "bfloat16", "bfloat16", 16, 1, 256, 256, 128)
+    ] = (32, 2048, 32, 2048)
 
     assert mod.get_tuned_block_sizes_v3(
         "v",
@@ -143,20 +143,17 @@ def test_target_verify_uses_tokens_per_seq_bucket(monkeypatch):
         128,
         tokens_per_seq=4,
     ) == (4, 2048, 4, 2048)
-    assert (
-        mod.get_tuned_block_sizes_v3(
-            "v",
-            jnp.bfloat16,
-            jnp.bfloat16,
-            16,
-            1,
-            256,
-            256,
-            128,
-            tokens_per_seq=8,
-        )
-        is None
-    )
+    assert mod.get_tuned_block_sizes_v3(
+        "v",
+        jnp.bfloat16,
+        jnp.bfloat16,
+        16,
+        1,
+        256,
+        256,
+        128,
+        tokens_per_seq=8,
+    ) == (8, 2048, 8, 2048)
     assert (
         mod.get_tuned_block_sizes_v3(
             "m",

--- a/python/sgl_jax/test/test_tuned_block_sizes_v3.py
+++ b/python/sgl_jax/test/test_tuned_block_sizes_v3.py
@@ -108,6 +108,146 @@ def test_sliding_window_separates_buckets(monkeypatch):
     ) == (1, 256, 1, 256)
 
 
+def test_target_verify_uses_tokens_per_seq_bucket(monkeypatch):
+    """Target verify must not share a key with ordinary MIXED traffic."""
+    from sgl_jax.srt.kernels.ragged_paged_attention import tuned_block_sizes_v3 as mod
+
+    monkeypatch.setattr(mod, "get_tpu_version", lambda: 7)
+    monkeypatch.setattr(
+        mod,
+        "get_simplified_key",
+        lambda ps, q_dt, kv_dt, q_h, kv_h, hd, mnt: (
+            "TPU v7",
+            "bfloat16",
+            "bfloat16",
+            q_h,
+            kv_h,
+            hd,
+            ps,
+            mnt,
+        ),
+    )
+    mod.TUNED_BLOCK_SIZES_V3["TPU v7"].clear()
+    mod.TUNED_BLOCK_SIZES_V3["TPU v7"][
+        ("v", None, 4, "bfloat16", "bfloat16", 16, 1, 256, 256, 128)
+    ] = (4, 2048, 4, 2048)
+
+    assert mod.get_tuned_block_sizes_v3(
+        "v",
+        jnp.bfloat16,
+        jnp.bfloat16,
+        16,
+        1,
+        256,
+        256,
+        128,
+        tokens_per_seq=4,
+    ) == (4, 2048, 4, 2048)
+    assert (
+        mod.get_tuned_block_sizes_v3(
+            "v",
+            jnp.bfloat16,
+            jnp.bfloat16,
+            16,
+            1,
+            256,
+            256,
+            128,
+            tokens_per_seq=8,
+        )
+        is None
+    )
+    assert (
+        mod.get_tuned_block_sizes_v3(
+            "m",
+            jnp.bfloat16,
+            jnp.bfloat16,
+            16,
+            1,
+            256,
+            256,
+            128,
+        )
+        is None
+    )
+
+
+def test_target_verify_requires_tokens_per_seq():
+    with pytest.raises(ValueError, match="tokens_per_seq"):
+        get_tuned_block_sizes_v3(
+            "v",
+            jnp.bfloat16,
+            jnp.bfloat16,
+            16,
+            1,
+            256,
+            256,
+            128,
+        )
+
+
+@pytest.mark.parametrize(
+    ("sliding_window", "tokens_per_seq", "max_num_tokens", "expected"),
+    [
+        (None, 4, 16, (4, 2048, 4, 2048)),
+        (None, 4, 32, (4, 2048, 4, 2048)),
+        (None, 4, 64, (4, 2048, 4, 2048)),
+        (None, 4, 128, (4, 2048, 4, 2048)),
+        (None, 4, 256, (4, 2048, 4, 2048)),
+        (None, 2, 128, (2, 2048, 2, 2048)),
+        (None, 8, 128, (8, 2048, 8, 2048)),
+        (128, 4, 16, (4, 256, 4, 256)),
+        (128, 4, 32, (4, 256, 4, 256)),
+        (128, 4, 64, (4, 256, 4, 256)),
+        (128, 4, 128, (4, 256, 4, 256)),
+        (128, 4, 256, (4, 256, 4, 256)),
+        (128, 2, 128, (2, 256, 2, 256)),
+        (128, 8, 128, (8, 256, 8, 256)),
+    ],
+)
+def test_mimo_target_verify_tuned_matrix(
+    monkeypatch,
+    sliding_window,
+    tokens_per_seq,
+    max_num_tokens,
+    expected,
+):
+    """The measured full/SWA matrix must route to its distinct winners."""
+    from sgl_jax.srt.kernels.ragged_paged_attention import tuned_block_sizes_v3 as mod
+
+    monkeypatch.setattr(mod, "get_tpu_version", lambda: 7)
+    monkeypatch.setattr(
+        mod,
+        "get_simplified_key",
+        lambda ps, q_dt, kv_dt, q_h, kv_h, hd, mnt: (
+            "TPU v7",
+            "bfloat16",
+            "bfloat16",
+            q_h,
+            kv_h,
+            hd,
+            ps,
+            mnt,
+        ),
+    )
+
+    assert (
+        mod.get_tuned_block_sizes_v3(
+            "v",
+            jnp.bfloat16,
+            jnp.bfloat16,
+            16,
+            1,
+            256,
+            256,
+            max_num_tokens,
+            sliding_window=sliding_window,
+            tokens_per_seq=tokens_per_seq,
+        )
+        == expected
+    )
+
+
 def test_invalid_stage_raises():
     with pytest.raises(ValueError):
         get_tuned_block_sizes_v3("x", jnp.bfloat16, jnp.bfloat16, 32, 1, 128, 256, 64)


### PR DESCRIPTION
## Summary

- add a lookup-only RPA v3 `v` stage for speculative target verification while continuing to execute the MIXED pallas call
- keep the `d`/`m`/`v` tuning-key schema uniform; verify table entries store a query-tile cap and clamp it to the static draft length during tracing
- select decode-like block sizes by total-Q bucket and sliding-window mode
- add MiMo v2.5 Pro TPU v7x entries for q2/q4/q8, total Q 16-256, full attention, and SWA128
- add production-shaped target-verify tuners and lookup tests

## Performance

TPU v7x, BF16, per-shard heads 16/1, head dim 256, page size 256:

| Workload | Baseline | Tuned | Speedup |
|---|---:|---:|---:|
| full, q4 x bs4, 16K | 0.2108 ms | 0.0543 ms | 3.885x |
| full, q4 x bs32, 16K | 1.6580 ms | 0.3977 ms | 4.169x |
| SWA128, q4 x bs4, 16K | 0.0108 ms | 0.0098 ms | 1.096x |
| SWA128, q4 x bs32, 16K | 0.0559 ms | 0.0498 ms | 1.121x |

The selected full-attention tuple `(4, 2048, 4, 2048)` remained the winner from 4K through 32K context. SWA128 consistently selected `(4, 256, 4, 256)`.

Custom tree-mask verification remains on the generic path; the new table applies to chain/DFlash and EAGLE topk=1 verification.

## Validation

- TPU v7x final validation: 22 tests passed
- uniform-key follow-up validation: 22 tests passed (`exp-y3iwsxyjrk`)
- final 16-token rerun: full 0.0543 ms, SWA128 0.0098 ms
- Falcon experiments: `exp-d8lgdnpuxs`, `exp-ma7fhbjxew`, `exp-ddfmw2lp7g`
- Falcon operator analysis: `an-ggylzd55zx` (64 metrics, no warnings)
- pre-commit hooks: passed
- Ruff, Python compile, and diff checks: passed