### PR TITLE
Fix speculative metrics test initialization after queue metrics change

### DIFF
--- a/python/sgl_jax/test/test_spec_accept_metrics.py
+++ b/python/sgl_jax/test/test_spec_accept_metrics.py
@@ -73,13 +73,14 @@ class TestComputeAvgSpecAcceptLength(unittest.TestCase):
 
 class TestSpecAcceptCounters(unittest.TestCase):
     def test_init_metrics_defines_the_counters_the_processor_increments(self):
-        obj = types.SimpleNamespace()
+        obj = types.SimpleNamespace(server_args=types.SimpleNamespace(enable_metrics=False))
         SchedulerMetricsMixin.init_metrics(obj)
         self.assertEqual(obj.cum_spec_accept_length, 0)
         self.assertEqual(obj.cum_spec_accept_count, 0)
 
     def test_accounting_moves_both_counter_pairs(self):
         scheduler = Scheduler.__new__(Scheduler)
+        scheduler.server_args = types.SimpleNamespace(enable_metrics=False)
         SchedulerMetricsMixin.init_metrics(scheduler)
         scheduler.num_generated_tokens = 0
         scheduler.accept_token = 0
@@ -113,6 +114,7 @@ class TestSpecAcceptCounters(unittest.TestCase):
 
     def test_log_decode_stats_reset_does_not_touch_cumulative_counters(self):
         scheduler = Scheduler.__new__(Scheduler)
+        scheduler.server_args = types.SimpleNamespace(enable_metrics=False, decode_log_interval=1)
         SchedulerMetricsMixin.init_metrics(scheduler)
         scheduler.running_batch = _Batch()
         scheduler.last_decode_stats_tic = 0.0
@@ -121,7 +123,6 @@ class TestSpecAcceptCounters(unittest.TestCase):
         scheduler._get_token_info = lambda: (0, 0.0, 0, 0)
         scheduler.spec_algorithm = _SpecAlgorithm()
         scheduler.waiting_queue = []
-        scheduler.server_args = types.SimpleNamespace(decode_log_interval=1)
         # One interval's worth of what log_decode_stats consumes...
         scheduler.accept_token = 30
         scheduler.draft_token = 40
@@ -148,6 +149,7 @@ class TestSpecAcceptCounters(unittest.TestCase):
 class TestGetInternalStateExposesAcceptLength(unittest.TestCase):
     def _make_scheduler(self):
         scheduler = Scheduler.__new__(Scheduler)
+        scheduler.server_args = types.SimpleNamespace(enable_metrics=False)
         SchedulerMetricsMixin.init_metrics(scheduler)
         scheduler.token_to_kv_pool_allocator = _Allocator()
         scheduler.max_total_num_tokens = 1024


### PR DESCRIPTION
## Motivation

Fixes #1608. The speculative acceptance metrics tests construct bare scheduler objects without `server_args`, so the queue-time histogram initialization introduced by #1555 raises `AttributeError`. Reproduced on current main (`1910c6835`): 5 failed, 3 passed.

## Modifications

Set minimal `server_args` with `enable_metrics=False` before all four `init_metrics` call sites. Move `decode_log_interval=1` into the same initialization for the decode logging test. This matches the production Scheduler initialization order and preserves the mixin contract.

## Accuracy Tests

Test-only change; no model output changes.

Local CPU validation (Python 3.12):
- `PYTHONPATH=python python -m pytest -q python/sgl_jax/test/test_spec_accept_metrics.py` — 8 passed.
- `PYTHONPATH=python python python/sgl_jax/test/test_spec_accept_metrics.py` — 8 tests, OK (the CI test entry point).
- `python -m black --check --config python/pyproject.toml python/sgl_jax/test/test_spec_accept_metrics.py` — passed.
- `python -m ruff check python/sgl_jax/test/test_spec_accept_metrics.py` — passed.
- `git diff --check` — passed.

Full CPU suite and TPU tests were not run locally; remote CI is pending.

## Benchmarking and Profiling

Not applicable: test fixture initialization only.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
