### PR TITLE
feat: add Muse Glimmer model and native parsers

### DIFF
--- a/python/sgl_jax/srt/configs/muse_glimmer.py
+++ b/python/sgl_jax/srt/configs/muse_glimmer.py
@@ -1,0 +1,117 @@
+"""Local Hugging Face configuration for Muse Glimmer checkpoints."""
+
+from __future__ import annotations
+
+from transformers import PretrainedConfig
+
+
+class MuseGlimmerTextConfig(PretrainedConfig):
+    model_type = "muse_glimmer_text"
+
+    def __init__(
+        self,
+        vocab_size: int = 202048,
+        hidden_size: int = 6656,
+        intermediate_size: int = 19968,
+        num_hidden_layers: int = 52,
+        num_attention_heads: int = 32,
+        num_key_value_heads: int = 2,
+        head_dim: int = 128,
+        hidden_activation: str = "silu",
+        max_position_embeddings: int = 131072,
+        rms_norm_eps: float = 1e-5,
+        post_norm_eps: float = 1e-8,
+        sliding_window: int = 2048,
+        layer_types: list[str] | None = None,
+        rope_parameters: dict | None = None,
+        qk_scale_factor: float = 3.87,
+        output_multiplier: float = 0.19611613513818404,
+        final_logit_softcapping: float = 20.0,
+        attention_bias: bool = False,
+        tie_word_embeddings: bool = False,
+        **kwargs,
+    ) -> None:
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.hidden_activation = hidden_activation
+        self.max_position_embeddings = max_position_embeddings
+        self.rms_norm_eps = rms_norm_eps
+        self.post_norm_eps = post_norm_eps
+        self.sliding_window = sliding_window
+        self.layer_types = layer_types or [
+            "full_attention" if (i + 1) % 4 == 0 else "sliding_attention"
+            for i in range(num_hidden_layers)
+        ]
+        self.rope_parameters = rope_parameters or {
+            "rope_type": "default",
+            "rope_theta": 500000.0,
+        }
+        self.rope_theta = self.rope_parameters.get("rope_theta", 500000.0)
+        self.qk_scale_factor = qk_scale_factor
+        self.output_multiplier = output_multiplier
+        self.final_logit_softcapping = final_logit_softcapping
+        self.attention_bias = attention_bias
+        super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
+
+
+class MuseGlimmerConfig(PretrainedConfig):
+    model_type = "muse_glimmer"
+    sub_configs = {"text_config": MuseGlimmerTextConfig}
+
+    def __init__(
+        self,
+        text_config: dict | MuseGlimmerTextConfig | None = None,
+        image_token_id: int = 200092,
+        video_token_id: int = 200091,
+        **kwargs,
+    ) -> None:
+        if text_config is None:
+            text_config = MuseGlimmerTextConfig()
+        elif isinstance(text_config, dict):
+            text_config = MuseGlimmerTextConfig(**text_config)
+        self.text_config = text_config
+        self.image_token_id = image_token_id
+        self.video_token_id = video_token_id
+
+        # ModelConfig has a few root-level hybrid-attention checks.
+        self.layer_types = list(text_config.layer_types)
+        self.sliding_window = text_config.sliding_window
+        self.num_hidden_layers = text_config.num_hidden_layers
+        self.num_attention_heads = text_config.num_attention_heads
+        self.num_key_value_heads = text_config.num_key_value_heads
+        self.head_dim = text_config.head_dim
+        super().__init__(**kwargs)
+
+
+class MuseGlimmerAssistantConfig(PretrainedConfig):
+    model_type = "muse_glimmer_assistant"
+
+    def __init__(
+        self,
+        vocab_size: int = 202048,
+        use_sliding_window: bool = True,
+        dflash_config: dict | None = None,
+        rope_parameters: dict | None = None,
+        **kwargs,
+    ) -> None:
+        self.vocab_size = vocab_size
+        self.use_sliding_window = use_sliding_window
+        self.dflash_config = {"causal": False} | (dflash_config or {})
+        self.rope_parameters = rope_parameters or {
+            "rope_type": "default",
+            "rope_theta": 500000.0,
+        }
+        self.rope_theta = self.rope_parameters.get("rope_theta", 500000.0)
+        super().__init__(**kwargs)
+
+
+__all__ = [
+    "MuseGlimmerAssistantConfig",
+    "MuseGlimmerConfig",
+    "MuseGlimmerTextConfig",
+]

--- a/python/sgl_jax/srt/entrypoints/openai/protocol.py
+++ b/python/sgl_jax/srt/entrypoints/openai/protocol.py
@@ -303,6 +303,7 @@ class ChatCompletionMessageGenericParam(BaseModel):
     content: str | list[ChatCompletionMessageContentTextPart] | None
     tool_call_id: str | None = None
     name: str | None = None
+    reasoning: str | None = None
     reasoning_content: str | None = None
     tool_calls: list[ToolCall] | None = Field(default=None, examples=[None])
 

--- a/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
+++ b/python/sgl_jax/srt/entrypoints/openai/serving_chat.py
@@ -47,6 +47,13 @@ from sgl_jax.utils import convert_json_schema_to_str
 logger = logging.getLogger(__name__)
 
 
+def normalize_message_reasoning(message: dict[str, Any]) -> dict[str, Any]:
+    """Expose vLLM's ``reasoning`` request field to HF chat templates."""
+    if message.get("reasoning_content") is None and message.get("reasoning") is not None:
+        message["reasoning_content"] = message["reasoning"]
+    return message
+
+
 class OpenAIServingChat(OpenAIServingBase):
     """Handler for /v1/chat/completions requests"""
 
@@ -171,7 +178,7 @@ class OpenAIServingChat(OpenAIServingBase):
         for message in request.messages:
             if message.content is None:
                 message.content = ""
-            msg_dict = message.model_dump()
+            msg_dict = normalize_message_reasoning(message.model_dump())
 
             # Process content based on detected template format
             processed_msg = process_content_for_template_format(
@@ -366,7 +373,7 @@ Assistant: {% endif %}"""
         """Build sampling parameters for the request"""
 
         skip_special = request.skip_special_tokens
-        if self.tokenizer_manager.server_args.reasoning_parser == "gemma4":
+        if self.tokenizer_manager.server_args.reasoning_parser in ("gemma4", "muse_glimmer"):
             skip_special = False
 
         sampling_params = {
@@ -956,15 +963,25 @@ Assistant: {% endif %}"""
                 if isinstance(call_item.parameters, str):
                     latest_delta_len = len(call_item.parameters)
 
-                expected_call = json.dumps(
-                    parser.detector.prev_tool_call_arr[index].get("arguments", {}),
-                    ensure_ascii=False,
-                )
-                actual_call = parser.detector.streamed_args_for_tool[index]
-                if latest_delta_len > 0:
-                    actual_call = actual_call[:-latest_delta_len]
-                remaining_call = expected_call.replace(actual_call, "", 1)
-                call_item.parameters = remaining_call
+                tool_index = call_item.tool_index
+                if (
+                    tool_index >= 0
+                    and tool_index < len(parser.detector.prev_tool_call_arr)
+                    and tool_index < len(parser.detector.streamed_args_for_tool)
+                ):
+                    expected_args = parser.detector.prev_tool_call_arr[tool_index].get(
+                        "arguments", {}
+                    )
+                    expected_call = (
+                        expected_args
+                        if isinstance(expected_args, str)
+                        else json.dumps(expected_args, ensure_ascii=False)
+                    )
+                    actual_call = parser.detector.streamed_args_for_tool[tool_index]
+                    if latest_delta_len > 0:
+                        actual_call = actual_call[:-latest_delta_len]
+                    if expected_call.startswith(actual_call):
+                        call_item.parameters = expected_call[len(actual_call) :]
                 finish_reason_type = "tool_calls"
 
             tool_call = ToolCall(

--- a/python/sgl_jax/srt/function_call/base_format_detector.py
+++ b/python/sgl_jax/srt/function_call/base_format_detector.py
@@ -306,6 +306,10 @@ class BaseFormatDetector(ABC):
         """Return True if this detector supports structural tag format."""
         return True
 
+    def parses_required_natively(self) -> bool:
+        """Return True when required tool calls use the model's native format."""
+        return False
+
     @abstractmethod
     def structure_info(self) -> _GetInfoFunc:
         """

--- a/python/sgl_jax/srt/function_call/function_call_parser.py
+++ b/python/sgl_jax/srt/function_call/function_call_parser.py
@@ -13,6 +13,7 @@ from sgl_jax.srt.function_call.glm4_moe_detector import Glm4MoeDetector
 from sgl_jax.srt.function_call.glm47_moe_detector import Glm47MoeDetector
 from sgl_jax.srt.function_call.ling3_detector import Ling3Detector
 from sgl_jax.srt.function_call.mimo_detector import MiMoDetector
+from sgl_jax.srt.function_call.muse_glimmer_detector import MuseGlimmerDetector
 from sgl_jax.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
 from sgl_jax.srt.function_call.qwen25_detector import Qwen25Detector
 from sgl_jax.srt.function_call.utils import get_json_schema_constraint
@@ -33,6 +34,7 @@ class FunctionCallParser:
         "qwen25": Qwen25Detector,
         "qwen3_coder": Qwen3CoderDetector,
         "mimo": MiMoDetector,
+        "muse_glimmer": MuseGlimmerDetector,
         "glm47": Glm47MoeDetector,
         "glm45": Glm4MoeDetector,
         "ling3": Ling3Detector,
@@ -168,7 +170,9 @@ class FunctionCallParser:
         ):
             strict_tag = self.get_structure_tag()
             return ("structural_tag", strict_tag)
-        elif tool_choice == "required" or isinstance(tool_choice, ToolChoice):
+        elif (
+            tool_choice == "required" or isinstance(tool_choice, ToolChoice)
+        ) and not self.detector.parses_required_natively():
             json_schema = get_json_schema_constraint(self.tools, tool_choice)
             if json_schema is None:
                 return None

--- a/python/sgl_jax/srt/function_call/muse_glimmer_detector.py
+++ b/python/sgl_jax/srt/function_call/muse_glimmer_detector.py
@@ -1,0 +1,114 @@
+"""ATEM tool-call detector for Muse Glimmer."""
+
+from __future__ import annotations
+
+import json
+import re
+
+from sgl_jax.srt.entrypoints.openai.protocol import Tool
+from sgl_jax.srt.function_call.base_format_detector import BaseFormatDetector
+from sgl_jax.srt.function_call.core_types import (
+    StreamingParseResult,
+    StructureInfo,
+    ToolCallItem,
+)
+
+_INVOKE_RE = re.compile(r"<atem:invoke\b.*?</atem:invoke>", re.DOTALL)
+_NAME_RE = re.compile(r'<atem:invoke\b[^>]*?\bname="([^"]+)"')
+_PARAM_RE = re.compile(
+    r'<atem:parameter\b[^>]*?\bname="(?P<key>[^"]+)"[^>]*?>(?P<value>.*?)</atem:parameter>',
+    re.DOTALL,
+)
+_OPEN = "<atem:function_calls>"
+_CLOSE = "</atem:function_calls>"
+
+
+def _decode_value(raw: str):
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return raw
+
+
+class MuseGlimmerDetector(BaseFormatDetector):
+    def __init__(self):
+        super().__init__()
+        self.bot_token = _OPEN
+        self.eot_token = _CLOSE
+        self._emitted_calls = 0
+
+    @staticmethod
+    def _normalize_name(name: str, tools: list[Tool]) -> str:
+        registered = {tool.function.name for tool in tools if tool.function.name}
+        if name in registered:
+            return name
+        head, separator, tail = name.partition(".")
+        if separator and head == tail and head in registered:
+            return head
+        return name
+
+    @classmethod
+    def _parse_calls(cls, text: str, tools: list[Tool]) -> list[ToolCallItem]:
+        registered = {tool.function.name for tool in tools if tool.function.name}
+        calls = []
+        for index, invoke in enumerate(_INVOKE_RE.findall(text)):
+            name_match = _NAME_RE.search(invoke)
+            if name_match is None:
+                continue
+            name = cls._normalize_name(name_match.group(1), tools)
+            if registered and name not in registered:
+                continue
+            arguments = {
+                match.group("key"): _decode_value(match.group("value"))
+                for match in _PARAM_RE.finditer(invoke)
+            }
+            calls.append(
+                ToolCallItem(
+                    tool_index=index,
+                    name=name,
+                    parameters=json.dumps(arguments, ensure_ascii=False),
+                )
+            )
+        return calls
+
+    def has_tool_call(self, text: str) -> bool:
+        return _OPEN in text or "<atem:invoke" in text
+
+    def detect_and_parse(self, text: str, tools: list[Tool]) -> StreamingParseResult:
+        calls = self._parse_calls(text, tools)
+        if calls:
+            return StreamingParseResult(calls=calls)
+        if self.has_tool_call(text):
+            return StreamingParseResult()
+        return StreamingParseResult(normal_text=text)
+
+    def parse_streaming_increment(self, new_text: str, tools: list[Tool]) -> StreamingParseResult:
+        self._buffer += new_text
+        if not self.has_tool_call(self._buffer):
+            partial = self._ends_with_partial_token(self._buffer, self.bot_token)
+            if partial:
+                normal = self._buffer[:-partial]
+                self._buffer = self._buffer[-partial:]
+            else:
+                normal = self._buffer
+                self._buffer = ""
+            return StreamingParseResult(normal_text=normal)
+
+        calls = self._parse_calls(self._buffer, tools)
+        if len(calls) <= self._emitted_calls:
+            return StreamingParseResult()
+        emitted = calls[self._emitted_calls :]
+        self._emitted_calls = len(calls)
+        return StreamingParseResult(calls=emitted)
+
+    def supports_structural_tag(self) -> bool:
+        return False
+
+    def parses_required_natively(self) -> bool:
+        return True
+
+    def structure_info(self):
+        return lambda name: StructureInfo(begin="", end="", trigger=_OPEN)
+
+    def build_ebnf(self, tools: list[Tool]) -> str:
+        return ""

--- a/python/sgl_jax/srt/hf_transformers_utils.py
+++ b/python/sgl_jax/srt/hf_transformers_utils.py
@@ -24,6 +24,10 @@ from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_N
 from sgl_jax.srt.configs.bailing_hybrid import BailingHybridConfig
 from sgl_jax.srt.configs.gemma4 import Gemma4Config
 from sgl_jax.srt.configs.kimi_linear import KimiLinearConfig
+from sgl_jax.srt.configs.muse_glimmer import (
+    MuseGlimmerAssistantConfig,
+    MuseGlimmerConfig,
+)
 from sgl_jax.srt.configs.qwen3_5 import Qwen3_5DenseConfig, Qwen3_5HybridConfig
 from sgl_jax.srt.managers.tiktoken_tokenizer import TiktokenTokenizer
 from sgl_jax.srt.utils.common_utils import is_remote_url, lru_cache_frozenset
@@ -46,14 +50,19 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = {
         Qwen3_5HybridConfig,
         Qwen3_5DenseConfig,
         Gemma4Config,
+        MuseGlimmerConfig,
+        MuseGlimmerAssistantConfig,
     ]
 }
 
-if "glm_moe_dsa" not in CONFIG_MAPPING:
+if "glm_moe_dsa" not in CONFIG_MAPPING or "muse_glimmer" not in CONFIG_MAPPING:
     with contextlib.suppress(Exception):
         from transformers.models.auto.tokenization_auto import TOKENIZER_MAPPING
 
-        TOKENIZER_MAPPING._reverse_config_mapping["GlmMoeDsaConfig"] = "gpt2"
+        if "glm_moe_dsa" not in CONFIG_MAPPING:
+            TOKENIZER_MAPPING._reverse_config_mapping["GlmMoeDsaConfig"] = "gpt2"
+        if "muse_glimmer" not in CONFIG_MAPPING:
+            TOKENIZER_MAPPING._reverse_config_mapping["MuseGlimmerConfig"] = "gpt2"
 
 # Register local configs; suppress() defers to stock on a name clash (fine for
 # bailing/kimi which don't clash, and for the glm stub where stock is preferable).

--- a/python/sgl_jax/srt/models/dflash.py
+++ b/python/sgl_jax/srt/models/dflash.py
@@ -229,6 +229,7 @@ class DFlashDecoderLayer(nnx.Module):
         layer_id: int = 0,
         dtype: jnp.dtype = jnp.bfloat16,
     ):
+        self.layer_id = layer_id
         hidden_size = int(config.hidden_size)
         rms_norm_eps = float(getattr(config, "rms_norm_eps", 1e-6))
         self.input_layernorm = RMSNorm(
@@ -411,7 +412,17 @@ class DFlashDraftModel(nnx.Module):
                 sharding=(None, None),
                 transpose=True,
             ),
+            "encoder.fc.weight": WeightMapping(
+                target_path="fc.weight",
+                sharding=(None, None),
+                transpose=True,
+            ),
             "hidden_norm.weight": WeightMapping(
+                target_path="hidden_norm.scale",
+                sharding=(None,),
+                transpose=False,
+            ),
+            "encoder.output_norm_enc.weight": WeightMapping(
                 target_path="hidden_norm.scale",
                 sharding=(None,),
                 transpose=False,

--- a/python/sgl_jax/srt/models/muse_glimmer.py
+++ b/python/sgl_jax/srt/models/muse_glimmer.py
@@ -1,0 +1,471 @@
+"""Text-only Muse Glimmer implementation for SGLang-JAX."""
+
+from __future__ import annotations
+
+import logging
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+from transformers import PretrainedConfig
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead, get_rope
+from sgl_jax.srt.layers.layernorm import GemmaRMSNorm, RMSNorm
+from sgl_jax.srt.layers.linear import LinearBase
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
+from sgl_jax.srt.layers.radix_attention import RadixAttention
+from sgl_jax.srt.mem_cache.memory_pool import KVCache, MemoryPools
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+from sgl_jax.srt.precision_tracer import precision_tracer
+from sgl_jax.srt.utils.profiling_utils import named_scope
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+
+logger = logging.getLogger(__name__)
+
+
+def _query_prescale(config: PretrainedConfig) -> float:
+    explicit = getattr(config, "scale_query_by", None)
+    if explicit is not None:
+        return float(explicit)
+    factor = float(getattr(config, "qk_scale_factor", 1.0))
+    sqrt_head_dim = float(config.head_dim) ** 0.5
+    return factor / sqrt_head_dim if factor >= sqrt_head_dim else factor
+
+
+class MuseGlimmerMLP(nnx.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        layer_id: int,
+        dtype: jnp.dtype,
+    ) -> None:
+        if getattr(config, "hidden_activation", "silu") != "silu":
+            raise ValueError("Muse Glimmer requires SiLU activation")
+        self.layer_id = layer_id
+        self.gate_proj = LinearBase(
+            config.hidden_size,
+            config.intermediate_size,
+            mesh=mesh,
+            use_bias=False,
+            kernel_axes=(None, "tensor"),
+            params_dtype=dtype,
+            scope_name="gate_proj",
+        )
+        self.up_proj = LinearBase(
+            config.hidden_size,
+            config.intermediate_size,
+            mesh=mesh,
+            use_bias=False,
+            kernel_axes=(None, "tensor"),
+            params_dtype=dtype,
+            scope_name="up_proj",
+        )
+        self.down_proj = LinearBase(
+            config.intermediate_size,
+            config.hidden_size,
+            mesh=mesh,
+            use_bias=False,
+            kernel_axes=("tensor", None),
+            params_dtype=dtype,
+            scope_name="down_proj",
+        )
+
+    @named_scope
+    def __call__(self, hidden_states: jax.Array) -> jax.Array:
+        gate, _ = self.gate_proj(hidden_states)
+        up, _ = self.up_proj(hidden_states)
+        output, _ = self.down_proj(jax.nn.silu(gate) * up)
+        return output
+
+
+class MuseGlimmerAttention(nnx.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        layer_id: int,
+        dtype: jnp.dtype,
+    ) -> None:
+        self.layer_id = layer_id
+        self.hidden_size = int(config.hidden_size)
+        self.q_head_num = int(config.num_attention_heads)
+        self.kv_head_num = int(config.num_key_value_heads)
+        self.head_dim = int(config.head_dim)
+        self.mesh = mesh
+        layer_types = getattr(config, "layer_types", [])
+        layer_type = layer_types[layer_id] if layer_id < len(layer_types) else "sliding_attention"
+        self.use_rope = layer_type == "sliding_attention"
+        self.sliding_window = int(getattr(config, "sliding_window", 2048)) if self.use_rope else 0
+        self.query_prescale = _query_prescale(config)
+
+        self.q_proj = LinearBase(
+            self.hidden_size,
+            self.q_head_num * self.head_dim,
+            mesh=mesh,
+            use_bias=False,
+            kernel_axes=(None, "tensor"),
+            params_dtype=dtype,
+            scope_name="q_proj",
+        )
+        self.k_proj = LinearBase(
+            self.hidden_size,
+            self.kv_head_num * self.head_dim,
+            mesh=mesh,
+            use_bias=False,
+            kernel_axes=(None, "tensor"),
+            params_dtype=dtype,
+            scope_name="k_proj",
+        )
+        self.v_proj = LinearBase(
+            self.hidden_size,
+            self.kv_head_num * self.head_dim,
+            mesh=mesh,
+            use_bias=False,
+            kernel_axes=(None, "tensor"),
+            params_dtype=dtype,
+            scope_name="v_proj",
+        )
+        self.gate_proj = LinearBase(
+            self.hidden_size,
+            self.q_head_num * self.head_dim,
+            mesh=mesh,
+            use_bias=False,
+            kernel_axes=(None, "tensor"),
+            params_dtype=dtype,
+            scope_name="gate_proj",
+        )
+        self.o_proj = LinearBase(
+            self.q_head_num * self.head_dim,
+            self.hidden_size,
+            mesh=mesh,
+            use_bias=False,
+            kernel_axes=("tensor", None),
+            params_dtype=dtype,
+            scope_name="o_proj",
+        )
+        self.qk_norm = RMSNorm(
+            self.head_dim,
+            epsilon=float(config.rms_norm_eps),
+            use_scale=False,
+            scope_name="qk_norm",
+        )
+
+        rope_parameters = dict(getattr(config, "rope_parameters", {}) or {})
+        rope_theta = float(rope_parameters.get("rope_theta", 500000.0))
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=int(getattr(config, "max_position_embeddings", 131072)),
+            base=rope_theta,
+            is_neox_style=True,
+            rope_scaling=rope_parameters,
+            dtype=dtype,
+        )
+        self.attn = RadixAttention(
+            num_heads=self.q_head_num,
+            head_dim=self.head_dim,
+            scaling=self.head_dim**-0.5,
+            num_kv_heads=self.kv_head_num,
+            layer_id=layer_id,
+            sliding_window_size=self.sliding_window,
+        )
+
+    @named_scope
+    def __call__(
+        self,
+        positions: jax.Array,
+        hidden_states: jax.Array,
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: KVCache,
+    ) -> tuple[jax.Array, jax.Array]:
+        q, _ = self.q_proj(hidden_states)
+        k, _ = self.k_proj(hidden_states)
+        v, _ = self.v_proj(hidden_states)
+        q = q.reshape(
+            -1,
+            self.q_head_num,
+            self.head_dim,
+            out_sharding=NamedSharding(self.mesh, P("data", "tensor", None)),
+        )
+        k = k.reshape(
+            -1,
+            self.kv_head_num,
+            self.head_dim,
+            out_sharding=NamedSharding(self.mesh, P("data", "tensor", None)),
+        )
+        v = v.reshape(
+            -1,
+            self.kv_head_num,
+            self.head_dim,
+            out_sharding=NamedSharding(self.mesh, P("data", "tensor", None)),
+        )
+        q = self.qk_norm(q) * self.query_prescale
+        k = self.qk_norm(k)
+        if self.use_rope:
+            q, k = self.rotary_emb(positions, q, k)
+        attn_output, kv_fused = self.attn(q, k, v, forward_batch, token_to_kv_pool)
+        gate, _ = self.gate_proj(hidden_states)
+        attn_output = attn_output * jax.nn.sigmoid(gate.reshape(attn_output.shape))
+        output, _ = self.o_proj(attn_output)
+        return output, kv_fused
+
+
+class MuseGlimmerDecoderLayer(nnx.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        layer_id: int,
+        dtype: jnp.dtype,
+    ) -> None:
+        hidden_size = int(config.hidden_size)
+        self.layer_id = layer_id
+        self.input_layernorm = GemmaRMSNorm(
+            hidden_size, epsilon=float(config.rms_norm_eps), add_unit_offset=True
+        )
+        self.self_attn = MuseGlimmerAttention(config, mesh, layer_id, dtype)
+        self.post_attention_layernorm = GemmaRMSNorm(
+            hidden_size,
+            epsilon=float(getattr(config, "post_norm_eps", 1e-8)),
+            add_unit_offset=True,
+        )
+        self.pre_feedforward_layernorm = GemmaRMSNorm(
+            hidden_size, epsilon=float(config.rms_norm_eps), add_unit_offset=True
+        )
+        self.mlp = MuseGlimmerMLP(config, mesh, layer_id, dtype)
+        self.post_feedforward_layernorm = GemmaRMSNorm(
+            hidden_size,
+            epsilon=float(getattr(config, "post_norm_eps", 1e-8)),
+            add_unit_offset=True,
+        )
+
+    def __call__(
+        self,
+        positions: jax.Array,
+        hidden_states: jax.Array,
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: KVCache,
+    ) -> tuple[jax.Array, jax.Array, list[jax.Array]]:
+        callbacks = []
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        callbacks.append(
+            precision_tracer.jit_pure_callback_record(
+                hidden_states, "input_layernorm_output", "INPUT_LAYERNORM", self.layer_id
+            )
+        )
+        hidden_states, kv_fused = self.self_attn(
+            positions, hidden_states, forward_batch, token_to_kv_pool
+        )
+        callbacks.append(
+            precision_tracer.jit_pure_callback_record(
+                hidden_states, "self_attn_output", "SELF_ATTN", self.layer_id
+            )
+        )
+        hidden_states = residual + self.post_attention_layernorm(hidden_states)
+        residual = hidden_states
+        hidden_states = self.pre_feedforward_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + self.post_feedforward_layernorm(hidden_states)
+        callbacks.append(
+            precision_tracer.jit_pure_callback_record(
+                hidden_states, "mlp_output", "MLP", self.layer_id
+            )
+        )
+        return hidden_states, kv_fused, callbacks
+
+
+class MuseGlimmerModel(nnx.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        dtype: jnp.dtype,
+    ) -> None:
+        self.embed_tokens = Embed(
+            num_embeddings=config.vocab_size,
+            features=config.hidden_size,
+            dtype=dtype,
+            kernel_axes=("tensor", None),
+            param_dtype=dtype,
+            mesh=mesh,
+        )
+        self.embed_norm = RMSNorm(
+            config.hidden_size,
+            epsilon=float(config.rms_norm_eps),
+            use_scale=False,
+            scope_name="embed_norm",
+        )
+        self.layers = nnx.data(
+            [
+                MuseGlimmerDecoderLayer(config, mesh, layer_id, dtype)
+                for layer_id in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = GemmaRMSNorm(
+            config.hidden_size,
+            epsilon=float(config.rms_norm_eps),
+            add_unit_offset=False,
+        )
+        self.layers_to_capture: list[int] = []
+
+    def __call__(self, forward_batch: ForwardBatch, token_to_kv_pool: KVCache):
+        if (
+            forward_batch.input_embedding is not None
+            and forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
+        ):
+            hidden_states = forward_batch.input_embedding
+        else:
+            hidden_states = self.embed_norm(self.embed_tokens(forward_batch.input_ids))
+
+        kv_fused = []
+        callbacks = []
+        aux_hidden_states = []
+        for layer_id, layer in enumerate(self.layers):
+            hidden_states, layer_kv, layer_callbacks = layer(
+                forward_batch.positions,
+                hidden_states,
+                forward_batch,
+                token_to_kv_pool,
+            )
+            if layer_id + 1 in self.layers_to_capture:
+                aux_hidden_states.append(hidden_states)
+            kv_fused.append(layer_kv)
+            callbacks.extend(layer_callbacks)
+        hidden_states = self.norm(hidden_states)
+        callbacks.append(
+            precision_tracer.jit_pure_callback_record(
+                hidden_states, "transformer_output", "TRANSFORMER"
+            )
+        )
+        return hidden_states, aux_hidden_states, kv_fused, callbacks
+
+
+class MuseGlimmerForConditionalGeneration(nnx.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ) -> None:
+        self.mesh = mesh
+        self.config = getattr(config, "text_config", config)
+        self.dtype = dtype
+        self.model = MuseGlimmerModel(self.config, mesh, dtype)
+        self.lm_head = ParallelLMHead(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            dtype=dtype,
+            param_dtype=dtype,
+            kernel_axes=("tensor", None),
+        )
+        self.output_multiplier = float(getattr(self.config, "output_multiplier", 1.0))
+        self.logits_processor = LogitsProcessor(
+            self.config.vocab_size,
+            soft_cap=float(getattr(self.config, "final_logit_softcapping", 0.0) or 0.0),
+            mesh=mesh,
+        )
+        self.capture_aux_hidden_states = False
+
+    def load_weights(self, model_config: ModelConfig) -> None:
+        loader = WeightLoader(self, model_config, self.mesh, self.dtype)
+        mappings = self._create_weight_mappings()
+        if not loader.dummy_mode:
+            weight_info = loader._scan_weight_info()
+            mappings = {key: value for key, value in mappings.items() if key in weight_info}
+        loader.load_weights_from_safetensors(mappings)
+        logger.info("Muse Glimmer weights loaded successfully")
+
+    def _create_weight_mappings(self) -> dict[str, WeightMapping]:
+        prefix = "model.language_model"
+        mappings: dict[str, WeightMapping] = {
+            f"{prefix}.embed_tokens.weight": WeightMapping(
+                "model.embed_tokens.embedding", sharding=("tensor", None)
+            ),
+            f"{prefix}.norm.weight": WeightMapping("model.norm.weight", sharding=(None,)),
+            "lm_head.weight": WeightMapping("lm_head.embedding", sharding=("tensor", None)),
+        }
+        for layer_id in range(self.config.num_hidden_layers):
+            source = f"{prefix}.layers.{layer_id}"
+            target = f"model.layers.{layer_id}"
+            for name in (
+                "input_layernorm",
+                "post_attention_layernorm",
+                "pre_feedforward_layernorm",
+                "post_feedforward_layernorm",
+            ):
+                mappings[f"{source}.{name}.weight"] = WeightMapping(
+                    f"{target}.{name}.weight", sharding=(None,)
+                )
+            for name in ("q_proj", "k_proj", "v_proj", "gate_proj"):
+                mappings[f"{source}.self_attn.{name}.weight"] = WeightMapping(
+                    f"{target}.self_attn.{name}.weight",
+                    sharding=(None, "tensor"),
+                    transpose=True,
+                )
+            mappings[f"{source}.self_attn.o_proj.weight"] = WeightMapping(
+                f"{target}.self_attn.o_proj.weight",
+                sharding=("tensor", None),
+                transpose=True,
+            )
+            for name in ("gate_proj", "up_proj"):
+                mappings[f"{source}.mlp.{name}.weight"] = WeightMapping(
+                    f"{target}.mlp.{name}.weight",
+                    sharding=(None, "tensor"),
+                    transpose=True,
+                )
+            mappings[f"{source}.mlp.down_proj.weight"] = WeightMapping(
+                f"{target}.mlp.down_proj.weight",
+                sharding=("tensor", None),
+                transpose=True,
+            )
+        return mappings
+
+    def get_embed_and_head(self) -> tuple[jax.Array, jax.Array]:
+        return self.model.embed_tokens.embedding.value, self.lm_head.embedding.value
+
+    def set_embed_and_head(
+        self,
+        embed_weight: jax.Array | None = None,
+        head_weight: jax.Array | None = None,
+    ) -> None:
+        if embed_weight is not None:
+            self.model.embed_tokens.embedding.value = embed_weight
+        if head_weight is not None:
+            self.lm_head.embedding.value = head_weight
+
+    def set_dflash_layers_to_capture(self, layer_ids: list[int] | None) -> None:
+        if layer_ids is None:
+            raise ValueError("DFLASH requires explicit target layer ids")
+        self.capture_aux_hidden_states = True
+        self.model.layers_to_capture = [int(layer_id) + 1 for layer_id in layer_ids]
+
+    def __call__(
+        self,
+        forward_batch: ForwardBatch,
+        memory_pools: MemoryPools,
+        logits_metadata: LogitsMetadata,
+    ):
+        hidden_states, aux_hidden_states, kv_fused, callbacks = self.model(
+            forward_batch, memory_pools.token_to_kv_pool
+        )
+        if not self.capture_aux_hidden_states:
+            aux_hidden_states = None
+        output = self.logits_processor(
+            hidden_states * self.output_multiplier,
+            self.lm_head,
+            logits_metadata,
+            aux_hidden_states=aux_hidden_states,
+        )
+        return output, {"token_to_kv_pool": kv_fused}, callbacks, None
+
+
+class MuseGlimmerForCausalLM(MuseGlimmerForConditionalGeneration):
+    pass
+
+
+EntryClass = [MuseGlimmerForConditionalGeneration, MuseGlimmerForCausalLM]

--- a/python/sgl_jax/srt/reasoning_parser.py
+++ b/python/sgl_jax/srt/reasoning_parser.py
@@ -1,3 +1,6 @@
+import re
+
+
 class StreamingParseResult:
     """Result of streaming incremental parsing."""
 
@@ -312,6 +315,78 @@ class Ling3Detector(Glm45Detector):
         return result
 
 
+class MuseGlimmerDetector(BaseReasoningFormatDetector):
+    """Split Muse Glimmer Harmony channels into reasoning and visible content."""
+
+    _header_re = re.compile(
+        r"(?:<\|start\|>assistant\s*)?\s*to=(?P<recipient>[^\s<]+)<\|message\|>"
+    )
+    _end_re = re.compile(r"<\|eom\|>|<\|eot\|>")
+    _markers = ("<|eom|>", "<|eot|>", "<|start|>", "<|message|>")
+
+    def __init__(self, stream_reasoning: bool = True):
+        super().__init__("to=self<|message|>", "<|eom|>", stream_reasoning=stream_reasoning)
+        self._full_text = ""
+        self._emitted_reasoning = 0
+        self._emitted_normal = 0
+
+    @classmethod
+    def _safe_open_body(cls, body: str) -> str:
+        for overlap in range(min(len(body), max(map(len, cls._markers)) - 1), 0, -1):
+            suffix = body[-overlap:]
+            if any(marker.startswith(suffix) for marker in cls._markers):
+                return body[:-overlap]
+        return body
+
+    @classmethod
+    def _classify(cls, text: str) -> tuple[str, str]:
+        reasoning = []
+        normal = []
+        matches = list(cls._header_re.finditer(text))
+        if not matches:
+            stripped = text.lstrip()
+            if (
+                stripped in {"t", "to", "to="}
+                or stripped.startswith("to=")
+                or stripped.startswith("<|start|")
+            ):
+                return "", ""
+            return "", text
+        for index, match in enumerate(matches):
+            body_start = match.end()
+            next_header = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+            end_match = cls._end_re.search(text, body_start, next_header)
+            closed = end_match is not None
+            body_end = end_match.start() if end_match is not None else next_header
+            body = text[body_start:body_end]
+            if not closed and index == len(matches) - 1:
+                body = cls._safe_open_body(body)
+            recipient = match.group("recipient")
+            if recipient == "self":
+                reasoning.append(body)
+            elif recipient == "user":
+                normal.append(body)
+            else:
+                normal.append(body)
+        return "".join(reasoning), "".join(normal)
+
+    def detect_and_parse(self, text: str) -> StreamingParseResult:
+        reasoning, normal = self._classify(text)
+        return StreamingParseResult(normal_text=normal, reasoning_text=reasoning)
+
+    def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
+        self._full_text += new_text
+        reasoning, normal = self._classify(self._full_text)
+        reasoning_delta = reasoning[self._emitted_reasoning :]
+        normal_delta = normal[self._emitted_normal :]
+        self._emitted_reasoning = len(reasoning)
+        self._emitted_normal = len(normal)
+        return StreamingParseResult(
+            normal_text=normal_delta,
+            reasoning_text=reasoning_delta,
+        )
+
+
 class ReasoningParser:
     """
     Parser that handles both streaming and non-streaming scenarios for extracting
@@ -331,6 +406,7 @@ class ReasoningParser:
         "glm45": Glm45Detector,
         "gemma4": Gemma4Detector,
         "ling3": Ling3Detector,
+        "muse_glimmer": MuseGlimmerDetector,
     }
 
     def __init__(self, model_type: str | None = None, stream_reasoning: bool = True):

--- a/python/sgl_jax/test/models/test_dflash.py
+++ b/python/sgl_jax/test/models/test_dflash.py
@@ -54,7 +54,9 @@ def test_dflash_weight_mapping_covers_tiny_config():
 
     expected = {
         "fc.weight",
+        "encoder.fc.weight",
         "hidden_norm.weight",
+        "encoder.output_norm_enc.weight",
         "norm.weight",
     }
     for layer_idx in range(2):
@@ -124,3 +126,13 @@ def test_qwen3_dflash_capture_sets_explicit_layers():
     model.set_dflash_layers_to_capture([1, 3])
     assert model.capture_aux_hidden_states is True
     assert model.model.layers_to_capture == [2, 4]
+
+
+def test_muse_assistant_config_flattens_rope_theta():
+    from sgl_jax.srt.configs.muse_glimmer import MuseGlimmerAssistantConfig
+
+    config = MuseGlimmerAssistantConfig(
+        rope_parameters={"rope_type": "default", "rope_theta": 500000.0}
+    )
+
+    assert config.rope_theta == 500000.0

--- a/python/sgl_jax/test/test_muse_glimmer_parser.py
+++ b/python/sgl_jax/test/test_muse_glimmer_parser.py
@@ -1,0 +1,90 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+from sgl_jax.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    Function,
+    Tool,
+)
+from sgl_jax.srt.entrypoints.openai.serving_chat import (
+    OpenAIServingChat,
+    normalize_message_reasoning,
+)
+from sgl_jax.srt.function_call.function_call_parser import FunctionCallParser
+
+
+def _weather_tool() -> Tool:
+    return Tool(
+        type="function",
+        function=Function(
+            name="get_weather",
+            description="Get weather for a city.",
+            parameters={
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        ),
+    )
+
+
+def test_required_tool_choice_uses_native_muse_format():
+    parser = FunctionCallParser([_weather_tool()], "muse_glimmer")
+
+    assert parser.get_structure_constraint("required") is None
+
+
+def test_request_reasoning_alias_is_preserved_for_chat_templates():
+    request = ChatCompletionRequest(
+        model="muse_glimmer_30b",
+        messages=[
+            {
+                "role": "assistant",
+                "content": "final answer",
+                "reasoning": "prior reasoning",
+            }
+        ],
+    )
+
+    message = normalize_message_reasoning(request.messages[0].model_dump())
+
+    assert message["reasoning"] == "prior reasoning"
+    assert message["reasoning_content"] == "prior reasoning"
+
+
+def test_streaming_tool_call_finishes_without_detector_state():
+    parser = FunctionCallParser([_weather_tool()], "muse_glimmer")
+    service = object.__new__(OpenAIServingChat)
+    request = SimpleNamespace(model="muse_glimmer_30b", stream_options=None)
+    content = {"meta_info": {"id": "request-id"}}
+    delta = (
+        '<atem:function_calls><atem:invoke name="get_weather">'
+        '<atem:parameter name="city">"Paris"</atem:parameter>'
+        "</atem:invoke></atem:function_calls>"
+    )
+
+    async def collect_chunks() -> list[str]:
+        return [
+            chunk
+            async for chunk in service._process_tool_call_stream(
+                0,
+                delta,
+                {0: parser},
+                content,
+                request,
+                "stop",
+            )
+        ]
+
+    chunks = asyncio.run(collect_chunks())
+
+    assert len(chunks) == 1
+    payload = json.loads(chunks[0].removeprefix("data: "))
+    choice = payload["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    tool_call = choice["delta"]["tool_calls"][0]
+    assert tool_call["function"] == {
+        "name": "get_weather",
+        "arguments": '{"city": "Paris"}',
+    }

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -360,6 +360,11 @@ suites = {
         ),
         TestFile("python/sgl_jax/test/speculative/test_spec_info.py", 0.2, runner="pytest"),
         TestFile("python/sgl_jax/test/models/test_dflash.py", 0.2, runner="pytest"),
+        TestFile(
+            "python/sgl_jax/test/test_muse_glimmer_parser.py",
+            0.2,
+            runner="pytest",
+        ),
         TestFile("python/sgl_jax/test/models/test_mimo_v2_nextn.py", 0.2, runner="pytest"),
         TestFile(
             "python/sgl_jax/test/multimodal/test_kimi_k25_weight_mapping.py",


### PR DESCRIPTION
## Motivation

SGLang-JAX cannot currently load Muse Glimmer target checkpoints or expose their Harmony reasoning channels and native ATEM tool calls through the OpenAI-compatible API. This PR adds the architecture and parser support required for ordinary TPU inference. Generic DFlash runtime fixes are submitted separately under #1591.

Closes #1590. Parent: #1588. Design: #1589.

## Modifications

- Add target and assistant configuration classes and register them with the Hugging Face loader.
- Add the text-only target model with tensor-parallel weight mappings and auxiliary hidden-state capture.
- Accept the assistant checkpoint's encoder and output-normalization aliases.
- Add Harmony reasoning parsing and native ATEM tool-call parsing for streaming and non-streaming responses.
- Preserve the request-side reasoning alias and support native required tool calls.
- Add focused configuration, mapping, and parser tests.

## Accuracy Tests

- Reasoning parser probe produced separate non-empty reasoning and visible content.
- Required tool-call probe produced `get_weather({"city":"Paris"})` with `finish_reason="tool_calls"`.
- The combined Muse Glimmer + DFlash stack completed 979/979 persistent-server requests on TPU v7e without failures.

## Benchmarking and Profiling

Combined-stack validation on TPU v7e, TP=2, concurrency=4:

- 0.885 requests/s
- 326.1 output tokens/s
- 43.38% speculative acceptance
- p50/p95/p99 end-to-end latency: 3.50 / 10.53 / 18.50 seconds

The DFlash performance changes are isolated in the companion PR for #1591.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] The necessary documentation update is tracked in #1589.

Test plan:

```bash
pre-commit run --files $(git diff --name-only origin/main...HEAD)
pytest -q \
  python/sgl_jax/test/test_muse_glimmer_parser.py \
  python/sgl_jax/test/models/test_dflash.py
```

Result: 9 passed.
