### PR TITLE
fix(rpa): guard int16 span math by kv capacity

### DIFF
--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -59,6 +59,26 @@ def _semaphore_kwargs(disable_semaphore_checks: bool) -> dict:
     return {}
 
 
+def _get_span_int_dtype(
+    q_dtype: jnp.dtype,
+    *,
+    tpu_version: int,
+    use_causal_mask: bool,
+    pages_per_seq: int,
+    page_size: int,
+) -> jnp.dtype:
+    """Select the narrow span dtype only when the full per-sequence capacity is safe."""
+
+    if (
+        get_dtype_packing(q_dtype) != 1
+        and tpu_version >= 6
+        and use_causal_mask
+        and pages_per_seq * page_size <= jnp.iinfo(jnp.int16).max
+    ):
+        return jnp.int16
+    return jnp.int32
+
+
 class RpaCase(Enum):
     """Represents the different cases for Ragged Paged Attention.
 
@@ -486,11 +506,10 @@ def _ragged_paged_attention_kernel_loop(
         if soft_cap is not None:
             s = soft_cap * jnp.tanh(s / soft_cap)
 
-        # Use int16 for span computations when safe: non-f32 dtype on TPU v6+
-        # with causal mask. Custom mask shapes can trigger a Mosaic compiler bug.
-        int_ty = jnp.int32
-        if get_dtype_packing(q.dtype) != 1 and tpu_version >= 6 and use_causal_mask:
-            int_ty = jnp.int16
+        # Use int16 only when the entire per-sequence KV capacity fits in int16.
+        # Custom mask shapes can trigger a Mosaic compiler bug, so the causal-mask
+        # guard remains part of the fast-path check.
+        int_ty = span_int_ty
         processed_q_len_int = processed_q_len.astype(int_ty)
         processed_kv_len_int = processed_kv_len.astype(int_ty)
         effective_kv_len_int = effective_kv_len.astype(int_ty)
@@ -1814,6 +1833,13 @@ def ragged_paged_attention(
 
     use_causal_mask = causal == 1
     tpu_version = get_tpu_version()
+    span_int_ty = _get_span_int_dtype(
+        q.dtype,
+        tpu_version=tpu_version,
+        use_causal_mask=use_causal_mask,
+        pages_per_seq=pages_per_seq,
+        page_size=page_size,
+    )
 
     def run_rpa_kernel(
         q,

--- a/python/sgl_jax/test/test_kernel_utils.py
+++ b/python/sgl_jax/test/test_kernel_utils.py
@@ -1,6 +1,11 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import jax.numpy as jnp
+
+from sgl_jax.srt.kernels.ragged_paged_attention.ragged_paged_attention_v3 import (
+    _get_span_int_dtype,
+)
 from sgl_jax.srt.kernels.ragged_paged_attention.util import get_tpu_version
 
 
@@ -43,6 +48,45 @@ class TestKernelUtils(unittest.TestCase):
         mock_device.device_kind = "NVIDIA H100"
         mock_jax_devices.return_value = [mock_device]
         self.assertEqual(get_tpu_version(), -1)
+
+    def test_get_span_int_dtype_requires_safe_capacity(self):
+        self.assertEqual(
+            _get_span_int_dtype(
+                jnp.bfloat16,
+                tpu_version=6,
+                use_causal_mask=True,
+                pages_per_seq=255,
+                page_size=128,
+            ),
+            jnp.int16,
+        )
+        self.assertEqual(
+            _get_span_int_dtype(
+                jnp.bfloat16,
+                tpu_version=6,
+                use_causal_mask=True,
+                pages_per_seq=256,
+                page_size=128,
+            ),
+            jnp.int32,
+        )
+
+    def test_get_span_int_dtype_keeps_existing_guards(self):
+        for q_dtype, tpu_version, use_causal_mask in (
+            (jnp.float32, 6, True),
+            (jnp.bfloat16, 5, True),
+            (jnp.bfloat16, 6, False),
+        ):
+            self.assertEqual(
+                _get_span_int_dtype(
+                    q_dtype,
+                    tpu_version=tpu_version,
+                    use_causal_mask=use_causal_mask,
+                    pages_per_seq=255,
+                    page_size=128,
+                ),
+                jnp.int32,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- bound the RPA v3 int16 span fast path by full per-sequence KV capacity
- keep the existing causal-mask / TPU v6+ guard that avoids the Mosaic custom-mask bug
- add a CPU unit test that locks the dtype selection at the 32767-token boundary

## Testing
- `uv run --system-certs --python 3.12 --with pytest --with 'jax[cpu]==0.10.2' --with numpy~=2.2.6 --with psutil~=7.0.0 --with pyzmq~=27.0.1 --with fastapi~=0.116.1 --with orjson~=3.11.1 env PYTHONPATH=/Users/bytedance/Documents/trae_projects/repostew/sglang-jax/python python -m pytest /Users/bytedance/Documents/trae_projects/repostew/sglang-jax/python/sgl_jax/test/test_kernel_utils.py -q`

Fixes #1541.
