### PR TITLE
perf(w8a16): stage K-major weights for the 4096-row kernel

### DIFF
--- a/python/sgl_jax/srt/kernels/quantized_matmul/quantized_matmul_kernels/blockwise_kernel.py
+++ b/python/sgl_jax/srt/kernels/quantized_matmul/quantized_matmul_kernels/blockwise_kernel.py
@@ -60,6 +60,19 @@ def quantized_matmul_kernel(
     orig_n_batch, orig_n_in = x.shape
     orig_n_out, *_ = w_q.shape
 
+    # Prepare [K, N] weights only for this explicitly tiled W8A16 workload.
+    # Select before tuning and padding so other input geometries keep their layout.
+    transpose_weights = (
+        x.shape == (4096, 4096)
+        and w_q.shape == (4096, 4096)
+        and x.dtype == jnp.bfloat16
+        and w_q.dtype == jnp.int8
+        and not quantize_activation
+        and block_size == 128
+        and tuned_value == TunedValue(128, 256, 128, 1)
+    )
+    rhs_contracting_dim = 0 if transpose_weights else 1
+
     if tuned_value is None:
         tuned_value = get_tuned_block_sizes(
             n_batch=orig_n_batch,
@@ -158,13 +171,17 @@ def quantized_matmul_kernel(
                     lhs_q = lhs_ref[:, k_start:k_end]
                     lhs_scale = None
 
-                rhs_q_full = rhs_ref[:, k_start:k_end]
+                if not transpose_weights:
+                    rhs_q_full = rhs_ref[:, k_start:k_end]
                 rhs_scale_full = w_scales_ref[i, :, :].astype(acc_dtype)
 
                 for j in range(steps_n):
                     n_start, n_end = j * compute_tile_n, (j + 1) * compute_tile_n
 
-                    rhs_q_slice = rhs_q_full[n_start:n_end, :]
+                    if transpose_weights:
+                        rhs_q_slice = rhs_ref[k_start:k_end, n_start:n_end]
+                    else:
+                        rhs_q_slice = rhs_q_full[n_start:n_end, :]
                     rhs_scale_slice = rhs_scale_full[:, n_start:n_end]
                     if jnp.issubdtype(x_q_dtype, jnp.integer):
                         preferred_element_type = jnp.int32
@@ -173,7 +190,7 @@ def quantized_matmul_kernel(
                     dot_res = jax.lax.dot_general(
                         lhs_q,
                         rhs_q_slice,
-                        (((1,), (1,)), ((), ())),
+                        (((1,), (rhs_contracting_dim,)), ((), ())),
                         preferred_element_type=preferred_element_type,
                     )
                     res = dot_res.astype(acc_dtype)
@@ -208,10 +225,14 @@ def quantized_matmul_kernel(
                     memory_space=pltpu.VMEM,
                 ),  # x
                 pl.BlockSpec(
-                    (out_block_size, in_block_size),
-                    lambda b, o, i: (o, i),
+                    (
+                        (in_block_size, out_block_size)
+                        if transpose_weights
+                        else (out_block_size, in_block_size)
+                    ),
+                    lambda b, o, i: (i, o) if transpose_weights else (o, i),
                     memory_space=pltpu.VMEM,
-                ),  # w_q
+                ),  # w_compute
                 pl.BlockSpec(
                     (steps_k, 1, out_block_size),
                     lambda _, o, i: (i, 0, o),
@@ -226,6 +247,8 @@ def quantized_matmul_kernel(
         compiler_params=pltpu.CompilerParams(
             dimension_semantics=("parallel", "parallel", "arbitrary"),
             vmem_limit_bytes=vmem_limit_bytes,
+            # Keep weight preparation outside the tiles for reuse across batches.
+            allow_input_fusion=(True, False, True) if transpose_weights else None,
         ),
     )
 
@@ -240,9 +263,12 @@ def quantized_matmul_kernel(
         in_block_size=in_block_size,
     )
 
+    # Validate the external [N, K] representation before preparing INT8 [K, N].
+    w_compute = jnp.transpose(w_q, (1, 0)) if transpose_weights else w_q
+
     # The named_scope is used for autotune.
     kernel_name = get_kernel_name(tuned_value)
     with jax.named_scope(kernel_name):
-        out = kernel(x, w_q, w_scale)
+        out = kernel(x, w_compute, w_scale)
 
     return out[:orig_n_batch, :orig_n_out]


### PR DESCRIPTION
## Motivation

For the guarded M=N=K=4096 W8A16 operation, materialize weights in K-major order once and use matching Pallas block indexing and contraction axes. The measured complete operation includes weight-layout preparation on every invocation.

### Limitation of the current abstraction

The original weight representation repeatedly requires transposed MXU pushes across batch tiles. Existing transpose, BlockSpec, dot_general and input-fusion controls express the change. Scope: BF16 activations, INT8 weights, block size 128 and explicit tile (128,256,128,1); other configurations retain the original path.

## Modifications

- `python/sgl_jax/srt/kernels/quantized_matmul/quantized_matmul_kernels/blockwise_kernel.py`

## Accuracy Tests

Exact canonical/scaled output parity and two additional TPU cases spanning the full INT8 range with nonuniform scales. BF16 rounding, scale application and accumulation order are preserved.

All repository pre-commit checks passed for this commit, including the applicable type checker. Each implementation has one DCO-signed commit.

The retained TPU correctness/audit receipts are in the evidence bundle. No new TPU run was performed in the upstream publication checkout.

## Benchmarking and Profiling

**Measured on the frozen captured revisions below. These figures are not a benchmark of this PR rebased onto today's upstream main.**

| Captured case | Baseline (us) | Candidate (us) | Reduction | Speedup | Ratio CI95 |
| --- | ---: | ---: | ---: | ---: | --- |
| long | 7664.059203 | 6218.495730 | **18.86%** | 1.2325x | [0.811290680, 0.811484415] |

Hardware: 1 local TPUv6e chip(s); JAX 0.11.1; explicit captured geometry and seed 1729. Each result is a mean of block medians from ten independent baseline/candidate pairs, with 50 exact compiled-program execution spans per block, 20 warmups and separate host timing. The gate requires >2% lower mean device latency and bootstrap ratio CI95 upper bound <1 (10,000 resamples, seed 1729). Canonical/scaled correctness comparisons retain the original tolerance. No full-model speedup is claimed.

### Post-compilation trace evidence

All 20 raw confirmation XPlane traces per shape and their execution records are retained. The publication audit re-read each raw trace, checked the serialized executable's HLO identity, reconstructed all 50 samples and reproduced its median. Multi-chip spans require a shared host execution identity and complete device partitions; single-chip traces may use the recorded device/queue/run identity.

Representative pair 00 for the **long** case:

| Role | Exact HLO identity | Devices | Samples | Block median (us) |
| --- | --- | ---: | ---: | ---: |
| baseline | `jit__lambda` / ID `15` / PID `3148629` | 1 | 50 | 7664.178086 |
| candidate | `jit__lambda` / ID `15` / PID `3148196` | 1 | 50 | 6220.255547 |

[Download every confirmation trace and the verification bundle](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-long.tar.gz). SHA256: `230c27226ba4cd36c161ace566bdf4b208aa9d63c421d8cd10bd2bb3d52ae3c2`.

After extraction, `python verify_evidence.py` (NumPy required) checks all bundle hashes and recomputes samples/statistics from the included selected events. Original `.xplane.pb` files remain the primary traces; raw output tensors and every repeated executable are not included.

### Post-compilation HLO and LLO dumps

All 64 transposed BF16 matrix-unit push sites become ordinary pushes. HLO retains the explicit weight-layout copy. The complete measured improvement includes changed memory scheduling.

| Shape | Full baseline LLO | Full candidate LLO | Compiled baseline HLO | Compiled candidate HLO |
| --- | --- | --- | --- | --- |
| long | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-long-long-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-long-long-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-long-long-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-long-long-candidate.hlo.txt.gz) |

<details>
<summary>Representative records from the full numbered LLO dumps</summary>

These excerpts show static emitted sites selected from changed vector opcodes. Counts and excerpts support code inspection; they do not quantify dynamic cycles.

### baseline

```text
247 : {[vmem:$0x3ffe0] = vst.8x128 v62}
248 : {s3 = simm.u32 $50;  s1 = sld [smem:$0x3b];  v59 = vimm.8x128.s32 $0;  v62 = vlaneseq.8x128.u32;  [vmem:$0x3fff8] = vst.8x128 v59}
249 : {[vmem:$0x3fff0] = vst.8x128 v60}
250 : {p0 = slt.s32 s1, $95;  s2 = simm.u32 $0;  v59 = vsel.8x128 vm0, $0x1, v59;  v63 = vand.8x128.u32 $0x380, v62;  [vmem:$0x3ffd8] = vst.8x128 v63}
251 : {p0 = slt.s32 s1, $85;  s2 = simm.u32 @p0 $1;  vm0 = veq.8x128.s32 v63, $0;  [vmem:$0x3ffe8] = vst.8x128 v61}
261 : {p0 = slt.s32 s1, $15;  s2 = simm.u32 @p0 $32;  [vmem:$0x3ffd0] = vst.8x128 v0}
262 : {s2 = simm.u32 @p0 $72;  s3 = simm.u32 @p0 $6;  [vmem:$0x3ffc8] = vst.8x128 v1}
263 : {p0 = slt.s32 s1, $5;  v60 = vpack.i.8x128.f32.bf16 v61, v60;  v61 = vpack.i.8x128.f32.bf16 v60, v61;  [vmem:$0x3ffc0] = vst.8x128 v2}
```

### candidate

```text
247 : {[vmem:$0x3ffe0] = vst.8x128 v62}
248 : {s3 = simm.u32 $50;  s1 = sld [smem:$0x3b];  v59 = vimm.8x128.s32 $0;  v62 = vlaneseq.8x128.u32;  [vmem:$0x3fff8] = vst.8x128 v59}
249 : {[vmem:$0x3fff0] = vst.8x128 v60}
250 : {p0 = slt.s32 s1, $95;  s2 = simm.u32 $0;  v59 = vsel.8x128 vm0, $0x1, v59;  v63 = vand.8x128.u32 $0x380, v62;  [vmem:$0x3ffd8] = vst.8x128 v63}
251 : {p0 = slt.s32 s1, $85;  s2 = simm.u32 @p0 $1;  vm0 = veq.8x128.s32 v63, $0;  [vmem:$0x3ffe8] = vst.8x128 v61}
261 : {p0 = slt.s32 s1, $15;  s2 = simm.u32 @p0 $32;  [vmem:$0x3ffd0] = vst.8x128 v0}
262 : {s2 = simm.u32 @p0 $72;  s3 = simm.u32 @p0 $6;  [vmem:$0x3ffc8] = vst.8x128 v1}
263 : {p0 = slt.s32 s1, $5;  v60 = vpack.i.8x128.f32.bf16 v61, v60;  v61 = vpack.i.8x128.f32.bf16 v60, v61;  [vmem:$0x3ffc0] = vst.8x128 v2}
```

</details>

### Source provenance and remaining limits

- Measured baseline: `027fa79a6498a1afef5a36c4e093c07d2f12f1ef`; exact measured patch and accepted candidate IDs/revisions are in the bundle.
- PR base: `3f1f38715b5dcd4b8ef11e4186e029e3e90f9570`. PR implementation commit: `4a32ae8e0182aa30d8c85c386265bf8ee34ee06f`.
- The source was ported onto current upstream and checked locally. Fresh TPU lowering/performance confirmation on that upstream revision remains outstanding; this PR is a draft for review.
- Performance is limited to the reported geometries, dtypes, runtime, partition and guarded paths. Original captures and any unsuccessful search attempts are not relabeled as new upstream measurements.
- The short/medium/long W8A16 PRs are independently measured source variants touching the same function. They have not been combined or jointly measured; consolidation requires new validation.

## Checklist

- [x] English description with motivation and implementation scope.
- [x] Test results and reproducible evidence verification command provided.
- [x] Numerical and measurement limitations stated.
- [ ] Fresh TPU validation of the upstream port and any consolidation with overlapping variants.
