### PR TITLE
CI: fall back from us-south1 to us-east5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: [ pull_request ]
 
 jobs:
   lint:
-    runs-on: arc-runner-cpu-us-south1-b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-cpu-us-east5-a' || 'arc-runner-cpu-us-south1-b' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -75,7 +75,7 @@ jobs:
 
   nightly-test-accuracy-text-models-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-accuracy-text-models-1-tpu-daily')
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -96,7 +96,7 @@ jobs:
 
   nightly-test-perf-text-models-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-perf-text-models-1-tpu-daily')
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -117,7 +117,7 @@ jobs:
 
   nightly-test-openai-api-surface-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-openai-api-surface-1-tpu-daily')
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -147,7 +147,7 @@ jobs:
 
   nightly-infra-smoke-1-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-infra-smoke-1-tpu-daily')
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -168,7 +168,7 @@ jobs:
 
   nightly-test-accuracy-text-models-4-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-accuracy-text-models-4-tpu-daily')
-    runs-on: arc-runner-v6e-4-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-4-us-east5-a' || 'arc-runner-v6e-4-us-south1-ai1b' }}
     # Read-only + persist-credentials:false — this job runs PR-HEAD code, so it must not
     # hold a write token; PASS/FAIL is posted from the separate comment job below.
     permissions:
@@ -240,7 +240,7 @@ jobs:
 
   nightly-test-perf-text-models-4-tpu-daily:
     if: github.repository == 'sgl-project/sglang-jax' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-perf-text-models-4-tpu-daily')
-    runs-on: arc-runner-v6e-4-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-4-us-east5-a' || 'arc-runner-v6e-4-us-south1-ai1b' }}
     # Read-only + persist-credentials:false — runs PR-HEAD code, no write token here;
     # PASS/FAIL is posted from the separate comment job below.
     permissions:
@@ -365,7 +365,7 @@ jobs:
       - nightly-test-accuracy-text-models-4-tpu-daily
       - nightly-test-perf-text-models-4-tpu-daily
     if: always() && github.ref == 'refs/heads/main' && github.repository == 'sgl-project/sglang-jax' && inputs.pr_number == ''
-    runs-on: arc-runner-v6e-4-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-4-us-east5-a' || 'arc-runner-v6e-4-us-south1-ai1b' }}
     continue-on-error: true
     timeout-minutes: 20
     env:

--- a/.github/workflows/nightly-test-summize.yml
+++ b/.github/workflows/nightly-test-summize.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   generate-summary:
     if: github.repository == 'sgl-project/sglang-jax'
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     continue-on-error: true
     env:
       TZ: Asia/Shanghai

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -27,7 +27,7 @@ jobs:
   unit-test-1-tpu:
     needs: [coordinator]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +52,7 @@ jobs:
   unit-test-4-tpu:
     needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-4-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-4-us-east5-a' || 'arc-runner-v6e-4-us-south1-ai1b' }}
     strategy:
       fail-fast: false
       matrix:
@@ -77,7 +77,7 @@ jobs:
   unit-test-cpu:
     needs: [coordinator]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-cpu-us-south1-b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-cpu-us-east5-a' || 'arc-runner-cpu-us-south1-b' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -97,7 +97,7 @@ jobs:
   e2e-test-1-tpu:
     needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     strategy:
       fail-fast: false
       matrix:
@@ -125,7 +125,7 @@ jobs:
   e2e-test-4-tpu:
     needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-4-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-4-us-east5-a' || 'arc-runner-v6e-4-us-south1-ai1b' }}
     strategy:
       fail-fast: false
       matrix:
@@ -154,7 +154,7 @@ jobs:
   accuracy-test-1-tpu:
     needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     strategy:
       fail-fast: false
       matrix:
@@ -183,7 +183,7 @@ jobs:
     needs: [coordinator, unit-test-1-tpu, unit-test-cpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
 
-    runs-on: arc-runner-v6e-4-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-4-us-east5-a' || 'arc-runner-v6e-4-us-south1-ai1b' }}
     strategy:
       fail-fast: false
       matrix:
@@ -214,7 +214,7 @@ jobs:
     if: >-
       needs.coordinator.outputs.run_main_test == 'true' &&
       (needs.coordinator.outputs.requires_4tpu == 'true' || needs.coordinator.outputs.run_full == 'true')
-    runs-on: arc-runner-v6e-4-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-4-us-east5-a' || 'arc-runner-v6e-4-us-south1-ai1b' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -242,7 +242,7 @@ jobs:
     if: >-
       needs.coordinator.outputs.run_main_test == 'true' &&
       (needs.coordinator.outputs.run_accuracy_extra == 'true' || needs.coordinator.outputs.run_full == 'true')
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -268,7 +268,7 @@ jobs:
   performance-test-1-tpu:
     needs: [coordinator, unit-test-4-tpu, e2e-test-1-tpu, e2e-test-4-tpu, accuracy-test-1-tpu, accuracy-test-4-tpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     strategy:
       fail-fast: false
       matrix:
@@ -296,7 +296,7 @@ jobs:
   performance-test-4-tpu:
     needs: [coordinator, unit-test-4-tpu, e2e-test-1-tpu, e2e-test-4-tpu, accuracy-test-1-tpu, accuracy-test-4-tpu]
     if: needs.coordinator.outputs.run_main_test == 'true'
-    runs-on: arc-runner-v6e-4-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-4-us-east5-a' || 'arc-runner-v6e-4-us-south1-ai1b' }}
     strategy:
       fail-fast: false
       matrix:
@@ -327,7 +327,7 @@ jobs:
     if: >-
       needs.coordinator.outputs.run_main_test == 'true' &&
       (needs.coordinator.outputs.run_perf == 'true' || needs.coordinator.outputs.run_full == 'true')
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -352,7 +352,7 @@ jobs:
   pallas-kernel-benchmark:
     needs: [coordinator]
     if: needs.coordinator.outputs.run_pallas_bench == 'true'
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/runner-region-fallback.yml
+++ b/.github/workflows/runner-region-fallback.yml
@@ -1,0 +1,128 @@
+name: Runner Region Fallback
+
+# Managed workflows use us-east5 on attempt 1 and us-south1 on later attempts.
+# This watchdog supplies the queue timeout that GitHub Actions does not provide.
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: runner-region-fallback
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  fallback:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Re-run workflows stuck waiting for us-east5 runners
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const queueTimeoutMs = 10 * 60 * 1000;
+            const eastRunnerLabel = /-us-east5-a$/;
+            const managedWorkflowPaths = new Set([
+              ".github/workflows/lint.yml",
+              ".github/workflows/nightly-test-daily.yml",
+              ".github/workflows/nightly-test-summize.yml",
+              ".github/workflows/pr-test.yml",
+              ".github/workflows/weekly-test.yml",
+            ]);
+
+            const candidateRuns = new Map();
+            for (const status of ["queued", "in_progress"]) {
+              const runs = await github.paginate(
+                github.rest.actions.listWorkflowRunsForRepo,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  status,
+                  per_page: 100,
+                },
+              );
+              for (const run of runs) {
+                if (
+                  Number(run.run_attempt) === 1 &&
+                  managedWorkflowPaths.has(run.path)
+                ) {
+                  candidateRuns.set(run.id, run);
+                }
+              }
+            }
+
+            const now = Date.now();
+            for (const run of candidateRuns.values()) {
+              const jobs = await github.paginate(
+                github.rest.actions.listJobsForWorkflowRun,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id,
+                  filter: "latest",
+                  per_page: 100,
+                },
+              );
+
+              const staleJobs = jobs.filter((job) => {
+                if (job.status !== "queued" || !job.started_at) {
+                  return false;
+                }
+                if (!job.labels.some((label) => eastRunnerLabel.test(label))) {
+                  return false;
+                }
+                return now - Date.parse(job.started_at) >= queueTimeoutMs;
+              });
+
+              if (staleJobs.length === 0) {
+                continue;
+              }
+
+              core.warning(
+                `Run ${run.id} has ${staleJobs.length} job(s) waiting for ` +
+                  `us-east5 runners for at least 10 minutes; switching the ` +
+                  `whole workflow to us-south1.`,
+              );
+
+              await github.rest.actions.cancelWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              });
+
+              let cancelled = false;
+              for (let attempt = 0; attempt < 24; attempt += 1) {
+                await new Promise((resolve) => setTimeout(resolve, 5000));
+                const { data: currentRun } =
+                  await github.rest.actions.getWorkflowRun({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: run.id,
+                  });
+                if (currentRun.status === "completed") {
+                  cancelled = true;
+                  break;
+                }
+              }
+
+              if (!cancelled) {
+                core.warning(
+                  `Run ${run.id} did not finish cancelling within two minutes; ` +
+                    `the next watchdog run will retry it.`,
+                );
+                continue;
+              }
+
+              await github.rest.actions.reRunWorkflow({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              });
+              core.notice(
+                `Re-ran ${run.html_url}; attempt 2 will use us-south1 runners.`,
+              );
+            }

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -21,7 +21,7 @@ jobs:
 
   nightly-test-accuracy-text-models-1-tpu:
     if: github.repository == 'sgl-project/sglang-jax'
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +86,7 @@ jobs:
 
   nightly-test-accuracy-text-models-4-tpu:
     if: github.repository == 'sgl-project/sglang-jax'
-    runs-on: arc-runner-v6e-4-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-4-us-east5-a' || 'arc-runner-v6e-4-us-south1-ai1b' }}
     strategy:
       fail-fast: false
       matrix:
@@ -129,7 +129,7 @@ jobs:
 
   nightly-test-perf-text-models-1-tpu:
     if: github.repository == 'sgl-project/sglang-jax'
-    runs-on: arc-runner-v6e-1-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-1-us-east5-a' || 'arc-runner-v6e-1-us-south1-ai1b' }}
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -173,7 +173,7 @@ jobs:
 
   nightly-test-perf-text-models-4-tpu-part1:
     if: github.repository == 'sgl-project/sglang-jax'
-    runs-on: arc-runner-v6e-4-us-south1-ai1b
+    runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-4-us-east5-a' || 'arc-runner-v6e-4-us-south1-ai1b' }}
     env:
       TZ: Asia/Shanghai
       JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -239,7 +239,7 @@ jobs:
 
   nightly-test-perf-text-models-4-tpu-part2:
       if: github.repository == 'sgl-project/sglang-jax'
-      runs-on: arc-runner-v6e-4-us-south1-ai1b
+      runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-4-us-east5-a' || 'arc-runner-v6e-4-us-south1-ai1b' }}
       env:
         TZ: Asia/Shanghai
         JAX_COMPILATION_CACHE_DIR: /xla-cache
@@ -283,7 +283,7 @@ jobs:
 
   nightly-test-perf-text-models-4-tpu-part3:
         if: github.repository == 'sgl-project/sglang-jax'
-        runs-on: arc-runner-v6e-4-us-south1-ai1b
+        runs-on: ${{ github.run_attempt == '1' && 'arc-runner-v6e-4-us-east5-a' || 'arc-runner-v6e-4-us-south1-ai1b' }}
         env:
           TZ: Asia/Shanghai
           JAX_COMPILATION_CACHE_DIR: /xla-cache


### PR DESCRIPTION
## Summary

- Route the first workflow attempt to the us-east5 self-hosted runners.
- Route subsequent attempts to the us-south1 self-hosted runners.
- Add a watchdog that checks every five minutes and re-runs a workflow when an us-east5 runner job has remained queued for at least ten minutes.

## Fallback behavior

The fallback restarts the whole workflow in us-south1. Only the first attempt is monitored, so a second capacity failure remains queued for normal investigation.