### PR TITLE
fix(dsa): streamindex_topk compressed visibility follows completed groups (ratio > 1)

### DIFF
--- a/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
+++ b/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
@@ -425,7 +425,10 @@ def _scores_kernel(
                     + bq_idx * bq_sz
                     + jnp.arange(bq_sz, dtype=jnp.int32)
                 )
-                bq_pos_compressed_vec.append(q_pos // compression_ratio)
+                # Last visible compressed entry: the one whose final token
+                # (entry+1)*ratio-1 is at or before q_pos, i.e. entries
+                # [0, (q_pos+1)//ratio). Identity for ratio == 1.
+                bq_pos_compressed_vec.append((q_pos + 1) // compression_ratio - 1)
 
             # Wait for cur bq if not ready yet
             wait_fetch_bq(batch_start_seq_idx, bq_idx, bq_sem_idx)
@@ -496,7 +499,10 @@ def _scores_kernel(
                     + bq_idx * bq_sz
                     + jnp.arange(bq_sz, dtype=jnp.int32)
                 )
-                bq_pos_compressed_vec.append(q_pos // compression_ratio)
+                # Last visible compressed entry: the one whose final token
+                # (entry+1)*ratio-1 is at or before q_pos, i.e. entries
+                # [0, (q_pos+1)//ratio). Identity for ratio == 1.
+                bq_pos_compressed_vec.append((q_pos + 1) // compression_ratio - 1)
 
             wait_fetch_bq(batch_start_seq_idx, bq_idx, bq_sem_idx)
             bq_vec = load_bq(bq_sem_idx)
@@ -657,7 +663,10 @@ def streamindex_topk(
         sequences[i:j] are chunked-prefill-only, and sequences[j:k] are mixed. The
         k is also the total number of sequences.
       k: Number of top-K elements to retrieve.
-      compression_ratio: KV cache compression ratio.
+      compression_ratio: KV cache compression ratio. Compressed entry ``e``
+        covers original positions ``[e*ratio, (e+1)*ratio-1]`` and is visible
+        to a query only once its last token is at or before the query
+        position (``e < (q_pos+1)//ratio``, the DeepSeek-V4 indexer rule).
       num_kv_pages_per_block: number of kv pages to be processed in one block in
         the pallas kernel. This is a tuple of (decode, prefill, mixed) cases.
       num_queries_per_block: number of queries to be processed in one block in the

--- a/test/srt/kernels/dsa/test_streamindex_topk.py
+++ b/test/srt/kernels/dsa/test_streamindex_topk.py
@@ -93,7 +93,11 @@ def _numpy_topk_oracle(
             q_abs_pos = (S_total - T_seq) + t_idx
 
             for s_idx in range(S_valid):
-                if s_idx * comp_ratio > q_abs_pos:
+                # Compressed entry ``s_idx`` covers original positions
+                # [s_idx*ratio, (s_idx+1)*ratio-1]; it is visible only once its
+                # last token is at or before the query (DeepSeek-V4
+                # ``inference/model.py`` Indexer mask).
+                if (s_idx + 1) * comp_ratio - 1 > q_abs_pos:
                     continue
 
                 score = 0.0
@@ -455,7 +459,10 @@ def test_streamindex_topk_quantized():
     naive_scores = np.full((T_seq, max(S_valid, k)), -np.inf, dtype=np.float32)
 
     for t_idx in range(T_seq):
+        q_abs_pos = (S_seq - T_seq) + t_idx
         for s_idx in range(S_valid):
+            if (s_idx + 1) * comp_ratio - 1 > q_abs_pos:
+                continue
             score = 0.0
             for h in range(H_I):
                 h_kv = h // (H_I // H_KV)
@@ -586,6 +593,83 @@ def test_streamindex_topk_bf16_matches_oracle(T_list, S_list, k):
             assert (
                 inter / len(want) >= 0.99
             ), f"row {row}: only {inter}/{len(want)} topk overlap vs oracle"
+
+
+def _run_topk_bf16(c, *, seq_lens, cu_q, dist, k, ratio, rows=None):
+    q = c["q"] if rows is None else c["q"][:rows]
+    w = c["w"] if rows is None else c["w"][:rows]
+    got = streamindex_topk(
+        q=q,
+        indexer_weights=w,
+        cache_kv=c["cache4d"],
+        seq_lens=jnp.asarray(np.array(seq_lens, np.int32)),
+        page_indices=jnp.asarray(c["block_table"].flatten()),
+        cu_q_lens=jnp.asarray(np.array(cu_q, np.int32)),
+        distribution=jnp.asarray(dist, jnp.int32),
+        k=k,
+        compression_ratio=ratio,
+        num_kv_pages_per_block=2,
+        num_queries_per_block=8,
+    )
+    return np.asarray(jax.block_until_ready(got))
+
+
+@pytest.mark.parametrize(
+    "T_list, S_list",
+    [
+        ([6], [22]),  # prefill chunk 16..21 over a ratio-4 cache
+        ([1, 7], [21, 23]),  # decode at 20 + prefill chunk 16..22
+        ([3], [12]),  # chunk end exactly on a group boundary
+        ([5], [5]),  # prefill from position 0: nothing visible before pos 3
+    ],
+)
+def test_streamindex_topk_compressed_visibility_is_completed_groups(T_list, S_list):
+    """With ``compression_ratio > 1`` a query at position ``p`` may see only the
+    compressed entries whose *last* token is at or before ``p``, i.e. entries
+    ``[0, (p+1)//ratio)`` (DeepSeek-V4 ``inference/model.py`` Indexer mask).
+    ``k`` exceeds the entry count, so the returned set must equal that range
+    exactly; the entry the query sits inside must not appear.
+    """
+    ratio, k = 4, 1024
+    page_size, H, D = 64, 8, 128
+    c = _build_bf16_case(T_list, S_list, page_size, H, D, num_pages=16, seed=1)
+    B = len(S_list)
+    nd = int(c["dist"][0])
+    got = _run_topk_bf16(
+        c, seq_lens=S_list, cu_q=np.asarray(c["cu_q"]), dist=(nd, nd, B), k=k, ratio=ratio
+    )
+    _verify_padding_at_end(got)
+    cu_q = np.asarray(c["cu_q"])
+    for b in range(B):
+        kv_len = S_list[b] // ratio
+        for t in range(T_list[b]):
+            row = cu_q[b] + t
+            pos = S_list[b] - T_list[b] + t
+            visible = min(kv_len, (pos + 1) // ratio)
+            selected = sorted(got[row][got[row] >= 0].tolist())
+            assert selected == list(range(visible)), (
+                f"seq {b} query pos {pos}: selected {selected}, expected entries" f" [0, {visible})"
+            )
+
+
+def test_streamindex_topk_selection_does_not_depend_on_chunk_end():
+    """The same query must select the same compressed entries whether or not the
+    chunk it arrives in also completes the next group. Two chunks starting at
+    position 16: one ends at 17 (group 4 incomplete), one ends at 19 (group 4
+    complete). Rows for positions 16 and 17 must be identical in both.
+    """
+    ratio, k = 4, 1024
+    page_size, H, D = 64, 8, 128
+    c = _build_bf16_case([4], [20], page_size, H, D, num_pages=16, seed=2)
+    long_chunk = _run_topk_bf16(c, seq_lens=[20], cu_q=[0, 4], dist=(0, 0, 1), k=k, ratio=ratio)
+    short_chunk = _run_topk_bf16(
+        c, seq_lens=[18], cu_q=[0, 2], dist=(0, 0, 1), k=k, ratio=ratio, rows=2
+    )
+    np.testing.assert_array_equal(
+        np.sort(short_chunk, axis=-1),
+        np.sort(long_chunk[:2], axis=-1),
+        err_msg="later tokens in the chunk changed an earlier query's selection",
+    )
 
 
 def test_fixed_stride_pages_repack_multi_seq():


### PR DESCRIPTION
## Motivation

`streamindex_topk` bounds the causal window in compressed space with `k_span <= q_pos // compression_ratio`. For `compression_ratio > 1` that admits the entry the query itself sits inside. The compressor only writes an entry when its group completes, so inside a prefill chunk a query at position `p` with `(p + 1) % ratio != 0` could select a slot whose content is produced by tokens *after* `p`, and the same query selected different entries depending on where its chunk happened to end. Nothing in the repo hits this today because the only caller (`dsa_sparse_backend`, GLM-5.2) passes `compression_ratio=1`, where both rules coincide.

DeepSeek-V4's reference implementation (`deepseek-ai/DeepSeek-V4-Flash`, `inference/model.py`, `Indexer.forward`) masks with `arange(seqlen // ratio) >= arange(1, seqlen + 1) // ratio`: entry `e` is visible only if `e < (p + 1) // ratio`, i.e. once its last token `(e + 1) * ratio - 1` is at or before the query. This PR makes the kernel use that bound so it can serve as the V4 CSA indexer (`compression_ratio=4`). Context: sgl-project/sglang-jax#1460 (V4 roadmap item); the V4 indexer module being built on `epic/dsv4` currently reimplements the scoring in plain JAX precisely because of this mask difference and notes it can become a thin wrapper over this kernel once the bound is fixed.

## Modifications

- `python/sgl_jax/srt/kernels/dsa/streamindex_topk.py`: `bq_pos_compressed = (q_pos + 1) // compression_ratio - 1` in both grids (was `q_pos // compression_ratio`); docstring states the visibility rule. `kv_len = seq_len // compression_ratio` is unchanged. Identity for `compression_ratio == 1`.
- `test/srt/kernels/dsa/test_streamindex_topk.py`: the shared NumPy oracle and the fp8 packed-cache case now encode the same rule (the fp8 case previously had no causal mask at all and relied on every entry being visible). New tests: `test_streamindex_topk_compressed_visibility_is_completed_groups` (ratio 4; prefill chunk, mixed decode+prefill, chunk end on a group boundary, prefill from position 0; asserts the exact visible set per query) and `test_streamindex_topk_selection_does_not_depend_on_chunk_end` (same query, chunk ending at 17 vs 19, identical selection).
- `streamindex_page_topk` (page mode) is untouched; it already rejects `compression_ratio != 1`.

## Accuracy Tests

TPU v7x, single host (8 devices), jax/jaxlib 0.11.1:

```
# before the kernel change (tests only): 7 failed, 24 passed
#   every failure = one extra entry selected, the query's own in-progress group
# after:
python -m pytest test/srt/kernels/dsa/test_streamindex_topk.py test/srt/kernels/dsa/test_streamindex_page_topk.py -q
31 passed in 27.21s
```

Full `test/srt/kernels/dsa/` directory on the same host (`JAX_PLATFORMS=tpu,cpu`, the qblock/ref cases pin a CPU backend): `48 passed, 3 skipped in 59.29s`.

`pre-commit run --files <changed>` clean (isort / ruff / black).

## Benchmarking and Profiling

No performance change: one scalar expression per query block differs; no kernel structure, tiling, or memory traffic changes.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
