### PR TITLE
docs(cookbook): make Markdown links GitHub-compatible

### DIFF
--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-R1.md
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-R1.md
@@ -15,7 +15,7 @@ title: "DeepSeek R1"
 - **MLA** — uses the FlashAttention Pallas MLA kernel by default; no extra flag needed.
 - **MoE with shared + routed experts** — 256 routed experts and 1 shared expert per MoE layer; first 3 layers are dense MLP. See §2.4 for the backend choice.
 - **FP8 block-quant compatibility** — the per-rank `out_dim` of the shared expert `gate_proj` / `up_proj` must be **strictly greater than** `block_size_out=128`. This forces the v6e-64 mesh shape and is why `--dp-size 8` (effective tensor axis 8) is recommended over `--dp-size 4` (tensor axis 16, which collides with the block size — see §2.4).
-- Reasoning surface needs `--reasoning-parser deepseek-r1` at launch — see [§3.2](/autoregressive/DeepSeek/DeepSeek-R1#3-2-reasoning-thinking-enabled-streaming) for the streaming pattern.
+- Reasoning surface needs `--reasoning-parser deepseek-r1` at launch — see [§3.2](../../autoregressive/DeepSeek/DeepSeek-R1.md#3-2-reasoning-thinking-enabled-streaming) for the streaming pattern.
 
 **Recommended Generation Parameters**: `temperature=0.6`, `top_p=0.95`, `max_tokens=4096+` (give room for thinking).
 
@@ -30,11 +30,11 @@ title: "DeepSeek R1"
 | **v7x-16** | 2x2x4 | 4 | 16 chips / 32 devices | 32 | 4 | 8 | 32 | Launch and benchmark template in §4.2. v7x exposes 2 JAX devices/chip; keep tensor axis 8 for the FP8 block-quant and MLA layout. |
 | **v6e-64** | 8x8 | 16 | 64 | 64 | 8 | 8 | 64 | This is the slice we measured on. `dp=8` required for FP8 shared-expert block-quant compatibility (`2048/8=256 > 128 = block_size`); `dp=4` silently collapses. Dense MLP block-quant scale grid `(144, 56)` further requires `144 % tensor == 0`, so tensor=8 is the only working option. HBM is tight at `dp=8`; see §2.4 Memory Management. |
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install). Multi-host required — use [GKE Indexed Job launcher](/deployment/gke-indexed-job) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](/deployment/skypilot).
+Install per [Install guide](../../get_started/install.md). Multi-host required — use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](../../deployment/skypilot.md).
 
 For evaluation, additionally install `evalscope` in the client environment:
 
@@ -46,7 +46,7 @@ pip install evalscope==0.17.1
 
 #### Multi-host — TPU v6e-64
 
-Use [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=deepseek-r1`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=8x8`, `parallelism: 16`, `completions: 16`, and `backoffLimit: 16` (transient GKE control-plane blips happen; a non-zero backoff lets the job survive). Put these model-specific flags into `<LAUNCH_FLAGS>`:
+Use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) with `<JOB>=deepseek-r1`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=8x8`, `parallelism: 16`, `completions: 16`, and `backoffLimit: 16` (transient GKE control-plane blips happen; a non-zero backoff lets the job survive). Put these model-specific flags into `<LAUNCH_FLAGS>`:
 
 ```bash
   --model-path deepseek-ai/DeepSeek-R1 \
@@ -65,12 +65,12 @@ Use [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=deepseek
 
 Mount a shared `JAX_COMPILATION_CACHE_DIR` on the same PVC as the model weights — first-time compile is ~4 minutes total (EXTEND ~70 s + DECODE ~3 min); subsequent restarts with the same mesh shape skip almost all of that.
 
-For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/deployment/skypilot) with the same launch flags.
+For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](../../deployment/skypilot.md) with the same launch flags.
 
 ### 2.4 Configuration Tips
 
 **Reasoning Parser:**
-- `--reasoning-parser deepseek-r1` is **required** for R1 — without it, the model's `<think>` content stays inline in `content` instead of being split into `reasoning_content`. See [§3.2](/autoregressive/DeepSeek/DeepSeek-R1#3-2-reasoning-thinking-enabled-streaming) for the streaming pattern.
+- `--reasoning-parser deepseek-r1` is **required** for R1 — without it, the model's `<think>` content stays inline in `content` instead of being split into `reasoning_content`. See [§3.2](../../autoregressive/DeepSeek/DeepSeek-R1.md#3-2-reasoning-thinking-enabled-streaming) for the streaming pattern.
 
 **Tensor/Data Mesh Layout:**
 - Mesh shape is `Mesh(data=dp_size, tensor=tp_size/dp_size)`. On v6e-64 with `--tp-size 64 --dp-size 8`, the tensor axis is **8**.
@@ -98,13 +98,13 @@ For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/dep
 - `JAX_COMPILATION_CACHE_DIR` is mandatory — without it, first request blocks ~4 min per node and is repeated on every restart.
 - Mount a shared PVC at the cache directory to amortize compilation across all 16 nodes and across pod restarts. Mesh shape (`data × tensor`) is part of the cache key; changing `--dp-size` invalidates the cache.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage). For thinking + content streaming see §3.2.
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md). For thinking + content streaming see §3.2.
 
 Short Python OpenAI client example (replace `<rank0-ip>` with your rank-0 internal IP; give `max_tokens` room for the thinking trace):
 
@@ -172,7 +172,7 @@ Let me verify: 10% of 240 is 24, 5% is 12, so 15% = 24 + 12 = 36. ✓
 
 For non-streaming requests, the field appears on `response.choices[0].message.reasoning_content` and `response.choices[0].message.content`.
 
-> R1 does not ship with a native tool-call format. For tool-call workloads, see the **Parser key reference** in [Parser key reference](/autoregressive#parser-key-reference) for the list of cookbook recipes with tool-call parsers registered.
+> R1 does not ship with a native tool-call format. For tool-call workloads, see the **Parser key reference** in [Parser key reference](../../autoregressive/index.md#parser-key-reference) for the list of cookbook recipes with tool-call parsers registered.
 
 ## 4. Benchmark
 
@@ -192,7 +192,7 @@ For non-streaming requests, the field appears on `response.choices[0].message.re
 | Reasoning Parser | deepseek-r1 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](/autoregressive/DeepSeek/DeepSeek-R1#2-3-launch).
+**Deployment Command** — same as [§2.3](../../autoregressive/DeepSeek/DeepSeek-R1.md#2-3-launch).
 
 **Benchmark Command**
 
@@ -275,5 +275,5 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
 ## Additional Resources
 
 - [DeepSeek-R1 model card](https://huggingface.co/deepseek-ai/DeepSeek-R1)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V2.md
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V2.md
@@ -27,11 +27,11 @@ title: "DeepSeek V2"
 |---|---|---|---|---|---|---|---|
 | DeepSeek-V2-Lite | **v6e-4**  | 2x2 | 1 | 4  | 4  | 4  | This is the slice we measured on. BF16 ~32 GB — single host. |
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install). For V2-Lite single-host use [Single-host Docker template](/deployment/single-host-docker).
+Install per [Install guide](../../get_started/install.md). For V2-Lite single-host use [Single-host Docker template](../../deployment/single-host-docker.md).
 
 ### 2.3 Launch
 
@@ -71,13 +71,13 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
 **Compilation Cache Hygiene:**
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min per node.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage).
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md).
 
 Short Python OpenAI client example (replace `<rank0-ip>` with your rank-0 internal IP):
 
@@ -112,7 +112,7 @@ print(resp.choices[0].message.content)
 
 > **Use the `-Chat` checkpoint for accuracy eval.** The base `DeepSeek-V2-Lite` ships without a chat template; evalscope's few-shot GSM8K prompt loops indefinitely against `/v1/chat/completions` (observed 0.014 score, `finish_reason: length`). The instruct-tuned `DeepSeek-V2-Lite-Chat` has the chat template and parses `\nThe answer is X` reliably.
 
-**Deployment Command** — same as [§2.3](/autoregressive/DeepSeek/DeepSeek-V2#2-3-launch) but swap `--model-path` to `deepseek-ai/DeepSeek-V2-Lite-Chat`.
+**Deployment Command** — same as [§2.3](../../autoregressive/DeepSeek/DeepSeek-V2.md#2-3-launch) but swap `--model-path` to `deepseek-ai/DeepSeek-V2-Lite-Chat`.
 
 **Benchmark Command** — example for GSM8K:
 
@@ -162,5 +162,5 @@ Mean TPOT (ms):                          7.41
 ## Additional Resources
 
 - [DeepSeek-V2-Lite model card](https://huggingface.co/deepseek-ai/DeepSeek-V2-Lite)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.md
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.md
@@ -30,11 +30,11 @@ title: "DeepSeek V3"
 | **v7x-16** | 2x2x4 | 4 | 16 chips / 32 devices | 32 | 4 | 8 | 32 | Launch and benchmark template in §4.2. v7x exposes 2 JAX devices/chip; keep tensor axis 8 for the FP8 block-quant and MLA layout. |
 | **v6e-64** | 8x8 | 16 | 64 | 64 | 8 | 8 | 64 | This is the slice we measured on. `dp=8` is required for FP8 shared-expert block-quant compatibility (`2048/8=256 > 128 = block_size`); `dp=4` silently collapses. HBM is tight at `dp=8`; see §2.4 Memory Management. |
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install). Multi-host required — use [GKE Indexed Job launcher](/deployment/gke-indexed-job) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](/deployment/skypilot).
+Install per [Install guide](../../get_started/install.md). Multi-host required — use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](../../deployment/skypilot.md).
 
 For evaluation, additionally install `evalscope` in the client environment (any host that can reach the served `:30000` port — typically a port-forwarded client laptop):
 
@@ -46,7 +46,7 @@ pip install evalscope==0.17.1
 
 #### Multi-host — TPU v6e-64
 
-Use [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=deepseek-v3`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=8x8`, `parallelism: 16`, `completions: 16`, and `backoffLimit: 16` (transient GKE control-plane blips happen; a non-zero backoff lets the job survive). Put these model-specific flags into `<LAUNCH_FLAGS>`:
+Use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) with `<JOB>=deepseek-v3`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=8x8`, `parallelism: 16`, `completions: 16`, and `backoffLimit: 16` (transient GKE control-plane blips happen; a non-zero backoff lets the job survive). Put these model-specific flags into `<LAUNCH_FLAGS>`:
 
 ```bash
   --model-path deepseek-ai/DeepSeek-V3 \
@@ -64,7 +64,7 @@ Use [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=deepseek
 
 Mount a shared `JAX_COMPILATION_CACHE_DIR` on the same PVC as the model weights — first-time compile is ~4 minutes total (EXTEND ~70 s + DECODE ~3 min); subsequent restarts with the same mesh shape skip almost all of that.
 
-For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/deployment/skypilot) with the same launch flags.
+For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](../../deployment/skypilot.md) with the same launch flags.
 
 ### 2.4 Configuration Tips
 
@@ -89,13 +89,13 @@ For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/dep
 - `JAX_COMPILATION_CACHE_DIR` is mandatory — without it, first request blocks ~4 min per node and is repeated on every restart.
 - Mount a shared PVC at the cache directory to amortize compilation across all 16 nodes and across pod restarts. Mesh shape (`data × tensor`) is part of the cache key; changing `--dp-size` invalidates the cache.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage).
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md).
 
 Short Python OpenAI client example (replace `<rank0-ip>` with your rank-0 internal IP):
 
@@ -114,7 +114,7 @@ resp = client.chat.completions.create(
 print(resp.choices[0].message.content)
 ```
 
-> DeepSeek V3 is non-reasoning and has no native tool-call format. For those workloads, see the **Parser key reference** in [Parser key reference](/autoregressive#parser-key-reference) for the list of cookbook recipes with reasoning / tool-call parsers registered.
+> DeepSeek V3 is non-reasoning and has no native tool-call format. For those workloads, see the **Parser key reference** in [Parser key reference](../../autoregressive/index.md#parser-key-reference) for the list of cookbook recipes with reasoning / tool-call parsers registered.
 
 ## 4. Benchmark
 
@@ -133,7 +133,7 @@ print(resp.choices[0].message.content)
 | Expert Parallelism | 64 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](/autoregressive/DeepSeek/DeepSeek-V3#2-3-launch).
+**Deployment Command** — same as [§2.3](../../autoregressive/DeepSeek/DeepSeek-V3.md#2-3-launch).
 
 **Benchmark Command**
 
@@ -216,5 +216,5 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
 
 - [DeepSeek-V3 model card](https://huggingface.co/deepseek-ai/DeepSeek-V3)
 - [SGLang DeepSeek V3 guide](https://docs.sglang.io/docs/basic_usage/deepseek_v3)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/GLM/GLM-4.5.md
+++ b/docs/cookbook/autoregressive/GLM/GLM-4.5.md
@@ -26,17 +26,17 @@ title: "GLM-4.5"
 | GLM-4.5-Air (106B) | **v7x-4** | 2x2x1 | 1 | 4 chips / 8 devices | 8 | 8 | Recommended throughput recipe in §4.2. v7x exposes 2 JAX devices/chip. |
 | GLM-4.5-Air (106B) | **v6e-32** | 4x8 | 8  | 32 | 32 | 32 | This is the slice we measured on. BF16 ~210 GB. |
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install). Multi-host required — use [GKE Indexed Job launcher](/deployment/gke-indexed-job) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](/deployment/skypilot).
+Install per [Install guide](../../get_started/install.md). Multi-host required — use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](../../deployment/skypilot.md).
 
 ### 2.3 Launch
 
 #### Multi-host — TPU v6e-32
 
-Use [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=glm-4-5-air`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=4x8`, `parallelism: 8`, and `completions: 8`. Put these model-specific flags into `<LAUNCH_FLAGS>`:
+Use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) with `<JOB>=glm-4-5-air`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=4x8`, `parallelism: 8`, and `completions: 8`. Put these model-specific flags into `<LAUNCH_FLAGS>`:
 
 ```bash
   --model-path zai-org/GLM-4.5-Air \
@@ -54,7 +54,7 @@ Use [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=glm-4-5-
 
 > `--moe-backend epmoe` is mandatory for GLM-4.5-Air. The fused Pallas backend requires `moe_intermediate_size % 512 == 0`; GLM-4.5-Air's `moe_intermediate_size=1408` fails that alignment and crashes at startup (`tile_n` divisibility assert).
 
-For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/deployment/skypilot) with the same launch flags. The model recipe does not require users to run repository-local SkyPilot helper scripts.
+For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](../../deployment/skypilot.md) with the same launch flags. The model recipe does not require users to run repository-local SkyPilot helper scripts.
 
 ### 2.4 Configuration Tips
 
@@ -77,13 +77,13 @@ For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/dep
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min per node.
 - Mount a shared PVC across the cluster's nodes to amortize compilation.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage).
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md).
 
 Short Python OpenAI client example (replace `<rank0-ip>` with your rank-0 internal IP):
 
@@ -238,7 +238,7 @@ To see the full set of `--reasoning-parser` / `--tool-call-parser` keys availabl
 | Expert Parallelism | 32 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](/autoregressive/GLM/GLM-4.5#2-3-launch).
+**Deployment Command** — same as [§2.3](../../autoregressive/GLM/GLM-4.5.md#2-3-launch).
 
 **Benchmark Command** — example for GSM8K:
 
@@ -321,5 +321,5 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
 ## Additional Resources
 
 - [GLM-4.5-Air model card](https://huggingface.co/zai-org/GLM-4.5-Air)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/Google/Gemma2.md
+++ b/docs/cookbook/autoregressive/Google/Gemma2.md
@@ -30,11 +30,11 @@ title: "Gemma 2"
 |---|---|---|---|---|---|
 | Gemma 2 27B-it | **v6e-4** | 2x2 | 4 | 4 | This is the slice we measured on. BF16 ~54 GB — fits with `--mem-fraction-static 0.85` (~13.5 GB weights/chip + dual KV pools). |
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install) and use [Single-host Docker template](/deployment/single-host-docker) for the container setup.
+Install per [Install guide](../../get_started/install.md) and use [Single-host Docker template](../../deployment/single-host-docker.md) for the container setup.
 
 ### 2.3 Launch
 
@@ -69,19 +69,19 @@ The 27B-it `--mem-fraction-static 0.85` leaves room for the dual (global + slidi
 
 **Hybrid Attention (Gemma-specific):**
 - Gemma 2 alternates global (8K context) and sliding-window (4K) attention layers. SGL-JAX manages two KV pools — global and sliding — which is more memory-sensitive than uniform-attention models at the same parameter count.
-- `--swa-full-tokens-ratio` (default 0.8) controls the per-layer ratio of sliding-window vs full-attention layers and gates pool sizing. If you see sliding-window pool exhaustion at high concurrency, lower this ratio to give the sliding pool more capacity. See [troubleshooting §SWA pool exhaustion](/deployment/troubleshooting#swa-pool-exhaustion-mimo-hybrid-attention-models).
+- `--swa-full-tokens-ratio` (default 0.8) controls the per-layer ratio of sliding-window vs full-attention layers and gates pool sizing. If you see sliding-window pool exhaustion at high concurrency, lower this ratio to give the sliding pool more capacity. See [troubleshooting §SWA pool exhaustion](../../deployment/troubleshooting.md#swa-pool-exhaustion-mimo-hybrid-attention-models).
 
 **Compilation Cache Hygiene:**
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min while XLA/Pallas re-compiles.
 - The cache keys on full kernel shape: changing `--page-size`, `--tp-size`, or `--swa-full-tokens-ratio` invalidates cached entries.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage). Pass `top_k` via `extra_body={"top_k": 64}` since the OpenAI schema does not include it.
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md). Pass `top_k` via `extra_body={"top_k": 64}` since the OpenAI schema does not include it.
 
 Short Python OpenAI client example:
 
@@ -101,7 +101,7 @@ resp = client.chat.completions.create(
 print(resp.choices[0].message.content)
 ```
 
-> Gemma 2 is non-reasoning and has no native tool-call format. For those workloads, see the **Parser key reference** in [Parser key reference](/autoregressive#parser-key-reference) for the list of cookbook recipes with reasoning / tool-call parsers registered.
+> Gemma 2 is non-reasoning and has no native tool-call format. For those workloads, see the **Parser key reference** in [Parser key reference](../../autoregressive/index.md#parser-key-reference) for the list of cookbook recipes with reasoning / tool-call parsers registered.
 
 ## 4. Benchmark
 
@@ -118,7 +118,7 @@ print(resp.choices[0].message.content)
 | Tensor Parallelism | 4 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3 27B-it](/autoregressive/Google/Gemma2#2-3-launch).
+**Deployment Command** — same as [§2.3 27B-it](../../autoregressive/Google/Gemma2.md#2-3-launch).
 
 **Benchmark Command** — example for GSM8K:
 
@@ -190,5 +190,5 @@ Mean ITL (ms):                           14.48
 ## Additional Resources
 
 - [Gemma 2 27B-it model card](https://huggingface.co/google/gemma-2-27b-it)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues including the SWA pool exhaustion note.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues including the SWA pool exhaustion note.

--- a/docs/cookbook/autoregressive/Grok/Grok2.md
+++ b/docs/cookbook/autoregressive/Grok/Grok2.md
@@ -13,7 +13,7 @@ title: "Grok-2"
 **Key Features**:
 
 - **~269B MoE / ~70B active** — 8 experts, 2 active per token (25% active fraction); served via SGL-JAX `Grok1ForCausalLM` runtime. The validated v6e-64 path uses `--moe-backend epmoe`.
-- **Base model, not chat-tuned** — has no chat template; use the raw `/v1/completions` endpoint (see [§3.1](/autoregressive/Grok/Grok2#3-1-basic-text-completion-base-model)), not `/v1/chat/completions`. xAI did not release a chat / instruct variant.
+- **Base model, not chat-tuned** — has no chat template; use the raw `/v1/completions` endpoint (see [§3.1](../../autoregressive/Grok/Grok2.md#3-1-basic-text-completion-base-model)), not `/v1/chat/completions`. xAI did not release a chat / instruct variant.
 - **Pre-sharded TP=8 safetensors checkpoint** — files named `pytorch_model-NNNNN-TP-{000..007}.safetensors`. The 8 per-expert/per-shard files imply the checkpoint expects **TP to be a multiple of 8** when serving (matches `--ep-size 8` for the MoE experts).
 - **GQA attention** — `num_attention_heads=64`, `num_key_value_heads=8` → 8 KV heads (sharding constraint: tensor axis must divide 8).
 - **Long context** — `max_position_embeddings=131072` (128K tokens native).
@@ -35,11 +35,11 @@ title: "Grok-2"
 
 **Pre-sharded TP=8 constraint**: the checkpoint files are named `pytorch_model-NNNNN-TP-{000..007}.safetensors` — `--tp-size` must be a multiple of 8 so the loader can map each pre-shard onto a contiguous device slice. v6e-64 (`tp=64=8×8`) satisfies this.
 
-For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies) — the `--tp-size = chip_count × devices_per_chip` and `tp_size % 8 == 0` rules carry over directly.
+For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies) — the `--tp-size = chip_count × devices_per_chip` and `tp_size % 8 == 0` rules carry over directly.
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install). **Build pin**: use sglang-jax 0.1.0 or later. For multi-host serving, use [GKE Indexed Job launcher](/deployment/gke-indexed-job) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](/deployment/skypilot).
+Install per [Install guide](../../get_started/install.md). **Build pin**: use sglang-jax 0.1.0 or later. For multi-host serving, use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](../../deployment/skypilot.md).
 
 The community tokenizer is downloaded on first launch — no extra pip needed beyond standard install. For evaluation, additionally install `evalscope`:
 
@@ -51,7 +51,7 @@ pip install evalscope==0.17.1
 
 #### Multi-host — TPU v6e-64
 
-Use [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=grok-2`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=8x8`, `parallelism: 16`, `completions: 16`, and `backoffLimit: 16`. Put these model-specific flags into `<LAUNCH_FLAGS>`:
+Use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) with `<JOB>=grok-2`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=8x8`, `parallelism: 16`, `completions: 16`, and `backoffLimit: 16`. Put these model-specific flags into `<LAUNCH_FLAGS>`:
 
 ```bash
   --model-path /models/grok-2 \
@@ -71,7 +71,7 @@ Use [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=grok-2`,
 
 Mount a shared `JAX_COMPILATION_CACHE_DIR` on the same PVC as the model weights — first cold compile is ~5-10 min, much faster than 1T-class models since the MoE kernel shape sweep is smaller.
 
-For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/deployment/skypilot) with the same launch flags. The model recipe does not require users to run repository-local SkyPilot helper scripts.
+For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](../../deployment/skypilot.md) with the same launch flags. The model recipe does not require users to run repository-local SkyPilot helper scripts.
 
 ### 2.4 Configuration Tips
 
@@ -102,13 +102,13 @@ For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/dep
 - `JAX_COMPILATION_CACHE_DIR` is mandatory — without it, first request blocks ~5-10 min per node (smaller than 1T-class models but still non-trivial).
 - On multi-node clusters, mount a shared PVC at the cache directory so all 16 nodes share warmups. Mesh shape (`data × tensor`) is part of the cache key; changing `--tp-size` or `--ep-size` invalidates the cache.
 
-For full flag definitions and defaults see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions and defaults see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Text Completion (base model)
 
-For the standard cURL / Python `requests` / OpenAI client / native `/generate` patterns see [Basic API usage](/base/basic-api-usage). Grok-2 is a base model with no chat template — use the raw `/v1/completions` endpoint, not `/v1/chat/completions`. Replace `127.0.0.1` with your rank-0 internal IP:
+For the standard cURL / Python `requests` / OpenAI client / native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md). Grok-2 is a base model with no chat template — use the raw `/v1/completions` endpoint, not `/v1/chat/completions`. Replace `127.0.0.1` with your rank-0 internal IP:
 
 ```bash
 curl -X POST http://<rank0-ip>:30000/v1/completions \
@@ -139,7 +139,7 @@ print(resp.choices[0].text)
 
 > **Why not `/v1/chat/completions`?** Grok-2 has no chat template — sending `messages` either fails (no template registered) or wraps the prompt in a community-grafted template the model wasn't trained on. The community-template path looks superficially OK on single-turn sanity prompts but silently degrades accuracy on chat-format eval datasets: the model doesn't emit EOS at the end of a short answer and continues in-context with self-generated follow-ups (per design §6.F base models skip §4 Accuracy entirely).
 
-> Grok-2 has no hybrid reasoning or native tool-calling format. For those workloads, see the **Parser key reference** in [Parser key reference](/autoregressive#parser-key-reference) for the list of cookbook recipes with reasoning / tool-call parsers registered.
+> Grok-2 has no hybrid reasoning or native tool-calling format. For those workloads, see the **Parser key reference** in [Parser key reference](../../autoregressive/index.md#parser-key-reference) for the list of cookbook recipes with reasoning / tool-call parsers registered.
 
 ## 4. Benchmark
 
@@ -180,7 +180,7 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
 
 - [Grok-2 Model Card](https://huggingface.co/xai-org/grok-2)
 - [Community tokenizer](https://huggingface.co/alvarobartt/grok-2-tokenizer)
-- [GKE Indexed Job launcher](/deployment/gke-indexed-job) — primary multi-host launcher template.
-- [SkyPilot launcher](/deployment/skypilot) — advanced v6e experiment alternative.
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) — primary multi-host launcher template.
+- [SkyPilot launcher](../../deployment/skypilot.md) — advanced v6e experiment alternative.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/InclusionAI/Ling-2.6.md
+++ b/docs/cookbook/autoregressive/InclusionAI/Ling-2.6.md
@@ -28,11 +28,11 @@ title: "Ling 2.6"
 | Ling-2.6-1T | **v6e-64** | 8x8 | 16 | 64 | 64 | 8 | 64 | This is the slice we measured on. Trillion-scale; multi-host mandatory. `dp=8` required (GLA `num_groups=8` ≤ tensor axis); `--disable-radix-cache` required (hybrid recurrent state). |
 | Ling-2.6-1T | **v7x-16** | 2×2×4 | 4 | 16 | 32 | 8 | 32 | v7x exposes 2 JAX devices/chip, so `--tp-size` = 16 chips × 2 = 32. Runs the V2 fused MoE kernel (`--moe-backend fused_v2`). Same `dp=8` and `--disable-radix-cache` constraints as v6e-64. |
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install). **Build pin**: use sglang-jax 0.1.0 or later — earlier builds crash at weight load on Ling-2.6's compressed-tensors FP8 QKV split. Multi-host required — use [GKE Indexed Job launcher](/deployment/gke-indexed-job). Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](/deployment/skypilot).
+Install per [Install guide](../../get_started/install.md). **Build pin**: use sglang-jax 0.1.0 or later — earlier builds crash at weight load on Ling-2.6's compressed-tensors FP8 QKV split. Multi-host required — use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md). Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](../../deployment/skypilot.md).
 
 For evaluation, additionally install `evalscope` in the client environment:
 
@@ -68,7 +68,7 @@ python3 -u -m sgl_jax.launch_server \
 
 > `--moe-backend` is tunable — `epmoe` (megablox GMM), `fused` (Pallas fused MoE V1), or `fused_v2` (Pallas fused MoE V2, double-buffered); the fused kernels require full EP (`--ep-size` = `--tp-size`). See §2.4.
 
-On GKE, use the [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=ling-2-6`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=8x8`, `parallelism: 16`, `completions: 16`, and `backoffLimit: 16`; the launcher injects `--nnodes`, `--node-rank`, `--dist-init-addr`, `--host`, and `--port`, so drop those and put the remaining model flags into `<LAUNCH_FLAGS>`. For temporary v6e experiments, advanced users can adapt the [SkyPilot launcher](/deployment/skypilot) with the same flags.
+On GKE, use the [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) with `<JOB>=ling-2-6`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=8x8`, `parallelism: 16`, `completions: 16`, and `backoffLimit: 16`; the launcher injects `--nnodes`, `--node-rank`, `--dist-init-addr`, `--host`, and `--port`, so drop those and put the remaining model flags into `<LAUNCH_FLAGS>`. For temporary v6e experiments, advanced users can adapt the [SkyPilot launcher](../../deployment/skypilot.md) with the same flags.
 
 #### Multi-host — TPU v7x-16 (fused MoE V2)
 
@@ -134,13 +134,13 @@ All nodes must sit in the same TPU slice and reach each other on the `--dist-ini
 **Compilation Cache Hygiene:**
 - Set `JAX_COMPILATION_CACHE_DIR` to a shared path (same PVC across all nodes) to persist the JIT cache across restarts.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage). For thinking + content streaming see §3.2.
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md). For thinking + content streaming see §3.2.
 
 Short Python OpenAI client example (replace `<rank0-ip>` with your rank-0 internal IP):
 
@@ -204,7 +204,7 @@ For non-streaming requests, the field appears on `response.choices[0].message.re
 
 ### 4.1 Accuracy — GSM8K
 
-**Deployment Command** — launch a server per [§2.3 Launch](/autoregressive/InclusionAI/Ling-2.6#2-3-launch).
+**Deployment Command** — launch a server per [§2.3 Launch](../../autoregressive/InclusionAI/Ling-2.6.md#2-3-launch).
 
 **Benchmark Command**
 
@@ -232,7 +232,7 @@ evalscope eval \
 
 Sanity-checks the quantized fused-MoE serving path on competition math: AIME 2026 (`MathArena/aime_2026`, 30 problems, pass@1; extracted answers exact-matched against the reference). Point `test/srt/run_eval.py` at the served Ling-2.6-1T endpoint.
 
-**Deployment Command** — launch a server per [§2.3 Launch](/autoregressive/InclusionAI/Ling-2.6#2-3-launch).
+**Deployment Command** — launch a server per [§2.3 Launch](../../autoregressive/InclusionAI/Ling-2.6.md#2-3-launch).
 
 **Benchmark Command**
 
@@ -322,5 +322,5 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
 ## Additional Resources
 
 - [Ling-2.6-1T model card](https://huggingface.co/inclusionAI/Ling-2.6-1T)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/Llama/Llama3.1.md
+++ b/docs/cookbook/autoregressive/Llama/Llama3.1.md
@@ -24,11 +24,11 @@ For Llama 4 see the upstream sgl-cookbook (`Llama/Llama4.md`).
 |---|---|---|---|---|---|
 | Llama 3.1 8B-Instruct | **v6e-4** | 2x2 | 4 | 4 | This is the slice we measured on. BF16 ~16 GB — fits with headroom; single-host serving. |
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install) and use [Single-host Docker template](/deployment/single-host-docker) for the container setup.
+Install per [Install guide](../../get_started/install.md) and use [Single-host Docker template](../../deployment/single-host-docker.md) for the container setup.
 
 ### 2.3 Launch
 
@@ -63,13 +63,13 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
 **Compilation Cache Hygiene:**
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min while XLA/Pallas re-compiles.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage).
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md).
 
 Short Python OpenAI client example:
 
@@ -88,7 +88,7 @@ resp = client.chat.completions.create(
 print(resp.choices[0].message.content)
 ```
 
-> Llama 3 Instruct is non-reasoning and has no native tool-call format. For those workloads, see the **Parser key reference** in [Parser key reference](/autoregressive#parser-key-reference) for the list of cookbook recipes with reasoning / tool-call parsers registered.
+> Llama 3 Instruct is non-reasoning and has no native tool-call format. For those workloads, see the **Parser key reference** in [Parser key reference](../../autoregressive/index.md#parser-key-reference) for the list of cookbook recipes with reasoning / tool-call parsers registered.
 
 ## 4. Benchmark
 
@@ -105,7 +105,7 @@ print(resp.choices[0].message.content)
 | Tensor Parallelism | 4 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](/autoregressive/Llama/Llama3.1#2-3-launch).
+**Deployment Command** — same as [§2.3](../../autoregressive/Llama/Llama3.1.md#2-3-launch).
 
 **Benchmark Command** — example for GSM8K:
 
@@ -177,5 +177,5 @@ Mean ITL (ms):                           9.87
 ## Additional Resources
 
 - [Llama 3.1 8B-Instruct model card](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/Llama/Llama3.3-70B.md
+++ b/docs/cookbook/autoregressive/Llama/Llama3.3-70B.md
@@ -33,17 +33,17 @@ For Llama 4 see the upstream sgl-cookbook (`Llama/Llama4.md`).
 | Llama 3.3 70B | **v7x-4** | 2x2x1 | 1 | 4 chips / 8 devices | 8 | Recommended throughput recipe in §4.2. v7x exposes 2 JAX devices/chip. |
 | Llama 3.3 70B | **v6e-16** | 4x4 | 4 | 16 | 16 | This is the slice we measured on. BF16 ~140 GB — fits with `--mem-fraction-static 0.85` (~8.75 GB weights/chip + ample KV headroom). |
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install). Multi-host required — use [GKE Indexed Job launcher](/deployment/gke-indexed-job) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](/deployment/skypilot).
+Install per [Install guide](../../get_started/install.md). Multi-host required — use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](../../deployment/skypilot.md).
 
 ### 2.3 Launch
 
 #### Multi-host — TPU v6e-16
 
-Use [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=llama-70b`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=4x4`, `parallelism: 4`, and `completions: 4`. Put these model-specific flags into `<LAUNCH_FLAGS>`:
+Use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) with `<JOB>=llama-70b`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=4x4`, `parallelism: 4`, and `completions: 4`. Put these model-specific flags into `<LAUNCH_FLAGS>`:
 
 ```bash
   --model-path meta-llama/Llama-3.3-70B-Instruct \
@@ -58,7 +58,7 @@ Use [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=llama-70
   --skip-server-warmup
 ```
 
-For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/deployment/skypilot) with the same launch flags. The model recipe does not require users to run repository-local SkyPilot helper scripts.
+For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](../../deployment/skypilot.md) with the same launch flags. The model recipe does not require users to run repository-local SkyPilot helper scripts.
 
 ### 2.4 Configuration Tips
 
@@ -79,13 +79,13 @@ For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/dep
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min per node.
 - The cache is per-node; mount a shared PVC at the cache directory to amortize compilation across all 4 nodes.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage).
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md).
 
 Short Python OpenAI client example (replace `<rank0-ip>` with your rank-0 internal IP):
 
@@ -104,7 +104,7 @@ resp = client.chat.completions.create(
 print(resp.choices[0].message.content)
 ```
 
-> Llama 3 Instruct is non-reasoning and has no native tool-call format. For those workloads, see the **Parser key reference** in [Parser key reference](/autoregressive#parser-key-reference) for the list of cookbook recipes with reasoning / tool-call parsers registered.
+> Llama 3 Instruct is non-reasoning and has no native tool-call format. For those workloads, see the **Parser key reference** in [Parser key reference](../../autoregressive/index.md#parser-key-reference) for the list of cookbook recipes with reasoning / tool-call parsers registered.
 
 ## 4. Benchmark
 
@@ -121,7 +121,7 @@ print(resp.choices[0].message.content)
 | Tensor Parallelism | 16 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3 v6e-16](/autoregressive/Llama/Llama3.3-70B#2-3-launch).
+**Deployment Command** — same as [§2.3 v6e-16](../../autoregressive/Llama/Llama3.3-70B.md#2-3-launch).
 
 **Benchmark Command** — example for GSM8K:
 
@@ -200,5 +200,5 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
 ## Additional Resources
 
 - [Llama 3.3 70B model card](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-Linear.md
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-Linear.md
@@ -31,11 +31,11 @@ title: "Kimi-Linear"
 | Kimi-Linear-48B-A3B | **v6e-16** | 4x4 | 4 | 16 | 16 | One of two slices we measured on. BF16 ~96 GB — multi-host required to fit weights + recurrent state pool. |
 | Kimi-Linear-48B-A3B | **v6e-32** | 4x8 | 8 | 32 | 32 | The other slice we measured on. More HBM per active expert and larger recurrent state budget for long-prompt linear-attention workloads. |
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install). Multi-host recommended at this size — use [GKE Indexed Job launcher](/deployment/gke-indexed-job) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](/deployment/skypilot).
+Install per [Install guide](../../get_started/install.md). Multi-host recommended at this size — use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](../../deployment/skypilot.md).
 
 ### 2.3 Launch
 
@@ -46,7 +46,7 @@ Two slices we measured on, each as a separate launch path:
 
 #### Multi-host — TPU v6e-16
 
-Use [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=kimi-linear`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=4x4`, `parallelism: 4`, and `completions: 4`. Put these model-specific flags into `<LAUNCH_FLAGS>`:
+Use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) with `<JOB>=kimi-linear`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=4x4`, `parallelism: 4`, and `completions: 4`. Put these model-specific flags into `<LAUNCH_FLAGS>`:
 
 ```bash
   --model-path moonshotai/Kimi-Linear-48B-A3B-Instruct \
@@ -82,7 +82,7 @@ Same template with `<TOPOLOGY>=4x8`, `parallelism: 8`, `completions: 8`, and `--
   --skip-server-warmup
 ```
 
-For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/deployment/skypilot) with the same launch flags. The model recipe does not require users to run repository-local SkyPilot helper scripts.
+For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](../../deployment/skypilot.md) with the same launch flags. The model recipe does not require users to run repository-local SkyPilot helper scripts.
 
 ### 2.4 Configuration Tips
 
@@ -108,13 +108,13 @@ For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/dep
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min per node.
 - Mount a shared PVC across the cluster's 4 nodes to amortize compilation.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage). For long-context streaming see §3.2.
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md). For long-context streaming see §3.2.
 
 Short Python OpenAI client example (replace `<rank0-ip>` with your rank-0 internal IP):
 
@@ -162,7 +162,7 @@ for chunk in stream:
 print()
 ```
 
-> Kimi-Linear-Instruct ships with a chat template but no native reasoning or tool-call format. For reasoning / tool-call workloads, pick a model with `--reasoning-parser` / `--tool-call-parser` support — see the **Parser key reference** table in [Parser key reference](/autoregressive#parser-key-reference) for the list of cookbook recipes with reasoning / tool-call parsers registered.
+> Kimi-Linear-Instruct ships with a chat template but no native reasoning or tool-call format. For reasoning / tool-call workloads, pick a model with `--reasoning-parser` / `--tool-call-parser` support — see the **Parser key reference** table in [Parser key reference](../../autoregressive/index.md#parser-key-reference) for the list of cookbook recipes with reasoning / tool-call parsers registered.
 
 ## 4. Benchmark
 
@@ -180,7 +180,7 @@ print()
 | Recurrent State Memory Ratio | 0.9 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — see [§2.3](/autoregressive/Moonshotai/Kimi-Linear#2-3-launch) (v6e-16) or [§2.3](/autoregressive/Moonshotai/Kimi-Linear#2-3-launch) (v6e-32).
+**Deployment Command** — see [§2.3](../../autoregressive/Moonshotai/Kimi-Linear.md#2-3-launch) (v6e-16) or [§2.3](../../autoregressive/Moonshotai/Kimi-Linear.md#2-3-launch) (v6e-32).
 
 **Benchmark Command** — example for GSM8K:
 
@@ -224,5 +224,5 @@ v6e-32 delivers ~5% throughput / 13% TTFT improvement over v6e-16. Scaling is su
 ## Additional Resources
 
 - [Kimi-Linear model card](https://huggingface.co/moonshotai/Kimi-Linear-48B-A3B-Instruct)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/Qwen/Qwen.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen.md
@@ -6,7 +6,7 @@ title: "Qwen-7B-Chat"
 
 > **Validated recipe** — empirically validated on TPU v6e-4 with sglang-jax 0.1.0.
 >
-> First-generation Qwen recipe. For Qwen3-8B / Qwen3-32B see [Qwen3 recipe](/autoregressive/Qwen/Qwen3).
+> First-generation Qwen recipe. For Qwen3-8B / Qwen3-32B see [Qwen3 recipe](../../autoregressive/Qwen/Qwen3.md).
 
 ## 1. Model Introduction
 
@@ -30,11 +30,11 @@ title: "Qwen-7B-Chat"
 |---|---|---|---|---|
 | **v6e-4** | 2x2 | 4 | 4 | This is the slice we measured on. Single host; v6e is 1:1 chip↔device. |
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies). For larger Qwen sizes (8B / 32B) see [Qwen3 recipe](/autoregressive/Qwen/Qwen3).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies). For larger Qwen sizes (8B / 32B) see [Qwen3 recipe](../../autoregressive/Qwen/Qwen3.md).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install) and use [Single-host Docker template](/deployment/single-host-docker) for the container setup.
+Install per [Install guide](../../get_started/install.md) and use [Single-host Docker template](../../deployment/single-host-docker.md) for the container setup.
 
 Extra pip for accuracy benchmarking only:
 
@@ -75,13 +75,13 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -u -m sgl_jax.launch_server \
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min while XLA/Pallas re-compiles.
 - The cache keys on full kernel shape: changing `--page-size`, `--tp-size`, or context length invalidates cached entries.
 
-For full flag definitions and defaults see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions and defaults see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage).
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md).
 
 Short Python OpenAI client example:
 
@@ -100,7 +100,7 @@ resp = client.chat.completions.create(
 print(resp.choices[0].message.content)
 ```
 
-> Qwen-7B-Chat is a first-generation chat model without hybrid reasoning or native tool-calling formats. For reasoning / tool-call workloads use [Qwen3](/autoregressive/Qwen/Qwen3) or a later Qwen series.
+> Qwen-7B-Chat is a first-generation chat model without hybrid reasoning or native tool-calling formats. For reasoning / tool-call workloads use [Qwen3](../../autoregressive/Qwen/Qwen3.md) or a later Qwen series.
 
 ## 4. Benchmark
 
@@ -117,7 +117,7 @@ print(resp.choices[0].message.content)
 | Tensor Parallelism | 4 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3 Single-host](/autoregressive/Qwen/Qwen#2-3-launch).
+**Deployment Command** — same as [§2.3 Single-host](../../autoregressive/Qwen/Qwen.md#2-3-launch).
 
 **Benchmark Command**
 
@@ -144,7 +144,7 @@ evalscope eval \
 
 **Test Environment** — same as §4.1.
 
-**Deployment Command** — same as [§2.3 Single-host](/autoregressive/Qwen/Qwen#2-3-launch).
+**Deployment Command** — same as [§2.3 Single-host](../../autoregressive/Qwen/Qwen.md#2-3-launch).
 
 **Benchmark Command**
 
@@ -206,7 +206,7 @@ Max ITL (ms):                            154.39
 ## Additional Resources
 
 - [Qwen Model Cards](https://huggingface.co/Qwen)
-- [Qwen3 recipe](/autoregressive/Qwen/Qwen3) — newer Qwen3 8B/32B recipe with TPU benchmark rows.
+- [Qwen3 recipe](../../autoregressive/Qwen/Qwen3.md) — newer Qwen3 8B/32B recipe with TPU benchmark rows.
 - [JAX Scaling Book](https://jax-ml.github.io/scaling-book/)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/Qwen/Qwen2.5-VL.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen2.5-VL.md
@@ -17,7 +17,7 @@ title: "Qwen2.5-VL"
 - [**Qwen/Qwen2.5-VL-32B-Instruct**](https://huggingface.co/Qwen/Qwen2.5-VL-32B-Instruct) — 32B; validated on v7x-8 with `--tp-size 8 --dp-size 4`.
 - [**Qwen/Qwen2.5-VL-72B-Instruct**](https://huggingface.co/Qwen/Qwen2.5-VL-72B-Instruct) — 72B; multi-host serving is pending.
 
-For the text-only Qwen3 dense recipes see [Qwen3 recipe](/autoregressive/Qwen/Qwen3).
+For the text-only Qwen3 dense recipes see [Qwen3 recipe](./Qwen3.md).
 
 **Key Features**:
 
@@ -40,11 +40,11 @@ For the text-only Qwen3 dense recipes see [Qwen3 recipe](/autoregressive/Qwen/Qw
 
 The validated benchmark uses data-parallel vision-encoder placement. TP vision-encoder placement was separately verified on the same topology.
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices, see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices, see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install). For the current single-host VL path use [Single-host Docker template](/deployment/single-host-docker).
+Install per [Install guide](../../get_started/install.md). For the current single-host VL path use [Single-host Docker template](../../deployment/single-host-docker.md).
 
 Extra pip for accuracy benchmarking only:
 
@@ -102,7 +102,7 @@ The regular server recognizes the model's multimodal contract. The separate `--m
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` avoids recompiling the vision and autoregressive kernels after restart.
 - The cache keys on full kernel shape: changing `--page-size`, `--tp-size`, image resolution buckets, or `--context-length` invalidates cached entries.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference); run `python -m sgl_jax.launch_server --help` to see the available flags.
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md); run `python -m sgl_jax.launch_server --help` to see the available flags.
 
 ## 3. Invocation
 
@@ -230,7 +230,7 @@ print(response.choices[0].message.content)
 
 > **Long video / large image set:** Make sure `--context-length` is large enough to fit the vision token count plus the text prompt and response. Each high-resolution image and each sampled video frame contributes a non-trivial number of vision tokens to the prefill.
 
-> Qwen2.5-VL is non-reasoning (no `<think>` blocks) and does not ship a native tool-call format. For reasoning workloads use [Qwen3](/autoregressive/Qwen/Qwen3); for tool-calling workloads use a model with `--tool-call-parser` support (see [`Qwen3.md` §3.3](/autoregressive/Qwen/Qwen3#3-3-tool-calling)).
+> Qwen2.5-VL is non-reasoning (no `<think>` blocks) and does not ship a native tool-call format. For reasoning workloads use [Qwen3](./Qwen3.md); for tool-calling workloads use a model with `--tool-call-parser` support (see [`Qwen3.md` §3.3](./Qwen3.md#3-3-tool-calling)).
 
 ## 4. Benchmark
 
@@ -251,7 +251,7 @@ The data below is a snapshot of Qwen2.5-VL-32B-Instruct on a single TPU v7x-8. A
 | Generation | `max_tokens=8192`, temperature 0, seed 42 |
 | Evaluation batch size | 24 |
 
-**Deployment Command** — use the [§2.3 v7x-8 launch command](/autoregressive/Qwen/Qwen2.5-VL#2-3-launch).
+**Deployment Command** — use the [§2.3 v7x-8 launch command](./Qwen2.5-VL.md#2-3-launch).
 
 **Benchmark Command**
 
@@ -373,6 +373,6 @@ This is a saturated burst workload, so TTFT includes scheduler queueing in addit
 ## Additional Resources
 
 - [Qwen2.5-VL model collection](https://huggingface.co/Qwen)
-- [Qwen3 recipe](/autoregressive/Qwen/Qwen3) — text-only Qwen3 dense recipe (Qwen3 series is the reasoning generation).
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Qwen3 recipe](./Qwen3.md) — text-only Qwen3 dense recipe (Qwen3 series is the reasoning generation).
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/Qwen/Qwen3-MoE.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3-MoE.md
@@ -10,7 +10,7 @@ title: "Qwen3-MoE"
 
 [**Qwen/Qwen3-30B-A3B**](https://huggingface.co/Qwen/Qwen3-30B-A3B) is Alibaba's MoE variant of the Qwen3 series — a sparse mixture-of-experts decoder with 30B total / 3B activated parameters and the same hybrid reasoning + tool-call format as dense Qwen3; multi-host on v6e-16.
 
-For the dense Qwen3 variants (8B / 32B) see [Qwen3 recipe](/autoregressive/Qwen/Qwen3).
+For the dense Qwen3 variants (8B / 32B) see [Qwen3 recipe](../../autoregressive/Qwen/Qwen3.md).
 
 **Key Features**:
 
@@ -36,17 +36,17 @@ For the dense Qwen3 variants (8B / 32B) see [Qwen3 recipe](/autoregressive/Qwen/
 | Qwen3-30B-A3B | **v7x-4** | 2x2x1 | 1 | 4 chips / 8 devices | 8 | 8 | Recommended throughput recipe in §4.2. v7x exposes 2 JAX devices/chip. |
 | Qwen3-30B-A3B   | **v6e-16** | 4x4 | 4  | 16 | 16 | 16 | This is the slice we measured on. BF16 ~60 GB. |
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install). For multi-host launches use [GKE Indexed Job launcher](/deployment/gke-indexed-job) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](/deployment/skypilot).
+Install per [Install guide](../../get_started/install.md). For multi-host launches use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](../../deployment/skypilot.md).
 
 ### 2.3 Launch
 
 #### Multi-host — TPU v6e-16
 
-Use [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=qwen3-moe`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=4x4`, `parallelism: 4`, and `completions: 4`. Put these model-specific flags into `<LAUNCH_FLAGS>`:
+Use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) with `<JOB>=qwen3-moe`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=4x4`, `parallelism: 4`, and `completions: 4`. Put these model-specific flags into `<LAUNCH_FLAGS>`:
 
 ```bash
   --model-path Qwen/Qwen3-30B-A3B \
@@ -64,7 +64,7 @@ Use [GKE Indexed Job launcher](/deployment/gke-indexed-job) with `<JOB>=qwen3-mo
 
 > Note: 30B-A3B uses `--moe-backend epmoe`, not `fused`. The fused MoE kernel requires `intermediate_size % 512 == 0`; Qwen3-30B-A3B's per-expert FFN inner dim is 768 (not a multiple of 512), so launching with `--moe-backend fused` raises `ValueError: Expected intermediate_size=768 to be aligned to bf=512`. See §2.4 MoE Backend.
 
-For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/deployment/skypilot) with the same launch flags. The model recipe does not require users to run repository-local SkyPilot helper scripts.
+For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](../../deployment/skypilot.md) with the same launch flags. The model recipe does not require users to run repository-local SkyPilot helper scripts.
 
 ### 2.4 Configuration Tips
 
@@ -89,13 +89,13 @@ For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/dep
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min per node.
 - On multi-node clusters the cache is per-node. Mount a shared PVC to amortize compilation across all nodes.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage). For thinking + content streaming see §3.2, for tool calling see §3.3.
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md). For thinking + content streaming see §3.2, for tool calling see §3.3.
 
 Short Python OpenAI client example (replace `<rank0-ip>` with your rank-0 internal IP; thinking-off baseline):
 
@@ -303,7 +303,7 @@ To see the full set of `--reasoning-parser` / `--tool-call-parser` keys availabl
 | Expert Parallelism | 16 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](/autoregressive/Qwen/Qwen3-MoE#2-3-launch).
+**Deployment Command** — same as [§2.3](../../autoregressive/Qwen/Qwen3-MoE.md#2-3-launch).
 
 **Benchmark Command** — example for GSM8K (with thinking-on for reasoning):
 
@@ -382,6 +382,6 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
 ## Additional Resources
 
 - [Qwen3-30B-A3B model card](https://huggingface.co/Qwen/Qwen3-30B-A3B)
-- [Qwen3 recipe](/autoregressive/Qwen/Qwen3) — dense Qwen3-8B / 32B recipe (same reasoning/tool-call format).
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Qwen3 recipe](../../autoregressive/Qwen/Qwen3.md) — dense Qwen3-8B / 32B recipe (same reasoning/tool-call format).
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.md
@@ -35,11 +35,11 @@ title: "Qwen3"
 | Qwen3-8B | **v6e-4** | 2x2 | 4 | 4 | This is the slice we measured on. Single host; ~16 GB BF16 weights. |
 | Qwen3-32B | **v6e-4** | 2x2 | 4 | 4 | This is the slice we measured on. Single host; ~64 GB BF16 weights — fits with `--mem-fraction-static 0.8`. |
 
-Both v6e rows fit on a single v6e-4 host with `bfloat16`; the v7x row uses one 4-chip v7x slice. See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+Both v6e rows fit on a single v6e-4 host with `bfloat16`; the v7x row uses one 4-chip v7x slice. See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install) and use [Single-host Docker template](/deployment/single-host-docker) for the container setup.
+Install per [Install guide](../../get_started/install.md) and use [Single-host Docker template](../../deployment/single-host-docker.md) for the container setup.
 
 ### 2.3 Launch
 
@@ -81,13 +81,13 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python3 -u -m sgl_jax.launch_server \
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min while XLA/Pallas re-compiles.
 - The cache keys on full kernel shape: changing `--page-size`, `--tp-size`, `--chunked-prefill-size`, or `--context-length` invalidates cached entries.
 
-For full flag definitions and defaults see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions and defaults see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage). For thinking + content streaming see §3.2, for tool calling see §3.3.
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md). For thinking + content streaming see §3.2, for tool calling see §3.3.
 
 Short Python OpenAI client example (thinking-off baseline):
 
@@ -318,7 +318,7 @@ To see the full set of `--tool-call-parser` keys available in your build, run `p
 | Tensor Parallelism | 4 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3 Single-host](/autoregressive/Qwen/Qwen3#2-3-launch).
+**Deployment Command** — same as [§2.3 Single-host](../../autoregressive/Qwen/Qwen3.md#2-3-launch).
 
 **Benchmark Command**
 
@@ -414,7 +414,7 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
 
 Methodology: TTFT measured at `output_len=1` to isolate first-token latency; ITL / throughput measured at `output_len=1024`. Workload sweeps input lengths 1024 / 4096 / 8192 tokens × output lengths 1 / 1024 tokens × concurrency 8 / 16 / 32 / 64 / 128 / 256.
 
-**Deployment Command** — same as [§2.3 Single-host](/autoregressive/Qwen/Qwen3#2-3-launch).
+**Deployment Command** — same as [§2.3 Single-host](../../autoregressive/Qwen/Qwen3.md#2-3-launch).
 
 **Benchmark Command** — bash driver that sweeps (ISL × OSL × concurrency):
 
@@ -488,5 +488,5 @@ Lower than the 1977 tok/s c=64 table cell because c=16 leaves the batch under-fi
 ## Additional Resources
 
 - [Qwen Model Cards](https://huggingface.co/Qwen)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/Xiaomi/MiMo-7B.md
+++ b/docs/cookbook/autoregressive/Xiaomi/MiMo-7B.md
@@ -29,11 +29,11 @@ title: "MiMo-7B"
 |---|---|---|---|---|---|
 | MiMo-7B-RL | **v6e-4** | 2x2 | 4 | 4 | This is the slice we measured on. BF16 weights ~14 GB — fits with headroom; single-host serving. |
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install) and use [Single-host Docker template](/deployment/single-host-docker) for the container setup.
+Install per [Install guide](../../get_started/install.md) and use [Single-host Docker template](../../deployment/single-host-docker.md) for the container setup.
 
 ### 2.3 Launch
 
@@ -57,7 +57,7 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
 - `--mem-fraction-static 0.88` is the TPU default. Raise to `0.9` for dedicated serving / higher concurrency.
 
 **Tool Calling:**
-- MiMo-7B-RL uses the `mimo` tool-call parser format. Add `--tool-call-parser mimo` when using the OpenAI tools API. See [§3.3](/autoregressive/Xiaomi/MiMo-7B#3-3-tool-calling) for the request/response pattern.
+- MiMo-7B-RL uses the `mimo` tool-call parser format. Add `--tool-call-parser mimo` when using the OpenAI tools API. See [§3.3](../../autoregressive/Xiaomi/MiMo-7B.md#3-3-tool-calling) for the request/response pattern.
 
 **Reasoning Parser:**
 - MiMo-7B-RL uses `--reasoning-parser mimo` (alias of the `qwen3` reasoning parser — same `<think>...</think>` format + `enable_thinking` switch). Append to the §2.3 launch command to expose `reasoning_content` separated from `content`.
@@ -67,13 +67,13 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
 **Compilation Cache Hygiene:**
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min while XLA/Pallas re-compiles.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage). For thinking + content streaming see §3.2, for tool calling see §3.3.
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md). For thinking + content streaming see §3.2, for tool calling see §3.3.
 
 Short Python OpenAI client example:
 
@@ -285,7 +285,7 @@ To see the full set of `--reasoning-parser` / `--tool-call-parser` keys availabl
 | Reasoning Parser | `mimo` (thinking-on per-request via `chat_template_kwargs.enable_thinking=true`) |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](/autoregressive/Xiaomi/MiMo-7B#2-3-launch) plus `--reasoning-parser mimo --tool-call-parser mimo`.
+**Deployment Command** — same as [§2.3](../../autoregressive/Xiaomi/MiMo-7B.md#2-3-launch) plus `--reasoning-parser mimo --tool-call-parser mimo`.
 
 **Benchmark Command**
 
@@ -322,7 +322,7 @@ Recommended additional datasets for reasoning variants: AIME 2025, MATH.
 | Tensor Parallelism | 4 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](/autoregressive/Xiaomi/MiMo-7B#2-3-launch).
+**Deployment Command** — same as [§2.3](../../autoregressive/Xiaomi/MiMo-7B.md#2-3-launch).
 
 **Benchmark Command**
 
@@ -384,5 +384,5 @@ Max ITL (ms):                            38.99
 ## Additional Resources
 
 - [MiMo-7B-RL model card](https://huggingface.co/XiaomiMiMo/MiMo-7B-RL)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/Xiaomi/MiMo-V2-Flash.md
+++ b/docs/cookbook/autoregressive/Xiaomi/MiMo-V2-Flash.md
@@ -35,11 +35,11 @@ title: "MiMo-V2-Flash"
 | **v7x-8** | 1 host × 4 chips | 4 | 1 | 4 chips → 8 JAX devices | 8 | 2 | 8 | `epmoe` | One of two slices we measured on. v7x exposes 2 JAX devices/chip; `--tp-size` counts devices not chips. |
 | **v6e-16** | 4x4 | 4 | 4 | 16 | 16 | 4 | 16 | `fused` | The other slice we measured on. Multi-host required. |
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation / HBM / device-per-chip reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation / HBM / device-per-chip reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install) and use one of the launcher templates from [Deployment templates](/deployment).
+Install per [Install guide](../../get_started/install.md) and use one of the launcher templates from [Deployment templates](../../deployment/index.md).
 
 Extra pip for accuracy benchmarking only:
 
@@ -56,7 +56,7 @@ Two slices we measured on, each as a separate launch path:
 
 #### Single-host — TPU v7x-8
 
-Boot a TPU container per [Single-host Docker template](/deployment/single-host-docker), then:
+Boot a TPU container per [Single-host Docker template](../../deployment/single-host-docker.md), then:
 
 ```bash
 JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -u -m sgl_jax.launch_server \
@@ -98,9 +98,9 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -u -m sgl_jax.launch_server \
 
 **Launcher** — wrap the above into GKE:
 
-- **GKE Indexed Job + headless Service** — adapt [GKE Indexed Job launcher](/deployment/gke-indexed-job). Differences from the template: `<JOB>=mimo-v2-flash`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=4x4`, `<N>=4`, `<MODEL_PATH>=XiaomiMiMo/MiMo-V2-Flash`, `<HTTP_PORT>=30000`, plus the launch flags above. `${NODE_RANK}` comes from `${JOB_COMPLETION_INDEX}`.
+- **GKE Indexed Job + headless Service** — adapt [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md). Differences from the template: `<JOB>=mimo-v2-flash`, `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=4x4`, `<N>=4`, `<MODEL_PATH>=XiaomiMiMo/MiMo-V2-Flash`, `<HTTP_PORT>=30000`, plus the launch flags above. `${NODE_RANK}` comes from `${JOB_COMPLETION_INDEX}`.
 
-For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/deployment/skypilot) with the same launch flags.
+For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](../../deployment/skypilot.md) with the same launch flags.
 
 ### 2.4 Configuration Tips
 
@@ -127,13 +127,13 @@ For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/dep
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min while XLA/Pallas re-compiles every kernel.
 - The cache keys on full kernel shape: changing `--page-size`, `--tp-size`, `--chunked-prefill-size`, or `--context-length` invalidates cached entries. Use a fresh cache dir per tuning experiment to avoid stale-cache cross-pollution.
 
-For full flag definitions and defaults see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions and defaults see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage). For thinking + content streaming see §3.2, for tool calling see §3.3.
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md). For thinking + content streaming see §3.2, for tool calling see §3.3.
 
 Short Python OpenAI client example (single-host v7x-8 default; for multi-host v6e-16 serving replace `127.0.0.1` with your rank-0 internal IP; thinking-off baseline):
 
@@ -390,7 +390,7 @@ To see the full set of `--tool-call-parser` keys available in your build, run `p
 | Reasoning Parser | `mimo` |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3 Multi-host](/autoregressive/Xiaomi/MiMo-V2-Flash#2-3-launch), plus `--reasoning-parser mimo`.
+**Deployment Command** — same as [§2.3 Multi-host](../../autoregressive/Xiaomi/MiMo-V2-Flash.md#2-3-launch), plus `--reasoning-parser mimo`.
 
 **Benchmark Command**
 
@@ -431,7 +431,7 @@ This recipe uses a **single-workload configuration sweep**: one fixed ISL/OSL/co
 
 **Workload**: 256 prompts, ISL=16384, OSL=1024, concurrency=64 (single fixed cell).
 
-**Deployment Command** — same shape as [§2.3 Single-host](/autoregressive/Xiaomi/MiMo-V2-Flash#2-3-launch), with `--dp-size 1` and the sweep dimensions (`--moe-backend` / `--chunked-prefill-size` / `--swa-full-tokens-ratio` / `--mem-fraction-static`) varied per row.
+**Deployment Command** — same shape as [§2.3 Single-host](../../autoregressive/Xiaomi/MiMo-V2-Flash.md#2-3-launch), with `--dp-size 1` and the sweep dimensions (`--moe-backend` / `--chunked-prefill-size` / `--swa-full-tokens-ratio` / `--mem-fraction-static`) varied per row.
 
 **Benchmark Command**
 
@@ -470,6 +470,6 @@ The fused MoE tuned-config table covers the EP=8 shapes (server logs report `Usi
 ## Additional Resources
 
 - [MiMo-V2-Flash Model Card](https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash)
-- [TPU topology reference](/base/tpu-topology-reference)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [TPU topology reference](../../base/tpu-topology-reference.md)
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md
+++ b/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md
@@ -36,11 +36,11 @@ title: "MiMo-V2.5-Pro"
 
 MiMo-V2.5-Pro is multi-host only — all nodes must be in the same TPU slice and reach each other on the JAX init port (`5000` by default) and the TPU process port (`8471`).
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation / HBM / device-per-chip reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation / HBM / device-per-chip reference. For other slices (larger v6e, v7x variants, scaled-down configs), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install) and use one of the launcher templates from [Deployment templates](/deployment).
+Install per [Install guide](../../get_started/install.md) and use one of the launcher templates from [Deployment templates](../../deployment/index.md).
 
 The `jax0.8.1-rev1` image is what SGL-JAX's GKE launcher and advanced SkyPilot path use; pinning it keeps the JAX runtime in lockstep with the SGL-JAX `[tpu]` extras.
 
@@ -98,7 +98,7 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
 
 `${NODE_RANK}` ranges from `0` to `15`.
 
-For the GKE Indexed Job + headless Service manifest pattern that wraps the launch command, see [GKE Indexed Job launcher](/deployment/gke-indexed-job). For v7x-16 fill in `<JOB>=mimo-v25-pro`, `<ACCELERATOR>=tpu7x`, `<TOPOLOGY>=2x2x4`, `<N>=4`; for v6e-64 fill in `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=4x4x4`, `<N>=16`. Paste the matching launch flags above into `<LAUNCH_FLAGS>`. For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](/deployment/skypilot) with the same launch flags.
+For the GKE Indexed Job + headless Service manifest pattern that wraps the launch command, see [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md). For v7x-16 fill in `<JOB>=mimo-v25-pro`, `<ACCELERATOR>=tpu7x`, `<TOPOLOGY>=2x2x4`, `<N>=4`; for v6e-64 fill in `<ACCELERATOR>=tpu-v6e-slice`, `<TOPOLOGY>=4x4x4`, `<N>=16`. Paste the matching launch flags above into `<LAUNCH_FLAGS>`. For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](../../deployment/skypilot.md) with the same launch flags.
 
 ### 2.4 Configuration Tips
 
@@ -136,13 +136,13 @@ For the GKE Indexed Job + headless Service manifest pattern that wraps the launc
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` is mandatory — without it, first request blocks ~4 min while XLA/Pallas re-compiles every kernel.
 - The cache keys on full kernel shape: changing `--page-size`, `--tp-size`, `--chunked-prefill-size`, or `--context-length` invalidates cached entries. Give each tuning experiment its own cache dir to avoid stale-cache misses across runs.
 
-For full flag definitions and defaults see [Launch flags reference](/base/launch-flags-reference).
+For full flag definitions and defaults see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
 
 ### 3.1 Basic Chat Completion
 
-For full cURL + native `/generate` patterns see [Basic API usage](/base/basic-api-usage). For thinking + content streaming see §3.2, for tool calling see §3.3.
+For full cURL + native `/generate` patterns see [Basic API usage](../../base/basic-api-usage.md). For thinking + content streaming see §3.2, for tool calling see §3.3.
 
 Short Python OpenAI client example (replace `<rank0-ip>` with your rank-0 internal IP; tool-calling sampling baseline — for long thinking-on chains raise `max_tokens`):
 
@@ -395,7 +395,7 @@ To see the full set of `--tool-call-parser` keys available in your build, run `p
 | Reasoning Parser | `mimo` |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3 Multi-host (v6e-64)](/autoregressive/Xiaomi/MiMo-V2.5-Pro#2-3-launch), plus `--reasoning-parser mimo`.
+**Deployment Command** — same as [§2.3 Multi-host (v6e-64)](../../autoregressive/Xiaomi/MiMo-V2.5-Pro.md#2-3-launch), plus `--reasoning-parser mimo`.
 
 **Benchmark Command**
 
@@ -430,7 +430,7 @@ evalscope eval \
 | Data Parallelism | 4 |
 | Expert Parallelism | 32 |
 
-**Deployment Command** — same as [§2.3 Multi-host (v7x-16)](/autoregressive/Xiaomi/MiMo-V2.5-Pro#2-3-launch).
+**Deployment Command** — same as [§2.3 Multi-host (v7x-16)](../../autoregressive/Xiaomi/MiMo-V2.5-Pro.md#2-3-launch).
 
 **Benchmark Command**
 
@@ -521,8 +521,8 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
 ## Additional Resources
 
 - [MiMo-V2.5-Pro Model Card](https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro)
-- [TPU topology reference](/base/tpu-topology-reference)
-- [Launch flags reference](/base/launch-flags-reference)
-- [GKE Indexed Job launcher](/deployment/gke-indexed-job) — primary multi-host launcher.
-- [SkyPilot launcher](/deployment/skypilot) — advanced v6e experiment alternative.
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [TPU topology reference](../../base/tpu-topology-reference.md)
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) — primary multi-host launcher.
+- [SkyPilot launcher](../../deployment/skypilot.md) — advanced v6e experiment alternative.
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/autoregressive/index.md
+++ b/docs/cookbook/autoregressive/index.md
@@ -22,64 +22,64 @@ End-to-end serving recipes for autoregressive models on SGL-JAX, organized by ve
 
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
-| ✅ | DeepSeek-V2-Lite | [`DeepSeek/DeepSeek-V2.md`](/autoregressive/DeepSeek/DeepSeek-V2) | v6e-4 | MoE + MLA |
-| ✅ | DeepSeek-V3 | [`DeepSeek/DeepSeek-V3.md`](/autoregressive/DeepSeek/DeepSeek-V3) | v6e-64 / v7x-16 | MoE + MLA |
-| ✅ | DeepSeek-R1 | [`DeepSeek/DeepSeek-R1.md`](/autoregressive/DeepSeek/DeepSeek-R1) | v6e-64 / v7x-16 | MoE + MLA + reasoning (`deepseek-r1`) |
+| ✅ | DeepSeek-V2-Lite | [`DeepSeek/DeepSeek-V2.md`](./DeepSeek/DeepSeek-V2.md) | v6e-4 | MoE + MLA |
+| ✅ | DeepSeek-V3 | [`DeepSeek/DeepSeek-V3.md`](./DeepSeek/DeepSeek-V3.md) | v6e-64 / v7x-16 | MoE + MLA |
+| ✅ | DeepSeek-R1 | [`DeepSeek/DeepSeek-R1.md`](./DeepSeek/DeepSeek-R1.md) | v6e-64 / v7x-16 | MoE + MLA + reasoning (`deepseek-r1`) |
 
 ### GLM — `GLM/`
 
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
-| ✅ | GLM-4.5-Air (106B) | [`GLM/GLM-4.5.md`](/autoregressive/GLM/GLM-4.5) | v6e-32 / v7x-4 | MoE + reasoning/tool (`glm45`) |
+| ✅ | GLM-4.5-Air (106B) | [`GLM/GLM-4.5.md`](./GLM/GLM-4.5.md) | v6e-32 / v7x-4 | MoE + reasoning/tool (`glm45`) |
 
 ### Google — `Google/`
 
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
-| ✅ | Gemma 2 27B-it | [`Google/Gemma2.md`](/autoregressive/Google/Gemma2) | v6e-4 | dense (hybrid attn) |
+| ✅ | Gemma 2 27B-it | [`Google/Gemma2.md`](./Google/Gemma2.md) | v6e-4 | dense (hybrid attn) |
 
 ### Grok — `Grok/`
 
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
-| ✅ | Grok-2 (base) | [`Grok/Grok2.md`](/autoregressive/Grok/Grok2) | v6e-64 | MoE (8 experts, 2 active) |
+| ✅ | Grok-2 (base) | [`Grok/Grok2.md`](./Grok/Grok2.md) | v6e-64 | MoE (8 experts, 2 active) |
 
 ### InclusionAI — `InclusionAI/`
 
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
-| ✅ | Ling 2.6-1T | [`InclusionAI/Ling-2.6.md`](/autoregressive/InclusionAI/Ling-2.6) | v6e-64 / v7x-16 | MoE + linear attn |
+| ✅ | Ling 2.6-1T | [`InclusionAI/Ling-2.6.md`](./InclusionAI/Ling-2.6.md) | v6e-64 / v7x-16 | MoE + linear attn |
 
 ### Llama — `Llama/`
 
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
-| ✅ | Llama 3.1 8B-Instruct | [`Llama/Llama3.1.md`](/autoregressive/Llama/Llama3.1) | v6e-4 | dense |
-| ✅ | Llama 3.3 70B | [`Llama/Llama3.3-70B.md`](/autoregressive/Llama/Llama3.3-70B) | v6e-16 / v7x-4 | dense |
+| ✅ | Llama 3.1 8B-Instruct | [`Llama/Llama3.1.md`](./Llama/Llama3.1.md) | v6e-4 | dense |
+| ✅ | Llama 3.3 70B | [`Llama/Llama3.3-70B.md`](./Llama/Llama3.3-70B.md) | v6e-16 / v7x-4 | dense |
 
 ### Moonshotai — `Moonshotai/`
 
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
-| ✅ | Kimi-Linear (48B-A3B) | [`Moonshotai/Kimi-Linear.md`](/autoregressive/Moonshotai/Kimi-Linear) | v6e-16 | dense + linear attn |
+| ✅ | Kimi-Linear (48B-A3B) | [`Moonshotai/Kimi-Linear.md`](./Moonshotai/Kimi-Linear.md) | v6e-16 | dense + linear attn |
 
 ### Qwen — `Qwen/`
 
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
-| ✅ | Qwen-7B-Chat | [`Qwen/Qwen.md`](/autoregressive/Qwen/Qwen) | v6e-4 | dense |
-| ✅ | Qwen3-8B / Qwen3-32B | [`Qwen/Qwen3.md`](/autoregressive/Qwen/Qwen3) | v6e-4; 8B v7x-4 | dense + reasoning (`qwen3`) + tool (`qwen25`) |
-| ✅ | Qwen3-30B-A3B | [`Qwen/Qwen3-MoE.md`](/autoregressive/Qwen/Qwen3-MoE) | v6e-16 / v7x-4 | MoE + reasoning (`qwen3`) + tool (`qwen25`) |
-| ✅ | Qwen2.5-VL (3B / 7B / 32B / 72B) | [`Qwen/Qwen2.5-VL.md`](/autoregressive/Qwen/Qwen2.5-VL) | v6e-4 for 3B/7B/32B; 32B also validated on v7x-8; 72B pending | vision-language autoregressive decoder |
+| ✅ | Qwen-7B-Chat | [`Qwen/Qwen.md`](./Qwen/Qwen.md) | v6e-4 | dense |
+| ✅ | Qwen3-8B / Qwen3-32B | [`Qwen/Qwen3.md`](./Qwen/Qwen3.md) | v6e-4; 8B v7x-4 | dense + reasoning (`qwen3`) + tool (`qwen25`) |
+| ✅ | Qwen3-30B-A3B | [`Qwen/Qwen3-MoE.md`](./Qwen/Qwen3-MoE.md) | v6e-16 / v7x-4 | MoE + reasoning (`qwen3`) + tool (`qwen25`) |
+| ✅ | Qwen2.5-VL (3B / 7B / 32B / 72B) | [`Qwen/Qwen2.5-VL.md`](./Qwen/Qwen2.5-VL.md) | v6e-4 for 3B/7B/32B; 32B also validated on v7x-8; 72B pending | vision-language autoregressive decoder |
 | 📝 | Qwen2 / Qwen2-MoE | _no recipe — same family runtime path_ | — | dense / MoE |
 
 ### Xiaomi — `Xiaomi/`
 
 | Status | Model | Recipe | Min TPU | Backend |
 |---|---|---|---|---|
-| ✅ | MiMo-V2-Flash | [`Xiaomi/MiMo-V2-Flash.md`](/autoregressive/Xiaomi/MiMo-V2-Flash) | v7x-8 or v6e-16 | MoE + reasoning/tool (`mimo`) |
-| ✅ | MiMo-V2.5-Pro | [`Xiaomi/MiMo-V2.5-Pro.md`](/autoregressive/Xiaomi/MiMo-V2.5-Pro) | v6e-64 (v7x-16 alternative) | MoE + reasoning/tool (`mimo`) |
-| ✅ | MiMo-7B-RL | [`Xiaomi/MiMo-7B.md`](/autoregressive/Xiaomi/MiMo-7B) | v6e-4 | dense + reasoning/tool (`mimo`) |
+| ✅ | MiMo-V2-Flash | [`Xiaomi/MiMo-V2-Flash.md`](./Xiaomi/MiMo-V2-Flash.md) | v7x-8 or v6e-16 | MoE + reasoning/tool (`mimo`) |
+| ✅ | MiMo-V2.5-Pro | [`Xiaomi/MiMo-V2.5-Pro.md`](./Xiaomi/MiMo-V2.5-Pro.md) | v6e-64 (v7x-16 alternative) | MoE + reasoning/tool (`mimo`) |
+| ✅ | MiMo-7B-RL | [`Xiaomi/MiMo-7B.md`](./Xiaomi/MiMo-7B.md) | v6e-4 | dense + reasoning/tool (`mimo`) |
 
 > Upgrade path: 🚧 → 🧪 requires real `evalscope` (accuracy), launch validation, or `bench_serving` output for at least one variant / hardware path. 🧪 → ✅ requires the recipe's claimed primary path to have complete launch and invocation evidence without unresolved required cells. Publish throughput tables only for representative release-quality datapoints; otherwise keep a benchmark command template without a result row.
 
@@ -91,21 +91,21 @@ A model that generates text one token at a time, conditioning on its own previou
 - **MoE LLMs** — Qwen3-MoE / DeepSeek V2/V3/R1 / GLM-4.5 / Ling 2.6 / MiMo-V2-Flash / MiMo-V2.5-Pro / Kimi-Linear / Grok-2 (base).
 - **Vision-language decoders** — Qwen2.5-VL ingests image / video inputs, but the answer is still produced by an autoregressive generation stage.
 
-Diffusion image/video generation models live in [Diffusion recipes](/diffusion).
+Diffusion image/video generation models live in [Diffusion recipes](../diffusion/index.md).
 
 ## Picking a starting recipe to clone for a new model
 
 | Goal | Clone from |
 |---|---|
-| Single-host dense model | [`Qwen/Qwen.md`](/autoregressive/Qwen/Qwen) ✅ or [`Llama/Llama3.1.md`](/autoregressive/Llama/Llama3.1) ✅ |
-| Dense model with benchmark rows | [`Qwen/Qwen3.md`](/autoregressive/Qwen/Qwen3) ✅ |
-| Single-host MoE with backend choice | [`Xiaomi/MiMo-V2-Flash.md`](/autoregressive/Xiaomi/MiMo-V2-Flash) ✅ |
-| Vision-language chat | [`Qwen/Qwen2.5-VL.md`](/autoregressive/Qwen/Qwen2.5-VL) ✅ |
-| Large multi-node MoE with GKE manifest | [`Xiaomi/MiMo-V2.5-Pro.md`](/autoregressive/Xiaomi/MiMo-V2.5-Pro) ✅ |
-| Multi-node dense | [`Llama/Llama3.3-70B.md`](/autoregressive/Llama/Llama3.3-70B) ✅ (+ [GKE Indexed Job launcher](/deployment/gke-indexed-job)) |
-| Base model (no chat template, `/v1/completions` flow) | [`Grok/Grok2.md`](/autoregressive/Grok/Grok2) ✅ |
-| Linear-attention model with recurrent state | [`Moonshotai/Kimi-Linear.md`](/autoregressive/Moonshotai/Kimi-Linear) ✅ or [`InclusionAI/Ling-2.6.md`](/autoregressive/InclusionAI/Ling-2.6) ✅ |
-| Reasoning model (RL-tuned, `<think>` blocks) | [`DeepSeek/DeepSeek-R1.md`](/autoregressive/DeepSeek/DeepSeek-R1) ✅ |
+| Single-host dense model | [`Qwen/Qwen.md`](./Qwen/Qwen.md) ✅ or [`Llama/Llama3.1.md`](./Llama/Llama3.1.md) ✅ |
+| Dense model with benchmark rows | [`Qwen/Qwen3.md`](./Qwen/Qwen3.md) ✅ |
+| Single-host MoE with backend choice | [`Xiaomi/MiMo-V2-Flash.md`](./Xiaomi/MiMo-V2-Flash.md) ✅ |
+| Vision-language chat | [`Qwen/Qwen2.5-VL.md`](./Qwen/Qwen2.5-VL.md) ✅ |
+| Large multi-node MoE with GKE manifest | [`Xiaomi/MiMo-V2.5-Pro.md`](./Xiaomi/MiMo-V2.5-Pro.md) ✅ |
+| Multi-node dense | [`Llama/Llama3.3-70B.md`](./Llama/Llama3.3-70B.md) ✅ (+ [GKE Indexed Job launcher](../deployment/gke-indexed-job.md)) |
+| Base model (no chat template, `/v1/completions` flow) | [`Grok/Grok2.md`](./Grok/Grok2.md) ✅ |
+| Linear-attention model with recurrent state | [`Moonshotai/Kimi-Linear.md`](./Moonshotai/Kimi-Linear.md) ✅ or [`InclusionAI/Ling-2.6.md`](./InclusionAI/Ling-2.6.md) ✅ |
+| Reasoning model (RL-tuned, `<think>` blocks) | [`DeepSeek/DeepSeek-R1.md`](./DeepSeek/DeepSeek-R1.md) ✅ |
 
 ## Parser key reference
 
@@ -113,12 +113,12 @@ Reasoning models that emit `<think>` blocks need `--reasoning-parser <key>` at l
 
 | Parser key | Reasoning | Tool-call | Where used in cookbook |
 |---|---|---|---|
-| `deepseek-r1` | ✓ (`<think>...</think>`) | — | [DeepSeek-R1](/autoregressive/DeepSeek/DeepSeek-R1), Ling 2.6 reasoning variants (use as `<think>` parser) |
-| `qwen3` | ✓ (`<think>...</think>` + `enable_thinking` switch) | — | [Qwen3](/autoregressive/Qwen/Qwen3), [Qwen3-MoE](/autoregressive/Qwen/Qwen3-MoE) |
+| `deepseek-r1` | ✓ (`<think>...</think>`) | — | [DeepSeek-R1](./DeepSeek/DeepSeek-R1.md), Ling 2.6 reasoning variants (use as `<think>` parser) |
+| `qwen3` | ✓ (`<think>...</think>` + `enable_thinking` switch) | — | [Qwen3](./Qwen/Qwen3.md), [Qwen3-MoE](./Qwen/Qwen3-MoE.md) |
 | `qwen25` | — | ✓ | Qwen3 / Qwen3-MoE tool-calling |
 | `qwen3_coder` | — | ✓ | Qwen3-Coder variants |
-| `mimo` | ✓ (alias of `qwen3` parser) | ✓ | [MiMo-V2-Flash](/autoregressive/Xiaomi/MiMo-V2-Flash), [MiMo-V2.5-Pro](/autoregressive/Xiaomi/MiMo-V2.5-Pro), [MiMo-7B](/autoregressive/Xiaomi/MiMo-7B) |
-| `glm45` | ✓ (`<think>...</think>`) | ✓ | [GLM-4.5 / 4.5-Air](/autoregressive/GLM/GLM-4.5) |
+| `mimo` | ✓ (alias of `qwen3` parser) | ✓ | [MiMo-V2-Flash](./Xiaomi/MiMo-V2-Flash.md), [MiMo-V2.5-Pro](./Xiaomi/MiMo-V2.5-Pro.md), [MiMo-7B](./Xiaomi/MiMo-7B.md) |
+| `glm45` | ✓ (`<think>...</think>`) | ✓ | [GLM-4.5 / 4.5-Air](./GLM/GLM-4.5.md) |
 | `kimi` | ✓ (`◁think▷...◁/think▷`) | — | Reserved for Kimi reasoning variants; Kimi-Linear-Instruct is not reasoning |
 
 Run `python -m sgl_jax.launch_server --help` against your checkout to see the full registered set — these keys are the cookbook-relevant subset.

--- a/docs/cookbook/base/basic-api-usage.md
+++ b/docs/cookbook/base/basic-api-usage.md
@@ -6,7 +6,7 @@ title: "Basic API Usage"
 
 This page is the shared reference for sending requests to a running sglang-jax server. Every recipe's §3.1 Basic Usage links here for the cURL / Python / streaming patterns; the recipe pages then add only the model-specific bits (recommended sampling parameters, parser keys, multi-turn examples).
 
-For installing the server see [Install guide](/get_started/install). For the full launch-flag reference see [Launch flags reference](/base/launch-flags-reference).
+For installing the server see [Install guide](../get_started/install.md). For the full launch-flag reference see [Launch flags reference](../base/launch-flags-reference.md).
 
 ## 1. Launch a Server
 
@@ -155,4 +155,4 @@ print()
 
 ## 6. What's Next
 
-For model-specific behavior (recommended sampling parameters, reasoning parser, tool-call parser, multi-host launch flags) see the recipe in [Autoregressive recipes](/autoregressive). The recipe's §3.1 will name the model path and recommended parameters; everything else on this page applies unchanged.
+For model-specific behavior (recommended sampling parameters, reasoning parser, tool-call parser, multi-host launch flags) see the recipe in [Autoregressive recipes](../autoregressive/index.md). The recipe's §3.1 will name the model path and recommended parameters; everything else on this page applies unchanged.

--- a/docs/cookbook/base/launch-flags-reference.md
+++ b/docs/cookbook/base/launch-flags-reference.md
@@ -32,7 +32,7 @@ grep -n 'add_argument' python/sgl_jax/srt/server_args.py
 
 | Flag | Default | Notes |
 |---|---|---|
-| `--tensor-parallel-size` / `--tp-size` | `1` | Total JAX devices across all nodes. See [`tpu-topology-reference.md`](/base/tpu-topology-reference) for the v7x 2-devices-per-chip rule. |
+| `--tensor-parallel-size` / `--tp-size` | `1` | Total JAX devices across all nodes. See [`tpu-topology-reference.md`](../base/tpu-topology-reference.md) for the v7x 2-devices-per-chip rule. |
 | `--data-parallel-size` / `--dp-size` | `1` | DP factor for the **attention** path only. Attention TP becomes `tp_size / dp_size`. MoE layers still run with full `ep_size`. |
 | `--dp-schedule-policy` | auto | DP rank assignment policy. If unset, radix-cache serving uses `cache_aware`; `--disable-radix-cache` and Pathways PD use `min_running_queue`. Explicit choices are `cache_aware`, `shape_aware`, `min_running_queue`, and `round_robin`; use non-default choices as workload-specific tuning overrides. |
 | `--ep-size` | `1` | Expert parallelism. Typically `--ep-size == --tp-size` for MoE models. |
@@ -62,7 +62,7 @@ grep -n 'add_argument' python/sgl_jax/srt/server_args.py
 | Flag | Default | Choices | Notes |
 |---|---|---|---|
 | `--attention-backend` | `fa` | `native` / `fa` / `fa_mha` | `fa` = FlashAttention on Pallas (MHA / MLA). `fa_mha` forces MHA path for MLA models. |
-| `--moe-backend` | `epmoe` | `epmoe` / `fused` / `auto` | Scale-dependent. At EP≤8 (single host v7x-8) `epmoe` wins on MiMo-V2-Flash; at EP≥16 (multi-node) `fused` wins. See [MiMo-V2-Flash recipe](/autoregressive/Xiaomi/MiMo-V2-Flash) for measured numbers. |
+| `--moe-backend` | `epmoe` | `epmoe` / `fused` / `auto` | Scale-dependent. At EP≤8 (single host v7x-8) `epmoe` wins on MiMo-V2-Flash; at EP≥16 (multi-node) `fused` wins. See [MiMo-V2-Flash recipe](../autoregressive/Xiaomi/MiMo-V2-Flash.md) for measured numbers. |
 
 ## 6. Networking & multi-node
 
@@ -94,13 +94,13 @@ grep -n 'add_argument' python/sgl_jax/srt/server_args.py
 
 | Parser | Cookbook recipes |
 |---|---|
-| `mimo` (reasoning + tool) | [`mimo-v2.5-pro.md`](/autoregressive/Xiaomi/MiMo-V2.5-Pro) · [`mimo-v2-flash.md`](/autoregressive/Xiaomi/MiMo-V2-Flash) · [`mimo-7b.md`](/autoregressive/Xiaomi/MiMo-7B) |
-| `deepseek-r1` (reasoning) | [`deepseek-v3.md`](/autoregressive/DeepSeek/DeepSeek-V3) (R1 / V3.2-Speciale) |
-| `glm45` (reasoning + tool) | [`glm4-moe.md`](/autoregressive/GLM/GLM-4.5) (GLM-4.5 / 4.6) |
+| `mimo` (reasoning + tool) | [`mimo-v2.5-pro.md`](../autoregressive/Xiaomi/MiMo-V2.5-Pro.md) · [`mimo-v2-flash.md`](../autoregressive/Xiaomi/MiMo-V2-Flash.md) · [`mimo-7b.md`](../autoregressive/Xiaomi/MiMo-7B.md) |
+| `deepseek-r1` (reasoning) | [`deepseek-v3.md`](../autoregressive/DeepSeek/DeepSeek-V3.md) (R1 / V3.2-Speciale) |
+| `glm45` (reasoning + tool) | [`glm4-moe.md`](../autoregressive/GLM/GLM-4.5.md) (GLM-4.5 / 4.6) |
 | `qwen3` (reasoning), `qwen25` / `qwen3_coder` (tool) | _no Qwen recipe currently sets these — pick by model card on a per-checkpoint basis_ |
 | `kimi` (reasoning) | _no Kimi recipe currently sets this_ |
 
-For complete request/response examples see [`mimo-v2.5-pro.md` §3.2](/autoregressive/Xiaomi/MiMo-V2.5-Pro#3-2-reasoning-thinking-on-default-thinking-off-optional) (reasoning streaming) and [§3.3](/autoregressive/Xiaomi/MiMo-V2.5-Pro#3-3-tool-calling) (tool calling).
+For complete request/response examples see [`mimo-v2.5-pro.md` §3.2](../autoregressive/Xiaomi/MiMo-V2.5-Pro.md#3-2-reasoning-thinking-on-default-thinking-off-optional) (reasoning streaming) and [§3.3](../autoregressive/Xiaomi/MiMo-V2.5-Pro.md#3-3-tool-calling) (tool calling).
 
 ## 9. Compilation cache (environment, not a flag)
 

--- a/docs/cookbook/base/tpu-topology-reference.md
+++ b/docs/cookbook/base/tpu-topology-reference.md
@@ -32,12 +32,12 @@ v6e (and every other generation) is 1:1 chip→device, so `--tp-size` matches ch
 
 | Slice name | Nodes | Chips/node | JAX devices | Used by |
 |---|---|---|---|---|
-| `v6e-4` | 1 | 4 | 4 | [Qwen-7B-Chat](/autoregressive/Qwen/Qwen), [Qwen3-8B / 32B](/autoregressive/Qwen/Qwen3), [Qwen2.5-VL](/autoregressive/Qwen/Qwen2.5-VL), [Wan 2.1](/diffusion/Wan/Wan2.1), [Wan 2.2](/diffusion/Wan/Wan2.2) |
-| `v6e-16` (`4x4`) | 4 | 4 | 16 | [MiMo-V2-Flash](/autoregressive/Xiaomi/MiMo-V2-Flash) (multi-node) |
-| `v6e-32` | 8 | 4 | 32 | [Grok-2](/autoregressive/Grok/Grok2) |
-| `v6e-64` (`4x4x4`) | 16 | 4 | 64 | [MiMo-V2.5-Pro](/autoregressive/Xiaomi/MiMo-V2.5-Pro) |
-| `v7x-8` | 1 | 4 | 8 | [Qwen2.5-VL-32B](/autoregressive/Qwen/Qwen2.5-VL), [MiMo-V2-Flash](/autoregressive/Xiaomi/MiMo-V2-Flash) (single-node) |
-| `v7x-16` (`2x2x4`) | 4 | 4 | 32 | [MiMo-V2.5-Pro](/autoregressive/Xiaomi/MiMo-V2.5-Pro) |
+| `v6e-4` | 1 | 4 | 4 | [Qwen-7B-Chat](../autoregressive/Qwen/Qwen.md), [Qwen3-8B / 32B](../autoregressive/Qwen/Qwen3.md), [Qwen2.5-VL](../autoregressive/Qwen/Qwen2.5-VL.md), [Wan 2.1](../diffusion/Wan/Wan2.1.md), [Wan 2.2](../diffusion/Wan/Wan2.2.md) |
+| `v6e-16` (`4x4`) | 4 | 4 | 16 | [MiMo-V2-Flash](../autoregressive/Xiaomi/MiMo-V2-Flash.md) (multi-node) |
+| `v6e-32` | 8 | 4 | 32 | [Grok-2](../autoregressive/Grok/Grok2.md) |
+| `v6e-64` (`4x4x4`) | 16 | 4 | 64 | [MiMo-V2.5-Pro](../autoregressive/Xiaomi/MiMo-V2.5-Pro.md) |
+| `v7x-8` | 1 | 4 | 8 | [Qwen2.5-VL-32B](../autoregressive/Qwen/Qwen2.5-VL.md), [MiMo-V2-Flash](../autoregressive/Xiaomi/MiMo-V2-Flash.md) (single-node) |
+| `v7x-16` (`2x2x4`) | 4 | 4 | 32 | [MiMo-V2.5-Pro](../autoregressive/Xiaomi/MiMo-V2.5-Pro.md) |
 
 ## Choosing `--tp-size`
 
@@ -139,7 +139,7 @@ Before you hit "go", verify against `python/sgl_jax/srt/configs/model_config.py`
 | 5 | Hybrid recurrent models (Ling-2.6, Kimi-Linear) require `--disable-radix-cache` | Server asserts on startup | Recipe §2.4 |
 | 6 | MLA models (DeepSeek family) require `--page-size >= 2` | MLA backend asserts on startup | Recipe §2.4 |
 
-The recipe's §2.4 Configuration Tips covers these constraints; see the [central Troubleshooting page](/deployment/troubleshooting) if launch still fails.
+The recipe's §2.4 Configuration Tips covers these constraints; see the [central Troubleshooting page](../deployment/troubleshooting.md) if launch still fails.
 
 ### Step 4 — If launch hits OOM
 
@@ -171,14 +171,14 @@ If you size a slice this section's math suggests, run the recipe end-to-end, and
 
 | Identifier | Value | Used in |
 |---|---|---|
-| GKE accelerator label (v7x) | `cloud.google.com/gke-tpu-accelerator: tpu7x` | [MiMo-V2.5-Pro GKE manifest](/autoregressive/Xiaomi/MiMo-V2.5-Pro) |
+| GKE accelerator label (v7x) | `cloud.google.com/gke-tpu-accelerator: tpu7x` | [MiMo-V2.5-Pro GKE manifest](../autoregressive/Xiaomi/MiMo-V2.5-Pro.md) |
 | GKE topology label | `cloud.google.com/gke-tpu-topology: 2x2x4` | same |
 | Docker image | `us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.8.1-rev1` | same |
-| SkyPilot resource (v6e) | `tpu-v6e-N` where N is 1, 4, 8, 16, 32, or 64 | [SkyPilot launcher](/deployment/skypilot), `scripts/launch_tpu.sh` |
-| SkyPilot runtime (v6e) | `runtime_version: v2-alpha-tpuv6e` | `scripts/tpu_resource.sky.yaml`, [`developer_guide/tpu_resources_guide.md`](/developer_guide/tpu_resources_guide) |
+| SkyPilot resource (v6e) | `tpu-v6e-N` where N is 1, 4, 8, 16, 32, or 64 | [SkyPilot launcher](../deployment/skypilot.md), `scripts/launch_tpu.sh` |
+| SkyPilot runtime (v6e) | `runtime_version: v2-alpha-tpuv6e` | `scripts/tpu_resource.sky.yaml`, [`developer_guide/tpu_resources_guide.md`](../developer_guide/tpu_resources_guide.md) |
 
 ## What this page intentionally does NOT cover
 
 - Pricing / region availability — see Google Cloud TPU docs.
-- Provisioning / quota workflows — see [`developer_guide/tpu_resources_guide.md`](/developer_guide/tpu_resources_guide) (SkyPilot) and per-recipe GKE manifests.
+- Provisioning / quota workflows — see [`developer_guide/tpu_resources_guide.md`](../developer_guide/tpu_resources_guide.md) (SkyPilot) and per-recipe GKE manifests.
 - Per-recipe TP/DP/EP numbers and the §4 benchmark data points — those live in each recipe's `## 2.1 Hardware Matrix`. This page covers the **scaling math** to adapt them, not the specific tested numbers.

--- a/docs/cookbook/deployment/gke-indexed-job.md
+++ b/docs/cookbook/deployment/gke-indexed-job.md
@@ -13,6 +13,6 @@ Common conventions:
 - Let GKE provide TPU worker environment variables such as `TPU_PROCESS_ADDRESSES` and `TPU_WORKER_HOSTNAMES`.
 - Keep `JAX_COMPILATION_CACHE_DIR` set for every rank.
 
-For topology sizing, see [TPU topology reference](/base/tpu-topology-reference). For multi-node startup failures, see [Troubleshooting](/deployment/troubleshooting).
+For topology sizing, see [TPU topology reference](../base/tpu-topology-reference.md). For multi-node startup failures, see [Troubleshooting](../deployment/troubleshooting.md).
 
 The full canonical template lives in the main Sphinx docs at `docs/deployment/gke-indexed-job.md`.

--- a/docs/cookbook/deployment/index.md
+++ b/docs/cookbook/deployment/index.md
@@ -8,9 +8,9 @@ Cookbook recipes keep their model-specific launch commands inline. This page is 
 
 | Topic | Use it for |
 |---|---|
-| [Single-host Docker](/deployment/single-host-docker) | One TPU host such as v6e-4, v6e-8, or v7x-8. |
-| [GKE Indexed Job](/deployment/gke-indexed-job) | Multi-host TPU slices on GKE. |
-| [SkyPilot](/deployment/skypilot) | Advanced multi-host v6e experiments. |
-| [Troubleshooting](/deployment/troubleshooting) | Startup, multi-node, runtime, tokenizer, and cache failures shared across recipes. |
+| [Single-host Docker](../deployment/single-host-docker.md) | One TPU host such as v6e-4, v6e-8, or v7x-8. |
+| [GKE Indexed Job](../deployment/gke-indexed-job.md) | Multi-host TPU slices on GKE. |
+| [SkyPilot](../deployment/skypilot.md) | Advanced multi-host v6e experiments. |
+| [Troubleshooting](../deployment/troubleshooting.md) | Startup, multi-node, runtime, tokenizer, and cache failures shared across recipes. |
 
 The canonical Sphinx pages live under `docs/deployment/`; these cookbook pages are thin Mintlify-safe bridges for recipe links.

--- a/docs/cookbook/deployment/single-host-docker.md
+++ b/docs/cookbook/deployment/single-host-docker.md
@@ -13,6 +13,6 @@ Common conventions:
 - Entrypoint: `python -m sgl_jax.launch_server`.
 - Compilation cache: set `JAX_COMPILATION_CACHE_DIR` to a writable path such as `/tmp/jit_cache`.
 
-Follow the current recipe's §2.3 launch command after preparing the container. For runtime flags, see [Launch flags reference](/base/launch-flags-reference). For failures, see [Troubleshooting](/deployment/troubleshooting).
+Follow the current recipe's §2.3 launch command after preparing the container. For runtime flags, see [Launch flags reference](../base/launch-flags-reference.md). For failures, see [Troubleshooting](../deployment/troubleshooting.md).
 
 The full canonical template lives in the main Sphinx docs at `docs/deployment/single-host-docker.md`.

--- a/docs/cookbook/deployment/skypilot.md
+++ b/docs/cookbook/deployment/skypilot.md
@@ -13,6 +13,6 @@ Common conventions:
 - Keep distributed flags aligned with the recipe: `--nnodes`, `--node-rank`, `--dist-init-addr`, `--tp-size`, `--dp-size`, and `--ep-size`.
 - Use a persistent compilation cache when running repeated experiments.
 
-For TPU sizing, see [TPU topology reference](/base/tpu-topology-reference). For provisioning and quota notes, see [TPU resources guide](/developer_guide/tpu_resources_guide).
+For TPU sizing, see [TPU topology reference](../base/tpu-topology-reference.md). For provisioning and quota notes, see [TPU resources guide](../developer_guide/tpu_resources_guide.md).
 
 The full canonical template lives in the main Sphinx docs at `docs/deployment/skypilot.md`.

--- a/docs/cookbook/developer_guide/tpu_resources_guide.md
+++ b/docs/cookbook/developer_guide/tpu_resources_guide.md
@@ -6,7 +6,7 @@ title: "TPU Resources Guide"
 
 Use this page as the cookbook-local pointer for TPU provisioning notes referenced by topology and SkyPilot guidance.
 
-For cookbook sizing math, start with [TPU topology reference](/base/tpu-topology-reference). Recipes list only topologies that have been validated or partially validated.
+For cookbook sizing math, start with [TPU topology reference](../base/tpu-topology-reference.md). Recipes list only topologies that have been validated or partially validated.
 
 When provisioning TPU resources:
 

--- a/docs/cookbook/diffusion/Wan/Wan2.1.md
+++ b/docs/cookbook/diffusion/Wan/Wan2.1.md
@@ -17,7 +17,7 @@ title: "Wan 2.1 T2V"
 
 **Recommended Generation Parameters** (request body, not launch flags):
 
-- `size` - `720*1280` (default), `480*832` (lower-cost), or another precompiled bucket. **Format is `WIDTH*HEIGHT` (asterisk-separated), the same syntax as `--precompile-width-heights`.** Sending `WIDTHxHEIGHT` (lowercase `x`) raises `ValueError: invalid literal for int() with base 10: ...` and crashes the GlobalScheduler. Must match a precompiled bucket; see [§2.4 Configuration Tips](/diffusion/Wan/Wan2.1#2-4-configuration-tips).
+- `size` - `720*1280` (default), `480*832` (lower-cost), or another precompiled bucket. **Format is `WIDTH*HEIGHT` (asterisk-separated), the same syntax as `--precompile-width-heights`.** Sending `WIDTHxHEIGHT` (lowercase `x`) raises `ValueError: invalid literal for int() with base 10: ...` and crashes the GlobalScheduler. Must match a precompiled bucket; see [§2.4 Configuration Tips](../../diffusion/Wan/Wan2.1.md#2-4-configuration-tips).
 - `num_frames` - defaults to the model-card recommended count, commonly 41 for Wan 2.1.
 - `num_inference_steps` - defaults to the model-card recommended count.
 - `seconds` / `fps` - alternative way to specify frame count; the server resolves to `num_frames`.
@@ -34,11 +34,11 @@ title: "Wan 2.1 T2V"
 
 > Wan 2.1 runs through SGL-JAX's built-in staged multimodal runtime. Use the `--tp-size` shown for this model; moving to a larger TPU host or slice does not automatically make every stage use more devices.
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install) and use [Single-host Docker template](/deployment/single-host-docker) for the container setup.
+Install per [Install guide](../../get_started/install.md) and use [Single-host Docker template](../../deployment/single-host-docker.md) for the container setup.
 
 No extra pip package is needed for video generation. The response returns a video path or URL, and any post-processing such as MP4 transcoding happens client-side.
 
@@ -107,7 +107,7 @@ VAE tiling is enabled by default in the multimodal server and there is no `--no-
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` avoids recompiling the same `(resolution x frame-count)` buckets across server restarts.
 - The cache keys on full kernel shape. Changing `--precompile-width-heights`, `--precompile-frame-paddings`, `--tp-size`, or `--dit-precision` invalidates cached entries.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference) and the multimodal-specific options (`python -m sgl_jax.launch_server --multimodal --help`).
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md) and the multimodal-specific options (`python -m sgl_jax.launch_server --multimodal --help`).
 
 ## 3. Invocation
 
@@ -217,5 +217,5 @@ This is a single-shot smoke datapoint, not a throughput sweep. Throughput sweeps
 
 - [Wan-AI model collection](https://huggingface.co/Wan-AI)
 - [Wan2.1-T2V-14B-Diffusers model card](https://huggingface.co/Wan-AI/Wan2.1-T2V-14B-Diffusers)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/diffusion/Wan/Wan2.2.md
+++ b/docs/cookbook/diffusion/Wan/Wan2.2.md
@@ -22,7 +22,7 @@ title: "Wan 2.2 T2V"
 
 **Recommended Generation Parameters** (request body, not launch flags):
 
-- `size` - `720*1280` (default), `480*832` (lower-cost), or another precompiled bucket. **Format is `WIDTH*HEIGHT` (asterisk-separated), the same syntax as `--precompile-width-heights`.** Sending `WIDTHxHEIGHT` (lowercase `x`) raises `ValueError: invalid literal for int() with base 10: ...` and crashes the GlobalScheduler. Must match a precompiled bucket; see [§2.4 Configuration Tips](/diffusion/Wan/Wan2.2#2-4-configuration-tips).
+- `size` - `720*1280` (default), `480*832` (lower-cost), or another precompiled bucket. **Format is `WIDTH*HEIGHT` (asterisk-separated), the same syntax as `--precompile-width-heights`.** Sending `WIDTHxHEIGHT` (lowercase `x`) raises `ValueError: invalid literal for int() with base 10: ...` and crashes the GlobalScheduler. Must match a precompiled bucket; see [§2.4 Configuration Tips](../../diffusion/Wan/Wan2.2.md#2-4-configuration-tips).
 - `num_frames` - choose a value you also pass through `--precompile-frame-paddings`.
 - `num_inference_steps` - defaults to the model-card recommended count.
 - `seconds` / `fps` - alternative way to specify frame count; the server resolves to `num_frames`.
@@ -39,11 +39,11 @@ title: "Wan 2.2 T2V"
 
 > Wan 2.2 runs through SGL-JAX's built-in staged multimodal runtime. Use the `--tp-size` shown for this model; moving to a larger TPU host or slice does not automatically make every stage use more devices.
 
-See [TPU topology reference](/base/tpu-topology-reference) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](/base/tpu-topology-reference#adapting-to-other-topologies).
+See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU generation reference. For other slices (larger v6e, v7x variants), see [Adapting to other topologies](../../base/tpu-topology-reference.md#adapting-to-other-topologies).
 
 ### 2.2 Environment
 
-Install per [Install guide](/get_started/install) and use [Single-host Docker template](/deployment/single-host-docker) for the container setup.
+Install per [Install guide](../../get_started/install.md) and use [Single-host Docker template](../../deployment/single-host-docker.md) for the container setup.
 
 No extra pip package is needed for video generation. The response returns a video path or URL, and any post-processing such as MP4 transcoding happens client-side.
 
@@ -112,7 +112,7 @@ VAE tiling is enabled by default in the multimodal server and there is no `--no-
 - `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache` avoids recompiling the same `(resolution x frame-count)` buckets across server restarts.
 - The cache keys on full kernel shape. Changing `--precompile-width-heights`, `--precompile-frame-paddings`, `--tp-size`, or `--dit-precision` invalidates cached entries.
 
-For full flag definitions see [Launch flags reference](/base/launch-flags-reference) and the multimodal-specific options (`python -m sgl_jax.launch_server --multimodal --help`).
+For full flag definitions see [Launch flags reference](../../base/launch-flags-reference.md) and the multimodal-specific options (`python -m sgl_jax.launch_server --multimodal --help`).
 
 ## 3. Invocation
 
@@ -222,5 +222,5 @@ This is a single-shot smoke datapoint, not a throughput sweep. Throughput sweeps
 
 - [Wan-AI model collection](https://huggingface.co/Wan-AI)
 - [Wan2.2-T2V-A14B-Diffusers model card](https://huggingface.co/Wan-AI/Wan2.2-T2V-A14B-Diffusers)
-- [Launch flags reference](/base/launch-flags-reference)
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [Launch flags reference](../../base/launch-flags-reference.md)
+- [Cross-recipe troubleshooting](../../deployment/troubleshooting.md) — cross-recipe generic issues.

--- a/docs/cookbook/diffusion/index.md
+++ b/docs/cookbook/diffusion/index.md
@@ -22,8 +22,8 @@ End-to-end serving recipes for diffusion-style image and video generation models
 
 | Status | Model | Recipe | Min TPU | Modality | Endpoint |
 |---|---|---|---|---|---|
-| ✅ | Wan 2.1 T2V-14B | [`Wan/Wan2.1.md`](/diffusion/Wan/Wan2.1) | v6e-4 | Text-to-video diffusion | `/api/v1/videos/generation`, `/api/v1/images/generation` |
-| ✅ | Wan 2.2 T2V A14B | [`Wan/Wan2.2.md`](/diffusion/Wan/Wan2.2) | v6e-4 | Text-to-video diffusion | `/api/v1/videos/generation`, `/api/v1/images/generation` |
+| ✅ | Wan 2.1 T2V-14B | [`Wan/Wan2.1.md`](../diffusion/Wan/Wan2.1.md) | v6e-4 | Text-to-video diffusion | `/api/v1/videos/generation`, `/api/v1/images/generation` |
+| ✅ | Wan 2.2 T2V A14B | [`Wan/Wan2.2.md`](../diffusion/Wan/Wan2.2.md) | v6e-4 | Text-to-video diffusion | `/api/v1/videos/generation`, `/api/v1/images/generation` |
 
 > Upgrade path: 🚧 → 🧪 requires measured launch / quality / wall-clock output for at least one variant and hardware path. 🧪 → ✅ requires complete evidence for the recipe's claimed primary path.
 
@@ -31,7 +31,7 @@ End-to-end serving recipes for diffusion-style image and video generation models
 
 A diffusion recipe covers models where the expensive generation loop is denoising, not autoregressive token decoding. For Wan, SGL-JAX stages a text encoder, a DiT denoiser, and a VAE decoder; the endpoint returns an image or video artifact rather than chat tokens.
 
-Autoregressive text and vision-language decoders, including Qwen2.5-VL, live in [Autoregressive recipes](/autoregressive).
+Autoregressive text and vision-language decoders, including Qwen2.5-VL, live in [Autoregressive recipes](../autoregressive/index.md).
 
 ## Built-in Staging Constraint
 
@@ -48,15 +48,15 @@ Current cookbook-facing configuration summary:
 
 ## Shared references
 
-- [TPU topology reference](/base/tpu-topology-reference) — TPU generation / HBM / topology.
-- [Launch flags reference](/base/launch-flags-reference) — launch flag full table; diffusion-specific flags appear when you run `python -m sgl_jax.launch_server --multimodal --help`.
-- [Deployment templates](/deployment) — launcher templates (single-host Docker, GKE Indexed Job, and advanced SkyPilot v6e experiments).
-- [Cross-recipe troubleshooting](/deployment/troubleshooting) — cross-recipe generic issues.
+- [TPU topology reference](../base/tpu-topology-reference.md) — TPU generation / HBM / topology.
+- [Launch flags reference](../base/launch-flags-reference.md) — launch flag full table; diffusion-specific flags appear when you run `python -m sgl_jax.launch_server --multimodal --help`.
+- [Deployment templates](../deployment/index.md) — launcher templates (single-host Docker, GKE Indexed Job, and advanced SkyPilot v6e experiments).
+- [Cross-recipe troubleshooting](../deployment/troubleshooting.md) — cross-recipe generic issues.
 
 ## Picking a starting recipe to clone
 
 | Goal | Clone from |
 |---|---|
-| Text-to-video diffusion with Wan 2.1 | [`Wan/Wan2.1.md`](/diffusion/Wan/Wan2.1) ✅ |
-| Text-to-video diffusion with Wan 2.2 | [`Wan/Wan2.2.md`](/diffusion/Wan/Wan2.2) ✅ |
-| Text-to-image diffusion (prompt → image) | Use [`Wan/Wan2.1.md`](/diffusion/Wan/Wan2.1) or [`Wan/Wan2.2.md`](/diffusion/Wan/Wan2.2) as the current staged runtime pattern, then replace the model path and endpoint examples as needed |
+| Text-to-video diffusion with Wan 2.1 | [`Wan/Wan2.1.md`](../diffusion/Wan/Wan2.1.md) ✅ |
+| Text-to-video diffusion with Wan 2.2 | [`Wan/Wan2.2.md`](../diffusion/Wan/Wan2.2.md) ✅ |
+| Text-to-image diffusion (prompt → image) | Use [`Wan/Wan2.1.md`](../diffusion/Wan/Wan2.1.md) or [`Wan/Wan2.2.md`](../diffusion/Wan/Wan2.2.md) as the current staged runtime pattern, then replace the model path and endpoint examples as needed |

--- a/docs/cookbook/get_started/install.md
+++ b/docs/cookbook/get_started/install.md
@@ -18,6 +18,6 @@ Use the extra that matches your hardware:
 - `python[gpu]` for GPU experiments.
 - `python[cpu]` for CPU-only debugging.
 
-After installation, return to the model recipe and use its §2.3 launch command. For reusable launcher patterns, see [Deployment references](/deployment).
+After installation, return to the model recipe and use its §2.3 launch command. For reusable launcher patterns, see [Deployment references](../deployment/index.md).
 
 The full canonical installation guide lives in the main Sphinx docs at `docs/get_started/install.md`.

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -12,16 +12,16 @@ End-to-end recipes for serving specific models on specific TPU (or GPU) topologi
 
 | Section | What's inside |
 |---|---|
-| [`autoregressive/`](/autoregressive) | Token-generating recipes organized by vendor subdir: text-only LLMs plus vision-language decoders such as Qwen2.5-VL. |
-| [`diffusion/`](/diffusion) | Diffusion-style media generation recipes such as Wan 2.1/2.2 T2V. |
-| [`base/basic-api-usage.md`](/base/basic-api-usage) | Shared request examples for running OpenAI-compatible and native API calls. |
-| [`base/tpu-topology-reference.md`](/base/tpu-topology-reference) | TPU generation, topology, device-count, and HBM reference. |
-| [`base/launch-flags-reference.md`](/base/launch-flags-reference) | Cookbook-focused launch flag notes used by model recipes. |
-| [`deployment/`](/deployment) | Cookbook-local bridge pages for cross-cutting deployment templates and troubleshooting. |
-| [`get_started/install.md`](/get_started/install) | Cookbook-local bridge page for installation prerequisites. |
-| [`add-recipe.md`](/add-recipe) | Checklist for adding a new recipe or upgrading a recipe from Starter to Validated. |
+| [`autoregressive/`](./autoregressive/index.md) | Token-generating recipes organized by vendor subdir: text-only LLMs plus vision-language decoders such as Qwen2.5-VL. |
+| [`diffusion/`](./diffusion/index.md) | Diffusion-style media generation recipes such as Wan 2.1/2.2 T2V. |
+| [`base/basic-api-usage.md`](./base/basic-api-usage.md) | Shared request examples for running OpenAI-compatible and native API calls. |
+| [`base/tpu-topology-reference.md`](./base/tpu-topology-reference.md) | TPU generation, topology, device-count, and HBM reference. |
+| [`base/launch-flags-reference.md`](./base/launch-flags-reference.md) | Cookbook-focused launch flag notes used by model recipes. |
+| [`deployment/`](./deployment/index.md) | Cookbook-local bridge pages for cross-cutting deployment templates and troubleshooting. |
+| [`get_started/install.md`](./get_started/install.md) | Cookbook-local bridge page for installation prerequisites. |
+| [`add-recipe.md`](./add-recipe.md) | Checklist for adding a new recipe or upgrading a recipe from Starter to Validated. |
 
-Cross-cutting launcher templates and troubleshooting live in the main Sphinx docs. Cookbook recipes link to the cookbook-local [Deployment references](/deployment) and [Troubleshooting](/deployment/troubleshooting) bridge pages so Mintlify can resolve them inside the cookbook root.
+Cross-cutting launcher templates and troubleshooting live in the main Sphinx docs. Cookbook recipes link to the cookbook-local [Deployment references](./deployment/index.md) and [Troubleshooting](./deployment/troubleshooting.md) bridge pages so Mintlify can resolve them inside the cookbook root.
 
 ## Conventions
 
@@ -32,7 +32,7 @@ Every recipe follows the **same four-section template** so you can scan any page
 3. **Invocation** — basic `curl` / OpenAI-compatible request examples; reasoning / tool-call patterns where applicable.
 4. **Benchmark** — accuracy (`evalscope`) and throughput (`bench_serving`) commands with reference numbers.
 
-Model-specific constraints are documented inline in each recipe's §2.4 Configuration Tips; cross-cutting startup / multi-node / runtime failures live in [Troubleshooting](/deployment/troubleshooting).
+Model-specific constraints are documented inline in each recipe's §2.4 Configuration Tips; cross-cutting startup / multi-node / runtime failures live in [Troubleshooting](./deployment/troubleshooting.md).
 
 Recipes carry one of five status banners at the top:
 
@@ -44,51 +44,51 @@ Recipes carry one of five status banners at the top:
 
 ## Hardware coverage at a glance
 
-Status prefix: ✅ validated · 🧪 partially validated · 🚧 starter (not yet measured). See [`autoregressive/index.md`](/autoregressive) for the full status legend and vendor breakdown.
+Status prefix: ✅ validated · 🧪 partially validated · 🚧 starter (not yet measured). See [`autoregressive/index.md`](./autoregressive/index.md) for the full status legend and vendor breakdown.
 
 ### Single-host (1 node)
 
 | TPU | Topology | Recipes |
 |---|---|---|
-| v6e-4 | 2x2 | ✅ [Qwen-7B-Chat](/autoregressive/Qwen/Qwen) · ✅ [Qwen3-8B / 32B](/autoregressive/Qwen/Qwen3) · ✅ [Qwen2.5-VL 3B / 7B candidates](/autoregressive/Qwen/Qwen2.5-VL) (`--tp-size 1`) · ✅ [Qwen2.5-VL 32B](/autoregressive/Qwen/Qwen2.5-VL) (`--tp-size 4`) · ✅ [Llama 3.1 8B-Instruct](/autoregressive/Llama/Llama3.1) · ✅ [Gemma 2 27B-it](/autoregressive/Google/Gemma2) · ✅ [MiMo-7B-RL](/autoregressive/Xiaomi/MiMo-7B) · ✅ [DeepSeek-V2-Lite](/autoregressive/DeepSeek/DeepSeek-V2) |
-| v7x-8 | single host (4 chips × 2 devices) | ✅ [Qwen2.5-VL-32B](/autoregressive/Qwen/Qwen2.5-VL) (`--tp-size 8 --dp-size 4`) · ✅ [MiMo-V2-Flash](/autoregressive/Xiaomi/MiMo-V2-Flash) |
+| v6e-4 | 2x2 | ✅ [Qwen-7B-Chat](./autoregressive/Qwen/Qwen.md) · ✅ [Qwen3-8B / 32B](./autoregressive/Qwen/Qwen3.md) · ✅ [Qwen2.5-VL 3B / 7B candidates](./autoregressive/Qwen/Qwen2.5-VL.md) (`--tp-size 1`) · ✅ [Qwen2.5-VL 32B](./autoregressive/Qwen/Qwen2.5-VL.md) (`--tp-size 4`) · ✅ [Llama 3.1 8B-Instruct](./autoregressive/Llama/Llama3.1.md) · ✅ [Gemma 2 27B-it](./autoregressive/Google/Gemma2.md) · ✅ [MiMo-7B-RL](./autoregressive/Xiaomi/MiMo-7B.md) · ✅ [DeepSeek-V2-Lite](./autoregressive/DeepSeek/DeepSeek-V2.md) |
+| v7x-8 | single host (4 chips × 2 devices) | ✅ [Qwen2.5-VL-32B](./autoregressive/Qwen/Qwen2.5-VL.md) (`--tp-size 8 --dp-size 4`) · ✅ [MiMo-V2-Flash](./autoregressive/Xiaomi/MiMo-V2-Flash.md) |
 
 ### Multi-host
 
 | TPU | Topology | Nodes | Recipes |
 |---|---|---|---|
-| v6e-16 | 4x4 | 4 | ✅ [MiMo-V2-Flash](/autoregressive/Xiaomi/MiMo-V2-Flash) · ✅ [Qwen3-30B-A3B MoE](/autoregressive/Qwen/Qwen3-MoE) · ✅ [Kimi-Linear](/autoregressive/Moonshotai/Kimi-Linear) |
-| v6e-32 | 4x8 | 8 | ✅ [Llama 3.3 70B](/autoregressive/Llama/Llama3.3-70B) · ✅ [GLM-4.5-Air](/autoregressive/GLM/GLM-4.5) |
-| v6e-64 | 4x4x4 | 16 | ✅ [MiMo-V2.5-Pro](/autoregressive/Xiaomi/MiMo-V2.5-Pro) · ✅ [Grok-2](/autoregressive/Grok/Grok2) · ✅ [DeepSeek-V3](/autoregressive/DeepSeek/DeepSeek-V3) · ✅ [DeepSeek-R1](/autoregressive/DeepSeek/DeepSeek-R1) · ✅ [Ling-2.6](/autoregressive/InclusionAI/Ling-2.6) |
-| v7x-16 | 2x2x4 | 4 | 🧪 [MiMo-V2.5-Pro](/autoregressive/Xiaomi/MiMo-V2.5-Pro) · ✅ [Ling-2.6](/autoregressive/InclusionAI/Ling-2.6) · ✅ [DeepSeek-V3](/autoregressive/DeepSeek/DeepSeek-V3) · ✅ [DeepSeek-R1](/autoregressive/DeepSeek/DeepSeek-R1) |
+| v6e-16 | 4x4 | 4 | ✅ [MiMo-V2-Flash](./autoregressive/Xiaomi/MiMo-V2-Flash.md) · ✅ [Qwen3-30B-A3B MoE](./autoregressive/Qwen/Qwen3-MoE.md) · ✅ [Kimi-Linear](./autoregressive/Moonshotai/Kimi-Linear.md) |
+| v6e-32 | 4x8 | 8 | ✅ [Llama 3.3 70B](./autoregressive/Llama/Llama3.3-70B.md) · ✅ [GLM-4.5-Air](./autoregressive/GLM/GLM-4.5.md) |
+| v6e-64 | 4x4x4 | 16 | ✅ [MiMo-V2.5-Pro](./autoregressive/Xiaomi/MiMo-V2.5-Pro.md) · ✅ [Grok-2](./autoregressive/Grok/Grok2.md) · ✅ [DeepSeek-V3](./autoregressive/DeepSeek/DeepSeek-V3.md) · ✅ [DeepSeek-R1](./autoregressive/DeepSeek/DeepSeek-R1.md) · ✅ [Ling-2.6](./autoregressive/InclusionAI/Ling-2.6.md) |
+| v7x-16 | 2x2x4 | 4 | 🧪 [MiMo-V2.5-Pro](./autoregressive/Xiaomi/MiMo-V2.5-Pro.md) · ✅ [Ling-2.6](./autoregressive/InclusionAI/Ling-2.6.md) · ✅ [DeepSeek-V3](./autoregressive/DeepSeek/DeepSeek-V3.md) · ✅ [DeepSeek-R1](./autoregressive/DeepSeek/DeepSeek-R1.md) |
 
 ### Diffusion (`--multimodal` server)
 
 | TPU | Topology | Recipes |
 |---|---|---|
-| v6e-4 | 2x2 | ✅ [Wan 2.1 T2V-14B](/diffusion/Wan/Wan2.1) (`--tp-size 2`) · ✅ [Wan 2.2 T2V A14B](/diffusion/Wan/Wan2.2) (`--tp-size 1`) |
+| v6e-4 | 2x2 | ✅ [Wan 2.1 T2V-14B](./diffusion/Wan/Wan2.1.md) (`--tp-size 2`) · ✅ [Wan 2.2 T2V A14B](./diffusion/Wan/Wan2.2.md) (`--tp-size 1`) |
 
 ### Pending autoregressive paths
 
 | Scope | Recipes |
 |---|---|
-| Multi-host VL | ✅ [Qwen2.5-VL 72B](/autoregressive/Qwen/Qwen2.5-VL) (needs a matching staged path + scheduler fix) |
+| Multi-host VL | ✅ [Qwen2.5-VL 72B](./autoregressive/Qwen/Qwen2.5-VL.md) (needs a matching staged path + scheduler fix) |
 
-For TPU generation/HBM/per-chip-device specs, see [`base/tpu-topology-reference.md`](/base/tpu-topology-reference).
+For TPU generation/HBM/per-chip-device specs, see [`base/tpu-topology-reference.md`](./base/tpu-topology-reference.md).
 
 Vision-language and diffusion rows are constrained by SGL-JAX's built-in staged runtime. A larger TPU slice is not automatically used unless the selected model path supports that placement.
 
 ## Adding a new recipe
 
 1. Pick the most similar existing recipe as a starting point:
-   - Validated single-host dense: [`autoregressive/Qwen/Qwen.md`](/autoregressive/Qwen/Qwen) is the smallest fully measured pattern.
-   - Validated multi-host reference: [`autoregressive/Moonshotai/Kimi-Linear.md`](/autoregressive/Moonshotai/Kimi-Linear) shows the complete multi-host benchmark / accuracy structure.
-   - Partially validated large-MoE pattern: [`autoregressive/Xiaomi/MiMo-V2.5-Pro.md`](/autoregressive/Xiaomi/MiMo-V2.5-Pro) is the broadest GKE / multi-host reference, with some benchmark cells still pending.
-   - Starter pattern: [`autoregressive/Llama/Llama3.1.md`](/autoregressive/Llama/Llama3.1) is the smallest skeleton.
+   - Validated single-host dense: [`autoregressive/Qwen/Qwen.md`](./autoregressive/Qwen/Qwen.md) is the smallest fully measured pattern.
+   - Validated multi-host reference: [`autoregressive/Moonshotai/Kimi-Linear.md`](./autoregressive/Moonshotai/Kimi-Linear.md) shows the complete multi-host benchmark / accuracy structure.
+   - Partially validated large-MoE pattern: [`autoregressive/Xiaomi/MiMo-V2.5-Pro.md`](./autoregressive/Xiaomi/MiMo-V2.5-Pro.md) is the broadest GKE / multi-host reference, with some benchmark cells still pending.
+   - Starter pattern: [`autoregressive/Llama/Llama3.1.md`](./autoregressive/Llama/Llama3.1.md) is the smallest skeleton.
 2. Copy its four-section structure.
 3. Place the new file under `autoregressive/<Vendor>/` (PascalCase, matching upstream [sgl-cookbook](https://github.com/sgl-project/sgl-cookbook/tree/main/docs/autoregressive) naming). Create a new vendor subdir if needed.
 4. Mark the top banner **Starter** until you have measured numbers; then upgrade to **Partially validated** or **Validated** based on the status legend.
 5. Fill in real `evalscope` and `bench_serving` outputs — do not leave `_Pending_` cells in a Validated recipe's claimed primary path.
-6. Add an entry to this index's *Hardware coverage* table and to [`autoregressive/index.md`](/autoregressive) or [`diffusion/index.md`](/diffusion).
-7. Cross-link tunable flags in §2.4 to [`base/launch-flags-reference.md`](/base/launch-flags-reference) for non-obvious flags.
+6. Add an entry to this index's *Hardware coverage* table and to [`autoregressive/index.md`](./autoregressive/index.md) or [`diffusion/index.md`](./diffusion/index.md).
+7. Cross-link tunable flags in §2.4 to [`base/launch-flags-reference.md`](./base/launch-flags-reference.md) for non-obvious flags.
 8. Keep benchmark evidence in the recipe's own Benchmark section so validation numbers stay next to the launch command they validate.


### PR DESCRIPTION

## Motivation


Markdown reference link not working in github.

Cookbook links rendered by repository Markdown started at the repository root or omitted the target filename, producing 404s outside Mintlify.

## Modifications


Replace all 275 root-relative cookbook links with file-relative links across 31 pages.

Point every internal link at an explicit .md file and every directory route at index.md, preserving anchors so Mintlify and GitHub resolve the same targets.


## Accuracy Tests

mint validate: passes.
mint broken-links: passes.
Tested in github by clicking the reference link



## Checklist

- [ ] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
