### PR TITLE
docs(cookbook): add stable cross-renderer anchors

### DIFF
--- a/docs/cookbook/add-recipe.md
+++ b/docs/cookbook/add-recipe.md
@@ -48,5 +48,6 @@ When adding a page:
 2. Add it to the relevant model index, such as `autoregressive/index.md` or `diffusion/index.md`.
 3. Add or update the hardware coverage table in `docs/cookbook/index.md`.
 4. Keep benchmark matrices in the recipe benchmark section or summarize them there; do not create a standalone benchmark-report section.
-5. If the recipe introduces a non-obvious runtime flag, link to `/base/launch-flags-reference`.
-6. Keep cookbook links inside the `docs/cookbook` root with extensionless root routes such as `/deployment/troubleshooting`. Do not link to `../deployment/*`, `../get_started/*`, or other paths outside the cookbook root.
+5. If the recipe introduces a non-obvious runtime flag, link to `base/launch-flags-reference.md` using a file-relative path from the current page (for example, `../../base/launch-flags-reference.md` from a vendor recipe).
+6. Keep internal cookbook links inside the `docs/cookbook` root. Use file-relative paths with the `.md` extension, and point directory landing pages at their explicit `index.md` file; do not use root-relative site routes or paths outside the cookbook root.
+7. For cross-page section links, add a stable explicit anchor such as `<a id="configuration-tips"></a>` immediately before the target heading and link to that ID. Do not rely on an automatically generated heading slug, because GitHub and Mintlify generate different IDs for numbered headings.

--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-R1.md
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-R1.md
@@ -15,7 +15,7 @@ title: "DeepSeek R1"
 - **MLA** — uses the FlashAttention Pallas MLA kernel by default; no extra flag needed.
 - **MoE with shared + routed experts** — 256 routed experts and 1 shared expert per MoE layer; first 3 layers are dense MLP. See §2.4 for the backend choice.
 - **FP8 block-quant compatibility** — the per-rank `out_dim` of the shared expert `gate_proj` / `up_proj` must be **strictly greater than** `block_size_out=128`. This forces the v6e-64 mesh shape and is why `--dp-size 8` (effective tensor axis 8) is recommended over `--dp-size 4` (tensor axis 16, which collides with the block size — see §2.4).
-- Reasoning surface needs `--reasoning-parser deepseek-r1` at launch — see [§3.2](../../autoregressive/DeepSeek/DeepSeek-R1.md#3-2-reasoning-thinking-enabled-streaming) for the streaming pattern.
+- Reasoning surface needs `--reasoning-parser deepseek-r1` at launch — see [§3.2](../../autoregressive/DeepSeek/DeepSeek-R1.md#reasoning-streaming) for the streaming pattern.
 
 **Recommended Generation Parameters**: `temperature=0.6`, `top_p=0.95`, `max_tokens=4096+` (give room for thinking).
 
@@ -41,6 +41,8 @@ For evaluation, additionally install `evalscope` in the client environment:
 ```bash
 pip install evalscope==0.17.1
 ```
+
+<a id="deployment-launch"></a>
 
 ### 2.3 Launch
 
@@ -70,7 +72,7 @@ For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](../.
 ### 2.4 Configuration Tips
 
 **Reasoning Parser:**
-- `--reasoning-parser deepseek-r1` is **required** for R1 — without it, the model's `<think>` content stays inline in `content` instead of being split into `reasoning_content`. See [§3.2](../../autoregressive/DeepSeek/DeepSeek-R1.md#3-2-reasoning-thinking-enabled-streaming) for the streaming pattern.
+- `--reasoning-parser deepseek-r1` is **required** for R1 — without it, the model's `<think>` content stays inline in `content` instead of being split into `reasoning_content`. See [§3.2](../../autoregressive/DeepSeek/DeepSeek-R1.md#reasoning-streaming) for the streaming pattern.
 
 **Tensor/Data Mesh Layout:**
 - Mesh shape is `Mesh(data=dp_size, tensor=tp_size/dp_size)`. On v6e-64 with `--tp-size 64 --dp-size 8`, the tensor axis is **8**.
@@ -122,6 +124,8 @@ resp = client.chat.completions.create(
 )
 print(resp.choices[0].message.content)
 ```
+
+<a id="reasoning-streaming"></a>
 
 ### 3.2 Reasoning (thinking-enabled streaming)
 
@@ -192,7 +196,7 @@ For non-streaming requests, the field appears on `response.choices[0].message.re
 | Reasoning Parser | deepseek-r1 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](../../autoregressive/DeepSeek/DeepSeek-R1.md#2-3-launch).
+**Deployment Command** — same as [§2.3](../../autoregressive/DeepSeek/DeepSeek-R1.md#deployment-launch).
 
 **Benchmark Command**
 

--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V2.md
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V2.md
@@ -33,6 +33,8 @@ See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU g
 
 Install per [Install guide](../../get_started/install.md). For V2-Lite single-host use [Single-host Docker template](../../deployment/single-host-docker.md).
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 #### Single-host — TPU v6e-4 (DeepSeek-V2-Lite)
@@ -112,7 +114,7 @@ print(resp.choices[0].message.content)
 
 > **Use the `-Chat` checkpoint for accuracy eval.** The base `DeepSeek-V2-Lite` ships without a chat template; evalscope's few-shot GSM8K prompt loops indefinitely against `/v1/chat/completions` (observed 0.014 score, `finish_reason: length`). The instruct-tuned `DeepSeek-V2-Lite-Chat` has the chat template and parses `\nThe answer is X` reliably.
 
-**Deployment Command** — same as [§2.3](../../autoregressive/DeepSeek/DeepSeek-V2.md#2-3-launch) but swap `--model-path` to `deepseek-ai/DeepSeek-V2-Lite-Chat`.
+**Deployment Command** — same as [§2.3](../../autoregressive/DeepSeek/DeepSeek-V2.md#deployment-launch) but swap `--model-path` to `deepseek-ai/DeepSeek-V2-Lite-Chat`.
 
 **Benchmark Command** — example for GSM8K:
 

--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.md
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.md
@@ -42,6 +42,8 @@ For evaluation, additionally install `evalscope` in the client environment (any 
 pip install evalscope==0.17.1
 ```
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 #### Multi-host — TPU v6e-64
@@ -133,7 +135,7 @@ print(resp.choices[0].message.content)
 | Expert Parallelism | 64 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](../../autoregressive/DeepSeek/DeepSeek-V3.md#2-3-launch).
+**Deployment Command** — same as [§2.3](../../autoregressive/DeepSeek/DeepSeek-V3.md#deployment-launch).
 
 **Benchmark Command**
 

--- a/docs/cookbook/autoregressive/GLM/GLM-4.5.md
+++ b/docs/cookbook/autoregressive/GLM/GLM-4.5.md
@@ -32,6 +32,8 @@ See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU g
 
 Install per [Install guide](../../get_started/install.md). Multi-host required — use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](../../deployment/skypilot.md).
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 #### Multi-host — TPU v6e-32
@@ -238,7 +240,7 @@ To see the full set of `--reasoning-parser` / `--tool-call-parser` keys availabl
 | Expert Parallelism | 32 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](../../autoregressive/GLM/GLM-4.5.md#2-3-launch).
+**Deployment Command** — same as [§2.3](../../autoregressive/GLM/GLM-4.5.md#deployment-launch).
 
 **Benchmark Command** — example for GSM8K:
 

--- a/docs/cookbook/autoregressive/Google/Gemma2.md
+++ b/docs/cookbook/autoregressive/Google/Gemma2.md
@@ -36,6 +36,8 @@ See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU g
 
 Install per [Install guide](../../get_started/install.md) and use [Single-host Docker template](../../deployment/single-host-docker.md) for the container setup.
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 #### Single-host — TPU v6e-4 (Gemma 2 27B-it)
@@ -118,7 +120,7 @@ print(resp.choices[0].message.content)
 | Tensor Parallelism | 4 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3 27B-it](../../autoregressive/Google/Gemma2.md#2-3-launch).
+**Deployment Command** — same as [§2.3 27B-it](../../autoregressive/Google/Gemma2.md#deployment-launch).
 
 **Benchmark Command** — example for GSM8K:
 

--- a/docs/cookbook/autoregressive/Grok/Grok2.md
+++ b/docs/cookbook/autoregressive/Grok/Grok2.md
@@ -13,7 +13,7 @@ title: "Grok-2"
 **Key Features**:
 
 - **~269B MoE / ~70B active** — 8 experts, 2 active per token (25% active fraction); served via SGL-JAX `Grok1ForCausalLM` runtime. The validated v6e-64 path uses `--moe-backend epmoe`.
-- **Base model, not chat-tuned** — has no chat template; use the raw `/v1/completions` endpoint (see [§3.1](../../autoregressive/Grok/Grok2.md#3-1-basic-text-completion-base-model)), not `/v1/chat/completions`. xAI did not release a chat / instruct variant.
+- **Base model, not chat-tuned** — has no chat template; use the raw `/v1/completions` endpoint (see [§3.1](../../autoregressive/Grok/Grok2.md#basic-text-completion)), not `/v1/chat/completions`. xAI did not release a chat / instruct variant.
 - **Pre-sharded TP=8 safetensors checkpoint** — files named `pytorch_model-NNNNN-TP-{000..007}.safetensors`. The 8 per-expert/per-shard files imply the checkpoint expects **TP to be a multiple of 8** when serving (matches `--ep-size 8` for the MoE experts).
 - **GQA attention** — `num_attention_heads=64`, `num_key_value_heads=8` → 8 KV heads (sharding constraint: tensor axis must divide 8).
 - **Long context** — `max_position_embeddings=131072` (128K tokens native).
@@ -105,6 +105,8 @@ For temporary v6e experiments, advanced users can adapt [SkyPilot launcher](../.
 For full flag definitions and defaults see [Launch flags reference](../../base/launch-flags-reference.md).
 
 ## 3. Invocation
+
+<a id="basic-text-completion"></a>
 
 ### 3.1 Basic Text Completion (base model)
 

--- a/docs/cookbook/autoregressive/InclusionAI/Ling-2.6.md
+++ b/docs/cookbook/autoregressive/InclusionAI/Ling-2.6.md
@@ -40,6 +40,8 @@ For evaluation, additionally install `evalscope` in the client environment:
 pip install evalscope==0.17.1
 ```
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 #### Multi-host — TPU v6e-64
@@ -204,7 +206,7 @@ For non-streaming requests, the field appears on `response.choices[0].message.re
 
 ### 4.1 Accuracy — GSM8K
 
-**Deployment Command** — launch a server per [§2.3 Launch](../../autoregressive/InclusionAI/Ling-2.6.md#2-3-launch).
+**Deployment Command** — launch a server per [§2.3 Launch](../../autoregressive/InclusionAI/Ling-2.6.md#deployment-launch).
 
 **Benchmark Command**
 
@@ -232,7 +234,7 @@ evalscope eval \
 
 Sanity-checks the quantized fused-MoE serving path on competition math: AIME 2026 (`MathArena/aime_2026`, 30 problems, pass@1; extracted answers exact-matched against the reference). Point `test/srt/run_eval.py` at the served Ling-2.6-1T endpoint.
 
-**Deployment Command** — launch a server per [§2.3 Launch](../../autoregressive/InclusionAI/Ling-2.6.md#2-3-launch).
+**Deployment Command** — launch a server per [§2.3 Launch](../../autoregressive/InclusionAI/Ling-2.6.md#deployment-launch).
 
 **Benchmark Command**
 

--- a/docs/cookbook/autoregressive/Llama/Llama3.1.md
+++ b/docs/cookbook/autoregressive/Llama/Llama3.1.md
@@ -30,6 +30,8 @@ See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU g
 
 Install per [Install guide](../../get_started/install.md) and use [Single-host Docker template](../../deployment/single-host-docker.md) for the container setup.
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 #### Single-host — TPU v6e-4
@@ -105,7 +107,7 @@ print(resp.choices[0].message.content)
 | Tensor Parallelism | 4 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](../../autoregressive/Llama/Llama3.1.md#2-3-launch).
+**Deployment Command** — same as [§2.3](../../autoregressive/Llama/Llama3.1.md#deployment-launch).
 
 **Benchmark Command** — example for GSM8K:
 

--- a/docs/cookbook/autoregressive/Llama/Llama3.3-70B.md
+++ b/docs/cookbook/autoregressive/Llama/Llama3.3-70B.md
@@ -39,6 +39,8 @@ See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU g
 
 Install per [Install guide](../../get_started/install.md). Multi-host required — use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](../../deployment/skypilot.md).
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 #### Multi-host — TPU v6e-16
@@ -121,7 +123,7 @@ print(resp.choices[0].message.content)
 | Tensor Parallelism | 16 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3 v6e-16](../../autoregressive/Llama/Llama3.3-70B.md#2-3-launch).
+**Deployment Command** — same as [§2.3 v6e-16](../../autoregressive/Llama/Llama3.3-70B.md#deployment-launch).
 
 **Benchmark Command** — example for GSM8K:
 

--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-Linear.md
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-Linear.md
@@ -37,6 +37,8 @@ See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU g
 
 Install per [Install guide](../../get_started/install.md). Multi-host recommended at this size — use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](../../deployment/skypilot.md).
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 Two slices we measured on, each as a separate launch path:
@@ -180,7 +182,7 @@ print()
 | Recurrent State Memory Ratio | 0.9 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — see [§2.3](../../autoregressive/Moonshotai/Kimi-Linear.md#2-3-launch) (v6e-16) or [§2.3](../../autoregressive/Moonshotai/Kimi-Linear.md#2-3-launch) (v6e-32).
+**Deployment Command** — see [§2.3](../../autoregressive/Moonshotai/Kimi-Linear.md#deployment-launch) (v6e-16) or [§2.3](../../autoregressive/Moonshotai/Kimi-Linear.md#deployment-launch) (v6e-32).
 
 **Benchmark Command** — example for GSM8K:
 

--- a/docs/cookbook/autoregressive/Qwen/Qwen.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen.md
@@ -42,6 +42,8 @@ Extra pip for accuracy benchmarking only:
 pip install evalscope
 ```
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 #### Single-host — TPU v6e-4
@@ -117,7 +119,7 @@ print(resp.choices[0].message.content)
 | Tensor Parallelism | 4 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3 Single-host](../../autoregressive/Qwen/Qwen.md#2-3-launch).
+**Deployment Command** — same as [§2.3 Single-host](../../autoregressive/Qwen/Qwen.md#deployment-launch).
 
 **Benchmark Command**
 
@@ -144,7 +146,7 @@ evalscope eval \
 
 **Test Environment** — same as §4.1.
 
-**Deployment Command** — same as [§2.3 Single-host](../../autoregressive/Qwen/Qwen.md#2-3-launch).
+**Deployment Command** — same as [§2.3 Single-host](../../autoregressive/Qwen/Qwen.md#deployment-launch).
 
 **Benchmark Command**
 

--- a/docs/cookbook/autoregressive/Qwen/Qwen2.5-VL.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen2.5-VL.md
@@ -52,6 +52,8 @@ Extra pip for accuracy benchmarking only:
 pip install 'evalscope[app,perf]==1.5.1'
 ```
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 #### Single-host — TPU v7x-8
@@ -230,7 +232,7 @@ print(response.choices[0].message.content)
 
 > **Long video / large image set:** Make sure `--context-length` is large enough to fit the vision token count plus the text prompt and response. Each high-resolution image and each sampled video frame contributes a non-trivial number of vision tokens to the prefill.
 
-> Qwen2.5-VL is non-reasoning (no `<think>` blocks) and does not ship a native tool-call format. For reasoning workloads use [Qwen3](./Qwen3.md); for tool-calling workloads use a model with `--tool-call-parser` support (see [`Qwen3.md` §3.3](./Qwen3.md#3-3-tool-calling)).
+> Qwen2.5-VL is non-reasoning (no `<think>` blocks) and does not ship a native tool-call format. For reasoning workloads use [Qwen3](./Qwen3.md); for tool-calling workloads use a model with `--tool-call-parser` support (see [`Qwen3.md` §3.3](./Qwen3.md#tool-calling)).
 
 ## 4. Benchmark
 
@@ -251,7 +253,7 @@ The data below is a snapshot of Qwen2.5-VL-32B-Instruct on a single TPU v7x-8. A
 | Generation | `max_tokens=8192`, temperature 0, seed 42 |
 | Evaluation batch size | 24 |
 
-**Deployment Command** — use the [§2.3 v7x-8 launch command](./Qwen2.5-VL.md#2-3-launch).
+**Deployment Command** — use the [§2.3 v7x-8 launch command](./Qwen2.5-VL.md#deployment-launch).
 
 **Benchmark Command**
 

--- a/docs/cookbook/autoregressive/Qwen/Qwen3-MoE.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3-MoE.md
@@ -42,6 +42,8 @@ See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU g
 
 Install per [Install guide](../../get_started/install.md). For multi-host launches use [GKE Indexed Job launcher](../../deployment/gke-indexed-job.md) as the primary user-facing path. Advanced users running temporary v6e experiments can adapt [SkyPilot launcher](../../deployment/skypilot.md).
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 #### Multi-host — TPU v6e-16
@@ -303,7 +305,7 @@ To see the full set of `--reasoning-parser` / `--tool-call-parser` keys availabl
 | Expert Parallelism | 16 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](../../autoregressive/Qwen/Qwen3-MoE.md#2-3-launch).
+**Deployment Command** — same as [§2.3](../../autoregressive/Qwen/Qwen3-MoE.md#deployment-launch).
 
 **Benchmark Command** — example for GSM8K (with thinking-on for reasoning):
 

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.md
@@ -41,6 +41,8 @@ Both v6e rows fit on a single v6e-4 host with `bfloat16`; the v7x row uses one 4
 
 Install per [Install guide](../../get_started/install.md) and use [Single-host Docker template](../../deployment/single-host-docker.md) for the container setup.
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 #### Single-host — TPU v6e-4
@@ -188,6 +190,8 @@ The capital of France is Paris.
 
 To see the full set of `--reasoning-parser` keys available in your build, run `python -m sgl_jax.launch_server --help`.
 
+<a id="tool-calling"></a>
+
 ### 3.3 Tool Calling
 
 Launch with `--tool-call-parser qwen25` (compatible with Qwen3 tool-call format) plus `--reasoning-parser qwen3` if you also want thinking. Append these flags to the §2.3 launch command.
@@ -318,7 +322,7 @@ To see the full set of `--tool-call-parser` keys available in your build, run `p
 | Tensor Parallelism | 4 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3 Single-host](../../autoregressive/Qwen/Qwen3.md#2-3-launch).
+**Deployment Command** — same as [§2.3 Single-host](../../autoregressive/Qwen/Qwen3.md#deployment-launch).
 
 **Benchmark Command**
 
@@ -414,7 +418,7 @@ PYTHONPATH=/tmp/sglang-jax/python python -m sgl_jax.bench_serving \
 
 Methodology: TTFT measured at `output_len=1` to isolate first-token latency; ITL / throughput measured at `output_len=1024`. Workload sweeps input lengths 1024 / 4096 / 8192 tokens × output lengths 1 / 1024 tokens × concurrency 8 / 16 / 32 / 64 / 128 / 256.
 
-**Deployment Command** — same as [§2.3 Single-host](../../autoregressive/Qwen/Qwen3.md#2-3-launch).
+**Deployment Command** — same as [§2.3 Single-host](../../autoregressive/Qwen/Qwen3.md#deployment-launch).
 
 **Benchmark Command** — bash driver that sweeps (ISL × OSL × concurrency):
 

--- a/docs/cookbook/autoregressive/Xiaomi/MiMo-7B.md
+++ b/docs/cookbook/autoregressive/Xiaomi/MiMo-7B.md
@@ -35,6 +35,8 @@ See [TPU topology reference](../../base/tpu-topology-reference.md) for the TPU g
 
 Install per [Install guide](../../get_started/install.md) and use [Single-host Docker template](../../deployment/single-host-docker.md) for the container setup.
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 #### Single-host — TPU v6e-4
@@ -57,7 +59,7 @@ JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
 - `--mem-fraction-static 0.88` is the TPU default. Raise to `0.9` for dedicated serving / higher concurrency.
 
 **Tool Calling:**
-- MiMo-7B-RL uses the `mimo` tool-call parser format. Add `--tool-call-parser mimo` when using the OpenAI tools API. See [§3.3](../../autoregressive/Xiaomi/MiMo-7B.md#3-3-tool-calling) for the request/response pattern.
+- MiMo-7B-RL uses the `mimo` tool-call parser format. Add `--tool-call-parser mimo` when using the OpenAI tools API. See [§3.3](../../autoregressive/Xiaomi/MiMo-7B.md#tool-calling) for the request/response pattern.
 
 **Reasoning Parser:**
 - MiMo-7B-RL uses `--reasoning-parser mimo` (alias of the `qwen3` reasoning parser — same `<think>...</think>` format + `enable_thinking` switch). Append to the §2.3 launch command to expose `reasoning_content` separated from `content`.
@@ -150,6 +152,8 @@ response = client.chat.completions.create(
 )
 print(response.choices[0].message.content)
 ```
+
+<a id="tool-calling"></a>
 
 ### 3.3 Tool Calling
 
@@ -285,7 +289,7 @@ To see the full set of `--reasoning-parser` / `--tool-call-parser` keys availabl
 | Reasoning Parser | `mimo` (thinking-on per-request via `chat_template_kwargs.enable_thinking=true`) |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](../../autoregressive/Xiaomi/MiMo-7B.md#2-3-launch) plus `--reasoning-parser mimo --tool-call-parser mimo`.
+**Deployment Command** — same as [§2.3](../../autoregressive/Xiaomi/MiMo-7B.md#deployment-launch) plus `--reasoning-parser mimo --tool-call-parser mimo`.
 
 **Benchmark Command**
 
@@ -322,7 +326,7 @@ Recommended additional datasets for reasoning variants: AIME 2025, MATH.
 | Tensor Parallelism | 4 |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3](../../autoregressive/Xiaomi/MiMo-7B.md#2-3-launch).
+**Deployment Command** — same as [§2.3](../../autoregressive/Xiaomi/MiMo-7B.md#deployment-launch).
 
 **Benchmark Command**
 

--- a/docs/cookbook/autoregressive/Xiaomi/MiMo-V2-Flash.md
+++ b/docs/cookbook/autoregressive/Xiaomi/MiMo-V2-Flash.md
@@ -47,6 +47,8 @@ Extra pip for accuracy benchmarking only:
 pip install evalscope==0.17.1
 ```
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 Two slices we measured on, each as a separate launch path:
@@ -390,7 +392,7 @@ To see the full set of `--tool-call-parser` keys available in your build, run `p
 | Reasoning Parser | `mimo` |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3 Multi-host](../../autoregressive/Xiaomi/MiMo-V2-Flash.md#2-3-launch), plus `--reasoning-parser mimo`.
+**Deployment Command** — same as [§2.3 Multi-host](../../autoregressive/Xiaomi/MiMo-V2-Flash.md#deployment-launch), plus `--reasoning-parser mimo`.
 
 **Benchmark Command**
 
@@ -431,7 +433,7 @@ This recipe uses a **single-workload configuration sweep**: one fixed ISL/OSL/co
 
 **Workload**: 256 prompts, ISL=16384, OSL=1024, concurrency=64 (single fixed cell).
 
-**Deployment Command** — same shape as [§2.3 Single-host](../../autoregressive/Xiaomi/MiMo-V2-Flash.md#2-3-launch), with `--dp-size 1` and the sweep dimensions (`--moe-backend` / `--chunked-prefill-size` / `--swa-full-tokens-ratio` / `--mem-fraction-static`) varied per row.
+**Deployment Command** — same shape as [§2.3 Single-host](../../autoregressive/Xiaomi/MiMo-V2-Flash.md#deployment-launch), with `--dp-size 1` and the sweep dimensions (`--moe-backend` / `--chunked-prefill-size` / `--swa-full-tokens-ratio` / `--mem-fraction-static`) varied per row.
 
 **Benchmark Command**
 

--- a/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md
+++ b/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md
@@ -50,6 +50,8 @@ Extra pip for accuracy benchmarking only:
 pip install evalscope==0.17.1
 ```
 
+<a id="deployment-launch"></a>
+
 ### 2.3 Launch
 
 MiMo-V2.5-Pro is multi-host only. Run the same command on every node; only `${NODE_RANK}` and `${MASTER_ADDR}` vary across nodes.
@@ -160,6 +162,8 @@ resp = client.chat.completions.create(
 print(resp.choices[0].message.content)
 ```
 
+<a id="reasoning-modes"></a>
+
 ### 3.2 Reasoning (thinking-on default, thinking-off optional)
 
 MiMo-V2.5-Pro is a hybrid reasoning model: thinking-on is the default; turn it off per-request via `chat_template_kwargs`. Launch the server with `--reasoning-parser mimo` so the API splits `reasoning_content` from `content`:
@@ -246,6 +250,8 @@ The capital of France is Paris.
 ```
 
 To see the full set of `--reasoning-parser` keys available in your build, run `python -m sgl_jax.launch_server --help`.
+
+<a id="tool-calling"></a>
 
 ### 3.3 Tool Calling
 
@@ -395,7 +401,7 @@ To see the full set of `--tool-call-parser` keys available in your build, run `p
 | Reasoning Parser | `mimo` |
 | Tested build | sglang-jax 0.1.0 |
 
-**Deployment Command** — same as [§2.3 Multi-host (v6e-64)](../../autoregressive/Xiaomi/MiMo-V2.5-Pro.md#2-3-launch), plus `--reasoning-parser mimo`.
+**Deployment Command** — same as [§2.3 Multi-host (v6e-64)](../../autoregressive/Xiaomi/MiMo-V2.5-Pro.md#deployment-launch), plus `--reasoning-parser mimo`.
 
 **Benchmark Command**
 
@@ -430,7 +436,7 @@ evalscope eval \
 | Data Parallelism | 4 |
 | Expert Parallelism | 32 |
 
-**Deployment Command** — same as [§2.3 Multi-host (v7x-16)](../../autoregressive/Xiaomi/MiMo-V2.5-Pro.md#2-3-launch).
+**Deployment Command** — same as [§2.3 Multi-host (v7x-16)](../../autoregressive/Xiaomi/MiMo-V2.5-Pro.md#deployment-launch).
 
 **Benchmark Command**
 

--- a/docs/cookbook/base/launch-flags-reference.md
+++ b/docs/cookbook/base/launch-flags-reference.md
@@ -100,7 +100,7 @@ grep -n 'add_argument' python/sgl_jax/srt/server_args.py
 | `qwen3` (reasoning), `qwen25` / `qwen3_coder` (tool) | _no Qwen recipe currently sets these — pick by model card on a per-checkpoint basis_ |
 | `kimi` (reasoning) | _no Kimi recipe currently sets this_ |
 
-For complete request/response examples see [`mimo-v2.5-pro.md` §3.2](../autoregressive/Xiaomi/MiMo-V2.5-Pro.md#3-2-reasoning-thinking-on-default-thinking-off-optional) (reasoning streaming) and [§3.3](../autoregressive/Xiaomi/MiMo-V2.5-Pro.md#3-3-tool-calling) (tool calling).
+For complete request/response examples see [`mimo-v2.5-pro.md` §3.2](../autoregressive/Xiaomi/MiMo-V2.5-Pro.md#reasoning-modes) (reasoning streaming) and [§3.3](../autoregressive/Xiaomi/MiMo-V2.5-Pro.md#tool-calling) (tool calling).
 
 ## 9. Compilation cache (environment, not a flag)
 

--- a/docs/cookbook/diffusion/Wan/Wan2.1.md
+++ b/docs/cookbook/diffusion/Wan/Wan2.1.md
@@ -17,7 +17,7 @@ title: "Wan 2.1 T2V"
 
 **Recommended Generation Parameters** (request body, not launch flags):
 
-- `size` - `720*1280` (default), `480*832` (lower-cost), or another precompiled bucket. **Format is `WIDTH*HEIGHT` (asterisk-separated), the same syntax as `--precompile-width-heights`.** Sending `WIDTHxHEIGHT` (lowercase `x`) raises `ValueError: invalid literal for int() with base 10: ...` and crashes the GlobalScheduler. Must match a precompiled bucket; see [§2.4 Configuration Tips](../../diffusion/Wan/Wan2.1.md#2-4-configuration-tips).
+- `size` - `720*1280` (default), `480*832` (lower-cost), or another precompiled bucket. **Format is `WIDTH*HEIGHT` (asterisk-separated), the same syntax as `--precompile-width-heights`.** Sending `WIDTHxHEIGHT` (lowercase `x`) raises `ValueError: invalid literal for int() with base 10: ...` and crashes the GlobalScheduler. Must match a precompiled bucket; see [§2.4 Configuration Tips](../../diffusion/Wan/Wan2.1.md#configuration-tips).
 - `num_frames` - defaults to the model-card recommended count, commonly 41 for Wan 2.1.
 - `num_inference_steps` - defaults to the model-card recommended count.
 - `seconds` / `fps` - alternative way to specify frame count; the server resolves to `num_frames`.
@@ -67,6 +67,8 @@ Swap to a different Wan release at your own risk; other Wan releases have differ
 VAE tiling is enabled by default in the multimodal server and there is no `--no-vae-tiling` flag to disable it today.
 
 > `--multimodal` is required. Without it, the text-only launcher boots and the `/api/v1/videos/generation` endpoint is not registered.
+
+<a id="configuration-tips"></a>
 
 ### 2.4 Configuration Tips
 

--- a/docs/cookbook/diffusion/Wan/Wan2.2.md
+++ b/docs/cookbook/diffusion/Wan/Wan2.2.md
@@ -22,7 +22,7 @@ title: "Wan 2.2 T2V"
 
 **Recommended Generation Parameters** (request body, not launch flags):
 
-- `size` - `720*1280` (default), `480*832` (lower-cost), or another precompiled bucket. **Format is `WIDTH*HEIGHT` (asterisk-separated), the same syntax as `--precompile-width-heights`.** Sending `WIDTHxHEIGHT` (lowercase `x`) raises `ValueError: invalid literal for int() with base 10: ...` and crashes the GlobalScheduler. Must match a precompiled bucket; see [§2.4 Configuration Tips](../../diffusion/Wan/Wan2.2.md#2-4-configuration-tips).
+- `size` - `720*1280` (default), `480*832` (lower-cost), or another precompiled bucket. **Format is `WIDTH*HEIGHT` (asterisk-separated), the same syntax as `--precompile-width-heights`.** Sending `WIDTHxHEIGHT` (lowercase `x`) raises `ValueError: invalid literal for int() with base 10: ...` and crashes the GlobalScheduler. Must match a precompiled bucket; see [§2.4 Configuration Tips](../../diffusion/Wan/Wan2.2.md#configuration-tips).
 - `num_frames` - choose a value you also pass through `--precompile-frame-paddings`.
 - `num_inference_steps` - defaults to the model-card recommended count.
 - `seconds` / `fps` - alternative way to specify frame count; the server resolves to `num_frames`.
@@ -72,6 +72,8 @@ Do not reuse commands from other Wan releases for Wan 2.2 — Wan 2.2's current 
 VAE tiling is enabled by default in the multimodal server and there is no `--no-vae-tiling` flag to disable it today.
 
 > `--multimodal` is required. Without it, the text-only launcher boots and the `/api/v1/videos/generation` endpoint is not registered.
+
+<a id="configuration-tips"></a>
 
 ### 2.4 Configuration Tips
 


### PR DESCRIPTION
## Summary

- add explicit semantic anchors for numbered cookbook sections referenced across pages
- retarget 32 section links so they resolve consistently in GitHub and Mintlify
- update `add-recipe.md` to document file-relative `.md` links, explicit `index.md` targets, and stable cross-page anchors

This follows up on #1571, which fixed GitHub file navigation while retaining Mintlify-generated section fragments.

## Validation

- `mint@4.2.856 broken-links --check-anchors`
- static scan of 365 internal cookbook links: no root-relative links, missing targets, or unresolved fragments
- `git diff --check`