### PR TITLE
Increase timeout for unit test to 40 minutes

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
       - name: Run unit test
-        timeout-minutes: 30
+        timeout-minutes: 40
         shell: bash
         env:
           SGLANG_JAX_IS_IN_CI: true


### PR DESCRIPTION
https://github.com/sgl-project/sglang-jax/issues/1528 - Increase timeout for unit test to 40 minutes to avoid PR failures

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
Recently after new tests were added for the GDN attention, which is taking time close to the timeout time, which fails those tests with timeout. which is evident from these last 2 runs for this test

https://github.com/sgl-project/sglang-jax/actions/runs/31850790234/job/94929526772?pr=1505 - 29 min 18 sec
https://github.com/sgl-project/sglang-jax/actions/runs/32001984727/job/95342450358?pr=1498 - 29 min 54 sec

Increasing the time for this particular stage will fix this timeout issue, as the job takes ~29 mins right now, and regression by some seconds fails the whole 30 min test and wastes the compute resources used for the whole PR-test run.



## Modifications

Increased the timeout for tests

## Accuracy Tests

NA

## Benchmarking and Profiling

NA

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
