### PR TITLE
fix(sampler): align the mask top-k/top-p/min-p path with the sort path (#289)

### DIFF
--- a/python/sgl_jax/srt/layers/sampler.py
+++ b/python/sgl_jax/srt/layers/sampler.py
@@ -14,6 +14,10 @@ from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
 from sgl_jax.srt.utils.jax_utils import is_tpu_runtime
 from sgl_jax.srt.utils.profiling_utils import named_scope
 
+# Rejection value for the mask sampling path. Low enough that `softmax` flushes
+# it to 0.0, and shared by every filter in that path -- they have to agree.
+_MASK_FILL_VALUE = -1e12
+
 
 class Sampler(nnx.Module):
     def __init__(self, rngs: nnx.Rngs = None, mesh: Mesh = None):
@@ -331,12 +335,23 @@ def top_p_normalize_probs_jax(
 
 
 def _apply_min_p_filter(operands):
-    """Apply min_p filtering when need_min_p_sampling=True"""
+    """Keep entries whose probability is >= `min_p` times the row maximum.
+
+    `use_probs` selects the space `inputs` lives in; both the threshold and the
+    rejection value follow from it:
+
+    * ``True``  -- probabilities. Threshold ``max(p) * min_p``, reject to ``0.0``.
+    * ``False`` -- logits. Threshold ``max(z) + log(min_p)``, reject to
+      ``_MASK_FILL_VALUE`` (``0.0`` is an ordinary logit, not a rejection).
+    """
     inputs, min_ps, use_probs = operands
     max_per_bs = jnp.max(inputs, axis=1)
-    min_p_thresholds = max_per_bs * min_ps
-    min_p_mask = inputs < min_p_thresholds.reshape(-1, 1)
-    return jnp.where(min_p_mask, 0.0, inputs)
+    if use_probs:
+        min_p_thresholds = max_per_bs * min_ps
+        return jnp.where(inputs < min_p_thresholds.reshape(-1, 1), 0.0, inputs)
+    # log(0) = -inf, so min_p=0 (the "disabled" encoding) rejects nothing.
+    min_p_thresholds = max_per_bs + jnp.log(min_ps)
+    return jnp.where(inputs < min_p_thresholds.reshape(-1, 1), _MASK_FILL_VALUE, inputs)
 
 
 def top_k_top_p_min_p_sampling_from_probs_jax(
@@ -424,11 +439,17 @@ def top_k_top_p_min_p_sampling_from_probs_jax_with_mask(args):
         rng,
     ) = args
     logits = logits.astype(jnp.float32)
-    logits = topk_mask(logits, top_ks, replace_val=-1e12)
-    logits = topp_mask(logits, top_ps, replace_val=-1e12)
 
+    # Before the masks: the cutoffs below have to be measured on the scaled
+    # distribution, which is what the sort path samples from.
     temperatures = temperatures.astype(logits.dtype)
     logits = jnp.divide(logits, temperatures)
+
+    # top-p first: `topp_mask` softmaxes internally, so after top-k it would
+    # measure the nucleus on the renormalized tail. `topk_mask` ranks by value,
+    # so it is unaffected by the sentinels top-p leaves behind.
+    logits = topp_mask(logits, top_ps, replace_val=_MASK_FILL_VALUE)
+    logits = topk_mask(logits, top_ks, replace_val=_MASK_FILL_VALUE)
 
     min_p_operands = (logits, min_ps)
     apply_min_p_filter_fn = lambda op: _apply_min_p_filter((*op, False))

--- a/python/sgl_jax/test/test_sampler.py
+++ b/python/sgl_jax/test/test_sampler.py
@@ -1,9 +1,11 @@
 import unittest
+from unittest import mock
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 
+from sgl_jax.srt.layers import sampler as sampler_mod
 from sgl_jax.srt.layers.sampler import multinomial_with_seed
 
 
@@ -102,6 +104,215 @@ class TestMultinomialWithSeed(unittest.TestCase):
         self.assertTrue(jnp.all(sample >= 0))
         self.assertTrue(jnp.all(sample < vocab_size))
         self.assertTrue(sample.dtype in [jnp.int32, jnp.int64])
+
+
+# ---------------------------------------------------------------------------
+# `--use-sort-for-toppk-minp` selects between two implementations of the same
+# top-k / top-p / min-p semantics, and defaults to False -- so the mask path is
+# what production runs. The two have to sample from the same distribution.
+# ---------------------------------------------------------------------------
+
+_VOCAB = 4096
+_BATCH = 4
+# The masks reject with `_MASK_FILL_VALUE`; anything above half of it is a real
+# logit that survived.
+_KEPT_LOGIT_FLOOR = sampler_mod._MASK_FILL_VALUE / 2
+# How far down the fixture's sorted distribution the probabilities are known to
+# be tie-free. See `test_fixture_ties_sit_below_every_cutoff`.
+_TIE_FREE_PREFIX = 512
+
+
+def _make_logits(seed: int = 0) -> jax.Array:
+    """Logits with a realistic shape: a broad tail plus a band of peaks."""
+    k1, k2 = jax.random.split(jax.random.PRNGKey(seed))
+    logits = jax.random.normal(k1, (_BATCH, _VOCAB))
+    peaks = jax.random.randint(k2, (_BATCH, 200), 0, _VOCAB)
+    return logits.at[jnp.arange(_BATCH)[:, None], peaks].add(3.0).astype(jnp.float32)
+
+
+def _make_args(logits, temperature, top_k, top_p, min_p):
+    """Build the 10-tuple `args` that `Sampler._regular_sampling` passes down.
+
+    `sampling_seeds=None` selects the plain `multinomial` in both paths, which is
+    the function the tests below intercept.
+    """
+    temperatures = jnp.full((_BATCH, 1), temperature, dtype=jnp.float32)
+    probs = jax.nn.softmax(jnp.divide(logits, temperatures), axis=-1)
+    return (
+        logits,
+        probs,
+        jnp.full((_BATCH,), top_k, dtype=jnp.int32),
+        jnp.full((_BATCH,), top_p, dtype=jnp.float32),
+        jnp.full((_BATCH,), min_p, dtype=jnp.float32),
+        jnp.arange(_BATCH, dtype=jnp.int32),
+        temperatures,
+        None,
+        jnp.asarray(min_p > 0.0),
+        jax.random.PRNGKey(0),
+    )
+
+
+def _capture(path_fn, args):
+    """Run one sampling path and return the tensor it was about to sample from."""
+    captured = {}
+
+    def spy(operands):
+        captured["inputs"] = operands[0]
+        return jnp.zeros((_BATCH, 1), dtype=jnp.int32)
+
+    with mock.patch.object(sampler_mod, "multinomial", new=spy):
+        path_fn(args)
+    return captured["inputs"]
+
+
+def _mask_path_probs(args):
+    """Vocab-ordered distribution the mask path samples from."""
+    return np.asarray(
+        jax.nn.softmax(
+            _capture(sampler_mod.top_k_top_p_min_p_sampling_from_probs_jax_with_mask, args), axis=-1
+        )
+    )
+
+
+def _sort_path_probs(args):
+    """Vocab-ordered distribution the sort path samples from.
+
+    The sort path hands `multinomial` a *descending-sorted* weight vector, so the
+    capture has to be scattered back through the sort permutation, which is
+    recomputed here. See `test_fixture_ties_sit_below_every_cutoff` for why that
+    reconstruction is exact for this fixture.
+    """
+    probs = args[1]
+    kept = _capture(sampler_mod.top_k_top_p_min_p_sampling_from_probs_jax_with_sort, args)
+    order = jnp.argsort(probs, axis=-1)[:, ::-1]
+    dense = jnp.zeros_like(probs).at[jnp.arange(_BATCH)[:, None], order].set(kept)
+    return np.asarray(dense / dense.sum(axis=-1, keepdims=True))
+
+
+def _total_variation(a, b):
+    return float(np.abs(a - b).sum(axis=-1).max() / 2)
+
+
+# (name, temperature, top_k, top_p, min_p)
+_CONFIGS = [
+    ("top_p only", 0.6, _VOCAB, 0.95, 0.0),
+    ("top_k only", 0.7, 20, 1.0, 0.0),
+    ("top_k + top_p", 0.7, 20, 0.80, 0.0),
+    ("top_k + top_p + min_p", 0.8, 50, 0.90, 0.10),
+    ("min_p only", 1.0, _VOCAB, 1.0, 0.05),
+    ("temperature 1.0", 1.0, 20, 0.80, 0.02),
+    ("top_p tighter than top_k", 0.7, 200, 0.30, 0.0),
+]
+
+
+class TestMaskPathMatchesSortPath(unittest.TestCase):
+    """The two sampling paths must filter to the same distribution.
+
+    Runs on whatever the default backend is. The sharding pitfall recorded in
+    test_sampler_deterministic_cond.py needs an explicit mesh, which the
+    unsharded fixture below never builds.
+    """
+
+    def test_fixture_ties_sit_below_every_cutoff(self):
+        """Precondition for the sort-permutation reconstruction in `_sort_path_probs`.
+
+        float32 does tie a handful of probabilities far down the 4096-wide tail,
+        so the permutation is ambiguous there. That is harmless as long as the
+        ties sit below everything the configs keep: the leading
+        `_TIE_FREE_PREFIX` probabilities are distinct, and `test_paths_agree`
+        pins that no config keeps more than that many tokens.
+        """
+        probs = np.asarray(_make_args(_make_logits(), 0.6, _VOCAB, 1.0, 0.0)[1])
+        for row in probs:
+            head = np.sort(row)[::-1][:_TIE_FREE_PREFIX]
+            self.assertEqual(len(np.unique(head)), _TIE_FREE_PREFIX)
+
+    def test_paths_agree(self):
+        logits = _make_logits()
+        for name, temperature, top_k, top_p, min_p in _CONFIGS:
+            with self.subTest(config=name):
+                args = _make_args(logits, temperature, top_k, top_p, min_p)
+                mask_probs = _mask_path_probs(args)
+                self.assertLessEqual(int((mask_probs > 0.0).sum(axis=-1).max()), _TIE_FREE_PREFIX)
+                tv = _total_variation(mask_probs, _sort_path_probs(args))
+                self.assertLess(
+                    tv,
+                    1e-5,
+                    f"mask and sort paths disagree on {name!r}: total variation {tv:.3e}",
+                )
+
+    def test_paths_keep_the_same_tokens(self):
+        """A distribution match could in principle hide a swapped tail; pin the support too."""
+        logits = _make_logits()
+        for name, temperature, top_k, top_p, min_p in _CONFIGS:
+            with self.subTest(config=name):
+                args = _make_args(logits, temperature, top_k, top_p, min_p)
+                mask_kept = _mask_path_probs(args) > 0.0
+                sort_kept = _sort_path_probs(args) > 0.0
+                np.testing.assert_array_equal(mask_kept, sort_kept, f"support differs on {name!r}")
+
+    def test_temperature_is_applied_before_top_p(self):
+        """Temperature reshapes the distribution, so it has to move the nucleus.
+
+        Applying it after the masks instead makes the kept set identical at
+        every temperature, which is what this asserts against.
+        """
+        logits = _make_logits()
+        kept = {
+            t: _capture(
+                sampler_mod.top_k_top_p_min_p_sampling_from_probs_jax_with_mask,
+                _make_args(logits, t, _VOCAB, 0.90, 0.0),
+            )
+            > _KEPT_LOGIT_FLOOR
+            for t in (0.5, 1.0, 2.0)
+        }
+        self.assertLess(int(kept[0.5].sum()), int(kept[1.0].sum()))
+        self.assertLess(int(kept[1.0].sum()), int(kept[2.0].sum()))
+
+    def test_top_p_measures_the_unmasked_distribution(self):
+        """top-p has to see the real distribution, not the top-k-renormalized one.
+
+        Checked against an explicit reference rather than against the sort path,
+        so the two production paths agreeing on something wrong would still fail
+        here. Running top-k first inflates every prefix mass by 1/mass(top-k), so
+        the top_p cutoff is reached earlier and the nucleus comes out strictly
+        narrower -- for this fixture, 75-200 tokens per row instead of 7-38.
+        """
+        top_k, top_p = 200, 0.6
+        args = _make_args(_make_logits(), 1.0, top_k, top_p, 0.0)
+
+        probs = np.asarray(args[1])
+        order = np.argsort(probs, axis=-1)[:, ::-1]
+        ordered = np.take_along_axis(probs, order, axis=-1)
+        keep = (np.cumsum(ordered, axis=-1) - ordered) <= top_p  # top-p, full probs
+        keep &= np.arange(_VOCAB)[None, :] < top_k  # intersected with top-k
+        expected = np.zeros_like(keep)
+        np.put_along_axis(expected, order, keep, axis=-1)
+
+        np.testing.assert_array_equal(_mask_path_probs(args) > 0.0, expected)
+
+    def test_min_p_rejects_in_logit_space(self):
+        """min_p on the mask path must use the sentinel, not 0.0.
+
+        0.0 is an ordinary logit and sits far above the -1e12 the top-k/top-p
+        masks write, so filling with it resurrects rejected tokens.
+        """
+        logits = _make_logits()
+        args = _make_args(logits, 1.0, _VOCAB, 1.0, 0.30)
+        captured = _capture(sampler_mod.top_k_top_p_min_p_sampling_from_probs_jax_with_mask, args)
+        rejected = np.asarray(captured <= _KEPT_LOGIT_FLOOR)
+        self.assertTrue(rejected.any(), "min_p=0.30 should reject something")
+        # Rejected entries carry exactly zero probability, not merely a small one.
+        self.assertTrue(np.all(_mask_path_probs(args)[rejected] == 0.0))
+
+    def test_min_p_zero_rejects_nothing(self):
+        """min_p=0 is the disabled encoding; log(0) = -inf must not mask or NaN."""
+        logits = _make_logits()
+        filtered = sampler_mod._apply_min_p_filter(
+            (logits, jnp.zeros((_BATCH,), dtype=jnp.float32), False)
+        )
+        self.assertFalse(bool(jnp.isnan(filtered).any()))
+        np.testing.assert_array_equal(np.asarray(filtered), np.asarray(logits))
 
 
 if __name__ == "__main__":

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -272,7 +272,7 @@ suites = {
         TestFile("python/sgl_jax/test/kernels/fused_moe_v2_test.py", 3),
         TestFile("python/sgl_jax/test/kernels/biased_topk_test.py", 1, runner="pytest"),
         TestFile("python/sgl_jax/test/kernels/grouped_topk_test.py", 1, runner="pytest"),
-        TestFile("python/sgl_jax/test/test_sampler.py", 0.2),
+        TestFile("python/sgl_jax/test/test_sampler.py", 0.5),
         TestFile("python/sgl_jax/test/test_sampler_deterministic_cond.py", 0.3),
         TestFile("python/sgl_jax/test/test_utils.py", 0.1),
         TestFile("python/sgl_jax/test/mem_cache/test_kv_cache.py", 0.7),


### PR DESCRIPTION


**TL;DR** — `--use-sort-for-toppk-minp` selects between two implementations of
the same top-k / top-p / min-p sampling. They do not agree, and the default one
(the mask path) is wrong in three ways:

1. temperature is applied *after* the masks, so top-p measures the unscaled
   distribution;
2. top-k runs before top-p, so top-p measures the top-k renormalized
   distribution and keeps too few tokens;
3. `min_p` applies the probability-space formula to logits and rejects to
   `0.0`, which does not reject anything.

This PR fixes all three. The two paths then agree: total variation below `1e-5`
and exactly the same set of kept tokens. New unit tests check this, and they
need no model eval.

Unblocks #289. It does not close it — see "Not in this PR".

## Motivation

Today the sampling behaviour of the server depends on a flag that is only
supposed to trade compile time for speed.

**Background.** #245 replaced `jnp.sort` with the mask kernels and won a large
amount of precompile time. Accuracy then dropped on some datasets, so #287 added
this flag as an escape hatch, describing it as a temporary trade-off between
precompile speed and accuracy, to be removed in #289 once there was a better
accuracy toolchain.

**There is no trade-off to make here.** The gap is three bugs in the mask path,
not a property of the mask approach. Once they are fixed the two paths agree,
and that is checkable on CPU, so #289 does not have to wait for an accuracy
toolchain.

Why it was never localized: #245 argued that the switch cannot change accuracy,
using the Gumbel-Max trick. That argument is correct, but it only covers
dropping the sort step. It says nothing about the order the filters run in, or
the space `min_p` runs in. That is where the three bugs are.

## Modifications

Everything is in `top_k_top_p_min_p_sampling_from_probs_jax_with_mask` and the
`min_p` helper. The sort path is not touched.

**1. Apply temperature before the masks.**

The sort path samples from `softmax(logits / temperatures)`, so it measures
every cutoff on the scaled distribution. The mask path divided by the
temperature *after* both masks, so it measured the cutoffs on the unscaled one.
The top-k cutoff does not depend on scale, so this is invisible when only top-k
is on. The top-p cutoff does depend on it. With top-k off, the old mask path
kept the same tokens at every temperature.

**2. Run top-p before top-k.**

`topp_mask` calls `softmax` on its own input. So when it runs after top-k, it
measures top-p on the renormalized top-k distribution. Every prefix sum is
larger by a factor of `1 / mass(top-k)`, the `top_p` cutoff is reached earlier,
and fewer tokens survive. On the fixture added here, `top_k=200, top_p=0.6`
keeps 7-38 tokens per row instead of 75-200.

The sort path takes both cutoffs from the same unmasked distribution and
intersects them. Running top-p first gives the same answer: `topk_mask` compares
values and never renormalizes, so the entries top-p masked out sit below every
surviving logit and cannot move the top-k cutoff.

**3. Make `_apply_min_p_filter` use its `use_probs` argument.**

The helper unpacked `use_probs` and then never read it. It always applied the
probability rule: threshold `max(p) * min_p`, reject to `0.0`. But the mask path
passes logits, not probabilities.

The logit-space form is not a new rule, it is the same inequality rewritten.
With `p = softmax(z)` and `Z` the shared denominator:

```
p_i          >= max(p) * min_p               the rule the sort path applies
exp(z_i)/Z   >= exp(z_max)/Z * min_p         substitute p = softmax(z)
exp(z_i)     >= exp(z_max) * min_p           Z cancels
z_i          >= z_max + log(min_p)           log is monotone
```

So the threshold becomes `max(z) + log(min_p)`. `min_p = 0` gives
`log(0) = -inf`, which rejects nothing - the correct "disabled" behaviour.

The fill value was wrong too: `0.0` is an ordinary logit, far above the `-1e12`
the other two masks write, so rejected tokens were not removed at all. They came
back with a high probability.

`-1e12` is now a module constant, since the `min_p` filter has to agree with the
two masks on it.

## Accuracy Tests

The new tests compare what the two paths hand to `multinomial`, over a table of
temperature / `top_k` / `top_p` / `min_p` settings:

- total variation below `1e-5`
- exactly the same set of kept tokens

There is also one directed guard per bug, plus a numpy reference for the top-p
rule that does not trust either path. I checked that each guard fails when its
bug is put back.

This needs no model eval. The claim is that two implementations agree, and that
is a numerical property.

```bash
python python/sgl_jax/test/test_sampler.py
```

The file is already in the `unit-test-tpu-v6e-1` suite, so PR CI runs these on
TPU. The `run_suite.py` change only raises its scheduling weight there, 0.2 ->
0.5 minutes, now that the file does more than start a process.

## Benchmarking and Profiling

No measurable cost change, and the precompile win from #245 is kept. It is the
same two binary searches in the other order, plus one `log` over a `[B]` vector
for `min_p`.

## Where the ordering came from, and one question

SGLang GPU applies top-k first and top-p second, but never renormalizes between
them: its top-p test is `(probs_sum - probs_sort) > top_ps`, where `probs_sum`
is the cumulative sum of the *original* sorted probabilities. Both cutoffs are
measured on the unmasked distribution and then intersected, so the textual order
does not matter there. This repo's sort path does the same. The mask path cannot
copy that order, because `topp_mask` renormalizes internally; running top-p
first is how it reproduces the same semantics.

The chained order looks like it arrived with the kernels: vLLM's
`tpu-inference` uses the same `topk_mask` / `topp_mask`, chains them the same
way, and has no `min_p` at all -- consistent with `min_p` being added here
during the port, in the wrong space.

So: I made the mask path match SGLang GPU and this repo's sort path. If you
would rather keep the chained `tpu-inference` behaviour, then the sort path is
the one that should change, and the same test would hold it to that instead.
Please tell me which you want.

## Not in this PR

- **Removing the flag**, which is what #289 asks for. I plan to open that as a
  follow-up PR once this one is merged and has gone through nightly CI: it is a
  mechanical deletion of the flag and the sort path, and by then it needs no
  eval evidence, because the two paths are already known to be equal.
- One difference between the paths is left, and it is pre-existing - this PR
  touches neither cast. In `Sampler._regular_sampling` the sort path casts back
  with `.astype(logits.dtype)` before `softmax`, so with a bf16 `lm_head` it
  computes probabilities in bf16, while the mask path starts with
  `.astype(jnp.float32)`. I left it alone because it is out of scope here. It
  does not block removing the flag; if anything it argues for keeping the mask
  path, which is the more precise of the two.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
