### PR TITLE
perf(ling3): improve long-context agent serving

### DIFF
--- a/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/tuned_tile_sizes.py
+++ b/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/tuned_tile_sizes.py
@@ -10,6 +10,9 @@ from sgl_jax.srt.utils.jax_utils import get_device_name
 # Values are (tile_m, tile_k, tile_n).
 TUNED_TILE_SIZES_GMM_V2 = {
     "TPU v7": {
+        # Ling-3.0-tiny replicated EPMoE, decode BS=1 hot wi shape.
+        # Measured kernel latency: 0.555ms -> 0.382ms (31.1% lower).
+        ("bfloat16", "bfloat16", 128, 32, 1536, 512): (32, 768, 512),
         # Ling-3.0-tiny replicated EPMoE, 2K balanced prefill hot shapes.
         ("bfloat16", "bfloat16", 128, 2048, 1536, 512): (32, 1536, 512),
         ("bfloat16", "bfloat16", 128, 2048, 512, 1536): (32, 512, 1536),

--- a/python/sgl_jax/srt/kernels/mla/v2/tuned_block_sizes.py
+++ b/python/sgl_jax/srt/kernels/mla/v2/tuned_block_sizes.py
@@ -147,6 +147,18 @@ TUNED_BLOCK_SIZES_MLA: dict[str, dict[tuple, tuple]] = {
         ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 256, 1024): (8, 256),
         ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 256, 2048): (8, 256),
         ("mixed", "bfloat16", "bfloat16", 8, 512, 64, 256, 4096): (8, 256),
+        # ===== Ling-3.0-Tiny (16 q-heads, TP8/DP8 → attention TP=1, page=256) =====
+        # The table key does not include actual KV length, so these are minimax
+        # choices that beat the fallback at both KV=2048 and KV=8192. Kernel
+        # latency reductions versus mixed=(1,16):
+        #   mnt=64:  (16,32), 13.5% / 25.3%
+        #   mnt=128: (8,16),  31.5% / 33.3%
+        #   mnt=256: (4,64),  35.3% / 35.4%
+        # Decode winners changed with KV length (or stayed below 10%), so no
+        # Ling-3 decode entries are installed from this sweep.
+        ("mixed", "bfloat16", "bfloat16", 16, 512, 64, 256, 64): (16, 32),
+        ("mixed", "bfloat16", "bfloat16", 16, 512, 64, 256, 128): (8, 16),
+        ("mixed", "bfloat16", "bfloat16", 16, 512, 64, 256, 256): (4, 64),
         # ===== DeepSeek-V3 671B (num_q_heads=128 → 16/shard, kv_lora=512,
         # page=128). decode reuses v6e sweep; mixed bq capped at 128 — v7x
         # scoped VMEM limit is 57.6M (< v6e), bq=256 OOMs by 3.6M at mnt≥256.

--- a/python/sgl_jax/srt/managers/dp_schedule_policy.py
+++ b/python/sgl_jax/srt/managers/dp_schedule_policy.py
@@ -119,17 +119,23 @@ def pick_force_cache_aware_dp(
 ) -> int | None:
     """Strict cache affinity with shape-aware miss fallback.
 
-    Prefer the longest cached prefix among eligible ranks regardless of load,
-    breaking equal-prefix ties by ``(running, tokens, rank)``. Fall back to
-    shape-aware scheduling only when no eligible rank has a reusable prefix.
+    Prefer the globally longest cached prefix regardless of load, breaking
+    equal-prefix ties by ``(running, tokens, rank)``. If every rank holding that
+    prefix is temporarily admission-ineligible, defer instead of spilling to a
+    shorter hit or miss. Fall back to shape-aware scheduling only on a complete
+    cache miss.
     """
     if not eligible:
         return None
 
     if prompt_len > 0:
-        best_match = max(matches.get(r, 0) for r in eligible)
+        # ``matches`` includes admission-ineligible ranks. Preserving affinity
+        # requires comparing eligible ranks against the global best match.
+        best_match = max(matches.values(), default=0)
         if best_match > 0:
             best_holders = [r for r in eligible if matches.get(r, 0) == best_match]
+            if not best_holders:
+                return None
             return min(best_holders, key=lambda r: (counts[r], token_counts[r], r))
 
     return pick_shape_aware_dp(eligible, input_counts, output_counts, item_input, item_output)

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -959,9 +959,9 @@ class Scheduler(
         """Route ``req`` by the configured cache policy with shape-aware fallback.
 
         ``cache_aware`` keeps its soft affinity/load tradeoff;
-        ``force_cache_aware`` always prefers the longest eligible cache hit.
-        Both use shape-aware selection on a full miss and return None if all DP
-        ranks are full.
+        ``force_cache_aware`` always prefers the globally longest cache hit and
+        defers if all of its holders are temporarily full. Both use shape-aware
+        selection on a full miss and return None if all DP ranks are full.
         """
         if self.dp_size == 1:
             return 0
@@ -976,7 +976,10 @@ class Scheduler(
         matches: dict[int, int] = {}
         prompt_len = len(token_ids) if token_ids else 0
         if token_ids:
-            for dp_rank in eligible:
+            probe_ranks = (
+                range(self.dp_size) if self.dp_schedule_policy == "force_cache_aware" else eligible
+            )
+            for dp_rank in probe_ranks:
                 matches[dp_rank] = self._cached_prefix_len(token_ids, extra_key, dp_rank)
 
         running_input, running_output = self._get_dp_io_snapshot()

--- a/test/srt/test_dp_schedule_policy.py
+++ b/test/srt/test_dp_schedule_policy.py
@@ -189,11 +189,18 @@ def test_force_cache_aware_full_miss_falls_back_to_shape_aware():
     )
 
 
-def test_force_cache_aware_considers_only_eligible_matches():
+def test_force_cache_aware_defers_for_ineligible_longest_holder():
     counts = [8, 0]
     tokens = [800, 0]
     matches = {0: 1024, 1: 512}
-    assert _pick([1], counts, tokens, matches, prompt_len=1200, picker=force_pick) == 1
+    assert _pick([1], counts, tokens, matches, prompt_len=1200, picker=force_pick) is None
+
+
+def test_force_cache_aware_defers_when_only_holder_is_ineligible():
+    counts = [8, 0]
+    tokens = [800, 0]
+    matches = {0: 1024, 1: 0}
+    assert _pick([1], counts, tokens, matches, prompt_len=1200, picker=force_pick) is None
 
 
 def _req(


### PR DESCRIPTION
## Motivation

Follow up on #1565 after the Ling-3 model, replicated MoE, and forced cache-aware scheduling changes landed on `main`.

Long-context agent traffic repeatedly extends a mostly stable conversation prefix. Under saturation, the current `force_cache_aware` implementation only probes admission-eligible DP ranks, so it can spill a request away from the rank holding its longest prefix and recompute the context. Ling-3 also has stable TPU v7 MLA mixed-prefill and small-M GMM hot shapes that benefit from targeted tuning.

This PR ports only the runtime changes selected from https://github.com/primatrix/sglang-jax/pull/340 and follow-up measurements. It does not add tuner, benchmark, or standalone tuning-table lookup test files.

**Current PR diff:** 5 files, 41 insertions, and 10 deletions. It contains no precompile/bucket code, tuner or benchmark scripts, or standalone table-hit tests.

## Modifications

- Make `force_cache_aware` compare cache matches across all DP ranks. If the global longest-prefix holder is temporarily admission-ineligible, defer the request instead of spilling it to a shorter hit or a cache miss.
- Keep the existing soft `cache_aware` policy and full-miss shape-aware fallback unchanged.
- Add TPU v7 Ling-3.0-Tiny MLA mixed-prefill block sizes selected across KV lengths 2K and 8K.
- Add the TPU v7 replicated-EPMoE GMM tile for the decode BS=1 `wi` hot shape.
- Add two focused assertions for the new scheduling behavior.

## Accuracy Tests

- A 4-turn Ling-3.0-Tiny agent workload completed with a 100% request/quality pass rate and 100% later-turn prefix-cache hit rate.
- The kernel changes only select block/tile sizes for exact TPU v7 shapes; algorithms and dtypes are unchanged. Other devices and shapes retain the existing fallback.
- Local focused tests:

```bash
PYTHONPATH=python python3 -m pytest -q \
  test/srt/test_dp_rank_assignment.py \
  test/srt/test_dp_schedule_policy.py \
  test/srt/test_dp_schedule_shape_aware.py
```

Result: `45 passed`.

## Benchmarking and Profiling

Hardware and model used for the measurements:

- one TPU v7x-8 slice
- `inclusionAI/Ling-3.0-Tiny` at revision `b61f4338de3e68ffc9c0bc1ed5e902981a4a929e`
- JAX/JAXlib 0.11.1 and libtpu 0.0.46
- TP8 / attention DP8 / MoE DP8 / EP1, BF16

### Server command

Prepare the same model revision once:

```bash
export MODEL_DIR=/models/Ling-3.0-Tiny

hf download inclusionAI/Ling-3.0-Tiny \
  --revision b61f4338de3e68ffc9c0bc1ed5e902981a4a929e \
  --local-dir "$MODEL_DIR"
```

Start the server from the repository root. The precompile flags below are existing `main` runtime settings from the measured configuration; this PR does not add or change them.

```bash
export MODEL_DIR=/models/Ling-3.0-Tiny
export PYTHONPATH="$PWD/python${PYTHONPATH:+:$PYTHONPATH}"

JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache \
python3 -u -m sgl_jax.launch_server \
  --model-path "$MODEL_DIR" \
  --served-model-name ling3-tiny \
  --trust-remote-code \
  --reasoning-parser ling3 \
  --tool-call-parser ling3 \
  --device tpu \
  --dtype bfloat16 \
  --tp-size 8 \
  --dp-size 8 \
  --moe-dp-size 8 \
  --ep-size 1 \
  --moe-backend epmoe \
  --attention-backend fa \
  --dp-schedule-policy force_cache_aware \
  --enable-cache-report \
  --enable-unified-radix-tree \
  --enable-recurrent-extra-buffer \
  --page-size 256 \
  --max-prefill-tokens 16384 \
  --chunked-prefill-size 2048 \
  --recurrent-track-interval 1024 \
  --max-recurrent-state-size 256 \
  --max-running-requests 64 \
  --precompile-bs-paddings 8 16 24 32 40 48 56 64 \
  --precompile-token-paddings 512 1024 1536 2048 \
  --mem-fraction-static 0.9 \
  --random-seed 42 \
  --host 0.0.0.0 \
  --port 30000
```

Overlap scheduling stays enabled. Do not pass `--disable-overlap-schedule` or a serving-side `--context-length` override.

### Long-context multi-turn workload

The existing `generated-shared-prefix` dataset exercises the intended public scenario without another benchmark script:

```bash
python3 -m sgl_jax.bench_serving \
  --backend sglang-oai-chat \
  --base-url http://127.0.0.1:30000 \
  --model "$MODEL_DIR" \
  --served-model-name ling3-tiny \
  --dataset-name generated-shared-prefix \
  --gsp-num-groups 8 \
  --gsp-prompts-per-group 8 \
  --gsp-system-prompt-len 8192 \
  --gsp-question-len 256 \
  --gsp-output-len 512 \
  --gsp-num-turns 4 \
  --gsp-range-ratio 1 \
  --max-concurrency 64 \
  --request-rate 1000000 \
  --warmup-requests 8 \
  --flush-cache \
  --seed 42 \
  --output-file /tmp/ling3-agent-c64.jsonl
```

In the saturated shuffled-prefix validation, the cache hit rate increased from 90.625% to 100%. Throughput increased from 88.82 req/s to 124.20-138.56 req/s across two candidate runs (+40%-56%). This gain is specific to repeated-prefix traffic; it is not expected for random prompts.

### Random serving regression matrix

Run each point three times and compare medians:

```bash
for spec in \
  "8192 8 64 64" \
  "2048 256 128 64" \
  "256 512 128 64" \
  "256 512 64 8"
do
  set -- $spec
  input_len=$1
  output_len=$2
  num_prompts=$3
  concurrency=$4

  for repeat in 1 2 3
  do
    python3 -m sgl_jax.bench_serving \
      --backend sgl-jax \
      --base-url http://127.0.0.1:30000 \
      --model "$MODEL_DIR" \
      --served-model-name ling3-tiny \
      --dataset-name random \
      --num-prompts "$num_prompts" \
      --random-input-len "$input_len" \
      --random-output-len "$output_len" \
      --random-range-ratio 1 \
      --request-rate 1000000 \
      --max-concurrency "$concurrency" \
      --warmup-requests 8 \
      --flush-cache \
      --tokenize-prompt \
      --seed 42 \
      --output-file "/tmp/ling3-random-${input_len}-${output_len}-c${concurrency}-r${repeat}.jsonl"
  done
done
```

Median total throughput stayed neutral on random, no-prefix-reuse traffic:

| Workload | `main` | This PR | Change |
|---|---:|---:|---:|
| 8K input / 8 output, C64 | 125,450.80 tok/s | 127,109.60 tok/s | +1.3% |
| 2K input / 256 output, C64 | 29,855.94 tok/s | 30,115.19 tok/s | +0.9% |
| 256 input / 512 output, C64 | 8,377.87 tok/s | 8,347.25 tok/s | -0.4% |
| 256 input / 512 output, C8 | 1,175.85 tok/s | 1,199.26 tok/s | +2.0% |

### Kernel results

| Hot shape | Selected config | Result vs fallback |
|---|---:|---:|
| MLA mixed MNT=64, KV=2K / 8K | `(16, 32)` | 13.5% / 25.3% lower latency |
| MLA mixed MNT=128, KV=2K / 8K | `(8, 16)` | 31.5% / 33.3% lower latency |
| MLA mixed MNT=256, KV=2K / 8K | `(4, 64)` | 35.3% / 35.4% lower latency |
| GMM decode BS=1 `wi`, M=32 | `(32, 768, 512)` | 0.555 ms to 0.382 ms, 31.1% lower latency |

No Ling-3 MLA decode entries are added because the winners did not generalize across KV=2K and KV=8K.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.

