### PR TITLE
feat(fused-moe-v2): fixed-K rotating gather banks + tuner pruning fixes

### DIFF
--- a/python/sgl_jax/srt/kernels/fused_moe/v2/bench_v2.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/bench_v2.py
@@ -13,9 +13,9 @@ Env vars:
   BENCH_FP8     — 1 to enable fp8 weights
   BENCH_QBK     — quant_block_k for fp8 (default: 128)
   BENCH_DIRECT_SCALED_DOT — 1 to use direct-scaled-dot for both FFN1/FFN2
-  BENCH_INTERLEAVE_BT — comma-separated 0/1 interleave BT gather banking
+  BENCH_GATHER_BANKS — fixed rotating gather banks K (default: 2); gather-compute
+                       overlap is unconditional for num_bt > 1
   BENCH_VARIANT — label written to BENCH_JSONL for ablation tracking
-  BENCH_KERNEL_ABLATION — static in-kernel stage cut (default: full)
   BENCH_TUNE    — 1 to auto-generate bt/bf candidates
   BENCH_MAX_CONFIGS — maximum auto-tune candidates per token shape (default: 48)
   BENCH_TUNE_VMEM_HEADROOM — VMEM budget ratio used by the tuner (default: 0.95)
@@ -256,6 +256,7 @@ if os.environ.get("BENCH_SINGLE_HOST", "0") != "1":
 log(f"initialized: {jax.device_count()} devices, {jax.process_count()} procs")
 
 from kernel import FusedMoEBlockConfig, fused_ep_moe_v2, ref_moe
+from tune_prune import prune_candidates
 
 P = jax.sharding.PartitionSpec
 num_devices = jax.device_count()
@@ -290,7 +291,6 @@ tune_max_configs = int(os.environ.get("BENCH_MAX_CONFIGS", "48"))
 tune_vmem_headroom = float(os.environ.get("BENCH_TUNE_VMEM_HEADROOM", "0.95"))
 metrics_jsonl = os.environ.get("BENCH_JSONL")
 benchmark_variant = os.environ.get("BENCH_VARIANT", "fused_moe_v2_tune")
-kernel_ablation_mode = os.environ.get("BENCH_KERNEL_ABLATION", "full")
 _explicit_block_shape = any(
     os.environ.get(k) is not None for k in ("BENCH_BT", "BENCH_BF", "BENCH_BTC", "BENCH_BTS")
 )
@@ -305,11 +305,9 @@ use_split = os.environ.get("BENCH_SPLIT", "0") == "1"
 direct_scaled_dot = os.environ.get("BENCH_DIRECT_SCALED_DOT", "0") == "1"
 enable_act_quant = os.environ.get("BENCH_ACT_QUANT", "0") == "1"
 enable_bt_scatter_overlap = os.environ.get("BENCH_BT_SCATTER_OVERLAP", "1") == "1"
+_gb = os.environ.get("BENCH_GATHER_BANKS")
+fixed_gather_banks = int(_gb) if _gb else 2
 cross_expert_prefetch_modes = parse_csv_str("BENCH_CROSS_EXPERT_PREFETCH", ["full"])
-interleave_bt_modes = parse_csv_bool(
-    "BENCH_INTERLEAVE_BT",
-    [True],
-)
 valid_cross_expert_prefetch_modes = {"none", "full", "w13"}
 invalid_modes = [
     mode for mode in cross_expert_prefetch_modes if mode not in valid_cross_expert_prefetch_modes
@@ -319,25 +317,6 @@ if invalid_modes:
         f"Unsupported BENCH_CROSS_EXPERT_PREFETCH values {invalid_modes}; "
         "expected one of none, full, or w13."
     )
-valid_kernel_ablation_modes = {
-    "full",
-    "no_shared",
-    "no_weight_hbm",
-    "routed_no_gather",
-    "ffn_io_store_only",
-    "ffn_io_only",
-    "token_io_only",
-    "scatter_only",
-    "metadata_prequant",
-    "metadata_only",
-}
-if kernel_ablation_mode not in valid_kernel_ablation_modes:
-    raise ValueError(
-        f"Unsupported BENCH_KERNEL_ABLATION={kernel_ablation_mode!r}; "
-        f"expected one of {sorted(valid_kernel_ablation_modes)}."
-    )
-if check_correctness and kernel_ablation_mode != "full":
-    raise ValueError("BENCH_CHECK=1 is only valid with BENCH_KERNEL_ABLATION=full.")
 valid_routing_modes = {"random", "deterministic", "hot_expert"}
 if routing_mode not in valid_routing_modes:
     raise ValueError(
@@ -355,10 +334,6 @@ if direct_scaled_dot:
 if enable_bt_scatter_overlap:
     log("bt_scatter_overlap=True (next-BT scatter HBM bank overlap)")
 log(f"cross_expert_prefetch={cross_expert_prefetch_modes}")
-if kernel_ablation_mode != "full":
-    log(f"kernel_ablation_mode={kernel_ablation_mode} (benchmark-only, output is invalid)")
-if interleave_bt_modes != [True]:
-    log(f"interleave_bt sweep: {interleave_bt_modes}")
 
 bt_candidates = parse_csv_int("BENCH_BT", [128])
 bf_candidates = parse_csv_int("BENCH_BF", [256])
@@ -430,7 +405,6 @@ def _estimate_vmem_bytes_v2(
     use_fp8=False,
     quant_block_k=128,
     direct_scaled_dot=True,
-    interleave_bt=True,
     enable_bt_scatter_overlap=True,
     verbose=False,
 ):
@@ -444,8 +418,10 @@ def _estimate_vmem_bytes_v2(
     acc_bt = math.gcd(bt, 16)
     num_bt = local_num_tokens // bt if bt > 0 else 1
     use_bt_scatter_bank = enable_bt_scatter_overlap and num_bt > 1
-    use_gather_bank = interleave_bt and num_bt > 1
-    smem_banks = num_bt if use_gather_bank else 2
+    use_gather_bank = num_bt > 1
+    # fixed-K gather banks: metadata/topk use Km=K+1=3 (K=2 payload), so routing
+    # SMEM scales with min(num_bt, 3), not num_bt.
+    smem_banks = min(num_bt, 3) if use_gather_bank else 2
 
     # Gather accumulation: (2, top_k, acc_bt, t_packing, h_per_t)
     b_a2a_g_acc = 2 * top_k * acc_bt * hidden_size * token_bytes
@@ -581,7 +557,6 @@ def generate_tune_candidates(
     use_fp8=False,
     quant_block_k=128,
     direct_scaled_dot=True,
-    interleave_bt=True,
     enable_bt_scatter_overlap=True,
     vmem_budget=64 * 1024 * 1024,
     vmem_headroom=0.95,
@@ -699,7 +674,6 @@ def generate_tune_candidates(
                             use_fp8=use_fp8,
                             quant_block_k=quant_block_k,
                             direct_scaled_dot=direct_scaled_dot,
-                            interleave_bt=interleave_bt,
                             enable_bt_scatter_overlap=enable_bt_scatter_overlap,
                             verbose=verbose and first_verbose,
                         )
@@ -714,68 +688,7 @@ def generate_tune_candidates(
                             continue
                         configs.append(bc)
 
-    if len(configs) <= max_configs:
-        log(f"  tune: {len(configs)} configs (all pass VMEM filter)")
-        return configs
-
-    buckets = {}
-    for cfg in configs:
-        bk = (cfg.bt, cfg.bts or cfg.bt)
-        buckets.setdefault(bk, []).append(cfg)
-    for bk in buckets:
-        # Preserve BF and BTC diversity under the max-config cap. Sorting the
-        # whole bucket by BF first can spend every slot on bf=1024; naively
-        # round-robining BF can then spend every slot on the same btc. Build a
-        # small Latin-style traversal over (BF, BTC), starting near btc=32 but
-        # rotating the starting BTC for each BF.
-        by_pair = {}
-        for cfg in buckets[bk]:
-            by_pair.setdefault((cfg.bf, cfg.btc), []).append(cfg)
-        for pair in by_pair:
-            by_pair[pair].sort(key=lambda c: c.bse, reverse=True)
-        ordered = []
-        bf_keys = sorted({cfg.bf for cfg in buckets[bk]}, reverse=True)
-        btc_keys = sorted(
-            {cfg.btc for cfg in buckets[bk]},
-            key=lambda btc: (abs(math.log2(btc / 32)), -btc),
-        )
-        round_idx = 0
-        while any(by_pair[pair] for pair in by_pair):
-            for bf_idx, bf in enumerate(bf_keys):
-                for offset in range(len(btc_keys)):
-                    btc = btc_keys[(round_idx + bf_idx + offset) % len(btc_keys)]
-                    queue = by_pair.get((bf, btc), [])
-                    if queue:
-                        ordered.append(queue.pop(0))
-                        break
-            round_idx += 1
-        buckets[bk] = ordered
-
-    selected = []
-    selected_keys = set()
-    bucket_keys = sorted(buckets.keys(), reverse=True)
-    while len(selected) < max_configs:
-        made_progress = False
-        for bk in bucket_keys:
-            bucket = buckets[bk]
-            if not bucket:
-                continue
-            cfg = bucket.pop(0)
-            key = (cfg.bt, cfg.bf, cfg.btc, cfg.bts, cfg.bse)
-            if key not in selected_keys:
-                selected_keys.add(key)
-                selected.append(cfg)
-                made_progress = True
-            if len(selected) >= max_configs:
-                break
-        if not made_progress:
-            break
-
-    log(
-        f"  tune: {len(configs)} valid -> {len(selected)} selected "
-        f"(max={max_configs}, {len(bucket_keys)} bt/bts buckets)"
-    )
-    return selected
+    return prune_candidates(configs, max_configs, log=log)
 
 
 if tune_mode:
@@ -988,7 +901,6 @@ for num_tokens in token_candidates:
             use_fp8=use_fp8,
             quant_block_k=quant_block_k,
             direct_scaled_dot=direct_scaled_dot,
-            interleave_bt=interleave_bt_modes[0],
             enable_bt_scatter_overlap=enable_bt_scatter_overlap,
             bse=bse,
             use_shared_expert=use_shared_expert,
@@ -1023,6 +935,11 @@ for num_tokens in token_candidates:
                     use_shared_expert=use_shared_expert,
                     use_grouped_topk=False,
                     enable_act_quant=enable_act_quant,
+                    quant_mode=(
+                        "none"
+                        if not use_fp8
+                        else ("per_channel" if quant_block_k is None else "blockwise")
+                    ),
                 )
             except Exception as e:  # e.g. num_tokens not aligned to ep_size
                 log(f"  tuned lookup skipped ({e}); using defaults")
@@ -1071,7 +988,6 @@ for num_tokens in token_candidates:
         for bc_raw in block_configs_to_try
         for flags in itertools.product(
             cross_expert_prefetch_modes,
-            interleave_bt_modes,
         )
     ]
     seen_resolved_configs = set()
@@ -1079,15 +995,12 @@ for num_tokens in token_candidates:
     for (
         bc,
         xprefetch_mode,
-        interleave_bt,
     ) in configs_to_try:
         bt, bf, btc, bts = bc.bt, bc.bf, bc.btc, bc.bts
         tag = (
             f"bt={bt},bf={bf},btc={btc},bts={bts},bse={bc.bse},"
             f"xprefetch={xprefetch_mode},"
-            f"direct={int(direct_scaled_dot)},"
-            f"ilv_bt={int(interleave_bt)},"
-            f"ablation={kernel_ablation_mode}"
+            f"direct={int(direct_scaled_dot)}"
         )
 
         padded_nt = num_tokens
@@ -1107,19 +1020,16 @@ for num_tokens in token_candidates:
             f"bt={bc_resolved.bt},bf={bc_resolved.bf},"
             f"btc={bc_resolved.btc},bts={bc_resolved.bts},bse={bc_resolved.bse},"
             f"xprefetch={xprefetch_mode},"
-            f"direct={int(direct_scaled_dot)},"
-            f"ilv_bt={int(interleave_bt)},"
-            f"ablation={kernel_ablation_mode}"
+            f"direct={int(direct_scaled_dot)}"
         )
         resolved_key = (
             bc_resolved.bt,
             bc_resolved.bf,
             bc_resolved.btc,
             bc_resolved.bts,
+            bc_resolved.bse,
             xprefetch_mode,
             direct_scaled_dot,
-            interleave_bt,
-            kernel_ablation_mode,
         )
         if resolved_key in seen_resolved_configs:
             log(f"  SKIP duplicate resolved config {tag} -> {tag_resolved}")
@@ -1152,9 +1062,8 @@ for num_tokens in token_candidates:
                 direct_scaled_dot=direct_scaled_dot,
                 enable_act_quant=enable_act_quant,
                 cross_expert_prefetch_mode=xprefetch_mode,
-                interleave_bt=interleave_bt,
+                fixed_gather_banks=fixed_gather_banks,
                 enable_bt_scatter_overlap=enable_bt_scatter_overlap,
-                kernel_ablation_mode=kernel_ablation_mode,
             )
 
         try:
@@ -1192,6 +1101,12 @@ for num_tokens in token_candidates:
             continue
 
 # --- Summary ---
+if not results:
+    raise RuntimeError(
+        "No fused MoE v2 configurations produced valid timings. "
+        "Check the block configs and static kernel flags."
+    )
+
 if results:
     log("")
     log("=== Summary ===")
@@ -1230,7 +1145,6 @@ if results:
                         "shared_expert_intermediate_size": se_inter if use_shared_expert else 0,
                         "enable_act_quant": enable_act_quant,
                         "enable_bt_scatter_overlap": enable_bt_scatter_overlap,
-                        "kernel_ablation_mode": kernel_ablation_mode,
                         "routing_mode": routing_mode,
                         "block_config": tag,
                         "latency_ms": float(avg),
@@ -1299,7 +1213,7 @@ if check_correctness:
             w3_shared_scale=w3_shared_scale,
             direct_scaled_dot=direct_scaled_dot,
             enable_act_quant=enable_act_quant,
-            interleave_bt=interleave_bt_modes[0],
+            fixed_gather_banks=fixed_gather_banks,
             enable_bt_scatter_overlap=enable_bt_scatter_overlap,
         )
         ref_kwargs = {"swiglu_limit": SWIGLU_LIMIT, "shared_swiglu_limit": SHARED_SWIGLU_LIMIT}

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/kernel.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/kernel.py
@@ -340,7 +340,7 @@ def _fused_ep_moe_kernel(
     shared_swiglu_limit: float | None = None,
     enable_bt_scatter_overlap: bool = True,
     cross_expert_prefetch_mode: str = "full",
-    interleave_bt: bool = True,
+    fixed_gather_banks: int | None = 2,
     direct_scaled_dot: bool = False,
     bt: int,
     bf: int,
@@ -349,7 +349,6 @@ def _fused_ep_moe_kernel(
     bse: int,
     quant_block_k: int | None = None,
     enable_act_quant: bool = False,
-    kernel_ablation_mode: str = "full",
 ):
     # ===== Dimension extraction =====
     dp_rank = lax.axis_index(dp_axis_name)
@@ -363,9 +362,16 @@ def _fused_ep_moe_kernel(
     assert local_num_tokens % bt == 0
     num_bt = local_num_tokens // bt
     use_bt_scatter_bank = enable_bt_scatter_overlap and num_bt > 1
-    use_gather_bank = interleave_bt and num_bt > 1
+    use_gather_bank = num_bt > 1
     use_bt_banking = use_bt_scatter_bank or use_gather_bank
-    num_bt_banks = num_bt if use_gather_bank else (2 if use_bt_scatter_bank else 1)
+    use_fixed_gather_banks = (
+        use_gather_bank and fixed_gather_banks is not None and fixed_gather_banks < num_bt
+    )
+    _gather_bank_count = fixed_gather_banks if use_fixed_gather_banks else num_bt
+    num_bt_banks = _gather_bank_count if use_gather_bank else (2 if use_bt_scatter_bank else 1)
+    # Km (metadata/topk depth) read from the metadata SMEM alloc: Km=K+1 on the
+    # fixed path, else == num_bt_banks. Keeps inner/outer bank depths in sync.
+    smem_banks = t2e_routing_x2_smem.shape[0] if use_gather_bank else 2
     if use_bt_banking:
         expert_buffer_count = a2a_s_x2_hbm.shape[1]
         a2a_max_tokens = a2a_s_x2_hbm.shape[2]
@@ -424,29 +430,6 @@ def _fused_ep_moe_kernel(
     n_sg = h_per_t // ffn1_qbk if ffn1_qbk is not None else 1
     n_sg2 = bf // ffn2_qbk if ffn2_qbk is not None else 1
 
-    ablation_stop_after_metadata = kernel_ablation_mode in (
-        "metadata_only",
-        "metadata_prequant",
-    )
-    ablation_skip_prequant = kernel_ablation_mode == "metadata_only"
-    ablation_scatter_only = kernel_ablation_mode == "scatter_only"
-    ablation_token_io_only = kernel_ablation_mode == "token_io_only"
-    ablation_ffn_io_store_only = kernel_ablation_mode == "ffn_io_store_only"
-    ablation_ffn_io_only = kernel_ablation_mode in (
-        "token_io_only",
-        "ffn_io_only",
-        "ffn_io_store_only",
-    )
-    ablation_stop_before_gather = kernel_ablation_mode in (
-        "scatter_only",
-        "token_io_only",
-        "ffn_io_only",
-        "ffn_io_store_only",
-        "routed_no_gather",
-    )
-    ablation_skip_weight_hbm = kernel_ablation_mode == "no_weight_hbm"
-    ablation_skip_shared = kernel_ablation_mode != "full"
-
     enable_cross_expert_prefetch = cross_expert_prefetch_mode != "none"
     full_cross_expert_prefetch = cross_expert_prefetch_mode == "full"
     # This is a legality guard, not a tuning flag. The rolling slot reuse below
@@ -458,11 +441,11 @@ def _fused_ep_moe_kernel(
     # direct and dequant paths.
     can_split_w13_w2_prefetch = can_cross_expert_prefetch and not full_cross_expert_prefetch
     can_full_cross_expert_prefetch = can_cross_expert_prefetch and full_cross_expert_prefetch
-    can_bt_scatter_overlap = use_bt_scatter_bank and not ablation_stop_after_metadata
+    can_bt_scatter_overlap = use_bt_scatter_bank
 
     se_inter_size = 0
     se_total_blocks = 0
-    if w1_shared_hbm is not None and not ablation_skip_shared:
+    if w1_shared_hbm is not None:
         se_inter_size = w2_shared_hbm.shape[0]
         se_total_blocks = cdiv(se_inter_size, bse)
 
@@ -472,12 +455,12 @@ def _fused_ep_moe_kernel(
 
     def a2a_bank_for_bt(bt_id):
         if use_gather_bank:
-            return bt_id
+            return bt_id % num_bt_banks
         return bt_id & jnp.int32(1)
 
     def bt_bank_id(bt_id):
         if use_gather_bank:
-            return bt_id
+            return bt_id % smem_banks
         return bt_id & jnp.int32(1)
 
     def a2a_s_ref(a2a_bank_id, e_sem_id, start, size):
@@ -903,8 +886,6 @@ def _fused_ep_moe_kernel(
 
     @jax.named_scope("w1_load")
     def start_fetch_w1(local_e_id, slot, bf_id, priority=1):
-        if ablation_skip_weight_hbm:
-            return
         for p in range(t_packing):
             pltpu.make_async_copy(
                 src_ref=w1_hbm.at[
@@ -929,8 +910,6 @@ def _fused_ep_moe_kernel(
 
     @jax.named_scope("w1_load_wait")
     def wait_fetch_w1(slot):
-        if ablation_skip_weight_hbm:
-            return
         pltpu.make_async_copy(
             src_ref=b_w1_x2_vmem.at[slot],
             dst_ref=b_w1_x2_vmem.at[slot],
@@ -945,8 +924,6 @@ def _fused_ep_moe_kernel(
 
     @jax.named_scope("w3_load")
     def start_fetch_w3(local_e_id, slot, bf_id, priority=1):
-        if ablation_skip_weight_hbm:
-            return
         for p in range(t_packing):
             pltpu.make_async_copy(
                 src_ref=w3_hbm.at[
@@ -971,8 +948,6 @@ def _fused_ep_moe_kernel(
 
     @jax.named_scope("w3_load_wait")
     def wait_fetch_w3(slot):
-        if ablation_skip_weight_hbm:
-            return
         pltpu.make_async_copy(
             src_ref=b_w3_x2_vmem.at[slot],
             dst_ref=b_w3_x2_vmem.at[slot],
@@ -987,8 +962,6 @@ def _fused_ep_moe_kernel(
 
     @jax.named_scope("w2_load")
     def start_fetch_w2(local_e_id, slot, bf_id, priority=0):
-        if ablation_skip_weight_hbm:
-            return
         for p in range(out_packing):
             pltpu.make_async_copy(
                 src_ref=w2_hbm.at[
@@ -1013,8 +986,6 @@ def _fused_ep_moe_kernel(
 
     @jax.named_scope("w2_load_wait")
     def wait_fetch_w2(slot):
-        if ablation_skip_weight_hbm:
-            return
         pltpu.make_async_copy(
             src_ref=b_w2_x2_vmem.at[slot],
             dst_ref=b_w2_x2_vmem.at[slot],
@@ -1099,8 +1070,6 @@ def _fused_ep_moe_kernel(
 
     @jax.named_scope("dequant_w1")
     def dequant_w1(slot):
-        if ablation_skip_weight_hbm:
-            return
         if w1_scale_hbm is None or direct_scaled_dot:
             return
         for p in range(t_packing):
@@ -1120,8 +1089,6 @@ def _fused_ep_moe_kernel(
 
     @jax.named_scope("dequant_w3")
     def dequant_w3(slot):
-        if ablation_skip_weight_hbm:
-            return
         if w3_scale_hbm is None or direct_scaled_dot:
             return
         for p in range(t_packing):
@@ -1141,8 +1108,6 @@ def _fused_ep_moe_kernel(
 
     @jax.named_scope("dequant_w2")
     def dequant_w2(slot):
-        if ablation_skip_weight_hbm:
-            return
         if w2_scale_hbm is None or direct_scaled_dot:
             return
         for p in range(out_packing):
@@ -1364,6 +1329,45 @@ def _fused_ep_moe_kernel(
                         wait_fetch_w3(slot)
 
                         def gate_up_btc_direct(btc_id, ___):
+                            if per_channel and enable_act_quant:
+                                # per-channel scale is whole-K (p_id-invariant), so
+                                # fold it OUT of the t_packing loop: accumulate raw
+                                # f32 dots across the K-slices, apply per-token ×
+                                # per-channel scale ONCE (saves ~3/4 of FFN1's VPU
+                                # scale-muls). n_sg==1 here. Math-identical
+                                # (Σ d·s == (Σ d)·s); f32 rounding within tol.
+                                g_raw = jnp.zeros((btc, bf), dtype=jnp.float32)
+                                u_raw = jnp.zeros((btc, bf), dtype=jnp.float32)
+                                for p_id in range(t_packing):
+                                    x_slice = b_x_vmem[
+                                        pl.ds(btc_id * btc, btc), p_id, pl.ds(0, ffn1_qbk)
+                                    ]
+                                    w1_tile = b_w1_x2_vmem[
+                                        slot, p_id, pl.ds(0, ffn1_qbk), pl.ds(0, bf)
+                                    ]
+                                    w3_tile = b_w3_x2_vmem[
+                                        slot, p_id, pl.ds(0, ffn1_qbk), pl.ds(0, bf)
+                                    ]
+                                    g_raw = g_raw + jnp.dot(
+                                        x_slice, w1_tile, preferred_element_type=jnp.float32
+                                    )
+                                    u_raw = u_raw + jnp.dot(
+                                        x_slice, w3_tile, preferred_element_type=jnp.float32
+                                    )
+                                x_s = b_x_scale_vmem[pl.ds(btc_id * btc, btc), pl.ds(0, 1)]
+                                s1 = b_w1_scale_x2_vmem[
+                                    slot, 0, pl.ds(0, 1), 0, pl.ds(0, bf)
+                                ].reshape(bf)
+                                s3 = b_w3_scale_x2_vmem[
+                                    slot, 0, pl.ds(0, 1), 0, pl.ds(0, bf)
+                                ].reshape(bf)
+                                b_gate_acc_vmem.at[pl.ds(btc_id * btc, btc), pl.ds(0, bf)][...] = (
+                                    g_raw * (x_s * s1[jnp.newaxis, :])
+                                )
+                                b_up_acc_vmem.at[pl.ds(btc_id * btc, btc), pl.ds(0, bf)][...] = (
+                                    u_raw * (x_s * s3[jnp.newaxis, :])
+                                )
+                                return None
                             gate = jnp.zeros((btc, bf), dtype=jnp.float32)
                             up = jnp.zeros((btc, bf), dtype=jnp.float32)
                             with jax.named_scope("ffn1_gate_up"):
@@ -1649,84 +1653,6 @@ def _fused_ep_moe_kernel(
 
         return lax.cond(has_tokens, _run_active, _run_inactive, None)
 
-    @jax.named_scope("expert_ffn_io_only")
-    def expert_ffn_io_only(bt_sem_id, e_sem_id, local_e_id, a2a_bank_id):
-        """Run routed-token and weight HBM traffic without FFN arithmetic.
-
-        This is a benchmark-only stage cut. It preserves the production bytes
-        (including FP8 scales) and DMA waits, but deliberately uses a simple
-        within-expert double-buffer schedule so the result is an exposed-IO
-        bound rather than a claim that IO and compute are additive. The
-        ffn_io_store_only mode additionally stores one production-sized expert
-        result tile to HBM; its VMEM contents are intentionally unspecified.
-        """
-        e_id = my_id * local_num_experts + local_e_id
-        dyn_sz = expert_sizes_x2_smem[bt_sem_id, 0, e_id]
-        num_bts_tiles = (dyn_sz.astype(jnp.int32) + (bts - 1)) // bts
-
-        def _bts_body(bts_id, _):
-            tile_start = bts_id * bts
-            pltpu.make_async_copy(
-                src_ref=a2a_s_ref(a2a_bank_id, e_sem_id, tile_start, bts),
-                dst_ref=b_x_vmem,
-                sem=x_stage_sem.at[0],
-            ).start(priority=1)
-            pltpu.make_async_copy(
-                src_ref=b_x_vmem,
-                dst_ref=b_x_vmem,
-                sem=x_stage_sem.at[0],
-            ).wait()
-
-            if enable_act_quant:
-                scale_f32 = b_x_vmem.bitcast(jnp.float32)[
-                    pl.ds(0, bts),
-                    0,
-                    h_per_t - 1,
-                ]
-                b_x_scale_vmem.at[pl.ds(0, bts), pl.ds(0, 1)][...] = scale_f32[:, jnp.newaxis]
-                b_x_vmem.at[
-                    pl.ds(0, bts),
-                    pl.ds(0, t_packing),
-                    h_per_t - 1,
-                ][
-                    ...
-                ] = jnp.zeros((bts, t_packing), jnp.float8_e4m3fn)
-
-            if not ablation_token_io_only:
-                start_fetch_w13_w2(local_e_id, 0, 0)
-                if num_bf >= 2:
-                    start_fetch_w13_w2(local_e_id, 1, 1)
-                for bf_id in range(num_bf):
-                    slot = bf_id % 2
-                    wait_fetch_w1(slot)
-                    wait_fetch_w3(slot)
-                    dequant_w1(slot)
-                    dequant_w3(slot)
-                    wait_fetch_w2(slot)
-                    dequant_w2(slot)
-                    next_bf_id = bf_id + 2
-                    if next_bf_id < num_bf:
-                        start_fetch_w13_w2(local_e_id, slot, next_bf_id)
-
-            if ablation_ffn_io_store_only:
-                # Reproduce the production expert-result DMA exactly, without
-                # materializing the result through FFN arithmetic or f32->bf16
-                # writeback. The payload size, destination, semaphore, and wait
-                # are the same as expert_store_dma above.
-                pltpu.make_async_copy(
-                    src_ref=b_y_stage_vmem,
-                    dst_ref=a2a_s_acc_ref(a2a_bank_id, e_sem_id, tile_start, bts),
-                    sem=y_store_sem.at[0],
-                ).start()
-                pltpu.make_async_copy(
-                    src_ref=b_y_stage_vmem,
-                    dst_ref=b_y_stage_vmem,
-                    sem=y_store_sem.at[0],
-                ).wait()
-            return None
-
-        lax.fori_loop(0, num_bts_tiles, _bts_body, None, unroll=False)
-
     # ===== Output accumulation =====
 
     def acc_and_store_output(*, bt_sem_id, out_buf_id, gather_bank_id):
@@ -1798,7 +1724,7 @@ def _fused_ep_moe_kernel(
             target = b_output_x2_vmem.at[
                 out_buf_id, pl.ds(out_offset, acc_bt), pl.ds(0, hidden_size)
             ]
-            if w1_shared_hbm is not None and not ablation_skip_shared:
+            if w1_shared_hbm is not None:
                 # SE wrote its dense output into b_output during the SE-first
                 # phase; add the routed gather result on top.
                 se_tile = target[...].astype(jnp.float32)
@@ -1829,18 +1755,18 @@ def _fused_ep_moe_kernel(
 
     @jax.named_scope("output_store")
     def start_send_bo(*, bt_id, priority=0):
-        bt_sem_id = bt_bank_id(bt_id)
+        out_buf_id = a2a_bank_for_bt(bt_id)  # b_output + store sem are K-deep
         bt_start = bt_id * bt
         pltpu.make_async_copy(
-            src_ref=b_output_x2_vmem.at[bt_sem_id],
+            src_ref=b_output_x2_vmem.at[out_buf_id],
             dst_ref=output_hbm.at[pl.ds(bt_start, bt)],
-            sem=local_sems.at[bt_sem_id, 7],
+            sem=local_sems.at[out_buf_id, 7],
         ).start(priority=priority)
 
     @jax.named_scope("output_store_wait")
     def wait_store_output(*, bt_id):
         is_valid = jnp.logical_and(bt_id >= 0, bt_id < num_bt)
-        bt_sem_id = bt_bank_id(bt_id)
+        out_buf_id = a2a_bank_for_bt(bt_id)  # b_output + store sem are K-deep
 
         @pl.when(is_valid)
         def _():
@@ -1849,7 +1775,7 @@ def _fused_ep_moe_kernel(
             pltpu.make_async_copy(
                 src_ref=ref,
                 dst_ref=ref,
-                sem=local_sems.at[bt_sem_id, 7],
+                sem=local_sems.at[out_buf_id, 7],
             ).wait()
 
     # ===== Shared expert (reads weights directly from HBM refs) =====
@@ -2072,10 +1998,7 @@ def _fused_ep_moe_kernel(
     # The quantize is pq-chunked so its f32 temp stays ~1MB (fits alongside SE).
     # Needs bt<=bts.
     use_per_bt_prequant = (
-        enable_act_quant
-        and not ablation_skip_prequant
-        and bt <= bts
-        and not os.environ.get("SGLJAX_SKIP_PREQUANT")
+        enable_act_quant and bt <= bts and not os.environ.get("SGLJAX_SKIP_PREQUANT")
     )
 
     # Chunk the quantize so the f32 intermediate stays small (a single (bt, hidden)
@@ -2134,20 +2057,10 @@ def _fused_ep_moe_kernel(
     def run_bt(bt_id, e_sem_id, *, skip_post_gather=False):
         bt_start = bt_id * bt
         bt_sem_id = bt_bank_id(bt_id)
-        gather_bank_id = bt_id
+        gather_bank_id = a2a_bank_for_bt(bt_id)
         next_bt_id = bt_id + jnp.int32(1)
         a2a_bank_id = a2a_bank_for_bt(bt_id)
-        out_buf_id = bt_bank_id(bt_id)
-
-        @pl.when(next_bt_id < num_bt)
-        def _():
-            start_fetch_topk(bt_id=next_bt_id)
-            if use_per_bt_prequant:
-                prequant_bt(next_bt_id)
-
-        current_bt_scatter_prefetched = jnp.logical_and(
-            can_bt_scatter_overlap, bt_id > jnp.int32(0)
-        )
+        out_buf_id = a2a_bank_for_bt(bt_id)  # b_output is K-deep (%K); metadata/topk %Km
 
         def prepare_bt_metadata(_bt_id, _bt_sem_id):
             wait_fetch_topk(bt_id=_bt_id)
@@ -2157,6 +2070,17 @@ def _fused_ep_moe_kernel(
                 bt_sem_id=_bt_sem_id,
                 t2e_routing=_t2e_routing,
             )
+
+        # 1-ahead topk prefetch then prequant for next.
+        @pl.when(next_bt_id < num_bt)
+        def _():
+            start_fetch_topk(bt_id=next_bt_id)
+            if use_per_bt_prequant:
+                prequant_bt(next_bt_id)
+
+        current_bt_scatter_prefetched = jnp.logical_and(
+            can_bt_scatter_overlap, bt_id > jnp.int32(0)
+        )
 
         if can_bt_scatter_overlap:
 
@@ -2168,9 +2092,6 @@ def _fused_ep_moe_kernel(
             prepare_bt_metadata(bt_id, bt_sem_id)
 
         t2e_routing = b_topk_ids_x2_vmem[bt_sem_id]
-
-        if ablation_stop_after_metadata:
-            return e_sem_id
 
         if not skip_post_gather:
             wait_store_output(bt_id=bt_id - 2)
@@ -2192,6 +2113,14 @@ def _fused_ep_moe_kernel(
             @pl.when(next_bt_id < num_bt)
             def _():
                 prepare_bt_metadata(next_bt_id, next_bt_sem_id)
+                if use_fixed_gather_banks:
+                    # Reuse of a2a scatter bank (next%K): drain block (next-K)'s
+                    # outbound send before overwriting the payload HBM. Metadata
+                    # lives on the separate Km bank (next%Km), covered by Km depth.
+                    @pl.when(next_bt_id >= jnp.int32(num_bt_banks))
+                    def _():
+                        wait_a2a_scatter_send_batch(a2a_bank_id=next_a2a_bank_id)
+
                 start_a2a_scatter_batch(
                     bt_sem_id=next_bt_sem_id,
                     bt_start=next_bt_start,
@@ -2219,23 +2148,6 @@ def _fused_ep_moe_kernel(
 
         n_act = lax.fori_loop(0, local_num_experts, _build_active, jnp.int32(0), unroll=False)
         n_active_x2_smem[bt_sem_id, 0] = n_act
-
-        if ablation_scatter_only:
-
-            def _wait_scatter_only(i, _):
-                local_e_id = active_ids_x2_smem[bt_sem_id, i]
-                wait_a2a_scatter_recv(
-                    bt_sem_id=bt_sem_id,
-                    e_sem_id=local_e_id,
-                    local_e_id=local_e_id,
-                    a2a_bank_id=a2a_bank_id,
-                )
-                return None
-
-            lax.fori_loop(0, n_act, _wait_scatter_only, None, unroll=False)
-            if not use_gather_bank:
-                wait_a2a_scatter_send_batch(a2a_bank_id=a2a_bank_id)
-            return e_sem_id
 
         # ===== SE-first phase: compute all shared-expert blocks BEFORE the
         # routed expert loop, overlapping the scatter-recv / metadata window.
@@ -2266,41 +2178,26 @@ def _fused_ep_moe_kernel(
                 a2a_bank_id=a2a_bank_id,
             )
             expert_slot = (i % jnp.int32(2)) if global_rolling_wb else None
-            if ablation_ffn_io_only:
-                expert_ffn_io_only(
-                    bt_sem_id,
-                    e_sem_id_local,
-                    local_e_id,
-                    a2a_bank_id,
-                )
-                next_bf0_w13_prefetched = jnp.bool_(False)
-            else:
-                next_bf0_w13_prefetched = expert_ffn(
-                    bt_sem_id,
-                    e_sem_id_local,
-                    local_e_id,
-                    bf0_w13_prefetched,
-                    a2a_bank_id,
-                    next_local_e_id=next_local_e_id,
-                    has_next=has_next,
-                    expert_slot=expert_slot,
-                )
-            if not ablation_stop_before_gather:
-                start_a2a_gather(
-                    bt_sem_id=bt_sem_id,
-                    e_sem_id=e_sem_id_local,
-                    local_e_id=local_e_id,
-                    a2a_bank_id=a2a_bank_id,
-                    gather_bank_id=gather_bank_id,
-                )
+            next_bf0_w13_prefetched = expert_ffn(
+                bt_sem_id,
+                e_sem_id_local,
+                local_e_id,
+                bf0_w13_prefetched,
+                a2a_bank_id,
+                next_local_e_id=next_local_e_id,
+                has_next=has_next,
+                expert_slot=expert_slot,
+            )
+            start_a2a_gather(
+                bt_sem_id=bt_sem_id,
+                e_sem_id=e_sem_id_local,
+                local_e_id=local_e_id,
+                a2a_bank_id=a2a_bank_id,
+                gather_bank_id=gather_bank_id,
+            )
             return next_bf0_w13_prefetched
 
         lax.fori_loop(0, n_active, compute_expert_batch_compact, init_carry, unroll=False)
-
-        if ablation_stop_before_gather:
-            if not use_gather_bank:
-                wait_a2a_scatter_send_batch(a2a_bank_id=a2a_bank_id)
-            return e_sem_id
 
         if not skip_post_gather:
             wait_a2a_scatter_send_batch(a2a_bank_id=a2a_bank_id)
@@ -2329,12 +2226,7 @@ def _fused_ep_moe_kernel(
     # ===== Kernel start =====
     sync_barrier()
 
-    if (
-        enable_act_quant
-        and not ablation_skip_prequant
-        and not use_per_bt_prequant
-        and not os.environ.get("SGLJAX_SKIP_PREQUANT")
-    ):
+    if enable_act_quant and not use_per_bt_prequant and not os.environ.get("SGLJAX_SKIP_PREQUANT"):
         # Standalone prequant: bf16 tokens -> fp8 + per-token f32 scale.
         # Scale is embedded into the last fp8 column via bitcast (4 fp8 bytes
         # == 1 f32). FFN1 reads it back out via the matching bitcast.
@@ -2391,22 +2283,75 @@ def _fused_ep_moe_kernel(
             pltpu.SemaphoreType.DMA,
         )
 
+    if use_gather_bank and use_fixed_gather_banks:
+        # ---- Fixed-K single K-deep software pipeline ----
+        # Only K gather banks are live (not num_bt), decoupling gather-overlap
+        # SMEM/VMEM/HBM/sems from token count. Each iteration i first drains
+        # block i-K (freeing bank i%K), then fires block i into that same bank.
+        # All 1-ahead prefetches (topk, scatter) are disabled on this path, so
+        # fire(i) never writes bank (i+1)%K => K_min=2.
+        K = num_bt_banks  # gather/output/scatter depth; metadata/topk = smem_banks = K+1
+
+        def _drain(j):
+            bt_sem_id = bt_bank_id(j)  # metadata/topk %Km
+            gather_bank_id = a2a_bank_for_bt(j)  # %K
+            a2a_bank_id = a2a_bank_for_bt(j)  # %K
+            out_buf_id = a2a_bank_for_bt(j)  # b_output %K
+            # scatter-send drain moved to fire's reuse-wait (before it re-scatters
+            # this a2a bank); re-waiting here would double-consume the send sem.
+            wait_a2a_gather_recv_all(bt_sem_id=bt_sem_id, gather_bank_id=gather_bank_id)
+            # Free b_output bank (j-K)%K == j%K before acc overwrites it: the
+            # prior occupant (block j-K)'s async store DMA must have drained.
+            # wait_store_output's internal is_valid no-ops j-K<0.
+            wait_store_output(bt_id=j - jnp.int32(K))
+            acc_and_store_output(
+                bt_sem_id=bt_sem_id, out_buf_id=out_buf_id, gather_bank_id=gather_bank_id
+            )
+            sync_barrier()
+            start_send_bo(bt_id=j)
+            tail_start = max(local_num_experts - expert_buffer_count, 0)
+            for tail_e_id in range(tail_start, local_num_experts):
+                wait_a2a_gather_send(
+                    bt_sem_id=bt_sem_id,
+                    e_sem_id=tail_e_id,
+                    local_e_id=tail_e_id,
+                    a2a_bank_id=a2a_bank_id,
+                    gather_bank_id=gather_bank_id,
+                )
+
+        def _pipe_body(i, e_sem_id):
+            @pl.when(i >= jnp.int32(K))
+            def _():
+                _drain(i - jnp.int32(K))
+
+            # Fire block i (i<num_bt); thread e_sem_id carry via lax.cond so the
+            # tail iterations (i>=num_bt, drain-only) leave it unchanged.
+            e_sem_id = lax.cond(
+                i < jnp.int32(num_bt),
+                lambda es: run_bt(i, es, skip_post_gather=True),
+                lambda es: es,
+                e_sem_id,
+            )
+            return e_sem_id
+
+        lax.fori_loop(0, num_bt + K, _pipe_body, jnp.int32(0), unroll=False)
+
+        # Tail: drain the last K blocks' async work that no later iteration
+        # reaches — output stores (never re-waited) AND scatter sends (their a2a
+        # bank is never reused, so fire's reuse-wait never drains them). Missing
+        # the scatter-send drain leaves its send sem nonzero -> Mosaic core-halt.
+        for _t in range(K):
+            _tail_bt = jnp.int32(num_bt - K + _t)
+            wait_store_output(bt_id=_tail_bt)
+            wait_a2a_scatter_send_batch(a2a_bank_id=a2a_bank_for_bt(_tail_bt))
+        return
+
     if use_gather_bank:
 
         def _run_bt_expert_only(bt_id, e_sem_id):
             return run_bt(bt_id, e_sem_id, skip_post_gather=True)
 
         lax.fori_loop(0, num_bt, _run_bt_expert_only, jnp.int32(0), unroll=False)
-
-        if ablation_stop_after_metadata:
-            sync_barrier()
-            return
-
-        if ablation_stop_before_gather:
-            for _bt_i in range(num_bt):
-                wait_a2a_scatter_send_batch(a2a_bank_id=jnp.int32(_bt_i))
-            sync_barrier()
-            return
 
         def _run_bt_post_gather(bt_id, _):
             bt_sem_id = bt_bank_id(bt_id)
@@ -2442,10 +2387,6 @@ def _fused_ep_moe_kernel(
     else:
         lax.fori_loop(0, num_bt, run_bt, jnp.int32(0), unroll=False)
 
-    if ablation_stop_after_metadata or ablation_stop_before_gather:
-        sync_barrier()
-        return
-
     if use_gather_bank:
         for _bt_i in range(num_bt):
             wait_store_output(bt_id=jnp.int32(_bt_i))
@@ -2474,9 +2415,8 @@ def _fused_ep_moe_kernel(
         "quant_block_k",
         "direct_scaled_dot",
         "cross_expert_prefetch_mode",
-        "interleave_bt",
+        "fixed_gather_banks",
         "enable_act_quant",
-        "kernel_ablation_mode",
     ],
 )
 def fused_ep_moe_v2(
@@ -2512,11 +2452,13 @@ def fused_ep_moe_v2(
     block_config: FusedMoEBlockConfig | None = None,
     direct_scaled_dot: bool = False,
     cross_expert_prefetch_mode: str = "full",
-    interleave_bt: bool = True,
+    # Number of rotating gather banks (K) for the gather-compute overlap software
+    # pipeline. Overlap is always on when num_bt > 1 (no separate enable switch).
+    # K < num_bt => K-deep sliding window (payload double-buffered at K=2, metadata
+    # Km=K+1), decoupling gather SMEM/VMEM from token count. K >= num_bt => legacy
+    # per-block banking. num_bt <= 1 (decode) => no overlap.
+    fixed_gather_banks: int | None = 2,
     enable_act_quant: bool = False,
-    # Benchmark-only static stage cut. Non-full modes intentionally do not
-    # produce numerically valid output and must never be used for inference.
-    kernel_ablation_mode: str = "full",
     dp_axis_name: str = "data",
     tp_axis_name: str = "tensor",
 ):
@@ -2524,23 +2466,6 @@ def fused_ep_moe_v2(
         raise ValueError(
             f"Unsupported {cross_expert_prefetch_mode=}; "
             "expected one of 'none', 'full', or 'w13'."
-        )
-    valid_kernel_ablation_modes = {
-        "full",
-        "no_shared",
-        "no_weight_hbm",
-        "routed_no_gather",
-        "ffn_io_store_only",
-        "ffn_io_only",
-        "token_io_only",
-        "scatter_only",
-        "metadata_prequant",
-        "metadata_only",
-    }
-    if kernel_ablation_mode not in valid_kernel_ablation_modes:
-        raise ValueError(
-            f"Unsupported {kernel_ablation_mode=}; expected one of "
-            f"{sorted(valid_kernel_ablation_modes)}."
         )
     if enable_act_quant:
         if not direct_scaled_dot:
@@ -2716,10 +2641,20 @@ def fused_ep_moe_v2(
     wb_slots = 2
     num_bt = local_num_tokens // bt
     use_bt_scatter_bank = enable_bt_scatter_overlap and num_bt > 1
-    use_gather_bank = interleave_bt and num_bt > 1
+    use_gather_bank = num_bt > 1
     use_bt_banking = use_bt_scatter_bank or use_gather_bank
-    num_bt_banks = num_bt if use_gather_bank else (2 if use_bt_scatter_bank else 1)
-    smem_banks = num_bt if use_gather_bank else 2
+    use_fixed_gather_banks = (
+        use_gather_bank and fixed_gather_banks is not None and fixed_gather_banks < num_bt
+    )
+    if use_fixed_gather_banks:
+        assert fixed_gather_banks >= 2, "fixed_gather_banks must be >= 2"
+    _gather_bank_count = fixed_gather_banks if use_fixed_gather_banks else num_bt
+    num_bt_banks = _gather_bank_count if use_gather_bank else (2 if use_bt_scatter_bank else 1)
+    # metadata/topk get one extra bank (Km = K+1) so their 1-ahead generation is
+    # not overwritten before drain(j) reads block j's metadata; scatter/gather/
+    # output stay at K.
+    _md_extra = 1 if use_fixed_gather_banks else 0
+    smem_banks = (_gather_bank_count + _md_extra) if use_gather_bank else 2
     use_w1_dequant_scratch = w1_scale is not None and not direct_scaled_dot
     use_w3_dequant_scratch = w3_scale is not None and not direct_scaled_dot
     use_w2_dequant_scratch = w2_scale is not None and not direct_scaled_dot
@@ -2734,14 +2669,12 @@ def fused_ep_moe_v2(
         scope_name += "-route_smem_topk"
     if use_bt_scatter_bank:
         scope_name += "-bt_scatter_overlap"
-    if interleave_bt:
-        scope_name += "-interleave_bt"
+    if use_gather_bank:
+        scope_name += f"-gather_banks_{_gather_bank_count}"
     if w1_shared is not None:
         scope_name += f"-se_bse_{bse}"
     if enable_act_quant:
         scope_name += "-act_quant"
-    if kernel_ablation_mode != "full":
-        scope_name += f"-ablate_{kernel_ablation_mode}"
 
     scratch_shapes = (
         # SMEM: routing/metadata
@@ -2768,7 +2701,7 @@ def fused_ep_moe_v2(
         pltpu.VMEM((smem_banks, bt, padded_top_k), jnp.float32),  # topk_weights
         pltpu.VMEM((smem_banks, bt, padded_top_k), jnp.int32),  # topk_ids
         # VMEM: output double buffer
-        pltpu.VMEM((smem_banks, bt, hidden_size), out_dtype),  # output
+        pltpu.VMEM((num_bt_banks, bt, hidden_size), out_dtype),  # output (K-deep, out_buf_id=%K)
         # VMEM: weight double buffers
         pltpu.VMEM((wb_slots, t_packing, h_per_t, bf), w1.dtype),  # W1
         pltpu.VMEM((wb_slots, t_packing, h_per_t, bf), w3.dtype),  # W3
@@ -2856,7 +2789,7 @@ def fused_ep_moe_v2(
                 shared_swiglu_limit=shared_swiglu_limit,
                 enable_bt_scatter_overlap=use_bt_scatter_bank,
                 cross_expert_prefetch_mode=cross_expert_prefetch_mode,
-                interleave_bt=interleave_bt,
+                fixed_gather_banks=fixed_gather_banks,
                 enable_act_quant=enable_act_quant,
                 direct_scaled_dot=direct_scaled_dot,
                 bt=bt,
@@ -2865,7 +2798,6 @@ def fused_ep_moe_v2(
                 bts=bts,
                 bse=bse,
                 quant_block_k=quant_block_k,
-                kernel_ablation_mode=kernel_ablation_mode,
             ),
             out_shape=jax.ShapeDtypeStruct((local_num_tokens, hidden_size), out_dtype),
             grid_spec=pltpu.PrefetchScalarGridSpec(

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/tune_prune.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/tune_prune.py
@@ -1,0 +1,115 @@
+"""Candidate pruning for the fused_moe v2 autotuner (offline, bench-time only).
+
+Split out of bench_v2.py so the pruning heuristic is unit-testable in isolation:
+bench_v2.py runs a full kernel sweep at import time, so importing it from a test
+is not possible. This module has no jax/kernel dependency -- it operates purely
+on candidate objects exposing .bt/.bf/.btc/.bts/.bse (FusedMoEBlockConfig).
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def prune_candidates(configs, max_configs, log=None):
+    """Cut a VMEM-valid candidate list down to max_configs for benchmarking.
+
+    Buckets by (bt, bts). Within each bucket it first SEEDS the compute-favorable
+    (large bf, largest btc) corner, then fills the rest with a diversity-preserving
+    Latin traversal over (bf, btc); finally it round-robins across buckets until
+    max_configs are chosen.
+
+    The seed is what fixes the historical blind spot: without it the (large bf,
+    large btc) point -- the MXU-saturating optimum for compute-bound prefill --
+    sank to a within-bucket depth the round-robin never reached, so the tuner
+    "never tested" btc=128 with a large bf and always shipped btc=64.
+    """
+    if log is None:
+
+        def log(*_a, **_k):
+            return None
+
+    if len(configs) <= max_configs:
+        log(f"  tune: {len(configs)} configs (all pass VMEM filter)")
+        return configs
+
+    buckets = {}
+    for cfg in configs:
+        bk = (cfg.bt, cfg.bts or cfg.bt)
+        buckets.setdefault(bk, []).append(cfg)
+    for bk in buckets:
+        # Preserve BF and BTC diversity under the max-config cap. Sorting the
+        # whole bucket by BF first can spend every slot on bf=1024; naively
+        # round-robining BF can then spend every slot on the same btc. Build a
+        # small Latin-style traversal over (BF, BTC), rotating the starting BTC
+        # for each BF -- but seed the compute-favorable corner first (below).
+        by_pair = {}
+        for cfg in buckets[bk]:
+            by_pair.setdefault((cfg.bf, cfg.btc), []).append(cfg)
+        for pair in by_pair:
+            by_pair[pair].sort(key=lambda c: c.bse, reverse=True)
+        ordered = []
+        bf_keys = sorted({cfg.bf for cfg in buckets[bk]}, reverse=True)
+        btc_keys_all = {cfg.btc for cfg in buckets[bk]}
+        # Corner seeding: put the compute-favorable (large bf, largest btc) point
+        # at the front so the diversity round-robin cannot evict it under a tight
+        # max_configs. The MXU 128x128 systolic array wants a large compute-tile
+        # M (= btc); the prefill optimum is (large bf, large btc), which the Latin
+        # traversal alone buries deep (e.g. bf1024xbtc128 at within-bucket index
+        # ~11 while only ~2 survive per bucket at 21 buckets / 48 slots). Seed the
+        # top-2 bf (the optimum is often the 2nd-largest bf, not the max) paired
+        # with the largest available btc. btc_max is bounded by bts (btc divides
+        # bts), so decode buckets (small bts) only seed small btc -- adaptive, no
+        # small-shape regression. Missing (bf, btc_max) pairs (e.g. bf=2048xbtc=128
+        # dropped by the VMEM filter upstream) are simply skipped.
+        btc_max = max(btc_keys_all)
+        for bf in bf_keys[:2]:
+            queue = by_pair.get((bf, btc_max), [])
+            if queue:
+                ordered.append(queue.pop(0))
+        # Tail btc order anchored at the MXU-saturation point for this bucket's
+        # token-block size (bt = bk[0]), not a fixed 32: prefill (bt>=128) then
+        # also prefers large btc in the tail, while decode (small bt) collapses
+        # the anchor to bt and keeps its small-btc-first order.
+        anchor = max(8, min(bk[0], 128))
+        btc_keys = sorted(
+            btc_keys_all,
+            key=lambda btc: (abs(math.log2(btc / anchor)), -btc),
+        )
+        round_idx = 0
+        while any(by_pair[pair] for pair in by_pair):
+            for bf_idx, bf in enumerate(bf_keys):
+                for offset in range(len(btc_keys)):
+                    btc = btc_keys[(round_idx + bf_idx + offset) % len(btc_keys)]
+                    queue = by_pair.get((bf, btc), [])
+                    if queue:
+                        ordered.append(queue.pop(0))
+                        break
+            round_idx += 1
+        buckets[bk] = ordered
+
+    selected = []
+    selected_keys = set()
+    bucket_keys = sorted(buckets.keys(), reverse=True)
+    while len(selected) < max_configs:
+        made_progress = False
+        for bk in bucket_keys:
+            bucket = buckets[bk]
+            if not bucket:
+                continue
+            cfg = bucket.pop(0)
+            key = (cfg.bt, cfg.bf, cfg.btc, cfg.bts, cfg.bse)
+            if key not in selected_keys:
+                selected_keys.add(key)
+                selected.append(cfg)
+                made_progress = True
+            if len(selected) >= max_configs:
+                break
+        if not made_progress:
+            break
+
+    log(
+        f"  tune: {len(configs)} valid -> {len(selected)} selected "
+        f"(max={max_configs}, {len(bucket_keys)} bt/bts buckets)"
+    )
+    return selected

--- a/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v2/tuned_block_configs.py
@@ -21,10 +21,12 @@ logger = logging.getLogger(__name__)
 # Key (without device_name):
 #   (tokens_dtype, weight_dtype, num_tokens, num_experts, top_k,
 #    hidden_size, intermediate_size, ep_size, use_shared_expert, use_grouped_topk,
-#    enable_act_quant)
-# enable_act_quant is the last field (Mode 1 fp8-token vs Mode 2 bf16-token want
-# different configs, esp. for shared-expert prefill). Lookup falls back to the
-# legacy 10-field key (no enable_act_quant) for pre-existing entries.
+#    enable_act_quant, quant_mode)
+# enable_act_quant and quant_mode are optional trailing fields. quant_mode
+# ("per_channel" | "blockwise" | "none") lets a shape store distinct winners for
+# per-channel vs block-wise FP8, whose optimal tiles differ. Lookup is 3-level:
+# the full key (with quant_mode) -> the key without quant_mode -> the legacy
+# 10-field key (no enable_act_quant), so pre-existing entries still hit.
 #
 # Value: (bt, bf, btc, bse, bts)
 # fmt: off
@@ -112,6 +114,18 @@ DEFAULT_V2_BLOCK_CONFIG = FusedMoEBlockConfig(
 )
 
 
+def should_interleave_fused_moe_v2_bt(*, num_tokens: int, ep_size: int) -> bool:
+    """Deprecated shim: gather overlap is now unconditional for num_bt > 1 via
+    the kernel's fixed-K gather banks, so there is no token-count gate. Retained
+    only to validate inputs for callers that still probe it; always returns True.
+    """
+    if ep_size <= 0:
+        raise ValueError(f"Expected {ep_size=} to be > 0.")
+    if num_tokens % ep_size != 0:
+        raise ValueError(f"Expected {num_tokens=} to be aligned to {ep_size=}.")
+    return True
+
+
 def get_simplified_key(
     *,
     dtype: jnp.dtype,
@@ -125,11 +139,14 @@ def get_simplified_key(
     use_shared_expert: bool,
     use_grouped_topk: bool,
     enable_act_quant: bool = False,
+    quant_mode: str | None = None,
 ) -> tuple:
     if ep_size <= 0:
         raise ValueError(f"Expected {ep_size=} to be > 0.")
     if num_tokens % ep_size != 0:
         raise ValueError(f"Expected {num_tokens=} to be aligned to {ep_size=}.")
+    if quant_mode not in (None, "none", "blockwise", "per_channel"):
+        raise ValueError(f"Unsupported {quant_mode=}")
 
     device = get_device_name()
     dtype_name = jnp.dtype(dtype).name
@@ -147,6 +164,7 @@ def get_simplified_key(
         bool(use_shared_expert),
         bool(use_grouped_topk),
         bool(enable_act_quant),
+        quant_mode,
     )
 
 
@@ -163,6 +181,7 @@ def get_tuned_fused_moe_v2_block_config(
     use_shared_expert: bool = False,
     use_grouped_topk: bool = False,
     enable_act_quant: bool = False,
+    quant_mode: str | None = None,
 ) -> FusedMoEBlockConfig:
     keys = get_simplified_key(
         dtype=dtype,
@@ -176,11 +195,13 @@ def get_tuned_fused_moe_v2_block_config(
         use_shared_expert=use_shared_expert,
         use_grouped_topk=use_grouped_topk,
         enable_act_quant=enable_act_quant,
+        quant_mode=quant_mode,
     )
     device_name = keys[0]
-    table_key = keys[1:]  # includes enable_act_quant (last element)
-    # Backward compatible: prefer the act_quant-specific key, then fall back to
-    # the legacy key (without enable_act_quant) so pre-existing entries still hit.
+    # 3-level fallback: full key (with quant_mode) -> without quant_mode ->
+    # legacy 10-field key (no enable_act_quant), so pre-existing entries still hit.
+    table_key_quant = keys[1:]
+    table_key = table_key_quant[:-1]
     table_key_legacy = table_key[:-1]
 
     def _lookup(k):
@@ -191,7 +212,9 @@ def get_tuned_fused_moe_v2_block_config(
             cfg = TUNED_BLOCK_CONFIGS.get("*", {}).get(k)
         return cfg
 
-    cfg_tuple = _lookup(table_key)
+    cfg_tuple = _lookup(table_key_quant)
+    if cfg_tuple is None:
+        cfg_tuple = _lookup(table_key)
     if cfg_tuple is None:
         cfg_tuple = _lookup(table_key_legacy)
 

--- a/python/sgl_jax/srt/layers/fused_moe.py
+++ b/python/sgl_jax/srt/layers/fused_moe.py
@@ -374,16 +374,16 @@ class FusedEPMoE(nnx.Module):
                     w2_scale, self.hidden_size, self.quant_block_n
                 )
             else:
-                # (E, K//wsz, N) → (E, K//wsz, 1, N)
-                w1_scale_4d = w1_scale.reshape(
-                    w1_scale.shape[0], w1_scale.shape[1], 1, w1_scale.shape[2]
-                )
-                w3_scale_4d = w3_scale.reshape(
-                    w3_scale.shape[0], w3_scale.shape[1], 1, w3_scale.shape[2]
-                )
-                w2_scale_4d = w2_scale.reshape(
-                    w2_scale.shape[0], w2_scale.shape[1], 1, w2_scale.shape[2]
-                )
+                if self.quant_block_k is None:
+                    # Per-channel reduction over K returns [E, N].
+                    w1_scale_4d = w1_scale[:, None, None, :]
+                    w3_scale_4d = w3_scale[:, None, None, :]
+                    w2_scale_4d = w2_scale[:, None, None, :]
+                else:
+                    # Sub-channel [E, K//wsz, N] -> [E, K//wsz, 1, N].
+                    w1_scale_4d = w1_scale[:, :, None, :]
+                    w3_scale_4d = w3_scale[:, :, None, :]
+                    w2_scale_4d = w2_scale[:, :, None, :]
 
             if hasattr(self, "w1_scale"):
                 del self.w1_scale
@@ -588,6 +588,12 @@ class FusedEPMoEV2(FusedEPMoE):
         enable_act_quant = (
             self.activation_quantized_dtype is not None and self.enable_act_quant_cfg is not False
         ) and (w1_scale is not None)
+        quant_block_k = self.quant_block_k if hasattr(self, "quant_block_k") else None
+        quant_mode = (
+            "none"
+            if w1_scale is None
+            else ("per_channel" if quant_block_k is None else "blockwise")
+        )
 
         if block_config is None:
             block_config = get_tuned_fused_moe_v2_block_config(
@@ -602,6 +608,7 @@ class FusedEPMoEV2(FusedEPMoE):
                 use_shared_expert=self.w1_shared is not None,
                 use_grouped_topk=self.use_grouped_topk,
                 enable_act_quant=enable_act_quant,
+                quant_mode=quant_mode,
             )
 
         direct_scaled_dot = w1_scale is not None
@@ -623,7 +630,7 @@ class FusedEPMoEV2(FusedEPMoE):
             swiglu_limit=swiglu_limit,
             shared_swiglu_limit=shared_swiglu_limit,
             block_config=block_config,
-            quant_block_k=self.quant_block_k if hasattr(self, "quant_block_k") else None,
+            quant_block_k=quant_block_k,
             w1_scale=w1_scale,
             w2_scale=w2_scale,
             w3_scale=w3_scale,

--- a/python/sgl_jax/test/test_fused_moe_v2_tuner_prune.py
+++ b/python/sgl_jax/test/test_fused_moe_v2_tuner_prune.py
@@ -1,0 +1,112 @@
+"""Unit tests for the fused_moe v2 autotuner candidate pruning (tune_prune).
+
+Pins the fix for the historical blind spot where the compute-favorable
+(large bf, large btc) corner was pruned out for prefill shapes, so the tuner
+"never tested" btc=128 with a large bf and always shipped btc=64. Also guards
+that decode/small shapes are NOT polluted with large btc (the seed is adaptive,
+bounded by bts).
+
+tune_prune has no jax/kernel dependency, so these run in milliseconds.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+_V2 = pathlib.Path(__file__).resolve().parents[1] / "srt" / "kernels" / "fused_moe" / "v2"
+sys.path.insert(0, str(_V2))
+
+from tune_prune import prune_candidates  # noqa: E402
+
+
+class Cfg:
+    """Minimal stand-in for FusedMoEBlockConfig (prune only reads these)."""
+
+    def __init__(self, bt, bf, btc, bts, bse):
+        self.bt, self.bf, self.btc, self.bts, self.bse = bt, bf, btc, bts, bse
+
+    def tup(self):
+        return (self.bt, self.bf, self.btc, self.bts, self.bse)
+
+    def __repr__(self):
+        return f"Cfg{self.tup()}"
+
+
+# btc candidates = divisors of bts that are multiples of 8 (mirrors
+# _aligned_divisors(bts, 8) in bench_v2).
+def _btc_divs(bts):
+    return [v for v in (128, 64, 32, 16, 8) if bts % v == 0 and v <= bts]
+
+
+def _prefill_grid():
+    """A 16384-token-prefill-like candidate set: one big (bt=128,bts=128) bucket
+    plus several other buckets, so total > max_configs and >1 bucket contend.
+    (bf=2048, btc=128) is omitted to mimic its upstream VMEM-filter drop."""
+    cfgs = []
+    for bf in (2048, 1024, 512, 256, 128):
+        for btc in _btc_divs(128):
+            if bf == 2048 and btc == 128:
+                continue  # VMEM-oversized, dropped before pruning
+            cfgs.append(Cfg(128, bf, btc, 128, 1024))
+    for bt, bts in ((256, 256), (128, 256), (64, 64), (32, 32)):
+        for bf in (1024, 512, 256):
+            for btc in _btc_divs(bts)[:3]:
+                cfgs.append(Cfg(bt, bf, btc, bts, 512))
+    return cfgs
+
+
+def test_prefill_corner_survives_prune():
+    """The compute-favorable (bt=128, bf=1024, btc=128, bts=128) corner must be
+    selected — this is the exact config manual sweeps proved optimal and that the
+    old anchor-32 Latin traversal buried below the survival depth."""
+    cfgs = _prefill_grid()
+    assert len(cfgs) > 48, "test setup must exceed the cap to exercise pruning"
+    selected = prune_candidates(cfgs, 48)
+    tups = {c.tup() for c in selected}
+    assert (128, 1024, 128, 128, 1024) in tups, (
+        f"large-bf x large-btc corner was pruned out: "
+        f"{sorted(t for t in tups if t[0] == 128 and t[3] == 128)}"
+    )
+    # And more generally at least one btc=128 config survives.
+    assert any(c.btc == 128 for c in selected)
+
+
+def test_decode_small_btc_not_polluted():
+    """Decode buckets (small bts) must keep small btc — the seed is bounded by
+    bts (btc divides bts), so it never injects btc=128 into a bts=8 bucket."""
+    cfgs = []
+    # decode buckets
+    for bf in (512, 1024):
+        cfgs.append(Cfg(8, bf, 8, 8, 128))
+        cfgs.append(Cfg(8, bf, 8, 8, 512))
+    for bf in (512, 1024):
+        for btc in (16, 8):
+            cfgs.append(Cfg(16, bf, btc, 16, 512))
+    # prefill padding to force pruning
+    for bf in (2048, 1024, 512, 256, 128):
+        for btc in _btc_divs(128):
+            cfgs.append(Cfg(128, bf, btc, 128, 1024))
+    max_configs = 12
+    assert len(cfgs) > max_configs
+    selected = prune_candidates(cfgs, max_configs)
+    # seed is bts-bounded: no small-bts bucket ever gets btc > its bts
+    for c in selected:
+        assert c.btc <= c.bts, f"{c} violates btc<=bts (seed polluted a small bucket)"
+    # the prefill corner still wins a slot even under the tighter cap
+    assert any(c.tup() == (128, 1024, 128, 128, 1024) for c in selected)
+
+
+def test_no_prune_when_under_cap():
+    """Below the cap, all candidates are returned unchanged."""
+    cfgs = [Cfg(128, 1024, btc, 128, 1024) for btc in (128, 64, 32)]
+    selected = prune_candidates(cfgs, 48)
+    assert len(selected) == len(cfgs)
+    assert {c.tup() for c in selected} == {c.tup() for c in cfgs}
+
+
+def test_selected_respects_cap():
+    """Pruning never returns more than max_configs."""
+    cfgs = _prefill_grid()
+    selected = prune_candidates(cfgs, 48)
+    assert len(selected) <= 48


### PR DESCRIPTION
## Summary

Two independent improvements to the fused MoE v2 kernel and its autotuner.

### Kernel — fixed-K rotating gather banks
Replaces the `interleave_bt` boolean gate with a K-deep sliding window (default `K=2`) that decouples the gather/scatter/output overlap pipeline from the token count — gather-compute overlap is now unconditional for `num_bt > 1`. Metadata/topk get a `K+1` bank so the 1-ahead prefetch isn't overwritten before its block is consumed, with a fixed-K pipeline tail drain.

### Kernel — FFN1 per-channel scale fold
On the per-channel activation-quant path, the per-channel weight scale was applied inside the `t_packing` accumulation loop, running the scale VPU multiply ~4x redundantly (the scale is invariant across the packing slices). Now accumulates raw f32 dots and applies the scale once after the loop — math-identical (`Σ d·s == (Σ d)·s`, f32 rounding within tol), cutting ~3/4 of the FFN1 scale ops.

### Tuner — pruning fix + quant_mode key
- Autotuner candidate pruning is extracted into `tune_prune.prune_candidates` (unit-testable, no jax/kernel dependency). It seeds the compute-favorable (large `bf`, largest `btc`) corner before the diversity round-robin, so the MXU-saturating prefill optimum isn't pruned out under the max-config cap — previously the tuner could never test large-`btc` × large-`bf` and shipped a smaller `btc`. `bse` is included in the dedup key so all `bse` candidates get benched.
- `tuned_block_configs` gains an optional trailing `quant_mode` key field so a shape can store distinct winners for per-channel vs block-wise FP8 (their optimal tiles differ). Lookup is 3-level (full key → without `quant_mode` → legacy 10-field), so **all pre-existing entries keep hitting unchanged**.

Also removes the benchmark-only `kernel_ablation_mode` / `ablation_*` stage-cut flags and the abandoned coalesced-scatter scratch.

## Test plan
- `tune_prune` unit tests (`test_fused_moe_v2_tuner_prune.py`): 4 passing — corner-seed survives the cap, decode buckets aren't polluted with large `btc`, no-op under cap, respects cap.
- Backward-compat of tuned-config lookup verified: the 3-level fallback keeps 11-field (`enable_act_quant`) and legacy 10-field keys hitting when `quant_mode` is not supplied (existing configs return identical block configs).
- `py_compile` clean across kernel / bench / tuner / layers.
- Note: kernel-side changes (fixed-K banking, scale fold) are equivalence-preserving refactors; recommend a TPU CI run to confirm compile + numerics on the target hardware.
