### PR TITLE
fix(kda): prevent packed boundary gate overflow

### DIFF
--- a/python/sgl_jax/srt/kernels/kda/mega_kda/kernel.py
+++ b/python/sgl_jax/srt/kernels/kda/mega_kda/kernel.py
@@ -989,29 +989,41 @@ def _fwd_mega_kernel_native_segids(
         # Aqk/L (FULL-style, no cross-seg masking in loop for stability)
         BC = QK_BC
         beta_f32 = beta[:, :, None]
-        # Restart the log-domain prefix at the packed segment boundary. This
-        # preserves segment B's initial-state contribution; within-segment
-        # gate differences used by Aqk/L are unchanged by the constant shift.
-        first_segment_total = jnp.min(
-            jnp.where(seg_A_mask[None, :, None] > 0, g_cumsum, 0.0),
-            axis=1,
-            keepdims=True,
-        )
-        g_cumsum = g_cumsum - first_segment_total * seg_B_mask[None, :, None]
+        # Build the intra terms before restarting segment B's log-domain
+        # prefix. Resetting first introduces a large positive discontinuity at
+        # the packed boundary, so the factored exponentials can overflow before
+        # the cross-segment entries are masked. Within-segment gate differences
+        # are invariant to the later constant shift.
+        continuous_g_cumsum = g_cumsum
         if lower_bound is None:
             Aqk, L, _ = _build_unbounded_intra_terms(
-                q, k, g_cumsum, beta, scale, BC, OUTPUT_PRECISION
+                q, k, continuous_g_cumsum, beta, scale, BC, OUTPUT_PRECISION
             )
         else:
             Aqk, L, _ = _build_bounded_intra_terms(
-                q, k, g_cumsum, beta, scale, BC, OUTPUT_PRECISION, safe_gate
+                q,
+                k,
+                continuous_g_cumsum,
+                beta,
+                scale,
+                BC,
+                OUTPUT_PRECISION,
+                safe_gate,
             )
 
-        # Mask L for segment-independent solve
-        same_seg_L = (
-            seg_A_mask[:, None] * seg_A_mask[None, :] + seg_B_mask[:, None] * seg_B_mask[None, :]
+        # Restart segment B for its initial-state and final-state paths.
+        first_segment_total = jnp.min(
+            jnp.where(seg_A_mask[None, :, None] > 0, continuous_g_cumsum, 0.0),
+            axis=1,
+            keepdims=True,
         )
-        L = L * same_seg_L[None]
+        g_cumsum = continuous_g_cumsum - first_segment_total * seg_B_mask[None, :, None]
+
+        # Mask L for segment-independent solve
+        same_seg_L = (seg_A_mask[:, None] * seg_A_mask[None, :]) + (
+            seg_B_mask[:, None] * seg_B_mask[None, :]
+        ) > 0
+        L = jnp.where(same_seg_L[None], L, 0.0)
 
         # Solve (same as FULL)
         v_beta = v * beta_f32
@@ -1150,7 +1162,7 @@ def _fwd_mega_kernel_native_segids(
         # Output: Aqk is already same-segment masked.  Build the correct
         # per-segment v_new before the intra-chunk matmul so segment B does not
         # need two additional Aqk compensation matmuls.
-        Aqk_seg = Aqk * same_seg_L[None]
+        Aqk_seg = jnp.where(same_seg_L[None], Aqk, 0.0)
         if SKIP_STAGE4_MASK:
             Aqk_stage4 = Aqk_seg.astype(jnp.float32)
         else:

--- a/python/sgl_jax/test/kernels/mega_kda_test.py
+++ b/python/sgl_jax/test/kernels/mega_kda_test.py
@@ -160,6 +160,35 @@ def test_bounded_boundary_preserves_nonzero_initial_state():
     np.testing.assert_allclose(actual, reference, rtol=2e-2, atol=2e-4)
 
 
+def test_bounded_boundary_with_strong_decay_matches_naive():
+    """A packed boundary must not make factored gate exponentials overflow."""
+    arrays = _case(16, (63, 65), seed=1558)
+    arrays["g"] = jnp.zeros_like(arrays["g"])
+    arrays["a_log"] = jnp.zeros_like(arrays["a_log"])
+    arrays["dt_bias"] = jnp.full_like(arrays["dt_bias"], np.log(1.5))
+
+    reference_output, reference_state = _reference(arrays)
+    mega_output, mega_state = _mega(arrays)
+    jax.block_until_ready((reference_output, reference_state, mega_output, mega_state))
+
+    actual_output = np.asarray(mega_output, dtype=np.float32)
+    actual_state = np.asarray(mega_state, dtype=np.float32)
+    assert np.isfinite(actual_output).all()
+    assert np.isfinite(actual_state).all()
+    np.testing.assert_allclose(
+        actual_output,
+        np.asarray(reference_output, dtype=np.float32),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+    np.testing.assert_allclose(
+        actual_state,
+        np.asarray(reference_state, dtype=np.float32),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+
+
 @pytest.mark.parametrize(
     ("heads", "lengths"),
     [


### PR DESCRIPTION
## Motivation

Mega KDA can produce non-finite outputs when a prefill tile contains a packed segment boundary. The boundary path resets the second segment's cumulative gate before building the factored intra terms. That creates a large positive discontinuity, so `exp2` may overflow before cross-segment entries are masked. In Ling3-Tiny serving this surfaced as repeated `!` output under concurrent long agentic requests.

## Changes

- Build `Aqk` and `L` from the continuous cumulative gate.
- Restart segment B only for the initial-state/final-state paths.
- Use `jnp.where` for cross-segment masking so masked non-finite values cannot propagate.
- Add a 16-head `(63, 65)` packed-boundary regression with strong but valid bounded gate decay.

## Validation

- Regression test on unmodified `main`: fails with the full 128-token output becoming NaN.
- Patched Mega KDA test suite on TPU v7x-8: **16 passed** (`exp-gi0ltcvh8m`, artifact `art-vmrb2nkvtb`).
- Ling3-Tiny E2E on TP8/DP8/EP1/MoE-DP8: 7 cases x 3 trials, 69 requests, **0 degenerate outputs**, including the three previously stable failure cases (`exp-otz1xz506n`, artifact `art-1wsaqulotk`).
- Patched Mega latency remains in the original Mega range (~1.1-1.6 s); no systematic regression versus the unpatched Mega runs.
- `ruff format --check`, `ruff check`, and `git diff --check` pass.

This is intentionally separate from the cache-aware DP scheduling PR.