### PR TITLE
Gemma4 mtp

### DIFF
--- a/docs/features/speculative_decoding.md
+++ b/docs/features/speculative_decoding.md
@@ -27,6 +27,10 @@ Two draft families are available:
 - **NEXTN** – fused MTP / NextN speculative path. The CLI and enum support it,
   but the overlap path is restricted to the fused `topk=1` shape described in
   `ServerArgs` validation.
+- **Frozen-KV MTP** – Gemma 4's assistant architecture. It reads the target
+  model's committed KV cache and target hidden states; it does not own or write
+  a separate draft KV cache. The server recognizes the Gemma assistant
+  checkpoint and selects the dedicated Frozen-KV worker automatically.
 
 ## Enabling speculative decoding
 
@@ -99,6 +103,30 @@ At the time of writing we have not published public drafts for other models. If
 you have your own EAGLE/EAGLE3 distilled checkpoint, point
 `--speculative-draft-model-path` to that repo and ensure the tokenizer exactly
 matches the target model.
+
+### Gemma 4 Frozen-KV MTP
+
+The text-only `google/gemma-4-31B-it` assistant is a Frozen-KV MTP draft, not
+an ordinary EAGLE checkpoint. Launch it through the familiar `NEXTN` interface;
+the server promotes the Gemma assistant architecture to the dedicated worker.
+
+```bash
+python3 -m sgl_jax.launch_server \
+  --model-path google/gemma-4-31B-it \
+  --speculative-algorithm NEXTN \
+  --speculative-draft-model-path google/gemma-4-31B-it-assistant \
+  --speculative-num-steps 3 \
+  --speculative-num-draft-tokens 4 \
+  --speculative-eagle-topk 1 \
+  --device tpu --tp-size 4 --attention-backend fa --page-size 128 \
+  --disable-overlap-schedule
+```
+
+Frozen-KV uses a dedicated non-overlap state handoff: after target verification,
+the accepted token and corresponding target hidden state seed the next assistant
+proposal. It supports non-overlap prefill admission and batch merge, but does
+not support speculative overlap scheduling. Use greedy/top-k-one decoding for
+the validated path.
 
 ## Known Gaps
 

--- a/python/sgl_jax/srt/configs/gemma4.py
+++ b/python/sgl_jax/srt/configs/gemma4.py
@@ -34,3 +34,24 @@ class Gemma4Config(PretrainedConfig):
             self.sliding_window = getattr(tc, "sliding_window", None)
             self.attention_k_eq_v = getattr(tc, "attention_k_eq_v", None)
             self.hybrid_layer_pattern = getattr(tc, "hybrid_layer_pattern", None)
+
+
+class Gemma4AssistantConfig(Gemma4Config):
+    """Config for Gemma4 assistant (MTP draft) checkpoints.
+
+    Inherits ``Gemma4Config.__init__`` so the head_dim / swa_head_dim remap
+    fires automatically. Additional kwargs (backbone_hidden_size,
+    use_ordered_embeddings, etc.) are stored via PretrainedConfig.
+    """
+
+    model_type = "gemma4_assistant"
+
+
+class Gemma4UnifiedAssistantConfig(Gemma4Config):
+    """Config for Gemma4 unified assistant (12B) checkpoints.
+
+    Text path is identical to the non-unified assistant; only the model_type
+    string differs (``gemma4_unified_assistant`` vs ``gemma4_assistant``).
+    """
+
+    model_type = "gemma4_unified_assistant"

--- a/python/sgl_jax/srt/hf_transformers_utils.py
+++ b/python/sgl_jax/srt/hf_transformers_utils.py
@@ -22,7 +22,11 @@ from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
 
 from sgl_jax.srt.configs.bailing_hybrid import BailingHybridConfig
-from sgl_jax.srt.configs.gemma4 import Gemma4Config
+from sgl_jax.srt.configs.gemma4 import (
+    Gemma4AssistantConfig,
+    Gemma4Config,
+    Gemma4UnifiedAssistantConfig,
+)
 from sgl_jax.srt.configs.kimi_linear import KimiLinearConfig
 from sgl_jax.srt.configs.qwen3_5 import Qwen3_5DenseConfig, Qwen3_5HybridConfig
 from sgl_jax.srt.managers.tiktoken_tokenizer import TiktokenTokenizer
@@ -46,6 +50,8 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = {
         Qwen3_5HybridConfig,
         Qwen3_5DenseConfig,
         Gemma4Config,
+        Gemma4AssistantConfig,
+        Gemma4UnifiedAssistantConfig,
     ]
 }
 
@@ -302,7 +308,11 @@ def get_tokenizer(
                 import json
 
                 model_config_data = json.load(f)
-                if model_config_data.get("model_type") == "gemma4":
+                if model_config_data.get("model_type") in (
+                    "gemma4",
+                    "gemma4_assistant",
+                    "gemma4_unified_assistant",
+                ):
                     kwargs.setdefault("extra_special_tokens", {})
     except Exception as e:
         logger.debug("Failed to inspect config.json for extra_special_tokens workaround: %s", e)

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -69,6 +69,33 @@ def _pad_page_indices(
     return page_indices
 
 
+def _remap_full_pages_to_swa(
+    page_indices: np.ndarray,
+    *,
+    page_size: int,
+    dp_size: int,
+    swa_mapping,
+) -> np.ndarray | None:
+    """Translate full-pool page IDs into the matching SWA sub-pool pages."""
+    if swa_mapping is None:
+        return None
+
+    full_loc = (np.asarray(page_indices, dtype=np.int64) * page_size).astype(np.int32)
+    if isinstance(swa_mapping, list):
+        if len(swa_mapping) != dp_size:
+            raise ValueError(
+                f"Expected one SWA mapping per DP rank; got {len(swa_mapping)} for dp={dp_size}."
+            )
+        full_2d = full_loc.reshape(dp_size, -1)
+        swa_2d = np.empty_like(full_2d)
+        for rank in range(dp_size):
+            swa_2d[rank] = np.asarray(swa_mapping[rank])[full_2d[rank]]
+        swa_loc = swa_2d.ravel()
+    else:
+        swa_loc = np.asarray(swa_mapping)[full_loc]
+    return (swa_loc // page_size).astype(np.int32)
+
+
 @register_pytree_node_class
 @dataclass
 class FlashAttentionMetadata:
@@ -252,19 +279,15 @@ class FlashAttention(AttentionBackend):
         if batch.forward_mode == ForwardMode.TARGET_VERIFY:
             metadata.custom_mask = batch.spec_info_padded.custom_mask
 
-        swa_mapping = getattr(self, "swa_index_mapping", None)
-        if swa_mapping is not None:
-            full_loc = (page_indices.astype(np.int64) * self.page_size).astype(np.int32)
-            if isinstance(swa_mapping, list):
-                full_2d = full_loc.reshape(batch.dp_size, -1)
-                swa_2d = np.empty_like(full_2d)
-                for r in range(batch.dp_size):
-                    swa_2d[r] = np.asarray(swa_mapping[r])[full_2d[r]]
-                swa_loc = swa_2d.ravel()
-            else:
-                swa_loc = np.asarray(swa_mapping)[full_loc]
+        swa_page_indices = _remap_full_pages_to_swa(
+            page_indices,
+            page_size=self.page_size,
+            dp_size=batch.dp_size,
+            swa_mapping=getattr(self, "swa_index_mapping", None),
+        )
+        if swa_page_indices is not None:
             metadata.swa_page_indices = device_array(
-                (swa_loc // self.page_size).astype(np.int32),
+                swa_page_indices,
                 sharding=data_sharding,
             )
         return metadata
@@ -372,13 +395,16 @@ class FlashAttention(AttentionBackend):
             ) * self.page_size
         cu_kv_lens = _per_dp_cumsum(aligned_seq_lens, dp_size, per_dp_bs)
 
-        if batch.forward_mode == ForwardMode.DRAFT_EXTEND and not getattr(
-            batch.spec_info_padded, "device_seq_lens_for_draft_extend", False
-        ):
-            # Truncate each req's page list from allocate_len → seq_len, keeping
-            # the DP-segmented layout from padding_for_decode (rank r's pages
-            # at [r*per_dp_pg : ...]). page_indices (line 212) is already
-            # cache_loc[::page_size]//page_size, so re-gather from it per-rank.
+        if batch.forward_mode in (
+            ForwardMode.TARGET_VERIFY,
+            ForwardMode.DRAFT_EXTEND,
+        ) and not getattr(batch.spec_info_padded, "device_seq_lens_for_draft_extend", False):
+            # The source page list is allocation-packed by padding_for_decode,
+            # but these forwards consume only each request's logical sequence
+            # pages. Repack per request while preserving the DP-segmented
+            # layout. Without this TARGET_VERIFY gives a later request an
+            # earlier request's reserved page whenever the earlier allocation
+            # crosses a page boundary.
             allocate_lens = batch.spec_info_padded.allocate_lens
             if hasattr(allocate_lens, "device"):
                 allocate_lens = jax.device_get(allocate_lens)
@@ -446,19 +472,15 @@ class FlashAttention(AttentionBackend):
             )
         # Hybrid SWA targets need swa_page_indices for TARGET_VERIFY too,
         # otherwise SWA layers index the swa sub-pool with full-pool page ids.
-        swa_mapping = getattr(self, "swa_index_mapping", None)
-        if swa_mapping is not None:
-            full_loc = (page_indices.astype(np.int64) * self.page_size).astype(np.int32)
-            if isinstance(swa_mapping, list):
-                full_2d = full_loc.reshape(dp_size, -1)
-                swa_2d = np.empty_like(full_2d)
-                for r in range(dp_size):
-                    swa_2d[r] = np.asarray(swa_mapping[r])[full_2d[r]]
-                swa_loc = swa_2d.ravel()
-            else:
-                swa_loc = np.asarray(swa_mapping)[full_loc]
+        swa_page_indices = _remap_full_pages_to_swa(
+            page_indices,
+            page_size=self.page_size,
+            dp_size=dp_size,
+            swa_mapping=getattr(self, "swa_index_mapping", None),
+        )
+        if swa_page_indices is not None:
             metadata.swa_page_indices = device_array(
-                (swa_loc // self.page_size).astype(np.int32),
+                swa_page_indices,
                 sharding=NamedSharding(self.mesh, P("data")),
             )
         return metadata
@@ -549,6 +571,18 @@ class FlashAttention(AttentionBackend):
         distribution = np.column_stack(
             [np.zeros_like(local_n), np.zeros_like(local_n), local_n]
         ).ravel()
+        # Frozen-KV drafts read the target's hybrid cache directly, so each
+        # recurrent step needs the same full-pool-to-SWA remap as target verify.
+        swa_page_indices_per_step = [
+            _remap_full_pages_to_swa(
+                step_pages,
+                page_size=self.page_size,
+                dp_size=dp_size,
+                swa_mapping=getattr(self, "swa_index_mapping", None),
+            )
+            for step_pages in page_indices
+        ]
+
         metadata = []
         for i in range(batch.speculative_num_steps):
             metadata_tmp = FlashAttentionMetadata()
@@ -568,6 +602,11 @@ class FlashAttention(AttentionBackend):
                 ),
                 sharding=(NamedSharding(self.mesh, P("data"))),
             )
+            if swa_page_indices_per_step[i] is not None:
+                metadata_tmp.swa_page_indices = device_array(
+                    swa_page_indices_per_step[i],
+                    sharding=NamedSharding(self.mesh, P("data")),
+                )
             metadata.append(metadata_tmp)
         return metadata
 

--- a/python/sgl_jax/srt/layers/kv_share.py
+++ b/python/sgl_jax/srt/layers/kv_share.py
@@ -1,0 +1,58 @@
+"""Cross-model MTP KV-cache sharing: maps Gemma4 MTP draft layers to
+their target (verifier) model KV-cache layers.
+
+Gemma4 MTP draft attention is Q-only — K/V come from the target model's
+KV cache. Which target layer each draft layer reads from is determined by
+matching ``layer_types`` (full vs sliding attention) between the two
+HF configs.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+
+def compute_mtp_kv_share_map(draft_config, target_config) -> dict[str, str]:
+    """Return ``{'draft_layer.i': 'layer.j'}`` mapping speculative MTP layers
+    to their cross-model KV sharing target verifier layer cache array indices.
+
+    Each draft layer's Q-only attention reads K/V from a specific target
+    verifier layer of the same attention type (full or sliding). This
+    mapping is consumed at runtime to redirect draft attention to the
+    corresponding target KV cache slot.
+
+    Target layers that are themselves KV-shared (the last
+    ``num_kv_shared_layers``) are excluded — only the non-shared source
+    layer is a valid cache owner.
+    """
+    draft_text_config = getattr(draft_config, "text_config", draft_config)
+    target_text_config = getattr(target_config, "text_config", target_config)
+
+    target_layer_types = getattr(target_text_config, "layer_types", [])
+    target_num_kv_shared = getattr(target_text_config, "num_kv_shared_layers", 0)
+    num_non_shared = len(target_layer_types) - target_num_kv_shared
+
+    # Group verifier non-shared layers by attention type
+    type_to_target_indices = defaultdict(list)
+    for idx, lt in enumerate(target_layer_types[:num_non_shared]):
+        type_to_target_indices[lt].append(idx)
+
+    draft_layer_types = getattr(draft_text_config, "layer_types", [])
+    draft_num_layers = getattr(draft_text_config, "num_hidden_layers", 4)
+
+    redirects = {}
+    for draft_idx in range(draft_num_layers):
+        draft_layer_type = (
+            draft_layer_types[draft_idx] if draft_idx < len(draft_layer_types) else "full_attention"
+        )
+        candidates = type_to_target_indices.get(draft_layer_type, [])
+        if candidates:
+            target_idx = candidates[-1]
+            redirects[f"draft_layer.{draft_idx}"] = f"layer.{target_idx}"
+        else:
+            raise ValueError(
+                f"MTP cross-model KV-share: draft layer {draft_idx} of type "
+                f"{draft_layer_type!r} has no matching same-type verifier layer "
+                f"in target configuration (candidates are empty)."
+            )
+    return redirects

--- a/python/sgl_jax/srt/layers/logits_processor.py
+++ b/python/sgl_jax/srt/layers/logits_processor.py
@@ -410,7 +410,10 @@ class LogitsProcessor(nnx.Module):
             elif logits_metadata.capture_hidden_mode.is_last():
                 # Get the last token hidden states. If sample_indices is None,
                 # pruned states only contain the last tokens already.
-                if aux_hidden_states is not None:
+                # Length check mirrors the is_full() branch above: an empty aux
+                # list means nothing was captured, so fall back to the final
+                # hidden rather than jnp.concat([]).
+                if aux_hidden_states is not None and len(aux_hidden_states) > 0:
                     aux_pruned_states = jnp.concat(aux_pruned_states, axis=-1)
 
                     hidden_states_to_store = (

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -2779,7 +2779,7 @@ class ScheduleBatch:
             return out
 
         if legacy_host_scatter:
-            return type(flat)(
+            kwargs = dict(
                 topk_p=_scatter1(flat.topk_p),
                 topk_index=_scatter1(flat.topk_index),
                 hidden_states=_scatter1(flat.hidden_states),
@@ -2791,8 +2791,13 @@ class ScheduleBatch:
                 new_seq_lens=_scatter1(flat.new_seq_lens),
                 future_indices=_scatter1(flat.future_indices),
             )
+            if getattr(flat, "seed_state", None) is not None:
+                kwargs["seed_state"] = flat.seed_state.scatter(selector, total_bs)
+            if hasattr(flat, "relay_seed_mask"):
+                kwargs["relay_seed_mask"] = _scatter1(getattr(flat, "relay_seed_mask", None))
+            return type(flat)(**kwargs)
 
-        return type(flat)(
+        kwargs = dict(
             topk_p=_scatter1(flat.topk_p, data_sharded=True),
             topk_index=_scatter1(flat.topk_index, data_sharded=True),
             hidden_states=_scatter1(flat.hidden_states),
@@ -2804,6 +2809,14 @@ class ScheduleBatch:
             new_seq_lens=_scatter1(flat.new_seq_lens),
             future_indices=_scatter1(flat.future_indices),
         )
+        if getattr(flat, "seed_state", None) is not None:
+            kwargs["seed_state"] = flat.seed_state.scatter(selector, total_bs)
+        if hasattr(flat, "relay_seed_mask"):
+            # This is scheduler metadata, not a device model tensor.  It tells
+            # Frozen-KV whether a restored relay row starts from a target seed
+            # or from ordinary prefill proposal state.
+            kwargs["relay_seed_mask"] = _scatter1(getattr(flat, "relay_seed_mask", None))
+        return type(flat)(**kwargs)
 
     @staticmethod
     def _split_spec_info_per_rank(flat, real_bs_per_dp: list[int]) -> list:
@@ -2906,6 +2919,7 @@ class ScheduleBatch:
             if n == 0:
                 out.append(None)
                 continue
+            end = offset + n
             kwargs = {"capture_hidden_mode": flat.capture_hidden_mode}
             for f in per_req_fields:
                 v = getattr(flat, f, None)
@@ -2918,6 +2932,13 @@ class ScheduleBatch:
                     kwargs[f] = None
                 else:
                     kwargs[f] = None if v is None else v[offset : offset + n]
+            if getattr(flat, "seed_state", None) is not None:
+                kwargs["seed_state"] = flat.seed_state.filter(
+                    np.arange(offset, end, dtype=np.int32)
+                )
+            if hasattr(flat, "relay_seed_mask"):
+                value = getattr(flat, "relay_seed_mask", None)
+                kwargs["relay_seed_mask"] = None if value is None else np.asarray(value)[offset:end]
             out.append(type(flat)(**kwargs))
             offset += n
         return out
@@ -3021,6 +3042,25 @@ class ScheduleBatch:
             else:
                 nonnull = [np.asarray(v) for v in nonnull]
                 kwargs[f] = np.concatenate(nonnull, axis=0)
+        seed_states = [getattr(s, "seed_state", None) for s in nonempty]
+        if any(s is not None for s in seed_states):
+            if not all(s is not None for s in seed_states):
+                raise ValueError("Frozen-KV seed_state must be present on every non-empty DP rank")
+            merged_seed = seed_states[0]
+            for seed in seed_states[1:]:
+                merged_seed = merged_seed.merge(seed)
+            kwargs["seed_state"] = merged_seed
+        if hasattr(nonempty[0], "relay_seed_mask"):
+            relay_masks = [getattr(s, "relay_seed_mask", None) for s in nonempty]
+            nonnull_masks = [m for m in relay_masks if m is not None]
+            if nonnull_masks:
+                if len(nonnull_masks) != len(nonempty):
+                    raise ValueError(
+                        "Frozen-KV relay_seed_mask must be present on every non-empty DP rank"
+                    )
+                kwargs["relay_seed_mask"] = np.concatenate(
+                    [np.asarray(m, dtype=bool) for m in nonnull_masks], axis=0
+                )
         return type(nonempty[0])(**kwargs)
 
     def get_model_worker_batch(

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -217,6 +217,29 @@ class Scheduler(
     A scheduler that manages a tensor parallel TPU worker, which managaes fixed multi TPU devices.
     """
 
+    def _select_eagle_worker_class(self, server_args: ServerArgs):
+        """Select the worker from the resolved speculative algorithm and model shape."""
+        if self.spec_algorithm.is_frozen_kv_mtp():
+            from sgl_jax.srt.speculative.frozen_kv_mtp_worker import FrozenKvMtpWorker
+
+            return FrozenKvMtpWorker
+
+        n_mtp = getattr(self.tp_worker.model_config.hf_config, "num_nextn_predict_layers", None)
+        if n_mtp is None and self.spec_algorithm.is_nextn():
+            n_mtp = server_args.speculative_num_steps
+        self._spec_multi_layer = n_mtp is not None and n_mtp > 1
+
+        if self._spec_multi_layer:
+            from sgl_jax.srt.speculative.multi_layer_eagle_worker import (
+                MultiLayerEAGLEWorker,
+            )
+
+            return MultiLayerEAGLEWorker
+
+        from sgl_jax.srt.speculative.eagle_worker import EAGLEWorker
+
+        return EAGLEWorker
+
     def __init__(
         self,
         server_args: ServerArgs,
@@ -411,25 +434,7 @@ class Scheduler(
         # launch draft worker
         self._spec_multi_layer = False
         if self.spec_algorithm is not None and self.spec_algorithm.is_eagle():
-            # Multi-layer vs single-layer is a model property (how many MTP heads
-            # the target ships), not a CLI-algorithm property. NEXTN with a single
-            # MTP head behaves exactly like EAGLE (same head run N times).
-            # DeepSeek-style configs expose num_nextn_predict_layers; MiMo-style
-            # configs don't, so fall back to --speculative-num-steps under NEXTN
-            # (one MTP weight set per step).
-            n_mtp = getattr(self.tp_worker.model_config.hf_config, "num_nextn_predict_layers", None)
-            if n_mtp is None and self.spec_algorithm.is_nextn():
-                n_mtp = server_args.speculative_num_steps
-            self._spec_multi_layer = n_mtp is not None and n_mtp > 1
-            if self._spec_multi_layer:
-                from sgl_jax.srt.speculative.multi_layer_eagle_worker import (
-                    MultiLayerEAGLEWorker as _SpecWorkerCls,
-                )
-            else:
-                from sgl_jax.srt.speculative.eagle_worker import (
-                    EAGLEWorker as _SpecWorkerCls,
-                )
-
+            _SpecWorkerCls = self._select_eagle_worker_class(server_args)
             self.draft_worker = _SpecWorkerCls(
                 server_args=server_args,
                 target_worker=self.tp_worker,

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -130,6 +130,49 @@ RECORD_STEP_TIME = get_bool_env_var("SGLANG_RECORD_STEP_TIME")
 GRAMMAR_TIMEOUT = float(os.environ.get("SGLANG_GRAMMAR_TIMEOUT", 300))
 
 
+def _split_spec_new_seq_lens(
+    new_seq_lens,
+    *,
+    real_bs_per_dp: list[int],
+    per_dp_bs: int,
+) -> list[np.ndarray]:
+    """Map speculative sequence lengths back to their DP-attention ranks.
+
+    Frozen-KV publishes only live request rows in rank order, while existing
+    static-shape speculative programs can publish the full padded DP bucket.
+    Only the scheduler knows both ``real_bs_per_dp`` and ``per_dp_bs``, so it
+    normalizes the two layouts here instead of teaching a model worker about
+    scheduler padding policy.
+    """
+    invalid_rank_size = any(rank_bs < 0 or rank_bs > per_dp_bs for rank_bs in real_bs_per_dp)
+    if per_dp_bs <= 0 or invalid_rank_size:
+        raise ValueError(
+            "Invalid speculative DP batch geometry: "
+            f"per_dp_bs={per_dp_bs}, real_bs_per_dp={real_bs_per_dp}."
+        )
+    values = np.asarray(new_seq_lens).reshape(-1)
+    real_bs = sum(real_bs_per_dp)
+    padded_bs = per_dp_bs * len(real_bs_per_dp)
+    if values.shape[0] == real_bs:
+        result = []
+        offset = 0
+        for rank_bs in real_bs_per_dp:
+            result.append(values[offset : offset + rank_bs])
+            offset += rank_bs
+        return result
+    if values.shape[0] == padded_bs:
+        return [
+            values[rank * per_dp_bs : rank * per_dp_bs + rank_bs]
+            for rank, rank_bs in enumerate(real_bs_per_dp)
+        ]
+    raise ValueError(
+        "Speculative next sequence lengths match neither compact nor DP-padded "
+        "request layout: "
+        f"rows={values.shape[0]}, real_bs={real_bs}, padded_bs={padded_bs}, "
+        f"real_bs_per_dp={real_bs_per_dp}."
+    )
+
+
 def _clear_embedding_pools(
     workers: Iterable[ModelWorker | ModelWorkerClient | None],
 ) -> None:
@@ -2755,12 +2798,28 @@ class Scheduler(
                 )
                 advance_from_accept_lens = False
             per_dp_bs = model_worker_batch.per_dp_bs_size
+            new_seq_lens_per_dp = None
+            if new_seq_lens is not None:
+                # Do not use ``dp_rank * per_dp_bs`` unconditionally here.
+                # Frozen-KV returns compact rank-concatenated rows, so an
+                # unbalanced DP-attention batch such as [15, 16] starts rank 1
+                # at row 15 rather than at its static bucket offset, row 32.
+                real_bs_per_dp = list(model_worker_batch.real_bs_per_dp)
+                new_seq_lens_per_dp = _split_spec_new_seq_lens(
+                    new_seq_lens,
+                    real_bs_per_dp=real_bs_per_dp,
+                    per_dp_bs=per_dp_bs,
+                )
             for dp_rank, info in enumerate(batch.reqs_info):
                 if info.seq_lens is None or len(info.seq_lens) == 0:
                     continue
                 if new_seq_lens is not None:
-                    off = dp_rank * per_dp_bs
-                    delta = new_seq_lens[off : off + len(info.seq_lens)]
+                    delta = new_seq_lens_per_dp[dp_rank]
+                    if len(delta) != len(info.seq_lens):
+                        raise ValueError(
+                            "Speculative next sequence lengths lost request rows during DP split: "
+                            f"rank={dp_rank}, rows={len(delta)}, requests={len(info.seq_lens)}."
+                        )
                     if advance_from_accept_lens:
                         info.seq_lens = info.seq_lens + delta
                     else:

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -441,6 +441,16 @@ class KVCache(abc.ABC):
     def get_fused_kv_buffer(self, layer_id: int) -> jax.Array:
         raise NotImplementedError()
 
+    def get_all_fused_kv_buffers(self) -> list[jax.Array]:
+        """Every layer's fused KV buffer, in ``replace_buffer`` order.
+
+        Frozen-KV draft models (Gemma4 MTP) read the target's cache but must not
+        write to it. ``memory_pools`` is a donated jit argument, so a model that
+        returns nothing leaves the donated buffers deleted — returning this list
+        unchanged is the pass-through that keeps the cache alive and intact.
+        """
+        return [self.get_fused_kv_buffer(i) for i in range(self.layer_num)]
+
     @abc.abstractmethod
     def get_kv_buffer(self, layer_id: int) -> tuple[jax.Array, jax.Array]:
         """Get separate K and V buffers for native attention.
@@ -880,6 +890,10 @@ class SWAKVPool(KVCache):
         if is_swa:
             return self.swa_kv_pool.get_fused_kv_buffer(layer_id_pool)
         return self.full_kv_pool.get_fused_kv_buffer(layer_id_pool)
+
+    def get_all_fused_kv_buffers(self) -> list[jax.Array]:
+        # SWAKVPool has no self.layer_num; replace_buffer keys off layers_mapping.
+        return [self.get_fused_kv_buffer(i) for i in range(len(self.layers_mapping))]
 
     def _remap_swa_loc(self, loc: jax.Array) -> jax.Array:
         """Remap full-pool indices to SWA-pool indices, handling both DP=1 and DP>1.

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -665,6 +665,22 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                 # if there is no aux layer, set to None
                 eagle_aux_hidden_state_layer_ids = None
             self.model.set_eagle3_layers_to_capture(eagle_aux_hidden_state_layer_ids)
+        elif self.server_args.speculative_algorithm == "FROZEN_KV_MTP" and not self.is_draft_worker:
+            # Gemma4 FROZEN_KV_MTP: the draft model consumes target hidden states
+            # through forward_batch.spec_info.hidden_states. The target's FINAL
+            # transformer output (post-norm, backbone_hidden_size-dim) is what the
+            # draft's pre_projection expects. Use a never-matching layer id so no
+            # intermediate layer is captured and FULL-mode falls back to final hidden.
+            self.model.capture_aux_hidden_states = True
+            # SGLang uses 1-based layer convention: layer i captures layer i-1's
+            # output. num_hidden_layers + 1 never matches the enumerate range
+            # (0..num_hidden_layers-1), so aux_hidden_states stays empty and the
+            # logits processor's FULL-mode fallback stores the final hidden.
+            last_layer_idx = self.model_config.num_hidden_layers
+            if hasattr(self.model, "set_eagle3_layers_to_capture"):
+                self.model.set_eagle3_layers_to_capture([last_layer_idx])
+            elif hasattr(self.model.model, "layers_to_capture"):
+                self.model.model.layers_to_capture = [last_layer_idx]
         elif self.server_args.speculative_algorithm == "DFLASH" and not self.is_draft_worker:
             # The captured layers must match the draft checkpoint's projection input.
             from sgl_jax.srt.speculative.dflash_util import parse_dflash_draft_config

--- a/python/sgl_jax/srt/models/gemma4.py
+++ b/python/sgl_jax/srt/models/gemma4.py
@@ -599,6 +599,21 @@ class Gemma4ForCausalLM(nnx.Module):
         )
         self.capture_aux_hidden_states = False
 
+    def get_embed_and_head(self):
+        """Expose the input embedding and output head to a speculative draft.
+
+        Required by the draft workers' shared-embed step (same contract as
+        llama.py / qwen3.py). The Gemma4 assistant draft embeds tokens with the
+        TARGET's embedding, so this is what binds its ``_target_embed_weight``.
+
+        Gemma4 ties the head by default and only creates ``lm_head`` when
+        ``tie_word_embeddings`` is false, so fall back to the embedding.
+        """
+        embed = self.model.embed_tokens.embedding.value
+        lm_head = getattr(self, "lm_head", None)
+        head = lm_head.embedding.value if lm_head is not None else embed
+        return embed, head
+
     def load_weights(self, model_config: ModelConfig):
         loader = WeightLoader(
             model=self,
@@ -915,6 +930,15 @@ class Gemma4ForCausalLM(nnx.Module):
         hidden_states, aux_hidden_states, layers_kv_fused, layers_callback_flag, layers_topk_ids = (
             self.model(forward_batch, kv_pool)
         )
+        # Gemma4Model always returns a list, so it is [] (not None) when nothing
+        # is captured. LogitsProcessor branches on `is not None` and would then
+        # jnp.concat([]) under CaptureHiddenMode.LAST — i.e. on every speculative
+        # verify forward. Mirror llama.py / qwen3.py and normalize to None.
+        # FROZEN_KV_MTP sets capture_aux_hidden_states with a never-matching layer
+        # id on purpose (it wants the final hidden, not an intermediate one), so
+        # the list can be empty even when capture is on — normalize both cases.
+        if not self.capture_aux_hidden_states or not aux_hidden_states:
+            aux_hidden_states = None
         if not getattr(self.config, "tie_word_embeddings", True):
             output = self.logits_processor(
                 hidden_states, self.lm_head, logits_metadata, aux_hidden_states=aux_hidden_states

--- a/python/sgl_jax/srt/models/gemma4_mtp.py
+++ b/python/sgl_jax/srt/models/gemma4_mtp.py
@@ -1,0 +1,810 @@
+"""Gemma4 MTP (Multi-Token Prediction) draft model for speculative decoding.
+
+Q-only attention layers that read K/V from the target verifier model's KV
+cache. Ported from the vllm-project/tpu-inference JAX-native implementation
+(PRs #2751, #2771) and the SGLang GPU ``Gemma4AssistantForCausalLM``.
+
+Key design (matches SGLang GPU):
+- Token embedding uses the *target* model's embedding (backbone_hidden_size-dim),
+  stored as ``_target_embed_weight``. Draft's own ``embed_tokens``
+  (hidden_size-dim) is only used via tied lm_head.
+- ``pre_projection(2*bb_dim → hidden_size)``, ``post_projection(hidden_size → bb_dim)``.
+- Attention is Q-only — K/V come from target KV cache via layer_id redirect.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+from transformers import PretrainedConfig
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.layers.embeddings import Embed, ParallelLMHead, get_rope
+from sgl_jax.srt.layers.layernorm import GemmaRMSNorm
+from sgl_jax.srt.layers.linear import LinearBase
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
+from sgl_jax.srt.layers.radix_attention import RadixAttention
+from sgl_jax.srt.mem_cache.memory_pool import KVCache
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+from sgl_jax.srt.utils.profiling_utils import named_scope
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+
+logger = logging.getLogger(__name__)
+
+init_fn = nnx.initializers.uniform()
+
+
+# ---------------------------------------------------------------------------
+# Q-only Attention (K/V from target model's shared KV cache)
+# ---------------------------------------------------------------------------
+
+
+class Gemma4MTPAttention(nnx.Module):
+    """Q-only attention for Gemma4 MTP draft layers.
+
+    Only projects Q (and optionally applies Q-norm + RoPE). K/V are dummy
+    zeros — the real K/V are read from the target model's KV cache via
+    RadixAttention with a redirected layer_id (set by the draft worker's
+    KV-share map). The Pallas kernel writes dummy K/V to draft-specific
+    page slots (allocated via EagleDraftInput), separate from target pages.
+    """
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        layer_id: int,
+        max_position_embeddings: int,
+        attention_bias: bool,
+        dtype: jnp.dtype,
+        mesh: jax.sharding.Mesh,
+    ):
+        self.layer_id = layer_id
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        rms_norm_eps = getattr(config, "rms_norm_eps", 1e-6)
+
+        self.layer_type = "full_attention"
+        if hasattr(config, "layer_types") and layer_id < len(config.layer_types):
+            self.layer_type = config.layer_types[layer_id]
+
+        self.is_sliding = self.layer_type == "sliding_attention"
+        self.sliding_window = getattr(config, "sliding_window", 0) if self.is_sliding else 0
+
+        # Per-layer-type RoPE parameters
+        rope_parameters = getattr(config, "rope_parameters", {})
+        rope_params = dict(rope_parameters.get(self.layer_type, {}))
+        if not self.is_sliding:
+            if "rope_type" not in rope_params:
+                rope_params["rope_type"] = "proportional"
+            if "partial_rotary_factor" not in rope_params:
+                rope_params["partial_rotary_factor"] = 0.25
+            rope_theta = rope_params.get("rope_theta", getattr(config, "rope_theta", 1000000.0))
+        else:
+            if "rope_type" not in rope_params:
+                rope_params["rope_type"] = "default"
+            if "partial_rotary_factor" not in rope_params:
+                rope_params["partial_rotary_factor"] = 1.0
+            rope_theta = rope_params.get(
+                "rope_theta", getattr(config, "rope_local_base_freq", 10000.0)
+            )
+
+        if not self.is_sliding:
+            self.head_dim = getattr(config, "head_dim", self.hidden_size // self.num_heads)
+        else:
+            self.head_dim = getattr(
+                config,
+                "swa_head_dim",
+                getattr(config, "head_dim", self.hidden_size // self.num_heads),
+            )
+
+        use_k_eq_v = (not self.is_sliding) and getattr(config, "attention_k_eq_v", False)
+        if use_k_eq_v:
+            self.num_kv_heads = getattr(config, "num_key_value_heads", self.num_heads)
+        else:
+            self.num_kv_heads = getattr(
+                config,
+                "swa_num_key_value_heads",
+                getattr(config, "num_key_value_heads", self.num_heads),
+            )
+
+        self.q_head_num = self.num_heads
+        self.kv_head_num = self.num_kv_heads
+        self.mesh = mesh
+
+        self.q_proj = LinearBase(
+            input_size=self.hidden_size,
+            output_size=self.num_heads * self.head_dim,
+            use_bias=attention_bias,
+            kernel_axes=(None, "tensor"),
+            params_dtype=dtype,
+            mesh=mesh,
+            scope_name="q_proj",
+        )
+        self.q_norm = GemmaRMSNorm(self.head_dim, epsilon=rms_norm_eps, add_unit_offset=False)
+        self.o_proj = LinearBase(
+            input_size=self.num_heads * self.head_dim,
+            output_size=self.hidden_size,
+            use_bias=attention_bias,
+            kernel_axes=("tensor", None),
+            params_dtype=dtype,
+            mesh=mesh,
+            scope_name="o_proj",
+        )
+
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=max_position_embeddings,
+            base=rope_theta,
+            is_neox_style=True,
+            rope_scaling=rope_params,
+            dtype=dtype,
+        )
+
+        self.attn = RadixAttention(
+            num_heads=self.num_heads,
+            head_dim=self.head_dim,
+            scaling=1.0,
+            num_kv_heads=self.num_kv_heads,
+            layer_id=layer_id,
+            sliding_window_size=self.sliding_window,
+        )
+
+    @named_scope
+    def __call__(
+        self,
+        positions: jax.Array,
+        hidden_states: jax.Array,
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: KVCache,
+    ) -> tuple[jax.Array, jax.Array]:
+        q, _ = self.q_proj(hidden_states)
+        q = q.reshape(
+            -1,
+            self.q_head_num,
+            self.head_dim,
+            out_sharding=NamedSharding(self.mesh, P("data", "tensor", None)),
+        )
+        q = self.q_norm(q)
+        dummy_k = jnp.zeros_like(q)
+        q, _ = self.rotary_emb(positions, q, dummy_k)
+
+        # Dummy K/V — real K/V from target KV cache via redirected layer_id.
+        # Name the sharding: a bare jnp.zeros() is REPLICATED under an explicit
+        # mesh, whereas real projected K/V (and q above) are head-sharded on
+        # "tensor". The attention backend's shard_map in_specs expect the latter,
+        # so leaving these replicated forces an implicit reshard on every draft
+        # step at best, and a sharding error at worst.
+        kv_sharding = NamedSharding(self.mesh, P("data", "tensor", None))
+        dummy_k = jnp.zeros(
+            (q.shape[0], self.kv_head_num, self.head_dim),
+            dtype=q.dtype,
+            out_sharding=kv_sharding,
+        )
+        dummy_v = jnp.zeros(
+            (q.shape[0], self.kv_head_num, self.head_dim),
+            dtype=q.dtype,
+            out_sharding=kv_sharding,
+        )
+
+        attn_output, kv_fused = self.attn(q, dummy_k, dummy_v, forward_batch, token_to_kv_pool)
+        output, _ = self.o_proj(attn_output)
+        return output, kv_fused
+
+
+# ---------------------------------------------------------------------------
+# MTP Decoder Layer
+# ---------------------------------------------------------------------------
+
+
+class Gemma4MTPDecoderLayer(nnx.Module):
+    """Dense MTP decoder layer (no MoE)."""
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        layer_id: int = 0,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.layer_id = layer_id
+        self.hidden_size = config.hidden_size
+        self.mesh = mesh
+        max_position_embeddings = getattr(config, "max_position_embeddings", 256000)
+        attention_bias = getattr(config, "attention_bias", False)
+        rms_norm_eps = getattr(config, "rms_norm_eps", 1e-6)
+
+        self.layer_type = "full_attention"
+        if hasattr(config, "layer_types") and layer_id < len(config.layer_types):
+            self.layer_type = config.layer_types[layer_id]
+
+        self.layer_scalar = nnx.Param(jnp.ones((1,), dtype=dtype))
+        self.input_layernorm = GemmaRMSNorm(
+            config.hidden_size,
+            epsilon=rms_norm_eps,
+            add_unit_offset=False,
+        )
+        self.self_attn = Gemma4MTPAttention(
+            config=config,
+            layer_id=layer_id,
+            max_position_embeddings=max_position_embeddings,
+            attention_bias=attention_bias,
+            dtype=dtype,
+            mesh=mesh,
+        )
+        self.post_attention_layernorm = GemmaRMSNorm(
+            config.hidden_size,
+            epsilon=rms_norm_eps,
+            add_unit_offset=False,
+        )
+        self.pre_feedforward_layernorm = GemmaRMSNorm(
+            config.hidden_size,
+            epsilon=rms_norm_eps,
+            add_unit_offset=False,
+        )
+        self.post_feedforward_layernorm = GemmaRMSNorm(
+            config.hidden_size,
+            epsilon=rms_norm_eps,
+            add_unit_offset=False,
+        )
+
+        from sgl_jax.srt.models.gemma4 import Gemma4MLP
+
+        self.mlp = Gemma4MLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            layer_id=layer_id,
+            dtype=dtype,
+            mesh=mesh,
+        )
+
+    @named_scope
+    def __call__(
+        self,
+        positions: jax.Array,
+        hidden_states: jax.Array,
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: KVCache,
+    ):
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, kv_fused = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+            forward_batch=forward_batch,
+            token_to_kv_pool=token_to_kv_pool,
+        )
+        attn_output = self.post_attention_layernorm(hidden_states)
+        hidden_states = residual + attn_output
+        residual = hidden_states
+
+        mlp_input = self.pre_feedforward_layernorm(hidden_states)
+        hidden_states = self.mlp(mlp_input)
+        mlp_output = self.post_feedforward_layernorm(hidden_states)
+        outputs = residual + mlp_output
+        outputs = outputs * self.layer_scalar.value
+        return outputs, kv_fused, [], None
+
+
+# ---------------------------------------------------------------------------
+# Schema-driven per-layer weight specs
+# ---------------------------------------------------------------------------
+
+_LAYER_WEIGHT_SPECS: list[tuple[str, tuple, bool]] = [
+    ("layer_scalar", (None,), False),
+    ("input_layernorm.weight", (None,), False),
+    ("post_attention_layernorm.weight", (None,), False),
+    ("pre_feedforward_layernorm.weight", (None,), False),
+    ("post_feedforward_layernorm.weight", (None,), False),
+    ("self_attn.q_proj.weight", (None, "tensor"), True),
+    ("self_attn.q_norm.weight", (None,), False),
+    ("self_attn.o_proj.weight", ("tensor", None), True),
+    ("mlp.gate_proj.weight", (None, "tensor"), True),
+    ("mlp.up_proj.weight", (None, "tensor"), True),
+    ("mlp.down_proj.weight", ("tensor", None), True),
+]
+
+
+# ---------------------------------------------------------------------------
+# Gemma4AssistantForCausalLM — main MTP draft model
+# ---------------------------------------------------------------------------
+
+
+class Gemma4AssistantForCausalLM(nnx.Module):
+    """Gemma4 MTP (frozen-KV) draft model for speculative decoding.
+
+    Matches the HF checkpoint ``"architectures": ["Gemma4AssistantForCausalLM"]``
+    and the upstream SGLang GPU ``Gemma4AssistantForCausalLM`` pattern:
+
+    - Token embedding uses the *target* model's embedding (backbone_hidden_size-dim),
+      stored as ``_target_embed_weight``.
+    - Draft's own ``embed_tokens`` (hidden_size-dim) is only used via tied lm_head.
+    - ``set_embed_and_head(embed, head)`` stores the target embedding, discards head.
+    - Attention is Q-only — K/V come from target KV cache via redirected layer_id.
+    - ``pre_projection(2*bb_dim → hidden_size)``, ``post_projection(hidden_size → bb_dim)``.
+    """
+
+    # The draft worker's shared-embed path calls set_embed_and_head() only when
+    # this is set, and falls back to set_embed() otherwise -- which is a no-op
+    # here. Without this flag _target_embed_weight never binds and the first
+    # forward raises "target embedding is not bound". Same convention as
+    # mimo_v2_nextn.py.
+    load_lm_head_from_target = True
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        super().__init__()
+        self.mesh = mesh
+        self.config = getattr(config, "text_config", config)
+        self.dtype = dtype
+
+        full_config = config
+        backbone_hidden_size = getattr(full_config, "backbone_hidden_size", self.config.hidden_size)
+        num_mtp_layers = getattr(self.config, "num_hidden_layers", 4)
+        self.num_mtp_layers = num_mtp_layers
+        self.backbone_hidden_size = backbone_hidden_size
+        self.normalizer = backbone_hidden_size**0.5
+
+        # -- Core MTP layers (inlined from MultiTokenPredictor) -----------------
+
+        # Draft's own embed_tokens (hidden_size-dim) — for tied lm_head only.
+        # Token embedding in forward uses target's embedding instead.
+        self.embed_tokens = Embed(
+            num_embeddings=self.config.vocab_size,
+            features=self.config.hidden_size,
+            param_dtype=dtype,
+            dtype=dtype,
+        )
+
+        self.pre_projection = LinearBase(
+            input_size=2 * backbone_hidden_size,
+            output_size=self.config.hidden_size,
+            use_bias=False,
+            params_dtype=dtype,
+            kernel_axes=(None, "tensor"),
+            mesh=mesh,
+            scope_name="pre_projection",
+        )
+        self.post_projection = LinearBase(
+            input_size=self.config.hidden_size,
+            output_size=backbone_hidden_size,
+            use_bias=False,
+            params_dtype=dtype,
+            kernel_axes=(None, "tensor"),
+            mesh=mesh,
+            scope_name="post_projection",
+        )
+
+        self.layers = nnx.data(
+            [
+                Gemma4MTPDecoderLayer(config=self.config, mesh=mesh, layer_id=i, dtype=dtype)
+                for i in range(num_mtp_layers)
+            ]
+        )
+
+        self.norm = GemmaRMSNorm(
+            self.config.hidden_size,
+            epsilon=getattr(self.config, "rms_norm_eps", 1e-6),
+            add_unit_offset=False,
+        )
+
+        # -- Output -------------------------------------------------------------
+
+        self.final_logit_softcapping = getattr(self.config, "final_logit_softcapping", None)
+
+        # Draft's lm_head: hidden_size → vocab.
+        # When tie_word_embeddings=True (default for Gemma4 MTP), lm_head
+        # aliases embed_tokens (hidden_size-dim).
+        if not getattr(self.config, "tie_word_embeddings", True):
+            self.lm_head = ParallelLMHead(
+                self.config.vocab_size,
+                self.config.hidden_size,
+                dtype=dtype,
+                param_dtype=dtype,
+                kernel_axes=("tensor", None),
+            )
+
+        # -- Sparse masked (centroid-based) embedder (inlined) ------------------
+
+        use_ordered = getattr(full_config, "use_ordered_embeddings", False)
+        if use_ordered:
+            num_centroids = getattr(full_config, "num_centroids", 2048)
+            top_k = getattr(full_config, "centroid_intermediate_top_k", 32)
+            self.masked_num_centroids = num_centroids
+            self.masked_centroid_top_k = top_k
+            self.masked_vocab_size_per_centroid = self.config.vocab_size // num_centroids
+            self.masked_num_selected = top_k * self.masked_vocab_size_per_centroid
+            self.masked_centroids = LinearBase(
+                input_size=self.config.hidden_size,
+                output_size=num_centroids,
+                use_bias=False,
+                params_dtype=dtype,
+                kernel_axes=(None, "tensor"),
+                mesh=mesh,
+                scope_name="masked_centroids",
+            )
+            self.masked_token_ordering = nnx.Param(
+                jnp.zeros((self.config.vocab_size,), dtype=jnp.int32),
+                eager_sharding=False,
+            )
+        else:
+            self.masked_centroids = None
+
+        self.logits_processor = LogitsProcessor(
+            self.config.vocab_size,
+            soft_cap=getattr(self.config, "final_logit_softcapping", None),
+            mesh=self.mesh,
+        )
+        self.capture_aux_hidden_states = False
+
+    # ------------------------------------------------------------------
+    # Weight loading
+    # ------------------------------------------------------------------
+
+    def load_weights(self, model_config: ModelConfig):
+        loader = WeightLoader(
+            model=self,
+            model_config=model_config,
+            mesh=self.mesh,
+            dtype=self.dtype,
+        )
+        weight_mappings = self._create_weight_mappings()
+        if not loader.dummy_mode:
+            weight_info = loader._scan_weight_info()
+            weight_mappings = {k: v for k, v in weight_mappings.items() if k in weight_info}
+        loader.load_weights_from_safetensors(weight_mappings)
+        logger.info("Gemma4 MTP weights loaded successfully!")
+
+    def _create_weight_mappings(self) -> dict:
+        mappings = {}
+
+        # Draft's own embed_tokens (hidden_size-dim, loaded from checkpoint)
+        mappings["model.embed_tokens.weight"] = WeightMapping(
+            target_path="embed_tokens.embedding",
+            sharding=("tensor", None),
+            transpose=False,
+        )
+
+        # lm_head: tied to embed_tokens by default
+        if not hasattr(self, "lm_head") or self.lm_head is None:
+            mappings["lm_head.weight"] = WeightMapping(
+                target_path="embed_tokens.embedding",
+                sharding=("tensor", None),
+                transpose=False,
+            )
+        else:
+            mappings["lm_head.weight"] = WeightMapping(
+                target_path="lm_head.embedding",
+                sharding=("tensor", None),
+                transpose=False,
+            )
+
+        # Pre/post projections.
+        #
+        # NOTE THE MISSING "model." PREFIX. In google/gemma-4-*-it-assistant these
+        # two tensors sit at the TOP LEVEL of the checkpoint -- verified against
+        # the safetensors header:
+        #     pre_projection.weight        [1024, 10752]   (hidden, 2*backbone)
+        #     post_projection.weight       [5376, 1024]    (backbone, hidden)
+        #     model.embed_tokens.weight    [262144, 1024]  <- these DO carry it
+        #     model.norm.weight            [1024]
+        # Mapping them as "model.pre_projection.weight" matched nothing, so both
+        # stayed ShapeDtypeStruct placeholders, model_runner swapped them for empty
+        # arrays (the "replaced 2 ShapeDtypeStruct state placeholders" log line),
+        # and the first forward died in dot_general with a (0,) contracting
+        # dimension. A silent no-match is the dangerous part: nothing warns, and
+        # the loader still reports "weights loaded successfully".
+        mappings["pre_projection.weight"] = WeightMapping(
+            target_path="pre_projection.weight",
+            sharding=(None, "tensor"),
+            transpose=True,
+        )
+        mappings["post_projection.weight"] = WeightMapping(
+            target_path="post_projection.weight",
+            sharding=(None, "tensor"),
+            transpose=True,
+        )
+        mappings["model.norm.weight"] = WeightMapping(
+            target_path="norm.weight",
+            sharding=(None,),
+            transpose=False,
+        )
+
+        # Centroid masked embedder (inlined attributes)
+        if self.masked_centroids is not None:
+            mappings["masked_embedding.centroids.weight"] = WeightMapping(
+                target_path="masked_centroids.weight",
+                sharding=(None, "tensor"),
+                transpose=True,
+            )
+            mappings["masked_embedding.token_ordering"] = WeightMapping(
+                target_path="masked_token_ordering",
+                sharding=(None,),
+                transpose=False,
+            )
+
+        # Per-layer mappings (schema-driven)
+        attn_bias = getattr(self.config, "attention_bias", False)
+        for layer_idx in range(self.num_mtp_layers):
+            mappings.update(self._create_layer_mappings(layer_idx, attn_bias))
+
+        # "mtp." prefix (native checkpoint layout)
+        for k, v in list(mappings.items()):
+            if k.startswith("model."):
+                mappings[k.replace("model.", "mtp.", 1)] = v
+
+        # "language_model.model." prefix (multimodal layout)
+        for k, v in list(mappings.items()):
+            if k.startswith("model."):
+                mappings[f"language_model.{k}"] = v
+
+        return mappings
+
+    def _create_layer_mappings(self, layer_idx: int, attn_bias: bool) -> dict:
+        hf_prefix = f"model.layers.{layer_idx}"
+        target_prefix = f"layers.{layer_idx}"
+
+        mappings = {}
+        for suffix, sharding, transpose in _LAYER_WEIGHT_SPECS:
+            mappings[f"{hf_prefix}.{suffix}"] = WeightMapping(
+                target_path=f"{target_prefix}.{suffix}",
+                sharding=sharding,
+                transpose=transpose,
+            )
+
+        if attn_bias:
+            for proj in ("q_proj", "o_proj"):
+                mappings[f"{hf_prefix}.self_attn.{proj}.bias"] = WeightMapping(
+                    target_path=f"{target_prefix}.self_attn.{proj}.bias",
+                    sharding=(None,),
+                    transpose=False,
+                )
+        return mappings
+
+    # ------------------------------------------------------------------
+    # Forward pass
+    # ------------------------------------------------------------------
+
+    def _embed_input_ids(self, input_ids: jax.Array) -> jax.Array:
+        """Embed tokens using the stored TARGET embedding (backbone_hidden_size-dim)."""
+        if not hasattr(self, "_target_embed_weight") or self._target_embed_weight is None:
+            raise RuntimeError(
+                "Gemma4 MTP target embedding is not bound. "
+                "Call set_embed_and_head() before forward."
+            )
+        embed = self._target_embed_weight
+        embed = embed.value if hasattr(embed, "value") else embed
+
+        # The target's embedding is VOCAB-sharded -- gemma4.py builds it with
+        # kernel_axes=("tensor", None), so this array is [vocab@tensor, features].
+        # Gathering arbitrary rows from it therefore needs a collective, and under
+        # an explicit-sharding mesh JAX refuses to guess the output spec: plain
+        # `embed[input_ids]` raises ShardingTypeError. Name the spec instead, with
+        # exactly the expression Embed.__call__ uses on this same array, so the
+        # draft's embeddings are laid out identically to the target's.
+        output_pspec = P("data", *([None] * (input_ids.ndim - 1)), None)
+        token_embed = embed.at[input_ids].get(out_sharding=NamedSharding(self.mesh, output_pspec))
+        return token_embed * self.normalizer
+
+    def __call__(
+        self,
+        forward_batch: ForwardBatch,
+        memory_pools: Any,
+        logits_metadata: LogitsMetadata,
+    ):
+        kv_pool = memory_pools.token_to_kv_pool
+        target_hidden_states = forward_batch.spec_info.hidden_states
+        positions = forward_batch.positions
+
+        # Embed with TARGET embedding (backbone_hidden_size-dim) + target hidden
+        inputs_embeds = self._embed_input_ids(forward_batch.input_ids)
+
+        # These two arrive with different specs: the embedding gather produces
+        # P("data", None) (the repo's convention for [tokens, features], as in
+        # sampler.py), while the captured target hidden states come back
+        # replicated as P(None, None). jnp.concatenate requires its operands to
+        # agree, so under an explicit-sharding mesh the mismatch is an error
+        # rather than an implicit resharding. Move the replicated one onto the
+        # sharded spec -- that direction is a local slice, whereas gathering the
+        # embeddings up to replicated would cost an all-gather every draft step.
+        target_hidden_states = jax.sharding.reshard(
+            target_hidden_states, NamedSharding(self.mesh, P("data", None))
+        )
+        combined = jnp.concatenate([inputs_embeds, target_hidden_states], axis=-1)
+        hidden_states, _ = self.pre_projection(combined)
+
+        # Run all MTP layers. The per-layer fused KV the attention kernel returns
+        # is DISCARDED on purpose — see the frozen-KV note on the return below.
+        for layer in self.layers:
+            hidden_states, _, _, _ = layer(
+                positions=positions,
+                hidden_states=hidden_states,
+                forward_batch=forward_batch,
+                token_to_kv_pool=kv_pool,
+            )
+
+        draft_hidden = self.norm(hidden_states)
+
+        # Compute logits from the hidden_size-dim tensor (lm_head's input space).
+        if hasattr(self, "lm_head") and self.lm_head is not None:
+            output = self.logits_processor(draft_hidden, self.lm_head, logits_metadata)
+        else:
+            output = self.logits_processor(draft_hidden, self.embed_tokens, logits_metadata)
+
+        # The captured hidden is fed back as the NEXT draft step's
+        # spec_info.hidden_states (eagle_draft_worker.draft_forward), where it is
+        # concatenated with a backbone-dim embedding into pre_projection(2*bb_dim).
+        # So it has to leave here in backbone space, not hidden space. Projecting
+        # after the logits processor's row selection is equivalent to projecting
+        # before it (post_projection is per-token linear) and touches fewer rows.
+        if output.hidden_states is not None:
+            output.hidden_states, _ = self.post_projection(output.hidden_states)
+
+        # Frozen KV: this draft never owns KV state. Its attention reads the
+        # TARGET's cache (RadixAttention.layer_id is redirected by the draft
+        # worker) and its dummy zero K/V must never reach the pool — the write
+        # back in MemoryPools.replace_all is POSITIONAL, so returning the draft's
+        # own per-layer arrays would land them in target layers 0..N-1 and destroy
+        # verified KV. memory_pools is a donated jit argument, so we cannot return
+        # nothing either; pass the target's buffers straight through, unmodified.
+        return output, {"token_to_kv_pool": kv_pool.get_all_fused_kv_buffers()}, [], None
+
+    # ------------------------------------------------------------------
+    # Embed / head sharing with target model
+    # ------------------------------------------------------------------
+
+    def get_embed_and_head(self):
+        """Return (target_embed_weight, lm_head_weight).
+
+        ``target_embed_weight`` is the TARGET embedding (bb-dim), set via
+        ``set_embed_and_head()``. ``lm_head_weight`` is the draft's own.
+        """
+        target_embed = getattr(self, "_target_embed_weight", None)
+        if target_embed is None:
+            target_embed = self.embed_tokens.embedding
+        head = (
+            self.lm_head.embedding
+            if hasattr(self, "lm_head") and self.lm_head is not None
+            else self.embed_tokens.embedding
+        )
+        return target_embed, head
+
+    def set_embed(self, _embed_weight):
+        """No-op: single-embed set not used by Gemma4 MTP."""
+        pass
+
+    def set_embed_and_head(self, embed_weight, head_weight):
+        """Store target embedding for token embed; discard target head.
+
+        Matches SGLang GPU: ``set_embed_and_head(embed, head)`` stores
+        ``embed`` as the target embedding (backbone_hidden_size-dim) and
+        ignores ``head`` — the assistant keeps its own lm_head.
+        """
+        del head_weight
+        self._target_embed_weight = embed_weight
+
+    # ------------------------------------------------------------------
+    # Logit computation (with optional masked embedder)
+    # ------------------------------------------------------------------
+
+    def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
+        """Standalone logit computation — NOT used by ``__call__``.
+
+        ``__call__`` deliberately goes through ``self.logits_processor`` (dense
+        full-vocab head) even when ``use_ordered_embeddings`` loaded the centroid
+        weights. The masked path is an *approximation*, not a different id space:
+        ``masked_token_ordering`` stores token ids grouped into centroid clusters
+        and ``_select_and_score`` indexes an unpermuted ``lm_head`` by those ids,
+        so the dense path is strictly more accurate, never wrong. It scores
+        ``centroid_intermediate_top_k * (vocab / num_centroids)`` candidates via a
+        large per-token gather, which on TPU is usually slower than the dense
+        matmul it replaces — the tradeoff that makes it a win on GPU does not
+        obviously carry over.
+
+        Enabling it in ``__call__`` is therefore a benchmark-gated optimization,
+        not a fix. Kept here (and unit-tested) so that switch is a small change.
+        """
+        if self.masked_centroids is not None:
+            return self._compute_logits_masked(hidden_states)
+
+        if hasattr(self, "lm_head") and self.lm_head is not None:
+            # ParallelLMHead weight is (vocab_size, hidden_size); transpose for
+            # (hidden_states) @ (hidden_size, vocab_size) → (tokens, vocab_size).
+            logits = hidden_states @ self.lm_head.embedding.value.T
+        else:
+            # Embed.embedding is (vocab_size, hidden_size); .decode() handles
+            # the transpose internally.
+            logits = self.embed_tokens.decode(hidden_states)
+
+        if self.final_logit_softcapping is not None:
+            logits = jnp.tanh(logits / self.final_logit_softcapping) * self.final_logit_softcapping
+        return logits
+
+    def _get_full_lm_head_weight(self) -> jax.Array:
+        if hasattr(self, "lm_head") and self.lm_head is not None:
+            return self.lm_head.embedding.value
+        return self.embed_tokens.embedding.value
+
+    # -- Inlined MaskedEmbedder methods -----------------------------------------
+
+    def _select_and_score(
+        self,
+        hidden_states: jax.Array,
+        lm_head_weight: jax.Array,
+    ) -> tuple[jax.Array, jax.Array]:
+        num_tokens = hidden_states.shape[0]
+        if lm_head_weight.shape == (self.config.hidden_size, self.config.vocab_size):
+            lm_head_weight = lm_head_weight.T
+        elif lm_head_weight.shape != (self.config.vocab_size, self.config.hidden_size):
+            raise ValueError(f"Unexpected lm_head_weight shape: {lm_head_weight.shape}")
+        centroid_logits, _ = self.masked_centroids(hidden_states)
+        # The centroid projection shards its output vocabulary over the tensor
+        # axis.  Top-k needs to compare every centroid for each token, so the
+        # selected axis must be replicated before invoking lax.top_k.  This is
+        # the same explicit reshard used by the generic speculative top-k
+        # helper; leaving the output tensor-sharded fails under explicit
+        # multi-device sharding (and can select only local centroids).
+        centroid_logits = jax.sharding.reshard(centroid_logits, NamedSharding(self.mesh, P()))
+        _, top_k_indices = jax.lax.top_k(centroid_logits, k=self.masked_centroid_top_k)
+        clusters = self.masked_token_ordering.value.reshape(
+            self.masked_num_centroids, self.masked_vocab_size_per_centroid
+        )
+        # Both gathers pick arbitrary rows by token id. Under an explicit-sharding
+        # mesh jnp.take cannot infer an output spec for that (and lm_head_weight is
+        # vocab-sharded, so it needs a collective), which is why plain jnp.take
+        # raises ShardingTypeError. Name the output spec so JAX inserts the
+        # all-gather — the cost that makes this path a poor trade on TPU and the
+        # reason compute_logits() is not wired into __call__.
+        replicated = NamedSharding(self.mesh, P())
+        selected = clusters.at[top_k_indices].get(out_sharding=replicated)
+        selected_flat = selected.reshape(num_tokens, self.masked_num_selected)
+        embeddings = lm_head_weight.at[selected_flat].get(out_sharding=replicated)
+        logits = jnp.einsum("td,tsd->ts", hidden_states, embeddings)
+        return logits, selected_flat
+
+    def _compute_logits_masked(self, hidden_states: jax.Array) -> jax.Array:
+        logits, indices = self._select_and_score(hidden_states, self._get_full_lm_head_weight())
+        num_tokens = hidden_states.shape[0]
+        output = jnp.full(
+            (num_tokens, self.config.vocab_size),
+            jnp.finfo(hidden_states.dtype).min,
+            dtype=hidden_states.dtype,
+        )
+        row_indices = jnp.arange(num_tokens)[:, None]
+        return output.at[row_indices, indices].set(logits)
+
+    def _get_top_tokens_masked(
+        self, hidden_states: jax.Array, lm_head_weight: jax.Array
+    ) -> jax.Array:
+        logits, indices = self._select_and_score(hidden_states, lm_head_weight)
+        best_idx = jnp.argmax(logits, axis=-1, keepdims=True)
+        return jnp.take_along_axis(indices, best_idx, axis=-1).squeeze(-1)
+
+
+# ---------------------------------------------------------------------------
+# Unified assistant alias (12B model — text path identical)
+# ---------------------------------------------------------------------------
+
+
+class Gemma4UnifiedAssistantForCausalLM(Gemma4AssistantForCausalLM):
+    """Alias matching the HF unified assistant checkpoint arch name.
+
+    The 12B-it-unified-assistant checkpoint declares
+    ``"architectures": ["Gemma4UnifiedAssistantForCausalLM"]`` with
+    ``model_type: "gemma4_unified_assistant"``. The text transformer path
+    is identical to the non-unified assistant — this alias lets the
+    ``ModelRegistry`` resolve it directly.
+    """
+
+
+EntryClass = [Gemma4AssistantForCausalLM, Gemma4UnifiedAssistantForCausalLM]

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -57,6 +57,22 @@ def apply_multimodal_model_defaults(server_args, model_config) -> None:
         server_args.limit_mm_data_per_request = {"image": 16}
 
 
+# Exact list, matching resolve_speculative_algorithm in upstream
+# sgl-project/sglang (srt/arg_groups/speculative_hook.py). Kept exact rather
+# than a Gemma4*Assistant* pattern so a future assistant variant fails loudly
+# on the unsupported path instead of being silently promoted into a frozen-KV
+# path that may not fit it. Keep in sync with EntryClass in models/gemma4_mtp.py.
+_FROZEN_KV_MTP_DRAFT_ARCHS = (
+    "Gemma4AssistantForCausalLM",
+    "Gemma4UnifiedAssistantForCausalLM",
+)
+
+
+def _is_frozen_kv_mtp_arch(architecture: str) -> bool:
+    """Is this draft architecture a Q-only, KV-sharing (frozen-KV) MTP head?"""
+    return architecture in _FROZEN_KV_MTP_DRAFT_ARCHS
+
+
 def _validate_disaggregation_host_ip(host_ip: str) -> str:
     if host_ip in _REJECTED_PD_HOST_ALIASES:
         raise ValueError(
@@ -1581,7 +1597,7 @@ class ServerArgs:
         parser.add_argument(
             "--speculative-algorithm",
             type=str,
-            choices=["EAGLE", "EAGLE3", "NEXTN", "STANDALONE", "DFLASH"],
+            choices=["EAGLE", "EAGLE3", "NEXTN", "FROZEN_KV_MTP", "STANDALONE", "DFLASH"],
             help="Speculative algorithm.",
             default=ServerArgs.speculative_algorithm,
         )
@@ -1964,7 +1980,97 @@ class ServerArgs:
         )
         return hf_config
 
+    def get_speculative_draft_hf_config(self):
+        """HF config of the draft checkpoint, or None if it cannot be read.
+
+        Best-effort: a missing or unreadable draft config is not fatal here, the
+        draft ModelWorker will fail with a better message than arg validation can.
+        """
+        if not self.speculative_draft_model_path:
+            return None
+        try:
+            return get_config(
+                self.speculative_draft_model_path,
+                trust_remote_code=self.trust_remote_code,
+                revision=self.speculative_draft_model_revision or self.revision,
+            )
+        except Exception as e:
+            logger.debug("Could not read draft config for algorithm promotion: %s", e)
+            return None
+
+    def maybe_promote_speculative_algorithm(self):
+        """Promote NEXTN/EAGLE to FROZEN_KV_MTP for Gemma4 assistant drafts.
+
+        Mirrors ``resolve_speculative_algorithm`` in upstream sgl-project/sglang
+        (srt/arg_groups/speculative_hook.py): both NEXTN and EAGLE promote, and
+        EAGLE3 is rejected outright for this draft architecture. Upstream's
+        Gemma 4 cookbook documents ``--speculative-algorithm NEXTN`` with a
+        ``*-it-assistant`` draft, so users never type FROZEN_KV_MTP.
+
+        Without the promotion that documented command silently does the wrong
+        thing here: NEXTN routes to MultiLayerDraftWorker's per-layer branch,
+        which builds one full draft model per step and never applies the
+        KV-share redirect, so the Q-only attention reads an empty draft-local
+        cache and returns garbage rather than failing.
+
+        Deliberately NOT copied from upstream: its fallthrough rewrites a
+        non-Gemma4 NEXTN to EAGLE. Upstream has no NEXTN enum member, whereas
+        here NEXTN is a distinct algorithm with its own per-layer worker for
+        DeepSeek/MiMo drafts, so that rewrite would break it.
+        """
+        if self.speculative_algorithm not in ("NEXTN", "EAGLE", "EAGLE3"):
+            return
+        draft_config = self.get_speculative_draft_hf_config()
+        if draft_config is None:
+            return
+        architectures = getattr(draft_config, "architectures", None) or []
+        matched = next((a for a in architectures if _is_frozen_kv_mtp_arch(a)), None)
+        if matched is None:
+            return
+
+        if self.speculative_algorithm == "EAGLE3":
+            raise ValueError(
+                f"{matched} draft requires --speculative-algorithm NEXTN or EAGLE; "
+                f"EAGLE3 is not supported for this draft architecture."
+            )
+
+        logger.info(
+            "Detected %s draft; promoting --speculative-algorithm %s to FROZEN_KV_MTP.",
+            matched,
+            self.speculative_algorithm,
+        )
+        self.speculative_algorithm = "FROZEN_KV_MTP"
+
+    def _validate_frozen_kv_mtp_args(self):
+        """Fail at startup for configurations the dedicated worker cannot run."""
+        if self.speculative_algorithm != "FROZEN_KV_MTP":
+            return
+        if self.speculative_draft_model_path is None:
+            raise ValueError("FROZEN_KV_MTP requires --speculative-draft-model-path.")
+
+        draft_config = self.get_speculative_draft_hf_config()
+        architectures = getattr(draft_config, "architectures", None) or []
+        if not any(_is_frozen_kv_mtp_arch(arch) for arch in architectures):
+            raise ValueError(
+                "FROZEN_KV_MTP requires a supported Gemma 4 assistant draft architecture; "
+                f"found {architectures or 'no architecture metadata'}."
+            )
+        if self.speculative_eagle_topk != 1:
+            raise ValueError("FROZEN_KV_MTP requires --speculative-eagle-topk=1.")
+        if self.speculative_num_draft_tokens != self.speculative_num_steps + 1:
+            raise ValueError(
+                "FROZEN_KV_MTP requires --speculative-num-draft-tokens to equal "
+                "--speculative-num-steps + 1."
+            )
+        if not self.disable_overlap_schedule:
+            raise ValueError("FROZEN_KV_MTP currently requires --disable-overlap-schedule.")
+
     def check_server_args(self):
+        # Runs before every speculative_algorithm check below, so they all see
+        # the promoted value rather than the raw CLI string.
+        self.maybe_promote_speculative_algorithm()
+        self._validate_frozen_kv_mtp_args()
+
         assert (self.tp_size) % self.nnodes == 0, "tp_size must be divisible by number of nodes"
 
         if self.moe_dp_size < 1:

--- a/python/sgl_jax/srt/speculative/base_worker.py
+++ b/python/sgl_jax/srt/speculative/base_worker.py
@@ -57,6 +57,33 @@ class BaseDraftWorker(ABC):
     def draft_extend_for_decode(self, model_worker_batch, batch_output):
         pass
 
+    def build_next_draft_input_after_verify(
+        self,
+        *,
+        verified_id,
+        hidden_states,
+        new_seq_lens,
+        allocate_lens,
+        accept_lens,
+        accept_index,
+        model_worker_batch,
+    ):
+        """Build the next-round draft state after shared target verification.
+
+        The default keeps the existing EAGLE behavior: verification has already
+        gathered the accepted token and corresponding target hidden state, so
+        construct the usual ``new_draft_input`` object from those arrays.
+        Algorithms with a different handoff (for example Frozen-KV) can
+        override this seam without replacing the common target verification
+        and scheduler bookkeeping.
+        """
+        return self.new_draft_input(
+            verified_id=verified_id,
+            new_seq_lens=new_seq_lens,
+            allocate_lens=allocate_lens,
+            hidden_states=hidden_states,
+        )
+
 
 class BaseSpecWorker:
     """Speculative decode orchestrator.
@@ -146,6 +173,28 @@ class BaseSpecWorker:
             and not getattr(model_worker_batch, "return_logprob", False)
             and not getattr(model_worker_batch, "return_output_logprob_only", False)
         )
+
+    def supports_non_fused_spec_prefill_precompile(self) -> bool:
+        """Whether generic startup may warm this algorithm's normal EXTEND path.
+
+        Batch/token/cache bucket selection stays in ``EAGLEWorker``.  An
+        algorithm opts in only when ``forward_batch_speculative_generation``
+        can safely execute its non-fused prefill path using the standard dummy
+        batch.  This is deliberately separate from whether fused prefill or
+        overlap is supported.
+        """
+        return False
+
+    @staticmethod
+    def wait_for_spec_prefill_precompile(result) -> None:
+        """Wait for small output leaves so startup compilation really completes."""
+        leaves = [getattr(result, "next_token_ids", None)]
+        draft_input = getattr(result, "next_draft_input", None)
+        if draft_input is not None:
+            leaves.append(getattr(draft_input, "topk_index", None))
+        for leaf in leaves:
+            if hasattr(leaf, "block_until_ready"):
+                leaf.block_until_ready()
 
     def _get_cur_allocate_lens(self, model_worker_batch: ModelWorkerBatch):
         allocate_lens = getattr(model_worker_batch.spec_info_padded, "allocate_lens", None)
@@ -364,7 +413,7 @@ class BaseSpecWorker:
 
     def verify(self, model_worker_batch: ModelWorkerBatch, cur_allocate_lens: jax.Array):
         from sgl_jax.srt.managers.scheduler import GenerationBatchResult
-        from sgl_jax.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
+        from sgl_jax.srt.speculative.eagle_info import EagleVerifyInput
 
         spec_info: EagleVerifyInput = model_worker_batch.spec_info_padded
         spec_info.allocate_lens = cur_allocate_lens
@@ -372,7 +421,6 @@ class BaseSpecWorker:
         forward_metadata = self.target_worker.model_runner.attn_backend.get_eagle_forward_metadata(
             model_worker_batch
         )
-
         logits_output, _, cache_miss_count = self.target_worker.forward_batch_generation(
             model_worker_batch, skip_sample=True, forward_metadata=forward_metadata
         )
@@ -422,11 +470,14 @@ class BaseSpecWorker:
             # scheduler-visible length must advance from the original length by the
             # accepted tokens, so add that slot back when publishing new_seq_lens.
             new_seq_lens = model_worker_batch.seq_lens + accept_length + 1
-        next_draft_input = EagleDraftInput(
+        next_draft_input = self.draft_worker.build_next_draft_input_after_verify(
             verified_id=verified_id,
+            hidden_states=logits_output.hidden_states,
             new_seq_lens=new_seq_lens,
             allocate_lens=cur_allocate_lens,
-            hidden_states=logits_output.hidden_states,
+            accept_lens=accept_length,
+            accept_index=accept_index,
+            model_worker_batch=model_worker_batch,
         )
 
         model_worker_batch.spec_info_padded = next_draft_input

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -28,13 +28,23 @@ from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
 from sgl_jax.srt.utils.jax_utils import device_array
 
 
-class EagleDraftWorker(BaseDraftWorker):
-    """EAGLE draft model worker.
+class EagleDraftWorkerBase(BaseDraftWorker):
+    """Shared EAGLE-shaped draft-worker mechanics.
 
     Holds a ``ModelWorker`` (the draft model runner) via composition and
     implements draft-specific logic: multi-step decode, tree building,
     prefill extend, and decode extend.
+
+    This named base keeps reusable proposal machinery separate from the
+    ordinary concrete EAGLE worker. Frozen-KV can reuse these mechanics while
+    owning its target-KV setup and future seed handoff independently.
     """
+
+    draft_input_cls = EagleDraftInput
+
+    def new_draft_input(self, **kwargs) -> EagleDraftInput:
+        """Construct this worker's persistent next-round speculative state."""
+        return self.draft_input_cls(**kwargs)
 
     def __init__(self, server_args, target_worker: ModelWorker):
         self.server_args = server_args
@@ -217,7 +227,7 @@ class EagleDraftWorker(BaseDraftWorker):
     ) -> None:
         sel = np.asarray(model_worker_batch.logits_indices_selector)
         verified_id_np = np.asarray(jax.device_get(next_token_ids))[sel]
-        model_worker_batch.spec_info_padded = EagleDraftInput(
+        model_worker_batch.spec_info_padded = self.new_draft_input(
             hidden_states=hidden_states,
             verified_id=verified_id_np,
             num_tokens_per_batch=np.asarray(1, dtype=jnp.int32),
@@ -270,7 +280,7 @@ class EagleDraftWorker(BaseDraftWorker):
     ) -> None:
         if batch_output.next_draft_input.verified_id.shape[0] <= 0:
             return
-        draft_input = EagleDraftInput(
+        draft_input = self.new_draft_input(
             hidden_states=batch_output.logits_output.hidden_states,
             allocate_lens=batch_output.next_draft_input.allocate_lens,
         )
@@ -279,9 +289,11 @@ class EagleDraftWorker(BaseDraftWorker):
             self.draft_model_runner,
             batch_output,
             self.speculative_num_draft_tokens,
+            prepare_batch_for_forward=self.prepare_draft_extend_batch,
         )
 
         forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
+        forward_batch.spec_info = self.model_forward_spec_info(forward_batch.spec_info)
         if forward_batch.input_ids.shape[0] <= 0:
             return
         draft_logits_output, _, _ = self.draft_model_runner.forward(
@@ -319,6 +331,26 @@ class EagleDraftWorker(BaseDraftWorker):
             : model_worker_batch.real_bs
         ]
         batch_output.accept_lens = accept_host
+
+    def prepare_draft_extend_batch(
+        self, model_worker_batch: ModelWorkerBatch, step_plus_1: int
+    ) -> None:
+        """Optional pre-forward DRAFT_EXTEND normalization hook.
+
+        Generic EAGLE keeps its existing real-size behavior.  Frozen-KV
+        overrides this hook because its non-overlap merge intentionally lets
+        the live request count vary within a compiled batch bucket.
+        """
+        del model_worker_batch, step_plus_1
+
+    def model_forward_spec_info(self, spec_info: EagleDraftInput) -> EagleDraftInput:
+        """Return the speculative state that is an actual model input.
+
+        Generic EAGLE passes its persistent state through unchanged.  Frozen-KV
+        overrides this to keep scheduler-only KV allocation bookkeeping out of
+        the JAX executable's input pytree.
+        """
+        return spec_info
 
     # -- Internal draft helpers --
 
@@ -604,8 +636,19 @@ class EagleDraftWorker(BaseDraftWorker):
         return select_bs_index
 
 
+class EagleDraftWorker(EagleDraftWorkerBase):
+    """Concrete ordinary EAGLE draft worker.
+
+    Existing EAGLE and multi-layer callers keep this public class name. The
+    implementation is inherited from ``EagleDraftWorkerBase`` so Frozen-KV can
+    reuse common proposal mechanics without subclassing this concrete worker.
+    """
+
+    pass
+
+
 # ---------------------------------------------------------------------------
-# Module-level JIT helpers (used exclusively by EagleDraftWorker)
+# Module-level JIT helpers (used by EAGLE-shaped draft workers)
 # ---------------------------------------------------------------------------
 
 

--- a/python/sgl_jax/srt/speculative/eagle_info.py
+++ b/python/sgl_jax/srt/speculative/eagle_info.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -221,6 +222,7 @@ class EagleDraftInput:
         speculative_num_draft_tokens: int,
         *,
         use_device_metadata: bool = False,
+        prepare_batch_for_forward: Callable[[ModelWorkerBatch, int], None] | None = None,
     ):
         legacy_non_overlap = (
             model_worker_batch.spec_algorithm is not None
@@ -260,6 +262,8 @@ class EagleDraftInput:
         ) or model_worker_batch.spec_info_padded.accept_length is None:
             model_worker_batch.spec_info_padded.accept_length = batch_output.accept_lens
         model_worker_batch.input_ids = batch_output.next_draft_input.verified_id
+        if prepare_batch_for_forward is not None:
+            prepare_batch_for_forward(model_worker_batch, step_plus_1)
         if use_device_metadata:
             forward_metadata = draft_model_runner.attn_backend.get_eagle_base_metadata(
                 model_worker_batch
@@ -620,22 +624,18 @@ class EagleVerifyInput:
         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
         model_worker_batch.extend_seq_lens = self.draft_token
 
-    def sample(
+    def sample_device(
         self,
         model_worker_batch: ModelWorkerBatch,
         logits_output: LogitsProcessorOutput,
         rng: nnx.Rngs,
         mesh: Mesh,
-    ) -> jax.Array:
-        """
-        Verify and find accepted tokens based on logits output and batch
-        (which contains spec decoding information).
+    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+        """Return acceptance tensors without a host transfer.
 
-        WARNING: This API in-place modifies the states of logits_output
-
-        This API updates values inside logits_output based on the accepted
-        tokens. I.e., logits_output.next_token_logits only contains
-        accepted token logits.
+        The generic ``sample`` wrapper below preserves the scheduler's
+        host-facing API; dedicated workers can retain the accepted row on
+        device to construct their next-round seed state.
         """
         sampling_info = model_worker_batch.sampling_info
         bs = self.retrive_index.shape[0]
@@ -740,14 +740,32 @@ class EagleVerifyInput:
                 rng=simulation_rng,
             )
 
-        for arr in (predict, accept_index, accept_length):
+        accept_index = accept_index.reshape(-1)
+        safe_accept_index = jnp.clip(accept_index, 0, predict.shape[0] - 1)
+        verified_id = jnp.where(
+            accept_index >= 0,
+            jnp.take(predict, safe_accept_index, axis=0),
+            jnp.zeros_like(accept_index, dtype=predict.dtype),
+        )
+        return predict, verified_id, accept_length, accept_index
+
+    def sample(
+        self,
+        model_worker_batch: ModelWorkerBatch,
+        logits_output: LogitsProcessorOutput,
+        rng: nnx.Rngs,
+        mesh: Mesh,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Return acceptance in the generic scheduler's host representation."""
+        predict, verified_id, accept_length, accept_index = self.sample_device(
+            model_worker_batch, logits_output, rng, mesh
+        )
+        for arr in (predict, verified_id, accept_index, accept_length):
             if hasattr(arr, "copy_to_host_async"):
                 arr.copy_to_host_async()
-        predict = np.asarray(predict)
-        accept_index = np.asarray(accept_index)
-        accept_length = np.asarray(accept_length)
-
-        accept_index = accept_index.flatten()
-        verified_id = np.zeros_like(accept_index, dtype=predict.dtype)
-        verified_id[accept_index != -1] = predict[accept_index[accept_index != -1]]
-        return predict, verified_id, accept_length, accept_index
+        return (
+            np.asarray(predict),
+            np.asarray(verified_id),
+            np.asarray(accept_length),
+            np.asarray(accept_index).reshape(-1),
+        )

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -81,16 +81,30 @@ class EAGLEWorker(BaseSpecWorker):
                     dp_size=dp_size,
                     per_dp_bs_size=per_dp_bs,
                 )
-                if not self._can_use_fused_spec_prefill(model_worker_batch):
+                use_fused_prefill = self._can_use_fused_spec_prefill(model_worker_batch)
+                use_non_fused_prefill = (
+                    not use_fused_prefill and self.supports_non_fused_spec_prefill_precompile()
+                )
+                if not use_fused_prefill and not use_non_fused_prefill:
                     logger.warning(
-                        "[SPEC_EXTEND] skip fused precompile because fused spec prefill is disabled"
+                        "[SPEC_EXTEND] skip precompile because neither fused prefill nor "
+                        "the non-fused prefill capability is available"
                     )
                     continue
-                if self.spec_relay_buffers is not None:
+                if use_fused_prefill and self.spec_relay_buffers is not None:
                     self.forward_batch_speculative_prefill_overlap(model_worker_batch)
                     jax.block_until_ready(self.spec_relay_buffers)
                 else:
-                    self.forward_batch_speculative_generation(model_worker_batch)
+                    result = self.forward_batch_speculative_generation(model_worker_batch)
+                    if use_non_fused_prefill:
+                        self.wait_for_spec_prefill_precompile(result)
+                        logger.info(
+                            "[SPEC_EXTEND] compiled path=non_fused padded_bs=%d "
+                            "padded_tokens=%d cache_loc_size=%d",
+                            bs,
+                            num_tokens,
+                            self.precompile_cache_loc_paddings[-1],
+                        )
         end_time = time.perf_counter()
         logger.info("[SPEC_EXTEND] Precompile finished in %.0f secs", end_time - start_time)
 
@@ -163,11 +177,22 @@ class EAGLEWorker(BaseSpecWorker):
                 else:
                     topk_shape = (bs, num_steps, self.topk) if is_multi_layer else (bs, self.topk)
                 data_sharding = NamedSharding(self.mesh, P("data"))
-                spec_info = EagleDraftInput(
+                spec_info = self.draft_worker.new_draft_input(
                     topk_p=jax.device_put(np.ones(topk_shape, dtype=np.float32), data_sharding),
                     topk_index=jax.device_put(np.ones(topk_shape, dtype=np.int32), data_sharding),
+                    # TARGET's hidden size, not the draft's. spec_info.hidden_states
+                    # always carries TARGET hidden states -- either captured from
+                    # the target's verify forward, or projected back into target
+                    # space by the draft (gemma4_mtp's post_projection exists for
+                    # exactly that). base_worker.py's relay buffers already size
+                    # this from the target; precompile disagreed.
+                    # For EAGLE/NEXTN the two models share a hidden size, so this
+                    # is a no-op there. FROZEN_KV_MTP is the first algorithm where
+                    # they differ (draft 1024 vs target 5376), and the mismatch
+                    # showed up as a dot_general contracting-dim error in
+                    # pre_projection: 5376+1024=6400 fed to a 2*5376=10752 input.
                     hidden_states=np.ones(
-                        (bs, self.draft_worker.model_config.hidden_size),
+                        (bs, self.target_worker.model_config.hidden_size),
                         dtype=(
                             jnp.bfloat16 if self.server_args.dtype == "bfloat16" else np.float32
                         ),
@@ -191,7 +216,7 @@ class EAGLEWorker(BaseSpecWorker):
                     jax.block_until_ready(self.spec_relay_buffers)
 
                     model_worker_batch = _make_decode_batch()
-                    spec_info = EagleDraftInput(
+                    spec_info = self.draft_worker.new_draft_input(
                         future_indices=np.asarray(
                             model_worker_batch.req_pool_indices, dtype=np.int32
                         ),

--- a/python/sgl_jax/srt/speculative/frozen_kv_mtp_seed.py
+++ b/python/sgl_jax/srt/speculative/frozen_kv_mtp_seed.py
@@ -1,0 +1,316 @@
+"""Device-resident seed state for the Frozen-KV MTP draft loop.
+
+Gemma 4's assistant does not own a draft KV cache.  After target verification,
+the next assistant proposal therefore starts from the target hidden state at
+the last accepted row and its corresponding token.  This module describes
+that hand-off without depending on EAGLE's draft-extension state or on the
+serving scheduler.
+
+The scheduler still owns request admission, slot padding, and batch buckets.
+``select_after_verify`` only adapts the scheduler's padded verification layout
+to one seed row per live request.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+from jax.tree_util import register_pytree_node_class
+
+
+@partial(jax.jit, static_argnames=("draft_token_num",))
+def verify_frozen_kv_mtp_chain_greedy(
+    draft_tokens: jax.Array,
+    target_logits: jax.Array,
+    *,
+    draft_token_num: int,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Greedily verify a top-k-one Frozen-KV MTP chain on its native layout.
+
+    Unlike generic EAGLE tree verification, Gemma 4 Frozen-KV MTP is launched
+    with one candidate per depth, so its verify graph is a linear chain.  That
+    means acceptance is local to each request:
+
+    ``target_argmax[i] == draft_tokens[i + 1]``.
+
+    Keeping this expression in JAX lets the target logits retain their model
+    output sharding.  In particular, callers must not first turn logits and
+    hidden states into ``P()``-replicated arrays solely to enter the generic
+    tree Pallas kernel.  The returned token layout is the scheduler's standard
+    ``[slot0 candidates..., slot1 candidates...]`` layout, and every accepted
+    length includes the bonus target token, matching ``EagleVerifyInput``.
+
+    This deliberately supports only the linear ``topk == 1`` contract.  A
+    branching EAGLE tree has different traversal semantics and continues to
+    use the generic verifier.
+    """
+    draft_token_num = int(draft_token_num)
+    if draft_token_num <= 0:
+        raise ValueError("draft_token_num must be positive")
+    if draft_tokens.ndim != 1:
+        raise ValueError("Frozen-KV draft_tokens must be rank 1")
+    if target_logits.ndim != 2:
+        raise ValueError("Frozen-KV target_logits must have shape [rows, vocab]")
+    if draft_tokens.shape[0] != target_logits.shape[0]:
+        raise ValueError(
+            "Frozen-KV draft token and target-logit rows must match: "
+            f"{draft_tokens.shape[0]} vs {target_logits.shape[0]}."
+        )
+    if draft_tokens.shape[0] % draft_token_num:
+        raise ValueError(
+            "Frozen-KV target rows must be divisible by draft_token_num: "
+            f"rows={draft_tokens.shape[0]}, draft_token_num={draft_token_num}."
+        )
+
+    candidates = draft_tokens.reshape((-1, draft_token_num)).astype(jnp.int32)
+    # ``argmax`` is lowered against the target program's existing layout.  On
+    # TP this may contain the necessary vocab reduction, but it must not force
+    # the *whole* [rows, vocab] tensor through a host-orchestrated P() replica.
+    target_predict = jnp.argmax(target_logits, axis=-1).astype(jnp.int32).reshape(candidates.shape)
+    # The target's flat candidate rows are commonly sharded over ``data``.
+    # After a [rows] -> [request, depth] reshape, that layout can place the
+    # *depth* axis on the mesh (e.g. the c1 precompile shape is [1, 4@data]).
+    # Prefix acceptance reduces over depth, so make depth local before cumprod.
+    # This transfers only tiny token-ID vectors, never [rows, vocab] logits or
+    # [rows, hidden] target states.  For c1/c2 the request dimension cannot be
+    # partitioned over TP, so the small vectors are replicated instead.
+    sharding = getattr(jax.typeof(target_predict).sharding, "mesh", None)
+    if sharding is not None and not getattr(sharding, "empty", False):
+        from jax.sharding import NamedSharding
+        from jax.sharding import PartitionSpec as P
+
+        data_size = int(sharding.shape.get("data", 1))
+        request_spec = (
+            P("data", None)
+            if "data" in sharding.shape and candidates.shape[0] % data_size == 0
+            else P()
+        )
+        request_sharding = NamedSharding(sharding, request_spec)
+        candidates = jax.sharding.reshard(candidates, request_sharding)
+        target_predict = jax.sharding.reshard(target_predict, request_sharding)
+    matches = target_predict[:, :-1] == candidates[:, 1:]
+    accepted_draft = jnp.sum(jnp.cumprod(matches.astype(jnp.int32), axis=1), axis=1)
+    accept_lengths = (accepted_draft + 1).astype(jnp.int32)
+
+    rows = jnp.arange(draft_token_num, dtype=jnp.int32)[None, :]
+    bases = jnp.arange(candidates.shape[0], dtype=jnp.int32)[:, None] * draft_token_num
+    accept_index = jnp.where(rows < accept_lengths[:, None], bases + rows, -1)
+    return target_predict.reshape(-1), accept_lengths, accept_index.reshape(-1)
+
+
+@register_pytree_node_class
+@dataclass(frozen=True)
+class FrozenKvMtpSeedState:
+    """One next-draft seed per live request.
+
+    All fields are request-aligned.  ``bonus_token`` and ``target_hidden`` are
+    device values; the length and identity arrays are carried alongside them
+    so merge/filter operations cannot accidentally detach page metadata from
+    the corresponding seed.
+    """
+
+    bonus_token: jax.Array
+    target_hidden: jax.Array
+    committed_lens: jax.Array
+    allocate_lens: jax.Array
+    request_indices: jax.Array
+    valid_mask: jax.Array
+
+    def __post_init__(self):
+        """Reject state whose request-aligned fields have drifted apart.
+
+        The verify-to-draft handoff is device-resident, so values cannot be
+        checked eagerly.  Static leading dimensions are nevertheless known
+        during tracing and are enough to catch the dangerous case where a
+        token/hidden seed is paired with another request's length or page
+        metadata.
+        """
+        fields = (
+            ("target_hidden", self.target_hidden),
+            ("committed_lens", self.committed_lens),
+            ("allocate_lens", self.allocate_lens),
+            ("request_indices", self.request_indices),
+            ("valid_mask", self.valid_mask),
+        )
+        if self.bonus_token.ndim != 1:
+            raise ValueError("Frozen-KV bonus_token must be rank 1")
+        if self.target_hidden.ndim < 2:
+            raise ValueError("Frozen-KV target_hidden must have a batch dimension")
+        batch_size = self.bonus_token.shape[0]
+        for name, value in fields:
+            if value.ndim == 0 or value.shape[0] != batch_size:
+                raise ValueError(
+                    f"Frozen-KV seed field {name!r} has {value.shape}; "
+                    f"expected leading dimension {batch_size}"
+                )
+
+    def tree_flatten(self):
+        return (
+            (
+                self.bonus_token,
+                self.target_hidden,
+                self.committed_lens,
+                self.allocate_lens,
+                self.request_indices,
+                self.valid_mask,
+            ),
+            None,
+        )
+
+    @classmethod
+    def tree_unflatten(cls, _aux_data, children):
+        return cls(*children)
+
+    @property
+    def batch_size(self) -> int:
+        return self.bonus_token.shape[0]
+
+    def merge(self, other: FrozenKvMtpSeedState) -> FrozenKvMtpSeedState:
+        """Append another prefilled/running state in scheduler order."""
+        if not isinstance(other, FrozenKvMtpSeedState):
+            raise TypeError(f"expected FrozenKvMtpSeedState, got {type(other).__name__}")
+        if self.target_hidden.ndim != other.target_hidden.ndim:
+            raise ValueError("Frozen-KV seed hidden-state ranks must match")
+        if self.target_hidden.shape[1:] != other.target_hidden.shape[1:]:
+            raise ValueError("Frozen-KV seed hidden-state shapes must match")
+        return FrozenKvMtpSeedState(
+            bonus_token=jnp.concatenate((self.bonus_token, other.bonus_token), axis=0),
+            target_hidden=jnp.concatenate((self.target_hidden, other.target_hidden), axis=0),
+            committed_lens=jnp.concatenate((self.committed_lens, other.committed_lens), axis=0),
+            allocate_lens=jnp.concatenate((self.allocate_lens, other.allocate_lens), axis=0),
+            request_indices=jnp.concatenate((self.request_indices, other.request_indices), axis=0),
+            valid_mask=jnp.concatenate((self.valid_mask, other.valid_mask), axis=0),
+        )
+
+    def filter(self, indices: jax.Array) -> FrozenKvMtpSeedState:
+        """Keep request rows after completion/retraction/filtering."""
+        indices = jnp.asarray(indices, dtype=jnp.int32)
+        return FrozenKvMtpSeedState(
+            bonus_token=jnp.take(self.bonus_token, indices, axis=0),
+            target_hidden=jnp.take(self.target_hidden, indices, axis=0),
+            committed_lens=jnp.take(self.committed_lens, indices, axis=0),
+            allocate_lens=jnp.take(self.allocate_lens, indices, axis=0),
+            request_indices=jnp.take(self.request_indices, indices, axis=0),
+            valid_mask=jnp.take(self.valid_mask, indices, axis=0),
+        )
+
+    def scatter(self, selector: jax.Array, total_size: int) -> FrozenKvMtpSeedState:
+        """Place compact request seeds into scheduler-padded slots.
+
+        This is metadata transport only; bucket selection remains owned by the
+        scheduler. Invalid padded slots are marked false and never consumed by
+        the Frozen worker.
+        """
+        selector = jnp.asarray(selector, dtype=jnp.int32)
+        total_size = int(total_size)
+        if selector.ndim != 1 or selector.shape[0] != self.batch_size:
+            raise ValueError("Frozen-KV seed selector must match seed batch size")
+        zeros_token = jnp.zeros((total_size,), dtype=self.bonus_token.dtype)
+        zeros_hidden = jnp.zeros(
+            (total_size,) + self.target_hidden.shape[1:], dtype=self.target_hidden.dtype
+        )
+        zeros_int = jnp.zeros((total_size,), dtype=self.committed_lens.dtype)
+        zeros_bool = jnp.zeros((total_size,), dtype=bool)
+        return FrozenKvMtpSeedState(
+            bonus_token=zeros_token.at[selector].set(self.bonus_token),
+            target_hidden=zeros_hidden.at[selector].set(self.target_hidden),
+            committed_lens=zeros_int.at[selector].set(self.committed_lens),
+            allocate_lens=zeros_int.at[selector].set(self.allocate_lens),
+            request_indices=zeros_int.at[selector].set(self.request_indices),
+            valid_mask=zeros_bool.at[selector].set(self.valid_mask),
+        )
+
+
+@partial(jax.jit, static_argnames=("rows_per_request",))
+def select_after_verify(
+    verified_tokens: jax.Array,
+    target_hidden: jax.Array,
+    slot_selector: jax.Array,
+    accept_lengths: jax.Array,
+    committed_lens: jax.Array,
+    allocate_lens: jax.Array,
+    request_indices: jax.Array,
+    *,
+    rows_per_request: int,
+) -> FrozenKvMtpSeedState:
+    """Select one accepted target row per request from padded verify output.
+
+    ``slot_selector`` maps compact live-request order to padded scheduler slots.
+    For a row layout of ``rows_per_request`` candidates per slot, the accepted
+    row is ``slot * rows_per_request + accept_length - 1``.  The operation is
+    pure JAX and can therefore run inside the device-side verify-to-draft
+    hand-off.  Invalid acceptance lengths are represented by ``valid_mask``
+    while indexing a clipped row to keep the compiled program memory-safe.
+    """
+    rows_per_request = int(rows_per_request)
+    if rows_per_request <= 0:
+        raise ValueError("rows_per_request must be positive")
+
+    verified_tokens = jnp.asarray(verified_tokens)
+    target_hidden = jnp.asarray(target_hidden)
+    slot_selector = jnp.asarray(slot_selector, dtype=jnp.int32)
+    accept_lengths = jnp.asarray(accept_lengths, dtype=jnp.int32)
+    committed_lens = jnp.asarray(committed_lens, dtype=jnp.int32)
+    allocate_lens = jnp.asarray(allocate_lens, dtype=jnp.int32)
+    request_indices = jnp.asarray(request_indices, dtype=jnp.int32)
+
+    if verified_tokens.ndim != 1:
+        raise ValueError("Frozen-KV verified_tokens must be rank 1")
+    if target_hidden.ndim < 2 or target_hidden.shape[0] != verified_tokens.shape[0]:
+        raise ValueError("Frozen-KV verify tokens and hidden rows must be aligned")
+    request_count = slot_selector.shape[0]
+    for name, value in (
+        ("accept_lengths", accept_lengths),
+        ("committed_lens", committed_lens),
+        ("allocate_lens", allocate_lens),
+        ("request_indices", request_indices),
+    ):
+        if value.ndim != 1 or value.shape[0] != request_count:
+            raise ValueError(
+                f"Frozen-KV {name} must have one entry per selected request "
+                f"(got {value.shape}, expected ({request_count},))"
+            )
+    if target_hidden.shape[0] < rows_per_request:
+        raise ValueError("Frozen-KV verify rows are smaller than one request bucket")
+
+    row_offset = accept_lengths - 1
+    valid_mask = (row_offset >= 0) & (row_offset < rows_per_request)
+    safe_offset = jnp.clip(row_offset, 0, rows_per_request - 1)
+    flat_rows = slot_selector * rows_per_request + safe_offset
+
+    def gather_selected_rows(value: jax.Array) -> jax.Array:
+        """Gather compact seed rows while retaining a legal mesh layout.
+
+        JAX cannot infer whether this cross-row gather should remain
+        partitioned or become replicated.  The answer depends on the compact
+        request bucket, not on the large padded source.  State it explicitly
+        for both the selected token and its corresponding hidden row.
+        """
+        value_sharding = jax.typeof(value).sharding
+        mesh = getattr(value_sharding, "mesh", None)
+        if mesh is None or getattr(mesh, "empty", False):
+            return jnp.take(value, flat_rows, axis=0)
+        from jax.sharding import NamedSharding
+        from jax.sharding import PartitionSpec as P
+
+        data_size = int(mesh.shape.get("data", 1))
+        # A c1/c2 request bucket cannot be partitioned across TP.  Replicate
+        # its selected *seed rows* (not the full candidate hidden tensor).
+        # Larger buckets preserve request-row data sharding for the relay.
+        if "data" in mesh.shape and request_count % data_size == 0:
+            selected_spec = P("data", *([None] * (value.ndim - 1)))
+        else:
+            selected_spec = P()
+        return value.at[flat_rows].get(out_sharding=NamedSharding(mesh, selected_spec))
+
+    return FrozenKvMtpSeedState(
+        bonus_token=gather_selected_rows(verified_tokens),
+        target_hidden=gather_selected_rows(target_hidden),
+        committed_lens=committed_lens,
+        allocate_lens=allocate_lens,
+        request_indices=request_indices,
+        valid_mask=valid_mask,
+    )

--- a/python/sgl_jax/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sgl_jax/srt/speculative/frozen_kv_mtp_worker.py
@@ -484,6 +484,7 @@ class FrozenKvMtpDraftWorker(EagleDraftWorkerBase):
 
         data_sharding = NamedSharding(self.mesh, P("data"))
         hidden_sharding = NamedSharding(self.mesh, P("data", None))
+        replicated_sharding = NamedSharding(self.mesh, P())
 
         @partial(
             jax.jit,
@@ -502,11 +503,16 @@ class FrozenKvMtpDraftWorker(EagleDraftWorkerBase):
             dp_size: int,
         ):
             future_indices = jax.sharding.reshard(future_indices, data_sharding)
-            selector = jax.sharding.reshard(selector, data_sharding)
-            verified_id = jax.sharding.reshard(verified_id, data_sharding)
-            draft_token_ids = jax.sharding.reshard(draft_token_ids, data_sharding)
-            hidden_states = jax.sharding.reshard(hidden_states, hidden_sharding)
-            is_target_seed = jax.sharding.reshard(is_target_seed, data_sharding)
+            # These are compact live-request rows, not the scheduler's padded
+            # DP-attention bucket. A c1 prefill is valid when dp_size > 1, and
+            # even a divisible live-row count need not be balanced by rank.
+            # Replicate the compact values, then use the scheduler-provided
+            # selector to scatter them into their real DP-padded slots below.
+            selector = jax.sharding.reshard(selector, replicated_sharding)
+            verified_id = jax.sharding.reshard(verified_id, replicated_sharding)
+            draft_token_ids = jax.sharding.reshard(draft_token_ids, replicated_sharding)
+            hidden_states = jax.sharding.reshard(hidden_states, replicated_sharding)
+            is_target_seed = jax.sharding.reshard(is_target_seed, replicated_sharding)
 
             total_bs = future_indices.shape[0]
 
@@ -652,42 +658,52 @@ class FrozenKvMtpDraftWorker(EagleDraftWorkerBase):
         seq_lens = jnp.asarray(model_worker_batch.seq_lens, dtype=jnp.int32).reshape(-1)
         allocate = jnp.asarray(allocate_lens, dtype=jnp.int32).reshape(-1)
         req_indices = jnp.asarray(model_worker_batch.req_pool_indices, dtype=jnp.int32).reshape(-1)
-        if min(int(seq_lens.shape[0]), int(allocate.shape[0]), int(req_indices.shape[0])) <= int(
-            selector_host.max(initial=-1)
-        ):
-            raise ValueError("Frozen-KV device verify metadata is smaller than its live selector.")
 
-        def gather_request_rows(value):
-            """Gather selected scheduler rows without losing native sharding.
+        def compact_request_rows(value, field):
+            """Normalize compact or padded scheduler metadata to live rows.
 
-            The padded verifier can be TP-sharded by candidate rows, while the
-            compact live request count may be c1/c2 and therefore cannot use a
-            data-partitioned result.  Annotate only this small metadata gather;
-            never force its source into a replicated layout first.
+            ``_get_cur_allocate_lens`` already compacts ``allocate_lens`` on
+            the host, whereas seq lengths, request-pool indices, and verifier
+            acceptance retain the DP-padded scheduler layout.  Treat both
+            representations as an explicit contract instead of indexing a
+            compact vector with global padded slots.
             """
+            if int(value.shape[0]) == int(selector.shape[0]):
+                return value
+            max_slot = int(selector_host.max(initial=-1))
+            if int(value.shape[0]) <= max_slot:
+                raise ValueError(
+                    "Frozen-KV device verify metadata does not match its live selector: "
+                    f"field={field}, rows={value.shape[0]}, "
+                    f"requests={selector.shape[0]}, selector={selector_host.tolist()}"
+                )
+
+            # The padded verifier can be TP-sharded by candidate rows, while
+            # the compact live request count may be c1/c2 and therefore cannot
+            # use a data-partitioned result. Annotate only this small metadata
+            # gather; never force its source into a replicated layout first.
             value_sharding = jax.typeof(value).sharding
             if isinstance(value_sharding, NamedSharding):
-                mesh = value_sharding.mesh
-                # Generic startup precompile can use a TP-only mesh, whereas
-                # serving meshes also have ``data``.  Only partition compact
-                # scheduler metadata when that axis actually exists.
-                data_size = int(mesh.shape.get("data", 1))
-                if "data" in mesh.shape and selector.shape[0] % data_size == 0:
-                    output_spec = P("data", *([None] * (value.ndim - 1)))
-                else:
-                    output_spec = P()
-                return value.at[selector].get(out_sharding=NamedSharding(mesh, output_spec))
+                # The compact result is ordered by live request, not by equal
+                # DP-attention partitions. Even a divisible row count can
+                # represent an unbalanced batch, so keep this small metadata
+                # gather replicated. The relay publisher scatters these rows
+                # into the scheduler's explicitly selected padded slots.
+                output_spec = P(*([None] * value.ndim))
+                return value.at[selector].get(
+                    out_sharding=NamedSharding(value_sharding.mesh, output_spec)
+                )
             return jnp.take(value, selector, axis=0)
 
-        accept_live = gather_request_rows(accept_padded)
+        accept_live = compact_request_rows(accept_padded, "accept_lengths")
         seed_state = select_after_verify(
             jnp.asarray(verified_tokens, dtype=jnp.int32),
             jnp.asarray(target_hidden),
             selector,
             accept_live,
-            gather_request_rows(seq_lens) + accept_live + 1,
-            gather_request_rows(allocate),
-            gather_request_rows(req_indices),
+            compact_request_rows(seq_lens, "seq_lens") + accept_live + 1,
+            compact_request_rows(allocate, "allocate_lens"),
+            compact_request_rows(req_indices, "req_pool_indices"),
             rows_per_request=rows_per_request,
         )
         self._publish_seed_relay(

--- a/python/sgl_jax/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sgl_jax/srt/speculative/frozen_kv_mtp_worker.py
@@ -1,0 +1,1417 @@
+"""Frozen-KV MTP speculative worker (Gemma4 assistant drafts).
+
+The draft model's attention is Q-only: it reads K/V from the *target* verifier's
+KV cache instead of owning one. The worker has its own Frozen-KV state and
+target-cache setup, while reusing only the common EAGLE-shaped proposal
+mechanics through ``EagleDraftWorkerBase``.
+
+Mirrors upstream sgl-project/sglang, where ``SpeculativeAlgorithm.create_worker``
+routes FROZEN_KV_MTP to a dedicated ``FrozenKVMTPWorkerV2`` checked before the
+EAGLE branch, rather than folding it into the multi-layer (per-MTP-head) worker.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+from jax.tree_util import register_pytree_node_class
+
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata
+from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
+from sgl_jax.srt.managers.tp_worker import ModelWorker
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+from sgl_jax.srt.speculative.base_worker import replicate_to_mesh
+from sgl_jax.srt.speculative.eagle_draft_worker import (
+    EagleDraftWorkerBase,
+    topk_probs_from_logits,
+)
+from sgl_jax.srt.speculative.eagle_info import EagleDraftInput
+from sgl_jax.srt.speculative.eagle_worker import EAGLEWorker
+from sgl_jax.srt.speculative.frozen_kv_mtp_seed import (
+    FrozenKvMtpSeedState,
+    select_after_verify,
+    verify_frozen_kv_mtp_chain_greedy,
+)
+from sgl_jax.srt.speculative.relay_buffer import (
+    SpecSeedRelayBuffers,
+    create_spec_seed_relay_buffers,
+    gather_spec_seed_relay_buffers,
+    update_spec_seed_relay_buffers,
+)
+from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+from sgl_jax.srt.utils.jax_utils import device_array
+
+logger = logging.getLogger(__name__)
+
+
+@register_pytree_node_class
+@dataclass
+class FrozenKvMtpDraftInput(EagleDraftInput):
+    """Checked per-request state for Frozen-KV non-overlap batch merging.
+
+    Target KV pages remain owned by each request's token-pool row.  This state
+    holds the matching token/hidden/length handles, which must stay in the same
+    order whenever a completed prefill joins an active decode batch.
+    """
+
+    _REQUIRED_FIELDS = ("topk_p", "topk_index", "hidden_states", "verified_id", "allocate_lens")
+    _OPTIONAL_PER_REQUEST_FIELDS = (
+        "accept_length",
+        "accept_length_cpu",
+        "new_seq_lens",
+    )
+    # The seed is deliberately optional while prefill and legacy compatibility
+    # states are being migrated. Once present, it is the sole source for the
+    # next Frozen proposal's token/target-hidden pair.
+    seed_state: FrozenKvMtpSeedState | None = None
+    # Opaque relay descriptors deliberately keep model tensors on device.  This
+    # host-side, request-aligned bit is the only Frozen-specific information
+    # needed before the next static scheduler bucket is selected: rows marked
+    # true need an assistant seed forward; false rows are fresh prefills and
+    # already contain ordinary one-token proposal state in the relay buffer.
+    relay_seed_mask: np.ndarray | None = None
+    # Upstream EAGLE no longer carries this legacy overlap relay handle. Frozen
+    # keeps the explicit sentinel so its non-overlap state validation can reject
+    # an accidental mixed lifecycle before a batch is merged or filtered.
+    pending_draft_extend_result: object | None = None
+
+    def tree_flatten(self):
+        """Keep Frozen's scheduler-visible length state across JAX pytrees.
+
+        ``EagleDraftInput`` omits allocation and logical sequence lengths
+        because generic EAGLE recreates them around its legacy handoff. Frozen
+        non-overlap merging consumes those values directly, so dropping them
+        during a scatter/copy would break the request-to-page association.
+        """
+        children, aux_data = super().tree_flatten()
+        return (
+            children
+            + (
+                self.allocate_lens,
+                self.new_seq_lens,
+                self.seed_state,
+                self.relay_seed_mask,
+            ),
+            aux_data,
+        )
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        # ``tree_flatten`` appends four Frozen-only children after the base
+        # EAGLE state.  Pass exactly the base children back to its unflattener.
+        obj = EagleDraftInput.tree_unflatten.__func__(cls, aux_data, children[:-4])
+        obj.allocate_lens = children[-4]
+        obj.new_seq_lens = children[-3]
+        obj.seed_state = children[-2]
+        obj.relay_seed_mask = children[-1]
+        obj.pending_draft_extend_result = None
+        return obj
+
+    def _batch_size(self) -> int:
+        if self.future_indices is not None:
+            return int(np.asarray(self.future_indices).shape[0])
+        if self.verified_id is None:
+            raise ValueError("Frozen-KV MTP state is missing verified_id.")
+        return int(np.asarray(self.verified_id).shape[0])
+
+    def _validate_non_overlap_state(self) -> None:
+        """Ensure every state array describes the same request/KV allocation."""
+        if self.pending_draft_extend_result is not None:
+            raise ValueError(
+                "Frozen-KV MTP non-overlap state must not carry a pending draft-extend result."
+            )
+
+        batch_size = self._batch_size()
+        if self.future_indices is not None:
+            # A relay descriptor deliberately carries only scheduler-owned
+            # request metadata. The variable-sized model tensors live in a
+            # request-indexed device buffer and are restored only after the
+            # scheduler has selected the next static bucket. This is the same
+            # generic future_indices lifecycle used by existing relay users.
+            unexpected = [
+                field
+                for field in (
+                    "topk_p",
+                    "topk_index",
+                    "hidden_states",
+                    "verified_id",
+                    "accept_length",
+                    "seed_state",
+                )
+                if getattr(self, field, None) is not None
+            ]
+            if unexpected:
+                raise ValueError(
+                    "Frozen-KV MTP relay state must not retain model tensors: " f"{unexpected}."
+                )
+            for field in (
+                "allocate_lens",
+                "new_seq_lens",
+                "accept_length_cpu",
+                "relay_seed_mask",
+            ):
+                value = getattr(self, field, None)
+                if value is not None and np.asarray(value).shape[0] != batch_size:
+                    raise ValueError(
+                        f"Frozen-KV MTP relay field {field!r} has "
+                        f"{np.asarray(value).shape[0]} rows; expected {batch_size}."
+                    )
+            return
+
+        for field in self._REQUIRED_FIELDS:
+            value = getattr(self, field)
+            if value is None:
+                raise ValueError(f"Frozen-KV MTP state is missing required field {field!r}.")
+            if np.asarray(value).shape[0] != batch_size:
+                raise ValueError(
+                    f"Frozen-KV MTP field {field!r} has {np.asarray(value).shape[0]} rows; "
+                    f"expected {batch_size}."
+                )
+        for field in self._OPTIONAL_PER_REQUEST_FIELDS:
+            value = getattr(self, field)
+            if value is not None and np.asarray(value).shape[0] != batch_size:
+                raise ValueError(
+                    f"Frozen-KV MTP optional field {field!r} has "
+                    f"{np.asarray(value).shape[0]} rows; expected {batch_size}."
+                )
+
+        allocate_lens = np.asarray(self.allocate_lens)
+        if np.any(allocate_lens < 0):
+            raise ValueError("Frozen-KV MTP allocation lengths must be non-negative.")
+        if self.new_seq_lens is not None and np.any(allocate_lens < np.asarray(self.new_seq_lens)):
+            raise ValueError(
+                "Frozen-KV MTP allocation length is shorter than its committed sequence length."
+            )
+        if self.seed_state is not None and self.seed_state.batch_size != batch_size:
+            raise ValueError(
+                "Frozen-KV seed state has a different request count from draft state: "
+                f"seed={self.seed_state.batch_size}, state={batch_size}."
+            )
+
+    @staticmethod
+    def _select(value, indices):
+        return None if value is None else np.asarray(value)[indices]
+
+    def _invalid_seed_state(self) -> FrozenKvMtpSeedState:
+        """Represent prefill-origin rows that have no post-verify seed yet.
+
+        A merged non-overlap batch can contain both an existing speculative
+        request (which has a target token/hidden seed from verification) and a
+        request that has just completed prefill.  The latter starts from its
+        normal draft-input fields, not a synthetic target-verify row.  Carry a
+        shape-compatible, invalid seed entry for it so one batched draft can
+        retain both forms of input.
+        """
+        batch_size = self._batch_size()
+        hidden = jnp.asarray(self.hidden_states)
+        return FrozenKvMtpSeedState(
+            bonus_token=jnp.asarray(self.verified_id, dtype=jnp.int32),
+            target_hidden=hidden,
+            committed_lens=jnp.asarray(
+                (
+                    self.new_seq_lens
+                    if self.new_seq_lens is not None
+                    else np.zeros(batch_size, dtype=np.int32)
+                ),
+                dtype=jnp.int32,
+            ),
+            allocate_lens=jnp.asarray(self.allocate_lens, dtype=jnp.int32),
+            request_indices=jnp.arange(batch_size, dtype=jnp.int32),
+            valid_mask=jnp.zeros((batch_size,), dtype=bool),
+        )
+
+    def filter_batch(self, new_indices: np.ndarray, has_been_filtered: bool = True) -> None:
+        """Keep state rows in exact request-pool order after finish/retract."""
+        if self.future_indices is not None:
+            # Reuse the generic opaque-relay metadata operation. It does not
+            # materialize model state because no model state is present here.
+            if self.relay_seed_mask is not None:
+                src = np.asarray(self.relay_seed_mask)
+                idx = (
+                    slice(0, len(new_indices))
+                    if has_been_filtered and len(new_indices) == len(src)
+                    else np.asarray(new_indices, dtype=np.int32)
+                )
+                self.relay_seed_mask = src[idx]
+            super().filter_batch(new_indices, has_been_filtered)
+            self._validate_non_overlap_state()
+            return
+        self._ensure_host()
+        self._validate_non_overlap_state()
+        new_indices = np.asarray(new_indices, dtype=np.int32)
+        indices = (
+            slice(0, len(new_indices))
+            if has_been_filtered and len(new_indices) == self._batch_size()
+            else new_indices
+        )
+        for field in self._REQUIRED_FIELDS + self._OPTIONAL_PER_REQUEST_FIELDS:
+            setattr(self, field, self._select(getattr(self, field), indices))
+        if self.seed_state is not None:
+            self.seed_state = self.seed_state.filter(jnp.asarray(indices, dtype=jnp.int32))
+        self._validate_non_overlap_state()
+
+    def trim_to_length(self, n: int) -> None:
+        """Trim opaque relay metadata with the same request rows as the base input."""
+        n = int(n)
+        if self.future_indices is not None:
+            super().trim_to_length(n)
+            if self.relay_seed_mask is not None:
+                self.relay_seed_mask = np.asarray(self.relay_seed_mask, dtype=bool)[:n]
+            self._validate_non_overlap_state()
+            return
+
+        old_size = self._batch_size()
+        super().trim_to_length(n)
+        if self.seed_state is not None and n < old_size:
+            self.seed_state = self.seed_state.filter(jnp.arange(n, dtype=jnp.int32))
+        self._validate_non_overlap_state()
+
+    def merge_batch(self, other: EagleDraftInput) -> None:
+        """Append a completed Frozen-KV prefill without reinterpreting pages.
+
+        ``allocate_lens`` stays paired with its request-pool row.  The
+        attention backend derives physical pages from that row and applies the
+        per-request page-compaction rule; this method only concatenates rows.
+        """
+        if not isinstance(other, FrozenKvMtpDraftInput):
+            raise TypeError(
+                "Frozen-KV MTP non-overlap merge requires FrozenKvMtpDraftInput on both "
+                f"sides; got {type(other).__name__}."
+            )
+        if self.future_indices is not None or other.future_indices is not None:
+            # Generic relay descriptors can be concatenated without touching
+            # device-resident model state. Mixing descriptor and non-relay
+            # state is intentionally rejected by the base contract: callers
+            # must publish *both* a running decode and a new prefill before
+            # admitting their merged batch.
+            left_mask, right_mask = self.relay_seed_mask, other.relay_seed_mask
+            if (left_mask is None) != (right_mask is None):
+                raise ValueError(
+                    "Frozen-KV MTP relay merge requires relay_seed_mask on both sides or neither."
+                )
+            super().merge_batch(other)
+            if left_mask is not None:
+                self.relay_seed_mask = np.concatenate(
+                    [np.asarray(left_mask, dtype=bool), np.asarray(right_mask, dtype=bool)]
+                )
+            self._validate_non_overlap_state()
+            return
+        self._ensure_host()
+        other._ensure_host()
+        self._validate_non_overlap_state()
+        other._validate_non_overlap_state()
+        left_seed = self.seed_state or self._invalid_seed_state()
+        right_seed = other.seed_state or other._invalid_seed_state()
+
+        for field in self._REQUIRED_FIELDS:
+            setattr(
+                self,
+                field,
+                np.concatenate(
+                    [np.asarray(getattr(self, field)), np.asarray(getattr(other, field))]
+                ),
+            )
+        for field in self._OPTIONAL_PER_REQUEST_FIELDS:
+            left, right = getattr(self, field), getattr(other, field)
+            if left is None and right is None:
+                continue
+            if left is None or right is None:
+                if field in ("accept_length", "accept_length_cpu"):
+                    # A prefill has no prior verification outcome. This field
+                    # is optional scheduler bookkeeping; a merged batch cannot
+                    # truthfully carry a per-request accept length for every
+                    # row until after its next target verification.
+                    setattr(self, field, None)
+                    continue
+                raise ValueError(
+                    f"Frozen-KV MTP merge requires optional field {field!r} on both sides or neither."
+                )
+            setattr(self, field, np.concatenate([np.asarray(left), np.asarray(right)]))
+        self.seed_state = left_seed.merge(right_seed)
+        self._validate_non_overlap_state()
+
+
+class FrozenKvMtpDraftWorker(EagleDraftWorkerBase):
+    """Dedicated Frozen-KV draft worker whose KV reads are redirected.
+
+    The worker owns the Gemma-specific target-KV setup and the Frozen state
+    contract. It reuses only the EAGLE-shaped proposal mechanics from the
+    abstract ``EagleDraftWorkerBase``; the target worker and scheduler still
+    own shared verification, admission, padding buckets, and merge orchestration.
+    """
+
+    draft_input_cls = FrozenKvMtpDraftInput
+
+    def new_draft_input(self, **kwargs) -> FrozenKvMtpDraftInput:
+        """Construct the persistent Frozen-KV state owned by this worker."""
+        return self.draft_input_cls(**kwargs)
+
+    @property
+    def draft_model_runner(self):
+        return self._worker.get_model_runner()
+
+    @property
+    def mesh(self):
+        return self._worker.mesh
+
+    @property
+    def model_config(self):
+        return self._worker.model_config
+
+    @property
+    def compilation_manager(self):
+        return self._worker.compilation_manager
+
+    @property
+    def max_req_len(self):
+        return self._worker.max_req_len
+
+    def get_max_padded_size(self):
+        return self._worker.get_max_padded_size()
+
+    def __init__(self, server_args, target_worker: ModelWorker):
+        from sgl_jax.srt.layers.kv_share import compute_mtp_kv_share_map
+        from sgl_jax.srt.model_executor.model_runner_kv_cache_mixin import (
+            _build_non_hybrid_memory_pools,
+        )
+
+        self.server_args = server_args
+        self.target_worker_ref = target_worker
+        self.topk = server_args.speculative_eagle_topk
+        self.speculative_num_steps = server_args.speculative_num_steps
+        self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
+        self.page_size = server_args.page_size
+        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
+        self.hot_token_ids = None
+
+        # NB: ModelWorker.get_memory_pool() returns (req_to_token_pool,
+        # token_to_kv_pool_ALLOCATOR) -- every other caller discards the second
+        # value with `_`. The KV cache itself only comes off the model runner.
+        req_to_token_pool, _ = target_worker.get_memory_pool()
+        target_token_to_kv_pool = target_worker.model_runner.token_to_kv_pool
+
+        self._worker = ModelWorker(
+            server_args,
+            target_worker.mesh,
+            req_to_token_pool=req_to_token_pool,
+            is_draft_worker=True,
+        )
+
+        self._kv_share_map = compute_mtp_kv_share_map(
+            self._worker.model_config.hf_config, target_worker.model_config.hf_config
+        )
+        logger.info("Frozen-KV MTP KV-share map: %s", self._kv_share_map)
+
+        # Alias the target's KV pool in. Combined with the layer_id redirection
+        # below, this makes every draft attention read land on the target's cache.
+        draft_runner = self._worker.model_runner
+        draft_runner.token_to_kv_pool = target_token_to_kv_pool
+        draft_runner.memory_pools = _build_non_hybrid_memory_pools(target_token_to_kv_pool)
+
+        self._redirect_layer_ids(draft_runner.model, target_worker.model_runner.model)
+
+        self._share_embed_head(target_worker)
+
+        # The target's SWA remap table must be visible to the draft's backend,
+        # since the draft now indexes the target's (possibly hybrid) pool.
+        target_allocator = target_worker.model_runner.token_to_kv_pool_allocator
+        target_swa_mapping = getattr(target_allocator, "full_to_swa_index_mapping", None)
+        if target_swa_mapping is not None:
+            object.__setattr__(draft_runner.attn_backend, "swa_index_mapping", target_swa_mapping)
+
+        EagleDraftInput.ALLOC_LEN_PER_DECODE = max(
+            self.speculative_num_steps * self.topk, self.speculative_num_draft_tokens
+        )
+
+        self._worker.model_runner.initialize_jit()
+
+        # Allocated lazily by the outer Frozen worker only for the opt-in
+        # seed-relay route.  Do not use BaseSpecWorker.spec_relay_buffers:
+        # that buffer selects the generic overlap/fused execution path, which
+        # Frozen-KV intentionally does not implement.
+        self.seed_relay_buffers: SpecSeedRelayBuffers | None = None
+        self._jit_publish_seed_relay = None
+        self._jit_gather_seed_relay = None
+
+        (
+            self.precompile_token_paddings,
+            self.precompile_bs_paddings,
+            self.precompile_cache_loc_paddings,
+        ) = target_worker.get_precompile_paddings()
+
+    def init_seed_relay_buffers(self) -> None:
+        """Allocate the generic request-indexed top-1 relay once per server.
+
+        This owns values, not scheduling: request IDs, batch merge, and bucket
+        selection stay in ``ScheduleBatch``.  The buffer is separate from the
+        generic overlap relay because Frozen-KV's normal path is non-overlap.
+        """
+        if getattr(self, "seed_relay_buffers", None) is not None:
+            return
+        hidden_dtype = jnp.bfloat16 if self.server_args.dtype == "bfloat16" else jnp.float32
+        req_to_token_pool, _ = self.target_worker_ref.get_memory_pool()
+        self.seed_relay_buffers = create_spec_seed_relay_buffers(
+            self.mesh,
+            req_to_token_pool,
+            dp_size=self.server_args.dp_size,
+            hidden_size=self.target_worker_ref.model_config.hidden_size,
+            hidden_dtype=hidden_dtype,
+        )
+
+    def _init_jit_seed_relay_ops(self) -> None:
+        """Create generic bucketed device programs for Frozen relay state.
+
+        Request IDs and the choice of padded batch remain scheduler-owned host
+        metadata.  Once a scheduler bucket is chosen, however, compact-row
+        scatter/update and request-indexed gather must execute as a single
+        device program.  Calling the pure relay helpers eagerly creates many
+        tiny dispatches and turns otherwise asynchronous JAX arrays into host
+        synchronization points.  This mirrors DFlash's cached relay JITs;
+        it does not introduce a Frozen-specific batch policy.
+        """
+        if getattr(self, "_jit_publish_seed_relay", None) is not None:
+            return
+
+        from functools import partial
+
+        data_sharding = NamedSharding(self.mesh, P("data"))
+        hidden_sharding = NamedSharding(self.mesh, P("data", None))
+
+        @partial(
+            jax.jit,
+            donate_argnames=("buffers",),
+            static_argnames=("dp_size",),
+        )
+        def publish(
+            buffers,
+            future_indices,
+            selector,
+            verified_id,
+            draft_token_ids,
+            hidden_states,
+            is_target_seed,
+            *,
+            dp_size: int,
+        ):
+            future_indices = jax.sharding.reshard(future_indices, data_sharding)
+            selector = jax.sharding.reshard(selector, data_sharding)
+            verified_id = jax.sharding.reshard(verified_id, data_sharding)
+            draft_token_ids = jax.sharding.reshard(draft_token_ids, data_sharding)
+            hidden_states = jax.sharding.reshard(hidden_states, hidden_sharding)
+            is_target_seed = jax.sharding.reshard(is_target_seed, data_sharding)
+
+            total_bs = future_indices.shape[0]
+
+            def scatter_rows(value, *, output_sharding, fill_value=0):
+                out = jax.sharding.reshard(
+                    jnp.full((total_bs,) + value.shape[1:], fill_value, dtype=value.dtype),
+                    output_sharding,
+                )
+                return out.at[selector].set(value, out_sharding=output_sharding)
+
+            valid_mask = (
+                jax.sharding.reshard(jnp.zeros((total_bs,), dtype=bool), data_sharding)
+                .at[selector]
+                .set(True, out_sharding=data_sharding)
+            )
+            return update_spec_seed_relay_buffers(
+                buffers,
+                future_indices,
+                valid_mask,
+                scatter_rows(verified_id, output_sharding=data_sharding),
+                scatter_rows(draft_token_ids, output_sharding=data_sharding),
+                scatter_rows(hidden_states, output_sharding=hidden_sharding),
+                scatter_rows(is_target_seed, output_sharding=data_sharding, fill_value=False),
+                dp_size=dp_size,
+            )
+
+        @partial(jax.jit, static_argnames=("dp_size",))
+        def gather(buffers, future_indices, relay_seed_mask, *, dp_size: int):
+            future_indices = jax.sharding.reshard(future_indices, data_sharding)
+            relay_seed_mask = jax.sharding.reshard(relay_seed_mask, data_sharding)
+            verified_id, draft_token_ids, hidden_states, _is_target_seed = (
+                gather_spec_seed_relay_buffers(buffers, future_indices, dp_size=dp_size)
+            )
+            # `relay_seed_mask` is scheduler-owned lifecycle metadata.  It is
+            # authoritative for this round; `is_target_seed` remains stored as
+            # part of the generic relay contract for diagnostics/future users.
+            return (
+                verified_id,
+                draft_token_ids,
+                hidden_states,
+                future_indices,
+                relay_seed_mask,
+            )
+
+        self._jit_publish_seed_relay = publish
+        self._jit_gather_seed_relay = gather
+
+    def _publish_seed_relay(
+        self,
+        *,
+        model_worker_batch: ModelWorkerBatch,
+        verified_id,
+        draft_token_ids,
+        hidden_states,
+        is_target_seed,
+    ) -> None:
+        """Publish compact Frozen state into the scheduler's current bucket.
+
+        The verifier/prefill outputs are compact request rows, while a relay
+        update must have a DP-divisible leading dimension.  Scatter those rows
+        onto the already-selected scheduler slots on device; this is the last
+        place where their dynamic size is visible.  Subsequent merge/filter
+        touches only host metadata and the next draft gathers the selected
+        static bucket from this request-indexed store.
+        """
+        if getattr(self, "seed_relay_buffers", None) is None:
+            return
+        self._init_jit_seed_relay_ops()
+        selector = jnp.asarray(model_worker_batch.logits_indices_selector, dtype=jnp.int32)
+        if selector.shape[0] != jnp.asarray(verified_id).shape[0]:
+            raise ValueError(
+                "Frozen-KV relay publication must receive one compact row per selector: "
+                f"selector={selector.shape[0]}, rows={jnp.asarray(verified_id).shape[0]}."
+            )
+
+        with jax.set_mesh(self.mesh):
+            self.seed_relay_buffers = self._jit_publish_seed_relay(
+                self.seed_relay_buffers,
+                model_worker_batch.req_pool_indices,
+                selector,
+                verified_id,
+                draft_token_ids,
+                hidden_states,
+                is_target_seed,
+                dp_size=self.server_args.dp_size,
+            )
+
+    @staticmethod
+    def _compact_request_rows(value, selector: np.ndarray, expected: int):
+        """Return compact live rows without changing their value dtype."""
+        value = np.asarray(value)
+        if value.shape[0] == expected:
+            return value
+        if value.shape[0] > int(selector.max(initial=-1)):
+            return value[selector]
+        raise ValueError(
+            "Frozen-KV verify metadata does not match live requests or padded slots: "
+            f"rows={value.shape[0]}, requests={expected}, selector={selector.tolist()}"
+        )
+
+    def publish_seed_after_verify_device(
+        self,
+        *,
+        model_worker_batch: ModelWorkerBatch,
+        verified_tokens: jax.Array,
+        target_hidden: jax.Array,
+        accept_lengths: jax.Array,
+        allocate_lens,
+    ) -> None:
+        """Select and relay the next Frozen seed without host acceptance reads.
+
+        ``EagleVerifyInput.sample_device`` returns a padded candidate layout.
+        The scheduler only needs its small acceptance result on host, whereas
+        Frozen's next proposal needs the selected target token/hidden pair on
+        device.  Select and publish that pair before the caller waits for the
+        scheduler result.  Request IDs and bucket selection remain scheduler
+        metadata; no model-specific admission policy enters this path.
+        """
+        if getattr(self, "seed_relay_buffers", None) is None:
+            return
+
+        selector_host = np.asarray(
+            getattr(model_worker_batch, "logits_indices_selector", ()), dtype=np.int32
+        ).reshape(-1)
+        if selector_host.size == 0:
+            return
+        selector = jnp.asarray(selector_host, dtype=jnp.int32)
+        accept_padded = jnp.asarray(accept_lengths, dtype=jnp.int32).reshape(-1)
+        if int(accept_padded.shape[0]) <= int(selector_host.max(initial=-1)):
+            raise ValueError(
+                "Frozen-KV device verify acceptance has fewer padded rows than its selector: "
+                f"accept_rows={accept_padded.shape[0]}, selector={selector_host.tolist()}"
+            )
+
+        rows_per_request = self.speculative_num_steps + 1
+        if int(verified_tokens.shape[0]) < int(accept_padded.shape[0]) * rows_per_request:
+            raise ValueError(
+                "Frozen-KV device verify tokens do not cover the padded candidate layout: "
+                f"tokens={verified_tokens.shape[0]}, accept_rows={accept_padded.shape[0]}, "
+                f"rows_per_request={rows_per_request}"
+            )
+
+        seq_lens = jnp.asarray(model_worker_batch.seq_lens, dtype=jnp.int32).reshape(-1)
+        allocate = jnp.asarray(allocate_lens, dtype=jnp.int32).reshape(-1)
+        req_indices = jnp.asarray(model_worker_batch.req_pool_indices, dtype=jnp.int32).reshape(-1)
+        if min(int(seq_lens.shape[0]), int(allocate.shape[0]), int(req_indices.shape[0])) <= int(
+            selector_host.max(initial=-1)
+        ):
+            raise ValueError("Frozen-KV device verify metadata is smaller than its live selector.")
+
+        def gather_request_rows(value):
+            """Gather selected scheduler rows without losing native sharding.
+
+            The padded verifier can be TP-sharded by candidate rows, while the
+            compact live request count may be c1/c2 and therefore cannot use a
+            data-partitioned result.  Annotate only this small metadata gather;
+            never force its source into a replicated layout first.
+            """
+            value_sharding = jax.typeof(value).sharding
+            if isinstance(value_sharding, NamedSharding):
+                mesh = value_sharding.mesh
+                # Generic startup precompile can use a TP-only mesh, whereas
+                # serving meshes also have ``data``.  Only partition compact
+                # scheduler metadata when that axis actually exists.
+                data_size = int(mesh.shape.get("data", 1))
+                if "data" in mesh.shape and selector.shape[0] % data_size == 0:
+                    output_spec = P("data", *([None] * (value.ndim - 1)))
+                else:
+                    output_spec = P()
+                return value.at[selector].get(out_sharding=NamedSharding(mesh, output_spec))
+            return jnp.take(value, selector, axis=0)
+
+        accept_live = gather_request_rows(accept_padded)
+        seed_state = select_after_verify(
+            jnp.asarray(verified_tokens, dtype=jnp.int32),
+            jnp.asarray(target_hidden),
+            selector,
+            accept_live,
+            gather_request_rows(seq_lens) + accept_live + 1,
+            gather_request_rows(allocate),
+            gather_request_rows(req_indices),
+            rows_per_request=rows_per_request,
+        )
+        self._publish_seed_relay(
+            model_worker_batch=model_worker_batch,
+            verified_id=seed_state.bonus_token,
+            draft_token_ids=seed_state.bonus_token,
+            hidden_states=seed_state.target_hidden,
+            is_target_seed=seed_state.valid_mask,
+        )
+
+    def build_next_draft_input_after_verify(
+        self,
+        *,
+        verified_id,
+        hidden_states,
+        new_seq_lens,
+        allocate_lens,
+        accept_lens,
+        accept_index,
+        model_worker_batch,
+    ) -> FrozenKvMtpDraftInput:
+        """Publish one target-hidden/token seed per request after verify.
+
+        The common verifier has already made ``verified_id`` and
+        ``hidden_states`` request-row aligned using its safe acceptance index.
+        Frozen keeps that pair as a device-resident ``FrozenKvMtpSeedState``;
+        the next ``draft`` consumes it before entering the recurrent proposal
+        loop. No generic EAGLE extension result is returned as the seed state.
+        """
+        accept_padded = np.asarray(accept_lens, dtype=np.int32).reshape(-1)
+        if accept_padded.size == 0:
+            return self.new_draft_input(
+                verified_id=np.empty(0, dtype=np.int32),
+                hidden_states=jnp.empty((0, 0), dtype=jnp.float32),
+                topk_p=np.empty((0, 1), dtype=np.float32),
+                topk_index=np.empty((0, 1), dtype=np.int32),
+                accept_length=accept_padded,
+                accept_length_cpu=accept_padded.copy(),
+                allocate_lens=np.empty(0, dtype=np.int32),
+                new_seq_lens=np.empty(0, dtype=np.int32),
+                seed_state=None,
+            )
+
+        selector = np.asarray(
+            getattr(model_worker_batch, "logits_indices_selector", np.arange(accept_padded.size)),
+            dtype=np.int32,
+        ).reshape(-1)
+        # ``EagleVerifyInput.sample`` returns one accept length for every
+        # *padded* verifier slot.  The Frozen seed state instead has one row
+        # per live scheduler request, identified by ``selector``.  Earlier we
+        # assumed those shapes were already compact, which crashed the first
+        # real Seed-MTP request at c1: selector=(1,), accept_lens=(16,).
+        accept = self._compact_request_rows(accept_padded, selector, selector.size)
+        if selector.size != accept.size:
+            raise ValueError(
+                "Frozen-KV verify selector must have one slot per accepted request: "
+                f"selector={selector.shape}, accept_lens={accept.shape}"
+            )
+
+        verified = jnp.asarray(verified_id)
+        hidden = jnp.asarray(hidden_states)
+        accept_index = np.asarray(accept_index).reshape(-1)
+        if accept_index.size % accept_padded.size != 0:
+            raise ValueError(
+                "Frozen-KV accept_index must contain a fixed candidate width per request: "
+                f"rows={accept_index.size}, padded_requests={accept_padded.size}"
+            )
+        rows_per_request = accept_index.size // accept_padded.size
+        if verified.shape[0] < accept_padded.size * rows_per_request:
+            raise ValueError(
+                "Frozen-KV verified rows are smaller than the padded verifier layout: "
+                f"rows={verified.shape[0]}, padded_requests={accept_padded.size}, "
+                f"rows_per_request={rows_per_request}"
+            )
+        committed = self._compact_request_rows(new_seq_lens, selector, accept.size)
+        allocated = self._compact_request_rows(allocate_lens, selector, accept.size)
+        req_indices = np.asarray(
+            getattr(model_worker_batch, "req_pool_indices", np.arange(accept.size)),
+            dtype=np.int32,
+        ).reshape(-1)
+        req_indices = self._compact_request_rows(req_indices, selector, accept.size)
+        seed_state = select_after_verify(
+            verified,
+            hidden,
+            jnp.asarray(selector),
+            jnp.asarray(accept),
+            jnp.asarray(committed),
+            jnp.asarray(allocated),
+            jnp.asarray(req_indices),
+            rows_per_request=rows_per_request,
+        )
+        if getattr(self, "seed_relay_buffers", None) is not None:
+            # Publish the target-selected seed in request-pool storage, then
+            # return only scheduler metadata.  In particular, do not return
+            # ``seed_state`` here: split/merge/filter would otherwise
+            # materialize its variable-size hidden tensor before the next
+            # static decode bucket is known.
+            self._publish_seed_relay(
+                model_worker_batch=model_worker_batch,
+                verified_id=seed_state.bonus_token,
+                draft_token_ids=seed_state.bonus_token,
+                hidden_states=seed_state.target_hidden,
+                is_target_seed=seed_state.valid_mask,
+            )
+            return self.new_draft_input(
+                future_indices=req_indices,
+                allocate_lens=allocated,
+                new_seq_lens=committed,
+                accept_length_cpu=accept.copy(),
+                relay_seed_mask=np.ones((accept.size,), dtype=bool),
+            )
+        # These fields remain the scheduler-compatible representation. The
+        # dedicated draft consumes seed_state and replaces top-k values after
+        # its seed forward; they are not interpreted as a generic EAGLE
+        # DRAFT_EXTEND result.
+        return self.new_draft_input(
+            verified_id=seed_state.bonus_token,
+            hidden_states=seed_state.target_hidden,
+            topk_p=jnp.ones((accept.size, 1), dtype=jnp.float32),
+            topk_index=seed_state.bonus_token[:, None],
+            accept_length=jnp.asarray(accept),
+            accept_length_cpu=accept.copy(),
+            allocate_lens=allocated,
+            new_seq_lens=committed,
+            seed_state=seed_state,
+        )
+
+    def _consume_seed_state(self, seed_state: FrozenKvMtpSeedState) -> tuple[jax.Array, jax.Array]:
+        """Consume and validate the next Frozen proposal's seed pair.
+
+        The returned token/hidden tensors are the inputs to the dedicated seed
+        forward. Keeping this tiny seam separate lets fake runners test the
+        handoff without constructing a TPU model runner.
+        """
+        if not isinstance(seed_state, FrozenKvMtpSeedState):
+            raise TypeError(f"expected FrozenKvMtpSeedState, got {type(seed_state).__name__}")
+        if not bool(np.all(np.asarray(seed_state.valid_mask))):
+            raise ValueError("Frozen-KV cannot start a proposal from an invalid seed row")
+        return seed_state.bonus_token, seed_state.target_hidden
+
+    def _prepare_seed_proposal(self, model_worker_batch: ModelWorkerBatch) -> jax.Array | None:
+        """Expose the seed-row mask for the next assistant seed forward.
+
+        The scheduler has already scattered ``seed_state`` into its DP-padded
+        slots.  Earlier experimental code compacted those slots and installed
+        target hidden states as if they were EAGLE hidden states.  That skips
+        Gemma's required assistant seed forward and also destroys the DP slot
+        layout.  Keep the padded layout intact: ``draft_forward`` will run one
+        assistant forward for every bucket slot and use this mask to retain its
+        result only for rows which came from target verification.
+        """
+        state = model_worker_batch.spec_info_padded
+        if not isinstance(state, FrozenKvMtpDraftInput) or state.seed_state is None:
+            return None
+        seed_state = state.seed_state
+        valid_mask = jnp.asarray(seed_state.valid_mask, dtype=bool)
+        state_rows = int(state.verified_id.shape[0])
+        if seed_state.batch_size != state_rows:
+            raise ValueError(
+                "Frozen-KV seed state and draft fields must have the same DP-padded slots: "
+                f"seed_bs={seed_state.batch_size}, draft_bs={state_rows}."
+            )
+
+        # Keep the target pair in the ordinary per-slot input fields so it
+        # survives merge/split/scatter implementations which do not know about
+        # ``seed_state`` yet.  Do not touch top-k values: target hidden is the
+        # *input* of the assistant seed forward, never generic EAGLE output.
+        # Relay lookup is data-sharded, while inherited draft-input fields can
+        # be replicated. `where` does not insert a collective implicitly, so
+        # align its predicate with each consumer field explicitly.
+        def _mask_for(reference):
+            sharding = getattr(reference, "sharding", None)
+            if not isinstance(sharding, NamedSharding):
+                return valid_mask if sharding is None else jax.device_put(valid_mask, sharding)
+            # A hidden-state reference is rank two/three, but the `where`
+            # predicate remains rank one before broadcasting.  Preserve the
+            # relevant leading partition axes without applying a rank-two
+            # sharding annotation to a vector.
+            mask_sharding = NamedSharding(
+                sharding.mesh, P(*tuple(sharding.spec)[: valid_mask.ndim])
+            )
+            return jax.device_put(valid_mask, mask_sharding)
+
+        token_mask = _mask_for(state.verified_id)
+        hidden_mask = _mask_for(state.hidden_states)
+        state.verified_id = jnp.where(
+            token_mask,
+            jnp.asarray(seed_state.bonus_token, dtype=jnp.int32),
+            jnp.asarray(state.verified_id, dtype=jnp.int32),
+        )
+        state.hidden_states = jnp.where(
+            hidden_mask[:, None],
+            jnp.asarray(seed_state.target_hidden),
+            jnp.asarray(state.hidden_states),
+        )
+        state.seed_state = None
+        return token_mask
+
+    def _restore_seed_relay(self, model_worker_batch: ModelWorkerBatch) -> None:
+        """Restore opaque relay metadata into one scheduler-selected bucket.
+
+        ``future_indices`` is intentionally consumed here, after
+        ``ScheduleBatch`` has merged/filtered and DP-scattered request metadata.
+        No dynamic model tensor participates in those operations.  The request
+        pool is the stable key, so slot reordering cannot pair one request with
+        another request's target hidden state.
+        """
+        state = model_worker_batch.spec_info_padded
+        if not isinstance(state, FrozenKvMtpDraftInput) or state.future_indices is None:
+            return
+        if getattr(self, "seed_relay_buffers", None) is None:
+            raise RuntimeError(
+                "Frozen-KV received a relay descriptor without initialized seed relay buffers."
+            )
+        if state.relay_seed_mask is None:
+            raise ValueError("Frozen-KV relay descriptor is missing relay_seed_mask.")
+
+        future_indices = np.asarray(state.future_indices, dtype=np.int32)
+        relay_seed_mask = np.asarray(state.relay_seed_mask, dtype=bool)
+        if future_indices.shape != relay_seed_mask.shape:
+            raise ValueError(
+                "Frozen-KV relay future_indices and relay_seed_mask must have identical shapes: "
+                f"indices={future_indices.shape}, mask={relay_seed_mask.shape}."
+            )
+        self._init_jit_seed_relay_ops()
+        with jax.set_mesh(self.mesh):
+            (
+                verified_id,
+                draft_token_ids,
+                hidden_states,
+                device_indices,
+                device_relay_seed_mask,
+            ) = self._jit_gather_seed_relay(
+                self.seed_relay_buffers,
+                future_indices,
+                relay_seed_mask,
+                dp_size=int(model_worker_batch.dp_size),
+            )
+
+        state.verified_id = verified_id
+        state.topk_index = draft_token_ids[:, None]
+        # A top-1 proposal's probability affects tree scores but not its only
+        # candidate token.  The first recurrent model forward replaces it
+        # immediately; use a device scalar rather than retaining a second
+        # request-indexed float buffer solely for that degenerate tree shape.
+        state.topk_p = jnp.ones_like(state.topk_index, dtype=jnp.float32)
+        state.hidden_states = hidden_states
+        state.future_indices = None
+        state.relay_seed_mask = None
+
+        # Always retain a device mask, including an all-false one.  Branching
+        # on `np.any` would materialize the just-gathered device relay state on
+        # the host; `_prepare_seed_proposal` naturally becomes a no-op when no
+        # row needs a target-hidden assistant seed forward.
+        state.seed_state = FrozenKvMtpSeedState(
+            bonus_token=verified_id,
+            target_hidden=hidden_states,
+            committed_lens=jnp.asarray(state.new_seq_lens, dtype=jnp.int32),
+            allocate_lens=jnp.asarray(state.allocate_lens, dtype=jnp.int32),
+            request_indices=device_indices,
+            valid_mask=device_relay_seed_mask,
+        )
+        # Do not call ``_validate_non_overlap_state`` here: its intentional
+        # CPU-side structural checks would materialize the freshly gathered
+        # device arrays. Descriptor validation happens before the scheduler
+        # stores the state; shape checks above cover this reconstruction seam.
+
+    @staticmethod
+    def _pad_seed_valid_mask(valid_mask, *, padded_bs: int, dp_size: int) -> jax.Array:
+        """Pad a scheduler-slot mask with the same DP layout as draft fields."""
+        valid_mask = jnp.asarray(valid_mask, dtype=bool).reshape(-1)
+        if valid_mask.shape[0] == padded_bs:
+            return valid_mask
+        if valid_mask.shape[0] > padded_bs or padded_bs % dp_size:
+            raise ValueError(
+                "Frozen-KV seed mask cannot be padded to the draft bucket: "
+                f"mask={valid_mask.shape[0]}, padded_bs={padded_bs}, dp_size={dp_size}."
+            )
+        if dp_size == 1 or valid_mask.shape[0] % dp_size:
+            return jnp.pad(valid_mask, (0, padded_bs - valid_mask.shape[0]))
+        per_dp_real = valid_mask.shape[0] // dp_size
+        per_dp_padded = padded_bs // dp_size
+        return jnp.pad(
+            valid_mask.reshape(dp_size, per_dp_real),
+            ((0, 0), (0, per_dp_padded - per_dp_real)),
+        ).reshape(-1)
+
+    @staticmethod
+    def _replace_seed_rows(
+        *,
+        valid_mask: jax.Array,
+        old_topk_p: jax.Array,
+        old_topk_index: jax.Array,
+        old_hidden: jax.Array,
+        seed_topk_p: jax.Array,
+        seed_topk_index: jax.Array,
+        seed_hidden: jax.Array,
+    ) -> tuple[jax.Array, jax.Array, jax.Array]:
+        """Use seed-forward outputs without disturbing freshly-prefilled rows."""
+        valid_mask = jnp.asarray(valid_mask, dtype=bool)
+
+        def _reshard_like(value: jax.Array, reference: jax.Array) -> jax.Array:
+            """Match the persistent draft state's layout before `where`.
+
+            The seed model forward returns data-sharded output, whereas the
+            existing generic draft state is intentionally replicated at this
+            handoff.  JAX rejects `where` across those layouts (correctly: it
+            would otherwise require an implicit collective).  The state layout
+            is the consumer contract for the inherited recurrence, so make the
+            one explicit reshard here.
+            """
+            sharding = jax.typeof(reference).sharding
+            # CPU unit tests use a zero-axis NamedSharding, which is already
+            # effectively replicated and is not a legal `reshard` target.
+            if isinstance(sharding, NamedSharding) and sharding.mesh.axis_names:
+                return jax.sharding.reshard(value, sharding)
+            return value
+
+        def _mask_like(reference: jax.Array) -> jax.Array:
+            sharding = getattr(reference, "sharding", None)
+            if not isinstance(sharding, NamedSharding):
+                return valid_mask if sharding is None else jax.device_put(valid_mask, sharding)
+            mask_sharding = NamedSharding(
+                sharding.mesh, P(*tuple(sharding.spec)[: valid_mask.ndim])
+            )
+            return jax.device_put(valid_mask, mask_sharding)
+
+        seed_topk_p = _reshard_like(seed_topk_p, old_topk_p)
+        seed_topk_index = _reshard_like(seed_topk_index, old_topk_index)
+        seed_hidden = _reshard_like(seed_hidden, old_hidden)
+        return (
+            jnp.where(_mask_like(old_topk_p)[:, None], seed_topk_p, old_topk_p),
+            jnp.where(
+                _mask_like(old_topk_index)[:, None],
+                seed_topk_index,
+                old_topk_index,
+            ),
+            jnp.where(_mask_like(old_hidden)[:, None], seed_hidden, old_hidden),
+        )
+
+    def _run_seed_forward(
+        self,
+        model_worker_batch: ModelWorkerBatch,
+        *,
+        target_hidden: jax.Array,
+    ) -> tuple[jax.Array, jax.Array, jax.Array]:
+        """Run Gemma's one-token target-hidden -> assistant-state transition.
+
+        Target verification produced the final accepted token and its target
+        hidden state.  Gemma's assistant must consume that pair before the
+        ordinary EAGLE-shaped recurrence can select a first draft candidate.
+        This is intentionally a DECODE-shaped assistant operation: it reads
+        the target KV view and has no assistant-owned cache to extend.
+        """
+        if self.topk != 1:
+            raise NotImplementedError(
+                "Frozen-KV seed forward currently supports speculative_eagle_topk=1 only."
+            )
+        state = model_worker_batch.spec_info_padded
+        assert isinstance(state, FrozenKvMtpDraftInput)
+        bs = int(model_worker_batch.seq_lens.shape[0])
+        if target_hidden.shape[0] != bs:
+            raise ValueError(
+                "Frozen-KV seed hidden state must match the padded draft batch: "
+                f"hidden_bs={target_hidden.shape[0]}, draft_bs={bs}."
+            )
+
+        metadata_per_step = self.draft_model_runner.attn_backend.get_eagle_multi_step_metadata(
+            model_worker_batch
+        )
+        logits_metadata = LogitsMetadata.from_model_worker_batch(
+            model_worker_batch, self.draft_model_runner.mesh
+        )
+        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
+        forward_batch.out_cache_loc = np.empty((1,))
+        forward_batch.cache_loc = np.empty((1,))
+        forward_batch.spec_info = EagleDraftInput(hidden_states=jnp.asarray(target_hidden))
+        # ``device_array`` intentionally accepts host arrays and therefore
+        # calls ``np.asarray`` internally. The accepted Frozen seed is already
+        # device-resident; preserve it with an explicit reshard instead.
+        input_sharding = NamedSharding(self.mesh, P())
+        forward_batch.input_ids = jax.device_put(
+            jnp.asarray(state.verified_id, dtype=jnp.int32), input_sharding
+        )
+        # The seed token is already committed in target KV. Its target hidden
+        # therefore belongs to the final committed position, not the next
+        # proposal position. The attention metadata still exposes the target
+        # cache at the current committed sequence length.
+        forward_batch.positions = device_array(
+            np.asarray(model_worker_batch.seq_lens, dtype=np.int32) - 1,
+            sharding=NamedSharding(self.mesh, P()),
+        )
+        forward_batch.bid = model_worker_batch.bid
+        self.draft_model_runner.attn_backend.forward_metadata = metadata_per_step[0]
+        logits_output, _, _ = self.draft_model_runner.forward(
+            forward_batch,
+            logits_metadata=logits_metadata,
+        )
+        topk_p, topk_index = topk_probs_from_logits(logits_output.next_token_logits, self.topk)
+        if self.hot_token_ids is not None:
+            topk_index = self._map_hot_token_ids(topk_index)
+        return topk_p, topk_index, replicate_to_mesh(self.mesh, logits_output.hidden_states)
+
+    def draft_forward(self, model_worker_batch: ModelWorkerBatch):
+        """Start Frozen proposals with an assistant seed forward when required."""
+        valid_mask = getattr(model_worker_batch, "_frozen_kv_seed_valid_mask", None)
+        if valid_mask is None:
+            return super().draft_forward(model_worker_batch)
+
+        state = model_worker_batch.spec_info_padded
+        assert isinstance(state, FrozenKvMtpDraftInput)
+        padded_mask = self._pad_seed_valid_mask(
+            valid_mask,
+            padded_bs=int(model_worker_batch.seq_lens.shape[0]),
+            dp_size=int(model_worker_batch.dp_size),
+        )
+        seed_topk_p, seed_topk_index, seed_hidden = self._run_seed_forward(
+            model_worker_batch,
+            target_hidden=jnp.asarray(state.hidden_states),
+        )
+        state.topk_p, state.topk_index, state.hidden_states = self._replace_seed_rows(
+            valid_mask=padded_mask,
+            old_topk_p=jnp.asarray(state.topk_p),
+            old_topk_index=jnp.asarray(state.topk_index),
+            old_hidden=jnp.asarray(state.hidden_states),
+            seed_topk_p=seed_topk_p,
+            seed_topk_index=seed_topk_index,
+            seed_hidden=seed_hidden,
+        )
+        return super().draft_forward(model_worker_batch)
+
+    def draft_extend_for_prefill(self, model_worker_batch, hidden_states, next_token_ids) -> None:
+        """Publish the prefill's committed length for a later non-overlap merge."""
+        super().draft_extend_for_prefill(model_worker_batch, hidden_states, next_token_ids)
+        draft_input = model_worker_batch.spec_info_padded
+        assert isinstance(draft_input, FrozenKvMtpDraftInput)
+        selector = np.asarray(model_worker_batch.logits_indices_selector)
+        draft_input.new_seq_lens = np.asarray(model_worker_batch.seq_lens)[selector].copy()
+        draft_input._validate_non_overlap_state()
+        if getattr(self, "seed_relay_buffers", None) is not None:
+            # The inherited prefill extension currently computes the assistant
+            # proposal correctly, but leaves compact model tensors in
+            # ``draft_input``. Publish those tensors immediately and keep only
+            # scheduler metadata for non-overlap merge/filter. A later dedicated
+            # prefill program can remove that inherited host capture as a
+            # separate, measurable change; this slice removes the cross-round
+            # materialization without changing prefill math.
+            self._publish_seed_relay(
+                model_worker_batch=model_worker_batch,
+                verified_id=draft_input.verified_id,
+                draft_token_ids=jnp.asarray(draft_input.topk_index)[:, 0],
+                hidden_states=draft_input.hidden_states,
+                is_target_seed=jnp.zeros((selector.size,), dtype=bool),
+            )
+            model_worker_batch.spec_info_padded = self.new_draft_input(
+                future_indices=np.asarray(model_worker_batch.req_pool_indices, dtype=np.int32)[
+                    selector
+                ],
+                allocate_lens=np.asarray(draft_input.allocate_lens),
+                new_seq_lens=np.asarray(draft_input.new_seq_lens),
+                relay_seed_mask=np.zeros((selector.size,), dtype=bool),
+            )
+            model_worker_batch.spec_info_padded._validate_non_overlap_state()
+
+    def draft_extend_for_decode(self, model_worker_batch, batch_output) -> None:
+        """Publish the already-selected seed; do not run generic DRAFT_EXTEND.
+
+        ``BaseSpecWorker.verify`` has already called
+        ``build_next_draft_input_after_verify``. Frozen's next draft consumes
+        that state at the start of ``draft``; there is no assistant forward at
+        this boundary and no host-visible generic extension result.
+        """
+        next_state = batch_output.next_draft_input
+        if not isinstance(next_state, FrozenKvMtpDraftInput):
+            raise TypeError(
+                "Frozen-KV verify must publish FrozenKvMtpDraftInput, got "
+                f"{type(next_state).__name__}"
+            )
+        next_state._validate_non_overlap_state()
+        model_worker_batch.spec_info_padded = next_state
+        batch_output.accept_lens = np.asarray(batch_output.accept_lens, dtype=np.int32)
+
+    def draft(self, model_worker_batch):
+        """Run the seed transition, then the common recurrent proposal loop."""
+        self._restore_seed_relay(model_worker_batch)
+        valid_mask = self._prepare_seed_proposal(model_worker_batch)
+        if valid_mask is None:
+            return super().draft(model_worker_batch)
+
+        # This marker is deliberately ephemeral. It describes the current
+        # scheduler batch only; persisting it in ``FrozenKvMtpDraftInput``
+        # would make a finished/retracted request's validity leak into a later
+        # batch.
+        model_worker_batch._frozen_kv_seed_valid_mask = valid_mask
+        try:
+            return super().draft(model_worker_batch)
+        finally:
+            delattr(model_worker_batch, "_frozen_kv_seed_valid_mask")
+
+    def _redirect_layer_ids(self, draft_model, target_model) -> None:
+        """Point each draft layer at the target cache slot it shares K/V with.
+
+        Both checks below guard silent corruption rather than crashes: a missing
+        entry leaves a layer reading target layer 0, and a geometry mismatch
+        reads the cache at the wrong stride. Neither raises on its own.
+        """
+        for draft_layer_idx, layer in enumerate(draft_model.layers):
+            draft_name = f"draft_layer.{draft_layer_idx}"
+            if draft_name not in self._kv_share_map:
+                raise ValueError(
+                    f"Frozen-KV MTP: no KV-share entry for {draft_name}. That layer "
+                    f"would read layer 0 of the target cache, silently producing garbage."
+                )
+            target_name = self._kv_share_map[draft_name]
+            target_layer_idx = int(target_name.split(".")[-1])
+
+            target_attn = target_model.model.layers[target_layer_idx].self_attn.attn
+            draft_attn = layer.self_attn.attn
+            if (draft_attn.head_dim, draft_attn.kv_head_num) != (
+                target_attn.head_dim,
+                target_attn.kv_head_num,
+            ):
+                raise ValueError(
+                    f"Frozen-KV MTP KV-share geometry mismatch: {draft_name} has "
+                    f"(head_dim={draft_attn.head_dim}, kv_heads={draft_attn.kv_head_num}) "
+                    f"but target {target_name} cache holds "
+                    f"(head_dim={target_attn.head_dim}, kv_heads={target_attn.kv_head_num})."
+                )
+            if bool(draft_attn.sliding_window_size) != bool(target_attn.sliding_window_size):
+                raise ValueError(
+                    f"Frozen-KV MTP KV-share attention-type mismatch: {draft_name} "
+                    f"(sliding={bool(draft_attn.sliding_window_size)}) mapped to "
+                    f"{target_name} (sliding={bool(target_attn.sliding_window_size)})."
+                )
+
+            draft_attn.layer_id = target_layer_idx
+            logger.debug(
+                "Frozen-KV MTP: draft_layer.%d -> target layer.%d",
+                draft_layer_idx,
+                target_layer_idx,
+            )
+
+    def _share_embed_head(self, target_worker: ModelWorker) -> None:
+        """Bind the target's embedding; the assistant keeps its own lm_head."""
+        embed, head = target_worker.model_runner.model.get_embed_and_head()
+        m = self._worker.model_runner.model
+        if getattr(m, "load_lm_head_from_target", False):
+            m.set_embed_and_head(embed, head)
+        else:
+            m.set_embed(embed)
+
+
+class FrozenKvMtpWorker(EAGLEWorker):
+    """EAGLE orchestration with a frozen-KV draft worker.
+
+    Startup bucket selection and dummy-batch construction are inherited from
+    ``EAGLEWorker`` just like ordinary multi-layer MTP.  Frozen-KV only opts
+    into that shared driver's non-fused prefill branch because its query-only
+    assistant cannot use the generic fused NEXTN prefill path.
+    """
+
+    def __init__(self, server_args, target_worker: ModelWorker):
+        super().__init__(
+            server_args,
+            target_worker,
+            draft_worker=FrozenKvMtpDraftWorker(server_args, target_worker),
+        )
+        # This is deliberately independent from ``spec_relay_buffers``:
+        # setting the latter would select EAGLE's overlap/fused machinery
+        # rather than Frozen-KV's non-overlap path.
+        self.draft_worker.init_seed_relay_buffers()
+
+    def supports_non_fused_spec_prefill_precompile(self) -> bool:
+        return True
+
+    def verify(self, model_worker_batch: ModelWorkerBatch, cur_allocate_lens=None):
+        """Dedicated Frozen-KV target verify and seed-relay handoff.
+
+        Ordinary EAGLE's ``verify`` materializes predict, acceptance indices,
+        and acceptance lengths immediately, then uses those CPU values to pick
+        target-hidden rows.  Frozen-KV instead consumes the device acceptance
+        result first: it selects each accepted target row and publishes the
+        next assistant seed into its device relay.  Only the small acceptance
+        length vector is then read by the scheduler-facing descriptor.
+
+        This is deliberately the first DFlash-aligned slice, not a full target
+        forward fusion: the target executable is unchanged, but the
+        verify-to-next-draft ownership boundary is Frozen-specific and no
+        longer inherits generic EAGLE's host handoff.
+        """
+        if not self.server_args.disable_overlap_schedule:
+            return super().verify(model_worker_batch, cur_allocate_lens)
+
+        from sgl_jax.srt.managers.scheduler import GenerationBatchResult
+        from sgl_jax.srt.speculative.eagle_info import EagleVerifyInput
+
+        if cur_allocate_lens is None:
+            cur_allocate_lens = self._get_cur_allocate_lens(model_worker_batch)
+        spec_info = model_worker_batch.spec_info_padded
+        if not isinstance(spec_info, EagleVerifyInput):
+            raise TypeError(
+                "Frozen-KV target verify requires EagleVerifyInput, got "
+                f"{type(spec_info).__name__}."
+            )
+
+        spec_info.allocate_lens = cur_allocate_lens
+        spec_info.prepare_for_verify(model_worker_batch)
+        forward_metadata = self.target_worker.model_runner.attn_backend.get_eagle_forward_metadata(
+            model_worker_batch
+        )
+        logits_output, _, cache_miss_count = self.target_worker.forward_batch_generation(
+            model_worker_batch, skip_sample=True, forward_metadata=forward_metadata
+        )
+        # Frozen-KV MTP's public contract is a top-k-one chain.  Verify that
+        # chain directly against the target's native output sharding, following
+        # DFlash's target-verify design.  Generic EAGLE tree verification has
+        # P()-replicated Pallas inputs, which used to force both target logits
+        # and target hidden states through ``replicate_to_mesh`` here before
+        # the Frozen-specific seed relay could consume them.
+        #
+        # Keep the generic route as a correctness fallback for a future
+        # branching configuration: its retrieval graph is not a linear chain.
+        native_chain_verify = (
+            model_worker_batch.sampling_info.is_all_greedy
+            and spec_info.custom_mask is None
+            and spec_info.draft_token_num == spec_info.spec_steps + 1
+        )
+        if native_chain_verify:
+            (
+                predict_device,
+                accept_lengths_device,
+                accept_index_device,
+            ) = verify_frozen_kv_mtp_chain_greedy(
+                spec_info.draft_token,
+                logits_output.next_token_logits,
+                draft_token_num=spec_info.draft_token_num,
+            )
+            # For a linear chain each candidate row's target argmax is both
+            # the scheduler-visible prediction and the potential next seed.
+            verified_tokens_device = predict_device
+        else:
+            logits_output.next_token_logits, logits_output.hidden_states = replicate_to_mesh(
+                self.mesh, logits_output.next_token_logits, logits_output.hidden_states
+            )
+            (
+                predict_device,
+                verified_tokens_device,
+                accept_lengths_device,
+                accept_index_device,
+            ) = spec_info.sample_device(
+                model_worker_batch,
+                logits_output,
+                self.draft_worker.draft_model_runner.rngs,
+                self.mesh,
+            )
+
+        # Select and store the next target token/hidden seed before the host
+        # waits for acceptance.  This follows DFlash's target-verify ownership:
+        # device state is advanced first, host scheduler metadata follows.
+        self.draft_worker.publish_seed_after_verify_device(
+            model_worker_batch=model_worker_batch,
+            verified_tokens=verified_tokens_device,
+            target_hidden=logits_output.hidden_states,
+            accept_lengths=accept_lengths_device,
+            allocate_lens=cur_allocate_lens,
+        )
+
+        accept_width = self.speculative_num_steps + 1
+        draft_width = self.speculative_num_draft_tokens
+        flat_accept_index = jnp.asarray(accept_index_device, dtype=jnp.int32).reshape(-1)
+        request_ids = jnp.arange(flat_accept_index.shape[0], dtype=jnp.int32) // accept_width
+        per_request_last = request_ids * draft_width + draft_width - 1
+        safe_index = jnp.where(flat_accept_index >= 0, flat_accept_index, per_request_last)
+
+        # Preserve the target program's data/tensor output layouts through the
+        # scheduler-facing candidate-row gather. Plain advanced indexing cannot
+        # infer a safe output sharding when rows are TP-partitioned. This is a
+        # device gather, not a host materialization or a P() replication.
+        def gather_rows(value, indices):
+            value_sharding = jax.typeof(value).sharding
+            if isinstance(value_sharding, NamedSharding):
+                return value.at[indices].get(out_sharding=value_sharding)
+            return value[indices]
+
+        logits_output.next_token_logits = gather_rows(logits_output.next_token_logits, safe_index)
+        logits_output.hidden_states = gather_rows(logits_output.hidden_states, safe_index)
+        model_worker_batch.positions = gather_rows(model_worker_batch.positions, safe_index)
+
+        # The scheduler needs the acceptance length, but not the candidate-row
+        # acceptance index. Start that small transfer after the relay dispatch;
+        # it can overlap later device work exactly as in DFlash.
+        if hasattr(accept_lengths_device, "copy_to_host_async"):
+            accept_lengths_device.copy_to_host_async()
+        accept_padded = np.asarray(accept_lengths_device, dtype=np.int32).reshape(-1)
+        selector = np.asarray(model_worker_batch.logits_indices_selector, dtype=np.int32).reshape(
+            -1
+        )
+        accept_live = self.draft_worker._compact_request_rows(
+            accept_padded, selector, selector.size
+        )
+        seq_lens = np.asarray(model_worker_batch.seq_lens, dtype=np.int32).reshape(-1)
+        allocate_lens = self.draft_worker._compact_request_rows(
+            cur_allocate_lens, selector, selector.size
+        )
+        req_indices = self.draft_worker._compact_request_rows(
+            model_worker_batch.req_pool_indices, selector, selector.size
+        )
+        new_seq_lens = seq_lens[selector] + accept_live + 1
+        next_draft_input = self.draft_worker.new_draft_input(
+            future_indices=req_indices,
+            allocate_lens=allocate_lens,
+            new_seq_lens=new_seq_lens,
+            accept_length_cpu=accept_live.copy(),
+            relay_seed_mask=np.ones((selector.size,), dtype=bool),
+        )
+        next_draft_input._validate_non_overlap_state()
+        model_worker_batch.spec_info_padded = next_draft_input
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=predict_device,
+            next_draft_input=next_draft_input,
+            accept_lens=accept_padded,
+            bid=model_worker_batch.bid,
+            cache_miss_count=cache_miss_count,
+            extend_input_len_per_req=None,
+            extend_logprob_start_len_per_req=None,
+        )

--- a/python/sgl_jax/srt/speculative/overlap_utils.py
+++ b/python/sgl_jax/srt/speculative/overlap_utils.py
@@ -80,7 +80,11 @@ def can_merge_spec_non_overlap_prefill(enable_overlap, spec_algorithm) -> bool:
         not enable_overlap
         and spec_algorithm is not None
         and not spec_algorithm.is_none()
-        and (spec_algorithm.is_eagle3() or spec_algorithm.is_dflash())
+        and (
+            spec_algorithm.is_eagle3()
+            or spec_algorithm.is_dflash()
+            or spec_algorithm.is_frozen_kv_mtp()
+        )
     )
 
 

--- a/python/sgl_jax/srt/speculative/relay_buffer.py
+++ b/python/sgl_jax/srt/speculative/relay_buffer.py
@@ -12,11 +12,40 @@ RELAY_STATE_SPEC = P("data", None, None)
 RELAY_ID_SPEC = P("data", None)
 
 
+def _array_sharding(value):
+    """Return sharding for either a concrete JAX array or a JIT tracer.
+
+    Relay helpers are intentionally usable in CPU state tests *and* inside
+    cached device programs.  ``Array.sharding`` is available in the former,
+    whereas a tracer exposes the same information through ``jax.typeof``.
+    """
+    sharding = getattr(value, "sharding", None)
+    return sharding if sharding is not None else jax.typeof(value).sharding
+
+
 class SpecRelayBuffers(NamedTuple):
     topk_index: jax.Array
     hidden_states: jax.Array
     verified_id: jax.Array
     new_seq_lens: jax.Array
+
+
+class SpecSeedRelayBuffers(NamedTuple):
+    """Request-indexed single-token proposal state shared between spec rounds.
+
+    This is intentionally smaller than :class:`SpecRelayBuffers`: top-1
+    speculative algorithms need one verified token, one proposal token, and
+    one hidden state per request.  A Frozen-KV row can be either a normal
+    prefill-origin proposal or a target-verify-origin seed; ``is_target_seed``
+    identifies the latter.  The scheduler owns the request-to-slot mapping;
+    this buffer only preserves device-resident values across that
+    variable-size scheduler boundary.
+    """
+
+    token_ids: jax.Array
+    draft_token_ids: jax.Array
+    hidden_states: jax.Array
+    is_target_seed: jax.Array
 
 
 class DFlashRelayBuffers(NamedTuple):
@@ -55,6 +84,36 @@ def create_spec_relay_buffers(
             jnp.zeros((dp_size, capacity), dtype=jnp.int32),
             id_sharding,
         ),
+    )
+
+
+def create_spec_seed_relay_buffers(
+    mesh,
+    req_to_token_pool,
+    *,
+    dp_size: int,
+    hidden_size: int,
+    hidden_dtype,
+) -> SpecSeedRelayBuffers:
+    """Create DP-local request-indexed buffers for token/hidden seed state.
+
+    A fixed request-pool index is stable while the scheduler merges, filters,
+    and repads a live batch.  Keeping the value storage keyed by that index
+    avoids a host materialization merely to reshape a variable-sized batch.
+    """
+    capacity = int(req_to_token_pool.req_to_token.shape[0])
+    hidden_sharding = NamedSharding(mesh, RELAY_STATE_SPEC)
+    id_sharding = NamedSharding(mesh, RELAY_ID_SPEC)
+    return SpecSeedRelayBuffers(
+        token_ids=jax.device_put(jnp.zeros((dp_size, capacity), dtype=jnp.int32), id_sharding),
+        draft_token_ids=jax.device_put(
+            jnp.zeros((dp_size, capacity), dtype=jnp.int32), id_sharding
+        ),
+        hidden_states=jax.device_put(
+            jnp.zeros((dp_size, capacity, hidden_size), dtype=hidden_dtype),
+            hidden_sharding,
+        ),
+        is_target_seed=jax.device_put(jnp.zeros((dp_size, capacity), dtype=bool), id_sharding),
     )
 
 
@@ -121,6 +180,55 @@ def update_spec_relay_buffers(
             new_seq_lens,
             mode="drop",
             out_sharding=RELAY_ID_SPEC,
+        ),
+    )
+
+
+def update_spec_seed_relay_buffers(
+    buffers: SpecSeedRelayBuffers,
+    future_indices,
+    valid_mask,
+    token_ids,
+    draft_token_ids,
+    hidden_states,
+    is_target_seed,
+    *,
+    dp_size: int,
+) -> SpecSeedRelayBuffers:
+    """Publish DP-padded target seeds without touching invalid padded rows."""
+    per_dp_bs = future_indices.shape[0] // dp_size
+    indices = future_indices.reshape((dp_size, per_dp_bs))
+    valid = valid_mask.reshape((dp_size, per_dp_bs))
+    dp_indices = jnp.arange(dp_size, dtype=jnp.int32)[:, None]
+    scatter_indices = jnp.where(
+        valid,
+        indices,
+        jnp.full_like(indices, buffers.token_ids.shape[1]),
+    )
+    token_ids = token_ids.reshape((dp_size, per_dp_bs))
+    draft_token_ids = draft_token_ids.reshape((dp_size, per_dp_bs))
+    hidden_states = hidden_states.reshape((dp_size, per_dp_bs) + hidden_states.shape[1:])
+    is_target_seed = is_target_seed.reshape((dp_size, per_dp_bs))
+    return SpecSeedRelayBuffers(
+        token_ids=buffers.token_ids.at[dp_indices, scatter_indices].set(
+            token_ids,
+            mode="drop",
+            out_sharding=_array_sharding(buffers.token_ids),
+        ),
+        draft_token_ids=buffers.draft_token_ids.at[dp_indices, scatter_indices].set(
+            draft_token_ids,
+            mode="drop",
+            out_sharding=_array_sharding(buffers.draft_token_ids),
+        ),
+        hidden_states=buffers.hidden_states.at[dp_indices, scatter_indices].set(
+            hidden_states,
+            mode="drop",
+            out_sharding=_array_sharding(buffers.hidden_states),
+        ),
+        is_target_seed=buffers.is_target_seed.at[dp_indices, scatter_indices].set(
+            is_target_seed,
+            mode="drop",
+            out_sharding=_array_sharding(buffers.is_target_seed),
         ),
     )
 
@@ -198,6 +306,39 @@ def gather_spec_relay_buffers(
         verified_id = jax.sharding.reshard(verified_id, flat_sharding)
         new_seq_lens = jax.sharding.reshard(new_seq_lens, flat_sharding)
     return topk_index, hidden_states, verified_id, new_seq_lens
+
+
+def gather_spec_seed_relay_buffers(
+    buffers: SpecSeedRelayBuffers,
+    future_indices,
+    *,
+    dp_size: int,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    """Gather one-token proposal state into the next DP-padded draft batch."""
+    per_dp_bs = future_indices.shape[0] // dp_size
+    indices = future_indices.reshape((dp_size, per_dp_bs))
+    dp_indices = jnp.arange(dp_size, dtype=jnp.int32)[:, None]
+    token_ids = (
+        buffers.token_ids.at[dp_indices, indices]
+        .get(out_sharding=_array_sharding(buffers.token_ids))
+        .reshape(future_indices.shape)
+    )
+    draft_token_ids = (
+        buffers.draft_token_ids.at[dp_indices, indices]
+        .get(out_sharding=_array_sharding(buffers.draft_token_ids))
+        .reshape(future_indices.shape)
+    )
+    hidden_states = (
+        buffers.hidden_states.at[dp_indices, indices]
+        .get(out_sharding=_array_sharding(buffers.hidden_states))
+        .reshape(future_indices.shape + buffers.hidden_states.shape[2:])
+    )
+    is_target_seed = (
+        buffers.is_target_seed.at[dp_indices, indices]
+        .get(out_sharding=_array_sharding(buffers.is_target_seed))
+        .reshape(future_indices.shape)
+    )
+    return token_ids, draft_token_ids, hidden_states, is_target_seed
 
 
 def gather_dflash_relay_buffers(

--- a/python/sgl_jax/srt/speculative/spec_info.py
+++ b/python/sgl_jax/srt/speculative/spec_info.py
@@ -60,6 +60,7 @@ class SpeculativeAlgorithm(IntEnum):
     EAGLE = auto()
     EAGLE3 = auto()
     NEXTN = auto()
+    FROZEN_KV_MTP = auto()
     STANDALONE = auto()
     DFLASH = auto()
 
@@ -67,10 +68,17 @@ class SpeculativeAlgorithm(IntEnum):
         return self == SpeculativeAlgorithm.NONE
 
     def is_eagle(self):
+        # FROZEN_KV_MTP is included for the same reason EAGLE3 and NEXTN are:
+        # it shares EAGLE's chain-verify token accounting at every gate site.
+        # Mirrors upstream sgl-project/sglang, whose is_eagle() also covers it
+        # (with a FIXME to drop it once their scheduler supports it natively).
+        # Only the KV pool differs, and that is handled by the draft worker,
+        # not by these predicates.
         return self in (
             SpeculativeAlgorithm.EAGLE,
             SpeculativeAlgorithm.EAGLE3,
             SpeculativeAlgorithm.NEXTN,
+            SpeculativeAlgorithm.FROZEN_KV_MTP,
         )
 
     def is_eagle3(self):
@@ -78,6 +86,9 @@ class SpeculativeAlgorithm(IntEnum):
 
     def is_nextn(self):
         return self == SpeculativeAlgorithm.NEXTN
+
+    def is_frozen_kv_mtp(self):
+        return self == SpeculativeAlgorithm.FROZEN_KV_MTP
 
     def is_standalone(self):
         return self == SpeculativeAlgorithm.STANDALONE
@@ -91,6 +102,7 @@ class SpeculativeAlgorithm(IntEnum):
             "EAGLE": SpeculativeAlgorithm.EAGLE,
             "EAGLE3": SpeculativeAlgorithm.EAGLE3,
             "NEXTN": SpeculativeAlgorithm.NEXTN,
+            "FROZEN_KV_MTP": SpeculativeAlgorithm.FROZEN_KV_MTP,
             "STANDALONE": SpeculativeAlgorithm.STANDALONE,
             "DFLASH": SpeculativeAlgorithm.DFLASH,
             None: SpeculativeAlgorithm.NONE,

--- a/python/sgl_jax/test/models/test_gemma4_mtp.py
+++ b/python/sgl_jax/test/models/test_gemma4_mtp.py
@@ -1,0 +1,557 @@
+"""Unit tests for the Gemma4 MTP draft model.
+
+Hub-free, mirroring ``test_qwen3_5`` / ``test_mimo_v2_nextn``: the config is
+built in-process from the real ``google/gemma-4-12B-it-assistant``
+``config.json`` scalars, with the real value noted beside each shrunk one (no
+``from_pretrained`` / ``hf_hub_download``, so it never skips on an offline
+runner). Dims are shrunk to keep module construction cheap on CPU; every
+structural value and every *relationship* between values is verbatim, because
+those are what the model actually branches on.
+
+Two relationships in particular must survive shrinking, since collapsing either
+one hides a real defect:
+  * ``backbone_hidden_size != hidden_size`` -- equal values make a missing
+    post_projection dimensionally invisible.
+  * ``global_head_dim != head_dim`` -- equal values hide which one a layer picks.
+
+Re-snapshot from the checkpoint if a future revision renames or adds keys.
+
+Run on CPU with simulated devices:
+    JAX_PLATFORMS=cpu XLA_FLAGS=--xla_force_host_platform_device_count=4 \\
+      python -m pytest python/sgl_jax/test/models/test_gemma4_mtp.py -v
+"""
+
+import os
+
+os.environ.setdefault("XLA_FLAGS", "--xla_force_host_platform_device_count=4")
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+from sgl_jax.srt.configs.gemma4 import Gemma4UnifiedAssistantConfig
+from sgl_jax.srt.models.gemma4_mtp import (
+    Gemma4AssistantForCausalLM,
+    Gemma4MTPAttention,
+    Gemma4MTPDecoderLayer,
+    Gemma4UnifiedAssistantForCausalLM,
+)
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+
+# Single-device mesh with explicit axis types for unit tests.
+MESH = create_device_mesh(ici_parallelism=[1, -1], dcn_parallelism=[1, 1])
+
+# Real layer_types of the 12B assistant: three local layers then one global.
+# Verbatim -- layer 0 is sliding and layer 3 is full, which is what the
+# per-layer-type head_dim / KV-head / RoPE branches key off.
+REAL_LAYER_TYPES = ["sliding_attention"] * 3 + ["full_attention"]
+SLIDING_LAYER_ID = 0
+FULL_LAYER_ID = 3
+
+# text_config. HF names the *sliding* variant unprefixed and the full-attention
+# variant with a `global_` prefix; Gemma4Config remaps them to swa_head_dim /
+# head_dim, so building through that class exercises the remap too.
+_TEXT_CONFIG = {
+    "hidden_size": 128,  # real 1024
+    "intermediate_size": 256,  # real 8192
+    "num_attention_heads": 4,  # real 16
+    "head_dim": 128,  # real 256  (sliding; 128-aligned, see merge_kv)
+    "global_head_dim": 256,  # real 512  (full; kept 2x the sliding one)
+    "num_key_value_heads": 2,  # real 8    (sliding)
+    "num_global_key_value_heads": 1,  # real 1    (full) -- verbatim
+    "vocab_size": 256,  # real 262144
+    "max_position_embeddings": 4096,  # real 262144
+    "num_hidden_layers": 4,  # verbatim
+    "num_kv_shared_layers": 4,  # verbatim -- every draft layer is KV-shared
+    "layer_types": REAL_LAYER_TYPES,  # verbatim
+    "sliding_window": 1024,  # verbatim
+    "attention_k_eq_v": True,  # verbatim
+    "attention_bias": False,  # verbatim
+    "rms_norm_eps": 1e-6,  # verbatim
+    "tie_word_embeddings": True,  # verbatim
+    "final_logit_softcapping": None,  # verbatim
+    "rope_parameters": {  # verbatim
+        "full_attention": {
+            "partial_rotary_factor": 0.25,
+            "rope_theta": 1000000.0,
+            "rope_type": "proportional",
+        },
+        "sliding_attention": {"rope_theta": 10000.0, "rope_type": "default"},
+    },
+}
+
+# Top-level keys (siblings of text_config in the real file).
+_TOP_CONFIG = {
+    "backbone_hidden_size": 384,  # real 3840 = the target's hidden_size
+    "use_ordered_embeddings": False,  # verbatim
+    "num_centroids": 16,  # real 2048
+    "centroid_intermediate_top_k": 4,  # real 32
+    "tie_word_embeddings": True,  # verbatim
+}
+
+# tie_word_embeddings is excluded: it appears at BOTH levels in the real file,
+# and the model reads it off text_config, so it must not route top-level only.
+_TOP_LEVEL_KEYS = frozenset(_TOP_CONFIG) - {"tie_word_embeddings"}
+
+BACKBONE_HIDDEN = _TOP_CONFIG["backbone_hidden_size"]
+DRAFT_HIDDEN = _TEXT_CONFIG["hidden_size"]
+VOCAB = _TEXT_CONFIG["vocab_size"]
+
+
+def _make_config(**overrides) -> Gemma4UnifiedAssistantConfig:
+    """Real 12B assistant config with dims shrunk; overrides route by key."""
+    text = dict(_TEXT_CONFIG)
+    top = dict(_TOP_CONFIG)
+    for key, value in overrides.items():
+        if key in _TOP_LEVEL_KEYS:
+            top[key] = value
+        else:
+            text[key] = value
+    # Present at both levels in the real file; keep them in sync.
+    if "tie_word_embeddings" in overrides:
+        top["tie_word_embeddings"] = overrides["tie_word_embeddings"]
+    return Gemma4UnifiedAssistantConfig(text_config=text, **top)
+
+
+def _text_config(**overrides):
+    """The remapped text_config, for constructing a layer/attention directly."""
+    return _make_config(**overrides).text_config
+
+
+class TestConfigRemap:
+    """HF names the sliding variant unprefixed and the full one `global_`.
+
+    Gemma4Config swaps them into (head_dim = full, swa_head_dim = sliding).
+    Getting that backwards is silent -- attention still builds, just with the
+    wrong head width -- so it is pinned against the real checkpoint's values.
+    """
+
+    def test_global_becomes_head_dim(self):
+        tc = _text_config()
+        assert tc.head_dim == _TEXT_CONFIG["global_head_dim"]  # full
+        assert tc.swa_head_dim == _TEXT_CONFIG["head_dim"]  # sliding
+
+    def test_global_becomes_num_key_value_heads(self):
+        tc = _text_config()
+        assert tc.num_key_value_heads == _TEXT_CONFIG["num_global_key_value_heads"]
+        assert tc.swa_num_key_value_heads == _TEXT_CONFIG["num_key_value_heads"]
+
+    def test_remap_is_not_applied_twice(self):
+        """_gemma4_remapped guards it; a second pass would swap them back."""
+        cfg = _make_config()
+        first = (cfg.text_config.head_dim, cfg.text_config.swa_head_dim)
+        Gemma4UnifiedAssistantConfig(text_config=cfg.text_config)
+        assert (cfg.text_config.head_dim, cfg.text_config.swa_head_dim) == first
+
+    def test_the_two_head_dims_differ(self):
+        """Guard the fixture itself: equal values would make the swap untestable."""
+        assert _TEXT_CONFIG["head_dim"] != _TEXT_CONFIG["global_head_dim"]
+
+
+class TestPerLayerTypeGeometry:
+    """Each layer picks head_dim / KV heads by its own attention type."""
+
+    def _attn(self, layer_id):
+        with jax.set_mesh(MESH):
+            return Gemma4MTPAttention(
+                config=_text_config(),
+                layer_id=layer_id,
+                max_position_embeddings=4096,
+                attention_bias=False,
+                dtype=jnp.bfloat16,
+                mesh=MESH,
+            )
+
+    def test_full_layer_uses_global_geometry(self):
+        attn = self._attn(FULL_LAYER_ID)
+        assert attn.head_dim == _TEXT_CONFIG["global_head_dim"]
+        # attention_k_eq_v is true, so a full layer takes the global KV count.
+        assert attn.num_kv_heads == _TEXT_CONFIG["num_global_key_value_heads"]
+
+    def test_sliding_layer_uses_local_geometry(self):
+        attn = self._attn(SLIDING_LAYER_ID)
+        assert attn.head_dim == _TEXT_CONFIG["head_dim"]
+        assert attn.num_kv_heads == _TEXT_CONFIG["num_key_value_heads"]
+
+    def test_layers_of_different_types_disagree(self):
+        """The whole point of the KV-share map: a draft layer may only read a
+        target layer of its own attention type."""
+        full, sliding = self._attn(FULL_LAYER_ID), self._attn(SLIDING_LAYER_ID)
+        assert (full.head_dim, full.num_kv_heads) != (
+            sliding.head_dim,
+            sliding.num_kv_heads,
+        )
+
+    def test_rope_differs_per_layer_type(self):
+        """Real rope_parameters: full is 'proportional' at 1e6, sliding
+        'default' at 1e4. A single shared RoPE would be wrong for one of them."""
+        full, sliding = self._attn(FULL_LAYER_ID), self._attn(SLIDING_LAYER_ID)
+        assert full.rotary_emb is not sliding.rotary_emb
+        assert full.head_dim != sliding.head_dim
+
+
+class TestGemma4MTPAttention:
+    """Tests for the Q-only MTP attention layer."""
+
+    def test_construction_full_attention(self):
+        config = _text_config()
+        with jax.set_mesh(MESH):
+            attn = Gemma4MTPAttention(
+                config=config,
+                layer_id=FULL_LAYER_ID,
+                max_position_embeddings=4096,
+                attention_bias=False,
+                dtype=jnp.bfloat16,
+                mesh=MESH,
+            )
+        assert attn.is_sliding is False
+        assert attn.layer_type == "full_attention"
+        assert attn.sliding_window == 0
+
+    def test_construction_sliding_attention(self):
+        config = _text_config()
+        with jax.set_mesh(MESH):
+            attn = Gemma4MTPAttention(
+                config=config,
+                layer_id=SLIDING_LAYER_ID,
+                max_position_embeddings=4096,
+                attention_bias=False,
+                dtype=jnp.bfloat16,
+                mesh=MESH,
+            )
+        assert attn.is_sliding is True
+        assert attn.layer_type == "sliding_attention"
+        assert attn.sliding_window == 1024
+
+
+class TestGemma4MTPDecoderLayer:
+    """Tests for the MTP decoder layer."""
+
+    def test_construction(self):
+        config = _text_config()
+        with jax.set_mesh(MESH):
+            layer = Gemma4MTPDecoderLayer(
+                config=config,
+                mesh=MESH,
+                layer_id=0,
+                dtype=jnp.bfloat16,
+            )
+        assert layer.layer_id == 0
+        assert layer.self_attn is not None
+        assert layer.mlp is not None
+
+
+class TestGemma4AssistantForCausalLM:
+    """Tests for the top-level Gemma4 assistant (MTP) model."""
+
+    def test_construction(self):
+        config = _make_config()
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(
+                config=config,
+                mesh=MESH,
+                dtype=jnp.bfloat16,
+            )
+        assert model.num_mtp_layers == 4
+        assert len(model.layers) == 4
+        assert model.normalizer == BACKBONE_HIDDEN**0.5
+        # tie_word_embeddings=True → lm_head is not created
+        assert not hasattr(model, "lm_head") or model.lm_head is None
+
+    def test_construction_with_separate_lm_head(self):
+        config = _make_config(tie_word_embeddings=False)
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(
+                config=config,
+                mesh=MESH,
+                dtype=jnp.bfloat16,
+            )
+        assert model.lm_head is not None
+
+    def test_construction_with_ordered_embeddings(self):
+        config = _make_config(
+            use_ordered_embeddings=True,
+            num_centroids=16,
+            centroid_intermediate_top_k=4,
+        )
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(
+                config=config,
+                mesh=MESH,
+                dtype=jnp.bfloat16,
+            )
+        assert model.masked_centroids is not None
+        assert model.masked_num_centroids == 16
+        assert model.masked_vocab_size_per_centroid == VOCAB // 16
+
+    def test_get_embed_and_head(self):
+        config = _make_config(tie_word_embeddings=False)
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(
+                config=config,
+                mesh=MESH,
+                dtype=jnp.bfloat16,
+            )
+        embed, head = model.get_embed_and_head()
+        assert embed is not None
+        assert head is not None
+
+    def test_set_embed(self):
+        config = _make_config()
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(
+                config=config,
+                mesh=MESH,
+                dtype=jnp.bfloat16,
+            )
+        new_embed = nnx.Param(jnp.ones((VOCAB, BACKBONE_HIDDEN), dtype=jnp.bfloat16))
+        model.set_embed(new_embed)  # no-op, shouldn't crash
+
+    def test_set_embed_and_head(self):
+        config = _make_config()
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(
+                config=config,
+                mesh=MESH,
+                dtype=jnp.bfloat16,
+            )
+        target_embed = nnx.Param(jnp.ones((VOCAB, BACKBONE_HIDDEN), dtype=jnp.bfloat16))
+        target_head = nnx.Param(jnp.ones((VOCAB, BACKBONE_HIDDEN), dtype=jnp.bfloat16))
+        model.set_embed_and_head(target_embed, target_head)
+        assert model._target_embed_weight is target_embed
+
+    def test_checkpoint_keys_match_the_real_assistant_layout(self):
+        """Pin the exact HF key names, which are NOT uniformly prefixed.
+
+        Read off the safetensors header of google/gemma-4-31B-it-assistant:
+
+            pre_projection.weight          [1024, 10752]   <- top level
+            post_projection.weight         [5376, 1024]    <- top level
+            model.embed_tokens.weight      [262144, 1024]  <- model. prefix
+            model.norm.weight              [1024]          <- model. prefix
+
+        A mapping key that matches nothing fails SILENTLY: the parameter stays a
+        ShapeDtypeStruct placeholder, model_runner swaps it for an empty array,
+        the model reports "loaded successfully", and the first forward dies in
+        dot_general with a (0,) contracting dimension. Nothing else in the suite
+        catches that, because module shapes are correct either way.
+        """
+        config = _make_config()
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(config=config, mesh=MESH, dtype=jnp.bfloat16)
+        mappings = model._create_weight_mappings()
+
+        for key in ("pre_projection.weight", "post_projection.weight"):
+            assert key in mappings, f"{key} is top-level in the checkpoint"
+            assert (
+                f"model.{key}" not in mappings
+            ), f"model.{key} matches no tensor in the checkpoint"
+
+        for key in ("model.embed_tokens.weight", "model.norm.weight"):
+            assert key in mappings, f"{key} carries the model. prefix in the checkpoint"
+
+    def test_weight_mappings_exist(self):
+        config = _make_config()
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(
+                config=config,
+                mesh=MESH,
+                dtype=jnp.bfloat16,
+            )
+        mappings = model._create_weight_mappings()
+        assert len(mappings) > 0
+        # All 4 layers have mappings (HF keys use model.layers. prefix)
+        for layer_idx in range(4):
+            prefix = f"model.layers.{layer_idx}"
+            assert any(
+                k.startswith(prefix) for k in mappings
+            ), f"Missing weight mappings for layer {layer_idx}"
+        # mtp. prefix aliases exist
+        assert any(k.startswith("mtp.") for k in mappings)
+        # Target paths use the inlined (flat) structure
+        target_paths = {v.target_path for v in mappings.values()}
+        assert any(
+            p.startswith("layers.0.") for p in target_paths
+        ), "Expected target_paths to use flat 'layers.N.' prefix"
+
+    def test_softcapping(self):
+        config = _make_config(final_logit_softcapping=50.0)
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(
+                config=config,
+                mesh=MESH,
+                dtype=jnp.bfloat16,
+            )
+        assert model.final_logit_softcapping == 50.0
+
+    def test_compute_logits_masked(self):
+        config = _make_config(
+            use_ordered_embeddings=True,
+            num_centroids=16,
+            centroid_intermediate_top_k=4,
+            tie_word_embeddings=False,
+        )
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(
+                config=config,
+                mesh=MESH,
+                dtype=jnp.float32,
+            )
+            assert model.masked_centroids is not None
+
+            @jax.jit
+            def _compute(m, h):
+                return m.compute_logits(h)
+
+            hidden = jnp.ones((1, DRAFT_HIDDEN), dtype=jnp.float32)
+            logits = _compute(model, hidden)
+            assert logits.shape == (1, VOCAB)
+
+    def test_compute_logits_lm_head(self):
+        config = _make_config(
+            tie_word_embeddings=False,
+            use_ordered_embeddings=False,
+        )
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(
+                config=config,
+                mesh=MESH,
+                dtype=jnp.float32,
+            )
+
+            @jax.jit
+            def _compute(m, h):
+                return m.compute_logits(h)
+
+            hidden = jnp.ones((1, DRAFT_HIDDEN), dtype=jnp.float32)
+            logits = _compute(model, hidden)
+            assert logits.shape == (1, VOCAB)
+
+    def test_select_and_score_shapes(self):
+        config = _make_config(
+            use_ordered_embeddings=True,
+            num_centroids=16,
+            centroid_intermediate_top_k=4,
+        )
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(
+                config=config,
+                mesh=MESH,
+                dtype=jnp.float32,
+            )
+
+            @jax.jit
+            def _compute(m, h, w):
+                return m._select_and_score(h, w)
+
+            bs = 2
+            hidden = jnp.ones((bs, DRAFT_HIDDEN), dtype=jnp.float32)
+            lm_head_weight = jnp.ones((VOCAB, DRAFT_HIDDEN), dtype=jnp.float32)
+            logits, indices = _compute(model, hidden, lm_head_weight)
+            assert logits.shape == (bs, 4 * (VOCAB // 16))
+            assert indices.shape == (bs, 4 * (VOCAB // 16))
+
+
+class TestProjectionContract:
+    """The draft's hidden lives in two spaces and the projections move between them.
+
+    ``pre_projection`` takes [target_embed(bb) ; target_hidden(bb)] -> hidden_size.
+    ``post_projection`` takes hidden_size -> bb, because the captured hidden is fed
+    back as the NEXT draft step's ``spec_info.hidden_states`` and re-enters
+    ``pre_projection``. Every earlier test used backbone_hidden_size == hidden_size,
+    which makes a missing post_projection invisible; these do not.
+    """
+
+    BB = 128
+    HIDDEN = 256
+
+    def _model(self, **overrides):
+        config = _make_config(
+            hidden_size=self.HIDDEN,
+            backbone_hidden_size=self.BB,
+            **overrides,
+        )
+        with jax.set_mesh(MESH):
+            return Gemma4AssistantForCausalLM(config=config, mesh=MESH, dtype=jnp.float32)
+
+    def test_pre_projection_consumes_two_backbone_vectors(self):
+        model = self._model()
+        assert model.pre_projection.weight.value.shape == (2 * self.BB, self.HIDDEN)
+
+    def test_post_projection_returns_to_backbone_space(self):
+        model = self._model()
+        assert model.post_projection.weight.value.shape == (self.HIDDEN, self.BB)
+
+    def test_post_projection_round_trip_shape(self):
+        """A draft hidden must come out of post_projection sized for pre_projection."""
+        model = self._model()
+        with jax.set_mesh(MESH):
+            draft_hidden = jnp.ones((3, self.HIDDEN), dtype=jnp.float32)
+            projected, _ = model.post_projection(draft_hidden)
+        assert projected.shape == (3, self.BB)
+
+        # The fed-back hidden concatenated with a backbone-dim embedding must be
+        # exactly what pre_projection accepts — this is the invariant that broke
+        # when post_projection was never called.
+        embed = jnp.ones((3, self.BB), dtype=jnp.float32)
+        combined = jnp.concatenate([embed, projected], axis=-1)
+        assert combined.shape[-1] == model.pre_projection.weight.value.shape[0]
+
+    def test_normalizer_uses_backbone_dim(self):
+        """Token embedding comes from the TARGET, so it scales by sqrt(bb)."""
+        model = self._model()
+        assert model.normalizer == self.BB**0.5
+
+
+class TestSharedEmbedWiring:
+    """The draft worker binds the target's embedding through a shared helper.
+
+    That helper calls set_embed_and_head() only when the model declares
+    load_lm_head_from_target, and set_embed() otherwise -- which is a no-op
+    here. Without the flag nothing binds and the first forward raises. Nothing
+    else in the suite exercises the flag, so it is pinned directly.
+    """
+
+    def test_declares_load_lm_head_from_target(self):
+        assert Gemma4AssistantForCausalLM.load_lm_head_from_target is True
+        assert Gemma4UnifiedAssistantForCausalLM.load_lm_head_from_target is True
+
+    def test_worker_shared_embed_path_actually_binds(self):
+        """Replays the branch the draft worker takes, rather than trusting it."""
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(config=_make_config(), mesh=MESH, dtype=jnp.bfloat16)
+        embed = nnx.Param(jnp.ones((VOCAB, BACKBONE_HIDDEN), dtype=jnp.bfloat16))
+        head = nnx.Param(jnp.ones((VOCAB, DRAFT_HIDDEN), dtype=jnp.bfloat16))
+
+        if getattr(model, "load_lm_head_from_target", False):
+            model.set_embed_and_head(embed, head)
+        else:
+            model.set_embed(embed)
+
+        assert getattr(model, "_target_embed_weight", None) is embed
+
+    def test_set_embed_alone_is_insufficient(self):
+        """Why the flag matters: the single-arg setter binds nothing."""
+        with jax.set_mesh(MESH):
+            model = Gemma4AssistantForCausalLM(config=_make_config(), mesh=MESH, dtype=jnp.bfloat16)
+        model.set_embed(nnx.Param(jnp.ones((VOCAB, BACKBONE_HIDDEN), dtype=jnp.bfloat16)))
+        assert getattr(model, "_target_embed_weight", None) is None
+
+
+class TestGemma4UnifiedAssistantForCausalLM:
+    """Tests for the unified assistant pass-through alias."""
+
+    def test_is_subclass(self):
+        assert issubclass(Gemma4UnifiedAssistantForCausalLM, Gemma4AssistantForCausalLM)
+
+    def test_construction(self):
+        config = _make_config()
+        with jax.set_mesh(MESH):
+            model = Gemma4UnifiedAssistantForCausalLM(
+                config=config,
+                mesh=MESH,
+                dtype=jnp.bfloat16,
+            )
+        assert isinstance(model, Gemma4AssistantForCausalLM)
+        assert model.num_mtp_layers == 4

--- a/python/sgl_jax/test/speculative/test_eagle_utils.py
+++ b/python/sgl_jax/test/speculative/test_eagle_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import jax
@@ -15,6 +16,53 @@ from sgl_jax.test.test_utils import CustomTestCase
 
 
 class TestVerifyTree(CustomTestCase):
+    @staticmethod
+    def _frozen_args(**overrides):
+        from sgl_jax.srt.server_args import ServerArgs
+
+        kwargs = dict(
+            model_path="target",
+            speculative_algorithm="FROZEN_KV_MTP",
+            speculative_draft_model_path="draft",
+            speculative_num_steps=3,
+            speculative_num_draft_tokens=4,
+            speculative_eagle_topk=1,
+            disable_overlap_schedule=True,
+            grammar_backend="none",
+        )
+        kwargs.update(overrides)
+        args = ServerArgs(**kwargs)
+        args.get_speculative_draft_hf_config = Mock(
+            return_value=SimpleNamespace(architectures=["Gemma4AssistantForCausalLM"])
+        )
+        return args
+
+    def test_frozen_kv_mtp_server_args_accept_supported_chain(self):
+        self._frozen_args().check_server_args()
+
+    def test_gemma4_nextn_promotes_to_frozen_kv_mtp(self):
+        args = self._frozen_args(speculative_algorithm="NEXTN")
+
+        args.check_server_args()
+
+        self.assertEqual(args.speculative_algorithm, "FROZEN_KV_MTP")
+
+    def test_frozen_kv_mtp_server_args_reject_branching_tree(self):
+        with self.assertRaisesRegex(ValueError, "speculative-eagle-topk=1"):
+            self._frozen_args(speculative_eagle_topk=2).check_server_args()
+
+    def test_frozen_kv_mtp_server_args_reject_wrong_chain_width(self):
+        with self.assertRaisesRegex(ValueError, "speculative-num-draft-tokens"):
+            self._frozen_args(speculative_num_draft_tokens=6).check_server_args()
+
+    def test_frozen_kv_mtp_server_args_reject_other_architecture(self):
+        args = self._frozen_args()
+        args.get_speculative_draft_hf_config.return_value = SimpleNamespace(
+            architectures=["LlamaForCausalLM"]
+        )
+        with self.assertRaisesRegex(ValueError, "supported Gemma 4 assistant"):
+            args.check_server_args()
+
     def test_eagle3_overlap_server_args_allow_linear_fa(self):
         from sgl_jax.srt.server_args import ServerArgs
 

--- a/python/sgl_jax/test/speculative/test_frozen_kv_mtp_merge.py
+++ b/python/sgl_jax/test/speculative/test_frozen_kv_mtp_merge.py
@@ -1,0 +1,269 @@
+"""CPU tests for Frozen-KV MTP's non-overlap batch-merge contract."""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from sgl_jax.srt.managers.schedule_batch import ScheduleBatch, ScheduleReqsInfo
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+from sgl_jax.srt.speculative.frozen_kv_mtp_seed import FrozenKvMtpSeedState
+from sgl_jax.srt.speculative.frozen_kv_mtp_worker import (
+    FrozenKvMtpDraftInput,
+    FrozenKvMtpDraftWorker,
+)
+from sgl_jax.srt.speculative.overlap_utils import can_merge_spec_non_overlap_prefill
+from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+
+def _state(rows: list[tuple[int, int, int, int]]) -> FrozenKvMtpDraftInput:
+    """Build rows of (verified_token, hidden_tag, allocated, committed)."""
+    verified, hidden, allocated, committed = map(np.asarray, zip(*rows, strict=True))
+    return FrozenKvMtpDraftInput(
+        topk_p=verified[:, None].astype(np.float32) / 100,
+        topk_index=(verified + 1)[:, None].astype(np.int32),
+        hidden_states=hidden[:, None].astype(np.float32),
+        verified_id=verified.astype(np.int32),
+        accept_length=np.full(len(rows), 2, dtype=np.int32),
+        accept_length_cpu=np.full(len(rows), 2, dtype=np.int32),
+        allocate_lens=allocated.astype(np.int32),
+        new_seq_lens=committed.astype(np.int32),
+    )
+
+
+def _batch(rows: list[tuple[int, int, int, int]]) -> ScheduleBatch:
+    """Minimal single-rank batch exercising the production merge method."""
+
+    class Req:
+        lora_id = "0"
+
+    info = ScheduleReqsInfo()
+    info.reqs = [Req() for _ in rows]
+    info.req_pool_indices = np.arange(len(rows), dtype=np.int32)
+    info.seq_lens = np.asarray([row[3] for row in rows], dtype=np.int32)
+    info.seq_lens_sum = int(info.seq_lens.sum())
+    info.out_cache_loc = None
+    info.output_ids = None
+    info.top_logprobs_nums = None
+    info.token_ids_logprobs = None
+    info.sampling_info = None
+    info.spec_info = _state(rows)
+
+    batch = ScheduleBatch.__new__(ScheduleBatch)
+    batch.__dict__.update(
+        dp_size=1,
+        reqs_info=[info],
+        forward_mode=ForwardMode.DECODE,
+        return_logprob=False,
+        return_output_logprob_only=False,
+        return_hidden_states=False,
+        has_stream=False,
+        has_grammar=False,
+    )
+    return batch
+
+
+def test_frozen_kv_merge_keeps_token_seed_and_kv_length_rows_together():
+    running = _state([(11, 101, 128, 127)])
+    prefill = _state([(22, 202, 256, 255), (33, 303, 384, 383)])
+
+    running.merge_batch(prefill)
+
+    np.testing.assert_array_equal(running.verified_id, [11, 22, 33])
+    np.testing.assert_array_equal(running.hidden_states[:, 0], [101, 202, 303])
+    np.testing.assert_array_equal(running.allocate_lens, [128, 256, 384])
+    np.testing.assert_array_equal(running.new_seq_lens, [127, 255, 383])
+    np.testing.assert_array_equal(running.accept_length, [2, 2, 2])
+
+
+def test_frozen_kv_merge_allows_prefill_without_accept_length_and_preserves_its_input():
+    """GSM8K c32 merges a verified decode batch with a fresh prefill batch."""
+    running = _state([(11, 101, 128, 127)])
+    running.seed_state = FrozenKvMtpSeedState(
+        bonus_token=jnp.asarray([99], dtype=jnp.int32),
+        target_hidden=jnp.asarray([[909]], dtype=jnp.float32),
+        committed_lens=jnp.asarray([127], dtype=jnp.int32),
+        allocate_lens=jnp.asarray([128], dtype=jnp.int32),
+        request_indices=jnp.asarray([5], dtype=jnp.int32),
+        valid_mask=jnp.asarray([True]),
+    )
+    prefill = _state([(22, 202, 256, 255)])
+    prefill.accept_length = None
+    prefill.accept_length_cpu = None
+
+    running.merge_batch(prefill)
+
+    assert running.accept_length is None
+    assert running.accept_length_cpu is None
+    np.testing.assert_array_equal(running.seed_state.valid_mask, [True, False])
+
+    worker = FrozenKvMtpDraftWorker.__new__(FrozenKvMtpDraftWorker)
+    batch = type(
+        "Batch",
+        (),
+        {
+            "spec_info_padded": running,
+            "logits_indices_selector": np.asarray([0, 1], dtype=np.int32),
+        },
+    )()
+    worker._prepare_seed_proposal(batch)
+
+    # Existing decoded request consumes its target seed; the new prefill keeps
+    # its own generic draft token/hidden state until it is verified once.
+    np.testing.assert_array_equal(running.verified_id, [99, 22])
+    np.testing.assert_array_equal(running.hidden_states[:, 0], [909, 202])
+    assert running.seed_state is None
+
+
+def test_frozen_kv_state_remains_a_jax_pytree_after_its_specialization():
+    state = _state([(11, 101, 128, 127)])
+
+    leaves, treedef = jax.tree_util.tree_flatten(state)
+    restored = jax.tree_util.tree_unflatten(treedef, leaves)
+
+    assert isinstance(restored, FrozenKvMtpDraftInput)
+    np.testing.assert_array_equal(restored.verified_id, [11])
+    np.testing.assert_array_equal(restored.allocate_lens, [128])
+    np.testing.assert_array_equal(restored.new_seq_lens, [127])
+    np.testing.assert_array_equal(restored.accept_length, [2])
+    np.testing.assert_array_equal(restored.accept_length_cpu, [2])
+
+
+def test_frozen_kv_filter_retract_keeps_page_boundary_metadata_aligned():
+    # The entries deliberately land in distinct 128-token page ranges.  A
+    # retraction must remove every matching state row, not only draft logits.
+    state = _state(
+        [
+            (11, 101, 128, 127),
+            (22, 202, 256, 255),
+            (33, 303, 384, 383),
+        ]
+    )
+
+    state.filter_batch(np.array([2, 0], dtype=np.int32), has_been_filtered=False)
+
+    np.testing.assert_array_equal(state.verified_id, [33, 11])
+    np.testing.assert_array_equal(state.hidden_states[:, 0], [303, 101])
+    np.testing.assert_array_equal(state.allocate_lens, [384, 128])
+    np.testing.assert_array_equal(state.new_seq_lens, [383, 127])
+    np.testing.assert_array_equal(state.accept_length_cpu, [2, 2])
+
+
+def test_schedule_batch_merge_uses_the_frozen_contract_for_prefill_admission():
+    running = _batch([(11, 101, 128, 127)])
+    prefill = _batch([(22, 202, 256, 255)])
+
+    running.merge_batch(prefill)
+
+    info = running.reqs_info[0]
+    assert len(info.reqs) == 2
+    assert isinstance(info.spec_info, FrozenKvMtpDraftInput)
+    np.testing.assert_array_equal(info.spec_info.verified_id, [11, 22])
+    np.testing.assert_array_equal(info.spec_info.allocate_lens, [128, 256])
+    np.testing.assert_array_equal(info.seq_lens, [127, 255])
+
+
+def test_frozen_kv_state_round_trips_through_dp_scatter_and_split():
+    flat = _state([(11, 101, 128, 127), (22, 202, 256, 255), (33, 303, 384, 383)])
+    padded = ScheduleBatch._scatter_spec_info_to_dp_slots(
+        flat, selector=np.array([0, 1, 3], dtype=np.int32), total_bs=4
+    )
+    assert isinstance(padded, FrozenKvMtpDraftInput)
+
+    # The worker compacts its padded output using the same selector before the
+    # scheduler splits it back to per-DP-rank state.
+    selector = np.array([0, 1, 3], dtype=np.int32)
+    compact = FrozenKvMtpDraftInput(
+        topk_p=np.asarray(padded.topk_p)[selector],
+        topk_index=np.asarray(padded.topk_index)[selector],
+        hidden_states=np.asarray(padded.hidden_states)[selector],
+        verified_id=np.asarray(padded.verified_id)[selector],
+        accept_length=np.asarray(padded.accept_length)[selector],
+        accept_length_cpu=np.asarray(padded.accept_length_cpu)[selector],
+        allocate_lens=np.asarray(padded.allocate_lens)[selector],
+        new_seq_lens=np.asarray(padded.new_seq_lens)[selector],
+    )
+    rank0, rank1 = ScheduleBatch._split_spec_info_per_rank(compact, [2, 1])
+    for state, tokens, allocated in ((rank0, [11, 22], [128, 256]), (rank1, [33], [384])):
+        assert isinstance(state, FrozenKvMtpDraftInput)
+        np.testing.assert_array_equal(state.verified_id, tokens)
+        np.testing.assert_array_equal(state.allocate_lens, allocated)
+
+
+def test_frozen_kv_non_overlap_admission_is_allowed_only_for_its_checked_state_path():
+    assert can_merge_spec_non_overlap_prefill(False, SpeculativeAlgorithm.FROZEN_KV_MTP)
+    assert not can_merge_spec_non_overlap_prefill(True, SpeculativeAlgorithm.FROZEN_KV_MTP)
+    assert not can_merge_spec_non_overlap_prefill(False, SpeculativeAlgorithm.NEXTN)
+
+
+def test_frozen_kv_merge_rejects_missing_or_mismatched_state():
+    running = _state([(11, 101, 128, 127)])
+    incomplete = FrozenKvMtpDraftInput(
+        topk_p=np.ones((1, 1), dtype=np.float32),
+        topk_index=np.ones((1, 1), dtype=np.int32),
+        hidden_states=np.ones((1, 1), dtype=np.float32),
+        verified_id=np.ones((1,), dtype=np.int32),
+        allocate_lens=np.array([127], dtype=np.int32),
+        new_seq_lens=np.array([128], dtype=np.int32),
+    )
+    with pytest.raises(ValueError, match="shorter than its committed sequence length"):
+        running.merge_batch(incomplete)
+
+
+def test_frozen_kv_relay_descriptor_merges_and_scatter_without_host_model_state():
+    """The generic future_indices lifecycle is valid for Frozen-KV too."""
+    left = FrozenKvMtpDraftInput(
+        future_indices=np.asarray([7], dtype=np.int32),
+        allocate_lens=np.asarray([128], dtype=np.int32),
+        new_seq_lens=np.asarray([120], dtype=np.int32),
+        accept_length_cpu=np.asarray([3], dtype=np.int32),
+    )
+    right = FrozenKvMtpDraftInput(
+        future_indices=np.asarray([11], dtype=np.int32),
+        allocate_lens=np.asarray([256], dtype=np.int32),
+        new_seq_lens=np.asarray([240], dtype=np.int32),
+        accept_length_cpu=np.asarray([2], dtype=np.int32),
+    )
+
+    left.merge_batch(right)
+    left.filter_batch(np.asarray([1], dtype=np.int32), has_been_filtered=False)
+    padded = ScheduleBatch._scatter_spec_info_to_dp_slots(
+        left, selector=np.asarray([2], dtype=np.int32), total_bs=4
+    )
+
+    assert isinstance(padded, FrozenKvMtpDraftInput)
+    assert padded.topk_p is None
+    assert padded.hidden_states is None
+    np.testing.assert_array_equal(padded.future_indices, [0, 0, 11, 0])
+    np.testing.assert_array_equal(padded.allocate_lens, [0, 0, 256, 0])
+    np.testing.assert_array_equal(padded.new_seq_lens, [0, 0, 240, 0])
+
+
+def test_frozen_kv_relay_descriptor_rejects_mixed_nonrelay_merge():
+    relay = FrozenKvMtpDraftInput(
+        future_indices=np.asarray([7], dtype=np.int32),
+        allocate_lens=np.asarray([128], dtype=np.int32),
+        new_seq_lens=np.asarray([120], dtype=np.int32),
+    )
+    with pytest.raises(AssertionError, match="future_indices"):
+        relay.merge_batch(_state([(22, 202, 256, 255)]))
+
+
+def test_frozen_kv_relay_descriptor_trim_keeps_seed_mask_request_aligned():
+    state = FrozenKvMtpDraftInput(
+        future_indices=np.asarray([7, 11, 13], dtype=np.int32),
+        allocate_lens=np.asarray([128, 256, 384], dtype=np.int32),
+        new_seq_lens=np.asarray([120, 240, 360], dtype=np.int32),
+        relay_seed_mask=np.asarray([True, False, True]),
+    )
+
+    state.trim_to_length(2)
+
+    np.testing.assert_array_equal(state.future_indices, [7, 11])
+    np.testing.assert_array_equal(state.relay_seed_mask, [True, False])

--- a/python/sgl_jax/test/speculative/test_frozen_kv_mtp_relay_dp.py
+++ b/python/sgl_jax/test/speculative/test_frozen_kv_mtp_relay_dp.py
@@ -1,0 +1,184 @@
+"""DP-attention relay-layout regressions for Frozen-KV MTP."""
+
+from __future__ import annotations
+
+import os
+import types
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("XLA_FLAGS", "--xla_force_host_platform_device_count=2")
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.speculative.frozen_kv_mtp_worker import FrozenKvMtpDraftWorker
+from sgl_jax.srt.speculative.relay_buffer import (
+    create_spec_seed_relay_buffers,
+    gather_spec_seed_relay_buffers,
+)
+
+
+@pytest.mark.skipif(jax.device_count() < 2, reason="requires two CPU test devices")
+def test_single_live_prefill_publishes_into_a_dp2_seed_relay():
+    """A compact c1 update must not be partitioned across two DP replicas."""
+    mesh = Mesh(
+        np.asarray(jax.devices()[:2]).reshape(2, 1),
+        ("data", "tensor"),
+        axis_types=(jax.sharding.AxisType.Explicit,) * 2,
+    )
+    worker = FrozenKvMtpDraftWorker.__new__(FrozenKvMtpDraftWorker)
+    worker._worker = types.SimpleNamespace(mesh=mesh)
+    worker.server_args = types.SimpleNamespace(dp_size=2)
+    worker._jit_publish_seed_relay = None
+    worker._jit_gather_seed_relay = None
+    req_pool = types.SimpleNamespace(req_to_token=np.zeros((8, 1), dtype=np.int32))
+    worker.seed_relay_buffers = create_spec_seed_relay_buffers(
+        mesh,
+        req_pool,
+        dp_size=2,
+        hidden_size=3,
+        hidden_dtype=jnp.float32,
+    )
+    batch = types.SimpleNamespace(
+        logits_indices_selector=np.asarray([0], dtype=np.int32),
+        # The scheduler bucket is DP-divisible even though only slot zero is live.
+        req_pool_indices=jnp.asarray([3, 0], dtype=jnp.int32),
+    )
+
+    worker._publish_seed_relay(
+        model_worker_batch=batch,
+        verified_id=jnp.asarray([42], dtype=jnp.int32),
+        draft_token_ids=jnp.asarray([43], dtype=jnp.int32),
+        hidden_states=jnp.asarray([[1.0, 2.0, 3.0]], dtype=jnp.float32),
+        is_target_seed=jnp.asarray([True]),
+    )
+
+    indices = jax.device_put(jnp.asarray([3, 0], dtype=jnp.int32), NamedSharding(mesh, P("data")))
+    token_ids, draft_ids, hidden, is_target_seed = gather_spec_seed_relay_buffers(
+        worker.seed_relay_buffers, indices, dp_size=2
+    )
+    np.testing.assert_array_equal(token_ids, [42, 0])
+    np.testing.assert_array_equal(draft_ids, [43, 0])
+    np.testing.assert_allclose(hidden, [[1.0, 2.0, 3.0], [0.0, 0.0, 0.0]])
+    np.testing.assert_array_equal(is_target_seed, [True, False])
+
+
+@pytest.mark.skipif(jax.device_count() < 2, reason="requires two CPU test devices")
+@pytest.mark.parametrize(
+    ("selector", "expected_tokens"),
+    [
+        ([0, 1], [51, 52, 0, 0]),
+        ([0, 2], [51, 0, 52, 0]),
+    ],
+    ids=("concentrated_on_rank_zero", "split_across_ranks"),
+)
+def test_compact_updates_use_explicit_dp_padded_slots(selector, expected_tokens):
+    """A compact row count does not imply balanced DP-attention ranks."""
+    mesh = Mesh(
+        np.asarray(jax.devices()[:2]).reshape(2, 1),
+        ("data", "tensor"),
+        axis_types=(jax.sharding.AxisType.Explicit,) * 2,
+    )
+    worker = FrozenKvMtpDraftWorker.__new__(FrozenKvMtpDraftWorker)
+    worker._worker = types.SimpleNamespace(mesh=mesh)
+    worker.server_args = types.SimpleNamespace(dp_size=2)
+    worker._jit_publish_seed_relay = None
+    worker._jit_gather_seed_relay = None
+    req_pool = types.SimpleNamespace(req_to_token=np.zeros((8, 1), dtype=np.int32))
+    worker.seed_relay_buffers = create_spec_seed_relay_buffers(
+        mesh,
+        req_pool,
+        dp_size=2,
+        hidden_size=2,
+        hidden_dtype=jnp.float32,
+    )
+    batch = types.SimpleNamespace(
+        logits_indices_selector=np.asarray(selector, dtype=np.int32),
+        req_pool_indices=jax.device_put(
+            jnp.asarray([3, 4, 5, 6], dtype=jnp.int32),
+            NamedSharding(mesh, P("data")),
+        ),
+    )
+
+    worker._publish_seed_relay(
+        model_worker_batch=batch,
+        verified_id=jnp.asarray([51, 52], dtype=jnp.int32),
+        draft_token_ids=jnp.asarray([61, 62], dtype=jnp.int32),
+        hidden_states=jnp.asarray([[1.0, 2.0], [3.0, 4.0]], dtype=jnp.float32),
+        is_target_seed=jnp.asarray([True, True]),
+    )
+
+    indices = jax.device_put(
+        jnp.asarray([3, 4, 5, 6], dtype=jnp.int32), NamedSharding(mesh, P("data"))
+    )
+    token_ids, _, _, is_target_seed = gather_spec_seed_relay_buffers(
+        worker.seed_relay_buffers, indices, dp_size=2
+    )
+    np.testing.assert_array_equal(token_ids, expected_tokens)
+    np.testing.assert_array_equal(is_target_seed, np.asarray(expected_tokens) != 0)
+
+
+@pytest.mark.skipif(jax.device_count() < 2, reason="requires two CPU test devices")
+def test_dp2_verify_accepts_compact_allocate_lens_with_padded_metadata():
+    """Verify handoff must not index compact allocation rows by padded slots."""
+    mesh = Mesh(
+        np.asarray(jax.devices()[:2]).reshape(2, 1),
+        ("data", "tensor"),
+        axis_types=(jax.sharding.AxisType.Explicit,) * 2,
+    )
+    worker = FrozenKvMtpDraftWorker.__new__(FrozenKvMtpDraftWorker)
+    worker._worker = types.SimpleNamespace(mesh=mesh)
+    worker.server_args = types.SimpleNamespace(dp_size=2)
+    worker.speculative_num_steps = 3
+    worker._jit_publish_seed_relay = None
+    worker._jit_gather_seed_relay = None
+    req_pool = types.SimpleNamespace(req_to_token=np.zeros((8, 1), dtype=np.int32))
+    worker.seed_relay_buffers = create_spec_seed_relay_buffers(
+        mesh,
+        req_pool,
+        dp_size=2,
+        hidden_size=3,
+        hidden_dtype=jnp.float32,
+    )
+    batch = types.SimpleNamespace(
+        logits_indices_selector=np.asarray([0], dtype=np.int32),
+        seq_lens=jax.device_put(
+            jnp.asarray([10, 0], dtype=jnp.int32), NamedSharding(mesh, P("data"))
+        ),
+        req_pool_indices=jax.device_put(
+            jnp.asarray([3, 0], dtype=jnp.int32), NamedSharding(mesh, P("data"))
+        ),
+    )
+    verified_tokens = jax.device_put(
+        jnp.arange(100, 108, dtype=jnp.int32), NamedSharding(mesh, P("data"))
+    )
+    hidden = jax.device_put(
+        jnp.arange(24, dtype=jnp.float32).reshape(8, 3),
+        NamedSharding(mesh, P("data", None)),
+    )
+    accept_lengths = jax.device_put(
+        jnp.asarray([3, 0], dtype=jnp.int32), NamedSharding(mesh, P("data"))
+    )
+
+    # This field is intentionally compact: BaseDraftWorker._get_cur_allocate_lens
+    # has already selected live rows before entering FrozenKvMtpWorker.verify.
+    worker.publish_seed_after_verify_device(
+        model_worker_batch=batch,
+        verified_tokens=verified_tokens,
+        target_hidden=hidden,
+        accept_lengths=accept_lengths,
+        allocate_lens=np.asarray([20], dtype=np.int32),
+    )
+
+    indices = jax.device_put(jnp.asarray([3, 0], dtype=jnp.int32), NamedSharding(mesh, P("data")))
+    token_ids, draft_ids, selected_hidden, is_target_seed = gather_spec_seed_relay_buffers(
+        worker.seed_relay_buffers, indices, dp_size=2
+    )
+    np.testing.assert_array_equal(token_ids, [102, 0])
+    np.testing.assert_array_equal(draft_ids, [102, 0])
+    np.testing.assert_allclose(selected_hidden, [[6.0, 7.0, 8.0], [0.0, 0.0, 0.0]])
+    np.testing.assert_array_equal(is_target_seed, [True, False])

--- a/python/sgl_jax/test/speculative/test_frozen_kv_mtp_verify.py
+++ b/python/sgl_jax/test/speculative/test_frozen_kv_mtp_verify.py
@@ -1,0 +1,173 @@
+"""Unit coverage for Frozen-KV's dedicated device-first verify handoff."""
+
+from __future__ import annotations
+
+import types
+
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.speculative.eagle_info import EagleVerifyInput
+from sgl_jax.srt.speculative.frozen_kv_mtp_worker import (
+    FrozenKvMtpDraftWorker,
+    FrozenKvMtpWorker,
+)
+
+
+class _FakeNextDraftInput:
+    def _validate_non_overlap_state(self):
+        return None
+
+
+class _FakeDraftWorker:
+    _compact_request_rows = staticmethod(FrozenKvMtpDraftWorker._compact_request_rows)
+
+    def __init__(self, calls):
+        self.calls = calls
+        self.draft_model_runner = types.SimpleNamespace(rngs=object())
+
+    def publish_seed_after_verify_device(self, **kwargs):
+        self.calls.append(("publish", kwargs))
+
+    def new_draft_input(self, **kwargs):
+        self.calls.append(("descriptor", kwargs))
+        return _FakeNextDraftInput()
+
+
+class _FakeVerifyInput(EagleVerifyInput):
+    draft_token = jnp.arange(8, dtype=jnp.int32)
+    custom_mask = jnp.ones((1,), dtype=bool)
+    positions = jnp.arange(8, dtype=jnp.int32)
+    spec_steps = 3
+    draft_token_num = 4
+
+    def sample_device(self, model_worker_batch, logits_output, rng, mesh):
+        del model_worker_batch, logits_output, rng, mesh
+        # Two padded slots, four candidate rows per slot. Only slot zero is live.
+        return (
+            jnp.arange(8, dtype=jnp.int32),
+            jnp.arange(100, 108, dtype=jnp.int32),
+            jnp.array([3, 0], dtype=jnp.int32),
+            jnp.array([[0, 1, 2, -1], [-1, -1, -1, -1]], dtype=jnp.int32),
+        )
+
+
+def test_dedicated_verify_publishes_device_seed_before_host_descriptor(monkeypatch):
+    """The Frozen path must not use generic EAGLE's host sample handoff."""
+    import sgl_jax.srt.speculative.frozen_kv_mtp_worker as frozen_module
+
+    # The real operation is an explicit layout conversion. CPU unit coverage
+    # needs only its data-flow contract, not a physical TPU mesh.
+    monkeypatch.setattr(frozen_module, "replicate_to_mesh", lambda _mesh, *xs: xs)
+
+    calls = []
+    draft = _FakeDraftWorker(calls)
+    verify_input = _FakeVerifyInput.__new__(_FakeVerifyInput)
+    model_worker_batch = types.SimpleNamespace(
+        spec_info_padded=verify_input,
+        seq_lens=np.array([10, 0], dtype=np.int32),
+        positions=jnp.arange(8, dtype=jnp.int32),
+        logits_indices_selector=np.array([0], dtype=np.int32),
+        req_pool_indices=np.array([17, -1], dtype=np.int32),
+        sampling_info=types.SimpleNamespace(is_all_greedy=False),
+        bid=3,
+    )
+    logits_output = types.SimpleNamespace(
+        next_token_logits=jnp.arange(8 * 3, dtype=jnp.float32).reshape(8, 3),
+        hidden_states=jnp.arange(8 * 2, dtype=jnp.float32).reshape(8, 2),
+    )
+    target_worker = types.SimpleNamespace(
+        model_runner=types.SimpleNamespace(
+            attn_backend=types.SimpleNamespace(get_eagle_forward_metadata=lambda _mwb: "metadata")
+        ),
+        forward_batch_generation=lambda _mwb, **_kwargs: (logits_output, None, 0),
+    )
+    worker = FrozenKvMtpWorker.__new__(FrozenKvMtpWorker)
+    worker.server_args = types.SimpleNamespace(disable_overlap_schedule=True)
+    worker._target_worker = target_worker
+    worker._draft_worker = draft
+    worker.mesh = object()
+    worker.page_size = 128
+    worker.speculative_num_steps = 3
+    worker.speculative_num_draft_tokens = 4
+
+    result = worker.verify(model_worker_batch, jnp.array([20, 0], dtype=jnp.int32))
+
+    assert [name for name, _ in calls] == ["publish", "descriptor"]
+    published = calls[0][1]
+    assert isinstance(published["accept_lengths"], type(jnp.array(0)))
+    np.testing.assert_array_equal(published["accept_lengths"], np.array([3, 0]))
+    descriptor = calls[1][1]
+    np.testing.assert_array_equal(descriptor["future_indices"], np.array([17], dtype=np.int32))
+    np.testing.assert_array_equal(descriptor["allocate_lens"], np.array([20], dtype=np.int32))
+    np.testing.assert_array_equal(descriptor["new_seq_lens"], np.array([13], dtype=np.int32))
+    np.testing.assert_array_equal(descriptor["accept_length_cpu"], np.array([3], dtype=np.int32))
+    np.testing.assert_array_equal(descriptor["relay_seed_mask"], np.array([True]))
+    np.testing.assert_array_equal(result.accept_lens, np.array([3, 0], dtype=np.int32))
+    np.testing.assert_array_equal(result.next_token_ids, np.arange(8, dtype=np.int32))
+
+
+def test_dedicated_verify_uses_native_chain_logits_without_replication(monkeypatch):
+    """Frozen top-k-one verify must follow DFlash's native-sharding pattern."""
+    import sgl_jax.srt.speculative.frozen_kv_mtp_worker as frozen_module
+
+    def fail_if_replicated(*_args, **_kwargs):
+        raise AssertionError("native Frozen-KV chain verify must not replicate target output")
+
+    monkeypatch.setattr(frozen_module, "replicate_to_mesh", fail_if_replicated)
+
+    class _NativeChainVerifyInput(_FakeVerifyInput):
+        custom_mask = None
+        draft_token_num = 4
+        spec_steps = 3
+        draft_token = jnp.asarray([7, 10, 11, 12, 8, 30, 31, 32], dtype=jnp.int32)
+
+        def sample_device(self, *_args, **_kwargs):
+            raise AssertionError("native Frozen-KV chain must not enter generic tree sampling")
+
+    calls = []
+    draft = _FakeDraftWorker(calls)
+    verify_input = _NativeChainVerifyInput.__new__(_NativeChainVerifyInput)
+    model_worker_batch = types.SimpleNamespace(
+        spec_info_padded=verify_input,
+        seq_lens=np.array([10, 20], dtype=np.int32),
+        positions=jnp.arange(8, dtype=jnp.int32),
+        logits_indices_selector=np.array([0, 1], dtype=np.int32),
+        req_pool_indices=np.array([17, 19], dtype=np.int32),
+        sampling_info=types.SimpleNamespace(is_all_greedy=True),
+        bid=3,
+    )
+    target_top1 = jnp.asarray([10, 11, 99, 13, 88, 30, 31, 32], dtype=jnp.int32)
+    logits = jnp.full((8, 128), -10.0, dtype=jnp.float32)
+    logits = logits.at[jnp.arange(8), target_top1].set(10.0)
+    logits_output = types.SimpleNamespace(
+        next_token_logits=logits,
+        hidden_states=jnp.arange(16, dtype=jnp.float32).reshape(8, 2),
+    )
+    target_hidden_before_scheduler_gather = logits_output.hidden_states
+    target_worker = types.SimpleNamespace(
+        model_runner=types.SimpleNamespace(
+            attn_backend=types.SimpleNamespace(get_eagle_forward_metadata=lambda _mwb: "metadata")
+        ),
+        forward_batch_generation=lambda _mwb, **_kwargs: (logits_output, None, 0),
+    )
+    worker = FrozenKvMtpWorker.__new__(FrozenKvMtpWorker)
+    worker.server_args = types.SimpleNamespace(disable_overlap_schedule=True)
+    worker._target_worker = target_worker
+    worker._draft_worker = draft
+    worker.mesh = object()
+    worker.page_size = 128
+    worker.speculative_num_steps = 3
+    worker.speculative_num_draft_tokens = 4
+
+    result = worker.verify(model_worker_batch, jnp.array([20, 30], dtype=jnp.int32))
+
+    assert [name for name, _ in calls] == ["publish", "descriptor"]
+    published = calls[0][1]
+    np.testing.assert_array_equal(published["verified_tokens"], target_top1)
+    np.testing.assert_array_equal(published["accept_lengths"], [3, 1])
+    # Target hidden rows are still the original target-forward object; no
+    # host-orchestrated P() replica is introduced before seed selection.
+    assert published["target_hidden"] is target_hidden_before_scheduler_gather
+    np.testing.assert_array_equal(result.next_token_ids, target_top1)
+    np.testing.assert_array_equal(result.accept_lens, [3, 1])

--- a/python/sgl_jax/test/speculative/test_gemma4_mtp_e2e.py
+++ b/python/sgl_jax/test/speculative/test_gemma4_mtp_e2e.py
@@ -1,0 +1,565 @@
+"""End-to-end forward tests for the Gemma4 FROZEN_KV_MTP draft model.
+
+These drive the *real* pieces the speculative loop depends on — a real
+``MHATokenToKVPool``, the native attention backend, the real ``LogitsProcessor``
+— rather than shapes alone, because the defects this guards against are all
+invisible at construction time:
+
+* the draft's dummy zero K/V reaching the target's shared KV pool
+* the draft's captured hidden leaving in the wrong vector space
+* an empty aux-hidden list crashing the target's verify forward
+
+A full Scheduler run needs real checkpoints and TPU kernels, so these stop at
+the model/pool boundary, which is exactly where the frozen-KV contract lives.
+
+Run on CPU:
+    JAX_PLATFORMS=cpu XLA_FLAGS=--xla_force_host_platform_device_count=1 \\
+      python -m pytest python/sgl_jax/test/speculative/test_gemma4_mtp_e2e.py -v
+"""
+
+import os
+
+os.environ.setdefault("XLA_FLAGS", "--xla_force_host_platform_device_count=1")
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+from functools import partial
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+from transformers import PretrainedConfig
+
+from sgl_jax.srt.layers.attention.flashattention_backend import FlashAttention
+from sgl_jax.srt.layers.attention.native_backend import NativeAttention
+from sgl_jax.srt.layers.embeddings import Embed
+from sgl_jax.srt.layers.kv_share import compute_mtp_kv_share_map
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
+from sgl_jax.srt.mem_cache.memory_pool import MemoryPools, MHATokenToKVPool
+from sgl_jax.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
+from sgl_jax.srt.models.gemma4_mtp import Gemma4AssistantForCausalLM
+from sgl_jax.srt.speculative.base_worker import replicate_to_mesh
+from sgl_jax.srt.speculative.eagle_info import EagleDraftInput
+from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+# Pinned to a single device rather than create_device_mesh's "use everything":
+# these tests assert on KV-pool contents and hidden-state shapes, not on
+# sharding, and a mesh whose width depends on XLA_FLAGS makes them pass alone
+# but fail inside the wider suite.
+MESH = jax.sharding.Mesh(
+    np.asarray(jax.devices()[:1]).reshape(1, 1),
+    ("data", "tensor"),
+    axis_types=(jax.sharding.AxisType.Explicit,) * 2,
+)
+
+# Snapshotted from google/gemma-4-12B-it{,-assistant}, dims shrunk for CPU
+# (real value in the comment). Relationships are preserved, not the magnitudes.
+#
+# Unlike the unit tests, every layer here is full_attention: MHATokenToKVPool
+# has one head geometry for all layers, whereas a real hybrid target uses
+# SWAKVPool to give sliding and full layers different widths. These tests are
+# about the frozen-KV contract and the hidden-state space, not per-type
+# geometry (test_gemma4_mtp.py covers that), so the single-geometry pool is the
+# cheaper fixture. The values below are therefore the *global* (full-attention)
+# ones from the real config.
+BACKBONE_HIDDEN = 384  # real 3840 = the target's hidden_size
+DRAFT_HIDDEN = 128  # real 1024; must stay != BACKBONE_HIDDEN
+# 128-aligned: merge_kv pads head_dim up to 128, so an unaligned head_dim makes
+# the pool wider than the attention layer and o_proj mismatches. The real
+# global_head_dim (512) is already aligned.
+HEAD_DIM = 128  # real global_head_dim 512
+NUM_HEADS = 2  # real 16
+NUM_KV_HEADS = 1  # real num_global_key_value_heads 1 -- verbatim
+VOCAB = 256  # real 262144
+NUM_DRAFT_LAYERS = 2  # real 4
+# The target has more layers than the draft — that gap is what makes a
+# positional KV write-back land on the wrong layers. Real ratio is 48:4.
+NUM_TARGET_LAYERS = 6  # real 48
+POOL_SIZE = 128
+DTYPE = jnp.float32
+# merge_kv aligns head_dim up to 128, so the pool is allocated at the aligned
+# width even though attention runs at HEAD_DIM. Production does the same thing
+# in ModelRunnerKVCacheMixin (`head_dim=(head_dim + 127) // 128 * 128`).
+POOL_HEAD_DIM = (HEAD_DIM + 127) // 128 * 128
+
+
+def test_target_verify_compacts_reserved_pages_between_requests():
+    """TARGET_VERIFY must not interpret request A's reserve page as request B's KV.
+
+    ``padding_for_decode`` packs the source cache by ``allocate_lens``.  Here,
+    each request owns two physical pages but target verification needs only its
+    first page.  The ``cu_kv_lens`` rows therefore require the compact page
+    sequence ``[A0, B0]``.  Without target-verify compaction the backend passes
+    ``[A0, A1, B0, B1]`` through unchanged, so B reads A's reserve page whenever
+    both requests are in one batch.
+    """
+    page_size = 8
+    backend = FlashAttention(1, 1, 8, page_size=page_size, mesh=MESH)
+
+    def _page(page_id: int) -> np.ndarray:
+        return np.arange(page_id * page_size, (page_id + 1) * page_size, dtype=np.int32)
+
+    # cache_loc is in the same allocation-packed form produced by
+    # EagleDraftWorker.padding_for_decode: [A0, A1, B0, B1].
+    batch = SimpleNamespace(
+        forward_mode=ForwardMode.TARGET_VERIFY,
+        cache_loc=np.concatenate([_page(10), _page(11), _page(20), _page(21)]),
+        seq_lens=np.array([4, 4], dtype=np.int32),  # prepare_for_verify already subtracted 1
+        dp_size=1,
+        per_dp_bs_size=2,
+        logits_indices_selector=np.array([0, 1], dtype=np.int32),
+        spec_info_padded=SimpleNamespace(
+            custom_mask=None,
+            draft_token_num=4,
+            allocate_lens=np.array([9, 9], dtype=np.int32),
+        ),
+    )
+
+    metadata = backend.get_eagle_forward_metadata(batch)
+    # Verification length is seq_len + 4 == 8, i.e. one page per request.
+    # The first two physical page IDs consumed by its two cu_kv rows must be
+    # A0 then B0, not A0 then A1.
+    np.testing.assert_array_equal(np.asarray(metadata.page_indices)[:2], [10, 20])
+
+
+def test_frozen_draft_steps_remap_target_pages_to_swa_pool():
+    """Every recurrent draft step must address the target's SWA sub-pool."""
+    page_size = 8
+    backend = FlashAttention(1, 1, 8, page_size=page_size, mesh=MESH)
+    mapping = np.zeros(1024, dtype=np.int32)
+    mapping[10 * page_size] = 100 * page_size
+    mapping[20 * page_size] = 200 * page_size
+    backend.swa_index_mapping = mapping
+
+    def _page(page_id: int) -> np.ndarray:
+        return np.arange(page_id * page_size, (page_id + 1) * page_size, dtype=np.int32)
+
+    batch = SimpleNamespace(
+        forward_mode=ForwardMode.DECODE,
+        cache_loc=np.concatenate([_page(10), _page(11), _page(20), _page(21)]),
+        seq_lens=np.array([4, 4], dtype=np.int32),
+        dp_size=1,
+        per_dp_bs_size=2,
+        logits_indices_selector=np.array([0, 1], dtype=np.int32),
+        speculative_num_steps=3,
+        speculative_eagle_topk=1,
+        spec_algorithm=SpeculativeAlgorithm.FROZEN_KV_MTP,
+        spec_info_padded=EagleDraftInput(allocate_lens=np.array([9, 9], dtype=np.int32)),
+    )
+
+    metadata = backend.get_eagle_multi_step_metadata(batch)
+
+    assert len(metadata) == 3
+    for step_metadata in metadata:
+        np.testing.assert_array_equal(
+            np.asarray(step_metadata.swa_page_indices)[:2],
+            np.array([100, 200], dtype=np.int32),
+        )
+
+
+def _draft_config() -> PretrainedConfig:
+    return PretrainedConfig(
+        hidden_size=DRAFT_HIDDEN,
+        intermediate_size=2 * DRAFT_HIDDEN,
+        num_attention_heads=NUM_HEADS,
+        num_key_value_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        swa_head_dim=HEAD_DIM,
+        vocab_size=VOCAB,
+        num_hidden_layers=NUM_DRAFT_LAYERS,
+        max_position_embeddings=1024,
+        rms_norm_eps=1e-6,
+        attention_bias=False,
+        rope_theta=10000.0,
+        layer_types=["full_attention"] * NUM_DRAFT_LAYERS,
+        sliding_window=0,
+        tie_word_embeddings=True,
+        backbone_hidden_size=BACKBONE_HIDDEN,
+        use_ordered_embeddings=False,
+    )
+
+
+def _target_config() -> PretrainedConfig:
+    return PretrainedConfig(
+        layer_types=["full_attention"] * NUM_TARGET_LAYERS,
+        num_kv_shared_layers=0,
+        num_hidden_layers=NUM_TARGET_LAYERS,
+    )
+
+
+def _make_pool(seed: int = 0) -> MHATokenToKVPool:
+    """A target-shaped KV pool pre-filled with a distinctive per-layer pattern.
+
+    Non-zero, layer-distinguishable contents are the point: zero-filled buffers
+    would make a clobbering write indistinguishable from a correct no-op.
+    """
+    with jax.set_mesh(MESH):
+        pool = MHATokenToKVPool(
+            size=POOL_SIZE,
+            page_size=1,
+            dtype=DTYPE,
+            head_num=NUM_KV_HEADS,
+            head_dim=POOL_HEAD_DIM,
+            layer_num=NUM_TARGET_LAYERS,
+            mesh=MESH,
+        )
+        for layer_id in range(NUM_TARGET_LAYERS):
+            buf = pool.kv_buffer[layer_id]
+            pool.kv_buffer[layer_id] = jnp.full_like(buf, float(seed + layer_id + 1))
+    return pool
+
+
+def _make_model() -> Gemma4AssistantForCausalLM:
+    with jax.set_mesh(MESH):
+        model = Gemma4AssistantForCausalLM(config=_draft_config(), mesh=MESH, dtype=DTYPE)
+        # The draft embeds tokens with the TARGET's embedding (backbone-dim).
+        model.set_embed_and_head(
+            nnx.Param(
+                jax.random.normal(jax.random.PRNGKey(1), (VOCAB, BACKBONE_HIDDEN), dtype=DTYPE)
+                * 0.02
+            ),
+            None,
+        )
+    return model
+
+
+def _redirect_layer_ids(model: Gemma4AssistantForCausalLM) -> dict[str, str]:
+    """Apply the same layer_id redirection MultiLayerDraftWorker._init_gemma4_mtp does."""
+    share_map = compute_mtp_kv_share_map(_draft_config(), _target_config())
+    for i, layer in enumerate(model.layers):
+        target_idx = int(share_map[f"draft_layer.{i}"].split(".")[-1])
+        layer.self_attn.attn.layer_id = target_idx
+    return share_map
+
+
+def _make_forward_batch(num_tokens: int, seq_len: int, hidden: jax.Array) -> ForwardBatch:
+    """An EXTEND batch for a single request whose prefix is already in the pool."""
+    backend = NativeAttention(num_attn_heads=NUM_HEADS, num_kv_heads=NUM_KV_HEADS, mesh=MESH)
+    spec_info = EagleDraftInput(hidden_states=hidden)
+    spec_info.capture_hidden_mode = CaptureHiddenMode.LAST
+    return ForwardBatch(
+        bid=0,
+        forward_mode=ForwardMode.EXTEND,
+        batch_size=1,
+        input_ids=jnp.arange(num_tokens, dtype=jnp.int32) % VOCAB,
+        req_pool_indices=jnp.zeros((1,), dtype=jnp.int32),
+        seq_lens=jnp.array([seq_len], dtype=jnp.int32),
+        out_cache_loc=jnp.arange(seq_len - num_tokens, seq_len, dtype=jnp.int32),
+        positions=jnp.arange(seq_len - num_tokens, seq_len, dtype=jnp.int32),
+        attn_backend=backend,
+        cache_loc=jnp.arange(seq_len, dtype=jnp.int32),
+        extend_prefix_lens=jnp.array([seq_len - num_tokens], dtype=jnp.int32),
+        extend_seq_lens=jnp.array([num_tokens], dtype=jnp.int32),
+        spec_info=spec_info,
+        capture_hidden_mode=CaptureHiddenMode.LAST,
+    )
+
+
+def _logits_metadata(num_tokens: int) -> LogitsMetadata:
+    # The serving path constructs both arrays with P("data") sharding.  JAX
+    # 0.10 validates shard_map inputs strictly, so a default-replicated test
+    # array is not a faithful CPU stand-in for the production metadata.
+    data_sharding = jax.sharding.NamedSharding(MESH, jax.sharding.PartitionSpec("data"))
+    return LogitsMetadata(
+        forward_mode=ForwardMode.EXTEND,
+        capture_hidden_mode=CaptureHiddenMode.LAST,
+        extend_seq_lens=jax.device_put(jnp.array([num_tokens], dtype=jnp.int32), data_sharding),
+        logits_indices=jax.device_put(jnp.array([num_tokens - 1], dtype=jnp.int32), data_sharding),
+    )
+
+
+def _run_draft(model, pool, num_tokens=4, seq_len=8, hidden=None):
+    if hidden is None:
+        hidden = (
+            jax.random.normal(jax.random.PRNGKey(2), (num_tokens, BACKBONE_HIDDEN), dtype=DTYPE)
+            * 0.1
+        )
+    fb = _make_forward_batch(num_tokens, seq_len, hidden)
+    with jax.set_mesh(MESH):
+        return model(fb, MemoryPools(token_to_kv_pool=pool), _logits_metadata(num_tokens))
+
+
+@pytest.fixture(scope="module")
+def wired():
+    model = _make_model()
+    share_map = _redirect_layer_ids(model)
+    return model, share_map
+
+
+class TestKvShareWiring:
+    def test_layer_ids_point_into_the_target_range(self, wired):
+        model, share_map = wired
+        for i, layer in enumerate(model.layers):
+            expected = int(share_map[f"draft_layer.{i}"].split(".")[-1])
+            assert layer.self_attn.attn.layer_id == expected
+            # Redirected ids must address the TARGET pool, not the draft's own
+            # 0..NUM_DRAFT_LAYERS-1 range.
+            assert 0 <= layer.self_attn.attn.layer_id < NUM_TARGET_LAYERS
+
+    def test_redirect_actually_leaves_the_draft_index_space(self, wired):
+        _, share_map = wired
+        targets = {int(v.split(".")[-1]) for v in share_map.values()}
+        assert max(targets) >= NUM_DRAFT_LAYERS, (
+            "Test is not exercising redirection: every draft layer already maps "
+            "to an index inside the draft's own range."
+        )
+
+
+class TestFrozenKvContract:
+    """The draft must read the target's cache and never write to it."""
+
+    def test_pool_update_covers_every_target_layer(self, wired):
+        """A short list is the positional-write bug: it silently overwrites
+        target layers 0..len-1 instead of the layers the draft actually read."""
+        model, _ = wired
+        pool = _make_pool()
+        _, pool_updates, _, _ = _run_draft(model, pool)
+        assert len(pool_updates["token_to_kv_pool"]) == NUM_TARGET_LAYERS
+
+    def test_pool_update_is_the_targets_own_buffers(self, wired):
+        model, _ = wired
+        pool = _make_pool()
+        before = [np.asarray(b) for b in pool.kv_buffer]
+        _, pool_updates, _, _ = _run_draft(model, pool)
+        for layer_id, updated in enumerate(pool_updates["token_to_kv_pool"]):
+            np.testing.assert_array_equal(
+                np.asarray(updated),
+                before[layer_id],
+                err_msg=f"draft modified KV for target layer {layer_id}",
+            )
+
+    def test_target_kv_survives_replace_all(self, wired):
+        """The B1 regression: run the real write-back and assert the target's
+        verified KV is bitwise untouched."""
+        model, _ = wired
+        pool = _make_pool()
+        pools = MemoryPools(token_to_kv_pool=pool)
+        before = [np.asarray(b) for b in pool.kv_buffer]
+
+        _, pool_updates, _, _ = _run_draft(model, pool)
+        pools.replace_all(pool_updates)
+
+        for layer_id in range(NUM_TARGET_LAYERS):
+            np.testing.assert_array_equal(
+                np.asarray(pool.kv_buffer[layer_id]),
+                before[layer_id],
+                err_msg=(
+                    f"target KV layer {layer_id} changed after a draft forward — "
+                    "frozen-KV draft wrote into the shared pool"
+                ),
+            )
+
+    def test_pool_round_trips_through_a_jitted_donated_call(self, wired):
+        """Replays ModelRunner's real dispatch: jax.jit with the pools donated,
+        then replace_all() from the returned updates.
+
+        What this pins: the model is jit-compatible with MemoryPools as a
+        donated pytree argument, and the refill round-trips to the same buffers.
+        The eager tests above never enter jit at all.
+
+        What it does NOT pin, despite the donation: on the CPU backend XLA
+        declines to donate ("Some donated buffers were not usable") and the
+        inputs survive, so the deleted-buffer failure mode this pass-through
+        exists to prevent only reproduces on TPU. The real guard against a
+        short/empty update list is test_pool_update_covers_every_target_layer.
+        """
+        model, _ = wired
+        pool = _make_pool()
+        pools = MemoryPools(token_to_kv_pool=pool)
+        before = [np.asarray(b) for b in pool.kv_buffer]
+
+        graphdef, state = nnx.split(model)
+        leaves, state_def = jax.tree_util.tree_flatten(state)
+
+        @partial(jax.jit, donate_argnames=["memory_pools"], static_argnames=["state_def"])
+        def jitted(graphdef, state_def, leaves, forward_batch, memory_pools, meta):
+            m = nnx.merge(graphdef, jax.tree_util.tree_unflatten(state_def, leaves))
+            return m(forward_batch, memory_pools, meta)
+
+        num_tokens = 4
+        hidden = jnp.ones((num_tokens, BACKBONE_HIDDEN), dtype=DTYPE) * 0.1
+        fb = _make_forward_batch(num_tokens, 8, hidden)
+        with jax.set_mesh(MESH):
+            _, pool_updates, _, _ = jitted(
+                graphdef, state_def, leaves, fb, pools, _logits_metadata(num_tokens)
+            )
+            pools.replace_all(pool_updates)
+
+        updates = pool_updates["token_to_kv_pool"]
+        assert len(updates) == NUM_TARGET_LAYERS, (
+            f"jitted draft returned {len(updates)} pool updates for a "
+            f"{NUM_TARGET_LAYERS}-layer target; on TPU the unreturned buffers "
+            f"are donated away and the pool is left holding deleted arrays"
+        )
+        for layer_id in range(NUM_TARGET_LAYERS):
+            buf = pool.kv_buffer[layer_id]
+            assert not buf.is_deleted(), f"target KV layer {layer_id} is deleted"
+            # The refill must have installed the returned arrays, not left the
+            # pool on its pre-call ones.
+            assert buf is updates[layer_id]
+            np.testing.assert_array_equal(np.asarray(buf), before[layer_id])
+
+    def test_no_layer_was_zeroed(self, wired):
+        """Sharpest form of the clobber: dummy K/V are zeros, the pattern is not."""
+        model, _ = wired
+        pool = _make_pool()
+        pools = MemoryPools(token_to_kv_pool=pool)
+        _run_draft(model, pool)
+        pools.replace_all(_run_draft(model, pool)[1])
+        for layer_id in range(NUM_TARGET_LAYERS):
+            buf = np.asarray(pool.kv_buffer[layer_id])
+            assert np.count_nonzero(buf) == buf.size, (
+                f"target KV layer {layer_id} contains zeros — the draft's dummy "
+                "K/V reached the shared pool"
+            )
+
+
+class TestHiddenStateSpace:
+    """The captured hidden is the next draft step's input; it must be backbone-dim."""
+
+    def test_output_hidden_is_backbone_dim(self, wired):
+        model, _ = wired
+        pool = _make_pool()
+        output, _, _, _ = _run_draft(model, pool)
+        assert output.hidden_states is not None
+        assert output.hidden_states.shape[-1] == BACKBONE_HIDDEN, (
+            f"captured hidden is {output.hidden_states.shape[-1]}-dim; the next "
+            f"draft step concatenates it into pre_projection(2*{BACKBONE_HIDDEN})"
+        )
+
+    def test_logits_still_span_the_full_vocab(self, wired):
+        model, _ = wired
+        pool = _make_pool()
+        output, _, _, _ = _run_draft(model, pool)
+        assert output.next_token_logits.shape[-1] == VOCAB
+
+    def test_captured_hidden_feeds_the_next_draft_step(self, wired):
+        """The B3 regression: step N's output must be a valid step N+1 input.
+
+        This is the multi-step autoregressive loop EagleDraftWorker.draft_forward
+        runs; a hidden left in draft space raises on the concatenate.
+        """
+        model, _ = wired
+        pool = _make_pool()
+        output, _, _, _ = _run_draft(model, pool, num_tokens=4, seq_len=8)
+
+        # EagleDraftWorker.draft_forward replicates the captured hidden before
+        # feeding it to the next step; do the same so this exercises the real
+        # sequence rather than a sharding it would never see.
+        fed_back = replicate_to_mesh(MESH, output.hidden_states)
+        # draft_forward feeds one hidden per active token; broadcast the captured
+        # last-token hidden to the next step's token count the same way.
+        next_tokens = 4
+        if fed_back.shape[0] != next_tokens:
+            fed_back = jnp.broadcast_to(
+                fed_back.reshape(1, -1)[:1], (next_tokens, fed_back.shape[-1])
+            )
+
+        output2, _, _, _ = _run_draft(
+            model, pool, num_tokens=next_tokens, seq_len=12, hidden=fed_back
+        )
+        assert output2.next_token_logits.shape[-1] == VOCAB
+        assert output2.hidden_states.shape[-1] == BACKBONE_HIDDEN
+
+    def test_outputs_are_finite(self, wired):
+        model, _ = wired
+        pool = _make_pool()
+        output, _, _, _ = _run_draft(model, pool)
+        assert jnp.all(jnp.isfinite(output.next_token_logits))
+        assert jnp.all(jnp.isfinite(output.hidden_states))
+
+
+class TestReadsRedirectedLayer:
+    def test_output_depends_on_the_mapped_target_layer(self, wired):
+        """Changing the cache the draft was redirected to must change its output.
+
+        If the redirect were ignored the draft would read layer 0 and this would
+        produce identical logits.
+        """
+        model, share_map = wired
+        mapped = sorted({int(v.split(".")[-1]) for v in share_map.values()})
+
+        pool_a = _make_pool(seed=0)
+        out_a, _, _, _ = _run_draft(model, pool_a)
+
+        pool_b = _make_pool(seed=0)
+        with jax.set_mesh(MESH):
+            for layer_id in mapped:
+                buf = pool_b.kv_buffer[layer_id]
+                pool_b.kv_buffer[layer_id] = jnp.full_like(buf, 42.0)
+        out_b, _, _, _ = _run_draft(model, pool_b)
+
+        assert not np.allclose(
+            np.asarray(out_a.next_token_logits), np.asarray(out_b.next_token_logits)
+        ), "draft output ignored the KV-share redirect"
+
+    def test_output_ignores_unmapped_target_layers(self, wired):
+        """The complement: layers the draft never reads must not affect it."""
+        model, share_map = wired
+        mapped = {int(v.split(".")[-1]) for v in share_map.values()}
+        unmapped = [i for i in range(NUM_TARGET_LAYERS) if i not in mapped]
+        assert unmapped, "test needs at least one unread target layer"
+
+        pool_a = _make_pool(seed=0)
+        out_a, _, _, _ = _run_draft(model, pool_a)
+
+        pool_b = _make_pool(seed=0)
+        with jax.set_mesh(MESH):
+            for layer_id in unmapped:
+                buf = pool_b.kv_buffer[layer_id]
+                pool_b.kv_buffer[layer_id] = jnp.full_like(buf, -7.0)
+        out_b, _, _, _ = _run_draft(model, pool_b)
+
+        np.testing.assert_allclose(
+            np.asarray(out_a.next_token_logits),
+            np.asarray(out_b.next_token_logits),
+            rtol=1e-5,
+            atol=1e-5,
+            err_msg="draft read a target layer outside its KV-share map",
+        )
+
+
+class TestAuxHiddenStatesCapture:
+    """B2: an empty aux list must not crash the target's verify forward."""
+
+    def _processor(self):
+        with jax.set_mesh(MESH):
+            processor = LogitsProcessor(VOCAB, mesh=MESH)
+            head = Embed(
+                num_embeddings=VOCAB,
+                features=DRAFT_HIDDEN,
+                param_dtype=DTYPE,
+                dtype=DTYPE,
+            )
+        return processor, head
+
+    def _run(self, aux, mode):
+        processor, head = self._processor()
+        hidden = jnp.ones((3, DRAFT_HIDDEN), dtype=DTYPE)
+        meta = LogitsMetadata(forward_mode=ForwardMode.DECODE, capture_hidden_mode=mode)
+        with jax.set_mesh(MESH):
+            return processor(hidden, head, meta, aux_hidden_states=aux)
+
+    @pytest.mark.parametrize("mode", [CaptureHiddenMode.LAST, CaptureHiddenMode.FULL])
+    def test_empty_aux_list_falls_back_to_final_hidden(self, mode):
+        """Gemma4Model always returns a list, so [] reaches here whenever no
+        layer matched. Both capture modes must fall back, not concat([])."""
+        out = self._run([], mode)
+        assert out.hidden_states is not None
+        assert out.hidden_states.shape[-1] == DRAFT_HIDDEN
+
+    def test_none_aux_still_works(self):
+        out = self._run(None, CaptureHiddenMode.LAST)
+        assert out.hidden_states.shape[-1] == DRAFT_HIDDEN
+
+    def test_populated_aux_is_still_concatenated(self):
+        """The guard must not disable real EAGLE3-style aux capture."""
+        aux = [jnp.ones((3, DRAFT_HIDDEN), dtype=DTYPE) for _ in range(2)]
+        out = self._run(aux, CaptureHiddenMode.LAST)
+        assert out.hidden_states.shape[-1] == 2 * DRAFT_HIDDEN

--- a/python/sgl_jax/test/speculative/test_spec_dp_seq_lens.py
+++ b/python/sgl_jax/test/speculative/test_spec_dp_seq_lens.py
@@ -1,0 +1,58 @@
+"""DP-attention layout regressions for speculative scheduler sequence lengths."""
+
+import numpy as np
+import pytest
+
+from sgl_jax.srt.managers.scheduler import _split_spec_new_seq_lens
+
+
+def test_split_compact_spec_sequence_lengths_across_unbalanced_dp_ranks():
+    values = np.arange(31, dtype=np.int32)
+
+    rank0, rank1 = _split_spec_new_seq_lens(
+        values,
+        real_bs_per_dp=[15, 16],
+        per_dp_bs=32,
+    )
+
+    np.testing.assert_array_equal(rank0, np.arange(15, dtype=np.int32))
+    np.testing.assert_array_equal(rank1, np.arange(15, 31, dtype=np.int32))
+
+
+def test_split_padded_spec_sequence_lengths_across_unbalanced_dp_ranks():
+    values = np.concatenate(
+        (
+            np.arange(15, dtype=np.int32),
+            np.full(17, -1, dtype=np.int32),
+            np.arange(100, 116, dtype=np.int32),
+            np.full(16, -1, dtype=np.int32),
+        )
+    )
+
+    rank0, rank1 = _split_spec_new_seq_lens(
+        values,
+        real_bs_per_dp=[15, 16],
+        per_dp_bs=32,
+    )
+
+    np.testing.assert_array_equal(rank0, np.arange(15, dtype=np.int32))
+    np.testing.assert_array_equal(rank1, np.arange(100, 116, dtype=np.int32))
+
+
+def test_split_spec_sequence_lengths_rejects_unknown_layout():
+    with pytest.raises(ValueError, match="neither compact nor DP-padded"):
+        _split_spec_new_seq_lens(
+            np.arange(30, dtype=np.int32),
+            real_bs_per_dp=[15, 16],
+            per_dp_bs=32,
+        )
+
+
+@pytest.mark.parametrize("real_bs_per_dp", ([33, 0], [-1, 1]))
+def test_split_spec_sequence_lengths_rejects_invalid_dp_geometry(real_bs_per_dp):
+    with pytest.raises(ValueError, match="Invalid speculative DP batch geometry"):
+        _split_spec_new_seq_lens(
+            np.arange(32, dtype=np.int32),
+            real_bs_per_dp=real_bs_per_dp,
+            per_dp_bs=32,
+        )

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -312,8 +312,22 @@ suites = {
             0.1,
             runner="pytest",
         ),
+        TestFile("python/sgl_jax/test/models/test_gemma4_mtp.py", 3, runner="pytest"),
         TestFile("python/sgl_jax/test/multimodal/test_rotary_embedding.py", 0.1),
         TestFile("test/srt/test_radix_input_ids.py", 0.1, runner="pytest"),
+        # Gemma 4 Frozen-KV MTP integration boundaries: target-KV access,
+        # request-state merge, and device-first target verify handoff.
+        TestFile(
+            "python/sgl_jax/test/speculative/test_frozen_kv_mtp_merge.py",
+            1,
+            runner="pytest",
+        ),
+        TestFile(
+            "python/sgl_jax/test/speculative/test_frozen_kv_mtp_verify.py",
+            1,
+            runner="pytest",
+        ),
+        TestFile("python/sgl_jax/test/speculative/test_gemma4_mtp_e2e.py", 9, runner="pytest"),
         TestFile("test/srt/test_tokenizer_manager_event.py", 0.1),
         TestFile("test/srt/disaggregation/test_pd_auth.py", 0.3, runner="pytest"),
         TestFile("test/srt/disaggregation/test_pd_bootstrap.py", 0.5, runner="pytest"),


### PR DESCRIPTION
## Motivation

This PR adds text-only Gemma 4 Frozen-KV MTP speculative decoding on the
SGLang-JAX TPU path.

Closes #1522.

Gemma 4's assistant is not an independent causal draft model: its query-only
attention reads the target model's committed KV cache and target hidden state,
and it must not create or mutate an assistant-owned KV cache. Supporting it
therefore requires a dedicated worker lifecycle rather than treating it as an
ordinary EAGLE/NEXTN checkpoint.

The server continues to expose the familiar `NEXTN` launch interface (similar
to the [SGLang implementation](https://github.com/sgl-project/sglang/pull/24436)).
When it recognizes a supported Gemma 4 assistant architecture, it promotes the
request to the dedicated `FROZEN_KV_MTP` implementation.

## Supported contract and non-goals

Validated configuration:

- target: `google/gemma-4-31B-it`;
- assistant: `google/gemma-4-31B-it-assistant`;
- text-only serving on TPU;
- TP=4 on TPU v6e-4;
- DP attention with DP=2 and effective TP=4 per replica on TPU v6e-8
  (`--tp-size 8 --dp-size 2`);
- linear speculation with `topk=1`;
- greedy request sampling for the fused two-dispatch path;
- `speculative_num_draft_tokens == speculative_num_steps + 1`;
- non-overlap scheduling;
- FlashAttention with page size 128.

This PR does not enable speculative overlap scheduling or branched/top-k>1
Frozen-KV speculation. Unsupported model/algorithm combinations fail at
startup, and non-greedy requests are rejected before speculative execution.
Existing non-Gemma speculative configurations remain on their existing
workers; Frozen-KV MTP is off unless a supported assistant is selected.

## Modifications

The diff is large but mostly additive implementation and focused tests:

| Category | Files | Additions | Deletions | Reviewer focus |
|---|---:|---:|---:|---|
| Assistant and Frozen-KV implementation | 6 | 2,489 | 0 | Assistant model, dedicated worker, compact state, seed relay, fused decode |
| Shared model/runtime integration | 16 | 638 | 106 | Scheduler, attention metadata, EAGLE hooks, launch validation, DP layouts |
| Tests and suite registration | 9 | 2,130 | 0 | Geometry, lifecycle, merge/filter, verification, E2E, DP relay/layout, request validation |
| Documentation | 1 | 30 | 1 | Supported launch contract |
| **Total** | **32** | **5,287** | **107** | |

### Core invariants

1. **Target KV ownership:** the assistant aliases the target's committed KV by
   attention group and never writes assistant-owned KV.
2. **Logical page metadata:** target verification compacts each request's
   logical pages independently; another request's reserved pages must never be
   interpreted as its prefix.
3. **Seed alignment:** the accepted token and matching target hidden-state row
   remain aligned through padded batches, merge, filter, and retract.
4. **Merge capability:** a newly completed prefill may join an active
   non-overlap Frozen-KV decode batch only after its speculative state satisfies
   the lifecycle contract.
5. **DP layout handling:** compact live-request metadata remains compact until
   it is scattered into the scheduler-selected DP-sharded bucket. Compact and
   scheduler-padded sequence/allocation metadata are distinguished explicitly,
   including unbalanced replica splits such as 15/16.
6. **Fail-fast launch contract:** unsupported assistants, overlap, `topk>1`,
   and inconsistent step/token counts are rejected at startup.
7. **Two fused dispatches in greedy steady state:** a supported greedy decode
   round executes exactly one fused draft executable,
   `jit_draft_extend_fused`, and exactly one fused target-verification
   executable, `jit_fused_verify`. Acceptance, accepted-row selection, seed
   relay updates, assistant seed execution, and recurrent proposal work remain
   fused inside those two compiled programs rather than appearing as separate
   TPU dispatches.
8. **No assistant prefill or decode fallback:** target prefill publishes its
   final token/hidden pair as the initial seed. The assistant starts only in
   `jit_draft_extend_fused`; incompatible runners and unsupported sampling are
   rejected instead of silently selecting the removed host-orchestrated path.

The steady-state execution shape is therefore:

```text
target prefill -> publish initial target token/hidden seed
               -> jit_draft_extend_fused (seed + recurrent proposals + verify packing)
               -> jit_fused_verify (target forward + acceptance + next-seed publication)
               -> repeat the last two dispatches
```

### Suggested review order

The commits are intended to be reviewed in order:

1. `d858c55c` — assistant model/configuration and model-level tests.
2. `f94c5bdc` — reusable draft-state and device-verification hooks.
3. `56ceb46d` — capability-based startup precompile for the non-overlap
   speculative prefill path; this does not reintroduce a decode fallback.
4. `6754416d` — target KV and target-hidden-state sharing.
5. `54465605` — per-request Frozen-KV page metadata.
6. `ba498200` — worker lifecycle, merge/filter state, seed relay, and focused
   tests.
7. `0c9e7e0c` — assistant detection, argument validation, and server routing.
8. `19c17d70` — registered test-suite coverage.
9. `34d70ed3` — user-facing launch documentation.
10. `418d4d5f` — DP-attention relay and compact/padded metadata handling.
11. `8f37fda4` — fused Frozen-KV verification, seed relay, and fixed-depth
    draft proposal dispatches.
12. `184f5567` — reject sampling contracts unsupported by the fused linear
    worker.
13. `8c3b1edc` — remove the legacy host-orchestrated Frozen-KV decode fallback
    and its obsolete state.

## Correctness validation

### Focused local tests

The focused model, lifecycle, verification, E2E, launch, relay, and DP-layout
suite passes on both CPU and TPU: **93 passed** in each environment. The final
TPU run completed in 23.00 seconds.

<details>
<summary>Focused test command</summary>

```bash
python -m pytest -q \
  python/sgl_jax/test/speculative/test_frozen_kv_mtp_merge.py \
  python/sgl_jax/test/speculative/test_frozen_kv_mtp_relay_dp.py \
  python/sgl_jax/test/speculative/test_frozen_kv_mtp_verify.py \
  python/sgl_jax/test/speculative/test_gemma4_mtp_e2e.py \
  python/sgl_jax/test/speculative/test_spec_request_validation.py \
  python/sgl_jax/test/models/test_gemma4_mtp.py
```

</details>

### Full GSM8K on TPU

The final fused TP=4 evaluation used concurrency 32 and completed without
scheduler exceptions. The DP-attention row is the earlier real v6e-8
qualification; the final branch additionally passes the focused TPU DP
relay/layout coverage above.

| Hardware / parallelism | Examples | Score | Result |
|---|---:|---:|---|
| TPU v6e-4, TP=4, final fused decode | 1,319 / 1,319 | **0.976497** | PASS |
| TPU v6e-8, DP attention DP=2, effective TP=4/replica, pre-fusion | 1,319 / 1,319 | **0.974981** | PASS |

```bash
python test/srt/run_eval.py \
  --eval-name gsm8k \
  --num-threads 32 \
  --host 127.0.0.1 \
  --port 30000
```

## Performance validation

### Final random 1024/4096 matrix — TPU v6e-4, TP=4

Every cell uses the reviewer-requested workload:

- random dataset with fixed 1,024-token input and 4,096-token output
  (`range_ratio=1`);
- `3 * concurrency` prompts at concurrency 1 / 2 / 4 / 8 / 16 / 32 / 64 / 128;
- request rate `inf`;
- radix cache disabled and zero cache hits;
- fresh target-only and MTP server processes with otherwise identical flags;
- diagnostics and XProf disabled;
- a 1,024/32 conditioning pass before each measured cell.

The target-only and pre-fusion columns are the controlled 2026-09-10 results.
The final column was rerun after fused dispatch and removal of the legacy
decode fallback. Its tested content matches final branch commit `8c3b1edc`.
TTFT is omitted because this long-output matrix measures steady-state decode
performance.

The percentage columns are throughput deltas calculated as
`(fused / comparison - 1) * 100`. For example, `+190.8%` means that fused MTP
delivers 290.8% of baseline throughput, or 2.908x baseline.

| C | Prompts | Baseline tok/s | Pre-fusion MTP tok/s | Final fused MTP tok/s | Throughput Δ vs baseline | Throughput Δ vs pre-fusion |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 3 | 54.30 | 72.33 | **157.89** | **+190.8%** | **+118.3%** |
| 2 | 6 | 104.28 | 135.33 | **293.74** | **+181.7%** | **+117.1%** |
| 4 | 12 | 200.21 | 263.16 | **555.97** | **+177.7%** | **+111.3%** |
| 8 | 24 | 375.70 | 532.87 | **984.70** | **+162.1%** | **+84.8%** |
| 16 | 48 | 525.79 | 755.10 | **1,431.22** | **+172.2%** | **+89.5%** |
| 32 | 96 | 526.32 | 763.50 | **1,446.31** | **+174.8%** | **+89.4%** |
| 64 | 192 | 553.45 | 776.54 | **1,469.65** | **+165.5%** | **+89.3%** |
| 128 | 384 | 554.97 | 779.26 | **1,490.78** | **+168.6%** | **+91.3%** |

| C | Baseline TPOT ms | Pre-fusion MTP TPOT ms | Final fused MTP TPOT ms |
|---:|---:|---:|---:|
| 1 | 18.37 | 13.77 | **6.29** |
| 2 | 19.11 | 14.06 | **6.47** |
| 4 | 19.90 | 14.10 | **6.66** |
| 8 | 21.18 | 14.50 | **7.38** |
| 16 | 22.80 | 16.08 | **8.57** |
| 32 | 22.92 | 18.51 | **10.12** |
| 64 | 23.03 | 21.82 | **11.93** |
| 128 | 22.99 | 28.59 | **14.22** |

All measured and conditioning cells completed successfully. Across the final
fused matrix, 1,886 log samples had mean accepted length **3.815** (minimum
2.00, maximum 4.00). All 930 logged prefill samples reported
`#cached-token: 0`.

### XProf: exactly two fused top-level dispatches per speculative round

This is the profile after implementing `jit_fused_verify` and `jit_draft_extend_fused`

<img width="1386" height="1044" alt="0ebfa8c129bb91d0a87640b9572adb35" src="https://github.com/user-attachments/assets/3c5ed621-efa8-4802-ac17-3e9a14c42819" />


There is no third top-level executable. `reshard`, `gather`, `add`, and
`select_n` are internal HLO operations within the two programs rather than
independently dispatched work. The trace contains no `jitted_model_rule` or
standalone `jitted_run_model` execution anymore. 

### DP-attention qualification — TPU v6e-8, DP=2

This uses `--tp-size 8 --dp-size 2`, i.e. two data-parallel serving replicas
with effective TP=4 per replica. The workload is the requested C=32 point:
random 1,024/4,096, 96 prompts, request rate `inf`, overlap and radix cache
disabled.

| Metric | Target-only baseline | Frozen-KV MTP | Change |
|---|---:|---:|---:|
| Output throughput | 987.22 tok/s | 1,153.65 tok/s | **+16.9%** |
| Mean TPOT / ITL | 24.26 ms | 20.02 ms | **-17.5%** |

This pre-fusion result qualifies non-overlap DP attention at DP=2, not generic
model-training DP or multi-host serving. The full concurrency-32 GSM8K run
also completed all 1,319 examples with score **0.974981** and no scheduler
exceptions. The fused route has TPU unit coverage for DP metadata but still
requires a fresh v6e-8 DP=2 end-to-end rerun.

## Overlap schedule status

Overlap scheduling is not implemented in this PR. Omitting
`--disable-overlap-schedule` exits nonzero before serving with:

```text
ValueError: FROZEN_KV_MTP currently requires --disable-overlap-schedule.
```

This is intentional fail-fast qualification, not an overlap benchmark.

## Reproduction commands

<details>
<summary>Environment and server arguments</summary>

```bash
export TARGET=google/gemma-4-31B-it
export TARGET_REVISION=842da3794eaa0b77d5f08bae87a17459d91ff475
export DRAFT=google/gemma-4-31B-it-assistant
export DRAFT_REVISION=627c5ec1458b9086b841a91e0512fd31fd2fbbf1

unset SGLJAX_SPEC_STAGE_TIMING
unset SGLJAX_SPEC_ADMISSION_TRACE
unset SGLJAX_SPEC_KV_DEBUG
unset SGLJAX_SPEC_VERIFY_DEBUG

COMMON_SERVER_ARGS=(
  --model-path "$TARGET"
  --revision "$TARGET_REVISION"
  --context-length 8192
  --max-seq-len 8192
  --port 30000
  --device tpu
  --attention-backend fa
  --tp-size 4
  --page-size 128
  --mem-fraction-static 0.85
  --max-running-requests 128
  --max-prefill-tokens 4096
  --chunked-prefill-size 4096
  --precompile-token-paddings 4096
  --swa-full-tokens-ratio 0.8
  --max-total-tokens 55000
  --random-seed 3
  --trust-remote-code
  --skip-server-warmup
  --disable-overlap-schedule
  --disable-radix-cache
)

MTP_ARGS=(
  --speculative-algorithm NEXTN
  --speculative-draft-model-path "$DRAFT"
  --speculative-draft-model-revision "$DRAFT_REVISION"
  --speculative-num-steps 3
  --speculative-num-draft-tokens 4
  --speculative-eagle-topk 1
)
```

Start a fresh target-only server:

```bash
python -m sgl_jax.launch_server "${COMMON_SERVER_ARGS[@]}"
```

Or start a fresh Frozen-KV MTP server:

```bash
python -m sgl_jax.launch_server \
  "${COMMON_SERVER_ARGS[@]}" \
  "${MTP_ARGS[@]}"
```

For the v6e-8 DP-attention run, replace `--tp-size 4` with:

```bash
--tp-size 8 --dp-size 2
```

</details>

<details>
<summary>Steady-state two-dispatch XProf</summary>

Start the MTP server above and leave it running. In one shell, start a
decode-stage capture:

```bash
PROFILE_ROOT="$PWD/gemma4-mtp-xprof"
mkdir -p "$PROFILE_ROOT"

python -m sgl_jax.profiler \
  --url http://127.0.0.1:30000 \
  --output-dir "$PROFILE_ROOT" \
  --profile-name steady \
  --num-steps 100 \
  --profile-by-stage \
  --profile-stages decode \
  > "$PROFILE_ROOT/profile.txt" 2>&1 &
PROFILE_PID=$!
```

In a second shell, drive a single long request so the measured window contains
warm steady-state decode rounds:

```bash
python -m sgl_jax.bench_serving \
  --backend sglang --dataset-name random \
  --num-prompts 1 --max-concurrency 1 \
  --random-input-len 1024 --random-output-len 1024 \
  --random-range-ratio 1 --request-rate inf \
  --warmup-requests 0 --seed 1 \
  --host 127.0.0.1 --port 30000 \
  > "$PROFILE_ROOT/bench.txt"

wait "$PROFILE_PID"
```

Open the resulting `plugins/profile/...trace.json.gz` in XProf and count
top-level `CommonPjRtLoadedExecutable::Execute` events. Do not use the
profiled benchmark's latency or throughput as a performance measurement.

</details>

<details>
<summary>Requested 1024/4096 matrix</summary>

Run the loop once against a fresh target-only server and once against a fresh
MTP server. Keep the server flags identical except for `MTP_ARGS`.

```bash
RUN_KIND=baseline  # use mtp for the MTP server
RESULT_DIR="$PWD/gemma4-mtp-matrix/$RUN_KIND"
mkdir -p "$RESULT_DIR"

for C in 1 2 4 8 16 32 64 128; do
  python -m sgl_jax.bench_serving \
    --backend sglang \
    --dataset-name random \
    --num-prompts "$C" \
    --random-input-len 1024 \
    --random-output-len 32 \
    --random-range-ratio 1 \
    --max-concurrency "$C" \
    --request-rate inf \
    --warmup-requests 0 \
    --seed 1 \
    --host 127.0.0.1 \
    --port 30000 \
    > "$RESULT_DIR/conditioning-c${C}.txt" || exit 1

  python -m sgl_jax.bench_serving \
    --backend sglang \
    --dataset-name random \
    --num-prompts "$((3 * C))" \
    --random-input-len 1024 \
    --random-output-len 4096 \
    --random-range-ratio 1 \
    --max-concurrency "$C" \
    --request-rate inf \
    --warmup-requests 0 \
    --seed 1 \
    --host 127.0.0.1 \
    --port 30000 \
    > "$RESULT_DIR/measured-c${C}.txt" || exit 1
done
```

</details>

<details>
<summary>DP-attention C=32 A/B</summary>

Start target-only and MTP servers separately with `--tp-size 8 --dp-size 2`,
then run this conditioning pass followed by the measured pass against each:

```bash
python -m sgl_jax.bench_serving \
  --backend sglang --dataset-name random \
  --num-prompts 32 --max-concurrency 32 \
  --random-input-len 1024 --random-output-len 32 \
  --random-range-ratio 1 --request-rate inf \
  --warmup-requests 0 --seed 1 \
  --host 127.0.0.1 --port 30000

python -m sgl_jax.bench_serving \
  --backend sglang --dataset-name random \
  --num-prompts 96 --max-concurrency 32 \
  --random-input-len 1024 --random-output-len 4096 \
  --random-range-ratio 1 --request-rate inf \
  --warmup-requests 0 --seed 1 \
  --host 127.0.0.1 --port 30000
```

</details>

## Checklist

- [x] English description and linked motivation.
- [x] Focused CPU tests: 93 passed.
- [x] Final fused TPU-focused tests: 93 passed.
- [x] Full final-fused GSM8K at concurrency 32 on TP=4: 1,319/1,319,
      score 0.976497.
- [x] Pre-fusion full GSM8K and performance qualification with DP attention DP=2.
- [x] Final fused v6e-4 C=1..128 sweep with fixed 1,024/4,096 lengths.
- [x] XProf confirms exactly two fused top-level decode executables per round.
- [x] Cache-hit rate confirmed zero with radix cache disabled.
- [ ] Rerun fused DP-attention correctness and performance on v6e-8.
- [x] Unsupported overlap scheduling fails explicitly at launch.
- [x] Unsupported non-greedy requests fail before speculative execution.
- [x] Exact rerun commands included.
- [x] User-facing launch documentation included.
