### PR TITLE
perf(moe): remove metadata synchronization barriers

### DIFF
--- a/python/sgl_jax/srt/kernels/fused_moe/v2/bench_v2.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/bench_v2.py
@@ -461,11 +461,14 @@ def _estimate_vmem_bytes_v2(
     # Output staging: (bts, t_packing, h_per_t) t_dtype
     b_y_stage = bts * hidden_size * token_bytes
 
+    # Kernel-scoped double-buffered metadata mailbox:
+    # (2, num_devices, 1, padded_num_experts) i32.
+    b_metadata_mailbox = 2 * ep_size * padded_num_experts * 4
+
     # Scoped metadata temporaries (run_scoped, only one path active)
     local_num_experts = num_experts // ep_size
     b_scoped = (
         bt * padded_top_k * 4  # t2e_routing
-        + ep_size * padded_num_experts * 4  # d2e_count
         + 2 * padded_num_experts * 4  # expert_offsets
         + padded_num_experts * 4  # expert_starts
         + padded_num_experts * 4  # expert_sizes
@@ -505,6 +508,7 @@ def _estimate_vmem_bytes_v2(
         + b_x
         + b_y_acc
         + b_y_stage
+        + b_metadata_mailbox
         + b_scoped
         + b_sems
     )
@@ -527,6 +531,9 @@ def _estimate_vmem_bytes_v2(
             log(f"      W2 dequant:     {mb(b_w2_dq)} MB")
         log(f"      gate+up acc:    {mb(b_gate_acc + b_up_acc)} MB  ({bts},{bf}) f32")
         log(f"      x+y_acc+y_stg:  {mb(b_x + b_y_acc + b_y_stage)} MB")
+        log(
+            f"      metadata mbox:  {mb(b_metadata_mailbox)} MB  (2,{ep_size},{padded_num_experts}) i32"
+        )
         log(f"      scoped+sems:    {mb(b_scoped + b_sems)} MB")
         log(f"      Total:          {mb(total)} MB")
 

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/bench_v2.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/bench_v2.py
@@ -486,7 +486,7 @@ def _estimate_vmem_bytes_v2(
             else local_num_experts * 4
         )
         + (num_bt_banks * 4 if use_gather_bank else 4)  # a2a_gather
-        + 3 * 4  # a2a_acc + md_send + md_recv + barrier
+        + 6 * 4  # a2a_acc + md_send[2] + md_recv[2] + barrier
     )
 
     total = (

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/kernel.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/kernel.py
@@ -327,8 +327,8 @@ def _fused_ep_moe_kernel(
     gather_send_x2_sems,  # DMA(expert_buffer_count,)
     a2a_gather_sem,  # DMA (num_experts,) — per-expert gather recv
     a2a_acc_sems,  # DMA(1,)
-    md_send_sem,  # DMA scalar
-    md_recv_sem,  # DMA scalar
+    md_send_sems,  # (2,) — one DMA semaphore per metadata mailbox bank
+    md_recv_sems,  # (2,) — one DMA semaphore per metadata mailbox bank
     barrier_sem,  # BARRIER
     *,
     # Static params
@@ -552,9 +552,13 @@ def _fused_ep_moe_kernel(
         # Keep the direct-all-gather mailbox alive for the full kernel. Two
         # banks are sufficient: before a rank can start metadata generation
         # N+2, it must receive generation N+1 from every peer, which means
-        # every peer has already finished consuming generation N.
+        # every peer has already finished consuming generation N. The DMA
+        # semaphores must use the same bank so an N+1 completion cannot satisfy
+        # an N wait while ranks progress at different speeds.
         md_bank_id = bt_id & jnp.int32(1)
         d2e_count_vmem = d2e_count_x2_vmem.at[md_bank_id]
+        md_send_sem = md_send_sems.at[md_bank_id]
+        md_recv_sem = md_recv_sems.at[md_bank_id]
 
         def _inkernel_allreduce(
             t2e_routing_vmem,
@@ -591,7 +595,9 @@ def _fused_ep_moe_kernel(
                 keepdims=True,
             ).reshape(1, padded_num_experts)
 
-            d2e_count_vmem[...] = jnp.zeros_like(d2e_count_vmem)
+            # Every peer writes its complete histogram row before the reduction,
+            # so no receiver-side initialization is needed. Clearing the full
+            # bank here is racy: a faster peer may already have written its row.
             d2e_count_vmem[my_id] = local_sizes
 
             # Metadata all-reduce = 1-round direct all-gather of per-device
@@ -2633,8 +2639,8 @@ def fused_ep_moe_v2(
             pltpu.SemaphoreType.DMA((num_bt_banks,)) if use_gather_bank else pltpu.SemaphoreType.DMA
         ),  # a2a_gather
         pltpu.SemaphoreType.DMA((1,)),  # a2a_acc
-        pltpu.SemaphoreType.DMA,  # md_send
-        pltpu.SemaphoreType.DMA,  # md_recv
+        pltpu.SemaphoreType.DMA((2,)),  # md_send, banked with metadata mailbox
+        pltpu.SemaphoreType.DMA((2,)),  # md_recv, banked with metadata mailbox
         pltpu.SemaphoreType.BARRIER,  # barrier
     )
 

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/kernel.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/kernel.py
@@ -290,6 +290,7 @@ def _fused_ep_moe_kernel(
     n_active_x2_smem,  # (smem_banks, 1) — compact loop
     a2a_s_sends_x2_smem,  # (expert_buffer_count,) or (2, expert_buffer_count)
     # --- VMEM scratch ---
+    d2e_count_x2_vmem,  # (2, num_devices, 1, padded_num_experts)
     a2a_g_acc_vmem,  # (2, top_k, acc_bt, t_packing, h_per_t)
     b_topk_weights_x2_vmem,  # (2, bt, padded_top_k)
     b_topk_ids_x2_vmem,  # (2, bt, padded_top_k)
@@ -548,10 +549,15 @@ def _fused_ep_moe_kernel(
 
         offsets_sem = local_sems.at[bt_sem_id, 8]
         routing_sem = local_sems.at[bt_sem_id, 9]
+        # Keep the direct-all-gather mailbox alive for the full kernel. Two
+        # banks are sufficient: before a rank can start metadata generation
+        # N+2, it must receive generation N+1 from every peer, which means
+        # every peer has already finished consuming generation N.
+        md_bank_id = bt_id & jnp.int32(1)
+        d2e_count_vmem = d2e_count_x2_vmem.at[md_bank_id]
 
         def _inkernel_allreduce(
             t2e_routing_vmem,
-            d2e_count_vmem,
             offsets_vmem,
             starts_vmem,
             sizes_vmem,
@@ -588,8 +594,6 @@ def _fused_ep_moe_kernel(
             d2e_count_vmem[...] = jnp.zeros_like(d2e_count_vmem)
             d2e_count_vmem[my_id] = local_sizes
 
-            sync_barrier()
-
             # Metadata all-reduce = 1-round direct all-gather of per-device
             # histogram rows via fori_loop + dynamic device_id. No static unroll
             # (compile-safe at any ep), no per-round sync_barrier (the old log2(N)
@@ -620,7 +624,6 @@ def _fused_ep_moe_kernel(
                 return None
 
             lax.fori_loop(1, num_devices, _md_drain, None, unroll=False)
-            sync_barrier()
 
             reduced_sizes = jnp.zeros((1, padded_num_experts), dtype=jnp.int32)
             reduced_starts = jnp.zeros((1, padded_num_experts), dtype=jnp.int32)
@@ -661,7 +664,6 @@ def _fused_ep_moe_kernel(
         pl.run_scoped(
             _inkernel_allreduce,
             pltpu.VMEM(t2e_routing_x2_smem.shape[1:], t2e_routing_x2_smem.dtype),
-            pltpu.VMEM(d2e_count_x2_smem.shape[1:], d2e_count_x2_smem.dtype),
             pltpu.VMEM(expert_offsets_x2_smem.shape[1:], expert_offsets_x2_smem.dtype),
             pltpu.VMEM(expert_starts_x2_smem.shape[1:], expert_starts_x2_smem.dtype),
             pltpu.VMEM(expert_sizes_x2_smem.shape[1:], expert_sizes_x2_smem.dtype),
@@ -2549,6 +2551,11 @@ def fused_ep_moe_v2(
             if use_bt_banking
             else pltpu.SMEM((expert_buffer_count,), jnp.int32)
         ),  # a2a_s_sends
+        # VMEM: double-buffered metadata all-gather mailbox. Keeping this
+        # kernel-scoped makes peer destinations valid without a metadata-entry
+        # barrier; alternating banks prevents the next block from clobbering a
+        # peer that is still materializing the previous generation.
+        pltpu.VMEM((2, num_devices, 1, padded_num_experts), jnp.int32),
         # VMEM: gather accumulation
         pltpu.VMEM((2, top_k, acc_bt, out_packing, h_per_out), out_dtype),  # a2a_g_acc
         # VMEM: topk


### PR DESCRIPTION
## Summary

- Keep a kernel-lifetime, double-buffered VMEM mailbox for direct metadata all-gather.
- Select both the mailbox and its DMA completion semaphores with `bt_id & 1`.
- Remove the metadata-ready and metadata-drained global barriers without adding a replacement barrier.
- Do not clear the shared mailbox bank: every rank fully overwrites its own row in every generation, so clearing peer-owned rows would itself race with incoming DMA writes.
- Preserve all per-peer send and receive DMA completion waits before consuming the gathered metadata.
- Update the benchmark VMEM estimator for the two send and two receive metadata semaphores.

## Why this is safe

The first barrier-free version covered mailbox lifetime but missed two protocol details:

1. A receiver clearing the whole bank could erase a peer row that had already arrived.
2. Reusing one scalar DMA semaphore across generations could let an `N+1` completion satisfy an `N` wait when ranks progressed at different speeds.

The corrected protocol is:

- The two mailbox banks live for the entire kernel, so every remote DMA destination is always valid.
- Rank `r` is the only writer of row `r`; it overwrites that complete row before sending it to every peer. No receiver-side bank clear is needed.
- Metadata send/receive semaphores use the same two-way bank selection as the mailbox, preventing adjacent generations from aliasing completion counts.
- Before consuming generation `N`, a rank waits for one message from every peer on generation `N`'s bank.
- Before a rank can send generation `N+1`, it has already consumed `N`; therefore receipt of `N+1` from every peer proves that all peers finished consuming `N`, making the bank safe for generation `N+2`.

No global metadata barrier remains.

For the tuned EP128 shape (`padded_num_experts=384`), the mailbox costs:

`2 * 128 * 384 * sizeof(int32) = 393,216 bytes = 0.375 MiB/device`

The extra banked DMA semaphores add four scalar semaphore slots versus the original two.

## Epoch-reuse stress validation

These are candidate-only functional stress runs on the final `ce1b6be37` implementation, not performance comparisons. They use JAX 0.10.2, libtpu 0.0.42.1, FP8 weights, activation quantization, direct scaled dot, BT scatter overlap, interleaved BT gather, and DVFS p-state 7.

Each case used 2 warmups and 5 iterations. The earlier rough wall-latency values have been removed; the paired multi-token A/B below is the authoritative performance result.

| EP / hardware | Routing | Global tokens | Local `num_bt` | Result |
|---|---|---:|---:|---|
| EP32 / v7x-16 chips | random | 8,192 | 2 | pass |
| EP32 / v7x-16 chips | random | 12,288 | 3 | pass |
| EP32 / v7x-16 chips | hot expert | 8,192 | 2 | pass |
| EP32 / v7x-16 chips | hot expert | 12,288 | 3 | pass |
| EP128 / v7x-64 chips | random | 2,048 | 1 | pass |
| EP128 / v7x-64 chips | random | 49,152 | 3 | pass |
| EP128 / v7x-64 chips | hot expert | 49,152 | 3 | pass |

`num_bt=3` is the important case: generation 2 reuses mailbox/semaphore bank 0 after generations 0 and 1, so this covers actual bank reuse rather than only touching both banks.

Falcon experiments:

- EP32: `exp-e917bge7wu`
- EP128: `exp-ymsfnqszx8`

## Correctness

For the final epoch-safety change, an A/B reference check used identical inputs on a
single-host EP8 reduced model with `num_bt=3`:

| Version | `max_abs_err` | `rel_err` |
|---|---:|---:|
| rebased main (`d8b61193a`) | 0.0025 | 0.173065 |
| barrier-free (`ce1b6be37`) | 0.0025 | 0.173065 |

The raw errors match exactly. Both jobs intentionally report the same script-level
failure because this reduced model's reference output is very small and the
benchmark's relative-only threshold is 0.08; the absolute error is 0.0025 in both
versions. This A/B is evidence of no numerical change from the barrier-free
protocol rather than evidence from an arbitrarily relaxed tolerance.

Falcon experiments:

- Barrier baseline: `exp-adaz5imhtm`
- Barrier-free candidate: `exp-qa5f5327fh`

## Local checks

- `isort --check-only --diff --profile=black` on both changed Python files
- `ruff check --output-format=github --fix` on both changed Python files
- `black --check` on both changed Python files
- `python3 -m py_compile` on both changed Python files
- `git diff --check`
- Commit-time pre-commit suite, including AST, isort, Ruff, Black, codespell, and mypy


## Multi-token EP128 performance A/B

This follow-up compares the rebased-main baseline (`d8b61193a`) with the barrier-free candidate (`ce1b6be37`) on the same TPU v7x 64-chip / 128-device `4x4x4` slice at EP128 and DVFS p-state 7. The benchmark uses MiMo-V2.5-Pro dimensions (`E=384`, `top_k=8`, `H=6144`, `I=2048`), random routing, FP8 weights, activation quantization, direct scaled dot, BT scatter overlap, and interleaved BT gather.

Runs were interleaved as baseline-r1, candidate-r1, baseline-r2, candidate-r2. Each round used 7 warmups and 100 synchronized `block_until_ready` host-wall samples. The table reports the pooled median across 200 samples per version; the confidence interval is a non-parametric bootstrap interval for candidate minus baseline latency.

| Tokens / block config | Baseline | Barrier-free | Improvement | 95% bootstrap delta |
|---|---:|---:|---:|---:|
| 512 / `bt=8,bf=1024,btc=32,bts=32,bse=256` | 0.5785 ms | 0.5650 ms | +2.33% | [-0.0365, +0.0010] ms |
| 2,048 / `bt=16,bf=1024,btc=64,bts=64,bse=256` | 0.6275 ms | 0.6120 ms | +2.47% | [-0.0240, -0.0015] ms |
| 16,384 / `bt=128,bf=1024,btc=64,bts=256,bse=256` | 1.1390 ms | 1.1305 ms | +0.75% | [-0.0280, +0.0085] ms |
| 16,384 / `bt=64,bf=1024,btc=64,bts=256,bse=256` | 1.0540 ms | 1.0410 ms | +1.23% | [-0.0225, -0.0050] ms |

The 2,048-token and 16,384-token/`bt=64` improvements are stable in this run because their intervals do not cross zero. The 512-token and 16,384-token/`bt=128` pooled medians are also faster, but the differences are within the measured noise. No tested shape regressed in pooled median latency, and `bt=64` remains the better 16,384-token configuration.

Falcon artifacts:

- Performance experiment: `exp-7toycpq4gi`
- Operator analysis: `an-f5imiffdm3`

## MiMo-V2.5-Pro AIME25 accuracy

An end-to-end AIME25 run validated the barrier-free candidate (`ce1b6be37`) on TPU v7x 16 chips / 32 devices with `TP32 / DP4 / EP32`, fused MoE v2, sequence parallelism enabled, speculative decoding disabled, `chunked-prefill-size=2048`, and DVFS p-state 7.

Generation settings were `temperature=1`, `top_p=0.95`, `max_tokens=131072`, and `enable_thinking=true`. The run evaluated all 30 AIME25 problems with three repeats.

| Metric | Result |
|---|---:|
| pass@1 (average of 3) | 91.11% +/- 1.92% |
| SEM | 1.11% |
| Per-repeat accuracy | 90.00%, 90.00%, 93.33% |
| pass@3 | 96.67% |
| majority@3 | 94.44% |
| Completed samples | 90 / 90 |
| Generated tokens | 1.8M |
| Error rate | 0.00% |
| Truncated rate | 0.00% |
| Stop rate | 100.00% |

This candidate-only run provides end-to-end evidence that the new metadata protocol does not cause an obvious accuracy failure: every request completed, no output was truncated, and the final score remained healthy. It is not presented as a matched baseline-vs-candidate statistical A/B; the reduced-model numerical A/B above covers the direct before/after kernel comparison.

Falcon experiment: `exp-wlvtkrowke`