### PR TITLE
perf(kda): optimize the KDA prefill kernel on TPU

### DIFF
--- a/python/sgl_jax/srt/kernels/kda/kda.py
+++ b/python/sgl_jax/srt/kernels/kda/kda.py
@@ -1,16 +1,6 @@
 # Adapted from https://github.com/primatrix/pallas-kernel (rev 3c691ad3)
 # Vendored to remove external dependency after the upstream repository went private.
-#
-# This file merges the following modules into a single file:
-#   - tops/utils.py (cdiv, align_up, pad_to_multiple, prepare_lens, prepare_chunk_indices, assert_shape, assert_shape_or_none)
-#   - tops/ops/utils.py (exp, exp2, get_interpret)
-#   - tops/ops/common/cumsum.py (chunk_local_cumsum_vector via _chunk_cumsum_kernel)
-#   - tops/ops/kda/chunk_intra_fwd.py (_solve_unit_lower_triangular, _kda_fwd_intra_kernel, kda_fwd_intra)
-#   - tops/ops/common/chunk_delta_h.py (_prepare_chunk_offsets, _chunk_gated_delta_rule_fwd_kernel, chunk_gated_delta_rule_fwd_h)
-#   - tops/ops/gla/chunk.py (_chunk_kda_fwd_o_gk_varlen_kernel renamed to _chunk_kda_fwd_o_gk_pl_kernel, chunk_kda_fwd_o_gk_varlen renamed to chunk_kda_fwd_o_gk)
-#   - tops/ops/kda/gate.py (kda_gate_chunk_cumsum, pallas_kda_gate_cumsum)
-#   - tops/ops/kda/chunk_fwd.py (_align_seqs, _unalign_output, chunk_kda_fwd)
-"""KDA chunked forward pass for variable-length sequences (self-contained)."""
+"""Core KDA kernels and the variable-length forward entry point."""
 
 from __future__ import annotations
 
@@ -24,6 +14,13 @@ import jax.experimental.pallas as pl
 import jax.numpy as jnp
 from jax.experimental.pallas import dslice
 from jax.experimental.pallas import tpu as pltpu
+
+from sgl_jax.srt.kernels.kda.v2.unified_layout import (
+    from_unified_layout,
+    prepare_intra_layout,
+    restore_intra_layout,
+    to_unified_layout,
+)
 
 # ============================================================================
 # Utilities
@@ -350,36 +347,78 @@ def _solve_unit_lower_triangular(A, b):
     return jnp.concatenate(blocks, axis=0)
 
 
-def _kda_fwd_intra_kernel(
-    q_ref,
-    k_ref,
-    g_ref,
-    beta_ref,
-    v_ref,
-    u_out_ref,
-    w_out_ref,
-    qg_out_ref,
-    kg_out_ref,
-    Aqk_out_ref,
-    Akk_inv_out_ref,
+def _neumann_fused_wide(L, z, BT):
+    # K3-branch solve: L is strictly lower triangular => nilpotent (L^BT = 0),
+    # so (I+L)^-1 equals the finite factorization (I-L)(I+L^2)...(I+L^{BT/2})
+    # exactly. Propagate Z = [I | v_beta | k_eg_beta] through the factors
+    # (they are polynomials in L and commute): log2(BT)-1 power dots plus
+    # log2(BT) wide [BT,BT]@[BT,BT+V+K] dots that fill the MXU lane width.
+    # Runs in one bf16 MXU pass: applying factors to the RHS never
+    # materializes the explicit inverse, whose compounding rounding error is
+    # what makes the DIRECT bf16 form fail the 5e-4 oracle gate (measured:
+    # direct 6.9e-04 FAIL, fused 2.77e-04 OK). Do not "simplify" this into
+    # inverse-then-multiply.
+    z = z - jax.lax.dot(L, z, preferred_element_type=jnp.float32)
+    Lp = L
+    for _ in range(int(math.log2(BT)) - 1):
+        Lp = jax.lax.dot(Lp, Lp, preferred_element_type=jnp.float32)
+        z = z + jax.lax.dot(Lp, z, preferred_element_type=jnp.float32)
+    return z
+
+
+def _intra_head_math(
+    q,
+    k,
+    g,
+    beta,
+    v,
+    a_vec,
+    bias_vec,
     *,
     chunk_size,
     head_dim,
     value_dim,
     scale,
-    disable_recompute,
     safe_gate,
+    APPLY_GATE,
+    LOWER_BOUND,
+    PRE_CUMSUM,
+    WANT_AINV,
 ):
-    dtype = q_ref.dtype
-    q = q_ref[0, 0, 0]
-    k = k_ref[0, 0, 0]
-    g = g_ref[0, 0, 0]
-    beta = beta_ref[0, 0, 0]
-    v = v_ref[0, 0, 0]
+    """Compute one head and one chunk of the intra stage.
 
-    BT = chunk_size
+    This pure function is shared by both kernel layouts. Inputs are q/k/g
+    [BT,K], beta [BT,1], v [BT,V], and optional a_vec/bias_vec [K]. It returns
+    u [BT,V], w [BT,K], kg [BT,K], Aqk [BT,BT], optional A_inv [BT,BT], and
+    fp32 g_cum [BT,K]. With WANT_AINV=False (the inference default), the
+    safe_gate fused-wide RHS omits the identity block (320 to 256 columns), so
+    (I+L)^-1 is neither computed nor returned.
+    """
+    dtype = q.dtype
 
+    BT = chunk_size  # 64
+
+    # ---- Fused stage 1: gate activation + chunk-local cumsum (log2 domain) ----
     g_f32 = g.astype(jnp.float32)
+    if not PRE_CUMSUM:
+        if APPLY_GATE:
+            b_a = a_vec.astype(jnp.float32)  # [K] exp(A_log[h]), broadcast per channel
+            b_bias = bias_vec.astype(jnp.float32)  # [K] dt_bias[h]
+            if LOWER_BOUND is None:
+                g_f32 = -b_a * jax.nn.softplus(g_f32 + b_bias)
+            else:
+                g_f32 = LOWER_BOUND * jax.nn.sigmoid(b_a * (g_f32 + b_bias))
+        # Chunk-local prefix sum via a Hillis-Steele doubling scan with
+        # log2(BT) shift-and-add steps. Pallas TPU does not lower jnp.cumsum.
+        num_steps = int(math.log2(BT))
+        assert (1 << num_steps) == BT, "chunk_size must be a power of 2 for the in-kernel scan"
+        for d in range(num_steps):
+            stride = 1 << d
+            top = g_f32[:stride, :]
+            bot = g_f32[stride:, :] + g_f32[:-stride, :]
+            g_f32 = jnp.concatenate([top, bot], axis=0)
+        g_f32 = g_f32 * _RCP_LN2  # [64, 128], convert to the log2 domain
+    g_cum = g_f32
     q_f32 = q.astype(jnp.float32)
     k_f32 = k.astype(jnp.float32)
     beta_f32 = beta.astype(jnp.float32)
@@ -388,45 +427,175 @@ def _kda_fwd_intra_kernel(
     # For causal (i >= j): g_cumsum[i] <= g_cumsum[j], so g[i]-g[j] <= 0,
     # giving exp2 in (0, 1].  This avoids the split-normalization overflow
     # that occurs with exp2(g-gn) when per-step gate changes exceed ~127.
-    causal_bt = jnp.tril(jnp.ones((BT, BT), dtype=jnp.float32))
-    strict_bt = jnp.tril(jnp.ones((BT, BT), dtype=jnp.float32), k=-1)
+    causal_bt = jnp.tril(
+        jnp.ones((BT, BT), dtype=jnp.float32)
+    )  # [64, 64], i >= j, including diagonal, for Aqk
+    strict_bt = jnp.tril(
+        jnp.ones((BT, BT), dtype=jnp.float32), k=-1
+    )  # [64, 64], i > j, excluding diagonal, for L
 
-    # g_diff[i, j, k] = g[i, k] - g[j, k];  shape [BT, BT, K]
-    g_diff = g_f32[:, None, :] - g_f32[None, :, :]
-    # Mask anti-causal entries to -126 before exp2 to prevent overflow;
-    # they will be zeroed by causal_bt / strict_bt anyway.
-    g_diff = jnp.where(causal_bt[:, :, None] > 0, g_diff, -126.0)
-    decay = exp2(jnp.maximum(g_diff, -126.0))  # [BT, BT, K]
+    if safe_gate:
+        # safe_gate path: Aqk/L become BT/16 per-sub-chunk GEMMs
+        # [BT,K]@[K,16] on the MXU instead of a [BT,BT,K] elementwise tensor
+        # on the VPU ([16,16,128]).
+        SB = 16
+        aqk_subchunks, l_subchunks = [], []  # Four [64, 16] blocks each
+        for blk in range(BT // SB):
+            cols = slice(blk * SB, (blk + 1) * SB)
+            r_b = g_f32[blk * SB + SB // 2 : blk * SB + SB // 2 + 1, :]  # [1, K] = [1, 128]
+            row = exp2(g_f32 - r_b)  # [64,128] - [1,128], broadcast to [BT, K]
+            col = k_f32[cols] * exp2(r_b - g_f32[cols])  # [SB, K]
+            #     [16,128]    * exp2([1,128] - [16,128] -> [16,128]) -> [16, 128]
+            # Column factor k[j] * 2^(r-g[j]), restricted to this 16-column block.
 
-    # Aqk[i, j] = scale * sum_k q[i,k] * k[j,k] * decay[i,j,k]
-    Aqk = scale * jnp.sum(q_f32[:, None, :] * decay * k_f32[None, :, :], axis=-1)
+            aqk_subchunks.append(
+                jax.lax.dot_general(
+                    q_f32 * row,  # [BT=64, K=128] * [BT=64, K=128]
+                    col,  # [BT=64, K=128]
+                    (
+                        ((1,), (1,)),  # Contract dimension 1 (K=128) on both operands.
+                        ((), ()),  # No batch dimensions.
+                    ),
+                    preferred_element_type=jnp.float32,
+                )
+            )
+            # lhs = q_f32 * row: elementwise [64, 128]. dot_general contracts
+            # dimension 1 (K) on both operands: [64,128] x [16,128] -> [64,16].
+            # This is the MXU GEMM for Aqk_block[i, j_local].
+
+            l_subchunks.append(
+                jax.lax.dot_general(
+                    k_f32 * row,  # [64,128] * [64,128]
+                    col,  # [64,128]
+                    (((1,), (1,)), ((), ())),
+                    preferred_element_type=jnp.float32,
+                )
+            )
+            # Same contraction with lhs = k_f32 * row: [64,128] -> [64,16].
+
+        o_i = jnp.arange(BT, dtype=jnp.int32)
+        # Aqk[i, j] = scale * sum_k q[i,k] * k[j,k] * exp2(g[i,k] - g[j,k])
+        Aqk = jnp.where(
+            o_i[:, None] >= o_i[None, :], scale * jnp.concatenate(aqk_subchunks, axis=-1), 0.0
+        )
+        # L[i, j] = sum_k k[i,k] * k[j,k] * exp2(g[i,k] - g[j,k])   (i > j)
+        L = jnp.where(o_i[:, None] > o_i[None, :], jnp.concatenate(l_subchunks, axis=-1), 0.0)
+    else:
+        # g_diff[i, j, k] = g[i, k] - g[j, k];  shape [BT, BT, K]
+        g_diff = g_f32[:, None, :] - g_f32[None, :, :]
+        #            [64,1,128]    -   [1, 64, 128] --> [64, 64, 128]
+
+        # Mask anti-causal entries to -126 before exp2 to prevent overflow;
+        # they will be zeroed by causal_bt / strict_bt anyway.
+        g_diff = jnp.where(causal_bt[:, :, None] > 0, g_diff, -126.0)
+        # Broadcast [64,64,1] to [64,64,128]. Anti-causal entries (i < j)
+        # have positive g_diff, so fill them with -126 before exp2 to avoid overflow.
+
+        decay = exp2(
+            jnp.maximum(g_diff, -126.0)
+        )  # [BT, BT, K], per-channel decay from position j to i
+
+        # Aqk[i, j] = scale * sum_k q[i,k] * k[j,k] * decay[i,j,k]
+        Aqk = scale * jnp.sum(q_f32[:, None, :] * decay * k_f32[None, :, :], axis=-1)
+
+        # L[i, j] = beta[i] * sum_k k[i,k] * k[j,k] * decay[i,j,k]   (i > j)
+        L = jnp.sum(k_f32[:, None, :] * decay * k_f32[None, :, :], axis=-1)
+
     Aqk = (Aqk * causal_bt).astype(dtype)
-
-    # L[i, j] = beta[i] * sum_k k[i,k] * k[j,k] * decay[i,j,k]   (i > j)
-    L = jnp.sum(k_f32[:, None, :] * decay * k_f32[None, :, :], axis=-1) * beta_f32 * strict_bt
+    L = L * beta_f32 * strict_bt
 
     v_beta = v.astype(jnp.float32) * beta_f32
     k_eg_beta = k_f32 * exp2(g_f32) * beta_f32
     identity = jnp.eye(BT, dtype=jnp.float32)
 
-    combined_b = jnp.concatenate([v_beta, k_eg_beta, identity], axis=-1)
-    combined_x = _solve_unit_lower_triangular(L, combined_b)
+    if safe_gate:
+        # Kimi-K3 special branch (bounded gate, lower_bound validated in
+        # [-5, 0)): fused-wide finite Neumann, one bf16 MXU pass.  (PR#2)
+        parts = ([identity] if WANT_AINV else []) + [v_beta, k_eg_beta]
+        z = jnp.concatenate(parts, axis=-1)
+        z = _neumann_fused_wide(L, z, BT)
+        off = BT if WANT_AINV else 0
+        A_inv = z[:, :BT] if WANT_AINV else None
+        u = z[:, off : off + value_dim]
+        w = z[:, off + value_dim :]
+    else:
+        # General KDA: sequential forward substitution (upstream original).
+        parts = [v_beta, k_eg_beta] + ([identity] if WANT_AINV else [])
+        combined_b = jnp.concatenate(parts, axis=-1)
+        combined_x = _solve_unit_lower_triangular(L, combined_b)
 
-    u = combined_x[:, :value_dim]
-    w = combined_x[:, value_dim : value_dim + head_dim]
-    A_inv = combined_x[:, value_dim + head_dim :]
+        u = combined_x[:, :value_dim]
+        w = combined_x[:, value_dim : value_dim + head_dim]
+        A_inv = combined_x[:, value_dim + head_dim :] if WANT_AINV else None
 
     g_last = g_f32[BT - 1 : BT, :]
     kg = k_f32 * exp2(g_last - g_f32)
 
-    qg = q_f32 * exp2(g_f32) if disable_recompute else jnp.zeros_like(q_f32)
+    return u, w, kg, Aqk, A_inv, g_cum
 
-    u_out_ref[0, 0, 0] = u.astype(u_out_ref.dtype)
-    w_out_ref[0, 0, 0] = w.astype(w_out_ref.dtype)
-    qg_out_ref[0, 0, 0] = qg.astype(qg_out_ref.dtype)
-    kg_out_ref[0, 0, 0] = kg.astype(kg_out_ref.dtype)
-    Aqk_out_ref[0, 0, 0] = Aqk.astype(Aqk_out_ref.dtype)
-    Akk_inv_out_ref[0, 0, 0] = A_inv.astype(Akk_inv_out_ref.dtype)
+
+# Unified-addressing layout: arrays are [1, H, T_alloc, D], grid=(H, NC),
+# and block c maps directly to rows [c*BT, (c+1)*BT). Each kernel ref is a
+# [1, 1, BT, D] block selected by BlockSpec.
+def _kda_fwd_intra_kernel(
+    q_ref,  # [1, 1, BT, K] = [1, 1, 64, 128]
+    k_ref,  # [1, 1, BT, K]
+    g_ref,  # [1, 1, BT, K]
+    beta_ref,  # [1, 1, BT, 1]
+    v_ref,  # [1, 1, BT, V]
+    a_ref,  # [1, 1, 1, K] exp(A_log), broadcast per head; None if APPLY_GATE=False
+    bias_ref,  # [1, 1, 1, K] dt_bias; None if APPLY_GATE=False
+    u_out_ref,  # [1, 1, BT, V]
+    w_out_ref,  # [1, 1, 1, BT, K]
+    qg_out_ref,  # [1, 1, 1, BT, V]
+    kg_out_ref,  #
+    Aqk_out_ref,  #
+    Akk_inv_out_ref,  #
+    g_cum_out_ref,  # [1, 1, 1, BT, K] fp32 fused stage-1 output for stages 3+4
+    *,
+    chunk_size,  # 64
+    head_dim,  # K=128
+    value_dim,  # V=128
+    scale,
+    disable_recompute,
+    safe_gate,
+    APPLY_GATE,  # Whether fused stage 1 applies gate activation in-kernel
+    LOWER_BOUND,  # None -> -exp(A)*softplus; float -> lb*sigmoid
+    PRE_CUMSUM,  # True for fuse=False: g is already the stage-1 log2 prefix sum
+):
+    # q_r, k_r, g_r, v_r:
+    # beta_r: [B, H, N, D, 1]
+    a_vec = a_ref[0, 0, 0] if APPLY_GATE else None
+    bias_vec = bias_ref[0, 0, 0] if APPLY_GATE else None
+    u, w, kg, Aqk, A_inv, g_cum = _intra_head_math(
+        q_ref[0, 0],
+        k_ref[0, 0],
+        g_ref[0, 0],
+        beta_ref[0, 0],
+        v_ref[0, 0],
+        a_vec,
+        bias_vec,
+        chunk_size=chunk_size,
+        head_dim=head_dim,
+        value_dim=value_dim,
+        scale=scale,
+        safe_gate=safe_gate,
+        APPLY_GATE=APPLY_GATE,
+        LOWER_BOUND=LOWER_BOUND,
+        PRE_CUMSUM=PRE_CUMSUM,
+        WANT_AINV=True,
+    )
+    g_cum_out_ref[0, 0] = g_cum.astype(g_cum_out_ref.dtype)
+    u_out_ref[0, 0] = u.astype(u_out_ref.dtype)
+    w_out_ref[0, 0] = w.astype(w_out_ref.dtype)
+    if disable_recompute:
+        # qg only exists to let backward skip recomputation; otherwise the
+        # output slot is None and nothing is written (saves a full HBM store).
+        qg = q_ref[0, 0].astype(jnp.float32) * exp2(g_cum)
+        qg_out_ref[0, 0] = qg.astype(qg_out_ref.dtype)
+    kg_out_ref[0, 0] = kg.astype(kg_out_ref.dtype)
+    Aqk_out_ref[0, 0] = Aqk.astype(Aqk_out_ref.dtype)
+    Akk_inv_out_ref[0, 0] = A_inv.astype(Akk_inv_out_ref.dtype)
 
 
 @functools.partial(
@@ -436,6 +605,10 @@ def _kda_fwd_intra_kernel(
         "scale",
         "safe_gate",
         "disable_recompute",
+        "use_gate_in_kernel",
+        "lower_bound",
+        "unified_layout",
+        "pre_cumsum",
     ],
 )
 def kda_fwd_intra(
@@ -445,82 +618,61 @@ def kda_fwd_intra(
     gk,
     beta,
     scale,
-    cu_seqlens,
     chunk_size=64,
-    chunk_indices=None,
-    safe_gate=True,
+    safe_gate=False,
     disable_recompute=False,
+    use_gate_in_kernel=False,
+    A_log=None,
+    dt_bias=None,
+    lower_bound=None,
+    unified_layout=True,
+    pre_cumsum=False,
+    cu_seqlens=None,
 ):
-    assert cu_seqlens is not None, "cu_seqlens must be provided for varlen"
-    B, T, H, K = q.shape
-    V = v.shape[-1]
+    """Run intra stage K1 with either addressing mode.
+
+    With unified_layout=True, inputs and outputs use [1, H, T, D]. After
+    _align_seqs, global chunk c maps directly to rows [c*BT, (c+1)*BT), so
+    no gather or scatter is needed. With unified_layout=False, inputs and
+    outputs use the legacy [1, T, H, D] layout: chunk_starts are derived from
+    cu_seqlens, data is gathered into blocks, then scattered back along T.
+
+    With pre_cumsum=True (the fuse=False ablation path), gk already contains
+    the stage-1 log2 prefix sum, so activation and scanning are skipped here.
+    """
     BT = chunk_size
-    assert B == 1, f"varlen requires B=1 (packed layout), got B={B}"
     assert BT >= 16 and BT % 16 == 0
 
-    assert_shape(q, (B, T, H, K), "q")
-    assert_shape(k, (B, T, H, K), "k")
-    assert_shape(v, (B, T, H, V), "v")
-    assert_shape(gk, (B, T, H, K), "gk")
-    assert_shape(beta, (B, T, H), "beta")
-
-    N = cu_seqlens.shape[0] - 1
-    T_alloc = T + BT
-
-    pad4d = lambda x: jnp.pad(x, ((0, 0), (0, BT), (0, 0), (0, 0)))
-    q_pad, k_pad, gk_pad, v_pad = pad4d(q), pad4d(k), pad4d(gk), pad4d(v)
-    beta_pad = jnp.pad(beta.reshape(B, T, H, 1), ((0, 0), (0, BT), (0, 0), (0, 0)))
-
-    cu_i32 = cu_seqlens.astype(jnp.int32)
-    seq_lens = jnp.diff(cu_i32)
-    chunks_per_seq = (seq_lens + BT - 1) // BT
-    cum_chunks = jnp.pad(jnp.cumsum(chunks_per_seq), (1, 0))
-    total_chunks = cum_chunks[-1]
-
-    NC_max = len(chunk_indices) if chunk_indices is not None else T // BT + N
-    flat_idx = jnp.arange(NC_max, dtype=jnp.int32)
-    is_valid = flat_idx < total_chunks
-
-    seq_id = jnp.minimum(jnp.searchsorted(cum_chunks[1:], flat_idx, side="right"), N - 1)
-    local_ci = flat_idx - cum_chunks[seq_id]
-    bos = cu_i32[seq_id]
-    # After _align_seqs, every sequence is BT-aligned, so all chunks are full.
-    # No partial-chunk masking needed.
-    chunk_starts = jnp.where(is_valid, bos + local_ci * BT, 0)
-
-    def gather(x_pad, D):
-        def extract(start):
-            return jax.lax.dynamic_slice(x_pad, (0, start, 0, 0), (1, BT, H, D))[0]
-
-        return jax.vmap(extract)(chunk_starts)
-
-    q_c, k_c, gk_c, beta_c, v_c = (
-        gather(q_pad, K),
-        gather(k_pad, K),
-        gather(gk_pad, K),
-        gather(beta_pad, 1),
-        gather(v_pad, V),
+    (q4, k4, g4, beta4, v4), layout_metadata = prepare_intra_layout(
+        q, k, v, gk, beta, BT, unified_layout, cu_seqlens
     )
+    B, H, K, V, NC, _ = layout_metadata
 
-    def _to_bhnd(x):
-        return x.transpose(2, 0, 1, 3)[None]
-
-    q_r, k_r, g_r, beta_r, v_r = (
-        _to_bhnd(q_c),
-        _to_bhnd(k_c),
-        _to_bhnd(gk_c),
-        _to_bhnd(beta_c),
-        _to_bhnd(v_c),
-    )
-
-    grid = (B, H, NC_max)
-
-    def _make_spec(last_dim):
-        return pl.BlockSpec(
-            index_map=lambda i, j, n: (i, j, n, 0, 0), block_shape=(1, 1, 1, BT, last_dim)
+    # Per-head constants for fused stage 1: exp(A_log) and dt_bias,
+    # broadcast to [1,H,1,K].
+    if use_gate_in_kernel and not pre_cumsum:
+        assert A_log is not None
+        a_r = jnp.broadcast_to(
+            jnp.exp(A_log.astype(jnp.float32))[None, :, None, None], (1, H, 1, K)
         )
+        db = (
+            jnp.zeros((H, K), jnp.float32)
+            if dt_bias is None
+            else dt_bias.astype(jnp.float32).reshape(H, K)
+        )
+        bias_r = db[None, :, None, :]
+        gate_spec = pl.BlockSpec(block_shape=(1, 1, 1, K), index_map=lambda h, c: (0, h, 0, 0))
+        apply_gate = True
+    else:
+        a_r, bias_r, gate_spec = None, None, None
+        apply_gate = False
 
-    u_r, w_r, qg_r, kg_r, Aqk_r, Akk_inv_r = pl.pallas_call(
+    def _spec(last_dim):
+        return pl.BlockSpec(block_shape=(1, 1, BT, last_dim), index_map=lambda h, c: (0, h, c, 0))
+
+    dt = q4.dtype
+    TB = NC * BT  # T dimension of kernel arrays; equals T_u with unified addressing.
+    u4, w4, qg4, kg4, Aqk4, Akk4, g_cum4 = pl.pallas_call(
         functools.partial(
             _kda_fwd_intra_kernel,
             chunk_size=BT,
@@ -529,47 +681,39 @@ def kda_fwd_intra(
             scale=scale,
             disable_recompute=disable_recompute,
             safe_gate=safe_gate,
+            APPLY_GATE=apply_gate,
+            LOWER_BOUND=lower_bound,
+            PRE_CUMSUM=pre_cumsum,
         ),
         interpret=get_interpret(),
         out_shape=[
-            jax.ShapeDtypeStruct((B, H, NC_max, BT, V), q.dtype),
-            jax.ShapeDtypeStruct((B, H, NC_max, BT, K), q.dtype),
-            jax.ShapeDtypeStruct((B, H, NC_max, BT, K), q.dtype),
-            jax.ShapeDtypeStruct((B, H, NC_max, BT, K), q.dtype),
-            jax.ShapeDtypeStruct((B, H, NC_max, BT, BT), q.dtype),
-            jax.ShapeDtypeStruct((B, H, NC_max, BT, BT), q.dtype),
+            jax.ShapeDtypeStruct((1, H, TB, V), dt),
+            jax.ShapeDtypeStruct((1, H, TB, K), dt),
+            jax.ShapeDtypeStruct((1, H, TB, K), dt) if disable_recompute else None,
+            jax.ShapeDtypeStruct((1, H, TB, K), dt),
+            jax.ShapeDtypeStruct((1, H, TB, BT), dt),
+            jax.ShapeDtypeStruct((1, H, TB, BT), dt),
+            jax.ShapeDtypeStruct((1, H, TB, K), jnp.float32),
         ],
-        in_specs=[_make_spec(K), _make_spec(K), _make_spec(K), _make_spec(1), _make_spec(V)],
+        in_specs=[_spec(K), _spec(K), _spec(K), _spec(1), _spec(V), gate_spec, gate_spec],
         out_specs=[
-            _make_spec(V),
-            _make_spec(K),
-            _make_spec(K),
-            _make_spec(K),
-            _make_spec(BT),
-            _make_spec(BT),
+            _spec(V),
+            _spec(K),
+            _spec(K) if disable_recompute else None,
+            _spec(K),
+            _spec(BT),
+            _spec(BT),
+            _spec(K),
         ],
-        grid=grid,
-        compiler_params=pltpu.CompilerParams(
-            dimension_semantics=("parallel", "parallel", "parallel")
-        ),
-    )(q_r, k_r, g_r, beta_r, v_r)
+        grid=(H, NC),
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "parallel")),
+    )(q4, k4, g4, beta4, v4, a_r, bias_r)
 
-    pos = chunk_starts[:, None] + jnp.arange(BT)[None, :]
-    pos = jnp.where(is_valid[:, None], pos, T_alloc - 1)
-    flat_pos = pos.reshape(-1)
-
-    def _scatter(chunks_r, D):
-        chunks = chunks_r[0].transpose(1, 2, 0, 3)
-        flat_chunks = chunks.reshape(-1, H, D)
-        out = jnp.zeros((T_alloc, H, D), dtype=chunks.dtype)
-        out = out.at[flat_pos].add(flat_chunks)
-        return out[:T][None]
-
-    w_out, u_out, kg_out = _scatter(w_r, K), _scatter(u_r, V), _scatter(kg_r, K)
-    Aqk_out, Akk_out = _scatter(Aqk_r, BT), _scatter(Akk_inv_r, BT)
-    qg_out = _scatter(qg_r, K) if disable_recompute else None
-
-    return w_out, u_out, qg_out, kg_out, Aqk_out, Akk_out
+    return restore_intra_layout(
+        (w4, u4, qg4, kg4, Aqk4, Akk4, g_cum4),
+        chunk_size=BT,
+        layout_metadata=layout_metadata,
+    )
 
 
 # ============================================================================
@@ -745,6 +889,9 @@ def chunk_gated_delta_rule_fwd_h(
         g_t = None
 
     if gk is not None:
+        # NOTE: the kernel only reads gk[BT-1], but a [1,1,1,K] block is illegal
+        # on TPU (sublane dim must be a multiple of 8 or the full array dim), so
+        # the full [BT, K] block is shipped. The fused path avoids this entirely.
         gk_fp32 = gk.astype(jnp.float32)
         if K_PADSIZE > K:
             gk_fp32 = jnp.pad(gk_fp32, ((0, 0), (0, 0), (0, 0), (0, K_PADSIZE - K)))
@@ -849,6 +996,10 @@ def chunk_gated_delta_rule_fwd_h(
     ht_out = ht_out[:, :, :K, :V] if output_final_state else None
 
     return h_out, v_new_out, ht_out
+
+
+# ============================================================================
+# ============================================================================
 
 
 # ============================================================================
@@ -1124,6 +1275,10 @@ def _unalign_output(o, orig_cu_seqlens, aligned_cu_seqlens, T_out):
 # ============================================================================
 
 
+# ============================================================================
+# ============================================================================
+
+
 @functools.partial(
     jax.jit,
     static_argnames=(
@@ -1138,6 +1293,11 @@ def _unalign_output(o, orig_cu_seqlens, aligned_cu_seqlens, T_out):
         "return_intermediate_states",
         "cp_context",
         "transpose_state_layout",
+        "fuse",
+        "unified_layout",
+        "flat_grid",
+        "head_block",
+        "return_backward_intermediates",
     ),
 )
 def chunk_kda_fwd(
@@ -1153,7 +1313,7 @@ def chunk_kda_fwd(
     use_qk_l2norm_in_kernel: bool = False,
     chunk_indices: jax.Array | None = None,
     chunk_size: int = 64,
-    safe_gate: bool = True,
+    safe_gate: bool = False,
     lower_bound: float | None = None,
     use_gate_in_kernel: bool = False,
     A_log: jax.Array | None = None,
@@ -1162,20 +1322,22 @@ def chunk_kda_fwd(
     return_intermediate_states: bool = False,
     cp_context: None = None,
     transpose_state_layout: bool = False,
+    fuse: bool = True,
+    unified_layout: bool = True,
+    flat_grid: bool = True,
+    head_block: bool = True,
+    return_backward_intermediates: bool = False,
 ):
-    """KDA chunked forward pass for variable-length sequences (varlen).
+    """Run the chunked KDA forward pass for varlen-packed B=1 inputs."""
+    # Keep optimization-specific implementations out of this base module.
+    # Local imports avoid cycles because those modules reuse common kernels here.
+    from sgl_jax.srt.kernels.kda.v2.flat_grid import chunk_gated_delta_rule_fwd_h_flat
+    from sgl_jax.srt.kernels.kda.v2.fused import chunk_kda_fused_h_o
+    from sgl_jax.srt.kernels.kda.v2.head_block import (
+        chunk_kda_fused_h_o_hb,
+        kda_fwd_intra_hb,
+    )
 
-    cu_seqlens must not be None. B must be 1 (packed layout).
-
-    Four-stage pipeline:
-      1. Gate activation + chunk-local cumsum
-      2. Intra-chunk delta-rule solve via Neumann series
-      3. Inter-chunk hidden state propagation via delta-rule recurrence
-      4. Output computation (inter-chunk state + intra-chunk attention)
-
-    Returns:
-        12-tuple: o, final_state, g, Aqk, Akk, w, u, qg, kg, v_new, h, initial_state
-    """
     B, T, H, K = q.shape
     V = v.shape[-1]
     BT = chunk_size
@@ -1185,6 +1347,11 @@ def chunk_kda_fwd(
     assert not transpose_state_layout
     assert not return_intermediate_states
     assert not disable_recompute
+    assert fuse or not unified_layout, "unified_layout=True requires fuse=True"
+    if safe_gate and use_gate_in_kernel and lower_bound is None:
+        raise ValueError(
+            "`lower_bound` must be specified when `safe_gate=True` and `use_gate_in_kernel=True`."
+        )
 
     assert_shape(q, (B, T, H, K), "q")
     assert_shape(k, (B, T, H, K), "k")
@@ -1206,7 +1373,6 @@ def chunk_kda_fwd(
         align=BT,
     )
     T = q.shape[1]
-    chunk_indices = prepare_chunk_indices(cu_seqlens, BT, max_T=T)
 
     assert T % BT == 0
 
@@ -1225,79 +1391,195 @@ def chunk_kda_fwd(
         valid_mask = in_range.any(axis=0)  # [T]
         g = jnp.where(valid_mask[None, :, None, None], g, -1e4)
 
-    # Step 1: Gate cumsum
-    if use_gate_in_kernel:
-        assert A_log is not None
-        g_cumsum = kda_gate_chunk_cumsum(
-            g=g,
-            A_log=A_log,
+    in_dtype = q.dtype
+
+    # The head-block fast path requires a TPU-compatible head tile and bounded gates.
+    use_hb = head_block and fuse and (H % 8 == 0) and safe_gate
+
+    if fuse and use_hb:
+        w_n, u_n, kg_n, Aqk_n, gcum_n = kda_fwd_intra_hb(
+            q,
+            k,
+            v,
+            gk=g,
+            beta=beta,
+            scale=scale,
             chunk_size=BT,
-            scale=_RCP_LN2,
+            safe_gate=safe_gate,
+            use_gate_in_kernel=use_gate_in_kernel,
+            A_log=A_log,
             dt_bias=dt_bias,
             lower_bound=lower_bound,
-            cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices,
         )
+        o, final_state = chunk_kda_fused_h_o_hb(
+            q=q,
+            kg=kg_n,
+            w=w_n,
+            u=u_n,
+            g_cumsum=gcum_n,
+            A=Aqk_n,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            chunk_size=BT,
+            cu_seqlens=cu_seqlens,
+        )
+        Aqk = Aqk_n if return_backward_intermediates else None
+        Akk = None  # The head-block inference path does not compute (I+L)^-1.
+        g_cumsum = gcum_n if (return_backward_intermediates and not use_gate_in_kernel) else None
+    elif fuse:
+        if unified_layout:
+            # Unified addressing: transpose once to [1,H,T,D]; no K1/K2 copy.
+            q_u, k_u, v_u, g_u = map(to_unified_layout, (q, k, v, g))
+            beta_u = to_unified_layout(beta.reshape(B, T, H, 1))
+
+            w_u, u_u, qg_u, kg_u, Aqk_u, Akk_u, gcum_u = kda_fwd_intra(
+                q_u,
+                k_u,
+                v_u,
+                gk=g_u,
+                beta=beta_u,
+                scale=scale,
+                safe_gate=safe_gate,
+                chunk_size=BT,
+                use_gate_in_kernel=use_gate_in_kernel,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                lower_bound=lower_bound,
+                unified_layout=True,
+            )
+            o, final_state = chunk_kda_fused_h_o(
+                q=q_u,
+                kg=kg_u,
+                w=w_u,
+                u=u_u,
+                g_cumsum=gcum_u,
+                A=Aqk_u,
+                scale=scale,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                chunk_size=BT,
+                cu_seqlens=cu_seqlens,
+                unified_in=True,
+                flat_grid=flat_grid,
+            )
+            if return_backward_intermediates:
+                Aqk, Akk = map(from_unified_layout, (Aqk_u, Akk_u))
+                g_cumsum = None if use_gate_in_kernel else from_unified_layout(gcum_u)
+            else:
+                Aqk, Akk, g_cumsum = None, None, None
+        else:
+            # Fused stages with legacy addressing to measure gather/scatter cost.
+            w_, u_, qg_, kg_, Aqk, Akk, gcum_ = kda_fwd_intra(
+                q,
+                k,
+                v,
+                gk=g,
+                beta=beta,
+                scale=scale,
+                safe_gate=safe_gate,
+                chunk_size=BT,
+                use_gate_in_kernel=use_gate_in_kernel,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                lower_bound=lower_bound,
+                unified_layout=False,
+                cu_seqlens=cu_seqlens,
+            )
+            o, final_state = chunk_kda_fused_h_o(
+                q=q,
+                kg=kg_,
+                w=w_,
+                u=u_,
+                g_cumsum=gcum_,
+                A=Aqk,
+                scale=scale,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                chunk_size=BT,
+                cu_seqlens=cu_seqlens,
+                unified_in=False,
+                flat_grid=flat_grid,
+            )
+            g_cumsum = None if use_gate_in_kernel else gcum_
+            if not return_backward_intermediates:
+                Aqk, Akk, g_cumsum = None, None, None
     else:
-        g_cumsum = pallas_kda_gate_cumsum(
-            g=g,
-            scale=_RCP_LN2,
-            chunk_size=chunk_size,
+        # Original upstream four-stage pipeline used as the ablation baseline.
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT, max_T=T)
+        if use_gate_in_kernel:
+            assert A_log is not None
+            g_cumsum_ = kda_gate_chunk_cumsum(
+                g=g,
+                A_log=A_log,
+                chunk_size=BT,
+                scale=_RCP_LN2,
+                dt_bias=dt_bias,
+                lower_bound=lower_bound,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+            )
+        else:
+            g_cumsum_ = pallas_kda_gate_cumsum(
+                g=g,
+                scale=_RCP_LN2,
+                chunk_size=BT,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+            )
+        w_, u_, qg_, kg_, Aqk, Akk, _unused = kda_fwd_intra(
+            q,
+            k,
+            v,
+            gk=g_cumsum_,
+            beta=beta,
+            scale=scale,
+            safe_gate=safe_gate,
+            chunk_size=BT,
+            use_gate_in_kernel=use_gate_in_kernel,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            lower_bound=lower_bound,
+            unified_layout=False,
+            pre_cumsum=True,
+            cu_seqlens=cu_seqlens,
+        )
+        fwd_h = chunk_gated_delta_rule_fwd_h_flat if flat_grid else chunk_gated_delta_rule_fwd_h
+        h_, v_new_, final_state = fwd_h(
+            k=kg_,
+            w=w_,
+            u=u_,
+            gk=g_cumsum_,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            chunk_size=BT,
+            use_exp2=True,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
         )
-
-    # Step 2: Intra-chunk solve
-    w, u, qg, kg, Aqk, Akk = kda_fwd_intra(
-        q=q,
-        k=k,
-        v=v,
-        gk=g_cumsum,
-        beta=beta,
-        scale=scale,
-        safe_gate=safe_gate,
-        chunk_size=BT,
-        cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
-    )
-
-    # Step 3: Inter-chunk state propagation
-    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
-        k=kg,
-        w=w,
-        u=u,
-        gk=g_cumsum,
-        initial_state=initial_state,
-        output_final_state=output_final_state,
-        chunk_size=BT,
-        use_exp2=True,
-        cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
-    )
-
-    # Step 4: Output computation
-    o = chunk_kda_fwd_o_gk(
-        q=q,
-        v=v_new,
-        g=g_cumsum,
-        A=Aqk,
-        h=h,
-        scale=scale,
-        chunk_size=BT,
-        use_exp2=True,
-        cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
-    )
+        o = chunk_kda_fwd_o_gk(
+            q=q,
+            v=v_new_,
+            g=g_cumsum_,
+            A=Aqk,
+            h=h_,
+            scale=scale,
+            chunk_size=BT,
+            use_exp2=True,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+        g_cumsum = None if use_gate_in_kernel else g_cumsum_
+        if not return_backward_intermediates:
+            Aqk, Akk, g_cumsum = None, None, None
 
     # Cast output back to input dtype (e.g. bfloat16)
-    o = o.astype(q.dtype)
+    o = o.astype(in_dtype)
 
     # Unalign output
     o = _unalign_output(o, _orig_cu_seqlens, cu_seqlens, T_input)
 
     # Release intermediates
     w, u, qg, kg, v_new, h = None, None, None, None, None, None
-    if use_gate_in_kernel:
-        g_cumsum = None
 
     return o, final_state, g_cumsum, Aqk, Akk, w, u, qg, kg, v_new, h, initial_state

--- a/python/sgl_jax/srt/kernels/kda/v2/__init__.py
+++ b/python/sgl_jax/srt/kernels/kda/v2/__init__.py
@@ -1,0 +1,1 @@
+"""KDA v2 optimization kernels."""

--- a/python/sgl_jax/srt/kernels/kda/v2/flat_grid.py
+++ b/python/sgl_jax/srt/kernels/kda/v2/flat_grid.py
@@ -1,0 +1,372 @@
+"""Flat-grid and sequence-grid KDA v2 scheduling kernels."""
+
+from __future__ import annotations
+
+import functools
+
+import jax
+import jax.experimental.pallas as pl
+import jax.numpy as jnp
+from jax.experimental.pallas import tpu as pltpu
+
+from sgl_jax.srt.kernels.kda.kda import (
+    align_up,
+    assert_shape,
+    assert_shape_or_none,
+    exp,
+    exp2,
+    get_interpret,
+    pad_to_multiple,
+)
+from sgl_jax.srt.kernels.kda.v2.fused import _fused_h_o_chunk_step
+
+
+def _chunk_gated_delta_rule_fwd_kernel_flat(
+    seq_ids_ref,
+    is_first_ref,
+    is_last_ref,
+    k_ref,
+    v_ref,
+    w_ref,
+    g_ref,
+    gk_ref,
+    h0_ref,
+    h_ref,
+    v_new_ref,
+    ht_ref,
+    scratch_ref,
+    *,
+    USE_G,
+    USE_GK,
+    USE_INITIAL_STATE,
+    STORE_FINAL_STATE,
+    SAVE_NEW_VALUE,
+    USE_EXP2,
+):
+    # Flat-chunk grid (h, nt): every step is a real chunk -- O(total_chunks)
+    # instead of the previous O(N x total_chunks) where each sequence swept
+    # the full global chunk range and idled through chunks it did not own.
+    # Sequence boundaries come from the prefetched flags: reset the state
+    # carry at a sequence's first chunk, emit its final state at the last.
+    idx_nt = pl.program_id(1)
+
+    BT = k_ref.shape[2]
+    K, V = k_ref.shape[-1], v_ref.shape[-1]
+    b_k = k_ref[0, 0]
+
+    @pl.when(is_first_ref[idx_nt] == 1)
+    def _():
+        scratch_ref[...] = jnp.zeros([K, V], dtype=jnp.float32)
+        if USE_INITIAL_STATE:
+            scratch_ref[...] = h0_ref[0, 0].astype(jnp.float32)
+
+    h_ref[0, 0, 0] = scratch_ref[...].astype(h_ref.dtype)
+
+    b_w = w_ref[0, 0]
+    b_v = jnp.dot(
+        b_w.astype(jnp.float32),
+        scratch_ref[...],
+        precision=jax.lax.Precision.HIGHEST,
+        preferred_element_type=jnp.float32,
+    )
+    b_u = v_ref[0, 0]
+    b_v = b_u.astype(b_v.dtype) - b_v
+    if SAVE_NEW_VALUE:
+        v_new_ref[0, 0] = b_v.astype(v_new_ref.dtype)
+
+    if USE_G:
+        b_g = g_ref[0, 0, :, 0]
+        b_g_last = g_ref[0, 0, BT - 1, 0].astype(jnp.float32)
+        if USE_EXP2:
+            b_v = b_v * exp2(b_g_last - b_g)[:, None]
+            b_g_last = exp2(b_g_last)
+        else:
+            b_v = b_v * exp(b_g_last - b_g)[:, None]
+            b_g_last = exp(b_g_last)
+        scratch_ref[...] *= b_g_last
+    if USE_GK:
+        b_gk_last = gk_ref[0, 0, BT - 1].astype(jnp.float32)
+        if USE_EXP2:
+            scratch_ref[...] *= exp2(b_gk_last)[:, None]
+        else:
+            scratch_ref[...] *= exp(b_gk_last)[:, None]
+
+    scratch_ref[...] += jnp.dot(
+        b_k.astype(jnp.float32).T,
+        b_v.astype(jnp.float32),
+        precision=jax.lax.Precision.HIGHEST,
+        preferred_element_type=jnp.float32,
+    )
+
+    if STORE_FINAL_STATE:
+
+        @pl.when(is_last_ref[idx_nt] == 1)
+        def _():
+            ht_ref[0, 0] = scratch_ref[...].astype(ht_ref.dtype)
+
+
+def chunk_gated_delta_rule_fwd_h_flat(
+    k,
+    w,
+    u,
+    g=None,
+    gk=None,
+    initial_state=None,
+    output_final_state=False,
+    chunk_size=64,
+    save_new_value=True,
+    use_exp2=True,
+    cu_seqlens=None,
+    chunk_indices=None,
+):
+    B, T, H, K = k.shape
+    V = u.shape[-1]
+    BT = chunk_size
+
+    assert cu_seqlens is not None, "This varlen-only module requires cu_seqlens"
+    assert B == 1, f"varlen mode requires B==1, got B={B}"
+
+    N = cu_seqlens.shape[-1] - 1
+    assert_shape(k, (B, T, H, K), "k")
+    assert_shape(w, (B, T, H, K), "w")
+    assert_shape(u, (B, T, H, V), "u")
+    assert_shape_or_none(g, (B, T, H), "g")
+    assert_shape_or_none(gk, (B, T, H, K), "gk")
+    assert_shape_or_none(initial_state, (N, H, K, V), "initial_state")
+    assert K <= 256, "current kernel does not support head dimension larger than 256."
+
+    # --- Varlen launcher (flat-chunk grid) ---
+    # Runs after _align_seqs, so every sequence is BT-aligned and the packed
+    # chunk list is contiguous: the grid is O(total_chunks). The previous
+    # (N, H, NT_max) grid swept the FULL global chunk range once per
+    # sequence, idling through foreign chunks -- a per-sequence tax measured
+    # at ~0.5us x (N-1) x (T/BT) x H (e.g. ~46 ms for 8x1024 packed at
+    # T=8192, H=96 on v6e).
+    k = k.astype(jnp.float32)
+    w = w.astype(jnp.float32)
+    u_f32 = u.astype(jnp.float32)
+
+    K_PADSIZE = int(align_up(K, 128))
+    V_ALIGNED = int(align_up(V, 128))
+
+    assert chunk_indices is not None
+    NT = len(chunk_indices)
+    assert NT == T // BT, "flat-chunk fwd_h requires BT-aligned packing"
+
+    cu_i32 = cu_seqlens.astype(jnp.int32)
+    chunks_per_seq = jnp.diff(cu_i32) // BT
+    cum_chunks = jnp.pad(jnp.cumsum(chunks_per_seq), (1, 0))
+    flat_idx = jnp.arange(NT, dtype=jnp.int32)
+    seq_ids = jnp.minimum(jnp.searchsorted(cum_chunks[1:], flat_idx, side="right"), N - 1).astype(
+        jnp.int32
+    )
+    local_ids = flat_idx - cum_chunks[seq_ids]
+    is_first = (local_ids == 0).astype(jnp.int32)
+    is_last = (local_ids == chunks_per_seq[seq_ids] - 1).astype(jnp.int32)
+
+    def _padk(x):
+        if K_PADSIZE > K:
+            return jnp.pad(x, ((0, 0), (0, 0), (0, 0), (0, K_PADSIZE - K)))
+        return x
+
+    k_t = jnp.transpose(_padk(k), (0, 2, 1, 3))
+    w_t = jnp.transpose(_padk(w), (0, 2, 1, 3))
+    v_pad = jnp.pad(u_f32, ((0, 0), (0, 0), (0, 0), (0, V_ALIGNED - V))) if V_ALIGNED > V else u_f32
+    v_t = jnp.transpose(v_pad, (0, 2, 1, 3))
+
+    if g is not None:
+        g_fp32 = g.astype(jnp.float32).reshape(B, T, H, 1)
+        g_fp32 = pad_to_multiple(g_fp32, 128, -1, 0)
+        g_t = jnp.transpose(g_fp32, (0, 2, 1, 3))
+    else:
+        g_t = None
+
+    if gk is not None:
+        gk_fp32 = gk.astype(jnp.float32)
+        if K_PADSIZE > K:
+            gk_fp32 = jnp.pad(gk_fp32, ((0, 0), (0, 0), (0, 0), (0, K_PADSIZE - K)))
+        gk_t = jnp.transpose(gk_fp32, (0, 2, 1, 3))
+    else:
+        gk_t = None
+
+    if initial_state is not None:
+        h0 = initial_state
+        if V_ALIGNED > V:
+            h0 = jnp.pad(h0, ((0, 0), (0, 0), (0, 0), (0, V_ALIGNED - V)))
+        if K_PADSIZE > K:
+            h0 = jnp.pad(h0, ((0, 0), (0, 0), (0, K_PADSIZE - K), (0, 0)))
+    else:
+        h0 = None
+
+    g_pad_size = g_t.shape[-1] if g_t is not None else 128
+    h_spec = jax.ShapeDtypeStruct([B, NT, H, K_PADSIZE, V_ALIGNED], k.dtype)
+    v_new_spec = jax.ShapeDtypeStruct([B, H, T, V_ALIGNED], jnp.float32) if save_new_value else None
+    ht_spec = (
+        jax.ShapeDtypeStruct([N, H, K_PADSIZE, V_ALIGNED], jnp.float32)
+        if output_final_state
+        else None
+    )
+
+    def _t_index_map(h, nt, seq_ids_ref, is_first_ref, is_last_ref):
+        return (0, h, nt, 0)
+
+    def _h_index_map(h, nt, seq_ids_ref, is_first_ref, is_last_ref):
+        return (0, nt, h, 0, 0)
+
+    def _state_index_map(h, nt, seq_ids_ref, is_first_ref, is_last_ref):
+        return (seq_ids_ref[nt], h, 0, 0)
+
+    k_blockspec = pl.BlockSpec([1, 1, BT, K_PADSIZE], index_map=_t_index_map)
+    v_blockspec = pl.BlockSpec([1, 1, BT, V_ALIGNED], index_map=_t_index_map)
+    w_blockspec = pl.BlockSpec([1, 1, BT, K_PADSIZE], index_map=_t_index_map)
+    g_blockspec = (
+        pl.BlockSpec([1, 1, BT, g_pad_size], index_map=_t_index_map) if g is not None else None
+    )
+    gk_blockspec = (
+        pl.BlockSpec([1, 1, BT, K_PADSIZE], index_map=_t_index_map) if gk is not None else None
+    )
+    h0_blockspec = (
+        pl.BlockSpec([1, 1, K_PADSIZE, V_ALIGNED], index_map=_state_index_map)
+        if initial_state is not None
+        else None
+    )
+
+    h_blockspec_out = pl.BlockSpec([1, 1, 1, K_PADSIZE, V_ALIGNED], index_map=_h_index_map)
+    v_new_blockspec_out = (
+        pl.BlockSpec([1, 1, BT, V_ALIGNED], index_map=_t_index_map) if save_new_value else None
+    )
+    ht_blockspec_out = (
+        pl.BlockSpec([1, 1, K_PADSIZE, V_ALIGNED], index_map=_state_index_map)
+        if output_final_state
+        else None
+    )
+
+    scratch = pltpu.VMEM((K_PADSIZE, V_ALIGNED), jnp.float32)
+    grid = (H, NT)
+    interpret = get_interpret()
+
+    h_out, v_new_out, ht_out = pl.pallas_call(
+        functools.partial(
+            _chunk_gated_delta_rule_fwd_kernel_flat,
+            USE_G=(g is not None),
+            USE_GK=(gk is not None),
+            USE_INITIAL_STATE=(initial_state is not None),
+            STORE_FINAL_STATE=output_final_state,
+            SAVE_NEW_VALUE=save_new_value,
+            USE_EXP2=use_exp2,
+        ),
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=3,
+            grid=grid,
+            in_specs=[
+                k_blockspec,
+                v_blockspec,
+                w_blockspec,
+                g_blockspec,
+                gk_blockspec,
+                h0_blockspec,
+            ],
+            out_specs=[h_blockspec_out, v_new_blockspec_out, ht_blockspec_out],
+            scratch_shapes=[scratch],
+        ),
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "arbitrary")),
+        out_shape=[h_spec, v_new_spec, ht_spec],
+        interpret=interpret,
+    )(seq_ids, is_first, is_last, k_t, v_t, w_t, g_t, gk_t, h0)
+
+    h_out = h_out[:, :, :, :K, :V]
+    v_new_out = jnp.transpose(v_new_out[:, :, :, :V], (0, 2, 1, 3)) if save_new_value else None
+    ht_out = ht_out[:, :, :K, :V] if output_final_state else None
+
+    return h_out, v_new_out, ht_out
+
+
+def _chunk_kda_fused_h_o_kernel(
+    seq_id_ref,  # [NC] prefetch: owning sequence, consumed only by index_map
+    start_flag_ref,  # [NC] prefetch: first chunk of a sequence; resets state
+    end_flag_ref,  # [NC] prefetch: last chunk of a sequence; writes final_state
+    q_ref,  # [1, 1, BT, K]
+    k_ref,  # [1, 1, BT, K]   kg from stage 2 (k * exp2(g_last - g))
+    v_ref,  # [1, 1, BT, V]   u from stage 2 (corrected values)
+    w_ref,  # [1, 1, BT, K]
+    g_ref,  # [1, 1, BT, K]   g_cumsum (fp32, log2 domain)
+    A_ref,  # [1, 1, BT, BT]  Aqk from stage 2
+    h0_ref,  # [1, 1, K, V] or None
+    o_ref,  # [1, 1, BT, V] out
+    ht_ref,  # [1, 1, K, V] out or None
+    scratch_ref,  # [K, V] f32, persistent hidden state
+    *,
+    scale,
+    USE_INITIAL_STATE,
+    STORE_FINAL_STATE,
+):
+    """Run a flat chunk grid (flat_grid=True) with grid=(H, NC).
+
+    The c dimension advances serially in packed order, so total work is
+    O(chunks), independent of sequence count N. Start/end flags mark sequence
+    boundaries. Inputs for inactive chunks are zero from K1, making their
+    residual and state updates no-ops.
+    """
+    idx_c = pl.program_id(1)
+    K, V = k_ref.shape[-1], v_ref.shape[-1]
+
+    @pl.when(start_flag_ref[idx_c] == 1)
+    def _():
+        scratch_ref[...] = jnp.zeros([K, V], dtype=jnp.float32)
+        if USE_INITIAL_STATE:
+            scratch_ref[...] = h0_ref[0, 0].astype(jnp.float32)
+
+    _fused_h_o_chunk_step(q_ref, k_ref, v_ref, w_ref, g_ref, A_ref, o_ref, scratch_ref, scale)
+
+    @pl.when(end_flag_ref[idx_c] == 1)
+    def _():
+        if STORE_FINAL_STATE:
+            ht_ref[0, 0] = scratch_ref[...].astype(ht_ref.dtype)
+
+
+def _chunk_kda_fused_h_o_kernel_seqgrid(
+    seqlens_ref,  # [N+1] prefetch: cu_seqlens
+    q_ref,
+    k_ref,
+    v_ref,
+    w_ref,
+    g_ref,
+    A_ref,
+    h0_ref,
+    o_ref,
+    ht_ref,
+    scratch_ref,
+    *,
+    scale,
+    USE_INITIAL_STATE,
+    STORE_FINAL_STATE,
+):
+    """Run the legacy (N, H, NT_max) grid for flat_grid=False ablation.
+
+    Every sequence scans the global chunk range. Steps where nt >= real_NT
+    remain idle but still incur grid and DMA costs, producing O(N x chunks)
+    scheduling overhead.
+    """
+    idx_n = pl.program_id(0)
+    idx_nt = pl.program_id(2)
+
+    bos = seqlens_ref[idx_n]
+    eos = seqlens_ref[idx_n + 1]
+    BT = k_ref.shape[2]
+    real_NT = (eos - bos) // BT
+    K, V = k_ref.shape[-1], v_ref.shape[-1]
+
+    @pl.when(idx_nt == 0)
+    def _():
+        scratch_ref[...] = jnp.zeros([K, V], dtype=jnp.float32)
+        if USE_INITIAL_STATE:
+            scratch_ref[...] = h0_ref[0, 0].astype(jnp.float32)
+
+    @pl.when(idx_nt < real_NT)
+    def _():
+        _fused_h_o_chunk_step(q_ref, k_ref, v_ref, w_ref, g_ref, A_ref, o_ref, scratch_ref, scale)
+
+    @pl.when(idx_nt == real_NT - 1)
+    def _():
+        if STORE_FINAL_STATE:
+            ht_ref[0, 0] = scratch_ref[...].astype(ht_ref.dtype)

--- a/python/sgl_jax/srt/kernels/kda/v2/fused.py
+++ b/python/sgl_jax/srt/kernels/kda/v2/fused.py
@@ -1,0 +1,256 @@
+"""Fused KDA v2 recurrence and output kernels."""
+
+from __future__ import annotations
+
+import functools
+
+import jax
+import jax.experimental.pallas as pl
+import jax.numpy as jnp
+from jax.experimental.pallas import tpu as pltpu
+
+from sgl_jax.srt.kernels.kda.kda import align_up, exp2, get_interpret
+
+
+def _fused_step_math(q, kk, v, w, g, A, S, scale):
+    """Run one fused recurrence step for one head and chunk.
+
+    Returns o [BT,V] and S_new [K,V].
+    """
+    BT = q.shape[0]
+    b_v = jnp.dot(
+        w.astype(jnp.float32),
+        S,
+        precision=jax.lax.Precision.HIGHEST,
+        preferred_element_type=jnp.float32,
+    )
+    b_v = v.astype(jnp.float32) - b_v  # [BT, V] delta-rule residual (formerly v_new)
+
+    b_g = g.astype(jnp.float32)
+    b_g_ref = b_g[0:1, :]
+    b_qg = q.astype(jnp.float32) * exp2(jnp.maximum(b_g - b_g_ref, -126.0))
+    b_h_scaled = S * exp2(jnp.maximum(b_g_ref[0], -126.0))[:, None]
+    b_o = scale * jnp.dot(
+        b_qg,
+        b_h_scaled,
+        precision=jax.lax.Precision.HIGHEST,
+        preferred_element_type=jnp.float32,
+    )
+    m_s = jnp.arange(BT)[:, None] >= jnp.arange(BT)[None, :]
+    b_A = jnp.where(m_s, A.astype(jnp.float32), 0.0)
+    b_o += jnp.dot(
+        b_A, b_v, precision=jax.lax.Precision.HIGHEST, preferred_element_type=jnp.float32
+    )
+
+    S_new = S * exp2(b_g[BT - 1])[:, None] + jnp.dot(
+        kk.astype(jnp.float32).T,
+        b_v,
+        precision=jax.lax.Precision.HIGHEST,
+        preferred_element_type=jnp.float32,
+    )
+    return b_o, S_new
+
+
+def _fused_h_o_chunk_step(q_ref, k_ref, v_ref, w_ref, g_ref, A_ref, o_ref, scratch_ref, scale):
+    """Legacy-layout wrapper that reads [1,1,BT,*] refs and writes the result."""
+    b_o, S_new = _fused_step_math(
+        q_ref[0, 0],
+        k_ref[0, 0],
+        v_ref[0, 0],
+        w_ref[0, 0],
+        g_ref[0, 0],
+        A_ref[0, 0],
+        scratch_ref[...],
+        scale,
+    )
+    o_ref[0, 0] = b_o.astype(o_ref.dtype)
+    scratch_ref[...] = S_new
+
+
+def chunk_kda_fused_h_o(
+    q,  # unified_in=True: [1, H, T, K]; False: [1, T, H, K]
+    kg,
+    w,
+    u,
+    g_cumsum,
+    A,
+    scale,
+    initial_state=None,
+    output_final_state=False,
+    chunk_size=64,
+    cu_seqlens=None,
+    unified_in=True,
+    flat_grid=True,
+):
+    # Import locally because flat_grid reuses the fused chunk math above.
+    from sgl_jax.srt.kernels.kda.v2.flat_grid import (
+        _chunk_kda_fused_h_o_kernel,
+        _chunk_kda_fused_h_o_kernel_seqgrid,
+    )
+
+    BT = chunk_size
+    assert cu_seqlens is not None
+    N = cu_seqlens.shape[-1] - 1
+
+    if unified_in:
+        B, H, T_out, K = q.shape
+        V = u.shape[-1]
+        assert B == 1 and T_out % BT == 0
+        K_PADSIZE = int(align_up(K, 128))
+        V_ALIGNED = int(align_up(V, 128))
+
+        def _padlast(x, D, D_pad):
+            if D_pad > D:
+                return jnp.pad(x, ((0, 0), (0, 0), (0, 0), (0, D_pad - D)))
+            return x
+
+        q_t = _padlast(q, K, K_PADSIZE)
+        k_t = _padlast(kg, K, K_PADSIZE)
+        w_t = _padlast(w, K, K_PADSIZE)
+        v_t = _padlast(u, V, V_ALIGNED)
+        g_t = _padlast(g_cumsum, K, K_PADSIZE)
+        A_t = A
+        if not flat_grid:
+            # The legacy grid needs a trailing trash block as its clamp target.
+            pad_t = lambda x: jnp.pad(x, ((0, 0), (0, 0), (0, BT), (0, 0)))
+            q_t, k_t, w_t, v_t, g_t, A_t = map(pad_t, (q_t, k_t, w_t, v_t, g_t, A_t))
+    else:
+        # Legacy _prep for the data-movement ablation: materialize fp32,
+        # append a trailing pad, and transpose the [1,T,H,D] input.
+        B, T_out, H, K = q.shape
+        V = u.shape[-1]
+        assert B == 1 and T_out % BT == 0
+        K_PADSIZE = int(align_up(K, 128))
+        V_ALIGNED = int(align_up(V, 128))
+
+        def _prep(x, D, D_pad):
+            x = x.astype(jnp.float32) if x.dtype != jnp.float32 else x
+            if D_pad > D:
+                x = jnp.pad(x, ((0, 0), (0, 0), (0, 0), (0, D_pad - D)))
+            x = jnp.pad(x, ((0, 0), (0, BT), (0, 0), (0, 0)))
+            return jnp.transpose(x, (0, 2, 1, 3))  # [1, H, T+BT, D_pad]
+
+        q_t = _prep(q, K, K_PADSIZE)
+        k_t = _prep(kg, K, K_PADSIZE)
+        w_t = _prep(w, K, K_PADSIZE)
+        v_t = _prep(u, V, V_ALIGNED)
+        g_t = _prep(g_cumsum, K, K_PADSIZE)
+        A_t = _prep(A, BT, BT)
+
+    T_pad = q_t.shape[2]
+
+    if initial_state is not None:
+        h0 = initial_state
+        if V_ALIGNED > V:
+            h0 = jnp.pad(h0, ((0, 0), (0, 0), (0, 0), (0, V_ALIGNED - V)))
+        if K_PADSIZE > K:
+            h0 = jnp.pad(h0, ((0, 0), (0, 0), (0, K_PADSIZE - K), (0, 0)))
+    else:
+        h0 = None
+
+    ht_spec = (
+        jax.ShapeDtypeStruct([N, H, K_PADSIZE, V_ALIGNED], jnp.float32)
+        if output_final_state
+        else None
+    )
+    scratch = pltpu.VMEM((K_PADSIZE, V_ALIGNED), jnp.float32)
+    kernel_kw = dict(
+        scale=scale,
+        USE_INITIAL_STATE=(initial_state is not None),
+        STORE_FINAL_STATE=output_final_state,
+    )
+    cu_i32 = cu_seqlens.astype(jnp.int32)
+
+    if flat_grid:
+        # Flat grid: O(chunks), with sequence identity in three prefetched scalars.
+        NC = T_pad // BT
+        chunk_bos = jnp.arange(NC, dtype=jnp.int32) * BT
+        seq_id = jnp.clip(jnp.searchsorted(cu_i32[1:], chunk_bos, side="right"), 0, N - 1).astype(
+            jnp.int32
+        )
+        start_flag = (chunk_bos == cu_i32[seq_id]).astype(jnp.int32)
+        end_flag = (chunk_bos + BT == cu_i32[seq_id + 1]).astype(jnp.int32)
+
+        _state_index_map = lambda h, c, seq_id_ref, *_: (seq_id_ref[c], h, 0, 0)
+        tspec = lambda D: pl.BlockSpec([1, 1, BT, D], index_map=lambda h, c, *_: (0, h, c, 0))
+        h0_blockspec = (
+            pl.BlockSpec([1, 1, K_PADSIZE, V_ALIGNED], index_map=_state_index_map)
+            if initial_state is not None
+            else None
+        )
+        ht_blockspec = (
+            pl.BlockSpec([1, 1, K_PADSIZE, V_ALIGNED], index_map=_state_index_map)
+            if output_final_state
+            else None
+        )
+
+        o_out, ht_out = pl.pallas_call(
+            functools.partial(_chunk_kda_fused_h_o_kernel, **kernel_kw),
+            grid_spec=pltpu.PrefetchScalarGridSpec(
+                num_scalar_prefetch=3,
+                grid=(H, NC),
+                in_specs=[
+                    tspec(K_PADSIZE),
+                    tspec(K_PADSIZE),
+                    tspec(V_ALIGNED),
+                    tspec(K_PADSIZE),
+                    tspec(K_PADSIZE),
+                    tspec(BT),
+                    h0_blockspec,
+                ],
+                out_specs=[tspec(V_ALIGNED), ht_blockspec],
+                scratch_shapes=[scratch],
+            ),
+            compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "arbitrary")),
+            out_shape=[jax.ShapeDtypeStruct([1, H, T_pad, V_ALIGNED], jnp.float32), ht_spec],
+            interpret=get_interpret(),
+        )(seq_id, start_flag, end_flag, q_t, k_t, v_t, w_t, g_t, A_t, h0)
+    else:
+        # Legacy (N, H, NT_max) ablation grid: O(N x chunks).
+        T_ref = T_pad - BT  # Logical T; block T_ref//BT is the clamp target.
+        NT_max = T_ref // BT
+
+        def _t_index_map(n, h, nt, seqlens_ref):
+            bos = pl.multiple_of(seqlens_ref[n], BT)
+            return (0, h, jnp.minimum(bos // BT + nt, T_ref // BT), 0)
+
+        _state_index_map = lambda n, h, nt, *_: (n, h, 0, 0)
+        tspec = lambda D: pl.BlockSpec([1, 1, BT, D], index_map=_t_index_map)
+        h0_blockspec = (
+            pl.BlockSpec([1, 1, K_PADSIZE, V_ALIGNED], index_map=_state_index_map)
+            if initial_state is not None
+            else None
+        )
+        ht_blockspec = (
+            pl.BlockSpec([1, 1, K_PADSIZE, V_ALIGNED], index_map=_state_index_map)
+            if output_final_state
+            else None
+        )
+
+        o_out, ht_out = pl.pallas_call(
+            functools.partial(_chunk_kda_fused_h_o_kernel_seqgrid, **kernel_kw),
+            grid_spec=pltpu.PrefetchScalarGridSpec(
+                num_scalar_prefetch=1,
+                grid=(N, H, NT_max),
+                in_specs=[
+                    tspec(K_PADSIZE),
+                    tspec(K_PADSIZE),
+                    tspec(V_ALIGNED),
+                    tspec(K_PADSIZE),
+                    tspec(K_PADSIZE),
+                    tspec(BT),
+                    h0_blockspec,
+                ],
+                out_specs=[tspec(V_ALIGNED), ht_blockspec],
+                scratch_shapes=[scratch],
+            ),
+            compiler_params=pltpu.CompilerParams(
+                dimension_semantics=("parallel", "parallel", "arbitrary")
+            ),
+            out_shape=[jax.ShapeDtypeStruct([1, H, T_pad, V_ALIGNED], jnp.float32), ht_spec],
+            interpret=get_interpret(),
+        )(cu_i32, q_t, k_t, v_t, w_t, g_t, A_t, h0)
+
+    o = jnp.transpose(o_out[:, :, :T_out, :V], (0, 2, 1, 3))
+    ht_out = ht_out[:, :, :K, :V] if output_final_state else None
+    return o, ht_out

--- a/python/sgl_jax/srt/kernels/kda/v2/head_block.py
+++ b/python/sgl_jax/srt/kernels/kda/v2/head_block.py
@@ -1,0 +1,358 @@
+"""Native-layout head-block KDA v2 kernels."""
+
+from __future__ import annotations
+
+import functools
+import math
+
+import jax
+import jax.experimental.pallas as pl
+import jax.numpy as jnp
+from jax.experimental.pallas import tpu as pltpu
+
+from sgl_jax.srt.kernels.kda.kda import _RCP_LN2, _intra_head_math, exp2, get_interpret
+
+
+def _kda_fwd_intra_kernel_hb(
+    q_ref,  # [1, BT, H, K]
+    k_ref,  # [1, BT, H, K]
+    g_ref,  # [1, BT, H, K]
+    beta_ref,  # [1, BT, H, 1]
+    v_ref,  # [1, BT, H, V]
+    a_ref,  # [H, K] or None
+    bias_ref,  # [H, K] or None
+    u_out_ref,  # [1, BT, H, V]
+    w_out_ref,  # [1, BT, H, K]
+    kg_out_ref,  # [1, BT, H, K]
+    Aqk_out_ref,  # [1, BT, H, BT]
+    g_cum_out_ref,  # [1, BT, H, K] f32
+    *,
+    chunk_size,
+    head_dim,
+    value_dim,
+    scale,
+    safe_gate,
+    APPLY_GATE,
+    LOWER_BOUND,
+    NUM_HEADS,
+):
+    if not safe_gate:
+        # Debug path (elementwise decay plus row-wise elimination): process
+        # heads serially and keep _intra_head_math as the single source.
+        for h in range(NUM_HEADS):
+            a_vec = a_ref[h] if APPLY_GATE else None
+            bias_vec = bias_ref[h] if APPLY_GATE else None
+            u, w, kg, Aqk, _, g_cum = _intra_head_math(
+                q_ref[0, :, h, :],
+                k_ref[0, :, h, :],
+                g_ref[0, :, h, :],
+                beta_ref[0, :, h, :],
+                v_ref[0, :, h, :],
+                a_vec,
+                bias_vec,
+                chunk_size=chunk_size,
+                head_dim=head_dim,
+                value_dim=value_dim,
+                scale=scale,
+                safe_gate=safe_gate,
+                APPLY_GATE=APPLY_GATE,
+                LOWER_BOUND=LOWER_BOUND,
+                PRE_CUMSUM=False,
+                WANT_AINV=False,
+            )
+            u_out_ref[0, :, h, :] = u.astype(u_out_ref.dtype)
+            w_out_ref[0, :, h, :] = w.astype(w_out_ref.dtype)
+            kg_out_ref[0, :, h, :] = kg.astype(kg_out_ref.dtype)
+            Aqk_out_ref[0, :, h, :] = Aqk.astype(Aqk_out_ref.dtype)
+            g_cum_out_ref[0, :, h, :] = g_cum.astype(g_cum_out_ref.dtype)
+        return
+
+    # ---- safe_gate fast path: vectorize elementwise work across H and
+    # interleave MXU stages. Each head is independent. Stage-major issue
+    # traverses h within a stage, so adjacent MXU instructions have no data
+    # dependency and can pipeline fill/drain. Elementwise work handles all
+    # heads together, reducing instruction count by H. ----
+    BT = chunk_size
+    H = NUM_HEADS
+    # Stage 1: gate activation and prefix sum, vectorized across H.
+    g_all = g_ref[0].astype(jnp.float32)  # [BT, H, K]
+    if APPLY_GATE:
+        a_all = a_ref[...].astype(jnp.float32)  # [H, K]
+        b_all = bias_ref[...].astype(jnp.float32)
+        g_all = LOWER_BOUND * jax.nn.sigmoid(a_all[None] * (g_all + b_all[None]))
+    num_steps = int(math.log2(BT))
+    assert (1 << num_steps) == BT
+    for d in range(num_steps):
+        s = 1 << d
+        g_all = jnp.concatenate([g_all[:s], g_all[s:] + g_all[:-s]], axis=0)
+    g_all = g_all * _RCP_LN2
+    g_cum_out_ref[0] = g_all.astype(g_cum_out_ref.dtype)
+
+    q_all = q_ref[0].astype(jnp.float32)
+    k_all = k_ref[0].astype(jnp.float32)
+    v_all = v_ref[0].astype(jnp.float32)
+    beta_all = beta_ref[0].astype(jnp.float32)  # [BT, H, 1]
+
+    # Build strip rows/columns vectorized across H; interleave GEMMs by (blk, h).
+    SB = 16
+    o_i = jnp.arange(BT, dtype=jnp.int32)
+    causal = o_i[:, None] >= o_i[None, :]
+    strict = o_i[:, None] > o_i[None, :]
+    dn = (((1,), (1,)), ((), ()))
+    aqk_parts = [[] for _ in range(H)]
+    l_parts = [[] for _ in range(H)]
+    for blk in range(BT // SB):
+        cols = slice(blk * SB, (blk + 1) * SB)
+        r_b = g_all[blk * SB + SB // 2 : blk * SB + SB // 2 + 1]  # [1, H, K]
+        row_all = exp2(g_all - r_b)  # [BT, H, K]
+        col_all = k_all[cols] * exp2(r_b - g_all[cols])  # [SB, H, K]
+        qrow = q_all * row_all
+        krow = k_all * row_all
+        for h in range(H):
+            aqk_parts[h].append(
+                jax.lax.dot_general(
+                    qrow[:, h], col_all[:, h], dn, preferred_element_type=jnp.float32
+                )
+            )
+            l_parts[h].append(
+                jax.lax.dot_general(
+                    krow[:, h], col_all[:, h], dn, preferred_element_type=jnp.float32
+                )
+            )
+
+    v_beta = v_all * beta_all  # [BT, H, V]
+    k_eg_beta = k_all * exp2(g_all) * beta_all  # [BT, H, K]
+
+    Aqks, Ls, zs = [], [], []
+    for h in range(H):
+        Aqks.append(jnp.where(causal, scale * jnp.concatenate(aqk_parts[h], -1), 0.0))
+        Ls.append(jnp.where(strict, jnp.concatenate(l_parts[h], -1), 0.0) * beta_all[:, h])
+        zs.append(jnp.concatenate([v_beta[:, h], k_eg_beta[:, h]], axis=-1))
+
+    # Fused-wide Neumann factor chain with stages interleaved across H.
+    zs = [z - jax.lax.dot(L, z, preferred_element_type=jnp.float32) for L, z in zip(Ls, zs)]
+    Lp = list(Ls)
+    for _ in range(int(math.log2(BT)) - 1):
+        Lp = [jax.lax.dot(P, P, preferred_element_type=jnp.float32) for P in Lp]
+        zs = [z + jax.lax.dot(P, z, preferred_element_type=jnp.float32) for P, z in zip(Lp, zs)]
+
+    # Assemble outputs and write them back vectorized across H.
+    u_all = jnp.stack([z[:, :value_dim] for z in zs], axis=1)
+    w_all = jnp.stack([z[:, value_dim:] for z in zs], axis=1)
+    kg_all = k_all * exp2(g_all[BT - 1 : BT] - g_all)
+    u_out_ref[0] = u_all.astype(u_out_ref.dtype)
+    w_out_ref[0] = w_all.astype(w_out_ref.dtype)
+    kg_out_ref[0] = kg_all.astype(kg_out_ref.dtype)
+    Aqk_out_ref[0] = jnp.stack(Aqks, axis=1).astype(Aqk_out_ref.dtype)
+
+
+def kda_fwd_intra_hb(
+    q,
+    k,
+    v,
+    gk,
+    beta,
+    scale,
+    chunk_size=64,
+    safe_gate=False,
+    use_gate_in_kernel=False,
+    A_log=None,
+    dt_bias=None,
+    lower_bound=None,
+):
+    """Run head-block K1 with native [1, T, H, D] I/O and grid=(NC,)."""
+    B, T, H, K = q.shape
+    V = v.shape[-1]
+    BT = chunk_size
+    assert B == 1 and T % BT == 0 and H % 8 == 0
+    NC = T // BT
+
+    beta4 = beta.reshape(B, T, H, 1)
+    if use_gate_in_kernel:
+        assert A_log is not None
+        a_r = jnp.broadcast_to(jnp.exp(A_log.astype(jnp.float32))[:, None], (H, K))
+        bias_r = (
+            jnp.zeros((H, K), jnp.float32)
+            if dt_bias is None
+            else dt_bias.astype(jnp.float32).reshape(H, K)
+        )
+        gate_spec = pl.BlockSpec(block_shape=(H, K), index_map=lambda c: (0, 0))
+    else:
+        a_r, bias_r, gate_spec = None, None, None
+
+    def _spec(last_dim):
+        return pl.BlockSpec(block_shape=(1, BT, H, last_dim), index_map=lambda c: (0, c, 0, 0))
+
+    dt = q.dtype
+    u4, w4, kg4, Aqk4, g_cum4 = pl.pallas_call(
+        functools.partial(
+            _kda_fwd_intra_kernel_hb,
+            chunk_size=BT,
+            head_dim=K,
+            value_dim=V,
+            scale=scale,
+            safe_gate=safe_gate,
+            APPLY_GATE=use_gate_in_kernel,
+            LOWER_BOUND=lower_bound,
+            NUM_HEADS=H,
+        ),
+        interpret=get_interpret(),
+        out_shape=[
+            jax.ShapeDtypeStruct((1, T, H, V), dt),
+            jax.ShapeDtypeStruct((1, T, H, K), dt),
+            jax.ShapeDtypeStruct((1, T, H, K), dt),
+            jax.ShapeDtypeStruct((1, T, H, BT), dt),
+            jax.ShapeDtypeStruct((1, T, H, K), jnp.float32),
+        ],
+        in_specs=[_spec(K), _spec(K), _spec(K), _spec(1), _spec(V), gate_spec, gate_spec],
+        out_specs=[_spec(V), _spec(K), _spec(K), _spec(BT), _spec(K)],
+        grid=(NC,),
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel",)),
+    )(q, k, gk, beta4, v, a_r, bias_r)
+    return w4, u4, kg4, Aqk4, g_cum4
+
+
+def _chunk_kda_fused_h_o_kernel_hb(
+    seq_id_ref,  # [NC] prefetch
+    start_flag_ref,  # [NC]
+    end_flag_ref,  # [NC]
+    q_ref,  # [1, BT, H, K]
+    k_ref,  # [1, BT, H, K]  kg
+    v_ref,  # [1, BT, H, V]  u
+    w_ref,  # [1, BT, H, K]
+    g_ref,  # [1, BT, H, K]  g_cumsum f32
+    A_ref,  # [1, BT, H, BT]
+    h0_ref,  # [1, H, K, V] or None
+    o_ref,  # [1, BT, H, V] out, stored directly in input dtype
+    ht_ref,  # [1, H, K, V] out or None
+    scratch_ref,  # [H, K, V] fp32, with all head states resident in VMEM
+    *,
+    scale,
+    USE_INITIAL_STATE,
+    STORE_FINAL_STATE,
+    NUM_HEADS,
+):
+    idx_c = pl.program_id(0)
+
+    @pl.when(start_flag_ref[idx_c] == 1)
+    def _():
+        scratch_ref[...] = jnp.zeros_like(scratch_ref)
+        if USE_INITIAL_STATE:
+            scratch_ref[...] = h0_ref[0].astype(jnp.float32)
+
+    # Vectorize elementwise work across H and interleave MXU issue by stage:
+    # A computes residuals, B/C compute o, and D updates state.
+    q_all = q_ref[0].astype(jnp.float32)  # [BT, H, K]
+    k_all = k_ref[0].astype(jnp.float32)
+    v_all = v_ref[0].astype(jnp.float32)  # [BT, H, V]
+    w_all = w_ref[0].astype(jnp.float32)
+    g_all = g_ref[0].astype(jnp.float32)
+    A_all = A_ref[0].astype(jnp.float32)  # [BT, H, BT]
+    S_all = scratch_ref[...]  # [H, K, V]
+
+    BT = q_ref.shape[1]
+    g0 = g_all[0:1]  # [1, H, K]
+    qg_all = q_all * exp2(jnp.maximum(g_all - g0, -126.0))
+    h_scale = exp2(jnp.maximum(g0[0], -126.0))  # [H, K]
+    g_last = g_all[BT - 1]  # [H, K]
+    m_s = jnp.arange(BT)[:, None] >= jnp.arange(BT)[None, :]
+    A_mask = jnp.where(m_s[:, None, :], A_all, 0.0)  # [BT, H, BT]
+
+    HI = jax.lax.Precision.HIGHEST
+    bv = [
+        v_all[:, h]
+        - jnp.dot(w_all[:, h], S_all[h], precision=HI, preferred_element_type=jnp.float32)
+        for h in range(NUM_HEADS)
+    ]
+    o1 = [
+        scale
+        * jnp.dot(
+            qg_all[:, h],
+            S_all[h] * h_scale[h][:, None],
+            precision=HI,
+            preferred_element_type=jnp.float32,
+        )
+        for h in range(NUM_HEADS)
+    ]
+    o2 = [
+        jnp.dot(A_mask[:, h], bv[h], precision=HI, preferred_element_type=jnp.float32)
+        for h in range(NUM_HEADS)
+    ]
+    o_ref[0] = jnp.stack([a + b for a, b in zip(o1, o2)], axis=1).astype(o_ref.dtype)
+
+    upd = [
+        jnp.dot(k_all[:, h].T, bv[h], precision=HI, preferred_element_type=jnp.float32)
+        for h in range(NUM_HEADS)
+    ]
+    scratch_ref[...] = S_all * exp2(g_last)[:, :, None] + jnp.stack(upd, axis=0)
+
+    @pl.when(end_flag_ref[idx_c] == 1)
+    def _():
+        if STORE_FINAL_STATE:
+            ht_ref[0] = scratch_ref[...].astype(ht_ref.dtype)
+
+
+def chunk_kda_fused_h_o_hb(
+    q,
+    kg,
+    w,
+    u,
+    g_cumsum,
+    A,
+    scale,
+    initial_state=None,
+    output_final_state=False,
+    chunk_size=64,
+    cu_seqlens=None,
+):
+    """Run head-block K2 serially over grid=(NC,) with native [1,T,H,D] input.
+
+    The output o is stored directly in the input dtype.
+    """
+    B, T, H, K = q.shape
+    V = u.shape[-1]
+    BT = chunk_size
+    assert cu_seqlens is not None
+    assert B == 1 and T % BT == 0 and H % 8 == 0
+    N = cu_seqlens.shape[-1] - 1
+    NC = T // BT
+
+    cu_i32 = cu_seqlens.astype(jnp.int32)
+    chunk_bos = jnp.arange(NC, dtype=jnp.int32) * BT
+    seq_id = jnp.clip(jnp.searchsorted(cu_i32[1:], chunk_bos, side="right"), 0, N - 1).astype(
+        jnp.int32
+    )
+    start_flag = (chunk_bos == cu_i32[seq_id]).astype(jnp.int32)
+    end_flag = (chunk_bos + BT == cu_i32[seq_id + 1]).astype(jnp.int32)
+
+    def _spec(last_dim):
+        return pl.BlockSpec(block_shape=(1, BT, H, last_dim), index_map=lambda c, *_: (0, c, 0, 0))
+
+    _state_map = lambda c, seq_id_ref, *_: (seq_id_ref[c], 0, 0, 0)
+    h0_blockspec = (
+        pl.BlockSpec([1, H, K, V], index_map=_state_map) if initial_state is not None else None
+    )
+    ht_blockspec = pl.BlockSpec([1, H, K, V], index_map=_state_map) if output_final_state else None
+    ht_spec = jax.ShapeDtypeStruct([N, H, K, V], jnp.float32) if output_final_state else None
+
+    o_out, ht_out = pl.pallas_call(
+        functools.partial(
+            _chunk_kda_fused_h_o_kernel_hb,
+            scale=scale,
+            USE_INITIAL_STATE=(initial_state is not None),
+            STORE_FINAL_STATE=output_final_state,
+            NUM_HEADS=H,
+        ),
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=3,
+            grid=(NC,),
+            in_specs=[_spec(K), _spec(K), _spec(V), _spec(K), _spec(K), _spec(BT), h0_blockspec],
+            out_specs=[_spec(V), ht_blockspec],
+            scratch_shapes=[pltpu.VMEM((H, K, V), jnp.float32)],
+        ),
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("arbitrary",)),
+        out_shape=[jax.ShapeDtypeStruct([1, T, H, V], q.dtype), ht_spec],
+        interpret=get_interpret(),
+    )(seq_id, start_flag, end_flag, q, kg, u, w, g_cumsum, A, initial_state)
+
+    return o_out, ht_out

--- a/python/sgl_jax/srt/kernels/kda/v2/unified_layout.py
+++ b/python/sgl_jax/srt/kernels/kda/v2/unified_layout.py
@@ -1,0 +1,97 @@
+"""Layout transforms used by the fused KDA v2 kernels."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+
+def to_unified_layout(x: jax.Array) -> jax.Array:
+    """Convert [B, T, H, D] to [B, H, T, D]."""
+    return jnp.transpose(x, (0, 2, 1, 3))
+
+
+def from_unified_layout(x: jax.Array) -> jax.Array:
+    """Convert [B, H, T, D] to [B, T, H, D]."""
+    return jnp.transpose(x, (0, 2, 1, 3))
+
+
+def prepare_intra_layout(q, k, v, gk, beta, chunk_size, unified_layout, cu_seqlens):
+    """Prepare K1 inputs and return the metadata needed to restore outputs."""
+    BT = chunk_size
+    if unified_layout:
+        B, H, T_u, K = q.shape
+        V = v.shape[-1]
+        assert B == 1 and T_u % BT == 0
+        NC = T_u // BT
+        return (q, k, gk, beta, v), (B, H, K, V, NC, None)
+
+    B, T, H, K = q.shape
+    V = v.shape[-1]
+    assert B == 1
+    assert cu_seqlens is not None, "unified_layout=False needs cu_seqlens for gather"
+    N = cu_seqlens.shape[0] - 1
+    T_alloc = T + BT
+
+    pad4d = lambda x: jnp.pad(x, ((0, 0), (0, BT), (0, 0), (0, 0)))
+    q_pad, k_pad, g_pad, v_pad = pad4d(q), pad4d(k), pad4d(gk), pad4d(v)
+    beta_pad = jnp.pad(beta.reshape(B, T, H, 1), ((0, 0), (0, BT), (0, 0), (0, 0)))
+
+    cu_i32 = cu_seqlens.astype(jnp.int32)
+    chunks_per_seq = (jnp.diff(cu_i32) + BT - 1) // BT
+    cum_chunks = jnp.pad(jnp.cumsum(chunks_per_seq), (1, 0))
+    total_chunks = cum_chunks[-1]
+    NC = T // BT + N
+    flat_idx = jnp.arange(NC, dtype=jnp.int32)
+    is_valid = flat_idx < total_chunks
+    seq_id = jnp.minimum(jnp.searchsorted(cum_chunks[1:], flat_idx, side="right"), N - 1)
+    local_ci = flat_idx - cum_chunks[seq_id]
+    chunk_starts = jnp.where(is_valid, cu_i32[seq_id] + local_ci * BT, 0)
+
+    def gather(x_pad, dim):
+        def extract(start):
+            return jax.lax.dynamic_slice(x_pad, (0, start, 0, 0), (1, BT, H, dim))[0]
+
+        return jax.vmap(extract)(chunk_starts)
+
+    def to_kernel_layout(x_chunks):
+        return x_chunks.transpose(2, 0, 1, 3).reshape(1, H, NC * BT, x_chunks.shape[3])
+
+    inputs = (
+        to_kernel_layout(gather(q_pad, K)),
+        to_kernel_layout(gather(k_pad, K)),
+        to_kernel_layout(gather(g_pad, K)),
+        to_kernel_layout(gather(beta_pad, 1)),
+        to_kernel_layout(gather(v_pad, V)),
+    )
+    restore = (T, T_alloc, chunk_starts, is_valid)
+    return inputs, (B, H, K, V, NC, restore)
+
+
+def restore_intra_layout(outputs, *, chunk_size, layout_metadata):
+    """Restore K1 outputs to [B, T, H, D] for the legacy addressing path."""
+    B, H, K, V, NC, restore = layout_metadata
+    if restore is None:
+        return outputs
+
+    BT = chunk_size
+    T, T_alloc, chunk_starts, is_valid = restore
+    w4, u4, qg4, kg4, Aqk4, Akk4, g_cum4 = outputs
+    pos = chunk_starts[:, None] + jnp.arange(BT)[None, :]
+    pos = jnp.where(is_valid[:, None], pos, T_alloc - 1)
+    flat_pos = pos.reshape(-1)
+
+    def scatter(x4, dim):
+        chunks = x4.reshape(H, NC, BT, dim).transpose(1, 2, 0, 3).reshape(-1, H, dim)
+        out = jnp.zeros((T_alloc, H, dim), dtype=x4.dtype)
+        out = out.at[flat_pos].add(chunks)
+        return out[:T][None]
+
+    w_out = scatter(w4, K)
+    u_out = scatter(u4, V)
+    qg_out = scatter(qg4, K) if qg4 is not None else None
+    kg_out = scatter(kg4, K)
+    Aqk_out = scatter(Aqk4, BT)
+    Akk_out = scatter(Akk4, BT)
+    g_cum_out = scatter(g_cum4, K)
+    return w_out, u_out, qg_out, kg_out, Aqk_out, Akk_out, g_cum_out

--- a/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import jax
@@ -353,6 +354,11 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         A_log = layer.A_log.value.reshape(H)
         dt_bias = layer.dt_bias.value.reshape(H, -1)
         scale = scale if scale is not None else layer.scale
+        # Bounded-gate models (gate_lower_bound is not None) take the safe_gate fast
+        # path; unbounded gates keep the generic path. KDA_FORCE_BASELINE=1 turns every
+        # switch off (== upstream kernel path) for A/B runs with identical gate semantics.
+        lower_bound = getattr(layer, "kda_gate_lower_bound", None)
+        opt_on = os.environ.get("KDA_FORCE_BASELINE") != "1"
 
         def _chunk_kda_call(q, k, v, g, beta, initial_state, cu_seqlens, A_log, dt_bias):
             o, final_state, *_ = chunk_kda(
@@ -368,6 +374,12 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
                 use_gate_in_kernel=True,
                 A_log=A_log,
                 dt_bias=dt_bias,
+                safe_gate=(lower_bound is not None) and opt_on,
+                lower_bound=lower_bound,
+                fuse=opt_on,
+                unified_layout=opt_on,
+                flat_grid=opt_on,
+                head_block=opt_on,
             )
             return o, final_state
 

--- a/python/sgl_jax/srt/models/kimi_linear.py
+++ b/python/sgl_jax/srt/models/kimi_linear.py
@@ -251,6 +251,9 @@ class KimiDeltaAttention(nnx.Module):
             A_log=self.A_log,
             dt_bias=self.dt_bias,
         )
+        # Bounded gate (Kimi-K3-class models): when the config declares gate_lower_bound,
+        # KDA prefill takes the safe_gate path.
+        self.attn.kda_gate_lower_bound = linear_config.get("gate_lower_bound")
 
     def __call__(
         self,

--- a/python/sgl_jax/test/kernels/kda_test.py
+++ b/python/sgl_jax/test/kernels/kda_test.py
@@ -314,7 +314,7 @@ def _full_naive_reference(
     return jnp.concatenate(outputs, axis=1), jnp.stack(final_states, axis=0)
 
 
-def _run_full_32k_case(*, include_zero_length: bool):
+def _run_full_32k_case(*, include_zero_length: bool, lower_bound: float | None = None):
     (
         seq_lens,
         cu_seqlens,
@@ -327,6 +327,11 @@ def _run_full_32k_case(*, include_zero_length: bool):
         dt_bias,
         initial_state,
     ) = _make_full_32k_case(include_zero_length=include_zero_length)
+    if lower_bound is not None:
+        # Drive the bounded gate over its full range: exp(A_log)*(raw_g+dt_bias)
+        # spanning +-20 puts the activated gate at ~0, lower_bound/2 and
+        # ~lower_bound, which is what stresses the strip-GEMM fast path.
+        raw_g = (8.0 * raw_g.astype(jnp.float32)).astype(raw_g.dtype)
 
     scale = _K**-0.5
     optimized_output, optimized_final_state, *_ = chunk_kda(
@@ -343,14 +348,25 @@ def _run_full_32k_case(*, include_zero_length: bool):
         use_gate_in_kernel=True,
         A_log=A_log,
         dt_bias=dt_bias,
+        safe_gate=lower_bound is not None,
+        lower_bound=lower_bound,
     )
     # Materialize the optimized pipeline first so a baseline failure is
     # unambiguously Stage 1 VMEM, not naive-reference compile or host memory.
     jax.block_until_ready((optimized_output, optimized_final_state))
 
-    activated_g = -jnp.exp(A_log.astype(jnp.float32))[None, None, :, None] * (
-        jax.nn.softplus(raw_g.astype(jnp.float32) + dt_bias.astype(jnp.float32)[None, None, :, :])
-    )
+    if lower_bound is None:
+        activated_g = -jnp.exp(A_log.astype(jnp.float32))[None, None, :, None] * (
+            jax.nn.softplus(
+                raw_g.astype(jnp.float32) + dt_bias.astype(jnp.float32)[None, None, :, :]
+            )
+        )
+    else:
+        # Mirrors kda_gate_chunk_cumsum's lower_bound path (and FLA gate.py).
+        activated_g = lower_bound * jax.nn.sigmoid(
+            jnp.exp(A_log.astype(jnp.float32))[None, None, :, None]
+            * (raw_g.astype(jnp.float32) + dt_bias.astype(jnp.float32)[None, None, :, :])
+        )
     reference_output, reference_final_state = _full_naive_reference(
         seq_lens,
         cu_seqlens,
@@ -422,6 +438,45 @@ def test_chunk_kda_32k_no_zero_length_output_and_final_state_match_naive_recurre
     """No-zero full path: logical/aligned/allocated T = 32768/34816/34880."""
     seq_lens, optimized_final_state, reference_final_state = _run_full_32k_case(
         include_zero_length=False
+    )
+
+    nonempty_mask = np.asarray(seq_lens, dtype=np.int32) > 0
+    assert nonempty_mask.shape == (32,)
+    assert nonempty_mask.all()
+    np.testing.assert_allclose(
+        np.asarray(optimized_final_state),
+        np.asarray(reference_final_state),
+        rtol=2e-2,
+        atol=1e-2,
+    )
+
+
+def test_chunk_kda_32k_varlen_lower_bound_matches_naive_recurrent_kda():
+    """Bounded gate (Kimi-K3: lower_bound=-5) through the strip-GEMM intra path.
+
+    Same 33-request varlen fixture as the softplus node, with raw_g widened so
+    the activated gate covers ~0, -2.5 and ~-5 -- the range that distinguishes
+    the safe_gate fast path from the generic decay-tensor path.
+    """
+    seq_lens, optimized_final_state, reference_final_state = _run_full_32k_case(
+        include_zero_length=True, lower_bound=-5.0
+    )
+
+    nonempty_mask = np.asarray(seq_lens, dtype=np.int32) > 0
+    assert nonempty_mask.shape == (33,)
+    assert np.count_nonzero(nonempty_mask) == 32
+    np.testing.assert_allclose(
+        np.asarray(optimized_final_state)[nonempty_mask],
+        np.asarray(reference_final_state)[nonempty_mask],
+        rtol=2e-2,
+        atol=1e-2,
+    )
+
+
+def test_chunk_kda_32k_no_zero_length_lower_bound_matches_naive_recurrent_kda():
+    """Bounded-gate variant of the no-zero-length full path."""
+    seq_lens, optimized_final_state, reference_final_state = _run_full_32k_case(
+        include_zero_length=False, lower_bound=-5.0
     )
 
     nonempty_mask = np.asarray(seq_lens, dtype=np.int32) > 0


### PR DESCRIPTION
## Motivation

Improve KDA TPU prefill performance without changing the `chunk_kda_fwd` API.

## Modifications

- Replace the bounded-gate Aqk/L and triangular solve with MXU strip GEMMs and a finite-Neumann solve (`safe_gate`).
- Fuse gate cumsum with intra and recurrence with output, keeping `h` and `v_new` in VMEM.
- Remove gather/scatter and transpose glue with unified addressing, then flatten the recurrence grid over packed chunks.
- Add a native `[1, T, H, D]` path that processes eight heads per program and interleaves MXU work across stages.
- Omit backward-only intermediates during inference unless explicitly requested.
- Preserve safe fallbacks and expose each optimization through a static ablation switch.

## Accuracy Tests

- `python/sgl_jax/test/kernels/kda_test.py`: 7/7 passed on TPU v6e.
- All 14 supported ablation-switch combinations match the naive reference in interpret mode and on TPU v6e.
- Applying the Neumann factor chain directly to the RHS has a maximum error of `2.77e-4` against the fp32 oracle (`atol=5e-4`), versus `6.9e-4` for bf16 invert-then-multiply.

## Benchmarking and Profiling

Raw data and figure sources: [kda-tpu-bench/results](https://github.com/Junyi-99/kda-tpu-bench/tree/main/results).

### Protocol and variants

- `original`: all five kernel switches off; `mxu_port`: `safe_gate` only; `optimized`: all five switches on.
- The primary grid, ShareGPT, and utilization benchmarks use one TPU v6e chip, `jax==0.10.2`, BF16 with fp32 strip-GEMM accumulation, and Kimi-K3 per-chip geometry (`H=24`, `K=V=128`, `BT=64`, `lower_bound=-5`). Each point is the median of 100 iterations after 20 warmups; compilation is excluded. The waterfall's middle workload is the labeled `H=16` packed case.
- `S` is the uncached length of each sequence. `B` sequences are packed with `cu_seqlens` into one `[1, T, H, D]` call, where `T=B×S`; there is no tensor batch dimension.

### Primary kernel benchmark

On the core `S=8…1024`, `B=1…64` grid, `optimized` improves all 56 points by **5.14×–32.69×** (geometric mean **13.55×**). `mxu_port` alone gives **1.26×–3.48×** (geometric mean **2.34×**).

The heatmap below extends `S` to 16,384, for 84 points in total. Of those, 78 are measured and every one improves: **5.14×–33.05×**, geometric mean **13.93×** (`mxu_port` alone **1.25×–3.48×**, geometric mean **2.23×**); best point `S=2048, B=64`, 2237.58 → 67.70 ms. The remaining six exceed HBM, and the two cases are marked apart: `OOM` where neither variant fits, and `base OOM` where `original` and `mxu_port` fail to compile but `optimized` still runs. The latter three — `S=4096,B=64`, `S=8192,B=32` and `S=16384,B=16`, all 262,144 tokens — need 51.73G of 31.25G HBM on the unmodified path, while `optimized` completes in 134.48 / 132.95 / 131.51 ms. Those three are the same token count reached by three different `(B, S)` splits and land within **1.1%** of each other.

![Latency over the fixed-length grid](https://raw.githubusercontent.com/Junyi-99/kda-tpu-bench/main/results/kda-fig6-main.png)

![Speedup over the extended fixed-length grid](https://raw.githubusercontent.com/Junyi-99/kda-tpu-bench/main/results/kda-fig7-heatmap-wide.png)

For the ShareGPT prompt-length distribution (52,229 tokenizer-exact lengths, pinned dataset revision and vLLM filter), 100 seed-0 batches per `B` are shared across variants. Geometric-mean speedup rises from **7.88×** at `B=1` to **31.16×** at `B=64`; the overall geometric mean is **14.34×**.

The cumulative ablation is workload-dependent: `safe_gate` contributes most for a short single sequence, while `flat_grid` contributes most at high concurrency.

![Cumulative ablation on three representative workloads](https://raw.githubusercontent.com/Junyi-99/kda-tpu-bench/main/results/kda-fig5-waterfall.png)

Hardware counters show the optimized path raising mean MXU busy utilization from **16.4%** (`mxu_port`) to **38.2%**.

![Instruction mix and hardware-counter utilization](https://raw.githubusercontent.com/Junyi-99/kda-tpu-bench/main/results/kda-fig11-units.png)

### Batch and sequence scaling (`H=8` follow-up)

These figures are from a separate single-chip sweep with `H=8`, `K=V=128`, `BT=64`, and `lower_bound=-5`. They report the mean of 10 iterations after 3 warmups. Use them for scaling trends, not absolute comparisons with the `H=24` results above.

At `B=1`, latency scales approximately as `T^0.89` for `original` and `T^0.57` for `optimized`.

![Sequence-length scaling at B=1](https://raw.githubusercontent.com/Junyi-99/kda-tpu-bench/main/results/bs-sweep/fig2_latency_scaling.png)

With a fixed 8,192-token budget, splitting one sequence into 16 increases latency by **1.67×** for `original`, **2.27×** for `mxu_port`, and **1.27×** for `optimized`.

![Constant token budget](https://raw.githubusercontent.com/Junyi-99/kda-tpu-bench/main/results/bs-sweep/fig3_constant_token_budget.png)

At `S=8,192`, per-sequence cost from `B=1` to `B=64` rises **3.2×** for `original`, **5.9×** for `mxu_port`, and only **1.17×** for `optimized`. Eight reproducible `B` values are 19–26% slower than their neighbors; the cause is still unknown.

![Per-sequence cost at S=8192](https://raw.githubusercontent.com/Junyi-99/kda-tpu-bench/main/results/bs-sweep/fig7_per_sequence_step.png)

Raw logs and analysis: [`results/bs-sweep/`](https://github.com/Junyi-99/kda-tpu-bench/tree/main/results/bs-sweep).

### End-to-end serving: Kimi-Linear-48B

Real weights, TP=4 on TPU v6e-4; ShareGPT, 160 prompts, concurrency 32. Kimi-Linear has an unbounded gate, so only `fuse`, `unified_layout`, and `flat_grid` apply; `safe_gate` and `head_block` do not.

| Metric | Upstream KDA | This PR | Speedup |
|---|---:|---:|---:|
| TTFT p50 | 244 ms | **164 ms** | **1.49×** |
| TPOT p50 | 36.7 ms | **28.9 ms** | **1.27×** |
| Wall time, 160 requests | 45.2 s | **36.7 s** | **1.23×** |

`_forward_decode` is unchanged; the TPOT improvement comes from reduced prefill interference. GSM8K accuracy is **0.94** over 200 examples.

### End-to-end serving: mini-K3

Same protocol on a 12-layer mini-K3 with K3-faithful geometry and dummy weights. Its bounded gate (`gate_lower_bound=-5`) enables all five switches.

| Metric | Upstream KDA | This PR | Speedup |
|---|---:|---:|---:|
| TTFT p50 | 2,816 ms | **989 ms** | **2.85×** |
| TPOT p50 | 36.4 ms | **15.4 ms** | **2.36×** |
| Wall time, 160 requests | 62.5 s | **33.6 s** | **1.86×** |

In a 30-second steady-state trace, the target KDA kernel falls from **59.3%** to **4.6%** of device time. Achieved BF16 rate rises from **20.9** to **52.2 TFLOP/s/chip**, and HBM bandwidth utilization rises from **27%** to **68%**; MoE becomes the dominant cost.

Raw data and A/B script: [`results/e2e/`](https://github.com/Junyi-99/kda-tpu-bench/tree/main/results/e2e).

## Reproduce

```bash
IMAGE=ghcr.io/junyi-99/kda-tpu-bench:latest
ARGS=(--rm --privileged --net=host -v "$(pwd)/out:/out")

# Kernel microbenchmark: 56-point S×B grid across original, mxu_port, and optimized.
docker run "${ARGS[@]}" "$IMAGE" grid

# The 84-point extended grid behind the heatmap (not wired into a mode; split by
# --seq-lens so a preemption costs one column). Cells above ~262k tokens OOM by design.
docker run "${ARGS[@]}" -it "$IMAGE" shell
#   PALLAS_INTERPRET=0 python bench/bench_kda_grid_wide.py --seq-lens 2048,4096,8192,16384
#   python bench/plot_grid_heatmap.py results/kda_grid.json ~/kda_grid_wide.json \
#     --seq-lens 8,16,32,64,128,256,512,1024,2048,4096,8192,16384 --out heatmap.png

# Kimi-Linear-48B serving A/B: this PR and the upstream KDA path, 160 ShareGPT prompts at concurrency 32.
docker run "${ARGS[@]}" -e E2E_MODEL=/dev/shm/kimi-linear-48b "$IMAGE" e2e

# mini-K3 serving, this PR: 160 ShareGPT prompts at concurrency 32.
docker run "${ARGS[@]}" -e MODEL=mini-k3 "$IMAGE" bench-serving

# mini-K3 serving, upstream KDA path: the matching baseline for the command above.
docker run "${ARGS[@]}" -e MODEL=mini-k3 -e KDA_FORCE_BASELINE=1 "$IMAGE" bench-serving

# Kimi-Linear-48B correctness: GSM8K accuracy over 200 examples.
docker run "${ARGS[@]}" -e MODEL=kimi-linear-48b "$IMAGE" run-eval

# Kernel attribution: instruction mix and MXU/VPU hardware counters for all three variants.
docker run "${ARGS[@]}" "$IMAGE" llo
```

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
