### PR TITLE
fix(quant): close static-FP8 kernel gaps — gmm_v2 W8A8+block-wise rhs_scale, v7x dense tuned tiles, fused_v2 MoE scale sharding

### DIFF
--- a/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/gmm_v2.py
+++ b/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/gmm_v2.py
@@ -239,7 +239,8 @@ def inner_kernel(
                         tiled_rhs[start_k:end_k, :],
                         preferred_element_type=jnp.float32,
                     ).astype(acc_ref.dtype)
-                    acc += block_acc * tiled_rhs_ref.scale[blk_i, 0, :].astype(acc_ref.dtype)
+                    # Keep the scale slice 2D [1, tile_n] for strict rank promotion.
+                    acc += block_acc * tiled_rhs_ref.scale[blk_i, 0:1, :].astype(acc_ref.dtype)
             else:
                 # Unquantized matmul path.
                 acc = jnp.matmul(
@@ -299,7 +300,16 @@ def inner_kernel(
                         preferred_element_type=preferred_element_type,
                     ).astype(acc_ref.dtype)
 
-                    acc_n += block_acc * block_scale.astype(acc_ref.dtype)
+                    block_acc = block_acc * block_scale.astype(acc_ref.dtype)
+                    if is_block_rhs_scale:
+                        # W8A8 block-wise rhs_scale: q_block_size == rhs_block
+                        # (enforced in make_gmm_configs), so this K block maps
+                        # 1:1 onto rhs scale row start_k // rhs_block. Keep the
+                        # slice 2D [1, col] for strict rank promotion.
+                        block_acc = block_acc * tiled_rhs_ref.scale[
+                            start_k // rhs_block, 0:1, start_n:end_n
+                        ].astype(acc_ref.dtype)
+                    acc_n += block_acc
 
                 acc_list.append(acc_n)
             acc = jnp.concatenate(acc_list, axis=1)
@@ -845,19 +855,20 @@ def make_gmm_configs(
             if tpu_info.int8_ops_per_second > 0:
                 lhs_q_dtype = jnp.int8.dtype
 
-    if lhs_q_dtype is not None and rhs_scale is not None and rhs_scale.shape[1] > 1:
-        raise NotImplementedError(
-            "gmm_v2 block-wise rhs_scale + lhs activation quant not yet supported; "
-            "pass maybe_quantize_lhs=False for W8A16."
-        )
+    # Default lhs quantization block: input quantization involves reading all
+    # elements in a block to compute the scale value. Since this operation is
+    # very memory intensive, we use a block size that is small enough to
+    # minimize memory overhead but large enough to minimize compute overhead.
+    lhs_quant_block_size = 512
+    if lhs_q_dtype is not None and block_size is not None and block_size < dims.size_k:
+        # W8A8 + block-wise rhs_scale: each K block's partial product must be
+        # rescaled by its own rhs scale before accumulation, so the lhs quant
+        # granularity must match the rhs block grid exactly.
+        lhs_quant_block_size = block_size
 
     lhs_cfgs = InputConfigs(
         quant_dtype=lhs_q_dtype,
-        # Input quantization involves reading all elements in a block to compute
-        # scale value. Since this operation is very memory intensive, we use a
-        # block size that is small enough to minimize memory overhead but large
-        # enough to minimize compute overhead of quantization.
-        quant_block_size=512,
+        quant_block_size=lhs_quant_block_size,
     )
 
     if out_dtype is None:
@@ -1071,11 +1082,8 @@ def is_supported_by_gmm_v2(
 ) -> bool:
     if rhs_scale is None:
         return True
-    if rhs_scale.ndim != 4:
-        return False
-    if rhs_scale.shape[1] == 1:
-        return True
-    # Block-wise rhs_scale (k_blocks > 1) is only implemented for the W8A16
-    # path (no lhs activation quant). Route W8A8 + block-scale to gmm_v1,
-    # which supports it via pre-quantized lhs in the backend.
-    return not maybe_quantize_lhs
+    # Per-channel (k_blocks == 1) and block-wise (k_blocks > 1) rhs_scale are
+    # both supported, with and without lhs activation quant. The W8A8 +
+    # block-scale path rescales each K block's partial product by its own rhs
+    # scale inside the quantized matmul loop.
+    return rhs_scale.ndim == 4

--- a/python/sgl_jax/srt/kernels/quantized_matmul/quantized_matmul_kernels/tuned_block_sizes.py
+++ b/python/sgl_jax/srt/kernels/quantized_matmul/quantized_matmul_kernels/tuned_block_sizes.py
@@ -640,6 +640,44 @@ TUNED_BLOCK_SIZES_RAW = {
     (7, 8192, 5120, 8192, "float8_e4m3fn", "float8_e4m3fn"): (512, 5120, 2048),
     (7, 8192, 8192, 14336, "float8_e4m3fn", "float8_e4m3fn"): (1024, 4096, 1024),
     (7, 8192, 8192, 4096, "float8_e4m3fn", "float8_e4m3fn"): (1024, 2048, 4096),
+    # ===== GLM-5.2 on TPU v7x tp16 (per-device dense linear shapes: MLA
+    # q_a/q_b/kv_a/o_proj, dense-layer MLP, shared experts, indexer).
+    # Tiles are chosen to divide the operand dims exactly (no jnp.pad on
+    # the way into the kernel) with whole-K in_block where VMEM allows;
+    # out_block must stay a multiple of the 256-lane MXU column. Validated
+    # on v7x 2026-08-09. n_out=128 shapes keep the fallback path.
+    (7, 1, 2048, 6144, "bfloat16", "float8_e4m3fn"): (1, 2048, 2048),
+    (7, 8, 2048, 6144, "bfloat16", "float8_e4m3fn"): (8, 2048, 2048),
+    (7, 32, 2048, 6144, "bfloat16", "float8_e4m3fn"): (32, 2048, 2048),
+    (7, 64, 2048, 6144, "bfloat16", "float8_e4m3fn"): (64, 2048, 2048),
+    (7, 1, 1024, 2048, "bfloat16", "float8_e4m3fn"): (1, 1024, 2048),
+    (7, 8, 1024, 2048, "bfloat16", "float8_e4m3fn"): (8, 1024, 2048),
+    (7, 32, 1024, 2048, "bfloat16", "float8_e4m3fn"): (32, 1024, 2048),
+    (7, 64, 1024, 2048, "bfloat16", "float8_e4m3fn"): (64, 1024, 2048),
+    (7, 1, 576, 6144, "bfloat16", "float8_e4m3fn"): (1, 256, 2048),
+    (7, 8, 576, 6144, "bfloat16", "float8_e4m3fn"): (8, 256, 2048),
+    (7, 32, 576, 6144, "bfloat16", "float8_e4m3fn"): (32, 256, 2048),
+    (7, 64, 576, 6144, "bfloat16", "float8_e4m3fn"): (64, 256, 2048),
+    (7, 1, 6144, 1024, "bfloat16", "float8_e4m3fn"): (1, 2048, 1024),
+    (7, 8, 6144, 1024, "bfloat16", "float8_e4m3fn"): (8, 2048, 1024),
+    (7, 32, 6144, 1024, "bfloat16", "float8_e4m3fn"): (32, 2048, 1024),
+    (7, 64, 6144, 1024, "bfloat16", "float8_e4m3fn"): (64, 2048, 1024),
+    (7, 1, 6144, 128, "bfloat16", "float8_e4m3fn"): (1, 2048, 128),
+    (7, 8, 6144, 128, "bfloat16", "float8_e4m3fn"): (8, 2048, 128),
+    (7, 32, 6144, 128, "bfloat16", "float8_e4m3fn"): (32, 2048, 128),
+    (7, 64, 6144, 128, "bfloat16", "float8_e4m3fn"): (64, 2048, 128),
+    (7, 1, 768, 6144, "bfloat16", "float8_e4m3fn"): (1, 768, 2048),
+    (7, 8, 768, 6144, "bfloat16", "float8_e4m3fn"): (8, 768, 2048),
+    (7, 32, 768, 6144, "bfloat16", "float8_e4m3fn"): (32, 768, 2048),
+    (7, 64, 768, 6144, "bfloat16", "float8_e4m3fn"): (64, 768, 2048),
+    (7, 1, 6144, 768, "bfloat16", "float8_e4m3fn"): (1, 2048, 768),
+    (7, 8, 6144, 768, "bfloat16", "float8_e4m3fn"): (8, 2048, 768),
+    (7, 32, 6144, 768, "bfloat16", "float8_e4m3fn"): (32, 2048, 768),
+    (7, 64, 6144, 768, "bfloat16", "float8_e4m3fn"): (64, 2048, 768),
+    (7, 1, 4096, 2048, "bfloat16", "float8_e4m3fn"): (1, 2048, 2048),
+    (7, 8, 4096, 2048, "bfloat16", "float8_e4m3fn"): (8, 2048, 2048),
+    (7, 32, 4096, 2048, "bfloat16", "float8_e4m3fn"): (32, 2048, 2048),
+    (7, 64, 4096, 2048, "bfloat16", "float8_e4m3fn"): (64, 2048, 2048),
     # go/keep-sorted end
 }
 

--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -1307,9 +1307,14 @@ class Glm5ForCausalLM(nnx.Module):
                     # and replicated on the block dims (matches deepseek_v3); the
                     # loader's _maybe_convert_epmoe_scale_for_kernel handles the
                     # [E, out_blocks, k_blocks] → [E, k_blocks, 1, n_out] expand.
+                    # The expert-dim spec must follow the weight mapping's:
+                    # epmoe loads on the ("expert","tensor") moe_mesh, but
+                    # fused/fused_v2 run shard_map on the main mesh with
+                    # P(("data","tensor")) — a hardcoded "expert" here makes
+                    # shard_map reject the scale under fused_v2 static FP8.
                     new_moe_mappings[scale_key] = WeightMapping(
                         target_path=[target_scale_param] + scale_src_paths,
-                        sharding=("expert", None, None),
+                        sharding=(mapping.sharding[0], None, None),
                         transpose=False,
                         concat_axis=mapping.concat_axis,
                         physical_to_logical_map=mapping.physical_to_logical_map,

--- a/python/sgl_jax/test/kernels/gmm_test.py
+++ b/python/sgl_jax/test/kernels/gmm_test.py
@@ -332,6 +332,7 @@ class GmmTest(jtu.JaxTestCase):
         num_groups=[16, 32],
         weight_dtype=[jnp.int8, jnp.float8_e4m3fn],
         group_offset=[0, 2, 3],
+        block_size=[128, None],
     )
     def test_gmm_v2_activation_weight_quantized(
         self,
@@ -341,9 +342,12 @@ class GmmTest(jtu.JaxTestCase):
         num_groups,
         weight_dtype,
         group_offset,
+        block_size,
     ):
-        # TODO(kyuyeunk, wenxindong): Add subchannel quantization on gmm_v2.
-        block_size = in_size
+        # block_size=None -> per-channel; block_size=128 -> sub-channel
+        # (W8A8 + block-wise rhs_scale, e.g. DeepSeek/GLM static FP8 ckpts).
+        if block_size is None:
+            block_size = in_size
         num_local_groups = num_groups - group_offset
         key = jax.random.key(0)
 
@@ -371,7 +375,12 @@ class GmmTest(jtu.JaxTestCase):
             maybe_quantize_lhs=True,
         ).astype(lhs.dtype)
 
-        self.assertArraysAllClose(actual, expected, atol=1.1, rtol=1.1)
+        # Sub-channel accumulates per-K-block partials in bf16 with a rescale
+        # between blocks, which reorders roundings vs the f32 reference; the
+        # per-channel tolerance leaves single-element margin violations
+        # (~1e-5 of elements) on v7x, so allow slightly more slack there.
+        tol = 1.5 if block_size < in_size else 1.1
+        self.assertArraysAllClose(actual, expected, atol=tol, rtol=tol)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Serving block-wise static FP8 checkpoints (`weight_block_size=[128,128]`, e.g. GLM-5.2-FP8 / DeepSeek-style) currently hits three gaps:

1. **MoE routed experts fall back to gmm_v1.** `is_supported_by_gmm_v2` rejects W8A8 + block-wise `rhs_scale` (k_blocks > 1), so the static-FP8 MoE path (activation quant enabled from `activation_scheme: dynamic`) drops to gmm_v1 with 128-row alignment — at decode bs=1 that pads 8 topk rows to 128 (16× wasted work) plus extra pad ops.
2. **Dense block-wise `quantized_matmul` has no v7x tuned tiles for GLM-5.2 shapes.** All 469 dense-linear kernel calls per decode step (78 layers × MLA q_a/q_b/kv_a/o_proj, dense-layer MLP, shared experts, indexer) run on clamped fallback tiles: 2.49 ms/step vs ~0.5 ms of pure HBM time.
3. **`moe_backend=fused_v2` + static FP8 crashes at warmup.** The GLM-5 static scale weight-mappings hardcode `sharding=("expert", None, None)` (the epmoe `("expert","tensor")` moe_mesh convention), while fused/fused_v2 run shard_map on the main mesh with `P(("data","tensor"))`:
   ```
   ValueError: in_specs passed to shard_map: P(('data', 'tensor'), None, None, None) does not
   match the specs of the input: P('expert', None, None, None) for arg: float32[256@expert,48,1,2048]
   ```

### Changes

- **`gmm_v2.py`** — support W8A8 + block-wise `rhs_scale` (sub-channel):
  - When the rhs is block-quantized, align the in-kernel lhs activation-quant block to the rhs quant block, and rescale each K block's partial product by its own rhs scale inside the quantized matmul loop (per-token lhs scale × per-block rhs scale, same structure as the existing per-channel path).
  - Remove the W8A8+block-scale rejection from `is_supported_by_gmm_v2`.
  - Keep the W8A16 block-scale slice 2D (`[blk, 0:1, :]`) — the previous 1D slice trips `jax_numpy_rank_promotion='raise'` (latent; surfaces on v7x where int8 rhs has no hardware dot support and W8A8 requests degrade to this W8A16 path).
- **`tuned_block_sizes.py`** — add TPU v7 entries for GLM-5.2 tp16 per-device dense shapes (n_batch 1/8/32/64 × 8 shapes). Tiles are chosen to divide the operand dims exactly so the kernel wrapper does no out-of-kernel `jnp.pad`, with whole-K `in_block` where VMEM allows; `out_block` stays a multiple of the 256-lane MXU column (n_out=576 uses 256 with minimal padding). Each entry compile/run-validated on v7x.
- **`glm5_moe.py`** — static-FP8 MoE scale mappings inherit the expert-dim spec from the weight mapping (`mapping.sharding[0]`) instead of hardcoding `"expert"`, so epmoe keeps the moe_mesh layout and fused/fused_v2 get the main-mesh layout.
- **`gmm_test.py`** — parameterize `test_gmm_v2_activation_weight_quantized` with `block_size=[128, None]` (resolves the in-code TODO for sub-channel coverage) and relax tolerance slightly for the sub-channel combos (bf16 per-K-block rescale reorders roundings vs the f32 reference; single-element margin violations otherwise).

### Why not tune-and-keep gmm_v1?

gmm_v2's 32-row alignment vs gmm_v1's 128 is structural at decode (topk rows ≪ 128), and v2 already owns the per-channel W8A8 path; extending it to sub-channel keeps one code path for all static-FP8 checkpoints.

## Results

GLM-5.2-FP8 (block-wise static, 753B) on TPU v7x, 16 chips / 2 hosts, tp16/ep16, `dsa_sparse` attention, epmoe backend, 1K-context single-stream decode (differential TPOT (t600−t100)/500, ×2 runs, <0.1% variance):

| config | decode TPOT | dense qmm / step | MoE / step |
|---|---|---|---|
| static FP8, before | 17.52 ms | 2.49 ms | gmm_v1 1.21 ms + pad |
| static FP8, **this PR** | **14.00 ms** | **1.19 ms** | **gmm_v2 1.00 ms** |
| W8A8 dynamic quant (BF16 ckpt), same commit | 14.05 ms | — | gmm_v2 (per-channel) |

Static FP8 now matches the dynamic-quant W8A8 baseline while skipping the per-step activation amax (~1.7 ms at these shapes, already included above) and staying deterministic. XProf per-step device module: 13.88 ms vs 14.39 ms (W8A8).

Concurrency sanity: cc=8 steady decode 213 tok/s (pre-PR: 200 tok/s) — no regression.

## Test plan

- [x] `pytest python/sgl_jax/test/kernels/gmm_test.py -k gmm_v2_activation` on v7x: 96/96 pass (int8/fp8 × per-channel/sub-channel × group offsets). Two initial failures triaged: one is the jtu first-test compilation-cache assertion (environment artifact, passes with `JAX_ENABLE_COMPILATION_CACHE=false`), one was the sub-channel tolerance addressed above.
- [x] e2e GLM-5.2-FP8 v7x tp16: decode TPOT 17.52 → 14.00 ms (×2 runs each config)
- [x] GSM8K 200q 5-shot, temperature 0: **0.955** with this PR (pre-PR static FP8: 0.955; W8A8 dynamic baseline: 0.950) — no accuracy change
- [x] cc=8 steady decode throughput: 213 tok/s vs 200 pre-PR
- [x] fused_v2 + static FP8 no longer crashes at warmup (scale sharding fix verified by serving)
- [x] `pre-commit run` (isort/ruff/black/mypy) clean

## Notes for reviewers

- Routing change: W8A8 + block-wise static checkpoints previously ran gmm_v1 and now take gmm_v2 (same numerics family as the existing per-channel W8A8 v2 path; covered by the new sub-channel unit tests + GSM8K). If you'd prefer an escape hatch env to force the old routing during rollout, happy to add one.
- The stock `tune_blockwise_block_sizes.py` sweep times only the Pallas kernel segment from the trace, which ignores the out-of-kernel `jnp.pad` when tiles don't divide the operand — a sweep-picked table initially regressed e2e (pad 0.95→2.39 ms/step). The entries here use exact-divisor tiles instead; a follow-up could add pad-aware timing to the tuner.
- `deepseek_v3.py` and `minimax_m2.py` hardcode the same `sharding=("expert", None, None)` for static MoE scales; they are unaffected today (epmoe-only) but would hit the same shard_map rejection if switched to `moe_backend=fused_v2`. Kept out of this PR to stay minimal — happy to apply the same one-line fix there as a follow-up if preferred.
