### PR TITLE
perf(rpa): tile packed output conversion for 4096-token prefill

### DIFF
--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -1255,11 +1255,44 @@ def prepare_inputs(
     return q, kv, attention_sink
 
 
+def _prepare_outputs_packed_bf16_kernel(src_ref, dst_ref):
+    # Bitcasting packs the second-minor dimension, keeping each pair of BF16
+    # query heads together in one uint32 word throughout the conversion.
+    src = src_ref.bitcast(jnp.uint32).reshape(2, 256, 128)
+    dst = dst_ref.bitcast(jnp.uint32).reshape(512, 128)
+    for h in range(2):
+        for g in range(2):
+            # dst[t, 4*h + 2*g + p, d] = src[h, t, g, p, d].
+            dst[pl.ds(2 * h + g, 128, 4), :] = src[h, pl.ds(g, 128, 2), :]
+
+
 def prepare_outputs(
     out,  # [actual_num_kv_heads, max_num_tokens, num_q_heads_per_kv_head // q_packing, q_packing, head_dim]
     actual_num_q_heads_per_kv_head: int,
     actual_head_dim: int,
 ):
+    if (
+        out.shape == (2, 4096, 2, 2, 128)
+        and out.dtype == jnp.bfloat16
+        and actual_num_q_heads_per_kv_head == 4
+        and actual_head_dim == 128
+    ):
+        # Materialize the public layout directly in independent 128-token
+        # tiles, without a global BF16 transpose/reshape.
+        # Use integer call boundaries to preserve BF16 subnormals and NaN
+        # payloads without floating-point normalization during transfers.
+        out_bits = lax.bitcast_convert_type(out, jnp.uint16)
+        result_bits = pl.pallas_call(
+            _prepare_outputs_packed_bf16_kernel,
+            out_shape=jax.ShapeDtypeStruct((4096, 8, 128), jnp.uint16),
+            grid=(32,),
+            in_specs=[pl.BlockSpec((2, 128, 2, 2, 128), lambda i: (0, i, 0, 0, 0))],
+            out_specs=pl.BlockSpec((128, 8, 128), lambda i: (i, 0, 0)),
+            compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel",)),
+            name="rpa_prepare_outputs_packed_bf16",
+        )(out_bits)
+        return lax.bitcast_convert_type(result_bits, out.dtype)
+
     (
         actual_num_kv_heads,
         max_num_tokens,

--- a/test/srt/kernels/test_ragged_paged_attention_prepare_outputs.py
+++ b/test/srt/kernels/test_ragged_paged_attention_prepare_outputs.py
@@ -1,0 +1,85 @@
+"""CPU regressions for the RPA output conversion's integer transport contract.
+
+Run with JAX_PLATFORMS=cpu and PYTHONPATH=python. Tracing checks the actual
+Pallas boundary without TPU lowering. The exhaustive interpreter check skips
+the known JAX 0.11.1 strided-index limitation; it does not replace TPU validation.
+"""
+
+from functools import partial
+from unittest.mock import patch
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from sgl_jax.srt.kernels.ragged_paged_attention import ragged_paged_attention_v3 as rpa
+
+
+def test_packed_output_call_uses_integer_transport():
+    prepare = partial(rpa.prepare_outputs, actual_num_q_heads_per_kv_head=4, actual_head_dim=128)
+    traced = jax.make_jaxpr(prepare)(jax.ShapeDtypeStruct((2, 4096, 2, 2, 128), jnp.bfloat16)).jaxpr
+    assert traced.outvars[0].aval.shape == (4096, 8, 128)
+    assert traced.outvars[0].aval.dtype == jnp.bfloat16
+
+    (call,) = [eqn for eqn in traced.eqns if eqn.primitive.name == "pallas_call"]
+    # A floating-point boundary can normalize subnormals and NaN payloads even
+    # when the kernel itself only copies packed integers.
+    for var in (*call.invars, *call.outvars):
+        assert var.aval.dtype == jnp.uint16
+    assert all(
+        eqn.primitive.name == "bitcast_convert_type" for eqn in traced.eqns if eqn is not call
+    )
+
+
+def test_packed_output_all_bf16_bits_in_cpu_interpreter():
+    shape = (2, 4096, 2, 2, 128)
+    # Use integer host/device transport so BF16 transfer normalization cannot
+    # hide a regression. Shuffle all patterns across both lanes of packed pairs.
+    patterns = np.random.default_rng(0).permutation(np.arange(65536, dtype=np.uint16))
+    bits = np.resize(patterns, shape)
+    expected = bits.transpose(1, 0, 2, 3, 4).reshape(4096, 8, 128)
+
+    @jax.jit
+    def transport(x):
+        out = rpa.prepare_outputs(jax.lax.bitcast_convert_type(x, jnp.bfloat16), 4, 128)
+        return jax.lax.bitcast_convert_type(out, jnp.uint16)
+
+    with (
+        jax.default_device(jax.devices("cpu")[0]),
+        patch.object(rpa.pl, "pallas_call", partial(rpa.pl.pallas_call, interpret=True)),
+    ):
+        try:
+            actual = np.asarray(transport(jnp.asarray(bits)))
+        except ValueError as exc:
+            if str(exc) != "Invalid type of idxer: TypedInt":
+                raise
+            pytest.skip(f"JAX CPU Pallas interpreter cannot execute the strided refs: {exc}")
+    np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "shape,dtype,heads,width",
+    [
+        ((2, 128, 2, 2, 128), jnp.bfloat16, 4, 128),
+        ((2, 4096, 2, 2, 128), jnp.bfloat16, 3, 128),
+        ((2, 4096, 2, 2, 128), jnp.bfloat16, 4, 127),
+        ((2, 4096, 2, 2, 128), jnp.float32, 4, 128),
+    ],
+    ids=["tokens", "heads", "width", "dtype"],
+)
+def test_output_fallbacks(shape, dtype, heads, width):
+    # Small integers are exactly representable in both tested floating dtypes.
+    source = (np.arange(np.prod(shape), dtype=np.int32) % 251 - 125).reshape(shape)
+    expected = source.transpose(1, 0, 2, 3, 4).reshape(shape[1], shape[0], 4, shape[-1])
+    expected = expected[:, :, :heads, :width].reshape(shape[1], shape[0] * heads, width)
+    prepare = partial(
+        rpa.prepare_outputs, actual_num_q_heads_per_kv_head=heads, actual_head_dim=width
+    )
+    with jax.default_device(jax.devices("cpu")[0]):
+        out = jnp.asarray(source, dtype=dtype)
+        traced = jax.make_jaxpr(prepare)(out)
+        assert all(eqn.primitive.name != "pallas_call" for eqn in traced.jaxpr.eqns)
+        actual = jax.jit(prepare)(out)
+        assert actual.dtype == dtype
+        np.testing.assert_array_equal(np.asarray(actual), expected)


### PR DESCRIPTION
## Motivation

Materialize packed output in 128-token tiles for the 4096-token prefill shape. Use uint16 Pallas call boundaries and external BF16 bitcasts so this layout operation preserves every bit pattern.

### Limitation of the current abstraction

The original output expression creates unpack/repack and masked-load OR sequences. Existing Pallas tiling and integer reference/call boundaries express the conversion. BF16 call boundaries can normalize subnormals/NaN payloads, so the implementation uses integer transport explicitly.

## Modifications

- `python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py`
- `test/srt/kernels/test_ragged_paged_attention_prepare_outputs.py`

## Accuracy Tests

Captured attention/cache outputs are exact across all 13 pairs. The measured corrected source passed a full-shape exhaustive BF16-bit test and three fallbacks. Upstream CPU checks: five passed; one interpreter check skipped the known JAX 0.11.1 strided-index limitation. It does not replace the retained TPU bit-pattern evidence.

All repository pre-commit checks passed for this commit, including the applicable type checker. Each implementation has one DCO-signed commit.

Targeted CPU command used in the upstream checkout:

```bash
JAX_PLATFORMS=cpu PYTHONPATH=python python -m pytest -q test/srt/kernels/test_ragged_paged_attention_prepare_outputs.py
```

## Benchmarking and Profiling

**Measured on the frozen captured revisions below. These figures are not a benchmark of this PR rebased onto today's upstream main.**

| Captured case | Baseline (us) | Candidate (us) | Reduction | Speedup | Ratio CI95 |
| --- | ---: | ---: | ---: | ---: | --- |
| long | 724.628621 | 701.659918 | **3.17%** | 1.0327x | [0.968159161, 0.968467423] |

Hardware: 1 local TPUv6e chip(s); JAX 0.11.1; explicit captured geometry and seed 1729. Each result is a mean of block medians from ten independent baseline/candidate pairs, with 50 exact compiled-program execution spans per block, 20 warmups and separate host timing. The gate requires >2% lower mean device latency and bootstrap ratio CI95 upper bound <1 (10,000 resamples, seed 1729). Canonical/scaled correctness comparisons retain the original tolerance. No full-model speedup is claimed.

### Post-compilation trace evidence

All 20 raw confirmation XPlane traces per shape and their execution records are retained. The publication audit re-read each raw trace, checked the serialized executable's HLO identity, reconstructed all 50 samples and reproduced its median. Multi-chip spans require a shared host execution identity and complete device partitions; single-chip traces may use the recorded device/queue/run identity.

Representative pair 00 for the **long** case:

| Role | Exact HLO identity | Devices | Samples | Block median (us) |
| --- | --- | ---: | ---: | ---: |
| baseline | `jit__lambda` / ID `27` / PID `3618640` | 1 | 50 | 724.858086 |
| candidate | `jit__lambda` / ID `27` / PID `3616525` | 1 | 50 | 701.644961 |

[Download every confirmation trace and the verification bundle](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/rpa-output-long.tar.gz). SHA256: `835e79116c3eda4a1d268b02e8b3f003e587d9fe7b7109f46018e2aea10544c5`.

After extraction, `python verify_evidence.py` (NumPy required) checks all bundle hashes and recomputes samples/statistics from the included selected events. Original `.xplane.pb` files remain the primary traces; raw output tensors and every repeated executable are not included.

### Post-compilation HLO and LLO dumps

The full numbered LLO and compiled HLO expose bounded output stores and integer transport. The included measurements are from the corrected source with newly sealed timing evidence.

| Shape | Full baseline LLO | Full candidate LLO | Compiled baseline HLO | Compiled candidate HLO |
| --- | --- | --- | --- | --- |
| long | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/rpa-output-long-long-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/rpa-output-long-long-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/rpa-output-long-long-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/rpa-output-long-long-candidate.hlo.txt.gz) |

<details>
<summary>Representative records from the full numbered LLO dumps</summary>

These excerpts show static emitted sites selected from changed vector opcodes. Counts and excerpts support code inspection; they do not quantify dynamic cycles.

### baseline

```text
287 : {p0 = seq.s32 s0, s3;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
288 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
289 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
290 : {(pc) = sbr.rel @!p0 $-3 (=0xffffffffffffffed);  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
291 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
292 : {s0 = sadd.s32 $1, s0;  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  _ = vdelay s2;  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
293 : {p0 = seq.s32 @!p0 s0, s3;  p0 = por @p0 $0, $0;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
294 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
```

### candidate

```text
287 : {p0 = seq.s32 s0, s3;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
288 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
289 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
290 : {(pc) = sbr.rel @!p0 $-3 (=0xffffffffffffffed);  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
291 : {v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v3 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mubr0) = vmatmulprep v59;  v62 = vpop.8x128 (mrf0)}
292 : {s0 = sadd.s32 $1, s0;  v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v60 = vld.8x128 [vmem:$0x3ff88];  v61 = vld.8x128 [vmem:$0x3ff80];  _ = vdelay s2;  (mrf0) = vmatmul.8x128.f32 v59;  v63 = vpop.8x128 (mrf0)}
293 : {p0 = seq.s32 @!p0 s0, s3;  p0 = por @p0 $0, $0;  v0 = vmul.8x128.f32 v60, v61;  v1 = vmul.8x128.f32 v61, v60;  v2 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff90];  v61 = vld.8x128 [vmem:$0x3ff88];  (mubr1) = vmatmulprep v59;  v63 = vpop.8x128 (mrf1)}
294 : {v4 = vmul.8x128.f32 v61, v60;  v5 = vmul.8x128.f32 v60, v61;  v6 = vmul.8x128.f32 v61, v60;  v7 = vmul.8x128.f32 v60, v61;  v60 = vld.8x128 [vmem:$0x3ff80];  v61 = vld.8x128 [vmem:$0x3ff90];  (mrf1) = vmatmul.8x128.f32 v59;  v62 = vpop.8x128 (mrf1)}
```

</details>

### Source provenance and remaining limits

- Measured baseline: `027fa79a6498a1afef5a36c4e093c07d2f12f1ef`; exact measured patch and accepted candidate IDs/revisions are in the bundle.
- PR base: `3f1f38715b5dcd4b8ef11e4186e029e3e90f9570`. PR implementation commit: `4a17d431aab013d52efd0dcb7aec66ec33a3de37`.
- The source was ported onto current upstream and checked locally. Fresh TPU lowering/performance confirmation on that upstream revision remains outstanding; this PR is a draft for review.
- Performance is limited to the reported geometries, dtypes, runtime, partition and guarded paths. Original captures and any unsuccessful search attempts are not relabeled as new upstream measurements.
- The medium and long output-conversion PRs use the same tile helper with different guards/grids. They overlap in source and need consolidation plus validation before both can be integrated.

## Checklist

- [x] English description with motivation and implementation scope.
- [x] Test results and reproducible evidence verification command provided.
- [x] Numerical and measurement limitations stated.
- [ ] Fresh TPU validation of the upstream port and any consolidation with overlapping variants.
