### PR TITLE
perf(gmm): support output-rounded SiLU multiplication

### DIFF
--- a/python/sgl_jax/srt/kernels/gmm/megablox_gmm_backend.py
+++ b/python/sgl_jax/srt/kernels/gmm/megablox_gmm_backend.py
@@ -7,7 +7,11 @@ import jax.numpy as jnp
 
 from sgl_jax.srt.kernels.gmm.megablox_gmm_kernel.gmm import gmm as gmm_v1_kernel
 from sgl_jax.srt.kernels.gmm.megablox_gmm_kernel.gmm_v2 import gmm_v2 as gmm_v2_kernel
-from sgl_jax.srt.kernels.gmm.megablox_gmm_kernel.gmm_v2 import is_supported_by_gmm_v2
+from sgl_jax.srt.kernels.gmm.megablox_gmm_kernel.gmm_v2 import (
+    is_supported_by_gmm_v2,
+    materialize_output_activation,
+    validate_output_activation,
+)
 from sgl_jax.srt.utils.jax_utils import is_tpu_runtime
 from sgl_jax.srt.utils.quantization.quantization_utils import quantize_tensor_simple
 
@@ -28,6 +32,8 @@ def gmm(
     acc_dtype: jnp.dtype | None = None,
     activation_quantized_dtype: jnp.dtype | None = None,
     v2_tile_info: Any = None,
+    output_multiplier: jax.Array | None = None,
+    output_activation: str | None = None,
 ) -> jax.Array:
     """Dispatch GMM to v2 or v1, with optional activation quantization.
 
@@ -57,13 +63,29 @@ def gmm(
             output afterwards.
         v2_tile_info: Optional TileSizes or TileFn for v2 kernel tiling.
             Defaults to calculate_tiling (auto-tiler) when None.
+        output_multiplier: Optional operand matching the logical, unpadded
+            output shape and dtype. Must be paired with output_activation.
+        output_activation: Static epilogue mode. "silu" rounds the GMM result
+            to the output dtype, computes silu(result) * output_multiplier in
+            at least FP32, and rounds the product to the output dtype. Only
+            visited rows are activated. Unvisited rows are zero when
+            zero_initialize=True and unspecified otherwise. Supported BF16 v2
+            tiles fuse the epilogue; other configurations materialize it.
     """
+    output_dtype = lhs.dtype if preferred_element_type is None else preferred_element_type
+    validate_output_activation(
+        (lhs.shape[0], rhs.shape[-1]), output_dtype, output_multiplier, output_activation
+    )
     if interpret is None:
         interpret = not is_tpu_runtime()
 
     use_gmm_v2 = not interpret and is_supported_by_gmm_v2(
         rhs_scale, maybe_quantize_lhs=maybe_quantize_lhs
     )
+    materialize_epilogue = output_activation is not None and (
+        not use_gmm_v2 or activation_quantized_dtype is not None
+    )
+    logical_group_sizes = group_sizes
 
     # Pad LHS to multiple of 128 (or 32 for v2) on TPU to avoid small/unaligned tiles
     m = lhs.shape[0]
@@ -72,6 +94,12 @@ def gmm(
     if not interpret and m % alignment != 0:
         pad_size = alignment - (m % alignment)
         lhs = jax.lax.pad(lhs, jnp.zeros((), dtype=lhs.dtype), ((0, pad_size, 0), (0, 0, 0)))
+        if output_multiplier is not None and not materialize_epilogue:
+            output_multiplier = jax.lax.pad(
+                output_multiplier,
+                jnp.zeros((), dtype=output_multiplier.dtype),
+                ((0, pad_size, 0), (0, 0, 0)),
+            )
         group_sizes = group_sizes.at[-1].add(pad_size)
 
     lhs_scale = None
@@ -83,6 +111,9 @@ def gmm(
         v2_kwargs = {}
         if v2_tile_info is not None:
             v2_kwargs["tile_info"] = v2_tile_info
+        if output_activation is not None and not materialize_epilogue:
+            v2_kwargs["output_multiplier"] = output_multiplier
+            v2_kwargs["output_activation"] = output_activation
         out = gmm_v2_kernel(
             lhs,
             rhs,
@@ -116,5 +147,17 @@ def gmm(
     # Slice output back to original size if padded
     if pad_size > 0:
         out = out[:m]
+
+    if materialize_epilogue:
+        # Finish activation dequantization, logical slicing and output rounding
+        # before applying the same epilogue contract as the fused v2 path.
+        out = materialize_output_activation(
+            out.astype(output_dtype),
+            output_multiplier,
+            logical_group_sizes,
+            group_offset,
+            rhs.shape[0],
+            zero_initialize=zero_initialize,
+        )
 
     return out

--- a/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/gmm_v2.py
+++ b/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/gmm_v2.py
@@ -73,6 +73,7 @@ class GmmConfigs:
     out_dtype: jnp.dtype
     acc_dtype: jnp.dtype
     zero_init: bool
+    output_activation: str | None = None
 
 
 TileFn = Callable[[jnp.dtype, jnp.dtype, Dimensions, int], TileSizes]
@@ -111,6 +112,16 @@ class IndexMaps:
         group_id = self.metadata_ref.gm_id_to_group_id[gm_id]
         return (group_id, k_id, 0, n_id)
 
+    def output_multiplier_index_map(self, n_id: jax.Array, gm_id: jax.Array, _: jax.Array):
+        m_start = self.metadata_ref.gm_id_to_m_offset[gm_id]
+        m_end = self.metadata_ref.gm_id_to_m_offset[gm_id + 1]
+
+        # Unlike the output DMA, the epilogue needs the final partial sublane
+        # on every step, including rows carried forward through partial_out_ref.
+        row_start = m_start // self.cfgs.dims.size_lhs_sublane
+        row_end = pl.cdiv(m_end, self.cfgs.dims.size_lhs_sublane)
+        return (pl.ds(row_start, row_end - row_start), 0, n_id)
+
     def out_index_map(self, n_id: jax.Array, gm_id: jax.Array, _: jax.Array):
         is_last_gm = gm_id == (pl.num_programs(1) - 1)
         m_start = self.metadata_ref.gm_id_to_m_offset[gm_id]
@@ -127,7 +138,7 @@ class IndexMaps:
 
 def generate_block_specs(
     metadata_ref: MetadataRef, cfgs: GmmConfigs
-) -> tuple[tuple[pl.BlockSpec, WeightsRef], pl.BlockSpec]:
+) -> tuple[tuple[pl.BlockSpec, WeightsRef, pl.BlockSpec | None], pl.BlockSpec]:
     """Generates block specs for the given lhs, rhs, and out refs."""
 
     index_map = IndexMaps(metadata_ref, cfgs)
@@ -177,7 +188,15 @@ def generate_block_specs(
         index_map.out_index_map,
     )
 
-    return (lhs_block_spec, rhs_block_spec), out_block_spec
+    output_multiplier_spec = None
+    if cfgs.output_activation is not None:
+        output_multiplier_spec = pl.BlockSpec(
+            (bounded_slice_gm, cfgs.dims.size_lhs_sublane, cfgs.tiles.tile_n),
+            index_map.output_multiplier_index_map,
+            pipeline_mode=pl.Buffered(buffer_count=2),
+        )
+
+    return (lhs_block_spec, rhs_block_spec, output_multiplier_spec), out_block_spec
 
 
 # Define kernels.
@@ -188,6 +207,7 @@ def inner_kernel(
     tiled_lhs_ref: jax.Array,
     # [tile_m // size_lhs_sublane, size_lhs_sublane, tile_k]
     tiled_rhs_ref: WeightsRef,  # [tile_k, tile_n]
+    tiled_output_multiplier_ref: jax.Array | None,
     # Out
     tiled_out_ref: jax.Array,
     # [tile_m // size_lhs_sublane, size_lhs_sublane, tile_n]
@@ -210,6 +230,8 @@ def inner_kernel(
         tiled_lhs_ref: Contains value lhs[m_start:m_end, k_start:k_end]
         tiled_rhs_ref: Contains value rhs[g_id, k_start:k_end, n_start:n_end]. where
             g_id is the group associated with lhs[m_start:m_end, :]
+        tiled_output_multiplier_ref: Optional multiplier for all rows in the tile,
+            including the final partial sublane, and the same output columns.
         tiled_out_ref: Contains value out[m_start:m_end, n_start:n_end]
         partial_out_ref: Contains last size_lhs_sublane rows of the previous output.
             Will be initialized to zero if this is first tile for grid[n_id, :, :].
@@ -326,6 +348,15 @@ def inner_kernel(
                 acc *= tiled_rhs_ref.scale[...].astype(acc.dtype)
             if cfgs.rhs_cfgs.has_bias:
                 acc += tiled_rhs_ref.bias[...].astype(acc.dtype)
+
+            if cfgs.output_activation == "silu":
+                with jax.named_scope("output_silu_gating"):
+                    # Match the materialized gate GMM's BF16 rounding before
+                    # doing the activation and multiplication in FP32. Activate
+                    # only the new result, before merging previously gated rows.
+                    gate = acc.astype(cfgs.out_dtype)
+                    multiplier = tiled_output_multiplier_ref[...].reshape(acc.shape)
+                    acc = _silu_output(gate, multiplier)
 
             gm_id = pl.program_id(1)
 
@@ -582,6 +613,7 @@ def kernel_main(
     # In
     lhs_ref: jax.Array,  # [size_m, size_k]
     rhs_ref: WeightsRef,  # [size_group, size_k, size_n]
+    output_multiplier_ref: jax.Array | None,  # [size_m, size_n]
     # Out
     out_ref: jax.Array,  # [size_m, size_n]
     # Scratch memory
@@ -611,6 +643,7 @@ def kernel_main(
         group_offset_ref: Reference to the group offset.
         lhs_ref: Reference to the lhs.
         rhs_ref: Reference to the rhs.
+        output_multiplier_ref: Optional reference to the output-shaped multiplier.
         out_ref: Reference to the out.
         partial_out_ref: Reference to the partial output.
         acc_ref: Reference to the accumulator.
@@ -654,9 +687,14 @@ def kernel_main(
     # Bounded slice requires second last dim to be aligned to the sublane size.
     # rhs_ref uses static tiling thus reshape is not needed.
     lhs_in = lhs_ref.reshape(-1, cfgs.dims.size_lhs_sublane, lhs_ref.shape[-1])
+    output_multiplier_in = None
+    if output_multiplier_ref is not None:
+        output_multiplier_in = output_multiplier_ref.reshape(
+            -1, cfgs.dims.size_lhs_sublane, output_multiplier_ref.shape[-1]
+        )
     out_in = out_ref.reshape(-1, cfgs.dims.size_lhs_sublane, out_ref.shape[-1])
     scratches = [partial_out_ref, acc_ref, metadata_ref]
-    pipeline_fn(lhs_in, rhs_ref, out_in, scratches=scratches)
+    pipeline_fn(lhs_in, rhs_ref, output_multiplier_in, out_in, scratches=scratches)
 
     if cfgs.zero_init:
         zero_out_end(out_ref, semaphore_ref, zero_size, dims=cfgs.dims)
@@ -787,6 +825,7 @@ def get_cost_estimate(
     rhs: WeightsRef,
     out_dtype: jnp.dtype,
     dims: Dimensions,
+    output_multiplier: jax.Array | None = None,
 ):
     """Returns the cost estimate for the GMM kernel."""
     assert isinstance(rhs.weight, jax.Array)
@@ -806,12 +845,99 @@ def get_cost_estimate(
     out_bytes = dims.size_m * dims.size_n * jnp.dtype(out_dtype).itemsize
 
     total_bytes = lhs_bytes + rhs_bytes + out_bytes
+    transcendentals = 0
+    if output_multiplier is not None:
+        # As for the matmul estimate, use full M; metadata selects local rows.
+        output_elements = dims.size_m * dims.size_n
+        total_bytes += output_elements * output_multiplier.dtype.itemsize
+        flops += 4 * output_elements
+        transcendentals = 2 * output_elements  # exp and reciprocal
 
     return pl.CostEstimate(
         flops=flops,
         bytes_accessed=total_bytes,
-        transcendentals=0,
+        transcendentals=transcendentals,
     )
+
+
+def validate_output_activation(output_shape, output_dtype, output_multiplier, output_activation):
+    """Validate the paired epilogue arguments against the logical, unpadded output."""
+    if output_activation not in (None, "silu"):
+        raise ValueError(f"Unsupported output activation: {output_activation}")
+    if (output_activation is None) != (output_multiplier is None):
+        raise ValueError("output_activation and output_multiplier must be supplied together")
+    if output_multiplier is not None and (
+        output_multiplier.shape != output_shape
+        or output_multiplier.dtype != jnp.dtype(output_dtype)
+    ):
+        raise ValueError("output_multiplier must match the logical GMM output shape and dtype")
+
+
+def _silu_output(gate, multiplier):
+    """Gate is already rounded to the GMM output dtype; round again only at the end."""
+    compute_dtype = jnp.promote_types(gate.dtype, jnp.float32)
+    gate_f32 = gate.astype(compute_dtype)
+    up = multiplier.astype(compute_dtype)
+    sigmoid = lax.reciprocal(1.0 + jnp.exp(-gate_f32))
+    return (gate_f32 * sigmoid * up).astype(gate.dtype)
+
+
+def materialize_output_activation(
+    out, output_multiplier, group_sizes, group_offset, num_groups, *, zero_initialize
+):
+    """Apply the epilogue to visited rows while retaining the initialization contract."""
+    offset = jnp.asarray(0 if group_offset is None else group_offset, dtype=jnp.int32).reshape(())
+    group_ids = jnp.arange(group_sizes.shape[0], dtype=jnp.int32)
+    row_start = jnp.sum(jnp.where(group_ids < offset, group_sizes, 0))
+    row_end = jnp.sum(jnp.where(group_ids < offset + num_groups, group_sizes, 0))
+    rows = jnp.arange(out.shape[0], dtype=jnp.int32)[:, None]
+    visited = (row_start <= rows) & (rows < row_end)
+    gated = _silu_output(out, output_multiplier)
+    # In particular, NaNs in an unvisited multiplier must not turn zero-filled
+    # rows into NaNs. With zero_initialize=False those rows remain unspecified.
+    unvisited = jnp.zeros_like(out) if zero_initialize else out
+    return jnp.where(visited, gated, unvisited)
+
+
+def can_fuse_output_silu(lhs, rhs, cfgs: GmmConfigs, vmem_limit_bytes: int) -> bool:
+    """Admit unquantized BF16 full-K/full-N tiles without changing the chosen tiling."""
+    dims, tiles = cfgs.dims, cfgs.tiles
+    num_lanes = pltpu.get_tpu_info().num_lanes
+    if (
+        lhs.dtype != jnp.bfloat16
+        or rhs.dtype != jnp.bfloat16
+        or cfgs.out_dtype != jnp.bfloat16
+        or cfgs.acc_dtype != jnp.float32
+        or cfgs.lhs_cfgs.quant_dtype is not None
+        or cfgs.rhs_cfgs.has_scale
+        or tiles.tile_k != dims.size_k
+        or tiles.tile_n != dims.size_n
+        or tiles.tile_k % num_lanes != 0
+        or tiles.tile_n % num_lanes != 0
+        or tiles.tile_m <= 0
+        or tiles.tile_m % dims.size_lhs_sublane != 0
+        or dims.size_m % dims.size_lhs_sublane != 0
+    ):
+        return False
+
+    # Budget double-buffered LHS, multiplier and output, triple-buffered RHS,
+    # accumulator and partial-output scratches, plus six FP32 epilogue tiles.
+    # This is a conservative admission estimate, not a compiler spill check.
+    lhs_elements = tiles.tile_m * tiles.tile_k
+    out_elements = tiles.tile_m * tiles.tile_n
+    out_bytes = cfgs.out_dtype.itemsize
+    f32_bytes = jnp.dtype(jnp.float32).itemsize
+    vmem_bytes = 2 * lhs_elements * jnp.dtype(lhs.dtype).itemsize
+    vmem_bytes += 3 * tiles.tile_k * tiles.tile_n * jnp.dtype(rhs.dtype).itemsize
+    vmem_bytes += 4 * out_elements * out_bytes
+    vmem_bytes += out_elements * jnp.dtype(cfgs.acc_dtype).itemsize
+    vmem_bytes += dims.size_lhs_sublane * tiles.tile_n * out_bytes
+    vmem_bytes += 6 * out_elements * f32_bytes
+    if cfgs.rhs_cfgs.has_bias:
+        vmem_bytes += 2 * tiles.tile_n * f32_bytes
+    if cfgs.zero_init:
+        vmem_bytes += min(2 * 1024 * 1024, dims.size_m * num_lanes * out_bytes)
+    return vmem_bytes <= vmem_limit_bytes
 
 
 def get_scope_name(dims: Dimensions, tiles: TileSizes) -> str:
@@ -932,6 +1058,7 @@ def get_metadata(cfgs: GmmConfigs):
         "acc_dtype",
         "maybe_quantize_lhs",
         "zero_initialize",
+        "output_activation",
     ]
 )
 def gmm_v2(
@@ -949,6 +1076,8 @@ def gmm_v2(
     acc_dtype: jnp.dtype | None = None,
     maybe_quantize_lhs: bool = True,
     zero_initialize: bool = True,
+    output_multiplier: jax.Array | None = None,
+    output_activation: str | None = None,
 ) -> jax.Array:
     """GMM kernel implemented with emit_pipeline.
 
@@ -970,12 +1099,27 @@ def gmm_v2(
           acc_dtype: Optional jnp.dtype for the accumulator.
           maybe_quantize_lhs: Quantize lhs if set to True and rhs is quantized.
           zero_initialize: Whether to initialize unvisited output elements to zero.
+          output_multiplier: Optional operand matching the logical output shape
+              and dtype, paired with output_activation.
+          output_activation: Static epilogue mode. "silu" rounds the GMM result
+              to the output dtype, computes silu(result) * output_multiplier in
+              at least FP32, and rounds the product to the output dtype. Only
+              visited rows are activated; unvisited rows are zero when
+              zero_initialize=True and unspecified otherwise. Unquantized BF16
+              full-K/full-N tiles fuse the epilogue when the VMEM estimate fits;
+              other configurations materialize it after the unchanged GMM.
 
     Returns:
           Output of shape [size_m, size_n].
     """
 
     del precision
+    validate_output_activation(
+        (lhs.shape[0], rhs.shape[-1]),
+        lhs.dtype if preferred_element_type is None else preferred_element_type,
+        output_multiplier,
+        output_activation,
+    )
 
     if group_offset is None:
         group_offset = jnp.array([0], dtype=jnp.int32)
@@ -1002,6 +1146,14 @@ def gmm_v2(
     )
     dims = cfgs.dims
     tiles = cfgs.tiles
+
+    materialized_multiplier = None
+    if output_activation is not None:
+        if can_fuse_output_silu(lhs, rhs, cfgs, vmem_limit_bytes):
+            cfgs = dataclasses.replace(cfgs, output_activation=output_activation)
+        else:
+            materialized_multiplier = output_multiplier
+            output_multiplier = None
 
     # Prepare block specs.
     rhs_scale_spec = rhs_bias_spec = None
@@ -1064,7 +1216,7 @@ def gmm_v2(
     out_init = jax.ShapeDtypeStruct((dims.size_m, aligned_n), cfgs.out_dtype)
     rhs_weights = WeightsRef(weight=rhs, scale=rhs_scale, bias=rhs_bias)
 
-    return pl.pallas_call(
+    out = pl.pallas_call(
         functools.partial(kernel_main, cfgs=cfgs),
         out_shape=out_init,
         grid_spec=pltpu.PrefetchScalarGridSpec(
@@ -1076,6 +1228,7 @@ def gmm_v2(
                     scale=rhs_scale_spec,
                     bias=rhs_bias_spec,
                 ),
+                pl.BlockSpec(memory_space=pltpu.HBM) if output_multiplier is not None else None,
             ],
             out_specs=pl.BlockSpec(memory_space=pltpu.HBM),
             scratch_shapes=scratch_shapes,
@@ -1084,10 +1237,20 @@ def gmm_v2(
             vmem_limit_bytes=vmem_limit_bytes,
             disable_bounds_checks=True,
         ),
-        name=get_scope_name(dims, tiles),
-        cost_estimate=get_cost_estimate(lhs, rhs_weights, out_init.dtype, dims),
+        name=get_scope_name(dims, tiles) + ("-output_silu" if cfgs.output_activation else ""),
+        cost_estimate=get_cost_estimate(lhs, rhs_weights, out_init.dtype, dims, output_multiplier),
         metadata=get_metadata(cfgs),
-    )(group_sizes, group_offset, lhs, rhs_weights)[:, : dims.size_n]
+    )(group_sizes, group_offset, lhs, rhs_weights, output_multiplier)[:, : dims.size_n]
+    if materialized_multiplier is not None:
+        out = materialize_output_activation(
+            out,
+            materialized_multiplier,
+            group_sizes,
+            group_offset,
+            dims.size_group,
+            zero_initialize=zero_initialize,
+        )
+    return out
 
 
 def is_supported_by_gmm_v2(

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -707,33 +707,74 @@ class EPMoE(nnx.Module):
         )
 
         # === GEMM1: x @ w0 and x @ w1 ===
-        layer_w0 = gmm(
-            lhs=x,
-            rhs=w0_kernel,
-            rhs_scale=w0_kernel_scale,
-            rhs_bias=w0_kernel_bias,
-            zero_initialize=False,
-            activation_quantized_dtype=act_q_dtype,
-            **gmm_kwargs,
+        use_output_epilogue = (
+            self.activation == "silu"
+            and self.dtype == jnp.bfloat16
+            and act_q_dtype is None
+            and pre_gather_q is None
+            and self.ep_size == 4
+            and self.tp_size == 1
+            and inputs_2d.shape == (512, 2048)
+            and x.shape == (4096, 2048)
+            and group_sizes.shape == (64,)
+            and w0_kernel.shape == w1_kernel.shape == (16, 2048, 1024)
+            and wo_kernel.shape == (16, 1024, 2048)
+            and all(w.dtype == jnp.bfloat16 for w in (w0_kernel, w1_kernel, wo_kernel))
+            and all(s is None for s in (w0_kernel_scale, w1_kernel_scale, wo_kernel_scale))
         )
-        layer_w1 = gmm(
-            lhs=x,
-            rhs=w1_kernel,
-            rhs_scale=w1_kernel_scale,
-            rhs_bias=w1_kernel_bias,
-            zero_initialize=False,
-            activation_quantized_dtype=act_q_dtype,
-            **gmm_kwargs,
-        )
-
-        # === Activation ===
-        if self.activation == "silu":
-            layer_act = jax.nn.silu(layer_w0)
-        elif self.activation == "gelu":
-            layer_act = jax.nn.gelu(layer_w0)
+        if use_output_epilogue:
+            # Limit the integration to the short BF16 expert-parallel geometry.
+            # Produce up first so the gate GMM can consume it in its final-K
+            # epilogue. The backend retains materialization for unsupported
+            # tiling, VMEM capacity and interpretation, without changing routing.
+            layer_w1 = gmm(
+                lhs=x,
+                rhs=w1_kernel,
+                rhs_scale=w1_kernel_scale,
+                rhs_bias=w1_kernel_bias,
+                zero_initialize=False,
+                activation_quantized_dtype=act_q_dtype,
+                **gmm_kwargs,
+            )
+            intermediate_layer = gmm(
+                lhs=x,
+                rhs=w0_kernel,
+                rhs_scale=w0_kernel_scale,
+                rhs_bias=w0_kernel_bias,
+                zero_initialize=False,
+                activation_quantized_dtype=act_q_dtype,
+                output_multiplier=layer_w1,
+                output_activation="silu",
+                **gmm_kwargs,
+            )
         else:
-            raise ValueError(f"Unsupported activation function {self.activation}")
-        intermediate_layer = jnp.multiply(layer_act, layer_w1)
+            layer_w0 = gmm(
+                lhs=x,
+                rhs=w0_kernel,
+                rhs_scale=w0_kernel_scale,
+                rhs_bias=w0_kernel_bias,
+                zero_initialize=False,
+                activation_quantized_dtype=act_q_dtype,
+                **gmm_kwargs,
+            )
+            layer_w1 = gmm(
+                lhs=x,
+                rhs=w1_kernel,
+                rhs_scale=w1_kernel_scale,
+                rhs_bias=w1_kernel_bias,
+                zero_initialize=False,
+                activation_quantized_dtype=act_q_dtype,
+                **gmm_kwargs,
+            )
+
+            # === Activation ===
+            if self.activation == "silu":
+                layer_act = jax.nn.silu(layer_w0)
+            elif self.activation == "gelu":
+                layer_act = jax.nn.gelu(layer_w0)
+            else:
+                raise ValueError(f"Unsupported activation function {self.activation}")
+            intermediate_layer = jnp.multiply(layer_act, layer_w1)
 
         # === GEMM2: intermediate @ wo ===
         return gmm(


### PR DESCRIPTION
## Motivation

Compute the up projection first and apply output-rounded SiLU(gate) * up in the gate GMM epilogue, eliminating separate activation materialization.

### Limitation of the current abstraction

The GMM interface previously had no epilogue that applied SiLU after the original output rounding and before partial-row merging. The optional epilogue extends that library contract using existing Pallas primitives, with bounded multiplier loads and materialized fallbacks.

## Modifications

- `python/sgl_jax/srt/kernels/gmm/megablox_gmm_backend.py`
- `python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/gmm_v2.py`
- `python/sgl_jax/srt/layers/moe.py`

## Accuracy Tests

All 13 captured/scaled output pairs are bit exact and all 26 pilot/confirmation timing blocks were audited. Broader output-epilogue boundary/fallback TPU checks remain pending; the long variant's input-activation tests do not validate this distinct output contract.

All repository pre-commit checks passed for this commit, including the applicable type checker. Each implementation has one DCO-signed commit.

The retained TPU correctness/audit receipts are in the evidence bundle. No new TPU run was performed in the upstream publication checkout.

## Benchmarking and Profiling

**Measured on the frozen captured revisions below. These figures are not a benchmark of this PR rebased onto today's upstream main.**

| Captured case | Baseline (us) | Candidate (us) | Reduction | Speedup | Ratio CI95 |
| --- | ---: | ---: | ---: | ---: | --- |
| short | 431.893277 | 420.913758 | **2.54%** | 1.0261x | [0.966645181, 0.982611983] |

Hardware: 4 local TPUv6e chip(s); JAX 0.11.1; explicit captured geometry and seed 1729. Each result is a mean of block medians from ten independent baseline/candidate pairs, with 50 exact compiled-program execution spans per block, 20 warmups and separate host timing. The gate requires >2% lower mean device latency and bootstrap ratio CI95 upper bound <1 (10,000 resamples, seed 1729). Canonical/scaled correctness comparisons retain the original tolerance. No full-model speedup is claimed.

### Post-compilation trace evidence

All 20 raw confirmation XPlane traces per shape and their execution records are retained. The publication audit re-read each raw trace, checked the serialized executable's HLO identity, reconstructed all 50 samples and reproduced its median. Multi-chip spans require a shared host execution identity and complete device partitions; single-chip traces may use the recorded device/queue/run identity.

Representative pair 00 for the **short** case:

| Role | Exact HLO identity | Devices | Samples | Block median (us) |
| --- | --- | ---: | ---: | ---: |
| baseline | `jit_fn` / ID `54` / PID `4015196` | 4 | 50 | 432.458203 |
| candidate | `jit_fn` / ID `54` / PID `4013838` | 4 | 50 | 418.492539 |

[Download every confirmation trace and the verification bundle](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/moe-output-gating.tar.gz). SHA256: `2187d4ffdfe1d955c2a97e6661df66614b82799abededc1e87f26cdb796dd3bc`.

After extraction, `python verify_evidence.py` (NumPy required) checks all bundle hashes and recomputes samples/statistics from the included selected events. Original `.xplane.pb` files remain the primary traces; raw output tensors and every repeated executable are not included.

### Post-compilation HLO and LLO dumps

The retained complete HLO/LLO expose the gate-projection epilogue and activation placement. Its full-program four-chip measurements include the changed projection ordering.

| Shape | Full baseline LLO | Full candidate LLO | Compiled baseline HLO | Compiled candidate HLO |
| --- | --- | --- | --- | --- |
| short | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/moe-output-gating-short-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/moe-output-gating-short-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/moe-output-gating-short-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/moe-output-gating-short-candidate.hlo.txt.gz) |

<details>
<summary>Representative records from the full numbered LLO dumps</summary>

These excerpts show static emitted sites selected from changed vector opcodes. Counts and excerpts support code inspection; they do not quantify dynamic cycles.

### baseline

```text
287 : {p0 = seq.s32 s0, s3;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
288 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
289 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
290 : {(pc) = sbr.rel @!p0 $-3 (=0xffffffffffffffed);  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
291 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
292 : {s0 = sadd.s32 $1, s0;  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  _ = vdelay s2;  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
293 : {p0 = seq.s32 @!p0 s0, s3;  p0 = por @p0 $0, $0;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
294 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
```

### candidate

```text
287 : {p0 = seq.s32 s0, s3;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
288 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
289 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
290 : {(pc) = sbr.rel @!p0 $-3 (=0xffffffffffffffed);  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
291 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
292 : {s0 = sadd.s32 $1, s0;  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  _ = vdelay s2;  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
293 : {p0 = seq.s32 @!p0 s0, s3;  p0 = por @p0 $0, $0;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
294 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
```

</details>

### Source provenance and remaining limits

- Measured baseline: `027fa79a6498a1afef5a36c4e093c07d2f12f1ef`; exact measured patch and accepted candidate IDs/revisions are in the bundle.
- PR base: `3f1f38715b5dcd4b8ef11e4186e029e3e90f9570`. PR implementation commit: `11311372060339616e8ce8aebbebdd2956d074fc`.
- The source was ported onto current upstream and checked locally. Fresh TPU lowering/performance confirmation on that upstream revision remains outstanding; this PR is a draft for review.
- Performance is limited to the reported geometries, dtypes, runtime, partition and guarded paths. Original captures and any unsuccessful search attempts are not relabeled as new upstream measurements.
- Resolved the import conflict by adding only the new activation helpers; did not restore baseline-only tiling helper imports removed from upstream.
- The input-gating and output-gating MoE PRs are alternative activation placements, independently measured. They must not be stacked without resolving their shared call sites and revalidating semantics/performance.

## Checklist

- [x] English description with motivation and implementation scope.
- [x] Test results and reproducible evidence verification command provided.
- [x] Numerical and measurement limitations stated.
- [ ] Fresh TPU validation of the upstream port and any consolidation with overlapping variants.
