### PR TITLE
fix: allow bootstrap health check to connect via both IPv4 and IPv6 loopback

### DIFF
--- a/python/sgl_jax/srt/disaggregation/bootstrap.py
+++ b/python/sgl_jax/srt/disaggregation/bootstrap.py
@@ -620,16 +620,17 @@ class BootstrapServer:
         self._started = False
 
     def _wait_until_ready(self, timeout_s: float) -> None:
-        url = f"http://127.0.0.1:{self._port}/health"
+        targets = ["127.0.0.1", "[::1]"]
         deadline = time.monotonic() + timeout_s
         last_err: Exception | None = None
         while time.monotonic() < deadline:
-            try:
-                r = httpx.get(url, timeout=0.5)
-                if r.status_code == 200:
-                    return
-            except Exception as e:  # noqa: BLE001
-                last_err = e
+            for target in targets:
+                try:
+                    r = httpx.get(f"http://{target}:{self._port}/health", timeout=0.5)
+                    if r.status_code == 200:
+                        return
+                except Exception as e:  # noqa: BLE001
+                    last_err = e
             time.sleep(0.05)
         raise TimeoutError(
             f"BootstrapServer did not become ready within {timeout_s}s (last error: {last_err})"

--- a/test/srt/disaggregation/test_pd_bootstrap.py
+++ b/test/srt/disaggregation/test_pd_bootstrap.py
@@ -51,6 +51,66 @@ def server_and_client():
     server.stop()
 
 
+class TestWaitUntilReady:
+    """Tests for IPv4 and IPv6 target health checks invoked via server.start()."""
+
+    def test_ipv4_target_success(self, monkeypatch):
+        server = BootstrapServer(port=8998)
+        called_urls: list[str] = []
+
+        def mock_get(url: str, timeout: float = 0.5):
+            called_urls.append(url)
+            resp = mock.MagicMock()
+            resp.status_code = 200
+            return resp
+
+        monkeypatch.setattr("threading.Thread", mock.MagicMock())
+        monkeypatch.setattr("sgl_jax.srt.disaggregation.bootstrap.httpx.get", mock_get)
+        server.start()
+        assert server.is_started is True
+        assert called_urls == ["http://127.0.0.1:8998/health"]
+
+    def test_ipv6_target_success_when_ipv4_fails(self, monkeypatch):
+        server = BootstrapServer(port=8998)
+        called_urls: list[str] = []
+
+        def mock_get(url: str, timeout: float = 0.5):
+            called_urls.append(url)
+            if "127.0.0.1" in url:
+                raise httpx.ConnectError("IPv4 connection refused")
+            resp = mock.MagicMock()
+            resp.status_code = 200
+            return resp
+
+        monkeypatch.setattr("threading.Thread", mock.MagicMock())
+        monkeypatch.setattr("sgl_jax.srt.disaggregation.bootstrap.httpx.get", mock_get)
+        server.start()
+        assert server.is_started is True
+        assert "http://127.0.0.1:8998/health" in called_urls
+        assert "http://[::1]:8998/health" in called_urls
+
+    def test_both_targets_fail_raises_timeout(self, monkeypatch):
+        server = BootstrapServer(port=8998)
+        monkeypatch.setattr("threading.Thread", mock.MagicMock())
+        monkeypatch.setattr(
+            "sgl_jax.srt.disaggregation.bootstrap.httpx.get",
+            mock.MagicMock(side_effect=httpx.ConnectError("connection refused")),
+        )
+        current_time = [100.0]
+
+        def mock_monotonic():
+            return current_time[0]
+
+        def mock_sleep(seconds: float):
+            current_time[0] += seconds + 1.0
+
+        monkeypatch.setattr("sgl_jax.srt.disaggregation.bootstrap.time.monotonic", mock_monotonic)
+        monkeypatch.setattr("sgl_jax.srt.disaggregation.bootstrap.time.sleep", mock_sleep)
+
+        with pytest.raises(TimeoutError, match="BootstrapServer did not become ready"):
+            server.start()
+
+
 # ==================================================================
 # Bootstrap server + client (from test_bootstrap_server)
 # ==================================================================


### PR DESCRIPTION


## Motivation

This is a bug fix for `python/sgl_jax/srt/disaggregation/bootstrap.py`. the previous health check only allow the self ip to be ipv4. The updated implementation extends the current health check to allow ipv6 address.

## Modifications

Extend the 

## Accuracy Tests

Unit tests added

## Benchmarking and Profiling
N/A

## Checklist

- [X] Please use English, otherwise it will be closed.
- [X] The purpose of the PR, or link existing issues this PR will resolve.
- [X] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
