### PR TITLE
ci: disable post-merge PR Test to free TPU runner capacity

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,10 +1,6 @@
 name: PR Test
 
 on:
-  push:
-    branches:
-      - main
-      - "epic/*"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
     branches:


### PR DESCRIPTION
## Summary

- Remove `push: main` trigger from `pr-test.yml` so that merging to main no longer re-runs the full PR Test suite
- This frees up scarce TPU runners (`arc-runner-v6e-1` / `arc-runner-v6e-4`) for actual PR validation
- Post-merge coverage continues via Nightly Test Daily (scheduled)

## Context

Multiple CI jobs have been queued **8-17+ hours** because post-merge runs compete with PR CI for the same TPU runner pool. With the current resource constraints, the post-merge full test is redundant (the PR already passed the same tests before merge) and blocking developer velocity.

## Test plan

- [ ] Verify that merging a PR to main no longer triggers a `PR Test` run
- [ ] Confirm PR CI still triggers normally on `pull_request` events
- [ ] Monitor runner queue depth over the next 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)