### PR TITLE
perf(mla): separate KV transfers from short-prefill compute blocks

### DIFF
--- a/python/sgl_jax/srt/kernels/mla/v2/kernel.py
+++ b/python/sgl_jax/srt/kernels/mla/v2/kernel.py
@@ -318,6 +318,26 @@ def _mla_ragged_paged_attention_kernel(
     bkv_sz = bkv_sz_per_kv_packing * kv_packing
     page_size = page_size_per_kv_packing * kv_packing
 
+    can_skip_causal_blocks = (
+        batch_size == 1
+        and static_q_len is None
+        and q_dtype == jnp.bfloat16
+        and kv_dtype == jnp.bfloat16
+        and mask_value == DEFAULT_MASK_VALUE
+    )
+    # Separate compute width from the unchanged KV transfer geometry only for
+    # the short prefill shape. Other shapes retain whole-block attention.
+    use_attention_subblocks = (
+        can_skip_causal_blocks
+        and ql_nope_hbm_ref.shape[0] == 512
+        and num_q_heads == 8
+        and lkv_dim == 512
+        and r_dim == 128
+        and page_size == 128
+        and bq_sz == 256
+        and bkv_sz == 1024
+    )
+
     start_seq_idx = start_end_seq_idx_ref[0]
     end_seq_idx = start_end_seq_idx_ref[1]
     batch_start_seq_idx = start_seq_idx + pl.program_id(0) * batch_size
@@ -340,11 +360,13 @@ def _mla_ragged_paged_attention_kernel(
     def flash_attention(
         ql_nope,  # [batch_size, actual_bq_sz * num_q_heads, lkv_dim]
         q_pe,  # [batch_size, actual_bq_sz * num_q_heads, r_dim]
-        kv_c,  # [batch_size, bkv_sz, lkv_dim] <- Correspond to data from bkvc_x2_ref
-        k_pe,  # [batch_size, bkv_sz, r_dim] <- Correspond to data from bpe_x2_ref
+        kv_c,  # [batch_size, compute_bkv_sz, lkv_dim] <- Data from bkvc_x2_ref
+        k_pe,  # [batch_size, compute_bkv_sz, r_dim] <- Data from bkpe_x2_ref
         *,
         bq_idx,
         bkv_idx,
+        compute_key_start=None,
+        initialize=None,
     ):
         assert len(ql_nope.shape) == 3
         assert len(q_pe.shape) == 3
@@ -355,14 +377,19 @@ def _mla_ragged_paged_attention_kernel(
         assert q_pe.shape[1] % bq_sz == 0
         assert ql_nope.shape[2] == lkv_dim
         assert q_pe.shape[2] == r_dim
-        assert kv_c.shape == (batch_size, bkv_sz, lkv_dim)
-        assert k_pe.shape == (batch_size, bkv_sz, r_dim)
+        compute_bkv_sz = kv_c.shape[1]
+        assert kv_c.shape == (batch_size, compute_bkv_sz, lkv_dim)
+        assert k_pe.shape == (batch_size, compute_bkv_sz, r_dim)
+        if compute_key_start is None:
+            compute_key_start = bkv_idx * bkv_sz
+        if initialize is None:
+            initialize = bkv_idx == 0
         head_l_ref = l_ref.at[:, : ql_nope.shape[1]]
         head_m_ref = m_ref.at[:, : ql_nope.shape[1]]
         head_acc_ref = acc_ref.at[:, : ql_nope.shape[1]]
 
         def load_with_init(ref, init_val):
-            return jnp.where(bkv_idx == 0, jnp.full_like(ref, init_val), ref[...])
+            return jnp.where(initialize, jnp.full_like(ref, init_val), ref[...])
 
         # Follow FlashAttention-2 forward pass.
         q = jnp.concatenate([ql_nope, q_pe], axis=-1)
@@ -374,7 +401,7 @@ def _mla_ragged_paged_attention_kernel(
         if q_scale is not None:
             s *= q_scale
 
-        k_span = bkv_idx * bkv_sz + lax.broadcasted_iota(jnp.int32, s.shape[1:], 1)
+        k_span = compute_key_start + lax.broadcasted_iota(jnp.int32, s.shape[1:], 1)
 
         mask_list = []
         for b in range(batch_size):
@@ -1038,15 +1065,22 @@ def _mla_ragged_paged_attention_kernel(
 
         return q_nope_vec, q_rope_vec
 
-    def load_bkv(bkv_sem_idx):
+    def load_bkv(bkv_sem_idx, *, local_offset=0, slice_len=bkv_sz):
+        # Offsets and lengths are in tokens; the uint32 Ref view packs BF16
+        # pairs. A 256-token subblock therefore loads 128 packed rows.
+        assert 0 < slice_len <= bkv_sz
+        assert slice_len % kv_packing == 0
+        packed_slice = pl.ds(
+            floor_div_on_kv_packing(local_offset, kv_packing), slice_len // kv_packing
+        )
         bkvc_vecs = []
         bkpe_vecs = []
         for b in range(batch_size):
-            bkvc_ref = bkvc_x2_ref.bitcast(jnp.uint32).at[bkv_sem_idx, b, :bkv_sz_per_kv_packing]
-            bkvc_vec = pltpu.bitcast(bkvc_ref[...], kv_dtype).reshape(bkv_sz, lkv_dim)
+            bkvc_ref = bkvc_x2_ref.bitcast(jnp.uint32).at[bkv_sem_idx, b, packed_slice]
+            bkvc_vec = pltpu.bitcast(bkvc_ref[...], kv_dtype).reshape(slice_len, lkv_dim)
 
-            bkpe_ref = bkpe_x2_ref.bitcast(jnp.uint32).at[bkv_sem_idx, b, :bkv_sz_per_kv_packing]
-            bkpe_vec = pltpu.bitcast(bkpe_ref[...], kv_dtype).reshape(bkv_sz, r_dim)
+            bkpe_ref = bkpe_x2_ref.bitcast(jnp.uint32).at[bkv_sem_idx, b, packed_slice]
+            bkpe_vec = pltpu.bitcast(bkpe_ref[...], kv_dtype).reshape(slice_len, r_dim)
             bkvc_vecs.append(bkvc_vec)
             bkpe_vecs.append(bkpe_vec)
         return jnp.stack(bkvc_vecs), jnp.stack(bkpe_vecs)
@@ -1156,41 +1190,85 @@ def _mla_ragged_paged_attention_kernel(
                 def update_cur_bkv_to_cache():
                     start_update_kv_cache(batch_start_seq_idx, bkv_sem_idx, offsets, update_szs)
 
-                # Load bkv into vreg. There is no need to mask out invalid k/v entries,
-                # because the score of invalid Q.K^T pairs are masked (to be zero) in
-                # flash attention, so that the invalid kv entries
-                # (as long as they are not NaN or inf) won't affect to the output.
-                bkvc, bkpe = load_bkv(
-                    bkv_sem_idx,
-                )
+                def compute_attention_block(
+                    *,
+                    local_offset=0,
+                    slice_len=bkv_sz,
+                    compute_key_start=None,
+                    initialize=None,
+                ):
+                    # Load operands only inside the visibility guards. Invalid
+                    # finite K/V entries are masked out by flash attention.
+                    bkvc, bkpe = load_bkv(
+                        bkv_sem_idx, local_offset=local_offset, slice_len=slice_len
+                    )
 
-                bq_nope_vec, bq_pe_vec = load_bq(bq_sem_idx, actual_bq_sz=actual_bq_sz)
+                    bq_nope_vec, bq_pe_vec = load_bq(bq_sem_idx, actual_bq_sz=actual_bq_sz)
 
-                debug_print("[RPA debug] flash attention")
-                debug_print(
-                    "[RPA debug] bq_nope_vec.shape={}, {}",
-                    bq_nope_vec.shape[0],
-                    bq_nope_vec.shape[1],
-                )  # num_bkv=3, bkv_sz=512
-                debug_print(
-                    "[RPA debug] bq_pe_vec.shape={}, {}",
-                    bq_pe_vec.shape[0],
-                    bq_pe_vec.shape[1],
-                )
-                debug_print("[RPA debug] bkvc.shape={}, {}", bkvc.shape[0], bkvc.shape[1])
-                debug_print("[RPA debug] bkpe.shape={}, {}", bkpe.shape[0], bkpe.shape[1])
+                    debug_print("[RPA debug] flash attention")
+                    debug_print(
+                        "[RPA debug] bq_nope_vec.shape={}, {}",
+                        bq_nope_vec.shape[0],
+                        bq_nope_vec.shape[1],
+                    )  # num_bkv=3, bkv_sz=512
+                    debug_print(
+                        "[RPA debug] bq_pe_vec.shape={}, {}",
+                        bq_pe_vec.shape[0],
+                        bq_pe_vec.shape[1],
+                    )
+                    debug_print("[RPA debug] bkvc.shape={}, {}", bkvc.shape[0], bkvc.shape[1])
+                    debug_print("[RPA debug] bkpe.shape={}, {}", bkpe.shape[0], bkpe.shape[1])
 
-                if debug_mode:
-                    return
+                    if debug_mode:
+                        return
 
-                flash_attention(
-                    bq_nope_vec,
-                    bq_pe_vec,
-                    bkvc,
-                    bkpe,
-                    bq_idx=bq_idx,
-                    bkv_idx=bkv_idx,
-                )
+                    flash_attention(
+                        bq_nope_vec,
+                        bq_pe_vec,
+                        bkvc,
+                        bkpe,
+                        bq_idx=bq_idx,
+                        bkv_idx=bkv_idx,
+                        compute_key_start=compute_key_start,
+                        initialize=initialize,
+                    )
+
+                # The first query block must still update every new KV block,
+                # so all transfers, packing and cache updates stay above here.
+                block_start = bkv_idx * bkv_sz
+                has_visible_kv = True
+                if can_skip_causal_blocks:
+                    q_len = (
+                        cu_q_lens_ref[batch_start_seq_idx + 1] - cu_q_lens_ref[batch_start_seq_idx]
+                    )
+                    visible_end = (
+                        kv_lens_ref[batch_start_seq_idx]
+                        - q_len
+                        + jnp.minimum((bq_idx + 1) * actual_bq_sz, q_len)
+                    )
+                    has_visible_kv = block_start < visible_end
+
+                @pl.when(has_visible_kv)
+                def compute_visible_attention():
+                    if use_attention_subblocks:
+
+                        def compute_with_subblock(sub_idx, _):
+                            local_offset = sub_idx * 256
+                            compute_key_start = block_start + local_offset
+
+                            @pl.when(compute_key_start < visible_end)
+                            def compute_visible_subblock():
+                                compute_attention_block(
+                                    local_offset=local_offset,
+                                    slice_len=256,
+                                    compute_key_start=compute_key_start,
+                                    # Carry softmax state across both loops.
+                                    initialize=jnp.logical_and(bkv_idx == 0, sub_idx == 0),
+                                )
+
+                        lax.fori_loop(0, 4, compute_with_subblock, None, unroll=False)
+                    else:
+                        compute_attention_block()
 
             lax.fori_loop(0, num_bkv, compute_with_bkv, None, unroll=False)
 


### PR DESCRIPTION
## Motivation

Retain 1024-token KV transfers/cache updates but process attention in guarded 256-token subblocks, carrying online-softmax state between them.

### Limitation of the current abstraction

The original schedule couples attention compute granularity to transfer granularity. The neighboring paged-attention implementation already separates these using existing Pallas control flow. This specialization targets the captured 512-query, eight-head BF16/default-mask configuration.

## Modifications

- `python/sgl_jax/srt/kernels/mla/v2/kernel.py`

## Accuracy Tests

The changed attention reduction order stays within the original atol=rtol=0.01: maximum absolute difference 0.001953125, using at most 15.625% of its allowed tolerance. All 39 captured cache arrays are bit exact. Additional boundary validation remains pending; long/medium MLA tests are not coverage of this distinct code.

All repository pre-commit checks passed for this commit, including the applicable type checker. Each implementation has one DCO-signed commit.

The retained TPU correctness/audit receipts are in the evidence bundle. No new TPU run was performed in the upstream publication checkout.

## Benchmarking and Profiling

**Measured on the frozen captured revisions below. These figures are not a benchmark of this PR rebased onto today's upstream main.**

| Captured case | Baseline (us) | Candidate (us) | Reduction | Speedup | Ratio CI95 |
| --- | ---: | ---: | ---: | ---: | --- |
| short | 59.563090 | 51.569441 | **13.42%** | 1.1550x | [0.865598604, 0.865994858] |

Hardware: 1 local TPUv6e chip(s); JAX 0.11.1; explicit captured geometry and seed 1729. Each result is a mean of block medians from ten independent baseline/candidate pairs, with 50 exact compiled-program execution spans per block, 20 warmups and separate host timing. The gate requires >2% lower mean device latency and bootstrap ratio CI95 upper bound <1 (10,000 resamples, seed 1729). Canonical/scaled correctness comparisons retain the original tolerance. No full-model speedup is claimed.

### Post-compilation trace evidence

All 20 raw confirmation XPlane traces per shape and their execution records are retained. The publication audit re-read each raw trace, checked the serialized executable's HLO identity, reconstructed all 50 samples and reproduced its median. Multi-chip spans require a shared host execution identity and complete device partitions; single-chip traces may use the recorded device/queue/run identity.

Representative pair 00 for the **short** case:

| Role | Exact HLO identity | Devices | Samples | Block median (us) |
| --- | --- | ---: | ---: | ---: |
| baseline | `jit__lambda` / ID `73` / PID `4110717` | 1 | 50 | 59.583164 |
| candidate | `jit__lambda` / ID `73` / PID `4109246` | 1 | 50 | 51.568672 |

[Download every confirmation trace and the verification bundle](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-compute-blocks.tar.gz). SHA256: `60d9ee52c829a57998c3b21f7d621b328287dd17e4645d6370cde11a4b7ec568`.

After extraction, `python verify_evidence.py` (NumPy required) checks all bundle hashes and recomputes samples/statistics from the included selected events. Original `.xplane.pb` files remain the primary traces; raw output tensors and every repeated executable are not included.

### Post-compilation HLO and LLO dumps

Full HLO/LLO show the nested compute-subblock loop within unchanged KV transfers and the carried softmax state. The original numerical tolerance was not relaxed.

| Shape | Full baseline LLO | Full candidate LLO | Compiled baseline HLO | Compiled candidate HLO |
| --- | --- | --- | --- | --- |
| short | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-compute-blocks-short-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-compute-blocks-short-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-compute-blocks-short-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/mla-compute-blocks-short-candidate.hlo.txt.gz) |

<details>
<summary>Representative records from the full numbered LLO dumps</summary>

These excerpts show static emitted sites selected from changed vector opcodes. Counts and excerpts support code inspection; they do not quantify dynamic cycles.

### baseline

```text
287 : {p0 = seq.s32 s0, s3;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
288 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
289 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
290 : {(pc) = sbr.rel @!p0 $-3 (=0xffffffffffffffed);  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
291 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
292 : {s0 = sadd.s32 $1, s0;  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  _ = vdelay s2;  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
293 : {p0 = seq.s32 @!p0 s0, s3;  p0 = por @p0 $0, $0;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
294 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
```

### candidate

```text
287 : {p0 = seq.s32 s0, s3;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
288 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
289 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
290 : {(pc) = sbr.rel @!p0 $-3 (=0xffffffffffffffed);  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
291 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
292 : {s0 = sadd.s32 $1, s0;  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  _ = vdelay s2;  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
293 : {p0 = seq.s32 @!p0 s0, s3;  p0 = por @p0 $0, $0;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
294 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
```

</details>

### Source provenance and remaining limits

- Measured baseline: `027fa79a6498a1afef5a36c4e093c07d2f12f1ef`; exact measured patch and accepted candidate IDs/revisions are in the bundle.
- PR base: `3f1f38715b5dcd4b8ef11e4186e029e3e90f9570`. PR implementation commit: `a8f3971a7ea26470fe5d009959286889b82342b7`.
- The source was ported onto current upstream and checked locally. Fresh TPU lowering/performance confirmation on that upstream revision remains outstanding; this PR is a draft for review.
- Performance is limited to the reported geometries, dtypes, runtime, partition and guarded paths. Original captures and any unsuccessful search attempts are not relabeled as new upstream measurements.
- The causal-block and short compute-subblock variants overlap in the MLA implementation. Their reported gains are independent; a combined implementation has not been validated.

## Checklist

- [x] English description with motivation and implementation scope.
- [x] Test results and reproducible evidence verification command provided.
- [x] Numerical and measurement limitations stated.
- [ ] Fresh TPU validation of the upstream port and any consolidation with overlapping variants.
