### PR TITLE
feat(vlm): Add in-model multimodal runtime and Qwen2.5-VL implementation

### DIFF
--- a/python/sgl_jax/srt/layers/embeddings.py
+++ b/python/sgl_jax/srt/layers/embeddings.py
@@ -659,11 +659,27 @@ def get_rope(
             raise ValueError("Unknown RoPE scaling type")
 
         if scaling_type == "default":
-            # HF transformers uses rope_type="default" to mean "no scaling",
-            # equivalent to rope_scaling=None.  Fall back to plain RotaryEmbedding.
-            rotary_emb = RotaryEmbedding(
-                head_size, rotary_dim, max_position, base, is_neox_style, dtype
-            )
+            if "mrope_section" in rope_scaling:
+                # Qwen2.5-VL / Omni: HF config is rope_type="default" plus an
+                # mrope_section -> multimodal sectioned RoPE. Aligns upstream
+                # get_rope (the model/attention stay mrope-agnostic; the 3D
+                # positions come from forward_batch.mrope_positions).
+                rotary_emb = MRotaryEmbedding(
+                    head_size,
+                    rotary_dim,
+                    max_position,
+                    base,
+                    is_neox_style,
+                    dtype,
+                    mrope_section=rope_scaling["mrope_section"],
+                    mrope_interleaved=rope_scaling.get("mrope_interleaved", False),
+                )
+            else:
+                # HF transformers uses rope_type="default" to mean "no scaling",
+                # equivalent to rope_scaling=None.  Fall back to plain RotaryEmbedding.
+                rotary_emb = RotaryEmbedding(
+                    head_size, rotary_dim, max_position, base, is_neox_style, dtype
+                )
         elif scaling_type == "proportional":
             rotary_emb = ProportionalRotaryEmbedding(
                 head_size,

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -528,6 +528,12 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         self.model_config.hf_config.enable_sequence_parallel = (
             self.server_args.enable_sequence_parallel
         )
+        self.model_config.hf_config.vision_encoder_parallel = getattr(
+            self.server_args, "vision_encoder_parallel", "dp"
+        )
+        self.model_config.hf_config.precompile_vision_patch_paddings = getattr(
+            self.server_args, "precompile_vision_patch_paddings", None
+        )
 
         if self.server_args.ep_dispatch_algorithm:
             with jax.set_mesh(self.mesh):

--- a/python/sgl_jax/srt/models/qwen2.py
+++ b/python/sgl_jax/srt/models/qwen2.py
@@ -7,7 +7,7 @@ from flax import nnx
 from transformers import PretrainedConfig
 
 from sgl_jax.srt.configs.model_config import ModelConfig
-from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead, RotaryEmbedding
+from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead, get_rope
 from sgl_jax.srt.layers.layernorm import RMSNorm
 from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
@@ -127,12 +127,13 @@ class Qwen2Attention(nnx.Module):
             params_dtype=dtype,
             mesh=mesh,
         )
-        self.rotary_emb = RotaryEmbedding(
+        self.rotary_emb = get_rope(
             head_size=self.head_dim,
             rotary_dim=self.head_dim,
-            max_position_embeddings=max_position_embeddings,
+            max_position=max_position_embeddings,
             base=rope_theta,
             is_neox_style=True,
+            rope_scaling=rope_scaling,
             dtype=dtype,
         )
 
@@ -281,6 +282,7 @@ class Qwen2Model(nnx.Module):
         self,
         forward_batch: ForwardBatch,
         token_to_kv_pool: KVCache,
+        positions: jax.Array | None = None,
     ):
         residual = None
         input_embeds = (
@@ -293,9 +295,10 @@ class Qwen2Model(nnx.Module):
         )
         layers_kv_fused = []
         layers_callback_flag = []
+        positions = forward_batch.positions if positions is None else positions
         for layer in self.layers:
             hidden_states, residual, kv_fused, callback_flag = layer(
-                forward_batch.positions,
+                positions,
                 hidden_states,
                 forward_batch,
                 token_to_kv_pool,

--- a/python/sgl_jax/srt/models/qwen2_5_vl.py
+++ b/python/sgl_jax/srt/models/qwen2_5_vl.py
@@ -373,6 +373,7 @@ class Qwen2_5_VisionTransformer(nnx.Module):
         input_buckets: tuple[int, ...] | None = None,
     ):
         self.mesh = mesh
+        self.dtype = dtype
         self.vision_tp = vision_tp
         self.specs = VisionShardSpecs(mesh, vision_tp)
         self.input_buckets = input_buckets or tuple(resolve_vision_patch_buckets(None))
@@ -491,6 +492,7 @@ class Qwen2_5_VisionTransformer(nnx.Module):
             patch_dim=self.patch_dim,
             merge_unit=self.spatial_merge_unit,
             rope_type="rope_3d",
+            dtype=self.dtype,
         )
 
     def _build_metadata(
@@ -632,11 +634,7 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module, InModelMultimodalContract):
         # Vision tower.
         self.visual_config = config.vision_config
 
-        from sgl_jax.srt.managers.schedule_batch import global_server_args_dict
-
-        vision_tp = resolve_encoder_tp(
-            mesh, global_server_args_dict.get("vision_encoder_parallel", "dp")
-        )
+        vision_tp = resolve_encoder_tp(mesh, getattr(config, "vision_encoder_parallel", "dp"))
         self.visual = Qwen2_5_VisionTransformer(
             config=self.visual_config,
             dtype=self.dtype,
@@ -646,7 +644,7 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module, InModelMultimodalContract):
             vision_tp=vision_tp,
             input_buckets=tuple(
                 resolve_vision_patch_buckets(
-                    global_server_args_dict.get("precompile_vision_patch_paddings")
+                    getattr(config, "precompile_vision_patch_paddings", None)
                 )
             ),
         )
@@ -678,6 +676,7 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module, InModelMultimodalContract):
             buckets=self.visual.input_buckets,
             merge_unit=self.visual.spatial_merge_unit,
             rope_type="rope_3d",
+            dtype=self.dtype,
         )
 
     def get_multimodal_encode_funcs(self):

--- a/python/sgl_jax/srt/models/qwen2_5_vl.py
+++ b/python/sgl_jax/srt/models/qwen2_5_vl.py
@@ -1,0 +1,966 @@
+import logging
+import math
+from collections.abc import Callable
+from functools import partial
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+from jax.typing import ArrayLike
+from transformers import modeling_flax_utils
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.hf_transformers_utils import get_hf_text_config
+from sgl_jax.srt.layers.embeddings import ParallelLMHead
+from sgl_jax.srt.layers.linear import LinearBase
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
+from sgl_jax.srt.mem_cache.memory_pool import MemoryPools
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+from sgl_jax.srt.models.qwen2 import Qwen2Model
+from sgl_jax.srt.multimodal.common.modality_enum import Modality, MultimodalDataItem
+from sgl_jax.srt.multimodal.configs.qwen_vl.qwen_2_5_vl_config import (
+    QwenVLModelVitConfig,
+)
+from sgl_jax.srt.multimodal.in_model.interface import InModelMultimodalContract
+from sgl_jax.srt.multimodal.in_model.lane_packing import (
+    encoder_num_lanes,
+    precompile_mrope_vision_model,
+    run_mrope_vision_model,
+)
+from sgl_jax.srt.multimodal.layers.attention.flash_attention_backend import (
+    VisionAttentionMetadata,
+    make_vision_attention_backend,
+)
+from sgl_jax.srt.multimodal.layers.vision_sharding import (
+    VisionShardSpecs,
+    apply_data_sharding,
+    resolve_encoder_tp,
+)
+from sgl_jax.srt.utils.common_utils import resolve_vision_patch_buckets
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+_init_fn = nnx.initializers.uniform()
+
+
+def _apply_rotary_pos_emb_vision(
+    x: jax.Array,
+    cos: jax.Array,
+    sin: jax.Array,
+) -> jax.Array:
+    """Apply precomputed vision RoPE to ``x[B, T, heads, head_dim]``."""
+    half_dim = x.shape[-1] // 2
+    x_real, x_imag = x[..., :half_dim], x[..., half_dim:]
+    return jnp.concatenate(
+        [x_real * cos - x_imag * sin, x_real * sin + x_imag * cos],
+        axis=-1,
+    ).astype(x.dtype)
+
+
+class Qwen2_5_VisionPatchEmbed(nnx.Module):
+    """3D (temporal × spatial) patch embedding conv."""
+
+    def __init__(
+        self,
+        mesh: Mesh,
+        rngs: nnx.Rngs = None,
+        patch_size: int = 14,
+        temporal_patch_size: int = 2,
+        in_channels: int = 3,
+        hidden_size: int = 1152,
+        dtype: jnp.dtype = jnp.bfloat16,
+        vision_tp: bool = False,
+    ) -> None:
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.hidden_size = hidden_size
+        self.mesh = mesh
+        self.specs = VisionShardSpecs(mesh, vision_tp)
+
+        self.proj = nnx.Conv(
+            in_features=in_channels,
+            out_features=hidden_size,
+            kernel_size=(temporal_patch_size, patch_size, patch_size),
+            strides=(temporal_patch_size, patch_size, patch_size),
+            use_bias=False,
+            param_dtype=dtype,
+            rngs=rngs or nnx.Rngs(0),
+        )
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        """*x*: ``[B, S, C·T·H·W]`` → ``[B, S, hidden_size]``."""
+        B, S, D = x.shape
+        C = D // (self.temporal_patch_size * self.patch_size * self.patch_size)
+        x = x.reshape(B, S, C, self.temporal_patch_size, self.patch_size, self.patch_size)
+        x = apply_data_sharding(x, self.mesh, PartitionSpec(self.specs.batch_axis))
+
+        # [B, S, C, T, H, W] → [B, S, T, H, W, C]
+        x = jnp.transpose(x, (0, 1, 3, 4, 5, 2))
+
+        sh = None
+        if "data" in self.mesh.abstract_mesh.explicit_axes:
+            sh = self.specs.sharding(self.specs.batch_axis)
+
+        x = x.reshape(
+            B * S,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+            C,
+            out_sharding=sh,
+        )
+        x = self.proj(x, out_sharding=sh)
+        x = x.reshape(B, S, 1, 1, 1, self.hidden_size, out_sharding=sh)
+        return jnp.squeeze(x, axis=(2, 3, 4))
+
+
+class Qwen2_5_VLMLP(nnx.Module):
+    """ViT MLP: gate/up → SiLU gate → down."""
+
+    def __init__(
+        self,
+        config: QwenVLModelVitConfig,
+        dtype: jnp.dtype,
+        mesh: Mesh,
+        rngs: nnx.Rngs = None,
+        vision_tp: bool = False,
+    ):
+        self.specs = VisionShardSpecs(mesh, vision_tp)
+        self.act_fn = modeling_flax_utils.ACT2FN[config.hidden_act]
+
+        self.gate_proj = LinearBase(
+            config.hidden_size,
+            config.intermediate_size,
+            mesh=mesh,
+            use_bias=True,
+            kernel_axes=self.specs.col_kernel_axes,
+            params_dtype=dtype,
+        )
+        self.up_proj = LinearBase(
+            config.hidden_size,
+            config.intermediate_size,
+            mesh=mesh,
+            use_bias=True,
+            kernel_axes=self.specs.col_kernel_axes,
+            params_dtype=dtype,
+        )
+        self.down_proj = LinearBase(
+            config.intermediate_size,
+            config.hidden_size,
+            mesh=mesh,
+            use_bias=True,
+            kernel_axes=self.specs.row_kernel_axes,
+            params_dtype=dtype,
+        )
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        specs = self.specs
+        col = specs.sharding(specs.batch_axis, None, specs.tensor_axis)
+        row = specs.sharding(specs.batch_axis)
+        gate, _ = self.gate_proj(x, out_sharding=col)
+        up, _ = self.up_proj(x, out_sharding=col)
+        out, _ = self.down_proj(self.act_fn(gate) * up, out_sharding=row)
+        return out
+
+
+class Qwen2_5_VisionAttention(nnx.Module):
+    """ViT self-attention with fused QKV, RoPE, and block-diagonal flash attn."""
+
+    def __init__(
+        self,
+        config: QwenVLModelVitConfig,
+        dtype: jnp.dtype,
+        mesh: Mesh,
+        rngs: nnx.Rngs = None,
+        vision_tp: bool = False,
+    ):
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_heads
+        self.head_dim = self.hidden_size // self.num_heads
+        self.mesh = mesh
+        self.specs = VisionShardSpecs(mesh, vision_tp)
+
+        if self.specs.tp:
+            tp_size = int(mesh.shape["tensor"])
+            assert (
+                self.num_heads % tp_size == 0
+            ), f"vision num_heads={self.num_heads} must be divisible by tp={tp_size}"
+
+        self.q_proj = LinearBase(
+            self.hidden_size,
+            self.hidden_size,
+            mesh=mesh,
+            use_bias=True,
+            kernel_axes=self.specs.col_kernel_axes,
+            params_dtype=dtype,
+        )
+        self.k_proj = LinearBase(
+            self.hidden_size,
+            self.hidden_size,
+            mesh=mesh,
+            use_bias=True,
+            kernel_axes=self.specs.col_kernel_axes,
+            params_dtype=dtype,
+        )
+        self.v_proj = LinearBase(
+            self.hidden_size,
+            self.hidden_size,
+            mesh=mesh,
+            use_bias=True,
+            kernel_axes=self.specs.col_kernel_axes,
+            params_dtype=dtype,
+        )
+        self.proj = LinearBase(
+            self.hidden_size,
+            self.hidden_size,
+            mesh=mesh,
+            use_bias=True,
+            kernel_axes=self.specs.row_kernel_axes,
+            params_dtype=dtype,
+        )
+
+        self.attn_backend = make_vision_attention_backend(
+            mesh,
+            sm_scale=1.0 / math.sqrt(self.head_dim),
+            causal=False,
+            head_tp=self.specs.tp,
+            use_varlen=True,
+        )
+
+    def __call__(
+        self,
+        x: jax.Array,
+        rotary_cos: jax.Array,
+        rotary_sin: jax.Array,
+        metadata: VisionAttentionMetadata,
+    ) -> jax.Array:
+        B, T, D = x.shape
+        specs = self.specs
+        col = specs.sharding(specs.batch_axis, None, specs.tensor_axis)
+
+        # Project Q, K, V separately (TP-safe: each is independently column-parallel).
+        q, _ = self.q_proj(x, out_sharding=col)
+        k, _ = self.k_proj(x, out_sharding=col)
+        v, _ = self.v_proj(x, out_sharding=col)
+
+        hs = specs.sharding(specs.batch_axis, None, specs.tensor_axis, None)
+        q = q.reshape(B, T, self.num_heads, self.head_dim, out_sharding=hs)
+        k = k.reshape(B, T, self.num_heads, self.head_dim, out_sharding=hs)
+        v = v.reshape(B, T, self.num_heads, self.head_dim, out_sharding=hs)
+
+        q = _apply_rotary_pos_emb_vision(q, rotary_cos, rotary_sin)
+        k = _apply_rotary_pos_emb_vision(k, rotary_cos, rotary_sin)
+
+        out = self.attn_backend(q, k, v, metadata)
+        out = out.reshape(B, T, D, out_sharding=col)
+        out, _ = self.proj(out, out_sharding=specs.sharding(specs.batch_axis))
+        return out
+
+
+class Qwen2_5_VisionBlock(nnx.Module):
+    """One ViT transformer block: attn (pre-norm) + MLP (pre-norm)."""
+
+    def __init__(
+        self,
+        config: QwenVLModelVitConfig,
+        dtype: jnp.dtype,
+        mesh: Mesh,
+        rngs: nnx.Rngs = None,
+        norm_eps: float = 1e-6,
+        vision_tp: bool = False,
+    ):
+        _rngs = rngs or nnx.Rngs(0)
+        norm = partial(
+            nnx.RMSNorm, epsilon=norm_eps, scale_init=nnx.with_partitioning(_init_fn, (None,))
+        )
+
+        self.norm1 = norm(config.hidden_size, dtype=dtype, rngs=_rngs)
+        self.norm2 = norm(config.hidden_size, dtype=dtype, rngs=_rngs)
+        self.attn = Qwen2_5_VisionAttention(
+            config,
+            dtype,
+            rngs=rngs,
+            mesh=mesh,
+            vision_tp=vision_tp,
+        )
+        self.mlp = Qwen2_5_VLMLP(config, dtype, rngs=rngs, mesh=mesh, vision_tp=vision_tp)
+
+    def __call__(
+        self,
+        x: jax.Array,
+        rotary_cos: jax.Array,
+        rotary_sin: jax.Array,
+        metadata: VisionAttentionMetadata,
+    ) -> jax.Array:
+        x = x + self.attn(self.norm1(x), rotary_cos, rotary_sin, metadata)
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class Qwen2_5_VisionPatchMerger(nnx.Module):
+    """Spatial merge: LN → reshape(sms²) → 2-layer MLP → [B, T/sms², d_model]."""
+
+    def __init__(
+        self,
+        d_model: int,
+        context_dim: int,
+        norm_layer: Callable,
+        spatial_merge_size: int,
+        dtype: jnp.dtype,
+        mesh: Mesh,
+        rngs: nnx.Rngs = None,
+        vision_tp: bool = False,
+    ):
+        self.hidden_size = context_dim * (spatial_merge_size**2)
+        self.mesh = mesh
+        self.specs = VisionShardSpecs(mesh, vision_tp)
+        _rngs = rngs or nnx.Rngs(0)
+
+        self.ln_q = norm_layer(
+            context_dim,
+            dtype=dtype,
+            rngs=_rngs,
+            scale_init=nnx.with_partitioning(_init_fn, (None,)),
+        )
+        self.mlp_fc1 = LinearBase(
+            self.hidden_size,
+            self.hidden_size,
+            mesh=mesh,
+            use_bias=True,
+            kernel_axes=self.specs.col_kernel_axes,
+            params_dtype=dtype,
+        )
+        self.mlp_act = modeling_flax_utils.ACT2FN["gelu"]
+        self.mlp_fc2 = LinearBase(
+            self.hidden_size,
+            d_model,
+            mesh=mesh,
+            use_bias=True,
+            kernel_axes=self.specs.row_kernel_axes,
+            params_dtype=dtype,
+        )
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        specs = self.specs
+        row = specs.sharding(specs.batch_axis)
+        x = self.ln_q(x)
+        B = x.shape[0]
+        x = x.reshape(B, -1, self.hidden_size, out_sharding=row)
+        x, _ = self.mlp_fc1(
+            x, out_sharding=specs.sharding(specs.batch_axis, None, specs.tensor_axis)
+        )
+        x = self.mlp_act(x)
+        x, _ = self.mlp_fc2(x, out_sharding=row)
+        return x
+
+
+class Qwen2_5_VisionTransformer(nnx.Module):
+    """Qwen2.5-VL ViT: patch embed → window / full-attn blocks → merge → reorder."""
+
+    def __init__(
+        self,
+        config: QwenVLModelVitConfig,
+        dtype: jnp.dtype,
+        mesh: Mesh,
+        rngs: nnx.Rngs = None,
+        norm_eps: float = 1e-6,
+        vision_tp: bool = False,
+        input_buckets: tuple[int, ...] | None = None,
+    ):
+        self.mesh = mesh
+        self.vision_tp = vision_tp
+        self.specs = VisionShardSpecs(mesh, vision_tp)
+        self.input_buckets = input_buckets or tuple(resolve_vision_patch_buckets(None))
+        self.spatial_merge_size = config.spatial_merge_size
+        self.spatial_merge_unit = self.spatial_merge_size**2
+        if any(bucket <= 0 or bucket % self.spatial_merge_unit for bucket in self.input_buckets):
+            raise ValueError(
+                f"vision patch buckets must be positive multiples of {self.spatial_merge_unit}"
+            )
+
+        self.patch_embed = Qwen2_5_VisionPatchEmbed(
+            patch_size=config.patch_size,
+            temporal_patch_size=config.temporal_patch_size,
+            in_channels=config.in_channels,
+            hidden_size=config.hidden_size,
+            dtype=dtype,
+            rngs=rngs,
+            mesh=mesh,
+            vision_tp=vision_tp,
+        )
+        self.blocks = nnx.List(
+            [
+                Qwen2_5_VisionBlock(
+                    config,
+                    dtype,
+                    rngs=rngs,
+                    mesh=mesh,
+                    norm_eps=norm_eps,
+                    vision_tp=vision_tp,
+                )
+                for i in range(config.depth)
+            ]
+        )
+        self.merger = Qwen2_5_VisionPatchMerger(
+            d_model=config.out_hidden_size,
+            context_dim=config.hidden_size,
+            norm_layer=partial(nnx.RMSNorm, epsilon=norm_eps),
+            spatial_merge_size=config.spatial_merge_size,
+            dtype=dtype,
+            rngs=rngs,
+            mesh=mesh,
+            vision_tp=vision_tp,
+        )
+
+        self.fullatt_block_indexes = config.fullatt_block_indexes
+        self.patch_size = config.patch_size
+        self.patch_dim = config.in_channels * config.temporal_patch_size * config.patch_size**2
+        self.window_size = config.window_size
+        self.rotary_dim = config.hidden_size // config.num_heads // 2
+        self.theta = float(getattr(config, "rope_theta", 10000.0))
+        self.rot_dim = 2 * len(range(0, self.rotary_dim, 2))
+
+    def __call__(
+        self,
+        patches: ArrayLike,
+        grid_thw: np.ndarray,
+    ) -> jax.Array:
+        return self.encode(patches, grid_thw)
+
+    def _forward(
+        self,
+        patches: jax.Array,
+        indices: jax.Array,
+        position_ids: jax.Array,
+        window_attn: VisionAttentionMetadata,
+        full_attn: VisionAttentionMetadata,
+    ) -> jax.Array:
+        B, S = patches.shape[:2]
+        u = self.spatial_merge_unit
+        n_units = S // u
+        window_index, reverse_indices = indices[:, :, 0], indices[:, :, 1]
+        inv_freq = 1.0 / (
+            self.theta ** (jnp.arange(0, self.rotary_dim, 2, dtype=jnp.float32) / self.rotary_dim)
+        )
+        rotary_pos_emb = (position_ids[..., None].astype(jnp.float32) * inv_freq).reshape(
+            B, S, self.rot_dim
+        )
+        rotary_cos = jnp.cos(rotary_pos_emb)[:, :, None, :]
+        rotary_sin = jnp.sin(rotary_pos_emb)[:, :, None, :]
+
+        x = self.patch_embed(patches)
+        x = x.reshape(B, n_units, u, -1)
+
+        # Window reorder (batch axis stays on 0).
+        x = jnp.take_along_axis(x, window_index[:, :, None, None], axis=1)
+        x = x.reshape(B, S, -1)
+
+        # Select the pre-planned metadata per block: full-frame for the layers in
+        # ``fullatt_block_indexes``, otherwise the local-window layout.
+        layout_metadata = (window_attn, full_attn)
+        for i, blk in enumerate(self.blocks):
+            block_meta = layout_metadata[int(i in self.fullatt_block_indexes)]
+            x = blk(x, rotary_cos, rotary_sin, block_meta)
+
+        x = self.merger(x)
+        return jnp.take_along_axis(x, reverse_indices[:, :, None], axis=1)
+
+    def encode(
+        self,
+        patches: ArrayLike,
+        grid_thw: np.ndarray,
+    ) -> jax.Array:
+        batch_sharding = self.specs.sharding(self.specs.batch_axis)
+        patches = jax.device_put(patches, batch_sharding)
+        metadata = self._build_metadata(grid_thw, patches.shape[1])
+        metadata = jax.device_put(metadata, batch_sharding)
+        with jax.set_mesh(self.mesh):
+            return self._encode_jit(patches, *metadata)
+
+    def precompile(self) -> None:
+        precompile_mrope_vision_model(
+            self,
+            mesh=self.mesh,
+            num_lanes=encoder_num_lanes(self.mesh, self.vision_tp),
+            buckets=self.input_buckets,
+            patch_dim=self.patch_dim,
+            merge_unit=self.spatial_merge_unit,
+            rope_type="rope_3d",
+        )
+
+    def _build_metadata(
+        self,
+        lane_grids: np.ndarray,
+        capacity: int,
+    ) -> tuple[np.ndarray, np.ndarray, VisionAttentionMetadata, VisionAttentionMetadata]:
+        lane_grids = np.asarray(lane_grids, dtype=np.int32)
+        if lane_grids.ndim == 2:
+            lane_grids = lane_grids[None]
+        batch = len(lane_grids)
+        merge = self.spatial_merge_size
+        unit = self.spatial_merge_unit
+        num_units = capacity // unit
+        window = self.window_size // merge // self.patch_size
+        unit_range = np.arange(num_units, dtype=np.int32)
+        indices = np.broadcast_to(unit_range[None, :, None], (batch, num_units, 2)).copy()
+        position_ids = np.zeros((batch, capacity, 2), dtype=np.int32)
+        cu_seqlens = np.zeros((batch, 2, num_units + 1), dtype=np.int32)
+
+        def grid_layout(t: int, h: int, w: int):
+            grid_h, grid_w = h // merge, w // merge
+            index = np.arange(t * grid_h * grid_w).reshape(t, grid_h, grid_w)
+            pad_h, pad_w = (-grid_h) % window, (-grid_w) % window
+            windows_h, windows_w = (grid_h + pad_h) // window, (grid_w + pad_w) // window
+            index = np.pad(index, ((0, 0), (0, pad_h), (0, pad_w)), constant_values=-1)
+            index = index.reshape(t, windows_h, window, windows_w, window)
+            index = index.transpose(0, 1, 3, 2, 4).reshape(-1, window, window)
+            window_lengths = (index != -1).sum(axis=(1, 2)).astype(np.int32) * unit
+            index = index.reshape(-1)
+            index = index[index != -1].astype(np.int32)
+
+            y, x = np.indices((h, w))
+            coords = np.stack((y, x), axis=-1)
+            coords = coords.reshape(grid_h, merge, grid_w, merge, 2)
+            coords = coords.transpose(0, 2, 1, 3, 4).reshape(h * w, 2)
+            coords = np.tile(coords, (t, 1))
+            coords = coords.reshape(-1, unit, 2)[index].reshape(t * h * w, 2)
+            return index, window_lengths, coords
+
+        for lane, grids in enumerate(lane_grids):
+            patch_offset = unit_offset = 0
+            window_ends = []
+            frame_ends = []
+            for grid in grids:
+                if not np.any(grid):
+                    continue
+                t, h, w = map(int, grid)
+                patch_count = t * h * w
+                window_index, window_lengths, coords = grid_layout(t, h, w)
+                unit_count = patch_count // unit
+                patch_slice = slice(patch_offset, patch_offset + patch_count)
+                unit_slice = slice(unit_offset, unit_offset + unit_count)
+                indices[lane, unit_slice, 0] = window_index + unit_offset
+                position_ids[lane, patch_slice] = coords
+                window_ends.extend(patch_offset + np.cumsum(window_lengths))
+                frame_ends.extend(patch_offset + np.arange(1, t + 1, dtype=np.int32) * h * w)
+                patch_offset += patch_count
+                unit_offset += unit_count
+            indices[lane, :, 1] = np.argsort(indices[lane, :, 0]).astype(np.int32)
+            for layout, ends in enumerate((window_ends, frame_ends)):
+                count = len(ends)
+                cu_seqlens[lane, layout, 1 : count + 1] = ends
+                cu_seqlens[lane, layout, count + 1 :] = patch_offset
+        # cu_seqlens[:, 0] is the window layout, [:, 1] the full-frame layout.
+        window_cu_seqlens = cu_seqlens[:, 0]
+        full_cu_seqlens = cu_seqlens[:, 1]
+        # Static bounds must depend only on the compile bucket, not the request's
+        # exact segment values, so requests in one bucket share a compilation.
+        window_max_seq_len = min(capacity, window * window * unit)
+        return (
+            indices,
+            position_ids,
+            VisionAttentionMetadata(
+                window_cu_seqlens,
+                max_seq_len=window_max_seq_len,
+            ),
+            VisionAttentionMetadata(
+                full_cu_seqlens,
+                max_seq_len=capacity,
+            ),
+        )
+
+    @jax.jit
+    def _encode_jit(
+        self,
+        patches: jax.Array,
+        indices: jax.Array,
+        position_ids: jax.Array,
+        window_attn: VisionAttentionMetadata,
+        full_attn: VisionAttentionMetadata,
+    ) -> jax.Array:
+        features = self._forward(patches, indices, position_ids, window_attn, full_attn)
+        # Keep the DP lane-to-replicated transition inside the compiled encode.
+        # An eager reshard of a multi-device result can otherwise stage through
+        # the host when no source device owns the complete array.
+        return jax.sharding.reshard(
+            features,
+            NamedSharding(
+                self.mesh,
+                PartitionSpec(*([None] * features.ndim)),
+            ),
+        )
+
+
+class Qwen2_5_VLForConditionalGeneration(nnx.Module, InModelMultimodalContract):
+    """Qwen2.5-VL: vision tower + Qwen2 backbone (+ MRoPE) + lm_head.
+
+    The visual encode stays outside the backbone JIT. MRoPE positions are
+    selected by this wrapper and passed to the shared ``Qwen2Model`` backbone.
+    """
+
+    mrope_position_axes = 3
+
+    def __init__(self, config=None, dtype=None, mesh=None, rngs=None):
+        super().__init__()
+        self.mesh = mesh
+        self.config = config
+        self.text_config = get_hf_text_config(config) or config
+        self.dtype = dtype or jnp.bfloat16
+        self.is_mrope_enabled = "mrope_section" in (
+            getattr(self.text_config, "rope_scaling", None) or {}
+        )
+
+        # Language backbone.
+        self.model = Qwen2Model(self.text_config, mesh=mesh, dtype=self.dtype)
+        if not getattr(self.text_config, "tie_word_embeddings", False):
+            self.lm_head = ParallelLMHead(
+                self.text_config.vocab_size,
+                self.text_config.hidden_size,
+                dtype=self.dtype,
+                param_dtype=self.dtype,
+                kernel_axes=("tensor", None),
+            )
+        self.logits_processor = LogitsProcessor(self.text_config.vocab_size, mesh=self.mesh)
+        self.image_token_id = getattr(self.config, "image_token_id", None)
+        self.video_token_id = getattr(self.config, "video_token_id", None)
+
+        # Vision tower.
+        self.visual_config = config.vision_config
+
+        from sgl_jax.srt.managers.schedule_batch import global_server_args_dict
+
+        vision_tp = resolve_encoder_tp(
+            mesh, global_server_args_dict.get("vision_encoder_parallel", "dp")
+        )
+        self.visual = Qwen2_5_VisionTransformer(
+            config=self.visual_config,
+            dtype=self.dtype,
+            rngs=rngs,
+            mesh=mesh,
+            norm_eps=getattr(self.visual_config, "rms_norm_eps", 1e-6),
+            vision_tp=vision_tp,
+            input_buckets=tuple(
+                resolve_vision_patch_buckets(
+                    global_server_args_dict.get("precompile_vision_patch_paddings")
+                )
+            ),
+        )
+
+    def get_input_embeddings(self) -> Callable[[jax.Array], jax.Array]:
+        return self.model.embed_tokens
+
+    def precompile_multimodal(self) -> None:
+        self.visual.precompile()
+
+    def get_multimodal_embedding_packed_capacities(self) -> tuple[int, ...]:
+        rows = encoder_num_lanes(self.mesh, self.visual.vision_tp)
+        unit = self.visual.spatial_merge_unit
+        return tuple(rows * bucket // unit for bucket in self.visual.input_buckets)
+
+    def get_image_feature(self, items: list[MultimodalDataItem]) -> jax.Array:
+        return self._get_visual_feature(items)
+
+    def get_video_feature(self, items: list[MultimodalDataItem]) -> jax.Array:
+        return self._get_visual_feature(items)
+
+    def _get_visual_feature(self, items: list[MultimodalDataItem]) -> jax.Array:
+        num_lanes = encoder_num_lanes(self.mesh, self.visual.vision_tp)
+        return run_mrope_vision_model(
+            self.visual,
+            items,
+            mesh=self.mesh,
+            num_lanes=num_lanes,
+            buckets=self.visual.input_buckets,
+            merge_unit=self.visual.spatial_merge_unit,
+            rope_type="rope_3d",
+        )
+
+    def get_multimodal_encode_funcs(self):
+        return {
+            Modality.IMAGE: self.get_image_feature,
+            Modality.MULTI_IMAGES: self.get_image_feature,
+            Modality.VIDEO: self.get_video_feature,
+        }
+
+    def load_weights(self, model_config: ModelConfig) -> None:
+        # Text backbone + lm_head.
+        loader = WeightLoader(
+            model=self, model_config=model_config, mesh=self.mesh, dtype=self.dtype
+        )
+        loader.load_weights_from_safetensors(self._language_weight_mappings())
+        logger.info("Qwen2.5-VL (LLM) weights loaded.")
+        # ViT weights — carry vision head info so _split_qkv_weight can slice the
+        # fused ``qkv.weight`` / ``qkv.bias`` into q_proj, k_proj, v_proj.
+        vc = self.visual_config
+        vision_model_config = SimpleNamespace(
+            model_path=model_config.model_path,
+            num_attention_heads=vc.num_heads,
+            hidden_size=vc.hidden_size,
+            get_total_num_kv_heads=lambda: vc.num_heads,  # no GQA in ViT
+        )
+        self._load_vision_weights(vision_model_config)
+
+    def _language_weight_mappings(self) -> dict:
+        mappings = {
+            "model.embed_tokens.weight": WeightMapping(
+                target_path="model.embed_tokens.embedding",
+                sharding=("tensor", None),
+                transpose=False,
+            ),
+            "model.norm.weight": WeightMapping(
+                target_path="model.norm.scale", sharding=(None,), transpose=False
+            ),
+        }
+
+        if not getattr(self.text_config, "tie_word_embeddings", False):
+            mappings["lm_head.weight"] = WeightMapping(
+                target_path="lm_head.embedding", sharding=("tensor", None), transpose=False
+            )
+
+        for layer_idx in range(self.text_config.num_hidden_layers):
+            mappings.update(self._language_layer_mappings(layer_idx))
+
+        return mappings
+
+    def _language_layer_mappings(self, layer_idx: int) -> dict:
+        prefix = f"model.layers.{layer_idx}"
+        target_prefix = f"model.layers.{layer_idx}"
+
+        mappings = {
+            f"{prefix}.input_layernorm.weight": WeightMapping(
+                target_path=f"{target_prefix}.input_layernorm.scale",
+                sharding=(None,),
+                transpose=False,
+            ),
+            f"{prefix}.post_attention_layernorm.weight": WeightMapping(
+                target_path=f"{target_prefix}.post_attention_layernorm.scale",
+                sharding=(None,),
+                transpose=False,
+            ),
+            f"{prefix}.self_attn.q_proj.weight": WeightMapping(
+                target_path=f"{target_prefix}.self_attn.q_proj.weight",
+                sharding=(None, "tensor"),
+                transpose=True,
+                head_dim_padding=True,
+                kv_head_padding=False,
+            ),
+            f"{prefix}.self_attn.k_proj.weight": WeightMapping(
+                target_path=f"{target_prefix}.self_attn.k_proj.weight",
+                sharding=(None, "tensor"),
+                transpose=True,
+                head_dim_padding=True,
+                kv_head_padding=True,
+            ),
+            f"{prefix}.self_attn.v_proj.weight": WeightMapping(
+                target_path=f"{target_prefix}.self_attn.v_proj.weight",
+                sharding=(None, "tensor"),
+                transpose=True,
+                head_dim_padding=True,
+                kv_head_padding=True,
+            ),
+            f"{prefix}.self_attn.o_proj.weight": WeightMapping(
+                target_path=f"{target_prefix}.self_attn.o_proj.weight",
+                sharding=("tensor", None),
+                transpose=True,
+                head_dim_padding=True,
+                kv_head_padding=False,
+            ),
+            f"{prefix}.mlp.gate_proj.weight": WeightMapping(
+                target_path=f"{target_prefix}.mlp.gate_proj.weight",
+                sharding=(None, "tensor"),
+                transpose=True,
+            ),
+            f"{prefix}.mlp.up_proj.weight": WeightMapping(
+                target_path=f"{target_prefix}.mlp.up_proj.weight",
+                sharding=(None, "tensor"),
+                transpose=True,
+            ),
+            f"{prefix}.mlp.down_proj.weight": WeightMapping(
+                target_path=f"{target_prefix}.mlp.down_proj.weight",
+                sharding=("tensor", None),
+                transpose=True,
+            ),
+        }
+
+        if getattr(self.text_config, "attention_bias", True):
+            mappings.update(
+                {
+                    f"{prefix}.self_attn.q_proj.bias": WeightMapping(
+                        target_path=f"{target_prefix}.self_attn.q_proj.bias",
+                        sharding=(None,),
+                        transpose=False,
+                        head_dim_padding=True,
+                        kv_head_padding=False,
+                    ),
+                    f"{prefix}.self_attn.k_proj.bias": WeightMapping(
+                        target_path=f"{target_prefix}.self_attn.k_proj.bias",
+                        sharding=(None,),
+                        transpose=False,
+                        head_dim_padding=True,
+                        kv_head_padding=True,
+                    ),
+                    f"{prefix}.self_attn.v_proj.bias": WeightMapping(
+                        target_path=f"{target_prefix}.self_attn.v_proj.bias",
+                        sharding=(None,),
+                        transpose=False,
+                        head_dim_padding=True,
+                        kv_head_padding=True,
+                    ),
+                    f"{prefix}.self_attn.o_proj.bias": WeightMapping(
+                        target_path=f"{target_prefix}.self_attn.o_proj.bias",
+                        sharding=(None,),
+                        transpose=False,
+                    ),
+                }
+            )
+
+        return mappings
+
+    def _load_vision_weights(self, model_config) -> None:
+        loader = WeightLoader(
+            model=self, model_config=model_config, mesh=self.mesh, dtype=self.dtype
+        )
+        mappings = self._vision_weight_mappings()
+        with self.mesh:
+            loader.load_weights_from_safetensors(mappings)
+        logger.info("Qwen2.5-VL ViT weights loaded.")
+
+    def _vision_weight_mappings(self) -> dict:
+        tp = self.visual.specs.tp
+        col = (None, "tensor") if tp else (None, None)
+        row = ("tensor", None) if tp else (None, None)
+
+        mappings = {
+            # Patch embed Conv3D: PyTorch [out,in,kd,kh,kw] → JAX [kd,kh,kw,in,out].
+            "visual.patch_embed.proj.weight": WeightMapping(
+                target_path="visual.patch_embed.proj.kernel",
+                sharding=(None, None, None, None, None),
+                transpose_axes=(2, 3, 4, 1, 0),
+            ),
+            "visual.merger.ln_q.weight": WeightMapping(
+                target_path="visual.merger.ln_q.scale",
+                sharding=(None,),
+                transpose=False,
+            ),
+            **self._merger_mlp_mappings(col, row),
+        }
+        for i in range(getattr(self.visual_config, "depth", 0)):
+            mappings.update(self._block_mappings(i, col, row))
+        return mappings
+
+    @staticmethod
+    def _merger_mlp_mappings(col, row) -> dict:
+        """Weight mappings for the patch merger MLP (mlp.0 / mlp.2 in HF)."""
+        return {
+            "visual.merger.mlp.0.weight": WeightMapping(
+                target_path="visual.merger.mlp_fc1.weight", sharding=col, transpose=True
+            ),
+            "visual.merger.mlp.0.bias": WeightMapping(
+                target_path="visual.merger.mlp_fc1.bias", sharding=(None,), transpose=False
+            ),
+            "visual.merger.mlp.2.weight": WeightMapping(
+                target_path="visual.merger.mlp_fc2.weight", sharding=row, transpose=True
+            ),
+            "visual.merger.mlp.2.bias": WeightMapping(
+                target_path="visual.merger.mlp_fc2.bias", sharding=(None,), transpose=False
+            ),
+        }
+
+    @staticmethod
+    def _block_mappings(layer_idx: int, col, row) -> dict:
+        """Weight mappings for one ViT block (``visual.blocks.{i}.*``).
+
+        The fused ``qkv.weight`` / ``qkv.bias`` are split into separate
+        q/k/v projections so column-parallel sharding is TP-safe (each
+        projection independently stripe-interleaves its own output slice).
+        """
+        p = f"visual.blocks.{layer_idx}"
+        return {
+            f"{p}.norm1.weight": WeightMapping(
+                target_path=f"{p}.norm1.scale", sharding=(None,), transpose=False
+            ),
+            f"{p}.norm2.weight": WeightMapping(
+                target_path=f"{p}.norm2.scale", sharding=(None,), transpose=False
+            ),
+            f"{p}.attn.qkv.weight": WeightMapping(
+                target_path=[
+                    f"{p}.attn.q_proj.weight",
+                    f"{p}.attn.k_proj.weight",
+                    f"{p}.attn.v_proj.weight",
+                ],
+                sharding=col,
+                transpose=True,
+            ),
+            f"{p}.attn.qkv.bias": WeightMapping(
+                target_path=[
+                    f"{p}.attn.q_proj.bias",
+                    f"{p}.attn.k_proj.bias",
+                    f"{p}.attn.v_proj.bias",
+                ],
+                sharding=(None,),
+                transpose=False,
+            ),
+            f"{p}.attn.proj.weight": WeightMapping(
+                target_path=f"{p}.attn.proj.weight", sharding=row, transpose=True
+            ),
+            f"{p}.attn.proj.bias": WeightMapping(
+                target_path=f"{p}.attn.proj.bias", sharding=(None,), transpose=False
+            ),
+            f"{p}.mlp.gate_proj.weight": WeightMapping(
+                target_path=f"{p}.mlp.gate_proj.weight", sharding=col, transpose=True
+            ),
+            f"{p}.mlp.gate_proj.bias": WeightMapping(
+                target_path=f"{p}.mlp.gate_proj.bias", sharding=(None,), transpose=False
+            ),
+            f"{p}.mlp.up_proj.weight": WeightMapping(
+                target_path=f"{p}.mlp.up_proj.weight", sharding=col, transpose=True
+            ),
+            f"{p}.mlp.up_proj.bias": WeightMapping(
+                target_path=f"{p}.mlp.up_proj.bias", sharding=(None,), transpose=False
+            ),
+            f"{p}.mlp.down_proj.weight": WeightMapping(
+                target_path=f"{p}.mlp.down_proj.weight", sharding=row, transpose=True
+            ),
+            f"{p}.mlp.down_proj.bias": WeightMapping(
+                target_path=f"{p}.mlp.down_proj.bias", sharding=(None,), transpose=False
+            ),
+        }
+
+    def get_embed_and_head(self):
+        if getattr(self.text_config, "tie_word_embeddings", False):
+            w = self.model.embed_tokens.embedding.value
+            return (w, w)
+        return (self.model.embed_tokens.embedding.value, self.lm_head.embedding.value)
+
+    def set_embed_and_head(
+        self, embed_weight: jax.Array | None = None, head_weight: jax.Array | None = None
+    ) -> None:
+        if embed_weight is not None:
+            self.model.embed_tokens.embedding.value = embed_weight
+        if head_weight is not None:
+            self.lm_head.embedding.value = head_weight
+
+    def __call__(
+        self,
+        forward_batch: ForwardBatch,
+        memory_pools: MemoryPools,
+        logits_metadata: LogitsMetadata,
+    ):
+        positions = (
+            forward_batch.mrope_positions if self.is_mrope_enabled else forward_batch.positions
+        )
+        hidden_states, layers_kv_fused, layers_callback_flag = self.model(
+            forward_batch, memory_pools.token_to_kv_pool, positions=positions
+        )
+        head = (
+            self.model.embed_tokens
+            if getattr(self.text_config, "tie_word_embeddings", False)
+            else self.lm_head
+        )
+        output = self.logits_processor(hidden_states, head, logits_metadata)
+        return output, layers_kv_fused, layers_callback_flag, None

--- a/python/sgl_jax/srt/models/registry.py
+++ b/python/sgl_jax/srt/models/registry.py
@@ -67,10 +67,26 @@ class _ModelRegistry:
 
         return self._raise_for_unsupported(architectures)
 
+    def is_in_model_multimodal(self, architectures: str | list[str]) -> bool:
+        from sgl_jax.srt.multimodal.in_model.interface import InModelMultimodalContract
+
+        try:
+            model_cls, _ = self.resolve_model_cls(architectures)
+        except ValueError:
+            return False
+        return issubclass(model_cls, InModelMultimodalContract)
+
 
 @lru_cache
-def import_model_classes():
-    model_arch_name_to_cls = {}
+def import_model_classes() -> dict[str, type[Any]]:
+    model_arch_name_to_cls: dict[str, type[Any]] = {}
+
+    def register(model_cls: type[Any]) -> None:
+        assert (
+            model_cls.__name__ not in model_arch_name_to_cls
+        ), f"Duplicated model implementation for {model_cls.__name__}"
+        model_arch_name_to_cls[model_cls.__name__] = model_cls
+
     package_name = "sgl_jax.srt.models"
     package = importlib.import_module(package_name)
     for _, name, ispkg in pkgutil.iter_modules(package.__path__, package_name + "."):
@@ -83,16 +99,10 @@ def import_model_classes():
             if hasattr(module, "EntryClass"):
                 entry = module.EntryClass
                 if isinstance(entry, list):  # To support multiple model classes in one module
-                    for tmp in entry:
-                        assert (
-                            tmp.__name__ not in model_arch_name_to_cls
-                        ), f"Duplicated model implementation for {tmp.__name__}"
-                        model_arch_name_to_cls[tmp.__name__] = tmp
+                    for model_cls in entry:
+                        register(model_cls)
                 else:
-                    assert (
-                        entry.__name__ not in model_arch_name_to_cls
-                    ), f"Duplicated model implementation for {entry.__name__}"
-                    model_arch_name_to_cls[entry.__name__] = entry
+                    register(entry)
 
     return model_arch_name_to_cls
 

--- a/python/sgl_jax/srt/multimodal/in_model/embedding_pool.py
+++ b/python/sgl_jax/srt/multimodal/in_model/embedding_pool.py
@@ -1,0 +1,224 @@
+"""Device-resident, paged cache of encoder embeddings, keyed by item hash.
+
+The pool mirrors the KV cache's paging model (see
+:class:`sgl_jax.srt.mem_cache.allocator.PagedTokenToKVPoolAllocator`): a fixed
+device buffer split into ``page_size``-row pages, a free-list of page ids, and
+LRU eviction over whole cache entries.  Unlike the KV cache it is *content
+addressed* -- an entry is keyed by ``MultimodalDataItem.hash`` (the whole
+image / audio clip), not by token ids -- because multimodal embeddings share no
+token-level prefix.
+
+``pages`` stores opaque encoder output rows as
+``[num_pages, page_size, hidden]``. Any model-specific feature packing is
+already reflected in ``hidden``.
+
+Writes are performed by a ``jit``+``donate`` scatter so the large device buffer
+is updated in place (eager ``.at[].set`` would copy the whole pool per write).
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Sequence
+from contextlib import nullcontext
+from dataclasses import dataclass
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+from jax.typing import ArrayLike
+
+from sgl_jax.srt.multimodal.in_model.lane_packing import replicate_across_mesh
+
+
+@dataclass(frozen=True)
+class EmbeddingPoolEntry:
+    """Locates one cached item inside the pool.
+
+    ``page_ids`` are the (possibly non-contiguous) pages holding the item's
+    tokens back-to-back; ``length`` is the item's true token count (the tail of
+    the last page is padding).
+    """
+
+    page_ids: np.ndarray  # [num_pages_for_item], int32
+    length: int
+
+
+@partial(jax.jit, donate_argnames=("buffer",))
+def _scatter_rows(buffer: jax.Array, slots: jax.Array, rows: jax.Array) -> jax.Array:
+    """In-place masked scatter of bucket-shaped ``rows`` into ``buffer``.
+
+    ``buffer`` is flattened over its leading ``(page, offset)`` axes. ``slots``
+    and the leading axes of ``rows`` are flattened together; a negative slot
+    marks padding and is converted to a positive out-of-bounds sentinel so JAX
+    drops it instead of applying its usual negative-index wrapping.
+    """
+    flat = buffer.reshape(-1, *buffer.shape[2:])
+    flat_slots = slots.reshape(-1)
+    flat_rows = rows.reshape(-1, *buffer.shape[2:])
+    if flat_slots.shape[0] != flat_rows.shape[0]:
+        raise ValueError(
+            f"slots/rows length mismatch: {flat_slots.shape[0]} != {flat_rows.shape[0]}"
+        )
+    safe_slots = jnp.where(flat_slots >= 0, flat_slots, flat.shape[0])
+    flat = flat.at[safe_slots].set(flat_rows.astype(buffer.dtype), mode="drop")
+    return flat.reshape(buffer.shape)
+
+
+class EmbeddingPool:
+    """Byte-bounded (page-count-bounded) LRU of encoder embeddings on device."""
+
+    def __init__(
+        self,
+        num_pages: int,
+        page_size: int,
+        hidden: int,
+        dtype: jnp.dtype,
+        *,
+        mesh: Mesh | None = None,
+    ) -> None:
+        if num_pages <= 0 or page_size <= 0:
+            raise ValueError("embedding pool needs positive num_pages and page_size")
+        self.num_pages = num_pages
+        self.page_size = page_size
+        self.hidden = hidden
+        self.mesh = mesh
+
+        self._free_pages = np.arange(num_pages, dtype=np.int32)
+        self._entries: OrderedDict[int, EmbeddingPoolEntry] = OrderedDict()
+
+        self._pages = self._zeros((num_pages, page_size, hidden), dtype)
+
+    # -- buffers -----------------------------------------------------------
+    @property
+    def pages(self) -> jax.Array:
+        return self._pages
+
+    def _zeros(self, shape: tuple[int, ...], dtype: jnp.dtype) -> jax.Array:
+        if self.mesh is None:
+            return jnp.zeros(shape, dtype=dtype)
+        sharding = NamedSharding(
+            self.mesh,
+            PartitionSpec(*([None] * len(shape))),
+        )
+        with jax.set_mesh(self.mesh):
+            return jnp.zeros(shape, dtype=dtype, out_sharding=sharding)
+
+    def _replicate(self, value: ArrayLike) -> jax.Array:
+        if self.mesh is None:
+            return jnp.asarray(value)
+        return replicate_across_mesh(value, self.mesh)
+
+    # -- allocation --------------------------------------------------------
+    def _pages_for(self, length: int) -> int:
+        return (length + self.page_size - 1) // self.page_size
+
+    def _alloc(self, n_pages: int) -> np.ndarray | None:
+        """Reserve ``n_pages`` pages, evicting LRU entries under pressure."""
+        while len(self._free_pages) < n_pages and self._entries:
+            _, evicted = self._entries.popitem(last=False)
+            self._free_pages = np.concatenate([self._free_pages, evicted.page_ids])
+        if len(self._free_pages) < n_pages:
+            return None
+        out = self._free_pages[:n_pages].copy()
+        self._free_pages = self._free_pages[n_pages:]
+        return out
+
+    def _reserve(self, item_hash: int, n_pages: int) -> np.ndarray | None:
+        """Drop any prior entry for ``item_hash`` and reserve ``n_pages`` fresh pages.
+
+        The ``n_pages > num_pages`` guard fails fast *before* eviction, so an item
+        too large for the whole pool never flushes the resident entries.
+        """
+        if n_pages > self.num_pages:
+            return None
+        previous = self._entries.pop(item_hash, None)
+        if previous is not None:
+            self._free_pages = np.concatenate([self._free_pages, previous.page_ids])
+        return self._alloc(n_pages)
+
+    def _slots(self, page_ids: np.ndarray) -> np.ndarray:
+        """Flat row indices covered by ``page_ids`` (page-aligned)."""
+        return (page_ids[:, None] * self.page_size + np.arange(self.page_size)).reshape(-1)
+
+    # -- public API --------------------------------------------------------
+    def lookup(self, item_hash: int) -> EmbeddingPoolEntry | None:
+        """Return the entry for ``item_hash`` (moved to MRU) or ``None``."""
+        entry = self._entries.pop(item_hash, None)
+        if entry is not None:
+            self._entries[item_hash] = entry
+        return entry
+
+    def write_packed(
+        self,
+        item_hashes: Sequence[int],
+        packed_embeddings: ArrayLike,
+        lengths: Sequence[int],
+        *,
+        write_mask: Sequence[bool] | None = None,
+    ) -> tuple[EmbeddingPoolEntry | None, ...]:
+        """Cache one padded encoder output whose items are packed in input order."""
+        item_hashes = tuple(map(int, item_hashes))
+        lengths = tuple(map(int, lengths))
+        write_mask = (True,) * len(lengths) if write_mask is None else tuple(map(bool, write_mask))
+        if len(item_hashes) != len(lengths):
+            raise ValueError(f"item/length count mismatch: {len(item_hashes)} != {len(lengths)}")
+        if len(write_mask) != len(lengths):
+            raise ValueError(f"mask/length count mismatch: {len(write_mask)} != {len(lengths)}")
+
+        packed_embeddings = self._replicate(packed_embeddings)
+        if packed_embeddings.ndim != 2 or packed_embeddings.shape[1] != self.hidden:
+            raise ValueError(
+                "packed embeddings must have shape "
+                f"[capacity, {self.hidden}], got {packed_embeddings.shape}"
+            )
+        capacity = int(packed_embeddings.shape[0])
+        if any(length < 0 for length in lengths) or sum(lengths) > capacity:
+            raise ValueError(f"invalid item lengths {lengths} for capacity {capacity}")
+
+        planned: list[tuple[int, EmbeddingPoolEntry, int, int] | None] = []
+        offset = 0
+        for item_hash, length, should_write in zip(item_hashes, lengths, write_mask, strict=True):
+            page_ids = self._reserve(item_hash, self._pages_for(length)) if should_write else None
+            if page_ids is None:
+                planned.append(None)
+            else:
+                entry = EmbeddingPoolEntry(page_ids, length)
+                self._entries[item_hash] = entry
+                planned.append((item_hash, entry, offset, length))
+            offset += length
+
+        slots = np.full(capacity, -1, dtype=np.int32)
+        results: list[EmbeddingPoolEntry | None] = []
+        for plan in planned:
+            if plan is None:
+                results.append(None)
+                continue
+            item_hash, entry, offset, length = plan
+            if self._entries.get(item_hash) is not entry:
+                results.append(None)
+                continue
+            slots[offset : offset + length] = self._slots(entry.page_ids)[:length]
+            results.append(entry)
+
+        if any(entry is not None and entry.length for entry in results):
+            slots = self._replicate(slots)
+            self._pages = _scatter_rows(self._pages, slots, packed_embeddings)
+        return tuple(results)
+
+    def precompile_packed_write(self, capacity: int) -> None:
+        """Compile the packed writer for one encoder bucket without changing LRU state."""
+        if capacity <= 0:
+            raise ValueError("packed writer capacity must be positive")
+        with jax.set_mesh(self.mesh) if self.mesh is not None else nullcontext():
+            slots = self._replicate(np.full(capacity, -1, dtype=np.int32))
+            rows = self._zeros((capacity, self.hidden), self._pages.dtype)
+            self._pages = _scatter_rows(self._pages, slots, rows)
+            jax.block_until_ready(self._pages)
+
+    def clear(self) -> None:
+        """Free all pages (buffers are kept; only the free-list/table reset)."""
+        self._entries.clear()
+        self._free_pages = np.arange(self.num_pages, dtype=np.int32)

--- a/python/sgl_jax/srt/multimodal/in_model/host_orchestration.py
+++ b/python/sgl_jax/srt/multimodal/in_model/host_orchestration.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from contextlib import nullcontext
+from dataclasses import dataclass
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.models.registry import ModelRegistry
+from sgl_jax.srt.multimodal.common.modality_enum import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sgl_jax.srt.multimodal.in_model.embedding_pool import (
+    EmbeddingPool,
+    EmbeddingPoolEntry,
+)
+from sgl_jax.srt.multimodal.in_model.interface import InModelMultimodalContract
+
+
+@dataclass(frozen=True)
+class _MergeMapping:
+    source_start: int
+    destination_start: int
+    length: int
+
+
+@dataclass(frozen=True)
+class ItemTask:
+    item: MultimodalDataItem
+    output_len: int
+    merge_mappings: tuple[_MergeMapping, ...]
+
+    @property
+    def has_unmerged_tail(self) -> bool:
+        last = self.merge_mappings[-1]
+        return last.source_start + last.length < self.output_len
+
+
+_MultimodalBatch = dict[Modality, tuple[ItemTask, ...]]
+
+
+def _build_item_task(
+    item: MultimodalDataItem,
+    token_base: int,
+    chunk_start: int,
+    chunk_end: int,
+) -> ItemTask | None:
+    mappings: list[_MergeMapping] = []
+    output_len = 0
+    for start, end in item.placeholder_ranges or ():
+        overlap_start = max(start, chunk_start)
+        overlap_end = min(end, chunk_end)
+        if overlap_start < overlap_end:
+            mappings.append(
+                _MergeMapping(
+                    source_start=output_len + overlap_start - start,
+                    destination_start=token_base + overlap_start - chunk_start,
+                    length=overlap_end - overlap_start,
+                )
+            )
+        output_len += end - start
+    return ItemTask(item, output_len, tuple(mappings)) if mappings else None
+
+
+def build_multimodal_batch(
+    reqs_info: list | None,
+    dp_size: int,
+    model_config: ModelConfig,
+    per_dp_token: int,
+) -> _MultimodalBatch | None:
+    """Build tasks for placeholders visible in this prefill chunk."""
+    if not ModelRegistry.is_in_model_multimodal(model_config.hf_config.architectures):
+        return None
+
+    grouped: dict[Modality, list[ItemTask]] = {}
+    for dp_rank, info in enumerate((reqs_info or ())[:dp_size]):
+        request_base = dp_rank * per_dp_token
+        for req_index, req in enumerate(info.reqs or ()):
+            prefix_len = (
+                info.prefix_lens[req_index]
+                if info.prefix_lens is not None
+                else len(getattr(req, "prefix_indices", ()))
+            )
+            extend_len = (
+                info.extend_lens[req_index]
+                if info.extend_lens is not None
+                else getattr(req, "extend_input_len", 0)
+            )
+            if isinstance(req.mm_inputs, MultimodalInputs):
+                for item in req.mm_inputs.mm_items:
+                    task = _build_item_task(
+                        item,
+                        request_base,
+                        prefix_len,
+                        prefix_len + extend_len,
+                    )
+                    if task is not None:
+                        grouped.setdefault(item.modality, []).append(task)
+            request_base += extend_len
+
+    if not grouped:
+        return None
+    return {modality: tuple(tasks) for modality, tasks in grouped.items()}
+
+
+@partial(jax.jit, static_argnames=("out_sharding",))
+def _gather_overlay(
+    running: jax.Array,
+    source: jax.Array,
+    pos_idx: jax.Array,
+    mask: jax.Array,
+    *,
+    out_sharding: NamedSharding | None,
+) -> jax.Array:
+    if out_sharding is None:
+        gathered = source[pos_idx]
+    else:
+        gathered = source.at[pos_idx].get(out_sharding=out_sharding)
+    return jnp.where(mask[:, None], gathered, running)
+
+
+def _build_gather_indices(
+    tasks: tuple[ItemTask, ...],
+    num_tokens: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Map each destination token to its item-ordered packed source row."""
+
+    pos_idx = np.zeros(num_tokens, dtype=np.int32)
+    mask = np.zeros(num_tokens, dtype=np.bool_)
+    source_offset = 0
+    for task in tasks:
+        for mapping in task.merge_mappings:
+            dst, length = mapping.destination_start, mapping.length
+            if dst < 0 or dst + length > num_tokens:
+                raise ValueError("multimodal merge slice exceeds the token batch")
+            span = slice(dst, dst + length)
+            pos_idx[span] = source_offset + mapping.source_start + np.arange(length, dtype=np.int32)
+            mask[span] = True
+        source_offset += task.output_len
+    return pos_idx, mask
+
+
+def _place_token_vector(vector: np.ndarray, running: jax.Array, mesh: Mesh | None) -> jax.Array:
+    """Shard a ``[T]`` index/mask vector like ``running``'s token axis."""
+
+    if mesh is not None and isinstance(running.sharding, NamedSharding):
+        token_spec = running.sharding.spec[0] if running.sharding.spec else None
+        return jax.device_put(vector, NamedSharding(mesh, PartitionSpec(token_spec)))
+    return jnp.asarray(vector)
+
+
+def _apply_gather(
+    running: jax.Array,
+    source: jax.Array,
+    pos_idx: np.ndarray,
+    mask: np.ndarray,
+    mesh: Mesh | None,
+) -> jax.Array:
+    if not mask.any():
+        return running
+
+    pos_dev = _place_token_vector(pos_idx, running, mesh)
+    mask_dev = _place_token_vector(mask, running, mesh)
+    sharded = mesh is not None and isinstance(running.sharding, NamedSharding)
+    out_sharding = running.sharding if sharded else None
+    return _gather_overlay(
+        running,
+        source,
+        pos_dev,
+        mask_dev,
+        out_sharding=out_sharding,
+    )
+
+
+def _gather_merge(
+    running: jax.Array,
+    packed: jax.Array,
+    tasks: tuple[ItemTask, ...],
+    mesh: Mesh | None,
+) -> jax.Array:
+    expected_width = running.shape[-1]
+    min_capacity = sum(task.output_len for task in tasks)
+    if packed.ndim != 2 or packed.shape[1] != expected_width or packed.shape[0] < min_capacity:
+        raise ValueError(
+            f"packed embeddings must be [capacity, {expected_width}] with capacity >= "
+            f"{min_capacity}, got {packed.shape}"
+        )
+    pos_idx, mask = _build_gather_indices(tasks, running.shape[0])
+    return _apply_gather(running, packed, pos_idx, mask, mesh)
+
+
+def _build_pool_gather_indices(
+    tasks: Sequence[ItemTask],
+    entries: Sequence[EmbeddingPoolEntry],
+    page_size: int,
+    num_tokens: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Map each destination token to a flat row in the embedding pool."""
+
+    pos_idx = np.zeros(num_tokens, dtype=np.int32)
+    mask = np.zeros(num_tokens, dtype=np.bool_)
+    for task, entry in zip(tasks, entries, strict=True):
+        for mapping in task.merge_mappings:
+            dst, length = mapping.destination_start, mapping.length
+            if dst < 0 or dst + length > num_tokens:
+                raise ValueError("multimodal merge slice exceeds the token batch")
+            token = mapping.source_start + np.arange(length, dtype=np.int32)
+            span = slice(dst, dst + length)
+            pos_idx[span] = entry.page_ids[token // page_size] * page_size + token % page_size
+            mask[span] = True
+    return pos_idx, mask
+
+
+def _gather_from_pool(
+    running: jax.Array,
+    pool: EmbeddingPool,
+    tasks: Sequence[ItemTask],
+    entries: Sequence[EmbeddingPoolEntry],
+    mesh: Mesh | None,
+) -> jax.Array:
+    """Overlay cache hits by gathering from the pool's paged buffers."""
+
+    pos_idx, mask = _build_pool_gather_indices(tasks, entries, pool.page_size, running.shape[0])
+    return _apply_gather(
+        running,
+        pool.pages.reshape(-1, pool.hidden),
+        pos_idx,
+        mask,
+        mesh,
+    )
+
+
+def _write_misses_to_pool(
+    pool: EmbeddingPool,
+    packed: jax.Array,
+    tasks: Sequence[ItemTask],
+) -> None:
+    write_mask = tuple(task.has_unmerged_tail for task in tasks)
+    if not any(write_mask):
+        return
+    pool.write_packed(
+        tuple(task.item.hash for task in tasks),
+        packed,
+        tuple(task.output_len for task in tasks),
+        write_mask=write_mask,
+    )
+
+
+def _split_embeddings(
+    running: jax.Array,
+    hidden: int,
+    deepstack_dim: int,
+    mesh: Mesh | None,
+) -> tuple[jax.Array, jax.Array | None]:
+    if not deepstack_dim:
+        return running, None
+    running, deepstack = jnp.split(running, (hidden,), axis=-1)
+    deepstack = deepstack.reshape(running.shape[0], deepstack_dim, hidden).transpose(1, 0, 2)
+    if isinstance(running.sharding, NamedSharding):
+        token_spec = running.sharding.spec[0] if running.sharding.spec else None
+        deepstack = jax.sharding.reshard(
+            deepstack,
+            NamedSharding(mesh, PartitionSpec(None, token_spec, None)),
+        )
+    return running, deepstack
+
+
+def precompile_multimodal_inputs(
+    input_ids: jax.Array,
+    multimodal_model: InModelMultimodalContract,
+    embedding_pool: EmbeddingPool | None = None,
+) -> tuple[jax.Array, jax.Array | None]:
+    """Warm merge kernels and return a multimodal-shaped forward input."""
+    capacities = tuple(map(int, multimodal_model.get_multimodal_embedding_packed_capacities()))
+    if any(capacity <= 0 for capacity in capacities):
+        raise ValueError(f"invalid multimodal packed capacities: {capacities}")
+
+    mesh = multimodal_model.mesh
+    with jax.set_mesh(mesh) if mesh is not None else nullcontext():
+        running = multimodal_model.get_input_embeddings()(input_ids)
+        num_tokens, hidden = running.shape
+        deepstack_dim = multimodal_model.deepstack_visual_layers
+        if deepstack_dim:
+            running = jnp.pad(running, ((0, 0), (0, hidden * deepstack_dim)))
+
+        item = MultimodalDataItem(modality=Modality.IMAGE)
+        for capacity in capacities or (num_tokens,):
+            length = min(num_tokens, capacity)
+            task = ItemTask(item, length, (_MergeMapping(0, 0, length),))
+            packed = jnp.zeros((capacity, running.shape[-1]), running.dtype)
+            if mesh is not None:
+                packed = jax.device_put(packed, NamedSharding(mesh, PartitionSpec()))
+            running = _gather_merge(running, packed, (task,), mesh)
+            jax.block_until_ready(running)
+
+        if embedding_pool is not None:
+            length = min(num_tokens, embedding_pool.page_size)
+            task = ItemTask(item, length, (_MergeMapping(0, 0, length),))
+            entry = EmbeddingPoolEntry(np.asarray([0], dtype=np.int32), length)
+            running = _gather_from_pool(running, embedding_pool, (task,), (entry,), mesh)
+            jax.block_until_ready(running)
+
+    return _split_embeddings(running, hidden, deepstack_dim, mesh)
+
+
+def precompile_multimodal_components(
+    multimodal_model: InModelMultimodalContract,
+    embedding_pool: EmbeddingPool | None = None,
+) -> None:
+    multimodal_model.precompile_multimodal()
+    if embedding_pool is not None:
+        for capacity in multimodal_model.get_multimodal_embedding_packed_capacities():
+            embedding_pool.precompile_packed_write(capacity)
+
+
+def embed_multimodal_inputs(
+    multimodal_batch: _MultimodalBatch,
+    input_ids: jax.Array,
+    multimodal_model: InModelMultimodalContract,
+    embedding_pool: EmbeddingPool | None = None,
+) -> tuple[jax.Array, jax.Array | None]:
+    """Merge padded, item-ordered encoder outputs into the token stream."""
+    mesh = multimodal_model.mesh
+    with jax.set_mesh(mesh) if mesh is not None else nullcontext():
+        running = multimodal_model.get_input_embeddings()(input_ids)
+        hidden = running.shape[-1]
+        deepstack_dim = multimodal_model.deepstack_visual_layers
+        if deepstack_dim:
+            running = jnp.pad(running, ((0, 0), (0, hidden * deepstack_dim)))
+
+        encode_funcs = multimodal_model.get_multimodal_encode_funcs()
+        for modality, tasks in multimodal_batch.items():
+            encode_func = encode_funcs.get(modality)
+            if encode_func is None:
+                raise ValueError(
+                    f"no embedding function for modality {modality}; "
+                    "in-model multimodal models must expose one"
+                )
+
+            if embedding_pool is None:
+                packed = encode_func([task.item for task in tasks])
+                running = _gather_merge(running, packed, tasks, mesh)
+                continue
+
+            # Pool present: split hits from misses by item hash. Misses run the
+            # encoder and merge from its packed output (same cost as the no-pool
+            # path) then are written back for reuse; hits merge straight from the
+            # pool's paged buffers.
+            hit_tasks: list[ItemTask] = []
+            hit_entries: list[EmbeddingPoolEntry] = []
+            miss_tasks: list[ItemTask] = []
+            for task in tasks:
+                if task.item.hash is None:
+                    task.item.set_pad_value()
+                entry = embedding_pool.lookup(task.item.hash)
+                if entry is not None:
+                    hit_tasks.append(task)
+                    hit_entries.append(entry)
+                else:
+                    miss_tasks.append(task)
+            # Consume hits before a miss write is allowed to evict their pages.
+            if hit_tasks:
+                running = _gather_from_pool(running, embedding_pool, hit_tasks, hit_entries, mesh)
+            if miss_tasks:
+                packed = encode_func([task.item for task in miss_tasks])
+                running = _gather_merge(running, packed, tuple(miss_tasks), mesh)
+                _write_misses_to_pool(embedding_pool, packed, miss_tasks)
+
+        return _split_embeddings(running, hidden, deepstack_dim, mesh)

--- a/python/sgl_jax/srt/multimodal/in_model/interface.py
+++ b/python/sgl_jax/srt/multimodal/in_model/interface.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Mapping
+
+import jax
+from jax.sharding import Mesh
+
+from sgl_jax.srt.multimodal.common.modality_enum import Modality, MultimodalDataItem
+
+MultimodalEncodeFunc = Callable[[list[MultimodalDataItem]], jax.Array]
+MultimodalEncodeFuncs = Mapping[Modality, MultimodalEncodeFunc]
+
+
+class InModelMultimodalContract(ABC):
+    mesh: Mesh | None = None
+    deepstack_visual_layers: int = 0
+
+    def precompile_multimodal(self) -> None:
+        """Warm model-specific multimodal encoders."""
+        return None
+
+    def get_multimodal_embedding_packed_capacities(self) -> tuple[int, ...]:
+        """Return finite packed-array capacities for warmup."""
+        return ()
+
+    @abstractmethod
+    def get_input_embeddings(self) -> Callable[[jax.Array], jax.Array]:
+        raise NotImplementedError
+
+    def get_multimodal_encode_funcs(self) -> MultimodalEncodeFuncs:
+        """Return per-modality encoders producing padded, item-ordered arrays."""
+        return {}

--- a/python/sgl_jax/srt/multimodal/in_model/lane_packing.py
+++ b/python/sgl_jax/srt/multimodal/in_model/lane_packing.py
@@ -95,7 +95,7 @@ def _bucket_capacity(length: int, buckets: tuple[int, ...], unit: int) -> int:
     """Smallest ``unit``-aligned bucket that fits ``length`` (power-of-two fallback)."""
     return next(
         (bucket for bucket in buckets if bucket >= length and bucket % unit == 0),
-        ((1 << (length - 1).bit_length()) + unit - 1) // unit * unit,
+        1 << (length - 1).bit_length(),
     )
 
 
@@ -105,7 +105,7 @@ def pack_lanes(
     *,
     buckets: tuple[int, ...],
     merge_unit: int,
-    dtype: np.dtype | type = np.float32,
+    dtype: np.dtype | type,
 ) -> PackedLanes:
     features_np = [np.asarray(item.feature) for item in items]
     lengths = [feature.shape[0] for feature in features_np]
@@ -150,6 +150,7 @@ def pack_vision_inputs(
     num_lanes: int,
     buckets: tuple[int, ...],
     merge_unit: int,
+    dtype: np.dtype | type,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     _validate_vision_items(items, merge_unit)
     packed = pack_lanes(
@@ -157,6 +158,7 @@ def pack_vision_inputs(
         num_lanes,
         buckets=buckets,
         merge_unit=merge_unit,
+        dtype=dtype,
     )
     grid_thw = np.zeros(
         (num_lanes, max(map(len, packed.lanes)), 3),
@@ -174,6 +176,7 @@ def pack_2d_position_inputs(
     num_lanes: int,
     buckets: tuple[int, ...],
     merge_unit: int,
+    dtype: np.dtype | type,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Pack vision inputs that carry explicit per-patch 2D positions."""
     item_positions = []
@@ -210,6 +213,7 @@ def pack_2d_position_inputs(
         num_lanes,
         buckets=buckets,
         merge_unit=merge_unit,
+        dtype=dtype,
     )
     position_ids = np.full(
         (num_lanes, packed.cap, 2),
@@ -273,6 +277,7 @@ def run_mrope_vision_model(
     buckets: tuple[int, ...],
     merge_unit: int,
     rope_type: Literal["rope_3d", "rope_2d", "rope_2d_packed"],
+    dtype: np.dtype | type,
 ) -> jax.Array:
     """Pack, run, and restore a sharded vision model with RoPE metadata."""
     if rope_type == "rope_2d_packed":
@@ -281,6 +286,7 @@ def run_mrope_vision_model(
             num_lanes=num_lanes,
             buckets=buckets,
             merge_unit=merge_unit,
+            dtype=dtype,
         )
         output = vision_model(patches, position_ids, patch_counts)
     elif rope_type in ("rope_3d", "rope_2d"):
@@ -289,6 +295,7 @@ def run_mrope_vision_model(
             num_lanes=num_lanes,
             buckets=buckets,
             merge_unit=merge_unit,
+            dtype=dtype,
         )
         output = vision_model(patches, grid_thw)
     else:
@@ -307,6 +314,7 @@ def precompile_mrope_vision_model(
     patch_dim: int,
     merge_unit: int,
     rope_type: Literal["rope_3d", "rope_2d", "rope_2d_packed"],
+    dtype: np.dtype | type,
 ) -> None:
     merge_size = math.isqrt(merge_unit)
     for capacity in buckets:
@@ -320,7 +328,7 @@ def precompile_mrope_vision_model(
             )
         item = MultimodalDataItem(
             modality=Modality.IMAGE,
-            feature=np.zeros((capacity, patch_dim), dtype=np.float32),
+            feature=np.zeros((capacity, patch_dim), dtype=dtype),
             placeholder_ranges=[(0, capacity // merge_unit)],
             model_specific_data=model_specific_data,
         )
@@ -332,5 +340,6 @@ def precompile_mrope_vision_model(
             buckets=buckets,
             merge_unit=merge_unit,
             rope_type=rope_type,
+            dtype=dtype,
         )
         jax.block_until_ready(output)

--- a/python/sgl_jax/srt/multimodal/in_model/lane_packing.py
+++ b/python/sgl_jax/srt/multimodal/in_model/lane_packing.py
@@ -1,0 +1,336 @@
+"""Lane packing and output restoration for multimodal encoders."""
+
+from __future__ import annotations
+
+import functools
+import math
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+from jax.typing import ArrayLike
+
+from sgl_jax.srt.multimodal.common.modality_enum import Modality, MultimodalDataItem
+
+
+def get_grid_thw(item: MultimodalDataItem) -> tuple[int, int, int]:
+    value = item.get("image_grid_thw")
+    if value is None:
+        value = item.get("video_grid_thw")
+    return tuple(int(entry) for entry in np.asarray(value).reshape(3))
+
+
+def _validate_vision_items(items: list[MultimodalDataItem], merge_unit: int) -> None:
+    for item_index, item in enumerate(items):
+        feature = item.feature
+        # When the Processor creates an Item, if the feature is None, it should not create the Item.
+        if feature is None or feature.ndim == 0:
+            raise ValueError(f"Vision item {item_index} feature must have a patch dimension.")
+
+        feature_patches = int(feature.shape[0])
+        grid_patches = math.prod(get_grid_thw(item))
+        placeholder_patches = (
+            sum(end - start for start, end in item.placeholder_ranges or ()) * merge_unit
+        )
+        if not feature_patches == grid_patches == placeholder_patches:
+            raise ValueError(
+                f"Vision item {item_index} patch counts must match: "
+                f"feature rows={feature_patches}, grid_thw product={grid_patches}, "
+                f"placeholder tokens * merge_unit={placeholder_patches}."
+            )
+
+
+def encoder_num_lanes(mesh: Mesh, tensor_parallel: bool) -> int:
+    data_size = int(mesh.shape.get("data", 1))
+    tensor_size = int(mesh.shape.get("tensor", 1))
+    return data_size * (1 if tensor_parallel else tensor_size)
+
+
+@functools.cache
+def _replicate_fn(mesh: Mesh, ndim: int):
+    # Cache the jitted function to avoid creating a new lambda and triggering
+    # redundant tracing or compilation for the same mesh and ndim.
+    spec = NamedSharding(mesh, PartitionSpec())
+    return jax.jit(lambda a: jax.sharding.reshard(a, spec))
+
+
+def replicate_across_mesh(array: ArrayLike, mesh: Mesh) -> jax.Array:
+    """Replicate an array across a mesh, returning a jax.Array with the right sharding."""
+    spec = NamedSharding(mesh, PartitionSpec())
+    if not isinstance(array, jax.Array):
+        return jax.device_put(array, spec)
+    # JAX canonicalizes a rank-N replicated output to ``P(None, ..., None)``
+    # even when it was requested with ``P()``.  Compare the effective layout
+    # instead of the syntactic PartitionSpec so an already-replicated encoder
+    # result does not compile an identity reshard on the first real request.
+    if array.sharding.is_fully_replicated and array.sharding.device_set == spec.device_set:
+        return array
+    return _replicate_fn(mesh, array.ndim)(array)
+
+
+def balance_lanes(item_lengths: list[int] | tuple[int, ...], num_lanes: int) -> list[list[int]]:
+    """Greedily balance items over ``num_lanes`` lanes by descending length."""
+    lanes: list[list[int]] = [[] for _ in range(num_lanes)]
+    loads = [0] * num_lanes
+    for index in sorted(range(len(item_lengths)), key=lambda i: (-item_lengths[i], i)):
+        lane = min(range(num_lanes), key=lambda i: (loads[i], i))
+        lanes[lane].append(index)
+        loads[lane] += item_lengths[index]
+    return lanes
+
+
+@dataclass(frozen=True)
+class PackedLanes:
+    features: np.ndarray  # [num_lanes, cap, *feature_shape]
+    output_indices: np.ndarray
+    lanes: list[list[int]]
+    cap: int
+
+
+def _bucket_capacity(length: int, buckets: tuple[int, ...], unit: int) -> int:
+    """Smallest ``unit``-aligned bucket that fits ``length`` (power-of-two fallback)."""
+    return next(
+        (bucket for bucket in buckets if bucket >= length and bucket % unit == 0),
+        ((1 << (length - 1).bit_length()) + unit - 1) // unit * unit,
+    )
+
+
+def pack_lanes(
+    items: list[MultimodalDataItem],
+    num_lanes: int,
+    *,
+    buckets: tuple[int, ...],
+    merge_unit: int,
+    dtype: np.dtype | type = np.float32,
+) -> PackedLanes:
+    features_np = [np.asarray(item.feature) for item in items]
+    lengths = [feature.shape[0] for feature in features_np]
+    lanes = balance_lanes(lengths, num_lanes)
+    lane_loads = [sum(lengths[index] for index in lane) for lane in lanes]
+    cap = _bucket_capacity(max(lane_loads), buckets, merge_unit)
+    features = np.zeros((num_lanes, cap, *features_np[0].shape[1:]), dtype=dtype)
+    output_cap = cap // merge_unit
+    output_starts = np.zeros(len(items), dtype=np.int32)
+
+    for lane_index, lane in enumerate(lanes):
+        input_offset = 0
+        output_offset = 0
+        for item_index in lane:
+            feature = features_np[item_index]
+            end = input_offset + feature.shape[0]
+            features[lane_index, input_offset:end] = feature
+            out_len = feature.shape[0] // merge_unit
+            output_starts[item_index] = lane_index * output_cap + output_offset
+            input_offset = end
+            output_offset += out_len
+
+    output_indices = np.full(num_lanes * output_cap, -1, dtype=np.int32)
+    cursor = 0
+    for length, source_start in zip(lengths, output_starts, strict=True):
+        output_len = length // merge_unit
+        output_indices[cursor : cursor + output_len] = source_start + np.arange(
+            output_len, dtype=np.int32
+        )
+        cursor += output_len
+    return PackedLanes(
+        features=features,
+        output_indices=output_indices,
+        lanes=lanes,
+        cap=cap,
+    )
+
+
+def pack_vision_inputs(
+    items: list[MultimodalDataItem],
+    *,
+    num_lanes: int,
+    buckets: tuple[int, ...],
+    merge_unit: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    _validate_vision_items(items, merge_unit)
+    packed = pack_lanes(
+        items,
+        num_lanes,
+        buckets=buckets,
+        merge_unit=merge_unit,
+    )
+    grid_thw = np.zeros(
+        (num_lanes, max(map(len, packed.lanes)), 3),
+        dtype=np.int32,
+    )
+    for lane_index, lane in enumerate(packed.lanes):
+        for item_offset, item_index in enumerate(lane):
+            grid_thw[lane_index, item_offset] = get_grid_thw(items[item_index])
+    return packed.features, grid_thw, packed.output_indices
+
+
+def pack_2d_position_inputs(
+    items: list[MultimodalDataItem],
+    *,
+    num_lanes: int,
+    buckets: tuple[int, ...],
+    merge_unit: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Pack vision inputs that carry explicit per-patch 2D positions."""
+    item_positions = []
+    for item_index, item in enumerate(items):
+        positions_value = item.get("pixel_position_ids")
+        if positions_value is None:
+            raise ValueError(f"Vision item {item_index} is missing pixel_position_ids.")
+        positions = np.asarray(positions_value, dtype=np.int32)
+        if positions.ndim != 2 or positions.shape[1] != 2:
+            raise ValueError(
+                f"Vision item {item_index} pixel_position_ids must have shape "
+                f"[patches, 2], got {positions.shape}."
+            )
+        feature = item.feature
+        if feature is None or feature.ndim == 0:
+            raise ValueError(f"Vision item {item_index} feature must have a patch dimension.")
+        item_length = int(feature.shape[0])
+        if len(positions) != item_length:
+            raise ValueError(
+                f"Vision item {item_index} patch and position counts must match: "
+                f"feature rows={item_length}, position rows={len(positions)}."
+            )
+        if item_length % merge_unit:
+            raise ValueError(
+                f"Vision item {item_index} patch count {item_length} must be divisible "
+                f"by merge unit {merge_unit}."
+            )
+        if np.any(positions < 0):
+            raise ValueError(f"Vision item {item_index} pixel_position_ids must be non-negative.")
+        item_positions.append(positions)
+
+    packed = pack_lanes(
+        items,
+        num_lanes,
+        buckets=buckets,
+        merge_unit=merge_unit,
+    )
+    position_ids = np.full(
+        (num_lanes, packed.cap, 2),
+        -1,
+        dtype=np.int32,
+    )
+    patch_counts = np.zeros(
+        (num_lanes, max(map(len, packed.lanes))),
+        dtype=np.int32,
+    )
+    for lane_index, lane in enumerate(packed.lanes):
+        offset = 0
+        for item_offset, item_index in enumerate(lane):
+            positions = item_positions[item_index]
+            item_length = len(positions)
+            end = offset + item_length
+            position_ids[lane_index, offset:end] = positions
+            patch_counts[lane_index, item_offset] = item_length
+            offset = end
+    return packed.features, position_ids, patch_counts, packed.output_indices
+
+
+def _restore_input_order(
+    output: jax.Array,
+    indices: jax.Array,
+    mask: jax.Array,
+    *,
+    out_sharding: NamedSharding,
+) -> jax.Array:
+    output = output.reshape(-1, output.shape[-1])
+    output = output.at[indices].get(out_sharding=out_sharding)
+    return jnp.where(mask[:, None], output, jnp.zeros((), output.dtype))
+
+
+_restore_input_order_jit = jax.jit(_restore_input_order, static_argnames=("out_sharding",))
+
+
+def restore_encoder_output(
+    output: jax.Array,
+    output_indices: np.ndarray,
+    mesh: Mesh,
+) -> jax.Array:
+    output_indices = np.asarray(output_indices, dtype=np.int32)
+    mask = output_indices >= 0
+    indices = np.maximum(output_indices, 0)
+    out_sharding = NamedSharding(mesh, PartitionSpec())
+    return _restore_input_order_jit(
+        output,
+        indices,
+        mask,
+        out_sharding=out_sharding,
+    )
+
+
+def run_mrope_vision_model(
+    vision_model: Callable[..., jax.Array],
+    items: list[MultimodalDataItem],
+    *,
+    mesh: Mesh,
+    num_lanes: int,
+    buckets: tuple[int, ...],
+    merge_unit: int,
+    rope_type: Literal["rope_3d", "rope_2d", "rope_2d_packed"],
+) -> jax.Array:
+    """Pack, run, and restore a sharded vision model with RoPE metadata."""
+    if rope_type == "rope_2d_packed":
+        patches, position_ids, patch_counts, output_indices = pack_2d_position_inputs(
+            items,
+            num_lanes=num_lanes,
+            buckets=buckets,
+            merge_unit=merge_unit,
+        )
+        output = vision_model(patches, position_ids, patch_counts)
+    elif rope_type in ("rope_3d", "rope_2d"):
+        patches, grid_thw, output_indices = pack_vision_inputs(
+            items,
+            num_lanes=num_lanes,
+            buckets=buckets,
+            merge_unit=merge_unit,
+        )
+        output = vision_model(patches, grid_thw)
+    else:
+        raise ValueError(f"Unsupported vision RoPE type: {rope_type}")
+
+    with jax.set_mesh(mesh):
+        return restore_encoder_output(output, output_indices, mesh)
+
+
+def precompile_mrope_vision_model(
+    vision_model: Callable[..., jax.Array],
+    *,
+    mesh: Mesh,
+    num_lanes: int,
+    buckets: tuple[int, ...],
+    patch_dim: int,
+    merge_unit: int,
+    rope_type: Literal["rope_3d", "rope_2d", "rope_2d_packed"],
+) -> None:
+    merge_size = math.isqrt(merge_unit)
+    for capacity in buckets:
+        model_specific_data = {}
+        if rope_type == "rope_2d_packed":
+            y, x = np.indices((merge_size, capacity // merge_size))
+            model_specific_data["pixel_position_ids"] = np.stack((x, y), axis=-1).reshape(-1, 2)
+        else:
+            model_specific_data["image_grid_thw"] = np.asarray(
+                (1, merge_size, capacity // merge_size), dtype=np.int32
+            )
+        item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            feature=np.zeros((capacity, patch_dim), dtype=np.float32),
+            placeholder_ranges=[(0, capacity // merge_unit)],
+            model_specific_data=model_specific_data,
+        )
+        output = run_mrope_vision_model(
+            vision_model,
+            [item],
+            mesh=mesh,
+            num_lanes=num_lanes,
+            buckets=buckets,
+            merge_unit=merge_unit,
+            rope_type=rope_type,
+        )
+        jax.block_until_ready(output)

--- a/python/sgl_jax/srt/multimodal/kernels/tuned_block_sizes.py
+++ b/python/sgl_jax/srt/multimodal/kernels/tuned_block_sizes.py
@@ -2,6 +2,7 @@
 
 import logging
 
+import jax
 import jax.numpy as jnp
 
 from sgl_jax.srt.utils.jax_utils import get_device_name
@@ -45,6 +46,11 @@ def get_tuned_block_sizes(
     head_dim,
 ) -> tuple[int, int]:
     """Look up for the best (num_queries_per_blk,) from auto-tuned table."""
+
+    # The tuned table is TPU-only; off-TPU (e.g. CPU interpret) fall back to the
+    # default block_q rather than probing for a TPU device name.
+    if "TPU" not in jax.devices()[0].device_kind:
+        return 256
 
     keys = get_simplified_key(
         q_dtype,

--- a/python/sgl_jax/srt/multimodal/layers/attention/flash_attention_backend.py
+++ b/python/sgl_jax/srt/multimodal/layers/attention/flash_attention_backend.py
@@ -1,14 +1,89 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any
+
 import jax
-import jax.experimental.pallas as pl
+import jax.numpy as jnp
 from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.layers.attention.base_attn_backend import AttentionBackend
-from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
-from sgl_jax.srt.multimodal.kernels.flash_attention import flash_attention
+from sgl_jax.srt.multimodal.kernels.flash_attention import SegmentIds, flash_attention
+from sgl_jax.srt.multimodal.kernels.varlen_attention import varlen_attention
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
 
 
-def align_to(x, a):
-    return pl.cdiv(x, a) * a
+@dataclasses.dataclass
+class VisionAttentionMetadata:
+    """Block-diagonal (packed) self-attention layout for the vision tower.
+
+    ``cu_seqlens`` are bucket-shaped cumulative segment boundaries with shape
+    ``[num_lanes, K + 1]``: each row starts with zero, holds a lane's cumulative
+    segment ends, then repeats the final valid end through the padding slots.
+    ``max_seq_len`` is a host-computed upper bound on every positive boundary
+    difference. It is static JAX metadata so the varlen backend can select
+    compile-time block sizes without inspecting traced boundary values. The
+    bound should be stable for an input-shape bucket to avoid recompilation for
+    different segment values with the same shapes.
+    """
+
+    cu_seqlens: Any
+    max_seq_len: int | None = None
+
+
+jax.tree_util.register_dataclass(
+    VisionAttentionMetadata,
+    data_fields=["cu_seqlens"],
+    meta_fields=["max_seq_len"],
+)
+
+
+def vision_segment_ids_from_cu_seqlens(
+    cu_seqlens: jax.Array,
+    sequence_length: int,
+    *,
+    search_method: str = "compare_all",
+) -> SegmentIds:
+    """Expand bucket-shaped vision boundaries to dense self-attention ids.
+
+    ``cu_seqlens`` has shape ``[B, K + 1]``.  Every row starts with zero,
+    contains the cumulative exclusive ends of its real segments, and repeats
+    its final valid end through the remaining bucket slots.  An empty lane is
+    therefore all zeros.  Tokens at or beyond the final end receive ``-1`` so
+    bucket padding cannot attend to real tokens.
+
+    The conversion is deliberately shared by all vision attention backends and
+    runs on each batch shard; no cross-device collective is needed.
+    """
+    if cu_seqlens.ndim != 2 or cu_seqlens.shape[1] < 1:
+        raise ValueError(
+            "vision cu_seqlens must have shape [batch, boundary_capacity + 1], "
+            f"got {cu_seqlens.shape}"
+        )
+    if not jnp.issubdtype(cu_seqlens.dtype, jnp.integer):
+        raise ValueError(f"vision cu_seqlens must be integer, got {cu_seqlens.dtype}")
+
+    positions = jnp.arange(sequence_length, dtype=cu_seqlens.dtype)
+
+    def lane_segment_ids(boundaries):
+        # ``side='right'`` assigns a token exactly at a boundary to the next
+        # segment.  Repeated tail boundaries only affect padded positions,
+        # which are overwritten with -1 below.
+        ids = (
+            jnp.searchsorted(
+                boundaries,
+                positions,
+                side="right",
+                method=search_method,
+            )
+            - 1
+        )
+        return jnp.where(positions < boundaries[-1], ids, -1).astype(jnp.int32)
+
+    dense = jax.vmap(lane_segment_ids)(cu_seqlens)
+    return SegmentIds(q=dense, kv=dense)
 
 
 class FlashAttentionBackend(AttentionBackend):
@@ -51,3 +126,244 @@ class FlashAttentionBackend(AttentionBackend):
     def get_forward_metadata(self, batch: ModelWorkerBatch):
         """Init the metadata for a forward pass and return it"""
         return None
+
+
+class VisionFlashAttentionBackend(AttentionBackend):
+    """Batch-sharded segment-flash attention for the in-model VLM ViT.
+
+    Kept SEPARATE from ``FlashAttentionBackend`` (which is head-TP, used by
+    ``USPAttention`` for Flux / Wan / Qwen3-Omni audio) so that class stays
+    untouched. With replicated ViT weights, batch lanes span both ``data`` and
+    ``tensor``. With ``head_tp=True``, batch is sharded on ``data`` and heads on
+    ``tensor``. Bucket-shaped cumulative lengths follow the batch sharding and
+    are expanded to dense ids locally inside the shard map. On CPU meshes the
+    same Pallas kernel runs in interpret mode, so this is the only vision
+    backend.
+    """
+
+    def __init__(
+        self,
+        mesh,
+        sm_scale=1.0,
+        causal=False,
+        vmem_limit_bytes: int | None = None,
+        head_tp: bool = False,
+    ):
+        interpret = mesh.devices.flat[0].platform == "cpu"
+        if vmem_limit_bytes is None:
+            if mesh.devices.flat[0].platform == "tpu":
+                from jax.experimental.pallas import tpu as pltpu
+
+                # Keep the Pallas program below the physical VMEM capacity.
+                # The old 128 MiB default lets the compiler produce programs
+                # that exceed v7x's 64 MiB per-core limit.
+                vmem_limit_bytes = int(pltpu.get_tpu_info().vmem_capacity_bytes * 0.9)
+            else:
+                vmem_limit_bytes = 128 * 1024 * 1024
+        self.vmem_limit_bytes = vmem_limit_bytes
+        if head_tp:
+            if "tensor" not in mesh.axis_names:
+                raise ValueError("head_tp requires a tensor mesh axis")
+            batch_axis = "data"
+            head_axis = "tensor"
+        else:
+            batch_axis = ("data", "tensor") if "tensor" in mesh.axis_names else "data"
+            head_axis = None
+        qkv_spec = P(batch_axis, head_axis, None, None)
+        metadata_spec = P(batch_axis, None)
+        in_specs = (qkv_spec, qkv_spec, qkv_spec, metadata_spec)
+        out_specs = qkv_spec
+
+        def _flash_attention(q, k, v, cu_seqlens):
+            segment_ids = vision_segment_ids_from_cu_seqlens(
+                cu_seqlens,
+                q.shape[2],
+                search_method="scan",
+            )
+            return flash_attention(
+                q,
+                k,
+                v,
+                segment_ids=segment_ids,
+                sm_scale=sm_scale,
+                causal=causal,
+                vmem_limit_bytes=self.vmem_limit_bytes,
+                interpret=interpret,
+            )
+
+        self.jit_flash_attention = jax.jit(
+            jax.shard_map(
+                _flash_attention, mesh=mesh, in_specs=in_specs, out_specs=out_specs, check_vma=False
+            )
+        )
+
+    def __call__(self, q, k, v, metadata: VisionAttentionMetadata):
+        """Segment-flash attention over batch-leading ``[B, T, heads, head_dim]``.
+
+        Adapts to the kernel's head-leading layout and pads the sequence to the
+        tile its block-size path needs, then restores ``[B, T, heads, head_dim]``
+        so every vision backend shares one THD in/out contract.
+        """
+        cu_seqlens = metadata.cu_seqlens
+        if q.shape[0] != cu_seqlens.shape[0]:
+            raise ValueError(
+                f"vision cu_seqlens batch must match q/k/v: {cu_seqlens.shape[0]} != {q.shape[0]}"
+            )
+        seq_len = q.shape[1]
+        if seq_len != k.shape[1]:
+            raise ValueError("a single vision cu_seqlens requires equal q and kv lengths")
+
+        # [B, T, H, D] -> [B, H, T, D] for the kernel.
+        q, k, v = (jnp.transpose(x, (0, 2, 1, 3)) for x in (q, k, v))
+
+        # The dense kernel's default query tile is 256 tokens.
+        alignment = 256
+        aligned = max(256, ((seq_len + alignment - 1) // alignment) * alignment)
+        pad = aligned - seq_len
+        if pad:
+            q, k, v = (jnp.pad(x, ((0, 0), (0, 0), (0, pad), (0, 0))) for x in (q, k, v))
+
+        out = self.jit_flash_attention(q, k, v, cu_seqlens)  # [B, H, aligned, D]
+        return jnp.transpose(out[:, :, :seq_len], (0, 2, 1, 3))  # -> [B, T, H, D]
+
+    def get_forward_metadata(self, batch: ModelWorkerBatch):
+        """Init the metadata for a forward pass and return it"""
+        return None
+
+
+class VisionVarlenAttentionBackend(AttentionBackend):
+    """Batch-sharded packed variable-length vision attention.
+
+    Shares the ``[B, T, heads, head_dim]`` + bucket-shaped ``cu_seqlens``
+    contract of :class:`VisionFlashAttentionBackend`, but each batch lane maps
+    *directly* to the ``varlen_attention`` kernel's packed ``[tokens, heads,
+    head_dim]`` layout: no head-major transpose and no sequence padding (the
+    kernel reserves its own DMA tail slack). A lane's ``num_seqs`` is the count
+    of positive-length segments in its bucket row -- the repeated tail ends
+    become zero-length segments the kernel skips. Unlike the flash backend this
+    kernel supports GQA, per-call local ``window_size`` and per-head attention
+    sinks, so it backs models like MiMo-V2. It is TPU-only.
+    """
+
+    def __init__(
+        self,
+        mesh,
+        sm_scale: float = 1.0,
+        head_tp: bool = False,
+        vmem_limit_bytes: int = 128 * 1024 * 1024,
+    ):
+        self.mesh = mesh
+        self.sm_scale = sm_scale
+        self.vmem_limit_bytes = vmem_limit_bytes
+        if mesh.devices.flat[0].platform != "tpu":
+            raise ValueError("VisionVarlenAttentionBackend requires a TPU mesh")
+        if head_tp:
+            if "tensor" not in mesh.axis_names:
+                raise ValueError("head_tp requires a tensor mesh axis")
+            batch_axis = "data"
+            self.head_axis = "tensor"
+        else:
+            batch_axis = ("data", "tensor") if "tensor" in mesh.axis_names else "data"
+            self.head_axis = None
+        # q/k/v are token-major [B, T, heads, head_dim]: batch on dim 0, heads on dim 2.
+        self.qkv_spec = P(batch_axis, None, self.head_axis, None)
+        self.cu_spec = P(batch_axis, None)
+
+    def __call__(
+        self,
+        q,  # [B, T, heads, head_dim]
+        k,  # [B, T, kv_heads, head_dim]
+        v,  # [B, T, kv_heads, head_dim]
+        cu_seqlens,  # int32[B, boundary_capacity + 1] or VisionAttentionMetadata
+        attention_sink=None,  # float[heads] or None
+        *,
+        window_size: tuple[int, int] = (-1, -1),
+    ):
+        # Accept either a raw cu_seqlens array (MiMo/Omni) or the shared
+        # VisionAttentionMetadata (Qwen VL), so this backend is a drop-in for
+        # VisionFlashAttentionBackend's (q, k, v, metadata) contract too.
+        max_seq_len = None
+        if isinstance(cu_seqlens, VisionAttentionMetadata):
+            max_seq_len = cu_seqlens.max_seq_len
+            cu_seqlens = cu_seqlens.cu_seqlens
+        if q.shape[0] != cu_seqlens.shape[0]:
+            raise ValueError(
+                f"vision cu_seqlens batch must match q/k/v: {cu_seqlens.shape[0]} != {q.shape[0]}"
+            )
+        if q.shape[1] != k.shape[1]:
+            raise ValueError("a single vision cu_seqlens requires equal q and kv lengths")
+
+        def per_lane(lane_q, lane_k, lane_v, lane_cu, lane_sink):
+            # A lane's num_seqs is the count of positive-length bucket segments;
+            # the repeated tail ends collapse to zero-length segments the kernel skips.
+            num_seqs = jnp.sum(jnp.diff(lane_cu) > 0, dtype=jnp.int32).reshape(1)
+            return varlen_attention(
+                lane_q,
+                lane_k,
+                lane_v,
+                lane_cu,
+                num_seqs,
+                sm_scale=self.sm_scale,
+                window_size=window_size,
+                attention_sink=lane_sink,
+                max_seq_len=max_seq_len,
+                vmem_limit_bytes=self.vmem_limit_bytes,
+            )
+
+        # A sink is a shard_map input so it follows the head sharding; without one
+        # it is broadcast (in_axes=None) as a plain Python ``None`` per lane.
+        over_batch = (0, 0, 0, 0, None)
+        if attention_sink is None:
+
+            def sharded(bq, bk, bv, bcu):
+                return jax.vmap(per_lane, in_axes=over_batch)(bq, bk, bv, bcu, None)
+
+            in_specs = (self.qkv_spec, self.qkv_spec, self.qkv_spec, self.cu_spec)
+            args = (q, k, v, cu_seqlens)
+        else:
+
+            def sharded(bq, bk, bv, bcu, sink):
+                return jax.vmap(per_lane, in_axes=over_batch)(bq, bk, bv, bcu, sink)
+
+            in_specs = (*(self.qkv_spec,) * 3, self.cu_spec, P(self.head_axis))
+            args = (q, k, v, cu_seqlens, attention_sink)
+
+        return jax.shard_map(
+            sharded, mesh=self.mesh, in_specs=in_specs, out_specs=self.qkv_spec, check_vma=False
+        )(*args)
+
+    def get_forward_metadata(self, batch: ModelWorkerBatch):
+        """Init the metadata for a forward pass and return it"""
+        return None
+
+
+def make_vision_attention_backend(
+    mesh,
+    *,
+    sm_scale,
+    causal: bool = False,
+    head_tp: bool = False,
+    use_varlen: bool = False,
+) -> AttentionBackend:
+    """Build the batch-sharded vision attention backend.
+
+    On TPU, ``use_varlen`` routes the tower through the packed
+    ``varlen_attention`` kernel instead of the dense ``flash_attention``
+    kernel. Varlen walks each cu_seqlens segment, so window
+    layers cost O(sum segment^2) rather than the dense O(T^2). The host-computed
+    maximum segment length in :class:`VisionAttentionMetadata` selects the
+    v7x-tuned block sizes. CPU meshes use the flash backend's test-only
+    interpreter path.
+    """
+    if use_varlen and mesh.devices.flat[0].platform == "tpu":
+        return VisionVarlenAttentionBackend(
+            mesh,
+            sm_scale=sm_scale,
+            head_tp=head_tp,
+        )
+    return VisionFlashAttentionBackend(
+        mesh,
+        sm_scale=sm_scale,
+        causal=causal,
+        head_tp=head_tp,
+    )

--- a/python/sgl_jax/srt/multimodal/layers/attention/flash_attention_backend.py
+++ b/python/sgl_jax/srt/multimodal/layers/attention/flash_attention_backend.py
@@ -40,6 +40,18 @@ jax.tree_util.register_dataclass(
 )
 
 
+def _resolve_vision_vmem_limit_bytes(mesh, vmem_limit_bytes: int | None) -> int:
+    if vmem_limit_bytes is not None:
+        return vmem_limit_bytes
+    if mesh.devices.flat[0].platform == "tpu":
+        from jax.experimental.pallas import tpu as pltpu
+
+        # Keep Pallas programs below the physical per-core VMEM capacity.
+        # A fixed 128 MiB limit exceeds the 64 MiB capacity of v7x.
+        return int(pltpu.get_tpu_info().vmem_capacity_bytes * 0.9)
+    return 128 * 1024 * 1024
+
+
 def vision_segment_ids_from_cu_seqlens(
     cu_seqlens: jax.Array,
     sequence_length: int,
@@ -150,17 +162,7 @@ class VisionFlashAttentionBackend(AttentionBackend):
         head_tp: bool = False,
     ):
         interpret = mesh.devices.flat[0].platform == "cpu"
-        if vmem_limit_bytes is None:
-            if mesh.devices.flat[0].platform == "tpu":
-                from jax.experimental.pallas import tpu as pltpu
-
-                # Keep the Pallas program below the physical VMEM capacity.
-                # The old 128 MiB default lets the compiler produce programs
-                # that exceed v7x's 64 MiB per-core limit.
-                vmem_limit_bytes = int(pltpu.get_tpu_info().vmem_capacity_bytes * 0.9)
-            else:
-                vmem_limit_bytes = 128 * 1024 * 1024
-        self.vmem_limit_bytes = vmem_limit_bytes
+        self.vmem_limit_bytes = _resolve_vision_vmem_limit_bytes(mesh, vmem_limit_bytes)
         if head_tp:
             if "tensor" not in mesh.axis_names:
                 raise ValueError("head_tp requires a tensor mesh axis")
@@ -250,13 +252,13 @@ class VisionVarlenAttentionBackend(AttentionBackend):
         mesh,
         sm_scale: float = 1.0,
         head_tp: bool = False,
-        vmem_limit_bytes: int = 128 * 1024 * 1024,
+        vmem_limit_bytes: int | None = None,
     ):
         self.mesh = mesh
         self.sm_scale = sm_scale
-        self.vmem_limit_bytes = vmem_limit_bytes
         if mesh.devices.flat[0].platform != "tpu":
             raise ValueError("VisionVarlenAttentionBackend requires a TPU mesh")
+        self.vmem_limit_bytes = _resolve_vision_vmem_limit_bytes(mesh, vmem_limit_bytes)
         if head_tp:
             if "tensor" not in mesh.axis_names:
                 raise ValueError("head_tp requires a tensor mesh axis")

--- a/python/sgl_jax/srt/multimodal/layers/vision_sharding.py
+++ b/python/sgl_jax/srt/multimodal/layers/vision_sharding.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+
+import jax
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+
+
+def apply_data_sharding(x: jax.Array, mesh: Mesh, spec: PartitionSpec) -> jax.Array:
+    sharding = NamedSharding(mesh, spec)
+    if "data" in mesh.explicit_axes:
+        return jax.sharding.reshard(x, sharding)
+    return jax.lax.with_sharding_constraint(x, sharding)
+
+
+def resolve_encoder_tp(mesh: Mesh, mode: str) -> bool:
+    if mode != "tp":
+        return False
+    return "tensor" in mesh.shape and int(mesh.shape["tensor"]) > 1
+
+
+@dataclass(frozen=True)
+class VisionShardSpecs:
+    """Vision-encoder sharding built from two axes.
+
+    ``batch_axis`` shards the leading dim; ``tensor_axis`` is ``"tensor"`` under
+    tensor parallelism and ``None`` otherwise. Call sites spell out the layout
+    directly via :meth:`sharding`, e.g. a column-parallel output is
+    ``sharding(batch_axis, None, tensor_axis)``. JAX pads a spec shorter than the
+    array rank with replicated trailing dims, so batch-only sharding is simply
+    ``sharding(batch_axis)`` regardless of ndim.
+    """
+
+    mesh: Mesh
+    tp: bool
+
+    @property
+    def batch_axis(self) -> str | tuple[str, str]:
+        if self.tp:
+            return "data"
+        if "tensor" in self.mesh.axis_names:
+            return ("data", "tensor")
+        return "data"
+
+    @property
+    def tensor_axis(self) -> str | None:
+        return "tensor" if self.tp else None
+
+    @property
+    def col_kernel_axes(self) -> tuple[None, str | None]:
+        return (None, self.tensor_axis)
+
+    @property
+    def row_kernel_axes(self) -> tuple[str | None, None]:
+        return (self.tensor_axis, None)
+
+    def sharding(self, *spec: str | tuple[str, ...] | None) -> NamedSharding:
+        return NamedSharding(self.mesh, PartitionSpec(*spec))

--- a/python/sgl_jax/srt/utils/common_utils.py
+++ b/python/sgl_jax/srt/utils/common_utils.py
@@ -38,6 +38,13 @@ logger = logging.getLogger(__name__)
 
 PRECOMPILE_DEFAULT_TOKEN_PADDINGS = [1 << i for i in range(6, 14)]
 PRECOMPILE_DEFAULT_BS_PADDINGS = [1 << i for i in range(0, 9)]
+PRECOMPILE_DEFAULT_VISION_PATCH_PADDINGS = [256, 1024, 2048, 4096, 5120, 8192, 12288, 16384]
+
+
+def resolve_vision_patch_buckets(user_paddings: list[int] | None) -> list[int]:
+    """Return sorted, de-duplicated positive vision patch buckets."""
+    paddings = user_paddings or PRECOMPILE_DEFAULT_VISION_PATCH_PADDINGS
+    return sorted({p for p in paddings if p > 0})
 
 
 def align_bs_for_fused_ep(bs: int, ep_size: int) -> int:

--- a/python/sgl_jax/test/multimodal/test_flash_attention_kernel.py
+++ b/python/sgl_jax/test/multimodal/test_flash_attention_kernel.py
@@ -31,7 +31,14 @@ def jit_flash_attention(q, k, v):
         )
     if seg_q is not None and seg_kv is not None:
         segment_ids = SegmentIds(q=seg_q, kv=seg_kv)
-    output = flash_attention(q, k, v, segment_ids=segment_ids, causal=False)
+    output = flash_attention(
+        q,
+        k,
+        v,
+        segment_ids=segment_ids,
+        causal=False,
+        interpret=jax.default_backend() == "cpu",
+    )
     output = output[:, :, :q_len, :]
     return output
 

--- a/python/sgl_jax/test/test_embedding_pool.py
+++ b/python/sgl_jax/test/test_embedding_pool.py
@@ -1,0 +1,193 @@
+from unittest.mock import patch
+
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.multimodal.in_model import embedding_pool as embedding_pool_module
+from sgl_jax.srt.multimodal.in_model.embedding_pool import EmbeddingPool
+
+
+def _read(pool, entry):
+    """Reconstruct an entry's stored rows from the paged buffer."""
+    rows = []
+    for k in range(entry.length):
+        page = int(entry.page_ids[k // pool.page_size])
+        off = k % pool.page_size
+        rows.append(np.asarray(pool.pages[page, off]))
+    return np.stack(rows)
+
+
+def _write(pool, item_hash, emb):
+    """Cache one item through the pool's packed writer."""
+    emb = jnp.asarray(emb)
+    (entry,) = pool.write_packed((item_hash,), emb, (emb.shape[0],))
+    return entry
+
+
+def test_lru_eviction_frees_pages():
+    pool = EmbeddingPool(num_pages=4, page_size=2, hidden=1, dtype=jnp.float32)
+    _write(pool, 0xA, jnp.asarray([[1.0], [2.0], [3.0]]))  # pages 0,1
+    _write(pool, 0xB, jnp.asarray([[4.0], [5.0], [6.0]]))  # pages 2,3 -> full
+    # No free pages left; writing C must evict the LRU entry (A).
+    entry_c = _write(pool, 0xC, jnp.asarray([[7.0]]))
+    assert entry_c is not None
+    assert pool.lookup(0xA) is None  # evicted
+    assert pool.lookup(0xB) is not None  # survived
+    np.testing.assert_array_equal(_read(pool, pool.lookup(0xC))[:, 0], [7])
+
+
+def test_lookup_touch_protects_from_eviction():
+    pool = EmbeddingPool(num_pages=4, page_size=2, hidden=1, dtype=jnp.float32)
+    _write(pool, 0xA, jnp.asarray([[1.0], [2.0], [3.0]]))
+    _write(pool, 0xB, jnp.asarray([[4.0], [5.0], [6.0]]))
+    pool.lookup(0xA)  # A becomes MRU, so B is now the eviction victim
+    _write(pool, 0xC, jnp.asarray([[7.0]]))
+    assert pool.lookup(0xB) is None
+    assert pool.lookup(0xA) is not None
+
+
+def test_rewrite_reuses_freed_pages():
+    pool = EmbeddingPool(num_pages=4, page_size=2, hidden=1, dtype=jnp.float32)
+    _write(pool, 1, jnp.asarray([[1.0], [2.0], [3.0]]))
+    second = _write(pool, 1, jnp.asarray([[9.0]]))
+    assert second.length == 1
+    # Overwriting the same hash releases the old pages before re-allocating.
+    assert len(pool._free_pages) == 3
+    np.testing.assert_array_equal(_read(pool, pool.lookup(1))[:, 0], [9])
+
+
+def test_write_packed_roundtrips_items_and_drops_padding():
+    pool = EmbeddingPool(num_pages=4, page_size=2, hidden=1, dtype=jnp.float32)
+    pool._pages = pool.pages.at[-1, -1, 0].set(99)
+    packed = jnp.asarray(
+        [
+            [101.0],
+            [102.0],
+            [103.0],
+            [200.0],
+            [201.0],
+            [202.0],
+            [203.0],
+        ]
+    )
+
+    (entry,) = pool.write_packed((1,), packed, (3,))
+
+    assert entry is not None
+    assert entry.length == 3
+    assert len(entry.page_ids) == 2
+    np.testing.assert_array_equal(_read(pool, entry)[:, 0], [101, 102, 103])
+    assert pool.lookup(1) is entry
+    assert pool.lookup(999) is None
+    assert np.asarray(pool.pages[-1, -1, 0]) == 99
+
+
+def test_write_packed_keeps_writer_shape_fixed_across_true_lengths():
+    pool = EmbeddingPool(num_pages=8, page_size=2, hidden=1, dtype=jnp.float32)
+    packed = jnp.arange(8, dtype=jnp.float32).reshape(8, 1)
+
+    with patch.object(
+        embedding_pool_module,
+        "_scatter_rows",
+        wraps=embedding_pool_module._scatter_rows,
+    ) as scatter:
+        pool.write_packed((1, 2), packed, (1, 3))
+        pool.write_packed((3,), packed, (2,))
+
+    assert [call.args[1].shape for call in scatter.call_args_list] == [(8,), (8,)]
+    assert [call.args[2].shape for call in scatter.call_args_list] == [
+        (8, 1),
+        (8, 1),
+    ]
+
+
+def test_write_packed_preserves_wide_feature_rows():
+    pool = EmbeddingPool(
+        num_pages=4,
+        page_size=2,
+        hidden=3,
+        dtype=jnp.float32,
+    )
+    packed = jnp.asarray(
+        [
+            [2.0, 20.0, 21.0],
+            [3.0, 30.0, 31.0],
+            [4.0, 40.0, 41.0],
+            [0.0, 0.0, 0.0],
+        ]
+    )
+
+    (entry,) = pool.write_packed((1,), packed, (2,))
+
+    assert entry is not None
+    np.testing.assert_array_equal(
+        _read(pool, entry),
+        [[2, 20, 21], [3, 30, 31]],
+    )
+
+
+def test_write_packed_scatter_once_and_skips_entries_evicted_during_planning():
+    pool = EmbeddingPool(num_pages=2, page_size=1, hidden=1, dtype=jnp.float32)
+    packed = jnp.asarray([[10.0], [20.0], [30.0]])
+
+    with patch.object(
+        embedding_pool_module,
+        "_scatter_rows",
+        wraps=embedding_pool_module._scatter_rows,
+    ) as scatter:
+        entries = pool.write_packed(
+            (1, 2, 3),
+            packed,
+            (1, 1, 1),
+        )
+
+    scatter.assert_called_once()
+    assert entries[0] is None
+    assert entries[1] is not None
+    assert entries[2] is not None
+    assert pool.lookup(1) is None
+    np.testing.assert_array_equal(_read(pool, pool.lookup(2))[:, 0], [20])
+    np.testing.assert_array_equal(_read(pool, pool.lookup(3))[:, 0], [30])
+
+
+def test_write_packed_duplicate_hash_keeps_only_last_placement():
+    pool = EmbeddingPool(num_pages=2, page_size=1, hidden=1, dtype=jnp.float32)
+    packed = jnp.asarray([[10.0], [20.0]])
+
+    first, last = pool.write_packed(
+        (1, 1),
+        packed,
+        (1, 1),
+    )
+
+    assert first is None
+    assert last is pool.lookup(1)
+    np.testing.assert_array_equal(_read(pool, last)[:, 0], [20])
+    assert len(pool._free_pages) == 1
+
+
+def test_write_packed_oversized_item_does_not_disturb_other_entries():
+    pool = EmbeddingPool(num_pages=2, page_size=1, hidden=1, dtype=jnp.float32)
+    existing = _write(pool, 1, jnp.asarray([[5.0]]))
+    packed = jnp.asarray([[10.0], [11.0], [12.0], [20.0]])
+
+    oversized, normal = pool.write_packed(
+        (1, 2),
+        packed,
+        (3, 1),
+    )
+
+    assert oversized is None
+    assert pool.lookup(1) is existing
+    assert normal is pool.lookup(2)
+    np.testing.assert_array_equal(_read(pool, existing)[:, 0], [5])
+    np.testing.assert_array_equal(_read(pool, normal)[:, 0], [20])
+    assert len(pool._free_pages) == 0
+
+
+def test_clear_resets_free_list():
+    pool = EmbeddingPool(num_pages=4, page_size=2, hidden=1, dtype=jnp.float32)
+    _write(pool, 1, jnp.asarray([[1.0], [2.0], [3.0]]))
+    pool.clear()
+    assert pool.lookup(1) is None
+    assert len(pool._free_pages) == 4

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -302,6 +302,11 @@ suites = {
     # have a conditional CPU pin gated on USE_DEVICE_TYPE=cpu — the
     # cpu-test CI job sets that env var.
     "unit-test-cpu": [
+        TestFile(
+            "python/sgl_jax/test/test_embedding_pool.py",
+            0.1,
+            runner="pytest",
+        ),
         TestFile("test/srt/test_tokenizer_manager_event.py", 0.1),
         TestFile("test/srt/disaggregation/test_pd_auth.py", 0.3, runner="pytest"),
         TestFile("test/srt/disaggregation/test_pd_bootstrap.py", 0.5, runner="pytest"),


### PR DESCRIPTION
## Motivation

This is the second part of the Qwen2.5-VL upstream landing and depends on #1544.

The request contract and media-aware cache identity are provided by the previous PR. This PR adds the model-agnostic in-model multimodal runtime and the Qwen2.5-VL implementation, while intentionally keeping the model unreachable from the serving path.

Separating the runtime/model implementation from serving activation allows the model code, vision sharding, and embedding orchestration to be reviewed without changing Scheduler or ModelRunner behavior.

This consolidates the final implementation developed in #1433, #1444, and #1480.

## Modifications

- Add `InModelMultimodalContract`.
- Add multimodal lane packing and host orchestration.
- Add the paged multimodal embedding pool.
- Add vision DP/TP sharding utilities.
- Add variable-length vision Flash Attention support.
- Add Qwen2.5-VL:
  - Vision transformer.
  - Image and video encoding.
  - MRoPE support.
  - DeepStack embedding support.
  - Weight loading and sharding.
- Add embedding pool and vision attention tests.
- Preserve the existing text-only Qwen2 path when multimodal positions are absent.

### Dormant-by-design boundary

This PR intentionally does not export:

```python
EntryClass = Qwen2_5_VLForConditionalGeneration
```

Therefore Qwen2.5-VL is not registered by `ModelRegistry` and cannot be selected or reached by the serving path in this PR.

Scheduler, ForwardBatch, ModelRunner, HBM accounting, and serving arguments are not activated until the following PR.

### Compatibility

- Vision-specific attention and sharding are only called by the new VLM runtime.
- Existing serving models cannot reach the new runtime.
- Generic preprocessing performance changes from #1538/#1542 are excluded.

## Accuracy Tests

- [x] Paged multimodal embedding pool behavior and placement.
- [x] Variable-length vision Flash Attention numerical accuracy.
- [x] RoPE/MRoPE float32 phase computation.

Results:

- Embedding pool: 10 tests passed.
- Vision Flash Attention numerical comparison: 1 test passed.
- RoPE/MRoPE precision regression: 4 test cases passed.

## Benchmarking and Profiling

No serving performance claim is made in this PR because the runtime remains dormant.
The follow-up serving PR will report end-to-end compilation, memory, and latency results.

## Test Plan

Commit-level pre-commit hooks passed locally.

```bash
python -m pytest -q \
  python/sgl_jax/test/test_embedding_pool.py \
  python/sgl_jax/test/multimodal/test_flash_attention_kernel.py \
  python/sgl_jax/test/layers/test_rotary_embedding.py
```


## Checklist

- [x] The PR description is written in English.
- [x] The purpose and dependency are documented.
- [x] A test plan is provided.
- [x] The model is not registered or serving-reachable.
- [x] Targeted component tests passed on TPU.
- [x] TPU component numerical validation is attached.
