### PR TITLE
fix(profiler): honour explicit host_tracer_level=0 / python_tracer_level=0

### DIFF
--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -683,8 +683,8 @@ class ProfileReqInput:
     num_steps: int | None = None
     # Sets the trace level for host-side activities.
     # 0: Disables host (CPU) tracing entirely.
-    # 1: Enables tracing of only user-instrumented TraceMe events (this is the default).
-    # 2: Includes level 1 traces plus high-level program execution details like expensive XLA operations.
+    # 1: Enables tracing of only user-instrumented TraceMe events.
+    # 2: Includes level 1 traces plus high-level program execution details like expensive XLA operations (this is the default).
     # 3: Includes level 2 traces plus more verbose, low-level program execution details such as cheap XLA operations.
     host_tracer_level: int | None = None
     # Controls whether Python tracing is enabled.

--- a/python/sgl_jax/srt/managers/scheduler_profiler_mixing.py
+++ b/python/sgl_jax/srt/managers/scheduler_profiler_mixing.py
@@ -131,9 +131,9 @@ class _ProfileManager:
         logger.info("Stage-based profiling: starting trace for '%s' -> %s", stage, stage_dir)
 
         profiler_options = jax.profiler.ProfileOptions()
-        if self._host_tracer_level:
+        if self._host_tracer_level is not None:
             profiler_options.host_tracer_level = self._host_tracer_level
-        if self._python_tracer_level:
+        if self._python_tracer_level is not None:
             profiler_options.python_tracer_level = self._python_tracer_level
 
         jax.profiler.start_trace(stage_dir, profiler_options=profiler_options)
@@ -213,9 +213,9 @@ class SchedulerProfilerMixin:
         )
 
         profiler_options = jax.profiler.ProfileOptions()
-        if host_tracer_level:
+        if host_tracer_level is not None:
             profiler_options.host_tracer_level = host_tracer_level
-        if python_tracer_level:
+        if python_tracer_level is not None:
             profiler_options.python_tracer_level = python_tracer_level
 
         print(f"profiler_options: {profiler_options}")

--- a/python/sgl_jax/test/test_profiler_tracer_levels.py
+++ b/python/sgl_jax/test/test_profiler_tracer_levels.py
@@ -1,0 +1,47 @@
+import tempfile
+import unittest
+from unittest import mock
+
+import jax
+
+from sgl_jax.srt.managers.scheduler_profiler_mixing import _ProfileManager
+
+
+class TestProfilerTracerLevels(unittest.TestCase):
+    """An explicit tracer level of 0 must reach jax.profiler.ProfileOptions.
+
+    0 disables the corresponding tracer; None means "unset, keep JAX's default".
+    """
+
+    def _captured_options(self, **levels):
+        manager = _ProfileManager()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager.configure(
+                output_dir=tmpdir,
+                num_steps=1,
+                interesting_stages=["decode"],
+                **levels,
+            )
+            with mock.patch.object(jax.profiler, "start_trace") as start_trace:
+                manager._do_start(stage="decode")
+        return start_trace.call_args.kwargs["profiler_options"]
+
+    def test_explicit_zero_disables_tracers(self):
+        options = self._captured_options(host_tracer_level=0, python_tracer_level=0)
+        self.assertEqual(options.host_tracer_level, 0)
+        self.assertEqual(options.python_tracer_level, 0)
+
+    def test_none_keeps_jax_defaults(self):
+        options = self._captured_options()
+        defaults = jax.profiler.ProfileOptions()
+        self.assertEqual(options.host_tracer_level, defaults.host_tracer_level)
+        self.assertEqual(options.python_tracer_level, defaults.python_tracer_level)
+
+    def test_explicit_nonzero_is_applied(self):
+        options = self._captured_options(host_tracer_level=3, python_tracer_level=1)
+        self.assertEqual(options.host_tracer_level, 3)
+        self.assertEqual(options.python_tracer_level, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Resolves #1510.

`/start_profile` silently ignores `host_tracer_level=0` and `python_tracer_level=0`. Both sites that build `jax.profiler.ProfileOptions` gate on truthiness, so an explicit `0` is dropped and JAX's defaults apply instead (`host_tracer_level=2`, `python_tracer_level=1` on jax 0.10.2).

`None` is already the "unset" sentinel (`ProfileReqInput.host_tracer_level: int | None = None`), and `0` is documented as meaningful both in that dataclass (`# 0: Disables Python function call tracing.`) and in `.claude/skills/profiling-capture/references/capture-recipes.md` ("0 off"). So the documented way to turn the Python tracer off does not work, and there is no other way to do it through this API.

This is not cosmetic. The Python tracer's per-step overhead is a large fraction of a short decode step, so decode reads several times too slow while prefill amortises it and looks fine — one capture can be right about prefill and badly wrong about decode. The extra volume also pushes the XSpace past protobuf's 2 GB ceiling, where `WriteBinaryProto` (`xla/tsl/platform/env.cc:631`) discards the `bool` from `AppendToString` and emits a **0-byte `.xplane.pb` while reporting success**.

## Modifications

- `scheduler_profiler_mixing.py`: `if <level>:` → `if <level> is not None:` in `_ProfileManager._do_start` and `SchedulerProfilerMixin.start_profile` (4 lines).
- New `python/sgl_jax/test/test_profiler_tracer_levels.py`: CPU-only, no TPU, `jax.profiler.start_trace` mocked. Covers explicit `0` (disabled), explicit non-zero (applied), and `None` (JAX defaults preserved).
- `io_struct.py`: the `ProfileReqInput` comment marked level 1 as the `host_tracer_level` default; JAX's default is 2. Split into its own commit so it can be dropped if you'd rather keep this PR to the fix.

`start_step` uses the same truthy pattern but is **deliberately left alone**: `start_step=0` currently falls into the immediate-start branch, and "start at step 0" is "start now". Switching it to `is not None` would defer the start by one forward pass — a behaviour change with no benefit.

## Accuracy Tests

Not applicable — no change to kernels or model forward code. The only behaviour change is that a tracer level of `0`, which previously did nothing, now reaches `ProfileOptions`.

## Benchmarking and Profiling

Measured on a TPU v7x 2x2x2 slice, 32k prefill + 64 decode steps:

| | Python tracer on (before) | `python_tracer_level: 0` honoured (after) |
|---|---|---|
| decode TPOT | 130.07 ms | **43.19 ms** |
| prefill | 22.29 s | 22.18 s |
| trace size | 2.21 GB → 0-byte `.xplane.pb` | 1.863 GB, writes correctly on both ranks |

## Test plan

```bash
uv venv --python 3.12 && uv pip install -e "python[cpu]"
python -m unittest python.sgl_jax.test.test_profiler_tracer_levels -v
```

On `main` the new test fails with `AssertionError: 2 != 0` (requested `host_tracer_level=0`, got JAX's default). With this PR, 3/3 pass. `pre-commit run --from-ref main --to-ref HEAD` is clean.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
