### PR TITLE
feat(pd): support Raiden data-parallel transfer routing

### DIFF
--- a/python/sgl_jax/srt/disaggregation/base/transfer.py
+++ b/python/sgl_jax/srt/disaggregation/base/transfer.py
@@ -51,6 +51,7 @@ class PrefillTransferContext:
     req_id: str
     transfer_id: str
     bootstrap_room: int | None
+    dp_rank: int
     buffer_id: int | None
     payload_factory: Callable[[], dict[str, Any]]
     block_ids_factory: Callable[[], list[int]]
@@ -71,6 +72,8 @@ class DecodeTransferContext:
     req_id: str
     transfer_id: str
     bootstrap_room: int | None
+    local_dp_rank: int
+    source_dp_rank: int
     peer_info: Mapping[str, object]
     kv_indices: Any
     page_size: int
@@ -112,13 +115,14 @@ class TransferBackend(Protocol):
 
     def try_start_decode(self, context: DecodeTransferContext) -> DecodeAdmission: ...
 
-    def prefill_transport_metadata(self) -> dict[str, object]: ...
+    def prefill_transport_metadata(self, dp_rank: int = 0) -> dict[str, object]: ...
 
     def cleanup_transfer(
         self,
         bootstrap_room: int | None,
         *,
         jax_process_index: int | None = None,
+        source_dp_rank: int = 0,
     ) -> None: ...
 
     def inflight_count(self) -> tuple[int, int]: ...

--- a/python/sgl_jax/srt/disaggregation/base/transfer.py
+++ b/python/sgl_jax/srt/disaggregation/base/transfer.py
@@ -22,8 +22,7 @@ def slots_to_page_ids(slots: Any, page_size: int, token_count: int) -> tuple[int
     values = np.asarray(slots).reshape(-1)
     if values.size < token_count:
         raise ValueError(
-            f"KV slot count is smaller than token count: slots={values.size}, "
-            f"tokens={token_count}"
+            f"KV slot count is smaller than token count: slots={values.size}, tokens={token_count}"
         )
     values = values[:token_count].astype(np.int64, copy=False)
     pages: list[int] = []

--- a/python/sgl_jax/srt/disaggregation/base/transfer.py
+++ b/python/sgl_jax/srt/disaggregation/base/transfer.py
@@ -71,8 +71,8 @@ class DecodeTransferContext:
     req_id: str
     transfer_id: str
     bootstrap_room: int | None
-    local_dp_rank: int
-    source_dp_rank: int
+    decode_dp_rank: int
+    prefill_dp_rank: int
     peer_info: Mapping[str, object]
     kv_indices: Any
     page_size: int
@@ -121,7 +121,7 @@ class TransferBackend(Protocol):
         bootstrap_room: int | None,
         *,
         jax_process_index: int | None = None,
-        source_dp_rank: int = 0,
+        prefill_dp_rank: int = 0,
     ) -> None: ...
 
     def inflight_count(self) -> tuple[int, int]: ...

--- a/python/sgl_jax/srt/disaggregation/bootstrap.py
+++ b/python/sgl_jax/srt/disaggregation/bootstrap.py
@@ -871,13 +871,16 @@ class HeartbeatDaemon:
 
     def _loop(self) -> None:
         while not self._stop_event.is_set():
+            self._heartbeat_once()
+            self._stop_event.wait(self._interval_s)
+
+    def _heartbeat_once(self) -> None:
+        for bootstrap_key in self._bootstrap_keys:
             try:
-                for bootstrap_key in self._bootstrap_keys:
-                    self._client.heartbeat(bootstrap_key)
+                self._client.heartbeat(bootstrap_key)
             except Exception:
                 logger.warning(
                     "bootstrap heartbeat for %s failed; will retry",
-                    self._bootstrap_keys,
+                    bootstrap_key,
                     exc_info=True,
                 )
-            self._stop_event.wait(self._interval_s)

--- a/python/sgl_jax/srt/disaggregation/bootstrap.py
+++ b/python/sgl_jax/srt/disaggregation/bootstrap.py
@@ -26,7 +26,7 @@ BOOTSTRAP_CAPABILITIES = ("transfer_metadata",)
 
 # PD wire protocol version. Bump when ``PrefillInfo``
 # or any of the 4 endpoint payloads change shape.
-PROTOCOL_VERSION: int = 3
+PROTOCOL_VERSION: int = 4
 MIN_COMPATIBLE_VERSION: int = 1
 
 
@@ -106,6 +106,8 @@ def check_prefill_compat(
     local_page_size: int,
     local_kv_dtype: str,
     expected_transfer_engine: str | None = None,
+    expected_dp_rank: int | None = None,
+    expected_dp_size: int | None = None,
 ) -> None:
     """Raise ``ValueError`` if the prefill peer's KV layout is incompatible.
 
@@ -137,6 +139,19 @@ def check_prefill_compat(
         raise ValueError(
             f"PD transfer engine mismatch: prefill={peer_engine}, decode={expected_transfer_engine}"
         )
+    peer_dp_rank = int(info.get("system_dp_rank", 0))
+    if expected_dp_rank is not None and peer_dp_rank != expected_dp_rank:
+        raise ValueError(
+            f"PD source rank mismatch: prefill={peer_dp_rank}, expected={expected_dp_rank}"
+        )
+    peer_dp_size = int(
+        transport_metadata.get("dp_size", 1) if isinstance(transport_metadata, dict) else 1
+    )
+    if expected_dp_size is not None and peer_dp_size != expected_dp_size:
+        raise ValueError(
+            f"PD topology mismatch: prefill dp_size={peer_dp_size}, "
+            f"decode dp_size={expected_dp_size}"
+        )
 
 
 class RegisterPrefillRequest(BaseModel):
@@ -159,6 +174,7 @@ class RegisterTransferRequest(BaseModel):
     bootstrap_room: int
     transfer_id: str
     jax_process_index: int = 0
+    source_dp_rank: int = 0
     transport_metadata: dict[str, object]
 
 
@@ -180,8 +196,8 @@ class _Registry:
     ttl_seconds: float = HEARTBEAT_TTL_SECONDS
     clock: Callable[[], float] = time.monotonic
     # A multi-host request has distinct physical page IDs on every P process.
-    transfers: dict[tuple[int, int], dict[str, object]] = field(default_factory=dict)
-    transfer_last_seen: dict[tuple[int, int], float] = field(default_factory=dict)
+    transfers: dict[tuple[int, int, int], dict[str, object]] = field(default_factory=dict)
+    transfer_last_seen: dict[tuple[int, int, int], float] = field(default_factory=dict)
     transfer_ttl_seconds: float = TRANSFER_METADATA_TTL_SECONDS
 
     def now(self) -> float:
@@ -225,14 +241,19 @@ class _Registry:
             self._evict_stale_locked()
             return list(self.prefills.values())
 
-    def pick_for_room(self, bootstrap_room: int) -> PrefillInfo | None:
+    def pick_for_room(self, bootstrap_room: int, dp_rank: int = 0) -> PrefillInfo | None:
         with self.lock:
             self._evict_stale_locked()
-            if not self.prefills:
+            matching = {
+                key: info
+                for key, info in self.prefills.items()
+                if info.system_dp_rank == int(dp_rank)
+            }
+            if not matching:
                 return None
-            keys = sorted(self.prefills.keys())
+            keys = sorted(matching)
             chosen = keys[bootstrap_room % len(keys)]
-            return self.prefills[chosen]
+            return matching[chosen]
 
     def _evict_stale_transfers_locked(self) -> None:
         cutoff = self.now() - self.transfer_ttl_seconds
@@ -246,23 +267,34 @@ class _Registry:
             self._evict_stale_transfers_locked()
             room = int(info["bootstrap_room"])
             process_index = int(info.get("jax_process_index", 0))
+            source_dp_rank = int(info.get("source_dp_rank", 0))
             if not str(info.get("transfer_id", "")):
                 raise ValueError("transfer_id must be non-empty")
-            key = (room, process_index)
+            key = (room, process_index, source_dp_rank)
             self.transfers[key] = info
             self.transfer_last_seen[key] = self.now()
 
     def get_transfer(
-        self, bootstrap_room: int, jax_process_index: int = 0
+        self,
+        bootstrap_room: int,
+        jax_process_index: int = 0,
+        source_dp_rank: int = 0,
     ) -> dict[str, object] | None:
         with self.lock:
             self._evict_stale_transfers_locked()
-            info = self.transfers.get((int(bootstrap_room), int(jax_process_index)))
+            info = self.transfers.get(
+                (int(bootstrap_room), int(jax_process_index), int(source_dp_rank))
+            )
             return dict(info) if info is not None else None
 
-    def pop_room(self, bootstrap_room: int, jax_process_index: int = 0) -> None:
+    def pop_room(
+        self,
+        bootstrap_room: int,
+        jax_process_index: int = 0,
+        source_dp_rank: int = 0,
+    ) -> None:
         with self.lock:
-            key = (int(bootstrap_room), int(jax_process_index))
+            key = (int(bootstrap_room), int(jax_process_index), int(source_dp_rank))
             self.transfers.pop(key, None)
             self.transfer_last_seen.pop(key, None)
 
@@ -337,8 +369,8 @@ def build_app(
         return {"prefills": [p.to_dict() for p in registry.list_all()]}
 
     @app.get("/get_prefill_info")
-    def get_prefill_info(bootstrap_room: int) -> dict[str, object]:
-        info = registry.pick_for_room(bootstrap_room)
+    def get_prefill_info(bootstrap_room: int, dp_rank: int = 0) -> dict[str, object]:
+        info = registry.pick_for_room(bootstrap_room, dp_rank)
         if info is None:
             raise HTTPException(
                 status_code=503,
@@ -355,8 +387,12 @@ def build_app(
         return {"status": "registered"}
 
     @app.get("/get_transfer_info")
-    def get_transfer_info(bootstrap_room: int, jax_process_index: int = 0) -> dict[str, object]:
-        info = registry.get_transfer(bootstrap_room, jax_process_index)
+    def get_transfer_info(
+        bootstrap_room: int,
+        jax_process_index: int = 0,
+        source_dp_rank: int = 0,
+    ) -> dict[str, object]:
+        info = registry.get_transfer(bootstrap_room, jax_process_index, source_dp_rank)
         if info is None:
             # Not registered yet: 404 lets the decode side treat it as
             # "defer + retry" (never abort) rather than a hard error.
@@ -364,14 +400,19 @@ def build_app(
                 status_code=404,
                 detail=(
                     f"no transfer info for bootstrap_room={bootstrap_room}, "
-                    f"jax_process_index={jax_process_index}"
+                    f"jax_process_index={jax_process_index}, "
+                    f"source_dp_rank={source_dp_rank}"
                 ),
             )
         return info
 
     @app.post("/pop_transfer")
-    def pop_transfer(bootstrap_room: int, jax_process_index: int = 0) -> dict[str, str]:
-        registry.pop_room(bootstrap_room, jax_process_index)
+    def pop_transfer(
+        bootstrap_room: int,
+        jax_process_index: int = 0,
+        source_dp_rank: int = 0,
+    ) -> dict[str, str]:
+        registry.pop_room(bootstrap_room, jax_process_index, source_dp_rank)
         return {"status": "popped"}
 
     # Bootstrap runs as a standalone single process and does NOT inherit
@@ -614,10 +655,10 @@ class BootstrapClient:
         r.raise_for_status()
         return r.json()["prefills"]
 
-    def get_prefill_info(self, bootstrap_room: int) -> dict[str, object]:
+    def get_prefill_info(self, bootstrap_room: int, dp_rank: int = 0) -> dict[str, object]:
         r = self._client.get(
             f"{self._base_url}/get_prefill_info",
-            params={"bootstrap_room": bootstrap_room},
+            params={"bootstrap_room": bootstrap_room, "dp_rank": dp_rank},
             timeout=self._timeout_s,
             headers=self._headers(),
         )
@@ -633,12 +674,14 @@ class BootstrapClient:
         transfer_id: str,
         *,
         jax_process_index: int = 0,
+        source_dp_rank: int = 0,
         transport_metadata: dict[str, object],
     ) -> None:
         payload = {
             "bootstrap_room": bootstrap_room,
             "transfer_id": transfer_id,
             "jax_process_index": jax_process_index,
+            "source_dp_rank": source_dp_rank,
             "transport_metadata": transport_metadata,
         }
         r = self._client.post(
@@ -650,13 +693,18 @@ class BootstrapClient:
         r.raise_for_status()
 
     def get_transfer_info(
-        self, bootstrap_room: int, *, jax_process_index: int = 0
+        self,
+        bootstrap_room: int,
+        *,
+        jax_process_index: int = 0,
+        source_dp_rank: int = 0,
     ) -> dict[str, object] | None:
         r = self._client.get(
             f"{self._base_url}/get_transfer_info",
             params={
                 "bootstrap_room": bootstrap_room,
                 "jax_process_index": jax_process_index,
+                "source_dp_rank": source_dp_rank,
             },
             timeout=self._timeout_s,
             headers=self._headers(),
@@ -666,12 +714,19 @@ class BootstrapClient:
         r.raise_for_status()
         return r.json()
 
-    def pop_transfer(self, bootstrap_room: int, *, jax_process_index: int = 0) -> None:
+    def pop_transfer(
+        self,
+        bootstrap_room: int,
+        *,
+        jax_process_index: int = 0,
+        source_dp_rank: int = 0,
+    ) -> None:
         r = self._client.post(
             f"{self._base_url}/pop_transfer",
             params={
                 "bootstrap_room": bootstrap_room,
                 "jax_process_index": jax_process_index,
+                "source_dp_rank": source_dp_rank,
             },
             timeout=self._timeout_s,
             headers=self._headers(),
@@ -716,13 +771,18 @@ class PrefillInfoCache:
         self._sorted_keys = sorted(by_key)
         self._last_refresh = self._clock()
 
-    def _pick_locked(self, bootstrap_room: int) -> dict[str, object] | None:
-        if not self._sorted_keys:
+    def _pick_locked(self, bootstrap_room: int, dp_rank: int = 0) -> dict[str, object] | None:
+        keys = [
+            key
+            for key in self._sorted_keys
+            if int(self._by_key[key].get("system_dp_rank", 0)) == int(dp_rank)
+        ]
+        if not keys:
             return None
-        chosen = self._sorted_keys[bootstrap_room % len(self._sorted_keys)]
+        chosen = keys[bootstrap_room % len(keys)]
         return self._by_key[chosen]
 
-    def pick_for_room(self, bootstrap_room: int) -> dict[str, object] | None:
+    def pick_for_room(self, bootstrap_room: int, dp_rank: int = 0) -> dict[str, object] | None:
         """Return prefill info for ``bootstrap_room``, or ``None`` if no
         prefill is registered yet (caller should defer + retry).
 
@@ -758,7 +818,7 @@ class PrefillInfoCache:
                             len(self._sorted_keys),
                             exc,
                         )
-            info = self._pick_locked(bootstrap_room)
+            info = self._pick_locked(bootstrap_room, dp_rank)
         if info is None:
             return None
         _reject_if_below_protocol_floor(info)
@@ -774,11 +834,15 @@ class HeartbeatDaemon:
     def __init__(
         self,
         client: BootstrapClient,
-        bootstrap_key: str,
+        bootstrap_keys: str | list[str],
         interval_s: float = HEARTBEAT_INTERVAL_SECONDS,
     ) -> None:
         self._client = client
-        self._bootstrap_key = bootstrap_key
+        self._bootstrap_keys = (
+            [bootstrap_keys] if isinstance(bootstrap_keys, str) else list(bootstrap_keys)
+        )
+        if not self._bootstrap_keys:
+            raise ValueError("HeartbeatDaemon requires at least one bootstrap key")
         self._interval_s = interval_s
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
@@ -790,7 +854,7 @@ class HeartbeatDaemon:
         self._stop_event.clear()
         self._thread = threading.Thread(
             target=self._loop,
-            name=f"BootstrapHeartbeat-{self._bootstrap_key}",
+            name=f"BootstrapHeartbeat-{self._bootstrap_keys[0]}",
             daemon=True,
         )
         self._thread.start()
@@ -808,11 +872,12 @@ class HeartbeatDaemon:
     def _loop(self) -> None:
         while not self._stop_event.is_set():
             try:
-                self._client.heartbeat(self._bootstrap_key)
+                for bootstrap_key in self._bootstrap_keys:
+                    self._client.heartbeat(bootstrap_key)
             except Exception:
                 logger.warning(
                     "bootstrap heartbeat for %s failed; will retry",
-                    self._bootstrap_key,
+                    self._bootstrap_keys,
                     exc_info=True,
                 )
             self._stop_event.wait(self._interval_s)

--- a/python/sgl_jax/srt/disaggregation/bootstrap.py
+++ b/python/sgl_jax/srt/disaggregation/bootstrap.py
@@ -142,7 +142,7 @@ def check_prefill_compat(
     peer_dp_rank = int(info.get("system_dp_rank", 0))
     if expected_dp_rank is not None and peer_dp_rank != expected_dp_rank:
         raise ValueError(
-            f"PD source rank mismatch: prefill={peer_dp_rank}, expected={expected_dp_rank}"
+            f"PD Prefill rank mismatch: prefill={peer_dp_rank}, expected={expected_dp_rank}"
         )
     peer_dp_size = int(
         transport_metadata.get("dp_size", 1) if isinstance(transport_metadata, dict) else 1
@@ -174,7 +174,7 @@ class RegisterTransferRequest(BaseModel):
     bootstrap_room: int
     transfer_id: str
     jax_process_index: int = 0
-    source_dp_rank: int = 0
+    prefill_dp_rank: int = 0
     transport_metadata: dict[str, object]
 
 
@@ -267,10 +267,10 @@ class _Registry:
             self._evict_stale_transfers_locked()
             room = int(info["bootstrap_room"])
             process_index = int(info.get("jax_process_index", 0))
-            source_dp_rank = int(info.get("source_dp_rank", 0))
+            prefill_dp_rank = int(info.get("prefill_dp_rank", 0))
             if not str(info.get("transfer_id", "")):
                 raise ValueError("transfer_id must be non-empty")
-            key = (room, process_index, source_dp_rank)
+            key = (room, process_index, prefill_dp_rank)
             self.transfers[key] = info
             self.transfer_last_seen[key] = self.now()
 
@@ -278,12 +278,12 @@ class _Registry:
         self,
         bootstrap_room: int,
         jax_process_index: int = 0,
-        source_dp_rank: int = 0,
+        prefill_dp_rank: int = 0,
     ) -> dict[str, object] | None:
         with self.lock:
             self._evict_stale_transfers_locked()
             info = self.transfers.get(
-                (int(bootstrap_room), int(jax_process_index), int(source_dp_rank))
+                (int(bootstrap_room), int(jax_process_index), int(prefill_dp_rank))
             )
             return dict(info) if info is not None else None
 
@@ -291,10 +291,10 @@ class _Registry:
         self,
         bootstrap_room: int,
         jax_process_index: int = 0,
-        source_dp_rank: int = 0,
+        prefill_dp_rank: int = 0,
     ) -> None:
         with self.lock:
-            key = (int(bootstrap_room), int(jax_process_index), int(source_dp_rank))
+            key = (int(bootstrap_room), int(jax_process_index), int(prefill_dp_rank))
             self.transfers.pop(key, None)
             self.transfer_last_seen.pop(key, None)
 
@@ -390,9 +390,9 @@ def build_app(
     def get_transfer_info(
         bootstrap_room: int,
         jax_process_index: int = 0,
-        source_dp_rank: int = 0,
+        prefill_dp_rank: int = 0,
     ) -> dict[str, object]:
-        info = registry.get_transfer(bootstrap_room, jax_process_index, source_dp_rank)
+        info = registry.get_transfer(bootstrap_room, jax_process_index, prefill_dp_rank)
         if info is None:
             # Not registered yet: 404 lets the decode side treat it as
             # "defer + retry" (never abort) rather than a hard error.
@@ -401,7 +401,7 @@ def build_app(
                 detail=(
                     f"no transfer info for bootstrap_room={bootstrap_room}, "
                     f"jax_process_index={jax_process_index}, "
-                    f"source_dp_rank={source_dp_rank}"
+                    f"prefill_dp_rank={prefill_dp_rank}"
                 ),
             )
         return info
@@ -410,9 +410,9 @@ def build_app(
     def pop_transfer(
         bootstrap_room: int,
         jax_process_index: int = 0,
-        source_dp_rank: int = 0,
+        prefill_dp_rank: int = 0,
     ) -> dict[str, str]:
-        registry.pop_room(bootstrap_room, jax_process_index, source_dp_rank)
+        registry.pop_room(bootstrap_room, jax_process_index, prefill_dp_rank)
         return {"status": "popped"}
 
     # Bootstrap runs as a standalone single process and does NOT inherit
@@ -674,14 +674,14 @@ class BootstrapClient:
         transfer_id: str,
         *,
         jax_process_index: int = 0,
-        source_dp_rank: int = 0,
+        prefill_dp_rank: int = 0,
         transport_metadata: dict[str, object],
     ) -> None:
         payload = {
             "bootstrap_room": bootstrap_room,
             "transfer_id": transfer_id,
             "jax_process_index": jax_process_index,
-            "source_dp_rank": source_dp_rank,
+            "prefill_dp_rank": prefill_dp_rank,
             "transport_metadata": transport_metadata,
         }
         r = self._client.post(
@@ -697,14 +697,14 @@ class BootstrapClient:
         bootstrap_room: int,
         *,
         jax_process_index: int = 0,
-        source_dp_rank: int = 0,
+        prefill_dp_rank: int = 0,
     ) -> dict[str, object] | None:
         r = self._client.get(
             f"{self._base_url}/get_transfer_info",
             params={
                 "bootstrap_room": bootstrap_room,
                 "jax_process_index": jax_process_index,
-                "source_dp_rank": source_dp_rank,
+                "prefill_dp_rank": prefill_dp_rank,
             },
             timeout=self._timeout_s,
             headers=self._headers(),
@@ -719,14 +719,14 @@ class BootstrapClient:
         bootstrap_room: int,
         *,
         jax_process_index: int = 0,
-        source_dp_rank: int = 0,
+        prefill_dp_rank: int = 0,
     ) -> None:
         r = self._client.post(
             f"{self._base_url}/pop_transfer",
             params={
                 "bootstrap_room": bootstrap_room,
                 "jax_process_index": jax_process_index,
-                "source_dp_rank": source_dp_rank,
+                "prefill_dp_rank": prefill_dp_rank,
             },
             timeout=self._timeout_s,
             headers=self._headers(),

--- a/python/sgl_jax/srt/disaggregation/common/capacity.py
+++ b/python/sgl_jax/srt/disaggregation/common/capacity.py
@@ -1,0 +1,25 @@
+"""Capacity helpers shared by PD transfer backends and admission."""
+
+from __future__ import annotations
+
+
+def per_rank_inflight_limit(max_inflight: int, dp_size: int) -> int:
+    """Return the Raiden slot/admission limit for one DP rank.
+
+    ``max_inflight`` is the server-wide limit. Raiden uses one manager per DP
+    rank, so giving every manager the global value over-allocates transient
+    buffers by ``dp_size``. Divide the capacity evenly and round up so the
+    aggregate remains at least the configured global limit.
+
+    A non-positive global value retains the existing "unlimited" admission
+    sentinel. Raiden factory validation rejects that sentinel before manager
+    construction.
+    """
+
+    max_inflight = int(max_inflight)
+    dp_size = int(dp_size)
+    if dp_size <= 0:
+        raise ValueError(f"dp_size must be positive, got {dp_size}")
+    if max_inflight <= 0:
+        return max_inflight
+    return max(1, (max_inflight + dp_size - 1) // dp_size)

--- a/python/sgl_jax/srt/disaggregation/common/capacity.py
+++ b/python/sgl_jax/srt/disaggregation/common/capacity.py
@@ -1,20 +1,10 @@
-"""Capacity helpers shared by PD transfer backends and admission."""
+"""PD transfer capacity helpers."""
 
 from __future__ import annotations
 
 
 def per_rank_inflight_limit(max_inflight: int, dp_size: int) -> int:
-    """Return the Raiden slot/admission limit for one DP rank.
-
-    ``max_inflight`` is the server-wide limit. Raiden uses one manager per DP
-    rank, so giving every manager the global value over-allocates transient
-    buffers by ``dp_size``. Divide the capacity evenly and round up so the
-    aggregate remains at least the configured global limit.
-
-    A non-positive global value retains the existing "unlimited" admission
-    sentinel. Raiden factory validation rejects that sentinel before manager
-    construction.
-    """
+    """Split the global transfer budget across rank-local managers."""
 
     max_inflight = int(max_inflight)
     dp_size = int(dp_size)

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -389,7 +389,7 @@ class SchedulerDisaggregationDecodeMixin:
                     state = KVPoll.FAILED
             if entry.cancelled:
                 if entry.kv_indices is not None:
-                    self._release_decode_kv_indices(entry.kv_indices)
+                    self._release_decode_kv_indices(entry.kv_indices, entry.req.dp_rank)
                 continue
             if state == KVPoll.SUCCESS:
                 try:

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -21,6 +21,7 @@ from sgl_jax.srt.disaggregation.base.transfer import (
     TransferBackend,
 )
 from sgl_jax.srt.disaggregation.bootstrap import BootstrapClient, PrefillInfoCache
+from sgl_jax.srt.disaggregation.common.capacity import per_rank_inflight_limit
 from sgl_jax.srt.mem_cache.memory_pool import write_kv_layer
 
 if TYPE_CHECKING:
@@ -526,6 +527,7 @@ class SchedulerDisaggregationDecodeMixin:
         page_size = allocator.page_size
         reserved_per = self.server_args.disaggregation_num_reserved_decode_tokens
         max_inflight = self.server_args.disaggregation_max_inflight_transfers
+        per_rank_inflight = per_rank_inflight_limit(max_inflight, self.dp_size)
         n_transfer = len(self.disagg_transfer_queue)
         admitted = 0
         transfer_per_dp = [0] * self.dp_size
@@ -546,6 +548,15 @@ class SchedulerDisaggregationDecodeMixin:
             # and retry next tick (deferral, never abort).
             if max_inflight > 0 and (n_transfer + admitted) >= max_inflight:
                 break
+            # Each DP rank owns one Raiden manager and its own fixed slot pool.
+            # Skip a saturated rank while allowing later requests for other
+            # ranks to proceed, preventing cross-rank head-of-line blocking.
+            if (
+                per_rank_inflight > 0
+                and transfer_per_dp[local_dp_rank] + admitted_per_dp[local_dp_rank]
+                >= per_rank_inflight
+            ):
+                continue
             seqlen = len(entry.req.origin_input_ids)
             page_aligned = ((seqlen + page_size - 1) // page_size) * page_size
             n_running = _batch_req_count_for_dp(self.running_batch, local_dp_rank)

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -30,6 +30,43 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _batch_req_count(batch) -> int:
+    if batch is None:
+        return 0
+    reqs_info = getattr(batch, "reqs_info", None)
+    if reqs_info is None:
+        return len(getattr(batch, "reqs", ()) or ())
+    return sum(len(info.reqs) if info.reqs else 0 for info in reqs_info)
+
+
+def _batch_req_count_for_dp(batch, dp_rank: int) -> int:
+    if batch is None:
+        return 0
+    reqs_info = getattr(batch, "reqs_info", None)
+    if reqs_info is not None:
+        info = reqs_info[dp_rank]
+        return len(info.reqs) if info.reqs else 0
+    return sum(
+        1
+        for req in (getattr(batch, "reqs", ()) or ())
+        if (getattr(req, "dp_rank", None) if getattr(req, "dp_rank", None) is not None else 0)
+        == dp_rank
+    )
+
+
+def _request_dp_rank(req, dp_size: int, *, source: bool = False) -> int:
+    field = "disagg_prefill_dp_rank" if source else "dp_rank"
+    value = getattr(req, field, None)
+    if value is None:
+        if dp_size == 1:
+            return 0
+        raise ValueError(f"PD request {req.rid!r} is missing {field} for dp_size={dp_size}")
+    value = int(value)
+    if not 0 <= value < dp_size:
+        raise ValueError(f"PD request {req.rid!r} has {field}={value} outside [0, {dp_size})")
+    return value
+
+
 @dataclass
 class DecodeBookkeeping:
     """Per-request decode-side state."""
@@ -209,10 +246,13 @@ class SchedulerDisaggregationDecodeMixin:
         except Exception:
             ns, nr = (-1, -1)
         try:
-            kv_avail = self.token_to_kv_pool_allocator.available_size()
+            kv_avail = [
+                self.token_to_kv_pool_allocator.available_size(dp_rank)
+                for dp_rank in range(self.dp_size)
+            ]
         except Exception:
             kv_avail = -1
-        running = len(self.running_batch.reqs) if self.running_batch is not None else 0
+        running = _batch_req_count(self.running_batch)
         return (
             f"prealloc_q={prealloc} transfer_q={transfer} "
             f"inflight_send={ns} inflight_recv={nr} "
@@ -246,17 +286,20 @@ class SchedulerDisaggregationDecodeMixin:
             try:
                 from sgl_jax.srt.disaggregation.common.metrics import time_phase
 
+                source_dp_rank = _request_dp_rank(req, self.dp_size, source=True)
                 self._pd_mark_time(req, "bootstrap_start")
                 with time_phase("bootstrap", "decode"):
                     if jax.process_count() > 1:
                         # Multi-host caches the matched peer after the first
                         # lookup, so this does no per-request network I/O.
-                        p_info = self._pick_prefill_peer_for_this_host()
+                        p_info = self._pick_prefill_peer_for_this_host(source_dp_rank)
                     else:
                         # Local cache resolution (sglang-style): a warm cache
                         # does zero network I/O, so this no longer blocks the
                         # event loop.
-                        p_info = self.disagg_prefill_info_cache.pick_for_room(req.bootstrap_room)
+                        p_info = self.disagg_prefill_info_cache.pick_for_room(
+                            req.bootstrap_room, source_dp_rank
+                        )
                 self._pd_mark_time(req, "bootstrap_done")
             except Exception:
                 logger.exception(
@@ -289,6 +332,8 @@ class SchedulerDisaggregationDecodeMixin:
                     local_page_size=self.server_args.page_size,
                     local_kv_dtype=resolve_kv_dtype_name(local_kv_pool.dtype),
                     expected_transfer_engine=(None if manager is None else manager.engine_name),
+                    expected_dp_rank=source_dp_rank,
+                    expected_dp_size=self.dp_size,
                 )
             except ValueError as exc:
                 logger.error(
@@ -374,7 +419,7 @@ class SchedulerDisaggregationDecodeMixin:
                         entry.req_id,
                     )
                     if entry.kv_indices is not None:
-                        self._release_decode_kv_indices(entry.kv_indices)
+                        self._release_decode_kv_indices(entry.kv_indices, entry.req.dp_rank)
                     self._abort_decode_request(
                         entry.req,
                         "kv_writeback",
@@ -388,35 +433,42 @@ class SchedulerDisaggregationDecodeMixin:
                 )
                 self._record_decode_transfer_failure("receiver_terminal_failed")
                 if entry.kv_indices is not None:
-                    self._release_decode_kv_indices(entry.kv_indices)
+                    self._release_decode_kv_indices(entry.kv_indices, entry.req.dp_rank)
                 self._abort_decode_request(
                     entry.req,
                     "receiver_terminal_failed",
                     cleanup_transfer=False,
                 )
 
-    def _pick_prefill_peer_for_this_host(self: Scheduler) -> dict[str, object]:
+    def _pick_prefill_peer_for_this_host(self: Scheduler, dp_rank: int) -> dict[str, object]:
         """Multi-host: find the P host whose jax_process_index matches ours.
         That host's local KV shard is exactly the slice this D host needs.
         Requires P/D to have the same nproc (same-TP constraint).
         """
-        if getattr(self, "_disagg_prefill_peer", None) is not None:
-            return self._disagg_prefill_peer
+        peers = getattr(self, "_disagg_prefill_peers", None)
+        if peers is None:
+            peers = self._disagg_prefill_peers = {}
+        if dp_rank in peers:
+            return peers[dp_rank]
         my_pidx = jax.process_index()
         my_nproc = jax.process_count()
         all_p = self.disagg_bootstrap_client.list_prefills()
         for p in all_p:
-            if int(p.get("jax_process_index", -1)) == my_pidx:
+            if (
+                int(p.get("jax_process_index", -1)) == my_pidx
+                and int(p.get("system_dp_rank", 0)) == dp_rank
+            ):
                 if int(p.get("jax_process_count", 0)) != my_nproc:
                     raise RuntimeError(
                         f"P/D process_count mismatch: P={p.get('jax_process_count')} "
                         f"D={my_nproc}. Per-host shard transfer requires same nproc."
                     )
-                self._disagg_prefill_peer = p
+                peers[dp_rank] = p
                 return p
         raise RuntimeError(
-            f"no prefill host with jax_process_index={my_pidx} registered "
-            f"(got {[(p.get('host'), p.get('jax_process_index')) for p in all_p]})"
+            f"no prefill host with jax_process_index={my_pidx}, dp_rank={dp_rank} "
+            "registered (got "
+            f"{[(p.get('host'), p.get('jax_process_index'), p.get('system_dp_rank')) for p in all_p]})"
         )
 
     def _drain_transfer_queue_synced(self: Scheduler) -> list[DecodeBookkeeping]:
@@ -474,11 +526,18 @@ class SchedulerDisaggregationDecodeMixin:
         page_size = allocator.page_size
         reserved_per = self.server_args.disaggregation_num_reserved_decode_tokens
         max_inflight = self.server_args.disaggregation_max_inflight_transfers
-        n_running = len(self.running_batch.reqs) if self.running_batch is not None else 0
         n_transfer = len(self.disagg_transfer_queue)
         admitted = 0
+        transfer_per_dp = [0] * self.dp_size
+        with self.disagg_transfer_queue._lock:
+            for transfer_entry in self.disagg_transfer_queue._entries.values():
+                rank = _request_dp_rank(transfer_entry.req, self.dp_size)
+                transfer_per_dp[rank] += 1
+        admitted_per_dp = [0] * self.dp_size
 
         for entry in self.disagg_prealloc_queue.items_fifo():
+            local_dp_rank = _request_dp_rank(entry.req, self.dp_size)
+            source_dp_rank = _request_dp_rank(entry.req, self.dp_size, source=True)
             # In-flight transfer cap: each admitted transfer holds a pulled KV
             # destination buffer on decode HBM (untracked by the paged-pool
             # budget below) until it is scattered. Stop admitting once the cap
@@ -489,12 +548,15 @@ class SchedulerDisaggregationDecodeMixin:
                 break
             seqlen = len(entry.req.origin_input_ids)
             page_aligned = ((seqlen + page_size - 1) // page_size) * page_size
-            reserved = reserved_per * (n_running + n_transfer + admitted)
-            if page_aligned + reserved > allocator.available_size():
+            n_running = _batch_req_count_for_dp(self.running_batch, local_dp_rank)
+            reserved = reserved_per * (
+                n_running + transfer_per_dp[local_dp_rank] + admitted_per_dp[local_dp_rank]
+            )
+            if page_aligned + reserved > allocator.available_size(local_dp_rank):
                 # Insufficient capacity: defer this and all later (FIFO) reqs.
                 break
 
-            kv_indices = allocator.alloc(page_aligned)
+            kv_indices = allocator.alloc(page_aligned, dp_rank=local_dp_rank)
             if kv_indices is None:
                 # Budget check should prevent this; treat a surprise shortfall
                 # as transient and retry next tick rather than abort.
@@ -506,6 +568,8 @@ class SchedulerDisaggregationDecodeMixin:
                         req_id=entry.req.rid,
                         transfer_id=entry.req.disagg_transfer_id or entry.req.rid,
                         bootstrap_room=entry.req.bootstrap_room,
+                        local_dp_rank=local_dp_rank,
+                        source_dp_rank=source_dp_rank,
                         peer_info=entry.p_info or {},
                         kv_indices=kv_indices,
                         page_size=page_size,
@@ -522,13 +586,13 @@ class SchedulerDisaggregationDecodeMixin:
                     entry.req.rid,
                 )
                 self._record_decode_transfer_failure("receiver_init")
-                self._release_decode_kv_indices(kv_indices)
+                self._release_decode_kv_indices(kv_indices, local_dp_rank)
                 self.disagg_prealloc_queue.remove(entry.req_id)
                 self._abort_decode_request(entry.req, "receiver_init")
                 continue
 
             if admission.state == AdmissionState.DEFERRED:
-                self._release_decode_kv_indices(kv_indices)
+                self._release_decode_kv_indices(kv_indices, local_dp_rank)
                 timeout_s = self.server_args.disaggregation_pull_timeout_seconds
                 if timeout_s > 0 and time.monotonic() - entry.created_at >= timeout_s:
                     self.disagg_prealloc_queue.remove(entry.req_id)
@@ -547,6 +611,7 @@ class SchedulerDisaggregationDecodeMixin:
             self.disagg_prealloc_queue.remove(entry.req_id)
             self.disagg_transfer_queue.add(entry)
             admitted += 1
+            admitted_per_dp[local_dp_rank] += 1
 
     # ------------------------------------------------------------------
     # Overridable / test-friendly hooks
@@ -566,7 +631,7 @@ class SchedulerDisaggregationDecodeMixin:
             req.pd_time_stats = ts
         ts.mark(name)
 
-    def _release_decode_kv_indices(self: Scheduler, kv_indices) -> None:
+    def _release_decode_kv_indices(self: Scheduler, kv_indices, dp_rank: int | None) -> None:
         """Release KV indices back to the allocator."""
 
         if kv_indices is None:
@@ -574,7 +639,8 @@ class SchedulerDisaggregationDecodeMixin:
         allocator = self.token_to_kv_pool_allocator
         if allocator is not None:
             try:
-                allocator.free(kv_indices)
+                rank = 0 if dp_rank is None and self.dp_size == 1 else int(dp_rank)
+                allocator.free(kv_indices, dp_rank=rank)
             except Exception:
                 logger.exception("failed to free kv_indices=%r", kv_indices)
 
@@ -753,6 +819,7 @@ class SchedulerDisaggregationDecodeMixin:
                 manager.cleanup_transfer(
                     room,
                     jax_process_index=getattr(req, "disagg_peer_process_index", None),
+                    source_dp_rank=_request_dp_rank(req, self.dp_size, source=True),
                 )
         self._release_decode_req_resources(req)
         try:

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -150,6 +150,15 @@ class DecodeTransferQueue:
                 raise ValueError(f"DecodeTransferQueue already tracks req_id={entry.req_id!r}")
             self._entries[entry.req_id] = entry
 
+    def count_by_rank(self, dp_size: int) -> list[int]:
+        """Return an atomic snapshot of in-flight transfers per Decode rank."""
+
+        counts = [0] * dp_size
+        with self._lock:
+            for entry in self._entries.values():
+                counts[_request_dp_rank(entry.req, dp_size)] += 1
+        return counts
+
     def drain_terminal(self) -> list[DecodeBookkeeping]:
         """Return entries whose receiver reached SUCCESS or FAILED."""
 
@@ -530,12 +539,9 @@ class SchedulerDisaggregationDecodeMixin:
         per_rank_inflight = per_rank_inflight_limit(max_inflight, self.dp_size)
         n_transfer = len(self.disagg_transfer_queue)
         admitted = 0
-        transfer_per_dp = [0] * self.dp_size
-        with self.disagg_transfer_queue._lock:
-            for transfer_entry in self.disagg_transfer_queue._entries.values():
-                rank = _request_dp_rank(transfer_entry.req, self.dp_size)
-                transfer_per_dp[rank] += 1
+        transfer_per_dp = self.disagg_transfer_queue.count_by_rank(self.dp_size)
         admitted_per_dp = [0] * self.dp_size
+        capacity_blocked_ranks: set[int] = set()
 
         for entry in self.disagg_prealloc_queue.items_fifo():
             local_dp_rank = _request_dp_rank(entry.req, self.dp_size)
@@ -548,6 +554,11 @@ class SchedulerDisaggregationDecodeMixin:
             # and retry next tick (deferral, never abort).
             if max_inflight > 0 and (n_transfer + admitted) >= max_inflight:
                 break
+            # Once one request cannot fit a rank-local KV pool, retain FIFO
+            # within that rank for the rest of this admission pass. Other
+            # ranks remain independent and may continue making progress.
+            if local_dp_rank in capacity_blocked_ranks:
+                continue
             # Each DP rank owns one Raiden manager and its own fixed slot pool.
             # Skip a saturated rank while allowing later requests for other
             # ranks to proceed, preventing cross-rank head-of-line blocking.
@@ -564,14 +575,16 @@ class SchedulerDisaggregationDecodeMixin:
                 n_running + transfer_per_dp[local_dp_rank] + admitted_per_dp[local_dp_rank]
             )
             if page_aligned + reserved > allocator.available_size(local_dp_rank):
-                # Insufficient capacity: defer this and all later (FIFO) reqs.
-                break
+                capacity_blocked_ranks.add(local_dp_rank)
+                continue
 
             kv_indices = allocator.alloc(page_aligned, dp_rank=local_dp_rank)
             if kv_indices is None:
                 # Budget check should prevent this; treat a surprise shortfall
-                # as transient and retry next tick rather than abort.
-                break
+                # as transient. Block only this rank so other ranks can still
+                # make progress without violating rank-local FIFO.
+                capacity_blocked_ranks.add(local_dp_rank)
+                continue
 
             try:
                 admission = self.disagg_kv_manager.try_start_decode(
@@ -826,12 +839,35 @@ class SchedulerDisaggregationDecodeMixin:
         manager = getattr(self, "disagg_kv_manager", None)
         room = getattr(req, "bootstrap_room", None)
         if manager is not None and cleanup_transfer:
-            with suppress(Exception):
-                manager.cleanup_transfer(
+            try:
+                source_dp_rank = _request_dp_rank(req, self.dp_size, source=True)
+            except Exception:
+                logger.warning(
+                    "cannot resolve source DP rank while cleaning up aborted "
+                    "req_id=%s bootstrap_room=%s reason=%s; transfer metadata "
+                    "will expire by TTL",
+                    req.rid,
                     room,
-                    jax_process_index=getattr(req, "disagg_peer_process_index", None),
-                    source_dp_rank=_request_dp_rank(req, self.dp_size, source=True),
+                    reason,
+                    exc_info=True,
                 )
+            else:
+                try:
+                    manager.cleanup_transfer(
+                        room,
+                        jax_process_index=getattr(req, "disagg_peer_process_index", None),
+                        source_dp_rank=source_dp_rank,
+                    )
+                except Exception:
+                    logger.warning(
+                        "failed to clean up transfer metadata for req_id=%s "
+                        "bootstrap_room=%s source_dp_rank=%s reason=%s",
+                        req.rid,
+                        room,
+                        source_dp_rank,
+                        reason,
+                        exc_info=True,
+                    )
         self._release_decode_req_resources(req)
         try:
             from sgl_jax.srt.managers.io_struct import AbortReq

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -55,8 +55,8 @@ def _batch_req_count_for_dp(batch, dp_rank: int) -> int:
     )
 
 
-def _request_dp_rank(req, dp_size: int, *, source: bool = False) -> int:
-    field = "disagg_prefill_dp_rank" if source else "dp_rank"
+def _request_dp_rank(req, dp_size: int, *, prefill: bool = False) -> int:
+    field = "disagg_prefill_dp_rank" if prefill else "dp_rank"
     value = getattr(req, field, None)
     if value is None:
         if dp_size == 1:
@@ -151,8 +151,6 @@ class DecodeTransferQueue:
             self._entries[entry.req_id] = entry
 
     def count_by_rank(self, dp_size: int) -> list[int]:
-        """Return an atomic snapshot of in-flight transfers per Decode rank."""
-
         counts = [0] * dp_size
         with self._lock:
             for entry in self._entries.values():
@@ -296,19 +294,19 @@ class SchedulerDisaggregationDecodeMixin:
             try:
                 from sgl_jax.srt.disaggregation.common.metrics import time_phase
 
-                source_dp_rank = _request_dp_rank(req, self.dp_size, source=True)
+                prefill_dp_rank = _request_dp_rank(req, self.dp_size, prefill=True)
                 self._pd_mark_time(req, "bootstrap_start")
                 with time_phase("bootstrap", "decode"):
                     if jax.process_count() > 1:
                         # Multi-host caches the matched peer after the first
                         # lookup, so this does no per-request network I/O.
-                        p_info = self._pick_prefill_peer_for_this_host(source_dp_rank)
+                        p_info = self._pick_prefill_peer_for_this_host(prefill_dp_rank)
                     else:
                         # Local cache resolution (sglang-style): a warm cache
                         # does zero network I/O, so this no longer blocks the
                         # event loop.
                         p_info = self.disagg_prefill_info_cache.pick_for_room(
-                            req.bootstrap_room, source_dp_rank
+                            req.bootstrap_room, prefill_dp_rank
                         )
                 self._pd_mark_time(req, "bootstrap_done")
             except Exception:
@@ -342,7 +340,7 @@ class SchedulerDisaggregationDecodeMixin:
                     local_page_size=self.server_args.page_size,
                     local_kv_dtype=resolve_kv_dtype_name(local_kv_pool.dtype),
                     expected_transfer_engine=(None if manager is None else manager.engine_name),
-                    expected_dp_rank=source_dp_rank,
+                    expected_dp_rank=prefill_dp_rank,
                     expected_dp_size=self.dp_size,
                 )
             except ValueError as exc:
@@ -518,16 +516,7 @@ class SchedulerDisaggregationDecodeMixin:
         return out
 
     def _admit_decode_prealloc(self: Scheduler) -> None:
-        """Capacity-gated FIFO admission of preallocated PD reqs.
-
-        Pops reqs from the prealloc queue into the transfer queue only while
-        the paged pool has room, reserving ``num_reserved_decode_tokens`` of
-        headroom per in-flight/running request so a running decode step can
-        always alloc its next token even when every other req is mid-transfer
-        (transfer-queue reqs cannot be retracted). KV indices are allocated
-        here, not at intake. Reqs that don't fit stay queued and retry next
-        tick — deferral, never abort.
-        """
+        """Admit transfers without consuming non-retractable Decode headroom."""
 
         allocator = self.token_to_kv_pool_allocator
         if allocator is None:
@@ -544,46 +533,33 @@ class SchedulerDisaggregationDecodeMixin:
         capacity_blocked_ranks: set[int] = set()
 
         for entry in self.disagg_prealloc_queue.items_fifo():
-            local_dp_rank = _request_dp_rank(entry.req, self.dp_size)
-            source_dp_rank = _request_dp_rank(entry.req, self.dp_size, source=True)
-            # In-flight transfer cap: each admitted transfer holds a pulled KV
-            # destination buffer on decode HBM (untracked by the paged-pool
-            # budget below) until it is scattered. Stop admitting once the cap
-            # is reached so a burst of concurrent requests cannot allocate that
-            # many transient buffers at once and OOM. Excess reqs stay queued
-            # and retry next tick (deferral, never abort).
+            decode_dp_rank = _request_dp_rank(entry.req, self.dp_size)
+            prefill_dp_rank = _request_dp_rank(entry.req, self.dp_size, prefill=True)
+            # Pulled KV buffers remain outside paged-pool accounting until scatter.
             if max_inflight > 0 and (n_transfer + admitted) >= max_inflight:
                 break
-            # Once one request cannot fit a rank-local KV pool, retain FIFO
-            # within that rank for the rest of this admission pass. Other
-            # ranks remain independent and may continue making progress.
-            if local_dp_rank in capacity_blocked_ranks:
+            # Preserve FIFO within a blocked rank without stalling other ranks.
+            if decode_dp_rank in capacity_blocked_ranks:
                 continue
-            # Each DP rank owns one Raiden manager and its own fixed slot pool.
-            # Skip a saturated rank while allowing later requests for other
-            # ranks to proceed, preventing cross-rank head-of-line blocking.
             if (
                 per_rank_inflight > 0
-                and transfer_per_dp[local_dp_rank] + admitted_per_dp[local_dp_rank]
+                and transfer_per_dp[decode_dp_rank] + admitted_per_dp[decode_dp_rank]
                 >= per_rank_inflight
             ):
                 continue
             seqlen = len(entry.req.origin_input_ids)
             page_aligned = ((seqlen + page_size - 1) // page_size) * page_size
-            n_running = _batch_req_count_for_dp(self.running_batch, local_dp_rank)
+            n_running = _batch_req_count_for_dp(self.running_batch, decode_dp_rank)
             reserved = reserved_per * (
-                n_running + transfer_per_dp[local_dp_rank] + admitted_per_dp[local_dp_rank]
+                n_running + transfer_per_dp[decode_dp_rank] + admitted_per_dp[decode_dp_rank]
             )
-            if page_aligned + reserved > allocator.available_size(local_dp_rank):
-                capacity_blocked_ranks.add(local_dp_rank)
+            if page_aligned + reserved > allocator.available_size(decode_dp_rank):
+                capacity_blocked_ranks.add(decode_dp_rank)
                 continue
 
-            kv_indices = allocator.alloc(page_aligned, dp_rank=local_dp_rank)
+            kv_indices = allocator.alloc(page_aligned, dp_rank=decode_dp_rank)
             if kv_indices is None:
-                # Budget check should prevent this; treat a surprise shortfall
-                # as transient. Block only this rank so other ranks can still
-                # make progress without violating rank-local FIFO.
-                capacity_blocked_ranks.add(local_dp_rank)
+                capacity_blocked_ranks.add(decode_dp_rank)
                 continue
 
             try:
@@ -592,8 +568,8 @@ class SchedulerDisaggregationDecodeMixin:
                         req_id=entry.req.rid,
                         transfer_id=entry.req.disagg_transfer_id or entry.req.rid,
                         bootstrap_room=entry.req.bootstrap_room,
-                        local_dp_rank=local_dp_rank,
-                        source_dp_rank=source_dp_rank,
+                        decode_dp_rank=decode_dp_rank,
+                        prefill_dp_rank=prefill_dp_rank,
                         peer_info=entry.p_info or {},
                         kv_indices=kv_indices,
                         page_size=page_size,
@@ -610,13 +586,13 @@ class SchedulerDisaggregationDecodeMixin:
                     entry.req.rid,
                 )
                 self._record_decode_transfer_failure("receiver_init")
-                self._release_decode_kv_indices(kv_indices, local_dp_rank)
+                self._release_decode_kv_indices(kv_indices, decode_dp_rank)
                 self.disagg_prealloc_queue.remove(entry.req_id)
                 self._abort_decode_request(entry.req, "receiver_init")
                 continue
 
             if admission.state == AdmissionState.DEFERRED:
-                self._release_decode_kv_indices(kv_indices, local_dp_rank)
+                self._release_decode_kv_indices(kv_indices, decode_dp_rank)
                 timeout_s = self.server_args.disaggregation_pull_timeout_seconds
                 if timeout_s > 0 and time.monotonic() - entry.created_at >= timeout_s:
                     self.disagg_prealloc_queue.remove(entry.req_id)
@@ -635,7 +611,7 @@ class SchedulerDisaggregationDecodeMixin:
             self.disagg_prealloc_queue.remove(entry.req_id)
             self.disagg_transfer_queue.add(entry)
             admitted += 1
-            admitted_per_dp[local_dp_rank] += 1
+            admitted_per_dp[decode_dp_rank] += 1
 
     # ------------------------------------------------------------------
     # Overridable / test-friendly hooks
@@ -840,10 +816,10 @@ class SchedulerDisaggregationDecodeMixin:
         room = getattr(req, "bootstrap_room", None)
         if manager is not None and cleanup_transfer:
             try:
-                source_dp_rank = _request_dp_rank(req, self.dp_size, source=True)
+                prefill_dp_rank = _request_dp_rank(req, self.dp_size, prefill=True)
             except Exception:
                 logger.warning(
-                    "cannot resolve source DP rank while cleaning up aborted "
+                    "cannot resolve Prefill DP rank while cleaning up aborted "
                     "req_id=%s bootstrap_room=%s reason=%s; transfer metadata "
                     "will expire by TTL",
                     req.rid,
@@ -856,15 +832,15 @@ class SchedulerDisaggregationDecodeMixin:
                     manager.cleanup_transfer(
                         room,
                         jax_process_index=getattr(req, "disagg_peer_process_index", None),
-                        source_dp_rank=source_dp_rank,
+                        prefill_dp_rank=prefill_dp_rank,
                     )
                 except Exception:
                     logger.warning(
                         "failed to clean up transfer metadata for req_id=%s "
-                        "bootstrap_room=%s source_dp_rank=%s reason=%s",
+                        "bootstrap_room=%s prefill_dp_rank=%s reason=%s",
                         req.rid,
                         room,
-                        source_dp_rank,
+                        prefill_dp_rank,
                         reason,
                         exc_info=True,
                     )

--- a/python/sgl_jax/srt/disaggregation/factory.py
+++ b/python/sgl_jax/srt/disaggregation/factory.py
@@ -145,13 +145,15 @@ def _create_raiden_backend(
         kv_caches=list(kv_pool.kv_buffer),
         max_blocks=max_blocks,
         num_slots=num_slots,
+        dp_size=server_args.dp_size,
         timeout_s=float(server_args.disaggregation_pull_timeout_seconds),
     )
     logger.info(
-        "Raiden backend ready: max_blocks=%d num_slots=%d layers=%d",
+        "Raiden backend ready: max_blocks=%d num_slots=%d layers=%d dp_size=%d",
         max_blocks,
         num_slots,
         kv_pool.layer_num,
+        server_args.dp_size,
     )
     return RaidenTransferKVManager(
         wrapper,

--- a/python/sgl_jax/srt/disaggregation/factory.py
+++ b/python/sgl_jax/srt/disaggregation/factory.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from sgl_jax.srt.disaggregation.common.capacity import per_rank_inflight_limit
+
 if TYPE_CHECKING:
     from sgl_jax.srt.disaggregation.base.transfer import TransferBackend
     from sgl_jax.srt.managers.scheduler import Scheduler
@@ -140,7 +142,10 @@ def _create_raiden_backend(
     )
     page_size = max(1, int(server_args.page_size))
     max_blocks = (int(scheduler.max_req_input_len) + page_size - 1) // page_size
-    num_slots = int(server_args.disaggregation_max_inflight_transfers)
+    num_slots = per_rank_inflight_limit(
+        server_args.disaggregation_max_inflight_transfers,
+        server_args.dp_size,
+    )
     wrapper.start(
         kv_caches=list(kv_pool.kv_buffer),
         max_blocks=max_blocks,
@@ -149,7 +154,7 @@ def _create_raiden_backend(
         timeout_s=float(server_args.disaggregation_pull_timeout_seconds),
     )
     logger.info(
-        "Raiden backend ready: max_blocks=%d num_slots=%d layers=%d dp_size=%d",
+        "Raiden backend ready: max_blocks=%d slots_per_rank=%d layers=%d dp_size=%d",
         max_blocks,
         num_slots,
         kv_pool.layer_num,

--- a/python/sgl_jax/srt/disaggregation/jax_transfer/conn.py
+++ b/python/sgl_jax/srt/disaggregation/jax_transfer/conn.py
@@ -199,7 +199,7 @@ class JaxTransferKVManager(CommonKVManager):
     def prepare_prefill_batch(self, kv_buffers: Any) -> None:  # noqa: ARG002
         return
 
-    def prefill_transport_metadata(self) -> dict[str, object]:
+    def prefill_transport_metadata(self, dp_rank: int = 0) -> dict[str, object]:  # noqa: ARG002
         return {"engine": self.engine_name}
 
     def start_prefill(self, context: PrefillTransferContext) -> PrefillTransfer:
@@ -254,6 +254,7 @@ class JaxTransferKVManager(CommonKVManager):
         bootstrap_room: int | None,
         *,
         jax_process_index: int | None = None,  # noqa: ARG002
+        source_dp_rank: int = 0,  # noqa: ARG002
     ) -> None:  # noqa: ARG002
         return
 

--- a/python/sgl_jax/srt/disaggregation/jax_transfer/conn.py
+++ b/python/sgl_jax/srt/disaggregation/jax_transfer/conn.py
@@ -196,10 +196,12 @@ class JaxTransferKVManager(CommonKVManager):
             raise RuntimeError("host KV pool is full")
         return buffer_id
 
-    def prepare_prefill_batch(self, kv_buffers: Any) -> None:  # noqa: ARG002
+    def prepare_prefill_batch(self, kv_buffers: Any) -> None:
+        del kv_buffers
         return
 
-    def prefill_transport_metadata(self, dp_rank: int = 0) -> dict[str, object]:  # noqa: ARG002
+    def prefill_transport_metadata(self, dp_rank: int = 0) -> dict[str, object]:
+        del dp_rank
         return {"engine": self.engine_name}
 
     def start_prefill(self, context: PrefillTransferContext) -> PrefillTransfer:
@@ -253,9 +255,10 @@ class JaxTransferKVManager(CommonKVManager):
         self,
         bootstrap_room: int | None,
         *,
-        jax_process_index: int | None = None,  # noqa: ARG002
-        source_dp_rank: int = 0,  # noqa: ARG002
-    ) -> None:  # noqa: ARG002
+        jax_process_index: int | None = None,
+        prefill_dp_rank: int = 0,
+    ) -> None:
+        del bootstrap_room, jax_process_index, prefill_dp_rank
         return
 
     # ------------------------------------------------------------------
@@ -379,7 +382,8 @@ class JaxTransferKVSender(KVSender, StateHolder):
     def transfer_started_at(self) -> float | None:
         return self._transfer_started_at
 
-    def init(self, kv_indices, transfer_id: str | None = None) -> None:  # noqa: ARG002
+    def init(self, kv_indices, transfer_id: str | None = None) -> None:
+        del kv_indices
         with self._state_lock:
             self._transfer_id = transfer_id or self._req_id
             self._transition_to(KVPoll.WAITING_FOR_INPUT)

--- a/python/sgl_jax/srt/disaggregation/mini_lb.py
+++ b/python/sgl_jax/srt/disaggregation/mini_lb.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import random
 from http import HTTPStatus
 from itertools import chain
@@ -9,6 +10,13 @@ from itertools import chain
 logger = logging.getLogger(__name__)
 
 AIOHTTP_STREAM_READ_CHUNK_SIZE = 1024 * 64
+
+
+def _get_dp_size(server_info: dict) -> int:
+    dp_size = server_info.get("dp_size")
+    if dp_size is not None:
+        return int(dp_size)
+    return max(1, len(server_info.get("internal_states") or []))
 
 
 class MiniLoadBalancer:
@@ -63,8 +71,8 @@ class MiniLoadBalancer:
                 self.decode_urls[0],
                 ("get_server_info", "server_info"),
             )
-        self.prefill_dp_size = len(prefill_info.get("internal_states", [1]))
-        self.decode_dp_size = len(decode_info.get("internal_states", [1]))
+        self.prefill_dp_size = _get_dp_size(prefill_info)
+        self.decode_dp_size = _get_dp_size(decode_info)
         logger.info(
             "[MiniLB] DP sizes: prefill=%s, decode=%s",
             self.prefill_dp_size,
@@ -72,16 +80,54 @@ class MiniLoadBalancer:
         )
 
     def _fork_dp_requests(self, request: dict):
+        if self.prefill_dp_size != self.decode_dp_size:
+            raise RuntimeError(
+                "PD Raiden requires homogeneous DP topology: "
+                f"prefill dp_size={self.prefill_dp_size}, "
+                f"decode dp_size={self.decode_dp_size}"
+            )
         p_rank = random.randint(0, self.prefill_dp_size - 1)
         d_rank = random.randint(0, self.decode_dp_size - 1)
 
         prefill_req = request.copy()
         decode_req = request.copy()
-        prefill_req["routed_dp_rank"] = p_rank
-        decode_req["routed_dp_rank"] = d_rank
+        prefill_req["dp_rank"] = p_rank
+        decode_req["dp_rank"] = d_rank
         decode_req["disagg_prefill_dp_rank"] = p_rank
 
         return prefill_req, decode_req, d_rank
+
+    @staticmethod
+    def _room_rank(bootstrap_room, dp_size: int):
+        if isinstance(bootstrap_room, list):
+            return [int(room) % dp_size for room in bootstrap_room]
+        return int(bootstrap_room) % dp_size
+
+    async def _align_dp_requests(self, request: dict):
+        await self._ensure_dp_sizes()
+        p_size = int(self.prefill_dp_size or 1)
+        d_size = int(self.decode_dp_size or 1)
+        if p_size != d_size:
+            raise RuntimeError(
+                "PD Raiden requires homogeneous DP topology: "
+                f"prefill dp_size={p_size}, decode dp_size={d_size}"
+            )
+
+        forced_rank = os.getenv("SGLANG_JAX_PD_FORCE_DP_RANK")
+        if forced_rank is not None:
+            forced = int(forced_rank)
+            if not 0 <= forced < p_size:
+                raise ValueError(f"SGLANG_JAX_PD_FORCE_DP_RANK={forced} is outside [0, {p_size})")
+            dp_rank = forced
+        else:
+            dp_rank = self._room_rank(request["bootstrap_room"], p_size)
+
+        prefill_req = request.copy()
+        decode_req = request.copy()
+        prefill_req["dp_rank"] = dp_rank
+        decode_req["dp_rank"] = dp_rank
+        decode_req["disagg_prefill_dp_rank"] = dp_rank
+        return prefill_req, decode_req
 
     def select_pair(self) -> tuple[str, int | None, str]:
         pidx = random.randint(0, len(self.prefill_urls) - 1)
@@ -113,8 +159,7 @@ class MiniLoadBalancer:
                 expected_decode_dp_rank,
             ) = self._fork_dp_requests(modified_request)
         else:
-            prefill_req = modified_request
-            decode_req = modified_request
+            prefill_req, decode_req = await self._align_dp_requests(modified_request)
 
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=self.timeout)
@@ -176,13 +221,15 @@ class MiniLoadBalancer:
 
         assert endpoint[0] != "/", f"Endpoint should not start with '/': {endpoint}"
 
+        prefill_req, decode_req = await self._align_dp_requests(modified_request)
+
         async def stream_results():
             async with aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=self.timeout)
             ) as session:
                 tasks = [
-                    session.post(f"{prefill_server}/{endpoint}", json=modified_request),
-                    session.post(f"{decode_server}/{endpoint}", json=modified_request),
+                    session.post(f"{prefill_server}/{endpoint}", json=prefill_req),
+                    session.post(f"{decode_server}/{endpoint}", json=decode_req),
                 ]
                 prefill_response, decode_response = await asyncio.gather(*tasks)
 

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -26,6 +26,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _batch_reqs(batch) -> tuple[Req, ...]:
+    if batch is None:
+        return ()
+    reqs_info = getattr(batch, "reqs_info", None)
+    if reqs_info is None:
+        return tuple(getattr(batch, "reqs", ()) or ())
+    return tuple(req for info in reqs_info for req in (info.reqs or ()))
+
+
 # Bucket page counts to bound XLA's per-shape compile pool.
 # Largest bucket (512 pages × 128 tokens/page) covers 64k-token prompts.
 _KV_GATHER_PAGE_BUCKETS = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512)
@@ -202,7 +211,8 @@ class SchedulerDisaggregationPrefillMixin:
             self.cur_batch = batch
 
             if batch:
-                for req in batch.reqs:
+                batch_reqs = _batch_reqs(batch)
+                for req in batch_reqs:
                     if req.bootstrap_room is not None:
                         self._pd_mark_time(req, "forward_start")
                 result = self.run_batch(batch)
@@ -216,14 +226,16 @@ class SchedulerDisaggregationPrefillMixin:
             self.send_kv_chunk()
             # PD reqs are finished and released inside process_prefill_chunk;
             # do not merge them into running_batch.
+            batch_reqs = _batch_reqs(batch)
             self.last_batch = (
-                None if batch and any(r.bootstrap_room is not None for r in batch.reqs) else batch
+                None if batch and any(r.bootstrap_room is not None for r in batch_reqs) else batch
             )
 
     def process_prefill_chunk(self: Scheduler, batch, result) -> None:
         """Extract KV for PD reqs and hand off to sender."""
 
-        pd_reqs = [req for req in batch.reqs if req.bootstrap_room is not None]
+        batch_reqs = _batch_reqs(batch)
+        pd_reqs = [req for req in batch_reqs if req.bootstrap_room is not None]
         if not pd_reqs:
             self.process_batch_result(batch, result)
             return
@@ -243,7 +255,7 @@ class SchedulerDisaggregationPrefillMixin:
         if ready_to_transfer:
             kv_pool = self.token_to_kv_pool_allocator.get_kvcache()
             self.disagg_kv_manager.prepare_prefill_batch(kv_pool.kv_buffer)
-        for req in batch.reqs:
+        for req in batch_reqs:
             if req.bootstrap_room is None:
                 continue
             req_id = req.rid
@@ -267,6 +279,7 @@ class SchedulerDisaggregationPrefillMixin:
                         req_id=req_id,
                         transfer_id=req.disagg_transfer_id or req_id,
                         bootstrap_room=req.bootstrap_room,
+                        dp_rank=int(req.dp_rank),
                         buffer_id=req.disagg_host_buffer_id,
                         payload_factory=lambda req_obj=req: {"kv": self._extract_req_kv(req_obj)},
                         block_ids_factory=lambda req_obj=req: self._extract_req_block_ids(req_obj),

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -283,10 +283,12 @@ class SchedulerDisaggregationPrefillMixin:
                         buffer_id=req.disagg_host_buffer_id,
                         payload_factory=lambda req_obj=req: {"kv": self._extract_req_kv(req_obj)},
                         block_ids_factory=lambda req_obj=req: self._extract_req_block_ids(req_obj),
-                        on_payload=lambda payload, req_obj=req: self._maybe_log_prefill_extract_debug(
-                            req_obj,
-                            payload["kv"],
-                            use_d2h_staging=self.disagg_use_d2h_staging,
+                        on_payload=lambda payload, req_obj=req: (
+                            self._maybe_log_prefill_extract_debug(
+                                req_obj,
+                                payload["kv"],
+                                use_d2h_staging=self.disagg_use_d2h_staging,
+                            )
                         ),
                         on_ready=lambda req_obj=req: self._pd_mark_time(req_obj, "transfer_start"),
                     )

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -57,12 +57,7 @@ def _globalize_rank_local_page_ids(
     dp_size: int,
     total_pages: int,
 ):
-    """Map allocator-local page IDs onto the global data-sharded page axis.
-
-    Every DP shard owns a leading padding page at local ID 0, followed by its
-    independently allocated pages. The global KV buffer concatenates those
-    equally sized shards along the page axis.
-    """
+    """Preserve each DP shard's padding page when indexing the global page axis."""
 
     import numpy as np
 
@@ -439,7 +434,7 @@ class SchedulerDisaggregationPrefillMixin:
         )
         idx_sharding = _NamedSharding(kv_pool.mesh, _P(None))
         page_indices = jax.device_put(page_ids, idx_sharding)
-        # out_sharding describes the gather output, not the pool.
+        # Page indices are replicated; preserve pool sharding on the remaining axes.
         pool_pspec = kv_pool.kv_sharding.spec
         gather_pspec = _P(None, *pool_pspec[1:])
         gather_out_sharding = _NamedSharding(kv_pool.mesh, gather_pspec)

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -50,6 +50,42 @@ def _pad_to_page_bucket(num_pages: int) -> int:
     return ((num_pages + largest - 1) // largest) * largest
 
 
+def _globalize_rank_local_page_ids(
+    page_ids,
+    *,
+    dp_rank: int,
+    dp_size: int,
+    total_pages: int,
+):
+    """Map allocator-local page IDs onto the global data-sharded page axis.
+
+    Every DP shard owns a leading padding page at local ID 0, followed by its
+    independently allocated pages. The global KV buffer concatenates those
+    equally sized shards along the page axis.
+    """
+
+    import numpy as np
+
+    ids = np.asarray(page_ids)
+    dp_rank = int(dp_rank)
+    dp_size = int(dp_size)
+    total_pages = int(total_pages)
+    if dp_size <= 0:
+        raise ValueError(f"dp_size must be positive, got {dp_size}")
+    if not 0 <= dp_rank < dp_size:
+        raise ValueError(f"dp_rank={dp_rank} is outside [0, {dp_size})")
+    if total_pages <= 0 or total_pages % dp_size:
+        raise ValueError(
+            f"global KV page count {total_pages} is not divisible by dp_size={dp_size}"
+        )
+    pages_per_rank = total_pages // dp_size
+    if np.any(ids < 0) or np.any(ids >= pages_per_rank):
+        raise ValueError(
+            f"rank-local KV page IDs must be in [0, {pages_per_rank}); got {ids.tolist()}"
+        )
+    return ids + dp_rank * pages_per_rank
+
+
 @partial(jax.jit, static_argnames=("out_sharding",))
 def _jit_gather_one_layer(buf, page_indices, out_sharding):
     """Gather ``page_indices`` from a single per-layer KV buffer.
@@ -386,12 +422,6 @@ class SchedulerDisaggregationPrefillMixin:
             page_ids = _np.concatenate(
                 [page_ids, _np.zeros(padded_pages - num_pages, dtype=page_ids.dtype)]
             )
-        idx_sharding = _NamedSharding(kv_pool.mesh, _P(None))
-        page_indices = jax.device_put(page_ids, idx_sharding)
-        # out_sharding describes the gather output, not the pool.
-        pool_pspec = kv_pool.kv_sharding.spec
-        gather_pspec = _P(None, *pool_pspec[1:])
-        gather_out_sharding = _NamedSharding(kv_pool.mesh, gather_pspec)
         layer_buffers = [
             kv_pool.get_kv_buffer(layer_id)
             for layer_id in range(
@@ -399,6 +429,20 @@ class SchedulerDisaggregationPrefillMixin:
                 kv_pool.start_layer + kv_pool.layer_num,
             )
         ]
+        if not layer_buffers:
+            raise ValueError("cannot gather debug KV from an empty layer range")
+        page_ids = _globalize_rank_local_page_ids(
+            page_ids,
+            dp_rank=int(getattr(req, "dp_rank", 0) or 0),
+            dp_size=int(getattr(kv_pool, "dp_size", 1)),
+            total_pages=int(layer_buffers[0].shape[0]),
+        )
+        idx_sharding = _NamedSharding(kv_pool.mesh, _P(None))
+        page_indices = jax.device_put(page_ids, idx_sharding)
+        # out_sharding describes the gather output, not the pool.
+        pool_pspec = kv_pool.kv_sharding.spec
+        gather_pspec = _P(None, *pool_pspec[1:])
+        gather_out_sharding = _NamedSharding(kv_pool.mesh, gather_pspec)
         layer_kvs = _jit_gather_all_layers(layer_buffers, page_indices, gather_out_sharding)
         if jax.process_count() > 1:
             # Multi-host: expose only this host's TP shard as a fully-addressable

--- a/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
+++ b/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
@@ -135,6 +135,8 @@ class RaidenMetadata:
     local_block_ids: tuple[int, ...]
     bootstrap_room: int | None
     jax_process_index: int = 0
+    source_dp_rank: int = 0
+    local_dp_rank: int = 0
     direct_commit: Callable[[Mapping[str, object] | None], None] | None = None
     expected_debug: Mapping[str, object] | None = None
 
@@ -173,15 +175,23 @@ class RaidenTransferKVManager(CommonKVManager):
         # serving layer must finish the donated KV writes before registration.
         jax.block_until_ready(kv_buffers)
 
-    def prefill_transport_metadata(self) -> dict[str, object]:
-        endpoints = list(self.wrapper.endpoints or [])
-        control_port = self.wrapper.control_port
-        if endpoints:
-            control_port = int(str(endpoints[0]["endpoint"]).rsplit(":", 1)[1])
+    def prefill_transport_metadata(self, dp_rank: int = 0) -> dict[str, object]:
+        try:
+            endpoints = self.wrapper.endpoints_by_dp_rank[int(dp_rank)]
+        except KeyError as exc:
+            raise ValueError(
+                f"Raiden has no endpoints for dp_rank={dp_rank}; "
+                f"available={sorted(self.wrapper.endpoints_by_dp_rank)}"
+            ) from exc
+        if not endpoints:
+            raise RuntimeError(f"Raiden did not publish endpoints for dp_rank={dp_rank}")
+        control_port = int(str(endpoints[0]["endpoint"]).rsplit(":", 1)[1])
         if not 0 < control_port <= 65535:
             raise RuntimeError("Raiden did not publish a valid control endpoint")
         return {
             "engine": self.engine_name,
+            "dp_rank": int(dp_rank),
+            "dp_size": self.wrapper.dp_size,
             "local_control_port": control_port,
             "endpoints": endpoints,
         }
@@ -194,6 +204,7 @@ class RaidenTransferKVManager(CommonKVManager):
             sender.attach_block_ids(
                 block_ids,
                 bootstrap_room=context.bootstrap_room,
+                dp_rank=context.dp_rank,
             )
             from sgl_jax.srt.disaggregation.debug_utils import kv_debug_enabled
 
@@ -221,6 +232,7 @@ class RaidenTransferKVManager(CommonKVManager):
             info = self.bootstrap_client.get_transfer_info(
                 context.bootstrap_room,
                 jax_process_index=peer_process_index,
+                source_dp_rank=context.source_dp_rank,
             )
         except Exception as exc:  # transient bootstrap failure
             logger.warning(
@@ -239,6 +251,12 @@ class RaidenTransferKVManager(CommonKVManager):
                     "Raiden transfer ID mismatch: "
                     f"expected={context.transfer_id!r}, got={info.get('transfer_id')!r}"
                 )
+            published_source_rank = int(info.get("source_dp_rank", 0))
+            if published_source_rank != context.source_dp_rank:
+                raise ValueError(
+                    "Raiden transfer source rank mismatch: "
+                    f"expected={context.source_dp_rank}, got={published_source_rank}"
+                )
             metadata = info.get("transport_metadata", info)
             if not isinstance(metadata, dict):
                 raise TypeError("Raiden request transport_metadata must be a mapping")
@@ -255,12 +273,33 @@ class RaidenTransferKVManager(CommonKVManager):
                 peer_metadata = context.peer_info
             if not isinstance(peer_metadata, dict):
                 raise TypeError("prefill transport_metadata must be a mapping")
+            peer_dp_rank = int(
+                peer_metadata.get("dp_rank", context.peer_info.get("system_dp_rank", 0))
+            )
+            if peer_dp_rank != context.source_dp_rank:
+                raise ValueError(
+                    "prefill endpoint rank mismatch: "
+                    f"expected={context.source_dp_rank}, got={peer_dp_rank}"
+                )
+            peer_dp_size = int(peer_metadata.get("dp_size", self.wrapper.dp_size))
+            if peer_dp_size != self.wrapper.dp_size:
+                raise ValueError(
+                    "Raiden DP topology mismatch: "
+                    f"prefill={peer_dp_size}, decode={self.wrapper.dp_size}"
+                )
             peer_host = str(context.peer_info["host"])
             peer_endpoints = _endpoint_descriptors(
                 peer_metadata.get("endpoints"),
                 peer_host=peer_host,
             )
-            local_endpoints = list(self.wrapper.endpoints or [])
+            try:
+                local_endpoints = list(
+                    self.wrapper.endpoints_by_dp_rank[context.local_dp_rank]
+                )
+            except KeyError as exc:
+                raise ValueError(
+                    f"Raiden has no local manager for dp_rank={context.local_dp_rank}"
+                ) from exc
             _validate_endpoint_topology(peer_endpoints, local_endpoints)
             remote_endpoint: object = (
                 peer_endpoints[0]["endpoint"] if len(peer_endpoints) == 1 else peer_endpoints
@@ -286,6 +325,8 @@ class RaidenTransferKVManager(CommonKVManager):
                     local_block_ids=local_block_ids,
                     bootstrap_room=context.bootstrap_room,
                     jax_process_index=peer_process_index,
+                    source_dp_rank=context.source_dp_rank,
+                    local_dp_rank=context.local_dp_rank,
                     direct_commit=context.direct_commit,
                     expected_debug=(
                         metadata.get("kv_debug")
@@ -306,10 +347,16 @@ class RaidenTransferKVManager(CommonKVManager):
         req_id: str,
         transfer_id: str,
         block_ids: list[int],
+        dp_rank: int = 0,
     ) -> bool:
         if not block_ids:
             raise ValueError("Raiden transfer requires at least one KV block")
-        return self.wrapper.register_read(req_id, _uuid_to_int(transfer_id), block_ids)
+        return self.wrapper.register_read(
+            req_id,
+            _uuid_to_int(transfer_id),
+            block_ids,
+            dp_rank=dp_rank,
+        )
 
     def publish_transfer(
         self,
@@ -317,6 +364,7 @@ class RaidenTransferKVManager(CommonKVManager):
         block_ids: list[int],
         bootstrap_room: int | None,
         debug_metadata: Mapping[str, object] | None,
+        dp_rank: int = 0,
     ) -> None:
         if bootstrap_room is None:
             return
@@ -327,6 +375,7 @@ class RaidenTransferKVManager(CommonKVManager):
             bootstrap_room,
             transfer_id,
             jax_process_index=jax.process_index(),
+            source_dp_rank=dp_rank,
             transport_metadata=transport_metadata,
         )
 
@@ -335,6 +384,7 @@ class RaidenTransferKVManager(CommonKVManager):
         bootstrap_room: int | None,
         *,
         jax_process_index: int | None = None,
+        source_dp_rank: int = 0,
     ) -> None:
         if bootstrap_room is None:
             return
@@ -344,6 +394,7 @@ class RaidenTransferKVManager(CommonKVManager):
             self.bootstrap_client.pop_transfer(
                 bootstrap_room,
                 jax_process_index=jax_process_index,
+                source_dp_rank=source_dp_rank,
             )
 
     def poll_engine(self) -> None:
@@ -423,6 +474,7 @@ class RaidenTransferKVSender(KVSender, StateHolder):
         self._transfer_id: str | None = None
         self._block_ids: list[int] | None = None
         self._bootstrap_room: int | None = None
+        self._dp_rank: int = 0
         self._state_lock = threading.Lock()
         self._timer: object | None = None
         self._transfer_started_at: float | None = None
@@ -441,11 +493,18 @@ class RaidenTransferKVSender(KVSender, StateHolder):
         self._transfer_id = transfer_id or self._req_id
         self._transition_to(KVPoll.WAITING_FOR_INPUT)
 
-    def attach_block_ids(self, block_ids: list[int], *, bootstrap_room: int | None) -> None:
+    def attach_block_ids(
+        self,
+        block_ids: list[int],
+        *,
+        bootstrap_room: int | None,
+        dp_rank: int = 0,
+    ) -> None:
         if self._block_ids is not None:
             raise RuntimeError(f"sender {self._req_id!r} is already configured")
         self._block_ids = list(block_ids)
         self._bootstrap_room = bootstrap_room
+        self._dp_rank = int(dp_rank)
 
     def attach_debug_metadata(self, metadata: Mapping[str, object]) -> None:
         self._debug_metadata = dict(metadata)
@@ -458,6 +517,7 @@ class RaidenTransferKVSender(KVSender, StateHolder):
                 self.uuid,
                 self.uuid,
                 self._block_ids,
+                dp_rank=self._dp_rank,
             )
             self._transition_to(KVPoll.TRANSFERRING)
             if needed:
@@ -475,6 +535,7 @@ class RaidenTransferKVSender(KVSender, StateHolder):
                 self._block_ids,
                 self._bootstrap_room,
                 self._debug_metadata,
+                dp_rank=self._dp_rank,
             )
         except Exception:  # noqa: BLE001
             logger.exception("Raiden transfer metadata publish failed for %s", self._req_id)
@@ -538,7 +599,10 @@ class RaidenTransferKVSender(KVSender, StateHolder):
                 reason=reason,
             )
         self._manager.forget(self.uuid)
-        self._manager.cleanup_transfer(self._bootstrap_room)
+        self._manager.cleanup_transfer(
+            self._bootstrap_room,
+            source_dp_rank=self._dp_rank,
+        )
         if state == KVPoll.FAILED:
             with suppress(Exception):
                 PD_TRANSFER_FAILURES_TOTAL.labels(reason=reason, role="prefill").inc()
@@ -596,6 +660,7 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
                         self._metadata.remote_endpoint,
                         list(self._metadata.remote_block_ids),
                         list(self._metadata.local_block_ids),
+                        local_dp_rank=self._metadata.local_dp_rank,
                     )
                 except Exception:  # noqa: BLE001
                     logger.exception("Raiden start_read() failed for %s", self._req_id)
@@ -675,6 +740,7 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
         self._manager.cleanup_transfer(
             metadata.bootstrap_room if metadata else None,
             jax_process_index=metadata.jax_process_index if metadata else None,
+            source_dp_rank=metadata.source_dp_rank if metadata else 0,
         )
         if state == KVPoll.FAILED:
             with suppress(Exception):

--- a/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
+++ b/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
@@ -293,9 +293,7 @@ class RaidenTransferKVManager(CommonKVManager):
                 peer_host=peer_host,
             )
             try:
-                local_endpoints = list(
-                    self.wrapper.endpoints_by_dp_rank[context.local_dp_rank]
-                )
+                local_endpoints = list(self.wrapper.endpoints_by_dp_rank[context.local_dp_rank])
             except KeyError as exc:
                 raise ValueError(
                     f"Raiden has no local manager for dp_rank={context.local_dp_rank}"

--- a/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
+++ b/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
@@ -135,8 +135,8 @@ class RaidenMetadata:
     local_block_ids: tuple[int, ...]
     bootstrap_room: int | None
     jax_process_index: int = 0
-    source_dp_rank: int = 0
-    local_dp_rank: int = 0
+    prefill_dp_rank: int = 0
+    decode_dp_rank: int = 0
     direct_commit: Callable[[Mapping[str, object] | None], None] | None = None
     expected_debug: Mapping[str, object] | None = None
 
@@ -232,7 +232,7 @@ class RaidenTransferKVManager(CommonKVManager):
             info = self.bootstrap_client.get_transfer_info(
                 context.bootstrap_room,
                 jax_process_index=peer_process_index,
-                source_dp_rank=context.source_dp_rank,
+                prefill_dp_rank=context.prefill_dp_rank,
             )
         except Exception as exc:  # transient bootstrap failure
             logger.warning(
@@ -251,11 +251,11 @@ class RaidenTransferKVManager(CommonKVManager):
                     "Raiden transfer ID mismatch: "
                     f"expected={context.transfer_id!r}, got={info.get('transfer_id')!r}"
                 )
-            published_source_rank = int(info.get("source_dp_rank", 0))
-            if published_source_rank != context.source_dp_rank:
+            metadata_prefill_dp_rank = int(info.get("prefill_dp_rank", 0))
+            if metadata_prefill_dp_rank != context.prefill_dp_rank:
                 raise ValueError(
-                    "Raiden transfer source rank mismatch: "
-                    f"expected={context.source_dp_rank}, got={published_source_rank}"
+                    "Raiden transfer Prefill rank mismatch: "
+                    f"expected={context.prefill_dp_rank}, got={metadata_prefill_dp_rank}"
                 )
             metadata = info.get("transport_metadata", info)
             if not isinstance(metadata, dict):
@@ -276,10 +276,10 @@ class RaidenTransferKVManager(CommonKVManager):
             peer_dp_rank = int(
                 peer_metadata.get("dp_rank", context.peer_info.get("system_dp_rank", 0))
             )
-            if peer_dp_rank != context.source_dp_rank:
+            if peer_dp_rank != context.prefill_dp_rank:
                 raise ValueError(
                     "prefill endpoint rank mismatch: "
-                    f"expected={context.source_dp_rank}, got={peer_dp_rank}"
+                    f"expected={context.prefill_dp_rank}, got={peer_dp_rank}"
                 )
             peer_dp_size = int(peer_metadata.get("dp_size", self.wrapper.dp_size))
             if peer_dp_size != self.wrapper.dp_size:
@@ -293,10 +293,10 @@ class RaidenTransferKVManager(CommonKVManager):
                 peer_host=peer_host,
             )
             try:
-                local_endpoints = list(self.wrapper.endpoints_by_dp_rank[context.local_dp_rank])
+                local_endpoints = list(self.wrapper.endpoints_by_dp_rank[context.decode_dp_rank])
             except KeyError as exc:
                 raise ValueError(
-                    f"Raiden has no local manager for dp_rank={context.local_dp_rank}"
+                    f"Raiden has no Decode manager for dp_rank={context.decode_dp_rank}"
                 ) from exc
             _validate_endpoint_topology(peer_endpoints, local_endpoints)
             remote_endpoint: object = (
@@ -323,8 +323,8 @@ class RaidenTransferKVManager(CommonKVManager):
                     local_block_ids=local_block_ids,
                     bootstrap_room=context.bootstrap_room,
                     jax_process_index=peer_process_index,
-                    source_dp_rank=context.source_dp_rank,
-                    local_dp_rank=context.local_dp_rank,
+                    prefill_dp_rank=context.prefill_dp_rank,
+                    decode_dp_rank=context.decode_dp_rank,
                     direct_commit=context.direct_commit,
                     expected_debug=(
                         metadata.get("kv_debug")
@@ -373,7 +373,7 @@ class RaidenTransferKVManager(CommonKVManager):
             bootstrap_room,
             transfer_id,
             jax_process_index=jax.process_index(),
-            source_dp_rank=dp_rank,
+            prefill_dp_rank=dp_rank,
             transport_metadata=transport_metadata,
         )
 
@@ -382,7 +382,7 @@ class RaidenTransferKVManager(CommonKVManager):
         bootstrap_room: int | None,
         *,
         jax_process_index: int | None = None,
-        source_dp_rank: int = 0,
+        prefill_dp_rank: int = 0,
     ) -> None:
         if bootstrap_room is None:
             return
@@ -392,7 +392,7 @@ class RaidenTransferKVManager(CommonKVManager):
             self.bootstrap_client.pop_transfer(
                 bootstrap_room,
                 jax_process_index=jax_process_index,
-                source_dp_rank=source_dp_rank,
+                prefill_dp_rank=prefill_dp_rank,
             )
 
     def poll_engine(self) -> None:
@@ -487,7 +487,8 @@ class RaidenTransferKVSender(KVSender, StateHolder):
     def transfer_started_at(self) -> float | None:
         return self._transfer_started_at
 
-    def init(self, kv_indices, transfer_id: str | None = None) -> None:  # noqa: ARG002
+    def init(self, kv_indices, transfer_id: str | None = None) -> None:
+        del kv_indices
         self._transfer_id = transfer_id or self._req_id
         self._transition_to(KVPoll.WAITING_FOR_INPUT)
 
@@ -599,7 +600,7 @@ class RaidenTransferKVSender(KVSender, StateHolder):
         self._manager.forget(self.uuid)
         self._manager.cleanup_transfer(
             self._bootstrap_room,
-            source_dp_rank=self._dp_rank,
+            prefill_dp_rank=self._dp_rank,
         )
         if state == KVPoll.FAILED:
             with suppress(Exception):
@@ -658,7 +659,7 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
                         self._metadata.remote_endpoint,
                         list(self._metadata.remote_block_ids),
                         list(self._metadata.local_block_ids),
-                        local_dp_rank=self._metadata.local_dp_rank,
+                        decode_dp_rank=self._metadata.decode_dp_rank,
                     )
                 except Exception:  # noqa: BLE001
                     logger.exception("Raiden start_read() failed for %s", self._req_id)
@@ -683,7 +684,8 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
             )
         return self.state
 
-    def commit(self, install: Callable[[Any], None]) -> None:  # noqa: ARG002
+    def commit(self, install: Callable[[Any], None]) -> None:
+        del install
         if self.state != KVPoll.SUCCESS:
             raise RuntimeError("cannot commit an incomplete Raiden receive")
         assert self._metadata is not None
@@ -738,7 +740,7 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
         self._manager.cleanup_transfer(
             metadata.bootstrap_room if metadata else None,
             jax_process_index=metadata.jax_process_index if metadata else None,
-            source_dp_rank=metadata.source_dp_rank if metadata else 0,
+            prefill_dp_rank=metadata.prefill_dp_rank if metadata else 0,
         )
         if state == KVPoll.FAILED:
             with suppress(Exception):

--- a/python/sgl_jax/srt/disaggregation/raiden_transfer/wrapper.py
+++ b/python/sgl_jax/srt/disaggregation/raiden_transfer/wrapper.py
@@ -26,8 +26,8 @@ class RaidenTransferWrapper:
         self._control_port = control_port
         self._parallelism = max(1, int(parallelism))
         self._init_lock = threading.Lock()
-        self._engine: Any | None = None
-        self._endpoints: list[Any] | None = None
+        self._engines: dict[int, Any] = {}
+        self._endpoints_by_dp_rank: dict[int, list[Any]] = {}
 
     @property
     def host_ip(self) -> str:
@@ -43,15 +43,23 @@ class RaidenTransferWrapper:
 
     @property
     def is_started(self) -> bool:
-        return self._engine is not None
+        return bool(self._engines)
 
     @property
     def engine(self) -> Any:
-        return self._engine
+        return self._engines.get(0)
 
     @property
     def endpoints(self) -> list[Any] | None:
-        return self._endpoints
+        return self._endpoints_by_dp_rank.get(0)
+
+    @property
+    def endpoints_by_dp_rank(self) -> dict[int, list[Any]]:
+        return {rank: list(endpoints) for rank, endpoints in self._endpoints_by_dp_rank.items()}
+
+    @property
+    def dp_size(self) -> int:
+        return len(self._engines)
 
     def start(
         self,
@@ -59,13 +67,14 @@ class RaidenTransferWrapper:
         *,
         max_blocks: int,
         num_slots: int,
+        dp_size: int = 1,
         timeout_s: float = 120.0,
     ) -> Any:
-        if self._engine is not None:
-            return self._engine
+        if self._engines:
+            return self.engine
         with self._init_lock:
-            if self._engine is not None:
-                return self._engine
+            if self._engines:
+                return self.engine
             try:
                 from tpu_raiden.api.jax.kv_cache_manager import KVCacheManager
             except ModuleNotFoundError as exc:
@@ -78,31 +87,53 @@ class RaidenTransferWrapper:
                 raise ValueError("Raiden requires at least one KV cache tensor")
             if max_blocks <= 0 or num_slots <= 0:
                 raise ValueError("Raiden max_blocks and num_slots must be positive")
+            if dp_size <= 0:
+                raise ValueError("Raiden dp_size must be positive")
 
-            self._engine = KVCacheManager(
-                kv_caches=list(kv_caches),
-                local_control_port=self._control_port,
-                max_blocks=int(max_blocks),
-                num_slots=int(num_slots),
-                timeout_s=float(timeout_s),
-                parallelism=self._parallelism,
-                # A manager-lifetime PJRT hold would block serving compute;
-                # request pages stay owned until Raiden reports terminal.
-                unsafe_skip_buffer_lock=True,
-            )
-            self._endpoints = self._engine.get_local_endpoints()
-            logger.info(
-                "Raiden started at %s with endpoints=%s (jax=%s)",
-                self._control_port,
-                self._endpoints,
-                jax.__version__,
-            )
-        return self._engine
+            caches_by_rank = _split_kv_caches_by_dp_rank(kv_caches, int(dp_size))
+            for dp_rank, rank_caches in caches_by_rank.items():
+                control_port = 0 if self._control_port == 0 else self._control_port + dp_rank
+                if control_port > 65535:
+                    raise ValueError(
+                        f"Raiden control port overflows for dp_rank={dp_rank}: {control_port}"
+                    )
+                engine = KVCacheManager(
+                    kv_caches=rank_caches,
+                    local_control_port=control_port,
+                    max_blocks=int(max_blocks),
+                    num_slots=int(num_slots),
+                    timeout_s=float(timeout_s),
+                    parallelism=self._parallelism,
+                    # A manager-lifetime PJRT hold would block serving compute;
+                    # request pages stay owned until Raiden reports terminal.
+                    unsafe_skip_buffer_lock=True,
+                )
+                endpoints = list(engine.get_local_endpoints())
+                self._engines[dp_rank] = engine
+                self._endpoints_by_dp_rank[dp_rank] = endpoints
+                logger.info(
+                    "Raiden started for dp_rank=%d at requested_port=%s with endpoints=%s (jax=%s)",
+                    dp_rank,
+                    control_port,
+                    endpoints,
+                    jax.__version__,
+                )
+        return self.engine
 
-    def register_read(self, req_id: str, uuid: int, block_ids: list[int]) -> bool:
-        if self._engine is None:
+    def _engine_for_rank(self, dp_rank: int) -> Any:
+        try:
+            return self._engines[int(dp_rank)]
+        except KeyError as exc:
+            raise ValueError(
+                f"Raiden dp_rank={dp_rank} is unavailable; started ranks={sorted(self._engines)}"
+            ) from exc
+
+    def register_read(
+        self, req_id: str, uuid: int, block_ids: list[int], *, dp_rank: int = 0
+    ) -> bool:
+        if not self._engines:
             raise RuntimeError("RaidenTransferWrapper.start() must be called first")
-        return bool(self._engine.register_read(req_id, uuid, list(block_ids)))
+        return bool(self._engine_for_rank(dp_rank).register_read(req_id, uuid, list(block_ids)))
 
     def start_read(
         self,
@@ -111,10 +142,12 @@ class RaidenTransferWrapper:
         remote_endpoint: Any,
         remote_block_ids: list[int],
         local_block_ids: list[int],
+        *,
+        local_dp_rank: int = 0,
     ) -> None:
-        if self._engine is None:
+        if not self._engines:
             raise RuntimeError("RaidenTransferWrapper.start() must be called first")
-        self._engine.start_read(
+        self._engine_for_rank(local_dp_rank).start_read(
             req_id,
             uuid,
             remote_endpoint,
@@ -124,9 +157,100 @@ class RaidenTransferWrapper:
         )
 
     def poll_stats(self) -> tuple[list[str], list[str], list[str]]:
-        if self._engine is None:
+        if not self._engines:
             raise RuntimeError("RaidenTransferWrapper.start() must be called first")
-        return self._engine.poll_stats()
+        sent: list[str] = []
+        received: list[str] = []
+        failed: list[str] = []
+        for engine in self._engines.values():
+            rank_sent, rank_received, rank_failed = engine.poll_stats()
+            sent.extend(rank_sent)
+            received.extend(rank_received)
+            failed.extend(rank_failed)
+        return sent, received, failed
+
+
+def _partition_without_data_axis(partition: object) -> object:
+    if partition == "data":
+        return None
+    if isinstance(partition, tuple) and "data" in partition:
+        remaining = tuple(axis for axis in partition if axis != "data")
+        if not remaining:
+            return None
+        return remaining[0] if len(remaining) == 1 else remaining
+    return partition
+
+
+def _rank_local_array(array: Any, dp_rank: int, dp_size: int) -> Any:
+    """Build a zero-copy fully-addressable view for one mesh ``data`` rank."""
+
+    import numpy as np
+    from jax.sharding import Mesh, NamedSharding, PartitionSpec
+
+    sharding = getattr(array, "sharding", None)
+    if not isinstance(sharding, NamedSharding):
+        raise ValueError(
+            f"Raiden DP requires NamedSharding KV arrays; got {type(sharding).__name__}"
+        )
+    mesh = sharding.mesh
+    axis_names = tuple(mesh.axis_names)
+    if "data" not in axis_names:
+        raise ValueError(f"Raiden DP requires a data mesh axis, got {axis_names}")
+    mesh_dp_size = int(mesh.shape["data"])
+    if mesh_dp_size != dp_size:
+        raise ValueError(
+            f"Raiden DP topology mismatch: configured dp_size={dp_size}, "
+            f"KV mesh data size={mesh_dp_size}"
+        )
+    if not 0 <= dp_rank < dp_size:
+        raise ValueError(f"dp_rank={dp_rank} is outside [0, {dp_size})")
+
+    data_axis = axis_names.index("data")
+    rank_devices = np.take(np.asarray(mesh.devices), dp_rank, axis=data_axis)
+    rank_axis_names = tuple(axis for axis in axis_names if axis != "data")
+    if not rank_axis_names:
+        rank_devices = np.asarray(rank_devices).reshape(1)
+        rank_axis_names = ("_raiden",)
+    rank_mesh = Mesh(rank_devices, rank_axis_names)
+
+    original_spec = tuple(sharding.spec)
+    rank_spec = tuple(_partition_without_data_axis(partition) for partition in original_spec)
+    rank_sharding = NamedSharding(rank_mesh, PartitionSpec(*rank_spec))
+
+    rank_shape = list(array.shape)
+    for dim, partition in enumerate(original_spec):
+        axes = partition if isinstance(partition, tuple) else (partition,)
+        if "data" in axes:
+            if rank_shape[dim] % dp_size:
+                raise ValueError(
+                    f"KV dimension {dim} size {rank_shape[dim]} is not divisible "
+                    f"by dp_size={dp_size}"
+                )
+            rank_shape[dim] //= dp_size
+    rank_shape = tuple(rank_shape)
+
+    shard_by_device = {shard.device: shard.data for shard in array.addressable_shards}
+    device_indices = rank_sharding.addressable_devices_indices_map(rank_shape)
+    missing = [device for device in device_indices if device not in shard_by_device]
+    if missing:
+        raise RuntimeError(
+            f"Raiden dp_rank={dp_rank} is not fully addressable on process "
+            f"{jax.process_index()}; missing devices={missing}"
+        )
+    return jax.make_array_from_single_device_arrays(
+        rank_shape,
+        rank_sharding,
+        [shard_by_device[device] for device in device_indices],
+    )
+
+
+def _split_kv_caches_by_dp_rank(kv_caches: list[Any], dp_size: int) -> dict[int, list[Any]]:
+    if dp_size == 1:
+        return {0: list(kv_caches)}
+    return {
+        dp_rank: [_rank_local_array(cache, dp_rank, dp_size) for cache in kv_caches]
+        for dp_rank in range(dp_size)
+    }
 
 
 def get_or_create_raiden_wrapper(

--- a/python/sgl_jax/srt/disaggregation/raiden_transfer/wrapper.py
+++ b/python/sgl_jax/srt/disaggregation/raiden_transfer/wrapper.py
@@ -104,8 +104,7 @@ class RaidenTransferWrapper:
                     num_slots=int(num_slots),
                     timeout_s=float(timeout_s),
                     parallelism=self._parallelism,
-                    # A manager-lifetime PJRT hold would block serving compute;
-                    # request pages stay owned until Raiden reports terminal.
+                    # A manager-lifetime PJRT hold would block serving compute.
                     unsafe_skip_buffer_lock=True,
                 )
                 endpoints = list(engine.get_local_endpoints())
@@ -143,11 +142,11 @@ class RaidenTransferWrapper:
         remote_block_ids: list[int],
         local_block_ids: list[int],
         *,
-        local_dp_rank: int = 0,
+        decode_dp_rank: int = 0,
     ) -> None:
         if not self._engines:
             raise RuntimeError("RaidenTransferWrapper.start() must be called first")
-        self._engine_for_rank(local_dp_rank).start_read(
+        self._engine_for_rank(decode_dp_rank).start_read(
             req_id,
             uuid,
             remote_endpoint,
@@ -166,9 +165,7 @@ class RaidenTransferWrapper:
             try:
                 rank_sent, rank_received, rank_failed = engine.poll_stats()
             except Exception:
-                # Raiden poll_stats destructively drains completion events. Do
-                # not discard results already drained from healthy ranks when
-                # one manager fails to poll.
+                # Preserve events already drained from healthy ranks.
                 logger.exception("Raiden poll_stats failed for dp_rank=%d", dp_rank)
                 continue
             sent.extend(rank_sent)
@@ -189,7 +186,7 @@ def _partition_without_data_axis(partition: object) -> object:
 
 
 def _rank_local_array(array: Any, dp_rank: int, dp_size: int) -> Any:
-    """Build a zero-copy fully-addressable view for one mesh ``data`` rank."""
+    """Expose one data shard without changing physical buffer ownership."""
 
     import numpy as np
     from jax.sharding import Mesh, NamedSharding, PartitionSpec

--- a/python/sgl_jax/srt/disaggregation/raiden_transfer/wrapper.py
+++ b/python/sgl_jax/srt/disaggregation/raiden_transfer/wrapper.py
@@ -162,8 +162,15 @@ class RaidenTransferWrapper:
         sent: list[str] = []
         received: list[str] = []
         failed: list[str] = []
-        for engine in self._engines.values():
-            rank_sent, rank_received, rank_failed = engine.poll_stats()
+        for dp_rank, engine in self._engines.items():
+            try:
+                rank_sent, rank_received, rank_failed = engine.poll_stats()
+            except Exception:
+                # Raiden poll_stats destructively drains completion events. Do
+                # not discard results already drained from healthy ranks when
+                # one manager fails to poll.
+                logger.exception("Raiden poll_stats failed for dp_rank=%d", dp_rank)
+                continue
             sent.extend(rank_sent)
             received.extend(rank_received)
             failed.extend(rank_failed)
@@ -205,6 +212,18 @@ def _rank_local_array(array: Any, dp_rank: int, dp_size: int) -> Any:
     if not 0 <= dp_rank < dp_size:
         raise ValueError(f"dp_rank={dp_rank} is outside [0, {dp_size})")
 
+    original_spec = tuple(sharding.spec)
+    data_sharded_dims = []
+    for dim, partition in enumerate(original_spec):
+        axes = partition if isinstance(partition, tuple) else (partition,)
+        if "data" in axes:
+            data_sharded_dims.append(dim)
+    if not data_sharded_dims:
+        raise ValueError(
+            "Raiden DP requires the KV PartitionSpec to shard a tensor "
+            f"dimension along the data mesh axis; got spec={sharding.spec}"
+        )
+
     data_axis = axis_names.index("data")
     rank_devices = np.take(np.asarray(mesh.devices), dp_rank, axis=data_axis)
     rank_axis_names = tuple(axis for axis in axis_names if axis != "data")
@@ -213,7 +232,6 @@ def _rank_local_array(array: Any, dp_rank: int, dp_size: int) -> Any:
         rank_axis_names = ("_raiden",)
     rank_mesh = Mesh(rank_devices, rank_axis_names)
 
-    original_spec = tuple(sharding.spec)
     rank_spec = tuple(_partition_without_data_axis(partition) for partition in original_spec)
     rank_sharding = NamedSharding(rank_mesh, PartitionSpec(*rank_spec))
 

--- a/python/sgl_jax/srt/disaggregation/runtime.py
+++ b/python/sgl_jax/srt/disaggregation/runtime.py
@@ -21,9 +21,10 @@ def install_disaggregation_wiring(scheduler: Scheduler, server_args: ServerArgs)
     mode = server_args.disaggregation_mode
     if mode == "null":
         return
-    if server_args.dp_size > 1:
+    if server_args.dp_size > 1 and not server_args.disaggregation_use_raiden:
         raise RuntimeError(
-            f"PD disaggregation does not yet support dp_size>1 (got dp_size={server_args.dp_size})."
+            "PD disaggregation with dp_size>1 requires the Raiden transfer "
+            f"engine (got dp_size={server_args.dp_size})."
         )
     if server_args.disaggregation_bootstrap_url is None:
         raise RuntimeError("disaggregation_mode != null requires bootstrap_url")
@@ -99,26 +100,32 @@ def install_disaggregation_wiring(scheduler: Scheduler, server_args: ServerArgs)
         prefill_kv_pool = scheduler.token_to_kv_pool_allocator.get_kvcache()
         kv_dtype_name = resolve_kv_dtype_name(prefill_kv_pool.dtype)
 
-        bootstrap_key = f"{local_host}:{transfer_port}"
-        scheduler.disagg_bootstrap_client.register_prefill(
-            bootstrap_key=bootstrap_key,
-            host=local_host,
-            transfer_port=transfer_port,
-            side_channel_port=side_channel_port,
-            tp_rank=server_args.node_rank,
-            tp_size=server_args.tp_size,
-            system_dp_rank=0,
-            jax_process_index=jax.process_index(),
-            jax_process_count=jax.process_count(),
-            page_size=server_args.page_size,
-            kv_dtype=kv_dtype_name,
-            transport_metadata=scheduler.disagg_kv_manager.prefill_transport_metadata(),
-        )
+        bootstrap_keys = []
+        for dp_rank in range(server_args.dp_size):
+            bootstrap_key = f"{local_host}:{transfer_port}:dp_{dp_rank}"
+            scheduler.disagg_bootstrap_client.register_prefill(
+                bootstrap_key=bootstrap_key,
+                host=local_host,
+                transfer_port=transfer_port,
+                side_channel_port=side_channel_port,
+                tp_rank=server_args.node_rank,
+                tp_size=server_args.tp_size // server_args.dp_size,
+                system_dp_rank=dp_rank,
+                jax_process_index=jax.process_index(),
+                jax_process_count=jax.process_count(),
+                page_size=server_args.page_size,
+                kv_dtype=kv_dtype_name,
+                transport_metadata=(
+                    scheduler.disagg_kv_manager.prefill_transport_metadata(dp_rank)
+                ),
+            )
+            bootstrap_keys.append(bootstrap_key)
         scheduler.disagg_heartbeat = HeartbeatDaemon(
-            scheduler.disagg_bootstrap_client, bootstrap_key
+            scheduler.disagg_bootstrap_client, bootstrap_keys
         )
         scheduler.disagg_heartbeat.start()
-        scheduler.disagg_bootstrap_key = bootstrap_key
+        scheduler.disagg_bootstrap_keys = bootstrap_keys
+        scheduler.disagg_bootstrap_key = bootstrap_keys[0]
     else:
         scheduler.disagg_prefill_info_cache = PrefillInfoCache(scheduler.disagg_bootstrap_client)
         scheduler.disagg_prealloc_queue = DecodePreallocQueue()
@@ -161,8 +168,13 @@ def _make_disagg_shutdown(scheduler: Scheduler, mode: str):
         state["done"] = True
         if mode == "prefill":
             try:
-                key = scheduler.disagg_bootstrap_key
-                scheduler.disagg_bootstrap_client.unregister_prefill(key)
+                keys = getattr(
+                    scheduler,
+                    "disagg_bootstrap_keys",
+                    [scheduler.disagg_bootstrap_key],
+                )
+                for key in keys:
+                    scheduler.disagg_bootstrap_client.unregister_prefill(key)
             except Exception:
                 logger.warning(
                     "PD shutdown: unregister_prefill failed",

--- a/python/sgl_jax/srt/disaggregation/runtime.py
+++ b/python/sgl_jax/srt/disaggregation/runtime.py
@@ -167,19 +167,20 @@ def _make_disagg_shutdown(scheduler: Scheduler, mode: str):
             return
         state["done"] = True
         if mode == "prefill":
-            try:
-                keys = getattr(
-                    scheduler,
-                    "disagg_bootstrap_keys",
-                    [scheduler.disagg_bootstrap_key],
-                )
-                for key in keys:
+            keys = getattr(
+                scheduler,
+                "disagg_bootstrap_keys",
+                [scheduler.disagg_bootstrap_key],
+            )
+            for key in keys:
+                try:
                     scheduler.disagg_bootstrap_client.unregister_prefill(key)
-            except Exception:
-                logger.warning(
-                    "PD shutdown: unregister_prefill failed",
-                    exc_info=True,
-                )
+                except Exception:
+                    logger.warning(
+                        "PD shutdown: unregister_prefill failed for %s",
+                        key,
+                        exc_info=True,
+                    )
             with suppress(Exception):
                 scheduler.disagg_heartbeat.stop()
         try:

--- a/python/sgl_jax/srt/entrypoints/openai/protocol.py
+++ b/python/sgl_jax/srt/entrypoints/openai/protocol.py
@@ -169,9 +169,11 @@ class CompletionRequest(BaseModel):
     session_params: dict | None = None
 
     # For PD disaggregation
+    dp_rank: list[int] | int | None = None
     bootstrap_host: list[str] | str | None = None
     bootstrap_port: list[int] | int | None = None
     bootstrap_room: list[int] | int | None = None
+    disagg_prefill_dp_rank: list[int] | int | None = None
     disagg_transfer_id: list[str] | str | None = None
 
     # For request id
@@ -439,9 +441,11 @@ class ChatCompletionRequest(BaseModel):
     rid: list[str] | str | None = None
 
     # For PD disaggregation
+    dp_rank: int | None = None
     bootstrap_host: str | None = None
     bootstrap_port: int | None = None
     bootstrap_room: int | None = None
+    disagg_prefill_dp_rank: int | None = None
     disagg_transfer_id: str | None = None
 
 

--- a/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
+++ b/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
@@ -98,9 +98,11 @@ class OpenAIServingChat(OpenAIServingBase):
             stream=request.stream,
             extra_key=request.extra_key,
             rid=request.rid,
+            dp_rank=request.dp_rank,
             bootstrap_host=request.bootstrap_host,
             bootstrap_port=request.bootstrap_port,
             bootstrap_room=request.bootstrap_room,
+            disagg_prefill_dp_rank=request.disagg_prefill_dp_rank,
             disagg_transfer_id=request.disagg_transfer_id,
         )
 

--- a/python/sgl_jax/srt/entrypoints/openai/serving_completions.py
+++ b/python/sgl_jax/srt/entrypoints/openai/serving_completions.py
@@ -82,9 +82,11 @@ class OpenAIServingCompletion(OpenAIServingBase):
             extra_key=request.extra_key,
             rid=request.rid,
             return_routed_experts=request.return_routed_experts,
+            dp_rank=request.dp_rank,
             bootstrap_host=request.bootstrap_host,
             bootstrap_port=request.bootstrap_port,
             bootstrap_room=request.bootstrap_room,
+            disagg_prefill_dp_rank=request.disagg_prefill_dp_rank,
             disagg_transfer_id=request.disagg_transfer_id,
         )
 

--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -171,6 +171,9 @@ class TokenizedGenerateReqInput:
     bootstrap_host: str | None = None
     bootstrap_port: int | None = None
     bootstrap_room: int | None = None
+    # Prefill rank that owns the source KV pages. Decode may use a different
+    # local ``dp_rank`` for explicit cross-rank correctness testing.
+    disagg_prefill_dp_rank: int | None = None
     # Optional wire-level transfer identity. When omitted we fall back
     # to ``rid``; callers that may reuse ``rid`` across retries should
     # provide a per-attempt value to isolate late acks.
@@ -315,10 +318,14 @@ class GenerateReqInput:
 
     return_routed_experts: list[bool] | bool | None = None
 
+    # The data parallel rank for this request.
+    dp_rank: list[int] | int | None = None
+
     # PD disaggregation routing keys.
     bootstrap_host: list[str] | str | None = None
     bootstrap_port: list[int] | int | None = None
     bootstrap_room: list[int] | int | None = None
+    disagg_prefill_dp_rank: list[int] | int | None = None
     disagg_transfer_id: list[str] | str | None = None
 
     def contains_mm_input(self) -> bool:
@@ -556,6 +563,7 @@ class GenerateReqInput:
             lora_path=self.lora_path[i] if self.lora_path is not None else None,
             lora_id=self.lora_id[i] if self.lora_id is not None else None,
             return_routed_experts=self.return_routed_experts[i],
+            dp_rank=self.dp_rank[i] if isinstance(self.dp_rank, list) else self.dp_rank,
             # PD disaggregation passthrough.
             # Supports both scalar and list shapes.
             bootstrap_host=(
@@ -572,6 +580,11 @@ class GenerateReqInput:
                 self.bootstrap_room[i]
                 if isinstance(self.bootstrap_room, list)
                 else self.bootstrap_room
+            ),
+            disagg_prefill_dp_rank=(
+                self.disagg_prefill_dp_rank[i]
+                if isinstance(self.disagg_prefill_dp_rank, list)
+                else self.disagg_prefill_dp_rank
             ),
             disagg_transfer_id=(
                 self.disagg_transfer_id[i]

--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -165,14 +165,13 @@ class TokenizedGenerateReqInput:
     return_hidden_states: bool = False
     # multimodal inputs (e.g., mrope positions, embeddings)
     mm_inputs: dict | None = None
-    # The data parallel rank for this request
+    # Decode DP rank selected by request routing.
     dp_rank: int | None = None
     # PD disaggregation routing keys.
     bootstrap_host: str | None = None
     bootstrap_port: int | None = None
     bootstrap_room: int | None = None
-    # Prefill rank that owns the source KV pages. Decode may use a different
-    # local ``dp_rank`` for explicit cross-rank correctness testing.
+    # Prefill DP rank that owns this request's KV cache.
     disagg_prefill_dp_rank: int | None = None
     # Optional wire-level transfer identity. When omitted we fall back
     # to ``rid``; callers that may reuse ``rid`` across retries should
@@ -318,7 +317,7 @@ class GenerateReqInput:
 
     return_routed_experts: list[bool] | bool | None = None
 
-    # The data parallel rank for this request.
+    # Decode DP rank selected by request routing.
     dp_rank: list[int] | int | None = None
 
     # PD disaggregation routing keys.

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -224,6 +224,7 @@ class Req:
         self.bootstrap_host: str | None = None
         self.bootstrap_port: int | None = None
         self.bootstrap_room: int | None = None
+        self.disagg_prefill_dp_rank: int | None = None
         self.disagg_transfer_id: str | None = None
         self.disagg_host_buffer_id: int | None = None
         self.disagg_peer_process_index: int = 0

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1313,6 +1313,7 @@ class Scheduler(
         req.bootstrap_host = recv_req.bootstrap_host
         req.bootstrap_port = recv_req.bootstrap_port
         req.bootstrap_room = recv_req.bootstrap_room
+        req.disagg_prefill_dp_rank = getattr(recv_req, "disagg_prefill_dp_rank", None)
         req.disagg_transfer_id = recv_req.disagg_transfer_id or req.rid
         if hasattr(recv_req, "mm_inputs") and recv_req.mm_inputs:
             req.mm_inputs = recv_req.mm_inputs
@@ -2741,7 +2742,7 @@ class Scheduler(
                 if entry.receiver is not None:
                     entry.receiver.abort()
                 if entry.kv_indices is not None:
-                    self._release_decode_kv_indices(entry.kv_indices)
+                    self._release_decode_kv_indices(entry.kv_indices, entry.req.dp_rank)
                 self._abort_decode_request(
                     entry.req,
                     "abort_request",

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -378,13 +378,47 @@ class TokenizerManager:
             obj.return_routed_experts,
         )
 
+        disagg_mode = getattr(self.server_args, "disaggregation_mode", "null")
+        dp_size = int(getattr(self.server_args, "dp_size", 1))
+        dp_rank = getattr(obj, "dp_rank", None)
+        if disagg_mode != "null":
+            if dp_rank is None:
+                if dp_size > 1:
+                    raise ValueError(
+                        f"disaggregation_mode={disagg_mode} with dp_size={dp_size} "
+                        "requires an explicit dp_rank"
+                    )
+                dp_rank = 0
+            if isinstance(dp_rank, bool) or not isinstance(dp_rank, int):
+                raise ValueError(f"dp_rank must be an integer, got {dp_rank!r}")
+            if not 0 <= dp_rank < dp_size:
+                raise ValueError(f"dp_rank={dp_rank} is outside [0, {dp_size})")
+
+        prefill_dp_rank = getattr(obj, "disagg_prefill_dp_rank", None)
+        if disagg_mode == "decode":
+            if prefill_dp_rank is None:
+                if dp_size > 1:
+                    raise ValueError(
+                        f"disaggregation_mode=decode with dp_size={dp_size} requires "
+                        "an explicit disagg_prefill_dp_rank"
+                    )
+                prefill_dp_rank = 0
+            if isinstance(prefill_dp_rank, bool) or not isinstance(prefill_dp_rank, int):
+                raise ValueError(
+                    f"disagg_prefill_dp_rank must be an integer, got {prefill_dp_rank!r}"
+                )
+            if not 0 <= prefill_dp_rank < dp_size:
+                raise ValueError(
+                    f"disagg_prefill_dp_rank={prefill_dp_rank} is outside [0, {dp_size})"
+                )
+
         # PD disaggregation passthrough. When the engine is
         # running in disaggregation_mode=decode, the request body MUST
         # carry bootstrap_{host,port,room}.
         #
         # If the request didn't carry bootstrap_* fields but the engine
         # knows its bootstrap URL, auto-derive them.
-        if getattr(self.server_args, "disaggregation_mode", "null") == "decode":
+        if disagg_mode == "decode":
             bootstrap_url = getattr(self.server_args, "disaggregation_bootstrap_url", None)
             if (
                 obj.bootstrap_host is None or obj.bootstrap_port is None
@@ -416,6 +450,8 @@ class TokenizerManager:
         tokenized_obj.bootstrap_host = getattr(obj, "bootstrap_host", None)
         tokenized_obj.bootstrap_port = getattr(obj, "bootstrap_port", None)
         tokenized_obj.bootstrap_room = getattr(obj, "bootstrap_room", None)
+        tokenized_obj.dp_rank = dp_rank
+        tokenized_obj.disagg_prefill_dp_rank = prefill_dp_rank
         tokenized_obj.disagg_transfer_id = getattr(obj, "disagg_transfer_id", None)
         # note: When only `return_logprob` is specified, we assume that only the output probability is required.
         if (
@@ -1031,6 +1067,12 @@ class TokenizerManager:
                 "finish_reason": recv_obj.finished_reasons[i],
                 "prompt_tokens": recv_obj.prompt_tokens[i],
             }
+            dp_rank = getattr(state.obj, "dp_rank", None)
+            if dp_rank is not None:
+                meta_info["dp_rank"] = dp_rank
+            disagg_prefill_dp_rank = getattr(state.obj, "disagg_prefill_dp_rank", None)
+            if disagg_prefill_dp_rank is not None:
+                meta_info["disagg_prefill_dp_rank"] = disagg_prefill_dp_rank
 
             if getattr(state.obj, "return_logprob", False) or getattr(
                 state.obj, "return_output_logprob_only", False

--- a/scripts/disaggregation/gke/pd_raiden_smoke_job.yaml.in
+++ b/scripts/disaggregation/gke/pd_raiden_smoke_job.yaml.in
@@ -1,5 +1,5 @@
 # Render only the listed deployment fields so pod-time variables remain intact:
-# envsubst '${TPU_ACCELERATOR} ${TPU_TOPOLOGY} ${PD_IMAGE} ${MODEL_PATH} ${RAIDEN_WHEEL_DIR} ${MODEL_CACHE_PVC}'
+# envsubst '${TPU_ACCELERATOR} ${TPU_TOPOLOGY} ${PD_IMAGE} ${MODEL_PATH} ${RAIDEN_WHEEL_DIR} ${MODEL_CACHE_PVC} ${DP_SIZE} ${TP_SIZE}'
 apiVersion: v1
 kind: Service
 metadata:
@@ -48,6 +48,10 @@ spec:
           value: ${MODEL_PATH}
         - name: RAIDEN_WHEEL_DIR
           value: ${RAIDEN_WHEEL_DIR}
+        - name: DP_SIZE
+          value: "${DP_SIZE}"
+        - name: TP_SIZE
+          value: "${TP_SIZE}"
         resources:
           requests:
             google.com/tpu: 1

--- a/scripts/disaggregation/run_raiden_smoke.sh
+++ b/scripts/disaggregation/run_raiden_smoke.sh
@@ -10,6 +10,14 @@ PREFILL_PORT=${PREFILL_PORT:-10000}
 DECODE_PORT=${DECODE_PORT:-10001}
 ROUTER_PORT=${ROUTER_PORT:-30000}
 MAX_INFLIGHT=${MAX_INFLIGHT:-2}
+DP_SIZE=${DP_SIZE:-1}
+TP_SIZE=${TP_SIZE:-1}
+
+if (( DP_SIZE < 1 || TP_SIZE < 1 || TP_SIZE % DP_SIZE != 0 )); then
+  printf 'TP_SIZE (%s) must be positive and divisible by DP_SIZE (%s)\n' \
+    "${TP_SIZE}" "${DP_SIZE}" >&2
+  exit 2
+fi
 
 wait_for_health() {
   local url=$1
@@ -22,6 +30,8 @@ wait_for_health() {
 
 common_args=(
   --model-path "${MODEL_PATH}"
+  --tp-size "${TP_SIZE}"
+  --dp-size "${DP_SIZE}"
   --page-size 128
   --disable-radix-cache
   --disaggregation-bootstrap-url "http://${PREFILL_HOST}:${BOOTSTRAP_PORT}"

--- a/test/srt/disaggregation/test_pd_bootstrap.py
+++ b/test/srt/disaggregation/test_pd_bootstrap.py
@@ -110,6 +110,23 @@ def test_register_multiple_room_hashing(server_and_client):
     assert set(seen) == {"p0", "p1", "p2"}
 
 
+def test_prefill_selection_isolated_by_dp_rank(server_and_client):
+    _, client = server_and_client
+    for dp_rank in range(4):
+        client.register_prefill(
+            bootstrap_key=f"p-dp-{dp_rank}",
+            host="10.0.0.1",
+            transfer_port=30001 + dp_rank,
+            side_channel_port=9600,
+            system_dp_rank=dp_rank,
+        )
+
+    for dp_rank in range(4):
+        info = client.get_prefill_info(bootstrap_room=17, dp_rank=dp_rank)
+        assert info["bootstrap_key"] == f"p-dp-{dp_rank}"
+        assert info["system_dp_rank"] == dp_rank
+
+
 def test_re_register_overwrites_and_refreshes(server_and_client):
     _, client = server_and_client
     client.register_prefill(
@@ -402,6 +419,30 @@ def test_transfer_metadata_is_reusable_per_process_and_ttl_bounded():
     assert registry.get_transfer(7, 1) is None
 
 
+def test_transfer_metadata_namespaces_same_page_ids_by_source_dp_rank():
+    registry = _Registry()
+    for source_dp_rank in range(4):
+        registry.register_transfer(
+            {
+                "bootstrap_room": 9,
+                "transfer_id": f"rank-{source_dp_rank}",
+                "jax_process_index": 0,
+                "source_dp_rank": source_dp_rank,
+                "transport_metadata": {"remote_block_ids": [1, 2]},
+            }
+        )
+
+    assert [registry.get_transfer(9, 0, rank)["transfer_id"] for rank in range(4)] == [
+        "rank-0",
+        "rank-1",
+        "rank-2",
+        "rank-3",
+    ]
+    registry.pop_room(9, 0, 2)
+    assert registry.get_transfer(9, 0, 2) is None
+    assert registry.get_transfer(9, 0, 1)["transfer_id"] == "rank-1"
+
+
 def test_prefill_decode_transfer_engines_must_match():
     info = {
         "protocol_version": 3,
@@ -421,6 +462,35 @@ def test_prefill_decode_transfer_engines_must_match():
             local_page_size=128,
             local_kv_dtype="bfloat16",
             expected_transfer_engine="jax",
+        )
+
+
+def test_prefill_decode_dp_topology_must_match():
+    info = {
+        "system_dp_rank": 2,
+        "transport_metadata": {"engine": "raiden", "dp_size": 4},
+    }
+    check_prefill_compat(
+        info,
+        local_page_size=128,
+        local_kv_dtype="bfloat16",
+        expected_transfer_engine="raiden",
+        expected_dp_rank=2,
+        expected_dp_size=4,
+    )
+    with pytest.raises(ValueError, match="source rank mismatch"):
+        check_prefill_compat(
+            info,
+            local_page_size=128,
+            local_kv_dtype="bfloat16",
+            expected_dp_rank=1,
+        )
+    with pytest.raises(ValueError, match="topology mismatch"):
+        check_prefill_compat(
+            info,
+            local_page_size=128,
+            local_kv_dtype="bfloat16",
+            expected_dp_size=2,
         )
 
 
@@ -605,11 +675,15 @@ def test_generate_req_input_carries_bootstrap_fields():
         bootstrap_host="10.0.0.1",
         bootstrap_port=8998,
         bootstrap_room=42,
+        dp_rank=3,
+        disagg_prefill_dp_rank=1,
         disagg_transfer_id="wire-1",
     )
     assert obj.bootstrap_host == "10.0.0.1"
     assert obj.bootstrap_port == 8998
     assert obj.bootstrap_room == 42
+    assert obj.dp_rank == 3
+    assert obj.disagg_prefill_dp_rank == 1
     assert obj.disagg_transfer_id == "wire-1"
 
 
@@ -618,19 +692,24 @@ def test_tokenized_generate_req_input_has_bootstrap_fields():
     assert tokenized.bootstrap_host is None
     assert tokenized.bootstrap_port is None
     assert tokenized.bootstrap_room is None
+    assert tokenized.disagg_prefill_dp_rank is None
     assert tokenized.disagg_transfer_id is None
 
     tokenized.bootstrap_host = "10.0.0.1"
     tokenized.bootstrap_port = 8998
     tokenized.bootstrap_room = 42
+    tokenized.dp_rank = 3
+    tokenized.disagg_prefill_dp_rank = 1
     tokenized.disagg_transfer_id = "wire-1"
     assert tokenized.bootstrap_host == "10.0.0.1"
     assert tokenized.bootstrap_port == 8998
     assert tokenized.bootstrap_room == 42
+    assert tokenized.dp_rank == 3
+    assert tokenized.disagg_prefill_dp_rank == 1
     assert tokenized.disagg_transfer_id == "wire-1"
 
 
-def _make_fake_tokenizer_manager(disaggregation_mode: str):
+def _make_fake_tokenizer_manager(disaggregation_mode: str, dp_size: int = 1):
     """Build a stripped-down TokenizerManager-ish object with just
     enough surface for ``_create_tokenized_object`` to run.
     """
@@ -645,6 +724,7 @@ def _make_fake_tokenizer_manager(disaggregation_mode: str):
     )
     tm.server_args = SimpleNamespace(
         disaggregation_mode=disaggregation_mode,
+        dp_size=dp_size,
     )
     return tm
 
@@ -672,6 +752,51 @@ def test_tokenizer_passes_bootstrap_fields_through_in_decode_mode():
     assert tokenized.bootstrap_port == 8998
     assert tokenized.bootstrap_room == 42
     assert tokenized.disagg_transfer_id == "wire-r1"
+    assert tokenized.dp_rank == 0
+    assert tokenized.disagg_prefill_dp_rank == 0
+
+
+def test_tokenizer_requires_explicit_source_and_destination_rank_for_dp():
+    tm = _make_fake_tokenizer_manager("decode", dp_size=4)
+    base = {
+        "rid": "r1",
+        "text": "hi",
+        "sampling_params": {"max_new_tokens": 4},
+        "bootstrap_host": "10.0.0.1",
+        "bootstrap_port": 8998,
+        "bootstrap_room": 42,
+    }
+    with (
+        mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
+        mock.patch.object(SamplingParams, "verify", lambda self, v: None),
+        pytest.raises(ValueError, match="explicit dp_rank"),
+    ):
+        tm._create_tokenized_object(
+            GenerateReqInput(**base), input_text="hi", input_ids=[1, 2, 3]
+        )
+
+    with (
+        mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
+        mock.patch.object(SamplingParams, "verify", lambda self, v: None),
+        pytest.raises(ValueError, match="explicit disagg_prefill_dp_rank"),
+    ):
+        tm._create_tokenized_object(
+            GenerateReqInput(**base, dp_rank=2),
+            input_text="hi",
+            input_ids=[1, 2, 3],
+        )
+
+    with (
+        mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
+        mock.patch.object(SamplingParams, "verify", lambda self, v: None),
+    ):
+        tokenized = tm._create_tokenized_object(
+            GenerateReqInput(**base, dp_rank=3, disagg_prefill_dp_rank=1),
+            input_text="hi",
+            input_ids=[1, 2, 3],
+        )
+    assert tokenized.dp_rank == 3
+    assert tokenized.disagg_prefill_dp_rank == 1
 
 
 def test_tokenizer_rejects_missing_fields_in_decode_mode():

--- a/test/srt/disaggregation/test_pd_bootstrap.py
+++ b/test/srt/disaggregation/test_pd_bootstrap.py
@@ -310,7 +310,7 @@ def test_heartbeat_daemon_survives_transient_server_errors():
     try:
         time.sleep(0.1)
         assert call_count["n"] >= 3, (
-            f"daemon should have kept beating after raises, " f"saw n={call_count['n']}"
+            f"daemon should have kept beating after raises, saw n={call_count['n']}"
         )
     finally:
         daemon.stop()
@@ -747,7 +747,9 @@ def test_tokenizer_passes_bootstrap_fields_through_in_decode_mode():
         mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
         mock.patch.object(SamplingParams, "verify", lambda self, v: None),
     ):
-        tokenized = tm._create_tokenized_object(obj, input_text="hi", input_ids=[1, 2, 3])
+        tokenized = tm._create_tokenized_object(
+            obj, input_text="hi", input_ids=[1, 2, 3]
+        )
     assert tokenized.bootstrap_host == "10.0.0.1"
     assert tokenized.bootstrap_port == 8998
     assert tokenized.bootstrap_room == 42
@@ -825,7 +827,9 @@ def test_tokenizer_allows_missing_fields_in_null_mode():
         mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
         mock.patch.object(SamplingParams, "verify", lambda self, v: None),
     ):
-        tokenized = tm._create_tokenized_object(obj, input_text="hi", input_ids=[1, 2, 3])
+        tokenized = tm._create_tokenized_object(
+            obj, input_text="hi", input_ids=[1, 2, 3]
+        )
     assert tokenized.bootstrap_room is None
 
 
@@ -842,7 +846,9 @@ def test_tokenizer_allows_missing_fields_in_prefill_mode():
         mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
         mock.patch.object(SamplingParams, "verify", lambda self, v: None),
     ):
-        tokenized = tm._create_tokenized_object(obj, input_text="hi", input_ids=[1, 2, 3])
+        tokenized = tm._create_tokenized_object(
+            obj, input_text="hi", input_ids=[1, 2, 3]
+        )
     assert tokenized.bootstrap_room is None
 
 
@@ -890,7 +896,9 @@ def test_decode_mode_auto_derives_from_bootstrap_url():
         mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
         mock.patch.object(SamplingParams, "verify", lambda self, v: None),
     ):
-        tokenized = tm._create_tokenized_object(obj, input_text="hi", input_ids=[1, 2, 3])
+        tokenized = tm._create_tokenized_object(
+            obj, input_text="hi", input_ids=[1, 2, 3]
+        )
     assert tokenized.bootstrap_host == "10.0.0.5"
     assert tokenized.bootstrap_port == 8998
     # Stable CRC32 of "r-auto".
@@ -916,7 +924,9 @@ def test_decode_mode_auto_derive_brackets_ipv6_host():
         mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
         mock.patch.object(SamplingParams, "verify", lambda self, v: None),
     ):
-        tokenized = tm._create_tokenized_object(obj, input_text="hi", input_ids=[1, 2, 3])
+        tokenized = tm._create_tokenized_object(
+            obj, input_text="hi", input_ids=[1, 2, 3]
+        )
     assert tokenized.bootstrap_host == "[fe80::1]"
     assert tokenized.bootstrap_port == 8998
 
@@ -939,7 +949,9 @@ def test_decode_mode_explicit_values_win_over_auto_derive():
         mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
         mock.patch.object(SamplingParams, "verify", lambda self, v: None),
     ):
-        tokenized = tm._create_tokenized_object(obj, input_text="hi", input_ids=[1, 2, 3])
+        tokenized = tm._create_tokenized_object(
+            obj, input_text="hi", input_ids=[1, 2, 3]
+        )
     assert tokenized.bootstrap_host == "10.0.0.99"
     assert tokenized.bootstrap_port == 9999
     assert tokenized.bootstrap_room == 42

--- a/test/srt/disaggregation/test_pd_bootstrap.py
+++ b/test/srt/disaggregation/test_pd_bootstrap.py
@@ -316,6 +316,23 @@ def test_heartbeat_daemon_survives_transient_server_errors():
         daemon.stop()
 
 
+def test_heartbeat_daemon_attempts_every_dp_rank_after_one_failure():
+    from sgl_jax.srt.disaggregation.bootstrap import HeartbeatDaemon
+
+    client = mock.MagicMock()
+
+    def _heartbeat(key):
+        if key == "rank-0":
+            raise RuntimeError("rank-0 transient")
+
+    client.heartbeat.side_effect = _heartbeat
+    daemon = HeartbeatDaemon(client, ["rank-0", "rank-1"])
+
+    daemon._heartbeat_once()
+
+    assert client.heartbeat.call_args_list == [mock.call("rank-0"), mock.call("rank-1")]
+
+
 # --- Protocol version skew tests ---
 
 

--- a/test/srt/disaggregation/test_pd_bootstrap.py
+++ b/test/srt/disaggregation/test_pd_bootstrap.py
@@ -436,15 +436,15 @@ def test_transfer_metadata_is_reusable_per_process_and_ttl_bounded():
     assert registry.get_transfer(7, 1) is None
 
 
-def test_transfer_metadata_namespaces_same_page_ids_by_source_dp_rank():
+def test_transfer_metadata_namespaces_same_page_ids_by_prefill_dp_rank():
     registry = _Registry()
-    for source_dp_rank in range(4):
+    for prefill_dp_rank in range(4):
         registry.register_transfer(
             {
                 "bootstrap_room": 9,
-                "transfer_id": f"rank-{source_dp_rank}",
+                "transfer_id": f"rank-{prefill_dp_rank}",
                 "jax_process_index": 0,
-                "source_dp_rank": source_dp_rank,
+                "prefill_dp_rank": prefill_dp_rank,
                 "transport_metadata": {"remote_block_ids": [1, 2]},
             }
         )
@@ -495,7 +495,7 @@ def test_prefill_decode_dp_topology_must_match():
         expected_dp_rank=2,
         expected_dp_size=4,
     )
-    with pytest.raises(ValueError, match="source rank mismatch"):
+    with pytest.raises(ValueError, match="Prefill rank mismatch"):
         check_prefill_compat(
             info,
             local_page_size=128,

--- a/test/srt/disaggregation/test_pd_bootstrap.py
+++ b/test/srt/disaggregation/test_pd_bootstrap.py
@@ -309,9 +309,9 @@ def test_heartbeat_daemon_survives_transient_server_errors():
     daemon.start()
     try:
         time.sleep(0.1)
-        assert call_count["n"] >= 3, (
-            f"daemon should have kept beating after raises, saw n={call_count['n']}"
-        )
+        assert (
+            call_count["n"] >= 3
+        ), f"daemon should have kept beating after raises, saw n={call_count['n']}"
     finally:
         daemon.stop()
 
@@ -764,9 +764,7 @@ def test_tokenizer_passes_bootstrap_fields_through_in_decode_mode():
         mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
         mock.patch.object(SamplingParams, "verify", lambda self, v: None),
     ):
-        tokenized = tm._create_tokenized_object(
-            obj, input_text="hi", input_ids=[1, 2, 3]
-        )
+        tokenized = tm._create_tokenized_object(obj, input_text="hi", input_ids=[1, 2, 3])
     assert tokenized.bootstrap_host == "10.0.0.1"
     assert tokenized.bootstrap_port == 8998
     assert tokenized.bootstrap_room == 42
@@ -790,9 +788,7 @@ def test_tokenizer_requires_explicit_source_and_destination_rank_for_dp():
         mock.patch.object(SamplingParams, "verify", lambda self, v: None),
         pytest.raises(ValueError, match="explicit dp_rank"),
     ):
-        tm._create_tokenized_object(
-            GenerateReqInput(**base), input_text="hi", input_ids=[1, 2, 3]
-        )
+        tm._create_tokenized_object(GenerateReqInput(**base), input_text="hi", input_ids=[1, 2, 3])
 
     with (
         mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
@@ -844,9 +840,7 @@ def test_tokenizer_allows_missing_fields_in_null_mode():
         mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
         mock.patch.object(SamplingParams, "verify", lambda self, v: None),
     ):
-        tokenized = tm._create_tokenized_object(
-            obj, input_text="hi", input_ids=[1, 2, 3]
-        )
+        tokenized = tm._create_tokenized_object(obj, input_text="hi", input_ids=[1, 2, 3])
     assert tokenized.bootstrap_room is None
 
 
@@ -863,9 +857,7 @@ def test_tokenizer_allows_missing_fields_in_prefill_mode():
         mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
         mock.patch.object(SamplingParams, "verify", lambda self, v: None),
     ):
-        tokenized = tm._create_tokenized_object(
-            obj, input_text="hi", input_ids=[1, 2, 3]
-        )
+        tokenized = tm._create_tokenized_object(obj, input_text="hi", input_ids=[1, 2, 3])
     assert tokenized.bootstrap_room is None
 
 
@@ -913,9 +905,7 @@ def test_decode_mode_auto_derives_from_bootstrap_url():
         mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
         mock.patch.object(SamplingParams, "verify", lambda self, v: None),
     ):
-        tokenized = tm._create_tokenized_object(
-            obj, input_text="hi", input_ids=[1, 2, 3]
-        )
+        tokenized = tm._create_tokenized_object(obj, input_text="hi", input_ids=[1, 2, 3])
     assert tokenized.bootstrap_host == "10.0.0.5"
     assert tokenized.bootstrap_port == 8998
     # Stable CRC32 of "r-auto".
@@ -941,9 +931,7 @@ def test_decode_mode_auto_derive_brackets_ipv6_host():
         mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
         mock.patch.object(SamplingParams, "verify", lambda self, v: None),
     ):
-        tokenized = tm._create_tokenized_object(
-            obj, input_text="hi", input_ids=[1, 2, 3]
-        )
+        tokenized = tm._create_tokenized_object(obj, input_text="hi", input_ids=[1, 2, 3])
     assert tokenized.bootstrap_host == "[fe80::1]"
     assert tokenized.bootstrap_port == 8998
 
@@ -966,9 +954,7 @@ def test_decode_mode_explicit_values_win_over_auto_derive():
         mock.patch.object(SamplingParams, "normalize", lambda self, t: None),
         mock.patch.object(SamplingParams, "verify", lambda self, v: None),
     ):
-        tokenized = tm._create_tokenized_object(
-            obj, input_text="hi", input_ids=[1, 2, 3]
-        )
+        tokenized = tm._create_tokenized_object(obj, input_text="hi", input_ids=[1, 2, 3])
     assert tokenized.bootstrap_host == "10.0.0.99"
     assert tokenized.bootstrap_port == 9999
     assert tokenized.bootstrap_room == 42

--- a/test/srt/disaggregation/test_pd_decode.py
+++ b/test/srt/disaggregation/test_pd_decode.py
@@ -333,9 +333,13 @@ def test_manager_owns_persistent_pull_worker_pool():
     """The manager starts a pool of long-lived workers that drain the queue
     and run each receiver's blocking pull off the event loop."""
 
-    mgr = JaxTransferKVManager(wrapper=object(), zmq_notifier=object(), pull_worker_count=4)
+    mgr = JaxTransferKVManager(
+        wrapper=object(), zmq_notifier=object(), pull_worker_count=4
+    )
 
-    worker_threads = [t for t in threading.enumerate() if t.name.startswith("jax-kv-pull-worker")]
+    worker_threads = [
+        t for t in threading.enumerate() if t.name.startswith("jax-kv-pull-worker")
+    ]
     assert len(worker_threads) == 4
     assert all(t.daemon for t in worker_threads)
 
@@ -429,7 +433,13 @@ class _AdmScheduler:
     _admit_decode_prealloc = SchedulerDisaggregationDecodeMixin._admit_decode_prealloc
 
     def __init__(
-        self, capacity, reserved, page_size=1, n_running=0, raise_on_init=False, max_inflight=0
+        self,
+        capacity,
+        reserved,
+        page_size=1,
+        n_running=0,
+        raise_on_init=False,
+        max_inflight=0,
     ):
         self.token_to_kv_pool_allocator = _Allocator(capacity, page_size)
         self.dp_size = 1
@@ -462,7 +472,9 @@ def _adm_p_info():
 
 
 def _enqueue(sched, rid, seqlen):
-    entry = DecodeBookkeeping(req_id=rid, req=_AdmReq(rid, seqlen), p_info=_adm_p_info())
+    entry = DecodeBookkeeping(
+        req_id=rid, req=_AdmReq(rid, seqlen), p_info=_adm_p_info()
+    )
     sched.disagg_prealloc_queue.add(entry)
     return entry
 
@@ -618,6 +630,40 @@ def test_cancel_matching_retains_inflight_entry_until_terminal():
     assert cancelled == [entry]
     assert entry.cancelled is True
     assert len(queue) == 1
+
+
+def test_cancelled_terminal_transfer_releases_destination_rank_pages():
+    class _CancelledDrainScheduler:
+        process_decode_queue = SchedulerDisaggregationDecodeMixin.process_decode_queue
+
+        def __init__(self, entry):
+            self.entry = entry
+            self.released = []
+
+        def _admit_decode_prealloc(self):
+            return
+
+        def _drain_transfer_queue_synced(self):
+            return [self.entry]
+
+        def _release_decode_kv_indices(self, kv_indices, dp_rank):
+            self.released.append((kv_indices, dp_rank))
+
+    req = _AdmReq("cancelled", 4)
+    req.dp_rank = 3
+    entry = DecodeBookkeeping(
+        req_id=req.rid,
+        req=req,
+        receiver=object(),
+        kv_indices=[12, 13, 14, 15],
+        synced_state=KVPoll.SUCCESS,
+        cancelled=True,
+    )
+    sched = _CancelledDrainScheduler(entry)
+
+    sched.process_decode_queue()
+
+    assert sched.released == [([12, 13, 14, 15], 3)]
 
 
 def test_inflight_cap_is_partitioned_per_rank_without_cross_rank_head_of_line():
@@ -868,7 +914,11 @@ class TestReaperLifecycle:
         assert m._reaper_thread is None
 
     def test_reaper_thread_fails_stale_participant(self):
-        m = _Mgr(ack_timeout_seconds=0.05, pull_timeout_seconds=0.0, reaper_interval_seconds=0.01)
+        m = _Mgr(
+            ack_timeout_seconds=0.05,
+            pull_timeout_seconds=0.0,
+            reaper_interval_seconds=0.01,
+        )
         s = _FakeParticipant(started_at=time.monotonic() - 1.0)
         m.register_sender("r1", s)
         m.start_reaper()
@@ -885,7 +935,11 @@ class TestTerminalRecords:
     def test_record_and_get(self):
         m = _mgr()
         m.record_terminal(
-            "r1", role="prefill", transfer_id="t1", state=KVPoll.FAILED, reason="timeout"
+            "r1",
+            role="prefill",
+            transfer_id="t1",
+            state=KVPoll.FAILED,
+            reason="timeout",
         )
         rec = m.get_terminal_record("r1", role="prefill")
         assert rec is not None
@@ -898,6 +952,8 @@ class TestTerminalRecords:
 
     def test_register_clears_prior_terminal_record(self):
         m = _mgr()
-        m.record_terminal("r1", role="prefill", transfer_id="t1", state=KVPoll.FAILED, reason="x")
+        m.record_terminal(
+            "r1", role="prefill", transfer_id="t1", state=KVPoll.FAILED, reason="x"
+        )
         m.register_sender("r1", _FakeParticipant(1.0))
         assert m.get_terminal_record("r1", role="prefill") is None

--- a/test/srt/disaggregation/test_pd_decode.py
+++ b/test/srt/disaggregation/test_pd_decode.py
@@ -620,6 +620,25 @@ def test_cancel_matching_retains_inflight_entry_until_terminal():
     assert len(queue) == 1
 
 
+def test_inflight_cap_is_partitioned_per_rank_without_cross_rank_head_of_line():
+    # Global cap 8 over DP4 gives each rank 2 Raiden slots. A third rank-0
+    # request must stay queued, while a later rank-1 request can still use its
+    # own manager's capacity.
+    sched = _AdmScheduler(capacity=100, reserved=0, max_inflight=8)
+    sched.dp_size = 4
+    _enqueue(sched, "rank0-a", seqlen=4).req.dp_rank = 0
+    _enqueue(sched, "rank0-b", seqlen=4).req.dp_rank = 0
+    _enqueue(sched, "rank0-c", seqlen=4).req.dp_rank = 0
+    _enqueue(sched, "rank1-a", seqlen=4).req.dp_rank = 1
+
+    sched._admit_decode_prealloc()
+
+    assert len(sched.disagg_transfer_queue) == 3
+    assert len(sched.disagg_prealloc_queue) == 1
+    assert sched.token_to_kv_pool_allocator.alloc_ranks == [0, 0, 1]
+    assert sched.aborted == []
+
+
 # ---- from test_pd_decode_bootstrap_cache.py ----
 
 

--- a/test/srt/disaggregation/test_pd_decode.py
+++ b/test/srt/disaggregation/test_pd_decode.py
@@ -358,18 +358,22 @@ class _Allocator:
         self._capacity = capacity
         self._used = 0
         self.freed = []
+        self.available_ranks = []
+        self.alloc_ranks = []
 
-    def available_size(self):
+    def available_size(self, dp_rank=0):
+        self.available_ranks.append(dp_rank)
         return self._capacity - self._used
 
-    def alloc(self, n):
+    def alloc(self, n, dp_rank=0):
+        self.alloc_ranks.append(dp_rank)
         if self._used + n > self._capacity:
             return None
         self._used += n
         return object()
 
-    def free(self, idx):
-        self.freed.append(idx)
+    def free(self, idx, dp_rank=0):
+        self.freed.append((idx, dp_rank))
 
 
 class _Receiver:
@@ -412,6 +416,8 @@ class _AdmReq:
         self.disagg_transfer_id = None
         self.bootstrap_room = 1
         self.origin_input_ids = list(range(seqlen))
+        self.dp_rank = 0
+        self.disagg_prefill_dp_rank = 0
 
 
 class _Batch:
@@ -426,6 +432,7 @@ class _AdmScheduler:
         self, capacity, reserved, page_size=1, n_running=0, raise_on_init=False, max_inflight=0
     ):
         self.token_to_kv_pool_allocator = _Allocator(capacity, page_size)
+        self.dp_size = 1
         self.server_args = _AdmServerArgs(reserved, max_inflight=max_inflight)
         self.running_batch = _Batch(n_running)
         self.disagg_prealloc_queue = DecodePreallocQueue()
@@ -443,8 +450,8 @@ class _AdmScheduler:
     def _record_decode_transfer_failure(self, reason):
         self.failures.append(reason)
 
-    def _release_decode_kv_indices(self, kv_indices):
-        self.token_to_kv_pool_allocator.free(kv_indices)
+    def _release_decode_kv_indices(self, kv_indices, dp_rank):
+        self.token_to_kv_pool_allocator.free(kv_indices, dp_rank=dp_rank)
 
     def _abort_decode_request(self, req, reason):
         self.aborted.append((req.rid, reason))
@@ -470,6 +477,22 @@ def test_admit_when_capacity_sufficient():
     assert len(sched.disagg_prealloc_queue) == 0
     assert len(sched.disagg_transfer_queue) == 2
     assert sched.aborted == []
+
+
+def test_admission_routes_allocator_and_transfer_to_destination_and_source_ranks():
+    sched = _AdmScheduler(capacity=100, reserved=0)
+    sched.dp_size = 4
+    entry = _enqueue(sched, "cross-rank", seqlen=4)
+    entry.req.dp_rank = 3
+    entry.req.disagg_prefill_dp_rank = 1
+
+    sched._admit_decode_prealloc()
+
+    assert sched.token_to_kv_pool_allocator.available_ranks[-1] == 3
+    assert sched.token_to_kv_pool_allocator.alloc_ranks == [3]
+    context = sched.disagg_kv_manager.created[0][1].inited
+    assert context.local_dp_rank == 3
+    assert context.source_dp_rank == 1
 
 
 def test_defer_when_capacity_insufficient_does_not_abort():
@@ -606,6 +629,8 @@ class _Req:
         self.bootstrap_room = room
         self.disagg_transfer_id = None
         self.origin_input_ids = [1, 2, 3, 4]
+        self.dp_rank = 0
+        self.disagg_prefill_dp_rank = 0
 
 
 class _ServerArgs:
@@ -631,7 +656,7 @@ class _FakeCache:
         self._results = list(results)
         self.calls = 0
 
-    def pick_for_room(self, room):
+    def pick_for_room(self, room, dp_rank=0):  # noqa: ARG002
         self.calls += 1
         return self._results.pop(0) if self._results else None
 
@@ -646,6 +671,7 @@ class _FakeScheduler:
 
     def __init__(self, cache):
         self.server_args = _ServerArgs()
+        self.dp_size = 1
         self.waiting_queue = []
         self.disagg_prefill_info_cache = cache
         self.disagg_prealloc_queue = DecodePreallocQueue()

--- a/test/srt/disaggregation/test_pd_decode.py
+++ b/test/srt/disaggregation/test_pd_decode.py
@@ -333,13 +333,9 @@ def test_manager_owns_persistent_pull_worker_pool():
     """The manager starts a pool of long-lived workers that drain the queue
     and run each receiver's blocking pull off the event loop."""
 
-    mgr = JaxTransferKVManager(
-        wrapper=object(), zmq_notifier=object(), pull_worker_count=4
-    )
+    mgr = JaxTransferKVManager(wrapper=object(), zmq_notifier=object(), pull_worker_count=4)
 
-    worker_threads = [
-        t for t in threading.enumerate() if t.name.startswith("jax-kv-pull-worker")
-    ]
+    worker_threads = [t for t in threading.enumerate() if t.name.startswith("jax-kv-pull-worker")]
     assert len(worker_threads) == 4
     assert all(t.daemon for t in worker_threads)
 
@@ -472,9 +468,7 @@ def _adm_p_info():
 
 
 def _enqueue(sched, rid, seqlen):
-    entry = DecodeBookkeeping(
-        req_id=rid, req=_AdmReq(rid, seqlen), p_info=_adm_p_info()
-    )
+    entry = DecodeBookkeeping(req_id=rid, req=_AdmReq(rid, seqlen), p_info=_adm_p_info())
     sched.disagg_prealloc_queue.add(entry)
     return entry
 
@@ -952,8 +946,6 @@ class TestTerminalRecords:
 
     def test_register_clears_prior_terminal_record(self):
         m = _mgr()
-        m.record_terminal(
-            "r1", role="prefill", transfer_id="t1", state=KVPoll.FAILED, reason="x"
-        )
+        m.record_terminal("r1", role="prefill", transfer_id="t1", state=KVPoll.FAILED, reason="x")
         m.register_sender("r1", _FakeParticipant(1.0))
         assert m.get_terminal_record("r1", role="prefill") is None

--- a/test/srt/disaggregation/test_pd_decode.py
+++ b/test/srt/disaggregation/test_pd_decode.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 import time
+from types import SimpleNamespace
+from unittest import mock
 
 from sgl_jax.srt.disaggregation.base.kv_manager import KVPoll
 from sgl_jax.srt.disaggregation.base.transfer import DecodeAdmission
@@ -376,6 +379,29 @@ class _Allocator:
         self.freed.append((idx, dp_rank))
 
 
+class _PerRankAllocator:
+    def __init__(self, capacities, *, fail_alloc_ranks=()):
+        self.page_size = 1
+        self._capacities = list(capacities)
+        self._used = [0] * len(self._capacities)
+        self._fail_alloc_ranks = set(fail_alloc_ranks)
+        self.freed = []
+
+    def available_size(self, dp_rank=0):
+        return self._capacities[dp_rank] - self._used[dp_rank]
+
+    def alloc(self, n, dp_rank=0):
+        if dp_rank in self._fail_alloc_ranks:
+            return None
+        if self._used[dp_rank] + n > self._capacities[dp_rank]:
+            return None
+        self._used[dp_rank] += n
+        return (dp_rank, n)
+
+    def free(self, idx, dp_rank=0):
+        self.freed.append((idx, dp_rank))
+
+
 class _Receiver:
     def __init__(self, raise_on_init=False):
         self._raise = raise_on_init
@@ -467,6 +493,34 @@ def _adm_p_info():
     return {"host": "1.2.3.4", "transfer_port": 5000, "side_channel_port": 5001}
 
 
+def test_abort_logs_when_source_rank_cannot_be_resolved(caplog):
+    class _AbortScheduler:
+        _abort_decode_request = SchedulerDisaggregationDecodeMixin._abort_decode_request
+
+        def __init__(self):
+            self.dp_size = 2
+            self.disagg_kv_manager = mock.Mock()
+            self._comm_backend = None
+            self.send_to_tokenizer = SimpleNamespace(send_pyobj=mock.Mock())
+
+        def _release_decode_req_resources(self, req):
+            pass
+
+    sched = _AbortScheduler()
+    req = SimpleNamespace(
+        rid="missing-source-rank",
+        bootstrap_room=17,
+        disagg_prefill_dp_rank=None,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        sched._abort_decode_request(req, "bootstrap_lookup")
+
+    sched.disagg_kv_manager.cleanup_transfer.assert_not_called()
+    assert "cannot resolve source DP rank" in caplog.text
+    sched.send_to_tokenizer.send_pyobj.assert_called_once()
+
+
 def _enqueue(sched, rid, seqlen):
     entry = DecodeBookkeeping(req_id=rid, req=_AdmReq(rid, seqlen), p_info=_adm_p_info())
     sched.disagg_prealloc_queue.add(entry)
@@ -499,6 +553,41 @@ def test_admission_routes_allocator_and_transfer_to_destination_and_source_ranks
     context = sched.disagg_kv_manager.created[0][1].inited
     assert context.local_dp_rank == 3
     assert context.source_dp_rank == 1
+
+
+def test_rank_local_capacity_block_does_not_starve_other_ranks_or_break_rank_fifo():
+    sched = _AdmScheduler(capacity=100, reserved=0, max_inflight=4)
+    sched.dp_size = 2
+    sched.token_to_kv_pool_allocator = _PerRankAllocator([0, 100])
+    rank0_head = _enqueue(sched, "rank0-head", seqlen=4)
+    rank0_head.req.dp_rank = 0
+    rank1 = _enqueue(sched, "rank1", seqlen=4)
+    rank1.req.dp_rank = 1
+    rank0_tail = _enqueue(sched, "rank0-tail", seqlen=1)
+    rank0_tail.req.dp_rank = 0
+
+    sched._admit_decode_prealloc()
+
+    assert sched.disagg_transfer_queue.count_by_rank(2) == [0, 1]
+    assert [entry.req_id for entry in sched.disagg_prealloc_queue.items_fifo()] == [
+        "rank0-head",
+        "rank0-tail",
+    ]
+
+
+def test_rank_local_alloc_shortfall_does_not_starve_other_ranks():
+    sched = _AdmScheduler(capacity=100, reserved=0, max_inflight=4)
+    sched.dp_size = 2
+    sched.token_to_kv_pool_allocator = _PerRankAllocator([100, 100], fail_alloc_ranks={0})
+    rank0 = _enqueue(sched, "rank0", seqlen=4)
+    rank0.req.dp_rank = 0
+    rank1 = _enqueue(sched, "rank1", seqlen=4)
+    rank1.req.dp_rank = 1
+
+    sched._admit_decode_prealloc()
+
+    assert sched.disagg_transfer_queue.count_by_rank(2) == [0, 1]
+    assert [entry.req_id for entry in sched.disagg_prealloc_queue.items_fifo()] == ["rank0"]
 
 
 def test_defer_when_capacity_insufficient_does_not_abort():

--- a/test/srt/disaggregation/test_pd_decode.py
+++ b/test/srt/disaggregation/test_pd_decode.py
@@ -493,7 +493,7 @@ def _adm_p_info():
     return {"host": "1.2.3.4", "transfer_port": 5000, "side_channel_port": 5001}
 
 
-def test_abort_logs_when_source_rank_cannot_be_resolved(caplog):
+def test_abort_logs_when_prefill_rank_cannot_be_resolved(caplog):
     class _AbortScheduler:
         _abort_decode_request = SchedulerDisaggregationDecodeMixin._abort_decode_request
 
@@ -508,7 +508,7 @@ def test_abort_logs_when_source_rank_cannot_be_resolved(caplog):
 
     sched = _AbortScheduler()
     req = SimpleNamespace(
-        rid="missing-source-rank",
+        rid="missing-prefill-rank",
         bootstrap_room=17,
         disagg_prefill_dp_rank=None,
     )
@@ -517,7 +517,7 @@ def test_abort_logs_when_source_rank_cannot_be_resolved(caplog):
         sched._abort_decode_request(req, "bootstrap_lookup")
 
     sched.disagg_kv_manager.cleanup_transfer.assert_not_called()
-    assert "cannot resolve source DP rank" in caplog.text
+    assert "cannot resolve Prefill DP rank" in caplog.text
     sched.send_to_tokenizer.send_pyobj.assert_called_once()
 
 
@@ -539,7 +539,7 @@ def test_admit_when_capacity_sufficient():
     assert sched.aborted == []
 
 
-def test_admission_routes_allocator_and_transfer_to_destination_and_source_ranks():
+def test_admission_routes_allocator_and_transfer_to_decode_and_prefill_ranks():
     sched = _AdmScheduler(capacity=100, reserved=0)
     sched.dp_size = 4
     entry = _enqueue(sched, "cross-rank", seqlen=4)
@@ -551,8 +551,8 @@ def test_admission_routes_allocator_and_transfer_to_destination_and_source_ranks
     assert sched.token_to_kv_pool_allocator.available_ranks[-1] == 3
     assert sched.token_to_kv_pool_allocator.alloc_ranks == [3]
     context = sched.disagg_kv_manager.created[0][1].inited
-    assert context.local_dp_rank == 3
-    assert context.source_dp_rank == 1
+    assert context.decode_dp_rank == 3
+    assert context.prefill_dp_rank == 1
 
 
 def test_rank_local_capacity_block_does_not_starve_other_ranks_or_break_rank_fifo():
@@ -715,7 +715,7 @@ def test_cancel_matching_retains_inflight_entry_until_terminal():
     assert len(queue) == 1
 
 
-def test_cancelled_terminal_transfer_releases_destination_rank_pages():
+def test_cancelled_terminal_transfer_releases_decode_rank_pages():
     class _CancelledDrainScheduler:
         process_decode_queue = SchedulerDisaggregationDecodeMixin.process_decode_queue
 
@@ -750,9 +750,6 @@ def test_cancelled_terminal_transfer_releases_destination_rank_pages():
 
 
 def test_inflight_cap_is_partitioned_per_rank_without_cross_rank_head_of_line():
-    # Global cap 8 over DP4 gives each rank 2 Raiden slots. A third rank-0
-    # request must stay queued, while a later rank-1 request can still use its
-    # own manager's capacity.
     sched = _AdmScheduler(capacity=100, reserved=0, max_inflight=8)
     sched.dp_size = 4
     _enqueue(sched, "rank0-a", seqlen=4).req.dp_rank = 0
@@ -804,7 +801,7 @@ class _FakeCache:
         self._results = list(results)
         self.calls = 0
 
-    def pick_for_room(self, room, dp_rank=0):  # noqa: ARG002
+    def pick_for_room(self, _room, _dp_rank=0):
         self.calls += 1
         return self._results.pop(0) if self._results else None
 

--- a/test/srt/disaggregation/test_pd_lifecycle.py
+++ b/test/srt/disaggregation/test_pd_lifecycle.py
@@ -47,7 +47,9 @@ class TestConstants:
         assert MIN_COMPATIBLE_VERSION <= PROTOCOL_VERSION
 
     def test_prefill_info_defaults_to_current_version(self):
-        info = PrefillInfo(bootstrap_key="h:1", host="h", transfer_port=1, side_channel_port=2)
+        info = PrefillInfo(
+            bootstrap_key="h:1", host="h", transfer_port=1, side_channel_port=2
+        )
         assert info.protocol_version == PROTOCOL_VERSION
 
 
@@ -146,7 +148,11 @@ class TestGracefulShutdown:
         assert r.failed_reason == "shutdown"
 
     def test_stops_reaper(self):
-        m = _Mgr(ack_timeout_seconds=10.0, pull_timeout_seconds=10.0, reaper_interval_seconds=0.01)
+        m = _Mgr(
+            ack_timeout_seconds=10.0,
+            pull_timeout_seconds=10.0,
+            reaper_interval_seconds=0.01,
+        )
         m.start_reaper()
         assert m._reaper_thread is not None
         m.graceful_shutdown(drain_timeout_seconds=0.0)
@@ -241,6 +247,24 @@ class TestRuntimeShutdownClosure:
         sched.disagg_bootstrap_client.unregister_prefill = _boom
         shutdown = _make_disagg_shutdown(sched, "prefill")
         shutdown()
+        assert sched.disagg_kv_manager.shutdown_calls == 1
+
+    def test_prefill_unregister_attempts_every_dp_rank_after_one_failure(self):
+        sched = _FakeScheduler()
+        sched.disagg_bootstrap_keys = ["h:1:dp_0", "h:1:dp_1"]
+        attempted = []
+
+        def _unregister(key):
+            attempted.append(key)
+            if key.endswith("dp_0"):
+                raise RuntimeError("rank-0 unregister failed")
+
+        sched.disagg_bootstrap_client.unregister_prefill = _unregister
+        shutdown = _make_disagg_shutdown(sched, "prefill")
+
+        shutdown()
+
+        assert attempted == ["h:1:dp_0", "h:1:dp_1"]
         assert sched.disagg_kv_manager.shutdown_calls == 1
 
 

--- a/test/srt/disaggregation/test_pd_lifecycle.py
+++ b/test/srt/disaggregation/test_pd_lifecycle.py
@@ -47,9 +47,7 @@ class TestConstants:
         assert MIN_COMPATIBLE_VERSION <= PROTOCOL_VERSION
 
     def test_prefill_info_defaults_to_current_version(self):
-        info = PrefillInfo(
-            bootstrap_key="h:1", host="h", transfer_port=1, side_channel_port=2
-        )
+        info = PrefillInfo(bootstrap_key="h:1", host="h", transfer_port=1, side_channel_port=2)
         assert info.protocol_version == PROTOCOL_VERSION
 
 

--- a/test/srt/disaggregation/test_pd_prefill.py
+++ b/test/srt/disaggregation/test_pd_prefill.py
@@ -180,7 +180,9 @@ class TestPrefillInfoFields:
         assert d["kv_dtype"] == "bfloat16"
 
     def test_defaults_are_backward_compatible(self):
-        info = PrefillInfo(bootstrap_key="h:1", host="h", transfer_port=1, side_channel_port=2)
+        info = PrefillInfo(
+            bootstrap_key="h:1", host="h", transfer_port=1, side_channel_port=2
+        )
         assert info.page_size == 0
         assert info.kv_dtype == ""
 
@@ -417,7 +419,9 @@ def _make_pool(pool_size=2):
 def _layers(padded_pages, seed=0):
     rng = np.random.default_rng(seed)
     return [
-        jnp.asarray(rng.standard_normal((padded_pages, *_PER_LAYER_SHAPE)).astype(np.float32))
+        jnp.asarray(
+            rng.standard_normal((padded_pages, *_PER_LAYER_SHAPE)).astype(np.float32)
+        )
         for _ in range(_LAYER_NUM)
     ]
 
@@ -530,7 +534,13 @@ def _make_mesh():
 def _make_kv_buffers(mesh, num_layers=_NUM_LAYERS, rng_seed=42):
     """Create per-layer KV buffers mimicking memory_pool.py layout."""
     rng = np.random.default_rng(rng_seed)
-    shape = (_NUM_PAGES_POOL, _PAGE_SIZE, _HEAD_NUM_KV * 2 // _PACKING, _PACKING, _HEAD_DIM)
+    shape = (
+        _NUM_PAGES_POOL,
+        _PAGE_SIZE,
+        _HEAD_NUM_KV * 2 // _PACKING,
+        _PACKING,
+        _HEAD_DIM,
+    )
     sharding = NamedSharding(mesh, P("data", None, "tensor", None, None))
     buffers = []
     for _ in range(num_layers):
@@ -579,14 +589,22 @@ class TestPerLayerGather:
             idx_sharding,
         )
         results = _jit_gather_all_layers(buffers, page_indices, gather_sharding)
-        expected_shape = (num_pages, _PAGE_SIZE, _HEAD_NUM_KV * 2 // _PACKING, _PACKING, _HEAD_DIM)
+        expected_shape = (
+            num_pages,
+            _PAGE_SIZE,
+            _HEAD_NUM_KV * 2 // _PACKING,
+            _PACKING,
+            _HEAD_DIM,
+        )
         for result in results:
             assert result.shape == expected_shape
 
     def test_gather_single_layer(self, setup):
         """_jit_gather_one_layer works correctly standalone."""
         buffers, gather_sharding, idx_sharding, _ = setup
-        page_indices = jax.device_put(jnp.array([0, 3, 7], dtype=jnp.int32), idx_sharding)
+        page_indices = jax.device_put(
+            jnp.array([0, 3, 7], dtype=jnp.int32), idx_sharding
+        )
         result = _jit_gather_one_layer(buffers[0], page_indices, gather_sharding)
         expected = np.asarray(buffers[0])[[0, 3, 7]]
         np.testing.assert_array_equal(np.asarray(result), expected)
@@ -594,7 +612,9 @@ class TestPerLayerGather:
     def test_gather_stack_matches_monolithic(self, setup):
         """jnp.stack(per_layer_results) matches what a monolithic gather would produce."""
         buffers, gather_sharding, idx_sharding, _ = setup
-        page_indices = jax.device_put(jnp.array([1, 5, 10, 20], dtype=jnp.int32), idx_sharding)
+        page_indices = jax.device_put(
+            jnp.array([1, 5, 10, 20], dtype=jnp.int32), idx_sharding
+        )
         per_layer = _jit_gather_all_layers(buffers, page_indices, gather_sharding)
         stacked = jnp.stack(per_layer, axis=0)
         assert stacked.shape[0] == _NUM_LAYERS
@@ -610,7 +630,9 @@ class TestPerLayerGather:
     def test_gather_duplicate_indices(self, setup):
         """Gathering same page multiple times works correctly."""
         buffers, gather_sharding, idx_sharding, _ = setup
-        page_indices = jax.device_put(jnp.array([0, 0, 0, 0], dtype=jnp.int32), idx_sharding)
+        page_indices = jax.device_put(
+            jnp.array([0, 0, 0, 0], dtype=jnp.int32), idx_sharding
+        )
         results = _jit_gather_all_layers(buffers, page_indices, gather_sharding)
         for i, result in enumerate(results):
             page0 = np.asarray(buffers[i])[0]
@@ -675,8 +697,12 @@ class TestGatherCompileCaching:
         _ = _jit_gather_one_layer(buffers[0], page_indices, gather_sharding)
 
         # Subsequent calls should use cached compilation
-        lowered_0 = _jit_gather_one_layer.lower(buffers[0], page_indices, gather_sharding)
-        lowered_1 = _jit_gather_one_layer.lower(buffers[1], page_indices, gather_sharding)
+        lowered_0 = _jit_gather_one_layer.lower(
+            buffers[0], page_indices, gather_sharding
+        )
+        lowered_1 = _jit_gather_one_layer.lower(
+            buffers[1], page_indices, gather_sharding
+        )
         # Same HLO text means same compiled kernel will be reused
         assert lowered_0.as_text() == lowered_1.as_text()
 
@@ -704,7 +730,10 @@ class _FakePool:
 
     def copy_from_device(self, layers, buffer_id):
         self.copy_calls.append((layers, buffer_id))
-        if self._raise_on_call is not None and len(self.copy_calls) == self._raise_on_call:
+        if (
+            self._raise_on_call is not None
+            and len(self.copy_calls) == self._raise_on_call
+        ):
             raise RuntimeError("simulated D2H failure")
         return StagedData(buffer_id=buffer_id, array_pytree=layers)
 
@@ -719,7 +748,9 @@ def test_path_a_uses_reserved_buffer_and_no_op_on_done():
     mgr._wrapper = w
     mgr._host_pool = pool
     layers = [jnp.ones((2, 3)), jnp.ones((2, 3))]
-    status = mgr.producer_handoff("uuid-1", {"kv": layers}, use_d2h_staging=True, buffer_id=5)
+    status = mgr.producer_handoff(
+        "uuid-1", {"kv": layers}, use_d2h_staging=True, buffer_id=5
+    )
     # copy_from_device called once with the reserved buffer id
     assert pool.copy_calls == [(layers, 5)]
     # registered under the sub-uuid as the pytree

--- a/test/srt/disaggregation/test_pd_prefill.py
+++ b/test/srt/disaggregation/test_pd_prefill.py
@@ -284,6 +284,22 @@ def test_room_modulo_selection_matches_server():
     assert cache.pick_for_room(4)["bootstrap_key"] == "b"  # 4 % 3 == 1
 
 
+def test_prefill_info_cache_filters_by_dp_rank():
+    clock = _Clock()
+    client = _FakeClient(
+        [
+            _pf("rank-1", system_dp_rank=1),
+            _pf("rank-0", system_dp_rank=0),
+            _pf("rank-3", system_dp_rank=3),
+            _pf("rank-2", system_dp_rank=2),
+        ]
+    )
+    cache = PrefillInfoCache(client, refresh_interval_s=1.0, clock=clock)
+
+    for rank in range(4):
+        assert cache.pick_for_room(123, rank)["bootstrap_key"] == f"rank-{rank}"
+
+
 def test_miss_is_rate_limited_then_resolves():
     clock = _Clock()
     client = _FakeClient([])  # no prefill registered yet

--- a/test/srt/disaggregation/test_pd_prefill.py
+++ b/test/srt/disaggregation/test_pd_prefill.py
@@ -180,9 +180,7 @@ class TestPrefillInfoFields:
         assert d["kv_dtype"] == "bfloat16"
 
     def test_defaults_are_backward_compatible(self):
-        info = PrefillInfo(
-            bootstrap_key="h:1", host="h", transfer_port=1, side_channel_port=2
-        )
+        info = PrefillInfo(bootstrap_key="h:1", host="h", transfer_port=1, side_channel_port=2)
         assert info.page_size == 0
         assert info.kv_dtype == ""
 
@@ -419,9 +417,7 @@ def _make_pool(pool_size=2):
 def _layers(padded_pages, seed=0):
     rng = np.random.default_rng(seed)
     return [
-        jnp.asarray(
-            rng.standard_normal((padded_pages, *_PER_LAYER_SHAPE)).astype(np.float32)
-        )
+        jnp.asarray(rng.standard_normal((padded_pages, *_PER_LAYER_SHAPE)).astype(np.float32))
         for _ in range(_LAYER_NUM)
     ]
 
@@ -602,9 +598,7 @@ class TestPerLayerGather:
     def test_gather_single_layer(self, setup):
         """_jit_gather_one_layer works correctly standalone."""
         buffers, gather_sharding, idx_sharding, _ = setup
-        page_indices = jax.device_put(
-            jnp.array([0, 3, 7], dtype=jnp.int32), idx_sharding
-        )
+        page_indices = jax.device_put(jnp.array([0, 3, 7], dtype=jnp.int32), idx_sharding)
         result = _jit_gather_one_layer(buffers[0], page_indices, gather_sharding)
         expected = np.asarray(buffers[0])[[0, 3, 7]]
         np.testing.assert_array_equal(np.asarray(result), expected)
@@ -612,9 +606,7 @@ class TestPerLayerGather:
     def test_gather_stack_matches_monolithic(self, setup):
         """jnp.stack(per_layer_results) matches what a monolithic gather would produce."""
         buffers, gather_sharding, idx_sharding, _ = setup
-        page_indices = jax.device_put(
-            jnp.array([1, 5, 10, 20], dtype=jnp.int32), idx_sharding
-        )
+        page_indices = jax.device_put(jnp.array([1, 5, 10, 20], dtype=jnp.int32), idx_sharding)
         per_layer = _jit_gather_all_layers(buffers, page_indices, gather_sharding)
         stacked = jnp.stack(per_layer, axis=0)
         assert stacked.shape[0] == _NUM_LAYERS
@@ -630,9 +622,7 @@ class TestPerLayerGather:
     def test_gather_duplicate_indices(self, setup):
         """Gathering same page multiple times works correctly."""
         buffers, gather_sharding, idx_sharding, _ = setup
-        page_indices = jax.device_put(
-            jnp.array([0, 0, 0, 0], dtype=jnp.int32), idx_sharding
-        )
+        page_indices = jax.device_put(jnp.array([0, 0, 0, 0], dtype=jnp.int32), idx_sharding)
         results = _jit_gather_all_layers(buffers, page_indices, gather_sharding)
         for i, result in enumerate(results):
             page0 = np.asarray(buffers[i])[0]
@@ -697,12 +687,8 @@ class TestGatherCompileCaching:
         _ = _jit_gather_one_layer(buffers[0], page_indices, gather_sharding)
 
         # Subsequent calls should use cached compilation
-        lowered_0 = _jit_gather_one_layer.lower(
-            buffers[0], page_indices, gather_sharding
-        )
-        lowered_1 = _jit_gather_one_layer.lower(
-            buffers[1], page_indices, gather_sharding
-        )
+        lowered_0 = _jit_gather_one_layer.lower(buffers[0], page_indices, gather_sharding)
+        lowered_1 = _jit_gather_one_layer.lower(buffers[1], page_indices, gather_sharding)
         # Same HLO text means same compiled kernel will be reused
         assert lowered_0.as_text() == lowered_1.as_text()
 
@@ -730,10 +716,7 @@ class _FakePool:
 
     def copy_from_device(self, layers, buffer_id):
         self.copy_calls.append((layers, buffer_id))
-        if (
-            self._raise_on_call is not None
-            and len(self.copy_calls) == self._raise_on_call
-        ):
+        if self._raise_on_call is not None and len(self.copy_calls) == self._raise_on_call:
             raise RuntimeError("simulated D2H failure")
         return StagedData(buffer_id=buffer_id, array_pytree=layers)
 
@@ -748,9 +731,7 @@ def test_path_a_uses_reserved_buffer_and_no_op_on_done():
     mgr._wrapper = w
     mgr._host_pool = pool
     layers = [jnp.ones((2, 3)), jnp.ones((2, 3))]
-    status = mgr.producer_handoff(
-        "uuid-1", {"kv": layers}, use_d2h_staging=True, buffer_id=5
-    )
+    status = mgr.producer_handoff("uuid-1", {"kv": layers}, use_d2h_staging=True, buffer_id=5)
     # copy_from_device called once with the reserved buffer id
     assert pool.copy_calls == [(layers, 5)]
     # registered under the sub-uuid as the pytree

--- a/test/srt/disaggregation/test_pd_prefill.py
+++ b/test/srt/disaggregation/test_pd_prefill.py
@@ -26,6 +26,7 @@ from sgl_jax.srt.disaggregation.jax_transfer.wrapper import JaxTransferWrapper
 from sgl_jax.srt.disaggregation.prefill import (
     _KV_GATHER_PAGE_BUCKETS,
     PrefillBootstrapQueue,
+    _globalize_rank_local_page_ids,
     _jit_gather_all_layers,
     _jit_gather_one_layer,
     _pad_to_page_bucket,
@@ -670,6 +671,29 @@ class TestPadToPageBucket:
     )
     def test_bucket_selection(self, input_pages, expected_bucket):
         assert _pad_to_page_bucket(input_pages) == expected_bucket
+
+
+class TestGlobalizeRankLocalPageIds:
+    def test_offsets_each_rank_by_its_padded_global_page_shard(self):
+        local_ids = np.array([0, 1, 4], dtype=np.int32)
+
+        actual = _globalize_rank_local_page_ids(
+            local_ids,
+            dp_rank=2,
+            dp_size=4,
+            total_pages=20,
+        )
+
+        np.testing.assert_array_equal(actual, np.array([10, 11, 14], dtype=np.int32))
+
+    def test_rejects_page_ids_outside_the_rank_local_shard(self):
+        with pytest.raises(ValueError, match="rank-local KV page IDs"):
+            _globalize_rank_local_page_ids(
+                np.array([5], dtype=np.int32),
+                dp_rank=0,
+                dp_size=4,
+                total_pages=20,
+            )
 
 
 class TestGatherCompileCaching:

--- a/test/srt/disaggregation/test_pd_raiden.py
+++ b/test/srt/disaggregation/test_pd_raiden.py
@@ -10,7 +10,6 @@ import types
 from unittest import mock
 
 import pytest
-
 from sgl_jax.raiden import raiden_requested
 from sgl_jax.srt.disaggregation.base.kv_manager import KVPoll
 from sgl_jax.srt.disaggregation.base.transfer import (
@@ -18,6 +17,7 @@ from sgl_jax.srt.disaggregation.base.transfer import (
     DecodeTransferContext,
     slots_to_page_ids,
 )
+from sgl_jax.srt.disaggregation.common.capacity import per_rank_inflight_limit
 from sgl_jax.srt.disaggregation.factory import create_transfer_backend
 from sgl_jax.srt.disaggregation.raiden_transfer.conn import (
     RaidenMetadata,
@@ -608,6 +608,16 @@ def test_raiden_cli_is_opt_in():
     )
     assert defaults.disaggregation_use_raiden is False
     assert selected.disaggregation_use_raiden is True
+
+
+@pytest.mark.parametrize(
+    ("max_inflight", "dp_size", "expected"),
+    [(8, 1, 8), (8, 2, 4), (32, 4, 8), (10, 4, 3), (0, 4, 0)],
+)
+def test_raiden_inflight_capacity_is_partitioned_per_rank(
+    max_inflight, dp_size, expected
+):
+    assert per_rank_inflight_limit(max_inflight, dp_size) == expected
 
 
 @pytest.mark.parametrize(

--- a/test/srt/disaggregation/test_pd_raiden.py
+++ b/test/srt/disaggregation/test_pd_raiden.py
@@ -48,21 +48,45 @@ class _FakeBootstrap:
 
 
 class _FakeRaiden:
-    endpoints = [{"endpoint": "10.0.0.1:7777", "shards": [0]}]
     control_port = 7777
 
-    def __init__(self) -> None:
+    def __init__(self, dp_size: int = 1) -> None:
+        self.dp_size = dp_size
+        self._endpoints_by_dp_rank = {
+            rank: [
+                {
+                    "endpoint": f"10.0.0.1:{7777 + rank * 10}",
+                    "shards": [0],
+                }
+            ]
+            for rank in range(dp_size)
+        }
         self.registered: list[tuple] = []
         self.started: list[tuple] = []
         self.stats = ([], [], [])
         self.register_result = True
 
-    def register_read(self, *args):
-        self.registered.append(args)
+    @property
+    def endpoints_by_dp_rank(self):
+        return {
+            rank: list(endpoints)
+            for rank, endpoints in self._endpoints_by_dp_rank.items()
+        }
+
+    @property
+    def endpoints(self):
+        return self._endpoints_by_dp_rank.get(0, [])
+
+    @endpoints.setter
+    def endpoints(self, value):
+        self._endpoints_by_dp_rank[0] = value
+
+    def register_read(self, *args, **kwargs):
+        self.registered.append((args, kwargs))
         return self.register_result
 
-    def start_read(self, *args):
-        self.started.append(args)
+    def start_read(self, *args, **kwargs):
+        self.started.append((args, kwargs))
 
     def poll_stats(self):
         return self.stats
@@ -78,14 +102,17 @@ def test_raiden_sender_registers_once_and_completes_from_poll_stats():
     manager = _manager(raiden, bootstrap)
     sender = manager.create_sender("req-1")
     sender.init(None, transfer_id="wire-1")
-    sender.attach_block_ids([3, 8, 13], bootstrap_room=42)
+    sender.attach_block_ids([3, 8, 13], bootstrap_room=42, dp_rank=0)
 
     sender.send()
 
-    assert raiden.registered == [("wire-1", _uuid_to_int("wire-1"), [3, 8, 13])]
+    assert raiden.registered == [
+        (("wire-1", _uuid_to_int("wire-1"), [3, 8, 13]), {"dp_rank": 0})
+    ]
     assert bootstrap.registered[0][0] == (42, "wire-1")
     assert bootstrap.registered[0][1] == {
         "jax_process_index": 0,
+        "source_dp_rank": 0,
         "transport_metadata": {"remote_block_ids": [3, 8, 13]},
     }
     assert sender.poll() == KVPoll.TRANSFERRING
@@ -112,11 +139,16 @@ def test_raiden_receiver_starts_direct_block_read_and_pops_metadata():
     )
 
     assert receiver.poll() == KVPoll.TRANSFERRING
-    assert raiden.started == [("wire-2", _uuid_to_int("wire-2"), "10.0.0.1:7777", [1, 4], [9, 10])]
+    assert raiden.started == [
+        (
+            ("wire-2", _uuid_to_int("wire-2"), "10.0.0.1:7777", [1, 4], [9, 10]),
+            {"local_dp_rank": 0},
+        )
+    ]
 
     raiden.stats = ([], ["wire-2"], [])
     assert receiver.poll() == KVPoll.SUCCESS
-    assert bootstrap.popped == [(43, {"jax_process_index": 3})]
+    assert bootstrap.popped == [(43, {"jax_process_index": 3, "source_dp_rank": 0})]
     assert "req-2" not in manager._receivers
 
 
@@ -164,7 +196,7 @@ def test_raiden_failure_and_abort_cleanup_are_terminal_and_idempotent():
     raiden.stats = ([], [], ["wire-3"])
     assert receiver.poll() == KVPoll.FAILED
     receiver.abort()
-    assert bootstrap.popped == [(44, {"jax_process_index": 0})]
+    assert bootstrap.popped == [(44, {"jax_process_index": 0, "source_dp_rank": 0})]
 
 
 def test_raiden_abort_waits_for_engine_terminal_before_cleanup():
@@ -260,6 +292,7 @@ def test_raiden_manager_owns_decode_admission_and_endpoint_mapping():
     bootstrap = _FakeBootstrap()
     bootstrap.transfer_info = {
         "transfer_id": "wire-4",
+        "source_dp_rank": 0,
         "transport_metadata": {"remote_block_ids": [3, 4]},
     }
     manager = _manager(raiden, bootstrap)
@@ -267,10 +300,14 @@ def test_raiden_manager_owns_decode_admission_and_endpoint_mapping():
         req_id="req-4",
         transfer_id="wire-4",
         bootstrap_room=45,
+        local_dp_rank=0,
+        source_dp_rank=0,
         peer_info={
             "host": "10.0.0.1",
             "transport_metadata": {
                 "engine": "raiden",
+                "dp_rank": 0,
+                "dp_size": 1,
                 "local_control_port": 7777,
                 "endpoints": raiden.endpoints,
             },
@@ -286,7 +323,62 @@ def test_raiden_manager_owns_decode_admission_and_endpoint_mapping():
     assert admission.state == AdmissionState.ADMITTED
     assert admission.receiver is not None
     assert admission.receiver.poll() == KVPoll.TRANSFERRING
-    assert raiden.started == [("wire-4", _uuid_to_int("wire-4"), "10.0.0.1:7777", [3, 4], [9, 10])]
+    assert raiden.started == [
+        (
+            ("wire-4", _uuid_to_int("wire-4"), "10.0.0.1:7777", [3, 4], [9, 10]),
+            {"local_dp_rank": 0},
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("source_dp_rank", "local_dp_rank"),
+    [(source, destination) for source in range(4) for destination in range(4)],
+)
+def test_raiden_manager_routes_all_dp4_source_destination_pairs(
+    source_dp_rank, local_dp_rank
+):
+    raiden = _FakeRaiden(dp_size=4)
+    bootstrap = _FakeBootstrap()
+    bootstrap.transfer_info = {
+        "transfer_id": "wire-cross",
+        "source_dp_rank": source_dp_rank,
+        "transport_metadata": {"remote_block_ids": [1]},
+    }
+    manager = _manager(raiden, bootstrap)
+    source_endpoints = raiden.endpoints_by_dp_rank[source_dp_rank]
+
+    admission = manager.try_start_decode(
+        DecodeTransferContext(
+            req_id="req-cross",
+            transfer_id="wire-cross",
+            bootstrap_room=91,
+            local_dp_rank=local_dp_rank,
+            source_dp_rank=source_dp_rank,
+            peer_info={
+                "host": "10.0.0.9",
+                "system_dp_rank": source_dp_rank,
+                "transport_metadata": {
+                    "engine": "raiden",
+                    "dp_rank": source_dp_rank,
+                    "dp_size": 4,
+                    "endpoints": source_endpoints,
+                },
+            },
+            kv_indices=[2, 3],
+            page_size=2,
+            prompt_tokens=2,
+            spec_factory=lambda: None,
+        )
+    )
+
+    assert admission.state == AdmissionState.ADMITTED
+    assert bootstrap.transfer_info is not None
+    assert admission.receiver.poll() == KVPoll.TRANSFERRING
+    args, kwargs = raiden.started[-1]
+    assert args[2] == f"10.0.0.9:{7777 + source_dp_rank * 10}"
+    assert args[3:] == ([1], [1])
+    assert kwargs == {"local_dp_rank": local_dp_rank}
 
 
 def test_raiden_manager_rejects_peer_without_endpoint_descriptors():
@@ -294,6 +386,7 @@ def test_raiden_manager_rejects_peer_without_endpoint_descriptors():
     bootstrap = _FakeBootstrap()
     bootstrap.transfer_info = {
         "transfer_id": "wire-legacy",
+        "source_dp_rank": 0,
         "transport_metadata": {"remote_block_ids": [3]},
     }
     manager = _manager(raiden, bootstrap)
@@ -338,6 +431,8 @@ def test_raiden_preserves_published_shard_endpoints():
             req_id="req-shards",
             transfer_id="wire-shards",
             bootstrap_room=50,
+            local_dp_rank=0,
+            source_dp_rank=0,
             peer_info={
                 "host": "10.0.0.1",
                 "transport_metadata": {"engine": "raiden", "endpoints": endpoints},
@@ -357,6 +452,49 @@ def test_raiden_preserves_published_shard_endpoints():
     ]
 
 
+def test_raiden_manager_preserves_each_published_endpoint_port_and_shards():
+    raiden = _FakeRaiden()
+    raiden._endpoints_by_dp_rank[0] = [
+        {"endpoint": "0.0.0.0:7001", "shards": [0, 2]},
+        {"endpoint": "0.0.0.0:7999", "shards": [1, 3]},
+    ]
+    bootstrap = _FakeBootstrap()
+    bootstrap.transfer_info = {
+        "transfer_id": "wire-endpoints",
+        "source_dp_rank": 0,
+        "transport_metadata": {"remote_block_ids": [1]},
+    }
+    manager = _manager(raiden, bootstrap)
+    admission = manager.try_start_decode(
+        DecodeTransferContext(
+            req_id="req-endpoints",
+            transfer_id="wire-endpoints",
+            bootstrap_room=48,
+            local_dp_rank=0,
+            source_dp_rank=0,
+            peer_info={
+                "host": "10.0.0.8",
+                "transport_metadata": {
+                    "engine": "raiden",
+                    "dp_rank": 0,
+                    "dp_size": 1,
+                    "endpoints": raiden.endpoints,
+                },
+            },
+            kv_indices=[2, 3],
+            page_size=2,
+            prompt_tokens=2,
+            spec_factory=lambda: None,
+        )
+    )
+    assert admission.receiver.poll() == KVPoll.TRANSFERRING
+    remote = raiden.started[-1][0][2]
+    assert remote == [
+        {"endpoint": "10.0.0.8:7001", "shards": [0, 2]},
+        {"endpoint": "10.0.0.8:7999", "shards": [1, 3]},
+    ]
+
+
 def test_raiden_manager_defers_until_request_metadata_is_published():
     manager = _manager(_FakeRaiden(), _FakeBootstrap())
     admission = manager.try_start_decode(
@@ -364,6 +502,8 @@ def test_raiden_manager_defers_until_request_metadata_is_published():
             req_id="req-5",
             transfer_id="wire-5",
             bootstrap_room=46,
+            local_dp_rank=0,
+            source_dp_rank=0,
             peer_info={},
             kv_indices=[],
             page_size=128,
@@ -379,7 +519,7 @@ def test_raiden_prefill_metadata_requires_a_bound_control_port():
     raiden.endpoints = []
     raiden.control_port = 0
 
-    with pytest.raises(RuntimeError, match="valid control endpoint"):
+    with pytest.raises(RuntimeError, match="did not publish endpoints"):
         _manager(raiden, _FakeBootstrap()).prefill_transport_metadata()
 
 
@@ -424,7 +564,9 @@ def test_register_read_false_does_not_publish_stale_metadata():
 def test_raiden_loader_is_opt_in():
     assert not raiden_requested([])
     assert raiden_requested(["--disaggregation-use-raiden"])
-    assert not raiden_requested(["--disaggregation-use-raiden", "--no-disaggregation-use-raiden"])
+    assert not raiden_requested(
+        ["--disaggregation-use-raiden", "--no-disaggregation-use-raiden"]
+    )
 
 
 def test_launch_server_spawn_reimport_preloads_raiden_before_jax():
@@ -461,7 +603,9 @@ def test_raiden_cli_is_opt_in():
     parser = argparse.ArgumentParser()
     ServerArgs.add_cli_args(parser)
     defaults = parser.parse_args(["--model-path", "dummy"])
-    selected = parser.parse_args(["--model-path", "dummy", "--disaggregation-use-raiden"])
+    selected = parser.parse_args(
+        ["--model-path", "dummy", "--disaggregation-use-raiden"]
+    )
     assert defaults.disaggregation_use_raiden is False
     assert selected.disaggregation_use_raiden is True
 
@@ -498,7 +642,9 @@ def test_raiden_factory_rejects_invalid_config(override, error):
 
 def test_raiden_wrapper_uses_public_jax_api_and_configured_parallelism():
     engine = mock.MagicMock()
-    engine.get_local_endpoints.return_value = [{"endpoint": "127.0.0.1:7788", "shards": [0]}]
+    engine.get_local_endpoints.return_value = [
+        {"endpoint": "127.0.0.1:7788", "shards": [0]}
+    ]
     manager_cls = mock.MagicMock(return_value=engine)
     modules = {
         "tpu_raiden": types.ModuleType("tpu_raiden"),
@@ -520,3 +666,47 @@ def test_raiden_wrapper_uses_public_jax_api_and_configured_parallelism():
     assert kwargs["num_slots"] == 8
     assert kwargs["unsafe_skip_buffer_lock"] is True
     engine.start_read.assert_called_once_with("req", 11, "remote:1", [1], [2], 3)
+
+
+def test_raiden_wrapper_routes_each_operation_to_its_dp_manager():
+    engines = [mock.MagicMock() for _ in range(4)]
+    for rank, engine in enumerate(engines):
+        engine.get_local_endpoints.return_value = [
+            {"endpoint": f"127.0.0.1:{7800 + rank}", "shards": [0]}
+        ]
+        engine.register_read.return_value = True
+        engine.poll_stats.return_value = ([], [], [])
+    manager_cls = mock.MagicMock(side_effect=engines)
+    modules = {
+        "tpu_raiden": types.ModuleType("tpu_raiden"),
+        "tpu_raiden.api": types.ModuleType("tpu_raiden.api"),
+        "tpu_raiden.api.jax": types.ModuleType("tpu_raiden.api.jax"),
+        "tpu_raiden.api.jax.kv_cache_manager": types.ModuleType(
+            "tpu_raiden.api.jax.kv_cache_manager"
+        ),
+    }
+    modules["tpu_raiden.api.jax.kv_cache_manager"].KVCacheManager = manager_cls
+
+    with (
+        mock.patch.dict(sys.modules, modules),
+        mock.patch(
+            "sgl_jax.srt.disaggregation.raiden_transfer.wrapper._split_kv_caches_by_dp_rank",
+            return_value={rank: [f"rank-{rank}"] for rank in range(4)},
+        ),
+    ):
+        wrapper = RaidenTransferWrapper("127.0.0.1", 0, parallelism=2)
+        wrapper.start([object()], max_blocks=8, num_slots=4, dp_size=4)
+        wrapper.register_read("req", 7, [1], dp_rank=2)
+        wrapper.start_read(
+            "req",
+            7,
+            "remote:1",
+            [1],
+            [2],
+            local_dp_rank=3,
+        )
+
+    assert wrapper.dp_size == 4
+    assert sorted(wrapper.endpoints_by_dp_rank) == [0, 1, 2, 3]
+    engines[2].register_read.assert_called_once_with("req", 7, [1])
+    engines[3].start_read.assert_called_once_with("req", 7, "remote:1", [1], [2], 2)

--- a/test/srt/disaggregation/test_pd_raiden.py
+++ b/test/srt/disaggregation/test_pd_raiden.py
@@ -217,7 +217,7 @@ def test_raiden_abort_waits_for_engine_terminal_before_cleanup():
     raiden.stats = (["wire-abort"], [], [])
     assert sender.poll() == KVPoll.FAILED
     assert "req-abort" not in manager._senders
-    assert bootstrap.popped == [(48, {"jax_process_index": 0})]
+    assert bootstrap.popped == [(48, {"jax_process_index": 0, "source_dp_rank": 0})]
 
 
 def test_raiden_receiver_abort_waits_for_engine_terminal():
@@ -245,7 +245,7 @@ def test_raiden_receiver_abort_waits_for_engine_terminal():
     raiden.stats = ([], ["wire-abort"], [])
     assert receiver.poll() == KVPoll.FAILED
     assert "req-abort" not in manager._receivers
-    assert bootstrap.popped == [(49, {"jax_process_index": 0})]
+    assert bootstrap.popped == [(49, {"jax_process_index": 0, "source_dp_rank": 0})]
 
 
 def test_raiden_reaper_marks_timeout_without_pruning_sender():
@@ -376,7 +376,7 @@ def test_raiden_manager_routes_all_dp4_source_destination_pairs(
     assert bootstrap.transfer_info is not None
     assert admission.receiver.poll() == KVPoll.TRANSFERRING
     args, kwargs = raiden.started[-1]
-    assert args[2] == f"10.0.0.9:{7777 + source_dp_rank * 10}"
+    assert args[2] == f"10.0.0.1:{7777 + source_dp_rank * 10}"
     assert args[3:] == ([1], [1])
     assert kwargs == {"local_dp_rank": local_dp_rank}
 
@@ -397,6 +397,8 @@ def test_raiden_manager_rejects_peer_without_endpoint_descriptors():
                 req_id="req-legacy",
                 transfer_id="wire-legacy",
                 bootstrap_room=47,
+                local_dp_rank=0,
+                source_dp_rank=0,
                 peer_info={
                     "host": "10.0.0.1",
                     "local_control_port": 7777,
@@ -446,7 +448,7 @@ def test_raiden_preserves_published_shard_endpoints():
 
     assert admission.receiver is not None
     admission.receiver.poll()
-    assert raiden.started[0][2] == [
+    assert raiden.started[0][0][2] == [
         {"endpoint": "10.0.0.1:7001", "shards": [0, 2]},
         {"endpoint": "10.0.0.1:7013", "shards": [1, 3]},
     ]

--- a/test/srt/disaggregation/test_pd_raiden.py
+++ b/test/srt/disaggregation/test_pd_raiden.py
@@ -9,7 +9,10 @@ import sys
 import types
 from unittest import mock
 
+import jax
+import numpy as np
 import pytest
+from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec
 
 from sgl_jax.raiden import raiden_requested
 from sgl_jax.srt.disaggregation.base.kv_manager import KVPoll
@@ -25,7 +28,10 @@ from sgl_jax.srt.disaggregation.raiden_transfer.conn import (
     RaidenTransferKVManager,
     _uuid_to_int,
 )
-from sgl_jax.srt.disaggregation.raiden_transfer.wrapper import RaidenTransferWrapper
+from sgl_jax.srt.disaggregation.raiden_transfer.wrapper import (
+    RaidenTransferWrapper,
+    _rank_local_array,
+)
 from sgl_jax.srt.server_args import ServerArgs
 
 
@@ -708,3 +714,55 @@ def test_raiden_wrapper_routes_each_operation_to_its_dp_manager():
     assert sorted(wrapper.endpoints_by_dp_rank) == [0, 1, 2, 3]
     engines[2].register_read.assert_called_once_with("req", 7, [1])
     engines[3].start_read.assert_called_once_with("req", 7, "remote:1", [1], [2], 2)
+
+
+def test_raiden_wrapper_preserves_drained_events_when_one_rank_poll_fails(caplog):
+    engines = [mock.MagicMock() for _ in range(3)]
+    engines[0].poll_stats.return_value = (["sent-0"], [], ["failed-0"])
+    engines[1].poll_stats.side_effect = RuntimeError("rank poll failed")
+    engines[2].poll_stats.return_value = ([], ["received-2"], [])
+    wrapper = RaidenTransferWrapper("127.0.0.1")
+    wrapper._engines = {rank: engine for rank, engine in enumerate(engines)}
+
+    with caplog.at_level("ERROR"):
+        stats = wrapper.poll_stats()
+
+    assert stats == (["sent-0"], ["received-2"], ["failed-0"])
+    assert "Raiden poll_stats failed for dp_rank=1" in caplog.text
+
+
+def test_rank_local_array_builds_real_views_for_each_data_rank():
+    devices = jax.local_devices()
+    if jax.process_count() != 1 or len(devices) < 2 or len(devices) % 2:
+        pytest.skip("requires an even number of locally addressable JAX devices")
+    mesh = Mesh(
+        np.asarray(devices).reshape(2, len(devices) // 2),
+        ("data", "tensor"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit),
+    )
+    sharding = NamedSharding(mesh, PartitionSpec("data", None))
+    source = np.arange(32, dtype=np.int32).reshape(8, 4)
+    array = jax.device_put(source, sharding)
+
+    rank0 = _rank_local_array(array, dp_rank=0, dp_size=2)
+    rank1 = _rank_local_array(array, dp_rank=1, dp_size=2)
+
+    assert rank0.shape == rank1.shape == (4, 4)
+    np.testing.assert_array_equal(np.asarray(rank0), source[:4])
+    np.testing.assert_array_equal(np.asarray(rank1), source[4:])
+
+
+def test_rank_local_array_rejects_kv_replicated_across_data_axis():
+    devices = jax.local_devices()
+    if jax.process_count() != 1 or len(devices) < 2 or len(devices) % 2:
+        pytest.skip("requires an even number of locally addressable JAX devices")
+    mesh = Mesh(
+        np.asarray(devices).reshape(2, len(devices) // 2),
+        ("data", "tensor"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit),
+    )
+    sharding = NamedSharding(mesh, PartitionSpec(None, None))
+    array = jax.device_put(np.arange(32, dtype=np.int32).reshape(8, 4), sharding)
+
+    with pytest.raises(ValueError, match="KV PartitionSpec"):
+        _rank_local_array(array, dp_rank=0, dp_size=2)

--- a/test/srt/disaggregation/test_pd_raiden.py
+++ b/test/srt/disaggregation/test_pd_raiden.py
@@ -50,7 +50,7 @@ class _FakeBootstrap:
     def pop_transfer(self, room: int, **kwargs) -> None:
         self.popped.append((room, kwargs))
 
-    def get_transfer_info(self, room: int, **kwargs):  # noqa: ARG002
+    def get_transfer_info(self, _room: int, **_kwargs):
         return self.transfer_info
 
 
@@ -114,7 +114,7 @@ def test_raiden_sender_registers_once_and_completes_from_poll_stats():
     assert bootstrap.registered[0][0] == (42, "wire-1")
     assert bootstrap.registered[0][1] == {
         "jax_process_index": 0,
-        "source_dp_rank": 0,
+        "prefill_dp_rank": 0,
         "transport_metadata": {"remote_block_ids": [3, 8, 13]},
     }
     assert sender.poll() == KVPoll.TRANSFERRING
@@ -144,13 +144,13 @@ def test_raiden_receiver_starts_direct_block_read_and_pops_metadata():
     assert raiden.started == [
         (
             ("wire-2", _uuid_to_int("wire-2"), "10.0.0.1:7777", [1, 4], [9, 10]),
-            {"local_dp_rank": 0},
+            {"decode_dp_rank": 0},
         )
     ]
 
     raiden.stats = ([], ["wire-2"], [])
     assert receiver.poll() == KVPoll.SUCCESS
-    assert bootstrap.popped == [(43, {"jax_process_index": 3, "source_dp_rank": 0})]
+    assert bootstrap.popped == [(43, {"jax_process_index": 3, "prefill_dp_rank": 0})]
     assert "req-2" not in manager._receivers
 
 
@@ -198,7 +198,7 @@ def test_raiden_failure_and_abort_cleanup_are_terminal_and_idempotent():
     raiden.stats = ([], [], ["wire-3"])
     assert receiver.poll() == KVPoll.FAILED
     receiver.abort()
-    assert bootstrap.popped == [(44, {"jax_process_index": 0, "source_dp_rank": 0})]
+    assert bootstrap.popped == [(44, {"jax_process_index": 0, "prefill_dp_rank": 0})]
 
 
 def test_raiden_abort_waits_for_engine_terminal_before_cleanup():
@@ -219,7 +219,7 @@ def test_raiden_abort_waits_for_engine_terminal_before_cleanup():
     raiden.stats = (["wire-abort"], [], [])
     assert sender.poll() == KVPoll.FAILED
     assert "req-abort" not in manager._senders
-    assert bootstrap.popped == [(48, {"jax_process_index": 0, "source_dp_rank": 0})]
+    assert bootstrap.popped == [(48, {"jax_process_index": 0, "prefill_dp_rank": 0})]
 
 
 def test_raiden_receiver_abort_waits_for_engine_terminal():
@@ -247,7 +247,7 @@ def test_raiden_receiver_abort_waits_for_engine_terminal():
     raiden.stats = ([], ["wire-abort"], [])
     assert receiver.poll() == KVPoll.FAILED
     assert "req-abort" not in manager._receivers
-    assert bootstrap.popped == [(49, {"jax_process_index": 0, "source_dp_rank": 0})]
+    assert bootstrap.popped == [(49, {"jax_process_index": 0, "prefill_dp_rank": 0})]
 
 
 def test_raiden_reaper_marks_timeout_without_pruning_sender():
@@ -294,7 +294,7 @@ def test_raiden_manager_owns_decode_admission_and_endpoint_mapping():
     bootstrap = _FakeBootstrap()
     bootstrap.transfer_info = {
         "transfer_id": "wire-4",
-        "source_dp_rank": 0,
+        "prefill_dp_rank": 0,
         "transport_metadata": {"remote_block_ids": [3, 4]},
     }
     manager = _manager(raiden, bootstrap)
@@ -302,8 +302,8 @@ def test_raiden_manager_owns_decode_admission_and_endpoint_mapping():
         req_id="req-4",
         transfer_id="wire-4",
         bootstrap_room=45,
-        local_dp_rank=0,
-        source_dp_rank=0,
+        decode_dp_rank=0,
+        prefill_dp_rank=0,
         peer_info={
             "host": "10.0.0.1",
             "transport_metadata": {
@@ -328,41 +328,41 @@ def test_raiden_manager_owns_decode_admission_and_endpoint_mapping():
     assert raiden.started == [
         (
             ("wire-4", _uuid_to_int("wire-4"), "10.0.0.1:7777", [3, 4], [9, 10]),
-            {"local_dp_rank": 0},
+            {"decode_dp_rank": 0},
         )
     ]
 
 
 @pytest.mark.parametrize(
-    ("source_dp_rank", "local_dp_rank"),
-    [(source, destination) for source in range(4) for destination in range(4)],
+    ("prefill_dp_rank", "decode_dp_rank"),
+    [(prefill, decode) for prefill in range(4) for decode in range(4)],
 )
-def test_raiden_manager_routes_all_dp4_source_destination_pairs(source_dp_rank, local_dp_rank):
+def test_raiden_manager_routes_all_dp4_prefill_decode_pairs(prefill_dp_rank, decode_dp_rank):
     raiden = _FakeRaiden(dp_size=4)
     bootstrap = _FakeBootstrap()
     bootstrap.transfer_info = {
         "transfer_id": "wire-cross",
-        "source_dp_rank": source_dp_rank,
+        "prefill_dp_rank": prefill_dp_rank,
         "transport_metadata": {"remote_block_ids": [1]},
     }
     manager = _manager(raiden, bootstrap)
-    source_endpoints = raiden.endpoints_by_dp_rank[source_dp_rank]
+    prefill_endpoints = raiden.endpoints_by_dp_rank[prefill_dp_rank]
 
     admission = manager.try_start_decode(
         DecodeTransferContext(
             req_id="req-cross",
             transfer_id="wire-cross",
             bootstrap_room=91,
-            local_dp_rank=local_dp_rank,
-            source_dp_rank=source_dp_rank,
+            decode_dp_rank=decode_dp_rank,
+            prefill_dp_rank=prefill_dp_rank,
             peer_info={
                 "host": "10.0.0.9",
-                "system_dp_rank": source_dp_rank,
+                "system_dp_rank": prefill_dp_rank,
                 "transport_metadata": {
                     "engine": "raiden",
-                    "dp_rank": source_dp_rank,
+                    "dp_rank": prefill_dp_rank,
                     "dp_size": 4,
-                    "endpoints": source_endpoints,
+                    "endpoints": prefill_endpoints,
                 },
             },
             kv_indices=[2, 3],
@@ -376,9 +376,9 @@ def test_raiden_manager_routes_all_dp4_source_destination_pairs(source_dp_rank, 
     assert bootstrap.transfer_info is not None
     assert admission.receiver.poll() == KVPoll.TRANSFERRING
     args, kwargs = raiden.started[-1]
-    assert args[2] == f"10.0.0.1:{7777 + source_dp_rank * 10}"
+    assert args[2] == f"10.0.0.1:{7777 + prefill_dp_rank * 10}"
     assert args[3:] == ([1], [1])
-    assert kwargs == {"local_dp_rank": local_dp_rank}
+    assert kwargs == {"decode_dp_rank": decode_dp_rank}
 
 
 def test_raiden_manager_rejects_peer_without_endpoint_descriptors():
@@ -386,7 +386,7 @@ def test_raiden_manager_rejects_peer_without_endpoint_descriptors():
     bootstrap = _FakeBootstrap()
     bootstrap.transfer_info = {
         "transfer_id": "wire-legacy",
-        "source_dp_rank": 0,
+        "prefill_dp_rank": 0,
         "transport_metadata": {"remote_block_ids": [3]},
     }
     manager = _manager(raiden, bootstrap)
@@ -397,8 +397,8 @@ def test_raiden_manager_rejects_peer_without_endpoint_descriptors():
                 req_id="req-legacy",
                 transfer_id="wire-legacy",
                 bootstrap_room=47,
-                local_dp_rank=0,
-                source_dp_rank=0,
+                decode_dp_rank=0,
+                prefill_dp_rank=0,
                 peer_info={
                     "host": "10.0.0.1",
                     "local_control_port": 7777,
@@ -433,8 +433,8 @@ def test_raiden_preserves_published_shard_endpoints():
             req_id="req-shards",
             transfer_id="wire-shards",
             bootstrap_room=50,
-            local_dp_rank=0,
-            source_dp_rank=0,
+            decode_dp_rank=0,
+            prefill_dp_rank=0,
             peer_info={
                 "host": "10.0.0.1",
                 "transport_metadata": {"engine": "raiden", "endpoints": endpoints},
@@ -463,7 +463,7 @@ def test_raiden_manager_preserves_each_published_endpoint_port_and_shards():
     bootstrap = _FakeBootstrap()
     bootstrap.transfer_info = {
         "transfer_id": "wire-endpoints",
-        "source_dp_rank": 0,
+        "prefill_dp_rank": 0,
         "transport_metadata": {"remote_block_ids": [1]},
     }
     manager = _manager(raiden, bootstrap)
@@ -472,8 +472,8 @@ def test_raiden_manager_preserves_each_published_endpoint_port_and_shards():
             req_id="req-endpoints",
             transfer_id="wire-endpoints",
             bootstrap_room=48,
-            local_dp_rank=0,
-            source_dp_rank=0,
+            decode_dp_rank=0,
+            prefill_dp_rank=0,
             peer_info={
                 "host": "10.0.0.8",
                 "transport_metadata": {
@@ -504,8 +504,8 @@ def test_raiden_manager_defers_until_request_metadata_is_published():
             req_id="req-5",
             transfer_id="wire-5",
             bootstrap_room=46,
-            local_dp_rank=0,
-            source_dp_rank=0,
+            decode_dp_rank=0,
+            prefill_dp_rank=0,
             peer_info={},
             kv_indices=[],
             page_size=128,
@@ -707,7 +707,7 @@ def test_raiden_wrapper_routes_each_operation_to_its_dp_manager():
             "remote:1",
             [1],
             [2],
-            local_dp_rank=3,
+            decode_dp_rank=3,
         )
 
     assert wrapper.dp_size == 4

--- a/test/srt/disaggregation/test_pd_raiden.py
+++ b/test/srt/disaggregation/test_pd_raiden.py
@@ -10,6 +10,7 @@ import types
 from unittest import mock
 
 import pytest
+
 from sgl_jax.raiden import raiden_requested
 from sgl_jax.srt.disaggregation.base.kv_manager import KVPoll
 from sgl_jax.srt.disaggregation.base.transfer import (
@@ -68,10 +69,7 @@ class _FakeRaiden:
 
     @property
     def endpoints_by_dp_rank(self):
-        return {
-            rank: list(endpoints)
-            for rank, endpoints in self._endpoints_by_dp_rank.items()
-        }
+        return {rank: list(endpoints) for rank, endpoints in self._endpoints_by_dp_rank.items()}
 
     @property
     def endpoints(self):
@@ -106,9 +104,7 @@ def test_raiden_sender_registers_once_and_completes_from_poll_stats():
 
     sender.send()
 
-    assert raiden.registered == [
-        (("wire-1", _uuid_to_int("wire-1"), [3, 8, 13]), {"dp_rank": 0})
-    ]
+    assert raiden.registered == [(("wire-1", _uuid_to_int("wire-1"), [3, 8, 13]), {"dp_rank": 0})]
     assert bootstrap.registered[0][0] == (42, "wire-1")
     assert bootstrap.registered[0][1] == {
         "jax_process_index": 0,
@@ -335,9 +331,7 @@ def test_raiden_manager_owns_decode_admission_and_endpoint_mapping():
     ("source_dp_rank", "local_dp_rank"),
     [(source, destination) for source in range(4) for destination in range(4)],
 )
-def test_raiden_manager_routes_all_dp4_source_destination_pairs(
-    source_dp_rank, local_dp_rank
-):
+def test_raiden_manager_routes_all_dp4_source_destination_pairs(source_dp_rank, local_dp_rank):
     raiden = _FakeRaiden(dp_size=4)
     bootstrap = _FakeBootstrap()
     bootstrap.transfer_info = {
@@ -566,9 +560,7 @@ def test_register_read_false_does_not_publish_stale_metadata():
 def test_raiden_loader_is_opt_in():
     assert not raiden_requested([])
     assert raiden_requested(["--disaggregation-use-raiden"])
-    assert not raiden_requested(
-        ["--disaggregation-use-raiden", "--no-disaggregation-use-raiden"]
-    )
+    assert not raiden_requested(["--disaggregation-use-raiden", "--no-disaggregation-use-raiden"])
 
 
 def test_launch_server_spawn_reimport_preloads_raiden_before_jax():
@@ -605,9 +597,7 @@ def test_raiden_cli_is_opt_in():
     parser = argparse.ArgumentParser()
     ServerArgs.add_cli_args(parser)
     defaults = parser.parse_args(["--model-path", "dummy"])
-    selected = parser.parse_args(
-        ["--model-path", "dummy", "--disaggregation-use-raiden"]
-    )
+    selected = parser.parse_args(["--model-path", "dummy", "--disaggregation-use-raiden"])
     assert defaults.disaggregation_use_raiden is False
     assert selected.disaggregation_use_raiden is True
 
@@ -616,9 +606,7 @@ def test_raiden_cli_is_opt_in():
     ("max_inflight", "dp_size", "expected"),
     [(8, 1, 8), (8, 2, 4), (32, 4, 8), (10, 4, 3), (0, 4, 0)],
 )
-def test_raiden_inflight_capacity_is_partitioned_per_rank(
-    max_inflight, dp_size, expected
-):
+def test_raiden_inflight_capacity_is_partitioned_per_rank(max_inflight, dp_size, expected):
     assert per_rank_inflight_limit(max_inflight, dp_size) == expected
 
 
@@ -654,9 +642,7 @@ def test_raiden_factory_rejects_invalid_config(override, error):
 
 def test_raiden_wrapper_uses_public_jax_api_and_configured_parallelism():
     engine = mock.MagicMock()
-    engine.get_local_endpoints.return_value = [
-        {"endpoint": "127.0.0.1:7788", "shards": [0]}
-    ]
+    engine.get_local_endpoints.return_value = [{"endpoint": "127.0.0.1:7788", "shards": [0]}]
     manager_cls = mock.MagicMock(return_value=engine)
     modules = {
         "tpu_raiden": types.ModuleType("tpu_raiden"),

--- a/test/srt/disaggregation/test_pd_router.py
+++ b/test/srt/disaggregation/test_pd_router.py
@@ -176,6 +176,8 @@ def lb_instance(router_args):
     import sgl_jax.srt.disaggregation.mini_lb as mini_lb_module
 
     instance = MiniLoadBalancer(router_args)
+    instance.prefill_dp_size = 1
+    instance.decode_dp_size = 1
     mini_lb_module.lb = instance
     yield instance
     mini_lb_module.lb = None
@@ -283,6 +285,42 @@ class TestGenerateEndpoint:
         assert data == {"text": "hello world"}
 
 
+class TestDpRouting:
+    def test_normal_routing_aligns_prefill_and_decode_rank(self, lb_instance):
+        lb_instance.prefill_dp_size = 4
+        lb_instance.decode_dp_size = 4
+        prefill, decode = asyncio.run(
+            lb_instance._align_dp_requests({"bootstrap_room": 6, "text": "hello"})
+        )
+        assert prefill["dp_rank"] == 2
+        assert decode["dp_rank"] == 2
+        assert decode["disagg_prefill_dp_rank"] == 2
+
+    def test_batch_routing_aligns_each_room(self, lb_instance):
+        lb_instance.prefill_dp_size = 4
+        lb_instance.decode_dp_size = 4
+        prefill, decode = asyncio.run(
+            lb_instance._align_dp_requests(
+                {"bootstrap_room": [4, 7], "text": ["a", "b"]}
+            )
+        )
+        assert prefill["dp_rank"] == [0, 3]
+        assert decode["dp_rank"] == [0, 3]
+        assert decode["disagg_prefill_dp_rank"] == [0, 3]
+
+    def test_normal_routing_rejects_heterogeneous_dp(self, lb_instance):
+        lb_instance.prefill_dp_size = 4
+        lb_instance.decode_dp_size = 2
+        with pytest.raises(RuntimeError, match="homogeneous DP topology"):
+            asyncio.run(lb_instance._align_dp_requests({"bootstrap_room": 1}))
+
+    def test_external_routing_rejects_heterogeneous_dp(self, lb_instance):
+        lb_instance.prefill_dp_size = 4
+        lb_instance.decode_dp_size = 2
+        with pytest.raises(RuntimeError, match="homogeneous DP topology"):
+            lb_instance._fork_dp_requests({"bootstrap_room": 1})
+
+
 class TestV1CompletionsEndpoint:
     @patch("aiohttp.ClientSession")
     def test_completions(self, mock_session_cls, client, lb_instance):
@@ -358,6 +396,8 @@ class TestBootstrapInjection:
             prefill_bootstrap_host="10.31.0.1",
         )
         instance = MiniLoadBalancer(args)
+        instance.prefill_dp_size = 1
+        instance.decode_dp_size = 1
         mini_lb_module.lb = instance
 
         captured_requests = []
@@ -707,11 +747,15 @@ class TestProtocolFields:
             bootstrap_host="10.0.0.1",
             bootstrap_port=8998,
             bootstrap_room=12345,
+            dp_rank=3,
+            disagg_prefill_dp_rank=1,
             disagg_transfer_id="tid-001",
         )
         assert req.bootstrap_host == "10.0.0.1"
         assert req.bootstrap_port == 8998
         assert req.bootstrap_room == 12345
+        assert req.dp_rank == 3
+        assert req.disagg_prefill_dp_rank == 1
         assert req.disagg_transfer_id == "tid-001"
 
     def test_completion_request_has_bootstrap_fields(self):
@@ -721,11 +765,15 @@ class TestProtocolFields:
             bootstrap_host="10.0.0.2",
             bootstrap_port=9998,
             bootstrap_room=67890,
+            dp_rank=2,
+            disagg_prefill_dp_rank=0,
             disagg_transfer_id="tid-002",
         )
         assert req.bootstrap_host == "10.0.0.2"
         assert req.bootstrap_port == 9998
         assert req.bootstrap_room == 67890
+        assert req.dp_rank == 2
+        assert req.disagg_prefill_dp_rank == 0
         assert req.disagg_transfer_id == "tid-002"
 
     def test_completion_request_accepts_batch_bootstrap_fields(self):
@@ -735,11 +783,15 @@ class TestProtocolFields:
             bootstrap_host=["10.0.0.1", "10.0.0.1"],
             bootstrap_port=[8998, 8998],
             bootstrap_room=[1, 2],
+            dp_rank=[2, 3],
+            disagg_prefill_dp_rank=[0, 1],
             disagg_transfer_id=["tid-0", "tid-1"],
         )
         assert req.bootstrap_host == ["10.0.0.1", "10.0.0.1"]
         assert req.bootstrap_port == [8998, 8998]
         assert req.bootstrap_room == [1, 2]
+        assert req.dp_rank == [2, 3]
+        assert req.disagg_prefill_dp_rank == [0, 1]
         assert req.disagg_transfer_id == ["tid-0", "tid-1"]
 
     def test_bootstrap_fields_default_none(self):
@@ -750,6 +802,8 @@ class TestProtocolFields:
         assert req.bootstrap_host is None
         assert req.bootstrap_port is None
         assert req.bootstrap_room is None
+        assert req.dp_rank is None
+        assert req.disagg_prefill_dp_rank is None
         assert req.disagg_transfer_id is None
 
 

--- a/test/srt/disaggregation/test_pd_router.py
+++ b/test/srt/disaggregation/test_pd_router.py
@@ -82,7 +82,9 @@ class TestEnsureRequestIdentityFields:
         assert result["disagg_transfer_id"] == "abc123"
 
     def test_preserves_existing_transfer_id(self):
-        result = ensure_request_identity_fields({"text": "hello", "disagg_transfer_id": "tid123"})
+        result = ensure_request_identity_fields(
+            {"text": "hello", "disagg_transfer_id": "tid123"}
+        )
         assert result["rid"] == "tid123"
         assert result["disagg_transfer_id"] == "tid123"
 
@@ -358,7 +360,9 @@ class TestV1CompletionsEndpoint:
 
 class TestBootstrapInjection:
     @patch("aiohttp.ClientSession")
-    def test_generate_injects_bootstrap_fields(self, mock_session_cls, client, lb_instance):
+    def test_generate_injects_bootstrap_fields(
+        self, mock_session_cls, client, lb_instance
+    ):
         captured_requests = []
 
         async def capture_post(url, json=None):
@@ -726,7 +730,9 @@ class TestOtherArgs:
         assert args.port == 8080
 
     def test_flags(self):
-        args = _parse(["--mini-lb", "--pd-disaggregation", "--test-external-dp-routing"])
+        args = _parse(
+            ["--mini-lb", "--pd-disaggregation", "--test-external-dp-routing"]
+        )
         assert args.mini_lb is True
         assert args.pd_disaggregation is True
         assert args.test_external_dp_routing is True

--- a/test/srt/disaggregation/test_pd_router.py
+++ b/test/srt/disaggregation/test_pd_router.py
@@ -82,9 +82,7 @@ class TestEnsureRequestIdentityFields:
         assert result["disagg_transfer_id"] == "abc123"
 
     def test_preserves_existing_transfer_id(self):
-        result = ensure_request_identity_fields(
-            {"text": "hello", "disagg_transfer_id": "tid123"}
-        )
+        result = ensure_request_identity_fields({"text": "hello", "disagg_transfer_id": "tid123"})
         assert result["rid"] == "tid123"
         assert result["disagg_transfer_id"] == "tid123"
 
@@ -302,9 +300,7 @@ class TestDpRouting:
         lb_instance.prefill_dp_size = 4
         lb_instance.decode_dp_size = 4
         prefill, decode = asyncio.run(
-            lb_instance._align_dp_requests(
-                {"bootstrap_room": [4, 7], "text": ["a", "b"]}
-            )
+            lb_instance._align_dp_requests({"bootstrap_room": [4, 7], "text": ["a", "b"]})
         )
         assert prefill["dp_rank"] == [0, 3]
         assert decode["dp_rank"] == [0, 3]
@@ -360,9 +356,7 @@ class TestV1CompletionsEndpoint:
 
 class TestBootstrapInjection:
     @patch("aiohttp.ClientSession")
-    def test_generate_injects_bootstrap_fields(
-        self, mock_session_cls, client, lb_instance
-    ):
+    def test_generate_injects_bootstrap_fields(self, mock_session_cls, client, lb_instance):
         captured_requests = []
 
         async def capture_post(url, json=None):
@@ -730,9 +724,7 @@ class TestOtherArgs:
         assert args.port == 8080
 
     def test_flags(self):
-        args = _parse(
-            ["--mini-lb", "--pd-disaggregation", "--test-external-dp-routing"]
-        )
+        args = _parse(["--mini-lb", "--pd-disaggregation", "--test-external-dp-routing"])
         assert args.mini_lb is True
         assert args.pd_disaggregation is True
         assert args.test_external_dp_routing is True


### PR DESCRIPTION
## Summary

This PR builds on the optional Raiden transfer engine introduced in #1490 and adds data-parallel routing for PD disaggregation.

The previous Raiden path assumed a single DP rank. With multiple ranks, that assumption loses the identity of the Prefill KV owner and the Decode allocator, so endpoint selection, page lookup, admission control, and cleanup can target the wrong rank-local namespace.

This change:

- creates one Raiden KV manager per local DP rank, backed by rank-local zero-copy JAX KV views
- propagates the Prefill source rank and Decode destination rank through request, bootstrap, transfer, scheduler, and cleanup metadata
- selects the source endpoint by `disagg_prefill_dp_rank` and the destination manager/allocator by `dp_rank`
- includes process and source-rank identity in bootstrap keys
- partitions the configured inflight capacity across DP ranks and enforces both global and per-rank admission limits
- lets ranks with available KV capacity continue admission when another rank is blocked, while preserving FIFO within each rank
- preserves abort-safe ownership: KV pages are not released until Raiden reaches a terminal state
- isolates heartbeat, unregister, and destructive Raiden completion polling failures per rank
- validates that KV arrays are physically sharded over the data axis and maps debug gathers to the correct rank-local page shard
- rejects DP > 1 with the legacy JAX transfer engine; this path is supported by Raiden only

## Routing model

Raiden transfers do not require the source and destination ranks to be equal:

```text
request -> Prefill rank i -> Decode rank j
```

The normal MiniLB path currently keeps the ranks aligned (`i == j`). Direct requests can select distinct source and destination ranks, which is used by the exhaustive routing tests. Production cross-rank load balancing and cross-topology resharding are outside this PR.

## Validation

### Local tests

- `test/srt/disaggregation`: **432 passed, 12 skipped**
- Ruff lint: passed
- Black formatting: passed
- `git diff --check`: passed

### TPU correctness

Validated with Qwen3-8B on two single-host v6e-4 systems, using four TPU devices on each side:

| Topology | Source × destination pairs | Deterministic request checks | Result |
| --- | ---: | ---: | ---: |
| DP1 × TP4 | 1 / 1 | 4 / 4 | PASS |
| DP2 × TP2 | 4 / 4 | 16 / 16 | PASS |
| DP4 × TP1 | 16 / 16 | 64 / 64 | PASS |

Additional checks:

- PD output exactly matched non-PD output at the same DP/TP topology
- cancellation followed by a sentinel request passed for DP1, DP2, and DP4
- normal MiniLB traffic reached every DP rank
- no transfer mismatch, KV extraction, out-of-memory, or leaked-hold errors were observed

### Throughput

Setup: Qwen3-8B, random-token input length 4096, output length 1 or 256, 32 warmup requests, 64 measured requests, concurrency 32, fixed seed, radix cache disabled, and a fixed four-device allocation. Only the Raiden transfer engine is benchmarked for PD.

| Workload | Mode | DP1 × TP4 | DP2 × TP2 | DP4 × TP1 |
| --- | --- | ---: | ---: | ---: |
| 4096 → 1 | Raiden PD | 7.238 req/s | **10.878 req/s** | 7.247 req/s |
| 4096 → 1 | non-PD control | 13.421 req/s | **16.120 req/s** | 10.696 req/s |
| 4096 → 256 | Raiden PD | **5.204 req/s** | 4.808 req/s | 3.137 req/s |
| 4096 → 256 | non-PD control | **6.980 req/s** | 5.387 req/s | 4.200 req/s |

For 4096 → 1, Raiden PD improves by **50.3%** from DP1 to DP2. DP4 then drops **33.4%** versus DP2; the non-PD control drops **33.6%** over the same topology change. For 4096 → 256, DP4 is **39.7%** below DP1 with Raiden PD and **39.8%** below DP1 without PD. Because the same DP4 shape appears without PD, the regression is not specific to the Raiden transfer path; changing TP4 → TP2 → TP1 under a fixed device count also changes dense-model batching and operator efficiency.

## Current limitations

- Prefill and Decode must use the same `dp_size` and compatible per-rank endpoint shard layouts.
- Mixed pre-v4/v4 DP deployments are not supported. After a non-graceful restart, a pre-v4 Prefill registration may remain selectable until the 30-second heartbeat TTL expires; upgrade both sides before enabling DP > 1.
- A v4 DP Prefill paired with a pre-v4 Decode may surface incompatibility as a transfer timeout because the older Decode does not understand the per-rank transfer namespace.
- Normal MiniLB routing remains same-rank; a production cross-rank scheduling policy is not included.
- Cross-topology KV resharding is not included.
- Multi-process (`jax.process_count() > 1`) Prefill/Decode deployments have not yet been validated.
- Raiden remains an optional, ABI-matched installation through the existing #1490 build and deployment flow.
