### PR TITLE
fix(mla): tiling-legal fallback block sizes + GLM-5.2 v6e tuned entries (#1546)

### DIFF
--- a/python/sgl_jax/srt/kernels/mla/v2/kernel.py
+++ b/python/sgl_jax/srt/kernels/mla/v2/kernel.py
@@ -1412,6 +1412,7 @@ def mla_ragged_paged_attention(
         # placeholder. The "decode" tuned entry also carries
         # `decode_batch_size`, which overrides the caller's value if hit.
         from sgl_jax.srt.kernels.mla.v2.tuned_block_sizes import (
+            get_fallback_block_sizes_mla,
             get_tuned_block_sizes_mla,
         )
 
@@ -1442,18 +1443,23 @@ def mla_ragged_paged_attention(
             page_size_lookup,
             max_num_tokens_lookup,
         )
-        # Fallback hardcoded defaults match the historical
-        # mla_backend.py:97-106 defaults — same numbers that prod was using
-        # before the tuned table existed.
+        # Fallback defaults are derived from the dtype tiling and per-shard
+        # head count so a table miss always yields a Mosaic-legal block
+        # (#1546); for >=16-head bf16 shards they reduce to the historical
+        # mla_backend.py:97-106 numbers.
         if tuned_d is not None:
             bkv_p_d, bq_d, dbs_lookup = tuned_d
             decode_batch_size = dbs_lookup
         else:
-            bkv_p_d, bq_d = 3, 1
+            bkv_p_d, bq_d = get_fallback_block_sizes_mla(
+                "decode", ql_nope.dtype, actual_num_q_heads, page_size_lookup
+            )
         if tuned_m is not None:
             bkv_p_m, bq_m = tuned_m
         else:
-            bkv_p_m, bq_m = 1, 16
+            bkv_p_m, bq_m = get_fallback_block_sizes_mla(
+                "mixed", ql_nope.dtype, actual_num_q_heads, page_size_lookup
+            )
 
         num_kv_pages_per_blocks = (bkv_p_d, 1, bkv_p_m)  # slot[1] is dead
         num_queries_per_blocks = (bq_d, 1, bq_m)

--- a/python/sgl_jax/srt/kernels/mla/v2/tuned_block_sizes.py
+++ b/python/sgl_jax/srt/kernels/mla/v2/tuned_block_sizes.py
@@ -76,6 +76,34 @@ TUNED_BLOCK_SIZES_MLA: dict[str, dict[tuple, tuple]] = {
         ("mixed", "bfloat16", "bfloat16", 16, 512, 64, 128, 256): (8, 256),
         ("mixed", "bfloat16", "bfloat16", 16, 512, 64, 128, 512): (8, 256),
         ("mixed", "bfloat16", "bfloat16", 16, 512, 64, 128, 1024): (8, 256),
+        # ===== GLM-5.2 (kv_lora_rank=512, qk_rope_head_dim=64) =====
+        # Deploy: --tp-size 64 --dp-size 8 --page-size 128
+        # → attention_tp = 8 → per-shard num_q_heads = 64/8 = 8.
+        # Transitional values (#1546): borrowed row-for-row from the DSv3
+        # 16-head family above; validated on a v6e-64 slice with a paired
+        # eval + throughput sweep up to concurrency 460 (zero Mosaic
+        # errors). A tuner sweep should replace these.
+        ("decode", "bfloat16", "bfloat16", 8, 512, 64, 128, 1): (16, 1, 2),
+        ("decode", "bfloat16", "bfloat16", 8, 512, 64, 128, 8): (16, 1, 2),
+        ("decode", "bfloat16", "bfloat16", 8, 512, 64, 128, 16): (32, 1, 2),
+        ("decode", "bfloat16", "bfloat16", 8, 512, 64, 128, 32): (32, 1, 2),
+        ("decode", "bfloat16", "bfloat16", 8, 512, 64, 128, 64): (32, 1, 2),
+        ("decode", "bfloat16", "bfloat16", 8, 512, 64, 128, 128): (32, 1, 2),
+        ("decode", "bfloat16", "bfloat16", 8, 512, 64, 128, 256): (32, 1, 2),
+        ("decode", "bfloat16", "bfloat16", 8, 512, 64, 128, 512): (32, 1, 2),
+        ("decode", "bfloat16", "bfloat16", 8, 512, 64, 128, 1024): (32, 1, 2),
+        ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 128, 1): (16, 64),
+        ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 128, 8): (16, 64),
+        ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 128, 16): (16, 64),
+        ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 128, 32): (16, 64),
+        ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 128, 64): (16, 64),
+        ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 128, 128): (16, 128),
+        ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 128, 256): (8, 256),
+        ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 128, 512): (8, 256),
+        ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 128, 1024): (8, 256),
+        ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 128, 2048): (8, 256),
+        ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 128, 4096): (8, 256),
+        ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 128, 8192): (8, 256),
     },
     "TPU v7": {
         # ===== Ling-2.6-1T (kv_lora_rank=512, qk_rope_head_dim=64) =====

--- a/python/sgl_jax/srt/kernels/mla/v2/tuned_block_sizes.py
+++ b/python/sgl_jax/srt/kernels/mla/v2/tuned_block_sizes.py
@@ -36,6 +36,8 @@ import logging
 import jax.numpy as jnp
 
 from sgl_jax.srt.kernels.ragged_paged_attention.util import (
+    align_to,
+    get_dtype_packing,
     get_tpu_version,
     next_power_of_2,
 )
@@ -305,3 +307,45 @@ def get_tuned_block_sizes_mla(
             device_name,
         )
     return hit
+
+
+def get_fallback_block_sizes_mla(
+    case_label: str,
+    q_dtype,
+    actual_num_q_heads: int,
+    page_size: int,
+) -> tuple:
+    """Tiling-legal hardcoded fallback for tuned-table misses (#1546).
+
+    The historical mixed fallback ``(1, 16)`` implicitly assumed the packed
+    q/o layout fills whole sublane tiles: each token occupies
+    ``align(num_q_heads, q_packing)`` rows, and the bf16 tile is
+    ``8 * q_packing = 16`` rows. With >= 16 q-heads/shard every token fills
+    the tile and any block shape is legal; with fewer heads (e.g. GLM-5.2
+    tp16 -> 4 heads/shard) token boundaries land inside the tile and Mosaic
+    rejects the window at larger mnt buckets
+    (E2002 CompileTimeMosaicMisalignedBlockAndTiling).
+
+    For the sub-tile case we return a block from the validated family: a
+    q-block covering whole tile groups (``bq * heads_padded`` a multiple of
+    ``sublane_tile**2``) and a 2048-token KV block. A table miss should cost
+    performance, never a crash.
+
+    Returns ``(num_kv_pages_per_block, num_queries_per_block)`` for both
+    cases; the decode fallback keeps the historical ``(3, 1)`` (decode runs
+    with ``bq_sz = 1``, no observed illegal geometry).
+    """
+    if case_label == "decode":
+        return (3, 1)
+    if case_label != "mixed":
+        raise ValueError(f"case_label must be 'decode' or 'mixed', got {case_label!r}")
+    q_packing = get_dtype_packing(jnp.dtype(q_dtype))
+    sublane_tile = 8 * q_packing
+    heads_padded = align_to(actual_num_q_heads, q_packing)
+    if heads_padded % sublane_tile == 0:
+        # every token fills whole sublane tiles: the historical fallback is
+        # legal and keeps prod behaviour unchanged for >=16-head shards.
+        return (1, 16)
+    num_queries_per_block = max(sublane_tile, (sublane_tile * sublane_tile) // heads_padded)
+    num_kv_pages_per_block = max(1, 2048 // page_size)
+    return (num_kv_pages_per_block, num_queries_per_block)

--- a/python/sgl_jax/test/test_mla_attention.py
+++ b/python/sgl_jax/test/test_mla_attention.py
@@ -597,6 +597,27 @@ class TestMLAAttention(CustomTestCase):
         # Single-sequence prefill, pure q_len == kv_len, spans many pages.
         self.run_test("prefill", [(1024, 1024)], page_size=32)
 
+    def test_prefill_fallback_subtile_heads_page128(self):
+        # 4 q-heads/shard, page 128, mnt >= 256: the geometry that crashed
+        # Mosaic (E2002) with the historical hardcoded (1, 16) mixed fallback
+        # (#1546). The table is emptied so the lookup always misses and the
+        # derived fallback block sizes are what actually compiles. Total head
+        # count scales with the mesh so the per-shard count stays 4.
+        from sgl_jax.srt.kernels.mla.v2 import tuned_block_sizes as tbs
+
+        with mock.patch.dict(
+            tbs.TUNED_BLOCK_SIZES_MLA,
+            {device: {} for device in tbs.TUNED_BLOCK_SIZES_MLA},
+            clear=True,
+        ):
+            self.run_test(
+                "prefill",
+                [(300, 300), (200, 500)],
+                num_heads=4 * mesh.shape["tensor"],
+                page_size=128,
+                max_total_token_size=204800,  # divisible by page_size=128
+            )
+
     # ---------------- decode -----------------
     # Batch of single-token decodes with diverse kv_lens around page boundaries
     # (e.g. 127 vs 128 vs 129 for page_size=64 stresses aligned vs. partial

--- a/python/sgl_jax/test/test_tuned_block_sizes_mla.py
+++ b/python/sgl_jax/test/test_tuned_block_sizes_mla.py
@@ -25,7 +25,9 @@ def _patch_env(monkeypatch, *, tpu_version: int = 7, device: str = "TPU v7"):
 
 
 def test_empty_table_returns_none(monkeypatch):
-    _patch_env(monkeypatch)
+    # "TPU v5" ships an empty dict — a supported device with no entries yet.
+    # (The "TPU v7" table now carries entries at this key, see #1344.)
+    _patch_env(monkeypatch, tpu_version=5, device="TPU v5")
     assert (
         get_tuned_block_sizes_mla("decode", jnp.bfloat16, jnp.bfloat16, 8, 512, 64, 256, 128)
         is None
@@ -113,7 +115,8 @@ def test_pre_v5_returns_none(monkeypatch):
 
 def test_warned_misses_is_one_shot_per_key(monkeypatch, caplog):
     """Each unique miss-key logs INFO at most once."""
-    _patch_env(monkeypatch)
+    # Use the empty "TPU v5" table so every lookup below is a genuine miss.
+    _patch_env(monkeypatch, tpu_version=5, device="TPU v5")
     import logging
 
     # Bind caplog to the module's logger explicitly — relying on root-level
@@ -131,3 +134,23 @@ def test_warned_misses_is_one_shot_per_key(monkeypatch, caplog):
     get_tuned_block_sizes_mla("mixed", jnp.bfloat16, jnp.bfloat16, 8, 512, 64, 256, 512)
     miss_records = [r for r in caplog.records if "MLA tuned-block-size LOOKUP MISS" in r.message]
     assert len(miss_records) == 2, f"expected 2 miss logs, got {len(miss_records)}"
+
+
+def test_glm52_v6e_entries_hit(monkeypatch):
+    """GLM-5.2 v6e deploy shape (tp64/dp8 -> 8 q-heads/shard, page 128) must
+    hit the table for every decode/mixed mnt bucket (#1546)."""
+    _patch_env(monkeypatch, tpu_version=6, device="TPU v6e")
+    for mnt in (1, 8, 16, 32, 64, 128, 256, 512, 1024):
+        hit = get_tuned_block_sizes_mla("decode", jnp.bfloat16, jnp.bfloat16, 8, 512, 64, 128, mnt)
+        assert hit is not None and len(hit) == 3, f"decode mnt={mnt} missed"
+    for mnt in (1, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192):
+        hit = get_tuned_block_sizes_mla("mixed", jnp.bfloat16, jnp.bfloat16, 8, 512, 64, 128, mnt)
+        assert hit is not None and len(hit) == 2, f"mixed mnt={mnt} missed"
+
+
+def test_glm52_v7_entries_hit(monkeypatch):
+    """GLM-5.2 v7 tp16 shape (4 q-heads/shard, page 128) mixed buckets (#1546)."""
+    _patch_env(monkeypatch, tpu_version=7, device="TPU v7")
+    for mnt in (1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096):
+        hit = get_tuned_block_sizes_mla("mixed", jnp.bfloat16, jnp.bfloat16, 4, 512, 64, 128, mnt)
+        assert hit is not None and len(hit) == 2, f"mixed mnt={mnt} missed"

--- a/python/sgl_jax/test/test_tuned_block_sizes_mla.py
+++ b/python/sgl_jax/test/test_tuned_block_sizes_mla.py
@@ -154,3 +154,62 @@ def test_glm52_v7_entries_hit(monkeypatch):
     for mnt in (1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096):
         hit = get_tuned_block_sizes_mla("mixed", jnp.bfloat16, jnp.bfloat16, 4, 512, 64, 128, mnt)
         assert hit is not None and len(hit) == 2, f"mixed mnt={mnt} missed"
+
+
+def test_fallback_decode_keeps_historical_values():
+    from sgl_jax.srt.kernels.mla.v2.tuned_block_sizes import (
+        get_fallback_block_sizes_mla,
+    )
+
+    assert get_fallback_block_sizes_mla("decode", jnp.bfloat16, 4, 128) == (3, 1)
+    assert get_fallback_block_sizes_mla("decode", jnp.bfloat16, 16, 128) == (3, 1)
+
+
+def test_fallback_mixed_full_tile_heads_keep_historical_values():
+    from sgl_jax.srt.kernels.mla.v2.tuned_block_sizes import (
+        get_fallback_block_sizes_mla,
+    )
+
+    # >=16-head bf16 shards fill whole sublane tiles: historical (1, 16).
+    assert get_fallback_block_sizes_mla("mixed", jnp.bfloat16, 16, 128) == (1, 16)
+    assert get_fallback_block_sizes_mla("mixed", jnp.bfloat16, 32, 128) == (1, 16)
+
+
+def test_fallback_mixed_subtile_heads_are_tiling_legal():
+    """Sub-tile head counts must never return the historical (1, 16) —
+    that's the exact block Mosaic rejects at mnt>=256 for 4-head bf16
+    shards (#1546) — and must land in the validated family."""
+    from sgl_jax.srt.kernels.mla.v2.tuned_block_sizes import (
+        get_fallback_block_sizes_mla,
+    )
+    from sgl_jax.srt.kernels.ragged_paged_attention.util import (
+        align_to,
+        get_dtype_packing,
+    )
+
+    # GLM-5.2 tp16 (4 heads, page 128) must get the v7x-validated (16, 64).
+    assert get_fallback_block_sizes_mla("mixed", jnp.bfloat16, 4, 128) == (16, 64)
+
+    for dtype in (jnp.bfloat16, jnp.float32):
+        packing = get_dtype_packing(jnp.dtype(dtype))
+        tile = 8 * packing
+        for heads in (1, 2, 4, 8):
+            heads_padded = align_to(heads, packing)
+            if heads_padded % tile == 0:
+                continue
+            for page_size in (64, 128, 256):
+                bkv_p, bq = get_fallback_block_sizes_mla("mixed", dtype, heads, page_size)
+                # q-block rows cover whole tile groups
+                assert (bq * heads_padded) % (tile * packing) == 0, (dtype, heads, page_size)
+                assert bq * heads_padded >= tile * tile, (dtype, heads, page_size)
+                # KV block is a whole number of pages covering 2048 tokens
+                assert bkv_p >= 1 and bkv_p * page_size >= min(2048, page_size)
+
+
+def test_fallback_rejects_bad_case_label():
+    from sgl_jax.srt.kernels.mla.v2.tuned_block_sizes import (
+        get_fallback_block_sizes_mla,
+    )
+
+    with pytest.raises(ValueError):
+        get_fallback_block_sizes_mla("prefill", jnp.bfloat16, 4, 128)


### PR DESCRIPTION
Closes #1546.

Two-part fix, exactly as scoped in the issue:

## 1. Correctness: the fallback can no longer produce an illegal block

`mla_ragged_paged_attention`'s hardcoded mixed fallback `(1, 16)` implicitly
assumed the packed q/o layout fills whole sublane tiles: each token occupies
`align(num_q_heads, q_packing)` rows and the bf16 tile is `8 * q_packing = 16`
rows. With >= 16 q-heads/shard every token fills the tile and any block is
legal — with fewer heads (GLM-5.2 tp16 → 4 heads/shard) token boundaries land
inside the tile and Mosaic rejects the window at larger mnt buckets
(`E2002 CompileTimeMosaicMisalignedBlockAndTiling`), killing the server at
compile time on the first table miss.

New `get_fallback_block_sizes_mla()` in `tuned_block_sizes.py`:

- per-token rows fill whole tiles → historical `(1, 16)` (behaviour unchanged
  for every existing >= 16-head deployment);
- sub-tile head counts → a block from the validated family: q-block rows
  covering whole tile groups (`bq * heads_padded` a multiple of the squared
  sublane tile) and a 2048-token KV block. For 4 heads / page 128 this derives
  `(16, 64)` — the same value the v7x tuned entry uses.
- decode fallback keeps `(3, 1)` (decode runs `bq_sz = 1`; no observed illegal
  geometry) but is routed through the same helper for symmetry.

A lookup miss now costs performance, never a crash.

## 2. Performance: GLM-5.2 v6e tuned entries

The v7 `(4, 512, 64, 128, *)` family landed with #1545; this adds the matching
`TPU v6e` family for the GLM-5.2 v6e deploy shape (tp64/dp8 → 8 q-heads/shard,
page 128): 9 decode + 12 mixed buckets, values borrowed row-for-row from the
DSv3 16-head family. Transitional until a proper
`get_block_spec_config_mla.py` sweep; validated with a paired eval +
throughput sweep up to concurrency 460 with zero Mosaic errors.

## Tests

- `test_tuned_block_sizes_mla.py`: fallback derivation invariants
  (sub-tile head counts never get `(1, 16)`; 4-head/page-128 derives the
  v7x-validated `(16, 64)`; >= 16-head keeps historical values), GLM family
  hit coverage for both devices, plus repointing two existing tests at the
  empty `TPU v5` table (their `TPU v7` keys gained entries in #1344).
- `test_mla_attention.py::test_prefill_fallback_subtile_heads_page128`:
  compile+numerics coverage of the fallback path at the crash geometry
  (4 q-heads/shard, page 128, mnt >= 256; the table is emptied so the
  fallback block is what actually compiles). One honest caveat: the E2002
  does not reproduce with the *old* fallback in this isolated test (we
  probed direct kernel calls on a v7x host across mnt 256..8192, including
  feeding q from an in-jit matmul — all compiled). The illegal window only
  materializes when XLA picks the multi-token packed layout for the
  donated q/o buffer inside the full server graph, which matches the
  layout-dependent analysis above and the production stack traces in this
  issue. The test still pins the contract that a table miss must compile
  and match the reference on every device.

## Validation

- v7x host (4 chips): `test_mla_attention.py` + `test_tuned_block_sizes_mla.py`
  — 33 passed with the fix (per-shard head count 4, the issue geometry).
- v6e chip: same suites — 33 passed (includes all 16-head standard shapes:
  no behaviour change; >= 16-head fallback values are bit-identical).
- CPU: table/fallback unit tests 15 passed.

## Test plan

- [x] v7x MLA attention + tuned-table suites green at the issue geometry
- [x] v6e MLA attention + tuned-table suites green
- [x] pre-commit clean
