### PR TITLE
feat(runtime): add --moe-dp-size for replicated EPMoE

### DIFF
--- a/docs/cookbook/add-recipe.md
+++ b/docs/cookbook/add-recipe.md
@@ -30,7 +30,7 @@ For a validated recipe, include:
 
 | Evidence | Requirement |
 |---|---|
-| Hardware | TPU/GPU type, topology, node count, chip count, and `--tp-size` / `--dp-size` / `--ep-size`. |
+| Hardware | TPU/GPU type, topology, node count, chip count, and `--tp-size` / `--dp-size` / `--ep-size`; include `--moe-dp-size` when MoE DP is enabled. |
 | Environment | SGL-JAX commit or version, JAX/JAXLIB/libtpu versions, container image when relevant. |
 | Launch | Copy-pasteable server command for the claimed primary path. |
 | Invocation | At least one `curl` or OpenAI-compatible request example. |

--- a/docs/cookbook/base/launch-flags-reference.md
+++ b/docs/cookbook/base/launch-flags-reference.md
@@ -34,6 +34,7 @@ grep -n 'add_argument' python/sgl_jax/srt/server_args.py
 |---|---|---|
 | `--tensor-parallel-size` / `--tp-size` | `1` | Total JAX devices across all nodes. See [`tpu-topology-reference.md`](../base/tpu-topology-reference.md) for the v7x 2-devices-per-chip rule. |
 | `--data-parallel-size` / `--dp-size` | `1` | DP factor for the **attention** path only. Attention TP becomes `tp_size / dp_size`. MoE layers still run with full `ep_size`. |
+| `--moe-data-parallel-size` / `--moe-dp-size` | `1` | DP factor for MoE. The default preserves the existing EP/TP layout. Replicated MoE currently requires `moe_dp_size == dp_size`, `ep_size == 1`, the `epmoe` backend, and an unquantized Ling-3.0-Tiny model. |
 | `--dp-schedule-policy` | auto | DP rank assignment policy. If unset, radix-cache serving uses `cache_aware`; `--disable-radix-cache` and Pathways PD use `min_running_queue`. Explicit choices are `cache_aware`, `shape_aware`, `min_running_queue`, and `round_robin`; use non-default choices as workload-specific tuning overrides. |
 | `--ep-size` | `1` | Expert parallelism. Typically `--ep-size == --tp-size` for MoE models. |
 

--- a/docs/cookbook/base/tpu-topology-reference.md
+++ b/docs/cookbook/base/tpu-topology-reference.md
@@ -48,7 +48,7 @@ v6e-N    →  --tp-size = N
 v7x-N    →  --tp-size = N * 2      (N is chip count)
 ```
 
-For MoE models also set `--ep-size = --tp-size` to put one expert shard per device, and split attention with `--dp-size` (attention-TP becomes `tp_size / dp_size`).
+For the standard MoE layout, also set `--ep-size = --tp-size` to put one expert shard per device, and split attention with `--dp-size` (attention-TP becomes `tp_size / dp_size`). Replicated MoE is configured independently with `--moe-dp-size = --dp-size` and currently requires `--ep-size 1`; omitting `--moe-dp-size` preserves the standard layout.
 
 ## Per-chip HBM accounting
 

--- a/docs/features/server_arguments.md
+++ b/docs/features/server_arguments.md
@@ -104,6 +104,7 @@ For reusable Docker, GKE, and SkyPilot launchers, see [Deployment](../deployment
 |---|---|
 | `--tensor-parallel-size`, `--tp-size` | Total tensor-parallel JAX devices. |
 | `--data-parallel-size`, `--dp-size` | Data parallelism factor for supported execution paths. |
+| `--moe-data-parallel-size`, `--moe-dp-size` | MoE data parallelism factor. Defaults to `1`; replicated MoE currently requires it to equal `--dp-size`. |
 | `--dp-schedule-policy` | DP rank assignment policy. If unset, radix-cache serving uses `cache_aware`; `--disable-radix-cache` and Pathways PD use `min_running_queue`. Explicit choices are `cache_aware`, `shape_aware`, `min_running_queue`, and `round_robin`; use non-default choices as workload-specific tuning overrides. |
 | `--ep-size` | Expert parallelism size for MoE models. |
 | `--ep-num-redundant-experts` | Add redundant physical experts for EP load balancing. |

--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -57,6 +57,8 @@ _FUSED_MOE_V2_SUPPORTED_ARCHITECTURES = frozenset(
 
 _FORCED_FUSED_EP_MOE_ARCHS = frozenset({"Qwen3_5MoeForConditionalGeneration"})
 
+_MOE_DP_SUPPORTED_ARCHITECTURES = frozenset({"BailingMoeV3ForCausalLM"})
+
 
 def _assert_fused_moe_v2_supported(moe_backend: MoEBackend, architectures: list[str]) -> None:
     if moe_backend != MoEBackend.FUSED_V2:
@@ -66,6 +68,26 @@ def _assert_fused_moe_v2_supported(moe_backend: MoEBackend, architectures: list[
         "moe_backend='fused_v2' only supports Bailing/MiMo/GLM model architectures for now; "
         f"got architectures={architectures}"
     )
+
+
+def _assert_moe_data_parallel_supported(
+    moe_dp_size: int,
+    moe_backend: MoEBackend,
+    architectures: list[str],
+    quantization_config: QuantizationConfig | None,
+) -> None:
+    if moe_dp_size == 1:
+        return
+
+    if moe_backend != MoEBackend.EPMOE:
+        raise ValueError("MoE data parallelism currently requires moe_backend='epmoe'")
+    if not any(arch in _MOE_DP_SUPPORTED_ARCHITECTURES for arch in architectures):
+        raise ValueError(
+            "MoE data parallelism currently supports only Ling-3.0-Tiny "
+            f"(BailingMoeV3ForCausalLM); got architectures={architectures}"
+        )
+    if quantization_config is not None:
+        raise ValueError("MoE data parallelism currently supports unquantized experts only")
 
 
 class ModelConfig:
@@ -87,6 +109,7 @@ class ModelConfig:
         model_layer_nums: int | None = None,
         multimodal: bool = False,
         moe_backend: str | MoEBackend = MoEBackend.AUTO,
+        moe_dp_size: int = 1,
         model_sub_dir: str | None = None,
     ) -> None:
         self.model_path = model_path
@@ -95,6 +118,7 @@ class ModelConfig:
         self.model_impl = model_impl
         self.quantization = quantization
         self.quantization_config_path = quantization_config_path
+        self.moe_dp_size = moe_dp_size
         # Create unified quantization config from path
         self.quantization_config = QuantizationConfig.from_path(quantization_config_path)
         # if ep_size > 1, use ep moe, else use fused moe
@@ -168,6 +192,12 @@ class ModelConfig:
         # 3. Otherwise -> None
         # After this, quantization_config is always QuantizationConfig or None
         self.quantization_config = self._resolve_quantization_config()
+        _assert_moe_data_parallel_supported(
+            self.moe_dp_size,
+            self.moe_backend,
+            self.hf_config.architectures,
+            self.quantization_config,
+        )
 
         # Attach unified quantization config to hf_config so models can access it.
         # Only set when non-None: HuggingFace's to_dict() calls
@@ -571,6 +601,7 @@ class ModelConfig:
             model_layer_nums=server_args.model_layer_nums,
             multimodal=server_args.multimodal,
             moe_backend=server_args.moe_backend,
+            moe_dp_size=server_args.moe_dp_size,
             model_sub_dir=model_sub_dir,
             **kwargs,
         )

--- a/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/gmm_v2.py
+++ b/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/gmm_v2.py
@@ -10,6 +10,10 @@ from jax import lax
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
+from sgl_jax.srt.kernels.gmm.megablox_gmm_kernel.tuned_tile_sizes import (
+    get_tuned_gmm_v2_tile_sizes,
+)
+
 # Util.
 
 
@@ -665,6 +669,17 @@ def calculate_tiling(
     vmem_limit_bytes: int,
 ) -> TileSizes:
     """Calculate optimal tile sizes for GMM kernel."""
+
+    tuned_tiles = get_tuned_gmm_v2_tile_sizes(
+        lhs_dtype=lhs_dtype,
+        rhs_dtype=rhs_dtype,
+        num_groups=dims.size_group,
+        size_m=dims.size_m,
+        size_k=dims.size_k,
+        size_n=dims.size_n,
+    )
+    if tuned_tiles is not None:
+        return TileSizes(*tuned_tiles)
 
     lhs_bits = jax.dtypes.itemsize_bits(lhs_dtype)
     rhs_bits = jax.dtypes.itemsize_bits(rhs_dtype)

--- a/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/tuned_tile_sizes.py
+++ b/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/tuned_tile_sizes.py
@@ -1,0 +1,43 @@
+"""Shape-specific GMM v2 tile sizes measured on supported TPU generations."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from sgl_jax.srt.utils.jax_utils import get_device_name
+
+# Key: (lhs dtype, rhs dtype, groups, M, K, N).
+# Values are (tile_m, tile_k, tile_n).
+TUNED_TILE_SIZES_GMM_V2 = {
+    "TPU v7": {
+        # Ling-3.0-tiny replicated EPMoE, 2K balanced prefill hot shapes.
+        ("bfloat16", "bfloat16", 128, 2048, 1536, 512): (32, 1536, 512),
+        ("bfloat16", "bfloat16", 128, 2048, 512, 1536): (32, 512, 1536),
+    },
+}
+
+
+def get_tuned_gmm_v2_tile_sizes(
+    *,
+    lhs_dtype: jnp.dtype,
+    rhs_dtype: jnp.dtype,
+    num_groups: int,
+    size_m: int,
+    size_k: int,
+    size_n: int,
+    device_name: str | None = None,
+) -> tuple[int, int, int] | None:
+    if device_name is None:
+        device_name = get_device_name()
+    table = TUNED_TILE_SIZES_GMM_V2.get(device_name)
+    if table is None:
+        return None
+    key = (
+        jnp.dtype(lhs_dtype).name,
+        jnp.dtype(rhs_dtype).name,
+        int(num_groups),
+        int(size_m),
+        int(size_k),
+        int(size_n),
+    )
+    return table.get(key)

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -16,19 +16,12 @@ from sgl_jax.srt.kernels.gmm.megablox_gmm_backend import gmm
 # Re-export for backward compatibility: external code imports from this module.
 from sgl_jax.srt.layers.fused_moe import FusedEPMoE, FusedEPMoEV2  # noqa: F401
 from sgl_jax.srt.layers.gate import GateLogit, TopK  # noqa: F401
-from sgl_jax.srt.utils.common_utils import get_bool_env_var
 from sgl_jax.srt.utils.profiling_utils import named_scope
 from sgl_jax.srt.utils.quantization.quantization_utils import (
     quantize_tensor,
     quantize_tensor_simple,
 )
 from sgl_jax.srt.utils.weight_utils import WeightMapping
-
-_REPLICATED_MOE_ENV = "SGLANG_JAX_ENABLE_REPLICATED_MOE"
-
-
-def _is_replicated_moe_enabled() -> bool:
-    return get_bool_env_var(_REPLICATED_MOE_ENV)
 
 
 class EPMoE(nnx.Module):
@@ -47,11 +40,13 @@ class EPMoE(nnx.Module):
         quantization_config=None,
         physical_to_logical_map: "jax.Array | None" = None,
         pre_gather_quant_dtype=None,
+        moe_dp_size: int = 1,
     ):
         self.num_experts_per_tok = num_experts_per_tok
         self.physical_to_logical_map = physical_to_logical_map
         self.pre_gather_quant_dtype = pre_gather_quant_dtype
-        self.replicate_experts = _is_replicated_moe_enabled()
+        self.moe_dp_size = moe_dp_size
+        self.replicate_experts = self.moe_dp_size > 1
 
         metadata = None if self.replicate_experts else get_global_expert_location_metadata()
         if metadata is not None and layer_id is not None:
@@ -80,6 +75,8 @@ class EPMoE(nnx.Module):
             getattr(quantization_config, "weight_block_size", None) if quantization_config else None
         )
 
+        if self.moe_dp_size < 1:
+            raise ValueError(f"moe_dp_size must be at least 1, got {self.moe_dp_size}")
         if self.replicate_experts and self.ep_size != 1:
             raise ValueError(f"replicated EPMoE requires ep_size=1, got ep_size={self.ep_size}")
         if self.replicate_experts and (
@@ -97,6 +94,11 @@ class EPMoE(nnx.Module):
                 raise ValueError(
                     "replicated EPMoE requires a model mesh with ('data', 'tensor') axes; "
                     f"got {self.mesh.axis_names}"
+                )
+            if self.mesh.shape["data"] != self.moe_dp_size:
+                raise ValueError(
+                    "replicated EPMoE requires moe_dp_size to match the model mesh data axis; "
+                    f"got moe_dp_size={self.moe_dp_size}, data={self.mesh.shape['data']}"
                 )
             self.tp_size = self.mesh.shape["tensor"]
             self.experts_per_device = self.num_experts

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -16,12 +16,19 @@ from sgl_jax.srt.kernels.gmm.megablox_gmm_backend import gmm
 # Re-export for backward compatibility: external code imports from this module.
 from sgl_jax.srt.layers.fused_moe import FusedEPMoE, FusedEPMoEV2  # noqa: F401
 from sgl_jax.srt.layers.gate import GateLogit, TopK  # noqa: F401
+from sgl_jax.srt.utils.common_utils import get_bool_env_var
 from sgl_jax.srt.utils.profiling_utils import named_scope
 from sgl_jax.srt.utils.quantization.quantization_utils import (
     quantize_tensor,
     quantize_tensor_simple,
 )
 from sgl_jax.srt.utils.weight_utils import WeightMapping
+
+_REPLICATED_MOE_ENV = "SGLANG_JAX_ENABLE_REPLICATED_MOE"
+
+
+def _is_replicated_moe_enabled() -> bool:
+    return get_bool_env_var(_REPLICATED_MOE_ENV)
 
 
 class EPMoE(nnx.Module):
@@ -44,8 +51,9 @@ class EPMoE(nnx.Module):
         self.num_experts_per_tok = num_experts_per_tok
         self.physical_to_logical_map = physical_to_logical_map
         self.pre_gather_quant_dtype = pre_gather_quant_dtype
+        self.replicate_experts = _is_replicated_moe_enabled()
 
-        metadata = get_global_expert_location_metadata()
+        metadata = None if self.replicate_experts else get_global_expert_location_metadata()
         if metadata is not None and layer_id is not None:
             self.num_experts = metadata.num_physical_experts
         else:
@@ -72,25 +80,48 @@ class EPMoE(nnx.Module):
             getattr(quantization_config, "weight_block_size", None) if quantization_config else None
         )
 
-        if self.num_experts % self.ep_size != 0:
+        if self.replicate_experts and self.ep_size != 1:
+            raise ValueError(f"replicated EPMoE requires ep_size=1, got ep_size={self.ep_size}")
+        if self.replicate_experts and (
+            self.quantized_dtype is not None or self.activation_quantized_dtype is not None
+        ):
+            raise NotImplementedError(
+                "replicated EPMoE currently supports unquantized experts only"
+            )
+        if not self.replicate_experts and self.num_experts % self.ep_size != 0:
             raise ValueError(
                 f"num_experts({self.num_experts}) must be divisible by ep_size ({self.ep_size})"
             )
-        world_size = math.prod(self.mesh.shape.values())
-        self.tp_size = world_size // self.ep_size
-        self.experts_per_device = self.num_experts // self.ep_size
+        if self.replicate_experts:
+            if "data" not in self.mesh.axis_names or "tensor" not in self.mesh.axis_names:
+                raise ValueError(
+                    "replicated EPMoE requires a model mesh with ('data', 'tensor') axes; "
+                    f"got {self.mesh.axis_names}"
+                )
+            self.tp_size = self.mesh.shape["tensor"]
+            self.experts_per_device = self.num_experts
+            self.moe_mesh = self.mesh
+            self.updated_mesh = self.mesh.abstract_mesh
+            wi_sharding = P(None, None, "tensor")
+            wo_sharding = P(None, "tensor", None)
+        else:
+            world_size = math.prod(self.mesh.shape.values())
+            self.tp_size = world_size // self.ep_size
+            self.experts_per_device = self.num_experts // self.ep_size
 
-        devices = self.mesh.devices.flatten()
-        self.moe_mesh = jax.sharding.Mesh(
-            devices.reshape(self.ep_size, self.tp_size),
-            axis_names=("expert", "tensor"),
-            axis_types=(jax.sharding.AxisType.Explicit, jax.sharding.AxisType.Explicit),
-        )
+            devices = self.mesh.devices.flatten()
+            self.moe_mesh = jax.sharding.Mesh(
+                devices.reshape(self.ep_size, self.tp_size),
+                axis_names=("expert", "tensor"),
+                axis_types=(jax.sharding.AxisType.Explicit, jax.sharding.AxisType.Explicit),
+            )
 
-        abstract_mesh = self.mesh.abstract_mesh
-        self.updated_mesh = abstract_mesh.update(
-            axis_sizes=(self.ep_size, self.tp_size), axis_names=("expert", "tensor")
-        )
+            abstract_mesh = self.mesh.abstract_mesh
+            self.updated_mesh = abstract_mesh.update(
+                axis_sizes=(self.ep_size, self.tp_size), axis_names=("expert", "tensor")
+            )
+            wi_sharding = P("expert", None, "tensor")
+            wo_sharding = P("expert", "tensor", None)
 
         with jax.sharding.use_abstract_mesh(self.updated_mesh):
             # MOE weights' shape is (num_experts, k, n)
@@ -99,7 +130,7 @@ class EPMoE(nnx.Module):
                     jax.random.PRNGKey(0),
                     (self.num_experts, hidden_size, intermediate_dim),
                     dtype=weight_dtype,
-                    out_sharding=P("expert", None, "tensor"),
+                    out_sharding=wi_sharding,
                 )
             )
 
@@ -108,7 +139,7 @@ class EPMoE(nnx.Module):
                     jax.random.PRNGKey(0),
                     (self.num_experts, hidden_size, intermediate_dim),
                     dtype=weight_dtype,
-                    out_sharding=P("expert", None, "tensor"),
+                    out_sharding=wi_sharding,
                 )
             )
 
@@ -117,7 +148,7 @@ class EPMoE(nnx.Module):
                     jax.random.PRNGKey(0),
                     (self.num_experts, intermediate_dim, hidden_size),
                     dtype=weight_dtype,
-                    out_sharding=P("expert", "tensor", None),
+                    out_sharding=wo_sharding,
                 )
             )
 
@@ -416,8 +447,22 @@ class EPMoE(nnx.Module):
         *,
         out_sharding: jax.sharding.NamedSharding | None = None,
     ) -> jax.Array:
+        if self.replicate_experts:
+            if out_sharding is None:
+                out_sharding = jax.sharding.NamedSharding(
+                    self.mesh,
+                    P("data", *([None] * (hidden_states.ndim - 1))),
+                )
+            return self._call_replicated(
+                hidden_states,
+                topk_weights,
+                topk_ids,
+                out_sharding=out_sharding,
+            )
+
         if out_sharding is None:
             out_sharding = jax.sharding.NamedSharding(self.mesh, P(*([None] * hidden_states.ndim)))
+
         # Translate the caller's target sharding (on self.mesh: data,tensor)
         # into shard_map out_specs (on self.moe_mesh: expert,tensor). Only
         # 'tensor' is shared between the two meshes; everything else is
@@ -495,6 +540,53 @@ class EPMoE(nnx.Module):
         # consistent context.
         return jax.sharding.reshard(result, out_sharding)
 
+    def _call_replicated(
+        self,
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        *,
+        out_sharding: jax.sharding.NamedSharding,
+    ) -> jax.Array:
+        token_spec = P("data", *([None] * (hidden_states.ndim - 1)))
+        routing_spec = P("data", *([None] * (topk_ids.ndim - 1)))
+        out_spec = out_sharding.spec
+        token_axis = out_spec[0] if len(out_spec) > 0 else None
+        token_axes = token_axis if isinstance(token_axis, tuple) else (token_axis,)
+        if self.mesh.shape["data"] > 1 and "data" not in token_axes:
+            raise ValueError(
+                "replicated EPMoE output must shard the token dimension over the data axis"
+            )
+        scatter_on_tensor = "tensor" in token_axes
+
+        with jax.sharding.use_abstract_mesh(self.updated_mesh):
+            hidden_states = jax.sharding.reshard(hidden_states, token_spec)
+            topk_weights = jax.sharding.reshard(topk_weights, routing_spec)
+            topk_ids = jax.sharding.reshard(topk_ids, routing_spec)
+            result = shard_map(
+                partial(self._forward, scatter_on_tensor=scatter_on_tensor),
+                mesh=self.moe_mesh,
+                in_specs=(
+                    token_spec,
+                    routing_spec,
+                    routing_spec,
+                    P(None, None, "tensor"),
+                    P(None, None, "tensor"),
+                    P(None, "tensor", None),
+                ),
+                out_specs=out_spec,
+                check_vma=False,
+            )(
+                hidden_states,
+                topk_weights,
+                topk_ids,
+                self.wi_0[...],
+                self.wi_1[...],
+                self.wo[...],
+            )
+
+        return jax.sharding.reshard(result, out_sharding)
+
     def _forward(
         self,
         hidden_states,
@@ -512,7 +604,11 @@ class EPMoE(nnx.Module):
         *,
         scatter_on_tensor: bool = False,
     ):
-        expert_shard_id = jax.lax.axis_index("expert")
+        expert_shard_id = (
+            jnp.array(0, dtype=jnp.int32)
+            if self.replicate_experts
+            else jax.lax.axis_index("expert")
+        )
 
         inputs_2d, token_indices, sorted_selected_experts, group_sizes = self._permute(
             hidden_states, topk_ids

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -136,6 +136,7 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
             self.attention_tp_size
         )
         self.ep_size = server_args.ep_size
+        self.moe_dp_size = server_args.moe_dp_size
         self.server_args = server_args
         self.embedding_pool: EmbeddingPool | None = None
         self.is_generation = model_config.is_generation
@@ -571,6 +572,7 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
         self.model_config.configure_for_tensor_parallel(self.attention_tp_size)
         self.model_config.log_kv_heads_info(self.attention_tp_size)
         self.model_config.hf_config.ep_size = self.ep_size
+        self.model_config.hf_config.moe_dp_size = self.moe_dp_size
         self.model_config.hf_config.ep_num_redundant_experts = (
             self.server_args.ep_num_redundant_experts
         )

--- a/python/sgl_jax/srt/models/bailing_moe_v3.py
+++ b/python/sgl_jax/srt/models/bailing_moe_v3.py
@@ -20,7 +20,7 @@ from sgl_jax.srt.layers.gate import GateLogit, TopK
 from sgl_jax.srt.layers.layernorm import RMSNorm
 from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
-from sgl_jax.srt.layers.moe import EPMoE, _is_replicated_moe_enabled
+from sgl_jax.srt.layers.moe import EPMoE
 from sgl_jax.srt.layers.radix_linear_attention import RadixLinearAttention
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
 from sgl_jax.srt.models.deepseek_v3 import DeepseekV3Attention
@@ -359,7 +359,8 @@ class BailingMoeV3DecoderLayer(nnx.Module):
         self.mesh = mesh
         self.hidden_size = config.hidden_size
         self.is_kda = config.is_kda_layer(layer_idx)
-        self.replicate_moe = _is_replicated_moe_enabled()
+        self.moe_dp_size = getattr(config, "moe_dp_size", 1)
+        self.replicate_moe = self.moe_dp_size > 1
 
         if self.is_kda:
             self.self_attn = BailingKDAAttention(
@@ -427,6 +428,7 @@ class BailingMoeV3DecoderLayer(nnx.Module):
                 layer_id=layer_idx,
                 ep_size=getattr(config, "ep_size", 1),
                 quantization_config=getattr(config, "quantization_config", None),
+                moe_dp_size=self.moe_dp_size,
             )
             if config.num_shared_experts > 0:
                 self.shared_experts = BailingMoeV3MLP(
@@ -613,9 +615,10 @@ class BailingMoeV3ForCausalLM(nnx.Module):
         self.config = config
         self.mesh = mesh
         self.dtype = dtype
-        self.replicate_moe = _is_replicated_moe_enabled()
+        self.moe_dp_size = getattr(config, "moe_dp_size", 1)
+        self.replicate_moe = self.moe_dp_size > 1
         if self.replicate_moe:
-            logger.warning("Enabling replicated MoE through SGLANG_JAX_ENABLE_REPLICATED_MOE")
+            logger.info("Enabling replicated MoE with moe_dp_size=%d", self.moe_dp_size)
         self.model = BailingMoeV3Model(config=config, mesh=mesh, dtype=dtype)
 
         if not getattr(config, "tie_word_embeddings", False):

--- a/python/sgl_jax/srt/models/bailing_moe_v3.py
+++ b/python/sgl_jax/srt/models/bailing_moe_v3.py
@@ -20,7 +20,7 @@ from sgl_jax.srt.layers.gate import GateLogit, TopK
 from sgl_jax.srt.layers.layernorm import RMSNorm
 from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
-from sgl_jax.srt.layers.moe import EPMoE
+from sgl_jax.srt.layers.moe import EPMoE, _is_replicated_moe_enabled
 from sgl_jax.srt.layers.radix_linear_attention import RadixLinearAttention
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
 from sgl_jax.srt.models.deepseek_v3 import DeepseekV3Attention
@@ -359,6 +359,7 @@ class BailingMoeV3DecoderLayer(nnx.Module):
         self.mesh = mesh
         self.hidden_size = config.hidden_size
         self.is_kda = config.is_kda_layer(layer_idx)
+        self.replicate_moe = _is_replicated_moe_enabled()
 
         if self.is_kda:
             self.self_attn = BailingKDAAttention(
@@ -493,7 +494,7 @@ class BailingMoeV3DecoderLayer(nnx.Module):
             topk_weights, topk_ids = self.topk(
                 router_logits,
                 correction_bias,
-                dispatch_info=dispatch_info,
+                dispatch_info=None if self.replicate_moe else dispatch_info,
                 routing_sharding=NamedSharding(self.mesh, P("data", None)),
             )
 
@@ -612,6 +613,9 @@ class BailingMoeV3ForCausalLM(nnx.Module):
         self.config = config
         self.mesh = mesh
         self.dtype = dtype
+        self.replicate_moe = _is_replicated_moe_enabled()
+        if self.replicate_moe:
+            logger.warning("Enabling replicated MoE through SGLANG_JAX_ENABLE_REPLICATED_MOE")
         self.model = BailingMoeV3Model(config=config, mesh=mesh, dtype=dtype)
 
         if not getattr(config, "tie_word_embeddings", False):
@@ -828,7 +832,7 @@ class BailingMoeV3ForCausalLM(nnx.Module):
                 get_global_expert_location_metadata,
             )
 
-            metadata = get_global_expert_location_metadata()
+            metadata = None if self.replicate_moe else get_global_expert_location_metadata()
             phy_to_log = None
             if metadata is not None:
                 physical_to_logical_map = np.array(jax.device_get(metadata.physical_to_logical_map))
@@ -839,11 +843,16 @@ class BailingMoeV3ForCausalLM(nnx.Module):
                 ("up_proj", "wi_1"),
                 ("down_proj", "wo"),
             ):
-                sharding = (
-                    ("expert", "tensor", None)
-                    if target_name == "wo"
-                    else ("expert", None, "tensor")
-                )
+                if self.replicate_moe:
+                    sharding = (
+                        (None, "tensor", None) if target_name == "wo" else (None, None, "tensor")
+                    )
+                else:
+                    sharding = (
+                        ("expert", "tensor", None)
+                        if target_name == "wo"
+                        else ("expert", None, "tensor")
+                    )
                 target_path_base = f"{target_prefix}.experts.{target_name}"
                 expert_keys = [
                     f"{prefix}.mlp.experts.{i}.{source_name}.weight"

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -150,6 +150,7 @@ class ServerArgs:
 
     # Data parallel
     dp_size: int = 1
+    moe_dp_size: int = 1
     dp_schedule_policy: str | None = None
 
     # Logging
@@ -1290,6 +1291,18 @@ class ServerArgs:
             help="The data parallelism size.",
         )
         parser.add_argument(
+            "--moe-data-parallel-size",
+            "--moe-dp-size",
+            dest="moe_dp_size",
+            type=int,
+            default=ServerArgs.moe_dp_size,
+            help=(
+                "The MoE data parallelism size. The default (1) preserves the "
+                "existing EP/TP layout. Replicated MoE currently requires this "
+                "to equal --dp-size with --ep-size 1."
+            ),
+        )
+        parser.add_argument(
             "--dp-schedule-policy",
             type=str,
             choices=["round_robin", "min_running_queue", "cache_aware", "shape_aware"],
@@ -1944,6 +1957,27 @@ class ServerArgs:
 
     def check_server_args(self):
         assert (self.tp_size) % self.nnodes == 0, "tp_size must be divisible by number of nodes"
+
+        if self.moe_dp_size < 1:
+            raise ValueError("--moe-dp-size must be at least 1")
+
+        # moe_dp_size=1 is the compatibility path and deliberately keeps all
+        # existing recipes under their previous EP/TP validation rules.
+        if self.moe_dp_size > 1:
+            if self.moe_dp_size != self.dp_size:
+                raise ValueError(
+                    "replicated MoE currently requires --moe-dp-size to equal --dp-size"
+                )
+            if self.tp_size % self.dp_size != 0:
+                raise ValueError("replicated MoE requires --tp-size to be divisible by --dp-size")
+            if self.ep_size != 1:
+                raise ValueError("replicated MoE currently requires --ep-size 1")
+            if self.moe_backend != "epmoe":
+                raise ValueError("replicated MoE currently requires --moe-backend epmoe")
+            if self.ep_num_redundant_experts != 0:
+                raise ValueError("replicated MoE does not support --ep-num-redundant-experts")
+            if self.ep_dispatch_algorithm is not None:
+                raise ValueError("replicated MoE does not support --ep-dispatch-algorithm")
 
         # Check chunked prefill
         # Skip validation if chunked prefill is disabled (i.e., size <= 0).


### PR DESCRIPTION
## Motivation

Add an explicit runtime option for running MoE with the same data-parallel factor as attention. This is currently intended for unquantized Ling-3.0-Tiny serving, where each DP rank keeps a complete expert table and uses tensor parallelism only within that replica.

This replaces the earlier environment-variable prototype with a typed server argument. The default remains `1`, so existing recipes and the standard EPMoE/EP layout are unchanged unless the new flag is explicitly enabled.

Related prototype and discussion: #1565.

## Modifications

- Add `--moe-data-parallel-size` / `--moe-dp-size` and plumb it through `ServerArgs`, `ModelConfig`, `ModelRunner`, the Ling-3 model config, and `EPMoE`.
- When `moe_dp_size > 1`, replicate the complete expert table over the model mesh's data axis while retaining tensor sharding inside each replica.
- Keep routing, permutation, grouped matmul, activation, unpermutation, and tensor-axis reduction in the existing `EPMoE` implementation.
- Use local routing and replicated checkpoint mappings for Ling-3 while MoE DP is enabled; bypass EPLB remapping only on this path.
- Preserve the 2-D hidden-state and routing-weight contract introduced by #1577 for both standard and replicated EPMoE.
- Retain the exact-match TPU v7 GMM v2 tile configurations measured for the Ling-3.0-Tiny 2K prefill hot shapes.
- Update the server-argument and cookbook documentation.

Example:

```bash
python -m sgl_jax.launch_server \
  --model-path inclusionAI/Ling-3.0-Tiny \
  --device tpu \
  --tp-size 8 \
  --dp-size 8 \
  --moe-dp-size 8 \
  --ep-size 1 \
  --moe-backend epmoe
```

Omitting `--moe-dp-size` keeps its default value of `1`. In particular, setting `--dp-size` alone continues to apply DP to attention without changing the MoE layout, so existing recipes do not need to be updated.

## Current scope and validation

Replicated MoE currently requires:

- `moe_dp_size == dp_size > 1`
- `tp_size` divisible by `dp_size`
- `ep_size == 1`
- `moe_backend == epmoe`
- `BailingMoeV3ForCausalLM` (Ling-3.0-Tiny)
- unquantized experts
- no redundant experts or EPLB dispatch algorithm

Unsupported combinations fail during argument or model validation instead of silently selecting a different layout.

Post-rebase local validation used an ad-hoc four-device CPU check for both CLI aliases, supported and rejected argument combinations, the standard EPMoE mesh/weight layout, and the replicated mesh/weight layout. The existing MoE regression tests also pass:

```text
python -m pytest -q \
  python/sgl_jax/test/test_moe_weight_loader_sharding.py \
  python/sgl_jax/test/test_moe_topk.py
8 passed
```

No dedicated test file is included in this PR. Repository-pinned Ruff, Black, and isort hooks pass for all changed Python files, and `git diff --check` passes.

## Accuracy Tests

Falcon experiment `exp-39813tcnor` exercised the feature end to end on one TPU v7x-8 with:

```text
tp_size=8, dp_size=8, moe_dp_size=8, ep_size=1
moe_backend=epmoe
JAX/JAXLIB=0.11.1, libtpu=0.0.46
```

The run used feature commit `80fc3b9a2da112e04d5f65761a86b2d88fa4d87e` before the conflict-only rebase onto current `main`. All 69 weight groups loaded, the OpenAI-compatible smoke test passed, and GSM8K completed all 1,319 examples:

| Run | GSM8K | Duration | Errors |
|---|---:|---:|---:|
| Replicated MoE candidate (`exp-39813tcnor`) | 92.04% | 30m28s | 0 |
| Reference replicated-MoE run (`exp-om7a8ohufw`) | 93.56% | 28m55s | 0 |

Both evaluations used `temperature=1.0`, `top_p=0.95`, and thinking enabled, so exact scores are stochastic. The candidate exited successfully with `gsm8k_exit_code=0`; Falcon artifact `art-6zyayx7xz0` is `SUCCEEDED`, and the server error-marker scan found no traceback, fatal error, resource exhaustion, or failed check.

The GSM8K client used the evaluator's reference/default generation limit; no explicit `--max-tokens` override was passed.

## Benchmarking and Profiling

The GMM v2 tuning table contains only the previously measured TPU v7 Ling-3.0-Tiny 2K prefill hot shapes from `primatrix/sglang-jax#340`. Lookup is keyed by the exact device, dtype, expert count, and matrix dimensions; all other models and shapes continue to use the existing auto-tiler.

## Checklist

- [x] The PR title and description are in English.
- [x] The motivation and current supported scope are documented.
- [x] The test plan and end-to-end accuracy evidence are included.
- [x] Server-argument and cookbook documentation are updated.
