### PR TITLE
perf(pathways): reduce per-step overhead; fix PD abort lifecycle, cpp fastpath and FP8 scale sharding

### DIFF
--- a/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
+++ b/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
@@ -7,6 +7,7 @@ carries the wiring hooks. See design in issue #1427.
 from __future__ import annotations
 
 import copy
+import dataclasses
 import logging
 import os
 import threading
@@ -34,6 +35,24 @@ from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache, SWAChunkCache
 logger = logging.getLogger(__name__)
 _PD_DBG = bool(os.environ.get("SGLANG_PD_DBG"))
 _PD_DBG_TIMING = bool(os.environ.get("SGLANG_PD_DBG_TIMING")) or _PD_DBG
+
+
+@dataclasses.dataclass
+class _PdInflight:
+    """Lifecycle handle for one request in the async P pipeline (#1486).
+
+    outstanding counts P batches currently in flight (queued or forwarding or
+    waiting in ready_q/defer) that carry this req: a chunked req can have
+    chunk N draining while chunk N+1 forwards. Abort finalization (P KV +
+    reservation release + client abort) may only run when outstanding == 0 --
+    otherwise the in-flight batch drains later and finalizes exactly once.
+    """
+
+    req: object
+    p_idx: int
+    tokens: int
+    outstanding: int = 0
+    pending_abort: bool = False
 
 
 class PathwaysPDSchedulerMixin:
@@ -225,8 +244,12 @@ class PathwaysPDSchedulerMixin:
         # ready_q items whose D-pool alloc was deferred (avail < need+reserved)
         self._pd_defer: list = []
         # reqs pushed to prefill_q but not yet drained into running_batch;
-        # tracked by rid so a chunked req counts once, not once-per-chunk.
-        self._pd_inflight_rids: set[str] = set()
+        # keyed by rid so a chunked req counts once, not once-per-chunk.
+        # Registry (#1486): each entry keeps a handle on the req across the
+        # whole async P pipeline (queue -> prefill thread -> ready_q/defer ->
+        # migrate), so abort/retract can always find it -- previously a req
+        # past its final chunk existed only as a rid string.
+        self._pd_inflight: dict[str, _PdInflight] = {}
         # D-pool tokens the inflight rids will need at migrate time (page-
         # padded full IL per req) -- the admission-side reservation ledger.
         self._pd_inflight_tokens = 0
@@ -654,6 +677,10 @@ class PathwaysPDSchedulerMixin:
             t_enq_ready,
         ) = item
         p_alloc, p_r2t, p_tree = self.p_allocs[p_idx], self.p_r2ts[p_idx], self.p_trees[p_idx]
+        # This batch is no longer in flight for its reqs (#1486); any
+        # pending_abort entry that reaches outstanding == 0 below is
+        # finalized on the matching path (done / mid-chunk / failure).
+        self._pd_batch_outstanding(batch, -1)
         chunked_excl = {
             dp: info.chunked_req
             for dp, info in enumerate(batch.reqs_info)
@@ -682,7 +709,7 @@ class PathwaysPDSchedulerMixin:
         allocator = self.token_to_kv_pool_allocator
         if done_per_req:
             n_running = sum(len(x.reqs) for x in self.running_batch.reqs_info if x.reqs)
-            reserved = self._pd_reserved_per * (n_running + len(self._pd_inflight_rids))
+            reserved = self._pd_reserved_per * (n_running + len(self._pd_inflight))
             reserved_per_rank = reserved // max(1, self.dp_size)
             need_by_rank = defaultdict(int)
             for r, _, p in done_per_req:
@@ -782,6 +809,15 @@ class PathwaysPDSchedulerMixin:
                     (time.perf_counter() - t0) * 1e3,
                     len(done_per_req),
                 )
+        # Aborted reqs that just migrated: flag them finished so the standard
+        # prefill-result path below caches/frees their D KV and streams the
+        # abort to the client -- keeps the gather/scatter page layout of live
+        # reqs in the same mixed batch untouched (#1486).
+        for r, _, _ in done_per_req:
+            entry = self._pd_inflight.get(r.rid)
+            if entry is not None and entry.pending_abort and not r.finished():
+                r.set_finish_with_abort("Aborted by AbortReq.")
+                logger.info("[pd_async] aborted request dropped after migrate. rid=%s", r.rid)
         batch.req_to_token_pool = self.req_to_token_pool
         batch.token_to_kv_pool_allocator = self.token_to_kv_pool_allocator
         batch.tree_cache = self.tree_cache
@@ -793,6 +829,13 @@ class PathwaysPDSchedulerMixin:
         with jax.profiler.TraceAnnotation("pd_process_prefill"):
             self.process_batch_result_prefill(batch, result, None)
         for r in chunked_excl.values():
+            # Aborted mid-chunk owner whose last in-flight batch just drained:
+            # finalize (frees P KV, clears the owner slot, streams the abort)
+            # instead of caching for a chunk N+1 that must never build (#1486).
+            entry = self._pd_inflight.get(r.rid)
+            if entry is not None and entry.pending_abort and entry.outstanding == 0:
+                self._pd_finalize_aborted(entry)
+                continue
             # Redundant with the prefill thread's own update (same numpy read,
             # done right after forward — see _pd_prefill_loop) but harmless
             # and kept as a safety net. _pd_chunk_pending is NOT touched here:
@@ -869,18 +912,97 @@ class PathwaysPDSchedulerMixin:
         n = len(r.origin_input_ids)
         return -(-n // self.page_size) * self.page_size
 
-    def _pd_track_inflight(self, r) -> None:
-        """Reserve r's D-pool footprint at admission. Idempotent per rid so
-        a chunked req's chunk-2..N batches don't double-count."""
-        if r.rid not in self._pd_inflight_rids:
-            self._pd_inflight_rids.add(r.rid)
-            self._pd_inflight_tokens += self._pd_req_kv_tokens(r)
+    def _pd_track_inflight(self, r, p_idx: int = 0) -> None:
+        """Reserve r's D-pool footprint at admission and register its
+        lifecycle handle (#1486). Idempotent per rid so a chunked req's
+        chunk-2..N batches don't double-count the reservation; the per-batch
+        outstanding count is bumped separately by the batch-build loop."""
+        if r.rid not in self._pd_inflight:
+            tokens = self._pd_req_kv_tokens(r)
+            self._pd_inflight[r.rid] = _PdInflight(req=r, p_idx=p_idx, tokens=tokens)
+            self._pd_inflight_tokens += tokens
 
     def _pd_untrack_inflight(self, r) -> None:
-        """Release r's reservation (migrated into D, or prefill failed)."""
-        if r.rid in self._pd_inflight_rids:
-            self._pd_inflight_rids.discard(r.rid)
-            self._pd_inflight_tokens = max(0, self._pd_inflight_tokens - self._pd_req_kv_tokens(r))
+        """Release r's reservation (migrated into D, aborted, or prefill
+        failed). Releases exactly the tokens reserved at track time."""
+        entry = self._pd_inflight.pop(r.rid, None)
+        if entry is not None:
+            self._pd_inflight_tokens = max(0, self._pd_inflight_tokens - entry.tokens)
+
+    def _pd_batch_outstanding(self, batch, delta: int) -> None:
+        """Adjust the in-flight batch count for every tracked req in batch."""
+        for info in batch.reqs_info:
+            for r in info.reqs or ():
+                entry = self._pd_inflight.get(r.rid)
+                if entry is not None:
+                    entry.outstanding = max(0, entry.outstanding + delta)
+
+    def _pd_abort_matching(self, recv_req) -> None:
+        """Pathways-side abort coverage (#1486): mark matching in-flight
+        entries pending_abort; anything still carried by an in-flight P batch
+        finalizes exactly once when that batch drains, idle entries (e.g. a
+        chunked owner between chunks) finalize immediately."""
+        if getattr(self, "_pd_inflight", None) is None:
+            return
+        abort_all = getattr(recv_req, "abort_all", False)
+        rid = getattr(recv_req, "rid", "") or ""
+        n_marked = 0
+        for entry in list(self._pd_inflight.values()):
+            if not (abort_all or entry.req.rid.startswith(rid)):
+                continue
+            entry.pending_abort = True
+            n_marked += 1
+            if entry.outstanding == 0:
+                self._pd_finalize_aborted(entry)
+        if n_marked:
+            logger.info("[pd_async] abort matched %d in-flight P-pipeline request(s)", n_marked)
+
+    def _pd_quiesce(self, timeout_s: float = 30.0) -> None:
+        """Drain the whole async P pipeline before pause/retract (#1486): wait
+        out in-flight prefill batches and consume every ready/deferred item so
+        no late P result can merge into running_batch next to a requeued copy
+        of the same request."""
+        if getattr(self, "_pd_inflight", None) is None:
+            return
+        deadline = time.perf_counter() + timeout_s
+        while time.perf_counter() < deadline:
+            self._pd_drain_ready_multi()
+            busy = (
+                any(not q.empty() for q in self._pd_prefill_qs)
+                or any(self._pd_chunk_pending)
+                or not self._pd_ready_q.empty()
+                or bool(self._pd_defer)
+                or any(e.outstanding > 0 for e in self._pd_inflight.values())
+            )
+            if not busy:
+                return
+            time.sleep(0.01)
+        logger.warning(
+            "[pd_async] quiesce timed out after %.0fs: inflight=%d ready=%d defer=%d",
+            timeout_s,
+            len(self._pd_inflight),
+            self._pd_ready_q.qsize(),
+            len(self._pd_defer),
+        )
+
+    def _pd_finalize_aborted(self, entry) -> None:
+        """Exactly-once teardown of an aborted in-flight req: free P-side KV
+        and req slot, drop the chunked-owner pointer, release the admission
+        reservation, and stream the abort to the client."""
+        r = entry.req
+        p_idx = entry.p_idx
+        if r.req_pool_idx is not None:
+            self.p_trees[p_idx].cache_finished_req(r)
+            self.p_r2ts[p_idx].free_slots.append(r.req_pool_idx)
+            r.req_pool_idx = None
+        for dp, owner in enumerate(self.p_chunked_reqs[p_idx]):
+            if owner is not None and owner.rid == r.rid:
+                self.p_chunked_reqs[p_idx][dp] = None
+        if not r.finished():
+            r.set_finish_with_abort("Aborted by AbortReq.")
+        self._pd_untrack_inflight(r)
+        self.stream_output([r], False, False)
+        logger.info("[pd_async] aborted in-flight request finalized. rid=%s", r.rid)
 
     def _pd_token_gate_closed(self) -> bool:
         """D-side token-level admission reservation (#1427 follow-up).
@@ -902,9 +1024,7 @@ class PathwaysPDSchedulerMixin:
         for alloc in self.d_allocs:
             f = getattr(alloc, "full_available_size", alloc.available_size)
             avail += sum(f(dp_rank=rk) for rk in range(self.dp_size))
-        reserved = self._pd_reserved_per * (
-            self._pd_total_d_running() + len(self._pd_inflight_rids)
-        )
+        reserved = self._pd_reserved_per * (self._pd_total_d_running() + len(self._pd_inflight))
         closed = self._pd_inflight_tokens + reserved >= avail
         if closed:
             self._pd_gate_ticks += 1
@@ -913,7 +1033,7 @@ class PathwaysPDSchedulerMixin:
                     "[pd-backpressure] admission paused x%d: inflight=%d reqs "
                     "%d tok + reserved %d >= D avail %d",
                     self._pd_gate_ticks,
-                    len(self._pd_inflight_rids),
+                    len(self._pd_inflight),
                     self._pd_inflight_tokens,
                     reserved,
                     avail,
@@ -955,6 +1075,15 @@ class PathwaysPDSchedulerMixin:
         gate_closed = self._pd_token_gate_closed()
         for _off in range(n_p):
             i = (self._pd_next_p + _off) % n_p
+            # Aborted chunked owner with no batch in flight: finalize here so
+            # its P KV frees and no chunk N+1 is ever built (#1486). Owners
+            # with a batch still in flight finalize on that batch's drain.
+            for dp, owner in enumerate(self.p_chunked_reqs[i]):
+                if owner is None:
+                    continue
+                entry = self._pd_inflight.get(owner.rid)
+                if entry is not None and entry.pending_abort and entry.outstanding == 0:
+                    self._pd_finalize_aborted(entry)
             if self._pd_chunk_pending[i]:
                 continue
             if self._pd_prefill_qs[i].full():
@@ -976,11 +1105,11 @@ class PathwaysPDSchedulerMixin:
             # d_running reached 64, freezing P admission for ~2min bursts and
             # capping C128 D running at 64.)
             # n_decode>1: total D r2t slots = n_d * saved * dp_size, and
-            # d_running/_pd_inflight_rids are already summed across all D.
+            # d_running/_pd_inflight are already summed across all D.
             self.per_dp_max_running_requests = max(
                 0,
                 saved * self._pd_n_decode
-                - (len(self._pd_inflight_rids) + d_running + self.dp_size - 1) // self.dp_size,
+                - (len(self._pd_inflight) + d_running + self.dp_size - 1) // self.dp_size,
             )
             try:
                 with self._pd_swap_p_pool(i):
@@ -1021,7 +1150,8 @@ class PathwaysPDSchedulerMixin:
             ), "[pd_async] return_hidden_states not yet supported on the async prefill path"
             for info in new_batch.reqs_info:
                 for r in info.reqs or ():
-                    self._pd_track_inflight(r)
+                    self._pd_track_inflight(r, p_idx=i)
+            self._pd_batch_outstanding(new_batch, +1)
             # Set pending only when this batch has a mid-chunk req (whose next
             # chunk depends on this one draining). Final-chunk / non-chunked
             # batches leave pending untouched so the main loop can immediately
@@ -1179,7 +1309,7 @@ class PathwaysPDSchedulerMixin:
                     (_it2 - _it1) * 1e3,
                     (_it3 - _it2) * 1e3,
                     _runs,
-                    len(self._pd_inflight_rids),
+                    len(self._pd_inflight),
                 )
 
     def _pd_gather_output(self, arr, is_prefill: bool) -> np.ndarray:

--- a/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
+++ b/python/sgl_jax/srt/disaggregation/pathways_scheduler.py
@@ -677,10 +677,6 @@ class PathwaysPDSchedulerMixin:
             t_enq_ready,
         ) = item
         p_alloc, p_r2t, p_tree = self.p_allocs[p_idx], self.p_r2ts[p_idx], self.p_trees[p_idx]
-        # This batch is no longer in flight for its reqs (#1486); any
-        # pending_abort entry that reaches outstanding == 0 below is
-        # finalized on the matching path (done / mid-chunk / failure).
-        self._pd_batch_outstanding(batch, -1)
         chunked_excl = {
             dp: info.chunked_req
             for dp, info in enumerate(batch.reqs_info)
@@ -689,6 +685,7 @@ class PathwaysPDSchedulerMixin:
         if result is None:
             # prefill thread reported failure; free P, clear inflight/chunked.
             # TODO: proper stream-abort to client (currently client times out).
+            self._pd_batch_outstanding(batch, -1)
             all_reqs = []
             for info in batch.reqs_info:
                 for r in info.reqs or ():
@@ -735,6 +732,11 @@ class PathwaysPDSchedulerMixin:
                     )
                 return
             self._pd_defer_ticks = 0
+        # Only now is this batch really consumed (#1501 review): decrementing
+        # before the capacity gate would let a deferred item hit outstanding==0
+        # while still parked in _pd_defer, so an abort in that window could
+        # finalize the req (freeing its P slots) under the deferred item.
+        self._pd_batch_outstanding(batch, -1)
         d_pages_all = []
         for r, p_slots, p_pages in done_per_req:
             seq_len = len(r.fill_ids)
@@ -957,15 +959,24 @@ class PathwaysPDSchedulerMixin:
         if n_marked:
             logger.info("[pd_async] abort matched %d in-flight P-pipeline request(s)", n_marked)
 
-    def _pd_quiesce(self, timeout_s: float = 30.0) -> None:
+    def _pd_quiesce(self, warn_interval_s: float = 30.0) -> None:
         """Drain the whole async P pipeline before pause/retract (#1486): wait
         out in-flight prefill batches and consume every ready/deferred item so
         no late P result can merge into running_batch next to a requeued copy
-        of the same request."""
+        of the same request.
+
+        Fail-closed (#1501 review): blocks until the pipeline is actually
+        drained rather than proceeding on a timeout -- a late P result after
+        retract would recreate exactly the race this drain exists to prevent,
+        and its P-side pages cannot be reclaimed while the prefill thread may
+        still be executing on them. Long waits (e.g. a cold-shape compile on
+        the P thread) are surfaced with a periodic warning instead.
+        """
         if getattr(self, "_pd_inflight", None) is None:
             return
-        deadline = time.perf_counter() + timeout_s
-        while time.perf_counter() < deadline:
+        t0 = time.perf_counter()
+        last_warn = t0
+        while True:
             self._pd_drain_ready_multi()
             busy = (
                 any(not q.empty() for q in self._pd_prefill_qs)
@@ -977,13 +988,16 @@ class PathwaysPDSchedulerMixin:
             if not busy:
                 return
             time.sleep(0.01)
-        logger.warning(
-            "[pd_async] quiesce timed out after %.0fs: inflight=%d ready=%d defer=%d",
-            timeout_s,
-            len(self._pd_inflight),
-            self._pd_ready_q.qsize(),
-            len(self._pd_defer),
-        )
+            now = time.perf_counter()
+            if now - last_warn >= warn_interval_s:
+                last_warn = now
+                logger.warning(
+                    "[pd_async] quiesce still draining after %.0fs: inflight=%d ready=%d defer=%d",
+                    now - t0,
+                    len(self._pd_inflight),
+                    self._pd_ready_q.qsize(),
+                    len(self._pd_defer),
+                )
 
     def _pd_finalize_aborted(self, entry) -> None:
         """Exactly-once teardown of an aborted in-flight req: free P-side KV
@@ -1003,6 +1017,32 @@ class PathwaysPDSchedulerMixin:
         self._pd_untrack_inflight(r)
         self.stream_output([r], False, False)
         logger.info("[pd_async] aborted in-flight request finalized. rid=%s", r.rid)
+
+    def _pd_retract_chunked_owners(self) -> list:
+        """Retract chunked owners parked between chunks in the P pools (#1501
+        review). _retract_parked_chunked_reqs is a no-op under pathways PD, so
+        without this a mid-chunk request would survive retract holding P-side
+        KV and later resume from its pre-retract prefix -- stale KV if retract
+        preceded a weight update. Frees P KV + req slot, drops registry and
+        admission accounting, resets the req, and returns it for requeueing so
+        it recomputes from scratch. Call only after _pd_quiesce (no batch in
+        flight for these owners)."""
+        out = []
+        for p_idx in range(len(self.p_chunked_reqs)):
+            for dp, owner in enumerate(self.p_chunked_reqs[p_idx]):
+                if owner is None:
+                    continue
+                if owner.req_pool_idx is not None:
+                    self.p_trees[p_idx].cache_finished_req(owner)
+                    self.p_r2ts[p_idx].free_slots.append(owner.req_pool_idx)
+                    owner.req_pool_idx = None
+                self.p_chunked_reqs[p_idx][dp] = None
+                self._pd_untrack_inflight(owner)
+                owner.reset_for_retract()
+                out.append(owner)
+        if out:
+            logger.info("[pd_async] retracted %d parked chunked owner(s)", len(out))
+        return out
 
     def _pd_token_gate_closed(self) -> bool:
         """D-side token-level admission reservation (#1427 follow-up).
@@ -1077,13 +1117,23 @@ class PathwaysPDSchedulerMixin:
             i = (self._pd_next_p + _off) % n_p
             # Aborted chunked owner with no batch in flight: finalize here so
             # its P KV frees and no chunk N+1 is ever built (#1486). Owners
-            # with a batch still in flight finalize on that batch's drain.
+            # with a batch still in flight finalize on that batch's drain --
+            # and until then, skip building on this slice entirely (#1501
+            # review): the P thread clears _pd_chunk_pending before the
+            # result is drained, so without this guard an abort landing in
+            # that window would still enqueue chunk N+1.
+            abort_pending_owner = False
             for dp, owner in enumerate(self.p_chunked_reqs[i]):
                 if owner is None:
                     continue
                 entry = self._pd_inflight.get(owner.rid)
-                if entry is not None and entry.pending_abort and entry.outstanding == 0:
-                    self._pd_finalize_aborted(entry)
+                if entry is not None and entry.pending_abort:
+                    if entry.outstanding == 0:
+                        self._pd_finalize_aborted(entry)
+                    else:
+                        abort_pending_owner = True
+            if abort_pending_owner:
+                continue
             if self._pd_chunk_pending[i]:
                 continue
             if self._pd_prefill_qs[i].full():

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -2821,6 +2821,13 @@ class Scheduler(
                     self._add_request_to_queue(req)
 
             self._retract_parked_chunked_reqs(retracted_reqs)
+            # Pathways PD: the helper above is a no-op there, but chunked
+            # owners parked in the P pools must also be retracted or they
+            # would resume on pre-retract KV (#1501 review). Guarded no-op
+            # outside pathways PD.
+            if getattr(self, "_pd_inflight", None) is not None:
+                for req in self._pd_retract_chunked_owners():
+                    self._add_request_to_queue(req)
             self.last_batch = None
             self.cur_batch = None
             logger.info("Paused generation retracted")

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1204,7 +1204,7 @@ class Scheduler(
                         (_it2 - _it1) * 1e3,
                         (_it3 - _it2) * 1e3,
                         sum(len(i.reqs) for i in self.running_batch.reqs_info),
-                        len(getattr(self, "_pd_inflight_rids", ())),
+                        len(getattr(self, "_pd_inflight", ())),
                     )
 
     def run_publisher(self, recv_reqs):
@@ -2762,6 +2762,13 @@ class Scheduler(
                     self._release_decode_kv_indices(entry.kv_indices)
                 self._abort_decode_request(entry.req, "abort_request")
 
+        # Pathways single-process PD: requests inside the async P pipeline
+        # (prefill queues / forward / ready_q / defer / migrate) are invisible
+        # to every container above; mark them via the in-flight registry so
+        # they finalize exactly once (#1486). No-op unless pathways PD is on.
+        if getattr(self, "_pd_inflight", None) is not None:
+            self._pd_abort_matching(recv_req)
+
         # Decode reqs deferred because no prefill was registered yet hold no KV
         # or receiver, but abort_request must still drop them so a cancelled
         # request is not re-admitted on the next decode tick.
@@ -2793,6 +2800,13 @@ class Scheduler(
 
         consumed = self._process_pending_chunked_aborts()
         self._retire_chunked_req_batch_owners(consumed)
+
+        # Pathways single-process PD: drain the async P pipeline as well so a
+        # late prefill result cannot merge into running_batch alongside a
+        # requeued copy of the same request after retract (#1486). No-op
+        # unless pathways PD is on.
+        if getattr(self, "_pd_inflight", None) is not None:
+            self._pd_quiesce()
 
         if recv_req.mode == "retract":
             self.running_batch.filter_batch()

--- a/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
@@ -163,6 +163,14 @@ class ModelWorkerClient:
                 self.mesh,
             )
             next_token_ids = self.async_gather_fn(next_token_ids)
+            # Kick off the D2H transfer here, on the forward thread, so the
+            # scheduler's resolve_last_batch_result finds the copy in flight
+            # instead of paying the full interactive device_get round-trip.
+            # Matters most under the Pathways proxy backend, where a blocking
+            # device_get of even a few hundred bytes costs ~20 ms of
+            # client->proxy->worker RTT (#772).
+            if hasattr(next_token_ids, "copy_to_host_async"):
+                next_token_ids.copy_to_host_async()
             self.output_queue.put((None, logits_output, next_token_ids, cache_miss_count))
 
     def resolve_last_batch_result(self, launch_done: threading.Event | None = None):

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -211,6 +211,32 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         model_def, model_state = nnx.split(self.model)
         # note export for external modification
         self.model_state_leaves, model_state_def = jax.tree_util.tree_flatten(model_state)
+        # Static-quant checkpoints can leave jax.ShapeDtypeStruct placeholders
+        # in module state (e.g. the pre-quant weight slot of QuantizedLinear
+        # when the weight mapping targets .weight_q). jaxlib's ToPyArgSignature
+        # rejects ShapeDtypeStruct, so ComputeCallSignature fails and every
+        # jitted_run_model call falls back to the python dispatch path -- the
+        # per-decode-step cpp cache miss of #1452. The placeholders are dead
+        # on the forward path (a used leaf with a changed shape would fail to
+        # compile); swap them for zero-length arrays so the cpp fastpath can
+        # build a signature.
+        _sds_paths = []
+        _state_paths = None
+        for _i, _x in enumerate(self.model_state_leaves):
+            if isinstance(_x, jax.ShapeDtypeStruct):
+                if _state_paths is None:
+                    _state_paths = jax.tree_util.tree_flatten_with_path(model_state)[0]
+                _sds_paths.append(jax.tree_util.keystr(_state_paths[_i][0]))
+                self.model_state_leaves[_i] = jax.device_put(
+                    jnp.zeros((0,), dtype=_x.dtype), NamedSharding(self.mesh, P())
+                )
+        if _sds_paths:
+            logger.info(
+                "[model_runner] replaced %d ShapeDtypeStruct state placeholders "
+                "with empty arrays (pjit cpp fastpath, #1452); e.g. %s",
+                len(_sds_paths),
+                _sds_paths[:4],
+            )
         self._model_def = model_def
         self._model_state_def = model_state_def
         sampler_def, sampler_state = nnx.split(self.sampler)

--- a/python/sgl_jax/srt/utils/jax_utils.py
+++ b/python/sgl_jax/srt/utils/jax_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import gc
 from collections import defaultdict
+from functools import cache
 from typing import Any
 
 import jax
@@ -218,9 +219,33 @@ def get_available_device_memory(
     return int(free_gpu_memory * (1 << 10))
 
 
+@cache
+def _canonical_named_sharding(mesh, spec, memory_kind) -> "jax.sharding.NamedSharding":
+    return jax.sharding.NamedSharding(mesh, spec, memory_kind=memory_kind)
+
+
+def canonicalize_sharding(sharding):
+    """Map equal NamedShardings onto one canonical object per (mesh, spec).
+
+    jaxlib's PjitFunctionCache fast-path compares input shardings by object
+    pointer; handing pjit a fresh NamedSharding every step defeats that
+    fast-path and, under dp=1 + Pathways proxy, misses the cpp cache entirely
+    (issue #1452). Shardings with explicit logical device ids are passed
+    through untouched, as they are not covered by the (mesh, spec,
+    memory_kind) cache key.
+    """
+    if isinstance(sharding, jax.sharding.NamedSharding) and (
+        getattr(sharding, "_logical_device_ids", None) is None
+    ):
+        return _canonical_named_sharding(sharding.mesh, sharding.spec, sharding.memory_kind)
+    return sharding
+
+
 def device_array(data, sharding=None, **kwargs) -> jax.Array:
     if sharding is None:
         return jax.device_put(data, device=sharding, **kwargs)
+
+    sharding = canonicalize_sharding(sharding)
 
     def _to_device(arr):
         arr = np.asarray(arr)

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -1017,7 +1017,18 @@ class WeightLoader:
             weight.shape[1],
             n_out,
         )
-        return expand_block_scale(weight, n_out, block_size_out)
+        expanded = expand_block_scale(weight, n_out, block_size_out)
+        # The expansion inherits the compact 2D scale's (effectively replicated)
+        # layout, but the model placeholder declares the kernel-boundary sharding
+        # (e.g. P(None, None, "tensor")). jax 0.8.x shard_map silently reshards on
+        # this textual mismatch; jax 0.10.x checks strictly and raises. Same class
+        # of fix as the MoE/MLA boundaries in #1493.
+        target_sharding = getattr(model_param.value, "sharding", None)
+        if target_sharding is not None and expanded.ndim == len(
+            getattr(target_sharding, "spec", ())
+        ):
+            expanded = jax.sharding.reshard(expanded, target_sharding)
+        return expanded
 
     def _scan_weight_info(self) -> dict[str, list[dict]]:
         """

--- a/test/srt/disaggregation/test_pathways_pd.py
+++ b/test/srt/disaggregation/test_pathways_pd.py
@@ -879,7 +879,7 @@ def test_abort_prefix_matching_only():
 
 
 @pytest.mark.unit
-def test_quiesce_returns_when_pipeline_empty_and_times_out_when_stuck():
+def test_quiesce_returns_when_empty_and_blocks_until_drained():
     fake = _FakeLifecycleSelf()
     fake._pd_prefill_qs = [queue.Queue()]
     fake._pd_chunk_pending = [False]
@@ -893,12 +893,51 @@ def test_quiesce_returns_when_pipeline_empty_and_times_out_when_stuck():
 
     fake._pd_drain_ready_multi = _drain
     # empty pipeline: returns immediately after one drain sweep
-    PathwaysPDSchedulerMixin._pd_quiesce(fake, timeout_s=1.0)
+    PathwaysPDSchedulerMixin._pd_quiesce(fake, warn_interval_s=1.0)
     assert fake.drained == 1
-    # stuck outstanding batch: must hit the timeout, not hang forever
+    # stuck outstanding batch: fail-closed -- must NOT return until the
+    # pipeline actually drains (#1501 review), even past a warn interval.
     r = _FakeLcReq("req-q")
     fake._pd_track_inflight(r, p_idx=0)
     fake._pd_inflight["req-q"].outstanding = 1
+    release_after = fake.drained + 12  # ~0.12s of ticks, > warn interval below
+
+    def _drain_then_release():
+        fake.drained += 1
+        if fake.drained >= release_after:
+            fake._pd_inflight["req-q"].outstanding = 0
+        return 0
+
+    fake._pd_drain_ready_multi = _drain_then_release
     t0 = time.perf_counter()
-    PathwaysPDSchedulerMixin._pd_quiesce(fake, timeout_s=0.2)
-    assert 0.15 < time.perf_counter() - t0 < 2.0
+    PathwaysPDSchedulerMixin._pd_quiesce(fake, warn_interval_s=0.05)
+    assert fake.drained >= release_after  # waited through, didn't bail early
+    assert time.perf_counter() - t0 < 5.0
+
+
+def test_retract_requeues_parked_chunked_owner():
+    fake = _FakeLifecycleSelf()
+
+    class _FakeRetractReq(_FakeLcReq):
+        def __init__(self, rid):
+            super().__init__(rid)
+            self.reset_calls = 0
+
+        def reset_for_retract(self):
+            self.reset_calls += 1
+
+    owner = _FakeRetractReq("req-ret")
+    fake._pd_track_inflight(owner, p_idx=0)
+    fake.p_chunked_reqs[0][0] = owner
+    out = PathwaysPDSchedulerMixin._pd_retract_chunked_owners(fake)
+    assert out == [owner]
+    assert fake.p_chunked_reqs[0][0] is None
+    assert owner.req_pool_idx is None
+    assert fake.p_trees[0].finished == ["req-ret"]
+    assert fake.p_r2ts[0].free_slots == [3]
+    assert "req-ret" not in fake._pd_inflight  # registry + ledger released
+    assert owner.reset_calls == 1
+    assert owner.finished() is False  # requeued, NOT aborted to the client
+    assert fake.streamed == []
+    # idempotent on empty state
+    assert PathwaysPDSchedulerMixin._pd_retract_chunked_owners(fake) == []

--- a/test/srt/disaggregation/test_pathways_pd.py
+++ b/test/srt/disaggregation/test_pathways_pd.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import queue
 import threading
+import time
 from types import SimpleNamespace
 
 import jax
@@ -635,7 +636,7 @@ class _FakeGateSelf(PathwaysPDSchedulerMixin):
         self.dp_size = dp_size
         self._pd_reserved_per = reserved_per
         self._d_running = d_running
-        self._pd_inflight_rids = set()
+        self._pd_inflight = {}
         self._pd_inflight_tokens = 0
         self._pd_gate_ticks = 0
 
@@ -661,7 +662,7 @@ def test_track_untrack_inflight_idempotent():
     assert fake._pd_inflight_tokens == 8
     PathwaysPDSchedulerMixin._pd_untrack_inflight(fake, r)
     assert fake._pd_inflight_tokens == 0
-    assert not fake._pd_inflight_rids
+    assert not fake._pd_inflight
     # double-untrack (failure path after success path) must not go negative
     PathwaysPDSchedulerMixin._pd_untrack_inflight(fake, r)
     assert fake._pd_inflight_tokens == 0
@@ -730,3 +731,174 @@ def test_fuse_for_batch_is_batch_level():
     assert not w._pd_fuse_for_batch(prefill)
     w._pd_fuse_sample = False
     assert not w._pd_fuse_for_batch(plain)
+
+
+# ---------------------------------------------------------------------------
+# #1486: in-flight registry + abort/retract lifecycle
+# ---------------------------------------------------------------------------
+
+from sgl_jax.srt.disaggregation.pathways_scheduler import _PdInflight  # noqa: E402
+
+
+class _FakeLcReq:
+    def __init__(self, rid, n_input=8, pool_idx=3):
+        self.rid = rid
+        self.origin_input_ids = list(range(n_input))
+        self.req_pool_idx = pool_idx
+        self._finished = False
+        self.finish_reason = None
+
+    def finished(self):
+        return self._finished
+
+    def set_finish_with_abort(self, msg):
+        self._finished = True
+        self.finish_reason = msg
+
+
+class _FakeTree:
+    def __init__(self):
+        self.finished = []
+
+    def cache_finished_req(self, r):
+        self.finished.append(r.rid)
+
+
+class _FakeLifecycleSelf:
+    """Minimal state for registry/abort mixin methods."""
+
+    page_size = 4
+
+    def __init__(self, n_p=1, dp=1):
+        self._pd_inflight = {}
+        self._pd_inflight_tokens = 0
+        self.p_trees = [_FakeTree() for _ in range(n_p)]
+        self.p_r2ts = [SimpleNamespace(free_slots=[]) for _ in range(n_p)]
+        self.p_chunked_reqs = [[None] * dp for _ in range(n_p)]
+        self.streamed = []
+
+    def stream_output(self, reqs, a, b):
+        self.streamed.extend(r.rid for r in reqs)
+
+    # bind mixin methods under test
+    _pd_req_kv_tokens = PathwaysPDSchedulerMixin._pd_req_kv_tokens
+    _pd_track_inflight = PathwaysPDSchedulerMixin._pd_track_inflight
+    _pd_untrack_inflight = PathwaysPDSchedulerMixin._pd_untrack_inflight
+    _pd_batch_outstanding = PathwaysPDSchedulerMixin._pd_batch_outstanding
+    _pd_abort_matching = PathwaysPDSchedulerMixin._pd_abort_matching
+    _pd_finalize_aborted = PathwaysPDSchedulerMixin._pd_finalize_aborted
+
+
+def _fake_batch(*reqs):
+    return SimpleNamespace(reqs_info=[SimpleNamespace(reqs=list(reqs))])
+
+
+@pytest.mark.unit
+def test_registry_track_idempotent_untrack_exact():
+    fake = _FakeLifecycleSelf()
+    r = _FakeLcReq("req-a", n_input=10)  # 10 tokens -> 3 pages * 4 = 12
+    fake._pd_track_inflight(r, p_idx=0)
+    fake._pd_track_inflight(r, p_idx=0)  # chunk-2 re-track: no double count
+    assert fake._pd_inflight_tokens == 12
+    assert fake._pd_inflight["req-a"].outstanding == 0
+    r.origin_input_ids.extend([0] * 100)  # mutate after track
+    fake._pd_untrack_inflight(r)  # must release exactly what was reserved
+    assert fake._pd_inflight_tokens == 0
+    assert fake._pd_inflight == {}
+
+
+@pytest.mark.unit
+def test_batch_outstanding_bump_and_floor():
+    fake = _FakeLifecycleSelf()
+    r = _FakeLcReq("req-b")
+    fake._pd_track_inflight(r, p_idx=0)
+    b = _fake_batch(r)
+    fake._pd_batch_outstanding(b, +1)
+    fake._pd_batch_outstanding(b, +1)
+    assert fake._pd_inflight["req-b"].outstanding == 2
+    fake._pd_batch_outstanding(b, -1)
+    fake._pd_batch_outstanding(b, -1)
+    fake._pd_batch_outstanding(b, -1)  # floor at 0, never negative
+    assert fake._pd_inflight["req-b"].outstanding == 0
+
+
+@pytest.mark.unit
+def test_abort_idle_entry_finalizes_exactly_once():
+    fake = _FakeLifecycleSelf()
+    r = _FakeLcReq("req-c", pool_idx=7)
+    fake._pd_track_inflight(r, p_idx=0)
+    fake.p_chunked_reqs[0][0] = r  # chunked owner between chunks
+    fake._pd_abort_matching(SimpleNamespace(rid="req-c", abort_all=False))
+    assert fake._pd_inflight == {}  # released
+    assert fake._pd_inflight_tokens == 0
+    assert fake.p_trees[0].finished == ["req-c"]  # P KV freed once
+    assert fake.p_r2ts[0].free_slots == [7]
+    assert fake.p_chunked_reqs[0][0] is None  # owner cleared
+    assert r.finished() and fake.streamed == ["req-c"]
+    # second abort for same rid: no entry left, must be a no-op
+    fake._pd_abort_matching(SimpleNamespace(rid="req-c", abort_all=False))
+    assert fake.p_trees[0].finished == ["req-c"]
+
+
+@pytest.mark.unit
+def test_abort_inflight_entry_marks_but_defers():
+    fake = _FakeLifecycleSelf()
+    r = _FakeLcReq("req-d")
+    fake._pd_track_inflight(r, p_idx=0)
+    fake._pd_batch_outstanding(_fake_batch(r), +1)  # batch in flight
+    fake._pd_abort_matching(SimpleNamespace(rid="req-d", abort_all=False))
+    entry = fake._pd_inflight["req-d"]
+    assert entry.pending_abort and entry.outstanding == 1
+    assert fake.p_trees[0].finished == []  # nothing freed yet
+    assert not r.finished()
+    # batch drains -> outstanding 0 -> the drain path finalizes
+    fake._pd_batch_outstanding(_fake_batch(r), -1)
+    fake._pd_finalize_aborted(entry)
+    assert fake._pd_inflight == {} and fake.streamed == ["req-d"]
+
+
+@pytest.mark.unit
+def test_abort_all_matches_every_entry():
+    fake = _FakeLifecycleSelf()
+    r1, r2 = _FakeLcReq("x-1"), _FakeLcReq("y-2")
+    fake._pd_track_inflight(r1, p_idx=0)
+    fake._pd_track_inflight(r2, p_idx=0)
+    fake._pd_abort_matching(SimpleNamespace(rid="", abort_all=True))
+    assert fake._pd_inflight == {}
+    assert sorted(fake.streamed) == ["x-1", "y-2"]
+
+
+@pytest.mark.unit
+def test_abort_prefix_matching_only():
+    fake = _FakeLifecycleSelf()
+    r1, r2 = _FakeLcReq("abc-1"), _FakeLcReq("xyz-2")
+    fake._pd_track_inflight(r1, p_idx=0)
+    fake._pd_track_inflight(r2, p_idx=0)
+    fake._pd_abort_matching(SimpleNamespace(rid="abc", abort_all=False))
+    assert "xyz-2" in fake._pd_inflight and "abc-1" not in fake._pd_inflight
+
+
+@pytest.mark.unit
+def test_quiesce_returns_when_pipeline_empty_and_times_out_when_stuck():
+    fake = _FakeLifecycleSelf()
+    fake._pd_prefill_qs = [queue.Queue()]
+    fake._pd_chunk_pending = [False]
+    fake._pd_ready_q = queue.Queue()
+    fake._pd_defer = []
+    fake.drained = 0
+
+    def _drain():
+        fake.drained += 1
+        return 0
+
+    fake._pd_drain_ready_multi = _drain
+    # empty pipeline: returns immediately after one drain sweep
+    PathwaysPDSchedulerMixin._pd_quiesce(fake, timeout_s=1.0)
+    assert fake.drained == 1
+    # stuck outstanding batch: must hit the timeout, not hang forever
+    r = _FakeLcReq("req-q")
+    fake._pd_track_inflight(r, p_idx=0)
+    fake._pd_inflight["req-q"].outstanding = 1
+    t0 = time.perf_counter()
+    PathwaysPDSchedulerMixin._pd_quiesce(fake, timeout_s=0.2)
+    assert 0.15 < time.perf_counter() - t0 < 2.0

--- a/test/srt/test_jax_utils.py
+++ b/test/srt/test_jax_utils.py
@@ -1,0 +1,86 @@
+import unittest
+
+import jax
+import numpy as np
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+
+from sgl_jax.srt.utils.jax_utils import device_array
+
+
+def _make_mesh():
+    return Mesh(np.array(jax.devices()[:1]).reshape(1, 1), ("data", "tensor"))
+
+
+class TestDeviceArrayShardingReuse(unittest.TestCase):
+    """device_array must hand out a canonical NamedSharding per (mesh, spec).
+
+    jaxlib's PjitFunctionCache fast-path compares input shardings by object
+    pointer; a fresh NamedSharding per call defeats it and forces the pjit
+    python slow path on every step (issue #1452).
+    """
+
+    def test_sharding_is_pointer_stable_across_calls(self):
+        mesh = _make_mesh()
+        data = np.arange(8, dtype=np.int32)
+        (a1,) = device_array((data,), sharding=NamedSharding(mesh, PartitionSpec("data")))
+        (a2,) = device_array((data,), sharding=NamedSharding(mesh, PartitionSpec("data")))
+        self.assertIs(a1.sharding, a2.sharding)
+
+    def test_sharding_is_pointer_stable_across_equal_meshes(self):
+        # Equal-but-distinct Mesh objects must also canonicalize to one object.
+        data = np.arange(8, dtype=np.int32)
+        (a1,) = device_array((data,), sharding=NamedSharding(_make_mesh(), PartitionSpec("data")))
+        (a2,) = device_array((data,), sharding=NamedSharding(_make_mesh(), PartitionSpec("data")))
+        self.assertIs(a1.sharding, a2.sharding)
+
+    def test_distinct_specs_get_distinct_shardings(self):
+        mesh = _make_mesh()
+        data = np.arange(8, dtype=np.int32)
+        (a1,) = device_array((data,), sharding=NamedSharding(mesh, PartitionSpec("data")))
+        (a2,) = device_array((data,), sharding=NamedSharding(mesh, PartitionSpec(None)))
+        self.assertEqual(a1.sharding.spec, PartitionSpec("data"))
+        self.assertEqual(a2.sharding.spec, PartitionSpec(None))
+
+    def test_values_unchanged(self):
+        mesh = _make_mesh()
+        data = np.arange(8, dtype=np.int32)
+        (arr,) = device_array((data,), sharding=NamedSharding(mesh, PartitionSpec("data")))
+        np.testing.assert_array_equal(np.asarray(arr), data)
+
+    def test_none_sharding_path_unchanged(self):
+        arr = device_array(np.arange(4, dtype=np.int32))
+        np.testing.assert_array_equal(np.asarray(arr), np.arange(4, dtype=np.int32))
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestShapeDtypeStructDefeatsCppCache(unittest.TestCase):
+    """A jax.ShapeDtypeStruct leaf among jit args fails ComputeCallSignature
+    in jaxlib and forces the python dispatch path on every call (#1452).
+    ModelRunner replaces such placeholders with zero-length arrays at init."""
+
+    def test_sds_arg_misses_every_call_and_arrays_do_not(self):
+        import jax._src.test_util as jtu
+
+        a = jax.device_put(np.zeros((4,), np.float32), jax.devices()[0])
+        sds = jax.ShapeDtypeStruct((4,), np.float32)
+        f = jax.jit(lambda xs: len(xs))
+        f([a, a])
+        with jtu.count_pjit_cpp_cache_miss() as c:
+            f([a, a])
+        self.assertEqual(c(), 0)
+        f([a, sds])
+        misses = []
+        for _ in range(3):
+            with jtu.count_pjit_cpp_cache_miss() as c:
+                f([a, sds])
+            misses.append(c())
+        self.assertEqual(misses, [1, 1, 1])
+        # replacement with a real (even zero-length) array restores the fastpath
+        fixed = jax.device_put(np.zeros((0,), np.float32), jax.devices()[0])
+        f([a, fixed])
+        with jtu.count_pjit_cpp_cache_miss() as c:
+            f([a, fixed])
+        self.assertEqual(c(), 0)


### PR DESCRIPTION
Refs #772, #1486; Fixes #1452, #1499

### Motivation

This is the Stage-4 batch of the Pathways integration roadmap item ("Benchmark and optimize Pathways integration, including the remaining device_get/host-transfer overhead and the decode fast-path miss" — #772, #774, #1452), plus the async P-pipeline lifecycle gap reported in #1486.

We first reproduced the #772 gap with DeepSeek-R1-Distill-Qwen-1.5B (tp4, dp1, bf16, page 256, chunked prefill 2048, radix off; `bench_serving` random 1024/1024, 384 prompts, max-concurrency 256; 3 rounds, warm rounds quoted, variance <1.5%) on identical single-host TPU v7x hardware, native vs `--device=proxy --enable-single-process`, and decomposed each decode step into H2D metadata upload / dispatch / resolve-D2H. The entire gap sits in the blocking `jax.device_get(next_token_ids)` in `resolve_last_batch_result`: ~21 ms per step for a few-hundred-byte array under the proxy backend (pure client→proxy→worker round-trip), vs ~3 ms native. H2D and dispatch are at parity.

Numbers on the current 0.10.x dependency set (see the compatibility note on Pathways image tags):

| config | stack (all jax 0.10.2) | output tok/s | median ITL |
|---|---|---|---|
| native (main baseline) | client 0.10.2 | 9682 (9662–9695 ×3) | 29.9 ms |
| native (this PR) | client 0.10.2 | 9675 | 29.8 ms |
| Pathways (main baseline) | client + Pathways images 0.10.2 | 4047 | 49.5 ms |
| Pathways (this PR) | client + Pathways images 0.10.2 | 5344 | 38.8 ms |

(For reference, on the previously-validated jax 0.8.1 stack the same A/B was native 8987 vs Pathways 3938 → 5365 tok/s, i.e. 43.8% → 59.8% of native.)

### Compatibility notes: first full validation on the jax 0.10.x stack

Pathways serving had previously only been validated up to the jax 0.9 series; this PR's validation is the first on 0.10.x. Two pitfalls worth documenting:

1. **Pathways image tags.** The **static** image tags (`pathways/{server,proxy_server}:jax-0.10.1`, and there is no static `jax-0.10.2` tag) point at older binaries whose Mosaic deserializer tops out at version 13, so a jax 0.10.2 client fails every Pallas kernel under `--device=proxy` with `Failed to deserialize the Mosaic module: expected <= 13 but got 15` (native is unaffected — compile and execute share a process). The **dated daily builds** (e.g. `:20260727-jax_0.10.2`, also tagged `:latest`) are a single multi-version binary and work correctly with the 0.10.2 pin — all Pathways numbers and regression runs in this PR use `20260727-jax_0.10.2`, i.e. the exact pinned dependency set end to end.

2. **FP8 block-quant models crash on 0.10.x without the #1499 fix.** jax 0.8.x `shard_map` silently reshards on a textual in_specs mismatch; 0.10.x validates strictly. Static-quant checkpoints (GLM-5.2-FP8 and other DeepSeek-format FP8 models) load their compact 2D linear scales, expand them 2D→3D, and assign without resharding to the placeholder's declared sharding — so on 0.10.x every such model crashes at the first precompile, native and proxy alike (reproduced on unmodified main both ways; #1493 fixed the same class at the MoE/MLA boundaries but missed the linear path). Fixed here by resharding the expanded scale to the placeholder's sharding (see #1499 for the full analysis, including a static audit of the remaining latent spots — none of which trigger at tp16).

### Changes

1. **Start the next-token D2H on the forward thread** — right after the replicate-gather, `next_token_ids.copy_to_host_async()` so the scheduler's `resolve_last_batch_result` finds the copy in flight instead of paying the full interactive round-trip. Decode-phase resolve drops 21→8 ms/step under proxy (+33% output throughput); native unaffected (3 rounds, within variance).
2. **`device_array`: canonical `NamedSharding` per (mesh, spec, memory_kind)** — pjit's cpp fast-path compares input shardings by pointer; constructing a fresh `NamedSharding` per call defeats it and pays `NamedSharding.__init__` per metadata array per step (+2.5% under proxy on the same config).
3. **Async P-pipeline abort/retract lifecycle (#1486)** — the in-flight rid set becomes a registry `rid → (req, p_idx, reserved tokens, outstanding batch count, pending_abort)`. `abort_request` reaches requests anywhere in the pipeline: idle entries finalize immediately (P KV + req slot + admission token accounting + client abort, exactly once), in-flight entries finalize when their batch drains; chunk continuation stops for aborted owners; requests that already migrated are flagged finished so the standard prefill-result path frees their D KV without touching the mixed batch's page layout; pause/retract quiesces the pipeline so a late P result can't merge beside a requeued copy. The two `scheduler.py` hooks are getattr-guarded no-ops outside pathways PD.
4. **Replace `jax.ShapeDtypeStruct` state placeholders (#1452)** — static-quant checkpoints leave SDS placeholders in module state; jaxlib's `ToPyArgSignature` rejects them (`ComputeCallSignature failed: INVALID_ARGUMENT ... Got type ShapeDtypeStruct`, visible with `TF_CPP_VMODULE=pjit=3,jax_jit=3`), so every `jitted_run_model` call takes the python dispatch path — the per-decode-step cpp cache miss reported in #1452. The placeholders are dead on the forward path (a used leaf with a changed shape would fail to compile); they're swapped for zero-length arrays at `initialize_jit`, with the replaced paths logged. Note the root cause is unrelated to dp/proxy as originally guessed in the issue — the original attribution was a control-group artifact.
5. **Reshard expanded block-quant linear scales to their declared sharding (#1499)** — unblocks every FP8 block-quant checkpoint on jax 0.10.x (crash at first precompile on unmodified main, native and proxy alike); details in the compatibility note above and in #1499.

### Validation

- unit: sharding canonicalization + SDS-fastpath repro/restore (`test/srt/test_jax_utils.py`), lifecycle registry/abort/quiesce (`test/srt/disaggregation/test_pathways_pd.py`, 7 new tests)
- #772 repro: numbers above; greedy outputs byte-identical native vs proxy; gsm8k 200q native 0.600 / proxy 0.600
- #1486 e2e (MiMo tp8 2P1D Pathways): 24 aborts at t=2s → 24/24 terminated, registry marks confirmed in logs for in-pipeline requests, post-abort health 8/8, no leak after 12-abort stress round, 0 tracebacks
- #1452 (GLM static-quant MLA/epmoe tp16 dp1 + proxy): 156 placeholders replaced; decode `#cache_miss` 545/545 → 0 in steady state (only legit first-call-per-shape misses remain); gsm8k before/after 0.820 / 0.840 (parity)
- PD regression matrix (MiMo SWA/GQA tp8 2P1D, Pathways), run on BOTH stacks: jax 0.8.1 — correctness 336/336, bench 15534/15486/15512 tok/s (baseline band), gsm8k 0.855, no crash; jax 0.10.2 end-to-end (first 0.10.x Pathways-PD validation) — correctness 336/336, bench 15778/15713/15769 tok/s, gsm8k 0.890, no crash
- GLM-5.2-FP8 (MLA/epmoe) PD matrix @0.10.2 (tp16 2-slice, Pathways; requires the #1499 fix to even start on this stack): correctness 336/336 (SHORT/MID/LONG × conc 4/8/16), bench C64 16K/4K 192-req — 1276.0 / 1274.7 tok/s (r1/r2, 0.1% variance), median ITL 75.08 / 75.18 ms, no crash. The pre-PR baseline on the same workload/topology (jax 0.8.1 stack) was 1043.6 tok/s at 89.28 ms median ITL — the −14.2 ms/step matches the decode-resolve RTT this PR removes (21→8 ms measured in the #772 decomposition), plus the 0.10.2 stack gain. gsm8k 200q: 0.965 (a second independent bring-up scored 0.955).
- #1499 fix evidence: unmodified main crashes at first precompile on GLM static-quant, reproduced BOTH under `--device=proxy` (PD) and native `--device=tpu` (identical `shard_map in_specs ... does not match` error); with the fix the same configs fire up and pass (native: bench 1024/1024 C256 ×3 rounds = 1106.1 / 1106.1 / 1106.0 output tok/s, <0.01% variance, no crash).

