### PR TITLE
feat(vlm): support offline multimodal inputs and add Qwen3-VL CI coverage

### DIFF
--- a/.github/workflows/nightly-test-daily.yml
+++ b/.github/workflows/nightly-test-daily.yml
@@ -6,10 +6,7 @@ name: Nightly Test Daily
 run-name: >-
   ${{ inputs.pr_number != '' && format('Nightly Test Daily — PR #{0} {1}', inputs.pr_number, inputs.cases || inputs.job_filter) || 'Nightly Test Daily' }}
 
-# NOTE: The daily nightly suites are currently empty shells. Coverage will be
-# redefined as part of the nightly vs daily split decision. The workflow is
-# kept so any new daily case can be added by populating run_suite.py without
-# restructuring CI.
+# The single-host catalog also carries VLM cases alongside text-model cases.
 
 on:
   schedule:
@@ -186,6 +183,8 @@ jobs:
           persist-credentials: false
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
+        with:
+          install-target: python[all,multimodal]
       - name: Run 4-TPU accuracy daily suite
         id: run
         timeout-minutes: 150
@@ -212,6 +211,13 @@ jobs:
             cp "${files[@]}" "$DEST"/
             echo "Published ${#files[@]} accuracy JSON file(s) to $DEST"
           fi
+
+      - name: Upload accuracy results, including per-sample VLM answers
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: single-host-accuracy-results
+          path: test/nightly_test_output/accuracy
 
   nightly-test-accuracy-4-tpu-comment:
     # Posts PASS/FAIL from a clean job (no PR-HEAD code ran here) so the write token

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -103,6 +103,8 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
+        with:
+          install-target: python[all,multimodal]
       - name: Run e2e test
         timeout-minutes: 120
         shell: bash

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -325,6 +325,32 @@ jobs:
               python3 scripts/ci/publish.py --data-type perf --source-dir ./test/nightly_test_output
 
 
+  weekly-test-vlm-4-tpu:
+    if: github.repository == 'sgl-project/sglang-jax'
+    runs-on: arc-runner-v6e-4-us-south1-ai1b
+    env:
+      JAX_COMPILATION_CACHE_DIR: /xla-cache
+      RESULTS_DIR: ${{ github.workspace }}/test/nightly_test_output/vlm
+      VLM_TP_SIZE: "4"
+      VLM_FULL_REGRESSION: "1"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-venv
+        with:
+          install-target: python[all,multimodal]
+      - name: Check VLM cache, chunk and encoder sharding equivalence
+        timeout-minutes: 60
+        run: python test/srt/test_vlm_models.py
+      - name: Run full MMBench V1.1 CircularEval
+        if: ${{ !cancelled() }}
+        timeout-minutes: 120
+        run: python test/srt/nightly/single_host/suite_runner.py --suite vlm-weekly-v6e-4
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: weekly-vlm-results
+          path: test/nightly_test_output/vlm
+
   nightly-test-finish:
     needs: [
       nightly-test-accuracy-text-models-1-tpu,
@@ -333,6 +359,7 @@ jobs:
       nightly-test-perf-text-models-4-tpu-part1,
       nightly-test-perf-text-models-4-tpu-part2,
       nightly-test-perf-text-models-4-tpu-part3,
+      weekly-test-vlm-4-tpu,
     ]
     if: always() && github.repository == 'sgl-project/sglang-jax'
     runs-on: ubuntu-latest
@@ -350,6 +377,7 @@ jobs:
 
           has_failure=false
           for job_result in \
+            "vlm-4-tpu=${{ needs.weekly-test-vlm-4-tpu.result }}" \
             "accuracy-1-tpu=${{ needs.nightly-test-accuracy-text-models-1-tpu.result }}" \
             "accuracy-4-tpu=${{ needs.nightly-test-accuracy-text-models-4-tpu.result }}" \
             "perf-text-1-tpu=${{ needs.nightly-test-perf-text-models-1-tpu.result }}" \

--- a/docs/architecture/02-entrypoints-and-tokenization.md
+++ b/docs/architecture/02-entrypoints-and-tokenization.md
@@ -229,11 +229,17 @@ engine = Engine(model_path="Qwen/Qwen2.5-7B")
 result = engine.generate(prompt="Hello", sampling_params={"max_new_tokens": 50})
 
 # Asynchronous
-async for chunk in engine.async_generate(prompt="Hello", sampling_params={"max_new_tokens": 50}, stream=True):
+chunks = await engine.async_generate(prompt="Hello", sampling_params={"max_new_tokens": 50}, stream=True)
+async for chunk in chunks:
     print(chunk)
 ```
 
 `generate()` builds a `GenerateReqInput` and delegates to `tokenizer_manager.generate_request()` for processing. In streaming mode, the async generator is wrapped as a sync generator.
+
+Both methods accept keyword-only `image_data` and `video_data`. For batched
+prompts, pass one media entry per prompt; nest lists for multiple images.
+Qwen-VL requires chat-template-formatted text in `prompt`, rather than
+multimodal `input_ids`. Pass media separately from `sampling_params`.
 
 **Extension APIs**:
 

--- a/docs/developer_guide/ci_architecture.md
+++ b/docs/developer_guide/ci_architecture.md
@@ -192,6 +192,7 @@ Test files are located in the folder ```test/srt/*``` and start with prefix ```t
 | --- | --- | --- |
 | Qwen-7B (TP only)<br>Qwen3-8B (TP only)<br>Qwen3-30B-A3B (enable TP and EP)<br>gemma2<br>bailing_moe(enable TP and EP) | • mmlu<br>• mmlu-pro<br>• aime-24/25<br>• gsm8k | 2% |
 | deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B | • mmlu<br>• mmlu-pro<br>• aime-24/25<br>• gsm8k<br>• math | 2% |
+| Qwen3-VL-2B-Instruct (TP4) | MMBench_DEV_EN_V11 CircularEval: 200 questions daily; full dev weekly | Daily: 75% ±5 pp (70–80%); weekly: 77% ±3 pp (74–80%) |
 
 ### Performance Test (1x TPU, 4x TPUs)
 #### PR Test Workflow

--- a/python/sgl_jax/srt/entrypoints/engine.py
+++ b/python/sgl_jax/srt/entrypoints/engine.py
@@ -42,6 +42,7 @@ from sgl_jax.srt.managers.io_struct import (
     ContinueGenerationReqInput,
     EmbeddingReqInput,
     GenerateReqInput,
+    MultimodalDataInputFormat,
     PauseGenerationReqInput,
     ReleaseMemoryOccupationReqInput,
     ResumeMemoryOccupationReqInput,
@@ -163,6 +164,9 @@ class Engine(EngineBase):
         stream: bool = False,
         lora_path: list[str] | str | None = None,
         return_routed_experts: list[bool] | bool | None = False,
+        *,
+        image_data: MultimodalDataInputFormat | None = None,
+        video_data: MultimodalDataInputFormat | None = None,
     ) -> dict | Iterator[dict]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -183,6 +187,8 @@ class Engine(EngineBase):
             stream=stream,
             lora_path=lora_path,
             return_routed_experts=return_routed_experts,
+            image_data=image_data,
+            video_data=video_data,
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
 
@@ -214,6 +220,9 @@ class Engine(EngineBase):
         stream: bool = False,
         lora_path: list[str] | str | None = None,
         return_routed_experts: list[bool] | bool | None = False,
+        *,
+        image_data: MultimodalDataInputFormat | None = None,
+        video_data: MultimodalDataInputFormat | None = None,
     ) -> dict | AsyncIterator[dict]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -234,6 +243,8 @@ class Engine(EngineBase):
             stream=stream,
             lora_path=lora_path,
             return_routed_experts=return_routed_experts,
+            image_data=image_data,
+            video_data=video_data,
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
 

--- a/test/srt/eval/mmbench_utils.py
+++ b/test/srt/eval/mmbench_utils.py
@@ -1,0 +1,108 @@
+# Copyright 2023 VLMEvalKit Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 (see repository LICENSE)
+# Adapted from open-compass/VLMEvalKit at d21c5e969983dea6741a98eb2f7ec566ab82ee91:
+# vlmeval/utils/matching_util.py and vlmeval/vlm/qwen3_vl/prompt.py.
+# Changes: retain only Qwen3-VL MCQ text and exact-matching answer extraction;
+# use the standard logger instead of VLMEvalKit's logger. No LLM judge fallback.
+
+import copy as cp
+import logging
+import os
+import re
+import string
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+_VERBOSE_ANSWER_RE = re.compile(r"(?i)(?:correct\s+)?answer\s+is\s+\**([ABCD])\**")
+
+
+def choices_for(row):
+    return {
+        letter: row[letter]
+        for letter in string.ascii_uppercase
+        if letter in row and not pd.isna(row[letter])
+    }
+
+
+def prompt_for(row):
+    options = choices_for(row)
+    hint = row.get("hint")
+    prompt = f"Hint: {hint}\n" if hint is not None and not pd.isna(hint) else ""
+    prompt += f"Question: {row['question']}\n"
+    if options:
+        prompt += "Options:\n"
+        prompt += "".join(f"{letter}. {text}\n" for letter, text in options.items())
+        prompt += "Answer with the option letter only."
+    return prompt.rstrip()
+
+
+def can_infer_option(answer, choices):
+    verbose = os.environ.get("VERBOSE", 0)
+    # Choices is a dictionary
+    if "Failed to obtain answer via API" in answer:
+        return False
+
+    reject_to_answer = [
+        "Sorry, I can't help with images of people yet.",
+        "I can't process this file.",
+        "I'm sorry, but without the image provided",
+        "Cannot determine the answer",
+    ]
+    for err in reject_to_answer:
+        if err in answer:
+            return "Z"
+
+    def count_choice(splits, choices, prefix="", suffix=""):
+        cnt = 0
+        for c in choices:
+            if prefix + c + suffix in splits:
+                cnt += 1
+        return cnt
+
+    answer_mod = cp.copy(answer)
+    chars = ".()[],:;!*#{}"
+    for c in chars:
+        answer_mod = answer_mod.replace(c, " ")
+
+    splits = [x.strip() for x in answer_mod.split()]
+    count = count_choice(splits, choices)
+
+    if count == 1:
+        for ch in choices:
+            if "A" in splits and len(splits) > 3 and verbose:
+                logger.info("A might be a quantifier in the string: %s.", answer)
+                return False
+            if ch in splits and splits.index(ch) > (len(splits) - 5):
+                return ch
+    elif count == 0 and count_choice(splits, {"Z", ""}) == 1:
+        return "Z"
+
+    match = _VERBOSE_ANSWER_RE.search(answer or "")
+    if match and match.group(1).upper() in choices:
+        return match.group(1).upper()
+
+    return False
+
+
+def can_infer_text(answer, choices):
+    answer = answer.lower()
+    if len(answer) > 2 * sum(len(str(v)) for v in choices.values()):
+        return False
+    assert isinstance(choices, dict)
+    for k in choices:
+        assert k in string.ascii_uppercase
+        choices[k] = str(choices[k]).lower()
+    cands = []
+    for k in choices:
+        if choices[k] in answer:
+            cands.append(k)
+    if len(cands) == 1:
+        return cands[0]
+    return False
+
+
+def can_infer(answer, choices):
+    answer = str(answer)
+    copt = can_infer_option(answer, choices)
+    return copt if copt else can_infer_text(answer, choices)

--- a/test/srt/eval/simple_eval_mmbench.py
+++ b/test/srt/eval/simple_eval_mmbench.py
@@ -1,0 +1,167 @@
+"""MMBench V1.1: pinned questions, Qwen3-VL prompts and CircularEval."""
+
+# Image reference resolution / CircularEval adapted from VLMEvalKit's
+# vlmeval/dataset/image_base.py and dataset/utils/multiple_choice.py at REVISION.
+# Copyright 2023 VLMEvalKit Authors. SPDX-License-Identifier: Apache-2.0.
+# Changes: fixed single-image dataset, in-memory scoring, no judge/result cache.
+# See repository LICENSE.
+
+import base64
+import hashlib
+import io
+import json
+import math
+import os
+import random
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pandas as pd
+from eval.mmbench_utils import can_infer, choices_for, prompt_for
+from PIL import Image
+from vlm_utils import MODEL_REVISION, complete, image_content
+
+DATASET = "MMBench_DEV_EN_V11"
+DATASET_SHA256 = "27a54ae2e8f54502361cc5a41ed5fc35f4253af74734b5593d7b1de545eb5656"
+REVISION = "d21c5e969983dea6741a98eb2f7ec566ab82ee91"
+
+
+def load_data():
+    # Preserve VLMEvalKit's existing cache environment variable.
+    root = os.environ.get("LMUData", Path.home() / "LMUData")  # noqa: SIM112
+    path = Path(root) / f"{DATASET}.tsv"
+    if not path.exists():
+        import requests
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        url = f"https://opencompass.openxlab.space/utils/benchmarks/MMBench/{DATASET}.tsv"
+        try:
+            response = requests.get(url, timeout=120)
+        except requests.exceptions.SSLError:
+            # The public dataset host has an expired certificate. Authenticate the
+            # bytes with the pinned SHA256 below; never disable TLS globally.
+            response = requests.get(url, timeout=120, verify=False)
+        response.raise_for_status()
+        if hashlib.sha256(response.content).hexdigest() != DATASET_SHA256:
+            raise ValueError("MMBench V1.1 checksum mismatch")
+        path.write_bytes(response.content)
+    if hashlib.sha256(path.read_bytes()).hexdigest() != DATASET_SHA256:
+        raise ValueError("MMBench V1.1 checksum mismatch")
+    data = pd.read_csv(path, sep="\t")
+    # The pinned TSV stores a base64 image or the index of another image row.
+    images = dict(zip(data["index"].astype(str), data["image"].astype(str)))
+    data["image"] = [
+        images[value] if len(value) <= 64 else value for value in data["image"].astype(str)
+    ]
+    return data
+
+
+def select_indices(data, limit):
+    originals = data.loc[data["index"].between(0, 999_999), "index"].tolist()
+    if limit is None:
+        ids = originals
+    elif 0 < limit <= len(originals):
+        ids = random.Random(0).sample(originals, limit)
+    else:
+        raise ValueError("MMBench limit must be between 1 and the number of original questions")
+    if not ids or len(set(ids)) != len(ids) or not set(ids) <= set(originals):
+        raise ValueError("Missing or duplicate MMBench question IDs")
+    selected = data[data["index"].mod(1_000_000).isin(ids)].copy()
+    # Preserve every row from the checksum-pinned source for these originals.
+    # Some four-option questions have only three rotations ("all of the above"
+    # stays fixed), so option count must not determine group completeness.
+    if not selected["index"].is_unique:
+        raise ValueError("Duplicate MMBench permutation IDs")
+    return selected
+
+
+def messages_for(row):
+    with Image.open(io.BytesIO(base64.b64decode(row["image"]))) as image:
+        content = [image_content(image), {"type": "text", "text": prompt_for(row)}]
+    return [{"role": "user", "content": content}]
+
+
+def run_mmbench(args):
+    from openai import OpenAI
+
+    started = time.monotonic()
+    data = select_indices(load_data(), args.num_examples)
+    generation = {
+        "temperature": args.temperature,
+        "max_tokens": args.max_tokens,
+        "seed": args.seed,
+    }
+    with tempfile.TemporaryDirectory(prefix="mmbench-v11-") as temporary:
+        output = (
+            Path(os.environ.get("RESULTS_DIR", temporary))
+            / f"mmbench-v11-{args.num_examples or 'full'}"
+        )
+        output.mkdir(parents=True, exist_ok=True)
+        prepared = time.monotonic()
+        base_url = args.base_url or f"http://{args.host}:{args.port}"
+        with OpenAI(
+            base_url=base_url + "/v1", api_key="EMPTY", timeout=120, max_retries=0
+        ) as client:
+
+            def evaluate(row):
+                try:
+                    answer = complete(client, messages_for(row), **generation)
+                except Exception as exc:
+                    raise RuntimeError(f"MMBench {row['index']}: {exc}") from exc
+                return {
+                    "id": int(row["index"]),
+                    "answer": row["answer"],
+                    "response": answer,
+                }
+
+            samples = []
+            with (
+                ThreadPoolExecutor(max_workers=args.num_threads) as pool,
+                (output / "responses.jsonl").open("w") as stream,
+            ):
+                try:
+                    for sample in pool.map(evaluate, (row for _, row in data.iterrows())):
+                        samples.append(sample)
+                        stream.write(json.dumps(sample) + "\n")
+                        stream.flush()
+                except Exception:
+                    pool.shutdown(wait=False, cancel_futures=True)
+                    raise
+        inferred = time.monotonic()
+        if len(samples) != len(data):
+            raise ValueError("Missing MMBench responses")
+        predictions = data.drop(columns="image", errors="ignore").copy()
+        predictions["prediction"] = [sample["response"] for sample in samples]
+        predictions["parsed_answer"] = predictions.apply(
+            lambda row: can_infer(row["prediction"], choices_for(row)) or "Z", axis=1
+        )
+        predictions["correct"] = predictions["parsed_answer"] == predictions["answer"]
+        # All source permutations must be correct; unmatched answers fail the group.
+        questions = predictions.groupby(predictions["index"].mod(1_000_000))["correct"].all()
+        score = questions.mean()
+        if score is None or not math.isfinite(score):
+            raise ValueError("MMBench produced no finite score")
+        predictions.to_csv(output / "predictions.tsv", sep="\t", index=False)
+        questions.to_csv(output / "questions.csv")
+        ids = [str(sample["id"]) for sample in samples]
+        return {
+            "score": float(score),
+            "num_examples": int(data["index"].mod(1_000_000).nunique()),
+            "num_requests": len(samples),
+            "dataset_id": DATASET,
+            "dataset_sha256": DATASET_SHA256,
+            "vlmevalkit_revision": REVISION,
+            "model_revision": MODEL_REVISION,
+            "split": "dev",
+            "evaluation_protocol": "circulareval-exact-matching",
+            "prompt_version": "qwen3-vl-vlmevalkit",
+            "sample_ids_sha256": hashlib.sha256("\n".join(ids).encode()).hexdigest(),
+            "timing_seconds": {
+                "prepare": prepared - started,
+                "inference": inferred - prepared,
+                "grading": time.monotonic() - inferred,
+            },
+            "samples": samples,
+        }

--- a/test/srt/multimodal/test_engine_multimodal.py
+++ b/test/srt/multimodal/test_engine_multimodal.py
@@ -1,0 +1,63 @@
+"""CPU contract tests for embedded multimodal generation."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from sgl_jax.srt.entrypoints.engine import Engine
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("media_field", ["image_data", "video_data"])
+@pytest.mark.parametrize("batched", [False, True])
+def test_engine_preserves_media(asynchronous, stream, media_field, batched):
+    # Multiple images/frames per prompt must remain grouped through normalization.
+    media = [["first-a", "first-b"], ["second"]]
+    prompts = ["first prompt", "second prompt"]
+    expected = [{"text": "first answer"}, {"text": "second answer"}]
+    if not batched:
+        media, prompts, expected = media[0], prompts[0], expected[0]
+
+    async def generate_request(request, _):
+        assert getattr(request, media_field) is media
+        request.normalize_batch_and_arguments()
+        for i in range(2 if batched else 1):
+            item = request[i] if batched else request
+            assert item.text == (prompts[i] if batched else prompts)
+            assert getattr(item, media_field) == (media[i] if batched else media)
+            assert item.return_logprob
+        if request.stream:
+            for result in expected if batched else [expected]:
+                yield result
+        else:
+            yield expected
+
+    loop = asyncio.new_event_loop()
+    engine = SimpleNamespace(
+        loop=loop,
+        tokenizer_manager=SimpleNamespace(generate_request=generate_request),
+    )
+    kwargs = dict(
+        prompt=prompts,
+        sampling_params={"max_new_tokens": 2},
+        return_logprob=True,
+        stream=stream,
+        **{media_field: media},
+    )
+
+    async def run_async():
+        result = await Engine.async_generate(engine, **kwargs)
+        return [item async for item in result] if stream else result
+
+    try:
+        if asynchronous:
+            result = loop.run_until_complete(run_async())
+        else:
+            result = Engine.generate(engine, **kwargs)
+            if stream:
+                result = list(result)
+        assert result == ([expected] if stream and not batched else expected)
+    finally:
+        loop.close()

--- a/test/srt/nightly/cases.py
+++ b/test/srt/nightly/cases.py
@@ -157,6 +157,7 @@ class AccuracyCase:
     limit: int | None = None
     timeout: int | None = None
     score_threshold: float | None = None
+    score_upper_threshold: float | None = None
 
 
 # Default gsm8k sampling (greedy). Lives here (host-neutral, stdlib-only) so the

--- a/test/srt/nightly/launch_profiles/qwen3-vl-2b-v6e-4.yaml
+++ b/test/srt/nightly/launch_profiles/qwen3-vl-2b-v6e-4.yaml
@@ -1,0 +1,37 @@
+name: qwen3-vl-2b-tp4
+target: v6e-4
+model_path: Qwen/Qwen3-VL-2B-Instruct
+revision: 89644892e4d85e24eaac8bacfd4f463576704203
+tp_size: 4
+dp_size: 1
+port: 30020
+server_args:
+  - --skip-server-warmup
+  - --dtype
+  - bfloat16
+  - --attention-backend
+  - fa
+  - --page-size
+  - "64"
+  - --context-length
+  - "4096"
+  - --max-seq-len
+  - "4096"
+  - --max-running-requests
+  - "4"
+  - --max-total-tokens
+  - "16384"
+  - --max-prefill-tokens
+  - "4096"
+  - --chunked-prefill-size
+  - "4096"
+  - --precompile-token-paddings
+  - "4096"
+  - --precompile-bs-paddings
+  - "4"
+  - --precompile-vision-patch-paddings
+  - "12288"
+  - --mem-fraction-static
+  - "0.8"
+  - --random-seed
+  - "42"

--- a/test/srt/nightly/multi_host/accuracy_case_runner.py
+++ b/test/srt/nightly/multi_host/accuracy_case_runner.py
@@ -65,6 +65,12 @@ def run_accuracy_case(case: AccuracyCase, profile: LaunchProfile) -> None:
                     f"against threshold={case.score_threshold}"
                 ),
             )
+        if case.score_upper_threshold is not None and score > case.score_upper_threshold:
+            raise SuiteError(
+                kind="threshold",
+                message=f"Accuracy case {case.name} score={score:.4f} above "
+                f"upper threshold={case.score_upper_threshold:.4f}",
+            )
         if score < case.score_threshold:
             raise SuiteError(
                 kind="threshold",

--- a/test/srt/nightly/profiles.py
+++ b/test/srt/nightly/profiles.py
@@ -58,6 +58,7 @@ class LaunchProfile(BaseModel):
     name: str
     target: str
     model_path: str
+    revision: str | None = None
     tp_size: int = Field(gt=0)
     dp_size: int = Field(gt=0)
     ep_size: int | None = Field(default=None, gt=0)

--- a/test/srt/nightly/results.py
+++ b/test/srt/nightly/results.py
@@ -81,7 +81,9 @@ def build_accuracy_result(
     if case.score_threshold is None or score is None:
         passed = None
     else:
-        passed = score >= case.score_threshold
+        passed = score >= case.score_threshold and (
+            case.score_upper_threshold is None or score <= case.score_upper_threshold
+        )
 
     return {
         "schema_version": ACCURACY_RESULT_SCHEMA_VERSION,
@@ -93,6 +95,11 @@ def build_accuracy_result(
         "target": target,
         "score": score,
         "score_threshold": case.score_threshold,
+        **(
+            {"score_upper_threshold": case.score_upper_threshold}
+            if case.score_upper_threshold is not None
+            else {}
+        ),
         "passed": passed,
         "metrics": metrics if isinstance(metrics, dict) else {},
         "started_at": _utc_iso(started_at),

--- a/test/srt/nightly/schemas/accuracy_result.v1.yaml
+++ b/test/srt/nightly/schemas/accuracy_result.v1.yaml
@@ -100,11 +100,18 @@ fields:
     description: "Lower bound the case is gated against. Null = warn-only (no gating)."
     example: 0.85
 
+  score_upper_threshold:
+    type: [number, "null"]
+    required: false
+    description: "Optional inclusive upper bound, used with score_threshold."
+    example: 0.80
+
   passed:
     type: [boolean, "null"]
     required: true
     description: |
-      Gating outcome. `true` iff `score >= score_threshold`. Null when either
+      Gating outcome. `true` iff `score >= score_threshold` and the optional
+      upper bound is not exceeded. Null when either
       `score` or `score_threshold` is null (gating not applicable).
     example: true
 

--- a/test/srt/nightly/single_host/accuracy_case_runner.py
+++ b/test/srt/nightly/single_host/accuracy_case_runner.py
@@ -80,6 +80,11 @@ def run_accuracy_case(
 
     score = result["score"]
     threshold = case.score_threshold
+    upper = (
+        f", upper_threshold={_fmt(case.score_upper_threshold)}"
+        if case.score_upper_threshold is not None
+        else ""
+    )
     if result["passed"] is True:
         status = "PASS"
     elif result["passed"] is False:
@@ -89,12 +94,13 @@ def run_accuracy_case(
 
     if is_in_ci():
         write_github_step_summary(
-            f"### {case.name}\n" f"score={_fmt(score)}  threshold={_fmt(threshold)}  **{status}**\n"
+            f"### {case.name}\n"
+            f"score={_fmt(score)}  threshold={_fmt(threshold)}{upper}  **{status}**\n"
         )
 
     print(
         f"[accuracy-runner] {case.name}: score={_fmt(score)}, "
-        f"threshold={_fmt(threshold)}, {status}",
+        f"threshold={_fmt(threshold)}{upper}, {status}",
         flush=True,
     )
 
@@ -128,8 +134,15 @@ def profile_server_spec(profile: LaunchProfile) -> dict:
         dist_init_addr=f"127.0.0.1:{profile.port + _DIST_INIT_PORT_OFFSET}",
         port=profile.port,
     )
+    if profile.revision:
+        from huggingface_hub import snapshot_download
+
+        # Use the same immutable snapshot for weights, tokenizer and benchmark processor.
+        model = snapshot_download(profile.model_path, revision=profile.revision)
+    else:
+        model = _local_or_hf(profile.model_path)
     return {
-        "model": _local_or_hf(profile.model_path),
+        "model": model,
         "base_url": f"http://127.0.0.1:{profile.port}",
         "other_args": build_other_server_args(profile, runtime),
     }

--- a/test/srt/nightly/single_host/suite_runner.py
+++ b/test/srt/nightly/single_host/suite_runner.py
@@ -83,6 +83,19 @@ def _gsm8k_case(name: str, model_id: str, threshold: float, eval_batch_size: int
     )
 
 
+def _mmbench_case(name: str, limit: int | None, threshold: float) -> AccuracyCase:
+    return AccuracyCase(
+        name=name,
+        dataset="mmbench_v11",
+        model_id="Qwen/Qwen3-VL-2B-Instruct",
+        limit=limit,
+        eval_batch_size=4,
+        generation_config={"temperature": 0.0, "max_tokens": 32, "seed": 42},
+        score_threshold=threshold,
+        score_upper_threshold=0.80,
+    )
+
+
 SUITES: dict[str, SingleHostSuite] = {
     "accuracy-text-models-v6e-4": SingleHostSuite(
         name="accuracy-text-models-v6e-4",
@@ -147,6 +160,19 @@ SUITES: dict[str, SingleHostSuite] = {
             SingleHostRun(
                 launch_profile="qwen3-moe-fp8-fused-v6e-4.yaml",
                 cases=[_gsm8k_case("qwen3-moe-fp8-fused", "Qwen/Qwen3-30B-A3B-FP8", 0.93, 64)],
+            ),
+            SingleHostRun(
+                launch_profile="qwen3-vl-2b-v6e-4.yaml",
+                cases=[_mmbench_case("qwen3-vl-2b-mmbench-v11", 200, 0.70)],
+            ),
+        ],
+    ),
+    "vlm-weekly-v6e-4": SingleHostSuite(
+        name="vlm-weekly-v6e-4",
+        runs=[
+            SingleHostRun(
+                launch_profile="qwen3-vl-2b-v6e-4.yaml",
+                cases=[_mmbench_case("qwen3-vl-2b-mmbench-v11-full", None, 0.74)],
             ),
         ],
     ),
@@ -215,6 +241,12 @@ def _gate_accuracy(case: AccuracyCase, result: dict) -> tuple[str, str] | None:
         return None
     if result["score"] is None:
         return ("case", f"{case.name}: eval produced no score")
+    if case.score_upper_threshold is not None and result["score"] > case.score_upper_threshold:
+        return (
+            "threshold",
+            f"{case.name}: score={result['score']:.4f} above "
+            f"upper threshold={case.score_upper_threshold:.4f}",
+        )
     if not result["passed"]:
         return (
             "threshold",

--- a/test/srt/run_eval.py
+++ b/test/srt/run_eval.py
@@ -51,6 +51,11 @@ def run_eval(args):
 
     base_url = f"{args.base_url}/v1" if args.base_url else f"http://{args.host}:{args.port}/v1"
 
+    if args.eval_name == "mmbench_v11":
+        from eval.simple_eval_mmbench import run_mmbench
+
+        return run_mmbench(args)
+
     if args.eval_name == "mmlu":
         from eval.simple_eval_mmlu import MMLUEval
 

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -304,6 +304,7 @@ suites = {
     # have a conditional CPU pin gated on USE_DEVICE_TYPE=cpu — the
     # cpu-test CI job sets that env var.
     "unit-test-cpu": [
+        TestFile("test/srt/test_vlm_ci.py", 0.1, runner="pytest"),
         TestFile("test/srt/multimodal/test_engine_multimodal.py", 0.1, runner="pytest"),
         TestFile(
             "python/sgl_jax/test/test_embedding_pool.py",
@@ -541,6 +542,7 @@ suites = {
         ),
     ],
     "e2e-test-tpu-v6e-1": [
+        TestFile("test/srt/test_vlm_models.py", 15),
         # openai_server e2e test
         TestFile("test/srt/openai_server/basic/test_openai_server.py", 1),
         TestFile("test/srt/openai_server/features/test_ebnf.py", 2),

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -304,6 +304,7 @@ suites = {
     # have a conditional CPU pin gated on USE_DEVICE_TYPE=cpu — the
     # cpu-test CI job sets that env var.
     "unit-test-cpu": [
+        TestFile("test/srt/multimodal/test_engine_multimodal.py", 0.1, runner="pytest"),
         TestFile(
             "python/sgl_jax/test/test_embedding_pool.py",
             0.1,

--- a/test/srt/test_vlm_ci.py
+++ b/test/srt/test_vlm_ci.py
@@ -1,0 +1,177 @@
+"""CPU checks for CircularEval integrity, response failures and VLM routing."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from eval.mmbench_utils import can_infer
+from eval.simple_eval_mmbench import messages_for, run_mmbench, select_indices
+from PIL import Image
+from vlm_utils import image_content
+
+
+@pytest.fixture
+def mmbench_data():
+    image = image_content(Image.new("RGB", (8, 8), "red"))["image_url"]["url"].split(",", 1)[1]
+    common = {
+        "category": "test",
+        "split": "dev",
+        "question": "Which color?",
+        "hint": "Look.",
+        "image": image,
+        "C": None,
+        "D": None,
+    }
+    return pd.DataFrame(
+        [
+            dict(common, index=0, A="red", B="blue", answer="A"),
+            dict(common, index=1000000, A="blue", B="red", answer="B"),
+        ]
+    )
+
+
+def test_mmbench_preserves_image_hint_and_options(mmbench_data):
+    messages = messages_for(mmbench_data.iloc[0])
+    assert [m["role"] for m in messages] == ["user"]
+    content = messages[0]["content"]
+    assert content[0] == image_content(Image.new("RGB", (8, 8), "red"))
+    assert "Hint: Look." in content[1]["text"]
+    assert "A. red" in content[1]["text"] and "B. blue" in content[1]["text"]
+    assert "C." not in content[1]["text"]
+
+
+def test_mmbench_selection_preserves_all_source_rotations(mmbench_data):
+    data = mmbench_data
+    assert len(select_indices(data, None)) == 2
+    assert select_indices(data, None)["index"].tolist() == [0, 1000000]
+    with pytest.raises(ValueError, match="Missing"):
+        select_indices(data.iloc[0:0], None)
+    assert select_indices(data, 1)["index"].tolist() == [0, 1000000]
+    for limit in (0, -1, 200):
+        with pytest.raises(ValueError, match="limit"):
+            select_indices(data, limit)
+
+
+def test_mmbench_sampling_is_repeatable_and_preserves_groups(mmbench_data):
+    data = pd.concat(
+        [mmbench_data.assign(index=mmbench_data["index"] + i) for i in range(4)],
+        ignore_index=True,
+    )
+    expected = [1, 1000001, 3, 1000003]
+    assert select_indices(data, 2)["index"].tolist() == expected
+    assert select_indices(data, 2)["index"].tolist() == expected
+
+
+def test_mmbench_four_options_can_have_three_source_rotations(mmbench_data):
+    data = pd.concat([mmbench_data, mmbench_data.iloc[:1]], ignore_index=True)
+    data["index"] = [0, 1000000, 2000000]
+    data["C"] = "green"
+    data["D"] = "All above are not right"
+    assert len(select_indices(data, None)) == 3
+
+
+def test_mmbench_rejects_corrupt_cached_dataset(monkeypatch, tmp_path):
+    from eval.simple_eval_mmbench import DATASET, load_data
+
+    monkeypatch.setenv("LMUData", str(tmp_path))
+    (tmp_path / f"{DATASET}.tsv").write_text("corrupt")
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        load_data()
+
+
+@pytest.mark.parametrize(
+    "answers,score",
+    [(["A. red", "B. red"], 1.0), (["A", "A"], 0.0), (["A or B", "B"], 0.0)],
+)
+def test_circular_scoring_and_repeated_runs(monkeypatch, tmp_path, mmbench_data, answers, score):
+    monkeypatch.setattr("eval.simple_eval_mmbench.load_data", lambda: mmbench_data)
+    monkeypatch.setenv("RESULTS_DIR", str(tmp_path))
+    client = MagicMock()
+    client.__enter__.return_value = client
+    create = client.chat.completions.create
+
+    def response(text, reason="stop"):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(finish_reason=reason, message=SimpleNamespace(content=text))]
+        )
+
+    monkeypatch.setattr("openai.OpenAI", lambda **kwargs: client)
+    args = SimpleNamespace(
+        base_url="http://localhost:30000",
+        num_examples=None,
+        num_threads=1,
+        temperature=0,
+        max_tokens=32,
+        seed=42,
+    )
+    create.side_effect = [response(a) for a in answers]
+    result = run_mmbench(args)
+    assert result["score"] == score
+    assert result["num_examples"] == 1 and result["num_requests"] == 2
+    assert [s["id"] for s in result["samples"]] == [0, 1000000]
+    # Repeating in the same artifact directory must grade the new responses.
+    create.side_effect = [response("A"), response("A")]
+    assert run_mmbench(args)["score"] == 0.0
+    for score in (None, float("nan"), float("inf")):
+        create.side_effect = [response("A"), response("B")]
+        with monkeypatch.context() as patch:
+            patch.setattr(pd.Series, "mean", lambda self, value=score: value)
+            with pytest.raises(ValueError, match="no finite score"):
+                run_mmbench(args)
+    create.side_effect = [response("A", "length")]
+    with pytest.raises(RuntimeError, match="Incomplete VLM response"):
+        run_mmbench(args)
+    create.side_effect = [response("  ")]
+    with pytest.raises(RuntimeError, match="Incomplete VLM response"):
+        run_mmbench(args)
+    args.base_url = None
+    args.host, args.port = "localhost", 30000
+    create.side_effect = [response("A"), response("B")]
+    assert run_mmbench(args)["score"] == 1.0
+    create.side_effect = RuntimeError("server failed")
+    with pytest.raises(RuntimeError, match="server failed"):
+        run_mmbench(args)
+
+
+@pytest.mark.parametrize(
+    "answer,expected",
+    [
+        ("B. dog", "B"),
+        ("The answer is **B**.", "B"),
+        ("dog", "B"),
+        ("A or B", False),
+        ("b", False),
+        ("Cannot determine the answer", "Z"),
+    ],
+)
+def test_mmbench_answer_extraction(answer, expected, monkeypatch):
+    monkeypatch.delenv("VERBOSE", raising=False)
+    assert can_infer(answer, {"A": "cat", "B": "dog"}) == expected
+
+
+def test_mmbench_uses_standard_eval_entrypoint(monkeypatch):
+    from run_eval import run_eval
+
+    expected = {"score": 0.75}
+    args = SimpleNamespace(eval_name="mmbench_v11", base_url=None, host="localhost", port=30000)
+    monkeypatch.setattr("run_eval.set_ulimit", lambda: None)
+    monkeypatch.setattr("eval.simple_eval_mmbench.run_mmbench", lambda received: expected)
+    assert run_eval(args) == expected
+
+
+@pytest.mark.parametrize("limit,lower", [(200, 0.70), (None, 0.74)])
+@pytest.mark.parametrize(
+    "point,expected",
+    [("below", False), ("lower", True), ("upper", True), ("above", False)],
+)
+def test_mmbench_score_interval(limit, lower, point, expected):
+    from nightly.results import build_accuracy_result
+    from nightly.single_host.suite_runner import _gate_accuracy, _mmbench_case
+
+    case = _mmbench_case("test", limit, lower)
+    score = {"below": lower - 0.001, "lower": lower, "upper": 0.80, "above": 0.801}[point]
+    result = build_accuracy_result(case, "test", "v7x-8", {"score": score}, 0, 1)
+    assert result["score_upper_threshold"] == 0.80
+    assert result["passed"] is expected
+    assert (_gate_accuracy(case, result) is None) is expected

--- a/test/srt/test_vlm_models.py
+++ b/test/srt/test_vlm_models.py
@@ -1,0 +1,132 @@
+"""Real-weight VLM smoke and scheduling regression (one TPU by default)."""
+
+import os
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+from openai import OpenAI
+from PIL import Image
+from vlm_utils import complete, image_content
+
+from sgl_jax.srt.utils import kill_process_tree
+from sgl_jax.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_server,
+)
+
+
+class TestVLM(unittest.TestCase):
+    def test_serving_equivalence(self):
+        from nightly.single_host.accuracy_case_runner import (
+            load_profile_file,
+            profile_server_spec,
+        )
+
+        profile = load_profile_file("qwen3-vl-2b-v6e-4.yaml")
+        profile.tp_size = int(os.getenv("VLM_TP_SIZE", "1"))
+        full = os.getenv("VLM_FULL_REGRESSION") == "1"
+        inputs = [
+            ([("red", (224, 224))], "red"),
+            ([("blue", (224, 224))], "blue"),
+            ([("red", (224, 224)), ("blue", (224, 224))], "red"),
+            ([("blue", (224, 224)), ("red", (224, 224))], "blue"),
+        ]
+        if full:
+            # 784 vision tokens cross a 256-token chunk; reserved for weekly CI.
+            inputs += [
+                ([("red", (448, 224))], "red"),
+                ([("blue", (896, 896))], "blue"),
+            ]
+        messages = [
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        *[image_content(Image.new("RGB", size, color)) for color, size in images],
+                        {
+                            "type": "text",
+                            "text": "What color fills the first image? Answer with one color word only.",
+                        },
+                    ],
+                }
+            ]
+            for images, _ in inputs
+        ]
+        # Include a text-only request in the same concurrent workload.
+        messages.append([{"role": "user", "content": "Reply with exactly the word hello."}])
+        expected = [answer for _, answer in inputs] + ["hello"]
+        reference = None
+        modes = [("256", False, "dp")]
+        if full:
+            modes.insert(0, ("-1", True, "dp"))
+        if full and profile.tp_size > 1:
+            modes.append(("256", False, "tp"))
+        for chunk, no_cache, encoder in modes:
+            with self.subTest(chunk=chunk, no_cache=no_cache, encoder=encoder):
+                spec = profile_server_spec(profile)
+                # Bound cold compilation to this fixed four-request workload.
+                # Four small-image requests contain at most 1536 patches.
+                extra = [
+                    "--context-length",
+                    "1024",
+                    "--max-seq-len",
+                    "1024",
+                    "--max-total-tokens",
+                    "4096",
+                    "--chunked-prefill-size",
+                    chunk,
+                    "--vision-encoder-parallel",
+                    encoder,
+                    "--max-prefill-tokens",
+                    "2048" if full else "256",
+                    "--precompile-token-paddings",
+                    "256",
+                    *(["2048"] if full else []),
+                    "--max-running-requests",
+                    "4",
+                    "--precompile-bs-paddings",
+                    "4",
+                    "--precompile-vision-patch-paddings",
+                    "5120" if full else "1536",
+                ]
+                if no_cache:
+                    extra.append("--disable-radix-cache")
+                process = popen_launch_server(
+                    spec["model"],
+                    spec["base_url"],
+                    timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                    other_args=spec["other_args"] + extra,
+                )
+                try:
+                    with OpenAI(
+                        base_url=spec["base_url"] + "/v1",
+                        api_key="EMPTY",
+                        timeout=120,
+                        max_retries=0,
+                    ) as client:
+
+                        def ask(message):
+                            return (
+                                complete(client, message, temperature=0, max_tokens=16, seed=42)
+                                .lower()
+                                .strip(" .!\n")
+                            )
+
+                        if full:
+                            serial = list(map(ask, messages))
+                            self.assertEqual(serial, expected)
+                            reference = serial if reference is None else reference
+                            self.assertEqual(serial, reference)
+                        response = requests.post(spec["base_url"] + "/flush_cache", timeout=30)
+                        response.raise_for_status()
+                        with ThreadPoolExecutor(max_workers=4) as pool:
+                            # Cold mixed batch, then the same workload with cached images/prefixes.
+                            for _ in range(2):
+                                self.assertEqual(list(pool.map(ask, messages)), expected)
+                finally:
+                    kill_process_tree(process.pid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/vlm_utils.py
+++ b/test/srt/vlm_utils.py
@@ -1,0 +1,26 @@
+"""Small shared helpers for deterministic VLM serving tests."""
+
+import base64
+import io
+
+MODEL_ID = "Qwen/Qwen3-VL-2B-Instruct"
+MODEL_REVISION = "89644892e4d85e24eaac8bacfd4f463576704203"
+
+
+def image_content(image):
+    buffer = io.BytesIO()
+    image.convert("RGB").save(buffer, format="PNG")
+    url = "data:image/png;base64," + base64.b64encode(buffer.getvalue()).decode()
+    return {"type": "image_url", "image_url": {"url": url}}
+
+
+def complete(client, messages, **generation):
+    response = client.chat.completions.create(model=MODEL_ID, messages=messages, **generation)
+    choice = response.choices[0]
+    content = (choice.message.content or "").strip()
+    if choice.finish_reason != "stop" or not content:
+        raise ValueError(
+            f"Incomplete VLM response: {choice.finish_reason}; "
+            f"content={(choice.message.content or '')[:200]!r}"
+        )
+    return content


### PR DESCRIPTION
## Motivation

Add regression coverage for Qwen3-VL and support multimodal inputs in the offline Engine API.

## Modifications

  - Use Qwen/Qwen3-VL-2B-Instruct for all VLM CI tests.
  - Support image/video inputs in the offline Engine API.
  - PR: 8 solid-color image questions and 2 text-only requests, covering image order and cold/warm caches (~1m15s).
  - Nightly: MMBench V1.1 CircularEval on 200 questions, with a 70–80% accuracy range (~2m05s).
  - Weekly: full-dev evaluation (74–80%) and 63 serving checks for chunking, cache, and encoder DP/TP equivalence (~8m12s).
  - Use a local evaluator without a VLMEvalKit dependency.
## Accuracy Tests

  - v7x TP8: PR smoke and 63 weekly serving checks passed.
  - MMBench: 78.5% nightly; 77.01% full dev.
  - v6e validation pending.

  ## Benchmarking and Profiling

  Not run; no performance changes.

  ## Checklist

  - [x] Please use English, otherwise it will be closed.
  - [x] The purpose of the PR, or link existing issues this PR will resolve.
  - [x] The test plan, such as providing test command.
  - [x] (Optional) The necessary documentation update.