### PR TITLE
perf(rpa): tile packed output conversion for 2048-token prefill

### DIFF
--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -1255,11 +1255,44 @@ def prepare_inputs(
     return q, kv, attention_sink
 
 
+def _prepare_outputs_packed_bf16_kernel(src_ref, dst_ref):
+    # Bitcasting packs the second-minor dimension, keeping each pair of BF16
+    # query heads together in one uint32 word throughout the conversion.
+    src = src_ref.bitcast(jnp.uint32).reshape(2, 256, 128)
+    dst = dst_ref.bitcast(jnp.uint32).reshape(512, 128)
+    for h in range(2):
+        for g in range(2):
+            # dst[t, 4*h + 2*g + p, d] = src[h, t, g, p, d].
+            dst[pl.ds(2 * h + g, 128, 4), :] = src[h, pl.ds(g, 128, 2), :]
+
+
 def prepare_outputs(
     out,  # [actual_num_kv_heads, max_num_tokens, num_q_heads_per_kv_head // q_packing, q_packing, head_dim]
     actual_num_q_heads_per_kv_head: int,
     actual_head_dim: int,
 ):
+    if (
+        out.shape == (2, 2048, 2, 2, 128)
+        and out.dtype == jnp.bfloat16
+        and actual_num_q_heads_per_kv_head == 4
+        and actual_head_dim == 128
+    ):
+        # Materialize the public layout directly in independent 128-token
+        # tiles, without a global BF16 transpose/reshape.
+        # Use integer call boundaries to preserve BF16 subnormals and NaN
+        # payloads without floating-point normalization during transfers.
+        out_bits = lax.bitcast_convert_type(out, jnp.uint16)
+        result_bits = pl.pallas_call(
+            _prepare_outputs_packed_bf16_kernel,
+            out_shape=jax.ShapeDtypeStruct((2048, 8, 128), jnp.uint16),
+            grid=(16,),
+            in_specs=[pl.BlockSpec((2, 128, 2, 2, 128), lambda i: (0, i, 0, 0, 0))],
+            out_specs=pl.BlockSpec((128, 8, 128), lambda i: (i, 0, 0)),
+            compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel",)),
+            name="rpa_prepare_outputs_packed_bf16",
+        )(out_bits)
+        return lax.bitcast_convert_type(result_bits, out.dtype)
+
     (
         actual_num_kv_heads,
         max_num_tokens,


### PR DESCRIPTION
## Motivation

Materialize the 2048-token packed output through 16 bounded 128-token tiles, using uint16 Pallas call boundaries and external BF16 bitcasts.

### Limitation of the current abstraction

The original output layout expression produces avoidable conversion overhead. Existing Pallas tiling and integer transport support the rewrite. The tile helper is AST-identical to the corrected long variant, while the shape guard and grid are specific to this medium case.

## Modifications

- `python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py`

## Accuracy Tests

All 13 captured/scaled output/cache pairs are bit exact. Earlier exhaustive BF16-bit tests support the identical long-case helper, but they are not new whole-shape tests of the medium specialization. Broader upstream validation remains required.

All repository pre-commit checks passed for this commit, including the applicable type checker. Each implementation has one DCO-signed commit.

The retained TPU correctness/audit receipts are in the evidence bundle. No new TPU run was performed in the upstream publication checkout.

## Benchmarking and Profiling

**Measured on the frozen captured revisions below. These figures are not a benchmark of this PR rebased onto today's upstream main.**

| Captured case | Baseline (us) | Candidate (us) | Reduction | Speedup | Ratio CI95 |
| --- | ---: | ---: | ---: | ---: | --- |
| medium | 230.680969 | 223.631512 | **3.06%** | 1.0315x | [0.969169838, 0.969700130] |

Hardware: 1 local TPUv6e chip(s); JAX 0.11.1; explicit captured geometry and seed 1729. Each result is a mean of block medians from ten independent baseline/candidate pairs, with 50 exact compiled-program execution spans per block, 20 warmups and separate host timing. The gate requires >2% lower mean device latency and bootstrap ratio CI95 upper bound <1 (10,000 resamples, seed 1729). Canonical/scaled correctness comparisons retain the original tolerance. No full-model speedup is claimed.

### Post-compilation trace evidence

All 20 raw confirmation XPlane traces per shape and their execution records are retained. The publication audit re-read each raw trace, checked the serialized executable's HLO identity, reconstructed all 50 samples and reproduced its median. Multi-chip spans require a shared host execution identity and complete device partitions; single-chip traces may use the recorded device/queue/run identity.

Representative pair 00 for the **medium** case:

| Role | Exact HLO identity | Devices | Samples | Block median (us) |
| --- | --- | ---: | ---: | ---: |
| baseline | `jit__lambda` / ID `27` / PID `4135017` | 1 | 50 | 230.789375 |
| candidate | `jit__lambda` / ID `27` / PID `4134144` | 1 | 50 | 223.591172 |

[Download every confirmation trace and the verification bundle](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/rpa-output-medium.tar.gz). SHA256: `d7ee25ae7c2aba8d1385202a423fc99584cb878397d2930156f41a8216cf710a`.

After extraction, `python verify_evidence.py` (NumPy required) checks all bundle hashes and recomputes samples/statistics from the included selected events. Original `.xplane.pb` files remain the primary traces; raw output tensors and every repeated executable are not included.

### Post-compilation HLO and LLO dumps

Full HLO/LLO expose the 16-tile output conversion and integer call boundaries. All 20 independent confirmation traces correspond to this medium source variant.

| Shape | Full baseline LLO | Full candidate LLO | Compiled baseline HLO | Compiled candidate HLO |
| --- | --- | --- | --- | --- |
| medium | [baseline LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/rpa-output-medium-medium-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/rpa-output-medium-medium-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/rpa-output-medium-medium-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/rpa-output-medium-medium-candidate.hlo.txt.gz) |

<details>
<summary>Representative records from the full numbered LLO dumps</summary>

These excerpts show static emitted sites selected from changed vector opcodes. Counts and excerpts support code inspection; they do not quantify dynamic cycles.

### baseline

```text
247 : {[vmem:$0x3ffe0] = vst.8x128 v62}
248 : {s3 = simm.u32 $50;  s1 = sld [smem:$0x3b];  v59 = vimm.8x128.s32 $0;  v62 = vlaneseq.8x128.u32;  [vmem:$0x3fff8] = vst.8x128 v59}
249 : {[vmem:$0x3fff0] = vst.8x128 v60}
250 : {p0 = slt.s32 s1, $95;  s2 = simm.u32 $0;  v59 = vsel.8x128 vm0, $0x1, v59;  v63 = vand.8x128.u32 $0x380, v62;  [vmem:$0x3ffd8] = vst.8x128 v63}
251 : {p0 = slt.s32 s1, $85;  s2 = simm.u32 @p0 $1;  vm0 = veq.8x128.s32 v63, $0;  [vmem:$0x3ffe8] = vst.8x128 v61}
261 : {p0 = slt.s32 s1, $15;  s2 = simm.u32 @p0 $32;  [vmem:$0x3ffd0] = vst.8x128 v0}
262 : {s2 = simm.u32 @p0 $72;  s3 = simm.u32 @p0 $6;  [vmem:$0x3ffc8] = vst.8x128 v1}
263 : {p0 = slt.s32 s1, $5;  v60 = vpack.i.8x128.f32.bf16 v61, v60;  v61 = vpack.i.8x128.f32.bf16 v60, v61;  [vmem:$0x3ffc0] = vst.8x128 v2}
```

### candidate

```text
247 : {[vmem:$0x3ffe0] = vst.8x128 v62}
248 : {s3 = simm.u32 $50;  s1 = sld [smem:$0x3b];  v59 = vimm.8x128.s32 $0;  v62 = vlaneseq.8x128.u32;  [vmem:$0x3fff8] = vst.8x128 v59}
249 : {[vmem:$0x3fff0] = vst.8x128 v60}
250 : {p0 = slt.s32 s1, $95;  s2 = simm.u32 $0;  v59 = vsel.8x128 vm0, $0x1, v59;  v63 = vand.8x128.u32 $0x380, v62;  [vmem:$0x3ffd8] = vst.8x128 v63}
251 : {p0 = slt.s32 s1, $85;  s2 = simm.u32 @p0 $1;  vm0 = veq.8x128.s32 v63, $0;  [vmem:$0x3ffe8] = vst.8x128 v61}
261 : {p0 = slt.s32 s1, $15;  s2 = simm.u32 @p0 $32;  [vmem:$0x3ffd0] = vst.8x128 v0}
262 : {s2 = simm.u32 @p0 $72;  s3 = simm.u32 @p0 $6;  [vmem:$0x3ffc8] = vst.8x128 v1}
263 : {p0 = slt.s32 s1, $5;  v60 = vpack.i.8x128.f32.bf16 v61, v60;  v61 = vpack.i.8x128.f32.bf16 v60, v61;  [vmem:$0x3ffc0] = vst.8x128 v2}
```

</details>

### Source provenance and remaining limits

- Measured baseline: `027fa79a6498a1afef5a36c4e093c07d2f12f1ef`; exact measured patch and accepted candidate IDs/revisions are in the bundle.
- PR base: `3f1f38715b5dcd4b8ef11e4186e029e3e90f9570`. PR implementation commit: `1df49839da22c408f987533afaf2cc96622b59a0`.
- The source was ported onto current upstream and checked locally. Fresh TPU lowering/performance confirmation on that upstream revision remains outstanding; this PR is a draft for review.
- Performance is limited to the reported geometries, dtypes, runtime, partition and guarded paths. Original captures and any unsuccessful search attempts are not relabeled as new upstream measurements.
- The medium and long output-conversion PRs use the same tile helper with different guards/grids. They overlap in source and need consolidation plus validation before both can be integrated.

## Checklist

- [x] English description with motivation and implementation scope.
- [x] Test results and reproducible evidence verification command provided.
- [x] Numerical and measurement limitations stated.
- [ ] Fresh TPU validation of the upstream port and any consolidation with overlapping variants.
