### PR TITLE
perf(mla): skip wholly future causal attention blocks

### DIFF
--- a/python/sgl_jax/srt/kernels/mla/v2/kernel.py
+++ b/python/sgl_jax/srt/kernels/mla/v2/kernel.py
@@ -1156,41 +1156,64 @@ def _mla_ragged_paged_attention_kernel(
                 def update_cur_bkv_to_cache():
                     start_update_kv_cache(batch_start_seq_idx, bkv_sem_idx, offsets, update_szs)
 
-                # Load bkv into vreg. There is no need to mask out invalid k/v entries,
-                # because the score of invalid Q.K^T pairs are masked (to be zero) in
-                # flash attention, so that the invalid kv entries
-                # (as long as they are not NaN or inf) won't affect to the output.
-                bkvc, bkpe = load_bkv(
-                    bkv_sem_idx,
-                )
+                # Skip wholly future blocks only for BF16 ragged prefill with the
+                # default mask. Keep all DMA and cache work above unconditional:
+                # the first query block must still update every new KV block.
+                has_visible_kv = True
+                if (
+                    batch_size == 1
+                    and static_q_len is None
+                    and q_dtype == jnp.bfloat16
+                    and kv_dtype == jnp.bfloat16
+                    and mask_value == DEFAULT_MASK_VALUE
+                ):
+                    q_len = (
+                        cu_q_lens_ref[batch_start_seq_idx + 1] - cu_q_lens_ref[batch_start_seq_idx]
+                    )
+                    visible_end = (
+                        kv_lens_ref[batch_start_seq_idx]
+                        - q_len
+                        + jnp.minimum((bq_idx + 1) * actual_bq_sz, q_len)
+                    )
+                    has_visible_kv = bkv_idx * bkv_sz < visible_end
 
-                bq_nope_vec, bq_pe_vec = load_bq(bq_sem_idx, actual_bq_sz=actual_bq_sz)
+                @pl.when(has_visible_kv)
+                def compute_attention_block():
+                    # Load bkv into vreg. There is no need to mask out invalid k/v entries,
+                    # because the score of invalid Q.K^T pairs are masked (to be zero) in
+                    # flash attention, so that the invalid kv entries
+                    # (as long as they are not NaN or inf) won't affect to the output.
+                    bkvc, bkpe = load_bkv(
+                        bkv_sem_idx,
+                    )
 
-                debug_print("[RPA debug] flash attention")
-                debug_print(
-                    "[RPA debug] bq_nope_vec.shape={}, {}",
-                    bq_nope_vec.shape[0],
-                    bq_nope_vec.shape[1],
-                )  # num_bkv=3, bkv_sz=512
-                debug_print(
-                    "[RPA debug] bq_pe_vec.shape={}, {}",
-                    bq_pe_vec.shape[0],
-                    bq_pe_vec.shape[1],
-                )
-                debug_print("[RPA debug] bkvc.shape={}, {}", bkvc.shape[0], bkvc.shape[1])
-                debug_print("[RPA debug] bkpe.shape={}, {}", bkpe.shape[0], bkpe.shape[1])
+                    bq_nope_vec, bq_pe_vec = load_bq(bq_sem_idx, actual_bq_sz=actual_bq_sz)
 
-                if debug_mode:
-                    return
+                    debug_print("[RPA debug] flash attention")
+                    debug_print(
+                        "[RPA debug] bq_nope_vec.shape={}, {}",
+                        bq_nope_vec.shape[0],
+                        bq_nope_vec.shape[1],
+                    )  # num_bkv=3, bkv_sz=512
+                    debug_print(
+                        "[RPA debug] bq_pe_vec.shape={}, {}",
+                        bq_pe_vec.shape[0],
+                        bq_pe_vec.shape[1],
+                    )
+                    debug_print("[RPA debug] bkvc.shape={}, {}", bkvc.shape[0], bkvc.shape[1])
+                    debug_print("[RPA debug] bkpe.shape={}, {}", bkpe.shape[0], bkpe.shape[1])
 
-                flash_attention(
-                    bq_nope_vec,
-                    bq_pe_vec,
-                    bkvc,
-                    bkpe,
-                    bq_idx=bq_idx,
-                    bkv_idx=bkv_idx,
-                )
+                    if debug_mode:
+                        return
+
+                    flash_attention(
+                        bq_nope_vec,
+                        bq_pe_vec,
+                        bkvc,
+                        bkpe,
+                        bq_idx=bq_idx,
+                        bkv_idx=bkv_idx,
+                    )
 
             lax.fori_loop(0, num_bkv, compute_with_bkv, None, unroll=False)
 


### PR DESCRIPTION
## Motivation

Skip QK, softmax and PV for KV blocks wholly beyond the runtime causal query boundary. Retain DMA, cache writes, semaphores and the original attention precision.

### Limitation of the current abstraction

The MLA schedule computes blocks already known to be fully masked. Existing pl.when control flow and the causal-boundary pattern in neighboring paged attention express the optimization. The guard covers single-sequence BF16 dynamic-length prefill with the default mask.

## Modifications

- `python/sgl_jax/srt/kernels/mla/v2/kernel.py`

## Accuracy Tests

Exact attention outputs and complete updated caches on all captured/scaled pairs. Eight supplemental TPU cases cover partial blocks, cached prefixes, fragmented pages, custom masks and decode. The medium and long measured kernel bytes are identical.

All repository pre-commit checks passed for this commit, including the applicable type checker. Each implementation has one DCO-signed commit.

The retained TPU correctness/audit receipts are in the evidence bundle. No new TPU run was performed in the upstream publication checkout.

## Benchmarking and Profiling

**Measured on the frozen captured revisions below. These figures are not a benchmark of this PR rebased onto today's upstream main.**

| Captured case | Baseline (us) | Candidate (us) | Reduction | Speedup | Ratio CI95 |
| --- | ---: | ---: | ---: | ---: | --- |
| medium | 385.644414 | 353.357086 | **8.37%** | 1.0914x | [0.916186845, 0.916380652] |
| long | 1328.570125 | 1137.354012 | **14.39%** | 1.1681x | [0.856028349, 0.856120847] |

Hardware: 1 local TPUv6e chip(s); JAX 0.11.1; explicit captured geometry and seed 1729. Each result is a mean of block medians from ten independent baseline/candidate pairs, with 50 exact compiled-program execution spans per block, 20 warmups and separate host timing. The gate requires >2% lower mean device latency and bootstrap ratio CI95 upper bound <1 (10,000 resamples, seed 1729). Canonical/scaled correctness comparisons retain the original tolerance. No full-model speedup is claimed.

### Post-compilation trace evidence

All 20 raw confirmation XPlane traces per shape and their execution records are retained. The publication audit re-read each raw trace, checked the serialized executable's HLO identity, reconstructed all 50 samples and reproduced its median. Multi-chip spans require a shared host execution identity and complete device partitions; single-chip traces may use the recorded device/queue/run identity.

Representative pair 00 for the **long** case:

| Role | Exact HLO identity | Devices | Samples | Block median (us) |
| --- | --- | ---: | ---: | ---: |
| baseline | `jit__lambda` / ID `73` / PID `3387785` | 1 | 50 | 1328.568711 |
| candidate | `jit__lambda` / ID `73` / PID `3386906` | 1 | 50 | 1137.427539 |

[Download every confirmation trace and the verification bundle](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-causal-skip.tar.gz). SHA256: `03aa3012ac34fde183df69b3e7966854cc2e1411d04f9ee2fc2c79d94d744c07`.

After extraction, `python verify_evidence.py` (NumPy required) checks all bundle hashes and recomputes samples/statistics from the included selected events. Original `.xplane.pb` files remain the primary traces; raw output tensors and every repeated executable are not included.

### Post-compilation HLO and LLO dumps

The long geometry requires attention computation for 40 of 64 query/KV block pairs. A mapped branch bypasses the attention region while cache-update DMA occurs before it; no DMA is inside the skipped region.

| Shape | Full baseline LLO | Full candidate LLO | Compiled baseline HLO | Compiled candidate HLO |
| --- | --- | --- | --- | --- |
| long | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-causal-skip-long-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-causal-skip-long-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-causal-skip-long-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-causal-skip-long-candidate.hlo.txt.gz) |
| medium | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-causal-skip-medium-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-causal-skip-medium-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-causal-skip-medium-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-causal-skip-medium-candidate.hlo.txt.gz) |

<details>
<summary>Representative records from the full numbered LLO dumps</summary>

These excerpts show static emitted sites selected from changed vector opcodes. Counts and excerpts support code inspection; they do not quantify dynamic cycles.

Static vector instruction counts remain unchanged here; the optimization changes runtime control flow. Candidate record 12087 branches around the attention region. Record offsets in the two dumps are independent.

### baseline

```text
12086 : {s13 = sld [smem:$0x5d3];  v22 = vcombine.low.8x128 v59, v58;  v23 = vcombine.low.8x128 v61, v60;  v0 = vshrl.8x128.u32 v39, $0x7;  v62 = vld.8x128 [vmem:s4+$0xfe ss:$0];  v63 = vld.8x128 [vmem:s4+$0xff ss:$0]}
12087 : {v24 = vcombine.low.8x128 v63, v62;  v1 = vimm.8x128.s32 $1966171168;  v13 = vld.8x128 [vmem:s4+$0xc0 ss:$0];  v16 = vld.8x128 [vmem:s4+$0xc1 ss:$0]}
12088 : {s6 = sld [smem:$0x5cd];  v28 = vcombine.low.8x128 v16, v13;  v2 = vunpack.i.l.8x128.s4 v1;  [vmem:$0xab84] = vst.8x128 v0;  v17 = vld.8x128 [vmem:s4+$0xc2 ss:$0];  v18 = vld.8x128 [vmem:s4+$0xc3 ss:$0]}
```

### candidate

```text
12078 : {s22 = sld [smem:$0x5cd]}
12079 : {s13 = sld [smem:s14+$0x2c3]}
12080 : {s10 = sld [smem:s22+$0x2c3]}
12081 : {s8 = sld [smem:s22+$0x1c3]}
12082 : {s20 = ssub.s32 s13, s10}
12083 : {p1 = slt.s32 s18, s20;  s5 = ssub.s32 s8, s20}
12084 : {s18 = smov.u32 @!p1 s20}
12085 : {s27 = sadd.s32 s18, s5}
12086 : {p2 = sge.s32 s28, s27}
12087 : {(pc) = sbr.rel @p2 $+13709 (=0x6368)}
```

</details>

### Source provenance and remaining limits

- Measured baseline: `027fa79a6498a1afef5a36c4e093c07d2f12f1ef`; exact measured patch and accepted candidate IDs/revisions are in the bundle.
- PR base: `3f1f38715b5dcd4b8ef11e4186e029e3e90f9570`. PR implementation commit: `45f7542982e22abc9ead6f0fb8f45d229148404a`.
- The source was ported onto current upstream and checked locally. Fresh TPU lowering/performance confirmation on that upstream revision remains outstanding; this PR is a draft for review.
- Performance is limited to the reported geometries, dtypes, runtime, partition and guarded paths. Original captures and any unsuccessful search attempts are not relabeled as new upstream measurements.
- The causal-block and short compute-subblock variants overlap in the MLA implementation. Their reported gains are independent; a combined implementation has not been validated.

## Checklist

- [x] English description with motivation and implementation scope.
- [x] Test results and reproducible evidence verification command provided.
- [x] Numerical and measurement limitations stated.
- [ ] Fresh TPU validation of the upstream port and any consolidation with overlapping variants.
