### PR TITLE
perf(grouped-topk): use exact FP32 priorities for stable index reductions

### DIFF
--- a/python/sgl_jax/srt/kernels/grouped_topk/v1/kernel.py
+++ b/python/sgl_jax/srt/kernels/grouped_topk/v1/kernel.py
@@ -20,8 +20,8 @@ Renormalize / routed_scaling_factor are applied by the caller (`TopK.__call__`).
 
 Tie-break: selection uses `max` + masked `min(iota)` (smallest index achieving the max) rather than
 `argmax`, because TPU Mosaic's reduction argmax does not break ties toward the lowest index.
-The final f32 path implements the index minimum with exact reversed f32 priorities when possible,
-allowing that reduction to use native floating-point max instructions.
+The unpacked group and expert selections implement the index minimum with exact reversed f32
+priorities when possible, allowing those reductions to use native floating-point max instructions.
 """
 
 from __future__ import annotations
@@ -92,14 +92,24 @@ def _grouped_topk_kernel(
         v2 = jnp.max(jnp.where(s_iota == i1, NEG_INF, sg), axis=1, keepdims=True)
         group_scores = jnp.squeeze(v1 + v2, axis=1)  # [G, BT]
 
-    # ② select `topk_group` groups, lowest-index tie-break (max + masked-min).
+    # ② select `topk_group` groups, lowest-index tie-break.
     with jax.named_scope("group_select"):
         group_mask = jnp.zeros((n_group, bt), dtype=jnp.bool_)
         g_iota = jax.lax.broadcasted_iota(jnp.int32, (n_group, bt), 0)
+        use_float_group_priority = not packed and n_group <= (1 << 24)
+        if use_float_group_priority:
+            # Exact reversed priorities preserve ties and the no-match sentinel.
+            group_priority = (n_group - g_iota).astype(jnp.float32)
         tmp = group_scores
         for _ in range(topk_group):
             gmax = jnp.max(tmp, axis=0, keepdims=True)
-            gi = jnp.min(jnp.where(tmp == gmax, g_iota, n_group), axis=0, keepdims=True)
+            if use_float_group_priority:
+                max_priority = jnp.max(
+                    jnp.where(tmp == gmax, group_priority, 0.0), axis=0, keepdims=True
+                )
+                gi = n_group - max_priority.astype(jnp.int32)
+            else:
+                gi = jnp.min(jnp.where(tmp == gmax, g_iota, n_group), axis=0, keepdims=True)
             m = g_iota == gi
             group_mask = jnp.logical_or(group_mask, m)
             tmp = jnp.where(m, NEG_INF, tmp)

--- a/python/sgl_jax/srt/kernels/grouped_topk/v1/kernel.py
+++ b/python/sgl_jax/srt/kernels/grouped_topk/v1/kernel.py
@@ -20,6 +20,8 @@ Renormalize / routed_scaling_factor are applied by the caller (`TopK.__call__`).
 
 Tie-break: selection uses `max` + masked `min(iota)` (smallest index achieving the max) rather than
 `argmax`, because TPU Mosaic's reduction argmax does not break ties toward the lowest index.
+The final f32 path implements the index minimum with exact reversed f32 priorities when possible,
+allowing that reduction to use native floating-point max instructions.
 """
 
 from __future__ import annotations
@@ -115,8 +117,9 @@ def _grouped_topk_kernel(
     #    small and static) so the picks overlap.
     #
     #    Two selection modes (compile-time `packed`):
-    #      packed=False — the f32 contract: `max` + masked-`min` finds the smallest expert id at the
-    #        max score, bit-exact to `lax.top_k` on the f32 scores.
+    #      packed=False — the f32 contract: `max` + stable index selection finds the smallest expert
+    #        id at the max score, bit-exact to `lax.top_k` on the f32 scores. Bounded ids use exact
+    #        reversed f32 priorities for the index reduction; scores are never rounded.
     #      packed=True  — the bf16 contract: bf16-round each score into an int32 order-preserving key
     #        (plain int order == (score DESC, index ASC)), so each pick is ONE reduction + a low-bit
     #        decode instead of the max+masked-min pair. Lossless for bf16 inputs (the low 16 mantissa
@@ -142,6 +145,12 @@ def _grouped_topk_kernel(
                 work0 = (key_score & clear_mask) | (E - 1 - e_iota)  # [E, BT] packed key
         else:
             work0 = masked  # [E, BT] f32 working scores
+            if E <= (1 << 24):
+                # All priorities 0..E are exact in f32. TPU lowers an integer min
+                # tree to compare/select pairs, while f32 max uses native vmax.
+                # Higher priority means lower expert id; zero is the no-match
+                # sentinel and decodes back to E, just like the masked min below.
+                index_priority = (E - e_iota).astype(jnp.float32)
 
         def _pick(k, carry):
             cur, ids_buf, w_buf = carry
@@ -150,9 +159,18 @@ def _grouped_topk_kernel(
                 idx = (E - 1) - (kmax & low_mask)  # [1, BT] lowest-index winner from the low bits
             else:
                 cmax = jnp.max(cur, axis=0, keepdims=True)
-                idx = jnp.min(
-                    jnp.where(cur == cmax, e_iota, E), axis=0, keepdims=True
-                )  # [1, BT] lowest expert id achieving the max
+                if E <= (1 << 24):
+                    max_priority = jnp.max(
+                        jnp.where(cur == cmax, index_priority, 0.0),
+                        axis=0,
+                        keepdims=True,
+                    )
+                    idx = E - max_priority.astype(jnp.int32)
+                else:
+                    # Keep integer selection when f32 cannot represent every id.
+                    idx = jnp.min(
+                        jnp.where(cur == cmax, e_iota, E), axis=0, keepdims=True
+                    )  # [1, BT] lowest expert id achieving the max
             sel = e_iota == idx  # [E, BT]
             # weight from PRE-bias logits via masked sum (gather is unsupported in Pallas/Mosaic).
             wval = jnp.sum(jnp.where(sel, logits, 0.0), axis=0, keepdims=True)  # [1, BT]

--- a/python/sgl_jax/test/kernels/grouped_topk_test.py
+++ b/python/sgl_jax/test/kernels/grouped_topk_test.py
@@ -210,6 +210,34 @@ def test_matches_ref_on_flat_ties():
     np.testing.assert_allclose(np.array(w_pal), np.array(w_ref), rtol=0, atol=1e-6)
 
 
+@pytest.mark.parametrize("topk_group", [1, 2, 3, 4])
+@pytest.mark.parametrize("block_tokens", [128, 256])
+def test_matches_ref_on_group_boundary_ties(topk_group, block_tokens):
+    """Tied group sums must keep the lowest group ids at the selection boundary."""
+    bs, E, G, k = 256, 256, 4, 4
+    # Group 2 wins outright; groups 0, 1 and 3 tie despite different expert scores.
+    scores = jnp.zeros((G, E // G), dtype=jnp.float32)
+    scores = scores.at[:, :2].set(
+        jnp.array([[0.875, 0.125], [0.625, 0.375], [0.75, 0.75], [0.9375, 0.0625]])
+    )
+    bias = jnp.arange(E, dtype=jnp.float32) / 1024
+    logits = jnp.broadcast_to(scores.reshape(E) - bias, (bs, E))
+    w_ref, ids_ref = ref_biased_grouped_topk(
+        logits, bias, num_expert_group=G, topk_group=topk_group, topk=k
+    )
+    w_pal, ids_pal = grouped_topk_pallas(
+        logits,
+        bias,
+        num_expert_group=G,
+        topk_group=topk_group,
+        topk=k,
+        block_tokens=block_tokens,
+        interpret=True,
+    )
+    np.testing.assert_array_equal(np.array(ids_pal), np.array(ids_ref))
+    np.testing.assert_array_equal(np.array(w_pal), np.array(w_ref))
+
+
 # --- bf16 packed-key final-select path (packed=True; caller enables it when logits are bf16) -------
 #
 # IMPORTANT: the packed path builds an int32 order key with bitcast_convert_type + bf16 rounding +

--- a/python/sgl_jax/test/kernels/grouped_topk_test.py
+++ b/python/sgl_jax/test/kernels/grouped_topk_test.py
@@ -73,6 +73,7 @@ def _logits(bs, e, seed):
 
 CONFIGS = [
     # (E, G, Gtop, k, name)
+    (896, 1, 1, 16, "router_E896_G1_Gtop1_k16"),
     (256, 8, 4, 8, "A_E256_G8_Gtop4_k8"),  # sgl-jax DeepSeek-V3 / Ling
     (512, 8, 4, 8, "B_E512_G8_Gtop4_k8"),  # MaxText
     (128, 4, 2, 6, "small_E128_G4_Gtop2_k6"),


### PR DESCRIPTION
## Motivation

The FP32 grouped top-k selector finds the lowest group or expert index matching the maximum score using an integer minimum reduction. On the measured TPU lowering, these index reductions generate compare/select work. Encode the indices as exact reversed FP32 priorities so the reductions can use floating-point maximum instructions while preserving stable selection.

## Modifications

- For unpacked group selection with `num_expert_group <= 2**24`, encode each group index `i` as `float32(num_expert_group - i)` and reduce matching priorities with `max`.
- Apply the same representation to unpacked expert selection with expert count `E <= 2**24`, using `float32(E - i)`.
- Decode only the winning priority back to an integer index. All priorities are exactly representable; zero preserves the existing no-match sentinel for each index domain.
- Retain integer reductions above each exact-representation bound and leave the packed BF16 path unchanged. Scores and output weights are not rounded.
- Add the captured 896-expert, one-group, top-16 configuration to the existing reference-comparison matrix at 256, 512, and 1,024 tokens.
- Add eight exact weight/ID comparisons for tied group scores at the retention boundary: retain one through four groups, with both one-block and two-block execution. Distinct pre-bias weights also check that selection gathers the correct weights.

This uses existing JAX/Pallas operations and preserves the public interface. The optimization is independent of token count and supports both all-groups and subset-of-groups routing. It introduces no workload-specific shape dispatch or tile configuration changes. The PR is based on upstream `main` at `ddadf777972b761d494034822057e1b85c57d8c9`; it is independent of the all-groups shortcut in #1633.

## Accuracy Tests

```bash
JAX_PLATFORMS=cpu PYTHONPATH=python python -m pytest -q -rs \
  python/sgl_jax/test/kernels/grouped_topk_test.py
pre-commit run --files python/sgl_jax/srt/kernels/grouped_topk/v1/kernel.py \
  python/sgl_jax/test/kernels/grouped_topk_test.py --show-diff-on-failure
```

On the complete upstream implementation with JAX 0.11.1: **33 passed, 15 skipped**. All skips are TPU-only packed-path cases; the real model-stack reference comparison passed. All applicable pre-commit checks passed, including mypy.

The earlier captured FP32 TPU7x expert-selection candidate passed exact weight/ID comparisons, native ISS validation, and source/LLO reproduction in all three hardware repetitions. The separate TPUv6e group-and-expert candidate passed exact comparisons on captured and scaled inputs, with ten independently compiled baseline/candidate pairs for each of three input sizes.

## Benchmarking and Profiling

**These measurements belong to the specified captured revisions. The complete current PR, including the group-selection extension, has not been benchmarked on TPU.**

### Captured TPU7x expert-selection candidate

The kernel at the original expert-selection commit [1aa6f0b](https://github.com/JianmingTONG/sglang-jax/commit/1aa6f0b55eabff3d9a728dc0316724e5110509d4) is byte-identical to this measured candidate. Its upstream baseline kernel also matches the captured baseline kernel. That statement applies to the original commit, before the group-selection extension.

| 2,048-token TPU7x router | Device span (microseconds) |
| --- | ---: |
| Saved baseline | 71.291417 |
| Candidate repetition 1 | 62.935399 |
| Candidate repetition 2 | 63.107968 |
| Candidate repetition 3 | 62.973815 |

The three separate candidate measurements are **11.48–11.72% lower** than one retained baseline span. Native ISS cycles decreased **383,524 → 367,622**. Native code replaces **29,184** integer comparison sites with floating maxima and removes **29,199** selects, **26,315** stores, and **24,760** loads. These are static code counts, not dynamic execution counts.

Measured source: [baseline 027fa79](https://github.com/JianmingTONG/sglang-jax/commit/027fa79a6498a1afef5a36c4e093c07d2f12f1ef) → [candidate cc67bcd](https://github.com/JianmingTONG/sglang-jax/commit/cc67bcd4ea5002e42f3922770b9805a34314f147). HiERevo candidate: `003-7c08d864f6fc42ba`.

### Captured TPUv6e group-and-expert candidate

The earlier group-and-expert implementation used exact negative-index priorities rather than the equivalent reversed positive priorities in this PR. Its measurements support the representation optimization, but do not measure the current PR or isolate the contribution of group selection.

| Captured input | Baseline (us) | Candidate (us) | Reduction | Candidate/baseline ratio CI95 |
| --- | ---: | ---: | ---: | --- |
| Short | 4.676121 | 4.408894 | 5.71% | [0.941455480, 0.944112353] |
| Medium | 14.343418 | 13.124316 | 8.50% | [0.914464733, 0.915634520] |
| Long | 26.066672 | 23.607231 | 9.44% | [0.905150018, 0.906152009] |

Each result is the mean of block medians from ten independent baseline/candidate pairs, with 50 exact compiled-program execution spans per block, on one TPUv6e chip with JAX 0.11.1. Measured candidate: `c132ebb33341ce6433f257b9cf2db2debbb21dc4`, against baseline `027fa79a6498a1afef5a36c4e093c07d2f12f1ef`.

[Download the confirmation traces and verification bundle](https://github.com/JianmingTONG/sglang-jax/releases/download/hierevo-kernel-evidence-20260909/grouped-topk.tar.gz). SHA256: `7bb96a83eea476346af8e00972d77c52bdef9b2dd045682872ee2cee59b44617`. After extraction, `python verify_evidence.py` (NumPy required) checks bundle hashes and recomputes samples/statistics from the included selected events. Original XPlane traces are included; raw output tensors and every repeated executable are not included. The [earlier submission #1620](https://github.com/sgl-project/sglang-jax/pull/1620) retains per-shape HLO/LLO links and detailed provenance; this PR consolidates the group-selection transformation with the expert-selection implementation.

Neither campaign establishes a consistent >2% host-latency reduction or model serving gains. Fresh TPU lowering and performance validation of the complete current PR remains outstanding. Performance on other shapes/devices and combined router optimizations requires separate measurement.

## Checklist

- [x] English description and motivation.
- [x] Implementation scope and exact-representation guards documented.
- [x] Test commands and results provided.
- [x] Captured performance evidence and measurement limits stated.
- [ ] Fresh TPU validation of the complete current implementation.
