### PR TITLE
fix(dsa): budget and report the indexer key cache in the KV pool sizing

### DIFF
--- a/docs/architecture/04-model-executor.md
+++ b/docs/architecture/04-model-executor.md
@@ -340,7 +340,13 @@ The standard tuple structure returned by the model forward:
 
 ## 4.9 Memory Profiling and KV Cache Allocation
 
-`cell_size` is the byte size that a single token occupies across all layers and KV heads — the basic unit for converting "available HBM" into "number of tokens that can be held". `max_total_num_tokens = available_kv_cache_bytes // cell_size` directly determines the capacity of `ReqToTokenPool` and `TokenToKVPoolAllocator`, as well as the total budget of `PrefillAdder`. The exact formula depends on the model architecture: standard MHA/GQA uses `num_kv_heads × align128(head_dim) × 2 × num_layers × dtype_size` (`×2` accounts for K/V; `align128` matches TPU MXU/VMEM tile boundaries); Absorbed MLA (DeepSeek V3) only caches the latent representation, so there is no `×2`, and the latent segments are aligned to 128 independently and the pool is fully replicated.
+`cell_size` is the byte size that a single token occupies across all layers and KV heads — the basic unit for converting "available HBM" into "number of tokens that can be held". `max_total_num_tokens = available_kv_cache_bytes // cell_size` directly determines the capacity of `ReqToTokenPool` and `TokenToKVPoolAllocator`, as well as the total budget of `PrefillAdder`. The exact formula depends on the model architecture:
+
+- **Standard MHA/GQA** — `num_kv_heads × align128(head_dim) × 2 × num_layers × dtype_size` (`×2` accounts for K/V; `align128` matches TPU MXU/VMEM tile boundaries)
+- **Absorbed MLA (DeepSeek V3)** — only the latent representation is cached, so there is no `×2`; the latent segments are aligned to 128 independently (`align128(kv_lora_rank) + align128(qk_rope_head_dim)`) and the pool is fully replicated
+- **Absorbed MLA + DSA (`--attention-backend dsa_sparse`)** — the latent term above **plus** a second term for the DSA indexer key buffer: `align128(index_head_dim) × num_indexer_layers × dtype_size`. The two terms use different layer counts on purpose — latent per KV-pool layer, indexer per "full" indexer layer over the whole model (`build_index_share_map`). On GLM-5.2 the indexer adds ~5% to the per-token cost, so sizing `--max-total-num-tokens` from the MLA formula alone over-provisions the pool
+
+All three omit the page-packing pad (`align(page_size, 32 // dtype_bits)`), which only bites when `page_size` is below the packing factor; `_compute_cell_size()` applies it.
 
 ### 4.9.1 Memory Pool Initialization
 
@@ -350,6 +356,7 @@ The standard tuple structure returned by the model forward:
 |---------|---------|-----------|
 | Standard MHA/GQA | `MHATokenToKVPool` | `TokenToKVPoolAllocator` (page_size=1) or `PagedTokenToKVPoolAllocator` |
 | Absorbed MLA | `MLATokenToKVPool` | Same as above |
+| Absorbed MLA + DSA sparse | `MLATokenToKVPool` (+ `num_indexer_layers` indexer key buffers) | Same as above |
 | Hybrid SWA | `SWAKVPool` (dual pool) | `SWATokenToKVPoolAllocator` (dual allocator) |
 
 Hybrid SWA models allocate Full-Attention and SWA pool sizes proportionally via `set_num_token_hybrid()`:

--- a/docs/architecture/07-kv-cache.md
+++ b/docs/architecture/07-kv-cache.md
@@ -208,6 +208,8 @@ Shape: (total_num_pages,
 
 **Key design**: `kv_dim = align128(kv_lora_rank) + align128(qk_rope_head_dim)`, with the two segments **independently aligned** (not `align128(lora + rope)`). E.g., `lora=192, rope=64` → `256 + 128 = 384`, not `align(256, 128) = 256`.
 
+**DSA indexer key buffers** (`--attention-backend dsa_sparse`): a *second* set of paged buffers in the same layout with `kv_dim = align128(index_head_dim)`, one per "full" indexer layer (`num_indexer_layers`, from `build_index_share_map`). Reached via `get_indexer_key_buffer(slot)` — indexed by indexer **slot**, not by layer id, so it does not go through the usual layer-id translation. Counted by both `get_kv_size_bytes()` and `_compute_cell_size()` (§4.9).
+
 | Feature | MHA Pool | MLA Pool |
 |---------|----------|----------|
 | Buffer dimensions | 5D | 4D |
@@ -233,6 +235,8 @@ The current SWA uses a Full + SWA dual-pool structure, with `SWATokenToKVPoolAll
 #### 7.2.4.5 HybridLinearKVPool
 
 Used by **hybrid models** that mix attention with linear-recurrent layers (e.g., Kimi-Linear: MLA + KDA). Wraps **one** inner `MHA`/`MLATokenToKVPool` sized only to the full-attention layers; linear-recurrent layers don't allocate KV slots — their state lives in `RecurrentStatePool` (§7.2.5), and req-pool slot coordination uses `HybridReqToTokenPool` (§7.2.3). The three classes together form the complete hybrid configuration.
+
+Combining this with `dsa_sparse` is rejected at startup: the DSA indexer slot space spans every layer while this wrapper indexes full-attention layers only, and nothing reconciles the two.
 
 **Core fields**:
 

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -1392,9 +1392,11 @@ class MLATokenToKVPool(KVCache):
 
     def _calculate_memory_usage(self):
         """Calculate memory usage for the 4D paged MLA cache."""
+        # `get_kv_size_bytes` is the authoritative total (it also feeds the
+        # scheduler gauge); the components below only split it for the log.
+        self.mem_usage = self.get_kv_size_bytes() / GB
         latent_bytes = self._buffer_bytes() * self.layer_num
         indexer_bytes = self._indexer_buffer_bytes() * self.num_indexer_layers
-        self.mem_usage = (latent_bytes + indexer_bytes) / GB
 
         breakdown = (
             f" (latent {latent_bytes / GB:.2f} GB + DSA indexer {indexer_bytes / GB:.2f} GB)"

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -1392,30 +1392,47 @@ class MLATokenToKVPool(KVCache):
 
     def _calculate_memory_usage(self):
         """Calculate memory usage for the 4D paged MLA cache."""
-        total_bytes = self._buffer_bytes() * self.layer_num
-        self.mem_usage = total_bytes / GB
+        latent_bytes = self._buffer_bytes() * self.layer_num
+        indexer_bytes = self._indexer_buffer_bytes() * self.num_indexer_layers
+        self.mem_usage = (latent_bytes + indexer_bytes) / GB
 
         logger.info(
-            "JAX MLA KV Cache allocated. #tokens: %s, KV size: %.2f GB",
+            "JAX MLA KV Cache allocated. #tokens: %s, KV size: %.2f GB"
+            " (latent %.2f GB + DSA indexer %.2f GB)",
             self.size,
-            total_bytes / GB,
+            self.mem_usage,
+            latent_bytes / GB,
+            indexer_bytes / GB,
         )
 
-    def _buffer_bytes(self) -> int:
+    def _buffer_bytes(self, kv_dim: int | None = None) -> int:
+        """Bytes for ONE paged buffer of ``kv_dim`` feature width (default: latent)."""
         total_num_pages = (self.size + self.page_size * self.dp_size) // self.page_size
         from sgl_jax.srt.kernels.mla.v2.kernel import get_kv_cache_shape
 
         shape = get_kv_cache_shape(
             total_num_pages=total_num_pages,
             page_size=self.page_size,
-            kv_dim=self.kv_dim,
+            kv_dim=self.kv_dim if kv_dim is None else kv_dim,
             kv_dtype=self.dtype,
         )
         return shape[0] * shape[1] * shape[2] * shape[3] * jnp.dtype(self.dtype).itemsize
 
+    def _indexer_buffer_bytes(self) -> int:
+        """Bytes for ONE DSA indexer key buffer; 0 when none is allocated."""
+        if not (self.indexer_key_dim and self.num_indexer_layers):
+            return 0
+        return self._buffer_bytes(kv_dim=self.indexer_key_dim)
+
     def get_kv_size_bytes(self):
-        """Calculate KV cache size in bytes."""
-        return self._buffer_bytes() * self.layer_num
+        """Resident bytes for this pool, including the DSA indexer key buffers.
+
+        Counting only the latent buffers under-stated resident HBM by the
+        indexer's share (~5% on GLM-5.2) — the same blind spot that let the
+        pool over-provision without it showing up in the startup log.
+        """
+        latent = self._buffer_bytes() * self.layer_num
+        return latent + self._indexer_buffer_bytes() * self.num_indexer_layers
 
     def get_fused_kv_buffer(self, layer_id: int) -> jax.Array:
         """Return the 4D paged buffer; consumed directly by the MLA v2 kernel."""

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -1396,13 +1396,16 @@ class MLATokenToKVPool(KVCache):
         indexer_bytes = self._indexer_buffer_bytes() * self.num_indexer_layers
         self.mem_usage = (latent_bytes + indexer_bytes) / GB
 
+        breakdown = (
+            f" (latent {latent_bytes / GB:.2f} GB + DSA indexer {indexer_bytes / GB:.2f} GB)"
+            if indexer_bytes
+            else ""
+        )
         logger.info(
-            "JAX MLA KV Cache allocated. #tokens: %s, KV size: %.2f GB"
-            " (latent %.2f GB + DSA indexer %.2f GB)",
+            "JAX MLA KV Cache allocated. #tokens: %s, KV size: %.2f GB%s",
             self.size,
             self.mem_usage,
-            latent_bytes / GB,
-            indexer_bytes / GB,
+            breakdown,
         )
 
     def _buffer_bytes(self, kv_dim: int | None = None) -> int:
@@ -1425,12 +1428,7 @@ class MLATokenToKVPool(KVCache):
         return self._buffer_bytes(kv_dim=self.indexer_key_dim)
 
     def get_kv_size_bytes(self):
-        """Resident bytes for this pool, including the DSA indexer key buffers.
-
-        Counting only the latent buffers under-stated resident HBM by the
-        indexer's share (~5% on GLM-5.2) — the same blind spot that let the
-        pool over-provision without it showing up in the startup log.
-        """
+        """Resident bytes for this pool, including the DSA indexer key buffers."""
         latent = self._buffer_bytes() * self.layer_num
         return latent + self._indexer_buffer_bytes() * self.num_indexer_layers
 

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -1423,8 +1423,6 @@ class MLATokenToKVPool(KVCache):
 
     def _indexer_buffer_bytes(self) -> int:
         """Bytes for ONE DSA indexer key buffer; 0 when none is allocated."""
-        if not (self.indexer_key_dim and self.num_indexer_layers):
-            return 0
         return self._buffer_bytes(kv_dim=self.indexer_key_dim)
 
     def get_kv_size_bytes(self):

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -291,15 +291,11 @@ def _build_non_hybrid_memory_pools(token_to_kv_pool) -> MemoryPools:
 class ModelRunnerKVCacheMixin:
 
     def _dsa_indexer_cache_params(self: ModelRunner) -> tuple[int, int]:
-        """``(indexer_key_dim, num_indexer_layers)`` for the DSA indexer key cache.
+        """``(indexer_key_dim, num_indexer_layers)``, or ``(0, 0)`` when no DSA
+        indexer key cache is allocated.
 
-        Returns ``(0, 0)`` when no indexer cache is allocated.
-
-        Single source of truth for the two places that must agree: the memory
-        *budget* (:meth:`_compute_cell_size`) and the actual *allocation*
-        (``MLATokenToKVPool._create_buffers``). They previously derived this
-        independently — in practice only the allocation side did — so the
-        profiler sized the KV pool as though the indexer buffer did not exist.
+        Shared by the KV pool's memory budget (:meth:`_compute_cell_size`) and its
+        allocation (``MLATokenToKVPool._create_buffers``), which must agree.
         """
         if self.server_args.attention_backend != "dsa_sparse":
             return 0, 0
@@ -335,13 +331,18 @@ class ModelRunnerKVCacheMixin:
             per_token = kv_dim * aligned_ps * dtype_size // self.page_size
             cell_size = per_token * num_layers
 
-            # DSA allocates a SECOND paged buffer, for indexer keys, one slot per
-            # "full" layer (`MLATokenToKVPool._create_buffers`). It is laid out by
-            # the same `get_kv_cache_shape`, so it costs the same per token with
-            # `kv_dim` replaced by the aligned indexer key dim. Omitting it made
-            # the profiler over-provision the pool, and the excess came out of the
-            # (1 - mem_fraction) activation reserve rather than out of KV — the
-            # resource that actually binds at long context.
+            # DSA allocates a second paged buffer for indexer keys, one slot per
+            # "full" layer. It uses the same `get_kv_cache_shape` layout, so it
+            # costs the same per token with `kv_dim` replaced by the aligned
+            # indexer key dim.
+            # Note the two terms use different layer counts, deliberately: they
+            # mirror two different allocations. The latent buffer exists per
+            # KV-pool layer (`_kv_pool_layer_count`, which drops non-attention
+            # layers on hybrid-recurrent models); the indexer buffer exists per
+            # "full" layer, counted over the whole model by the same
+            # `build_index_share_map` the pool is constructed from. Budget
+            # matching allocation is the invariant here, not the two counts
+            # matching each other.
             indexer_key_dim, num_indexer_layers = self._dsa_indexer_cache_params()
             if indexer_key_dim > 0 and num_indexer_layers > 0:
                 indexer_per_token = (
@@ -725,8 +726,6 @@ class ModelRunnerKVCacheMixin:
                     f"kv_lora_rank={kv_lora_rank}, qk_rope_head_dim={qk_rope_head_dim}."
                 )
 
-            # Same helper the cell-size budget uses, so the pool can never
-            # allocate a buffer the profiler did not account for.
             dsa_kwargs = {}
             indexer_key_dim, num_indexer_layers = self._dsa_indexer_cache_params()
             if indexer_key_dim > 0:

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -634,6 +634,16 @@ class ModelRunnerKVCacheMixin:
         if self.linear_recurrent_config is not None:
             from sgl_jax.srt.mem_cache.memory_pool import HybridLinearKVPool
 
+            # The DSA indexer slot space is built by `build_index_share_map`
+            # over every layer; the hybrid pool indexes full-ATTENTION layers
+            # only. Nothing reconciles the two, and `HybridLinearKVPool` does
+            # not expose `get_indexer_key_buffer` at all, so such a config
+            # would allocate and budget indexer buffers and then die on the
+            # first full-indexer forward. Fail here with the reason instead.
+            assert not kvcache_kwargs.get(
+                "num_indexer_layers"
+            ), "hybrid-recurrent models do not support --attention-backend dsa_sparse"
+
             return HybridLinearKVPool(
                 size=self.max_total_num_tokens,
                 page_size=self.page_size,

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -308,6 +308,8 @@ class ModelRunnerKVCacheMixin:
             getattr(cfg, "index_skip_topk_offset", 0),
             cfg.num_hidden_layers,
         )
+        if num_full == 0:
+            return 0, 0
         return cfg.index_head_dim, num_full
 
     def _compute_cell_size(self: ModelRunner) -> int:
@@ -332,19 +334,11 @@ class ModelRunnerKVCacheMixin:
             cell_size = per_token * num_layers
 
             # DSA allocates a second paged buffer for indexer keys, one slot per
-            # "full" layer. It uses the same `get_kv_cache_shape` layout, so it
-            # costs the same per token with `kv_dim` replaced by the aligned
-            # indexer key dim.
-            # Note the two terms use different layer counts, deliberately: they
-            # mirror two different allocations. The latent buffer exists per
-            # KV-pool layer (`_kv_pool_layer_count`, which drops non-attention
-            # layers on hybrid-recurrent models); the indexer buffer exists per
-            # "full" layer, counted over the whole model by the same
-            # `build_index_share_map` the pool is constructed from. Budget
-            # matching allocation is the invariant here, not the two counts
-            # matching each other.
+            # "full" layer, in the same `get_kv_cache_shape` layout with `kv_dim`
+            # replaced by the aligned indexer key dim. Its layer count is per
+            # full layer over the whole model, not per KV-pool layer.
             indexer_key_dim, num_indexer_layers = self._dsa_indexer_cache_params()
-            if indexer_key_dim > 0 and num_indexer_layers > 0:
+            if indexer_key_dim > 0:
                 indexer_per_token = (
                     align128(indexer_key_dim) * aligned_ps * dtype_size // self.page_size
                 )

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -290,6 +290,30 @@ def _build_non_hybrid_memory_pools(token_to_kv_pool) -> MemoryPools:
 
 class ModelRunnerKVCacheMixin:
 
+    def _dsa_indexer_cache_params(self: ModelRunner) -> tuple[int, int]:
+        """``(indexer_key_dim, num_indexer_layers)`` for the DSA indexer key cache.
+
+        Returns ``(0, 0)`` when no indexer cache is allocated.
+
+        Single source of truth for the two places that must agree: the memory
+        *budget* (:meth:`_compute_cell_size`) and the actual *allocation*
+        (``MLATokenToKVPool._create_buffers``). They previously derived this
+        independently — in practice only the allocation side did — so the
+        profiler sized the KV pool as though the indexer buffer did not exist.
+        """
+        if self.server_args.attention_backend != "dsa_sparse":
+            return 0, 0
+
+        from sgl_jax.srt.kernels.dsa.ref import build_index_share_map
+
+        cfg = self.model_config.hf_text_config
+        _, _, num_full = build_index_share_map(
+            getattr(cfg, "indexer_types", None),
+            getattr(cfg, "index_skip_topk_offset", 0),
+            cfg.num_hidden_layers,
+        )
+        return cfg.index_head_dim, num_full
+
     def _compute_cell_size(self: ModelRunner) -> int:
         """Per-token KV cache cost in bytes per device, summed across layers."""
 
@@ -309,7 +333,23 @@ class ModelRunnerKVCacheMixin:
             kv_packing = 32 // dtype_bits
             aligned_ps = (self.page_size + kv_packing - 1) // kv_packing * kv_packing
             per_token = kv_dim * aligned_ps * dtype_size // self.page_size
-            return per_token * num_layers
+            cell_size = per_token * num_layers
+
+            # DSA allocates a SECOND paged buffer, for indexer keys, one slot per
+            # "full" layer (`MLATokenToKVPool._create_buffers`). It is laid out by
+            # the same `get_kv_cache_shape`, so it costs the same per token with
+            # `kv_dim` replaced by the aligned indexer key dim. Omitting it made
+            # the profiler over-provision the pool, and the excess came out of the
+            # (1 - mem_fraction) activation reserve rather than out of KV — the
+            # resource that actually binds at long context.
+            indexer_key_dim, num_indexer_layers = self._dsa_indexer_cache_params()
+            if indexer_key_dim > 0 and num_indexer_layers > 0:
+                indexer_per_token = (
+                    align128(indexer_key_dim) * aligned_ps * dtype_size // self.page_size
+                )
+                cell_size += indexer_per_token * num_indexer_layers
+
+            return cell_size
 
         swa_num_kv_heads = getattr(self.model_config.hf_config, "swa_num_key_value_heads", None)
         if swa_num_kv_heads is not None:
@@ -685,17 +725,13 @@ class ModelRunnerKVCacheMixin:
                     f"kv_lora_rank={kv_lora_rank}, qk_rope_head_dim={qk_rope_head_dim}."
                 )
 
+            # Same helper the cell-size budget uses, so the pool can never
+            # allocate a buffer the profiler did not account for.
             dsa_kwargs = {}
-            if self.server_args.attention_backend == "dsa_sparse":
-                from sgl_jax.srt.kernels.dsa.ref import build_index_share_map
-
-                _, _, num_full = build_index_share_map(
-                    getattr(hf_text_config, "indexer_types", None),
-                    getattr(hf_text_config, "index_skip_topk_offset", 0),
-                    hf_text_config.num_hidden_layers,
-                )
-                dsa_kwargs["indexer_key_dim"] = hf_text_config.index_head_dim
-                dsa_kwargs["num_indexer_layers"] = num_full
+            indexer_key_dim, num_indexer_layers = self._dsa_indexer_cache_params()
+            if indexer_key_dim > 0:
+                dsa_kwargs["indexer_key_dim"] = indexer_key_dim
+                dsa_kwargs["num_indexer_layers"] = num_indexer_layers
 
             self.token_to_kv_pool = self._maybe_wrap_hybrid_kv_pool(
                 MLATokenToKVPool,

--- a/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
@@ -57,7 +57,15 @@ def test_recurrent_admission_cap_already_aligned_unchanged():
 class _CellSizeRunner(ModelRunnerKVCacheMixin):
     """Minimal stand-in exposing only what _compute_cell_size reads."""
 
-    def __init__(self, attention_backend, num_layers=78, page_size=128):
+    def __init__(
+        self,
+        attention_backend,
+        num_layers=78,
+        page_size=128,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+        index_head_dim=128,
+    ):
         import jax.numpy as jnp
 
         self.kv_cache_dtype = jnp.bfloat16
@@ -71,10 +79,10 @@ class _CellSizeRunner(ModelRunnerKVCacheMixin):
             indexer_types[i] = "full"
         self.model_config = types.SimpleNamespace(
             hf_text_config=types.SimpleNamespace(
-                kv_lora_rank=512,
-                qk_rope_head_dim=64,
+                kv_lora_rank=kv_lora_rank,
+                qk_rope_head_dim=qk_rope_head_dim,
                 num_hidden_layers=num_layers,
-                index_head_dim=128,
+                index_head_dim=index_head_dim,
                 index_skip_topk_offset=3,
                 indexer_types=indexer_types,
             )
@@ -87,11 +95,9 @@ class _CellSizeRunner(ModelRunnerKVCacheMixin):
 def _allocated_bytes_per_token(kv_dim, page_size=128):
     """Per-token bytes the POOL would allocate for a buffer of this width.
 
-    Derived from `get_kv_cache_shape` — the function `_create_buffers` actually
-    allocates with — rather than from hand arithmetic. The budget open-codes the
-    formula, so this keeps the test pinning budget-against-allocation instead of
-    budget-against-a-comment; if the alignment or packing rule ever changes, the
-    allocation moves and these assertions move with it.
+    Derived from `get_kv_cache_shape` — what `_create_buffers` allocates with —
+    so these assertions pin the budget against the allocation, and follow it if
+    the alignment or packing rule changes.
     """
     import jax.numpy as jnp
 
@@ -126,11 +132,28 @@ def test_cell_size_includes_dsa_indexer_cache():
     assert cell > _MLA_BYTES_PER_TOKEN
 
 
-def test_dsa_indexer_params_report_the_full_layer_count():
-    """21 of GLM-5.2's 78 layers are "full" and each gets an indexer buffer.
+@pytest.mark.parametrize("page_size", [1, 64, 128])
+def test_cell_size_pads_page_size_to_the_kv_packing_boundary(page_size):
+    """With bf16 (packing=2) and page_size=1 a page holds 2 slots for 1 token,
+    so the per-token cost is double the naive width. Both terms pay it."""
+    cell = _CellSizeRunner("dsa_sparse", page_size=page_size)._compute_cell_size()
+    assert cell == _allocated_bytes_per_token(640, page_size) * 78 + (
+        _allocated_bytes_per_token(128, page_size) * 21
+    )
 
-    Asserted against the concrete expected count rather than against a second
-    call to `build_index_share_map`, which no plausible implementation could fail.
-    """
+
+def test_cell_size_pads_latent_segments_independently():
+    """The latent width is align(lora,128) + align(rope,128), NOT
+    align(lora + rope, 128) — the kernel slices nope and rope as adjacent
+    buffers. lora=192/rope=64 separates the two formulas (384 vs 256); the
+    GLM/DeepSeek shape (512/64) does not, since both give 640."""
+    cell = _CellSizeRunner(
+        "fa", kv_lora_rank=192, qk_rope_head_dim=64
+    )._compute_cell_size()
+    assert cell == _allocated_bytes_per_token(256 + 128) * 78
+
+
+def test_dsa_indexer_params_report_the_full_layer_count():
+    """21 of GLM-5.2's 78 layers are "full" and each gets an indexer buffer."""
     assert _CellSizeRunner("dsa_sparse")._dsa_indexer_cache_params() == (128, 21)
     assert _CellSizeRunner("fa")._dsa_indexer_cache_params() == (0, 0)

--- a/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
@@ -209,6 +209,8 @@ def test_allocated_bytes_match_the_budget_and_the_report():
 
     # Reporting: what the scheduler's `kvcache` gauge and the startup log show.
     assert pool.get_kv_size_bytes() == resident
+    # `mem_usage` (the startup log) is the same total, not a parallel sum.
+    assert pool.mem_usage == pytest.approx(resident / 1024**3)
 
     # Budgeting: what the profiler sizes the pool against.
     cell = runner._compute_cell_size()

--- a/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
@@ -147,9 +147,7 @@ def test_cell_size_pads_latent_segments_independently():
     align(lora + rope, 128) — the kernel slices nope and rope as adjacent
     buffers. lora=192/rope=64 separates the two formulas (384 vs 256); the
     GLM/DeepSeek shape (512/64) does not, since both give 640."""
-    cell = _CellSizeRunner(
-        "fa", kv_lora_rank=192, qk_rope_head_dim=64
-    )._compute_cell_size()
+    cell = _CellSizeRunner("fa", kv_lora_rank=192, qk_rope_head_dim=64)._compute_cell_size()
     assert cell == _allocated_bytes_per_token(256 + 128) * 78
 
 

--- a/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
@@ -254,3 +254,40 @@ def test_latent_only_budget_overshoots_the_available_memory():
     # Post-fix: sized with the indexer counted, only the spare page is left over.
     fitted = _resident_bytes(_build_pool(runner, pool_size_for(runner._compute_cell_size()), mesh))
     assert 0 < fitted <= budget + slack
+
+
+class _HybridDSARunner(_CellSizeRunner):
+    """A DSA runner that also reports as hybrid-recurrent.
+
+    `linear_recurrent_config` is a read-only property derived from `hf_config`;
+    overriding it here keeps the test off the per-architecture config sniffing.
+    """
+
+    @property
+    def linear_recurrent_config(self):
+        return types.SimpleNamespace(full_attention_layer_ids=[0, 4])
+
+
+def test_hybrid_pool_rejects_a_dsa_indexer_cache():
+    """The DSA indexer slot space spans every layer; the hybrid pool indexes
+    full-attention layers only, and never exposes `get_indexer_key_buffer`.
+    Such a config would allocate and budget the indexer buffers, then die on
+    the first full-indexer forward — so refuse it at startup instead."""
+    runner = _HybridDSARunner("dsa_sparse", num_layers=8)
+    runner.max_total_num_tokens = 256
+    runner.mesh = None  # never reached: the assert fires before allocation
+
+    indexer_key_dim, num_indexer_layers = runner._dsa_indexer_cache_params()
+    assert num_indexer_layers > 0, "test needs a DSA indexer buffer to reject"
+
+    from sgl_jax.srt.mem_cache.memory_pool import MLATokenToKVPool
+
+    with pytest.raises(AssertionError, match="dsa_sparse"):
+        runner._maybe_wrap_hybrid_kv_pool(
+            MLATokenToKVPool,
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            dp_size=1,
+            indexer_key_dim=indexer_key_dim,
+            num_indexer_layers=num_indexer_layers,
+        )

--- a/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
@@ -234,7 +234,8 @@ def test_latent_only_budget_overshoots_the_available_memory():
     mesh = _single_device_mesh()
     page = runner.page_size
 
-    def pages_for(cell_size):
+    def pool_size_for(cell_size):
+        """Page-aligned token count that fits the budget at this per-token cost."""
         return (budget // cell_size) // page * page
 
     # Every pool carries one unbudgeted spare page per DP rank per layer
@@ -245,9 +246,9 @@ def test_latent_only_budget_overshoots_the_available_memory():
 
     # Pre-fix: the latent-only cell size, i.e. what a non-DSA config is charged.
     latent_only_cell = _CellSizeRunner("fa", num_layers=8)._compute_cell_size()
-    over = _resident_bytes(_build_pool(runner, pages_for(latent_only_cell), mesh))
+    over = _resident_bytes(_build_pool(runner, pool_size_for(latent_only_cell), mesh))
     assert over - budget > slack
 
     # Post-fix: sized with the indexer counted, only the spare page is left over.
-    fitted = _resident_bytes(_build_pool(runner, pages_for(runner._compute_cell_size()), mesh))
+    fitted = _resident_bytes(_build_pool(runner, pool_size_for(runner._compute_cell_size()), mesh))
     assert 0 < fitted <= budget + slack

--- a/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
@@ -133,10 +133,13 @@ def test_cell_size_includes_dsa_indexer_cache():
     assert cell > _MLA_BYTES_PER_TOKEN
 
 
-@pytest.mark.parametrize("page_size", [1, 64, 128])
+@pytest.mark.parametrize("page_size", [1, 128])
 def test_cell_size_pads_page_size_to_the_kv_packing_boundary(page_size):
     """With bf16 (packing=2) and page_size=1 a page holds 2 slots for 1 token,
-    so the per-token cost is double the naive width. Both terms pay it."""
+    so the per-token cost is double the naive width. Both terms pay it.
+
+    Only page_size=1 exercises the pad; 128 is the production value and stands
+    in for every even page size (they all leave `aligned_ps == page_size`)."""
     cell = _CellSizeRunner("dsa_sparse", page_size=page_size)._compute_cell_size()
     assert cell == _allocated_bytes_per_token(640, page_size) * 78 + (
         _allocated_bytes_per_token(128, page_size) * 21
@@ -150,12 +153,6 @@ def test_cell_size_pads_latent_segments_independently():
     GLM/DeepSeek shape (512/64) does not, since both give 640."""
     cell = _CellSizeRunner("fa", kv_lora_rank=192, qk_rope_head_dim=64)._compute_cell_size()
     assert cell == _allocated_bytes_per_token(256 + 128) * 78
-
-
-def test_dsa_indexer_params_report_the_full_layer_count():
-    """21 of GLM-5.2's 78 layers are "full" and each gets an indexer buffer."""
-    assert _CellSizeRunner("dsa_sparse")._dsa_indexer_cache_params() == (128, 21)
-    assert _CellSizeRunner("fa")._dsa_indexer_cache_params() == (0, 0)
 
 
 def _single_device_mesh():

--- a/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
@@ -78,6 +78,7 @@ class _CellSizeRunner(ModelRunnerKVCacheMixin):
         for i in (0, 1, 2, *range(6, num_layers, 4)):
             indexer_types[i] = "full"
         self.model_config = types.SimpleNamespace(
+            hf_config=types.SimpleNamespace(),
             hf_text_config=types.SimpleNamespace(
                 kv_lora_rank=kv_lora_rank,
                 qk_rope_head_dim=qk_rope_head_dim,
@@ -85,7 +86,7 @@ class _CellSizeRunner(ModelRunnerKVCacheMixin):
                 index_head_dim=index_head_dim,
                 index_skip_topk_offset=3,
                 indexer_types=indexer_types,
-            )
+            ),
         )
 
     def _kv_pool_layer_count(self):
@@ -155,3 +156,101 @@ def test_dsa_indexer_params_report_the_full_layer_count():
     """21 of GLM-5.2's 78 layers are "full" and each gets an indexer buffer."""
     assert _CellSizeRunner("dsa_sparse")._dsa_indexer_cache_params() == (128, 21)
     assert _CellSizeRunner("fa")._dsa_indexer_cache_params() == (0, 0)
+
+
+def _single_device_mesh():
+    import jax
+
+    return jax.make_mesh((1,), ("data",))
+
+
+def _build_pool(runner, size, mesh, dp_size=1):
+    """Build the real pool this runner's config would allocate at `size` tokens."""
+    import jax.numpy as jnp
+
+    from sgl_jax.srt.mem_cache.memory_pool import MLATokenToKVPool
+
+    cfg = runner.model_config.hf_text_config
+    indexer_key_dim, num_indexer_layers = runner._dsa_indexer_cache_params()
+    return MLATokenToKVPool(
+        size=size,
+        page_size=runner.page_size,
+        dtype=jnp.bfloat16,
+        kv_lora_rank=cfg.kv_lora_rank,
+        qk_rope_head_dim=cfg.qk_rope_head_dim,
+        layer_num=runner._kv_pool_layer_count(),
+        mesh=mesh,
+        dp_size=dp_size,
+        indexer_key_dim=indexer_key_dim,
+        num_indexer_layers=num_indexer_layers,
+    )
+
+
+def _resident_bytes(pool):
+    """Bytes actually held by the pool's live buffers, measured not derived."""
+    return sum(b.nbytes for b in pool.kv_buffer) + sum(b.nbytes for b in pool.indexer_key_buffer)
+
+
+def test_allocated_bytes_match_the_budget_and_the_report():
+    """Budget, report, and allocation must agree on one live pool.
+
+    The other tests compare the budget against `get_kv_cache_shape`; this one
+    compares it against the bytes of the arrays that actually got allocated,
+    which is the invariant the DSA indexer buffer broke.
+
+    The pool allocates `size + page_size * dp_size` tokens' worth of pages —
+    one spare page per DP rank, per layer — which `_compute_cell_size` has
+    never counted. That slack is pre-existing and independent of DSA; expressing
+    it as `cell * page_size * dp_size` keeps it visible instead of absorbed.
+    """
+    runner = _CellSizeRunner("dsa_sparse", num_layers=8)
+    assert runner._dsa_indexer_cache_params()[1] > 0, "test needs a DSA indexer buffer"
+
+    size = 256
+    pool = _build_pool(runner, size, _single_device_mesh())
+    resident = _resident_bytes(pool)
+
+    # Reporting: what the scheduler's `kvcache` gauge and the startup log show.
+    assert pool.get_kv_size_bytes() == resident
+
+    # Budgeting: what the profiler sizes the pool against.
+    cell = runner._compute_cell_size()
+    assert resident == cell * (size + runner.page_size * 1)
+
+
+def test_latent_only_budget_overshoots_the_available_memory():
+    """Reproduce the production over-provisioning without a TPU.
+
+    Sizing a DSA pool with the pre-fix, latent-only budget (what a non-DSA
+    config is charged) makes it allocate more than the profiler said was
+    available — the excess coming out of the activation reserve. The fixed
+    budget fits.
+    """
+    runner = _CellSizeRunner("dsa_sparse", num_layers=8)
+    available = 16 * 1024 * 1024
+    runner.get_available_device_memory = lambda: available
+    runner.mem_fraction_static = 1.0
+
+    budget = runner._profile_available_bytes(total_device_memory=0)
+    assert budget == available
+
+    mesh = _single_device_mesh()
+    page = runner.page_size
+
+    def pages_for(cell_size):
+        return (budget // cell_size) // page * page
+
+    # Every pool carries one unbudgeted spare page per DP rank per layer
+    # (`_create_buffers` allocates `size + page_size * dp_size` tokens). That
+    # slack predates DSA and bounds how far a correctly budgeted pool may
+    # exceed the profiled budget.
+    slack = runner._compute_cell_size() * page
+
+    # Pre-fix: the latent-only cell size, i.e. what a non-DSA config is charged.
+    latent_only_cell = _CellSizeRunner("fa", num_layers=8)._compute_cell_size()
+    over = _resident_bytes(_build_pool(runner, pages_for(latent_only_cell), mesh))
+    assert over - budget > slack
+
+    # Post-fix: sized with the indexer counted, only the spare page is left over.
+    fitted = _resident_bytes(_build_pool(runner, pages_for(runner._compute_cell_size()), mesh))
+    assert 0 < fitted <= budget + slack

--- a/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
@@ -54,11 +54,6 @@ def test_recurrent_admission_cap_already_aligned_unchanged():
     assert cap == 8
 
 
-# ---------------------------------------------------------------------------
-# _compute_cell_size must budget the DSA indexer key cache
-# ---------------------------------------------------------------------------
-
-
 class _CellSizeRunner(ModelRunnerKVCacheMixin):
     """Minimal stand-in exposing only what _compute_cell_size reads."""
 
@@ -89,11 +84,30 @@ class _CellSizeRunner(ModelRunnerKVCacheMixin):
         return self._num_layers
 
 
-# align128(512) + align128(64) = 640 dims; 640 * 128 * 2 // 128 = 1280 B/layer.
-_MLA_BYTES_PER_TOKEN = 1280 * 78
-# The indexer cache uses the same layout with kv_dim = align128(128) = 128,
-# i.e. 256 B/layer over the 21 "full" layers.
-_INDEXER_BYTES_PER_TOKEN = 256 * 21
+def _allocated_bytes_per_token(kv_dim, page_size=128):
+    """Per-token bytes the POOL would allocate for a buffer of this width.
+
+    Derived from `get_kv_cache_shape` — the function `_create_buffers` actually
+    allocates with — rather than from hand arithmetic. The budget open-codes the
+    formula, so this keeps the test pinning budget-against-allocation instead of
+    budget-against-a-comment; if the alignment or packing rule ever changes, the
+    allocation moves and these assertions move with it.
+    """
+    import jax.numpy as jnp
+
+    from sgl_jax.srt.kernels.mla.v2.kernel import get_kv_cache_shape
+
+    pages, rows, packing, dim = get_kv_cache_shape(
+        total_num_pages=1, page_size=page_size, kv_dim=kv_dim, kv_dtype=jnp.bfloat16
+    )
+    per_page = pages * rows * packing * dim * jnp.dtype(jnp.bfloat16).itemsize
+    return per_page // page_size
+
+
+# GLM-5.2: latent width align128(512) + align128(64) = 640, over 78 layers.
+_MLA_BYTES_PER_TOKEN = _allocated_bytes_per_token(640) * 78
+# Indexer keys: align128(128) = 128, over the 21 "full" layers.
+_INDEXER_BYTES_PER_TOKEN = _allocated_bytes_per_token(128) * 21
 
 
 def test_cell_size_excludes_indexer_for_non_dsa_mla():
@@ -112,14 +126,11 @@ def test_cell_size_includes_dsa_indexer_cache():
     assert cell > _MLA_BYTES_PER_TOKEN
 
 
-def test_dsa_indexer_params_match_index_share_map():
-    """The helper must agree with the map the pool itself is built from."""
-    from sgl_jax.srt.kernels.dsa.ref import build_index_share_map
+def test_dsa_indexer_params_report_the_full_layer_count():
+    """21 of GLM-5.2's 78 layers are "full" and each gets an indexer buffer.
 
-    runner = _CellSizeRunner("dsa_sparse")
-    cfg = runner.model_config.hf_text_config
-    _, _, num_full = build_index_share_map(
-        cfg.indexer_types, cfg.index_skip_topk_offset, cfg.num_hidden_layers
-    )
-    assert runner._dsa_indexer_cache_params() == (cfg.index_head_dim, num_full)
+    Asserted against the concrete expected count rather than against a second
+    call to `build_index_share_map`, which no plausible implementation could fail.
+    """
+    assert _CellSizeRunner("dsa_sparse")._dsa_indexer_cache_params() == (128, 21)
     assert _CellSizeRunner("fa")._dsa_indexer_cache_params() == (0, 0)

--- a/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/test/test_model_runner_kv_cache_mixin.py
@@ -52,3 +52,74 @@ def test_recurrent_admission_cap_already_aligned_unchanged():
     # 16 // 2 = 8 is already a dp_size=4 multiple.
     cap = ModelRunnerKVCacheMixin._resolve_max_num_reqs(_fake_runner(16, 4), 1000)
     assert cap == 8
+
+
+# ---------------------------------------------------------------------------
+# _compute_cell_size must budget the DSA indexer key cache
+# ---------------------------------------------------------------------------
+
+
+class _CellSizeRunner(ModelRunnerKVCacheMixin):
+    """Minimal stand-in exposing only what _compute_cell_size reads."""
+
+    def __init__(self, attention_backend, num_layers=78, page_size=128):
+        import jax.numpy as jnp
+
+        self.kv_cache_dtype = jnp.bfloat16
+        self.page_size = page_size
+        self.use_mla_backend = True
+        self._num_layers = num_layers
+        self.server_args = ServerArgs(model_path="dummy", attention_backend=attention_backend)
+        # GLM-5.2 shape: "full" at layers 0-2, then every 4th, giving 21 full layers.
+        indexer_types = ["shared"] * num_layers
+        for i in (0, 1, 2, *range(6, num_layers, 4)):
+            indexer_types[i] = "full"
+        self.model_config = types.SimpleNamespace(
+            hf_text_config=types.SimpleNamespace(
+                kv_lora_rank=512,
+                qk_rope_head_dim=64,
+                num_hidden_layers=num_layers,
+                index_head_dim=128,
+                index_skip_topk_offset=3,
+                indexer_types=indexer_types,
+            )
+        )
+
+    def _kv_pool_layer_count(self):
+        return self._num_layers
+
+
+# align128(512) + align128(64) = 640 dims; 640 * 128 * 2 // 128 = 1280 B/layer.
+_MLA_BYTES_PER_TOKEN = 1280 * 78
+# The indexer cache uses the same layout with kv_dim = align128(128) = 128,
+# i.e. 256 B/layer over the 21 "full" layers.
+_INDEXER_BYTES_PER_TOKEN = 256 * 21
+
+
+def test_cell_size_excludes_indexer_for_non_dsa_mla():
+    """`fa` allocates no indexer buffer, so it must not be charged for one."""
+    assert _CellSizeRunner("fa")._compute_cell_size() == _MLA_BYTES_PER_TOKEN
+
+
+def test_cell_size_includes_dsa_indexer_cache():
+    """`MLATokenToKVPool._create_buffers` allocates a second paged buffer for
+    DSA indexer keys. Budgeting only the latent KV over-provisions the pool, and
+    the excess is taken from the activation reserve rather than from KV."""
+    cell = _CellSizeRunner("dsa_sparse")._compute_cell_size()
+    assert cell == _MLA_BYTES_PER_TOKEN + _INDEXER_BYTES_PER_TOKEN
+    # Guard the regression direction explicitly: under-counting here is what
+    # silently eats the (1 - mem_fraction) reserve.
+    assert cell > _MLA_BYTES_PER_TOKEN
+
+
+def test_dsa_indexer_params_match_index_share_map():
+    """The helper must agree with the map the pool itself is built from."""
+    from sgl_jax.srt.kernels.dsa.ref import build_index_share_map
+
+    runner = _CellSizeRunner("dsa_sparse")
+    cfg = runner.model_config.hf_text_config
+    _, _, num_full = build_index_share_map(
+        cfg.indexer_types, cfg.index_skip_topk_offset, cfg.num_hidden_layers
+    )
+    assert runner._dsa_indexer_cache_params() == (cfg.index_head_dim, num_full)
+    assert _CellSizeRunner("fa")._dsa_indexer_cache_params() == (0, 0)


### PR DESCRIPTION
## Motivation

Resolves #1533.

With `--attention-backend dsa_sparse`, `MLATokenToKVPool._create_buffers` allocates a **second** paged buffer for the DSA indexer keys — one slot per "full" layer — but `_compute_cell_size` counts only the MLA latent buffer. The profiler sizes the KV pool as though that buffer did not exist, so the pool over-allocates on every `dsa_sparse` config.

The excess does not come out of the KV budget; it comes out of the `(1 - mem_fraction_static)` activation reserve, which is what actually binds at long context. The failure is silent: the server starts, reports a healthy pool, and has less headroom than requested.

Measured on GLM-5.2-FP8 (TPU v7x, tp16 ep16 dp2, page_size 128, bf16), from one server's own startup log:

```
available_kv_cache = 8.70 GiB   <- budget the profiler sizes against
KV buffer          = 8.75 GiB   (17.50 GB global / dp2)
indexer buffer     = 0.47 GiB   (0.94 GB global / dp2)  <- not counted
allocated          = 9.22 GiB   => 5.4% over budget
```

The indexer buffer is laid out by the same `get_kv_cache_shape`, so it costs the same per token with `kv_dim` replaced by the aligned indexer key dim: `align128(128) * 128 * 2 / 128 = 256 B/layer`, and `256 * 21` full layers = 5,376 B/token against the latent's 99,840 — matching the 0.94 GB the pool logs.

Introduced in #1478, which added the indexer key buffer.

## Modifications

1. **Budget the indexer buffer** (`model_runner_kv_cache_mixin.py`). New helper `_dsa_indexer_cache_params()` returns `(indexer_key_dim, num_indexer_layers)`, or `(0, 0)` when no indexer cache is allocated. Both `_compute_cell_size` (the budget) and the `MLATokenToKVPool` construction (the allocation) now derive the geometry from that one helper, so they cannot drift apart again — the allocation site already computed these numbers and the sizing site simply never asked for them.

   The two terms of the sum use different layer counts on purpose: latent per KV-pool layer (which drops non-attention layers on hybrid-recurrent models), indexer per "full" layer over the whole model. Budget matching *allocation* is the invariant, not the two counts matching each other.

2. **Report the indexer buffer** (`memory_pool.py`). `_buffer_bytes` sized only the latent buffer, so `mem_usage`, the `JAX MLA KV Cache allocated` log line, and `get_kv_size_bytes` (which feeds the scheduler's `kvcache` gauge) all under-reported resident HBM by the indexer's share — an operator reading the startup log saw 8.75 GB where 9.22 GB was resident. The log line now breaks out latent and indexer, and only when an indexer buffer exists (plain MLA deployments get the original line back).

Non-DSA MLA (`fa`) is unaffected: it allocates no indexer buffer and is charged for none.

## Accuracy Tests

Not applicable — no kernel or model forward code is touched. The change affects only how many tokens the pool is sized for and what the pool reports.

## Benchmarking and Profiling

No throughput or latency impact: the same buffers are allocated, they are now counted. The user-visible effect is that `max_tokens` on a `dsa_sparse` config drops by the indexer's share (~5% on GLM-5.2), which is the over-provisioning being removed — the reserve it was taken from is returned.

## Test plan

`python/sgl_jax/test/test_model_runner_kv_cache_mixin.py`, already collected by the `unit-test-cpu` suite — no TPU needed:

```bash
uv pip install -e "python[cpu]"
python -m pytest python/sgl_jax/test/test_model_runner_kv_cache_mixin.py -q   # 11 passed
```

Seven new cases, in two layers:

- **Budget vs. layout** — the indexer is charged on `dsa_sparse` and not on `fa`; the bf16 packing pad is covered at `page_size` 1 and 128; and the latent width is pinned as `align(lora,128) + align(rope,128)`, *not* `align(lora + rope, 128)` (the kernel slices nope and rope as adjacent buffers; `lora=192/rope=64` separates the two formulas, the GLM/DeepSeek 512/64 shape does not). Expected byte counts are derived from `get_kv_cache_shape` — the function `_create_buffers` allocates with — so the tests follow the alignment rule if it changes instead of pinning a stale constant.
- **Budget vs. allocation** — two cases build a real `MLATokenToKVPool` on a single-device CPU mesh and compare the budget against `b.nbytes` of the buffers that actually got allocated, which is the invariant that broke. One pins resident bytes against both `get_kv_size_bytes()` and `cell_size * (size + page_size * dp_size)`; the other reproduces the production over-provisioning without hardware — sizing a DSA pool with the latent-only budget allocates past `_profile_available_bytes`, while the fixed budget stays within it.

Verified by mutation: reverting the budget fix fails 5 of the 7; reverting only the `get_kv_size_bytes` reporting fix fails the allocation test. Both reverts were run against this branch on jax 0.10.2 CPU.

### Note for reviewers (out of scope here)

`_create_buffers` allocates `(size + page_size * dp_size) // page_size` pages — one spare page per DP rank, per layer — which `_compute_cell_size` has never counted. It predates this change and is tiny at production sizes (~0.1%), so it is left alone; the allocation tests name it as explicit slack rather than absorb it into a loose assertion. Happy to fix it here or in a follow-up if you prefer.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, and the issue it resolves (#1533).
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
