### PR TITLE
perf(grouped-topk): skip group selection when every group is retained

### DIFF
--- a/python/sgl_jax/srt/kernels/grouped_topk/v1/kernel.py
+++ b/python/sgl_jax/srt/kernels/grouped_topk/v1/kernel.py
@@ -80,34 +80,39 @@ def _grouped_topk_kernel(
     with jax.named_scope("bias_add"):
         scores = logits + bias_ref[...][:, None]  # [E, BT] post-bias
 
-    # ① group score = sum of top-2 within each group, via 2-pass max (no sort). argmax tie-break is
-    #    irrelevant here — the top-2 sum is identical whichever of two equal maxima is masked first.
-    with jax.named_scope("group_top2"):
-        sg = jnp.reshape(scores, (n_group, S, bt))  # [G, S, BT]
-        v1 = jnp.max(sg, axis=1, keepdims=True)
-        i1 = jnp.argmax(sg, axis=1, keepdims=True)
-        s_iota = jax.lax.broadcasted_iota(jnp.int32, (n_group, S, bt), 1)
-        v2 = jnp.max(jnp.where(s_iota == i1, NEG_INF, sg), axis=1, keepdims=True)
-        group_scores = jnp.squeeze(v1 + v2, axis=1)  # [G, BT]
+    # Selecting every group retains every expert; group scores cannot affect
+    # the expert set. Keep the original selection when groups are dropped.
+    if topk_group == n_group:
+        masked = scores
+    else:
+        # ① group score = sum of top-2 within each group, via 2-pass max (no sort). argmax tie-break is
+        #    irrelevant here — the top-2 sum is identical whichever of two equal maxima is masked first.
+        with jax.named_scope("group_top2"):
+            sg = jnp.reshape(scores, (n_group, S, bt))  # [G, S, BT]
+            v1 = jnp.max(sg, axis=1, keepdims=True)
+            i1 = jnp.argmax(sg, axis=1, keepdims=True)
+            s_iota = jax.lax.broadcasted_iota(jnp.int32, (n_group, S, bt), 1)
+            v2 = jnp.max(jnp.where(s_iota == i1, NEG_INF, sg), axis=1, keepdims=True)
+            group_scores = jnp.squeeze(v1 + v2, axis=1)  # [G, BT]
 
-    # ② select `topk_group` groups, lowest-index tie-break (max + masked-min).
-    with jax.named_scope("group_select"):
-        group_mask = jnp.zeros((n_group, bt), dtype=jnp.bool_)
-        g_iota = jax.lax.broadcasted_iota(jnp.int32, (n_group, bt), 0)
-        tmp = group_scores
-        for _ in range(topk_group):
-            gmax = jnp.max(tmp, axis=0, keepdims=True)
-            gi = jnp.min(jnp.where(tmp == gmax, g_iota, n_group), axis=0, keepdims=True)
-            m = g_iota == gi
-            group_mask = jnp.logical_or(group_mask, m)
-            tmp = jnp.where(m, NEG_INF, tmp)
+        # ② select `topk_group` groups, lowest-index tie-break (max + masked-min).
+        with jax.named_scope("group_select"):
+            group_mask = jnp.zeros((n_group, bt), dtype=jnp.bool_)
+            g_iota = jax.lax.broadcasted_iota(jnp.int32, (n_group, bt), 0)
+            tmp = group_scores
+            for _ in range(topk_group):
+                gmax = jnp.max(tmp, axis=0, keepdims=True)
+                gi = jnp.min(jnp.where(tmp == gmax, g_iota, n_group), axis=0, keepdims=True)
+                m = g_iota == gi
+                group_mask = jnp.logical_or(group_mask, m)
+                tmp = jnp.where(m, NEG_INF, tmp)
 
-    # ③ mask experts in dropped groups -> -inf. Applied ONCE (loop-invariant) before the pick loop.
-    with jax.named_scope("expert_mask"):
-        masked = jnp.reshape(
-            jnp.where(group_mask[:, None, :], jnp.reshape(scores, (n_group, S, bt)), NEG_INF),
-            (E, bt),
-        )  # [E, BT]
+        # ③ mask experts in dropped groups -> -inf. Applied ONCE (loop-invariant) before the pick loop.
+        with jax.named_scope("expert_mask"):
+            masked = jnp.reshape(
+                jnp.where(group_mask[:, None, :], jnp.reshape(scores, (n_group, S, bt)), NEG_INF),
+                (E, bt),
+            )  # [E, BT]
 
     # ④ select `topk` experts, lowest-index tie-break; weight = PRE-bias logit at the winner. A
     #    fori_loop carries the [E,BT] working array and writes each pick into ROW k of the [topk,BT]

--- a/python/sgl_jax/test/kernels/grouped_topk_test.py
+++ b/python/sgl_jax/test/kernels/grouped_topk_test.py
@@ -76,6 +76,8 @@ CONFIGS = [
     (256, 8, 4, 8, "A_E256_G8_Gtop4_k8"),  # sgl-jax DeepSeek-V3 / Ling
     (512, 8, 4, 8, "B_E512_G8_Gtop4_k8"),  # MaxText
     (128, 4, 2, 6, "small_E128_G4_Gtop2_k6"),
+    (896, 1, 1, 16, "all_E896_G1_Gtop1_k16"),
+    (128, 4, 4, 8, "all_E128_G4_Gtop4_k8"),
 ]
 BATCHES = [256, 512, 1024]
 
@@ -207,6 +209,33 @@ def test_matches_ref_on_flat_ties():
     )
     np.testing.assert_array_equal(np.array(ids_pal), np.array(ids_ref))
     np.testing.assert_allclose(np.array(w_pal), np.array(w_ref), rtol=0, atol=1e-6)
+
+
+@pytest.mark.parametrize("groups", [1, 4])
+@pytest.mark.parametrize("packed", [False, True])
+@pytest.mark.parametrize("flat", [False, True])
+def test_all_groups_preserves_exact_weights_and_tie_breaking(groups, packed, flat):
+    experts, tokens, topk = 128, 128, 8
+    values = jnp.full((experts,), 0.5) if flat else (jnp.arange(experts) % 17) / 32.0
+    logits = jnp.broadcast_to(values, (tokens, experts)).astype(jnp.float32)
+    bias = jnp.zeros((experts,), dtype=jnp.float32)
+    if packed:
+        logits, bias = logits.astype(jnp.bfloat16), bias.astype(jnp.bfloat16)
+    reference = ref_biased_grouped_topk_bf16 if packed else ref_biased_grouped_topk
+    expected_weights, expected_ids = reference(
+        logits, bias, num_expert_group=groups, topk_group=groups, topk=topk
+    )
+    weights, ids = grouped_topk_pallas(
+        logits,
+        bias,
+        num_expert_group=groups,
+        topk_group=groups,
+        topk=topk,
+        packed=packed,
+        interpret=True,
+    )
+    np.testing.assert_array_equal(np.array(ids), np.array(expected_ids))
+    np.testing.assert_array_equal(np.array(weights), np.array(expected_weights))
 
 
 # --- bf16 packed-key final-select path (packed=True; caller enables it when logits are bf16) -------


### PR DESCRIPTION
## Motivation

Grouped top-k computes group scores, ranks groups, and masks experts even when `topk_group == num_expert_group`. In that configuration every group is retained, so those operations are unnecessary. Skip them and pass the post-bias scores directly to the existing expert selector.

## Modifications

- Specialize the kernel on `topk_group == n_group`; retain the existing implementation when groups are dropped.
- Preserve expert ranking, pre-bias output weights, and lowest-index ties in the FP32 and packed BF16 selection paths.
- Add all-groups configurations and exact weight/ID regression checks for one or multiple groups and flat/repeated scores.

The guard is independent of token count. This is an independent change based on upstream `main` at `ddadf777972b761d494034822057e1b85c57d8c9`.

## Accuracy Tests

```bash
JAX_PLATFORMS=cpu PYTHONPATH=python python -m pytest -q -rs \
  python/sgl_jax/test/kernels/grouped_topk_test.py
pre-commit run --files python/sgl_jax/srt/kernels/grouped_topk/v1/kernel.py \
  python/sgl_jax/test/kernels/grouped_topk_test.py --show-diff-on-failure
```

On this upstream port with JAX 0.11.1: **35 passed, 19 skipped**. Skips comprise 18 TPU-only packed-path cases and one optional model-stack import. All applicable pre-commit checks passed, including mypy.

The captured FP32 TPU7x workload passed exact weight/ID comparisons, native ISS validation, and source/LLO reproduction in all three hardware repetitions.

## Benchmarking and Profiling

**These measurements were collected on the captured revision, not by rerunning this upstream port.** The kernel file is byte-identical to the measured candidate. The upstream baseline kernel also matches the captured baseline kernel.

| 512-token TPU7x router | Device span (microseconds) |
| --- | ---: |
| Saved baseline | 18.302596 |
| Candidate repetition 1 | 17.298920 |
| Candidate repetition 2 | 17.283314 |
| Candidate repetition 3 | 17.374475 |

The three separate candidate measurements are **5.07–5.57% lower** than one retained baseline span. Native ISS cycles, including common input setup, decreased **93,227 → 91,122**. Static `vmax.8x128.f32` sites decreased **8,208 → 7,296** and `vsel.8x128` sites **22,501 → 20,844**; these counts are not dynamic execution counts.

Measured source: [baseline 027fa79](https://github.com/JianmingTONG/sglang-jax/commit/027fa79a6498a1afef5a36c4e093c07d2f12f1ef) → [candidate c46250c](https://github.com/JianmingTONG/sglang-jax/commit/c46250c234710b94deeef302347ad37e5e3c3158). HierEvo candidate: `008-e3ec0d5019bc4af9`.

Host latency did not improve. The result does not establish model serving gains, performance on other shapes/devices, or gains from combining this patch with other router changes.

## Checklist

- [x] English description and motivation.
- [x] Implementation scope and correctness guards documented.
- [x] Test commands and results provided.
- [x] Captured performance evidence and measurement limits stated.
