### PR TITLE
fix(build): align Raiden build with JAX 0.11.1

### DIFF
--- a/scripts/disaggregation/build_raiden_wheel.sh
+++ b/scripts/disaggregation/build_raiden_wheel.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-: "${RAIDEN_SRC:?set RAIDEN_SRC to a tpu-raiden checkout}"
+: "${RAIDEN_SRC:?set RAIDEN_SRC to a tpu-sync checkout}"
 : "${RAIDEN_CACHE_ROOT:?set RAIDEN_CACHE_ROOT to a persistent cache directory}"
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PATCH="$SCRIPT_DIR/patches/tpu-sync/jax-0.11.1.patch"
 PYTHON_BIN=${PYTHON_BIN:-python3.12}
-JAX_VERSION=${JAX_VERSION:-0.10.2}
-JAXLIB_VERSION=${JAXLIB_VERSION:-${JAX_VERSION}}
-LIBTPU_VERSION=${LIBTPU_VERSION:-0.0.42.1}
-RAIDEN_COMMIT=${RAIDEN_COMMIT:-$(git -C "${RAIDEN_SRC}" rev-parse HEAD)}
+JAX_VERSION=0.11.1
+JAXLIB_VERSION=0.11.1
+LIBTPU_VERSION=0.0.46.1
+RAIDEN_COMMIT=6d43141191210b73359d22743be619532ad587dc
 CACHE_DIR=${RAIDEN_CACHE_ROOT}/${RAIDEN_COMMIT}-jax${JAX_VERSION}-jaxlib${JAXLIB_VERSION}-libtpu${LIBTPU_VERSION}
+
+test "$(git -C "${RAIDEN_SRC}" rev-parse HEAD)" = "${RAIDEN_COMMIT}"
+if ! git -C "${RAIDEN_SRC}" apply --reverse --check "$PATCH" 2>/dev/null; then
+  git -C "${RAIDEN_SRC}" apply --check "$PATCH"
+  git -C "${RAIDEN_SRC}" apply "$PATCH"
+fi
 
 if [[ -s "${CACHE_DIR}/READY" && -s "${CACHE_DIR}/SHA256SUMS" ]]; then
   (
@@ -20,7 +28,6 @@ if [[ -s "${CACHE_DIR}/READY" && -s "${CACHE_DIR}/SHA256SUMS" ]]; then
   exit 0
 fi
 
-test "$(git -C "${RAIDEN_SRC}" rev-parse HEAD)" = "${RAIDEN_COMMIT}"
 grep -q "jax==${JAX_VERSION}" "${RAIDEN_SRC}/requirements.txt"
 grep -q "jaxlib==${JAXLIB_VERSION}" "${RAIDEN_SRC}/requirements.txt"
 grep -q "libtpu==${LIBTPU_VERSION}" "${RAIDEN_SRC}/requirements.txt"

--- a/scripts/disaggregation/patches/tpu-sync/jax-0.11.1.patch
+++ b/scripts/disaggregation/patches/tpu-sync/jax-0.11.1.patch
@@ -1,0 +1,78 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index caa34b9..182ae52 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -27,3 +27,3 @@ git_override(
+     module_name = "jax",
+-    commit = "a1521744c6dc074443fe549f19f48d7197abf759",
++    commit = "2d66622450e2c8633cda2307688ef7aa294bd6eb",
+     patch_strip = 1,
+@@ -43,3 +43,3 @@ git_override(
+     module_name = "xla",
+-    commit = "131bf41acb4650e4391a640c3f1859c1c86ad74b",
++    commit = "dcf304bc5dca1932b99f740b911dbd73631a1a69",
+     patch_strip = 1,
+diff --git a/ci/wheel/BUILD.bazel b/ci/wheel/BUILD.bazel
+index f3e6bbc..a311f16 100644
+--- a/ci/wheel/BUILD.bazel
++++ b/ci/wheel/BUILD.bazel
+@@ -56,5 +56,5 @@ COMMON_REQUIRES = [
+ JAX_REQUIRES = COMMON_REQUIRES + [
+-    "jax==0.11.0",
+-    "jaxlib==0.11.0",
+-    "libtpu==0.0.47",
++    "jax==0.11.1",
++    "jaxlib==0.11.1",
++    "libtpu==0.0.46.1",
+ ]
+diff --git a/requirements.txt b/requirements.txt
+index a52ff8e..f61ccc6 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -6,5 +6,5 @@ absl-py
+ numpy
+-jax==0.11.0
+-jaxlib==0.11.0
+-libtpu==0.0.47
++jax==0.11.1
++jaxlib==0.11.1
++libtpu==0.0.46.1
+ grpcio-tools
+diff --git a/third_party/py/jax_remove_local_wheels.patch b/third_party/py/jax_remove_local_wheels.patch
+index d586683..e1bdb80 100644
+--- a/third_party/py/jax_remove_local_wheels.patch
++++ b/third_party/py/jax_remove_local_wheels.patch
+@@ -2,5 +2,5 @@
+ +++ b/MODULE.bazel
+-@@ -140,7 +140,7 @@
+- python.toolchain(python_version = "3.14")
+-
++@@ -145,7 +145,7 @@
++ python.toolchain(python_version = "3.15")
++
+  ### Pypi
+@@ -8,6 +8,6 @@
+ +pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+-
++
+  [pip.parse(
+      download_only = True,
+-@@ -149,9 +149,6 @@
++@@ -154,18 +154,6 @@
+          "numpy": ["numpy_headers"],
+@@ -16,3 +16,12 @@
+ -    local_wheels = {
++-        "jax": "dist/jax-*.whl",
++-        "jaxlib": "dist/jaxlib-*.whl",
++-        "jax-cuda12-pjrt": "dist/jax_cuda12_pjrt-*.whl",
++-        "jax-cuda12-plugin": "dist/jax_cuda12_plugin-*.whl",
++-        "jax-cuda13-pjrt": "dist/jax_cuda13_pjrt-*.whl",
++-        "jax-cuda13-plugin": "dist/jax_cuda13_plugin-*.whl",
+ -        "libtpu": "dist/libtpu-*.whl",  # On CI, we use the downloaded nightly version of libtpu.
++-        "ml_dtypes": "dist/ml_dtypes-*.whl",
++-        "numpy": "dist/numpy-*.whl",  # On TSAN CI, we use a custom TSAN-instrumented NumPy wheel.
++-        "scipy": "dist/scipy-*.whl",
+ -    },
+@@ -21,2 +30 @@
+          "3.12",
+-</content>


### PR DESCRIPTION
## Motivation

sglang-jax has upgraded to jaxlib 0.11.1, while TPU Sync at `6d43141191210b73359d22743be619532ad587dc` still pins JAX/XLA sources aligned with jaxlib 0.11.0. Running a wheel built from that revision with jaxlib 0.11.1 produced `MemoryError: std::bad_alloc` or `ValueError: vector::reserve` during KV cache manager creation.

Source and release-binary inspection confirms an ABI mismatch: IFRT's switch from LLVM RTTI to its own implementation removed inherited virtual function slots and changed the `PjRtArray` vtable layout. For example, a `client()` call compiled against the old interface selects `GetReadyFuture()` in the jaxlib 0.11.1 vtable instead. These functions have incompatible calling conventions, which can lead to an invalid allocation size. 

Raiden's native build uses JAX/XLA C++ headers selected by the source commit pins in `MODULE.bazel`; updating the installed Python packages does not update those pins.

As a temporary compatibility fix, this PR repoints Raiden's JAX and XLA build dependencies to the revisions used by JAX 0.11.1, and aligns the Python dependency declarations and wheel metadata with that runtime.

## Modifications

- Pin TPU Sync to `6d43141191210b73359d22743be619532ad587dc` and apply a compatibility patch from the existing wheel build script.
- Align JAX/XLA source revisions and build/wheel dependencies with JAX and jaxlib 0.11.1 and libtpu 0.0.46.1. Refresh TPU Sync's nested JAX patch for the corresponding `MODULE.bazel`.
- Preserve the existing Python 3.12 default, `RAIDEN_SRC` / `RAIDEN_CACHE_ROOT` inputs, versioned cache directory, and wheel / `READY` / `SHA256SUMS` outputs.

This change covers wheel construction and ABI alignment. It does not include migration of sglang-jax's `tpu_raiden` imports to upstream's `tpu_sync` namespace.

## Accuracy Tests

- Passed shell syntax, commit hooks, and diff whitespace checks.
- Verified patch application to the pinned TPU Sync checkout, repeated application detection, and nested patch application to JAX 0.11.1.
- Passed mocked build/cache checks, including cache reuse, checksum corruption, build failure, missing native extensions, and conflicting source changes.

Build command, after checking out the pinned TPU Sync revision and preparing its build dependencies:

```bash
RAIDEN_SRC=/path/to/tpu-sync RAIDEN_CACHE_ROOT=/path/to/cache \
  bash scripts/disaggregation/build_raiden_wheel.sh
```

## Benchmarking and Profiling

Not performed; this PR changes the build configuration and makes no performance claim.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
