### PR TITLE
feat(metrics): report the speculative accept length in /get_server_info

### DIFF
--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -71,7 +71,10 @@ from sgl_jax.srt.managers.schedule_policy import (
     PrefillAdder,
     SchedulePolicy,
 )
-from sgl_jax.srt.managers.scheduler_metrics_mixin import SchedulerMetricsMixin
+from sgl_jax.srt.managers.scheduler_metrics_mixin import (
+    SchedulerMetricsMixin,
+    compute_avg_spec_accept_length,
+)
 from sgl_jax.srt.managers.scheduler_output_processor_mixin import (
     SchedulerOutputProcessorMixin,
 )
@@ -1515,6 +1518,9 @@ class Scheduler(
     def get_internal_state(self, recv_req: GetInternalStateReq):
         ret = dict(global_server_args_dict)
         ret["last_gen_throughput"] = self.last_gen_throughput
+        ret["avg_spec_accept_length"] = compute_avg_spec_accept_length(
+            self.cum_spec_accept_length, self.cum_spec_accept_count
+        )
         ret["memory_usage"] = {
             "kvcache": round(self.token_to_kv_pool_allocator.get_kvcache().mem_usage, 2),
             "token_capacity": int(self.max_total_num_tokens),

--- a/python/sgl_jax/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_metrics_mixin.py
@@ -17,13 +17,24 @@ logger = logging.getLogger(__name__)
 RECORD_STEP_TIME = get_bool_env_var("SGLANG_RECORD_STEP_TIME")
 
 
+def compute_avg_spec_accept_length(cum_accept_length: int, cum_accept_count: int) -> float | None:
+    """Tokens committed per verify step; >= 1.0, since the bonus token always lands.
+
+    None rather than 0.0 before the first verify step: the benchmark clients
+    print any float verbatim and only fall back to "n/a" on None.
+    """
+    if cum_accept_count <= 0:
+        return None
+    return cum_accept_length / cum_accept_count
+
+
 class SchedulerMetricsMixin:
     def init_metrics(self: Scheduler):
         self.last_gen_throughput: float = 0.0
         self.last_input_throughput: float = 0.0
         self.step_time_dict = defaultdict(list)  # Dict[batch size -> step time]
-        self.spec_num_total_accepted_tokens = 0
-        self.spec_num_total_forward_ct = 0
+        # accept_token / spec_num_forward_ct count the same thing, but log_decode_stats
+        # zeroes them every interval; these two are never reset.
         self.cum_spec_accept_length = 0
         self.cum_spec_accept_count = 0
         self.total_retracted_reqs = 0

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -370,6 +370,31 @@ class SchedulerOutputProcessorMixin:
                             and getattr(info.spec_info, "future_indices", None) is not None
                         ), "spec relay prefill output must carry future_indices"
 
+    def account_spec_decode_tokens(self: Scheduler, batch: ScheduleBatch, next_token_ids):
+        """Token counters for one speculative verify step.
+
+        Moves the per-interval pair log_decode_stats prints and resets, and the
+        cumulative pair get_internal_state reports; the two must stay in step.
+        Split out of process_batch_result_decode so a CPU test can reach it.
+        """
+        active_spec_reqs = 0
+        per_dp_bs = batch.per_dp_bs_size
+        for dp_rank, info in enumerate(batch.reqs_info):
+            base = dp_rank * per_dp_bs
+            for j, req in enumerate(info.reqs or []):
+                if self.enable_overlap and (req.finished() or req.is_retracted):
+                    continue
+                if req.is_retracted:
+                    continue
+                accepted = len(next_token_ids[base + j])
+                self.num_generated_tokens += accepted
+                self.accept_token += accepted
+                self.cum_spec_accept_length += accepted
+                active_spec_reqs += 1
+        self.spec_num_forward_ct += active_spec_reqs
+        self.cum_spec_accept_count += active_spec_reqs
+        self.draft_token += active_spec_reqs * self.draft_worker.speculative_num_draft_tokens
+
     def process_batch_result_decode(
         self: Scheduler,
         batch: ScheduleBatch,
@@ -420,21 +445,7 @@ class SchedulerOutputProcessorMixin:
         if not is_spec_decode:
             self.num_generated_tokens += batch.batch_size()
         else:
-            active_spec_reqs = 0
-            per_dp_bs = batch.per_dp_bs_size
-            for dp_rank, info in enumerate(batch.reqs_info):
-                base = dp_rank * per_dp_bs
-                for j, req in enumerate(info.reqs or []):
-                    if self.enable_overlap and (req.finished() or req.is_retracted):
-                        continue
-                    if req.is_retracted:
-                        continue
-                    accepted = len(next_token_ids[base + j])
-                    self.num_generated_tokens += accepted
-                    self.accept_token += accepted
-                    active_spec_reqs += 1
-            self.spec_num_forward_ct += active_spec_reqs
-            self.draft_token += active_spec_reqs * self.draft_worker.speculative_num_draft_tokens
+            self.account_spec_decode_tokens(batch, next_token_ids)
         # FIXME(pc) add spec decode metrics
 
         if self.enable_overlap:

--- a/python/sgl_jax/test/test_spec_accept_metrics.py
+++ b/python/sgl_jax/test/test_spec_accept_metrics.py
@@ -1,0 +1,188 @@
+"""Accept-length telemetry for speculative decoding.
+
+Pins what the benchmark clients depend on: the None-vs-float contract, the
+accounting moving both counter pairs, and the cumulative pair surviving the
+per-interval reset in ``log_decode_stats``.
+"""
+
+import types
+import unittest
+
+from sgl_jax.srt.managers.scheduler import Scheduler
+from sgl_jax.srt.managers.scheduler_metrics_mixin import (
+    SchedulerMetricsMixin,
+    compute_avg_spec_accept_length,
+)
+
+
+class _Batch:
+    dp_size = 1
+    reqs_info = []
+    cache_miss_count = 0
+
+    def is_empty(self):
+        return True
+
+    def batch_size(self):
+        return 2
+
+
+class _SpecAlgorithm:
+    def is_none(self):
+        return False
+
+
+class _Req:
+    def __init__(self, retracted=False):
+        self.is_retracted = retracted
+
+    def finished(self):
+        return False
+
+
+class _SpecBatch:
+    def __init__(self, reqs, per_dp_bs):
+        self.per_dp_bs_size = per_dp_bs
+        self.reqs_info = [types.SimpleNamespace(reqs=reqs)]
+
+
+class _KVCache:
+    mem_usage = 1.0
+
+
+class _Allocator:
+    def get_kvcache(self):
+        return _KVCache()
+
+    def available_size(self, dp_rank=None):
+        return 100
+
+
+class TestComputeAvgSpecAcceptLength(unittest.TestCase):
+    def test_returns_none_before_any_verify_step(self):
+        # 0.0 would read as a real measurement to the bench clients.
+        self.assertIsNone(compute_avg_spec_accept_length(0, 0))
+
+    def test_ratio(self):
+        self.assertAlmostEqual(compute_avg_spec_accept_length(35, 10), 3.5)
+
+    def test_no_speculative_gain_is_one(self):
+        # The bonus token always lands, so the floor is 1.0.
+        self.assertAlmostEqual(compute_avg_spec_accept_length(10, 10), 1.0)
+
+
+class TestSpecAcceptCounters(unittest.TestCase):
+    def test_init_metrics_defines_the_counters_the_processor_increments(self):
+        obj = types.SimpleNamespace()
+        SchedulerMetricsMixin.init_metrics(obj)
+        self.assertEqual(obj.cum_spec_accept_length, 0)
+        self.assertEqual(obj.cum_spec_accept_count, 0)
+
+    def test_accounting_moves_both_counter_pairs(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        SchedulerMetricsMixin.init_metrics(scheduler)
+        scheduler.num_generated_tokens = 0
+        scheduler.accept_token = 0
+        scheduler.draft_token = 0
+        scheduler.spec_num_forward_ct = 0
+        scheduler.enable_overlap = False
+        scheduler.draft_worker = types.SimpleNamespace(speculative_num_draft_tokens=4)
+        # Two live requests committing 3 and 1 tokens; the retracted slot must
+        # not be counted at all.
+        batch = _SpecBatch(
+            [_Req(), _Req(), _Req(retracted=True)],
+            per_dp_bs=3,
+        )
+        next_token_ids = [[11, 12, 13], [21], [31, 32]]
+
+        scheduler.account_spec_decode_tokens(batch, next_token_ids)
+
+        self.assertEqual(scheduler.cum_spec_accept_length, 4)  # 3 + 1
+        self.assertEqual(scheduler.cum_spec_accept_count, 2)  # two live reqs
+        # Same amounts, or the logged accept-len and the exported average diverge.
+        self.assertEqual(scheduler.accept_token, 4)
+        self.assertEqual(scheduler.spec_num_forward_ct, 2)
+        self.assertEqual(scheduler.num_generated_tokens, 4)
+        self.assertEqual(scheduler.draft_token, 8)  # 2 reqs * 4 draft tokens
+        self.assertAlmostEqual(
+            compute_avg_spec_accept_length(
+                scheduler.cum_spec_accept_length, scheduler.cum_spec_accept_count
+            ),
+            2.0,
+        )
+
+    def test_log_decode_stats_reset_does_not_touch_cumulative_counters(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        SchedulerMetricsMixin.init_metrics(scheduler)
+        scheduler.running_batch = _Batch()
+        scheduler.last_decode_stats_tic = 0.0
+        scheduler.num_generated_tokens = 30
+        scheduler.is_hybrid = False
+        scheduler._get_token_info = lambda: (0, 0.0, 0, 0)
+        scheduler.spec_algorithm = _SpecAlgorithm()
+        scheduler.waiting_queue = []
+        scheduler.server_args = types.SimpleNamespace(decode_log_interval=1)
+        # One interval's worth of what log_decode_stats consumes...
+        scheduler.accept_token = 30
+        scheduler.draft_token = 40
+        scheduler.spec_num_forward_ct = 10
+        # ...and the cumulative twins covering two intervals.
+        scheduler.cum_spec_accept_length = 60
+        scheduler.cum_spec_accept_count = 20
+
+        scheduler.log_decode_stats()
+
+        self.assertEqual(scheduler.accept_token, 0)
+        self.assertEqual(scheduler.draft_token, 0)
+        self.assertEqual(scheduler.spec_num_forward_ct, 0)
+        self.assertEqual(scheduler.cum_spec_accept_length, 60)
+        self.assertEqual(scheduler.cum_spec_accept_count, 20)
+        self.assertAlmostEqual(
+            compute_avg_spec_accept_length(
+                scheduler.cum_spec_accept_length, scheduler.cum_spec_accept_count
+            ),
+            3.0,
+        )
+
+
+class TestGetInternalStateExposesAcceptLength(unittest.TestCase):
+    def _make_scheduler(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        SchedulerMetricsMixin.init_metrics(scheduler)
+        scheduler.token_to_kv_pool_allocator = _Allocator()
+        scheduler.max_total_num_tokens = 1024
+        scheduler._engine_paused = False
+        scheduler.waiting_queue = []
+        scheduler.pending_dp_reqs = []
+        scheduler.running_batch = _Batch()
+        scheduler.cur_batch = None
+        scheduler.last_batch = None
+        scheduler.chunked_reqs = [None]
+        scheduler.tree_cache = None
+        scheduler.req_to_token_pool = None
+        scheduler.dp_size = 1
+        scheduler.num_generated_tokens = 0
+        scheduler.forward_ct_decode = 0
+        scheduler.new_token_ratio = 0.25
+        scheduler.init_new_token_ratio = 0.75
+        scheduler.disagg_prefill_queue = None
+        scheduler.disagg_prealloc_queue = None
+        scheduler.disagg_transfer_queue = None
+        return scheduler
+
+    def test_key_is_none_without_spec_decode(self):
+        scheduler = self._make_scheduler()
+        state = scheduler.get_internal_state(None).internal_state
+        self.assertIn("avg_spec_accept_length", state)
+        self.assertIsNone(state["avg_spec_accept_length"])
+
+    def test_key_reports_the_running_average(self):
+        scheduler = self._make_scheduler()
+        scheduler.cum_spec_accept_length = 27
+        scheduler.cum_spec_accept_count = 9
+        state = scheduler.get_internal_state(None).internal_state
+        self.assertAlmostEqual(state["avg_spec_accept_length"], 3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -343,6 +343,7 @@ suites = {
         TestFile("python/sgl_jax/test/test_scheduler_chunked_ownership.py", 0.1),
         TestFile("python/sgl_jax/test/test_scheduler_dp_load.py", 0.1, runner="pytest"),
         TestFile("python/sgl_jax/test/test_scheduler_retraction.py", 0.1),
+        TestFile("python/sgl_jax/test/test_spec_accept_metrics.py", 0.1),
         TestFile("python/sgl_jax/test/test_swa_schedule_budget.py", 0.1),
         TestFile("test/srt/test_dtype_config_llama.py", 1),
         TestFile("test/srt/test_dtype_config_consistency.py", 10),


### PR DESCRIPTION
## TL;DR

Speculative decoding has no health metric anyone can read: the accept length is computed
but reachable only from a log line that resets every interval, and the two benchmark
clients that ask for it get `n/a`. This exports it on `/get_server_info`, so a run that
has silently stopped benefiting from speculation becomes visible.

## Why it matters

Speculation is lossless, so if the accept length collapsed to 1.0 — every speculated token
rejected, the draft model contributing nothing but latency — accuracy would not move and
nothing in CI would notice: `test/srt/test_speculative_decoding.py` is the only end-to-end
speculative test, and its only assertion is an MMLU score (`:92`). The readers already
exist and always print `n/a` (`bench_one_batch_server.py:265`,
`bench_serving.py:2391-2392`); nothing in the tree writes the key. I also want the number as
the baseline for judging whether tree drafting (`--speculative-eagle-topk > 1`) would pay
for itself here.

## The change

- `scheduler_output_processor_mixin.py:392,395` — increment `cum_spec_accept_length` and
  `cum_spec_accept_count` alongside the per-interval pair they mirror. Both were
  initialised in `init_metrics` and never touched by anything.
- The block holding them moves out of `process_batch_result_decode` into
  `account_spec_decode_tokens` (`:373`), unchanged apart from the two new lines. It is a
  pure move, and it is what makes the increments reachable from a CPU test — speculative
  decoding otherwise needs a TPU and a draft model.
- `scheduler.py:1515` — expose the ratio in `get_internal_state`. It returns `None`, not
  `0.0`, when no verify step has run: the bench clients print any float verbatim and only
  fall back to `n/a` on `None`.
- `init_metrics` — drop `spec_num_total_accepted_tokens` / `spec_num_total_forward_ct`,
  which have no reader and no writer anywhere in the tree.

The exported value is the same quantity as the logged `accept-len`, averaged over the
whole run instead of the last interval. Floor 1.0, since every verify step commits the
bonus token; ceiling `--speculative-num-draft-tokens`.

## Test

`python/sgl_jax/test/test_spec_accept_metrics.py`, in `unit-test-cpu`: the `None`-at-zero
contract the bench clients depend on, that `account_spec_decode_tokens` moves both pairs
by the same amounts and skips retracted slots, and that `log_decode_stats` resets the
per-interval pair without touching the cumulative one.

Mutation-checked locally: returning `0.0` instead of `None`, dropping either increment,
counting retracted slots, and resetting the cumulative pair in `log_decode_stats` each
fail at least one test.
