### PR TITLE
[Perf] feat(dsa): query-block sparse-MLA prefill kernel (2.2x TTFT @ 110k, 2.6x @ 16k)

### DIFF
--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
@@ -1,0 +1,92 @@
+"""Blocked (query-batched) sparse-MLA prefill — P1 of the DSA attend path.
+
+The deployed per-query kernel (``sparse_mla_prefill.py``) runs one program per
+query: each of the ``S`` queries independently DMAs its ``K`` selected pages. At
+long context the selections overlap heavily (sinks + local windows), so the same
+physical page is re-fetched by thousands of programs — ~298x redundant HBM
+traffic per layer at 110k — and the score matmul feeds only ``H`` (~4) sublane
+rows, idling the MXU.
+
+The blocked kernel amortises both: ``QB`` queries share one program, the block's
+selected-page **union** is DMA'd once per page, and per-query selection is
+restored with a ``-inf`` membership bias (bitmap AND causal AND kv_len) inside a
+flash-softmax over ``QB*H`` score rows.
+
+This module hosts (in build order):
+
+1. ``build_block_unit_tables`` — jnp preprocessing (outside the kernel): turn
+   ``topk_units [T, K]`` into per-block union tables + membership bitmaps.
+2. the Pallas query-block kernel itself (v1: single-sequence flat).
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+_SENTINEL = jnp.iinfo(jnp.int32).max
+
+
+def build_block_unit_tables(
+    topk_units,  # [T, K] int32 selected unit ids per query, -1 padded
+    *,
+    query_block: int,  # QB: queries per block
+    u_max: int,  # static cap on the per-block union size
+):
+    """Per-query-block union + membership tables for the blocked kernel.
+
+    Returns ``(blk_units, blk_member, blk_counts)``:
+
+    * ``blk_units [nQB, u_max]`` int32 — the block's selected units, sorted
+      ascending, ``-1`` padded. Uniques beyond ``u_max`` are dropped.
+    * ``blk_member [nQB, query_block, u_max]`` int8 — 1 where query ``q`` of the
+      block selected ``blk_units[b, u]`` (the kernel's -inf bias source).
+    * ``blk_counts [nQB]`` int32 — the TRUE union size, **uncapped**: a value
+      ``> u_max`` means the block overflowed and its tables are incomplete; the
+      caller must gate (pick ``u_max >= min(query_block*K, num_units)`` to make
+      overflow impossible).
+
+    ``T`` need not divide ``query_block``; trailing queries are padded with
+    ``-1`` rows (all-zero membership). Unit ids are opaque keys: callers with
+    packed multi-request (ragged) inputs lift seq-local ids to global keys
+    (e.g. ``base + page``) before calling, so blocks may straddle requests.
+    """
+    T, K = topk_units.shape
+    qb = query_block
+    n_blk = -(-T // qb)
+    pad = n_blk * qb - T
+    tk = jnp.pad(topk_units.astype(jnp.int32), ((0, pad), (0, 0)), constant_values=-1)
+    flat = tk.reshape(n_blk, qb * K)
+
+    # sort with -1/padding mapped to a +inf sentinel so invalids sink to the end
+    vals = jnp.where(flat < 0, _SENTINEL, flat)
+    svals = jnp.sort(vals, axis=1)
+    is_new = jnp.concatenate([jnp.ones((n_blk, 1), bool), svals[:, 1:] != svals[:, :-1]], axis=1)
+    uniq = is_new & (svals != _SENTINEL)
+    blk_counts = uniq.sum(axis=1).astype(jnp.int32)
+
+    # compact: scatter each first-occurrence to its rank; overflow ranks drop
+    rank = jnp.cumsum(uniq, axis=1) - 1
+    rank = jnp.where(uniq, rank, u_max)  # non-unique/sentinel -> out of range
+    rows = jnp.broadcast_to(jnp.arange(n_blk, dtype=jnp.int32)[:, None], rank.shape)
+    blk_units = jnp.full((n_blk, u_max), -1, jnp.int32)
+    blk_units = blk_units.at[rows, rank].set(svals, mode="drop")
+
+    # membership: binary-search every (query, k) selection in the compacted
+    # table (valid prefix ascending; -1 pad remapped to the sentinel so the
+    # array is globally sorted). O(T*K*log u_max) and no [.., K, u_max]
+    # broadcast materialisation.
+    search_tbl = jnp.where(blk_units < 0, _SENTINEL, blk_units)
+    pos = jax.vmap(jnp.searchsorted)(search_tbl, vals)  # [n_blk, qb*K]
+    pos_c = jnp.minimum(pos, u_max - 1)
+    hit = (
+        (vals != _SENTINEL)
+        & (pos < u_max)
+        & (jnp.take_along_axis(search_tbl, pos_c, axis=1) == vals)
+    )
+    b_idx = jnp.broadcast_to(jnp.arange(n_blk, dtype=jnp.int32)[:, None, None], (n_blk, qb, K))
+    q_idx = jnp.broadcast_to(jnp.arange(qb, dtype=jnp.int32)[None, :, None], (n_blk, qb, K))
+    u_idx = jnp.where(hit, pos, u_max).reshape(n_blk, qb, K)  # miss -> dropped
+    blk_member = jnp.zeros((n_blk, qb, u_max), jnp.int8)
+    blk_member = blk_member.at[b_idx, q_idx, u_idx].set(1, mode="drop")
+    return blk_units, blk_member, blk_counts

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
@@ -9,14 +9,20 @@ rows, idling the MXU.
 
 The blocked kernel amortises both: ``QB`` queries share one program, the block's
 selected-page **union** is DMA'd once per page, and per-query selection is
-restored with a ``-inf`` membership bias (bitmap AND causal AND kv_len) inside a
+restored with a ``-inf`` membership bias (bitmap AND causal) inside a
 flash-softmax over ``QB*H`` score rows.
 
-This module hosts (in build order):
+This module hosts:
 
 1. ``build_block_unit_tables`` — jnp preprocessing (outside the kernel): turn
-   ``topk_units [T, K]`` into per-block union tables + membership bitmaps.
-2. the Pallas query-block kernel itself (v1: single-sequence flat).
+   ``topk_units [T, K]`` into per-block union lists + a **by-unit-id** membership
+   bitmap. Deliberately scatter-free: an earlier compacted-slot bitmap built with
+   a 3D ``.at[].set`` scatter cost ~25 ms/layer on TPU at the 110k shape; the
+   broadcast-compare + sort form is ~0.6 ms.
+2. the Pallas query-block kernel (v1: single-sequence flat KV) with an
+   ``NBUF``-deep ring of unit DMAs — the per-unit fetches are latency-bound
+   (~1.5 µs each), so the next units are prefetched while the current one is
+   scored.
 """
 
 from __future__ import annotations
@@ -30,11 +36,14 @@ from jax.experimental.pallas import tpu as pltpu
 
 _SENTINEL = jnp.iinfo(jnp.int32).max
 
+_NBUF = 4  # DMA ring depth (prefetch distance)
+
 
 def build_block_unit_tables(
     topk_units,  # [T, K] int32 selected unit ids per query, -1 padded
     *,
     query_block: int,  # QB: queries per block
+    num_units: int,  # total unit-id space (ids are in [0, num_units) or -1)
     u_max: int,  # static cap on the per-block union size
 ):
     """Per-query-block union + membership tables for the blocked kernel.
@@ -43,56 +52,43 @@ def build_block_unit_tables(
 
     * ``blk_units [nQB, u_max]`` int32 — the block's selected units, sorted
       ascending, ``-1`` padded. Uniques beyond ``u_max`` are dropped.
-    * ``blk_member [nQB, query_block, u_max]`` int8 — 1 where query ``q`` of the
-      block selected ``blk_units[b, u]`` (the kernel's -inf bias source).
+    * ``blk_member [nQB, query_block, num_units]`` int8 — 1 where query ``q`` of
+      the block selected unit id ``p`` (indexed **by unit id**, not by union
+      slot — the kernel's -inf bias source).
     * ``blk_counts [nQB]`` int32 — the TRUE union size, **uncapped**: a value
-      ``> u_max`` means the block overflowed and its tables are incomplete; the
-      caller must gate (pick ``u_max >= min(query_block*K, num_units)`` to make
-      overflow impossible).
+      ``> u_max`` means ``blk_units`` is incomplete and the caller must gate
+      (pick ``u_max >= min(query_block*K, num_units)`` to make overflow
+      impossible). ``blk_member`` is by-id and unaffected by overflow.
 
     ``T`` need not divide ``query_block``; trailing queries are padded with
-    ``-1`` rows (all-zero membership). Unit ids are opaque keys: callers with
-    packed multi-request (ragged) inputs lift seq-local ids to global keys
-    (e.g. ``base + page``) before calling, so blocks may straddle requests.
+    ``-1`` rows (all-zero membership). Callers with packed multi-request
+    (ragged) inputs lift seq-local ids to global keys (e.g. ``base + page``)
+    before calling, so blocks may straddle requests.
     """
     T, K = topk_units.shape
     qb = query_block
     n_blk = -(-T // qb)
     pad = n_blk * qb - T
     tk = jnp.pad(topk_units.astype(jnp.int32), ((0, pad), (0, 0)), constant_values=-1)
-    flat = tk.reshape(n_blk, qb * K)
+    tk = tk.reshape(n_blk, qb, K)
 
-    # sort with -1/padding mapped to a +inf sentinel so invalids sink to the end
-    vals = jnp.where(flat < 0, _SENTINEL, flat)
-    svals = jnp.sort(vals, axis=1)
-    is_new = jnp.concatenate([jnp.ones((n_blk, 1), bool), svals[:, 1:] != svals[:, :-1]], axis=1)
-    uniq = is_new & (svals != _SENTINEL)
-    blk_counts = uniq.sum(axis=1).astype(jnp.int32)
+    # membership by unit id: broadcast compare + reduce over K (fuses on TPU;
+    # negative/padded selections match nothing).
+    ids = jnp.arange(num_units, dtype=jnp.int32)
+    sel = (tk[:, :, :, None] == ids[None, None, None, :]).any(axis=2)  # [nQB,qb,NU]
+    blk_member = sel.astype(jnp.int8)
 
-    # compact: scatter each first-occurrence to its rank; overflow ranks drop
-    rank = jnp.cumsum(uniq, axis=1) - 1
-    rank = jnp.where(uniq, rank, u_max)  # non-unique/sentinel -> out of range
-    rows = jnp.broadcast_to(jnp.arange(n_blk, dtype=jnp.int32)[:, None], rank.shape)
-    blk_units = jnp.full((n_blk, u_max), -1, jnp.int32)
-    blk_units = blk_units.at[rows, rank].set(svals, mode="drop")
-
-    # membership: binary-search every (query, k) selection in the compacted
-    # table (valid prefix ascending; -1 pad remapped to the sentinel so the
-    # array is globally sorted). O(T*K*log u_max) and no [.., K, u_max]
-    # broadcast materialisation.
-    search_tbl = jnp.where(blk_units < 0, _SENTINEL, blk_units)
-    pos = jax.vmap(jnp.searchsorted)(search_tbl, vals)  # [n_blk, qb*K]
-    pos_c = jnp.minimum(pos, u_max - 1)
-    hit = (
-        (vals != _SENTINEL)
-        & (pos < u_max)
-        & (jnp.take_along_axis(search_tbl, pos_c, axis=1) == vals)
+    # union list: presence per block, compacted by sorting masked unit ids
+    present = sel.any(axis=1)  # [n_blk, NU]
+    blk_counts = present.sum(axis=1).astype(jnp.int32)
+    masked = jnp.where(present, ids[None, :], _SENTINEL)
+    srt = jax.lax.sort(masked, dimension=1)
+    srt = (
+        srt[:, :u_max]
+        if u_max < num_units
+        else jnp.pad(srt, ((0, 0), (0, u_max - num_units)), constant_values=_SENTINEL)
     )
-    b_idx = jnp.broadcast_to(jnp.arange(n_blk, dtype=jnp.int32)[:, None, None], (n_blk, qb, K))
-    q_idx = jnp.broadcast_to(jnp.arange(qb, dtype=jnp.int32)[None, :, None], (n_blk, qb, K))
-    u_idx = jnp.where(hit, pos, u_max).reshape(n_blk, qb, K)  # miss -> dropped
-    blk_member = jnp.zeros((n_blk, qb, u_max), jnp.int8)
-    blk_member = blk_member.at[b_idx, q_idx, u_idx].set(1, mode="drop")
+    blk_units = jnp.where(srt == _SENTINEL, -1, srt)
     return blk_units, blk_member, blk_counts
 
 
@@ -101,25 +97,30 @@ def _qblock_kernel(
     units_ref,  # [1, 1, 1, U_pad]  SMEM  block union unit ids (-1 pad)
     cnt_ref,  # [1, 1, 1, 1]        SMEM  block union size (loop bound)
     qpos_ref,  # [1, 1, 1, QBHp]    VMEM  per-row query position (-1 on pad rows)
-    mem_ref,  # [1, 1, U_pad, QBHp] VMEM  int8 membership, unit-major
+    mem_ref,  # [1, 1, NU_pad, QBHp] VMEM int8 membership, indexed by unit id
     kv_hbm,  # [B, T(+RBF), Dk_pad] HBM   flat latent (DMA-gathered)
     o_ref,  # [1, 1, QBHp, Dv]
-    kv_scratch,  # [RBF, Dk_pad] VMEM     one gathered unit
-    sem,  # DMA semaphore
+    kv_scratch,  # [NBUF, RBF, Dk_pad] VMEM  DMA ring
+    sem,  # DMA semaphores (NBUF,)
     *,
     sm_scale: float,
     Dv: int,
     RB: int,
     RBF: int,
 ):
-    """Query-block sparse-MLA kernel, v1 (flat single-buffer form).
+    """Query-block sparse-MLA kernel (flat KV), ring-prefetched.
 
     Score layout is **key-major**: the unit's ``RBF`` keys sit on the sublane
     axis and the block's ``QB*H`` (query, head) rows sit on the *lane* axis
     (``s = kv · qᵀ -> [RBF, QBHp]``). That orientation lets the per-unit
-    membership bias come straight from a dynamic **sublane** row read of
-    ``mem_ref`` (lane-axis dynamic slicing is not needed anywhere), and the
-    flash-softmax state (``m``/``l``) lives as plain lane vectors.
+    membership bias come from an aligned-window sublane read of ``mem_ref``
+    (no lane-axis dynamic slicing anywhere), and the flash-softmax state
+    (``m``/``l``) lives as plain lane vectors.
+
+    Unit fetches are pipelined through an ``NBUF``-slot VMEM ring: iteration
+    ``j`` waits on slot ``j % NBUF`` while slots for ``j+1 .. j+NBUF-1`` are in
+    flight — without this the loop is bound by per-DMA latency (~1.5 µs), not
+    bandwidth.
     """
     b = pl.program_id(0)
     QBHp = q_ref.shape[2]
@@ -128,6 +129,19 @@ def _qblock_kernel(
     qpos_row = qpos_ref[0, 0]  # [1, QBHp] int32
     rows = jax.lax.broadcasted_iota(jnp.int32, (RBF, 1), 0)  # key row within unit
 
+    def _copy(j, slot):
+        u = jnp.maximum(units_ref[0, 0, 0, j], 0)
+        return pltpu.make_async_copy(
+            kv_hbm.at[b, pl.ds(u * RB, RBF), :], kv_scratch.at[slot], sem.at[slot]
+        )
+
+    # prologue: fill the ring (d=d: bind the loop var per iteration, B023)
+    for d in range(_NBUF - 1):
+
+        @pl.when(d < cnt)
+        def _(d=d):
+            _copy(d, d).start()
+
     m0 = jnp.full((QBHp,), -jnp.inf, dtype=jnp.float32)
     l0 = jnp.zeros((QBHp,), dtype=jnp.float32)
     acc0 = jnp.zeros((QBHp, Dv), dtype=jnp.float32)
@@ -135,16 +149,23 @@ def _qblock_kernel(
     def unit_body(j, carry):
         m_i, l_i, acc = carry
         u = units_ref[0, 0, 0, j]  # scalar unit id (>= 0 for j < cnt)
-        pltpu.make_async_copy(kv_hbm.at[b, pl.ds(u * RB, RBF), :], kv_scratch.at[...], sem).start()
+        slot = jax.lax.rem(j, _NBUF)
 
-        # membership row for this unit. A direct mem_ref[0, 0, j, :] is not
+        # keep the ring full: issue the fetch NBUF-1 ahead
+        nxt = j + _NBUF - 1
+
+        @pl.when(nxt < cnt)
+        def _():
+            _copy(nxt, jax.lax.rem(nxt, _NBUF)).start()
+
+        # membership row for this unit id. A direct mem_ref[.., u, :] is not
         # Mosaic-lowerable (int8 tile is (32, 128): a dynamic sublane index
         # must be provably %32), so read the aligned 32-row window containing
-        # j — (j // 32) * 32 is provably aligned, the same idiom as the paged
-        # r8*8 trick — and select row j within it via an iota compare + max.
-        j32 = (j // 32) * 32
-        mem_win = mem_ref[0, 0, pl.ds(j32, 32), :]  # [32, QBHp] int8
-        rowsel = jax.lax.broadcasted_iota(jnp.int32, (32, 1), 0) == (j - j32)
+        # u — (u // 32) * 32 is provably aligned, the same idiom as the paged
+        # r8*8 trick — and select row u within it via an iota compare + max.
+        u32 = (u // 32) * 32
+        mem_win = mem_ref[0, 0, pl.ds(u32, 32), :]  # [32, QBHp] int8
+        rowsel = jax.lax.broadcasted_iota(jnp.int32, (32, 1), 0) == (u - u32)
         mem_row = jnp.max(
             jnp.where(rowsel, mem_win.astype(jnp.int32), 0), axis=0, keepdims=True
         )  # [1, QBHp]
@@ -154,8 +175,8 @@ def _qblock_kernel(
             valid &= rows < RB  # drop sublane over-fetch rows
         bias = jnp.where(valid, 0.0, -jnp.inf)  # [RBF, QBHp] fp32
 
-        pltpu.make_async_copy(kv_hbm.at[b, pl.ds(u * RB, RBF), :], kv_scratch.at[...], sem).wait()
-        kv_blk = kv_scratch[...]  # [RBF, Dk_pad]
+        _copy(j, slot).wait()
+        kv_blk = kv_scratch[slot]  # [RBF, Dk_pad]
 
         # score: [RBF,Dk]·[QBHp,Dk] -> [RBF, QBHp] (keys sublane, queries lane)
         s = (
@@ -219,22 +240,25 @@ def sparse_mla_attention_qblock(
         u_max = min(QB * K, num_units)
 
     # ── preprocessing (jnp, outside the kernel) ────────────────────────────
-    blk_u, bm, bc = jax.vmap(
-        functools.partial(build_block_unit_tables, query_block=QB, u_max=u_max)
+    blk_u, blk_m, blk_c = jax.vmap(
+        functools.partial(build_block_unit_tables, query_block=QB, num_units=num_units, u_max=u_max)
     )(indices)
-    # blk_u [B,nQB,u_max] bm [B,nQB,QB,u_max] bc [B,nQB]
+    # blk_u [B,nQB,u_max] blk_m [B,nQB,QB,NU] blk_c [B,nQB]
     nQB = blk_u.shape[1]
-    U_pad = ((u_max + 31) // 32) * 32  # int8 sublane tile
+    U_pad = ((u_max + 31) // 32) * 32
+    NU_pad = ((num_units + 31) // 32) * 32  # int8 sublane tile
     QBH = QB * H
     QBHp = ((QBH + 127) // 128) * 128  # lane axis of the score
 
-    # membership: -> unit-major [B,nQB,U_pad,QBHp] int8, rows H-expanded so the
+    # membership: -> id-major [B,nQB,NU_pad,QBHp] int8, lanes H-expanded so the
     # kernel's lane r = q*H + h reads member[q] directly.
-    memt = jnp.repeat(bm.transpose(0, 1, 3, 2), H, axis=3)  # [B,nQB,u_max,QBH]
-    memt = jnp.pad(memt, ((0, 0), (0, 0), (0, U_pad - u_max), (0, QBHp - QBH)))
+    memt = jnp.repeat(blk_m.transpose(0, 1, 3, 2), H, axis=3)  # [B,nQB,NU,QBH]
+    memt = jnp.pad(memt, ((0, 0), (0, 0), (0, NU_pad - num_units), (0, QBHp - QBH)))
     units4 = jnp.pad(blk_u, ((0, 0), (0, 0), (0, U_pad - u_max)), constant_values=-1)
     units4 = units4.reshape(B, nQB, 1, U_pad)
-    counts4 = bc.reshape(B, nQB, 1, 1)
+    # clamp: if a block overflowed u_max (impossible with the default cap), only
+    # the retained prefix of the union is walked.
+    counts4 = jnp.minimum(blk_c, u_max).reshape(B, nQB, 1, 1)
 
     # q -> [B, nQB, QBHp, Dk_pad] (row = q*H + h), zero pad rows/features
     Dk_pad = ((Dk + 127) // 128) * 128
@@ -263,14 +287,14 @@ def sparse_mla_attention_qblock(
             pl.BlockSpec((1, 1, 1, U_pad), lambda b, n: (b, n, 0, 0), memory_space=smem),
             pl.BlockSpec((1, 1, 1, 1), lambda b, n: (b, n, 0, 0), memory_space=smem),
             pl.BlockSpec((1, 1, 1, QBHp), lambda b, n: (b, n, 0, 0)),  # qpos rows
-            pl.BlockSpec((1, 1, U_pad, QBHp), lambda b, n: (b, n, 0, 0)),  # membership
+            pl.BlockSpec((1, 1, NU_pad, QBHp), lambda b, n: (b, n, 0, 0)),  # membership
             pl.BlockSpec(memory_space=pltpu.HBM),  # kv (untiled, DMA-gathered)
         ],
         out_specs=pl.BlockSpec((1, 1, QBHp, Dv), lambda b, n: (b, n, 0, 0)),
         out_shape=jax.ShapeDtypeStruct((B, nQB, QBHp, Dv), jnp.float32),
         scratch_shapes=[
-            pltpu.VMEM((RBF, Dk_pad), kv.dtype),
-            pltpu.SemaphoreType.DMA,
+            pltpu.VMEM((_NBUF, RBF, Dk_pad), kv.dtype),
+            pltpu.SemaphoreType.DMA((_NBUF,)),
         ],
         interpret=interpret,
     )(q4, units4, counts4, pos_rows, memt, kv)

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
@@ -32,15 +32,31 @@ Implementation notes (each earned on the TPU):
 from __future__ import annotations
 
 import functools
+import logging
 
 import jax
 import jax.numpy as jnp
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
+logger = logging.getLogger(__name__)
+
 _SENTINEL = jnp.iinfo(jnp.int32).max
 
 _NBUF = 4  # DMA ring depth (prefetch distance)
+
+
+@functools.cache
+def _warn_umax_truncation(u_max: int, u_safe: int) -> None:
+    # functools.cache => one warning per distinct (u_max, u_safe), not per trace
+    logger.warning(
+        "sparse_mla_attention_qblock: u_max=%d < %d (the lossless bound "
+        "min(query_block*K, num_units)); blocks whose selected-page union "
+        "exceeds the cap silently drop the tail of the union, so outputs may "
+        "lose accuracy vs the per-query kernel.",
+        u_max,
+        u_safe,
+    )
 
 
 def build_block_unit_tables(
@@ -259,7 +275,15 @@ def sparse_mla_attention_qblock(
     * ragged (``q_seq_id`` set): ``kv`` is the packed 4D paged MLA cache and
       ``indices`` are **seq-local page ids** (as produced by the indexer);
       they are lifted to global page-table keys here. Requires
-      ``read_block == page_size`` and ``B == 1``.
+      ``read_block == page_size`` (``% 16 == 0``) and ``B == 1``.
+
+    ``u_max`` caps the per-block union table. The default,
+    ``min(query_block * K, num_units)``, makes overflow impossible and is
+    lossless. An explicitly smaller cap trades accuracy for preprocessing
+    footprint: a block whose true union exceeds it has the tail of its sorted
+    union silently dropped (those keys are never attended), so outputs may
+    diverge from :func:`sparse_mla_prefill.sparse_mla_attention`. A one-time
+    warning is logged when such a cap is in effect.
     """
     B, S, H, Dk = q.shape
     K = indices.shape[2]
@@ -274,6 +298,14 @@ def sparse_mla_attention_qblock(
             raise ValueError("ragged mode requires seq_lens, cu_kv_lens and page_indices")
         if page_size is None or page_size != RB:
             raise ValueError("qblock ragged mode requires read_block == page_size")
+        if RB % 16 != 0:
+            # same contract as the per-query paged kernel: _copy resolves the
+            # page start as (PS//8)*8 and reads RBF = align_up(RB, 16) rows, so
+            # a non-%16 page size would offset wrong / cross a page silently.
+            raise ValueError(
+                f"qblock ragged mode requires read_block % 16 == 0 (got {RB}): "
+                "exact PS//8 sublane offset, no cross-page over-fetch"
+            )
 
     Dk_pad = ((Dk + 127) // 128) * 128
     RBF = ((RB + 15) // 16) * 16
@@ -305,8 +337,11 @@ def sparse_mla_attention_qblock(
         kv2 = jnp.pad(kv, ((0, 0), (0, RBF), (0, Dk_pad - Dk)))
         pt_arg = jnp.zeros((B, 1, 1, 1), jnp.int32)
 
+    u_safe = min(QB * K, num_units)
     if u_max is None:
-        u_max = min(QB * K, num_units)
+        u_max = u_safe
+    elif u_max < u_safe:
+        _warn_umax_truncation(u_max, u_safe)
 
     # ── preprocessing (jnp, outside the kernel) ────────────────────────────
     blk_u, blk_m, blk_c = jax.vmap(

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
@@ -21,8 +21,12 @@ This module hosts (in build order):
 
 from __future__ import annotations
 
+import functools
+
 import jax
 import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
 
 _SENTINEL = jnp.iinfo(jnp.int32).max
 
@@ -90,3 +94,177 @@ def build_block_unit_tables(
     blk_member = jnp.zeros((n_blk, qb, u_max), jnp.int8)
     blk_member = blk_member.at[b_idx, q_idx, u_idx].set(1, mode="drop")
     return blk_units, blk_member, blk_counts
+
+
+def _qblock_kernel(
+    q_ref,  # [1, 1, QBHp, Dk_pad] VMEM  (q*H+h rows; zero-padded)
+    units_ref,  # [1, 1, 1, U_pad]  SMEM  block union unit ids (-1 pad)
+    cnt_ref,  # [1, 1, 1, 1]        SMEM  block union size (loop bound)
+    qpos_ref,  # [1, 1, 1, QBHp]    VMEM  per-row query position (-1 on pad rows)
+    mem_ref,  # [1, 1, U_pad, QBHp] VMEM  int8 membership, unit-major
+    kv_hbm,  # [B, T(+RBF), Dk_pad] HBM   flat latent (DMA-gathered)
+    o_ref,  # [1, 1, QBHp, Dv]
+    kv_scratch,  # [RBF, Dk_pad] VMEM     one gathered unit
+    sem,  # DMA semaphore
+    *,
+    sm_scale: float,
+    Dv: int,
+    RB: int,
+    RBF: int,
+):
+    """Query-block sparse-MLA kernel, v1 (flat single-buffer form).
+
+    Score layout is **key-major**: the unit's ``RBF`` keys sit on the sublane
+    axis and the block's ``QB*H`` (query, head) rows sit on the *lane* axis
+    (``s = kv · qᵀ -> [RBF, QBHp]``). That orientation lets the per-unit
+    membership bias come straight from a dynamic **sublane** row read of
+    ``mem_ref`` (lane-axis dynamic slicing is not needed anywhere), and the
+    flash-softmax state (``m``/``l``) lives as plain lane vectors.
+    """
+    b = pl.program_id(0)
+    QBHp = q_ref.shape[2]
+    q = q_ref[0, 0]  # [QBHp, Dk_pad]
+    cnt = cnt_ref[0, 0, 0, 0]
+    qpos_row = qpos_ref[0, 0]  # [1, QBHp] int32
+    rows = jax.lax.broadcasted_iota(jnp.int32, (RBF, 1), 0)  # key row within unit
+
+    m0 = jnp.full((QBHp,), -jnp.inf, dtype=jnp.float32)
+    l0 = jnp.zeros((QBHp,), dtype=jnp.float32)
+    acc0 = jnp.zeros((QBHp, Dv), dtype=jnp.float32)
+
+    def unit_body(j, carry):
+        m_i, l_i, acc = carry
+        u = units_ref[0, 0, 0, j]  # scalar unit id (>= 0 for j < cnt)
+        pltpu.make_async_copy(kv_hbm.at[b, pl.ds(u * RB, RBF), :], kv_scratch.at[...], sem).start()
+
+        # membership row for this unit: dynamic sublane read -> [QBHp] lanes
+        mem_row = mem_ref[0, 0, j, :]
+        kp = u * RB + rows  # [RBF, 1] key positions
+        valid = (mem_row[None, :] > 0) & (kp <= qpos_row)  # [RBF, QBHp]
+        if RBF > RB:
+            valid &= rows < RB  # drop sublane over-fetch rows
+        bias = jnp.where(valid, 0.0, -jnp.inf)  # [RBF, QBHp] fp32
+
+        pltpu.make_async_copy(kv_hbm.at[b, pl.ds(u * RB, RBF), :], kv_scratch.at[...], sem).wait()
+        kv_blk = kv_scratch[...]  # [RBF, Dk_pad]
+
+        # score: [RBF,Dk]·[QBHp,Dk] -> [RBF, QBHp] (keys sublane, queries lane)
+        s = (
+            jax.lax.dot_general(
+                kv_blk, q, (((1,), (1,)), ((), ())), preferred_element_type=jnp.float32
+            )
+            * sm_scale
+        )
+        s = s + bias
+
+        # flash-softmax over keys = axis 0 (the sublane axis)
+        m_cur = jnp.max(s, axis=0)  # [QBHp]
+        m_new = jnp.maximum(m_i, m_cur)
+        corr = jnp.where(jnp.isneginf(m_new), 0.0, m_new)
+        p = jnp.exp(s - corr[None, :])  # [RBF, QBHp]
+        alpha = jnp.where(jnp.isneginf(m_new), 1.0, jnp.exp(m_i - m_new))
+        l_new = l_i * alpha + jnp.sum(p, axis=0)
+        v_blk = kv_blk[:, :Dv]  # [RBF, Dv]
+        # acc[qh, dv] += sum_r p[r, qh] * v[r, dv]  (contract the key axis)
+        acc = acc * alpha[:, None] + jax.lax.dot_general(
+            p.astype(kv_blk.dtype),
+            v_blk,
+            (((0,), (0,)), ((), ())),
+            preferred_element_type=jnp.float32,
+        )
+        return (m_new, l_new, acc)
+
+    m_i, l_i, acc = jax.lax.fori_loop(0, cnt, unit_body, (m0, l0, acc0))
+    out = acc / jnp.where(l_i == 0.0, 1.0, l_i)[:, None]
+    o_ref[0, 0] = out.astype(o_ref.dtype)
+
+
+def sparse_mla_attention_qblock(
+    q,  # [B, S, H, Dk]        Dk = kv_lora_rank + qk_rope_head_dim
+    kv,  # [B, T, Dk]           flat MLA latent cache (value = first Dv cols)
+    indices,  # [B, S, K] int32  selected unit ids (unit == read_block tokens)
+    positions,  # [B, S] int32   query positions (causal bound)
+    *,
+    kv_lora_rank: int = 512,
+    read_block: int = 128,
+    query_block: int = 64,
+    u_max: int | None = None,  # per-block union cap; default makes overflow impossible
+    sm_scale: float,
+    interpret: bool = False,
+):
+    """Blocked sparse MLA-latent attention (query-batching kernel, v1: flat KV).
+
+    Semantics match :func:`sparse_mla_prefill.sparse_mla_attention` (same inputs,
+    same masked-softmax math); the difference is purely execution shape: queries
+    are processed ``query_block`` at a time and each block DMAs its selected-page
+    *union* once instead of per query. Returns ``[B, S, H, kv_lora_rank]`` fp32.
+    """
+    B, S, H, Dk = q.shape
+    K = indices.shape[2]
+    Dv = kv_lora_rank
+    RB = read_block
+    QB = query_block
+    T = kv.shape[1]
+    num_units = -(-T // RB)
+    if u_max is None:
+        u_max = min(QB * K, num_units)
+
+    # ── preprocessing (jnp, outside the kernel) ────────────────────────────
+    blk_u, bm, bc = jax.vmap(
+        functools.partial(build_block_unit_tables, query_block=QB, u_max=u_max)
+    )(indices)
+    # blk_u [B,nQB,u_max] bm [B,nQB,QB,u_max] bc [B,nQB]
+    nQB = blk_u.shape[1]
+    U_pad = ((u_max + 31) // 32) * 32  # int8 sublane tile
+    QBH = QB * H
+    QBHp = ((QBH + 127) // 128) * 128  # lane axis of the score
+
+    # membership: -> unit-major [B,nQB,U_pad,QBHp] int8, rows H-expanded so the
+    # kernel's lane r = q*H + h reads member[q] directly.
+    memt = jnp.repeat(bm.transpose(0, 1, 3, 2), H, axis=3)  # [B,nQB,u_max,QBH]
+    memt = jnp.pad(memt, ((0, 0), (0, 0), (0, U_pad - u_max), (0, QBHp - QBH)))
+    units4 = jnp.pad(blk_u, ((0, 0), (0, 0), (0, U_pad - u_max)), constant_values=-1)
+    units4 = units4.reshape(B, nQB, 1, U_pad)
+    counts4 = bc.reshape(B, nQB, 1, 1)
+
+    # q -> [B, nQB, QBHp, Dk_pad] (row = q*H + h), zero pad rows/features
+    Dk_pad = ((Dk + 127) // 128) * 128
+    Sp = nQB * QB
+    q4 = jnp.pad(q, ((0, 0), (0, Sp - S), (0, 0), (0, Dk_pad - Dk)))
+    q4 = q4.reshape(B, nQB, QBH, Dk_pad)
+    q4 = jnp.pad(q4, ((0, 0), (0, 0), (0, QBHp - QBH), (0, 0)))
+
+    # per-row positions (-1 on padded rows => nothing valid => zero output row)
+    pos_p = jnp.pad(positions.astype(jnp.int32), ((0, 0), (0, Sp - S)), constant_values=-1)
+    pos_rows = jnp.repeat(pos_p.reshape(B, nQB, QB), H, axis=2)  # [B,nQB,QBH]
+    pos_rows = jnp.pad(pos_rows, ((0, 0), (0, 0), (0, QBHp - QBH)), constant_values=-1)
+    pos_rows = pos_rows.reshape(B, nQB, 1, QBHp)
+
+    # flat KV: pad features to Dk_pad and rows by RBF (tail-unit over-fetch guard)
+    RBF = ((RB + 15) // 16) * 16
+    kv = jnp.pad(kv, ((0, 0), (0, RBF), (0, Dk_pad - Dk)))
+
+    kernel = functools.partial(_qblock_kernel, sm_scale=sm_scale, Dv=Dv, RB=RB, RBF=RBF)
+    smem = pltpu.SMEM
+    out = pl.pallas_call(
+        kernel,
+        grid=(B, nQB),
+        in_specs=[
+            pl.BlockSpec((1, 1, QBHp, Dk_pad), lambda b, n: (b, n, 0, 0)),  # q
+            pl.BlockSpec((1, 1, 1, U_pad), lambda b, n: (b, n, 0, 0), memory_space=smem),
+            pl.BlockSpec((1, 1, 1, 1), lambda b, n: (b, n, 0, 0), memory_space=smem),
+            pl.BlockSpec((1, 1, 1, QBHp), lambda b, n: (b, n, 0, 0)),  # qpos rows
+            pl.BlockSpec((1, 1, U_pad, QBHp), lambda b, n: (b, n, 0, 0)),  # membership
+            pl.BlockSpec(memory_space=pltpu.HBM),  # kv (untiled, DMA-gathered)
+        ],
+        out_specs=pl.BlockSpec((1, 1, QBHp, Dv), lambda b, n: (b, n, 0, 0)),
+        out_shape=jax.ShapeDtypeStruct((B, nQB, QBHp, Dv), jnp.float32),
+        scratch_shapes=[
+            pltpu.VMEM((RBF, Dk_pad), kv.dtype),
+            pltpu.SemaphoreType.DMA,
+        ],
+        interpret=interpret,
+    )(q4, units4, counts4, pos_rows, memt, kv)
+
+    out = out[:, :, :QBH, :].reshape(B, Sp, H, Dv)
+    return out[:, :S]

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
@@ -137,10 +137,19 @@ def _qblock_kernel(
         u = units_ref[0, 0, 0, j]  # scalar unit id (>= 0 for j < cnt)
         pltpu.make_async_copy(kv_hbm.at[b, pl.ds(u * RB, RBF), :], kv_scratch.at[...], sem).start()
 
-        # membership row for this unit: dynamic sublane read -> [QBHp] lanes
-        mem_row = mem_ref[0, 0, j, :]
+        # membership row for this unit. A direct mem_ref[0, 0, j, :] is not
+        # Mosaic-lowerable (int8 tile is (32, 128): a dynamic sublane index
+        # must be provably %32), so read the aligned 32-row window containing
+        # j — (j // 32) * 32 is provably aligned, the same idiom as the paged
+        # r8*8 trick — and select row j within it via an iota compare + max.
+        j32 = (j // 32) * 32
+        mem_win = mem_ref[0, 0, pl.ds(j32, 32), :]  # [32, QBHp] int8
+        rowsel = jax.lax.broadcasted_iota(jnp.int32, (32, 1), 0) == (j - j32)
+        mem_row = jnp.max(
+            jnp.where(rowsel, mem_win.astype(jnp.int32), 0), axis=0, keepdims=True
+        )  # [1, QBHp]
         kp = u * RB + rows  # [RBF, 1] key positions
-        valid = (mem_row[None, :] > 0) & (kp <= qpos_row)  # [RBF, QBHp]
+        valid = (mem_row > 0) & (kp <= qpos_row)  # [RBF, QBHp]
         if RBF > RB:
             valid &= rows < RB  # drop sublane over-fetch rows
         bias = jnp.where(valid, 0.0, -jnp.inf)  # [RBF, QBHp] fp32

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
@@ -9,20 +9,24 @@ rows, idling the MXU.
 
 The blocked kernel amortises both: ``QB`` queries share one program, the block's
 selected-page **union** is DMA'd once per page, and per-query selection is
-restored with a ``-inf`` membership bias (bitmap AND causal) inside a
+restored with a ``-inf`` membership bias (bitmap AND causal AND kv_len) inside a
 flash-softmax over ``QB*H`` score rows.
 
-This module hosts:
+Implementation notes (each earned on the TPU):
 
-1. ``build_block_unit_tables`` — jnp preprocessing (outside the kernel): turn
-   ``topk_units [T, K]`` into per-block union lists + a **by-unit-id** membership
-   bitmap. Deliberately scatter-free: an earlier compacted-slot bitmap built with
-   a 3D ``.at[].set`` scatter cost ~25 ms/layer on TPU at the 110k shape; the
-   broadcast-compare + sort form is ~0.6 ms.
-2. the Pallas query-block kernel (v1: single-sequence flat KV) with an
-   ``NBUF``-deep ring of unit DMAs — the per-unit fetches are latency-bound
-   (~1.5 µs each), so the next units are prefetched while the current one is
-   scored.
+* Preprocessing is **scatter-free**: a 3D ``.at[b, q, u].set`` membership
+  scatter cost ~25 ms/layer at the 110k shape; the broadcast-compare form is
+  ~1 ms. The membership bitmap is indexed by **union slot** (not unit id), so
+  its footprint is bounded by ``u_max`` — independent of the packed page-table
+  width (a by-id bitmap explodes at high concurrency).
+* Unit fetches are pipelined through an ``NBUF``-slot VMEM ring: the per-unit
+  DMAs are latency-bound (~1.5 µs each), so without prefetch the loop runs at
+  DMA latency, not bandwidth (measured 27 ms -> 7.6 ms at the 110k shape).
+* Score layout is **key-major** ([RBF keys, QB*H rows]): the membership bias
+  comes from an aligned-window sublane read (int8 tile is (32, 128), so a
+  dynamic sublane index must be provably %32 — read the ``(j//32)*32`` window
+  and select the row with an iota compare), and no lane-axis dynamic slicing
+  or in-kernel transpose is needed anywhere.
 """
 
 from __future__ import annotations
@@ -43,7 +47,6 @@ def build_block_unit_tables(
     topk_units,  # [T, K] int32 selected unit ids per query, -1 padded
     *,
     query_block: int,  # QB: queries per block
-    num_units: int,  # total unit-id space (ids are in [0, num_units) or -1)
     u_max: int,  # static cap on the per-block union size
 ):
     """Per-query-block union + membership tables for the blocked kernel.
@@ -52,18 +55,19 @@ def build_block_unit_tables(
 
     * ``blk_units [nQB, u_max]`` int32 — the block's selected units, sorted
       ascending, ``-1`` padded. Uniques beyond ``u_max`` are dropped.
-    * ``blk_member [nQB, query_block, num_units]`` int8 — 1 where query ``q`` of
-      the block selected unit id ``p`` (indexed **by unit id**, not by union
-      slot — the kernel's -inf bias source).
+    * ``blk_member [nQB, query_block, u_max]`` int8 — 1 where query ``q`` of the
+      block selected ``blk_units[b, u]`` (indexed by union **slot**; the
+      kernel's -inf bias source).
     * ``blk_counts [nQB]`` int32 — the TRUE union size, **uncapped**: a value
-      ``> u_max`` means ``blk_units`` is incomplete and the caller must gate
+      ``> u_max`` means the tables are incomplete and the caller must gate
       (pick ``u_max >= min(query_block*K, num_units)`` to make overflow
-      impossible). ``blk_member`` is by-id and unaffected by overflow.
+      impossible).
 
     ``T`` need not divide ``query_block``; trailing queries are padded with
-    ``-1`` rows (all-zero membership). Callers with packed multi-request
-    (ragged) inputs lift seq-local ids to global keys (e.g. ``base + page``)
-    before calling, so blocks may straddle requests.
+    ``-1`` rows (all-zero membership). Unit ids are opaque keys: callers with
+    packed multi-request (ragged) inputs lift seq-local ids to global keys
+    (e.g. ``page_table_base + page``) before calling, so blocks may straddle
+    requests.
     """
     T, K = topk_units.shape
     qb = query_block
@@ -71,24 +75,28 @@ def build_block_unit_tables(
     pad = n_blk * qb - T
     tk = jnp.pad(topk_units.astype(jnp.int32), ((0, pad), (0, 0)), constant_values=-1)
     tk = tk.reshape(n_blk, qb, K)
+    flat = tk.reshape(n_blk, qb * K)
 
-    # membership by unit id: broadcast compare + reduce over K (fuses on TPU;
-    # negative/padded selections match nothing).
-    ids = jnp.arange(num_units, dtype=jnp.int32)
-    sel = (tk[:, :, :, None] == ids[None, None, None, :]).any(axis=2)  # [nQB,qb,NU]
-    blk_member = sel.astype(jnp.int8)
+    # union list: sort with -1 mapped to a +inf sentinel, mark first occurrences,
+    # compact by rank (2D scatter — cheap, unlike a 3D membership scatter).
+    vals = jnp.where(flat < 0, _SENTINEL, flat)
+    svals = jnp.sort(vals, axis=1)
+    is_new = jnp.concatenate([jnp.ones((n_blk, 1), bool), svals[:, 1:] != svals[:, :-1]], axis=1)
+    uniq = is_new & (svals != _SENTINEL)
+    blk_counts = uniq.sum(axis=1).astype(jnp.int32)
+    rank = jnp.cumsum(uniq, axis=1) - 1
+    rank = jnp.where(uniq, rank, u_max)  # non-unique/sentinel -> dropped
+    rows = jnp.broadcast_to(jnp.arange(n_blk, dtype=jnp.int32)[:, None], rank.shape)
+    blk_units = jnp.full((n_blk, u_max), -1, jnp.int32)
+    blk_units = blk_units.at[rows, rank].set(svals, mode="drop")
 
-    # union list: presence per block, compacted by sorting masked unit ids
-    present = sel.any(axis=1)  # [n_blk, NU]
-    blk_counts = present.sum(axis=1).astype(jnp.int32)
-    masked = jnp.where(present, ids[None, :], _SENTINEL)
-    srt = jax.lax.sort(masked, dimension=1)
-    srt = (
-        srt[:, :u_max]
-        if u_max < num_units
-        else jnp.pad(srt, ((0, 0), (0, u_max - num_units)), constant_values=_SENTINEL)
+    # membership by slot: broadcast compare against the compacted union (fuses
+    # into a compare+reduce on TPU; -1 pads on either side never match).
+    blk_member = (
+        ((tk[:, :, :, None] == blk_units[:, None, None, :]) & (tk[:, :, :, None] >= 0))
+        .any(axis=2)
+        .astype(jnp.int8)
     )
-    blk_units = jnp.where(srt == _SENTINEL, -1, srt)
     return blk_units, blk_member, blk_counts
 
 
@@ -97,8 +105,11 @@ def _qblock_kernel(
     units_ref,  # [1, 1, 1, U_pad]  SMEM  block union unit ids (-1 pad)
     cnt_ref,  # [1, 1, 1, 1]        SMEM  block union size (loop bound)
     qpos_ref,  # [1, 1, 1, QBHp]    VMEM  per-row query position (-1 on pad rows)
-    mem_ref,  # [1, 1, NU_pad, QBHp] VMEM int8 membership, indexed by unit id
-    kv_hbm,  # [B, T(+RBF), Dk_pad] HBM   flat latent (DMA-gathered)
+    kvlen_ref,  # [1, 1, 1, QBHp]   VMEM  per-row kv length bound
+    base_ref,  # [1, 1, 1, QBHp]    VMEM  per-row page-table base, in TOKENS
+    mem_ref,  # [1, 1, U_pad, QBHp] VMEM  int8 membership by union slot
+    kv_hbm,  # flat: [B, T(+RBF), Dk_pad]; paged: [1, num_pages*PS, Dk_pad] HBM
+    pt_ref,  # [1, 1, 1, PTW]      SMEM  packed page table (paged only)
     o_ref,  # [1, 1, QBHp, Dv]
     kv_scratch,  # [NBUF, RBF, Dk_pad] VMEM  DMA ring
     sem,  # DMA semaphores (NBUF,)
@@ -107,33 +118,40 @@ def _qblock_kernel(
     Dv: int,
     RB: int,
     RBF: int,
+    paged: bool,
+    PS: int,  # page size (paged only; == RB in v1 paged mode)
+    PTW: int,
 ):
-    """Query-block sparse-MLA kernel (flat KV), ring-prefetched.
+    """Query-block sparse-MLA kernel, ring-prefetched (flat or packed-paged KV).
 
-    Score layout is **key-major**: the unit's ``RBF`` keys sit on the sublane
-    axis and the block's ``QB*H`` (query, head) rows sit on the *lane* axis
-    (``s = kv · qᵀ -> [RBF, QBHp]``). That orientation lets the per-unit
-    membership bias come from an aligned-window sublane read of ``mem_ref``
-    (no lane-axis dynamic slicing anywhere), and the flash-softmax state
-    (``m``/``l``) lives as plain lane vectors.
-
-    Unit fetches are pipelined through an ``NBUF``-slot VMEM ring: iteration
-    ``j`` waits on slot ``j % NBUF`` while slots for ``j+1 .. j+NBUF-1`` are in
-    flight — without this the loop is bound by per-DMA latency (~1.5 µs), not
-    bandwidth.
+    In paged mode a unit id is a **global key** = position in the packed
+    ``page_indices`` table (the caller lifts seq-local pages by the request's
+    base), so the DMA source is ``page_indices[u] * PS`` and the key's
+    seq-local position is ``u*RB + r - base_tokens[row]`` — a plain 2D
+    broadcast, which is what lets one block hold queries from different
+    requests.
     """
     b = pl.program_id(0)
     QBHp = q_ref.shape[2]
     q = q_ref[0, 0]  # [QBHp, Dk_pad]
     cnt = cnt_ref[0, 0, 0, 0]
     qpos_row = qpos_ref[0, 0]  # [1, QBHp] int32
+    kvlen_row = kvlen_ref[0, 0]  # [1, QBHp] int32
+    base_row = base_ref[0, 0]  # [1, QBHp] int32 (tokens; 0 when flat)
     rows = jax.lax.broadcasted_iota(jnp.int32, (RBF, 1), 0)  # key row within unit
 
     def _copy(j, slot):
         u = jnp.maximum(units_ref[0, 0, 0, j], 0)
-        return pltpu.make_async_copy(
-            kv_hbm.at[b, pl.ds(u * RB, RBF), :], kv_scratch.at[slot], sem.at[slot]
-        )
+        if paged:
+            # whole-page unit: physical row 0 of page pt[u]. The token axis is
+            # sublane-tiled (8): express the offset as r8*8 so divisibility is
+            # provable (PS % 8 == 0), the same idiom as the dense paged kernel.
+            pp = pt_ref[0, 0, 0, jnp.minimum(u, PTW - 1)]
+            r8 = pp * (PS // 8)
+            src = kv_hbm.at[0, pl.ds(r8 * 8, RBF), :]
+        else:
+            src = kv_hbm.at[b, pl.ds(u * RB, RBF), :]
+        return pltpu.make_async_copy(src, kv_scratch.at[slot], sem.at[slot])
 
     # prologue: fill the ring (d=d: bind the loop var per iteration, B023)
     for d in range(_NBUF - 1):
@@ -158,19 +176,20 @@ def _qblock_kernel(
         def _():
             _copy(nxt, jax.lax.rem(nxt, _NBUF)).start()
 
-        # membership row for this unit id. A direct mem_ref[.., u, :] is not
-        # Mosaic-lowerable (int8 tile is (32, 128): a dynamic sublane index
-        # must be provably %32), so read the aligned 32-row window containing
-        # u — (u // 32) * 32 is provably aligned, the same idiom as the paged
-        # r8*8 trick — and select row u within it via an iota compare + max.
-        u32 = (u // 32) * 32
-        mem_win = mem_ref[0, 0, pl.ds(u32, 32), :]  # [32, QBHp] int8
-        rowsel = jax.lax.broadcasted_iota(jnp.int32, (32, 1), 0) == (u - u32)
+        # membership row for this slot: aligned 32-row window + iota select
+        # (a direct dynamic sublane index is not provably %32 — Mosaic E2003).
+        j32 = (j // 32) * 32
+        mem_win = mem_ref[0, 0, pl.ds(j32, 32), :]  # [32, QBHp] int8
+        rowsel = jax.lax.broadcasted_iota(jnp.int32, (32, 1), 0) == (j - j32)
         mem_row = jnp.max(
             jnp.where(rowsel, mem_win.astype(jnp.int32), 0), axis=0, keepdims=True
         )  # [1, QBHp]
-        kp = u * RB + rows  # [RBF, 1] key positions
-        valid = (mem_row > 0) & (kp <= qpos_row)  # [RBF, QBHp]
+
+        # seq-local key positions per (key row, query row): kp = u*RB + r - base.
+        # For queries of a different request than the unit's owner this is
+        # garbage, but their membership bit is 0 so the lane is -inf anyway.
+        kp = (u * RB + rows) - base_row  # [RBF, QBHp]
+        valid = (mem_row > 0) & (kp <= qpos_row) & (kp < kvlen_row)
         if RBF > RB:
             valid &= rows < RB  # drop sublane over-fetch rows
         bias = jnp.where(valid, 0.0, -jnp.inf)  # [RBF, QBHp] fp32
@@ -211,7 +230,7 @@ def _qblock_kernel(
 
 def sparse_mla_attention_qblock(
     q,  # [B, S, H, Dk]        Dk = kv_lora_rank + qk_rope_head_dim
-    kv,  # [B, T, Dk]           flat MLA latent cache (value = first Dv cols)
+    kv,  # [B, T, Dk] flat latent | packed 4D paged cache (ragged mode)
     indices,  # [B, S, K] int32  selected unit ids (unit == read_block tokens)
     positions,  # [B, S] int32   query positions (causal bound)
     *,
@@ -221,39 +240,88 @@ def sparse_mla_attention_qblock(
     u_max: int | None = None,  # per-block union cap; default makes overflow impossible
     sm_scale: float,
     interpret: bool = False,
+    # ── packed-ragged mode (multi-request extend; mirrors sparse_mla_attention) ──
+    page_size: int | None = None,
+    q_seq_id=None,  # [total_tokens] int32  token -> request id (enables ragged mode)
+    seq_lens=None,  # [num_seqs] int32       per-request kv length (causal bound)
+    cu_kv_lens=None,  # [num_seqs+1] int32    page-aligned kv offsets
+    page_indices=None,  # [total_pages] int32 packed physical page ids
 ):
-    """Blocked sparse MLA-latent attention (query-batching kernel, v1: flat KV).
+    """Blocked sparse MLA-latent attention (query-batching kernel).
 
-    Semantics match :func:`sparse_mla_prefill.sparse_mla_attention` (same inputs,
-    same masked-softmax math); the difference is purely execution shape: queries
-    are processed ``query_block`` at a time and each block DMAs its selected-page
+    Semantics match :func:`sparse_mla_prefill.sparse_mla_attention` (same
+    masked-softmax math); the difference is purely execution shape: queries are
+    processed ``query_block`` at a time and each block DMAs its selected-page
     *union* once instead of per query. Returns ``[B, S, H, kv_lora_rank]`` fp32.
+
+    Modes:
+    * flat (default): ``kv`` is ``[B, T, Dk]``; ``indices`` are unit ids over it.
+    * ragged (``q_seq_id`` set): ``kv`` is the packed 4D paged MLA cache and
+      ``indices`` are **seq-local page ids** (as produced by the indexer);
+      they are lifted to global page-table keys here. Requires
+      ``read_block == page_size`` and ``B == 1``.
     """
     B, S, H, Dk = q.shape
     K = indices.shape[2]
     Dv = kv_lora_rank
     RB = read_block
     QB = query_block
-    T = kv.shape[1]
-    num_units = -(-T // RB)
+    ragged = q_seq_id is not None
+    if ragged:
+        if B != 1:
+            raise ValueError(f"ragged mode packs all requests into B=1 (got B={B})")
+        if seq_lens is None or cu_kv_lens is None or page_indices is None:
+            raise ValueError("ragged mode requires seq_lens, cu_kv_lens and page_indices")
+        if page_size is None or page_size != RB:
+            raise ValueError("qblock ragged mode requires read_block == page_size")
+
+    Dk_pad = ((Dk + 127) // 128) * 128
+    RBF = ((RB + 15) // 16) * 16
+
+    if ragged:
+        ps = page_size
+        PTW = page_indices.shape[0]
+        num_units = PTW
+        # lift seq-local pages to global page-table keys; resolve per-row bounds
+        qsid = jnp.clip(q_seq_id, 0, seq_lens.shape[0] - 1).astype(jnp.int32)
+        base_pages = (cu_kv_lens[qsid] // ps).astype(jnp.int32)  # [S]
+        idx_g = jnp.where(indices >= 0, indices + base_pages.reshape(B, S, 1), -1)
+        kvlen_tok = seq_lens[qsid].astype(jnp.int32)  # [S]
+        base_tok = base_pages * ps  # [S]
+        if kv.shape[-1] != Dk_pad:
+            raise ValueError(f"paged cache last dim {kv.shape[-1]} != Dk_pad {Dk_pad}")
+        num_pages = kv.shape[0]
+        kv2 = kv.reshape(1, num_pages * ps, Dk_pad)
+        pt_arg = page_indices.reshape(1, 1, 1, PTW).astype(jnp.int32)
+    else:
+        ps = 0
+        PTW = 1
+        T = kv.shape[1]
+        num_units = -(-T // RB)
+        idx_g = indices
+        kvlen_tok = jnp.full((S,), T, jnp.int32)
+        base_tok = jnp.zeros((S,), jnp.int32)
+        # flat KV: pad features to Dk_pad and rows by RBF (tail-unit over-fetch)
+        kv2 = jnp.pad(kv, ((0, 0), (0, RBF), (0, Dk_pad - Dk)))
+        pt_arg = jnp.zeros((B, 1, 1, 1), jnp.int32)
+
     if u_max is None:
         u_max = min(QB * K, num_units)
 
     # ── preprocessing (jnp, outside the kernel) ────────────────────────────
     blk_u, blk_m, blk_c = jax.vmap(
-        functools.partial(build_block_unit_tables, query_block=QB, num_units=num_units, u_max=u_max)
-    )(indices)
-    # blk_u [B,nQB,u_max] blk_m [B,nQB,QB,NU] blk_c [B,nQB]
+        functools.partial(build_block_unit_tables, query_block=QB, u_max=u_max)
+    )(idx_g)
+    # blk_u [B,nQB,u_max] blk_m [B,nQB,QB,u_max] blk_c [B,nQB]
     nQB = blk_u.shape[1]
-    U_pad = ((u_max + 31) // 32) * 32
-    NU_pad = ((num_units + 31) // 32) * 32  # int8 sublane tile
+    U_pad = ((u_max + 31) // 32) * 32  # int8 sublane tile
     QBH = QB * H
     QBHp = ((QBH + 127) // 128) * 128  # lane axis of the score
 
-    # membership: -> id-major [B,nQB,NU_pad,QBHp] int8, lanes H-expanded so the
+    # membership -> slot-major [B,nQB,U_pad,QBHp] int8, lanes H-expanded so the
     # kernel's lane r = q*H + h reads member[q] directly.
-    memt = jnp.repeat(blk_m.transpose(0, 1, 3, 2), H, axis=3)  # [B,nQB,NU,QBH]
-    memt = jnp.pad(memt, ((0, 0), (0, 0), (0, NU_pad - num_units), (0, QBHp - QBH)))
+    memt = jnp.repeat(blk_m.transpose(0, 1, 3, 2), H, axis=3)  # [B,nQB,u_max,QBH]
+    memt = jnp.pad(memt, ((0, 0), (0, 0), (0, U_pad - u_max), (0, QBHp - QBH)))
     units4 = jnp.pad(blk_u, ((0, 0), (0, 0), (0, U_pad - u_max)), constant_values=-1)
     units4 = units4.reshape(B, nQB, 1, U_pad)
     # clamp: if a block overflowed u_max (impossible with the default cap), only
@@ -261,24 +329,35 @@ def sparse_mla_attention_qblock(
     counts4 = jnp.minimum(blk_c, u_max).reshape(B, nQB, 1, 1)
 
     # q -> [B, nQB, QBHp, Dk_pad] (row = q*H + h), zero pad rows/features
-    Dk_pad = ((Dk + 127) // 128) * 128
     Sp = nQB * QB
     q4 = jnp.pad(q, ((0, 0), (0, Sp - S), (0, 0), (0, Dk_pad - Dk)))
     q4 = q4.reshape(B, nQB, QBH, Dk_pad)
     q4 = jnp.pad(q4, ((0, 0), (0, 0), (0, QBHp - QBH), (0, 0)))
 
-    # per-row positions (-1 on padded rows => nothing valid => zero output row)
-    pos_p = jnp.pad(positions.astype(jnp.int32), ((0, 0), (0, Sp - S)), constant_values=-1)
-    pos_rows = jnp.repeat(pos_p.reshape(B, nQB, QB), H, axis=2)  # [B,nQB,QBH]
-    pos_rows = jnp.pad(pos_rows, ((0, 0), (0, 0), (0, QBHp - QBH)), constant_values=-1)
-    pos_rows = pos_rows.reshape(B, nQB, 1, QBHp)
+    def _rows(vec, fill):
+        # [B, S] -> [B, nQB, 1, QBHp] with H-expansion and `fill` on pad rows
+        v = jnp.pad(vec.reshape(B, S), ((0, 0), (0, Sp - S)), constant_values=fill)
+        v = jnp.repeat(v.reshape(B, nQB, QB), H, axis=2)
+        v = jnp.pad(v, ((0, 0), (0, 0), (0, QBHp - QBH)), constant_values=fill)
+        return v.reshape(B, nQB, 1, QBHp)
 
-    # flat KV: pad features to Dk_pad and rows by RBF (tail-unit over-fetch guard)
-    RBF = ((RB + 15) // 16) * 16
-    kv = jnp.pad(kv, ((0, 0), (0, RBF), (0, Dk_pad - Dk)))
+    # pad rows: qpos=-1 => no key can satisfy kp <= qpos => zero output row
+    pos_rows = _rows(positions.astype(jnp.int32), -1)
+    kvlen_rows = _rows(jnp.broadcast_to(kvlen_tok, (B, S)), 0)
+    base_rows = _rows(jnp.broadcast_to(base_tok, (B, S)), 0)
 
-    kernel = functools.partial(_qblock_kernel, sm_scale=sm_scale, Dv=Dv, RB=RB, RBF=RBF)
+    kernel = functools.partial(
+        _qblock_kernel,
+        sm_scale=sm_scale,
+        Dv=Dv,
+        RB=RB,
+        RBF=RBF,
+        paged=ragged,
+        PS=ps,
+        PTW=PTW,
+    )
     smem = pltpu.SMEM
+    row_spec = pl.BlockSpec((1, 1, 1, QBHp), lambda b, n: (b, n, 0, 0))
     out = pl.pallas_call(
         kernel,
         grid=(B, nQB),
@@ -286,18 +365,89 @@ def sparse_mla_attention_qblock(
             pl.BlockSpec((1, 1, QBHp, Dk_pad), lambda b, n: (b, n, 0, 0)),  # q
             pl.BlockSpec((1, 1, 1, U_pad), lambda b, n: (b, n, 0, 0), memory_space=smem),
             pl.BlockSpec((1, 1, 1, 1), lambda b, n: (b, n, 0, 0), memory_space=smem),
-            pl.BlockSpec((1, 1, 1, QBHp), lambda b, n: (b, n, 0, 0)),  # qpos rows
-            pl.BlockSpec((1, 1, NU_pad, QBHp), lambda b, n: (b, n, 0, 0)),  # membership
+            row_spec,  # qpos rows
+            row_spec,  # kvlen rows
+            row_spec,  # base rows (tokens)
+            pl.BlockSpec((1, 1, U_pad, QBHp), lambda b, n: (b, n, 0, 0)),  # membership
             pl.BlockSpec(memory_space=pltpu.HBM),  # kv (untiled, DMA-gathered)
+            pl.BlockSpec((1, 1, 1, PTW), lambda b, n: (b, 0, 0, 0), memory_space=smem),
         ],
         out_specs=pl.BlockSpec((1, 1, QBHp, Dv), lambda b, n: (b, n, 0, 0)),
         out_shape=jax.ShapeDtypeStruct((B, nQB, QBHp, Dv), jnp.float32),
         scratch_shapes=[
-            pltpu.VMEM((_NBUF, RBF, Dk_pad), kv.dtype),
+            pltpu.VMEM((_NBUF, RBF, Dk_pad), kv2.dtype),
             pltpu.SemaphoreType.DMA((_NBUF,)),
         ],
         interpret=interpret,
-    )(q4, units4, counts4, pos_rows, memt, kv)
+    )(q4, units4, counts4, pos_rows, kvlen_rows, base_rows, memt, kv2, pt_arg)
 
     out = out[:, :, :QBH, :].reshape(B, Sp, H, Dv)
     return out[:, :S]
+
+
+def prefill_write_and_attend_ragged_qblock(
+    ql,  # [total_tokens, H, kv_lora_rank]   absorbed latent query (nope)
+    qpe,  # [total_tokens, H, rope]           rope query
+    kvc,  # [total_tokens, kv_lora_rank]      new c_kv to write
+    kpe,  # [total_tokens, rope]              new k_rope to write
+    cache,  # [P, ps//pk, pk, Dk_pad]         paged fused latent cache
+    topk_pages,  # [total_tokens, K] int32    seq-local page ids (-1 padded)
+    positions,  # [total_tokens] int32        absolute query positions (causal bound)
+    loc,  # [total_tokens] int32              physical flat slot per token
+    seq_lens,  # [num_seqs] int32             per-request kv length
+    cu_q_lens,  # [num_seqs+1] int32          per-request query offsets
+    cu_kv_lens,  # [num_seqs+1] int32         page-aligned kv offsets
+    page_indices,  # [total_pages] int32      packed physical page ids
+    *,
+    kv_lora_rank: int,
+    page_size: int,
+    sm_scale: float,
+    query_block: int = 64,
+    interpret: bool = False,
+):
+    """Packed-ragged self-write + **blocked** sparse-MLA prefill.
+
+    Drop-in replacement for
+    :func:`sparse_mla_prefill.prefill_write_and_attend_ragged` (same signature
+    plus ``query_block``); only the attend execution shape differs.
+    """
+    T, H, Dv = ql.shape
+    rope = qpe.shape[-1]
+    ps = page_size
+    Pn, pspk, pk, Dk_pad = cache.shape
+    S = seq_lens.shape[0]
+
+    q_sparse = jnp.concatenate([ql, qpe], axis=-1)  # [T, H, Dv+rope]
+
+    # self-write: per-token scatter to out_cache_loc (identical to the
+    # per-query wrapper; mode="drop"+wrap_negative_indices=False drops -1 pads).
+    row = jnp.zeros((T, Dk_pad), cache.dtype)
+    row = row.at[:, :Dv].set(kvc.astype(cache.dtype))
+    row = row.at[:, Dv : Dv + rope].set(kpe.reshape(T, rope).astype(cache.dtype))
+    flat = cache.reshape(Pn * ps, Dk_pad)
+    flat = flat.at[loc].set(row, mode="drop", wrap_negative_indices=False)
+    cache_new = flat.reshape(Pn, pspk, pk, Dk_pad)
+
+    # token -> request id (same convention as the per-query ragged wrapper)
+    t = jnp.arange(T, dtype=jnp.int32)
+    q_seq_id = jnp.clip(jnp.searchsorted(cu_q_lens[1:], t, side="right"), 0, S - 1).astype(
+        jnp.int32
+    )
+
+    out = sparse_mla_attention_qblock(
+        q_sparse.reshape(1, T, H, q_sparse.shape[2]),
+        cache_new,
+        topk_pages.reshape(1, T, -1),
+        positions.reshape(1, T),
+        kv_lora_rank=Dv,
+        read_block=ps,
+        query_block=query_block,
+        sm_scale=float(sm_scale),
+        page_size=ps,
+        q_seq_id=q_seq_id,
+        seq_lens=seq_lens,
+        cu_kv_lens=cu_kv_lens,
+        page_indices=page_indices,
+        interpret=interpret,
+    )
+    return out.reshape(T, H, Dv), cache_new

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -25,6 +25,9 @@ from jax.tree_util import register_pytree_node_class
 from sgl_jax.srt.kernels.dsa.ref import streamindex_page_topk_ref, streamindex_topk_ref
 from sgl_jax.srt.kernels.dsa.sparse_mla import compute_topk_pages, sparse_mla_page_level
 from sgl_jax.srt.kernels.dsa.sparse_mla_prefill import prefill_write_and_attend_ragged
+from sgl_jax.srt.kernels.dsa.sparse_mla_prefill_qblock import (
+    prefill_write_and_attend_ragged_qblock,
+)
 from sgl_jax.srt.kernels.dsa.streamindex_topk import (
     streamindex_page_topk,
     streamindex_topk,
@@ -73,6 +76,14 @@ _INDEXER_KERNEL_KV_PAGES_PER_BLOCK = 64
 # reduce to the same per-query-token kernel contract and are validated by the
 # A1/A2 parity gates in test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py.
 _PREFILL_SPARSE = int(os.environ.get("DSA_PREFILL_SPARSE", "0"))
+# Opt-in refinement of DSA_PREFILL_SPARSE: run the sparse extend through the
+# query-BLOCK kernel (``sparse_mla_prefill_qblock``) — QB queries share one
+# program and each block DMAs its selected-page *union* once, instead of one
+# program (and K page DMAs) per query. Wins whenever neighbouring queries'
+# selections overlap (sinks + local windows); parity-gated against the
+# per-query kernel. Default OFF; requires DSA_PREFILL_SPARSE=1.
+_PREFILL_QBLOCK = os.environ.get("DSA_PREFILL_QBLOCK", "0") == "1"
+_PREFILL_QBLOCK_QB = int(os.environ.get("DSA_PREFILL_QBLOCK_QB", "64"))
 
 
 @register_pytree_node_class
@@ -621,23 +632,43 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
         out_specs = (P(dpa, "tensor", None), P(dpa, None, None, None))
 
         def _run(ql_, qpe_, kvc_, kpe_, cache_, tp_, pos_, loc_, sl_, cuq_, cukv_, pi_):
-            o, cache_new = prefill_write_and_attend_ragged(
-                ql_,
-                qpe_,
-                kvc_,
-                kpe_,
-                cache_,
-                tp_,
-                pos_,
-                loc_,
-                sl_,
-                cuq_,
-                cukv_,
-                pi_,
-                kv_lora_rank=kv_lora_rank,
-                page_size=page_size,
-                sm_scale=sm,
-            )
+            if _PREFILL_QBLOCK:
+                o, cache_new = prefill_write_and_attend_ragged_qblock(
+                    ql_,
+                    qpe_,
+                    kvc_,
+                    kpe_,
+                    cache_,
+                    tp_,
+                    pos_,
+                    loc_,
+                    sl_,
+                    cuq_,
+                    cukv_,
+                    pi_,
+                    kv_lora_rank=kv_lora_rank,
+                    page_size=page_size,
+                    sm_scale=sm,
+                    query_block=_PREFILL_QBLOCK_QB,
+                )
+            else:
+                o, cache_new = prefill_write_and_attend_ragged(
+                    ql_,
+                    qpe_,
+                    kvc_,
+                    kpe_,
+                    cache_,
+                    tp_,
+                    pos_,
+                    loc_,
+                    sl_,
+                    cuq_,
+                    cukv_,
+                    pi_,
+                    kv_lora_rank=kv_lora_rank,
+                    page_size=page_size,
+                    sm_scale=sm,
+                )
             return o.astype(ql_.dtype), cache_new
 
         return jax.shard_map(_run, in_specs=in_specs, out_specs=out_specs, check_vma=False)(

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -76,13 +76,15 @@ _INDEXER_KERNEL_KV_PAGES_PER_BLOCK = 64
 # reduce to the same per-query-token kernel contract and are validated by the
 # A1/A2 parity gates in test/srt/kernels/dsa/test_sparse_mla_prefill_parity.py.
 _PREFILL_SPARSE = int(os.environ.get("DSA_PREFILL_SPARSE", "0"))
-# Opt-in refinement of DSA_PREFILL_SPARSE: run the sparse extend through the
-# query-BLOCK kernel (``sparse_mla_prefill_qblock``) — QB queries share one
+# Within DSA_PREFILL_SPARSE=1, the sparse extend runs through the query-BLOCK
+# kernel (``sparse_mla_prefill_qblock``) by DEFAULT — QB queries share one
 # program and each block DMAs its selected-page *union* once, instead of one
-# program (and K page DMAs) per query. Wins whenever neighbouring queries'
-# selections overlap (sinks + local windows); parity-gated against the
-# per-query kernel. Default OFF; requires DSA_PREFILL_SPARSE=1.
-_PREFILL_QBLOCK = os.environ.get("DSA_PREFILL_QBLOCK", "0") == "1"
+# program (and K page DMAs) per query. Semantics are parity-gated against the
+# per-query kernel (same masked-softmax math); it wins whenever neighbouring
+# queries' selections overlap (sinks + local windows). The default sparse=0
+# path is completely unaffected. ``DSA_PREFILL_QBLOCK=0`` is an escape hatch
+# back to the per-query kernel (e.g. for pathological no-locality selections).
+_PREFILL_QBLOCK = os.environ.get("DSA_PREFILL_QBLOCK", "1") == "1"
 _PREFILL_QBLOCK_QB = int(os.environ.get("DSA_PREFILL_QBLOCK_QB", "64"))
 
 

--- a/test/srt/kernels/dsa/test_qblock_kernel_parity.py
+++ b/test/srt/kernels/dsa/test_qblock_kernel_parity.py
@@ -213,3 +213,105 @@ if __name__ == "__main__":
     test_empty_and_padded_queries()
     test_small_u_max_padding()
     print("QBLOCK PARITY OK")
+
+
+# ── packed-ragged parity: qblock ragged vs the deployed ragged wrapper ──────
+
+prefill_write_and_attend_ragged = smp.prefill_write_and_attend_ragged
+prefill_write_and_attend_ragged_qblock = qb_mod.prefill_write_and_attend_ragged_qblock
+
+_PS = 128
+_KV_LORA, _ROPE = 512, 64
+_DK_PAD = 640
+_H8 = 8
+_SC = 1.0 / (192.0**0.5)
+
+
+def _ragged_case(seq_lens_list, K, seed=0):
+    """Static-shape packed batch: per-request query block padded to S_pad,
+    physical pages a permutation (so bases/loc are genuinely exercised)."""
+    rng = np.random.default_rng(seed)
+    num_seqs = len(seq_lens_list)
+    pages_per_seq = int(np.ceil(max(seq_lens_list) / _PS))
+    S_pad = pages_per_seq * _PS
+    total = num_seqs * S_pad
+    num_pages = num_seqs * pages_per_seq
+    phys = rng.permutation(num_pages).reshape(num_seqs, pages_per_seq).astype(np.int32)
+
+    ql = np.zeros((total, _H8, _KV_LORA), np.float32)
+    qpe = np.zeros((total, _H8, _ROPE), np.float32)
+    kvc = np.zeros((total, _KV_LORA), np.float32)
+    kpe = np.zeros((total, _ROPE), np.float32)
+    positions = np.zeros(total, np.int32)
+    loc = np.full(total, -1, np.int32)
+    tp = np.full((total, K), -1, np.int32)
+    real = np.zeros(total, bool)
+    for i, L in enumerate(seq_lens_list):
+        base = i * S_pad
+        ql[base : base + L] = rng.standard_normal((L, _H8, _KV_LORA)) * 0.1
+        qpe[base : base + L] = rng.standard_normal((L, _H8, _ROPE)) * 0.1
+        kvc[base : base + L] = rng.standard_normal((L, _KV_LORA)) * 0.1
+        kpe[base : base + L] = rng.standard_normal((L, _ROPE)) * 0.1
+        for j in range(L):
+            t = base + j
+            real[t] = True
+            positions[t] = j
+            loc[t] = phys[i, j // _PS] * _PS + (j % _PS)
+            hi = j // _PS + 1
+            n = min(K, hi)
+            ch = rng.choice(hi, size=n, replace=False)
+            if 0 not in ch:
+                ch[0] = 0
+            tp[t, :n] = ch
+    return dict(
+        ql=jnp.asarray(ql),
+        qpe=jnp.asarray(qpe),
+        kvc=jnp.asarray(kvc),
+        kpe=jnp.asarray(kpe),
+        cache=jnp.zeros((num_pages, _PS, 1, _DK_PAD), jnp.float32),
+        topk_pages=jnp.asarray(tp),
+        positions=jnp.asarray(positions),
+        loc=jnp.asarray(loc),
+        seq_lens=jnp.asarray(seq_lens_list, jnp.int32),
+        cu_q_lens=jnp.asarray(np.arange(num_seqs + 1) * S_pad, jnp.int32),
+        cu_kv_lens=jnp.asarray(np.arange(num_seqs + 1) * pages_per_seq * _PS, jnp.int32),
+        page_indices=jnp.asarray(phys.reshape(-1)),
+        real=real,
+    )
+
+
+@pytest.mark.parametrize(
+    "seq_lens_list, qb",
+    [
+        # varlen incl. a 1-token (decode-like) row; QB=48 does not divide the
+        # 256-token per-request padding => blocks straddle request boundaries
+        ([200, 512, 1, 129], 48),
+        # uniform blocks aligned to requests
+        ([256, 256], 64),
+    ],
+)
+def test_ragged_qblock_vs_deployed(seq_lens_list, qb):
+    c = _ragged_case(seq_lens_list, K=4, seed=11)
+    args = (
+        c["ql"],
+        c["qpe"],
+        c["kvc"],
+        c["kpe"],
+        c["cache"],
+        c["topk_pages"],
+        c["positions"],
+        c["loc"],
+        c["seq_lens"],
+        c["cu_q_lens"],
+        c["cu_kv_lens"],
+        c["page_indices"],
+    )
+    kw = dict(kv_lora_rank=_KV_LORA, page_size=_PS, sm_scale=_SC, interpret=True)
+    o_cur, cache_cur = prefill_write_and_attend_ragged(*args, **kw)
+    o_qb, cache_qb = prefill_write_and_attend_ragged_qblock(*args, query_block=qb, **kw)
+    real = c["real"]
+    d_o = np.abs(np.asarray(o_qb)[real] - np.asarray(o_cur)[real]).max()
+    d_c = np.abs(np.asarray(cache_qb) - np.asarray(cache_cur)).max()
+    print(f"[ragged qblock qb={qb}] |o_qb-o_cur|={d_o:.3e} |cache diff|={d_c:.3e}")
+    assert d_c == 0.0, "self-write must be identical"
+    assert d_o < 2e-3, f"ragged qblock vs deployed ragged drifted: {d_o}"

--- a/test/srt/kernels/dsa/test_qblock_kernel_parity.py
+++ b/test/srt/kernels/dsa/test_qblock_kernel_parity.py
@@ -1,0 +1,215 @@
+"""Parity: blocked (query-batched) sparse-MLA prefill kernel vs the deployed
+per-query kernel AND a masked-softmax numpy reference (flat KV, v1 scope).
+
+Runs on CPU via ``interpret=True``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+jax.config.update("jax_platform_name", "cpu")
+
+_HERE = os.path.dirname(__file__)
+
+
+def _load(name):
+    path = os.path.normpath(
+        os.path.join(_HERE, f"../../../../python/sgl_jax/srt/kernels/dsa/{name}.py")
+    )
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+smp = _load("sparse_mla_prefill")
+qb_mod = _load("sparse_mla_prefill_qblock")
+
+sparse_mla_attention = smp.sparse_mla_attention
+units_to_token_ids = smp.units_to_token_ids
+sparse_mla_attention_qblock = qb_mod.sparse_mla_attention_qblock
+
+
+def _reference(q, kv, indices, positions, *, read_block, kv_lora_rank, sm_scale):
+    """Masked-softmax sparse MLA over the selected units, fp32 (same oracle as
+    test_sparse_mla_prefill_parity)."""
+    B, S, H, Dk = q.shape
+    T = kv.shape[1]
+    Dv = kv_lora_rank
+    tok = np.asarray(units_to_token_ids(jnp.asarray(indices), read_block))
+    q = np.asarray(q, np.float32)
+    kv = np.asarray(kv, np.float32)
+    pos = np.asarray(positions)
+    out = np.zeros((B, S, H, Dv), np.float32)
+    for b in range(B):
+        for s in range(S):
+            ids = tok[b, s]
+            valid = (ids >= 0) & (ids <= pos[b, s]) & (ids < T)
+            ids_safe = np.where(valid, ids, 0)
+            k_sel = kv[b, ids_safe]
+            logits = (q[b, s] @ k_sel.T) * sm_scale
+            logits = np.where(valid[None, :], logits, -np.inf)
+            m = logits.max(-1, keepdims=True)
+            m = np.where(np.isneginf(m), 0.0, m)
+            p = np.exp(logits - m)
+            p = np.where(valid[None, :], p, 0.0)
+            denom = p.sum(-1, keepdims=True)
+            p = p / np.where(denom == 0.0, 1.0, denom)
+            out[b, s] = p @ k_sel[:, :Dv]
+    return out
+
+
+def _make_case(*, B, S, H, K, pages, page_size=128, seed=0, empty_rows=()):
+    rng = np.random.default_rng(seed)
+    kv_lora_rank, rope = 512, 64
+    Dk = kv_lora_rank + rope
+    T = page_size * pages
+    q = jnp.asarray(rng.standard_normal((B, S, H, Dk)) * 0.1, jnp.float32)
+    kv = jnp.asarray(rng.standard_normal((B, T, Dk)) * 0.1, jnp.float32)
+    positions = np.zeros((B, S), np.int32)
+    for b in range(B):
+        positions[b] = np.linspace(page_size // 2, T - 1, S).astype(np.int32)
+    idx = np.full((B, S, K), -1, np.int32)
+    for b in range(B):
+        for s in range(S):
+            hi = int(positions[b, s] // page_size + 1)
+            n = min(K, hi)
+            choices = rng.choice(hi, size=n, replace=False)
+            if 0 not in choices:
+                choices[0] = 0
+            idx[b, s, :n] = choices
+    for t in empty_rows:  # fully -1 rows (padding-like queries)
+        idx[:, t, :] = -1
+    return dict(
+        q=q,
+        kv=kv,
+        indices=jnp.asarray(idx),
+        positions=jnp.asarray(positions),
+        kv_lora_rank=kv_lora_rank,
+        page_size=page_size,
+        sm_scale=1.0 / (192.0**0.5),
+    )
+
+
+def _run_both(c, *, query_block):
+    common = dict(
+        kv_lora_rank=c["kv_lora_rank"],
+        read_block=c["page_size"],
+        sm_scale=c["sm_scale"],
+        interpret=True,
+    )
+    ref = _reference(
+        c["q"],
+        c["kv"],
+        c["indices"],
+        c["positions"],
+        read_block=c["page_size"],
+        kv_lora_rank=c["kv_lora_rank"],
+        sm_scale=c["sm_scale"],
+    )
+    out_qb = np.asarray(
+        sparse_mla_attention_qblock(
+            c["q"], c["kv"], c["indices"], c["positions"], query_block=query_block, **common
+        )
+    )
+    out_cur = np.asarray(
+        sparse_mla_attention(
+            c["q"],
+            c["kv"],
+            c["indices"],
+            c["positions"],
+            block_units=c["indices"].shape[2],
+            **common,
+        )
+    )
+    e_qb = np.abs(out_qb - ref).max()
+    e_cur = np.abs(out_cur - ref).max()
+    e_x = np.abs(out_qb - out_cur).max()
+    print(f"[qblock] |qb-ref|={e_qb:.3e} |cur-ref|={e_cur:.3e} |qb-cur|={e_x:.3e}")
+    assert e_qb < 2e-3, f"qblock vs reference parity failed: {e_qb}"
+    assert e_x < 2e-3, f"qblock vs deployed kernel drifted: {e_x}"
+
+
+def test_deployment_shape_qb64_h4():
+    # deployment-like: H=4 heads/device, QB=64 (QBH=256), 6 pages, 2 blocks
+    c = _make_case(B=1, S=128, H=4, K=3, pages=6, seed=0)
+    _run_both(c, query_block=64)
+
+
+def test_qbh_exact_128():
+    # QB*H == 128 exactly (no lane padding), B=2
+    c = _make_case(B=2, S=48, H=8, K=3, pages=4, seed=1)
+    _run_both(c, query_block=16)
+
+
+def test_ragged_tail_block():
+    # S not a multiple of QB: trailing block is partially padded
+    c = _make_case(B=1, S=45, H=4, K=2, pages=4, seed=2)
+    _run_both(c, query_block=32)
+
+
+def test_empty_and_padded_queries():
+    # some queries select nothing (all -1): their output must be 0 and must not
+    # poison neighbours in the same block
+    c = _make_case(B=1, S=40, H=4, K=2, pages=4, seed=3, empty_rows=(5, 6, 39))
+    _run_both(c, query_block=32)
+    out = np.asarray(
+        sparse_mla_attention_qblock(
+            c["q"],
+            c["kv"],
+            c["indices"],
+            c["positions"],
+            kv_lora_rank=c["kv_lora_rank"],
+            read_block=c["page_size"],
+            query_block=32,
+            sm_scale=c["sm_scale"],
+            interpret=True,
+        )
+    )
+    assert np.abs(out[:, [5, 6, 39]]).max() == 0.0, "empty-selection rows must be zero"
+
+
+def test_small_u_max_padding():
+    # u_max smaller than U_pad tiling forces -1 padded unit slots beyond counts
+    c = _make_case(B=1, S=64, H=4, K=2, pages=3, seed=4)
+    common = dict(
+        kv_lora_rank=c["kv_lora_rank"],
+        read_block=c["page_size"],
+        sm_scale=c["sm_scale"],
+        interpret=True,
+    )
+    ref = _reference(
+        c["q"],
+        c["kv"],
+        c["indices"],
+        c["positions"],
+        read_block=c["page_size"],
+        kv_lora_rank=c["kv_lora_rank"],
+        sm_scale=c["sm_scale"],
+    )
+    out = np.asarray(
+        sparse_mla_attention_qblock(
+            c["q"], c["kv"], c["indices"], c["positions"], query_block=64, u_max=3, **common
+        )
+    )
+    err = np.abs(out - ref).max()
+    print(f"[qblock u_max=pages] |qb-ref|={err:.3e}")
+    assert err < 2e-3
+
+
+if __name__ == "__main__":
+    test_deployment_shape_qb64_h4()
+    test_qbh_exact_128()
+    test_ragged_tail_block()
+    test_empty_and_padded_queries()
+    test_small_u_max_padding()
+    print("QBLOCK PARITY OK")

--- a/test/srt/kernels/dsa/test_qblock_kernel_parity.py
+++ b/test/srt/kernels/dsa/test_qblock_kernel_parity.py
@@ -315,3 +315,61 @@ def test_ragged_qblock_vs_deployed(seq_lens_list, qb):
     print(f"[ragged qblock qb={qb}] |o_qb-o_cur|={d_o:.3e} |cache diff|={d_c:.3e}")
     assert d_c == 0.0, "self-write must be identical"
     assert d_o < 2e-3, f"ragged qblock vs deployed ragged drifted: {d_o}"
+
+
+# ── argument validation: ragged page-size guard, u_max truncation warning ───
+
+
+def test_ragged_rejects_non16_page_size():
+    # RB == page_size == 24 passes the equality check but must hit the %16
+    # guard (same contract as the per-query paged kernel) before any layout
+    # work — the arrays are never touched, so dummies suffice.
+    S = 8
+    q = jnp.zeros((1, S, 2, 576), jnp.float32)
+    kv = jnp.zeros((4, 24, 1, _DK_PAD), jnp.float32)
+    idx = jnp.full((1, S, 2), -1, jnp.int32)
+    pos = jnp.zeros((1, S), jnp.int32)
+    with pytest.raises(ValueError, match="read_block % 16 == 0"):
+        sparse_mla_attention_qblock(
+            q,
+            kv,
+            idx,
+            pos,
+            read_block=24,
+            sm_scale=_SC,
+            page_size=24,
+            q_seq_id=jnp.zeros((S,), jnp.int32),
+            seq_lens=jnp.asarray([S], jnp.int32),
+            cu_kv_lens=jnp.asarray([0, 96], jnp.int32),
+            page_indices=jnp.asarray([0, 1, 2, 3], jnp.int32),
+        )
+
+
+def test_umax_reduced_warns_once(caplog):
+    # explicit u_max below the lossless bound min(QB*K, num_units) must log a
+    # one-time warning; the default (None) must stay silent.
+    qb_mod._warn_umax_truncation.cache_clear()
+    c = _make_case(B=1, S=64, H=4, K=2, pages=4, seed=5)
+    common = dict(
+        kv_lora_rank=c["kv_lora_rank"],
+        read_block=c["page_size"],
+        query_block=64,
+        sm_scale=c["sm_scale"],
+        interpret=True,
+    )
+    with caplog.at_level("WARNING", logger=qb_mod.__name__):
+        sparse_mla_attention_qblock(
+            c["q"], c["kv"], c["indices"], c["positions"], u_max=3, **common
+        )
+        sparse_mla_attention_qblock(
+            c["q"], c["kv"], c["indices"], c["positions"], u_max=3, **common
+        )
+    hits = [r for r in caplog.records if "u_max" in r.getMessage()]
+    assert len(hits) == 1, f"expected exactly one truncation warning, got {len(hits)}"
+
+    caplog.clear()
+    with caplog.at_level("WARNING", logger=qb_mod.__name__):
+        sparse_mla_attention_qblock(c["q"], c["kv"], c["indices"], c["positions"], **common)
+    assert not [
+        r for r in caplog.records if "u_max" in r.getMessage()
+    ], "default u_max must not warn"

--- a/test/srt/kernels/dsa/test_qblock_kernel_tpu.py
+++ b/test/srt/kernels/dsa/test_qblock_kernel_tpu.py
@@ -98,3 +98,85 @@ def test_qblock_tpu_parity(B, S, H, K, pages, qb, dtype, tol):
     )
     assert e_qb < tol, f"qblock vs oracle: {e_qb}"
     assert e_x < tol, f"qblock vs deployed kernel: {e_x}"
+
+
+# ── packed-ragged TPU parity: qblock ragged vs deployed ragged wrapper ──────
+
+from sgl_jax.srt.kernels.dsa.sparse_mla_prefill import prefill_write_and_attend_ragged
+from sgl_jax.srt.kernels.dsa.sparse_mla_prefill_qblock import (
+    prefill_write_and_attend_ragged_qblock,
+)
+
+_PS = 128
+_ROPE = 64
+_DK_PAD = 640
+
+
+@pytest.mark.parametrize(
+    "seq_lens_list, qb, tol",
+    [
+        ([640, 1024, 1, 200], 48, 3e-2),  # varlen, blocks straddle requests
+        ([1024, 1024], 64, 3e-2),  # aligned blocks
+    ],
+)
+def test_ragged_qblock_tpu(seq_lens_list, qb, tol):
+    rng = np.random.default_rng(17)
+    H = 4
+    K = 6
+    num_seqs = len(seq_lens_list)
+    pages_per_seq = int(np.ceil(max(seq_lens_list) / _PS))
+    S_pad = pages_per_seq * _PS
+    total = num_seqs * S_pad
+    num_pages = num_seqs * pages_per_seq
+    phys = rng.permutation(num_pages).reshape(num_seqs, pages_per_seq).astype(np.int32)
+
+    ql = np.zeros((total, H, _KV_LORA), np.float32)
+    qpe = np.zeros((total, H, _ROPE), np.float32)
+    kvc = np.zeros((total, _KV_LORA), np.float32)
+    kpe = np.zeros((total, _ROPE), np.float32)
+    positions = np.zeros(total, np.int32)
+    loc = np.full(total, -1, np.int32)
+    tp = np.full((total, K), -1, np.int32)
+    real = np.zeros(total, bool)
+    for i, L in enumerate(seq_lens_list):
+        base = i * S_pad
+        ql[base : base + L] = rng.standard_normal((L, H, _KV_LORA)) * 0.1
+        qpe[base : base + L] = rng.standard_normal((L, H, _ROPE)) * 0.1
+        kvc[base : base + L] = rng.standard_normal((L, _KV_LORA)) * 0.1
+        kpe[base : base + L] = rng.standard_normal((L, _ROPE)) * 0.1
+        for j in range(L):
+            t = base + j
+            real[t] = True
+            positions[t] = j
+            loc[t] = phys[i, j // _PS] * _PS + (j % _PS)
+            hi = j // _PS + 1
+            n = min(K, hi)
+            ch = rng.choice(hi, size=n, replace=False)
+            if 0 not in ch:
+                ch[0] = 0
+            tp[t, :n] = ch
+
+    args = (
+        jnp.asarray(ql, jnp.bfloat16),
+        jnp.asarray(qpe, jnp.bfloat16),
+        jnp.asarray(kvc, jnp.bfloat16),
+        jnp.asarray(kpe, jnp.bfloat16),
+        jnp.zeros((num_pages, _PS // 2, 2, _DK_PAD), jnp.bfloat16),
+        jnp.asarray(tp),
+        jnp.asarray(positions),
+        jnp.asarray(loc),
+        jnp.asarray(seq_lens_list, jnp.int32),
+        jnp.asarray(np.arange(num_seqs + 1) * S_pad, jnp.int32),
+        jnp.asarray(np.arange(num_seqs + 1) * pages_per_seq * _PS, jnp.int32),
+        jnp.asarray(phys.reshape(-1)),
+    )
+    kw = dict(kv_lora_rank=_KV_LORA, page_size=_PS, sm_scale=_SCALE)
+    o_cur, cache_cur = prefill_write_and_attend_ragged(*args, **kw)
+    o_qb, cache_qb = prefill_write_and_attend_ragged_qblock(*args, query_block=qb, **kw)
+    d_o = np.abs(np.asarray(o_qb)[real] - np.asarray(o_cur)[real]).max()
+    d_c = np.abs(
+        np.asarray(cache_qb, dtype=np.float32) - np.asarray(cache_cur, dtype=np.float32)
+    ).max()
+    print(f"[tpu ragged qblock qb={qb}] |o_qb-o_cur|={d_o:.3e} |cache diff|={d_c:.3e}")
+    assert d_c == 0.0, "self-write must be identical"
+    assert d_o < tol, f"ragged qblock vs deployed drifted: {d_o}"

--- a/test/srt/kernels/dsa/test_qblock_kernel_tpu.py
+++ b/test/srt/kernels/dsa/test_qblock_kernel_tpu.py
@@ -1,0 +1,100 @@
+"""TPU parity: blocked (query-batched) sparse-MLA prefill kernel vs the
+deployed per-query kernel and a numpy masked-softmax oracle, compiled (no
+interpret). TPU-only (same convention as test_streamindex_topk.py).
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from sgl_jax.srt.kernels.dsa.sparse_mla_prefill import (
+    sparse_mla_attention,
+    units_to_token_ids,
+)
+from sgl_jax.srt.kernels.dsa.sparse_mla_prefill_qblock import (
+    sparse_mla_attention_qblock,
+)
+
+if jax.default_backend() != "tpu":
+    pytest.skip("qblock TPU parity requires TPU", allow_module_level=True)
+
+_SCALE = 1.0 / (192.0**0.5)
+_KV_LORA = 512
+
+
+def _oracle(q, kv, indices, positions, *, read_block):
+    B, S, H, Dk = q.shape
+    T = kv.shape[1]
+    tok = np.asarray(units_to_token_ids(jnp.asarray(indices), read_block))
+    q = np.asarray(q, np.float32)
+    kv = np.asarray(kv, np.float32)
+    pos = np.asarray(positions)
+    out = np.zeros((B, S, H, _KV_LORA), np.float32)
+    for b in range(B):
+        for s in range(S):
+            ids = tok[b, s]
+            valid = (ids >= 0) & (ids <= pos[b, s]) & (ids < T)
+            ids_safe = np.where(valid, ids, 0)
+            k_sel = kv[b, ids_safe]
+            logits = (q[b, s] @ k_sel.T) * _SCALE
+            logits = np.where(valid[None, :], logits, -np.inf)
+            m = logits.max(-1, keepdims=True)
+            m = np.where(np.isneginf(m), 0.0, m)
+            p = np.exp(logits - m)
+            p = np.where(valid[None, :], p, 0.0)
+            denom = p.sum(-1, keepdims=True)
+            out[b, s] = (p / np.where(denom == 0.0, 1.0, denom)) @ k_sel[:, :_KV_LORA]
+    return out
+
+
+def _case(*, B, S, H, K, pages, dtype, page_size=128, seed=0):
+    rng = np.random.default_rng(seed)
+    Dk = _KV_LORA + 64
+    T = page_size * pages
+    q = jnp.asarray(rng.standard_normal((B, S, H, Dk)) * 0.1, dtype)
+    kv = jnp.asarray(rng.standard_normal((B, T, Dk)) * 0.1, dtype)
+    positions = np.zeros((B, S), np.int32)
+    for b in range(B):
+        positions[b] = np.linspace(page_size // 2, T - 1, S).astype(np.int32)
+    idx = np.full((B, S, K), -1, np.int32)
+    for b in range(B):
+        for s in range(S):
+            hi = int(positions[b, s] // page_size + 1)
+            n = min(K, hi)
+            ch = rng.choice(hi, size=n, replace=False)
+            if 0 not in ch:
+                ch[0] = 0
+            idx[b, s, :n] = ch
+    return q, kv, jnp.asarray(idx), jnp.asarray(positions), page_size
+
+
+@pytest.mark.parametrize(
+    "B, S, H, K, pages, qb, dtype, tol",
+    [
+        # deployment shape: H=4/device, QB=64 (QBH=256), bf16
+        (1, 512, 4, 8, 16, 64, jnp.bfloat16, 3e-2),
+        # fp32 tight-tolerance correctness anchor
+        (1, 128, 4, 4, 8, 64, jnp.float32, 2e-3),
+        # QBH exactly 128, multi-batch
+        (2, 96, 8, 4, 8, 16, jnp.float32, 2e-3),
+        # ragged tail block (S % QB != 0)
+        (1, 200, 4, 6, 12, 64, jnp.bfloat16, 3e-2),
+    ],
+)
+def test_qblock_tpu_parity(B, S, H, K, pages, qb, dtype, tol):
+    q, kv, idx, pos, ps = _case(B=B, S=S, H=H, K=K, pages=pages, dtype=dtype, seed=B + S)
+    common = dict(kv_lora_rank=_KV_LORA, read_block=ps, sm_scale=_SCALE)
+    out_qb = np.asarray(sparse_mla_attention_qblock(q, kv, idx, pos, query_block=qb, **common))
+    out_cur = np.asarray(sparse_mla_attention(q, kv, idx, pos, block_units=K, **common))
+    ref = _oracle(q, kv, idx, pos, read_block=ps)
+    e_qb = np.abs(out_qb - ref).max()
+    e_cur = np.abs(out_cur - ref).max()
+    e_x = np.abs(out_qb - out_cur).max()
+    print(
+        f"[tpu qblock {dtype.__name__} S={S}] |qb-ref|={e_qb:.3e} |cur-ref|={e_cur:.3e} |qb-cur|={e_x:.3e}"
+    )
+    assert e_qb < tol, f"qblock vs oracle: {e_qb}"
+    assert e_x < tol, f"qblock vs deployed kernel: {e_x}"

--- a/test/srt/kernels/dsa/test_qblock_preprocess.py
+++ b/test/srt/kernels/dsa/test_qblock_preprocess.py
@@ -5,16 +5,14 @@ The preprocessing turns per-query page selections ``topk_units [T, K]`` into
 per-query-block tables:
 
 * ``blk_units  [nQB, U_max]``  — sorted union of the block's selected units, -1 pad
-* ``blk_member [nQB, QB, num_units]`` int8 — query-to-unit-id membership bitmap
-  (indexed **by unit id**, not by union slot)
-* ``blk_counts [nQB]``        — TRUE unique count (uncapped; > U_max ⇒ the units
-  list is truncated and the caller must gate on it)
+* ``blk_member [nQB, QB, U_max]`` int8 — query-to-union-slot membership bitmap
+* ``blk_counts [nQB]``        — TRUE unique count (uncapped; > U_max ⇒ overflow,
+  the caller must gate on it before trusting the tables)
 
-Parity contract (vs the per-query kernel semantics): for every query ``t``,
-``{ p : blk_member[b, t - b*QB, p] == 1 }`` must equal
-``{ x in topk_units[t] : x >= 0 }`` — i.e. the -inf membership bias in the
-blocked kernel reproduces the per-query selection exactly — and ``blk_units``
-must list each block's union (sorted, -1 padded).
+Parity contract (vs the per-query kernel semantics): for every query ``t`` whose
+block did not overflow, ``{ blk_units[b, u] : blk_member[b, t - b*QB, u] == 1 }``
+must equal ``{ x in topk_units[t] : x >= 0 }`` — i.e. the -inf membership bias in
+the blocked kernel reproduces the per-query selection exactly.
 
 Pure jnp — runs on CPU; TPU shape/e2e checks live with the kernel tests.
 """
@@ -27,41 +25,44 @@ import pytest
 from sgl_jax.srt.kernels.dsa.sparse_mla_prefill_qblock import build_block_unit_tables
 
 
-def _oracle(topk: np.ndarray, qb: int, num_units: int, u_max: int):
+def _oracle(topk: np.ndarray, qb: int, u_max: int):
     """Reference in plain python sets."""
     T, K = topk.shape
     n_blk = -(-T // qb)
     pad = n_blk * qb - T
     tk = np.pad(topk, ((0, pad), (0, 0)), constant_values=-1).reshape(n_blk, qb, K)
     units = np.full((n_blk, u_max), -1, np.int32)
-    member = np.zeros((n_blk, qb, num_units), np.int8)
+    member = np.zeros((n_blk, qb, u_max), np.int8)
     counts = np.zeros((n_blk,), np.int32)
     for b in range(n_blk):
         uniq = sorted({int(x) for x in tk[b].ravel() if x >= 0})
         counts[b] = len(uniq)
         keep = uniq[:u_max]
         units[b, : len(keep)] = keep
+        col = {u: j for j, u in enumerate(keep)}
         for q in range(qb):
             for x in tk[b, q]:
-                if int(x) >= 0:
-                    member[b, q, int(x)] = 1
+                if int(x) in col:
+                    member[b, q, col[int(x)]] = 1
     return units, member, counts
 
 
-def _check(topk: np.ndarray, qb: int, num_units: int, u_max: int):
+def _check(topk: np.ndarray, qb: int, u_max: int):
     units, member, counts = jax.jit(
-        build_block_unit_tables, static_argnames=("query_block", "num_units", "u_max")
-    )(jnp.asarray(topk, jnp.int32), query_block=qb, num_units=num_units, u_max=u_max)
-    ounits, omember, ocounts = _oracle(topk, qb, num_units, u_max)
+        build_block_unit_tables, static_argnames=("query_block", "u_max")
+    )(jnp.asarray(topk, jnp.int32), query_block=qb, u_max=u_max)
+    ounits, omember, ocounts = _oracle(topk, qb, u_max)
     np.testing.assert_array_equal(np.asarray(counts), ocounts)
     np.testing.assert_array_equal(np.asarray(units), ounits)
     np.testing.assert_array_equal(np.asarray(member), omember)
     # per-query set reconstruction (the actual kernel-facing contract)
     T = topk.shape[0]
-    m_np = np.asarray(member)
+    u_np, m_np = np.asarray(units), np.asarray(member)
     for t in range(T):
         b, q = divmod(t, qb)
-        got = set(np.nonzero(m_np[b, q])[0].tolist())
+        if ocounts[b] > u_max:
+            continue  # overflowed block: caller must gate, no contract
+        got = {int(u_np[b, j]) for j in np.nonzero(m_np[b, q])[0]}
         want = {int(x) for x in topk[t] if x >= 0}
         assert got == want, f"query {t}: {got} != {want}"
 
@@ -79,21 +80,21 @@ def test_parity_110k_shape():
     # 110k deployment shape: 8192-query chunk, K=32 pages, 880-page pool.
     rng = np.random.default_rng(0)
     tk = _local_topk(rng, T=8192, K=32, num_units=880, spread=40)
-    _check(tk, qb=64, num_units=880, u_max=880)
+    _check(tk, qb=64, u_max=880)
 
 
 def test_parity_uniform_random():
     # no locality at all — worst-case unions
     rng = np.random.default_rng(1)
     tk = rng.integers(0, 96, size=(256, 8)).astype(np.int32)
-    _check(tk, qb=32, num_units=96, u_max=96)
+    _check(tk, qb=32, u_max=96)
 
 
 @pytest.mark.parametrize("T", [1, 63, 64, 65, 130])
 def test_block_boundaries(T):
     rng = np.random.default_rng(2)
     tk = rng.integers(0, 40, size=(T, 4)).astype(np.int32)
-    _check(tk, qb=64, num_units=40, u_max=40)
+    _check(tk, qb=64, u_max=40)
 
 
 def test_padded_and_empty_rows():
@@ -102,31 +103,22 @@ def test_padded_and_empty_rows():
     tk[10] = -1  # fully padded query (e.g. beyond seq end)
     tk[20, 2:] = -1  # partially padded topk row
     tk[64:] = -1  # whole second block empty
-    _check(tk, qb=64, num_units=40, u_max=40)
+    _check(tk, qb=64, u_max=40)
 
 
 def test_duplicates_within_query():
     tk = np.array([[3, 3, 7, 7], [7, 3, 3, 3], [-1, 5, 5, -1]], np.int32)
-    _check(tk, qb=2, num_units=8, u_max=8)
-
-
-def test_u_max_exceeds_num_units():
-    # u_max wider than the id space: units tail must stay -1 padded
-    tk = np.array([[0, 3], [3, 1]], np.int32)
-    _check(tk, qb=2, num_units=4, u_max=8)
+    _check(tk, qb=2, u_max=8)
 
 
 def test_overflow_reported_uncapped():
     # true union (16) exceeds u_max (8): counts must report the TRUE size so the
-    # caller can gate; retained prefix = first u_max sorted uniques; the by-id
-    # membership is unaffected by the truncation.
+    # caller can gate; retained prefix = first u_max sorted uniques.
     tk = np.arange(16, dtype=np.int32).reshape(4, 4)  # one block, 16 uniques
-    units, member, counts = build_block_unit_tables(
-        jnp.asarray(tk), query_block=4, num_units=16, u_max=8
-    )
+    units, member, counts = build_block_unit_tables(jnp.asarray(tk), query_block=4, u_max=8)
     assert int(counts[0]) == 16
     np.testing.assert_array_equal(np.asarray(units[0]), np.arange(8))
-    _, omember, _ = _oracle(tk, 4, 16, 8)
+    ounits, omember, _ = _oracle(tk, 4, 8)
     np.testing.assert_array_equal(np.asarray(member), omember)
 
 
@@ -145,5 +137,4 @@ def test_packed_multirequest_global_keys(num_seqs):
         tk[tk % 5 == 0] = -1  # sprinkle padding
         rows.append(np.where(tk >= 0, tk + base, -1))
     tk_packed = np.concatenate(rows, axis=0)
-    nu = num_seqs * pages_per_seq
-    _check(tk_packed, qb=64, num_units=nu, u_max=nu)
+    _check(tk_packed, qb=64, u_max=num_seqs * pages_per_seq)

--- a/test/srt/kernels/dsa/test_qblock_preprocess.py
+++ b/test/srt/kernels/dsa/test_qblock_preprocess.py
@@ -5,14 +5,16 @@ The preprocessing turns per-query page selections ``topk_units [T, K]`` into
 per-query-block tables:
 
 * ``blk_units  [nQB, U_max]``  — sorted union of the block's selected units, -1 pad
-* ``blk_member [nQB, QB, U_max]`` int8 — query-to-unit membership bitmap
-* ``blk_counts [nQB]``        — TRUE unique count (uncapped; > U_max ⇒ overflow,
-  the caller must gate on it before trusting the tables)
+* ``blk_member [nQB, QB, num_units]`` int8 — query-to-unit-id membership bitmap
+  (indexed **by unit id**, not by union slot)
+* ``blk_counts [nQB]``        — TRUE unique count (uncapped; > U_max ⇒ the units
+  list is truncated and the caller must gate on it)
 
-Parity contract (vs the per-query kernel semantics): for every query ``t`` whose
-block did not overflow, ``{ blk_units[b, u] : blk_member[b, t - b*QB, u] == 1 }``
-must equal ``{ x in topk_units[t] : x >= 0 }`` — i.e. the -inf membership bias in
-the blocked kernel reproduces the per-query selection exactly.
+Parity contract (vs the per-query kernel semantics): for every query ``t``,
+``{ p : blk_member[b, t - b*QB, p] == 1 }`` must equal
+``{ x in topk_units[t] : x >= 0 }`` — i.e. the -inf membership bias in the
+blocked kernel reproduces the per-query selection exactly — and ``blk_units``
+must list each block's union (sorted, -1 padded).
 
 Pure jnp — runs on CPU; TPU shape/e2e checks live with the kernel tests.
 """
@@ -25,44 +27,41 @@ import pytest
 from sgl_jax.srt.kernels.dsa.sparse_mla_prefill_qblock import build_block_unit_tables
 
 
-def _oracle(topk: np.ndarray, qb: int, u_max: int):
+def _oracle(topk: np.ndarray, qb: int, num_units: int, u_max: int):
     """Reference in plain python sets."""
     T, K = topk.shape
     n_blk = -(-T // qb)
     pad = n_blk * qb - T
     tk = np.pad(topk, ((0, pad), (0, 0)), constant_values=-1).reshape(n_blk, qb, K)
     units = np.full((n_blk, u_max), -1, np.int32)
-    member = np.zeros((n_blk, qb, u_max), np.int8)
+    member = np.zeros((n_blk, qb, num_units), np.int8)
     counts = np.zeros((n_blk,), np.int32)
     for b in range(n_blk):
         uniq = sorted({int(x) for x in tk[b].ravel() if x >= 0})
         counts[b] = len(uniq)
         keep = uniq[:u_max]
         units[b, : len(keep)] = keep
-        col = {u: j for j, u in enumerate(keep)}
         for q in range(qb):
             for x in tk[b, q]:
-                if int(x) in col:
-                    member[b, q, col[int(x)]] = 1
+                if int(x) >= 0:
+                    member[b, q, int(x)] = 1
     return units, member, counts
 
 
-def _check(topk: np.ndarray, qb: int, u_max: int):
+def _check(topk: np.ndarray, qb: int, num_units: int, u_max: int):
     units, member, counts = jax.jit(
-        build_block_unit_tables, static_argnames=("query_block", "u_max")
-    )(jnp.asarray(topk, jnp.int32), query_block=qb, u_max=u_max)
-    ounits, omember, ocounts = _oracle(topk, qb, u_max)
+        build_block_unit_tables, static_argnames=("query_block", "num_units", "u_max")
+    )(jnp.asarray(topk, jnp.int32), query_block=qb, num_units=num_units, u_max=u_max)
+    ounits, omember, ocounts = _oracle(topk, qb, num_units, u_max)
     np.testing.assert_array_equal(np.asarray(counts), ocounts)
     np.testing.assert_array_equal(np.asarray(units), ounits)
     np.testing.assert_array_equal(np.asarray(member), omember)
     # per-query set reconstruction (the actual kernel-facing contract)
     T = topk.shape[0]
-    u_np, m_np = np.asarray(units), np.asarray(member)
+    m_np = np.asarray(member)
     for t in range(T):
         b, q = divmod(t, qb)
-        if ocounts[b] > u_max:
-            continue  # overflowed block: caller must gate, no contract
-        got = {int(u_np[b, j]) for j in np.nonzero(m_np[b, q])[0]}
+        got = set(np.nonzero(m_np[b, q])[0].tolist())
         want = {int(x) for x in topk[t] if x >= 0}
         assert got == want, f"query {t}: {got} != {want}"
 
@@ -80,21 +79,21 @@ def test_parity_110k_shape():
     # 110k deployment shape: 8192-query chunk, K=32 pages, 880-page pool.
     rng = np.random.default_rng(0)
     tk = _local_topk(rng, T=8192, K=32, num_units=880, spread=40)
-    _check(tk, qb=64, u_max=880)
+    _check(tk, qb=64, num_units=880, u_max=880)
 
 
 def test_parity_uniform_random():
     # no locality at all — worst-case unions
     rng = np.random.default_rng(1)
     tk = rng.integers(0, 96, size=(256, 8)).astype(np.int32)
-    _check(tk, qb=32, u_max=96)
+    _check(tk, qb=32, num_units=96, u_max=96)
 
 
 @pytest.mark.parametrize("T", [1, 63, 64, 65, 130])
 def test_block_boundaries(T):
     rng = np.random.default_rng(2)
     tk = rng.integers(0, 40, size=(T, 4)).astype(np.int32)
-    _check(tk, qb=64, u_max=40)
+    _check(tk, qb=64, num_units=40, u_max=40)
 
 
 def test_padded_and_empty_rows():
@@ -103,22 +102,31 @@ def test_padded_and_empty_rows():
     tk[10] = -1  # fully padded query (e.g. beyond seq end)
     tk[20, 2:] = -1  # partially padded topk row
     tk[64:] = -1  # whole second block empty
-    _check(tk, qb=64, u_max=40)
+    _check(tk, qb=64, num_units=40, u_max=40)
 
 
 def test_duplicates_within_query():
     tk = np.array([[3, 3, 7, 7], [7, 3, 3, 3], [-1, 5, 5, -1]], np.int32)
-    _check(tk, qb=2, u_max=8)
+    _check(tk, qb=2, num_units=8, u_max=8)
+
+
+def test_u_max_exceeds_num_units():
+    # u_max wider than the id space: units tail must stay -1 padded
+    tk = np.array([[0, 3], [3, 1]], np.int32)
+    _check(tk, qb=2, num_units=4, u_max=8)
 
 
 def test_overflow_reported_uncapped():
     # true union (16) exceeds u_max (8): counts must report the TRUE size so the
-    # caller can gate; retained prefix = first u_max sorted uniques.
+    # caller can gate; retained prefix = first u_max sorted uniques; the by-id
+    # membership is unaffected by the truncation.
     tk = np.arange(16, dtype=np.int32).reshape(4, 4)  # one block, 16 uniques
-    units, member, counts = build_block_unit_tables(jnp.asarray(tk), query_block=4, u_max=8)
+    units, member, counts = build_block_unit_tables(
+        jnp.asarray(tk), query_block=4, num_units=16, u_max=8
+    )
     assert int(counts[0]) == 16
     np.testing.assert_array_equal(np.asarray(units[0]), np.arange(8))
-    ounits, omember, _ = _oracle(tk, 4, 8)
+    _, omember, _ = _oracle(tk, 4, 16, 8)
     np.testing.assert_array_equal(np.asarray(member), omember)
 
 
@@ -137,4 +145,5 @@ def test_packed_multirequest_global_keys(num_seqs):
         tk[tk % 5 == 0] = -1  # sprinkle padding
         rows.append(np.where(tk >= 0, tk + base, -1))
     tk_packed = np.concatenate(rows, axis=0)
-    _check(tk_packed, qb=64, u_max=num_seqs * pages_per_seq)
+    nu = num_seqs * pages_per_seq
+    _check(tk_packed, qb=64, num_units=nu, u_max=nu)

--- a/test/srt/kernels/dsa/test_qblock_preprocess.py
+++ b/test/srt/kernels/dsa/test_qblock_preprocess.py
@@ -1,0 +1,140 @@
+"""CPU parity for the query-block preprocessing of the blocked sparse-MLA
+prefill kernel (P1: attend query-batching).
+
+The preprocessing turns per-query page selections ``topk_units [T, K]`` into
+per-query-block tables:
+
+* ``blk_units  [nQB, U_max]``  — sorted union of the block's selected units, -1 pad
+* ``blk_member [nQB, QB, U_max]`` int8 — query-to-unit membership bitmap
+* ``blk_counts [nQB]``        — TRUE unique count (uncapped; > U_max ⇒ overflow,
+  the caller must gate on it before trusting the tables)
+
+Parity contract (vs the per-query kernel semantics): for every query ``t`` whose
+block did not overflow, ``{ blk_units[b, u] : blk_member[b, t - b*QB, u] == 1 }``
+must equal ``{ x in topk_units[t] : x >= 0 }`` — i.e. the -inf membership bias in
+the blocked kernel reproduces the per-query selection exactly.
+
+Pure jnp — runs on CPU; TPU shape/e2e checks live with the kernel tests.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from sgl_jax.srt.kernels.dsa.sparse_mla_prefill_qblock import build_block_unit_tables
+
+
+def _oracle(topk: np.ndarray, qb: int, u_max: int):
+    """Reference in plain python sets."""
+    T, K = topk.shape
+    n_blk = -(-T // qb)
+    pad = n_blk * qb - T
+    tk = np.pad(topk, ((0, pad), (0, 0)), constant_values=-1).reshape(n_blk, qb, K)
+    units = np.full((n_blk, u_max), -1, np.int32)
+    member = np.zeros((n_blk, qb, u_max), np.int8)
+    counts = np.zeros((n_blk,), np.int32)
+    for b in range(n_blk):
+        uniq = sorted({int(x) for x in tk[b].ravel() if x >= 0})
+        counts[b] = len(uniq)
+        keep = uniq[:u_max]
+        units[b, : len(keep)] = keep
+        col = {u: j for j, u in enumerate(keep)}
+        for q in range(qb):
+            for x in tk[b, q]:
+                if int(x) in col:
+                    member[b, q, col[int(x)]] = 1
+    return units, member, counts
+
+
+def _check(topk: np.ndarray, qb: int, u_max: int):
+    units, member, counts = jax.jit(
+        build_block_unit_tables, static_argnames=("query_block", "u_max")
+    )(jnp.asarray(topk, jnp.int32), query_block=qb, u_max=u_max)
+    ounits, omember, ocounts = _oracle(topk, qb, u_max)
+    np.testing.assert_array_equal(np.asarray(counts), ocounts)
+    np.testing.assert_array_equal(np.asarray(units), ounits)
+    np.testing.assert_array_equal(np.asarray(member), omember)
+    # per-query set reconstruction (the actual kernel-facing contract)
+    T = topk.shape[0]
+    u_np, m_np = np.asarray(units), np.asarray(member)
+    for t in range(T):
+        b, q = divmod(t, qb)
+        if ocounts[b] > u_max:
+            continue  # overflowed block: caller must gate, no contract
+        got = {int(u_np[b, j]) for j in np.nonzero(m_np[b, q])[0]}
+        want = {int(x) for x in topk[t] if x >= 0}
+        assert got == want, f"query {t}: {got} != {want}"
+
+
+def _local_topk(rng, T, K, num_units, spread):
+    """Locality-flavoured selection: pages near the query's own page + sinks."""
+    base = (np.arange(T) * num_units // max(T, 1))[:, None]
+    jitter = rng.integers(-spread, spread + 1, size=(T, K))
+    tk = np.clip(base + jitter, 0, num_units - 1)
+    tk[:, 0] = 0  # sink page for everyone (heavy overlap)
+    return tk.astype(np.int32)
+
+
+def test_parity_110k_shape():
+    # 110k deployment shape: 8192-query chunk, K=32 pages, 880-page pool.
+    rng = np.random.default_rng(0)
+    tk = _local_topk(rng, T=8192, K=32, num_units=880, spread=40)
+    _check(tk, qb=64, u_max=880)
+
+
+def test_parity_uniform_random():
+    # no locality at all — worst-case unions
+    rng = np.random.default_rng(1)
+    tk = rng.integers(0, 96, size=(256, 8)).astype(np.int32)
+    _check(tk, qb=32, u_max=96)
+
+
+@pytest.mark.parametrize("T", [1, 63, 64, 65, 130])
+def test_block_boundaries(T):
+    rng = np.random.default_rng(2)
+    tk = rng.integers(0, 40, size=(T, 4)).astype(np.int32)
+    _check(tk, qb=64, u_max=40)
+
+
+def test_padded_and_empty_rows():
+    rng = np.random.default_rng(3)
+    tk = rng.integers(0, 40, size=(96, 4)).astype(np.int32)
+    tk[10] = -1  # fully padded query (e.g. beyond seq end)
+    tk[20, 2:] = -1  # partially padded topk row
+    tk[64:] = -1  # whole second block empty
+    _check(tk, qb=64, u_max=40)
+
+
+def test_duplicates_within_query():
+    tk = np.array([[3, 3, 7, 7], [7, 3, 3, 3], [-1, 5, 5, -1]], np.int32)
+    _check(tk, qb=2, u_max=8)
+
+
+def test_overflow_reported_uncapped():
+    # true union (16) exceeds u_max (8): counts must report the TRUE size so the
+    # caller can gate; retained prefix = first u_max sorted uniques.
+    tk = np.arange(16, dtype=np.int32).reshape(4, 4)  # one block, 16 uniques
+    units, member, counts = build_block_unit_tables(jnp.asarray(tk), query_block=4, u_max=8)
+    assert int(counts[0]) == 16
+    np.testing.assert_array_equal(np.asarray(units[0]), np.arange(8))
+    ounits, omember, _ = _oracle(tk, 4, 8)
+    np.testing.assert_array_equal(np.asarray(member), omember)
+
+
+@pytest.mark.parametrize("num_seqs", [8, 32])  # concurrency envelope: cc=8 / cc=32
+def test_packed_multirequest_global_keys(num_seqs):
+    # Ragged/packed form (cc>1): requests packed on the token axis, seq-local page
+    # ids lifted to global keys by each request's page-table base. Query blocks
+    # straddle request boundaries — membership must still be exact per query.
+    rng = np.random.default_rng(4)
+    K, pages_per_seq = 8, 24
+    q_lens = rng.integers(3, 90, size=num_seqs)
+    rows = []
+    for rid in range(num_seqs):
+        base = rid * pages_per_seq
+        tk = rng.integers(0, pages_per_seq, size=(q_lens[rid], K)).astype(np.int32)
+        tk[tk % 5 == 0] = -1  # sprinkle padding
+        rows.append(np.where(tk >= 0, tk + base, -1))
+    tk_packed = np.concatenate(rows, axis=0)
+    _check(tk_packed, qb=64, u_max=num_seqs * pages_per_seq)


### PR DESCRIPTION
### Motivation

The DSA sparse prefill kernel (`sparse_mla_prefill.py`) runs one program per query: each of the `S` queries independently DMAs its `K` selected pages from HBM. At long context the per-query selections overlap heavily (attention sinks + local windows), so the same physical page is re-fetched by thousands of programs. At 110k ctx (880 pages, 8192-query chunk, K=32) each page is fetched ~298x: **38.7 GB of HBM reads per layer against a 129 MB KV cache**. The score matmul also feeds only `H` (~4 with head-TP) sublane rows, idling the MXU. Profiling shows this attend kernel at ~47% of the 110k TTFT.

This is the same redundancy that GPU sparse-MLA kernels (e.g. DeepSeek's `flashmla_sparse`) eliminate with warp-level sharing of gathered KV; this PR is the TPU analogue.

### Design

Within the existing `DSA_PREFILL_SPARSE=1` opt-in surface, the sparse extend now runs blocked by **default** — no new flag to discover. The semantics are parity-gated identical to the per-query kernel (same masked-softmax math; only the execution shape changes), the default `DSA_PREFILL_SPARSE=0` path and CI are untouched, and `DSA_PREFILL_QBLOCK=0` remains as an escape hatch back to the per-query kernel. Three parts:

1. **jnp preprocessing** (`build_block_unit_tables`): group queries into blocks of `QB=64` (`DSA_PREFILL_QBLOCK_QB`), compute each block's selected-page **union** (sorted, compacted) plus a per-query membership bitmap. Scatter-free (broadcast-compare + sort): ~0.5 ms/layer at the 110k shape.
2. **Pallas kernel** (`sparse_mla_prefill_qblock.py`): grid over query blocks; the block's union pages are DMA'd **once each** through an `NBUF=4` prefetch ring (the per-page fetches are latency-bound, not bandwidth-bound). Per-query selection is restored inside flash-softmax with a `-inf` bias = membership AND causal AND kv_len. Score layout is key-major (`[page_rows, QB*H]`), which fills the MXU lane axis (4 head rows -> 256 rows) and keeps all bitmap reads on the sublane axis (Mosaic-friendly: aligned 32-row window + iota select).
3. **Ragged/paged mode**: seq-local page ids are lifted to global page-table keys, so one block may hold queries from different requests (packed multi-request extend, same metadata as the dense path). Wired behind the existing `DSA_PREFILL_SPARSE` ragged call site.

### Prior art

The macro-structure (query-block x KV-block flash softmax, ring-buffered async page DMA, clamped always-legal copies with mask-side correctness) matches tokamax's public MLA ragged-paged-attention kernel ([`openxla/tokamax`, `_src/ops/experimental/mla`](https://github.com/openxla/tokamax/tree/main/tokamax/_src/ops/experimental/mla)). The deltas are workload-driven: RPA walks dense contiguous KV, so a depth-2 double buffer with multi-page batched DMAs saturates bandwidth, while top-k sparse gather fetches discontiguous 128-token pages (latency-bound, ~1.5 us each) and needs a deeper (`NBUF=4`) prefetch ring; and RPA has no page-dedup problem, which is the core of this kernel (block-union + membership bias). To my knowledge there is no public TPU kernel for top-k sparse paged MLA prefill. In-kernel KV cache write-back (fused in RPA) is a natural follow-up kept out of this PR to stay minimal.

### Results (v7x, GLM-5.2 fp8, tp16, page 128, ctx 135k, chunk 8192, single stream)

Paired on the same deployment, flag flipped in place; OFF arm reproduces the #1545 numbers exactly.

| metric | OFF (per-query kernel) | ON (qblock QB=64) | delta |
|---|---|---|---|
| TTFT 16k | 9.28 s | **3.58 s** | **-61.4% (2.59x)** |
| TTFT 110k (x3) | 65.53 / 65.54 / 65.54 s | **30.37 / 30.40 / 30.41 s** | **-53.6% (2.16x)** |
| decode TPOT 110k | 15.25 ms | 15.34 ms | unchanged (decode path untouched) |

Kernel microbench (110k shape, per-layer-per-chunk, bf16): per-query 43.3 ms -> qblock 8.1 ms (**5.4x**) on a locality-flavoured selection (union ~69 pages/block); 8.9x when all queries share the same pages.

### Cross-generation validation (v6e-64, GLM-5.2 BF16 + dynamic W8A8, tp64/dp8/ep64, ctx 8k)

Same paired protocol on TPU v6e (previous generation, and the first multi-`dp` validation of the sparse extend path). Kernel parity 32/32 unmodified; paired throughput (1k-in/1k-out random):

| concurrency | default (qblock) | DSA_PREFILL_QBLOCK=0 | ratio |
|---|---|---|---|
| 64 | 578.7 tok/s | 389.0 | **1.49x** |
| 256 | 1121.6 | 845.3 | **1.33x** |
| 460 | 1739.5 | 1240.1 | **1.40x** |

GSM8K 200q paired: 0.965 / 0.955; needle 25/25 both arms; zero Mosaic/runtime errors across both arms. Note this is a short-context saturated-selection workload — the kernel still wins on pure page-DMA dedup even when sparsity itself saves nothing.

### Known boundary (documented; why an escape hatch exists)

Blocked execution does more FLOPs per query (each query scores the whole block union). It wins whenever neighbouring queries' selections overlap — measured break-even at union ≈ 520 of 880 pages per 64-query block; a pathological **uniform-random** selection (union ≈ 795/880, no sinks, no locality) is ~0.5x vs the per-query kernel. Real DSA selections are sink+local-window dominated (same assumption as the GPU sparse kernels), and the e2e numbers above confirm the win at both 16k and 110k. `DSA_PREFILL_QBLOCK_QB` tunes the tradeoff.

### Accuracy gates

- CPU parity (interpret): 19/19 — preprocessing set-reconstruction vs python-set oracle (incl. cc=8/32 packed multi-request shapes); kernel vs masked-softmax oracle AND vs the deployed per-query kernel (<2e-3 fp32); ragged qblock vs deployed ragged (blocks straddling requests; caches bit-identical).
- TPU parity: 6/6 (bf16/fp32, flat + ragged; |err| ~1e-4).
- Needle 76k, 5 depths x 5 values, paired: **ON 25/25 vs OFF 25/25** (answer digits identical in all samples).
- GSM8K 200q paired (5-shot, temp 0, parallel 32): **ON 0.950 vs OFF 0.970** — both above the 0.93 regression bar; **193/200 predictions byte-identical**, the 7 divergent generations are downstream token divergence from bf16-level numeric perturbation (same signature as prior paired runs on this path). Same run shows the concurrency win: 200 questions in 116 s (ON) vs 234 s (OFF).
- Compile envelope: precompile grid bs {1,8,32} x tokens {512..4096} passes with qblock ON; live requests at cc=1 / 8 / 32 all served with zero tracebacks / Mosaic errors.

### Test plan

- [x] `test_qblock_preprocess.py` (13 cases, CPU)
- [x] `test_qblock_kernel_parity.py` (6 cases, CPU interpret, incl. ragged)
- [x] `test_qblock_kernel_tpu.py` (6 cases, TPU)
- [x] GSM8K 200q paired ON/OFF (0.950 / 0.970, 193/200 identical)
- [x] cc=1/8/32 compile envelope (precompile grid + live requests at each cc)
