### PR TITLE
fix(mla): bind mesh explicitly to shard_map in MLA and DSA attention backends

### DIFF
--- a/python/sgl_jax/srt/kernels/fused_mlp.py
+++ b/python/sgl_jax/srt/kernels/fused_mlp.py
@@ -128,18 +128,18 @@ def apply_fused_mlp_sharded(
     b_inter: int = 128,
 ) -> jax.Array:
     in_specs = (
-        P(None, None),  # x
+        P("data", None),  # x
         P(None, "tensor"),  # w_gu (combined gate/up weight, sharded along tensor axis)
         P("tensor", None),  # wd (down weight, sharded along tensor axis)
     )
-    out_specs = P(None, None)
+    out_specs = P("data", None)
 
     @functools.partial(
         shard_map,
         mesh=mesh,
         in_specs=in_specs,
         out_specs=out_specs,
-        check_rep=False,
+        check_vma=False,
     )
     def local_fused_mlp(x_loc, w_gu_loc, wd_loc):
         seq_len, hidden_size = x_loc.shape

--- a/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
+++ b/python/sgl_jax/srt/layers/attention/dsa_sparse_backend.py
@@ -420,7 +420,9 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
                 vmem_limit_bytes=self.vmem_limit_bytes,
             )
 
-        return jax.shard_map(_run, in_specs=in_specs, out_specs=out_specs, check_vma=False)(
+        return jax.shard_map(
+            _run, mesh=self.mesh, in_specs=in_specs, out_specs=out_specs, check_vma=False
+        )(
             ql,
             qpe,
             kvc,
@@ -473,7 +475,9 @@ class DSASparseAttentionBackend(MLAAttentionBackend):
                 vmem_limit_bytes=self.vmem_limit_bytes,
             )
 
-        return jax.shard_map(_run, in_specs=in_specs, out_specs=out_specs, check_vma=False)(
+        return jax.shard_map(
+            _run, mesh=self.mesh, in_specs=in_specs, out_specs=out_specs, check_vma=False
+        )(
             ql,
             qpe,
             kvc,

--- a/python/sgl_jax/srt/layers/attention/mla_backend.py
+++ b/python/sgl_jax/srt/layers/attention/mla_backend.py
@@ -358,6 +358,7 @@ class MLAAttentionBackend(AttentionBackend):
 
         o_latent, updated_cache = jax.shard_map(
             _run,
+            mesh=self.mesh,
             in_specs=in_specs,
             out_specs=out_specs,
             check_vma=False,


### PR DESCRIPTION
## Description
1. Explicitly pass `mesh=self.mesh` to `jax.shard_map` invocations in both `MLAAttentionBackend` and `DSASparseAttentionBackend`.
2. Update `apply_fused_mlp_sharded` in `fused_mlp.py` to support `P("data", None)` sharded inputs/outputs and replace `check_rep=False` with `check_vma=False`.

### Motivation
When running in data-parallel or unified mesh environments (e.g., DP=32, TP=1 or hybrid TP/DP), `jax.shard_map` requires the explicit mesh context and correct data partition specifications to resolve against the global mesh.

> **Note:** Code cleanup and unified mesh consolidation are currently in progress.

### Test Plan
- Verified shard_map partitioning across TP=32, DP=32, and EP=32 configurations.
- Tested inference and forward pass on TPU v7x.