### PR TITLE
perf: use in-place recurrent state cloning

### DIFF
--- a/benchmark/kernels/h0_clone/bench_h0_clone.py
+++ b/benchmark/kernels/h0_clone/bench_h0_clone.py
@@ -1,0 +1,102 @@
+"""Benchmark recurrent-state CoW clone against the former JAX scatter path.
+
+Run this on a TPU host. The roofline is a lower bound: each clone must read one
+slot and write one slot, so the minimum transfer is ``2 * state_bytes``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import jax
+import jax.numpy as jnp
+
+from sgl_jax.srt.kernels.h0_clone import clone_slots_inplace
+
+
+def slow_clone(buffer, src, dst):
+    payload_dims = (1,) * (buffer.ndim - 1)
+    values = jnp.where((src == 0).reshape((-1,) + payload_dims), buffer[dst], buffer[src])
+    return buffer.at[dst].set(values)
+
+
+def _time_us(fn, tries: int) -> float:
+    for _ in range(3):
+        jax.block_until_ready(fn())
+    elapsed = []
+    for _ in range(tries):
+        start = time.perf_counter()
+        jax.block_until_ready(fn())
+        elapsed.append((time.perf_counter() - start) * 1e6)
+    return min(elapsed)
+
+
+def _dtype_bytes(dtype) -> int:
+    return jnp.dtype(dtype).itemsize
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--layers", type=int, default=48)
+    parser.add_argument("--slots", type=int, default=128)
+    parser.add_argument("--clones", type=int, default=8)
+    parser.add_argument("--heads", type=int, default=32)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--conv-proj", type=int, default=8192)
+    parser.add_argument("--conv-history", type=int, default=3)
+    parser.add_argument("--peak-hbm-gbps", type=float, required=True)
+    parser.add_argument("--tries", type=int, default=20)
+    args = parser.parse_args()
+
+    if not (0 < args.clones and 2 * args.clones < args.slots):
+        raise ValueError("--clones must be positive and leave distinct source/destination slots")
+    if args.conv_history < 1:
+        raise ValueError("--conv-history must be positive")
+
+    temporal = jnp.zeros(
+        (args.slots, args.heads, args.head_dim, args.head_dim), dtype=jnp.float32
+    )
+    conv = jnp.zeros((args.slots, args.conv_proj, args.conv_history), dtype=jnp.bfloat16)
+    src = jnp.arange(1, args.clones + 1, dtype=jnp.int32)
+    dst = jnp.arange(args.clones + 1, 2 * args.clones + 1, dtype=jnp.int32)
+
+    fast_temporal = jax.jit(clone_slots_inplace)
+    fast_conv = jax.jit(clone_slots_inplace)
+    slow_temporal = jax.jit(slow_clone)
+    slow_conv = jax.jit(slow_clone)
+
+    def fast():
+        temporal_out = fast_temporal(temporal, src, dst)
+        return fast_conv(conv, src, dst), temporal_out
+
+    def slow():
+        temporal_out = slow_temporal(temporal, src, dst)
+        return slow_conv(conv, src, dst), temporal_out
+
+    fast_us = _time_us(fast, args.tries)
+    slow_us = _time_us(slow, args.tries)
+    slot_bytes = (
+        args.heads * args.head_dim * args.head_dim * _dtype_bytes(jnp.float32)
+        + args.conv_proj * args.conv_history * _dtype_bytes(jnp.bfloat16)
+    )
+    state_bytes = args.layers * args.clones * slot_bytes
+    roofline_us = 2 * state_bytes / (args.peak_hbm_gbps * 1e9) * 1e6
+    fast_total_us = fast_us * args.layers
+    slow_total_us = slow_us * args.layers
+    fast_gbps = (2 * args.clones * slot_bytes) / fast_us / 1e3
+
+    print(f"device={jax.devices()[0]}")
+    print(f"layers={args.layers} cloned_slots={args.clones} slot_bytes={slot_bytes:,}")
+    print(f"state_bytes={state_bytes:,} roofline_us={roofline_us:.2f}")
+    print(
+        f"per_layer: slow_us={slow_us:.2f} fast_us={fast_us:.2f} speedup={slow_us / fast_us:.2f}x"
+    )
+    print(f"estimated_all_layers: slow_us={slow_total_us:.2f} fast_us={fast_total_us:.2f}")
+    print(f"fast_effective_bandwidth_gbps={fast_gbps:.1f}")
+    if fast_us >= slow_us:
+        raise SystemExit("FAIL: Pallas clone did not beat the slow full-buffer scatter path")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/h0_clone/bench_h0_clone.py
+++ b/benchmark/kernels/h0_clone/bench_h0_clone.py
@@ -54,9 +54,7 @@ def main():
     if args.conv_history < 1:
         raise ValueError("--conv-history must be positive")
 
-    temporal = jnp.zeros(
-        (args.slots, args.heads, args.head_dim, args.head_dim), dtype=jnp.float32
-    )
+    temporal = jnp.zeros((args.slots, args.heads, args.head_dim, args.head_dim), dtype=jnp.float32)
     conv = jnp.zeros((args.slots, args.conv_proj, args.conv_history), dtype=jnp.bfloat16)
     src = jnp.arange(1, args.clones + 1, dtype=jnp.int32)
     dst = jnp.arange(args.clones + 1, 2 * args.clones + 1, dtype=jnp.int32)
@@ -76,10 +74,9 @@ def main():
 
     fast_us = _time_us(fast, args.tries)
     slow_us = _time_us(slow, args.tries)
-    slot_bytes = (
-        args.heads * args.head_dim * args.head_dim * _dtype_bytes(jnp.float32)
-        + args.conv_proj * args.conv_history * _dtype_bytes(jnp.bfloat16)
-    )
+    slot_bytes = args.heads * args.head_dim * args.head_dim * _dtype_bytes(
+        jnp.float32
+    ) + args.conv_proj * args.conv_history * _dtype_bytes(jnp.bfloat16)
     state_bytes = args.layers * args.clones * slot_bytes
     roofline_us = 2 * state_bytes / (args.peak_hbm_gbps * 1e9) * 1e6
     fast_total_us = fast_us * args.layers

--- a/python/sgl_jax/srt/kernels/h0_clone/__init__.py
+++ b/python/sgl_jax/srt/kernels/h0_clone/__init__.py
@@ -1,0 +1,5 @@
+"""In-place Pallas kernels for recurrent-state copy-on-write."""
+
+from sgl_jax.srt.kernels.h0_clone.kernel import clone_slots_inplace
+
+__all__ = ["clone_slots_inplace"]

--- a/python/sgl_jax/srt/kernels/h0_clone/kernel.py
+++ b/python/sgl_jax/srt/kernels/h0_clone/kernel.py
@@ -1,0 +1,115 @@
+"""In-place slot cloning for recurrent-state copy-on-write.
+
+The recurrent pool keeps temporal state and convolution state in separate HBM
+buffers.  Each invocation aliases its buffer input to its output and copies the
+selected source rows directly to their destination rows; it therefore avoids
+the full-buffer materialization produced by ``buf.at[dst].set(buf[src])``.
+"""
+
+from __future__ import annotations
+
+import functools
+import math
+import os
+
+import jax
+import jax.experimental.pallas as pl
+import jax.numpy as jnp
+
+
+def _interpret_enabled() -> bool:
+    return os.environ.get("PALLAS_INTERPRET", "").strip().lower() in ("1", "true")
+
+
+def _block_size(num_elements: int) -> int:
+    """Choose a lane-friendly block that tiles a slot without a tail mask."""
+    for candidate in range(min(num_elements, 128), 0, -1):
+        if num_elements % candidate == 0:
+            return candidate
+    raise AssertionError("every positive integer has a divisor in [1, num_elements]")
+
+
+def _clone_slots_kernel(src_ref, dst_ref, buffer_ref, out_ref, *, block_size: int):
+    """Copy one contiguous payload tile for one (src, dst) pair."""
+    pair = pl.program_id(0)
+    tile = pl.program_id(1)
+    src = src_ref[0]
+    dst = dst_ref[0]
+    offset = tile * block_size
+    payload_slice = pl.ds(offset, block_size)
+
+    # ``src == 0`` is the fixed-shape no-op sentinel. Reading the output in
+    # that case makes the aliasing contract explicit and preserves slot zero.
+    src_payload = buffer_ref[src, payload_slice]
+    dst_payload = out_ref[dst, payload_slice]
+    out_ref[dst, payload_slice] = jnp.where(src == 0, dst_payload, src_payload)
+
+
+def _slow_clone(buffer: jax.Array, src_indices: jax.Array, dst_indices: jax.Array) -> jax.Array:
+    """Portable reference used outside TPU Pallas lowering."""
+    payload_dims = (1,) * (buffer.ndim - 1)
+    values = jnp.where(
+        (src_indices == 0).reshape((-1,) + payload_dims),
+        buffer[dst_indices],
+        buffer[src_indices],
+    )
+    return buffer.at[dst_indices].set(values)
+
+
+def clone_slots_inplace(
+    buffer: jax.Array,
+    src_indices: jax.Array,
+    dst_indices: jax.Array,
+    *,
+    interpret: bool | None = None,
+) -> jax.Array:
+    """Clone local pool slots into an aliased output buffer.
+
+    ``buffer`` must have slot as its leading dimension. ``src_indices`` and
+    ``dst_indices`` are rank-one, per-DP-rank-local arrays with identical
+    shapes. A source index of zero leaves the corresponding destination slot
+    unchanged. Callers must provide pairwise distinct destination slots that
+    do not overlap any non-zero source slot in the same launch.
+    """
+    if buffer.ndim < 2:
+        raise ValueError(f"buffer must have a slot and payload dimension, got {buffer.shape}")
+    if src_indices.ndim != 1 or dst_indices.ndim != 1:
+        raise ValueError(
+            "src_indices and dst_indices must be rank-one, got "
+            f"{src_indices.shape} and {dst_indices.shape}"
+        )
+    if src_indices.shape != dst_indices.shape:
+        raise ValueError(
+            f"src_indices shape {src_indices.shape} != dst_indices shape {dst_indices.shape}"
+        )
+    if src_indices.dtype != jnp.int32 or dst_indices.dtype != jnp.int32:
+        raise ValueError("src_indices and dst_indices must use int32")
+    if src_indices.shape[0] == 0:
+        return buffer
+
+    slot_payload = math.prod(buffer.shape[1:])
+    block_size = _block_size(slot_payload)
+    buffer_2d = buffer.reshape((buffer.shape[0], slot_payload))
+    if interpret is None:
+        # CPU is test-only for this TPU-oriented kernel; Pallas interpret keeps
+        # the pool's unit tests runnable without a TPU backend.
+        interpret = _interpret_enabled() or jax.default_backend() == "cpu"
+    if not interpret and jax.default_backend() != "tpu":
+        return _slow_clone(buffer, src_indices, dst_indices)
+
+    kernel = functools.partial(_clone_slots_kernel, block_size=block_size)
+    cloned_2d = pl.pallas_call(
+        kernel,
+        grid=(src_indices.shape[0], slot_payload // block_size),
+        in_specs=[
+            pl.BlockSpec((1,), lambda pair, _tile: (pair,)),
+            pl.BlockSpec((1,), lambda pair, _tile: (pair,)),
+            pl.BlockSpec(memory_space=pl.ANY),
+        ],
+        out_specs=pl.BlockSpec(memory_space=pl.ANY),
+        out_shape=jax.ShapeDtypeStruct(buffer_2d.shape, buffer_2d.dtype),
+        input_output_aliases={2: 0},
+        interpret=interpret,
+        name="recurrent-h0-clone",
+    )(src_indices, dst_indices, buffer_2d)
+    return cloned_2d.reshape(buffer.shape)

--- a/python/sgl_jax/srt/kernels/h0_clone/kernel.py
+++ b/python/sgl_jax/srt/kernels/h0_clone/kernel.py
@@ -14,6 +14,7 @@ import os
 
 import jax
 import jax.experimental.pallas as pl
+import jax.experimental.pallas.tpu as pltpu
 import jax.numpy as jnp
 
 
@@ -29,20 +30,29 @@ def _block_size(num_elements: int) -> int:
     raise AssertionError("every positive integer has a divisor in [1, num_elements]")
 
 
-def _clone_slots_kernel(src_ref, dst_ref, buffer_ref, out_ref, *, block_size: int):
+def _clone_slots_kernel(
+    src_ref, dst_ref, buffer_ref, out_ref, scratch_ref, sem, *, block_size: int
+):
     """Copy one contiguous payload tile for one (src, dst) pair."""
     pair = pl.program_id(0)
     tile = pl.program_id(1)
-    src = src_ref[0]
-    dst = dst_ref[0]
+    src = src_ref[pair]
+    dst = dst_ref[pair]
     offset = tile * block_size
     payload_slice = pl.ds(offset, block_size)
 
-    # ``src == 0`` is the fixed-shape no-op sentinel. Reading the output in
-    # that case makes the aliasing contract explicit and preserves slot zero.
-    src_payload = buffer_ref[src, payload_slice]
-    dst_payload = out_ref[dst, payload_slice]
-    out_ref[dst, payload_slice] = jnp.where(src == 0, dst_payload, src_payload)
+    # Pool buffers live in HBM (pl.ANY), so Mosaic requires DMA rather than a
+    # direct load/store.  For the no-op sentinel, copy dst onto itself; this
+    # avoids a read from the output alias while preserving its contents.
+    source_slot = jnp.where(src == 0, dst, src)
+    gather = pltpu.make_async_copy(
+        buffer_ref.at[source_slot, payload_slice], scratch_ref, sem
+    )
+    gather.start()
+    gather.wait()
+    scatter = pltpu.make_async_copy(scratch_ref, out_ref.at[dst, payload_slice], sem)
+    scatter.start()
+    scatter.wait()
 
 
 def _slow_clone(buffer: jax.Array, src_indices: jax.Array, dst_indices: jax.Array) -> jax.Array:
@@ -98,15 +108,19 @@ def clone_slots_inplace(
         return _slow_clone(buffer, src_indices, dst_indices)
 
     kernel = functools.partial(_clone_slots_kernel, block_size=block_size)
+    grid_spec = pltpu.PrefetchScalarGridSpec(
+        num_scalar_prefetch=2,
+        in_specs=[pl.BlockSpec(memory_space=pl.ANY)],
+        out_specs=pl.BlockSpec(memory_space=pl.ANY),
+        grid=(src_indices.shape[0], slot_payload // block_size),
+        scratch_shapes=[
+            pltpu.VMEM((block_size,), buffer.dtype),
+            pltpu.SemaphoreType.DMA,
+        ],
+    )
     cloned_2d = pl.pallas_call(
         kernel,
-        grid=(src_indices.shape[0], slot_payload // block_size),
-        in_specs=[
-            pl.BlockSpec((1,), lambda pair, _tile: (pair,)),
-            pl.BlockSpec((1,), lambda pair, _tile: (pair,)),
-            pl.BlockSpec(memory_space=pl.ANY),
-        ],
-        out_specs=pl.BlockSpec(memory_space=pl.ANY),
+        grid_spec=grid_spec,
         out_shape=jax.ShapeDtypeStruct(buffer_2d.shape, buffer_2d.dtype),
         input_output_aliases={2: 0},
         interpret=interpret,

--- a/python/sgl_jax/srt/kernels/h0_clone/kernel.py
+++ b/python/sgl_jax/srt/kernels/h0_clone/kernel.py
@@ -45,9 +45,7 @@ def _clone_slots_kernel(
     # direct load/store.  For the no-op sentinel, copy dst onto itself; this
     # avoids a read from the output alias while preserving its contents.
     source_slot = jnp.where(src == 0, dst, src)
-    gather = pltpu.make_async_copy(
-        buffer_ref.at[source_slot, payload_slice], scratch_ref, sem
-    )
+    gather = pltpu.make_async_copy(buffer_ref.at[source_slot, payload_slice], scratch_ref, sem)
     gather.start()
     gather.wait()
     scatter = pltpu.make_async_copy(scratch_ref, out_ref.at[dst, payload_slice], sem)

--- a/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
+++ b/python/sgl_jax/srt/mem_cache/recurrent_state_pool.py
@@ -12,6 +12,8 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jax.tree_util import register_pytree_node_class
 
+from sgl_jax.srt.kernels.h0_clone import clone_slots_inplace
+
 # Module-level cache for jitted zero-allocators (recurrent/conv buffers).
 _RECURRENT_ZERO_ALLOCATOR_CACHE: dict = {}
 
@@ -233,20 +235,16 @@ class RecurrentStatePool:
         mesh = self.mesh
         data_axis = self.data_partition_axis
 
-        def _temporal(buf, src, dst):
-            # Donated-buffer aliasing barriers: without them the scatter races the
-            # gather under multi-host SPMD -> NaN. Value-preserving; do not remove.
+        def _clone(buf, src, dst):
+            # The outer forward donates the pool. Keep these barriers around the
+            # Pallas read/write alias boundary: without them a later recurrent
+            # gather can race this clone under multi-host SPMD.
             buf = jax.lax.optimization_barrier(buf)
-            val = jnp.where((src == 0).reshape(-1, 1, 1, 1), buf[dst], buf[src])
-            return jax.lax.optimization_barrier(buf.at[dst].set(val))
-
-        def _conv(buf, src, dst):
-            buf = jax.lax.optimization_barrier(buf)  # see _temporal
-            val = jnp.where((src == 0).reshape(-1, 1, 1), buf[dst], buf[src])
-            return jax.lax.optimization_barrier(buf.at[dst].set(val))
+            cloned = clone_slots_inplace(buf, src, dst)
+            return jax.lax.optimization_barrier(cloned)
 
         copy_temporal = jax.shard_map(
-            _temporal,
+            _clone,
             mesh=mesh,
             in_specs=(
                 P(data_axis, self.recurrent_partition_axis, None, None),
@@ -257,7 +255,7 @@ class RecurrentStatePool:
             check_vma=False,
         )
         copy_conv = jax.shard_map(
-            _conv,
+            _clone,
             mesh=mesh,
             in_specs=(
                 P(data_axis, self.conv_partition_axis, None),

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -62,11 +62,11 @@ def _maybe_apply_recurrent_cow(forward_batch, memory_pools):
         return memory_pools
     rsp = memory_pools.recurrent_state_pool
     new_recurrent, new_conv = rsp.copy_slots(src, forward_batch.recurrent_indices)
-    _, aux = rsp.tree_flatten()
-    new_rsp = type(rsp).tree_unflatten(aux, (new_recurrent, new_conv))
-    pools = dict(memory_pools._pools)
-    pools["recurrent_state_pool"] = new_rsp
-    return type(memory_pools)(**pools)
+    # Preserve the input MemoryPools pytree so the enclosing donated JIT can
+    # alias its buffers to the clone outputs instead of allocating a second
+    # pool container. The model subsequently reads these replacement leaves.
+    rsp.replace_buffer((new_recurrent, new_conv))
+    return memory_pools
 
 
 class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
@@ -394,6 +394,7 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
 
             model_state = jax.tree_util.tree_unflatten(model_state_def, model_state_leaves)
             model = nnx.merge(model_def, model_state)
+            memory_pools = _maybe_apply_recurrent_cow(forward_batch, memory_pools)
             with LoraBatchContext.set_batch(forward_batch):
                 output, pool_updates, aux, layers_topk_ids = model(
                     forward_batch, memory_pools, logits_metadata

--- a/python/sgl_jax/test/mem_cache/test_recurrent_h0_clone.py
+++ b/python/sgl_jax/test/mem_cache/test_recurrent_h0_clone.py
@@ -1,0 +1,53 @@
+"""Correctness and donation coverage for the recurrent Pallas CoW clone."""
+
+from __future__ import annotations
+
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.kernels.h0_clone import clone_slots_inplace
+
+
+def _slow_clone(buffer, src, dst):
+    """S5a reference: immutable gather/scatter over the whole buffer."""
+    payload_dims = (1,) * (buffer.ndim - 1)
+    value = jnp.where((src == 0).reshape((-1,) + payload_dims), buffer[dst], buffer[src])
+    return buffer.at[dst].set(value)
+
+
+class TestRecurrentH0Clone:
+    def test_temporal_and_conv_match_slow_path(self):
+        temporal = jnp.arange(6 * 2 * 4 * 4, dtype=jnp.float32).reshape(6, 2, 4, 4)
+        conv = jnp.arange(6 * 12 * 3, dtype=jnp.bfloat16).reshape(6, 12, 3)
+        src = jnp.array([1, 0, 4], dtype=jnp.int32)
+        dst = jnp.array([2, 3, 5], dtype=jnp.int32)
+
+        actual_temporal = jax.jit(clone_slots_inplace)(temporal, src, dst)
+        actual_conv = jax.jit(clone_slots_inplace)(conv, src, dst)
+
+        np.testing.assert_array_equal(actual_temporal, _slow_clone(temporal, src, dst))
+        np.testing.assert_array_equal(actual_conv, _slow_clone(conv, src, dst))
+
+    def test_donated_buffer_can_feed_the_next_clone(self):
+        @partial(jax.jit, donate_argnums=(0,))
+        def clone_and_consume(buffer, src, dst):
+            cloned = clone_slots_inplace(buffer, src, dst)
+            return cloned, jnp.sum(cloned[dst])
+
+        src = jnp.array([1], dtype=jnp.int32)
+        dst = jnp.array([2], dtype=jnp.int32)
+        first_input = jnp.arange(4 * 2 * 8, dtype=jnp.float32).reshape(4, 2, 8)
+        expected_first = _slow_clone(first_input, src, dst)
+        first, first_sum = clone_and_consume(first_input, src, dst)
+        np.testing.assert_array_equal(first, expected_first)
+
+        second_src = jnp.array([2], dtype=jnp.int32)
+        second_dst = jnp.array([3], dtype=jnp.int32)
+        second, second_sum = clone_and_consume(first, second_src, second_dst)
+        expected_second = _slow_clone(expected_first, second_src, second_dst)
+        np.testing.assert_array_equal(second, expected_second)
+        assert float(first_sum) > 0.0
+        assert float(second_sum) > 0.0

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -354,6 +354,7 @@ suites = {
         TestFile("python/sgl_jax/test/mem_cache/test_unified_radix_cache.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_unified_radix_tree_flag.py", 1),
         TestFile("python/sgl_jax/test/mem_cache/test_paged_allocator_multi_dp.py", 1),
+        TestFile("python/sgl_jax/test/mem_cache/test_recurrent_h0_clone.py", 0.5, runner="pytest"),
         TestFile("python/sgl_jax/test/mem_cache/test_host_kv_pool.py", 1, runner="pytest"),
         TestFile("python/sgl_jax/test/mem_cache/test_hicache_controller.py", 0.5, runner="pytest"),
         TestFile("python/sgl_jax/test/mem_cache/test_hicache_e2e.py", 5, runner="pytest"),


### PR DESCRIPTION
## Summary
- add a Pallas recurrent-state slot clone kernel with input/output aliasing
- use it for recurrent copy-on-write while preserving donated pool buffers
- add correctness/donation coverage and a TPU microbenchmark