### PR TITLE
fix: [Docs] LoRA usage documentation

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,6 +7,7 @@ Feature docs describe runtime capabilities, operational behavior, and user-visib
 | [Attention backend](attention_backend.md) | Attention backend abstraction and extension points. |
 | [Chunked prefill](chunked_prefill.md) | Splitting long prefill into smaller chunks. |
 | [Global JIT compile](global_jit_compile.md) | Compilation cache and startup flow. |
+| [LoRA](lora.md) | LoRA adapter serving support. |
 | [Quantization](quantization.md) | Quantized model serving support. |
 | [Radix cache](radix_cache.md) | Prefix KV cache reuse. |
 | [Run in Pathways](run_in_pathways.md) | Pathways execution notes. |

--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -50,7 +50,7 @@ uv run python -u -m sgl_jax.launch_server \
   --lora-paths adapter1=/path/to/adapter1 adapter2=/path/to/adapter2
 ```
 
-Adapters can also be specified as a JSON dict `{"adapter1": "/path/to/adapter1", ...}`.
+When constructing `ServerArgs` programmatically, adapters can also be specified as a dict `{"adapter1": "/path/to/adapter1", ...}` (the CLI `--lora-paths` only accepts `name=path` / `path` forms).
 
 ### Sending requests with a specific adapter
 
@@ -68,8 +68,10 @@ curl http://localhost:30000/v1/completions \
   }'
 ```
 
-The same field is used in the OpenAI chat completions protocol and in the Python engine API
-(`Engine.generate(..., lora_path="adapter1")`).
+The same field is used in the Python engine API
+(`Engine.generate(..., lora_path="adapter1")`). Chat completions does not yet
+forward `lora_path` to the generation request, so the adapter would be ignored
+there.
 
 ### Server arguments
 
@@ -77,11 +79,10 @@ The same field is used in the OpenAI chat completions protocol and in the Python
 |----------|---------|-------------|
 | `--enable-lora` | `None` | Enable dynamic LoRA (auto-enabled when `--lora-paths` is set). |
 | `--lora-paths` | `None` | Adapters to preload; `name=path` / `path` / dict format. |
-| `--max-loras-per-batch` | `8` | Maximum number of different adapters per batch. |
+| `--max-loras-per-batch` | `8` | Maximum number of different adapters per batch. Preloaded adapters are pinned, so at most `max_loras_per_batch - 1` (7 with the default) can be preloaded. |
 | `--max-lora-rank` | `None` | Maximum LoRA rank; auto-inferred from the loaded adapters when unset. |
 | `--lora-target-modules` | `None` | Modules to apply LoRA to (`q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj`, or `all`); auto-inferred from the adapters when unset. |
-| `--max-loaded-loras` | `None` | Maximum adapters kept loaded in memory. |
-| `--lora-eviction-policy` | `lru` | Eviction policy (reserved; no runtime eviction is triggered in the current version). |
+
 
 `qkv` and `gate_up` projections are automatically handled by merging the corresponding per-module
 LoRA weights, and adapters with different ranks are padded to `max_lora_rank`.
@@ -91,7 +92,7 @@ LoRA weights, and adapters with different ranks are padded to `max_lora_rank`.
 Static LoRA is intended for RL scenarios where only a single adapter is used and requests never
 switch adapters at runtime. It is mutually exclusive with `--enable-lora`:
 
-- Supports exactly one adapter (weights are merged into the base model; BGMV is not used)
+- Supports exactly one adapter via fixed `A`/`B` buffers updated externally between RL steps (weights are not merged into the base model; BGMV is not used)
 - Requires explicit `--lora-scaling` (`alpha / rank`)
 - Does not accept `--lora-paths` and requires `--max-loras-per-batch 1`
 
@@ -110,7 +111,10 @@ uv run python -u -m sgl_jax.launch_server \
   --dtype=bfloat16 \
   --skip-server-warmup \
   --enable-static-lora \
-  --lora-scaling 1.0
+  --lora-scaling 1.0 \
+  --max-lora-rank 8 \
+  --lora-target-modules q_proj \
+  --max-loras-per-batch 1
 ```
 
 ## Limitations

--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -1,0 +1,122 @@
+# LoRA
+
+sglang-jax supports serving LoRA (Low-Rank Adaptation) adapters on top of a base model. LoRA adds
+adaptation capability without modifying the original weights: for the original weight `W`, the LoRA
+output is `W·x + (B·A)·x * scaling`, where `A` is the down-projection (`hidden → rank`), `B` is the
+up-projection (`rank → hidden`), and `scaling = alpha / rank`.
+
+LoRA adapters are loaded from standard HuggingFace LoRA adapter directories containing
+`adapter_config.json` and the adapter `safetensors` weights. Deep implementation details live in
+[Architecture: LoRA Dynamic Adapters](../architecture/10-lora.md).
+
+## Two Modes
+
+sglang-jax provides two LoRA modes:
+
+| Mode | Flag | Description |
+|------|------|-------------|
+| Dynamic LoRA | `--enable-lora` | Multiple adapters, per-request adapter switching with per-request KV-cache isolation. |
+| Static LoRA | `--enable-static-lora` | Single adapter for RL scenarios; weights are merged into the base model at load time. Mutually exclusive with `--enable-lora`. |
+
+`--enable-lora` is auto-enabled whenever `--lora-paths` is provided.
+
+## Dynamic LoRA
+
+### Launching the server
+
+Pass the adapter paths to `--lora-paths`. Adapters can be given as:
+
+- `name=path` — explicit adapter name (used in requests)
+- `path` — name is derived from the path basename
+- HuggingFace repo IDs (both forms above apply)
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache \
+uv run python -u -m sgl_jax.launch_server \
+  --model-path meta-llama/Llama-2-7b-chat-hf \
+  --trust-remote-code \
+  --dist-init-addr=0.0.0.0:10011 \
+  --nnodes=1 \
+  --tp-size=1 \
+  --device=tpu \
+  --random-seed=3 \
+  --node-rank=0 \
+  --mem-fraction-static=0.8 \
+  --max-prefill-tokens=8192 \
+  --download-dir=/tmp \
+  --dtype=bfloat16 \
+  --skip-server-warmup \
+  --enable-lora \
+  --lora-paths adapter1=/path/to/adapter1 adapter2=/path/to/adapter2
+```
+
+Adapters can also be specified as a JSON dict `{"adapter1": "/path/to/adapter1", ...}`.
+
+### Sending requests with a specific adapter
+
+Requests select an adapter by the adapter **name** (the key/name registered via `--lora-paths`)
+through the `lora_path` request field. Requests that omit `lora_path` run on the base model.
+
+```bash
+curl http://localhost:30000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta-llama/Llama-2-7b-chat-hf",
+    "prompt": "The capital of France is",
+    "max_tokens": 32,
+    "lora_path": "adapter1"
+  }'
+```
+
+The same field is used in the OpenAI chat completions protocol and in the Python engine API
+(`Engine.generate(..., lora_path="adapter1")`).
+
+### Server arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--enable-lora` | `None` | Enable dynamic LoRA (auto-enabled when `--lora-paths` is set). |
+| `--lora-paths` | `None` | Adapters to preload; `name=path` / `path` / dict format. |
+| `--max-loras-per-batch` | `8` | Maximum number of different adapters per batch. |
+| `--max-lora-rank` | `None` | Maximum LoRA rank; auto-inferred from the loaded adapters when unset. |
+| `--lora-target-modules` | `None` | Modules to apply LoRA to (`q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj`, or `all`); auto-inferred from the adapters when unset. |
+| `--max-loaded-loras` | `None` | Maximum adapters kept loaded in memory. |
+| `--lora-eviction-policy` | `lru` | Eviction policy (reserved; no runtime eviction is triggered in the current version). |
+
+`qkv` and `gate_up` projections are automatically handled by merging the corresponding per-module
+LoRA weights, and adapters with different ranks are padded to `max_lora_rank`.
+
+## Static LoRA
+
+Static LoRA is intended for RL scenarios where only a single adapter is used and requests never
+switch adapters at runtime. It is mutually exclusive with `--enable-lora`:
+
+- Supports exactly one adapter (weights are merged into the base model; BGMV is not used)
+- Requires explicit `--lora-scaling` (`alpha / rank`)
+- Does not accept `--lora-paths` and requires `--max-loras-per-batch 1`
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache \
+uv run python -u -m sgl_jax.launch_server \
+  --model-path meta-llama/Llama-2-7b-chat-hf \
+  --trust-remote-code \
+  --dist-init-addr=0.0.0.0:10011 \
+  --nnodes=1 \
+  --tp-size=1 \
+  --device=tpu \
+  --node-rank=0 \
+  --mem-fraction-static=0.8 \
+  --download-dir=/tmp \
+  --dtype=bfloat16 \
+  --skip-server-warmup \
+  --enable-static-lora \
+  --lora-scaling 1.0
+```
+
+## Limitations
+
+- All configured adapters are loaded at startup; dynamic adapter (un)loading and runtime eviction are
+  not yet supported in the current version.
+- KV caches are fully isolated per adapter, so different adapters do not share prefix caches even
+  with identical prompts.
+- DFLASH (speculative decoding) does not support LoRA.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ the model cookbook is maintained as a Mintlify-style recipe collection.
    features/attention_backend
    features/chunked_prefill
    features/global_jit_compile
+   features/lora
    features/quantization
    features/radix_cache
    features/run_in_pathways


### PR DESCRIPTION
Fixes #594

Added `docs/features/lora.md` with LoRA usage documentation (dynamic/static modes, server args, adapter selection, examples, limitations) and registered it in `docs/features/index.md` and `docs/index.rst`.

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.