### PR TITLE
feat(vlm): Add Qwen-VL preprocessing and cache-aware request identity

### DIFF
--- a/python/sgl_jax/srt/managers/dp_schedule_policy.py
+++ b/python/sgl_jax/srt/managers/dp_schedule_policy.py
@@ -17,7 +17,9 @@ BALANCE_REL = 1.1
 CACHE_THRESHOLD = 0.5
 
 
-def req_prefix_match_key(req) -> tuple[list[int] | None, str | None]:
+def req_prefix_match_key(
+    req, cache_input_ids: list[int] | None = None
+) -> tuple[list[int] | None, str | None]:
     """Effective ``(token_ids, extra_key)`` for a cache-affinity prefix probe.
 
     Mirrors the key the request will use for its *real* radix lookup, so the
@@ -36,7 +38,7 @@ def req_prefix_match_key(req) -> tuple[list[int] | None, str | None]:
     prefix (an unexpanded batch, an empty/one-token prompt, or a request whose
     reusable prefix clamps to zero), so the caller falls back to load balancing.
     """
-    input_ids = req.input_ids
+    input_ids = cache_input_ids or req.input_ids
     if not isinstance(input_ids, list) or not input_ids or not isinstance(input_ids[0], int):
         return None, None
 

--- a/python/sgl_jax/srt/managers/dp_schedule_policy.py
+++ b/python/sgl_jax/srt/managers/dp_schedule_policy.py
@@ -17,9 +17,7 @@ BALANCE_REL = 1.1
 CACHE_THRESHOLD = 0.5
 
 
-def req_prefix_match_key(
-    req, cache_input_ids: list[int] | None = None
-) -> tuple[list[int] | None, str | None]:
+def req_prefix_match_key(req) -> tuple[list[int] | None, str | None]:
     """Effective ``(token_ids, extra_key)`` for a cache-affinity prefix probe.
 
     Mirrors the key the request will use for its *real* radix lookup, so the
@@ -38,9 +36,10 @@ def req_prefix_match_key(
     prefix (an unexpanded batch, an empty/one-token prompt, or a request whose
     reusable prefix clamps to zero), so the caller falls back to load balancing.
     """
-    input_ids = cache_input_ids or req.input_ids
+    input_ids = req.radix_input_ids
     if not isinstance(input_ids, list) or not input_ids or not isinstance(input_ids[0], int):
         return None, None
+    assert len(input_ids) == len(req.input_ids)
 
     extra_key = req.extra_key
     lora_id = getattr(req, "lora_id", None)

--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -419,6 +419,12 @@ class GenerateReqInput:
                 self.input_ids = [self.input_ids]
             if self.input_embeds is not None:
                 self.input_embeds = [self.input_embeds]
+            if self.image_data is not None:
+                self.image_data = [self.image_data]
+            if self.video_data is not None:
+                self.video_data = [self.video_data]
+            if self.audio_data is not None:
+                self.audio_data = [self.audio_data]
 
     def _normalize_batch_inputs(self):
         """Normalize inputs for a batch of examples, including parallel sampling expansion."""

--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from sgl_jax.srt.managers.schedule_batch import BaseFinishReason
-from sgl_jax.srt.multimodal.common.modality_enum import flatten_nested_list
+from sgl_jax.srt.multimodal.common.modality_enum import (
+    MultimodalInputs,
+    flatten_nested_list,
+)
 
 # Handle serialization of Image for pydantic
 if TYPE_CHECKING:
@@ -164,7 +167,7 @@ class TokenizedGenerateReqInput:
     # whether to return hidden states
     return_hidden_states: bool = False
     # multimodal inputs (e.g., mrope positions, embeddings)
-    mm_inputs: dict | None = None
+    mm_inputs: MultimodalInputs | dict | None = None
     # Decode DP rank selected by request routing.
     dp_rank: int | None = None
     # PD disaggregation routing keys.
@@ -551,6 +554,10 @@ class GenerateReqInput:
         return GenerateReqInput(
             text=self.text[i] if self.text is not None else None,
             input_ids=self.input_ids[i] if self.input_ids is not None else None,
+            input_embeds=self.input_embeds[i] if self.input_embeds is not None else None,
+            image_data=self.image_data[i] if self.image_data is not None else None,
+            video_data=self.video_data[i] if self.video_data is not None else None,
+            audio_data=self.audio_data[i] if self.audio_data is not None else None,
             sampling_params=self.sampling_params[i],
             rid=self.rid[i],
             return_logprob=self.return_logprob[i],

--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -10,6 +10,7 @@ import numpy as np
 from sgl_jax.srt.managers.schedule_batch import BaseFinishReason
 from sgl_jax.srt.multimodal.common.modality_enum import (
     MultimodalInputs,
+    build_radix_input_ids,
     flatten_nested_list,
 )
 
@@ -143,6 +144,9 @@ class TokenizedGenerateReqInput:
     text: list[str] | str | None = None
     # The token ids for text; one can specify either text or input_ids
     input_ids: list[list[int]] | list[int] | None = None
+    # Canonical radix-cache identity. This equals input_ids for text requests
+    # and contains hash-substituted multimodal placeholder IDs otherwise.
+    radix_input_ids: list[list[int]] | list[int] = field(default_factory=list)
     # The sampling_params. See descriptions below.
     sampling_params: list[dict] | dict | None = None
     # Whether to return logprobs.
@@ -180,6 +184,23 @@ class TokenizedGenerateReqInput:
     # to ``rid``; callers that may reuse ``rid`` across retries should
     # provide a per-attempt value to isolate late acks.
     disagg_transfer_id: str | None = None
+
+    def __post_init__(self):
+        if not self.radix_input_ids and self.input_ids:
+            if isinstance(self.input_ids[0], int):
+                self.radix_input_ids = build_radix_input_ids(self.input_ids, self.mm_inputs)
+            else:
+                # Batched requests are expanded before scheduling. Preserve a
+                # canonical copy until then rather than aliasing model IDs.
+                self.radix_input_ids = copy.deepcopy(self.input_ids)
+
+        if (
+            self.input_ids
+            and isinstance(self.input_ids[0], int)
+            and self.radix_input_ids
+            and isinstance(self.radix_input_ids[0], int)
+        ):
+            assert len(self.input_ids) == len(self.radix_input_ids)
 
 
 @dataclass

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -48,9 +48,10 @@ from sgl_jax.srt.mem_cache.common import (
     release_kv_cache,
 )
 from sgl_jax.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPool
-from sgl_jax.srt.mem_cache.radix_cache import RadixKey
+from sgl_jax.srt.mem_cache.radix_cache import RadixKey, build_radix_key
 from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
+from sgl_jax.srt.multimodal.common.modality_enum import MultimodalInputs
 from sgl_jax.srt.precision_tracer import (
     PrecisionTracerRequestMetadata,
     precision_tracer,
@@ -205,8 +206,8 @@ class Req:
         # Used for radix cache matching to differentiate different images/videos
         # If None, origin_input_ids is used for cache matching
         self.cache_input_ids: list[int] | None = None
-        # Multimodal inputs (e.g., mrope positions) from tokenizer
-        self.mm_inputs: dict | None = None
+        # Multimodal inputs (e.g., image items and mrope positions) from tokenizer.
+        self.mm_inputs: MultimodalInputs | dict | None = None
 
         # Each decode stage's output ids
         self.output_ids = []
@@ -489,7 +490,7 @@ class Req:
                 )
                 match_result = tree_cache.match_prefix(
                     MatchPrefixParams(
-                        key=RadixKey(self.adjust_max_prefix_ids(), self.extra_key, self.dp_rank),
+                        key=self.match_key(),
                         cow_recurrent=(
                             tree_cache.supports_recurrent() and not is_running_recurrent
                         ),
@@ -523,6 +524,10 @@ class Req:
 
         max_prefix_len = max(max_prefix_len, 0)
         return self.fill_ids[:max_prefix_len]
+
+    def match_key(self) -> RadixKey:
+        real_prefix = self.adjust_max_prefix_ids()
+        return build_radix_key(self, len(real_prefix))
 
     def pop_committed_kv_cache(self) -> int:
         # Idempotent: the PD prefill abort path can run release a second time

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -190,6 +190,7 @@ class Req:
         multimodal_embedding: list[list[float]] | None = None,
         deepstack_visual_embedding: list[list[float]] | None = None,
         deepstack_visual_pos_mask: list[int] | None = None,
+        radix_input_ids: list[int] | None = None,
     ):
         # Input and output info
         self.rid = rid
@@ -201,11 +202,10 @@ class Req:
             else origin_input_ids  # Before image padding
         )
         self.origin_input_ids = origin_input_ids
-
-        # Cache input IDs with hash-based values for multimodal placeholder tokens
-        # Used for radix cache matching to differentiate different images/videos
-        # If None, origin_input_ids is used for cache matching
-        self.cache_input_ids: list[int] | None = None
+        self.radix_input_ids = (
+            radix_input_ids if radix_input_ids is not None else list(origin_input_ids)
+        )
+        assert len(self.origin_input_ids) == len(self.radix_input_ids)
         # Multimodal inputs (e.g., image items and mrope positions) from tokenizer.
         self.mm_inputs: MultimodalInputs | dict | None = None
 
@@ -696,6 +696,7 @@ class Req:
     def set_finish_with_abort(self, error_msg: str):
         # set it to one token to skip the long prefill
         self.origin_input_ids = [0]
+        self.radix_input_ids = [0]
         self.grammar = None
         self.return_logprob = False
         self.to_finish = FINISH_ABORT(error_msg, HTTPStatus.BAD_REQUEST, "BadRequestError")

--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -20,7 +20,7 @@ from sgl_jax.srt.mem_cache.base_prefix_cache import (
     InsertParams,
     MatchPrefixParams,
 )
-from sgl_jax.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
+from sgl_jax.srt.mem_cache.radix_cache import RadixCache, TreeNode
 
 if TYPE_CHECKING:
     from sgl_jax.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
@@ -152,14 +152,9 @@ class SchedulePolicy:
         self.waiting_queue_radix_tree.reset()
 
         for r in waiting_queue:
-            prefix_ids = r.adjust_max_prefix_ids()
-            extra_key = r.extra_key
+            match_key = r.match_key()
             # NOTE: the prefix_indices must always be aligned with last_node
-            match_result = self.tree_cache.match_prefix(
-                MatchPrefixParams(
-                    key=RadixKey(token_ids=prefix_ids, extra_key=extra_key, dp_rank=r.dp_rank)
-                )
-            )
+            match_result = self.tree_cache.match_prefix(MatchPrefixParams(key=match_key))
             r.prefix_indices = match_result.device_indices
             r.last_node = match_result.last_device_node
             r.last_host_node = match_result.last_host_node
@@ -174,9 +169,7 @@ class SchedulePolicy:
             # It is kind of common when the engine is long running (e.g., imagine the prefix "the").
             if len(r.prefix_indices) <= IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD:
                 in_batch_match = self.waiting_queue_radix_tree.match_prefix(
-                    MatchPrefixParams(
-                        key=RadixKey(token_ids=prefix_ids, extra_key=extra_key, dp_rank=r.dp_rank)
-                    )
+                    MatchPrefixParams(key=match_key)
                 )
                 in_batch_matching_prefixes = in_batch_match.device_indices
                 if (
@@ -188,10 +181,8 @@ class SchedulePolicy:
                     # Insert with a dummy key
                     self.waiting_queue_radix_tree.insert(
                         InsertParams(
-                            key=RadixKey(
-                                token_ids=prefix_ids, extra_key=extra_key, dp_rank=r.dp_rank
-                            ),
-                            value=np.empty(len(prefix_ids), dtype=np.bool_),
+                            key=match_key,
+                            value=np.empty(len(match_key), dtype=np.bool_),
                         )
                     )
         return temporary_deprioritized

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -87,7 +87,6 @@ from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
 from sgl_jax.srt.model_executor.model_runner_kv_cache_mixin import (
     recurrent_admission_blocked,
 )
-from sgl_jax.srt.multimodal.common.modality_enum import build_cache_input_ids
 from sgl_jax.srt.multimodal.tokenizer_utils import resolve_tokenizer_subdir
 from sgl_jax.srt.precision_tracer import precision_tracer
 from sgl_jax.srt.server_args import PortArgs, ServerArgs
@@ -946,8 +945,7 @@ class Scheduler(
         if not eligible:
             return None
 
-        cache_input_ids = build_cache_input_ids(req.input_ids, req.mm_inputs)
-        token_ids, extra_key = req_prefix_match_key(req, cache_input_ids)
+        token_ids, extra_key = req_prefix_match_key(req)
         matches: dict[int, int] = {}
         prompt_len = len(token_ids) if token_ids else 0
         if token_ids:
@@ -1313,6 +1311,7 @@ class Scheduler(
             recv_req.text,
             recv_req.input_ids,
             recv_req.sampling_params,
+            radix_input_ids=recv_req.radix_input_ids,
             return_logprob=recv_req.return_logprob,
             return_output_logprob_only=recv_req.return_output_logprob_only,
             top_logprobs_num=recv_req.top_logprobs_num,
@@ -1348,7 +1347,6 @@ class Scheduler(
                 req.deepstack_visual_embedding = _extract_mm_value(
                     recv_req.mm_inputs, "deepstack_visual_embedding"
                 )
-            req.cache_input_ids = build_cache_input_ids(req.origin_input_ids, req.mm_inputs)
         # Validate prompt length
         error_msg = validate_input_length(
             req,

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -58,6 +58,7 @@ from sgl_jax.srt.managers.schedule_batch import (
     FINISH_ABORT,
     Req,
     ScheduleBatch,
+    _extract_mm_value,
     acc_global_bid,
     global_server_args_dict,
 )
@@ -86,6 +87,7 @@ from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
 from sgl_jax.srt.model_executor.model_runner_kv_cache_mixin import (
     recurrent_admission_blocked,
 )
+from sgl_jax.srt.multimodal.common.modality_enum import build_cache_input_ids
 from sgl_jax.srt.multimodal.tokenizer_utils import resolve_tokenizer_subdir
 from sgl_jax.srt.precision_tracer import precision_tracer
 from sgl_jax.srt.server_args import PortArgs, ServerArgs
@@ -944,7 +946,8 @@ class Scheduler(
         if not eligible:
             return None
 
-        token_ids, extra_key = req_prefix_match_key(req)
+        cache_input_ids = build_cache_input_ids(req.input_ids, req.mm_inputs)
+        token_ids, extra_key = req_prefix_match_key(req, cache_input_ids)
         matches: dict[int, int] = {}
         prompt_len = len(token_ids) if token_ids else 0
         if token_ids:
@@ -1332,17 +1335,20 @@ class Scheduler(
         req.disagg_transfer_id = recv_req.disagg_transfer_id or req.rid
         if hasattr(recv_req, "mm_inputs") and recv_req.mm_inputs:
             req.mm_inputs = recv_req.mm_inputs
-            multimodal_embedding = recv_req.mm_inputs.get("multimodal_embedding")
+            multimodal_embedding = _extract_mm_value(recv_req.mm_inputs, "multimodal_embedding")
             req.multimodal_embedding = multimodal_embedding
             if (
-                recv_req.mm_inputs.get("deepstack_visual_pos_mask") is not None
-                and recv_req.mm_inputs.get("deepstack_visual_embedding") is not None
+                _extract_mm_value(recv_req.mm_inputs, "deepstack_visual_pos_mask") is not None
+                and _extract_mm_value(recv_req.mm_inputs, "deepstack_visual_embedding") is not None
             ):
                 req.apply_for_deepstack = True
-                req.deepstack_visual_pos_mask = recv_req.mm_inputs.get("deepstack_visual_pos_mask")
-                req.deepstack_visual_embedding = recv_req.mm_inputs.get(
-                    "deepstack_visual_embedding"
+                req.deepstack_visual_pos_mask = _extract_mm_value(
+                    recv_req.mm_inputs, "deepstack_visual_pos_mask"
                 )
+                req.deepstack_visual_embedding = _extract_mm_value(
+                    recv_req.mm_inputs, "deepstack_visual_embedding"
+                )
+            req.cache_input_ids = build_cache_input_ids(req.origin_input_ids, req.mm_inputs)
         # Validate prompt length
         error_msg = validate_input_length(
             req,

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -30,7 +30,11 @@ import zmq.asyncio
 from fastapi import BackgroundTasks
 
 from sgl_jax.srt.configs.model_config import ModelConfig
-from sgl_jax.srt.hf_transformers_utils import get_tokenizer
+from sgl_jax.srt.hf_transformers_utils import (
+    get_processor,
+    get_tokenizer,
+    get_tokenizer_from_processor,
+)
 from sgl_jax.srt.lora.lora_registry import LoRARegistry
 from sgl_jax.srt.managers.io_struct import (
     AbortReq,
@@ -61,6 +65,10 @@ from sgl_jax.srt.managers.io_struct import (
     SetInternalStateReqOutput,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
+)
+from sgl_jax.srt.multimodal.manager.multimodal_processor import (
+    get_mm_processor_cls,
+    import_processors,
 )
 from sgl_jax.srt.multimodal.tokenizer_utils import resolve_tokenizer_subdir
 from sgl_jax.srt.sampling.sampling_params import SamplingParams
@@ -161,24 +169,54 @@ class TokenizerManager:
         self._cond = asyncio.Condition()
 
         self.mm_processor = None
+        self.processor = None
 
         if server_args.skip_tokenizer_init:
-            self.tokenizer = self.processor = None
+            self.tokenizer = None
         else:
             tokenizer_subdir = ""
             if server_args.multimodal:
                 tokenizer_subdir = resolve_tokenizer_subdir(
                     server_args.model_path, server_args.tokenizer_path
                 )
-            self.tokenizer = get_tokenizer(
-                server_args.tokenizer_path,
-                tokenizer_mode=server_args.tokenizer_mode,
-                trust_remote_code=server_args.trust_remote_code,
-                revision=server_args.revision,
-                tokenizer_backend=server_args.tokenizer_backend,
-                sub_dir=tokenizer_subdir,
-                download_dir=server_args.download_dir,
-            )
+
+            if self.model_config is not None and self.model_config.is_multimodal:
+                import_processors("sgl_jax.srt.multimodal.processors")
+                mm_processor_cls = get_mm_processor_cls(self.model_config.hf_config)
+            else:
+                mm_processor_cls = None
+
+            if mm_processor_cls is not None:
+                tokenizer_path = server_args.tokenizer_path
+                if tokenizer_subdir:
+                    tokenizer_path = os.path.join(tokenizer_path, tokenizer_subdir)
+                self.processor = get_processor(
+                    tokenizer_path,
+                    tokenizer_mode=server_args.tokenizer_mode,
+                    trust_remote_code=server_args.trust_remote_code,
+                    revision=server_args.revision,
+                    use_fast=False,
+                )
+                self.mm_processor = mm_processor_cls(
+                    self.model_config.hf_config, server_args, self.processor
+                )
+                self.tokenizer = get_tokenizer_from_processor(self.processor)
+            else:
+                if self.model_config is not None and self.model_config.is_multimodal:
+                    logger.info(
+                        "No SGL-JAX multimodal processor registered for architectures %s; "
+                        "falling back to text tokenizer.",
+                        self.model_config.hf_config.architectures,
+                    )
+                self.tokenizer = get_tokenizer(
+                    server_args.tokenizer_path,
+                    tokenizer_mode=server_args.tokenizer_mode,
+                    trust_remote_code=server_args.trust_remote_code,
+                    revision=server_args.revision,
+                    tokenizer_backend=server_args.tokenizer_backend,
+                    sub_dir=tokenizer_subdir,
+                    download_dir=server_args.download_dir,
+                )
 
         # Store states
         self.no_create_loop = False
@@ -299,7 +337,23 @@ class TokenizerManager:
         # Tokenize
         input_text = obj.text
         input_ids = obj.input_ids
-        if input_ids is None and input_text is not None:
+        mm_inputs = None
+        if isinstance(obj, GenerateReqInput) and obj.contains_mm_input():
+            if self.mm_processor is None:
+                raise ValueError(
+                    "Multimodal input was provided, but the model has no multimodal processor."
+                )
+            self._validate_mm_limits(obj)
+            mm_inputs = await self.mm_processor.process_mm_data_async(
+                image_data=obj.image_data,
+                input_text=input_text or input_ids,
+                request_obj=obj,
+            )
+            if mm_inputs is None:
+                raise ValueError("The multimodal processor produced no output.")
+            if mm_inputs.input_ids is not None:
+                input_ids = mm_inputs.input_ids
+        elif input_ids is None and input_text is not None:
             if self.tokenizer is None:
                 raise ValueError(
                     "Tokenizer is not initialized but input_text requires tokenization"
@@ -308,7 +362,7 @@ class TokenizerManager:
             input_ids = encoded["input_ids"]
 
         self._validate_one_request(obj, input_ids)
-        return self._create_tokenized_object(obj, input_text, input_ids)
+        return self._create_tokenized_object(obj, input_text, input_ids, mm_inputs)
 
     def _validate_one_request(
         self, obj: GenerateReqInput | EmbeddingReqInput, input_ids: list[int]
@@ -336,6 +390,18 @@ class TokenizerManager:
             )
             raise ValueError(error_msg)
 
+    def _validate_mm_limits(self, obj: GenerateReqInput | EmbeddingReqInput) -> None:
+        if not self.server_args.limit_mm_data_per_request:
+            return
+        for modality, limit in self.server_args.limit_mm_data_per_request.items():
+            data = getattr(obj, f"{modality}_data", None)
+            if data:
+                count = len(data) if isinstance(data, list) else 1
+                if count > limit:
+                    raise ValueError(
+                        f"{modality.capitalize()} count {count} exceeds limit {limit} per request."
+                    )
+
     def _validate_input_ids_in_vocab(self, input_ids: list[int], vocab_size: int) -> None:
         if any(id >= vocab_size for id in input_ids):
             raise ValueError(
@@ -347,6 +413,7 @@ class TokenizerManager:
         obj: GenerateReqInput,
         input_text: str,
         input_ids: list[int],
+        mm_inputs: object | None = None,
     ) -> TokenizedGenerateReqInput:
         """Create a tokenized request object from common parameters."""
         # Parse sampling parameters
@@ -363,19 +430,20 @@ class TokenizerManager:
         # Build return object
 
         tokenized_obj = TokenizedGenerateReqInput(
-            obj.rid,
-            input_text,
-            input_ids,
-            sampling_params,
-            obj.return_logprob,
-            obj.return_output_logprob_only,
-            obj.logprob_start_len,
-            obj.top_logprobs_num,
-            obj.token_ids_logprob,
-            obj.stream,
-            obj.lora_id,
-            obj.extra_key,
-            obj.return_routed_experts,
+            rid=obj.rid,
+            text=input_text,
+            input_ids=input_ids,
+            sampling_params=sampling_params,
+            return_logprob=obj.return_logprob,
+            return_output_logprob_only=obj.return_output_logprob_only,
+            logprob_start_len=obj.logprob_start_len,
+            top_logprobs_num=obj.top_logprobs_num,
+            token_ids_logprob=obj.token_ids_logprob,
+            stream=obj.stream,
+            lora_id=obj.lora_id,
+            extra_key=obj.extra_key,
+            return_routed_experts=obj.return_routed_experts,
+            mm_inputs=mm_inputs,
         )
 
         disagg_mode = getattr(self.server_args, "disaggregation_mode", "null")

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -66,6 +66,7 @@ from sgl_jax.srt.managers.io_struct import (
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
 )
+from sgl_jax.srt.multimodal.common.modality_enum import build_radix_input_ids
 from sgl_jax.srt.multimodal.manager.multimodal_processor import (
     get_mm_processor_cls,
     import_processors,
@@ -433,6 +434,7 @@ class TokenizerManager:
             rid=obj.rid,
             text=input_text,
             input_ids=input_ids,
+            radix_input_ids=build_radix_input_ids(input_ids, mm_inputs),
             sampling_params=sampling_params,
             return_logprob=obj.return_logprob,
             return_output_logprob_only=obj.return_output_logprob_only,

--- a/python/sgl_jax/srt/managers/utils.py
+++ b/python/sgl_jax/srt/managers/utils.py
@@ -23,6 +23,7 @@ def validate_input_length(
     Returns:
         Error message if validation fails, None if successful
     """
+    assert len(req.origin_input_ids) == len(req.radix_input_ids)
     if len(req.origin_input_ids) >= max_req_input_len:
         if allow_auto_truncate:
             logger.warning(
@@ -31,6 +32,8 @@ def validate_input_length(
                 max_req_input_len,
             )
             req.origin_input_ids = req.origin_input_ids[:max_req_input_len]
+            req.radix_input_ids = req.radix_input_ids[:max_req_input_len]
+            assert len(req.origin_input_ids) == len(req.radix_input_ids)
             return None
         else:
             error_msg = (

--- a/python/sgl_jax/srt/mem_cache/radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/radix_cache.py
@@ -58,16 +58,9 @@ class RadixKey:
 
 
 def build_radix_key(req: Req, key_len: int) -> RadixKey:
-    """Build a request key from text tokens and multimodal identities."""
-    cache_input_ids = getattr(req, "cache_input_ids", None)
-    if cache_input_ids is not None:
-        key_sequence = cache_input_ids + req.output_ids if req.output_ids else cache_input_ids
-    else:
-        key_sequence = req.fill_ids
-        if len(key_sequence) < key_len:
-            key_sequence = (
-                req.origin_input_ids + req.output_ids if req.output_ids else req.origin_input_ids
-            )
+    """Build a request key from its canonical radix-cache identity."""
+    assert len(req.radix_input_ids) == len(req.origin_input_ids)
+    key_sequence = req.radix_input_ids + req.output_ids if req.output_ids else req.radix_input_ids
     return RadixKey(key_sequence[:key_len], req.extra_key, req.dp_rank)
 
 

--- a/python/sgl_jax/srt/mem_cache/radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/radix_cache.py
@@ -57,6 +57,20 @@ class RadixKey:
         return f"RadixKey(extra_key={self.extra_key!r}, dp_rank={self.dp_rank!r}, token_ids={preview}{'...' if len(self.token_ids) > 10 else ''})"
 
 
+def build_radix_key(req: Req, key_len: int) -> RadixKey:
+    """Build a request key from text tokens and multimodal identities."""
+    cache_input_ids = getattr(req, "cache_input_ids", None)
+    if cache_input_ids is not None:
+        key_sequence = cache_input_ids + req.output_ids if req.output_ids else cache_input_ids
+    else:
+        key_sequence = req.fill_ids
+        if len(key_sequence) < key_len:
+            key_sequence = (
+                req.origin_input_ids + req.output_ids if req.output_ids else req.origin_input_ids
+            )
+    return RadixKey(key_sequence[:key_len], req.extra_key, req.dp_rank)
+
+
 class TreeNode:
     counter = 0
 
@@ -298,7 +312,7 @@ class RadixCache(BasePrefixCache):
             self.token_to_kv_pool_allocator.free(kv_indices, dp_rank=dp_rank)
             return
 
-        token_ids = (req.origin_input_ids + req.output_ids)[:committed_kv_len]
+        radix_key = build_radix_key(req, committed_kv_len)
         # For EAGLE radix cache, we will convert the key to bigram key, e.g. [1,2,3,4] -> [(1,2), (2,3), (3,4)], the length will -1. ((len([(1,2), (2,3), (3,4)]) = len([1,2,3,4]) - 1))
         # So for the corresponding kv length should also -1. Then we get the actual_kv_len, and use it to do later calculation and slicing.
         actual_kv_len = committed_kv_len - 1 if self.is_eagle else committed_kv_len
@@ -326,7 +340,7 @@ class RadixCache(BasePrefixCache):
             # Radix Cache takes over one reference from memory pool
             new_prefix_len = self.insert(
                 InsertParams(
-                    key=RadixKey(token_ids[:page_aligned_token_len], req.extra_key, req.dp_rank),
+                    key=radix_key[:page_aligned_token_len],
                     value=page_aligned_kv_indices,
                 )
             )
@@ -346,8 +360,7 @@ class RadixCache(BasePrefixCache):
             return
 
         dp_rank = req.dp_rank if req.dp_rank is not None else 0
-        token_ids = req.fill_ids
-        all_token_len = len(token_ids)
+        all_token_len = len(req.fill_ids)
         # For EAGLE radix cache, we will convert the key to bigram key, e.g. [1,2,3,4] -> [(1,2), (2,3), (3,4)], the length will -1. ((len([(1,2), (2,3), (3,4)]) = len([1,2,3,4]) - 1))
         # So for the corresponding kv length should also -1. Then we get the actual_kv_len, and use it to do later calculation and slicing.
         actual_kv_len = all_token_len - 1 if self.is_eagle else all_token_len
@@ -362,7 +375,8 @@ class RadixCache(BasePrefixCache):
 
         # For EAGLE, the page_aligned_len is for the bigram key, the normal key len should +1
         page_aligned_token_len = page_aligned_len + 1 if self.is_eagle else page_aligned_len
-        page_aligned_token_ids = token_ids[:page_aligned_token_len]
+        # Real fill_ids drive kv slicing above; the KEY uses the hash-substituted ids.
+        radix_key = build_radix_key(req, page_aligned_token_len)
 
         # cache_protected_len, not len(prefix_indices): see cache_finished_req above.
         old_prefix_len = req.cache_protected_len
@@ -372,7 +386,6 @@ class RadixCache(BasePrefixCache):
             old_prefix_len -= 1
 
         # Radix Cache takes over one reference from memory pool
-        radix_key = RadixKey(page_aligned_token_ids, req.extra_key, req.dp_rank)
         new_prefix_len = self.insert(InsertParams(key=radix_key, value=page_aligned_kv_indices))
         self.token_to_kv_pool_allocator.free(
             kv_indices[old_prefix_len:new_prefix_len], dp_rank=dp_rank

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -26,7 +26,7 @@ from sgl_jax.srt.mem_cache.radix_cache import (
     _key_match_page_size1 as _key_match_page_size1_radix,
 )
 from sgl_jax.srt.mem_cache.radix_cache import _key_match_paged as _key_match_paged_radix
-from sgl_jax.srt.mem_cache.radix_cache import get_child_key
+from sgl_jax.srt.mem_cache.radix_cache import build_radix_key, get_child_key
 
 if TYPE_CHECKING:
     from sgl_jax.srt.managers.schedule_batch import Req
@@ -410,8 +410,8 @@ class SWARadixCache(BasePrefixCache):
             self.token_to_kv_pool_allocator.free(kv_indices, dp_rank=dp_rank)
             return
 
-        token_ids = (req.origin_input_ids + req.output_ids)[:committed_kv_len]
-        kv_indices = self.req_to_token_pool.req_to_token[req.req_pool_idx, : len(token_ids)]
+        radix_key = build_radix_key(req, committed_kv_len)
+        kv_indices = self.req_to_token_pool.req_to_token[req.req_pool_idx, : len(radix_key)]
 
         if self.page_size != 1:
             page_aligned_len = len(kv_indices) // self.page_size * self.page_size
@@ -427,7 +427,7 @@ class SWARadixCache(BasePrefixCache):
             # Note: the insert function already frees the overlapped kv_indices
             self.insert(
                 InsertParams(
-                    key=RadixKey(token_ids[:page_aligned_len], req.extra_key, req.dp_rank),
+                    key=radix_key[:page_aligned_len],
                     value=page_aligned_kv_indices,
                     prev_prefix_len=req.cache_protected_len,
                     swa_evicted_seqlen=req.swa_evicted_seqlen,
@@ -451,8 +451,8 @@ class SWARadixCache(BasePrefixCache):
             req.prefix_indices = kv_indices.copy()
             return
 
-        token_ids = req.fill_ids
-        kv_indices = self.req_to_token_pool.req_to_token[req.req_pool_idx, : len(token_ids)]
+        radix_key = build_radix_key(req, len(req.fill_ids))
+        kv_indices = self.req_to_token_pool.req_to_token[req.req_pool_idx, : len(radix_key)]
 
         if self.page_size != 1:
             page_aligned_len = len(kv_indices) // self.page_size * self.page_size
@@ -460,23 +460,21 @@ class SWARadixCache(BasePrefixCache):
         else:
             page_aligned_len = len(kv_indices)
             page_aligned_kv_indices = kv_indices.copy()
-        page_aligned_token_ids = token_ids[:page_aligned_len]
+        page_aligned_key = radix_key[:page_aligned_len]
 
         # Radix Cache takes one ref in memory pool
         # Note: the insert function already frees the overlapped kv_indices
         old_prefix_len = req.cache_protected_len
         new_prefix_len = self.insert(
             InsertParams(
-                key=RadixKey(page_aligned_token_ids, req.extra_key, req.dp_rank),
+                key=page_aligned_key,
                 value=page_aligned_kv_indices,
                 prev_prefix_len=old_prefix_len,
                 swa_evicted_seqlen=req.swa_evicted_seqlen,
             )
         )
 
-        match_result = self.match_prefix(
-            MatchPrefixParams(key=RadixKey(page_aligned_token_ids, req.extra_key, req.dp_rank))
-        )
+        match_result = self.match_prefix(MatchPrefixParams(key=page_aligned_key))
         new_indices = match_result.device_indices
         new_last_node = match_result.last_device_node
         assert old_prefix_len <= len(new_indices), f"{old_prefix_len=}, {new_indices=}"

--- a/python/sgl_jax/srt/mem_cache/unified_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/unified_radix_cache.py
@@ -36,6 +36,7 @@ from sgl_jax.srt.mem_cache.radix_cache import (
     _convert_to_bigram_key,
     _key_match_page_size1,
     _key_match_paged,
+    build_radix_key,
     get_child_key,
 )
 from sgl_jax.srt.mem_cache.unified_cache_components import (
@@ -334,7 +335,7 @@ class UnifiedRadixCache(BasePrefixCache):
                 )
             return
 
-        token_ids = (req.origin_input_ids + req.output_ids)[:committed_kv_len]
+        radix_key = build_radix_key(req, committed_kv_len)
         # For the EAGLE bigram key the key length is one less than the token
         # length, so the corresponding kv length is reduced by one as well.
         actual_kv_len = committed_kv_len - 1 if self.is_eagle else committed_kv_len
@@ -350,11 +351,11 @@ class UnifiedRadixCache(BasePrefixCache):
             old_prefix_len -= 1
 
         insert_params = InsertParams() if is_insert else None
-        effective_cache_len = len(token_ids)
+        effective_cache_len = len(radix_key)
         if is_insert:
             for component in self._components_tuple:
                 cl = component.prepare_for_caching_req(
-                    req, insert_params, len(token_ids), is_finished=True
+                    req, insert_params, len(radix_key), is_finished=True
                 )
                 if cl is not None:
                     effective_cache_len = min(effective_cache_len, cl)
@@ -380,9 +381,7 @@ class UnifiedRadixCache(BasePrefixCache):
 
         insert_result = None
         if is_insert and effective_cache_len > 0:
-            insert_params.key = RadixKey(
-                token_ids[:page_aligned_token_len], req.extra_key, req.dp_rank
-            )
+            insert_params.key = radix_key[:page_aligned_token_len]
             insert_params.value = page_aligned_kv_indices
             # Radix cache takes over one reference from the memory pool.
             insert_result = self.insert(insert_params)
@@ -412,8 +411,8 @@ class UnifiedRadixCache(BasePrefixCache):
             return
 
         dp_rank = req.dp_rank if req.dp_rank is not None else 0
-        token_ids = req.fill_ids
-        all_token_len = len(token_ids)
+        radix_key = build_radix_key(req, len(req.fill_ids))
+        all_token_len = len(radix_key)
         actual_kv_len = all_token_len - 1 if self.is_eagle else all_token_len
         kv_indices = self.req_to_token_pool.read(req.req_pool_idx, all_token_len)
 
@@ -452,10 +451,9 @@ class UnifiedRadixCache(BasePrefixCache):
 
         # For EAGLE, page_aligned_len is for the bigram key; the token len is +1.
         page_aligned_token_len = page_aligned_len + 1 if self.is_eagle else page_aligned_len
-        page_aligned_token_ids = token_ids[:page_aligned_token_len]
+        page_aligned_key = radix_key[:page_aligned_token_len]
 
-        radix_key = RadixKey(page_aligned_token_ids, req.extra_key, req.dp_rank)
-        insert_params.key = radix_key
+        insert_params.key = page_aligned_key
         insert_params.value = page_aligned_kv_indices
         # Radix cache takes over one reference from the memory pool.
         insert_result = self.insert(insert_params)
@@ -465,7 +463,9 @@ class UnifiedRadixCache(BasePrefixCache):
         )
 
         # Prefix indices may have been updated, reuse them.
-        new_match_result = self.match_prefix(MatchPrefixParams(key=radix_key, full_only=True))
+        new_match_result = self.match_prefix(
+            MatchPrefixParams(key=page_aligned_key, full_only=True)
+        )
         new_indices = new_match_result.device_indices
         new_last_node = new_match_result.last_device_node
 

--- a/python/sgl_jax/srt/multimodal/common/modality_enum.py
+++ b/python/sgl_jax/srt/multimodal/common/modality_enum.py
@@ -409,3 +409,14 @@ def build_cache_input_ids(
         return None
     padded_ids = pad_input_tokens(input_ids, mm_inputs.mm_items)
     return padded_ids if padded_ids != input_ids else None
+
+
+def build_radix_input_ids(
+    input_ids: list[int],
+    mm_inputs: MultimodalInputs | dict | None,
+) -> list[int]:
+    """Build the canonical token identity used by every radix-cache operation."""
+    cache_input_ids = build_cache_input_ids(input_ids, mm_inputs)
+    radix_input_ids = cache_input_ids if cache_input_ids is not None else list(input_ids)
+    assert len(radix_input_ids) == len(input_ids)
+    return radix_input_ids

--- a/python/sgl_jax/srt/multimodal/common/modality_enum.py
+++ b/python/sgl_jax/srt/multimodal/common/modality_enum.py
@@ -76,17 +76,45 @@ def tensor_hash(tensor_list: Any) -> int:
 def pad_input_tokens(
     input_ids: list[int],
     mm_items: list["MultimodalDataItem"],
+    im_token_id: int | None = None,
+    video_token_id: int | None = None,
+    audio_token_id: int | None = None,
 ) -> list[int]:
-    """Replace placeholder ranges with per-item Radix identity tokens."""
+    """Replace multimodal placeholders with per-item Radix identity tokens.
+
+    New processors provide exact placeholder ranges. Legacy processors only
+    provide one token ID per modality, so retain token-based replacement as a
+    fallback for items without ranges.
+    """
     if not input_ids or not mm_items:
         return input_ids
+
     padded_ids = list(input_ids)
+    fallback_pad_values: dict[int, int] = {}
     for item in mm_items:
         if item.pad_value is None:
             item.set_pad_value()
         if item.placeholder_ranges is not None:
             for start, end in item.placeholder_ranges:
                 padded_ids[start:end] = [item.pad_value] * (end - start)  # type: ignore[list-item]
+            continue
+
+        token_id = None
+        if item.is_image():
+            token_id = im_token_id
+        elif item.is_video():
+            token_id = video_token_id
+        elif item.is_audio():
+            token_id = audio_token_id
+        if token_id is not None and item.pad_value is not None:
+            # Match the legacy behavior: one multimodal item may contain all
+            # payloads of a modality, so its identity covers every matching
+            # placeholder token.
+            fallback_pad_values.setdefault(token_id, item.pad_value)
+
+    for index, token_id in enumerate(padded_ids):
+        if token_id in fallback_pad_values:
+            padded_ids[index] = fallback_pad_values[token_id]
     return padded_ids
 
 

--- a/python/sgl_jax/srt/multimodal/common/modality_enum.py
+++ b/python/sgl_jax/srt/multimodal/common/modality_enum.py
@@ -293,9 +293,10 @@ class MultimodalInputs:
     audio_start_id: int | None = None
     audio_end_id: int | None = None
 
-    # QWen2-VL related
-    mrope_positions: jax.Array | None = None
-    mrope_position_delta: jax.Array | None = None
+    # QWen2-VL related. Keep request/scheduler metadata on host; conversion to
+    # jax.Array happens only when ForwardBatch is built for model execution.
+    mrope_positions: np.ndarray | None = None
+    mrope_position_delta: np.ndarray | None = None
 
     @staticmethod
     def from_dict(obj: dict):
@@ -332,10 +333,9 @@ class MultimodalInputs:
         for arg in optional_args:
             if arg in obj:
                 value = obj[arg]
-                if isinstance(value, (np.ndarray, jax.Array)):
-                    setattr(ret, arg, jax.device_put(value))
-                else:
-                    setattr(ret, arg, value)
+                if arg in ("mrope_positions", "mrope_position_delta"):
+                    value = None if value is None else np.asarray(value, dtype=np.int32)
+                setattr(ret, arg, value)
 
         return ret
 
@@ -362,19 +362,19 @@ class MultimodalInputs:
         # Merge mm_items
         self.mm_items += other.mm_items
 
-        # Merge mrope_positions (JAX array handling)
+        # Merge host-side mrope_positions.
         if self.mrope_positions is not None:
             if other.mrope_positions is not None:
-                self.mrope_positions = jnp.concatenate(
+                self.mrope_positions = np.concatenate(
                     [self.mrope_positions, other.mrope_positions], axis=1
                 )
         else:
             self.mrope_positions = other.mrope_positions
 
-        # Merge mrope_position_delta (JAX array handling)
+        # Merge host-side mrope_position_delta.
         if self.mrope_position_delta is not None:
             if other.mrope_position_delta is not None:
-                self.mrope_position_delta = jnp.concatenate(
+                self.mrope_position_delta = np.concatenate(
                     [self.mrope_position_delta, other.mrope_position_delta], axis=0
                 )
         else:

--- a/python/sgl_jax/srt/multimodal/common/modality_enum.py
+++ b/python/sgl_jax/srt/multimodal/common/modality_enum.py
@@ -76,75 +76,17 @@ def tensor_hash(tensor_list: Any) -> int:
 def pad_input_tokens(
     input_ids: list[int],
     mm_items: list["MultimodalDataItem"],
-    im_token_id: int = None,
-    video_token_id: int = None,
-    audio_token_id: int = None,
 ) -> list[int]:
-    """
-    Replace multimodal placeholder tokens in input_ids with corresponding pad_values from mm_items.
-    This is critical for radix cache to differentiate between different images/videos.
-    Different images/videos will have different pad_values (hash-based), so the cache
-    will correctly identify them as different prefixes.
-    Args:
-        input_ids: The input token IDs containing placeholder tokens
-        mm_items: List of multimodal data items with pad_value set
-        im_token_id: Token ID used for image placeholders
-        video_token_id: Token ID used for video placeholders
-        audio_token_id: Token ID used for audio placeholders
-    Returns:
-        Modified input_ids with placeholder tokens replaced by pad_values
-    """
+    """Replace placeholder ranges with per-item Radix identity tokens."""
     if not input_ids or not mm_items:
         return input_ids
-
-    # Build mapping from token_id to list of pad_values for each modality
-    # We need to handle multiple items of the same modality
-    image_pad_values = []
-    video_pad_values = []
-    audio_pad_values = []
-
+    padded_ids = list(input_ids)
     for item in mm_items:
         if item.pad_value is None:
             item.set_pad_value()
-
-        if item.is_image() and im_token_id is not None:
-            image_pad_values.append(item.pad_value)
-        elif item.is_video() and video_token_id is not None:
-            video_pad_values.append(item.pad_value)
-        elif item.is_audio() and audio_token_id is not None:
-            audio_pad_values.append(item.pad_value)
-
-    # Create a mutable copy of input_ids
-    padded_ids = list(input_ids)
-
-    # Replace image tokens
-    if im_token_id is not None and image_pad_values:
-        image_idx = 0
-        for i, token_id in enumerate(padded_ids):
-            if token_id == im_token_id:
-                # Use the pad_value for current image, cycling through if needed
-                pad_value = image_pad_values[min(image_idx, len(image_pad_values) - 1)]
-                padded_ids[i] = pad_value
-                # Don't increment image_idx for each token, only when we hit a boundary
-                # Actually, for simple replacement, use same pad_value for all tokens of an image
-
-    # Replace video tokens
-    if video_token_id is not None and video_pad_values:
-        video_idx = 0
-        for i, token_id in enumerate(padded_ids):
-            if token_id == video_token_id:
-                # Use the pad_value for current video
-                pad_value = video_pad_values[min(video_idx, len(video_pad_values) - 1)]
-                padded_ids[i] = pad_value
-
-    # Replace audio tokens
-    if audio_token_id is not None and audio_pad_values:
-        audio_idx = 0
-        for i, token_id in enumerate(padded_ids):
-            if token_id == audio_token_id:
-                pad_value = audio_pad_values[min(audio_idx, len(audio_pad_values) - 1)]
-                padded_ids[i] = pad_value
-
+        if item.placeholder_ranges is not None:
+            for start, end in item.placeholder_ranges:
+                padded_ids[start:end] = [item.pad_value] * (end - start)  # type: ignore[list-item]
     return padded_ids
 
 
@@ -179,13 +121,11 @@ class MultimodalDataItem:
     modality: Modality
     hash: int | None = None
     pad_value: int | None = None
-    offsets: list | None = None
+    # Half-open token-index ranges [start, end) of multimodal placeholders in input_ids (per request).
+    placeholder_ranges: list[tuple[int, int]] | None = None
 
     # Raw features returned by processor, e.g. pixel_values or audio_features
     feature: jax.Array | np.ndarray | None = None
-    # Precomputed embeddings passed as final encoder embeddings
-    # Only one of feature and precomputed_embeddings is non-empty
-    precomputed_embeddings: jax.Array | np.ndarray | None = None
 
     # Model-specific data stored in dictionary
     model_specific_data: dict[str, Any] = dataclasses.field(default_factory=dict)
@@ -205,27 +145,35 @@ class MultimodalDataItem:
     def set(self, key: str, value: Any):
         self.__setitem__(key, value)
 
+    def get(self, key: str, default: Any = None) -> Any:
+        if key in self.__dataclass_fields__ and key != "model_specific_data":
+            return getattr(self, key)
+        return self.model_specific_data.get(key, default)
+
     @staticmethod
     def is_empty_list(lst):
         if lst is None:
             return True
         return len([item for item in flatten_nested_list(lst) if item is not None]) == 0
 
-    def set_pad_value(self):
-        """
-        Set padding value after hashing the data first
-        """
+    def set_pad_value(self) -> None:
         if self.hash is None:
-            if self.feature is not None:
-                hashed_feature = self.feature
-            else:
-                hashed_feature = self.precomputed_embeddings
-            self.hash = hash_feature(hashed_feature)
+            feature = self.feature
+            layout = (
+                (tuple(feature.shape), str(feature.dtype))
+                if isinstance(feature, (jax.Array, np.ndarray))
+                else None
+            )
+            self.hash = hash_feature(
+                (
+                    self.modality,
+                    hash_feature(feature),
+                    layout,
+                    hash_feature(self.model_specific_data),
+                )
+            )
         assert self.hash is not None
-        # Use a smaller modulo to keep pad_value in a reasonable range
-        # The pad_value is used for radix cache differentiation, not for embedding lookup
-        # We use a 24-bit range which gives ~16M unique values, sufficient for cache keys
-        self.pad_value = self.hash % (1 << 24)
+        self.pad_value = -(self.hash & ((1 << 63) - 1)) - 1
 
     def is_modality(self, modality: Modality) -> bool:
         return self.modality == modality
@@ -251,8 +199,22 @@ class MultimodalDataItem:
         kwargs = dict(obj)
         modality = kwargs.pop("modality")
         if isinstance(modality, str):
-            modality = Modality[modality]
-        ret = MultimodalDataItem(modality=modality, **kwargs)
+            modality = Modality.from_str(modality)
+
+        field_names = set(MultimodalDataItem.__dataclass_fields__)
+        model_specific_data = dict(kwargs.pop("model_specific_data", {}) or {})
+        item_kwargs = {}
+        for key, value in kwargs.items():
+            if key in field_names and key != "model_specific_data":
+                item_kwargs[key] = value
+            else:
+                model_specific_data[key] = value
+
+        ret = MultimodalDataItem(
+            modality=modality,
+            model_specific_data=model_specific_data,
+            **item_kwargs,
+        )
         ret.validate()
         return ret
 
@@ -269,9 +231,9 @@ class MultimodalDataItem:
                     [jax.device_put(self.feature), jax.device_put(other.feature)], axis=0
                 )
 
-        # Merge offsets
-        if self.offsets is not None and other.offsets is not None:
-            self.offsets += other.offsets
+        # Merge placeholder ranges
+        if self.placeholder_ranges is not None and other.placeholder_ranges is not None:
+            self.placeholder_ranges += other.placeholder_ranges
 
         # Update hash
         self.hash = hash((self.hash, other.hash))
@@ -284,6 +246,7 @@ class MultimodalInputs:
 
     # List of data items
     mm_items: list[MultimodalDataItem]
+    input_ids: list[int] | None = None
     image_pad_len: list | None = None
     num_image_tokens: int | None = None
 
@@ -402,3 +365,19 @@ class MultimodalInputs:
             self.num_image_tokens += other.num_image_tokens
         elif self.num_image_tokens is None:
             self.num_image_tokens = other.num_image_tokens
+
+
+def build_cache_input_ids(
+    input_ids: list[int] | None,
+    mm_inputs: MultimodalInputs | dict | None,
+) -> list[int] | None:
+    """Build hash-substituted IDs used only for multimodal cache keys."""
+    if (
+        not isinstance(mm_inputs, MultimodalInputs)
+        or not mm_inputs.mm_items
+        or not input_ids
+        or not isinstance(input_ids[0], int)
+    ):
+        return None
+    padded_ids = pad_input_tokens(input_ids, mm_inputs.mm_items)
+    return padded_ids if padded_ids != input_ids else None

--- a/python/sgl_jax/srt/multimodal/manager/global_scheduler.py
+++ b/python/sgl_jax/srt/multimodal/manager/global_scheduler.py
@@ -291,6 +291,7 @@ class GlobalScheduler:
         )
         req.origin_input_text = input.prompt
         req.origin_input_ids = input.input_ids
+        req.radix_input_ids = list(input.input_ids or [])
         req.omni_inputs = input.mm_inputs
         if input.mm_inputs:
             mm_items = input.mm_inputs.get("mm_items", [])
@@ -366,7 +367,7 @@ class GlobalScheduler:
             video_token_id = input.mm_inputs.get("video_token_id")
             audio_token_id = input.mm_inputs.get("audio_token_id")
             if req.input_ids:
-                req.cache_input_ids = pad_input_tokens(
+                req.radix_input_ids = pad_input_tokens(
                     input_ids=list(req.input_ids),
                     mm_items=all_mm_items,
                     im_token_id=im_token_id,

--- a/python/sgl_jax/srt/multimodal/manager/mrope_utils.py
+++ b/python/sgl_jax/srt/multimodal/manager/mrope_utils.py
@@ -1,6 +1,59 @@
 import numpy as np
 
 
+def contiguous_runs(token_types) -> list[tuple[int, int, int]]:
+    """Split a 1-D label sequence into ``(label, start, end)`` contiguous runs."""
+    token_types = np.asarray(token_types)
+    runs = []
+    start = 0
+    for index in range(1, token_types.size + 1):
+        if index == token_types.size or token_types[index] != token_types[start]:
+            runs.append((int(token_types[start]), start, index))
+            start = index
+    return runs
+
+
+def compute_qwen3vl_mrope_positions(
+    *,
+    mm_token_type_ids,
+    image_grid_thw,
+    video_grid_thw,
+    spatial_merge_size,
+) -> tuple[np.ndarray, int]:
+    token_types = np.asarray(mm_token_type_ids, dtype=np.int32).reshape(-1)
+    if token_types.size == 0:
+        return np.zeros((3, 0), dtype=np.int32), 0
+    video_frames = [(1, int(h), int(w)) for t, h, w in video_grid_thw or [] for _ in range(int(t))]
+    grids = {1: iter(image_grid_thw or []), 2: iter(video_frames)}
+    groups = contiguous_runs(token_types)
+
+    position_groups = []
+    current = 0
+    for modality, start, end in groups:
+        if modality == 0:
+            length = end - start
+            position_groups.append(
+                np.broadcast_to(np.arange(length, dtype=np.int32), (3, length)) + current
+            )
+            current += length
+            continue
+        try:
+            t, h, w = next(grids[modality])
+        except (KeyError, StopIteration) as exc:
+            raise ValueError("Qwen3-VL token types do not match vision grids.") from exc
+        t, h, w = int(t), int(h) // spatial_merge_size, int(w) // spatial_merge_size
+        if end - start != t * h * w:
+            raise ValueError("Qwen3-VL vision token group does not match grid_thw.")
+        temporal, height, width = np.meshgrid(
+            np.arange(t), np.arange(h), np.arange(w), indexing="ij"
+        )
+        position_groups.append(np.stack((temporal, height, width), axis=0).reshape(3, -1) + current)
+        current += max(t, h, w)
+
+    positions = np.concatenate(position_groups, axis=1).astype(np.int32)
+    return positions, int(positions.max() + 1 - token_types.size)
+
+
 def compute_mrope_positions(
     *,
     input_ids: list[int],

--- a/python/sgl_jax/srt/multimodal/manager/multimodal_processor.py
+++ b/python/sgl_jax/srt/multimodal/manager/multimodal_processor.py
@@ -1,0 +1,48 @@
+import importlib
+import inspect
+import logging
+import pkgutil
+
+from sgl_jax.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+
+logger = logging.getLogger(__name__)
+
+PROCESSOR_MAPPING: dict[str, type[BaseMultimodalProcessor]] = {}
+
+
+def import_processors(package_name: str) -> None:
+    package = importlib.import_module(package_name)
+    for _, name, ispkg in pkgutil.iter_modules(package.__path__, package_name + "."):
+        if ispkg:
+            continue
+        try:
+            module = importlib.import_module(name)
+        except Exception as e:
+            logger.warning("Ignore import error when loading %s: %s", name, e)
+            continue
+        for _, cls in inspect.getmembers(module, inspect.isclass):
+            if cls.__module__ != module.__name__:
+                continue
+            if not issubclass(cls, BaseMultimodalProcessor) or cls is BaseMultimodalProcessor:
+                continue
+            for arch in getattr(cls, "models", ()):
+                PROCESSOR_MAPPING[arch] = cls
+
+
+def get_mm_processor_cls(hf_config) -> type[BaseMultimodalProcessor] | None:
+    for arch in hf_config.architectures:
+        processor_cls = PROCESSOR_MAPPING.get(arch)
+        if processor_cls is not None:
+            return processor_cls
+    return None
+
+
+def get_mm_processor(hf_config, server_args, processor) -> BaseMultimodalProcessor:
+    processor_cls = get_mm_processor_cls(hf_config)
+    if processor_cls is not None:
+        return processor_cls(hf_config, server_args, processor)
+
+    raise ValueError(
+        f"No multimodal processor registered for architecture: {hf_config.architectures}.\n"
+        f"Registered architectures: {sorted(PROCESSOR_MAPPING)}"
+    )

--- a/python/sgl_jax/srt/multimodal/manager/schedule_batch.py
+++ b/python/sgl_jax/srt/multimodal/manager/schedule_batch.py
@@ -93,7 +93,7 @@ class Req:
     input_embeds: jax.Array | None = None
     image_grid_thw: tuple | None = None
     video_grid_thw: tuple | None = None
-    cache_input_ids: list[int] | None = None
+    radix_input_ids: list[int] = field(default_factory=list)
 
     # Batch info
     num_outputs_per_prompt: int = 1
@@ -243,13 +243,15 @@ class Req:
                         max_new_tokens=1,
                         stop=self.extra.get("stop"),
                     )
+                model_input_ids = self.input_ids or self.origin_input_ids
                 tokenized_req = TokenizedGenerateReqInput(
                     rid=self.rid,
-                    input_ids=self.input_ids or self.origin_input_ids,
+                    input_ids=model_input_ids,
+                    radix_input_ids=self.radix_input_ids or list(model_input_ids or []),
                     sampling_params=sampling_params,
                     stream=bool(self.extra.get("stream", False)),
+                    mm_inputs=self.omni_inputs,
                 )
-                tokenized_req.mm_inputs = self.omni_inputs
                 return [tokenized_req]
             return [
                 TokenizedGenerateReqInput(

--- a/python/sgl_jax/srt/multimodal/processors/base_processor.py
+++ b/python/sgl_jax/srt/multimodal/processors/base_processor.py
@@ -1,0 +1,118 @@
+import asyncio
+import base64
+import concurrent.futures
+import io
+import os
+from abc import ABC, abstractmethod
+from urllib.parse import unquote, urlparse
+
+import numpy as np
+import requests
+from PIL import Image
+
+from sgl_jax.srt.multimodal.common.modality_enum import MultimodalInputs
+
+# Safety limits for fetching remote multimodal payloads. These are intentionally
+# conservative and should become configurable via ServerArgs.
+DEFAULT_HTTP_TIMEOUT_SECS = 30
+MAX_REMOTE_BYTES = 64 * 1024 * 1024  # 64 MiB hard cap per asset
+
+IMAGE_IO_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=8,
+    thread_name_prefix="image-data-executor",
+)
+
+
+def _fetch_url(url: str) -> bytes:
+    with requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT_SECS, stream=True) as response:
+        response.raise_for_status()
+        content_length = response.headers.get("Content-Length")
+        if content_length is not None and int(content_length) > MAX_REMOTE_BYTES:
+            raise ValueError(
+                f"Remote asset at {url} reports {content_length} bytes, "
+                f"exceeds limit of {MAX_REMOTE_BYTES} bytes."
+            )
+        buffer = bytearray()
+        for chunk in response.iter_content(chunk_size=1 << 20):
+            buffer.extend(chunk)
+            if len(buffer) > MAX_REMOTE_BYTES:
+                raise ValueError(
+                    f"Remote asset at {url} exceeds limit of {MAX_REMOTE_BYTES} bytes."
+                )
+        return bytes(buffer)
+
+
+def _normalize_image_source(source) -> bytes | str:
+    """Normalize an image source into raw bytes or a local file path.
+
+    Accepts: bytes, http(s) URL, file:// URI, data: URI, local file path,
+    or a bare base64 string.
+    """
+    if isinstance(source, bytes):
+        return source
+    if not isinstance(source, str):
+        raise ValueError(f"Unsupported image source: {type(source)}")
+    if source.startswith(("http://", "https://")):
+        return _fetch_url(source)
+    if source.startswith("file://"):
+        return unquote(urlparse(source).path)
+    if source.startswith("data:"):
+        return base64.b64decode(source.split(",", 1)[1], validate=True)
+    if os.path.isfile(source):
+        return source
+    return base64.b64decode(source, validate=True)
+
+
+class BaseMultimodalProcessor(ABC):
+    models: tuple[str, ...] = ()
+
+    def __init__(self, hf_config, server_args, processor):
+        self.hf_config = hf_config
+        self.server_args = server_args
+        self.processor = processor
+
+    def apply_chat_template(self, *args, **kwargs):
+        return self.processor.apply_chat_template(*args, **kwargs)
+
+    @abstractmethod
+    async def process_mm_data_async(
+        self,
+        image_data,
+        input_text,
+        request_obj,
+        **kwargs,
+    ) -> MultimodalInputs:
+        """Process multimodal payload and return a ``MultimodalInputs``."""
+        pass
+
+    @staticmethod
+    def normalize_data(data) -> list:
+        if data is None:
+            return []
+        return data if isinstance(data, list) else [data]
+
+    @staticmethod
+    def unwrap_source(source):
+        if isinstance(source, dict) and "url" in source:
+            return source["url"]
+        if hasattr(source, "url"):
+            return source.url
+        return source
+
+    @classmethod
+    def load_image(cls, source) -> Image.Image:
+        source = cls.unwrap_source(source)
+        if isinstance(source, Image.Image):
+            return source.convert("RGB")
+        if isinstance(source, np.ndarray):
+            return Image.fromarray(source).convert("RGB")
+
+        payload = _normalize_image_source(source)
+        if isinstance(payload, bytes):
+            return Image.open(io.BytesIO(payload)).convert("RGB")
+        return Image.open(payload).convert("RGB")
+
+    @classmethod
+    async def load_image_async(cls, source) -> Image.Image:
+        future = IMAGE_IO_EXECUTOR.submit(cls.load_image, source)
+        return await asyncio.wrap_future(future)

--- a/python/sgl_jax/srt/multimodal/processors/base_processor.py
+++ b/python/sgl_jax/srt/multimodal/processors/base_processor.py
@@ -23,7 +23,7 @@ IMAGE_IO_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
 )
 
 
-def _fetch_url(url: str) -> bytes:
+def fetch_remote_bytes(url: str) -> bytes:
     with requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT_SECS, stream=True) as response:
         response.raise_for_status()
         content_length = response.headers.get("Content-Length")
@@ -53,7 +53,7 @@ def _normalize_image_source(source) -> bytes | str:
     if not isinstance(source, str):
         raise ValueError(f"Unsupported image source: {type(source)}")
     if source.startswith(("http://", "https://")):
-        return _fetch_url(source)
+        return fetch_remote_bytes(source)
     if source.startswith("file://"):
         return unquote(urlparse(source).path)
     if source.startswith("data:"):

--- a/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
+++ b/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
@@ -175,20 +175,9 @@ def _write_temp_video(payload: bytes) -> str:
         return tmp.name
 
 
-def _unwrap_source(source):
-    if isinstance(source, dict) and "url" in source:
-        return source["url"]
-    if hasattr(source, "url"):
-        return source.url
-    return source
-
-
 def preprocess_video(source, video_config: dict) -> np.ndarray:
     if isinstance(source, np.ndarray):
         return _resize_video_frames(source, video_config)
-
-    source = _unwrap_source(source)
-
     from decord import VideoReader, cpu
 
     tmp_path = None
@@ -509,7 +498,7 @@ class QwenVLProcessor(BaseMultimodalProcessor):
     async def _load_videos_async(self, video_data, video_config):
         return await asyncio.gather(
             *(
-                asyncio.to_thread(preprocess_video, item, video_config)
+                asyncio.to_thread(preprocess_video, self.unwrap_source(item), video_config)
                 for item in self.normalize_data(video_data)
             )
         )

--- a/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
+++ b/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
@@ -6,7 +6,6 @@ import os
 import tempfile
 
 import numpy as np
-import requests
 from PIL import Image
 
 from sgl_jax.srt.multimodal.common.modality_enum import (
@@ -19,7 +18,10 @@ from sgl_jax.srt.multimodal.manager.mrope_utils import (
     compute_qwen3vl_mrope_positions,
     contiguous_runs,
 )
-from sgl_jax.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+from sgl_jax.srt.multimodal.processors.base_processor import (
+    BaseMultimodalProcessor,
+    fetch_remote_bytes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +41,6 @@ FPS_MAX_FRAMES = 768
 _QWEN3VL_ARCHITECTURES = frozenset(
     {
         "Qwen3VLForConditionalGeneration",
-        "Qwen3_5ForConditionalGeneration",
-        "Qwen3_5MoeForConditionalGeneration",
     }
 )
 
@@ -201,9 +201,7 @@ def preprocess_video(source, video_config: dict) -> np.ndarray:
             if os.path.exists(source):
                 vr = VideoReader(source, ctx=ctx)
             elif source.startswith(("http://", "https://")):
-                response = requests.get(source, timeout=10)
-                response.raise_for_status()
-                tmp_path = _write_temp_video(response.content)
+                tmp_path = _write_temp_video(fetch_remote_bytes(source))
                 vr = VideoReader(tmp_path, ctx=ctx)
             elif source.startswith("data:") and "base64," in source:
                 payload = source.split("base64,", 1)[1]
@@ -240,8 +238,6 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         "Qwen2VLForConditionalGeneration",
         "Qwen2_5_VLForConditionalGeneration",
         "Qwen3VLForConditionalGeneration",
-        "Qwen3_5ForConditionalGeneration",
-        "Qwen3_5MoeForConditionalGeneration",
     )
 
     async def process_mm_data_async(

--- a/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
+++ b/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
@@ -1,0 +1,550 @@
+import asyncio
+import base64
+import logging
+import math
+import os
+import tempfile
+
+import numpy as np
+import requests
+from PIL import Image
+
+from sgl_jax.srt.multimodal.common.modality_enum import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sgl_jax.srt.multimodal.manager.mrope_utils import (
+    compute_mrope_positions,
+    compute_qwen3vl_mrope_positions,
+    contiguous_runs,
+)
+from sgl_jax.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+
+logger = logging.getLogger(__name__)
+
+IMAGE_FACTOR = 28
+MIN_PIXELS = 4 * 28 * 28
+MAX_PIXELS = 16384 * 28 * 28
+MAX_RATIO = 200
+VIDEO_TOTAL_PIXELS = int(float(os.environ.get("VIDEO_MAX_PIXELS", 128000 * 28 * 28 * 0.9)))
+VIDEO_MIN_PIXELS = 128 * 28 * 28
+VIDEO_MAX_PIXELS = 768 * 28 * 28
+FRAME_FACTOR = 2
+FPS = 2.0
+FPS_MIN_FRAMES = 4
+FPS_MAX_FRAMES = 768
+
+# Architectures whose HF processor emits mm token-type ids (Qwen3-VL family).
+_QWEN3VL_ARCHITECTURES = frozenset(
+    {
+        "Qwen3VLForConditionalGeneration",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    }
+)
+
+
+def smart_resize(
+    height: int,
+    width: int,
+    factor: int = IMAGE_FACTOR,
+    min_pixels: int = MIN_PIXELS,
+    max_pixels: int = MAX_PIXELS,
+) -> tuple[int, int]:
+    """Ported from SGLang Qwen-VL video preprocessing."""
+    if max(height, width) / min(height, width) > MAX_RATIO:
+        ratio = max(height, width) / min(height, width)
+        raise ValueError(f"absolute aspect ratio must be smaller than {MAX_RATIO}, got {ratio}")
+    h_bar = max(factor, round_by_factor(height, factor))
+    w_bar = max(factor, round_by_factor(width, factor))
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = floor_by_factor(height / beta, factor)
+        w_bar = floor_by_factor(width / beta, factor)
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = ceil_by_factor(height * beta, factor)
+        w_bar = ceil_by_factor(width * beta, factor)
+    return h_bar, w_bar
+
+
+def round_by_factor(number: int, factor: int) -> int:
+    return round(number / factor) * factor
+
+
+def ceil_by_factor(number: int, factor: int) -> int:
+    return math.ceil(number / factor) * factor
+
+
+def floor_by_factor(number: int, factor: int) -> int:
+    return math.floor(number / factor) * factor
+
+
+def smart_nframes(video_config: dict, total_frames: int, video_fps: int | float) -> int:
+    assert not (
+        "fps" in video_config and "nframes" in video_config
+    ), "Only accept either `fps` or `nframes`"
+    if "nframes" in video_config:
+        nframes = round_by_factor(video_config["nframes"], FRAME_FACTOR)
+    else:
+        fps = video_config.get("fps", FPS)
+        min_frames = ceil_by_factor(video_config.get("min_frames", FPS_MIN_FRAMES), FRAME_FACTOR)
+        max_frames = floor_by_factor(
+            video_config.get("max_frames", min(FPS_MAX_FRAMES, total_frames)),
+            FRAME_FACTOR,
+        )
+        nframes = total_frames / video_fps * fps
+        nframes = min(min(max(nframes, min_frames), max_frames), total_frames)
+        nframes = floor_by_factor(nframes, FRAME_FACTOR)
+    if not (FRAME_FACTOR <= nframes <= total_frames):
+        raise ValueError(
+            f"nframes should in interval [{FRAME_FACTOR}, {total_frames}], but got {nframes}."
+        )
+    return int(nframes)
+
+
+def _resize_video_frames(video: np.ndarray, video_config: dict) -> np.ndarray:
+    if video.ndim != 4:
+        raise ValueError(f"Expected video array with 4 dims (T,H,W,C), got {video.shape}")
+
+    nframes, height, width = video.shape[0], video.shape[1], video.shape[2]
+    factor = int(video_config.get("factor", IMAGE_FACTOR))
+    min_pixels = video_config.get("min_pixels", VIDEO_MIN_PIXELS)
+    total_pixels = video_config.get("total_pixels", VIDEO_TOTAL_PIXELS)
+    max_pixels = max(
+        min(
+            video_config.get("max_pixels", VIDEO_MAX_PIXELS),
+            total_pixels / nframes * FRAME_FACTOR,
+        ),
+        int(min_pixels * 1.05),
+    )
+
+    max_pixels_supposed = video_config.get("max_pixels", max_pixels)
+    max_pixels = min(max_pixels_supposed, max_pixels)
+    if "resized_height" in video_config and "resized_width" in video_config:
+        resized_height, resized_width = smart_resize(
+            video_config["resized_height"],
+            video_config["resized_width"],
+            factor=factor,
+        )
+    else:
+        resized_height, resized_width = smart_resize(
+            height,
+            width,
+            factor=factor,
+            min_pixels=min_pixels,
+            max_pixels=max_pixels,
+        )
+
+    if resized_height == height and resized_width == width:
+        logger.info(
+            "Qwen-VL video resize skipped: frames=%s, size=%sx%s, max_pixels=%s",
+            nframes,
+            height,
+            width,
+            max_pixels,
+        )
+        return video
+
+    logger.info(
+        "Qwen-VL video resized: frames=%s, original=%sx%s, resized=%sx%s, "
+        "min_pixels=%s, max_pixels=%s",
+        nframes,
+        height,
+        width,
+        resized_height,
+        resized_width,
+        min_pixels,
+        max_pixels,
+    )
+
+    resized_frames = []
+    for frame in video:
+        img = Image.fromarray(frame)
+        if img.mode != "RGB":
+            img = img.convert("RGB")
+        img = img.resize((resized_width, resized_height), resample=Image.BILINEAR)
+        resized_frames.append(np.asarray(img))
+    return np.stack(resized_frames, axis=0)
+
+
+def _write_temp_video(payload: bytes) -> str:
+    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+        tmp.write(payload)
+        return tmp.name
+
+
+def _unwrap_source(source):
+    if isinstance(source, dict) and "url" in source:
+        return source["url"]
+    if hasattr(source, "url"):
+        return source.url
+    return source
+
+
+def preprocess_video(source, video_config: dict) -> np.ndarray:
+    if isinstance(source, np.ndarray):
+        return _resize_video_frames(source, video_config)
+
+    source = _unwrap_source(source)
+
+    from decord import VideoReader, cpu
+
+    tmp_path = None
+    try:
+        ctx = cpu(0)
+        if isinstance(source, bytes):
+            tmp_path = _write_temp_video(source)
+            vr = VideoReader(tmp_path, ctx=ctx)
+        elif isinstance(source, str):
+            if os.path.exists(source):
+                vr = VideoReader(source, ctx=ctx)
+            elif source.startswith(("http://", "https://")):
+                response = requests.get(source, timeout=10)
+                response.raise_for_status()
+                tmp_path = _write_temp_video(response.content)
+                vr = VideoReader(tmp_path, ctx=ctx)
+            elif source.startswith("data:") and "base64," in source:
+                payload = source.split("base64,", 1)[1]
+                tmp_path = _write_temp_video(base64.b64decode(payload))
+                vr = VideoReader(tmp_path, ctx=ctx)
+            else:
+                tmp_path = _write_temp_video(base64.b64decode(source, validate=True))
+                vr = VideoReader(tmp_path, ctx=ctx)
+        else:
+            raise ValueError(f"Unsupported video input type: {type(source)}")
+
+        total_frames = len(vr)
+        if total_frames <= 0:
+            raise ValueError("Video must have at least one frame.")
+        video_fps = float(vr.get_avg_fps() or 1.0)
+        nframes = smart_nframes(video_config, total_frames=total_frames, video_fps=video_fps)
+        frame_indices = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
+        frame_indices = np.unique(frame_indices)
+        logger.info(
+            "Qwen-VL video frames sampled: total_frames=%s, fps=%.3f, sampled_frames=%s",
+            total_frames,
+            video_fps,
+            len(frame_indices),
+        )
+        video = vr.get_batch(frame_indices).asnumpy()
+        return _resize_video_frames(video, video_config)
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+class QwenVLProcessor(BaseMultimodalProcessor):
+    models = (
+        "Qwen2VLForConditionalGeneration",
+        "Qwen2_5_VLForConditionalGeneration",
+        "Qwen3VLForConditionalGeneration",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    )
+
+    async def process_mm_data_async(
+        self,
+        image_data,
+        input_text,
+        request_obj,
+        **kwargs,
+    ) -> MultimodalInputs:
+        if getattr(request_obj, "audio_data", None) is not None:
+            raise ValueError("Qwen-VL does not support audio inputs.")
+        if isinstance(input_text, list):
+            # TODO: support multimodal input_ids without decode + retokenize drift.
+            raise ValueError(
+                "Multimodal input_ids are not supported for Qwen-VL. "
+                "Please provide text input instead."
+            )
+
+        images = await self._load_images_async(image_data)
+        video_data = self.normalize_data(getattr(request_obj, "video_data", None))
+        video_config = self._build_video_config(request_obj)
+        videos = await self._load_videos_async(video_data, video_config)
+        processor_kwargs = {}
+        if videos:
+            processor_kwargs["videos_kwargs"] = {
+                "do_sample_frames": False,
+                "fps": video_config.get("fps", FPS),
+            }
+        uses_qwen3vl_processor = not _QWEN3VL_ARCHITECTURES.isdisjoint(self.hf_config.architectures)
+        if uses_qwen3vl_processor:
+            processor_kwargs["return_mm_token_type_ids"] = True
+
+        processor_output = self.processor(
+            text=[input_text],
+            images=images or None,
+            videos=videos or None,
+            padding=True,
+            return_tensors="pt",
+            **processor_kwargs,
+        )
+
+        input_ids_array = self._to_numpy(processor_output.get("input_ids"))
+        if input_ids_array is None:
+            raise ValueError("HF multimodal processor did not return input_ids.")
+        input_ids = input_ids_array.reshape(-1).tolist()
+        pixel_values = self._to_numpy(processor_output.get("pixel_values"))
+        pixel_values_videos = self._to_numpy(processor_output.get("pixel_values_videos"))
+        image_grid_thw = self._to_grid_list(processor_output.get("image_grid_thw"))
+        video_grid_thw = self._to_grid_list(processor_output.get("video_grid_thw"))
+        mm_token_type_ids = self._to_numpy(processor_output.get("mm_token_type_ids"))
+        if images or videos:
+            logger.info(
+                "Qwen-VL processor output: images=%s, videos=%s, image_grid_thw=%s, "
+                "video_grid_thw=%s, pixel_values_shape=%s, pixel_values_videos_shape=%s",
+                len(images),
+                len(videos),
+                image_grid_thw,
+                video_grid_thw,
+                None if pixel_values is None else pixel_values.shape,
+                None if pixel_values_videos is None else pixel_values_videos.shape,
+            )
+        second_per_grid_ts_value = processor_output.get("second_per_grid_ts")
+        if second_per_grid_ts_value is None:
+            second_per_grid_ts_value = processor_output.get("video_second_per_grid")
+        second_per_grid_ts = self._to_list(second_per_grid_ts_value)
+
+        vision_config = self.hf_config.vision_config
+        video_token_id = getattr(self.hf_config, "video_token_id", None)
+        if uses_qwen3vl_processor:
+            mm_token_type_ids = (
+                np.zeros(len(input_ids), dtype=np.int32)
+                if mm_token_type_ids is None
+                else mm_token_type_ids.reshape(-1).copy()
+            )
+            input_ids_array = np.asarray(input_ids)
+            mm_token_type_ids[input_ids_array == self.hf_config.image_token_id] = 1
+            mm_token_type_ids[input_ids_array == video_token_id] = 2
+            image_placeholder_ranges = self._grouped_placeholder_ranges(
+                mm_token_type_ids, 1, image_grid_thw, vision_config.spatial_merge_size
+            )
+            video_placeholder_ranges = self._grouped_placeholder_ranges(
+                mm_token_type_ids, 2, video_grid_thw, vision_config.spatial_merge_size, True
+            )
+        else:
+            image_placeholder_ranges = self._compute_image_placeholder_ranges(
+                input_ids=input_ids,
+                grids=image_grid_thw,
+                image_token_id=self.hf_config.image_token_id,
+                spatial_merge_size=vision_config.spatial_merge_size,
+            )
+            video_placeholder_ranges = self._compute_placeholder_ranges(
+                input_ids=input_ids,
+                grids=video_grid_thw,
+                token_id=video_token_id,
+                spatial_merge_size=vision_config.spatial_merge_size,
+                modality_name="VIDEO",
+            )
+        mm_items = []
+        mm_items.extend(
+            self._build_items(
+                pixel_values,
+                image_grid_thw,
+                image_placeholder_ranges,
+                Modality.IMAGE,
+                "image_grid_thw",
+            )
+        )
+        video_items = self._build_items(
+            pixel_values_videos,
+            video_grid_thw,
+            video_placeholder_ranges,
+            Modality.VIDEO,
+            "video_grid_thw",
+        )
+        self._set_video_timing(video_items, second_per_grid_ts)
+        mm_items.extend(video_items)
+        for item in mm_items:
+            item.set_pad_value()
+
+        if uses_qwen3vl_processor:
+            mrope_positions, mrope_position_delta = compute_qwen3vl_mrope_positions(
+                mm_token_type_ids=mm_token_type_ids,
+                image_grid_thw=image_grid_thw,
+                video_grid_thw=video_grid_thw,
+                spatial_merge_size=vision_config.spatial_merge_size,
+            )
+        else:
+            mrope_positions, mrope_position_delta = compute_mrope_positions(
+                input_ids=input_ids,
+                image_grid_thw=image_grid_thw,
+                video_grid_thw=video_grid_thw,
+                second_per_grid_ts=second_per_grid_ts,
+                vision_start_token_id=self.hf_config.vision_start_token_id,
+                image_token_id=self.hf_config.image_token_id,
+                video_token_id=video_token_id,
+                spatial_merge_size=vision_config.spatial_merge_size,
+                tokens_per_second=getattr(vision_config, "tokens_per_second", None),
+            )
+        mrope_position_delta = np.asarray([[mrope_position_delta]], dtype=np.int32)
+
+        return MultimodalInputs(
+            mm_items=mm_items,
+            input_ids=input_ids,
+            im_start_id=self.hf_config.vision_start_token_id,
+            im_end_id=self.hf_config.vision_end_token_id,
+            im_token_id=self.hf_config.image_token_id,
+            video_token_id=video_token_id,
+            mrope_positions=mrope_positions,
+            mrope_position_delta=mrope_position_delta,
+        )
+
+    @staticmethod
+    def _build_items(features, grids, placeholder_ranges, modality, grid_key):
+        if features is None:
+            return []
+        if not grids:
+            raise ValueError(f"Missing {grid_key} metadata for {modality.name} inputs.")
+        if len(placeholder_ranges) != len(grids):
+            raise ValueError(
+                f"{modality.name} placeholder range count does not match grid metadata: "
+                f"{len(placeholder_ranges)} != {len(grids)}."
+            )
+
+        feature_counts = [int(np.prod(grid)) for grid in grids]
+        if sum(feature_counts) != len(features):
+            raise ValueError(
+                f"{modality.name} feature count does not match grid metadata: "
+                f"{len(features)} != {sum(feature_counts)}."
+            )
+
+        items = []
+        offset = 0
+        for count, grid in zip(feature_counts, grids):
+            item = MultimodalDataItem(
+                modality=modality,
+                feature=features[offset : offset + count],
+            )
+            item.set(grid_key, np.asarray([grid], dtype=np.int32))
+            ranges = placeholder_ranges[len(items)]
+            item.placeholder_ranges = [ranges] if isinstance(ranges, tuple) else ranges
+            items.append(item)
+            offset += count
+        return items
+
+    @staticmethod
+    def _set_video_timing(
+        items: list[MultimodalDataItem],
+        second_per_grid_ts: list[float] | None,
+    ) -> None:
+        if second_per_grid_ts is None:
+            return
+        if len(items) != len(second_per_grid_ts):
+            raise ValueError("Video timing count does not match video inputs.")
+        for item, seconds in zip(items, second_per_grid_ts, strict=True):
+            item.set("second_per_grid_ts", seconds)
+
+    async def _load_images_async(self, image_data):
+        return await asyncio.gather(
+            *(self.load_image_async(item) for item in self.normalize_data(image_data))
+        )
+
+    @staticmethod
+    def _compute_image_placeholder_ranges(input_ids, grids, image_token_id, spatial_merge_size):
+        return QwenVLProcessor._compute_placeholder_ranges(
+            input_ids=input_ids,
+            grids=grids,
+            token_id=image_token_id,
+            spatial_merge_size=spatial_merge_size,
+            modality_name="IMAGE",
+        )
+
+    @staticmethod
+    def _compute_placeholder_ranges(input_ids, grids, token_id, spatial_merge_size, modality_name):
+        if not grids:
+            return []
+        if token_id is None:
+            raise ValueError(f"{modality_name} token id is not configured.")
+
+        placeholder_ranges = []
+        search_start = 0
+        for grid in grids:
+            token_count = int(np.prod(grid) // (spatial_merge_size**2))
+            start = None
+            for idx in range(search_start, len(input_ids)):
+                if input_ids[idx] == token_id:
+                    start = idx
+                    break
+            if start is None:
+                raise ValueError(
+                    f"Missing {modality_name} placeholder tokens in processor input_ids."
+                )
+
+            end = start + token_count
+            if end > len(input_ids) or any(
+                input_token_id != token_id for input_token_id in input_ids[start:end]
+            ):
+                raise ValueError(
+                    f"{modality_name} placeholder token span does not match grid metadata."
+                )
+            placeholder_ranges.append((start, end))
+            search_start = end
+
+        return placeholder_ranges
+
+    @staticmethod
+    def _grouped_placeholder_ranges(token_types, modality, grids, merge, split_temporal=False):
+        token_types = np.asarray(token_types)
+        if token_types.size == 0:
+            if grids:
+                raise ValueError("Qwen3-VL token types do not match vision grid metadata.")
+            return []
+        groups = [
+            (start, end) for label, start, end in contiguous_runs(token_types) if label == modality
+        ]
+        result = []
+        offset = 0
+        for t, h, w in grids or []:
+            count = int(t) if split_temporal else 1
+            ranges = groups[offset : offset + count]
+            expected = int(t * h * w // (merge * merge))
+            if len(ranges) != count or sum(end - start for start, end in ranges) != expected:
+                raise ValueError("Qwen3-VL token types do not match vision grid metadata.")
+            result.append(ranges)
+            offset += count
+        if offset != len(groups):
+            raise ValueError("Qwen3-VL has unmatched vision token groups.")
+        return result
+
+    async def _load_videos_async(self, video_data, video_config):
+        return await asyncio.gather(
+            *(
+                asyncio.to_thread(preprocess_video, item, video_config)
+                for item in self.normalize_data(video_data)
+            )
+        )
+
+    def _build_video_config(self, request_obj):
+        vision_config = self.hf_config.vision_config
+        video_config = {"factor": int(vision_config.patch_size * vision_config.spatial_merge_size)}
+        fps = getattr(request_obj, "fps", None)
+        if fps is not None:
+            video_config["fps"] = fps
+        nframes = getattr(request_obj, "num_frames", None)
+        if nframes is not None and "fps" not in video_config:
+            video_config["nframes"] = nframes
+        return video_config
+
+    @staticmethod
+    def _to_numpy(value):
+        if value is None:
+            return None
+        if hasattr(value, "detach"):
+            value = value.detach().cpu().numpy()
+        return np.asarray(value)
+
+    @classmethod
+    def _to_grid_list(cls, value):
+        if value is None:
+            return None
+        return [tuple(int(item) for item in row) for row in cls._to_numpy(value).tolist()]
+
+    @classmethod
+    def _to_list(cls, value):
+        if value is None:
+            return None
+        return cls._to_numpy(value).reshape(-1).tolist()

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -231,6 +231,7 @@ class ServerArgs:
 
     # Multimodal
     multimodal: bool = False
+    limit_mm_data_per_request: dict[str, int] | None = None
 
     enable_return_routed_experts: bool = False
     enable_expert_balance_debug: bool = False
@@ -1561,6 +1562,13 @@ class ServerArgs:
             "--multimodal",
             action="store_true",
             help="Enable multimodal HTTP server.",
+        )
+        parser.add_argument(
+            "--limit-mm-data-per-request",
+            type=json.loads,
+            default=ServerArgs.limit_mm_data_per_request,
+            help="JSON object that limits multimodal items per request, "
+            "for example '{\"image\": 16}'.",
         )
 
         # LoRA

--- a/python/sgl_jax/test/mem_cache/test_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_radix_cache.py
@@ -569,6 +569,7 @@ class MockRequest:
     ):
         self.req_pool_idx = req_pool_idx
         self.origin_input_ids = origin_input_ids
+        self.radix_input_ids = list(origin_input_ids)
         self.output_ids = output_ids
         self.fill_ids = fill_ids
         self.prefix_indices = prefix_indices

--- a/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
@@ -1,6 +1,7 @@
 # cd python && USE_DEVICE_TYPE=cpu python -m pytest sgl_jax/test/mem_cache/test_swa_radix_cache.py -q
 
 import os
+from types import SimpleNamespace
 
 # Simulate multi-device on CPU to satisfy JAX Mesh creation
 if os.environ.get("USE_DEVICE_TYPE") == "cpu":
@@ -1229,6 +1230,58 @@ class TestSWARadixCache(CustomTestCase):
         )
 
         self._verify_size_consistency_for(cache, "after simulated cache_unfinished_req")
+
+    def test_request_cache_paths_use_cache_input_ids_with_pages(self):
+        token_ids = list(range(1, 9))
+        for finished, req_pool_idx in ((False, 0), (True, 1)):
+            cache = SWARadixCache(
+                req_to_token_pool=self.req_pool,
+                token_to_kv_pool_allocator=self.allocator,
+                sliding_window_size=64,
+                page_size=4,
+                disable=False,
+            )
+            cache_input_ids = list(
+                range(
+                    -301 - req_pool_idx * len(token_ids), -309 - req_pool_idx * len(token_ids), -1
+                )
+            )
+            kv_indices = self._alloc_indices(len(token_ids))
+            self.req_pool.write((req_pool_idx, slice(0, len(token_ids))), kv_indices)
+            req = SimpleNamespace(
+                req_pool_idx=req_pool_idx,
+                origin_input_ids=token_ids,
+                output_ids=[],
+                fill_ids=token_ids,
+                cache_input_ids=cache_input_ids,
+                prefix_indices=np.empty((0,), dtype=np.int32),
+                last_node=cache.root_node,
+                extra_key=None,
+                dp_rank=None,
+                cache_protected_len=0,
+                last_matched_prefix_len=0,
+                swa_evicted_seqlen=0,
+                swa_uuid_for_lock=None,
+                pop_committed_kv_cache=lambda: len(token_ids),
+            )
+
+            if finished:
+                cache.cache_finished_req(req)
+            else:
+                cache.cache_unfinished_req(req)
+
+            self.assertEqual(
+                len(
+                    cache.match_prefix(
+                        MatchPrefixParams(key=RadixKey(cache_input_ids))
+                    ).device_indices
+                ),
+                len(token_ids),
+            )
+            self.assertEqual(
+                len(cache.match_prefix(MatchPrefixParams(key=RadixKey(token_ids))).device_indices),
+                0,
+            )
 
 
 class TestSchedulerCacheInit(CustomTestCase):

--- a/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
@@ -1231,7 +1231,7 @@ class TestSWARadixCache(CustomTestCase):
 
         self._verify_size_consistency_for(cache, "after simulated cache_unfinished_req")
 
-    def test_request_cache_paths_use_cache_input_ids_with_pages(self):
+    def test_request_cache_paths_use_radix_input_ids_with_pages(self):
         token_ids = list(range(1, 9))
         for finished, req_pool_idx in ((False, 0), (True, 1)):
             cache = SWARadixCache(
@@ -1241,7 +1241,7 @@ class TestSWARadixCache(CustomTestCase):
                 page_size=4,
                 disable=False,
             )
-            cache_input_ids = list(
+            radix_input_ids = list(
                 range(
                     -301 - req_pool_idx * len(token_ids), -309 - req_pool_idx * len(token_ids), -1
                 )
@@ -1251,9 +1251,9 @@ class TestSWARadixCache(CustomTestCase):
             req = SimpleNamespace(
                 req_pool_idx=req_pool_idx,
                 origin_input_ids=token_ids,
+                radix_input_ids=radix_input_ids,
                 output_ids=[],
                 fill_ids=token_ids,
-                cache_input_ids=cache_input_ids,
                 prefix_indices=np.empty((0,), dtype=np.int32),
                 last_node=cache.root_node,
                 extra_key=None,
@@ -1273,7 +1273,7 @@ class TestSWARadixCache(CustomTestCase):
             self.assertEqual(
                 len(
                     cache.match_prefix(
-                        MatchPrefixParams(key=RadixKey(cache_input_ids))
+                        MatchPrefixParams(key=RadixKey(radix_input_ids))
                     ).device_indices
                 ),
                 len(token_ids),

--- a/python/sgl_jax/test/mem_cache/test_unified_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_unified_radix_cache.py
@@ -646,6 +646,7 @@ class TestUnifiedRadixCacheWithRequests(CustomTestCase):
 
         # --- chunked prefill: cache_unfinished_req ---
         prefill_ids = list(range(1, 13))  # 12 tokens
+        cache_prefill_ids = list(range(-101, -113, -1))
         reqs = []
         for cache, pool, alloc in stacks:
             kv_indices = alloc.alloc(len(prefill_ids), dp_rank=0)
@@ -659,6 +660,7 @@ class TestUnifiedRadixCacheWithRequests(CustomTestCase):
                 prefix_indices=np.empty((0,), dtype=np.int32),
                 last_node=cache.root_node,
             )
+            req.cache_input_ids = list(cache_prefill_ids)
             req.last_matched_prefix_len = 0
             cache.cache_unfinished_req(req)
             reqs.append(req)
@@ -679,6 +681,21 @@ class TestUnifiedRadixCacheWithRequests(CustomTestCase):
         self.assertEqual(unified.total_size(), 12)
         # The unified req now points at the locked path, not root.
         self.assertIsNot(unified_req.last_node, unified.root_node)
+        for cache, _, _ in stacks:
+            self.assertEqual(
+                len(
+                    cache.match_prefix(MatchPrefixParams(key=RadixKey(prefill_ids))).device_indices
+                ),
+                0,
+            )
+            self.assertEqual(
+                len(
+                    cache.match_prefix(
+                        MatchPrefixParams(key=RadixKey(cache_prefill_ids))
+                    ).device_indices
+                ),
+                12,
+            )
 
         # --- completion: cache_finished_req on the same req objects ---
         # Production flow: cache_unfinished during chunked prefill, then
@@ -707,7 +724,7 @@ class TestUnifiedRadixCacheWithRequests(CustomTestCase):
         self.assertEqual(unified.evictable_size(0), 16)
         self.assertEqual(unified.total_size(), 16)
 
-        full_sequence = prefill_ids + output_ids
+        full_sequence = cache_prefill_ids + output_ids
         radix_match = radix.match_prefix(MatchPrefixParams(key=RadixKey(full_sequence)))
         unified_match = unified.match_prefix(MatchPrefixParams(key=RadixKey(full_sequence)))
         self.assertEqual(len(radix_match.device_indices), len(unified_match.device_indices))

--- a/python/sgl_jax/test/mem_cache/test_unified_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_unified_radix_cache.py
@@ -556,6 +556,7 @@ class MockRequest:
     ):
         self.req_pool_idx = req_pool_idx
         self.origin_input_ids = origin_input_ids
+        self.radix_input_ids = list(origin_input_ids)
         self.output_ids = output_ids
         self.fill_ids = fill_ids
         self.prefix_indices = prefix_indices
@@ -660,7 +661,7 @@ class TestUnifiedRadixCacheWithRequests(CustomTestCase):
                 prefix_indices=np.empty((0,), dtype=np.int32),
                 last_node=cache.root_node,
             )
-            req.cache_input_ids = list(cache_prefill_ids)
+            req.radix_input_ids = list(cache_prefill_ids)
             req.last_matched_prefix_len = 0
             cache.cache_unfinished_req(req)
             reqs.append(req)
@@ -1071,6 +1072,7 @@ class _ReleaseReq:
         self.req_pool_idx = req_pool_idx
         self.recurrent_pool_idx = recurrent_pool_idx
         self.origin_input_ids = list(origin_input_ids)
+        self.radix_input_ids = list(origin_input_ids)
         self.output_ids = []
         self.fill_ids = list(origin_input_ids)
         self.dp_rank = dp_rank
@@ -1102,6 +1104,7 @@ class _RunningRecurrentReq:
         self.req_pool_idx = req_pool_idx
         self.recurrent_pool_idx = recurrent_pool_idx
         self.origin_input_ids = list(fill_ids)
+        self.radix_input_ids = list(fill_ids)
         self.output_ids = []
         self.fill_ids = list(fill_ids)
         self.dp_rank = dp_rank
@@ -1303,8 +1306,12 @@ class TestUnifiedRadixCacheRecurrent(CustomTestCase):
         recurrent validator collapses its cached FULL prefix to root."""
         state_pool, pool, allocator, cache = self._create_recurrent_setup()
 
-        chunk1 = list(range(1, 9))
+        full_prompt = list(range(1, 13))
+        chunk1 = full_prompt[:8]
+        chunk2 = full_prompt[8:]
         req = _RunningRecurrentReq(req_pool_idx=None, recurrent_pool_idx=None, fill_ids=chunk1)
+        req.origin_input_ids = full_prompt
+        req.radix_input_ids = list(full_prompt)
         pool.alloc([req])  # assigns req_pool_idx + a running recurrent slot
         self.assertIsNotNone(req.recurrent_pool_idx)
         running_slot = req.recurrent_pool_idx
@@ -1345,7 +1352,6 @@ class TestUnifiedRadixCacheRecurrent(CustomTestCase):
         self.assertIsNone(wrong_probe.recurrent_cow_src_index)
 
         # (c) second continuation
-        chunk2 = list(range(9, 13))
         req.fill_ids = chunk1 + chunk2
         kv2 = allocator.alloc(len(chunk2), dp_rank=0)
         self.assertIsNotNone(kv2)

--- a/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
+++ b/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
@@ -1,0 +1,117 @@
+import asyncio
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from sgl_jax.srt.multimodal.common.modality_enum import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+    build_cache_input_ids,
+)
+from sgl_jax.srt.multimodal.processors.qwen_vl import QwenVLProcessor
+
+IMAGE_TOKEN = 151655
+
+
+def test_build_cache_input_ids_uses_item_hash():
+    input_ids = [1, IMAGE_TOKEN, IMAGE_TOKEN, 2]
+    item = MultimodalDataItem(
+        modality=Modality.IMAGE,
+        pad_value=123456,
+        placeholder_ranges=[(1, 3)],
+    )
+
+    assert build_cache_input_ids(input_ids, MultimodalInputs([item])) == [
+        1,
+        123456,
+        123456,
+        2,
+    ]
+    assert input_ids == [1, IMAGE_TOKEN, IMAGE_TOKEN, 2]
+
+
+def test_qwen_vl_rejects_audio_inputs():
+    processor = QwenVLProcessor(SimpleNamespace(), SimpleNamespace(), object())
+    request = SimpleNamespace(audio_data=["audio.wav"])
+
+    with pytest.raises(ValueError, match="does not support audio"):
+        asyncio.run(processor.process_mm_data_async(None, "prompt", request))
+
+
+def test_placeholder_ranges_are_half_open():
+    input_ids = [1, 2, IMAGE_TOKEN, IMAGE_TOKEN, 3, *([IMAGE_TOKEN] * 4), 4]
+    ranges = QwenVLProcessor._compute_image_placeholder_ranges(
+        input_ids,
+        [(1, 2, 4), (1, 4, 4)],
+        IMAGE_TOKEN,
+        spatial_merge_size=2,
+    )
+    assert ranges == [(2, 4), (5, 9)]
+
+
+@pytest.mark.parametrize(
+    ("input_ids", "token_id", "match"),
+    [
+        ([1, 2], IMAGE_TOKEN, "Missing IMAGE placeholder"),
+        ([IMAGE_TOKEN, 1], IMAGE_TOKEN, "span does not match"),
+        ([IMAGE_TOKEN, IMAGE_TOKEN], None, "token id is not configured"),
+    ],
+)
+def test_placeholder_ranges_reject_invalid_spans(input_ids, token_id, match):
+    with pytest.raises(ValueError, match=match):
+        QwenVLProcessor._compute_image_placeholder_ranges(
+            input_ids,
+            [(1, 2, 4)],
+            token_id,
+            spatial_merge_size=2,
+        )
+
+
+def test_build_items_splits_features_and_metadata():
+    items = QwenVLProcessor._build_items(
+        np.arange(24).reshape(24, 1),
+        [(1, 2, 4), (1, 4, 4)],
+        [(2, 4), (5, 9)],
+        Modality.IMAGE,
+        "image_grid_thw",
+    )
+    assert [item.feature.shape for item in items] == [(8, 1), (16, 1)]
+    assert [item.placeholder_ranges for item in items] == [[(2, 4)], [(5, 9)]]
+    np.testing.assert_array_equal(items[1].get("image_grid_thw"), [[1, 4, 4]])
+
+
+def test_video_timing_changes_item_identity():
+    def make_item(seconds):
+        item = QwenVLProcessor._build_items(
+            np.ones((8, 1)),
+            [(1, 2, 4)],
+            [(0, 2)],
+            Modality.VIDEO,
+            "video_grid_thw",
+        )[0]
+        QwenVLProcessor._set_video_timing([item], [seconds])
+        item.set_pad_value()
+        return item
+
+    assert make_item(0.5).hash != make_item(1.0).hash
+
+
+@pytest.mark.parametrize(
+    ("features", "grids", "ranges", "match"),
+    [
+        (np.ones((8, 1)), [], [], "Missing image_grid_thw"),
+        (np.ones((8, 1)), [(1, 2, 4)], [], "range count"),
+        (np.ones((7, 1)), [(1, 2, 4)], [(0, 2)], "feature count"),
+    ],
+)
+def test_build_items_validates_shapes(features, grids, ranges, match):
+    with pytest.raises(ValueError, match=match):
+        QwenVLProcessor._build_items(
+            features,
+            grids,
+            ranges,
+            Modality.IMAGE,
+            "image_grid_thw",
+        )

--- a/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
+++ b/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
@@ -8,14 +8,14 @@ from sgl_jax.srt.multimodal.common.modality_enum import (
     Modality,
     MultimodalDataItem,
     MultimodalInputs,
-    build_cache_input_ids,
+    build_radix_input_ids,
 )
 from sgl_jax.srt.multimodal.processors.qwen_vl import QwenVLProcessor
 
 IMAGE_TOKEN = 151655
 
 
-def test_build_cache_input_ids_uses_item_hash():
+def test_build_radix_input_ids():
     input_ids = [1, IMAGE_TOKEN, IMAGE_TOKEN, 2]
     item = MultimodalDataItem(
         modality=Modality.IMAGE,
@@ -23,13 +23,14 @@ def test_build_cache_input_ids_uses_item_hash():
         placeholder_ranges=[(1, 3)],
     )
 
-    assert build_cache_input_ids(input_ids, MultimodalInputs([item])) == [
+    assert build_radix_input_ids(input_ids, MultimodalInputs([item])) == [
         1,
         123456,
         123456,
         2,
     ]
     assert input_ids == [1, IMAGE_TOKEN, IMAGE_TOKEN, 2]
+    assert build_radix_input_ids([1, 2], None) == [1, 2]
 
 
 def test_qwen_vl_rejects_audio_inputs():

--- a/test/srt/test_dp_schedule_policy.py
+++ b/test/srt/test_dp_schedule_policy.py
@@ -148,9 +148,17 @@ def test_all_full_returns_none():
     assert _pick([], [0, 0], [0, 0], {}, prompt_len=4) is None
 
 
-def _req(input_ids, extra_key=None, lora_id=None, return_logprob=False, logprob_start_len=-1):
+def _req(
+    input_ids,
+    extra_key=None,
+    lora_id=None,
+    return_logprob=False,
+    logprob_start_len=-1,
+    radix_input_ids=None,
+):
     return SimpleNamespace(
         input_ids=input_ids,
+        radix_input_ids=input_ids if radix_input_ids is None else radix_input_ids,
         extra_key=extra_key,
         lora_id=lora_id,
         return_logprob=return_logprob,
@@ -164,9 +172,9 @@ def test_match_key_uses_reusable_prefix_not_full():
     assert match_key(_req([1, 2, 3, 4], extra_key="lora-a")) == ([1, 2, 3], "lora-a")
 
 
-def test_match_key_prefers_multimodal_cache_input_ids():
-    req = _req([1, 99, 99, 4])
-    assert match_key(req, [1, 123456, 123456, 4]) == (
+def test_match_key_uses_canonical_multimodal_radix_input_ids():
+    req = _req([1, 99, 99, 4], radix_input_ids=[1, 123456, 123456, 4])
+    assert match_key(req) == (
         [1, 123456, 123456],
         None,
     )

--- a/test/srt/test_dp_schedule_policy.py
+++ b/test/srt/test_dp_schedule_policy.py
@@ -164,6 +164,14 @@ def test_match_key_uses_reusable_prefix_not_full():
     assert match_key(_req([1, 2, 3, 4], extra_key="lora-a")) == ([1, 2, 3], "lora-a")
 
 
+def test_match_key_prefers_multimodal_cache_input_ids():
+    req = _req([1, 99, 99, 4])
+    assert match_key(req, [1, 123456, 123456, 4]) == (
+        [1, 123456, 123456],
+        None,
+    )
+
+
 def test_match_key_appends_lora_id():
     # Matches Req.__init__: lora_id is concatenated into extra_key.
     assert match_key(_req([1, 2, 3, 4], extra_key="salt:", lora_id="adapter")) == (

--- a/test/srt/test_radix_input_ids.py
+++ b/test/srt/test_radix_input_ids.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+from sgl_jax.srt.managers.utils import validate_input_length
+from sgl_jax.srt.mem_cache.radix_cache import build_radix_key
+
+
+def test_auto_truncate_preserves_radix_input_ids_invariant():
+    req = SimpleNamespace(
+        origin_input_ids=[1, 2, 3, 4],
+        radix_input_ids=[1, 101, 101, 4],
+    )
+
+    validate_input_length(req, max_req_input_len=3, allow_auto_truncate=True)
+    assert req.origin_input_ids == [1, 2, 3]
+    assert req.radix_input_ids == [1, 101, 101]
+
+
+def test_radix_key_uses_only_canonical_prompt_identity():
+    req = SimpleNamespace(
+        origin_input_ids=[1, 2, 3],
+        radix_input_ids=[1, 101, 101],
+        output_ids=[4],
+        fill_ids=[999, 999, 999, 999],
+        extra_key="adapter",
+        dp_rank=1,
+    )
+
+    key = build_radix_key(req, key_len=4)
+    assert key.token_ids == [1, 101, 101, 4]
+    assert (key.extra_key, key.dp_rank) == ("adapter", 1)


### PR DESCRIPTION
<!-- Suggested title: [Multimodal] Add Qwen-VL preprocessing and cache-aware request identity -->

## Motivation

This is the first part of the Qwen2.5-VL upstream landing from `epic/vlm`.

Multimodal requests need a typed preprocessing contract and media-aware cache identity before the model runtime can be introduced. Placeholder token IDs alone cannot distinguish requests containing different images or videos, which may produce incorrect Radix Cache hits and DP routing decisions.

This PR only lands request preprocessing and cache identity. It does not add or enable the in-model Qwen2.5-VL runtime.

This consolidates the final functionality developed in #1398, #1439, and #1479.

## Modifications

- Add `MultimodalInputs` and `MultimodalDataItem` as the request-side contract.
- Track per-item placeholder ranges, feature hashes, and cache identity values.
- Add synchronous Qwen-VL image and video preprocessing.
- Compute Qwen MRoPE metadata during preprocessing.
- Add architecture-scoped multimodal processor registration.
- Pass typed multimodal inputs through `TokenizerManager`.
- Use `cache_input_ids` for:
  - Radix Cache lookup and insertion.
  - SWA and unified cache paths.
  - Cache-aware DP routing.
- Add image/video processor, cache fallback, and DP routing tests.

### Compatibility

- Requests without `cache_input_ids` continue using the existing token cache key.
- Text-only requests do not enter the multimodal processor path.
- Models without a registered processor continue using the existing tokenizer path.
- No model is registered and no new model execution path is enabled by this PR.
- Async preprocessing and offloading from #1538/#1542 are intentionally excluded.

## Accuracy Tests

Not applicable. This PR does not modify model forward computation or model weights.

## Benchmarking and Profiling

Not applicable. This PR establishes the request contract and does not claim a performance improvement.

## Test Plan

After integrating all VLM features, the following tests should be run in the development/CI environment.

```bash
python -m pytest -q \
  python/sgl_jax/test/multimodal/test_qwen_vl_processor.py \
  python/sgl_jax/test/mem_cache/test_swa_radix_cache.py \
  python/sgl_jax/test/mem_cache/test_unified_radix_cache.py \
  test/srt/test_dp_schedule_policy.py
```

## Checklist

- [x] The PR description is written in English.
- [x] The purpose and scope are documented.
- [x] A test plan is provided.
- [x] Text and non-multimodal fallback behavior is preserved.
- [ ] Targeted tests passed in the development/CI environment.
