### PR TITLE
fix(quant): round to nearest when quantizing to integer dtypes

### DIFF
--- a/python/sgl_jax/srt/utils/quantization/quantization_utils.py
+++ b/python/sgl_jax/srt/utils/quantization/quantization_utils.py
@@ -310,7 +310,12 @@ def quantize_tensor_simple(
     scale = x_abs_max / max_val
     # Guard all-zero slices to avoid 0/0 -> NaN.
     scale_safe = scale + (scale == 0).astype(scale.dtype)
-    x_q = jnp.clip(x / scale_safe, min_val, max_val).astype(dtype)
+    x_scaled = x / scale_safe
+    if jnp.issubdtype(dtype, jnp.integer):
+        # float->int casts truncate toward zero; integer quantization needs
+        # round-to-nearest. Float targets (fp8) round in the cast itself.
+        x_scaled = jnp.round(x_scaled)
+    x_q = jnp.clip(x_scaled, min_val, max_val).astype(dtype)
     return x_q, scale.astype(out_dtype)
 
 
@@ -405,7 +410,11 @@ def quantize_tensor(
 
     # Guard all-zero blocks/tensors: scale==0 would produce 0/0 -> NaN.
     scale_safe = scale + (scale == 0).astype(scale.dtype)
-    tensor_q = jnp.clip(tensor / scale_safe, dtype_min, dtype_max)
+    tensor_scaled = tensor / scale_safe
+    if jnp.issubdtype(dtype, jnp.integer):
+        # Round to nearest before the integer cast below.
+        tensor_scaled = jnp.round(tensor_scaled)
+    tensor_q = jnp.clip(tensor_scaled, dtype_min, dtype_max)
     if block_size is not None and isinstance(original_input_sharding, NamedSharding):
         tensor_q = jax.lax.reshape(tensor_q, orig_shape, out_sharding=original_input_sharding)
     else:

--- a/python/sgl_jax/test/kernels/quantized_linear_test.py
+++ b/python/sgl_jax/test/kernels/quantized_linear_test.py
@@ -18,6 +18,7 @@ from sgl_jax.srt.layers.linear import LinearBase, QuantizedLinear
 from sgl_jax.srt.utils.quantization.quantization_utils import (
     apply_linear_quantization,
     quantize_tensor,
+    quantize_tensor_simple,
 )
 
 blockwise_quant_util = importlib.import_module(
@@ -531,6 +532,62 @@ def test_ignored_layers_exact_match_does_not_overmatch():
     apply_linear_quantization(model_config, model, is_static_input=False)
     assert isinstance(model.self_attn.q_proj, QuantizedLinear)
     assert isinstance(model.self_attn.o_proj, QuantizedLinear)
+
+
+def _max_abs_err_in_lsb(original, dequantized, scale):
+    """Per-element quantization error, expressed in units of one scale step."""
+    return float(jnp.max(jnp.abs(dequantized - original) / scale))
+
+
+def test_quantize_tensor_int8_rounds_to_nearest():
+    """Integer quantization must round, not truncate: error stays within 0.5 LSB."""
+    w = jax.random.normal(jax.random.PRNGKey(0), (512, 1024), jnp.float32)
+
+    w_q, scale = quantize_tensor(dtype=jnp.int8, tensor=w, axis=1)
+    dequantized = w_q.astype(jnp.float32) * scale[:, None]
+
+    assert _max_abs_err_in_lsb(w, dequantized, scale[:, None]) <= 0.5 + 1e-4
+    # Truncation biases every code toward zero; rounding leaves no such bias.
+    shrinkage = float((jnp.abs(dequantized) - jnp.abs(w)).mean())
+    assert abs(shrinkage) < 1e-4, f"systematic magnitude bias: {shrinkage:.3e}"
+
+
+def test_quantize_tensor_simple_int8_rounds_to_nearest():
+    """Same requirement on the per-token activation quantizer."""
+    x = jax.random.normal(jax.random.PRNGKey(1), (256, 512), jnp.float32)
+
+    x_q, scale = quantize_tensor_simple(x, jnp.int8, dim=-1)
+    dequantized = x_q.astype(jnp.float32) * scale
+
+    assert _max_abs_err_in_lsb(x, dequantized, scale) <= 0.5 + 1e-4
+    shrinkage = float((jnp.abs(dequantized) - jnp.abs(x)).mean())
+    assert abs(shrinkage) < 1e-4, f"systematic magnitude bias: {shrinkage:.3e}"
+
+
+def test_int8_quantizers_agree_with_kernel_quantizer():
+    """quantize_tensor/_simple must produce the same codes as util.quantize_block."""
+    x = jax.random.normal(jax.random.PRNGKey(2), (256, 512), jnp.float32)
+
+    expected, _ = blockwise_quant_util.quantize_block(x, axis=-1, target_dtype=jnp.int8)
+
+    w_q, _ = quantize_tensor(dtype=jnp.int8, tensor=x, axis=-1)
+    np.testing.assert_array_equal(np.asarray(w_q), np.asarray(expected))
+
+    x_q, _ = quantize_tensor_simple(x, jnp.int8, dim=-1)
+    np.testing.assert_array_equal(np.asarray(x_q), np.asarray(expected))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float8_e4m3fn, jnp.float8_e5m2])
+def test_float8_quantization_is_not_rounded_twice(dtype):
+    """Float targets round in the cast; the integer guard must leave them alone."""
+    x = jax.random.normal(jax.random.PRNGKey(3), (128, 256), jnp.float32)
+
+    expected, _ = blockwise_quant_util.quantize_block(x, axis=-1, target_dtype=dtype)
+    x_q, _ = quantize_tensor(dtype=dtype, tensor=x, axis=-1)
+
+    np.testing.assert_array_equal(
+        np.asarray(x_q).view(np.uint8), np.asarray(expected).view(np.uint8)
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`quantize_tensor()` and `quantize_tensor_simple()` scale the input and then cast straight to the target dtype. For integer targets that cast truncates toward zero, so every int8 code is biased toward zero by up to 1 LSB instead of ±0.5 — half of all codes come out one step low, and the dequantized tensor is systematically smaller in magnitude than the original.

`quantized_matmul_kernels/util.py:quantize_block()` already gets this right: it branches on dtype and calls `jnp.round()` only for integers, since `float->float8` rounds in the cast itself. 

## Modifications

Added a `jnp.issubdtype(dtype, jnp.integer)`-guarded `jnp.round()` before the clip in both quantizers, matching the existing shape of `util.py:308`. Float targets are untouched.

Both quantizers are on the serving path:

| | weights (load time) | activations (per step) |
|---|---|---|
| per-channel | `quantize_tensor`, `linear.py:419` | `quantize_tensor_simple`, `kernel.py:110` |
| block-wise | `quantize_tensor`, `linear.py:401` | `quantize_block` — already correct |

plus `moe.py:388-400,682`, `fused_moe.py:316-348,408-418` and `megablox_gmm_backend.py:79`.

All four shipped int8 configs quantize weights on the fly (`is_static_checkpoint: false`), so all four take this path. Static FP8 checkpoints are unaffected — their weights are quantized offline and fp8 activations round in the cast — which is probably why this went unnoticed.

## Accuracy Tests

CPU, `quantize_block()` as the reference, per-channel int8 over a 512x512 gaussian:

| | truncate (current) | round (this PR) |
|---|---|---|
| codes differing from reference | 49.8% | 0 |
| reconstruction RMS error | 1.485e-02 | 7.425e-03 |
| `\|\|W_hat\|\| / \|\|W\|\|` | 0.9880 | 1.0001 |
| W8A8 matmul relative error | 2.511e-02 | 1.042e-02 |

The 2x factor is the expected one: truncation error is uniform on [0, 1) LSB (RMS `1/sqrt(3)`), round-to-nearest is uniform on [-0.5, 0.5] (RMS `1/(2*sqrt(3))`). It holds at 1.99x across per-tensor / per-channel / block-wise-128 and across Qwen3-32B and DeepSeek-V3 weight shapes. `float8_e4m3fn` output is bit-identical before and after.

Four new cases in `quantized_linear_test.py`, all CPU-runnable and already registered in `unit-test-tpu-v6e-1`:

- `test_quantize_tensor_int8_rounds_to_nearest` — error within 0.5 LSB, no magnitude bias
- `test_quantize_tensor_simple_int8_rounds_to_nearest` — same for the activation quantizer
- `test_int8_quantizers_agree_with_kernel_quantizer` — codes match `quantize_block()` exactly
- `test_float8_quantization_is_not_rounded_twice` — guard so the integer-only branch can't be dropped later

The three int8 cases fail on main (max error 1.0 LSB). No existing test regresses: the same pre-existing failures (Pallas needs interpret mode on CPU) occur with and without the patch — 22 passed before, 27 after.

Existing coverage could not catch this. The only kernel-level numerical test passes `quantize_activation=False` (`quantized_linear_test.py:146`) and all three e2e quantization suites use configs with `activation_dtype: null`, so `quantize_tensor_simple` had no test at all; `int8_w8a8.yaml`, the one config that turns activation quant on, is referenced only from docs. On the weight side `_assert_close` allows `rel_error < 0.05`, wide enough to absorb a 2x error. Happy to tighten that tolerance in a follow-up.

## Benchmarking and Profiling

No meaningful cost. Weight quantization runs once at load. On the activation path this adds a single elementwise `jnp.round` per quantized matmul, fused into the surrounding elementwise chain; fp8 paths — the ones used by the shipped production configs — take the guarded branch and are unchanged.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.

Test command:

```
python -m pytest python/sgl_jax/test/kernels/quantized_linear_test.py -q -k "rounds_to_nearest or agree_with_kernel or rounded_twice"
```
