### PR TITLE
ci: migrate self-hosted runners to us-south1

### DIFF
--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -12,6 +12,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Install Python 3.12 and venv support
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3.12 python3.12-venv
     - name: Create venv and install dependencies
       shell: bash
       env:

--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -2,7 +2,7 @@ name: 'Setup Python venv'
 description: 'Create Python 3.12 venv, install uv and project dependencies'
 inputs:
   install-target:
-    description: 'Project install target passed to `uv pip install -e` (e.g. "python[cpu]", "python[all]")'
+    description: 'Project install target passed to `uv pip install -e` (e.g. "python[cpu]", "python[all]"); empty skips project installation'
     required: false
     default: 'python[all]'
   extra-packages:
@@ -26,7 +26,9 @@ runs:
         python3.12 -m venv .venv
         source .venv/bin/activate
         pip install uv
-        uv pip install -e "$INSTALL_TARGET"
+        if [ -n "$INSTALL_TARGET" ]; then
+          uv pip install -e "$INSTALL_TARGET"
+        fi
         if [ -n "$EXTRA_PACKAGES" ]; then
           set -f
           # shellcheck disable=SC2086

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: [ pull_request ]
 
 jobs:
   lint:
-    runs-on: arc-runner-cpu
+    runs-on: arc-runner-cpu-us-south1-b
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
+        with:
+          install-target: ''
+          extra-packages: pre-commit
+
       - name: Install pre-commit hook
-        run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install pre-commit
-          pre-commit install
+        run: pre-commit install
 
       - name: Linting
         run: |

--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -75,7 +75,7 @@ jobs:
 
   nightly-test-accuracy-text-models-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-accuracy-text-models-1-tpu-daily')
-    runs-on: arc-runner-v6e-1
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -96,7 +96,7 @@ jobs:
 
   nightly-test-perf-text-models-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-perf-text-models-1-tpu-daily')
-    runs-on: arc-runner-v6e-1
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -117,7 +117,7 @@ jobs:
 
   nightly-test-openai-api-surface-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-openai-api-surface-1-tpu-daily')
-    runs-on: arc-runner-v6e-1
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -147,7 +147,7 @@ jobs:
 
   nightly-infra-smoke-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-infra-smoke-1-tpu-daily')
-    runs-on: arc-runner-v6e-1
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -168,7 +168,7 @@ jobs:
 
   nightly-test-accuracy-text-models-4-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-accuracy-text-models-4-tpu-daily')
-    runs-on: arc-runner-v6e-4
+    runs-on: arc-runner-v6e-4-us-south1-ai1b
     # Read-only + persist-credentials:false — this job runs PR-HEAD code, so it must not
     # hold a write token; PASS/FAIL is posted from the separate comment job below.
     permissions:
@@ -240,7 +240,7 @@ jobs:
 
   nightly-test-perf-text-models-4-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-perf-text-models-4-tpu-daily')
-    runs-on: arc-runner-v6e-4
+    runs-on: arc-runner-v6e-4-us-south1-ai1b
     # Read-only + persist-credentials:false — runs PR-HEAD code, no write token here;
     # PASS/FAIL is posted from the separate comment job below.
     permissions:
@@ -365,7 +365,7 @@ jobs:
       - nightly-test-accuracy-text-models-4-tpu-daily
       - nightly-test-perf-text-models-4-tpu-daily
     if: always() && github.ref == 'refs/heads/main' && github.repository == 'sgl-project/sglang-jax' && inputs.pr_number == ''
-    runs-on: arc-runner-v6e-4
+    runs-on: arc-runner-v6e-4-us-south1-ai1b
     continue-on-error: true
     timeout-minutes: 20
     env:

--- a/.github/workflows/nightly-test-summize.yml
+++ b/.github/workflows/nightly-test-summize.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   generate-summary:
     if: github.repository == 'sgl-project/sglang-jax'
-    runs-on: arc-runner-v6e-1
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     continue-on-error: true
     env:
       TZ: Asia/Shanghai

--- a/.github/workflows/nightly-test-summize.yml
+++ b/.github/workflows/nightly-test-summize.yml
@@ -33,11 +33,10 @@ jobs:
         run: echo "DATE_DIR=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Set up Python Environment
-        run: |
-          python3.12 -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip install requests pandas matplotlib seaborn
+        uses: ./.github/actions/setup-venv
+        with:
+          install-target: ''
+          extra-packages: requests pandas matplotlib seaborn
 
 
       - name: Prepare Image Directory

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -27,29 +27,14 @@ jobs:
   unit-test-1-tpu:
     needs: [coordinator]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: ${{ matrix.runner }}
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - part: 0
-            runner: arc-runner-v6e-1-us-south1-canary
-          - part: 1
-            runner: arc-runner-v6e-1
-          - part: 2
-            runner: arc-runner-v6e-1
-          - part: 3
-            runner: arc-runner-v6e-1
-          - part: 4
-            runner: arc-runner-v6e-1
+        part: [0, 1, 2, 3, 4]
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-      - name: Install Python venv support on the canary runner
-        if: matrix.runner == 'arc-runner-v6e-1-us-south1-canary'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y python3.12-venv
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
       - name: Run unit test
@@ -67,7 +52,7 @@ jobs:
   unit-test-4-tpu:
     needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-4
+    runs-on: arc-runner-v6e-4-us-south1-ai1b
     strategy:
       fail-fast: false
       matrix:
@@ -92,7 +77,7 @@ jobs:
   unit-test-cpu:
     needs: [coordinator]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-cpu
+    runs-on: arc-runner-cpu-us-south1-b
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -112,7 +97,7 @@ jobs:
   e2e-test-1-tpu:
     needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-1
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     strategy:
       fail-fast: false
       matrix:
@@ -140,7 +125,7 @@ jobs:
   e2e-test-4-tpu:
     needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-4
+    runs-on: arc-runner-v6e-4-us-south1-ai1b
     strategy:
       fail-fast: false
       matrix:
@@ -169,7 +154,7 @@ jobs:
   accuracy-test-1-tpu:
     needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-1
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     strategy:
       fail-fast: false
       matrix:
@@ -198,7 +183,7 @@ jobs:
     needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
 
-    runs-on: arc-runner-v6e-4
+    runs-on: arc-runner-v6e-4-us-south1-ai1b
     strategy:
       fail-fast: false
       matrix:
@@ -229,7 +214,7 @@ jobs:
     if: >-
       needs.coordinator.outputs.run_main_test == 'true' &&
       (needs.coordinator.outputs.requires_4tpu == 'true' || needs.coordinator.outputs.run_full == 'true')
-    runs-on: arc-runner-v6e-4
+    runs-on: arc-runner-v6e-4-us-south1-ai1b
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -257,7 +242,7 @@ jobs:
     if: >-
       needs.coordinator.outputs.run_main_test == 'true' &&
       (needs.coordinator.outputs.run_accuracy_extra == 'true' || needs.coordinator.outputs.run_full == 'true')
-    runs-on: arc-runner-v6e-1
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -283,7 +268,7 @@ jobs:
   performance-test-1-tpu:
     needs: [coordinator, unit-test-4-tpu, e2e-test-1-tpu, e2e-test-4-tpu, accuracy-test-1-tpu, accuracy-test-4-tpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-1
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     strategy:
       fail-fast: false
       matrix:
@@ -311,7 +296,7 @@ jobs:
   performance-test-4-tpu:
     needs: [coordinator, unit-test-4-tpu, e2e-test-1-tpu, e2e-test-4-tpu, accuracy-test-1-tpu, accuracy-test-4-tpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-4
+    runs-on: arc-runner-v6e-4-us-south1-ai1b
     strategy:
       fail-fast: false
       matrix:
@@ -342,7 +327,7 @@ jobs:
     if: >-
       needs.coordinator.outputs.run_main_test == 'true' &&
       (needs.coordinator.outputs.run_perf == 'true' || needs.coordinator.outputs.run_full == 'true')
-    runs-on: arc-runner-v6e-1
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -367,7 +352,7 @@ jobs:
   pallas-kernel-benchmark:
     needs: [coordinator]
     if: needs.coordinator.outputs.run_pallas_bench == 'true'
-    runs-on: arc-runner-v6e-1
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -27,11 +27,21 @@ jobs:
   unit-test-1-tpu:
     needs: [coordinator]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-1
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        part: [0, 1, 2, 3, 4]
+        include:
+          - part: 0
+            runner: arc-runner-v6e-1-us-south1-canary
+          - part: 1
+            runner: arc-runner-v6e-1
+          - part: 2
+            runner: arc-runner-v6e-1
+          - part: 3
+            runner: arc-runner-v6e-1
+          - part: 4
+            runner: arc-runner-v6e-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -45,6 +45,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+      - name: Install Python venv support on the canary runner
+        if: matrix.runner == 'arc-runner-v6e-1-us-south1-canary'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3.12-venv
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
       - name: Run unit test

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       runner:
-        description: 'Runner label (arc-runner-v6e-1, arc-runner-v6e-4, arc-runner-cpu)'
+        description: 'Runner label (arc-runner-v6e-1-us-south1-ai1b, arc-runner-v6e-4-us-south1-ai1b, arc-runner-cpu-us-south1-b)'
         required: true
         type: string
       ref:

--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -11,7 +11,7 @@ on:
         default: '24'
         type: string
       filter:
-        description: 'Filter runner labels (e.g., arc-runner-v6e-1, arc-runner-v6e-4)'
+        description: 'Filter runner labels (e.g., arc-runner-v6e-1-us-south1-ai1b, arc-runner-v6e-4-us-south1-ai1b)'
         required: false
         type: string
 

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -21,7 +21,7 @@ jobs:
 
   nightly-test-accuracy-text-models-1-tpu:
     if: github.repository == 'sgl-project/sglang-jax'
-    runs-on: arc-runner-v6e-1
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +86,7 @@ jobs:
 
   nightly-test-accuracy-text-models-4-tpu:
     if: github.repository == 'sgl-project/sglang-jax'
-    runs-on: arc-runner-v6e-4
+    runs-on: arc-runner-v6e-4-us-south1-ai1b
     strategy:
       fail-fast: false
       matrix:
@@ -129,7 +129,7 @@ jobs:
 
   nightly-test-perf-text-models-1-tpu:
     if: github.repository == 'sgl-project/sglang-jax'
-    runs-on: arc-runner-v6e-1
+    runs-on: arc-runner-v6e-1-us-south1-ai1b
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -173,7 +173,7 @@ jobs:
 
   nightly-test-perf-text-models-4-tpu-part1:
     if: github.repository == 'sgl-project/sglang-jax'
-    runs-on: arc-runner-v6e-4
+    runs-on: arc-runner-v6e-4-us-south1-ai1b
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -239,7 +239,7 @@ jobs:
 
   nightly-test-perf-text-models-4-tpu-part2:
       if: github.repository == 'sgl-project/sglang-jax'
-      runs-on: arc-runner-v6e-4
+      runs-on: arc-runner-v6e-4-us-south1-ai1b
       env:
         TZ: Asia/Shanghai
         JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -283,7 +283,7 @@ jobs:
 
   nightly-test-perf-text-models-4-tpu-part3:
         if: github.repository == 'sgl-project/sglang-jax'
-        runs-on: arc-runner-v6e-4
+        runs-on: arc-runner-v6e-4-us-south1-ai1b
         env:
           TZ: Asia/Shanghai
           JAX_COMPILATION_CACHE_DIR: /xla-cache

--- a/scripts/ci/slash_command_parse.py
+++ b/scripts/ci/slash_command_parse.py
@@ -115,9 +115,9 @@ def format_nightly_list():
 
 
 RUNNER_SUFFIXES = [
-    ("-cpu", "arc-runner-cpu"),
-    ("-v6e-4", "arc-runner-v6e-4"),
-    ("-v6e-1", "arc-runner-v6e-1"),
+    ("-cpu", "arc-runner-cpu-us-south1-b"),
+    ("-v6e-4", "arc-runner-v6e-4-us-south1-ai1b"),
+    ("-v6e-1", "arc-runner-v6e-1-us-south1-ai1b"),
 ]
 
 STAGE_JOBS = {
@@ -145,15 +145,15 @@ STAGE_ALIASES = {
 }
 
 JOB_TO_SUITE = {
-    "unit-test-1-tpu": ("unit-test-tpu-v6e-1", "arc-runner-v6e-1"),
-    "unit-test-cpu": ("unit-test-cpu", "arc-runner-cpu"),
-    "unit-test-4-tpu": ("unit-test-tpu-v6e-4", "arc-runner-v6e-4"),
-    "e2e-test-1-tpu": ("e2e-test-tpu-v6e-1", "arc-runner-v6e-1"),
-    "e2e-test-4-tpu": ("e2e-test-tpu-v6e-4", "arc-runner-v6e-4"),
-    "accuracy-test-1-tpu": ("accuracy-test-tpu-v6e-1", "arc-runner-v6e-1"),
-    "accuracy-test-4-tpu": ("accuracy-test-tpu-v6e-4", "arc-runner-v6e-4"),
-    "performance-test-1-tpu": ("performance-test-tpu-v6e-1", "arc-runner-v6e-1"),
-    "performance-test-4-tpu": ("performance-test-tpu-v6e-4", "arc-runner-v6e-4"),
+    "unit-test-1-tpu": ("unit-test-tpu-v6e-1", "arc-runner-v6e-1-us-south1-ai1b"),
+    "unit-test-cpu": ("unit-test-cpu", "arc-runner-cpu-us-south1-b"),
+    "unit-test-4-tpu": ("unit-test-tpu-v6e-4", "arc-runner-v6e-4-us-south1-ai1b"),
+    "e2e-test-1-tpu": ("e2e-test-tpu-v6e-1", "arc-runner-v6e-1-us-south1-ai1b"),
+    "e2e-test-4-tpu": ("e2e-test-tpu-v6e-4", "arc-runner-v6e-4-us-south1-ai1b"),
+    "accuracy-test-1-tpu": ("accuracy-test-tpu-v6e-1", "arc-runner-v6e-1-us-south1-ai1b"),
+    "accuracy-test-4-tpu": ("accuracy-test-tpu-v6e-4", "arc-runner-v6e-4-us-south1-ai1b"),
+    "performance-test-1-tpu": ("performance-test-tpu-v6e-1", "arc-runner-v6e-1-us-south1-ai1b"),
+    "performance-test-4-tpu": ("performance-test-tpu-v6e-4", "arc-runner-v6e-4-us-south1-ai1b"),
 }
 
 

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -105,7 +105,7 @@ def get_jobs_for_run(repo, run_id):
     )
 
 
-_RUNNER_LABEL_MAP = {"cpu-runner": "arc-runner-cpu"}
+_RUNNER_LABEL_MAP = {"cpu-runner": "arc-runner-cpu-us-south1-b"}
 
 
 def _meaningful_labels(label_dicts):
@@ -130,7 +130,7 @@ def get_runners(repo, online_only=False):
                 inferred = (
                     m.group(1)
                     if m
-                    else ("arc-runner-cpu" if name.startswith("runnerdeploy-") else None)
+                    else ("arc-runner-cpu-us-south1-b" if name.startswith("runnerdeploy-") else None)
                 )
                 if inferred:
                     runner.setdefault("labels", []).append({"name": inferred})

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -130,7 +130,9 @@ def get_runners(repo, online_only=False):
                 inferred = (
                     m.group(1)
                     if m
-                    else ("arc-runner-cpu-us-south1-b" if name.startswith("runnerdeploy-") else None)
+                    else (
+                        "arc-runner-cpu-us-south1-b" if name.startswith("runnerdeploy-") else None
+                    )
                 )
                 if inferred:
                     runner.setdefault("labels", []).append({"name": inferred})

--- a/test/srt/nightly/single_host/README.md
+++ b/test/srt/nightly/single_host/README.md
@@ -127,7 +127,7 @@ Pass/fail is conveyed through the process **exit code**:
 
 ## Triggering CI
 
-The v6e-4 suites run on the `arc-runner-v6e-4` runner via
+The v6e-4 suites run on the `arc-runner-v6e-4-us-south1-ai1b` runner via
 `.github/workflows/nightly-test-daily.yml`:
 
 - `nightly-test-accuracy-text-models-4-tpu-daily` → `--suite accuracy-text-models-v6e-4`

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -282,7 +282,7 @@ suites = {
         TestFile("python/sgl_jax/test/layers/test_merged_column_parallel_linear.py", 0.1),
         TestFile("test/srt/kernels/dsa/test_streamindex_topk.py", 3, runner="pytest"),
     ],
-    # CPU-only unit tests — moved off arc-runner-v6e-1 to a dedicated
+    # CPU-only unit tests — moved off the v6e-1 TPU runner to a dedicated
     # CPU runner so they don't consume TPU capacity. Either pure
     # Python / numpy / mocks (no JAX device ops) or JAX kernels whose
     # header already pins JAX_PLATFORMS=cpu and which target CPU


### PR DESCRIPTION
## Summary

The previous self-hosted CI runner nodes in `us-east5` are no longer available, so the CI workloads are being migrated to `us-south1`.

- Rename the self-hosted runner labels to include their deployment location:
  - `arc-runner-cpu-us-south1-b`
  - `arc-runner-v6e-1-us-south1-ai1b`
  - `arc-runner-v6e-4-us-south1-ai1b`