### PR TITLE
fix(attention): write back all new KV in RPA v3 sliding-window attention

### DIFF
--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -886,6 +886,17 @@ def _ragged_paged_attention_kernel_loop(
 
         actual_bq_csz = min(bq_csz, actual_bq_sz)
 
+        def get_bkv_start(bq_idx):
+            start = 0
+            if sliding_window is not None:
+                start = jnp.maximum(kv_q_gap + bq_idx * actual_bq_sz - sliding_window, 0) // bkv_sz
+                # Only the last query block writes back KV. It must visit all
+                # new KV blocks, including those outside its attention window.
+                start = lax.select(
+                    bq_idx == num_bq - 1, jnp.minimum(start, kv_q_gap // bkv_sz), start
+                )
+            return start
+
         def get_next_bq_ids(seq_idx, bq_idx, bq_sem_idx):
             next_bq_idx = bq_idx + 1
             is_last_bq = next_bq_idx == num_bq
@@ -903,12 +914,7 @@ def _ragged_paged_attention_kernel_loop(
             next_seq_idx = lax.select(is_last_bq, seq_idx + 1, seq_idx)
             next_bkv_sem_idx = lax.select(bkv_sem_idx == 0, 1, 0)
 
-            next_bq_start_bkv_idx = 0
-            if sliding_window is not None:
-                next_bq_start_bkv_idx = (
-                    jnp.maximum(kv_q_gap + (bq_idx + 1) * actual_bq_sz - sliding_window, 0)
-                    // bkv_sz
-                )
+            next_bq_start_bkv_idx = get_bkv_start(bq_idx + 1)
             next_bkv_idx = lax.select(is_last_bkv, next_bq_start_bkv_idx, next_bkv_idx)
             next_bkv_idx = lax.select(is_last_bq, next_seq_start_bkv_idx, next_bkv_idx)
             return next_seq_idx, next_bq_idx, next_bkv_idx, next_bkv_sem_idx
@@ -941,9 +947,10 @@ def _ragged_paged_attention_kernel_loop(
             )
 
             processed_q_len = kv_q_gap + bq_idx * actual_bq_sz
-            start_bkv_idx = 0
+            attention_start_bkv_idx = 0
             if sliding_window is not None:
-                start_bkv_idx = jnp.maximum(processed_q_len - sliding_window, 0) // bkv_sz
+                attention_start_bkv_idx = jnp.maximum(processed_q_len - sliding_window, 0) // bkv_sz
+            start_bkv_idx = get_bkv_start(bq_idx)
             if use_causal_mask:
                 effective_kv_len = jnp.minimum(kv_len, processed_q_len + actual_bq_sz)
             else:
@@ -1029,7 +1036,12 @@ def _ragged_paged_attention_kernel_loop(
                 def attention_loop(idx):
                     bkv_start = idx * bkv_csz
 
-                    @pl.when(bkv_start < effective_bkv_sz)
+                    @pl.when(
+                        jnp.logical_and(
+                            bkv_start < effective_bkv_sz,
+                            bkv_idx >= attention_start_bkv_idx,
+                        )
+                    )
                     def _():
                         for bq_start in range(0, actual_bq_sz, actual_bq_csz):
                             # Slice custom mask for this compute sub-block

--- a/python/sgl_jax/test/test_rpa_v3_kv_writeback.py
+++ b/python/sgl_jax/test/test_rpa_v3_kv_writeback.py
@@ -25,48 +25,39 @@ from sgl_jax.srt.kernels.ragged_paged_attention.ragged_paged_attention_v3 import
     ids=["cold", "warm-ragged", "chunk-prefill", "decode", "full", "sink"],
 )
 def test_kv_writeback(sequences, page_size, window, chunk_size, sink):
-    # Each sequence is (new token count, cached prefix length). Use multiple
-    # query blocks, unaligned boundaries and a non-contiguous physical page map.
-    q_lens = [q_len for q_len, _ in sequences]
-    kv_lens = [q_len + prefix for q_len, prefix in sequences]
-    page_counts = [(length + page_size - 1) // page_size for length in kv_lens]
-    capacities = np.array(page_counts) * page_size
-    num_pages = sum(page_counts)
-    num_tokens = sum(q_lens)
+    # Each sequence is (new token count, cached prefix length).
+    q_lens, prefixes = np.array(sequences).T
+    kv_lens = q_lens + prefixes
+    cu_q_lens = np.r_[0, np.cumsum(q_lens)]
+    page_counts = (kv_lens + page_size - 1) // page_size
+    page_offsets = np.r_[0, np.cumsum(page_counts)]
+    num_tokens = cu_q_lens[-1]
     padded_tokens = (num_tokens + 31) // 32 * 32
     num_heads, head_dim = 4, 128
     rng = np.random.default_rng(42)
-    page_indices = rng.permutation(np.arange(1, num_pages + 1))
+    page_indices = rng.permutation(np.arange(1, page_offsets[-1] + 1))
     # The first/last pages and unused slots within mapped pages must stay intact.
-    cache = np.full((num_pages + 2, page_size, 1, 2, head_dim), -7, np.float32)
+    cache = np.full((page_offsets[-1] + 2, page_size, 1, 2, head_dim), -7, np.float32)
     expected_cache = cache.copy()
-    keys = np.zeros((padded_tokens, 1, head_dim), np.float32)
-    values = np.zeros_like(keys)
+    new_kv = np.zeros((padded_tokens, 2, head_dim), np.float32)
     reference_pages = np.zeros((len(sequences), max(page_counts)), np.int32)
-    token_offset = page_offset = 0
-    for seq_idx, ((q_len, prefix), kv_len, page_count) in enumerate(
-        zip(sequences, kv_lens, page_counts)
-    ):
-        kv = rng.integers(-4, 5, size=(kv_len, 2, head_dim)).astype(np.float32)
-        pages = page_indices[page_offset : page_offset + page_count]
-        reference_pages[seq_idx, :page_count] = pages
+    for i, prefix in enumerate(prefixes):
+        kv = rng.integers(-4, 5, size=(kv_lens[i], 2, head_dim)).astype(np.float32)
+        pages = page_indices[page_offsets[i] : page_offsets[i + 1]]
+        reference_pages[i, : len(pages)] = pages
         # Token-level scatter is independent of the kernel's DMA/window tiling.
-        for position in range(kv_len):
-            physical_page = pages[position // page_size]
-            slot = position % page_size
-            expected_cache[physical_page, slot, 0] = kv[position]
-            if position < prefix:
-                cache[physical_page, slot, 0] = kv[position]
-        keys[token_offset : token_offset + q_len, 0] = kv[prefix:, 0]
-        values[token_offset : token_offset + q_len, 0] = kv[prefix:, 1]
-        token_offset += q_len
-        page_offset += page_count
+        positions = np.arange(kv_lens[i])
+        physical_pages, slots = pages[positions // page_size], positions % page_size
+        expected_cache[physical_pages, slots, 0] = kv
+        cache[physical_pages[:prefix], slots[:prefix], 0] = kv[:prefix]
+        new_kv[cu_q_lens[i] : cu_q_lens[i + 1]] = kv[prefix:]
 
     queries = jnp.asarray(
         rng.uniform(-0.25, 0.25, (padded_tokens, num_heads, head_dim)), jnp.bfloat16
     )
-    cu_q_lens = jnp.asarray(np.cumsum([0] + q_lens), jnp.int32)
+    cu_q_lens = jnp.asarray(cu_q_lens, jnp.int32)
     kv_lens = jnp.asarray(kv_lens, jnp.int32)
+    attention_args = dict(sm_scale=head_dim**-0.5, sliding_window=window, attention_sink=sink)
     expected_output = ref_ragged_paged_attention(
         queries,
         jnp.asarray(expected_cache[:, :, :, 0, :], jnp.bfloat16),
@@ -75,31 +66,27 @@ def test_kv_writeback(sequences, page_size, window, chunk_size, sink):
         jnp.asarray(reference_pages),
         cu_q_lens,
         jnp.array([len(sequences)], jnp.int32),
-        sm_scale=head_dim**-0.5,
-        sliding_window=window,
-        attention_sink=sink,
+        **attention_args,
     )
     count = len(sequences)
-    decode_count = count if all(q_len == 1 for q_len in q_lens) else 0
+    decode_count = count if np.all(q_lens == 1) else 0
     prefill_count = count if chunk_size is not None else decode_count
     output, updated_cache = ragged_paged_attention(
         queries,
-        jnp.asarray(keys, jnp.bfloat16),
-        jnp.asarray(values, jnp.bfloat16),
+        jnp.asarray(new_kv[:, 0:1], jnp.bfloat16),
+        jnp.asarray(new_kv[:, 1:2], jnp.bfloat16),
         jnp.asarray(cache, jnp.bfloat16),
         kv_lens,
         jnp.asarray(page_indices, jnp.int32),
         cu_q_lens,
-        jnp.asarray(np.cumsum(np.r_[0, capacities]), jnp.int32),
+        jnp.asarray(page_offsets * page_size, jnp.int32),
         jnp.array([decode_count, prefill_count, count], jnp.int32),
         None,
-        sliding_window=window,
-        sm_scale=head_dim**-0.5,
         chunk_prefill_size=chunk_size,
-        attention_sink=sink,
         d_block_sizes=(1, 256, 1, 256),
         p_block_sizes=(32, 256, 32, 256),
         m_block_sizes=(32, 256, 32, 256),
+        **attention_args,
     )
     output, updated_cache = jax.device_get((output, updated_cache))
 

--- a/python/sgl_jax/test/test_rpa_v3_kv_writeback.py
+++ b/python/sgl_jax/test/test_rpa_v3_kv_writeback.py
@@ -1,0 +1,113 @@
+"""New KV must survive SWA prefill even outside the last query block's window."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from sgl_jax.srt.kernels.ragged_paged_attention.ragged_paged_attention_v3 import (
+    ragged_paged_attention,
+    ref_ragged_paged_attention,
+)
+
+
+@pytest.mark.skipif(jax.default_backend() != "tpu", reason="Requires TPU DMA support")
+@pytest.mark.parametrize(
+    "sequences,page_size,window,chunk_size,sink",
+    [
+        ([(393, 0)], 256, 128, None, None),
+        ([(393, 273), (137, 512)], 128, 128, None, None),
+        ([(416, 256)], 256, 128, 416, None),
+        ([(1, 512), (1, 273)], 256, 128, None, None),
+        ([(393, 0)], 256, None, None, None),
+        ([(393, 0)], 256, 128, None, 2.0),
+    ],
+    ids=["cold", "warm-ragged", "chunk-prefill", "decode", "full", "sink"],
+)
+def test_kv_writeback(sequences, page_size, window, chunk_size, sink):
+    # Each sequence is (new token count, cached prefix length). Use multiple
+    # query blocks, unaligned boundaries and a non-contiguous physical page map.
+    q_lens = [q_len for q_len, _ in sequences]
+    kv_lens = [q_len + prefix for q_len, prefix in sequences]
+    page_counts = [(length + page_size - 1) // page_size for length in kv_lens]
+    capacities = np.array(page_counts) * page_size
+    num_pages = sum(page_counts)
+    num_tokens = sum(q_lens)
+    padded_tokens = (num_tokens + 31) // 32 * 32
+    num_heads, head_dim = 4, 128
+    rng = np.random.default_rng(42)
+    page_indices = rng.permutation(np.arange(1, num_pages + 1))
+    # The first/last pages and unused slots within mapped pages must stay intact.
+    cache = np.full((num_pages + 2, page_size, 1, 2, head_dim), -7, np.float32)
+    expected_cache = cache.copy()
+    keys = np.zeros((padded_tokens, 1, head_dim), np.float32)
+    values = np.zeros_like(keys)
+    reference_pages = np.zeros((len(sequences), max(page_counts)), np.int32)
+    token_offset = page_offset = 0
+    for seq_idx, ((q_len, prefix), kv_len, page_count) in enumerate(
+        zip(sequences, kv_lens, page_counts)
+    ):
+        kv = rng.integers(-4, 5, size=(kv_len, 2, head_dim)).astype(np.float32)
+        pages = page_indices[page_offset : page_offset + page_count]
+        reference_pages[seq_idx, :page_count] = pages
+        # Token-level scatter is independent of the kernel's DMA/window tiling.
+        for position in range(kv_len):
+            physical_page = pages[position // page_size]
+            slot = position % page_size
+            expected_cache[physical_page, slot, 0] = kv[position]
+            if position < prefix:
+                cache[physical_page, slot, 0] = kv[position]
+        keys[token_offset : token_offset + q_len, 0] = kv[prefix:, 0]
+        values[token_offset : token_offset + q_len, 0] = kv[prefix:, 1]
+        token_offset += q_len
+        page_offset += page_count
+
+    queries = jnp.asarray(
+        rng.uniform(-0.25, 0.25, (padded_tokens, num_heads, head_dim)), jnp.bfloat16
+    )
+    cu_q_lens = jnp.asarray(np.cumsum([0] + q_lens), jnp.int32)
+    kv_lens = jnp.asarray(kv_lens, jnp.int32)
+    expected_output = ref_ragged_paged_attention(
+        queries,
+        jnp.asarray(expected_cache[:, :, :, 0, :], jnp.bfloat16),
+        jnp.asarray(expected_cache[:, :, :, 1, :], jnp.bfloat16),
+        kv_lens,
+        jnp.asarray(reference_pages),
+        cu_q_lens,
+        jnp.array([len(sequences)], jnp.int32),
+        sm_scale=head_dim**-0.5,
+        sliding_window=window,
+        attention_sink=sink,
+    )
+    count = len(sequences)
+    decode_count = count if all(q_len == 1 for q_len in q_lens) else 0
+    prefill_count = count if chunk_size is not None else decode_count
+    output, updated_cache = ragged_paged_attention(
+        queries,
+        jnp.asarray(keys, jnp.bfloat16),
+        jnp.asarray(values, jnp.bfloat16),
+        jnp.asarray(cache, jnp.bfloat16),
+        kv_lens,
+        jnp.asarray(page_indices, jnp.int32),
+        cu_q_lens,
+        jnp.asarray(np.cumsum(np.r_[0, capacities]), jnp.int32),
+        jnp.array([decode_count, prefill_count, count], jnp.int32),
+        None,
+        sliding_window=window,
+        sm_scale=head_dim**-0.5,
+        chunk_prefill_size=chunk_size,
+        attention_sink=sink,
+        d_block_sizes=(1, 256, 1, 256),
+        p_block_sizes=(32, 256, 32, 256),
+        m_block_sizes=(32, 256, 32, 256),
+    )
+    output, updated_cache = jax.device_get((output, updated_cache))
+
+    np.testing.assert_allclose(
+        output[:num_tokens].astype(np.float32),
+        np.asarray(expected_output, np.float32),
+        atol=0.03,
+        rtol=0.03,
+    )
+    # Includes all new KV, the unchanged prefix, page tails and guard pages.
+    np.testing.assert_array_equal(updated_cache.astype(np.float32), expected_cache)

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -266,6 +266,7 @@ suites = {
         TestFile("python/sgl_jax/test/test_flashattention_mha.py", 11, runner="pytest"),
         TestFile("python/sgl_jax/test/test_flashattention_gqa.py", 11, runner="pytest"),
         TestFile("python/sgl_jax/test/test_flashattention_misc.py", 7, runner="pytest"),
+        TestFile("python/sgl_jax/test/test_rpa_v3_kv_writeback.py", 1, runner="pytest"),
         TestFile("python/sgl_jax/test/test_mla_attention.py", 2.5),
         TestFile("python/sgl_jax/test/test_moe_topk.py", 0.3),
         TestFile("python/sgl_jax/test/kernels/fused_moe_v1_test.py", 9),


### PR DESCRIPTION
## Motivation

RPA v3 writes new KV back only on the last query block, but SWA can skip earlier new KV blocks on that iteration. Immediate attention outputs can still be correct while later prefix reuse reads unwritten cache slots. For example, q_len=393, bq=32, bkv=256 and window=128 leave tokens [0, 256) unwritten on a cold prefill.

## Modifications

Use the earlier of the SWA start and the first new KV block on the last query iteration, with the same helper for current-block traversal and next-block prefetch. Keep the original attention start so extra blocks only perform KV writeback. Add six production-entry regressions checking the whole pool (including prefix, page tails and guard pages) and dense attention.
## Accuracy Tests

- Real TPU v7x (single JAX device), JAX/jaxlib 0.11.1: all 6 regressions passed. With only the kernel reverted to base `50d59b48`, cold/warm-ragged/chunk-prefill/sink failed the KV-pool assertion; decode/FULL passed. All 6 valid-token attention outputs were byte-identical before/after the fix.
- Local JAX 0.11.1: 23 related CPU tests passed; all 6 new TPU tests explicitly skipped. All six kernel input configurations traced successfully, but were not compiled/executed on TPU locally.
- Pre-commit and `git diff --check` passed.

The six cases cover cold prefill, ragged warm prefixes with shuffled pages, static chunk prefill, decode, FULL attention and a sink. Custom masks are outside this regression matrix.


## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.

