### PR TITLE
[Spec Decoding] Support Qwen3 DSpark in Stage1

### DIFF
--- a/docs/features/speculative_decoding.md
+++ b/docs/features/speculative_decoding.md
@@ -157,3 +157,35 @@ architecture. If the verification width is omitted, the checkpoint's
 when this flag is set. An explicitly supplied verification width takes precedence.
 Choose the layout using the checkpoint's reference implementation; enabling the
 flag is not itself evidence of checkpoint compatibility or improved acceptance.
+
+
+## DSpark stage1: vanilla Markov head
+
+The DFLASH runtime also supports DSpark checkpoints with `markov_rank > 0`
+and `markov_head_type="vanilla"`. Use `--dspark-sample-from-anchor`; the
+verification width must equal checkpoint `block_size + 1` (for example, 8
+for a block7 checkpoint). If omitted, the verification width is inferred as
+explained above. Draft and target vocabulary sizes must match.
+
+The backbone runs once per block to produce all base logits. Candidates are
+then sampled greedily in sequence:
+
+```text
+previous_token = anchor
+for position in draft_output_positions:
+    logits = base_logits[position] + W2(W1[previous_token])
+    candidate = argmax(logits)
+    previous_token = candidate
+```
+
+The checkpoint supplies `markov_head.markov_w1.weight` (a vocabulary-to-rank
+embedding) and `markov_head.markov_w2.weight` (a rank-to-vocabulary projection).
+The projection is transposed into the JAX linear weight layout and sharded
+along vocabulary across TP ranks; the embedding is replicated. Missing
+required weights cause loading to fail.
+
+Stage1 verifies all candidates at a fixed width. Confidence head weights, if
+present, are unused; there is no confidence-based truncation or dynamic
+verification planning. Gated and recurrent Markov heads are unsupported.
+Checkpoints without a Markov head (`markov_rank` absent or zero) retain the
+existing DFlash sampling path.

--- a/docs/features/speculative_decoding.md
+++ b/docs/features/speculative_decoding.md
@@ -190,7 +190,7 @@ Stage1 verifies all candidates at a fixed width. Confidence head weights, if
 present, are unused; there is no confidence-based truncation or dynamic
 verification planning. Gated and recurrent Markov heads are unsupported.
 Checkpoints without a Markov head (`markov_rank` absent or zero) continue to use
-`DFLASH`. DFlash rejects Markov checkpoints rather than silently ignoring the head.
+`DFLASH`. The DFLASH path loads only backbone weights; use DSPARK to include the Markov head.
 
 For `deepseek-ai/dspark_qwen3_8b_block7`:
 

--- a/docs/features/speculative_decoding.md
+++ b/docs/features/speculative_decoding.md
@@ -150,8 +150,8 @@ accepted-context KV materialization retain the full verification width. Both
 layouts use greedy draft sampling and verification.
 
 The flag describes the checkpoint prediction layout, independently of whether
-a Markov head is present. This implementation supports the flag with DFLASH.
-It defaults to false and is not inferred from the checkpoint name or
+a Markov head is present. The flag is supported with DFLASH and DSPARK.
+For DFLASH it defaults to false and is not inferred from the checkpoint name or
 architecture. If the verification width is omitted, the checkpoint's
 `block_size` is used unchanged for the default layout, or incremented by one
 when this flag is set. An explicitly supplied verification width takes precedence.
@@ -161,8 +161,10 @@ flag is not itself evidence of checkpoint compatibility or improved acceptance.
 
 ## DSpark stage1: vanilla Markov head
 
-The DFLASH runtime also supports DSpark checkpoints with `markov_rank > 0`
-and `markov_head_type="vanilla"`. Use `--dspark-sample-from-anchor`; the
+Use `--speculative-algorithm DSPARK` for DSpark checkpoints with
+`markov_rank > 0` and `markov_head_type="vanilla"`. This selects the dedicated
+DSpark model and worker and automatically enables sampling from the anchor.
+The
 verification width must equal checkpoint `block_size + 1` (for example, 8
 for a block7 checkpoint). If omitted, the verification width is inferred as
 explained above. Draft and target vocabulary sizes must match.
@@ -187,5 +189,17 @@ required weights cause loading to fail.
 Stage1 verifies all candidates at a fixed width. Confidence head weights, if
 present, are unused; there is no confidence-based truncation or dynamic
 verification planning. Gated and recurrent Markov heads are unsupported.
-Checkpoints without a Markov head (`markov_rank` absent or zero) retain the
-existing DFlash sampling path.
+Checkpoints without a Markov head (`markov_rank` absent or zero) continue to use
+`DFLASH`. DFlash rejects Markov checkpoints rather than silently ignoring the head.
+
+For `deepseek-ai/dspark_qwen3_8b_block7`:
+
+```bash
+--speculative-algorithm DSPARK \
+--speculative-draft-model-path deepseek-ai/dspark_qwen3_8b_block7 \
+--speculative-num-draft-tokens 8 \
+--speculative-num-steps 1 \
+--speculative-eagle-topk 1 \
+--grammar-backend none \
+--disable-overlap-schedule
+```

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1707,7 +1707,7 @@ class ScheduleBatch:
         # (asserts shape[0] == batch_size); rebuild via _concat, run it, then
         # split allocate_lens back to per-rank.
         if self.spec_algorithm is not None and (
-            self.spec_algorithm.is_eagle() or self.spec_algorithm.is_block_draft()
+            self.spec_algorithm.is_eagle() or self.spec_algorithm.is_dflash_family()
         ):
             for info in self.reqs_info:
                 if not info.reqs:

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1707,7 +1707,7 @@ class ScheduleBatch:
         # (asserts shape[0] == batch_size); rebuild via _concat, run it, then
         # split allocate_lens back to per-rank.
         if self.spec_algorithm is not None and (
-            self.spec_algorithm.is_eagle() or self.spec_algorithm.is_dflash()
+            self.spec_algorithm.is_eagle() or self.spec_algorithm.is_block_draft()
         ):
             for info in self.reqs_info:
                 if not info.reqs:

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -437,10 +437,11 @@ class Scheduler(
             )
             if self.enable_overlap and hasattr(self.draft_worker, "init_spec_relay_buffers"):
                 self.draft_worker.init_spec_relay_buffers()
-        elif self.spec_algorithm is not None and self.spec_algorithm.is_dflash():
-            from sgl_jax.srt.speculative.dflash_worker import (
-                DFlashWorker as _SpecWorkerCls,
-            )
+        elif self.spec_algorithm is not None and self.spec_algorithm.is_block_draft():
+            if self.spec_algorithm.is_dspark():
+                from sgl_jax.srt.speculative.dspark_worker import DSparkWorker as _SpecWorkerCls
+            else:
+                from sgl_jax.srt.speculative.dflash_worker import DFlashWorker as _SpecWorkerCls
 
             self.draft_worker = _SpecWorkerCls(
                 server_args=server_args,
@@ -1409,7 +1410,7 @@ class Scheduler(
             self._add_request_to_queue(req)
             return
 
-        if self.spec_algorithm is not None and self.spec_algorithm.is_dflash():
+        if self.spec_algorithm is not None and self.spec_algorithm.is_block_draft():
             dflash_err = validate_dflash_request(req)
             if dflash_err is not None:
                 req.set_finish_with_abort(dflash_err)
@@ -2692,7 +2693,7 @@ class Scheduler(
                 batch_output.next_token_ids
                 if (
                     self.spec_algorithm is not None
-                    and (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_dflash())
+                    and (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_block_draft())
                     and (batch.forward_mode.is_decode() or defer_spec_prefill_output)
                     and self.enable_overlap
                 )
@@ -2707,7 +2708,7 @@ class Scheduler(
         )
         if (
             self.spec_algorithm is not None
-            and (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_dflash())
+            and (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_block_draft())
             and batch_output.next_draft_input is not None
         ):
             assert isinstance(batch_output.next_draft_input, (EagleDraftInput, DFlashDraftInput))

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -437,7 +437,7 @@ class Scheduler(
             )
             if self.enable_overlap and hasattr(self.draft_worker, "init_spec_relay_buffers"):
                 self.draft_worker.init_spec_relay_buffers()
-        elif self.spec_algorithm is not None and self.spec_algorithm.is_block_draft():
+        elif self.spec_algorithm is not None and self.spec_algorithm.is_dflash_family():
             if self.spec_algorithm.is_dspark():
                 from sgl_jax.srt.speculative.dspark_worker import DSparkWorker as _SpecWorkerCls
             else:
@@ -1410,7 +1410,7 @@ class Scheduler(
             self._add_request_to_queue(req)
             return
 
-        if self.spec_algorithm is not None and self.spec_algorithm.is_block_draft():
+        if self.spec_algorithm is not None and self.spec_algorithm.is_dflash_family():
             dflash_err = validate_dflash_request(req)
             if dflash_err is not None:
                 req.set_finish_with_abort(dflash_err)
@@ -2693,7 +2693,7 @@ class Scheduler(
                 batch_output.next_token_ids
                 if (
                     self.spec_algorithm is not None
-                    and (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_block_draft())
+                    and (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_dflash_family())
                     and (batch.forward_mode.is_decode() or defer_spec_prefill_output)
                     and self.enable_overlap
                 )
@@ -2708,7 +2708,7 @@ class Scheduler(
         )
         if (
             self.spec_algorithm is not None
-            and (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_block_draft())
+            and (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_dflash_family())
             and batch_output.next_draft_input is not None
         ):
             assert isinstance(batch_output.next_draft_input, (EagleDraftInput, DFlashDraftInput))

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -439,9 +439,13 @@ class Scheduler(
                 self.draft_worker.init_spec_relay_buffers()
         elif self.spec_algorithm is not None and self.spec_algorithm.is_dflash_family():
             if self.spec_algorithm.is_dspark():
-                from sgl_jax.srt.speculative.dspark_worker import DSparkWorker as _SpecWorkerCls
+                from sgl_jax.srt.speculative.dspark_worker import (
+                    DSparkWorker as _SpecWorkerCls,
+                )
             else:
-                from sgl_jax.srt.speculative.dflash_worker import DFlashWorker as _SpecWorkerCls
+                from sgl_jax.srt.speculative.dflash_worker import (
+                    DFlashWorker as _SpecWorkerCls,
+                )
 
             self.draft_worker = _SpecWorkerCls(
                 server_args=server_args,

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -502,7 +502,7 @@ class SchedulerOutputProcessorMixin:
                 new_accepted_len = 1
                 if not is_spec_decode:
                     req.output_ids.append(next_token_id)
-                elif self.spec_algorithm.is_eagle() or self.spec_algorithm.is_block_draft():
+                elif self.spec_algorithm.is_eagle() or self.spec_algorithm.is_dflash_family():
                     req.output_ids.extend([int(t) for t in next_token_id])
                     new_accepted_len = len(next_token_id)
 
@@ -528,7 +528,7 @@ class SchedulerOutputProcessorMixin:
                     )
                 elif (
                     is_spec_decode
-                    and (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_block_draft())
+                    and (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_dflash_family())
                     and not legacy_eagle3_non_overlap
                 ):
                     req.kv_committed_len += new_accepted_len - 1

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -502,7 +502,7 @@ class SchedulerOutputProcessorMixin:
                 new_accepted_len = 1
                 if not is_spec_decode:
                     req.output_ids.append(next_token_id)
-                elif self.spec_algorithm.is_eagle() or self.spec_algorithm.is_dflash():
+                elif self.spec_algorithm.is_eagle() or self.spec_algorithm.is_block_draft():
                     req.output_ids.extend([int(t) for t in next_token_id])
                     new_accepted_len = len(next_token_id)
 
@@ -528,7 +528,7 @@ class SchedulerOutputProcessorMixin:
                     )
                 elif (
                     is_spec_decode
-                    and (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_dflash())
+                    and (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_block_draft())
                     and not legacy_eagle3_non_overlap
                 ):
                     req.kv_committed_len += new_accepted_len - 1

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -683,7 +683,7 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                 # if there is no aux layer, set to None
                 eagle_aux_hidden_state_layer_ids = None
             self.model.set_eagle3_layers_to_capture(eagle_aux_hidden_state_layer_ids)
-        elif self.server_args.speculative_algorithm == "DFLASH" and not self.is_draft_worker:
+        elif self.server_args.speculative_algorithm in ("DFLASH", "DSPARK") and not self.is_draft_worker:
             # The captured layers must match the draft checkpoint's projection input.
             from sgl_jax.srt.speculative.dflash_util import parse_dflash_draft_config
 

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -683,7 +683,10 @@ class ModelRunner(ModelRunnerKVCacheMixin, BaseModelRunner):
                 # if there is no aux layer, set to None
                 eagle_aux_hidden_state_layer_ids = None
             self.model.set_eagle3_layers_to_capture(eagle_aux_hidden_state_layer_ids)
-        elif self.server_args.speculative_algorithm in ("DFLASH", "DSPARK") and not self.is_draft_worker:
+        elif (
+            self.server_args.speculative_algorithm in ("DFLASH", "DSPARK")
+            and not self.is_draft_worker
+        ):
             # The captured layers must match the draft checkpoint's projection input.
             from sgl_jax.srt.speculative.dflash_util import parse_dflash_draft_config
 

--- a/python/sgl_jax/srt/models/dflash.py
+++ b/python/sgl_jax/srt/models/dflash.py
@@ -333,6 +333,22 @@ class DFlashDraftModel(nnx.Module):
         self.config = config
         self.mesh = mesh
         self.dtype = dtype
+        self.markov_rank = int(getattr(config, "markov_rank", 0))
+        if self.markov_rank < 0:
+            raise ValueError("markov_rank must be non-negative.")
+        if self.markov_rank:
+            if getattr(config, "markov_head_type", None) != "vanilla":
+                raise ValueError("DSpark stage1 only supports markov_head_type='vanilla'.")
+            from sgl_jax.srt.models.dspark_head import VanillaMarkovHead
+
+            self.markov_head = VanillaMarkovHead(
+                vocab_size=int(config.vocab_size),
+                markov_rank=self.markov_rank,
+                mesh=mesh,
+                dtype=dtype,
+            )
+        else:
+            self.markov_head = None
         self.model = DFlashBackbone(config=config, mesh=mesh, dtype=dtype)
 
         hidden_size = int(config.hidden_size)
@@ -401,7 +417,19 @@ class DFlashDraftModel(nnx.Module):
             mesh=self.mesh,
             dtype=self.dtype,
         )
-        loader.load_weights_from_safetensors(self._create_weight_mappings())
+        mappings = self._create_weight_mappings()
+        if self.markov_head is not None and not loader.dummy_mode:
+            keys = set(loader._scan_weight_info())
+            missing = set(mappings) - keys
+            if missing:
+                raise ValueError(
+                    f"DSpark checkpoint is missing required weights: {sorted(missing)}."
+                )
+            if any(key.startswith("confidence_head.") for key in keys):
+                logger.info(
+                    "DSpark stage1 ignores confidence head weights; verifies all proposals."
+                )
+        loader.load_weights_from_safetensors(mappings)
         logger.info("DFlash draft weights loaded successfully.")
 
     def _create_weight_mappings(self) -> dict[str, WeightMapping]:
@@ -501,6 +529,21 @@ class DFlashDraftModel(nnx.Module):
                     transpose=False,
                 )
 
+        if int(getattr(self.config, "markov_rank", 0)) > 0:
+            mappings.update(
+                {
+                    "markov_head.markov_w1.weight": WeightMapping(
+                        target_path="markov_head.markov_w1",
+                        sharding=(None, None),
+                        transpose=False,
+                    ),
+                    "markov_head.markov_w2.weight": WeightMapping(
+                        target_path="markov_head.markov_w2.weight",
+                        sharding=(None, "tensor"),
+                        transpose=True,
+                    ),
+                }
+            )
         return mappings
 
 

--- a/python/sgl_jax/srt/models/dflash.py
+++ b/python/sgl_jax/srt/models/dflash.py
@@ -400,8 +400,6 @@ class DFlashDraftModel(nnx.Module):
         return jnp.argmax(base_logits, axis=-1).astype(jnp.int32)
 
     def load_weights(self, model_config: ModelConfig) -> None:
-        if int(getattr(self.config, "markov_rank", 0)) > 0:
-            raise ValueError("Markov checkpoints require --speculative-algorithm DSPARK.")
         loader = WeightLoader(
             model=self,
             model_config=model_config,

--- a/python/sgl_jax/srt/models/dflash.py
+++ b/python/sgl_jax/srt/models/dflash.py
@@ -333,22 +333,6 @@ class DFlashDraftModel(nnx.Module):
         self.config = config
         self.mesh = mesh
         self.dtype = dtype
-        self.markov_rank = int(getattr(config, "markov_rank", 0))
-        if self.markov_rank < 0:
-            raise ValueError("markov_rank must be non-negative.")
-        if self.markov_rank:
-            if getattr(config, "markov_head_type", None) != "vanilla":
-                raise ValueError("DSpark stage1 only supports markov_head_type='vanilla'.")
-            from sgl_jax.srt.models.dspark_head import VanillaMarkovHead
-
-            self.markov_head = VanillaMarkovHead(
-                vocab_size=int(config.vocab_size),
-                markov_rank=self.markov_rank,
-                mesh=mesh,
-                dtype=dtype,
-            )
-        else:
-            self.markov_head = None
         self.model = DFlashBackbone(config=config, mesh=mesh, dtype=dtype)
 
         hidden_size = int(config.hidden_size)
@@ -410,26 +394,21 @@ class DFlashDraftModel(nnx.Module):
         output = LogitsProcessorOutput(next_token_logits=None, hidden_states=hidden_states)
         return output, {"token_to_kv_pool": layers_kv_fused}, [], None
 
+    def sample_block_tokens(
+        self, base_logits: jax.Array, first_prev_tokens: jax.Array
+    ) -> jax.Array:
+        return jnp.argmax(base_logits, axis=-1).astype(jnp.int32)
+
     def load_weights(self, model_config: ModelConfig) -> None:
+        if int(getattr(self.config, "markov_rank", 0)) > 0:
+            raise ValueError("Markov checkpoints require --speculative-algorithm DSPARK.")
         loader = WeightLoader(
             model=self,
             model_config=model_config,
             mesh=self.mesh,
             dtype=self.dtype,
         )
-        mappings = self._create_weight_mappings()
-        if self.markov_head is not None and not loader.dummy_mode:
-            keys = set(loader._scan_weight_info())
-            missing = set(mappings) - keys
-            if missing:
-                raise ValueError(
-                    f"DSpark checkpoint is missing required weights: {sorted(missing)}."
-                )
-            if any(key.startswith("confidence_head.") for key in keys):
-                logger.info(
-                    "DSpark stage1 ignores confidence head weights; verifies all proposals."
-                )
-        loader.load_weights_from_safetensors(mappings)
+        loader.load_weights_from_safetensors(self._create_weight_mappings())
         logger.info("DFlash draft weights loaded successfully.")
 
     def _create_weight_mappings(self) -> dict[str, WeightMapping]:
@@ -529,21 +508,6 @@ class DFlashDraftModel(nnx.Module):
                     transpose=False,
                 )
 
-        if int(getattr(self.config, "markov_rank", 0)) > 0:
-            mappings.update(
-                {
-                    "markov_head.markov_w1.weight": WeightMapping(
-                        target_path="markov_head.markov_w1",
-                        sharding=(None, None),
-                        transpose=False,
-                    ),
-                    "markov_head.markov_w2.weight": WeightMapping(
-                        target_path="markov_head.markov_w2.weight",
-                        sharding=(None, "tensor"),
-                        transpose=True,
-                    ),
-                }
-            )
         return mappings
 
 

--- a/python/sgl_jax/srt/models/dspark.py
+++ b/python/sgl_jax/srt/models/dspark.py
@@ -7,6 +7,8 @@ from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.layers.linear import LinearBase
+from sgl_jax.srt.models.dflash import DFlashDraftModel
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
 
 
 class VanillaMarkovHead(nnx.Module):
@@ -71,3 +73,62 @@ class VanillaMarkovHead(nnx.Module):
             prev_tokens = jnp.argmax(logits, axis=-1).astype(jnp.int32)
             tokens.append(prev_tokens)
         return jnp.stack(tokens, axis=1)
+
+
+class DSparkDraftModel(DFlashDraftModel):
+    """DSpark stage1: DFlash backbone with a token-conditioned Markov head."""
+
+    def __init__(self, config, mesh, dtype=jnp.bfloat16):
+        rank = int(getattr(config, "markov_rank", 0))
+        if rank <= 0 or getattr(config, "markov_head_type", None) != "vanilla":
+            raise ValueError("DSPARK stage1 requires markov_rank > 0 and a vanilla Markov head.")
+        super().__init__(config=config, mesh=mesh, dtype=dtype)
+        self.markov_head = VanillaMarkovHead(
+            vocab_size=int(config.vocab_size), markov_rank=rank, mesh=mesh, dtype=dtype
+        )
+
+    def sample_block_tokens(self, base_logits, first_prev_tokens):
+        return self.markov_head.sample_block_tokens(base_logits, first_prev_tokens)
+
+    def _create_weight_mappings(self):
+        mappings = DFlashDraftModel._create_weight_mappings(self)
+        mappings.update(
+            {
+                "markov_head.markov_w1.weight": WeightMapping(
+                    target_path="markov_head.markov_w1", sharding=(None, None), transpose=False
+                ),
+                "markov_head.markov_w2.weight": WeightMapping(
+                    target_path="markov_head.markov_w2.weight",
+                    sharding=(None, "tensor"),
+                    transpose=True,
+                ),
+            }
+        )
+        return mappings
+
+    def load_weights(self, model_config):
+        import logging
+
+        loader = WeightLoader(
+            model=self, model_config=model_config, mesh=self.mesh, dtype=self.dtype
+        )
+        mappings = self._create_weight_mappings()
+        if not loader.dummy_mode:
+            keys = set(loader._scan_weight_info())
+            missing = set(mappings) - keys
+            if missing:
+                raise ValueError(
+                    f"DSPARK checkpoint is missing required weights: {sorted(missing)}."
+                )
+            if any(key.startswith("confidence_head.") for key in keys):
+                logging.getLogger(__name__).info(
+                    "DSPARK stage1 ignores confidence head weights; verifies all proposals."
+                )
+        loader.load_weights_from_safetensors(mappings)
+
+
+class Qwen3DSparkModel(DSparkDraftModel):
+    pass
+
+
+EntryClass = Qwen3DSparkModel

--- a/python/sgl_jax/srt/models/dspark_head.py
+++ b/python/sgl_jax/srt/models/dspark_head.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.layers.linear import LinearBase
+
+
+class VanillaMarkovHead(nnx.Module):
+    """Low-rank token-to-token correction used by DSpark stage1."""
+
+    def __init__(
+        self,
+        *,
+        vocab_size: int,
+        markov_rank: int,
+        mesh: jax.sharding.Mesh,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ) -> None:
+        if int(markov_rank) <= 0:
+            raise ValueError(f"VanillaMarkovHead requires markov_rank > 0, got {markov_rank}.")
+        self.vocab_size = int(vocab_size)
+        self.markov_rank = int(markov_rank)
+        self.mesh = mesh
+        self.markov_w1 = nnx.Param(
+            jax.random.normal(
+                jax.random.PRNGKey(0),
+                (self.vocab_size, self.markov_rank),
+                dtype=dtype,
+                out_sharding=P(None, None),
+            )
+        )
+        self.markov_w2 = LinearBase(
+            input_size=self.markov_rank,
+            output_size=self.vocab_size,
+            use_bias=False,
+            kernel_axes=(None, "tensor"),
+            params_dtype=dtype,
+            mesh=mesh,
+            scope_name="markov_w2",
+        )
+
+    def get_prev_embeddings(self, token_ids: jax.Array) -> jax.Array:
+        sharding = NamedSharding(self.mesh, P("data", None))
+        return self.markov_w1.value.at[token_ids.astype(jnp.int32)].get(out_sharding=sharding)
+
+    def apply_step_logits(
+        self,
+        base_logits: jax.Array,
+        token_ids: jax.Array,
+    ) -> tuple[jax.Array, jax.Array]:
+        markov_embedding = self.get_prev_embeddings(token_ids)
+        bias, _ = self.markov_w2(markov_embedding)
+        return base_logits + bias, markov_embedding
+
+    def sample_block_tokens(
+        self, base_logits: jax.Array, first_prev_tokens: jax.Array
+    ) -> jax.Array:
+        """Greedily sample each correction using the preceding sampled token."""
+        if base_logits.ndim != 3 or base_logits.shape[-1] != self.vocab_size:
+            raise ValueError("Markov logits must have shape [batch, proposals, vocab_size].")
+        if first_prev_tokens.shape != base_logits.shape[:1]:
+            raise ValueError("Markov seed tokens must have shape [batch].")
+        prev_tokens = first_prev_tokens.astype(jnp.int32)
+        tokens = []
+        for step in range(base_logits.shape[1]):
+            logits, _ = self.apply_step_logits(base_logits[:, step, :], prev_tokens)
+            prev_tokens = jnp.argmax(logits, axis=-1).astype(jnp.int32)
+            tokens.append(prev_tokens)
+        return jnp.stack(tokens, axis=1)

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -2035,7 +2035,8 @@ class ServerArgs:
         if self.speculative_algorithm == "DSPARK":
             self.speculative_sample_from_anchor = True
         if self.speculative_sample_from_anchor and self.speculative_algorithm not in (
-            "DFLASH", "DSPARK"
+            "DFLASH",
+            "DSPARK",
         ):
             raise ValueError(
                 "--speculative-sample-from-anchor requires --speculative-algorithm DFLASH or DSPARK."

--- a/python/sgl_jax/srt/server_args.py
+++ b/python/sgl_jax/srt/server_args.py
@@ -1584,7 +1584,7 @@ class ServerArgs:
         parser.add_argument(
             "--speculative-algorithm",
             type=str,
-            choices=["EAGLE", "EAGLE3", "NEXTN", "STANDALONE", "DFLASH"],
+            choices=["EAGLE", "EAGLE3", "NEXTN", "STANDALONE", "DFLASH", "DSPARK"],
             help="Speculative algorithm.",
             default=ServerArgs.speculative_algorithm,
         )
@@ -1625,7 +1625,7 @@ class ServerArgs:
             "--speculative-sample-from-anchor",
             action="store_true",
             help="Sample draft candidates starting at the anchor output position "
-            "(currently DFLASH only). "
+            "(DFLASH or DSPARK). "
             "Draft query length is --speculative-num-draft-tokens minus one; "
             "the latter remains the target verify length including the seed.",
         )
@@ -2023,22 +2023,26 @@ class ServerArgs:
                 and self.speculative_num_draft_tokens == self.speculative_num_steps + 1
                 and self.attention_backend == "fa"
             )
-            supports_dflash_overlap = self.speculative_algorithm == "DFLASH"
+            supports_dflash_overlap = self.speculative_algorithm in ("DFLASH", "DSPARK")
             if not (supports_nextn_overlap or supports_eagle3_overlap or supports_dflash_overlap):
                 raise ValueError(
-                    "Speculative overlap scheduler only supports DFLASH, EAGLE3+FA, "
+                    "Speculative overlap scheduler only supports DFLASH/DSPARK, EAGLE3+FA, "
                     "or NEXTN with --speculative-eagle-topk=1 and "
                     "--speculative-num-draft-tokens == --speculative-num-steps + 1. "
                     "Please pass --disable-overlap-schedule for other speculative configs."
                 )
 
-        if self.speculative_sample_from_anchor and self.speculative_algorithm != "DFLASH":
+        if self.speculative_algorithm == "DSPARK":
+            self.speculative_sample_from_anchor = True
+        if self.speculative_sample_from_anchor and self.speculative_algorithm not in (
+            "DFLASH", "DSPARK"
+        ):
             raise ValueError(
-                "--speculative-sample-from-anchor requires --speculative-algorithm DFLASH."
+                "--speculative-sample-from-anchor requires --speculative-algorithm DFLASH or DSPARK."
             )
 
         # DFLASH: non-causal one-shot diffusion draft + linear-chain greedy verify.
-        if self.speculative_algorithm == "DFLASH":
+        if self.speculative_algorithm in ("DFLASH", "DSPARK"):
             if self.tp_size < 1:
                 raise ValueError("DFLASH requires --tp-size>=1.")
             if self.speculative_eagle_topk != 1:

--- a/python/sgl_jax/srt/speculative/dflash_worker.py
+++ b/python/sgl_jax/srt/speculative/dflash_worker.py
@@ -86,6 +86,17 @@ class TargetVerifyPlan:
 class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
     """DFlash draft/verify runtime worker (greedy, DP/TP aware)."""
 
+    algorithm = SpeculativeAlgorithm.DFLASH
+
+    @staticmethod
+    def _draft_model_class():
+        from sgl_jax.srt.models.dflash import DFlashDraftModel
+
+        return DFlashDraftModel
+
+    def _validate_draft_model(self, draft_model):
+        pass
+
     def __init__(self, server_args, target_worker: ModelWorker):
         super().__init__(
             server_args,
@@ -102,25 +113,14 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         draft_server_args = copy.deepcopy(server_args)
         draft_server_args.skip_tokenizer_init = True
 
-        from sgl_jax.srt.models.dflash import DFlashDraftModel
-
         self._worker = ModelWorker(
             server_args=draft_server_args,
             mesh=self.mesh,
             req_to_token_pool=self.req_to_token_pool,
             is_draft_worker=True,
-            model_class=DFlashDraftModel,
+            model_class=self._draft_model_class(),
         )
         draft_model = self.draft_model_runner.model
-        if draft_model.markov_head is not None:
-            if not self.sample_from_anchor:
-                raise ValueError("DSpark Markov checkpoints require --dspark-sample-from-anchor.")
-            if self.draft_query_tokens != int(draft_model.config.block_size):
-                raise ValueError(
-                    "DSpark stage1 requires verify width = checkpoint block_size + 1."
-                )
-            logger.info("DSpark stage1: vanilla Markov head, rank=%d.", draft_model.markov_rank)
-
         # Alias the KV allocator so draft block allocation draws from the same
         # free list the target uses (no collision with committed slots).
         self.draft_model_runner.token_to_kv_pool_allocator = self.token_to_kv_pool_allocator
@@ -130,11 +130,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         self._target_lm_head = head_weight  # [vocab, hidden], for greedy head sampling
         self._target_embed = embed_weight  # [vocab, hidden]
         self._target_vocab_size = int(target_worker.model_runner.model_config.vocab_size)
-        if (
-            draft_model.markov_head is not None
-            and draft_model.markov_head.vocab_size != self._target_vocab_size
-        ):
-            raise ValueError("DSpark Markov head and target must have the same vocabulary size.")
+        self._validate_draft_model(draft_model)
 
         pool_pages = (
             int(target_worker.max_total_num_tokens) + self.page_size - 1
@@ -175,10 +171,11 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         self._init_jit_draft_block()
 
         logger.info(
-            "Initialized DFLASH worker: verify_tokens=%d, draft_query_tokens=%d, "
+            "Initialized %s worker: verify_tokens=%d, draft_query_tokens=%d, "
             "sample_from_anchor=%s, mask_token_id=%d, "
             "draft_layers=%d, page_indices_pool_capacity=%d, "
             "page_indices_per_seq_capacity=%d",
+            self.algorithm.name,
             self.block_size,
             self.draft_query_tokens,
             self.sample_from_anchor,
@@ -688,7 +685,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         mwb.positions = np.asarray(positions_flat, dtype=np.int32)
         mwb.seq_lens = np.asarray(prefix_lens, dtype=np.int32)
         mwb.capture_hidden_mode = CaptureHiddenMode.NULL
-        mwb.spec_algorithm = SpeculativeAlgorithm.DFLASH
+        mwb.spec_algorithm = self.algorithm
         mwb.spec_info_padded = DFlashVerifyInput(
             draft_token=block_ids_flat,
             draft_token_num=self.block_size,
@@ -859,12 +856,8 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
                 lm_head.T,
                 out_sharding=logits_sharding,
             )[:, :vocab_size]
-            if model.markov_head is None:
-                draft_next = jnp.argmax(logits, axis=-1).astype(jnp.int32)
-                draft_next = draft_next.reshape(proposal_hidden.shape[:-1])
-            else:
-                base_logits = logits.reshape((*proposal_hidden.shape[:-1], vocab_size))
-                draft_next = model.markov_head.sample_block_tokens(base_logits, seed[:, 0])
+            base_logits = logits.reshape((*proposal_hidden.shape[:-1], vocab_size))
+            draft_next = model.sample_block_tokens(base_logits, seed[:, 0])
             seed = jax.sharding.reshard(seed, cache_row_sharding)
             draft_next = jax.sharding.reshard(draft_next, cache_row_sharding)
             draft_token = jnp.concatenate([seed, draft_next], axis=1).reshape(-1)
@@ -1584,7 +1577,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
                 num_tokens,
                 ForwardMode.EXTEND,
                 manager.cache_loc_buckets[-1],
-                speculative_algorithm=SpeculativeAlgorithm.DFLASH,
+                speculative_algorithm=self.algorithm,
                 dp_size=manager.dp_size,
                 per_dp_bs_size=bs // manager.dp_size,
             )
@@ -1776,7 +1769,7 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             num_tokens,
             ForwardMode.TARGET_VERIFY,
             bs * row_width,
-            speculative_algorithm=SpeculativeAlgorithm.DFLASH,
+            speculative_algorithm=self.algorithm,
             dp_size=dp_size,
             per_dp_bs_size=per_dp_bs,
         )

--- a/python/sgl_jax/srt/speculative/dflash_worker.py
+++ b/python/sgl_jax/srt/speculative/dflash_worker.py
@@ -112,6 +112,14 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
             model_class=DFlashDraftModel,
         )
         draft_model = self.draft_model_runner.model
+        if draft_model.markov_head is not None:
+            if not self.sample_from_anchor:
+                raise ValueError("DSpark Markov checkpoints require --dspark-sample-from-anchor.")
+            if self.draft_query_tokens != int(draft_model.config.block_size):
+                raise ValueError(
+                    "DSpark stage1 requires verify width = checkpoint block_size + 1."
+                )
+            logger.info("DSpark stage1: vanilla Markov head, rank=%d.", draft_model.markov_rank)
 
         # Alias the KV allocator so draft block allocation draws from the same
         # free list the target uses (no collision with committed slots).
@@ -122,6 +130,11 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
         self._target_lm_head = head_weight  # [vocab, hidden], for greedy head sampling
         self._target_embed = embed_weight  # [vocab, hidden]
         self._target_vocab_size = int(target_worker.model_runner.model_config.vocab_size)
+        if (
+            draft_model.markov_head is not None
+            and draft_model.markov_head.vocab_size != self._target_vocab_size
+        ):
+            raise ValueError("DSpark Markov head and target must have the same vocabulary size.")
 
         pool_pages = (
             int(target_worker.max_total_num_tokens) + self.page_size - 1
@@ -846,8 +859,12 @@ class DFlashWorker(BaseSpecWorker, BaseDraftWorker):
                 lm_head.T,
                 out_sharding=logits_sharding,
             )[:, :vocab_size]
-            draft_next = jnp.argmax(logits, axis=-1).astype(jnp.int32)
-            draft_next = draft_next.reshape(proposal_hidden.shape[:-1])
+            if model.markov_head is None:
+                draft_next = jnp.argmax(logits, axis=-1).astype(jnp.int32)
+                draft_next = draft_next.reshape(proposal_hidden.shape[:-1])
+            else:
+                base_logits = logits.reshape((*proposal_hidden.shape[:-1], vocab_size))
+                draft_next = model.markov_head.sample_block_tokens(base_logits, seed[:, 0])
             seed = jax.sharding.reshard(seed, cache_row_sharding)
             draft_next = jax.sharding.reshard(draft_next, cache_row_sharding)
             draft_token = jnp.concatenate([seed, draft_next], axis=1).reshape(-1)

--- a/python/sgl_jax/srt/speculative/dspark_worker.py
+++ b/python/sgl_jax/srt/speculative/dspark_worker.py
@@ -1,0 +1,22 @@
+from sgl_jax.srt.speculative.dflash_worker import DFlashWorker
+from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+
+
+class DSparkWorker(DFlashWorker):
+    """DSpark Markov drafting with fixed-width target verification."""
+
+    algorithm = SpeculativeAlgorithm.DSPARK
+
+    @staticmethod
+    def _draft_model_class():
+        from sgl_jax.srt.models.dspark import DSparkDraftModel
+
+        return DSparkDraftModel
+
+    def _validate_draft_model(self, draft_model):
+        if not self.sample_from_anchor:
+            raise ValueError("DSPARK requires sampling from the anchor position.")
+        if self.draft_query_tokens != int(draft_model.config.block_size):
+            raise ValueError("DSPARK requires verify width = checkpoint block_size + 1.")
+        if draft_model.markov_head.vocab_size != self._target_vocab_size:
+            raise ValueError("DSPARK draft and target must have the same vocabulary size.")

--- a/python/sgl_jax/srt/speculative/overlap_utils.py
+++ b/python/sgl_jax/srt/speculative/overlap_utils.py
@@ -80,7 +80,7 @@ def can_merge_spec_non_overlap_prefill(enable_overlap, spec_algorithm) -> bool:
         not enable_overlap
         and spec_algorithm is not None
         and not spec_algorithm.is_none()
-        and (spec_algorithm.is_eagle3() or spec_algorithm.is_dflash())
+        and (spec_algorithm.is_eagle3() or spec_algorithm.is_block_draft())
     )
 
 

--- a/python/sgl_jax/srt/speculative/overlap_utils.py
+++ b/python/sgl_jax/srt/speculative/overlap_utils.py
@@ -80,7 +80,7 @@ def can_merge_spec_non_overlap_prefill(enable_overlap, spec_algorithm) -> bool:
         not enable_overlap
         and spec_algorithm is not None
         and not spec_algorithm.is_none()
-        and (spec_algorithm.is_eagle3() or spec_algorithm.is_block_draft())
+        and (spec_algorithm.is_eagle3() or spec_algorithm.is_dflash_family())
     )
 
 

--- a/python/sgl_jax/srt/speculative/spec_info.py
+++ b/python/sgl_jax/srt/speculative/spec_info.py
@@ -62,6 +62,7 @@ class SpeculativeAlgorithm(IntEnum):
     NEXTN = auto()
     STANDALONE = auto()
     DFLASH = auto()
+    DSPARK = auto()
 
     def is_none(self):
         return self == SpeculativeAlgorithm.NONE
@@ -85,6 +86,12 @@ class SpeculativeAlgorithm(IntEnum):
     def is_dflash(self):
         return self == SpeculativeAlgorithm.DFLASH
 
+    def is_dspark(self):
+        return self == SpeculativeAlgorithm.DSPARK
+
+    def is_block_draft(self):
+        return self.is_dflash() or self.is_dspark()
+
     @staticmethod
     def from_string(name: str):
         name_map = {
@@ -93,6 +100,7 @@ class SpeculativeAlgorithm(IntEnum):
             "NEXTN": SpeculativeAlgorithm.NEXTN,
             "STANDALONE": SpeculativeAlgorithm.STANDALONE,
             "DFLASH": SpeculativeAlgorithm.DFLASH,
+            "DSPARK": SpeculativeAlgorithm.DSPARK,
             None: SpeculativeAlgorithm.NONE,
         }
         if name is not None:

--- a/python/sgl_jax/srt/speculative/spec_info.py
+++ b/python/sgl_jax/srt/speculative/spec_info.py
@@ -89,7 +89,7 @@ class SpeculativeAlgorithm(IntEnum):
     def is_dspark(self):
         return self == SpeculativeAlgorithm.DSPARK
 
-    def is_block_draft(self):
+    def is_dflash_family(self):
         return self.is_dflash() or self.is_dspark()
 
     @staticmethod


### PR DESCRIPTION
## Benchmark

- **Hardware:** TPU v7x-8; TP8×DP1 and TP4×DP2.
- **Target:** `Qwen/Qwen3-8B`
- **Draft:** `deepseek-ai/dspark_qwen3_8b_block7`
- **Serving:** Overlap enabled, BF16, FA, memory fraction `0.65`, page size `64`, chunked prefill `2048`, maximum running requests `128`, radix cache disabled.

### Speed Benchmark

Dataset: `random`; input/output lengths: **1024/4096 tokens**; range ratio: `1.0`; requests: **3×concurrency**; request rate: `inf`. Recorded cache hit rate: **0**.

Output throughput in **tokens/s**:

| Concurrency | TP8×DP1 Baseline | TP8×DP1 DSpark | Speedup | TP4×DP2 Baseline | TP4×DP2 DSpark | Speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 106.8 | 537.2 | 5.03× | 102.5 | 519.1 | 5.06× |
| 2 | 211.2 | 1,022.9 | 4.84× | 204.0 | 874.2 | 4.28× |
| 4 | 412.4 | 1,964.5 | 4.76× | 404.1 | 1,958.3 | 4.85× |
| 8 | 810.1 | 3,222.6 | 3.98× | 793.3 | 3,283.1 | 4.14× |
| 16 | 1,505.7 | 6,506.9 | 4.32× | 1,559.3 | 7,754.5 | 4.97× |
| 32 | 2,838.1 | 9,682.3 | 3.41× | 2,945.0 | 10,544.8 | 3.58× |
| 64| 3,829.9 | 12,185.0 | 3.18× | 4,517.5 | 15,134.9 | 3.35× |
| 128| 4,365.9 | 13,899.2 | 3.18× | 5,577.7 | 17,656.4 | 3.17× |

### Accuracy Benchmark

- **Dataset:** GSM8K, 500 samples, using DeepSpec’s data selection and prompt format.
- **Seed:** `980406`
- **Generation:** Temperature `0`, thinking disabled, maximum output `2048` tokens, concurrency `16`.
- **Scoring:** Custom numeric exact match with answer-format normalization.
- This differs from the paper’s **temperature=1** evaluation protocol.

| Configuration | Baseline Accuracy | DSpark Accuracy | DSpark Acceptance Length |
|---|---:|---:|---:|
| TP8×DP1 | 92.8% (464/500) | 93.2% (466/500) | 5.488 |
| TP4×DP2 | 92.8% (464/500) | 93.0% (465/500) | 5.473 |

## Repro

Use `feat/dspark-stage1` at commit `0d0271d0f76376d09bf4b12f663240a7f4e8c989`

Launch each configuration on TPU v7x-8:

```bash
DP=1         # 1 or 2
MODE=dspark  # dspark or baseline

SPEC_ARGS=()
if [[ "$MODE" == "dspark" ]]; then
  SPEC_ARGS=(
    --speculative-algorithm DSPARK
    --speculative-draft-model-path deepseek-ai/dspark_qwen3_8b_block7
    --speculative-num-draft-tokens 8
    --speculative-num-steps 1
    --speculative-eagle-topk 1
  )
fi

python -m sgl_jax.launch_server \
  --model-path Qwen/Qwen3-8B \
  "${SPEC_ARGS[@]}" \
  --tp-size 8 \
  --dp-size "$DP" \
  --dtype bfloat16 \
  --attention-backend fa \
  --mem-fraction-static 0.65 \
  --page-size 64 \
  --chunked-prefill-size 2048 \
  --max-running-requests 128 \
  --trust-remote-code \
  --disable-radix-cache \
  --grammar-backend none \
  --random-seed 980406 \
  --host 0.0.0.0 \
  --port 30000
```

On this branch, `--tp-size` specifies the total mesh size: `8/1` produces TP8×DP1, while `8/2` produces TP4×DP2. Overlap remains enabled by default, and `DSPARK` automatically enables sampling from the anchor.

After the server becomes ready, run the speed benchmark:

```bash
for C in 1 2 4 8 16 32 64 128; do
  OUT="results/dp${DP}/${MODE}/bs_${C}"
  mkdir -p "$OUT"

  python -m sgl_jax.bench_serving \
    --backend sgl-jax \
    --host 127.0.0.1 \
    --port 30000 \
    --dataset-name random \
    --random-input-len 1024 \
    --random-output-len 4096 \
    --random-range-ratio 1.0 \
    --num-prompts "$((3 * C))" \
    --max-concurrency "$C" \
    --request-rate inf \
    --seed 980406 \
    --output-file "$OUT/result.jsonl"
done
```

For GSM8K, shuffle the official test split with `random.Random(980406)` and select the first 500 samples. Apply the Qwen3 chat template with `enable_thinking=False`, appending:

```text
Please reason step by step, and put your final answer within \boxed{}.
```

Send requests to `/generate` with temperature `0`, `max_new_tokens=2048`, and concurrency `16`. Score the final boxed numeric answer against the GSM8K gold answer using the same formatting normalization for all configurations. Measure acceptance length from the difference in server acceptance counters before and after evaluation.

This accuracy procedure uses DeepSpec’s data selection and prompt format, but differs from the paper’s temperature-1 sampling protocol.
