### PR TITLE
perf(vlm): parallelize multimodal preprocessing

### DIFF
--- a/python/sgl_jax/srt/entrypoints/engine.py
+++ b/python/sgl_jax/srt/entrypoints/engine.py
@@ -302,8 +302,14 @@ class Engine(EngineBase):
 
     def shutdown(self):
         """Shutdown the engine"""
+        tokenizer_manager = getattr(self, "tokenizer_manager", None)
+        if tokenizer_manager is not None:
+            tokenizer_manager.shutdown()
         kill_process_tree(os.getpid(), include_parent=False)
-        if self.server_args.enable_single_process:
+        if (
+            getattr(self, "server_args", None) is not None
+            and self.server_args.enable_single_process
+        ):
             self.send_to_rpc.close()
 
     def __enter__(self):

--- a/python/sgl_jax/srt/entrypoints/http_server.py
+++ b/python/sgl_jax/srt/entrypoints/http_server.py
@@ -127,7 +127,10 @@ async def lifespan(fast_api_app: FastAPI):
     warmup_thread = getattr(fast_api_app, "warmup_thread", None)
     if warmup_thread is not None:
         warmup_thread.start()
-    yield
+    try:
+        yield
+    finally:
+        _global_state.tokenizer_manager.shutdown()
 
 
 # Fast API

--- a/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
+++ b/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
@@ -159,6 +159,7 @@ class OpenAIServingChat(OpenAIServingBase):
         """Apply Jinja chat template"""
         prompt = ""
         prompt_ids = []
+        prompt_from_mm_template = False
         openai_compatible_messages = []
         image_data = []
         video_data = []
@@ -237,7 +238,10 @@ Assistant: {% endif %}"""
                     tools=tools,
                     **chat_template_kwargs,
                 )
-                prompt_ids = self.tokenizer_manager.tokenizer.encode(prompt)
+                # The multimodal processor consumes this string and tokenizes it
+                # together with the image inputs later. Avoid encoding it here
+                # only to immediately decode it below.
+                prompt_from_mm_template = True
             else:
                 prompt_ids = self.tokenizer_manager.tokenizer.apply_chat_template(
                     openai_compatible_messages,
@@ -265,12 +269,17 @@ Assistant: {% endif %}"""
             prompt_ids = prompt_ids["input_ids"]
 
         if assistant_prefix:
+            # Preserve the existing token-level concatenation semantics for the
+            # uncommon continue_final_message path.
+            if prompt_from_mm_template:
+                prompt_ids = self.tokenizer_manager.tokenizer.encode(prompt)
+                prompt_from_mm_template = False
             encoded = self.tokenizer_manager.tokenizer.encode(assistant_prefix)
             if encoded and encoded[0] == self.tokenizer_manager.tokenizer.bos_token_id:
                 encoded = encoded[1:]
             prompt_ids += encoded
 
-        if is_multimodal:
+        if is_multimodal and not prompt_from_mm_template:
             prompt = self.tokenizer_manager.tokenizer.decode(prompt_ids)
 
         stop = request.stop

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -200,6 +200,7 @@ class TokenizerManager:
                     tokenizer_mode=server_args.tokenizer_mode,
                     trust_remote_code=server_args.trust_remote_code,
                     revision=server_args.revision,
+                    use_fast=True,
                 )
                 self.mm_processor = mm_processor_cls(
                     self.model_config.hf_config, server_args, self.processor

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -228,6 +228,7 @@ class TokenizerManager:
         self.rid_to_state: dict[str, ReqState] = {}
         self.health_check_failed = False
         self.gracefully_exit = False
+        self._shutdown = False
         self.last_receive_tstamp = 0
         self.dump_requests_folder = ""  # By default do not dump
         self.dump_requests_threshold = 1000
@@ -293,6 +294,13 @@ class TokenizerManager:
             ]
         )
         self.wait_timeout = int(os.environ.get("SGLANG_WAIT_TIMEOUT", "4"))
+
+    def shutdown(self):
+        if self._shutdown:
+            return
+        self._shutdown = True
+        if self.mm_processor is not None:
+            self.mm_processor.shutdown()
 
     async def generate_request(
         self,
@@ -1111,6 +1119,7 @@ class TokenizerManager:
                 self.dump_requests_before_crash()
                 break
 
+        self.shutdown()
         kill_process_tree(os.getpid(), include_parent=True)
         sys.exit(0)
 

--- a/python/sgl_jax/srt/multimodal/processors/base_processor.py
+++ b/python/sgl_jax/srt/multimodal/processors/base_processor.py
@@ -21,6 +21,10 @@ IMAGE_IO_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
     max_workers=8,
     thread_name_prefix="image-data-executor",
 )
+HF_PROCESSOR_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=4,
+    thread_name_prefix="hf-mm-processor",
+)
 
 
 def _fetch_url(url: str) -> bytes:
@@ -116,3 +120,25 @@ class BaseMultimodalProcessor(ABC):
     async def load_image_async(cls, source) -> Image.Image:
         future = IMAGE_IO_EXECUTOR.submit(cls.load_image, source)
         return await asyncio.wrap_future(future)
+
+    async def _run_hf_processor_async(
+        self,
+        input_text: str,
+        image_sources: list,
+        videos: list | None,
+        processor_kwargs: dict,
+    ):
+        def run_hf_processor():
+            kwargs = {
+                "text": [input_text],
+                "images": [self.load_image(source) for source in image_sources] or None,
+                "padding": True,
+                "return_tensors": "pt",
+                **processor_kwargs,
+            }
+            if videos is not None:
+                kwargs["videos"] = videos or None
+            return self.processor(**kwargs)
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(HF_PROCESSOR_EXECUTOR, run_hf_processor)

--- a/python/sgl_jax/srt/multimodal/processors/base_processor.py
+++ b/python/sgl_jax/srt/multimodal/processors/base_processor.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import concurrent.futures
 import io
+import logging
 import os
 from abc import ABC, abstractmethod
 from urllib.parse import unquote, urlparse
@@ -11,20 +12,14 @@ import requests
 from PIL import Image
 
 from sgl_jax.srt.multimodal.common.modality_enum import MultimodalInputs
+from sgl_jax.srt.multimodal.processors.executor import MultimodalProcessorExecutor
+
+logger = logging.getLogger(__name__)
 
 # Safety limits for fetching remote multimodal payloads. These are intentionally
 # conservative and should become configurable via ServerArgs.
 DEFAULT_HTTP_TIMEOUT_SECS = 30
 MAX_REMOTE_BYTES = 64 * 1024 * 1024  # 64 MiB hard cap per asset
-
-IMAGE_IO_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
-    max_workers=8,
-    thread_name_prefix="image-data-executor",
-)
-HF_PROCESSOR_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
-    max_workers=4,
-    thread_name_prefix="hf-mm-processor",
-)
 
 
 def _fetch_url(url: str) -> bytes:
@@ -69,11 +64,53 @@ def _normalize_image_source(source) -> bytes | str:
 
 class BaseMultimodalProcessor(ABC):
     models: tuple[str, ...] = ()
+    auto_mm_io_worker_num = 4
+    auto_mm_processor_worker_num = 1
+    supports_mm_processor_concurrency = False
 
     def __init__(self, hf_config, server_args, processor):
         self.hf_config = hf_config
         self.server_args = server_args
         self.processor = processor
+        self._shutdown = False
+
+        requested_io_workers = getattr(server_args, "mm_io_worker_num", 0)
+        env_io_workers = os.environ.get("SGLANG_IO_WORKERS")
+        self.mm_io_worker_num = (
+            requested_io_workers
+            or (int(env_io_workers) if env_io_workers is not None else 0)
+            or self.auto_mm_io_worker_num
+        )
+        if self.mm_io_worker_num <= 0:
+            raise ValueError("Multimodal I/O worker count must be positive.")
+        self.io_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.mm_io_worker_num,
+            thread_name_prefix="sgl-jax-mm-io",
+        )
+
+        self.mm_processor_worker_num = (
+            getattr(server_args, "mm_processor_worker_num", 0) or self.auto_mm_processor_worker_num
+        )
+        if self.mm_processor_worker_num <= 0:
+            raise ValueError("Multimodal processor worker count must be positive.")
+        if self.mm_processor_worker_num > 1 and not self.supports_mm_processor_concurrency:
+            logger.warning(
+                "%s does not support concurrent multimodal processing; using one worker.",
+                type(self).__name__,
+            )
+            self.mm_processor_worker_num = 1
+        try:
+            self.mm_processor_executor = MultimodalProcessorExecutor(
+                processor, self.mm_processor_worker_num
+            )
+        except Exception:
+            logger.warning(
+                "Unable to clone %s processor; using one worker.",
+                type(self).__name__,
+                exc_info=True,
+            )
+            self.mm_processor_worker_num = 1
+            self.mm_processor_executor = MultimodalProcessorExecutor(processor, 1)
 
     def apply_chat_template(self, *args, **kwargs):
         return self.processor.apply_chat_template(*args, **kwargs)
@@ -116,10 +153,12 @@ class BaseMultimodalProcessor(ABC):
             return Image.open(io.BytesIO(payload)).convert("RGB")
         return Image.open(payload).convert("RGB")
 
-    @classmethod
-    async def load_image_async(cls, source) -> Image.Image:
-        future = IMAGE_IO_EXECUTOR.submit(cls.load_image, source)
-        return await asyncio.wrap_future(future)
+    async def _run_io_async(self, function, *args):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self.io_executor, function, *args)
+
+    async def load_image_async(self, source) -> Image.Image:
+        return await self._run_io_async(self.load_image, source)
 
     async def _run_hf_processor_async(
         self,
@@ -128,17 +167,25 @@ class BaseMultimodalProcessor(ABC):
         videos: list | None,
         processor_kwargs: dict,
     ):
-        def run_hf_processor():
+        images = await asyncio.gather(*(self.load_image_async(source) for source in image_sources))
+
+        def run_hf_processor(*, processor):
             kwargs = {
                 "text": [input_text],
-                "images": [self.load_image(source) for source in image_sources] or None,
+                "images": images or None,
                 "padding": True,
                 "return_tensors": "pt",
                 **processor_kwargs,
             }
             if videos is not None:
                 kwargs["videos"] = videos or None
-            return self.processor(**kwargs)
+            return processor(**kwargs)
 
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(HF_PROCESSOR_EXECUTOR, run_hf_processor)
+        return await self.mm_processor_executor.run(run_hf_processor)
+
+    def shutdown(self) -> None:
+        if self._shutdown:
+            return
+        self._shutdown = True
+        self.io_executor.shutdown(wait=False, cancel_futures=True)
+        self.mm_processor_executor.shutdown()

--- a/python/sgl_jax/srt/multimodal/processors/executor.py
+++ b/python/sgl_jax/srt/multimodal/processors/executor.py
@@ -1,0 +1,47 @@
+import asyncio
+import concurrent.futures
+import copy
+import threading
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+
+class _WorkerState(threading.local):
+    processor: Any = None
+
+
+class MultimodalProcessorExecutor:
+    def __init__(self, processor: Any, max_workers: int):
+        self._processors = (
+            [processor]
+            if max_workers == 1
+            else [copy.deepcopy(processor) for _ in range(max_workers)]
+        )
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="sgl-jax-mm-processor",
+        )
+        self._worker_state = _WorkerState()
+        self._processor_lock = threading.Lock()
+
+    async def run(self, function: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, self._run, function, args, kwargs)
+
+    def _run(
+        self,
+        function: Callable[..., T],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> T:
+        processor = self._worker_state.processor
+        if processor is None:
+            with self._processor_lock:
+                processor = self._processors.pop()
+            self._worker_state.processor = processor
+        return function(*args, processor=processor, **kwargs)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(wait=False, cancel_futures=True)

--- a/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
+++ b/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
@@ -260,7 +260,7 @@ class QwenVLProcessor(BaseMultimodalProcessor):
                 "Please provide text input instead."
             )
 
-        images = await self._load_images_async(image_data)
+        image_sources = self.normalize_data(image_data)
         video_data = self.normalize_data(getattr(request_obj, "video_data", None))
         video_config = self._build_video_config(request_obj)
         videos = await self._load_videos_async(video_data, video_config)
@@ -274,13 +274,11 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         if uses_qwen3vl_processor:
             processor_kwargs["return_mm_token_type_ids"] = True
 
-        processor_output = self.processor(
-            text=[input_text],
-            images=images or None,
-            videos=videos or None,
-            padding=True,
-            return_tensors="pt",
-            **processor_kwargs,
+        processor_output = await self._run_hf_processor_async(
+            input_text,
+            image_sources,
+            videos,
+            processor_kwargs,
         )
 
         input_ids_array = self._to_numpy(processor_output.get("input_ids"))
@@ -292,11 +290,11 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         image_grid_thw = self._to_grid_list(processor_output.get("image_grid_thw"))
         video_grid_thw = self._to_grid_list(processor_output.get("video_grid_thw"))
         mm_token_type_ids = self._to_numpy(processor_output.get("mm_token_type_ids"))
-        if images or videos:
+        if image_sources or videos:
             logger.info(
                 "Qwen-VL processor output: images=%s, videos=%s, image_grid_thw=%s, "
                 "video_grid_thw=%s, pixel_values_shape=%s, pixel_values_videos_shape=%s",
-                len(images),
+                len(image_sources),
                 len(videos),
                 image_grid_thw,
                 video_grid_thw,
@@ -437,11 +435,6 @@ class QwenVLProcessor(BaseMultimodalProcessor):
             raise ValueError("Video timing count does not match video inputs.")
         for item, seconds in zip(items, second_per_grid_ts, strict=True):
             item.set("second_per_grid_ts", seconds)
-
-    async def _load_images_async(self, image_data):
-        return await asyncio.gather(
-            *(self.load_image_async(item) for item in self.normalize_data(image_data))
-        )
 
     @staticmethod
     def _compute_image_placeholder_ranges(input_ids, grids, image_token_id, spatial_merge_size):

--- a/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
+++ b/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
@@ -236,6 +236,9 @@ def preprocess_video(source, video_config: dict) -> np.ndarray:
 
 
 class QwenVLProcessor(BaseMultimodalProcessor):
+    auto_mm_io_worker_num = 16
+    auto_mm_processor_worker_num = 2
+    supports_mm_processor_concurrency = True
     models = (
         "Qwen2VLForConditionalGeneration",
         "Qwen2_5_VLForConditionalGeneration",
@@ -506,7 +509,7 @@ class QwenVLProcessor(BaseMultimodalProcessor):
     async def _load_videos_async(self, video_data, video_config):
         return await asyncio.gather(
             *(
-                asyncio.to_thread(preprocess_video, item, video_config)
+                self._run_io_async(preprocess_video, item, video_config)
                 for item in self.normalize_data(video_data)
             )
         )

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -263,6 +263,8 @@ class ServerArgs:
     limit_mm_data_per_request: dict[str, int] | None = None
     mm_embedding_cache_size_mb: int | None = None
     mm_embedding_page_size: int = 64
+    mm_io_worker_num: int = 0
+    mm_processor_worker_num: int = 0
 
     enable_return_routed_experts: bool = False
     enable_expert_balance_debug: bool = False
@@ -530,6 +532,10 @@ class ServerArgs:
             raise ValueError("--mm-embedding-cache-size-mb must be non-negative")
         if self.mm_embedding_page_size <= 0:
             raise ValueError("--mm-embedding-page-size must be positive")
+        if self.mm_io_worker_num < 0:
+            raise ValueError("--mm-io-worker-num must be non-negative")
+        if self.mm_processor_worker_num < 0:
+            raise ValueError("--mm-processor-worker-num must be non-negative")
 
         if self.ep_num_redundant_experts < 0:
             raise ValueError("ep_num_redundant_experts must be non-negative")
@@ -1605,6 +1611,18 @@ class ServerArgs:
             type=int,
             default=ServerArgs.mm_embedding_page_size,
             help="Token-block (page) size for the multimodal embedding pool.",
+        )
+        parser.add_argument(
+            "--mm-io-worker-num",
+            type=int,
+            default=ServerArgs.mm_io_worker_num,
+            help="Number of multimodal data loading workers. 0 uses the model default.",
+        )
+        parser.add_argument(
+            "--mm-processor-worker-num",
+            type=int,
+            default=ServerArgs.mm_processor_worker_num,
+            help="Number of multimodal processor workers. 0 uses the model default.",
         )
 
         # LoRA

--- a/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
+++ b/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 from types import SimpleNamespace
 
 import numpy as np
@@ -38,6 +39,40 @@ def test_qwen_vl_rejects_audio_inputs():
 
     with pytest.raises(ValueError, match="does not support audio"):
         asyncio.run(processor.process_mm_data_async(None, "prompt", request))
+
+
+def test_hf_processor_runs_outside_event_loop_thread():
+    worker_thread_id = None
+
+    def hf_processor(**kwargs):
+        nonlocal worker_thread_id
+        worker_thread_id = threading.get_ident()
+        return kwargs
+
+    processor = QwenVLProcessor(SimpleNamespace(), SimpleNamespace(), hf_processor)
+
+    async def run_processor():
+        event_loop_thread_id = threading.get_ident()
+        output = await processor._run_hf_processor_async(
+            "prompt",
+            image_sources=[],
+            videos=[],
+            processor_kwargs={"return_mm_token_type_ids": True},
+        )
+        return event_loop_thread_id, output
+
+    event_loop_thread_id, output = asyncio.run(run_processor())
+
+    assert worker_thread_id is not None
+    assert worker_thread_id != event_loop_thread_id
+    assert output == {
+        "text": ["prompt"],
+        "images": None,
+        "videos": None,
+        "padding": True,
+        "return_tensors": "pt",
+        "return_mm_token_type_ids": True,
+    }
 
 
 def test_placeholder_ranges_are_half_open():

--- a/test/srt/openai_server/basic/test_serving_chat.py
+++ b/test/srt/openai_server/basic/test_serving_chat.py
@@ -39,6 +39,7 @@ class _MockTokenizerManager:
         self.tokenizer.decode.return_value = "Test response"
         self.tokenizer.chat_template = None
         self.tokenizer.bos_token_id = 1
+        self.mm_processor = None
 
         # async generator stub for generate_request
         async def _mock_generate():
@@ -171,6 +172,47 @@ class ServingChatTestCase(unittest.TestCase):
             self.assertEqual(result2.stop, initial_stop_str)
             self.assertNotIn("CUSTOM_STOP", result2.stop)
             self.assertEqual(conv_ins.stop_str, initial_stop_str)
+
+    def test_multimodal_jinja_prompt_skips_encode_decode_round_trip(self):
+        self.template_manager.chat_template_name = None
+        self.tm.mm_processor = Mock()
+        self.tm.mm_processor.apply_chat_template.return_value = "<image>Test prompt"
+        self.tm.tokenizer.encode.reset_mock()
+        self.tm.tokenizer.decode.reset_mock()
+
+        result = self.chat._apply_jinja_template(self.basic_req, tools=None, is_multimodal=True)
+
+        self.assertEqual(result.prompt, "<image>Test prompt")
+        self.assertEqual(result.prompt_ids, [])
+        self.tm.tokenizer.encode.assert_not_called()
+        self.tm.tokenizer.decode.assert_not_called()
+
+    def test_multimodal_jinja_assistant_prefix_preserves_token_round_trip(self):
+        self.template_manager.chat_template_name = None
+        self.tm.mm_processor = Mock()
+        self.tm.mm_processor.apply_chat_template.return_value = "<image>Test prompt"
+        self.tm.tokenizer.encode.reset_mock()
+        self.tm.tokenizer.encode.side_effect = ([1, 2], [1, 3])
+        self.tm.tokenizer.decode.reset_mock()
+        self.tm.tokenizer.decode.return_value = "<image>Test prompt partial"
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[
+                {"role": "user", "content": "Hi?"},
+                {"role": "assistant", "content": "partial"},
+            ],
+            continue_final_message=True,
+        )
+
+        result = self.chat._apply_jinja_template(request, tools=None, is_multimodal=True)
+
+        self.assertEqual(result.prompt, "<image>Test prompt partial")
+        self.assertEqual(result.prompt_ids, [1, 2, 3])
+        self.assertEqual(
+            self.tm.tokenizer.encode.call_args_list,
+            [unittest.mock.call("<image>Test prompt"), unittest.mock.call("partial")],
+        )
+        self.tm.tokenizer.decode.assert_called_once_with([1, 2, 3])
 
     # ------------- sampling-params -------------
     def test_sampling_param_build(self):


### PR DESCRIPTION
## Motivation

Multimodal request preprocessing currently performs a redundant tokenize/decode round trip for rendered chat prompts and runs image and Hugging Face processor work in a way that can occupy the asyncio event loop.

This adds unnecessary CPU work and limits frontend responsiveness and preprocessing concurrency for image-heavy workloads.

## Modifications

- Forward rendered multimodal prompts directly to the multimodal processor, avoiding the redundant tokenizer encode/decode round trip while preserving `continue_final_message` behavior.
- Move image loading and Hugging Face processor execution off the asyncio event loop.
- Add a fixed-size multimodal processor thread pool with an isolated processor instance per worker.
- Add configurable `--mm-io-worker-num` and `--mm-processor-worker-num` server arguments.
- Use Qwen-VL defaults of 16 I/O workers and 2 processor workers, while falling back to one worker for processors that do not support concurrency.
- Clean up multimodal I/O and processor executors during server shutdown.
- Add regression coverage for prompt handling and asynchronous processor execution.

## Accuracy Tests

This PR does not change model forward, kernel, or weight-loading code.

End-to-end Qwen2.5-VL accuracy was validated on integration commit `22a96748b7ea21e08af72da4934ff349c7ae2df3`, which contains these preprocessing changes together with later integration fixes.

Configuration: Qwen2.5-VL-32B-Instruct, TPU v7x-8, DP4 x effective TP2, BF16 model/vision/KV, no quantization, context/max sequence 32768, EvalScope 1.5.1, `eval_batch_size=24`, `max_tokens=8192`, temperature 0, and seed 42.

| Dataset | Metric | Accuracy | Samples |
|---|---:|---:|---:|
| MMMU Val | Mean Accuracy | 62.67% | 900 |
| MMMU-Pro Vision | Mean Accuracy | 47.75% | 1,730 |

Targeted unit tests:

```bash
python -m pytest -q \
  python/sgl_jax/test/multimodal/test_qwen_vl_processor.py \
  test/srt/openai_server/basic/test_serving_chat.py
```

Result: `20 passed`.

## Benchmarking and Profiling

The following Qwen2.5-VL throughput results were collected on integration commit `22a96748b7ea21e08af72da4934ff349c7ae2df3`, which contains these preprocessing changes together with later integration fixes. The measurements validate the integrated serving path and are not an isolated before/after comparison for this PR.

Configuration:

- Model: `Qwen/Qwen2.5-VL-32B-Instruct`
- TPU: v7x-8, topology `2x2x1`
- Parallelism: DP4 x effective TP2
- Precision: BF16 model, vision tower, and KV cache; no quantization
- Context / maximum sequence: 2048 / 2048
- Radix cache: disabled
- Multimodal input: 1024 random text tokens and one 512x512 random JPEG
- Worker configuration: 16 I/O workers and 16 processor workers

The text workload was calibrated to match the multimodal workload's total input length. Average total input was 1423.000 tokens/request for text and 1422.303 tokens/request for multimodal requests.

### Benchmark Commands

Text throughput:

```bash
python -m sgl_jax.bench_serving \
  --backend sglang-oai-chat --host 127.0.0.1 --port 30000 \
  --model Qwen/Qwen2.5-VL-32B-Instruct \
  --dataset-name random --num-prompts 1000 \
  --random-input-len 1423 --random-output-len 500 \
  --random-range-ratio 1.0 --request-rate inf \
  --seed 0 --warmup-requests 1 --flush-cache --output-details
```

Multimodal throughput:

```bash
python -m sgl_jax.bench_serving \
  --backend sglang-oai-chat --host 127.0.0.1 --port 30000 \
  --model Qwen/Qwen2.5-VL-32B-Instruct \
  --dataset-name image --num-prompts 1000 \
  --random-input-len 1024 --random-output-len 500 \
  --random-range-ratio 1.0 --image-count 1 \
  --image-resolution 512x512 --image-format jpeg --image-content random \
  --request-rate inf --seed 0 --warmup-requests 1 --flush-cache --output-details
```

### Throughput Results

| Metric | Text | Multimodal | MM vs Text |
|---|---:|---:|---:|
| Duration (s) | 61.664 | 67.392 | +9.29% |
| Request throughput (req/s) | 16.217 | 14.839 | -8.50% |
| Input throughput (tok/s) | 23,076.60 | 21,104.98 | -8.54% |
| Output throughput (tok/s) | 8,108.43 | 7,419.30 | -8.50% |
| Total throughput (tok/s) | 31,185.03 | 28,524.28 | -8.53% |
| Mean TTFT (ms) | 16,360.14 | 21,333.40 | +30.40% |
| Median TTFT (ms) | 11,915.01 | 15,933.31 | +33.72% |
| P99 TTFT (ms) | 50,859.37 | 55,943.81 | +10.00% |
| Mean TPOT (ms) | 66.74 | 67.16 | +0.63% |
| Median TPOT (ms) | 71.36 | 73.84 | +3.48% |
| Median E2E (ms) | 47,550.97 | 52,888.29 | +11.22% |
| P99 E2E (ms) | 61,518.16 | 66,762.37 | +8.52% |

TTFT in this saturated-burst run includes scheduler queueing time.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
