### PR TITLE
fix(overlap): future-token ring wraparound corrupts outputs at high concurrency

### DIFF
--- a/python/sgl_jax/srt/managers/tp_worker.py
+++ b/python/sgl_jax/srt/managers/tp_worker.py
@@ -473,7 +473,7 @@ class ModelWorker:
         sampling_metadata: SamplingMetadata = None,
         forward_metadata=None,
         future_map=None,
-        future_ct=None,
+        future_slots=None,
     ) -> tuple[LogitsProcessorOutput, jax.Array | None, int]:
         # Prepare LoRA batch if LoRA is enabled
         if self.worker.server_args.enable_lora and self.need_prepare_lora_batch:
@@ -509,7 +509,6 @@ class ModelWorker:
             if model_worker_batch.sampling_info:
                 self._update_grammar_vocab_mask(model_worker_batch, sampling_metadata)
             fmap = future_map if future_map is not None else self._pd_dummy_future_map
-            fct = future_ct if future_ct is not None else 0
             (
                 next_token_ids_device,
                 logits_output,
@@ -518,7 +517,7 @@ class ModelWorker:
                 layers_topk_ids,
                 new_future_map,
             ) = self.model_runner.forward_and_sample(
-                forward_batch, logits_metadata, sampling_metadata, fmap, fct
+                forward_batch, logits_metadata, sampling_metadata, fmap
             )
             self.dump_topk_ids(layers_topk_ids, model_worker_batch)
             if launch_done is not None:

--- a/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sgl_jax/srt/managers/tp_worker_overlap_thread.py
@@ -16,7 +16,11 @@ from jax.sharding import NamedSharding, PartitionSpec
 
 from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
 from sgl_jax.srt.managers.tp_worker import ModelWorker
-from sgl_jax.srt.managers.utils import resolve_future_token_ids, set_future_token_ids
+from sgl_jax.srt.managers.utils import (
+    future_slot_indices,
+    resolve_future_token_ids,
+    set_future_token_ids,
+)
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
 from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
 from sgl_jax.srt.server_args import ServerArgs
@@ -45,10 +49,11 @@ class ModelWorkerClient:
         self.device = self.worker.device
         self.cur_sampling_info = None
 
-        # Init future mappings
-        self.future_token_ids_ct = 0
-        self.future_token_ids_limit = self.max_running_requests * 3
-        self.future_token_ids_map = jnp.zeros((self.max_running_requests * 5,), dtype=jnp.int32)
+        # Init future mappings. The map is indexed by req_pool_idx + 1 (one
+        # pending-token slot per request slot; index 0 reserved), not by a
+        # running cursor -- see set_future_token_ids.
+        self.future_map_size = self.worker.model_runner.req_to_token_pool.size + 2
+        self.future_token_ids_map = jnp.zeros((self.future_map_size,), dtype=jnp.int32)
         self.mesh = mesh
         sharding = NamedSharding(mesh, PartitionSpec(None))
         self.future_token_ids_map = jax.device_put(self.future_token_ids_map, sharding)
@@ -109,7 +114,7 @@ class ModelWorkerClient:
         while True:
             (
                 model_worker_batch,
-                future_token_ids_ct,
+                future_slot_indices_np,
                 sampling_metadata,
                 forward_metadata,
             ) = self.input_queue.get()
@@ -131,7 +136,7 @@ class ModelWorkerClient:
                             sampling_metadata=sampling_metadata,
                             forward_metadata=forward_metadata,
                             future_map=self.future_token_ids_map,
-                            future_ct=future_token_ids_ct,
+                            future_slots=future_slot_indices_np,
                         )
                     )
                 self.future_token_ids_map = new_future_map
@@ -158,7 +163,7 @@ class ModelWorkerClient:
             # set_future's cpp-fastpath cache hits; async_gather afterwards.
             self.future_token_ids_map = set_future_token_ids(
                 self.future_token_ids_map,
-                future_token_ids_ct,
+                future_slot_indices_np,
                 next_token_ids,
                 self.mesh,
             )
@@ -284,26 +289,24 @@ class ModelWorkerClient:
             model_worker_batch, self.worker.get_model_runner()
         )
 
+        # Per-request slots: placeholder value -(req_pool_idx + 1) round-trips
+        # through resolve_future_token_ids (map[-id]); padding rows get 0
+        # (a non-negative id, resolved as-is and never consumed).
+        seq_lens_np = np.asarray(model_worker_batch.seq_lens)
+        req_pool_np = np.asarray(model_worker_batch.req_pool_indices)
+        slots = future_slot_indices(seq_lens_np, req_pool_np, self.future_map_size)
+
         # Push a new batch to the queue (JAX handles synchronization automatically)
         self.input_queue.put(
             (
                 model_worker_batch,
-                self.future_token_ids_ct,
+                slots,
                 sampling_metadata,
                 forward_metadata,
             )
         )
 
-        # Allocate output future objects
-        bs = len(model_worker_batch.seq_lens)
-
-        future_next_token_ids = np.arange(
-            -(self.future_token_ids_ct + 1),
-            -(self.future_token_ids_ct + 1 + bs),
-            -1,
-            dtype=np.int32,
-        )
-        self.future_token_ids_ct = (self.future_token_ids_ct + bs) % self.future_token_ids_limit
+        future_next_token_ids = np.where(seq_lens_np > 0, -slots, 0).astype(np.int32)
         return None, future_next_token_ids, 0
 
     def run_precompile(self, only: str | None = None):

--- a/python/sgl_jax/srt/managers/utils.py
+++ b/python/sgl_jax/srt/managers/utils.py
@@ -54,8 +54,31 @@ def resolve_future_token_ids(input_ids, future_token_ids_map, mesh):
     return jax.sharding.reshard(input_ids_global, NamedSharding(mesh, P("data")))
 
 
+def future_slot_indices(seq_lens_np, req_pool_indices_np, map_size):
+    """Per-request future-map slots: real rows -> req_pool_idx + 1 (slot 0 is
+    reserved so 0 stays a valid "no placeholder" input id), padding rows ->
+    map_size (out of bounds, dropped by the scatter)."""
+    import numpy as np
+
+    return np.where(
+        seq_lens_np > 0,
+        req_pool_indices_np.astype(np.int32) + 1,
+        np.int32(map_size),
+    ).astype(np.int32)
+
+
 @jax.jit(static_argnames=("mesh"))
-def set_future_token_ids(future_token_ids_map, future_token_ids_ct, next_token_ids, mesh):
+def set_future_token_ids(future_token_ids_map, slot_indices, next_token_ids, mesh):
+    """Write each request's pending next token at its req-pool slot.
+
+    Slot addressing replaces the previous ring-buffer cursor: the cursor
+    advanced by the PADDED batch size (padded seq_lens), so a burst of
+    prefill batches wrapped the 3x ring and overwrote outstanding
+    placeholders before their first decode resolved them (silent first-token
+    corruption that grows with concurrency). A per-request slot cannot be
+    overwritten by another request; padding rows scatter out of bounds and
+    are dropped.
+    """
     next_token_ids_global = jax.sharding.reshard(next_token_ids, NamedSharding(mesh, P()))
-    start_indices = (future_token_ids_ct + 1,)
-    return jax.lax.dynamic_update_slice(future_token_ids_map, next_token_ids_global, start_indices)
+    slot_indices_global = jax.sharding.reshard(slot_indices, NamedSharding(mesh, P()))
+    return future_token_ids_map.at[slot_indices_global].set(next_token_ids_global, mode="drop")

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -252,7 +252,14 @@ class CompilationManager:
                 )
                 if future_token_ids_map is not None:
                     _, next_token_ids, _ = result
-                    set_future_token_ids(future_token_ids_map, 0, next_token_ids, mesh)
+                    from sgl_jax.srt.managers.utils import future_slot_indices
+
+                    slots = future_slot_indices(
+                        np.asarray(batch.seq_lens),
+                        np.asarray(batch.req_pool_indices),
+                        future_token_ids_map.shape[0],
+                    )
+                    set_future_token_ids(future_token_ids_map, slots, next_token_ids, mesh)
                 self._compiled_variants.add((ForwardMode.DECODE, bs_val, bs_val, False))
 
         end_time = time.perf_counter()

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -375,7 +375,6 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
             rng_step,
             sampling_metadata,
             future_token_ids_map,
-            future_token_ids_ct,
         ):
             # resolve_future_token_ids inlined: negative ids are future placeholders.
             ids = forward_batch.input_ids
@@ -407,11 +406,17 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                 use_sort_for_toppk_minp=use_sort_for_toppk_minp,
                 rng_override=rng_key,
             )
-            # async_gather + set_future_token_ids inlined.
+            # async_gather + set_future_token_ids inlined. Per-request slot
+            # scatter (req_pool_idx + 1); padding rows (seq_lens == 0) go out
+            # of bounds and are dropped. See managers/utils.set_future_token_ids.
             next_ids = jax.lax.with_sharding_constraint(next_ids, NamedSharding(_fused_mesh, P()))
-            new_future_map = jax.lax.dynamic_update_slice(
-                future_token_ids_map, next_ids, (future_token_ids_ct + 1,)
+            slot_ids = jnp.where(
+                forward_batch.seq_lens > 0,
+                forward_batch.req_pool_indices.astype(jnp.int32) + 1,
+                jnp.int32(future_token_ids_map.shape[0]),
             )
+            slot_ids = jax.lax.with_sharding_constraint(slot_ids, NamedSharding(_fused_mesh, P()))
+            new_future_map = future_token_ids_map.at[slot_ids].set(next_ids, mode="drop")
             return (
                 next_ids,
                 output,
@@ -422,9 +427,7 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                 new_future_map,
             )
 
-        def run_and_sample_wrapper(
-            forward_batch, logits_metadata, sampling_metadata, future_map, future_ct
-        ):
+        def run_and_sample_wrapper(forward_batch, logits_metadata, sampling_metadata, future_map):
             self._sampler_step += 1
             return jitted_run_and_sample(
                 model_def,
@@ -440,7 +443,6 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                 self._sampler_step,
                 sampling_metadata,
                 future_map,
-                jnp.asarray(future_ct, dtype=jnp.int32),
             )
 
         self.jitted_run_and_sample = run_and_sample_wrapper
@@ -748,9 +750,7 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         # layers_topk_ids required real_bs and original_input_len which could not be stored in ForwardBatch
         return output, cache_miss_count, layers_topk_ids
 
-    def forward_and_sample(
-        self, forward_batch, logits_metadata, sampling_metadata, future_map, future_ct
-    ):
+    def forward_and_sample(self, forward_batch, logits_metadata, sampling_metadata, future_map):
         import jax._src.test_util as jtu
 
         self.forward_pass_id += 1
@@ -769,7 +769,7 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                     token_logprobs,
                     new_future_map,
                 ) = self.jitted_run_and_sample(
-                    forward_batch, logits_metadata, sampling_metadata, future_map, future_ct
+                    forward_batch, logits_metadata, sampling_metadata, future_map
                 )
                 cache_miss_count = count()
             if self.tp_size == 1 and isinstance(pool_updates, list):

--- a/python/sgl_jax/test/managers/test_future_token_map.py
+++ b/python/sgl_jax/test/managers/test_future_token_map.py
@@ -1,0 +1,84 @@
+"""Unit tests for the req-pool-slot future-token map (overlap scheduling).
+
+Regression for the padded-bs ring wraparound: a burst of prefill batches
+advanced the old ring cursor by the PADDED batch size and overwrote
+outstanding placeholders before the owning request's first decode resolved
+them. The map is now indexed by req_pool_idx + 1; these tests pin the
+set/resolve round trip, padding-row drop, and wraparound immunity.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from sgl_jax.srt.managers.utils import future_slot_indices, set_future_token_ids
+
+
+@pytest.fixture
+def mesh():
+    return jax.sharding.Mesh(np.array(jax.devices()[:1]), ("data",))
+
+
+def _map(size=18):
+    return jnp.zeros((size,), dtype=jnp.int32)
+
+
+def test_set_resolve_round_trip(mesh):
+    fmap = _map()
+    seq_lens = np.array([5, 3, 9, 0], dtype=np.int32)  # last row is padding
+    req_pool = np.array([7, 2, 11, 0], dtype=np.int32)
+    slots = future_slot_indices(seq_lens, req_pool, fmap.shape[0])
+    tokens = jnp.array([101, 202, 303, 999], dtype=jnp.int32)
+
+    fmap = set_future_token_ids(fmap, slots, tokens, mesh)
+
+    # resolve_future_token_ids (unchanged by this fix) computes
+    # map[-placeholder] for negative ids; verify that lookup directly.
+    placeholders = np.where(seq_lens > 0, -slots, 0).astype(np.int32)
+    fmap_np = np.asarray(fmap)
+    np.testing.assert_array_equal(fmap_np[-placeholders[:3]], [101, 202, 303])
+    # padding row keeps a non-negative id (0) -> resolve passes it through
+    assert placeholders[3] == 0
+
+
+def test_padding_rows_do_not_clobber_slot_zero(mesh):
+    """Old failure shape: padding rows carrying req_pool_idx fill value 0
+    must not overwrite the request that legitimately owns pool idx 0."""
+    fmap = _map()
+    # real request at pool idx 0 writes its pending token
+    slots_a = future_slot_indices(
+        np.array([4], dtype=np.int32), np.array([0], dtype=np.int32), fmap.shape[0]
+    )
+    fmap = set_future_token_ids(fmap, slots_a, jnp.array([555], dtype=jnp.int32), mesh)
+    # another batch: one real row (pool idx 3) + three padding rows (fill 0)
+    seq_lens = np.array([6, 0, 0, 0], dtype=np.int32)
+    req_pool = np.array([3, 0, 0, 0], dtype=np.int32)
+    slots_b = future_slot_indices(seq_lens, req_pool, fmap.shape[0])
+    fmap = set_future_token_ids(fmap, slots_b, jnp.array([777, -1, -1, -1], dtype=jnp.int32), mesh)
+
+    assert int(fmap[1]) == 555  # pool idx 0 slot untouched by padding rows
+    assert int(fmap[4]) == 777
+
+
+def test_prefill_burst_does_not_wrap(mesh):
+    """The ring-cursor design corrupted this exact scenario: many padded
+    prefill batches between a request's prefill and its first decode."""
+    fmap = _map(size=34)
+    # request R prefills first: pool idx 5, pending token 4242
+    slots_r = future_slot_indices(
+        np.array([7], dtype=np.int32), np.array([5], dtype=np.int32), fmap.shape[0]
+    )
+    fmap = set_future_token_ids(fmap, slots_r, jnp.array([4242], dtype=jnp.int32), mesh)
+    # 50 subsequent padded prefill batches for OTHER requests
+    rng = np.random.default_rng(0)
+    for step in range(50):
+        pool_idx = int(rng.integers(6, 32))
+        seq_lens = np.full(8, 0, dtype=np.int32)  # padded batch of 8, 1 real row
+        req_pool = np.zeros(8, dtype=np.int32)
+        seq_lens[0], req_pool[0] = 3, pool_idx
+        slots = future_slot_indices(seq_lens, req_pool, fmap.shape[0])
+        toks = jnp.full((8,), 10_000 + step, dtype=jnp.int32)
+        fmap = set_future_token_ids(fmap, slots, toks, mesh)
+    # R's slot (pool idx 5 -> map index 6) must still hold its own token
+    assert int(np.asarray(fmap)[6]) == 4242

--- a/python/sgl_jax/test/managers/test_future_token_map.py
+++ b/python/sgl_jax/test/managers/test_future_token_map.py
@@ -7,6 +7,12 @@ them. The map is now indexed by req_pool_idx + 1; these tests pin the
 set/resolve round trip, padding-row drop, and wraparound immunity.
 """
 
+import os
+
+# CPU CI job runs this file with USE_DEVICE_TYPE=cpu (see run_suite.py unit-test-cpu)
+if os.environ.get("USE_DEVICE_TYPE") == "cpu":
+    os.environ["JAX_PLATFORMS"] = "cpu"
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -59,6 +65,35 @@ def test_padding_rows_do_not_clobber_slot_zero(mesh):
 
     assert int(fmap[1]) == 555  # pool idx 0 slot untouched by padding rows
     assert int(fmap[4]) == 777
+
+
+def test_runtime_padding_sentinel_rows_are_dropped(mesh):
+    """Pin the actual runtime padding contract: get_model_worker_batch pads
+    with req_pool_indices=-1 and seq_lens=0 (schedule_batch). Those rows must
+    resolve to the out-of-bounds slot and be dropped by the scatter, leaving
+    every other slot untouched."""
+    fmap = _map()
+    # a real request at pool idx 0 has an outstanding placeholder in slot 1
+    slots_a = future_slot_indices(
+        np.array([4], dtype=np.int32), np.array([0], dtype=np.int32), fmap.shape[0]
+    )
+    fmap = set_future_token_ids(fmap, slots_a, jnp.array([555], dtype=jnp.int32), mesh)
+
+    # padded batch exactly as the runtime builds it: -1 pool sentinel, seq_len 0
+    seq_lens = np.array([6, 0, 0, 0], dtype=np.int32)
+    req_pool = np.array([3, -1, -1, -1], dtype=np.int32)
+    slots = future_slot_indices(seq_lens, req_pool, fmap.shape[0])
+    np.testing.assert_array_equal(slots[1:], fmap.shape[0])  # out of bounds
+
+    before = np.asarray(fmap).copy()
+    fmap = set_future_token_ids(fmap, slots, jnp.array([777, -1, -1, -1], dtype=jnp.int32), mesh)
+    after = np.asarray(fmap)
+
+    assert after[1] == 555  # outstanding placeholder untouched
+    assert after[4] == 777  # real row landed in its own slot
+    untouched = np.ones_like(before, dtype=bool)
+    untouched[[1, 4]] = False
+    np.testing.assert_array_equal(after[untouched], before[untouched])
 
 
 def test_prefill_burst_does_not_wrap(mesh):

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -309,6 +309,11 @@ suites = {
             0.2,
             runner="pytest",
         ),
+        TestFile(
+            "python/sgl_jax/test/managers/test_future_token_map.py",
+            0.2,
+            runner="pytest",
+        ),
         TestFile("python/sgl_jax/test/test_scheduler_idle_check.py", 0.1),
         TestFile("python/sgl_jax/test/test_scheduler_chunked_ownership.py", 0.1),
         TestFile("test/srt/test_dtype_config_llama.py", 1),


### PR DESCRIPTION

**Likely fixes #1317** — same failure signature (accuracy collapsing with decode batch size under the overlap scheduler, hybrid/linear-attention models hit hardest, host-side bookkeeping clean). This PR reproduces and eliminates that signature on a hybrid-GDN model (A/B below); a Ling rerun on this branch should confirm and close #1317.

### Symptom

With the (default) overlap scheduler, generation accuracy degrades monotonically with server-side batch size, on every model family we tested, while low concurrency and `--disable-overlap-schedule` stay healthy. gsm8k 200q 5-shot greedy, same server, only client parallelism varied:

| model | healthy (c4) | collapsed |
|---|---|---|
| GLM-5.2-FP8 tp16 (v7x, 2 hosts) | 0.955 | **0.700** @ c64 |
| DeepSeek-R1-Distill-Qwen-1.5B bf16 tp4 (single host) | 0.670 | **0.435** @ c128 |

GLM cliff shape (overlap ON): c8 0.955 → c9 0.935 → c16 0.930 → c32 0.860 → c64 0.700. Controls on the same server: `--disable-overlap-schedule` c64 = 0.955; `--max-running-requests 8` with client c64 = 0.955. No retracts, Invalid ≤ 1%, bf16 and quantized models equally affected — this is not a numerics/quantization issue.

The failure signature is a corrupted token right at the start of a request's output (first decode steps), after which greedy decoding derails. A quick probe makes it countable: 128–384 concurrent greedy requests, each asked to echo its own unique codeword; any output that breaks its own codeword is an anomaly. On main: 8/768 anomalies (dense 1.5B) and **44/1152** (Qwen3.5-0.8B hybrid GDN — recurrent state compounds the corrupted token, which is why hybrid models are hit hardest, cf. #1317). With this fix: **0/768** on both.

### Root cause

`ModelWorkerClient.forward_batch_generation` allocates future-token placeholders from a ring buffer and advances the cursor by `bs = len(model_worker_batch.seq_lens)`.

Since the DP-support refactor (#939), `get_model_worker_batch` returns **padded** per-DP arrays — for extend batches padded to the *largest* bs bucket. So the cursor advances by the padded size (e.g. 256) per prefill batch instead of the number of real sequences (2–3), while the ring size (`max_running_requests * 3`) was chosen for real-bs advances. A burst of prefill batches wraps the ring within ~3 batches and overwrites outstanding placeholders **before the owning request's first decode batch resolves them** — that request's first input token silently resolves to whatever a newer batch wrote into the slot. The higher the concurrency, the more prefill batches run between a request's prefill and its first decode, hence the monotonic collapse. Phase-split (PD) deployments and `--disable-overlap-schedule` never consume placeholders, which is why they are immune.

Introduced by #939 (bisected: parent `b787fdef` healthy 0.650 @ c128, `de5287ed` collapsed 0.405; 7-round bisect on the 1.5B single-host setup).

### Fix

Index the future-token map by **`req_pool_idx + 1`** — one pending-token slot per request slot — instead of a moving cursor:

- No cursor, no sizing assumption, no wraparound: a request's slot can only be overwritten by its own next token (forward-thread order guarantees set-before-resolve).
- Placeholder value becomes `-(req_pool_idx + 1)`; `resolve_future_token_ids` is unchanged (it already maps `id -> map[-id]`).
- Padding rows scatter out of bounds and are dropped (`mode="drop"`), so they can never clobber the request that legitimately owns pool idx 0.
- Shapes stay static per bs bucket (no new compilation variants, no AOT impact).
- Applied to the plain overlap path, the fused Pathways-PD decode path (same transformation, slots derived in-jit from `forward_batch.req_pool_indices`/`seq_lens`), and the precompile stub.

### Accuracy after fix (same servers, overlap ON)

| check | main | this PR |
|---|---|---|
| GLM-5.2-FP8 gsm8k c64 | 0.700 / 0.700 | **0.950 / 0.960** |
| GLM-5.2-FP8 gsm8k c4 | 0.955 | 0.955 |
| 1.5B gsm8k c128 | 0.435 / 0.435 | **0.680** |
| 1.5B gsm8k c4 | 0.670 | 0.670 |
| codeword-echo anomalies, 1.5B dense | 8/768 | **0/768** |
| codeword-echo anomalies, Qwen3.5-0.8B GDN | 44/1152 | **0/768** |

### Performance

Same-pod paired A/B, 1.5B tp4, random 1024/1024, 384 prompts, max-concurrency 256, 2 rounds each:

| | output tok/s | median ITL |
|---|---|---|
| main | 8796 / 8850 | 31.9 / 31.6 ms |
| this PR | 8836 / 8805 | 31.6 / 31.9 ms |

Neutral (within run-to-run noise). The per-step op change is a same-size scatter replacing a `dynamic_update_slice`; the map shrinks from `max_running*5` to `req_pool_size+2`.

### Test plan

- [x] Unit tests: `python/sgl_jax/test/managers/test_future_token_map.py` — set/placeholder round trip, padding rows cannot clobber pool-idx-0 slot, placeholder survives a 50-batch padded prefill burst (the exact wraparound scenario)
- [x] gsm8k accuracy matrix before/after on GLM-5.2-FP8 (tp16, 2-host v7x) and DeepSeek-R1-Distill-Qwen-1.5B (tp4, single host), c4 no-regression + high-concurrency recovery
- [x] Codeword-echo contamination probe (3 model families: dense bf16, FP8 MoE MLA, hybrid GDN) — zero anomalies after fix
- [x] Same-pod paired throughput A/B — neutral
- [x] pre-commit (isort/ruff/black/mypy) green on both commits

Notes for reviewers:
- Legacy EAGLE spec paths force `disable_overlap_schedule` (server_args check) and never consume the future map — unaffected. The NEXTN-overlap path shares the fused decode jit updated here; semantics are covered by the unit tests, and we'd appreciate a PD-side CI run to double-confirm.
- #1317 reports the same shape of failure (accuracy collapse scaling with decode batch size under overlap, hybrid/GLA models hit hardest, host-side bookkeeping clean). The Qwen3.5-0.8B GDN A/B above reproduces and fixes that signature; retesting Ling on this branch should allow closing #1317.

