### PR TITLE
fix: leave TPU VMEM headroom in KV cache updates

### DIFF
--- a/python/sgl_jax/srt/kernels/update_kv_cache/update_kv_cache.py
+++ b/python/sgl_jax/srt/kernels/update_kv_cache/update_kv_cache.py
@@ -32,7 +32,10 @@ def get_slot_mapping(
     return slot_mapping.astype(jnp.int32)
 
 
-VMEM_SIZE = 64 * 1024 * 1024  # 32MB
+VMEM_SIZE = 64 * 1024 * 1024  # 64 MiB
+# Pallas programs need a small amount of VMEM beyond explicitly declared scratch.
+# A tile that consumes the full nominal capacity fails to compile on TPU v7e.
+VMEM_HEADROOM_BYTES = 128 * 1024
 
 
 def get_num_slices_per_block(new_kv: jax.Array, kv_cache: jax.Array, page_size=128):
@@ -56,7 +59,9 @@ def get_num_slices_per_block(new_kv: jax.Array, kv_cache: jax.Array, page_size=1
     kv_head_num = new_kv.shape[2] * new_kv.shape[3]
     head_dim = new_kv.shape[4]
 
-    max_num_slices_per_block = VMEM_SIZE // (bytes_per_element * page_size * kv_head_num * head_dim)
+    bytes_per_slice = bytes_per_element * page_size * kv_head_num * head_dim
+    usable_vmem_size = VMEM_SIZE - VMEM_HEADROOM_BYTES
+    max_num_slices_per_block = usable_vmem_size // bytes_per_slice
     assert (
         max_num_slices_per_block > 0
     ), f"max_num_slices_per_block={max_num_slices_per_block} is not greater than 0"

--- a/python/sgl_jax/test/kernels/test_update_kv_cache.py
+++ b/python/sgl_jax/test/kernels/test_update_kv_cache.py
@@ -1,0 +1,25 @@
+import jax.numpy as jnp
+
+from sgl_jax.srt.kernels.update_kv_cache.update_kv_cache import (
+    VMEM_HEADROOM_BYTES,
+    VMEM_SIZE,
+    get_num_slices_per_block,
+)
+
+
+def test_kv_update_tile_leaves_vmem_headroom():
+    new_kv = jnp.zeros((128, 1, 16, 2, 128), dtype=jnp.bfloat16)
+    kv_cache = jnp.zeros((1, 64, 16, 2, 128), dtype=jnp.bfloat16)
+
+    slices = get_num_slices_per_block(new_kv, kv_cache, page_size=64)
+    scratch_bytes = slices * 64 * 32 * 128 * jnp.dtype(jnp.bfloat16).itemsize
+
+    assert slices == 127
+    assert scratch_bytes <= VMEM_SIZE - VMEM_HEADROOM_BYTES
+
+
+def test_kv_update_tile_still_uses_all_input_tokens_when_small():
+    new_kv = jnp.zeros((8, 1, 4, 2, 128), dtype=jnp.bfloat16)
+    kv_cache = jnp.zeros((1, 16, 4, 2, 128), dtype=jnp.bfloat16)
+
+    assert get_num_slices_per_block(new_kv, kv_cache, page_size=16) == 8

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -347,6 +347,11 @@ suites = {
         TestFile("test/srt/test_dtype_config_consistency.py", 10),
         TestFile("python/sgl_jax/test/test_compilation_manager.py", 1),
         TestFile("python/sgl_jax/test/test_kernel_utils.py", 1),
+        TestFile(
+            "python/sgl_jax/test/kernels/test_update_kv_cache.py",
+            0.1,
+            runner="pytest",
+        ),
         TestFile("python/sgl_jax/test/speculative/test_dflash_info.py", 0.2, runner="pytest"),
         TestFile(
             "python/sgl_jax/test/speculative/test_dflash_server_args.py",


### PR DESCRIPTION
## Motivation

KV-cache update tiling currently allows the scratch buffer to consume the full nominal 64 MiB VMEM capacity. On TPU v7e with JAX 0.11.1, the compiler reports 63.94 MiB available and rejects these programs by 64 KiB.

This reproduces on untouched `main` in MHA/GQA page-size-64 tests and in long DFlash KV materialization.

Closes #1595.

## Modifications

- Reserve 128 KiB when deriving `num_slices_per_block`.
- Correct the VMEM size comment.
- Add CPU tests covering the headroom-limited and small-input cases.
- Register the new test in `unit-test-cpu`.

## Accuracy Tests

The tile computes the same KV-cache update with a slightly smaller block; no numerical operation changes.

## Benchmarking and Profiling

The affected page-size-64 tile changes from 128 to 127 slices. Smaller inputs remain unchanged. TPU regression validation is included in the follow-up test results.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] No documentation update is needed for this implementation detail.

Test plan:

```bash
pre-commit run --files \
  python/sgl_jax/srt/kernels/update_kv_cache/update_kv_cache.py \
  python/sgl_jax/test/kernels/test_update_kv_cache.py \
  test/srt/run_suite.py
pytest -q python/sgl_jax/test/kernels/test_update_kv_cache.py
```

Result: 2 passed.
