### PR TITLE
fix(fused-moe): pad odd local token extents

### DIFF
--- a/python/sgl_jax/srt/kernels/fused_moe/token_padding.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/token_padding.py
@@ -1,0 +1,53 @@
+"""Pure token-extent helpers for fused-MoE wrappers.
+
+This module intentionally has no JAX dependency so the launch-shape contract can
+be validated on a host that does not have, import, or initialize JAX.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def align_fused_moe_v1_local_tokens(local_num_tokens: int, t_packing: int) -> int:
+    """Round a logical local token count up to a legal v1 launch extent.
+
+    The v1 kernel permits the small decode tiles 2 and 4; larger token tiles
+    must be multiples of 8. The launch extent must also be divisible by the
+    dtype packing factor. The logical token count is not changed by this
+    helper: callers pad each device-local shard and slice the result back.
+    """
+
+    if local_num_tokens <= 0:
+        raise ValueError(f"Expected {local_num_tokens=} to be > 0.")
+    if t_packing <= 0:
+        raise ValueError(f"Expected {t_packing=} to be > 0.")
+
+    for small_extent in (2, 4):
+        if local_num_tokens <= small_extent and small_extent % t_packing == 0:
+            return small_extent
+
+    alignment = math.lcm(8, t_packing)
+    return ((local_num_tokens + alignment - 1) // alignment) * alignment
+
+
+def align_fused_moe_v1_num_tokens(
+    num_tokens: int,
+    ep_size: int,
+    t_packing: int,
+) -> int:
+    """Return the global-equivalent extent for rank-local v1 padding.
+
+    This value sizes v1 tuning and launch internals only. It is not a new
+    global tensor shape or scheduler bucket.
+    """
+
+    if num_tokens <= 0:
+        raise ValueError(f"Expected {num_tokens=} to be > 0.")
+    if ep_size <= 0:
+        raise ValueError(f"Expected {ep_size=} to be > 0.")
+    if num_tokens % ep_size != 0:
+        raise ValueError(f"Expected {num_tokens=} to be aligned to {ep_size=}.")
+
+    local_num_tokens = num_tokens // ep_size
+    return align_fused_moe_v1_local_tokens(local_num_tokens, t_packing) * ep_size

--- a/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
+++ b/python/sgl_jax/srt/kernels/fused_moe/v1/kernel.py
@@ -14,6 +14,8 @@ from jax import lax
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
+from sgl_jax.srt.kernels.fused_moe.token_padding import align_fused_moe_v1_num_tokens
+
 P = jax.sharding.PartitionSpec
 
 cdiv = pl.cdiv
@@ -3019,6 +3021,7 @@ def _validate_fused_ep_moe_args(
     b2: jax.Array | None,
     b3: jax.Array | None,
     block_config: FusedMoEBlockConfig,
+    launch_num_tokens: int,
     dp_axis_name: str,
     tp_axis_name: str,
 ) -> None:
@@ -3026,8 +3029,15 @@ def _validate_fused_ep_moe_args(
         raise NotImplementedError("Only 2D mesh is supported.")
 
     ep_size = get_ep_size(mesh, dp_axis_name, tp_axis_name)
-    num_tokens, hidden_size = tokens.shape
+    logical_num_tokens, hidden_size = tokens.shape
     num_experts, intermediate_size, _ = w2.shape
+    if logical_num_tokens % ep_size != 0:
+        raise ValueError(f"Expected {logical_num_tokens=} to be aligned to {ep_size=}.")
+    if launch_num_tokens < logical_num_tokens or launch_num_tokens % ep_size != 0:
+        raise ValueError(
+            "Expected launch_num_tokens to cover the logical token extent and be "
+            f"aligned to ep_size, got {logical_num_tokens=}, {launch_num_tokens=}, {ep_size=}."
+        )
 
     if w1.shape != (num_experts, hidden_size, intermediate_size):
         raise ValueError(
@@ -3044,14 +3054,14 @@ def _validate_fused_ep_moe_args(
             f"Expected {w3.shape=} to be {(num_experts, hidden_size, intermediate_size)}."
         )
 
-    if topk_weights.shape != (num_tokens, top_k):
-        raise ValueError(f"Expected {topk_weights.shape=} to be {(num_tokens, top_k)}.")
+    if topk_weights.shape != (logical_num_tokens, top_k):
+        raise ValueError(f"Expected {topk_weights.shape=} to be {(logical_num_tokens, top_k)}.")
 
-    if topk_ids.shape != (num_tokens, top_k):
-        raise ValueError(f"Expected {topk_ids.shape=} to be {(num_tokens, top_k)}.")
+    if topk_ids.shape != (logical_num_tokens, top_k):
+        raise ValueError(f"Expected {topk_ids.shape=} to be {(logical_num_tokens, top_k)}.")
 
     validate_fused_moe_block_config(
-        num_tokens=num_tokens,
+        num_tokens=launch_num_tokens,
         num_experts=num_experts,
         top_k=top_k,
         hidden_size=hidden_size,
@@ -3064,7 +3074,7 @@ def _validate_fused_ep_moe_args(
 
     # Mosaic DMA tiling constraint for `start_fetch_topk`: the slice shape along the
     # token dimension must be aligned to the underlying HBM tiling of topk weights/ids.
-    local_num_tokens = num_tokens // ep_size
+    local_num_tokens = launch_num_tokens // ep_size
     topk_bits = jnp.dtype(topk_weights.dtype).itemsize * 8
     topk_tile0 = math.gcd(256 // topk_bits, local_num_tokens)
     if block_config.bt % topk_tile0 != 0:
@@ -3358,13 +3368,25 @@ def fused_ep_moe(
                 "disable_sync_barrier is only supported with disable_a2a=True or ep_size=1."
             )
 
+    logical_num_tokens, hidden_size = tokens.shape
+    t_packing = get_dtype_packing(tokens.dtype)
+    launch_num_tokens = align_fused_moe_v1_num_tokens(
+        logical_num_tokens,
+        ep_size,
+        t_packing,
+    )
+    # Keep the scheduler-visible/global shape unchanged. Only device-local
+    # shards are padded inside shard_map for v1 launch legality.
+    orig_local_num_tokens = logical_num_tokens // ep_size
+    local_num_tokens = launch_num_tokens // ep_size
+    pad_local = local_num_tokens - orig_local_num_tokens
+
     num_experts, intermediate_size, _ = w2.shape
     if block_config is None:
         from .tuned_block_configs import get_tuned_fused_moe_block_config
 
-        num_tokens, hidden_size = tokens.shape
         block_config = get_tuned_fused_moe_block_config(
-            num_tokens=num_tokens,
+            num_tokens=launch_num_tokens,
             num_experts=num_experts,
             top_k=top_k,
             hidden_size=hidden_size,
@@ -3376,7 +3398,7 @@ def fused_ep_moe(
             use_grouped_topk=use_grouped_topk,
         )
     block_config = block_config.effective_for(
-        num_tokens=tokens.shape[0],
+        num_tokens=launch_num_tokens,
         ep_size=ep_size,
         dtype=tokens.dtype,
         quant_block_k=quant_block_k,
@@ -3405,17 +3427,16 @@ def fused_ep_moe(
         b2=b2,
         b3=b3,
         block_config=block_config,
+        launch_num_tokens=launch_num_tokens,
         dp_axis_name=dp_axis_name,
         tp_axis_name=tp_axis_name,
     )
 
     num_devices = ep_size
 
-    num_tokens, hidden_size = tokens.shape
     local_num_experts = num_experts // ep_size
     se_inter_size = w2_shared.shape[0] if w2_shared is not None else 0
 
-    local_num_tokens = num_tokens // ep_size
     bt = block_config.bt
     if bt <= 0:
         raise ValueError(f"Expected {bt=} to be > 0.")
@@ -3757,6 +3778,20 @@ def fused_ep_moe(
         w3_shared_scale=None,
         w2_shared_scale=None,
     ):
+        if pad_local > 0:
+            tokens = jnp.pad(tokens, ((0, pad_local), (0, 0), (0, 0)))
+            topk_weights = jnp.pad(
+                topk_weights,
+                ((0, pad_local), (0, 0)),
+                constant_values=0.0,
+            )
+            topk_ids = jnp.pad(
+                topk_ids,
+                ((0, pad_local), (0, 0)),
+                mode="constant",
+                constant_values=-1,
+            )
+
         if needs_jax_allreduce:
             metadata_starts, metadata_sizes, metadata_d2e_counts = jax_allreduce_metadata_by_bt(
                 topk_ids[:, :top_k],
@@ -3841,6 +3876,8 @@ def fused_ep_moe(
             metadata_sizes_arg,
             metadata_d2e_counts_arg,
         )
+        if pad_local > 0:
+            local_output = local_output[:orig_local_num_tokens]
         return local_output
 
     a2a_s_x2_hbm_scratch = pl.empty(

--- a/python/sgl_jax/test/kernels/fused_moe_v1_test.py
+++ b/python/sgl_jax/test/kernels/fused_moe_v1_test.py
@@ -172,6 +172,7 @@ class MoEKernelTest(jtu.JaxTestCase):
         use_grouped_topk=False,
         num_groups=1,
         top_k_groups=1,
+        use_jax_allreduce_metadata=True,
         atol=2e-1,
         rtol=2e-1,
     ):
@@ -278,8 +279,10 @@ class MoEKernelTest(jtu.JaxTestCase):
             w2_shared_scale=w2_shared_scale,
             w3_shared_scale=w3_shared_scale,
             block_config=block_config,
+            use_jax_allreduce_metadata=use_jax_allreduce_metadata,
             tp_axis_name="tensor",
         )
+        self.assertEqual(actual.shape, a.shape)
         expected = ref_moe(
             a,
             w1,
@@ -358,6 +361,35 @@ class MoEKernelTest(jtu.JaxTestCase):
             bd1c=256,
             bd2c=256,
             bse=512,
+        )
+
+    @parameterized.product(
+        local_num_tokens=[127, 128],
+        use_jax_allreduce_metadata=[True, False],
+    )
+    def test_per_rank_padding_boundary(self, local_num_tokens, use_jax_allreduce_metadata):
+        ep_size = self.mesh.shape["data"] * self.mesh.shape["tensor"]
+        self._test_moe(
+            dtype=jnp.bfloat16,
+            top_k=2,
+            num_experts=max(2, ep_size),
+            hidden_size=256,
+            intermediate_size=256,
+            num_tokens=local_num_tokens * ep_size,
+            seed=1415,
+            renormalize_topk_logits=True,
+            bt=128,
+            bf=256,
+            bd1=256,
+            bd2=256,
+            btc=128,
+            bfc=128,
+            bd1c=256,
+            bd2c=256,
+            bse=256,
+            use_jax_allreduce_metadata=use_jax_allreduce_metadata,
+            atol=2e-1,
+            rtol=2e-1,
         )
 
     def test_layer_reshards_dp_inputs_for_fused_kernel(self):

--- a/python/sgl_jax/test/kernels/test_fused_moe_token_padding.py
+++ b/python/sgl_jax/test/kernels/test_fused_moe_token_padding.py
@@ -1,0 +1,93 @@
+"""Host-only contracts for fused-MoE token padding."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from sgl_jax.srt.kernels.fused_moe.token_padding import (
+    align_fused_moe_v1_local_tokens,
+    align_fused_moe_v1_num_tokens,
+)
+
+
+@pytest.mark.parametrize(
+    ("logical", "packing", "physical"),
+    [
+        (1, 1, 2),
+        (1, 2, 2),
+        (1, 4, 4),
+        (2, 1, 2),
+        (2, 2, 2),
+        (2, 4, 4),
+        (3, 1, 4),
+        (3, 2, 4),
+        (3, 4, 4),
+        (4, 1, 4),
+        (4, 2, 4),
+        (4, 4, 4),
+        (5, 1, 8),
+        (5, 2, 8),
+        (5, 4, 8),
+        (6, 2, 8),
+        (7, 2, 8),
+        (8, 2, 8),
+        (9, 2, 16),
+        (127, 2, 128),
+        (128, 2, 128),
+    ],
+)
+def test_v1_local_token_alignment(logical: int, packing: int, physical: int) -> None:
+    assert align_fused_moe_v1_local_tokens(logical, packing) == physical
+
+
+@pytest.mark.parametrize(("logical", "packing"), [(0, 2), (-1, 2), (1, 0), (1, -1)])
+def test_v1_local_token_alignment_rejects_non_positive_inputs(logical: int, packing: int) -> None:
+    with pytest.raises(ValueError):
+        align_fused_moe_v1_local_tokens(logical, packing)
+
+
+def test_odd_local_extent_keeps_logical_bucket_while_aligning_each_ep_rank() -> None:
+    # Observed on TPU v6e-16 at EP16: the 2032 precompile bucket gives 2032 // 16 = 127
+    # local tokens, which the v1 kernel rejects for bf16 (t_packing=2).
+    logical_global_tokens = 2032
+    ep_size = 16
+    logical_local_tokens = logical_global_tokens // ep_size
+    physical_launch_by_logical_bucket = {
+        bucket: align_fused_moe_v1_num_tokens(bucket, ep_size, t_packing=2)
+        for bucket in (2032, 2048)
+    }
+
+    assert logical_local_tokens == 127
+    assert align_fused_moe_v1_local_tokens(logical_local_tokens, t_packing=2) == 128
+    assert physical_launch_by_logical_bucket == {2032: 2048, 2048: 2048}
+    assert list(physical_launch_by_logical_bucket) == [2032, 2048]
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "ep_size", "packing"),
+    [(0, 16, 2), (-1, 16, 2), (2032, 0, 2), (2031, 16, 2), (2052, 16, 2)],
+)
+def test_global_alignment_rejects_invalid_contract(
+    num_tokens: int,
+    ep_size: int,
+    packing: int,
+) -> None:
+    with pytest.raises(ValueError):
+        align_fused_moe_v1_num_tokens(num_tokens, ep_size, packing)
+
+
+def test_import_does_not_load_jax() -> None:
+    code = """
+import sys
+assert "jax" not in sys.modules
+assert "jaxlib" not in sys.modules
+import sgl_jax.srt.kernels.fused_moe.token_padding
+assert "jax" not in sys.modules
+assert "jaxlib" not in sys.modules
+"""
+    python_root = Path(__file__).resolve().parents[3]
+    subprocess.run([sys.executable, "-c", code], check=True, cwd=python_root)

--- a/python/sgl_jax/test/test_compilation_manager.py
+++ b/python/sgl_jax/test/test_compilation_manager.py
@@ -239,6 +239,23 @@ class TestBucketComputation(unittest.TestCase):
         assert 256 in cm.token_buckets
         assert 512 in cm.token_buckets
 
+    def test_issue_1415_dp4_keeps_adjacent_2032_and_2048_buckets(self):
+        cm = CompilationManager(
+            server_args=_make_server_args(
+                precompile_token_paddings=[512, 1024, 2032, 2048],
+            ),
+            max_padded_batch_size=64,
+            max_padded_num_tokens=2048,
+            dp_size=4,
+            tp_size=4,
+            page_size=128,
+            max_req_len=4096,
+            vocab_size=32000,
+        )
+
+        index_2032 = cm.token_buckets.index(2032)
+        assert cm.token_buckets[index_2032 : index_2032 + 2] == [2032, 2048]
+
 
 class TestLazyCompilation(unittest.TestCase):
     def test_register_variant_if_new_first_time(self):

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -332,6 +332,11 @@ suites = {
         TestFile("test/srt/test_dtype_config_llama.py", 1),
         TestFile("test/srt/test_dtype_config_consistency.py", 10),
         TestFile("python/sgl_jax/test/test_compilation_manager.py", 1),
+        TestFile(
+            "python/sgl_jax/test/kernels/test_fused_moe_token_padding.py",
+            0.1,
+            runner="pytest",
+        ),
         TestFile("python/sgl_jax/test/test_kernel_utils.py", 1),
         TestFile("python/sgl_jax/test/speculative/test_dflash_info.py", 0.2, runner="pytest"),
         TestFile(


### PR DESCRIPTION
## Motivation

The v1 fused-EP MoE kernel derives its launch extent from the global token count
(`local_num_tokens = num_tokens // ep_size`) and rejects the result when it is not a legal
tile. Any precompile bucket whose device-local share is odd therefore fails to compile. At
EP16 the `2032` bucket gives `2032 // 16 = 127`, and bf16 packing (`t_packing=2`) rejects it
deterministically on every rank, before the server ever reaches HTTP readiness:

```text
ValueError: Expected local_num_tokens=127 to be aligned to t_packing=2.
```

This is a launch-shape defect, not a numerical one: `num_tokens`, `ep_size` and `dtype` are
the only inputs, so it reproduces for any model on the fused-MoE v1 path whenever the
scheduler's bucket set and `ep_size` combine to an odd local extent. It was observed on a
v6e-16 host at `TP=16 / DP=4 / EP=16` while validating unrelated work.

## Modifications

- **New `srt/kernels/fused_moe/token_padding.py`** — `align_fused_moe_v1_local_tokens` rounds a
  logical local token count up to a legal v1 launch extent (the small decode tiles `2` and `4`
  are preserved; anything larger goes to `lcm(8, t_packing)`), and
  `align_fused_moe_v1_num_tokens` lifts that to the global-equivalent extent used for tuning and
  launch sizing. The module deliberately has **no JAX import**, so the launch-shape contract can
  be validated on a host with no accelerator.
- **`srt/kernels/fused_moe/v1/kernel.py`** — separate the logical extent from the launch extent.
  `logical_num_tokens` keeps owning the caller-visible contract (`topk_weights` / `topk_ids`
  shape checks); the new `launch_num_tokens` feeds block-config selection,
  `validate_fused_moe_block_config`, and the Mosaic DMA tiling check.
  `_validate_fused_ep_moe_args` gains a `launch_num_tokens` argument and asserts it covers the
  logical extent and stays `ep_size`-aligned.
- **Padding is device-local and symmetric.** Inside `shard_map`, `tokens`, `topk_weights` and
  `topk_ids` are padded to the legal local extent and `local_output` is sliced back on exit.
  Padded rows carry `topk_ids = -1` and `topk_weights = 0.0`, so they route to no expert and
  contribute nothing. The scheduler-visible global shape and the logical bucket are unchanged.
- **Already-legal shapes are untouched.** Both pad and slice are guarded by `pad_local > 0`, and
  the alignment helper is idempotent, so a configuration that compiles today emits no additional
  op and keeps its existing tuned block config.

## Unit Tests

Host CPU, no accelerator required (JAX 0.10.2):

- `python/sgl_jax/test/kernels/test_fused_moe_token_padding.py` — **32 / 32 PASS** (new file).
  Covers the small-tile cases, the `lcm(8, t_packing)` rounding, idempotence on already-legal
  extents, rejection of non-positive and `ep_size`-misaligned contracts, the exact `127 -> 128`
  regression, and that `2032` and `2048` stay distinct logical buckets while both launching at
  `2048`. Includes `test_import_does_not_load_jax`, which asserts the module stays JAX-free.
- `python/sgl_jax/test/test_compilation_manager.py` — **27 / 27 PASS**.

```bash
pytest python/sgl_jax/test/kernels/test_fused_moe_token_padding.py \
       python/sgl_jax/test/test_compilation_manager.py
```

Requires a TPU, registered in `unit-test-tpu-v6e-4` and **not run on this host**:

- `python/sgl_jax/test/kernels/fused_moe_v1_test.py::MoEKernelTest::test_per_rank_padding_boundary`
  — new, parameterized over `local_num_tokens = [127, 128]` and both
  `use_jax_allreduce_metadata` settings; the previously failing extent and its adjacent legal
  neighbour must produce the same result as the reference implementation. The shared `_test_moe`
  helper also gained `assertEqual(actual.shape, a.shape)`, so every existing kernel case now
  asserts padding is invisible to the caller.

```bash
python test/srt/run_suite.py --suite unit-test-tpu-v6e-4
```

Black (`--config python/pyproject.toml`), Ruff and isort pass.

## Accuracy Tests

Not applicable, and deliberately so. This change never alters a tensor that reaches the
reference computation: padded rows are routed nowhere (`topk_ids = -1`, weight `0.0`), the
output is sliced back to the logical extent, and configurations that already compiled take a
byte-identical path. The correctness claim is carried by
`test_per_rank_padding_boundary`, which compares the previously rejected `127` extent against
the same reference `ref_moe` used by every other kernel case.

## Benchmarking and Profiling

Not run. The only configurations whose behaviour changes are ones that previously failed to
compile, so there is no working baseline to regress against and no speedup is claimed. Padding
`127 -> 128` costs at most one extra token row per device; already-legal buckets emit no
additional op.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
