### PR TITLE
feat(dsa): packed-ragged sparse-MLA prefill — batching + radix + chunked prefill

### DIFF
--- a/docs/features/attention_backend.md
+++ b/docs/features/attention_backend.md
@@ -4,13 +4,14 @@ SGL-JAX exposes a small user-facing attention backend switch, while the runtime 
 
 ## User-facing choices
 
-`--attention-backend` accepts three values:
+`--attention-backend` accepts four values:
 
 | Value | Runtime behavior |
 |---|---|
 | `fa` | Default. Uses FlashAttention for MHA/GQA models and the absorbed MLA Pallas backend for MLA models. |
 | `fa_mha` | Forces MLA models through the decompressed MHA FlashAttention path. This is useful for kernel A/B checks, but uses much more KV cache than absorbed MLA. |
 | `native` | Pure JAX/native attention path, mainly for CPU/debugging. If `fa` or `fa_mha` is requested on CPU, the runtime falls back to `native`. |
+| `dsa_sparse` | DeepSeek Sparse Attention (DSA): a lightning-indexer selects the top-scoring pages of past tokens per query and attention runs only over that page set (page-block sparse guided by DSA scores), with IndexShare cross-layer reuse of the selection. For MLA models whose config carries the `index_*` fields only. See [DeepSeek Sparse Attention](#deepseek-sparse-attention-dsa_sparse). |
 
 Example:
 
@@ -28,11 +29,82 @@ python3 -u -m sgl_jax.launch_server \
 |---|---|---|
 | `FlashAttention` | `--attention-backend=fa` for MHA/GQA, or `fa_mha` for MLA fallback | TPU production attention with paged KV cache, SWA metadata, and Pallas kernels. |
 | `MLAAttentionBackend` | `--attention-backend=fa` when `model_config.attention_arch == MLA` | Absorbed MLA path for DeepSeek-family models. |
+| `DSASparseAttentionBackend` | `--attention-backend=dsa_sparse` for MLA models with `index_*` config | DeepSeek Sparse Attention: lightning-indexer top-k + sparse MLA over the selected pages (page-block), with IndexShare. |
 | `NativeAttention` | `--attention-backend=native`, or CPU fallback | Debugging and CPU execution. |
 | `HybridLinearAttnBackend` | Automatic wrapper for hybrid recurrent models | Routes full-attention layers to `FlashAttention`/`MLAAttentionBackend` and linear recurrent layers to KDA/GDN/Lightning backends. |
 | `KDAAttnBackend` | Automatic under `HybridLinearAttnBackend` for Kimi Linear | Kimi Delta Attention recurrent branch. |
 | `GDNAttnBackend` | Automatic under `HybridLinearAttnBackend` for Qwen3.5 hybrid configs | Gated DeltaNet recurrent branch. |
 | `LightningAttnBackend` | Automatic under `HybridLinearAttnBackend` for Bailing MoE V2.5 / Ling-2.6-flash | Lightning / Simple GLA recurrent branch. |
+
+## DeepSeek Sparse Attention (`dsa_sparse`)
+
+DSA cuts the cost of long-context attention by attending to a **selected subset** of past
+tokens instead of the full causal history. A small "lightning indexer" scores past tokens
+for each query and the highest-scoring ones (budget `index_topk`) are chosen. The selection
+is computed on the indexer layers and **reused across the following layers (IndexShare)**,
+so the indexer cost is amortized.
+
+Selection here is at **page granularity** (`page_size` tokens per unit), not exact per-token:
+the indexer's per-token scores are max-pooled to a score per page and the top
+`ceil(index_topk / page_size)` pages are attended in full. This is therefore **page-block
+sparse attention guided by the DSA indexer scores** — a superset of the exact token top-`k`
+set (attending whole pages shifts the softmax denominator), not a bit-exact token-level DSA.
+In practice it tracks dense closely on long-context retrieval (see the PR's NIAH/GSM8K
+results); treat page size and `index_topk` as the accuracy/speed knobs.
+
+Only MLA models whose config carries the DSA `index_*` fields (indexer head dim / heads /
+top-k) are eligible; other models ignore the flag.
+
+### Enabling it
+
+```bash
+python3 -u -m sgl_jax.launch_server \
+  --model-path <deepseek-sparse-MLA-checkpoint> \
+  --device=tpu \
+  --attention-backend=dsa_sparse \
+  --dsa-use-pallas          # use the Pallas kernels (default: the jnp reference)
+```
+
+Two environment variables tune the sparse path:
+
+| Env var | Meaning |
+|---|---|
+| `DSA_INDEX_TOPK` | Override the config's `index_topk` (selection budget, in tokens) at backend construction. Larger = closer to dense, slower. The kernel is compiled for this value, so **changing it requires a relaunch**. |
+| `DSA_PREFILL_SPARSE=1` | Opt in to running **prefill** through the fused sparse-MLA prefill kernel (below). Default off ⇒ prefill runs dense and only decode is sparse. |
+
+### Sparse prefill and its current scope
+
+With `DSA_PREFILL_SPARSE=1`, the prefill (EXTEND) step also attends only to the indexer's
+selected pages via a fused self-write + sparse-MLA Pallas kernel, which is where the
+long-context prefill speedup comes from.
+
+This initial version supports a **single-sequence, single-shot** prefill only. It does
+**not** yet support radix/prefix caching, request batching, or chunked prefill (a cache
+hit / multi-seq / split prompt turns prefill into a partial extend the sparse page table
+cannot represent). The runtime **fails fast with an actionable message** when
+`DSA_PREFILL_SPARSE=1` is combined with an incompatible config, so it must be launched
+with:
+
+```bash
+DSA_PREFILL_SPARSE=1 DSA_INDEX_TOPK=4096 python3 -u -m sgl_jax.launch_server \
+  --model-path <checkpoint> --device=tpu \
+  --attention-backend=dsa_sparse --dsa-use-pallas \
+  --disable-radix-cache \           # radix/prefix cache OFF
+  --max-running-requests 1 \        # single sequence
+  --context-length 49152 \
+  --chunked-prefill-size 49152      # >= context => single-shot (no chunking)
+```
+
+Radix-cache, batching, and chunked-prefill support are follow-ups. The guard is gated on
+`DSA_PREFILL_SPARSE`, so the default (dense-prefill) `dsa_sparse` path, other backends, and
+CI are unaffected.
+
+### Validation
+
+Kernel correctness is covered in CI by
+`test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py`, which checks the sparse-MLA
+prefill kernel against a masked-softmax reference on CPU (`interpret=True`, no TPU needed),
+in both flat and paged-cache modes.
 
 ## Notes for contributors
 

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py
@@ -319,6 +319,16 @@ def sparse_mla_attention(
         # packed page table: one flat physical-page list; each request's window
         # starts at cu_kv_lens[rid]//ps (the per-query ``base``). Per-query causal
         # bound is seq_lens[rid]. Both are resolved per token below.
+        #
+        # SMEM footprint: the whole flat table (PTW = sum of pages_per_seq over the
+        # packed batch) lives resident in SMEM via ``pt_spec`` at 4*PTW bytes. The
+        # block index map is constant in ``s`` (and ragged is B=1), so it is copied
+        # in once, not re-DMA'd per grid step. PTW is bounded by what fits in HBM:
+        # each page costs page_size*Dk_pad*2 HBM bytes vs 4 SMEM bytes (~1e4x), so
+        # any batch whose KV fits in HBM keeps this block in the low-KB range (~8KB
+        # at ctx 8k / page 128 / max_running 32). Reaching ~1MB here (~270k pages,
+        # e.g. 128k ctx / page 64 / max_running 128) implies ~20GB of resident KV,
+        # i.e. an HBM OOM would hit first.
         PTW = page_indices.shape[0]
         pt_arg = page_indices.reshape(1, 1, 1, PTW).astype(jnp.int32)
         qsid = jnp.clip(q_seq_id, 0, seq_lens.shape[0] - 1).astype(jnp.int32)

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py
@@ -50,8 +50,10 @@ def _sparse_mla_kernel_chunked_hminor(
     q_ref,  # [1, 1, Hp, Dk]  Hp padded to the bf16 sublane tile (16), NOT to 128
     idx_ref,  # [1, 1, 1, K]    SMEM
     pos_ref,  # [1, 1, 1, 1]    SMEM
+    kvlen_ref,  # [1, 1, 1, 1]  SMEM  per-query causal bound (seq_lens[rid]; == T single-seq)
+    base_ref,  # [1, 1, 1, 1]   SMEM  per-query page-table base (cu_kv_lens[rid]//ps; 0 single-seq)
     kv_hbm,  # flat: [B, T(+RBF), Dk] HBM;  paged: [1, num_pages*page_size, Dk] HBM
-    pt_ref,  # [1, 1, 1, max_pages] SMEM  page table for this request (paged only; dummy if flat)
+    pt_ref,  # [1, 1, 1, PTW] SMEM  page table (per-request slice at base + logical page)
     o_ref,  # [1, 1, Hp, Dv]
     kv_scratch,  # [CBR, Dk] VMEM  one chunk of gathered latent
     sem,  # DMA semaphores (G,)
@@ -60,12 +62,12 @@ def _sparse_mla_kernel_chunked_hminor(
     Dv: int,
     RB: int,
     RBF: int,
-    T: int,
     K: int,
     G: int,
     CBR: int,  # G*RBF rounded up to the 128-lane tile (score's key axis is the lane axis)
     paged: bool = False,  # read from the packed 4D paged latent cache via pt_ref
     page_size: int = 0,  # tokens per page (paged only; static)
+    PTW: int = 1,  # page-table width (max_pages single-seq / total packed pages ragged)
 ):
     """Head-minor relayout of the chunked kernel for **few heads/device** (head-TP).
 
@@ -86,6 +88,8 @@ def _sparse_mla_kernel_chunked_hminor(
     Hp = q_ref.shape[2]
     q = q_ref[0, 0]  # [Hp, Dk] bf16
     qpos = pos_ref[0, 0, 0, 0]
+    kv_len = kvlen_ref[0, 0, 0, 0]  # per-query causal bound (== T in single-seq)
+    base = base_ref[0, 0, 0, 0]  # per-query page-table base (== 0 in single-seq)
     NC = (K + G - 1) // G
 
     lane = jnp.arange(CBR, dtype=jnp.int32)  # [CBR] iota on the key (lane) axis
@@ -103,10 +107,16 @@ def _sparse_mla_kernel_chunked_hminor(
             # but pp (from the page table) is opaque to Mosaic. Express the offset as
             # an explicit `r8 * 8` (page_size and o0 are both %8) so divisibility is
             # provable — the same idiom the dense paged kernel uses.
-            lt = u * RB  # logical token start
+            #
+            # ``u`` is a SEQ-LOCAL logical page id; the request's pages start at
+            # ``base`` in the packed page table (base==0 for the single-seq per-b
+            # table). Clamp base+lp to the table width so a padded/-1 lane can't
+            # gather out of range (the lane is masked out below anyway).
+            lt = u * RB  # logical token start (within the request)
             lp = lt // page_size  # logical page (static divisor)
             o0 = lt - lp * page_size  # in-page offset (multiple of RB)
-            pp = pt_ref[0, 0, 0, lp]  # physical page id
+            pidx = jnp.minimum(base + lp, PTW - 1)
+            pp = pt_ref[0, 0, 0, pidx]  # physical page id
             r8 = pp * (page_size // 8) + o0 // 8  # (P*page_size + o0) // 8, exact
             return kv_hbm.at[0, pl.ds(r8 * 8, RBF), :]
         return kv_hbm.at[b, pl.ds(u * RB, RBF), :]
@@ -149,10 +159,12 @@ def _sparse_mla_kernel_chunked_hminor(
             u_vec = jnp.where(sel, u_g, u_vec)
             row_vec = jnp.where(sel, lane - lo, row_vec)
             ir_vec = jnp.where(sel, inr, ir_vec)
-        kp = u_vec * RB + row_vec  # [CBR] key positions
+        kp = u_vec * RB + row_vec  # [CBR] seq-local key positions
         # (u_vec >= 0) drops topk padding lanes (unit id -1); their DMA was
         # clamped to unit 0, so the read is safe and only the mask excludes them.
-        valid = (u_vec >= 0) & (row_vec < RB) & (ir_vec > 0) & (kp <= qpos) & (kp < T)
+        # ``kv_len`` is the per-request bound (seq_lens[rid]); in the single-seq
+        # path it equals the static T, so this is a strict generalisation.
+        valid = (u_vec >= 0) & (row_vec < RB) & (ir_vec > 0) & (kp <= qpos) & (kp < kv_len)
         bias = jnp.where(valid, 0.0, -jnp.inf)  # [CBR] fp32
 
         for g in range(G):
@@ -208,7 +220,17 @@ def sparse_mla_attention(
     page_table=None,  # [B, max_pages] int32: logical page -> physical page. When set,
     # ``kv`` is the packed 4D paged cache and the kernel gathers from it.
     page_size: int | None = None,  # tokens/page (required with page_table)
-    seq_len: int | None = None,  # logical T for the causal mask (required with page_table)
+    seq_len: int | None = None,  # logical T for the causal mask (required, non-ragged paged)
+    # ── packed-ragged mode (multi-request extend) ────────────────────────────
+    # When ``q_seq_id`` is set, ``q`` is packed as [1, total_tokens, H, Dk] and the
+    # per-query causal bound / page-table base are resolved per token from the same
+    # ragged metadata the dense path uses. ``page_indices`` (flat packed physical
+    # pages) replaces the per-request ``page_table``; ``indices`` are seq-local page
+    # ids relative to each request's window (page_indices[cu_kv_lens[rid]//ps + p]).
+    q_seq_id=None,  # [total_tokens] int32  token -> request id (enables ragged mode)
+    seq_lens=None,  # [num_seqs] int32       per-request kv length (causal bound)
+    cu_kv_lens=None,  # [num_seqs+1] int32    page-aligned kv offsets (page_indices stride)
+    page_indices=None,  # [total_pages] int32  packed physical page ids
 ):
     """Sparse MLA-latent attention (head-minor chunked kernel).
     Returns ``[B, S, H, kv_lora_rank]`` (float32).
@@ -236,7 +258,12 @@ def sparse_mla_attention(
     K = indices.shape[2]
     Dv = kv_lora_rank
     RB = read_block
-    paged = page_table is not None
+    ragged = q_seq_id is not None
+    paged = (page_table is not None) or ragged
+    if ragged and B != 1:
+        raise ValueError(f"ragged mode packs all requests into B=1 (got B={B})")
+    if ragged and (seq_lens is None or cu_kv_lens is None or page_indices is None):
+        raise ValueError("ragged mode requires seq_lens, cu_kv_lens and page_indices")
     if not block_units or block_units < 1:
         raise ValueError("sparse_mla_attention requires block_units >= 1")
     if sm_scale is None:
@@ -261,11 +288,15 @@ def sparse_mla_attention(
     if paged:
         if RB % 16 != 0:
             raise ValueError("paged KV requires read_block % 16 == 0 (no cross-page over-fetch)")
-        if page_size is None or seq_len is None:
-            raise ValueError("paged KV requires page_size and seq_len")
+        if page_size is None:
+            raise ValueError("paged KV requires page_size")
+        if not ragged and seq_len is None:
+            raise ValueError("non-ragged paged KV requires seq_len")
         if kv.shape[-1] != Dk_pad:
             raise ValueError(f"paged cache last dim {kv.shape[-1]} != Dk_pad {Dk_pad}")
-        T = seq_len
+        # T is the causal bound only in the non-ragged path (a single static scalar);
+        # ragged resolves the bound per token from seq_lens[q_seq_id] instead.
+        T = seq_len if not ragged else S
         # flatten [num_pages, ps//packing, packing, Dk_pad] -> [1, num_pages*page_size, Dk_pad]
         num_pages = kv.shape[0]
         kv = kv.reshape(1, num_pages * page_size, Dk_pad)
@@ -283,19 +314,30 @@ def sparse_mla_attention(
     # heads on the sublane axis (padded to the bf16 sublane tile of 16, not 128).
     G = max(1, min(block_units, K))
     RBF = ((RB + 15) // 16) * 16
-    if paged:
-        ps = page_size  # RBF == RB (RB%16==0) => no over-fetch
-        max_pages = (T + ps - 1) // ps
+    ps = page_size or 0
+    if ragged:
+        # packed page table: one flat physical-page list; each request's window
+        # starts at cu_kv_lens[rid]//ps (the per-query ``base``). Per-query causal
+        # bound is seq_lens[rid]. Both are resolved per token below.
+        PTW = page_indices.shape[0]
+        pt_arg = page_indices.reshape(1, 1, 1, PTW).astype(jnp.int32)
+        qsid = jnp.clip(q_seq_id, 0, seq_lens.shape[0] - 1).astype(jnp.int32)
+        kvlen_arg = seq_lens[qsid].reshape(B, S, 1, 1).astype(jnp.int32)
+        base_arg = (cu_kv_lens[qsid] // ps).reshape(B, S, 1, 1).astype(jnp.int32)
+    elif paged:
+        PTW = (T + ps - 1) // ps  # max_pages
         # page table is per-REQUEST (same for all query tokens s) => index by b only.
-        pt_arg = page_table.reshape(B, 1, 1, max_pages).astype(jnp.int32)
-        pt_spec = pl.BlockSpec(
-            (1, 1, 1, max_pages), lambda b, s: (b, 0, 0, 0), memory_space=pltpu.SMEM
-        )
+        pt_arg = page_table.reshape(B, 1, 1, PTW).astype(jnp.int32)
+        kvlen_arg = jnp.full((B, S, 1, 1), T, jnp.int32)  # static causal bound
+        base_arg = jnp.zeros((B, S, 1, 1), jnp.int32)  # per-b table => base 0
     else:
         kv = jnp.pad(kv, ((0, 0), (0, RBF), (0, 0)))
         # dummy 1-wide page table so the kernel signature is uniform (unused when flat).
+        PTW = 1
         pt_arg = jnp.zeros((B, 1, 1, 1), jnp.int32)
-        pt_spec = pl.BlockSpec((1, 1, 1, 1), lambda b, s: (b, 0, 0, 0), memory_space=pltpu.SMEM)
+        kvlen_arg = jnp.full((B, S, 1, 1), T, jnp.int32)
+        base_arg = jnp.zeros((B, S, 1, 1), jnp.int32)
+    pt_spec = pl.BlockSpec((1, 1, 1, PTW), lambda b, s: (b, 0, 0, 0), memory_space=pltpu.SMEM)
     CBR = ((G * RBF + 127) // 128) * 128  # key (lane) axis: %128
     Hq = ((H + 15) // 16) * 16  # heads on sublane: %16 (bf16 tile)
     if Hq != H:
@@ -306,31 +348,29 @@ def sparse_mla_attention(
         Dv=Dv,
         RB=RB,
         RBF=RBF,
-        T=T,
         K=K,
         G=G,
         CBR=CBR,
         paged=paged,
-        page_size=(page_size or 0),
+        page_size=ps,
+        PTW=PTW,
     )
     scratch_shapes = [
         pltpu.VMEM((CBR, Dk_pad), kv.dtype),  # one chunk of gathered latent
         pltpu.SemaphoreType.DMA((G,)),  # one semaphore per unit
     ]
 
+    smem = pltpu.SMEM
     in_specs = [
         pl.BlockSpec((1, 1, Hq, Dk_pad), lambda b, s: (b, s, 0, 0)),  # q (VMEM)
-        pl.BlockSpec(
-            (1, 1, 1, K), lambda b, s: (b, s, 0, 0), memory_space=pltpu.SMEM
-        ),  # indices (SMEM)
-        pl.BlockSpec(
-            (1, 1, 1, 1), lambda b, s: (b, s, 0, 0), memory_space=pltpu.SMEM
-        ),  # positions (SMEM)
-        pl.BlockSpec(memory_space=pltpu.HBM),  # kv (untiled HBM,
-        #                                                              full — DMA-gathered)
+        pl.BlockSpec((1, 1, 1, K), lambda b, s: (b, s, 0, 0), memory_space=smem),  # indices
+        pl.BlockSpec((1, 1, 1, 1), lambda b, s: (b, s, 0, 0), memory_space=smem),  # positions
+        pl.BlockSpec((1, 1, 1, 1), lambda b, s: (b, s, 0, 0), memory_space=smem),  # kv_len bound
+        pl.BlockSpec((1, 1, 1, 1), lambda b, s: (b, s, 0, 0), memory_space=smem),  # page base
+        pl.BlockSpec(memory_space=pltpu.HBM),  # kv (untiled HBM, full — DMA-gathered)
         pt_spec,  # page table (SMEM)
     ]
-    call_args = [q, indices4, positions4, kv, pt_arg]
+    call_args = [q, indices4, positions4, kvlen_arg, base_arg, kv, pt_arg]
 
     out = pl.pallas_call(
         kernel,
@@ -417,6 +457,87 @@ def prefill_write_and_attend(
         page_table=pt.reshape(1, -1),
         page_size=ps,
         seq_len=T,
+        interpret=interpret,
+    )
+    return out.reshape(T, H, Dv), cache_new
+
+
+def prefill_write_and_attend_ragged(
+    ql,  # [total_tokens, H, kv_lora_rank]   absorbed latent query (nope)
+    qpe,  # [total_tokens, H, rope]           rope query
+    kvc,  # [total_tokens, kv_lora_rank]      new c_kv to write
+    kpe,  # [total_tokens, rope]              new k_rope to write
+    cache,  # [P, ps//pk, pk, Dk_pad]         paged fused latent cache
+    topk_pages,  # [total_tokens, K] int32    seq-local page ids (-1 padded)
+    positions,  # [total_tokens] int32        absolute query positions (causal bound)
+    loc,  # [total_tokens] int32              physical flat slot per token (out_cache_loc)
+    seq_lens,  # [num_seqs] int32             per-request kv length
+    cu_q_lens,  # [num_seqs+1] int32          per-request query offsets (ragged segments)
+    cu_kv_lens,  # [num_seqs+1] int32         page-aligned kv offsets (page_indices stride)
+    page_indices,  # [total_pages] int32      packed physical page ids
+    *,
+    kv_lora_rank: int,
+    page_size: int,
+    sm_scale: float,
+    read_block: int | None = None,  # defaults to page_size (page-level selection)
+    interpret: bool = False,
+):
+    """Packed-ragged self-write + sparse-MLA prefill for **multi-request** extend.
+
+    Generalises :func:`prefill_write_and_attend` to a batch of ragged sequences
+    packed along the token axis (the same layout the dense ``mla_ragged_paged_attention``
+    and the indexer consume). Differences from the single-sequence wrapper:
+
+    * The self-write is unchanged — ``loc`` (out_cache_loc) already names each token's
+      physical slot, so ``flat.at[loc].set(...)`` is correct for any number of
+      sequences and any prefix (padded ``-1`` slots are dropped).
+    * The page table is **not** derived by the ``loc[::ps]`` stride (only valid for one
+      contiguous request). Instead the kernel reads the packed ``page_indices`` at a
+      per-request base ``cu_kv_lens[rid]//ps`` and uses ``seq_lens[rid]`` as the causal
+      bound, with ``rid = q_seq_id[token]`` recovered from ``cu_q_lens``.
+
+    Returns ``(o[total_tokens, H, kv_lora_rank], updated_cache)``.
+    """
+    T, H, Dv = ql.shape
+    rope = qpe.shape[-1]
+    ps = page_size
+    RB = read_block if read_block is not None else ps
+    assert ps % RB == 0, f"read_block {RB} must divide page_size {ps} (page-aligned units)"
+    Pn, pspk, pk, Dk_pad = cache.shape
+    K = topk_pages.shape[-1]
+    S = seq_lens.shape[0]
+
+    q_sparse = jnp.concatenate([ql, qpe], axis=-1)  # [T, H, Dv+rope]
+
+    # self-write: per-token scatter to out_cache_loc (suffix-safe, prefix-agnostic).
+    # mode="drop"+wrap_negative_indices=False drops padded -1 slots (see single-seq).
+    row = jnp.zeros((T, Dk_pad), cache.dtype)
+    row = row.at[:, :Dv].set(kvc.astype(cache.dtype))
+    row = row.at[:, Dv : Dv + rope].set(kpe.reshape(T, rope).astype(cache.dtype))
+    flat = cache.reshape(Pn * ps, Dk_pad)
+    flat = flat.at[loc].set(row, mode="drop", wrap_negative_indices=False)
+    cache_new = flat.reshape(Pn, pspk, pk, Dk_pad)
+
+    # token -> request id (same convention as _scatter_paged / the ref oracle).
+    t = jnp.arange(T, dtype=jnp.int32)
+    q_seq_id = jnp.clip(jnp.searchsorted(cu_q_lens[1:], t, side="right"), 0, S - 1).astype(
+        jnp.int32
+    )
+
+    out = sparse_mla_attention(
+        q_sparse.reshape(1, T, H, q_sparse.shape[2]),
+        cache_new,
+        topk_pages.reshape(1, T, -1),
+        positions.reshape(1, T),
+        kv_lora_rank=Dv,
+        read_block=RB,
+        block_units=K,
+        sm_scale=float(sm_scale),
+        page_size=ps,
+        q_seq_id=q_seq_id,
+        seq_lens=seq_lens,
+        cu_kv_lens=cu_kv_lens,
+        page_indices=page_indices,
         interpret=interpret,
     )
     return out.reshape(T, H, Dv), cache_new

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py
@@ -1,0 +1,451 @@
+"""TPU Pallas kernel for **sparse MLA-latent attention** (the DSA attention-consuming
+path) — the fused sparse-MLA *prefill* kernel.
+
+Given, per query, a set of selected past tokens (the lightning-indexer top-k), attend
+**only** to those tokens over the MLA *latent* cache. Prefill (S queries) and decode
+(S == 1) share the one kernel; this module is the prefill entry point.
+
+Design (mirrors DeepSeek's ``refs/dsa/tilelang_sparse_mla_fwd.py`` *algorithm*, not
+its GPU code):
+
+* **Sparse == dense-MLA with a gathered KV iteration.** The only structural change
+  from a dense paged-MLA kernel is that the inner loop walks the *selected* KV rows
+  (named by ``indices``) instead of all of them, with the usual flash/online-softmax
+  accumulation.
+* **Head-sharing is what makes it viable on TPU.** MLA caches a single latent vector
+  per token (``[Dk] = kv_lora_rank + qk_rope_head_dim = 512 + 64 = 576``) that is
+  reused by *all* query heads, so each fetched row feeds a fat ``[H, Dk]`` matmul.
+  The "value" is the first ``kv_lora_rank`` dims of the same latent.
+* **One kernel, prefill + decode:** the grid is over ``(batch, query_token)``;
+  decode is just ``S == 1``. Queries are *not* batched into a shared-K matmul because
+  each query has its own selection — parallelism comes from the head dim per query.
+* **Static counts, dynamic addresses.** The number of selected units is fixed
+  (``K``); only the *addresses* (which rows) are data-dependent, read from ``indices``
+  on-chip and used to drive per-unit DMAs from HBM.
+
+Selection granularity is parameterised by ``read_block`` (``RB``): ``indices[b, s, :]``
+are **unit ids**, one unit == ``RB`` contiguous tokens. Page-level selection sets
+``RB == page_size`` and consumes the indexer's page-topk directly; effective attended
+tokens per query == ``K * RB``.
+
+Only the **head-minor chunked** kernel is deployed (few heads/device, i.e. head-TP):
+``G`` selected units are gathered into one ``[CBR, Dk]`` tile with the abundant keys on
+the 128-wide MXU lane axis and the few heads on the sublane axis, so one MXU-filling
+matmul runs per chunk. (The v1 per-unit / non-head-minor / chunk-pipelined A/B
+baselines from the perf-characterization sweep are kept in git history only; they are
+not part of this deployed kernel.)
+"""
+
+from __future__ import annotations
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+
+def _sparse_mla_kernel_chunked_hminor(
+    q_ref,  # [1, 1, Hp, Dk]  Hp padded to the bf16 sublane tile (16), NOT to 128
+    idx_ref,  # [1, 1, 1, K]    SMEM
+    pos_ref,  # [1, 1, 1, 1]    SMEM
+    kv_hbm,  # flat: [B, T(+RBF), Dk] HBM;  paged: [1, num_pages*page_size, Dk] HBM
+    pt_ref,  # [1, 1, 1, max_pages] SMEM  page table for this request (paged only; dummy if flat)
+    o_ref,  # [1, 1, Hp, Dv]
+    kv_scratch,  # [CBR, Dk] VMEM  one chunk of gathered latent
+    sem,  # DMA semaphores (G,)
+    *,
+    sm_scale: float,
+    Dv: int,
+    RB: int,
+    RBF: int,
+    T: int,
+    K: int,
+    G: int,
+    CBR: int,  # G*RBF rounded up to the 128-lane tile (score's key axis is the lane axis)
+    paged: bool = False,  # read from the packed 4D paged latent cache via pt_ref
+    page_size: int = 0,  # tokens per page (paged only; static)
+):
+    """Head-minor relayout of the chunked kernel for **few heads/device** (head-TP).
+
+    A default chunked layout would put heads on the 128-wide MXU lane axis (score
+    ``[CBR, Hp]``), wasting ~97% of the MXU when a device holds only ~4 heads. Here we
+    swap the axes: the abundant **selected keys sit on the lane axis** (``CBR`` filling
+    128) and the few **heads sit on the sublane axis** (padded to 16), so 4 heads cost
+    a 4x sublane pad instead of a 32x lane pad. Score is ``[Hp, CBR]``, softmax reduces
+    over the key (lane) axis, value matmul contracts ``CBR``.
+
+    The validity mask lives on the *lane* axis (keys). A lane concat of ``RBF``-wide
+    pieces is not Mosaic-lowerable, so we build the ``[CBR]`` lane mask **arithmetically**
+    from an on-chip ``iota`` with per-unit **static-window** compares (no concat, no
+    dynamic gather, no integer div/mod on a vector): each chunk selects every lane's
+    unit id / row offset with ``G`` broadcasted ``where`` ops, recovers key positions,
+    and turns the boolean into a ``0 / -inf`` additive bias."""
+    b = pl.program_id(0)
+    Hp = q_ref.shape[2]
+    q = q_ref[0, 0]  # [Hp, Dk] bf16
+    qpos = pos_ref[0, 0, 0, 0]
+    NC = (K + G - 1) // G
+
+    lane = jnp.arange(CBR, dtype=jnp.int32)  # [CBR] iota on the key (lane) axis
+
+    def _src(u):
+        """HBM source slice ([RBF, Dk]) for selected unit ``u`` (logical unit id)."""
+        if paged:
+            # unit u == RB contiguous LOGICAL tokens starting at u*RB. RB divides
+            # page_size, so the whole unit lives in one physical page. The 4D cache
+            # is flattened to [num_pages*page_size, Dk]; token (page P, offset o) is
+            # row P*page_size + o. RB%16==0 => RBF==RB => no cross-page over-fetch.
+            #
+            # The token axis is sublane-tiled (8), so a *dynamic* slice offset must be
+            # provably %8. row0 = pp*page_size + o0 is always a multiple of RB(>=16),
+            # but pp (from the page table) is opaque to Mosaic. Express the offset as
+            # an explicit `r8 * 8` (page_size and o0 are both %8) so divisibility is
+            # provable — the same idiom the dense paged kernel uses.
+            lt = u * RB  # logical token start
+            lp = lt // page_size  # logical page (static divisor)
+            o0 = lt - lp * page_size  # in-page offset (multiple of RB)
+            pp = pt_ref[0, 0, 0, lp]  # physical page id
+            r8 = pp * (page_size // 8) + o0 // 8  # (P*page_size + o0) // 8, exact
+            return kv_hbm.at[0, pl.ds(r8 * 8, RBF), :]
+        return kv_hbm.at[b, pl.ds(u * RB, RBF), :]
+
+    # padded lanes (>= G*RBF) are never DMA'd; zero them so a stale/NaN row can't
+    # poison the (masked-out) score before the -inf bias is added.
+    if CBR > G * RBF:
+        pad = CBR - G * RBF
+        kv_scratch[pl.ds(G * RBF, pad), :] = jnp.zeros((pad, kv_scratch.shape[1]), kv_scratch.dtype)
+
+    m0 = jnp.full((Hp,), -jnp.inf, dtype=jnp.float32)
+    l0 = jnp.zeros((Hp,), dtype=jnp.float32)
+    acc0 = jnp.zeros((Hp, Dv), dtype=jnp.float32)
+
+    def chunk_body(c, carry):
+        m_i, l_i, acc = carry
+        base = c * G
+
+        # --- issue G gathers (overlap) into contiguous RBF-aligned lane slots ---
+        for g in range(G):
+            gidx = jnp.minimum(base + g, K - 1)
+            # clamp negative unit ids (topk padding == -1) to 0 for the DMA so the
+            # source offset stays in range; the lane is masked out below anyway.
+            u = jnp.maximum(idx_ref[0, 0, 0, gidx], 0)
+            dst = kv_scratch.at[pl.ds(g * RBF, RBF), :]
+            pltpu.make_async_copy(_src(u), dst, sem.at[g]).start()
+
+        # --- build the [CBR] lane validity bias arithmetically while DMAs run ---
+        # Accumulators are int32 (0/1), NOT bool: Mosaic can't materialise an i1 vector
+        # from a broadcast-scalar select (trunc i8->i1 is unsupported). The i1 predicate
+        # is only formed transiently by the final comparisons feeding the select.
+        u_vec = jnp.zeros((CBR,), jnp.int32)  # per-lane selected unit id
+        row_vec = jnp.zeros((CBR,), jnp.int32)  # per-lane row-within-unit (0..RBF-1)
+        ir_vec = jnp.zeros((CBR,), jnp.int32)  # 1 where the lane's unit id < K
+        for g in range(G):
+            lo = g * RBF  # static lane window for unit g
+            sel = (lane >= lo) & (lane < lo + RBF)  # [CBR] const partition (transient i1)
+            u_g = idx_ref[0, 0, 0, jnp.minimum(base + g, K - 1)]
+            inr = ((base + g) < K).astype(jnp.int32)  # scalar 0/1
+            u_vec = jnp.where(sel, u_g, u_vec)
+            row_vec = jnp.where(sel, lane - lo, row_vec)
+            ir_vec = jnp.where(sel, inr, ir_vec)
+        kp = u_vec * RB + row_vec  # [CBR] key positions
+        # (u_vec >= 0) drops topk padding lanes (unit id -1); their DMA was
+        # clamped to unit 0, so the read is safe and only the mask excludes them.
+        valid = (u_vec >= 0) & (row_vec < RB) & (ir_vec > 0) & (kp <= qpos) & (kp < T)
+        bias = jnp.where(valid, 0.0, -jnp.inf)  # [CBR] fp32
+
+        for g in range(G):
+            gidx = jnp.minimum(base + g, K - 1)
+            u = jnp.maximum(idx_ref[0, 0, 0, gidx], 0)
+            dst = kv_scratch.at[pl.ds(g * RBF, RBF), :]
+            pltpu.make_async_copy(_src(u), dst, sem.at[g]).wait()
+
+        kv_blk = kv_scratch[pl.ds(0, CBR), :]  # [CBR, Dk] bf16
+
+        # score: [Hp,Dk]·[CBR,Dk] -> [Hp, CBR]  (heads on sublane, keys on lanes)
+        s = (
+            jax.lax.dot_general(
+                q, kv_blk, (((1,), (1,)), ((), ())), preferred_element_type=jnp.float32
+            )
+            * sm_scale
+        )
+        s = s + bias[None, :]  # [Hp, CBR] fp32
+
+        # --- flash-softmax over keys = axis 1 (the lane axis) ---
+        m_cur = jnp.max(s, axis=1)  # [Hp]
+        m_new = jnp.maximum(m_i, m_cur)
+        corr = jnp.where(jnp.isneginf(m_new), 0.0, m_new)
+        p = jnp.exp(s - corr[:, None])  # [Hp, CBR]
+        alpha = jnp.where(jnp.isneginf(m_new), 1.0, jnp.exp(m_i - m_new))
+        l_i = l_i * alpha + jnp.sum(p, axis=1)  # [Hp]
+        v_blk = kv_blk[:, :Dv]  # [CBR, Dv]
+        # acc[Hp,Dv] += sum_cbr p[hp,cbr] * v[cbr,dv]
+        acc = acc * alpha[:, None] + jax.lax.dot_general(
+            p.astype(kv_blk.dtype),
+            v_blk,
+            (((1,), (0,)), ((), ())),
+            preferred_element_type=jnp.float32,
+        )
+        return (m_new, l_i, acc)
+
+    m_i, l_i, acc = jax.lax.fori_loop(0, NC, chunk_body, (m0, l0, acc0))
+    out = acc / jnp.where(l_i == 0.0, 1.0, l_i)[:, None]
+    o_ref[0, 0] = out.astype(o_ref.dtype)
+
+
+def sparse_mla_attention(
+    q,  # [B, S, H, Dk]        Dk = kv_lora_rank + qk_rope_head_dim
+    kv,  # [B, T, Dk]           MLA latent cache (value = first Dv cols)
+    indices,  # [B, S, K] int32      selected unit ids (unit == RB tokens)
+    positions,  # [B, S] int32         query positions (causal bound)
+    *,
+    kv_lora_rank: int = 512,
+    read_block: int = 1,
+    block_units: int | None = None,  # units gathered+matmul'd per chunk (G; parallelism knob)
+    sm_scale: float | None = None,
+    interpret: bool = False,
+    page_table=None,  # [B, max_pages] int32: logical page -> physical page. When set,
+    # ``kv`` is the packed 4D paged cache and the kernel gathers from it.
+    page_size: int | None = None,  # tokens/page (required with page_table)
+    seq_len: int | None = None,  # logical T for the causal mask (required with page_table)
+):
+    """Sparse MLA-latent attention (head-minor chunked kernel).
+    Returns ``[B, S, H, kv_lora_rank]`` (float32).
+
+    ``indices`` are *unit ids* (one unit = ``read_block`` contiguous tokens); set
+    ``read_block=1`` for token-granular (exact) DSA, or e.g. 128 for page-sized block
+    reads. Effective attended tokens per query == ``K * read_block``. ``block_units=G``
+    (>=1) sets how many units are gathered into one MXU-filling matmul per chunk
+    (``G>=K`` ⇒ a single chunk, the fastest measured config).
+
+    KV source:
+    * default: ``kv`` is a flat ``[B, T, Dk]`` latent buffer.
+    * paged (``page_table`` set): ``kv`` is the sglang-jax packed 4D MLA cache
+      ``[num_pages, align(page_size,packing)//packing, packing, align(lkv,128)+align(rope,128)]``.
+      Flattened to ``[num_pages*page_size, Dk_pad]``, token (physical page P, offset o)
+      is row ``P*page_size + o``; the kernel resolves each selected unit through
+      ``page_table`` and requires ``read_block % 16 == 0`` (so a unit never over-fetches
+      across a page).
+    """
+    B, S, H, Dk = q.shape
+    K = indices.shape[2]
+    Dv = kv_lora_rank
+    RB = read_block
+    paged = page_table is not None
+    if not block_units or block_units < 1:
+        raise ValueError("sparse_mla_attention requires block_units >= 1")
+    if sm_scale is None:
+        sm_scale = 1.0 / (Dk**0.5)  # note: true (unpadded) Dk
+
+    # TPU/Mosaic wants the lane (last) dim %128; the MLA latent is 576 = 512 + 64
+    # rope, so pad the feature dim with zeros to the next multiple of 128 (640).
+    # Padding the *contraction* dim with zeros leaves q·k unchanged, and the value
+    # is only the first Dv (=512) dims, so the pad never enters the output.
+    Dk_pad = ((Dk + 127) // 128) * 128
+    q = jnp.pad(q, ((0, 0), (0, 0), (0, 0), (0, Dk_pad - Dk))) if Dk_pad != Dk else q
+    if paged:
+        if RB % 16 != 0:
+            raise ValueError("paged KV requires read_block % 16 == 0 (no cross-page over-fetch)")
+        if page_size is None or seq_len is None:
+            raise ValueError("paged KV requires page_size and seq_len")
+        if kv.shape[-1] != Dk_pad:
+            raise ValueError(f"paged cache last dim {kv.shape[-1]} != Dk_pad {Dk_pad}")
+        T = seq_len
+        # flatten [num_pages, ps//packing, packing, Dk_pad] -> [1, num_pages*page_size, Dk_pad]
+        num_pages = kv.shape[0]
+        kv = kv.reshape(1, num_pages * page_size, Dk_pad)
+    else:
+        T = kv.shape[1]
+        if Dk_pad != Dk:
+            kv = jnp.pad(kv, ((0, 0), (0, 0), (0, Dk_pad - Dk)))
+
+    # Add a singleton axis so the per-(b,s) block's trailing two dims are legal
+    # (block over the S axis is 1, which is illegal as a *second-to-last* dim).
+    indices4 = indices.reshape(B, S, 1, K)
+    positions4 = positions.reshape(B, S, 1, 1)
+
+    # head-minor relayout: keys on the lane axis (fills the MXU even with ~4 heads),
+    # heads on the sublane axis (padded to the bf16 sublane tile of 16, not 128).
+    G = max(1, min(block_units, K))
+    RBF = ((RB + 15) // 16) * 16
+    if paged:
+        ps = page_size  # RBF == RB (RB%16==0) => no over-fetch
+        max_pages = (T + ps - 1) // ps
+        # page table is per-REQUEST (same for all query tokens s) => index by b only.
+        pt_arg = page_table.reshape(B, 1, 1, max_pages).astype(jnp.int32)
+        pt_spec = pl.BlockSpec(
+            (1, 1, 1, max_pages), lambda b, s: (b, 0, 0, 0), memory_space=pltpu.SMEM
+        )
+    else:
+        kv = jnp.pad(kv, ((0, 0), (0, RBF), (0, 0)))
+        # dummy 1-wide page table so the kernel signature is uniform (unused when flat).
+        pt_arg = jnp.zeros((B, 1, 1, 1), jnp.int32)
+        pt_spec = pl.BlockSpec((1, 1, 1, 1), lambda b, s: (b, 0, 0, 0), memory_space=pltpu.SMEM)
+    CBR = ((G * RBF + 127) // 128) * 128  # key (lane) axis: %128
+    Hq = ((H + 15) // 16) * 16  # heads on sublane: %16 (bf16 tile)
+    if Hq != H:
+        q = jnp.pad(q, ((0, 0), (0, 0), (0, Hq - H), (0, 0)))
+    kernel = functools.partial(
+        _sparse_mla_kernel_chunked_hminor,
+        sm_scale=sm_scale,
+        Dv=Dv,
+        RB=RB,
+        RBF=RBF,
+        T=T,
+        K=K,
+        G=G,
+        CBR=CBR,
+        paged=paged,
+        page_size=(page_size or 0),
+    )
+    scratch_shapes = [
+        pltpu.VMEM((CBR, Dk_pad), kv.dtype),  # one chunk of gathered latent
+        pltpu.SemaphoreType.DMA((G,)),  # one semaphore per unit
+    ]
+
+    in_specs = [
+        pl.BlockSpec((1, 1, Hq, Dk_pad), lambda b, s: (b, s, 0, 0)),  # q (VMEM)
+        pl.BlockSpec(
+            (1, 1, 1, K), lambda b, s: (b, s, 0, 0), memory_space=pltpu.SMEM
+        ),  # indices (SMEM)
+        pl.BlockSpec(
+            (1, 1, 1, 1), lambda b, s: (b, s, 0, 0), memory_space=pltpu.SMEM
+        ),  # positions (SMEM)
+        pl.BlockSpec(memory_space=pltpu.HBM),  # kv (untiled HBM,
+        #                                                              full — DMA-gathered)
+        pt_spec,  # page table (SMEM)
+    ]
+    call_args = [q, indices4, positions4, kv, pt_arg]
+
+    out = pl.pallas_call(
+        kernel,
+        grid=(B, S),
+        in_specs=in_specs,
+        out_specs=pl.BlockSpec((1, 1, Hq, Dv), lambda b, s: (b, s, 0, 0)),
+        out_shape=jax.ShapeDtypeStruct((B, S, Hq, Dv), jnp.float32),
+        scratch_shapes=scratch_shapes,
+        interpret=interpret,
+    )(*call_args)
+    if Hq != H:
+        out = out[:, :, :H, :]  # drop padded heads
+    return out
+
+
+def prefill_write_and_attend(
+    ql,  # [T, H, kv_lora_rank]   absorbed latent query (nope)
+    qpe,  # [T, H, rope]           rope query
+    kvc,  # [T, kv_lora_rank]      new c_kv to write
+    kpe,  # [T, rope]              new k_rope to write
+    cache,  # [P, ps//pk, pk, Dk_pad]  paged fused latent cache
+    topk_pages,  # [T, K] int32          seq-local page ids (-1 padded)
+    positions,  # [T] int32             absolute query positions (causal bound)
+    loc,  # [T] int32             physical flat slot per token (out_cache_loc)
+    *,
+    kv_lora_rank: int,
+    page_size: int,
+    sm_scale: float,
+    read_block: int | None = None,  # defaults to page_size (page-level selection)
+    interpret: bool = False,
+):
+    """Self-write the current chunk's latent into the paged cache, then attend
+    only the indexer-selected pages via the fused sparse-MLA prefill kernel.
+
+    **SINGLE-SEQUENCE, SINGLE-SHOT extend only** (the padded-bucket TTFT case). All
+    ``T`` tokens are one contiguous request prefilled from position 0, so a single
+    per-request page table ``pt = loc[::page_size] // page_size`` maps logical→physical
+    (page p's first token slot // ps) and ``seq_len == T`` is the causal bound
+    (per-token causality via ``positions``). This stride mapping is only valid under
+    that scope — enforced upstream by the ``model_runner`` ``DSA_PREFILL_SPARSE``
+    guards (radix cache OFF, ``max_running == 1``, ``chunked_prefill >= context``). A
+    partial / batched / chunked extend would reference pages outside the current chunk
+    and corrupt the table; support for that is a follow-up.
+
+    Returns ``(o[T,H,kv_lora_rank], updated_cache)``.
+    """
+    T, H, Dv = ql.shape
+    rope = qpe.shape[-1]
+    ps = page_size
+    RB = read_block if read_block is not None else ps
+    # page-level selection: a selected unit (RB tokens) must sit within one page so the
+    # paged gather never straddles a page boundary (kernel also asserts RB % 16 == 0).
+    assert ps % RB == 0, f"read_block {RB} must divide page_size {ps} (page-aligned units)"
+    Pn, pspk, pk, Dk_pad = cache.shape
+    K = topk_pages.shape[-1]
+
+    q_sparse = jnp.concatenate([ql, qpe], axis=-1)  # [T, H, Dv+rope]
+    # per-request logical→physical page table (page p's first token slot // ps).
+    # Valid ONLY for the single-shot contiguous extend above; clamp guards
+    # padding/-1 slots (out-of-range → OOB gather / core halt).
+    pt = jnp.clip(loc[::ps] // ps, 0, Pn - 1).astype(jnp.int32)
+
+    # self-write: [c_kv | k_pe | pad] row per token at its physical slot. Padded
+    # tokens carry out_cache_loc == -1 and MUST be skipped. NOTE: mode="drop" only
+    # drops OUT-OF-RANGE indices — it still WRAPS negatives (-1 -> last slot), which
+    # would silently corrupt the final physical KV slot on every prefill. Pass
+    # wrap_negative_indices=False so the -1 rows are actually dropped.
+    row = jnp.zeros((T, Dk_pad), cache.dtype)
+    row = row.at[:, :Dv].set(kvc.astype(cache.dtype))
+    row = row.at[:, Dv : Dv + rope].set(kpe.reshape(T, rope).astype(cache.dtype))
+    flat = cache.reshape(Pn * ps, Dk_pad)
+    flat = flat.at[loc].set(row, mode="drop", wrap_negative_indices=False)
+    cache_new = flat.reshape(Pn, pspk, pk, Dk_pad)
+
+    out = sparse_mla_attention(
+        q_sparse.reshape(1, T, H, q_sparse.shape[2]),
+        cache_new,
+        topk_pages.reshape(1, T, -1),
+        positions.reshape(1, T),
+        kv_lora_rank=Dv,
+        read_block=RB,
+        block_units=K,
+        sm_scale=float(sm_scale),
+        page_table=pt.reshape(1, -1),
+        page_size=ps,
+        seq_len=T,
+        interpret=interpret,
+    )
+    return out.reshape(T, H, Dv), cache_new
+
+
+def units_to_token_ids(indices, read_block: int):
+    """Expand unit ids ``[B, S, K]`` → token ids ``[B, S, K*read_block]``.
+
+    Convenience for validating against the token-granular numpy oracle
+    (``glm5_tpu.dsa.attention.dsa_attention``), which expects token indices.
+    """
+    starts = indices[..., None] * read_block  # [B,S,K,1]
+    offs = jnp.arange(read_block, dtype=indices.dtype)  # [RB]
+    return (starts + offs).reshape(indices.shape[:2] + (-1,))
+
+
+def flat_to_paged_cache(kv, page_size: int, kv_packing: int = 2):
+    """Pack a flat ``[B, T, Dk]`` latent into the sglang-jax 4D paged MLA cache
+    plus a **contiguous** page table ``[B, max_pages]``. Test/bench scaffolding
+    mirroring ``MLATokenToKVPool``'s layout
+    ``[num_pages, page_size//kv_packing, kv_packing, Dk]`` where token (page P,
+    within-page offset o) lives at ``[P, o//kv_packing, o%kv_packing, :]``.
+
+    Sequence ``b`` is assigned pages ``[b*pages_per_seq : (b+1)*pages_per_seq)``.
+    Returns ``(cache, page_table)`` as jnp arrays (cache dtype == kv dtype).
+    """
+    import numpy as _np
+
+    kv_np = _np.asarray(kv)
+    B, T, Dk = kv_np.shape
+    if page_size % kv_packing != 0:
+        raise ValueError(f"page_size {page_size} must be divisible by kv_packing {kv_packing}")
+    pages_per_seq = (T + page_size - 1) // page_size
+    num_pages = B * pages_per_seq
+    ps_pack = page_size // kv_packing
+    cache = _np.zeros((num_pages, ps_pack, kv_packing, Dk), dtype=kv_np.dtype)
+    page_table = _np.zeros((B, pages_per_seq), dtype=_np.int32)
+    for b in range(B):
+        for lp in range(pages_per_seq):
+            phys = b * pages_per_seq + lp
+            page_table[b, lp] = phys
+            for o in range(page_size):
+                t = lp * page_size + o
+                if t < T:
+                    cache[phys, o // kv_packing, o % kv_packing, :] = kv_np[b, t]
+    return jnp.asarray(cache), jnp.asarray(page_table)

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py
@@ -203,7 +203,7 @@ def sparse_mla_attention(
     kv_lora_rank: int = 512,
     read_block: int = 1,
     block_units: int | None = None,  # units gathered+matmul'd per chunk (G; parallelism knob)
-    sm_scale: float | None = None,
+    sm_scale: float | None = None,  # REQUIRED: 1/sqrt(qk_nope_head_dim + qk_rope_head_dim)
     interpret: bool = False,
     page_table=None,  # [B, max_pages] int32: logical page -> physical page. When set,
     # ``kv`` is the packed 4D paged cache and the kernel gathers from it.
@@ -212,6 +212,10 @@ def sparse_mla_attention(
 ):
     """Sparse MLA-latent attention (head-minor chunked kernel).
     Returns ``[B, S, H, kv_lora_rank]`` (float32).
+
+    ``sm_scale`` is **required**: the score is the absorbed q·k over the latent
+    ``Dk`` but the correct scale is the original ``1/sqrt(qk_nope_head_dim +
+    qk_rope_head_dim)`` (= 1/√192 for DS/GLM), which the latent dim doesn't encode.
 
     ``indices`` are *unit ids* (one unit = ``read_block`` contiguous tokens); set
     ``read_block=1`` for token-granular (exact) DSA, or e.g. 128 for page-sized block
@@ -236,7 +240,17 @@ def sparse_mla_attention(
     if not block_units or block_units < 1:
         raise ValueError("sparse_mla_attention requires block_units >= 1")
     if sm_scale is None:
-        sm_scale = 1.0 / (Dk**0.5)  # note: true (unpadded) Dk
+        # No safe default: the score is the absorbed q·k over the full latent Dk
+        # (kv_lora_rank + qk_rope_head_dim), but the correct scale is the ORIGINAL
+        # attention head dim 1/sqrt(qk_nope_head_dim + qk_rope_head_dim) (= 1/sqrt(192)
+        # for DS/GLM), which cannot be recovered from Dk or kv_lora_rank alone.
+        # Deriving it from the latent dim (the old 1/sqrt(Dk) default) silently
+        # under-scales the logits, so require the caller to pass it explicitly.
+        raise ValueError(
+            "sparse_mla_attention requires an explicit sm_scale "
+            "(1/sqrt(qk_nope_head_dim + qk_rope_head_dim)); the latent Dk is not the "
+            "score head dim, so there is no safe default."
+        )
 
     # TPU/Mosaic wants the lane (last) dim %128; the MLA latent is 576 = 512 + 64
     # rope, so pad the feature dim with zeros to the next multiple of 128 (640).

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -184,11 +184,20 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
         md = self.forward_metadata
 
         # ── dense short-circuit ────────────────────────────────────────────
-        # skip_offset layers, or layers with no indexer projections wired in,
-        # fall back to plain absorbed-MLA. The kv cache write still happens
-        # inside the dense kernel via input_output_aliases.
+        # Only a "full" layer with no indexer projections wired (q_idx is None)
+        # falls back to plain absorbed-MLA. Every full layer that HAS an indexer
+        # runs its own top-k + sparse attention, matching config.indexer_types
+        # (for GLM-5.2 layers 0..skip_offset-1 are declared "full" ⇒ sparse, not
+        # dense). We intentionally do NOT gate on `layer_id < self.skip_offset`
+        # here: index_skip_topk_offset selects which leading layers own their
+        # indexer vs share one (IndexShare), not which layers skip sparsity.
+        # Routing those full layers dense (a) diverged from the reference and
+        # (b) cascaded in sparse prefill — their shared followers then had no
+        # pages to reuse and fell to dense too (a 6-layer dense O(T²) block).
+        # The kv cache write still happens inside the dense kernel via
+        # input_output_aliases in the remaining (no-indexer) dense case.
         is_decode = forward_batch.forward_mode.is_decode()
-        if layer_id < self.skip_offset or (is_full and q_idx is None):
+        if is_full and q_idx is None:
             o, kv_cache = self._run_dense(
                 q, q_rope, new_kv_c, new_k_pe, kv_cache, sm_scale, layer, dpa, md
             )

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -57,9 +57,12 @@ _INDEXER_KERNEL_KV_PAGES_PER_BLOCK = 64
 # (``sparse_mla_prefill.sparse_mla_attention``) at page granularity instead of the
 # dense fallback. Default OFF ⇒ prefill behaviour is unchanged. Page-level
 # selection (read_block == page_size) consumes the indexer's page-topk directly.
-# Scope: packed-ragged extend — supports batching (max_running>1) via the same
-# ragged metadata the dense path uses. Radix/prefix caching and chunked prefill are
-# still gated off in model_runner (follow-ups A1/A2).
+# Scope: packed-ragged extend — supports the full serving surface via the same
+# ragged metadata the dense path uses: multi-request batching (max_running>1),
+# radix/prefix caching (a cache hit is an extend with a non-zero prefix), and
+# chunked prefill (each chunk is an extend over the growing prefix). All three
+# reduce to the same per-query-token kernel contract and are validated by the
+# A1/A2 parity gates in test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py.
 _PREFILL_SPARSE = int(os.environ.get("DSA_PREFILL_SPARSE", "0"))
 
 

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -24,7 +24,7 @@ from jax.tree_util import register_pytree_node_class
 
 from sgl_jax.srt.kernels.dsa.ref import streamindex_page_topk_ref, streamindex_topk_ref
 from sgl_jax.srt.kernels.dsa.sparse_mla import compute_topk_pages, sparse_mla_page_level
-from sgl_jax.srt.kernels.dsa.sparse_mla_prefill import prefill_write_and_attend
+from sgl_jax.srt.kernels.dsa.sparse_mla_prefill import prefill_write_and_attend_ragged
 from sgl_jax.srt.kernels.dsa.streamindex_topk import streamindex_topk
 from sgl_jax.srt.kernels.mla.v2.kernel import mla_ragged_paged_attention
 from sgl_jax.srt.layers.attention.mla_backend import MLAAttentionBackend
@@ -57,8 +57,9 @@ _INDEXER_KERNEL_KV_PAGES_PER_BLOCK = 64
 # (``sparse_mla_prefill.sparse_mla_attention``) at page granularity instead of the
 # dense fallback. Default OFF ⇒ prefill behaviour is unchanged. Page-level
 # selection (read_block == page_size) consumes the indexer's page-topk directly.
-# Scope: single-sequence extend (the padded-bucket TTFT case); multi-seq ragged
-# extend still needs per-token page tables (follow-up) — leave the flag off there.
+# Scope: packed-ragged extend — supports batching (max_running>1) via the same
+# ragged metadata the dense path uses. Radix/prefix caching and chunked prefill are
+# still gated off in model_runner (follow-ups A1/A2).
 _PREFILL_SPARSE = int(os.environ.get("DSA_PREFILL_SPARSE", "0"))
 
 
@@ -219,6 +220,10 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
         # writes the idx cache so later decode steps get valid topk).
         # Opt-in (DSA_PREFILL_SPARSE): run the fused sparse-MLA *prefill* kernel
         # over the indexer's page-topk — this is the EXTEND-sparsity gap PR.
+        # MIXED (chunked-prefill continuous batching: extend chunks + decodes in one
+        # batch) is is_decode()==False, so it flows here too; the packed-ragged path
+        # treats each decode request as a 1-query extend (extend_seq_lens==1), which
+        # the per-query-token kernel handles uniformly.
         if not is_decode:
             if _PREFILL_SPARSE:
                 idx_cache, topk_pages = self._maybe_index_prefill_pages(
@@ -551,8 +556,13 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
         self, ql, qpe, kvc, kpe, cache, topk_pages, sm_scale, dpa, md, forward_batch
     ):
         """Fused sparse-MLA prefill: self-write the current chunk's latent into the
-        paged fused cache, then attend only the page-topk pages. Single-sequence
-        extend scope (see ``_PREFILL_SPARSE``). Returns ``(o_latent, updated_cache)``.
+        paged fused cache, then attend only the page-topk pages.
+
+        Packed-ragged: threads the same ragged metadata the dense/indexer paths use
+        (``seq_lens``/``cu_q_lens``/``cu_kv_lens``/``page_indices``) so a batch of
+        multiple requests (``max_running>1``) prefills in one call. With a single
+        request this reduces to the previous single-shot behaviour. Returns
+        ``(o_latent, updated_cache)``.
         """
         loc = forward_batch.out_cache_loc.astype(jnp.int32)
         positions = forward_batch.positions.astype(jnp.int32)
@@ -569,11 +579,15 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
             P(dpa, None),  # topk_pages [T, K]
             P(dpa),  # positions [T]
             P(dpa),  # loc [T]
+            P(dpa),  # seq_lens [S]
+            P(dpa),  # cu_q_lens [S+1]
+            P(dpa),  # cu_kv_lens [S+1]
+            P(dpa),  # page_indices [total_pages]
         )
         out_specs = (P(dpa, "tensor", None), P(dpa, None, None, None))
 
-        def _run(ql_, qpe_, kvc_, kpe_, cache_, tp_, pos_, loc_):
-            o, cache_new = prefill_write_and_attend(
+        def _run(ql_, qpe_, kvc_, kpe_, cache_, tp_, pos_, loc_, sl_, cuq_, cukv_, pi_):
+            o, cache_new = prefill_write_and_attend_ragged(
                 ql_,
                 qpe_,
                 kvc_,
@@ -582,6 +596,10 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
                 tp_,
                 pos_,
                 loc_,
+                sl_,
+                cuq_,
+                cukv_,
+                pi_,
                 kv_lora_rank=kv_lora_rank,
                 page_size=page_size,
                 sm_scale=sm,
@@ -589,7 +607,18 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
             return o.astype(ql_.dtype), cache_new
 
         return jax.shard_map(_run, in_specs=in_specs, out_specs=out_specs, check_vma=False)(
-            ql, qpe, kvc, kpe, cache, topk_pages, positions, loc
+            ql,
+            qpe,
+            kvc,
+            kpe,
+            cache,
+            topk_pages,
+            positions,
+            loc,
+            md.seq_lens,
+            md.cu_q_lens,
+            md.cu_kv_lens,
+            md.page_indices,
         )
 
     def _run_dense(self, ql, qpe, kvc, kpe, cache, sm_scale, layer, dpa, md):

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -24,6 +24,7 @@ from jax.tree_util import register_pytree_node_class
 
 from sgl_jax.srt.kernels.dsa.ref import streamindex_page_topk_ref, streamindex_topk_ref
 from sgl_jax.srt.kernels.dsa.sparse_mla import compute_topk_pages, sparse_mla_page_level
+from sgl_jax.srt.kernels.dsa.sparse_mla_prefill import prefill_write_and_attend
 from sgl_jax.srt.kernels.dsa.streamindex_topk import streamindex_topk
 from sgl_jax.srt.kernels.mla.v2.kernel import mla_ragged_paged_attention
 from sgl_jax.srt.layers.attention.mla_backend import MLAAttentionBackend
@@ -37,7 +38,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _SPARSE_PALLAS_MAX_T = 1
-_DEBUG_N_HIT = False
 # Page-budget for the page-scoring indexer path: the indexer max-pools token
 # scores per page and selects this many pages directly (0 = off, use the
 # token-topk + page-union path with k_pages_max=512). Bounds sparse-MLA cost
@@ -52,6 +52,14 @@ _INDEXER_KERNEL = os.environ.get("DSA_INDEXER_KERNEL", "0") == "1"
 # bkv block of 64 pages (4K tokens @ page 64) benched fastest across
 # B=8..64, ctx 8K..128K on v7x/v6e.
 _INDEXER_KERNEL_KV_PAGES_PER_BLOCK = 64
+
+# Opt-in: run EXTEND/prefill through the fused sparse-MLA prefill kernel
+# (``sparse_mla_prefill.sparse_mla_attention``) at page granularity instead of the
+# dense fallback. Default OFF ⇒ prefill behaviour is unchanged. Page-level
+# selection (read_block == page_size) consumes the indexer's page-topk directly.
+# Scope: single-sequence extend (the padded-bucket TTFT case); multi-seq ragged
+# extend still needs per-token page tables (follow-up) — leave the flag off there.
+_PREFILL_SPARSE = int(os.environ.get("DSA_PREFILL_SPARSE", "0"))
 
 
 @register_pytree_node_class
@@ -197,11 +205,51 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
             )
             return o, DSAFusedCache(kv=kv_cache, idx=idx_cache, topk=topk, topk_pages=topk_pages)
 
-        # ── prefill/mixed → dense fallback: page_level is decode-only (one
-        # query token per seq). EXTEND/MIXED chunks route to plain dense; the
-        # indexer still writes idx cache so subsequent decode steps get valid
-        # topk. Multi-request DECODE (T>1) does go through the sparse path.
+        # ── prefill/mixed ─────────────────────────────────────────────────
+        # Default: dense fallback (page_level is decode-only; the indexer still
+        # writes the idx cache so later decode steps get valid topk).
+        # Opt-in (DSA_PREFILL_SPARSE): run the fused sparse-MLA *prefill* kernel
+        # over the indexer's page-topk — this is the EXTEND-sparsity gap PR.
         if not is_decode:
+            if _PREFILL_SPARSE:
+                idx_cache, topk_pages = self._maybe_index_prefill_pages(
+                    is_full, q_idx, k_idx, idx_weights, idx_cache, dpa, md
+                )
+                # Page selection for the sparse-prefill attend. A FULL (indexer)
+                # layer just produced [T, k_pages] page-topk; a SHARED layer gets
+                # None from `_maybe_index_prefill_pages` and reuses the preceding
+                # full layer's pages threaded via `dsa_topk_pages_in` (IndexShare).
+                # During prefill that thread is ALSO [T, k_pages] over the SAME T
+                # query rows (the full layer above ran the same single-shot prefill)
+                # — NOT the decode one-query-per-seq shape. None (a shared layer
+                # before any full layer) ⇒ fall through to the dense attend below.
+                topk_pages_use = topk_pages if is_full else dsa_topk_pages_in
+                if topk_pages_use is not None:
+                    o, kv_cache = self._run_sparse_prefill(
+                        q,
+                        q_rope,
+                        new_kv_c,
+                        new_k_pe,
+                        kv_cache,
+                        topk_pages_use,
+                        sm_scale,
+                        dpa,
+                        md,
+                        forward_batch,
+                    )
+                    return o, DSAFusedCache(
+                        kv=kv_cache,
+                        idx=idx_cache,
+                        topk=None,
+                        topk_pages=topk_pages if is_full else None,
+                    )
+                # no selection available (shared layer before any full) → dense
+                # fallback; idx cache already written above.
+                o, kv_cache = self._run_dense(
+                    q, q_rope, new_kv_c, new_k_pe, kv_cache, sm_scale, layer, dpa, md
+                )
+                return o, DSAFusedCache(kv=kv_cache, idx=idx_cache, topk=None, topk_pages=None)
+
             o, kv_cache = self._run_dense(
                 q, q_rope, new_kv_c, new_k_pe, kv_cache, sm_scale, layer, dpa, md
             )
@@ -348,13 +396,6 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
                     pages_per_seq=pages_per_seq,
                     k_pages_max=512,
                 )
-                if _DEBUG_N_HIT:
-                    jax.debug.print(
-                        "dsa_n_hit min={} max={} mean={}",
-                        jnp.min(jnp.sum(topk_pages >= 0, -1)),
-                        jnp.max(jnp.sum(topk_pages >= 0, -1)),
-                        jnp.mean(jnp.sum(topk_pages >= 0, -1).astype(jnp.float32)),
-                    )
             else:
                 topk_pages = jnp.full((topk.shape[0], 1), -1, jnp.int32)
             return cache3d.reshape(cache_.shape), topk, topk_pages
@@ -433,6 +474,113 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
             md.cu_q_lens,
             md.cu_kv_lens,
             md.distribution,
+        )
+
+    def _maybe_index_prefill_pages(self, is_full, q_idx, k_idx, idx_weights, idx_cache, dpa, md):
+        """Prefill page-topk: scatter ``k_idx`` into the paged indexer cache and,
+        on full layers, compute per-query **causal** page-level top-k via the
+        general (non-decode, ``one_token_per_seq=False``) indexer path.
+
+        Returns ``(idx_cache, topk_pages)`` where ``topk_pages`` is ``[T, k_pages]``
+        seq-local page ids (-1 padded) — exactly the sparse kernel's per-query
+        unit ids at ``read_block == page_size``. ``topk_pages`` is ``None`` on
+        shared layers / when no indexer is wired (caller reuses the threaded one).
+        """
+        if not is_full or q_idx is None:
+            return idx_cache, None
+        k_pages = (self.index_topk + self.page_size - 1) // self.page_size
+        in_specs = (
+            P(dpa, None, None),  # q_idx    [T, H_idx, D_idx] replicated
+            P(dpa, None),  # k_idx    [T, D_idx]
+            P(dpa, None),  # weights  [T, H_idx]
+            P(dpa, None, None, None),  # idx_cache paged
+            P(dpa),  # seq_lens
+            P(dpa),  # page_indices
+            P(dpa),  # cu_q_lens
+            P(dpa),  # cu_kv_lens
+            P(dpa),  # distribution
+        )
+        out_specs = (P(dpa, None, None, None), P(dpa, None))
+
+        def _run(q_, k_, w_, cache_, seq_lens_, pi_, cuq_, cukv_, dist_):
+            page_size = cache_.shape[1] * cache_.shape[2]
+            idx_dim = cache_.shape[3]
+            pages_per_seq = pi_.shape[0] // seq_lens_.shape[0]
+            cache3d = cache_.reshape(cache_.shape[0], page_size, idx_dim)
+            cache3d = _scatter_paged(cache3d, k_, seq_lens_, pi_, cuq_, cukv_, pages_per_seq)
+            topk_pages = streamindex_page_topk_ref(
+                q_,
+                w_,
+                cache3d,
+                seq_lens_,
+                pi_,
+                cuq_,
+                cukv_,
+                dist_,
+                k_pages=k_pages,
+                pages_per_seq=pages_per_seq,
+                one_token_per_seq=False,  # prefill: T>1 tokens/seq, per-query causal
+            )
+            return cache3d.reshape(cache_.shape), topk_pages
+
+        idx_cache, topk_pages = jax.shard_map(
+            _run, in_specs=in_specs, out_specs=out_specs, check_vma=False
+        )(
+            q_idx,
+            k_idx,
+            idx_weights,
+            idx_cache,
+            md.seq_lens,
+            md.page_indices,
+            md.cu_q_lens,
+            md.cu_kv_lens,
+            md.distribution,
+        )
+        return idx_cache, topk_pages
+
+    def _run_sparse_prefill(
+        self, ql, qpe, kvc, kpe, cache, topk_pages, sm_scale, dpa, md, forward_batch
+    ):
+        """Fused sparse-MLA prefill: self-write the current chunk's latent into the
+        paged fused cache, then attend only the page-topk pages. Single-sequence
+        extend scope (see ``_PREFILL_SPARSE``). Returns ``(o_latent, updated_cache)``.
+        """
+        loc = forward_batch.out_cache_loc.astype(jnp.int32)
+        positions = forward_batch.positions.astype(jnp.int32)
+        page_size = self.page_size
+        kv_lora_rank = self.kv_lora_rank
+        sm = float(sm_scale)
+
+        in_specs = (
+            P(dpa, "tensor", None),  # ql   [T, H, kv_lora_rank]
+            P(dpa, "tensor", None),  # qpe  [T, H, rope]
+            P(dpa, None),  # kvc  [T, kv_lora_rank]
+            P(dpa, None),  # kpe  [T, rope]
+            P(dpa, None, None, None),  # cache
+            P(dpa, None),  # topk_pages [T, K]
+            P(dpa),  # positions [T]
+            P(dpa),  # loc [T]
+        )
+        out_specs = (P(dpa, "tensor", None), P(dpa, None, None, None))
+
+        def _run(ql_, qpe_, kvc_, kpe_, cache_, tp_, pos_, loc_):
+            o, cache_new = prefill_write_and_attend(
+                ql_,
+                qpe_,
+                kvc_,
+                kpe_,
+                cache_,
+                tp_,
+                pos_,
+                loc_,
+                kv_lora_rank=kv_lora_rank,
+                page_size=page_size,
+                sm_scale=sm,
+            )
+            return o.astype(ql_.dtype), cache_new
+
+        return jax.shard_map(_run, in_specs=in_specs, out_specs=out_specs, check_vma=False)(
+            ql, qpe, kvc, kpe, cache, topk_pages, positions, loc
         )
 
     def _run_dense(self, ql, qpe, kvc, kpe, cache, sm_scale, layer, dpa, md):

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -3,6 +3,7 @@
 import contextlib
 import dataclasses
 import logging
+import os
 from functools import partial
 
 import jax
@@ -698,8 +699,68 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                 getattr(cfg, "index_skip_topk_offset", 0),
                 cfg.num_hidden_layers,
             )
+            # Per-launch override of the indexer top-k budget (page count = ceil(
+            # index_topk / page_size) is a static kernel shape, so this is fixed at
+            # startup). Unset ⇒ use the model config's default. Lets us sweep the
+            # DSA budget across relaunches without editing the model config.json.
+            _dsa_topk_env = os.environ.get("DSA_INDEX_TOPK")
+            _index_topk = int(_dsa_topk_env) if _dsa_topk_env else cfg.index_topk
+            if _dsa_topk_env:
+                logger.info(
+                    "DSA index_topk overridden by DSA_INDEX_TOPK=%s (cfg default %s)",
+                    _index_topk,
+                    cfg.index_topk,
+                )
+            # ── PR1 scope guards: DSA sparse PREFILL (DSA_PREFILL_SPARSE=1) ──
+            # This is the INITIAL single-sequence, single-shot sparse-MLA prefill.
+            # It assumes a single-shot extend from position 0 and does NOT yet
+            # support: radix/prefix caching (a cache hit turns prefill into a
+            # partial extend the current-chunk page table can't represent),
+            # batching (max_running>1 ⇒ multi-seq ragged extend), or chunked
+            # prefill (a split prompt references pages outside the chunk). Fail
+            # fast with an actionable message instead of silently emitting
+            # garbage. Gated on the opt-in flag, so the dense-prefill/decode
+            # paths — and CI, which never sets DSA_PREFILL_SPARSE — are unaffected.
+            if os.environ.get("DSA_PREFILL_SPARSE", "0") == "1":
+                sa = self.server_args
+                ctx_len = sa.context_length or getattr(self.model_config, "context_len", None)
+                problems = []
+                if not sa.disable_radix_cache:
+                    problems.append(
+                        "radix/prefix cache is ENABLED — pass --disable-radix-cache "
+                        "(a cache hit makes prefill a partial extend the sparse page "
+                        "table cannot represent → garbage output)"
+                    )
+                if sa.max_running_requests != 1:
+                    problems.append(
+                        f"max_running_requests={sa.max_running_requests} — set "
+                        "--max-running-requests 1 (batching needs multi-seq ragged "
+                        "extend, not supported yet)"
+                    )
+                if sa.chunked_prefill_size is None or (
+                    ctx_len is not None and sa.chunked_prefill_size < ctx_len
+                ):
+                    problems.append(
+                        f"chunked_prefill_size={sa.chunked_prefill_size} < "
+                        f"context_length={ctx_len} — set --chunked-prefill-size >= "
+                        "context length so prompts prefill single-shot (no chunking)"
+                    )
+                if problems:
+                    raise ValueError(
+                        "DSA_PREFILL_SPARSE=1 (initial single-sequence sparse-prefill) "
+                        "is incompatible with the current server args:\n  - "
+                        + "\n  - ".join(problems)
+                        + "\nThis is an initial version; radix-cache, batching and "
+                        "chunking support are follow-ups."
+                    )
+                logger.warning(
+                    "DSA sparse PREFILL enabled (initial single-seq, single-shot "
+                    "scope): radix-cache OFF, max_running=1, single-shot prefill "
+                    "(chunk>=context). index_topk=%s.",
+                    _index_topk,
+                )
             full_attn_backend = DSASparseAttentionBackend(
-                index_topk=cfg.index_topk,
+                index_topk=_index_topk,
                 index_head_dim=cfg.index_head_dim,
                 index_n_heads=cfg.index_n_heads,
                 skip_offset=getattr(cfg, "index_skip_topk_offset", 0),

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -711,52 +711,28 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                     _index_topk,
                     cfg.index_topk,
                 )
-            # ── PR1 scope guards: DSA sparse PREFILL (DSA_PREFILL_SPARSE=1) ──
-            # This is the INITIAL single-sequence, single-shot sparse-MLA prefill.
-            # It assumes a single-shot extend from position 0 and does NOT yet
-            # support: radix/prefix caching (a cache hit turns prefill into a
-            # partial extend the current-chunk page table can't represent),
-            # batching (max_running>1 ⇒ multi-seq ragged extend), or chunked
-            # prefill (a split prompt references pages outside the chunk). Fail
-            # fast with an actionable message instead of silently emitting
-            # garbage. Gated on the opt-in flag, so the dense-prefill/decode
-            # paths — and CI, which never sets DSA_PREFILL_SPARSE — are unaffected.
+            # ── DSA sparse PREFILL (DSA_PREFILL_SPARSE=1) ──
+            # The packed-ragged sparse-MLA prefill path now supports the full serving
+            # surface: multi-request batching (max_running>1), radix/prefix caching
+            # (a cache hit is an extend with a non-zero prefix), and chunked prefill
+            # (each chunk is an extend with the growing prefix as its cache). All
+            # three reduce to the same per-query-token kernel contract — the kernel
+            # uses the full ``seq_lens`` causal bound, absolute ``positions`` and
+            # prefix/chunk pages via ``page_indices``; the IndexShare carry is intra-
+            # pass so full layers rescore the full kv every chunk (no cross-chunk
+            # state). Validated by the CPU-interpret parity gates G0–G6 + A1/A2 in
+            # test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py. Gated on the
+            # opt-in flag, so the dense-prefill/decode paths — and CI, which never
+            # sets DSA_PREFILL_SPARSE — are unaffected.
             if os.environ.get("DSA_PREFILL_SPARSE", "0") == "1":
                 sa = self.server_args
-                ctx_len = sa.context_length or getattr(self.model_config, "context_len", None)
-                problems = []
-                if not sa.disable_radix_cache:
-                    problems.append(
-                        "radix/prefix cache is ENABLED — pass --disable-radix-cache "
-                        "(a cache hit makes prefill a partial extend the sparse page "
-                        "table cannot represent → garbage output)"
-                    )
-                if sa.max_running_requests != 1:
-                    problems.append(
-                        f"max_running_requests={sa.max_running_requests} — set "
-                        "--max-running-requests 1 (batching needs multi-seq ragged "
-                        "extend, not supported yet)"
-                    )
-                if sa.chunked_prefill_size is None or (
-                    ctx_len is not None and sa.chunked_prefill_size < ctx_len
-                ):
-                    problems.append(
-                        f"chunked_prefill_size={sa.chunked_prefill_size} < "
-                        f"context_length={ctx_len} — set --chunked-prefill-size >= "
-                        "context length so prompts prefill single-shot (no chunking)"
-                    )
-                if problems:
-                    raise ValueError(
-                        "DSA_PREFILL_SPARSE=1 (initial single-sequence sparse-prefill) "
-                        "is incompatible with the current server args:\n  - "
-                        + "\n  - ".join(problems)
-                        + "\nThis is an initial version; radix-cache, batching and "
-                        "chunking support are follow-ups."
-                    )
                 logger.warning(
-                    "DSA sparse PREFILL enabled (initial single-seq, single-shot "
-                    "scope): radix-cache OFF, max_running=1, single-shot prefill "
-                    "(chunk>=context). index_topk=%s.",
+                    "DSA sparse PREFILL enabled (packed-ragged): batching + radix + "
+                    "chunked-prefill supported. max_running=%s, radix_cache=%s, "
+                    "chunked_prefill_size=%s, index_topk=%s.",
+                    sa.max_running_requests,
+                    not sa.disable_radix_cache,
+                    sa.chunked_prefill_size,
                     _index_topk,
                 )
             full_attn_backend = DSASparseAttentionBackend(

--- a/test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py
+++ b/test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py
@@ -495,8 +495,15 @@ def _seq_slice(c, i):
 
 
 def test_ragged_parity_varlen():
-    """Ragged multi-request prefill vs masked-softmax oracle (varying seq_lens)."""
-    o, _, c = _run_ragged([384, 200, 512, 129], K=4, seed=1)
+    """Ragged multi-request prefill vs masked-softmax oracle (varying seq_lens).
+
+    Lengths span the boundary corners as well as multi-page requests:
+    ``1`` = a decode step packed as a single-query extend (MIXED mode) — the
+    minimal per-request block, exercising the base-offset / causal-bound math;
+    ``128`` = exactly one full page (== page_size), no partial remainder; plus
+    partial (200, 129) and multi-page-exact (384, 512) requests.
+    """
+    o, _, c = _run_ragged([384, 200, 512, 129, 1, 128], K=4, seed=1)
     ref = _ragged_reference(c)
     real = c["real"]
     err = np.abs(o[real] - ref[real])
@@ -631,6 +638,30 @@ def test_gate_G4_dense_equals_sparse_superset():
     assert d < 2e-3, f"G4: full-selection sparse != dense: {d}"
 
 
+def test_gate_G6_metadata_invariants():
+    """G6: the host-side packing-metadata contract the kernel relies on holds for
+    every batch shape — ``cu_q_lens`` covers all packed tokens (== ``len(loc)`` ==
+    num_seqs*S_pad), the flat page table has exactly ``num_seqs*pages_per_seq``
+    slots, and every seq-local top-k page id is in ``[-1, pages_per_seq)``. These
+    are asserted fail-fast inside ``_assemble`` (so G0–G5/A1/A2 already exercise
+    them); this is the standalone, CI-collected gate so the advertised G0–G6 list
+    matches what actually runs."""
+    for shape in ([512], [384, 200, 512, 129, 1, 128], [300, 128, 400]):
+        c = _make_ragged_batch(shape, K=4, seed=13)
+        loc = np.asarray(c["loc"])
+        cu_q = np.asarray(c["cu_q_lens"])
+        pidx = np.asarray(c["page_indices"])
+        tp = np.asarray(c["topk_pages"])
+        num_seqs = len(shape)
+        pps = c["pages_per_seq"]
+        assert (
+            cu_q[-1] == loc.shape[0] == num_seqs * c["S_pad"]
+        ), f"G6 cu_q_lens/total mismatch: seqs={shape}"
+        assert pidx.shape[0] == num_seqs * pps, f"G6 page-table width mismatch: seqs={shape}"
+        assert ((tp >= -1) & (tp < pps)).all(), f"G6 topk page id out of [-1,{pps}): seqs={shape}"
+        print(f"[G6 metadata] ok  seqs={shape}  pps={pps}  ptw={pidx.shape[0]}")
+
+
 def test_gate_A1_prefix_equivalence():
     """A1 (radix/prefix caching): a prompt prefilled single-shot must produce the
     same suffix outputs as prefilling it as [cached prefix] + [extend suffix].
@@ -754,6 +785,7 @@ if __name__ == "__main__":
     test_gate_G2_cross_seq_no_bleed()
     test_gate_G3_permutation_invariance()
     test_gate_G4_dense_equals_sparse_superset()
+    test_gate_G6_metadata_invariants()
     test_gate_A1_prefix_equivalence()
     test_gate_A2_chunked_equivalence()
     print("PARITY OK")

--- a/test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py
+++ b/test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py
@@ -40,6 +40,7 @@ sparse_mla_attention = smp.sparse_mla_attention
 units_to_token_ids = smp.units_to_token_ids
 flat_to_paged_cache = smp.flat_to_paged_cache
 prefill_write_and_attend = smp.prefill_write_and_attend
+prefill_write_and_attend_ragged = smp.prefill_write_and_attend_ragged
 
 
 def _reference(q, kv, indices, positions, *, read_block, kv_lora_rank, sm_scale):
@@ -310,6 +311,418 @@ def _run_write_attend_canary(seed=0):
     print(f"[write+attend canary] final-slot canary preserved; self-write max|err|={w_err:.3e}")
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Packed-ragged (A3 batching) harness + invariant gates G0–G6.
+#
+# Models the static-shape serving batch: ``num_seqs`` requests packed along the
+# token axis, each request's query block padded to a uniform ``S_pad`` tokens and
+# its KV padded to a uniform ``pages_per_seq`` pages (so ``cu_kv_lens[i]//ps ==
+# i*pages_per_seq`` and ``page_indices`` has ``num_seqs*pages_per_seq`` slots —
+# exactly what ``streamindex_page_topk_ref`` / ``sparse_mla_ref`` / ``_scatter_paged``
+# assume). Physical pages are a *permutation* so the per-request ``base`` and the
+# self-write ``loc`` are genuinely exercised (identity would hide base bugs).
+# ─────────────────────────────────────────────────────────────────────────────
+
+_H = 8
+_KV_LORA = 512
+_ROPE = 64
+_DK_PAD = 640
+_PS = 128
+_SCALE = 1.0 / ((_KV_LORA + _ROPE) ** 0.5)
+
+
+def _seq_inputs(rng, L, K):
+    """Self-contained inputs for ONE request of length ``L`` (single-shot, prefix 0):
+    query, latent to write, and seq-local causal page-topk. Independent of packing
+    position — the atom for the cross-run identity gates (G1/G2/G3)."""
+    ql = np.asarray(rng.standard_normal((L, _H, _KV_LORA)) * 0.1, np.float32)
+    qpe = np.asarray(rng.standard_normal((L, _H, _ROPE)) * 0.1, np.float32)
+    kvc = np.asarray(rng.standard_normal((L, _KV_LORA)) * 0.1, np.float32)
+    kpe = np.asarray(rng.standard_normal((L, _ROPE)) * 0.1, np.float32)
+    tp = np.full((L, K), -1, np.int32)
+    for j in range(L):
+        hi = j // _PS + 1  # causally-reachable seq-local pages
+        n = min(K, hi)
+        ch = rng.choice(hi, size=n, replace=False)
+        if 0 not in ch:
+            ch[0] = 0
+        tp[j, :n] = ch
+    return dict(ql=ql, qpe=qpe, kvc=kvc, kpe=kpe, tp=tp, L=int(L))
+
+
+def _assemble(seqs, seed_pages=0, page_perm=True):
+    """Pack a list of per-request ``_seq_inputs`` into the static-shape batch:
+    uniform ``S_pad`` query block and ``pages_per_seq`` KV pages per request,
+    physical pages a (optional) permutation. Returns a case dict."""
+    num_seqs = len(seqs)
+    K = seqs[0]["tp"].shape[1]
+    pages_per_seq = int(np.ceil(max(s["L"] for s in seqs) / _PS))
+    S_pad = pages_per_seq * _PS
+    total = num_seqs * S_pad
+    num_pages = num_seqs * pages_per_seq
+
+    prng = np.random.default_rng(seed_pages)
+    perm = prng.permutation(num_pages) if page_perm else np.arange(num_pages)
+    phys = perm.reshape(num_seqs, pages_per_seq).astype(np.int32)
+
+    ql = np.zeros((total, _H, _KV_LORA), np.float32)
+    qpe = np.zeros((total, _H, _ROPE), np.float32)
+    kvc = np.zeros((total, _KV_LORA), np.float32)
+    kpe = np.zeros((total, _ROPE), np.float32)
+    positions = np.zeros(total, np.int32)
+    loc = np.full(total, -1, np.int32)
+    tp = np.full((total, K), -1, np.int32)
+    real = np.zeros(total, bool)
+    for i, s in enumerate(seqs):
+        L = s["L"]
+        base = i * S_pad
+        ql[base : base + L] = s["ql"]
+        qpe[base : base + L] = s["qpe"]
+        kvc[base : base + L] = s["kvc"]
+        kpe[base : base + L] = s["kpe"]
+        tp[base : base + L] = s["tp"]
+        for j in range(L):
+            t = base + j
+            real[t] = True
+            positions[t] = j
+            loc[t] = phys[i, j // _PS] * _PS + (j % _PS)
+
+    cache = np.zeros((num_pages, _PS, 1, _DK_PAD), np.float32)
+    seq_lens = np.asarray([s["L"] for s in seqs], np.int32)
+    cu_q_lens = np.arange(num_seqs + 1, dtype=np.int32) * S_pad
+    cu_kv_lens = np.arange(num_seqs + 1, dtype=np.int32) * (pages_per_seq * _PS)
+    page_indices = phys.reshape(-1)
+
+    # G6 metadata invariants (host-side, fail fast before the kernel).
+    assert cu_q_lens[-1] == total == len(loc)
+    assert page_indices.shape[0] == num_seqs * pages_per_seq
+    assert ((tp >= -1) & (tp < pages_per_seq)).all(), "topk page id out of [-1, pages_per_seq)"
+
+    return dict(
+        ql=jnp.asarray(ql),
+        qpe=jnp.asarray(qpe),
+        kvc=jnp.asarray(kvc),
+        kpe=jnp.asarray(kpe),
+        cache=jnp.asarray(cache),
+        topk_pages=jnp.asarray(tp),
+        positions=jnp.asarray(positions),
+        loc=jnp.asarray(loc),
+        seq_lens=jnp.asarray(seq_lens),
+        cu_q_lens=jnp.asarray(cu_q_lens),
+        cu_kv_lens=jnp.asarray(cu_kv_lens),
+        page_indices=jnp.asarray(page_indices),
+        seq_lens_list=[s["L"] for s in seqs],
+        S_pad=S_pad,
+        pages_per_seq=pages_per_seq,
+        real=real,
+        _kvc=kvc,
+        _kpe=kpe,
+        _ql=ql,
+        _qpe=qpe,
+        _tp=tp,
+    )
+
+
+def _make_ragged_batch(seq_lens_list, K, seed=0, page_perm=True):
+    rng = np.random.default_rng(seed)
+    seqs = [_seq_inputs(rng, L, K) for L in seq_lens_list]
+    return _assemble(seqs, seed_pages=seed, page_perm=page_perm)
+
+
+def _ragged_reference(c):
+    """Masked-softmax oracle: each request is an independent single-shot prefill
+    over its own written latent (seq-local page ids => seq-local token ids)."""
+    S_pad = c["S_pad"]
+    total = c["_ql"].shape[0]
+    out = np.zeros((total, _H, _KV_LORA), np.float32)
+    latent = np.concatenate([c["_kvc"], c["_kpe"]], axis=-1)  # [total, 576]
+    q_full = np.concatenate([c["_ql"], c["_qpe"]], axis=-1)  # [total, H, 576]
+    tok = np.asarray(units_to_token_ids(jnp.asarray(c["_tp"]), _PS)).reshape(
+        total, -1
+    )  # [total, K*ps]
+    for i, L in enumerate(c["seq_lens_list"]):
+        base = i * S_pad
+        for j in range(L):
+            t = base + j
+            ids = tok[t]  # seq-local token ids
+            valid = (ids >= 0) & (ids <= j) & (ids < L)
+            ids_safe = np.where(valid, base + ids, base)  # into global latent
+            k_sel = latent[ids_safe]
+            logits = (q_full[t] @ k_sel.T) * _SCALE
+            logits = np.where(valid[None, :], logits, -np.inf)
+            m = logits.max(-1, keepdims=True)
+            m = np.where(np.isneginf(m), 0.0, m)
+            p = np.exp(logits - m)
+            p = np.where(valid[None, :], p, 0.0)
+            denom = p.sum(-1, keepdims=True)
+            out[t] = (p / np.where(denom == 0.0, 1.0, denom)) @ k_sel[:, :_KV_LORA]
+    return out
+
+
+def _run_case(c):
+    o, cache_new = prefill_write_and_attend_ragged(
+        c["ql"],
+        c["qpe"],
+        c["kvc"],
+        c["kpe"],
+        c["cache"],
+        c["topk_pages"],
+        c["positions"],
+        c["loc"],
+        c["seq_lens"],
+        c["cu_q_lens"],
+        c["cu_kv_lens"],
+        c["page_indices"],
+        kv_lora_rank=_KV_LORA,
+        page_size=_PS,
+        sm_scale=_SCALE,
+        interpret=True,
+    )
+    return np.asarray(o), np.asarray(cache_new)
+
+
+def _run_ragged(seq_lens_list, K, seed=0, page_perm=True):
+    c = _make_ragged_batch(seq_lens_list, K, seed=seed, page_perm=page_perm)
+    o, cache_new = _run_case(c)
+    return o, cache_new, c
+
+
+def _seq_slice(c, i):
+    """Global token indices of request i's REAL tokens."""
+    base = i * c["S_pad"]
+    L = c["seq_lens_list"][i]
+    return np.arange(base, base + L)
+
+
+def test_ragged_parity_varlen():
+    """Ragged multi-request prefill vs masked-softmax oracle (varying seq_lens)."""
+    o, _, c = _run_ragged([384, 200, 512, 129], K=4, seed=1)
+    ref = _ragged_reference(c)
+    real = c["real"]
+    err = np.abs(o[real] - ref[real])
+    print(f"[ragged varlen] max|err|={err.max():.3e}  seqs={c['seq_lens_list']}  shape={o.shape}")
+    assert err.max() < 2e-3, f"ragged parity failed: {err.max()}"
+
+
+def test_ragged_self_write_and_canary():
+    """G5: self-write landed for real tokens; padded (-1 loc) tokens touch nothing."""
+    o, cache_new, c = _run_ragged([300, 128, 400], K=4, seed=2)
+    flat = cache_new.reshape(-1, _DK_PAD)
+    loc = np.asarray(c["loc"])
+    kvc = c["_kvc"]
+    real = c["real"]
+    # every real token's latent landed at its physical slot
+    w_err = np.abs(flat[loc[real], :_KV_LORA] - kvc[real]).max()
+    assert w_err < 1e-6, f"ragged self-write failed: {w_err}"
+    # no physical slot outside the union of real locs was written (canary: all
+    # such slots must remain zero — the initial cache).
+    written = set(loc[real].tolist())
+    all_slots = set(range(flat.shape[0]))
+    untouched = np.array(sorted(all_slots - written), dtype=np.int64)
+    assert np.abs(flat[untouched]).max() < 1e-6, "padded/-1 write leaked into an unused slot"
+    print(f"[ragged self-write] max|err|={w_err:.3e}  untouched_slots={len(untouched)}")
+
+
+def test_gate_G0_single_seq_equivalence():
+    """G0: the ragged path with num_seqs==1 matches both the oracle and the
+    existing single-sequence prefill_write_and_attend on identical inputs."""
+    L, K = 512, 3
+    o_r, _, c = _run_ragged([L], K=K, seed=3, page_perm=False)  # identity pages
+    ref = _ragged_reference(c)
+    real = c["real"]
+    assert np.abs(o_r[real] - ref[real]).max() < 2e-3
+
+    # same inputs through the single-seq wrapper (contiguous loc, pages 0..P-1).
+    o_s, _ = prefill_write_and_attend(
+        c["ql"][:L],
+        c["qpe"][:L],
+        c["kvc"][:L],
+        c["kpe"][:L],
+        jnp.zeros((c["pages_per_seq"], _PS, 1, _DK_PAD), jnp.float32),
+        c["topk_pages"][:L],
+        c["positions"][:L],
+        jnp.arange(L, dtype=jnp.int32),
+        kv_lora_rank=_KV_LORA,
+        page_size=_PS,
+        sm_scale=_SCALE,
+        interpret=True,
+    )
+    d = np.abs(o_r[:L] - np.asarray(o_s)).max()
+    print(f"[G0 single-seq] ragged-vs-oracle & ragged-vs-single|err|={d:.3e}")
+    assert d < 2e-3, f"G0: ragged(num_seqs==1) != single-seq path: {d}"
+
+
+def test_gate_G1_batch_of_identical():
+    """G1: N *identical* requests → each request's output block is bit-for-bit the
+    same (same inputs, only the physical page numbering differs per slot, so this
+    also checks the per-request base indexing)."""
+    L, K = 384, 4
+    rng = np.random.default_rng(7)
+    a = _seq_inputs(rng, L, K)
+    c = _assemble([a, a, a], seed_pages=7, page_perm=True)
+    o, _ = _run_case(c)
+    b0, b1, b2 = (o[_seq_slice(c, i)] for i in range(3))
+    d = max(np.abs(b1 - b0).max(), np.abs(b2 - b0).max())
+    print(f"[G1] batch-of-identical inter-block max|err|={d:.3e}")
+    assert d < 1e-5, f"G1: identical requests produced different outputs: {d}"
+
+
+def test_gate_G2_cross_seq_no_bleed():
+    """G2: request A's output is identical whether run alone or batched beside an
+    unrelated request B (strongest catch for a wrong per-request page base /
+    causal frame — one sequence reading another's KV)."""
+    K = 4
+    a = _seq_inputs(np.random.default_rng(11), 300, K)  # fixed inputs for A
+    b = _seq_inputs(np.random.default_rng(22), 220, K)  # unrelated B
+    o_pair, _ = _run_case(_assemble([a, b], seed_pages=1, page_perm=True))
+    c_alone = _assemble([a], seed_pages=99, page_perm=False)
+    o_alone, _ = _run_case(c_alone)
+    LA = a["L"]
+    d = np.abs(o_pair[:LA] - o_alone[:LA]).max()
+    print(f"[G2] no-bleed A alone-vs-paired max|err|={d:.3e}")
+    assert d < 2e-3, f"G2: batching an unrelated seq changed A: {d}"
+
+
+def test_gate_G3_permutation_invariance():
+    """G3: permuting request order permutes the output blocks correspondingly —
+    A's output is the same in [A,B] and [B,A]."""
+    K = 4
+    a = _seq_inputs(np.random.default_rng(31), 256, K)
+    b = _seq_inputs(np.random.default_rng(41), 384, K)
+    o_ab, _ = _run_case(_assemble([a, b], seed_pages=3, page_perm=True))
+    c_ba = _assemble([b, a], seed_pages=5, page_perm=True)
+    o_ba, _ = _run_case(c_ba)
+    LA, LB = a["L"], b["L"]
+    S_pad = c_ba["S_pad"]
+    a_in_ab = o_ab[:LA]
+    a_in_ba = o_ba[S_pad : S_pad + LA]  # A is the 2nd request in [B, A]
+    b_in_ab = o_ab[S_pad : S_pad + LB]
+    b_in_ba = o_ba[:LB]
+    da = np.abs(a_in_ab - a_in_ba).max()
+    db = np.abs(b_in_ab - b_in_ba).max()
+    print(f"[G3] permutation invariance A|err|={da:.3e} B|err|={db:.3e}")
+    assert max(da, db) < 2e-3, f"G3: output depends on packing position: A={da} B={db}"
+
+
+def test_gate_G4_dense_equals_sparse_superset():
+    """G4: when K >= pages_per_seq (every reachable page selected), the sparse
+    output equals full causal MLA over each request's written latent."""
+    seq_lens = [384, 200, 512]
+    pages_per_seq = int(np.ceil(max(seq_lens) / _PS))
+    o, _, c = _run_ragged(seq_lens, K=pages_per_seq, seed=5)
+    # full (dense) reference: attend ALL causal tokens (not just selected pages).
+    latent = np.concatenate([c["_kvc"], c["_kpe"]], axis=-1)
+    q_full = np.concatenate([c["_ql"], c["_qpe"]], axis=-1)
+    S_pad = c["S_pad"]
+    dense = np.zeros_like(o)
+    for i, L in enumerate(seq_lens):
+        base = i * S_pad
+        lat = latent[base : base + L]
+        for j in range(L):
+            t = base + j
+            k_sel = lat[: j + 1]  # all causal tokens
+            logits = (q_full[t] @ k_sel.T) * _SCALE
+            p = np.exp(logits - logits.max(-1, keepdims=True))
+            p = p / p.sum(-1, keepdims=True)
+            dense[t] = p @ k_sel[:, :_KV_LORA]
+    real = c["real"]
+    d = np.abs(o[real] - dense[real]).max()
+    print(f"[G4] sparse(all pages) vs dense causal max|err|={d:.3e}")
+    assert d < 2e-3, f"G4: full-selection sparse != dense: {d}"
+
+
+def test_gate_A1_prefix_equivalence():
+    """A1 (radix/prefix caching): a prompt prefilled single-shot must produce the
+    same suffix outputs as prefilling it as [cached prefix] + [extend suffix].
+
+    Prefix path: pre-write the prefix latent into the cache, then run the ragged
+    wrapper over ONLY the suffix query tokens with *absolute* positions and the full
+    ``seq_lens`` causal bound. The extend tokens must match the single-shot run
+    exactly (the kernel already threads prefix pages via page_indices + seq_lens)."""
+    Lfull, K = 512, 4
+    Lp = 256  # cached prefix length
+    Le = Lfull - Lp
+    pps = int(np.ceil(Lfull / _PS))
+
+    rng = np.random.default_rng(23)
+    seq = _seq_inputs(rng, Lfull, K)  # ql/qpe/kvc/kpe/tp for the full prompt
+    # single-shot reference (identity pages ⇒ physical slot == token id)
+    c_full = _assemble([seq], seed_pages=0, page_perm=False)
+    o_full, _ = _run_case(c_full)
+
+    # prefix cache: write tokens 0..Lp-1 at their physical slots (== token id)
+    latent = np.concatenate([seq["kvc"], seq["kpe"]], axis=-1)  # [Lfull, 576]
+    cache_prefix = np.zeros((pps * _PS, _DK_PAD), np.float32)
+    cache_prefix[:Lp, : _KV_LORA + _ROPE] = latent[:Lp]
+    cache_prefix = jnp.asarray(cache_prefix.reshape(pps, _PS, 1, _DK_PAD))
+
+    o_suf, _ = prefill_write_and_attend_ragged(
+        jnp.asarray(seq["ql"][Lp:]),
+        jnp.asarray(seq["qpe"][Lp:]),
+        jnp.asarray(seq["kvc"][Lp:]),
+        jnp.asarray(seq["kpe"][Lp:]),
+        cache_prefix,
+        jnp.asarray(seq["tp"][Lp:]),  # seq-local page ids over the FULL kv
+        jnp.arange(Lp, Lfull, dtype=jnp.int32),  # ABSOLUTE positions
+        jnp.arange(Lp, Lfull, dtype=jnp.int32),  # physical slots for the suffix
+        jnp.asarray([Lfull], jnp.int32),  # full causal bound (prefix+extend)
+        jnp.asarray([0, Le], jnp.int32),  # cu_q_lens over the extend tokens
+        jnp.asarray([0, pps * _PS], jnp.int32),
+        jnp.arange(pps, dtype=jnp.int32),
+        kv_lora_rank=_KV_LORA,
+        page_size=_PS,
+        sm_scale=_SCALE,
+        interpret=True,
+    )
+    o_suf = np.asarray(o_suf)
+    d = np.abs(o_suf - o_full[Lp:Lfull]).max()
+    print(f"[A1 prefix-equiv] suffix single-shot-vs-cached max|err|={d:.3e} (Lp={Lp} Le={Le})")
+    assert d < 2e-3, f"A1: cached-prefix+extend != single-shot on the suffix: {d}"
+
+
+def test_gate_A2_chunked_equivalence():
+    """A2 (chunked prefill): prefilling a prompt in N sequential chunks must give
+    the same per-token outputs as a single-shot prefill. Each chunk is an extend
+    with the growing prefix as its cache — the same kernel machinery A1 validates,
+    applied repeatedly against a persistent cache (the IndexShare carry is intra-
+    pass, so no cross-chunk state is needed; full layers rescore the full kv)."""
+    Lfull, K = 512, 4
+    chunks = [(0, 160), (160, 320), (320, 512)]  # ragged chunk sizes
+    pps = int(np.ceil(Lfull / _PS))
+
+    rng = np.random.default_rng(29)
+    seq = _seq_inputs(rng, Lfull, K)
+    o_full, _ = _run_case(_assemble([seq], seed_pages=0, page_perm=False))
+
+    latent = np.concatenate([seq["kvc"], seq["kpe"]], axis=-1)
+    cache = jnp.zeros((pps, _PS, 1, _DK_PAD), jnp.float32)
+    worst = 0.0
+    for a, b in chunks:
+        Lc = b - a
+        o_c, cache = prefill_write_and_attend_ragged(
+            jnp.asarray(seq["ql"][a:b]),
+            jnp.asarray(seq["qpe"][a:b]),
+            jnp.asarray(seq["kvc"][a:b]),
+            jnp.asarray(seq["kpe"][a:b]),
+            cache,
+            jnp.asarray(seq["tp"][a:b]),
+            jnp.arange(a, b, dtype=jnp.int32),  # absolute positions
+            jnp.arange(a, b, dtype=jnp.int32),  # physical slots (== token id)
+            jnp.asarray([b], jnp.int32),  # causal bound = kv seen so far
+            jnp.asarray([0, Lc], jnp.int32),
+            jnp.asarray([0, pps * _PS], jnp.int32),
+            jnp.arange(pps, dtype=jnp.int32),
+            kv_lora_rank=_KV_LORA,
+            page_size=_PS,
+            sm_scale=_SCALE,
+            interpret=True,
+        )
+        d = np.abs(np.asarray(o_c) - o_full[a:b]).max()
+        worst = max(worst, float(d))
+    print(f"[A2 chunked-equiv] worst chunk-vs-single-shot max|err|={worst:.3e} chunks={chunks}")
+    assert worst < 2e-3, f"A2: N-chunk prefill != single-shot: {worst}"
+
+
 def test_parity_flat():
     _run("flat")
 
@@ -333,4 +746,14 @@ if __name__ == "__main__":
     for seed in range(3):
         _run_write_attend(seed)
     _run_write_attend_canary()
+    # packed-ragged (A3) parity + invariant gates
+    test_ragged_parity_varlen()
+    test_ragged_self_write_and_canary()
+    test_gate_G0_single_seq_equivalence()
+    test_gate_G1_batch_of_identical()
+    test_gate_G2_cross_seq_no_bleed()
+    test_gate_G3_permutation_invariance()
+    test_gate_G4_dense_equals_sparse_superset()
+    test_gate_A1_prefix_equivalence()
+    test_gate_A2_chunked_equivalence()
     print("PARITY OK")

--- a/test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py
+++ b/test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py
@@ -1,0 +1,336 @@
+"""Parity: fused sparse-MLA prefill kernel vs a masked-softmax reference.
+
+Validates ``sparse_mla_attention`` (poc kernel, placed at
+``sgl_jax.srt.kernels.dsa.sparse_mla_prefill``) at **page-level granularity**
+(``read_block == page_size``), which is exactly how PR1 wires it into the DSA
+backend's EXTEND path: the indexer's ``topk_pages`` (seq-local page ids) become
+the kernel's per-query unit ids.
+
+Two modes are checked against the same reference:
+  * flat  : ``kv`` is a flat [B, T, Dk] latent buffer.
+  * paged : ``kv`` is the packed 4D MLA cache + per-seq page table.
+
+Runs on CPU via ``interpret=True`` (no TPU needed).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+jax.config.update("jax_platform_name", "cpu")
+
+# Import the kernel module directly from its file (it only depends on jax/pallas,
+# so we don't need the full sgl_jax package installed for this parity check).
+_HERE = os.path.dirname(__file__)
+_KERNEL_PATH = os.path.normpath(
+    os.path.join(_HERE, "../../../../python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill.py")
+)
+_spec = importlib.util.spec_from_file_location("sparse_mla_prefill", _KERNEL_PATH)
+smp = importlib.util.module_from_spec(_spec)
+sys.modules["sparse_mla_prefill"] = smp
+_spec.loader.exec_module(smp)
+
+sparse_mla_attention = smp.sparse_mla_attention
+units_to_token_ids = smp.units_to_token_ids
+flat_to_paged_cache = smp.flat_to_paged_cache
+prefill_write_and_attend = smp.prefill_write_and_attend
+
+
+def _reference(q, kv, indices, positions, *, read_block, kv_lora_rank, sm_scale):
+    """Masked-softmax sparse MLA over the selected units, in fp32.
+
+    q:   [B, S, H, Dk]   kv: [B, T, Dk]   indices: [B, S, K] unit ids
+    positions: [B, S]    returns [B, S, H, kv_lora_rank]
+    """
+    B, S, H, Dk = q.shape
+    T = kv.shape[1]
+    Dv = kv_lora_rank
+    tok = np.asarray(units_to_token_ids(jnp.asarray(indices), read_block))  # [B,S,K*RB]
+    q = np.asarray(q, np.float32)
+    kv = np.asarray(kv, np.float32)
+    pos = np.asarray(positions)
+    out = np.zeros((B, S, H, Dv), np.float32)
+    for b in range(B):
+        for s in range(S):
+            ids = tok[b, s]
+            valid = (ids >= 0) & (ids <= pos[b, s]) & (ids < T)
+            ids_safe = np.where(valid, ids, 0)
+            k_sel = kv[b, ids_safe]  # [N, Dk]
+            logits = (q[b, s] @ k_sel.T) * sm_scale  # [H, N]
+            logits = np.where(valid[None, :], logits, -np.inf)
+            m = logits.max(-1, keepdims=True)
+            m = np.where(np.isneginf(m), 0.0, m)
+            p = np.exp(logits - m)
+            p = np.where(valid[None, :], p, 0.0)
+            denom = p.sum(-1, keepdims=True)
+            denom = np.where(denom == 0.0, 1.0, denom)
+            p = p / denom
+            out[b, s] = p @ k_sel[:, :Dv]  # [H, Dv]
+    return out
+
+
+def _make_case(seed=0):
+    rng = np.random.default_rng(seed)
+    B, S, H = 2, 6, 8
+    kv_lora_rank, rope = 512, 64
+    Dk = kv_lora_rank + rope
+    page_size = 128
+    pages_per_seq = 4
+    T = page_size * pages_per_seq
+    K = 3  # selected pages per query (page-level => RB=page_size)
+
+    q = jnp.asarray(rng.standard_normal((B, S, H, Dk)) * 0.1, jnp.float32)
+    kv = jnp.asarray(rng.standard_normal((B, T, Dk)) * 0.1, jnp.float32)
+
+    # query positions: spread across the context so causal bounds vary per token
+    positions = np.zeros((B, S), np.int32)
+    for b in range(B):
+        positions[b] = np.linspace(page_size, T - 1, S).astype(np.int32)
+    positions = jnp.asarray(positions)
+
+    # selection: page 0 (always causally valid) + random distinct pages, padded
+    # with -1 when fewer than K pages are causally reachable (exercises the
+    # kernel's topk-padding path — real indexer output is -1-padded).
+    idx = np.full((B, S, K), -1, np.int32)
+    for b in range(B):
+        for s in range(S):
+            hi = int(positions[b, s] // page_size + 1)  # causally-reachable pages
+            n = min(K, hi)
+            choices = rng.choice(hi, size=n, replace=False)
+            if 0 not in choices:
+                choices[0] = 0  # guarantee ≥1 valid key
+            idx[b, s, :n] = choices
+    indices = jnp.asarray(idx)
+    return dict(
+        q=q,
+        kv=kv,
+        indices=indices,
+        positions=positions,
+        kv_lora_rank=kv_lora_rank,
+        page_size=page_size,
+        T=T,
+        K=K,
+        sm_scale=1.0 / (Dk**0.5),
+    )
+
+
+def _run(mode="flat", seed=0):
+    c = _make_case(seed)
+    ref = _reference(
+        c["q"],
+        c["kv"],
+        c["indices"],
+        c["positions"],
+        read_block=c["page_size"],
+        kv_lora_rank=c["kv_lora_rank"],
+        sm_scale=c["sm_scale"],
+    )
+    if mode == "flat":
+        out = sparse_mla_attention(
+            c["q"],
+            c["kv"],
+            c["indices"],
+            c["positions"],
+            kv_lora_rank=c["kv_lora_rank"],
+            read_block=c["page_size"],
+            block_units=c["K"],
+            sm_scale=c["sm_scale"],
+            interpret=True,
+        )
+    else:
+        cache, page_table = flat_to_paged_cache(c["kv"], c["page_size"], kv_packing=2)
+        # pad feature dim to Dk_pad (kernel does this for q internally; cache must match)
+        Dk = c["q"].shape[-1]
+        Dk_pad = ((Dk + 127) // 128) * 128
+        if cache.shape[-1] != Dk_pad:
+            cache = jnp.pad(cache, ((0, 0), (0, 0), (0, 0), (0, Dk_pad - Dk)))
+        out = sparse_mla_attention(
+            c["q"],
+            cache,
+            c["indices"],
+            c["positions"],
+            kv_lora_rank=c["kv_lora_rank"],
+            read_block=c["page_size"],
+            block_units=c["K"],
+            sm_scale=c["sm_scale"],
+            interpret=True,
+            page_table=page_table,
+            page_size=c["page_size"],
+            seq_len=c["T"],
+        )
+    out = np.asarray(out)
+    err = np.abs(out - ref)
+    print(f"[{mode}] max|err|={err.max():.3e}  mean|err|={err.mean():.3e}  shape={out.shape}")
+    assert err.max() < 2e-3, f"{mode}: parity failed, max err {err.max()}"
+    return err.max()
+
+
+def _run_write_attend(seed=0):
+    """End-to-end: self-write latent into a paged cache, then page-level sparse
+    attend — vs a masked-softmax reference over the written latent. Single-seq."""
+    rng = np.random.default_rng(seed)
+    T, H = 512, 8
+    kv_lora_rank, rope = 512, 64
+    Dk_pad = 640
+    page_size = 128
+    pages = T // page_size  # single request occupies pages 0..pages-1
+    K = 3
+    scale = 1.0 / ((kv_lora_rank + rope) ** 0.5)
+
+    ql = jnp.asarray(rng.standard_normal((T, H, kv_lora_rank)) * 0.1, jnp.float32)
+    qpe = jnp.asarray(rng.standard_normal((T, H, rope)) * 0.1, jnp.float32)
+    kvc = jnp.asarray(rng.standard_normal((T, kv_lora_rank)) * 0.1, jnp.float32)
+    kpe = jnp.asarray(rng.standard_normal((T, rope)) * 0.1, jnp.float32)
+    # empty fp32 paged cache [P, ps//pk, pk, Dk_pad] with pk=1
+    cache = jnp.zeros((pages, page_size, 1, Dk_pad), jnp.float32)
+    loc = jnp.arange(T, dtype=jnp.int32)  # token t -> physical slot t
+    positions = jnp.arange(T, dtype=jnp.int32)
+
+    tp = np.full((T, K), -1, np.int32)
+    for t in range(T):
+        hi = t // page_size + 1
+        n = min(K, hi)
+        ch = rng.choice(hi, size=n, replace=False)
+        if 0 not in ch:
+            ch[0] = 0
+        tp[t, :n] = ch
+    topk_pages = jnp.asarray(tp)
+
+    o, cache_new = prefill_write_and_attend(
+        ql,
+        qpe,
+        kvc,
+        kpe,
+        cache,
+        topk_pages,
+        positions,
+        loc,
+        kv_lora_rank=kv_lora_rank,
+        page_size=page_size,
+        sm_scale=scale,
+        interpret=True,
+    )
+    o = np.asarray(o)
+
+    # reference over the written latent [T, 576]
+    latent = np.concatenate([np.asarray(kvc), np.asarray(kpe)], axis=-1)  # [T, 576]
+    q_full = np.concatenate([np.asarray(ql), np.asarray(qpe)], axis=-1)  # [T, H, 576]
+    tok = np.asarray(units_to_token_ids(topk_pages, page_size)).reshape(T, -1)  # [T, K*ps]
+    ref = np.zeros((T, H, kv_lora_rank), np.float32)
+    for t in range(T):
+        ids = tok[t]
+        valid = (ids >= 0) & (ids <= t) & (ids < T)
+        ids_safe = np.where(valid, ids, 0)
+        k_sel = latent[ids_safe]
+        logits = (q_full[t] @ k_sel.T) * scale
+        logits = np.where(valid[None, :], logits, -np.inf)
+        m = logits.max(-1, keepdims=True)
+        m = np.where(np.isneginf(m), 0.0, m)
+        p = np.exp(logits - m)
+        p = np.where(valid[None, :], p, 0.0)
+        denom = p.sum(-1, keepdims=True)
+        ref[t] = (p / np.where(denom == 0.0, 1.0, denom)) @ k_sel[:, :kv_lora_rank]
+
+    err = np.abs(o - ref)
+    # also verify the self-write landed: cache row for token t == [kvc|kpe|pad]
+    flat = np.asarray(cache_new).reshape(pages * page_size, Dk_pad)
+    w_err = np.abs(flat[:T, :kv_lora_rank] - np.asarray(kvc)).max()
+    print(f"[write+attend] max|err|={err.max():.3e}  self-write max|err|={w_err:.3e}")
+    assert err.max() < 2e-3, f"attend parity failed: {err.max()}"
+    assert w_err < 1e-6, f"self-write failed: {w_err}"
+    return err.max()
+
+
+def _run_write_attend_canary(seed=0):
+    """Regression: padded tokens carry out_cache_loc == -1 and MUST be dropped from
+    the self-write, NOT wrapped into the last physical slot (jax .at[].set(mode='drop')
+    still wraps negatives). Place a canary in the final slot (owned by no real token)
+    and a -1 loc for the padded tail; the canary must survive."""
+    rng = np.random.default_rng(seed)
+    T_real, T_pad, H = 256, 64, 8
+    T = T_real + T_pad
+    kv_lora_rank, rope = 512, 64
+    Dk_pad = 640
+    page_size = 128
+    pages = 3  # real request uses pages 0..1; page 2 holds the canary
+    K = 3
+    scale = 1.0 / ((kv_lora_rank + rope) ** 0.5)
+
+    ql = jnp.asarray(rng.standard_normal((T, H, kv_lora_rank)) * 0.1, jnp.float32)
+    qpe = jnp.asarray(rng.standard_normal((T, H, rope)) * 0.1, jnp.float32)
+    kvc = jnp.asarray(rng.standard_normal((T, kv_lora_rank)) * 0.1, jnp.float32)
+    kpe = jnp.asarray(rng.standard_normal((T, rope)) * 0.1, jnp.float32)
+
+    CANARY = 12345.0
+    cache = np.zeros((pages, page_size, 1, Dk_pad), np.float32)
+    cache[pages - 1, page_size - 1, 0, :] = CANARY  # very last physical slot
+    cache = jnp.asarray(cache)
+
+    # real tokens t -> slot t (pages 0..1); padded tail -> out_cache_loc == -1
+    loc = jnp.asarray(np.concatenate([np.arange(T_real), np.full(T_pad, -1)]).astype(np.int32))
+    positions = jnp.asarray(np.concatenate([np.arange(T_real), np.zeros(T_pad)]).astype(np.int32))
+
+    tp = np.full((T, K), -1, np.int32)
+    for t in range(T_real):
+        hi = t // page_size + 1
+        n = min(K, hi)
+        ch = rng.choice(hi, size=n, replace=False)
+        if 0 not in ch:
+            ch[0] = 0
+        tp[t, :n] = ch
+    topk_pages = jnp.asarray(tp)
+
+    _, cache_new = prefill_write_and_attend(
+        ql,
+        qpe,
+        kvc,
+        kpe,
+        cache,
+        topk_pages,
+        positions,
+        loc,
+        kv_lora_rank=kv_lora_rank,
+        page_size=page_size,
+        sm_scale=scale,
+        interpret=True,
+    )
+    flat = np.asarray(cache_new).reshape(pages * page_size, Dk_pad)
+    canary_after = flat[pages * page_size - 1]
+    assert np.allclose(
+        canary_after, CANARY
+    ), f"padded -1 loc corrupted the final KV slot: {canary_after[:3]} != {CANARY}"
+    w_err = np.abs(flat[:T_real, :kv_lora_rank] - np.asarray(kvc)[:T_real]).max()
+    assert w_err < 1e-6, f"self-write regressed: {w_err}"
+    print(f"[write+attend canary] final-slot canary preserved; self-write max|err|={w_err:.3e}")
+
+
+def test_parity_flat():
+    _run("flat")
+
+
+def test_parity_paged():
+    _run("paged")
+
+
+def test_prefill_write_and_attend():
+    _run_write_attend()
+
+
+def test_prefill_write_and_attend_padded_loc_canary():
+    _run_write_attend_canary()
+
+
+if __name__ == "__main__":
+    for seed in range(3):
+        _run("flat", seed)
+        _run("paged", seed)
+    for seed in range(3):
+        _run_write_attend(seed)
+    _run_write_attend_canary()
+    print("PARITY OK")


### PR DESCRIPTION
> **Stacked on #1512 → #1508.** Third in a chain: #1508 (opt-in sparse prefill) ← #1512 (`skip_offset` full-not-dense) ← **this** (batching/radix/chunked). It edits code introduced by both, so until they merge the diff below also contains their commits — **please review the top commit only** (`feat(dsa): packed-ragged sparse-MLA prefill …`). Merge order is #1508 → #1512 → this; I'll rebase down the stack as each lands and the diff will collapse to the batching delta (4 files).

## Motivation

#1508 shipped DSA sparse prefill in a deliberately narrow scope — **single-sequence, single-shot** — with fail-fast guards rejecting request batching, radix/prefix caching, and chunked prefill. That scope was fine to prove the kernel, but it blocks real serving: no concurrent throughput, no shared-prefix reuse, and prompts longer than one chunk can't be admitted.

This PR generalizes the sparse prefill to a **packed-ragged** kernel that attends multiple variable-length requests packed into a single EXTEND grid, and lifts the three guards. The single-sequence path is preserved as the `num_seqs == 1` special case (bit-identical to the #1508 kernel), so there is no regression on the existing path.

## Modifications

- **Kernel** `srt/kernels/dsa/sparse_mla_prefill.py`: packed-ragged sparse-MLA prefill matching the dense FlashAttention contract — per-query causal bounds + per-request page-table base offsets so N ragged requests share one grid; `prefill_write_and_attend_ragged` fuses the self-write and page-sparse attend over the packed batch.
- **Backend** `srt/layers/attention/dsa_sparse_backend.py`: route EXTEND through the ragged path (`q_seq_id` / `seq_lens` / `cu_kv_lens` / `page_indices`); `num_seqs == 1` stays a special case equal to the prior kernel.
- **Guards** `srt/model_executor/model_runner.py`: relax the `DSA_PREFILL_SPARSE` guards so `max_running_requests > 1` (batching), radix cache, and chunked prefill are supported — warn instead of hard-error.
- **Tests** `test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py`: ragged parity + invariant gates (G0–G6) and A1 prefix-equivalence / A2 chunk-equivalence, CPU-interpret, exact vs the single-shot reference.

## Correctness Tests

CPU-interpret parity (`interpret=True`, fp32 oracle, `max|err| < 2e-3`, most gates exact 0.0):

| Gate | Proves | Result |
|---|---|---|
| G0 single-seq equivalence | ragged `num_seqs==1` == existing `(B,S)` kernel | exact |
| G1 batch-of-identical | N identical requests each == single-request output | exact |
| G2 cross-seq isolation | request A unchanged batched beside unrelated B | exact |
| G3 permutation invariance | permuting request order permutes outputs | exact |
| G4 dense==sparse superset | `index_topk ≥ pages(seq)` ⇒ sparse == dense | pass |
| G5 self-write + canary | non-padded slots written; `loc==-1` untouched | pass |
| G6 metadata invariants | packed-batch contract: `cu_q_lens`/page-table width/topk-page-id bounds hold across shapes | pass |
| A1 prefix-equivalence | cached-prefix + extend == single-shot full prefill | exact |
| A2 chunk-equivalence | N-chunk prefill == single-shot prefill of same prompt | exact |

Device (v7x, GLM-5.2-FP8, 8 chips / `tp16-ep16-dp1`):

- **GSM8K — paired full 1319, batched + radix ON**, `max_running=32`, greedy, one server flipping only `DSA_PREFILL_SPARSE` (dense control verified byte-identical except the flag via `/proc/<pid>/environ`): **sparse 0.9674 vs dense 0.9689** (Δ −0.0015 = 2 problems in dense's favor, within noise) — no regression at full scale from batching + prefix caching. 3 concurrent requests answer correctly with no cross-request bleed; burst completion confirms real `max_running`>1 batching. (Standard prompts are <2k, so `index_topk=4096` selects all pages ⇒ sparse is a superset of dense — the clean plumbing/no-regression control, now paired and full-size.)
- **A2 chunked (`chunk=2048 < context=8192`).** Needle recall **6/6** across chunk boundaries (~5.1k-token, 3-chunk prompts; early-chunk needles recalled through two boundaries, selection genuinely sparse at 40 pages vs the 32-page budget). Long-context GSM8K (4-chunk ~7.2k prompts) matches the single-shot baseline (**0.867 vs 0.84**, within n-noise). Byte-exact chunk-invariance is not used as a gate: on repetitive prompts, fp reduction-order differences from accumulating KV chunk-by-chunk flip greedy even for the single-shot reference (output stays coherent) — margin-robust tests (needle, accuracy) are the correct signal.

*Single-sequence selection accuracy is validated in the parent PRs (#1508/#1512): paired n=200 `run_eval` (`test/srt/run_eval.py`, zero-shot chat) 0.960 vs 0.980, plus long-context 50/50 vs 48/50 under active pruning.*

**Long-context paired GSM8K, n=200 (batched).** The n=50 long-context pair from #1508 was deferred to ride with batching; here it is at n=200 on this PR's batched path. `gsm8k_longctx.py` builds ~7.2k-token many-shot prompts so the indexer genuinely prunes (~57→32 pages); one server, both arms identically batched (`--max-running-requests 16`, ctx 12288, `max_tokens=3072`, `index_topk=4096`), flipping only `DSA_PREFILL_SPARSE`:

| arm | accuracy | correct | truncated |
|---|---|---|---|
| sparse | **0.990** | 198/200 | 2 |
| dense  | **0.975** | 195/200 | 5 |

Δ +0.015 (sparse ≥ dense) — no accuracy degradation from selection-under-pruning at 4× the n=50 sample size, measured on the batched path the PR actually ships (both arms batched, so the paired delta isolates selection, not batching).

## Benchmarking and Profiling

Kernel microbench (`deploy/pod/dsa_prefill_phase_bench.py`, single device, per-device H=16, bf16, S=49152, K=32, page 128):

| T | (B,S) indexer / attend ms | ragged n=1 (P0) | n=8 | n=16 (P1 pack vs 1×T) |
|---|---|---|---|---|
| 16 384 | 71.9 / 87.6 | 85.6 (**0.98×**) | 118.7 (1.35×) | 124.4 (1.42×) |
| 32 768 | 143.4 / 165.1 | 167.2 (**1.01×**) | 205.2 (1.24×) | 235.4 (1.43×) |
| 49 152 | 212.1 / 244.9 | 245.2 (**1.00×**) | 285.9 (**1.17×**) | — |

- **P0**: ragged at `num_seqs==1` is within ~2% of the shipping `(B,S)` kernel (16k slightly faster) ⇒ no single-seq regression.
- **P1**: packing N seqs to the same total tokens stays ≤1.2× at realistic sizes (49k n=8 = 1.17×). Overhead grows with request *count* (per-request grid fixed cost), not total tokens — bounded ~1.4× at n=16, and lower the larger each request is (32k n=8 = 1.24×).
- **P5 mixed-length**: a realistic ragged batch `[512, 1024, 2048, 4096, 8192]` (15 872 tokens) attends in **95.2 ms** vs **103.0 ms** for the equal-length pack of the same count/total ⇒ **0.92× (mixed-length is *faster*)**, **0.0% padding waste** — so a real short+long mix packs *more* efficiently than the uniform case.

Batched throughput (`bench_serving` random dataset, in=1024 / out=256, distinct-length prompts `random-range-ratio 0.5`), the A3 payoff of relaxing `max_running==1`. Reported with **radix cache OFF** (`cache_hit_rate=0.000` verified at every point) so the curve is raw batched **compute** scaling, not prefix-cache hits:

| Concurrency B | req/s | total tok/s | mean TTFT | out-tok speedup |
|---|---|---|---|---|
| 1  | 0.096 | 93.9  | 2.86 s | 1.00× |
| 4  | 0.212 | 207.7 | 3.32 s | 2.22× |
| 8  | 0.267 | 259.1 | 4.27 s | 2.89× |
| 16 | 0.306 | 297.0 | 4.94 s | 3.35× |
| 32 | **0.344** | **333.4** | 6.32 s | **3.76×** |

Aggregate throughput scales **monotonically to ~3.6× at B=32** with no saturation regression. Decode dominates the latency growth (TPOT 41→444 ms as the batch fills); TTFT stays modest (2.9→6.3 s). The same sweep with **radix ON** lands within a few % (0.97–1.04×) — A1 caching adds no penalty on this decode-bound workload and only helps genuinely shared-prefix traffic. (An earlier `/v1/completions` shared-prefix probe reported 17.2→90.4 tok/s / 5.3×, but the identical prompts let radix cache the whole prefix and over-state scaling — the radix-OFF curve above is the headline.)

## Notes / follow-ups

- Throughput is measured **radix-OFF with distinct-length prompts** so it reflects raw batched compute; `bench_serving`'s "random" dataset shares prefixes, so radix-ON / identical-prompt runs show high `cache_hit` and over-state scaling.
- P1 n=8 @16k (1.35×) and n=16 (1.42–1.43×) are the points above the ≤1.2× guideline — small-L / high-request-count packing overhead (per-request grid fixed cost), not a concern for typical serving mixes (few large requests); the mixed-length P5 case is 0.92×.
- Cross-query KV page reuse (batch a block of queries against the union of their selected pages) is a further throughput follow-up, not in this PR.
- `bench_serving` tokenizer: GLM-5.2's `tokenizer_config.json` sets `tokenizer_class: TokenizersBackend`, which transformers 4.57 can't load; use a patched fast-tokenizer dir (`tokenizer_class: PreTrainedTokenizerFast`, drop the list-valued `extra_special_tokens`) via `--tokenizer`.