### PR TITLE
perf(moe): optimize EPMoE unpermute

### DIFF
--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -825,9 +825,10 @@ class EPMoE(nnx.Module):
 
         output = None
         for k in range(top_k):
-            contribution = jnp.take(
-                intermediate, indices=grouped_indices[:, k], axis=0
-            ).astype(jnp.float32) * weights_fp32[:, k, None]
+            contribution = (
+                jnp.take(intermediate, indices=grouped_indices[:, k], axis=0).astype(jnp.float32)
+                * weights_fp32[:, k, None]
+            )
             output = contribution if output is None else output + contribution
 
         final_output = output.astype(self.dtype)

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -780,6 +780,13 @@ class EPMoE(nnx.Module):
                 f"got shape {inputs.shape}"
             )
 
+        expected_indices_shape = (inputs.shape[0], self.num_experts_per_tok)
+        if top_k_indices.shape != expected_indices_shape:
+            raise ValueError(
+                "EPMoE._permute expects routing indices with shape "
+                f"{expected_indices_shape}, got shape {top_k_indices.shape}"
+            )
+
         flatten_selected_experts = jnp.ravel(top_k_indices)
         sorted_selected_experts = jnp.argsort(flatten_selected_experts, stable=True)
         # token_indices: maps each sorted position to the original token index.
@@ -797,13 +804,20 @@ class EPMoE(nnx.Module):
         )
 
     def _unpermute(self, intermediate, sorted_selected_experts, weights):
-        if weights.ndim != 2 or weights.shape[1] != self.num_experts_per_tok:
+        top_k = self.num_experts_per_tok
+        if weights.ndim != 2 or weights.shape[1] != top_k:
             raise ValueError(
                 "EPMoE._unpermute expects 2-D routing weights "
-                f"[tokens, {self.num_experts_per_tok}], got shape {weights.shape}"
+                f"[tokens, {top_k}], got shape {weights.shape}"
             )
 
-        expected_tokens = sorted_selected_experts.shape[0]
+        expected_tokens = weights.shape[0] * top_k
+        if sorted_selected_experts.ndim != 1 or sorted_selected_experts.shape[0] != expected_tokens:
+            raise ValueError(
+                "EPMoE._unpermute expects 1-D sorted routing indices with "
+                f"{expected_tokens} entries, got shape {sorted_selected_experts.shape}"
+            )
+
         actual_tokens = intermediate.shape[0]
 
         if actual_tokens != expected_tokens:
@@ -819,7 +833,6 @@ class EPMoE(nnx.Module):
             .at[sorted_selected_experts]
             .set(jnp.arange(expected_tokens, dtype=jnp.int32))
         )
-        top_k = self.num_experts_per_tok
         grouped_indices = jnp.reshape(argsort_indices, (weights.shape[0], top_k))
         weights_fp32 = weights.astype(jnp.float32)
 

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -819,21 +819,16 @@ class EPMoE(nnx.Module):
             .at[sorted_selected_experts]
             .set(jnp.arange(expected_tokens, dtype=jnp.int32))
         )
-        unsort_intermediate = jnp.take(intermediate, indices=argsort_indices, axis=0)
-
-        reshaped_intermediate = jnp.reshape(
-            unsort_intermediate,
-            (weights.shape[0], self.num_experts_per_tok, -1),
-        )
-
-        intermediate_fp32 = reshaped_intermediate.astype(jnp.float32)
+        top_k = self.num_experts_per_tok
+        grouped_indices = jnp.reshape(argsort_indices, (weights.shape[0], top_k))
         weights_fp32 = weights.astype(jnp.float32)
 
-        output = jnp.einsum(
-            "BKE,BK -> BE",
-            intermediate_fp32,
-            weights_fp32,
-        )
+        output = None
+        for k in range(top_k):
+            contribution = jnp.take(
+                intermediate, indices=grouped_indices[:, k], axis=0
+            ).astype(jnp.float32) * weights_fp32[:, k, None]
+            output = contribution if output is None else output + contribution
 
         final_output = output.astype(self.dtype)
 


### PR DESCRIPTION
## Motivation

> **Stacked on #1577.**

The einsum put `top_k` on the VPU's sublane axis, which for top_k < 8 cost a full relayout copy of the gathered values.

```python
reshaped_intermediate = jnp.reshape(unsort_intermediate, (weights.shape[0], top_k, -1))
output = jnp.einsum("BKE,BK -> BE", reshaped_intermediate.astype(jnp.float32), weights_fp32)
```

Reshaping the index array rather than the values, and summing over `top_k` with an unrolled loop instead of an einsum, means no `(tokens,top_k, hidden)` tensor is built. 

Related PR: https://github.com/sgl-project/sglang-jax/pull/1058

## Modifications

`python/sgl_jax/srt/layers/moe.py` — in `EPMoE._unpermute`, reshape
`argsort_indices` (`int32[tokens*top_k]`, ~128 KB) into `(tokens, top_k)` and gather
column `k` directly, then accumulate over `range(top_k)` in float32.

`test_unpermute_sums_over_top_k`, parametrised over `top_k ∈ {1, 4, 8}`. (The existing test covers `top_k = 2` only)

## Accuracy Tests

For `top_k ≤ 2`: bit-identical.

For `top_k ≥ 4`: the unrolled sequential float32 accumulation differs from XLA's reduction order by about one bfloat16 ulp. Comparing `_unpermute` output against the parent commit on identical inputs, TPU v6e-1:

| shape | max abs delta | bit-identical |
|---|---:|---|
| Grok-2 `top_k=2 hidden=8192` T=2048 | 0 | yes |
| Grok-2 `top_k=2 hidden=8192` T=8192 | 0 | yes |
| Qwen3-235B `top_k=8 hidden=4096` T=2048 | 0.0078125 | no |
| Qwen3-235B `top_k=8 hidden=4096` T=8192 | 0.03125 | no |

Please flag if bit-identity at `top_k ≥ 4` is required.

```bash
python3 -m pytest python/sgl_jax/test/layers/test_moe_unpermute.py \
                  python/sgl_jax/test/kernels/moe_block_quant_test.py \
                  python/sgl_jax/test/test_moe_weight_loader_sharding.py -q
# 12 passed
```

## Benchmarking and Profiling

`EPMoE._unpermute` alone, TPU v6e-1, bf16, median of 20 runs.

| model shape                      | tokens |    parent |       this PR |   speedup |
| -------------------------------- | -----: | --------: | ------------: | --------: |
| Grok-2 `top_k=2 hidden=8192`     |   2048 |  510.8 us |  **187.3 us** | **2.73x** |
| Grok-2 `top_k=2 hidden=8192`     |   8192 | 2759.3 us | **1493.7 us** | **1.85x** |
| Qwen3-235B `top_k=8 hidden=4096` |   2048 |  860.8 us |  **756.3 us** |     1.14x |
| Qwen3-235B `top_k=8 hidden=4096` |   8192 | 3519.5 us | **3299.0 us** |     1.07x |

At top_k=2 the peak temp allocation halves (512.1 → 256.4 MiB at T=8192)

 At `top_k=8` the
`(tokens, 8, hidden)` reshape is already a free bitcast. Among currently supported models only Grok-2 has `top_k = 2`; the rest are 6–16 and land in the smaller-gain column.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update. — n/a, internal perf change

https://claude.ai/code/session_01FStM6jUdJJWzzj4xCiXna6
