### PR TITLE
refactor(vlm): offload combined multimodal processing

### DIFF
--- a/python/sgl_jax/srt/multimodal/processors/base_processor.py
+++ b/python/sgl_jax/srt/multimodal/processors/base_processor.py
@@ -160,28 +160,112 @@ class BaseMultimodalProcessor(ABC):
     async def load_image_async(self, source) -> Image.Image:
         return await self._run_io_async(self.load_image, source)
 
-    async def _run_hf_processor_async(
+    async def load_images_async(self, image_sources: list) -> list[Image.Image]:
+        return await asyncio.gather(*(self.load_image_async(source) for source in image_sources))
+
+    @staticmethod
+    def _to_numpy(value):
+        if value is None:
+            return None
+        if hasattr(value, "detach"):
+            value = value.detach().cpu()
+            # NumPy has no portable bfloat16 representation. Multimodal
+            # features are host-side inputs, so use float32 for interchange.
+            if str(getattr(value, "dtype", "")) == "torch.bfloat16":
+                value = value.float()
+            value = value.numpy()
+        return np.asarray(value)
+
+    def process_mm_data(
         self,
         input_text: str,
-        image_sources: list,
-        videos: list | None,
-        processor_kwargs: dict,
+        images: list | None = None,
+        videos: list | None = None,
+        audios: list | None = None,
+        *,
+        processor,
+        **kwargs,
     ):
-        images = await asyncio.gather(*(self.load_image_async(source) for source in image_sources))
+        """Run the Hugging Face processor synchronously.
 
-        def run_hf_processor(*, processor):
-            kwargs = {
-                "text": [input_text],
-                "images": images or None,
-                "padding": True,
-                "return_tensors": "pt",
-                **processor_kwargs,
-            }
-            if videos is not None:
-                kwargs["videos"] = videos or None
-            return processor(**kwargs)
+        This mirrors upstream SGLang's processor layering. Callers should use
+        ``process_and_combine_mm_data_async`` so this CPU work runs in the
+        isolated multimodal processor executor.
+        """
+        processor_inputs = {
+            "text": [input_text],
+            "images": images or None,
+            "padding": True,
+            "return_tensors": "pt",
+            **kwargs,
+        }
+        if videos is not None:
+            processor_inputs["videos"] = videos or None
+        if audios is not None:
+            processor_inputs["audios"] = audios or None
+        return processor(**processor_inputs)
 
-        return await self.mm_processor_executor.run(run_hf_processor)
+    def collect_mm_items_from_processor_output(
+        self,
+        processor_output,
+        images: list | None = None,
+        videos: list | None = None,
+        audios: list | None = None,
+        **kwargs,
+    ) -> MultimodalInputs:
+        """Convert one HF processor output into the runtime MM contract.
+
+        Model adapters override this hook when their feature layout or token
+        metadata is model-specific. The default handles text-only output.
+        """
+        del images, videos, audios, kwargs
+        input_ids = self._to_numpy(processor_output.get("input_ids"))
+        if input_ids is None:
+            raise ValueError("HF multimodal processor did not return input_ids.")
+        return MultimodalInputs(mm_items=[], input_ids=input_ids.reshape(-1).tolist())
+
+    def process_and_combine_mm_data(
+        self,
+        input_text: str,
+        images: list | None = None,
+        videos: list | None = None,
+        audios: list | None = None,
+        *,
+        processor,
+        **processor_kwargs,
+    ) -> MultimodalInputs:
+        processor_output = self.process_mm_data(
+            input_text,
+            images=images,
+            videos=videos,
+            audios=audios,
+            processor=processor,
+            **processor_kwargs,
+        )
+        return self.collect_mm_items_from_processor_output(
+            processor_output,
+            images=images,
+            videos=videos,
+            audios=audios,
+        )
+
+    async def process_and_combine_mm_data_async(
+        self,
+        input_text: str,
+        images: list | None = None,
+        videos: list | None = None,
+        audios: list | None = None,
+        **processor_kwargs,
+    ) -> MultimodalInputs:
+        """Run HF processing and output collection outside the event loop."""
+        return await self.mm_processor_executor.run(
+            self.process_and_combine_mm_data,
+            input_text,
+            images,
+            videos,
+            audios,
+            **processor_kwargs,
+        )
 
     def shutdown(self) -> None:
         if self._shutdown:

--- a/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
+++ b/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
@@ -266,7 +266,10 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         image_sources = self.normalize_data(image_data)
         video_data = self.normalize_data(getattr(request_obj, "video_data", None))
         video_config = self._build_video_config(request_obj)
-        videos = await self._load_videos_async(video_data, video_config)
+        images, videos = await asyncio.gather(
+            self.load_images_async(image_sources),
+            self._load_videos_async(video_data, video_config),
+        )
         processor_kwargs = {}
         if videos:
             processor_kwargs["videos_kwargs"] = {
@@ -277,13 +280,24 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         if uses_qwen3vl_processor:
             processor_kwargs["return_mm_token_type_ids"] = True
 
-        processor_output = await self._run_hf_processor_async(
+        return await self.process_and_combine_mm_data_async(
             input_text,
-            image_sources,
-            videos,
-            processor_kwargs,
+            images=images,
+            videos=videos,
+            **processor_kwargs,
         )
 
+    def collect_mm_items_from_processor_output(
+        self,
+        processor_output,
+        images: list | None = None,
+        videos: list | None = None,
+        **kwargs,
+    ) -> MultimodalInputs:
+        del kwargs
+        image_count = len(images or [])
+        video_count = len(videos or [])
+        uses_qwen3vl_processor = not _QWEN3VL_ARCHITECTURES.isdisjoint(self.hf_config.architectures)
         input_ids_array = self._to_numpy(processor_output.get("input_ids"))
         if input_ids_array is None:
             raise ValueError("HF multimodal processor did not return input_ids.")
@@ -293,12 +307,12 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         image_grid_thw = self._to_grid_list(processor_output.get("image_grid_thw"))
         video_grid_thw = self._to_grid_list(processor_output.get("video_grid_thw"))
         mm_token_type_ids = self._to_numpy(processor_output.get("mm_token_type_ids"))
-        if image_sources or videos:
+        if image_count or video_count:
             logger.info(
                 "Qwen-VL processor output: images=%s, videos=%s, image_grid_thw=%s, "
                 "video_grid_thw=%s, pixel_values_shape=%s, pixel_values_videos_shape=%s",
-                len(image_sources),
-                len(videos),
+                image_count,
+                video_count,
                 image_grid_thw,
                 video_grid_thw,
                 None if pixel_values is None else pixel_values.shape,
@@ -524,14 +538,6 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         if nframes is not None and "fps" not in video_config:
             video_config["nframes"] = nframes
         return video_config
-
-    @staticmethod
-    def _to_numpy(value):
-        if value is None:
-            return None
-        if hasattr(value, "detach"):
-            value = value.detach().cpu().numpy()
-        return np.asarray(value)
 
     @classmethod
     def _to_grid_list(cls, value):

--- a/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
+++ b/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
@@ -16,6 +16,14 @@ from sgl_jax.srt.multimodal.processors.qwen_vl import QwenVLProcessor
 IMAGE_TOKEN = 151655
 
 
+def _make_qwen_processor():
+    hf_config = SimpleNamespace(
+        architectures=["Qwen2_5_VLForConditionalGeneration"],
+        vision_config=SimpleNamespace(patch_size=14, spatial_merge_size=2),
+    )
+    return QwenVLProcessor(hf_config, SimpleNamespace(), object())
+
+
 def test_build_cache_input_ids_uses_item_hash():
     input_ids = [1, IMAGE_TOKEN, IMAGE_TOKEN, 2]
     item = MultimodalDataItem(
@@ -41,38 +49,69 @@ def test_qwen_vl_rejects_audio_inputs():
         asyncio.run(processor.process_mm_data_async(None, "prompt", request))
 
 
-def test_hf_processor_runs_outside_event_loop_thread():
+def test_qwen_process_and_combine_runs_in_hf_processor_worker():
     worker_thread_id = None
+    processor = _make_qwen_processor()
 
-    def hf_processor(**kwargs):
+    def process_and_combine(*_, processor, **__):
         nonlocal worker_thread_id
         worker_thread_id = threading.get_ident()
-        return kwargs
+        return MultimodalInputs(mm_items=[], input_ids=[10, 11])
 
-    processor = QwenVLProcessor(SimpleNamespace(), SimpleNamespace(), hf_processor)
+    processor.process_and_combine_mm_data = process_and_combine
 
     async def run_processor():
         event_loop_thread_id = threading.get_ident()
-        output = await processor._run_hf_processor_async(
-            "prompt",
-            image_sources=[],
-            videos=[],
-            processor_kwargs={"return_mm_token_type_ids": True},
-        )
+        output = await processor.process_and_combine_mm_data_async("prompt")
         return event_loop_thread_id, output
 
-    event_loop_thread_id, output = asyncio.run(run_processor())
+    try:
+        event_loop_thread_id, output = asyncio.run(run_processor())
+    finally:
+        processor.shutdown()
 
-    assert worker_thread_id is not None
-    assert worker_thread_id != event_loop_thread_id
-    assert output == {
-        "text": ["prompt"],
-        "images": None,
-        "videos": None,
-        "padding": True,
-        "return_tensors": "pt",
-        "return_mm_token_type_ids": True,
-    }
+    assert worker_thread_id is not None and worker_thread_id != event_loop_thread_id
+    assert output.input_ids == [10, 11]
+
+
+def test_qwen_loads_images_and_videos_concurrently():
+    processor = _make_qwen_processor()
+
+    async def run_processor():
+        loaders_ready = asyncio.Barrier(2)
+
+        async def load(sources, expected_source, result):
+            assert sources == [expected_source]
+            await loaders_ready.wait()
+            return [result]
+
+        async def combine(input_text, images=None, videos=None, **kwargs):
+            assert input_text == "prompt"
+            assert images == ["loaded-image"]
+            assert videos == ["loaded-video"]
+            return MultimodalInputs(mm_items=[], input_ids=[10, 11])
+
+        processor.load_images_async = lambda sources: load(sources, "image-source", "loaded-image")
+        processor._load_videos_async = lambda sources, _: load(
+            sources, "video-source", "loaded-video"
+        )
+        processor.process_and_combine_mm_data_async = combine
+
+        return await asyncio.wait_for(
+            processor.process_mm_data_async(
+                "image-source",
+                "prompt",
+                SimpleNamespace(audio_data=None, video_data="video-source"),
+            ),
+            timeout=1,
+        )
+
+    try:
+        output = asyncio.run(run_processor())
+    finally:
+        processor.shutdown()
+
+    assert output.input_ids == [10, 11]
 
 
 def test_placeholder_ranges_are_half_open():


### PR DESCRIPTION
## Motivation

The existing SGLang-JAX async path offloads the Hugging Face processor call, but model-specific output collection still runs after that handoff. Qwen-VL image and video resources are also loaded at different points in the pipeline.

This change follows the multimodal processor layering used by [upstream SGLang](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/multimodal/processors/base_processor.py): synchronous `process_mm_data`, model-specific `collect_mm_items_from_processor_output`, and `process_and_combine_mm_data`. The combined stage is adapted to SGLang-JAX's existing bounded processor executor so CPU-heavy processing and output conversion stay off the asyncio event-loop thread.

## Modifications

- Add shared synchronous `process_mm_data` and `process_and_combine_mm_data` stages to `BaseMultimodalProcessor`.
- Execute the complete Hugging Face processing and output-collection stage in the bounded multimodal processor executor.
- Move the common tensor-to-NumPy conversion helper into the base processor.
- Load Qwen-VL image and video resources concurrently before handing them to the processor executor.
- Keep Qwen-specific feature, grid, placeholder, and mRoPE conversion in `collect_mm_items_from_processor_output`.
- Add focused tests for executor-thread isolation and concurrent image/video loading.

## Accuracy Tests

No model computation or numerical behavior is intentionally changed.

```bash
python -m pytest -q python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
# 13 passed
```

The commit also passes the repository pre-commit hooks, including ruff, mypy, and codespell.

## Benchmarking and Profiling

Not run. This PR changes preprocessing scheduling rather than model kernels; its thread-placement and resource-loading concurrency are covered by focused unit tests.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update. (N/A: internal refactor with no user-facing API change.)
