### PR TITLE
perf(grouped-topk): use FP32 priorities for stable index reductions

### DIFF
--- a/python/sgl_jax/srt/kernels/grouped_topk/v1/kernel.py
+++ b/python/sgl_jax/srt/kernels/grouped_topk/v1/kernel.py
@@ -14,12 +14,14 @@ Design — tokens in the lane dim (`[E, BT]`):
 Algorithm (matches `_biased_grouped_topk` exactly, ties included):
     scores = router_logits + correction_bias                    # post-bias "scores_for_choice"
     ① group score = sum of top-2 per group (2-pass max, no sort)
-    ② select `topk_group` groups        (max + masked-min: lowest-index tie-break)
-    ③ mask dropped groups to -inf, select `topk` experts (max + masked-min), weight = PRE-bias logit
+    ② select `topk_group` groups        (max + stable lowest-index tie-break)
+    ③ mask dropped groups to -inf, select `topk` experts (stable tie-break), weight = PRE-bias logit
 Renormalize / routed_scaling_factor are applied by the caller (`TopK.__call__`).
 
 Tie-break: selection uses `max` + masked `min(iota)` (smallest index achieving the max) rather than
 `argmax`, because TPU Mosaic's reduction argmax does not break ties toward the lowest index.
+For unpacked inputs with index bounds at most 2**24, the masked minimum is computed equivalently
+as a float32 maximum of negative indices, then negated and converted to int32 after reduction.
 """
 
 from __future__ import annotations
@@ -73,6 +75,8 @@ def _grouped_topk_kernel(
 ):
     S = num_experts // n_group
     E = num_experts
+    # Float32 exactly represents every index and the no-match sentinels within these bounds.
+    use_float_priority = not packed and n_group <= 2**24 and E <= 2**24
 
     # Transpose to [E, BT]: experts in sublane, tokens in lane. Every reduction below is over axis 0.
     logits = logits_ref[...].astype(jnp.float32).T  # [E, BT] pre-bias
@@ -90,14 +94,25 @@ def _grouped_topk_kernel(
         v2 = jnp.max(jnp.where(s_iota == i1, NEG_INF, sg), axis=1, keepdims=True)
         group_scores = jnp.squeeze(v1 + v2, axis=1)  # [G, BT]
 
-    # ② select `topk_group` groups, lowest-index tie-break (max + masked-min).
+    # ② select `topk_group` groups, lowest-index tie-break.
     with jax.named_scope("group_select"):
         group_mask = jnp.zeros((n_group, bt), dtype=jnp.bool_)
         g_iota = jax.lax.broadcasted_iota(jnp.int32, (n_group, bt), 0)
+        if use_float_priority:
+            g_priority = -g_iota.astype(jnp.float32)
         tmp = group_scores
         for _ in range(topk_group):
             gmax = jnp.max(tmp, axis=0, keepdims=True)
-            gi = jnp.min(jnp.where(tmp == gmax, g_iota, n_group), axis=0, keepdims=True)
+            if use_float_priority:
+                gi = (
+                    -jnp.max(
+                        jnp.where(tmp == gmax, g_priority, jnp.float32(-n_group)),
+                        axis=0,
+                        keepdims=True,
+                    )
+                ).astype(jnp.int32)
+            else:
+                gi = jnp.min(jnp.where(tmp == gmax, g_iota, n_group), axis=0, keepdims=True)
             m = g_iota == gi
             group_mask = jnp.logical_or(group_mask, m)
             tmp = jnp.where(m, NEG_INF, tmp)
@@ -115,8 +130,8 @@ def _grouped_topk_kernel(
     #    small and static) so the picks overlap.
     #
     #    Two selection modes (compile-time `packed`):
-    #      packed=False — the f32 contract: `max` + masked-`min` finds the smallest expert id at the
-    #        max score, bit-exact to `lax.top_k` on the f32 scores.
+    #      packed=False — the f32 contract: `max` + a stable tie-break finds the smallest expert id
+    #        at the max score, bit-exact to `lax.top_k` on the f32 scores.
     #      packed=True  — the bf16 contract: bf16-round each score into an int32 order-preserving key
     #        (plain int order == (score DESC, index ASC)), so each pick is ONE reduction + a low-bit
     #        decode instead of the max+masked-min pair. Lossless for bf16 inputs (the low 16 mantissa
@@ -124,6 +139,8 @@ def _grouped_topk_kernel(
     #        the caller selects packed only when router_logits is bf16.
     with jax.named_scope("final_select"):
         e_iota = jax.lax.broadcasted_iota(jnp.int32, (E, bt), 0)
+        if use_float_priority:
+            e_priority = -e_iota.astype(jnp.float32)
         row_iota = jax.lax.broadcasted_iota(jnp.int32, (topk, bt), 0)
         ids_init = jnp.full((topk, bt), -1, dtype=jnp.int32)
         w_init = jnp.zeros((topk, bt), dtype=jnp.float32)
@@ -150,9 +167,20 @@ def _grouped_topk_kernel(
                 idx = (E - 1) - (kmax & low_mask)  # [1, BT] lowest-index winner from the low bits
             else:
                 cmax = jnp.max(cur, axis=0, keepdims=True)
-                idx = jnp.min(
-                    jnp.where(cur == cmax, e_iota, E), axis=0, keepdims=True
-                )  # [1, BT] lowest expert id achieving the max
+                if use_float_priority:
+                    idx = (
+                        -jnp.max(
+                            jnp.where(cur == cmax, e_priority, jnp.float32(-E)),
+                            axis=0,
+                            keepdims=True,
+                        )
+                    ).astype(
+                        jnp.int32
+                    )  # [1, BT] decode only the reduced winner vector
+                else:
+                    idx = jnp.min(
+                        jnp.where(cur == cmax, e_iota, E), axis=0, keepdims=True
+                    )  # [1, BT] lowest expert id achieving the max
             sel = e_iota == idx  # [E, BT]
             # weight from PRE-bias logits via masked sum (gather is unsupported in Pallas/Mosaic).
             wval = jnp.sum(jnp.where(sel, logits, 0.0), axis=0, keepdims=True)  # [1, BT]


### PR DESCRIPTION
## Motivation

Stable tie-breaking reduces masked int32 indices with min, which lowers to compare/select chains on the measured TPU. Represent bounded index priorities as exact FP32 values, reduce with max, then convert only the winning vector to int32.

### Limitation of the current abstraction

The typed reduction expression hides a profitable representation choice. Existing JAX/Pallas arithmetic expresses the optimization; it adds no compiler primitive. FP32 index encoding is guarded to bounds at most 2**24; packed paths and larger bounds retain their original implementation.

## Modifications

- `python/sgl_jax/srt/kernels/grouped_topk/v1/kernel.py`

## Accuracy Tests

Exact routing indices and weights for captured canonical/scaled inputs. The existing CPU suite passed 22 tests; 12 TPU-only packed-path tests were skipped in the upstream checkout.

All repository pre-commit checks passed for this commit, including the applicable type checker. Each implementation has one DCO-signed commit.

Targeted CPU command used in the upstream checkout:

```bash
JAX_PLATFORMS=cpu PYTHONPATH=python python -m pytest -q python/sgl_jax/test/kernels/grouped_topk_test.py
```

## Benchmarking and Profiling

**Measured on the frozen captured revisions below. These figures are not a benchmark of this PR rebased onto today's upstream main.**

| Captured case | Baseline (us) | Candidate (us) | Reduction | Speedup | Ratio CI95 |
| --- | ---: | ---: | ---: | ---: | --- |
| short | 4.676121 | 4.408894 | **5.71%** | 1.0606x | [0.941455480, 0.944112353] |
| medium | 14.343418 | 13.124316 | **8.50%** | 1.0929x | [0.914464733, 0.915634520] |
| long | 26.066672 | 23.607231 | **9.44%** | 1.1042x | [0.905150018, 0.906152009] |

Hardware: 1 local TPUv6e chip(s); JAX 0.11.1; explicit captured geometry and seed 1729. Each result is a mean of block medians from ten independent baseline/candidate pairs, with 50 exact compiled-program execution spans per block, 20 warmups and separate host timing. The gate requires >2% lower mean device latency and bootstrap ratio CI95 upper bound <1 (10,000 resamples, seed 1729). Canonical/scaled correctness comparisons retain the original tolerance. No full-model speedup is claimed.

### Post-compilation trace evidence

All 20 raw confirmation XPlane traces per shape and their execution records are retained. The publication audit re-read each raw trace, checked the serialized executable's HLO identity, reconstructed all 50 samples and reproduced its median. Multi-chip spans require a shared host execution identity and complete device partitions; single-chip traces may use the recorded device/queue/run identity.

Representative pair 00 for the **short** case:

| Role | Exact HLO identity | Devices | Samples | Block median (us) |
| --- | --- | ---: | ---: | ---: |
| baseline | `jit__lambda` / ID `92` / PID `3125490` | 1 | 50 | 4.671250 |
| candidate | `jit__lambda` / ID `92` / PID `3124752` | 1 | 50 | 4.402422 |

[Download every confirmation trace and the verification bundle](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk.tar.gz). SHA256: `7bb96a83eea476346af8e00972d77c52bdef9b2dd045682872ee2cee59b44617`.

After extraction, `python verify_evidence.py` (NumPy required) checks all bundle hashes and recomputes samples/statistics from the included selected events. Original `.xplane.pb` files remain the primary traces; raw output tensors and every repeated executable are not included.

### Post-compilation HLO and LLO dumps

The measured lowering replaces 1,152 integer compare/select sites with floating maxima. These are static instruction sites, not a cycle estimate.

| Shape | Full baseline LLO | Full candidate LLO | Compiled baseline HLO | Compiled candidate HLO |
| --- | --- | --- | --- | --- |
| short | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk-short-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk-short-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk-short-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk-short-candidate.hlo.txt.gz) |
| medium | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk-medium-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk-medium-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk-medium-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk-medium-candidate.hlo.txt.gz) |
| long | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk-long-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk-long-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk-long-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk-long-candidate.hlo.txt.gz) |

<details>
<summary>Representative records from the full numbered LLO dumps</summary>

These excerpts show static emitted sites selected from changed vector opcodes. Counts and excerpts support code inspection; they do not quantify dynamic cycles.

### baseline

```text
250 : {p0 = slt.s32 s1, $95;  s2 = simm.u32 $0;  v59 = vsel.8x128 vm0, $0x1, v59;  v63 = vand.8x128.u32 $0x380, v62;  [vmem:$0x3ffd8] = vst.8x128 v63}
252 : {p0 = slt.s32 s1, $75;  s2 = simm.u32 @p0 $2;  v61 = vsel.8x128 vm0, $0xc1020000, v61;  v60 = vsel.8x128 vm0, $0xb8e90000, v60;  vm0 = veq.8x128.s32 v63, $128}
253 : {p0 = slt.s32 s1, $65;  s2 = simm.u32 @p0 $3;  v61 = vsel.8x128 vm0, $0x3ee90000, v61;  v60 = vsel.8x128 vm0, $0x471f0000, v60;  vm0 = veq.8x128.s32 v63, $256}
254 : {p0 = slt.s32 s1, $55;  s2 = simm.u32 @p0 $5;  v61 = vsel.8x128 vm0, $0xc0060000, v61;  v60 = vsel.8x128 vm0, $0xb8c80000, v60;  vm0 = veq.8x128.s32 v63, $384}
255 : {s2 = simm.u32 @p0 $8;  v61 = vsel.8x128 vm0, $0x3fb80000, v61;  v60 = vsel.8x128 vm0, $0x47570000, v60;  vm0 = veq.8x128.s32 v63, $512}
256 : {s3 = simm.u32 @p0 $25;  v61 = vsel.8x128 vm0, $0xc1850000, v61;  v60 = vsel.8x128 vm0, $0xc1850000, v60;  vm0 = veq.8x128.s32 v63, $640}
257 : {p0 = slt.s32 s1, $45;  v61 = vsel.8x128 vm0, $0x3c6a0000, v61;  v60 = vsel.8x128 vm0, $0x97eb0000, v60;  vm0 = veq.8x128.s32 v63, $768}
258 : {p0 = slt.s32 s1, $35;  s2 = simm.u32 @p0 $12;  v61 = vsel.8x128 vm0, $0xc3d40000, v61;  v60 = vsel.8x128 vm0, $0x68550000, v60}
```

### candidate

```text
250 : {p0 = slt.s32 s1, $95;  s2 = simm.u32 $0;  v59 = vsel.8x128 vm0, $0x1, v59;  v63 = vand.8x128.u32 $0x380, v62;  [vmem:$0x3ffd8] = vst.8x128 v63}
252 : {p0 = slt.s32 s1, $75;  s2 = simm.u32 @p0 $2;  v61 = vsel.8x128 vm0, $0xc1020000, v61;  v60 = vsel.8x128 vm0, $0xb8e90000, v60;  vm0 = veq.8x128.s32 v63, $128}
253 : {p0 = slt.s32 s1, $65;  s2 = simm.u32 @p0 $3;  v61 = vsel.8x128 vm0, $0x3ee90000, v61;  v60 = vsel.8x128 vm0, $0x471f0000, v60;  vm0 = veq.8x128.s32 v63, $256}
254 : {p0 = slt.s32 s1, $55;  s2 = simm.u32 @p0 $5;  v61 = vsel.8x128 vm0, $0xc0060000, v61;  v60 = vsel.8x128 vm0, $0xb8c80000, v60;  vm0 = veq.8x128.s32 v63, $384}
255 : {s2 = simm.u32 @p0 $8;  v61 = vsel.8x128 vm0, $0x3fb80000, v61;  v60 = vsel.8x128 vm0, $0x47570000, v60;  vm0 = veq.8x128.s32 v63, $512}
256 : {s3 = simm.u32 @p0 $25;  v61 = vsel.8x128 vm0, $0xc1850000, v61;  v60 = vsel.8x128 vm0, $0xc1850000, v60;  vm0 = veq.8x128.s32 v63, $640}
257 : {p0 = slt.s32 s1, $45;  v61 = vsel.8x128 vm0, $0x3c6a0000, v61;  v60 = vsel.8x128 vm0, $0x97eb0000, v60;  vm0 = veq.8x128.s32 v63, $768}
258 : {p0 = slt.s32 s1, $35;  s2 = simm.u32 @p0 $12;  v61 = vsel.8x128 vm0, $0xc3d40000, v61;  v60 = vsel.8x128 vm0, $0x68550000, v60}
```

</details>

### Source provenance and remaining limits

- Measured baseline: `027fa79a6498a1afef5a36c4e093c07d2f12f1ef`; exact measured patch and accepted candidate IDs/revisions are in the bundle.
- PR base: `3f1f38715b5dcd4b8ef11e4186e029e3e90f9570`. PR implementation commit: `15a91036c63c80a78cb5c0ee313990fdc934cee3`.
- The source was ported onto current upstream and checked locally. Fresh TPU lowering/performance confirmation on that upstream revision remains outstanding; this PR is a draft for review.
- Performance is limited to the reported geometries, dtypes, runtime, partition and guarded paths. Original captures and any unsuccessful search attempts are not relabeled as new upstream measurements.

## Checklist

- [x] English description with motivation and implementation scope.
- [x] Test results and reproducible evidence verification command provided.
- [x] Numerical and measurement limitations stated.
- [ ] Fresh TPU validation of the upstream port and any consolidation with overlapping variants.
