### PR TITLE
perf(vlm): simplify preprocessing and flatten vision inputs

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen2.5-VL.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen2.5-VL.md
@@ -71,7 +71,6 @@ python -u -m sgl_jax.launch_server \
   --max-prefill-tokens 16384 --chunked-prefill-size 4096 \
   --mem-fraction-static 0.9 --page-size 128 \
   --vision-encoder-parallel dp \
-  --mm-io-worker-num 4 \
   --mm-processor-worker-num 16 \
   --random-seed 0 \
   --skip-server-warmup \
@@ -325,7 +324,7 @@ python -u -m sgl_jax.launch_server \
   --max-prefill-tokens 16384 --chunked-prefill-size 4096 \
   --mem-fraction-static 0.9 --page-size 128 \
   --disable-radix-cache --vision-encoder-parallel dp \
-  --mm-io-worker-num 4 --mm-processor-worker-num 16 \
+  --mm-processor-worker-num 16 \
   --random-seed 0 --host 0.0.0.0 --port 30000
 ```
 

--- a/docs/cookbook/autoregressive/Qwen/Qwen3-VL.md
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3-VL.md
@@ -296,7 +296,7 @@ for dataset, batch_size in (("mmmu", 24), ("mmmu_pro", 256)):
 
 ### 4.2 Speed — single multimodal workload
 
-> **Multimodal throughput row.** The workload submits 1,000 requests at an unbounded request rate. Each request contains 1,024 random source-text tokens and one random 512×512 JPEG, averages 1,086.25 text tokens plus 258 vision tokens after chat templating, and generates 500 output tokens. The run uses one warmup request and flushes the cache before measurement.
+> **Multimodal throughput row.** The workload submits 1,000 requests at an unbounded request rate. Each request contains 1,024 random source-text tokens and one random 512×512 JPEG and generates 500 output tokens. The run totals 1,344,206 server-verified input tokens. The run uses one warmup request and flushes the cache before measurement.
 
 **Test Environment**
 
@@ -358,23 +358,26 @@ python -m sgl_jax.bench_serving \
 | Metric | Result |
 |---|---:|
 | Successful requests | 1,000 |
-| Avg text input tokens / request | 1,086.25 |
-| Avg vision input tokens / request | 258.00 |
-| Avg total input tokens / request | 1,344.25 |
-| Output tokens / request | 500 |
-| Mean TTFT | 16,636.34 ms |
-| Median TTFT | 13,818.60 ms |
-| P99 TTFT | 54,075.23 ms |
-| Duration | 64.332 s |
-| Request throughput | 15.544 req/s |
-| Input token throughput | 20,895.61 tok/s |
-| Output token throughput | 7,772.22 tok/s |
-| Total token throughput | 28,667.82 tok/s |
-| Mean TPOT | 73.94 ms |
-| Median TPOT | 77.37 ms |
-| P99 TPOT | 100.26 ms |
-| Median E2E latency | 52,606.81 ms |
-| P99 E2E latency | 63,657.17 ms |
+| Input tokens (server-verified) | 1,344,206 |
+| Output tokens (server-verified) | 500,000 |
+| Duration | 58.634 s |
+| Request throughput | 17.055 req/s |
+| Input token throughput | 22,925.18 tok/s |
+| Output token throughput | 8,527.41 tok/s |
+| Total token throughput | 31,452.59 tok/s |
+| Mean TTFT | 15,937.96 ms |
+| Median TTFT | 13,425.55 ms |
+| P99 TTFT | 49,192.05 ms |
+| Mean TPOT | 65.44 ms |
+| Median TPOT | 68.36 ms |
+| P99 TPOT | 90.18 ms |
+| Mean E2E latency | 48,591.19 ms |
+| Median E2E latency | 47,598.53 ms |
+| P99 E2E latency | 57,846.17 ms |
+| Mean ITL | 66.64 ms |
+| Median ITL | 33.06 ms |
+| P95 ITL | 62.41 ms |
+| P99 ITL | 358.61 ms |
 
 This is a saturated burst workload, so TTFT includes scheduler queueing in addition to media processing, vision encoding, embedding merge, and language-model prefill.
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "modelscope~=1.28.2",
     "msgpack-python~=0.5.6",
     "numpy~=2.2.6",
+    "numba>=0.61.2",
     "orjson~=3.11.1",
     "pillow~=11.3.0",
     "prometheus-client>=0.20.0",
@@ -34,6 +35,7 @@ dependencies = [
     "typing-extensions~=4.14.1",
     "uvicorn~=0.35.0",
     "uvloop~=0.21.0",
+    "xxhash>=3.0.0",
     "psutil",
     "httpx",
     "openai",
@@ -69,6 +71,7 @@ all = [
 ]
 multimodal = [
     "torch",
+    "torchcodec",
     "torchvision",
     "torchaudio",
     "decord",
@@ -196,5 +199,6 @@ explicit = true
 
 [tool.uv.sources]
 torch = { index = "pytorch-cpu" }
+torchcodec = { index = "pytorch-cpu" }
 torchvision = { index = "pytorch-cpu" }
 torchaudio = { index = "pytorch-cpu" }

--- a/python/sgl_jax/srt/hf_transformers_utils.py
+++ b/python/sgl_jax/srt/hf_transformers_utils.py
@@ -485,7 +485,7 @@ def get_processor(
     tokenizer_mode: str = "auto",
     trust_remote_code: bool = False,
     tokenizer_revision: str | None = None,
-    use_fast: bool | None = False,
+    use_fast: bool | None = True,
     **kwargs,
 ):
     # pop 'revision' from kwargs if present.

--- a/python/sgl_jax/srt/models/qwen2_5_vl.py
+++ b/python/sgl_jax/srt/models/qwen2_5_vl.py
@@ -9,7 +9,7 @@ import jax.numpy as jnp
 import numpy as np
 from flax import nnx
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
-from jax.typing import ArrayLike
+from numba import njit, types
 from transformers import modeling_flax_utils
 
 from sgl_jax.srt.configs.model_config import ModelConfig
@@ -31,7 +31,6 @@ from sgl_jax.srt.multimodal.in_model.lane_packing import (
     run_mrope_vision_model,
 )
 from sgl_jax.srt.multimodal.layers.attention.flash_attention_backend import (
-    VisionAttentionMetadata,
     make_vision_attention_backend,
 )
 from sgl_jax.srt.multimodal.layers.vision_sharding import (
@@ -53,7 +52,7 @@ def _apply_rotary_pos_emb_vision(
     cos: jax.Array,
     sin: jax.Array,
 ) -> jax.Array:
-    """Apply precomputed vision RoPE to ``x[B, T, heads, head_dim]``."""
+    """Apply precomputed vision RoPE to ``x[tokens, heads, head_dim]``."""
     half_dim = x.shape[-1] // 2
     x_real, x_imag = x[..., :half_dim], x[..., half_dim:]
     return jnp.concatenate(
@@ -93,30 +92,21 @@ class Qwen2_5_VisionPatchEmbed(nnx.Module):
         )
 
     def __call__(self, x: jax.Array) -> jax.Array:
-        """*x*: ``[B, S, C·T·H·W]`` → ``[B, S, hidden_size]``."""
-        B, S, D = x.shape
+        """*x*: ``[tokens, C·T·H·W]`` → ``[tokens, hidden_size]``."""
+        tokens, D = x.shape
         C = D // (self.temporal_patch_size * self.patch_size * self.patch_size)
-        x = x.reshape(B, S, C, self.temporal_patch_size, self.patch_size, self.patch_size)
+        x = x.reshape(tokens, C, self.temporal_patch_size, self.patch_size, self.patch_size)
         x = apply_data_sharding(x, self.mesh, PartitionSpec(self.specs.batch_axis))
 
-        # [B, S, C, T, H, W] → [B, S, T, H, W, C]
-        x = jnp.transpose(x, (0, 1, 3, 4, 5, 2))
+        # Each token is one independent convolution input patch.
+        x = jnp.transpose(x, (0, 2, 3, 4, 1))
 
         sh = None
         if "data" in self.mesh.abstract_mesh.explicit_axes:
             sh = self.specs.sharding(self.specs.batch_axis)
 
-        x = x.reshape(
-            B * S,
-            self.temporal_patch_size,
-            self.patch_size,
-            self.patch_size,
-            C,
-            out_sharding=sh,
-        )
         x = self.proj(x, out_sharding=sh)
-        x = x.reshape(B, S, 1, 1, 1, self.hidden_size, out_sharding=sh)
-        return jnp.squeeze(x, axis=(2, 3, 4))
+        return x.reshape(tokens, self.hidden_size, out_sharding=sh)
 
 
 class Qwen2_5_VLMLP(nnx.Module):
@@ -160,7 +150,7 @@ class Qwen2_5_VLMLP(nnx.Module):
 
     def __call__(self, x: jax.Array) -> jax.Array:
         specs = self.specs
-        col = specs.sharding(specs.batch_axis, None, specs.tensor_axis)
+        col = specs.sharding(specs.batch_axis, specs.tensor_axis)
         row = specs.sharding(specs.batch_axis)
         gate, _ = self.gate_proj(x, out_sharding=col)
         up, _ = self.up_proj(x, out_sharding=col)
@@ -237,27 +227,29 @@ class Qwen2_5_VisionAttention(nnx.Module):
         x: jax.Array,
         rotary_cos: jax.Array,
         rotary_sin: jax.Array,
-        metadata: VisionAttentionMetadata,
+        cu_seqlens: jax.Array,
+        *,
+        max_seq_len: int,
     ) -> jax.Array:
-        B, T, D = x.shape
+        tokens, D = x.shape
         specs = self.specs
-        col = specs.sharding(specs.batch_axis, None, specs.tensor_axis)
+        col = specs.sharding(specs.batch_axis, specs.tensor_axis)
 
         # Project Q, K, V separately (TP-safe: each is independently column-parallel).
         q, _ = self.q_proj(x, out_sharding=col)
         k, _ = self.k_proj(x, out_sharding=col)
         v, _ = self.v_proj(x, out_sharding=col)
 
-        hs = specs.sharding(specs.batch_axis, None, specs.tensor_axis, None)
-        q = q.reshape(B, T, self.num_heads, self.head_dim, out_sharding=hs)
-        k = k.reshape(B, T, self.num_heads, self.head_dim, out_sharding=hs)
-        v = v.reshape(B, T, self.num_heads, self.head_dim, out_sharding=hs)
+        hs = specs.sharding(specs.batch_axis, specs.tensor_axis, None)
+        q = q.reshape(tokens, self.num_heads, self.head_dim, out_sharding=hs)
+        k = k.reshape(tokens, self.num_heads, self.head_dim, out_sharding=hs)
+        v = v.reshape(tokens, self.num_heads, self.head_dim, out_sharding=hs)
 
         q = _apply_rotary_pos_emb_vision(q, rotary_cos, rotary_sin)
         k = _apply_rotary_pos_emb_vision(k, rotary_cos, rotary_sin)
 
-        out = self.attn_backend(q, k, v, metadata)
-        out = out.reshape(B, T, D, out_sharding=col)
+        out = self.attn_backend(q, k, v, cu_seqlens, max_seq_len=max_seq_len)
+        out = out.reshape(tokens, D, out_sharding=col)
         out, _ = self.proj(out, out_sharding=specs.sharding(specs.batch_axis))
         return out
 
@@ -295,15 +287,19 @@ class Qwen2_5_VisionBlock(nnx.Module):
         x: jax.Array,
         rotary_cos: jax.Array,
         rotary_sin: jax.Array,
-        metadata: VisionAttentionMetadata,
+        cu_seqlens: jax.Array,
+        *,
+        max_seq_len: int,
     ) -> jax.Array:
-        x = x + self.attn(self.norm1(x), rotary_cos, rotary_sin, metadata)
+        x = x + self.attn(
+            self.norm1(x), rotary_cos, rotary_sin, cu_seqlens, max_seq_len=max_seq_len
+        )
         x = x + self.mlp(self.norm2(x))
         return x
 
 
 class Qwen2_5_VisionPatchMerger(nnx.Module):
-    """Spatial merge: LN → reshape(sms²) → 2-layer MLP → [B, T/sms², d_model]."""
+    """Spatial merge: LN → reshape(sms²) → MLP → [tokens/sms², d_model]."""
 
     def __init__(
         self,
@@ -349,11 +345,8 @@ class Qwen2_5_VisionPatchMerger(nnx.Module):
         specs = self.specs
         row = specs.sharding(specs.batch_axis)
         x = self.ln_q(x)
-        B = x.shape[0]
-        x = x.reshape(B, -1, self.hidden_size, out_sharding=row)
-        x, _ = self.mlp_fc1(
-            x, out_sharding=specs.sharding(specs.batch_axis, None, specs.tensor_axis)
-        )
+        x = x.reshape(-1, self.hidden_size, out_sharding=row)
+        x, _ = self.mlp_fc1(x, out_sharding=specs.sharding(specs.batch_axis, specs.tensor_axis))
         x = self.mlp_act(x)
         x, _ = self.mlp_fc2(x, out_sharding=row)
         return x
@@ -426,62 +419,195 @@ class Qwen2_5_VisionTransformer(nnx.Module):
         self.theta = float(getattr(config, "rope_theta", 10000.0))
         self.rot_dim = 2 * len(range(0, self.rotary_dim, 2))
 
+    # Compile (or load the cache) before serving, with dimensions as runtime values.
+    # Accept strided and read-only grids without additional specializations.
+    @staticmethod
+    @njit(
+        types.int32[::1](
+            types.Array(types.int32, 3, "A", readonly=True),
+            types.int64,
+            types.int64,
+            types.int64,
+        ),
+        nogil=True,
+        cache=True,
+    )
+    def _build_metadata(grid_thw, capacity, merge, window):
+        """Write lane-local permutations, positions and boundaries in one pass.
+
+        The flat buffer matches ``Qwen2_5_VisionTransformer._metadata_views``.
+        Visit only valid merge units in window order, avoiding padded indices,
+        coordinate grids, gathers and per-image temporary arrays.
+        """
+        if merge <= 0 or window <= 0 or capacity < 0:
+            raise ValueError("merge/window must be positive and capacity non-negative")
+        unit = merge * merge
+        if capacity % unit:
+            raise ValueError("capacity must be divisible by the spatial merge unit")
+        if grid_thw.shape[2] != 3:
+            raise ValueError("grid_thw must have three coordinates per grid")
+        num_lanes = grid_thw.shape[0]
+        num_units = capacity // unit
+        positions_start = 2 * num_units
+        window_start = positions_start + 2 * capacity
+        full_start = window_start + num_units + 1
+        metadata = np.zeros((num_lanes, full_start + num_units + 1), dtype=np.int32)
+
+        for lane in range(num_lanes):
+            # Padding units retain the identity permutation and zero positions.
+            for index in range(num_units):
+                metadata[lane, 2 * index] = index
+                metadata[lane, 2 * index + 1] = index
+            patch_offset = unit_offset = 0
+            window_segment = frame_segment = 1
+            for image in range(grid_thw.shape[1]):
+                t, h, w = grid_thw[lane, image]
+                if t == 0 and h == 0 and w == 0:
+                    continue
+                # Validate before writing: Numba does not bounds-check array access.
+                if t <= 0 or h <= 0 or w <= 0 or h % merge or w % merge:
+                    raise ValueError("grid dimensions must be positive and spatially merge-aligned")
+                if t * h * w > capacity - patch_offset:
+                    raise ValueError("vision grids exceed the lane capacity")
+                grid_h, grid_w = h // merge, w // merge
+                image_unit_offset = unit_offset
+                for frame in range(t):
+                    frame_unit_offset = image_unit_offset + frame * grid_h * grid_w
+                    for window_y in range(0, grid_h, window):
+                        for window_x in range(0, grid_w, window):
+                            for y in range(window_y, min(window_y + window, grid_h)):
+                                for x in range(window_x, min(window_x + window, grid_w)):
+                                    source_unit = frame_unit_offset + y * grid_w + x
+                                    metadata[lane, 2 * unit_offset] = source_unit
+                                    metadata[lane, 2 * source_unit + 1] = unit_offset
+                                    for dy in range(merge):
+                                        for dx in range(merge):
+                                            position = positions_start + 2 * patch_offset
+                                            metadata[lane, position] = y * merge + dy
+                                            metadata[lane, position + 1] = x * merge + dx
+                                            patch_offset += 1
+                                    unit_offset += 1
+                            metadata[lane, window_start + window_segment] = patch_offset
+                            window_segment += 1
+                    metadata[lane, full_start + frame_segment] = patch_offset
+                    frame_segment += 1
+            # Repeated final ends describe empty segments in the bucket padding.
+            metadata[lane, window_start + window_segment : full_start] = patch_offset
+            metadata[lane, full_start + frame_segment :] = patch_offset
+        return metadata.reshape(-1)
+
+    def prepare_metadata(
+        self, grid_thw: np.ndarray, capacity: int, *, sharding: NamedSharding
+    ) -> jax.Array:
+        """Build host attention metadata and upload it with the input sharding."""
+        with jax.profiler.TraceAnnotation("encoder_metadata_host_build"):
+            grid_thw = np.asarray(grid_thw, dtype=np.int32)
+            if grid_thw.ndim == 2:
+                grid_thw = grid_thw[None]
+            if grid_thw.ndim != 3 or grid_thw.shape[-1] != 3:
+                raise ValueError("grid_thw must have shape [items, 3] or [lanes, items, 3]")
+            metadata = self._build_metadata(
+                grid_thw,
+                capacity,
+                self.spatial_merge_size,
+                self.window_size // self.spatial_merge_size // self.patch_size,
+            )
+        with jax.profiler.TraceAnnotation("encoder_metadata_device_put"):
+            return jax.device_put(metadata, sharding)
+
+    def _metadata_views(self, metadata: np.ndarray | jax.Array, capacity: int):
+        """Views of the same buffer on the host and inside the ViT JIT."""
+        leading_shape = metadata.shape[:-1]
+        num_units = capacity // self.spatial_merge_unit
+        indices_end = 2 * num_units
+        positions_end = indices_end + 2 * capacity
+        window_end = positions_end + num_units + 1
+        return (
+            metadata[..., :indices_end].reshape(*leading_shape, num_units, 2),
+            metadata[..., indices_end:positions_end].reshape(*leading_shape, capacity, 2),
+            metadata[..., positions_end:window_end],
+            metadata[..., window_end:],
+        )
+
+    def _reorder(self, x: jax.Array, indices: jax.Array) -> jax.Array:
+        """Gather within each device's lane, using lane-local unit indices."""
+        spec = PartitionSpec(self.specs.batch_axis)
+        return jax.shard_map(
+            lambda values, order: values[order],
+            mesh=self.mesh,
+            in_specs=(spec, spec),
+            out_specs=spec,
+            check_vma=False,
+        )(x, indices)
+
     def __call__(
         self,
-        patches: ArrayLike,
-        grid_thw: np.ndarray,
+        patches: jax.Array,
+        metadata: jax.Array,
     ) -> jax.Array:
-        return self.encode(patches, grid_thw)
+        return self.encode(patches, metadata)
 
     def _forward(
         self,
         patches: jax.Array,
         indices: jax.Array,
         position_ids: jax.Array,
-        window_attn: VisionAttentionMetadata,
-        full_attn: VisionAttentionMetadata,
+        window_cu_seqlens: jax.Array,
+        full_cu_seqlens: jax.Array,
     ) -> jax.Array:
-        B, S = patches.shape[:2]
+        """Run the ViT over flat tokens with lane-local indices and boundaries."""
+        tokens = patches.shape[0]
+        capacity = tokens // encoder_num_lanes(self.mesh, self.vision_tp)
         u = self.spatial_merge_unit
-        n_units = S // u
-        window_index, reverse_indices = indices[:, :, 0], indices[:, :, 1]
+        window_index, reverse_indices = indices[:, 0], indices[:, 1]
         inv_freq = 1.0 / (
             self.theta ** (jnp.arange(0, self.rotary_dim, 2, dtype=jnp.float32) / self.rotary_dim)
         )
         rotary_pos_emb = (position_ids[..., None].astype(jnp.float32) * inv_freq).reshape(
-            B, S, self.rot_dim
+            tokens, self.rot_dim
         )
-        rotary_cos = jnp.cos(rotary_pos_emb)[:, :, None, :]
-        rotary_sin = jnp.sin(rotary_pos_emb)[:, :, None, :]
+        rotary_cos = jnp.cos(rotary_pos_emb)[:, None, :]
+        rotary_sin = jnp.sin(rotary_pos_emb)[:, None, :]
 
         x = self.patch_embed(patches)
-        x = x.reshape(B, n_units, u, -1)
-
-        # Window reorder (batch axis stays on 0).
-        x = jnp.take_along_axis(x, window_index[:, :, None, None], axis=1)
-        x = x.reshape(B, S, -1)
+        x = x.reshape(tokens // u, u, -1)
+        x = self._reorder(x, window_index).reshape(tokens, -1)
 
         # Select the pre-planned metadata per block: full-frame for the layers in
         # ``fullatt_block_indexes``, otherwise the local-window layout.
-        layout_metadata = (window_attn, full_attn)
+        cu_seqlens = (window_cu_seqlens, full_cu_seqlens)
+        window = self.window_size // self.spatial_merge_size // self.patch_size
+        # Static bounds depend only on the compile bucket and model config so
+        # different segment values with the same shapes share a compilation.
+        max_seq_lens = (min(capacity, window * window * u), capacity)
         for i, blk in enumerate(self.blocks):
-            block_meta = layout_metadata[int(i in self.fullatt_block_indexes)]
-            x = blk(x, rotary_cos, rotary_sin, block_meta)
+            layout = int(i in self.fullatt_block_indexes)
+            x = blk(x, rotary_cos, rotary_sin, cu_seqlens[layout], max_seq_len=max_seq_lens[layout])
 
         x = self.merger(x)
-        return jnp.take_along_axis(x, reverse_indices[:, :, None], axis=1)
+        return self._reorder(x, reverse_indices)
 
+    @jax.jit
     def encode(
         self,
-        patches: ArrayLike,
-        grid_thw: np.ndarray,
+        patches: jax.Array,
+        metadata: jax.Array,
     ) -> jax.Array:
-        batch_sharding = self.specs.sharding(self.specs.batch_axis)
-        patches = jax.device_put(patches, batch_sharding)
-        metadata = self._build_metadata(grid_thw, patches.shape[1])
-        metadata = jax.device_put(metadata, batch_sharding)
-        with jax.set_mesh(self.mesh):
-            return self._encode_jit(patches, *metadata)
+        """Encode flat lane-major patch and metadata buffers."""
+        num_lanes = encoder_num_lanes(self.mesh, self.vision_tp)
+        capacity = patches.size // (num_lanes * self.patch_dim)
+        token_sharding = self.specs.sharding(self.specs.batch_axis)
+        patches = patches.reshape(-1, self.patch_dim, out_sharding=token_sharding)
+        spec = PartitionSpec(self.specs.batch_axis)
+        metadata_views = jax.shard_map(
+            partial(self._metadata_views, capacity=capacity),
+            mesh=self.mesh,
+            in_specs=spec,
+            out_specs=(spec,) * 4,
+            check_vma=False,
+        )(metadata)
+        patches = patches.astype(self.dtype)
+        return self._forward(patches, *metadata_views)
 
     def precompile(self) -> None:
         precompile_mrope_vision_model(
@@ -492,109 +618,8 @@ class Qwen2_5_VisionTransformer(nnx.Module):
             patch_dim=self.patch_dim,
             merge_unit=self.spatial_merge_unit,
             rope_type="rope_3d",
-            dtype=self.dtype,
-        )
-
-    def _build_metadata(
-        self,
-        lane_grids: np.ndarray,
-        capacity: int,
-    ) -> tuple[np.ndarray, np.ndarray, VisionAttentionMetadata, VisionAttentionMetadata]:
-        lane_grids = np.asarray(lane_grids, dtype=np.int32)
-        if lane_grids.ndim == 2:
-            lane_grids = lane_grids[None]
-        batch = len(lane_grids)
-        merge = self.spatial_merge_size
-        unit = self.spatial_merge_unit
-        num_units = capacity // unit
-        window = self.window_size // merge // self.patch_size
-        unit_range = np.arange(num_units, dtype=np.int32)
-        indices = np.broadcast_to(unit_range[None, :, None], (batch, num_units, 2)).copy()
-        position_ids = np.zeros((batch, capacity, 2), dtype=np.int32)
-        cu_seqlens = np.zeros((batch, 2, num_units + 1), dtype=np.int32)
-
-        def grid_layout(t: int, h: int, w: int):
-            grid_h, grid_w = h // merge, w // merge
-            index = np.arange(t * grid_h * grid_w).reshape(t, grid_h, grid_w)
-            pad_h, pad_w = (-grid_h) % window, (-grid_w) % window
-            windows_h, windows_w = (grid_h + pad_h) // window, (grid_w + pad_w) // window
-            index = np.pad(index, ((0, 0), (0, pad_h), (0, pad_w)), constant_values=-1)
-            index = index.reshape(t, windows_h, window, windows_w, window)
-            index = index.transpose(0, 1, 3, 2, 4).reshape(-1, window, window)
-            window_lengths = (index != -1).sum(axis=(1, 2)).astype(np.int32) * unit
-            index = index.reshape(-1)
-            index = index[index != -1].astype(np.int32)
-
-            y, x = np.indices((h, w))
-            coords = np.stack((y, x), axis=-1)
-            coords = coords.reshape(grid_h, merge, grid_w, merge, 2)
-            coords = coords.transpose(0, 2, 1, 3, 4).reshape(h * w, 2)
-            coords = np.tile(coords, (t, 1))
-            coords = coords.reshape(-1, unit, 2)[index].reshape(t * h * w, 2)
-            return index, window_lengths, coords
-
-        for lane, grids in enumerate(lane_grids):
-            patch_offset = unit_offset = 0
-            window_ends = []
-            frame_ends = []
-            for grid in grids:
-                if not np.any(grid):
-                    continue
-                t, h, w = map(int, grid)
-                patch_count = t * h * w
-                window_index, window_lengths, coords = grid_layout(t, h, w)
-                unit_count = patch_count // unit
-                patch_slice = slice(patch_offset, patch_offset + patch_count)
-                unit_slice = slice(unit_offset, unit_offset + unit_count)
-                indices[lane, unit_slice, 0] = window_index + unit_offset
-                position_ids[lane, patch_slice] = coords
-                window_ends.extend(patch_offset + np.cumsum(window_lengths))
-                frame_ends.extend(patch_offset + np.arange(1, t + 1, dtype=np.int32) * h * w)
-                patch_offset += patch_count
-                unit_offset += unit_count
-            indices[lane, :, 1] = np.argsort(indices[lane, :, 0]).astype(np.int32)
-            for layout, ends in enumerate((window_ends, frame_ends)):
-                count = len(ends)
-                cu_seqlens[lane, layout, 1 : count + 1] = ends
-                cu_seqlens[lane, layout, count + 1 :] = patch_offset
-        # cu_seqlens[:, 0] is the window layout, [:, 1] the full-frame layout.
-        window_cu_seqlens = cu_seqlens[:, 0]
-        full_cu_seqlens = cu_seqlens[:, 1]
-        # Static bounds must depend only on the compile bucket, not the request's
-        # exact segment values, so requests in one bucket share a compilation.
-        window_max_seq_len = min(capacity, window * window * unit)
-        return (
-            indices,
-            position_ids,
-            VisionAttentionMetadata(
-                window_cu_seqlens,
-                max_seq_len=window_max_seq_len,
-            ),
-            VisionAttentionMetadata(
-                full_cu_seqlens,
-                max_seq_len=capacity,
-            ),
-        )
-
-    @jax.jit
-    def _encode_jit(
-        self,
-        patches: jax.Array,
-        indices: jax.Array,
-        position_ids: jax.Array,
-        window_attn: VisionAttentionMetadata,
-        full_attn: VisionAttentionMetadata,
-    ) -> jax.Array:
-        features = self._forward(patches, indices, position_ids, window_attn, full_attn)
-        # Keep the DP lane-to-replicated transition inside the compiled encode.
-        # An eager reshard of a multi-device result can otherwise stage through
-        # the host when no source device owns the complete array.
-        return jax.sharding.reshard(
-            features,
-            NamedSharding(
-                self.mesh,
-                PartitionSpec(*([None] * features.ndim)),
-            ),
+            input_sharding=self.specs.sharding(self.specs.batch_axis),
+            output_sharding=self.specs.sharding(),
         )
 
 
@@ -661,12 +686,6 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module, InModelMultimodalContract):
         return tuple(rows * bucket // unit for bucket in self.visual.input_buckets)
 
     def get_image_feature(self, items: list[MultimodalDataItem]) -> jax.Array:
-        return self._get_visual_feature(items)
-
-    def get_video_feature(self, items: list[MultimodalDataItem]) -> jax.Array:
-        return self._get_visual_feature(items)
-
-    def _get_visual_feature(self, items: list[MultimodalDataItem]) -> jax.Array:
         num_lanes = encoder_num_lanes(self.mesh, self.visual.vision_tp)
         return run_mrope_vision_model(
             self.visual,
@@ -676,8 +695,12 @@ class Qwen2_5_VLForConditionalGeneration(nnx.Module, InModelMultimodalContract):
             buckets=self.visual.input_buckets,
             merge_unit=self.visual.spatial_merge_unit,
             rope_type="rope_3d",
-            dtype=self.dtype,
+            input_sharding=self.visual.specs.sharding(self.visual.specs.batch_axis),
+            output_sharding=self.visual.specs.sharding(),
         )
+
+    def get_video_feature(self, items: list[MultimodalDataItem]) -> jax.Array:
+        return self.get_image_feature(items)
 
     def get_multimodal_encode_funcs(self):
         return {

--- a/python/sgl_jax/srt/models/qwen2_5_vl.py
+++ b/python/sgl_jax/srt/models/qwen2_5_vl.py
@@ -423,7 +423,7 @@ class Qwen2_5_VisionTransformer(nnx.Module):
     # Accept strided and read-only grids without additional specializations.
     @staticmethod
     @njit(
-        types.int32[::1](
+        types.Tuple((types.int32[:, ::1], types.int32[:, ::1], types.int32[::1], types.int32[::1]))(
             types.Array(types.int32, 3, "A", readonly=True),
             types.int64,
             types.int64,
@@ -435,7 +435,6 @@ class Qwen2_5_VisionTransformer(nnx.Module):
     def _build_metadata(grid_thw, capacity, merge, window):
         """Write lane-local permutations, positions and boundaries in one pass.
 
-        The flat buffer matches ``Qwen2_5_VisionTransformer._metadata_views``.
         Visit only valid merge units in window order, avoiding padded indices,
         coordinate grids, gathers and per-image temporary arrays.
         """
@@ -448,16 +447,16 @@ class Qwen2_5_VisionTransformer(nnx.Module):
             raise ValueError("grid_thw must have three coordinates per grid")
         num_lanes = grid_thw.shape[0]
         num_units = capacity // unit
-        positions_start = 2 * num_units
-        window_start = positions_start + 2 * capacity
-        full_start = window_start + num_units + 1
-        metadata = np.zeros((num_lanes, full_start + num_units + 1), dtype=np.int32)
+        indices = np.zeros((num_lanes, num_units, 2), dtype=np.int32)
+        position_ids = np.zeros((num_lanes, capacity, 2), dtype=np.int32)
+        window_cu_seqlens = np.zeros((num_lanes, num_units + 1), dtype=np.int32)
+        full_cu_seqlens = np.zeros((num_lanes, num_units + 1), dtype=np.int32)
 
         for lane in range(num_lanes):
             # Padding units retain the identity permutation and zero positions.
             for index in range(num_units):
-                metadata[lane, 2 * index] = index
-                metadata[lane, 2 * index + 1] = index
+                indices[lane, index, 0] = index
+                indices[lane, index, 1] = index
             patch_offset = unit_offset = 0
             window_segment = frame_segment = 1
             for image in range(grid_thw.shape[1]):
@@ -478,27 +477,31 @@ class Qwen2_5_VisionTransformer(nnx.Module):
                             for y in range(window_y, min(window_y + window, grid_h)):
                                 for x in range(window_x, min(window_x + window, grid_w)):
                                     source_unit = frame_unit_offset + y * grid_w + x
-                                    metadata[lane, 2 * unit_offset] = source_unit
-                                    metadata[lane, 2 * source_unit + 1] = unit_offset
+                                    indices[lane, unit_offset, 0] = source_unit
+                                    indices[lane, source_unit, 1] = unit_offset
                                     for dy in range(merge):
                                         for dx in range(merge):
-                                            position = positions_start + 2 * patch_offset
-                                            metadata[lane, position] = y * merge + dy
-                                            metadata[lane, position + 1] = x * merge + dx
+                                            position_ids[lane, patch_offset, 0] = y * merge + dy
+                                            position_ids[lane, patch_offset, 1] = x * merge + dx
                                             patch_offset += 1
                                     unit_offset += 1
-                            metadata[lane, window_start + window_segment] = patch_offset
+                            window_cu_seqlens[lane, window_segment] = patch_offset
                             window_segment += 1
-                    metadata[lane, full_start + frame_segment] = patch_offset
+                    full_cu_seqlens[lane, frame_segment] = patch_offset
                     frame_segment += 1
             # Repeated final ends describe empty segments in the bucket padding.
-            metadata[lane, window_start + window_segment : full_start] = patch_offset
-            metadata[lane, full_start + frame_segment :] = patch_offset
-        return metadata.reshape(-1)
+            window_cu_seqlens[lane, window_segment:] = patch_offset
+            full_cu_seqlens[lane, frame_segment:] = patch_offset
+        return (
+            indices.reshape(-1, 2),
+            position_ids.reshape(-1, 2),
+            window_cu_seqlens.reshape(-1),
+            full_cu_seqlens.reshape(-1),
+        )
 
     def prepare_metadata(
         self, grid_thw: np.ndarray, capacity: int, *, sharding: NamedSharding
-    ) -> jax.Array:
+    ) -> dict[str, jax.Array]:
         """Build host attention metadata and upload it with the input sharding."""
         with jax.profiler.TraceAnnotation("encoder_metadata_host_build"):
             grid_thw = np.asarray(grid_thw, dtype=np.int32)
@@ -506,28 +509,20 @@ class Qwen2_5_VisionTransformer(nnx.Module):
                 grid_thw = grid_thw[None]
             if grid_thw.ndim != 3 or grid_thw.shape[-1] != 3:
                 raise ValueError("grid_thw must have shape [items, 3] or [lanes, items, 3]")
-            metadata = self._build_metadata(
+            indices, position_ids, window_cu_seqlens, full_cu_seqlens = self._build_metadata(
                 grid_thw,
                 capacity,
                 self.spatial_merge_size,
                 self.window_size // self.spatial_merge_size // self.patch_size,
             )
+            metadata = {
+                "indices": indices,
+                "position_ids": position_ids,
+                "window_cu_seqlens": window_cu_seqlens,
+                "full_cu_seqlens": full_cu_seqlens,
+            }
         with jax.profiler.TraceAnnotation("encoder_metadata_device_put"):
             return jax.device_put(metadata, sharding)
-
-    def _metadata_views(self, metadata: np.ndarray | jax.Array, capacity: int):
-        """Views of the same buffer on the host and inside the ViT JIT."""
-        leading_shape = metadata.shape[:-1]
-        num_units = capacity // self.spatial_merge_unit
-        indices_end = 2 * num_units
-        positions_end = indices_end + 2 * capacity
-        window_end = positions_end + num_units + 1
-        return (
-            metadata[..., :indices_end].reshape(*leading_shape, num_units, 2),
-            metadata[..., indices_end:positions_end].reshape(*leading_shape, capacity, 2),
-            metadata[..., positions_end:window_end],
-            metadata[..., window_end:],
-        )
 
     def _reorder(self, x: jax.Array, indices: jax.Array) -> jax.Array:
         """Gather within each device's lane, using lane-local unit indices."""
@@ -543,9 +538,9 @@ class Qwen2_5_VisionTransformer(nnx.Module):
     def __call__(
         self,
         patches: jax.Array,
-        metadata: jax.Array,
+        **metadata: jax.Array,
     ) -> jax.Array:
-        return self.encode(patches, metadata)
+        return self.encode(patches, **metadata)
 
     def _forward(
         self,
@@ -591,23 +586,23 @@ class Qwen2_5_VisionTransformer(nnx.Module):
     def encode(
         self,
         patches: jax.Array,
-        metadata: jax.Array,
+        *,
+        indices: jax.Array,
+        position_ids: jax.Array,
+        window_cu_seqlens: jax.Array,
+        full_cu_seqlens: jax.Array,
     ) -> jax.Array:
-        """Encode flat lane-major patch and metadata buffers."""
-        num_lanes = encoder_num_lanes(self.mesh, self.vision_tp)
-        capacity = patches.size // (num_lanes * self.patch_dim)
+        """Encode flat patches with lane-major attention metadata."""
         token_sharding = self.specs.sharding(self.specs.batch_axis)
         patches = patches.reshape(-1, self.patch_dim, out_sharding=token_sharding)
-        spec = PartitionSpec(self.specs.batch_axis)
-        metadata_views = jax.shard_map(
-            partial(self._metadata_views, capacity=capacity),
-            mesh=self.mesh,
-            in_specs=spec,
-            out_specs=(spec,) * 4,
-            check_vma=False,
-        )(metadata)
         patches = patches.astype(self.dtype)
-        return self._forward(patches, *metadata_views)
+        return self._forward(
+            patches,
+            indices,
+            position_ids,
+            window_cu_seqlens,
+            full_cu_seqlens,
+        )
 
     def precompile(self) -> None:
         precompile_mrope_vision_model(

--- a/python/sgl_jax/srt/models/qwen3_vl.py
+++ b/python/sgl_jax/srt/models/qwen3_vl.py
@@ -1,6 +1,5 @@
 import logging
 from collections.abc import Callable
-from functools import partial
 from types import SimpleNamespace
 
 import jax
@@ -450,9 +449,9 @@ class Qwen3VLVisionModel(nnx.Module):
     def __call__(
         self,
         patches: jax.Array,
-        metadata: jax.Array,
+        **metadata: jax.Array,
     ) -> jax.Array:
-        return self.encode(patches, metadata)
+        return self.encode(patches, **metadata)
 
     def _forward(
         self,
@@ -499,27 +498,27 @@ class Qwen3VLVisionModel(nnx.Module):
     def encode(
         self,
         patches: jax.Array,
-        metadata: jax.Array,
+        *,
+        pos_indices: jax.Array,
+        pos_weights: jax.Array,
+        position_ids: jax.Array,
+        cu_seqlens: jax.Array,
     ) -> jax.Array:
-        """Encode flat lane-major patch and metadata buffers."""
-        num_lanes = encoder_num_lanes(self.mesh, self.vision_tp)
-        capacity = patches.size // (num_lanes * self.patch_dim)
+        """Encode flat patches with lane-major position and attention metadata."""
         token_sharding = self.specs.sharding(self.specs.batch_axis)
         patches = patches.reshape(
             -1,
             self.patch_dim,
             out_sharding=token_sharding,
         )
-        spec = PartitionSpec(self.specs.batch_axis)
-        metadata_views = jax.shard_map(
-            partial(self._metadata_views, capacity=capacity),
-            mesh=self.mesh,
-            in_specs=spec,
-            out_specs=(spec,) * 4,
-            check_vma=False,
-        )(metadata)
         patches = patches.astype(self.dtype)
-        output, deepstack = self._forward(patches, *metadata_views)
+        output, deepstack = self._forward(
+            patches,
+            pos_indices,
+            pos_weights,
+            position_ids,
+            cu_seqlens,
+        )
         if self.mesh is not None:
             output = apply_data_sharding(output, self.mesh, PartitionSpec(self.specs.batch_axis))
             deepstack = apply_data_sharding(
@@ -562,7 +561,7 @@ class Qwen3VLVisionModel(nnx.Module):
         capacity: int,
         *,
         sharding: NamedSharding,
-    ) -> jax.Array:
+    ) -> dict[str, jax.Array]:
         with jax.profiler.TraceAnnotation("encoder_metadata_host_build"):
             grid_thw = np.asarray(grid_thw, dtype=np.int32)
             if grid_thw.ndim == 2:
@@ -573,21 +572,6 @@ class Qwen3VLVisionModel(nnx.Module):
         with jax.profiler.TraceAnnotation("encoder_metadata_device_put"):
             return jax.device_put(metadata, sharding)
 
-    def _metadata_views(self, metadata: np.ndarray | jax.Array, capacity: int):
-        """Decode one lane's flat metadata buffer into token-major views."""
-        leading_shape = metadata.shape[:-1]
-        indices_end = 4 * capacity
-        weights_end = indices_end + 4 * capacity
-        positions_end = weights_end + 2 * capacity
-        return (
-            metadata[..., :indices_end].reshape(*leading_shape, capacity, 4),
-            jax.lax.bitcast_convert_type(
-                metadata[..., indices_end:weights_end], jnp.float32
-            ).reshape(*leading_shape, capacity, 4),
-            metadata[..., weights_end:positions_end].reshape(*leading_shape, capacity, 2),
-            metadata[..., positions_end:],
-        )
-
     def _build_metadata(self, grid_thw: np.ndarray, capacity: int):
         lane_metadata = [
             self._lane_metadata(
@@ -596,19 +580,13 @@ class Qwen3VLVisionModel(nnx.Module):
             )
             for lane in grid_thw
         ]
-        flat_lanes = []
-        for pos_indices, pos_weights, position_ids, cu_seqlens in lane_metadata:
-            flat_lanes.append(
-                np.concatenate(
-                    (
-                        pos_indices.T.reshape(-1),
-                        np.ascontiguousarray(pos_weights.T).view(np.int32).reshape(-1),
-                        position_ids.reshape(-1),
-                        cu_seqlens,
-                    )
-                )
-            )
-        return np.stack(flat_lanes).reshape(-1)
+        pos_indices, pos_weights, position_ids, cu_seqlens = zip(*lane_metadata)
+        return {
+            "pos_indices": np.concatenate([indices.T for indices in pos_indices]),
+            "pos_weights": np.concatenate([weights.T for weights in pos_weights]),
+            "position_ids": np.concatenate(position_ids),
+            "cu_seqlens": np.concatenate(cu_seqlens),
+        }
 
 
 class Qwen3VLForConditionalGeneration(nnx.Module, InModelMultimodalContract):

--- a/python/sgl_jax/srt/models/qwen3_vl.py
+++ b/python/sgl_jax/srt/models/qwen3_vl.py
@@ -1,12 +1,13 @@
 import logging
 from collections.abc import Callable
+from functools import partial
 from types import SimpleNamespace
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 from flax import nnx
-from jax.sharding import PartitionSpec
+from jax.sharding import NamedSharding, PartitionSpec
 
 from sgl_jax.srt.configs.model_config import ModelConfig
 from sgl_jax.srt.hf_transformers_utils import get_hf_text_config
@@ -24,7 +25,6 @@ from sgl_jax.srt.multimodal.in_model.lane_packing import (
     run_mrope_vision_model,
 )
 from sgl_jax.srt.multimodal.layers.attention.flash_attention_backend import (
-    VisionAttentionMetadata,
     make_vision_attention_backend,
 )
 from sgl_jax.srt.multimodal.layers.vision_sharding import (
@@ -155,7 +155,7 @@ def _merge_order(x: np.ndarray, t: int, h: int, w: int, merge: int) -> np.ndarra
 def _rope(x: jax.Array, freqs: jax.Array) -> jax.Array:
     half = x.shape[-1] // 2
     left, right = x[..., :half], x[..., half:]
-    cos, sin = jnp.cos(freqs)[:, :, None], jnp.sin(freqs)[:, :, None]
+    cos, sin = jnp.cos(freqs)[:, None, :], jnp.sin(freqs)[:, None, :]
     return jnp.concatenate((left * cos - right * sin, left * sin + right * cos), axis=-1).astype(
         x.dtype
     )
@@ -181,10 +181,10 @@ class Qwen3VLPatchEmbed(nnx.Module):
         )
 
     def __call__(self, x):
-        batch, length, _ = x.shape
+        tokens = x.shape[0]
         sh = self.specs.sharding(self.specs.batch_axis)
         x = x.reshape(
-            batch * length,
+            tokens,
             self.channels,
             self.temporal,
             self.patch,
@@ -192,7 +192,7 @@ class Qwen3VLPatchEmbed(nnx.Module):
             out_sharding=sh,
         )
         x = jnp.transpose(x, (0, 2, 3, 4, 1))
-        x = self.proj(x, out_sharding=sh).reshape(batch, length, self.hidden, out_sharding=sh)
+        x = self.proj(x, out_sharding=sh).reshape(tokens, self.hidden, out_sharding=sh)
         if self.mesh is not None:
             x = apply_data_sharding(x, self.mesh, PartitionSpec(self.specs.batch_axis))
         return x
@@ -221,7 +221,7 @@ class Qwen3VLVisionMLP(nnx.Module):
 
     def __call__(self, x):
         specs = self.specs
-        x, _ = self.fc1(x, out_sharding=specs.sharding(specs.batch_axis, None, specs.tensor_axis))
+        x, _ = self.fc1(x, out_sharding=specs.sharding(specs.batch_axis, specs.tensor_axis))
         x = jax.nn.gelu(x, approximate=self.approximate)
         return self.fc2(x, out_sharding=specs.sharding(specs.batch_axis))[0]
 
@@ -263,10 +263,10 @@ class Qwen3VLVisionAttention(nnx.Module):
             use_varlen=True,
         )
 
-    def __call__(self, x, freqs, metadata):
-        batch, length, _ = x.shape
+    def __call__(self, x, freqs, cu_seqlens, *, max_seq_len: int):
+        tokens, hidden = x.shape
         specs = self.specs
-        col = specs.sharding(specs.batch_axis, None, specs.tensor_axis)
+        col = specs.sharding(specs.batch_axis, specs.tensor_axis)
         q, k, v = (
             layer(x, out_sharding=col)[0]
             for layer in (
@@ -275,13 +275,20 @@ class Qwen3VLVisionAttention(nnx.Module):
                 self.v_proj,
             )
         )
-        sharding = specs.sharding(specs.batch_axis, None, specs.tensor_axis, None)
+        sharding = specs.sharding(specs.batch_axis, specs.tensor_axis, None)
         q, k, v = (
-            value.reshape(batch, length, self.heads, self.head_dim, out_sharding=sharding)
+            value.reshape(tokens, self.heads, self.head_dim, out_sharding=sharding)
             for value in (q, k, v)
         )
-        output = self.backend(_rope(q, freqs), _rope(k, freqs), v, metadata)
-        output = output.reshape(batch, length, self.hidden, out_sharding=col)
+        q, k = _rope(q, freqs), _rope(k, freqs)
+        output = self.backend(
+            q,
+            k,
+            v,
+            cu_seqlens,
+            max_seq_len=max_seq_len,
+        )
+        output = output.reshape(tokens, hidden, out_sharding=col)
         return self.proj(output, out_sharding=specs.sharding(specs.batch_axis))[0]
 
 
@@ -300,8 +307,13 @@ class Qwen3VLVisionBlock(nnx.Module):
         self.attn = Qwen3VLVisionAttention(config, dtype, mesh, specs)
         self.mlp = Qwen3VLVisionMLP(config, dtype, mesh, specs)
 
-    def __call__(self, x, freqs, metadata):
-        x = x + self.attn(self.norm1(x), freqs, metadata)
+    def __call__(self, x, freqs, cu_seqlens, *, max_seq_len: int):
+        x = x + self.attn(
+            self.norm1(x),
+            freqs,
+            cu_seqlens,
+            max_seq_len=max_seq_len,
+        )
         return x + self.mlp(self.norm2(x))
 
 
@@ -339,10 +351,10 @@ class Qwen3VLPatchMerger(nnx.Module):
         specs = self.specs
         sharding = specs.sharding(specs.batch_axis)
         if self.postshuffle:
-            x = self.norm(x.reshape(x.shape[0], -1, self.hidden, out_sharding=sharding))
+            x = self.norm(x.reshape(-1, self.hidden, out_sharding=sharding))
         else:
-            x = self.norm(x).reshape(x.shape[0], -1, self.hidden, out_sharding=sharding)
-        x, _ = self.fc1(x, out_sharding=specs.sharding(specs.batch_axis, None, specs.tensor_axis))
+            x = self.norm(x).reshape(-1, self.hidden, out_sharding=sharding)
+        x, _ = self.fc1(x, out_sharding=specs.sharding(specs.batch_axis, specs.tensor_axis))
         x = jax.nn.gelu(x, approximate=False)
         return self.fc2(x, out_sharding=sharding)[0]
 
@@ -438,9 +450,9 @@ class Qwen3VLVisionModel(nnx.Module):
     def __call__(
         self,
         patches: jax.Array,
-        grid_thw: np.ndarray | jax.Array,
+        metadata: jax.Array,
     ) -> jax.Array:
-        return self.encode(patches, grid_thw)
+        return self.encode(patches, metadata)
 
     def _forward(
         self,
@@ -448,8 +460,10 @@ class Qwen3VLVisionModel(nnx.Module):
         pos_indices: jax.Array,
         pos_weights: jax.Array,
         position_ids: jax.Array,
-        metadata: VisionAttentionMetadata,
+        cu_seqlens: jax.Array,
     ) -> tuple[jax.Array, jax.Array]:
+        tokens = patches.shape[0]
+        capacity = tokens // encoder_num_lanes(self.mesh, self.vision_tp)
         inv_freq = 1.0 / (
             10000.0 ** (jnp.arange(0, self.rotary_dim, 2, dtype=jnp.float32) / self.rotary_dim)
         )
@@ -469,60 +483,65 @@ class Qwen3VLVisionModel(nnx.Module):
         # by every block.
         deepstack = []
         for index, block in enumerate(self.blocks):
-            x = block(x, rotary_pos_emb, metadata)
+            x = block(x, rotary_pos_emb, cu_seqlens, max_seq_len=capacity)
             if index in self.deepstack_indexes:
                 merger = self.deepstack_mergers[self.deepstack_indexes.index(index)]
                 deepstack.append(merger(x))
         merged = self.merger(x)
         deepstack = (
-            jnp.stack(deepstack, axis=2)
+            jnp.stack(deepstack, axis=1)
             if deepstack
-            else jnp.empty((x.shape[0], merged.shape[1], 0, merged.shape[2]), x.dtype)
+            else jnp.empty((merged.shape[0], 0, merged.shape[1]), x.dtype)
         )
         return merged, deepstack
 
     @jax.jit
-    def _encode_jit(
+    def encode(
         self,
         patches: jax.Array,
-        pos_indices: jax.Array,
-        pos_weights: jax.Array,
-        position_ids: jax.Array,
-        metadata: VisionAttentionMetadata,
+        metadata: jax.Array,
     ) -> jax.Array:
-        output, deepstack = self._forward(
-            patches,
-            pos_indices,
-            pos_weights,
-            position_ids,
-            metadata,
+        """Encode flat lane-major patch and metadata buffers."""
+        num_lanes = encoder_num_lanes(self.mesh, self.vision_tp)
+        capacity = patches.size // (num_lanes * self.patch_dim)
+        token_sharding = self.specs.sharding(self.specs.batch_axis)
+        patches = patches.reshape(
+            -1,
+            self.patch_dim,
+            out_sharding=token_sharding,
         )
+        spec = PartitionSpec(self.specs.batch_axis)
+        metadata_views = jax.shard_map(
+            partial(self._metadata_views, capacity=capacity),
+            mesh=self.mesh,
+            in_specs=spec,
+            out_specs=(spec,) * 4,
+            check_vma=False,
+        )(metadata)
+        patches = patches.astype(self.dtype)
+        output, deepstack = self._forward(patches, *metadata_views)
         if self.mesh is not None:
             output = apply_data_sharding(output, self.mesh, PartitionSpec(self.specs.batch_axis))
             deepstack = apply_data_sharding(
                 deepstack, self.mesh, PartitionSpec(self.specs.batch_axis)
             )
         # Concatenate deepstack planes onto the trailing feature axis so the merge
-        # gathers one [rows, cap, (1+D)*H] tensor. D is static at trace time.
-        deepstack_dim = deepstack.shape[2]
+        # gathers one [rows, (1+D)*H] tensor. D is static at trace time.
+        deepstack_dim = deepstack.shape[1]
         if deepstack_dim:
-            b, cap, h = output.shape
+            tokens, hidden = output.shape
             output = jnp.concatenate(
-                [output, deepstack.reshape(b, cap, deepstack_dim * h)], axis=-1
+                [
+                    output,
+                    deepstack.reshape(
+                        tokens,
+                        deepstack_dim * hidden,
+                        out_sharding=token_sharding,
+                    ),
+                ],
+                axis=-1,
             )
         return output
-
-    def encode(self, patches: jax.Array, grid_thw: np.ndarray | jax.Array) -> jax.Array:
-        batch_sharding = self.specs.sharding(self.specs.batch_axis)
-        patches = jax.device_put(patches, batch_sharding)
-        metadata = jax.device_put(
-            self._build_metadata(grid_thw, patches.shape[1]),
-            batch_sharding,
-        )
-        if self.mesh is None:
-            return self._encode_jit(patches, *metadata)
-        with jax.set_mesh(self.mesh):
-            return self._encode_jit(patches, *metadata)
 
     def precompile(self) -> None:
         precompile_mrope_vision_model(
@@ -533,13 +552,43 @@ class Qwen3VLVisionModel(nnx.Module):
             patch_dim=self.patch_dim,
             merge_unit=self.spatial_merge_unit,
             rope_type="rope_3d",
-            dtype=self.dtype,
+            input_sharding=self.specs.sharding(self.specs.batch_axis),
+            output_sharding=self.specs.sharding(),
         )
 
-    def _build_metadata(self, grid_thw: np.ndarray | jax.Array, capacity: int):
-        grid_thw = np.asarray(jax.device_get(grid_thw), dtype=np.int32)
-        if grid_thw.ndim == 2:
-            grid_thw = grid_thw[None]
+    def prepare_metadata(
+        self,
+        grid_thw: np.ndarray,
+        capacity: int,
+        *,
+        sharding: NamedSharding,
+    ) -> jax.Array:
+        with jax.profiler.TraceAnnotation("encoder_metadata_host_build"):
+            grid_thw = np.asarray(grid_thw, dtype=np.int32)
+            if grid_thw.ndim == 2:
+                grid_thw = grid_thw[None]
+            if grid_thw.ndim != 3 or grid_thw.shape[-1] != 3:
+                raise ValueError("grid_thw must have shape [items, 3] or [lanes, items, 3]")
+            metadata = self._build_metadata(grid_thw, capacity)
+        with jax.profiler.TraceAnnotation("encoder_metadata_device_put"):
+            return jax.device_put(metadata, sharding)
+
+    def _metadata_views(self, metadata: np.ndarray | jax.Array, capacity: int):
+        """Decode one lane's flat metadata buffer into token-major views."""
+        leading_shape = metadata.shape[:-1]
+        indices_end = 4 * capacity
+        weights_end = indices_end + 4 * capacity
+        positions_end = weights_end + 2 * capacity
+        return (
+            metadata[..., :indices_end].reshape(*leading_shape, capacity, 4),
+            jax.lax.bitcast_convert_type(
+                metadata[..., indices_end:weights_end], jnp.float32
+            ).reshape(*leading_shape, capacity, 4),
+            metadata[..., weights_end:positions_end].reshape(*leading_shape, capacity, 2),
+            metadata[..., positions_end:],
+        )
+
+    def _build_metadata(self, grid_thw: np.ndarray, capacity: int):
         lane_metadata = [
             self._lane_metadata(
                 [tuple(map(int, grid)) for grid in lane if np.any(grid)],
@@ -547,14 +596,19 @@ class Qwen3VLVisionModel(nnx.Module):
             )
             for lane in grid_thw
         ]
-        pos_indices, pos_weights, position_ids, cu_seqlens = (
-            np.stack(values) for values in zip(*lane_metadata, strict=True)
-        )
-        metadata = VisionAttentionMetadata(
-            cu_seqlens,
-            max_seq_len=capacity,
-        )
-        return pos_indices, pos_weights, position_ids, metadata
+        flat_lanes = []
+        for pos_indices, pos_weights, position_ids, cu_seqlens in lane_metadata:
+            flat_lanes.append(
+                np.concatenate(
+                    (
+                        pos_indices.T.reshape(-1),
+                        np.ascontiguousarray(pos_weights.T).view(np.int32).reshape(-1),
+                        position_ids.reshape(-1),
+                        cu_seqlens,
+                    )
+                )
+            )
+        return np.stack(flat_lanes).reshape(-1)
 
 
 class Qwen3VLForConditionalGeneration(nnx.Module, InModelMultimodalContract):
@@ -637,6 +691,8 @@ class Qwen3VLForConditionalGeneration(nnx.Module, InModelMultimodalContract):
             buckets=self.visual.input_buckets,
             merge_unit=self.visual.spatial_merge_unit,
             rope_type="rope_3d",
+            input_sharding=self.visual.specs.sharding(self.visual.specs.batch_axis),
+            output_sharding=self.visual.specs.sharding(),
         )
 
     def get_multimodal_encode_funcs(self):

--- a/python/sgl_jax/srt/multimodal/common/modality_enum.py
+++ b/python/sgl_jax/srt/multimodal/common/modality_enum.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 import jax
 import jax.numpy as jnp
 import numpy as np
+import xxhash
 
 
 def flatten_nested_list(nested_list):
@@ -28,8 +29,7 @@ def hash_feature(f: Any) -> int:
             return tensor_hash(f)
         return data_hash(tuple(flatten_nested_list(f)))
     elif isinstance(f, np.ndarray):
-        arr = np.ascontiguousarray(f)
-        return data_hash(arr.tobytes())
+        return _array_hash(f)
     elif isinstance(f, jnp.ndarray):
         return tensor_hash([f])
     return data_hash(pickle.dumps(f))
@@ -39,6 +39,11 @@ def data_hash(data: Any) -> int:
     """Hash raw data bytes"""
     hash_bytes = hashlib.sha256(data).digest()[:8]
     return int.from_bytes(hash_bytes, byteorder="big", signed=False)
+
+
+def _array_hash(array: np.ndarray) -> int:
+    """Hash a NumPy array without copying its contiguous byte buffer."""
+    return xxhash.xxh3_64_intdigest(np.ascontiguousarray(array))
 
 
 def tensor_hash(tensor_list: Any) -> int:
@@ -68,7 +73,7 @@ def tensor_hash(tensor_list: Any) -> int:
     # Handle numpy arrays with CPU-based hashing
     if isinstance(tensor, np.ndarray):
         arr = np.ascontiguousarray(tensor.astype(np.float32))
-        return data_hash(arr.tobytes())
+        return _array_hash(arr)
 
     raise TypeError(f"Unsupported tensor type: {type(tensor)}")
 

--- a/python/sgl_jax/srt/multimodal/in_model/lane_packing.py
+++ b/python/sgl_jax/srt/multimodal/in_model/lane_packing.py
@@ -324,12 +324,12 @@ def run_mrope_vision_model(
     input_sharding: NamedSharding,
     output_sharding: NamedSharding,
 ) -> jax.Array:
-    """Prepare sharded patch/metadata buffers, run the model, and restore order.
+    """Prepare sharded patches and metadata, run the model, and restore order.
 
     The model's ``prepare_metadata`` method receives host grids or positions/counts
-    plus ``capacity`` and ``sharding`` and returns a flat device metadata buffer.
-    Both inputs to ``vision_model(patches, metadata)`` are one-dimensional,
-    with contiguous lane slices following ``input_sharding``.
+    plus ``capacity`` and ``sharding`` and returns a dict of model-specific device arrays.
+    Patches are flat; metadata arrays retain their field shapes. Both use
+    contiguous lane slices following ``input_sharding``.
     The restored encoder output uses ``output_sharding``.
     Patches retain their input dtype; the model casts them inside its encode JIT.
     """
@@ -361,7 +361,7 @@ def run_mrope_vision_model(
         )
     with jax.set_mesh(mesh):
         with jax.profiler.TraceAnnotation("encoder_vision_dispatch"):
-            output = vision_model(patches, metadata)
+            output = vision_model(patches, **metadata)
         return restore_encoder_output(output, output_indices, output_sharding)
 
 

--- a/python/sgl_jax/srt/multimodal/in_model/lane_packing.py
+++ b/python/sgl_jax/srt/multimodal/in_model/lane_packing.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import functools
 import math
-from collections.abc import Callable
-from dataclasses import dataclass
 from typing import Literal
 
 import jax
@@ -13,8 +11,10 @@ import jax.numpy as jnp
 import numpy as np
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from jax.typing import ArrayLike
+from numba import njit, types
 
 from sgl_jax.srt.multimodal.common.modality_enum import Modality, MultimodalDataItem
+from sgl_jax.srt.utils.jax_utils import canonicalize_sharding
 
 
 def get_grid_thw(item: MultimodalDataItem) -> tuple[int, int, int]:
@@ -83,14 +83,6 @@ def balance_lanes(item_lengths: list[int] | tuple[int, ...], num_lanes: int) -> 
     return lanes
 
 
-@dataclass(frozen=True)
-class PackedLanes:
-    features: np.ndarray  # [num_lanes, cap, *feature_shape]
-    output_indices: np.ndarray
-    lanes: list[list[int]]
-    cap: int
-
-
 def _bucket_capacity(length: int, buckets: tuple[int, ...], unit: int) -> int:
     """Smallest ``unit``-aligned bucket that fits ``length`` (power-of-two fallback)."""
     return next(
@@ -99,49 +91,85 @@ def _bucket_capacity(length: int, buckets: tuple[int, ...], unit: int) -> int:
     )
 
 
+# Sizes are runtime values; compile once at import, before serving requests.
+@njit(
+    types.int32[::1](
+        types.Array(types.int32, 1, "C", readonly=True),
+        types.Array(types.int32, 1, "C", readonly=True),
+        types.int32,
+        types.int32,
+    ),
+    nogil=True,
+    cache=True,
+)
+def _build_output_indices(lengths, output_starts, output_size, merge_unit):
+    output_indices = np.full(output_size, -1, dtype=np.int32)
+    cursor = 0
+    for item_index in range(lengths.size):
+        output_len = lengths[item_index] // merge_unit
+        source_start = output_starts[item_index]
+        for index in range(output_len):
+            output_indices[cursor + index] = source_start + index
+        cursor += output_len
+    return output_indices
+
+
 def pack_lanes(
     items: list[MultimodalDataItem],
     num_lanes: int,
     *,
     buckets: tuple[int, ...],
     merge_unit: int,
-    dtype: np.dtype | type,
-) -> PackedLanes:
-    features_np = [np.asarray(item.feature) for item in items]
-    lengths = [feature.shape[0] for feature in features_np]
-    lanes = balance_lanes(lengths, num_lanes)
-    lane_loads = [sum(lengths[index] for index in lane) for lane in lanes]
-    cap = _bucket_capacity(max(lane_loads), buckets, merge_unit)
-    features = np.zeros((num_lanes, cap, *features_np[0].shape[1:]), dtype=dtype)
-    output_cap = cap // merge_unit
-    output_starts = np.zeros(len(items), dtype=np.int32)
+    input_sharding: NamedSharding,
+    dtype: np.dtype | type | None = None,
+) -> tuple[jax.Array, jax.Array, list[list[int]]]:
 
-    for lane_index, lane in enumerate(lanes):
-        input_offset = 0
-        output_offset = 0
-        for item_index in lane:
-            feature = features_np[item_index]
-            end = input_offset + feature.shape[0]
-            features[lane_index, input_offset:end] = feature
-            out_len = feature.shape[0] // merge_unit
-            output_starts[item_index] = lane_index * output_cap + output_offset
-            input_offset = end
-            output_offset += out_len
+    with jax.profiler.TraceAnnotation("encoder_pack_lane_plan"):
+        if not items:
+            raise ValueError("cannot pack an empty multimodal batch")
+        item_features = [np.asarray(item.feature) for item in items]
+        lengths = np.asarray([feature.shape[0] for feature in item_features], dtype=np.int32)
+        lanes = balance_lanes(lengths.tolist(), num_lanes)
+        lane_loads = [sum(int(lengths[index]) for index in lane) for lane in lanes]
+        cap = _bucket_capacity(max(lane_loads), buckets, merge_unit)
+        feature_shape = item_features[0].shape[1:]
+        if dtype is None:
+            dtype = np.result_type(*(feature.dtype for feature in item_features))
 
-    output_indices = np.full(num_lanes * output_cap, -1, dtype=np.int32)
-    cursor = 0
-    for length, source_start in zip(lengths, output_starts, strict=True):
-        output_len = length // merge_unit
-        output_indices[cursor : cursor + output_len] = source_start + np.arange(
-            output_len, dtype=np.int32
+    with jax.profiler.TraceAnnotation("encoder_pack_allocate"):
+        features = np.empty((num_lanes, cap, *feature_shape), dtype=dtype)
+        output_cap = cap // merge_unit
+        output_starts = np.empty(len(items), dtype=np.int32)
+
+    with jax.profiler.TraceAnnotation("encoder_pack_copy"):
+        for lane_index, lane in enumerate(lanes):
+            input_offset = output_offset = 0
+            for item_index in lane:
+                feature = item_features[item_index]
+                end = input_offset + feature.shape[0]
+                features[lane_index, input_offset:end] = feature
+                output_starts[item_index] = lane_index * output_cap + output_offset
+                input_offset = end
+                output_offset += feature.shape[0] // merge_unit
+
+    with jax.profiler.TraceAnnotation("encoder_pack_output_indices"):
+        output_indices = _build_output_indices(
+            lengths, output_starts, num_lanes * output_cap, merge_unit
         )
-        cursor += output_len
-    return PackedLanes(
-        features=features,
-        output_indices=output_indices,
-        lanes=lanes,
-        cap=cap,
+
+    shard_shape = input_sharding.shard_shape(features.shape)
+    if shard_shape[1:] != features.shape[1:]:
+        raise ValueError("Lane packing requires sharding only along the lane dimension.")
+    flat_sharding = canonicalize_sharding(
+        input_sharding.update(spec=PartitionSpec(*input_sharding.spec[:1]))
     )
+    indices_sharding = canonicalize_sharding(NamedSharding(input_sharding.mesh, PartitionSpec()))
+
+    with jax.profiler.TraceAnnotation("encoder_pack_device_put"):
+        features, output_indices = jax.device_put(
+            (features.reshape(-1), output_indices), (flat_sharding, indices_sharding)
+        )
+    return features, output_indices, lanes
 
 
 def pack_vision_inputs(
@@ -150,24 +178,28 @@ def pack_vision_inputs(
     num_lanes: int,
     buckets: tuple[int, ...],
     merge_unit: int,
-    dtype: np.dtype | type,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    _validate_vision_items(items, merge_unit)
-    packed = pack_lanes(
+    input_sharding: NamedSharding,
+    dtype: np.dtype | type | None = None,
+) -> tuple[jax.Array, jax.Array, np.ndarray]:
+    with jax.profiler.TraceAnnotation("encoder_pack_validate"):
+        _validate_vision_items(items, merge_unit)
+    features, output_indices, lanes = pack_lanes(
         items,
         num_lanes,
         buckets=buckets,
         merge_unit=merge_unit,
+        input_sharding=input_sharding,
         dtype=dtype,
     )
-    grid_thw = np.zeros(
-        (num_lanes, max(map(len, packed.lanes)), 3),
-        dtype=np.int32,
-    )
-    for lane_index, lane in enumerate(packed.lanes):
-        for item_offset, item_index in enumerate(lane):
-            grid_thw[lane_index, item_offset] = get_grid_thw(items[item_index])
-    return packed.features, grid_thw, packed.output_indices
+    with jax.profiler.TraceAnnotation("encoder_pack_lane_metadata"):
+        grid_thw = np.zeros(
+            (num_lanes, max(map(len, lanes)), 3),
+            dtype=np.int32,
+        )
+        for lane_index, lane in enumerate(lanes):
+            for item_offset, item_index in enumerate(lane):
+                grid_thw[lane_index, item_offset] = get_grid_thw(items[item_index])
+    return features, output_indices, grid_thw
 
 
 def pack_2d_position_inputs(
@@ -176,8 +208,9 @@ def pack_2d_position_inputs(
     num_lanes: int,
     buckets: tuple[int, ...],
     merge_unit: int,
-    dtype: np.dtype | type,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    input_sharding: NamedSharding,
+    dtype: np.dtype | type | None = None,
+) -> tuple[jax.Array, jax.Array, np.ndarray, np.ndarray]:
     """Pack vision inputs that carry explicit per-patch 2D positions."""
     item_positions = []
     for item_index, item in enumerate(items):
@@ -208,23 +241,25 @@ def pack_2d_position_inputs(
             raise ValueError(f"Vision item {item_index} pixel_position_ids must be non-negative.")
         item_positions.append(positions)
 
-    packed = pack_lanes(
+    features, output_indices, lanes = pack_lanes(
         items,
         num_lanes,
         buckets=buckets,
         merge_unit=merge_unit,
+        input_sharding=input_sharding,
         dtype=dtype,
     )
+    capacity = output_indices.size * merge_unit // num_lanes
     position_ids = np.full(
-        (num_lanes, packed.cap, 2),
+        (num_lanes, capacity, 2),
         -1,
         dtype=np.int32,
     )
     patch_counts = np.zeros(
-        (num_lanes, max(map(len, packed.lanes))),
+        (num_lanes, max(map(len, lanes))),
         dtype=np.int32,
     )
-    for lane_index, lane in enumerate(packed.lanes):
+    for lane_index, lane in enumerate(lanes):
         offset = 0
         for item_offset, item_index in enumerate(lane):
             positions = item_positions[item_index]
@@ -233,17 +268,18 @@ def pack_2d_position_inputs(
             position_ids[lane_index, offset:end] = positions
             patch_counts[lane_index, item_offset] = item_length
             offset = end
-    return packed.features, position_ids, patch_counts, packed.output_indices
+    return features, output_indices, position_ids, patch_counts
 
 
 def _restore_input_order(
     output: jax.Array,
-    indices: jax.Array,
-    mask: jax.Array,
+    output_indices: jax.Array,
     *,
     out_sharding: NamedSharding,
 ) -> jax.Array:
     output = output.reshape(-1, output.shape[-1])
+    mask = output_indices >= 0
+    indices = jnp.maximum(output_indices, 0)
     output = output.at[indices].get(out_sharding=out_sharding)
     return jnp.where(mask[:, None], output, jnp.zeros((), output.dtype))
 
@@ -253,23 +289,31 @@ _restore_input_order_jit = jax.jit(_restore_input_order, static_argnames=("out_s
 
 def restore_encoder_output(
     output: jax.Array,
-    output_indices: np.ndarray,
-    mesh: Mesh,
+    output_indices: jax.Array,
+    output_sharding: NamedSharding,
 ) -> jax.Array:
-    output_indices = np.asarray(output_indices, dtype=np.int32)
-    mask = output_indices >= 0
-    indices = np.maximum(output_indices, 0)
-    out_sharding = NamedSharding(mesh, PartitionSpec())
+    """Restore lane-packed output to item order.
+
+    Args:
+        output: Encoder output shaped ``[num_lanes * output_capacity, hidden_size]``.
+        output_indices: Gather indices shaped ``[num_lanes * output_capacity]``;
+            negative entries denote padding rows.
+        output_sharding: Sharding for the restored output.
+
+    Returns:
+        An array shaped ``[num_lanes * output_capacity, hidden_size]`` in item
+        order with ``output_sharding`` and padding rows zeroed.
+    """
+    output_sharding = canonicalize_sharding(output_sharding)
     return _restore_input_order_jit(
         output,
-        indices,
-        mask,
-        out_sharding=out_sharding,
+        output_indices,
+        out_sharding=output_sharding,
     )
 
 
 def run_mrope_vision_model(
-    vision_model: Callable[..., jax.Array],
+    vision_model,
     items: list[MultimodalDataItem],
     *,
     mesh: Mesh,
@@ -277,36 +321,52 @@ def run_mrope_vision_model(
     buckets: tuple[int, ...],
     merge_unit: int,
     rope_type: Literal["rope_3d", "rope_2d", "rope_2d_packed"],
-    dtype: np.dtype | type = jnp.bfloat16,
+    input_sharding: NamedSharding,
+    output_sharding: NamedSharding,
 ) -> jax.Array:
-    """Pack, run, and restore a sharded vision model with RoPE metadata."""
+    """Prepare sharded patch/metadata buffers, run the model, and restore order.
+
+    The model's ``prepare_metadata`` method receives host grids or positions/counts
+    plus ``capacity`` and ``sharding`` and returns a flat device metadata buffer.
+    Both inputs to ``vision_model(patches, metadata)`` are one-dimensional,
+    with contiguous lane slices following ``input_sharding``.
+    The restored encoder output uses ``output_sharding``.
+    Patches retain their input dtype; the model casts them inside its encode JIT.
+    """
     if rope_type == "rope_2d_packed":
-        patches, position_ids, patch_counts, output_indices = pack_2d_position_inputs(
+        patches, output_indices, position_ids, patch_counts = pack_2d_position_inputs(
             items,
             num_lanes=num_lanes,
             buckets=buckets,
             merge_unit=merge_unit,
-            dtype=dtype,
+            input_sharding=input_sharding,
         )
-        output = vision_model(patches, position_ids, patch_counts)
+        metadata_args = (position_ids, patch_counts)
     elif rope_type in ("rope_3d", "rope_2d"):
-        patches, grid_thw, output_indices = pack_vision_inputs(
+        patches, output_indices, grid_thw = pack_vision_inputs(
             items,
             num_lanes=num_lanes,
             buckets=buckets,
             merge_unit=merge_unit,
-            dtype=dtype,
+            input_sharding=input_sharding,
         )
-        output = vision_model(patches, grid_thw)
+        metadata_args = (grid_thw,)
     else:
         raise ValueError(f"Unsupported vision RoPE type: {rope_type}")
 
+    capacity = output_indices.size * merge_unit // num_lanes
+    with jax.profiler.TraceAnnotation("encoder_build_vision_metadata"):
+        metadata = vision_model.prepare_metadata(
+            *metadata_args, capacity=capacity, sharding=input_sharding
+        )
     with jax.set_mesh(mesh):
-        return restore_encoder_output(output, output_indices, mesh)
+        with jax.profiler.TraceAnnotation("encoder_vision_dispatch"):
+            output = vision_model(patches, metadata)
+        return restore_encoder_output(output, output_indices, output_sharding)
 
 
 def precompile_mrope_vision_model(
-    vision_model: Callable[..., jax.Array],
+    vision_model,
     *,
     mesh: Mesh,
     num_lanes: int,
@@ -314,7 +374,8 @@ def precompile_mrope_vision_model(
     patch_dim: int,
     merge_unit: int,
     rope_type: Literal["rope_3d", "rope_2d", "rope_2d_packed"],
-    dtype: np.dtype | type = jnp.bfloat16,
+    input_sharding: NamedSharding,
+    output_sharding: NamedSharding,
 ) -> None:
     merge_size = math.isqrt(merge_unit)
     for capacity in buckets:
@@ -328,7 +389,7 @@ def precompile_mrope_vision_model(
             )
         item = MultimodalDataItem(
             modality=Modality.IMAGE,
-            feature=np.zeros((capacity, patch_dim), dtype=dtype),
+            feature=np.zeros((capacity, patch_dim), dtype=np.float32),
             placeholder_ranges=[(0, capacity // merge_unit)],
             model_specific_data=model_specific_data,
         )
@@ -340,6 +401,7 @@ def precompile_mrope_vision_model(
             buckets=buckets,
             merge_unit=merge_unit,
             rope_type=rope_type,
-            dtype=dtype,
+            input_sharding=input_sharding,
+            output_sharding=output_sharding,
         )
         jax.block_until_ready(output)

--- a/python/sgl_jax/srt/multimodal/layers/attention/flash_attention_backend.py
+++ b/python/sgl_jax/srt/multimodal/layers/attention/flash_attention_backend.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import dataclasses
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
@@ -13,31 +12,6 @@ from sgl_jax.srt.multimodal.kernels.varlen_attention import varlen_attention
 
 if TYPE_CHECKING:
     from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
-
-
-@dataclasses.dataclass
-class VisionAttentionMetadata:
-    """Block-diagonal (packed) self-attention layout for the vision tower.
-
-    ``cu_seqlens`` are bucket-shaped cumulative segment boundaries with shape
-    ``[num_lanes, K + 1]``: each row starts with zero, holds a lane's cumulative
-    segment ends, then repeats the final valid end through the padding slots.
-    ``max_seq_len`` is a host-computed upper bound on every positive boundary
-    difference. It is static JAX metadata so the varlen backend can select
-    compile-time block sizes without inspecting traced boundary values. The
-    bound should be stable for an input-shape bucket to avoid recompilation for
-    different segment values with the same shapes.
-    """
-
-    cu_seqlens: Any
-    max_seq_len: int | None = None
-
-
-jax.tree_util.register_dataclass(
-    VisionAttentionMetadata,
-    data_fields=["cu_seqlens"],
-    meta_fields=["max_seq_len"],
-)
 
 
 def _resolve_vision_vmem_limit_bytes(mesh, vmem_limit_bytes: int | None) -> int:
@@ -141,16 +115,12 @@ class FlashAttentionBackend(AttentionBackend):
 
 
 class VisionFlashAttentionBackend(AttentionBackend):
-    """Batch-sharded segment-flash attention for the in-model VLM ViT.
+    """Segment-flash attention over flat ``[tokens, heads, head_dim]`` inputs.
 
-    Kept SEPARATE from ``FlashAttentionBackend`` (which is head-TP, used by
-    ``USPAttention`` for Flux / Wan / Qwen3-Omni audio) so that class stays
-    untouched. With replicated ViT weights, batch lanes span both ``data`` and
-    ``tensor``. With ``head_tp=True``, batch is sharded on ``data`` and heads on
-    ``tensor``. Bucket-shaped cumulative lengths follow the batch sharding and
-    are expanded to dense ids locally inside the shard map. On CPU meshes the
-    same Pallas kernel runs in interpret mode, so this is the only vision
-    backend.
+    Each token shard contains one complete lane. Its flat cumulative lengths
+    are expanded to segment ids locally. The dense kernel's singleton batch
+    and head-major layout are introduced only inside the shard map. CPU meshes
+    run the Pallas kernel in interpret mode.
     """
 
     def __init__(
@@ -171,18 +141,26 @@ class VisionFlashAttentionBackend(AttentionBackend):
         else:
             batch_axis = ("data", "tensor") if "tensor" in mesh.axis_names else "data"
             head_axis = None
-        qkv_spec = P(batch_axis, head_axis, None, None)
-        metadata_spec = P(batch_axis, None)
+        qkv_spec = P(batch_axis, head_axis, None)
+        metadata_spec = P(batch_axis)
         in_specs = (qkv_spec, qkv_spec, qkv_spec, metadata_spec)
         out_specs = qkv_spec
 
         def _flash_attention(q, k, v, cu_seqlens):
+            seq_len = q.shape[0]
+            # The dense kernel requires [1, heads, tokens, head_dim] and a
+            # sequence capacity aligned to its query tile.
+            q, k, v = (jnp.transpose(x, (1, 0, 2))[None] for x in (q, k, v))
+            aligned = max(256, ((seq_len + 255) // 256) * 256)
+            pad = aligned - seq_len
+            if pad:
+                q, k, v = (jnp.pad(x, ((0, 0), (0, 0), (0, pad), (0, 0))) for x in (q, k, v))
             segment_ids = vision_segment_ids_from_cu_seqlens(
-                cu_seqlens,
-                q.shape[2],
+                cu_seqlens[None],
+                aligned,
                 search_method="scan",
             )
-            return flash_attention(
+            out = flash_attention(
                 q,
                 k,
                 v,
@@ -192,6 +170,7 @@ class VisionFlashAttentionBackend(AttentionBackend):
                 vmem_limit_bytes=self.vmem_limit_bytes,
                 interpret=interpret,
             )
+            return jnp.transpose(out[0, :, :seq_len], (1, 0, 2))
 
         self.jit_flash_attention = jax.jit(
             jax.shard_map(
@@ -199,34 +178,13 @@ class VisionFlashAttentionBackend(AttentionBackend):
             )
         )
 
-    def __call__(self, q, k, v, metadata: VisionAttentionMetadata):
-        """Segment-flash attention over batch-leading ``[B, T, heads, head_dim]``.
-
-        Adapts to the kernel's head-leading layout and pads the sequence to the
-        tile its block-size path needs, then restores ``[B, T, heads, head_dim]``
-        so every vision backend shares one THD in/out contract.
-        """
-        cu_seqlens = metadata.cu_seqlens
-        if q.shape[0] != cu_seqlens.shape[0]:
-            raise ValueError(
-                f"vision cu_seqlens batch must match q/k/v: {cu_seqlens.shape[0]} != {q.shape[0]}"
-            )
-        seq_len = q.shape[1]
-        if seq_len != k.shape[1]:
+    def __call__(self, q, k, v, cu_seqlens: jax.Array, *, max_seq_len: int | None = None):
+        """Attend within lane-local segments; ``max_seq_len`` is varlen-only."""
+        if q.ndim != 3 or k.ndim != 3 or v.ndim != 3 or cu_seqlens.ndim != 1:
+            raise ValueError("vision attention requires [tokens, heads, dim] and flat cu_seqlens")
+        if q.shape[0] != k.shape[0] or q.shape[0] != v.shape[0]:
             raise ValueError("a single vision cu_seqlens requires equal q and kv lengths")
-
-        # [B, T, H, D] -> [B, H, T, D] for the kernel.
-        q, k, v = (jnp.transpose(x, (0, 2, 1, 3)) for x in (q, k, v))
-
-        # The dense kernel's default query tile is 256 tokens.
-        alignment = 256
-        aligned = max(256, ((seq_len + alignment - 1) // alignment) * alignment)
-        pad = aligned - seq_len
-        if pad:
-            q, k, v = (jnp.pad(x, ((0, 0), (0, 0), (0, pad), (0, 0))) for x in (q, k, v))
-
-        out = self.jit_flash_attention(q, k, v, cu_seqlens)  # [B, H, aligned, D]
-        return jnp.transpose(out[:, :, :seq_len], (0, 2, 1, 3))  # -> [B, T, H, D]
+        return self.jit_flash_attention(q, k, v, cu_seqlens)
 
     def get_forward_metadata(self, batch: ModelWorkerBatch):
         """Init the metadata for a forward pass and return it"""
@@ -234,17 +192,11 @@ class VisionFlashAttentionBackend(AttentionBackend):
 
 
 class VisionVarlenAttentionBackend(AttentionBackend):
-    """Batch-sharded packed variable-length vision attention.
+    """TPU variable-length attention over flat token and boundary buffers.
 
-    Shares the ``[B, T, heads, head_dim]`` + bucket-shaped ``cu_seqlens``
-    contract of :class:`VisionFlashAttentionBackend`, but each batch lane maps
-    *directly* to the ``varlen_attention`` kernel's packed ``[tokens, heads,
-    head_dim]`` layout: no head-major transpose and no sequence padding (the
-    kernel reserves its own DMA tail slack). A lane's ``num_seqs`` is the count
-    of positive-length segments in its bucket row -- the repeated tail ends
-    become zero-length segments the kernel skips. Unlike the flash backend this
-    kernel supports GQA, per-call local ``window_size`` and per-head attention
-    sinks, so it backs models like MiMo-V2. It is TPU-only.
+    Each token shard maps directly to the kernel's ``[tokens, heads, head_dim]``
+    layout. Lane-local cumulative lengths retain repeated tail ends; those
+    zero-length segments are skipped. No batch axis or vmap is needed.
     """
 
     def __init__(
@@ -267,32 +219,28 @@ class VisionVarlenAttentionBackend(AttentionBackend):
         else:
             batch_axis = ("data", "tensor") if "tensor" in mesh.axis_names else "data"
             self.head_axis = None
-        # q/k/v are token-major [B, T, heads, head_dim]: batch on dim 0, heads on dim 2.
-        self.qkv_spec = P(batch_axis, None, self.head_axis, None)
-        self.cu_spec = P(batch_axis, None)
+        self.qkv_spec = P(batch_axis, self.head_axis, None)
+        self.cu_spec = P(batch_axis)
 
     def __call__(
         self,
-        q,  # [B, T, heads, head_dim]
-        k,  # [B, T, kv_heads, head_dim]
-        v,  # [B, T, kv_heads, head_dim]
-        cu_seqlens,  # int32[B, boundary_capacity + 1] or VisionAttentionMetadata
+        q,  # [tokens, heads, head_dim]
+        k,  # [tokens, kv_heads, head_dim]
+        v,  # [tokens, kv_heads, head_dim]
+        cu_seqlens: jax.Array,  # Flat lane-local cumulative lengths.
         attention_sink=None,  # float[heads] or None
         *,
         window_size: tuple[int, int] = (-1, -1),
+        max_seq_len: int | None = None,
     ):
-        # Accept either a raw cu_seqlens array (MiMo/Omni) or the shared
-        # VisionAttentionMetadata (Qwen VL), so this backend is a drop-in for
-        # VisionFlashAttentionBackend's (q, k, v, metadata) contract too.
-        max_seq_len = None
-        if isinstance(cu_seqlens, VisionAttentionMetadata):
-            max_seq_len = cu_seqlens.max_seq_len
-            cu_seqlens = cu_seqlens.cu_seqlens
-        if q.shape[0] != cu_seqlens.shape[0]:
-            raise ValueError(
-                f"vision cu_seqlens batch must match q/k/v: {cu_seqlens.shape[0]} != {q.shape[0]}"
-            )
-        if q.shape[1] != k.shape[1]:
+        """Attend within segments, using a static length bound for kernel tuning.
+
+        ``max_seq_len`` should be a Python int stable within each input-shape
+        bucket. If omitted, the kernel uses the packed Q capacity as its bound.
+        """
+        if q.ndim != 3 or k.ndim != 3 or v.ndim != 3 or cu_seqlens.ndim != 1:
+            raise ValueError("vision attention requires [tokens, heads, dim] and flat cu_seqlens")
+        if q.shape[0] != k.shape[0] or q.shape[0] != v.shape[0]:
             raise ValueError("a single vision cu_seqlens requires equal q and kv lengths")
 
         def per_lane(lane_q, lane_k, lane_v, lane_cu, lane_sink):
@@ -312,20 +260,18 @@ class VisionVarlenAttentionBackend(AttentionBackend):
                 vmem_limit_bytes=self.vmem_limit_bytes,
             )
 
-        # A sink is a shard_map input so it follows the head sharding; without one
-        # it is broadcast (in_axes=None) as a plain Python ``None`` per lane.
-        over_batch = (0, 0, 0, 0, None)
+        # A sink follows the head sharding; each shard already contains one lane.
         if attention_sink is None:
 
-            def sharded(bq, bk, bv, bcu):
-                return jax.vmap(per_lane, in_axes=over_batch)(bq, bk, bv, bcu, None)
+            def sharded(q, k, v, cu):
+                return per_lane(q, k, v, cu, None)
 
             in_specs = (self.qkv_spec, self.qkv_spec, self.qkv_spec, self.cu_spec)
             args = (q, k, v, cu_seqlens)
         else:
 
-            def sharded(bq, bk, bv, bcu, sink):
-                return jax.vmap(per_lane, in_axes=over_batch)(bq, bk, bv, bcu, sink)
+            def sharded(q, k, v, cu, sink):
+                return per_lane(q, k, v, cu, sink)
 
             in_specs = (*(self.qkv_spec,) * 3, self.cu_spec, P(self.head_axis))
             args = (q, k, v, cu_seqlens, attention_sink)
@@ -347,13 +293,13 @@ def make_vision_attention_backend(
     head_tp: bool = False,
     use_varlen: bool = False,
 ) -> AttentionBackend:
-    """Build the batch-sharded vision attention backend.
+    """Build vision attention over flat tokens sharded into complete lanes.
 
     On TPU, ``use_varlen`` routes the tower through the packed
     ``varlen_attention`` kernel instead of the dense ``flash_attention``
     kernel. Varlen walks each cu_seqlens segment, so window
-    layers cost O(sum segment^2) rather than the dense O(T^2). The host-computed
-    maximum segment length in :class:`VisionAttentionMetadata` selects the
+    layers cost O(sum segment^2) rather than the dense O(T^2). The static
+    ``max_seq_len`` upper bound passed to the backend selects the
     v7x-tuned block sizes. CPU meshes use the flash backend's test-only
     interpreter path.
     """

--- a/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
+++ b/python/sgl_jax/srt/multimodal/manager/multimodal_tokenizer.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 import dataclasses
 import hashlib
 import io
@@ -20,6 +19,7 @@ import imageio.v3 as iio
 import librosa
 import numpy as np
 import psutil
+import pybase64
 import requests
 import setproctitle
 from PIL import Image
@@ -670,10 +670,10 @@ class MultimodalTokenizer(TokenizerManager):
                     vr = VideoReader(tmp_path, ctx=ctx)
                 elif source.startswith("data:") and "base64," in source:
                     payload = source.split("base64,", 1)[1]
-                    tmp_path = self._write_temp_video(base64.b64decode(payload))
+                    tmp_path = self._write_temp_video(pybase64.b64decode(payload))
                     vr = VideoReader(tmp_path, ctx=ctx)
                 else:
-                    tmp_path = self._write_temp_video(base64.b64decode(source, validate=True))
+                    tmp_path = self._write_temp_video(pybase64.b64decode(source, validate=True))
                     vr = VideoReader(tmp_path, ctx=ctx)
             else:
                 raise ValueError(f"Unsupported video input type: {type(source)}")
@@ -762,9 +762,9 @@ class MultimodalTokenizer(TokenizerManager):
             return Image.open(io.BytesIO(resp.content)).convert("RGB")
         if source.startswith("data:") and "base64," in source:
             payload = source.split("base64,", 1)[1]
-            return Image.open(io.BytesIO(base64.b64decode(payload))).convert("RGB")
+            return Image.open(io.BytesIO(pybase64.b64decode(payload))).convert("RGB")
         try:
-            return Image.open(io.BytesIO(base64.b64decode(source, validate=True))).convert("RGB")
+            return Image.open(io.BytesIO(pybase64.b64decode(source, validate=True))).convert("RGB")
         except Exception as exc:
             raise ValueError("Unsupported image source format") from exc
 

--- a/python/sgl_jax/srt/multimodal/processors/base_processor.py
+++ b/python/sgl_jax/srt/multimodal/processors/base_processor.py
@@ -1,18 +1,22 @@
-import asyncio
-import base64
-import concurrent.futures
+from __future__ import annotations
+
 import io
 import logging
 import os
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 from urllib.parse import unquote, urlparse
 
 import numpy as np
+import pybase64
 import requests
 from PIL import Image
 
 from sgl_jax.srt.multimodal.common.modality_enum import MultimodalInputs
 from sgl_jax.srt.multimodal.processors.executor import MultimodalProcessorExecutor
+
+if TYPE_CHECKING:
+    from transformers.image_utils import ImageInput
 
 logger = logging.getLogger(__name__)
 
@@ -56,37 +60,23 @@ def _normalize_image_source(source) -> bytes | str:
     if source.startswith("file://"):
         return unquote(urlparse(source).path)
     if source.startswith("data:"):
-        return base64.b64decode(source.split(",", 1)[1], validate=True)
+        return pybase64.b64decode(source.split(",", 1)[1], validate=True)
     if os.path.isfile(source):
         return source
-    return base64.b64decode(source, validate=True)
+    return pybase64.b64decode(source, validate=True)
 
 
 class BaseMultimodalProcessor(ABC):
     models: tuple[str, ...] = ()
-    auto_mm_io_worker_num = 4
     auto_mm_processor_worker_num = 1
     supports_mm_processor_concurrency = False
+    use_torchcodec_image_decode = False
 
     def __init__(self, hf_config, server_args, processor):
         self.hf_config = hf_config
         self.server_args = server_args
         self.processor = processor
         self._shutdown = False
-
-        requested_io_workers = getattr(server_args, "mm_io_worker_num", 0)
-        env_io_workers = os.environ.get("SGLANG_IO_WORKERS")
-        self.mm_io_worker_num = (
-            requested_io_workers
-            or (int(env_io_workers) if env_io_workers is not None else 0)
-            or self.auto_mm_io_worker_num
-        )
-        if self.mm_io_worker_num <= 0:
-            raise ValueError("Multimodal I/O worker count must be positive.")
-        self.io_executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=self.mm_io_worker_num,
-            thread_name_prefix="sgl-jax-mm-io",
-        )
 
         self.mm_processor_worker_num = (
             getattr(server_args, "mm_processor_worker_num", 0) or self.auto_mm_processor_worker_num
@@ -95,23 +85,22 @@ class BaseMultimodalProcessor(ABC):
             raise ValueError("Multimodal processor worker count must be positive.")
         if self.mm_processor_worker_num > 1 and not self.supports_mm_processor_concurrency:
             logger.warning(
-                "%s does not support concurrent multimodal processing; using synchronous processing.",
+                "%s does not support concurrent multimodal processing; using one worker.",
                 type(self).__name__,
             )
             self.mm_processor_worker_num = 1
-        self.mm_processor_executor = None
-        if self.mm_processor_worker_num > 1:
-            try:
-                self.mm_processor_executor = MultimodalProcessorExecutor(
-                    processor, self.mm_processor_worker_num
-                )
-            except Exception:
-                logger.warning(
-                    "Unable to clone %s processor; using synchronous processing.",
-                    type(self).__name__,
-                    exc_info=True,
-                )
-                self.mm_processor_worker_num = 1
+        try:
+            self.mm_processor_executor = MultimodalProcessorExecutor(
+                processor, self.mm_processor_worker_num
+            )
+        except Exception:
+            logger.warning(
+                "Unable to clone %s processor; using one worker.",
+                type(self).__name__,
+                exc_info=True,
+            )
+            self.mm_processor_worker_num = 1
+            self.mm_processor_executor = MultimodalProcessorExecutor(processor, 1)
 
     def apply_chat_template(self, *args, **kwargs):
         return self.processor.apply_chat_template(*args, **kwargs)
@@ -142,7 +131,7 @@ class BaseMultimodalProcessor(ABC):
         return source
 
     @classmethod
-    def load_image(cls, source) -> Image.Image:
+    def load_image(cls, source) -> ImageInput:
         source = cls.unwrap_source(source)
         if isinstance(source, Image.Image):
             return source.convert("RGB")
@@ -150,19 +139,18 @@ class BaseMultimodalProcessor(ABC):
             return Image.fromarray(source).convert("RGB")
 
         payload = _normalize_image_source(source)
+        if cls.use_torchcodec_image_decode:
+            from torchcodec.decoders import decode_image
+
+            try:
+                image = decode_image(payload, mode="RGB")
+                if image.ndim == 3:
+                    return image
+            except (RuntimeError, ValueError):
+                logger.debug("Falling back to Pillow image decode", exc_info=True)
         if isinstance(payload, bytes):
             return Image.open(io.BytesIO(payload)).convert("RGB")
         return Image.open(payload).convert("RGB")
-
-    async def _run_io_async(self, function, *args):
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(self.io_executor, function, *args)
-
-    async def load_image_async(self, source) -> Image.Image:
-        return await self._run_io_async(self.load_image, source)
-
-    async def load_images_async(self, image_sources: list) -> list[Image.Image]:
-        return await asyncio.gather(*(self.load_image_async(source) for source in image_sources))
 
     @staticmethod
     def _to_numpy(value):
@@ -177,6 +165,12 @@ class BaseMultimodalProcessor(ABC):
             value = value.numpy()
         return np.asarray(value)
 
+    @classmethod
+    def _to_grid_list(cls, value) -> list[tuple[int, int, int]]:
+        if value is None:
+            return []
+        return [tuple(map(int, row)) for row in cls._to_numpy(value).reshape(-1, 3)]
+
     def process_mm_data(
         self,
         input_text: str,
@@ -189,15 +183,14 @@ class BaseMultimodalProcessor(ABC):
     ):
         """Run the Hugging Face processor synchronously.
 
-        This mirrors upstream SGLang's processor layering. Callers should use
-        ``process_and_combine_mm_data_async`` so this CPU work runs in the
-        isolated multimodal processor executor.
+        Call this from a multimodal processor worker, after loading its inputs.
         """
         processor_inputs = {
             "text": [input_text],
             "images": images or None,
             "padding": True,
-            "return_tensors": "pt",
+            # Preserve float32 video timing metadata from the HF processor.
+            "return_tensors": "pt" if videos else None,
             **kwargs,
         }
         if videos is not None:
@@ -250,37 +243,8 @@ class BaseMultimodalProcessor(ABC):
             audios=audios,
         )
 
-    async def process_and_combine_mm_data_async(
-        self,
-        input_text: str,
-        images: list | None = None,
-        videos: list | None = None,
-        audios: list | None = None,
-        **processor_kwargs,
-    ) -> MultimodalInputs:
-        """Run HF processing with isolated workers when concurrency is enabled."""
-        if self.mm_processor_executor is None:
-            return self.process_and_combine_mm_data(
-                input_text,
-                images,
-                videos,
-                audios,
-                processor=self.processor,
-                **processor_kwargs,
-            )
-        return await self.mm_processor_executor.run(
-            self.process_and_combine_mm_data,
-            input_text,
-            images,
-            videos,
-            audios,
-            **processor_kwargs,
-        )
-
     def shutdown(self) -> None:
         if self._shutdown:
             return
         self._shutdown = True
-        self.io_executor.shutdown(wait=False, cancel_futures=True)
-        if self.mm_processor_executor is not None:
-            self.mm_processor_executor.shutdown()
+        self.mm_processor_executor.shutdown()

--- a/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
+++ b/python/sgl_jax/srt/multimodal/processors/qwen_vl.py
@@ -1,11 +1,10 @@
-import asyncio
-import base64
 import logging
 import math
 import os
 import tempfile
 
 import numpy as np
+import pybase64
 from PIL import Image
 
 from sgl_jax.srt.multimodal.common.modality_enum import (
@@ -45,6 +44,8 @@ _QWEN3VL_ARCHITECTURES = frozenset(
 )
 
 
+# Video preprocessing adapted from SGLang:
+# https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/multimodal/processors/qwen_vl.py
 def smart_resize(
     height: int,
     width: int,
@@ -194,10 +195,10 @@ def preprocess_video(source, video_config: dict) -> np.ndarray:
                 vr = VideoReader(tmp_path, ctx=ctx)
             elif source.startswith("data:") and "base64," in source:
                 payload = source.split("base64,", 1)[1]
-                tmp_path = _write_temp_video(base64.b64decode(payload))
+                tmp_path = _write_temp_video(pybase64.b64decode(payload))
                 vr = VideoReader(tmp_path, ctx=ctx)
             else:
-                tmp_path = _write_temp_video(base64.b64decode(source, validate=True))
+                tmp_path = _write_temp_video(pybase64.b64decode(source, validate=True))
                 vr = VideoReader(tmp_path, ctx=ctx)
         else:
             raise ValueError(f"Unsupported video input type: {type(source)}")
@@ -225,6 +226,7 @@ def preprocess_video(source, video_config: dict) -> np.ndarray:
 class QwenVLProcessor(BaseMultimodalProcessor):
     auto_mm_processor_worker_num = 2
     supports_mm_processor_concurrency = True
+    use_torchcodec_image_decode = True
     models = (
         "Qwen2VLForConditionalGeneration",
         "Qwen2_5_VLForConditionalGeneration",
@@ -250,10 +252,27 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         image_sources = self.normalize_data(image_data)
         video_data = self.normalize_data(getattr(request_obj, "video_data", None))
         video_config = self._build_video_config(request_obj)
-        images, videos = await asyncio.gather(
-            self.load_images_async(image_sources),
-            self._load_videos_async(video_data, video_config),
+        return await self.mm_processor_executor.run(
+            self._process_mm_data,
+            input_text,
+            image_sources,
+            video_data,
+            video_config,
         )
+
+    def _process_mm_data(
+        self,
+        input_text,
+        image_sources,
+        video_data,
+        video_config,
+        *,
+        processor,
+    ) -> MultimodalInputs:
+        images = [self.load_image(source) for source in image_sources]
+        videos = [
+            preprocess_video(self.unwrap_source(source), video_config) for source in video_data
+        ]
         processor_kwargs = {}
         if videos:
             processor_kwargs["videos_kwargs"] = {
@@ -264,10 +283,11 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         if uses_qwen3vl_processor:
             processor_kwargs["return_mm_token_type_ids"] = True
 
-        return await self.process_and_combine_mm_data_async(
+        return self.process_and_combine_mm_data(
             input_text,
             images=images,
             videos=videos,
+            processor=processor,
             **processor_kwargs,
         )
 
@@ -504,14 +524,6 @@ class QwenVLProcessor(BaseMultimodalProcessor):
             raise ValueError("Qwen3-VL has unmatched vision token groups.")
         return result
 
-    async def _load_videos_async(self, video_data, video_config):
-        return await asyncio.gather(
-            *(
-                self._run_io_async(preprocess_video, self.unwrap_source(item), video_config)
-                for item in video_data
-            )
-        )
-
     def _build_video_config(self, request_obj):
         vision_config = self.hf_config.vision_config
         video_config = {"factor": int(vision_config.patch_size * vision_config.spatial_merge_size)}
@@ -522,12 +534,6 @@ class QwenVLProcessor(BaseMultimodalProcessor):
         if nframes is not None and "fps" not in video_config:
             video_config["nframes"] = nframes
         return video_config
-
-    @classmethod
-    def _to_grid_list(cls, value):
-        if value is None:
-            return None
-        return [tuple(int(item) for item in row) for row in cls._to_numpy(value).tolist()]
 
     @classmethod
     def _to_list(cls, value):

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -262,7 +262,6 @@ class ServerArgs:
     # Multimodal
     multimodal: bool = False
     limit_mm_data_per_request: dict[str, int] | None = None
-    mm_io_worker_num: int = 0
     mm_processor_worker_num: int = 0
 
     enable_return_routed_experts: bool = False
@@ -548,8 +547,6 @@ class ServerArgs:
             self.model_path = download_from_hf(self.model_path, allow_patterns=None)
             if self.limit_mm_data_per_request is None:
                 self.limit_mm_data_per_request = {"image": 16}
-        if self.mm_io_worker_num < 0:
-            raise ValueError("--mm-io-worker-num must be non-negative")
         if self.mm_processor_worker_num < 0:
             raise ValueError("--mm-processor-worker-num must be non-negative")
 
@@ -1664,12 +1661,6 @@ class ServerArgs:
             type=json.loads,
             default=ServerArgs.limit_mm_data_per_request,
             help="JSON object that limits the number of multimodal items per request, e.g. '{\"image\": 16}'.",
-        )
-        parser.add_argument(
-            "--mm-io-worker-num",
-            type=int,
-            default=ServerArgs.mm_io_worker_num,
-            help="Number of multimodal data loading workers. 0 uses the model default.",
         )
         parser.add_argument(
             "--mm-processor-worker-num",

--- a/python/sgl_jax/srt/utils/common_utils.py
+++ b/python/sgl_jax/srt/utils/common_utils.py
@@ -38,7 +38,13 @@ logger = logging.getLogger(__name__)
 
 PRECOMPILE_DEFAULT_TOKEN_PADDINGS = [1 << i for i in range(6, 14)]
 PRECOMPILE_DEFAULT_BS_PADDINGS = [1 << i for i in range(0, 9)]
-PRECOMPILE_DEFAULT_VISION_PATCH_PADDINGS = [256, 1024, 2048, 4096, 5120, 8192, 12288, 16384]
+PRECOMPILE_DEFAULT_VISION_PATCH_PADDINGS = [
+    1024,
+    2048,
+    4096,
+    5120,
+    8192,
+]
 
 
 def resolve_vision_patch_buckets(user_paddings: list[int] | None) -> list[int]:

--- a/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
+++ b/python/sgl_jax/test/multimodal/test_qwen_vl_processor.py
@@ -16,12 +16,12 @@ from sgl_jax.srt.multimodal.processors.qwen_vl import QwenVLProcessor
 IMAGE_TOKEN = 151655
 
 
-def _make_qwen_processor():
+def _make_qwen_processor(workers=2):
     hf_config = SimpleNamespace(
         architectures=["Qwen2_5_VLForConditionalGeneration"],
         vision_config=SimpleNamespace(patch_size=14, spatial_merge_size=2),
     )
-    return QwenVLProcessor(hf_config, SimpleNamespace(), object())
+    return QwenVLProcessor(hf_config, SimpleNamespace(mm_processor_worker_num=workers), object())
 
 
 def test_build_radix_input_ids():
@@ -66,7 +66,7 @@ def test_qwen_process_and_combine_runs_in_hf_processor_worker():
 
     async def run_processor():
         event_loop_thread_id = threading.get_ident()
-        output = await processor.process_and_combine_mm_data_async("prompt")
+        output = await processor.process_mm_data_async(None, "prompt", SimpleNamespace())
         return event_loop_thread_id, output
 
     try:
@@ -78,29 +78,36 @@ def test_qwen_process_and_combine_runs_in_hf_processor_worker():
     assert output.input_ids == [10, 11]
 
 
-def test_qwen_loads_images_and_videos_concurrently():
-    processor = _make_qwen_processor()
+@pytest.mark.parametrize("workers", [1, 2])
+def test_qwen_loads_and_processes_images_and_videos_in_one_worker(monkeypatch, workers):
+    processor = _make_qwen_processor(workers)
+    stages = []
+    event_loop_thread_id = threading.get_ident()
+
+    def load_image(source):
+        assert source == "image-source"
+        stages.append(("image", threading.get_ident()))
+        return "loaded-image"
+
+    def load_video(source, config):
+        assert source == "video-source"
+        assert config["factor"] == 28
+        stages.append(("video", threading.get_ident()))
+        return "loaded-video"
+
+    def combine(input_text, images=None, videos=None, *, processor, **kwargs):
+        assert input_text == "prompt"
+        assert images == ["loaded-image"]
+        assert videos == ["loaded-video"]
+        assert kwargs["videos_kwargs"]["do_sample_frames"] is False
+        stages.append(("processor", threading.get_ident()))
+        return MultimodalInputs(mm_items=[], input_ids=[10, 11])
+
+    monkeypatch.setattr(processor, "load_image", load_image)
+    monkeypatch.setattr("sgl_jax.srt.multimodal.processors.qwen_vl.preprocess_video", load_video)
+    monkeypatch.setattr(processor, "process_and_combine_mm_data", combine)
 
     async def run_processor():
-        loaders_ready = asyncio.Barrier(2)
-
-        async def load(sources, expected_source, result):
-            assert sources == [expected_source]
-            await loaders_ready.wait()
-            return [result]
-
-        async def combine(input_text, images=None, videos=None, **kwargs):
-            assert input_text == "prompt"
-            assert images == ["loaded-image"]
-            assert videos == ["loaded-video"]
-            return MultimodalInputs(mm_items=[], input_ids=[10, 11])
-
-        processor.load_images_async = lambda sources: load(sources, "image-source", "loaded-image")
-        processor._load_videos_async = lambda sources, _: load(
-            sources, "video-source", "loaded-video"
-        )
-        processor.process_and_combine_mm_data_async = combine
-
         return await asyncio.wait_for(
             processor.process_mm_data_async(
                 "image-source",
@@ -116,6 +123,9 @@ def test_qwen_loads_images_and_videos_concurrently():
         processor.shutdown()
 
     assert output.input_ids == [10, 11]
+    assert [stage for stage, _ in stages] == ["image", "video", "processor"]
+    assert len({thread_id for _, thread_id in stages}) == 1
+    assert stages[0][1] != event_loop_thread_id
 
 
 def test_placeholder_ranges_are_half_open():

--- a/test/srt/multimodal/test_in_model_multimodal.py
+++ b/test/srt/multimodal/test_in_model_multimodal.py
@@ -143,7 +143,7 @@ def _qwen2_metadata(visual, grid_thw, capacity):
     metadata = visual.prepare_metadata(
         grid_thw, capacity, sharding=visual.specs.sharding(visual.specs.batch_axis)
     )
-    return visual._metadata_views(metadata.reshape(len(grid_thw), -1), capacity)
+    return jax.tree.map(lambda x: x.reshape(len(grid_thw), -1, *x.shape[1:]), metadata)
 
 
 def _run_grid_vision(visual, items):
@@ -246,14 +246,15 @@ def _schedule_batch(req, model_config=None):
 def _assert_vision_precompile(visual):
     calls = []
 
-    def encode(patches, metadata):
+    def encode(patches, **metadata):
         sharding = visual.specs.sharding(visual.specs.batch_axis)
-        for value in (patches, metadata):
+        assert patches.ndim == 1
+        for value in (patches, *metadata.values()):
             assert isinstance(value, jax.Array)
-            assert value.ndim == 1
-            assert value.sharding.is_equivalent_to(sharding, ndim=1)
-        assert metadata.dtype == jnp.int32
-        calls.append((patches.shape, metadata.shape))
+            assert value.sharding.is_equivalent_to(sharding, ndim=value.ndim)
+        for name, value in metadata.items():
+            assert value.dtype == (jnp.float32 if name == "pos_weights" else jnp.int32)
+        calls.append((patches.shape, {name: value.shape for name, value in metadata.items()}))
         num_lanes = encoder_num_lanes(visual.mesh, visual.vision_tp)
         capacity = patches.size // (num_lanes * visual.patch_dim)
         return jnp.zeros((num_lanes * capacity // visual.spatial_merge_unit, 1))
@@ -272,20 +273,52 @@ def test_qwen2_vision_precompile_warms_configured_buckets():
         deepstack_visual_indexes=[],
     )
     assert _assert_vision_precompile(_visual(config=config, input_buckets=(4, 8))) == [
-        ((4,), (14,)),
-        ((8,), (26,)),
+        (
+            (4,),
+            {
+                "indices": (1, 2),
+                "position_ids": (4, 2),
+                "window_cu_seqlens": (2,),
+                "full_cu_seqlens": (2,),
+            },
+        ),
+        (
+            (8,),
+            {
+                "indices": (2, 2),
+                "position_ids": (8, 2),
+                "window_cu_seqlens": (3,),
+                "full_cu_seqlens": (3,),
+            },
+        ),
     ]
 
 
-def test_qwen3_vision_precompile_uses_flat_buffers():
+def test_qwen3_vision_precompile_uses_structured_metadata():
     config = _vision_config(
         spatial_merge_size=2,
         num_position_embeddings=16,
         deepstack_visual_indexes=[],
     )
     assert _assert_vision_precompile(_qwen3_visual(config, input_buckets=(4, 8))) == [
-        ((4,), (42,)),
-        ((8,), (83,)),
+        (
+            (4,),
+            {
+                "pos_indices": (4, 4),
+                "pos_weights": (4, 4),
+                "position_ids": (4, 2),
+                "cu_seqlens": (2,),
+            },
+        ),
+        (
+            (8,),
+            {
+                "pos_indices": (8, 4),
+                "pos_weights": (8, 4),
+                "position_ids": (8, 2),
+                "cu_seqlens": (3,),
+            },
+        ),
     ]
 
 
@@ -722,7 +755,7 @@ def test_qwen2_vision_metadata_is_bucket_stable():
     visual = _visual(config, input_buckets=(32,))
     first = _items([(1, 4, 6)], [(0, 6)])
     patches, grid_thw, output_indices = _pack_qwen2(visual, first)
-    _, position_ids, _, _ = _qwen2_metadata(visual, grid_thw, patches.shape[1])
+    position_ids = _qwen2_metadata(visual, grid_thw, patches.shape[1])["position_ids"]
 
     np.testing.assert_array_equal(output_indices[:6], np.arange(6))
     assert position_ids.shape == (1, 32, 2)

--- a/test/srt/multimodal/test_in_model_multimodal.py
+++ b/test/srt/multimodal/test_in_model_multimodal.py
@@ -10,6 +10,7 @@ from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec
 from sgl_jax.srt.managers.schedule_batch import ScheduleBatch, ScheduleReqsInfo
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
 from sgl_jax.srt.models.qwen2_5_vl import Qwen2_5_VisionTransformer
+from sgl_jax.srt.models.qwen3_vl import Qwen3VLVisionModel
 from sgl_jax.srt.multimodal.common.modality_enum import (
     Modality,
     MultimodalDataItem,
@@ -96,36 +97,53 @@ def _visual(config=None, mesh=None, encoder_tp=False, input_buckets=(32,)):
         )
 
 
-def _items(grids, ranges):
+def _qwen3_visual(config=None, mesh=None, encoder_tp=False, input_buckets=(32,)):
+    mesh = mesh or _mesh()
+    with jax.set_mesh(mesh):
+        return Qwen3VLVisionModel(
+            config
+            or _vision_config(
+                num_position_embeddings=16,
+                deepstack_visual_indexes=[],
+            ),
+            jnp.float32,
+            mesh=mesh,
+            tp=encoder_tp,
+            input_buckets=input_buckets,
+        )
+
+
+def _items(grids, ranges, modality=Modality.IMAGE):
     rows = sum(int(np.prod(grid)) for grid in grids)
     features = np.arange(rows, dtype=np.float32).reshape(rows, 1)
     return QwenVLProcessor._build_items(
         features,
         grids,
         ranges,
-        Modality.IMAGE,
+        modality,
         "image_grid_thw",
     )
 
 
 def _pack_qwen2(visual, items):
-    patches, grid_thw, output_indices = pack_vision_inputs(
+    batch_sharding = visual.specs.sharding(visual.specs.batch_axis)
+    num_lanes = encoder_num_lanes(visual.mesh, visual.vision_tp)
+    patches, output_indices, grid_thw = pack_vision_inputs(
         items,
-        num_lanes=encoder_num_lanes(visual.mesh, visual.vision_tp),
+        num_lanes=num_lanes,
         buckets=visual.input_buckets,
         merge_unit=visual.spatial_merge_unit,
-        dtype=visual.dtype,
+        input_sharding=batch_sharding,
     )
-    batch_sharding = visual.specs.sharding(visual.specs.batch_axis)
-    patches = jax.device_put(patches, batch_sharding)
-    return patches, grid_thw, output_indices
+    # Tests inspecting per-lane metadata use the host planning layout.
+    return patches.reshape(num_lanes, -1, visual.patch_dim), grid_thw, output_indices
 
 
 def _qwen2_metadata(visual, grid_thw, capacity):
-    return jax.device_put(
-        visual._build_metadata(grid_thw, capacity),
-        visual.specs.sharding(visual.specs.batch_axis),
+    metadata = visual.prepare_metadata(
+        grid_thw, capacity, sharding=visual.specs.sharding(visual.specs.batch_axis)
     )
+    return visual._metadata_views(metadata.reshape(len(grid_thw), -1), capacity)
 
 
 def _run_grid_vision(visual, items):
@@ -137,7 +155,8 @@ def _run_grid_vision(visual, items):
         buckets=visual.input_buckets,
         merge_unit=visual.spatial_merge_unit,
         rope_type="rope_3d",
-        dtype=visual.dtype,
+        input_sharding=visual.specs.sharding(visual.specs.batch_axis),
+        output_sharding=visual.specs.sharding(),
     )
 
 
@@ -227,15 +246,17 @@ def _schedule_batch(req, model_config=None):
 def _assert_vision_precompile(visual):
     calls = []
 
-    def encode(patches, grid_thw):
-        calls.append((patches.shape, np.asarray(grid_thw).tolist()))
-        return jnp.zeros(
-            (
-                patches.shape[0],
-                patches.shape[1] // visual.spatial_merge_unit,
-                1,
-            )
-        )
+    def encode(patches, metadata):
+        sharding = visual.specs.sharding(visual.specs.batch_axis)
+        for value in (patches, metadata):
+            assert isinstance(value, jax.Array)
+            assert value.ndim == 1
+            assert value.sharding.is_equivalent_to(sharding, ndim=1)
+        assert metadata.dtype == jnp.int32
+        calls.append((patches.shape, metadata.shape))
+        num_lanes = encoder_num_lanes(visual.mesh, visual.vision_tp)
+        capacity = patches.size // (num_lanes * visual.patch_dim)
+        return jnp.zeros((num_lanes * capacity // visual.spatial_merge_unit, 1))
 
     with patch.object(type(visual), "encode", side_effect=encode):
         visual.precompile()
@@ -251,9 +272,52 @@ def test_qwen2_vision_precompile_warms_configured_buckets():
         deepstack_visual_indexes=[],
     )
     assert _assert_vision_precompile(_visual(config=config, input_buckets=(4, 8))) == [
-        ((1, 4, 1), [[[1, 2, 2]]]),
-        ((1, 8, 1), [[[1, 2, 4]]]),
+        ((4,), (14,)),
+        ((8,), (26,)),
     ]
+
+
+def test_qwen3_vision_precompile_uses_flat_buffers():
+    config = _vision_config(
+        spatial_merge_size=2,
+        num_position_embeddings=16,
+        deepstack_visual_indexes=[],
+    )
+    assert _assert_vision_precompile(_qwen3_visual(config, input_buckets=(4, 8))) == [
+        ((4,), (42,)),
+        ((8,), (83,)),
+    ]
+
+
+@pytest.mark.parametrize("encoder_tp", [False, True])
+def test_qwen3_flat_vision_matches_across_encoder_sharding(encoder_tp):
+    config = _vision_config(
+        hidden_size=8,
+        intermediate_size=16,
+        num_heads=2,
+        spatial_merge_size=2,
+        num_position_embeddings=16,
+        depth=1,
+        deepstack_visual_indexes=[0],
+        out_hidden_size=8,
+    )
+    items = _items(
+        [(1, 2, 2)] * 4,
+        [(0, 1), (1, 2), (2, 3), (3, 4)],
+    )
+    reference = _qwen3_visual(config, input_buckets=(16,))
+    visual = _qwen3_visual(
+        config,
+        _mesh(dp=2, tp=2),
+        encoder_tp,
+        input_buckets=(8,),
+    )
+
+    expected = np.asarray(_run_grid_vision(reference, items))
+    actual = np.asarray(_run_grid_vision(visual, items))
+
+    np.testing.assert_allclose(actual[: len(expected)], expected, rtol=2e-5, atol=2e-5)
+    np.testing.assert_array_equal(actual[len(expected) :], 0)
 
 
 @pytest.mark.parametrize("encoder_tp", [False, True])
@@ -655,20 +719,41 @@ def test_qwen2_vision_metadata_is_bucket_stable():
         depth=2,
         fullatt_block_indexes=[1],
     )
-    visual = _visual(config=config, input_buckets=(32,))
+    visual = _visual(config, input_buckets=(32,))
     first = _items([(1, 4, 6)], [(0, 6)])
     patches, grid_thw, output_indices = _pack_qwen2(visual, first)
-    metadata = _qwen2_metadata(visual, grid_thw, patches.shape[1])
-    _, position_ids, window_attn, full_attn = metadata
+    _, position_ids, _, _ = _qwen2_metadata(visual, grid_thw, patches.shape[1])
 
-    assert window_attn.max_seq_len == 16
-    assert full_attn.max_seq_len == 32
     np.testing.assert_array_equal(output_indices[:6], np.arange(6))
     assert position_ids.shape == (1, 32, 2)
 
-    jax.block_until_ready(visual.encode(patches, grid_thw))
-    cache_size = visual._encode_jit._cache_size()
+    jax.block_until_ready(_run_grid_vision(visual, first))
+    cache_size = visual.encode._cache_size()
     second = _items([(1, 4, 4), (2, 2, 2)], [(0, 4), (4, 6)])
-    second_patches, second_grid_thw, _ = _pack_qwen2(visual, second)
-    jax.block_until_ready(visual.encode(second_patches, second_grid_thw))
-    assert visual._encode_jit._cache_size() == cache_size
+    jax.block_until_ready(_run_grid_vision(visual, second))
+    assert visual.encode._cache_size() == cache_size
+
+
+@pytest.mark.parametrize("encoder_tp", [False, True])
+def test_packed_vision_matches_individual_images_with_empty_lanes(encoder_tp):
+    config = _vision_config(
+        hidden_size=8,
+        num_heads=2,
+        spatial_merge_size=2,
+        window_size=4,
+        depth=2,
+        fullatt_block_indexes=[1],
+    )
+    reference = _visual(config, input_buckets=(32,))
+    visual = _visual(config, _mesh(dp=2, tp=2), encoder_tp, input_buckets=(32,))
+    items = _items([(1, 2, 2), (1, 4, 6)], [(0, 1), (1, 7)])
+    items += _items([(2, 2, 4)], [(0, 4)], Modality.VIDEO)
+    expected = np.concatenate(
+        [
+            np.asarray(_run_grid_vision(reference, [item]))[: len(item.feature) // 4]
+            for item in items
+        ]
+    )
+    actual = np.asarray(_run_grid_vision(visual, items))
+    np.testing.assert_allclose(actual[: len(expected)], expected, rtol=2e-5, atol=2e-5)
+    np.testing.assert_array_equal(actual[len(expected) :], 0)


### PR DESCRIPTION
## Motivation

Reduce CPU preprocessing and host dispatch overhead in Qwen2.5-VL and Qwen3-VL serving. Media loading and Hugging Face processing currently use separate execution stages, while vision inputs and layout metadata require additional preparation around encoder execution. This change combines preprocessing in one worker task and prepares flat, explicitly sharded encoder inputs on the host.

Additionally, processing `bfloat16` in `pack_lanes` was observed to be slower on CPU compared to `float32`. Therefore, image preprocessing on the host is kept in `float32`, and the tensors are cast to the target model weight `dtype` at the encoder input after `device_put` to the accelerator.

## Modifications

- Load media and run the Hugging Face processor in the same multimodal processor worker. Remove the separate I/O executor and `--mm-io-worker-num`; worker concurrency is controlled by `--mm-processor-worker-num`.
- Use TorchCodec for Qwen image decoding with a Pillow fallback, pybase64 for base64 decoding, and xxhash for multimodal item hashing. Add the required dependencies and use the fast Hugging Face processor.
- Pack vision patches and metadata into flat buffers with explicit sharding. Build layout metadata on the host, use Numba for output-index construction, and restore the original item order with padding rows masked to zero.
- Keep image tensors in `float32` during host preprocessing/`pack_lanes` to avoid CPU `bfloat16` performance penalties, deferring the cast to the model `dtype` at the vision encoder input after device placement.
- Adapt Qwen2.5-VL, Qwen3-VL, attention, and vision precompilation to the flat input layout, retaining token-major outputs and Qwen3-VL DeepStack features.


## Accuracy Tests

## Benchmarking and Profiling

Qwen3-VL-32B-Instruct on a single TPU v7x-8, DP4 × effective TP2, with BF16 model and KV cache. The single-image workload uses one random 512×512 JPEG per request, a 2K context, an unbounded request rate, and 500 output tokens per request. Both cases complete 1,000 requests with identical server-verified input and output token totals.

Single-image multimodal serving reaches **8,527.41 output tok/s**, or **95.13%** of text-only throughput.  These are text-only versus multimodal measurements from the same comparison. TTFT includes scheduler queueing under the burst workload.

| Metric | Text | Single-image multimodal |
|---|---:|---:|
| Successful requests | 1,000 | 1,000 |
| Input tokens (server-verified) | 1,344,206 | 1,344,206 |
| Output tokens (server-verified) | 500,000 | 500,000 |
| Duration | 55.777 s | 58.634 s |
| Request throughput | 17.928 req/s | 17.055 req/s |
| Input token throughput | 24,099.43 tok/s | 22,925.18 tok/s |
| Output token throughput | 8,964.19 tok/s | 8,527.41 tok/s |
| Total token throughput | 33,063.62 tok/s | 31,452.59 tok/s |
| Mean TTFT | 13,820.48 ms | 15,937.96 ms |
| Median TTFT | 10,933.37 ms | 13,425.55 ms |
| P99 TTFT | 46,881.43 ms | 49,192.05 ms |
| Mean TPOT | 64.89 ms | 65.44 ms |
| Median TPOT | 68.54 ms | 68.36 ms |
| P99 TPOT | 82.26 ms | 90.18 ms |
| Mean E2E latency | 46,201.97 ms | 48,591.19 ms |
| Median E2E latency | 45,290.66 ms | 47,598.53 ms |
| P99 E2E latency | 55,445.41 ms | 57,846.17 ms |
| Mean ITL | 66.32 ms | 66.64 ms |
| Median ITL | 32.77 ms | 33.06 ms |
| P95 ITL | 88.20 ms | 62.41 ms |
| P99 ITL | 371.05 ms | 358.61 ms |

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [x] (Optional) The necessary documentation update.
