### PR TITLE
fix(ci): require PyArrow-compatible datasets

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "omegaconf",
     "imageio[ffmpeg]",
     "librosa>=0.10",
-    "datasets",
+    "datasets>=2.15.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- require datasets>=2.15.0 as a conservative lower bound that excludes releases through 2.14.6 which still use pa.PyExtensionType
- prevent uv backtracking from selecting the runtime-incompatible `datasets==2.14.4` + `pyarrow==25.0.1` pair
- keep the existing CI install strategy and transitive dependency ranges unchanged

## Root cause

![Dependency resolver conflict and backtracking](https://github.com/user-attachments/assets/228002f8-bd00-4e11-9e1a-f5b87849ca76)

With Python 3.12 and uv 0.12.9, the upload of AnyIO 4.15.0 introduced `typing_extensions>=4.16.0` while this project still allows only the 4.14.x line. During conflict backtracking, uv moved from `datasets==5.0.1` / `fsspec==2026.6.0` to `datasets==2.14.4` / `fsspec==2026.7.0`. Datasets 2.14.4 imports the removed `pa.PyExtensionType`, so every test shard can fail during collection with PyArrow 25.0.1.

The lower bound fixes the actual invalid dependency contract. Pinning FSSpec or AnyIO would constrain transitive implementation details, and only bumping `typing-extensions` would steer around the current trigger without excluding the known-bad Datasets release. A lockfile/constraints rollout would require a broader change to the repository CI installation model.

Reproducer: https://github.com/sgl-project/sglang-jax/actions/runs/33709154441/attempts/2

## Validation

- RED before the change: uv 0.12.9 dry-run selected `datasets==2.14.4`, `fsspec==2026.7.0`, `pyarrow==25.0.1`; the compatibility assertion exited 1
- GREEN after the change: the same dry-run selected `datasets==5.0.1`, `fsspec==2026.6.0`, `pyarrow==25.0.1`
- actual `uv pip install -e "python[cpu]"` in a fresh Python 3.12 venv; `import datasets, pyarrow, sgl_jax` passed and `pip check` reported no broken requirements
- `USE_DEVICE_TYPE=cpu SGLANG_JAX_IS_IN_CI=true NO_PROXY=127.0.0.1,localhost python test/srt/run_suite.py --suite unit-test-cpu` — all 77 test files passed
- uv 0.12.9 Linux x86_64 dry-runs for `python[all]` and `python[all,multimodal]` both resolved the compatible dependency set
- `git diff --check`


## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
