### PR TITLE
perf(kda): use producer-certified contiguous chunk addressing

### DIFF
--- a/python/sgl_jax/srt/kernels/kda/kda.py
+++ b/python/sgl_jax/srt/kernels/kda/kda.py
@@ -129,6 +129,27 @@ def get_interpret() -> bool:
     return env.strip().lower() in ("1", "true")
 
 
+def _aligned_chunk_input(x, chunk_size, num_chunks):
+    """View _align_seqs output as [B, H, NC, BT, D], padding only NC."""
+    B, T, H, D = x.shape
+    assert T % chunk_size == 0
+    physical_chunks = T // chunk_size
+    assert num_chunks >= physical_chunks
+    chunks = x.reshape(B, physical_chunks, chunk_size, H, D).transpose(0, 3, 1, 2, 4)
+    if num_chunks > physical_chunks:
+        chunks = jnp.pad(
+            chunks, ((0, 0), (0, 0), (0, num_chunks - physical_chunks), (0, 0), (0, 0))
+        )
+    return chunks
+
+
+def _aligned_chunk_output(chunks, chunk_valid, length):
+    """Restore contiguous tokens, zeroing the metadata-defined invalid tail."""
+    B, H, NC, BT, D = chunks.shape
+    chunks = jnp.where(chunk_valid[None, None, :, None, None], chunks, 0)
+    return chunks.transpose(0, 2, 3, 1, 4).reshape(B, NC * BT, H, D)[:, :length]
+
+
 # ============================================================================
 # Chunk-local cumulative sum (varlen Pallas kernel only)
 # ============================================================================
@@ -176,6 +197,7 @@ def chunk_local_cumsum_vector(
     head_first: bool = False,
     output_dtype: jnp.dtype | None = jnp.float32,
     chunk_indices: jax.Array | None = None,
+    _aligned_contiguous: bool = False,
 ) -> jax.Array:
     assert g.ndim == 4, f"g must be 4-D, got {g.ndim}-D"
     assert chunk_size == 2 ** (chunk_size.bit_length() - 1), "chunk_size must be power of 2"
@@ -210,39 +232,47 @@ def chunk_local_cumsum_vector(
         g_flat = jnp.pad(g_flat, ((0, pad_BH), (0, 0), (0, 0)))
     BH_padded = BH + pad_BH
 
-    if chunk_indices is None:
-        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
-    NC_max = len(chunk_indices)
-
-    g_flat = jnp.pad(g_flat, ((0, 0), (0, BT), (0, 0)))
-    T_alloc = T + BT
-
     cu_i32 = cu_seqlens.astype(jnp.int32)
-    chunk_indices_i32 = chunk_indices.astype(jnp.int32)
-    N = cu_i32.shape[0] - 1
-    chunks_per_seq = (jnp.diff(cu_i32) + BT - 1) // BT
+    if _aligned_contiguous:
+        # _align_seqs starts at zero and pads every sequence to a BT multiple.
+        # Its allocation can exceed cu_i32[-1]; shape alone is not validity.
+        assert T % BT == 0
+        NC_max = T // BT
+        token_valid = (jnp.arange(T, dtype=jnp.int32) < cu_i32[-1]).reshape(NC_max, BT)
+        g_chunks = g_flat.reshape(BH_padded, NC_max, BT, S_padded)
+    else:
+        if chunk_indices is None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+        NC_max = len(chunk_indices)
 
-    seq_id = chunk_indices_i32[:, 0]
-    local_ci = chunk_indices_i32[:, 1]
-    safe_seq_id = jnp.clip(seq_id, 0, N - 1)
-    chunk_valid = (
-        (seq_id == safe_seq_id) & (local_ci >= 0) & (local_ci < chunks_per_seq[safe_seq_id])
-    )
+        g_flat = jnp.pad(g_flat, ((0, 0), (0, BT), (0, 0)))
+        T_alloc = T + BT
 
-    bos = cu_i32[safe_seq_id]
-    eos = cu_i32[safe_seq_id + 1]
-    chunk_starts = jnp.where(chunk_valid, bos + local_ci * BT, 0)
-    positions = chunk_starts[:, None] + jnp.arange(BT, dtype=jnp.int32)[None, :]
-    token_valid = chunk_valid[:, None] & (positions < eos[:, None]) & (positions < T)
+        chunk_indices_i32 = chunk_indices.astype(jnp.int32)
+        N = cu_i32.shape[0] - 1
+        chunks_per_seq = (jnp.diff(cu_i32) + BT - 1) // BT
 
-    def _gather_chunk(start):
-        return jax.lax.dynamic_slice(
-            g_flat,
-            (0, start, 0),
-            (BH_padded, BT, S_padded),
+        seq_id = chunk_indices_i32[:, 0]
+        local_ci = chunk_indices_i32[:, 1]
+        safe_seq_id = jnp.clip(seq_id, 0, N - 1)
+        chunk_valid = (
+            (seq_id == safe_seq_id) & (local_ci >= 0) & (local_ci < chunks_per_seq[safe_seq_id])
         )
 
-    g_chunks = jax.vmap(_gather_chunk)(chunk_starts).transpose(1, 0, 2, 3)
+        bos = cu_i32[safe_seq_id]
+        eos = cu_i32[safe_seq_id + 1]
+        chunk_starts = jnp.where(chunk_valid, bos + local_ci * BT, 0)
+        positions = chunk_starts[:, None] + jnp.arange(BT, dtype=jnp.int32)[None, :]
+        token_valid = chunk_valid[:, None] & (positions < eos[:, None]) & (positions < T)
+
+        def _gather_chunk(start):
+            return jax.lax.dynamic_slice(
+                g_flat,
+                (0, start, 0),
+                (BH_padded, BT, S_padded),
+            )
+
+        g_chunks = jax.vmap(_gather_chunk)(chunk_starts).transpose(1, 0, 2, 3)
     g_chunks = jnp.where(token_valid[None, :, :, None], g_chunks, 0)
 
     elem_bytes = 4
@@ -280,12 +310,15 @@ def chunk_local_cumsum_vector(
     )(g_chunks)
 
     o_chunks = jnp.where(token_valid[None, :, :, None], o_chunks, 0)
-    sentinel = jnp.minimum(cu_i32[-1], T)
-    scatter_positions = jnp.where(token_valid, positions, sentinel).reshape(-1)
-    scatter_values = o_chunks.reshape(BH_padded, NC_max * BT, S_padded)
+    if _aligned_contiguous:
+        o_flat = o_chunks.reshape(BH_padded, T, S_padded)
+    else:
+        sentinel = jnp.minimum(cu_i32[-1], T)
+        scatter_positions = jnp.where(token_valid, positions, sentinel).reshape(-1)
+        scatter_values = o_chunks.reshape(BH_padded, NC_max * BT, S_padded)
 
-    o_flat = jnp.zeros((BH_padded, T_alloc, S_padded), dtype=o_chunks.dtype)
-    o_flat = o_flat.at[:, scatter_positions, :].add(scatter_values)
+        o_flat = jnp.zeros((BH_padded, T_alloc, S_padded), dtype=o_chunks.dtype)
+        o_flat = o_flat.at[:, scatter_positions, :].add(scatter_values)
 
     o_flat = o_flat[:BH, :T, :S]
 
@@ -436,6 +469,7 @@ def _kda_fwd_intra_kernel(
         "scale",
         "safe_gate",
         "disable_recompute",
+        "_aligned_contiguous",
     ],
 )
 def kda_fwd_intra(
@@ -450,6 +484,7 @@ def kda_fwd_intra(
     chunk_indices=None,
     safe_gate=True,
     disable_recompute=False,
+    _aligned_contiguous=False,
 ):
     assert cu_seqlens is not None, "cu_seqlens must be provided for varlen"
     B, T, H, K = q.shape
@@ -465,53 +500,60 @@ def kda_fwd_intra(
     assert_shape(beta, (B, T, H), "beta")
 
     N = cu_seqlens.shape[0] - 1
-    T_alloc = T + BT
-
-    pad4d = lambda x: jnp.pad(x, ((0, 0), (0, BT), (0, 0), (0, 0)))
-    q_pad, k_pad, gk_pad, v_pad = pad4d(q), pad4d(k), pad4d(gk), pad4d(v)
-    beta_pad = jnp.pad(beta.reshape(B, T, H, 1), ((0, 0), (0, BT), (0, 0), (0, 0)))
-
     cu_i32 = cu_seqlens.astype(jnp.int32)
-    seq_lens = jnp.diff(cu_i32)
-    chunks_per_seq = (seq_lens + BT - 1) // BT
-    cum_chunks = jnp.pad(jnp.cumsum(chunks_per_seq), (1, 0))
-    total_chunks = cum_chunks[-1]
-
-    NC_max = len(chunk_indices) if chunk_indices is not None else T // BT + N
+    if _aligned_contiguous:
+        assert T % BT == 0
+        NC_real = T // BT
+        total_chunks = cu_i32[-1] // BT
+    else:
+        seq_lens = jnp.diff(cu_i32)
+        chunks_per_seq = (seq_lens + BT - 1) // BT
+        cum_chunks = jnp.pad(jnp.cumsum(chunks_per_seq), (1, 0))
+        total_chunks = cum_chunks[-1]
+        NC_real = len(chunk_indices) if chunk_indices is not None else T // BT + N
+    NC_max = NC_real
     flat_idx = jnp.arange(NC_max, dtype=jnp.int32)
     is_valid = flat_idx < total_chunks
 
-    seq_id = jnp.minimum(jnp.searchsorted(cum_chunks[1:], flat_idx, side="right"), N - 1)
-    local_ci = flat_idx - cum_chunks[seq_id]
-    bos = cu_i32[seq_id]
-    # After _align_seqs, every sequence is BT-aligned, so all chunks are full.
-    # No partial-chunk masking needed.
-    chunk_starts = jnp.where(is_valid, bos + local_ci * BT, 0)
+    if _aligned_contiguous:
+        q_r, k_r, g_r, beta_r, v_r = (
+            _aligned_chunk_input(x, BT, NC_max) for x in (q, k, gk, beta.reshape(B, T, H, 1), v)
+        )
+    else:
+        T_alloc = T + BT
+        pad4d = lambda x: jnp.pad(x, ((0, 0), (0, BT), (0, 0), (0, 0)))
+        q_pad, k_pad, gk_pad, v_pad = pad4d(q), pad4d(k), pad4d(gk), pad4d(v)
+        beta_pad = pad4d(beta.reshape(B, T, H, 1))
 
-    def gather(x_pad, D):
-        def extract(start):
-            return jax.lax.dynamic_slice(x_pad, (0, start, 0, 0), (1, BT, H, D))[0]
+        seq_id = jnp.minimum(jnp.searchsorted(cum_chunks[1:], flat_idx, side="right"), N - 1)
+        local_ci = flat_idx - cum_chunks[seq_id]
+        bos = cu_i32[seq_id]
+        chunk_starts = jnp.where(is_valid, bos + local_ci * BT, 0)
 
-        return jax.vmap(extract)(chunk_starts)
+        def gather(x_pad, D):
+            def extract(start):
+                return jax.lax.dynamic_slice(x_pad, (0, start, 0, 0), (1, BT, H, D))[0]
 
-    q_c, k_c, gk_c, beta_c, v_c = (
-        gather(q_pad, K),
-        gather(k_pad, K),
-        gather(gk_pad, K),
-        gather(beta_pad, 1),
-        gather(v_pad, V),
-    )
+            return jax.vmap(extract)(chunk_starts)
 
-    def _to_bhnd(x):
-        return x.transpose(2, 0, 1, 3)[None]
+        q_c, k_c, gk_c, beta_c, v_c = (
+            gather(q_pad, K),
+            gather(k_pad, K),
+            gather(gk_pad, K),
+            gather(beta_pad, 1),
+            gather(v_pad, V),
+        )
 
-    q_r, k_r, g_r, beta_r, v_r = (
-        _to_bhnd(q_c),
-        _to_bhnd(k_c),
-        _to_bhnd(gk_c),
-        _to_bhnd(beta_c),
-        _to_bhnd(v_c),
-    )
+        def _to_bhnd(x):
+            return x.transpose(2, 0, 1, 3)[None]
+
+        q_r, k_r, g_r, beta_r, v_r = (
+            _to_bhnd(q_c),
+            _to_bhnd(k_c),
+            _to_bhnd(gk_c),
+            _to_bhnd(beta_c),
+            _to_bhnd(v_c),
+        )
 
     grid = (B, H, NC_max)
 
@@ -554,20 +596,23 @@ def kda_fwd_intra(
         ),
     )(q_r, k_r, g_r, beta_r, v_r)
 
-    pos = chunk_starts[:, None] + jnp.arange(BT)[None, :]
-    pos = jnp.where(is_valid[:, None], pos, T_alloc - 1)
-    flat_pos = pos.reshape(-1)
+    if not _aligned_contiguous:
+        pos = chunk_starts[:, None] + jnp.arange(BT)[None, :]
+        pos = jnp.where(is_valid[:, None], pos, T_alloc - 1)
+        flat_pos = pos.reshape(-1)
 
-    def _scatter(chunks_r, D):
+    def _restore(chunks_r, D):
+        if _aligned_contiguous:
+            return _aligned_chunk_output(chunks_r, is_valid, T)
         chunks = chunks_r[0].transpose(1, 2, 0, 3)
         flat_chunks = chunks.reshape(-1, H, D)
         out = jnp.zeros((T_alloc, H, D), dtype=chunks.dtype)
         out = out.at[flat_pos].add(flat_chunks)
         return out[:T][None]
 
-    w_out, u_out, kg_out = _scatter(w_r, K), _scatter(u_r, V), _scatter(kg_r, K)
-    Aqk_out, Akk_out = _scatter(Aqk_r, BT), _scatter(Akk_inv_r, BT)
-    qg_out = _scatter(qg_r, K) if disable_recompute else None
+    w_out, u_out, kg_out = _restore(w_r, K), _restore(u_r, V), _restore(kg_r, K)
+    Aqk_out, Akk_out = _restore(Aqk_r, BT), _restore(Akk_inv_r, BT)
+    qg_out = _restore(qg_r, K) if disable_recompute else None
 
     return w_out, u_out, qg_out, kg_out, Aqk_out, Akk_out
 
@@ -623,6 +668,11 @@ def _chunk_gated_delta_rule_fwd_kernel(
         scratch_ref[...] = jnp.zeros([K, V], dtype=jnp.float32)
         if USE_INITIAL_STATE:
             scratch_ref[...] = h0_ref[0, 0].astype(jnp.float32)
+        if STORE_FINAL_STATE:
+            # Empty sequences never enter the recurrence or its final store.
+            @pl.when(real_NT == 0)
+            def _():
+                ht_ref[0, 0] = scratch_ref[...].astype(ht_ref.dtype)
 
     @pl.when(idx_nt < real_NT)
     def _():
@@ -713,6 +763,21 @@ def chunk_gated_delta_rule_fwd_h(
     NT_max = T // BT
     chunk_offsets = _prepare_chunk_offsets(cu_seqlens, BT)
     assert initial_state is None or initial_state.shape == (N, H, K, V)
+
+    # A direct zero-token call has no grid iterations to initialize its state.
+    if T == 0:
+        ht = None
+        if output_final_state:
+            ht = (
+                initial_state.astype(jnp.float32)
+                if initial_state is not None
+                else jnp.zeros((N, H, K, V), dtype=jnp.float32)
+            )
+        return (
+            jnp.zeros((B, NT, H, K, V), dtype=jnp.float32),
+            u_f32 if save_new_value else None,
+            ht,
+        )
 
     T_alloc = T + BT
 
@@ -915,6 +980,7 @@ def chunk_kda_fwd_o_gk(
     chunk_indices=None,
     chunk_size=64,
     use_exp2=False,
+    _aligned_contiguous=False,
 ):
     assert cu_seqlens is not None, "This varlen-only module requires cu_seqlens"
     B, T, H, K = q.shape
@@ -925,39 +991,51 @@ def chunk_kda_fwd_o_gk(
     assert T % BT == 0
 
     N = cu_seqlens.shape[0] - 1
-    T_alloc = T + BT
-
-    pad4d = lambda x: jnp.pad(x, ((0, 0), (0, BT), (0, 0), (0, 0)))
-    q_pad, v_pad, g_pad, A_pad = pad4d(q), pad4d(v), pad4d(g), pad4d(A)
-
     cu_i32 = cu_seqlens.astype(jnp.int32)
-    seq_lens = jnp.diff(cu_i32)
-    chunks_per_seq = (seq_lens + BT - 1) // BT
-    cum_chunks = jnp.pad(jnp.cumsum(chunks_per_seq), (1, 0))
-    total_chunks = cum_chunks[-1]
-
-    NC_max = len(chunk_indices) if chunk_indices is not None else T // BT + N
+    if _aligned_contiguous:
+        NC_real = T // BT
+        total_chunks = cu_i32[-1] // BT
+    else:
+        seq_lens = jnp.diff(cu_i32)
+        chunks_per_seq = (seq_lens + BT - 1) // BT
+        cum_chunks = jnp.pad(jnp.cumsum(chunks_per_seq), (1, 0))
+        total_chunks = cum_chunks[-1]
+        NC_real = len(chunk_indices) if chunk_indices is not None else T // BT + N
+    NC_max = NC_real
     flat_idx = jnp.arange(NC_max, dtype=jnp.int32)
     is_valid = flat_idx < total_chunks
 
-    seq_id = jnp.minimum(jnp.searchsorted(cum_chunks[1:], flat_idx, side="right"), N - 1)
-    local_ci = flat_idx - cum_chunks[seq_id]
-    bos = cu_i32[seq_id]
-    # After _align_seqs, every sequence is BT-aligned — no partial chunks.
-    chunk_starts = jnp.where(is_valid, bos + local_ci * BT, 0)
+    if _aligned_contiguous:
+        _q = _aligned_chunk_input(q, BT, NC_max)[0]
+        _g = _aligned_chunk_input(g, BT, NC_max)[0]
+        _v = _aligned_chunk_input(v, BT, NC_max)[0]
+        _A = _aligned_chunk_input(A, BT, NC_max)[0]
+    else:
+        T_alloc = T + BT
+        pad4d = lambda x: jnp.pad(x, ((0, 0), (0, BT), (0, 0), (0, 0)))
+        v_pad, A_pad = pad4d(v), pad4d(A)
+        q_pad = pad4d(q)
+        g_pad = pad4d(g)
 
-    def gather(x_pad, D):
-        def extract(start):
-            return jax.lax.dynamic_slice(x_pad, (0, start, 0, 0), (1, BT, H, D))[0]
+        seq_id = jnp.minimum(jnp.searchsorted(cum_chunks[1:], flat_idx, side="right"), N - 1)
+        local_ci = flat_idx - cum_chunks[seq_id]
+        bos = cu_i32[seq_id]
+        chunk_starts = jnp.where(is_valid, bos + local_ci * BT, 0)
 
-        return jax.vmap(extract)(chunk_starts)
+        def gather(x_pad, D):
+            def extract(start):
+                return jax.lax.dynamic_slice(x_pad, (0, start, 0, 0), (1, BT, H, D))[0]
 
-    q_c, v_c, g_c, A_c = gather(q_pad, K), gather(v_pad, V), gather(g_pad, K), gather(A_pad, BT)
+            return jax.vmap(extract)(chunk_starts)
 
-    _q = q_c.transpose(2, 0, 1, 3)
-    _v = v_c.transpose(2, 0, 1, 3)
-    _g = g_c.transpose(2, 0, 1, 3)
-    _A = A_c.transpose(2, 0, 1, 3)
+        q_c = gather(q_pad, K)
+        g_c = gather(g_pad, K)
+        v_c, A_c = gather(v_pad, V), gather(A_pad, BT)
+
+        _q = q_c.transpose(2, 0, 1, 3)
+        _v = v_c.transpose(2, 0, 1, 3)
+        _g = g_c.transpose(2, 0, 1, 3)
+        _A = A_c.transpose(2, 0, 1, 3)
 
     _h = h[0].transpose(1, 0, 2, 3)
     if NC_max > NT_h:
@@ -982,6 +1060,9 @@ def chunk_kda_fwd_o_gk(
         compiler_params=pltpu.CompilerParams(disable_bounds_checks=True),
         interpret=get_interpret(),
     )(_q, _v, _g, _h, _A)
+
+    if _aligned_contiguous:
+        return _aligned_chunk_output(o_r[None], is_valid, T)
 
     pos = chunk_starts[:, None] + jnp.arange(BT)[None, :]
     pos = jnp.where(is_valid[:, None], pos, T_alloc - 1)
@@ -1010,6 +1091,7 @@ def kda_gate_chunk_cumsum(
     output_dtype=jnp.float32,
     chunk_indices=None,
     lower_bound=None,
+    _aligned_contiguous=False,
 ):
     B, T, H, K = g.shape
     assert_shape(g, (B, T, H, K), "g")
@@ -1033,6 +1115,7 @@ def kda_gate_chunk_cumsum(
         head_first=False,
         output_dtype=output_dtype or jnp.float32,
         chunk_indices=chunk_indices,
+        _aligned_contiguous=_aligned_contiguous,
     )
 
 
@@ -1045,6 +1128,7 @@ def pallas_kda_gate_cumsum(
     head_first=False,
     output_dtype=jnp.float32,
     chunk_indices=None,
+    _aligned_contiguous=False,
 ):
     B, T, H, K = g.shape
     assert_shape(g, (B, T, H, K), "g")
@@ -1058,6 +1142,7 @@ def pallas_kda_gate_cumsum(
         chunk_indices=chunk_indices,
         head_first=False,
         output_dtype=jnp.float32,
+        _aligned_contiguous=_aligned_contiguous,
     )
 
 
@@ -1199,12 +1284,15 @@ def chunk_kda_fwd(
     # Varlen alignment
     _orig_cu_seqlens = cu_seqlens
     T_input = T
+    # The alignment producer guarantees contiguous full chunks in canonical order.
+    # Standalone consumers retain their generic mapping by default.
     [q, k, v, g], [beta], cu_seqlens, _ = _align_seqs(
         [q, k, v, g],
         [beta],
         cu_seqlens,
         align=BT,
     )
+    _aligned_contiguous = True
     T = q.shape[1]
     chunk_indices = prepare_chunk_indices(cu_seqlens, BT, max_T=T)
 
@@ -1237,6 +1325,7 @@ def chunk_kda_fwd(
             lower_bound=lower_bound,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
+            _aligned_contiguous=_aligned_contiguous,
         )
     else:
         g_cumsum = pallas_kda_gate_cumsum(
@@ -1245,6 +1334,7 @@ def chunk_kda_fwd(
             chunk_size=chunk_size,
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
+            _aligned_contiguous=_aligned_contiguous,
         )
 
     # Step 2: Intra-chunk solve
@@ -1259,6 +1349,7 @@ def chunk_kda_fwd(
         chunk_size=BT,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        _aligned_contiguous=_aligned_contiguous,
     )
 
     # Step 3: Inter-chunk state propagation
@@ -1287,6 +1378,7 @@ def chunk_kda_fwd(
         use_exp2=True,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        _aligned_contiguous=_aligned_contiguous,
     )
 
     # Cast output back to input dtype (e.g. bfloat16)

--- a/python/sgl_jax/test/kernels/kda_test.py
+++ b/python/sgl_jax/test/kernels/kda_test.py
@@ -31,6 +31,7 @@ import numpy as np
 from sgl_jax.srt.kernels.kda import chunk_kda, naive_recurrent_kda
 from sgl_jax.srt.kernels.kda.kda import (
     align_up,
+    chunk_gated_delta_rule_fwd_h,
     chunk_local_cumsum_vector,
     kda_gate_chunk_cumsum,
     prepare_chunk_indices,
@@ -433,6 +434,144 @@ def test_chunk_kda_32k_no_zero_length_output_and_final_state_match_naive_recurre
         rtol=2e-2,
         atol=1e-2,
     )
+
+
+def _run_empty_sequence_case(seq_lens, *, with_initial_state, activate):
+    """Exercise empty states through the same full pipeline and recurrent reference."""
+    rng = np.random.default_rng(326)
+    total_t = sum(seq_lens)
+    shape = (1, total_t, _H, _K)
+    q, k, v = (jnp.asarray(0.1 * rng.standard_normal(shape), dtype=jnp.bfloat16) for _ in range(3))
+    raw_g = jnp.asarray(0.25 + 0.2 * rng.standard_normal(shape), dtype=jnp.float32)
+    beta = jax.nn.sigmoid(jnp.asarray(rng.standard_normal((1, total_t, _H)), dtype=jnp.float32))
+    A_log = jnp.asarray(-1.5 + 0.1 * rng.standard_normal((_H,)), dtype=jnp.float32)
+    dt_bias = jnp.asarray(0.1 + 0.2 * rng.standard_normal((_H, _K)), dtype=jnp.float32)
+    activated_g = -jnp.exp(A_log)[None, None, :, None] * jax.nn.softplus(
+        raw_g + dt_bias[None, None, :, :]
+    )
+    state_shape = (len(seq_lens), _H, _K, _V)
+    initial_state = (
+        jnp.asarray(0.03 * rng.standard_normal(state_shape), dtype=jnp.float32)
+        if with_initial_state
+        else None
+    )
+    cu_seqlens = jnp.asarray([0, *np.cumsum(seq_lens)], dtype=jnp.int32)
+    output, final_state, *_ = chunk_kda(
+        q,
+        k,
+        v,
+        raw_g if activate else activated_g,
+        beta,
+        scale=_K**-0.5,
+        initial_state=initial_state,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        chunk_size=_BT,
+        use_gate_in_kernel=activate,
+        A_log=A_log if activate else None,
+        dt_bias=dt_bias if activate else None,
+    )
+    # The existing packed reference helper takes an explicit state per request.
+    # No initial state is equivalent to an all-zero state for the recurrence.
+    reference_initial_state = (
+        initial_state if with_initial_state else jnp.zeros(state_shape, dtype=jnp.float32)
+    )
+    reference_output, reference_state = _full_naive_reference(
+        seq_lens,
+        cu_seqlens,
+        q,
+        k,
+        v,
+        activated_g,
+        beta,
+        reference_initial_state,
+        _K**-0.5,
+    )
+    jax.block_until_ready((output, final_state, reference_output, reference_state))
+    assert output.shape == reference_output.shape == (1, total_t, _H, _V)
+    assert final_state.shape == reference_state.shape == state_shape
+    assert final_state.dtype == reference_state.dtype == jnp.float32
+    assert np.isfinite(np.asarray(output, dtype=np.float32)).all()
+    assert np.isfinite(np.asarray(final_state)).all()
+    np.testing.assert_allclose(output, reference_output, rtol=2e-2, atol=1e-2)
+    np.testing.assert_allclose(final_state, reference_state, rtol=2e-2, atol=1e-2)
+    empty = np.asarray(seq_lens) == 0
+    np.testing.assert_array_equal(
+        np.asarray(final_state)[empty], np.asarray(reference_state)[empty]
+    )
+    np.testing.assert_array_equal(
+        np.asarray(final_state)[empty], np.asarray(reference_initial_state)[empty]
+    )
+
+
+def test_chunk_kda_empty_sequences_preserve_final_state():
+    """Leading, interior and trailing empties alongside partial and full chunks."""
+    for seq_lens, activate in (
+        ([13, 0, 67, 5, 0], True),
+        ([0, 1, 64, 0, 65, 0], False),
+    ):
+        for with_initial_state in (True, False):
+            _run_empty_sequence_case(
+                seq_lens,
+                with_initial_state=with_initial_state,
+                activate=activate,
+            )
+
+
+def test_chunk_kda_all_empty_sequences_preserve_final_state():
+    """All-empty inputs must still initialize every final state."""
+    for seq_lens in ([0], [0, 0, 0]):
+        for with_initial_state in (True, False):
+            _run_empty_sequence_case(
+                seq_lens,
+                with_initial_state=with_initial_state,
+                activate=True,
+            )
+
+
+def test_chunk_kda_zero_token_state_wrapper():
+    """A direct state call with no tiles preserves optional-output and state semantics."""
+    k = jnp.zeros((1, 0, _H, _K), dtype=jnp.bfloat16)
+    beta = jnp.zeros((1, 0, _H), dtype=jnp.float32)
+    cu_seqlens = jnp.zeros((4,), dtype=jnp.int32)
+    chunk_indices = jnp.zeros((0, 2), dtype=jnp.int32)
+    initial = jnp.asarray(
+        np.random.default_rng(326).standard_normal((3, _H, _K, _V)), dtype=jnp.float32
+    )
+    for initial_state in (initial, None):
+        _, expected = naive_recurrent_kda(
+            jnp.repeat(k, 3, axis=0),
+            jnp.repeat(k, 3, axis=0),
+            jnp.repeat(k, 3, axis=0),
+            jnp.repeat(k, 3, axis=0),
+            jnp.repeat(beta, 3, axis=0),
+            initial_state=initial_state,
+            output_final_state=True,
+        )
+        for output_final_state in (True, False):
+            for save_new_value in (True, False):
+                h, v_new, ht = chunk_gated_delta_rule_fwd_h(
+                    k,
+                    k,
+                    k,
+                    initial_state=initial_state,
+                    output_final_state=output_final_state,
+                    save_new_value=save_new_value,
+                    cu_seqlens=cu_seqlens,
+                    chunk_indices=chunk_indices,
+                )
+                assert h.shape == (1, 0, _H, _K, _V)
+                assert h.dtype == jnp.float32
+                if save_new_value:
+                    assert v_new.shape == k.shape
+                    assert v_new.dtype == jnp.float32
+                else:
+                    assert v_new is None
+                if output_final_state:
+                    assert ht.dtype == jnp.float32
+                    np.testing.assert_array_equal(ht, expected)
+                else:
+                    assert ht is None
 
 
 def test_chunk_local_cumsum_preserves_custom_chunk_order_and_masks_invalid_chunks():


### PR DESCRIPTION
## Motivation

Use a private producer-certified flag to let gate, intra-chunk and output stages consume the alignment helper's contiguous chunk layout directly. Generic standalone callers retain gather/scatter mapping. Also initialize final state for empty sequences and preserve state on zero-token calls.

### Limitation of the current abstraction

The producer already guarantees contiguous aligned chunks, but the consumer interfaces lose that guarantee and materialize indirect mappings. A private static flag and existing reshape/transpose/padding operations express the faster path. Upstream lacks the captured fork's grouped-tile and configurable-solve options; this port preserves upstream's existing single-chunk APIs.

## Modifications

- `python/sgl_jax/srt/kernels/kda/kda.py`
- `python/sgl_jax/test/kernels/kda_test.py`

## Accuracy Tests

Historical corrected candidate: exact captured outputs, recurrent-reference/boundary checks and fresh confirmation at all three lengths. The upstream port passed four CPU interpreter regressions covering mixed/all-empty sequences, zero-token optional outputs and custom chunk mappings. Its new TPU lowering and performance still require confirmation.

All repository pre-commit checks passed for this commit, including the applicable type checker. Each implementation has one DCO-signed commit.

Targeted CPU command used in the upstream checkout:

```bash
JAX_PLATFORMS=cpu PALLAS_INTERPRET=1 PYTHONPATH=python python -m pytest -q python/sgl_jax/test/kernels/kda_test.py -k "empty_sequences_preserve_final_state or zero_token_state_wrapper or custom_chunk_order"
```

## Benchmarking and Profiling

**Measured on the frozen captured revisions below. These figures are not a benchmark of this PR rebased onto today's upstream main.**

| Captured case | Baseline (us) | Candidate (us) | Reduction | Speedup | Ratio CI95 |
| --- | ---: | ---: | ---: | ---: | --- |
| short | 581.267750 | 407.732180 | **29.85%** | 1.4256x | [0.701427079, 0.701475202] |
| medium | 2181.230219 | 1487.099105 | **31.82%** | 1.4668x | [0.681762133, 0.681780092] |
| long | 4271.222387 | 2912.061117 | **31.82%** | 1.4667x | [0.681781994, 0.681790322] |

Hardware: 1 local TPUv6e chip(s); JAX 0.11.1; explicit captured geometry and seed 1729. Each result is a mean of block medians from ten independent baseline/candidate pairs, with 50 exact compiled-program execution spans per block, 20 warmups and separate host timing. The gate requires >2% lower mean device latency and bootstrap ratio CI95 upper bound <1 (10,000 resamples, seed 1729). Canonical/scaled correctness comparisons retain the original tolerance. No full-model speedup is claimed.

### Post-compilation trace evidence

All 20 raw confirmation XPlane traces per shape and their execution records are retained. The publication audit re-read each raw trace, checked the serialized executable's HLO identity, reconstructed all 50 samples and reproduced its median. Multi-chip spans require a shared host execution identity and complete device partitions; single-chip traces may use the recorded device/queue/run identity.

Representative pair 00 for the **long** case:

| Role | Exact HLO identity | Devices | Samples | Block median (us) |
| --- | --- | ---: | ---: | ---: |
| baseline | `jit_fn` / ID `24` / PID `3536477` | 1 | 50 | 4271.218125 |
| candidate | `jit_fn` / ID `24` / PID `3535434` | 1 | 50 | 2912.064336 |

[Download every confirmation trace and the verification bundle](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/kda-chunked.tar.gz). SHA256: `78b8c7901ff55ac966769190a7e41cfda0fe761909d2d1841d981866daf0496b`.

After extraction, `python verify_evidence.py` (NumPy required) checks all bundle hashes and recomputes samples/statistics from the included selected events. Original `.xplane.pb` files remain the primary traces; raw output tensors and every repeated executable are not included.

### Post-compilation HLO and LLO dumps

Saved HLO/LLO show the measured contiguous implementation replacing generic chunk layout preparation. The included dumps are from the corrected measured candidate, not from the new upstream port.

| Shape | Full baseline LLO | Full candidate LLO | Compiled baseline HLO | Compiled candidate HLO |
| --- | --- | --- | --- | --- |
| long | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/kda-chunked-long-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/kda-chunked-long-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/kda-chunked-long-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/kda-chunked-long-candidate.hlo.txt.gz) |
| medium | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/kda-chunked-medium-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/kda-chunked-medium-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/kda-chunked-medium-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/kda-chunked-medium-candidate.hlo.txt.gz) |
| short | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/kda-chunked-short-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/kda-chunked-short-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/kda-chunked-short-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/kda-chunked-short-candidate.hlo.txt.gz) |

<details>
<summary>Representative records from the full numbered LLO dumps</summary>

These excerpts show static emitted sites selected from changed vector opcodes. Counts and excerpts support code inspection; they do not quantify dynamic cycles.

### baseline

```text
247 : {[vmem:$0x3ffe0] = vst.8x128 v62}
248 : {s3 = simm.u32 $50;  s1 = sld [smem:$0x3b];  v59 = vimm.8x128.s32 $0;  v62 = vlaneseq.8x128.u32;  [vmem:$0x3fff8] = vst.8x128 v59}
249 : {[vmem:$0x3fff0] = vst.8x128 v60}
250 : {p0 = slt.s32 s1, $95;  s2 = simm.u32 $0;  v59 = vsel.8x128 vm0, $0x1, v59;  v63 = vand.8x128.u32 $0x380, v62;  [vmem:$0x3ffd8] = vst.8x128 v63}
251 : {p0 = slt.s32 s1, $85;  s2 = simm.u32 @p0 $1;  vm0 = veq.8x128.s32 v63, $0;  [vmem:$0x3ffe8] = vst.8x128 v61}
261 : {p0 = slt.s32 s1, $15;  s2 = simm.u32 @p0 $32;  [vmem:$0x3ffd0] = vst.8x128 v0}
262 : {s2 = simm.u32 @p0 $72;  s3 = simm.u32 @p0 $6;  [vmem:$0x3ffc8] = vst.8x128 v1}
263 : {p0 = slt.s32 s1, $5;  v60 = vpack.i.8x128.f32.bf16 v61, v60;  v61 = vpack.i.8x128.f32.bf16 v60, v61;  [vmem:$0x3ffc0] = vst.8x128 v2}
```

### candidate

```text
247 : {[vmem:$0x3ffe0] = vst.8x128 v62}
248 : {s3 = simm.u32 $50;  s1 = sld [smem:$0x3b];  v59 = vimm.8x128.s32 $0;  v62 = vlaneseq.8x128.u32;  [vmem:$0x3fff8] = vst.8x128 v59}
249 : {[vmem:$0x3fff0] = vst.8x128 v60}
250 : {p0 = slt.s32 s1, $95;  s2 = simm.u32 $0;  v59 = vsel.8x128 vm0, $0x1, v59;  v63 = vand.8x128.u32 $0x380, v62;  [vmem:$0x3ffd8] = vst.8x128 v63}
251 : {p0 = slt.s32 s1, $85;  s2 = simm.u32 @p0 $1;  vm0 = veq.8x128.s32 v63, $0;  [vmem:$0x3ffe8] = vst.8x128 v61}
261 : {p0 = slt.s32 s1, $15;  s2 = simm.u32 @p0 $32;  [vmem:$0x3ffd0] = vst.8x128 v0}
262 : {s2 = simm.u32 @p0 $72;  s3 = simm.u32 @p0 $6;  [vmem:$0x3ffc8] = vst.8x128 v1}
263 : {p0 = slt.s32 s1, $5;  v60 = vpack.i.8x128.f32.bf16 v61, v60;  v61 = vpack.i.8x128.f32.bf16 v60, v61;  [vmem:$0x3ffc0] = vst.8x128 v2}
```

</details>

### Source provenance and remaining limits

- Measured baseline: `027fa79a6498a1afef5a36c4e093c07d2f12f1ef`; exact measured patch and accepted candidate IDs/revisions are in the bundle.
- PR base: `3f1f38715b5dcd4b8ef11e4186e029e3e90f9570`. PR implementation commit: `f90af82d82480f84d49873563d36148843b6fa1d`.
- The source was ported onto current upstream and checked locally. Fresh TPU lowering/performance confirmation on that upstream revision remains outstanding; this PR is a draft for review.
- Performance is limited to the reported geometries, dtypes, runtime, partition and guarded paths. Original captures and any unsuccessful search attempts are not relabeled as new upstream measurements.
- Ported contiguous producer/consumer addressing and empty-state initialization to upstream single-chunk APIs. Captured fork-only grouped compute/state tiles, configurable triangular solve and zero-state elision options are not introduced. Historical 29.85–31.82% figures belong to the frozen captured baseline/candidate; this upstream port requires fresh TPU performance confirmation.

## Checklist

- [x] English description with motivation and implementation scope.
- [x] Test results and reproducible evidence verification command provided.
- [x] Numerical and measurement limitations stated.
- [ ] Fresh TPU validation of the upstream port and any consolidation with overlapping variants.
