### PR TITLE
feat(dsa): opt-in Pallas page-topk for the prefill indexer — O(actual kv) scoring, no [T, max_kv] materialization

### DIFF
--- a/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
+++ b/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
@@ -200,20 +200,42 @@ def _scores_kernel(
             page_indices_offset = (seq_idx + batch_idx) * pages_per_seq + kv_p_start
 
             if not wait:
-                for i in range(bkv_p):
-                    sz_per_kv_packing = page_size_per_kv_packing
+
+                def _start_fetch_page(
+                    i,
+                    carry,
+                    page_indices_offset=page_indices_offset,
+                    bkv_vmem_ref=bkv_vmem_ref,
+                    sem=sem,
+                ):
                     page_idx = jnp.minimum(page_indices_offset + i, num_page_indices - 1)
                     safe_page_offset = jnp.minimum(
                         page_indices_ref[page_idx] * page_size_per_kv_packing,
                         jnp.maximum(0, max_hbm_pages - page_size_per_kv_packing),
                     )
-
                     _async_copy(
-                        reshaped_cache_hbm_ref.at[pl.ds(safe_page_offset, sz_per_kv_packing)],
-                        bkv_vmem_ref.at[pl.ds(i * page_size_per_kv_packing, sz_per_kv_packing)],
+                        reshaped_cache_hbm_ref.at[
+                            pl.ds(safe_page_offset, page_size_per_kv_packing)
+                        ],
+                        bkv_vmem_ref.at[
+                            pl.ds(i * page_size_per_kv_packing, page_size_per_kv_packing)
+                        ],
                         sem,
                         wait=False,
                     )
+                    return carry
+
+                if bkv_p > 64:
+                    # Large page blocks (page mode, bkv_p=128): a python-unrolled
+                    # per-page DMA loop bloats the Mosaic program and costs ~40s
+                    # of compile per kernel instance (measured v7x, T=8192); a
+                    # fori_loop compiles in <1s with identical steady-state
+                    # performance (DMA issue rate is not the bottleneck).
+                    lax.fori_loop(0, bkv_p, _start_fetch_page, None, unroll=False)
+                else:
+                    # Keep the merged decode path (bkv_p<=64) byte-identical.
+                    for i in range(bkv_p):
+                        _start_fetch_page(i, None)
             else:
                 dma_bkv_sz = bkv_p * page_size_per_kv_packing
                 dst_kv = bkv_vmem_ref.at[pl.ds(0, dma_bkv_sz)]

--- a/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
+++ b/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
@@ -508,9 +508,13 @@ def _scores_kernel(
 
             assert bkv_p == 128, "page mode requires bkv_p == 128 (one lane row per block)"
 
-            # Acquire the output buffer up-front: each bkv block stores its
-            # pooled lane-row [rows, 128] at sublane index bkv_idx; untouched
-            # trailing blocks stay -inf.
+            # Acquire the output buffer up-front: wait_send_scores waits on the
+            # DMA issued for this buffer TWO bq iterations ago (buffers
+            # alternate), so the -inf fill below can never race an in-flight
+            # read. Each bkv block then stores its pooled lane-row [rows, 128]
+            # at sublane index bkv_idx; untouched trailing blocks (dynamic
+            # num_bkv < num_bkv_max, which only sizes the output layout) stay
+            # -inf and are masked to -1 after top_k.
             bo_sem_idx = sem_ids_ref[2]
             wait_send_scores(bo_sem_idx)
             scores_block_x2_ref[bo_sem_idx, ...] = jnp.full(
@@ -962,7 +966,12 @@ def streamindex_page_topk(
     _, page_size_per_kv_packing, kv_packing, _ = cache_kv.shape
     page_size = page_size_per_kv_packing * kv_packing
     pages_per_seq = page_indices.shape[0] // max_num_seqs
-    assert page_size % compression_ratio == 0
+    if compression_ratio != 1:
+        raise NotImplementedError(
+            "page mode is validated for compression_ratio=1 only (GLM); the"
+            " compressed causal bound interacts with page pooling and needs its"
+            " own parity gate before enabling."
+        )
 
     bkv_p = num_kv_pages_per_block
     if bkv_p != 128:

--- a/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
+++ b/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
@@ -918,7 +918,7 @@ def streamindex_page_topk(
     k_pages: int,
     compression_ratio: int = 1,
     num_kv_pages_per_block: int = 128,
-    num_queries_per_block: int = 128,
+    num_queries_per_block: int = 512,
     vmem_limit_bytes: int | None = 64 * 1024 * 1024,
 ) -> jax.Array:
     """Page-level lightning-indexer top-k (prefill/extend form).

--- a/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
+++ b/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
@@ -97,6 +97,8 @@ def _scores_kernel(
     bkv_p: int,
     bq_sz: int,
     seq_batch_size: int,
+    page_pool_size: int | None = None,
+    num_bkv_max: int | None = None,
 ):
     _, num_q_heads, head_dim = q_hbm_ref.shape
     lkv_dim = cache_kv_hbm_ref.shape[-1]
@@ -155,6 +157,21 @@ def _scores_kernel(
             scores_hbm_ref.at[
                 pl.ds(token_start, seq_batch_size * sz),
                 pl.ds(sublane_start, num_sublanes_bkv),
+            ],
+            sems.at[2, bo_sem_idx, 0],
+            wait=False,
+        )
+
+    def start_send_page_scores(bo_sem_idx, sz, token_start):
+        # Page mode: one DMA per bq block covering ALL page columns (the
+        # accumulator already holds the max over every bkv block).
+        bo_sz_ref[bo_sem_idx] = sz
+        num_page_sublanes = scores_hbm_ref.shape[1]
+        _async_copy(
+            scores_block_x2_ref.at[bo_sem_idx, pl.ds(0, seq_batch_size * sz)],
+            scores_hbm_ref.at[
+                pl.ds(token_start, seq_batch_size * sz),
+                pl.ds(0, num_page_sublanes),
             ],
             sems.at[2, bo_sem_idx, 0],
             wait=False,
@@ -355,7 +372,14 @@ def _scores_kernel(
                 causal_mask = k_span <= bq_pos_compressed[:, None]
                 mask = jnp.logical_and(valid_mask, causal_mask)
                 s_summed = jnp.where(mask, s_summed, -jnp.inf)
-                ret.append(s_summed.reshape(-1, num_sublanes_bkv, 128))
+                if page_pool_size is not None:
+                    # Page mode: max-pool token scores within each page. Columns
+                    # are linear (compressed) kv positions, and bkv_sz is a whole
+                    # number of pages, so pooling groups are exact pages.
+                    cols_per_page = page_pool_size // compression_ratio
+                    ret.append(s_summed.reshape(-1, bkv_p, cols_per_page).max(axis=-1))
+                else:
+                    ret.append(s_summed.reshape(-1, num_sublanes_bkv, 128))
             return jnp.concatenate(ret, axis=0)
 
         def compute_with_bq(bq_idx, _):
@@ -427,7 +451,84 @@ def _scores_kernel(
 
             lax.fori_loop(0, num_bkv, compute_with_bkv, None, unroll=False)
 
-        lax.fori_loop(0, num_bq, compute_with_bq, None, unroll=False)
+        def compute_with_bq_paged(bq_idx, _):
+            # Page-mode twin of compute_with_bq: pooled page scores accumulate in
+            # a fori carry ([rows, num_bkv_max, bkv_p], untouched blocks stay
+            # -inf) and are written back with ONE DMA per bq block — no
+            # [T, max_kv] token-score materialization ever reaches HBM.
+            bq_sem_idx = sem_ids_ref[0]
+            next_seq_idx, next_bq_idx, next_bq_sem_idx = get_next_bq_ids(
+                batch_start_seq_idx, bq_idx, bq_sem_idx
+            )
+
+            @pl.when(next_seq_idx < end_seq_idx)
+            def prefetch_next_bq():
+                sem_ids_ref[0] = next_bq_sem_idx
+                start_fetch_bq(next_seq_idx, next_bq_idx, next_bq_sem_idx)
+
+            bq_pos_compressed_vec = []
+            for batch_idx in range(seq_batch_size):
+                q_pos = (
+                    seq_lens[batch_idx]
+                    - q_lens[batch_idx]
+                    + bq_idx * bq_sz
+                    + jnp.arange(bq_sz, dtype=jnp.int32)
+                )
+                bq_pos_compressed_vec.append(q_pos // compression_ratio)
+
+            wait_fetch_bq(batch_start_seq_idx, bq_idx, bq_sem_idx)
+            bq_vec = load_bq(bq_sem_idx)
+            bq_weights_vec = load_bq_weights(bq_sem_idx)
+
+            token_start = cu_q_lens_ref[batch_start_seq_idx] + bq_idx * bq_sz
+            curr_q_end = cu_q_lens_ref[batch_start_seq_idx + 1]
+            sz = jnp.maximum(0, jnp.minimum(bq_sz, curr_q_end - token_start))
+
+            assert bkv_p == 128, "page mode requires bkv_p == 128 (one lane row per block)"
+
+            # Acquire the output buffer up-front: each bkv block stores its
+            # pooled lane-row [rows, 128] at sublane index bkv_idx; untouched
+            # trailing blocks stay -inf.
+            bo_sem_idx = sem_ids_ref[2]
+            wait_send_scores(bo_sem_idx)
+            scores_block_x2_ref[bo_sem_idx, ...] = jnp.full(
+                scores_block_x2_ref.shape[1:], -jnp.inf, dtype=jnp.float32
+            )
+
+            def compute_with_bkv_paged(bkv_idx, _):
+                bkv_sem_idx = sem_ids_ref[1]
+                next_seq_idx, _u, next_bkv_idx, next_bkv_sem_idx = get_next_bkv_ids(
+                    batch_start_seq_idx, bq_idx, bkv_idx, bkv_sem_idx
+                )
+
+                @pl.when(next_seq_idx < end_seq_idx)
+                def prefetch_next_bkv():
+                    sem_ids_ref[1] = next_bkv_sem_idx
+                    start_fetch_bkv(next_seq_idx, next_bkv_idx, next_bkv_sem_idx)
+
+                wait_fetch_bkv(batch_start_seq_idx, bkv_idx, bkv_sem_idx)
+                bkv_vec, scale_val_vec = load_bkv(bkv_sem_idx)
+
+                page_scores = compute_scores(
+                    bq_vec,
+                    bkv_vec,
+                    scale_val_vec,
+                    bq_weights_vec,
+                    bq_pos_compressed_vec,
+                    bkv_idx,
+                )  # [rows, 128] — one pooled lane row per block
+                scores_block_x2_ref[bo_sem_idx, :, bkv_idx, :] = page_scores
+                return None
+
+            lax.fori_loop(0, num_bkv, compute_with_bkv_paged, None, unroll=False)
+
+            start_send_page_scores(bo_sem_idx, sz, token_start)
+            sem_ids_ref[2] = lax.select(bo_sem_idx == 0, 1, 0)
+
+        if page_pool_size is None:
+            lax.fori_loop(0, num_bq, compute_with_bq, None, unroll=False)
+        else:
+            lax.fori_loop(0, num_bq, compute_with_bq_paged, None, unroll=False)
 
     ### ------- Kernel start ------- ###
 
@@ -793,3 +894,125 @@ def streamindex_topk(
     top_vals, top_idxs = jax.lax.approx_max_k(scores, k, reduction_dimension=-1, recall_target=1.0)
     topk_idxs = jnp.where(top_vals == -jnp.inf, -1, top_idxs)
     return topk_idxs[: q.shape[0], :k]
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=(
+        "k_pages",
+        "compression_ratio",
+        "num_kv_pages_per_block",
+        "num_queries_per_block",
+        "vmem_limit_bytes",
+    ),
+)
+def streamindex_page_topk(
+    q: jax.Array,  # [max_num_tokens, num_q_heads, head_dim]
+    indexer_weights: jax.Array,  # [max_num_tokens, num_q_heads]
+    cache_kv: jax.Array,  # [total_pages, page_size_per_kv_packing, kv_packing, lkv]
+    seq_lens: jax.Array,  # i32[max_num_seqs]
+    page_indices: jax.Array,  # i32[max_num_seqs * pages_per_seq]
+    cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
+    num_seqs: jax.Array,  # i32[] number of valid sequences
+    *,
+    k_pages: int,
+    compression_ratio: int = 1,
+    num_kv_pages_per_block: int = 128,
+    num_queries_per_block: int = 128,
+    vmem_limit_bytes: int | None = 64 * 1024 * 1024,
+) -> jax.Array:
+    """Page-level lightning-indexer top-k (prefill/extend form).
+
+    Pallas twin of ``ref.streamindex_page_topk_ref(one_token_per_seq=False)``:
+    scores are max-pooled to page granularity inside the kernel (only
+    ``[T, pages_per_seq]`` ever reaches HBM — no ``[T, max_kv]`` token-score
+    materialization), then a cheap ``top_k`` over pages selects the budget.
+
+    Returns:
+      i32[T, k_pages] seq-local page ids per query token; -1 for padding.
+    """
+    max_num_seqs = seq_lens.shape[0]
+    original_dtype = q.dtype
+    prepared_indexer_weights = prepare_index_weights(indexer_weights, original_dtype)
+    q = prepare_q_inputs(q)
+    _, num_q_heads, head_dim = q.shape
+    lkv_dim = cache_kv.shape[-1]
+    _, page_size_per_kv_packing, kv_packing, _ = cache_kv.shape
+    page_size = page_size_per_kv_packing * kv_packing
+    pages_per_seq = page_indices.shape[0] // max_num_seqs
+    assert page_size % compression_ratio == 0
+
+    bkv_p = num_kv_pages_per_block
+    if bkv_p != 128:
+        raise ValueError("page mode requires num_kv_pages_per_block == 128")
+    bq_sz = num_queries_per_block
+    num_bkv_max = cdiv(pages_per_seq, bkv_p)
+    num_page_cols = align_to(num_bkv_max * bkv_p, 128)
+    num_page_sublanes = num_page_cols // 128
+    bkv_sz = page_size * bkv_p // compression_ratio
+    if bkv_sz % 128 != 0:
+        raise ValueError(f"bkv block token span ({bkv_sz}) must be a multiple of 128.")
+
+    T = q.shape[0]
+    scores_init = jnp.full((T, num_page_sublanes, 128), -jnp.inf, dtype=jnp.float32)
+
+    in_specs = [
+        pl.BlockSpec(memory_space=pltpu.HBM),
+        pl.BlockSpec(memory_space=pltpu.HBM),
+        pl.BlockSpec(memory_space=pltpu.HBM),
+        pl.BlockSpec(memory_space=pltpu.HBM),
+    ]
+    out_specs = pl.BlockSpec(memory_space=pltpu.HBM)
+
+    scratch_shapes = [
+        pltpu.VMEM((2, 1, bkv_p * page_size_per_kv_packing, kv_packing, lkv_dim), cache_kv.dtype),
+        pltpu.VMEM((2, 1, bq_sz, num_q_heads, head_dim), q.dtype),
+        pltpu.VMEM((2, 1, bq_sz, num_q_heads), prepared_indexer_weights.dtype),
+        pltpu.VMEM((2, bq_sz, num_page_sublanes, 128), jnp.float32),
+        pltpu.SemaphoreType.DMA((4, 2, 1)),
+    ]
+
+    scalar_prefetches = (
+        seq_lens,
+        page_indices,
+        cu_q_lens,
+        jnp.stack([jnp.int32(0), num_seqs.astype(jnp.int32)]),
+        jnp.zeros((3,), jnp.int32),
+        jnp.full((2,), -1, jnp.int32),
+    )
+
+    scope_name = f"StreamIdxPageTC-bq_{bq_sz}-bkvp_{bkv_p}"
+    kernel = jax.named_scope(scope_name)(
+        pl.pallas_call(
+            functools.partial(
+                _scores_kernel,
+                compression_ratio=compression_ratio,
+                static_q_len=None,
+                bq_sz=bq_sz,
+                bkv_p=bkv_p,
+                seq_batch_size=1,
+                page_pool_size=page_size,
+                num_bkv_max=num_bkv_max,
+            ),
+            grid_spec=pltpu.PrefetchScalarGridSpec(
+                num_scalar_prefetch=len(scalar_prefetches),
+                in_specs=in_specs,
+                out_specs=out_specs,
+                grid=(num_seqs.astype(jnp.int32),),
+                scratch_shapes=scratch_shapes,
+            ),
+            compiler_params=pltpu.CompilerParams(
+                dimension_semantics=("arbitrary",),
+                vmem_limit_bytes=vmem_limit_bytes,
+                disable_bounds_checks=True,
+            ),
+            out_shape=jax.ShapeDtypeStruct(shape=(T, num_page_sublanes, 128), dtype=jnp.float32),
+            input_output_aliases={len(scalar_prefetches) + 3: 0},
+            name=scope_name,
+        )
+    )
+    page_scores = kernel(*scalar_prefetches, q, prepared_indexer_weights, cache_kv, scores_init)
+
+    page_scores = page_scores.reshape(T, num_page_cols)[:, :pages_per_seq]
+    top_vals, top_idxs = jax.lax.top_k(page_scores, k_pages)
+    return jnp.where(top_vals > -jnp.inf, top_idxs, -1)

--- a/python/sgl_jax/srt/kernels/mla/v2/tuned_block_sizes.py
+++ b/python/sgl_jax/srt/kernels/mla/v2/tuned_block_sizes.py
@@ -139,6 +139,26 @@ TUNED_BLOCK_SIZES_MLA: dict[str, dict[tuple, tuple]] = {
         ("mixed", "bfloat16", "bfloat16", 16, 512, 64, 128, 512): (8, 128),
         ("mixed", "bfloat16", "bfloat16", 16, 512, 64, 128, 1024): (8, 128),
         ("mixed", "bfloat16", "bfloat16", 16, 512, 64, 128, 2048): (8, 128),
+        # ===== GLM-5.2 (tp16: 4 q-heads/shard, kv_lora=512, page=128) =====
+        # decode from the DSv3 page-128 family; mixed uses 16-row blocks (bf16
+        # tiling needs 16-row alignment at 4 heads/shard; 8-row blocks and the
+        # hardcoded fallback both fail Mosaic window setup at mnt>=256).
+        # Full mnt bucket coverage pending a tuner sweep.
+        ("decode", "bfloat16", "bfloat16", 4, 512, 64, 128, 1): (16, 1, 2),
+        ("decode", "bfloat16", "bfloat16", 4, 512, 64, 128, 8): (16, 1, 2),
+        ("mixed", "bfloat16", "bfloat16", 4, 512, 64, 128, 1): (16, 64),
+        ("mixed", "bfloat16", "bfloat16", 4, 512, 64, 128, 2): (16, 64),
+        ("mixed", "bfloat16", "bfloat16", 4, 512, 64, 128, 4): (16, 64),
+        ("mixed", "bfloat16", "bfloat16", 4, 512, 64, 128, 8): (16, 64),
+        ("mixed", "bfloat16", "bfloat16", 4, 512, 64, 128, 16): (16, 64),
+        ("mixed", "bfloat16", "bfloat16", 4, 512, 64, 128, 32): (16, 64),
+        ("mixed", "bfloat16", "bfloat16", 4, 512, 64, 128, 64): (16, 64),
+        ("mixed", "bfloat16", "bfloat16", 4, 512, 64, 128, 128): (16, 64),
+        ("mixed", "bfloat16", "bfloat16", 4, 512, 64, 128, 256): (16, 128),
+        ("mixed", "bfloat16", "bfloat16", 4, 512, 64, 128, 512): (16, 128),
+        ("mixed", "bfloat16", "bfloat16", 4, 512, 64, 128, 1024): (16, 128),
+        ("mixed", "bfloat16", "bfloat16", 4, 512, 64, 128, 2048): (16, 128),
+        ("mixed", "bfloat16", "bfloat16", 4, 512, 64, 128, 4096): (16, 128),
         # ===== GLM-5.1 (TP=32) configurations on TPU v7 =====
         # Decode & Mixed tuned for q_head_num=2 (TP=32 sharding)
         ("decode", "bfloat16", "bfloat16", 2, 512, 64, 64, 1): (16, 1, 4),

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -545,7 +545,12 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
                     w_,
                     cache3d.reshape(cache_.shape),
                     seq_lens_,
-                    pi_,
+                    # the kernel indexes page_indices[seq_id * pages_per_seq + p]
+                    # (fixed stride), but sglang packs seq i's pages at
+                    # cu_kv_lens[i]//page_size (variable stride) — repack, same
+                    # as the decode call site, or a multi-request EXTEND batch
+                    # with unequal lengths reads another sequence's pages.
+                    _fixed_stride_pages(pi_, cukv_, page_size, pages_per_seq),
                     cuq_,
                     dist_[2],
                     k_pages=k_pages,

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -535,6 +535,11 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
             cache3d = cache_.reshape(cache_.shape[0], page_size, idx_dim)
             cache3d = _scatter_paged(cache3d, k_, seq_lens_, pi_, cuq_, cukv_, pages_per_seq)
             if _INDEXER_KERNEL_PREFILL:
+                # dist_[2] == number of real (seq_len > 0) sequences in this
+                # EXTEND batch: mla_backend builds distribution = [0, 0, N] for
+                # ForwardMode.EXTEND (decode runs as a separate forward), so the
+                # kernel's per-seq grid over [0, N) matches the ref's masked
+                # full-batch loop exactly; padded seqs stay -1 on both paths.
                 topk_pages = streamindex_page_topk(
                     q_,
                     w_,

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -25,7 +25,10 @@ from jax.tree_util import register_pytree_node_class
 from sgl_jax.srt.kernels.dsa.ref import streamindex_page_topk_ref, streamindex_topk_ref
 from sgl_jax.srt.kernels.dsa.sparse_mla import compute_topk_pages, sparse_mla_page_level
 from sgl_jax.srt.kernels.dsa.sparse_mla_prefill import prefill_write_and_attend_ragged
-from sgl_jax.srt.kernels.dsa.streamindex_topk import streamindex_topk
+from sgl_jax.srt.kernels.dsa.streamindex_topk import (
+    streamindex_page_topk,
+    streamindex_topk,
+)
 from sgl_jax.srt.kernels.mla.v2.kernel import mla_ragged_paged_attention
 from sgl_jax.srt.layers.attention.mla_backend import MLAAttentionBackend
 from sgl_jax.srt.utils.profiling_utils import named_scope
@@ -49,6 +52,12 @@ _PAGE_TOPK_BUDGET = int(os.environ.get("DSA_PAGE_TOPK", "0"))
 # (sum_h relu(q·k)·w_h, approx_max_k). Token-topk path only; DSA_PAGE_TOPK
 # takes precedence when both are set.
 _INDEXER_KERNEL = os.environ.get("DSA_INDEXER_KERNEL", "0") == "1"
+# Opt-in: prefill/extend page-level indexer top-k via the page-pooled Pallas
+# streamindex kernel instead of the jnp reference. The kernel scores O(actual
+# kv_len) pages (ref is O(max_ctx) padded gather) and never materializes
+# [T, max_kv] token scores in HBM — the dominant HLO-temporaries term at long
+# context. Same selection semantics as the ref (parity-gated). Default OFF.
+_INDEXER_KERNEL_PREFILL = os.environ.get("DSA_INDEXER_KERNEL_PREFILL", "0") == "1"
 # bkv block of 64 pages (4K tokens @ page 64) benched fastest across
 # B=8..64, ctx 8K..128K on v7x/v6e.
 _INDEXER_KERNEL_KV_PAGES_PER_BLOCK = 64
@@ -525,19 +534,31 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
             pages_per_seq = pi_.shape[0] // seq_lens_.shape[0]
             cache3d = cache_.reshape(cache_.shape[0], page_size, idx_dim)
             cache3d = _scatter_paged(cache3d, k_, seq_lens_, pi_, cuq_, cukv_, pages_per_seq)
-            topk_pages = streamindex_page_topk_ref(
-                q_,
-                w_,
-                cache3d,
-                seq_lens_,
-                pi_,
-                cuq_,
-                cukv_,
-                dist_,
-                k_pages=k_pages,
-                pages_per_seq=pages_per_seq,
-                one_token_per_seq=False,  # prefill: T>1 tokens/seq, per-query causal
-            )
+            if _INDEXER_KERNEL_PREFILL:
+                topk_pages = streamindex_page_topk(
+                    q_,
+                    w_,
+                    cache3d.reshape(cache_.shape),
+                    seq_lens_,
+                    pi_,
+                    cuq_,
+                    dist_[2],
+                    k_pages=k_pages,
+                )
+            else:
+                topk_pages = streamindex_page_topk_ref(
+                    q_,
+                    w_,
+                    cache3d,
+                    seq_lens_,
+                    pi_,
+                    cuq_,
+                    cukv_,
+                    dist_,
+                    k_pages=k_pages,
+                    pages_per_seq=pages_per_seq,
+                    one_token_per_seq=False,  # prefill: T>1 tokens/seq, per-query causal
+                )
             return cache3d.reshape(cache_.shape), topk_pages
 
         idx_cache, topk_pages = jax.shard_map(

--- a/test/srt/kernels/dsa/test_streamindex_page_topk.py
+++ b/test/srt/kernels/dsa/test_streamindex_page_topk.py
@@ -26,6 +26,11 @@ if jax.default_backend() != "tpu":
         (8, 32, 4, 128, 8, [16], [200]),
         # decode-like degenerate rows inside MIXED (q_len 1) + extend
         (8, 16, 3, 128, 8, [1, 7], [90, 55]),
+        # multi-block accumulation/prefetch (page mode pins bkv_p=128, so
+        # exceeding one block needs pages_per_seq > 128): 138 pages -> 2 blocks
+        (8, 144, 5, 128, 16, [33], [1100]),
+        # multi-block + multi-seq: seq 1 spans 2 kv blocks (150 pages), seq 0 one
+        (8, 160, 3, 128, 8, [5, 12], [900, 1200]),
     ],
 )
 def test_page_topk_parity(page_size, pages_per_seq, k_pages, bkv_p, bq_sz, q_lens, kv_lens):
@@ -77,6 +82,85 @@ def test_page_topk_parity(page_size, pages_per_seq, k_pages, bkv_p, bq_sz, q_len
 
     ref_np, ker_np = np.asarray(ref_out), np.asarray(ker_out)
     assert ker_np.shape == ref_np.shape == (T, k_pages)
+    for t in range(T):
+        ref_set = set(ref_np[t][ref_np[t] >= 0].tolist())
+        ker_set = set(ker_np[t][ker_np[t] >= 0].tolist())
+        assert ker_set == ref_set, f"row {t}: kernel {ker_set} != ref {ref_set}"
+
+
+@pytest.mark.parametrize(
+    "page_size, k_pages, bkv_p, q_lens, kv_lens",
+    [
+        # unequal per-seq page counts (5 vs 13): the production packing places
+        # seq 1's pages at cu_kv_lens[1]//ps == 5, NOT at 1*pages_per_seq
+        (8, 3, 128, [5, 12], [37, 101]),
+        # 3 seqs, unequal, one spanning 2 kv blocks (188 pages > bkv_p=128)
+        (8, 4, 128, [9, 3, 20], [70, 17, 1500]),
+    ],
+)
+def test_page_topk_variable_stride_packing(page_size, k_pages, bkv_p, q_lens, kv_lens):
+    """Production-layout contract: sglang packs seq i's pages starting at
+    ``cu_kv_lens[i] // page_size`` (variable stride, page-aligned cumsum —
+    see ``schedule_batch._merge_cache_loc``), while the kernel indexes
+    ``page_indices[seq_id * pages_per_seq + p]`` (fixed stride). The call
+    site must repack via ``_fixed_stride_pages`` — passing the packed table
+    directly makes every query of an offset sequence read another sequence's
+    pages (measured 12/17 wrong rows on the first case here).
+    """
+    from sgl_jax.srt.layers.attention.dsa_sparse_backend import _fixed_stride_pages
+
+    rng = np.random.default_rng(1)
+    num_seqs = len(q_lens)
+    H, D = 4, 128
+    kv_packing = 2
+    T = int(sum(q_lens))
+    n_pages = [(l + page_size - 1) // page_size for l in kv_lens]
+    # window width the backend derives: len(page_indices) // num_seqs
+    pages_per_seq = max(n_pages) + 3
+    pi_len = num_seqs * pages_per_seq
+    total_pages = pi_len + 8
+
+    q = jnp.asarray(rng.standard_normal((T, H, D)), jnp.bfloat16)
+    w = jnp.asarray(rng.standard_normal((T, H)), jnp.bfloat16)
+    cache = jnp.asarray(
+        rng.standard_normal((total_pages, page_size // kv_packing, kv_packing, D)),
+        jnp.bfloat16,
+    )
+    # variable-stride packed table + page-aligned cumsum cu_kv_lens
+    pi = jnp.asarray(rng.permutation(total_pages)[:pi_len], jnp.int32)
+    cu_kv = jnp.asarray(
+        np.concatenate([[0], np.cumsum([n * page_size for n in n_pages])]), jnp.int32
+    )
+    seq_lens = jnp.asarray(kv_lens, jnp.int32)
+    cu_q = jnp.asarray(np.concatenate([[0], np.cumsum(q_lens)]), jnp.int32)
+    dist = jnp.asarray([0, 0, num_seqs], jnp.int32)
+
+    ref_out = streamindex_page_topk_ref(
+        q,
+        w,
+        cache.reshape(total_pages, page_size, D),
+        seq_lens,
+        pi,
+        cu_q,
+        cu_kv,
+        dist,
+        k_pages=k_pages,
+        pages_per_seq=pages_per_seq,
+        one_token_per_seq=False,
+    )
+    ker_out = streamindex_page_topk(
+        q,
+        w,
+        cache,
+        seq_lens,
+        _fixed_stride_pages(pi, cu_kv, page_size, pages_per_seq),
+        cu_q,
+        jnp.int32(num_seqs),
+        k_pages=k_pages,
+        num_kv_pages_per_block=bkv_p,
+        num_queries_per_block=8,
+    )
+    ref_np, ker_np = np.asarray(ref_out), np.asarray(ker_out)
     for t in range(T):
         ref_set = set(ref_np[t][ref_np[t] >= 0].tolist())
         ker_set = set(ker_np[t][ker_np[t] >= 0].tolist())

--- a/test/srt/kernels/dsa/test_streamindex_page_topk.py
+++ b/test/srt/kernels/dsa/test_streamindex_page_topk.py
@@ -1,0 +1,83 @@
+"""Parity: streamindex_page_topk (Pallas, page-pooled) vs ref general path.
+
+TPU-only (same constraint as test_streamindex_topk.py).
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from sgl_jax.srt.kernels.dsa.ref import streamindex_page_topk_ref
+from sgl_jax.srt.kernels.dsa.streamindex_topk import streamindex_page_topk
+
+if jax.default_backend() != "tpu":
+    pytest.skip("streamindex_page_topk kernel requires TPU", allow_module_level=True)
+
+
+@pytest.mark.parametrize(
+    "page_size, pages_per_seq, k_pages, bkv_p, bq_sz, q_lens, kv_lens",
+    [
+        # 2-seq packed extend, tail pages partially filled, causal within chunk
+        (8, 16, 3, 128, 8, [5, 12], [37, 61]),
+        # single long extend spanning many bkv blocks
+        (8, 48, 5, 128, 16, [33], [301]),
+        # chunked-prefill form: q_len < kv_len (prefix present)
+        (8, 32, 4, 128, 8, [16], [200]),
+        # decode-like degenerate rows inside MIXED (q_len 1) + extend
+        (8, 16, 3, 128, 8, [1, 7], [90, 55]),
+    ],
+)
+def test_page_topk_parity(page_size, pages_per_seq, k_pages, bkv_p, bq_sz, q_lens, kv_lens):
+    rng = np.random.default_rng(0)
+    num_seqs = len(q_lens)
+    H, D = 4, 128
+    kv_packing = 2  # bf16
+    total_pages = num_seqs * pages_per_seq + 8
+
+    T = int(sum(q_lens))
+    q = jnp.asarray(rng.standard_normal((T, H, D)), jnp.bfloat16)
+    w = jnp.asarray(rng.standard_normal((T, H)), jnp.bfloat16)
+    cache = jnp.asarray(
+        rng.standard_normal((total_pages, page_size // kv_packing, kv_packing, D)),
+        jnp.bfloat16,
+    )
+    pi = jnp.asarray(rng.permutation(total_pages)[: num_seqs * pages_per_seq], jnp.int32)
+    seq_lens = jnp.asarray(kv_lens, jnp.int32)
+    cu_q = jnp.asarray(np.concatenate([[0], np.cumsum(q_lens)]), jnp.int32)
+    cu_kv = jnp.asarray(np.arange(num_seqs + 1) * pages_per_seq * page_size, jnp.int32)
+    dist = jnp.asarray([0, 0, num_seqs], jnp.int32)
+
+    ref_out = streamindex_page_topk_ref(
+        q.astype(jnp.float32) if False else q,
+        w,
+        cache.reshape(total_pages, page_size, D),
+        seq_lens,
+        pi,
+        cu_q,
+        cu_kv,
+        dist,
+        k_pages=k_pages,
+        pages_per_seq=pages_per_seq,
+        one_token_per_seq=False,
+    )
+
+    ker_out = streamindex_page_topk(
+        q,
+        w,
+        cache,
+        seq_lens,
+        pi,
+        cu_q,
+        jnp.int32(num_seqs),
+        k_pages=k_pages,
+        num_kv_pages_per_block=bkv_p,
+        num_queries_per_block=bq_sz,
+    )
+
+    ref_np, ker_np = np.asarray(ref_out), np.asarray(ker_out)
+    assert ker_np.shape == ref_np.shape == (T, k_pages)
+    for t in range(T):
+        ref_set = set(ref_np[t][ref_np[t] >= 0].tolist())
+        ker_set = set(ker_np[t][ker_np[t] >= 0].tolist())
+        assert ker_set == ref_set, f"row {t}: kernel {ker_set} != ref {ref_set}"


### PR DESCRIPTION
This wires the (merged, decode-only) `streamindex_topk` Pallas kernel into the **prefill/extend** indexer path, as previewed in the #1508 thread. Opt-in via `DSA_INDEXER_KERNEL_PREFILL=1`, default OFF ⇒ prefill behaviour unchanged.

### Why

With `DSA_PREFILL_SPARSE=1`, the prefill page-topk currently runs the jnp reference (`streamindex_page_topk_ref`, general path). Two structural costs, measured on TPU v7x tp16 (GLM-5.2 FP8, `page_size=128`, ctx 135168):

1. **O(max_ctx) work regardless of actual length** — the ref gathers and scores all `pages_per_seq` pages for every chunk. Profiled at 33% of a 110k-token chunked prefill (30.6s of 91.4s device time).
2. **[T, max_kv] f32 token scores materialize in HBM** — ~4.4 GB per full layer at chunk=8192/ctx=135k. XLA keeps enough of these alive that `HLO temporaries` alone exceed HBM: chunk 8192 + ctx 135168 fails at startup with `temporaries (98.54G) exceeds available HBM (94.75G)` (≈ 22 full layers × chunk × ctx × 4B). Operators today must drop to chunk 4096, paying ~33% extra TTFT at 16k.

### Modifications

- **Kernel** (`kernels/dsa/streamindex_topk.py`): opt-in *page mode* for `_scores_kernel` — per-KV-block token scores are max-pooled to page granularity in VMEM and stored as one lane-row per block (`bkv_p=128`); only `[T, pages_per_seq]` ever reaches HBM. New public wrapper `streamindex_page_topk` mirrors `streamindex_page_topk_ref(one_token_per_seq=False)` semantics (per-query causal bound, tail-page masking, -1 padding).
- **Compile-time fix**: the python-unrolled per-page DMA loop at `bkv_p=128` cost ~40s of Mosaic compile per kernel instantiation (T=8192), pushing cold-start past the server warmup timeout; a `fori_loop` page fetch compiles in 0.6s (68×) with identical steady-state timing. Decode-sized blocks (`bkv_p<=64`) keep the original unrolled loop, byte-identical to the merged path.
- **Backend wiring** (`dsa_sparse_backend.py`): `_maybe_index_prefill_pages` routes through the kernel under `DSA_INDEXER_KERNEL_PREFILL=1`; ref path untouched and remains the default.
- **Tests**: `test_streamindex_page_topk.py` — TPU parity vs the jnp ref across packed multi-seq, multi-block long extend, prefix (chunked/radix form), and mixed decode+extend batches.

### Performance

Kernel microbench (per-device shapes, tp16 head-TP: H=4, D=128, T=8192, `pages_per_seq`=1056 static; v7x):

| actual kv | jnp ref | kernel | speedup |
|---|---|---|---|
| 8k | 20.7 ms | 4.4 ms | 4.5× |
| 49k | 20.7 ms | 8.0 ms | 2.6× |
| 135k | 20.7 ms | 18.7 ms | 1.1× |

ref is flat (O(max_ctx)); the kernel is O(actual kv), which is what chunked prefill integrates over.

End-to-end, GLM-5.2 FP8 v7x tp16, single stream (TTFT, warm, variance <0.1%):

- **Paired isolation of the kernel effect** (same server, same chunk 4096, flipping only the flag): 76k prefill **62.1s → 44.5s (−28%)**.
- **Newly possible configuration**: chunk 8192 × ctx 135168 (no token-score materialization ⇒ the temporaries OOM term is gone). There, 110k prefill measures **65.5s** (×3, two deployments) and 16k measures **9.3s** — i.e. a single 135k-context server now matches the best short-context single-shot setup (9.75s at ctx 49k) within ~5%, instead of paying the previous ~35-40% small-chunk tax.
- Decode TPOT: no regression between the paired arms (15.3ms at 110k on the kernel arm).

(We deliberately do not quote a 110k ref-vs-kernel percentage: the pre-kernel 110k baseline was measured on an earlier revision of this PR stack, so the clean single-stream speedup claim is the paired 76k row.)

**Concurrent serving (the headline)** — paired precompiled servers, `bench_serving`, same seed/warmup, flipping only the flag:

| load | metric | ref | kernel | gain |
|---|---|---|---|---|
| prefill-heavy (in 4096 / out 128, cc=8) | output tok/s | 2.8 | **29.6** | **10.5×** |
| | median TTFT | 36.0s | 3.0s | 12.2× |
| | median TPOT | 2355ms | 230ms | 10.2× |
| balanced (in 1200 / out 512, cc=8) | output tok/s | 28.1 | **122.4** | **4.4×** |
| | median TTFT | 9.65s | 1.03s | 9.4× |
| | median TPOT | 224ms | 55.7ms | 4.0× |

Under concurrent serving the ref scorer pays its O(max_ctx) cost on **every engine step**, so a steady prefill stream convoys all decode behind ~450ms steps; the kernel collapses the step back to O(actual kv). The single-stream −28% substantially understates the serving-throughput impact.

### Accuracy

- Kernel-level: TPU parity gates vs the jnp ref (4 scenarios, exact page-set equality).
- Long-context paired (flip only `DSA_INDEXER_KERNEL_PREFILL`, chunk 4096): 76k single-needle grid (25 samples, 5 depths) **25/25 vs 25/25**; many-shot long-ctx GSM8K (n=50, `max_new_tokens=3072`) **0.960 vs 0.980** — the same ±1-question band as the #1508/#1512 controls.
- Short-context regression control (200q, 5-shot, temp 0, `parallel=8` against a batching server): kernel **0.965** vs ref **0.955**, both 0 invalid — within the ±1-2 question noise band. Standard GSM8K prompts sit far below `index_topk`, so the kernel selects all pages and is mathematically equivalent to the ref there; this cell is a plumbing no-regression check (same rationale as #1508's short control), and it also exercises the kernel under concurrent packed-extend batches (`max_running=32`).

### Limitations / follow-ups

- Page mode requires `bkv_p=128` (one lane-row per block) and `page_size × 128` block spans; deployments at `page_size=64` work (span 8192) but were not perf-tuned here.
- Page mode is explicitly scoped to `compression_ratio=1` (raises otherwise): the compressed causal bound interacts with page pooling and needs its own parity gate before enabling (DSv4-style caches).
- An independent adversarial review of this change was run pre-submission; its findings (distribution semantics at the call site, double-buffer wait semantics) are addressed as code comments, and the `distribution[2]` usage was verified against `mla_backend`'s EXTEND construction (`[0, 0, num_real_seqs]`).
- The high-kv tail (≥110k actual) approaches ref throughput; the remaining bottleneck is the thin-head (H=4) elementwise epilogue — bf16 intermediates / fused pooling are candidate follow-ups.
- Cold-start (single-stream config) compiles ~4.5min server-wide after the fori fix, same class as ref mode. For batching configs we verified startup-precompile from a **clean compilation cache**: 43min to ready (36min EXTEND grid + 3min DECODE grid), single launch, zero request-path stalls; with a persistent compilation cache the same restart is minutes. Recommend precompile (not on-demand compile) for any concurrent deployment.