### PR TITLE
feat(pd): overlap chunked prefill KV transfer with Raiden

### DIFF
--- a/python/sgl_jax/srt/disaggregation/base/transfer.py
+++ b/python/sgl_jax/srt/disaggregation/base/transfer.py
@@ -122,6 +122,7 @@ class TransferBackend(Protocol):
         *,
         jax_process_index: int | None = None,
         prefill_dp_rank: int = 0,
+        expected_transfer_id: str | None = None,
     ) -> None: ...
 
     def inflight_count(self) -> tuple[int, int]: ...

--- a/python/sgl_jax/srt/disaggregation/base/transfer.py
+++ b/python/sgl_jax/srt/disaggregation/base/transfer.py
@@ -12,6 +12,32 @@ import numpy as np
 from sgl_jax.srt.disaggregation.base.kv_manager import KVReceiver, KVSender
 
 
+def chunk_transfer_id(base_transfer_id: str, chunk_index: int) -> str:
+    """Return the v5 wire ID for one chunk of a logical PD transfer."""
+
+    if not base_transfer_id:
+        raise ValueError("base_transfer_id must be non-empty")
+    chunk_index = int(chunk_index)
+    if chunk_index < 0:
+        raise ValueError("chunk_index must be non-negative")
+    return f"{base_transfer_id}#c{chunk_index}"
+
+
+def parse_chunk_transfer_id(transfer_id: str) -> tuple[str, int]:
+    """Parse a v5 chunk wire ID into ``(base_transfer_id, chunk_index)``."""
+
+    base_transfer_id, separator, raw_index = str(transfer_id).rpartition("#c")
+    if not separator or not base_transfer_id or not raw_index:
+        raise ValueError(f"invalid chunk transfer_id={transfer_id!r}")
+    try:
+        chunk_index = int(raw_index)
+    except ValueError as exc:
+        raise ValueError(f"invalid chunk transfer_id={transfer_id!r}") from exc
+    if chunk_index < 0:
+        raise ValueError(f"invalid chunk transfer_id={transfer_id!r}")
+    return base_transfer_id, chunk_index
+
+
 def slots_to_page_ids(slots: Any, page_size: int, token_count: int) -> tuple[int, ...]:
     """Validate page-backed token slots and return their ordered page IDs."""
 

--- a/python/sgl_jax/srt/disaggregation/base/transfer.py
+++ b/python/sgl_jax/srt/disaggregation/base/transfer.py
@@ -107,6 +107,15 @@ class DecodeTransferContext:
     direct_commit: Callable[[Mapping[str, object] | None], None] | None = None
 
 
+@dataclass(frozen=True)
+class DecodeMetadataContext:
+    req_id: str
+    transfer_id: str
+    bootstrap_room: int | None
+    prefill_dp_rank: int
+    peer_info: Mapping[str, object]
+
+
 class AdmissionState(enum.Enum):
     ADMITTED = "admitted"
     DEFERRED = "deferred"
@@ -137,6 +146,8 @@ class TransferBackend(Protocol):
     def prepare_prefill_batch(self, kv_buffers: Any) -> None: ...
 
     def start_prefill(self, context: PrefillTransferContext) -> PrefillTransfer: ...
+
+    def poll_decode_metadata(self, context: DecodeMetadataContext) -> bool: ...
 
     def try_start_decode(self, context: DecodeTransferContext) -> DecodeAdmission: ...
 

--- a/python/sgl_jax/srt/disaggregation/bootstrap.py
+++ b/python/sgl_jax/srt/disaggregation/bootstrap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 import threading
 import time
@@ -22,12 +23,14 @@ HEARTBEAT_TTL_SECONDS = 30.0
 # Beat at ~TTL/3 so a single missed beat doesn't evict the entry.
 HEARTBEAT_INTERVAL_SECONDS = HEARTBEAT_TTL_SECONDS / 3.0
 TRANSFER_METADATA_TTL_SECONDS = 300.0
-BOOTSTRAP_CAPABILITIES = ("transfer_metadata",)
+BOOTSTRAP_CAPABILITIES = ("transfer_metadata", "chunk_transfer_metadata")
 
 # PD wire protocol version. Bump when ``PrefillInfo``
 # or any of the 4 endpoint payloads change shape.
-PROTOCOL_VERSION: int = 4
-MIN_COMPATIBLE_VERSION: int = 1
+PROTOCOL_VERSION: int = 5
+# v5 changes request transfer metadata from a single descriptor into a
+# per-chunk envelope. Mixed v4/v5 P/D peers are therefore unsupported.
+MIN_COMPATIBLE_VERSION: int = PROTOCOL_VERSION
 
 
 def _set_registry_size(n: int) -> None:
@@ -173,8 +176,14 @@ class RegisterPrefillRequest(BaseModel):
 class RegisterTransferRequest(BaseModel):
     bootstrap_room: int
     transfer_id: str
+    base_transfer_id: str | None = None
     jax_process_index: int = 0
     prefill_dp_rank: int = 0
+    chunk_index: int = 0
+    # Request-level transfer is represented as one final chunk. Chunked
+    # prefill publishes zero until the final descriptor fixes the total.
+    num_chunks: int = 1
+    chunk_page_offset: int = 0
     transport_metadata: dict[str, object]
 
 
@@ -270,8 +279,61 @@ class _Registry:
             prefill_dp_rank = int(info.get("prefill_dp_rank", 0))
             if not str(info.get("transfer_id", "")):
                 raise ValueError("transfer_id must be non-empty")
+            transfer_id = str(info["transfer_id"])
+            base_transfer_id = str(info.get("base_transfer_id") or transfer_id)
+            chunk_index = int(info.get("chunk_index", 0))
+            num_chunks = int(info.get("num_chunks", 1))
+            chunk_page_offset = int(info.get("chunk_page_offset", 0))
+            if chunk_index < 0:
+                raise ValueError("chunk_index must be non-negative")
+            if chunk_page_offset < 0:
+                raise ValueError("chunk_page_offset must be non-negative")
+            if num_chunks < 0:
+                raise ValueError("num_chunks must be non-negative")
+            if num_chunks and num_chunks != chunk_index + 1:
+                raise ValueError("the final chunk must publish num_chunks == chunk_index + 1")
+            expected_transfer_id = (
+                base_transfer_id
+                if base_transfer_id == transfer_id
+                else f"{base_transfer_id}#c{chunk_index}"
+            )
+            if transfer_id != expected_transfer_id:
+                raise ValueError(
+                    "chunk transfer_id must match base_transfer_id and chunk_index: "
+                    f"expected={expected_transfer_id!r}, got={transfer_id!r}"
+                )
             key = (room, process_index, prefill_dp_rank)
-            self.transfers[key] = info
+            bundle = self.transfers.get(key)
+            if bundle is not None and bundle.get("base_transfer_id") != base_transfer_id:
+                if chunk_index != 0:
+                    raise ValueError(
+                        "a new transfer may replace room metadata only from chunk zero"
+                    )
+                bundle = None
+            if bundle is None:
+                bundle = {
+                    "base_transfer_id": base_transfer_id,
+                    "chunks": {},
+                    "num_chunks": 0,
+                }
+                self.transfers[key] = bundle
+            chunks = bundle["chunks"]
+            assert isinstance(chunks, dict)
+            existing = chunks.get(chunk_index)
+            if existing is not None and existing != info:
+                raise ValueError(f"conflicting transfer metadata for chunk_index={chunk_index}")
+            known_total = int(bundle.get("num_chunks", 0))
+            if known_total and chunk_index >= known_total:
+                raise ValueError(
+                    f"chunk_index={chunk_index} is outside finalized num_chunks={known_total}"
+                )
+            if num_chunks and known_total not in (0, num_chunks):
+                raise ValueError(
+                    f"conflicting num_chunks: existing={known_total}, new={num_chunks}"
+                )
+            chunks[chunk_index] = dict(info)
+            if num_chunks:
+                bundle["num_chunks"] = num_chunks
             self.transfer_last_seen[key] = self.now()
 
     def get_transfer(
@@ -285,7 +347,7 @@ class _Registry:
             info = self.transfers.get(
                 (int(bootstrap_room), int(jax_process_index), int(prefill_dp_rank))
             )
-            return dict(info) if info is not None else None
+            return copy.deepcopy(info) if info is not None else None
 
     def pop_room(
         self,
@@ -673,15 +735,23 @@ class BootstrapClient:
         bootstrap_room: int,
         transfer_id: str,
         *,
+        base_transfer_id: str | None = None,
         jax_process_index: int = 0,
         prefill_dp_rank: int = 0,
+        chunk_index: int = 0,
+        num_chunks: int = 1,
+        chunk_page_offset: int = 0,
         transport_metadata: dict[str, object],
     ) -> None:
         payload = {
             "bootstrap_room": bootstrap_room,
             "transfer_id": transfer_id,
+            "base_transfer_id": base_transfer_id or transfer_id,
             "jax_process_index": jax_process_index,
             "prefill_dp_rank": prefill_dp_rank,
+            "chunk_index": chunk_index,
+            "num_chunks": num_chunks,
+            "chunk_page_offset": chunk_page_offset,
             "transport_metadata": transport_metadata,
         }
         r = self._client.post(

--- a/python/sgl_jax/srt/disaggregation/bootstrap.py
+++ b/python/sgl_jax/srt/disaggregation/bootstrap.py
@@ -354,11 +354,20 @@ class _Registry:
         bootstrap_room: int,
         jax_process_index: int = 0,
         prefill_dp_rank: int = 0,
-    ) -> None:
+        expected_transfer_id: str | None = None,
+    ) -> bool:
         with self.lock:
             key = (int(bootstrap_room), int(jax_process_index), int(prefill_dp_rank))
+            bundle = self.transfers.get(key)
+            if (
+                expected_transfer_id is not None
+                and bundle is not None
+                and bundle.get("base_transfer_id") != expected_transfer_id
+            ):
+                return False
             self.transfers.pop(key, None)
             self.transfer_last_seen.pop(key, None)
+            return bundle is not None
 
 
 def build_app(
@@ -473,8 +482,14 @@ def build_app(
         bootstrap_room: int,
         jax_process_index: int = 0,
         prefill_dp_rank: int = 0,
+        expected_transfer_id: str | None = None,
     ) -> dict[str, str]:
-        registry.pop_room(bootstrap_room, jax_process_index, prefill_dp_rank)
+        registry.pop_room(
+            bootstrap_room,
+            jax_process_index,
+            prefill_dp_rank,
+            expected_transfer_id,
+        )
         return {"status": "popped"}
 
     # Bootstrap runs as a standalone single process and does NOT inherit
@@ -790,14 +805,18 @@ class BootstrapClient:
         *,
         jax_process_index: int = 0,
         prefill_dp_rank: int = 0,
+        expected_transfer_id: str | None = None,
     ) -> None:
+        params: dict[str, object] = {
+            "bootstrap_room": bootstrap_room,
+            "jax_process_index": jax_process_index,
+            "prefill_dp_rank": prefill_dp_rank,
+        }
+        if expected_transfer_id is not None:
+            params["expected_transfer_id"] = expected_transfer_id
         r = self._client.post(
             f"{self._base_url}/pop_transfer",
-            params={
-                "bootstrap_room": bootstrap_room,
-                "jax_process_index": jax_process_index,
-                "prefill_dp_rank": prefill_dp_rank,
-            },
+            params=params,
             timeout=self._timeout_s,
             headers=self._headers(),
         )

--- a/python/sgl_jax/srt/disaggregation/bootstrap.py
+++ b/python/sgl_jax/srt/disaggregation/bootstrap.py
@@ -16,6 +16,11 @@ from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel
 from pydantic import Field as PydanticField
 
+from sgl_jax.srt.disaggregation.base.transfer import (
+    chunk_transfer_id,
+    parse_chunk_transfer_id,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -61,6 +66,7 @@ class PrefillInfo:
     protocol_version: int = PROTOCOL_VERSION
     page_size: int = 0
     kv_dtype: str = ""
+    chunk_prefill_transfer: bool = False
     transport_metadata: dict[str, object] = field(default_factory=lambda: {"engine": "jax"})
 
     def to_dict(self) -> dict[str, object]:
@@ -111,6 +117,7 @@ def check_prefill_compat(
     expected_transfer_engine: str | None = None,
     expected_dp_rank: int | None = None,
     expected_dp_size: int | None = None,
+    expected_chunk_prefill_transfer: bool | None = None,
 ) -> None:
     """Raise ``ValueError`` if the prefill peer's KV layout is incompatible.
 
@@ -155,6 +162,14 @@ def check_prefill_compat(
             f"PD topology mismatch: prefill dp_size={peer_dp_size}, "
             f"decode dp_size={expected_dp_size}"
         )
+    if expected_chunk_prefill_transfer is not None:
+        peer_chunk_prefill_transfer = bool(info.get("chunk_prefill_transfer", False))
+        if peer_chunk_prefill_transfer != expected_chunk_prefill_transfer:
+            raise ValueError(
+                "PD chunk prefill transfer mismatch: "
+                f"prefill={peer_chunk_prefill_transfer}, "
+                f"decode={expected_chunk_prefill_transfer}"
+            )
 
 
 class RegisterPrefillRequest(BaseModel):
@@ -170,6 +185,7 @@ class RegisterPrefillRequest(BaseModel):
     protocol_version: int = PROTOCOL_VERSION
     page_size: int = 0
     kv_dtype: str = ""
+    chunk_prefill_transfer: bool = False
     transport_metadata: dict[str, object] = PydanticField(default_factory=lambda: {"engine": "jax"})
 
 
@@ -184,6 +200,7 @@ class RegisterTransferRequest(BaseModel):
     # prefill publishes zero until the final descriptor fixes the total.
     num_chunks: int = 1
     chunk_page_offset: int = 0
+    expected_total_pages: int = 0
     transport_metadata: dict[str, object]
 
 
@@ -284,19 +301,28 @@ class _Registry:
             chunk_index = int(info.get("chunk_index", 0))
             num_chunks = int(info.get("num_chunks", 1))
             chunk_page_offset = int(info.get("chunk_page_offset", 0))
+            expected_total_pages = int(info.get("expected_total_pages", 0))
             if chunk_index < 0:
                 raise ValueError("chunk_index must be non-negative")
             if chunk_page_offset < 0:
                 raise ValueError("chunk_page_offset must be non-negative")
             if num_chunks < 0:
                 raise ValueError("num_chunks must be non-negative")
+            if expected_total_pages < 0:
+                raise ValueError("expected_total_pages must be non-negative")
             if num_chunks and num_chunks != chunk_index + 1:
                 raise ValueError("the final chunk must publish num_chunks == chunk_index + 1")
-            expected_transfer_id = (
-                base_transfer_id
-                if base_transfer_id == transfer_id
-                else f"{base_transfer_id}#c{chunk_index}"
-            )
+            if base_transfer_id == transfer_id:
+                expected_transfer_id = base_transfer_id
+            else:
+                parsed_base, parsed_index = parse_chunk_transfer_id(transfer_id)
+                if parsed_base != base_transfer_id or parsed_index != chunk_index:
+                    raise ValueError(
+                        "chunk transfer_id must match base_transfer_id and chunk_index: "
+                        f"base={base_transfer_id!r}, chunk_index={chunk_index}, "
+                        f"got={transfer_id!r}"
+                    )
+                expected_transfer_id = chunk_transfer_id(base_transfer_id, chunk_index)
             if transfer_id != expected_transfer_id:
                 raise ValueError(
                     "chunk transfer_id must match base_transfer_id and chunk_index: "
@@ -311,10 +337,13 @@ class _Registry:
                     )
                 bundle = None
             if bundle is None:
+                if base_transfer_id != transfer_id and chunk_index != 0:
+                    raise ValueError("a chunk transfer bundle must be created from chunk zero")
                 bundle = {
                     "base_transfer_id": base_transfer_id,
                     "chunks": {},
                     "num_chunks": 0,
+                    "expected_total_pages": expected_total_pages,
                 }
                 self.transfers[key] = bundle
             chunks = bundle["chunks"]
@@ -331,9 +360,17 @@ class _Registry:
                 raise ValueError(
                     f"conflicting num_chunks: existing={known_total}, new={num_chunks}"
                 )
+            known_total_pages = int(bundle.get("expected_total_pages", 0))
+            if expected_total_pages and known_total_pages not in (0, expected_total_pages):
+                raise ValueError(
+                    "conflicting expected_total_pages: "
+                    f"existing={known_total_pages}, new={expected_total_pages}"
+                )
             chunks[chunk_index] = dict(info)
             if num_chunks:
                 bundle["num_chunks"] = num_chunks
+            if expected_total_pages:
+                bundle["expected_total_pages"] = expected_total_pages
             self.transfer_last_seen[key] = self.now()
 
     def get_transfer(
@@ -662,6 +699,7 @@ class BootstrapClient:
         protocol_version: int = PROTOCOL_VERSION,
         page_size: int = 0,
         kv_dtype: str = "",
+        chunk_prefill_transfer: bool = False,
         transport_metadata: dict[str, object] | None = None,
     ) -> None:
         payload = {
@@ -677,6 +715,7 @@ class BootstrapClient:
             "protocol_version": protocol_version,
             "page_size": page_size,
             "kv_dtype": kv_dtype,
+            "chunk_prefill_transfer": bool(chunk_prefill_transfer),
             "transport_metadata": transport_metadata or {"engine": "jax"},
         }
         last_err: Exception | None = None
@@ -756,6 +795,7 @@ class BootstrapClient:
         chunk_index: int = 0,
         num_chunks: int = 1,
         chunk_page_offset: int = 0,
+        expected_total_pages: int = 0,
         transport_metadata: dict[str, object],
     ) -> None:
         payload = {
@@ -767,6 +807,7 @@ class BootstrapClient:
             "chunk_index": chunk_index,
             "num_chunks": num_chunks,
             "chunk_page_offset": chunk_page_offset,
+            "expected_total_pages": expected_total_pages,
             "transport_metadata": transport_metadata,
         }
         r = self._client.post(

--- a/python/sgl_jax/srt/disaggregation/common/capacity.py
+++ b/python/sgl_jax/srt/disaggregation/common/capacity.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+# At most this many child pulls per parent request are submitted concurrently.
+# The Raiden staging pool reserves the same number of slot waves.
+CHUNK_TRANSFER_WINDOW = 2
+
 
 def per_rank_inflight_limit(max_inflight: int, dp_size: int) -> int:
     """Split the global transfer budget across rank-local managers."""

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -86,6 +86,7 @@ class DecodeBookkeeping:
     # receiver setup can be deferred to the capacity-gated admission step.
     p_info: dict | None = None
     cancelled: bool = False
+    retracted: bool = False
     created_at: float = field(default_factory=time.monotonic)
 
 
@@ -189,6 +190,18 @@ class DecodeTransferQueue:
                     out.append(entry)
         return out
 
+    def retract_all(self) -> list[DecodeBookkeeping]:
+        """Mark active, non-cancelled receivers for retry after terminal drain."""
+
+        with self._lock:
+            entries = [entry for entry in self._entries.values() if not entry.cancelled]
+            for entry in entries:
+                entry.retracted = True
+        for entry in entries:
+            assert entry.receiver is not None
+            entry.receiver.abort()
+        return entries
+
 
 class SchedulerDisaggregationDecodeMixin:
     """Mixin for PD decode mode on Scheduler."""
@@ -217,6 +230,7 @@ class SchedulerDisaggregationDecodeMixin:
             self.process_input_requests_disagg_decode(recv_reqs)
 
             if self._engine_paused:
+                self._drain_decode_transfer_terminals()
                 continue
 
             wd.beat("process_decode_queue")
@@ -384,6 +398,10 @@ class SchedulerDisaggregationDecodeMixin:
         """Drive prealloc -> transfer -> ready transitions."""
 
         self._admit_decode_prealloc()
+        self._drain_decode_transfer_terminals()
+
+    def _drain_decode_transfer_terminals(self: Scheduler) -> None:
+        """Finalize terminal receivers without admitting new work."""
 
         for entry in self._drain_transfer_queue_synced():
             assert entry.receiver is not None
@@ -397,6 +415,12 @@ class SchedulerDisaggregationDecodeMixin:
             if entry.cancelled:
                 if entry.kv_indices is not None:
                     self._release_decode_kv_indices(entry.kv_indices, entry.req.dp_rank)
+                continue
+            if entry.retracted:
+                if entry.kv_indices is not None:
+                    self._release_decode_kv_indices(entry.kv_indices, entry.req.dp_rank)
+                entry.req.reset_for_retract()
+                self._pd_pending_bootstrap.append(entry.req)
                 continue
             if state == KVPoll.SUCCESS:
                 try:

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -17,6 +17,7 @@ from jax.sharding import NamedSharding, PartitionSpec
 from sgl_jax.srt.disaggregation.base.kv_manager import KVPoll, KVReceiver
 from sgl_jax.srt.disaggregation.base.transfer import (
     AdmissionState,
+    DecodeMetadataContext,
     DecodeTransferContext,
     TransferBackend,
 )
@@ -570,6 +571,19 @@ class SchedulerDisaggregationDecodeMixin:
                 capacity_blocked_ranks.add(decode_dp_rank)
                 continue
 
+            metadata_ready = self.disagg_kv_manager.poll_decode_metadata(
+                DecodeMetadataContext(
+                    req_id=entry.req.rid,
+                    transfer_id=get_disagg_transport_id(entry.req),
+                    bootstrap_room=entry.req.bootstrap_room,
+                    prefill_dp_rank=prefill_dp_rank,
+                    peer_info=entry.p_info or {},
+                )
+            )
+            if not metadata_ready:
+                self._expire_decode_prealloc(entry)
+                continue
+
             kv_indices = allocator.alloc(page_aligned, dp_rank=decode_dp_rank)
             if kv_indices is None:
                 capacity_blocked_ranks.add(decode_dp_rank)
@@ -606,11 +620,7 @@ class SchedulerDisaggregationDecodeMixin:
 
             if admission.state == AdmissionState.DEFERRED:
                 self._release_decode_kv_indices(kv_indices, decode_dp_rank)
-                timeout_s = self.server_args.disaggregation_pull_timeout_seconds
-                if timeout_s > 0 and time.monotonic() - entry.created_at >= timeout_s:
-                    self.disagg_prealloc_queue.remove(entry.req_id)
-                    self._record_decode_transfer_failure("metadata_timeout")
-                    self._abort_decode_request(entry.req, "metadata_timeout")
+                self._expire_decode_prealloc(entry)
                 continue
 
             receiver = admission.receiver
@@ -625,6 +635,14 @@ class SchedulerDisaggregationDecodeMixin:
             self.disagg_transfer_queue.add(entry)
             admitted += 1
             admitted_per_dp[decode_dp_rank] += 1
+
+    def _expire_decode_prealloc(self: Scheduler, entry: DecodeBookkeeping) -> None:
+        timeout_s = self.server_args.disaggregation_pull_timeout_seconds
+        if timeout_s <= 0 or time.monotonic() - entry.created_at < timeout_s:
+            return
+        self.disagg_prealloc_queue.remove(entry.req_id)
+        self._record_decode_transfer_failure("metadata_timeout")
+        self._abort_decode_request(entry.req, "metadata_timeout")
 
     # ------------------------------------------------------------------
     # Overridable / test-friendly hooks

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -22,6 +22,10 @@ from sgl_jax.srt.disaggregation.base.transfer import (
 )
 from sgl_jax.srt.disaggregation.bootstrap import BootstrapClient, PrefillInfoCache
 from sgl_jax.srt.disaggregation.common.capacity import per_rank_inflight_limit
+from sgl_jax.srt.managers.schedule_batch import (
+    advance_disagg_transfer_attempt,
+    get_disagg_transport_id,
+)
 from sgl_jax.srt.mem_cache.memory_pool import write_kv_layer
 
 if TYPE_CHECKING:
@@ -419,6 +423,7 @@ class SchedulerDisaggregationDecodeMixin:
             if entry.retracted:
                 if entry.kv_indices is not None:
                     self._release_decode_kv_indices(entry.kv_indices, entry.req.dp_rank)
+                advance_disagg_transfer_attempt(entry.req)
                 entry.req.reset_for_retract()
                 self._pd_pending_bootstrap.append(entry.req)
                 continue
@@ -590,7 +595,7 @@ class SchedulerDisaggregationDecodeMixin:
                 admission = self.disagg_kv_manager.try_start_decode(
                     DecodeTransferContext(
                         req_id=entry.req.rid,
-                        transfer_id=entry.req.disagg_transfer_id or entry.req.rid,
+                        transfer_id=get_disagg_transport_id(entry.req),
                         bootstrap_room=entry.req.bootstrap_room,
                         decode_dp_rank=decode_dp_rank,
                         prefill_dp_rank=prefill_dp_rank,
@@ -857,6 +862,7 @@ class SchedulerDisaggregationDecodeMixin:
                         room,
                         jax_process_index=getattr(req, "disagg_peer_process_index", None),
                         prefill_dp_rank=prefill_dp_rank,
+                        expected_transfer_id=get_disagg_transport_id(req),
                     )
                 except Exception:
                     logger.warning(

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -22,10 +22,7 @@ from sgl_jax.srt.disaggregation.base.transfer import (
 )
 from sgl_jax.srt.disaggregation.bootstrap import BootstrapClient, PrefillInfoCache
 from sgl_jax.srt.disaggregation.common.capacity import per_rank_inflight_limit
-from sgl_jax.srt.managers.schedule_batch import (
-    advance_disagg_transfer_attempt,
-    get_disagg_transport_id,
-)
+from sgl_jax.srt.managers.schedule_batch import get_disagg_transport_id
 from sgl_jax.srt.mem_cache.memory_pool import write_kv_layer
 
 if TYPE_CHECKING:
@@ -90,7 +87,6 @@ class DecodeBookkeeping:
     # receiver setup can be deferred to the capacity-gated admission step.
     p_info: dict | None = None
     cancelled: bool = False
-    retracted: bool = False
     created_at: float = field(default_factory=time.monotonic)
 
 
@@ -193,18 +189,6 @@ class DecodeTransferQueue:
                     entry.cancelled = True
                     out.append(entry)
         return out
-
-    def retract_all(self) -> list[DecodeBookkeeping]:
-        """Mark active, non-cancelled receivers for retry after terminal drain."""
-
-        with self._lock:
-            entries = [entry for entry in self._entries.values() if not entry.cancelled]
-            for entry in entries:
-                entry.retracted = True
-        for entry in entries:
-            assert entry.receiver is not None
-            entry.receiver.abort()
-        return entries
 
 
 class SchedulerDisaggregationDecodeMixin:
@@ -360,6 +344,13 @@ class SchedulerDisaggregationDecodeMixin:
                     expected_transfer_engine=(None if manager is None else manager.engine_name),
                     expected_dp_rank=prefill_dp_rank,
                     expected_dp_size=self.dp_size,
+                    expected_chunk_prefill_transfer=bool(
+                        getattr(
+                            self.server_args,
+                            "disaggregation_enable_chunk_prefill_transfer",
+                            False,
+                        )
+                    ),
                 )
             except ValueError as exc:
                 logger.error(
@@ -419,13 +410,6 @@ class SchedulerDisaggregationDecodeMixin:
             if entry.cancelled:
                 if entry.kv_indices is not None:
                     self._release_decode_kv_indices(entry.kv_indices, entry.req.dp_rank)
-                continue
-            if entry.retracted:
-                if entry.kv_indices is not None:
-                    self._release_decode_kv_indices(entry.kv_indices, entry.req.dp_rank)
-                advance_disagg_transfer_attempt(entry.req)
-                entry.req.reset_for_retract()
-                self._pd_pending_bootstrap.append(entry.req)
                 continue
             if state == KVPoll.SUCCESS:
                 try:

--- a/python/sgl_jax/srt/disaggregation/factory.py
+++ b/python/sgl_jax/srt/disaggregation/factory.py
@@ -5,12 +5,40 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from sgl_jax.srt.disaggregation.common.capacity import per_rank_inflight_limit
+from sgl_jax.srt.disaggregation.common.capacity import (
+    CHUNK_TRANSFER_WINDOW,
+    per_rank_inflight_limit,
+)
 
 if TYPE_CHECKING:
     from sgl_jax.srt.disaggregation.base.transfer import TransferBackend
     from sgl_jax.srt.managers.scheduler import Scheduler
     from sgl_jax.srt.server_args import ServerArgs
+
+
+def _raiden_transfer_pool_shape(
+    *,
+    max_req_input_len: int,
+    page_size: int,
+    parent_slots: int,
+    chunk_prefill_size: int | None,
+    chunk_transfer_enabled: bool,
+) -> tuple[int, int]:
+    """Return ``(max_blocks_per_slot, slots)`` for one Raiden DP rank."""
+
+    max_tokens_per_transfer = int(max_req_input_len)
+    num_slots = int(parent_slots)
+    if chunk_transfer_enabled:
+        if chunk_prefill_size is None or chunk_prefill_size <= 0:
+            raise ValueError("chunk transfer requires a positive chunk_prefill_size")
+        max_tokens_per_transfer = min(max_tokens_per_transfer, int(chunk_prefill_size))
+        # One wave can finish while the following chunk is registered. Raiden
+        # allocates max_blocks worth of host staging for every slot, so size
+        # each slot for one chunk rather than for the whole long prompt.
+        num_slots *= CHUNK_TRANSFER_WINDOW
+    max_blocks = (max_tokens_per_transfer + page_size - 1) // page_size
+    return max(1, max_blocks), max(1, num_slots)
+
 
 logger = logging.getLogger(__name__)
 
@@ -121,9 +149,20 @@ def _create_raiden_backend(
         raise ValueError("Raiden requires max_inflight_transfers > 0")
     if not getattr(server_args, "disable_radix_cache", False):
         raise ValueError("Raiden requires --disable-radix-cache")
+    chunk_transfer_enabled = bool(
+        getattr(server_args, "disaggregation_enable_chunk_prefill_transfer", False)
+    )
+    if (
+        chunk_transfer_enabled
+        and getattr(scheduler, "tree_cache", None) is not None
+        and scheduler.tree_cache.supports_swa()
+    ):
+        raise ValueError("Raiden chunk prefill transfer does not support sliding-window KV")
     if bootstrap_client is None or not hasattr(bootstrap_client, "require_capability"):
         raise RuntimeError("Raiden requires a bootstrap client with capability probing")
     bootstrap_client.require_capability("transfer_metadata")
+    if chunk_transfer_enabled:
+        bootstrap_client.require_capability("chunk_transfer_metadata")
 
     from sgl_jax.raiden import require_raiden_preloaded
 
@@ -141,10 +180,16 @@ def _create_raiden_backend(
         parallelism=server_args.disaggregation_channel_number,
     )
     page_size = max(1, int(server_args.page_size))
-    max_blocks = (int(scheduler.max_req_input_len) + page_size - 1) // page_size
-    num_slots = per_rank_inflight_limit(
+    parent_slots = per_rank_inflight_limit(
         server_args.disaggregation_max_inflight_transfers,
         server_args.dp_size,
+    )
+    max_blocks, num_slots = _raiden_transfer_pool_shape(
+        max_req_input_len=int(scheduler.max_req_input_len),
+        page_size=page_size,
+        parent_slots=parent_slots,
+        chunk_prefill_size=getattr(server_args, "chunked_prefill_size", None),
+        chunk_transfer_enabled=chunk_transfer_enabled,
     )
     wrapper.start(
         kv_caches=list(kv_pool.kv_buffer),
@@ -154,15 +199,22 @@ def _create_raiden_backend(
         timeout_s=float(server_args.disaggregation_pull_timeout_seconds),
     )
     logger.info(
-        "Raiden backend ready: max_blocks=%d slots_per_rank=%d layers=%d dp_size=%d",
+        "Raiden backend ready: max_blocks=%d slots_per_rank=%d layers=%d "
+        "dp_size=%d chunk_transfer=%s",
         max_blocks,
         num_slots,
         kv_pool.layer_num,
         server_args.dp_size,
+        chunk_transfer_enabled,
     )
     return RaidenTransferKVManager(
         wrapper,
         bootstrap_client,
+        enable_chunk_prefill_transfer=getattr(
+            server_args,
+            "disaggregation_enable_chunk_prefill_transfer",
+            False,
+        ),
         ack_timeout_seconds=server_args.disaggregation_ack_timeout_seconds,
         pull_timeout_seconds=server_args.disaggregation_pull_timeout_seconds,
         reaper_interval_seconds=server_args.disaggregation_orphan_reaper_interval_seconds,

--- a/python/sgl_jax/srt/disaggregation/factory.py
+++ b/python/sgl_jax/srt/disaggregation/factory.py
@@ -134,6 +134,12 @@ def _create_jax_backend(
     )
 
 
+def _tree_cache_supports_swa(tree_cache: object) -> bool:
+    """Probe optional SWA support without requiring every cache to implement it."""
+    supports_swa = getattr(tree_cache, "supports_swa", None)
+    return bool(supports_swa()) if callable(supports_swa) else False
+
+
 def _create_raiden_backend(
     scheduler: Scheduler,
     server_args: ServerArgs,
@@ -155,7 +161,7 @@ def _create_raiden_backend(
     if (
         chunk_transfer_enabled
         and getattr(scheduler, "tree_cache", None) is not None
-        and scheduler.tree_cache.supports_swa()
+        and _tree_cache_supports_swa(scheduler.tree_cache)
     ):
         raise ValueError("Raiden chunk prefill transfer does not support sliding-window KV")
     if bootstrap_client is None or not hasattr(bootstrap_client, "require_capability"):

--- a/python/sgl_jax/srt/disaggregation/jax_transfer/conn.py
+++ b/python/sgl_jax/srt/disaggregation/jax_transfer/conn.py
@@ -257,8 +257,9 @@ class JaxTransferKVManager(CommonKVManager):
         *,
         jax_process_index: int | None = None,
         prefill_dp_rank: int = 0,
+        expected_transfer_id: str | None = None,
     ) -> None:
-        del bootstrap_room, jax_process_index, prefill_dp_rank
+        del bootstrap_room, jax_process_index, prefill_dp_rank, expected_transfer_id
         return
 
     # ------------------------------------------------------------------

--- a/python/sgl_jax/srt/disaggregation/jax_transfer/conn.py
+++ b/python/sgl_jax/srt/disaggregation/jax_transfer/conn.py
@@ -32,6 +32,7 @@ from sgl_jax.srt.disaggregation.base.kv_manager import (
 )
 from sgl_jax.srt.disaggregation.base.transfer import (
     DecodeAdmission,
+    DecodeMetadataContext,
     DecodeTransferContext,
     PrefillTransfer,
     PrefillTransferContext,
@@ -250,6 +251,10 @@ class JaxTransferKVManager(CommonKVManager):
                 receiver.fail(reason="receiver_init")
             raise
         return DecodeAdmission.admitted(receiver)
+
+    def poll_decode_metadata(self, context: DecodeMetadataContext) -> bool:
+        del context
+        return True
 
     def cleanup_transfer(
         self,

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -277,12 +277,23 @@ class SchedulerDisaggregationPrefillMixin:
         self.set_next_batch_sampling_info_done(batch)
 
         chunked_now = tuple(r for r in getattr(self, "chunked_reqs", ()) if r is not None)
-        ready_to_transfer = [
-            req
-            for req in pd_reqs
-            if not any(req is chunked_req for chunked_req in chunked_now)
-            and req.rid not in self.disagg_prefill_queue._entries
-        ]
+        chunk_transfer_enabled = bool(
+            getattr(
+                self.server_args,
+                "disaggregation_enable_chunk_prefill_transfer",
+                False,
+            )
+        )
+        ready_to_transfer = (
+            list(pd_reqs)
+            if chunk_transfer_enabled
+            else [
+                req
+                for req in pd_reqs
+                if not any(req is chunked_req for chunked_req in chunked_now)
+                and req.rid not in self.disagg_prefill_queue._entries
+            ]
+        )
         if ready_to_transfer:
             kv_pool = self.token_to_kv_pool_allocator.get_kvcache()
             self.disagg_kv_manager.prepare_prefill_batch(kv_pool.kv_buffer)
@@ -291,6 +302,11 @@ class SchedulerDisaggregationPrefillMixin:
                 continue
             req_id = req.rid
             is_mid_chunk = any(req is cr for cr in chunked_now)
+            if chunk_transfer_enabled:
+                self._raiden_handoff_chunk(req, is_final=not is_mid_chunk)
+                if is_mid_chunk and req.is_chunked > 0:
+                    req.is_chunked -= 1
+                continue
             if is_mid_chunk:
                 # Still mid-chunk: KV is incomplete, and releasing the
                 # req_pool_idx here would leak the slot the next chunk
@@ -376,17 +392,131 @@ class SchedulerDisaggregationPrefillMixin:
         ts.mark(name)
 
     def _extract_req_block_ids(self: Scheduler, req: Req) -> list[int]:
+        return self._extract_req_block_ids_range(req, 0, len(req.origin_input_ids))
+
+    def _extract_req_block_ids_range(
+        self: Scheduler,
+        req: Req,
+        start: int,
+        end: int,
+    ) -> list[int]:
         from sgl_jax.srt.disaggregation.base.transfer import slots_to_page_ids
 
         req_to_token = self.req_to_token_pool.req_to_token
         kv_pool = self.token_to_kv_pool_allocator.get_kvcache()
         page_size = kv_pool.page_size
-        seqlen = len(req.origin_input_ids)
+        if not 0 <= start < end <= len(req.origin_input_ids):
+            raise ValueError(
+                f"invalid prefill chunk token range [{start}, {end}) for "
+                f"prompt length {len(req.origin_input_ids)}"
+            )
+        if start % page_size:
+            raise ValueError(
+                f"prefill chunk starts at unaligned token {start} for page_size={page_size}"
+            )
         slot_source = req_to_token[
             req.req_pool_idx,
-            :seqlen,
+            start:end,
         ]
-        return list(slots_to_page_ids(slot_source, page_size, seqlen))
+        return list(slots_to_page_ids(slot_source, page_size, end - start))
+
+    def _raiden_handoff_chunk(self: Scheduler, req: Req, *, is_final: bool) -> None:
+        """Register exactly the KV pages produced by the current prefill round."""
+
+        req_id = req.rid
+        sender = req.disagg_chunk_sender
+        if sender is not None and sender.has_pending_failure:
+            self._retire_failed_chunk_producer(req)
+            return
+
+        end = len(req.fill_ids)
+        scheduled_start = end - req.extend_input_len
+        start = int(req.start_send_idx)
+        if start != scheduled_start:
+            error = RuntimeError(
+                "chunk transfer cursor diverged from the scheduled prefix: "
+                f"cursor={start}, scheduled_start={scheduled_start}, end={end}"
+            )
+            logger.error("%s req_id=%s", error, req_id)
+            if sender is None or not sender.has_started_chunks:
+                self._abort_prefill_req(
+                    req,
+                    f"Prefill chunk handoff failed for req_id={req_id!r}: {error}",
+                    metric_reason="chunk_cursor",
+                )
+            else:
+                sender.fail(reason="chunk_cursor")
+            self._retire_failed_chunk_producer(req)
+            return
+
+        created_sender = False
+        if sender is None:
+            sender = self.disagg_kv_manager.create_sender(req_id)
+            sender.init(None, transfer_id=req.disagg_transfer_id or req_id)
+            req.disagg_chunk_sender = sender
+            created_sender = True
+
+        try:
+            page_size = self.token_to_kv_pool_allocator.get_kvcache().page_size
+            if not is_final and end % page_size:
+                raise ValueError(
+                    f"middle chunk ends at unaligned token {end} for page_size={page_size}"
+                )
+            block_ids = self._extract_req_block_ids_range(req, start, end)
+            sender.send_chunk(
+                req.disagg_chunk_index,
+                block_ids,
+                bootstrap_room=int(req.bootstrap_room),
+                chunk_page_offset=start // page_size,
+                is_final=is_final,
+                dp_rank=int(req.dp_rank),
+            )
+        except Exception as exc:
+            logger.exception(
+                "Raiden chunk handoff failed for req_id=%s chunk=%d",
+                req_id,
+                req.disagg_chunk_index,
+            )
+            if sender.has_started_chunks:
+                sender.fail(reason="chunk_handoff")
+                self._ensure_chunk_sender_queued(req, sender)
+                self._retire_failed_chunk_producer(req)
+            else:
+                with suppress(Exception):
+                    sender.abort()
+                with suppress(Exception):
+                    sender.clear()
+                req.disagg_chunk_sender = None
+                self._abort_prefill_req(
+                    req,
+                    f"Prefill chunk handoff failed for req_id={req_id!r}: {exc}",
+                    metric_reason="sender_init",
+                )
+                self._retire_failed_chunk_producer(req)
+            return
+
+        req.start_send_idx = end
+        req.disagg_chunk_index += 1
+        if created_sender:
+            self._pd_mark_time(req, "transfer_start")
+        self._ensure_chunk_sender_queued(req, sender)
+
+    def _ensure_chunk_sender_queued(self: Scheduler, req: Req, sender: KVSender) -> None:
+        if req.rid in self.disagg_prefill_queue._entries:
+            return
+
+        def _on_terminal(req_obj=req, sender_obj=sender):
+            self._on_prefill_transfer_terminal(req_obj, sender_obj)
+
+        self.disagg_prefill_queue.add(req.rid, sender, on_terminal=_on_terminal)
+
+    def _retire_failed_chunk_producer(self: Scheduler, req: Req) -> None:
+        dp_rank = int(req.dp_rank)
+        if self.chunked_reqs[dp_rank] is req:
+            self.chunked_reqs[dp_rank] = None
+        pending = getattr(self, "_pending_chunked_abort_reqs", None)
+        if pending is not None and pending[dp_rank] is req:
+            pending[dp_rank] = None
 
     def _extract_req_kv(self: Scheduler, req: Req):
         """Gather prefilled KV from the paged pool for ``req``.

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -18,10 +18,7 @@ from sgl_jax.srt.disaggregation.base.transfer import (
     PrefillTransferContext,
     TransferBackend,
 )
-from sgl_jax.srt.managers.schedule_batch import (
-    advance_disagg_transfer_attempt,
-    get_disagg_transport_id,
-)
+from sgl_jax.srt.managers.schedule_batch import get_disagg_transport_id
 
 if TYPE_CHECKING:
     from sgl_jax.srt.managers.schedule_batch import Req
@@ -226,20 +223,6 @@ class PrefillBootstrapQueue:
                     out.append(entry)
             return out
 
-    def retract_all(self) -> list[PrefillBookkeeping]:
-        """Mark live, non-cancelled transfers for retry after terminal drain."""
-
-        with self._lock:
-            entries = [
-                entry
-                for entry in self._entries.values()
-                if not entry.cancelled and entry.req is not None
-            ]
-        for entry in entries:
-            entry.req.disagg_retract_pending = True
-            entry.sender.abort()
-        return entries
-
 
 class SchedulerDisaggregationPrefillMixin:
     """Mixin for PD prefill mode on Scheduler."""
@@ -313,16 +296,13 @@ class SchedulerDisaggregationPrefillMixin:
                 False,
             )
         )
-        ready_to_transfer = (
-            list(pd_reqs)
-            if chunk_transfer_enabled
-            else [
-                req
-                for req in pd_reqs
-                if not any(req is chunked_req for chunked_req in chunked_now)
-                and req.rid not in self.disagg_prefill_queue._entries
-            ]
-        )
+        ready_to_transfer = [
+            req
+            for req in pd_reqs
+            if not chunk_transfer_enabled
+            and not any(req is chunked_req for chunked_req in chunked_now)
+            and req.rid not in self.disagg_prefill_queue._entries
+        ]
         if ready_to_transfer:
             kv_pool = self.token_to_kv_pool_allocator.get_kvcache()
             self.disagg_kv_manager.prepare_prefill_batch(kv_pool.kv_buffer)
@@ -491,12 +471,30 @@ class SchedulerDisaggregationPrefillMixin:
             created_sender = True
 
         try:
-            page_size = self.token_to_kv_pool_allocator.get_kvcache().page_size
+            kv_pool = self.token_to_kv_pool_allocator.get_kvcache()
+            page_size = kv_pool.page_size
             if not is_final and end % page_size:
                 raise ValueError(
                     f"middle chunk ends at unaligned token {end} for page_size={page_size}"
                 )
             block_ids = self._extract_req_block_ids_range(req, start, end)
+            expected_total_pages = (len(req.origin_input_ids) + page_size - 1) // page_size
+            if is_final:
+                from sgl_jax.srt.disaggregation.debug_utils import kv_debug_enabled
+
+                if kv_debug_enabled(req_id):
+                    from sgl_jax.srt.disaggregation.raiden_transfer.conn import (
+                        _debug_metadata,
+                    )
+
+                    payload = {"kv": self._extract_req_kv(req)}
+                    self._maybe_log_prefill_extract_debug(
+                        req,
+                        payload["kv"],
+                        use_d2h_staging=False,
+                        chunk_transfer=True,
+                    )
+                    sender.attach_debug_metadata(_debug_metadata(payload, expected_total_pages))
             sender.send_chunk(
                 req.disagg_chunk_index,
                 block_ids,
@@ -504,6 +502,10 @@ class SchedulerDisaggregationPrefillMixin:
                 chunk_page_offset=start // page_size,
                 is_final=is_final,
                 dp_rank=int(req.dp_rank),
+                expected_total_pages=expected_total_pages,
+                on_ready=lambda buffers=kv_pool.kv_buffer: (
+                    self.disagg_kv_manager.prepare_prefill_batch(buffers)
+                ),
             )
         except Exception as exc:
             logger.exception(
@@ -694,12 +696,9 @@ class SchedulerDisaggregationPrefillMixin:
             sender.clear()
             return
 
-        retract_pending = bool(getattr(req, "disagg_retract_pending", False))
         try:
             state = sender.poll()
-            if retract_pending:
-                pass
-            elif req.to_finish is not None:
+            if req.to_finish is not None:
                 req.check_finished()
                 req.output_ids = []
                 self._stream_prefill_req(req)
@@ -720,11 +719,6 @@ class SchedulerDisaggregationPrefillMixin:
             self._release_prefill_req_resources(req)
             if req.disagg_chunk_sender is sender:
                 req.disagg_chunk_sender = None
-
-        if retract_pending:
-            advance_disagg_transfer_attempt(req)
-            req.reset_for_retract()
-            self._add_request_to_queue(req)
 
     def _finish_prefill_only_success(self: Scheduler, req: Req) -> None:
         from sgl_jax.srt.managers.schedule_batch import FINISH_LENGTH

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -236,6 +236,10 @@ class SchedulerDisaggregationPrefillMixin:
             self.process_input_requests(recv_reqs)
 
             if self._engine_paused:
+                # Cancellation/retract keeps Raiden-owned source pages alive
+                # until the sender becomes terminal. Continue draining those
+                # senders while scheduling itself is paused.
+                self.send_kv_chunk()
                 continue
 
             batch = self.get_next_batch_to_run()
@@ -648,8 +652,23 @@ class SchedulerDisaggregationPrefillMixin:
         req: Req,
         sender: KVSender,
     ) -> None:
+        if req.disagg_chunk_sender is not None and req.disagg_chunk_sender is not sender:
+            # A callback from an older transfer attempt must never finish or
+            # release allocations belonging to a re-admitted request.
+            logger.warning("Ignoring stale prefill sender callback for req_id=%s", req.rid)
+            sender.clear()
+            return
+
+        retract_pending = bool(getattr(req, "disagg_retract_pending", False))
         try:
-            if sender.poll() == KVPoll.SUCCESS:
+            state = sender.poll()
+            if retract_pending:
+                pass
+            elif req.to_finish is not None:
+                req.check_finished()
+                req.output_ids = []
+                self._stream_prefill_req(req)
+            elif state == KVPoll.SUCCESS:
                 self._finish_prefill_only_success(req)
             else:
                 self._finish_prefill_only_failure(req, sender)
@@ -664,6 +683,12 @@ class SchedulerDisaggregationPrefillMixin:
             )
             sender.clear()
             self._release_prefill_req_resources(req)
+            if req.disagg_chunk_sender is sender:
+                req.disagg_chunk_sender = None
+
+        if retract_pending:
+            req.reset_for_retract()
+            self._add_request_to_queue(req)
 
     def _finish_prefill_only_success(self: Scheduler, req: Req) -> None:
         from sgl_jax.srt.managers.schedule_batch import FINISH_LENGTH

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -555,6 +555,15 @@ class SchedulerDisaggregationPrefillMixin:
         dp_rank = int(req.dp_rank)
         if self.chunked_reqs[dp_rank] is req:
             self.chunked_reqs[dp_rank] = None
+        last_batch = getattr(self, "last_batch", None)
+        if last_batch is not None and last_batch.forward_mode.is_extend():
+            info = last_batch.reqs_info[dp_rank]
+            if info.chunked_req is req:
+                # The sender terminal callback can release the request slot and
+                # KV pages before the next scheduler tick. Drop the batch-side
+                # owner as well so _sync_chunked_req_owners cannot resurrect a
+                # producer whose allocations are already reusable.
+                info.chunked_req = None
         pending = getattr(self, "_pending_chunked_abort_reqs", None)
         if pending is not None and pending[dp_rank] is req:
             pending[dp_rank] = None

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -18,6 +18,10 @@ from sgl_jax.srt.disaggregation.base.transfer import (
     PrefillTransferContext,
     TransferBackend,
 )
+from sgl_jax.srt.managers.schedule_batch import (
+    advance_disagg_transfer_attempt,
+    get_disagg_transport_id,
+)
 
 if TYPE_CHECKING:
     from sgl_jax.srt.managers.schedule_batch import Req
@@ -349,7 +353,7 @@ class SchedulerDisaggregationPrefillMixin:
                 transfer = self.disagg_kv_manager.start_prefill(
                     PrefillTransferContext(
                         req_id=req_id,
-                        transfer_id=req.disagg_transfer_id or req_id,
+                        transfer_id=get_disagg_transport_id(req),
                         bootstrap_room=req.bootstrap_room,
                         dp_rank=int(req.dp_rank),
                         buffer_id=req.disagg_host_buffer_id,
@@ -482,7 +486,7 @@ class SchedulerDisaggregationPrefillMixin:
         created_sender = False
         if sender is None:
             sender = self.disagg_kv_manager.create_sender(req_id)
-            sender.init(None, transfer_id=req.disagg_transfer_id or req_id)
+            sender.init(None, transfer_id=get_disagg_transport_id(req))
             req.disagg_chunk_sender = sender
             created_sender = True
 
@@ -718,6 +722,7 @@ class SchedulerDisaggregationPrefillMixin:
                 req.disagg_chunk_sender = None
 
         if retract_pending:
+            advance_disagg_transfer_attempt(req)
             req.reset_for_retract()
             self._add_request_to_queue(req)
 

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -440,7 +440,7 @@ class SchedulerDisaggregationPrefillMixin:
         req_id = req.rid
         sender = req.disagg_chunk_sender
         if sender is not None and sender.has_pending_failure:
-            self._retire_failed_chunk_producer(req)
+            self._retire_chunk_producer_ownership(req)
             return
 
         end = len(req.fill_ids)
@@ -460,7 +460,7 @@ class SchedulerDisaggregationPrefillMixin:
                 )
             else:
                 sender.fail(reason="chunk_cursor")
-            self._retire_failed_chunk_producer(req)
+            self._retire_chunk_producer_ownership(req)
             return
 
         created_sender = False
@@ -516,7 +516,7 @@ class SchedulerDisaggregationPrefillMixin:
             if sender.has_started_chunks:
                 sender.fail(reason="chunk_handoff")
                 self._ensure_chunk_sender_queued(req, sender)
-                self._retire_failed_chunk_producer(req)
+                self._retire_chunk_producer_ownership(req)
             else:
                 with suppress(Exception):
                     sender.abort()
@@ -528,7 +528,7 @@ class SchedulerDisaggregationPrefillMixin:
                     f"Prefill chunk handoff failed for req_id={req_id!r}: {exc}",
                     metric_reason="sender_init",
                 )
-                self._retire_failed_chunk_producer(req)
+                self._retire_chunk_producer_ownership(req)
             return
 
         req.start_send_idx = end
@@ -551,7 +551,7 @@ class SchedulerDisaggregationPrefillMixin:
             req=req,
         )
 
-    def _retire_failed_chunk_producer(self: Scheduler, req: Req) -> None:
+    def _retire_chunk_producer_ownership(self: Scheduler, req: Req) -> None:
         dp_rank = int(req.dp_rank)
         if self.chunked_reqs[dp_rank] is req:
             self.chunked_reqs[dp_rank] = None
@@ -704,6 +704,12 @@ class SchedulerDisaggregationPrefillMixin:
             logger.warning("Ignoring stale prefill sender callback for req_id=%s", req.rid)
             sender.clear()
             return
+
+        if req.disagg_chunk_sender is sender:
+            # The terminal callback is the single resource-release choke point
+            # for asynchronous read failures. Retire every scheduler owner
+            # before the request slot and KV pages become reusable.
+            self._retire_chunk_producer_ownership(req)
 
         try:
             state = sender.poll()

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -155,10 +155,12 @@ class PrefillBookkeeping:
 
     req_id: str
     sender: KVSender
+    req: Req | None = None
     # Optional callback the scheduler runs when this entry reaches a
     # terminal state — used to release ``req_to_token_pool`` and any
     # owned KV indices.
     on_terminal: object | None = None
+    cancelled: bool = False
 
 
 class PrefillBootstrapQueue:
@@ -177,12 +179,16 @@ class PrefillBootstrapQueue:
         req_id: str,
         sender: KVSender,
         on_terminal=None,
+        req: Req | None = None,
     ) -> None:
         with self._lock:
             if req_id in self._entries:
                 raise ValueError(f"PrefillBootstrapQueue already tracks req_id={req_id!r}")
             self._entries[req_id] = PrefillBookkeeping(
-                req_id=req_id, sender=sender, on_terminal=on_terminal
+                req_id=req_id,
+                sender=sender,
+                req=req,
+                on_terminal=on_terminal,
             )
 
     def drain_terminal(self) -> list[PrefillBookkeeping]:
@@ -209,11 +215,26 @@ class PrefillBootstrapQueue:
         """Return matching entries without releasing their owned KV pages."""
 
         with self._lock:
-            return [
+            out = []
+            for req_id, entry in self._entries.items():
+                if abort_all or req_id.startswith(rid_prefix):
+                    entry.cancelled = True
+                    out.append(entry)
+            return out
+
+    def retract_all(self) -> list[PrefillBookkeeping]:
+        """Mark live, non-cancelled transfers for retry after terminal drain."""
+
+        with self._lock:
+            entries = [
                 entry
-                for req_id, entry in self._entries.items()
-                if abort_all or req_id.startswith(rid_prefix)
+                for entry in self._entries.values()
+                if not entry.cancelled and entry.req is not None
             ]
+        for entry in entries:
+            entry.req.disagg_retract_pending = True
+            entry.sender.abort()
+        return entries
 
 
 class SchedulerDisaggregationPrefillMixin:
@@ -359,7 +380,12 @@ class SchedulerDisaggregationPrefillMixin:
             def _on_terminal(req_obj=req, sender_obj=transfer.sender):
                 self._on_prefill_transfer_terminal(req_obj, sender_obj)
 
-            self.disagg_prefill_queue.add(req_id, transfer.sender, on_terminal=_on_terminal)
+            self.disagg_prefill_queue.add(
+                req_id,
+                transfer.sender,
+                on_terminal=_on_terminal,
+                req=req,
+            )
 
     def send_kv_chunk(self: Scheduler) -> None:
         """Reap senders that reached SUCCESS / FAILED."""
@@ -512,7 +538,12 @@ class SchedulerDisaggregationPrefillMixin:
         def _on_terminal(req_obj=req, sender_obj=sender):
             self._on_prefill_transfer_terminal(req_obj, sender_obj)
 
-        self.disagg_prefill_queue.add(req.rid, sender, on_terminal=_on_terminal)
+        self.disagg_prefill_queue.add(
+            req.rid,
+            sender,
+            on_terminal=_on_terminal,
+            req=req,
+        )
 
     def _retire_failed_chunk_producer(self: Scheduler, req: Req) -> None:
         dp_rank = int(req.dp_rank)

--- a/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
+++ b/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
@@ -26,6 +26,7 @@ from sgl_jax.srt.disaggregation.base.transfer import (
     PrefillTransferContext,
     slots_to_page_ids,
 )
+from sgl_jax.srt.disaggregation.common.capacity import CHUNK_TRANSFER_WINDOW
 from sgl_jax.srt.disaggregation.common.core import CommonKVManager
 from sgl_jax.srt.disaggregation.common.metrics import (
     PD_TRANSFER_FAILURES_TOTAL,
@@ -141,6 +142,41 @@ class RaidenMetadata:
     expected_debug: Mapping[str, object] | None = None
 
 
+@dataclass(frozen=True)
+class RaidenChunkedMetadata:
+    base_uuid: str
+    remote_endpoint: object
+    local_block_ids: tuple[int, ...]
+    bootstrap_room: int
+    jax_process_index: int
+    prefill_dp_rank: int
+    decode_dp_rank: int
+    initial_chunks: Mapping[int, Mapping[str, object]]
+    known_num_chunks: int = 0
+    direct_commit: Callable[[Mapping[str, object] | None], None] | None = None
+
+
+def _normalize_transfer_bundle(
+    info: Mapping[str, object],
+) -> tuple[dict[int, Mapping[str, object]], int]:
+    """Normalize v5 metadata and the pre-v5 flat shape used by test doubles."""
+
+    raw_chunks = info.get("chunks")
+    if raw_chunks is None:
+        return {0: info}, 1
+    if not isinstance(raw_chunks, Mapping):
+        raise TypeError("Raiden transfer chunks must be a mapping")
+    chunks: dict[int, Mapping[str, object]] = {}
+    for raw_index, value in raw_chunks.items():
+        if not isinstance(value, Mapping):
+            raise TypeError("Raiden chunk metadata must be a mapping")
+        chunks[int(raw_index)] = value
+    num_chunks = int(info.get("num_chunks", 0) or 0)
+    if num_chunks < 0:
+        raise ValueError("Raiden num_chunks must be non-negative")
+    return chunks, num_chunks
+
+
 class RaidenTransferKVManager(CommonKVManager):
     engine_name = "raiden"
     requires_host_staging = False
@@ -151,6 +187,7 @@ class RaidenTransferKVManager(CommonKVManager):
         wrapper: RaidenTransferWrapper,
         bootstrap_client: object,
         *,
+        enable_chunk_prefill_transfer: bool = False,
         ack_timeout_seconds: float = 60.0,
         pull_timeout_seconds: float = 30.0,
         reaper_interval_seconds: float = 5.0,
@@ -162,6 +199,7 @@ class RaidenTransferKVManager(CommonKVManager):
         )
         self.wrapper = wrapper
         self.bootstrap_client = bootstrap_client
+        self.enable_chunk_prefill_transfer = bool(enable_chunk_prefill_transfer)
         self._poll_lock = threading.Lock()
         self._done_sending: set[str] = set()
         self._done_receiving: set[str] = set()
@@ -246,26 +284,28 @@ class RaidenTransferKVManager(CommonKVManager):
 
         receiver: RaidenTransferKVReceiver | None = None
         try:
-            if str(info.get("transfer_id", "")) != context.transfer_id:
+            chunks, known_num_chunks = _normalize_transfer_bundle(info)
+            if not chunks:
+                return DecodeAdmission.deferred("metadata_pending")
+            first_chunk = chunks.get(0)
+            if first_chunk is None:
+                return DecodeAdmission.deferred("chunk_zero_pending")
+
+            expected_first_id = (
+                f"{context.transfer_id}#c0"
+                if self.enable_chunk_prefill_transfer
+                else context.transfer_id
+            )
+            if str(first_chunk.get("transfer_id", "")) != expected_first_id:
                 raise ValueError(
                     "Raiden transfer ID mismatch: "
-                    f"expected={context.transfer_id!r}, got={info.get('transfer_id')!r}"
+                    f"expected={expected_first_id!r}, got={first_chunk.get('transfer_id')!r}"
                 )
-            metadata_prefill_dp_rank = int(info.get("prefill_dp_rank", 0))
+            metadata_prefill_dp_rank = int(first_chunk.get("prefill_dp_rank", 0))
             if metadata_prefill_dp_rank != context.prefill_dp_rank:
                 raise ValueError(
                     "Raiden transfer Prefill rank mismatch: "
                     f"expected={context.prefill_dp_rank}, got={metadata_prefill_dp_rank}"
-                )
-            metadata = info.get("transport_metadata", info)
-            if not isinstance(metadata, dict):
-                raise TypeError("Raiden request transport_metadata must be a mapping")
-            remote_block_ids = tuple(int(v) for v in metadata.get("remote_block_ids", ()))
-            expected_blocks = (context.prompt_tokens + context.page_size - 1) // context.page_size
-            if len(remote_block_ids) != expected_blocks:
-                raise ValueError(
-                    f"Raiden block count mismatch: expected={expected_blocks}, "
-                    f"remote={len(remote_block_ids)}"
                 )
 
             peer_metadata = context.peer_info.get("transport_metadata")
@@ -302,37 +342,68 @@ class RaidenTransferKVManager(CommonKVManager):
             remote_endpoint: object = (
                 peer_endpoints[0]["endpoint"] if len(peer_endpoints) == 1 else peer_endpoints
             )
-
             local_block_ids = slots_to_page_ids(
                 context.kv_indices,
                 context.page_size,
                 context.prompt_tokens,
             )
-            if len(local_block_ids) != len(remote_block_ids):
-                raise ValueError(
-                    f"Raiden local block count mismatch: remote={len(remote_block_ids)}, "
-                    f"local={len(local_block_ids)}"
-                )
 
             receiver = self.create_receiver(context.req_id)
-            receiver.init(
-                RaidenMetadata(
-                    uuid=context.transfer_id,
-                    remote_endpoint=remote_endpoint,
-                    remote_block_ids=remote_block_ids,
-                    local_block_ids=local_block_ids,
-                    bootstrap_room=context.bootstrap_room,
-                    jax_process_index=peer_process_index,
-                    prefill_dp_rank=context.prefill_dp_rank,
-                    decode_dp_rank=context.decode_dp_rank,
-                    direct_commit=context.direct_commit,
-                    expected_debug=(
-                        metadata.get("kv_debug")
-                        if isinstance(metadata.get("kv_debug"), Mapping)
-                        else None
-                    ),
+            if self.enable_chunk_prefill_transfer:
+                receiver.init(
+                    RaidenChunkedMetadata(
+                        base_uuid=context.transfer_id,
+                        remote_endpoint=remote_endpoint,
+                        local_block_ids=local_block_ids,
+                        bootstrap_room=int(context.bootstrap_room),
+                        jax_process_index=peer_process_index,
+                        prefill_dp_rank=context.prefill_dp_rank,
+                        decode_dp_rank=context.decode_dp_rank,
+                        initial_chunks=chunks,
+                        known_num_chunks=known_num_chunks,
+                        direct_commit=context.direct_commit,
+                    )
                 )
-            )
+            else:
+                if known_num_chunks != 1 or set(chunks) != {0}:
+                    raise ValueError(
+                        "request-level Raiden transfer requires exactly one finalized chunk"
+                    )
+                metadata = first_chunk.get("transport_metadata", first_chunk)
+                if not isinstance(metadata, Mapping):
+                    raise TypeError("Raiden request transport_metadata must be a mapping")
+                remote_block_ids = tuple(int(v) for v in metadata.get("remote_block_ids", ()))
+                expected_blocks = (
+                    context.prompt_tokens + context.page_size - 1
+                ) // context.page_size
+                if len(remote_block_ids) != expected_blocks:
+                    raise ValueError(
+                        f"Raiden block count mismatch: expected={expected_blocks}, "
+                        f"remote={len(remote_block_ids)}"
+                    )
+                if len(local_block_ids) != len(remote_block_ids):
+                    raise ValueError(
+                        f"Raiden local block count mismatch: remote={len(remote_block_ids)}, "
+                        f"local={len(local_block_ids)}"
+                    )
+                receiver.init(
+                    RaidenMetadata(
+                        uuid=context.transfer_id,
+                        remote_endpoint=remote_endpoint,
+                        remote_block_ids=remote_block_ids,
+                        local_block_ids=local_block_ids,
+                        bootstrap_room=context.bootstrap_room,
+                        jax_process_index=peer_process_index,
+                        prefill_dp_rank=context.prefill_dp_rank,
+                        decode_dp_rank=context.decode_dp_rank,
+                        direct_commit=context.direct_commit,
+                        expected_debug=(
+                            metadata.get("kv_debug")
+                            if isinstance(metadata.get("kv_debug"), Mapping)
+                            else None
+                        ),
+                    )
+                )
             return DecodeAdmission.admitted(receiver)
         except Exception:
             if receiver is not None:
@@ -363,6 +434,11 @@ class RaidenTransferKVManager(CommonKVManager):
         bootstrap_room: int | None,
         debug_metadata: Mapping[str, object] | None,
         dp_rank: int = 0,
+        *,
+        base_transfer_id: str | None = None,
+        chunk_index: int = 0,
+        num_chunks: int = 1,
+        chunk_page_offset: int = 0,
     ) -> None:
         if bootstrap_room is None:
             return
@@ -372,8 +448,12 @@ class RaidenTransferKVManager(CommonKVManager):
         self.bootstrap_client.register_transfer(
             bootstrap_room,
             transfer_id,
+            base_transfer_id=base_transfer_id,
             jax_process_index=jax.process_index(),
             prefill_dp_rank=dp_rank,
+            chunk_index=chunk_index,
+            num_chunks=num_chunks,
+            chunk_page_offset=chunk_page_offset,
             transport_metadata=transport_metadata,
         )
 
@@ -478,6 +558,9 @@ class RaidenTransferKVSender(KVSender, StateHolder):
         self._transfer_started_at: float | None = None
         self._pending_failure_reason: str | None = None
         self._debug_metadata: Mapping[str, object] | None = None
+        self._chunk_mode = False
+        self._started_chunks: set[int] = set()
+        self._num_chunks: int | None = None
 
     @property
     def uuid(self) -> str:
@@ -486,6 +569,16 @@ class RaidenTransferKVSender(KVSender, StateHolder):
     @property
     def transfer_started_at(self) -> float | None:
         return self._transfer_started_at
+
+    @property
+    def has_pending_failure(self) -> bool:
+        with self._state_lock:
+            return self._pending_failure_reason is not None
+
+    @property
+    def has_started_chunks(self) -> bool:
+        with self._state_lock:
+            return bool(self._started_chunks)
 
     def init(self, kv_indices, transfer_id: str | None = None) -> None:
         del kv_indices
@@ -507,6 +600,80 @@ class RaidenTransferKVSender(KVSender, StateHolder):
 
     def attach_debug_metadata(self, metadata: Mapping[str, object]) -> None:
         self._debug_metadata = dict(metadata)
+
+    def send_chunk(
+        self,
+        chunk_index: int,
+        block_ids: list[int],
+        *,
+        bootstrap_room: int,
+        chunk_page_offset: int,
+        is_final: bool,
+        dp_rank: int = 0,
+    ) -> None:
+        """Register and publish one newly-computed prefill chunk."""
+
+        if not self._manager.enable_chunk_prefill_transfer:
+            raise RuntimeError("chunk transfer is disabled on this Raiden manager")
+        chunk_index = int(chunk_index)
+        if chunk_index < 0:
+            raise ValueError("chunk_index must be non-negative")
+        if not block_ids:
+            raise ValueError("Raiden chunk transfer requires at least one KV block")
+        child_id = f"{self.uuid}#c{chunk_index}"
+        with self._state_lock:
+            if self.state not in (KVPoll.WAITING_FOR_INPUT, KVPoll.TRANSFERRING):
+                raise RuntimeError(f"cannot send chunk from terminal state {self.state.value}")
+            if chunk_index in self._started_chunks:
+                raise RuntimeError(f"chunk_index={chunk_index} was already registered")
+            if self._num_chunks is not None:
+                raise RuntimeError("cannot register a chunk after the final chunk")
+
+        needed = self._manager.register_read(
+            child_id,
+            child_id,
+            list(block_ids),
+            dp_rank=int(dp_rank),
+        )
+        if not needed:
+            raise RuntimeError(f"Raiden declined non-empty chunk transfer for {child_id!r}")
+
+        with self._state_lock:
+            self._chunk_mode = True
+            self._bootstrap_room = int(bootstrap_room)
+            self._dp_rank = int(dp_rank)
+            self._started_chunks.add(chunk_index)
+            if is_final:
+                self._num_chunks = chunk_index + 1
+            if self.state == KVPoll.WAITING_FOR_INPUT:
+                self._transition_to(KVPoll.TRANSFERRING)
+                self._timer = time_phase("ack", "prefill")
+                self._timer.__enter__()
+            # Timeout each producer-to-consumer progress interval rather than
+            # the whole long prompt. Otherwise a healthy multi-chunk request
+            # can exceed ack_timeout solely because later chunks are computing.
+            self._transfer_started_at = time.monotonic()
+
+        try:
+            self._manager.publish_transfer(
+                child_id,
+                list(block_ids),
+                int(bootstrap_room),
+                None,
+                dp_rank=int(dp_rank),
+                base_transfer_id=self.uuid,
+                chunk_index=chunk_index,
+                num_chunks=(chunk_index + 1 if is_final else 0),
+                chunk_page_offset=int(chunk_page_offset),
+            )
+        except Exception:
+            logger.exception(
+                "Raiden chunk metadata publish failed for req_id=%s chunk=%d",
+                self._req_id,
+                chunk_index,
+            )
+            self.request_abort("bootstrap_register")
+            raise
 
     def send(self) -> None:
         if self._block_ids is None:
@@ -544,7 +711,20 @@ class RaidenTransferKVSender(KVSender, StateHolder):
         with self._state_lock:
             if self.state != KVPoll.TRANSFERRING:
                 return self.state
+            chunk_mode = self._chunk_mode
+            started_chunks = tuple(sorted(self._started_chunks))
+            num_chunks = self._num_chunks
+            pending_failure = self._pending_failure_reason
         self._manager.poll_engine()
+        if chunk_mode:
+            child_ids = [f"{self.uuid}#c{k}" for k in started_chunks]
+            if not all(self._manager.sender_done(child_id) for child_id in child_ids):
+                return KVPoll.TRANSFERRING
+            if pending_failure is not None:
+                return self._finish(KVPoll.FAILED, pending_failure)
+            if num_chunks is None or started_chunks != tuple(range(num_chunks)):
+                return KVPoll.TRANSFERRING
+            return self._finish(KVPoll.SUCCESS, "raiden_chunks_done_sending")
         if not self._manager.sender_done(self.uuid):
             return KVPoll.TRANSFERRING
         # tpu-raiden@8756479 CompleteReadRaw reports send-side failures and
@@ -597,7 +777,13 @@ class RaidenTransferKVSender(KVSender, StateHolder):
                 state=state,
                 reason=reason,
             )
-        self._manager.forget(self.uuid)
+            forget_ids = (
+                [f"{self.uuid}#c{k}" for k in self._started_chunks]
+                if self._chunk_mode
+                else [self.uuid]
+            )
+        for transfer_id in forget_ids:
+            self._manager.forget(transfer_id)
         self._manager.cleanup_transfer(
             self._bootstrap_room,
             prefill_dp_rank=self._dp_rank,
@@ -621,9 +807,12 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
         StateHolder.__init__(self, KVPoll.BOOTSTRAPPING, role="decode")
         self._manager = manager
         self._req_id = req_id
-        self._metadata: RaidenMetadata | None = None
+        self._metadata: RaidenMetadata | RaidenChunkedMetadata | None = None
         self._state_lock = threading.Lock()
         self._started = False
+        self._started_chunks: set[int] = set()
+        self._chunk_records: dict[int, Mapping[str, object]] = {}
+        self._known_num_chunks: int | None = None
         self._timer: object | None = None
         self._transfer_started_at: float | None = None
         self._pending_failure_reason: str | None = None
@@ -633,12 +822,24 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
         return self._transfer_started_at
 
     def init(self, p_metadata) -> None:
-        if not isinstance(p_metadata, RaidenMetadata):
-            raise TypeError(f"expected RaidenMetadata, got {type(p_metadata).__name__}")
+        if not isinstance(p_metadata, (RaidenMetadata, RaidenChunkedMetadata)):
+            raise TypeError(
+                "expected RaidenMetadata or RaidenChunkedMetadata, "
+                f"got {type(p_metadata).__name__}"
+            )
         self._metadata = p_metadata
+        if isinstance(p_metadata, RaidenChunkedMetadata):
+            self._chunk_records = {
+                int(index): value for index, value in p_metadata.initial_chunks.items()
+            }
+            self._known_num_chunks = (
+                int(p_metadata.known_num_chunks) if p_metadata.known_num_chunks > 0 else None
+            )
         self._transition_to(KVPoll.WAITING_FOR_INPUT)
 
     def poll(self) -> KVPoll:
+        if isinstance(self._metadata, RaidenChunkedMetadata):
+            return self._poll_chunked()
         state = self.state
         if state == KVPoll.WAITING_FOR_INPUT:
             assert self._metadata is not None
@@ -684,13 +885,241 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
             )
         return self.state
 
+    def _poll_chunked(self) -> KVPoll:
+        metadata = self._metadata
+        assert isinstance(metadata, RaidenChunkedMetadata)
+        state = self.state
+        if state == KVPoll.WAITING_FOR_INPUT:
+            with self._state_lock:
+                if self.state != KVPoll.WAITING_FOR_INPUT:
+                    return self.state
+                self._transition_to(KVPoll.TRANSFERRING)
+                self._timer = time_phase("pull", "decode")
+                self._timer.__enter__()
+                self._transfer_started_at = time.monotonic()
+            self._discover_and_start_chunks(metadata)
+            state = self.state
+
+        if state != KVPoll.TRANSFERRING:
+            return state
+
+        with self._state_lock:
+            pending_failure = self._pending_failure_reason
+        if pending_failure is None:
+            self._discover_and_start_chunks(metadata)
+
+        self._manager.poll_engine()
+        with self._state_lock:
+            started_chunks = tuple(sorted(self._started_chunks))
+            num_chunks = self._known_num_chunks
+            pending_failure = self._pending_failure_reason
+
+        states = {
+            chunk_index: self._manager.receiver_state(f"{metadata.base_uuid}#c{chunk_index}")
+            for chunk_index in started_chunks
+        }
+        if any(value == "failed" for value in states.values()):
+            self.request_abort("raiden_failed_receiving")
+            pending_failure = self._pending_failure_reason
+        all_started_terminal = all(value in ("done", "failed") for value in states.values())
+        if pending_failure is not None:
+            if all_started_terminal:
+                return self._finish(KVPoll.FAILED, pending_failure)
+            return KVPoll.TRANSFERRING
+        if num_chunks is None or started_chunks != tuple(range(num_chunks)):
+            return KVPoll.TRANSFERRING
+        if not all(value == "done" for value in states.values()):
+            return KVPoll.TRANSFERRING
+        try:
+            self._validate_complete_chunk_layout(metadata, num_chunks)
+        except (TypeError, ValueError):
+            logger.exception("Raiden chunk layout validation failed for %s", self._req_id)
+            self.request_abort("chunk_layout")
+            return self._finish(KVPoll.FAILED, "chunk_layout")
+        return self._finish(KVPoll.SUCCESS, "raiden_chunks_done_receiving")
+
+    def _discover_and_start_chunks(self, metadata: RaidenChunkedMetadata) -> None:
+        with self._state_lock:
+            if self.state != KVPoll.TRANSFERRING or self._pending_failure_reason is not None:
+                return
+            complete = self._known_num_chunks is not None and self._started_chunks == set(
+                range(self._known_num_chunks)
+            )
+        if complete:
+            return
+
+        try:
+            info = self._manager.bootstrap_client.get_transfer_info(
+                metadata.bootstrap_room,
+                jax_process_index=metadata.jax_process_index,
+                prefill_dp_rank=metadata.prefill_dp_rank,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Raiden chunk metadata lookup failed for room=%s: %s",
+                metadata.bootstrap_room,
+                exc,
+            )
+            return
+        if info is not None:
+            chunks, known_num_chunks = _normalize_transfer_bundle(info)
+            conflict_reason: str | None = None
+            with self._state_lock:
+                for chunk_index, record in chunks.items():
+                    existing = self._chunk_records.get(chunk_index)
+                    if existing is not None and existing != record:
+                        conflict_reason = "chunk_metadata_conflict"
+                        break
+                    self._chunk_records[chunk_index] = record
+                if conflict_reason is None and known_num_chunks:
+                    if self._known_num_chunks not in (None, known_num_chunks):
+                        conflict_reason = "chunk_count_conflict"
+                    elif any(index >= known_num_chunks for index in self._chunk_records):
+                        conflict_reason = "chunk_index_out_of_range"
+                    else:
+                        self._known_num_chunks = known_num_chunks
+            if conflict_reason is not None:
+                self.request_abort(conflict_reason)
+                return
+
+        while True:
+            with self._state_lock:
+                started_chunks = tuple(self._started_chunks)
+                candidates = sorted(set(self._chunk_records) - self._started_chunks)
+                if not candidates or self._pending_failure_reason is not None:
+                    return
+                chunk_index = candidates[0]
+                record = self._chunk_records[chunk_index]
+            started_states = [
+                self._manager.receiver_state(f"{metadata.base_uuid}#c{index}")
+                for index in started_chunks
+            ]
+            if any(state == "failed" for state in started_states):
+                self.request_abort("raiden_failed_receiving")
+                return
+            active_pulls = sum(state is None for state in started_states)
+            if active_pulls >= CHUNK_TRANSFER_WINDOW:
+                return
+            try:
+                expected_id = f"{metadata.base_uuid}#c{chunk_index}"
+                if str(record.get("transfer_id", "")) != expected_id:
+                    raise ValueError(
+                        f"chunk transfer ID mismatch: expected={expected_id!r}, "
+                        f"got={record.get('transfer_id')!r}"
+                    )
+                if int(record.get("chunk_index", chunk_index)) != chunk_index:
+                    raise ValueError("chunk_index does not match its registry key")
+                if int(record.get("prefill_dp_rank", 0)) != metadata.prefill_dp_rank:
+                    raise ValueError("chunk Prefill DP rank mismatch")
+                transport = record.get("transport_metadata", record)
+                if not isinstance(transport, Mapping):
+                    raise TypeError("chunk transport_metadata must be a mapping")
+                remote_block_ids = [int(value) for value in transport.get("remote_block_ids", ())]
+                if not remote_block_ids:
+                    raise ValueError("Raiden chunk metadata has no remote blocks")
+                page_offset = int(record.get("chunk_page_offset", 0))
+                local_block_ids = list(
+                    metadata.local_block_ids[page_offset : page_offset + len(remote_block_ids)]
+                )
+                if len(local_block_ids) != len(remote_block_ids):
+                    raise ValueError(
+                        "Raiden chunk local block range is out of bounds: "
+                        f"offset={page_offset}, remote={len(remote_block_ids)}, "
+                        f"local_total={len(metadata.local_block_ids)}"
+                    )
+                self._validate_chunk_ranges(chunk_index, page_offset, len(remote_block_ids))
+                self._manager.wrapper.start_read(
+                    expected_id,
+                    _uuid_to_int(expected_id),
+                    metadata.remote_endpoint,
+                    remote_block_ids,
+                    local_block_ids,
+                    decode_dp_rank=metadata.decode_dp_rank,
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Raiden start_read failed for req_id=%s chunk=%d",
+                    self._req_id,
+                    chunk_index,
+                )
+                self.request_abort("raiden_start_read")
+                return
+            with self._state_lock:
+                self._started_chunks.add(chunk_index)
+                # Bound time since the latest started pull, not total prompt
+                # duration. The reaper still catches a producer that stops
+                # publishing after this chunk.
+                self._transfer_started_at = time.monotonic()
+
+    def _validate_chunk_ranges(self, chunk_index: int, page_offset: int, num_pages: int) -> None:
+        if page_offset < 0:
+            raise ValueError("chunk_page_offset must be non-negative")
+        new_end = page_offset + num_pages
+        for other_index, record in self._chunk_records.items():
+            if other_index == chunk_index:
+                continue
+            transport = record.get("transport_metadata", record)
+            if not isinstance(transport, Mapping):
+                continue
+            other_pages = len(transport.get("remote_block_ids", ()))
+            if other_pages <= 0:
+                continue
+            other_start = int(record.get("chunk_page_offset", 0))
+            other_end = other_start + other_pages
+            if max(page_offset, other_start) < min(new_end, other_end):
+                raise ValueError(
+                    f"Raiden chunk page ranges overlap: chunk={chunk_index}, "
+                    f"other={other_index}"
+                )
+
+    def _validate_complete_chunk_layout(
+        self,
+        metadata: RaidenChunkedMetadata,
+        num_chunks: int,
+    ) -> None:
+        expected_page_offset = 0
+        seen_remote_blocks: set[int] = set()
+        for chunk_index in range(num_chunks):
+            record = self._chunk_records[chunk_index]
+            page_offset = int(record.get("chunk_page_offset", 0))
+            if page_offset != expected_page_offset:
+                raise ValueError(
+                    "Raiden chunk page ranges must cover the prompt contiguously: "
+                    f"chunk={chunk_index}, expected_offset={expected_page_offset}, "
+                    f"actual_offset={page_offset}"
+                )
+            transport = record.get("transport_metadata", record)
+            if not isinstance(transport, Mapping):
+                raise TypeError("chunk transport_metadata must be a mapping")
+            remote_blocks = [int(value) for value in transport.get("remote_block_ids", ())]
+            if not remote_blocks:
+                raise ValueError(f"Raiden chunk {chunk_index} has no remote blocks")
+            duplicate_blocks = seen_remote_blocks.intersection(remote_blocks)
+            if duplicate_blocks:
+                raise ValueError(
+                    "Raiden remote blocks repeat across chunks: "
+                    f"chunk={chunk_index}, duplicates={sorted(duplicate_blocks)}"
+                )
+            seen_remote_blocks.update(remote_blocks)
+            expected_page_offset += len(remote_blocks)
+        if expected_page_offset != len(metadata.local_block_ids):
+            raise ValueError(
+                "Raiden chunks do not cover all decode prompt pages: "
+                f"covered={expected_page_offset}, expected={len(metadata.local_block_ids)}"
+            )
+
     def commit(self, install: Callable[[Any], None]) -> None:
         del install
         if self.state != KVPoll.SUCCESS:
             raise RuntimeError("cannot commit an incomplete Raiden receive")
         assert self._metadata is not None
         if self._metadata.direct_commit is not None:
-            self._metadata.direct_commit(self._metadata.expected_debug)
+            expected_debug = (
+                self._metadata.expected_debug
+                if isinstance(self._metadata, RaidenMetadata)
+                else None
+            )
+            self._metadata.direct_commit(expected_debug)
 
     def clear(self) -> None:
         self._manager._clear_terminal_record(self._req_id, role="decode")
@@ -728,7 +1157,15 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
             self._finish_timer()
             self._transfer_started_at = None
             metadata = self._metadata
-            transfer_id = metadata.uuid if metadata is not None else self._req_id
+            transfer_id = (
+                metadata.uuid
+                if isinstance(metadata, RaidenMetadata)
+                else (
+                    metadata.base_uuid
+                    if isinstance(metadata, RaidenChunkedMetadata)
+                    else self._req_id
+                )
+            )
             self._manager.record_terminal(
                 self._req_id,
                 role="decode",
@@ -736,7 +1173,13 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
                 state=state,
                 reason=reason,
             )
-        self._manager.forget(transfer_id)
+            forget_ids = (
+                [f"{metadata.base_uuid}#c{k}" for k in self._started_chunks]
+                if isinstance(metadata, RaidenChunkedMetadata)
+                else [transfer_id]
+            )
+        for child_id in forget_ids:
+            self._manager.forget(child_id)
         self._manager.cleanup_transfer(
             metadata.bootstrap_room if metadata else None,
             jax_process_index=metadata.jax_process_index if metadata else None,

--- a/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
+++ b/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
@@ -22,6 +22,7 @@ from sgl_jax.srt.disaggregation.base.kv_manager import (
 )
 from sgl_jax.srt.disaggregation.base.transfer import (
     DecodeAdmission,
+    DecodeMetadataContext,
     DecodeTransferContext,
     PrefillTransfer,
     PrefillTransferContext,
@@ -38,12 +39,12 @@ from sgl_jax.srt.disaggregation.raiden_transfer.wrapper import RaidenTransferWra
 
 logger = logging.getLogger(__name__)
 
-_CHUNK_METADATA_EXECUTOR = ThreadPoolExecutor(
+_METADATA_EXECUTOR = ThreadPoolExecutor(
     max_workers=8,
-    thread_name_prefix="RaidenChunkMetadata",
+    thread_name_prefix="RaidenMetadata",
 )
-_CHUNK_METADATA_MIN_POLL_SECONDS = 0.01
-_CHUNK_METADATA_MAX_POLL_SECONDS = 0.05
+_METADATA_MIN_POLL_SECONDS = 0.01
+_METADATA_MAX_POLL_SECONDS = 0.05
 _CHUNK_PRODUCER_TIMEOUT_SECONDS = 300.0
 
 
@@ -179,6 +180,14 @@ class _PendingSenderChunk:
     on_ready: Callable[[], None] | None = None
 
 
+@dataclass
+class _DecodeMetadataLookup:
+    future: Future | None = None
+    info: object | None = None
+    next_poll_at: float = 0.0
+    poll_interval: float = _METADATA_MIN_POLL_SECONDS
+
+
 def _normalize_transfer_bundle(
     info: Mapping[str, object],
 ) -> tuple[dict[int, Mapping[str, object]], int, int]:
@@ -230,6 +239,8 @@ class RaidenTransferKVManager(CommonKVManager):
         self._done_sending: set[str] = set()
         self._done_receiving: set[str] = set()
         self._failed_receiving: set[str] = set()
+        self._decode_metadata_lock = threading.Lock()
+        self._decode_metadata: dict[tuple[int, int, int, str], _DecodeMetadataLookup] = {}
 
     def reserve_prefill_buffer(self, existing: int | None) -> int | None:
         return existing
@@ -288,25 +299,103 @@ class RaidenTransferKVManager(CommonKVManager):
             raise
         return PrefillTransfer(sender=sender)
 
-    def try_start_decode(self, context: DecodeTransferContext) -> DecodeAdmission:
-        if context.bootstrap_room is None:
+    @staticmethod
+    def _decode_metadata_key(
+        bootstrap_room: int | None,
+        peer_process_index: int,
+        prefill_dp_rank: int,
+        transfer_id: str,
+    ) -> tuple[int, int, int, str]:
+        if bootstrap_room is None:
             raise ValueError("Raiden decode requires bootstrap_room")
+        return (
+            int(bootstrap_room),
+            int(peer_process_index),
+            int(prefill_dp_rank),
+            str(transfer_id),
+        )
+
+    def poll_decode_metadata(self, context: DecodeMetadataContext) -> bool:
+        """Return metadata readiness without blocking the scheduler thread."""
+
         peer_process_index = int(context.peer_info.get("jax_process_index", 0))
+        key = self._decode_metadata_key(
+            context.bootstrap_room,
+            peer_process_index,
+            context.prefill_dp_rank,
+            context.transfer_id,
+        )
+        now = time.monotonic()
+        with self._decode_metadata_lock:
+            lookup = self._decode_metadata.setdefault(key, _DecodeMetadataLookup())
+            if lookup.info is not None:
+                return True
+            future = lookup.future
+            if future is None:
+                if now < lookup.next_poll_at:
+                    return False
+                lookup.future = _METADATA_EXECUTOR.submit(
+                    self.bootstrap_client.get_transfer_info,
+                    context.bootstrap_room,
+                    jax_process_index=peer_process_index,
+                    prefill_dp_rank=context.prefill_dp_rank,
+                )
+                return False
+            if not future.done():
+                return False
+            lookup.future = None
+
+        info = None
         try:
-            info = self.bootstrap_client.get_transfer_info(
-                context.bootstrap_room,
-                jax_process_index=peer_process_index,
-                prefill_dp_rank=context.prefill_dp_rank,
-            )
-        except Exception as exc:  # transient bootstrap failure
+            info = future.result()
+        except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "Raiden metadata lookup failed for room=%s: %s",
                 context.bootstrap_room,
                 exc,
             )
-            return DecodeAdmission.deferred("metadata_lookup")
+
+        if info is not None and self.enable_chunk_prefill_transfer and isinstance(info, Mapping):
+            try:
+                chunks, _, _ = _normalize_transfer_bundle(info)
+            except (TypeError, ValueError):
+                # Preserve malformed metadata for try_start_decode to report as
+                # a permanent receiver-init error instead of retrying forever.
+                pass
+            else:
+                if 0 not in chunks:
+                    info = None
+
+        with self._decode_metadata_lock:
+            if self._decode_metadata.get(key) is not lookup:
+                return False
+            if info is not None:
+                lookup.info = info
+                return True
+            lookup.poll_interval = min(
+                lookup.poll_interval * 2,
+                _METADATA_MAX_POLL_SECONDS,
+            )
+            lookup.next_poll_at = time.monotonic() + lookup.poll_interval
+        return False
+
+    def try_start_decode(self, context: DecodeTransferContext) -> DecodeAdmission:
+        if context.bootstrap_room is None:
+            raise ValueError("Raiden decode requires bootstrap_room")
+        peer_process_index = int(context.peer_info.get("jax_process_index", 0))
+        metadata_key = self._decode_metadata_key(
+            context.bootstrap_room,
+            peer_process_index,
+            context.prefill_dp_rank,
+            context.transfer_id,
+        )
+        with self._decode_metadata_lock:
+            lookup = self._decode_metadata.get(metadata_key)
+            info = None if lookup is None else lookup.info
         if info is None:
             return DecodeAdmission.deferred("metadata_pending")
+        if not isinstance(info, Mapping):
+            raise TypeError("Raiden transfer metadata must be a mapping")
 
         receiver: RaidenTransferKVReceiver | None = None
         try:
@@ -438,6 +527,8 @@ class RaidenTransferKVManager(CommonKVManager):
                         ),
                     )
                 )
+            with self._decode_metadata_lock:
+                self._decode_metadata.pop(metadata_key, None)
             return DecodeAdmission.admitted(receiver)
         except Exception:
             if receiver is not None:
@@ -505,6 +596,17 @@ class RaidenTransferKVManager(CommonKVManager):
             return
         if jax_process_index is None:
             jax_process_index = jax.process_index()
+        with self._decode_metadata_lock:
+            matching_keys = [
+                key
+                for key in self._decode_metadata
+                if key[:3] == (int(bootstrap_room), int(jax_process_index), int(prefill_dp_rank))
+                and (expected_transfer_id is None or key[3] == str(expected_transfer_id))
+            ]
+            lookups = [self._decode_metadata.pop(key) for key in matching_keys]
+        for lookup in lookups:
+            if lookup.future is not None:
+                lookup.future.cancel()
         with suppress(Exception):
             self.bootstrap_client.pop_transfer(
                 bootstrap_room,
@@ -932,7 +1034,7 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
         self._pending_failure_reason: str | None = None
         self._metadata_future: Future | None = None
         self._next_metadata_poll_at = 0.0
-        self._metadata_poll_interval = _CHUNK_METADATA_MIN_POLL_SECONDS
+        self._metadata_poll_interval = _METADATA_MIN_POLL_SECONDS
 
     @property
     def transfer_started_at(self) -> float | None:
@@ -1076,7 +1178,9 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
             future = self._metadata_future
 
         info = None
+        lookup_completed = False
         if future is not None and future.done():
+            lookup_completed = True
             try:
                 info = future.result()
             except Exception as exc:  # noqa: BLE001
@@ -1116,16 +1220,23 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
                         metadata_changed |= self._known_num_chunks != known_num_chunks
                         self._known_num_chunks = known_num_chunks
                 if metadata_changed:
-                    self._metadata_poll_interval = _CHUNK_METADATA_MIN_POLL_SECONDS
+                    self._metadata_poll_interval = _METADATA_MIN_POLL_SECONDS
                 else:
                     self._metadata_poll_interval = min(
                         self._metadata_poll_interval * 2,
-                        _CHUNK_METADATA_MAX_POLL_SECONDS,
+                        _METADATA_MAX_POLL_SECONDS,
                     )
                 self._next_metadata_poll_at = time.monotonic() + self._metadata_poll_interval
             if conflict_reason is not None:
                 self.request_abort(conflict_reason)
                 return
+        elif lookup_completed:
+            with self._state_lock:
+                self._metadata_poll_interval = min(
+                    self._metadata_poll_interval * 2,
+                    _METADATA_MAX_POLL_SECONDS,
+                )
+                self._next_metadata_poll_at = time.monotonic() + self._metadata_poll_interval
 
         while True:
             with self._state_lock:
@@ -1209,7 +1320,7 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
                 and now >= self._next_metadata_poll_at
                 and self._pending_failure_reason is None
             ):
-                self._metadata_future = _CHUNK_METADATA_EXECUTOR.submit(
+                self._metadata_future = _METADATA_EXECUTOR.submit(
                     self._manager.bootstrap_client.get_transfer_info,
                     metadata.bootstrap_room,
                     jax_process_index=metadata.jax_process_index,

--- a/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
+++ b/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
@@ -7,6 +7,7 @@ import logging
 import threading
 import time
 from collections.abc import Callable, Mapping
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
@@ -24,6 +25,7 @@ from sgl_jax.srt.disaggregation.base.transfer import (
     DecodeTransferContext,
     PrefillTransfer,
     PrefillTransferContext,
+    chunk_transfer_id,
     slots_to_page_ids,
 )
 from sgl_jax.srt.disaggregation.common.capacity import CHUNK_TRANSFER_WINDOW
@@ -35,6 +37,14 @@ from sgl_jax.srt.disaggregation.common.metrics import (
 from sgl_jax.srt.disaggregation.raiden_transfer.wrapper import RaidenTransferWrapper
 
 logger = logging.getLogger(__name__)
+
+_CHUNK_METADATA_EXECUTOR = ThreadPoolExecutor(
+    max_workers=8,
+    thread_name_prefix="RaidenChunkMetadata",
+)
+_CHUNK_METADATA_MIN_POLL_SECONDS = 0.01
+_CHUNK_METADATA_MAX_POLL_SECONDS = 0.05
+_CHUNK_PRODUCER_TIMEOUT_SECONDS = 300.0
 
 
 def _uuid_to_int(value: str) -> int:
@@ -153,6 +163,7 @@ class RaidenChunkedMetadata:
     decode_dp_rank: int
     initial_chunks: Mapping[int, Mapping[str, object]]
     known_num_chunks: int = 0
+    expected_total_pages: int = 0
     direct_commit: Callable[[Mapping[str, object] | None], None] | None = None
 
 
@@ -164,16 +175,18 @@ class _PendingSenderChunk:
     chunk_page_offset: int
     is_final: bool
     dp_rank: int
+    expected_total_pages: int
+    on_ready: Callable[[], None] | None = None
 
 
 def _normalize_transfer_bundle(
     info: Mapping[str, object],
-) -> tuple[dict[int, Mapping[str, object]], int]:
+) -> tuple[dict[int, Mapping[str, object]], int, int]:
     """Normalize v5 metadata and the pre-v5 flat shape used by test doubles."""
 
     raw_chunks = info.get("chunks")
     if raw_chunks is None:
-        return {0: info}, 1
+        return {0: info}, 1, 0
     if not isinstance(raw_chunks, Mapping):
         raise TypeError("Raiden transfer chunks must be a mapping")
     chunks: dict[int, Mapping[str, object]] = {}
@@ -184,7 +197,10 @@ def _normalize_transfer_bundle(
     num_chunks = int(info.get("num_chunks", 0) or 0)
     if num_chunks < 0:
         raise ValueError("Raiden num_chunks must be non-negative")
-    return chunks, num_chunks
+    expected_total_pages = int(info.get("expected_total_pages", 0) or 0)
+    if expected_total_pages < 0:
+        raise ValueError("Raiden expected_total_pages must be non-negative")
+    return chunks, num_chunks, expected_total_pages
 
 
 class RaidenTransferKVManager(CommonKVManager):
@@ -294,7 +310,7 @@ class RaidenTransferKVManager(CommonKVManager):
 
         receiver: RaidenTransferKVReceiver | None = None
         try:
-            chunks, known_num_chunks = _normalize_transfer_bundle(info)
+            chunks, known_num_chunks, expected_total_pages = _normalize_transfer_bundle(info)
             if not chunks:
                 return DecodeAdmission.deferred("metadata_pending")
             first_chunk = chunks.get(0)
@@ -302,7 +318,7 @@ class RaidenTransferKVManager(CommonKVManager):
                 return DecodeAdmission.deferred("chunk_zero_pending")
 
             expected_first_id = (
-                f"{context.transfer_id}#c0"
+                chunk_transfer_id(context.transfer_id, 0)
                 if self.enable_chunk_prefill_transfer
                 else context.transfer_id
             )
@@ -360,6 +376,13 @@ class RaidenTransferKVManager(CommonKVManager):
 
             receiver = self.create_receiver(context.req_id)
             if self.enable_chunk_prefill_transfer:
+                if expected_total_pages <= 0:
+                    raise ValueError("Raiden chunk metadata is missing expected_total_pages")
+                if expected_total_pages != len(local_block_ids):
+                    raise ValueError(
+                        "Raiden chunk total block count mismatch: "
+                        f"expected={len(local_block_ids)}, remote={expected_total_pages}"
+                    )
                 receiver.init(
                     RaidenChunkedMetadata(
                         base_uuid=context.transfer_id,
@@ -371,6 +394,7 @@ class RaidenTransferKVManager(CommonKVManager):
                         decode_dp_rank=context.decode_dp_rank,
                         initial_chunks=chunks,
                         known_num_chunks=known_num_chunks,
+                        expected_total_pages=expected_total_pages,
                         direct_commit=context.direct_commit,
                     )
                 )
@@ -449,6 +473,7 @@ class RaidenTransferKVManager(CommonKVManager):
         chunk_index: int = 0,
         num_chunks: int = 1,
         chunk_page_offset: int = 0,
+        expected_total_pages: int = 0,
     ) -> None:
         if bootstrap_room is None:
             return
@@ -464,6 +489,7 @@ class RaidenTransferKVManager(CommonKVManager):
             chunk_index=chunk_index,
             num_chunks=num_chunks,
             chunk_page_offset=chunk_page_offset,
+            expected_total_pages=expected_total_pages,
             transport_metadata=transport_metadata,
         )
 
@@ -519,11 +545,15 @@ class RaidenTransferKVManager(CommonKVManager):
                 receivers = list(self._receivers.items())
             for req_id, receiver in receivers:
                 started = getattr(receiver, "transfer_started_at", None)
-                if (
-                    started is not None
-                    and now - started >= self._pull_timeout_s
-                    and receiver.request_abort("timeout")
-                ):
+                producer_wait_started = getattr(receiver, "producer_wait_started_at", None)
+                pull_timed_out = started is not None and now - started >= self._pull_timeout_s
+                producer_timed_out = (
+                    started is None
+                    and producer_wait_started is not None
+                    and now - producer_wait_started >= _CHUNK_PRODUCER_TIMEOUT_SECONDS
+                )
+                reason = "timeout" if pull_timed_out else "producer_timeout"
+                if (pull_timed_out or producer_timed_out) and receiver.request_abort(reason):
                     timed_out_receivers.append(req_id)
         return timed_out_senders, timed_out_receivers
 
@@ -575,6 +605,7 @@ class RaidenTransferKVSender(KVSender, StateHolder):
         self._started_chunks: set[int] = set()
         self._pending_chunks: dict[int, _PendingSenderChunk] = {}
         self._num_chunks: int | None = None
+        self._expected_total_pages: int | None = None
 
     @property
     def uuid(self) -> str:
@@ -624,6 +655,8 @@ class RaidenTransferKVSender(KVSender, StateHolder):
         chunk_page_offset: int,
         is_final: bool,
         dp_rank: int = 0,
+        expected_total_pages: int = 0,
+        on_ready: Callable[[], None] | None = None,
     ) -> None:
         """Queue one newly-computed chunk and fill available Raiden slots."""
 
@@ -641,7 +674,11 @@ class RaidenTransferKVSender(KVSender, StateHolder):
             chunk_page_offset=int(chunk_page_offset),
             is_final=bool(is_final),
             dp_rank=int(dp_rank),
+            expected_total_pages=int(expected_total_pages),
+            on_ready=on_ready,
         )
+        if pending.expected_total_pages <= 0:
+            raise ValueError("expected_total_pages must be positive")
         with self._pump_lock:
             with self._state_lock:
                 if self.state not in (KVPoll.WAITING_FOR_INPUT, KVPoll.TRANSFERRING):
@@ -652,6 +689,13 @@ class RaidenTransferKVSender(KVSender, StateHolder):
                     raise RuntimeError(f"chunk_index={chunk_index} was already registered")
                 if self._num_chunks is not None:
                     raise RuntimeError("cannot register a chunk after the final chunk")
+                if self._expected_total_pages not in (None, pending.expected_total_pages):
+                    raise ValueError(
+                        "expected_total_pages changed within one chunk transfer: "
+                        f"existing={self._expected_total_pages}, "
+                        f"new={pending.expected_total_pages}"
+                    )
+                self._expected_total_pages = pending.expected_total_pages
                 self._chunk_mode = True
                 self._bootstrap_room = pending.bootstrap_room
                 self._dp_rank = pending.dp_rank
@@ -674,7 +718,7 @@ class RaidenTransferKVSender(KVSender, StateHolder):
                     pending = next(iter(self._pending_chunks.values()))
 
                 active = sum(
-                    not self._manager.sender_done(f"{self.uuid}#c{index}")
+                    not self._manager.sender_done(chunk_transfer_id(self.uuid, index))
                     for index in started_chunks
                 )
                 if active >= CHUNK_TRANSFER_WINDOW:
@@ -694,7 +738,9 @@ class RaidenTransferKVSender(KVSender, StateHolder):
                     return
 
     def _start_pending_chunk(self, pending: _PendingSenderChunk) -> None:
-        child_id = f"{self.uuid}#c{pending.chunk_index}"
+        child_id = chunk_transfer_id(self.uuid, pending.chunk_index)
+        if pending.on_ready is not None:
+            pending.on_ready()
         needed = self._manager.register_read(
             child_id,
             child_id,
@@ -717,12 +763,13 @@ class RaidenTransferKVSender(KVSender, StateHolder):
             child_id,
             list(pending.block_ids),
             pending.bootstrap_room,
-            None,
+            self._debug_metadata if pending.is_final else None,
             dp_rank=pending.dp_rank,
             base_transfer_id=self.uuid,
             chunk_index=pending.chunk_index,
             num_chunks=(pending.chunk_index + 1 if pending.is_final else 0),
             chunk_page_offset=pending.chunk_page_offset,
+            expected_total_pages=pending.expected_total_pages,
         )
 
     def send(self) -> None:
@@ -776,7 +823,7 @@ class RaidenTransferKVSender(KVSender, StateHolder):
                 pending_chunks = bool(self._pending_chunks)
                 num_chunks = self._num_chunks
                 pending_failure = self._pending_failure_reason
-            child_ids = [f"{self.uuid}#c{k}" for k in started_chunks]
+            child_ids = [chunk_transfer_id(self.uuid, k) for k in started_chunks]
             if not all(self._manager.sender_done(child_id) for child_id in child_ids):
                 return KVPoll.TRANSFERRING
             if pending_failure is not None:
@@ -843,7 +890,7 @@ class RaidenTransferKVSender(KVSender, StateHolder):
                 reason=reason,
             )
             forget_ids = (
-                [f"{self.uuid}#c{k}" for k in self._started_chunks]
+                [chunk_transfer_id(self.uuid, k) for k in self._started_chunks]
                 if self._chunk_mode
                 else [self.uuid]
             )
@@ -881,11 +928,19 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
         self._known_num_chunks: int | None = None
         self._timer: object | None = None
         self._transfer_started_at: float | None = None
+        self._producer_wait_started_at: float | None = None
         self._pending_failure_reason: str | None = None
+        self._metadata_future: Future | None = None
+        self._next_metadata_poll_at = 0.0
+        self._metadata_poll_interval = _CHUNK_METADATA_MIN_POLL_SECONDS
 
     @property
     def transfer_started_at(self) -> float | None:
         return self._transfer_started_at
+
+    @property
+    def producer_wait_started_at(self) -> float | None:
+        return self._producer_wait_started_at
 
     def init(self, p_metadata) -> None:
         if not isinstance(p_metadata, (RaidenMetadata, RaidenChunkedMetadata)):
@@ -981,18 +1036,26 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
             pending_failure = self._pending_failure_reason
 
         states = {
-            chunk_index: self._manager.receiver_state(f"{metadata.base_uuid}#c{chunk_index}")
+            chunk_index: self._manager.receiver_state(
+                chunk_transfer_id(metadata.base_uuid, chunk_index)
+            )
             for chunk_index in started_chunks
         }
         if any(value == "failed" for value in states.values()):
             self.request_abort("raiden_failed_receiving")
             pending_failure = self._pending_failure_reason
         all_started_terminal = all(value in ("done", "failed") for value in states.values())
+        transfer_complete = num_chunks is not None and started_chunks == tuple(range(num_chunks))
+        if all_started_terminal and not transfer_complete:
+            with self._state_lock:
+                self._transfer_started_at = None
+                if self._producer_wait_started_at is None:
+                    self._producer_wait_started_at = time.monotonic()
         if pending_failure is not None:
             if all_started_terminal:
                 return self._finish(KVPoll.FAILED, pending_failure)
             return KVPoll.TRANSFERRING
-        if num_chunks is None or started_chunks != tuple(range(num_chunks)):
+        if not transfer_complete:
             return KVPoll.TRANSFERRING
         if not all(value == "done" for value in states.values()):
             return KVPoll.TRANSFERRING
@@ -1005,37 +1068,44 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
         return self._finish(KVPoll.SUCCESS, "raiden_chunks_done_receiving")
 
     def _discover_and_start_chunks(self, metadata: RaidenChunkedMetadata) -> None:
+        """Start locally-known chunks and poll bootstrap metadata off-thread."""
+
         with self._state_lock:
             if self.state != KVPoll.TRANSFERRING or self._pending_failure_reason is not None:
                 return
-            complete = self._known_num_chunks is not None and self._started_chunks == set(
-                range(self._known_num_chunks)
-            )
-        if complete:
-            return
+            future = self._metadata_future
 
-        try:
-            info = self._manager.bootstrap_client.get_transfer_info(
-                metadata.bootstrap_room,
-                jax_process_index=metadata.jax_process_index,
-                prefill_dp_rank=metadata.prefill_dp_rank,
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "Raiden chunk metadata lookup failed for room=%s: %s",
-                metadata.bootstrap_room,
-                exc,
-            )
-            return
+        info = None
+        if future is not None and future.done():
+            try:
+                info = future.result()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Raiden chunk metadata lookup failed for room=%s: %s",
+                    metadata.bootstrap_room,
+                    exc,
+                )
+            finally:
+                with self._state_lock:
+                    if self._metadata_future is future:
+                        self._metadata_future = None
+
+        metadata_changed = False
         if info is not None:
-            chunks, known_num_chunks = _normalize_transfer_bundle(info)
+            chunks, known_num_chunks, expected_total_pages = _normalize_transfer_bundle(info)
             conflict_reason: str | None = None
             with self._state_lock:
+                if expected_total_pages not in (0, metadata.expected_total_pages):
+                    conflict_reason = "chunk_total_pages_conflict"
                 for chunk_index, record in chunks.items():
+                    if conflict_reason is not None:
+                        break
                     existing = self._chunk_records.get(chunk_index)
                     if existing is not None and existing != record:
                         conflict_reason = "chunk_metadata_conflict"
                         break
+                    if existing is None:
+                        metadata_changed = True
                     self._chunk_records[chunk_index] = record
                 if conflict_reason is None and known_num_chunks:
                     if self._known_num_chunks not in (None, known_num_chunks):
@@ -1043,7 +1113,16 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
                     elif any(index >= known_num_chunks for index in self._chunk_records):
                         conflict_reason = "chunk_index_out_of_range"
                     else:
+                        metadata_changed |= self._known_num_chunks != known_num_chunks
                         self._known_num_chunks = known_num_chunks
+                if metadata_changed:
+                    self._metadata_poll_interval = _CHUNK_METADATA_MIN_POLL_SECONDS
+                else:
+                    self._metadata_poll_interval = min(
+                        self._metadata_poll_interval * 2,
+                        _CHUNK_METADATA_MAX_POLL_SECONDS,
+                    )
+                self._next_metadata_poll_at = time.monotonic() + self._metadata_poll_interval
             if conflict_reason is not None:
                 self.request_abort(conflict_reason)
                 return
@@ -1052,12 +1131,14 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
             with self._state_lock:
                 started_chunks = tuple(self._started_chunks)
                 candidates = sorted(set(self._chunk_records) - self._started_chunks)
-                if not candidates or self._pending_failure_reason is not None:
+                if self._pending_failure_reason is not None:
                     return
+                if not candidates:
+                    break
                 chunk_index = candidates[0]
                 record = self._chunk_records[chunk_index]
             started_states = [
-                self._manager.receiver_state(f"{metadata.base_uuid}#c{index}")
+                self._manager.receiver_state(chunk_transfer_id(metadata.base_uuid, index))
                 for index in started_chunks
             ]
             if any(state == "failed" for state in started_states):
@@ -1065,9 +1146,9 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
                 return
             active_pulls = sum(state is None for state in started_states)
             if active_pulls >= CHUNK_TRANSFER_WINDOW:
-                return
+                break
             try:
-                expected_id = f"{metadata.base_uuid}#c{chunk_index}"
+                expected_id = chunk_transfer_id(metadata.base_uuid, chunk_index)
                 if str(record.get("transfer_id", "")) != expected_id:
                     raise ValueError(
                         f"chunk transfer ID mismatch: expected={expected_id!r}, "
@@ -1112,10 +1193,29 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
                 return
             with self._state_lock:
                 self._started_chunks.add(chunk_index)
-                # Bound time since the latest started pull, not total prompt
-                # duration. The reaper still catches a producer that stops
-                # publishing after this chunk.
+                self._producer_wait_started_at = None
+                # Pull timeout covers only an active Raiden read. Producer
+                # compute gaps use the separate progress watchdog below.
                 self._transfer_started_at = time.monotonic()
+
+        now = time.monotonic()
+        with self._state_lock:
+            metadata_complete = self._known_num_chunks is not None and set(
+                range(self._known_num_chunks)
+            ).issubset(self._chunk_records)
+            if (
+                not metadata_complete
+                and self._metadata_future is None
+                and now >= self._next_metadata_poll_at
+                and self._pending_failure_reason is None
+            ):
+                self._metadata_future = _CHUNK_METADATA_EXECUTOR.submit(
+                    self._manager.bootstrap_client.get_transfer_info,
+                    metadata.bootstrap_room,
+                    jax_process_index=metadata.jax_process_index,
+                    prefill_dp_rank=metadata.prefill_dp_rank,
+                )
+                self._next_metadata_poll_at = now + self._metadata_poll_interval
 
     def _validate_chunk_ranges(self, chunk_index: int, page_offset: int, num_pages: int) -> None:
         if page_offset < 0:
@@ -1143,6 +1243,12 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
         metadata: RaidenChunkedMetadata,
         num_chunks: int,
     ) -> None:
+        if metadata.expected_total_pages != len(metadata.local_block_ids):
+            raise ValueError(
+                "Raiden expected_total_pages does not match decode allocation: "
+                f"metadata={metadata.expected_total_pages}, "
+                f"local={len(metadata.local_block_ids)}"
+            )
         expected_page_offset = 0
         seen_remote_blocks: set[int] = set()
         for chunk_index in range(num_chunks):
@@ -1180,11 +1286,19 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
             raise RuntimeError("cannot commit an incomplete Raiden receive")
         assert self._metadata is not None
         if self._metadata.direct_commit is not None:
-            expected_debug = (
-                self._metadata.expected_debug
-                if isinstance(self._metadata, RaidenMetadata)
-                else None
-            )
+            expected_debug = None
+            if isinstance(self._metadata, RaidenMetadata):
+                expected_debug = self._metadata.expected_debug
+            else:
+                for chunk_index in sorted(self._chunk_records, reverse=True):
+                    record = self._chunk_records[chunk_index]
+                    transport = record.get("transport_metadata", record)
+                    if not isinstance(transport, Mapping):
+                        continue
+                    candidate = transport.get("kv_debug")
+                    if isinstance(candidate, Mapping):
+                        expected_debug = candidate
+                        break
             self._metadata.direct_commit(expected_debug)
 
     def clear(self) -> None:
@@ -1222,6 +1336,9 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
             self._transition_to(state)
             self._finish_timer()
             self._transfer_started_at = None
+            self._producer_wait_started_at = None
+            metadata_future = self._metadata_future
+            self._metadata_future = None
             metadata = self._metadata
             transfer_id = (
                 metadata.uuid
@@ -1240,10 +1357,12 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
                 reason=reason,
             )
             forget_ids = (
-                [f"{metadata.base_uuid}#c{k}" for k in self._started_chunks]
+                [chunk_transfer_id(metadata.base_uuid, k) for k in self._started_chunks]
                 if isinstance(metadata, RaidenChunkedMetadata)
                 else [transfer_id]
             )
+        if metadata_future is not None:
+            metadata_future.cancel()
         for child_id in forget_ids:
             self._manager.forget(child_id)
         self._manager.cleanup_transfer(

--- a/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
+++ b/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
@@ -473,6 +473,7 @@ class RaidenTransferKVManager(CommonKVManager):
         *,
         jax_process_index: int | None = None,
         prefill_dp_rank: int = 0,
+        expected_transfer_id: str | None = None,
     ) -> None:
         if bootstrap_room is None:
             return
@@ -483,6 +484,7 @@ class RaidenTransferKVManager(CommonKVManager):
                 bootstrap_room,
                 jax_process_index=jax_process_index,
                 prefill_dp_rank=prefill_dp_rank,
+                expected_transfer_id=expected_transfer_id,
             )
 
     def poll_engine(self) -> None:
@@ -850,6 +852,7 @@ class RaidenTransferKVSender(KVSender, StateHolder):
         self._manager.cleanup_transfer(
             self._bootstrap_room,
             prefill_dp_rank=self._dp_rank,
+            expected_transfer_id=self.uuid,
         )
         if state == KVPoll.FAILED:
             with suppress(Exception):
@@ -1247,6 +1250,7 @@ class RaidenTransferKVReceiver(KVReceiver, StateHolder):
             metadata.bootstrap_room if metadata else None,
             jax_process_index=metadata.jax_process_index if metadata else None,
             prefill_dp_rank=metadata.prefill_dp_rank if metadata else 0,
+            expected_transfer_id=transfer_id,
         )
         if state == KVPoll.FAILED:
             with suppress(Exception):

--- a/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
+++ b/python/sgl_jax/srt/disaggregation/raiden_transfer/conn.py
@@ -156,6 +156,16 @@ class RaidenChunkedMetadata:
     direct_commit: Callable[[Mapping[str, object] | None], None] | None = None
 
 
+@dataclass(frozen=True)
+class _PendingSenderChunk:
+    chunk_index: int
+    block_ids: tuple[int, ...]
+    bootstrap_room: int
+    chunk_page_offset: int
+    is_final: bool
+    dp_rank: int
+
+
 def _normalize_transfer_bundle(
     info: Mapping[str, object],
 ) -> tuple[dict[int, Mapping[str, object]], int]:
@@ -559,7 +569,9 @@ class RaidenTransferKVSender(KVSender, StateHolder):
         self._pending_failure_reason: str | None = None
         self._debug_metadata: Mapping[str, object] | None = None
         self._chunk_mode = False
+        self._pump_lock = threading.RLock()
         self._started_chunks: set[int] = set()
+        self._pending_chunks: dict[int, _PendingSenderChunk] = {}
         self._num_chunks: int | None = None
 
     @property
@@ -611,7 +623,7 @@ class RaidenTransferKVSender(KVSender, StateHolder):
         is_final: bool,
         dp_rank: int = 0,
     ) -> None:
-        """Register and publish one newly-computed prefill chunk."""
+        """Queue one newly-computed chunk and fill available Raiden slots."""
 
         if not self._manager.enable_chunk_prefill_transfer:
             raise RuntimeError("chunk transfer is disabled on this Raiden manager")
@@ -620,60 +632,96 @@ class RaidenTransferKVSender(KVSender, StateHolder):
             raise ValueError("chunk_index must be non-negative")
         if not block_ids:
             raise ValueError("Raiden chunk transfer requires at least one KV block")
-        child_id = f"{self.uuid}#c{chunk_index}"
-        with self._state_lock:
-            if self.state not in (KVPoll.WAITING_FOR_INPUT, KVPoll.TRANSFERRING):
-                raise RuntimeError(f"cannot send chunk from terminal state {self.state.value}")
-            if chunk_index in self._started_chunks:
-                raise RuntimeError(f"chunk_index={chunk_index} was already registered")
-            if self._num_chunks is not None:
-                raise RuntimeError("cannot register a chunk after the final chunk")
+        pending = _PendingSenderChunk(
+            chunk_index=chunk_index,
+            block_ids=tuple(int(block_id) for block_id in block_ids),
+            bootstrap_room=int(bootstrap_room),
+            chunk_page_offset=int(chunk_page_offset),
+            is_final=bool(is_final),
+            dp_rank=int(dp_rank),
+        )
+        with self._pump_lock:
+            with self._state_lock:
+                if self.state not in (KVPoll.WAITING_FOR_INPUT, KVPoll.TRANSFERRING):
+                    raise RuntimeError(f"cannot send chunk from terminal state {self.state.value}")
+                if self._pending_failure_reason is not None:
+                    raise RuntimeError("cannot send a chunk after transfer cancellation")
+                if chunk_index in self._started_chunks or chunk_index in self._pending_chunks:
+                    raise RuntimeError(f"chunk_index={chunk_index} was already registered")
+                if self._num_chunks is not None:
+                    raise RuntimeError("cannot register a chunk after the final chunk")
+                self._chunk_mode = True
+                self._bootstrap_room = pending.bootstrap_room
+                self._dp_rank = pending.dp_rank
+                self._pending_chunks[chunk_index] = pending
+                if is_final:
+                    self._num_chunks = chunk_index + 1
+            self._pump_pending_chunks(raise_on_error=True)
 
+    def _pump_pending_chunks(self, *, raise_on_error: bool) -> None:
+        """Register at most ``CHUNK_TRANSFER_WINDOW`` active child reads."""
+
+        with self._pump_lock:
+            while True:
+                with self._state_lock:
+                    if self.state in (KVPoll.SUCCESS, KVPoll.FAILED):
+                        return
+                    if self._pending_failure_reason is not None or not self._pending_chunks:
+                        return
+                    started_chunks = tuple(self._started_chunks)
+                    pending = next(iter(self._pending_chunks.values()))
+
+                active = sum(
+                    not self._manager.sender_done(f"{self.uuid}#c{index}")
+                    for index in started_chunks
+                )
+                if active >= CHUNK_TRANSFER_WINDOW:
+                    return
+
+                try:
+                    self._start_pending_chunk(pending)
+                except Exception:
+                    logger.exception(
+                        "Raiden chunk registration failed for req_id=%s chunk=%d",
+                        self._req_id,
+                        pending.chunk_index,
+                    )
+                    self.request_abort("chunk_register")
+                    if raise_on_error:
+                        raise
+                    return
+
+    def _start_pending_chunk(self, pending: _PendingSenderChunk) -> None:
+        child_id = f"{self.uuid}#c{pending.chunk_index}"
         needed = self._manager.register_read(
             child_id,
             child_id,
-            list(block_ids),
-            dp_rank=int(dp_rank),
+            list(pending.block_ids),
+            dp_rank=pending.dp_rank,
         )
         if not needed:
             raise RuntimeError(f"Raiden declined non-empty chunk transfer for {child_id!r}")
 
         with self._state_lock:
-            self._chunk_mode = True
-            self._bootstrap_room = int(bootstrap_room)
-            self._dp_rank = int(dp_rank)
-            self._started_chunks.add(chunk_index)
-            if is_final:
-                self._num_chunks = chunk_index + 1
+            self._pending_chunks.pop(pending.chunk_index)
+            self._started_chunks.add(pending.chunk_index)
             if self.state == KVPoll.WAITING_FOR_INPUT:
                 self._transition_to(KVPoll.TRANSFERRING)
                 self._timer = time_phase("ack", "prefill")
                 self._timer.__enter__()
-            # Timeout each producer-to-consumer progress interval rather than
-            # the whole long prompt. Otherwise a healthy multi-chunk request
-            # can exceed ack_timeout solely because later chunks are computing.
             self._transfer_started_at = time.monotonic()
 
-        try:
-            self._manager.publish_transfer(
-                child_id,
-                list(block_ids),
-                int(bootstrap_room),
-                None,
-                dp_rank=int(dp_rank),
-                base_transfer_id=self.uuid,
-                chunk_index=chunk_index,
-                num_chunks=(chunk_index + 1 if is_final else 0),
-                chunk_page_offset=int(chunk_page_offset),
-            )
-        except Exception:
-            logger.exception(
-                "Raiden chunk metadata publish failed for req_id=%s chunk=%d",
-                self._req_id,
-                chunk_index,
-            )
-            self.request_abort("bootstrap_register")
-            raise
+        self._manager.publish_transfer(
+            child_id,
+            list(pending.block_ids),
+            pending.bootstrap_room,
+            None,
+            dp_rank=pending.dp_rank,
+            base_transfer_id=self.uuid,
+            chunk_index=pending.chunk_index,
+            num_chunks=(pending.chunk_index + 1 if pending.is_final else 0),
+            chunk_page_offset=pending.chunk_page_offset,
+        )
 
     def send(self) -> None:
         if self._block_ids is None:
@@ -717,12 +765,27 @@ class RaidenTransferKVSender(KVSender, StateHolder):
             pending_failure = self._pending_failure_reason
         self._manager.poll_engine()
         if chunk_mode:
+            if pending_failure is None:
+                self._pump_pending_chunks(raise_on_error=False)
+            with self._state_lock:
+                if self.state != KVPoll.TRANSFERRING:
+                    return self.state
+                started_chunks = tuple(sorted(self._started_chunks))
+                pending_chunks = bool(self._pending_chunks)
+                num_chunks = self._num_chunks
+                pending_failure = self._pending_failure_reason
             child_ids = [f"{self.uuid}#c{k}" for k in started_chunks]
             if not all(self._manager.sender_done(child_id) for child_id in child_ids):
                 return KVPoll.TRANSFERRING
             if pending_failure is not None:
                 return self._finish(KVPoll.FAILED, pending_failure)
+            if pending_chunks:
+                return KVPoll.TRANSFERRING
             if num_chunks is None or started_chunks != tuple(range(num_chunks)):
+                # No engine read is active while the next prefill chunk is
+                # computing, so the Raiden ack timeout must not cover compute.
+                with self._state_lock:
+                    self._transfer_started_at = None
                 return KVPoll.TRANSFERRING
             return self._finish(KVPoll.SUCCESS, "raiden_chunks_done_sending")
         if not self._manager.sender_done(self.uuid):
@@ -752,7 +815,7 @@ class RaidenTransferKVSender(KVSender, StateHolder):
 
     def request_abort(self, reason: str) -> bool:
         finish_now = False
-        with self._state_lock:
+        with self._pump_lock, self._state_lock:
             if self.state in (KVPoll.SUCCESS, KVPoll.FAILED):
                 return False
             if self._pending_failure_reason is not None:

--- a/python/sgl_jax/srt/disaggregation/runtime.py
+++ b/python/sgl_jax/srt/disaggregation/runtime.py
@@ -115,6 +115,9 @@ def install_disaggregation_wiring(scheduler: Scheduler, server_args: ServerArgs)
                 jax_process_count=jax.process_count(),
                 page_size=server_args.page_size,
                 kv_dtype=kv_dtype_name,
+                chunk_prefill_transfer=bool(
+                    server_args.disaggregation_enable_chunk_prefill_transfer
+                ),
                 transport_metadata=(
                     scheduler.disagg_kv_manager.prefill_transport_metadata(dp_rank)
                 ),

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -228,6 +228,8 @@ class Req:
         self.disagg_transfer_id: str | None = None
         self.disagg_host_buffer_id: int | None = None
         self.disagg_peer_process_index: int = 0
+        self.disagg_chunk_index: int = 0
+        self.disagg_chunk_sender = None
 
         # Memory pool info
         self.req_pool_idx: int | None = None
@@ -306,9 +308,9 @@ class Req:
         # but not by the tree (page_size > 1 chunked prefill).
         self.cache_protected_len = 0
 
-        # Whether or not if it is chunked. It increments whenever
-        # it is chunked, and decrement whenever chunked request is
-        # processed.
+        # Number of middle chunks that have been dispatched but whose results
+        # have not been processed yet. This is deliberately transient: use
+        # kv_committed_len for persistent chunked-prefill ownership.
         self.is_chunked = 0
 
         # For retraction
@@ -454,7 +456,11 @@ class Req:
         # continuation rounds must also preserve/update last_node and radix
         # lock state, not just prefix_indices.
         if getattr(self, "bootstrap_room", None) is not None and not self.output_ids:
-            if getattr(self, "is_chunked", 0) == 0:
+            # A completed middle chunk decrements is_chunked before
+            # this continuation round is initialized. kv_committed_len, not the
+            # in-flight counter, is the durable signal that prefix_indices owns
+            # already-computed prompt KV (#1496).
+            if self.kv_committed_len == 0:
                 self.prefix_indices = []
                 self.last_matched_prefix_len = 0
             self.extend_input_len = len(self.fill_ids) - len(self.prefix_indices)
@@ -663,6 +669,9 @@ class Req:
         self.decode_batch_idx = 0
         self.routed_experts = None
         self.latest_bid = None
+        self.start_send_idx = 0
+        self.disagg_chunk_index = 0
+        self.disagg_chunk_sender = None
         self.cache_protected_len = 0
         self.recurrent_pool_idx = None
         self.recurrent_cow_src_index = None

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -230,6 +230,7 @@ class Req:
         self.disagg_peer_process_index: int = 0
         self.disagg_chunk_index: int = 0
         self.disagg_chunk_sender = None
+        self.disagg_retract_pending: bool = False
 
         # Memory pool info
         self.req_pool_idx: int | None = None
@@ -672,6 +673,7 @@ class Req:
         self.start_send_idx = 0
         self.disagg_chunk_index = 0
         self.disagg_chunk_sender = None
+        self.disagg_retract_pending = False
         self.cache_protected_len = 0
         self.recurrent_pool_idx = None
         self.recurrent_cow_src_index = None

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -81,13 +81,7 @@ GLOBAL_SERVER_ARGS_KEYS = [
 
 
 def get_disagg_transport_id(req: Any) -> str:
-    base = getattr(req, "disagg_transfer_id", None) or req.rid
-    attempt = int(getattr(req, "disagg_transfer_attempt", 0))
-    return base if attempt == 0 else f"{base}#r{attempt}"
-
-
-def advance_disagg_transfer_attempt(req: Any) -> None:
-    req.disagg_transfer_attempt = int(getattr(req, "disagg_transfer_attempt", 0)) + 1
+    return getattr(req, "disagg_transfer_id", None) or req.rid
 
 
 PADDING_BUCKETS = [1 << i for i in range(6, 21)]
@@ -237,14 +231,10 @@ class Req:
         self.bootstrap_room: int | None = None
         self.disagg_prefill_dp_rank: int | None = None
         self.disagg_transfer_id: str | None = None
-        # Retracted transfers must not reuse a transport UUID while the
-        # previous Raiden read may still be retiring asynchronously.
-        self.disagg_transfer_attempt: int = 0
         self.disagg_host_buffer_id: int | None = None
         self.disagg_peer_process_index: int = 0
         self.disagg_chunk_index: int = 0
         self.disagg_chunk_sender = None
-        self.disagg_retract_pending: bool = False
 
         # Memory pool info
         self.req_pool_idx: int | None = None
@@ -687,7 +677,6 @@ class Req:
         self.start_send_idx = 0
         self.disagg_chunk_index = 0
         self.disagg_chunk_sender = None
-        self.disagg_retract_pending = False
         self.cache_protected_len = 0
         self.recurrent_pool_idx = None
         self.recurrent_cow_src_index = None
@@ -698,9 +687,6 @@ class Req:
     @property
     def disagg_transport_id(self) -> str:
         return get_disagg_transport_id(self)
-
-    def advance_disagg_transfer_attempt(self) -> None:
-        advance_disagg_transfer_attempt(self)
 
     def set_finish_with_abort(self, error_msg: str):
         # set it to one token to skip the long prefill

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -79,6 +79,17 @@ GLOBAL_SERVER_ARGS_KEYS = [
     "pd_disaggregation",
 ]
 
+
+def get_disagg_transport_id(req: Any) -> str:
+    base = getattr(req, "disagg_transfer_id", None) or req.rid
+    attempt = int(getattr(req, "disagg_transfer_attempt", 0))
+    return base if attempt == 0 else f"{base}#r{attempt}"
+
+
+def advance_disagg_transfer_attempt(req: Any) -> None:
+    req.disagg_transfer_attempt = int(getattr(req, "disagg_transfer_attempt", 0)) + 1
+
+
 PADDING_BUCKETS = [1 << i for i in range(6, 21)]
 
 # Put some global args for easy access
@@ -226,6 +237,9 @@ class Req:
         self.bootstrap_room: int | None = None
         self.disagg_prefill_dp_rank: int | None = None
         self.disagg_transfer_id: str | None = None
+        # Retracted transfers must not reuse a transport UUID while the
+        # previous Raiden read may still be retiring asynchronously.
+        self.disagg_transfer_attempt: int = 0
         self.disagg_host_buffer_id: int | None = None
         self.disagg_peer_process_index: int = 0
         self.disagg_chunk_index: int = 0
@@ -680,6 +694,13 @@ class Req:
         self.recurrent_ping_pong_track_buffer = None
         self.recurrent_next_track_idx = None
         self.recurrent_last_track_seqlen = None
+
+    @property
+    def disagg_transport_id(self) -> str:
+        return get_disagg_transport_id(self)
+
+    def advance_disagg_transfer_attempt(self) -> None:
+        advance_disagg_transfer_attempt(self)
 
     def set_finish_with_abort(self, error_msg: str):
         # set it to one token to skip the long prefill

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1906,7 +1906,9 @@ class Scheduler(
             if sender is not None:
                 # A peer may still be pulling this transport ID. Keep the
                 # producer and its pages owned while scheduling is paused, then
-                # resume the same chunk stream after continue_generation.
+                # resume the same chunk stream after continue_generation. The
+                # transfer reaper still bounds this drain by its ack/producer
+                # watchdogs, so an unusually long pause can finish as FAILED.
                 continue
             if id(req) in retracted_request_ids:
                 assert self._pending_chunked_abort_reqs[dp_rank] is None

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1904,10 +1904,9 @@ class Scheduler(
                 continue
             sender = getattr(req, "disagg_chunk_sender", None)
             if sender is not None:
-                assert self._pending_chunked_abort_reqs[dp_rank] is None
-                req.disagg_retract_pending = True
-                sender.abort()
-                self.chunked_reqs[dp_rank] = None
+                # A peer may still be pulling this transport ID. Keep the
+                # producer and its pages owned while scheduling is paused, then
+                # resume the same chunk stream after continue_generation.
                 continue
             if id(req) in retracted_request_ids:
                 assert self._pending_chunked_abort_reqs[dp_rank] is None
@@ -2751,6 +2750,8 @@ class Scheduler(
         if prefill_q is not None:
             for entry in prefill_q.cancel_matching(recv_req.rid, recv_req.abort_all):
                 logger.debug("Abort prefill queue request. rid=%s", entry.req_id)
+                if entry.req is not None:
+                    entry.req.to_finish = FINISH_ABORT()
                 entry.sender.abort()
 
         prealloc_q = self.disagg_prealloc_queue
@@ -2826,10 +2827,9 @@ class Scheduler(
             self._pd_quiesce()
 
         if recv_req.mode == "retract":
-            if self.disagg_prefill_queue is not None:
-                self.disagg_prefill_queue.retract_all()
-            if self.disagg_transfer_queue is not None:
-                self.disagg_transfer_queue.retract_all()
+            # An in-flight P/D transport cannot be retracted process-locally:
+            # the peer would keep using the original wire ID. Let transfer
+            # queues drain to a stable ownership boundary during the pause.
             self.running_batch.filter_batch()
             all_reqs = [
                 req for info in self.running_batch.reqs_info for req in info.reqs if info.reqs

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -2826,6 +2826,10 @@ class Scheduler(
             self._pd_quiesce()
 
         if recv_req.mode == "retract":
+            if self.disagg_prefill_queue is not None:
+                self.disagg_prefill_queue.retract_all()
+            if self.disagg_transfer_queue is not None:
+                self.disagg_transfer_queue.retract_all()
             self.running_batch.filter_batch()
             all_reqs = [
                 req for info in self.running_batch.reqs_info for req in info.reqs if info.reqs

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1863,6 +1863,17 @@ class Scheduler(
             if req.is_chunked > 0:
                 continue
 
+            # A chunk sender may still be reading these source KV pages. Hand
+            # finalization to its terminal callback; clearing scheduler
+            # ownership here prevents the request from being rescheduled while
+            # keeping the allocation alive until Raiden reports every child
+            # transfer done.
+            if getattr(req, "disagg_chunk_sender", None) is not None:
+                self.chunked_reqs[dp_rank] = None
+                self._pending_chunked_abort_reqs[dp_rank] = None
+                consumed[dp_rank] = req
+                continue
+
             self._finalize_chunked_abort(req, dp_rank)
             abort_out = AbortReq(rid=req.rid)
             if self._comm_backend is not None:
@@ -1890,6 +1901,13 @@ class Scheduler(
         retracted_request_ids = {id(req) for req in retracted_reqs}
         for dp_rank, req in enumerate(self.chunked_reqs):
             if req is None:
+                continue
+            sender = getattr(req, "disagg_chunk_sender", None)
+            if sender is not None:
+                assert self._pending_chunked_abort_reqs[dp_rank] is None
+                req.disagg_retract_pending = True
+                sender.abort()
+                self.chunked_reqs[dp_rank] = None
                 continue
             if id(req) in retracted_request_ids:
                 assert self._pending_chunked_abort_reqs[dp_rank] is None

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -251,6 +251,9 @@ class ServerArgs:
     # ``RuntimeError("use_d2h_staging=True requires a host_pool")``.
     disaggregation_enable_d2h: bool = False
     disaggregation_use_raiden: bool = False
+    # Stream each completed prefill chunk through Raiden instead of waiting
+    # for the whole prompt. Opt-in while the v5 protocol is validated.
+    disaggregation_enable_chunk_prefill_transfer: bool = False
     disaggregation_side_channel_port: int = 9600
     disaggregation_d2h_pool_size: int = 64
     disaggregation_d2h_max_tokens: int | None = None
@@ -550,6 +553,27 @@ class ServerArgs:
                     self.disaggregation_mode,
                 )
                 self.skip_server_warmup = True
+            if self.disaggregation_enable_chunk_prefill_transfer:
+                if not self.disaggregation_use_raiden:
+                    raise ValueError(
+                        "--disaggregation-enable-chunk-prefill-transfer requires "
+                        "--disaggregation-use-raiden"
+                    )
+                if not self.disable_radix_cache:
+                    raise ValueError(
+                        "--disaggregation-enable-chunk-prefill-transfer requires "
+                        "--disable-radix-cache"
+                    )
+                if self.chunked_prefill_size is None or self.chunked_prefill_size <= 0:
+                    raise ValueError(
+                        "--disaggregation-enable-chunk-prefill-transfer requires "
+                        "--chunked-prefill-size > 0"
+                    )
+                if self.chunked_prefill_size % self.page_size:
+                    raise ValueError(
+                        "--disaggregation-enable-chunk-prefill-transfer requires "
+                        "--chunked-prefill-size to be divisible by --page-size"
+                    )
         else:
             # null mode ignores the PD fields; warn so a misconfigured
             # deployment isn't silently ignored.
@@ -566,6 +590,11 @@ class ServerArgs:
                     "disaggregation_use_raiden",
                     self.disaggregation_use_raiden,
                     ServerArgs.disaggregation_use_raiden,
+                ),
+                (
+                    "disaggregation_enable_chunk_prefill_transfer",
+                    self.disaggregation_enable_chunk_prefill_transfer,
+                    ServerArgs.disaggregation_enable_chunk_prefill_transfer,
                 ),
             ]
             non_default = [name for name, value, default in pd_overrides if value != default]
@@ -1604,6 +1633,14 @@ class ServerArgs:
             action=argparse.BooleanOptionalAction,
             default=ServerArgs.disaggregation_use_raiden,
             help="Use tpu-raiden for direct block transfer into decode KV pages.",
+        )
+        parser.add_argument(
+            "--disaggregation-enable-chunk-prefill-transfer",
+            action=argparse.BooleanOptionalAction,
+            default=ServerArgs.disaggregation_enable_chunk_prefill_transfer,
+            help="Register and pull each completed prefill chunk through Raiden "
+            "so transfer overlaps the next chunk forward. Requires Raiden, "
+            "ChunkCache, and chunked prefill. Default OFF.",
         )
         parser.add_argument(
             "--disaggregation-side-channel-port",

--- a/python/sgl_jax/test/test_scheduler_chunked_ownership.py
+++ b/python/sgl_jax/test/test_scheduler_chunked_ownership.py
@@ -2,6 +2,8 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import numpy as np
+
 from sgl_jax.srt.managers.io_struct import AbortReq, PauseGenerationReqInput
 from sgl_jax.srt.managers.schedule_batch import FINISH_ABORT, Req, ScheduleBatch
 from sgl_jax.srt.managers.scheduler import GenerationBatchResult, Scheduler
@@ -349,6 +351,113 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
         self.assertTrue(req.finished())
         self.assertEqual(scheduler.chunked_reqs, [None])
         self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
+
+    def test_pd_continuation_preserves_committed_prefix_after_middle_result(self):
+        req = self._make_req("pd-continuation", [1, 2, 3, 4], [10, 11])
+        req.bootstrap_room = 7
+        req.is_chunked = 0
+        req.kv_committed_len = 2
+
+        req.init_next_round_input(SimpleNamespace(root_node=object(), disable=True))
+
+        self.assertEqual(list(req.prefix_indices), [10, 11])
+        self.assertEqual(req.extend_input_len, 2)
+
+    def test_pd_fresh_request_drops_uncommitted_stale_prefix(self):
+        req = self._make_req("pd-fresh", [1, 2, 3, 4], [10, 11])
+        req.bootstrap_room = 7
+        req.kv_committed_len = 0
+
+        req.init_next_round_input(SimpleNamespace(root_node=object(), disable=True))
+
+        self.assertEqual(req.prefix_indices, [])
+        self.assertEqual(req.extend_input_len, 4)
+
+    def test_pd_raiden_handoff_streams_page_aligned_chunks_once(self):
+        req = self._make_req("pd-chunks", [1, 2, 3, 4, 5, 6], [])
+        req.bootstrap_room = 91
+        req.disagg_transfer_id = "wire-pd-chunks"
+        req.req_pool_idx = 0
+        req.fill_ids = req.origin_input_ids[:4]
+        req.extend_input_len = 4
+        req.is_chunked = 1
+
+        class _Sender:
+            def __init__(self):
+                self.calls = []
+                self.has_pending_failure = False
+                self.has_started_chunks = False
+
+            def init(self, _indices, transfer_id=None):
+                self.transfer_id = transfer_id
+
+            def send_chunk(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+                self.has_started_chunks = True
+
+            def poll(self):
+                return None
+
+            def clear(self):
+                return None
+
+        class _Manager:
+            host_pool = None
+
+            def __init__(self):
+                self.sender = _Sender()
+                self.prepared = []
+
+            def create_sender(self, _req_id):
+                return self.sender
+
+            def prepare_prefill_batch(self, kv_buffer):
+                self.prepared.append(kv_buffer)
+
+        class _Queue:
+            def __init__(self):
+                self._entries = {}
+
+            def add(self, req_id, sender, on_terminal=None):
+                self._entries[req_id] = (sender, on_terminal)
+
+        scheduler, _ = self._make_scheduler(req, active_reqs=req)
+        scheduler.pd = "prefill"
+        scheduler.server_args = SimpleNamespace(
+            enable_request_time_stats_logging=False,
+            disaggregation_enable_chunk_prefill_transfer=True,
+        )
+        scheduler.disagg_kv_manager = _Manager()
+        scheduler.disagg_prefill_queue = _Queue()
+        kv_pool = SimpleNamespace(page_size=2, kv_buffer=object())
+        scheduler.token_to_kv_pool_allocator = SimpleNamespace(get_kvcache=lambda: kv_pool)
+        scheduler.req_to_token_pool = SimpleNamespace(
+            req_to_token=np.asarray([[8, 9, 20, 21, 30, 31]], dtype=np.int32)
+        )
+
+        scheduler.process_prefill_chunk(scheduler.last_batch, SimpleNamespace())
+
+        sender = scheduler.disagg_kv_manager.sender
+        self.assertEqual(sender.transfer_id, "wire-pd-chunks")
+        self.assertEqual(sender.calls[0][0], (0, [4, 10]))
+        self.assertEqual(sender.calls[0][1]["chunk_page_offset"], 0)
+        self.assertFalse(sender.calls[0][1]["is_final"])
+        self.assertEqual(req.start_send_idx, 4)
+        self.assertEqual(req.is_chunked, 0)
+        self.assertEqual(len(scheduler.disagg_prefill_queue._entries), 1)
+
+        req.fill_ids = list(req.origin_input_ids)
+        req.extend_input_len = 2
+        scheduler.chunked_reqs = [None]
+        scheduler.process_prefill_chunk(scheduler.last_batch, SimpleNamespace())
+
+        self.assertEqual(sender.calls[1][0], (1, [15]))
+        self.assertEqual(sender.calls[1][1]["chunk_page_offset"], 2)
+        self.assertTrue(sender.calls[1][1]["is_final"])
+        self.assertEqual(req.start_send_idx, 6)
+        self.assertEqual(req.disagg_chunk_index, 2)
+        self.assertEqual(len(scheduler.disagg_prefill_queue._entries), 1)
+        self.assertEqual(len(scheduler.disagg_kv_manager.prepared), 2)
 
     def test_retract_requeues_parked_chunk_after_releasing_allocation(self):
         req = self._make_req("parked", [1, 2], [10, 11])

--- a/python/sgl_jax/test/test_scheduler_chunked_ownership.py
+++ b/python/sgl_jax/test/test_scheduler_chunked_ownership.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 import numpy as np
 
+from sgl_jax.srt.disaggregation.base.kv_manager import KVPoll
 from sgl_jax.srt.managers.io_struct import AbortReq, PauseGenerationReqInput
 from sgl_jax.srt.managers.schedule_batch import FINISH_ABORT, Req, ScheduleBatch
 from sgl_jax.srt.managers.scheduler import GenerationBatchResult, Scheduler
@@ -192,6 +193,44 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
         self.assertEqual(scheduler.chunked_reqs, [None])
         self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
         self.assertEqual(scheduler.last_batch.reqs_info[0].reqs, [])
+
+    def test_abort_defers_pd_chunk_release_until_sender_is_terminal(self):
+        req = self._make_req("pd-sending", [1, 2, 3], [10, 11])
+        sender = SimpleNamespace(
+            abort=Mock(),
+            poll=Mock(return_value=KVPoll.FAILED),
+            clear=Mock(),
+        )
+        req.disagg_chunk_sender = sender
+        scheduler, _ = self._make_scheduler(req, active_reqs=req)
+        scheduler.pd = "prefill"
+        scheduler.server_args = SimpleNamespace(enable_request_time_stats_logging=False)
+        scheduler.disagg_prefill_queue = SimpleNamespace(
+            cancel_matching=lambda *_args: [SimpleNamespace(req_id=req.rid, sender=sender)]
+        )
+
+        with patch(
+            "sgl_jax.srt.managers.scheduler_output_processor_mixin.release_kv_cache"
+        ) as release:
+            scheduler.abort_request(AbortReq(rid=req.rid))
+            consumed = scheduler._process_pending_chunked_aborts()
+
+        sender.abort.assert_called_once_with()
+        release.assert_not_called()
+        scheduler._release_prefill_host_buffer.assert_not_called()
+        self.assertEqual(consumed, {0: req})
+        self.assertEqual(scheduler.chunked_reqs, [None])
+        self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
+        self.assertEqual(scheduler.send_to_tokenizer.send_pyobj.call_count, 0)
+
+        scheduler._release_prefill_req_resources = Mock()
+        scheduler._on_prefill_transfer_terminal(req, sender)
+
+        scheduler._release_prefill_req_resources.assert_called_once_with(req)
+        sender.clear.assert_called_once_with()
+        self.assertTrue(req.finished())
+        self.assertIsNone(req.disagg_chunk_sender)
+        scheduler.stream_output.assert_called_once()
 
     def test_pause_retires_consumed_chunk_owner_from_batch(self):
         req = self._make_req("parked", [1, 2, 3], [10, 11])
@@ -477,6 +516,39 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
         self.assertTrue(req.is_retracted)
         self.assertEqual(scheduler.chunked_reqs, [None])
         self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
+
+    def test_retract_waits_for_pd_chunk_sender_before_reset_and_requeue(self):
+        req = self._make_req("pd-retract", [1, 2], [10, 11])
+        sender = SimpleNamespace(
+            abort=Mock(),
+            poll=Mock(return_value=KVPoll.FAILED),
+            clear=Mock(),
+        )
+        req.disagg_chunk_sender = sender
+        scheduler, _ = self._make_scheduler(req, active_reqs=req)
+        scheduler.pd = "prefill"
+        scheduler.server_args = SimpleNamespace(enable_request_time_stats_logging=False)
+        scheduler._release_prefill_req_resources = Mock()
+
+        with patch("sgl_jax.srt.managers.scheduler.release_kv_cache") as release:
+            scheduler._retract_parked_chunked_reqs([])
+
+        sender.abort.assert_called_once_with()
+        release.assert_not_called()
+        self.assertTrue(req.disagg_retract_pending)
+        self.assertFalse(req.is_retracted)
+        self.assertEqual(scheduler.waiting_queue, [])
+        self.assertEqual(scheduler.chunked_reqs, [None])
+
+        scheduler._on_prefill_transfer_terminal(req, sender)
+
+        sender.clear.assert_called_once_with()
+        scheduler._release_prefill_req_resources.assert_called_once_with(req)
+        self.assertIsNone(req.disagg_chunk_sender)
+        self.assertFalse(req.disagg_retract_pending)
+        self.assertTrue(req.is_retracted)
+        self.assertEqual(scheduler.waiting_queue, [req])
+        scheduler.stream_output.assert_not_called()
 
     def test_retract_does_not_release_batch_owned_chunk_twice(self):
         req = self._make_req("active", [1, 2], [10, 11])

--- a/python/sgl_jax/test/test_scheduler_chunked_ownership.py
+++ b/python/sgl_jax/test/test_scheduler_chunked_ownership.py
@@ -266,6 +266,18 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
         self.assertIsNone(scheduler.last_batch.reqs_info[0].chunked_req)
         self.assertEqual(scheduler.send_to_tokenizer.send_pyobj.call_count, 1)
 
+    def test_retract_marks_both_pd_transfer_queues(self):
+        req = self._make_req("pd-retract", [1, 2], [10, 11])
+        scheduler, _ = self._make_scheduler(req)
+        scheduler.disagg_prefill_queue = Mock()
+        scheduler.disagg_transfer_queue = Mock()
+
+        with patch("sgl_jax.srt.managers.scheduler.release_kv_cache"):
+            scheduler.pause_generation(PauseGenerationReqInput(mode="retract"))
+
+        scheduler.disagg_prefill_queue.retract_all.assert_called_once_with()
+        scheduler.disagg_transfer_queue.retract_all.assert_called_once_with()
+
     def test_pending_abort_chunk_is_not_rescheduled(self):
         req = self._make_req("inflight", [1, 2], [10, 11])
         scheduler, _ = self._make_scheduler(req, active_reqs=req)
@@ -457,7 +469,8 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
             def __init__(self):
                 self._entries = {}
 
-            def add(self, req_id, sender, on_terminal=None):
+            def add(self, req_id, sender, on_terminal=None, req=None):
+                del req
                 self._entries[req_id] = (sender, on_terminal)
 
         scheduler, _ = self._make_scheduler(req, active_reqs=req)

--- a/python/sgl_jax/test/test_scheduler_chunked_ownership.py
+++ b/python/sgl_jax/test/test_scheduler_chunked_ownership.py
@@ -532,6 +532,7 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
 
     def test_retract_waits_for_pd_chunk_sender_before_reset_and_requeue(self):
         req = self._make_req("pd-retract", [1, 2], [10, 11])
+        req.disagg_transfer_id = "wire-pd-retract"
         sender = SimpleNamespace(
             abort=Mock(),
             poll=Mock(return_value=KVPoll.FAILED),
@@ -560,6 +561,8 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
         self.assertIsNone(req.disagg_chunk_sender)
         self.assertFalse(req.disagg_retract_pending)
         self.assertTrue(req.is_retracted)
+        self.assertEqual(req.disagg_transfer_attempt, 1)
+        self.assertEqual(req.disagg_transport_id, "wire-pd-retract#r1")
         self.assertEqual(scheduler.waiting_queue, [req])
         scheduler.stream_output.assert_not_called()
 

--- a/python/sgl_jax/test/test_scheduler_chunked_ownership.py
+++ b/python/sgl_jax/test/test_scheduler_chunked_ownership.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 
 from sgl_jax.srt.disaggregation.base.kv_manager import KVPoll
+from sgl_jax.srt.disaggregation.prefill import PrefillBootstrapQueue
 from sgl_jax.srt.managers.io_struct import AbortReq, PauseGenerationReqInput
 from sgl_jax.srt.managers.schedule_batch import FINISH_ABORT, Req, ScheduleBatch
 from sgl_jax.srt.managers.scheduler import GenerationBatchResult, Scheduler
@@ -139,7 +140,7 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
         scheduler, _ = self._make_scheduler(req, active_reqs=req)
         scheduler._pending_chunked_abort_reqs[0] = req
 
-        scheduler._retire_failed_chunk_producer(req)
+        scheduler._retire_chunk_producer_ownership(req)
 
         self.assertEqual(scheduler.chunked_reqs, [None])
         self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
@@ -147,6 +148,37 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
 
         scheduler._sync_chunked_req_owners()
         self.assertEqual(scheduler.chunked_reqs, [None])
+
+    def test_terminal_chunk_failure_retires_owner_before_resource_release(self):
+        req = self._make_req("failed-read", [1, 2, 3], [10, 11])
+        req.bootstrap_room = 91
+        sender = SimpleNamespace(
+            poll=Mock(return_value=KVPoll.FAILED),
+            clear=Mock(),
+            failure_exception=Mock(),
+        )
+        req.disagg_chunk_sender = sender
+        scheduler, cached = self._make_scheduler(req, active_reqs=req)
+        scheduler.pd = "prefill"
+        scheduler.server_args = SimpleNamespace(enable_request_time_stats_logging=False)
+        scheduler._pending_chunked_abort_reqs[0] = req
+
+        def assert_ownership_retired(released_req):
+            self.assertIs(released_req, req)
+            self.assertIsNone(scheduler.chunked_reqs[0])
+            self.assertIsNone(scheduler._pending_chunked_abort_reqs[0])
+            self.assertIsNone(scheduler.last_batch.reqs_info[0].chunked_req)
+
+        scheduler._release_prefill_req_resources = Mock(side_effect=assert_ownership_retired)
+
+        scheduler._on_prefill_transfer_terminal(req, sender)
+
+        scheduler._sync_chunked_req_owners()
+        self.assertEqual(scheduler._prepare_chunked_reqs_to_exclude(), {})
+        self.assertEqual(cached, [])
+        scheduler._release_prefill_req_resources.assert_called_once_with(req)
+        sender.clear.assert_called_once_with()
+        self.assertIsNone(req.disagg_chunk_sender)
 
     def test_restoring_one_dp_rank_preserves_the_other_rank_owner(self):
         req0 = self._make_req("rank-0", [1, 2, 3], [10, 11], dp_rank=0)
@@ -292,6 +324,53 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
 
         scheduler.disagg_prefill_queue.retract_all.assert_not_called()
         scheduler.disagg_transfer_queue.retract_all.assert_not_called()
+
+    def test_retract_keeps_prefill_chunk_draining_to_terminal(self):
+        req = self._make_req("pd-retract-drain", [1, 2, 3], [10, 11])
+        req.bootstrap_room = 92
+        req.disagg_transfer_id = "wire-pd-retract-drain"
+
+        class _Sender:
+            def __init__(self):
+                self.state = KVPoll.TRANSFERRING
+                self.clear = Mock()
+
+            def poll(self):
+                return self.state
+
+        sender = _Sender()
+        req.disagg_chunk_sender = sender
+        scheduler, _ = self._make_scheduler(req, active_reqs=req)
+        scheduler.pd = "prefill"
+        scheduler.server_args = SimpleNamespace(enable_request_time_stats_logging=False)
+        scheduler.disagg_prefill_queue = PrefillBootstrapQueue()
+        scheduler._release_prefill_req_resources = Mock()
+        scheduler.disagg_prefill_queue.add(
+            req.rid,
+            sender,
+            req=req,
+            on_terminal=lambda: scheduler._on_prefill_transfer_terminal(req, sender),
+        )
+
+        scheduler.pause_generation(PauseGenerationReqInput(mode="retract"))
+        self.assertTrue(scheduler._engine_paused)
+        self.assertEqual(len(scheduler.disagg_prefill_queue), 1)
+        self.assertEqual(req.disagg_transport_id, "wire-pd-retract-drain")
+
+        scheduler.send_kv_chunk()
+        scheduler._release_prefill_req_resources.assert_not_called()
+
+        sender.state = KVPoll.SUCCESS
+        scheduler.send_kv_chunk()
+
+        self.assertEqual(len(scheduler.disagg_prefill_queue), 0)
+        scheduler._release_prefill_req_resources.assert_called_once_with(req)
+        self.assertIsNone(req.disagg_chunk_sender)
+        self.assertIsNone(scheduler.chunked_reqs[0])
+        self.assertEqual(req.disagg_transport_id, "wire-pd-retract-drain")
+
+        scheduler.continue_generation(SimpleNamespace())
+        self.assertFalse(scheduler._engine_paused)
 
     def test_pending_abort_chunk_is_not_rescheduled(self):
         req = self._make_req("inflight", [1, 2], [10, 11])

--- a/python/sgl_jax/test/test_scheduler_chunked_ownership.py
+++ b/python/sgl_jax/test/test_scheduler_chunked_ownership.py
@@ -206,7 +206,7 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
         scheduler.pd = "prefill"
         scheduler.server_args = SimpleNamespace(enable_request_time_stats_logging=False)
         scheduler.disagg_prefill_queue = SimpleNamespace(
-            cancel_matching=lambda *_args: [SimpleNamespace(req_id=req.rid, sender=sender)]
+            cancel_matching=lambda *_args: [SimpleNamespace(req_id=req.rid, sender=sender, req=req)]
         )
 
         with patch(
@@ -216,6 +216,7 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
             consumed = scheduler._process_pending_chunked_aborts()
 
         sender.abort.assert_called_once_with()
+        self.assertIsNotNone(req.to_finish)
         release.assert_not_called()
         scheduler._release_prefill_host_buffer.assert_not_called()
         self.assertEqual(consumed, {0: req})
@@ -266,7 +267,7 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
         self.assertIsNone(scheduler.last_batch.reqs_info[0].chunked_req)
         self.assertEqual(scheduler.send_to_tokenizer.send_pyobj.call_count, 1)
 
-    def test_retract_marks_both_pd_transfer_queues(self):
+    def test_retract_leaves_active_pd_transfer_queues_draining(self):
         req = self._make_req("pd-retract", [1, 2], [10, 11])
         scheduler, _ = self._make_scheduler(req)
         scheduler.disagg_prefill_queue = Mock()
@@ -275,8 +276,8 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
         with patch("sgl_jax.srt.managers.scheduler.release_kv_cache"):
             scheduler.pause_generation(PauseGenerationReqInput(mode="retract"))
 
-        scheduler.disagg_prefill_queue.retract_all.assert_called_once_with()
-        scheduler.disagg_transfer_queue.retract_all.assert_called_once_with()
+        scheduler.disagg_prefill_queue.retract_all.assert_not_called()
+        scheduler.disagg_transfer_queue.retract_all.assert_not_called()
 
     def test_pending_abort_chunk_is_not_rescheduled(self):
         req = self._make_req("inflight", [1, 2], [10, 11])
@@ -444,6 +445,7 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
 
             def send_chunk(self, *args, **kwargs):
                 self.calls.append((args, kwargs))
+                kwargs["on_ready"]()
                 self.has_started_chunks = True
 
             def poll(self):
@@ -493,6 +495,7 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
         self.assertEqual(sender.transfer_id, "wire-pd-chunks")
         self.assertEqual(sender.calls[0][0], (0, [4, 10]))
         self.assertEqual(sender.calls[0][1]["chunk_page_offset"], 0)
+        self.assertEqual(sender.calls[0][1]["expected_total_pages"], 3)
         self.assertFalse(sender.calls[0][1]["is_final"])
         self.assertEqual(req.start_send_idx, 4)
         self.assertEqual(req.is_chunked, 0)
@@ -505,6 +508,7 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
 
         self.assertEqual(sender.calls[1][0], (1, [15]))
         self.assertEqual(sender.calls[1][1]["chunk_page_offset"], 2)
+        self.assertEqual(sender.calls[1][1]["expected_total_pages"], 3)
         self.assertTrue(sender.calls[1][1]["is_final"])
         self.assertEqual(req.start_send_idx, 6)
         self.assertEqual(req.disagg_chunk_index, 2)
@@ -530,7 +534,7 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
         self.assertEqual(scheduler.chunked_reqs, [None])
         self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
 
-    def test_retract_waits_for_pd_chunk_sender_before_reset_and_requeue(self):
+    def test_retract_preserves_active_pd_chunk_sender_and_wire_id(self):
         req = self._make_req("pd-retract", [1, 2], [10, 11])
         req.disagg_transfer_id = "wire-pd-retract"
         sender = SimpleNamespace(
@@ -542,28 +546,17 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
         scheduler, _ = self._make_scheduler(req, active_reqs=req)
         scheduler.pd = "prefill"
         scheduler.server_args = SimpleNamespace(enable_request_time_stats_logging=False)
-        scheduler._release_prefill_req_resources = Mock()
 
         with patch("sgl_jax.srt.managers.scheduler.release_kv_cache") as release:
             scheduler._retract_parked_chunked_reqs([])
 
-        sender.abort.assert_called_once_with()
+        sender.abort.assert_not_called()
         release.assert_not_called()
-        self.assertTrue(req.disagg_retract_pending)
         self.assertFalse(req.is_retracted)
         self.assertEqual(scheduler.waiting_queue, [])
-        self.assertEqual(scheduler.chunked_reqs, [None])
-
-        scheduler._on_prefill_transfer_terminal(req, sender)
-
-        sender.clear.assert_called_once_with()
-        scheduler._release_prefill_req_resources.assert_called_once_with(req)
-        self.assertIsNone(req.disagg_chunk_sender)
-        self.assertFalse(req.disagg_retract_pending)
-        self.assertTrue(req.is_retracted)
-        self.assertEqual(req.disagg_transfer_attempt, 1)
-        self.assertEqual(req.disagg_transport_id, "wire-pd-retract#r1")
-        self.assertEqual(scheduler.waiting_queue, [req])
+        self.assertEqual(scheduler.chunked_reqs, [req])
+        self.assertEqual(req.disagg_transport_id, "wire-pd-retract")
+        sender.clear.assert_not_called()
         scheduler.stream_output.assert_not_called()
 
     def test_retract_does_not_release_batch_owned_chunk_twice(self):

--- a/python/sgl_jax/test/test_scheduler_chunked_ownership.py
+++ b/python/sgl_jax/test/test_scheduler_chunked_ownership.py
@@ -134,6 +134,20 @@ class TestSchedulerChunkedOwnership(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "Chunked request mismatch"):
             scheduler._prepare_chunked_reqs_to_exclude()
 
+    def test_failed_pd_chunk_clears_batch_owner_before_terminal_release(self):
+        req = self._make_req("failed", [1, 2, 3], [10, 11])
+        scheduler, _ = self._make_scheduler(req, active_reqs=req)
+        scheduler._pending_chunked_abort_reqs[0] = req
+
+        scheduler._retire_failed_chunk_producer(req)
+
+        self.assertEqual(scheduler.chunked_reqs, [None])
+        self.assertEqual(scheduler._pending_chunked_abort_reqs, [None])
+        self.assertIsNone(scheduler.last_batch.reqs_info[0].chunked_req)
+
+        scheduler._sync_chunked_req_owners()
+        self.assertEqual(scheduler.chunked_reqs, [None])
+
     def test_restoring_one_dp_rank_preserves_the_other_rank_owner(self):
         req0 = self._make_req("rank-0", [1, 2, 3], [10, 11], dp_rank=0)
         req1 = self._make_req("rank-1", [4, 5, 6], [12, 13], dp_rank=1)

--- a/test/srt/disaggregation/test_pd_bootstrap.py
+++ b/test/srt/disaggregation/test_pd_bootstrap.py
@@ -409,7 +409,9 @@ def test_transfer_metadata_is_reusable_per_process_and_ttl_bounded():
             "remote_block_ids": [1, 2],
         }
     )
-    assert registry.get_transfer(7)["transfer_id"] == "first"
+    first = registry.get_transfer(7)
+    assert first["base_transfer_id"] == "first"
+    assert first["chunks"][0]["transfer_id"] == "first"
 
     registry.register_transfer(
         {
@@ -427,11 +429,11 @@ def test_transfer_metadata_is_reusable_per_process_and_ttl_bounded():
             "transport_metadata": {"remote_block_ids": [11]},
         }
     )
-    assert registry.get_transfer(7, 0)["transfer_id"] == "second"
-    assert registry.get_transfer(7, 1)["transfer_id"] == "peer"
+    assert registry.get_transfer(7, 0)["chunks"][0]["transfer_id"] == "second"
+    assert registry.get_transfer(7, 1)["chunks"][0]["transfer_id"] == "peer"
     registry.pop_room(7, 0)
     assert registry.get_transfer(7, 0) is None
-    assert registry.get_transfer(7, 1)["transfer_id"] == "peer"
+    assert registry.get_transfer(7, 1)["chunks"][0]["transfer_id"] == "peer"
     clock.t += 6.0
     assert registry.get_transfer(7, 1) is None
 
@@ -449,7 +451,7 @@ def test_transfer_metadata_namespaces_same_page_ids_by_prefill_dp_rank():
             }
         )
 
-    assert [registry.get_transfer(9, 0, rank)["transfer_id"] for rank in range(4)] == [
+    assert [registry.get_transfer(9, 0, rank)["chunks"][0]["transfer_id"] for rank in range(4)] == [
         "rank-0",
         "rank-1",
         "rank-2",
@@ -457,7 +459,72 @@ def test_transfer_metadata_namespaces_same_page_ids_by_prefill_dp_rank():
     ]
     registry.pop_room(9, 0, 2)
     assert registry.get_transfer(9, 0, 2) is None
-    assert registry.get_transfer(9, 0, 1)["transfer_id"] == "rank-1"
+    assert registry.get_transfer(9, 0, 1)["chunks"][0]["transfer_id"] == "rank-1"
+
+
+def _chunk_transfer_info(
+    base_transfer_id: str,
+    chunk_index: int,
+    *,
+    num_chunks: int = 0,
+    chunk_page_offset: int | None = None,
+) -> dict[str, object]:
+    return {
+        "bootstrap_room": 17,
+        "transfer_id": f"{base_transfer_id}#c{chunk_index}",
+        "base_transfer_id": base_transfer_id,
+        "jax_process_index": 2,
+        "prefill_dp_rank": 3,
+        "chunk_index": chunk_index,
+        "num_chunks": num_chunks,
+        "chunk_page_offset": (chunk_index * 2 if chunk_page_offset is None else chunk_page_offset),
+        "transport_metadata": {"remote_block_ids": [10 + chunk_index]},
+    }
+
+
+def test_chunk_transfer_registry_accumulates_and_finalizes_out_of_order():
+    registry = _Registry()
+    final = _chunk_transfer_info("wire", 2, num_chunks=3)
+    first = _chunk_transfer_info("wire", 0)
+    middle = _chunk_transfer_info("wire", 1)
+
+    registry.register_transfer(final)
+    registry.register_transfer(first)
+    registry.register_transfer(middle)
+
+    bundle = registry.get_transfer(17, 2, 3)
+    assert bundle["base_transfer_id"] == "wire"
+    assert bundle["num_chunks"] == 3
+    assert sorted(bundle["chunks"]) == [0, 1, 2]
+    assert bundle["chunks"][2]["chunk_page_offset"] == 4
+
+
+def test_chunk_transfer_registry_is_idempotent_and_rejects_conflicts():
+    registry = _Registry()
+    chunk = _chunk_transfer_info("wire", 0)
+    registry.register_transfer(chunk)
+    registry.register_transfer(dict(chunk))
+
+    conflicting = _chunk_transfer_info("wire", 0, chunk_page_offset=1)
+    with pytest.raises(ValueError, match="conflicting transfer metadata"):
+        registry.register_transfer(conflicting)
+
+    bad_final = _chunk_transfer_info("wire", 1, num_chunks=3)
+    with pytest.raises(ValueError, match="final chunk"):
+        registry.register_transfer(bad_final)
+
+
+def test_chunk_zero_replaces_stale_room_but_later_chunk_cannot():
+    registry = _Registry()
+    registry.register_transfer(_chunk_transfer_info("old", 0))
+
+    with pytest.raises(ValueError, match="only from chunk zero"):
+        registry.register_transfer(_chunk_transfer_info("new", 1))
+
+    registry.register_transfer(_chunk_transfer_info("new", 0))
+    bundle = registry.get_transfer(17, 2, 3)
+    assert bundle["base_transfer_id"] == "new"
+    assert bundle["chunks"][0]["transfer_id"] == "new#c0"
 
 
 def test_prefill_decode_transfer_engines_must_match():

--- a/test/srt/disaggregation/test_pd_bootstrap.py
+++ b/test/srt/disaggregation/test_pd_bootstrap.py
@@ -438,6 +438,23 @@ def test_transfer_metadata_is_reusable_per_process_and_ttl_bounded():
     assert registry.get_transfer(7, 1) is None
 
 
+def test_stale_generation_cleanup_does_not_pop_replacement_metadata():
+    registry = _Registry()
+    for transfer_id in ("wire#r0", "wire#r1"):
+        registry.register_transfer(
+            {
+                "bootstrap_room": 8,
+                "transfer_id": transfer_id,
+                "transport_metadata": {"remote_block_ids": [1]},
+            }
+        )
+
+    assert registry.pop_room(8, expected_transfer_id="wire#r0") is False
+    assert registry.get_transfer(8)["base_transfer_id"] == "wire#r1"
+    assert registry.pop_room(8, expected_transfer_id="wire#r1") is True
+    assert registry.get_transfer(8) is None
+
+
 def test_transfer_metadata_namespaces_same_page_ids_by_prefill_dp_rank():
     registry = _Registry()
     for prefill_dp_rank in range(4):

--- a/test/srt/disaggregation/test_pd_bootstrap.py
+++ b/test/srt/disaggregation/test_pd_bootstrap.py
@@ -495,23 +495,25 @@ def _chunk_transfer_info(
         "chunk_index": chunk_index,
         "num_chunks": num_chunks,
         "chunk_page_offset": (chunk_index * 2 if chunk_page_offset is None else chunk_page_offset),
+        "expected_total_pages": 3,
         "transport_metadata": {"remote_block_ids": [10 + chunk_index]},
     }
 
 
-def test_chunk_transfer_registry_accumulates_and_finalizes_out_of_order():
+def test_chunk_transfer_registry_accumulates_and_finalizes_after_chunk_zero():
     registry = _Registry()
     final = _chunk_transfer_info("wire", 2, num_chunks=3)
     first = _chunk_transfer_info("wire", 0)
     middle = _chunk_transfer_info("wire", 1)
 
-    registry.register_transfer(final)
     registry.register_transfer(first)
+    registry.register_transfer(final)
     registry.register_transfer(middle)
 
     bundle = registry.get_transfer(17, 2, 3)
     assert bundle["base_transfer_id"] == "wire"
     assert bundle["num_chunks"] == 3
+    assert bundle["expected_total_pages"] == 3
     assert sorted(bundle["chunks"]) == [0, 1, 2]
     assert bundle["chunks"][2]["chunk_page_offset"] == 4
 
@@ -542,6 +544,23 @@ def test_chunk_zero_replaces_stale_room_but_later_chunk_cannot():
     bundle = registry.get_transfer(17, 2, 3)
     assert bundle["base_transfer_id"] == "new"
     assert bundle["chunks"][0]["transfer_id"] == "new#c0"
+
+
+def test_chunk_registry_rejects_orphan_nonzero_chunk():
+    registry = _Registry()
+
+    with pytest.raises(ValueError, match="created from chunk zero"):
+        registry.register_transfer(_chunk_transfer_info("wire", 1))
+
+
+def test_chunk_registry_rejects_conflicting_expected_total_pages():
+    registry = _Registry()
+    registry.register_transfer(_chunk_transfer_info("wire", 0))
+    second = _chunk_transfer_info("wire", 1)
+    second["expected_total_pages"] = 4
+
+    with pytest.raises(ValueError, match="conflicting expected_total_pages"):
+        registry.register_transfer(second)
 
 
 def test_prefill_decode_transfer_engines_must_match():
@@ -592,6 +611,19 @@ def test_prefill_decode_dp_topology_must_match():
             local_page_size=128,
             local_kv_dtype="bfloat16",
             expected_dp_size=2,
+        )
+
+
+@pytest.mark.parametrize(("prefill_enabled", "decode_enabled"), [(True, False), (False, True)])
+def test_prefill_decode_chunk_transfer_flag_must_match(prefill_enabled, decode_enabled):
+    info = {"chunk_prefill_transfer": prefill_enabled}
+
+    with pytest.raises(ValueError, match="chunk prefill transfer mismatch"):
+        check_prefill_compat(
+            info,
+            local_page_size=128,
+            local_kv_dtype="bfloat16",
+            expected_chunk_prefill_transfer=decode_enabled,
         )
 
 

--- a/test/srt/disaggregation/test_pd_decode.py
+++ b/test/srt/disaggregation/test_pd_decode.py
@@ -715,29 +715,6 @@ def test_cancel_matching_retains_inflight_entry_until_terminal():
     assert len(queue) == 1
 
 
-def test_retract_all_aborts_live_receivers_but_skips_cancelled_entries():
-    queue = DecodeTransferQueue()
-    live_receiver = mock.Mock()
-    cancelled_receiver = mock.Mock()
-    live = DecodeBookkeeping(req_id="live", req=_AdmReq("live", 4), receiver=live_receiver)
-    cancelled = DecodeBookkeeping(
-        req_id="cancelled",
-        req=_AdmReq("cancelled", 4),
-        receiver=cancelled_receiver,
-        cancelled=True,
-    )
-    queue.add(live)
-    queue.add(cancelled)
-
-    retracted = queue.retract_all()
-
-    assert retracted == [live]
-    assert live.retracted is True
-    assert cancelled.retracted is False
-    live_receiver.abort.assert_called_once_with()
-    cancelled_receiver.abort.assert_not_called()
-
-
 def test_cancelled_terminal_transfer_releases_decode_rank_pages():
     class _CancelledDrainScheduler:
         process_decode_queue = SchedulerDisaggregationDecodeMixin.process_decode_queue
@@ -773,44 +750,6 @@ def test_cancelled_terminal_transfer_releases_decode_rank_pages():
     sched.process_decode_queue()
 
     assert sched.released == [([12, 13, 14, 15], 3)]
-
-
-def test_retracted_terminal_transfer_releases_pages_and_retries_bootstrap():
-    class _RetractedDrainScheduler:
-        _drain_decode_transfer_terminals = (
-            SchedulerDisaggregationDecodeMixin._drain_decode_transfer_terminals
-        )
-
-        def __init__(self, entry):
-            self.entry = entry
-            self.released = []
-            self._pd_pending_bootstrap = []
-
-        def _drain_transfer_queue_synced(self):
-            return [self.entry]
-
-        def _release_decode_kv_indices(self, kv_indices, dp_rank):
-            self.released.append((kv_indices, dp_rank))
-
-    req = _AdmReq("retracted", 4)
-    req.dp_rank = 2
-    req.reset_for_retract = mock.Mock()
-    entry = DecodeBookkeeping(
-        req_id=req.rid,
-        req=req,
-        receiver=object(),
-        kv_indices=[20, 21],
-        synced_state=KVPoll.FAILED,
-        retracted=True,
-    )
-    sched = _RetractedDrainScheduler(entry)
-
-    sched._drain_decode_transfer_terminals()
-
-    assert sched.released == [([20, 21], 2)]
-    req.reset_for_retract.assert_called_once_with()
-    assert req.disagg_transfer_attempt == 1
-    assert sched._pd_pending_bootstrap == [req]
 
 
 def test_inflight_cap_is_partitioned_per_rank_without_cross_rank_head_of_line():

--- a/test/srt/disaggregation/test_pd_decode.py
+++ b/test/srt/disaggregation/test_pd_decode.py
@@ -811,6 +811,7 @@ def test_retracted_terminal_transfer_releases_pages_and_retries_bootstrap():
 
     assert sched.released == [([20, 21], 2)]
     req.reset_for_retract.assert_called_once_with()
+    assert req.disagg_transfer_attempt == 1
     assert sched._pd_pending_bootstrap == [req]
 
 

--- a/test/srt/disaggregation/test_pd_decode.py
+++ b/test/srt/disaggregation/test_pd_decode.py
@@ -719,9 +719,7 @@ def test_retract_all_aborts_live_receivers_but_skips_cancelled_entries():
     queue = DecodeTransferQueue()
     live_receiver = mock.Mock()
     cancelled_receiver = mock.Mock()
-    live = DecodeBookkeeping(
-        req_id="live", req=_AdmReq("live", 4), receiver=live_receiver
-    )
+    live = DecodeBookkeeping(req_id="live", req=_AdmReq("live", 4), receiver=live_receiver)
     cancelled = DecodeBookkeeping(
         req_id="cancelled",
         req=_AdmReq("cancelled", 4),

--- a/test/srt/disaggregation/test_pd_decode.py
+++ b/test/srt/disaggregation/test_pd_decode.py
@@ -417,6 +417,12 @@ class _KVManager:
     def __init__(self, raise_on_init=False):
         self._raise = raise_on_init
         self.created = []
+        self.metadata_ready = True
+        self.metadata_polls = []
+
+    def poll_decode_metadata(self, context):
+        self.metadata_polls.append(context)
+        return self.metadata_ready
 
     def create_receiver(self, rid):
         r = _Receiver(raise_on_init=self._raise)
@@ -433,6 +439,7 @@ class _AdmServerArgs:
     def __init__(self, reserved, max_inflight=0):
         self.disaggregation_num_reserved_decode_tokens = reserved
         self.disaggregation_max_inflight_transfers = max_inflight
+        self.disaggregation_pull_timeout_seconds = 30.0
         self.enable_request_time_stats_logging = False
 
 
@@ -453,6 +460,7 @@ class _Batch:
 
 class _AdmScheduler:
     _admit_decode_prealloc = SchedulerDisaggregationDecodeMixin._admit_decode_prealloc
+    _expire_decode_prealloc = SchedulerDisaggregationDecodeMixin._expire_decode_prealloc
 
     def __init__(
         self,
@@ -537,6 +545,19 @@ def test_admit_when_capacity_sufficient():
     assert len(sched.disagg_prealloc_queue) == 0
     assert len(sched.disagg_transfer_queue) == 2
     assert sched.aborted == []
+
+
+def test_metadata_pending_does_not_allocate_decode_kv():
+    sched = _AdmScheduler(capacity=100, reserved=0)
+    sched.disagg_kv_manager.metadata_ready = False
+    _enqueue(sched, "pending", seqlen=4)
+
+    sched._admit_decode_prealloc()
+
+    assert len(sched.disagg_prealloc_queue) == 1
+    assert len(sched.disagg_transfer_queue) == 0
+    assert sched.token_to_kv_pool_allocator.alloc_ranks == []
+    assert len(sched.disagg_kv_manager.metadata_polls) == 1
 
 
 def test_admission_routes_allocator_and_transfer_to_decode_and_prefill_ranks():
@@ -750,6 +771,58 @@ def test_cancelled_terminal_transfer_releases_decode_rank_pages():
     sched.process_decode_queue()
 
     assert sched.released == [([12, 13, 14, 15], 3)]
+
+
+def test_paused_decode_drains_inflight_transfer_to_completion():
+    class _Receiver:
+        def commit(self, install):
+            install("received-kv")
+
+    class _PausedDrainScheduler:
+        _drain_decode_transfer_terminals = (
+            SchedulerDisaggregationDecodeMixin._drain_decode_transfer_terminals
+        )
+
+        def __init__(self, entry):
+            self._engine_paused = True
+            self.entry = entry
+            self.installed = []
+            self.bookkept = []
+            self.enqueued = []
+            self.server_args = SimpleNamespace(enable_request_time_stats_logging=False)
+
+        def _drain_transfer_queue_synced(self):
+            return [self.entry]
+
+        def _install_received_kv(self, req, kv_indices, kv):
+            self.installed.append((req, kv_indices, kv))
+
+        def _set_decode_bookkeeping(self, req, kv_indices):
+            self.bookkept.append((req, kv_indices))
+
+        def _enqueue_for_decode(self, req):
+            self.enqueued.append(req)
+
+        def _pd_mark_time(self, req, name):
+            pass
+
+    req = _AdmReq("paused-drain", 4)
+    req.pd_time_stats = None
+    entry = DecodeBookkeeping(
+        req_id=req.rid,
+        req=req,
+        receiver=_Receiver(),
+        kv_indices=[4, 5, 6, 7],
+        synced_state=KVPoll.SUCCESS,
+    )
+    sched = _PausedDrainScheduler(entry)
+
+    sched._drain_decode_transfer_terminals()
+
+    assert sched._engine_paused is True
+    assert sched.installed == [(req, [4, 5, 6, 7], "received-kv")]
+    assert sched.bookkept == [(req, [4, 5, 6, 7])]
+    assert sched.enqueued == [req]
 
 
 def test_inflight_cap_is_partitioned_per_rank_without_cross_rank_head_of_line():

--- a/test/srt/disaggregation/test_pd_decode.py
+++ b/test/srt/disaggregation/test_pd_decode.py
@@ -715,9 +715,37 @@ def test_cancel_matching_retains_inflight_entry_until_terminal():
     assert len(queue) == 1
 
 
+def test_retract_all_aborts_live_receivers_but_skips_cancelled_entries():
+    queue = DecodeTransferQueue()
+    live_receiver = mock.Mock()
+    cancelled_receiver = mock.Mock()
+    live = DecodeBookkeeping(
+        req_id="live", req=_AdmReq("live", 4), receiver=live_receiver
+    )
+    cancelled = DecodeBookkeeping(
+        req_id="cancelled",
+        req=_AdmReq("cancelled", 4),
+        receiver=cancelled_receiver,
+        cancelled=True,
+    )
+    queue.add(live)
+    queue.add(cancelled)
+
+    retracted = queue.retract_all()
+
+    assert retracted == [live]
+    assert live.retracted is True
+    assert cancelled.retracted is False
+    live_receiver.abort.assert_called_once_with()
+    cancelled_receiver.abort.assert_not_called()
+
+
 def test_cancelled_terminal_transfer_releases_decode_rank_pages():
     class _CancelledDrainScheduler:
         process_decode_queue = SchedulerDisaggregationDecodeMixin.process_decode_queue
+        _drain_decode_transfer_terminals = (
+            SchedulerDisaggregationDecodeMixin._drain_decode_transfer_terminals
+        )
 
         def __init__(self, entry):
             self.entry = entry
@@ -747,6 +775,43 @@ def test_cancelled_terminal_transfer_releases_decode_rank_pages():
     sched.process_decode_queue()
 
     assert sched.released == [([12, 13, 14, 15], 3)]
+
+
+def test_retracted_terminal_transfer_releases_pages_and_retries_bootstrap():
+    class _RetractedDrainScheduler:
+        _drain_decode_transfer_terminals = (
+            SchedulerDisaggregationDecodeMixin._drain_decode_transfer_terminals
+        )
+
+        def __init__(self, entry):
+            self.entry = entry
+            self.released = []
+            self._pd_pending_bootstrap = []
+
+        def _drain_transfer_queue_synced(self):
+            return [self.entry]
+
+        def _release_decode_kv_indices(self, kv_indices, dp_rank):
+            self.released.append((kv_indices, dp_rank))
+
+    req = _AdmReq("retracted", 4)
+    req.dp_rank = 2
+    req.reset_for_retract = mock.Mock()
+    entry = DecodeBookkeeping(
+        req_id=req.rid,
+        req=req,
+        receiver=object(),
+        kv_indices=[20, 21],
+        synced_state=KVPoll.FAILED,
+        retracted=True,
+    )
+    sched = _RetractedDrainScheduler(entry)
+
+    sched._drain_decode_transfer_terminals()
+
+    assert sched.released == [([20, 21], 2)]
+    req.reset_for_retract.assert_called_once_with()
+    assert sched._pd_pending_bootstrap == [req]
 
 
 def test_inflight_cap_is_partitioned_per_rank_without_cross_rank_head_of_line():

--- a/test/srt/disaggregation/test_pd_prefill.py
+++ b/test/srt/disaggregation/test_pd_prefill.py
@@ -13,6 +13,7 @@ from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.disaggregation.base.kv_manager import KVPoll
 from sgl_jax.srt.disaggregation.bootstrap import (
+    PROTOCOL_VERSION,
     PrefillInfo,
     PrefillInfoCache,
     build_app,
@@ -235,7 +236,7 @@ def _pf(key, **kw):
         "host": "h",
         "transfer_port": 1,
         "side_channel_port": 2,
-        "protocol_version": 1,
+        "protocol_version": PROTOCOL_VERSION,
     }
     d.update(kw)
     return d

--- a/test/srt/disaggregation/test_pd_prefill.py
+++ b/test/srt/disaggregation/test_pd_prefill.py
@@ -117,27 +117,6 @@ def test_cancel_matching_retains_prefill_entry_until_sender_terminal():
     assert len(queue) == 1
 
 
-def test_retract_all_aborts_live_entries_but_does_not_resurrect_cancelled_ones():
-    queue = PrefillBootstrapQueue()
-    _, live_sender = _make_sender()
-    _, cancelled_sender = _make_sender()
-    live_sender.abort = mock.Mock()
-    cancelled_sender.abort = mock.Mock()
-    live_req = SimpleNamespace(disagg_retract_pending=False)
-    cancelled_req = SimpleNamespace(disagg_retract_pending=False)
-    queue.add("live", live_sender, req=live_req)
-    queue.add("cancelled", cancelled_sender, req=cancelled_req)
-    queue.cancel_matching("cancelled", abort_all=False)
-
-    retracted = queue.retract_all()
-
-    assert [entry.req_id for entry in retracted] == ["live"]
-    assert live_req.disagg_retract_pending is True
-    assert cancelled_req.disagg_retract_pending is False
-    live_sender.abort.assert_called_once_with()
-    cancelled_sender.abort.assert_not_called()
-
-
 def test_staging_send_handoff_failure_unregisters_and_keeps_payload():
     mgr, sender = _make_sender()
 

--- a/test/srt/disaggregation/test_pd_prefill.py
+++ b/test/srt/disaggregation/test_pd_prefill.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest import mock
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -110,7 +113,29 @@ def test_cancel_matching_retains_prefill_entry_until_sender_terminal():
     cancelled = queue.cancel_matching("req-a", abort_all=False)
 
     assert [entry.req_id for entry in cancelled] == ["req-a"]
+    assert cancelled[0].cancelled is True
     assert len(queue) == 1
+
+
+def test_retract_all_aborts_live_entries_but_does_not_resurrect_cancelled_ones():
+    queue = PrefillBootstrapQueue()
+    _, live_sender = _make_sender()
+    _, cancelled_sender = _make_sender()
+    live_sender.abort = mock.Mock()
+    cancelled_sender.abort = mock.Mock()
+    live_req = SimpleNamespace(disagg_retract_pending=False)
+    cancelled_req = SimpleNamespace(disagg_retract_pending=False)
+    queue.add("live", live_sender, req=live_req)
+    queue.add("cancelled", cancelled_sender, req=cancelled_req)
+    queue.cancel_matching("cancelled", abort_all=False)
+
+    retracted = queue.retract_all()
+
+    assert [entry.req_id for entry in retracted] == ["live"]
+    assert live_req.disagg_retract_pending is True
+    assert cancelled_req.disagg_retract_pending is False
+    live_sender.abort.assert_called_once_with()
+    cancelled_sender.abort.assert_not_called()
 
 
 def test_staging_send_handoff_failure_unregisters_and_keeps_payload():

--- a/test/srt/disaggregation/test_pd_raiden.py
+++ b/test/srt/disaggregation/test_pd_raiden.py
@@ -24,6 +24,7 @@ from sgl_jax.srt.disaggregation.base.transfer import (
 from sgl_jax.srt.disaggregation.common.capacity import per_rank_inflight_limit
 from sgl_jax.srt.disaggregation.factory import (
     _raiden_transfer_pool_shape,
+    _tree_cache_supports_swa,
     create_transfer_backend,
 )
 from sgl_jax.srt.disaggregation.raiden_transfer.conn import (
@@ -1029,6 +1030,14 @@ def test_raiden_chunk_pool_uses_two_chunk_sized_slot_waves():
         chunk_prefill_size=1024,
         chunk_transfer_enabled=False,
     ) == (256, 4)
+
+
+def test_raiden_chunk_factory_allows_plain_chunk_cache_without_swa_probe():
+    plain_chunk_cache = types.SimpleNamespace()
+    swa_chunk_cache = types.SimpleNamespace(supports_swa=lambda: True)
+
+    assert _tree_cache_supports_swa(plain_chunk_cache) is False
+    assert _tree_cache_supports_swa(swa_chunk_cache) is True
 
 
 @pytest.mark.parametrize(

--- a/test/srt/disaggregation/test_pd_raiden.py
+++ b/test/srt/disaggregation/test_pd_raiden.py
@@ -22,8 +22,12 @@ from sgl_jax.srt.disaggregation.base.transfer import (
     slots_to_page_ids,
 )
 from sgl_jax.srt.disaggregation.common.capacity import per_rank_inflight_limit
-from sgl_jax.srt.disaggregation.factory import create_transfer_backend
+from sgl_jax.srt.disaggregation.factory import (
+    _raiden_transfer_pool_shape,
+    create_transfer_backend,
+)
 from sgl_jax.srt.disaggregation.raiden_transfer.conn import (
+    RaidenChunkedMetadata,
     RaidenMetadata,
     RaidenTransferKVManager,
     _uuid_to_int,
@@ -100,6 +104,43 @@ def _manager(fake_raiden: _FakeRaiden, bootstrap: _FakeBootstrap):
     return RaidenTransferKVManager(fake_raiden, bootstrap)
 
 
+def _chunk_manager(fake_raiden: _FakeRaiden, bootstrap: _FakeBootstrap):
+    return RaidenTransferKVManager(
+        fake_raiden,
+        bootstrap,
+        enable_chunk_prefill_transfer=True,
+    )
+
+
+def _chunk_record(
+    base_uuid: str,
+    chunk_index: int,
+    remote_block_ids: list[int],
+    *,
+    page_offset: int,
+    num_chunks: int = 0,
+    prefill_dp_rank: int = 0,
+) -> dict[str, object]:
+    return {
+        "transfer_id": f"{base_uuid}#c{chunk_index}",
+        "base_transfer_id": base_uuid,
+        "jax_process_index": 0,
+        "prefill_dp_rank": prefill_dp_rank,
+        "chunk_index": chunk_index,
+        "num_chunks": num_chunks,
+        "chunk_page_offset": page_offset,
+        "transport_metadata": {"remote_block_ids": remote_block_ids},
+    }
+
+
+def _chunk_bundle(base_uuid: str, records: list[dict[str, object]]):
+    return {
+        "base_transfer_id": base_uuid,
+        "chunks": {record["chunk_index"]: record for record in records},
+        "num_chunks": max((int(record["num_chunks"]) for record in records), default=0),
+    }
+
+
 def test_raiden_sender_registers_once_and_completes_from_poll_stats():
     raiden = _FakeRaiden()
     bootstrap = _FakeBootstrap()
@@ -113,8 +154,12 @@ def test_raiden_sender_registers_once_and_completes_from_poll_stats():
     assert raiden.registered == [(("wire-1", _uuid_to_int("wire-1"), [3, 8, 13]), {"dp_rank": 0})]
     assert bootstrap.registered[0][0] == (42, "wire-1")
     assert bootstrap.registered[0][1] == {
+        "base_transfer_id": None,
         "jax_process_index": 0,
         "prefill_dp_rank": 0,
+        "chunk_index": 0,
+        "num_chunks": 1,
+        "chunk_page_offset": 0,
         "transport_metadata": {"remote_block_ids": [3, 8, 13]},
     }
     assert sender.poll() == KVPoll.TRANSFERRING
@@ -122,6 +167,69 @@ def test_raiden_sender_registers_once_and_completes_from_poll_stats():
     raiden.stats = (["wire-1"], [], [])
     assert sender.poll() == KVPoll.SUCCESS
     assert "req-1" not in manager._senders
+
+
+def test_raiden_chunk_sender_waits_for_final_descriptor_and_every_child_ack():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    manager = _chunk_manager(raiden, bootstrap)
+    sender = manager.create_sender("req-chunk-send")
+    sender.init(None, transfer_id="wire-chunk-send")
+
+    sender.send_chunk(
+        0,
+        [3, 8],
+        bootstrap_room=81,
+        chunk_page_offset=0,
+        is_final=False,
+    )
+    assert sender.poll() == KVPoll.TRANSFERRING
+    raiden.stats = (["wire-chunk-send#c0"], [], [])
+    assert sender.poll() == KVPoll.TRANSFERRING
+
+    sender.send_chunk(
+        1,
+        [13],
+        bootstrap_room=81,
+        chunk_page_offset=2,
+        is_final=True,
+    )
+    assert [call[0][0] for call in raiden.registered] == [
+        "wire-chunk-send#c0",
+        "wire-chunk-send#c1",
+    ]
+    assert bootstrap.registered[0][1]["base_transfer_id"] == "wire-chunk-send"
+    assert bootstrap.registered[0][1]["num_chunks"] == 0
+    assert bootstrap.registered[1][1]["chunk_page_offset"] == 2
+    assert bootstrap.registered[1][1]["num_chunks"] == 2
+    assert sender.poll() == KVPoll.TRANSFERRING
+
+    raiden.stats = (["wire-chunk-send#c0", "wire-chunk-send#c1"], [], [])
+    assert sender.poll() == KVPoll.SUCCESS
+    assert bootstrap.popped == [(81, {"jax_process_index": 0, "prefill_dp_rank": 0})]
+
+
+def test_raiden_chunk_sender_abort_waits_for_started_children():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    manager = _chunk_manager(raiden, bootstrap)
+    sender = manager.create_sender("req-chunk-abort")
+    sender.init(None, transfer_id="wire-chunk-abort")
+    sender.send_chunk(
+        0,
+        [1],
+        bootstrap_room=82,
+        chunk_page_offset=0,
+        is_final=False,
+    )
+
+    sender.abort()
+    assert sender.poll() == KVPoll.TRANSFERRING
+    assert bootstrap.popped == []
+
+    raiden.stats = (["wire-chunk-abort#c0"], [], [])
+    assert sender.poll() == KVPoll.FAILED
+    assert bootstrap.popped == [(82, {"jax_process_index": 0, "prefill_dp_rank": 0})]
 
 
 def test_raiden_receiver_starts_direct_block_read_and_pops_metadata():
@@ -152,6 +260,214 @@ def test_raiden_receiver_starts_direct_block_read_and_pops_metadata():
     assert receiver.poll() == KVPoll.SUCCESS
     assert bootstrap.popped == [(43, {"jax_process_index": 3, "prefill_dp_rank": 0})]
     assert "req-2" not in manager._receivers
+
+
+def test_raiden_chunk_receiver_discovers_new_chunks_and_commits_after_all_done():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    first = _chunk_record("wire-chunk-recv", 0, [1, 4], page_offset=0)
+    bootstrap.transfer_info = _chunk_bundle("wire-chunk-recv", [first])
+    manager = _chunk_manager(raiden, bootstrap)
+    committed = []
+    receiver = manager.create_receiver("req-chunk-recv")
+    receiver.init(
+        RaidenChunkedMetadata(
+            base_uuid="wire-chunk-recv",
+            remote_endpoint="10.0.0.1:7777",
+            local_block_ids=(9, 10, 11),
+            bootstrap_room=83,
+            jax_process_index=0,
+            prefill_dp_rank=0,
+            decode_dp_rank=0,
+            initial_chunks={0: first},
+            direct_commit=committed.append,
+        )
+    )
+
+    assert receiver.poll() == KVPoll.TRANSFERRING
+    assert raiden.started[-1][0][0] == "wire-chunk-recv#c0"
+    assert raiden.started[-1][0][3:] == ([1, 4], [9, 10])
+
+    final = _chunk_record(
+        "wire-chunk-recv",
+        1,
+        [7],
+        page_offset=2,
+        num_chunks=2,
+    )
+    bootstrap.transfer_info = _chunk_bundle("wire-chunk-recv", [first, final])
+    assert receiver.poll() == KVPoll.TRANSFERRING
+    assert raiden.started[-1][0][0] == "wire-chunk-recv#c1"
+    assert raiden.started[-1][0][3:] == ([7], [11])
+
+    raiden.stats = ([], ["wire-chunk-recv#c0"], [])
+    assert receiver.poll() == KVPoll.TRANSFERRING
+    raiden.stats = (
+        [],
+        ["wire-chunk-recv#c0", "wire-chunk-recv#c1"],
+        [],
+    )
+    assert receiver.poll() == KVPoll.SUCCESS
+    receiver.commit(lambda _: None)
+    assert committed == [None]
+    assert bootstrap.popped == [(83, {"jax_process_index": 0, "prefill_dp_rank": 0})]
+
+
+def test_raiden_chunk_receiver_failure_waits_for_all_started_children():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    records = [
+        _chunk_record("wire-chunk-fail", 0, [1], page_offset=0),
+        _chunk_record(
+            "wire-chunk-fail",
+            1,
+            [2],
+            page_offset=1,
+            num_chunks=2,
+        ),
+    ]
+    bootstrap.transfer_info = _chunk_bundle("wire-chunk-fail", records)
+    manager = _chunk_manager(raiden, bootstrap)
+    receiver = manager.create_receiver("req-chunk-fail")
+    receiver.init(
+        RaidenChunkedMetadata(
+            base_uuid="wire-chunk-fail",
+            remote_endpoint="10.0.0.1:7777",
+            local_block_ids=(9, 10),
+            bootstrap_room=84,
+            jax_process_index=0,
+            prefill_dp_rank=0,
+            decode_dp_rank=0,
+            initial_chunks={index: record for index, record in enumerate(records)},
+            known_num_chunks=2,
+        )
+    )
+    assert receiver.poll() == KVPoll.TRANSFERRING
+
+    raiden.stats = ([], [], ["wire-chunk-fail#c0"])
+    assert receiver.poll() == KVPoll.TRANSFERRING
+    assert bootstrap.popped == []
+
+    raiden.stats = ([], ["wire-chunk-fail#c1"], ["wire-chunk-fail#c0"])
+    assert receiver.poll() == KVPoll.FAILED
+    assert bootstrap.popped == [(84, {"jax_process_index": 0, "prefill_dp_rank": 0})]
+
+
+def test_raiden_chunk_receiver_rejects_overlapping_page_ranges():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    records = [
+        _chunk_record("wire-overlap", 0, [1, 2], page_offset=0),
+        _chunk_record(
+            "wire-overlap",
+            1,
+            [3],
+            page_offset=1,
+            num_chunks=2,
+        ),
+    ]
+    bootstrap.transfer_info = _chunk_bundle("wire-overlap", records)
+    manager = _chunk_manager(raiden, bootstrap)
+    receiver = manager.create_receiver("req-overlap")
+    receiver.init(
+        RaidenChunkedMetadata(
+            base_uuid="wire-overlap",
+            remote_endpoint="10.0.0.1:7777",
+            local_block_ids=(9, 10, 11),
+            bootstrap_room=86,
+            jax_process_index=0,
+            prefill_dp_rank=0,
+            decode_dp_rank=0,
+            initial_chunks={index: record for index, record in enumerate(records)},
+            known_num_chunks=2,
+        )
+    )
+
+    assert receiver.poll() == KVPoll.FAILED
+    assert raiden.started == []
+
+
+def test_raiden_chunk_receiver_limits_each_parent_to_two_active_pulls():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    records = [
+        _chunk_record("wire-window", 0, [1], page_offset=0),
+        _chunk_record("wire-window", 1, [2], page_offset=1),
+        _chunk_record(
+            "wire-window",
+            2,
+            [3],
+            page_offset=2,
+            num_chunks=3,
+        ),
+    ]
+    bootstrap.transfer_info = _chunk_bundle("wire-window", records)
+    manager = _chunk_manager(raiden, bootstrap)
+    receiver = manager.create_receiver("req-window")
+    receiver.init(
+        RaidenChunkedMetadata(
+            base_uuid="wire-window",
+            remote_endpoint="10.0.0.1:7777",
+            local_block_ids=(9, 10, 11),
+            bootstrap_room=87,
+            jax_process_index=0,
+            prefill_dp_rank=0,
+            decode_dp_rank=0,
+            initial_chunks={index: record for index, record in enumerate(records)},
+            known_num_chunks=3,
+        )
+    )
+
+    assert receiver.poll() == KVPoll.TRANSFERRING
+    assert [call[0][0] for call in raiden.started] == [
+        "wire-window#c0",
+        "wire-window#c1",
+    ]
+
+    raiden.stats = ([], ["wire-window#c0"], [])
+    assert receiver.poll() == KVPoll.TRANSFERRING
+    assert len(raiden.started) == 2
+    assert receiver.poll() == KVPoll.TRANSFERRING
+    assert [call[0][0] for call in raiden.started] == [
+        "wire-window#c0",
+        "wire-window#c1",
+        "wire-window#c2",
+    ]
+
+
+def test_raiden_chunk_receiver_rejects_gaps_before_decode_commit():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    records = [
+        _chunk_record("wire-gap", 0, [1], page_offset=0),
+        _chunk_record(
+            "wire-gap",
+            1,
+            [2],
+            page_offset=2,
+            num_chunks=2,
+        ),
+    ]
+    bootstrap.transfer_info = _chunk_bundle("wire-gap", records)
+    manager = _chunk_manager(raiden, bootstrap)
+    receiver = manager.create_receiver("req-gap")
+    receiver.init(
+        RaidenChunkedMetadata(
+            base_uuid="wire-gap",
+            remote_endpoint="10.0.0.1:7777",
+            local_block_ids=(9, 10, 11),
+            bootstrap_room=88,
+            jax_process_index=0,
+            prefill_dp_rank=0,
+            decode_dp_rank=0,
+            initial_chunks={index: record for index, record in enumerate(records)},
+            known_num_chunks=2,
+        )
+    )
+    assert receiver.poll() == KVPoll.TRANSFERRING
+
+    raiden.stats = ([], ["wire-gap#c0", "wire-gap#c1"], [])
+    assert receiver.poll() == KVPoll.FAILED
 
 
 def test_raiden_commit_runs_direct_observability_hook():
@@ -331,6 +647,41 @@ def test_raiden_manager_owns_decode_admission_and_endpoint_mapping():
             {"decode_dp_rank": 0},
         )
     ]
+
+
+def test_raiden_chunk_decode_admission_starts_from_chunk_zero_metadata():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    first = _chunk_record("wire-admit-chunk", 0, [3], page_offset=0)
+    bootstrap.transfer_info = _chunk_bundle("wire-admit-chunk", [first])
+    manager = _chunk_manager(raiden, bootstrap)
+    context = DecodeTransferContext(
+        req_id="req-admit-chunk",
+        transfer_id="wire-admit-chunk",
+        bootstrap_room=85,
+        decode_dp_rank=0,
+        prefill_dp_rank=0,
+        peer_info={
+            "host": "10.0.0.1",
+            "transport_metadata": {
+                "engine": "raiden",
+                "dp_rank": 0,
+                "dp_size": 1,
+                "endpoints": raiden.endpoints,
+            },
+        },
+        kv_indices=[18, 19, 20, 21],
+        page_size=2,
+        prompt_tokens=4,
+        spec_factory=lambda: None,
+    )
+
+    admission = manager.try_start_decode(context)
+
+    assert admission.state == AdmissionState.ADMITTED
+    assert admission.receiver.poll() == KVPoll.TRANSFERRING
+    assert raiden.started[-1][0][0] == "wire-admit-chunk#c0"
+    assert raiden.started[-1][0][3:] == ([3], [9])
 
 
 @pytest.mark.parametrize(
@@ -604,8 +955,55 @@ def test_raiden_cli_is_opt_in():
     ServerArgs.add_cli_args(parser)
     defaults = parser.parse_args(["--model-path", "dummy"])
     selected = parser.parse_args(["--model-path", "dummy", "--disaggregation-use-raiden"])
+    chunked = parser.parse_args(
+        ["--model-path", "dummy", "--disaggregation-enable-chunk-prefill-transfer"]
+    )
     assert defaults.disaggregation_use_raiden is False
     assert selected.disaggregation_use_raiden is True
+    assert defaults.disaggregation_enable_chunk_prefill_transfer is False
+    assert chunked.disaggregation_enable_chunk_prefill_transfer is True
+
+
+@pytest.mark.parametrize(
+    ("override", "error"),
+    [
+        ({"disaggregation_use_raiden": False}, "requires --disaggregation-use-raiden"),
+        ({"disable_radix_cache": False}, "requires --disable-radix-cache"),
+        ({"chunked_prefill_size": 1000}, "divisible by --page-size"),
+    ],
+)
+def test_chunk_prefill_transfer_server_args_reject_incompatible_modes(override, error):
+    config = {
+        "model_path": "dummy",
+        "device": "tpu",
+        "disaggregation_mode": "prefill",
+        "disaggregation_bootstrap_url": "http://bootstrap",
+        "page_size": 128,
+        "disaggregation_enable_chunk_prefill_transfer": True,
+        "disaggregation_use_raiden": True,
+        "disable_radix_cache": True,
+        "chunked_prefill_size": 1024,
+    }
+    config.update(override)
+
+    with pytest.raises(ValueError, match=error):
+        ServerArgs(**config)
+
+
+def test_chunk_prefill_transfer_server_args_accept_raiden_chunk_cache():
+    args = ServerArgs(
+        model_path="dummy",
+        device="tpu",
+        disaggregation_mode="prefill",
+        disaggregation_bootstrap_url="http://bootstrap",
+        page_size=128,
+        disaggregation_enable_chunk_prefill_transfer=True,
+        disaggregation_use_raiden=True,
+        disable_radix_cache=True,
+        chunked_prefill_size=1024,
+    )
+
+    assert args.disaggregation_enable_chunk_prefill_transfer is True
 
 
 @pytest.mark.parametrize(
@@ -614,6 +1012,23 @@ def test_raiden_cli_is_opt_in():
 )
 def test_raiden_inflight_capacity_is_partitioned_per_rank(max_inflight, dp_size, expected):
     assert per_rank_inflight_limit(max_inflight, dp_size) == expected
+
+
+def test_raiden_chunk_pool_uses_two_chunk_sized_slot_waves():
+    assert _raiden_transfer_pool_shape(
+        max_req_input_len=32768,
+        page_size=128,
+        parent_slots=4,
+        chunk_prefill_size=1024,
+        chunk_transfer_enabled=True,
+    ) == (8, 8)
+    assert _raiden_transfer_pool_shape(
+        max_req_input_len=32768,
+        page_size=128,
+        parent_slots=4,
+        chunk_prefill_size=1024,
+        chunk_transfer_enabled=False,
+    ) == (256, 4)
 
 
 @pytest.mark.parametrize(

--- a/test/srt/disaggregation/test_pd_raiden.py
+++ b/test/srt/disaggregation/test_pd_raiden.py
@@ -210,7 +210,16 @@ def test_raiden_chunk_sender_waits_for_final_descriptor_and_every_child_ack():
 
     raiden.stats = (["wire-chunk-send#c0", "wire-chunk-send#c1"], [], [])
     assert sender.poll() == KVPoll.SUCCESS
-    assert bootstrap.popped == [(81, {"jax_process_index": 0, "prefill_dp_rank": 0})]
+    assert bootstrap.popped == [
+        (
+            81,
+            {
+                "jax_process_index": 0,
+                "prefill_dp_rank": 0,
+                "expected_transfer_id": "wire-chunk-send",
+            },
+        )
+    ]
 
 
 def test_raiden_chunk_sender_limits_active_children_to_transfer_window():
@@ -294,7 +303,16 @@ def test_raiden_chunk_sender_abort_waits_for_started_children():
 
     raiden.stats = (["wire-chunk-abort#c0"], [], [])
     assert sender.poll() == KVPoll.FAILED
-    assert bootstrap.popped == [(82, {"jax_process_index": 0, "prefill_dp_rank": 0})]
+    assert bootstrap.popped == [
+        (
+            82,
+            {
+                "jax_process_index": 0,
+                "prefill_dp_rank": 0,
+                "expected_transfer_id": "wire-chunk-abort",
+            },
+        )
+    ]
 
 
 def test_raiden_receiver_starts_direct_block_read_and_pops_metadata():
@@ -323,7 +341,16 @@ def test_raiden_receiver_starts_direct_block_read_and_pops_metadata():
 
     raiden.stats = ([], ["wire-2"], [])
     assert receiver.poll() == KVPoll.SUCCESS
-    assert bootstrap.popped == [(43, {"jax_process_index": 3, "prefill_dp_rank": 0})]
+    assert bootstrap.popped == [
+        (
+            43,
+            {
+                "jax_process_index": 3,
+                "prefill_dp_rank": 0,
+                "expected_transfer_id": "wire-2",
+            },
+        )
+    ]
     assert "req-2" not in manager._receivers
 
 
@@ -375,7 +402,16 @@ def test_raiden_chunk_receiver_discovers_new_chunks_and_commits_after_all_done()
     assert receiver.poll() == KVPoll.SUCCESS
     receiver.commit(lambda _: None)
     assert committed == [None]
-    assert bootstrap.popped == [(83, {"jax_process_index": 0, "prefill_dp_rank": 0})]
+    assert bootstrap.popped == [
+        (
+            83,
+            {
+                "jax_process_index": 0,
+                "prefill_dp_rank": 0,
+                "expected_transfer_id": "wire-chunk-recv",
+            },
+        )
+    ]
 
 
 def test_raiden_chunk_receiver_failure_waits_for_all_started_children():
@@ -415,7 +451,16 @@ def test_raiden_chunk_receiver_failure_waits_for_all_started_children():
 
     raiden.stats = ([], ["wire-chunk-fail#c1"], ["wire-chunk-fail#c0"])
     assert receiver.poll() == KVPoll.FAILED
-    assert bootstrap.popped == [(84, {"jax_process_index": 0, "prefill_dp_rank": 0})]
+    assert bootstrap.popped == [
+        (
+            84,
+            {
+                "jax_process_index": 0,
+                "prefill_dp_rank": 0,
+                "expected_transfer_id": "wire-chunk-fail",
+            },
+        )
+    ]
 
 
 def test_raiden_chunk_receiver_rejects_overlapping_page_ranges():
@@ -579,7 +624,16 @@ def test_raiden_failure_and_abort_cleanup_are_terminal_and_idempotent():
     raiden.stats = ([], [], ["wire-3"])
     assert receiver.poll() == KVPoll.FAILED
     receiver.abort()
-    assert bootstrap.popped == [(44, {"jax_process_index": 0, "prefill_dp_rank": 0})]
+    assert bootstrap.popped == [
+        (
+            44,
+            {
+                "jax_process_index": 0,
+                "prefill_dp_rank": 0,
+                "expected_transfer_id": "wire-3",
+            },
+        )
+    ]
 
 
 def test_raiden_abort_waits_for_engine_terminal_before_cleanup():
@@ -600,7 +654,16 @@ def test_raiden_abort_waits_for_engine_terminal_before_cleanup():
     raiden.stats = (["wire-abort"], [], [])
     assert sender.poll() == KVPoll.FAILED
     assert "req-abort" not in manager._senders
-    assert bootstrap.popped == [(48, {"jax_process_index": 0, "prefill_dp_rank": 0})]
+    assert bootstrap.popped == [
+        (
+            48,
+            {
+                "jax_process_index": 0,
+                "prefill_dp_rank": 0,
+                "expected_transfer_id": "wire-abort",
+            },
+        )
+    ]
 
 
 def test_raiden_receiver_abort_waits_for_engine_terminal():
@@ -628,7 +691,16 @@ def test_raiden_receiver_abort_waits_for_engine_terminal():
     raiden.stats = ([], ["wire-abort"], [])
     assert receiver.poll() == KVPoll.FAILED
     assert "req-abort" not in manager._receivers
-    assert bootstrap.popped == [(49, {"jax_process_index": 0, "prefill_dp_rank": 0})]
+    assert bootstrap.popped == [
+        (
+            49,
+            {
+                "jax_process_index": 0,
+                "prefill_dp_rank": 0,
+                "expected_transfer_id": "wire-abort",
+            },
+        )
+    ]
 
 
 def test_raiden_reaper_marks_timeout_without_pruning_sender():

--- a/test/srt/disaggregation/test_pd_raiden.py
+++ b/test/srt/disaggregation/test_pd_raiden.py
@@ -6,6 +6,8 @@ import argparse
 import os
 import subprocess
 import sys
+import threading
+import time
 import types
 from unittest import mock
 
@@ -19,6 +21,8 @@ from sgl_jax.srt.disaggregation.base.kv_manager import KVPoll
 from sgl_jax.srt.disaggregation.base.transfer import (
     AdmissionState,
     DecodeTransferContext,
+    chunk_transfer_id,
+    parse_chunk_transfer_id,
     slots_to_page_ids,
 )
 from sgl_jax.srt.disaggregation.common.capacity import (
@@ -49,6 +53,7 @@ class _FakeBootstrap:
         self.popped: list[tuple[int, dict]] = []
         self.transfer_info = None
         self.fail_register = False
+        self.get_calls = 0
 
     def register_transfer(self, *args, **kwargs) -> None:
         if self.fail_register:
@@ -59,6 +64,7 @@ class _FakeBootstrap:
         self.popped.append((room, kwargs))
 
     def get_transfer_info(self, _room: int, **_kwargs):
+        self.get_calls += 1
         return self.transfer_info
 
 
@@ -137,12 +143,29 @@ def _chunk_record(
     }
 
 
-def _chunk_bundle(base_uuid: str, records: list[dict[str, object]]):
+def _chunk_bundle(
+    base_uuid: str,
+    records: list[dict[str, object]],
+    *,
+    expected_total_pages: int,
+):
     return {
         "base_transfer_id": base_uuid,
         "chunks": {record["chunk_index"]: record for record in records},
         "num_chunks": max((int(record["num_chunks"]) for record in records), default=0),
+        "expected_total_pages": expected_total_pages,
     }
+
+
+def _poll_until(receiver, predicate, timeout: float = 1.0):
+    deadline = time.monotonic() + timeout
+    state = receiver.state
+    while time.monotonic() < deadline:
+        state = receiver.poll()
+        if predicate():
+            return state
+        time.sleep(0.001)
+    raise AssertionError(f"condition was not met before timeout; state={state}")
 
 
 def test_raiden_sender_registers_once_and_completes_from_poll_stats():
@@ -164,6 +187,7 @@ def test_raiden_sender_registers_once_and_completes_from_poll_stats():
         "chunk_index": 0,
         "num_chunks": 1,
         "chunk_page_offset": 0,
+        "expected_total_pages": 0,
         "transport_metadata": {"remote_block_ids": [3, 8, 13]},
     }
     assert sender.poll() == KVPoll.TRANSFERRING
@@ -186,6 +210,7 @@ def test_raiden_chunk_sender_waits_for_final_descriptor_and_every_child_ack():
         bootstrap_room=81,
         chunk_page_offset=0,
         is_final=False,
+        expected_total_pages=3,
     )
     assert sender.poll() == KVPoll.TRANSFERRING
     raiden.stats = (["wire-chunk-send#c0"], [], [])
@@ -197,6 +222,7 @@ def test_raiden_chunk_sender_waits_for_final_descriptor_and_every_child_ack():
         bootstrap_room=81,
         chunk_page_offset=2,
         is_final=True,
+        expected_total_pages=3,
     )
     assert [call[0][0] for call in raiden.registered] == [
         "wire-chunk-send#c0",
@@ -228,6 +254,7 @@ def test_raiden_chunk_sender_limits_active_children_to_transfer_window():
     manager = _chunk_manager(raiden, bootstrap)
     sender = manager.create_sender("req-chunk-window")
     sender.init(None, transfer_id="wire-chunk-window")
+    ready_callbacks = [mock.Mock() for _ in range(CHUNK_TRANSFER_WINDOW + 1)]
 
     for chunk_index in range(CHUNK_TRANSFER_WINDOW + 1):
         sender.send_chunk(
@@ -236,18 +263,23 @@ def test_raiden_chunk_sender_limits_active_children_to_transfer_window():
             bootstrap_room=83,
             chunk_page_offset=chunk_index,
             is_final=chunk_index == CHUNK_TRANSFER_WINDOW,
+            expected_total_pages=CHUNK_TRANSFER_WINDOW + 1,
+            on_ready=ready_callbacks[chunk_index],
         )
 
     assert [call[0][0] for call in raiden.registered] == [
         f"wire-chunk-window#c{index}" for index in range(CHUNK_TRANSFER_WINDOW)
     ]
     assert len(bootstrap.registered) == CHUNK_TRANSFER_WINDOW
+    assert all(callback.call_count == 1 for callback in ready_callbacks[:CHUNK_TRANSFER_WINDOW])
+    assert ready_callbacks[-1].call_count == 0
 
     raiden.stats = (["wire-chunk-window#c0"], [], [])
     assert sender.poll() == KVPoll.TRANSFERRING
     assert [call[0][0] for call in raiden.registered] == [
         f"wire-chunk-window#c{index}" for index in range(CHUNK_TRANSFER_WINDOW + 1)
     ]
+    assert ready_callbacks[-1].call_count == 1
 
     raiden.stats = (
         [f"wire-chunk-window#c{index}" for index in range(CHUNK_TRANSFER_WINDOW + 1)],
@@ -270,6 +302,7 @@ def test_raiden_chunk_sender_drops_queued_children_after_abort():
             bootstrap_room=84,
             chunk_page_offset=chunk_index,
             is_final=chunk_index == CHUNK_TRANSFER_WINDOW,
+            expected_total_pages=CHUNK_TRANSFER_WINDOW + 1,
         )
 
     sender.abort()
@@ -295,6 +328,7 @@ def test_raiden_chunk_sender_abort_waits_for_started_children():
         bootstrap_room=82,
         chunk_page_offset=0,
         is_final=False,
+        expected_total_pages=2,
     )
 
     sender.abort()
@@ -313,6 +347,34 @@ def test_raiden_chunk_sender_abort_waits_for_started_children():
             },
         )
     ]
+
+
+def test_raiden_chunk_sender_ack_timeout_excludes_prefill_compute_gap():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    manager = RaidenTransferKVManager(
+        raiden,
+        bootstrap,
+        enable_chunk_prefill_transfer=True,
+        ack_timeout_seconds=1.0,
+    )
+    sender = manager.create_sender("req-send-compute-gap")
+    sender.init(None, transfer_id="wire-send-compute-gap")
+    sender.send_chunk(
+        0,
+        [1],
+        bootstrap_room=85,
+        chunk_page_offset=0,
+        is_final=False,
+        expected_total_pages=2,
+    )
+    raiden.stats = (["wire-send-compute-gap#c0"], [], [])
+
+    assert sender.poll() == KVPoll.TRANSFERRING
+    assert sender.transfer_started_at is None
+    timed_out, _ = manager.reap_once(time.monotonic() + 2.0)
+
+    assert timed_out == []
 
 
 def test_raiden_receiver_starts_direct_block_read_and_pops_metadata():
@@ -358,7 +420,7 @@ def test_raiden_chunk_receiver_discovers_new_chunks_and_commits_after_all_done()
     raiden = _FakeRaiden()
     bootstrap = _FakeBootstrap()
     first = _chunk_record("wire-chunk-recv", 0, [1, 4], page_offset=0)
-    bootstrap.transfer_info = _chunk_bundle("wire-chunk-recv", [first])
+    bootstrap.transfer_info = _chunk_bundle("wire-chunk-recv", [first], expected_total_pages=3)
     manager = _chunk_manager(raiden, bootstrap)
     committed = []
     receiver = manager.create_receiver("req-chunk-recv")
@@ -372,6 +434,7 @@ def test_raiden_chunk_receiver_discovers_new_chunks_and_commits_after_all_done()
             prefill_dp_rank=0,
             decode_dp_rank=0,
             initial_chunks={0: first},
+            expected_total_pages=3,
             direct_commit=committed.append,
         )
     )
@@ -387,8 +450,10 @@ def test_raiden_chunk_receiver_discovers_new_chunks_and_commits_after_all_done()
         page_offset=2,
         num_chunks=2,
     )
-    bootstrap.transfer_info = _chunk_bundle("wire-chunk-recv", [first, final])
-    assert receiver.poll() == KVPoll.TRANSFERRING
+    bootstrap.transfer_info = _chunk_bundle(
+        "wire-chunk-recv", [first, final], expected_total_pages=3
+    )
+    assert _poll_until(receiver, lambda: len(raiden.started) == 2) == KVPoll.TRANSFERRING
     assert raiden.started[-1][0][0] == "wire-chunk-recv#c1"
     assert raiden.started[-1][0][3:] == ([7], [11])
 
@@ -414,6 +479,143 @@ def test_raiden_chunk_receiver_discovers_new_chunks_and_commits_after_all_done()
     ]
 
 
+def test_raiden_chunk_metadata_lookup_never_blocks_receiver_poll():
+    class _BlockingBootstrap(_FakeBootstrap):
+        def __init__(self):
+            super().__init__()
+            self.lookup_started = threading.Event()
+            self.release_lookup = threading.Event()
+
+        def get_transfer_info(self, _room: int, **_kwargs):
+            self.get_calls += 1
+            self.lookup_started.set()
+            assert self.release_lookup.wait(timeout=1.0)
+            return self.transfer_info
+
+    raiden = _FakeRaiden()
+    bootstrap = _BlockingBootstrap()
+    first = _chunk_record("wire-nonblocking", 0, [1], page_offset=0)
+    bootstrap.transfer_info = _chunk_bundle("wire-nonblocking", [first], expected_total_pages=2)
+    receiver = _chunk_manager(raiden, bootstrap).create_receiver("req-nonblocking")
+    receiver.init(
+        RaidenChunkedMetadata(
+            base_uuid="wire-nonblocking",
+            remote_endpoint="10.0.0.1:7777",
+            local_block_ids=(9, 10),
+            bootstrap_room=91,
+            jax_process_index=0,
+            prefill_dp_rank=0,
+            decode_dp_rank=0,
+            initial_chunks={0: first},
+            expected_total_pages=2,
+        )
+    )
+
+    try:
+        started_at = time.monotonic()
+        assert receiver.poll() == KVPoll.TRANSFERRING
+        elapsed = time.monotonic() - started_at
+
+        assert elapsed < 0.1
+        assert bootstrap.lookup_started.wait(timeout=1.0)
+    finally:
+        bootstrap.release_lookup.set()
+
+
+def test_raiden_chunk_receiver_skips_lookup_when_all_metadata_is_known():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    records = [
+        _chunk_record("wire-known", 0, [1], page_offset=0),
+        _chunk_record("wire-known", 1, [2], page_offset=1, num_chunks=2),
+    ]
+    receiver = _chunk_manager(raiden, bootstrap).create_receiver("req-known")
+    receiver.init(
+        RaidenChunkedMetadata(
+            base_uuid="wire-known",
+            remote_endpoint="10.0.0.1:7777",
+            local_block_ids=(9, 10),
+            bootstrap_room=92,
+            jax_process_index=0,
+            prefill_dp_rank=0,
+            decode_dp_rank=0,
+            initial_chunks={index: record for index, record in enumerate(records)},
+            known_num_chunks=2,
+            expected_total_pages=2,
+        )
+    )
+
+    assert receiver.poll() == KVPoll.TRANSFERRING
+    assert bootstrap.get_calls == 0
+
+
+def test_raiden_chunk_receiver_pull_timeout_excludes_producer_compute_gap():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    first = _chunk_record("wire-compute-gap", 0, [1], page_offset=0)
+    bootstrap.transfer_info = _chunk_bundle("wire-compute-gap", [first], expected_total_pages=2)
+    manager = RaidenTransferKVManager(
+        raiden,
+        bootstrap,
+        enable_chunk_prefill_transfer=True,
+        pull_timeout_seconds=1.0,
+    )
+    receiver = manager.create_receiver("req-compute-gap")
+    receiver.init(
+        RaidenChunkedMetadata(
+            base_uuid="wire-compute-gap",
+            remote_endpoint="10.0.0.1:7777",
+            local_block_ids=(9, 10),
+            bootstrap_room=93,
+            jax_process_index=0,
+            prefill_dp_rank=0,
+            decode_dp_rank=0,
+            initial_chunks={0: first},
+            expected_total_pages=2,
+        )
+    )
+    assert receiver.poll() == KVPoll.TRANSFERRING
+
+    raiden.stats = ([], ["wire-compute-gap#c0"], [])
+    assert receiver.poll() == KVPoll.TRANSFERRING
+    assert receiver.transfer_started_at is None
+    assert receiver.producer_wait_started_at is not None
+
+    _, timed_out = manager.reap_once(receiver.producer_wait_started_at + 2.0)
+    assert timed_out == []
+
+
+def test_raiden_chunk_commit_preserves_kv_debug_metadata():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    expected = {"global_digest": "chunk-digest"}
+    final = _chunk_record("wire-chunk-debug", 0, [1], page_offset=0, num_chunks=1)
+    final["transport_metadata"]["kv_debug"] = expected
+    committed = []
+    receiver = _chunk_manager(raiden, bootstrap).create_receiver("req-chunk-debug")
+    receiver.init(
+        RaidenChunkedMetadata(
+            base_uuid="wire-chunk-debug",
+            remote_endpoint="10.0.0.1:7777",
+            local_block_ids=(9,),
+            bootstrap_room=94,
+            jax_process_index=0,
+            prefill_dp_rank=0,
+            decode_dp_rank=0,
+            initial_chunks={0: final},
+            known_num_chunks=1,
+            expected_total_pages=1,
+            direct_commit=committed.append,
+        )
+    )
+    assert receiver.poll() == KVPoll.TRANSFERRING
+    raiden.stats = ([], ["wire-chunk-debug#c0"], [])
+    assert receiver.poll() == KVPoll.SUCCESS
+
+    receiver.commit(lambda _: None)
+    assert committed == [expected]
+
+
 def test_raiden_chunk_receiver_failure_waits_for_all_started_children():
     raiden = _FakeRaiden()
     bootstrap = _FakeBootstrap()
@@ -427,7 +629,7 @@ def test_raiden_chunk_receiver_failure_waits_for_all_started_children():
             num_chunks=2,
         ),
     ]
-    bootstrap.transfer_info = _chunk_bundle("wire-chunk-fail", records)
+    bootstrap.transfer_info = _chunk_bundle("wire-chunk-fail", records, expected_total_pages=2)
     manager = _chunk_manager(raiden, bootstrap)
     receiver = manager.create_receiver("req-chunk-fail")
     receiver.init(
@@ -441,6 +643,7 @@ def test_raiden_chunk_receiver_failure_waits_for_all_started_children():
             decode_dp_rank=0,
             initial_chunks={index: record for index, record in enumerate(records)},
             known_num_chunks=2,
+            expected_total_pages=2,
         )
     )
     assert receiver.poll() == KVPoll.TRANSFERRING
@@ -476,7 +679,7 @@ def test_raiden_chunk_receiver_rejects_overlapping_page_ranges():
             num_chunks=2,
         ),
     ]
-    bootstrap.transfer_info = _chunk_bundle("wire-overlap", records)
+    bootstrap.transfer_info = _chunk_bundle("wire-overlap", records, expected_total_pages=3)
     manager = _chunk_manager(raiden, bootstrap)
     receiver = manager.create_receiver("req-overlap")
     receiver.init(
@@ -490,6 +693,7 @@ def test_raiden_chunk_receiver_rejects_overlapping_page_ranges():
             decode_dp_rank=0,
             initial_chunks={index: record for index, record in enumerate(records)},
             known_num_chunks=2,
+            expected_total_pages=3,
         )
     )
 
@@ -511,7 +715,7 @@ def test_raiden_chunk_receiver_limits_each_parent_to_two_active_pulls():
             num_chunks=3,
         ),
     ]
-    bootstrap.transfer_info = _chunk_bundle("wire-window", records)
+    bootstrap.transfer_info = _chunk_bundle("wire-window", records, expected_total_pages=3)
     manager = _chunk_manager(raiden, bootstrap)
     receiver = manager.create_receiver("req-window")
     receiver.init(
@@ -525,6 +729,7 @@ def test_raiden_chunk_receiver_limits_each_parent_to_two_active_pulls():
             decode_dp_rank=0,
             initial_chunks={index: record for index, record in enumerate(records)},
             known_num_chunks=3,
+            expected_total_pages=3,
         )
     )
 
@@ -558,7 +763,7 @@ def test_raiden_chunk_receiver_rejects_gaps_before_decode_commit():
             num_chunks=2,
         ),
     ]
-    bootstrap.transfer_info = _chunk_bundle("wire-gap", records)
+    bootstrap.transfer_info = _chunk_bundle("wire-gap", records, expected_total_pages=3)
     manager = _chunk_manager(raiden, bootstrap)
     receiver = manager.create_receiver("req-gap")
     receiver.init(
@@ -572,6 +777,7 @@ def test_raiden_chunk_receiver_rejects_gaps_before_decode_commit():
             decode_dp_rank=0,
             initial_chunks={index: record for index, record in enumerate(records)},
             known_num_chunks=2,
+            expected_total_pages=3,
         )
     )
     assert receiver.poll() == KVPoll.TRANSFERRING
@@ -790,7 +996,7 @@ def test_raiden_chunk_decode_admission_starts_from_chunk_zero_metadata():
     raiden = _FakeRaiden()
     bootstrap = _FakeBootstrap()
     first = _chunk_record("wire-admit-chunk", 0, [3], page_offset=0)
-    bootstrap.transfer_info = _chunk_bundle("wire-admit-chunk", [first])
+    bootstrap.transfer_info = _chunk_bundle("wire-admit-chunk", [first], expected_total_pages=2)
     manager = _chunk_manager(raiden, bootstrap)
     context = DecodeTransferContext(
         req_id="req-admit-chunk",
@@ -819,6 +1025,39 @@ def test_raiden_chunk_decode_admission_starts_from_chunk_zero_metadata():
     assert admission.receiver.poll() == KVPoll.TRANSFERRING
     assert raiden.started[-1][0][0] == "wire-admit-chunk#c0"
     assert raiden.started[-1][0][3:] == ([3], [9])
+
+
+def test_raiden_chunk_decode_admission_rejects_total_page_mismatch():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    first = _chunk_record("wire-total-mismatch", 0, [3], page_offset=0)
+    bootstrap.transfer_info = _chunk_bundle("wire-total-mismatch", [first], expected_total_pages=3)
+    manager = _chunk_manager(raiden, bootstrap)
+    context = DecodeTransferContext(
+        req_id="req-total-mismatch",
+        transfer_id="wire-total-mismatch",
+        bootstrap_room=86,
+        decode_dp_rank=0,
+        prefill_dp_rank=0,
+        peer_info={
+            "host": "10.0.0.1",
+            "transport_metadata": {
+                "engine": "raiden",
+                "dp_rank": 0,
+                "dp_size": 1,
+                "endpoints": raiden.endpoints,
+            },
+        },
+        kv_indices=[18, 19, 20, 21],
+        page_size=2,
+        prompt_tokens=4,
+        spec_factory=lambda: None,
+    )
+
+    with pytest.raises(ValueError, match="total block count mismatch"):
+        manager.try_start_decode(context)
+
+    assert raiden.started == []
 
 
 @pytest.mark.parametrize(
@@ -1033,6 +1272,17 @@ def test_raiden_page_mapping_requires_aligned_contiguous_slots():
         slots_to_page_ids([9, 10], 2, 2)
     with pytest.raises(ValueError, match="not contiguous"):
         slots_to_page_ids([8, 10], 2, 2)
+
+
+def test_raiden_chunk_transfer_id_round_trip_and_validation():
+    transfer_id = chunk_transfer_id("wire-request", 7)
+
+    assert transfer_id == "wire-request#c7"
+    assert parse_chunk_transfer_id(transfer_id) == ("wire-request", 7)
+    with pytest.raises(ValueError, match="non-negative"):
+        chunk_transfer_id("wire-request", -1)
+    with pytest.raises(ValueError, match="invalid chunk transfer_id"):
+        parse_chunk_transfer_id("wire-request")
 
 
 def test_register_read_false_does_not_publish_stale_metadata():

--- a/test/srt/disaggregation/test_pd_raiden.py
+++ b/test/srt/disaggregation/test_pd_raiden.py
@@ -20,6 +20,7 @@ from sgl_jax.raiden import raiden_requested
 from sgl_jax.srt.disaggregation.base.kv_manager import KVPoll
 from sgl_jax.srt.disaggregation.base.transfer import (
     AdmissionState,
+    DecodeMetadataContext,
     DecodeTransferContext,
     chunk_transfer_id,
     parse_chunk_transfer_id,
@@ -66,6 +67,27 @@ class _FakeBootstrap:
     def get_transfer_info(self, _room: int, **_kwargs):
         self.get_calls += 1
         return self.transfer_info
+
+
+def _prepare_decode_metadata(manager, context, timeout=1.0):
+    metadata_context = DecodeMetadataContext(
+        req_id=context.req_id,
+        transfer_id=context.transfer_id,
+        bootstrap_room=context.bootstrap_room,
+        prefill_dp_rank=context.prefill_dp_rank,
+        peer_info=context.peer_info,
+    )
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if manager.poll_decode_metadata(metadata_context):
+            return
+        time.sleep(0.001)
+    raise AssertionError("decode metadata did not become ready")
+
+
+def _start_decode(manager, context):
+    _prepare_decode_metadata(manager, context)
+    return manager.try_start_decode(context)
 
 
 class _FakeRaiden:
@@ -520,6 +542,134 @@ def test_raiden_chunk_metadata_lookup_never_blocks_receiver_poll():
         assert bootstrap.lookup_started.wait(timeout=1.0)
     finally:
         bootstrap.release_lookup.set()
+
+
+def test_raiden_decode_admission_metadata_lookup_never_blocks_scheduler():
+    class _BlockingBootstrap(_FakeBootstrap):
+        def __init__(self):
+            super().__init__()
+            self.lookup_started = threading.Event()
+            self.release_lookup = threading.Event()
+
+        def get_transfer_info(self, _room: int, **_kwargs):
+            self.get_calls += 1
+            self.lookup_started.set()
+            assert self.release_lookup.wait(timeout=1.0)
+            return self.transfer_info
+
+    bootstrap = _BlockingBootstrap()
+    bootstrap.transfer_info = {
+        "transfer_id": "wire-admission-nonblocking",
+        "transport_metadata": {"remote_block_ids": [1]},
+    }
+    manager = _manager(_FakeRaiden(), bootstrap)
+    context = DecodeMetadataContext(
+        req_id="req-admission-nonblocking",
+        transfer_id="wire-admission-nonblocking",
+        bootstrap_room=92,
+        prefill_dp_rank=0,
+        peer_info={},
+    )
+
+    try:
+        started_at = time.monotonic()
+        ready = manager.poll_decode_metadata(context)
+        elapsed = time.monotonic() - started_at
+
+        assert not ready
+        assert elapsed < 0.1
+        assert bootstrap.lookup_started.wait(timeout=1.0)
+    finally:
+        bootstrap.release_lookup.set()
+
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        if manager.poll_decode_metadata(context):
+            break
+        time.sleep(0.001)
+    else:
+        raise AssertionError("admission metadata lookup did not finish")
+    assert bootstrap.get_calls == 1
+
+
+@pytest.mark.parametrize("raise_lookup", [False, True])
+def test_raiden_decode_admission_metadata_failures_back_off(raise_lookup):
+    class _RetryBootstrap(_FakeBootstrap):
+        def get_transfer_info(self, _room: int, **_kwargs):
+            self.get_calls += 1
+            if raise_lookup:
+                raise RuntimeError("bootstrap unavailable")
+            return None
+
+    bootstrap = _RetryBootstrap()
+    manager = _manager(_FakeRaiden(), bootstrap)
+    context = DecodeMetadataContext(
+        req_id="req-admission-backoff",
+        transfer_id="wire-admission-backoff",
+        bootstrap_room=93,
+        prefill_dp_rank=0,
+        peer_info={},
+    )
+    key = manager._decode_metadata_key(93, 0, 0, "wire-admission-backoff")
+
+    assert not manager.poll_decode_metadata(context)
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        manager.poll_decode_metadata(context)
+        with manager._decode_metadata_lock:
+            lookup = manager._decode_metadata[key]
+            completed = lookup.future is None and lookup.next_poll_at > time.monotonic()
+        if completed:
+            break
+        time.sleep(0.001)
+    else:
+        raise AssertionError("failed metadata lookup was not processed")
+
+    for _ in range(10):
+        assert not manager.poll_decode_metadata(context)
+    assert bootstrap.get_calls == 1
+    assert lookup.poll_interval >= 2 * 0.01
+
+
+@pytest.mark.parametrize("raise_lookup", [False, True])
+def test_raiden_chunk_receiver_metadata_failures_back_off(raise_lookup):
+    class _RetryBootstrap(_FakeBootstrap):
+        def get_transfer_info(self, _room: int, **_kwargs):
+            self.get_calls += 1
+            if raise_lookup:
+                raise RuntimeError("bootstrap unavailable")
+            return None
+
+    bootstrap = _RetryBootstrap()
+    first = _chunk_record("wire-receiver-backoff", 0, [1], page_offset=0)
+    receiver = _chunk_manager(_FakeRaiden(), bootstrap).create_receiver("req-receiver-backoff")
+    receiver.init(
+        RaidenChunkedMetadata(
+            base_uuid="wire-receiver-backoff",
+            remote_endpoint="10.0.0.1:7777",
+            local_block_ids=(9, 10),
+            bootstrap_room=94,
+            jax_process_index=0,
+            prefill_dp_rank=0,
+            decode_dp_rank=0,
+            initial_chunks={0: first},
+            expected_total_pages=2,
+        )
+    )
+
+    assert receiver.poll() == KVPoll.TRANSFERRING
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        receiver.poll()
+        if receiver._metadata_future is None and receiver._metadata_poll_interval > 0.01:
+            break
+        time.sleep(0.001)
+    else:
+        raise AssertionError("failed receiver metadata lookup was not processed")
+
+    for _ in range(10):
+        assert receiver.poll() == KVPoll.TRANSFERRING
+    assert bootstrap.get_calls == 1
 
 
 def test_raiden_chunk_receiver_skips_lookup_when_all_metadata_is_known():
@@ -979,7 +1129,7 @@ def test_raiden_manager_owns_decode_admission_and_endpoint_mapping():
         spec_factory=lambda: None,
     )
 
-    admission = manager.try_start_decode(context)
+    admission = _start_decode(manager, context)
 
     assert admission.state == AdmissionState.ADMITTED
     assert admission.receiver is not None
@@ -1019,7 +1169,7 @@ def test_raiden_chunk_decode_admission_starts_from_chunk_zero_metadata():
         spec_factory=lambda: None,
     )
 
-    admission = manager.try_start_decode(context)
+    admission = _start_decode(manager, context)
 
     assert admission.state == AdmissionState.ADMITTED
     assert admission.receiver.poll() == KVPoll.TRANSFERRING
@@ -1054,6 +1204,7 @@ def test_raiden_chunk_decode_admission_rejects_total_page_mismatch():
         spec_factory=lambda: None,
     )
 
+    _prepare_decode_metadata(manager, context)
     with pytest.raises(ValueError, match="total block count mismatch"):
         manager.try_start_decode(context)
 
@@ -1075,7 +1226,8 @@ def test_raiden_manager_routes_all_dp4_prefill_decode_pairs(prefill_dp_rank, dec
     manager = _manager(raiden, bootstrap)
     prefill_endpoints = raiden.endpoints_by_dp_rank[prefill_dp_rank]
 
-    admission = manager.try_start_decode(
+    admission = _start_decode(
+        manager,
         DecodeTransferContext(
             req_id="req-cross",
             transfer_id="wire-cross",
@@ -1096,7 +1248,7 @@ def test_raiden_manager_routes_all_dp4_prefill_decode_pairs(prefill_dp_rank, dec
             page_size=2,
             prompt_tokens=2,
             spec_factory=lambda: None,
-        )
+        ),
     )
 
     assert admission.state == AdmissionState.ADMITTED
@@ -1118,24 +1270,24 @@ def test_raiden_manager_rejects_peer_without_endpoint_descriptors():
     }
     manager = _manager(raiden, bootstrap)
 
+    context = DecodeTransferContext(
+        req_id="req-legacy",
+        transfer_id="wire-legacy",
+        bootstrap_room=47,
+        decode_dp_rank=0,
+        prefill_dp_rank=0,
+        peer_info={
+            "host": "10.0.0.1",
+            "local_control_port": 7777,
+        },
+        kv_indices=[18, 19],
+        page_size=2,
+        prompt_tokens=2,
+        spec_factory=lambda: None,
+    )
+    _prepare_decode_metadata(manager, context)
     with pytest.raises(ValueError, match="endpoint descriptors"):
-        manager.try_start_decode(
-            DecodeTransferContext(
-                req_id="req-legacy",
-                transfer_id="wire-legacy",
-                bootstrap_room=47,
-                decode_dp_rank=0,
-                prefill_dp_rank=0,
-                peer_info={
-                    "host": "10.0.0.1",
-                    "local_control_port": 7777,
-                },
-                kv_indices=[18, 19],
-                page_size=2,
-                prompt_tokens=2,
-                spec_factory=lambda: None,
-            )
-        )
+        manager.try_start_decode(context)
 
 
 def test_raiden_preserves_published_shard_endpoints():
@@ -1155,7 +1307,8 @@ def test_raiden_preserves_published_shard_endpoints():
         {"endpoint": "10.0.0.1:7013", "shards": [1, 3]},
     ]
 
-    admission = manager.try_start_decode(
+    admission = _start_decode(
+        manager,
         DecodeTransferContext(
             req_id="req-shards",
             transfer_id="wire-shards",
@@ -1170,7 +1323,7 @@ def test_raiden_preserves_published_shard_endpoints():
             page_size=2,
             prompt_tokens=2,
             spec_factory=lambda: None,
-        )
+        ),
     )
 
     assert admission.receiver is not None
@@ -1194,7 +1347,8 @@ def test_raiden_manager_preserves_each_published_endpoint_port_and_shards():
         "transport_metadata": {"remote_block_ids": [1]},
     }
     manager = _manager(raiden, bootstrap)
-    admission = manager.try_start_decode(
+    admission = _start_decode(
+        manager,
         DecodeTransferContext(
             req_id="req-endpoints",
             transfer_id="wire-endpoints",
@@ -1214,7 +1368,7 @@ def test_raiden_manager_preserves_each_published_endpoint_port_and_shards():
             page_size=2,
             prompt_tokens=2,
             spec_factory=lambda: None,
-        )
+        ),
     )
     assert admission.receiver.poll() == KVPoll.TRANSFERRING
     remote = raiden.started[-1][0][2]

--- a/test/srt/disaggregation/test_pd_raiden.py
+++ b/test/srt/disaggregation/test_pd_raiden.py
@@ -21,7 +21,10 @@ from sgl_jax.srt.disaggregation.base.transfer import (
     DecodeTransferContext,
     slots_to_page_ids,
 )
-from sgl_jax.srt.disaggregation.common.capacity import per_rank_inflight_limit
+from sgl_jax.srt.disaggregation.common.capacity import (
+    CHUNK_TRANSFER_WINDOW,
+    per_rank_inflight_limit,
+)
 from sgl_jax.srt.disaggregation.factory import (
     _raiden_transfer_pool_shape,
     _tree_cache_supports_swa,
@@ -208,6 +211,67 @@ def test_raiden_chunk_sender_waits_for_final_descriptor_and_every_child_ack():
     raiden.stats = (["wire-chunk-send#c0", "wire-chunk-send#c1"], [], [])
     assert sender.poll() == KVPoll.SUCCESS
     assert bootstrap.popped == [(81, {"jax_process_index": 0, "prefill_dp_rank": 0})]
+
+
+def test_raiden_chunk_sender_limits_active_children_to_transfer_window():
+    raiden = _FakeRaiden()
+    bootstrap = _FakeBootstrap()
+    manager = _chunk_manager(raiden, bootstrap)
+    sender = manager.create_sender("req-chunk-window")
+    sender.init(None, transfer_id="wire-chunk-window")
+
+    for chunk_index in range(CHUNK_TRANSFER_WINDOW + 1):
+        sender.send_chunk(
+            chunk_index,
+            [chunk_index + 1],
+            bootstrap_room=83,
+            chunk_page_offset=chunk_index,
+            is_final=chunk_index == CHUNK_TRANSFER_WINDOW,
+        )
+
+    assert [call[0][0] for call in raiden.registered] == [
+        f"wire-chunk-window#c{index}" for index in range(CHUNK_TRANSFER_WINDOW)
+    ]
+    assert len(bootstrap.registered) == CHUNK_TRANSFER_WINDOW
+
+    raiden.stats = (["wire-chunk-window#c0"], [], [])
+    assert sender.poll() == KVPoll.TRANSFERRING
+    assert [call[0][0] for call in raiden.registered] == [
+        f"wire-chunk-window#c{index}" for index in range(CHUNK_TRANSFER_WINDOW + 1)
+    ]
+
+    raiden.stats = (
+        [f"wire-chunk-window#c{index}" for index in range(CHUNK_TRANSFER_WINDOW + 1)],
+        [],
+        [],
+    )
+    assert sender.poll() == KVPoll.SUCCESS
+
+
+def test_raiden_chunk_sender_drops_queued_children_after_abort():
+    raiden = _FakeRaiden()
+    manager = _chunk_manager(raiden, _FakeBootstrap())
+    sender = manager.create_sender("req-chunk-window-abort")
+    sender.init(None, transfer_id="wire-chunk-window-abort")
+
+    for chunk_index in range(CHUNK_TRANSFER_WINDOW + 1):
+        sender.send_chunk(
+            chunk_index,
+            [chunk_index + 1],
+            bootstrap_room=84,
+            chunk_page_offset=chunk_index,
+            is_final=chunk_index == CHUNK_TRANSFER_WINDOW,
+        )
+
+    sender.abort()
+    raiden.stats = (
+        [f"wire-chunk-window-abort#c{index}" for index in range(CHUNK_TRANSFER_WINDOW)],
+        [],
+        [],
+    )
+
+    assert sender.poll() == KVPoll.FAILED
+    assert len(raiden.registered) == CHUNK_TRANSFER_WINDOW
 
 
 def test_raiden_chunk_sender_abort_waits_for_started_children():


### PR DESCRIPTION
## Motivation

PD disaggregation currently transfers a request's KV cache only after chunked prefill has completed, leaving the full transfer on the TTFT critical path. The continuation state can also lose the committed prefix between chunks and recompute prompt tokens, as reported in #1496.

This PR overlaps each completed prefill chunk's KV transfer with the next chunk's forward pass while preserving strict ownership and failure semantics.

Fixes #1496.

## Modifications

- Add an opt-in `--disaggregation-enable-chunk-prefill-transfer` path for Raiden and ChunkCache.
- Publish DP-scoped per-chunk descriptors through bootstrap protocol v5 and receive each chunk into its exact destination page range.
- Allocate Decode KV once, validate complete non-overlapping coverage, and enqueue Decode only after every child transfer succeeds.
- Bound concurrent child transfers and retain KV ownership until Raiden reaches an engine-terminal state.
- Handle cancellation, retraction, retry isolation, and partial-transfer failure without exposing partial KV or leaking request/KV slots.
- Preserve committed-prefix state across chunked-prefill continuation to avoid recomputation.
- Keep Raiden metadata discovery off the Decode scheduler thread, with bounded retry backoff and no Decode KV allocation before metadata is ready.

The request-level Raiden path remains the default. Mixed protocol-v4/v5 P/D deployments are rejected rather than silently downgraded.

## Accuracy Tests

- Deterministic baseline/chunk-transfer outputs matched across the v6e-1 long-prefill matrix and all Prefill/Decode rank pairs at v6e-4 DP=1/2/4.
- A two-host v7e-8 lifecycle run at `4067bbaf2` covered cancellation, retraction, post-failure sentinel requests, and final Prefill/Decode request-pool usage of zero.
- Review-fix head `303724310`: 217 passed, 2 skipped across the existing PD ownership, Prefill, Decode, and Raiden suites.
- New regression coverage verifies terminal read failures retire every chunk owner before resource release, admission metadata lookup never blocks the scheduler, empty/error lookups back off, pending metadata allocates no Decode KV, and paused P/D transfers drain to terminal.
- No CI workflow or test-matrix entry was added.

## Benchmarking and Profiling

On two v6e-1 hosts with Qwen3-0.6B, Raiden, DP1/TP1, and 216/216 successful measured requests, TTFT changed as follows:

- 2K chunks: -42.95% at 16K input, -32.69% at 32K, and -19.14% at 64K.
- 4K chunks: -34.99% at 16K input, -25.23% at 32K, and -15.13% at 64K.
- Absolute TTFT savings increased from 0.52-0.55s at 16K to 1.71-1.79s at 64K; first-to-second-token ITL was unchanged within noise.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
