### PR TITLE
feat(vlm): add Qwen3-VL support and cookbook

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen3-VL.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3-VL.md
@@ -1,0 +1,388 @@
+---
+title: "Qwen3-VL"
+---
+
+# Qwen3-VL on SGL-JAX
+
+> **Validated recipe** — Qwen3-VL-32B-Instruct validated on a single TPU v7x-8 with DP4 × effective TP2, including MMMU/MMMU-Pro Vision accuracy and a single-image multimodal serving benchmark.
+
+## 1. Model Introduction
+
+[**Qwen/Qwen3-VL-32B-Instruct**](https://huggingface.co/Qwen/Qwen3-VL-32B-Instruct) is a 32B dense vision-language instruction model that accepts text, images, and video and generates text. SGL-JAX serves it through the regular autoregressive server: multimodal requests pass through media loading, the in-model vision encoder, vision/text embedding merge, language-model prefill, and decode.
+
+The recipe validates `Qwen/Qwen3-VL-32B-Instruct`. Other Qwen3-VL sizes and Thinking variants require their own memory sizing and validation.
+
+For text-only Qwen3 dense models, see the [Qwen3 recipe](/autoregressive/Qwen/Qwen3).
+
+**Key Features**:
+
+- **Image and video understanding** — OpenAI-compatible chat requests can mix visual content with text prompts.
+- **Visual agent and OCR capabilities** — the model family targets visual interaction, document understanding, multilingual OCR, and spatial reasoning.
+- **Long-context multimodal input** — long text and visual token sequences share the same serving context budget.
+- **In-model vision encoder** — `--vision-encoder-parallel` selects data- or tensor-parallel placement for the ViT.
+
+**Recommended Generation Parameters**: choose parameters for the target task. The accuracy recipe in §4.1 uses deterministic decoding with `temperature=0`, `max_tokens=8192`, and seed 42.
+
+**License**: see the [Qwen3-VL-32B-Instruct model card](https://huggingface.co/Qwen/Qwen3-VL-32B-Instruct) for the authoritative license terms.
+
+## 2. Deployment
+
+### 2.1 Hardware Matrix
+
+| Model | TPU | Topology | `--tp-size` | Notes |
+|---|---|---|---|---|
+| Qwen3-VL-32B | **v7x-8** | `2x2x1` | 8 | Single host with 4 chips / 8 JAX devices; `--dp-size 4` gives DP4 × effective TP2. |
+
+The validated path uses data-parallel vision-encoder placement and full BF16 model, vision tower, and KV cache precision without quantization.
+
+See [TPU topology reference](/base/tpu-topology-reference) for TPU generation details. For other slices, see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+
+### 2.2 Environment
+
+Install per the [Install guide](/get_started/install). For the current single-host VL path, use the [Single-host Docker template](/deployment/single-host-docker).
+
+The validated source revision is `41bcb3f8f4b155853b468f9adc0a1c6f73888fb7` on `feat/qwen3-vl`.
+
+Extra packages for multimodal processing and accuracy benchmarking:
+
+```bash
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+pip install 'evalscope[app,perf]==1.5.1'
+```
+
+### 2.3 Launch
+
+#### Single-host — TPU v7x-8
+
+This 32K configuration is used for the accuracy run in §4.1:
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache \
+python -u -m sgl_jax.launch_server \
+  --model-path Qwen/Qwen3-VL-32B-Instruct \
+  --trust-remote-code \
+  --skip-server-warmup \
+  --device tpu \
+  --tp-size 8 --dp-size 4 \
+  --dtype bfloat16 --kv-cache-dtype bf16 \
+  --context-length 32768 --max-seq-len 32768 \
+  --max-running-requests 1024 \
+  --max-prefill-tokens 16384 --chunked-prefill-size 4096 \
+  --mem-fraction-static 0.8 --page-size 128 \
+  --disable-radix-cache \
+  --vision-encoder-parallel dp \
+  --mm-io-worker-num 4 \
+  --mm-processor-worker-num 2 \
+  --random-seed 0 \
+  --host 0.0.0.0 --port 30000
+```
+
+The regular server recognizes the model's multimodal contract. The separate `--multimodal` staged runtime used by diffusion recipes is not needed.
+
+### 2.4 Configuration Tips
+
+**Memory Management:**
+
+- VL workloads use HBM for KV cache and vision embeddings. Leave headroom for visual tensors that scale with image count and resolution.
+- Accuracy uses `--mem-fraction-static 0.8` with a 32K context. The 2K throughput run uses `0.9`; do not copy that value blindly to longer-context workloads.
+- Tune `--max-running-requests` against the target visual input distribution.
+
+**In-model multimodal serving:**
+
+- Qwen3-VL uses the regular autoregressive server; `--multimodal` is not required.
+- `--tp-size 8 --dp-size 4` is a global device mesh and gives effective TP2 inside each of four DP replicas.
+- `--vision-encoder-parallel dp` load-balances images across DP ranks.
+
+**Chunked Prefill and vision buckets:**
+
+- `--chunked-prefill-size 4096` bounds peak HBM during prefill. The budget includes both text and vision embeddings.
+- A 512×512 benchmark image produces processor tensors with shape `(1024, 1536)` before the model's vision-token merge. The default precompiled vision patch buckets cover this shape; `1024` is not the only runtime bucket or a model-wide image limit.
+
+**Multimodal workers:**
+
+- The validated Qwen3-VL configuration uses 4 I/O workers and 2 processor workers.
+- I/O workers load and decode media; processor workers run the Hugging Face processor. Increasing either value should be driven by host-side profiling and workload shape.
+
+**Remote media URLs:**
+
+- `image_url` and `video_url` inputs must be fetchable from the TPU host. For private media, use a controlled object-store URL, a base64 data URL, or a mounted local file.
+
+**Compilation Cache Hygiene:**
+
+- Set `JAX_COMPILATION_CACHE_DIR` to reuse compiled vision, prefill, and decode programs after restart.
+- Cache keys include full shapes and relevant serving flags. Changes to context length, parallelism, page size, or visual shapes can compile new programs.
+
+For complete flag definitions, see [Launch flags reference](/base/launch-flags-reference); run `python -m sgl_jax.launch_server --help` for the current CLI.
+
+## 3. Invocation
+
+### 3.1 Basic Chat Completion (text only)
+
+Qwen3-VL accepts text-only requests on the same OpenAI-compatible `/v1/chat/completions` endpoint. This is useful for checking server health before sending images:
+
+```bash
+curl -X POST http://127.0.0.1:30000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-VL-32B-Instruct",
+    "messages": [{"role": "user", "content": "Hello, who are you?"}],
+    "temperature": 0,
+    "max_tokens": 128
+  }'
+```
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:30000/v1", api_key="EMPTY")
+
+response = client.chat.completions.create(
+    model="Qwen/Qwen3-VL-32B-Instruct",
+    messages=[{"role": "user", "content": "Hello, who are you?"}],
+    temperature=0,
+    max_tokens=128,
+)
+print(response.choices[0].message.content)
+```
+
+### 3.2 Multimodal Input
+
+Vision-language input uses the OpenAI Vision API schema. Each `messages[i].content` is a list of content blocks that mixes visual inputs and text.
+
+#### Single Image
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:30000/v1", api_key="EMPTY")
+
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg"
+                },
+            },
+            {"type": "text", "text": "Describe the main content of this image."},
+        ],
+    }
+]
+
+response = client.chat.completions.create(
+    model="Qwen/Qwen3-VL-32B-Instruct",
+    messages=messages,
+    temperature=0,
+    max_tokens=256,
+)
+print(response.choices[0].message.content)
+```
+
+#### Multi-Image
+
+Stack multiple `image_url` blocks in the same content list, followed by the prompt:
+
+```python
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {"type": "image_url", "image_url": {"url": "https://example.com/before.jpg"}},
+            {"type": "image_url", "image_url": {"url": "https://example.com/after.jpg"}},
+            {"type": "text", "text": "Compare these images and describe what changed."},
+        ],
+    }
+]
+
+response = client.chat.completions.create(
+    model="Qwen/Qwen3-VL-32B-Instruct",
+    messages=messages,
+    max_tokens=256,
+)
+print(response.choices[0].message.content)
+```
+
+#### Video
+
+Use a `video_url` block for video input:
+
+```python
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {"type": "video_url", "video_url": {"url": "https://example.com/clip.mp4"}},
+            {"type": "text", "text": "Describe this video in three bullet points."},
+        ],
+    }
+]
+
+response = client.chat.completions.create(
+    model="Qwen/Qwen3-VL-32B-Instruct",
+    messages=messages,
+    max_tokens=512,
+)
+print(response.choices[0].message.content)
+```
+
+> **Validated scope:** the invocation interface supports text, images, and video, but the performance benchmark in this recipe validates only single-image requests containing prompt text and one 512×512 JPEG. Multi-image, video, Qwen3-VL Thinking variants, and tool-calling are outside this validation.
+
+## 4. Benchmark
+
+The data below is a snapshot of Qwen3-VL-32B-Instruct on a single TPU v7x-8 at source commit `41bcb3f8f4b155853b468f9adc0a1c6f73888fb7`. Accuracy and performance use separate context sizes, recorded in their respective environments.
+
+### 4.1 Accuracy — MMMU and MMMU-Pro Vision
+
+**Test Environment**
+
+| Field | Value |
+|---|---|
+| Hardware | TPU v7x-8, single host, 4 chips / 8 JAX devices |
+| Model | `Qwen/Qwen3-VL-32B-Instruct` |
+| Parallelism | DP4 × effective TP2 (`--tp-size 8 --dp-size 4`) |
+| Precision | BF16 model, vision, and KV; no quantization |
+| Context / max sequence | 32768 / 32768 |
+| Evaluator | EvalScope 1.5.1, OpenAI-compatible API |
+| Dataset source | Hugging Face `MMMU/MMMU` and `MMMU/MMMU_Pro` (`vision`) |
+| Generation | `max_tokens=8192`, temperature 0, seed 42 |
+| Evaluation batch size | 24 (MMMU); 256 (MMMU-Pro Vision) |
+
+**Deployment Command** — use the [§2.3 v7x-8 launch command](/autoregressive/Qwen/Qwen3-VL#2-3-launch).
+
+**Benchmark Command**
+
+```python
+import os
+
+from evalscope import TaskConfig, run_task
+
+dataset_args = {
+    "mmmu": {"dataset_id": "MMMU/MMMU"},
+    "mmmu_pro": {
+        "dataset_id": "MMMU/MMMU_Pro",
+        "extra_params": {"dataset_format": "vision"},
+    },
+}
+
+for dataset, batch_size in (("mmmu", 24), ("mmmu_pro", 256)):
+    task_cfg = TaskConfig(
+        model="Qwen/Qwen3-VL-32B-Instruct",
+        api_url="http://127.0.0.1:30000/v1",
+        api_key="EMPTY",
+        eval_type="openai_api",
+        datasets=[dataset],
+        dataset_hub="huggingface",
+        dataset_args={dataset: dataset_args[dataset]},
+        eval_batch_size=batch_size,
+        generation_config={
+            "max_tokens": 8192,
+            "temperature": 0.0,
+            "stream": False,
+        },
+        seed=42,
+        work_dir=os.path.join("./outputs/qwen3vl32b_vlm", dataset),
+    )
+    run_task(task_cfg=task_cfg)
+```
+
+**Test Results**
+
+| Dataset | Metric | Samples | Score |
+|---|---|---:|---:|
+| MMMU Val | Mean Accuracy | 900 | **72.22%** |
+| MMMU-Pro Vision | Mean Accuracy | 1,730 | **62.43%** |
+
+### 4.2 Speed — single multimodal workload
+
+> **Multimodal throughput row.** The workload submits 1,000 requests at an unbounded request rate. Each request contains 1,024 random source-text tokens and one random 512×512 JPEG, averages 1,086.25 text tokens plus 258 vision tokens after chat templating, and generates 500 output tokens. The run uses one warmup request and flushes the cache before measurement.
+
+**Test Environment**
+
+| Field | Value |
+|---|---|
+| Hardware | TPU v7x-8, single host, 4 chips / 8 JAX devices |
+| Model | `Qwen/Qwen3-VL-32B-Instruct` |
+| Source | `feat/qwen3-vl` at `41bcb3f8f4b155853b468f9adc0a1c6f73888fb7` |
+| Parallelism | DP4 × effective TP2 (`--tp-size 8 --dp-size 4`) |
+| Precision | BF16 model, vision, and KV; no quantization |
+| Context / max sequence | 2048 / 2048 |
+| Preprocessing | 4 I/O workers, 2 processor workers |
+| Cache | Radix cache disabled; cache flushed before the measured case |
+| Traffic | 1,000 requests, request rate `inf`, 500 output tokens |
+
+**Serving Flags Used**
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache \
+python -u -m sgl_jax.launch_server \
+  --model-path Qwen/Qwen3-VL-32B-Instruct \
+  --trust-remote-code --skip-server-warmup \
+  --device tpu --tp-size 8 --dp-size 4 \
+  --dtype bfloat16 --kv-cache-dtype bf16 \
+  --context-length 2048 --max-seq-len 2048 \
+  --max-running-requests 1024 \
+  --max-prefill-tokens 16384 --chunked-prefill-size 4096 \
+  --mem-fraction-static 0.9 --page-size 128 \
+  --disable-radix-cache --vision-encoder-parallel dp \
+  --mm-io-worker-num 4 --mm-processor-worker-num 2 \
+  --random-seed 0 --host 0.0.0.0 --port 30000
+```
+
+**Benchmark Command**
+
+```bash
+python -m sgl_jax.bench_serving \
+  --backend sglang-oai-chat \
+  --host 127.0.0.1 --port 30000 \
+  --model Qwen/Qwen3-VL-32B-Instruct \
+  --tokenizer Qwen/Qwen3-VL-32B-Instruct \
+  --dataset-name image \
+  --num-prompts 1000 \
+  --random-input-len 1024 \
+  --random-output-len 500 \
+  --random-range-ratio 1.0 \
+  --image-count 1 \
+  --image-resolution 512x512 \
+  --image-format jpeg \
+  --image-content random \
+  --request-rate inf \
+  --seed 0 \
+  --warmup-requests 1 \
+  --flush-cache --output-details
+```
+
+**Test Results**
+
+| Metric | Result |
+|---|---:|
+| Successful requests | 1,000 |
+| Avg text input tokens / request | 1,086.25 |
+| Avg vision input tokens / request | 258.00 |
+| Avg total input tokens / request | 1,344.25 |
+| Output tokens / request | 500 |
+| Mean TTFT | 16,636.34 ms |
+| Median TTFT | 13,818.60 ms |
+| P99 TTFT | 54,075.23 ms |
+| Duration | 64.332 s |
+| Request throughput | 15.544 req/s |
+| Input token throughput | 20,895.61 tok/s |
+| Output token throughput | 7,772.22 tok/s |
+| Total token throughput | 28,667.82 tok/s |
+| Mean TPOT | 73.94 ms |
+| Median TPOT | 77.37 ms |
+| P99 TPOT | 100.26 ms |
+| Median E2E latency | 52,606.81 ms |
+| P99 E2E latency | 63,657.17 ms |
+
+This is a saturated burst workload, so TTFT includes scheduler queueing in addition to media processing, vision encoding, embedding merge, and language-model prefill.
+
+## Additional Resources
+
+- [Qwen3-VL-32B-Instruct model card](https://huggingface.co/Qwen/Qwen3-VL-32B-Instruct)
+- [Qwen3-VL official repository](https://github.com/QwenLM/Qwen3-VL)
+- [Qwen3 recipe](/autoregressive/Qwen/Qwen3) — text-only Qwen3 dense recipe.
+- [Qwen2.5-VL recipe](/autoregressive/Qwen/Qwen2.5-VL) — previous-generation vision-language serving recipe.
+- [Launch flags reference](/base/launch-flags-reference)
+- [Cross-recipe troubleshooting](/deployment/troubleshooting)

--- a/docs/cookbook/autoregressive/index.md
+++ b/docs/cookbook/autoregressive/index.md
@@ -71,6 +71,7 @@ End-to-end serving recipes for autoregressive models on SGL-JAX, organized by ve
 | ✅ | Qwen3-8B / Qwen3-32B | [`Qwen/Qwen3.md`](./Qwen/Qwen3.md) | v6e-4; 8B v7x-4 | dense + reasoning (`qwen3`) + tool (`qwen25`) |
 | ✅ | Qwen3-30B-A3B | [`Qwen/Qwen3-MoE.md`](./Qwen/Qwen3-MoE.md) | v6e-16 / v7x-4 | MoE + reasoning (`qwen3`) + tool (`qwen25`) |
 | ✅ | Qwen2.5-VL (3B / 7B / 32B / 72B) | [`Qwen/Qwen2.5-VL.md`](./Qwen/Qwen2.5-VL.md) | v6e-4 for 3B/7B/32B; 32B also validated on v7x-8; 72B pending | vision-language autoregressive decoder |
+| ✅ | Qwen3-VL-32B-Instruct | [`Qwen/Qwen3-VL.md`](./Qwen/Qwen3-VL.md) | v7x-8 | vision-language autoregressive decoder; DP4 × effective TP2 |
 | 📝 | Qwen2 / Qwen2-MoE | _no recipe — same family runtime path_ | — | dense / MoE |
 
 ### Xiaomi — `Xiaomi/`
@@ -89,7 +90,7 @@ A model that generates text one token at a time, conditioning on its own previou
 
 - **Dense LLMs** — Qwen / Qwen3 / Llama / Gemma 2 / MiMo-7B.
 - **MoE LLMs** — Qwen3-MoE / DeepSeek V2/V3/R1 / GLM-4.5 / Ling 2.6 / MiMo-V2-Flash / MiMo-V2.5-Pro / Kimi-Linear / Grok-2 (base).
-- **Vision-language decoders** — Qwen2.5-VL ingests image / video inputs, but the answer is still produced by an autoregressive generation stage.
+- **Vision-language decoders** — Qwen2.5-VL and Qwen3-VL ingest image / video inputs, but the answer is still produced by an autoregressive generation stage.
 
 Diffusion image/video generation models live in [Diffusion recipes](../diffusion/index.md).
 
@@ -100,7 +101,7 @@ Diffusion image/video generation models live in [Diffusion recipes](../diffusion
 | Single-host dense model | [`Qwen/Qwen.md`](./Qwen/Qwen.md) ✅ or [`Llama/Llama3.1.md`](./Llama/Llama3.1.md) ✅ |
 | Dense model with benchmark rows | [`Qwen/Qwen3.md`](./Qwen/Qwen3.md) ✅ |
 | Single-host MoE with backend choice | [`Xiaomi/MiMo-V2-Flash.md`](./Xiaomi/MiMo-V2-Flash.md) ✅ |
-| Vision-language chat | [`Qwen/Qwen2.5-VL.md`](./Qwen/Qwen2.5-VL.md) ✅ |
+| Vision-language chat | [`Qwen/Qwen3-VL.md`](./Qwen/Qwen3-VL.md) ✅ or [`Qwen/Qwen2.5-VL.md`](./Qwen/Qwen2.5-VL.md) ✅ |
 | Large multi-node MoE with GKE manifest | [`Xiaomi/MiMo-V2.5-Pro.md`](./Xiaomi/MiMo-V2.5-Pro.md) ✅ |
 | Multi-node dense | [`Llama/Llama3.3-70B.md`](./Llama/Llama3.3-70B.md) ✅ (+ [GKE Indexed Job launcher](../deployment/gke-indexed-job.md)) |
 | Base model (no chat template, `/v1/completions` flow) | [`Grok/Grok2.md`](./Grok/Grok2.md) ✅ |

--- a/docs/cookbook/base/tpu-topology-reference.md
+++ b/docs/cookbook/base/tpu-topology-reference.md
@@ -36,7 +36,7 @@ v6e (and every other generation) is 1:1 chip→device, so `--tp-size` matches ch
 | `v6e-16` (`4x4`) | 4 | 4 | 16 | [MiMo-V2-Flash](../autoregressive/Xiaomi/MiMo-V2-Flash.md) (multi-node) |
 | `v6e-32` | 8 | 4 | 32 | [Grok-2](../autoregressive/Grok/Grok2.md) |
 | `v6e-64` (`4x4x4`) | 16 | 4 | 64 | [MiMo-V2.5-Pro](../autoregressive/Xiaomi/MiMo-V2.5-Pro.md) |
-| `v7x-8` | 1 | 4 | 8 | [Qwen2.5-VL-32B](../autoregressive/Qwen/Qwen2.5-VL.md), [MiMo-V2-Flash](../autoregressive/Xiaomi/MiMo-V2-Flash.md) (single-node) |
+| `v7x-8` | 1 | 4 | 8 | [Qwen2.5-VL-32B](../autoregressive/Qwen/Qwen2.5-VL.md), [Qwen3-VL-32B](../autoregressive/Qwen/Qwen3-VL.md), [MiMo-V2-Flash](../autoregressive/Xiaomi/MiMo-V2-Flash.md) (single-node) |
 | `v7x-16` (`2x2x4`) | 4 | 4 | 32 | [MiMo-V2.5-Pro](../autoregressive/Xiaomi/MiMo-V2.5-Pro.md) |
 
 ## Choosing `--tp-size`

--- a/docs/cookbook/diffusion/index.md
+++ b/docs/cookbook/diffusion/index.md
@@ -31,7 +31,7 @@ End-to-end serving recipes for diffusion-style image and video generation models
 
 A diffusion recipe covers models where the expensive generation loop is denoising, not autoregressive token decoding. For Wan, SGL-JAX stages a text encoder, a DiT denoiser, and a VAE decoder; the endpoint returns an image or video artifact rather than chat tokens.
 
-Autoregressive text and vision-language decoders, including Qwen2.5-VL, live in [Autoregressive recipes](../autoregressive/index.md).
+Autoregressive text and vision-language decoders, including Qwen2.5-VL and Qwen3-VL, live in [Autoregressive recipes](../autoregressive/index.md).
 
 ## Built-in Staging Constraint
 

--- a/docs/cookbook/docs.json
+++ b/docs/cookbook/docs.json
@@ -39,7 +39,8 @@
                       "autoregressive/Qwen/Qwen",
                       "autoregressive/Qwen/Qwen3",
                       "autoregressive/Qwen/Qwen3-MoE",
-                      "autoregressive/Qwen/Qwen2.5-VL"
+                      "autoregressive/Qwen/Qwen2.5-VL",
+                      "autoregressive/Qwen/Qwen3-VL"
                     ]
                   },
                   {

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -12,7 +12,7 @@ End-to-end recipes for serving specific models on specific TPU (or GPU) topologi
 
 | Section | What's inside |
 |---|---|
-| [`autoregressive/`](./autoregressive/index.md) | Token-generating recipes organized by vendor subdir: text-only LLMs plus vision-language decoders such as Qwen2.5-VL. |
+| [`autoregressive/`](./autoregressive/index.md) | Token-generating recipes organized by vendor subdir: text-only LLMs plus vision-language decoders such as Qwen2.5-VL and Qwen3-VL. |
 | [`diffusion/`](./diffusion/index.md) | Diffusion-style media generation recipes such as Wan 2.1/2.2 T2V. |
 | [`base/basic-api-usage.md`](./base/basic-api-usage.md) | Shared request examples for running OpenAI-compatible and native API calls. |
 | [`base/tpu-topology-reference.md`](./base/tpu-topology-reference.md) | TPU generation, topology, device-count, and HBM reference. |
@@ -51,7 +51,7 @@ Status prefix: ✅ validated · 🧪 partially validated · 🚧 starter (not ye
 | TPU | Topology | Recipes |
 |---|---|---|
 | v6e-4 | 2x2 | ✅ [Qwen-7B-Chat](./autoregressive/Qwen/Qwen.md) · ✅ [Qwen3-8B / 32B](./autoregressive/Qwen/Qwen3.md) · ✅ [Qwen2.5-VL 3B / 7B candidates](./autoregressive/Qwen/Qwen2.5-VL.md) (`--tp-size 1`) · ✅ [Qwen2.5-VL 32B](./autoregressive/Qwen/Qwen2.5-VL.md) (`--tp-size 4`) · ✅ [Llama 3.1 8B-Instruct](./autoregressive/Llama/Llama3.1.md) · ✅ [Gemma 2 27B-it](./autoregressive/Google/Gemma2.md) · ✅ [MiMo-7B-RL](./autoregressive/Xiaomi/MiMo-7B.md) · ✅ [DeepSeek-V2-Lite](./autoregressive/DeepSeek/DeepSeek-V2.md) |
-| v7x-8 | single host (4 chips × 2 devices) | ✅ [Qwen2.5-VL-32B](./autoregressive/Qwen/Qwen2.5-VL.md) (`--tp-size 8 --dp-size 4`) · ✅ [MiMo-V2-Flash](./autoregressive/Xiaomi/MiMo-V2-Flash.md) |
+| v7x-8 | single host (4 chips × 2 devices) | ✅ [Qwen2.5-VL-32B](./autoregressive/Qwen/Qwen2.5-VL.md) (`--tp-size 8 --dp-size 4`) · ✅ [Qwen3-VL-32B](./autoregressive/Qwen/Qwen3-VL.md) (`--tp-size 8 --dp-size 4`) · ✅ [MiMo-V2-Flash](./autoregressive/Xiaomi/MiMo-V2-Flash.md) |
 
 ### Multi-host
 

--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -998,6 +998,7 @@ multimodal_model_archs = [
     "Qwen2AudioForConditionalGeneration",
     "Qwen2VLForConditionalGeneration",
     "Qwen2_5_VLForConditionalGeneration",
+    "Qwen3VLForConditionalGeneration",
     "KimiVLForConditionalGeneration",
     "InternVLChatModel",
     "Phi4MMForCausalLM",

--- a/python/sgl_jax/srt/model_executor/compilation_manager.py
+++ b/python/sgl_jax/srt/model_executor/compilation_manager.py
@@ -166,7 +166,7 @@ class CompilationManager:
 
         start_time = time.perf_counter()
         bs = self.max_padded_batch_size
-        multimodal_options = (False, True) if self.precompile_in_model_multimodal else (False,)
+        multimodal_options = (True,) if self.precompile_in_model_multimodal else (False,)
         logger.info(
             "[EXTEND] Begin to precompile bs_paddings=%s token_paddings=%s multimodal=%s",
             [bs],
@@ -201,14 +201,14 @@ class CompilationManager:
                         precompile_multimodal_inputs,
                     )
 
-                    input_embedding, deepstack = precompile_multimodal_inputs(
+                    input_embedding, deepstack, apply_for_deepstack = precompile_multimodal_inputs(
                         batch.forward_batch.input_ids,
                         model_runner.model,
                         model_runner.embedding_pool,
                     )
                     batch.forward_batch.input_embedding = input_embedding
                     batch.forward_batch.deepstack_visual_embedding = deepstack
-                    batch.forward_batch.apply_for_deepstack = deepstack is not None
+                    batch.forward_batch.apply_for_deepstack = apply_for_deepstack
                 if future_token_ids_map is not None:
                     from sgl_jax.srt.managers.utils import resolve_future_token_ids
 
@@ -218,13 +218,12 @@ class CompilationManager:
                 forward_fn(
                     batch,
                     launch_done=None,
-                    skip_sample=use_multimodal_input,
+                    skip_sample=False,
                     sampling_metadata=sampling_metadata,
                 )
+                self._compiled_variants.add((ForwardMode.EXTEND, num_tokens, bs_val, False))
                 if use_multimodal_input:
                     self._compiled_multimodal_extend_shapes.add((num_tokens, bs_val))
-                else:
-                    self._compiled_variants.add((ForwardMode.EXTEND, num_tokens, bs_val, False))
 
         end_time = time.perf_counter()
         logger.info("[EXTEND] Precompile finished in %.0f secs", end_time - start_time)

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -596,11 +596,12 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         self.model_config.hf_config.enable_sequence_parallel = (
             self.server_args.enable_sequence_parallel
         )
-        self.model_config.hf_config.vision_encoder_parallel = getattr(
-            self.server_args, "vision_encoder_parallel", "dp"
+        self.model_config.hf_config.vision_encoder_parallel = (
+            self.server_args.vision_encoder_parallel
         )
-        self.model_config.hf_config.precompile_vision_patch_paddings = getattr(
-            self.server_args, "precompile_vision_patch_paddings", None
+
+        self.model_config.hf_config.precompile_vision_patch_paddings = (
+            self.server_args.precompile_vision_patch_paddings
         )
 
         if self.server_args.ep_dispatch_algorithm:

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -39,7 +39,7 @@ from sgl_jax.srt.model_executor.aot_dispatch import (
     aot_dispatch_requested,
 )
 from sgl_jax.srt.model_executor.base_model_runner import BaseModelRunner
-from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sgl_jax.srt.model_executor.model_runner_kv_cache_mixin import (
     ModelRunnerKVCacheMixin,
     _build_non_hybrid_memory_pools,
@@ -48,6 +48,7 @@ from sgl_jax.srt.model_loader.loader import get_model_loader
 from sgl_jax.srt.models.registry import ModelRegistry
 from sgl_jax.srt.multimodal.in_model.embedding_pool import EmbeddingPool
 from sgl_jax.srt.multimodal.in_model.host_orchestration import embed_multimodal_inputs
+from sgl_jax.srt.multimodal.in_model.interface import InModelMultimodalContract
 from sgl_jax.srt.precision_tracer import precision_tracer
 from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
 from sgl_jax.srt.server_args import ServerArgs
@@ -929,8 +930,11 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         self.forward_pass_id += 1
         precision_tracer.start_batch_trace(forward_batch.bid)
         precision_tracer.set_current_forward_pass_id(self.forward_pass_id)
-        if forward_batch.multimodal_batch is not None:
-            input_embedding, deepstack = embed_multimodal_inputs(
+        if isinstance(self.model, InModelMultimodalContract) and forward_batch.forward_mode in (
+            ForwardMode.EXTEND,
+            ForwardMode.MIXED,
+        ):
+            input_embedding, deepstack, apply_for_deepstack = embed_multimodal_inputs(
                 multimodal_batch=forward_batch.multimodal_batch,
                 input_ids=forward_batch.input_ids,
                 multimodal_model=self.model,
@@ -938,7 +942,7 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
             )
             forward_batch.input_embedding = input_embedding
             forward_batch.deepstack_visual_embedding = deepstack
-            forward_batch.apply_for_deepstack = deepstack is not None
+            forward_batch.apply_for_deepstack = apply_for_deepstack
         with jax.profiler.TraceAnnotation("_forward_raw"):
             ret = self._forward_raw(forward_batch, logits_metadata)
         return ret

--- a/python/sgl_jax/srt/models/qwen3.py
+++ b/python/sgl_jax/srt/models/qwen3.py
@@ -9,7 +9,7 @@ from jax.sharding import PartitionSpec as P
 from transformers import PretrainedConfig
 
 from sgl_jax.srt.configs.model_config import ModelConfig
-from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead, RotaryEmbedding
+from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead, get_rope
 from sgl_jax.srt.layers.layernorm import RMSNorm
 from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
@@ -95,12 +95,13 @@ class QWen3Attention(nnx.Module):
             mesh=mesh,
             scope_name="o_proj",
         )
-        self.rotary_emb = RotaryEmbedding(
+        self.rotary_emb = get_rope(
             head_size=self.head_dim,
             rotary_dim=self.head_dim,
-            max_position_embeddings=max_position_embeddings,
+            max_position=max_position_embeddings,
             base=rope_theta,
             is_neox_style=True,
+            rope_scaling=rope_scaling,
             dtype=dtype,
         )
 
@@ -348,24 +349,39 @@ class QWen3Model(nnx.Module):
         self,
         forward_batch: ForwardBatch,
         token_to_kv_pool: KVCache,
+        positions: jax.Array | None = None,
     ):
         residual = None
-        hidden_states = self.embed_tokens(forward_batch.input_ids)
+        hidden_states = (
+            self.embed_tokens(forward_batch.input_ids)
+            if forward_batch.input_embedding is None
+            else forward_batch.input_embedding
+        )
         layers_kv_fused = []
         layers_callback_flag = []
         aux_hidden_states = []
+        positions = forward_batch.positions if positions is None else positions
+        # When connecting the vision head, even without deepstack, it should be padded with 0, which avoids doubling the EXTEND compilation.
+        deepstack = forward_batch.deepstack_visual_embedding
         for layer_id, layer in enumerate(self.layers):
             if layer_id in self.layers_to_capture:
                 aux_hidden_states.append(
                     hidden_states + residual if residual is not None else hidden_states
                 )
             hidden_states, residual, kv_fused, callback_flag = layer(
-                forward_batch.positions,
+                positions,
                 hidden_states,
                 forward_batch,
                 token_to_kv_pool,
                 residual,
             )
+            if deepstack is not None and layer_id < deepstack.shape[0]:
+                hidden_states = jax.lax.cond(
+                    forward_batch.apply_for_deepstack,
+                    lambda values: values[0] + values[1].astype(values[0].dtype),
+                    lambda values: values[0],
+                    (hidden_states, deepstack[layer_id]),
+                )
             layers_kv_fused.append(kv_fused)
             layers_callback_flag.extend(callback_flag)
 

--- a/python/sgl_jax/srt/models/qwen3_vl.py
+++ b/python/sgl_jax/srt/models/qwen3_vl.py
@@ -593,11 +593,7 @@ class Qwen3VLForConditionalGeneration(nnx.Module, InModelMultimodalContract):
                 mesh=mesh,
             )
         self.logits_processor = LogitsProcessor(self.text_config.vocab_size, mesh=mesh)
-        from sgl_jax.srt.managers.schedule_batch import global_server_args_dict
-
-        encoder_tp = resolve_encoder_tp(
-            mesh, global_server_args_dict.get("vision_encoder_parallel", "dp")
-        )
+        encoder_tp = resolve_encoder_tp(mesh, getattr(config, "vision_encoder_parallel", "dp"))
         self.visual = Qwen3VLVisionModel(
             config.vision_config,
             self.dtype,
@@ -606,7 +602,7 @@ class Qwen3VLForConditionalGeneration(nnx.Module, InModelMultimodalContract):
             encoder_tp,
             tuple(
                 resolve_vision_patch_buckets(
-                    global_server_args_dict.get("precompile_vision_patch_paddings")
+                    getattr(config, "precompile_vision_patch_paddings", None)
                 )
             ),
         )

--- a/python/sgl_jax/srt/models/qwen3_vl.py
+++ b/python/sgl_jax/srt/models/qwen3_vl.py
@@ -359,6 +359,7 @@ class Qwen3VLVisionModel(nnx.Module):
     ):
         rngs = rngs or nnx.Rngs(0)
         self.mesh = mesh
+        self.dtype = dtype
         self.vision_tp = tp
         self.specs = VisionShardSpecs(mesh, tp)
         self.input_buckets = input_buckets or tuple(resolve_vision_patch_buckets(None))
@@ -532,6 +533,7 @@ class Qwen3VLVisionModel(nnx.Module):
             patch_dim=self.patch_dim,
             merge_unit=self.spatial_merge_unit,
             rope_type="rope_3d",
+            dtype=self.dtype,
         )
 
     def _build_metadata(self, grid_thw: np.ndarray | jax.Array, capacity: int):

--- a/python/sgl_jax/srt/models/qwen3_vl.py
+++ b/python/sgl_jax/srt/models/qwen3_vl.py
@@ -1,0 +1,783 @@
+import logging
+from collections.abc import Callable
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+from jax.sharding import PartitionSpec
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.hf_transformers_utils import get_hf_text_config
+from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead
+from sgl_jax.srt.layers.linear import LinearBase
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
+from sgl_jax.srt.mem_cache.memory_pool import MemoryPools
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+from sgl_jax.srt.models.qwen3 import QWen3Model
+from sgl_jax.srt.multimodal.common.modality_enum import Modality, MultimodalDataItem
+from sgl_jax.srt.multimodal.in_model.interface import InModelMultimodalContract
+from sgl_jax.srt.multimodal.in_model.lane_packing import (
+    encoder_num_lanes,
+    precompile_mrope_vision_model,
+    run_mrope_vision_model,
+)
+from sgl_jax.srt.multimodal.layers.attention.flash_attention_backend import (
+    VisionAttentionMetadata,
+    make_vision_attention_backend,
+)
+from sgl_jax.srt.multimodal.layers.vision_sharding import (
+    VisionShardSpecs,
+    apply_data_sharding,
+    resolve_encoder_tp,
+)
+from sgl_jax.srt.utils.common_utils import resolve_vision_patch_buckets
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+
+logger = logging.getLogger(__name__)
+
+
+def create_qwen3_weight_mappings(
+    config,
+    source_prefix: str = "model",
+    target_prefix: str = "model",
+) -> dict:
+    mappings = {
+        f"{source_prefix}.embed_tokens.weight": WeightMapping(
+            target_path=f"{target_prefix}.embed_tokens.embedding",
+            sharding=("tensor", None),
+            transpose=False,
+        ),
+        f"{source_prefix}.norm.weight": WeightMapping(
+            target_path=f"{target_prefix}.norm.scale", sharding=(None,), transpose=False
+        ),
+    }
+    if not getattr(config, "tie_word_embeddings", False):
+        mappings["lm_head.weight"] = WeightMapping(
+            target_path="lm_head.embedding", sharding=("tensor", None), transpose=False
+        )
+    for layer_idx in range(config.num_hidden_layers):
+        mappings.update(
+            create_qwen3_layer_mappings(config, layer_idx, source_prefix, target_prefix)
+        )
+    return mappings
+
+
+def create_qwen3_layer_mappings(
+    config,
+    layer_idx: int,
+    source_prefix: str = "model",
+    target_prefix: str = "model",
+) -> dict:
+    source = f"{source_prefix}.layers.{layer_idx}"
+    target = f"{target_prefix}.layers.{layer_idx}"
+    mappings = {
+        f"{source}.input_layernorm.weight": WeightMapping(
+            target_path=f"{target}.input_layernorm.scale", sharding=(None,), transpose=False
+        ),
+        f"{source}.post_attention_layernorm.weight": WeightMapping(
+            target_path=f"{target}.post_attention_layernorm.scale",
+            sharding=(None,),
+            transpose=False,
+        ),
+        f"{source}.self_attn.q_proj.weight": WeightMapping(
+            target_path=f"{target}.self_attn.q_proj.weight",
+            sharding=(None, "tensor"),
+            transpose=True,
+            kv_head_padding=False,
+        ),
+        f"{source}.self_attn.k_proj.weight": WeightMapping(
+            target_path=f"{target}.self_attn.k_proj.weight",
+            sharding=(None, "tensor"),
+            transpose=True,
+            kv_head_padding=True,
+        ),
+        f"{source}.self_attn.v_proj.weight": WeightMapping(
+            target_path=f"{target}.self_attn.v_proj.weight",
+            sharding=(None, "tensor"),
+            transpose=True,
+            kv_head_padding=True,
+        ),
+        f"{source}.self_attn.o_proj.weight": WeightMapping(
+            target_path=f"{target}.self_attn.o_proj.weight",
+            sharding=("tensor", None),
+            transpose=True,
+            kv_head_padding=False,
+        ),
+        f"{source}.self_attn.q_norm.weight": WeightMapping(
+            target_path=f"{target}.self_attn.q_norm.scale", sharding=(None,), transpose=False
+        ),
+        f"{source}.self_attn.k_norm.weight": WeightMapping(
+            target_path=f"{target}.self_attn.k_norm.scale", sharding=(None,), transpose=False
+        ),
+        f"{source}.mlp.gate_proj.weight": WeightMapping(
+            target_path=f"{target}.mlp.gate_proj.weight",
+            sharding=(None, "tensor"),
+            transpose=True,
+        ),
+        f"{source}.mlp.up_proj.weight": WeightMapping(
+            target_path=f"{target}.mlp.up_proj.weight",
+            sharding=(None, "tensor"),
+            transpose=True,
+        ),
+        f"{source}.mlp.down_proj.weight": WeightMapping(
+            target_path=f"{target}.mlp.down_proj.weight",
+            sharding=("tensor", None),
+            transpose=True,
+        ),
+    }
+    if getattr(config, "attention_bias", False):
+        for name, padding in (("q_proj", False), ("k_proj", True), ("v_proj", True)):
+            mappings[f"{source}.self_attn.{name}.bias"] = WeightMapping(
+                target_path=f"{target}.self_attn.{name}.bias",
+                sharding=(None,),
+                transpose=False,
+                kv_head_padding=padding,
+            )
+        mappings[f"{source}.self_attn.o_proj.bias"] = WeightMapping(
+            target_path=f"{target}.self_attn.o_proj.bias",
+            sharding=(None,),
+            transpose=False,
+        )
+    return mappings
+
+
+def _merge_order(x: np.ndarray, t: int, h: int, w: int, merge: int) -> np.ndarray:
+    return (
+        np.broadcast_to(x, (t, *x.shape))
+        .reshape(t, h // merge, merge, w // merge, merge, *x.shape[2:])
+        .transpose(0, 1, 3, 2, 4, *range(5, x.ndim + 3))
+        .reshape(t * h * w, *x.shape[2:])
+    )
+
+
+def _rope(x: jax.Array, freqs: jax.Array) -> jax.Array:
+    half = x.shape[-1] // 2
+    left, right = x[..., :half], x[..., half:]
+    cos, sin = jnp.cos(freqs)[:, :, None], jnp.sin(freqs)[:, :, None]
+    return jnp.concatenate((left * cos - right * sin, left * sin + right * cos), axis=-1).astype(
+        x.dtype
+    )
+
+
+class Qwen3VLPatchEmbed(nnx.Module):
+    def __init__(self, config, dtype, rngs, mesh, tp):
+        self.channels = config.in_channels
+        self.temporal = config.temporal_patch_size
+        self.patch = config.patch_size
+        self.hidden = config.hidden_size
+        self.mesh = mesh
+        self.specs = VisionShardSpecs(mesh, tp)
+        self.proj = nnx.Conv(
+            self.channels,
+            self.hidden,
+            (self.temporal, self.patch, self.patch),
+            strides=(self.temporal, self.patch, self.patch),
+            use_bias=True,
+            dtype=dtype,
+            param_dtype=dtype,
+            rngs=rngs,
+        )
+
+    def __call__(self, x):
+        batch, length, _ = x.shape
+        sh = self.specs.sharding(self.specs.batch_axis)
+        x = x.reshape(
+            batch * length,
+            self.channels,
+            self.temporal,
+            self.patch,
+            self.patch,
+            out_sharding=sh,
+        )
+        x = jnp.transpose(x, (0, 2, 3, 4, 1))
+        x = self.proj(x, out_sharding=sh).reshape(batch, length, self.hidden, out_sharding=sh)
+        if self.mesh is not None:
+            x = apply_data_sharding(x, self.mesh, PartitionSpec(self.specs.batch_axis))
+        return x
+
+
+class Qwen3VLVisionMLP(nnx.Module):
+    def __init__(self, config, dtype, mesh, specs):
+        self.fc1 = LinearBase(
+            config.hidden_size,
+            config.intermediate_size,
+            mesh,
+            use_bias=True,
+            kernel_axes=specs.col_kernel_axes,
+            params_dtype=dtype,
+        )
+        self.fc2 = LinearBase(
+            config.intermediate_size,
+            config.hidden_size,
+            mesh,
+            use_bias=True,
+            kernel_axes=specs.row_kernel_axes,
+            params_dtype=dtype,
+        )
+        self.specs = specs
+        self.approximate = config.hidden_act == "gelu_pytorch_tanh"
+
+    def __call__(self, x):
+        specs = self.specs
+        x, _ = self.fc1(x, out_sharding=specs.sharding(specs.batch_axis, None, specs.tensor_axis))
+        x = jax.nn.gelu(x, approximate=self.approximate)
+        return self.fc2(x, out_sharding=specs.sharding(specs.batch_axis))[0]
+
+
+class Qwen3VLVisionAttention(nnx.Module):
+    def __init__(self, config, dtype, mesh, specs):
+        self.hidden = config.hidden_size
+        self.heads = config.num_heads
+        self.head_dim = self.hidden // self.heads
+        self.specs = specs
+        if specs.tp:
+            assert (
+                self.heads % int(mesh.shape["tensor"]) == 0
+            ), f"vision num_heads={self.heads} must be divisible by tp={mesh.shape['tensor']}"
+        linear = lambda: LinearBase(
+            self.hidden,
+            self.hidden,
+            mesh,
+            use_bias=True,
+            kernel_axes=specs.col_kernel_axes,
+            params_dtype=dtype,
+        )
+        self.q_proj, self.k_proj, self.v_proj = linear(), linear(), linear()
+        self.proj = LinearBase(
+            self.hidden,
+            self.hidden,
+            mesh,
+            use_bias=True,
+            kernel_axes=specs.row_kernel_axes,
+            params_dtype=dtype,
+        )
+        self.backend = make_vision_attention_backend(
+            mesh,
+            sm_scale=self.head_dim**-0.5,
+            causal=False,
+            head_tp=specs.tp,
+            # Qwen3-VL vision uses one block-diagonal full-frame layout for every
+            # layer, so route it through the packed varlen kernel.
+            use_varlen=True,
+        )
+
+    def __call__(self, x, freqs, metadata):
+        batch, length, _ = x.shape
+        specs = self.specs
+        col = specs.sharding(specs.batch_axis, None, specs.tensor_axis)
+        q, k, v = (
+            layer(x, out_sharding=col)[0]
+            for layer in (
+                self.q_proj,
+                self.k_proj,
+                self.v_proj,
+            )
+        )
+        sharding = specs.sharding(specs.batch_axis, None, specs.tensor_axis, None)
+        q, k, v = (
+            value.reshape(batch, length, self.heads, self.head_dim, out_sharding=sharding)
+            for value in (q, k, v)
+        )
+        output = self.backend(_rope(q, freqs), _rope(k, freqs), v, metadata)
+        output = output.reshape(batch, length, self.hidden, out_sharding=col)
+        return self.proj(output, out_sharding=specs.sharding(specs.batch_axis))[0]
+
+
+class Qwen3VLVisionBlock(nnx.Module):
+    def __init__(self, config, dtype, rngs, mesh, tp):
+        specs = VisionShardSpecs(mesh, tp)
+        norm = lambda: nnx.LayerNorm(
+            config.hidden_size,
+            epsilon=1e-6,
+            dtype=dtype,
+            param_dtype=dtype,
+            use_fast_variance=False,
+            rngs=rngs,
+        )
+        self.norm1, self.norm2 = norm(), norm()
+        self.attn = Qwen3VLVisionAttention(config, dtype, mesh, specs)
+        self.mlp = Qwen3VLVisionMLP(config, dtype, mesh, specs)
+
+    def __call__(self, x, freqs, metadata):
+        x = x + self.attn(self.norm1(x), freqs, metadata)
+        return x + self.mlp(self.norm2(x))
+
+
+class Qwen3VLPatchMerger(nnx.Module):
+    def __init__(self, config, dtype, rngs, mesh, tp, postshuffle):
+        self.hidden = config.hidden_size * config.spatial_merge_size**2
+        self.postshuffle = postshuffle
+        self.specs = VisionShardSpecs(mesh, tp)
+        self.norm = nnx.LayerNorm(
+            self.hidden if postshuffle else config.hidden_size,
+            epsilon=1e-6,
+            dtype=dtype,
+            param_dtype=dtype,
+            use_fast_variance=False,
+            rngs=rngs,
+        )
+        self.fc1 = LinearBase(
+            self.hidden,
+            self.hidden,
+            mesh,
+            use_bias=True,
+            kernel_axes=self.specs.col_kernel_axes,
+            params_dtype=dtype,
+        )
+        self.fc2 = LinearBase(
+            self.hidden,
+            config.out_hidden_size,
+            mesh,
+            use_bias=True,
+            kernel_axes=self.specs.row_kernel_axes,
+            params_dtype=dtype,
+        )
+
+    def __call__(self, x):
+        specs = self.specs
+        sharding = specs.sharding(specs.batch_axis)
+        if self.postshuffle:
+            x = self.norm(x.reshape(x.shape[0], -1, self.hidden, out_sharding=sharding))
+        else:
+            x = self.norm(x).reshape(x.shape[0], -1, self.hidden, out_sharding=sharding)
+        x, _ = self.fc1(x, out_sharding=specs.sharding(specs.batch_axis, None, specs.tensor_axis))
+        x = jax.nn.gelu(x, approximate=False)
+        return self.fc2(x, out_sharding=sharding)[0]
+
+
+class Qwen3VLVisionModel(nnx.Module):
+    def __init__(
+        self,
+        config,
+        dtype,
+        rngs=None,
+        mesh=None,
+        tp=False,
+        input_buckets: tuple[int, ...] | None = None,
+    ):
+        rngs = rngs or nnx.Rngs(0)
+        self.mesh = mesh
+        self.vision_tp = tp
+        self.specs = VisionShardSpecs(mesh, tp)
+        self.input_buckets = input_buckets or tuple(resolve_vision_patch_buckets(None))
+        self.merge = int(config.spatial_merge_size)
+        self.spatial_merge_unit = self.merge**2
+        if any(bucket <= 0 or bucket % self.spatial_merge_unit for bucket in self.input_buckets):
+            raise ValueError(
+                f"vision patch buckets must be positive multiples of {self.spatial_merge_unit}"
+            )
+        self.num_grid = int(config.num_position_embeddings**0.5)
+        self.rotary_dim = int(config.hidden_size) // int(config.num_heads) // 2
+        self.patch_embed = Qwen3VLPatchEmbed(config, dtype, rngs, mesh, tp)
+        self.pos_embed = Embed(
+            config.num_position_embeddings,
+            config.hidden_size,
+            dtype=dtype,
+            param_dtype=dtype,
+            kernel_axes=(None, None),
+            mesh=mesh,
+        )
+        self.blocks = nnx.List(
+            [Qwen3VLVisionBlock(config, dtype, rngs, mesh, tp) for _ in range(config.depth)]
+        )
+        self.deepstack_indexes = tuple(config.deepstack_visual_indexes)
+        self.deepstack_mergers = nnx.List(
+            [
+                Qwen3VLPatchMerger(config, dtype, rngs, mesh, tp, True)
+                for _ in self.deepstack_indexes
+            ]
+        )
+        self.merger = Qwen3VLPatchMerger(config, dtype, rngs, mesh, tp, False)
+        self.patch_dim = config.in_channels * config.temporal_patch_size * config.patch_size**2
+
+    def _lane_metadata(self, grids: list[tuple[int, int, int]], capacity: int):
+        """Build one lane's padded metadata once on the host."""
+        pos_indices = np.zeros((4, capacity), dtype=np.int32)
+        pos_weights = np.zeros((4, capacity), dtype=np.float32)
+        position_ids = np.zeros((capacity, 2), dtype=np.int32)
+        cu_seqlens = np.zeros(capacity // self.spatial_merge_unit + 1, dtype=np.int32)
+        patch_offset, boundary_offset = 0, 1
+        for t, h, w in grids:
+            end = patch_offset + t * h * w
+            ys = np.linspace(0, self.num_grid - 1, h, dtype=np.float32)
+            xs = np.linspace(0, self.num_grid - 1, w, dtype=np.float32)
+            y0, x0 = ys.astype(np.int32), xs.astype(np.int32)
+            y1, x1 = np.minimum(y0 + 1, self.num_grid - 1), np.minimum(x0 + 1, self.num_grid - 1)
+            dy, dx = ys - y0, xs - x0
+            indices = (
+                y0[:, None] * self.num_grid + x0[None],
+                y0[:, None] * self.num_grid + x1[None],
+                y1[:, None] * self.num_grid + x0[None],
+                y1[:, None] * self.num_grid + x1[None],
+            )
+            weights = (
+                (1 - dy[:, None]) * (1 - dx[None]),
+                (1 - dy[:, None]) * dx[None],
+                dy[:, None] * (1 - dx[None]),
+                dy[:, None] * dx[None],
+            )
+            pos_indices[:, patch_offset:end] = np.stack(
+                [_merge_order(x[..., None], t, h, w, self.merge)[:, 0] for x in indices]
+            )
+            pos_weights[:, patch_offset:end] = np.stack(
+                [_merge_order(x[..., None], t, h, w, self.merge)[:, 0] for x in weights]
+            )
+            rows, cols = np.indices((h, w))
+            coords = _merge_order(np.stack((rows, cols), axis=-1), t, h, w, self.merge)
+            position_ids[patch_offset:end] = coords
+            cu_seqlens[boundary_offset : boundary_offset + t] = patch_offset + np.arange(
+                1, t + 1, dtype=np.int32
+            ) * (h * w)
+            patch_offset, boundary_offset = end, boundary_offset + t
+        cu_seqlens[boundary_offset:] = patch_offset
+        return pos_indices, pos_weights, position_ids, cu_seqlens
+
+    def __call__(
+        self,
+        patches: jax.Array,
+        grid_thw: np.ndarray | jax.Array,
+    ) -> jax.Array:
+        return self.encode(patches, grid_thw)
+
+    def _forward(
+        self,
+        patches: jax.Array,
+        pos_indices: jax.Array,
+        pos_weights: jax.Array,
+        position_ids: jax.Array,
+        metadata: VisionAttentionMetadata,
+    ) -> tuple[jax.Array, jax.Array]:
+        inv_freq = 1.0 / (
+            10000.0 ** (jnp.arange(0, self.rotary_dim, 2, dtype=jnp.float32) / self.rotary_dim)
+        )
+        rotary_pos_emb = jnp.concatenate(
+            (
+                position_ids[..., :1].astype(jnp.float32) * inv_freq,
+                position_ids[..., 1:].astype(jnp.float32) * inv_freq,
+            ),
+            axis=-1,
+        )
+        x = self.patch_embed(patches)
+        pos = self.pos_embed.embedding.at[pos_indices].get(
+            out_sharding=self.specs.sharding(self.specs.batch_axis)
+        )
+        x += jnp.sum(pos * pos_weights[..., None].astype(pos.dtype), axis=1).astype(x.dtype)
+        # One block-diagonal (full-frame) layout, planned on the host and shared
+        # by every block.
+        deepstack = []
+        for index, block in enumerate(self.blocks):
+            x = block(x, rotary_pos_emb, metadata)
+            if index in self.deepstack_indexes:
+                merger = self.deepstack_mergers[self.deepstack_indexes.index(index)]
+                deepstack.append(merger(x))
+        merged = self.merger(x)
+        deepstack = (
+            jnp.stack(deepstack, axis=2)
+            if deepstack
+            else jnp.empty((x.shape[0], merged.shape[1], 0, merged.shape[2]), x.dtype)
+        )
+        return merged, deepstack
+
+    @jax.jit
+    def _encode_jit(
+        self,
+        patches: jax.Array,
+        pos_indices: jax.Array,
+        pos_weights: jax.Array,
+        position_ids: jax.Array,
+        metadata: VisionAttentionMetadata,
+    ) -> jax.Array:
+        output, deepstack = self._forward(
+            patches,
+            pos_indices,
+            pos_weights,
+            position_ids,
+            metadata,
+        )
+        if self.mesh is not None:
+            output = apply_data_sharding(output, self.mesh, PartitionSpec(self.specs.batch_axis))
+            deepstack = apply_data_sharding(
+                deepstack, self.mesh, PartitionSpec(self.specs.batch_axis)
+            )
+        # Concatenate deepstack planes onto the trailing feature axis so the merge
+        # gathers one [rows, cap, (1+D)*H] tensor. D is static at trace time.
+        deepstack_dim = deepstack.shape[2]
+        if deepstack_dim:
+            b, cap, h = output.shape
+            output = jnp.concatenate(
+                [output, deepstack.reshape(b, cap, deepstack_dim * h)], axis=-1
+            )
+        return output
+
+    def encode(self, patches: jax.Array, grid_thw: np.ndarray | jax.Array) -> jax.Array:
+        batch_sharding = self.specs.sharding(self.specs.batch_axis)
+        patches = jax.device_put(patches, batch_sharding)
+        metadata = jax.device_put(
+            self._build_metadata(grid_thw, patches.shape[1]),
+            batch_sharding,
+        )
+        if self.mesh is None:
+            return self._encode_jit(patches, *metadata)
+        with jax.set_mesh(self.mesh):
+            return self._encode_jit(patches, *metadata)
+
+    def precompile(self) -> None:
+        precompile_mrope_vision_model(
+            self,
+            mesh=self.mesh,
+            num_lanes=encoder_num_lanes(self.mesh, self.vision_tp),
+            buckets=self.input_buckets,
+            patch_dim=self.patch_dim,
+            merge_unit=self.spatial_merge_unit,
+            rope_type="rope_3d",
+        )
+
+    def _build_metadata(self, grid_thw: np.ndarray | jax.Array, capacity: int):
+        grid_thw = np.asarray(jax.device_get(grid_thw), dtype=np.int32)
+        if grid_thw.ndim == 2:
+            grid_thw = grid_thw[None]
+        lane_metadata = [
+            self._lane_metadata(
+                [tuple(map(int, grid)) for grid in lane if np.any(grid)],
+                capacity,
+            )
+            for lane in grid_thw
+        ]
+        pos_indices, pos_weights, position_ids, cu_seqlens = (
+            np.stack(values) for values in zip(*lane_metadata, strict=True)
+        )
+        metadata = VisionAttentionMetadata(
+            cu_seqlens,
+            max_seq_len=capacity,
+        )
+        return pos_indices, pos_weights, position_ids, metadata
+
+
+class Qwen3VLForConditionalGeneration(nnx.Module, InModelMultimodalContract):
+    mrope_position_axes = 3
+
+    def __init__(self, config=None, dtype=None, mesh=None, rngs=None):
+        self.mesh = mesh
+        self.config = config
+        self.text_config = get_hf_text_config(config) or config
+        self.dtype = dtype or jnp.bfloat16
+        rope = getattr(self.text_config, "rope_parameters", None)
+        if rope:
+            self.text_config.rope_theta = rope.get(
+                "rope_theta", getattr(self.text_config, "rope_theta", 5_000_000)
+            )
+            self.text_config.rope_scaling = {
+                "rope_type": rope.get("rope_type", "default"),
+                "mrope_section": rope.get("mrope_section", [24, 20, 20]),
+                "mrope_interleaved": True,
+            }
+        elif not getattr(self.text_config, "rope_scaling", None):
+            self.text_config.rope_scaling = {
+                "rope_type": "default",
+                "mrope_section": [24, 20, 20],
+                "mrope_interleaved": True,
+            }
+        self.is_mrope_enabled = "mrope_section" in (
+            getattr(self.text_config, "rope_scaling", None) or {}
+        )
+        self.model = QWen3Model(self.text_config, mesh=mesh, dtype=self.dtype)
+        if not getattr(self.text_config, "tie_word_embeddings", False):
+            self.lm_head = ParallelLMHead(
+                self.text_config.vocab_size,
+                self.text_config.hidden_size,
+                dtype=self.dtype,
+                param_dtype=self.dtype,
+                kernel_axes=("tensor", None),
+                mesh=mesh,
+            )
+        self.logits_processor = LogitsProcessor(self.text_config.vocab_size, mesh=mesh)
+        from sgl_jax.srt.managers.schedule_batch import global_server_args_dict
+
+        encoder_tp = resolve_encoder_tp(
+            mesh, global_server_args_dict.get("vision_encoder_parallel", "dp")
+        )
+        self.visual = Qwen3VLVisionModel(
+            config.vision_config,
+            self.dtype,
+            rngs,
+            mesh,
+            encoder_tp,
+            tuple(
+                resolve_vision_patch_buckets(
+                    global_server_args_dict.get("precompile_vision_patch_paddings")
+                )
+            ),
+        )
+        self.deepstack_visual_layers = len(self.visual.deepstack_indexes)
+
+    def get_input_embeddings(self) -> Callable[[jax.Array], jax.Array]:
+        return self.model.embed_tokens
+
+    def precompile_multimodal(self) -> None:
+        self.visual.precompile()
+
+    def get_multimodal_embedding_packed_capacities(self) -> tuple[int, ...]:
+        rows = encoder_num_lanes(self.mesh, self.visual.vision_tp)
+        unit = self.visual.spatial_merge_unit
+        return tuple(rows * bucket // unit for bucket in self.visual.input_buckets)
+
+    def get_image_feature(self, items: list[MultimodalDataItem]) -> jax.Array:
+        return self._get_visual_feature(items)
+
+    def get_video_feature(self, items: list[MultimodalDataItem]) -> jax.Array:
+        return self._get_visual_feature(items)
+
+    def _get_visual_feature(self, items: list[MultimodalDataItem]) -> jax.Array:
+        num_lanes = encoder_num_lanes(self.mesh, self.visual.vision_tp)
+        return run_mrope_vision_model(
+            self.visual,
+            items,
+            mesh=self.mesh,
+            num_lanes=num_lanes,
+            buckets=self.visual.input_buckets,
+            merge_unit=self.visual.spatial_merge_unit,
+            rope_type="rope_3d",
+        )
+
+    def get_multimodal_encode_funcs(self):
+        return {
+            Modality.IMAGE: self.get_image_feature,
+            Modality.MULTI_IMAGES: self.get_image_feature,
+            Modality.VIDEO: self.get_video_feature,
+        }
+
+    def load_weights(self, model_config: ModelConfig) -> None:
+        text_loader = WeightLoader(self, model_config, self.mesh, self.dtype)
+        text_loader.load_weights_from_safetensors(
+            create_qwen3_weight_mappings(
+                self.text_config, source_prefix="model.language_model", target_prefix="model"
+            )
+        )
+        config = self.config.vision_config
+        vision_config = SimpleNamespace(
+            model_path=model_config.model_path,
+            num_attention_heads=config.num_heads,
+            hidden_size=config.hidden_size,
+            get_total_num_kv_heads=lambda: config.num_heads,
+        )
+        WeightLoader(self, vision_config, self.mesh, self.dtype).load_weights_from_safetensors(
+            self._vision_weight_mappings()
+        )
+        logger.info("Qwen3-VL weights loaded successfully")
+
+    @classmethod
+    def create_vision_weight_mappings(cls, config, visual):
+        specs = visual.specs
+        col, row = specs.col_kernel_axes, specs.row_kernel_axes
+        mappings = {
+            "model.visual.patch_embed.proj.weight": WeightMapping(
+                "visual.patch_embed.proj.kernel",
+                (None, None, None, None, None),
+                transpose_axes=(2, 3, 4, 1, 0),
+            ),
+            "model.visual.patch_embed.proj.bias": WeightMapping(
+                "visual.patch_embed.proj.bias", (None,), transpose=False
+            ),
+            "model.visual.pos_embed.weight": WeightMapping(
+                "visual.pos_embed.embedding", (None, None), transpose=False
+            ),
+        }
+        for index in range(config.vision_config.depth):
+            source, target = f"model.visual.blocks.{index}", f"visual.blocks.{index}"
+            mappings.update(cls._block_mappings(source, target, col, row))
+        mappings.update(cls._merger_mappings("model.visual.merger", "visual.merger", col, row))
+        for index, _ in enumerate(visual.deepstack_indexes):
+            mappings.update(
+                cls._merger_mappings(
+                    f"model.visual.deepstack_merger_list.{index}",
+                    f"visual.deepstack_mergers.{index}",
+                    col,
+                    row,
+                )
+            )
+        return mappings
+
+    def _vision_weight_mappings(self):
+        return self.create_vision_weight_mappings(self.config, self.visual)
+
+    @staticmethod
+    def _linear(source, target, sharding):
+        return {
+            f"{source}.weight": WeightMapping(target + ".weight", sharding, transpose=True),
+            f"{source}.bias": WeightMapping(target + ".bias", (None,), transpose=False),
+        }
+
+    @classmethod
+    def _block_mappings(cls, source, target, col, row):
+        mappings = {}
+        for name in ("norm1", "norm2"):
+            mappings[f"{source}.{name}.weight"] = WeightMapping(
+                f"{target}.{name}.scale", (None,), transpose=False
+            )
+            mappings[f"{source}.{name}.bias"] = WeightMapping(
+                f"{target}.{name}.bias", (None,), transpose=False
+            )
+        mappings[f"{source}.attn.qkv.weight"] = WeightMapping(
+            [f"{target}.attn.{name}_proj.weight" for name in "qkv"], col, transpose=True
+        )
+        mappings[f"{source}.attn.qkv.bias"] = WeightMapping(
+            [f"{target}.attn.{name}_proj.bias" for name in "qkv"], (None,), transpose=False
+        )
+        mappings.update(cls._linear(f"{source}.attn.proj", f"{target}.attn.proj", row))
+        mappings.update(cls._linear(f"{source}.mlp.linear_fc1", f"{target}.mlp.fc1", col))
+        mappings.update(cls._linear(f"{source}.mlp.linear_fc2", f"{target}.mlp.fc2", row))
+        return mappings
+
+    @classmethod
+    def _merger_mappings(cls, source, target, col, row):
+        mappings = {
+            f"{source}.norm.weight": WeightMapping(
+                f"{target}.norm.scale", (None,), transpose=False
+            ),
+            f"{source}.norm.bias": WeightMapping(f"{target}.norm.bias", (None,), transpose=False),
+        }
+        mappings.update(cls._linear(f"{source}.linear_fc1", f"{target}.fc1", col))
+        mappings.update(cls._linear(f"{source}.linear_fc2", f"{target}.fc2", row))
+        return mappings
+
+    def get_embed_and_head(self):
+        embed = self.model.embed_tokens.embedding.value
+        return (
+            (embed, embed)
+            if getattr(self.text_config, "tie_word_embeddings", False)
+            else (
+                embed,
+                self.lm_head.embedding.value,
+            )
+        )
+
+    def set_embed_and_head(self, embed_weight=None, head_weight=None):
+        if embed_weight is not None:
+            self.model.embed_tokens.embedding.value = embed_weight
+        if head_weight is not None and not getattr(self.text_config, "tie_word_embeddings", False):
+            self.lm_head.embedding.value = head_weight
+
+    def __call__(
+        self,
+        forward_batch: ForwardBatch,
+        memory_pools: MemoryPools,
+        logits_metadata: LogitsMetadata,
+    ):
+        positions = (
+            forward_batch.mrope_positions if self.is_mrope_enabled else forward_batch.positions
+        )
+        hidden, aux, kv, callbacks = self.model(
+            forward_batch, memory_pools.token_to_kv_pool, positions=positions
+        )
+        head = (
+            self.model.embed_tokens
+            if getattr(self.text_config, "tie_word_embeddings", False)
+            else self.lm_head
+        )
+        output = self.logits_processor(hidden, head, logits_metadata, aux_hidden_states=aux)
+        return output, {"token_to_kv_pool": kv}, callbacks, None
+
+
+EntryClass = Qwen3VLForConditionalGeneration

--- a/python/sgl_jax/srt/multimodal/in_model/host_orchestration.py
+++ b/python/sgl_jax/srt/multimodal/in_model/host_orchestration.py
@@ -276,7 +276,7 @@ def precompile_multimodal_inputs(
     input_ids: jax.Array,
     multimodal_model: InModelMultimodalContract,
     embedding_pool: EmbeddingPool | None = None,
-) -> tuple[jax.Array, jax.Array | None]:
+) -> tuple[jax.Array, jax.Array | None, bool]:
     """Warm merge kernels and return a multimodal-shaped forward input."""
     capacities = tuple(map(int, multimodal_model.get_multimodal_embedding_packed_capacities()))
     if any(capacity <= 0 for capacity in capacities):
@@ -307,7 +307,8 @@ def precompile_multimodal_inputs(
             running = _gather_from_pool(running, embedding_pool, (task,), (entry,), mesh)
             jax.block_until_ready(running)
 
-    return _split_embeddings(running, hidden, deepstack_dim, mesh)
+    input_embedding, deepstack = _split_embeddings(running, hidden, deepstack_dim, mesh)
+    return input_embedding, deepstack, deepstack_dim > 0
 
 
 def precompile_multimodal_components(
@@ -321,22 +322,32 @@ def precompile_multimodal_components(
 
 
 def embed_multimodal_inputs(
-    multimodal_batch: _MultimodalBatch,
+    multimodal_batch: _MultimodalBatch | None,
     input_ids: jax.Array,
     multimodal_model: InModelMultimodalContract,
     embedding_pool: EmbeddingPool | None = None,
-) -> tuple[jax.Array, jax.Array | None]:
+) -> tuple[jax.Array, jax.Array | None, bool]:
     """Merge padded, item-ordered encoder outputs into the token stream."""
     mesh = multimodal_model.mesh
     with jax.set_mesh(mesh) if mesh is not None else nullcontext():
         running = multimodal_model.get_input_embeddings()(input_ids)
         hidden = running.shape[-1]
         deepstack_dim = multimodal_model.deepstack_visual_layers
+        if deepstack_dim and multimodal_batch is None:
+            deepstack = jnp.zeros(
+                (deepstack_dim, running.shape[0], hidden),
+                dtype=running.dtype,
+                out_sharding=NamedSharding(
+                    mesh,
+                    PartitionSpec(None, "data", None),
+                ),
+            )
+            return running, deepstack, False
         if deepstack_dim:
             running = jnp.pad(running, ((0, 0), (0, hidden * deepstack_dim)))
 
         encode_funcs = multimodal_model.get_multimodal_encode_funcs()
-        for modality, tasks in multimodal_batch.items():
+        for modality, tasks in (multimodal_batch or {}).items():
             encode_func = encode_funcs.get(modality)
             if encode_func is None:
                 raise ValueError(
@@ -373,4 +384,6 @@ def embed_multimodal_inputs(
                 running = _gather_merge(running, packed, tuple(miss_tasks), mesh)
                 _write_misses_to_pool(embedding_pool, packed, miss_tasks)
 
-        return _split_embeddings(running, hidden, deepstack_dim, mesh)
+        input_embedding, deepstack = _split_embeddings(running, hidden, deepstack_dim, mesh)
+        apply_for_deepstack = deepstack_dim > 0 and multimodal_batch is not None
+        return input_embedding, deepstack, apply_for_deepstack

--- a/python/sgl_jax/srt/multimodal/in_model/lane_packing.py
+++ b/python/sgl_jax/srt/multimodal/in_model/lane_packing.py
@@ -277,7 +277,7 @@ def run_mrope_vision_model(
     buckets: tuple[int, ...],
     merge_unit: int,
     rope_type: Literal["rope_3d", "rope_2d", "rope_2d_packed"],
-    dtype: np.dtype | type,
+    dtype: np.dtype | type = jnp.bfloat16,
 ) -> jax.Array:
     """Pack, run, and restore a sharded vision model with RoPE metadata."""
     if rope_type == "rope_2d_packed":
@@ -314,7 +314,7 @@ def precompile_mrope_vision_model(
     patch_dim: int,
     merge_unit: int,
     rope_type: Literal["rope_3d", "rope_2d", "rope_2d_packed"],
-    dtype: np.dtype | type,
+    dtype: np.dtype | type = jnp.bfloat16,
 ) -> None:
     merge_size = math.isqrt(merge_unit)
     for capacity in buckets:

--- a/python/sgl_jax/test/test_compilation_manager.py
+++ b/python/sgl_jax/test/test_compilation_manager.py
@@ -443,7 +443,7 @@ class TestDummyBatch(unittest.TestCase):
         batch = cm._make_dummy_batch(32, 128, ForwardMode.EXTEND, 512)
         assert batch.capture_hidden_mode == CaptureHiddenMode.FULL
 
-    def test_precompile_extend_warms_text_and_multimodal_signatures(self):
+    def test_precompile_extend_uses_one_unified_multimodal_signature(self):
         cm = CompilationManager(
             server_args=_make_server_args(
                 precompile_token_paddings=[4],
@@ -486,7 +486,7 @@ class TestDummyBatch(unittest.TestCase):
             patch.object(
                 host_orchestration,
                 "precompile_multimodal_inputs",
-                return_value=(input_embedding, deepstack),
+                return_value=(input_embedding, deepstack, True),
             ) as precompile_multimodal_inputs,
             patch.object(
                 SamplingMetadata,
@@ -502,10 +502,7 @@ class TestDummyBatch(unittest.TestCase):
                 future_token_ids_map=None,
             )
 
-        assert calls == [
-            (None, None, False, False),
-            (input_embedding, deepstack, True, True),
-        ]
+        assert calls == [(input_embedding, deepstack, True, False)]
         assert cm._compiled_variants == {(ForwardMode.EXTEND, 4, 2, False)}
         assert cm._compiled_multimodal_extend_shapes == {(4, 2)}
         precompile_multimodal_inputs.assert_called_once_with(

--- a/test/srt/multimodal/test_in_model_multimodal.py
+++ b/test/srt/multimodal/test_in_model_multimodal.py
@@ -288,7 +288,7 @@ def test_qwen2_vision_encode_and_merge_spmd(encoder_tp):
         jnp.zeros(8, dtype=jnp.int32),
         Model(running),
     )
-    output, _ = host_orchestration.embed_multimodal_inputs(*args)
+    output, _, _ = host_orchestration.embed_multimodal_inputs(*args)
     assert output.sharding.spec == PartitionSpec("data", None)
     assert calls == 1
 
@@ -366,12 +366,14 @@ def test_merge_preserves_unmasked_tokens():
             return {Modality.AUDIO: lambda _: jnp.array([[10.0, 11.0], [20.0, 21.0]])}
 
     running = jnp.array([[1, 2], [3, 4], [5, 6]], dtype=jnp.float32)
-    output, _ = host_orchestration.embed_multimodal_inputs(
+    output, deepstack, apply_for_deepstack = host_orchestration.embed_multimodal_inputs(
         batch,
         jnp.zeros(3, dtype=jnp.int32),
         Model(running),
     )
     np.testing.assert_array_equal(output, [[10, 11], [3, 4], [20, 21]])
+    assert deepstack is None
+    assert apply_for_deepstack is False
 
 
 def test_packed_gather_merge_preserves_data_sharding():
@@ -407,13 +409,20 @@ def test_packed_gather_merge_preserves_data_sharding():
 
     Model.mesh = mesh
     running = jax.device_put(jnp.zeros((4, 1)), NamedSharding(mesh, PartitionSpec("data", None)))
-    out, ds = host_orchestration.embed_multimodal_inputs(
+    out, ds, apply_for_deepstack = host_orchestration.embed_multimodal_inputs(
         batch, jnp.zeros(4, dtype=jnp.int32), Model(running)
     )
     np.testing.assert_array_equal(out[:, 0], [10, 11, 20, 21])
     np.testing.assert_array_equal(ds[0, :, 0], [30, 31, 40, 41])
     assert out.sharding.spec == PartitionSpec("data", None)
     assert ds.sharding.spec == PartitionSpec(None, "data", None)
+    assert apply_for_deepstack is True
+
+    _, text_ds, text_apply_for_deepstack = host_orchestration.embed_multimodal_inputs(
+        None, jnp.zeros(4, dtype=jnp.int32), Model(running)
+    )
+    np.testing.assert_array_equal(text_ds, 0)
+    assert text_apply_for_deepstack is False
 
 
 def test_precompile_multimodal_inputs_matches_runtime_layout():
@@ -434,7 +443,7 @@ def test_precompile_multimodal_inputs_matches_runtime_layout():
         "_gather_merge",
         wraps=host_orchestration._gather_merge,
     ) as merge:
-        output, deepstack = host_orchestration.precompile_multimodal_inputs(
+        output, deepstack, apply_for_deepstack = host_orchestration.precompile_multimodal_inputs(
             jax.device_put(jnp.arange(4), data),
             Model(),
         )
@@ -444,6 +453,7 @@ def test_precompile_multimodal_inputs_matches_runtime_layout():
     np.testing.assert_array_equal(deepstack, 0)
     assert output.dtype == jnp.float32
     assert deepstack.dtype == jnp.float32
+    assert apply_for_deepstack is True
     assert output.sharding.spec == PartitionSpec("data", None)
     assert deepstack.sharding.spec == PartitionSpec(None, "data", None)
 
@@ -467,13 +477,13 @@ def test_embedding_pool_reuses_full_item_across_chunks():
 
     pool = EmbeddingPool(num_pages=4, page_size=2, hidden=1, dtype=jnp.float32)
     model = Model(jnp.zeros((2, 1), dtype=jnp.float32))
-    first, _ = host_orchestration.embed_multimodal_inputs(
+    first, _, _ = host_orchestration.embed_multimodal_inputs(
         _batch([item], prefix=0, extend=2, per_dp_token=2),
         jnp.zeros(2, dtype=jnp.int32),
         model,
         pool,
     )
-    second, _ = host_orchestration.embed_multimodal_inputs(
+    second, _, _ = host_orchestration.embed_multimodal_inputs(
         _batch([item], prefix=2, extend=2, per_dp_token=2),
         jnp.zeros(2, dtype=jnp.int32),
         model,
@@ -511,10 +521,11 @@ def test_model_runner_forward_embeds_multimodal_inputs():
 
     input_ids = jnp.asarray([1], dtype=jnp.int32)
     multimodal_batch = {Modality.IMAGE: ()}
-    model = object()
+    model = _TestInModelModel()
     embedding_pool = object()
     forward_batch = SimpleNamespace(
         bid=1,
+        forward_mode=ForwardMode.EXTEND,
         input_ids=input_ids,
         multimodal_batch=multimodal_batch,
         input_embedding=None,
@@ -533,7 +544,7 @@ def test_model_runner_forward_embeds_multimodal_inputs():
         patch(
             "sgl_jax.srt.model_executor.model_runner.embed_multimodal_inputs",
             autospec=True,
-            return_value=("embedded", "deepstack"),
+            return_value=("embedded", "deepstack", True),
         ) as embed,
         patch("sgl_jax.srt.model_executor.model_runner.precision_tracer.start_batch_trace"),
         patch(


### PR DESCRIPTION
## Motivation

This PR adds end-to-end serving support for `Qwen/Qwen3-VL-32B-Instruct` and documents the validated deployment path.

The existing Qwen3 implementation supports text-only inference, but it does not provide the Qwen3-VL vision encoder, multimodal position handling, visual embedding merge, or deepstack integration required to serve Qwen3-VL checkpoints. This change adds those model components and connects them to the existing in-model multimodal runtime while preserving the text-only Qwen3 path.

Additionally, this PR adds a Qwen3-VL cookbook covering deployment, OpenAI-compatible text/image/video invocation, MMMU and MMMU-Pro Vision accuracy, and a single-image multimodal serving benchmark.

## Modifications

### Qwen3-VL model support

- Register `Qwen3VLForConditionalGeneration` in the model registry.
- Add the Qwen3-VL vision encoder, patch embedding, rotary position embedding, transformer blocks, merger, and multimodal projector.
- Reuse the Qwen3 language-model implementation for Qwen3-VL while adding multimodal RoPE, visual embedding injection, and deepstack feature support.
- Preserve the existing text-only Qwen3 execution path.

### Multimodal runtime integration

- Extend compilation management to precompile the required multimodal execution shapes and vision patch buckets.
- Unify text and multimodal EXTEND signatures for in-model VLMs, reducing model-forward EXTEND precompile variants from two to one per token bucket.
- Update model-runner and host-orchestration paths to carry and apply Qwen3-VL deepstack embeddings.
- Keep text-only and multimodal execution stable through the shared in-model multimodal path.
- Set BF16 as the default dtype for the shared multimodal lane-packing helper.
- Add regression coverage for multimodal compilation and in-model multimodal serving.

### Documentation

- Add the Qwen3-VL cookbook and register it in the cookbook navigation.
- Document the validated TPU topology, launch flags, multimodal worker configuration, invocation examples, accuracy results, and single-image multimodal performance results.

## Accuracy Tests

| Item | Value |
| --- | --- |
| Model | `Qwen/Qwen3-VL-32B-Instruct` |
| Hardware | Single-host TPU v7x-8, topology `2x2x1` |
| Parallelism | DP4 x effective TP2 (`--tp-size 8 --dp-size 4`) |
| Precision | BF16 model, vision encoder, and KV cache |
| Context / max sequence | 32768 / 32768 |
| Evaluator | EvalScope 1.5.1, OpenAI-compatible API |
| Generation | `max_tokens=8192`, temperature 0, seed 42 |
| Evaluation batch size | 24 for MMMU; 256 for MMMU-Pro Vision |

### Server command

```bash
export MODEL_PATH=Qwen/Qwen3-VL-32B-Instruct
export JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache

python -u -m sgl_jax.launch_server \
  --model-path "$MODEL_PATH" \
  --trust-remote-code \
  --skip-server-warmup \
  --device tpu \
  --tp-size 8 \
  --dp-size 4 \
  --dtype bfloat16 \
  --kv-cache-dtype bf16 \
  --context-length 32768 \
  --max-seq-len 32768 \
  --max-running-requests 1024 \
  --max-prefill-tokens 16384 \
  --chunked-prefill-size 4096 \
  --mem-fraction-static 0.8 \
  --page-size 128 \
  --disable-radix-cache \
  --vision-encoder-parallel dp \
  --mm-io-worker-num 4 \
  --mm-processor-worker-num 2 \
  --random-seed 0 \
  --host 0.0.0.0 \
  --port 30000
```

### Evaluation command

Install the evaluator and save the following script as `eval_accuracy.py`:

```bash
pip install 'evalscope[app,perf]==1.5.1'
```

```python
import os

from evalscope import TaskConfig, run_task

dataset_args = {
    "mmmu": {"dataset_id": "MMMU/MMMU"},
    "mmmu_pro": {
        "dataset_id": "MMMU/MMMU_Pro",
        "extra_params": {"dataset_format": "vision"},
    },
}

for dataset, batch_size in (("mmmu", 24), ("mmmu_pro", 256)):
    task_cfg = TaskConfig(
        model="Qwen/Qwen3-VL-32B-Instruct",
        api_url="http://127.0.0.1:30000/v1",
        api_key="EMPTY",
        eval_type="openai_api",
        datasets=[dataset],
        dataset_hub="huggingface",
        dataset_args={dataset: dataset_args[dataset]},
        eval_batch_size=batch_size,
        generation_config={
            "max_tokens": 8192,
            "temperature": 0.0,
            "stream": False,
        },
        seed=42,
        work_dir=os.path.join("./outputs/qwen3vl32b_vlm", dataset),
    )
    run_task(task_cfg=task_cfg)
```

```bash
python eval_accuracy.py
```

### Results

| Dataset | Metric | Result | Samples |
| --- | --- | ---: | ---: |
| MMMU Val | Mean accuracy | **72.22%** | 900 |
| MMMU-Pro Vision | Mean accuracy | **62.43%** | 1,730 |

## Benchmarking and Profiling

### Precompile reduction

In-model VLMs previously compiled separate text and multimodal model-forward EXTEND variants for every token bucket. Text requests now use the same multimodal-shaped input signature, with zero-filled deepstack tensors and a runtime `apply_for_deepstack` flag when no visual input is present.

This reduces model-forward EXTEND precompile invocations from two to one per token bucket, a **50% reduction**. Vision encoder and embedding-merge bucket precompilation are unchanged, so this is not a claim that total server startup time is reduced by 50%.

### Setup

Both runs use `Qwen/Qwen3-VL-32B-Instruct` on a single TPU v7x-8 (`2x2x1`), DP4 x effective TP2, BF16 model/vision/KV, no quantization, 1,000 requests at an unbounded request rate, one warmup request, a cache flush, 1,024 random source-text tokens, and 500 output tokens per request.

The text run uses a 32,768-token context. The multimodal run uses a 2,048-token context and additionally sends one random 512 x 512 JPEG per request with 4 I/O workers and 2 processor workers. After chat templating and image processing, each multimodal request averages 1,086.25 text tokens and 258 vision tokens, or 1,344.25 total input tokens.

These are two independently measured serving workloads, not an equal-input A/B comparison.

### Text server command

The text benchmark reuses the 32K server command from the accuracy section.

### Text benchmark command

```bash
python -m sgl_jax.bench_serving \
  --backend sglang-oai-chat \
  --host 127.0.0.1 --port 30000 \
  --model "$MODEL_PATH" --tokenizer "$MODEL_PATH" \
  --dataset-name random \
  --num-prompts 1000 \
  --random-input-len 1024 \
  --random-output-len 500 \
  --random-range-ratio 1.0 \
  --request-rate inf \
  --seed 0 \
  --warmup-requests 1 \
  --flush-cache --output-details
```

### Multimodal server command

```bash
export MODEL_PATH=Qwen/Qwen3-VL-32B-Instruct
export JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache

python -u -m sgl_jax.launch_server \
  --model-path "$MODEL_PATH" \
  --trust-remote-code \
  --skip-server-warmup \
  --device tpu \
  --tp-size 8 \
  --dp-size 4 \
  --dtype bfloat16 \
  --kv-cache-dtype bf16 \
  --context-length 2048 \
  --max-seq-len 2048 \
  --max-running-requests 1024 \
  --max-prefill-tokens 16384 \
  --chunked-prefill-size 4096 \
  --mem-fraction-static 0.9 \
  --page-size 128 \
  --disable-radix-cache \
  --vision-encoder-parallel dp \
  --mm-io-worker-num 4 \
  --mm-processor-worker-num 2 \
  --random-seed 0 \
  --host 0.0.0.0 \
  --port 30000
```

### Multimodal benchmark command

```bash
python -m sgl_jax.bench_serving \
  --backend sglang-oai-chat \
  --host 127.0.0.1 --port 30000 \
  --model "$MODEL_PATH" --tokenizer "$MODEL_PATH" \
  --dataset-name image \
  --num-prompts 1000 \
  --random-input-len 1024 \
  --random-output-len 500 \
  --random-range-ratio 1.0 \
  --image-count 1 \
  --image-resolution 512x512 \
  --image-format jpeg \
  --image-content random \
  --request-rate inf \
  --seed 0 \
  --warmup-requests 1 \
  --flush-cache --output-details
```

### Results

| Metric | Text | Single-image multimodal |
| --- | ---: | ---: |
| Successful requests | 1,000 | 1,000 |
| Duration | 58.720 s | 64.332 s |
| Request throughput | 17.030 req/s | 15.544 req/s |
| Input token throughput | 17,438.83 tok/s | 20,895.61 tok/s |
| Output token throughput | **8,515.05 tok/s** | **7,772.22 tok/s** |
| Total token throughput | 25,953.88 tok/s | 28,667.82 tok/s |
| Mean TTFT | 14,085.46 ms | 16,636.34 ms |
| Median TTFT | 9,925.04 ms | 13,818.60 ms |
| P99 TTFT | 47,376.80 ms | 54,075.23 ms |
| Mean TPOT | 65.75 ms | 73.94 ms |
| Median TPOT | 70.23 ms | 77.37 ms |
| P99 TPOT | 84.61 ms | 100.26 ms |
| Median E2E latency | 44,980.55 ms | 52,606.81 ms |
| P99 E2E latency | 58,337.06 ms | 63,657.17 ms |

## Test Plan

Targeted regression tests:

TPU serving validation:

- [x] 1,000-request text benchmark.
- [x] 1,000-request single-image multimodal benchmark.
- [x] MMMU Val evaluation with all 900 samples completed.
- [x] MMMU-Pro Vision evaluation with all 1,730 samples completed.
- [x] Unified text/multimodal EXTEND precompile signature regression coverage.
- [x] Cookbook JSON, internal links, Markdown code fences, and formatting checks.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
