### PR TITLE
fix(linear): reshard block-quant scale for jax 0.10 explicit-mesh shard_map

### DIFF
--- a/python/sgl_jax/srt/layers/linear.py
+++ b/python/sgl_jax/srt/layers/linear.py
@@ -481,6 +481,14 @@ class QuantizedLinear(nnx.Module):
         else:
             # Per-channel scale: [n_out]
             w_scale_spec = P(output_axis)
+        # jax[tpu] 0.10 runs the mesh in Explicit-axis mode ("sharding in types"):
+        # shard_map requires each input's committed sharding to match in_specs
+        # exactly, and with_sharding_constraint is only an assert. FP8 block-quant
+        # scales can arrive REPLICATED from the weight loader (the kernel-ready 3D
+        # expansion drops the sharding), which trips col-parallel projections such
+        # as q_b_proj. Explicitly reshard the scale to its expected spec — a no-op
+        # when it is already correctly sharded.
+        scale_val = jax.sharding.reshard(scale_val, NamedSharding(self.mesh, w_scale_spec))
         in_specs = (P("data", input_axis), P(output_axis, input_axis), w_scale_spec)
 
         target = out_sharding or NamedSharding(self.mesh, P("data", output_axis))


### PR DESCRIPTION
## Motivation

`jax[tpu]` 0.10 runs the device mesh in **Explicit-axis mode** ("sharding in types"). Under it, `shard_map` requires each input's *committed* sharding to match `in_specs` exactly, and `with_sharding_constraint` is only an assertion — it no longer resharded. FP8 **block-quant** weight scales can arrive **replicated** from the weight loader (the kernel-ready 3D expansion drops the sharding), so a column-parallel projection such as `q_b_proj` reaches `shard_map` with a scale whose committed sharding doesn't match `w_scale_spec`, and 0.10 raises instead of resharding. This blocks loading/serving FP8 block-quant models (e.g. GLM-5.2-FP8) on `jax[tpu]` 0.10.

## Modifications

- `srt/layers/linear.py`: explicitly `jax.sharding.reshard(...)` the block-quant scale to its expected `w_scale_spec` before assembling the `shard_map` `in_specs`. It's a no-op when the scale is already correctly sharded, so only the FP8 block-quant path is affected; the non-quantized and already-sharded paths are unchanged.

## Testing

Serving **GLM-5.2-FP8** (block-quant FP8) on TPU v7x under `jax[tpu]` 0.10: without this change, `q_b_proj` trips the explicit-sharding mismatch at load / first forward; with it, the model loads and serves correctly. No effect when scales already arrive with the expected sharding.