### PR TITLE
perf(qwen3.5): sequence parallelism for the hybrid GDN+MoE path

### DIFF
--- a/python/sgl_jax/srt/models/qwen2_moe.py
+++ b/python/sgl_jax/srt/models/qwen2_moe.py
@@ -69,11 +69,16 @@ class Qwen2MoeMLP(nnx.Module):
 
         self.act_fn = jax.nn.silu
 
-    def __call__(self, hidden_states: jax.Array):
+    def __call__(
+        self,
+        hidden_states: jax.Array,
+        *,
+        out_sharding: jax.sharding.Sharding | None = None,
+    ):
         a1, _ = self.gate_proj(hidden_states)
         a2, _ = self.up_proj(hidden_states)
         intermediate_parallel = a2 * self.act_fn(a1)
-        output, _ = self.down_proj(intermediate_parallel)
+        output, _ = self.down_proj(intermediate_parallel, out_sharding=out_sharding)
         return output
 
 

--- a/python/sgl_jax/srt/models/qwen3_5.py
+++ b/python/sgl_jax/srt/models/qwen3_5.py
@@ -48,6 +48,7 @@ from sgl_jax.srt.layers.radix_linear_attention import RadixLinearAttention
 from sgl_jax.srt.mem_cache.memory_pool import MemoryPools
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
 from sgl_jax.srt.models.qwen2_moe import Qwen2MoeMLP
+from sgl_jax.srt.utils.parallel_utils import make_reduce_sharding
 from sgl_jax.srt.utils.weight_utils import WeightMapping
 
 logger = logging.getLogger(__name__)
@@ -143,7 +144,15 @@ class Qwen3_5Attention(nnx.Module):
             layer_id=layer_id,
         )
 
-    def __call__(self, positions, hidden_states, forward_batch, token_to_kv_pool):
+    def __call__(
+        self,
+        positions,
+        hidden_states,
+        forward_batch,
+        token_to_kv_pool,
+        *,
+        out_sharding: jax.sharding.Sharding | None = None,
+    ):
         T = hidden_states.shape[0]
         q_raw, _ = self.q_proj(hidden_states)
         k, _ = self.k_proj(hidden_states)
@@ -198,7 +207,7 @@ class Qwen3_5Attention(nnx.Module):
             attn_out = attn_out * jax.nn.sigmoid(gate)
             attn_out = attn_out.reshape(T, self.num_heads * self.head_dim)
 
-        out, _ = self.o_proj(attn_out)
+        out, _ = self.o_proj(attn_out, out_sharding=out_sharding)
         return out, kv_fused
 
 
@@ -319,7 +328,15 @@ class Qwen3_5GatedDeltaNet(nnx.Module):
         )
         return core_out * jax.nn.silu(z)
 
-    def __call__(self, positions, hidden_states, forward_batch, recurrent_state_pool):
+    def __call__(
+        self,
+        positions,
+        hidden_states,
+        forward_batch,
+        recurrent_state_pool,
+        *,
+        out_sharding: jax.sharding.Sharding | None = None,
+    ):
         del positions  # GDN is position-agnostic.
         qkvz, _ = self.in_proj_qkvz(hidden_states)  # [T, 2*key_dim + 2*value_dim]
         ba, _ = self.in_proj_ba(hidden_states)  # [T, 2*num_v_heads]
@@ -335,7 +352,7 @@ class Qwen3_5GatedDeltaNet(nnx.Module):
         core_out, attn_state = self.self_attn(forward_batch, q, k, v, a, b, recurrent_state_pool)
         # core_out: [T, value_dim] -> per-head RMSNorm + silu(z) gate.
         core_out = self._norm_gate(core_out, z)
-        out, _ = self.out_proj(core_out)
+        out, _ = self.out_proj(core_out, out_sharding=out_sharding)
         return out, attn_state
 
 
@@ -352,6 +369,7 @@ class Qwen3_5MoeBlock(nnx.Module):
     ):
         text_cfg = config.text_config
         self.layer_id = layer_id
+        self.mesh = mesh
         hidden = text_cfg.hidden_size
         inter = text_cfg.moe_intermediate_size
         se_inter = text_cfg.shared_expert_intermediate_size
@@ -404,17 +422,38 @@ class Qwen3_5MoeBlock(nnx.Module):
             scope_name="shared_expert_gate",
         )
 
-    def __call__(self, hidden_states, forward_batch, dispatch_info=None):
-        shared_out = self.shared_experts(hidden_states)
-        gate_logit, _ = self.shared_expert_gate(hidden_states)  # [T, 1]
+    def __call__(
+        self,
+        hidden_states,
+        forward_batch,
+        dispatch_info=None,
+        *,
+        out_sharding: jax.sharding.Sharding | None = None,
+    ):
+        shared_out = self.shared_experts(hidden_states, out_sharding=out_sharding)
+        gate_logit, _ = self.shared_expert_gate(hidden_states, out_sharding=out_sharding)  # [T, 1]
         shared_out = jax.nn.sigmoid(gate_logit) * shared_out
 
         router_logits = self.moe_gate(hidden_states)
-        topk_weights, topk_ids = self.topk(router_logits, dispatch_info=dispatch_info)
-        token_valid_mask = forward_batch.get_token_valid_mask(hidden_states.shape[0])
+        topk_weights, topk_ids = self.topk(
+            router_logits,
+            dispatch_info=dispatch_info,
+            routing_sharding=out_sharding,
+        )
+        mask_sharding = (
+            NamedSharding(self.mesh, P(out_sharding.spec[0])) if out_sharding is not None else None
+        )
+        token_valid_mask = forward_batch.get_token_valid_mask(
+            hidden_states.shape[0], out_sharding=mask_sharding
+        )
         topk_ids = jnp.where(token_valid_mask[:, None], topk_ids, -1)
 
-        routed_out = self.experts(hidden_states, topk_weights, topk_ids)
+        routed_out = self.experts(
+            hidden_states,
+            topk_weights,
+            topk_ids,
+            out_sharding=out_sharding,
+        )
         return routed_out + shared_out, jax.sharding.reshard(topk_ids, P(None))
 
 
@@ -430,6 +469,8 @@ class Qwen3_5DecoderLayer(nnx.Module):
         dtype: jnp.dtype = jnp.bfloat16,
     ):
         text_cfg = config.text_config
+        self.mesh = mesh
+        self.enable_sequence_parallel = getattr(config, "enable_sequence_parallel", False)
         self.is_full_attn = layer_id in text_cfg.full_attention_layer_ids
         self.is_moe = text_cfg.is_moe
 
@@ -464,6 +505,10 @@ class Qwen3_5DecoderLayer(nnx.Module):
         residual=None,
         dispatch_info: ExpertLocationMetadata | None = None,
     ):
+        reduce_sharding = make_reduce_sharding(
+            hidden_states, self.mesh, enable_sp=self.enable_sequence_parallel
+        )
+
         # Deferred-residual pre-norm pattern (mirrors qwen2_moe / kimi_linear).
         if residual is None:
             residual = hidden_states
@@ -477,18 +522,30 @@ class Qwen3_5DecoderLayer(nnx.Module):
             pool = memory_pools.token_to_kv_pool
         else:
             pool = memory_pools.recurrent_state_pool
-        hidden_states, attn_state = self.self_attn(positions, hidden_states, forward_batch, pool)
+        hidden_states, attn_state = self.self_attn(
+            positions,
+            hidden_states,
+            forward_batch,
+            pool,
+            out_sharding=reduce_sharding,
+        )
 
-        hidden_states = hidden_states + residual
+        hidden_states = hidden_states + jax.sharding.reshard(residual, reduce_sharding)
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
 
         # MoE MLP consumes routing info and returns topk_ids; dense takes only hidden.
         if self.is_moe:
-            hidden_states, topk_ids = self.mlp(hidden_states, forward_batch, dispatch_info)
+            hidden_states, topk_ids = self.mlp(
+                hidden_states,
+                forward_batch,
+                dispatch_info,
+                out_sharding=reduce_sharding,
+            )
         else:
-            hidden_states = self.mlp(hidden_states)
+            hidden_states = self.mlp(hidden_states, out_sharding=reduce_sharding)
             topk_ids = None
+        residual = jax.sharding.reshard(residual, reduce_sharding)
         return hidden_states, residual, attn_state, topk_ids
 
 

--- a/python/sgl_jax/test/layers/test_sequence_parallel.py
+++ b/python/sgl_jax/test/layers/test_sequence_parallel.py
@@ -13,6 +13,7 @@ import ast
 import inspect
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
 import jax
 import jax.numpy as jnp
@@ -21,6 +22,9 @@ from flax import nnx
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
+from sgl_jax.global_config import global_config
+from sgl_jax.srt.kernels.fused_moe.v1.kernel import FusedMoEBlockConfig
+from sgl_jax.srt.layers.fused_moe import FusedEPMoE
 from sgl_jax.srt.layers.linear import LinearBase, QuantizedLinear
 from sgl_jax.srt.layers.moe import EPMoE
 from sgl_jax.srt.models.grok import Grok1Attention, Grok1DecoderLayer, Grok1MLP
@@ -103,6 +107,11 @@ class TestMakeReduceSharding(CustomTestCase):
         self.assertTrue(should_scatter(dim_size=2 * _MIN_LOCAL, num_devices=2))
         # Must divide evenly.
         self.assertFalse(should_scatter(dim_size=2 * _MIN_LOCAL + 1, num_devices=2))
+        # Issue #1415 relies on these adjacent global buckets remaining distinct:
+        # 2032 stays on the DP fallback while 2048 enters SP on EP16.
+        with mock.patch.object(global_config, "tpu_scatter_min_local_size", 128):
+            self.assertFalse(should_scatter(dim_size=2032, num_devices=16))
+            self.assertTrue(should_scatter(dim_size=2048, num_devices=16))
 
 
 class TestQuantizedLinearScatter(CustomTestCase):
@@ -456,6 +465,134 @@ def _make_dp_tp_mesh(dp_size: int, tp_size: int) -> Mesh:
         axis_names=("data", "tensor"),
         axis_types=(jax.sharding.AxisType.Explicit,) * 2,
     )
+
+
+@unittest.skipIf(_TOTAL_DEVICES < 4, "Needs >=4 devices for dp=2, tp=2.")
+class TestQwen35Dp2Tp2SequenceParallel(CustomTestCase):
+    """Qwen3.5 boundary policy and row-reduction contracts on a v6e-4 mesh."""
+
+    TOKENS = 512
+    HIDDEN_SIZE = 256
+    INTERMEDIATE_DIM = 256
+    NUM_EXPERTS = 8
+
+    def setUp(self):
+        self.mesh = _make_dp_tp_mesh(dp_size=2, tp_size=2)
+
+    def test_qwen35_bucket_boundary_policy(self):
+        """508/513 fall back, while divisible 512/1024 buckets activate SP."""
+        cases = (
+            (508, True, "data"),
+            (512, True, ("data", "tensor")),
+            (513, True, "data"),
+            (1024, True, ("data", "tensor")),
+            (1024, False, "data"),
+        )
+        with jax.set_mesh(self.mesh):
+            for tokens, enabled, expected_axis in cases:
+                with self.subTest(tokens=tokens, enable_sequence_parallel=enabled):
+                    hidden_shape = SimpleNamespace(
+                        shape=(tokens, self.HIDDEN_SIZE),
+                        ndim=2,
+                    )
+                    target = make_reduce_sharding(
+                        hidden_shape,
+                        self.mesh,
+                        enable_sp=enabled,
+                    )
+                    self.assertEqual(_spec_dim(target, 0), expected_axis)
+
+    def test_linear_base_512_active_and_forced_dp_are_numerically_equal(self):
+        key = jax.random.PRNGKey(1415)
+        x_key, weight_key = jax.random.split(key)
+        x_host = jax.random.normal(
+            x_key,
+            (self.TOKENS, self.HIDDEN_SIZE),
+            dtype=jnp.bfloat16,
+        )
+        weight = jax.random.normal(
+            weight_key,
+            (self.HIDDEN_SIZE, self.HIDDEN_SIZE),
+            dtype=jnp.bfloat16,
+        )
+
+        with jax.set_mesh(self.mesh):
+            linear = _build_linear_base(weight, self.mesh)
+            x = jax.device_put(
+                x_host,
+                NamedSharding(self.mesh, P("data", "tensor")),
+            )
+            sp_target = make_reduce_sharding(x, self.mesh, enable_sp=True)
+            dp_target = make_reduce_sharding(x, self.mesh, enable_sp=False)
+            sp_output, _ = linear(x, out_sharding=sp_target)
+            dp_output, _ = linear(x, out_sharding=dp_target)
+
+        self.assertEqual(_spec_dim(sp_output.sharding, 0), ("data", "tensor"))
+        self.assertEqual(_spec_dim(dp_output.sharding, 0), "data")
+        np.testing.assert_allclose(
+            _as_fp32(sp_output),
+            _as_fp32(dp_output),
+            rtol=0.05,
+            atol=1.0,
+        )
+
+    def test_fused_ep_moe_512_active_and_forced_dp_are_numerically_equal(self):
+        block_config = FusedMoEBlockConfig(
+            bt=128,
+            btc=128,
+            bf=256,
+            bfc=256,
+            bd1=256,
+            bd1c=256,
+            bd2=256,
+            bd2c=256,
+            bse=256,
+        )
+        x_host, topk_weights_host, topk_ids_host = _make_moe_inputs(
+            self.TOKENS,
+            self.HIDDEN_SIZE,
+            self.NUM_EXPERTS,
+        )
+        input_sharding = NamedSharding(self.mesh, P(("data", "tensor"), None))
+
+        with jax.set_mesh(self.mesh):
+            moe = FusedEPMoE(
+                hidden_size=self.HIDDEN_SIZE,
+                num_experts=self.NUM_EXPERTS,
+                num_experts_per_tok=1,
+                ep_size=4,
+                mesh=self.mesh,
+                intermediate_dim=self.INTERMEDIATE_DIM,
+                quantization_config=None,
+            )
+            hidden_states = jax.device_put(x_host, input_sharding)
+            # Production ``TopK`` always returns float32 weights; the fused
+            # Pallas kernel's DMA scratch contract relies on that dtype.
+            topk_weights = jax.device_put(
+                topk_weights_host.astype(jnp.float32),
+                input_sharding,
+            )
+            topk_ids = jax.device_put(topk_ids_host, input_sharding)
+            sp_target = make_reduce_sharding(hidden_states, self.mesh, enable_sp=True)
+            dp_target = make_reduce_sharding(hidden_states, self.mesh, enable_sp=False)
+            sp_output = moe(
+                hidden_states,
+                topk_weights,
+                topk_ids,
+                block_config=block_config,
+                out_sharding=sp_target,
+            )
+            dp_output = moe(
+                hidden_states,
+                topk_weights,
+                topk_ids,
+                block_config=block_config,
+                out_sharding=dp_target,
+            )
+
+        self.assertEqual(_spec_dim(sp_output.sharding, 0), ("data", "tensor"))
+        self.assertEqual(_spec_dim(dp_output.sharding, 0), "data")
+        np.testing.assert_array_equal(_as_fp32(sp_output), _as_fp32(dp_output))
 
 
 class TestDpSpComposition(CustomTestCase):

--- a/python/sgl_jax/test/models/test_qwen3_5.py
+++ b/python/sgl_jax/test/models/test_qwen3_5.py
@@ -25,12 +25,15 @@ import os
 import re
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
 os.environ.setdefault("JAX_PLATFORMS", "cpu")
 
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.configs.qwen3_5 import Qwen3_5DenseConfig, Qwen3_5HybridConfig
 from sgl_jax.srt.utils.mesh_utils import create_device_mesh
@@ -39,6 +42,96 @@ _mesh = create_device_mesh(
     ici_parallelism=[1, 1], dcn_parallelism=[1, 1], devices=[jax.devices()[0]]
 )
 jax.sharding.set_mesh(_mesh)
+
+
+class _LinearRecorder:
+    """Minimal LinearBase stand-in that records the per-call output target."""
+
+    def __init__(self, output):
+        self.output = output
+        self.out_shardings = []
+
+    def __call__(self, *args, out_sharding=None, **kwargs):
+        del args, kwargs
+        self.out_shardings.append(out_sharding)
+        output = self.output
+        if out_sharding is not None:
+            output = jax.sharding.reshard(output, out_sharding)
+        return output, None
+
+
+class _ArrayRecorder:
+    """Array-returning stand-in for MLP, router, and expert modules."""
+
+    def __init__(self, output):
+        self.output = output
+        self.out_shardings = []
+
+    def __call__(self, *args, out_sharding=None, **kwargs):
+        del args, kwargs
+        self.out_shardings.append(out_sharding)
+        output = self.output
+        if out_sharding is not None:
+            output = jax.sharding.reshard(output, out_sharding)
+        return output
+
+
+class _PairRecorder:
+    """Pair-returning stand-in for attention modules."""
+
+    def __init__(self, output, state):
+        self.output = output
+        self.state = state
+        self.out_shardings = []
+        self.args = []
+
+    def __call__(self, *args, out_sharding=None, **kwargs):
+        del kwargs
+        self.args.append(args)
+        self.out_shardings.append(out_sharding)
+        output = self.output
+        if out_sharding is not None:
+            output = jax.sharding.reshard(output, out_sharding)
+        return output, self.state
+
+
+class _Identity:
+    def __call__(self, value, *args, **kwargs):
+        del args, kwargs
+        return value
+
+
+class _RotaryIdentity:
+    def __call__(self, positions, q, k):
+        del positions
+        return q, k
+
+
+class _TopKRecorder:
+    def __init__(self, weights, ids):
+        self.weights = weights
+        self.ids = ids
+        self.routing_shardings = []
+
+    def __call__(self, router_logits, dispatch_info=None, routing_sharding=None):
+        del router_logits, dispatch_info
+        self.routing_shardings.append(routing_sharding)
+        return self.weights, self.ids
+
+
+class _TokenMaskRecorder:
+    def __init__(self, mask):
+        self.mask = mask
+        self.out_sharding = None
+
+    def get_token_valid_mask(self, num_tokens, *, out_sharding=None):
+        if num_tokens != self.mask.shape[0]:
+            raise AssertionError(f"Expected {self.mask.shape[0]} tokens, got {num_tokens}.")
+        self.out_sharding = out_sharding
+        mask = self.mask
+        if out_sharding is not None:
+            mask = jax.sharding.reshard(mask, out_sharding)
+        return mask
 
 
 # RoPE block as the real config.json ships it (nested ``rope_parameters``, HF 5.x);
@@ -392,6 +485,227 @@ class TestQwen3_5(unittest.TestCase):
             )
             self.assertIsInstance(cap, _RoutedExpertsCapturerReal)
             self.assertEqual(cap.host_buffer.shape, (2, 1, 4))
+
+
+class TestQwen3_5SequenceParallelWiring(unittest.TestCase):
+    """Hub-free call-contract tests for Qwen3.5 sequence-parallel wiring.
+
+    The recorders deliberately stop before RadixAttention, GDN, and fused-MoE
+    kernels. These tests answer only whether the root flag selects a target and
+    whether that exact target reaches every row-parallel consumer.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mesh = _mesh
+
+    def _target(self):
+        return NamedSharding(self.mesh, P(("data", "tensor"), None))
+
+    def test_decoder_reads_root_sequence_parallel_flag_default_and_enabled(self):
+        from sgl_jax.srt.models.qwen3_5 import Qwen3_5DecoderLayer
+
+        default_cfg = _make_config(num_layers=4, is_moe=False)
+        default_layer = Qwen3_5DecoderLayer(default_cfg, self.mesh, layer_id=3)
+        self.assertFalse(default_layer.enable_sequence_parallel)
+
+        enabled_cfg = _make_config(num_layers=4, is_moe=False)
+        enabled_cfg.enable_sequence_parallel = True
+        enabled_layer = Qwen3_5DecoderLayer(enabled_cfg, self.mesh, layer_id=3)
+        self.assertTrue(enabled_layer.enable_sequence_parallel)
+
+    def test_qwen2_moe_mlp_threads_target_to_down_projection(self):
+        from sgl_jax.srt.models.qwen2_moe import Qwen2MoeMLP
+
+        tokens, hidden, intermediate = 4, 32, 64
+        mlp = Qwen2MoeMLP(hidden, intermediate, self.mesh)
+        down_proj = _LinearRecorder(jnp.zeros((tokens, hidden), dtype=jnp.bfloat16))
+        mlp.down_proj = down_proj
+        hidden_states = jnp.zeros((tokens, hidden), dtype=jnp.bfloat16)
+        target = self._target()
+
+        output = mlp(hidden_states, out_sharding=target)
+        self.assertIs(down_proj.out_shardings[-1], target)
+        self.assertEqual(output.sharding.spec, target.spec)
+
+        mlp(hidden_states)
+        self.assertIsNone(down_proj.out_shardings[-1])
+
+    def test_full_attention_threads_target_to_o_projection(self):
+        from sgl_jax.srt.models.qwen3_5 import Qwen3_5Attention
+
+        cfg = _make_config(num_layers=4, is_moe=False)
+        tc = cfg.text_config
+        tokens = 4
+        attn = Qwen3_5Attention(cfg, self.mesh, layer_id=3)
+        attn.q_proj = _LinearRecorder(
+            jnp.zeros(
+                (tokens, attn.num_heads * 2 * attn.head_dim),
+                dtype=jnp.bfloat16,
+            )
+        )
+        attn.k_proj = _LinearRecorder(
+            jnp.zeros((tokens, attn.num_kv_heads * attn.head_dim), dtype=jnp.bfloat16)
+        )
+        attn.v_proj = _LinearRecorder(
+            jnp.zeros((tokens, attn.num_kv_heads * attn.head_dim), dtype=jnp.bfloat16)
+        )
+        attn.q_norm = _Identity()
+        attn.k_norm = _Identity()
+        attn.rotary_emb = _RotaryIdentity()
+        attn.attn = _PairRecorder(
+            jnp.zeros((tokens, attn.num_heads * attn.head_dim), dtype=jnp.bfloat16),
+            "kv-state",
+        )
+        o_proj = _LinearRecorder(jnp.zeros((tokens, tc.hidden_size), dtype=jnp.bfloat16))
+        attn.o_proj = o_proj
+        target = self._target()
+
+        output, state = attn(
+            jnp.arange(tokens),
+            jnp.zeros((tokens, tc.hidden_size), dtype=jnp.bfloat16),
+            object(),
+            object(),
+            out_sharding=target,
+        )
+
+        self.assertIs(o_proj.out_shardings[-1], target)
+        self.assertEqual(output.sharding.spec, target.spec)
+        self.assertEqual(state, "kv-state")
+
+    def test_gdn_threads_target_to_out_projection(self):
+        from sgl_jax.srt.models.qwen3_5 import Qwen3_5GatedDeltaNet
+
+        cfg = _make_config(num_layers=4, is_moe=False)
+        tc = cfg.text_config
+        tokens = 4
+        gdn = Qwen3_5GatedDeltaNet(cfg, self.mesh, layer_id=0)
+        qkvz_width = 2 * gdn.key_dim + 2 * gdn.value_dim
+        gdn.in_proj_qkvz = _LinearRecorder(jnp.zeros((tokens, qkvz_width), dtype=jnp.bfloat16))
+        gdn.in_proj_ba = _LinearRecorder(
+            jnp.zeros((tokens, 2 * gdn.num_v_heads), dtype=jnp.bfloat16)
+        )
+        gdn._shard_dt = _Identity()
+        gdn._norm_gate = _Identity()
+        gdn.self_attn = _PairRecorder(
+            jnp.zeros((tokens, gdn.value_dim), dtype=jnp.bfloat16),
+            "recurrent-state",
+        )
+        out_proj = _LinearRecorder(jnp.zeros((tokens, tc.hidden_size), dtype=jnp.bfloat16))
+        gdn.out_proj = out_proj
+        target = self._target()
+
+        output, state = gdn(
+            jnp.arange(tokens),
+            jnp.zeros((tokens, tc.hidden_size), dtype=jnp.bfloat16),
+            object(),
+            object(),
+            out_sharding=target,
+        )
+
+        self.assertIs(out_proj.out_shardings[-1], target)
+        self.assertEqual(output.sharding.spec, target.spec)
+        self.assertEqual(state, "recurrent-state")
+
+    def test_moe_threads_target_to_shared_routed_and_mask_paths(self):
+        from sgl_jax.srt.models.qwen3_5 import Qwen3_5MoeBlock
+
+        cfg = _make_config(num_layers=4, is_moe=True)
+        tc = cfg.text_config
+        tokens = 4
+        hidden_states = jnp.zeros((tokens, tc.hidden_size), dtype=jnp.bfloat16)
+        block = Qwen3_5MoeBlock(cfg, self.mesh, layer_id=0)
+        shared = _ArrayRecorder(jnp.zeros_like(hidden_states))
+        shared_gate = _LinearRecorder(jnp.zeros((tokens, 1), dtype=jnp.bfloat16))
+        experts = _ArrayRecorder(jnp.zeros_like(hidden_states))
+        self.assertIs(block.topk.mesh, self.mesh)
+        block.shared_experts = shared
+        block.shared_expert_gate = shared_gate
+        block.moe_gate = _ArrayRecorder(jnp.zeros((tokens, tc.num_experts), dtype=jnp.float32))
+        raw_ids = jnp.arange(tokens * tc.num_experts_per_tok, dtype=jnp.int32).reshape(
+            tokens, tc.num_experts_per_tok
+        )
+        topk = _TopKRecorder(
+            jnp.ones((tokens, tc.num_experts_per_tok), dtype=jnp.bfloat16),
+            raw_ids,
+        )
+        block.topk = topk
+        block.experts = experts
+        forward_batch = _TokenMaskRecorder(jnp.array([True, False, True, False]))
+        target = self._target()
+
+        output, topk_ids = block(
+            hidden_states,
+            forward_batch,
+            dispatch_info=object(),
+            out_sharding=target,
+        )
+
+        self.assertIs(shared.out_shardings[-1], target)
+        self.assertIs(shared_gate.out_shardings[-1], target)
+        self.assertIs(topk.routing_shardings[-1], target)
+        self.assertIs(experts.out_shardings[-1], target)
+        self.assertEqual(output.sharding.spec, target.spec)
+        self.assertIsNotNone(forward_batch.out_sharding)
+        self.assertEqual(forward_batch.out_sharding.spec, P(("data", "tensor")))
+        self.assertTrue(
+            all(axis is None for axis in topk_ids.sharding.spec),
+            msg=f"topk_ids must remain replicated, got {topk_ids.sharding.spec}",
+        )
+        expected_ids = np.asarray(raw_ids).copy()
+        expected_ids[[1, 3], :] = -1
+        np.testing.assert_array_equal(np.asarray(topk_ids), expected_ids)
+
+    def test_decoder_threads_one_target_to_attention_mlp_and_residual(self):
+        from sgl_jax.srt.models.qwen3_5 import Qwen3_5DecoderLayer
+
+        cfg = _make_config(num_layers=4, is_moe=False)
+        cfg.enable_sequence_parallel = True
+        tc = cfg.text_config
+        tokens = 4
+        target = self._target()
+        memory_pools = SimpleNamespace(
+            token_to_kv_pool=object(),
+            recurrent_state_pool=object(),
+        )
+        cases = (
+            (3, memory_pools.token_to_kv_pool, "full-attention-state"),
+            (0, memory_pools.recurrent_state_pool, "gdn-state"),
+        )
+
+        for layer_id, expected_pool, expected_state in cases:
+            with self.subTest(layer_id=layer_id):
+                hidden_states = jnp.zeros((tokens, tc.hidden_size), dtype=jnp.bfloat16)
+                layer = Qwen3_5DecoderLayer(cfg, self.mesh, layer_id=layer_id)
+                layer.input_layernorm = _Identity()
+                layer.post_attention_layernorm = _Identity()
+                attention = _PairRecorder(jnp.zeros_like(hidden_states), expected_state)
+                mlp = _ArrayRecorder(jnp.zeros_like(hidden_states))
+                layer.self_attn = attention
+                layer.mlp = mlp
+
+                with mock.patch(
+                    "sgl_jax.srt.models.qwen3_5.make_reduce_sharding",
+                    return_value=target,
+                ) as make_target:
+                    output, residual, state, topk_ids = layer(
+                        jnp.arange(tokens),
+                        hidden_states,
+                        object(),
+                        memory_pools,
+                    )
+
+                args, kwargs = make_target.call_args
+                self.assertIs(args[0], hidden_states)
+                self.assertIs(args[1], self.mesh)
+                self.assertEqual(kwargs, {"enable_sp": True})
+                self.assertIs(attention.args[-1][3], expected_pool)
+                self.assertIs(attention.out_shardings[-1], target)
+                self.assertIs(mlp.out_shardings[-1], target)
+                self.assertEqual(output.sharding.spec, target.spec)
+                self.assertEqual(residual.sharding.spec, target.spec)
+                self.assertEqual(state, expected_state)
+                self.assertIsNone(topk_ids)
 
 
 class TestQwen3_5Dense(unittest.TestCase):

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -431,6 +431,11 @@ suites = {
     ],
     "unit-test-tpu-v6e-4": [
         TestFile("python/sgl_jax/test/test_mesh.py", 0.4),
+        TestFile(
+            "python/sgl_jax/test/layers/test_sequence_parallel.py",
+            1,
+            runner="pytest",
+        ),
         TestFile("python/sgl_jax/test/test_linear_tp.py", 0.3, runner="pytest"),
         TestFile(
             "python/sgl_jax/test/layers/test_lightning_backend_dp.py",


### PR DESCRIPTION
## Motivation

Closes #1415. Follows #1198 (model-agnostic threshold-gated reduce-scatter) and #1372
(dense Qwen3.5); part of the Qwen3.5 roadmap #1421, surfaced in review of #1267.

Qwen3.5's row-parallel reductions — MoE routed output, shared-expert and attention output
projections — are still plain `psum`, broadcasting the full hidden activation back to every
device and keeping the whole token dimension resident everywhere. #1198 already generalized
the fix and enabled it on Qwen3-MoE / MiMo-V2-Flash / Grok; Qwen3.5 was left out.

Qwen3.5 is not a drop-in for that wiring: in `Qwen3_5MoeBlock.__call__` the routed and shared
paths are reduced **independently** and summed afterwards, so there is no single fused
reduction to retarget —

```text
shared_out = shared_experts(h)   # Qwen2MoeMLP: row-parallel down_proj reduction
routed_out = experts(h, ...)     # FusedEPMoE: its own output reduction
return routed_out + shared_out   # sum happens AFTER both reductions
```

— and the hybrid backbone adds a GDN `out_proj` boundary that the existing SP models do not have.

## Modifications

- **`srt/models/qwen3_5.py` — one target per layer.** `Qwen3_5DecoderLayer.__call__` computes a
  single `make_reduce_sharding(hidden_states, mesh, enable_sp=self.enable_sequence_parallel)` and
  threads that exact object to attention, MLP, routing, the token-valid mask, and the residual
  reshard. Control flow mirrors `Qwen3MoeDecoderLayer.__call__` deliberately, so any divergence
  from that reference is a bug here. `enable_sequence_parallel` is read with
  `getattr(config, "enable_sequence_parallel", False)`, matching #1198.
- **`Qwen3_5MoeBlock.__call__`** — both reductions retargeted separately: `shared_experts`,
  `shared_expert_gate`, and `experts` all take `out_sharding`; `TopK` takes
  `routing_sharding=`; `get_token_valid_mask` takes a 1-D `NamedSharding(mesh, P(spec[0]))`
  derived from the same target, so routing, mask, and activations agree on the token axis.
- **`Qwen3_5Attention.__call__` / `Qwen3_5GatedDeltaNet.__call__`** — new keyword-only
  `out_sharding`, forwarded to `o_proj` / `out_proj`. GDN was listed as conditional in #1415;
  it goes through the same `should_scatter` gate, so it degrades to DP on its own whenever the
  bucket does not clear the per-device minimum — no separate opt-out needed.
- **`srt/models/qwen2_moe.py`** — `Qwen2MoeMLP.__call__` gains keyword-only `out_sharding`,
  passed to `down_proj`. This is the dense SwiGLU boundary and the shared-expert boundary at once
  (`Qwen3_5DecoderLayer` uses `Qwen2MoeMLP` for both). `LinearBase` already accepted the kwarg
  from #1198.
- **No new policy.** `--enable-sequence-parallel` remains the single switch and still defaults
  off; the threshold and divisibility rules stay owned by #1198. Below threshold every boundary
  returns the plain-DP target, so the DP fallback and the default path are unchanged by
  construction.
- **`test/srt/run_suite.py`** — register `test_sequence_parallel.py` in `unit-test-tpu-v6e-4`.
  It was only reachable through `--suite all`, so its cases never ran in the per-suite CI.

## Unit Tests

Run on a **host CPU backend** (JAX 0.10.2, `XLA_FLAGS=--xla_force_host_platform_device_count=8`) —
this host has no TPU:

- `python/sgl_jax/test/models/test_qwen3_5.py` — **24 / 24 PASS**, including 6 new
  `TestQwen3_5SequenceParallelWiring` cases that assert the exact target object reaches
  `down_proj`, `o_proj`, GDN `out_proj`, the shared/routed/mask paths and the residual, and that
  passing no target restores the previous behaviour.
- `python/sgl_jax/test/layers/test_sequence_parallel.py` — **20 / 24 PASS**, new cases:
  - `TestQwen35Dp2Tp2SequenceParallel::test_qwen35_bucket_boundary_policy` — PASS (5 subtests):
    508 and 513 fall back to DP, 512 and 1024 activate SP, `enable_sp=False` always DP.
  - `TestQwen35Dp2Tp2SequenceParallel::test_linear_base_512_active_and_forced_dp_are_numerically_equal`
    — PASS: SP-on and forced-DP are numerically equal at the `LinearBase` reduction boundary.
  - `TestDpSpComposition::test_quantized_linear_scatter_combines_data_and_tensor` — PASS: the
    DP+SP composition on the `("data", "tensor")` mesh required by #1415.
  - The 4 failures are all `FusedEPMoE` / `EPMoE` cases hitting
    `ValueError: Only interpret mode is supported on CPU backend` — Pallas needs a TPU. **Two of
    the four are pre-existing cases this PR does not touch**, which is how the failure is
    attributed to the backend rather than to this change.

```bash
XLA_FLAGS=--xla_force_host_platform_device_count=8 \
  pytest python/sgl_jax/test/models/test_qwen3_5.py \
         python/sgl_jax/test/layers/test_sequence_parallel.py
# on TPU:
python test/srt/run_suite.py --suite unit-test-tpu-v6e-4
```

Black (repo config), Ruff and isort pass.

## Accuracy Tests

**Not run — this PR is a Draft for exactly this reason.** The #1415 acceptance criteria are
SP-on vs SP-off token-identical greedy output at TP=16/DP=4 on v6e 4×4, plus accuracy parity on a
smoke MMLU-Pro / GPQA-Diamond subset (#1251 §4.3). No four-rank measured run has completed, so
neither is available. The CPU results above cover sharding-contract wiring and non-Pallas
numerical equivalence only; they say nothing about MoE kernels under SP, end-to-end token parity,
or accuracy. SP-off no-regression is likewise unmeasured and currently rests on construction.

Marking this Ready needs a v6e 4×4 run of the three arms (baseline SP-off, candidate SP-off,
candidate SP-on) on a fixed deterministic-greedy prompt whose prefill bucket clears
`data(4) × tensor(4) × TPU_SCATTER_MIN_LOCAL_SIZE(128) = 2048`.

## Benchmarking and Profiling

Not run. #1415 treats throughput / peak-HBM at the 16-chip serving point as the goal and
"no regression + correct" as the gate; this PR claims neither. No baseline measurement exists to
compare against, so no speedup is claimed.

## Known limits

- **Full-model SP-on admission has previously been blocked by a FusedEPMoE EP16 packing
  constraint**, not by this wiring: a scheduler bucket whose device-local token extent is not a
  legal v1 launch extent is rejected before the server reaches the requests. That is a separate
  wrapper/kernel-layer defect, **not fixed here**, and it needs its own change before an
  end-to-end SP-on run can be scored.
- SP activates only for Qwen3.5 on a `("data", "tensor")` mesh, only with
  `--enable-sequence-parallel`, and only for buckets clearing the per-device threshold. Every
  other configuration keeps the existing DP reduction.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
