### PR TITLE
perf(w8a16): stage the full K dimension at M=512

### DIFF
--- a/python/sgl_jax/srt/kernels/quantized_matmul/quantized_matmul_kernels/blockwise_kernel.py
+++ b/python/sgl_jax/srt/kernels/quantized_matmul/quantized_matmul_kernels/blockwise_kernel.py
@@ -57,6 +57,70 @@ def quantized_matmul_kernel(
         x_q_dtype = x.dtype
     quantize_activation = x_q_dtype != x.dtype
 
+    # Stage the full reduction dimension for this explicitly tuned geometry.
+    # Check before resolving default tuning so other configurations keep their
+    # existing scheduling.
+    if (
+        x.shape == (512, 4096)
+        and w_q.shape == (4096, 4096)
+        and w_scale.shape == (32, 1, 4096)
+        and x.dtype == jnp.bfloat16
+        and w_q.dtype == jnp.int8
+        and not quantize_activation
+        and block_size == 128
+        and tuned_value == TunedValue(128, 256, 128, 1)
+    ):
+        if w_scale.dtype != jnp.float32:
+            w_scale = w_scale.astype(jnp.float32)
+
+        def full_k_kernel(lhs_ref, rhs_ref, w_scales_ref, out_ref):
+            def contribution(i):
+                k_slice = pl.ds(i * 128, 128)
+                dot_res = jax.lax.dot_general(
+                    lhs_ref[:, k_slice],
+                    rhs_ref[:, k_slice],
+                    (((1,), (1,)), ((), ())),
+                    preferred_element_type=jnp.float32,
+                )
+                res = dot_res.astype(jnp.bfloat16)
+                scale = w_scales_ref[i, :, :].astype(jnp.bfloat16)
+                return (res * scale).astype(jnp.bfloat16)
+
+            # Peel the first contribution, then preserve the original order:
+            # each BF16 contribution is added to the preceding BF16 accumulator.
+            acc = contribution(0)
+
+            def body(i, acc):
+                return (contribution(i) + acc).astype(jnp.bfloat16)
+
+            acc = jax.lax.fori_loop(1, 32, body, acc, unroll=False)
+            out_ref[...] = acc
+
+        # Logical tiles use 1 MiB each for activations and weights, 32 KiB for
+        # all 32 FP32 scale blocks, and 64 KiB for output. The 8 MiB budget also
+        # allows buffering, layout padding, and temporaries; the general helper
+        # only accounts for one scale block.
+        kernel = pl.pallas_call(
+            full_k_kernel,
+            grid_spec=pltpu.PrefetchScalarGridSpec(
+                num_scalar_prefetch=0,
+                in_specs=[
+                    pl.BlockSpec((128, 4096), lambda b, o: (b, 0), memory_space=pltpu.VMEM),
+                    pl.BlockSpec((256, 4096), lambda b, o: (o, 0), memory_space=pltpu.VMEM),
+                    pl.BlockSpec((32, 1, 256), lambda b, o: (0, 0, o), memory_space=pltpu.VMEM),
+                ],
+                out_specs=pl.BlockSpec((128, 256), lambda b, o: (b, o)),
+                grid=(4, 16),
+            ),
+            out_shape=jax.ShapeDtypeStruct((512, 4096), x.dtype),
+            compiler_params=pltpu.CompilerParams(
+                dimension_semantics=("parallel", "parallel"),
+                vmem_limit_bytes=min(8 * 1024 * 1024, get_device_vmem_limit()),
+            ),
+        )
+        with jax.named_scope(get_kernel_name(tuned_value)):
+            return kernel(x, w_q, w_scale)
+
     orig_n_batch, orig_n_in = x.shape
     orig_n_out, *_ = w_q.shape
 


### PR DESCRIPTION
## Motivation

For M=512, N=K=4096, stage the full K dimension in activation and weight tiles, then accumulate the 32 original quantization groups sequentially.

### Limitation of the current abstraction

The original schedule transfers one small quantization group at a time. Transfer scope can grow without changing arithmetic grouping using existing Pallas buffering and loops. The specialization remains limited to the captured shape/dtypes/tuning configuration.

## Modifications

- `python/sgl_jax/srt/kernels/quantized_matmul/quantized_matmul_kernels/blockwise_kernel.py`

## Accuracy Tests

All 13 captured/scaled output pairs are exact, and two supplemental full-range INT8 inputs with nonuniform scales also match exactly. Original BF16 contribution, scale and accumulation boundaries remain intact.

All repository pre-commit checks passed for this commit, including the applicable type checker. Each implementation has one DCO-signed commit.

The retained TPU correctness/audit receipts are in the evidence bundle. No new TPU run was performed in the upstream publication checkout.

## Benchmarking and Profiling

**Measured on the frozen captured revisions below. These figures are not a benchmark of this PR rebased onto today's upstream main.**

| Captured case | Baseline (us) | Candidate (us) | Reduction | Speedup | Ratio CI95 |
| --- | ---: | ---: | ---: | ---: | --- |
| short | 958.715137 | 354.773977 | **62.99%** | 2.7023x | [0.370001886, 0.370103933] |

Hardware: 1 local TPUv6e chip(s); JAX 0.11.1; explicit captured geometry and seed 1729. Each result is a mean of block medians from ten independent baseline/candidate pairs, with 50 exact compiled-program execution spans per block, 20 warmups and separate host timing. The gate requires >2% lower mean device latency and bootstrap ratio CI95 upper bound <1 (10,000 resamples, seed 1729). Canonical/scaled correctness comparisons retain the original tolerance. No full-model speedup is claimed.

### Post-compilation trace evidence

All 20 raw confirmation XPlane traces per shape and their execution records are retained. The publication audit re-read each raw trace, checked the serialized executable's HLO identity, reconstructed all 50 samples and reproduced its median. Multi-chip spans require a shared host execution identity and complete device partitions; single-chip traces may use the recorded device/queue/run identity.

Representative pair 00 for the **short** case:

| Role | Exact HLO identity | Devices | Samples | Block median (us) |
| --- | --- | ---: | ---: | ---: |
| baseline | `jit__lambda` / ID `15` / PID `3752773` | 1 | 50 | 958.779961 |
| candidate | `jit__lambda` / ID `15` / PID `3752321` | 1 | 50 | 354.758750 |

[Download every confirmation trace and the verification bundle](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-short.tar.gz). SHA256: `89c4cfc3e82e75bcb263a810a56144664be98c1dbcc7b827daf8b75a3e90d7be`.

After extraction, `python verify_evidence.py` (NumPy required) checks all bundle hashes and recomputes samples/statistics from the included selected events. Original `.xplane.pb` files remain the primary traces; raw output tensors and every repeated executable are not included.

### Post-compilation HLO and LLO dumps

The compiled operation contains larger input staging and the original sequential group arithmetic. Full LLO and HLO are provided to inspect the transfer/compute separation; performance comes from complete-program timing.

| Shape | Full baseline LLO | Full candidate LLO | Compiled baseline HLO | Compiled candidate HLO |
| --- | --- | --- | --- | --- |
| short | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-short-short-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-short-short-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-short-short-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/w8a16-short-short-candidate.hlo.txt.gz) |

<details>
<summary>Representative records from the full numbered LLO dumps</summary>

These excerpts show static emitted sites selected from changed vector opcodes. Counts and excerpts support code inspection; they do not quantify dynamic cycles.

### baseline

```text
247 : {[vmem:$0x3ffe0] = vst.8x128 v62}
248 : {s3 = simm.u32 $50;  s1 = sld [smem:$0x3b];  v59 = vimm.8x128.s32 $0;  v62 = vlaneseq.8x128.u32;  [vmem:$0x3fff8] = vst.8x128 v59}
249 : {[vmem:$0x3fff0] = vst.8x128 v60}
250 : {p0 = slt.s32 s1, $95;  s2 = simm.u32 $0;  v59 = vsel.8x128 vm0, $0x1, v59;  v63 = vand.8x128.u32 $0x380, v62;  [vmem:$0x3ffd8] = vst.8x128 v63}
251 : {p0 = slt.s32 s1, $85;  s2 = simm.u32 @p0 $1;  vm0 = veq.8x128.s32 v63, $0;  [vmem:$0x3ffe8] = vst.8x128 v61}
261 : {p0 = slt.s32 s1, $15;  s2 = simm.u32 @p0 $32;  [vmem:$0x3ffd0] = vst.8x128 v0}
262 : {s2 = simm.u32 @p0 $72;  s3 = simm.u32 @p0 $6;  [vmem:$0x3ffc8] = vst.8x128 v1}
263 : {p0 = slt.s32 s1, $5;  v60 = vpack.i.8x128.f32.bf16 v61, v60;  v61 = vpack.i.8x128.f32.bf16 v60, v61;  [vmem:$0x3ffc0] = vst.8x128 v2}
```

### candidate

```text
247 : {[vmem:$0x3ffe0] = vst.8x128 v62}
248 : {s3 = simm.u32 $50;  s1 = sld [smem:$0x3b];  v59 = vimm.8x128.s32 $0;  v62 = vlaneseq.8x128.u32;  [vmem:$0x3fff8] = vst.8x128 v59}
249 : {[vmem:$0x3fff0] = vst.8x128 v60}
250 : {p0 = slt.s32 s1, $95;  s2 = simm.u32 $0;  v59 = vsel.8x128 vm0, $0x1, v59;  v63 = vand.8x128.u32 $0x380, v62;  [vmem:$0x3ffd8] = vst.8x128 v63}
251 : {p0 = slt.s32 s1, $85;  s2 = simm.u32 @p0 $1;  vm0 = veq.8x128.s32 v63, $0;  [vmem:$0x3ffe8] = vst.8x128 v61}
261 : {p0 = slt.s32 s1, $15;  s2 = simm.u32 @p0 $32;  [vmem:$0x3ffd0] = vst.8x128 v0}
262 : {s2 = simm.u32 @p0 $72;  s3 = simm.u32 @p0 $6;  [vmem:$0x3ffc8] = vst.8x128 v1}
263 : {p0 = slt.s32 s1, $5;  v60 = vpack.i.8x128.f32.bf16 v61, v60;  v61 = vpack.i.8x128.f32.bf16 v60, v61;  [vmem:$0x3ffc0] = vst.8x128 v2}
```

</details>

### Source provenance and remaining limits

- Measured baseline: `027fa79a6498a1afef5a36c4e093c07d2f12f1ef`; exact measured patch and accepted candidate IDs/revisions are in the bundle.
- PR base: `3f1f38715b5dcd4b8ef11e4186e029e3e90f9570`. PR implementation commit: `eff8234a472e657023dd10f67afdd082cb0e390e`.
- The source was ported onto current upstream and checked locally. Fresh TPU lowering/performance confirmation on that upstream revision remains outstanding; this PR is a draft for review.
- Performance is limited to the reported geometries, dtypes, runtime, partition and guarded paths. Original captures and any unsuccessful search attempts are not relabeled as new upstream measurements.
- The short/medium/long W8A16 PRs are independently measured source variants touching the same function. They have not been combined or jointly measured; consolidation requires new validation.

## Checklist

- [x] English description with motivation and implementation scope.
- [x] Test results and reproducible evidence verification command provided.
- [x] Numerical and measurement limitations stated.
- [ ] Fresh TPU validation of the upstream port and any consolidation with overlapping variants.
