### PR TITLE
fix(scheduler): reserve SWA cache headroom

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -801,6 +801,20 @@ def _build_recurrent_track_entries(
     )
 
 
+def swa_eviction_interval(sliding_window_size: int, page_size: int) -> int:
+    """Return the page-aligned decode interval between SWA evictions."""
+    multiplier = float(os.environ.get("SGL_JAX_SWA_EVICTION_INTERVAL_MULTIPLIER", "1.0"))
+    interval = max(page_size, int(sliding_window_size * multiplier))
+    return (interval // page_size) * page_size
+
+
+def swa_eviction_peak_tokens(sliding_window_size: int, page_size: int) -> int:
+    """Return the maximum live SWA tokens held between decode evictions."""
+    return (
+        sliding_window_size + swa_eviction_interval(sliding_window_size, page_size) + 2 * page_size
+    )
+
+
 @dataclasses.dataclass
 class ScheduleBatch:
     """Store all information of a batch on the scheduler.
@@ -1573,9 +1587,7 @@ class ScheduleBatch:
         )
 
         if self.forward_mode is not None and self.forward_mode.is_decode():
-            multiplier = float(os.environ.get("SGL_JAX_SWA_EVICTION_INTERVAL_MULTIPLIER", "1.0"))
-            evict_interval = max(page_size, int(sliding_window_size * multiplier))
-            evict_interval = (evict_interval // page_size) * page_size
+            evict_interval = swa_eviction_interval(sliding_window_size, page_size)
             for dp_rank, info in enumerate(self.reqs_info):
                 if not info.reqs:
                     continue

--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -9,7 +9,11 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from sgl_jax.srt.managers.schedule_batch import Req, ScheduleBatch
+from sgl_jax.srt.managers.schedule_batch import (
+    Req,
+    ScheduleBatch,
+    swa_eviction_peak_tokens,
+)
 from sgl_jax.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
 from sgl_jax.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
@@ -328,6 +332,11 @@ class PrefillAdder:
 
         self.is_hybrid = isinstance(self.token_to_kv_pool_allocator, SWATokenToKVPoolAllocator)
         self.rem_swa_token_offset = [0] * dp_size
+        if self.is_hybrid and running_batch is not None:
+            for dp_rank, info in enumerate(running_batch.reqs_info):
+                self.rem_swa_token_offset[dp_rank] = sum(
+                    self._swa_headroom_for_running_req(req) for req in (info.reqs or [])
+                )
 
     def rem_total_tokens_for_dp(self, dp_rank: int) -> int:
         """Calculate remaining total tokens for a specific DP rank.
@@ -374,17 +383,27 @@ class PrefillAdder:
     def _swa_budget_for_req(self, extend_input_len: int, dp_rank: int) -> int:
         """SWA pool budget per request.
 
-        With chunked prefill + overlap, peak SWA occupancy per request is
-        one chunk plus the sliding window. Floor at sliding_window_size
-        to reserve room for decode phase.
+        Eviction protects one extra page, rounds its boundary down, and the
+        live allocation up. The shared peak formula includes both page margins
+        plus the allocations made between eviction ticks.
         """
         rem_chunk = (
             self.rem_chunk_tokens_list[dp_rank] if self.rem_chunk_tokens_list is not None else None
         )
         alloc = min(extend_input_len, rem_chunk) if rem_chunk is not None else extend_input_len
-        return (
-            self.ceil_paged_tokens(max(alloc, self.tree_cache.sliding_window_size)) + self.page_size
+        return self.ceil_paged_tokens(max(alloc, self._swa_decode_peak_tokens()))
+
+    def _swa_decode_peak_tokens(self) -> int:
+        return self.ceil_paged_tokens(
+            swa_eviction_peak_tokens(self.tree_cache.sliding_window_size, self.page_size)
         )
+
+    def _swa_headroom_for_running_req(self, req: Req) -> int:
+        live_tokens = max(
+            0,
+            self.ceil_paged_tokens(req.kv_allocated_len) - req.swa_evicted_seqlen,
+        )
+        return max(0, self._swa_decode_peak_tokens() - live_tokens)
 
     @property
     def rem_total_tokens(self):

--- a/python/sgl_jax/test/test_swa_schedule_budget.py
+++ b/python/sgl_jax/test/test_swa_schedule_budget.py
@@ -1,0 +1,79 @@
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sgl_jax.srt.managers.schedule_batch import (
+    swa_eviction_interval,
+    swa_eviction_peak_tokens,
+)
+from sgl_jax.srt.managers.schedule_policy import PrefillAdder
+from sgl_jax.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
+
+
+class _DummySWAAllocator(SWATokenToKVPoolAllocator):
+    def __init__(self):
+        pass
+
+
+class _DummySWATreeCache:
+    def __init__(self, sliding_window_size: int):
+        self.sliding_window_size = sliding_window_size
+
+
+def _running_req(kv_allocated_len: int, swa_evicted_seqlen: int):
+    return SimpleNamespace(
+        kv_allocated_len=kv_allocated_len,
+        swa_evicted_seqlen=swa_evicted_seqlen,
+        sampling_params=SimpleNamespace(max_new_tokens=1024),
+        output_ids=[],
+    )
+
+
+class TestSWAScheduleBudget(unittest.TestCase):
+    def test_eviction_peak_includes_interval_and_page_margins(self):
+        with patch.dict(
+            os.environ,
+            {"SGL_JAX_SWA_EVICTION_INTERVAL_MULTIPLIER": "0.5"},
+        ):
+            self.assertEqual(swa_eviction_interval(100, 16), 48)
+            self.assertEqual(swa_eviction_peak_tokens(100, 16), 180)
+
+    def test_running_requests_reserve_remaining_decode_headroom_per_dp(self):
+        running_batch = SimpleNamespace(
+            reqs_info=[
+                SimpleNamespace(
+                    reqs=[
+                        _running_req(kv_allocated_len=160, swa_evicted_seqlen=32),
+                        _running_req(kv_allocated_len=300, swa_evicted_seqlen=32),
+                    ]
+                ),
+                SimpleNamespace(reqs=[_running_req(kv_allocated_len=95, swa_evicted_seqlen=0)]),
+            ]
+        )
+
+        with patch.dict(
+            os.environ,
+            {"SGL_JAX_SWA_EVICTION_INTERVAL_MULTIPLIER": "1.0"},
+        ):
+            adder = PrefillAdder(
+                page_size=16,
+                tree_cache=_DummySWATreeCache(sliding_window_size=100),
+                token_to_kv_pool_allocator=_DummySWAAllocator(),
+                running_batch=running_batch,
+                new_token_ratio=1.0,
+                rem_input_tokens=4096,
+                rem_chunk_tokens=64,
+                dp_size=2,
+            )
+
+            self.assertEqual(adder._swa_budget_for_req(4096, dp_rank=0), 240)
+
+        # Peak occupancy is ceil_page(100 + 96 + 2 * 16) = 240.
+        # DP0 has 128 live tokens in one request and >=240 in the other;
+        # DP1 has 96 live tokens.
+        self.assertEqual(adder.rem_swa_token_offset, [112, 144])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Hybrid sliding-window attention models use separate full-attention and SWA KV-cache pools. The current admission budget accounts for the sliding window but not for allocations accumulated between periodic SWA evictions, the two page-alignment margins, or the remaining decode headroom of requests already running on each DP rank.

As a result, the scheduler can admit more requests than the SWA pool can sustain. Decode then exhausts the SWA pool and retracts an otherwise healthy request even though the full-attention pool budget is valid.

## Modifications

- Add shared helpers for the page-aligned SWA eviction interval and peak live-token occupancy.
- Use the same eviction interval calculation in both decode eviction and admission budgeting.
- Reserve `sliding_window + eviction_interval + 2 * page_size` peak occupancy for newly admitted requests.
- Subtract the remaining SWA decode headroom of already-running requests independently for each DP rank.
- Add focused tests for interval/page-margin accounting and per-DP running-request reservations.

## Accuracy Tests

This change does not modify model weights, kernels, or model-forward numerics.

A model-level A/B reproduction was run with on a TPU v6e-4. It used a two-layer dummy Gemma2 hybrid model (one sliding-attention layer and one full-attention layer), a 64-token sliding window, 16-token pages, and two concurrent 8-token prompts generating 240 tokens each.

| Revision | HTTP status | KV-cache retraction events | Full/SWA pool tokens |
| --- | ---: | ---: | ---: |
| `main` (`32c7a4bb4`) | 200 | 1 | 272 / 224 |
| This change (`64945a53e`) | 200 | 0 | 272 / 224 |

The SWA-only commit removes the avoidable retraction without changing either cache-pool size.

## Benchmarking and Profiling

Not applicable. This is an admission-budget correctness fix; no kernels or model-forward operations are changed.

## Test Plan

```bash
python -m pytest -q \
  python/sgl_jax/test/test_swa_schedule_budget.py \
  python/sgl_jax/test/test_mixed_chunk_dp.py \
  python/sgl_jax/test/mem_cache/test_swa_allocator.py \
  python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
```

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] Documentation is not required for this internal scheduler correction.
