### PR TITLE
perf(w8a16): separate K transfers from quantization groups at M=2048

### DIFF
--- a/python/sgl_jax/srt/kernels/quantized_matmul/quantized_matmul_kernels/blockwise_kernel.py
+++ b/python/sgl_jax/srt/kernels/quantized_matmul/quantized_matmul_kernels/blockwise_kernel.py
@@ -79,6 +79,23 @@ def quantized_matmul_kernel(
     # The num_blocks should become 1 in case of channelwise.
     block_size = tuned_value.in_block_size if block_size == orig_n_in else block_size
 
+    # Transfer eight groups at a time for this W8A16 schedule, while keeping
+    # each dot and BF16 accumulation at the original 128-element granularity.
+    # Restrict this to the one-group tuning value: larger original K tiles
+    # have a different partial-sum grouping that must not be changed here.
+    use_rolled_reduction = (
+        x.shape == (2048, 4096)
+        and w_q.shape == (4096, 4096)
+        and w_scale.shape == (32, 1, 4096)
+        and x.dtype == jnp.bfloat16
+        and w_q.dtype == jnp.int8
+        and not quantize_activation
+        and block_size == 128
+        and tuned_value == TunedValue(128, 256, 128, 1)
+    )
+    if use_rolled_reduction:
+        in_block_size = 1024
+
     # Pad the inputs to be multiple of block size.
     padded_n_batch = next_multiple(orig_n_batch, batch_block_size)
     if orig_n_batch < padded_n_batch:
@@ -134,6 +151,15 @@ def quantized_matmul_kernel(
     )
 
     steps_k = in_block_size // block_size
+    if use_rolled_reduction:
+        # get_vmem_limit already accounts for the larger lhs/rhs transfers,
+        # double buffers, output and accumulator scratch, but reserves only
+        # one scale row. Reserve all groups, with the singleton row dimension
+        # padded to eight in VMEM. Match its two compute/spill copies plus the
+        # extra transfer buffer, and retain the device limit.
+        extra_scale_bytes = (steps_k * 8 - 1) * out_block_size * jnp.dtype(jnp.float32).itemsize
+        vmem_limit_bytes = min(vmem_limit_bytes + 3 * extra_scale_bytes, get_device_vmem_limit())
+
     # n_lane_multiplier > 1 could improve perf by reducing loop overhead and increasing instruction-level parallelism,
     # allowing the compiler to overlap output fusion and packing overhead with MXU computation
     # TODO(amandaliang): use pltpu.get_tpu_info().mxu_column_size when JAX version is newer
@@ -197,8 +223,49 @@ def quantized_matmul_kernel(
 
         unfold_args((is_first_step, is_last_step), (), accum)
 
+    def rolled_kernel(lhs_ref, rhs_ref, w_scales_ref, out_ref, acc_scratch):
+        pid_k = pl.program_id(2)
+        is_first_step = pid_k == 0
+        is_last_step = pid_k == (n_in - 1)
+
+        # The first tile has no initialized scratch. Its placeholder is
+        # replaced directly by the first group's result, without adding zero.
+        acc_block = jax.lax.cond(
+            is_first_step,
+            lambda: jnp.zeros((batch_block_size, out_block_size), acc_dtype),
+            lambda: acc_scratch[...],
+        )
+
+        def reduce_group(i, acc):
+            k_slice = pl.ds(i * block_size, block_size)
+            lhs_q = lhs_ref[:, k_slice]
+            rhs_q = rhs_ref[:, k_slice]
+            rhs_scale = w_scales_ref[i, :, :].astype(acc_dtype)
+            dot_res = jax.lax.dot_general(
+                lhs_q,
+                rhs_q,
+                (((1,), (1,)), ((), ())),
+                preferred_element_type=jnp.float32,
+            )
+            res = dot_res.astype(acc_dtype)
+            res = res * rhs_scale
+
+            # Keep the shared dot/scale body outside the conditional and
+            # preserve the baseline's BF16 res + previous_sum operand order.
+            return jax.lax.cond(is_first_step & (i == 0), lambda: res, lambda: res + acc)
+
+        acc_block = jax.lax.fori_loop(0, steps_k, reduce_group, acc_block, unroll=False)
+
+        def store_output():
+            out_ref[...] = acc_block.astype(out_ref.dtype)
+
+        def store_scratch():
+            acc_scratch[...] = acc_block
+
+        jax.lax.cond(is_last_step, store_output, store_scratch)
+
     kernel = pl.pallas_call(
-        kernel,
+        rolled_kernel if use_rolled_reduction else kernel,
         grid_spec=pltpu.PrefetchScalarGridSpec(
             num_scalar_prefetch=0,
             in_specs=[


### PR DESCRIPTION
## Motivation

For M=2048, N=K=4096, transfer eight quantization groups together with a K=1024 transfer tile, while a rolled loop retains eight sequential K=128 dot/scale steps.

### Limitation of the current abstraction

The original tile parameter couples transfer size to arithmetic grouping. Separating them amortizes transfers while preserving quantization semantics. Existing Pallas/JAX loops and VMEM controls are sufficient. The specialization is guarded by shape, dtypes, block size 128 and the original tuning tuple.

## Modifications

- `python/sgl_jax/srt/kernels/quantized_matmul/quantized_matmul_kernels/blockwise_kernel.py`

## Accuracy Tests

Exact canonical/scaled outputs and two extra TPU inputs covering full-range INT8 weights and nonuniform scales. FP32 dot accumulation and all BF16 conversion/partial-sum boundaries retain their original order.

All repository pre-commit checks passed for this commit, including the applicable type checker. Each implementation has one DCO-signed commit.

The retained TPU correctness/audit receipts are in the evidence bundle. No new TPU run was performed in the upstream publication checkout.

## Benchmarking and Profiling

**Measured on the frozen captured revisions below. These figures are not a benchmark of this PR rebased onto today's upstream main.**

| Captured case | Baseline (us) | Candidate (us) | Reduction | Speedup | Ratio CI95 |
| --- | ---: | ---: | ---: | ---: | --- |
| medium | 3834.214707 | 1516.241398 | **60.45%** | 2.5288x | [0.395426859, 0.395475889] |

Hardware: 1 local TPUv6e chip(s); JAX 0.11.1; explicit captured geometry and seed 1729. Each result is a mean of block medians from ten independent baseline/candidate pairs, with 50 exact compiled-program execution spans per block, 20 warmups and separate host timing. The gate requires >2% lower mean device latency and bootstrap ratio CI95 upper bound <1 (10,000 resamples, seed 1729). Canonical/scaled correctness comparisons retain the original tolerance. No full-model speedup is claimed.

### Post-compilation trace evidence

All 20 raw confirmation XPlane traces per shape and their execution records are retained. The publication audit re-read each raw trace, checked the serialized executable's HLO identity, reconstructed all 50 samples and reproduced its median. Multi-chip spans require a shared host execution identity and complete device partitions; single-chip traces may use the recorded device/queue/run identity.

Representative pair 00 for the **medium** case:

| Role | Exact HLO identity | Devices | Samples | Block median (us) |
| --- | --- | ---: | ---: | ---: |
| baseline | `jit__lambda` / ID `15` / PID `3272003` | 1 | 50 | 3834.185547 |
| candidate | `jit__lambda` / ID `15` / PID `3271521` | 1 | 50 | 1516.258867 |

[Download every confirmation trace and the verification bundle](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-medium.tar.gz). SHA256: `4fb2dec1eff66e096d42f127f10936069559506387f5883dc1582ae12798311e`.

After extraction, `python verify_evidence.py` (NumPy required) checks all bundle hashes and recomputes samples/statistics from the included selected events. Original `.xplane.pb` files remain the primary traces; raw output tensors and every repeated executable are not included.

### Post-compilation HLO and LLO dumps

Static BF16 matmul sites fall from 32 to 8 and INT8 unpack sites from 64 to 16. A rolled loop reuses the emitted arithmetic; the counts do not imply fourfold fewer executed operations.

| Shape | Full baseline LLO | Full candidate LLO | Compiled baseline HLO | Compiled candidate HLO |
| --- | --- | --- | --- | --- |
| medium | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-medium-medium-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-medium-medium-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-medium-medium-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-medium-medium-candidate.hlo.txt.gz) |

<details>
<summary>Representative records from the full numbered LLO dumps</summary>

These excerpts show static emitted sites selected from changed vector opcodes. Counts and excerpts support code inspection; they do not quantify dynamic cycles.

### baseline

```text
287 : {p0 = seq.s32 s0, s3;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
288 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
289 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
290 : {(pc) = sbr.rel @!p0 $-3 (=0xffffffffffffffed);  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
291 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
292 : {s0 = sadd.s32 $1, s0;  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  _ = vdelay s2;  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
293 : {p0 = seq.s32 @!p0 s0, s3;  p0 = por @p0 $0, $0;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
294 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
```

### candidate

```text
287 : {p0 = seq.s32 s0, s3;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
288 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
289 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
290 : {(pc) = sbr.rel @!p0 $-3 (=0xffffffffffffffed);  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
291 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
292 : {s0 = sadd.s32 $1, s0;  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  _ = vdelay s2;  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
293 : {p0 = seq.s32 @!p0 s0, s3;  p0 = por @p0 $0, $0;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
294 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
```

</details>

### Source provenance and remaining limits

- Measured baseline: `027fa79a6498a1afef5a36c4e093c07d2f12f1ef`; exact measured patch and accepted candidate IDs/revisions are in the bundle.
- PR base: `3f1f38715b5dcd4b8ef11e4186e029e3e90f9570`. PR implementation commit: `840ad48563eb7d2cd2abc94e1d14cefd650dda39`.
- The source was ported onto current upstream and checked locally. Fresh TPU lowering/performance confirmation on that upstream revision remains outstanding; this PR is a draft for review.
- Performance is limited to the reported geometries, dtypes, runtime, partition and guarded paths. Original captures and any unsuccessful search attempts are not relabeled as new upstream measurements.
- The short/medium/long W8A16 PRs are independently measured source variants touching the same function. They have not been combined or jointly measured; consolidation requires new validation.

## Checklist

- [x] English description with motivation and implementation scope.
- [x] Test results and reproducible evidence verification command provided.
- [x] Numerical and measurement limitations stated.
- [ ] Fresh TPU validation of the upstream port and any consolidation with overlapping variants.
