### PR TITLE
perf(gmm): support tile-local SiLU input gating

### DIFF
--- a/python/sgl_jax/srt/kernels/gmm/megablox_gmm_backend.py
+++ b/python/sgl_jax/srt/kernels/gmm/megablox_gmm_backend.py
@@ -7,7 +7,10 @@ import jax.numpy as jnp
 
 from sgl_jax.srt.kernels.gmm.megablox_gmm_kernel.gmm import gmm as gmm_v1_kernel
 from sgl_jax.srt.kernels.gmm.megablox_gmm_kernel.gmm_v2 import gmm_v2 as gmm_v2_kernel
-from sgl_jax.srt.kernels.gmm.megablox_gmm_kernel.gmm_v2 import is_supported_by_gmm_v2
+from sgl_jax.srt.kernels.gmm.megablox_gmm_kernel.gmm_v2 import (
+    is_supported_by_gmm_v2,
+    validate_lhs_activation,
+)
 from sgl_jax.srt.utils.jax_utils import is_tpu_runtime
 from sgl_jax.srt.utils.quantization.quantization_utils import quantize_tensor_simple
 
@@ -28,6 +31,8 @@ def gmm(
     acc_dtype: jnp.dtype | None = None,
     activation_quantized_dtype: jnp.dtype | None = None,
     v2_tile_info: Any = None,
+    lhs_multiplier: jax.Array | None = None,
+    lhs_activation: str | None = None,
 ) -> jax.Array:
     """Dispatch GMM to v2 or v1, with optional activation quantization.
 
@@ -57,13 +62,23 @@ def gmm(
             output afterwards.
         v2_tile_info: Optional TileSizes or TileFn for v2 kernel tiling.
             Defaults to calculate_tiling (auto-tiler) when None.
+        lhs_multiplier: Optional input with the same shape and dtype as lhs.
+        lhs_activation: Static activation mode. "silu" applies silu(lhs) *
+            lhs_multiplier, fused into supported v2 tiles. Other configurations
+            materialize the activation before the matmul or quantization.
     """
+    validate_lhs_activation(lhs, lhs_multiplier, lhs_activation)
     if interpret is None:
         interpret = not is_tpu_runtime()
 
     use_gmm_v2 = not interpret and is_supported_by_gmm_v2(
         rhs_scale, maybe_quantize_lhs=maybe_quantize_lhs
     )
+
+    if lhs_activation is not None and (not use_gmm_v2 or activation_quantized_dtype is not None):
+        lhs = jax.nn.silu(lhs) * lhs_multiplier
+        lhs_multiplier = None
+        lhs_activation = None
 
     # Pad LHS to multiple of 128 (or 32 for v2) on TPU to avoid small/unaligned tiles
     m = lhs.shape[0]
@@ -72,6 +87,12 @@ def gmm(
     if not interpret and m % alignment != 0:
         pad_size = alignment - (m % alignment)
         lhs = jax.lax.pad(lhs, jnp.zeros((), dtype=lhs.dtype), ((0, pad_size, 0), (0, 0, 0)))
+        if lhs_multiplier is not None:
+            lhs_multiplier = jax.lax.pad(
+                lhs_multiplier,
+                jnp.zeros((), dtype=lhs_multiplier.dtype),
+                ((0, pad_size, 0), (0, 0, 0)),
+            )
         group_sizes = group_sizes.at[-1].add(pad_size)
 
     lhs_scale = None
@@ -94,6 +115,8 @@ def gmm(
             maybe_quantize_lhs=maybe_quantize_lhs,
             zero_initialize=zero_initialize,
             acc_dtype=acc_dtype,
+            lhs_multiplier=lhs_multiplier,
+            lhs_activation=lhs_activation,
             **v2_kwargs,
         )
     else:

--- a/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/gmm_v2.py
+++ b/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/gmm_v2.py
@@ -33,6 +33,13 @@ class MetadataRef:
 
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
+class LhsRef:
+    value: Any
+    multiplier: Any | None = None
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
 class WeightsRef:
     weight: Any
     scale: Any | None
@@ -73,6 +80,7 @@ class GmmConfigs:
     out_dtype: jnp.dtype
     acc_dtype: jnp.dtype
     zero_init: bool
+    lhs_activation: str | None = None
 
 
 TileFn = Callable[[jnp.dtype, jnp.dtype, Dimensions, int], TileSizes]
@@ -127,7 +135,7 @@ class IndexMaps:
 
 def generate_block_specs(
     metadata_ref: MetadataRef, cfgs: GmmConfigs
-) -> tuple[tuple[pl.BlockSpec, WeightsRef], pl.BlockSpec]:
+) -> tuple[tuple[LhsRef, WeightsRef], pl.BlockSpec]:
     """Generates block specs for the given lhs, rhs, and out refs."""
 
     index_map = IndexMaps(metadata_ref, cfgs)
@@ -177,7 +185,12 @@ def generate_block_specs(
         index_map.out_index_map,
     )
 
-    return (lhs_block_spec, rhs_block_spec), out_block_spec
+    lhs_specs = LhsRef(
+        value=lhs_block_spec,
+        # Both inputs use the same bounded rows and default double buffering.
+        multiplier=lhs_block_spec if cfgs.lhs_activation is not None else None,
+    )
+    return (lhs_specs, rhs_block_spec), out_block_spec
 
 
 # Define kernels.
@@ -185,7 +198,7 @@ def generate_block_specs(
 
 def inner_kernel(
     # In
-    tiled_lhs_ref: jax.Array,
+    tiled_lhs_ref: LhsRef,
     # [tile_m // size_lhs_sublane, size_lhs_sublane, tile_k]
     tiled_rhs_ref: WeightsRef,  # [tile_k, tile_n]
     # Out
@@ -207,7 +220,7 @@ def inner_kernel(
     invalid data and needs to be masked out.
 
     Args:
-        tiled_lhs_ref: Contains value lhs[m_start:m_end, k_start:k_end]
+        tiled_lhs_ref: Contains lhs and optional multiplier for the same rows and K slice.
         tiled_rhs_ref: Contains value rhs[g_id, k_start:k_end, n_start:n_end]. where
             g_id is the group associated with lhs[m_start:m_end, :]
         tiled_out_ref: Contains value out[m_start:m_end, n_start:n_end]
@@ -219,7 +232,16 @@ def inner_kernel(
     """
 
     def _matmul(is_first_k_step: bool, is_last_k_step: bool):
-        tiled_lhs = tiled_lhs_ref[...].reshape(-1, cfgs.tiles.tile_k)
+        tiled_lhs = tiled_lhs_ref.value[...].reshape(-1, cfgs.tiles.tile_k)
+        if cfgs.lhs_activation == "silu":
+            # Match the fused XLA activation: FP32 arithmetic followed by one
+            # BF16 conversion before the FP32-accumulating matmul. The pipeline
+            # only invokes this for local expert tiles (plus boundary rows).
+            with jax.named_scope("lhs_silu_gating"):
+                gate = tiled_lhs.astype(jnp.float32)
+                up = tiled_lhs_ref.multiplier[...].reshape(gate.shape).astype(jnp.float32)
+                sigmoid = lax.reciprocal(1.0 + jnp.exp(-gate))
+                tiled_lhs = (gate * sigmoid * up).astype(tiled_lhs.dtype)
         tiled_rhs = tiled_rhs_ref.weight[...]
 
         valid_k = cfgs.dims.size_k % cfgs.tiles.tile_k
@@ -580,7 +602,7 @@ def kernel_main(
     lhs_group_sizes_ref: jax.Array,  # int32[size_lhs_group]
     group_offset_ref: jax.Array,  # int32[1]
     # In
-    lhs_ref: jax.Array,  # [size_m, size_k]
+    lhs_ref: LhsRef,  # Each leaf: [size_m, size_k]
     rhs_ref: WeightsRef,  # [size_group, size_k, size_n]
     # Out
     out_ref: jax.Array,  # [size_m, size_n]
@@ -609,7 +631,7 @@ def kernel_main(
     Args:
         lhs_group_sizes_ref: Reference to the group sizes of lhs.
         group_offset_ref: Reference to the group offset.
-        lhs_ref: Reference to the lhs.
+        lhs_ref: References to the lhs and optional multiplier.
         rhs_ref: Reference to the rhs.
         out_ref: Reference to the out.
         partial_out_ref: Reference to the partial output.
@@ -653,7 +675,9 @@ def kernel_main(
 
     # Bounded slice requires second last dim to be aligned to the sublane size.
     # rhs_ref uses static tiling thus reshape is not needed.
-    lhs_in = lhs_ref.reshape(-1, cfgs.dims.size_lhs_sublane, lhs_ref.shape[-1])
+    lhs_in = jax.tree.map(
+        lambda ref: ref.reshape(-1, cfgs.dims.size_lhs_sublane, ref.shape[-1]), lhs_ref
+    )
     out_in = out_ref.reshape(-1, cfgs.dims.size_lhs_sublane, out_ref.shape[-1])
     scratches = [partial_out_ref, acc_ref, metadata_ref]
     pipeline_fn(lhs_in, rhs_ref, out_in, scratches=scratches)
@@ -787,6 +811,7 @@ def get_cost_estimate(
     rhs: WeightsRef,
     out_dtype: jnp.dtype,
     dims: Dimensions,
+    lhs_multiplier: jax.Array | None = None,
 ):
     """Returns the cost estimate for the GMM kernel."""
     assert isinstance(rhs.weight, jax.Array)
@@ -794,6 +819,14 @@ def get_cost_estimate(
     flops = 2 * dims.size_m * dims.size_k * dims.size_n
 
     lhs_bytes = dims.size_m * dims.size_k * lhs.dtype.itemsize
+    transcendentals = 0
+    if lhs_multiplier is not None:
+        # As with the matmul estimate, use the full M as a static estimate;
+        # runtime metadata determines the local rows and boundary overhead.
+        activation_elements = dims.size_m * dims.size_k
+        lhs_bytes += activation_elements * lhs_multiplier.dtype.itemsize
+        flops += 4 * activation_elements
+        transcendentals = 2 * activation_elements  # exp and reciprocal
 
     rhs_bytes = (
         dims.size_group * dims.size_k * dims.size_n * jax.dtypes.itemsize_bits(rhs.weight)
@@ -810,8 +843,55 @@ def get_cost_estimate(
     return pl.CostEstimate(
         flops=flops,
         bytes_accessed=total_bytes,
-        transcendentals=0,
+        transcendentals=transcendentals,
     )
+
+
+def validate_lhs_activation(lhs, lhs_multiplier, lhs_activation):
+    """Validate the optional two-input activation without changing either input."""
+    if lhs_activation not in (None, "silu"):
+        raise ValueError(f"Unsupported lhs activation: {lhs_activation}")
+    if (lhs_activation is None) != (lhs_multiplier is None):
+        raise ValueError("lhs_activation and lhs_multiplier must be supplied together")
+    if lhs_multiplier is not None and (
+        lhs_multiplier.shape != lhs.shape or lhs_multiplier.dtype != lhs.dtype
+    ):
+        raise ValueError("lhs_multiplier must have the same shape and dtype as lhs")
+
+
+def can_fuse_lhs_silu(lhs, rhs, cfgs: GmmConfigs, vmem_limit_bytes: int) -> bool:
+    """Keep fusion on unquantized BF16 tiles that visit each K/N dimension once."""
+    dims, tiles = cfgs.dims, cfgs.tiles
+    if (
+        lhs.dtype != jnp.bfloat16
+        or rhs.dtype != jnp.bfloat16
+        or cfgs.out_dtype != jnp.bfloat16
+        or cfgs.acc_dtype != jnp.float32
+        or cfgs.lhs_cfgs.quant_dtype is not None
+        or cfgs.rhs_cfgs.has_scale
+        or tiles.tile_k != dims.size_k
+        or tiles.tile_n != dims.size_n
+    ):
+        return False
+
+    # Retain the incumbent geometry. Budget both double-buffered LHS leaves,
+    # triple-buffered weights, double-buffered output, and existing scratches.
+    # Reserve six FP32 activation tiles for vector temporaries as well. This
+    # is an admission estimate; compiler allocation/spills still need checking.
+    lhs_tile_elements = tiles.tile_m * tiles.tile_k
+    out_tile_elements = tiles.tile_m * tiles.tile_n
+    vmem_bytes = 2 * 2 * lhs_tile_elements * jnp.dtype(lhs.dtype).itemsize
+    vmem_bytes += 3 * tiles.tile_k * tiles.tile_n * jnp.dtype(rhs.dtype).itemsize
+    vmem_bytes += 2 * out_tile_elements * cfgs.out_dtype.itemsize
+    vmem_bytes += out_tile_elements * jnp.dtype(cfgs.acc_dtype).itemsize
+    vmem_bytes += dims.size_lhs_sublane * tiles.tile_n * cfgs.out_dtype.itemsize
+    if cfgs.rhs_cfgs.has_bias:
+        vmem_bytes += 2 * tiles.tile_n * jnp.dtype(jnp.float32).itemsize
+    if cfgs.zero_init:
+        num_lanes = pltpu.get_tpu_info().num_lanes
+        vmem_bytes += min(2 * 1024 * 1024, dims.size_m * num_lanes * cfgs.out_dtype.itemsize)
+    vmem_bytes += 6 * lhs_tile_elements * jnp.dtype(jnp.float32).itemsize
+    return vmem_bytes <= vmem_limit_bytes
 
 
 def get_scope_name(dims: Dimensions, tiles: TileSizes) -> str:
@@ -932,6 +1012,7 @@ def get_metadata(cfgs: GmmConfigs):
         "acc_dtype",
         "maybe_quantize_lhs",
         "zero_initialize",
+        "lhs_activation",
     ]
 )
 def gmm_v2(
@@ -949,6 +1030,8 @@ def gmm_v2(
     acc_dtype: jnp.dtype | None = None,
     maybe_quantize_lhs: bool = True,
     zero_initialize: bool = True,
+    lhs_multiplier: jax.Array | None = None,
+    lhs_activation: str | None = None,
 ) -> jax.Array:
     """GMM kernel implemented with emit_pipeline.
 
@@ -970,12 +1053,17 @@ def gmm_v2(
           acc_dtype: Optional jnp.dtype for the accumulator.
           maybe_quantize_lhs: Quantize lhs if set to True and rhs is quantized.
           zero_initialize: Whether to initialize unvisited output elements to zero.
+          lhs_multiplier: Optional input with the same shape and dtype as lhs.
+          lhs_activation: Static activation mode. "silu" computes silu(lhs) *
+              lhs_multiplier inside unquantized BF16 full-K/full-N tiles when
+              the memory estimate fits; otherwise materializes it before GMM.
 
     Returns:
           Output of shape [size_m, size_n].
     """
 
     del precision
+    validate_lhs_activation(lhs, lhs_multiplier, lhs_activation)
 
     if group_offset is None:
         group_offset = jnp.array([0], dtype=jnp.int32)
@@ -1002,6 +1090,15 @@ def gmm_v2(
     )
     dims = cfgs.dims
     tiles = cfgs.tiles
+
+    if lhs_activation is not None:
+        if can_fuse_lhs_silu(lhs, rhs, cfgs, vmem_limit_bytes):
+            cfgs = dataclasses.replace(cfgs, lhs_activation=lhs_activation)
+        else:
+            # Preserve the original activation and tiling for other dtypes,
+            # quantized inputs, split K/N tiles, or insufficient VMEM.
+            lhs = jax.nn.silu(lhs) * lhs_multiplier
+            lhs_multiplier = None
 
     # Prepare block specs.
     rhs_scale_spec = rhs_bias_spec = None
@@ -1062,6 +1159,11 @@ def gmm_v2(
 
     aligned_n = align_to(dims.size_n, num_lanes)
     out_init = jax.ShapeDtypeStruct((dims.size_m, aligned_n), cfgs.out_dtype)
+    lhs_inputs = LhsRef(value=lhs, multiplier=lhs_multiplier)
+    lhs_spec = LhsRef(
+        value=pl.BlockSpec(memory_space=pltpu.HBM),
+        multiplier=pl.BlockSpec(memory_space=pltpu.HBM) if lhs_multiplier is not None else None,
+    )
     rhs_weights = WeightsRef(weight=rhs, scale=rhs_scale, bias=rhs_bias)
 
     return pl.pallas_call(
@@ -1070,7 +1172,7 @@ def gmm_v2(
         grid_spec=pltpu.PrefetchScalarGridSpec(
             num_scalar_prefetch=2,
             in_specs=[
-                pl.BlockSpec(memory_space=pltpu.HBM),
+                lhs_spec,
                 WeightsRef(
                     weight=pl.BlockSpec(memory_space=pltpu.HBM),
                     scale=rhs_scale_spec,
@@ -1084,10 +1186,10 @@ def gmm_v2(
             vmem_limit_bytes=vmem_limit_bytes,
             disable_bounds_checks=True,
         ),
-        name=get_scope_name(dims, tiles),
-        cost_estimate=get_cost_estimate(lhs, rhs_weights, out_init.dtype, dims),
+        name=get_scope_name(dims, tiles) + ("-lhs_silu" if cfgs.lhs_activation else ""),
+        cost_estimate=get_cost_estimate(lhs, rhs_weights, out_init.dtype, dims, lhs_multiplier),
         metadata=get_metadata(cfgs),
-    )(group_sizes, group_offset, lhs, rhs_weights)[:, : dims.size_n]
+    )(group_sizes, group_offset, lhs_inputs, rhs_weights)[:, : dims.size_n]
 
 
 def is_supported_by_gmm_v2(

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -727,13 +727,27 @@ class EPMoE(nnx.Module):
         )
 
         # === Activation ===
-        if self.activation == "silu":
-            layer_act = jax.nn.silu(layer_w0)
-        elif self.activation == "gelu":
-            layer_act = jax.nn.gelu(layer_w0)
+        if (
+            self.activation == "silu"
+            and self.dtype == jnp.bfloat16
+            and act_q_dtype is None
+            and all(w.dtype == jnp.bfloat16 for w in (w0_kernel, w1_kernel, wo_kernel))
+            and all(s is None for s in (w0_kernel_scale, w1_kernel_scale, wo_kernel_scale))
+        ):
+            # Let the down GMM activate only the rows visited by its local
+            # expert metadata. The backend retains materialized activation for
+            # v1 and for v2 configurations without full-K/full-N tile capacity.
+            intermediate_layer = layer_w0
+            gmm_kwargs["lhs_multiplier"] = layer_w1
+            gmm_kwargs["lhs_activation"] = "silu"
         else:
-            raise ValueError(f"Unsupported activation function {self.activation}")
-        intermediate_layer = jnp.multiply(layer_act, layer_w1)
+            if self.activation == "silu":
+                layer_act = jax.nn.silu(layer_w0)
+            elif self.activation == "gelu":
+                layer_act = jax.nn.gelu(layer_w0)
+            else:
+                raise ValueError(f"Unsupported activation function {self.activation}")
+            intermediate_layer = jnp.multiply(layer_act, layer_w1)
 
         # === GEMM2: intermediate @ wo ===
         return gmm(


### PR DESCRIPTION
## Motivation

Extend GMM with optional lhs_multiplier/lhs_activation inputs so the down projection computes SiLU(gate) * up inside visited input tiles rather than materializing a separate activation tensor.

### Limitation of the current abstraction

The existing independent grouped-matmul interface cannot consume a tile-local gated input. Existing fused-MLP kernels expose a different contract. This extends the GMM library interface using existing Pallas operations; it does not add a compiler primitive. Unsupported dtypes, quantization and tilings retain materialized fallback behavior.

## Modifications

- `python/sgl_jax/srt/kernels/gmm/megablox_gmm_backend.py`
- `python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/gmm_v2.py`
- `python/sgl_jax/srt/layers/moe.py`

## Accuracy Tests

Exact canonical/scaled parity and six supplemental TPU cases covering expert offsets, partial/empty groups, an empty local shard, bias and split-K/split-N fallbacks. Original FP32 activation arithmetic and the BF16 conversion before matmul are retained.

All repository pre-commit checks passed for this commit, including the applicable type checker. Each implementation has one DCO-signed commit.

The retained TPU correctness/audit receipts are in the evidence bundle. No new TPU run was performed in the upstream publication checkout.

## Benchmarking and Profiling

**Measured on the frozen captured revisions below. These figures are not a benchmark of this PR rebased onto today's upstream main.**

| Captured case | Baseline (us) | Candidate (us) | Reduction | Speedup | Ratio CI95 |
| --- | ---: | ---: | ---: | ---: | --- |
| long | 3062.280566 | 2932.366410 | **4.24%** | 1.0443x | [0.956085358, 0.959159382] |

Hardware: 4 local TPUv6e chip(s); JAX 0.11.1; explicit captured geometry and seed 1729. Each result is a mean of block medians from ten independent baseline/candidate pairs, with 50 exact compiled-program execution spans per block, 20 warmups and separate host timing. The gate requires >2% lower mean device latency and bootstrap ratio CI95 upper bound <1 (10,000 resamples, seed 1729). Canonical/scaled correctness comparisons retain the original tolerance. No full-model speedup is claimed.

### Post-compilation trace evidence

All 20 raw confirmation XPlane traces per shape and their execution records are retained. The publication audit re-read each raw trace, checked the serialized executable's HLO identity, reconstructed all 50 samples and reproduced its median. Multi-chip spans require a shared host execution identity and complete device partitions; single-chip traces may use the recorded device/queue/run identity.

Representative pair 00 for the **long** case:

| Role | Exact HLO identity | Devices | Samples | Block median (us) |
| --- | --- | ---: | ---: | ---: |
| baseline | `jit_fn` / ID `54` / PID `3299100` | 4 | 50 | 3067.865000 |
| candidate | `jit_fn` / ID `54` / PID `3297869` | 4 | 50 | 2936.728164 |

[Download every confirmation trace and the verification bundle](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/moe-input-gating.tar.gz). SHA256: `3466e759b8e0ee4e64d6e945ad5b5732beef1334a614bd7d11baf89130bacf2d`.

After extraction, `python verify_evidence.py` (NumPy required) checks all bundle hashes and recomputes samples/statistics from the included selected events. Original `.xplane.pb` files remain the primary traces; raw output tensors and every repeated executable are not included.

### Post-compilation HLO and LLO dumps

Complete-module static vexp2 sites fall from 1,024 to 128 and reciprocal sites from 1,056 to 160. These support the visited-tile activation mechanism; measured correlated four-chip program spans establish latency.

| Shape | Full baseline LLO | Full candidate LLO | Compiled baseline HLO | Compiled candidate HLO |
| --- | --- | --- | --- | --- |
| long | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/moe-input-gating-long-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/moe-input-gating-long-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/moe-input-gating-long-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/moe-input-gating-long-candidate.hlo.txt.gz) |

<details>
<summary>Representative records from the full numbered LLO dumps</summary>

These excerpts show static emitted sites selected from changed vector opcodes. Counts and excerpts support code inspection; they do not quantify dynamic cycles.

### baseline

```text
287 : {p0 = seq.s32 s0, s3;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
288 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
289 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
290 : {(pc) = sbr.rel @!p0 $-3 (=0xffffffffffffffed);  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
291 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
292 : {s0 = sadd.s32 $1, s0;  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  _ = vdelay s2;  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
293 : {p0 = seq.s32 @!p0 s0, s3;  p0 = por @p0 $0, $0;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
294 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
```

### candidate

```text
287 : {p0 = seq.s32 s0, s3;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
288 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
289 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
290 : {(pc) = sbr.rel @!p0 $-3 (=0xffffffffffffffed);  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
291 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
292 : {s0 = sadd.s32 $1, s0;  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  _ = vdelay s2;  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
293 : {p0 = seq.s32 @!p0 s0, s3;  p0 = por @p0 $0, $0;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
294 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
```

</details>

### Source provenance and remaining limits

- Measured baseline: `027fa79a6498a1afef5a36c4e093c07d2f12f1ef`; exact measured patch and accepted candidate IDs/revisions are in the bundle.
- PR base: `3f1f38715b5dcd4b8ef11e4186e029e3e90f9570`. PR implementation commit: `1389e30a0ac44536cfb9239af2e54d5b3d109e01`.
- The source was ported onto current upstream and checked locally. Fresh TPU lowering/performance confirmation on that upstream revision remains outstanding; this PR is a draft for review.
- Performance is limited to the reported geometries, dtypes, runtime, partition and guarded paths. Original captures and any unsuccessful search attempts are not relabeled as new upstream measurements.
- Resolved the import conflict by adding only the new activation helpers; did not restore baseline-only tiling helper imports removed from upstream.
- The input-gating and output-gating MoE PRs are alternative activation placements, independently measured. They must not be stacked without resolving their shared call sites and revalidating semantics/performance.

## Checklist

- [x] English description with motivation and implementation scope.
- [x] Test results and reproducible evidence verification command provided.
- [x] Numerical and measurement limitations stated.
- [ ] Fresh TPU validation of the upstream port and any consolidation with overlapping variants.
