### PR TITLE
fix(server): clamp chunked_prefill_size to max_prefill_tokens

### DIFF
--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -340,6 +340,15 @@ class ServerArgs:
         # Set chunked prefill size
         if self.chunked_prefill_size is None:
             self.chunked_prefill_size = 4096
+        if 0 < self.max_prefill_tokens < self.chunked_prefill_size:
+            logger.warning(
+                "chunked_prefill_size (%d) > max_prefill_tokens (%d); clamping "
+                "chunked_prefill_size to %d so prefill chunks fit the padding buckets.",
+                self.chunked_prefill_size,
+                self.max_prefill_tokens,
+                self.max_prefill_tokens,
+            )
+            self.chunked_prefill_size = self.max_prefill_tokens
 
         # GGUF
         if (self.load_format == "auto" or self.load_format == "gguf") and check_gguf_file(

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -340,15 +340,24 @@ class ServerArgs:
         # Set chunked prefill size
         if self.chunked_prefill_size is None:
             self.chunked_prefill_size = 4096
+
         if 0 < self.max_prefill_tokens < self.chunked_prefill_size:
+            clamped_size = self.max_prefill_tokens // self.page_size * self.page_size
+
+            if clamped_size <= 0:
+                raise ValueError(
+                    f"max_prefill_tokens ({self.max_prefill_tokens}) must be at least "
+                    f"page_size ({self.page_size}) when chunked prefill is enabled."
+                )
+
             logger.warning(
                 "chunked_prefill_size (%d) > max_prefill_tokens (%d); clamping "
-                "chunked_prefill_size to %d so prefill chunks fit the padding buckets.",
+                "chunked_prefill_size to %d to fit the prefill limit and page size.",
                 self.chunked_prefill_size,
                 self.max_prefill_tokens,
-                self.max_prefill_tokens,
+                clamped_size,
             )
-            self.chunked_prefill_size = self.max_prefill_tokens
+            self.chunked_prefill_size = clamped_size
 
         # GGUF
         if (self.load_format == "auto" or self.load_format == "gguf") and check_gguf_file(


### PR DESCRIPTION
## Motivation

Fixes sgl-project/sglang-jax#1551.

When `max_prefill_tokens` is lower than `chunked_prefill_size`, a long prompt can create a prefill chunk with no matching padding bucket and terminate the scheduler.

## Modifications

Clamp `chunked_prefill_size` to `max_prefill_tokens` in `ServerArgs.__post_init__` when both are positive, and emit a warning. The default configuration and `chunked_prefill_size=-1` remain unchanged.

## Accuracy Tests

This change does not modify model or kernel code. The clamped path is equivalent to explicitly setting `--chunked-prefill-size 2048`.

```bash
python3 -m py_compile python/sgl_jax/srt/server_args.py
```

Verified on TPU v6e-4: a 4096-token request that previously crashed with `--max-prefill-tokens 2048` completes after clamping; prompts of 4096 and 8192 tokens were included.

## Benchmarking and Profiling

Not applicable; this change only normalizes server configuration.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update. No documentation change is needed.
