### PR TITLE
[DSA] Opt-in Pallas streamindex_topk kernel for indexer token top-k

### DIFF
--- a/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
+++ b/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
@@ -1,5 +1,8 @@
-# Vendored from vllm-project/tpu-inference @ 35011e5 (Apache-2.0)
-# tpu_inference/kernels/experimental/deepseek_v4/streamindex_topk.py
+# Vendored from vllm-project/tpu-inference @ 0641d9b (Apache-2.0)
+# tpu_inference/kernels/experimental/deepseek_v4/indexer/streamindex_topk.py
+# Local modification: `load_bkv` gains a static dtype branch so the same
+# kernel serves both the DSv4 packed-FP8 cache format (uint8 records with
+# inline e8m0 scales) and an unquantized bf16 cache (scale factor elided).
 # Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,41 +70,38 @@ class MlaCase(Enum):
         }[self]
 
 
-def _streamindex_topk_kernel(
+def _scores_kernel(
     # Prefetch
     seq_lens_ref,  # [max_num_seqs]
     page_indices_ref,  # [max_num_seqs * pages_per_seq]
     cu_q_lens_ref,  # [max_num_seqs + 1]
     start_end_seq_idx_ref,  # [2] (start_seq_idx, end_seq_idx)
     sem_ids_ref,  # [3] (bq_sem_idx, bkv_sem_idx, bo_sem_idx)
-    bo_ids_ref,  # [4] (bo_sem_0_seq_idx, bo_sem_1_seq_idx, bo_sem_0_bo_idx, bo_sem_1_bo_idx)
+    bo_sz_ref,  # [2] row count of each output buffer's in-flight DMA (-1 = none)
     # Input
     q_hbm_ref,  # [max_num_tokens, num_q_heads, head_dim]
     indexer_weights_hbm_ref,  # [max_num_tokens, num_q_heads]
     cache_kv_hbm_ref,  # [total_num_pages, page_size_per_kv_packing, kv_packing, lkv_dim]
+    scores_in_hbm_ref,  # aliased to the output
     # Output
-    topk_idxs_hbm_ref,  # [max_num_tokens, k]
+    scores_hbm_ref,  # [max_num_tokens, num_sublanes_total, 128]
     # Scratch
     bkv_x2_ref,  # [2, bkv_buf_sz_per_kv_packing, kv_packing, lkv_dim]
-    bq_x2_ref,  # [2, bq_sz, num_q_heads, q_packing, head_dim]
+    bq_x2_ref,  # [2, bq_sz, num_q_heads, head_dim]
     bq_weights_x2_ref,  # [2, bq_sz, num_q_heads]
-    bo_idxs_x2_ref,  # [2, bq_sz, k]
+    scores_block_x2_ref,  # [2, bq_sz, num_sublanes_bkv, 128]
     sems,  # [4, 2]
-    topk_vals_scratch,  # [bq_sz, k]
-    topk_idxs_scratch,  # [bq_sz, k]
     *,
-    k: int,
     compression_ratio: int,
     static_q_len: int,
     bkv_p: int,
     bq_sz: int,
-    actual_num_q_heads: int,
-    kv_packing: int,
+    seq_batch_size: int,
 ):
     _, num_q_heads, head_dim = q_hbm_ref.shape
     lkv_dim = cache_kv_hbm_ref.shape[-1]
 
-    total_num_pages, page_size_per_kv_packing, _, _ = cache_kv_hbm_ref.shape
+    total_num_pages, page_size_per_kv_packing, kv_packing, _ = cache_kv_hbm_ref.shape
 
     max_num_seqs = seq_lens_ref.shape[0]
     num_page_indices = page_indices_ref.shape[0]
@@ -116,94 +116,49 @@ def _streamindex_topk_kernel(
 
     bkv_sz_per_kv_packing = bkv_p * page_size_per_kv_packing
     bkv_sz = bkv_sz_per_kv_packing * kv_packing
+    num_sublanes_bkv = bkv_sz // 128
 
     start_seq_idx = start_end_seq_idx_ref[0]
     end_seq_idx = start_end_seq_idx_ref[1]
-    seq_idx = pl.program_id(0) + start_seq_idx
+    batch_start_seq_idx = start_seq_idx + pl.program_id(0) * seq_batch_size
+    batch_end_seq_idx = batch_start_seq_idx + seq_batch_size - 1
 
-    q_start = cu_q_lens_ref[seq_idx]
-    q_end = cu_q_lens_ref[seq_idx + 1]
-    q_len = q_end - q_start
+    q_lens = []
+    kv_lens = []
+    seq_lens = []
+    for batch_idx in range(seq_batch_size):
+        q_start = cu_q_lens_ref[batch_start_seq_idx + batch_idx]
+        q_end = cu_q_lens_ref[batch_start_seq_idx + batch_idx + 1]
+        q_len = q_end - q_start
+        q_lens.append(q_len)
+        seq_len = seq_lens_ref[batch_start_seq_idx + batch_idx]
+        seq_lens.append(seq_len)
+        kv_len = seq_len // compression_ratio
+        kv_lens.append(kv_len)
 
-    seq_len = seq_lens_ref[seq_idx]
-    kv_len = seq_len // compression_ratio
+    def wait_send_scores(bo_sem_idx):
+        # Wait for the output buffer's previous DMA (if any) before reusing it.
+        old_sz = bo_sz_ref[bo_sem_idx]
 
-    def compute_topk(
-        q,
-        kv,
-        scale_val,
-        *,
-        bkv_idx,
-        bq_pos_compressed,
-        bq_weights,
-    ):
-        head_vals_ref = topk_vals_scratch.at[:bq_sz]
-        head_idxs_ref = topk_idxs_scratch.at[:bq_sz]
+        @pl.when(old_sz >= 0)
+        def _():
+            dst = scores_block_x2_ref.at[bo_sem_idx, pl.ds(0, seq_batch_size * old_sz)]
+            _async_copy(dst, dst, sems.at[2, bo_sem_idx, 0], wait=True)
 
-        q_flat = q.reshape(
-            bq_sz * actual_num_q_heads,
-            head_dim,
+    def start_send_scores(bo_sem_idx, sz, token_start, bkv_idx):
+        # All sequences in the batch have the same sz. Issue a single DMA for the
+        # entire batch.
+        bo_sz_ref[bo_sem_idx] = sz
+        sublane_start = bkv_idx * num_sublanes_bkv
+        _async_copy(
+            scores_block_x2_ref.at[bo_sem_idx, pl.ds(0, seq_batch_size * sz)],
+            scores_hbm_ref.at[
+                pl.ds(token_start, seq_batch_size * sz),
+                pl.ds(sublane_start, num_sublanes_bkv),
+            ],
+            sems.at[2, bo_sem_idx, 0],
+            wait=False,
         )
-        s = jnp.einsum(
-            "nd,md->nm",
-            q_flat,
-            kv,
-            preferred_element_type=jnp.float32,
-        )
-        s = s.reshape(bq_sz, actual_num_q_heads, s.shape[-1])
-        s = s * scale_val.reshape(1, 1, -1)
-        s = jnp.maximum(s, 0.0)
-        s = s * bq_weights.astype(jnp.float32)[:, :, None]
-        s_summed = s.sum(axis=1)
-
-        k_span = bkv_idx * bkv_sz + lax.broadcasted_iota(jnp.int32, s_summed.shape, 1)
-
-        valid_mask = k_span < kv_len
-        causal_mask = k_span <= bq_pos_compressed[:, None]
-        mask = jnp.logical_and(valid_mask, causal_mask)
-
-        s_summed = jnp.where(mask, s_summed, -jnp.inf)
-
-        prev_vals = head_vals_ref[...]
-        prev_idxs = head_idxs_ref[...]
-
-        k_span_bcast = jnp.broadcast_to(k_span, s_summed.shape)
-        k_span_bcast = jnp.where(mask, k_span_bcast, -1)
-
-        concat_s = jnp.concatenate([prev_vals, s_summed], axis=1)
-        concat_i = jnp.concatenate([prev_idxs, k_span_bcast], axis=1)
-
-        col_indices = lax.broadcasted_iota(jnp.int32, concat_s.shape, 1)
-        s_work = concat_s
-
-        new_vals_list = []
-        new_idxs_list = []
-
-        for _ in range(k):
-            max_val = jnp.max(s_work, axis=1, keepdims=True)
-            is_max = s_work == max_val
-            idx = jnp.min(
-                jnp.where(is_max, col_indices, jnp.iinfo(jnp.int32).max),
-                axis=1,
-                keepdims=True,
-            )
-
-            is_chosen = col_indices == idx
-            orig_idx = jnp.max(jnp.where(is_chosen, concat_i, -1), axis=1, keepdims=True)
-
-            orig_idx = jnp.where(max_val <= -jnp.inf, -1, orig_idx)
-            max_val = jnp.where(max_val <= -jnp.inf, -jnp.inf, max_val)
-
-            new_vals_list.append(max_val)
-            new_idxs_list.append(orig_idx)
-
-            s_work = jnp.where(is_chosen, -jnp.inf, s_work)
-
-        new_vals = jnp.concatenate(new_vals_list, axis=1)
-        new_idxs = jnp.concatenate(new_idxs_list, axis=1)
-
-        head_vals_ref[...] = new_vals
-        head_idxs_ref[...] = new_idxs
 
     def _async_copy(src, dst, sem, wait):
         cp = pltpu.make_async_copy(src, dst, sem)
@@ -213,95 +168,69 @@ def _streamindex_topk_kernel(
             cp.start()
 
     def _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx, *, wait=False):
-        sem = sems.at[0, bkv_sem_idx]
-        bkv_vmem_ref = bkv_x2_ref.at[bkv_sem_idx]
-
         reshaped_cache_hbm_ref = cache_kv_hbm_ref.reshape(
             total_num_pages * page_size_per_kv_packing,
             kv_packing,
             lkv_dim,
         )
+        max_hbm_pages = reshaped_cache_hbm_ref.shape[0]
 
-        kv_p_start = bkv_idx * bkv_p
-        page_indices_offset = seq_idx * pages_per_seq + kv_p_start
+        for batch_idx in range(seq_batch_size):
+            sem = sems.at[0, bkv_sem_idx, batch_idx]
+            bkv_vmem_ref = bkv_x2_ref.at[bkv_sem_idx, batch_idx]
 
-        if not wait:
-            for i in range(bkv_p):
-                sz_per_kv_packing = page_size_per_kv_packing
-                page_idx = jnp.minimum(page_indices_offset + i, num_page_indices - 1)
+            kv_p_start = bkv_idx * bkv_p
+            page_indices_offset = (seq_idx + batch_idx) * pages_per_seq + kv_p_start
 
-                max_hbm_pages = reshaped_cache_hbm_ref.shape[0]
-                safe_page_offset = jnp.minimum(
-                    page_indices_ref[page_idx] * page_size_per_kv_packing,
-                    jnp.maximum(0, max_hbm_pages - page_size_per_kv_packing),
-                )
+            if not wait:
+                for i in range(bkv_p):
+                    sz_per_kv_packing = page_size_per_kv_packing
+                    page_idx = jnp.minimum(page_indices_offset + i, num_page_indices - 1)
+                    safe_page_offset = jnp.minimum(
+                        page_indices_ref[page_idx] * page_size_per_kv_packing,
+                        jnp.maximum(0, max_hbm_pages - page_size_per_kv_packing),
+                    )
 
+                    _async_copy(
+                        reshaped_cache_hbm_ref.at[pl.ds(safe_page_offset, sz_per_kv_packing)],
+                        bkv_vmem_ref.at[pl.ds(i * page_size_per_kv_packing, sz_per_kv_packing)],
+                        sem,
+                        wait=False,
+                    )
+            else:
+                dma_bkv_sz = bkv_p * page_size_per_kv_packing
+                dst_kv = bkv_vmem_ref.at[pl.ds(0, dma_bkv_sz)]
+                _async_copy(src=dst_kv, dst=dst_kv, sem=sem, wait=True)
+
+    def _fetch_bq(seq_idx, bq_idx, bq_sem_idx, *, wait=False):
+        for batch_idx in range(seq_batch_size):
+            sem = sems.at[1, bq_sem_idx, batch_idx]
+            weights_sem = sems.at[3, bq_sem_idx, batch_idx]
+            bq_vmem_ref = bq_x2_ref.at[bq_sem_idx, batch_idx]
+            bq_weights_vmem_ref = bq_weights_x2_ref.at[bq_sem_idx, batch_idx]
+
+            q_len_start = cu_q_lens_ref[seq_idx + batch_idx] + bq_idx * bq_sz
+            curr_q_end = cu_q_lens_ref[seq_idx + batch_idx + 1]
+            sz = jnp.maximum(0, jnp.minimum(bq_sz, curr_q_end - q_len_start))
+
+            if not wait:
                 _async_copy(
-                    reshaped_cache_hbm_ref.at[pl.ds(safe_page_offset, sz_per_kv_packing)],
-                    bkv_vmem_ref.at[pl.ds(i * page_size_per_kv_packing, sz_per_kv_packing)],
+                    q_hbm_ref.at[pl.ds(q_len_start, sz)],
+                    bq_vmem_ref.at[pl.ds(0, sz)],
                     sem,
                     wait=False,
                 )
-        else:
-            dma_bkv_sz = bkv_p * page_size_per_kv_packing
-            dst_kv = bkv_vmem_ref.at[pl.ds(0, dma_bkv_sz)]
-            _async_copy(src=dst_kv, dst=dst_kv, sem=sem, wait=True)
-
-    def _fetch_bq(seq_idx, bq_idx, bq_sem_idx, *, wait=False):
-        sem = sems.at[1, bq_sem_idx]
-        weights_sem = sems.at[3, bq_sem_idx]
-        bq_vmem_ref = bq_x2_ref.at[bq_sem_idx]
-        bq_weights_vmem_ref = bq_weights_x2_ref.at[bq_sem_idx]
-
-        q_len_start = cu_q_lens_ref[seq_idx] + bq_idx * bq_sz
-        curr_q_end = cu_q_lens_ref[seq_idx + 1]
-
-        sz = jnp.maximum(0, jnp.minimum(bq_sz, curr_q_end - q_len_start))
-        safe_q_start = jnp.minimum(
-            q_len_start, jnp.maximum(0, q_hbm_ref.shape[0] - jnp.maximum(1, sz))
-        )
-
-        if not wait:
-            _async_copy(
-                q_hbm_ref.at[pl.ds(safe_q_start, sz)],
-                bq_vmem_ref.at[pl.ds(0, sz)],
-                sem,
-                wait=False,
-            )
-            _async_copy(
-                indexer_weights_hbm_ref.at[pl.ds(safe_q_start, sz)],
-                bq_weights_vmem_ref.at[pl.ds(0, sz)],
-                weights_sem,
-                wait=False,
-            )
-        else:
-            dst = bq_vmem_ref.at[pl.ds(0, sz)]
-            _async_copy(dst, dst, sem, wait=True)
-            dst_w = bq_weights_vmem_ref.at[pl.ds(0, sz)]
-            _async_copy(dst_w, dst_w, weights_sem, wait=True)
-
-    def _send_bo(seq_idx, bo_idx, bo_sem_idx, *, wait=False):
-        sem_idxs = sems.at[2, bo_sem_idx]
-
-        q_len_start = cu_q_lens_ref[seq_idx] + bo_idx * bq_sz
-        curr_q_end = cu_q_lens_ref[seq_idx + 1]
-
-        sz = jnp.maximum(0, jnp.minimum(bq_sz, curr_q_end - q_len_start))
-        safe_q_start = jnp.minimum(
-            q_len_start,
-            jnp.maximum(0, topk_idxs_hbm_ref.shape[0] - jnp.maximum(1, sz)),
-        )
-
-        if not wait:
-            _async_copy(
-                bo_idxs_x2_ref.at[bo_sem_idx, pl.ds(0, sz)],
-                topk_idxs_hbm_ref.at[pl.ds(safe_q_start, sz)],
-                sem_idxs,
-                wait=False,
-            )
-        else:
-            dst_i = bo_idxs_x2_ref.at[bo_sem_idx, pl.ds(0, sz)]
-            _async_copy(dst_i, dst_i, sem_idxs, wait=True)
+                _async_copy(
+                    indexer_weights_hbm_ref.at[pl.ds(q_len_start, sz)],
+                    bq_weights_vmem_ref.at[pl.ds(0, sz)],
+                    weights_sem,
+                    wait=False,
+                )
+            else:
+                dst = bq_vmem_ref.at[pl.ds(0, sz)]
+                _async_copy(dst, dst, sem, wait=True)
+                dst_w = bq_weights_vmem_ref.at[pl.ds(0, sz)]
+                _async_copy(dst_w, dst_w, weights_sem, wait=True)
 
     def start_fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx):
         _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx)
@@ -315,49 +244,56 @@ def _streamindex_topk_kernel(
     def wait_fetch_bq(seq_idx, bq_idx, bq_sem_idx):
         return _fetch_bq(seq_idx, bq_idx, bq_sem_idx, wait=True)
 
-    def start_send_bo(seq_idx, bo_idx, bo_sem_idx):
-        bo_ids_ref[bo_sem_idx] = seq_idx
-        bo_ids_ref[bo_sem_idx + 2] = bo_idx
-        _send_bo(seq_idx, bo_idx, bo_sem_idx)
-
-    def wait_send_bo(bo_sem_idx):
-        old_seq_idx = bo_ids_ref[bo_sem_idx]
-        old_bo_idx = bo_ids_ref[bo_sem_idx + 2]
-
-        @pl.when(jnp.logical_and(old_seq_idx >= 0, old_seq_idx <= seq_idx))
-        def _():
-            _send_bo(old_seq_idx, old_bo_idx, bo_sem_idx, wait=True)
-
     def load_bq(bq_sem_idx):
-        q = bq_x2_ref.at[bq_sem_idx, :bq_sz][...]
-        q = q.reshape(bq_sz, num_q_heads, head_dim)
-        return q[:, :actual_num_q_heads, :]
+        data = bq_x2_ref.at[bq_sem_idx, :, :bq_sz][...].reshape(
+            seq_batch_size, bq_sz * num_q_heads, head_dim
+        )
+        bqs = []
+        for batch_idx in range(seq_batch_size):
+            bqs.append(data[batch_idx])
+        return bqs
 
     def load_bq_weights(bq_sem_idx):
-        w = bq_weights_x2_ref.at[bq_sem_idx, :bq_sz][...]
-        return w[:, :actual_num_q_heads]
+        data = bq_weights_x2_ref.at[bq_sem_idx, :, :bq_sz][...]
+        bq_weights = []
+        for batch_idx in range(seq_batch_size):
+            bq_weights.append(data[batch_idx])
+        return bq_weights
 
     def load_bkv(bkv_sem_idx):
-        bkv = bkv_x2_ref.at[bkv_sem_idx, :bkv_sz_per_kv_packing][...]
-        # Quantized FP8 index cache path: unpack keys and scale factors locally.
-        flat_bkv = bkv.reshape(-1, bkv.shape[-1])
-        fp8_val = flat_bkv[:, :head_dim]
-        fp8_val = pltpu.bitcast(fp8_val, jnp.float8_e4m3fn)
+        bkvs = []
+        bkv_scales = []
+        for batch_idx in range(seq_batch_size):
+            bkv = bkv_x2_ref.at[bkv_sem_idx, batch_idx, :bkv_sz_per_kv_packing][...]
 
-        # libtpu 0.0.41 not yet support the f8E8M0FNU element type, so decode the
-        # E8M0 scale bytes manually. E8M0 stores value = 2**(byte - 127).
-        scale_val = pltpu.bitcast(flat_bkv[:, head_dim : head_dim + 1], jnp.uint8)
-        scale_val = jnp.exp2(scale_val.astype(jnp.float32) - 127.0).astype(jnp.bfloat16)
+            flat_bkv = bkv.reshape(-1, bkv.shape[-1])
+            if bkv.dtype == jnp.uint8:
+                # Unpack quantized values and scales from the DSv4 FP8 cache
+                # format.
+                fp8_val = flat_bkv[:, :head_dim]
+                fp8_val = pltpu.bitcast(fp8_val, jnp.float8_e4m3fn)
+                scale_val = pltpu.bitcast(
+                    flat_bkv[:, head_dim : head_dim + 1].T, jnp.float8_e8m0fnu
+                ).astype(jnp.bfloat16)
 
-        # NOTE: Do NOT multiply the scales here. Return them separately.
-        return fp8_val.reshape(bkv_sz, head_dim), scale_val.reshape(bkv_sz, 1)
-
-    # --- KERNEL PROCESS LOOP ---
+                # NOTE: Do NOT multiply the scales here. Return them
+                # separately.
+                bkvs.append(fp8_val.reshape(bkv_sz, head_dim))
+                bkv_scales.append(scale_val)
+            else:
+                # Unquantized (e.g. bf16) cache: keys are stored directly as
+                # [*, head_dim] records, no scale factor.
+                bkvs.append(flat_bkv[:, :head_dim].reshape(bkv_sz, head_dim))
+                bkv_scales.append(None)
+        return bkvs, bkv_scales
 
     def process():
-        num_bkv = jnp.maximum(1, cdiv(kv_len, bkv_sz))
+        # num_bkv is determined by the longest sequence length in the batch.
+        kv_len_max = jnp.max(jnp.array(kv_lens))
+        num_bkv = jnp.maximum(1, cdiv(kv_len_max, bkv_sz))
         if static_q_len is None:
-            num_bq = jnp.maximum(1, cdiv(q_len, bq_sz))
+            assert seq_batch_size == 1
+            num_bq = jnp.maximum(1, cdiv(q_lens[0], bq_sz))
         else:
             num_bq = jnp.maximum(1, cdiv(static_q_len, bq_sz))
 
@@ -365,7 +301,7 @@ def _streamindex_topk_kernel(
             next_bq_idx = bq_idx + 1
             is_last_bq = next_bq_idx == num_bq
             next_bq_idx = lax.select(is_last_bq, 0, next_bq_idx)
-            next_seq_idx = lax.select(is_last_bq, seq_idx + 1, seq_idx)
+            next_seq_idx = lax.select(is_last_bq, seq_idx + seq_batch_size, seq_idx)
             next_bq_sem_idx = lax.select(bq_sem_idx == 0, 1, 0)
             return next_seq_idx, next_bq_idx, next_bq_sem_idx
 
@@ -376,14 +312,57 @@ def _streamindex_topk_kernel(
             next_bq_idx = lax.select(is_last_bkv, bq_idx + 1, bq_idx)
             is_last_bq = next_bq_idx == num_bq
             next_bq_idx = lax.select(is_last_bq, 0, next_bq_idx)
-            next_seq_idx = lax.select(is_last_bq, seq_idx + 1, seq_idx)
+            next_seq_idx = lax.select(is_last_bq, seq_idx + seq_batch_size, seq_idx)
             next_bkv_sem_idx = lax.select(bkv_sem_idx == 0, 1, 0)
             return next_seq_idx, next_bq_idx, next_bkv_idx, next_bkv_sem_idx
 
+        def compute_scores(
+            bq_vec,
+            bkv_vec,
+            scale_val_vec,
+            bq_weights_vec,
+            bq_pos_compressed_vec,
+            bkv_idx,
+        ):
+            assert len(bq_vec) == seq_batch_size
+            assert len(bkv_vec) == seq_batch_size
+            assert len(scale_val_vec) == seq_batch_size
+            assert len(bq_weights_vec) == seq_batch_size
+            assert len(bq_pos_compressed_vec) == seq_batch_size
+            ret = []
+
+            for batch_idx in range(seq_batch_size):
+                bq = bq_vec[batch_idx].reshape(-1, head_dim)
+                bkv = bkv_vec[batch_idx]
+                scale_val = scale_val_vec[batch_idx]
+                bq_weights = bq_weights_vec[batch_idx]
+                bq_pos_compressed = bq_pos_compressed_vec[batch_idx]
+
+                s = jnp.einsum(
+                    "nd,md->nm",
+                    bq,
+                    bkv,
+                    preferred_element_type=jnp.float32,
+                )
+                s = s.reshape(-1, num_q_heads, s.shape[-1])
+                s = jnp.maximum(s, 0.0)
+                s = s * bq_weights.astype(jnp.float32)[:, :, None]
+                s_summed = s.sum(axis=1)
+                if scale_val is not None:
+                    s_summed = s_summed * scale_val
+                k_span = bkv_idx * bkv_sz + lax.broadcasted_iota(jnp.int32, s_summed.shape, 1)
+                valid_mask = k_span < kv_lens[batch_idx]
+                causal_mask = k_span <= bq_pos_compressed[:, None]
+                mask = jnp.logical_and(valid_mask, causal_mask)
+                s_summed = jnp.where(mask, s_summed, -jnp.inf)
+                ret.append(s_summed.reshape(-1, num_sublanes_bkv, 128))
+            return jnp.concatenate(ret, axis=0)
+
         def compute_with_bq(bq_idx, _):
+
             bq_sem_idx = sem_ids_ref[0]
             next_seq_idx, next_bq_idx, next_bq_sem_idx = get_next_bq_ids(
-                seq_idx, bq_idx, bq_sem_idx
+                batch_start_seq_idx, bq_idx, bq_sem_idx
             )
 
             # Prefetch next bq
@@ -392,19 +371,31 @@ def _streamindex_topk_kernel(
                 sem_ids_ref[0] = next_bq_sem_idx
                 start_fetch_bq(next_seq_idx, next_bq_idx, next_bq_sem_idx)
 
-            # Initialize scratch space for top-K values and indices.
-            # TODO(hwanginho): Use b16 or fp8 format for top-K values scratch if
-            # possible.
-            topk_vals_scratch[...] = jnp.full((bq_sz, k), -jnp.inf, dtype=jnp.float32)
-            topk_idxs_scratch[...] = jnp.full((bq_sz, k), -1, dtype=jnp.int32)
+            bq_pos_compressed_vec = []
+            for batch_idx in range(seq_batch_size):
+                q_pos = (
+                    seq_lens[batch_idx]
+                    - q_lens[batch_idx]
+                    + bq_idx * bq_sz
+                    + jnp.arange(bq_sz, dtype=jnp.int32)
+                )
+                bq_pos_compressed_vec.append(q_pos // compression_ratio)
 
-            q_pos = seq_len - q_len + bq_idx * bq_sz + jnp.arange(bq_sz, dtype=jnp.int32)
-            bq_pos_compressed = q_pos // compression_ratio
+            # Wait for cur bq if not ready yet
+            wait_fetch_bq(batch_start_seq_idx, bq_idx, bq_sem_idx)
+            bq_vec = load_bq(bq_sem_idx)
+            bq_weights_vec = load_bq_weights(bq_sem_idx)
+
+            # If seq_batch_size > 1, static_q_len is always 1, therefore sz is always
+            # 1 for all sequences within the batch.
+            token_start = cu_q_lens_ref[batch_start_seq_idx] + bq_idx * bq_sz
+            curr_q_end = cu_q_lens_ref[batch_start_seq_idx + 1]
+            sz = jnp.maximum(0, jnp.minimum(bq_sz, curr_q_end - token_start))
 
             def compute_with_bkv(bkv_idx, _):
                 bkv_sem_idx = sem_ids_ref[1]
                 next_seq_idx, _, next_bkv_idx, next_bkv_sem_idx = get_next_bkv_ids(
-                    seq_idx, bq_idx, bkv_idx, bkv_sem_idx
+                    batch_start_seq_idx, bq_idx, bkv_idx, bkv_sem_idx
                 )
 
                 # Prefetch next bkv
@@ -413,55 +404,44 @@ def _streamindex_topk_kernel(
                     sem_ids_ref[1] = next_bkv_sem_idx
                     start_fetch_bkv(next_seq_idx, next_bkv_idx, next_bkv_sem_idx)
 
-                # Wait for cur bq if not ready yet
-                @pl.when(bkv_idx == 0)
-                def wait_cur_bq():
-                    wait_fetch_bq(seq_idx, bq_idx, bq_sem_idx)
-
                 # Wait for cur bkv
-                wait_fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx)
+                wait_fetch_bkv(batch_start_seq_idx, bkv_idx, bkv_sem_idx)
+                bkv_vec, scale_val_vec = load_bkv(bkv_sem_idx)
 
-                bkv, scale_val = load_bkv(bkv_sem_idx)
-                bq = load_bq(bq_sem_idx)
-                bq_weights = load_bq_weights(bq_sem_idx)
-
-                compute_topk(
-                    bq,
-                    bkv,
-                    scale_val,
-                    bkv_idx=bkv_idx,
-                    bq_pos_compressed=bq_pos_compressed,
-                    bq_weights=bq_weights,
+                scores = compute_scores(
+                    bq_vec,
+                    bkv_vec,
+                    scale_val_vec,
+                    bq_weights_vec,
+                    bq_pos_compressed_vec,
+                    bkv_idx,
                 )
 
+                # Double-buffered vreg -> VMEM -> HBM: reuse a buffer only after its
+                # previous DMA has drained, so the HBM write overlaps the next compute.
+                bo_sem_idx = sem_ids_ref[2]
+                wait_send_scores(bo_sem_idx)
+                scores_block_x2_ref[bo_sem_idx, ...] = scores
+                start_send_scores(bo_sem_idx, sz, token_start, bkv_idx)
+                sem_ids_ref[2] = lax.select(bo_sem_idx == 0, 1, 0)
+
             lax.fori_loop(0, num_bkv, compute_with_bkv, None, unroll=False)
-
-            out_idxs = topk_idxs_scratch[...]
-
-            bo_sem_idx = sem_ids_ref[2]
-            sem_ids_ref[2] = lax.select(bo_sem_idx == 0, jnp.int32(1), jnp.int32(0))
-
-            wait_send_bo(bo_sem_idx)
-
-            bo_idxs_x2_ref[bo_sem_idx, ...] = out_idxs.reshape(bo_idxs_x2_ref[bo_sem_idx].shape)
-
-            start_send_bo(seq_idx, bq_idx, bo_sem_idx)
 
         lax.fori_loop(0, num_bq, compute_with_bq, None, unroll=False)
 
     ### ------- Kernel start ------- ###
 
-    @pl.when(seq_idx == start_seq_idx)
+    @pl.when(batch_start_seq_idx == start_seq_idx)
     def prologue():
         start_fetch_bq(start_seq_idx, 0, 0)
         start_fetch_bkv(start_seq_idx, 0, 0)
 
     process()
 
-    @pl.when(seq_idx == end_seq_idx - 1)
+    @pl.when(batch_end_seq_idx == end_seq_idx - 1)
     def epilogue():
         for i in range(2):
-            wait_send_bo(i)
+            wait_send_scores(i)
 
     ### ------- Kernel end ------- ###
 
@@ -517,6 +497,7 @@ def prepare_outputs(out):
         "num_kv_pages_per_block",
         "num_queries_per_block",
         "vmem_limit_bytes",
+        "decode_req_batch_size",
     ),
 )
 def streamindex_topk(
@@ -533,6 +514,7 @@ def streamindex_topk(
     num_kv_pages_per_block: tuple[int, int, int] | int | None = None,
     num_queries_per_block: tuple[int, int, int] | int | None = None,
     vmem_limit_bytes: int = DEFAULT_VMEM_LIMIT_BYTES,
+    decode_req_batch_size: int = 4,
 ) -> jax.Array:
     """StreamIndex Top-K retrieval.
 
@@ -578,18 +560,29 @@ def streamindex_topk(
 
     original_dtype = q.dtype
 
-    prepared_indexer_weights = prepare_index_weights(
-        indexer_weights.astype(original_dtype), original_dtype
-    )
-
-    actual_num_q_heads = q.shape[1]
+    prepared_indexer_weights = prepare_index_weights(indexer_weights, original_dtype)
     q = prepare_q_inputs(q)
     lkv_dim = cache_kv.shape[-1]
+    _, page_size_per_kv_packing, kv_packing, _ = cache_kv.shape
+    page_size = page_size_per_kv_packing * kv_packing
+    pages_per_seq = page_indices.shape[0] // max_num_seqs
+
+    # Validate bkv_sz alignment due to TPU DMA constraints
+    for bkv_p in num_kv_pages_per_blocks:
+        bkv_sz = page_size * bkv_p
+        if bkv_sz % 128 != 0:
+            raise ValueError(
+                f"bkv_sz ({page_size} * {bkv_p} = {bkv_sz}) must be a multiple" " of 128."
+            )
+    num_sublanes_total = max(
+        align_to(pages_per_seq, bkv_p) * page_size // 128 for bkv_p in num_kv_pages_per_blocks
+    )
 
     def run_topk_kernel(
         q,
         prepared_indexer_weights,
         cache_kv,
+        scores,
         seq_lens,
         page_indices,
         cu_q_lens,
@@ -598,12 +591,15 @@ def streamindex_topk(
         static_q_len,
         num_kv_pages_per_block,
         num_queries_per_block,
+        seq_batch_size,
         case=MlaCase.MIXED,
     ):
-        # Dynamically extract parameters for the DMA mapping from the RAW tensor
-        _, page_size_per_kv_packing, kv_packing, _ = cache_kv.shape
-
         _, num_q_heads, head_dim = q.shape
+        # Only support batching for decode sequences.
+        # TODO: support batching for decode sequences with speculative decoding
+        # enabled, e.g. static_q_len = gamma + 1.
+        if seq_batch_size > 1:
+            assert static_q_len == 1
 
         bkv_p = num_kv_pages_per_block
         if static_q_len is not None:
@@ -612,22 +608,24 @@ def streamindex_topk(
             bq_sz = num_queries_per_block
         bkv_sz_per_kv_packing = bkv_p * page_size_per_kv_packing
         bkv_buf_sz_per_kv_packing = bkv_sz_per_kv_packing
+        num_sublanes_bkv = bkv_sz_per_kv_packing * kv_packing // 128
 
-        grid = (end_seq_idx - start_seq_idx,)
+        # If seq_batch_size > 1, caller already guaranteed that
+        # end_seq_idx - start_seq_idx % seq_batch_size == 0.
+        grid = ((end_seq_idx - start_seq_idx) // seq_batch_size,)
 
         in_specs = [
             pl.BlockSpec(memory_space=pltpu.HBM),  # q
             pl.BlockSpec(memory_space=pltpu.HBM),  # prepared_indexer_weights
             pl.BlockSpec(memory_space=pltpu.HBM),  # cache_kv
+            pl.BlockSpec(memory_space=pltpu.HBM),  # scores_init (aliased to out)
         ]
-        out_specs = pl.BlockSpec(memory_space=pltpu.HBM)  # out_idxs
-        assert k % 128 == 0
-        topk_shape = (k // 128, 128)
+        out_specs = pl.BlockSpec(memory_space=pltpu.HBM)  # scores
 
-        # Group VMEM layout securely by keeping physical shapes separated!
         bkv_double_buf = pltpu.VMEM(
             (
                 2,
+                seq_batch_size,
                 bkv_buf_sz_per_kv_packing,
                 kv_packing,
                 lkv_dim,
@@ -637,6 +635,7 @@ def streamindex_topk(
         bq_double_bufq = pltpu.VMEM(
             (
                 2,
+                seq_batch_size,
                 bq_sz,
                 num_q_heads,
                 head_dim,
@@ -646,28 +645,22 @@ def streamindex_topk(
         bq_weights_double_buf = pltpu.VMEM(
             (
                 2,
+                seq_batch_size,
                 bq_sz,
                 num_q_heads,
             ),
             prepared_indexer_weights.dtype,
         )
-        bo_idxs_double_buf = pltpu.VMEM(
-            (
-                2,
-                bq_sz,
-                *topk_shape,
-            ),
-            jnp.int32,
+        bo_scores_double_buf = pltpu.VMEM(
+            (2, seq_batch_size * bq_sz, num_sublanes_bkv, 128), jnp.float32
         )
 
         scratch_shapes = [
             bkv_double_buf,
             bq_double_bufq,
             bq_weights_double_buf,
-            bo_idxs_double_buf,
-            pltpu.SemaphoreType.DMA((4, 2)),
-            pltpu.VMEM((bq_sz, k), jnp.float32),
-            pltpu.VMEM((bq_sz, k), jnp.int32),
+            bo_scores_double_buf,
+            pltpu.SemaphoreType.DMA((4, 2, seq_batch_size)),
         ]
 
         scalar_prefetches = (
@@ -675,23 +668,20 @@ def streamindex_topk(
             page_indices,
             cu_q_lens,
             jnp.array([start_seq_idx, end_seq_idx], jnp.int32),
-            jnp.zeros((3,), jnp.int32),
-            jnp.full((4,), -1, jnp.int32),
+            jnp.zeros((3,), jnp.int32),  # (bq, bkv, bo) sem indices
+            jnp.full((2,), -1, jnp.int32),  # in-flight out DMA row counts
         )
 
-        scope_name = f"StreamIdxTopK-{case.symbol}-bq_{bq_sz}-bkvp_{bkv_p}"
-
+        scope_name = f"StreamIdxTC-{case.symbol}-bq_{bq_sz}-bkvp_{bkv_p}"
         kernel = jax.named_scope(scope_name)(
             pl.pallas_call(
                 functools.partial(
-                    _streamindex_topk_kernel,
-                    k=k,
+                    _scores_kernel,
                     compression_ratio=compression_ratio,
                     static_q_len=static_q_len,
                     bq_sz=bq_sz,
                     bkv_p=bkv_p,
-                    actual_num_q_heads=actual_num_q_heads,
-                    kv_packing=kv_packing,
+                    seq_batch_size=seq_batch_size,
                 ),
                 grid_spec=pltpu.PrefetchScalarGridSpec(
                     num_scalar_prefetch=len(scalar_prefetches),
@@ -705,7 +695,11 @@ def streamindex_topk(
                     vmem_limit_bytes=vmem_limit_bytes,
                     disable_bounds_checks=True,
                 ),
-                out_shape=jax.ShapeDtypeStruct(shape=(q.shape[0], *topk_shape), dtype=jnp.int32),
+                out_shape=jax.ShapeDtypeStruct(
+                    shape=(q.shape[0], num_sublanes_total, 128),
+                    dtype=jnp.float32,
+                ),
+                input_output_aliases={len(scalar_prefetches) + 3: 0},
                 name=scope_name,
             )
         )
@@ -714,29 +708,61 @@ def streamindex_topk(
             q,
             prepared_indexer_weights,
             cache_kv,
+            scores,
         )
 
-    decode_end = jnp.minimum(max_num_seqs, jnp.maximum(0, distribution[0]))
+    # Pre-fill the output with -inf and alias it, so masked / unwritten
+    # columns are already -inf.
+    scores_init = jnp.full(
+        (q.shape[0], num_sublanes_total, 128),
+        -jnp.inf,
+        dtype=jnp.float32,
+    )
 
-    q_idxs_decode = run_topk_kernel(
+    # TODO: we shall sort the sequences by length, so that multiple decode
+    # sequences in one batch have similar lengths to reduce waste of compute.
+    # With the same batch size, the longest sequence will determine number of
+    # blocks to run computation for.
+    decode_batch_end = distribution[0] // decode_req_batch_size * decode_req_batch_size
+    scores = run_topk_kernel(
         q,
         prepared_indexer_weights,
         cache_kv,
+        scores_init,
         seq_lens,
         page_indices,
         cu_q_lens,
         num_kv_pages_per_block=num_kv_pages_per_blocks[0],
         num_queries_per_block=num_queries_per_blocks[0],
         start_seq_idx=jnp.array(0),
-        end_seq_idx=distribution[0],
+        end_seq_idx=decode_batch_end,
         static_q_len=1,
+        seq_batch_size=decode_req_batch_size,
         case=MlaCase.DECODE,
     )
-
-    q_idxs_mixed = run_topk_kernel(
+    # Handle num_decode_seqs % decode_req_batch_size != 0 case.
+    scores = run_topk_kernel(
         q,
         prepared_indexer_weights,
         cache_kv,
+        scores,
+        seq_lens,
+        page_indices,
+        cu_q_lens,
+        num_kv_pages_per_block=num_kv_pages_per_blocks[0],
+        num_queries_per_block=num_queries_per_blocks[0],
+        start_seq_idx=decode_batch_end,
+        end_seq_idx=distribution[1],
+        static_q_len=1,
+        seq_batch_size=1,
+        case=MlaCase.DECODE,
+    )
+
+    scores = run_topk_kernel(
+        q,
+        prepared_indexer_weights,
+        cache_kv,
+        scores,
         seq_lens,
         page_indices,
         cu_q_lens,
@@ -745,17 +771,25 @@ def streamindex_topk(
         start_seq_idx=distribution[1],
         end_seq_idx=distribution[2],
         static_q_len=None,
+        seq_batch_size=1,
         case=MlaCase.MIXED,
     )
 
-    decode_tokens_end = cu_q_lens[decode_end]
+    scores = scores.reshape(q.shape[0], -1)
+    if scores.shape[1] < k:
+        scores = jnp.pad(
+            scores,
+            ((0, 0), (0, k - scores.shape[1])),
+            constant_values=-jnp.inf,
+        )
 
-    topk_idxs_decode = prepare_outputs(q_idxs_decode)
-    topk_idxs_mixed = prepare_outputs(q_idxs_mixed)
+    # TODO: Re-evaluate replacing this with the sparsecore_topk kernel
+    # once SparseCore supports direct VMEM access (e.g., on TPU v8).
+    # Currently, jax.lax.approx_max_k wins due to the HBM read/write tax, but
+    # direct VMEM streaming will allow SC to beat TensorCore performance.
 
-    token_indices = jnp.arange(topk_idxs_decode.shape[0])[:, None]
-    mask = token_indices < decode_tokens_end
-
-    topk_idxs = jnp.where(mask, topk_idxs_decode, topk_idxs_mixed)
-
-    return topk_idxs
+    # jax.lax.approx_max_k(recall_target=1.0) is equivalent to jax.lax.top_k
+    # but faster.
+    top_vals, top_idxs = jax.lax.approx_max_k(scores, k, reduction_dimension=-1, recall_target=1.0)
+    topk_idxs = jnp.where(top_vals == -jnp.inf, -1, top_idxs)
+    return topk_idxs[: q.shape[0], :k]

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -24,6 +24,7 @@ from jax.tree_util import register_pytree_node_class
 
 from sgl_jax.srt.kernels.dsa.ref import streamindex_page_topk_ref, streamindex_topk_ref
 from sgl_jax.srt.kernels.dsa.sparse_mla import compute_topk_pages, sparse_mla_page_level
+from sgl_jax.srt.kernels.dsa.streamindex_topk import streamindex_topk
 from sgl_jax.srt.kernels.mla.v2.kernel import mla_ragged_paged_attention
 from sgl_jax.srt.layers.attention.mla_backend import MLAAttentionBackend
 from sgl_jax.srt.utils.profiling_utils import named_scope
@@ -42,6 +43,15 @@ _DEBUG_N_HIT = False
 # token-topk + page-union path with k_pages_max=512). Bounds sparse-MLA cost
 # to O(budget) flat vs the union path which saturates 512 pages at long ctx.
 _PAGE_TOPK_BUDGET = int(os.environ.get("DSA_PAGE_TOPK", "0"))
+# Opt-in: score+topk via the Pallas streamindex kernel instead of the jnp
+# reference. The kernel reads O(actual kv_len) pages (vs the ref's O(max_ctx)
+# padded gather) and shares the ref's exact scoring semantics
+# (sum_h relu(q·k)·w_h, approx_max_k). Token-topk path only; DSA_PAGE_TOPK
+# takes precedence when both are set.
+_INDEXER_KERNEL = os.environ.get("DSA_INDEXER_KERNEL", "0") == "1"
+# bkv block of 64 pages (4K tokens @ page 64) benched fastest across
+# B=8..64, ctx 8K..128K on v7x/v6e.
+_INDEXER_KERNEL_KV_PAGES_PER_BLOCK = 64
 
 
 @register_pytree_node_class
@@ -299,7 +309,22 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
                     one_token_per_seq=True,
                 )
                 return cache3d.reshape(cache_.shape), topk, topk_pages
-            if compute_topk:
+            if compute_topk and _INDEXER_KERNEL:
+                topk = streamindex_topk(
+                    q_,
+                    w_,
+                    cache3d.reshape(cache_.shape),
+                    seq_lens_,
+                    _fixed_stride_pages(pi_, cukv_, page_size, pages_per_seq),
+                    cuq_,
+                    dist_,
+                    k=self.index_topk,
+                    # GLM indexer keys are uncompressed (one key per token).
+                    compression_ratio=1,
+                    num_kv_pages_per_block=_INDEXER_KERNEL_KV_PAGES_PER_BLOCK,
+                    num_queries_per_block=1,
+                )
+            elif compute_topk:
                 topk = streamindex_topk_ref(
                     q_,
                     w_,
@@ -460,6 +485,29 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
             md.cu_kv_lens,
             md.distribution,
         )
+
+
+def _fixed_stride_pages(
+    page_indices: jax.Array,
+    cu_kv_lens: jax.Array,
+    page_size: int,
+    pages_per_seq: int,
+) -> jax.Array:
+    """Repack the packed page table into the kernel's fixed-stride layout.
+
+    sglang packs seq i's pages starting at ``cu_kv_lens[i] // page_size``
+    (cu_kv_lens is page-aligned by construction); the streamindex kernel
+    indexes ``page_indices[seq_id * pages_per_seq + page_id]``. The two
+    coincide only when every sequence occupies exactly ``pages_per_seq``
+    slots (e.g. single-seq decode), so gather-repack here. Tail entries
+    beyond seq i's actual pages may alias a later sequence's pages — same
+    as the reference's ``dynamic_slice`` over the packed table — which is
+    harmless because both mask scores past ``kv_len``.
+    """
+    starts = cu_kv_lens[:-1] // page_size
+    gidx = starts[:, None] + jnp.arange(pages_per_seq)[None, :]
+    gidx = jnp.minimum(gidx, page_indices.shape[0] - 1)
+    return page_indices[gidx].reshape(-1)
 
 
 def _scatter_paged(

--- a/test/srt/kernels/dsa/test_streamindex_topk.py
+++ b/test/srt/kernels/dsa/test_streamindex_topk.py
@@ -1,0 +1,647 @@
+"""TPU tests for the vendored StreamIndex Top-K kernel.
+
+Upstream cases are ported from vllm-project/tpu-inference @ 0641d9b; the
+bf16 and packed-stride cases cover the local additions (bf16 direct-read
+cache branch, and the fixed-stride page-table repack used by
+``DSASparseAttentionBackend``).
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from sgl_jax.srt.kernels.dsa.ref import streamindex_topk_ref as jnp_topk_ref
+from sgl_jax.srt.kernels.dsa.streamindex_topk import streamindex_topk
+from sgl_jax.srt.layers.attention.dsa_sparse_backend import _fixed_stride_pages
+
+# The kernel's RefReshaper transform has no interpret-mode lowering, so these
+# tests only run on real TPU (see TPU test suite).
+if jax.default_backend() != "tpu":
+    pytest.skip("streamindex_topk kernel requires TPU", allow_module_level=True)
+
+
+# =====================================================================
+# Helper functions from the compressor implementation
+# =====================================================================
+def _to_byte_lane(x: jax.Array) -> jax.Array:
+    """Reinterpret each element of ``x``'s trailing dim as raw bytes."""
+    b = jax.lax.bitcast_convert_type(x, jnp.uint8)
+    if b.ndim > x.ndim:
+        b = b.reshape(*x.shape[:-1], -1)
+    return b
+
+
+def quantize_fp8_ue8m0(x: jax.Array, block_size: int):
+    """Block fp8 quantization with UE8M0 (power-of-two) block scales."""
+    fp8_max = float(jnp.finfo(jnp.float8_e4m3fn).max)
+    *lead, dim = x.shape
+    blocked = x.reshape(*lead, dim // block_size, block_size)
+    amax = jnp.clip(jnp.max(jnp.abs(blocked), axis=-1, keepdims=True), 1e-4, None)
+    scale = jnp.exp2(jnp.ceil(jnp.log2(amax / fp8_max)))
+    q = (blocked * (1.0 / scale)).astype(jnp.float8_e4m3fn).reshape(x.shape)
+    scale = jnp.squeeze(scale, -1).astype(jnp.float8_e8m0fnu)
+    return q, scale
+
+
+def _verify_padding_at_end(actual_topk_np):
+    """Verifies that -1 is only at the end of the innermost dimension."""
+    is_minus_one = (actual_topk_np == -1).astype(np.int32)
+    violations = np.diff(is_minus_one, axis=-1) < 0
+    assert not np.any(violations), "Padding (-1) is not at the end of the innermost dimension"
+
+
+# =====================================================================
+
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+
+def _numpy_topk_oracle(
+    q,
+    weights,
+    kv,
+    block_table,
+    T_list,
+    S_list,
+    cu_q_lens,
+    k,
+    comp_ratio,
+    H_I,
+    H_KV,
+):
+    """Naive NumPy reference implementation for StreamIndex Top-K."""
+    num_tokens = q.shape[0]
+    expected_topk = np.full((num_tokens, k), -1, dtype=np.int32)
+    B = len(T_list)
+
+    for b in range(B):
+        T_seq = T_list[b]
+        S_total = S_list[b]
+        q_start = cu_q_lens[b]
+
+        if T_seq == 0:
+            continue
+
+        S_valid = S_total // comp_ratio
+        seq_blocks = block_table[b]
+        seq_kv = np.concatenate([kv[p] for p in seq_blocks], axis=0)
+
+        naive_scores = np.full((T_seq, max(S_valid, k)), -np.inf, dtype=np.float32)
+
+        for t_idx in range(T_seq):
+            global_t = q_start + t_idx
+            q_abs_pos = (S_total - T_seq) + t_idx
+
+            for s_idx in range(S_valid):
+                if s_idx * comp_ratio > q_abs_pos:
+                    continue
+
+                score = 0.0
+                for h in range(H_I):
+                    h_kv = h // (H_I // H_KV)
+                    inner = np.dot(q[global_t, h], seq_kv[s_idx, h_kv])
+                    score += max(0.0, inner) * weights[global_t, h]
+
+                naive_scores[t_idx, s_idx] = score
+
+        seq_expected = np.argsort(-naive_scores, axis=-1)[:, :k]
+
+        for t_idx in range(T_seq):
+            for i in range(k):
+                idx = seq_expected[t_idx, i]
+                if naive_scores[t_idx, idx] == -np.inf:
+                    expected_topk[q_start + t_idx, i] = -1
+                else:
+                    expected_topk[q_start + t_idx, i] = idx
+
+    return expected_topk
+
+
+@pytest.mark.parametrize(
+    "B, num_tokens, page_size, max_blocks, H_I, H_KV, D, k, compression_ratio,"
+    " bq_sz, bkv_p, seq_lens_list, cu_q_lens_list",
+    [
+        # Small standard case
+        (2, 6, 64, 8, 4, 1, 64, 512, 2, 32, 2, [4, 6], [0, 3, 6]),
+        # # Single token batch (Decode Phase)
+        (1, 1, 128, 4, 2, 1, 32, 512, 1, 16, 1, [10], [0, 1]),
+        # Large batch, multiple tokens per sequence (Prefill Phase)
+        (
+            4,
+            20,
+            32,
+            16,
+            8,
+            1,
+            128,
+            512,
+            4,
+            64,
+            4,
+            [10, 20, 30, 40],
+            [0, 5, 10, 15, 20],
+        ),
+        # Odd chunk sizes -> Aligned
+        (2, 5, 128, 6, 4, 1, 16, 512, 1, 16, 1, [8, 12], [0, 2, 5]),
+        # Single head for KV but multiple heads for Queries (MQA/GQA pattern)
+        (2, 10, 32, 8, 8, 1, 64, 512, 2, 32, 4, [16, 24], [0, 4, 10]),
+        # # High D, High K
+        (1, 8, 32, 4, 2, 1, 256, 512, 1, 32, 4, [60], [0, 8]),
+        # Mixed batch: sequence 0 has 1 token (decode), sequence 1 has 5 tokens
+        # (prefill)
+        (2, 6, 64, 8, 4, 1, 64, 512, 2, 32, 2, [4, 6], [0, 1, 6]),
+    ],
+)
+def test_streamindex_topk_shape(
+    B,
+    num_tokens,
+    page_size,
+    max_blocks,
+    H_I,
+    H_KV,
+    D,
+    k,
+    compression_ratio,
+    bq_sz,
+    bkv_p,
+    seq_lens_list,
+    cu_q_lens_list,
+):
+    """Tests the shape and basic execution bounds of streamindex_topk."""
+    assert (page_size * bkv_p) % 128 == 0, (
+        f"bkv_sz ({page_size} * {bkv_p}) must be a multiple of 128 for TPU DMA" " alignment."
+    )
+    _ = H_KV
+    print(f"\n{'-'*60}")
+    print(f"SHAPE TEST: B={B}, Tokens={num_tokens}, k={k}")
+    print(f"{'-'*60}")
+
+    query_projection = jnp.zeros((num_tokens, H_I, D), dtype=jnp.float32)
+    indexer_weights = jnp.zeros((num_tokens, H_I), dtype=jnp.float32)
+
+    num_pages = max_blocks * B
+    q_lkv_dim = ((D + 127) // 128) * 128
+    record_width = q_lkv_dim + (q_lkv_dim // 128)
+    width = ((record_width + 127) // 128) * 128
+    kv_cache = jnp.zeros((num_pages, page_size // 4, 4, width), dtype=jnp.uint8)
+
+    block_table = jnp.zeros((B, max_blocks), dtype=jnp.int32)
+    page_indices = block_table.flatten()
+    cu_q_lens = jnp.array(cu_q_lens_list, dtype=jnp.int32)
+
+    print("Inputs:")
+    print(f"  - query_projection: {query_projection.shape}")
+    print(f"  - kv_cache:         {kv_cache.shape}")
+    print(f"  - seq_lens:         {seq_lens_list}")
+    print(f"  - cu_q_lens:        {cu_q_lens_list}")
+
+    # Count number of decode sequences (T == 1) at the beginning of the batch
+    num_decodes = 0
+    while num_decodes < B and (cu_q_lens_list[num_decodes + 1] - cu_q_lens_list[num_decodes]) == 1:
+        num_decodes += 1
+    distribution = (num_decodes, num_decodes, B)
+    expected_shape = (num_tokens, k)
+
+    seq_lens = jnp.array(seq_lens_list, dtype=jnp.int32)
+
+    out_shape_idxs = jax.eval_shape(
+        streamindex_topk,
+        query_projection,
+        indexer_weights,
+        kv_cache,
+        seq_lens,
+        page_indices,
+        cu_q_lens,
+        distribution,
+        k=k,
+        compression_ratio=compression_ratio,
+        num_kv_pages_per_block=bkv_p,
+        num_queries_per_block=bq_sz,
+    )
+
+    print("\nOutputs:")
+    print(f"  - Expected shape: {expected_shape}, dtype: int32")
+    print(f"  - Actual shape:   {out_shape_idxs.shape}, dtype:" f" {out_shape_idxs.dtype}")
+
+    assert out_shape_idxs.shape == expected_shape
+    assert out_shape_idxs.dtype == jnp.int32
+    print("Result: PASS")
+
+
+@pytest.mark.parametrize(
+    "B, T_list, S_list, page_size, H_I, H_KV, D, k, comp_ratio, bq_sz, bkv_p," " block_table_list",
+    [
+        # 1. Single sequence, highly fragmented block table
+        (1, [4], [16], 64, 4, 1, 16, 1024, 2, 8, 2, [[2, 0]]),
+        # 2. Batched Decode (T=1, B=2)
+        (2, [1, 1], [12, 16], 128, 4, 1, 16, 1024, 1, 8, 1, [[1, 3], [0, 2]]),
+        # 3. High GQA (8 Query Heads, 2 KV Heads)
+        (1, [6], [20], 64, 8, 1, 16, 1024, 1, 8, 2, [[4, 1, 3, 0, 2]]),
+        # 4. Multi-Batch Prefill with variable query/sequence lengths
+        (2, [5, 3], [16, 16], 32, 4, 1, 16, 1024, 1, 8, 4, [[3, 1], [2, 4]]),
+        # 5. Dummy sequences / Padding (B=3, but sequence 1 has 0 tokens)
+        (
+            3,
+            [2, 0, 3],
+            [16, 0, 8],
+            64,
+            4,
+            1,
+            16,
+            1024,
+            1,
+            8,
+            2,
+            [[1, 2], [0, 0], [4, 3]],
+        ),
+        # 6. Mixed batch: sequence 0 has 1 token, sequence 1 has 5 tokens
+        (2, [1, 5], [12, 16], 64, 4, 1, 16, 1024, 2, 8, 2, [[1, 3], [2, 0]]),
+    ],
+)
+def test_streamindex_topk_numerical_correctness(
+    B,
+    T_list,
+    S_list,
+    page_size,
+    H_I,
+    H_KV,
+    D,
+    k,
+    comp_ratio,
+    bq_sz,
+    bkv_p,
+    block_table_list,
+):
+    """Executes randomized input data against a naive NumPy ground truth."""
+    assert (page_size * bkv_p) % 128 == 0, (
+        f"bkv_sz ({page_size} * {bkv_p}) must be a multiple of 128 for TPU DMA" " alignment."
+    )
+    print(f"\n{'='*60}")
+    print(f"BATCHED NUMERICAL TEST (B={B})")
+    print(f"{'='*60}")
+
+    np.random.seed(42)
+
+    # 1. Setup Random Tensors
+    num_tokens = sum(T_list)
+    q = np.random.randn(num_tokens, H_I, D).astype(np.float32)
+    weights = np.random.uniform(-1.5, 1.5, size=(num_tokens, H_I)).astype(np.float32)
+
+    # Create a unified physical KV Cache pool large enough for all block indices
+    max_physical_page = np.max(block_table_list)
+    float32_kv = np.random.randn(max_physical_page + 1, page_size, H_KV, D).astype(np.float32)
+
+    # Pack cache using compressor's quantize_fp8_ue8m0 and _to_byte_lane
+    q_lkv_dim = ((D + 127) // 128) * 128
+    record_width = q_lkv_dim + (q_lkv_dim // 128)
+    width = ((record_width + 127) // 128) * 128
+
+    cache_kv = np.zeros((max_physical_page + 1, page_size // 4, 4, width), dtype=np.uint8)
+    dequantized_kv = np.zeros_like(float32_kv)
+
+    for p in range(max_physical_page + 1):
+        for s in range(page_size):
+            for h in range(H_KV):
+                row_kv = float32_kv[p, s, h]
+                # Quantize using D as block size (each head query key has dimension D)
+                q_jax, scale_jax = quantize_fp8_ue8m0(jnp.array(row_kv), D)
+                q_bytes = np.array(_to_byte_lane(q_jax))
+                scale_bytes = np.array(_to_byte_lane(scale_jax))
+                dq = np.array(q_jax).astype(np.float32)
+                dequantized_kv[p, s, h] = dq * float(scale_jax[0])
+                record = np.concatenate([q_bytes, scale_bytes], axis=-1)
+                record = np.pad(record, (0, width - record.shape[-1]))
+
+                w_idx = s // 4
+                lane_idx = s % 4
+                cache_kv[p, w_idx, lane_idx] = record
+
+    block_table = np.array(block_table_list, dtype=np.int32)
+    page_indices = block_table.flatten()
+    seq_lens = np.array(S_list, dtype=np.int32)
+    cu_q_lens = np.concatenate([[0], np.cumsum(T_list)]).astype(np.int32)
+
+    print("Configuration:")
+    print(f"  - Tokens total: {num_tokens}, Sequences(B): {B}, K: {k}")
+    print(f"  - GQA: {H_I} Query Heads -> {H_KV} KV Heads")
+    print(f"  - Compression Ratio: {comp_ratio}")
+
+    print("\nInputs Generated:")
+    print(f"  - Query Tensor: {q.shape}")
+    print(f"  - KV Cache:     {cache_kv.shape}")
+    print(f"  - Block Table:  {block_table.tolist()}")
+
+    # =====================================================================
+    # 2. NAIVE COMPUTATION (The Ground Truth)
+    # =====================================================================
+    print("\n[1/3] Computing exact ground-truth using naive NumPy loops...")
+    expected_topk = _numpy_topk_oracle(
+        q=q,
+        weights=weights,
+        kv=dequantized_kv,
+        block_table=block_table,
+        T_list=T_list,
+        S_list=S_list,
+        cu_q_lens=cu_q_lens,
+        k=k,
+        comp_ratio=comp_ratio,
+        H_I=H_I,
+        H_KV=H_KV,
+    )
+
+    print("\nGROUND TRUTH (Naive NumPy):")
+    print(expected_topk)
+
+    # =====================================================================
+    # 3. Pallas KERNEL COMPUTATION
+    # =====================================================================
+    print("\n[2/3] Executing optimized JAX Kernel (streamindex_pallas_topk)...")
+    # Count number of decode sequences (T == 1) at the beginning of the batch
+    num_decodes = 0
+    while num_decodes < B and T_list[num_decodes] == 1:
+        num_decodes += 1
+    distribution = (num_decodes, num_decodes, B)
+
+    actual_topk = streamindex_topk(
+        q=jnp.array(q),
+        indexer_weights=jnp.array(weights),
+        cache_kv=jnp.array(cache_kv),
+        seq_lens=jnp.array(seq_lens),
+        page_indices=jnp.array(page_indices),
+        cu_q_lens=jnp.array(cu_q_lens),
+        distribution=distribution,
+        k=k,
+        compression_ratio=comp_ratio,
+        num_kv_pages_per_block=bkv_p,
+        num_queries_per_block=bq_sz,
+    )
+
+    actual_topk_np = np.array(actual_topk)
+    _verify_padding_at_end(actual_topk_np)
+
+    print("\nACTUAL OUTPUT (JAX/XLA Kernel):")
+    print(actual_topk_np)
+
+    # =====================================================================
+    # 4. VERIFY
+    # =====================================================================
+    print("\n[3/3] Verifying absolute correctness...")
+    np.testing.assert_array_equal(
+        np.sort(actual_topk_np, axis=-1),
+        np.sort(expected_topk, axis=-1),
+        err_msg="JAX Pallas Kernel Top-K math did not match Naive Ground Truth",
+    )
+    print("MATCH VERIFIED! JAX kernel handles batches, fragmentation, and dummy" " padding.\n")
+
+
+def test_streamindex_topk_quantized():
+    """Verifies correctness of streamindex_topk on FP8 packed cache."""
+    np.random.seed(42)
+
+    T_seq = 4
+    S_seq = 512
+    page_size = 128
+    H_I = 2
+    H_KV = 1
+    D = 128
+    k = 512
+    comp_ratio = 4
+    bkv_p = 1
+    bq_sz = 1
+
+    q = np.random.randn(T_seq, H_I, D).astype(np.float32)
+    weights = np.random.uniform(0.5, 1.5, size=(T_seq, H_I)).astype(np.float32)
+
+    S_valid = S_seq // comp_ratio
+    # We need enough pages to hold S_valid compressed tokens.
+    num_pages = (S_valid + page_size - 1) // page_size
+    float32_kv = np.random.randn(num_pages, page_size, H_KV, D).astype(np.float32)
+
+    # Pack cache using compressor's quantize_fp8_ue8m0 and _to_byte_lane
+    width = 256
+    cache_kv = np.zeros((num_pages, page_size // 4, 4, width), dtype=np.uint8)
+
+    # Dequantized KV for naive ground truth
+    dequantized_kv = np.zeros_like(float32_kv)
+
+    for p in range(num_pages):
+        for s in range(page_size):
+            for h_kv in range(H_KV):
+                row_kv = float32_kv[p, s, h_kv]
+
+                # Quantize using compressor helper
+                # block_size = 128 since we want 1 scale factor for D=128
+                q_jax, scale_jax = quantize_fp8_ue8m0(jnp.array(row_kv), 128)
+
+                # Convert to bytes
+                q_bytes = np.array(_to_byte_lane(q_jax))
+                scale_bytes = np.array(_to_byte_lane(scale_jax))
+
+                # Store dequantized version exactly as hardware sees it for accurate
+                # validation
+                dq = np.array(q_jax).astype(np.float32)
+                dequantized_kv[p, s, h_kv] = dq * float(scale_jax[0])
+
+                record = np.concatenate([q_bytes, scale_bytes], axis=-1)
+                record = np.pad(record, (0, width - record.shape[-1]))
+
+                w_idx = s // 4
+                lane_idx = s % 4
+                cache_kv[p, w_idx, lane_idx] = record
+
+    # Compute expected top-k using exact dequantized keys
+    seq_kv = np.concatenate([dequantized_kv[p] for p in range(num_pages)], axis=0)
+
+    naive_scores = np.full((T_seq, max(S_valid, k)), -np.inf, dtype=np.float32)
+
+    for t_idx in range(T_seq):
+        for s_idx in range(S_valid):
+            score = 0.0
+            for h in range(H_I):
+                h_kv = h // (H_I // H_KV)
+                inner = np.dot(q[t_idx, h], seq_kv[s_idx, h_kv])
+                score += max(0.0, inner) * weights[t_idx, h]
+            naive_scores[t_idx, s_idx] = score
+
+    expected_topk = np.argsort(-naive_scores, axis=-1)[:, :k]
+    for t_idx in range(T_seq):
+        for i in range(k):
+            idx = expected_topk[t_idx, i]
+            if naive_scores[t_idx, idx] == -np.inf:
+                expected_topk[t_idx, i] = -1
+
+    # Pallas parameters
+    actual_topk = streamindex_topk(
+        q=jnp.array(q),
+        indexer_weights=jnp.array(weights),
+        cache_kv=jnp.array(cache_kv),
+        seq_lens=jnp.array([S_seq], dtype=jnp.int32),
+        page_indices=jnp.arange(num_pages, dtype=jnp.int32),
+        cu_q_lens=jnp.array([0, T_seq], dtype=jnp.int32),
+        distribution=jnp.array([0, 0, 1], dtype=jnp.int32),
+        k=k,
+        compression_ratio=comp_ratio,
+        num_kv_pages_per_block=bkv_p,
+        num_queries_per_block=bq_sz,
+    )
+
+    actual_topk_np = np.array(actual_topk)
+    _verify_padding_at_end(actual_topk_np)
+
+    np.testing.assert_array_equal(
+        np.sort(actual_topk_np, axis=-1),
+        np.sort(expected_topk, axis=-1),
+    )
+
+
+# =====================================================================
+# Local additions: bf16 direct-read branch + packed-stride wiring
+# =====================================================================
+
+
+def _build_bf16_case(T_list, S_list, page_size, H, D, num_pages, seed):
+    """Random decode/prefill batch over a bf16 (unquantized) indexer cache."""
+    rng = np.random.default_rng(seed)
+    B = len(S_list)
+    pps = max(-(-s // page_size) for s in S_list) + 1
+    total_pages_needed = B * pps
+    assert num_pages >= total_pages_needed + 1
+    perm = rng.permutation(num_pages - 1)[:total_pages_needed] + 1
+    block_table = perm.reshape(B, pps).astype(np.int32)
+
+    T = sum(T_list)
+    q = rng.standard_normal((T, H, D), dtype=np.float32)
+    w = rng.standard_normal((T, H), dtype=np.float32)
+    keys = rng.standard_normal((num_pages * page_size, D), dtype=np.float32)
+    keys_bf16 = jnp.asarray(keys, jnp.bfloat16).reshape(num_pages, page_size, D)
+
+    cu_q = np.concatenate([[0], np.cumsum(T_list)]).astype(np.int32)
+    nd = 0
+    while nd < B and T_list[nd] == 1:
+        nd += 1
+    return dict(
+        q=jnp.asarray(q, jnp.bfloat16),
+        w=jnp.asarray(w),
+        cache4d=keys_bf16.reshape(num_pages, page_size // 2, 2, D),
+        cache3d=keys_bf16,
+        block_table=block_table,
+        seq_lens=jnp.asarray(np.array(S_list, np.int32)),
+        cu_q=jnp.asarray(cu_q),
+        dist=jnp.asarray((nd, nd, B), jnp.int32),
+        pps=pps,
+    )
+
+
+@pytest.mark.parametrize(
+    "T_list, S_list, k",
+    [
+        ([1], [900], 128),  # single-seq decode
+        ([1, 1, 1], [40, 700, 260], 128),  # batched decode, uneven lens
+        ([4, 2], [500, 300], 128),  # prefill chunks
+    ],
+)
+def test_streamindex_topk_bf16_matches_oracle(T_list, S_list, k):
+    """bf16 direct-read kernel vs an exact fp32 numpy oracle.
+
+    The jnp reference is itself approximate (approx_max_k), so the kernel is
+    checked against exact scoring + argsort instead of implementation-vs-
+    implementation set overlap.
+    """
+    page_size = 64
+    H, D = 32, 128
+    c = _build_bf16_case(T_list, S_list, page_size, H, D, num_pages=64, seed=0)
+    B = len(S_list)
+
+    got = streamindex_topk(
+        q=c["q"],
+        indexer_weights=c["w"],
+        cache_kv=c["cache4d"],
+        seq_lens=c["seq_lens"],
+        page_indices=jnp.asarray(c["block_table"].flatten()),
+        cu_q_lens=c["cu_q"],
+        distribution=c["dist"],
+        k=k,
+        compression_ratio=1,
+        num_kv_pages_per_block=2,
+        num_queries_per_block=8,
+    )
+    got = np.asarray(jax.block_until_ready(got))
+    _verify_padding_at_end(got)
+
+    keys = np.asarray(c["cache3d"].astype(jnp.float32))
+    qf = np.asarray(c["q"].astype(jnp.float32))
+    wf = np.asarray(c["w"])
+    cu_q = np.asarray(c["cu_q"])
+    for b in range(B):
+        kv = keys[c["block_table"][b]].reshape(-1, D)[: S_list[b]]
+        for t in range(T_list[b]):
+            row = cu_q[b] + t
+            causal_end = (S_list[b] - T_list[b]) + t + 1
+            s = np.einsum("hd,sd->hs", qf[row], kv[:causal_end])
+            scores = np.einsum("h,hs->s", wf[row], np.maximum(s, 0.0))
+            n = min(k, causal_end)
+            want = set(np.argsort(-scores)[:n].tolist())
+            g = set(got[row][got[row] >= 0].tolist())
+            inter = len(g & want)
+            assert (
+                inter / len(want) >= 0.99
+            ), f"row {row}: only {inter}/{len(want)} topk overlap vs oracle"
+
+
+def test_fixed_stride_pages_repack_multi_seq():
+    """Packed variable-stride page table -> kernel parity on a multi-seq batch.
+
+    sglang packs seq i's pages at ``cu_kv_lens[i] // page_size``; with unequal
+    sequence lengths this differs from the kernel's fixed stride, so a decode
+    batch with B>=2 uneven lens exercises the repack (a single-seq batch would
+    pass even without it).
+    """
+    page_size = 64
+    H, D, k = 32, 128, 128
+    S_list = [70, 900, 260]
+    T_list = [1, 1, 1]
+    c = _build_bf16_case(T_list, S_list, page_size, H, D, num_pages=64, seed=1)
+    B = len(S_list)
+    pps = c["pps"]
+
+    # Build the packed layout: seq i occupies ceil(S_i/page) slots starting at
+    # cu_kv_lens[i] // page_size, in a buffer of size B * pps.
+    pages_needed = [-(-s // page_size) for s in S_list]
+    cu_kv = np.zeros(B + 1, np.int32)
+    for i in range(B):
+        cu_kv[i + 1] = cu_kv[i] + pages_needed[i] * page_size
+    packed = np.zeros(B * pps, np.int32)
+    for i in range(B):
+        start = cu_kv[i] // page_size
+        packed[start : start + pages_needed[i]] = c["block_table"][i, : pages_needed[i]]
+    packed = jnp.asarray(packed)
+
+    fixed = _fixed_stride_pages(packed, jnp.asarray(cu_kv), page_size, pps)
+    got = streamindex_topk(
+        q=c["q"],
+        indexer_weights=c["w"],
+        cache_kv=c["cache4d"],
+        seq_lens=c["seq_lens"],
+        page_indices=fixed,
+        cu_q_lens=c["cu_q"],
+        distribution=c["dist"],
+        k=k,
+        compression_ratio=1,
+        num_kv_pages_per_block=2,
+        num_queries_per_block=1,
+    )
+    got = np.asarray(jax.block_until_ready(got))
+    _verify_padding_at_end(got)
+
+    # Oracle: score directly against each seq's true pages.
+    keys = np.asarray(c["cache3d"].astype(jnp.float32))
+    qf = np.asarray(c["q"].astype(jnp.float32))
+    wf = np.asarray(c["w"])
+    for i in range(B):
+        kv = keys[c["block_table"][i]].reshape(-1, D)[: S_list[i]]
+        s = np.einsum("hd,sd->hs", qf[i], kv)
+        scores = np.einsum("h,hs->s", wf[i], np.maximum(s, 0.0))
+        want = set(np.argsort(-scores)[: min(k, S_list[i])].tolist())
+        g = set(got[i][got[i] >= 0].tolist())
+        inter = len(g & want)
+        assert inter / len(want) >= 0.99, f"seq {i}: {inter}/{len(want)}"

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -280,6 +280,7 @@ suites = {
         TestFile("test/srt/lora/test_align_lora_accuracy.py", 5.5),
         TestFile("python/sgl_jax/test/kernels/simple_gla_fused_test.py", 1, runner="pytest"),
         TestFile("python/sgl_jax/test/layers/test_merged_column_parallel_linear.py", 0.1),
+        TestFile("test/srt/kernels/dsa/test_streamindex_topk.py", 3, runner="pytest"),
     ],
     # CPU-only unit tests — moved off arc-runner-v6e-1 to a dedicated
     # CPU runner so they don't consume TPU capacity. Either pure


### PR DESCRIPTION
### Motivation

The DSA lightning-indexer top-k currently runs on a jnp reference (`streamindex_topk_ref`) that gathers the full padded page table per sequence — O(max_ctx) HBM reads per step regardless of actual context. This PR wires in the Pallas `streamindex_topk` kernel from `vllm-project/tpu-inference` as an **opt-in** replacement (default **off**), which reads only O(actual kv_len) pages and batches decode requests.

Follow-up to the feasibility work discussed in #1508 (comment): kernel correctness and GLM-shape performance were validated on v7x and v6e prior to this integration.

### What's in this PR

- **Commit 1 — re-vendor** `kernels/dsa/streamindex_topk.py` from tpu-inference @ `0641d9b` (scores-in-HBM + external `approx_max_k` + decode request batching). The previously vendored revision does in-kernel top-k, which at k=2048 compiles ~60s/shape and runs ~4x slower; it had no callers. Local modification: `load_bkv` gains a static dtype branch so one kernel serves both the DSv4 packed-FP8 cache format and an unquantized **bf16 cache read directly** (zero layout change — sglang's `indexer_key_buffer` `[P, page/2, 2, 128]` is already the kernel's expected layout).
- **Commit 2 — wiring**: `DSASparseAttentionBackend._maybe_index` calls the kernel instead of `streamindex_topk_ref` when `DSA_INDEXER_KERNEL=1` (env opt-in, same pattern as `DSA_PAGE_TOPK`, which takes precedence if both are set). The packed variable-stride page table is gather-repacked to the kernel's fixed stride per call (int32 gather, negligible). Scoring semantics are identical (`sum_h relu(q·k)·w_h`, `approx_max_k`, `-1` padding).
- **Commit 3 — tests**: 14 upstream cases (fp8-packed path) + bf16-vs-exact-oracle cases (decode single/multi-seq uneven lengths, prefill chunks) + a packed-stride repack case (B=3 uneven decode — the scenario where fixed-stride and packed layouts diverge). Registered in `unit-test-tpu-v6e-1`. TPU-gated: the kernel's RefReshaper transform has no interpret lowering.

### Correctness

- Unit: **18/18 pass** on v6e.
- e2e GSM8K (200q, 5-shot, temp 0, quick-test harness — same harness both sides): kernel ON **0.965** vs OFF **0.955**, Invalid 0 both. Within noise; no regression.

### Performance (e2e, GLM-5.2 tp16 on TPU v7x, w8a8, ctx 135168, dsa_sparse; ×2 runs, two seeds)

| metric | kernel ON | ref OFF | delta |
|---|---|---|---|
| decode TPOT @ cc=8 (1K in / 256 out) | 44.5 / 44.4 ms | 53.1 / 53.1 ms | **1.20x faster** |
| output throughput @ cc=8 | 162.7 / 163.1 tok/s | 138.5 / 138.4 tok/s | **+17.6%** |
| decode TPOT @ cc=64 (256 prompts) | 215.1 / 213.7 ms | 274.0 / 273.7 ms | **1.28x faster** |
| decode TPOT @ cc=1 | 34.2 ms | 15.9 ms | 2.1x slower |
| decode TPOT @ cc=1, 55K / 110K ctx | 40.6 / 43.0 ms | 24.5 / 25.5 ms | ~1.7x slower |

Notes:
- cc=64 output-throughput has ±23% run-to-run variance from prefill/scheduling interleave; TPOT is stable (<1%) on both sides, so TPOT is the reported metric.
- The single-stream loss is a constant ~17-18ms/step independent of context (1K → 110K), i.e. a fixed per-call overhead across the ~22 full-indexer layers, not an algorithmic/bandwidth effect. This is why the flag is opt-in and default off: enable it for high-concurrency serving; leave it off for single-stream.
- Planned follow-ups that address the fixed overhead and extend the win: fp8-packed cache path (quantize at cache-write; halves kernel read bytes — the packed-fp8 kernel variant was uniformly faster in microbenches), block-size tuning for small batches, and an optional scores output for the `DSA_PAGE_TOPK` page-scoring path.

### Test plan

- [x] `test/srt/kernels/dsa/test_streamindex_topk.py` 18/18 on TPU (registered in `unit-test-tpu-v6e-1`)
- [x] GSM8K on/off comparison, same server config (0.965 vs 0.955, Invalid 0)
- [x] cc=1/8/64 throughput/TPOT on/off, ×2 runs, two seeds
- [x] Long-context (55K / 110K) decode on/off
- [x] Default-off path unchanged: with the flag unset, `_maybe_index` executes the exact previous reference path (`DSA_PAGE_TOPK` precedence preserved)
- [x] pre-commit clean
