### PR TITLE
perf(dsa): pallas paged write-back for qblock self-write + QB=256 default (110k TTFT -28%)

### DIFF
--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
@@ -459,9 +459,20 @@ def prefill_write_and_attend_ragged_qblock(
     row = jnp.zeros((T, Dk_pad), cache.dtype)
     row = row.at[:, :Dv].set(kvc.astype(cache.dtype))
     row = row.at[:, Dv : Dv + rope].set(kpe.reshape(T, rope).astype(cache.dtype))
-    flat = cache.reshape(Pn * ps, Dk_pad)
-    flat = flat.at[loc].set(row, mode="drop", wrap_negative_indices=False)
-    cache_new = flat.reshape(Pn, pspk, pk, Dk_pad)
+    # Scatter directly into the 4D cache. The flat-view round-trip
+    # (reshape [Pn*ps, D] -> scatter -> reshape back) materialises TWO full
+    # relayout copies of the cache per call (the 4D pool and the 2D view get
+    # different tilings) — measured 13.8% of 110k prefill device time. 3D
+    # index math on ``loc`` is free; padded loc == -1 stays dropped (negative
+    # page index with wrap_negative_indices=False).
+    cache_new = paged_write_back(
+        cache,
+        row,
+        loc.astype(jnp.int32),
+        page_size=ps,
+        r_cap=T // ps + S + 34,
+        interpret=interpret,
+    )
 
     # token -> request id (same convention as the per-query ragged wrapper)
     t = jnp.arange(T, dtype=jnp.int32)
@@ -633,4 +644,8 @@ def paged_write_back(
         flat = flat.at[loc].set(row_w.reshape(Tp, D), mode="drop", wrap_negative_indices=False)
         return flat.reshape(cache.shape)
 
+    if interpret:
+        # interpret cannot lower dynamic-size DMAs; the scatter is the
+        # bit-identical reference semantics anyway.
+        return _scatter(cache, row_w, table)
     return jax.lax.cond(n_raw <= r_cap, _pallas, _scatter, cache, row_w, table)

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
@@ -486,3 +486,151 @@ def prefill_write_and_attend_ragged_qblock(
         interpret=interpret,
     )
     return out.reshape(T, H, Dv), cache_new
+
+
+# ── pallas paged write-back (self-write without the XLA scatter) ─────────────
+#
+# ``flat.at[loc].set(row)`` (and its 4D-index form) makes XLA canonicalise the
+# scatter through a flat view of the pool: two full-cache relayout copies per
+# call (the 4D pool and the 2D view tile differently) — measured 13.8% of 110k
+# prefill device time, plus the scatter itself (~4%). This kernel writes the
+# rows in place instead: the pool is input/output-aliased, and the new rows are
+# DMA'd HBM->HBM in maximal contiguous runs (out_cache_loc is page-contiguous,
+# so a chunked single-request prefill is ONE run; ragged batches get ~one run
+# per page). kv_packing word alignment is handled by splitting each run into
+# head-tokens / aligned-words / tail-tokens entries at trace time.
+
+
+def _build_write_runs(loc, *, kv_packing: int, r_cap: int):
+    """Run table for :func:`paged_write_back`.
+
+    Returns ``(table [3*r_cap, 4] int32, n_raw_runs)``; entry = (kind, src,
+    dst, n) where kind 0 = word run (src/dst in kv_packing-word indices) and
+    kind 1 = token run (src/dst in token indices). Entries with n == 0 are
+    no-ops. ``n_raw_runs > r_cap`` means the table overflowed and the caller
+    must fall back.
+    """
+    T = loc.shape[0]
+    pk = kv_packing
+    R = r_cap
+    loc = loc.astype(jnp.int32)
+    valid = loc >= 0
+    contig = jnp.concatenate(
+        [jnp.zeros((1,), bool), (loc[1:] == loc[:-1] + 1) & valid[1:] & valid[:-1]]
+    )
+    is_start = valid & ~contig
+    rid = jnp.cumsum(is_start) - 1  # run id per token (where valid)
+    n_raw = is_start.sum().astype(jnp.int32)
+
+    t_idx = jnp.arange(T, dtype=jnp.int32)
+    sidx = jnp.where(is_start, rid, R)
+    src0 = jnp.zeros((R,), jnp.int32).at[sidx].set(t_idx, mode="drop")
+    dst0 = jnp.zeros((R,), jnp.int32).at[sidx].set(loc, mode="drop")
+    lens = jnp.zeros((R,), jnp.int32).at[jnp.where(valid, rid, R)].add(1, mode="drop")
+
+    # split by word phase: aligned middle goes as one word run, edges per token
+    phase_ok = (src0 % pk) == (dst0 % pk)
+    head = jnp.where(phase_ok, (-dst0) % pk, 0)
+    head = jnp.minimum(head, lens)
+    words = jnp.where(phase_ok, (lens - head) // pk, 0)
+    tail = lens - head - words * pk
+
+    zero = jnp.zeros((R,), jnp.int32)
+    one = jnp.ones((R,), jnp.int32)
+    e_kind = jnp.stack([one, zero, one], axis=1)  # [R, 3]
+    e_src = jnp.stack([src0, (src0 + head) // pk, src0 + head + words * pk], axis=1)
+    e_dst = jnp.stack([dst0, (dst0 + head) // pk, dst0 + head + words * pk], axis=1)
+    e_n = jnp.stack([head, words, tail], axis=1)
+    table = jnp.stack([e_kind, e_src, e_dst, e_n], axis=2).reshape(3 * R, 4)
+    return table, n_raw
+
+
+def _write_back_kernel(tbl_ref, row_ref, cache_in_ref, out_ref, sem):
+    del cache_in_ref  # aliased with out_ref; all access goes through out_ref
+    Pn, pspk, pk, D = out_ref.shape
+    cache_w = out_ref.reshape(Pn * pspk, pk, D)  # word view (ref reshape: free)
+    cache_t = out_ref.reshape(Pn * pspk * pk, D)  # token view
+    Tw = row_ref.shape[0]
+    row_t = row_ref.reshape(Tw * pk, D)
+    E = tbl_ref.shape[0]
+
+    def entry(e, carry):
+        kind = tbl_ref[e, 0]
+        src = tbl_ref[e, 1]
+        dst = tbl_ref[e, 2]
+        n = tbl_ref[e, 3]
+
+        @pl.when((kind == 0) & (n > 0))
+        def _():
+            cp = pltpu.make_async_copy(row_ref.at[pl.ds(src, n)], cache_w.at[pl.ds(dst, n)], sem)
+            cp.start()
+            cp.wait()
+
+        @pl.when((kind == 1) & (n > 0))
+        def _():
+            def tok(i, c):
+                cp = pltpu.make_async_copy(
+                    row_t.at[pl.ds(src + i, 1)], cache_t.at[pl.ds(dst + i, 1)], sem
+                )
+                cp.start()
+                cp.wait()
+                return c
+
+            jax.lax.fori_loop(0, n, tok, 0)
+
+        return carry
+
+    jax.lax.fori_loop(0, E, entry, 0)
+
+
+def paged_write_back(
+    cache,  # [Pn, ps//pk, pk, D] paged pool
+    row,  # [T, D] new rows (already cache dtype / padded feature dim)
+    loc,  # [T] int32 flat slot per token; -1 = dropped
+    *,
+    page_size: int,
+    r_cap: int | None = None,
+    interpret: bool = False,
+):
+    """In-place paged self-write: ``cache[loc[t]] = row[t]`` for ``loc >= 0``.
+
+    Bit-identical to ``cache.reshape(-1, D).at[loc].set(row, mode="drop",
+    wrap_negative_indices=False)`` but without the scatter's flat-view
+    relayout round-trip. Falls back to that scatter when the run table
+    overflows ``r_cap`` (pathologically fragmented ``loc``).
+    """
+    Pn, pspk, pk, D = cache.shape
+    ps = page_size
+    assert pspk * pk == ps, (cache.shape, page_size)
+    T = row.shape[0]
+    Tp = -(-T // pk) * pk
+    if Tp != T:
+        row = jnp.pad(row, ((0, Tp - T), (0, 0)))
+        loc = jnp.pad(loc, ((0, Tp - T),), constant_values=-1)
+    if r_cap is None:
+        r_cap = 2 * (Tp // ps) + 130
+    table, n_raw = _build_write_runs(loc, kv_packing=pk, r_cap=r_cap)
+    row_w = row.reshape(Tp // pk, pk, D)
+
+    def _pallas(cache, row_w, table):
+        return pl.pallas_call(
+            _write_back_kernel,
+            in_specs=[
+                pl.BlockSpec(memory_space=pltpu.SMEM),  # run table
+                pl.BlockSpec(memory_space=pltpu.HBM),  # row (word view)
+                pl.BlockSpec(memory_space=pltpu.HBM),  # cache (aliased)
+            ],
+            out_specs=pl.BlockSpec(memory_space=pltpu.HBM),
+            out_shape=jax.ShapeDtypeStruct(cache.shape, cache.dtype),
+            scratch_shapes=[pltpu.SemaphoreType.DMA],
+            input_output_aliases={2: 0},
+            interpret=interpret,
+        )(table, row_w, cache)
+
+    def _scatter(cache, row_w, table):
+        del table
+        flat = cache.reshape(Pn * ps, D)
+        flat = flat.at[loc].set(row_w.reshape(Tp, D), mode="drop", wrap_negative_indices=False)
+        return flat.reshape(cache.shape)
+
+    return jax.lax.cond(n_raw <= r_cap, _pallas, _scatter, cache, row_w, table)

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
@@ -252,7 +252,7 @@ def sparse_mla_attention_qblock(
     *,
     kv_lora_rank: int = 512,
     read_block: int = 128,
-    query_block: int = 64,
+    query_block: int = 256,
     u_max: int | None = None,  # per-block union cap; default makes overflow impossible
     sm_scale: float,
     interpret: bool = False,
@@ -437,7 +437,7 @@ def prefill_write_and_attend_ragged_qblock(
     kv_lora_rank: int,
     page_size: int,
     sm_scale: float,
-    query_block: int = 64,
+    query_block: int = 256,
     interpret: bool = False,
 ):
     """Packed-ragged self-write + **blocked** sparse-MLA prefill.

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
@@ -556,13 +556,14 @@ def _build_write_runs(loc, *, kv_packing: int, r_cap: int):
     return table, n_raw
 
 
-def _write_back_kernel(tbl_ref, row_ref, cache_in_ref, out_ref, sem):
+def _write_back_kernel(tbl_ref, row_ref, cache_in_ref, out_ref, wdst_ref, wsrc_ref, sem):
     del cache_in_ref  # aliased with out_ref; all access goes through out_ref
     Pn, pspk, pk, D = out_ref.shape
-    cache_w = out_ref.reshape(Pn * pspk, pk, D)  # word view (ref reshape: free)
-    cache_t = out_ref.reshape(Pn * pspk * pk, D)  # token view
-    Tw = row_ref.shape[0]
-    row_t = row_ref.reshape(Tw * pk, D)
+    # word view: dim0 (words) is untiled, so dynamic word offsets are legal.
+    # A flat [Pn*ps, D] token view is NOT: it inherits the (pk, ...) pairing
+    # tile on dim0 and single-token slices at odd offsets fail Mosaic
+    # alignment. Edge tokens therefore go through a word-granular RMW below.
+    cache_w = out_ref.reshape(Pn * pspk, pk, D)
     E = tbl_ref.shape[0]
 
     def entry(e, carry):
@@ -579,12 +580,30 @@ def _write_back_kernel(tbl_ref, row_ref, cache_in_ref, out_ref, sem):
 
         @pl.when((kind == 1) & (n > 0))
         def _():
+            # per-token read-modify-write at word granularity: fetch the dst
+            # word (preserving the neighbour token), overwrite one row via
+            # statically-unrolled phase branches (pk is static), write back.
             def tok(i, c):
-                cp = pltpu.make_async_copy(
-                    row_t.at[pl.ds(src + i, 1)], cache_t.at[pl.ds(dst + i, 1)], sem
-                )
-                cp.start()
-                cp.wait()
+                st = src + i
+                dt = dst + i
+                sw = st // pk
+                dw = dt // pk
+                cpa = pltpu.make_async_copy(cache_w.at[pl.ds(dw, 1)], wdst_ref, sem)
+                cpa.start()
+                cpa.wait()
+                cpb = pltpu.make_async_copy(row_ref.at[pl.ds(sw, 1)], wsrc_ref, sem)
+                cpb.start()
+                cpb.wait()
+                for spv in range(pk):
+                    for dpv in range(pk):
+
+                        @pl.when((st % pk == spv) & (dt % pk == dpv))
+                        def _(spv=spv, dpv=dpv):
+                            wdst_ref[0, dpv, :] = wsrc_ref[0, spv, :]
+
+                cpc = pltpu.make_async_copy(wdst_ref, cache_w.at[pl.ds(dw, 1)], sem)
+                cpc.start()
+                cpc.wait()
                 return c
 
             jax.lax.fori_loop(0, n, tok, 0)
@@ -633,7 +652,11 @@ def paged_write_back(
             ],
             out_specs=pl.BlockSpec(memory_space=pltpu.HBM),
             out_shape=jax.ShapeDtypeStruct(cache.shape, cache.dtype),
-            scratch_shapes=[pltpu.SemaphoreType.DMA],
+            scratch_shapes=[
+                pltpu.VMEM((1, pk, D), cache.dtype),
+                pltpu.VMEM((1, pk, D), cache.dtype),
+                pltpu.SemaphoreType.DMA,
+            ],
             input_output_aliases={2: 0},
             interpret=interpret,
         )(table, row_w, cache)

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -85,7 +85,12 @@ _PREFILL_SPARSE = int(os.environ.get("DSA_PREFILL_SPARSE", "0"))
 # path is completely unaffected. ``DSA_PREFILL_QBLOCK=0`` is an escape hatch
 # back to the per-query kernel (e.g. for pathological no-locality selections).
 _PREFILL_QBLOCK = os.environ.get("DSA_PREFILL_QBLOCK", "1") == "1"
-_PREFILL_QBLOCK_QB = int(os.environ.get("DSA_PREFILL_QBLOCK_QB", "64"))
+# Default 256 from the QB sweep on GLM-5.2 (v7x tp16 and v6e-64): saturated
+# attend work scales as (T/QB) * ctx_pages, and 64->256 was uniformly positive
+# (110k TTFT -10%, 16k -11%) with paired-accuracy gates clean at every step.
+# 512 projects <2% further and grows the per-block union tail, so 256 is the
+# sweet spot. Override per deployment via DSA_PREFILL_QBLOCK_QB.
+_PREFILL_QBLOCK_QB = int(os.environ.get("DSA_PREFILL_QBLOCK_QB", "256"))
 
 
 @register_pytree_node_class

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -800,7 +800,11 @@ def _scatter_paged(
     offset = abs_pos % page_size
     page = page_indices[cu_kv_lens[seq_id] // page_size + page_local]
 
-    sentinel = cache3d.shape[0] - 1
+    # Padding rows must land on the reserved page: the allocator hands out
+    # local pages 1..pages_per_rank and keeps page 0 (reads through it are
+    # masked past kv_len), while the LAST page is allocatable — near-full
+    # pools would otherwise get offset 0 of a live page's keys clobbered.
+    sentinel = 0
     safe_page = jnp.where(valid, page, sentinel)
     safe_off = jnp.where(valid, offset, 0)
     return cache3d.at[safe_page, safe_off].set(new_tokens.astype(cache3d.dtype))

--- a/test/srt/kernels/dsa/test_qblock_kernel_tpu.py
+++ b/test/srt/kernels/dsa/test_qblock_kernel_tpu.py
@@ -180,3 +180,50 @@ def test_ragged_qblock_tpu(seq_lens_list, qb, tol):
     print(f"[tpu ragged qblock qb={qb}] |o_qb-o_cur|={d_o:.3e} |cache diff|={d_c:.3e}")
     assert d_c == 0.0, "self-write must be identical"
     assert d_o < tol, f"ragged qblock vs deployed drifted: {d_o}"
+
+
+# ── pallas write-back vs XLA scatter (bit-identical contract) ────────────────
+
+from sgl_jax.srt.kernels.dsa.sparse_mla_prefill_qblock import paged_write_back
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        # single-seq page-aligned chunk (the 110k shape): one giant run
+        dict(T=512, pages=6, locs="contig", seed=0),
+        # multi-request, non-adjacent physical pages: run per page
+        dict(T=384, pages=8, locs="scattered_pages", seed=1),
+        # odd offsets: run starts mid-word (kv_packing phase mismatch paths)
+        dict(T=131, pages=4, locs="odd", seed=2),
+        # padded tail: loc == -1 must be dropped (canary)
+        dict(T=256, pages=4, locs="padded", seed=3),
+    ],
+)
+def test_paged_write_back_parity(case):
+    rng = np.random.default_rng(case["seed"])
+    ps, pk, D = 128, 2, 640
+    T, Pn = case["T"], case["pages"]
+    row = jnp.asarray(rng.standard_normal((T, D)) * 0.1, jnp.bfloat16)
+    cache = jnp.asarray(rng.standard_normal((Pn, ps // pk, pk, D)) * 0.1, jnp.bfloat16)
+
+    if case["locs"] == "contig":
+        loc = np.arange(T, dtype=np.int32) + ps  # starts at page 1, aligned
+    elif case["locs"] == "scattered_pages":
+        pages = rng.permutation(Pn)[: -(-T // ps)]
+        loc = np.concatenate(
+            [p * ps + np.arange(min(ps, T - i * ps)) for i, p in enumerate(pages)]
+        ).astype(np.int32)
+    elif case["locs"] == "odd":
+        loc = np.arange(T, dtype=np.int32) + ps + 1  # word-phase mismatch start
+    else:  # padded
+        loc = np.concatenate([np.arange(T - 64) + ps, np.full(64, -1)]).astype(np.int32)
+    loc = jnp.asarray(loc)
+
+    # oracle: the XLA flat scatter
+    flat = cache.reshape(Pn * ps, D)
+    want = flat.at[loc].set(row, mode="drop", wrap_negative_indices=False).reshape(cache.shape)
+    got = paged_write_back(cache, row, loc, page_size=ps)
+    np.testing.assert_array_equal(
+        np.asarray(got, dtype=np.float32), np.asarray(want, dtype=np.float32)
+    )

--- a/test/srt/kernels/dsa/test_qblock_preprocess.py
+++ b/test/srt/kernels/dsa/test_qblock_preprocess.py
@@ -138,3 +138,27 @@ def test_packed_multirequest_global_keys(num_seqs):
         rows.append(np.where(tk >= 0, tk + base, -1))
     tk_packed = np.concatenate(rows, axis=0)
     _check(tk_packed, qb=64, u_max=num_seqs * pages_per_seq)
+
+
+def test_build_write_runs_table():
+    # run-table builder for the pallas write-back: word/token split + overflow
+    from sgl_jax.srt.kernels.dsa.sparse_mla_prefill_qblock import _build_write_runs
+
+    pk = 2
+    # aligned contiguous run + gap(-1) + odd-phase run
+    loc = np.array([4, 5, 6, 7, -1, -1, 11, 12, 13], np.int32)  # src 0..3 / 6..8
+    tbl, n_raw = _build_write_runs(jnp.asarray(loc), kv_packing=pk, r_cap=8)
+    tbl = np.asarray(tbl)
+    assert int(n_raw) == 2
+    live = tbl[tbl[:, 3] > 0]
+    # reconstruct per-token writes from the table and compare with the oracle
+    writes = {}
+    for kind, src, dst, n in live.tolist():
+        for i in range(n):
+            if kind == 0:  # word run
+                for w in range(pk):
+                    writes[(dst + i) * pk + w] = (src + i) * pk + w
+            else:
+                writes[dst + i] = src + i
+    want = {int(l): t for t, l in enumerate(loc) if l >= 0}
+    assert writes == want, (writes, want)

--- a/test/srt/kernels/dsa/test_ref.py
+++ b/test/srt/kernels/dsa/test_ref.py
@@ -172,15 +172,16 @@ def test_scatter_paged_padding_seq_no_leak():
     seq_lens = jnp.asarray([3, 0], jnp.int32)  # seq1 = padding
     cu_q_lens = jnp.asarray([0, 1, 2], jnp.int32)  # DECODE arange
     cu_kv_lens = jnp.asarray([0, ps, ps], jnp.int32)  # seq0 aligned=4, seq1 aligned=0
-    page_indices = jnp.asarray([0, 1, 2, 3], jnp.int32)
+    # Production allocator convention: real pages start at 1, page 0 reserved.
+    page_indices = jnp.asarray([1, 2, 3, 0], jnp.int32)
     new_tokens = jnp.asarray([[1.0] * D, [99.0] * D], jnp.float32)
 
     out = np.asarray(
         _scatter_paged(cache, new_tokens, seq_lens, page_indices, cu_q_lens, cu_kv_lens, pps)
     )
-    assert out[0, 2, 0] == 1.0  # real seq0 write
-    # padding seq1 must NOT leak into any non-sentinel page
-    assert not np.any(out[: P - 1] == 99.0), f"leaked: {np.argwhere(out[:P-1]==99.0)}"
+    assert out[1, 2, 0] == 1.0  # real seq0 write (page 1)
+    # padding seq1 may only land on the reserved page 0 — never a live page
+    assert not np.any(out[1:] == 99.0), f"leaked: {np.argwhere(out[1:]==99.0)}"
 
 
 def test_sparse_mla_multi_seq_packed_layout():

--- a/test/srt/kernels/dsa/test_scatter_paged_sentinel.py
+++ b/test/srt/kernels/dsa/test_scatter_paged_sentinel.py
@@ -1,0 +1,62 @@
+"""Padding rows in _scatter_paged must never clobber an allocatable page.
+
+The paged allocator hands out local pages 1..pages_per_rank and reserves
+page 0 (allocator.py); the last local page is therefore live. Routing
+invalid/padding rows to a live page corrupts offset 0 of that page's
+indexer keys whenever the pool is full enough for it to be allocated.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.layers.attention.dsa_sparse_backend import _scatter_paged
+
+jax.config.update("jax_platform_name", "cpu")
+
+PAGE_SIZE = 4
+NUM_PAGES = 8  # local pages 0..7; allocator hands out 1..7, page 0 reserved
+D = 16
+
+
+def _run_padded_batch(cache):
+    """One seq: kv_len=4, 3 new tail tokens (offsets 1..3), padded to T=8.
+
+    Offset 0 of the seq's page holds a pre-existing key that this batch does
+    not write — the slot the sentinel routing of padding rows lands on.
+    """
+    T = 8
+    new_tokens = jnp.full((T, D), 777.0, dtype=cache.dtype)
+    seq_lens = jnp.array([4], dtype=jnp.int32)
+    # seq uses the LAST allocatable page (7): the near-full-pool case.
+    page_indices = jnp.array([7, 0, 0, 0], dtype=jnp.int32)
+    cu_q_lens = jnp.array([0, 3], dtype=jnp.int32)
+    cu_kv_lens = jnp.array([0, PAGE_SIZE], dtype=jnp.int32)
+    return _scatter_paged(cache, new_tokens, seq_lens, page_indices, cu_q_lens, cu_kv_lens, 4)
+
+
+def test_padding_rows_do_not_clobber_live_pages():
+    cache = jnp.arange(NUM_PAGES * PAGE_SIZE * D, dtype=jnp.float32).reshape(
+        NUM_PAGES, PAGE_SIZE, D
+    )
+    out = np.asarray(_run_padded_batch(cache))
+    ref = np.asarray(cache)
+
+    # The seq's own 3 tail slots (offsets 1..3) on page 7 are written.
+    assert (out[7, 1:4] == 777.0).all()
+    # The pre-existing key at page 7 offset 0 must survive: padding rows
+    # must not be routed onto a live page.
+    assert (out[7, 0] == ref[7, 0]).all(), "padding rows clobbered a live page"
+    assert (out[1:7] == ref[1:7]).all()
+
+
+def test_padding_rows_land_on_reserved_page_zero_only():
+    cache = jnp.zeros((NUM_PAGES, PAGE_SIZE, D), dtype=jnp.float32)
+    out = np.asarray(_run_padded_batch(cache))
+    # Padding rows may only ever dirty the reserved page 0 (never handed out
+    # by the allocator; reads through it are masked past kv_len).
+    dirty = (out != 0).any(axis=2)  # [pages, offsets]
+    # page 7: only the seq's own offsets 1..3 may be dirty
+    assert not dirty[7, 0], "padding garbage on live page 7 offset 0"
+    # pages 1..6 fully clean; page 0 (reserved) is the only allowed dump target
+    assert not dirty[1:7].any()


### PR DESCRIPTION
Follow-up to #1567, shipping its two listed natural extensions together:

## 1. Paged write-back kernel (in-place self-write)

The qblock wrapper's self-write scattered new kv rows through a flat `[Pn*ps, D]` view of the 4D cache. XLA materializes TWO full relayout copies of the pool per call for that round-trip (the 4D pool and the 2D view get different tilings) — measured at 13.8% of 110k prefill device time. 4D-scatter rewrites do not help: the flatten/unflatten pair is generated by XLA's scatter normalization itself.

`paged_write_back` is a small pallas kernel that writes rows in place: a run table over `out_cache_loc` (contiguous-run detection host-free), HBM-direct row copies, `input_output_aliases` for the pool, and a `cond` fallback to the XLA path when the run budget is exceeded. Edge tokens whose rows straddle a packing-tile word boundary go through a word-granular read-modify-write (last commit) so the flat token view's inherited packing tiling stays bit-correct.

## 2. QB default 64 -> 256

Saturated attend work scales as `(T/QB) * ctx_pages`; the QB sweep is uniformly positive from 16k to 135k with accuracy gates clean at every step, and 512 projects <2% further. `DSA_PREFILL_QBLOCK_QB` still overrides.

## Measured (GLM-5.2, TPU v7x tp16, chunked 8192 / ctx 135k)

| stage | 110k TTFT | 16k |
|---|---|---|
| #1567 as merged (QB=64) | 30.2s | 2.71s |
| + write-back | 24.43s (-19%) | 2.71s |
| + QB=256 | **21.89s (-28% cumulative)** | **2.40s (-11%)** |

- decode TPOT unaffected (decode does not run the qblock path).
- v6e-64 (tp64/dp8, W8A8): same kernels zero-change; paired throughput ON/OFF 1.49/1.33/1.40x at cc 64/256/460.
- radix cache interop: write-back pages preserve prefix-reuse semantics — 32-session x 4-round agentic probe hits 32/32 every round, warm-round latency flat, needle 25/25 on reused prefixes.

## Accuracy

- evalscope gsm8k full 1319, thinking 4-shot: **0.9757** (write-back + QB256 stack, v6e).
- paired 200q gsm8k four arms (ON/OFF x QB64/256): 0.940-0.965 within noise, 190+/200 responses byte-identical to the OFF arm.
- needle 25/25 at every stage; cc=1/8/32 compile surface clean.

## Tests

- [x] CPU (jax 0.11.1): full dsa kernel suite 49 passed / 3 skips
- [x] TPU v7x (jax 0.11.1, post-#1567 image + this branch): full dsa suite 49 passed / 3 skips
- [x] pre-commit clean
