### PR TITLE
fix(dsa/moe): recover jax 0.11.1 long-context perf regressions

### DIFF
--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
@@ -331,7 +331,6 @@ def sparse_mla_attention_qblock(
         base_tok = base_pages * ps  # [S]
         if kv.shape[-1] != Dk_pad:
             raise ValueError(f"paged cache last dim {kv.shape[-1]} != Dk_pad {Dk_pad}")
-        num_pages = kv.shape[0]
         kv2 = kv  # native 4D pool; flattened inside the kernel (HBM ref view)
         pt_arg = page_indices.reshape(1, 1, 1, PTW).astype(jnp.int32)
     else:

--- a/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
+++ b/python/sgl_jax/srt/kernels/dsa/sparse_mla_prefill_qblock.py
@@ -124,7 +124,7 @@ def _qblock_kernel(
     kvlen_ref,  # [1, 1, 1, QBHp]   VMEM  per-row kv length bound
     base_ref,  # [1, 1, 1, QBHp]    VMEM  per-row page-table base, in TOKENS
     mem_ref,  # [1, 1, U_pad, QBHp] VMEM  int8 membership by union slot
-    kv_hbm,  # flat: [B, T(+RBF), Dk_pad]; paged: [1, num_pages*PS, Dk_pad] HBM
+    kv_hbm,  # flat: [B, T(+RBF), Dk_pad]; paged: 4D pool or [1, Pn*PS, Dk_pad] HBM
     pt_ref,  # [1, 1, 1, PTW]      SMEM  packed page table (paged only)
     o_ref,  # [1, 1, QBHp, Dv]
     kv_scratch,  # [NBUF, RBF, Dk_pad] VMEM  DMA ring
@@ -138,6 +138,15 @@ def _qblock_kernel(
     PS: int,  # page size (paged only; == RB in v1 paged mode)
     PTW: int,
 ):
+    if kv_hbm.ndim == 4:
+        # Paged pool passed in its native word-packed shape. Flattening the
+        # HBM ref here (instead of a host-side jnp.reshape) keeps the pool's
+        # native tile in the graph: on jax 0.11.1 the host-side flat view
+        # forces a full T(2,128)->T(8,128) retile copy of the pool per
+        # chunk (110k prefill: ~+2s). HBM refs are DMA-addressed, so the
+        # in-kernel view is free (same trick as _write_back_kernel).
+        _pn, _pspk, _pk, _dk = kv_hbm.shape
+        kv_hbm = kv_hbm.reshape(1, _pn * _pspk * _pk, _dk)
     """Query-block sparse-MLA kernel, ring-prefetched (flat or packed-paged KV).
 
     In paged mode a unit id is a **global key** = position in the packed
@@ -323,7 +332,7 @@ def sparse_mla_attention_qblock(
         if kv.shape[-1] != Dk_pad:
             raise ValueError(f"paged cache last dim {kv.shape[-1]} != Dk_pad {Dk_pad}")
         num_pages = kv.shape[0]
-        kv2 = kv.reshape(1, num_pages * ps, Dk_pad)
+        kv2 = kv  # native 4D pool; flattened inside the kernel (HBM ref view)
         pt_arg = page_indices.reshape(1, 1, 1, PTW).astype(jnp.int32)
     else:
         ps = 0
@@ -663,9 +672,15 @@ def paged_write_back(
 
     def _scatter(cache, row_w, table):
         del table
-        flat = cache.reshape(Pn * ps, D)
-        flat = flat.at[loc].set(row_w.reshape(Tp, D), mode="drop", wrap_negative_indices=False)
-        return flat.reshape(cache.shape)
+        # 4D-native scatter: same slot semantics as the flat-view version but
+        # without cache.reshape(Pn*ps, D), which on jax 0.11.1 materializes a
+        # full retile of the pool inside this cond branch (branch_1_fun,
+        # ~2ms/layer at 110k).
+        page = jnp.where(loc >= 0, loc // ps, -1)
+        rem = jnp.where(loc >= 0, loc % ps, 0)
+        return cache.at[page, rem // pk, rem % pk].set(
+            row.astype(cache.dtype), mode="drop", wrap_negative_indices=False
+        )
 
     if interpret:
         # interpret cannot lower dynamic-size DMAs; the scatter is the

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -835,12 +835,9 @@ class EPMoE(nnx.Module):
         )
         weights_fp32 = weights.astype(jnp.float32)
 
-        # Small (decode-shaped) batches: the einsum's (tokens, top_k, hidden)
-        # fp32 intermediate is tiny, while the unrolled per-k gather costs
-        # +0.9 ms/token on GLM-5.2 decode (top_k=8, 78L, TPU v7x, jax 0.11.1).
-        # Large (prefill-shaped) batches: that intermediate is ~0.5 GB/layer
-        # and the unrolled path from #1578 is a big win (-2.8 s on 110k TTFT).
-        # Branch on the static token count: both shapes get their fast path.
+        # Static token-count branch: small (decode) batches avoid the unrolled
+        # per-k gather overhead; large (prefill) batches avoid the fp32
+        # (tokens, top_k, hidden) intermediate. Benchmarks in the PR description.
         if weights.shape[0] <= 256:
             unsort_intermediate = jnp.take(intermediate, indices=argsort_indices, axis=0)
             reshaped_intermediate = jnp.reshape(

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -833,16 +833,36 @@ class EPMoE(nnx.Module):
             .at[sorted_selected_experts]
             .set(jnp.arange(expected_tokens, dtype=jnp.int32))
         )
-        grouped_indices = jnp.reshape(argsort_indices, (weights.shape[0], top_k))
         weights_fp32 = weights.astype(jnp.float32)
 
-        output = None
-        for k in range(top_k):
-            contribution = (
-                jnp.take(intermediate, indices=grouped_indices[:, k], axis=0).astype(jnp.float32)
-                * weights_fp32[:, k, None]
+        # Small (decode-shaped) batches: the einsum's (tokens, top_k, hidden)
+        # fp32 intermediate is tiny, while the unrolled per-k gather costs
+        # +0.9 ms/token on GLM-5.2 decode (top_k=8, 78L, TPU v7x, jax 0.11.1).
+        # Large (prefill-shaped) batches: that intermediate is ~0.5 GB/layer
+        # and the unrolled path from #1578 is a big win (-2.8 s on 110k TTFT).
+        # Branch on the static token count: both shapes get their fast path.
+        if weights.shape[0] <= 256:
+            unsort_intermediate = jnp.take(intermediate, indices=argsort_indices, axis=0)
+            reshaped_intermediate = jnp.reshape(
+                unsort_intermediate,
+                (weights.shape[0], top_k, -1),
             )
-            output = contribution if output is None else output + contribution
+            output = jnp.einsum(
+                "BKE,BK -> BE",
+                reshaped_intermediate.astype(jnp.float32),
+                weights_fp32,
+            )
+        else:
+            grouped_indices = jnp.reshape(argsort_indices, (weights.shape[0], top_k))
+            output = None
+            for k in range(top_k):
+                contribution = (
+                    jnp.take(intermediate, indices=grouped_indices[:, k], axis=0).astype(
+                        jnp.float32
+                    )
+                    * weights_fp32[:, k, None]
+                )
+                output = contribution if output is None else output + contribution
 
         final_output = output.astype(self.dtype)
 

--- a/python/sgl_jax/srt/model_executor/aot_dispatch.py
+++ b/python/sgl_jax/srt/model_executor/aot_dispatch.py
@@ -36,6 +36,8 @@ import os
 import jax
 from jax._src.lib import xla_client as _xc
 
+from sgl_jax.srt.utils.common_utils import get_bool_env_var
+
 logger = logging.getLogger(__name__)
 
 _ENV = os.environ.get("SGLANG_JAX_AOT_DISPATCH", "0")
@@ -57,6 +59,41 @@ def aot_dispatch_enabled(num_flat_args: int) -> bool:
     if _ENV == "auto":
         return num_flat_args >= _AUTO_MIN_ARGS
     return _ENV == "1"
+
+
+def decode_no_sc_gather_compiler_options_fn():
+    """Temporary XLA workaround for the jax 0.11.1 SparseCore gather-offload
+    decode regression on TPU v7x (#1613, jax-ml/jax#40553).
+
+    When SGLANG_JAX_DECODE_DISABLE_SC_GATHER_OFFLOAD is set on TPU, returns a
+    ``compiler_options_fn`` that compiles decode-shaped executables with the
+    offload pass disabled while prefill keeps the default (the offload is
+    profitable for large prefill gathers, and a process-global
+    LIBTPU_INIT_ARGS disable costs ~+12% on 110k prefill). Returns ``None``
+    when the workaround is not requested. Only effective together with
+    SGLANG_JAX_AOT_DISPATCH since it hooks the per-shape AOT compile path.
+    Remove once the upstream cost-model fix ships.
+    """
+    if not (
+        jax.default_backend() == "tpu"
+        and get_bool_env_var("SGLANG_JAX_DECODE_DISABLE_SC_GATHER_OFFLOAD")
+    ):
+        return None
+    logger.info(
+        "SGLANG_JAX_DECODE_DISABLE_SC_GATHER_OFFLOAD: decode executables "
+        "will be compiled with SparseCore gather offload disabled."
+    )
+
+    def _compiler_options_fn(dyn_args):
+        forward_batch = dyn_args[0]
+        if forward_batch.forward_mode.is_decode():
+            return {
+                "xla_tpu_offload_gather_to_sparsecore": "false",
+                "xla_tpu_offload_all_supported_gathers_to_sparsecore": "false",
+            }
+        return None
+
+    return _compiler_options_fn
 
 
 class AotDispatcher:

--- a/python/sgl_jax/srt/model_executor/aot_dispatch.py
+++ b/python/sgl_jax/srt/model_executor/aot_dispatch.py
@@ -77,13 +77,21 @@ class AotDispatcher:
     containers between calls.
     """
 
-    def __init__(self, jit_fn, stable_call_args: tuple, stable_flat_args: tuple, name: str):
+    def __init__(
+        self,
+        jit_fn,
+        stable_call_args: tuple,
+        stable_flat_args: tuple,
+        name: str,
+        compiler_options_fn=None,
+    ):
         self._jit_fn = jit_fn
         self._stable_call_args = stable_call_args
         self._stable_flat_args = stable_flat_args
         self._stable_ids = tuple(id(a) for a in stable_flat_args)
         self._cache = {}
         self._name = name
+        self._compiler_options_fn = compiler_options_fn
         self._enabled = None  # decided on first call from flat arg count
 
     def invalidate(self) -> None:
@@ -160,7 +168,17 @@ class AotDispatcher:
                 )
                 return self._jit_fn(*self._stable_call_args, *dyn_args)
 
-        compiled = self._jit_fn.lower(*self._stable_call_args, *dyn_args).compile()
+        compile_opts = self._compiler_options_fn(dyn_args) if self._compiler_options_fn else None
+        lowered = self._jit_fn.lower(*self._stable_call_args, *dyn_args)
+        if compile_opts:
+            logger.info(
+                "[aot-dispatch:%s] compiling with compiler_options=%s",
+                self._name,
+                compile_opts,
+            )
+            compiled = lowered.compile(compiler_options=compile_opts)
+        else:
+            compiled = lowered.compile()
         unsafe = compiled._executable.unsafe_call
         if (
             unsafe.ordered_effects

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -37,6 +37,7 @@ from sgl_jax.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
 from sgl_jax.srt.model_executor.aot_dispatch import (
     AotDispatcher,
     aot_dispatch_requested,
+    decode_no_sc_gather_compiler_options_fn,
 )
 from sgl_jax.srt.model_executor.base_model_runner import BaseModelRunner
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
@@ -385,41 +386,13 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
             )
             use_aot_dispatch = False
 
-        # Opt-in workaround for the jax 0.11.1 SparseCore gather-offload decode
-        # regression on TPU v7x (#1613, jax-ml/jax#40553): compile decode-shaped
-        # executables with the offload pass disabled while prefill keeps the
-        # default (the offload is profitable for large prefill gathers, and a
-        # process-global LIBTPU_INIT_ARGS disable costs ~+12% on 110k prefill).
-        # Only effective together with SGLANG_JAX_AOT_DISPATCH since it hooks
-        # the per-shape AOT compile path.
-        decode_no_sc_gather = jax.default_backend() == "tpu" and get_bool_env_var(
-            "SGLANG_JAX_DECODE_DISABLE_SC_GATHER_OFFLOAD"
-        )
-
-        def _run_model_compiler_options(dyn_args):
-            if not decode_no_sc_gather:
-                return None
-            forward_batch = dyn_args[0]
-            if forward_batch.forward_mode.is_decode():
-                return {
-                    "xla_tpu_offload_gather_to_sparsecore": "false",
-                    "xla_tpu_offload_all_supported_gathers_to_sparsecore": "false",
-                }
-            return None
-
         if use_aot_dispatch:
-            if decode_no_sc_gather:
-                logger.info(
-                    "SGLANG_JAX_DECODE_DISABLE_SC_GATHER_OFFLOAD: decode "
-                    "executables will be compiled with SparseCore gather "
-                    "offload disabled."
-                )
             self._run_model_dispatcher = AotDispatcher(
                 jitted_run_model,
                 stable_call_args=(model_def, model_state_def, self.model_state_leaves),
                 stable_flat_args=(model_def, self.model_state_leaves),
                 name="run_model",
-                compiler_options_fn=_run_model_compiler_options,
+                compiler_options_fn=decode_no_sc_gather_compiler_options_fn(),
             )
 
             def run_model_wrapper(forward_batch, logits_metadata):

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -385,12 +385,41 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
             )
             use_aot_dispatch = False
 
+        # Opt-in workaround for the jax 0.11.1 SparseCore gather-offload decode
+        # regression on TPU v7x (#1613, jax-ml/jax#40553): compile decode-shaped
+        # executables with the offload pass disabled while prefill keeps the
+        # default (the offload is profitable for large prefill gathers, and a
+        # process-global LIBTPU_INIT_ARGS disable costs ~+12% on 110k prefill).
+        # Only effective together with SGLANG_JAX_AOT_DISPATCH since it hooks
+        # the per-shape AOT compile path.
+        decode_no_sc_gather = jax.default_backend() == "tpu" and get_bool_env_var(
+            "SGLANG_JAX_DECODE_DISABLE_SC_GATHER_OFFLOAD"
+        )
+
+        def _run_model_compiler_options(dyn_args):
+            if not decode_no_sc_gather:
+                return None
+            forward_batch = dyn_args[0]
+            if forward_batch.forward_mode.is_decode():
+                return {
+                    "xla_tpu_offload_gather_to_sparsecore": "false",
+                    "xla_tpu_offload_all_supported_gathers_to_sparsecore": "false",
+                }
+            return None
+
         if use_aot_dispatch:
+            if decode_no_sc_gather:
+                logger.info(
+                    "SGLANG_JAX_DECODE_DISABLE_SC_GATHER_OFFLOAD: decode "
+                    "executables will be compiled with SparseCore gather "
+                    "offload disabled."
+                )
             self._run_model_dispatcher = AotDispatcher(
                 jitted_run_model,
                 stable_call_args=(model_def, model_state_def, self.model_state_leaves),
                 stable_flat_args=(model_def, self.model_state_leaves),
                 name="run_model",
+                compiler_options_fn=_run_model_compiler_options,
             )
 
             def run_model_wrapper(forward_batch, logits_metadata):


### PR DESCRIPTION
Fixes the jax 0.10.2 -> 0.11.1 performance regressions tracked in #1613 (upstream report: jax-ml/jax#40553). On GLM-5.2 v7x tp16 at the 135k-context config, decode TPOT regressed 13.7 -> 21.4 ms/token and 110k TTFT 22.1 -> 24.4 s; with this PR both return to the 0.10.2 baseline: **decode 13.68 ms/token, 110k TTFT 22.29 s** (baseline 13.67 / 22.13, i.e. within 1%).

Three independent 0.11.1 interactions, three scoped fixes:

1. **Decode SparseCore gather offload (opt-in)** — 0.11.1's libtpu now offloads the DSA decode sparse-KV gather (2048 indices from an HBM-resident paged pool) to SparseCore, costing ~7 ms/step at bs=1, while the same offload is genuinely profitable for prefill's large MoE gathers (a process-global `LIBTPU_INIT_ARGS` disable costs +11.6% on 110k TTFT). `AotDispatcher` gains a `compiler_options_fn` hook, and `SGLANG_JAX_DECODE_DISABLE_SC_GATHER_OFFLOAD=1` compiles only decode-shaped executables with `xla_tpu_offload_gather_to_sparsecore=false`. Default off; no behavior change unless the env var is set. The JAX team has confirmed in jax-ml/jax#40553 that per-executable `compiler_options` is **officially supported and a viable workaround** for this, that the compiler currently lacks a cost model for gather offload profitability, and that a cost-model fix is tracked internally — per cjx0709 in #1613, this flag is a workaround to revert once that fix ships. (The JAX team also suggested `jax.experimental.compute_on` per-op annotations as a finer-grained alternative; that would require annotating the specific gather inside the model/backend code, so this PR takes the runtime-level per-executable route and leaves per-op pinning as a possible follow-up.)

2. **qblock prefill kernel: keep the pool's native layout in the graph** — on 0.11.1 the host-side flat view `kv.reshape(1, Pn*ps, D)` of the 4D word-packed KV pool materializes a full T(2,128)->T(8,128) retile per chunk (~1.9 s per 110k prefill), and the write-back overflow `lax.cond` pays a matching retile inside its scatter branch (~2.0 s). The kernel now takes the pool 4D and flattens the HBM ref in-kernel (free, same trick as `_write_back_kernel`), and the overflow fallback scatters 4D-natively. GLM/DSA-only code path; no change for other models. qblock canaries 19/19.

3. **EPMoE unpermute: pick the strategy from the token count** — the unrolled per-k gather from #1578 avoids building the einsum's `(tokens, top_k, hidden)` fp32 intermediate, a large win for prefill-shaped batches on 0.11.1 (-2.8 s per 110k prefill vs the einsum path), but costs +0.9 ms/token on decode-shaped batches where that intermediate is tiny. Branch on the static token count (<=256 -> einsum, else unrolled) so both shapes keep their fast path. Bit-identical to the einsum reference for the small-batch path; the large-batch path is unchanged from #1578.

## Measurements (GLM-5.2 753B, v7x tp16, 2 hosts, 135k-context config)

| metric | 0.10.2 baseline | 0.11.1 before | 0.11.1 + this PR |
|---|---|---|---|
| decode TPOT (1k ctx, ignore_eos, (t257-t1)/256, 2 rounds) | 13.67 ms | 21.4 ms (+57%) | **13.68 ms** |
| 110k TTFT (x3) | 22.13 s | 24.4 s (+10%) | **22.29 s** |
| gsm8k 200q (5-shot, temp 0) | 0.950-0.955 (einsum numerics) | 0.960 (#1578 numerics) | 0.945 (back on the 0.10.2-equivalent einsum numerics for decode; within the 200-question noise of its historical band, 0 invalid) |
| 49k config TPOT / cc=1/8/32 | 13.33 ms | 13.33 ms (unaffected) | 13.31 / 13.32-13.33 ms (no regression; cc points serialized by max_running=1 in this config) |
| 16k TTFT | 3.55 s | — | 2.31 s |
| qblock kernel canaries | — | — | 19/19 passed |

## Test plan

- [x] decode TPOT recovery on v7x 135k (13.665 ms, 2 rounds, spread <0.1%)
- [x] 110k TTFT recovery (22.31 s x3, zero spread)
- [x] qblock TPU canaries (test_qblock_kernel_tpu.py + parity, 19/19)
- [x] CPU parity of the unpermute branch vs einsum reference (top_k in {1,2,4,8}, bitwise)
- [x] gsm8k 200q on the final stack (0.945, 0 invalid; numerics-path attribution above)
- [x] 49k config regression (TPOT 13.31; cc=1/8/32 all 13.32-13.33)
- [x] 16k TTFT spot check (2.31 s)
- [x] pre-commit clean
