### PR TITLE
feat(dsa): fused sparse-MLA prefill for DeepSeek Sparse Attention (opt-in)

### DIFF
--- a/docs/features/attention_backend.md
+++ b/docs/features/attention_backend.md
@@ -4,13 +4,14 @@ SGL-JAX exposes a small user-facing attention backend switch, while the runtime 
 
 ## User-facing choices
 
-`--attention-backend` accepts three values:
+`--attention-backend` accepts four values:
 
 | Value | Runtime behavior |
 |---|---|
 | `fa` | Default. Uses FlashAttention for MHA/GQA models and the absorbed MLA Pallas backend for MLA models. |
 | `fa_mha` | Forces MLA models through the decompressed MHA FlashAttention path. This is useful for kernel A/B checks, but uses much more KV cache than absorbed MLA. |
 | `native` | Pure JAX/native attention path, mainly for CPU/debugging. If `fa` or `fa_mha` is requested on CPU, the runtime falls back to `native`. |
+| `dsa_sparse` | DeepSeek Sparse Attention (DSA): a lightning-indexer selects the top-scoring pages of past tokens per query and attention runs only over that page set (page-block sparse guided by DSA scores), with IndexShare cross-layer reuse of the selection. For MLA models whose config carries the `index_*` fields only. See [DeepSeek Sparse Attention](#deepseek-sparse-attention-dsa_sparse). |
 
 Example:
 
@@ -28,11 +29,82 @@ python3 -u -m sgl_jax.launch_server \
 |---|---|---|
 | `FlashAttention` | `--attention-backend=fa` for MHA/GQA, or `fa_mha` for MLA fallback | TPU production attention with paged KV cache, SWA metadata, and Pallas kernels. |
 | `MLAAttentionBackend` | `--attention-backend=fa` when `model_config.attention_arch == MLA` | Absorbed MLA path for DeepSeek-family models. |
+| `DSASparseAttentionBackend` | `--attention-backend=dsa_sparse` for MLA models with `index_*` config | DeepSeek Sparse Attention: lightning-indexer top-k + sparse MLA over the selected pages (page-block), with IndexShare. |
 | `NativeAttention` | `--attention-backend=native`, or CPU fallback | Debugging and CPU execution. |
 | `HybridLinearAttnBackend` | Automatic wrapper for hybrid recurrent models | Routes full-attention layers to `FlashAttention`/`MLAAttentionBackend` and linear recurrent layers to KDA/GDN/Lightning backends. |
 | `KDAAttnBackend` | Automatic under `HybridLinearAttnBackend` for Kimi Linear | Kimi Delta Attention recurrent branch. |
 | `GDNAttnBackend` | Automatic under `HybridLinearAttnBackend` for Qwen3.5 hybrid configs | Gated DeltaNet recurrent branch. |
 | `LightningAttnBackend` | Automatic under `HybridLinearAttnBackend` for Bailing MoE V2.5 / Ling-2.6-flash | Lightning / Simple GLA recurrent branch. |
+
+## DeepSeek Sparse Attention (`dsa_sparse`)
+
+DSA cuts the cost of long-context attention by attending to a **selected subset** of past
+tokens instead of the full causal history. A small "lightning indexer" scores past tokens
+for each query and the highest-scoring ones (budget `index_topk`) are chosen. The selection
+is computed on the indexer layers and **reused across the following layers (IndexShare)**,
+so the indexer cost is amortized.
+
+Selection here is at **page granularity** (`page_size` tokens per unit), not exact per-token:
+the indexer's per-token scores are max-pooled to a score per page and the top
+`ceil(index_topk / page_size)` pages are attended in full. This is therefore **page-block
+sparse attention guided by the DSA indexer scores** — a superset of the exact token top-`k`
+set (attending whole pages shifts the softmax denominator), not a bit-exact token-level DSA.
+In practice it tracks dense closely on long-context retrieval (see the PR's NIAH/GSM8K
+results); treat page size and `index_topk` as the accuracy/speed knobs.
+
+Only MLA models whose config carries the DSA `index_*` fields (indexer head dim / heads /
+top-k) are eligible; other models ignore the flag.
+
+### Enabling it
+
+```bash
+python3 -u -m sgl_jax.launch_server \
+  --model-path <deepseek-sparse-MLA-checkpoint> \
+  --device=tpu \
+  --attention-backend=dsa_sparse \
+  --dsa-use-pallas          # use the Pallas kernels (default: the jnp reference)
+```
+
+Two environment variables tune the sparse path:
+
+| Env var | Meaning |
+|---|---|
+| `DSA_INDEX_TOPK` | Override the config's `index_topk` (selection budget, in tokens) at backend construction. Larger = closer to dense, slower. The kernel is compiled for this value, so **changing it requires a relaunch**. |
+| `DSA_PREFILL_SPARSE=1` | Opt in to running **prefill** through the fused sparse-MLA prefill kernel (below). Default off ⇒ prefill runs dense and only decode is sparse. |
+
+### Sparse prefill and its current scope
+
+With `DSA_PREFILL_SPARSE=1`, the prefill (EXTEND) step also attends only to the indexer's
+selected pages via a fused self-write + sparse-MLA Pallas kernel, which is where the
+long-context prefill speedup comes from.
+
+This initial version supports a **single-sequence, single-shot** prefill only. It does
+**not** yet support radix/prefix caching, request batching, or chunked prefill (a cache
+hit / multi-seq / split prompt turns prefill into a partial extend the sparse page table
+cannot represent). The runtime **fails fast with an actionable message** when
+`DSA_PREFILL_SPARSE=1` is combined with an incompatible config, so it must be launched
+with:
+
+```bash
+DSA_PREFILL_SPARSE=1 DSA_INDEX_TOPK=4096 python3 -u -m sgl_jax.launch_server \
+  --model-path <checkpoint> --device=tpu \
+  --attention-backend=dsa_sparse --dsa-use-pallas \
+  --disable-radix-cache \           # radix/prefix cache OFF
+  --max-running-requests 1 \        # single sequence
+  --context-length 49152 \
+  --chunked-prefill-size 49152      # >= context => single-shot (no chunking)
+```
+
+Radix-cache, batching, and chunked-prefill support are follow-ups. The guard is gated on
+`DSA_PREFILL_SPARSE`, so the default (dense-prefill) `dsa_sparse` path, other backends, and
+CI are unaffected.
+
+### Validation
+
+Kernel correctness is covered in CI by
+`test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py`, which checks the sparse-MLA
+prefill kernel against a masked-softmax reference on CPU (`interpret=True`, no TPU needed),
+in both flat and paged-cache modes.
 
 ## Notes for contributors
 

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py
@@ -1,0 +1,451 @@
+"""TPU Pallas kernel for **sparse MLA-latent attention** (the DSA attention-consuming
+path) — the fused sparse-MLA *prefill* kernel.
+
+Given, per query, a set of selected past tokens (the lightning-indexer top-k), attend
+**only** to those tokens over the MLA *latent* cache. Prefill (S queries) and decode
+(S == 1) share the one kernel; this module is the prefill entry point.
+
+Design (mirrors DeepSeek's ``refs/dsa/tilelang_sparse_mla_fwd.py`` *algorithm*, not
+its GPU code):
+
+* **Sparse == dense-MLA with a gathered KV iteration.** The only structural change
+  from a dense paged-MLA kernel is that the inner loop walks the *selected* KV rows
+  (named by ``indices``) instead of all of them, with the usual flash/online-softmax
+  accumulation.
+* **Head-sharing is what makes it viable on TPU.** MLA caches a single latent vector
+  per token (``[Dk] = kv_lora_rank + qk_rope_head_dim = 512 + 64 = 576``) that is
+  reused by *all* query heads, so each fetched row feeds a fat ``[H, Dk]`` matmul.
+  The "value" is the first ``kv_lora_rank`` dims of the same latent.
+* **One kernel, prefill + decode:** the grid is over ``(batch, query_token)``;
+  decode is just ``S == 1``. Queries are *not* batched into a shared-K matmul because
+  each query has its own selection — parallelism comes from the head dim per query.
+* **Static counts, dynamic addresses.** The number of selected units is fixed
+  (``K``); only the *addresses* (which rows) are data-dependent, read from ``indices``
+  on-chip and used to drive per-unit DMAs from HBM.
+
+Selection granularity is parameterised by ``read_block`` (``RB``): ``indices[b, s, :]``
+are **unit ids**, one unit == ``RB`` contiguous tokens. Page-level selection sets
+``RB == page_size`` and consumes the indexer's page-topk directly; effective attended
+tokens per query == ``K * RB``.
+
+Only the **head-minor chunked** kernel is deployed (few heads/device, i.e. head-TP):
+``G`` selected units are gathered into one ``[CBR, Dk]`` tile with the abundant keys on
+the 128-wide MXU lane axis and the few heads on the sublane axis, so one MXU-filling
+matmul runs per chunk. (The v1 per-unit / non-head-minor / chunk-pipelined A/B
+baselines from the perf-characterization sweep are kept in git history only; they are
+not part of this deployed kernel.)
+"""
+
+from __future__ import annotations
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+
+def _sparse_mla_kernel_chunked_hminor(
+    q_ref,  # [1, 1, Hp, Dk]  Hp padded to the bf16 sublane tile (16), NOT to 128
+    idx_ref,  # [1, 1, 1, K]    SMEM
+    pos_ref,  # [1, 1, 1, 1]    SMEM
+    kv_hbm,  # flat: [B, T(+RBF), Dk] HBM;  paged: [1, num_pages*page_size, Dk] HBM
+    pt_ref,  # [1, 1, 1, max_pages] SMEM  page table for this request (paged only; dummy if flat)
+    o_ref,  # [1, 1, Hp, Dv]
+    kv_scratch,  # [CBR, Dk] VMEM  one chunk of gathered latent
+    sem,  # DMA semaphores (G,)
+    *,
+    sm_scale: float,
+    Dv: int,
+    RB: int,
+    RBF: int,
+    T: int,
+    K: int,
+    G: int,
+    CBR: int,  # G*RBF rounded up to the 128-lane tile (score's key axis is the lane axis)
+    paged: bool = False,  # read from the packed 4D paged latent cache via pt_ref
+    page_size: int = 0,  # tokens per page (paged only; static)
+):
+    """Head-minor relayout of the chunked kernel for **few heads/device** (head-TP).
+
+    A default chunked layout would put heads on the 128-wide MXU lane axis (score
+    ``[CBR, Hp]``), wasting ~97% of the MXU when a device holds only ~4 heads. Here we
+    swap the axes: the abundant **selected keys sit on the lane axis** (``CBR`` filling
+    128) and the few **heads sit on the sublane axis** (padded to 16), so 4 heads cost
+    a 4x sublane pad instead of a 32x lane pad. Score is ``[Hp, CBR]``, softmax reduces
+    over the key (lane) axis, value matmul contracts ``CBR``.
+
+    The validity mask lives on the *lane* axis (keys). A lane concat of ``RBF``-wide
+    pieces is not Mosaic-lowerable, so we build the ``[CBR]`` lane mask **arithmetically**
+    from an on-chip ``iota`` with per-unit **static-window** compares (no concat, no
+    dynamic gather, no integer div/mod on a vector): each chunk selects every lane's
+    unit id / row offset with ``G`` broadcasted ``where`` ops, recovers key positions,
+    and turns the boolean into a ``0 / -inf`` additive bias."""
+    b = pl.program_id(0)
+    Hp = q_ref.shape[2]
+    q = q_ref[0, 0]  # [Hp, Dk] bf16
+    qpos = pos_ref[0, 0, 0, 0]
+    NC = (K + G - 1) // G
+
+    lane = jnp.arange(CBR, dtype=jnp.int32)  # [CBR] iota on the key (lane) axis
+
+    def _src(u):
+        """HBM source slice ([RBF, Dk]) for selected unit ``u`` (logical unit id)."""
+        if paged:
+            # unit u == RB contiguous LOGICAL tokens starting at u*RB. RB divides
+            # page_size, so the whole unit lives in one physical page. The 4D cache
+            # is flattened to [num_pages*page_size, Dk]; token (page P, offset o) is
+            # row P*page_size + o. RB%16==0 => RBF==RB => no cross-page over-fetch.
+            #
+            # The token axis is sublane-tiled (8), so a *dynamic* slice offset must be
+            # provably %8. row0 = pp*page_size + o0 is always a multiple of RB(>=16),
+            # but pp (from the page table) is opaque to Mosaic. Express the offset as
+            # an explicit `r8 * 8` (page_size and o0 are both %8) so divisibility is
+            # provable — the same idiom the dense paged kernel uses.
+            lt = u * RB  # logical token start
+            lp = lt // page_size  # logical page (static divisor)
+            o0 = lt - lp * page_size  # in-page offset (multiple of RB)
+            pp = pt_ref[0, 0, 0, lp]  # physical page id
+            r8 = pp * (page_size // 8) + o0 // 8  # (P*page_size + o0) // 8, exact
+            return kv_hbm.at[0, pl.ds(r8 * 8, RBF), :]
+        return kv_hbm.at[b, pl.ds(u * RB, RBF), :]
+
+    # padded lanes (>= G*RBF) are never DMA'd; zero them so a stale/NaN row can't
+    # poison the (masked-out) score before the -inf bias is added.
+    if CBR > G * RBF:
+        pad = CBR - G * RBF
+        kv_scratch[pl.ds(G * RBF, pad), :] = jnp.zeros((pad, kv_scratch.shape[1]), kv_scratch.dtype)
+
+    m0 = jnp.full((Hp,), -jnp.inf, dtype=jnp.float32)
+    l0 = jnp.zeros((Hp,), dtype=jnp.float32)
+    acc0 = jnp.zeros((Hp, Dv), dtype=jnp.float32)
+
+    def chunk_body(c, carry):
+        m_i, l_i, acc = carry
+        base = c * G
+
+        # --- issue G gathers (overlap) into contiguous RBF-aligned lane slots ---
+        for g in range(G):
+            gidx = jnp.minimum(base + g, K - 1)
+            # clamp negative unit ids (topk padding == -1) to 0 for the DMA so the
+            # source offset stays in range; the lane is masked out below anyway.
+            u = jnp.maximum(idx_ref[0, 0, 0, gidx], 0)
+            dst = kv_scratch.at[pl.ds(g * RBF, RBF), :]
+            pltpu.make_async_copy(_src(u), dst, sem.at[g]).start()
+
+        # --- build the [CBR] lane validity bias arithmetically while DMAs run ---
+        # Accumulators are int32 (0/1), NOT bool: Mosaic can't materialise an i1 vector
+        # from a broadcast-scalar select (trunc i8->i1 is unsupported). The i1 predicate
+        # is only formed transiently by the final comparisons feeding the select.
+        u_vec = jnp.zeros((CBR,), jnp.int32)  # per-lane selected unit id
+        row_vec = jnp.zeros((CBR,), jnp.int32)  # per-lane row-within-unit (0..RBF-1)
+        ir_vec = jnp.zeros((CBR,), jnp.int32)  # 1 where the lane's unit id < K
+        for g in range(G):
+            lo = g * RBF  # static lane window for unit g
+            sel = (lane >= lo) & (lane < lo + RBF)  # [CBR] const partition (transient i1)
+            u_g = idx_ref[0, 0, 0, jnp.minimum(base + g, K - 1)]
+            inr = ((base + g) < K).astype(jnp.int32)  # scalar 0/1
+            u_vec = jnp.where(sel, u_g, u_vec)
+            row_vec = jnp.where(sel, lane - lo, row_vec)
+            ir_vec = jnp.where(sel, inr, ir_vec)
+        kp = u_vec * RB + row_vec  # [CBR] key positions
+        # (u_vec >= 0) drops topk padding lanes (unit id -1); their DMA was
+        # clamped to unit 0, so the read is safe and only the mask excludes them.
+        valid = (u_vec >= 0) & (row_vec < RB) & (ir_vec > 0) & (kp <= qpos) & (kp < T)
+        bias = jnp.where(valid, 0.0, -jnp.inf)  # [CBR] fp32
+
+        for g in range(G):
+            gidx = jnp.minimum(base + g, K - 1)
+            u = jnp.maximum(idx_ref[0, 0, 0, gidx], 0)
+            dst = kv_scratch.at[pl.ds(g * RBF, RBF), :]
+            pltpu.make_async_copy(_src(u), dst, sem.at[g]).wait()
+
+        kv_blk = kv_scratch[pl.ds(0, CBR), :]  # [CBR, Dk] bf16
+
+        # score: [Hp,Dk]·[CBR,Dk] -> [Hp, CBR]  (heads on sublane, keys on lanes)
+        s = (
+            jax.lax.dot_general(
+                q, kv_blk, (((1,), (1,)), ((), ())), preferred_element_type=jnp.float32
+            )
+            * sm_scale
+        )
+        s = s + bias[None, :]  # [Hp, CBR] fp32
+
+        # --- flash-softmax over keys = axis 1 (the lane axis) ---
+        m_cur = jnp.max(s, axis=1)  # [Hp]
+        m_new = jnp.maximum(m_i, m_cur)
+        corr = jnp.where(jnp.isneginf(m_new), 0.0, m_new)
+        p = jnp.exp(s - corr[:, None])  # [Hp, CBR]
+        alpha = jnp.where(jnp.isneginf(m_new), 1.0, jnp.exp(m_i - m_new))
+        l_i = l_i * alpha + jnp.sum(p, axis=1)  # [Hp]
+        v_blk = kv_blk[:, :Dv]  # [CBR, Dv]
+        # acc[Hp,Dv] += sum_cbr p[hp,cbr] * v[cbr,dv]
+        acc = acc * alpha[:, None] + jax.lax.dot_general(
+            p.astype(kv_blk.dtype),
+            v_blk,
+            (((1,), (0,)), ((), ())),
+            preferred_element_type=jnp.float32,
+        )
+        return (m_new, l_i, acc)
+
+    m_i, l_i, acc = jax.lax.fori_loop(0, NC, chunk_body, (m0, l0, acc0))
+    out = acc / jnp.where(l_i == 0.0, 1.0, l_i)[:, None]
+    o_ref[0, 0] = out.astype(o_ref.dtype)
+
+
+def sparse_mla_attention(
+    q,  # [B, S, H, Dk]        Dk = kv_lora_rank + qk_rope_head_dim
+    kv,  # [B, T, Dk]           MLA latent cache (value = first Dv cols)
+    indices,  # [B, S, K] int32      selected unit ids (unit == RB tokens)
+    positions,  # [B, S] int32         query positions (causal bound)
+    *,
+    kv_lora_rank: int = 512,
+    read_block: int = 1,
+    block_units: int | None = None,  # units gathered+matmul'd per chunk (G; parallelism knob)
+    sm_scale: float | None = None,
+    interpret: bool = False,
+    page_table=None,  # [B, max_pages] int32: logical page -> physical page. When set,
+    # ``kv`` is the packed 4D paged cache and the kernel gathers from it.
+    page_size: int | None = None,  # tokens/page (required with page_table)
+    seq_len: int | None = None,  # logical T for the causal mask (required with page_table)
+):
+    """Sparse MLA-latent attention (head-minor chunked kernel).
+    Returns ``[B, S, H, kv_lora_rank]`` (float32).
+
+    ``indices`` are *unit ids* (one unit = ``read_block`` contiguous tokens); set
+    ``read_block=1`` for token-granular (exact) DSA, or e.g. 128 for page-sized block
+    reads. Effective attended tokens per query == ``K * read_block``. ``block_units=G``
+    (>=1) sets how many units are gathered into one MXU-filling matmul per chunk
+    (``G>=K`` ⇒ a single chunk, the fastest measured config).
+
+    KV source:
+    * default: ``kv`` is a flat ``[B, T, Dk]`` latent buffer.
+    * paged (``page_table`` set): ``kv`` is the sglang-jax packed 4D MLA cache
+      ``[num_pages, align(page_size,packing)//packing, packing, align(lkv,128)+align(rope,128)]``.
+      Flattened to ``[num_pages*page_size, Dk_pad]``, token (physical page P, offset o)
+      is row ``P*page_size + o``; the kernel resolves each selected unit through
+      ``page_table`` and requires ``read_block % 16 == 0`` (so a unit never over-fetches
+      across a page).
+    """
+    B, S, H, Dk = q.shape
+    K = indices.shape[2]
+    Dv = kv_lora_rank
+    RB = read_block
+    paged = page_table is not None
+    if not block_units or block_units < 1:
+        raise ValueError("sparse_mla_attention requires block_units >= 1")
+    if sm_scale is None:
+        sm_scale = 1.0 / (Dk**0.5)  # note: true (unpadded) Dk
+
+    # TPU/Mosaic wants the lane (last) dim %128; the MLA latent is 576 = 512 + 64
+    # rope, so pad the feature dim with zeros to the next multiple of 128 (640).
+    # Padding the *contraction* dim with zeros leaves q·k unchanged, and the value
+    # is only the first Dv (=512) dims, so the pad never enters the output.
+    Dk_pad = ((Dk + 127) // 128) * 128
+    q = jnp.pad(q, ((0, 0), (0, 0), (0, 0), (0, Dk_pad - Dk))) if Dk_pad != Dk else q
+    if paged:
+        if RB % 16 != 0:
+            raise ValueError("paged KV requires read_block % 16 == 0 (no cross-page over-fetch)")
+        if page_size is None or seq_len is None:
+            raise ValueError("paged KV requires page_size and seq_len")
+        if kv.shape[-1] != Dk_pad:
+            raise ValueError(f"paged cache last dim {kv.shape[-1]} != Dk_pad {Dk_pad}")
+        T = seq_len
+        # flatten [num_pages, ps//packing, packing, Dk_pad] -> [1, num_pages*page_size, Dk_pad]
+        num_pages = kv.shape[0]
+        kv = kv.reshape(1, num_pages * page_size, Dk_pad)
+    else:
+        T = kv.shape[1]
+        if Dk_pad != Dk:
+            kv = jnp.pad(kv, ((0, 0), (0, 0), (0, Dk_pad - Dk)))
+
+    # Add a singleton axis so the per-(b,s) block's trailing two dims are legal
+    # (block over the S axis is 1, which is illegal as a *second-to-last* dim).
+    indices4 = indices.reshape(B, S, 1, K)
+    positions4 = positions.reshape(B, S, 1, 1)
+
+    # head-minor relayout: keys on the lane axis (fills the MXU even with ~4 heads),
+    # heads on the sublane axis (padded to the bf16 sublane tile of 16, not 128).
+    G = max(1, min(block_units, K))
+    RBF = ((RB + 15) // 16) * 16
+    if paged:
+        ps = page_size  # RBF == RB (RB%16==0) => no over-fetch
+        max_pages = (T + ps - 1) // ps
+        # page table is per-REQUEST (same for all query tokens s) => index by b only.
+        pt_arg = page_table.reshape(B, 1, 1, max_pages).astype(jnp.int32)
+        pt_spec = pl.BlockSpec(
+            (1, 1, 1, max_pages), lambda b, s: (b, 0, 0, 0), memory_space=pltpu.SMEM
+        )
+    else:
+        kv = jnp.pad(kv, ((0, 0), (0, RBF), (0, 0)))
+        # dummy 1-wide page table so the kernel signature is uniform (unused when flat).
+        pt_arg = jnp.zeros((B, 1, 1, 1), jnp.int32)
+        pt_spec = pl.BlockSpec((1, 1, 1, 1), lambda b, s: (b, 0, 0, 0), memory_space=pltpu.SMEM)
+    CBR = ((G * RBF + 127) // 128) * 128  # key (lane) axis: %128
+    Hq = ((H + 15) // 16) * 16  # heads on sublane: %16 (bf16 tile)
+    if Hq != H:
+        q = jnp.pad(q, ((0, 0), (0, 0), (0, Hq - H), (0, 0)))
+    kernel = functools.partial(
+        _sparse_mla_kernel_chunked_hminor,
+        sm_scale=sm_scale,
+        Dv=Dv,
+        RB=RB,
+        RBF=RBF,
+        T=T,
+        K=K,
+        G=G,
+        CBR=CBR,
+        paged=paged,
+        page_size=(page_size or 0),
+    )
+    scratch_shapes = [
+        pltpu.VMEM((CBR, Dk_pad), kv.dtype),  # one chunk of gathered latent
+        pltpu.SemaphoreType.DMA((G,)),  # one semaphore per unit
+    ]
+
+    in_specs = [
+        pl.BlockSpec((1, 1, Hq, Dk_pad), lambda b, s: (b, s, 0, 0)),  # q (VMEM)
+        pl.BlockSpec(
+            (1, 1, 1, K), lambda b, s: (b, s, 0, 0), memory_space=pltpu.SMEM
+        ),  # indices (SMEM)
+        pl.BlockSpec(
+            (1, 1, 1, 1), lambda b, s: (b, s, 0, 0), memory_space=pltpu.SMEM
+        ),  # positions (SMEM)
+        pl.BlockSpec(memory_space=pltpu.HBM),  # kv (untiled HBM,
+        #                                                              full — DMA-gathered)
+        pt_spec,  # page table (SMEM)
+    ]
+    call_args = [q, indices4, positions4, kv, pt_arg]
+
+    out = pl.pallas_call(
+        kernel,
+        grid=(B, S),
+        in_specs=in_specs,
+        out_specs=pl.BlockSpec((1, 1, Hq, Dv), lambda b, s: (b, s, 0, 0)),
+        out_shape=jax.ShapeDtypeStruct((B, S, Hq, Dv), jnp.float32),
+        scratch_shapes=scratch_shapes,
+        interpret=interpret,
+    )(*call_args)
+    if Hq != H:
+        out = out[:, :, :H, :]  # drop padded heads
+    return out
+
+
+def prefill_write_and_attend(
+    ql,  # [T, H, kv_lora_rank]   absorbed latent query (nope)
+    qpe,  # [T, H, rope]           rope query
+    kvc,  # [T, kv_lora_rank]      new c_kv to write
+    kpe,  # [T, rope]              new k_rope to write
+    cache,  # [P, ps//pk, pk, Dk_pad]  paged fused latent cache
+    topk_pages,  # [T, K] int32          seq-local page ids (-1 padded)
+    positions,  # [T] int32             absolute query positions (causal bound)
+    loc,  # [T] int32             physical flat slot per token (out_cache_loc)
+    *,
+    kv_lora_rank: int,
+    page_size: int,
+    sm_scale: float,
+    read_block: int | None = None,  # defaults to page_size (page-level selection)
+    interpret: bool = False,
+):
+    """Self-write the current chunk's latent into the paged cache, then attend
+    only the indexer-selected pages via the fused sparse-MLA prefill kernel.
+
+    **SINGLE-SEQUENCE, SINGLE-SHOT extend only** (the padded-bucket TTFT case). All
+    ``T`` tokens are one contiguous request prefilled from position 0, so a single
+    per-request page table ``pt = loc[::page_size] // page_size`` maps logical→physical
+    (page p's first token slot // ps) and ``seq_len == T`` is the causal bound
+    (per-token causality via ``positions``). This stride mapping is only valid under
+    that scope — enforced upstream by the ``model_runner`` ``DSA_PREFILL_SPARSE``
+    guards (radix cache OFF, ``max_running == 1``, ``chunked_prefill >= context``). A
+    partial / batched / chunked extend would reference pages outside the current chunk
+    and corrupt the table; support for that is a follow-up.
+
+    Returns ``(o[T,H,kv_lora_rank], updated_cache)``.
+    """
+    T, H, Dv = ql.shape
+    rope = qpe.shape[-1]
+    ps = page_size
+    RB = read_block if read_block is not None else ps
+    # page-level selection: a selected unit (RB tokens) must sit within one page so the
+    # paged gather never straddles a page boundary (kernel also asserts RB % 16 == 0).
+    assert ps % RB == 0, f"read_block {RB} must divide page_size {ps} (page-aligned units)"
+    Pn, pspk, pk, Dk_pad = cache.shape
+    K = topk_pages.shape[-1]
+
+    q_sparse = jnp.concatenate([ql, qpe], axis=-1)  # [T, H, Dv+rope]
+    # per-request logical→physical page table (page p's first token slot // ps).
+    # Valid ONLY for the single-shot contiguous extend above; clamp guards
+    # padding/-1 slots (out-of-range → OOB gather / core halt).
+    pt = jnp.clip(loc[::ps] // ps, 0, Pn - 1).astype(jnp.int32)
+
+    # self-write: [c_kv | k_pe | pad] row per token at its physical slot. Padded
+    # tokens carry out_cache_loc == -1 and MUST be skipped. NOTE: mode="drop" only
+    # drops OUT-OF-RANGE indices — it still WRAPS negatives (-1 -> last slot), which
+    # would silently corrupt the final physical KV slot on every prefill. Pass
+    # wrap_negative_indices=False so the -1 rows are actually dropped.
+    row = jnp.zeros((T, Dk_pad), cache.dtype)
+    row = row.at[:, :Dv].set(kvc.astype(cache.dtype))
+    row = row.at[:, Dv : Dv + rope].set(kpe.reshape(T, rope).astype(cache.dtype))
+    flat = cache.reshape(Pn * ps, Dk_pad)
+    flat = flat.at[loc].set(row, mode="drop", wrap_negative_indices=False)
+    cache_new = flat.reshape(Pn, pspk, pk, Dk_pad)
+
+    out = sparse_mla_attention(
+        q_sparse.reshape(1, T, H, q_sparse.shape[2]),
+        cache_new,
+        topk_pages.reshape(1, T, -1),
+        positions.reshape(1, T),
+        kv_lora_rank=Dv,
+        read_block=RB,
+        block_units=K,
+        sm_scale=float(sm_scale),
+        page_table=pt.reshape(1, -1),
+        page_size=ps,
+        seq_len=T,
+        interpret=interpret,
+    )
+    return out.reshape(T, H, Dv), cache_new
+
+
+def units_to_token_ids(indices, read_block: int):
+    """Expand unit ids ``[B, S, K]`` → token ids ``[B, S, K*read_block]``.
+
+    Convenience for validating against the token-granular numpy oracle
+    (``glm5_tpu.dsa.attention.dsa_attention``), which expects token indices.
+    """
+    starts = indices[..., None] * read_block  # [B,S,K,1]
+    offs = jnp.arange(read_block, dtype=indices.dtype)  # [RB]
+    return (starts + offs).reshape(indices.shape[:2] + (-1,))
+
+
+def flat_to_paged_cache(kv, page_size: int, kv_packing: int = 2):
+    """Pack a flat ``[B, T, Dk]`` latent into the sglang-jax 4D paged MLA cache
+    plus a **contiguous** page table ``[B, max_pages]``. Test/bench scaffolding
+    mirroring ``MLATokenToKVPool``'s layout
+    ``[num_pages, page_size//kv_packing, kv_packing, Dk]`` where token (page P,
+    within-page offset o) lives at ``[P, o//kv_packing, o%kv_packing, :]``.
+
+    Sequence ``b`` is assigned pages ``[b*pages_per_seq : (b+1)*pages_per_seq)``.
+    Returns ``(cache, page_table)`` as jnp arrays (cache dtype == kv dtype).
+    """
+    import numpy as _np
+
+    kv_np = _np.asarray(kv)
+    B, T, Dk = kv_np.shape
+    if page_size % kv_packing != 0:
+        raise ValueError(f"page_size {page_size} must be divisible by kv_packing {kv_packing}")
+    pages_per_seq = (T + page_size - 1) // page_size
+    num_pages = B * pages_per_seq
+    ps_pack = page_size // kv_packing
+    cache = _np.zeros((num_pages, ps_pack, kv_packing, Dk), dtype=kv_np.dtype)
+    page_table = _np.zeros((B, pages_per_seq), dtype=_np.int32)
+    for b in range(B):
+        for lp in range(pages_per_seq):
+            phys = b * pages_per_seq + lp
+            page_table[b, lp] = phys
+            for o in range(page_size):
+                t = lp * page_size + o
+                if t < T:
+                    cache[phys, o // kv_packing, o % kv_packing, :] = kv_np[b, t]
+    return jnp.asarray(cache), jnp.asarray(page_table)

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py
@@ -203,7 +203,7 @@ def sparse_mla_attention(
     kv_lora_rank: int = 512,
     read_block: int = 1,
     block_units: int | None = None,  # units gathered+matmul'd per chunk (G; parallelism knob)
-    sm_scale: float | None = None,
+    sm_scale: float | None = None,  # REQUIRED: 1/sqrt(qk_nope_head_dim + qk_rope_head_dim)
     interpret: bool = False,
     page_table=None,  # [B, max_pages] int32: logical page -> physical page. When set,
     # ``kv`` is the packed 4D paged cache and the kernel gathers from it.
@@ -212,6 +212,10 @@ def sparse_mla_attention(
 ):
     """Sparse MLA-latent attention (head-minor chunked kernel).
     Returns ``[B, S, H, kv_lora_rank]`` (float32).
+
+    ``sm_scale`` is **required**: the score is the absorbed q·k over the latent
+    ``Dk`` but the correct scale is the original ``1/sqrt(qk_nope_head_dim +
+    qk_rope_head_dim)`` (= 1/√192 for DS/GLM), which the latent dim doesn't encode.
 
     ``indices`` are *unit ids* (one unit = ``read_block`` contiguous tokens); set
     ``read_block=1`` for token-granular (exact) DSA, or e.g. 128 for page-sized block
@@ -236,7 +240,17 @@ def sparse_mla_attention(
     if not block_units or block_units < 1:
         raise ValueError("sparse_mla_attention requires block_units >= 1")
     if sm_scale is None:
-        sm_scale = 1.0 / (Dk**0.5)  # note: true (unpadded) Dk
+        # No safe default: the score is the absorbed q·k over the full latent Dk
+        # (kv_lora_rank + qk_rope_head_dim), but the correct scale is the ORIGINAL
+        # attention head dim 1/sqrt(qk_nope_head_dim + qk_rope_head_dim) (= 1/sqrt(192)
+        # for DS/GLM), which cannot be recovered from Dk or kv_lora_rank alone.
+        # Deriving it from the latent dim (the old 1/sqrt(Dk) default) silently
+        # under-scales the logits, so require the caller to pass it explicitly.
+        raise ValueError(
+            "sparse_mla_attention requires an explicit sm_scale "
+            "(1/sqrt(qk_nope_head_dim + qk_rope_head_dim)); the latent Dk is not the "
+            "score head dim, so there is no safe default."
+        )
 
     # TPU/Mosaic wants the lane (last) dim %128; the MLA latent is 576 = 512 + 64
     # rope, so pad the feature dim with zeros to the next multiple of 128 (640).

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -24,6 +24,7 @@ from jax.tree_util import register_pytree_node_class
 
 from sgl_jax.srt.kernels.dsa.ref import streamindex_page_topk_ref, streamindex_topk_ref
 from sgl_jax.srt.kernels.dsa.sparse_mla import compute_topk_pages, sparse_mla_page_level
+from sgl_jax.srt.kernels.dsa.sparse_mla_prefill import prefill_write_and_attend
 from sgl_jax.srt.kernels.dsa.streamindex_topk import streamindex_topk
 from sgl_jax.srt.kernels.mla.v2.kernel import mla_ragged_paged_attention
 from sgl_jax.srt.layers.attention.mla_backend import MLAAttentionBackend
@@ -37,7 +38,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _SPARSE_PALLAS_MAX_T = 1
-_DEBUG_N_HIT = False
 # Page-budget for the page-scoring indexer path: the indexer max-pools token
 # scores per page and selects this many pages directly (0 = off, use the
 # token-topk + page-union path with k_pages_max=512). Bounds sparse-MLA cost
@@ -52,6 +52,14 @@ _INDEXER_KERNEL = os.environ.get("DSA_INDEXER_KERNEL", "0") == "1"
 # bkv block of 64 pages (4K tokens @ page 64) benched fastest across
 # B=8..64, ctx 8K..128K on v7x/v6e.
 _INDEXER_KERNEL_KV_PAGES_PER_BLOCK = 64
+
+# Opt-in: run EXTEND/prefill through the fused sparse-MLA prefill kernel
+# (``sparse_mla_prefill.sparse_mla_attention``) at page granularity instead of the
+# dense fallback. Default OFF ⇒ prefill behaviour is unchanged. Page-level
+# selection (read_block == page_size) consumes the indexer's page-topk directly.
+# Scope: single-sequence extend (the padded-bucket TTFT case); multi-seq ragged
+# extend still needs per-token page tables (follow-up) — leave the flag off there.
+_PREFILL_SPARSE = int(os.environ.get("DSA_PREFILL_SPARSE", "0"))
 
 
 @register_pytree_node_class
@@ -197,11 +205,51 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
             )
             return o, DSAFusedCache(kv=kv_cache, idx=idx_cache, topk=topk, topk_pages=topk_pages)
 
-        # ── prefill/mixed → dense fallback: page_level is decode-only (one
-        # query token per seq). EXTEND/MIXED chunks route to plain dense; the
-        # indexer still writes idx cache so subsequent decode steps get valid
-        # topk. Multi-request DECODE (T>1) does go through the sparse path.
+        # ── prefill/mixed ─────────────────────────────────────────────────
+        # Default: dense fallback (page_level is decode-only; the indexer still
+        # writes the idx cache so later decode steps get valid topk).
+        # Opt-in (DSA_PREFILL_SPARSE): run the fused sparse-MLA *prefill* kernel
+        # over the indexer's page-topk — this is the EXTEND-sparsity gap PR.
         if not is_decode:
+            if _PREFILL_SPARSE:
+                idx_cache, topk_pages = self._maybe_index_prefill_pages(
+                    is_full, q_idx, k_idx, idx_weights, idx_cache, dpa, md
+                )
+                # Page selection for the sparse-prefill attend. A FULL (indexer)
+                # layer just produced [T, k_pages] page-topk; a SHARED layer gets
+                # None from `_maybe_index_prefill_pages` and reuses the preceding
+                # full layer's pages threaded via `dsa_topk_pages_in` (IndexShare).
+                # During prefill that thread is ALSO [T, k_pages] over the SAME T
+                # query rows (the full layer above ran the same single-shot prefill)
+                # — NOT the decode one-query-per-seq shape. None (a shared layer
+                # before any full layer) ⇒ fall through to the dense attend below.
+                topk_pages_use = topk_pages if is_full else dsa_topk_pages_in
+                if topk_pages_use is not None:
+                    o, kv_cache = self._run_sparse_prefill(
+                        q,
+                        q_rope,
+                        new_kv_c,
+                        new_k_pe,
+                        kv_cache,
+                        topk_pages_use,
+                        sm_scale,
+                        dpa,
+                        md,
+                        forward_batch,
+                    )
+                    return o, DSAFusedCache(
+                        kv=kv_cache,
+                        idx=idx_cache,
+                        topk=None,
+                        topk_pages=topk_pages if is_full else None,
+                    )
+                # no selection available (shared layer before any full) → dense
+                # fallback; idx cache already written above.
+                o, kv_cache = self._run_dense(
+                    q, q_rope, new_kv_c, new_k_pe, kv_cache, sm_scale, layer, dpa, md
+                )
+                return o, DSAFusedCache(kv=kv_cache, idx=idx_cache, topk=None, topk_pages=None)
+
             o, kv_cache = self._run_dense(
                 q, q_rope, new_kv_c, new_k_pe, kv_cache, sm_scale, layer, dpa, md
             )
@@ -348,13 +396,6 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
                     pages_per_seq=pages_per_seq,
                     k_pages_max=512,
                 )
-                if _DEBUG_N_HIT:
-                    jax.debug.print(
-                        "dsa_n_hit min={} max={} mean={}",
-                        jnp.min(jnp.sum(topk_pages >= 0, -1)),
-                        jnp.max(jnp.sum(topk_pages >= 0, -1)),
-                        jnp.mean(jnp.sum(topk_pages >= 0, -1).astype(jnp.float32)),
-                    )
             else:
                 topk_pages = jnp.full((topk.shape[0], 1), -1, jnp.int32)
             return cache3d.reshape(cache_.shape), topk, topk_pages
@@ -433,6 +474,113 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
             md.cu_q_lens,
             md.cu_kv_lens,
             md.distribution,
+        )
+
+    def _maybe_index_prefill_pages(self, is_full, q_idx, k_idx, idx_weights, idx_cache, dpa, md):
+        """Prefill page-topk: scatter ``k_idx`` into the paged indexer cache and,
+        on full layers, compute per-query **causal** page-level top-k via the
+        general (non-decode, ``one_token_per_seq=False``) indexer path.
+
+        Returns ``(idx_cache, topk_pages)`` where ``topk_pages`` is ``[T, k_pages]``
+        seq-local page ids (-1 padded) — exactly the sparse kernel's per-query
+        unit ids at ``read_block == page_size``. ``topk_pages`` is ``None`` on
+        shared layers / when no indexer is wired (caller reuses the threaded one).
+        """
+        if not is_full or q_idx is None:
+            return idx_cache, None
+        k_pages = (self.index_topk + self.page_size - 1) // self.page_size
+        in_specs = (
+            P(dpa, None, None),  # q_idx    [T, H_idx, D_idx] replicated
+            P(dpa, None),  # k_idx    [T, D_idx]
+            P(dpa, None),  # weights  [T, H_idx]
+            P(dpa, None, None, None),  # idx_cache paged
+            P(dpa),  # seq_lens
+            P(dpa),  # page_indices
+            P(dpa),  # cu_q_lens
+            P(dpa),  # cu_kv_lens
+            P(dpa),  # distribution
+        )
+        out_specs = (P(dpa, None, None, None), P(dpa, None))
+
+        def _run(q_, k_, w_, cache_, seq_lens_, pi_, cuq_, cukv_, dist_):
+            page_size = cache_.shape[1] * cache_.shape[2]
+            idx_dim = cache_.shape[3]
+            pages_per_seq = pi_.shape[0] // seq_lens_.shape[0]
+            cache3d = cache_.reshape(cache_.shape[0], page_size, idx_dim)
+            cache3d = _scatter_paged(cache3d, k_, seq_lens_, pi_, cuq_, cukv_, pages_per_seq)
+            topk_pages = streamindex_page_topk_ref(
+                q_,
+                w_,
+                cache3d,
+                seq_lens_,
+                pi_,
+                cuq_,
+                cukv_,
+                dist_,
+                k_pages=k_pages,
+                pages_per_seq=pages_per_seq,
+                one_token_per_seq=False,  # prefill: T>1 tokens/seq, per-query causal
+            )
+            return cache3d.reshape(cache_.shape), topk_pages
+
+        idx_cache, topk_pages = jax.shard_map(
+            _run, in_specs=in_specs, out_specs=out_specs, check_vma=False
+        )(
+            q_idx,
+            k_idx,
+            idx_weights,
+            idx_cache,
+            md.seq_lens,
+            md.page_indices,
+            md.cu_q_lens,
+            md.cu_kv_lens,
+            md.distribution,
+        )
+        return idx_cache, topk_pages
+
+    def _run_sparse_prefill(
+        self, ql, qpe, kvc, kpe, cache, topk_pages, sm_scale, dpa, md, forward_batch
+    ):
+        """Fused sparse-MLA prefill: self-write the current chunk's latent into the
+        paged fused cache, then attend only the page-topk pages. Single-sequence
+        extend scope (see ``_PREFILL_SPARSE``). Returns ``(o_latent, updated_cache)``.
+        """
+        loc = forward_batch.out_cache_loc.astype(jnp.int32)
+        positions = forward_batch.positions.astype(jnp.int32)
+        page_size = self.page_size
+        kv_lora_rank = self.kv_lora_rank
+        sm = float(sm_scale)
+
+        in_specs = (
+            P(dpa, "tensor", None),  # ql   [T, H, kv_lora_rank]
+            P(dpa, "tensor", None),  # qpe  [T, H, rope]
+            P(dpa, None),  # kvc  [T, kv_lora_rank]
+            P(dpa, None),  # kpe  [T, rope]
+            P(dpa, None, None, None),  # cache
+            P(dpa, None),  # topk_pages [T, K]
+            P(dpa),  # positions [T]
+            P(dpa),  # loc [T]
+        )
+        out_specs = (P(dpa, "tensor", None), P(dpa, None, None, None))
+
+        def _run(ql_, qpe_, kvc_, kpe_, cache_, tp_, pos_, loc_):
+            o, cache_new = prefill_write_and_attend(
+                ql_,
+                qpe_,
+                kvc_,
+                kpe_,
+                cache_,
+                tp_,
+                pos_,
+                loc_,
+                kv_lora_rank=kv_lora_rank,
+                page_size=page_size,
+                sm_scale=sm,
+            )
+            return o.astype(ql_.dtype), cache_new
+
+        return jax.shard_map(_run, in_specs=in_specs, out_specs=out_specs, check_vma=False)(
+            ql, qpe, kvc, kpe, cache, topk_pages, positions, loc
         )
 
     def _run_dense(self, ql, qpe, kvc, kpe, cache, sm_scale, layer, dpa, md):

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -3,6 +3,7 @@
 import contextlib
 import dataclasses
 import logging
+import os
 from functools import partial
 
 import jax
@@ -698,8 +699,68 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                 getattr(cfg, "index_skip_topk_offset", 0),
                 cfg.num_hidden_layers,
             )
+            # Per-launch override of the indexer top-k budget (page count = ceil(
+            # index_topk / page_size) is a static kernel shape, so this is fixed at
+            # startup). Unset ⇒ use the model config's default. Lets us sweep the
+            # DSA budget across relaunches without editing the model config.json.
+            _dsa_topk_env = os.environ.get("DSA_INDEX_TOPK")
+            _index_topk = int(_dsa_topk_env) if _dsa_topk_env else cfg.index_topk
+            if _dsa_topk_env:
+                logger.info(
+                    "DSA index_topk overridden by DSA_INDEX_TOPK=%s (cfg default %s)",
+                    _index_topk,
+                    cfg.index_topk,
+                )
+            # ── PR1 scope guards: DSA sparse PREFILL (DSA_PREFILL_SPARSE=1) ──
+            # This is the INITIAL single-sequence, single-shot sparse-MLA prefill.
+            # It assumes a single-shot extend from position 0 and does NOT yet
+            # support: radix/prefix caching (a cache hit turns prefill into a
+            # partial extend the current-chunk page table can't represent),
+            # batching (max_running>1 ⇒ multi-seq ragged extend), or chunked
+            # prefill (a split prompt references pages outside the chunk). Fail
+            # fast with an actionable message instead of silently emitting
+            # garbage. Gated on the opt-in flag, so the dense-prefill/decode
+            # paths — and CI, which never sets DSA_PREFILL_SPARSE — are unaffected.
+            if os.environ.get("DSA_PREFILL_SPARSE", "0") == "1":
+                sa = self.server_args
+                ctx_len = sa.context_length or getattr(self.model_config, "context_len", None)
+                problems = []
+                if not sa.disable_radix_cache:
+                    problems.append(
+                        "radix/prefix cache is ENABLED — pass --disable-radix-cache "
+                        "(a cache hit makes prefill a partial extend the sparse page "
+                        "table cannot represent → garbage output)"
+                    )
+                if sa.max_running_requests != 1:
+                    problems.append(
+                        f"max_running_requests={sa.max_running_requests} — set "
+                        "--max-running-requests 1 (batching needs multi-seq ragged "
+                        "extend, not supported yet)"
+                    )
+                if sa.chunked_prefill_size is None or (
+                    ctx_len is not None and sa.chunked_prefill_size < ctx_len
+                ):
+                    problems.append(
+                        f"chunked_prefill_size={sa.chunked_prefill_size} < "
+                        f"context_length={ctx_len} — set --chunked-prefill-size >= "
+                        "context length so prompts prefill single-shot (no chunking)"
+                    )
+                if problems:
+                    raise ValueError(
+                        "DSA_PREFILL_SPARSE=1 (initial single-sequence sparse-prefill) "
+                        "is incompatible with the current server args:\n  - "
+                        + "\n  - ".join(problems)
+                        + "\nThis is an initial version; radix-cache, batching and "
+                        "chunking support are follow-ups."
+                    )
+                logger.warning(
+                    "DSA sparse PREFILL enabled (initial single-seq, single-shot "
+                    "scope): radix-cache OFF, max_running=1, single-shot prefill "
+                    "(chunk>=context). index_topk=%s.",
+                    _index_topk,
+                )
             full_attn_backend = DSASparseAttentionBackend(
-                index_topk=cfg.index_topk,
+                index_topk=_index_topk,
                 index_head_dim=cfg.index_head_dim,
                 index_n_heads=cfg.index_n_heads,
                 skip_offset=getattr(cfg, "index_skip_topk_offset", 0),

--- a/test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py
+++ b/test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py
@@ -1,0 +1,336 @@
+"""Parity: fused sparse-MLA prefill kernel vs a masked-softmax reference.
+
+Validates ``sparse_mla_attention`` (poc kernel, placed at
+``sgl_jax.srt.kernels.dsa.sparse_mla_prefill``) at **page-level granularity**
+(``read_block == page_size``), which is exactly how PR1 wires it into the DSA
+backend's EXTEND path: the indexer's ``topk_pages`` (seq-local page ids) become
+the kernel's per-query unit ids.
+
+Two modes are checked against the same reference:
+  * flat  : ``kv`` is a flat [B, T, Dk] latent buffer.
+  * paged : ``kv`` is the packed 4D MLA cache + per-seq page table.
+
+Runs on CPU via ``interpret=True`` (no TPU needed).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+jax.config.update("jax_platform_name", "cpu")
+
+# Import the kernel module directly from its file (it only depends on jax/pallas,
+# so we don't need the full sgl_jax package installed for this parity check).
+_HERE = os.path.dirname(__file__)
+_KERNEL_PATH = os.path.normpath(
+    os.path.join(_HERE, "../../../../python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py")
+)
+_spec = importlib.util.spec_from_file_location("sparse_mla_prefill", _KERNEL_PATH)
+smp = importlib.util.module_from_spec(_spec)
+sys.modules["sparse_mla_prefill"] = smp
+_spec.loader.exec_module(smp)
+
+sparse_mla_attention = smp.sparse_mla_attention
+units_to_token_ids = smp.units_to_token_ids
+flat_to_paged_cache = smp.flat_to_paged_cache
+prefill_write_and_attend = smp.prefill_write_and_attend
+
+
+def _reference(q, kv, indices, positions, *, read_block, kv_lora_rank, sm_scale):
+    """Masked-softmax sparse MLA over the selected units, in fp32.
+
+    q:   [B, S, H, Dk]   kv: [B, T, Dk]   indices: [B, S, K] unit ids
+    positions: [B, S]    returns [B, S, H, kv_lora_rank]
+    """
+    B, S, H, Dk = q.shape
+    T = kv.shape[1]
+    Dv = kv_lora_rank
+    tok = np.asarray(units_to_token_ids(jnp.asarray(indices), read_block))  # [B,S,K*RB]
+    q = np.asarray(q, np.float32)
+    kv = np.asarray(kv, np.float32)
+    pos = np.asarray(positions)
+    out = np.zeros((B, S, H, Dv), np.float32)
+    for b in range(B):
+        for s in range(S):
+            ids = tok[b, s]
+            valid = (ids >= 0) & (ids <= pos[b, s]) & (ids < T)
+            ids_safe = np.where(valid, ids, 0)
+            k_sel = kv[b, ids_safe]  # [N, Dk]
+            logits = (q[b, s] @ k_sel.T) * sm_scale  # [H, N]
+            logits = np.where(valid[None, :], logits, -np.inf)
+            m = logits.max(-1, keepdims=True)
+            m = np.where(np.isneginf(m), 0.0, m)
+            p = np.exp(logits - m)
+            p = np.where(valid[None, :], p, 0.0)
+            denom = p.sum(-1, keepdims=True)
+            denom = np.where(denom == 0.0, 1.0, denom)
+            p = p / denom
+            out[b, s] = p @ k_sel[:, :Dv]  # [H, Dv]
+    return out
+
+
+def _make_case(seed=0):
+    rng = np.random.default_rng(seed)
+    B, S, H = 2, 6, 8
+    kv_lora_rank, rope = 512, 64
+    Dk = kv_lora_rank + rope
+    page_size = 128
+    pages_per_seq = 4
+    T = page_size * pages_per_seq
+    K = 3  # selected pages per query (page-level => RB=page_size)
+
+    q = jnp.asarray(rng.standard_normal((B, S, H, Dk)) * 0.1, jnp.float32)
+    kv = jnp.asarray(rng.standard_normal((B, T, Dk)) * 0.1, jnp.float32)
+
+    # query positions: spread across the context so causal bounds vary per token
+    positions = np.zeros((B, S), np.int32)
+    for b in range(B):
+        positions[b] = np.linspace(page_size, T - 1, S).astype(np.int32)
+    positions = jnp.asarray(positions)
+
+    # selection: page 0 (always causally valid) + random distinct pages, padded
+    # with -1 when fewer than K pages are causally reachable (exercises the
+    # kernel's topk-padding path — real indexer output is -1-padded).
+    idx = np.full((B, S, K), -1, np.int32)
+    for b in range(B):
+        for s in range(S):
+            hi = int(positions[b, s] // page_size + 1)  # causally-reachable pages
+            n = min(K, hi)
+            choices = rng.choice(hi, size=n, replace=False)
+            if 0 not in choices:
+                choices[0] = 0  # guarantee ≥1 valid key
+            idx[b, s, :n] = choices
+    indices = jnp.asarray(idx)
+    return dict(
+        q=q,
+        kv=kv,
+        indices=indices,
+        positions=positions,
+        kv_lora_rank=kv_lora_rank,
+        page_size=page_size,
+        T=T,
+        K=K,
+        sm_scale=1.0 / (Dk**0.5),
+    )
+
+
+def _run(mode="flat", seed=0):
+    c = _make_case(seed)
+    ref = _reference(
+        c["q"],
+        c["kv"],
+        c["indices"],
+        c["positions"],
+        read_block=c["page_size"],
+        kv_lora_rank=c["kv_lora_rank"],
+        sm_scale=c["sm_scale"],
+    )
+    if mode == "flat":
+        out = sparse_mla_attention(
+            c["q"],
+            c["kv"],
+            c["indices"],
+            c["positions"],
+            kv_lora_rank=c["kv_lora_rank"],
+            read_block=c["page_size"],
+            block_units=c["K"],
+            sm_scale=c["sm_scale"],
+            interpret=True,
+        )
+    else:
+        cache, page_table = flat_to_paged_cache(c["kv"], c["page_size"], kv_packing=2)
+        # pad feature dim to Dk_pad (kernel does this for q internally; cache must match)
+        Dk = c["q"].shape[-1]
+        Dk_pad = ((Dk + 127) // 128) * 128
+        if cache.shape[-1] != Dk_pad:
+            cache = jnp.pad(cache, ((0, 0), (0, 0), (0, 0), (0, Dk_pad - Dk)))
+        out = sparse_mla_attention(
+            c["q"],
+            cache,
+            c["indices"],
+            c["positions"],
+            kv_lora_rank=c["kv_lora_rank"],
+            read_block=c["page_size"],
+            block_units=c["K"],
+            sm_scale=c["sm_scale"],
+            interpret=True,
+            page_table=page_table,
+            page_size=c["page_size"],
+            seq_len=c["T"],
+        )
+    out = np.asarray(out)
+    err = np.abs(out - ref)
+    print(f"[{mode}] max|err|={err.max():.3e}  mean|err|={err.mean():.3e}  shape={out.shape}")
+    assert err.max() < 2e-3, f"{mode}: parity failed, max err {err.max()}"
+    return err.max()
+
+
+def _run_write_attend(seed=0):
+    """End-to-end: self-write latent into a paged cache, then page-level sparse
+    attend — vs a masked-softmax reference over the written latent. Single-seq."""
+    rng = np.random.default_rng(seed)
+    T, H = 512, 8
+    kv_lora_rank, rope = 512, 64
+    Dk_pad = 640
+    page_size = 128
+    pages = T // page_size  # single request occupies pages 0..pages-1
+    K = 3
+    scale = 1.0 / ((kv_lora_rank + rope) ** 0.5)
+
+    ql = jnp.asarray(rng.standard_normal((T, H, kv_lora_rank)) * 0.1, jnp.float32)
+    qpe = jnp.asarray(rng.standard_normal((T, H, rope)) * 0.1, jnp.float32)
+    kvc = jnp.asarray(rng.standard_normal((T, kv_lora_rank)) * 0.1, jnp.float32)
+    kpe = jnp.asarray(rng.standard_normal((T, rope)) * 0.1, jnp.float32)
+    # empty fp32 paged cache [P, ps//pk, pk, Dk_pad] with pk=1
+    cache = jnp.zeros((pages, page_size, 1, Dk_pad), jnp.float32)
+    loc = jnp.arange(T, dtype=jnp.int32)  # token t -> physical slot t
+    positions = jnp.arange(T, dtype=jnp.int32)
+
+    tp = np.full((T, K), -1, np.int32)
+    for t in range(T):
+        hi = t // page_size + 1
+        n = min(K, hi)
+        ch = rng.choice(hi, size=n, replace=False)
+        if 0 not in ch:
+            ch[0] = 0
+        tp[t, :n] = ch
+    topk_pages = jnp.asarray(tp)
+
+    o, cache_new = prefill_write_and_attend(
+        ql,
+        qpe,
+        kvc,
+        kpe,
+        cache,
+        topk_pages,
+        positions,
+        loc,
+        kv_lora_rank=kv_lora_rank,
+        page_size=page_size,
+        sm_scale=scale,
+        interpret=True,
+    )
+    o = np.asarray(o)
+
+    # reference over the written latent [T, 576]
+    latent = np.concatenate([np.asarray(kvc), np.asarray(kpe)], axis=-1)  # [T, 576]
+    q_full = np.concatenate([np.asarray(ql), np.asarray(qpe)], axis=-1)  # [T, H, 576]
+    tok = np.asarray(units_to_token_ids(topk_pages, page_size)).reshape(T, -1)  # [T, K*ps]
+    ref = np.zeros((T, H, kv_lora_rank), np.float32)
+    for t in range(T):
+        ids = tok[t]
+        valid = (ids >= 0) & (ids <= t) & (ids < T)
+        ids_safe = np.where(valid, ids, 0)
+        k_sel = latent[ids_safe]
+        logits = (q_full[t] @ k_sel.T) * scale
+        logits = np.where(valid[None, :], logits, -np.inf)
+        m = logits.max(-1, keepdims=True)
+        m = np.where(np.isneginf(m), 0.0, m)
+        p = np.exp(logits - m)
+        p = np.where(valid[None, :], p, 0.0)
+        denom = p.sum(-1, keepdims=True)
+        ref[t] = (p / np.where(denom == 0.0, 1.0, denom)) @ k_sel[:, :kv_lora_rank]
+
+    err = np.abs(o - ref)
+    # also verify the self-write landed: cache row for token t == [kvc|kpe|pad]
+    flat = np.asarray(cache_new).reshape(pages * page_size, Dk_pad)
+    w_err = np.abs(flat[:T, :kv_lora_rank] - np.asarray(kvc)).max()
+    print(f"[write+attend] max|err|={err.max():.3e}  self-write max|err|={w_err:.3e}")
+    assert err.max() < 2e-3, f"attend parity failed: {err.max()}"
+    assert w_err < 1e-6, f"self-write failed: {w_err}"
+    return err.max()
+
+
+def _run_write_attend_canary(seed=0):
+    """Regression: padded tokens carry out_cache_loc == -1 and MUST be dropped from
+    the self-write, NOT wrapped into the last physical slot (jax .at[].set(mode='drop')
+    still wraps negatives). Place a canary in the final slot (owned by no real token)
+    and a -1 loc for the padded tail; the canary must survive."""
+    rng = np.random.default_rng(seed)
+    T_real, T_pad, H = 256, 64, 8
+    T = T_real + T_pad
+    kv_lora_rank, rope = 512, 64
+    Dk_pad = 640
+    page_size = 128
+    pages = 3  # real request uses pages 0..1; page 2 holds the canary
+    K = 3
+    scale = 1.0 / ((kv_lora_rank + rope) ** 0.5)
+
+    ql = jnp.asarray(rng.standard_normal((T, H, kv_lora_rank)) * 0.1, jnp.float32)
+    qpe = jnp.asarray(rng.standard_normal((T, H, rope)) * 0.1, jnp.float32)
+    kvc = jnp.asarray(rng.standard_normal((T, kv_lora_rank)) * 0.1, jnp.float32)
+    kpe = jnp.asarray(rng.standard_normal((T, rope)) * 0.1, jnp.float32)
+
+    CANARY = 12345.0
+    cache = np.zeros((pages, page_size, 1, Dk_pad), np.float32)
+    cache[pages - 1, page_size - 1, 0, :] = CANARY  # very last physical slot
+    cache = jnp.asarray(cache)
+
+    # real tokens t -> slot t (pages 0..1); padded tail -> out_cache_loc == -1
+    loc = jnp.asarray(np.concatenate([np.arange(T_real), np.full(T_pad, -1)]).astype(np.int32))
+    positions = jnp.asarray(np.concatenate([np.arange(T_real), np.zeros(T_pad)]).astype(np.int32))
+
+    tp = np.full((T, K), -1, np.int32)
+    for t in range(T_real):
+        hi = t // page_size + 1
+        n = min(K, hi)
+        ch = rng.choice(hi, size=n, replace=False)
+        if 0 not in ch:
+            ch[0] = 0
+        tp[t, :n] = ch
+    topk_pages = jnp.asarray(tp)
+
+    _, cache_new = prefill_write_and_attend(
+        ql,
+        qpe,
+        kvc,
+        kpe,
+        cache,
+        topk_pages,
+        positions,
+        loc,
+        kv_lora_rank=kv_lora_rank,
+        page_size=page_size,
+        sm_scale=scale,
+        interpret=True,
+    )
+    flat = np.asarray(cache_new).reshape(pages * page_size, Dk_pad)
+    canary_after = flat[pages * page_size - 1]
+    assert np.allclose(
+        canary_after, CANARY
+    ), f"padded -1 loc corrupted the final KV slot: {canary_after[:3]} != {CANARY}"
+    w_err = np.abs(flat[:T_real, :kv_lora_rank] - np.asarray(kvc)[:T_real]).max()
+    assert w_err < 1e-6, f"self-write regressed: {w_err}"
+    print(f"[write+attend canary] final-slot canary preserved; self-write max|err|={w_err:.3e}")
+
+
+def test_parity_flat():
+    _run("flat")
+
+
+def test_parity_paged():
+    _run("paged")
+
+
+def test_prefill_write_and_attend():
+    _run_write_attend()
+
+
+def test_prefill_write_and_attend_padded_loc_canary():
+    _run_write_attend_canary()
+
+
+if __name__ == "__main__":
+    for seed in range(3):
+        _run("flat", seed)
+        _run("paged", seed)
+    for seed in range(3):
+        _run_write_attend(seed)
+    _run_write_attend_canary()
+    print("PARITY OK")


### PR DESCRIPTION
## Motivation

DeepSeek-family MLA models ship DeepSeek Sparse Attention (DSA) — a lightning indexer selects a top-k set of past tokens per query and attention runs only over that set — but sgl-jax had no attention path that used it for **prefill**: `--attention-backend dsa_sparse` selected tokens at decode but ran a **dense** prefill. On long contexts the prefill (EXTEND) step dominates and scales O(T²), so a dense prefill negates DSA exactly where it matters most.

This PR adds the **sparse prefill** path: a fused self-write + sparse-MLA Pallas kernel that attends only the indexer's selected pages during EXTEND. This cuts the **attention** term on the sparsified layers from O(T²) to O(T·K) (K = the fixed per-query page budget). It does **not** make prefill asymptotically linear: a residual O(T²) remains from the un-sparsified dense `skip_offset` layers (full causal MLA) and from the lightning indexer's dense page-scoring (O(T·S)). The win is a much smaller quadratic constant; a streaming indexer is a follow-up. See Benchmarking.

Scope: initial **single-sequence, single-shot** version. It does not yet support radix/prefix caching, request batching, or chunked prefill; the runtime fails fast with an actionable message if enabled outside that scope. Those are follow-ups.

## Modifications

- **New kernel** `srt/kernels/dsa/sparse_mla_prefill.py`: head-minor chunked sparse-MLA prefill kernel (selected keys on the MXU lane axis, few heads on the sublane axis — efficient under head-TP), `prefill_write_and_attend` (self-write latent into the paged cache, then attend the selected pages), and paged-cache test scaffolding. `sparse_mla_attention` now **requires an explicit `sm_scale`** (raises if `None`): the correct scale is the original `1/sqrt(qk_nope_head_dim + qk_rope_head_dim)` (= 1/√192 for DS/GLM), which the absorbed latent dim `Dk` does not encode.
- **Backend wiring** `srt/layers/attention/dsa_sparse_backend.py`: opt-in (`DSA_PREFILL_SPARSE=1`) routing of EXTEND through the sparse kernel, consuming the indexer page-topk directly and reusing it across shared layers (IndexShare). Default off ⇒ dense prefill, unchanged.
- **Scope guard** `srt/model_executor/model_runner.py`: with `DSA_PREFILL_SPARSE=1`, hard-error unless radix cache is disabled, `max_running_requests == 1`, and `chunked_prefill_size >= context_length`; plus a `DSA_INDEX_TOPK` env override for the selection budget. Gated on the opt-in flag ⇒ CI / dense / decode paths unaffected.
- **Docs** `docs/features/attention_backend.md`: document the `dsa_sparse` backend, enabling flags/env, the sparse-prefill scope + guard, and the O(T·K)-attention / residual-O(T²) asymptotics.

## Accuracy Tests

All numbers are on **GLM-5.2-FP8** (`zai-org/GLM-5.2-FP8`, public, **MIT** — a DSA model: DeepSeek-style sparse attention + IndexShare), served on **TPU v7x (Ironwood), 8 chips / 16 JAX devices, `tp16 ep16 dp1` (head-TP)**, `page_size=128`, `disable_radix_cache`, `max_running_requests=1`, `context_length=8192`, `mem_fraction_static=0.72`, MoE backend `epmoe`, bf16 compute (FP8 weights). Server + eval:

```bash
DSA_PREFILL_SPARSE=<1|0> DSA_INDEX_TOPK=4096 python -m sgl_jax.launch_server \
  --model-path zai-org/GLM-5.2-FP8 --trust-remote-code --device tpu --dtype bfloat16 \
  --tp-size 16 --dp-size 1 --ep-size 16 --moe-backend epmoe --attention-backend dsa_sparse \
  --nnodes 2 --node-rank <r> --dist-init-addr <ip:port> \
  --context-length 8192 --chunked-prefill-size 8192 --max-prefill-tokens 8192 \
  --page-size 128 --mem-fraction-static 0.72 --disable-radix-cache --max-running-requests 1
python3 test/srt/run_eval.py --host 127.0.0.1 --port 30000 --eval-name gsm8k \
  --num-examples 50 --temperature 0 --model zai-org/GLM-5.2-FP8
```

- **CI (CPU) parity** — `test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py` checks the sparse-MLA prefill kernel vs a masked-softmax reference (`interpret=True`), flat and paged modes; no TPU required.
- **GSM8K no-regression control (standard, short prompts).** n=50, greedy (temp 0), **one server flipping only `DSA_PREFILL_SPARSE`**:

  | prefill path | GSM8K (n=50) |
  |---|---|
  | DSA sparse (`DSA_PREFILL_SPARSE=1`) | **47/50 (0.94)** |
  | dense control (`DSA_PREFILL_SPARSE=0`) | **47/50 (0.94)** |

  Identical. Standard GSM8K prompts (~100–300 tokens) fall below `index_topk=4096` (32 pages), so the sparse path selects *all* pages and is mathematically equal to dense — the matched score confirms the fused self-write + kernel introduce **no regression** on the served path (any sparse≠dense here would be a pure plumbing bug).
**Tightened to n=200 (on #1508+#1512).** Re-ran the same `run_eval` gsm8k control at 4× the sample size on the combined single-seq stack (`test/srt/run_eval.py --eval-name gsm8k --num-examples 200`, temp 0, no thinking, `max_running=1`, radix off):

  | prefill path | GSM8K run_eval (n=200) |
  |---|---|
  | DSA sparse (`DSA_PREFILL_SPARSE=1`) | **0.960 (192/200)** |
  | dense control (`DSA_PREFILL_SPARSE=0`) | **0.980 (196/200)** |

  Δ −0.020 (4/200, inside the n=200 noise band) — no meaningful regression at the tighter n=200 CI (same harness as the n=50 row above). Standard prompts stay under the `index_topk=4096` budget, so this is the plumbing/code-path check; selection-under-pruning is the long-context pair below.
- **Long-context recall (NIAH) — selection quality.** NIAH 5×5 grid, ctx ≈ 8k, same server/config:

  | Config | Selected pages | NIAH recall |
  |---|---|---|
  | Dense reference (full coverage) | 57 | 19/25 (76%) |
  | DSA `index_topk=4096` | 32 | 18/25 (72%) |
  | DSA `index_topk=3072` | 24 | 17/25 (68%) |
  | DSA `index_topk=2048` | 16 | 17/25 (68%) |

  DSA tracks dense within 1–2 needles even at ~3.6× page pruning; every miss is coherent text (no garbage). The absolute dense 19/25 is low for a 1M-context model like GLM-5.2 and reflects the strictness of our 25-sample single-needle grid (~4% grid noise), **not** model quality — read this as a *sparse-vs-dense delta*, not an absolute recall benchmark.
- **Long-context GSM8K — paired sparse-vs-dense under pruning.** `gsm8k_longctx.py` builds ~7k-token many-shot prompts so the indexer genuinely prunes (57→32 pages). One server, flipping only `DSA_PREFILL_SPARSE`, `index_topk=4096`, greedy, n=50:

  | prefill path | flag | long-ctx GSM8K (n=50) |
  |---|---|---|
  | DSA sparse | `DSA_PREFILL_SPARSE=1` | 43/50 (0.86) |
  | dense control | `DSA_PREFILL_SPARSE=0` | 42/50 (0.84) |

  Sparse ≥ dense — no accuracy collapse when pages are actively dropped. The low absolutes were a decode-budget artifact, not selection quality: at `max_tokens=900`, ~8/50 generations truncated inside GLM-5.2's thinking block before emitting `Answer:`. Re-running truncation-free (`context_length=12288`, `max_tokens=3072`, same 50 prompts, 1/50 truncated each) gives sparse **50/50** vs dense **48/50** — the pair holds and both jump once decode isn't capped. The n=50 long-ctx pair is a coarse check for the *selection* signal; the tightened **n=200** short-context control (above, on #1508+#1512) shows no regression at 4× the sample size, and the full-`evalscope` (1319) pass rides with the batching PR #1514. Extending this long-context pair to n=200 is the deferred long-context follow-up.

## Benchmarking and Profiling

Single-shot prefill wall time. **Two servers identical except `DSA_PREFILL_SPARSE`** (1 = sparse, 0 = dense), `index_topk=4096`. Config: **TPU v7x, 8 chips / 16 devices, `tp16 ep16 dp1` (head-TP)**, `page_size=128`, `disable_radix_cache`, `max_running_requests=1`, `mem_fraction_static=0.60`; **dense baseline `chunked_prefill_size = max_prefill_tokens = context` (single-shot)**. All three contexts are prompt lengths on **one `context_length=49152` server** (key span S pinned at 49k — see note), with the **prefill token-padding bucket pinned to each prompt length** via `--precompile-token-paddings 16384/32768/49152` — required, since the sparse-MLA prefill kernel grids over the padded bucket, so its cost tracks the bucket, not the actual prompt.

| Context (T) | Dense prefill | DSA sparse prefill | Speedup |
|---|---|---|---|
| 16k | 19.1 s | 10.5 s | 1.82× |
| 32k | 73.0 s | 23.1 s | 3.16× |
| 48k | 155.7 s | 38.4 s | 4.05× |

Dense scales ∝ T² (O(T²) causal MLA on all 78 layers). DSA replaces that with O(T·K) sparse attention on the 72 sparsified layers, but is **not** asymptotically linear — prefill stays O(T²) with a much smaller constant, from (a) the dense `skip_offset` layers and (b) the lightning indexer's O(T·S) page-score einsum. The widening 1.82×→4.05× gap is the smaller quadratic *constant* (6 dense layers vs 78), **not** linear scaling.

**Limitation (single-shot bucketing).** Because the kernel's cost tracks the padded bucket, a prompt that lands between the default paddings (`[64…8192]` + `context_length`) pads up to the next bucket: e.g. a 16k prompt at defaults pads to 49152 and runs at that cost (~34.7 s, slower than dense) purely from padding. Single-shot prefill keeps the bucket under the operator's control (the pinning above); the general fix is **chunked prefill (#1514)**, which splits the prompt to `chunked_prefill_size` so it never lands in an oversized bucket. A native ragged kernel gridding over actual tokens (`cu_seqlens`) is future work.

Per-layer device time, 16k→48k (T 16384→49152 = 3.0×; dense from xprof, attend/indexer measured directly in isolation):

| phase | @16k | @48k | scaling |
|---|---|---|---|
| dense MLA (`MLA-m`) | 224 ms | 2014 ms | **9.0× ⇒ O(T²)** |
| sparse attend | 86 ms | 245 ms | 2.84× (O(T·K)) |
| indexer select | 72 ms | 212 ms | 2.95× (O(T·S), S pinned ⇒ linear in T) |
| self-write (fused, in-place) | <1 ms | <3 ms | ~3× (O(T)) |

**Note — the dense-MLA row is a routing artifact, not a model requirement.** Those `MLA-m` layers are the first `index_skip_topk_offset` (=3) layers, which `config.indexer_types` actually marks as `"full"` (own-indexer **sparse**), plus their shared followers (3–5) that fall to dense only because the dense layers seed them no pages. Dropping the one-line `skip_offset` dense gate runs **all 78 layers sparse** and removes this O(T²) term outright (measured ~25% faster at 48k, GSM8K/needle correctness preserved) — so the dense MLA here is a removable leftover, not inherent to DSA prefill.

× 6 / 72 / 21 layers ⇒ 1.35 / 6.2 / 1.5 s @16k, 12.1 / 17.6 / 4.5 s @48k. **Fixed-S note:** because all points ran on one 49k server, the indexer's key span S is pinned at 49,152, so its O(T·S) reads as linear in T *here*; on a right-sized server (S ∝ T) the indexer becomes a **second O(T²)** term (matched-S: 24.5→212 ms 16k→48k = 8.66×), so this table is a **lower bound** on DSA's short-context speedup (the 16k indexer is ~3× over-provisioned). The **self-write is in-place** — the KV pool is donated (`jitted_run_model(donate_argnames=["memory_pools"])`), and on a 16k trace it is `scatter_custom_fusion` = 25 ms (0.82% of prefill), not a GB-scale copy. 64k single-shot prefill did not fit HBM on this hardware (documented ceiling).