### PR TITLE
fix: restore public CI sharding and NNX compatibility

### DIFF
--- a/python/sgl_jax/srt/multimodal/layers/rotary_embedding.py
+++ b/python/sgl_jax/srt/multimodal/layers/rotary_embedding.py
@@ -79,7 +79,7 @@ class NDRotaryEmbedding(nnx.Module):
         else:
             self.interpolation_factor = interpolation_factor
 
-        self.rope_generators = []
+        self.rope_generators = nnx.List([])
         for i in range(self.ndim):
             self.rope_generators.append(
                 OneDRotaryEmbedding(

--- a/python/sgl_jax/srt/multimodal/models/dits/flux.py
+++ b/python/sgl_jax/srt/multimodal/models/dits/flux.py
@@ -60,6 +60,14 @@ def _sdpa_attention(
     k = key.astype(jnp.float32)
     v = value.astype(jnp.float32)
 
+    if query.shape[0] == 1:
+        sharding = jax.typeof(q).sharding
+        if isinstance(sharding, NamedSharding) and not sharding.mesh.empty:
+            # JAX's grouped-query reshape drops the singleton batch sharding
+            # from Q. Match K/V at the boundary while preserving head sharding.
+            sharding = NamedSharding(sharding.mesh, P(None, *sharding.spec[1:]))
+            q, k, v = (jax.sharding.reshard(x, sharding) for x in (q, k, v))
+
     output = jax.nn.dot_product_attention(
         q,
         k,

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -637,10 +637,16 @@ def _reshape_per_dp_rows(values, dp_size: int):
 def _per_dp_cumsum_device(lens, dp_size: int):
     per_dp_bs = lens.shape[0] // dp_size
     lens_2d = _reshape_per_dp_rows(lens, dp_size)
+    rows_sharding = jax.typeof(lens_2d).sharding
     zeros = jnp.zeros_like(lens_2d[:, :1], dtype=jnp.int32)
-    result = jnp.concatenate([zeros, jnp.cumsum(lens_2d, axis=1, dtype=jnp.int32)], axis=1).reshape(
-        (dp_size * (per_dp_bs + 1),)
-    )
+    cumsum = jnp.cumsum(lens_2d, axis=1, dtype=jnp.int32)
+    if isinstance(rows_sharding, NamedSharding) and not rows_sharding.mesh.empty:
+        # Explicit-sharding JAX requires concatenate operands to carry the same
+        # sharding. zeros_like may otherwise infer replicated sharding even
+        # though lens_2d and its cumulative sum are data-sharded.
+        zeros = jax.sharding.reshard(zeros, rows_sharding)
+        cumsum = jax.sharding.reshard(cumsum, rows_sharding)
+    result = jnp.concatenate([zeros, cumsum], axis=1).reshape((dp_size * (per_dp_bs + 1),))
     sharding = jax.typeof(lens).sharding
     if isinstance(sharding, NamedSharding) and not sharding.mesh.empty:
         result = jax.sharding.reshard(result, sharding)

--- a/python/sgl_jax/test/layers/test_lightning_backend.py
+++ b/python/sgl_jax/test/layers/test_lightning_backend.py
@@ -324,7 +324,9 @@ def _run_backend_decode(B, H, K, dtype, h0, rng_seed, layer_id=_LAYER_ID):
 
     # Reference
     scale = K**-0.5
-    out_ref, state_ref = naive_gla_decode(q, k, v, g_gamma, h0, scale=scale)
+    # Match the replicated Q/K/V without changing the backend state carried across calls.
+    h0_ref = _put(h0)
+    out_ref, state_ref = naive_gla_decode(q, k, v, g_gamma, h0_ref, scale=scale)
     out_ref = out_ref.reshape(B, -1)
 
     return out_backend, state_backend, out_ref, state_ref, pool, pu

--- a/python/sgl_jax/test/multimodal/test_flux_attention.py
+++ b/python/sgl_jax/test/multimodal/test_flux_attention.py
@@ -1,0 +1,73 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.sharding import AxisType, Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.multimodal.layers.rotary_embedding import NDRotaryEmbedding
+from sgl_jax.srt.multimodal.models.dits.flux import FluxAttention, _sdpa_attention
+
+
+def _mesh(dp, tp):
+    if jax.device_count() < dp * tp:
+        pytest.skip(f"requires {dp * tp} devices")
+    return Mesh(
+        np.asarray(jax.devices()[: dp * tp]).reshape(dp, tp),
+        ("data", "tensor"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit),
+    )
+
+
+@pytest.mark.parametrize("dp,tp,batch", [(1, 1, 1), (1, 4, 1), (1, 4, 2), (2, 2, 2)])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.bfloat16])
+@pytest.mark.parametrize("causal,scale", [(False, None), (True, 0.25)])
+def test_sdpa_preserves_values_and_nontrivial_sharding(dp, tp, batch, dtype, causal, scale):
+    mesh = _mesh(dp, tp)
+    rng = np.random.default_rng(42)
+    sharding = NamedSharding(mesh, P("data", None, "tensor", None))
+    with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
+        q, k, v = [
+            jax.device_put(jnp.asarray(rng.normal(size=(batch, 8, 4, 8)), dtype), sharding)
+            for _ in range(3)
+        ]
+        output = jax.jit(lambda q, k, v: _sdpa_attention(q, k, v, causal, scale))(q, k, v)
+
+    # Full matmul precision makes this dense reference comparable on CPU and TPU.
+    # Preserve the softmax scale, causal mask and dtype.
+    q_np, k_np, v_np = [np.asarray(x, np.float32) for x in (q, k, v)]
+    scores = np.einsum("bthd,bshd->bhts", q_np, k_np) * (8**-0.5 if scale is None else scale)
+    if causal:
+        scores = np.where(np.tril(np.ones((8, 8), dtype=bool)), scores, -np.inf)
+    probs = np.exp(scores - scores.max(axis=-1, keepdims=True))
+    probs /= probs.sum(axis=-1, keepdims=True)
+    expected = np.einsum("bhts,bshd->bthd", probs, v_np)
+    expected = np.asarray(jnp.asarray(expected, dtype), np.float32)
+    np.testing.assert_allclose(np.asarray(output, np.float32), expected, atol=2e-6, rtol=2e-5)
+    assert output.dtype == dtype
+    assert output.sharding.spec == P(None if batch == 1 else "data", None, "tensor", None)
+    for operand in (q, k, v):
+        assert operand.sharding == sharding
+
+
+def test_flux_single_device_fallback_with_rotary_matches_batched_execution():
+    mesh = _mesh(1, 1)
+    with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
+        attention = FluxAttention(
+            query_dim=32, heads=4, dim_head=8, attention_impl="usp", mesh=mesh, pre_only=True
+        )
+        rope = NDRotaryEmbedding([2, 2, 4], 10000, use_real=True, repeat_interleave_real=True)
+        positions = jnp.arange(24, dtype=jnp.float32).reshape(8, 3)
+        rotary = rope(positions)
+        hidden = jax.device_put(
+            np.random.default_rng(0).normal(size=(1, 8, 32)).astype(np.float32),
+            NamedSharding(mesh, P()),
+        )
+        output = jax.jit(lambda x: attention(x, image_rotary_emb=rotary))(hidden)
+        # Duplicating the sample avoids a singleton batch while keeping the
+        # same weights and rotary values. The first sample must be unchanged.
+        expected = jax.jit(lambda x: attention(x, image_rotary_emb=rotary))(
+            jnp.repeat(hidden, 2, axis=0)
+        )[:1]
+    np.testing.assert_allclose(output, expected, atol=1e-5, rtol=1e-5)
+    assert output.shape == (1, 8, 32)

--- a/python/sgl_jax/test/multimodal/test_rotary_embedding.py
+++ b/python/sgl_jax/test/multimodal/test_rotary_embedding.py
@@ -1,0 +1,71 @@
+import unittest
+
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+
+from sgl_jax.srt.multimodal.layers.rotary_embedding import NDRotaryEmbedding
+
+
+class TestNDRotaryEmbedding(unittest.TestCase):
+    def test_wan_construction_and_eval_shape(self):
+        # Wan's 128-dimensional attention heads split over time, height, width.
+        kwargs = dict(rope_dim_list=[44, 42, 42], rope_theta=10000)
+        for construct in (NDRotaryEmbedding, nnx.eval_shape):
+            with self.subTest(construct=construct.__name__):
+                if construct is nnx.eval_shape:
+                    rope = construct(lambda: NDRotaryEmbedding(**kwargs))
+                else:
+                    rope = construct(**kwargs)
+                cos, sin = rope.forward_from_grid((2, 3, 4))
+                self.assertEqual(cos.shape, (24, 64))
+                self.assertEqual(sin.shape, (24, 64))
+
+    def test_wan_grid_matches_rotary_formula_with_frame_offset(self):
+        dims = [44, 42, 42]
+        rope = NDRotaryEmbedding(rope_dim_list=dims, rope_theta=10000)
+        cos, sin = rope.forward_from_grid((2, 3, 4), start_frame=5)
+        positions = np.stack(
+            np.meshgrid(np.arange(5, 7), np.arange(3), np.arange(4), indexing="ij"),
+            axis=-1,
+        ).reshape(-1, 3)
+        angles = np.concatenate(
+            [
+                positions[:, axis, None] * 10000.0 ** (-np.arange(0, dim, 2) / dim)
+                for axis, dim in enumerate(dims)
+            ],
+            axis=-1,
+        )
+        np.testing.assert_allclose(cos, np.cos(angles), atol=1e-6, rtol=1e-6)
+        np.testing.assert_allclose(sin, np.sin(angles), atol=1e-6, rtol=1e-6)
+
+    def test_explicit_positions_preserve_axis_factors_and_real_repetition(self):
+        dims = [4, 6, 8]
+        rescale = [1.0, 2.0, 3.0]
+        interpolation = [0.5, 1.0, 2.0]
+        positions = np.array([[0, 1, 2], [3, 2, 1]], dtype=np.float32)
+        # FLUX requests real embeddings with each frequency repeated twice.
+        rope = NDRotaryEmbedding(
+            rope_dim_list=dims,
+            rope_theta=10000,
+            theta_rescale_factor=rescale,
+            interpolation_factor=interpolation,
+            use_real=True,
+            repeat_interleave_real=True,
+        )
+        cos, sin = rope(jnp.asarray(positions))
+        angles = np.concatenate(
+            [
+                positions[:, axis, None]
+                * interpolation[axis]
+                * (10000 * rescale[axis] ** (dim / (dim - 2))) ** (-np.arange(0, dim, 2) / dim)
+                for axis, dim in enumerate(dims)
+            ],
+            axis=-1,
+        )
+        np.testing.assert_allclose(cos, np.repeat(np.cos(angles), 2, axis=-1), atol=1e-6)
+        np.testing.assert_allclose(sin, np.repeat(np.sin(angles), 2, axis=-1), atol=1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sgl_jax/test/speculative/test_draft_extend_fused.py
+++ b/python/sgl_jax/test/speculative/test_draft_extend_fused.py
@@ -1,0 +1,94 @@
+from functools import partial
+
+import jax
+import numpy as np
+import pytest
+from jax.sharding import AxisType, Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.layers.attention.flashattention_backend import FlashAttentionMetadata
+from sgl_jax.srt.speculative.draft_extend_fused import (
+    _make_draft_extend_metadata,
+    _make_target_verify_metadata,
+    _per_dp_cumsum_device,
+)
+
+
+def _explicit_mesh(dp_size):
+    if jax.device_count() < dp_size:
+        pytest.skip(f"requires {dp_size} devices")
+    return Mesh(
+        np.asarray(jax.devices()).reshape(dp_size, -1),
+        ("data", "tensor"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit),
+    )
+
+
+@pytest.mark.parametrize("use_jit", [False, True])
+@pytest.mark.parametrize(
+    "dp_size,lens,expected",
+    [
+        (1, [4, 0], [0, 4, 4]),
+        (2, [4, 0, 2, 3], [0, 4, 4, 0, 2, 5]),
+        (2, [0, 0, 2, 0], [0, 0, 0, 0, 2, 2]),
+    ],
+)
+def test_per_dp_cumsum_preserves_rank_boundaries_and_sharding(dp_size, lens, expected, use_jit):
+    mesh = _explicit_mesh(dp_size)
+    sharding = NamedSharding(mesh, P("data"))
+    cumsum = partial(_per_dp_cumsum_device, dp_size=dp_size)
+    if use_jit:
+        cumsum = jax.jit(cumsum)
+
+    with jax.set_mesh(mesh):
+        values = jax.device_put(np.asarray(lens, dtype=np.int32), sharding)
+        result = cumsum(values)
+
+    # Each rank starts at zero; padding must not consume query/KV offsets.
+    np.testing.assert_array_equal(np.asarray(result), expected)
+    assert result.dtype == np.int32
+    assert result.sharding == sharding
+
+
+@pytest.mark.parametrize("dp_size", [1, 2])
+@pytest.mark.parametrize("target_verify", [False, True])
+def test_fused_metadata_builds_sharded_query_and_kv_offsets(dp_size, target_verify):
+    mesh = _explicit_mesh(dp_size)
+    sharding = NamedSharding(mesh, P("data"))
+
+    with jax.set_mesh(mesh):
+        seq_lens = jax.device_put(np.asarray([5, 0, 3, 0][: dp_size * 2], np.int32), sharding)
+        query_lens = jax.device_put(np.asarray([2, 0, 1, 0][: dp_size * 2], np.int32), sharding)
+        allocated_lens = jax.device_put(np.asarray([8, 0, 4, 0][: dp_size * 2], np.int32), sharding)
+        pages = jax.device_put(
+            np.asarray([10, 11, 0, 0, 20, 0, 0, 0][: dp_size * 4], np.int32), sharding
+        )
+        old_metadata = FlashAttentionMetadata(page_indices=pages)
+        if target_verify:
+            make_metadata = jax.jit(
+                partial(
+                    _make_target_verify_metadata,
+                    speculative_num_draft_tokens=2,
+                    page_size=4,
+                    dp_size=dp_size,
+                )
+            )
+            verify_lens = jax.device_put(
+                np.asarray([3, 0, 1, 0][: dp_size * 2], np.int32), sharding
+            )
+            result = make_metadata(old_metadata, verify_lens, allocated_lens)
+        else:
+            make_metadata = jax.jit(
+                partial(_make_draft_extend_metadata, page_size=4, dp_size=dp_size)
+            )
+            result = make_metadata(old_metadata, seq_lens, allocated_lens, query_lens=query_lens)
+
+    # Exercise fused EAGLE3 callers with padded slots and page-aligned KV lengths.
+    expected_cu_q = [0, 2, 2, 0, 2, 2] if target_verify else [0, 2, 2, 0, 1, 1]
+    np.testing.assert_array_equal(np.asarray(result.cu_q_lens), expected_cu_q[: dp_size * 3])
+    np.testing.assert_array_equal(np.asarray(result.cu_kv_lens), [0, 8, 8, 0, 4, 4][: dp_size * 3])
+    np.testing.assert_array_equal(np.asarray(result.seq_lens), np.asarray(seq_lens))
+    np.testing.assert_array_equal(np.asarray(result.page_indices), np.asarray(pages))
+    np.testing.assert_array_equal(np.asarray(result.distribution), [0, 1, 1] * dp_size)
+    for value in jax.tree.leaves(result):
+        assert value.sharding == sharding

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -312,6 +312,7 @@ suites = {
             0.1,
             runner="pytest",
         ),
+        TestFile("python/sgl_jax/test/multimodal/test_rotary_embedding.py", 0.1),
         TestFile("test/srt/test_radix_input_ids.py", 0.1, runner="pytest"),
         TestFile("test/srt/test_tokenizer_manager_event.py", 0.1),
         TestFile("test/srt/disaggregation/test_pd_auth.py", 0.3, runner="pytest"),
@@ -447,6 +448,11 @@ suites = {
         TestFile("test/srt/test_native_attention_paged_decode.py", 1),
     ],
     "unit-test-tpu-v6e-4": [
+        TestFile(
+            "python/sgl_jax/test/speculative/test_draft_extend_fused.py",
+            0.1,
+            runner="pytest",
+        ),
         TestFile(
             "test/srt/multimodal/test_in_model_multimodal.py",
             1,

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -449,6 +449,11 @@ suites = {
     ],
     "unit-test-tpu-v6e-4": [
         TestFile(
+            "python/sgl_jax/test/multimodal/test_flux_attention.py",
+            0.1,
+            runner="pytest",
+        ),
+        TestFile(
             "python/sgl_jax/test/speculative/test_draft_extend_fused.py",
             0.1,
             runner="pytest",


### PR DESCRIPTION
## Motivation

Restore public CI compatibility with JAX 0.11.1 / Flax 0.12.9 in Lightning continuous-state references, EAGLE3 metadata precompilation, Wan2.1 initialization, and FLUX SDPA precompilation. This does not claim that the dependency upgrade first introduced every defect.

## Modifications

- Replicate only the Lightning test reference's incoming state to match its Q/K/V. Preserve the backend's sharded state, continuous decode chain, and numerical assertions.
- Align per-DP prefix-sum operands before concatenation. Extract only the targeted helper fix from #1594; no DFlash feature changes.
- Store rotary child modules in `nnx.List`, following the existing NNX container convention.
- Normalize the singleton batch dimension of FLUX SDPA inputs before JAX's grouped-query reshape drops that annotation from Q alone. Preserve head sharding and non-singleton DP layouts.
- Register regressions for numerical values, layouts, padding, metadata callers, RoPE construction, and real FLUX attention with RoPE in the CPU/4-TPU suites.

## Accuracy Tests

Local Python 3.12.12, JAX/jaxlib 0.11.1, Flax 0.12.9, four logical CPU devices:

```bash
USE_DEVICE_TYPE=cpu JAX_PLATFORMS=cpu JAX_NUM_CPU_DEVICES=4 \
  python -m pytest -q \
  python/sgl_jax/test/multimodal/test_flux_attention.py \
  python/sgl_jax/test/multimodal/test_rotary_embedding.py \
  python/sgl_jax/test/speculative/test_draft_extend_fused.py \
  python/sgl_jax/test/layers/test_lightning_backend.py::TestSlopeFormula
# 31 passed (+ 2 subtests)
```

The new FLUX tests produced **9 expected sharding failures / 8 passes before the fix**, then **17 passes**. They cover DP1/TP1, DP1/TP4, DP2/TP2, singleton/non-singleton batches, float32/bfloat16, causal masking, custom scaling, and a real single-device USP-to-SDPA fallback with RoPE. Independent NumPy comparisons use highest matmul precision in tests only. No-mesh eager/JIT smoke checks also pass.

Earlier local validation: cumsum and rotary regressions reproduced their original errors before the fixes; 19 adjacent speculative tests passed on one CPU. Lightning's reference-only recurrence matched independent NumPy calculations over 3 and 32 steps; a small real Wan model's `nnx.eval_shape` passed. The existing `test_wan2_1_dit.py` separately fails on an obsolete `rngs` constructor argument and is unchanged.

**Hardware evidence applies to the preceding commit `ae1b135e`:** [CI run 34010139430](https://github.com/sgl-project/sglang-jax/actions/runs/34010139430) passed CPU/1-TPU/4-TPU unit tests, 1/4-TPU accuracy tests, and both Wan2.1 e2e cases. Its remaining failure was FLUX SDPA in `e2e-test-4-tpu (1)`, addressed by this follow-up. Performance jobs were skipped after that failure.

**CI for the updated head is pending; prior hardware results are not claimed for the FLUX follow-up.** All applicable local pre-commit hooks passed.

## Benchmarking and Profiling

Not run. No kernel algorithm or model mathematics changes; runtime edits declare existing sharding/container intent.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
