### PR TITLE
fix: harden TPU DFlash for stochastic long contexts

### DIFF
--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -486,11 +486,10 @@ def _ragged_paged_attention_kernel_loop(
         if soft_cap is not None:
             s = soft_cap * jnp.tanh(s / soft_cap)
 
-        # Use int16 for span computations when safe: non-f32 dtype on TPU v6+
-        # with causal mask. Custom mask shapes can trigger a Mosaic compiler bug.
+        # These are absolute sequence positions. int16 overflows once either a
+        # position or ``k_span + sliding_window`` crosses 32767, which silently
+        # corrupts causal/sliding-window masks for long-context verification.
         int_ty = jnp.int32
-        if get_dtype_packing(q.dtype) != 1 and tpu_version >= 6 and use_causal_mask:
-            int_ty = jnp.int16
         processed_q_len_int = processed_q_len.astype(int_ty)
         processed_kv_len_int = processed_kv_len.astype(int_ty)
         effective_kv_len_int = effective_kv_len.astype(int_ty)

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -187,8 +187,8 @@ def validate_dflash_request(req) -> str | None:
         or getattr(sp, "structural_tag", None) is not None
     ):
         return "DFLASH speculative decoding does not support grammar-constrained decoding yet."
-    if sp.top_k != 1:
-        return "DFLASH speculative decoding currently only supports greedy sampling."
+    if getattr(sp, "min_p", 0.0) != 0.0:
+        return "DFLASH speculative decoding does not support min-p sampling yet."
     if (
         sp.frequency_penalty != 0.0
         or sp.presence_penalty != 0.0
@@ -2688,7 +2688,11 @@ class Scheduler(
                 precompile_cache_loc_paddings,
                 self.page_size,
                 self.server_args.enable_static_lora,
-                draft_token_num=self.draft_worker.speculative_num_draft_tokens,
+                draft_token_num=getattr(
+                    self.draft_worker,
+                    "speculative_num_kv_slots",
+                    self.draft_worker.speculative_num_draft_tokens,
+                ),
             )
 
         use_spec_decode_overlap = can_use_spec_decode_overlap(

--- a/python/sgl_jax/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_metrics_mixin.py
@@ -134,12 +134,23 @@ class SchedulerMetricsMixin:
             and self.draft_token > 0
             and self.spec_num_forward_ct > 0
         ):
-            accept_ratio = self.accept_token / self.draft_token
             accept_len = self.accept_token / self.spec_num_forward_ct
+            accepted_draft_tokens = self.accept_token - self.spec_num_forward_ct
+            drafted_tokens = self.draft_token - self.spec_num_forward_ct
+            if self.spec_algorithm.is_dflash():
+                accept_ratio = accepted_draft_tokens / drafted_tokens if drafted_tokens > 0 else 0.0
+            else:
+                accept_ratio = self.accept_token / self.draft_token
+            msg += (
+                f"accept-len {accept_len:.4f}, "
+                f"accept-ratio {accept_ratio:.4f}, "
+                f"accepted-draft {accepted_draft_tokens}, "
+                f"drafted {drafted_tokens}, "
+                f"spec-requests {self.spec_num_forward_ct}, "
+            )
             self.accept_token = 0
             self.draft_token = 0
             self.spec_num_forward_ct = 0
-            msg += f"accept-len {accept_len:.2f}, accept-ratio {accept_ratio:.2f}, "
 
         msg += (
             f"gen throughput (token/s): {self.last_gen_throughput:.2f}, "

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -843,7 +843,6 @@ class ModelRunnerKVCacheMixin:
                 )
                 self.max_total_num_tokens += spec_headroom
                 self.server_args.max_num_reqs = max_num_reqs
-                self.server_args.draft_runner_cache_size = self.max_total_num_tokens
 
         # 6. Apply constraints (CI, user cap, page align, dp).
         self.max_total_num_tokens = self._apply_token_constraints(
@@ -851,6 +850,12 @@ class ModelRunnerKVCacheMixin:
             None if self.is_draft_worker else max_total_tokens,
             dp_size,
         )
+        if (
+            not self.is_draft_worker
+            and self.spec_algorithm is not None
+            and not self.spec_algorithm.is_none()
+        ):
+            self.server_args.draft_runner_cache_size = self.max_total_num_tokens
 
         # 7. Hybrid SWA token split. draft_runner_cache_size was saved
         # above (per-chip, pre-dp) so the draft won't see hybrid inflation.

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -2012,11 +2012,15 @@ class ServerArgs:
                 and self.speculative_num_draft_tokens == self.speculative_num_steps + 1
                 and self.attention_backend == "fa"
             )
-            supports_dflash_overlap = self.speculative_algorithm == "DFLASH"
+            supports_dflash_overlap = (
+                self.speculative_algorithm == "DFLASH"
+                and self.speculative_eagle_topk == 1
+                and self.speculative_num_steps == 1
+            )
             if not (supports_nextn_overlap or supports_eagle3_overlap or supports_dflash_overlap):
                 raise ValueError(
-                    "Speculative overlap scheduler only supports DFLASH, EAGLE3+FA, "
-                    "or NEXTN with --speculative-eagle-topk=1 and "
+                    "Speculative overlap scheduler only supports DFLASH, EAGLE3+FA, or NEXTN "
+                    "with --speculative-eagle-topk=1 and "
                     "--speculative-num-draft-tokens == --speculative-num-steps + 1. "
                     "Please pass --disable-overlap-schedule for other speculative configs."
                 )

--- a/python/sgl_jax/srt/speculative/dflash_info.py
+++ b/python/sgl_jax/srt/speculative/dflash_info.py
@@ -7,6 +7,7 @@ import jax.numpy as jnp
 import numpy as np
 from jax.tree_util import register_pytree_node_class
 
+from sgl_jax.srt.layers.binary_search import topk_mask, topp_mask
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode
 
 
@@ -122,6 +123,119 @@ def dflash_greedy_verify(
 
     accept_lens_out = (accept_len_draft + 1).astype(jnp.int32)
     return accept_lens_out, target_predict_flat, bonus, accept_len_draft.astype(jnp.int32)
+
+
+def dflash_target_only_verify(
+    draft_token: jax.Array,
+    target_logits: jax.Array,
+    temperatures: jax.Array,
+    top_ks: jax.Array,
+    top_ps: jax.Array,
+    rng_key: jax.Array,
+    *,
+    draft_token_num: int,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    """Verify a linear DFlash proposal with target-only rejection sampling.
+
+    DFlash does not expose proposal probabilities. As in the TPU vLLM path,
+    each draft token is therefore accepted with probability ``p_target(token)``.
+    On rejection, the replacement is sampled from the target distribution with
+    the rejected draft token removed. If every proposal is accepted, the final
+    token is sampled from the target distribution at the bonus position.
+    """
+    block_size = int(draft_token_num)
+    candidates = draft_token.reshape((-1, block_size))
+    batch_size = candidates.shape[0]
+    vocab_size = target_logits.shape[-1]
+    temperatures = temperatures.reshape((batch_size, 1))
+    top_ks = top_ks.reshape((batch_size, 1))
+    top_ps = top_ps.reshape((batch_size, 1))
+
+    mesh = getattr(jax.typeof(target_logits).sharding, "mesh", None)
+    if mesh is not None and getattr(mesh, "empty", False):
+        mesh = None
+    target_logits = target_logits.reshape((batch_size, block_size, vocab_size))
+
+    def _verify_local(local_candidates, local_logits, local_temps, local_top_ks, local_top_ps, key):
+        local_bs = local_candidates.shape[0]
+        param_shape = (local_bs, block_size)
+        expanded_top_ks = jnp.broadcast_to(local_top_ks.reshape(-1, 1), param_shape)
+        expanded_top_ps = jnp.broadcast_to(local_top_ps.reshape(-1, 1), param_shape)
+        expanded_temperatures = jnp.broadcast_to(local_temps.reshape(-1, 1), param_shape)
+        expanded_top_ks = jnp.where(expanded_top_ks > 0, expanded_top_ks, vocab_size)
+
+        logits = local_logits.reshape((-1, vocab_size)).astype(jnp.float32)
+        logits = topk_mask(logits, expanded_top_ks.reshape(-1), replace_val=-jnp.inf)
+        logits = topp_mask(logits, expanded_top_ps.reshape(-1), replace_val=-jnp.inf)
+        logits = logits / jnp.maximum(expanded_temperatures.reshape(-1, 1), 1e-5)
+        logits = logits.reshape((local_bs, block_size, vocab_size))
+        target_probs = jax.nn.softmax(logits, axis=-1)
+
+        proposals = local_candidates[:, 1:]
+        proposal_probs = jnp.take_along_axis(
+            target_probs[:, :-1, :], proposals[:, :, None], axis=-1
+        ).squeeze(-1)
+        accept_key, recovery_key, bonus_key = jax.random.split(key, 3)
+        accepted = jax.random.uniform(accept_key, proposal_probs.shape) < proposal_probs
+        accepted_prefix = jnp.cumprod(accepted.astype(jnp.int32), axis=1)
+        accepted_drafts = jnp.sum(accepted_prefix, axis=1).astype(jnp.int32)
+
+        rejected_logits = jnp.where(
+            jax.nn.one_hot(proposals, vocab_size, dtype=jnp.bool_),
+            -jnp.inf,
+            logits[:, :-1, :],
+        )
+        recovered = jax.random.categorical(recovery_key, rejected_logits, axis=-1).astype(jnp.int32)
+        bonus = jax.random.categorical(bonus_key, logits[:, -1, :], axis=-1).astype(jnp.int32)
+
+        output = jnp.zeros((local_bs, block_size), dtype=jnp.int32)
+        for position in range(block_size - 1):
+            output = output.at[:, position].set(
+                jnp.where(
+                    position < accepted_drafts,
+                    proposals[:, position],
+                    jnp.where(position == accepted_drafts, recovered[:, position], 0),
+                )
+            )
+        output = output.at[:, -1].set(jnp.where(accepted_drafts == block_size - 1, bonus, 0))
+        verified_id = jnp.take_along_axis(output, accepted_drafts[:, None], axis=1).reshape(-1)
+        return accepted_drafts + 1, output.reshape(-1), verified_id, accepted_drafts
+
+    if mesh is None:
+        return _verify_local(candidates, target_logits, temperatures, top_ks, top_ps, rng_key)
+
+    from jax.sharding import NamedSharding
+    from jax.sharding import PartitionSpec as P
+
+    candidates = jax.sharding.reshard(candidates, NamedSharding(mesh, P("data", None)))
+    target_logits = jax.sharding.reshard(target_logits, NamedSharding(mesh, P("data", None, None)))
+    temperatures = jax.sharding.reshard(temperatures, NamedSharding(mesh, P("data", None)))
+    top_ks = jax.sharding.reshard(top_ks, NamedSharding(mesh, P("data", None)))
+    top_ps = jax.sharding.reshard(top_ps, NamedSharding(mesh, P("data", None)))
+
+    def _verify_shard(local_candidates, local_logits, local_temps, local_top_ks, local_top_ps, key):
+        return _verify_local(
+            local_candidates,
+            local_logits,
+            local_temps,
+            local_top_ks,
+            local_top_ps,
+            jax.random.fold_in(key, jax.lax.axis_index("data")),
+        )
+
+    return jax.shard_map(
+        _verify_shard,
+        mesh=mesh,
+        in_specs=(
+            P("data", None),
+            P("data", None, None),
+            P("data", None),
+            P("data", None),
+            P("data", None),
+            P(),
+        ),
+        out_specs=(P("data"), P("data"), P("data"), P("data")),
+    )(candidates, target_logits, temperatures, top_ks, top_ps, rng_key)
 
 
 @dataclass

--- a/python/sgl_jax/srt/speculative/dflash_worker.py
+++ b/python/sgl_jax/srt/speculative/dflash_worker.py
@@ -24,7 +24,7 @@ from sgl_jax.srt.speculative.dflash_info import (
     DFlashVerifyInput,
     _mask_draft_kv_writes,
     build_dflash_draft_block,
-    dflash_greedy_verify,
+    dflash_target_only_verify,
 )
 from sgl_jax.srt.speculative.dflash_util import (
     parse_dflash_draft_config,
@@ -41,6 +41,33 @@ from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
 logger = logging.getLogger(__name__)
 
 
+def _resolve_dflash_query_block_size(verify_width: int, checkpoint_max: int) -> int:
+    if verify_width > checkpoint_max:
+        raise ValueError(
+            "DFLASH verify width exceeds the assistant checkpoint canvas: "
+            f"verify_block_size={verify_width}, draft_block_size={checkpoint_max}."
+        )
+    return verify_width
+
+
+def _configure_draft_swa_mapping(
+    draft_kv_pool,
+    draft_attn_backend,
+    shared_allocator,
+    draft_layers: int,
+) -> None:
+    """Keep attention page indices consistent with the draft's physical KV pool."""
+    if getattr(draft_kv_pool, "swa_layer_nums", 0) != draft_layers:
+        draft_kv_pool.full_to_swa_index_mapping = None
+        object.__setattr__(draft_attn_backend, "swa_index_mapping", None)
+        return
+    shared_mapping = getattr(shared_allocator, "full_to_swa_index_mapping", None)
+    if shared_mapping is None:
+        return
+    draft_kv_pool.full_to_swa_index_mapping = shared_mapping
+    object.__setattr__(draft_attn_backend, "swa_index_mapping", shared_mapping)
+
+
 @dataclass(frozen=True)
 class DFlashVerifyBucketTemplate:
     extend_seq_lens: np.ndarray
@@ -53,6 +80,7 @@ class DFlashVerifyBucketTemplate:
 class DraftForwardPlan:
     forward_batch: ForwardBatch
     forward_metadata: object
+    page_indices: np.ndarray
     seq_lens: np.ndarray
     target_prefix_lens: np.ndarray
     positions_host: np.ndarray
@@ -80,11 +108,14 @@ class TargetVerifyPlan:
     allocated_lens: jax.Array
     relay_future_indices: jax.Array
     relay_valid_mask: jax.Array
+    temperatures: jax.Array
+    top_ks: jax.Array
+    top_ps: jax.Array
     update_relay: bool = False
 
 
 class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
-    """DFlash draft/verify runtime worker (greedy, DP/TP aware)."""
+    """DFlash draft/verify runtime worker (target-only sampling, DP/TP aware)."""
 
     def __init__(self, server_args, target_worker: ModelWorker):
         super().__init__(
@@ -93,11 +124,27 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             self,
         )
         self.block_size = self.speculative_num_draft_tokens
+        dflash_config = parse_dflash_draft_config(
+            server_args.speculative_draft_model_path,
+            revision=server_args.speculative_draft_model_revision,
+        )
+        self.draft_max_block_size = int(dflash_config.block_size)
+        # vLLM presents exactly one seed plus the requested draft proposals to
+        # the bidirectional DFlash head. The checkpoint block size is a maximum,
+        # not a requirement to append extra MASK tokens: those extra tokens can
+        # change every proposal because draft attention is non-causal.
+        self.draft_block_size = _resolve_dflash_query_block_size(
+            self.block_size, self.draft_max_block_size
+        )
+        self.speculative_num_kv_slots = self.draft_block_size
         self._target_impl = getattr(target_worker, "worker", target_worker)
         self._target_compilation_manager = self._target_impl.compilation_manager
 
         draft_server_args = copy.deepcopy(server_args)
         draft_server_args.skip_tokenizer_init = True
+        # The shared target allocator may address the target's hybrid-inflated pool.
+        # Give the draft the same physical capacity before constructing it.
+        draft_server_args.draft_runner_cache_size = int(target_worker.max_total_num_tokens)
 
         from sgl_jax.srt.models.dflash import DFlashDraftModel
 
@@ -113,10 +160,16 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         # Alias the KV allocator so draft block allocation draws from the same
         # free list the target uses (no collision with committed slots).
         self.draft_model_runner.token_to_kv_pool_allocator = self.token_to_kv_pool_allocator
+        _configure_draft_swa_mapping(
+            self.draft_model_runner.token_to_kv_pool,
+            self.draft_model_runner.attn_backend,
+            self.token_to_kv_pool_allocator,
+            int(draft_model.config.num_hidden_layers),
+        )
 
         target_model = target_worker.model_runner.model
         embed_weight, head_weight = target_model.get_embed_and_head()
-        self._target_lm_head = head_weight  # [vocab, hidden], for greedy head sampling
+        self._target_lm_head = head_weight  # [vocab, hidden], for draft head sampling
         self._target_embed = embed_weight  # [vocab, hidden]
         self._target_vocab_size = int(target_worker.model_runner.model_config.vocab_size)
 
@@ -133,10 +186,6 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         )
         self._verify_bucket_templates: dict[tuple, DFlashVerifyBucketTemplate] = {}
 
-        dflash_config = parse_dflash_draft_config(
-            server_args.speculative_draft_model_path,
-            revision=server_args.speculative_draft_model_revision,
-        )
         self._mask_token_id = resolve_mask_token_id(
             dflash_config,
             getattr(self._target_impl, "tokenizer", None),
@@ -159,10 +208,14 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         self._init_jit_draft_block()
 
         logger.info(
-            "Initialized DFLASH worker: block_size=%d, mask_token_id=%d, "
+            "Initialized DFLASH worker: verify_block_size=%d, draft_block_size=%d, "
+            "draft_max_block_size=%d, "
+            "mask_token_id=%d, "
             "draft_layers=%d, page_indices_pool_capacity=%d, "
             "page_indices_per_seq_capacity=%d",
             self.block_size,
+            self.draft_block_size,
+            self.draft_max_block_size,
             self._mask_token_id,
             self.draft_layers,
             self._page_indices_pool_capacity,
@@ -262,7 +315,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             target_hidden=logits_output.hidden_states,
             ctx_lens=accept_lens_out,
             draft_seq_lens=None,
-            block_size=self.block_size,
+            block_size=self.draft_block_size,
         )
         next_draft_input.new_seq_lens = new_seq_lens
         next_draft_input._target_verify_plan = plan
@@ -308,7 +361,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             target_hidden=target_hidden,
             ctx_lens=seq_lens,
             draft_seq_lens=prefix_lens,
-            block_size=self.block_size,
+            block_size=self.draft_block_size,
         )
 
         # Materialization only depends on target hidden states. Dispatch it before
@@ -360,8 +413,6 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
 
         if not model_worker_batch.forward_mode.is_extend():
             raise NotImplementedError("DFLASH prefill overlap requires an extend batch.")
-        if not self._can_use_fused_spec_prefill(model_worker_batch):
-            raise NotImplementedError("DFLASH prefill overlap only supports greedy sampling.")
 
         self.init_spec_relay_buffers()
         if model_worker_batch.sampling_info.temperatures.ndim == 1:
@@ -374,12 +425,9 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             self.mesh,
             vocab_size=self.target_worker.model_config.vocab_size,
         )
-        logits_output, _, cache_miss_count, bid, seq_lens = self.forward_target_extend(
-            model_worker_batch,
-            sampling_metadata,
-            skip_sample=True,
+        logits_output, next_token_ids, cache_miss_count, bid, seq_lens = (
+            self._forward_target_prefill_overlap(model_worker_batch, sampling_metadata)
         )
-        next_token_ids = jnp.argmax(logits_output.next_token_logits, axis=-1).astype(jnp.int32)
 
         sel = np.asarray(model_worker_batch.logits_indices_selector, dtype=np.int32)
         extend_seq_lens = np.asarray(model_worker_batch.extend_seq_lens, dtype=np.int32)[sel]
@@ -389,7 +437,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             target_hidden=logits_output.hidden_states,
             ctx_lens=extend_seq_lens,
             draft_seq_lens=extend_prefix_lens,
-            block_size=self.block_size,
+            block_size=self.draft_block_size,
         )
         self._append_target_hidden_to_draft_kv(model_worker_batch, materialize_input)
 
@@ -424,7 +472,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         future_indices = np.asarray(model_worker_batch.req_pool_indices, dtype=np.int32)[sel]
         next_draft_input = DFlashDraftInput(
             future_indices=future_indices,
-            block_size=self.block_size,
+            block_size=self.draft_block_size,
         )
         model_worker_batch.spec_info_padded = next_draft_input
         launch_done = getattr(model_worker_batch, "launch_done", None)
@@ -442,6 +490,17 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             extend_logprob_start_len_per_req=None,
         )
 
+    def _forward_target_prefill_overlap(self, model_worker_batch, sampling_metadata):
+        if model_worker_batch.sampling_info.is_all_greedy:
+            logits_output, _, cache_miss_count, bid, seq_lens = self.forward_target_extend(
+                model_worker_batch,
+                sampling_metadata,
+                skip_sample=True,
+            )
+            next_token_ids = jnp.argmax(logits_output.next_token_logits, axis=-1).astype(jnp.int32)
+            return logits_output, next_token_ids, cache_miss_count, bid, seq_lens
+        return self.forward_target_extend(model_worker_batch, sampling_metadata)
+
     def forward_batch_speculative_decode_overlap(self, model_worker_batch: ModelWorkerBatch):
         if not model_worker_batch.forward_mode.is_decode():
             raise NotImplementedError("DFLASH decode overlap requires a decode batch.")
@@ -458,7 +517,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         sel = np.asarray(model_worker_batch.logits_indices_selector, dtype=np.int32)
         next_draft_input = DFlashDraftInput(
             future_indices=np.asarray(model_worker_batch.req_pool_indices, dtype=np.int32)[sel],
-            block_size=self.block_size,
+            block_size=self.draft_block_size,
         )
         batch_output.next_draft_input = next_draft_input
         batch_output.spec_relay_buffers = self.spec_relay_buffers
@@ -516,7 +575,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             verified_id=verified_id,
             mask_token_id=self._mask_token_id,
             target_prefix_lens=target_prefix_lens,
-            block_size=self.block_size,
+            block_size=self.draft_block_size,
         )
         block_ids_flat = block_ids.reshape(-1)
         positions_flat = positions.reshape(-1)
@@ -545,7 +604,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             )
         allocated_lens = draft_input.allocate_lens
         if allocated_lens is None:
-            allocated_lens = target_prefix_lens + self.block_size
+            allocated_lens = target_prefix_lens + self.draft_block_size
         allocated_lens = np.asarray(allocated_lens, dtype=np.int32)
         reservation_base_lens = draft_input.reservation_base_lens
         if reservation_base_lens is None:
@@ -563,7 +622,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             bs,
             allocated_lens=allocated_lens if use_relay_state else None,
         )
-        template = self._get_verify_bucket_template(draft_mwb, bs)
+        template = self._get_verify_bucket_template(draft_mwb, bs, block_size=self.draft_block_size)
         metadata = self.draft_model_runner.attn_backend.get_eagle_forward_metadata(
             draft_mwb,
             page_indices=page_indices,
@@ -573,18 +632,18 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             distribution=template.distribution,
         )
         relay_future_indices = (
-            np.asarray(draft_input.future_indices, dtype=np.int32)
+            self._current_relay_indices(model_worker_batch, active_mask, bs)
             if use_relay_state
             else np.zeros((bs,), dtype=np.int32)
         )
-        relay_future_indices = np.where(active_mask, relay_future_indices, 0)
         data_sharding = NamedSharding(self.mesh, P("data"))
         return DraftForwardPlan(
             forward_batch=forward_batch,
             forward_metadata=metadata,
+            page_indices=page_indices,
             seq_lens=np.asarray(model_worker_batch.seq_lens, dtype=np.int32),
             target_prefix_lens=np.asarray(target_prefix_lens, dtype=np.int32),
-            positions_host=positions_flat,
+            positions_host=positions[:, : self.block_size].reshape(-1),
             allocated_lens=jax.device_put(allocated_lens, data_sharding),
             reservation_base_lens=jax.device_put(reservation_base_lens, data_sharding),
             relay_future_indices=jax.device_put(relay_future_indices, data_sharding),
@@ -603,6 +662,9 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         resolved_positions: jax.Array,
         resolved_cache_loc: jax.Array,
     ) -> TargetVerifyPlan:
+        from jax.sharding import NamedSharding
+        from jax.sharding import PartitionSpec as P
+
         bs = draft_plan.bs
         target_mwb = copy.copy(model_worker_batch)
         target_mwb.forward_mode = ForwardMode.TARGET_VERIFY
@@ -623,6 +685,22 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
 
         template = self._get_verify_bucket_template(target_mwb, bs)
 
+        # The draft and target runners can have different hybrid-KV layouts.
+        # In particular, Muse Glimmer's target mixes SWA and full-attention
+        # layers while its DFlash draft has a different cache layout. Reusing
+        # the draft backend's metadata would therefore give target SWA layers
+        # page indices derived from the wrong allocator mapping.
+        target_forward_metadata = (
+            self.target_worker.model_runner.attn_backend.get_eagle_forward_metadata(
+                target_mwb,
+                page_indices=draft_plan.page_indices,
+                page_indices_capacity=self._page_indices_capacity(bs),
+                extend_seq_lens=template.extend_seq_lens,
+                cu_q_lens=template.cu_q_lens,
+                distribution=template.distribution,
+            )
+        )
+
         # Reuse proposal positions, request indices, and other device buffers
         # from the draft plan. In particular, do not upload MASK ids for target
         # verify and overwrite them with draft_token afterwards.
@@ -638,10 +716,24 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         target_forward_batch.capture_hidden_mode = CaptureHiddenMode.FULL
         target_forward_batch.input_embedding = None
 
+        sampling_info = model_worker_batch.sampling_info
+        sampling_values = (
+            np.asarray(sampling_info.temperatures, dtype=np.float32),
+            np.asarray(sampling_info.top_ks, dtype=np.int32),
+            np.asarray(sampling_info.top_ps, dtype=np.float32),
+        )
+        if self.mesh is None:
+            temperatures, top_ks, top_ps = map(jnp.asarray, sampling_values)
+        else:
+            data_sharding = NamedSharding(self.mesh, P("data"))
+            temperatures, top_ks, top_ps = (
+                jax.device_put(value, data_sharding) for value in sampling_values
+            )
+
         return TargetVerifyPlan(
             model_worker_batch=target_mwb,
             forward_batch=target_forward_batch,
-            forward_metadata=draft_plan.forward_metadata,
+            forward_metadata=target_forward_metadata,
             logits_metadata=LogitsMetadata.from_model_worker_batch(target_mwb, self.mesh),
             seq_lens=draft_plan.seq_lens,
             target_prefix_lens=draft_plan.target_prefix_lens,
@@ -652,6 +744,9 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             allocated_lens=draft_plan.allocated_lens,
             relay_future_indices=draft_plan.relay_future_indices,
             relay_valid_mask=draft_plan.relay_valid_mask,
+            temperatures=temperatures,
+            top_ks=top_ks,
+            top_ps=top_ps,
         )
 
     def _make_draft_block_mwb(
@@ -672,7 +767,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         mwb.spec_algorithm = SpeculativeAlgorithm.DFLASH
         mwb.spec_info_padded = DFlashVerifyInput(
             draft_token=block_ids_flat,
-            draft_token_num=self.block_size,
+            draft_token_num=self.draft_block_size,
         )
         # DFlashDraftInput.prepare_for_decode already reserved and packed one
         # block per active request into the first half of each DP rank section.
@@ -681,7 +776,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         mwb.out_cache_loc = (
             np.asarray(base_mwb.out_cache_loc, dtype=np.int32)
             if use_relay_state
-            else self._verify_write_cache_loc(base_mwb)
+            else self._verify_write_cache_loc(base_mwb, self.draft_block_size)
         )
         mwb.cache_loc = None
         return mwb
@@ -702,7 +797,8 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         runner = self.draft_model_runner
         model_def = runner._model_def
         model_state_def = runner._model_state_def
-        block_size = self.block_size
+        block_size = self.draft_block_size
+        verify_block_size = self.block_size
         vocab_size = self._target_vocab_size
         embedding_sharding = NamedSharding(runner.mesh, P("data", "tensor"))
         logits_sharding = NamedSharding(runner.mesh, P("data", "tensor"))
@@ -715,6 +811,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             static_argnames=[
                 "model_state_def",
                 "block_size",
+                "verify_block_size",
                 "vocab_size",
                 "use_relay_state",
                 "dp_size",
@@ -735,6 +832,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             reservation_base_lens,
             *,
             block_size: int,
+            verify_block_size: int,
             vocab_size: int,
             use_relay_state: bool,
             dp_size: int,
@@ -812,7 +910,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             draft_hidden = output.hidden_states.reshape(
                 (-1, block_size, output.hidden_states.shape[-1])
             )
-            proposal_hidden = draft_hidden[:, 1:, :]
+            proposal_hidden = draft_hidden[:, 1:verify_block_size, :]
             proposal_flat = proposal_hidden.reshape((-1, proposal_hidden.shape[-1]))
             logits = jnp.dot(
                 proposal_flat,
@@ -826,12 +924,20 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             draft_next = jax.sharding.reshard(draft_next, cache_row_sharding)
             draft_token = jnp.concatenate([seed, draft_next], axis=1).reshape(-1)
             draft_token = jax.sharding.reshard(draft_token, token_sharding)
+            verify_positions = forward_batch.positions.reshape((-1, block_size))[
+                :, :verify_block_size
+            ].reshape(-1)
+            verify_cache_loc = selected_cache_loc.reshape((-1, block_size))[
+                :, :verify_block_size
+            ].reshape(-1)
+            verify_positions = jax.sharding.reshard(verify_positions, token_sharding)
+            verify_cache_loc = jax.sharding.reshard(verify_cache_loc, token_sharding)
             return (
                 pool_updates,
                 draft_token,
                 target_prefix_lens,
-                forward_batch.positions,
-                selected_cache_loc,
+                verify_positions,
+                verify_cache_loc,
             )
 
         self._jit_draft_block = _partial(
@@ -839,6 +945,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             model_def,
             model_state_def,
             block_size=block_size,
+            verify_block_size=verify_block_size,
             vocab_size=vocab_size,
         )
 
@@ -875,7 +982,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             return _call_and_replace()
 
     def _init_jit_target_verify(self):
-        """Build target model forward + DFlash greedy verification as one JIT."""
+        """Build target model forward + DFlash target-only verification as one JIT."""
         from functools import partial as _partial
 
         from flax import nnx
@@ -919,6 +1026,11 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             relay_buffers,
             relay_future_indices,
             relay_valid_mask,
+            temperatures,
+            top_ks,
+            top_ps,
+            base_rng_key,
+            rng_step,
             *,
             draft_token_num: int,
             use_relay_state: bool,
@@ -943,9 +1055,14 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
                 output, pool_updates, _, layers_topk_ids = model(
                     forward_batch, memory_pools, logits_metadata
                 )
-            accept_lens_out, next_token_ids_flat, new_verified_id, _ = dflash_greedy_verify(
+            rng_key = jax.random.fold_in(base_rng_key, rng_step)
+            accept_lens_out, next_token_ids_flat, new_verified_id, _ = dflash_target_only_verify(
                 draft_token,
                 output.next_token_logits,
+                temperatures,
+                top_ks,
+                top_ps,
+                rng_key,
                 draft_token_num=draft_token_num,
             )
             accept_lens_out = jax.sharding.reshard(accept_lens_out, token_sharding)
@@ -996,6 +1113,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             target_worker.prepare_lora_batch(model_worker_batch)
 
         def _call_and_replace():
+            runner._sampler_step += 1
             with jtu.count_pjit_cpp_cache_miss() as count:
                 (
                     output,
@@ -1017,6 +1135,11 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
                     self.spec_relay_buffers if plan.update_relay else None,
                     plan.relay_future_indices,
                     plan.relay_valid_mask,
+                    plan.temperatures,
+                    plan.top_ks,
+                    plan.top_ps,
+                    runner._sampler_base_rng,
+                    runner._sampler_step,
                     use_relay_state=plan.update_relay,
                     update_relay=plan.update_relay,
                     dp_size=plan.model_worker_batch.dp_size,
@@ -1071,7 +1194,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         from sgl_jax.srt.mem_cache.memory_pool import _set_fused_kv_buffer, merge_kv
 
         runner = self.draft_model_runner
-        pool = runner.token_to_kv_pool
+        pool, _ = self._get_draft_materialize_pool()
         page_size = pool.page_size
         kv_part = pool.kv_partition_axis
         data_part = pool.attention_data_partition_axis
@@ -1133,6 +1256,22 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
 
         self._jit_materialize_write = _partial(draft_extend, model_def, model_state_def)
 
+    def _get_draft_materialize_pool(self):
+        """Return the physical KV pool used by the DFlash draft layers."""
+        pool = self.draft_model_runner.token_to_kv_pool
+        if not hasattr(pool, "swa_kv_pool"):
+            return pool, None
+
+        if pool.swa_layer_nums == self.draft_layers and pool.full_layer_nums == 0:
+            first_layer_id = min(pool.layers_mapping)
+            return pool.swa_kv_pool, first_layer_id
+        if pool.full_layer_nums == self.draft_layers and pool.swa_layer_nums == 0:
+            return pool.full_kv_pool, None
+        raise NotImplementedError(
+            "DFLASH draft KV materialization does not support mixed sliding-window "
+            "and full-attention draft layers."
+        )
+
     def _append_target_hidden_to_draft_kv(
         self,
         model_worker_batch: ModelWorkerBatch,
@@ -1146,6 +1285,19 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             model_worker_batch,
             target_hidden,
         )
+
+        pool, remap_layer_id = self._get_draft_materialize_pool()
+        valid_cache_loc = cache_loc[cache_loc >= 0]
+        cache_capacity = int(pool.kv_buffer[0].shape[0]) * int(pool.page_size)
+        if (
+            remap_layer_id is None
+            and valid_cache_loc.size
+            and int(valid_cache_loc.max()) >= cache_capacity
+        ):
+            raise ValueError(
+                "DFLASH prefill cache location exceeds the draft KV pool: "
+                f"max={int(valid_cache_loc.max())}, capacity={cache_capacity}."
+            )
 
         self._run_jit_draft_extend(target_hidden, positions, cache_loc)
 
@@ -1164,7 +1316,8 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         accept_lens=None,
         active_mask=None,
     ):
-        pool = self.draft_model_runner.token_to_kv_pool
+        logical_pool = self.draft_model_runner.token_to_kv_pool
+        pool, remap_layer_id = self._get_draft_materialize_pool()
         if accept_lens is None:
             # Prefill metadata is already on the host. Build its fixed masks with
             # NumPy so they become inputs to jit_draft_extend instead of separate
@@ -1174,6 +1327,11 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             if active_mask is None:
                 active_mask = cache_loc >= 0
         cache_loc = jnp.asarray(cache_loc)
+        if remap_layer_id is not None:
+            valid_cache_loc = cache_loc >= 0
+            safe_cache_loc = jnp.where(valid_cache_loc, cache_loc, 0)
+            cache_loc = logical_pool.remap_cache_loc(safe_cache_loc, remap_layer_id)
+            cache_loc = jnp.where(valid_cache_loc, cache_loc, -1)
         accept_lens = jnp.asarray(accept_lens)
         active_mask = jnp.asarray(active_mask)
         if cache_loc.shape[0] % accept_lens.shape[0] != 0:
@@ -1360,7 +1518,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
 
         req_to_token = self.req_to_token_pool.req_to_token
         if allocated_lens is None:
-            allocated_lens = prefix_lens + self.block_size
+            allocated_lens = prefix_lens + getattr(self, "draft_block_size", self.block_size)
         allocated_lens = np.asarray(allocated_lens, dtype=np.int32)
         if allocated_lens.shape != (bs,):
             raise ValueError(
@@ -1424,6 +1582,8 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         self,
         model_worker_batch: ModelWorkerBatch,
         bs: int,
+        *,
+        block_size: int | None = None,
     ) -> DFlashVerifyBucketTemplate:
         from jax.sharding import NamedSharding
         from jax.sharding import PartitionSpec as P
@@ -1435,14 +1595,15 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             selector = np.arange(int(getattr(model_worker_batch, "real_bs", bs)), dtype=np.int32)
         else:
             selector = np.asarray(selector, dtype=np.int32)
-        key = (dp_size, per_dp_bs, tuple(selector.tolist()), self.block_size)
+        block_size = self.block_size if block_size is None else int(block_size)
+        key = (dp_size, per_dp_bs, tuple(selector.tolist()), block_size)
         cached = self._verify_bucket_templates.get(key)
         if cached is not None:
             return cached
 
         active_host = np.zeros(bs, dtype=np.bool_)
         active_host[selector] = True
-        extend_seq_lens = active_host.astype(np.int32) * self.block_size
+        extend_seq_lens = active_host.astype(np.int32) * block_size
         cu_q_lens = np.zeros((dp_size, per_dp_bs + 1), dtype=np.int32)
         cu_q_lens[:, 1:] = np.cumsum(
             extend_seq_lens.reshape(dp_size, per_dp_bs),
@@ -1476,6 +1637,21 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             mask[start:end] = True
         return mask
 
+    @staticmethod
+    def _current_relay_indices(
+        model_worker_batch,
+        active_mask: np.ndarray,
+        total_bs: int,
+    ) -> np.ndarray:
+        """Use the current batch order when reading request-indexed relay state."""
+        req_pool_indices = np.asarray(model_worker_batch.req_pool_indices, dtype=np.int32)
+        if req_pool_indices.shape != (total_bs,):
+            raise ValueError(
+                "DFLASH relay indices must match the padded decode batch: "
+                f"shape={req_pool_indices.shape}, bs={total_bs}."
+            )
+        return np.where(active_mask, req_pool_indices, 0)
+
     def _can_use_fused_spec_prefill(self, model_worker_batch: ModelWorkerBatch) -> bool:
         if (
             self.server_args.disable_overlap_schedule
@@ -1488,8 +1664,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             getattr(penalizer, "is_required", False)
         )
         return (
-            bool(getattr(sampling_info, "is_all_greedy", False))
-            and not has_penalty
+            not has_penalty
             and getattr(sampling_info, "vocab_mask", None) is None
             and not getattr(model_worker_batch, "return_logprob", False)
             and not getattr(model_worker_batch, "return_output_logprob_only", False)
@@ -1582,21 +1757,27 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         )
 
     def _precompile_dflash_variant(self, bs: int) -> None:
-        row_width = max(self.block_size, 16 * self.page_size)
+        row_width = max(self.draft_block_size, 16 * self.page_size)
         page_indices = np.zeros(self._page_indices_capacity(bs), dtype=np.int32)
-        draft_batch = self._make_verify_dummy_batch(bs, row_width, is_draft=True)
+        draft_batch = self._make_verify_dummy_batch(
+            bs, row_width, is_draft=True, block_size=self.draft_block_size
+        )
         use_relay_state = not self.server_args.disable_overlap_schedule
         if use_relay_state:
             draft_batch.out_cache_loc = np.arange(
                 1,
-                bs * 2 * self.block_size + 1,
+                bs * 2 * self.draft_block_size + 1,
                 dtype=np.int32,
             )
         else:
-            draft_batch.out_cache_loc = self._verify_write_cache_loc(draft_batch)
+            draft_batch.out_cache_loc = self._verify_write_cache_loc(
+                draft_batch, self.draft_block_size
+            )
         forward_batch = ForwardBatch.init_new(draft_batch, self.draft_model_runner)
         forward_batch.forward_mode = ForwardMode.TARGET_VERIFY
-        template = self._get_verify_bucket_template(draft_batch, bs)
+        template = self._get_verify_bucket_template(
+            draft_batch, bs, block_size=self.draft_block_size
+        )
         draft_metadata = self.draft_model_runner.attn_backend.get_eagle_forward_metadata(
             draft_batch,
             page_indices=page_indices,
@@ -1619,7 +1800,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
                 int(draft_batch.dp_size),
             )
             relay_future_indices = jax.device_put(future_indices, data_sharding)
-            allocated_lens = prefix_lens + 2 * self.block_size
+            allocated_lens = prefix_lens + 2 * self.draft_block_size
             self.init_spec_relay_buffers()
             self._update_relay(
                 jnp.ones((bs,), dtype=jnp.int32),
@@ -1630,10 +1811,11 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             )
         else:
             relay_future_indices = jax.device_put(np.zeros(bs, dtype=np.int32), data_sharding)
-            allocated_lens = prefix_lens + self.block_size
+            allocated_lens = prefix_lens + self.draft_block_size
         draft_plan = DraftForwardPlan(
             forward_batch=forward_batch,
             forward_metadata=draft_metadata,
+            page_indices=page_indices,
             seq_lens=prefix_lens + 1,
             target_prefix_lens=prefix_lens,
             positions_host=np.asarray(draft_batch.positions, dtype=np.int32),
@@ -1654,12 +1836,21 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
 
         # Match the serving dependency and sharding exactly: target verify
         # consumes the P("data") proposal produced by jit_draft.
-        target_batch = self._make_verify_dummy_batch(bs, row_width)
+        target_batch = self._make_verify_dummy_batch(bs, row_width, block_size=self.block_size)
         verify_input = DFlashVerifyInput(
             draft_token=draft_token,
             draft_token_num=self.block_size,
         )
         target_batch.spec_info_padded = verify_input
+        target_template = self._get_verify_bucket_template(target_batch, bs)
+        target_metadata = self.target_worker.model_runner.attn_backend.get_eagle_forward_metadata(
+            target_batch,
+            page_indices=page_indices,
+            page_indices_capacity=self._page_indices_capacity(bs),
+            extend_seq_lens=target_template.extend_seq_lens,
+            cu_q_lens=target_template.cu_q_lens,
+            distribution=target_template.distribution,
+        )
         target_forward_batch = copy.copy(forward_batch)
         target_forward_batch.input_ids = draft_token
         target_forward_batch.positions = resolved_positions
@@ -1672,20 +1863,32 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         target_plan = TargetVerifyPlan(
             model_worker_batch=target_batch,
             forward_batch=target_forward_batch,
-            forward_metadata=draft_metadata,
+            forward_metadata=target_metadata,
             logits_metadata=LogitsMetadata.from_model_worker_batch(target_batch, self.mesh),
             seq_lens=np.asarray(target_batch.seq_lens, dtype=np.int32) + 1,
             target_prefix_lens=np.asarray(target_batch.seq_lens, dtype=np.int32),
             resolved_target_prefix_lens=resolved_prefix_lens,
             draft_extend_positions=resolved_positions,
             draft_extend_cache_loc=resolved_cache_loc,
-            active_mask=template.active_mask,
+            active_mask=target_template.active_mask,
             allocated_lens=draft_plan.allocated_lens,
             relay_future_indices=draft_plan.relay_future_indices,
             relay_valid_mask=draft_plan.relay_valid_mask,
+            temperatures=jax.device_put(
+                np.asarray(target_batch.sampling_info.temperatures, dtype=np.float32),
+                data_sharding,
+            ),
+            top_ks=jax.device_put(
+                np.asarray(target_batch.sampling_info.top_ks, dtype=np.int32),
+                data_sharding,
+            ),
+            top_ps=jax.device_put(
+                np.asarray(target_batch.sampling_info.top_ps, dtype=np.float32),
+                data_sharding,
+            ),
             update_relay=use_relay_state,
         )
-        self.target_worker.model_runner.attn_backend.forward_metadata = draft_metadata
+        self.target_worker.model_runner.attn_backend.forward_metadata = target_metadata
         logits_output, _, accept_lens, *_ = self._run_jit_target_verify(target_plan)
         self._run_jit_draft_extend(
             logits_output.hidden_states,
@@ -1695,9 +1898,12 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             active_mask=target_plan.active_mask,
         )
 
-    def _verify_write_cache_loc(self, batch: ModelWorkerBatch) -> np.ndarray:
+    def _verify_write_cache_loc(
+        self, batch: ModelWorkerBatch, block_size: int | None = None
+    ) -> np.ndarray:
         dp_size = int(batch.dp_size)
-        per_dp_tokens = int(batch.per_dp_bs_size) * self.block_size
+        block_size = self.block_size if block_size is None else int(block_size)
+        per_dp_tokens = int(batch.per_dp_bs_size) * block_size
         out_cache_loc = np.asarray(batch.out_cache_loc, dtype=np.int32)
         if out_cache_loc.shape[0] % dp_size != 0:
             raise ValueError(
@@ -1713,9 +1919,13 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         return out_cache_loc.reshape(dp_size, per_dp_ocl)[:, :per_dp_tokens].reshape(-1)
 
     def _make_verify_dummy_batch(
-        self, bs: int, row_width: int, is_draft: bool = False
+        self,
+        bs: int,
+        row_width: int,
+        is_draft: bool = False,
+        block_size: int | None = None,
     ) -> ModelWorkerBatch:
-        block_size = self.block_size
+        block_size = self.block_size if block_size is None else int(block_size)
         num_tokens = bs * block_size
         dp_size = int(self._target_compilation_manager.dp_size)
         if bs % dp_size != 0:

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -637,10 +637,16 @@ def _reshape_per_dp_rows(values, dp_size: int):
 def _per_dp_cumsum_device(lens, dp_size: int):
     per_dp_bs = lens.shape[0] // dp_size
     lens_2d = _reshape_per_dp_rows(lens, dp_size)
+    rows_sharding = jax.typeof(lens_2d).sharding
     zeros = jnp.zeros_like(lens_2d[:, :1], dtype=jnp.int32)
-    result = jnp.concatenate([zeros, jnp.cumsum(lens_2d, axis=1, dtype=jnp.int32)], axis=1).reshape(
-        (dp_size * (per_dp_bs + 1),)
-    )
+    cumsum = jnp.cumsum(lens_2d, axis=1, dtype=jnp.int32)
+    if isinstance(rows_sharding, NamedSharding) and not rows_sharding.mesh.empty:
+        # Explicit-sharding JAX requires concatenate operands to carry the same
+        # sharding. zeros_like may otherwise infer replicated sharding even
+        # though lens_2d and its cumulative sum are data-sharded.
+        zeros = jax.sharding.reshard(zeros, rows_sharding)
+        cumsum = jax.sharding.reshard(cumsum, rows_sharding)
+    result = jnp.concatenate([zeros, cumsum], axis=1).reshape((dp_size * (per_dp_bs + 1),))
     sharding = jax.typeof(lens).sharding
     if isinstance(sharding, NamedSharding) and not sharding.mesh.empty:
         result = jax.sharding.reshard(result, sharding)

--- a/python/sgl_jax/test/speculative/test_dflash_info.py
+++ b/python/sgl_jax/test/speculative/test_dflash_info.py
@@ -8,6 +8,7 @@ from sgl_jax.srt.speculative.dflash_info import (
     DFlashVerifyInput,
     build_dflash_draft_block,
     dflash_greedy_verify,
+    dflash_target_only_verify,
 )
 from sgl_jax.srt.speculative.overlap_utils import (
     can_merge_spec_non_overlap_prefill,
@@ -85,6 +86,64 @@ def test_dflash_greedy_verify_keeps_outputs_data_sharded():
         assert output.sharding.spec == P("data")
     np.testing.assert_array_equal(np.asarray(accept_lens), np.full(bs, 4, dtype=np.int32))
     np.testing.assert_array_equal(np.asarray(verified_id), np.full(bs, 99, dtype=np.int32))
+
+
+def test_dflash_target_only_verify_matches_greedy_with_top_k_one():
+    draft_token = jnp.array([10, 11, 12, 13, 20, 21, 22, 23], dtype=jnp.int32)
+    target_predict = np.array([[11, 12, 13, 99], [21, 77, 88, 99]], dtype=np.int32)
+    logits = np.full((8, 100), -10.0, dtype=np.float32)
+    logits[np.arange(8), target_predict.reshape(-1)] = 10.0
+
+    actual = dflash_target_only_verify(
+        draft_token,
+        jnp.asarray(logits),
+        jnp.ones((2, 1), dtype=jnp.float32),
+        jnp.ones((2, 1), dtype=jnp.int32),
+        jnp.ones((2, 1), dtype=jnp.float32),
+        jax.random.PRNGKey(7),
+        draft_token_num=4,
+    )
+    expected = dflash_greedy_verify(
+        draft_token,
+        jnp.asarray(logits),
+        draft_token_num=4,
+    )
+
+    np.testing.assert_array_equal(np.asarray(actual[0]), np.asarray(expected[0]))
+    np.testing.assert_array_equal(np.asarray(actual[2]), np.asarray(expected[2]))
+    np.testing.assert_array_equal(np.asarray(actual[3]), np.asarray(expected[3]))
+    expected_rows = np.asarray(expected[1]).reshape(2, 4)
+    for index, (row, accepted) in enumerate(
+        zip(np.asarray(actual[1]).reshape(2, 4), np.asarray(actual[0]))
+    ):
+        expected_row = expected_rows[index]
+        np.testing.assert_array_equal(row[:accepted], expected_row[:accepted])
+
+
+def test_dflash_target_only_verify_accepts_by_target_probability():
+    draft_token = jnp.array([10, 11, 12, 13], dtype=jnp.int32)
+    logits = np.full((4, 32), -20.0, dtype=np.float32)
+    logits[0, 11] = 20.0
+    logits[1, 15] = 20.0
+    logits[2, 13] = 20.0
+    logits[3, 16] = 20.0
+
+    accept_lens, output, verified_id, accepted_drafts = dflash_target_only_verify(
+        draft_token,
+        jnp.asarray(logits),
+        jnp.ones((1, 1), dtype=jnp.float32),
+        jnp.full((1, 1), 32, dtype=jnp.int32),
+        jnp.ones((1, 1), dtype=jnp.float32),
+        jax.random.PRNGKey(0),
+        draft_token_num=4,
+    )
+
+    # The first proposal has probability one. The second has probability zero,
+    # so it is rejected and replaced by the only non-negligible token, 15.
+    np.testing.assert_array_equal(np.asarray(accept_lens), np.array([2], dtype=np.int32))
+    np.testing.assert_array_equal(np.asarray(accepted_drafts), np.array([1], dtype=np.int32))
+    np.testing.assert_array_equal(np.asarray(output)[:2], np.array([11, 15], dtype=np.int32))
+    np.testing.assert_array_equal(np.asarray(verified_id), np.array([15], dtype=np.int32))
 
 
 def test_dflash_draft_input_filter_batch():

--- a/python/sgl_jax/test/speculative/test_dflash_server_args.py
+++ b/python/sgl_jax/test/speculative/test_dflash_server_args.py
@@ -99,3 +99,18 @@ def test_dflash_server_args_allows_data_parallel_attention(monkeypatch):
 
     assert args.dp_size == 2
     assert args.tp_size // args.dp_size == 2
+
+
+def test_dflash_server_args_allows_overlap(monkeypatch):
+    def fail_parse(*args, **kwargs):
+        raise AssertionError("non-default DFlash draft token count should not be inferred")
+
+    monkeypatch.setattr(dflash_util, "parse_dflash_draft_config", fail_parse)
+
+    args = _dflash_args(
+        speculative_num_draft_tokens=16,
+        disable_overlap_schedule=False,
+    )
+    args.check_server_args()
+
+    assert not args.disable_overlap_schedule

--- a/python/sgl_jax/test/speculative/test_dflash_worker.py
+++ b/python/sgl_jax/test/speculative/test_dflash_worker.py
@@ -2,10 +2,19 @@ from types import SimpleNamespace
 
 import jax
 import numpy as np
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.layers.attention.flashattention_backend import _pad_page_indices
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata
 from sgl_jax.srt.speculative.dflash_info import DFlashDraftInput, _mask_draft_kv_writes
-from sgl_jax.srt.speculative.dflash_worker import DFlashWorker
+from sgl_jax.srt.speculative.dflash_worker import (
+    DFlashWorker,
+    DraftForwardPlan,
+    _configure_draft_swa_mapping,
+    _resolve_dflash_query_block_size,
+)
+from sgl_jax.srt.speculative.draft_extend_fused import _per_dp_cumsum_device
 
 
 def _bare_worker(**attrs):
@@ -13,6 +22,47 @@ def _bare_worker(**attrs):
     for k, v in attrs.items():
         object.__setattr__(w, k, v)
     return w
+
+
+def test_per_dp_cumsum_preserves_explicit_sharding():
+    mesh = jax.sharding.Mesh(
+        np.asarray(jax.devices()[:1]).reshape(1, 1),
+        ("data", "tensor"),
+        axis_types=(jax.sharding.AxisType.Explicit, jax.sharding.AxisType.Explicit),
+    )
+    sharding = NamedSharding(mesh, P("data"))
+    with jax.set_mesh(mesh):
+        lens = jax.device_put(np.asarray([4, 0], dtype=np.int32), sharding)
+        result = jax.jit(lambda values: _per_dp_cumsum_device(values, 1))(lens)
+
+    np.testing.assert_array_equal(np.asarray(result), np.asarray([0, 4, 4]))
+    assert result.sharding.spec == P("data")
+
+
+def test_dflash_runtime_query_width_uses_requested_nst():
+    assert _resolve_dflash_query_block_size(4, 16) == 4
+    with np.testing.assert_raises_regex(ValueError, "exceeds.*checkpoint canvas"):
+        _resolve_dflash_query_block_size(17, 16)
+
+
+def test_dflash_only_uses_swa_mapping_for_swa_backed_draft_layers():
+    mapping = np.array([0, 4, 7], dtype=np.int32)
+    allocator = SimpleNamespace(full_to_swa_index_mapping=mapping)
+    full_pool = SimpleNamespace(swa_layer_nums=0, full_to_swa_index_mapping="stale")
+    full_backend = SimpleNamespace(swa_index_mapping="stale")
+
+    _configure_draft_swa_mapping(full_pool, full_backend, allocator, draft_layers=5)
+
+    assert full_pool.full_to_swa_index_mapping is None
+    assert full_backend.swa_index_mapping is None
+
+    swa_pool = SimpleNamespace(swa_layer_nums=5, full_to_swa_index_mapping=None)
+    swa_backend = SimpleNamespace(swa_index_mapping=None)
+
+    _configure_draft_swa_mapping(swa_pool, swa_backend, allocator, draft_layers=5)
+
+    assert swa_pool.full_to_swa_index_mapping is mapping
+    assert swa_backend.swa_index_mapping is mapping
 
 
 def test_prefill_draft_extend_metadata_preserves_dp_rank_sections():
@@ -56,7 +106,7 @@ def test_draft_extend_masks_unaccepted_and_padded_rows():
 
 
 def test_verify_bucket_template_is_cached_by_active_slots():
-    mesh = jax.sharding.Mesh(np.asarray(jax.devices()).reshape(1, 1), ("data", "tensor"))
+    mesh = jax.sharding.Mesh(np.asarray(jax.devices()).reshape(1, -1), ("data", "tensor"))
     worker = _bare_worker(
         block_size=4,
         mesh=mesh,
@@ -79,6 +129,10 @@ def test_verify_bucket_template_is_cached_by_active_slots():
         np.asarray(first.active_mask), np.array([True, False, True, False])
     )
     np.testing.assert_array_equal(np.asarray(first.distribution), np.array([0, 2, 2]))
+
+    draft = worker._get_verify_bucket_template(mwb, bs=4, block_size=16)
+    assert draft is not first
+    np.testing.assert_array_equal(draft.extend_seq_lens, np.array([16, 0, 16, 0]))
 
 
 def test_build_page_indices_preserves_dp_rank_sections():
@@ -280,3 +334,72 @@ def test_pad_page_indices_rejects_fixed_capacity_overflow():
             max_num_seqs=2,
             fixed_capacity=8,
         )
+
+
+def test_target_verify_plan_rebuilds_metadata_with_target_backend(monkeypatch):
+    target_metadata = object()
+    calls = []
+
+    class TargetBackend:
+        def get_eagle_forward_metadata(self, batch, **kwargs):
+            calls.append((batch, kwargs))
+            return target_metadata
+
+    target_backend = TargetBackend()
+    worker = _bare_worker(
+        block_size=3,
+        mesh=None,
+        _page_indices_pool_capacity=16,
+        _page_indices_per_seq_capacity=8,
+        _target_worker=SimpleNamespace(model_runner=SimpleNamespace(attn_backend=target_backend)),
+    )
+    template = SimpleNamespace(
+        extend_seq_lens=np.array([3], dtype=np.int32),
+        cu_q_lens=np.array([0, 3], dtype=np.int32),
+        active_mask=np.array([True]),
+        distribution=np.array([0, 1, 1], dtype=np.int32),
+    )
+    worker._get_verify_bucket_template = lambda _batch, _bs: template
+    monkeypatch.setattr(
+        LogitsMetadata,
+        "from_model_worker_batch",
+        staticmethod(lambda _batch, _mesh: "logits-metadata"),
+    )
+
+    base_batch = SimpleNamespace(
+        dp_size=1,
+        sampling_info=SimpleNamespace(
+            temperatures=np.ones((1, 1), dtype=np.float32),
+            top_ks=np.ones((1, 1), dtype=np.int32),
+            top_ps=np.ones((1, 1), dtype=np.float32),
+        ),
+    )
+    draft_forward_batch = SimpleNamespace()
+    draft_plan = DraftForwardPlan(
+        forward_batch=draft_forward_batch,
+        forward_metadata=object(),
+        page_indices=np.array([2, 4, 0, 0], dtype=np.int32),
+        seq_lens=np.array([9], dtype=np.int32),
+        target_prefix_lens=np.array([8], dtype=np.int32),
+        positions_host=np.array([8, 9, 10], dtype=np.int32),
+        allocated_lens=np.array([11], dtype=np.int32),
+        reservation_base_lens=np.array([8], dtype=np.int32),
+        relay_future_indices=np.array([0], dtype=np.int32),
+        relay_valid_mask=np.array([True]),
+        use_relay_state=False,
+        dp_size=1,
+        bs=1,
+    )
+
+    plan = worker._build_target_verify_plan(
+        base_batch,
+        draft_plan,
+        draft_token=np.array([7, 8, 9], dtype=np.int32),
+        resolved_target_prefix_lens=np.array([8], dtype=np.int32),
+        resolved_positions=np.array([8, 9, 10], dtype=np.int32),
+        resolved_cache_loc=np.array([20, 21, 22], dtype=np.int32),
+    )
+
+    assert plan.forward_metadata is target_metadata
+    assert calls[0][1]["page_indices"] is draft_plan.page_indices
+    assert plan.forward_batch.attn_backend is target_backend


### PR DESCRIPTION
## Motivation

The TPU DFlash path currently assumes a fixed verification width and greedy sampling, and it can lose correctness for long-context or long-lived-server workloads. This PR makes the runtime width explicit, adds target-only stochastic verification, and fixes the KV/metadata invariants exercised by persistent TPU serving.

Closes #1591. Parent: #1588. Design: #1589. The current-main TPU validation also depends on the generic v7e VMEM fix in #1596.

## Modifications

- Verify exactly the runtime-requested DFlash block width instead of padding to the checkpoint maximum.
- Add target-only rejection sampling with `temperature`, `top_k`, and `top_p`.
- Keep long-context causal/sliding-window position arithmetic in `int32`.
- Size the draft KV pool from the target's post-hybrid capacity.
- Clear stale SWA remapping for fully backed draft layers and preserve correct page mappings across request turnover.
- Rebuild target verification metadata from the target backend and support overlap-prefill relay state.
- Report accepted draft tokens separately from the always-emitted target token.
- Add focused regression tests for runtime width, sampling, DP padding, page mapping, overlap metadata, and KV sizing.

## Accuracy Tests

The combined Muse Glimmer + DFlash stack completed 979/979 persistent-server requests on TPU v7e with no state divergence or request failures. Reasoning and required tool-call probes also passed.

After rebasing onto current main (JAX 0.11.1), the combined stack with #1596 completed a four-request long-context smoke at concurrency four: 4/4 successful, 128,176 input tokens and 756 output tokens. This run also caught and validated the explicit-sharding fix in this PR.

## Benchmarking and Profiling

TPU v7e, TP=2, concurrency=4, three draft proposals:

- precompiled non-overlap: 181.9 output tokens/s
- precompiled overlap: 193.3 output tokens/s
- full persistent workload: 326.1 output tokens/s and 43.38% speculative acceptance

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] The necessary documentation update is tracked in #1589.

Test plan:

```bash
pre-commit run --files $(git diff --name-only origin/main...HEAD)
pytest -q \
  python/sgl_jax/test/speculative/test_dflash_info.py \
  python/sgl_jax/test/speculative/test_dflash_server_args.py \
  python/sgl_jax/test/speculative/test_dflash_worker.py
```

Result: 39 passed.

