### PR TITLE
perf(rpa-v3): store the speculative tree mask with kv on the lane axis

### DIFF
--- a/benchmark/kernels/flash_attention/tune_target_verify_v3.py
+++ b/benchmark/kernels/flash_attention/tune_target_verify_v3.py
@@ -22,14 +22,13 @@ from pathlib import Path
 import jax
 import jax.numpy as jnp
 import numpy as np
-from utils import create_target_verify_uniform_data, create_tree_mask
+from utils import create_target_verify_uniform_data, create_tree_mask_rank3
 
 from sgl_jax.srt.kernels.ragged_paged_attention.ragged_paged_attention_v3 import (
     get_vmem_estimate_bytes,
     get_vmem_limit,
     ragged_paged_attention,
 )
-from sgl_jax.srt.kernels.ragged_paged_attention.util import cdiv
 from sgl_jax.srt.kernels.utils.perf import multiple_iteration_timeit_from_trace
 from sgl_jax.srt.utils.jax_utils import get_device_name
 
@@ -126,7 +125,6 @@ def _benchmark_one(
             distribution,
             custom_mask=custom_mask,
             causal=0 if use_mask else 1,
-            mask_aligned_to_cu_kv=use_mask,
             sm_scale=sm_scale,
             sliding_window=sliding_window,
             chunk_prefill_size=None,
@@ -248,13 +246,11 @@ def main():
     )
     inputs["distribution"] = values[-1]
     inputs["page_size"] = args.page_size
-    _kv_len = args.prefix_len + args.draft_token_num
     inputs["custom_mask"] = (
-        create_tree_mask(
+        create_tree_mask_rank3(
             batch_size=args.batch_size,
             draft_token_num=args.draft_token_num,
-            kv_len=_kv_len,
-            aligned_kv_len=cdiv(_kv_len, args.page_size) * args.page_size,
+            kv_len=args.prefix_len + args.draft_token_num,
         )
         if args.custom_mask
         else None

--- a/benchmark/kernels/flash_attention/tune_target_verify_v3.py
+++ b/benchmark/kernels/flash_attention/tune_target_verify_v3.py
@@ -22,13 +22,14 @@ from pathlib import Path
 import jax
 import jax.numpy as jnp
 import numpy as np
-from utils import create_target_verify_uniform_data
+from utils import create_target_verify_uniform_data, create_tree_mask
 
 from sgl_jax.srt.kernels.ragged_paged_attention.ragged_paged_attention_v3 import (
     get_vmem_estimate_bytes,
     get_vmem_limit,
     ragged_paged_attention,
 )
+from sgl_jax.srt.kernels.ragged_paged_attention.util import cdiv
 from sgl_jax.srt.kernels.utils.perf import multiple_iteration_timeit_from_trace
 from sgl_jax.srt.utils.jax_utils import get_device_name
 
@@ -93,6 +94,8 @@ def _benchmark_one(
     tries: int,
     sliding_window: int | None,
 ) -> float:
+    use_mask = inputs.get("custom_mask") is not None
+
     @functools.partial(
         jax.jit,
         static_argnames=("sm_scale", "m_block_sizes"),
@@ -107,6 +110,7 @@ def _benchmark_one(
         cu_q_lens,
         cu_kv_lens,
         distribution,
+        custom_mask,
         sm_scale,
         m_block_sizes,
     ):
@@ -120,8 +124,9 @@ def _benchmark_one(
             cu_q_lens,
             cu_kv_lens,
             distribution,
-            custom_mask=None,
-            causal=1,
+            custom_mask=custom_mask,
+            causal=0 if use_mask else 1,
+            mask_aligned_to_cu_kv=use_mask,
             sm_scale=sm_scale,
             sliding_window=sliding_window,
             chunk_prefill_size=None,
@@ -140,11 +145,19 @@ def _benchmark_one(
         inputs["cu_q_lens"],
         inputs["cu_kv_lens"],
         inputs["distribution"],
+        inputs.get("custom_mask"),
         head_dim**-0.5,
         block_sizes,
     )
     out = bound()
     jax.block_until_ready(out)
+    # This string is used as a REGEX over trace event names to pull
+    # device_duration_ps, so it must match the pallas_call name built in
+    # ragged_paged_attention_v3.py (`scope_name`) exactly. On a miss the
+    # extractor silently falls back to host-side MARKER events, which are not
+    # comparable -- two runs would then be timed by two different methods.
+    # Which mode ran is already recorded in the header line and the JSONL, so
+    # do not encode it here.
     scope = (
         f"RPAm-p_{inputs['page_size']}"
         f"-bq_{block_sizes[0]}_{block_sizes[2]}"
@@ -171,6 +184,15 @@ def main():
     parser.add_argument("--kv-head-num", type=int, default=1)
     parser.add_argument("--head-dim", type=int, default=256)
     parser.add_argument("--tries", type=int, default=5)
+    parser.add_argument(
+        "--custom-mask",
+        action="store_true",
+        help=(
+            "run the tree-mask path (causal=0 + a rank-3 custom_mask) instead of "
+            "causal verification. Run once with and once without to measure what "
+            "the mask costs; nothing else in this repo exercises the masked path."
+        ),
+    )
     parser.add_argument(
         "--sliding-window",
         type=int,
@@ -226,6 +248,17 @@ def main():
     )
     inputs["distribution"] = values[-1]
     inputs["page_size"] = args.page_size
+    _kv_len = args.prefix_len + args.draft_token_num
+    inputs["custom_mask"] = (
+        create_tree_mask(
+            batch_size=args.batch_size,
+            draft_token_num=args.draft_token_num,
+            kv_len=_kv_len,
+            aligned_kv_len=cdiv(_kv_len, args.page_size) * args.page_size,
+        )
+        if args.custom_mask
+        else None
+    )
 
     candidates = args.candidates or (
         _focused_candidates(args.draft_token_num, args.sliding_window or None)
@@ -239,8 +272,11 @@ def main():
         f"bs{args.batch_size}xq{args.draft_token_num} "
         f"prefix={args.prefix_len} page={args.page_size} "
         f"q_heads={args.q_head_num} kv_heads={args.kv_head_num} hd={args.head_dim} "
-        f"sliding_window={args.sliding_window or None}"
+        f"sliding_window={args.sliding_window or None} "
+        f"custom_mask={'on (causal=0)' if args.custom_mask else 'off (causal=1)'}"
     )
+    if args.custom_mask:
+        print(f"# custom_mask shape={inputs['custom_mask'].shape} dtype=int32")
     print(
         f"# shapes q={inputs['q'].shape} kv_cache={inputs['kv_cache'].shape} "
         f"page_indices={inputs['page_indices'].shape}"
@@ -256,7 +292,7 @@ def main():
             block_sizes[1],
             jnp.bfloat16,
             jnp.bfloat16,
-            use_custom_mask=False,
+            use_custom_mask=inputs.get("custom_mask") is not None,
             bkv_csz=block_sizes[3],
         )
         if est > vmem_limit:
@@ -303,6 +339,7 @@ def main():
                             "kv_head_num": args.kv_head_num,
                             "head_dim": args.head_dim,
                             "sliding_window": args.sliding_window or None,
+                            "custom_mask": bool(args.custom_mask),
                             "block_sizes": list(block_sizes),
                             "latency_ms": elapsed,
                             "estimated_vmem_mib": est / 2**20,

--- a/benchmark/kernels/flash_attention/utils.py
+++ b/benchmark/kernels/flash_attention/utils.py
@@ -174,16 +174,14 @@ def create_decode_uniform_data(
     )
 
 
-def create_tree_mask(
+def create_tree_mask_rank3(
     *,
     batch_size: int,
     draft_token_num: int,
     kv_len: int,
-    aligned_kv_len: int,
     seed: int = 42,
 ):
-    """Tree attention mask in the layout the kernel reads today: one flat int32
-    array holding a [draft_token_num, aligned_kv_len] block per sequence.
+    """Tree attention mask in the layout the kernel takes: [rows, 1, W] int32.
 
     Shaped after what ``eagle_util.build_tree_mask_for_draft_decode`` and the
     tree-structure kernel produce: the committed prefix is all ones (every
@@ -193,17 +191,18 @@ def create_tree_mask(
     keeping it faithful avoids anyone reading a degenerate all-ones result as
     representative.
 
-    Row width is the page-aligned kv length, i.e. the ``cu_kv_lens`` delta, so
-    this pairs with ``mask_aligned_to_cu_kv=True``.
+    ``W`` is the smallest power of two >= kv_len and >= 128, matching
+    ``flashattention_backend.mask_row_width``.
     """
+    width = max(128, 1 << max(kv_len - 1, 1).bit_length())
     prefix_len = kv_len - draft_token_num
     rng = np.random.default_rng(seed)
     corner = rng.integers(0, 2, size=(draft_token_num, draft_token_num), dtype=np.int64)
     np.fill_diagonal(corner, 1)  # a draft token always attends to itself
-    block = np.zeros((draft_token_num, aligned_kv_len), dtype=np.int32)
-    block[:, :prefix_len] = 1
-    block[:, prefix_len:kv_len] = corner.astype(np.int32)
-    return jnp.asarray(np.tile(block, (batch_size, 1)).reshape(-1))
+    mask = np.zeros((batch_size * draft_token_num, 1, width), dtype=np.int32)
+    mask[:, 0, :prefix_len] = 1
+    mask[:, 0, prefix_len:kv_len] = np.tile(corner.astype(np.int32), (batch_size, 1))
+    return jnp.asarray(mask)
 
 
 def create_target_verify_uniform_data(

--- a/benchmark/kernels/flash_attention/utils.py
+++ b/benchmark/kernels/flash_attention/utils.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from sgl_jax.srt.kernels.ragged_paged_attention.util import cdiv, get_dtype_packing
 
@@ -171,6 +172,38 @@ def create_decode_uniform_data(
         cache_loc,
         distribution,
     )
+
+
+def create_tree_mask(
+    *,
+    batch_size: int,
+    draft_token_num: int,
+    kv_len: int,
+    aligned_kv_len: int,
+    seed: int = 42,
+):
+    """Tree attention mask in the layout the kernel reads today: one flat int32
+    array holding a [draft_token_num, aligned_kv_len] block per sequence.
+
+    Shaped after what ``eagle_util.build_tree_mask_for_draft_decode`` and the
+    tree-structure kernel produce: the committed prefix is all ones (every
+    draft token attends to all of it) and only the trailing
+    ``draft_token_num x draft_token_num`` corner carries tree structure. Mask
+    content does not affect kernel timing -- the cost is structural -- but
+    keeping it faithful avoids anyone reading a degenerate all-ones result as
+    representative.
+
+    Row width is the page-aligned kv length, i.e. the ``cu_kv_lens`` delta, so
+    this pairs with ``mask_aligned_to_cu_kv=True``.
+    """
+    prefix_len = kv_len - draft_token_num
+    rng = np.random.default_rng(seed)
+    corner = rng.integers(0, 2, size=(draft_token_num, draft_token_num), dtype=np.int64)
+    np.fill_diagonal(corner, 1)  # a draft token always attends to itself
+    block = np.zeros((draft_token_num, aligned_kv_len), dtype=np.int32)
+    block[:, :prefix_len] = 1
+    block[:, prefix_len:kv_len] = corner.astype(np.int32)
+    return jnp.asarray(np.tile(block, (batch_size, 1)).reshape(-1))
 
 
 def create_target_verify_uniform_data(

--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -271,8 +271,10 @@ def get_vmem_estimate_bytes(
     )
 
     if use_custom_mask:
-        # bkvmask_double_buf: (2, bq_sz, bkv_sz, head_dim) in int32
-        total_bits += 2 * bq_sz * bkv_sz * head_dim * 32
+        # bkvmask_double_buf: (2, bq_sz, 1, bkv_sz) in int32. The size-1
+        # second-minor axis takes a (1, 128) tile, so it costs no sublane
+        # padding: one mask bit is one int32, not head_dim of them.
+        total_bits += 2 * bq_sz * bkv_sz * 32
 
     # Attention compute intermediates (f32). The for-loop over kv_heads is
     # statically unrolled by the compiler, so all heads' intermediates coexist
@@ -332,7 +334,7 @@ def _ragged_paged_attention_kernel_loop(
     page_indices_ref,  # [flat page indices]
     cu_q_lens_ref,  # [max_num_seqs + 1]
     cu_kv_lens_ref,  # [max_num_seqs + 1]
-    cu_seq_mask_lens,  # [max_num_seqs + 1]
+    cu_seq_mask_lens,  # [1], unused placeholder
     distribution_ref,  # [3] (decode_end, prefill_end, mixed_end)
     sem_ids_ref,  # [3] (bq_sem_idx, bkv_sem_idx, bo_sem_idx)
     bo_ids_ref,  # [4]
@@ -341,14 +343,14 @@ def _ragged_paged_attention_kernel_loop(
     q_hbm_ref,  # [actual_num_kv_heads, max_num_tokens, num_q_heads_per_kv_head // q_packing, q_packing, head_dim]
     kv_hbm_ref,  # [max_num_tokens, num_kv_heads_x2 // kv_packing, kv_packing, head_dim]
     kv_cache_hbm_ref,  # [total_num_pages, page_size, num_kv_heads_x2 // kv_packing, kv_packing, head_dim]
-    custom_mask_ref,  # [flatten_total_kv_len, head_dim] or None
-    zero_mask_ref,  # [bkv_sz, head_dim] or None
+    custom_mask_ref,  # [total_q_rows, 1, mask_width] or None
+    zero_mask_ref,  # [bq_sz, 1, bkv_sz] or None
     attention_sink_ref,  # [actual_num_kv_heads, num_q_heads_per_kv_head, 128] or None
     # Output
     o_hbm_ref,  # same shape as q_hbm_ref
     updated_kv_cache_hbm_ref,  # same shape as kv_cache_hbm_ref
     # Scratch
-    bkvmask_ref,  # [2, bq_sz, bkv_sz, head_dim] or None
+    bkvmask_ref,  # [2, bq_sz, 1, bkv_sz] or None
     bkv_x2_ref,  # [2, bkv_sz, num_kv_heads_x2 // kv_packing, kv_packing, head_dim]
     bq_x2_ref,  # [2, actual_num_kv_heads, bq_sz, num_q_heads_per_kv_head // q_packing, q_packing, head_dim]
     bo_x2_ref,  # [2, actual_num_kv_heads, bq_sz, ...]
@@ -376,7 +378,6 @@ def _ragged_paged_attention_kernel_loop(
     skip_kv_mask: bool = False,
     tpu_version: int = 6,
     debug_mode: bool = False,
-    mask_aligned_to_cu_kv: bool = False,
 ):
     assert q_hbm_ref.shape == o_hbm_ref.shape
     assert q_hbm_ref.shape[-1] == kv_cache_hbm_ref.shape[-1]
@@ -564,52 +565,55 @@ def _ragged_paged_attention_kernel_loop(
             cp.start()
 
     def _fetch_mask(seq_idx, bq_idx, bkvmask_idx, bkvmask_sem_idx, *, wait=False):
+        """Fetch the [bq_sz, bkv_sz] mask tile for this (bq, bkv) block.
+
+        The mask is a rectangle [total_q_rows, 1, mask_width] holding one int32
+        per mask bit, with kv on the lane axis. Two properties let the whole
+        tile arrive in a single DMA:
+
+        * A row is addressed by the global q-token index, which lands on the
+          LEADING dim. Mosaic's slice-alignment check only inspects the last
+          `tile_rank` dims, so a dynamic and unaligned row start is legal with
+          no `pl.multiple_of` promise -- worth more than it looks, since under
+          `disable_bounds_checks=True` a wrong promise miscompiles silently
+          rather than faulting.
+        * mask_width and bkv_sz are both multiples of 128 -- the host pads every
+          row to a common power-of-two width, and `bkv_alignment` is 128 on this
+          path -- so every lane offset and length below is lane-tile aligned by
+          construction.
+        """
         if custom_mask_ref is None:
             return
         sem = sems.at[4, bkvmask_sem_idx]
         kvmask_vmem_ref = bkvmask_ref.at[bkvmask_sem_idx]
 
-        if mask_aligned_to_cu_kv:
-            # Host padded each mask row to the page-aligned kv_len (= cu_kv_lens
-            # delta), so stride/offset/size are statically tiling(8)-divisible.
-            mask_kv_len = pl.multiple_of(cu_kv_lens_ref[seq_idx + 1] - cu_kv_lens_ref[seq_idx], 8)
-        else:
-            mask_kv_len = kv_lens_ref[seq_idx]
-        mask_start = bkvmask_idx * bkv_sz
-        mask_left = mask_kv_len - mask_start
-        load_kvmask_sz = jnp.minimum(bkv_sz, mask_left)
-        if mask_aligned_to_cu_kv:
-            load_kvmask_sz = pl.multiple_of(load_kvmask_sz, 8)
+        # Static: the rectangle is uniform, so there is no per-sequence stride
+        # and `cu_seq_mask_lens` is not needed at all.
+        mask_w = custom_mask_ref.shape[-1]
+        mask_start = pl.multiple_of(bkvmask_idx * bkv_sz, 128)
+        load_kvmask_sz = pl.multiple_of(jnp.minimum(bkv_sz, mask_w - mask_start), 128)
+        zero_sz = pl.multiple_of(bkv_sz - load_kvmask_sz, 128)
 
         q_len_start = cu_q_lens_ref[seq_idx] + bq_idx * bq_sz
         q_end = cu_q_lens_ref[seq_idx + 1]
         load_q_sz = jnp.minimum(bq_sz, q_end - q_len_start)
 
-        cur_seq_mask_start = cu_seq_mask_lens[seq_idx]
-        cur_bq_mask_start = cur_seq_mask_start + bq_idx * bq_sz * mask_kv_len
-        zero_sz = bkv_sz - load_kvmask_sz
-        if mask_aligned_to_cu_kv:
-            cur_seq_mask_start = pl.multiple_of(cur_seq_mask_start, 8)
-            zero_sz = pl.multiple_of(zero_sz, 8)
-
-        def loop_body(i, _):
-            start = cur_bq_mask_start + i * mask_kv_len + mask_start
-            if mask_aligned_to_cu_kv:
-                start = pl.multiple_of(start, 8)
-            _async_copy(
-                custom_mask_ref.at[pl.ds(start, load_kvmask_sz)],
-                kvmask_vmem_ref.at[i, pl.ds(0, load_kvmask_sz)],
-                sem,
-                wait,
-            )
-            _async_copy(
-                zero_mask_ref.at[pl.ds(0, zero_sz)],
-                kvmask_vmem_ref.at[i, pl.ds(load_kvmask_sz, zero_sz)],
-                sem,
-                wait,
-            )
-
-        lax.fori_loop(0, load_q_sz, loop_body, None, unroll=False)
+        _async_copy(
+            custom_mask_ref.at[pl.ds(q_len_start, load_q_sz), :, pl.ds(mask_start, load_kvmask_sz)],
+            kvmask_vmem_ref.at[pl.ds(0, load_q_sz), :, pl.ds(0, load_kvmask_sz)],
+            sem,
+            wait,
+        )
+        # Tail zero-fill. `zero_sz` is 0 whenever mask_width is a multiple of
+        # bkv_sz (the common case), but it must stay: a stale 1 left by the
+        # previous double-buffer tenant would let through a KV token that
+        # should have been masked, and the mask polarity is 1=keep.
+        _async_copy(
+            zero_mask_ref.at[pl.ds(0, load_q_sz), :, pl.ds(0, zero_sz)],
+            kvmask_vmem_ref.at[pl.ds(0, load_q_sz), :, pl.ds(load_kvmask_sz, zero_sz)],
+            sem,
+            wait,
+        )
 
     def _fetch_bkv(seq_idx, bkv_idx, bkv_sem_idx, *, wait=False):
         sem = sems.at[0, bkv_sem_idx]
@@ -1012,11 +1016,6 @@ def _ragged_paged_attention_kernel_loop(
                 if debug_mode:
                     return
 
-                # Load custom mask data for this block
-                custom_mask_data = None
-                if bkvmask_ref is not None:
-                    custom_mask_data = bkvmask_ref[bkv_sem_idx, :actual_bq_sz, :, 0]
-
                 # Flash attention with cur bkv and bq
                 effective_bkv_sz = jnp.minimum(effective_kv_len - bkv_idx * bkv_sz, bkv_sz)
                 effective_bkv_sz = jnp.maximum(effective_bkv_sz, 0)
@@ -1034,12 +1033,15 @@ def _ragged_paged_attention_kernel_loop(
                         for bq_start in range(0, actual_bq_sz, actual_bq_csz):
                             # Slice custom mask for this compute sub-block
                             cur_mask_data = None
-                            if custom_mask_data is not None:
+                            if bkvmask_ref is not None:
+                                # kv is on the lane axis, so this is a plain
+                                # 2-D read: the middle index drops a size-1
+                                # axis rather than gathering across sublanes.
                                 cur_mask_data = bkvmask_ref[
                                     bkv_sem_idx,
                                     pl.ds(bq_start, actual_bq_csz),
-                                    pl.ds(bkv_start, bkv_csz),
                                     0,
+                                    pl.ds(pl.multiple_of(bkv_start, 128), bkv_csz),
                                 ]
 
                             # Slice xai temperature for this compute sub-block
@@ -1552,6 +1554,12 @@ def get_default_block_sizes(
             raise NotImplementedError(f"Unsupported {tpu_version=}.")
 
     bkv_alignment = max(page_size, kv_packing)
+    if use_custom_mask:
+        # The mask puts kv on the lane axis, so every kv slice offset and length
+        # has to be a multiple of the 128-lane tile. The default alignment above
+        # does not give that: with page_size=16 and bf16 (kv_packing=2) it is
+        # only 16, and at page_size=1 it drops to kv_packing itself.
+        bkv_alignment = max(bkv_alignment, 128)
     # Custom-mask intermediates exceed v5/v6 scoped VMEM with a 32-row query tile.
     if use_custom_mask and tpu_version in (5, 6):
         bq_sz = min(bq_sz, 16)
@@ -1660,7 +1668,6 @@ def get_vmem_limit():
         "skip_kv_mask",
         "disable_semaphore_checks",
         "debug_mode",
-        "mask_aligned_to_cu_kv",
     ),
     donate_argnames=("queries", "keys", "values", "kv_cache_fused"),
 )
@@ -1696,7 +1703,6 @@ def ragged_paged_attention(
     skip_kv_mask: bool = False,
     disable_semaphore_checks: bool = True,
     debug_mode: bool = False,
-    mask_aligned_to_cu_kv: bool = False,
 ):
     """Ragged paged attention with fused KV cache.
 
@@ -1710,7 +1716,12 @@ def ragged_paged_attention(
       cu_q_lens: cumulative sum of effective query lengths.
       cu_kv_lens: cumulative sum of effective key/value lengths.
       distribution: (i, j, k) decode/prefill/mixed sequence ranges.
-      custom_mask: custom attention mask for speculative decoding.
+      custom_mask: custom attention mask for speculative decoding, as an
+        int32 rectangle [total_q_rows, 1, mask_width]. Row r is the mask for
+        global q token r (i.e. indexed by cu_q_lens), one int32 per mask bit
+        with 1 = keep, and mask_width must be a multiple of 128 and at least
+        the largest padded kv length in the batch. The host pads every row to
+        this common width.
       attention_sink: per-head sink logits for streaming inference.
       causal: 1 for causal mask, 0 for custom mask.
       sm_scale: softmax scale applied to Q@K^T.
@@ -1788,24 +1799,20 @@ def ragged_paged_attention(
     if out_dtype is None:
         out_dtype = jnp.float32 if q.dtype == jnp.float32 else jnp.bfloat16
 
-    # mask_aligned_to_cu_kv: when True the kernel uses cu_kv_lens deltas
-    # (page-aligned) as mask row widths; the host must have padded each row
-    # accordingly. target_verify always pads; prefill does not.
-
-    # Prepare custom mask.
+    # The mask is a rectangle: row r carries the mask for global q token r
+    # (i.e. rows are indexed by cu_q_lens), every row is the same width, and kv
+    # runs along the minor axis.
     if custom_mask is not None:
         if custom_mask.dtype == jnp.bool_:
             custom_mask = custom_mask.astype(jnp.int32)
-        custom_mask = jnp.repeat(jnp.expand_dims(custom_mask, axis=1), repeats=head_dim, axis=1)
-
-        q_lens = cu_q_lens[1:] - cu_q_lens[:-1]
-        mask_kv_lens = (cu_kv_lens[1:] - cu_kv_lens[:-1]) if mask_aligned_to_cu_kv else kv_lens
-        seq_mask_lens = mask_kv_lens * q_lens
-        cu_seq_mask_lens = jnp.concatenate(
-            [jnp.array([0], dtype=jnp.int32), jnp.cumsum(seq_mask_lens)]
-        )
-    else:
-        cu_seq_mask_lens = jnp.array([0])
+        if custom_mask.ndim != 3 or custom_mask.shape[1] != 1 or custom_mask.shape[2] % 128:
+            raise ValueError(
+                "custom_mask must be [total_q_rows, 1, mask_width] with mask_width a "
+                f"multiple of 128 (kv lives on the lane axis); got {custom_mask.shape}."
+            )
+    # Unread by the kernel, but kept in the scalar-prefetch tuple so that
+    # input_output_aliases keeps its absolute operand indices.
+    cu_seq_mask_lens = jnp.array([0], dtype=jnp.int32)
 
     # Scalar prefetch init values.
     init_sem_ids = jnp.zeros((3,), jnp.int32)
@@ -1826,6 +1833,11 @@ def ragged_paged_attention(
         static_q_len=None,
         case: RpaCase = RpaCase.MIXED,
     ):
+        if custom_mask is not None and (bkv_sz % 128 or bkv_csz % 128):
+            # Only get_default_block_sizes guarantees this; an explicit
+            # m_block_sizes or a tuned-table hit both bypass it.
+            raise ValueError(f"custom_mask needs 128-aligned kv blocks, got {bkv_sz=} {bkv_csz=}.")
+
         in_specs = [
             pl.BlockSpec(memory_space=pltpu.HBM),  # q
             pl.BlockSpec(memory_space=pltpu.HBM),  # kv
@@ -1873,7 +1885,7 @@ def ragged_paged_attention(
             bkvmask_double_buf = None
         else:
             bkvmask_double_buf = pltpu.VMEM(
-                (2, bq_sz, bkv_sz, head_dim),
+                (2, bq_sz, 1, bkv_sz),
                 jnp.int32,
             )
 
@@ -1944,7 +1956,6 @@ def ragged_paged_attention(
                 skip_kv_mask=skip_kv_mask,
                 tpu_version=tpu_version,
                 debug_mode=debug_mode,
-                mask_aligned_to_cu_kv=mask_aligned_to_cu_kv,
             ),
             grid_spec=pltpu.PrefetchScalarGridSpec(
                 num_scalar_prefetch=len(scalar_prefetches),
@@ -1977,7 +1988,7 @@ def ragged_paged_attention(
             name=scope_name,
         )
 
-        zero_mask = jnp.zeros((bkv_sz, head_dim), dtype=jnp.int32)
+        zero_mask = jnp.zeros((bq_sz, 1, bkv_sz), dtype=jnp.int32)
 
         if tpu_version >= 7:
 
@@ -2049,7 +2060,6 @@ def ragged_paged_attention(
                     use_custom_mask=custom_mask is not None,
                     sliding_window=sliding_window,
                 )
-
         return {
             "bq_sz": block_sizes[0],
             "bkv_sz": block_sizes[1],

--- a/python/sgl_jax/srt/kernels/utils/perf.py
+++ b/python/sgl_jax/srt/kernels/utils/perf.py
@@ -8,6 +8,7 @@ import random
 import re
 import shutil
 import string
+import warnings
 from typing import Any
 
 import jax
@@ -35,6 +36,15 @@ def _extract_marker_durations_ms(trace: dict[str, Any], task: str | None = None)
                 elif "dur" in e:
                     durations_ms.append(float(e["dur"]) / 1e3)
             return durations_ms
+        warnings.warn(
+            f"no trace event name matched task={task!r}; falling back to MARKER scope "
+            "events, whose durations are host-side and NOT comparable to the "
+            "device_duration_ps used on the matching path. Two runs measured through "
+            "different paths cannot be compared. Check that `task` matches the "
+            "pallas_call name exactly.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
     # Fallback: use MARKER-based extraction
     marker_events: list[dict[str, Any]] = []

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -39,6 +39,65 @@ def _per_dp_cumsum(lens, dp_size: int, per_dp_bs: int) -> np.ndarray:
     return cu.ravel()
 
 
+def mask_row_width(aligned_seq_lens) -> int:
+    """Common row width `W` for the rank-3 verify mask.
+
+    The kernel wants the mask as a rectangle `[total_q_rows, 1, W]` with kv on
+    the lane axis, which needs one width for the whole batch. Two constraints:
+
+    * ``W % 128 == 0`` -- kv lives on the lane axis, and Mosaic checks tile
+      alignment on the two minormost dims of every slice.
+    * ``W >= max(aligned_seq_lens)`` -- a narrower W would silently drop the
+      right-hand columns, i.e. exactly the draft tokens being verified.
+
+    Rounding up to a power of two (rather than using the raw batch max) keeps
+    the number of distinct traced shapes at O(log max_context_len) instead of
+    one per batch.
+    """
+    w_max = int(np.max(aligned_seq_lens, initial=1))
+    return max(128, 1 << max(w_max - 1, 1).bit_length())
+
+
+def _pack_verify_mask(
+    cm: np.ndarray,
+    seq_lens: np.ndarray,
+    aligned_seq_lens: np.ndarray,
+    cm_off: np.ndarray,
+    q: int,
+    dp_size: int,
+    per_dp_bs: int,
+) -> np.ndarray:
+    """Repack the flat tree mask into the kernel's rank-3 rectangle.
+
+    Returns `[dp_size * per_dp_bs * q, 1, W]` int32, 1 = keep.
+
+    Row layout must match what the kernel computes, which is
+    ``cu_q_lens_ref[seq_idx] + bq_idx * bq_sz`` where ``cu_q_lens`` is the
+    *per-DP-rank* cumsum of ``extend_seq_lens`` (see ``_per_dp_cumsum``). So
+    within a rank the real slots are packed back to back, `q` rows each, and
+    padding slots contribute no rows at all. Each rank's block is padded out to
+    the full ``per_dp_bs * q`` rows so the leading dim splits evenly under
+    ``P("data")`` and the shape stays bucket-stable.
+
+    Columns past a sequence's own kv_len stay zero. That is not just padding:
+    zero means "masked", which is the safe value if the kernel's independent
+    ``k_span < effective_kv_len`` guard is ever disabled (``skip_kv_mask``).
+    """
+    W = mask_row_width(aligned_seq_lens)
+    rows_per_rank = per_dp_bs * q
+    packed = np.zeros((dp_size * rows_per_rank, 1, W), dtype=np.int32)
+    for r in range(dp_size):
+        row = r * rows_per_rank
+        for j in range(per_dp_bs):
+            s = r * per_dp_bs + j
+            if seq_lens[s] <= 0:
+                continue
+            kl = int(seq_lens[s])
+            packed[row : row + q, 0, :kl] = cm[cm_off[s] : cm_off[s] + q * kl].reshape(q, kl)
+            row += q
+    return packed
+
+
 def _pad_page_indices(
     page_indices: np.ndarray,
     max_num_seqs: int,
@@ -322,45 +381,23 @@ class FlashAttention(AttentionBackend):
             seq_lens += extend_seq_lens
             aligned_seq_lens = ((seq_lens + self.page_size - 1) // self.page_size) * self.page_size
             # Verify mask must be (a) DP-segmented per rank when dp>1 so each
-            # rank's P("data") shard sees its own slots, and (b) padded so each
-            # row width = aligned_seq_lens (= cu_kv_lens delta). The RPA kernel
-            # always takes the cu_kv_lens-aligned path now (#1089 used to gate
-            # on page_size>=256, which broke dp=1 + smaller pages — Mosaic
-            # could not prove tiling(8) on the unaligned slice). dp=1 reduces
-            # to a single rank chunk; dp>1 keeps the per-rank repack from
-            # #1108 P1-7.
+            # rank's P("data") shard sees its own slots, and (b) laid out as the
+            # kernel's rectangle [total_q_rows, 1, W] -- kv on the lane axis,
+            # one uniform 128-aligned W for the whole batch (see mask_row_width
+            # and _pack_verify_mask). dp=1 reduces to a single rank chunk;
+            # dp>1 keeps the per-rank repack from #1108 P1-7.
             if metadata.custom_mask is not None:
                 q = batch.spec_info_padded.draft_token_num
                 cm = np.asarray(jax.device_get(metadata.custom_mask))
-                # Pin per-rank mask target from the pre-repacking mask capacity
-                # (tree_mask_capacity from build_tree, already bucket-stable).
-                cm_total = len(cm)
-                per_rank_mask_target = ((cm_total // dp_size + 7) // 8) * 8 or 8
+                assert cm.ndim == 1, f"unexpected tree-mask rank {cm.shape}"
                 # cm is DP-slot-ordered (build_tree got verified_seq_len = mwb.seq_lens-1
                 # over total_bs). Per-slot cm length = q*(verified_seq_len[s]+q); for pad
                 # slots verified_seq_len=-1 → q*(q-1).
                 cm_kl = np.where(seq_lens > 0, seq_lens, q - 1).astype(np.int64)
                 cm_off = np.concatenate([[0], np.cumsum(q * cm_kl)])
-                row_width = aligned_seq_lens
-                rank_chunks: list[np.ndarray] = []
-                for r in range(dp_size):
-                    parts = []
-                    for j in range(per_dp_bs):
-                        s = r * per_dp_bs + j
-                        kla = int(row_width[s])
-                        if seq_lens[s] > 0:
-                            kl = int(seq_lens[s])
-                            row = cm[cm_off[s] : cm_off[s] + q * kl].reshape(q, kl)
-                            parts.append(np.pad(row, ((0, 0), (0, kla - kl))).reshape(-1))
-                        elif kla > 0:
-                            parts.append(np.zeros(q * kla, dtype=cm.dtype))
-                    rank_chunks.append(
-                        np.concatenate(parts) if parts else np.zeros(0, dtype=cm.dtype)
-                    )
-                max_len = max(max((len(c) for c in rank_chunks), default=0), per_rank_mask_target)
-                packed = np.concatenate(
-                    [np.pad(c, (0, max_len - len(c))) for c in rank_chunks]
-                ).astype(np.int32)
+                packed = _pack_verify_mask(
+                    cm, seq_lens, aligned_seq_lens, cm_off, q, dp_size, per_dp_bs
+                )
                 metadata.custom_mask = device_array(
                     packed,
                     sharding=NamedSharding(self.mesh, P("data")),
@@ -662,7 +699,7 @@ class FlashAttention(AttentionBackend):
                 P(self.attention_data_partition_axis)
                 if self.forward_metadata.custom_mask is not None
                 else P()
-            ),  # custom_mask: DP-segmented per-rank (cu_seq_mask_lens is rank-local)
+            ),  # custom_mask: [total_q_rows, 1, W], leading dim DP-segmented
             (
                 P(self.kv_partition_axis) if attention_sink is not None else P()
             ),  # attention sink: (num_q_heads,), sharded by heads
@@ -675,10 +712,6 @@ class FlashAttention(AttentionBackend):
             ),  # updated kv_cache_fused (head interleaved) - 3D: [total_tokens, num_kv_heads*2, head_dim]
         )
 
-        mask_aligned_to_cu_kv = (
-            self.forward_metadata.custom_mask is not None
-            and forward_batch.forward_mode.is_target_verify()
-        )
         target_verify_tokens_per_seq = (
             getattr(forward_batch.spec_info, "draft_token_num", None)
             if forward_batch.forward_mode.is_target_verify()
@@ -726,7 +759,6 @@ class FlashAttention(AttentionBackend):
                     layer.xai_temperature_len if layer.xai_temperature_len > 0 else None
                 ),
                 softmax_dtype=layer.softmax_dtype,
-                mask_aligned_to_cu_kv=mask_aligned_to_cu_kv,
                 m_block_sizes=target_verify_m_block_sizes,
             )
 

--- a/python/sgl_jax/test/flashattention_common.py
+++ b/python/sgl_jax/test/flashattention_common.py
@@ -101,6 +101,29 @@ def create_custom_mask(lens):
     return jnp.concatenate(custom_masks)
 
 
+def create_custom_mask_rank3(lens, flat_mask):
+    """Rank-3 `[total_q_rows, 1, W]` int32 view of `create_custom_mask`'s output.
+
+    The kernel takes the mask as a rectangle with kv on the lane axis; the flat
+    bool form stays as-is and is fed to `ref_ragged_paged_attention`, which
+    recomputes its own `cumsum(q_len * kv_len)` offsets. Keeping the two
+    representations independent is the point: if the oracle also learned about
+    rectangles, the tests would compare a padding bug against itself.
+    """
+    q_lens = [q_len for q_len, _ in lens]
+    kv_lens = [kv_len for _, kv_len in lens]
+    width = max(128, 1 << max(max(kv_lens) - 1, 1).bit_length())
+    out = np.zeros((int(sum(q_lens)), 1, width), dtype=np.int32)
+    flat = np.asarray(flat_mask).astype(np.int32)
+    off = row = 0
+    for q_len, kv_len in zip(q_lens, kv_lens):
+        out[row : row + q_len, 0, :kv_len] = flat[off : off + q_len * kv_len].reshape(q_len, kv_len)
+        off += q_len * kv_len
+        row += q_len
+    assert off == flat.size, f"flat mask has {flat.size} entries, consumed {off}"
+    return jnp.asarray(out)
+
+
 def write_prefix_tokens_for_kv(forward_batch, token_to_kv_pool: KVCache, lens, k, v):
     """Write prefix tokens to KV cache and return extend tokens.
 
@@ -344,8 +367,10 @@ def create_test_data(
     if fb.spec_info is not None:
         from sgl_jax.srt.utils.jax_utils import device_array
 
+        # spec_info keeps the flat form (the reference implementation's input);
+        # the kernel gets the rank-3 rectangle.
         fb.attn_backend.forward_metadata.custom_mask = device_array(
-            (fb.spec_info.custom_mask),
+            create_custom_mask_rank3(lens, fb.spec_info.custom_mask),
             sharding=(NamedSharding(attention_backend.mesh, P("data"))),
         )
     return fb, current_kv_cache, q, k, v

--- a/python/sgl_jax/test/test_flashattention_custom_mask_dp.py
+++ b/python/sgl_jax/test/test_flashattention_custom_mask_dp.py
@@ -1,0 +1,241 @@
+"""DP=4 coverage for the rank-3 speculative custom mask (TPU, 4 chips).
+
+What this pins down
+-------------------
+The verify mask is a rectangle ``[total_q_rows, 1, W]`` sharded with ``P("data")``,
+so rank ``r`` receives a contiguous block of ``per_dp_bs * draft_token_num`` rows.
+Inside ``shard_map`` the kernel addresses a row as
+``cu_q_lens_ref[seq_idx] + bq_idx * bq_sz``, where ``cu_q_lens`` is the *rank-local*
+cumsum produced by ``_per_dp_cumsum``.
+
+If those two disagree, one rank reads another rank's mask. Nothing crashes: the
+model simply accepts wrong draft tokens. ``test_verify_mask_packing`` pins the
+packing arithmetic on the host, but only this test puts the real sharded array
+through the kernel.
+
+Method: run the same logical batch at dp=4 and at dp=1 with block sizes pinned, and
+require the outputs to agree. Every sequence gets its own random mask, so any
+cross-rank mix-up changes the result.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.kernels.ragged_paged_attention.ragged_paged_attention_v3 import (
+    ragged_paged_attention,
+)
+from sgl_jax.srt.layers.attention.flashattention_backend import (
+    _pack_verify_mask,
+    _per_dp_cumsum,
+)
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+from sgl_jax.test.test_utils import CustomTestCase
+
+PAGE_SIZE = 128
+HEAD_DIM = 128
+DTYPE = jnp.bfloat16
+GQA = 4
+DRAFT_TOKENS = 8
+BLOCKS = (16, 512, 16, 512)  # pinned so dp=1 and dp=4 make identical block choices
+
+
+def _cdiv(a, b):
+    return -(-a // b)
+
+
+def _build(kv_lens, n_kv_heads, dp_size, seed=0):
+    """Per-rank inputs for a target-verify step, plus the rank-3 mask.
+
+    ``kv_lens`` is the whole logical batch; it is split evenly across ranks. Page
+    indices are rank-local, because under ``shard_map`` each rank sees only its own
+    slice of the KV cache.
+    """
+    bs = len(kv_lens)
+    assert bs % dp_size == 0
+    per_dp_bs = bs // dp_size
+    q = DRAFT_TOKENS
+    packing = 32 // (jnp.dtype(DTYPE).itemsize * 8)
+    aligned = [_cdiv(kv, PAGE_SIZE) * PAGE_SIZE for kv in kv_lens]
+    pages_per_seq = max(_cdiv(kv, PAGE_SIZE) for kv in kv_lens)
+    pages_per_rank = per_dp_bs * pages_per_seq
+    width = max(128, 1 << max(max(aligned) - 1, 1).bit_length())
+
+    # Build the FLAT tree-kernel output, then hand it to the production packer.
+    # Doing the rectangle by hand here would make the test agree with whatever
+    # mental model wrote it -- the same trap as teaching an oracle about the
+    # layout it is supposed to check.
+    rng = np.random.default_rng(seed)
+    blocks = []
+    for kv in kv_lens:
+        prefix = kv - q
+        assert prefix > 0
+        block = np.zeros((q, kv), np.int32)
+        block[:, :prefix] = 1  # committed prefix: every draft token sees all of it
+        corner = np.tril(np.ones((q, q), np.int32))
+        corner *= (rng.random((q, q)) < 0.7) | np.eye(q, dtype=bool)
+        block[:, prefix:] = corner
+        blocks.append(block.reshape(-1))
+    cm = np.concatenate(blocks)
+
+    seq_lens_np = np.asarray(kv_lens, np.int32)
+    aligned_np = np.asarray(aligned, np.int32)
+    cm_kl = np.where(seq_lens_np > 0, seq_lens_np, q - 1).astype(np.int64)
+    cm_off = np.concatenate([[0], np.cumsum(q * cm_kl)])
+    mask = _pack_verify_mask(cm, seq_lens_np, aligned_np, cm_off, q, dp_size, per_dp_bs)
+    assert mask.shape == (bs * q, 1, width), mask.shape
+
+    extend = np.full((bs,), q, dtype=np.int32)
+    cu_q = _per_dp_cumsum(extend, dp_size, per_dp_bs)
+    cu_kv = _per_dp_cumsum(np.asarray(aligned, np.int32), dp_size, per_dp_bs)
+    # Rank-local page indices, repeated per rank.
+    page_indices = np.tile(np.arange(pages_per_rank, dtype=np.int32), dp_size)
+    distribution = np.tile(np.array([0, per_dp_bs, per_dp_bs], np.int32), dp_size)
+
+    total_q = bs * q
+    keys = jax.random.split(jax.random.PRNGKey(seed + 1), 4)
+    n_q_heads = GQA * n_kv_heads
+    # The cache must hold real values, not zeros. With k=0 every committed
+    # position scores 0, contributing exp(0)=1 to the denominator and nothing to
+    # the numerator, so (a) the output collapses to the eight new tokens diluted
+    # by ~2000 ones, which puts the whole signal below any usable tolerance, and
+    # (b) a wrong page index reads zeros just like a right one, so the rank-local
+    # page addressing this test also exercises would go unchecked.
+    #
+    # Both arms allocate the same total page count (dp=4: 4*32, dp=1: 1*128) and
+    # sequence s reads global pages [s*16, (s+1)*16) either way, so seeding from
+    # the same key gives both arms identical per-sequence cache contents.
+    return dict(
+        q=jax.random.normal(keys[0], (total_q, n_q_heads, HEAD_DIM), DTYPE),
+        k=jax.random.normal(keys[1], (total_q, n_kv_heads, HEAD_DIM), DTYPE),
+        v=jax.random.normal(keys[2], (total_q, n_kv_heads, HEAD_DIM), DTYPE),
+        cache=jax.random.normal(
+            keys[3],
+            (dp_size * pages_per_rank, PAGE_SIZE, n_kv_heads * 2 // packing, packing, HEAD_DIM),
+            DTYPE,
+        ),
+        kv_lens=jnp.asarray(kv_lens, jnp.int32),
+        page_indices=jnp.asarray(page_indices),
+        cu_q_lens=jnp.asarray(cu_q),
+        cu_kv_lens=jnp.asarray(cu_kv),
+        distribution=jnp.asarray(distribution),
+        custom_mask=jnp.asarray(mask),
+    )
+
+
+def _run(case, mesh):
+    """Mirror the backend's shard_map wiring, tp=1 so only the data axis splits."""
+    jax.sharding.set_mesh(mesh)
+    in_specs = (
+        P("data", "tensor"),  # queries
+        P("data", "tensor"),  # keys
+        P("data", "tensor"),  # values
+        P("data", None, "tensor", None, None),  # kv_cache_fused
+        P("data"),  # kv_lens
+        P("data"),  # page_indices
+        P("data"),  # cu_q_lens
+        P("data"),  # cu_kv_lens
+        P("data"),  # distribution
+        P("data"),  # custom_mask: [total_q_rows, 1, W], dim 0 split
+    )
+
+    def body(q, k, v, cache, kv_lens, page_indices, cu_q, cu_kv, dist, mask):
+        return ragged_paged_attention(
+            q,
+            k,
+            v,
+            cache,
+            kv_lens,
+            page_indices,
+            cu_q,
+            cu_kv,
+            dist,
+            mask,
+            causal=0,
+            sm_scale=HEAD_DIM**-0.5,
+            m_block_sizes=BLOCKS,
+        )
+
+    # Same construction as flashattention_backend's call site.
+    fn = jax.jit(
+        jax.shard_map(
+            body,
+            in_specs=in_specs,
+            out_specs=(P("data", "tensor"), P("data", None, "tensor", None, None)),
+            check_vma=False,
+        )
+    )
+    args = [
+        jax.device_put(case[n], NamedSharding(mesh, s))
+        for n, s in zip(
+            (
+                "q",
+                "k",
+                "v",
+                "cache",
+                "kv_lens",
+                "page_indices",
+                "cu_q_lens",
+                "cu_kv_lens",
+                "distribution",
+                "custom_mask",
+            ),
+            in_specs,
+            strict=True,
+        )
+    ]
+    out, _ = jax.block_until_ready(fn(*args))
+    return np.asarray(out)
+
+
+class TestCustomMaskDP(CustomTestCase):
+    """Requires 4 chips; registered in unit-test-tpu-v6e-4."""
+
+    KV_LENS = [2048, 1024, 1536, 512, 2048, 768, 1280, 2048]  # ragged on purpose
+
+    def _compare(self, n_kv_heads):
+        self.assertEqual(jax.device_count(), 4, "this test needs exactly 4 chips")
+
+        mesh4 = create_device_mesh(ici_parallelism=[4, 1], dcn_parallelism=[1, 1])
+        out4 = _run(_build(self.KV_LENS, n_kv_heads, dp_size=4), mesh4)
+
+        # The reference runs the whole batch on ONE chip. A [1, 4] mesh would not
+        # do: `P("data", "tensor")` would then split the head axis four ways, so
+        # the two runs would not be computing the same thing (and n_kv_heads=2
+        # would not even divide).
+        mesh1 = jax.sharding.Mesh(np.asarray(jax.devices()[:1]).reshape(1, 1), ("data", "tensor"))
+        out1 = _run(_build(self.KV_LENS, n_kv_heads, dp_size=1), mesh1)
+
+        # Sequences are laid out in the same order either way, attention is
+        # per-sequence, and BLOCKS is pinned, so the two runs should agree to the
+        # last bit; the tolerance is here only to absorb roughly one bf16 ULP
+        # (2**-8 relative). It has to stay that tight to be worth anything: the
+        # failure named below flips a sequence's eight draft columns, which moves
+        # each output element by ~1e-3, so a tolerance of 1e-2 would pass on a
+        # mask being read from the wrong rank entirely. Both arms build their
+        # mask through _pack_verify_mask, so the row layout under test is the
+        # production one, not the test's idea of it.
+        np.testing.assert_allclose(
+            out4.astype(np.float32),
+            out1.astype(np.float32),
+            rtol=4e-3,
+            atol=1e-4,
+            err_msg="dp=4 disagrees with dp=1: a rank is probably reading another "
+            "rank's mask rows (check _pack_verify_mask against _per_dp_cumsum)",
+        )
+
+    def test_custom_mask_dp4_matches_dp1_gqa(self):
+        self._compare(n_kv_heads=8)
+
+    def test_custom_mask_dp4_matches_dp1_narrow_kv(self):
+        # 2 kv heads: with tp=1 the tensor axis is trivial, but this keeps the
+        # per-rank kv-head count away from the value the single-chip tests use.
+        self._compare(n_kv_heads=2)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/python/sgl_jax/test/test_flashattention_custom_mask_dp.py
+++ b/python/sgl_jax/test/test_flashattention_custom_mask_dp.py
@@ -90,8 +90,20 @@ def _build(kv_lens, n_kv_heads, dp_size, seed=0):
     extend = np.full((bs,), q, dtype=np.int32)
     cu_q = _per_dp_cumsum(extend, dp_size, per_dp_bs)
     cu_kv = _per_dp_cumsum(np.asarray(aligned, np.int32), dp_size, per_dp_bs)
-    # Rank-local page indices, repeated per rank.
-    page_indices = np.tile(np.arange(pages_per_rank, dtype=np.int32), dp_size)
+    # Rank-local page indices. The kernel starts sequence i's pages at
+    # ``cu_kv_lens[i] // PAGE_SIZE`` (ragged_paged_attention_v3.py:640), i.e.
+    # packed by actual aligned length -- not at ``i * pages_per_seq``. Production
+    # reaches that layout by repacking page_indices on the host
+    # (flashattention_backend.py:426); index from cu_kv here for the same reason.
+    # A dense arange would instead point the two arms at different cache pages
+    # from the first short sequence onward, and the batch is ragged on purpose.
+    cu_kv_2d = cu_kv.reshape(dp_size, per_dp_bs + 1)
+    page_indices = np.zeros(dp_size * pages_per_rank, np.int32)
+    for r in range(dp_size):
+        for j in range(per_dp_bs):
+            n = aligned[r * per_dp_bs + j] // PAGE_SIZE
+            slot = r * pages_per_rank + cu_kv_2d[r, j] // PAGE_SIZE
+            page_indices[slot : slot + n] = j * pages_per_seq + np.arange(n)
     distribution = np.tile(np.array([0, per_dp_bs, per_dp_bs], np.int32), dp_size)
 
     total_q = bs * q
@@ -104,9 +116,10 @@ def _build(kv_lens, n_kv_heads, dp_size, seed=0):
     # (b) a wrong page index reads zeros just like a right one, so the rank-local
     # page addressing this test also exercises would go unchecked.
     #
-    # Both arms allocate the same total page count (dp=4: 4*32, dp=1: 1*128) and
-    # sequence s reads global pages [s*16, (s+1)*16) either way, so seeding from
-    # the same key gives both arms identical per-sequence cache contents.
+    # Both arms allocate the same total page count (dp=4: 4*32, dp=1: 1*128), and
+    # the page_indices packing above is what makes sequence s read global pages
+    # [s*16, (s+1)*16) in both, so seeding from the same key gives both arms
+    # identical per-sequence cache contents.
     return dict(
         q=jax.random.normal(keys[0], (total_q, n_q_heads, HEAD_DIM), DTYPE),
         k=jax.random.normal(keys[1], (total_q, n_kv_heads, HEAD_DIM), DTYPE),

--- a/python/sgl_jax/test/test_verify_mask_packing.py
+++ b/python/sgl_jax/test/test_verify_mask_packing.py
@@ -1,0 +1,131 @@
+"""Unit tests for the rank-3 verify-mask repack (pure numpy, no TPU).
+
+The repack in ``flashattention_backend`` is the only production producer of the
+attention kernel's ``custom_mask``, and it had no coverage at all. Its failure
+mode is silent: a mis-placed row means one sequence reads another's mask, and
+the model just accepts wrong draft tokens.
+
+The invariant under test is the one the kernel relies on: **row index ==
+per-DP-rank cumulative q-token index**, i.e. the same thing ``_per_dp_cumsum``
+produces for ``cu_q_lens``.
+"""
+
+import numpy as np
+import pytest
+
+from sgl_jax.srt.layers.attention.flashattention_backend import (
+    _pack_verify_mask,
+    _per_dp_cumsum,
+    mask_row_width,
+)
+
+
+def _build(seq_lens, q, page_size, dp_size, per_dp_bs):
+    """Mimic the host-side inputs of the repack, plus a per-slot oracle."""
+    seq_lens = np.asarray(seq_lens, dtype=np.int32)
+    aligned = ((seq_lens + page_size - 1) // page_size) * page_size
+    # Flat tree-mask layout: per slot q*kl entries, pad slots get q*(q-1).
+    cm_kl = np.where(seq_lens > 0, seq_lens, q - 1).astype(np.int64)
+    cm_off = np.concatenate([[0], np.cumsum(q * cm_kl)])
+    cm = np.zeros(int(cm_off[-1]), dtype=np.int32)
+    oracle = {}
+    rng = np.random.default_rng(0)
+    for s, kl in enumerate(seq_lens):
+        n = int(q * cm_kl[s])
+        block = rng.integers(0, 2, size=n, dtype=np.int64).astype(np.int32)
+        cm[cm_off[s] : cm_off[s] + n] = block
+        if kl > 0:
+            oracle[s] = block.reshape(q, int(kl))
+    return seq_lens, aligned, cm, cm_off, oracle
+
+
+def _pack(seq_lens, q=8, page_size=128, dp_size=1, per_dp_bs=None):
+    per_dp_bs = per_dp_bs if per_dp_bs is not None else len(seq_lens) // dp_size
+    sl, aligned, cm, cm_off, oracle = _build(seq_lens, q, page_size, dp_size, per_dp_bs)
+    packed = _pack_verify_mask(cm, sl, aligned, cm_off, q, dp_size, per_dp_bs)
+    return packed, sl, aligned, oracle, per_dp_bs
+
+
+@pytest.mark.parametrize(
+    "w_max,expected", [(1, 128), (128, 128), (129, 256), (2048, 2048), (2049, 4096)]
+)
+def test_row_width_is_pow2_and_covers_max(w_max, expected):
+    assert mask_row_width(np.array([w_max, 1], dtype=np.int32)) == expected
+
+
+def test_row_width_always_lane_aligned_and_wide_enough():
+    for lens in ([7], [900, 130], [4096, 1], [8193]):
+        w = mask_row_width(np.array(lens, dtype=np.int32))
+        assert w % 128 == 0
+        assert w >= max(lens)
+
+
+def _check_rows_match_cu_q_lens(packed, seq_lens, oracle, q, dp_size, per_dp_bs):
+    """The kernel indexes a row as cu_q_lens[slot] (per-DP-rank). Assert that."""
+    extend = np.where(np.asarray(seq_lens) > 0, q, 0).astype(np.int32)
+    cu = _per_dp_cumsum(extend, dp_size, per_dp_bs).reshape(dp_size, per_dp_bs + 1)
+    rows_per_rank = per_dp_bs * q
+    seen = 0
+    for r in range(dp_size):
+        for j in range(per_dp_bs):
+            s = r * per_dp_bs + j
+            if seq_lens[s] <= 0:
+                continue
+            row0 = r * rows_per_rank + int(cu[r, j])
+            kl = int(seq_lens[s])
+            np.testing.assert_array_equal(
+                packed[row0 : row0 + q, 0, :kl],
+                oracle[s],
+                err_msg=f"slot {s} landed at the wrong row",
+            )
+            seen += 1
+    assert seen == sum(1 for x in seq_lens if x > 0)
+
+
+def test_dense_batch_dp1():
+    seq_lens = [1000, 512, 2000, 128]
+    packed, sl, aligned, oracle, per_dp_bs = _pack(seq_lens)
+    assert packed.shape == (len(seq_lens) * 8, 1, mask_row_width(aligned))
+    assert packed.shape[2] % 128 == 0
+    _check_rows_match_cu_q_lens(packed, sl, oracle, 8, 1, per_dp_bs)
+
+
+def test_pad_slot_between_live_slots():
+    """The desync case: a padding slot must consume no rows.
+
+    If the packer advanced its cursor for pad slots, every sequence after the
+    pad would read the previous one's mask -- and nothing else in the stack
+    would notice.
+    """
+    seq_lens = [1000, 0, 700, 0]
+    packed, sl, aligned, oracle, per_dp_bs = _pack(seq_lens)
+    _check_rows_match_cu_q_lens(packed, sl, oracle, 8, 1, per_dp_bs)
+    # Rows past the two live sequences must be all zero (= masked).
+    assert not packed[16:].any()
+
+
+def test_dp2_segments_are_independent():
+    seq_lens = [1000, 0, 700, 640]  # rank0: 1 live, rank1: 2 live
+    packed, sl, aligned, oracle, per_dp_bs = _pack(seq_lens, dp_size=2)
+    assert packed.shape[0] == 2 * per_dp_bs * 8
+    _check_rows_match_cu_q_lens(packed, sl, oracle, 8, 2, per_dp_bs)
+    # Each rank owns a contiguous, equally sized block of the leading dim.
+    assert packed.shape[0] % 2 == 0
+
+
+def test_all_pad_batch_is_all_zero():
+    packed, sl, aligned, oracle, per_dp_bs = _pack([0, 0])
+    assert packed.shape[0] == 2 * 8
+    assert not packed.any()
+
+
+def test_columns_past_kv_len_are_masked():
+    seq_lens = [300]
+    packed, sl, aligned, oracle, per_dp_bs = _pack(seq_lens)
+    assert not packed[:, 0, 300:].any(), "padding columns must be 0 (= masked)"
+
+
+def test_width_bucket_is_stable_across_nearby_batches():
+    """Shape churn guard: batches inside one power-of-two bucket share W."""
+    widths = {mask_row_width(np.array([n], dtype=np.int32)) for n in (1100, 1500, 2048)}
+    assert widths == {2048}

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -308,6 +308,11 @@ suites = {
             runner="pytest",
         ),
         TestFile(
+            "python/sgl_jax/test/test_verify_mask_packing.py",
+            0.1,
+            runner="pytest",
+        ),
+        TestFile(
             "python/sgl_jax/test/multimodal/test_qwen_vl_processor.py",
             0.1,
             runner="pytest",
@@ -468,6 +473,11 @@ suites = {
         TestFile(
             "python/sgl_jax/test/layers/test_lightning_backend_dp.py",
             1,
+            runner="pytest",
+        ),
+        TestFile(
+            "python/sgl_jax/test/test_flashattention_custom_mask_dp.py",
+            2,
             runner="pytest",
         ),
         TestFile("python/sgl_jax/test/test_kda_attention.py", 6.5),


### PR DESCRIPTION
EAGLE speculative decoding drafts a **tree** of candidate tokens, not a chain. Sibling
branches sit next to each other in the KV cache but represent mutually exclusive futures
and must not see each other — a causal mask cannot express that, so target-verify passes
an explicit boolean mask over (draft token, kv position).

Today each bit of that mask is blown up to `head_dim` int32s — **512 bytes per bit** —
and the kernel reads back only lane 0 of each. The wasted bytes are the visible half of
the problem. The expensive half is that this layout lands kv on the VMEM **sublane**
axis while the consumer needs it on the **lane** axis, so every `(bq, bkv)` block pays a
scalarized sublane→lane transpose. On v6e that makes the masked path **61x slower than
causal verification at the same shape**, and ~98% of the gap is one line.

This PR stores the mask as `[total_q_rows, 1, W]` — one int32 per bit, kv on the lane
axis. The transposing read becomes a plain 2-D slice, the per-q-row DMA loop collapses
into two tiled copies, and the VMEM double buffer shrinks ~128x.

**9.2280 ms → 0.1677 ms (55x), output bitwise identical.**

## Motivation

`custom_mask` exists only for `topk > 1` — both producers are gated on it
(`eagle_draft_worker.py:130` and `:415`) — and the E2E speculative test has pinned topk to
1 since EAGLE support landed in #378 (2025-11-19). `test/srt/test_speculative_decoding.py:52`:

```python
# FIXME(pc) topk > 1 has poor performance now, change it when build_tree_mask_for_draft_decode kernel is  implemented
"--speculative-eagle-topk",
"1",
```

So the masked path is not reached by the default configuration today, which is also why a
61x regression on it could sit here unnoticed.

**This PR does not claim to unblock `topk > 1`.** That FIXME points at a different
component — the host-side `build_tree_mask_for_draft_decode`, still pure numpy — while the
cost measured in this PR is a separate one inside the target-verify attention kernel. There
is at least one further obstacle beyond both. This change removes the one that was located
and measured; whether that is sufficient is not established, and the change stands on its
own terms either way.

### Why the old layout is slow

`custom_mask` is expanded along `head_dim` on the way in (`ragged_paged_attention_v3.py:1799`),
so the VMEM scratch is `(2, bq_sz, bkv_sz, head_dim)` int32. TPU tiles the two minormost
dims, which decides which axis everything lands on:

```
BEFORE   bkvmask_ref[2, bq, bkv, head_dim] int32        tile (8,128) over (bkv, head_dim)

                     lane ────────────────────────►  head_dim: 128 copies of ONE bit
                                                        (one q row shown; bq is a
                                                         separate leading dim)
                        ┌─────┬─────┬─────┬ ─ ─ ┬─────┐
   s   kv = 0           │ b0  │ b0  │ b0  │     │ b0  │
   u   kv = 1           │ b1  │ b1  │ b1  │     │ b1  │
   b   kv = 2           │ b2  │ b2  │ b2  │     │ b2  │
   l     ...            │ ... │ ... │ ... │     │ ... │
   a   kv = 511         │b511 │b511 │b511 │     │b511 │
   n                    └─────┴─────┴─────┴ ─ ─ ┴─────┘
   e                       ▲
   │                       └── the kernel reads only this ONE column:  [..., 0]
   ▼

   but the consumer needs   s = [bq*heads, bkv_csz]   with kv on the LANE axis,
   i.e. exactly the transpose of what is stored.  So `[..., 0]` is not "read one
   element" — it is a sublane→lane relayout:

        8 target VREGs (32 KiB)   ←   touching 1024 source VREGs (4 MiB)
        amplification = head_dim = 128        Mosaic has no vector op for this
                                              shape, so it scalarizes.


AFTER    bkvmask_ref[2, bq, 1, bkv] int32               tile (1,128) over (1, bkv)

                     lane ────────────────────────►  kv: 128 DIFFERENT positions
                        ┌─────┬─────┬─────┬ ─ ─ ┬─────┐
       q row 0          │ b0  │ b1  │ b2  │     │b511 │  ← same 512 bits as above
       q row 1          │ c0  │ c1  │ c2  │     │c511 │  ← next q row's bits
         ...            │ ... │ ... │ ... │     │ ... │
                        └─────┴─────┴─────┴ ─ ─ ┴─────┘

   already in the layout the consumer wants.  The read becomes a plain 2-D slice;
   indexing 0 on the size-1 axis is a squeeze, not a relayout.
```

Supporting arithmetic: 143 µs to move 4 MiB implies ~29 GB/s, which is ~50x below this
chip's *HBM* bandwidth and orders below VMEM. No streaming read is that slow. This is
also the only place in the kernel that indexes the minormost dim with a scalar; every
other VMEM read goes through `strided_load` (`:796-807`), reshaping to 128 lanes and
slicing only sublanes.

An isolation run pins ~98% of the gap to this one read. The load-bearing arm keeps the
mask DMA, the whole 8 MiB scratch and the dynamic semaphore and query offsets, and changes
only which axis the values are read from — it lands within noise of removing the mask
branch entirely. So the DMA, the HBM traffic, the VMEM footprint and the dynamic
addressing are each independently exonerated.

## Modifications

* **The q row index moves to the leading dim.** Mosaic's slice-alignment check only
  inspects the last `tile_rank` dims, so a dynamic, unaligned row start is legal by
  construction. The rank-2 alternative needs a `pl.multiple_of` promise on a row offset
  derived from SMEM, and under `disable_bounds_checks=True` a wrong promise is a silent
  miscompile rather than a fault — not needing one is worth more than the line count
  suggests. (Verified on hardware: the rank-3 form compiles with an unaligned row start;
  the rank-2 equivalent is rejected.)
* **`_fetch_mask` collapses** from a per-q-row `fori_loop` issuing `2*load_q_sz` async
  copies into two tiled DMAs.
* **`get_vmem_estimate_bytes` now charges `2*bq*bkv*32` bits.** A `(R, 1, W)` int32
  scratch was measured to reach exactly `R*W*4` bytes, i.e. the size-1 second-minor axis
  takes a `(1, 128)` tile and costs no sublane padding. Leaving the old formula alone
  would have kept the block search charging 128x for a buffer that no longer exists and
  silently handed back much of the win.
* **Host side**, `flashattention_backend` packs every row to one power-of-two width
  `>= max(aligned_seq_lens)`. A rectangle needs a single width; rounding to a power of two
  keeps the number of distinct traced shapes at `O(log max_context_len)` rather than one
  per batch.
* Since kv now lives on the lane axis, **`bkv_alignment` is raised to 128** on the masked
  path, and `run_rpa_kernel` rejects non-128-aligned kv blocks outright — a tuned-table
  hit bypasses `get_default_block_sizes`, and failing loudly beats miscompiling.

### Behavior changes worth flagging

* **One shared buffer outside the mask path changes shape.** `zero_mask` is materialized
  and passed on every call, mask or not, and goes from `(bkv_sz, head_dim)` to
  `(bq_sz, 1, bkv_sz)` — e.g. 512 KiB to 64 KiB at `bkv=1024`. It is never read without a
  mask, so this is a smaller unconditional allocation and no semantic change, but it is the
  one place this PR touches the non-mask path. Making it conditional (as `custom_mask`
  already is) would be a non-mask-path change needing its own justification, so it is left
  alone here.
* **`custom_mask` is now rank-3 and validated at entry, and one producer does not match it.**
  The draft-decode path (`eagle_draft_worker.py:415`) sets `forward_metadata.custom_mask`
  directly in the old flat form, bypassing the backend repack, and would now hit a clear
  `ValueError`. Worth being precise that this is not a regression, because that mask has never
  reached the kernel by two independent routes: the call raises `TypeError` first (it passes
  `parents_list=None` into a builder whose first statement is `len(parents_list)`,
  `eagle_util.py:96`), and even without that, the object it writes to is replaced three lines
  before the first forward — `draft_forward` does
  `attn_backend.forward_metadata = metadata_per_step[i]` (`:512`), and
  `get_eagle_multi_step_metadata` builds a fresh `FlashAttentionMetadata()` that never sets
  `custom_mask`. Reviving that path needs a per-step restructure of `draft_forward`, not an
  ABI patch, so updating the producer here would only add a third dead form.
* **The trace-timing helper now warns on a `task` regex miss.** That string has to equal the
  `pallas_call` name; on a miss the extractor quietly fell back to host-side MARKER events
  instead of `device_duration_ps`. The two are not comparable — timing one configuration
  through each path produces a ratio that looks like a real effect and is not. Found the hard
  way while adding the masked benchmark in the first commit.

## Accuracy Tests

Three independent layers:

1. **Bitwise identity against the previous commit.** Same inputs, same bits carried, only
   the storage changed — so `max|delta| == 0.0` is the acceptance criterion, not a tolerance.
   Holds on uniform, **ragged** (`kv_len` 512..2048 within one batch — the only shape where
   a pad-to-max packing bug can show), and `q_len=16`.
2. **Existing masked accuracy tests** (`test_flashattention_mha.py`, `test_flashattention_gqa.py`,
   `-k custom_mask`) pass. These compare against `ref_ragged_paged_attention`, which still
   consumes the **flat** mask and recomputes its own `cumsum(q_len*kv_len)` offsets. The test
   helper derives the rank-3 view separately on purpose: if the oracle also learned about
   rectangles, the tests would be comparing a padding bug against itself.
3. **New CPU test for the host repack** (`test_verify_mask_packing.py`, in `unit-test-cpu`).
   That repack is the only production producer of this array and had no coverage at all,
   while its failure mode — one sequence reading another's mask — is silent. The test pins
   the invariant the kernel relies on (row index == per-DP-rank cumulative q-token index) and
   covers padding slots between live slots, `dp=2`, and the width bucketing.
4. **New 4-chip test** (`test_flashattention_custom_mask_dp.py`, in `unit-test-tpu-v6e-4`).
   The mask is sharded `P("data")`, so rank `r` gets a contiguous block of
   `per_dp_bs * draft_token_num` rows while the kernel addresses rows through the
   *rank-local* `cu_q_lens`. If those disagree one rank reads another's mask, silently.
   Worth stating plainly: **`dp > 1` with a mask had no hardware coverage before this PR
   either** — `test_flashattention_dp.py` is not registered in any suite, and
   `unit-test-tpu-v6e-4` contained no flashattention test at all. This PR changes the rank
   of the sharded array (1-D to 3-D), which is exactly the kind of thing that contract can
   break on, so it should not stay untested. The test runs the same ragged batch at `dp=4`
   and on a single chip with block sizes pinned, and requires the outputs to agree; every
   sequence gets its own random mask, so any cross-rank mix-up changes the result.

The split between the two new tests is deliberate. With no padding slots the packed array
is byte-identical at `dp=1` and `dp=4`, so the 4-chip test exercises the **sharding**
contract; padding slots, where the two layouts do diverge, are what the CPU test covers.
Both build their mask through `_pack_verify_mask` rather than by hand, so neither is
checking the layout against the test's own idea of it.

## Benchmarking and Profiling

v6e-1, jax 0.10.2 / libtpu 0.0.42.1. `bs16 x q_len8 x prefix2040`, page 128,
32 q-heads / 8 kv-heads, head_dim 128, bf16, blocks `(16,512,16,512)` (64 blocks).
Times are `device_duration_ps` from the trace, via this repo's own tuner.

| | time | µs / (bq,bkv) block | VMEM estimate |
|---|---|---|---|
| before (`HEAD~1`) | 9.2280 ms | 144.2 | 18.38 MiB |
| **after (`HEAD`)** | **0.1677 ms** | **2.6** | **10.44 MiB** |
| causal reference (`causal=1`) | 0.1519 ms | 2.4 | 10.38 MiB |

**55.0x.** The masked path now costs **10% more than causal verification** instead of
61x more. (The causal row is a reference point, not a no-op: it still applies a mask,
just one computed in registers with `tpu.iota`, already in the right layout.)

The VMEM estimate lines up exactly with the buffers: `18.38 − 10.44 = 7.94 MiB` is the
old mask double buffer (`2*16*512*128*4` = 8.0 MiB), and `10.44 − 10.38 = 0.06 MiB` is
the new one (`2*16*1*512*4` = 64 KiB).

### Reproducing

The benchmark lands in the **first commit** precisely so the before/after comes from one
command. No benchmark in this repo previously exercised a non-None `custom_mask`:
`bench_flashattention.py`, `tune_target_verify_v3.py` and `get_block_spec_config_v3.py`
all passed `custom_mask=None`, so the tuned block-size tables are measured on causal
verification only and this gap was invisible.

```bash
cd benchmark/kernels/flash_attention
python tune_target_verify_v3.py --batch-size 16 --draft-token-num 8 \
  --prefix-len 2040 --page-size 128 --q-head-num 32 --kv-head-num 8 \
  --head-dim 128 --candidate 16,512,16,512 --custom-mask
```

Run it at `HEAD~1` for the baseline and at `HEAD` for the result; drop `--custom-mask`
for the causal reference.

Two things are **not** in those numbers, and are not claimed:

* The `jnp.repeat` this PR removes runs *outside* `pallas_call`, so its cost was never
  part of the measured kernel time. On this config it materialized `262144 x 128` int32
  = **128 MiB** in HBM per call. That disappears too.
* The host-side repack and its blocking `device_get` were not measured. The new packing
  allocates `padded_bs * draft_token_num * W * 4` bytes, where `W` is the power-of-two
  round-up of the batch's largest aligned kv length (`mask_row_width`). The old packing
  concatenated per-slot chunks at each slot's own aligned length. On a uniform full batch
  the two are within 2x; on a ragged or heavily padded batch the rectangle is larger,
  because padding slots still occupy rows and one long request sets `W` for every row.
  What that buys is shape stability: `W` has one traced shape per context-length bucket,
  whereas the old `max_len` moved with batch composition, so its shape count was bounded
  only by the number of length combinations a batch could take. Nothing warms these up --
  `precompile_spec_decode` varies batch size only, over a dummy batch with `seq_lens = 1`
  -- so every distinct width costs a first-request compile.

## Follow-ups

Each of these lands as its own PR right after this one. They are split out because bundling
them would make this diff harder to review or would confound the measurement above — not
because they are optional. Listed in the order they will be sent:

1. **Drop `cu_seq_mask_lens` from the scalar prefetch tuple.** It has no consumer after this
   change (the rectangle is uniform, so a row index is just the global q-token index), but
   removing it means renumbering `input_output_aliases`, whose failure mode is silent buffer
   mis-donation. That is far easier to review as a diff containing nothing else.
2. **Remove the `bq_sz <= 16` cap for custom masks** (`:1563-1566`). Its stated reason —
   *"Custom-mask intermediates exceed v5/v6 scoped VMEM with a 32-row query tile"* — no longer
   holds once that intermediate drops from 16 MiB to 64 KiB. Lifting it changes the chosen
   block sizes, so it needs its own before/after rather than moving the numbers above.
3. **Have the tree kernel emit the final layout, and drop the host round-trip.**
   `build_eagle_tree_structure_kernel.py:367-371` allocates the mask `(capacity, 128)` int32
   and returns `tree_mask[:, 0]` at `:407`, discarding 127 of every 128 words: a Pallas store
   wants a full 128-lane minor dim, and a flat `(capacity,)` output is not directly
   expressible. The flat result is then pulled to the host (`flashattention_backend.py:391`,
   a blocking `device_get`), repacked into the rectangle with numpy (`:398`), and pushed back
   (`:401`), once per target-verify step.

   Kept separate because it changes the output contract of a kernel whose golden test
   (`test_eagle_tree_build.py`) gates merges, and because the host round-trip predates this
   PR -- folding it in would mix a pre-existing cost into this diff's measurement.
4. **The v1/v2 mirror kernel** (`ragged_paged_attention.py`) carries the same code and the same
   cost. It follows once this shape has settled in review.

**Beyond these.** The rectangle's width is set by the batch's longest sequence, but the
prefix columns carry no information: `build_eagle_tree_structure_kernel.py` initialises the
mask to all ones (`:20`, `:42`) and then only ever clears and re-sets the `draft_token_num`
draft columns (`:127-138`), so every draft token sees the whole committed prefix
unconditionally. Sending only the `q x q` corner would make `W` a constant 128 rather than
`pow2(max_kv)` -- less host memory, and, more usefully, a single traced shape instead of one
per context-length bucket, which the existing `seq_lens = 1` precompile batch would then
cover exactly. Upstream SGLang ships this as `TreeMaskMode.QLEN_ONLY`, with a bit-packed
variant on top. I have not prototyped it on this backend, so this is a direction, not a
commitment.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.


