### PR TITLE
perf(kda): add guarded Mega prefill kernel on TPU

### DIFF
--- a/benchmark/kernels/kda/bench_mega_kda.py
+++ b/benchmark/kernels/kda/bench_mega_kda.py
@@ -12,7 +12,10 @@ import jax.numpy as jnp
 import numpy as np
 
 from sgl_jax.srt.kernels.kda.kda import chunk_kda_fwd
-from sgl_jax.srt.kernels.kda.mega_kda import kda_forward_packed
+from sgl_jax.srt.kernels.kda.mega_kda import (
+    kda_forward_inference,
+    kda_forward_packed,
+)
 
 CHUNK_SIZE = 64
 KEY_DIM = VALUE_DIM = 128
@@ -79,15 +82,103 @@ def _measure(fn, args, warmups: int, iterations: int) -> list[float]:
     return samples
 
 
+def _make_padded_mega(
+    *,
+    tokens: int,
+    segments: int,
+    max_segments_per_tile: int,
+    lower_bound: float | None,
+):
+    """Build a Mega runner that includes repacking and output gathering.
+
+    ``max_segments_per_tile=2`` is the minimum-padding layout supported by
+    Mega's boundary path. ``max_segments_per_tile=1`` pads every request to a
+    separate 64-token tile. Both layouts keep padding inside the jitted region
+    so the benchmark measures the routing strategy rather than only the Pallas
+    call.
+    """
+    segment_length = tokens // segments
+    if segment_length > CHUNK_SIZE:
+        raise ValueError("the padding study only supports segment lengths <= 64")
+
+    segments_per_tile = min(max_segments_per_tile, CHUNK_SIZE // segment_length)
+    padded_tokens = ((segments + segments_per_tile - 1) // segments_per_tile) * CHUNK_SIZE
+    destination_positions = []
+    segment_ids = np.zeros(padded_tokens, dtype=np.int32)
+    for segment in range(segments):
+        tile = segment // segments_per_tile
+        slot = segment % segments_per_tile
+        start = tile * CHUNK_SIZE + slot * segment_length
+        positions = np.arange(start, start + segment_length, dtype=np.int32)
+        destination_positions.extend(positions.tolist())
+        segment_ids[positions] = segment + 1
+
+    destination_positions = jnp.asarray(destination_positions, dtype=jnp.int32)
+    segment_ids = jnp.asarray(segment_ids, dtype=jnp.int32)[None, :]
+
+    @jax.jit
+    def padded_mega(q, k, v, g, beta, a_log, dt_bias, initial_state, cu_seqlens):
+        del cu_seqlens
+
+        def _repack(value):
+            shape = list(value.shape)
+            shape[1] = padded_tokens
+            return jnp.zeros(shape, dtype=value.dtype).at[:, destination_positions].set(value)
+
+        output, final_state = kda_forward_inference(
+            _repack(q),
+            _repack(k),
+            _repack(v),
+            _repack(g),
+            _repack(beta),
+            segment_ids=segment_ids,
+            A_log=a_log,
+            dt_bias=dt_bias.reshape(-1),
+            scale=SCALE,
+            initial_state=initial_state[None, ...],
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=True,
+            use_gate_in_kernel=True,
+            safe_gate=True,
+            lower_bound=lower_bound,
+            chunk_size=CHUNK_SIZE,
+            N_max=segments,
+        )
+        return output[:, destination_positions], final_state[0]
+
+    return padded_mega, padded_tokens
+
+
+def _direct_mega_supported(tokens: int, segments: int) -> bool:
+    """Static equivalent of the runtime guard for equal-length segments."""
+    segment_length = tokens // segments
+    padded_tokens = (tokens + CHUNK_SIZE - 1) // CHUNK_SIZE * CHUNK_SIZE
+    starts = np.arange(segments, dtype=np.int32) * segment_length
+    ends = starts + segment_length
+    for tile_start in range(0, padded_tokens, CHUNK_SIZE):
+        overlaps = np.sum((starts < tile_start + CHUNK_SIZE) & (ends > tile_start))
+        if overlaps > 2:
+            return False
+    return True
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--tokens", type=int, default=4096)
     parser.add_argument("--heads", type=int, default=16)
-    parser.add_argument("--segments", type=int, choices=(1, 4), default=1)
+    parser.add_argument("--segments", type=int, choices=(1, 2, 4), default=1)
     parser.add_argument("--warmups", type=int, default=10)
     parser.add_argument("--iterations", type=int, default=50)
     parser.add_argument("--rounds", type=int, default=2)
     parser.add_argument("--seed", type=int, default=1550)
+    parser.add_argument(
+        "--padding-study",
+        action="store_true",
+        help=(
+            "also compare minimum tile packing and one-request-per-tile padding; "
+            "intended for short speculative extend batches"
+        ),
+    )
     parser.add_argument(
         "--gate-mode",
         choices=("bounded", "unbounded"),
@@ -141,31 +232,75 @@ def main() -> None:
             chunk_size=CHUNK_SIZE,
         )
 
-    chunked_result = chunked(*arrays)
-    mega_result = mega(*arrays)
-    _block((chunked_result, mega_result))
-    print(
-        json.dumps(
-            {
-                "event": "correctness",
-                "gate_mode": args.gate_mode,
-                "output_max_abs": float(
-                    jnp.max(
-                        jnp.abs(
-                            mega_result[0].astype(jnp.float32)
-                            - chunked_result[0].astype(jnp.float32)
-                        )
-                    )
-                ),
-                "state_max_abs": float(jnp.max(jnp.abs(mega_result[1] - chunked_result[1]))),
-            },
-            sort_keys=True,
+    runners = {"chunked": chunked}
+    effective_tokens = {
+        "chunked": args.segments
+        * ((args.tokens // args.segments + CHUNK_SIZE - 1) // CHUNK_SIZE)
+        * CHUNK_SIZE
+    }
+    if _direct_mega_supported(args.tokens, args.segments):
+        runners["mega"] = mega
+        effective_tokens["mega"] = (args.tokens + CHUNK_SIZE - 1) // CHUNK_SIZE * CHUNK_SIZE
+    elif not args.padding_study:
+        raise ValueError(
+            "the packed layout puts more than two requests in one Mega tile; "
+            "rerun with --padding-study to compare supported padded layouts"
         )
-    )
 
-    runners = {"chunked": chunked, "mega": mega}
+    if args.padding_study:
+        tile_padded, tile_tokens = _make_padded_mega(
+            tokens=args.tokens,
+            segments=args.segments,
+            max_segments_per_tile=2,
+            lower_bound=lower_bound,
+        )
+        segment_padded, segment_tokens = _make_padded_mega(
+            tokens=args.tokens,
+            segments=args.segments,
+            max_segments_per_tile=1,
+            lower_bound=lower_bound,
+        )
+        runners["mega_tile_padded"] = tile_padded
+        runners["mega_segment_padded"] = segment_padded
+        effective_tokens["mega_tile_padded"] = tile_tokens
+        effective_tokens["mega_segment_padded"] = segment_tokens
+
+    results = {variant: runner(*arrays) for variant, runner in runners.items()}
+    _block(tuple(results.values()))
+    chunked_result = results["chunked"]
+    for variant, result in results.items():
+        if variant == "chunked":
+            continue
+        print(
+            json.dumps(
+                {
+                    "event": "correctness",
+                    "variant": variant,
+                    "tokens": args.tokens,
+                    "segment_length": args.tokens // args.segments,
+                    "segments": args.segments,
+                    "effective_tokens": effective_tokens[variant],
+                    "gate_mode": args.gate_mode,
+                    "output_max_abs": float(
+                        jnp.max(
+                            jnp.abs(
+                                result[0].astype(jnp.float32)
+                                - chunked_result[0].astype(jnp.float32)
+                            )
+                        )
+                    ),
+                    "state_max_abs": float(
+                        jnp.max(jnp.abs(result[1] - chunked_result[1]))
+                    ),
+                },
+                sort_keys=True,
+            )
+        )
+
+    variants = tuple(runners)
     for round_index in range(args.rounds):
-        order = ("chunked", "mega") if round_index % 2 == 0 else ("mega", "chunked")
+        offset = round_index % len(variants)
+        order = variants[offset:] + variants[:offset]
         for variant in order:
             samples = _measure(
                 runners[variant],
@@ -180,10 +315,14 @@ def main() -> None:
                         "variant": variant,
                         "round": round_index,
                         "tokens": args.tokens,
+                        "segment_length": args.tokens // args.segments,
+                        "effective_tokens": effective_tokens[variant],
+                        "padding_ratio": effective_tokens[variant] / args.tokens,
                         "heads": args.heads,
                         "segments": args.segments,
                         "gate_mode": args.gate_mode,
                         "iterations": args.iterations,
+                        "latency_ms": statistics.median(samples),
                         "median_ms": statistics.median(samples),
                         "mean_ms": statistics.mean(samples),
                         "p90_ms": float(np.percentile(samples, 90)),

--- a/benchmark/kernels/kda/bench_mega_kda.py
+++ b/benchmark/kernels/kda/bench_mega_kda.py
@@ -1,0 +1,186 @@
+"""Compare the existing chunked KDA prefill with the Mega KDA kernel."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.kernels.kda.kda import chunk_kda_fwd
+from sgl_jax.srt.kernels.kda.mega_kda import kda_forward_packed
+
+CHUNK_SIZE = 64
+KEY_DIM = VALUE_DIM = 128
+LOWER_BOUND = -5.0
+SCALE = KEY_DIM**-0.5
+
+
+def _normalize(value: jax.Array) -> jax.Array:
+    value = value.astype(jnp.float32)
+    value *= jax.lax.rsqrt(jnp.sum(value * value, axis=-1, keepdims=True) + 1e-6)
+    return value.astype(jnp.bfloat16)
+
+
+def _inputs(tokens: int, heads: int, segments: int, seed: int):
+    if tokens % segments:
+        raise ValueError("tokens must be divisible by segments")
+    rng = np.random.default_rng(seed)
+    shape = (1, tokens, heads, KEY_DIM)
+
+    def bf16_normal(scale: float = 1.0):
+        return jnp.asarray(
+            rng.standard_normal(shape, dtype=np.float32) * scale,
+            dtype=jnp.bfloat16,
+        )
+
+    lengths = np.full(segments, tokens // segments, dtype=np.int32)
+    return (
+        bf16_normal(),
+        bf16_normal(),
+        bf16_normal(1.5),
+        jnp.asarray(
+            rng.uniform(-4.5, 4.5, shape).astype(np.float32),
+            dtype=jnp.bfloat16,
+        ),
+        jnp.asarray(
+            rng.uniform(0.05, 0.95, shape[:-1]).astype(np.float32),
+            dtype=jnp.bfloat16,
+        ),
+        jnp.asarray(rng.uniform(0.2, 3.0, (heads,)).astype(np.float32)),
+        jnp.asarray(rng.uniform(-8.0, -1.5, (heads, KEY_DIM)).astype(np.float32)),
+        jnp.asarray(
+            rng.standard_normal(
+                (segments, heads, KEY_DIM, VALUE_DIM),
+                dtype=np.float32,
+            )
+            * 0.1
+        ),
+        jnp.asarray([0, *np.cumsum(lengths)], dtype=jnp.int32),
+    )
+
+
+def _block(value) -> None:
+    jax.block_until_ready(value)
+
+
+def _measure(fn, args, warmups: int, iterations: int) -> list[float]:
+    for _ in range(warmups):
+        _block(fn(*args))
+    samples = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        _block(fn(*args))
+        samples.append((time.perf_counter() - start) * 1e3)
+    return samples
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tokens", type=int, default=4096)
+    parser.add_argument("--heads", type=int, default=16)
+    parser.add_argument("--segments", type=int, choices=(1, 4), default=1)
+    parser.add_argument("--warmups", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=50)
+    parser.add_argument("--rounds", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=1550)
+    args = parser.parse_args()
+
+    arrays = _inputs(args.tokens, args.heads, args.segments, args.seed)
+
+    @jax.jit
+    def chunked(q, k, v, g, beta, a_log, dt_bias, initial_state, cu_seqlens):
+        result = chunk_kda_fwd(
+            _normalize(q),
+            _normalize(k),
+            v,
+            g,
+            beta,
+            scale=SCALE,
+            initial_state=initial_state,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens,
+            chunk_size=CHUNK_SIZE,
+            safe_gate=True,
+            lower_bound=LOWER_BOUND,
+            use_gate_in_kernel=True,
+            A_log=a_log,
+            dt_bias=dt_bias,
+        )
+        return result[0], result[1]
+
+    @jax.jit
+    def mega(q, k, v, g, beta, a_log, dt_bias, initial_state, cu_seqlens):
+        return kda_forward_packed(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            cu_seqlens=cu_seqlens,
+            A_log=a_log,
+            dt_bias=dt_bias,
+            scale=SCALE,
+            initial_state=initial_state,
+            lower_bound=LOWER_BOUND,
+            chunk_size=CHUNK_SIZE,
+        )
+
+    chunked_result = chunked(*arrays)
+    mega_result = mega(*arrays)
+    _block((chunked_result, mega_result))
+    print(
+        json.dumps(
+            {
+                "event": "correctness",
+                "output_max_abs": float(
+                    jnp.max(
+                        jnp.abs(
+                            mega_result[0].astype(jnp.float32)
+                            - chunked_result[0].astype(jnp.float32)
+                        )
+                    )
+                ),
+                "state_max_abs": float(
+                    jnp.max(jnp.abs(mega_result[1] - chunked_result[1]))
+                ),
+            },
+            sort_keys=True,
+        )
+    )
+
+    runners = {"chunked": chunked, "mega": mega}
+    for round_index in range(args.rounds):
+        order = ("chunked", "mega") if round_index % 2 == 0 else ("mega", "chunked")
+        for variant in order:
+            samples = _measure(
+                runners[variant],
+                arrays,
+                warmups=args.warmups,
+                iterations=args.iterations,
+            )
+            print(
+                json.dumps(
+                    {
+                        "event": "latency",
+                        "variant": variant,
+                        "round": round_index,
+                        "tokens": args.tokens,
+                        "heads": args.heads,
+                        "segments": args.segments,
+                        "iterations": args.iterations,
+                        "median_ms": statistics.median(samples),
+                        "mean_ms": statistics.mean(samples),
+                        "p90_ms": float(np.percentile(samples, 90)),
+                    },
+                    sort_keys=True,
+                )
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/kda/bench_mega_kda.py
+++ b/benchmark/kernels/kda/bench_mega_kda.py
@@ -88,9 +88,20 @@ def main() -> None:
     parser.add_argument("--iterations", type=int, default=50)
     parser.add_argument("--rounds", type=int, default=2)
     parser.add_argument("--seed", type=int, default=1550)
+    parser.add_argument(
+        "--gate-mode",
+        choices=("bounded", "unbounded"),
+        default="bounded",
+        help="bounded selects K3's sigmoid gate; unbounded selects Kimi-Linear's softplus gate",
+    )
     args = parser.parse_args()
+    lower_bound = LOWER_BOUND if args.gate_mode == "bounded" else None
 
-    arrays = _inputs(args.tokens, args.heads, args.segments, args.seed)
+    arrays = list(_inputs(args.tokens, args.heads, args.segments, args.seed))
+    if args.gate_mode == "unbounded":
+        # Kimi-Linear produces FP32 beta even though q/k/v/g use BF16.
+        arrays[4] = arrays[4].astype(jnp.float32)
+    arrays = tuple(arrays)
 
     @jax.jit
     def chunked(q, k, v, g, beta, a_log, dt_bias, initial_state, cu_seqlens):
@@ -106,7 +117,7 @@ def main() -> None:
             cu_seqlens=cu_seqlens,
             chunk_size=CHUNK_SIZE,
             safe_gate=True,
-            lower_bound=LOWER_BOUND,
+            lower_bound=lower_bound,
             use_gate_in_kernel=True,
             A_log=a_log,
             dt_bias=dt_bias,
@@ -126,7 +137,7 @@ def main() -> None:
             dt_bias=dt_bias,
             scale=SCALE,
             initial_state=initial_state,
-            lower_bound=LOWER_BOUND,
+            lower_bound=lower_bound,
             chunk_size=CHUNK_SIZE,
         )
 
@@ -137,6 +148,7 @@ def main() -> None:
         json.dumps(
             {
                 "event": "correctness",
+                "gate_mode": args.gate_mode,
                 "output_max_abs": float(
                     jnp.max(
                         jnp.abs(
@@ -170,6 +182,7 @@ def main() -> None:
                         "tokens": args.tokens,
                         "heads": args.heads,
                         "segments": args.segments,
+                        "gate_mode": args.gate_mode,
                         "iterations": args.iterations,
                         "median_ms": statistics.median(samples),
                         "mean_ms": statistics.mean(samples),

--- a/benchmark/kernels/kda/bench_mega_kda.py
+++ b/benchmark/kernels/kda/bench_mega_kda.py
@@ -12,10 +12,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from sgl_jax.srt.kernels.kda.kda import chunk_kda_fwd
-from sgl_jax.srt.kernels.kda.mega_kda import (
-    kda_forward_inference,
-    kda_forward_packed,
-)
+from sgl_jax.srt.kernels.kda.mega_kda import kda_forward_inference, kda_forward_packed
 
 CHUNK_SIZE = 64
 KEY_DIM = VALUE_DIM = 128
@@ -103,6 +100,7 @@ def _make_padded_mega(
 
     segments_per_tile = min(max_segments_per_tile, CHUNK_SIZE // segment_length)
     padded_tokens = ((segments + segments_per_tile - 1) // segments_per_tile) * CHUNK_SIZE
+
     @jax.jit
     def padded_mega(q, k, v, g, beta, a_log, dt_bias, initial_state, cu_seqlens):
         source_positions = jnp.arange(tokens, dtype=jnp.int32)
@@ -114,12 +112,12 @@ def _make_padded_mega(
         )
         tile_indices = source_segments // segments_per_tile
         tile_source_starts = cu_seqlens[tile_indices * segments_per_tile]
-        destination_positions = (
-            tile_indices * CHUNK_SIZE + source_positions - tile_source_starts
+        destination_positions = tile_indices * CHUNK_SIZE + source_positions - tile_source_starts
+        segment_ids = (
+            jnp.zeros(padded_tokens, dtype=jnp.int32)
+            .at[destination_positions]
+            .set(source_segments + 1)[None, :]
         )
-        segment_ids = jnp.zeros(padded_tokens, dtype=jnp.int32).at[
-            destination_positions
-        ].set(source_segments + 1)[None, :]
 
         def _repack(value):
             shape = list(value.shape)
@@ -290,9 +288,7 @@ def main() -> None:
                             )
                         )
                     ),
-                    "state_max_abs": float(
-                        jnp.max(jnp.abs(result[1] - chunked_result[1]))
-                    ),
+                    "state_max_abs": float(jnp.max(jnp.abs(result[1] - chunked_result[1]))),
                 },
                 sort_keys=True,
             )

--- a/benchmark/kernels/kda/bench_mega_kda.py
+++ b/benchmark/kernels/kda/bench_mega_kda.py
@@ -145,9 +145,7 @@ def main() -> None:
                         )
                     )
                 ),
-                "state_max_abs": float(
-                    jnp.max(jnp.abs(mega_result[1] - chunked_result[1]))
-                ),
+                "state_max_abs": float(jnp.max(jnp.abs(mega_result[1] - chunked_result[1]))),
             },
             sort_keys=True,
         )

--- a/benchmark/kernels/kda/bench_mega_kda.py
+++ b/benchmark/kernels/kda/bench_mega_kda.py
@@ -103,22 +103,23 @@ def _make_padded_mega(
 
     segments_per_tile = min(max_segments_per_tile, CHUNK_SIZE // segment_length)
     padded_tokens = ((segments + segments_per_tile - 1) // segments_per_tile) * CHUNK_SIZE
-    destination_positions = []
-    segment_ids = np.zeros(padded_tokens, dtype=np.int32)
-    for segment in range(segments):
-        tile = segment // segments_per_tile
-        slot = segment % segments_per_tile
-        start = tile * CHUNK_SIZE + slot * segment_length
-        positions = np.arange(start, start + segment_length, dtype=np.int32)
-        destination_positions.extend(positions.tolist())
-        segment_ids[positions] = segment + 1
-
-    destination_positions = jnp.asarray(destination_positions, dtype=jnp.int32)
-    segment_ids = jnp.asarray(segment_ids, dtype=jnp.int32)[None, :]
-
     @jax.jit
     def padded_mega(q, k, v, g, beta, a_log, dt_bias, initial_state, cu_seqlens):
-        del cu_seqlens
+        source_positions = jnp.arange(tokens, dtype=jnp.int32)
+        lengths = jnp.diff(cu_seqlens).astype(jnp.int32)
+        source_segments = jnp.repeat(
+            jnp.arange(segments, dtype=jnp.int32),
+            lengths,
+            total_repeat_length=tokens,
+        )
+        tile_indices = source_segments // segments_per_tile
+        tile_source_starts = cu_seqlens[tile_indices * segments_per_tile]
+        destination_positions = (
+            tile_indices * CHUNK_SIZE + source_positions - tile_source_starts
+        )
+        segment_ids = jnp.zeros(padded_tokens, dtype=jnp.int32).at[
+            destination_positions
+        ].set(source_segments + 1)[None, :]
 
         def _repack(value):
             shape = list(value.shape)

--- a/python/sgl_jax/srt/kernels/kda/__init__.py
+++ b/python/sgl_jax/srt/kernels/kda/__init__.py
@@ -1,4 +1,15 @@
 from sgl_jax.srt.kernels.kda.kda import chunk_kda_fwd as chunk_kda
+from sgl_jax.srt.kernels.kda.mega_kda import (
+    is_mega_kda_layout_supported,
+    kda_forward_inference,
+    kda_forward_packed,
+)
 from sgl_jax.srt.kernels.kda.naive import naive_recurrent_kda
 
-__all__ = ["chunk_kda", "naive_recurrent_kda"]
+__all__ = [
+    "chunk_kda",
+    "is_mega_kda_layout_supported",
+    "kda_forward_inference",
+    "kda_forward_packed",
+    "naive_recurrent_kda",
+]

--- a/python/sgl_jax/srt/kernels/kda/mega_kda/__init__.py
+++ b/python/sgl_jax/srt/kernels/kda/mega_kda/__init__.py
@@ -13,9 +13,7 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 
-from sgl_jax.srt.kernels.kda.mega_kda.kernel import (
-    _chunk_kda_fwd_native_segids,
-)
+from sgl_jax.srt.kernels.kda.mega_kda.kernel import _chunk_kda_fwd_native_segids
 
 
 def is_mega_kda_layout_supported(

--- a/python/sgl_jax/srt/kernels/kda/mega_kda/__init__.py
+++ b/python/sgl_jax/srt/kernels/kda/mega_kda/__init__.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+# Adapted from a private upstream Pallas-kernel repository.
+# Upstream contact: pathfinder-pf.
+"""Inference-only Kimi Delta Attention forward operator.
+
+This module deliberately does not import ``chunk.py`` or register a custom
+VJP.  It provides a small public API around the native segment-ID Pallas
+mega-kernel so inference optimization cannot change the training path.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from sgl_jax.srt.kernels.kda.mega_kda.kernel import (
+    _chunk_kda_fwd_native_segids,
+)
+
+
+def is_mega_kda_layout_supported(
+    query_start_loc: jax.Array,
+    num_tokens: int,
+    chunk_size: int = 64,
+) -> jax.Array:
+    """Whether every mega-KDA tile intersects at most two live requests.
+
+    The native boundary path handles the first and last segment in a tile. A
+    third segment in the same tile would therefore be dropped. Derive the
+    runtime guard from request intervals instead of scanning all token rows:
+    serving buckets have few request slots but can have thousands of tokens.
+
+    Empty request slots and starts beyond the token bucket do not overlap any
+    tile. The result is a scalar device boolean so one compiled executable can
+    select the mega or chunked branch for each scheduled batch.
+    """
+    if num_tokens % chunk_size:
+        raise ValueError("mega KDA layout guard requires full token tiles")
+    if query_start_loc.shape[0] <= 3:
+        return jnp.asarray(True)
+
+    starts = jnp.minimum(query_start_loc[:-1], num_tokens)
+    ends = jnp.minimum(query_start_loc[1:], num_tokens)
+    tile_starts = jnp.arange(0, num_tokens, chunk_size, dtype=jnp.int32)
+    tile_ends = tile_starts + chunk_size
+    overlaps = (
+        (starts < ends)[:, None]
+        & (starts[:, None] < tile_ends[None, :])
+        & (ends[:, None] > tile_starts[None, :])
+    )
+    return jnp.all(jnp.sum(overlaps, axis=0) <= 2)
+
+
+def _segment_ids_from_cu_seqlens(
+    cu_seqlens: jax.Array,
+    num_tokens: int,
+) -> jax.Array:
+    """Build one-indexed packed segment IDs, with zero reserved for padding."""
+    lengths = jnp.diff(cu_seqlens).astype(jnp.int32)
+    segment_ids = jnp.repeat(
+        jnp.arange(1, cu_seqlens.shape[0], dtype=jnp.int32),
+        lengths,
+        total_repeat_length=num_tokens,
+    )
+    positions = jnp.arange(num_tokens, dtype=jnp.int32)
+    return jnp.where(positions < cu_seqlens[-1], segment_ids, 0)[None, :]
+
+
+def kda_forward_packed(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    g: jax.Array,
+    beta: jax.Array,
+    *,
+    cu_seqlens: jax.Array,
+    A_log: jax.Array,
+    dt_bias: jax.Array,
+    scale: float,
+    initial_state: jax.Array,
+    lower_bound: float,
+    chunk_size: int = 64,
+) -> tuple[jax.Array, jax.Array]:
+    """Run Mega KDA for a packed ``B=1`` inference batch.
+
+    Inputs use ``[1, T, H, K]`` for q/k/g, ``[1, T, H, V]`` for v,
+    ``[1, T, H]`` for beta, and ``[N, H, K, V]`` for per-request state.
+    ``cu_seqlens`` contains the ``N + 1`` packed request boundaries. The
+    output is trimmed back to ``T`` and the returned state is
+    ``[N, H, K, V]``.
+    """
+    if q.shape[0] != 1:
+        raise ValueError(f"packed Mega KDA requires B=1, got B={q.shape[0]}")
+    if initial_state.ndim != 4:
+        raise ValueError("packed Mega KDA initial_state must have shape [N, H, K, V]")
+
+    tokens = q.shape[1]
+    padded_tokens = (tokens + chunk_size - 1) // chunk_size * chunk_size
+    token_padding = padded_tokens - tokens
+
+    def _pad(array: jax.Array) -> jax.Array:
+        widths = [(0, 0)] * array.ndim
+        widths[1] = (0, token_padding)
+        return jnp.pad(array, widths)
+
+    segment_ids = _segment_ids_from_cu_seqlens(cu_seqlens, padded_tokens)
+    output, final_state = kda_forward_inference(
+        _pad(q),
+        _pad(k),
+        _pad(v),
+        _pad(g),
+        _pad(beta),
+        segment_ids=segment_ids,
+        A_log=A_log,
+        dt_bias=dt_bias.reshape(-1),
+        scale=scale,
+        initial_state=initial_state[None, ...],
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        safe_gate=True,
+        lower_bound=lower_bound,
+        chunk_size=chunk_size,
+        N_max=initial_state.shape[0],
+    )
+    return output[:, :tokens], final_state[0]
+
+
+def kda_forward_inference(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    g: jax.Array,
+    beta: jax.Array,
+    *,
+    segment_ids: jax.Array,
+    A_log: jax.Array | None = None,
+    dt_bias: jax.Array | None = None,
+    scale: float | None = None,
+    initial_state: jax.Array | None = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    use_gate_in_kernel: bool = False,
+    safe_gate: bool = True,
+    lower_bound: float | None = None,
+    chunk_size: int = 64,
+    N_max: int | None = None,
+    mini_batch: int | None = None,
+) -> tuple[jax.Array, jax.Array | None]:
+    """Run the standalone KDA inference forward kernel.
+
+    Args:
+      q: Query tensor ``[B, T, H, K]`` in BF16.
+      k: Key tensor ``[B, T, H, K]`` with the same dtype as ``q``.
+      v: Value tensor ``[B, T, H, V]`` with the same dtype as ``q``.
+      g: Raw gate tensor ``[B, T, H, K]``.
+      beta: Update coefficient ``[B, T, H]``.
+      segment_ids: One-indexed packed-sequence IDs ``[B, T]`` or ``[T]``;
+        zero denotes padding. Each segment is an independent request/state
+        boundary, not a parallel chunk of one request.
+      A_log: Per-head log decay ``[H]``.
+      dt_bias: Flattened gate bias ``[H*K]``.
+      scale: Attention scale. Defaults to ``K**-0.5``.
+      initial_state: Optional FP32 state ``[B, N, H, K, V]`` or
+        ``[N, H, K, V]``.
+      output_final_state: Return FP32 final state ``[B, N, H, K, V]``.
+      use_qk_l2norm_in_kernel: Must be True.
+      use_gate_in_kernel: Must be True.
+      safe_gate: Must be True.
+      lower_bound: Sigmoid-gate lower bound in ``[-5, 0)``.
+      chunk_size: Recurrently ordered token tile size; currently required to
+        be 64. Tiles within one segment are not sequence-parallel.
+      N_max: Static maximum number of packed segments.
+      mini_batch: Optional heads per Pallas program.
+
+    Returns:
+      A pair ``(output, final_state)``. Output is ``[B, T, H, V]`` and has
+      the input dtype. ``final_state`` is FP32 when requested, otherwise None.
+
+    Raises:
+      ValueError: If shapes, dtypes, or static inference options are invalid.
+    """
+    if q.dtype != jnp.bfloat16:
+        raise ValueError(f"kda_forward_inference currently requires BF16, got {q.dtype}")
+    if not (q.dtype == k.dtype == v.dtype == g.dtype):
+        raise ValueError("q, k, v, and g must have the same dtype")
+    if beta.dtype != q.dtype:
+        raise ValueError("beta must have the same dtype as q")
+    if chunk_size != 64:
+        raise ValueError("the optimized inference kernel currently requires chunk_size=64")
+    if q.shape[:3] != k.shape[:3] or q.shape != g.shape:
+        raise ValueError("q, k, and g must agree on [B, T, H, K]")
+    if q.shape[:3] != v.shape[:3] or q.shape[:3] != beta.shape:
+        raise ValueError("v and beta must agree with q on [B, T, H]")
+    if q.shape[-1] != k.shape[-1]:
+        raise ValueError("q and k must have the same key dimension")
+    if q.shape[1] % chunk_size:
+        raise ValueError("T must be padded to a multiple of chunk_size")
+    if segment_ids.ndim == 1:
+        segment_ids = segment_ids[None, :]
+    if segment_ids.shape != q.shape[:2]:
+        raise ValueError(f"segment_ids must have shape {q.shape[:2]}, got {segment_ids.shape}")
+    if segment_ids.dtype != jnp.int32:
+        raise ValueError(f"segment_ids must use int32, got {segment_ids.dtype}")
+    if A_log is None or dt_bias is None:
+        raise ValueError("fused gate activation requires A_log and dt_bias")
+    if not use_qk_l2norm_in_kernel:
+        raise ValueError(
+            "standalone inference requires in-kernel Q/K L2 normalization "
+            "to bound the triangular solve"
+        )
+    if not use_gate_in_kernel or not safe_gate:
+        raise ValueError("standalone inference requires safe fused gate activation")
+    if lower_bound is None or not (-5 <= lower_bound < 0):
+        raise ValueError("safe fused gate activation requires lower_bound in [-5, 0)")
+    if N_max is None:
+        if initial_state is not None:
+            N_max = initial_state.shape[-4]
+        else:
+            raise ValueError("N_max is required when initial_state is None")
+    if initial_state is not None and initial_state.dtype != jnp.float32:
+        raise ValueError("initial_state must use float32")
+
+    # exp(80) is finite in FP32 and already far beyond the sigmoid saturation
+    # point. Preserve valid model values while preventing exp(A_log) from
+    # becoming inf before gate activation.
+    A_log = jnp.minimum(A_log, jnp.asarray(80.0, dtype=A_log.dtype))
+
+    actual_scale = q.shape[-1] ** -0.5 if scale is None else scale
+    output, final_state, *_ = _chunk_kda_fwd_native_segids(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        segment_ids=segment_ids,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        scale=actual_scale,
+        chunk_size=chunk_size,
+        store_h=False,
+        store_v_new=False,
+        disable_recompute=False,
+        only_fwd=True,
+        safe_gate=safe_gate,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        use_gate_in_kernel=use_gate_in_kernel,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        lower_bound=lower_bound,
+        mini_batch=mini_batch,
+        N_max=N_max,
+        residual_chunk_layout=False,
+        batch_first=True,
+    )
+    return output, final_state
+
+
+__all__ = [
+    "is_mega_kda_layout_supported",
+    "kda_forward_inference",
+    "kda_forward_packed",
+]

--- a/python/sgl_jax/srt/kernels/kda/mega_kda/__init__.py
+++ b/python/sgl_jax/srt/kernels/kda/mega_kda/__init__.py
@@ -76,7 +76,7 @@ def kda_forward_packed(
     dt_bias: jax.Array,
     scale: float,
     initial_state: jax.Array,
-    lower_bound: float,
+    lower_bound: float | None,
     chunk_size: int = 64,
 ) -> tuple[jax.Array, jax.Array]:
     """Run Mega KDA for a packed ``B=1`` inference batch.
@@ -165,7 +165,8 @@ def kda_forward_inference(
       use_qk_l2norm_in_kernel: Must be True.
       use_gate_in_kernel: Must be True.
       safe_gate: Must be True.
-      lower_bound: Sigmoid-gate lower bound in ``[-5, 0)``.
+      lower_bound: Sigmoid-gate lower bound in ``[-5, 0)`` for K3, or None
+        for Kimi-Linear's unbounded ``-exp(A_log) * softplus`` gate.
       chunk_size: Recurrently ordered token tile size; currently required to
         be 64. Tiles within one segment are not sequence-parallel.
       N_max: Static maximum number of packed segments.
@@ -182,8 +183,8 @@ def kda_forward_inference(
         raise ValueError(f"kda_forward_inference currently requires BF16, got {q.dtype}")
     if not (q.dtype == k.dtype == v.dtype == g.dtype):
         raise ValueError("q, k, v, and g must have the same dtype")
-    if beta.dtype != q.dtype:
-        raise ValueError("beta must have the same dtype as q")
+    if beta.dtype not in (q.dtype, jnp.float32):
+        raise ValueError("beta must use the input dtype or float32")
     if chunk_size != 64:
         raise ValueError("the optimized inference kernel currently requires chunk_size=64")
     if q.shape[:3] != k.shape[:3] or q.shape != g.shape:
@@ -209,8 +210,8 @@ def kda_forward_inference(
         )
     if not use_gate_in_kernel or not safe_gate:
         raise ValueError("standalone inference requires safe fused gate activation")
-    if lower_bound is None or not (-5 <= lower_bound < 0):
-        raise ValueError("safe fused gate activation requires lower_bound in [-5, 0)")
+    if lower_bound is not None and not (-5 <= lower_bound < 0):
+        raise ValueError("bounded fused gate activation requires lower_bound in [-5, 0)")
     if N_max is None:
         if initial_state is not None:
             N_max = initial_state.shape[-4]

--- a/python/sgl_jax/srt/kernels/kda/mega_kda/kernel.py
+++ b/python/sgl_jax/srt/kernels/kda/mega_kda/kernel.py
@@ -84,6 +84,201 @@ def _build_chunk_metadata(segment_ids, chunk_size):
     return chunk_kind, seg_first, seg_last, seg_id
 
 
+def _build_unbounded_intra_terms(q, k, g_cumsum, beta, scale, block_size, precision):
+    """Build causal Aqk/L terms without positive gate exponentials.
+
+    Kimi-Linear's unbounded gate can accumulate far below the BF16/FP32
+    exponent range inside one 64-token tile.  Cross-block products use the
+    first gate value of the row block as a shared reference, which keeps both
+    factors in ``[0, 1]``.  The diagonal block uses the causal gate difference
+    directly because no single shared reference is safe on both sides of its
+    diagonal.
+    """
+    _, tokens, _ = q.shape
+    num_blocks = tokens // block_size
+    aqk_rows = []
+    l_rows = []
+
+    def _dot(lhs, rhs):
+        return jax.lax.dot_general(
+            lhs,
+            rhs,
+            (((2,), (2,)), ((0,), (0,))),
+            precision=precision,
+            preferred_element_type=jnp.float32,
+        )
+
+    for row_block in range(num_blocks):
+        row_start = row_block * block_size
+        row_end = row_start + block_size
+        q_row = q[:, row_start:row_end]
+        k_row = k[:, row_start:row_end]
+        g_row = g_cumsum[:, row_start:row_end]
+        reference = g_row[:, :1]
+        row_decay = jnp.exp2(jnp.clip(g_row - reference, -126.0, 0.0))
+        aqk_blocks = []
+        l_blocks = []
+
+        for col_block in range(row_block):
+            col_start = col_block * block_size
+            col_end = col_start + block_size
+            k_col = k[:, col_start:col_end]
+            g_col = g_cumsum[:, col_start:col_end]
+            col_decay = jnp.exp2(jnp.clip(reference - g_col, -126.0, 0.0))
+            scaled_k_col = k_col * col_decay
+            aqk_blocks.append(_dot(q_row * row_decay, scaled_k_col))
+            l_blocks.append(_dot(k_row * row_decay, scaled_k_col))
+
+        gate_diff = g_row[:, :, None, :] - g_row[:, None, :, :]
+        diagonal_decay = jnp.exp2(jnp.clip(gate_diff, -126.0, 0.0))
+        aqk_diagonal = jnp.sum(
+            q_row[:, :, None, :] * diagonal_decay * k_row[:, None, :, :],
+            axis=-1,
+        )
+        l_diagonal = jnp.sum(
+            k_row[:, :, None, :] * diagonal_decay * k_row[:, None, :, :],
+            axis=-1,
+        )
+        row_iota = jax.lax.broadcasted_iota(jnp.int32, aqk_diagonal.shape, 1)
+        col_iota = jax.lax.broadcasted_iota(jnp.int32, aqk_diagonal.shape, 2)
+        aqk_blocks.append(jnp.where(row_iota >= col_iota, aqk_diagonal, 0.0))
+        l_blocks.append(jnp.where(row_iota > col_iota, l_diagonal, 0.0))
+
+        trailing = tokens - row_end
+        if trailing:
+            zeros = jnp.zeros((q.shape[0], block_size, trailing), dtype=jnp.float32)
+            aqk_blocks.append(zeros)
+            l_blocks.append(zeros)
+        aqk_rows.append(jnp.concatenate(aqk_blocks, axis=2))
+        l_rows.append(jnp.concatenate(l_blocks, axis=2))
+
+    aqk = jnp.concatenate(aqk_rows, axis=1) * scale
+    lower_matrix = jnp.concatenate(l_rows, axis=1) * beta[:, :, None]
+    g_last = g_cumsum[:, -1:, :]
+    kg = k * jnp.exp2(jnp.clip(g_last - g_cumsum, -126.0, 0.0))
+    return aqk, lower_matrix, kg
+
+
+def _build_bounded_intra_terms(q, k, g_cumsum, beta, scale, block_size, precision, safe_gate):
+    """Build the existing fast factored Aqk/L terms for bounded K3 gates."""
+    mini_batch, tokens, _ = q.shape
+    num_blocks = tokens // block_size
+    reference_index = block_size // 2 if safe_gate else 0
+    row_iota = jax.lax.broadcasted_iota(jnp.int32, (block_size, tokens), 0)
+    col_iota = jax.lax.broadcasted_iota(jnp.int32, (block_size, tokens), 1)
+    aqk_rows = []
+    l_rows = []
+    k_inverse_prefix = None
+    previous_reference = None
+
+    for block in range(num_blocks):
+        start = block * block_size
+        end = start + block_size
+        q_block = q[:, start:end]
+        k_block = k[:, start:end]
+        g_block = g_cumsum[:, start:end]
+        reference = g_block[:, reference_index : reference_index + 1]
+        gate_difference = g_block - reference
+        gate_exp = jnp.exp2(gate_difference)
+        q_scaled = q_block * gate_exp
+        k_scaled = k_block * gate_exp
+        k_inverse_current = k_block * jnp.exp2(-gate_difference)
+        if block == 0:
+            k_inverse_prefix = k_inverse_current
+        else:
+            reference_decay = jnp.exp2(reference - previous_reference)
+            k_inverse_prefix = jnp.concatenate(
+                [k_inverse_prefix * reference_decay, k_inverse_current], axis=1
+            )
+        previous_reference = reference
+        qk_scaled = jnp.concatenate([q_scaled, k_scaled], axis=1)
+        qk_dot_valid = jax.lax.dot_general(
+            qk_scaled,
+            k_inverse_prefix,
+            (((2,), (2,)), ((0,), (0,))),
+            precision=precision,
+            preferred_element_type=jnp.float32,
+        )
+        if end < tokens:
+            qk_dot = jnp.concatenate(
+                [
+                    qk_dot_valid,
+                    jnp.zeros(
+                        (mini_batch, 2 * block_size, tokens - end),
+                        dtype=jnp.float32,
+                    ),
+                ],
+                axis=2,
+            )
+        else:
+            qk_dot = qk_dot_valid
+        aqk_row = qk_dot[:, :block_size] * scale
+        l_row = qk_dot[:, block_size:] * beta[:, start:end, None]
+        in_diagonal_block = (col_iota >= start) & (col_iota < end)
+        local_col = col_iota - start
+        aqk_row = jnp.where((~in_diagonal_block) | (row_iota >= local_col), aqk_row, 0.0)
+        l_row = jnp.where((~in_diagonal_block) | (row_iota > local_col), l_row, 0.0)
+        aqk_rows.append(aqk_row)
+        l_rows.append(l_row)
+
+    g_last = g_cumsum[:, -1:, :]
+    kg = k_inverse_prefix * jnp.exp2(g_last - previous_reference)
+    return jnp.concatenate(aqk_rows, axis=1), jnp.concatenate(l_rows, axis=1), kg
+
+
+def _solve_unbounded_block_forward(L, rhs, block_inverse, block_size, precision):
+    """Solve ``(I + L) x = rhs`` with stable block forward substitution."""
+    _, tokens, _ = L.shape
+    solved_blocks = []
+
+    def _dot(lhs, rhs):
+        return jax.lax.dot_general(
+            lhs,
+            rhs,
+            (((2,), (1,)), ((0,), (0,))),
+            precision=precision,
+            preferred_element_type=jnp.float32,
+        )
+
+    for block in range(tokens // block_size):
+        start = block * block_size
+        end = start + block_size
+        residual = rhs[:, start:end]
+        if solved_blocks:
+            solved_prefix = jnp.concatenate(solved_blocks, axis=1)
+            residual -= _dot(L[:, start:end, :start], solved_prefix)
+        inverse = block_inverse[:, start:end, start:end]
+        solved_blocks.append(_dot(inverse, residual))
+    return jnp.concatenate(solved_blocks, axis=1)
+
+
+def _solve_unbounded_unit_lower(L, rhs, block_size, precision):
+    """Create small diagonal inverses, then run ordered block substitution."""
+    tokens = L.shape[1]
+    identity = jnp.eye(tokens, dtype=jnp.float32)
+    indices = jnp.arange(tokens, dtype=jnp.int32)
+    block_indices = indices // block_size
+    same_block = (block_indices[:, None] == block_indices[None, :]).astype(jnp.float32)
+    negative_diagonal_blocks = -(L.astype(jnp.float32) * same_block[None])
+
+    def _dot(lhs, rhs):
+        return jax.lax.dot_general(
+            lhs,
+            rhs,
+            (((2,), (1,)), ((0,), (0,))),
+            precision=precision,
+            preferred_element_type=jnp.float32,
+        )
+
+    block_inverse = identity[None] + negative_diagonal_blocks
+    power = negative_diagonal_blocks
+    num_steps = {4: 1, 8: 2, 16: 3, 32: 4, 64: 5}[block_size]
+    for _ in range(num_steps):
+        power = _dot(power, power)
+        block_inverse = _dot(block_inverse, identity[None] + power)
+    return _solve_unbounded_block_forward(L, rhs, block_inverse, block_size, precision)
+
+
 # =====================================================================
 # Native segment_ids mega kernel -- avoids _align_seqs gather/scatter
 # =====================================================================
@@ -303,65 +498,15 @@ def _fwd_mega_kernel_native_segids(
 
         # --- Stage 2: Intra-chunk solve ---
         BC = QK_BC
-        NC = BT // BC
         beta_f32 = beta[:, :, None]
-        ref_idx = BC // 2 if safe_gate else 0
-        row_iota_bc_bt = jax.lax.broadcasted_iota(jnp.int32, (BC, BT), 0)
-        col_iota_bc_bt = jax.lax.broadcasted_iota(jnp.int32, (BC, BT), 1)
-        Aqk_rows, L_rows = [], []
-        k_eng_prefix = None
-        prev_gn = None
-        for i_sc in range(NC):
-            i_s = i_sc * BC
-            q_i, k_i = q[:, i_s : i_s + BC], k[:, i_s : i_s + BC]
-            g_i = g_cumsum[:, i_s : i_s + BC]
-            beta_i = beta_f32[:, i_s : i_s + BC]
-            gn = g_i[:, ref_idx : ref_idx + 1, :]
-            diff_i = g_i - gn
-            exp_i = jnp.exp2(diff_i)
-            q_eg, k_eg = q_i * exp_i, k_i * exp_i
-            j_end = i_s + BC
-            k_eng_current = k_i * jnp.exp2(-diff_i)
-            if i_sc == 0:
-                k_eng_prefix = k_eng_current
-            else:
-                ref_decay = jnp.exp2(gn - prev_gn)
-                k_eng_prefix = jnp.concatenate(
-                    [k_eng_prefix * ref_decay, k_eng_current],
-                    axis=1,
-                )
-            prev_gn = gn
-            qk_eg = jnp.concatenate([q_eg, k_eg], axis=1)
-            qk_dot_valid = jax.lax.dot_general(
-                qk_eg,
-                k_eng_prefix,
-                (((2,), (2,)), ((0,), (0,))),
-                precision=OUTPUT_PRECISION,
-                preferred_element_type=jnp.float32,
+        if lower_bound is None:
+            Aqk, L, kg = _build_unbounded_intra_terms(
+                q, k, g_cumsum, beta, scale, BC, OUTPUT_PRECISION
             )
-            if j_end < BT:
-                qk_dot = jnp.concatenate(
-                    [
-                        qk_dot_valid,
-                        jnp.zeros((MB, 2 * BC, BT - j_end), dtype=jnp.float32),
-                    ],
-                    axis=2,
-                )
-            else:
-                qk_dot = qk_dot_valid
-            Aqk_r = qk_dot[:, :BC] * scale
-            Akk_r = qk_dot[:, BC:] * beta_i
-            ind = (col_iota_bc_bt >= i_s) & (col_iota_bc_bt < i_s + BC)
-            cl = col_iota_bc_bt - i_s
-            Aqk_r = jnp.where((~ind) | (row_iota_bc_bt >= cl), Aqk_r, 0.0)
-            Akk_r = jnp.where((~ind) | (row_iota_bc_bt > cl), Akk_r, 0.0)
-            Aqk_rows.append(Aqk_r)
-            L_rows.append(Akk_r)
-
-        g_last = g_cumsum[:, BT - 1 : BT, :]
-        kg = k_eng_prefix * jnp.exp2(g_last - prev_gn)
-        Aqk = jnp.concatenate(Aqk_rows, axis=1)
-        L = jnp.concatenate(L_rows, axis=1)
+        else:
+            Aqk, L, kg = _build_bounded_intra_terms(
+                q, k, g_cumsum, beta, scale, BC, OUTPUT_PRECISION, safe_gate
+            )
 
         v_beta = v * beta_f32
         k_eg_beta = k * jnp.exp2(g_cumsum) * beta_f32
@@ -449,7 +594,10 @@ def _fwd_mega_kernel_native_segids(
             if NC_inv == 1:
                 A_inv = P
         else:
-            raise NotImplementedError("mega KDA supports only the Kimi-K3 bfloat16 Neumann path")
+            rhs = jnp.concatenate([v_beta, k_eg_beta], axis=-1)
+            result = _solve_unbounded_unit_lower(L, rhs, INV_BC, OUTPUT_PRECISION)
+            u = result[:, :, :V_PAD]
+            w = result[:, :, V_PAD : V_PAD + K_PAD]
 
         # --- Stage 3+4: State + Output ---
         b_h = scratch_ref[...]
@@ -595,62 +743,15 @@ def _fwd_mega_kernel_native_segids(
             shift *= 2
 
         BC = QK_BC
-        NC = BT // BC
         beta_f32 = beta[:, :, None]
-        ref_idx = BC // 2 if safe_gate else 0
-        row_iota_bc_bt = jax.lax.broadcasted_iota(jnp.int32, (BC, BT), 0)
-        col_iota_bc_bt = jax.lax.broadcasted_iota(jnp.int32, (BC, BT), 1)
-        Aqk_rows, L_rows = [], []
-        k_eng_prefix = None
-        prev_gn = None
-        for i_sc in range(NC):
-            i_s = i_sc * BC
-            q_i, k_i = q[:, i_s : i_s + BC], k[:, i_s : i_s + BC]
-            g_i = g_cumsum[:, i_s : i_s + BC]
-            beta_i = beta_f32[:, i_s : i_s + BC]
-            gn = g_i[:, ref_idx : ref_idx + 1, :]
-            diff_i = g_i - gn
-            exp_i = jnp.exp2(diff_i)
-            q_eg, k_eg = q_i * exp_i, k_i * exp_i
-            j_end = i_s + BC
-            k_eng_current = k_i * jnp.exp2(-diff_i)
-            if i_sc == 0:
-                k_eng_prefix = k_eng_current
-            else:
-                ref_decay = jnp.exp2(gn - prev_gn)
-                k_eng_prefix = jnp.concatenate(
-                    [k_eng_prefix * ref_decay, k_eng_current],
-                    axis=1,
-                )
-            prev_gn = gn
-            qk_eg = jnp.concatenate([q_eg, k_eg], axis=1)
-            qk_dot_valid = jax.lax.dot_general(
-                qk_eg,
-                k_eng_prefix,
-                (((2,), (2,)), ((0,), (0,))),
-                precision=OUTPUT_PRECISION,
-                preferred_element_type=jnp.float32,
+        if lower_bound is None:
+            Aqk, L, _ = _build_unbounded_intra_terms(
+                q, k, g_cumsum, beta, scale, BC, OUTPUT_PRECISION
             )
-            if j_end < BT:
-                qk_dot = jnp.concatenate(
-                    [
-                        qk_dot_valid,
-                        jnp.zeros((MB, 2 * BC, BT - j_end), dtype=jnp.float32),
-                    ],
-                    axis=2,
-                )
-            else:
-                qk_dot = qk_dot_valid
-            Aqk_r = qk_dot[:, :BC] * scale
-            Akk_r = qk_dot[:, BC:] * beta_i
-            ind = (col_iota_bc_bt >= i_s) & (col_iota_bc_bt < i_s + BC)
-            cl = col_iota_bc_bt - i_s
-            Aqk_r = jnp.where((~ind) | (row_iota_bc_bt >= cl), Aqk_r, 0.0)
-            Akk_r = jnp.where((~ind) | (row_iota_bc_bt > cl), Akk_r, 0.0)
-            Aqk_rows.append(Aqk_r)
-            L_rows.append(Akk_r)
-        Aqk = jnp.concatenate(Aqk_rows, axis=1)
-        L = jnp.concatenate(L_rows, axis=1)
+        else:
+            Aqk, L, _ = _build_bounded_intra_terms(
+                q, k, g_cumsum, beta, scale, BC, OUTPUT_PRECISION, safe_gate
+            )
         v_beta = v * beta_f32
         k_eg_beta = k * jnp.exp2(g_cumsum) * beta_f32
         I_bt = jnp.eye(BT, dtype=jnp.float32)
@@ -712,7 +813,10 @@ def _fwd_mega_kernel_native_segids(
             if NC_inv == 1:
                 A_inv = P
         else:
-            raise NotImplementedError("mega KDA supports only the Kimi-K3 bfloat16 Neumann path")
+            rhs = jnp.concatenate([v_beta, k_eg_beta], axis=-1)
+            result = _solve_unbounded_unit_lower(L, rhs, INV_BC, OUTPUT_PRECISION)
+            u = result[:, :, :V_PAD]
+            w = result[:, :, V_PAD : V_PAD + K_PAD]
         g_last = (g_cumsum * vm[None, :, None]).min(axis=1, keepdims=True)
         kg = k * jnp.exp2(g_last - g_cumsum) * vm[None, :, None]
 
@@ -884,63 +988,24 @@ def _fwd_mega_kernel_native_segids(
 
         # Aqk/L (FULL-style, no cross-seg masking in loop for stability)
         BC = QK_BC
-        NC = BT // BC
         beta_f32 = beta[:, :, None]
-        ref_idx = BC // 2 if safe_gate else 0
-        row_iota_bc_bt = jax.lax.broadcasted_iota(jnp.int32, (BC, BT), 0)
-        col_iota_bc_bt = jax.lax.broadcasted_iota(jnp.int32, (BC, BT), 1)
-        Aqk_rows, L_rows = [], []
-        k_eng_prefix = None
-        prev_gn = None
-        for i_sc in range(NC):
-            i_s = i_sc * BC
-            q_i = q[:, i_s : i_s + BC]
-            k_i = k[:, i_s : i_s + BC]
-            g_i = g_cumsum[:, i_s : i_s + BC]
-            beta_i = beta_f32[:, i_s : i_s + BC]
-            gn = g_i[:, ref_idx : ref_idx + 1, :]
-            diff_i = g_i - gn
-            exp_i = jnp.exp2(diff_i)
-            q_eg = q_i * exp_i
-            k_eg = k_i * exp_i
-            j_end = i_s + BC
-            k_eng_current = k_i * jnp.exp2(-diff_i)
-            if i_sc == 0:
-                k_eng_prefix = k_eng_current
-            else:
-                ref_decay = jnp.exp2(gn - prev_gn)
-                k_eng_prefix = jnp.concatenate(
-                    [k_eng_prefix * ref_decay, k_eng_current],
-                    axis=1,
-                )
-            prev_gn = gn
-            qk_eg = jnp.concatenate([q_eg, k_eg], axis=1)
-            qk_dot_valid = jax.lax.dot_general(
-                qk_eg,
-                k_eng_prefix,
-                (((2,), (2,)), ((0,), (0,))),
-                preferred_element_type=jnp.float32,
+        if lower_bound is None:
+            # Restart the log-domain prefix at the packed segment boundary.
+            # This preserves segment B's initial-state contribution even when
+            # segment A has accumulated a very negative unbounded gate.
+            first_segment_total = jnp.min(
+                jnp.where(seg_A_mask[None, :, None] > 0, g_cumsum, 0.0),
+                axis=1,
+                keepdims=True,
             )
-            if j_end < BT:
-                qk_dot = jnp.concatenate(
-                    [
-                        qk_dot_valid,
-                        jnp.zeros((MB, 2 * BC, BT - j_end), dtype=jnp.float32),
-                    ],
-                    axis=2,
-                )
-            else:
-                qk_dot = qk_dot_valid
-            Aqk_r = qk_dot[:, :BC] * scale
-            Akk_r = qk_dot[:, BC:] * beta_i
-            ind = (col_iota_bc_bt >= i_s) & (col_iota_bc_bt < i_s + BC)
-            cl = col_iota_bc_bt - i_s
-            Aqk_r = jnp.where((~ind) | (row_iota_bc_bt >= cl), Aqk_r, 0.0)
-            Akk_r = jnp.where((~ind) | (row_iota_bc_bt > cl), Akk_r, 0.0)
-            Aqk_rows.append(Aqk_r)
-            L_rows.append(Akk_r)
-        Aqk = jnp.concatenate(Aqk_rows, axis=1)
-        L = jnp.concatenate(L_rows, axis=1)
+            g_cumsum = g_cumsum - first_segment_total * seg_B_mask[None, :, None]
+            Aqk, L, _ = _build_unbounded_intra_terms(
+                q, k, g_cumsum, beta, scale, BC, OUTPUT_PRECISION
+            )
+        else:
+            Aqk, L, _ = _build_bounded_intra_terms(
+                q, k, g_cumsum, beta, scale, BC, OUTPUT_PRECISION, safe_gate
+            )
 
         # Mask L for segment-independent solve
         same_seg_L = (
@@ -1025,7 +1090,10 @@ def _fwd_mega_kernel_native_segids(
             u = result[:, :, :V_PAD]
             w = result[:, :, V_PAD : V_PAD + K_PAD]
         else:
-            raise NotImplementedError("mega KDA supports only the Kimi-K3 bfloat16 Neumann path")
+            rhs = jnp.concatenate([v_beta, k_eg_beta], axis=-1)
+            result = _solve_unbounded_unit_lower(L, rhs, INV_BC, OUTPUT_PRECISION)
+            u = result[:, :, :V_PAD]
+            w = result[:, :, V_PAD : V_PAD + K_PAD]
 
         if HAS_H0:
             if MANUAL_H0_DMA:
@@ -1111,7 +1179,7 @@ def _fwd_mega_kernel_native_segids(
         # produce inf * 0 = NaN for tokens belonging to the other segment.
         kg_A_exp = jnp.where(mask_A != 0, g_A_total - g_cumsum, 0.0)
         kg_A = k * jnp.exp2(kg_A_exp) * mask_A
-        g_cumsum_B_local = g_cumsum - g_A_total
+        g_cumsum_B_local = g_cumsum if lower_bound is None else g_cumsum - g_A_total
         kg_B_exp = jnp.where(mask_B != 0, g_B_total - g_cumsum_B_local, 0.0)
         kg_B = k * jnp.exp2(kg_B_exp) * mask_B
 
@@ -1242,6 +1310,8 @@ def _chunk_kda_fwd_native_segids_impl(
     BT = chunk_size
     if only_fwd and (disable_recompute or store_h or store_v_new):
         raise ValueError("only_fwd=True is incompatible with backward-intermediate storage")
+    if lower_bound is None and not only_fwd:
+        raise ValueError("unbounded Mega KDA currently supports inference-only forward execution")
     if disable_recompute:
         store_h = True
 
@@ -1320,7 +1390,10 @@ def _chunk_kda_fwd_native_segids_impl(
         else beta.transpose(2, 0, 1).reshape(H, B, NT, 1, BT)
     )
 
-    use_neumann = q.dtype == jnp.bfloat16
+    # The gate family is a model-static specialization. K3's bounded gate
+    # keeps the faster global Neumann composition; Kimi-Linear's unbounded
+    # gate uses ordered block substitution to avoid cancellation.
+    use_neumann = lower_bound is not None
     # With gate values as low as -5, a 32-token block can form masked
     # pre-causal products near 2**155 before the mask is applied. Keeping the
     # rescaling window at 16 bounds those products below the FP32/BF16 range.
@@ -1336,7 +1409,9 @@ def _chunk_kda_fwd_native_segids_impl(
     # 64x64 mask on the Stage 4 dependency chain.  Keep the training lowering
     # unchanged because it shares this kernel body.
     skip_stage4_mask = only_fwd
-    pack_head_inv = only_fwd and MB % 2 == 0 and os.environ.get("KDA_PACK_HEAD_INV", "1") == "1"
+    pack_head_inv = (
+        use_neumann and only_fwd and MB % 2 == 0 and os.environ.get("KDA_PACK_HEAD_INV", "1") == "1"
+    )
     clip_beta_in_kernel = only_fwd
     overlap_h0_dma = only_fwd and os.environ.get("KDA_OVERLAP_H0_DMA", "1") == "1"
     overlap_ht_dma = only_fwd and os.environ.get("KDA_OVERLAP_HT_DMA", "1") == "1"

--- a/python/sgl_jax/srt/kernels/kda/mega_kda/kernel.py
+++ b/python/sgl_jax/srt/kernels/kda/mega_kda/kernel.py
@@ -989,16 +989,16 @@ def _fwd_mega_kernel_native_segids(
         # Aqk/L (FULL-style, no cross-seg masking in loop for stability)
         BC = QK_BC
         beta_f32 = beta[:, :, None]
+        # Restart the log-domain prefix at the packed segment boundary. This
+        # preserves segment B's initial-state contribution; within-segment
+        # gate differences used by Aqk/L are unchanged by the constant shift.
+        first_segment_total = jnp.min(
+            jnp.where(seg_A_mask[None, :, None] > 0, g_cumsum, 0.0),
+            axis=1,
+            keepdims=True,
+        )
+        g_cumsum = g_cumsum - first_segment_total * seg_B_mask[None, :, None]
         if lower_bound is None:
-            # Restart the log-domain prefix at the packed segment boundary.
-            # This preserves segment B's initial-state contribution even when
-            # segment A has accumulated a very negative unbounded gate.
-            first_segment_total = jnp.min(
-                jnp.where(seg_A_mask[None, :, None] > 0, g_cumsum, 0.0),
-                axis=1,
-                keepdims=True,
-            )
-            g_cumsum = g_cumsum - first_segment_total * seg_B_mask[None, :, None]
             Aqk, L, _ = _build_unbounded_intra_terms(
                 q, k, g_cumsum, beta, scale, BC, OUTPUT_PRECISION
             )
@@ -1179,8 +1179,7 @@ def _fwd_mega_kernel_native_segids(
         # produce inf * 0 = NaN for tokens belonging to the other segment.
         kg_A_exp = jnp.where(mask_A != 0, g_A_total - g_cumsum, 0.0)
         kg_A = k * jnp.exp2(kg_A_exp) * mask_A
-        g_cumsum_B_local = g_cumsum if lower_bound is None else g_cumsum - g_A_total
-        kg_B_exp = jnp.where(mask_B != 0, g_B_total - g_cumsum_B_local, 0.0)
+        kg_B_exp = jnp.where(mask_B != 0, g_B_total - g_cumsum, 0.0)
         kg_B = k * jnp.exp2(kg_B_exp) * mask_B
 
         # seg_A final state

--- a/python/sgl_jax/srt/kernels/kda/mega_kda/kernel.py
+++ b/python/sgl_jax/srt/kernels/kda/mega_kda/kernel.py
@@ -1,0 +1,1736 @@
+# SPDX-License-Identifier: Apache-2.0
+# Adapted from a private upstream Pallas-kernel repository.
+# Upstream contact: pathfinder-pf.
+"""Inference-only native segment-ID KDA forward Pallas kernel.
+
+This module is intentionally separate from chunk_fwd_mega.py so inference
+optimizations cannot change the training, recompute, or context-parallel paths.
+"""
+
+# This file retains the source kernel's compact mathematical notation.
+# ruff: noqa: E702, E731, F841, SIM102, UP033
+
+from __future__ import annotations
+
+import functools
+import math
+import os
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+
+def align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+_RCP_LN2 = 1.0 / math.log(2)
+
+CHUNK_KIND_ALL_PAD = 0
+CHUNK_KIND_FULL_IN_SEGMENT = 1
+CHUNK_KIND_BOUNDARY = 2
+CHUNK_KIND_PARTIAL_PAD = 3
+CHUNK_FLAG_LAST_REAL = 4
+
+
+def _build_chunk_metadata(segment_ids, chunk_size):
+    """Build per-chunk metadata from segment IDs with zero denoting padding."""
+    orig_ndim = segment_ids.ndim
+    if orig_ndim == 1:
+        segment_ids = segment_ids[None, :]
+    batch, tokens = segment_ids.shape
+    block_tokens = int(chunk_size)
+    num_blocks = tokens // block_tokens
+    seg = segment_ids.astype(jnp.int32).reshape(batch, num_blocks, block_tokens)
+    seg_first = seg[:, :, 0]
+    valid_mask = seg > 0
+    pos = jnp.arange(block_tokens, dtype=jnp.int32)
+    last_valid_idx = jnp.where(valid_mask, pos[None, None, :], -1).max(axis=2)
+    has_any = last_valid_idx >= 0
+    safe_idx = jnp.where(has_any, last_valid_idx, 0)
+    seg_last = jnp.where(
+        has_any,
+        jnp.take_along_axis(seg, safe_idx[:, :, None], axis=2)[:, :, 0],
+        0,
+    )
+    seg_prev = jnp.concatenate(
+        [
+            jnp.zeros((batch, num_blocks, 1), dtype=jnp.int32),
+            seg[:, :, :-1],
+        ],
+        axis=2,
+    )
+    is_new = (seg != seg_prev) & (seg > 0)
+    distinct = is_new.sum(axis=2).astype(jnp.int32)
+    has_pad = (seg == 0).any(axis=2)
+    chunk_kind = jnp.where(
+        distinct == 0,
+        jnp.int32(CHUNK_KIND_ALL_PAD),
+        jnp.where(
+            distinct >= 2,
+            jnp.int32(CHUNK_KIND_BOUNDARY),
+            jnp.where(
+                has_pad,
+                jnp.int32(CHUNK_KIND_PARTIAL_PAD),
+                jnp.int32(CHUNK_KIND_FULL_IN_SEGMENT),
+            ),
+        ),
+    )
+    seg_id = jnp.where(chunk_kind == CHUNK_KIND_FULL_IN_SEGMENT, seg_first, 0).astype(jnp.int32)
+    if orig_ndim == 1:
+        return chunk_kind[0], seg_first[0], seg_last[0], seg_id[0]
+    return chunk_kind, seg_first, seg_last, seg_id
+
+
+# =====================================================================
+# Native segment_ids mega kernel -- avoids _align_seqs gather/scatter
+# =====================================================================
+
+
+def _fwd_mega_kernel_native_segids(
+    # Scalar-prefetch metadata
+    chunk_kind_meta_ref,  # [B, NT_META_PAD]
+    seg_first_meta_ref,  # [B, NT_META_PAD]
+    seg_last_meta_ref,  # [B, NT_META_PAD]
+    # Prefetch: segment_ids
+    seg_ids_ref,  # [B, 128] (128-aligned block)
+    # Inputs
+    q_ref,  # [MB, 1, BT, K_PAD]
+    k_ref,  # [MB, 1, BT, K_PAD]
+    v_ref,  # [MB, 1, BT, V_ALIGNED]
+    g_ref,  # [MB, 1, BT, K_PAD]
+    beta_ref,  # [MB, 1, 1, 1, BT]
+    h0_ref,  # auto window or full HBM ref for manual DMA
+    A_scale_ref,  # [MB, 1, 1, 1] or None
+    dt_bias_ref,  # [MB, 1, 1, K_PAD] or None
+    # Outputs
+    o_ref,  # [MB, 1, BT, V_ALIGNED]
+    ht_ref,  # all segments or streaming [2, MB, 1, K_PAD, V]
+    Aqk_ref,  # [MB, 1, BT, BT]
+    Akk_ref,  # [MB, 1, BT, BT]
+    g_cumsum_out_ref,  # [MB, 1, BT, K_PAD]
+    chunk_h_out_ref,  # [MB, 1, 1, K_PAD, V_ALIGNED] per-chunk h
+    # Scratch (VMEM persists across the NT loop for the same head and batch)
+    scratch_ref,  # [MB, K_PAD, V_ALIGNED] KV state
+    prev_seg_ref,  # [1] previous segment ID
+    final_state_dma_ref,  # [MB, K_PAD, V_ALIGNED] state write staging
+    state_dma_sem,  # DMA semaphore for conditional state transfers
+    *,
+    NT,
+    BT,
+    N_max,
+    scale,
+    cumsum_scale,
+    MB,
+    K_PAD,
+    V_PAD,
+    OUTPUT_PRECISION,
+    safe_gate,
+    NORMALIZE_QK,
+    use_gate_in_kernel,
+    lower_bound,
+    USE_NEUMANN,
+    QK_BC,
+    INV_BC,
+    SKIP_STAGE4_MASK,
+    PACK_HEAD_INV,
+    CLIP_BETA_IN_KERNEL,
+    PACKED_METADATA,
+    HAS_H0,
+    STORE_RESIDUALS,
+    STORE_H,
+    STORE_FINAL_STATE,
+    BATCH_FIRST,
+    MANUAL_H0_DMA,
+    MANUAL_HT_DMA,
+    OVERLAP_H0_DMA,
+    OVERLAP_HT_DMA,
+    RESIDUAL_CHUNK_LAYOUT,
+):
+    """Native segment_ids mega kernel body."""
+    i_b = pl.program_id(1)
+    i_c = pl.program_id(2)
+    chain_start = i_c == 0
+    t0 = i_c * BT
+
+    def _load_token_segment_ids():
+        seg_full = seg_ids_ref[i_b, :].astype(jnp.int32)  # [128]
+        if BT == 128:
+            return seg_full
+        seg_first_half = seg_full[:BT]
+        seg_second_half = seg_full[BT : 2 * BT]
+        use_second = ((i_c * BT) % 128) >= BT
+        return jnp.where(use_second, seg_second_half, seg_first_half)
+
+    if PACKED_METADATA:
+        packed_metadata = chunk_kind_meta_ref[i_b, i_c]
+        encoded_kind = packed_metadata & jnp.int32(0x7)
+        first_seg = (packed_metadata >> jnp.int32(3)) & jnp.int32(0x3FFF)
+        last_seg = packed_metadata >> jnp.int32(17)
+    else:
+        encoded_kind = chunk_kind_meta_ref[i_b, i_c]
+        first_seg = seg_first_meta_ref[i_b, i_c]
+        last_seg = seg_last_meta_ref[i_b, i_c]
+    kind = encoded_kind & jnp.int32(0x3)
+    is_last_real = (encoded_kind & jnp.int32(CHUNK_FLAG_LAST_REAL)) != 0
+
+    def _dma_state_to_ht(src_ref, segment_id):
+        h_start = pl.program_id(0) * MB
+        cp = pltpu.make_async_copy(
+            src_ref,
+            ht_ref.at[
+                segment_id - 1,
+                pl.ds(h_start, MB),
+                i_b,
+                pl.ds(None),
+                pl.ds(None),
+            ],
+            state_dma_sem,
+        )
+        cp.start()
+        cp.wait()
+
+    def _read_h0(segment_id):
+        return h0_ref[segment_id - 1, :, 0, :, :].astype(jnp.float32)
+
+    # ALL_PAD ----------------------------------------------------------
+    @pl.when(kind == CHUNK_KIND_ALL_PAD)
+    def _all_pad():
+        if BATCH_FIRST:
+            o_ref[0] = jnp.zeros([BT, MB, V_PAD], dtype=o_ref.dtype)
+        else:
+            o_ref[:, 0] = jnp.zeros([MB, BT, V_PAD], dtype=o_ref.dtype)
+        if STORE_RESIDUALS:
+            if RESIDUAL_CHUNK_LAYOUT:
+                Aqk_ref[:, 0, 0] = jnp.zeros([MB, BT, BT], dtype=Aqk_ref.dtype)
+                Akk_ref[:, 0, 0] = jnp.zeros([MB, BT, BT], dtype=Akk_ref.dtype)
+            else:
+                Aqk_ref[:, 0] = jnp.zeros([MB, BT, BT], dtype=Aqk_ref.dtype)
+                Akk_ref[:, 0] = jnp.zeros([MB, BT, BT], dtype=Akk_ref.dtype)
+
+            g_cumsum_out_ref[:, 0] = jnp.zeros([MB, BT, K_PAD], dtype=g_cumsum_out_ref.dtype)
+
+    # FULL_IN_SEGMENT fast path ---------------------------------------
+    @pl.when(kind == CHUNK_KIND_FULL_IN_SEGMENT)
+    def _full():
+        prev_seg = prev_seg_ref[0]
+        seg_changed = (first_seg != prev_seg) | chain_start
+
+        if STORE_FINAL_STATE:
+
+            @pl.when(seg_changed & (~chain_start))
+            def _save_prev():
+                if MANUAL_HT_DMA:
+                    _dma_state_to_ht(scratch_ref, prev_seg)
+                else:
+                    ht_ref[prev_seg - 1, ...] = scratch_ref[...].astype(ht_ref.dtype)[:, None, :, :]
+
+        @pl.when(seg_changed)
+        def _init():
+            scratch_ref[...] = jnp.zeros([MB, K_PAD, V_PAD], dtype=jnp.float32)
+
+        if HAS_H0:
+
+            @pl.when(seg_changed)
+            def _load_h0():
+                if MANUAL_H0_DMA:
+                    h_start = pl.program_id(0) * MB
+                    cp = pltpu.make_async_copy(
+                        h0_ref.at[
+                            first_seg - 1,
+                            pl.ds(h_start, MB),
+                            i_b,
+                            pl.ds(None),
+                            pl.ds(None),
+                        ],
+                        scratch_ref,
+                        state_dma_sem,
+                    )
+                    cp.start()
+                    cp.wait()
+                else:
+                    scratch_ref[...] = _read_h0(first_seg)
+
+        # --- Stage 1: Gate cumsum ---
+        if BATCH_FIRST:
+            q = q_ref[0].transpose(1, 0, 2).astype(jnp.float32)
+            k = k_ref[0].transpose(1, 0, 2).astype(jnp.float32)
+            v = v_ref[0].transpose(1, 0, 2).astype(jnp.float32)
+            g_raw = g_ref[0].transpose(1, 0, 2).astype(jnp.float32)
+        else:
+            q = q_ref[:, 0, :, :].astype(jnp.float32)
+            k = k_ref[:, 0, :, :].astype(jnp.float32)
+            v = v_ref[:, 0, :, :].astype(jnp.float32)
+            g_raw = g_ref[:, 0, :, :].astype(jnp.float32)
+        beta = (
+            beta_ref[0, 0].transpose(1, 0).astype(jnp.float32)
+            if BATCH_FIRST and beta_ref.ndim == 4
+            else beta_ref[:, 0, 0, 0, :].astype(jnp.float32)
+        )
+        if CLIP_BETA_IN_KERNEL:
+            beta = jnp.clip(beta, 0, 1)
+        if NORMALIZE_QK:
+            q *= jax.lax.rsqrt(jnp.sum(q * q, axis=-1, keepdims=True) + 1e-6)
+            k *= jax.lax.rsqrt(jnp.sum(k * k, axis=-1, keepdims=True) + 1e-6)
+            q = q.astype(jnp.bfloat16).astype(jnp.float32)
+            k = k.astype(jnp.bfloat16).astype(jnp.float32)
+
+        # Gate activation (matches cu_seqlens kernel)
+        g_f32 = g_raw
+        if use_gate_in_kernel:
+            dt_b = dt_bias_ref[:, 0, 0]
+            g_f32 = g_f32 + dt_b[:, None, :]
+            A_scale = A_scale_ref[:, 0, 0, 0]
+            if lower_bound is None:
+                g_f32 = -A_scale[:, None, None] * jax.nn.softplus(g_f32)
+            else:
+                g_f32 = lower_bound * jax.nn.sigmoid(A_scale[:, None, None] * g_f32)
+
+        g_cumsum = g_f32 * cumsum_scale
+        shift = 1
+        while shift < BT:
+            shifted = jnp.concatenate(
+                [
+                    jnp.zeros_like(g_cumsum[:, :shift]),
+                    g_cumsum[:, :-shift],
+                ],
+                axis=1,
+            )
+            g_cumsum = g_cumsum + shifted
+            shift *= 2
+
+        # --- Stage 2: Intra-chunk solve ---
+        BC = QK_BC
+        NC = BT // BC
+        beta_f32 = beta[:, :, None]
+        ref_idx = BC // 2 if safe_gate else 0
+        row_iota_bc_bt = jax.lax.broadcasted_iota(jnp.int32, (BC, BT), 0)
+        col_iota_bc_bt = jax.lax.broadcasted_iota(jnp.int32, (BC, BT), 1)
+        Aqk_rows, L_rows = [], []
+        k_eng_prefix = None
+        prev_gn = None
+        for i_sc in range(NC):
+            i_s = i_sc * BC
+            q_i, k_i = q[:, i_s : i_s + BC], k[:, i_s : i_s + BC]
+            g_i = g_cumsum[:, i_s : i_s + BC]
+            beta_i = beta_f32[:, i_s : i_s + BC]
+            gn = g_i[:, ref_idx : ref_idx + 1, :]
+            diff_i = g_i - gn
+            exp_i = jnp.exp2(diff_i)
+            q_eg, k_eg = q_i * exp_i, k_i * exp_i
+            j_end = i_s + BC
+            k_eng_current = k_i * jnp.exp2(-diff_i)
+            if i_sc == 0:
+                k_eng_prefix = k_eng_current
+            else:
+                ref_decay = jnp.exp2(gn - prev_gn)
+                k_eng_prefix = jnp.concatenate(
+                    [k_eng_prefix * ref_decay, k_eng_current],
+                    axis=1,
+                )
+            prev_gn = gn
+            qk_eg = jnp.concatenate([q_eg, k_eg], axis=1)
+            qk_dot_valid = jax.lax.dot_general(
+                qk_eg,
+                k_eng_prefix,
+                (((2,), (2,)), ((0,), (0,))),
+                precision=OUTPUT_PRECISION,
+                preferred_element_type=jnp.float32,
+            )
+            if j_end < BT:
+                qk_dot = jnp.concatenate(
+                    [
+                        qk_dot_valid,
+                        jnp.zeros((MB, 2 * BC, BT - j_end), dtype=jnp.float32),
+                    ],
+                    axis=2,
+                )
+            else:
+                qk_dot = qk_dot_valid
+            Aqk_r = qk_dot[:, :BC] * scale
+            Akk_r = qk_dot[:, BC:] * beta_i
+            ind = (col_iota_bc_bt >= i_s) & (col_iota_bc_bt < i_s + BC)
+            cl = col_iota_bc_bt - i_s
+            Aqk_r = jnp.where((~ind) | (row_iota_bc_bt >= cl), Aqk_r, 0.0)
+            Akk_r = jnp.where((~ind) | (row_iota_bc_bt > cl), Akk_r, 0.0)
+            Aqk_rows.append(Aqk_r)
+            L_rows.append(Akk_r)
+
+        g_last = g_cumsum[:, BT - 1 : BT, :]
+        kg = k_eng_prefix * jnp.exp2(g_last - prev_gn)
+        Aqk = jnp.concatenate(Aqk_rows, axis=1)
+        L = jnp.concatenate(L_rows, axis=1)
+
+        v_beta = v * beta_f32
+        k_eg_beta = k * jnp.exp2(g_cumsum) * beta_f32
+        I_bt = jnp.eye(BT, dtype=jnp.float32)
+        _dot = lambda a, b: jax.lax.dot_general(
+            a,
+            b,
+            (((2,), (1,)), ((0,), (0,))),
+            precision=OUTPUT_PRECISION,
+            preferred_element_type=jnp.float32,
+        )
+
+        if USE_NEUMANN:
+            BC_inv = INV_BC
+            NC_inv = BT // BC_inv
+            inv_dt = jnp.float32
+            L_inv = L.astype(inv_dt)
+            solve_bt = BT
+            solve_I = I_bt
+            if PACK_HEAD_INV:
+                # Pair independent heads in the MXU matrix dimensions. A
+                # 64x64 batched dot occupies a physical 128x128 tile, so two
+                # heads can share that tile without changing either BC8
+                # triangular system.
+                pair_mb = MB // 2
+                L_pair = L_inv.reshape(pair_mb, 2, BT, BT)
+                z = jnp.zeros_like(L_pair[:, 0])
+                L_inv = jnp.concatenate(
+                    [
+                        jnp.concatenate([L_pair[:, 0], z], axis=2),
+                        jnp.concatenate([z, L_pair[:, 1]], axis=2),
+                    ],
+                    axis=1,
+                )
+                solve_bt = 2 * BT
+                solve_I = jnp.eye(solve_bt, dtype=inv_dt)
+            _idx = jnp.arange(solve_bt, dtype=jnp.int32)
+            _blk = _idx // BC_inv
+            _same = (_blk[:, None] == _blk[None, :]).astype(inv_dt)
+            L_diag = L_inv * _same[None]
+            F = L_inv - L_diag
+            neg_Ld = -L_diag
+            S = solve_I[None] + neg_Ld
+            Mk = neg_Ld
+            num_diag_steps = {4: 1, 8: 2, 16: 3, 32: 4, 64: 5}[BC_inv]
+            for _ in range(num_diag_steps):
+                Mk = _dot(Mk, Mk)
+                S = _dot(S, solve_I[None] + Mk)
+            P = S
+            rhs = jnp.concatenate([v_beta.astype(inv_dt), k_eg_beta.astype(inv_dt)], axis=-1)
+            if PACK_HEAD_INV:
+                rhs = rhs.reshape(MB // 2, 2 * BT, V_PAD + K_PAD)
+            if NC_inv == 1:
+                result = _dot(P, rhs)
+            else:
+                F_and_rhs = jnp.concatenate([F, rhs], axis=-1)
+                P_merged = _dot(P, F_and_rhs)
+                G = P_merged[:, :, :solve_bt]
+                P_rhs = P_merged[:, :, solve_bt:]
+                H_mat = -G
+                inv_I_G = solve_I[None] + H_mat
+                Hk = H_mat
+                log2_NC_inv = {2: 1, 4: 2, 8: 3, 16: 4, 32: 5}[NC_inv]
+                num_horner_steps = log2_NC_inv - 1
+                if num_horner_steps > 0:
+                    Hk = _dot(Hk, Hk)
+                    for _ in range(num_horner_steps - 1):
+                        merged_lhs = jnp.concatenate([inv_I_G, Hk], axis=1)
+                        merged_products = _dot(merged_lhs, Hk)
+                        inv_I_G = inv_I_G + merged_products[:, :solve_bt]
+                        Hk = merged_products[:, solve_bt:]
+                    inv_I_G = inv_I_G + _dot(inv_I_G, Hk)
+                if STORE_RESIDUALS:
+                    rhs_and_inverse = jnp.concatenate([P_rhs, P], axis=-1)
+                    result_and_inverse = _dot(inv_I_G, rhs_and_inverse)
+
+                    result = result_and_inverse[:, :, : V_PAD + K_PAD]
+                    A_inv = result_and_inverse[:, :, V_PAD + K_PAD :]
+                else:
+                    result = _dot(inv_I_G, P_rhs)
+            if PACK_HEAD_INV:
+                result = result.reshape(MB, BT, V_PAD + K_PAD)
+            u = result[:, :, :V_PAD]
+            w = result[:, :, V_PAD : V_PAD + K_PAD]
+            if NC_inv == 1:
+                A_inv = P
+        else:
+            raise NotImplementedError("mega KDA supports only the Kimi-K3 bfloat16 Neumann path")
+
+        # --- Stage 3+4: State + Output ---
+        b_h = scratch_ref[...]
+        if STORE_H:
+            chunk_h_out_ref[:, 0, 0] = b_h.astype(chunk_h_out_ref.dtype)
+        b_qg = q * jnp.exp2(jnp.maximum(g_cumsum, -126.0))
+        b_v_o = jnp.matmul(
+            jnp.concatenate([w, b_qg], axis=1),
+            b_h,
+            precision=OUTPUT_PRECISION,
+            preferred_element_type=jnp.float32,
+        )
+        b_v_new = u - b_v_o[:, :BT]
+        b_o = b_v_o[:, BT:] * scale
+        if SKIP_STAGE4_MASK:
+            b_A = Aqk.astype(jnp.float32)
+        else:
+            m_s = (jnp.arange(BT)[:, None] >= jnp.arange(BT)[None, :]).astype(jnp.float32)
+            b_A = jnp.where(m_s[None, :, :], Aqk.astype(jnp.float32), 0.0)
+        b_o_h = jnp.matmul(
+            jnp.concatenate([b_A, kg.transpose(0, 2, 1)], axis=1),
+            b_v_new,
+            precision=OUTPUT_PRECISION,
+            preferred_element_type=jnp.float32,
+        )
+        b_o += b_o_h[:, :BT]
+        if BATCH_FIRST:
+            o_ref[0] = b_o.transpose(1, 0, 2).astype(o_ref.dtype)
+        else:
+            o_ref[:, 0] = b_o.astype(o_ref.dtype)
+
+        b_gk_last = g_cumsum[:, BT - 1, :]
+        b_h_new = b_h * jnp.exp2(b_gk_last)[:, :, None] + b_o_h[:, BT:]
+        scratch_ref[...] = b_h_new
+        if STORE_RESIDUALS:
+            if RESIDUAL_CHUNK_LAYOUT:
+                Aqk_ref[:, 0, 0] = Aqk.astype(Aqk_ref.dtype)
+                Akk_ref[:, 0, 0] = A_inv.astype(Akk_ref.dtype)
+            else:
+                Aqk_ref[:, 0] = Aqk.astype(Aqk_ref.dtype)
+                Akk_ref[:, 0] = A_inv.astype(Akk_ref.dtype)
+            g_cumsum_out_ref[:, 0] = g_cumsum.astype(g_cumsum_out_ref.dtype)
+        prev_seg_ref[...] = jnp.broadcast_to(first_seg, (128,))
+
+        if STORE_FINAL_STATE:
+
+            @pl.when(is_last_real)
+            def _final():
+                if MANUAL_HT_DMA:
+                    _dma_state_to_ht(scratch_ref, first_seg)
+                else:
+                    ht_ref[first_seg - 1, ...] = b_h_new.astype(ht_ref.dtype)[:, None, :, :]
+
+    # PARTIAL_PAD ------------------------------------------------------
+    @pl.when(kind == CHUNK_KIND_PARTIAL_PAD)
+    def _partial():
+        seg = _load_token_segment_ids()
+        prev_seg = prev_seg_ref[0]
+        seg_changed = (first_seg != prev_seg) | chain_start
+
+        if STORE_FINAL_STATE:
+
+            @pl.when(seg_changed & (~chain_start))
+            def _save_prev():
+                if MANUAL_HT_DMA:
+                    _dma_state_to_ht(scratch_ref, prev_seg)
+                else:
+                    ht_ref[prev_seg - 1, ...] = scratch_ref[...].astype(ht_ref.dtype)[:, None, :, :]
+
+        @pl.when(seg_changed)
+        def _init():
+            scratch_ref[...] = jnp.zeros([MB, K_PAD, V_PAD], dtype=jnp.float32)
+
+        if HAS_H0:
+
+            @pl.when(seg_changed)
+            def _load_h0():
+                if MANUAL_H0_DMA:
+                    h_start = pl.program_id(0) * MB
+                    cp = pltpu.make_async_copy(
+                        h0_ref.at[
+                            first_seg - 1,
+                            pl.ds(h_start, MB),
+                            i_b,
+                            pl.ds(None),
+                            pl.ds(None),
+                        ],
+                        scratch_ref,
+                        state_dma_sem,
+                    )
+                    cp.start()
+                    cp.wait()
+                else:
+                    scratch_ref[...] = _read_h0(first_seg)
+
+        vm = (seg > 0).astype(jnp.float32)  # [BT] valid mask
+        if BATCH_FIRST:
+            q = q_ref[0].transpose(1, 0, 2).astype(jnp.float32) * vm[None, :, None]
+            k = k_ref[0].transpose(1, 0, 2).astype(jnp.float32) * vm[None, :, None]
+            v = v_ref[0].transpose(1, 0, 2).astype(jnp.float32) * vm[None, :, None]
+            g_raw = g_ref[0].transpose(1, 0, 2).astype(jnp.float32) * vm[None, :, None]
+        else:
+            q = q_ref[:, 0, :, :].astype(jnp.float32) * vm[None, :, None]
+            k = k_ref[:, 0, :, :].astype(jnp.float32) * vm[None, :, None]
+            v = v_ref[:, 0, :, :].astype(jnp.float32) * vm[None, :, None]
+            g_raw = g_ref[:, 0, :, :].astype(jnp.float32) * vm[None, :, None]
+        beta = (
+            beta_ref[0, 0].transpose(1, 0).astype(jnp.float32)
+            if BATCH_FIRST and beta_ref.ndim == 4
+            else beta_ref[:, 0, 0, 0, :].astype(jnp.float32)
+        ) * vm[None, :]
+        if CLIP_BETA_IN_KERNEL:
+            beta = jnp.clip(beta, 0, 1)
+        if NORMALIZE_QK:
+            q *= jax.lax.rsqrt(jnp.sum(q * q, axis=-1, keepdims=True) + 1e-6)
+            k *= jax.lax.rsqrt(jnp.sum(k * k, axis=-1, keepdims=True) + 1e-6)
+            q = q.astype(jnp.bfloat16).astype(jnp.float32)
+            k = k.astype(jnp.bfloat16).astype(jnp.float32)
+
+        # Gate activation (must match FULL chunk)
+        g_f32 = g_raw
+        if use_gate_in_kernel:
+            dt_b = dt_bias_ref[:, 0, 0]
+            g_f32 = g_f32 + dt_b[:, None, :] * vm[None, :, None]
+            A_scale = A_scale_ref[:, 0, 0, 0]
+            if lower_bound is None:
+                g_f32 = -A_scale[:, None, None] * jax.nn.softplus(g_f32)
+            else:
+                g_f32 = lower_bound * jax.nn.sigmoid(A_scale[:, None, None] * g_f32)
+            g_f32 = g_f32 * vm[None, :, None]
+
+        g_cumsum = g_f32 * cumsum_scale
+        shift = 1
+        while shift < BT:
+            shifted = jnp.concatenate(
+                [
+                    jnp.zeros_like(g_cumsum[:, :shift]),
+                    g_cumsum[:, :-shift],
+                ],
+                axis=1,
+            )
+            g_cumsum = g_cumsum + shifted
+            shift *= 2
+
+        BC = QK_BC
+        NC = BT // BC
+        beta_f32 = beta[:, :, None]
+        ref_idx = BC // 2 if safe_gate else 0
+        row_iota_bc_bt = jax.lax.broadcasted_iota(jnp.int32, (BC, BT), 0)
+        col_iota_bc_bt = jax.lax.broadcasted_iota(jnp.int32, (BC, BT), 1)
+        Aqk_rows, L_rows = [], []
+        k_eng_prefix = None
+        prev_gn = None
+        for i_sc in range(NC):
+            i_s = i_sc * BC
+            q_i, k_i = q[:, i_s : i_s + BC], k[:, i_s : i_s + BC]
+            g_i = g_cumsum[:, i_s : i_s + BC]
+            beta_i = beta_f32[:, i_s : i_s + BC]
+            gn = g_i[:, ref_idx : ref_idx + 1, :]
+            diff_i = g_i - gn
+            exp_i = jnp.exp2(diff_i)
+            q_eg, k_eg = q_i * exp_i, k_i * exp_i
+            j_end = i_s + BC
+            k_eng_current = k_i * jnp.exp2(-diff_i)
+            if i_sc == 0:
+                k_eng_prefix = k_eng_current
+            else:
+                ref_decay = jnp.exp2(gn - prev_gn)
+                k_eng_prefix = jnp.concatenate(
+                    [k_eng_prefix * ref_decay, k_eng_current],
+                    axis=1,
+                )
+            prev_gn = gn
+            qk_eg = jnp.concatenate([q_eg, k_eg], axis=1)
+            qk_dot_valid = jax.lax.dot_general(
+                qk_eg,
+                k_eng_prefix,
+                (((2,), (2,)), ((0,), (0,))),
+                precision=OUTPUT_PRECISION,
+                preferred_element_type=jnp.float32,
+            )
+            if j_end < BT:
+                qk_dot = jnp.concatenate(
+                    [
+                        qk_dot_valid,
+                        jnp.zeros((MB, 2 * BC, BT - j_end), dtype=jnp.float32),
+                    ],
+                    axis=2,
+                )
+            else:
+                qk_dot = qk_dot_valid
+            Aqk_r = qk_dot[:, :BC] * scale
+            Akk_r = qk_dot[:, BC:] * beta_i
+            ind = (col_iota_bc_bt >= i_s) & (col_iota_bc_bt < i_s + BC)
+            cl = col_iota_bc_bt - i_s
+            Aqk_r = jnp.where((~ind) | (row_iota_bc_bt >= cl), Aqk_r, 0.0)
+            Akk_r = jnp.where((~ind) | (row_iota_bc_bt > cl), Akk_r, 0.0)
+            Aqk_rows.append(Aqk_r)
+            L_rows.append(Akk_r)
+        Aqk = jnp.concatenate(Aqk_rows, axis=1)
+        L = jnp.concatenate(L_rows, axis=1)
+        v_beta = v * beta_f32
+        k_eg_beta = k * jnp.exp2(g_cumsum) * beta_f32
+        I_bt = jnp.eye(BT, dtype=jnp.float32)
+        _dot = lambda a, b: jax.lax.dot_general(
+            a,
+            b,
+            (((2,), (1,)), ((0,), (0,))),
+            precision=OUTPUT_PRECISION,
+            preferred_element_type=jnp.float32,
+        )
+        if USE_NEUMANN:
+            BC_inv = INV_BC
+            NC_inv = BT // BC_inv
+            inv_dt = jnp.float32
+            L_inv = L.astype(inv_dt)
+            _idx = jnp.arange(BT, dtype=jnp.int32)
+            _blk = _idx // BC_inv
+            _same = (_blk[:, None] == _blk[None, :]).astype(inv_dt)
+            L_diag = L_inv * _same[None]
+            F = L_inv - L_diag
+            neg_Ld = -L_diag
+            S = I_bt[None] + neg_Ld
+            Mk = neg_Ld
+            num_diag_steps = {4: 1, 8: 2, 16: 3, 32: 4, 64: 5}[BC_inv]
+            for _ in range(num_diag_steps):
+                Mk = _dot(Mk, Mk)
+                S = _dot(S, I_bt[None] + Mk)
+            P = S
+            rhs = jnp.concatenate([v_beta.astype(inv_dt), k_eg_beta.astype(inv_dt)], axis=-1)
+            if NC_inv == 1:
+                result = _dot(P, rhs)
+            else:
+                F_and_rhs = jnp.concatenate([F, rhs], axis=-1)
+                P_merged = _dot(P, F_and_rhs)
+                G = P_merged[:, :, :BT]
+                P_rhs = P_merged[:, :, BT:]
+                H_mat = -G
+                inv_I_G = I_bt[None] + H_mat
+                Hk = H_mat
+                log2_NC_inv = {2: 1, 4: 2, 8: 3, 16: 4, 32: 5}[NC_inv]
+                num_horner_steps = log2_NC_inv - 1
+                if num_horner_steps > 0:
+                    Hk = _dot(Hk, Hk)
+                    for _ in range(num_horner_steps - 1):
+                        merged_lhs = jnp.concatenate([inv_I_G, Hk], axis=1)
+                        merged_products = _dot(merged_lhs, Hk)
+                        inv_I_G = inv_I_G + merged_products[:, :BT]
+                        Hk = merged_products[:, BT:]
+                    inv_I_G = inv_I_G + _dot(inv_I_G, Hk)
+                if STORE_RESIDUALS:
+                    rhs_and_inverse = jnp.concatenate([P_rhs, P], axis=-1)
+                    result_and_inverse = _dot(inv_I_G, rhs_and_inverse)
+                    result = result_and_inverse[:, :, : V_PAD + K_PAD]
+                    A_inv = result_and_inverse[:, :, V_PAD + K_PAD :]
+                else:
+                    result = _dot(inv_I_G, P_rhs)
+            u = result[:, :, :V_PAD]
+            w = result[:, :, V_PAD : V_PAD + K_PAD]
+            if NC_inv == 1:
+                A_inv = P
+        else:
+            raise NotImplementedError("mega KDA supports only the Kimi-K3 bfloat16 Neumann path")
+        g_last = (g_cumsum * vm[None, :, None]).min(axis=1, keepdims=True)
+        kg = k * jnp.exp2(g_last - g_cumsum) * vm[None, :, None]
+
+        b_h = scratch_ref[...]
+        if STORE_H:
+            chunk_h_out_ref[:, 0, 0] = b_h.astype(chunk_h_out_ref.dtype)
+        b_qg = q * jnp.exp2(jnp.maximum(g_cumsum, -126.0))
+        b_v_o = jnp.matmul(
+            jnp.concatenate([w, b_qg], axis=1),
+            b_h,
+            precision=OUTPUT_PRECISION,
+            preferred_element_type=jnp.float32,
+        )
+        b_v_new = u - b_v_o[:, :BT]
+        b_o = b_v_o[:, BT:] * scale
+        if SKIP_STAGE4_MASK:
+            b_A = Aqk.astype(jnp.float32)
+        else:
+            m_s = (jnp.arange(BT)[:, None] >= jnp.arange(BT)[None, :]).astype(jnp.float32)
+            b_A = jnp.where(m_s[None, :, :], Aqk.astype(jnp.float32), 0.0)
+        b_o_h = jnp.matmul(
+            jnp.concatenate([b_A, kg.transpose(0, 2, 1)], axis=1),
+            b_v_new,
+            precision=OUTPUT_PRECISION,
+            preferred_element_type=jnp.float32,
+        )
+        b_o += b_o_h[:, :BT]
+        b_o = b_o * vm[None, :, None]
+        if BATCH_FIRST:
+            o_ref[0] = b_o.transpose(1, 0, 2).astype(o_ref.dtype)
+        else:
+            o_ref[:, 0] = b_o.astype(o_ref.dtype)
+
+        b_gk_last = g_last[:, 0, :]
+        b_h_new = b_h * jnp.exp2(b_gk_last)[:, :, None] + b_o_h[:, BT:]
+        scratch_ref[...] = b_h_new
+        if STORE_FINAL_STATE:
+            if MANUAL_HT_DMA:
+                _dma_state_to_ht(scratch_ref, first_seg)
+            else:
+                ht_ref[first_seg - 1, ...] = b_h_new.astype(ht_ref.dtype)[:, None, :, :]
+        if STORE_RESIDUALS:
+            if RESIDUAL_CHUNK_LAYOUT:
+                Aqk_ref[:, 0, 0] = Aqk.astype(Aqk_ref.dtype)
+                Akk_ref[:, 0, 0] = A_inv.astype(Akk_ref.dtype)
+            else:
+                Aqk_ref[:, 0] = Aqk.astype(Aqk_ref.dtype)
+                Akk_ref[:, 0] = A_inv.astype(Akk_ref.dtype)
+            g_cumsum_out_ref[:, 0] = g_cumsum.astype(g_cumsum_out_ref.dtype)
+        prev_seg_ref[...] = jnp.broadcast_to(first_seg, (128,))
+
+        if STORE_FINAL_STATE:
+
+            @pl.when(is_last_real)
+            def _final():
+                if MANUAL_HT_DMA:
+                    _dma_state_to_ht(scratch_ref, first_seg)
+                else:
+                    ht_ref[first_seg - 1, ...] = b_h_new.astype(ht_ref.dtype)[:, None, :, :]
+
+    # BOUNDARY: two segments in one chunk -----------------------------
+    @pl.when(kind == CHUNK_KIND_BOUNDARY)
+    def _boundary():
+        seg = _load_token_segment_ids()
+        prev_seg = prev_seg_ref[0]
+        seg_changed = (first_seg != prev_seg) | chain_start
+
+        if STORE_FINAL_STATE:
+
+            @pl.when(seg_changed & (~chain_start))
+            def _save_prev():
+                if MANUAL_HT_DMA:
+                    _dma_state_to_ht(scratch_ref, prev_seg)
+                else:
+                    ht_ref[prev_seg - 1, ...] = scratch_ref[...].astype(ht_ref.dtype)[:, None, :, :]
+
+        @pl.when(seg_changed)
+        def _init():
+            scratch_ref[...] = jnp.zeros([MB, K_PAD, V_PAD], dtype=jnp.float32)
+
+        if HAS_H0:
+
+            @pl.when(seg_changed)
+            def _load_h0():
+                if MANUAL_H0_DMA:
+                    h_start = pl.program_id(0) * MB
+                    cp = pltpu.make_async_copy(
+                        h0_ref.at[
+                            first_seg - 1,
+                            pl.ds(h_start, MB),
+                            i_b,
+                            pl.ds(None),
+                            pl.ds(None),
+                        ],
+                        scratch_ref,
+                        state_dma_sem,
+                    )
+                    cp.start()
+                    cp.wait()
+                else:
+                    scratch_ref[...] = _read_h0(first_seg)
+
+        if HAS_H0 and MANUAL_H0_DMA and OVERLAP_H0_DMA:
+            h_start = pl.program_id(0) * MB
+            h0_B_copy = pltpu.make_async_copy(
+                h0_ref.at[
+                    last_seg - 1,
+                    pl.ds(h_start, MB),
+                    i_b,
+                    pl.ds(None),
+                    pl.ds(None),
+                ],
+                final_state_dma_ref,
+                state_dma_sem,
+            )
+            h0_B_copy.start()
+
+        # Segment masks
+        seg_A_mask = (seg == first_seg).astype(jnp.float32)  # [BT]
+        seg_B_mask = (seg == last_seg).astype(jnp.float32)  # [BT]
+
+        # --- FULL-style computation (backward-compatible) ---
+        if BATCH_FIRST:
+            q = q_ref[0].transpose(1, 0, 2).astype(jnp.float32)
+            k = k_ref[0].transpose(1, 0, 2).astype(jnp.float32)
+            v = v_ref[0].transpose(1, 0, 2).astype(jnp.float32)
+            g_raw = g_ref[0].transpose(1, 0, 2).astype(jnp.float32)
+        else:
+            q = q_ref[:, 0, :, :].astype(jnp.float32)
+            k = k_ref[:, 0, :, :].astype(jnp.float32)
+            v = v_ref[:, 0, :, :].astype(jnp.float32)
+            g_raw = g_ref[:, 0, :, :].astype(jnp.float32)
+        beta = (
+            beta_ref[0, 0].transpose(1, 0).astype(jnp.float32)
+            if BATCH_FIRST and beta_ref.ndim == 4
+            else beta_ref[:, 0, 0, 0, :].astype(jnp.float32)
+        )
+        if CLIP_BETA_IN_KERNEL:
+            beta = jnp.clip(beta, 0, 1)
+        if NORMALIZE_QK:
+            q *= jax.lax.rsqrt(jnp.sum(q * q, axis=-1, keepdims=True) + 1e-6)
+            k *= jax.lax.rsqrt(jnp.sum(k * k, axis=-1, keepdims=True) + 1e-6)
+            q = q.astype(jnp.bfloat16).astype(jnp.float32)
+            k = k.astype(jnp.bfloat16).astype(jnp.float32)
+
+        # Gate activation
+        g_f32 = g_raw
+        if use_gate_in_kernel:
+            dt_b = dt_bias_ref[:, 0, 0]
+            g_f32 = g_f32 + dt_b[:, None, :]
+            A_scale = A_scale_ref[:, 0, 0, 0]
+            if lower_bound is None:
+                g_f32 = -A_scale[:, None, None] * jax.nn.softplus(g_f32)
+            else:
+                g_f32 = lower_bound * jax.nn.sigmoid(A_scale[:, None, None] * g_f32)
+
+        g_cumsum = g_f32 * cumsum_scale
+        shift = 1
+        while shift < BT:
+            shifted = jnp.concatenate(
+                [
+                    jnp.zeros_like(g_cumsum[:, :shift]),
+                    g_cumsum[:, :-shift],
+                ],
+                axis=1,
+            )
+            g_cumsum = g_cumsum + shifted
+            shift *= 2
+
+        # Aqk/L (FULL-style, no cross-seg masking in loop for stability)
+        BC = QK_BC
+        NC = BT // BC
+        beta_f32 = beta[:, :, None]
+        ref_idx = BC // 2 if safe_gate else 0
+        row_iota_bc_bt = jax.lax.broadcasted_iota(jnp.int32, (BC, BT), 0)
+        col_iota_bc_bt = jax.lax.broadcasted_iota(jnp.int32, (BC, BT), 1)
+        Aqk_rows, L_rows = [], []
+        k_eng_prefix = None
+        prev_gn = None
+        for i_sc in range(NC):
+            i_s = i_sc * BC
+            q_i = q[:, i_s : i_s + BC]
+            k_i = k[:, i_s : i_s + BC]
+            g_i = g_cumsum[:, i_s : i_s + BC]
+            beta_i = beta_f32[:, i_s : i_s + BC]
+            gn = g_i[:, ref_idx : ref_idx + 1, :]
+            diff_i = g_i - gn
+            exp_i = jnp.exp2(diff_i)
+            q_eg = q_i * exp_i
+            k_eg = k_i * exp_i
+            j_end = i_s + BC
+            k_eng_current = k_i * jnp.exp2(-diff_i)
+            if i_sc == 0:
+                k_eng_prefix = k_eng_current
+            else:
+                ref_decay = jnp.exp2(gn - prev_gn)
+                k_eng_prefix = jnp.concatenate(
+                    [k_eng_prefix * ref_decay, k_eng_current],
+                    axis=1,
+                )
+            prev_gn = gn
+            qk_eg = jnp.concatenate([q_eg, k_eg], axis=1)
+            qk_dot_valid = jax.lax.dot_general(
+                qk_eg,
+                k_eng_prefix,
+                (((2,), (2,)), ((0,), (0,))),
+                preferred_element_type=jnp.float32,
+            )
+            if j_end < BT:
+                qk_dot = jnp.concatenate(
+                    [
+                        qk_dot_valid,
+                        jnp.zeros((MB, 2 * BC, BT - j_end), dtype=jnp.float32),
+                    ],
+                    axis=2,
+                )
+            else:
+                qk_dot = qk_dot_valid
+            Aqk_r = qk_dot[:, :BC] * scale
+            Akk_r = qk_dot[:, BC:] * beta_i
+            ind = (col_iota_bc_bt >= i_s) & (col_iota_bc_bt < i_s + BC)
+            cl = col_iota_bc_bt - i_s
+            Aqk_r = jnp.where((~ind) | (row_iota_bc_bt >= cl), Aqk_r, 0.0)
+            Akk_r = jnp.where((~ind) | (row_iota_bc_bt > cl), Akk_r, 0.0)
+            Aqk_rows.append(Aqk_r)
+            L_rows.append(Akk_r)
+        Aqk = jnp.concatenate(Aqk_rows, axis=1)
+        L = jnp.concatenate(L_rows, axis=1)
+
+        # Mask L for segment-independent solve
+        same_seg_L = (
+            seg_A_mask[:, None] * seg_A_mask[None, :] + seg_B_mask[:, None] * seg_B_mask[None, :]
+        )
+        L = L * same_seg_L[None]
+
+        # Solve (same as FULL)
+        v_beta = v * beta_f32
+        k_eg_beta = k * jnp.exp2(g_cumsum) * beta_f32
+        I_bt = jnp.eye(BT, dtype=jnp.float32)
+        _dot = lambda a, b: jax.lax.dot_general(
+            a, b, (((2,), (1,)), ((0,), (0,))), preferred_element_type=jnp.float32
+        )
+
+        if USE_NEUMANN:
+            BC_inv = INV_BC
+            NC_inv = BT // BC_inv
+            inv_dt = jnp.float32
+            L_inv = L.astype(inv_dt)
+            solve_bt = BT
+            solve_I = I_bt
+            if PACK_HEAD_INV:
+                pair_mb = MB // 2
+                L_pair = L_inv.reshape(pair_mb, 2, BT, BT)
+                z = jnp.zeros_like(L_pair[:, 0])
+                L_inv = jnp.concatenate(
+                    [
+                        jnp.concatenate([L_pair[:, 0], z], axis=2),
+                        jnp.concatenate([z, L_pair[:, 1]], axis=2),
+                    ],
+                    axis=1,
+                )
+                solve_bt = 2 * BT
+                solve_I = jnp.eye(solve_bt, dtype=inv_dt)
+            _idx = jnp.arange(solve_bt, dtype=jnp.int32)
+            _blk = _idx // BC_inv
+            _same = (_blk[:, None] == _blk[None, :]).astype(inv_dt)
+            L_diag = L_inv * _same[None]
+            F = L_inv - L_diag
+            neg_Ld = -L_diag
+            S = solve_I[None] + neg_Ld
+            Mk = neg_Ld
+            num_diag_steps = {4: 1, 8: 2, 16: 3, 32: 4, 64: 5}[BC_inv]
+            for _ in range(num_diag_steps):
+                Mk = _dot(Mk, Mk)
+                S = _dot(S, solve_I[None] + Mk)
+            P = S
+            rhs = jnp.concatenate([v_beta.astype(inv_dt), k_eg_beta.astype(inv_dt)], axis=-1)
+            if PACK_HEAD_INV:
+                rhs = rhs.reshape(MB // 2, 2 * BT, V_PAD + K_PAD)
+            if NC_inv == 1:
+                result = _dot(P, rhs)
+                A_inv = P
+            else:
+                F_and_rhs = jnp.concatenate([F, rhs], axis=-1)
+                P_merged = _dot(P, F_and_rhs)
+                G = P_merged[:, :, :solve_bt]
+                P_rhs = P_merged[:, :, solve_bt:]
+                H_mat = -G
+                inv_I_G = solve_I[None] + H_mat
+                Hk = H_mat
+                log2_NC_inv = {2: 1, 4: 2, 8: 3, 16: 4, 32: 5}[NC_inv]
+                num_horner_steps = log2_NC_inv - 1
+                if num_horner_steps > 0:
+                    Hk = _dot(Hk, Hk)
+                    for _ in range(num_horner_steps - 1):
+                        merged_lhs = jnp.concatenate([inv_I_G, Hk], axis=1)
+                        merged_products = _dot(merged_lhs, Hk)
+                        inv_I_G = inv_I_G + merged_products[:, :solve_bt]
+                        Hk = merged_products[:, solve_bt:]
+                    inv_I_G = inv_I_G + _dot(inv_I_G, Hk)
+                if STORE_RESIDUALS:
+                    rhs_and_inverse = jnp.concatenate([P_rhs, P], axis=-1)
+                    result_and_inverse = _dot(inv_I_G, rhs_and_inverse)
+                    result = result_and_inverse[:, :, : V_PAD + K_PAD]
+                    A_inv = result_and_inverse[:, :, V_PAD + K_PAD :]
+                else:
+                    result = _dot(inv_I_G, P_rhs)
+            if PACK_HEAD_INV:
+                result = result.reshape(MB, BT, V_PAD + K_PAD)
+            u = result[:, :, :V_PAD]
+            w = result[:, :, V_PAD : V_PAD + K_PAD]
+        else:
+            raise NotImplementedError("mega KDA supports only the Kimi-K3 bfloat16 Neumann path")
+
+        if HAS_H0:
+            if MANUAL_H0_DMA:
+                if OVERLAP_H0_DMA:
+                    h0_B_copy.wait()
+                else:
+                    h_start = pl.program_id(0) * MB
+                    cp = pltpu.make_async_copy(
+                        h0_ref.at[
+                            last_seg - 1,
+                            pl.ds(h_start, MB),
+                            i_b,
+                            pl.ds(None),
+                            pl.ds(None),
+                        ],
+                        final_state_dma_ref,
+                        state_dma_sem,
+                    )
+                    cp.start()
+                    cp.wait()
+            else:
+                final_state_dma_ref[...] = _read_h0(last_seg)
+        else:
+            final_state_dma_ref[...] = jnp.zeros([MB, K_PAD, V_PAD], dtype=jnp.float32)
+        h_B_initial = final_state_dma_ref[...]
+
+        g_last = g_cumsum[:, BT - 1 : BT, :]
+        kg = k * jnp.exp2(g_last - g_cumsum)
+
+        # --- Output + State ---
+        b_h = scratch_ref[...]
+        if STORE_H:
+            chunk_h_out_ref[:, 0, 0] = b_h.astype(chunk_h_out_ref.dtype)
+
+        b_qg = q * jnp.exp2(jnp.maximum(g_cumsum, -126.0))
+        b_v_o = jnp.matmul(
+            jnp.concatenate([w, b_qg], axis=1),
+            b_h,
+            precision=OUTPUT_PRECISION,
+            preferred_element_type=jnp.float32,
+        )
+        w_h = b_v_o[:, :BT]
+        b_v_new = u - w_h
+        state_o = b_v_o[:, BT:] * scale
+        b_v_o_B = jnp.matmul(
+            jnp.concatenate([w, b_qg], axis=1),
+            h_B_initial,
+            precision=OUTPUT_PRECISION,
+            preferred_element_type=jnp.float32,
+        )
+        w_h_B = b_v_o_B[:, :BT]
+        state_o_B = b_v_o_B[:, BT:] * scale
+
+        # Output: Aqk is already same-segment masked.  Build the correct
+        # per-segment v_new before the intra-chunk matmul so segment B does not
+        # need two additional Aqk compensation matmuls.
+        Aqk_seg = Aqk * same_seg_L[None]
+        if SKIP_STAGE4_MASK:
+            Aqk_stage4 = Aqk_seg.astype(jnp.float32)
+        else:
+            m_s = (jnp.arange(BT)[:, None] >= jnp.arange(BT)[None, :]).astype(jnp.float32)
+            Aqk_stage4 = jnp.where(m_s[None, :, :], Aqk_seg.astype(jnp.float32), 0.0)
+        mask_A = seg_A_mask[None, :, None]
+        mask_B = seg_B_mask[None, :, None]
+        v_new_B = (u - w_h_B) * mask_B
+        intra_rhs = b_v_new * mask_A + v_new_B
+        intra_o = jnp.matmul(
+            Aqk_stage4,
+            intra_rhs,
+            precision=OUTPUT_PRECISION,
+            preferred_element_type=jnp.float32,
+        )
+        b_o = (state_o + intra_o) * mask_A + (state_o_B + intra_o) * mask_B
+        if BATCH_FIRST:
+            o_ref[0] = b_o.transpose(1, 0, 2).astype(o_ref.dtype)
+        else:
+            o_ref[:, 0] = b_o.astype(o_ref.dtype)
+
+        # State: per-segment
+        g_A_total = jnp.sum(g_f32 * seg_A_mask[None, :, None], axis=1, keepdims=True) * cumsum_scale
+        g_B_total = jnp.sum(g_f32 * seg_B_mask[None, :, None], axis=1, keepdims=True) * cumsum_scale
+        # Mask the exponent before exp2. Masking the result afterwards can
+        # produce inf * 0 = NaN for tokens belonging to the other segment.
+        kg_A_exp = jnp.where(mask_A != 0, g_A_total - g_cumsum, 0.0)
+        kg_A = k * jnp.exp2(kg_A_exp) * mask_A
+        g_cumsum_B_local = g_cumsum - g_A_total
+        kg_B_exp = jnp.where(mask_B != 0, g_B_total - g_cumsum_B_local, 0.0)
+        kg_B = k * jnp.exp2(kg_B_exp) * mask_B
+
+        # seg_A final state
+        h_A_new = b_h * jnp.exp2(g_A_total[:, 0, :])[:, :, None] + jnp.matmul(
+            kg_A.transpose(0, 2, 1),
+            b_v_new * seg_A_mask[None, :, None],
+            precision=jax.lax.Precision.HIGHEST,
+            preferred_element_type=jnp.float32,
+        )
+        if STORE_FINAL_STATE:
+            if MANUAL_HT_DMA:
+                final_state_dma_ref[...] = h_A_new
+                if OVERLAP_HT_DMA:
+                    h_start = pl.program_id(0) * MB
+                    ht_A_copy = pltpu.make_async_copy(
+                        final_state_dma_ref,
+                        ht_ref.at[
+                            first_seg - 1,
+                            pl.ds(h_start, MB),
+                            i_b,
+                            pl.ds(None),
+                            pl.ds(None),
+                        ],
+                        state_dma_sem,
+                    )
+                    ht_A_copy.start()
+                else:
+                    _dma_state_to_ht(final_state_dma_ref, first_seg)
+            else:
+                ht_ref[first_seg - 1, ...] = h_A_new.astype(ht_ref.dtype)[:, None, :, :]
+
+        # seg_B starts inside this chunk and therefore uses its own h0.
+        h_B_new = h_B_initial * jnp.exp2(g_B_total[:, 0, :])[:, :, None] + jnp.matmul(
+            kg_B.transpose(0, 2, 1),
+            v_new_B,
+            precision=jax.lax.Precision.HIGHEST,
+            preferred_element_type=jnp.float32,
+        )
+        scratch_ref[...] = h_B_new
+        if STORE_FINAL_STATE and MANUAL_HT_DMA and OVERLAP_HT_DMA:
+            ht_A_copy.wait()
+        if STORE_FINAL_STATE:
+            if not MANUAL_HT_DMA:
+                ht_ref[last_seg - 1, ...] = h_B_new.astype(ht_ref.dtype)[:, None, :, :]
+
+        if STORE_RESIDUALS:
+            if RESIDUAL_CHUNK_LAYOUT:
+                Aqk_ref[:, 0, 0] = Aqk.astype(Aqk_ref.dtype)
+                Akk_ref[:, 0, 0] = A_inv.astype(Akk_ref.dtype)
+            else:
+                Aqk_ref[:, 0] = Aqk.astype(Aqk_ref.dtype)
+                Akk_ref[:, 0] = A_inv.astype(Akk_ref.dtype)
+            g_cumsum_out_ref[:, 0] = g_cumsum.astype(g_cumsum_out_ref.dtype)
+        prev_seg_ref[...] = jnp.broadcast_to(last_seg, (128,))
+
+        if STORE_FINAL_STATE:
+
+            @pl.when(is_last_real)
+            def _final():
+                if MANUAL_HT_DMA:
+                    _dma_state_to_ht(scratch_ref, last_seg)
+                else:
+                    ht_ref[last_seg - 1, ...] = h_B_new.astype(ht_ref.dtype)[:, None, :, :]
+
+
+def _fwd_mega_kernel_native_segids_packed(packed_metadata_ref, *args, **kwargs):
+    return _fwd_mega_kernel_native_segids(
+        packed_metadata_ref,
+        packed_metadata_ref,
+        packed_metadata_ref,
+        *args,
+        **kwargs,
+    )
+
+
+_NATIVE_SEGIDS_STATIC_ARGNAMES = [
+    "output_final_state",
+    "scale",
+    "chunk_size",
+    "store_h",
+    "store_v_new",
+    "disable_recompute",
+    "only_fwd",
+    "safe_gate",
+    "use_qk_l2norm_in_kernel",
+    "use_gate_in_kernel",
+    "lower_bound",
+    "mini_batch",
+    "N_max",
+    "residual_chunk_layout",
+    "batch_first",
+]
+
+
+def _chunk_kda_fwd_native_segids_impl(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    g: jax.Array,
+    beta: jax.Array,
+    segment_ids: jax.Array,
+    initial_state=None,
+    output_final_state=False,
+    scale=1.0,
+    chunk_size=64,
+    store_h=False,
+    store_v_new=False,
+    disable_recompute=False,
+    only_fwd=False,
+    safe_gate=True,
+    use_qk_l2norm_in_kernel=False,
+    use_gate_in_kernel=False,
+    A_log=None,
+    dt_bias=None,
+    lower_bound=None,
+    mini_batch=None,
+    N_max=None,
+    residual_chunk_layout=False,
+    batch_first=False,
+):
+    """Native segment_ids mega kernel wrapper. No _align_seqs."""
+    if batch_first:
+        B, T, H, K = q.shape
+    else:
+        H, B, T, K = q.shape
+    V = v.shape[-1]
+    BT = chunk_size
+    if only_fwd and (disable_recompute or store_h or store_v_new):
+        raise ValueError("only_fwd=True is incompatible with backward-intermediate storage")
+    if disable_recompute:
+        store_h = True
+
+    # Normalize segment_ids to [B, T]
+    if segment_ids.ndim == 1:
+        segment_ids = segment_ids[None, :]
+        if B > 1:
+            segment_ids = jnp.broadcast_to(segment_ids, (B, T))
+
+    NT = T // BT
+    packed_metadata = only_fwd and os.environ.get("KDA_PACKED_METADATA", "1") == "1"
+    chunk_kind, seg_first, seg_last, seg_id = _build_chunk_metadata(segment_ids, BT)
+    next_kind = jnp.concatenate(
+        [
+            chunk_kind[:, 1:],
+            jnp.zeros((B, 1), dtype=jnp.int32),
+        ],
+        axis=1,
+    )
+    is_last_real_chunk = (chunk_kind != CHUNK_KIND_ALL_PAD) & (next_kind == CHUNK_KIND_ALL_PAD)
+    chunk_kind = chunk_kind | (is_last_real_chunk.astype(jnp.int32) * CHUNK_FLAG_LAST_REAL)
+    if N_max is None:
+        N_max = int(segment_ids.max())  # Fallback: should not happen when called via dispatch
+    # The packed representation uses 3 kind/flag bits and two 14-bit segment IDs.
+    # Preserve the legacy three-prefetch ABI for unusually large N_max.
+    if packed_metadata and N_max >= 16384:
+        packed_metadata = False
+
+    K_PAD = int(align_up(K, 128))
+    V_ALIGNED = int(align_up(V, 128))
+    # Pad T to 128-aligned for segment_ids block spec (TPU requires last dim % 128 == 0)
+    T_PAD_S = int(align_up(T, 128))
+    NT_S = T_PAD_S // 128  # number of 128-blocks in T
+
+    def _pad(x, t):
+        p = t - x.shape[-1]
+        return jnp.pad(x, ((0, 0), (0, 0), (0, 0), (0, p))) if p > 0 else x
+
+    q_t, k_t, v_t, g_t = _pad(q, K_PAD), _pad(k, K_PAD), _pad(v, V_ALIGNED), _pad(g, K_PAD)
+    # Pad segment_ids to [B, T_PAD_S] (128-aligned in T dim)
+    if segment_ids.shape[-1] < T_PAD_S:
+        segment_ids = jnp.pad(segment_ids, ((0, 0), (0, T_PAD_S - segment_ids.shape[-1])))
+
+    # Rebuild metadata with padded T (chunk_size still BT, but more chunks now due to padding)
+    # Metadata arrays need last dim >= 128 or == array dim. Pad NT to 128 if needed.
+    NT_meta = T // BT  # original number of chunks
+    NT_meta_PAD = max(int(align_up(NT_meta, 128)), 128)  # at least 128
+    chunk_kind_padded = jnp.pad(
+        chunk_kind, ((0, 0), (0, NT_meta_PAD - NT_meta)), constant_values=CHUNK_KIND_ALL_PAD
+    )
+    seg_first_padded = jnp.pad(seg_first, ((0, 0), (0, NT_meta_PAD - NT_meta)))
+    seg_last_padded = jnp.pad(seg_last, ((0, 0), (0, NT_meta_PAD - NT_meta)))
+
+    env_mini_batch = os.environ.get("KDA_FWD_MB") if only_fwd else None
+    if mini_batch is None and env_mini_batch:
+        mini_batch = int(env_mini_batch)
+    if mini_batch is not None:
+        MB = mini_batch
+    elif only_fwd:
+        # The initial-state operand is scalar-prefetch-indexed to one segment.
+        # Try the full head group for inference; the final-state output window
+        # remains bounded by N_max and compilation will enforce the VMEM limit.
+        MB = min(H, 32)
+    else:
+        MB = min(H, 8)
+    while H % MB != 0:
+        MB //= 2
+
+    # The batch-first beta window is copy-free when one program owns the full
+    # head dimension. Smaller head groups use the head-first layout whose last
+    # dimension is the complete 64-token block and therefore TPU legal.
+    beta_batch_first = batch_first and only_fwd and MB == H
+    beta_t = (
+        beta.reshape(B, NT, BT, H)
+        if beta_batch_first
+        else beta.transpose(2, 0, 1).reshape(H, B, NT, 1, BT)
+    )
+
+    use_neumann = q.dtype == jnp.bfloat16
+    # With gate values as low as -5, a 32-token block can form masked
+    # pre-causal products near 2**155 before the mask is applied. Keeping the
+    # rescaling window at 16 bounds those products below the FP32/BF16 range.
+    qk_bc = 16
+    # A monolithic 64x64 Neumann polynomial can reach O(1e17)
+    # intermediates for correlated normalized keys with near-zero decay. The
+    # mathematically cancelling result then loses precision in FP32. Eight
+    # 8-token diagonal blocks bound the cancellation before the block-level
+    # composition on TPU MXU.
+    inv_bc = 8
+    # Stage 2 has already made Aqk causal in all three native segment-ID
+    # chunk variants.  In inference, avoid rebuilding and applying the same
+    # 64x64 mask on the Stage 4 dependency chain.  Keep the training lowering
+    # unchanged because it shares this kernel body.
+    skip_stage4_mask = only_fwd
+    pack_head_inv = only_fwd and MB % 2 == 0 and os.environ.get("KDA_PACK_HEAD_INV", "1") == "1"
+    clip_beta_in_kernel = only_fwd
+    overlap_h0_dma = only_fwd and os.environ.get("KDA_OVERLAP_H0_DMA", "1") == "1"
+    overlap_ht_dma = only_fwd and os.environ.get("KDA_OVERLAP_HT_DMA", "1") == "1"
+    _prec = jax.lax.Precision.DEFAULT if use_neumann else jax.lax.Precision.HIGHEST
+
+    # Prepare h0: broadcast to [1, H, 1, K_PAD, V_ALIGNED] so each grid point
+    # can read its own MB-sized block via _h0_map (avoids OOB on dim1).
+    has_h0 = initial_state is not None
+    state_dma_override = os.environ.get("KDA_MANUAL_STATE_DMA")
+    manual_state_dma = N_max >= 6 if state_dma_override is None else state_dma_override == "1"
+    h0_dma_override = os.environ.get("KDA_MANUAL_H0_DMA")
+    manual_h0_dma = (
+        only_fwd and has_h0 and (N_max > 6 if h0_dma_override is None else h0_dma_override == "1")
+    )
+    if has_h0:
+        h0 = initial_state
+        if h0.ndim == 4:
+            h0 = h0[None, ...]  # [1, N, H, K, V]
+        if h0.shape[0] < B:
+            h0 = jnp.broadcast_to(h0, (B,) + h0.shape[1:])
+
+        # Pass ALL N_max initial states for per-segment loading
+        # h0: [B, N_max, H, K, V] -> [N_max, H, B, K, V] -> pad -> [N_max, H, B, K_PAD, V_ALIGNED]
+        h0 = h0[:, :, :, :, :].transpose(1, 2, 0, 3, 4)  # [N_max, H, B, K, V]
+        if K_PAD > K:
+            h0 = jnp.pad(h0, ((0, 0), (0, 0), (0, 0), (0, K_PAD - K), (0, 0)))
+        if V_ALIGNED > V:
+            h0 = jnp.pad(h0, ((0, 0), (0, 0), (0, 0), (0, 0), (0, V_ALIGNED - V)))
+        h0_in = h0.astype(jnp.float32)  # [N_max, H, B, K_PAD, V_ALIGNED]
+    else:
+        h0_in = None
+
+    # Prepare A_log and dt_bias for gate activation inside kernel
+    if use_gate_in_kernel and A_log is not None:
+        H_A = A_log.shape[0]
+        n_rep = H // H_A
+        A_expanded = (
+            jnp.repeat(A_log.astype(jnp.float32), n_rep) if n_rep > 1 else A_log.astype(jnp.float32)
+        )
+        A_scale_in = jnp.exp(A_expanded).reshape(H, 1, 1, 1)
+    else:
+        A_scale_in = jnp.zeros((H, 1, 1, 1), dtype=jnp.float32)
+
+    if use_gate_in_kernel and dt_bias is not None:
+        H_A = A_log.shape[0]
+        n_rep = H // H_A
+        db_2d = dt_bias.reshape(-1)[: H_A * K].reshape(H_A, K).astype(jnp.float32)
+        if n_rep > 1:
+            db_2d = jnp.repeat(db_2d, n_rep, axis=0)
+        db_in = db_2d[:, None, None, :].astype(jnp.float32)  # [H, 1, 1, K]
+        if K_PAD > K:
+            db_in = jnp.pad(db_in, ((0, 0), (0, 0), (0, 0), (0, K_PAD - K)))
+        db_in = jnp.broadcast_to(db_in, (H, 1, 1, K_PAD))
+        # db_in stays [H, 1, 1, K_PAD]
+    else:
+        db_in = jnp.zeros((H, 1, 1, K_PAD), dtype=jnp.float32)
+
+    # Block specs -- index maps must accept all prefetch refs as args
+    # Note: index map returns block offset (in units of block size), not array element offset
+    def _seg_map(h, b, c, *refs):
+        # segment_ids has shape [B, T_PAD_S], block size is [B, 128]
+        # So we need to return (b_offset, seg_offset) where seg_offset is in units of 128
+        block_128 = (c * BT) // 128
+        return (0, block_128)
+
+    def _in_map(h, b, c, *refs):
+        return (b, c, h, 0) if batch_first else (h, b, c, 0)
+
+    def _h0_map(h, b, c, *refs):
+        return (0, h, b, 0, 0)
+
+    def _out_map(h, b, c, *refs):
+        return (h, b, c, 0)
+
+    def _out_chunk_map(h, b, c, *refs):
+        return (h, b, c, 0, 0)
+
+    def _beta_map(h, b, c, *refs):
+        return (b, c, 0, h) if beta_batch_first else (h, b, c, 0, 0)
+
+    def _ht_map(h, b, c, *refs):
+        return (0, h, b, 0, 0)
+
+    seg_spec = pl.BlockSpec([B, 128], index_map=_seg_map)
+    q_spec = pl.BlockSpec(
+        [1, BT, MB, K_PAD] if batch_first else [MB, 1, BT, K_PAD],
+        index_map=_in_map,
+    )
+    k_spec = pl.BlockSpec(
+        [1, BT, MB, K_PAD] if batch_first else [MB, 1, BT, K_PAD],
+        index_map=_in_map,
+    )
+    v_spec = pl.BlockSpec(
+        [1, BT, MB, V_ALIGNED] if batch_first else [MB, 1, BT, V_ALIGNED],
+        index_map=_in_map,
+    )
+    g_spec = pl.BlockSpec(
+        [1, BT, MB, K_PAD] if batch_first else [MB, 1, BT, K_PAD],
+        index_map=_in_map,
+    )
+    beta_spec = (
+        pl.BlockSpec([1, 1, BT, MB], index_map=_beta_map)
+        if beta_batch_first
+        else pl.BlockSpec([MB, 1, 1, 1, BT], index_map=_beta_map)
+    )
+    h0_spec = (
+        (
+            pl.BlockSpec(memory_space=pl.ANY)
+            if manual_h0_dma
+            else pl.BlockSpec(
+                [N_max, MB, 1, K_PAD, V_ALIGNED],
+                index_map=_h0_map,
+            )
+        )
+        if has_h0
+        else None
+    )
+
+    def _alog_map(h, b, c, *refs):
+        return (h, 0, 0, 0)
+
+    def _dtbias_map(h, b, c, *refs):
+        return (h, 0, 0, 0)
+
+    alog_spec = pl.BlockSpec([MB, 1, 1, 1], index_map=_alog_map)
+    dtbias_spec = pl.BlockSpec([MB, 1, 1, K_PAD], index_map=_dtbias_map)
+    if batch_first:
+
+        def _o_map(h, b, c, *refs):
+            return (b, c, h, 0)
+
+        o_spec = pl.BlockSpec([1, BT, MB, V_ALIGNED], index_map=_o_map)
+    else:
+        o_spec = pl.BlockSpec([MB, 1, BT, V_ALIGNED], index_map=_out_map)
+    store_final_state = output_final_state or store_h
+    ht_dma_override = os.environ.get("KDA_MANUAL_HT_DMA")
+    manual_ht_dma = (
+        only_fwd
+        and store_final_state
+        and (manual_state_dma if ht_dma_override is None else ht_dma_override == "1")
+    )
+    ht_spec = (
+        (
+            pl.BlockSpec(memory_space=pl.ANY)
+            if manual_ht_dma
+            else pl.BlockSpec(
+                [N_max, MB, 1, K_PAD, V_ALIGNED],
+                index_map=_ht_map,
+            )
+        )
+        if store_final_state
+        else None
+    )
+
+    store_residuals = not only_fwd
+    store_chunk_h = store_residuals and store_h
+    aqk_spec = (
+        pl.BlockSpec(
+            [MB, 1, 1, BT, BT] if residual_chunk_layout else [MB, 1, BT, BT],
+            index_map=_out_chunk_map if residual_chunk_layout else _out_map,
+        )
+        if store_residuals
+        else None
+    )
+    akk_spec = (
+        pl.BlockSpec(
+            [MB, 1, 1, BT, BT] if residual_chunk_layout else [MB, 1, BT, BT],
+            index_map=_out_chunk_map if residual_chunk_layout else _out_map,
+        )
+        if store_residuals
+        else None
+    )
+    g_cumsum_spec = (
+        pl.BlockSpec([MB, 1, BT, K_PAD], index_map=_out_map) if store_residuals else None
+    )
+    chunk_h_spec = (
+        pl.BlockSpec(
+            [MB, 1, 1, K_PAD, V_ALIGNED],
+            index_map=lambda h, b, c, *r: (h, b, c, 0, 0),
+        )
+        if store_chunk_h
+        else None
+    )
+
+    aqk_shape = (
+        jax.ShapeDtypeStruct(
+            (H, B, NT, BT, BT) if residual_chunk_layout else (H, B, T, BT),
+            q.dtype,
+        )
+        if store_residuals
+        else None
+    )
+    akk_shape = (
+        jax.ShapeDtypeStruct(
+            (H, B, NT, BT, BT) if residual_chunk_layout else (H, B, T, BT),
+            q.dtype,
+        )
+        if store_residuals
+        else None
+    )
+    g_cumsum_shape = (
+        jax.ShapeDtypeStruct((H, B, T, K_PAD), jnp.float32) if store_residuals else None
+    )
+
+    chunk_h_shape = (
+        jax.ShapeDtypeStruct((H, B, NT, K_PAD, V_ALIGNED), jnp.float32) if store_chunk_h else None
+    )
+
+    grid = (H // MB, B, NT)
+    if packed_metadata:
+        native_kernel = _fwd_mega_kernel_native_segids_packed
+        scalar_prefetch_count = 1
+        packed_meta = (
+            chunk_kind_padded.astype(jnp.int32)
+            | (seg_first_padded.astype(jnp.int32) << jnp.int32(3))
+            | (seg_last_padded.astype(jnp.int32) << jnp.int32(17))
+        )
+        scalar_inputs = (packed_meta,)
+    else:
+        native_kernel = _fwd_mega_kernel_native_segids
+        scalar_prefetch_count = 3
+        scalar_inputs = (
+            chunk_kind_padded,
+            seg_first_padded,
+            seg_last_padded,
+        )
+
+    o_out, ht_out, Aqk_out, Akk_out, g_cumsum_out, chunk_h_out = pl.pallas_call(
+        functools.partial(
+            native_kernel,
+            NT=NT,
+            BT=BT,
+            N_max=N_max,
+            scale=scale,
+            cumsum_scale=_RCP_LN2,
+            MB=MB,
+            K_PAD=K_PAD,
+            V_PAD=V_ALIGNED,
+            OUTPUT_PRECISION=_prec,
+            safe_gate=safe_gate,
+            NORMALIZE_QK=use_qk_l2norm_in_kernel,
+            use_gate_in_kernel=use_gate_in_kernel,
+            lower_bound=lower_bound,
+            USE_NEUMANN=use_neumann,
+            QK_BC=qk_bc,
+            INV_BC=inv_bc,
+            SKIP_STAGE4_MASK=skip_stage4_mask,
+            PACK_HEAD_INV=pack_head_inv,
+            CLIP_BETA_IN_KERNEL=clip_beta_in_kernel,
+            PACKED_METADATA=packed_metadata,
+            HAS_H0=has_h0,
+            STORE_RESIDUALS=store_residuals,
+            STORE_H=store_chunk_h,
+            STORE_FINAL_STATE=store_final_state,
+            BATCH_FIRST=batch_first,
+            MANUAL_H0_DMA=manual_h0_dma,
+            MANUAL_HT_DMA=manual_ht_dma,
+            OVERLAP_H0_DMA=overlap_h0_dma,
+            OVERLAP_HT_DMA=overlap_ht_dma,
+            RESIDUAL_CHUNK_LAYOUT=residual_chunk_layout,
+        ),
+        out_shape=[
+            jax.ShapeDtypeStruct(
+                (B, T, H, V_ALIGNED) if batch_first else (H, B, T, V_ALIGNED),
+                v.dtype,
+            ),
+            (
+                jax.ShapeDtypeStruct((N_max, H, B, K_PAD, V_ALIGNED), jnp.float32)
+                if store_final_state
+                else None
+            ),
+            aqk_shape,
+            akk_shape,
+            g_cumsum_shape,
+            chunk_h_shape,
+        ],
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=scalar_prefetch_count,
+            grid=grid,
+            in_specs=[
+                seg_spec,
+                q_spec,
+                k_spec,
+                v_spec,
+                g_spec,
+                beta_spec,
+                h0_spec,
+                alog_spec,
+                dtbias_spec,
+            ],
+            out_specs=[
+                o_spec,
+                ht_spec,
+                aqk_spec,
+                akk_spec,
+                g_cumsum_spec,
+                chunk_h_spec,
+            ],
+            scratch_shapes=[
+                pltpu.VMEM((MB, K_PAD, V_ALIGNED), jnp.float32),
+                pltpu.VMEM((128,), jnp.int32),
+                pltpu.VMEM((MB, K_PAD, V_ALIGNED), jnp.float32),
+                pltpu.SemaphoreType.DMA,
+            ],
+        ),
+        compiler_params=pltpu.CompilerParams(
+            dimension_semantics=("parallel", "parallel", "arbitrary"),
+            disable_bounds_checks=True,
+            vmem_limit_bytes=(60 * 1024 * 1024) if MB > 4 else None,
+        ),
+        interpret=os.environ.get("PALLAS_INTERPRET", "").strip().lower() in ("1", "true"),
+    )(
+        *scalar_inputs,
+        segment_ids,
+        q_t,
+        k_t,
+        v_t,
+        g_t,
+        beta_t,
+        h0_in,
+        A_scale_in,
+        db_in,
+    )
+
+    # Match the selected contract: [B, T, H, V] or [H, B, T, V].
+    o_out = o_out[..., :V]
+    # ht_out: [1, H, B, K_PAD, V_ALIGNED] -> [B, 1, H, K, V]
+    if ht_out is not None:
+        ht_out = ht_out[:, :, :, :K, :V].transpose(2, 0, 1, 3, 4)  # [B, N_max, H, K, V]
+
+    final_state = ht_out if store_final_state else None
+
+    # Trim g_cumsum: [H, B, T, K_PAD] -> [H, B, T, K]
+    if g_cumsum_out is not None and K_PAD > K:
+        g_cumsum_out = g_cumsum_out[:, :, :, :K]
+
+    if chunk_h_out is not None:
+        chunk_h_out = chunk_h_out[:, :, :, :K, :V]
+    return (
+        o_out,
+        final_state,
+        g_cumsum_out,
+        Aqk_out,
+        Akk_out,
+        None,
+        None,
+        None,
+        None,
+        None,
+        chunk_h_out,
+        None,
+    )
+
+
+_chunk_kda_fwd_native_segids = jax.jit(
+    _chunk_kda_fwd_native_segids_impl,
+    static_argnames=_NATIVE_SEGIDS_STATIC_ARGNAMES,
+)
+
+
+@functools.lru_cache(maxsize=None)
+def _native_residual_layout_jit_for_sharding(sharding):
+    """JIT variant whose ABI accepts the Pallas Aqk/Akk physical layout."""
+    from jax._src.layout import Format, Layout
+
+    pallas_layout = Layout(
+        major_to_minor=(0, 1, 2, 3, 4),
+        tiling=((8, 128), (2, 1)),
+    )
+    residual_format = Format(layout=pallas_layout, sharding=sharding)
+    return jax.jit(
+        _chunk_kda_fwd_native_segids_impl,
+        static_argnames=_NATIVE_SEGIDS_STATIC_ARGNAMES,
+        out_shardings=(
+            None,
+            None,
+            None,
+            residual_format,
+            residual_format,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+    )
+
+
+def _get_native_residual_layout_jit(q):
+    sharding = getattr(q, "sharding", None)
+    if sharding is None:
+        # Direct benchmark/eager use has a concrete array. A tracer without a
+        # concrete sharding falls back to the portable JIT variant.
+        return _chunk_kda_fwd_native_segids
+    return _native_residual_layout_jit_for_sharding(sharding)

--- a/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
@@ -365,7 +365,7 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
             raise ValueError(
                 f"SGLANG_JAX_KDA_PREFILL_KERNEL must be 'chunked' or 'mega', got {kernel!r}"
             )
-        use_mega = kernel == "mega" and lower_bound is not None
+        use_mega = kernel == "mega"
 
         def _prefill_call(q, k, v, g, beta, initial_state, cu_seqlens, A_log, dt_bias):
             operands = (q, k, v, g, beta, initial_state, cu_seqlens, A_log, dt_bias)

--- a/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
@@ -61,9 +61,9 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         v_conv_w = layer.v_conv1d.weight.value
         # _unpack_conv_states splits proj_size in 3 equal pieces; only valid
         # when proj_q == proj_k == proj_v (Kimi-Linear shape).
-        assert q_conv_w.shape[0] == k_conv_w.shape[0] == v_conv_w.shape[0], (
-            f"unequal Q/K/V proj widths: {q_conv_w.shape[0]}/{k_conv_w.shape[0]}/{v_conv_w.shape[0]}"
-        )
+        assert (
+            q_conv_w.shape[0] == k_conv_w.shape[0] == v_conv_w.shape[0]
+        ), f"unequal Q/K/V proj widths: {q_conv_w.shape[0]}/{k_conv_w.shape[0]}/{v_conv_w.shape[0]}"
         q_state, k_state, v_state = self._unpack_conv_states(conv_states)
 
         cu_q_lens = self.forward_metadata.cu_q_lens

--- a/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
+++ b/python/sgl_jax/srt/layers/attention/linear/kda_backend.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
 from jax.sharding import PartitionSpec as P
 
-from sgl_jax.srt.kernels.kda import chunk_kda, naive_recurrent_kda
+from sgl_jax.srt.kernels.kda import (
+    chunk_kda,
+    is_mega_kda_layout_supported,
+    kda_forward_packed,
+    naive_recurrent_kda,
+)
 from sgl_jax.srt.layers.attention.hybrid_linear_attn_backend import (
     LinearRecurrentAttnBackend,
 )
@@ -55,9 +61,9 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         v_conv_w = layer.v_conv1d.weight.value
         # _unpack_conv_states splits proj_size in 3 equal pieces; only valid
         # when proj_q == proj_k == proj_v (Kimi-Linear shape).
-        assert (
-            q_conv_w.shape[0] == k_conv_w.shape[0] == v_conv_w.shape[0]
-        ), f"unequal Q/K/V proj widths: {q_conv_w.shape[0]}/{k_conv_w.shape[0]}/{v_conv_w.shape[0]}"
+        assert q_conv_w.shape[0] == k_conv_w.shape[0] == v_conv_w.shape[0], (
+            f"unequal Q/K/V proj widths: {q_conv_w.shape[0]}/{k_conv_w.shape[0]}/{v_conv_w.shape[0]}"
+        )
         q_state, k_state, v_state = self._unpack_conv_states(conv_states)
 
         cu_q_lens = self.forward_metadata.cu_q_lens
@@ -104,11 +110,6 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         a = a.reshape(a.shape[0], layer.num_q_heads, layer.head_q_dim)
         b = b.reshape(b.shape[0], layer.num_q_heads)
 
-        # KDA requires L2-normalized q/k for all paths; upstream fuses this
-        # via use_qk_l2norm_in_kernel=True, while current kernel doesn't support.
-        q = l2_normalize(q)
-        k = l2_normalize(k)
-
         if forward_batch.forward_mode == ForwardMode.EXTEND:
             output, new_recurrent = self._forward_extend(
                 q,
@@ -122,6 +123,11 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
                 scale=layer.scale,
             )
         elif forward_batch.forward_mode == ForwardMode.DECODE:
+            # Decode uses the recurrent JAX path, so normalize Q/K before the
+            # call. Mega KDA performs the same normalization inside its prefill
+            # kernel; the chunked prefill fallback normalizes in its branch.
+            q = l2_normalize(q)
+            k = l2_normalize(k)
             output, new_recurrent = self._forward_decode(
                 q,
                 k,
@@ -345,7 +351,7 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         layer: RadixLinearAttention,
         scale: float | None = None,
     ) -> tuple[jax.Array, jax.Array]:
-        """Chunked prefill via Pallas kernel."""
+        """Prefill via Mega KDA, with a guarded fallback to the chunked kernel."""
         if layer.A_log is None or layer.dt_bias is None:
             raise ValueError("KDA gate activation requires layer.A_log and layer.dt_bias")
         H = q.shape[-2]
@@ -353,26 +359,66 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         A_log = layer.A_log.value.reshape(H)
         dt_bias = layer.dt_bias.value.reshape(H, -1)
         scale = scale if scale is not None else layer.scale
-
-        def _chunk_kda_call(q, k, v, g, beta, initial_state, cu_seqlens, A_log, dt_bias):
-            o, final_state, *_ = chunk_kda(
-                q,
-                k,
-                v,
-                g,
-                beta,
-                scale=scale,
-                initial_state=initial_state,
-                output_final_state=True,
-                cu_seqlens=cu_seqlens,
-                use_gate_in_kernel=True,
-                A_log=A_log,
-                dt_bias=dt_bias,
+        lower_bound = getattr(layer, "kda_gate_lower_bound", None)
+        kernel = os.environ.get("SGLANG_JAX_KDA_PREFILL_KERNEL", "mega").strip().lower()
+        if kernel not in {"chunked", "mega"}:
+            raise ValueError(
+                f"SGLANG_JAX_KDA_PREFILL_KERNEL must be 'chunked' or 'mega', got {kernel!r}"
             )
-            return o, final_state
+        use_mega = kernel == "mega" and lower_bound is not None
+
+        def _prefill_call(q, k, v, g, beta, initial_state, cu_seqlens, A_log, dt_bias):
+            operands = (q, k, v, g, beta, initial_state, cu_seqlens, A_log, dt_bias)
+
+            def _chunked(args):
+                q, k, v, g, beta, initial_state, cu_seqlens, A_log, dt_bias = args
+                q = l2_normalize(q)
+                k = l2_normalize(k)
+                o, final_state, *_ = chunk_kda(
+                    q,
+                    k,
+                    v,
+                    g,
+                    beta,
+                    scale=scale,
+                    initial_state=initial_state,
+                    output_final_state=True,
+                    cu_seqlens=cu_seqlens,
+                    use_gate_in_kernel=True,
+                    A_log=A_log,
+                    dt_bias=dt_bias,
+                    lower_bound=lower_bound,
+                )
+                return o, final_state
+
+            if not use_mega:
+                return _chunked(operands)
+
+            def _mega(args):
+                q, k, v, g, beta, initial_state, cu_seqlens, A_log, dt_bias = args
+                return kda_forward_packed(
+                    q,
+                    k,
+                    v,
+                    g,
+                    beta,
+                    cu_seqlens=cu_seqlens,
+                    A_log=A_log,
+                    dt_bias=dt_bias,
+                    scale=scale,
+                    initial_state=initial_state,
+                    lower_bound=lower_bound,
+                )
+
+            padded_tokens = (q.shape[1] + 63) // 64 * 64
+            layout_supported = is_mega_kda_layout_supported(
+                cu_seqlens,
+                padded_tokens,
+            )
+            return jax.lax.cond(layout_supported, _mega, _chunked, operands)
 
         sharded = jax.shard_map(
-            _chunk_kda_call,
+            _prefill_call,
             mesh=self.mesh,
             in_specs=(
                 P(None, "data", "tensor", None),  # q [1, T, H, K]
@@ -463,7 +509,12 @@ class KDAAttnBackend(LinearRecurrentAttnBackend):
         H = g.shape[-2]
         orig_dtype = g.dtype
         g32 = g.astype(jnp.float32) + layer.dt_bias.value.reshape(H, -1).astype(jnp.float32)
-        out = -jnp.exp(layer.A_log.value.reshape(H, 1).astype(jnp.float32)) * jax.nn.softplus(g32)
+        a_scale = jnp.exp(layer.A_log.value.reshape(H, 1).astype(jnp.float32))
+        lower_bound = getattr(layer, "kda_gate_lower_bound", None)
+        if lower_bound is None:
+            out = -a_scale * jax.nn.softplus(g32)
+        else:
+            out = lower_bound * jax.nn.sigmoid(a_scale * g32)
         return out.astype(orig_dtype)
 
     def _unpack_conv_states(

--- a/python/sgl_jax/srt/models/kimi_linear.py
+++ b/python/sgl_jax/srt/models/kimi_linear.py
@@ -251,6 +251,7 @@ class KimiDeltaAttention(nnx.Module):
             A_log=self.A_log,
             dt_bias=self.dt_bias,
         )
+        self.attn.kda_gate_lower_bound = linear_config.get("gate_lower_bound")
 
     def __call__(
         self,

--- a/python/sgl_jax/test/kernels/mega_kda_test.py
+++ b/python/sgl_jax/test/kernels/mega_kda_test.py
@@ -62,13 +62,15 @@ def _case(heads: int, lengths: tuple[int, ...], seed: int = 1550):
     }
 
 
-def _reference(arrays):
+def _reference(arrays, lower_bound: float | None = LOWER_BOUND):
     q = _normalize(arrays["q"])
     k = _normalize(arrays["k"])
-    activated_g = LOWER_BOUND * jax.nn.sigmoid(
-        jnp.exp(arrays["a_log"])[None, None, :, None]
-        * (arrays["g"].astype(jnp.float32) + arrays["dt_bias"][None, None, :, :])
-    )
+    gate_input = arrays["g"].astype(jnp.float32) + arrays["dt_bias"][None, None, :, :]
+    gate_scale = jnp.exp(arrays["a_log"])[None, None, :, None]
+    if lower_bound is None:
+        activated_g = -gate_scale * jax.nn.softplus(gate_input)
+    else:
+        activated_g = lower_bound * jax.nn.sigmoid(gate_scale * gate_input)
     outputs = []
     states = []
     offset = 0
@@ -89,7 +91,7 @@ def _reference(arrays):
     return jnp.concatenate(outputs, axis=1), jnp.stack(states)
 
 
-def _mega(arrays):
+def _mega(arrays, lower_bound: float | None = LOWER_BOUND):
     return kda_forward_packed(
         arrays["q"],
         arrays["k"],
@@ -101,7 +103,7 @@ def _mega(arrays):
         dt_bias=arrays["dt_bias"],
         scale=SCALE,
         initial_state=arrays["initial_state"],
-        lower_bound=LOWER_BOUND,
+        lower_bound=lower_bound,
     )
 
 
@@ -135,6 +137,61 @@ def test_mega_kda_matches_naive(heads: int, lengths: tuple[int, ...]):
     )
 
 
+@pytest.mark.parametrize(
+    ("heads", "lengths"),
+    [
+        (8, (61,)),
+        (8, (63, 65)),
+        (16, (64, 64)),
+    ],
+)
+def test_unbounded_mega_kda_matches_naive(heads: int, lengths: tuple[int, ...]):
+    arrays = _case(heads, lengths, seed=1554)
+    arrays["beta"] = arrays["beta"].astype(jnp.float32)
+    reference_output, reference_state = _reference(arrays, lower_bound=None)
+    mega_output, mega_state = _mega(arrays, lower_bound=None)
+    jax.block_until_ready((reference_output, reference_state, mega_output, mega_state))
+
+    np.testing.assert_allclose(
+        np.asarray(mega_output, dtype=np.float32),
+        np.asarray(reference_output, dtype=np.float32),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+    np.testing.assert_allclose(
+        np.asarray(mega_state, dtype=np.float32),
+        np.asarray(reference_state, dtype=np.float32),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+
+
+def test_unbounded_mega_kda_handles_extreme_gate_decay():
+    arrays = _case(8, (64,), seed=1555)
+    arrays["beta"] = arrays["beta"].astype(jnp.float32)
+    arrays["g"] = jnp.full_like(arrays["g"], 4.0)
+    arrays["dt_bias"] = jnp.ones_like(arrays["dt_bias"])
+    arrays["a_log"] = jnp.full_like(arrays["a_log"], np.log(4.0))
+    reference_output, reference_state = _reference(arrays, lower_bound=None)
+    mega_output, mega_state = _mega(arrays, lower_bound=None)
+    jax.block_until_ready((reference_output, reference_state, mega_output, mega_state))
+
+    assert np.isfinite(np.asarray(mega_output)).all()
+    assert np.isfinite(np.asarray(mega_state)).all()
+    np.testing.assert_allclose(
+        np.asarray(mega_output, dtype=np.float32),
+        np.asarray(reference_output, dtype=np.float32),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+    np.testing.assert_allclose(
+        np.asarray(mega_state, dtype=np.float32),
+        np.asarray(reference_state, dtype=np.float32),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+
+
 def test_mega_kda_state_chaining_matches_single_prefill():
     arrays = _case(8, (128,), seed=1552)
     full_output, full_state = _mega(arrays)
@@ -153,6 +210,42 @@ def test_mega_kda_state_chaining_matches_single_prefill():
     second["cu_seqlens"] = jnp.asarray([0, 64], dtype=jnp.int32)
     second["initial_state"] = first_state
     second_output, second_state = _mega(second)
+
+    split_output = jnp.concatenate([first_output, second_output], axis=1)
+    jax.block_until_ready((full_output, full_state, split_output, second_state))
+    np.testing.assert_allclose(
+        np.asarray(split_output, dtype=np.float32),
+        np.asarray(full_output, dtype=np.float32),
+        rtol=2e-2,
+        atol=1e-2,
+    )
+    np.testing.assert_allclose(
+        np.asarray(second_state, dtype=np.float32),
+        np.asarray(full_state, dtype=np.float32),
+        rtol=2e-2,
+        atol=1e-2,
+    )
+
+
+def test_unbounded_mega_kda_state_chaining_matches_single_prefill():
+    arrays = _case(8, (128,), seed=1556)
+    arrays["beta"] = arrays["beta"].astype(jnp.float32)
+    full_output, full_state = _mega(arrays, lower_bound=None)
+
+    first = dict(arrays)
+    for name in ("q", "k", "v", "g", "beta"):
+        first[name] = arrays[name][:, :64]
+    first["lengths"] = (64,)
+    first["cu_seqlens"] = jnp.asarray([0, 64], dtype=jnp.int32)
+    first_output, first_state = _mega(first, lower_bound=None)
+
+    second = dict(arrays)
+    for name in ("q", "k", "v", "g", "beta"):
+        second[name] = arrays[name][:, 64:]
+    second["lengths"] = (64,)
+    second["cu_seqlens"] = jnp.asarray([0, 64], dtype=jnp.int32)
+    second["initial_state"] = first_state
+    second_output, second_state = _mega(second, lower_bound=None)
 
     split_output = jnp.concatenate([first_output, second_output], axis=1)
     jax.block_until_ready((full_output, full_state, split_output, second_state))

--- a/python/sgl_jax/test/kernels/mega_kda_test.py
+++ b/python/sgl_jax/test/kernels/mega_kda_test.py
@@ -111,7 +111,6 @@ def _mega(arrays, lower_bound: float | None = LOWER_BOUND):
     ("heads", "lengths"),
     [
         (8, (61,)),
-        (8, (63, 65)),
         (12, (64, 64)),
         (16, (64, 64)),
         (24, (64, 64)),
@@ -135,6 +134,30 @@ def test_mega_kda_matches_naive(heads: int, lengths: tuple[int, ...]):
         rtol=5e-2,
         atol=5e-2,
     )
+
+
+def test_bounded_boundary_preserves_nonzero_initial_state():
+    """A segment starting inside a tile must use its own recurrent state."""
+    arrays = _case(8, (37, 91), seed=1557)
+    arrays["g"] = jnp.zeros_like(arrays["g"])
+    arrays["a_log"] = jnp.zeros_like(arrays["a_log"])
+    arrays["dt_bias"] = jnp.zeros_like(arrays["dt_bias"])
+    arrays["initial_state"] = jnp.zeros_like(arrays["initial_state"])
+    arrays["initial_state"] = (
+        arrays["initial_state"]
+        .at[1]
+        .set(jnp.broadcast_to(jnp.eye(K, V, dtype=jnp.float32), (8, K, V)))
+    )
+
+    reference_output, _ = _reference(arrays)
+    mega_output, _ = _mega(arrays)
+    jax.block_until_ready((reference_output, mega_output))
+
+    first_b_token = arrays["lengths"][0]
+    reference = np.asarray(reference_output[:, first_b_token], dtype=np.float32)
+    actual = np.asarray(mega_output[:, first_b_token], dtype=np.float32)
+    assert np.max(np.abs(reference)) > 1e-4
+    np.testing.assert_allclose(actual, reference, rtol=2e-2, atol=2e-4)
 
 
 @pytest.mark.parametrize(

--- a/python/sgl_jax/test/kernels/mega_kda_test.py
+++ b/python/sgl_jax/test/kernels/mega_kda_test.py
@@ -1,0 +1,187 @@
+"""Accuracy and packed-layout coverage for the inference-only Mega KDA kernel."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from sgl_jax.srt.kernels.kda.mega_kda import (
+    is_mega_kda_layout_supported,
+    kda_forward_packed,
+)
+from sgl_jax.srt.kernels.kda.naive import naive_recurrent_kda
+
+K = V = 128
+LOWER_BOUND = -5.0
+SCALE = K**-0.5
+
+
+def _normalize(value: jax.Array) -> jax.Array:
+    value = value.astype(jnp.float32)
+    value *= jax.lax.rsqrt(jnp.sum(value * value, axis=-1, keepdims=True) + 1e-6)
+    return value.astype(jnp.bfloat16)
+
+
+def _case(heads: int, lengths: tuple[int, ...], seed: int = 1550):
+    rng = np.random.default_rng(seed + heads)
+    tokens = sum(lengths)
+    shape = (1, tokens, heads, K)
+
+    def bf16_normal(scale: float = 1.0):
+        values = rng.standard_normal(shape, dtype=np.float32) * scale
+        return jnp.asarray(values, dtype=jnp.bfloat16)
+
+    return {
+        "q": bf16_normal(),
+        "k": bf16_normal(),
+        "v": bf16_normal(1.5),
+        "g": jnp.asarray(
+            rng.uniform(-4.5, 4.5, shape).astype(np.float32),
+            dtype=jnp.bfloat16,
+        ),
+        "beta": jnp.asarray(
+            rng.uniform(0.05, 0.95, shape[:-1]).astype(np.float32),
+            dtype=jnp.bfloat16,
+        ),
+        "a_log": jnp.asarray(rng.uniform(0.2, 3.0, (heads,)).astype(np.float32)),
+        "dt_bias": jnp.asarray(rng.uniform(-8.0, -1.5, (heads, K)).astype(np.float32)),
+        "initial_state": jnp.asarray(
+            rng.standard_normal(
+                (len(lengths), heads, K, V),
+                dtype=np.float32,
+            )
+            * 0.1
+        ),
+        "cu_seqlens": jnp.asarray(
+            [0, *np.cumsum(lengths, dtype=np.int32)],
+            dtype=jnp.int32,
+        ),
+        "lengths": lengths,
+    }
+
+
+def _reference(arrays):
+    q = _normalize(arrays["q"])
+    k = _normalize(arrays["k"])
+    activated_g = LOWER_BOUND * jax.nn.sigmoid(
+        jnp.exp(arrays["a_log"])[None, None, :, None]
+        * (arrays["g"].astype(jnp.float32) + arrays["dt_bias"][None, None, :, :])
+    )
+    outputs = []
+    states = []
+    offset = 0
+    for segment, length in enumerate(arrays["lengths"]):
+        output, state = naive_recurrent_kda(
+            q[:, offset : offset + length],
+            k[:, offset : offset + length],
+            arrays["v"][:, offset : offset + length],
+            activated_g[:, offset : offset + length],
+            arrays["beta"][:, offset : offset + length],
+            scale=SCALE,
+            initial_state=arrays["initial_state"][segment : segment + 1],
+            output_final_state=True,
+        )
+        outputs.append(output)
+        states.append(state[0])
+        offset += length
+    return jnp.concatenate(outputs, axis=1), jnp.stack(states)
+
+
+def _mega(arrays):
+    return kda_forward_packed(
+        arrays["q"],
+        arrays["k"],
+        arrays["v"],
+        arrays["g"],
+        arrays["beta"],
+        cu_seqlens=arrays["cu_seqlens"],
+        A_log=arrays["a_log"],
+        dt_bias=arrays["dt_bias"],
+        scale=SCALE,
+        initial_state=arrays["initial_state"],
+        lower_bound=LOWER_BOUND,
+    )
+
+
+@pytest.mark.parametrize(
+    ("heads", "lengths"),
+    [
+        (8, (61,)),
+        (8, (63, 65)),
+        (12, (64, 64)),
+        (16, (64, 64)),
+        (24, (64, 64)),
+    ],
+)
+def test_mega_kda_matches_naive(heads: int, lengths: tuple[int, ...]):
+    arrays = _case(heads, lengths)
+    reference_output, reference_state = _reference(arrays)
+    mega_output, mega_state = _mega(arrays)
+    jax.block_until_ready((reference_output, reference_state, mega_output, mega_state))
+
+    np.testing.assert_allclose(
+        np.asarray(mega_output, dtype=np.float32),
+        np.asarray(reference_output, dtype=np.float32),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+    np.testing.assert_allclose(
+        np.asarray(mega_state, dtype=np.float32),
+        np.asarray(reference_state, dtype=np.float32),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+
+
+def test_mega_kda_state_chaining_matches_single_prefill():
+    arrays = _case(8, (128,), seed=1552)
+    full_output, full_state = _mega(arrays)
+
+    first = dict(arrays)
+    for name in ("q", "k", "v", "g", "beta"):
+        first[name] = arrays[name][:, :64]
+    first["lengths"] = (64,)
+    first["cu_seqlens"] = jnp.asarray([0, 64], dtype=jnp.int32)
+    first_output, first_state = _mega(first)
+
+    second = dict(arrays)
+    for name in ("q", "k", "v", "g", "beta"):
+        second[name] = arrays[name][:, 64:]
+    second["lengths"] = (64,)
+    second["cu_seqlens"] = jnp.asarray([0, 64], dtype=jnp.int32)
+    second["initial_state"] = first_state
+    second_output, second_state = _mega(second)
+
+    split_output = jnp.concatenate([first_output, second_output], axis=1)
+    jax.block_until_ready((full_output, full_state, split_output, second_state))
+    np.testing.assert_allclose(
+        np.asarray(split_output, dtype=np.float32),
+        np.asarray(full_output, dtype=np.float32),
+        rtol=2e-2,
+        atol=1e-2,
+    )
+    np.testing.assert_allclose(
+        np.asarray(second_state, dtype=np.float32),
+        np.asarray(full_state, dtype=np.float32),
+        rtol=2e-2,
+        atol=1e-2,
+    )
+
+
+@pytest.mark.parametrize(
+    ("cu_seqlens", "expected"),
+    [
+        ([0, 64], True),
+        ([0, 63, 128], True),
+        ([0, 21, 42, 64], False),
+        ([0, 0, 32, 64], True),
+    ],
+)
+def test_mega_kda_layout_guard(cu_seqlens: list[int], expected: bool):
+    actual = is_mega_kda_layout_supported(
+        jnp.asarray(cu_seqlens, dtype=jnp.int32),
+        num_tokens=128,
+    )
+    assert bool(actual) is expected

--- a/python/sgl_jax/test/test_kda_attention.py
+++ b/python/sgl_jax/test/test_kda_attention.py
@@ -25,7 +25,7 @@ def _scaled_randn(rng: np.random.Generator, shape, scale: float = 0.1) -> np.nda
     # scale=0.1 is a test-only hack: it shrinks the recurrent state so bf16 noise
     # in the delta-rule update fits the global atol=1e-2 (shared with flashattn).
     # Kernel correctness is validated end-to-end (MMLU-pro on tp4dp4, PR #1047);
-    # only inputs that grow the state need it (q/k/v/a/b + initial state).
+    # only inputs that grow the state need it (q/k/v/a + initial state).
     return rng.standard_normal(shape).astype(np.float32) * scale
 
 
@@ -289,7 +289,8 @@ def create_test_data(
     k = normal((total_tokens, hidden))
     v = normal((total_tokens, hidden))
     a = normal((total_tokens, hidden))
-    b = normal((total_tokens, num_heads))
+    # Production Kimi-Linear computes beta as sigmoid(b_proj(...).float()).
+    b = jax.nn.sigmoid(normal((total_tokens, num_heads), scale=1.0).astype(jnp.float32))
 
     recurrent_indices = np.arange(1, batch_size + 1, dtype=np.int32)
     initial_ssm_state_dev = initial_ssm_state

--- a/python/sgl_jax/test/test_kda_attention_dp.py
+++ b/python/sgl_jax/test/test_kda_attention_dp.py
@@ -23,7 +23,7 @@ def _scaled_randn(rng: np.random.Generator, shape, scale: float = 0.1) -> np.nda
     # scale=0.1 is a test-only hack: it shrinks the recurrent state so bf16 noise
     # in the delta-rule update fits the global atol=1e-2 (shared with flashattn).
     # Kernel correctness is validated end-to-end (MMLU-pro on tp4dp4, PR #1047);
-    # only inputs that grow the state need it (q/k/v/a/b + initial state).
+    # only inputs that grow the state need it (q/k/v/a + initial state).
     return rng.standard_normal(shape).astype(np.float32) * scale
 
 
@@ -315,7 +315,9 @@ def create_test_data(
             k_i = _scaled_randn(rank_rng, (q_len, hidden))
             v_i = _scaled_randn(rank_rng, (q_len, hidden))
             a_i = _scaled_randn(rank_rng, (q_len, hidden))
-            b_i = _scaled_randn(rank_rng, (q_len, num_heads))
+            # Production Kimi-Linear computes beta as sigmoid(b_proj(...).float()).
+            b_logits = _scaled_randn(rank_rng, (q_len, num_heads), scale=1.0)
+            b_i = 1.0 / (1.0 + np.exp(-b_logits))
 
             req_has_initial_state = (
                 has_initial_state_per_rank is not None
@@ -447,7 +449,7 @@ def create_test_data(
     k_dev = jax.device_put(jnp.asarray(k_global, dtype=dtype), hidden_sharding)
     v_dev = jax.device_put(jnp.asarray(v_global, dtype=dtype), hidden_sharding)
     a_dev = jax.device_put(jnp.asarray(a_global, dtype=dtype), hidden_sharding)
-    b_dev = jax.device_put(jnp.asarray(b_global, dtype=dtype), head_sharding)
+    b_dev = jax.device_put(jnp.asarray(b_global, dtype=jnp.float32), head_sharding)
 
     return (
         fb,


### PR DESCRIPTION
## Motivation

The existing KDA prefill path launches a multi-stage chunked pipeline. This PR adds an inference-only Mega KDA Pallas kernel for both K3's bounded gate and Kimi-Linear's unbounded gate.

The kernel is adapted from a private upstream Pallas-kernel repository. The upstream contact is `pathfinder-pf`.

## Modifications

- Add Mega KDA under `kernels/kda/mega_kda/` without changing training or backward paths.
- Share packed segment handling, gate cumsum, state recurrence, and output fusion between both gate families.
- Keep a static solver specialization: bounded K3 uses the fast Neumann composition; unbounded Kimi-Linear uses overflow-safe decay construction and ordered block substitution.
- Restart the gate prefix at packed boundaries for both gate families so a segment starting inside a tile preserves its own non-zero initial state.
- Use Mega KDA by default for both K3 and Kimi-Linear prefill.
- Fall back to chunked KDA when a 64-token tile intersects more than two live requests.
- Keep `SGLANG_JAX_KDA_PREFILL_KERNEL=chunked` as the explicit escape hatch.

## Accuracy

```bash
PALLAS_INTERPRET=1 JAX_PLATFORMS=cpu uv run --project python --extra cpu --with pytest \
  pytest -q python/sgl_jax/test/kernels/mega_kda_test.py
```

Result: `15 passed in 19.57s` on CPU interpret mode. The suite covers bounded and unbounded gates, BF16 and FP32 beta, extreme unbounded decay, packed request boundaries, padding, layout fallback, and state chaining.

The packed-boundary regression uses one `T=128` input with lengths `(37, 91)`, a bounded gate, and a non-zero initial state for the second segment. It replaces a generic packed parameter, so this PR does not increase the kernel-test invocation count. Before the fix, the focused comparison fails with a maximum absolute output difference of `0.00213`; after the fix it passes at `rtol=2e-2, atol=2e-4`.

The existing backend integration fixtures now construct beta the same way as Kimi-Linear (`sigmoid(...float())`) instead of feeding signed random values. No model-level E2E or nightly test is added to CI.

On TPU v7x, direct unbounded comparisons against chunked KDA with production-like FP32 sigmoid beta covered 64, 128, packed, and 4096 tokens. The aggregate maximum absolute differences were:

- output: `0.0000610352`
- final state: `0.00013836`

## Kernel benchmark

```bash
PYTHONPATH=python python benchmark/kernels/kda/bench_mega_kda.py \
  --tokens 4096 --heads 16 --segments 1 --gate-mode unbounded \
  --warmups 10 --iterations 50 --rounds 2

PYTHONPATH=python python benchmark/kernels/kda/bench_mega_kda.py \
  --tokens 4096 --heads 16 --segments 4 --gate-mode unbounded \
  --warmups 10 --iterations 50 --rounds 2
```

Use `--gate-mode bounded` for the K3 specialization. Values below are the average of the two round medians on TPU v7x:

| Gate | Packed segments | Chunked | Mega KDA | Speedup |
|---|---:|---:|---:|---:|
| bounded | 1 | 16.275 ms | 0.409 ms | 39.8x |
| bounded | 4 | 19.078 ms | 0.418 ms | 45.6x |
| unbounded | 1 | 16.094 ms | 2.773 ms | 5.81x |
| unbounded | 4 | 18.847 ms | 2.768 ms | 6.81x |

Packed segments validate independent request boundaries; they are not sequence-parallel chunks.

## Kimi-Linear end-to-end benchmark

Start the default Mega server:

```bash
unset SGLANG_JAX_KDA_PREFILL_KERNEL
python -m sgl_jax.launch_server \
  --model-path moonshotai/Kimi-Linear-48B-A3B-Instruct \
  --trust-remote-code --device tpu --tp-size 8 --dp-size 1 \
  --skip-server-warmup --mem-fraction-static 0.85 \
  --max-prefill-tokens 4096 --chunked-prefill-size 4096 \
  --max-running-requests 8 --dtype bfloat16 \
  --attention-backend fa --page-size 256 --disable-radix-cache \
  --host 0.0.0.0 --port 30040
```

Run the workload:

```bash
python -m sgl_jax.bench_serving \
  --backend sgl-jax --host 127.0.0.1 --port 30040 \
  --model moonshotai/Kimi-Linear-48B-A3B-Instruct \
  --tokenizer moonshotai/Kimi-Linear-48B-A3B-Instruct \
  --dataset-name random --random-input-len 4096 --random-output-len 1 \
  --random-range-ratio 1 --num-prompts 8 --max-concurrency 1 \
  --request-rate inf --warmup-requests 2 --tokenize-prompt
```

For the fallback comparison, restart the same server after setting:

```bash
export SGLANG_JAX_KDA_PREFILL_KERNEL=chunked
```

Results for 8 fixed 4096-token prompts, concurrency 1, and one output token:

| Kernel | Median TTFT | Total token throughput |
|---|---:|---:|
| default Mega | 185.25 ms | 21,960.59 tok/s |
| chunked | 283.32 ms | 14,371.58 tok/s |

Mega reduces median TTFT by `34.6%` and increases total token throughput by `52.8%` in this prefill-focused workload.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
