### PR TITLE
Kimi k2.5 : Changes to support int4 checkpoint.

### DIFF
--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -537,6 +537,34 @@ class ModelConfig:
                         weight_block_size=weight_block_size,
                     )
                     return quant_config
+                elif format_type == "pack-quantized":
+                    logger.info(
+                        "Auto-detected compressed-tensors INT4 pack-quantized model. "
+                        "Creating QuantizationConfig for static int4."
+                    )
+                    weight_block_size = None
+                    if "config_groups" in hf_quant_config and isinstance(
+                        hf_quant_config["config_groups"], dict
+                    ):
+                        for group in hf_quant_config["config_groups"].values():
+                            weights_cfg = group.get("weights") if isinstance(group, dict) else None
+                            if not weights_cfg:
+                                continue
+                            group_size = weights_cfg.get("group_size")
+                            if group_size is not None:
+                                weight_block_size = (int(group_size), int(group_size))
+                            break
+
+                    ignored_layers = hf_quant_config.get("ignore") or []
+                    quant_config = QuantizationConfig(
+                        is_static_checkpoint=True,
+                        linear_rules=[],
+                        moe_weight_dtype=getattr(jnp, "int4", None),
+                        moe_activation_dtype=None,
+                        ignored_layers=list(ignored_layers),
+                        weight_block_size=weight_block_size,
+                    )
+                    return quant_config
                 else:
                     logger.warning(
                         "compressed-tensors format '%s' is not yet supported. "

--- a/python/sgl_jax/srt/configs/quantization_config.py
+++ b/python/sgl_jax/srt/configs/quantization_config.py
@@ -15,6 +15,8 @@ import yaml
 # Map string dtype names to JAX numpy dtypes
 DTYPE_MAP = {
     "int8": jnp.int8,
+    "int4": getattr(jnp, "int4", None),
+    "uint4": getattr(jnp, "uint4", None),
     "float8_e4m3fn": jnp.float8_e4m3fn,
     "float8_e5m2": jnp.float8_e5m2,
     "bfloat16": jnp.bfloat16,

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -220,7 +220,7 @@ class EPMoE(nnx.Module):
                         f"Expected k_blocks dimension to be 1 or {expected_k_blocks}."
                     )
             final_scale_sharding = (
-                P("expert", None, None, None)
+                P("expert", "tensor", None, None)
                 if scale_name == "wo_scale"
                 else P("expert", None, None, "tensor")
             )
@@ -247,7 +247,7 @@ class EPMoE(nnx.Module):
 
                 if scale.shape == (num_experts, out_dim, expected_k_blocks):
                     final_scale_sharding = (
-                        P("expert", None, None, None)
+                        P("expert", "tensor", None, None)
                         if scale_name == "wo_scale"
                         else P("expert", None, None, "tensor")
                     )
@@ -261,7 +261,7 @@ class EPMoE(nnx.Module):
                         else P("expert", "tensor", None)
                     )
                     final_scale_sharding = (
-                        P("expert", None, None, None)
+                        P("expert", "tensor", None, None)
                         if scale_name == "wo_scale"
                         else P("expert", None, None, "tensor")
                     )
@@ -340,40 +340,119 @@ class EPMoE(nnx.Module):
                 k_blocks_wi = (hidden_size // block_size_k) if block_size_k else 1
                 k_blocks_wo = (intermediate_dim // block_size_k) if block_size_k else 1
                 wi_scale_sharding = P("expert", None, None, "tensor")
-                wo_scale_sharding = P("expert", None, None, None)
+                wo_scale_sharding = P("expert", "tensor", None, None)
+                wi_sharding = P("expert", None, "tensor")
+                wo_sharding = P("expert", "tensor", None)
 
-                if hasattr(self, "wi_0_scale"):
-                    del self.wi_0_scale
-                self.wi_0_scale = nnx.Param(
-                    jnp.zeros(
-                        (num_experts, k_blocks_wi, 1, intermediate_dim),
-                        dtype=jnp.float32,
+                is_abstract = isinstance(self.wi_0.value, jax.ShapeDtypeStruct)
+
+                if is_abstract:
+                    if hasattr(self, "wi_0_scale"):
+                        del self.wi_0_scale
+                    self.wi_0_scale = nnx.Param(
+                        jax.ShapeDtypeStruct(
+                            (num_experts, k_blocks_wi, 1, intermediate_dim),
+                            dtype=self.dtype,
+                            sharding=jax.sharding.NamedSharding(self.moe_mesh, wi_scale_sharding),
+                        )
+                    )
+
+                    if hasattr(self, "wi_1_scale"):
+                        del self.wi_1_scale
+                    self.wi_1_scale = nnx.Param(
+                        jax.ShapeDtypeStruct(
+                            (num_experts, k_blocks_wi, 1, intermediate_dim),
+                            dtype=self.dtype,
+                            sharding=jax.sharding.NamedSharding(self.moe_mesh, wi_scale_sharding),
+                        )
+                    )
+
+                    if hasattr(self, "wo_scale"):
+                        del self.wo_scale
+                    self.wo_scale = nnx.Param(
+                        jax.ShapeDtypeStruct(
+                            (num_experts, k_blocks_wo, 1, hidden_size),
+                            dtype=self.dtype,
+                            sharding=jax.sharding.NamedSharding(self.moe_mesh, wo_scale_sharding),
+                        )
+                    )
+
+                    self.wi_0 = nnx.Param(
+                        jax.ShapeDtypeStruct(
+                            (num_experts, hidden_size, intermediate_dim),
+                            dtype=self.quantized_dtype,
+                            sharding=jax.sharding.NamedSharding(self.moe_mesh, wi_sharding),
+                        )
+                    )
+                    self.wi_1 = nnx.Param(
+                        jax.ShapeDtypeStruct(
+                            (num_experts, hidden_size, intermediate_dim),
+                            dtype=self.quantized_dtype,
+                            sharding=jax.sharding.NamedSharding(self.moe_mesh, wi_sharding),
+                        )
+                    )
+                    self.wo = nnx.Param(
+                        jax.ShapeDtypeStruct(
+                            (num_experts, intermediate_dim, hidden_size),
+                            dtype=self.quantized_dtype,
+                            sharding=jax.sharding.NamedSharding(self.moe_mesh, wo_sharding),
+                        )
+                    )
+                else:
+                    if hasattr(self, "wi_0_scale"):
+                        del self.wi_0_scale
+                    self.wi_0_scale = nnx.Param(
+                        jnp.zeros(
+                            (num_experts, k_blocks_wi, 1, intermediate_dim),
+                            dtype=self.dtype,
+                            out_sharding=wi_scale_sharding,
+                        ),
                         out_sharding=wi_scale_sharding,
-                    ),
-                    out_sharding=wi_scale_sharding,
-                )
+                    )
 
-                if hasattr(self, "wi_1_scale"):
-                    del self.wi_1_scale
-                self.wi_1_scale = nnx.Param(
-                    jnp.zeros(
-                        (num_experts, k_blocks_wi, 1, intermediate_dim),
-                        dtype=jnp.float32,
+                    if hasattr(self, "wi_1_scale"):
+                        del self.wi_1_scale
+                    self.wi_1_scale = nnx.Param(
+                        jnp.zeros(
+                            (num_experts, k_blocks_wi, 1, intermediate_dim),
+                            dtype=self.dtype,
+                            out_sharding=wi_scale_sharding,
+                        ),
                         out_sharding=wi_scale_sharding,
-                    ),
-                    out_sharding=wi_scale_sharding,
-                )
+                    )
 
-                if hasattr(self, "wo_scale"):
-                    del self.wo_scale
-                self.wo_scale = nnx.Param(
-                    jnp.zeros(
-                        (num_experts, k_blocks_wo, 1, hidden_size),
-                        dtype=jnp.float32,
+                    if hasattr(self, "wo_scale"):
+                        del self.wo_scale
+                    self.wo_scale = nnx.Param(
+                        jnp.zeros(
+                            (num_experts, k_blocks_wo, 1, hidden_size),
+                            dtype=self.dtype,
+                            out_sharding=wo_scale_sharding,
+                        ),
                         out_sharding=wo_scale_sharding,
-                    ),
-                    out_sharding=wo_scale_sharding,
-                )
+                    )
+
+                    self.wi_0 = nnx.Param(
+                        jnp.zeros(
+                            (num_experts, hidden_size, intermediate_dim),
+                            dtype=self.quantized_dtype,
+                        ),
+                        out_sharding=wi_sharding,
+                    )
+                    self.wi_1 = nnx.Param(
+                        jnp.zeros(
+                            (num_experts, hidden_size, intermediate_dim),
+                            dtype=self.quantized_dtype,
+                        ),
+                        out_sharding=wi_sharding,
+                    )
+                    self.wo = nnx.Param(
+                        jnp.zeros(
+                            (num_experts, intermediate_dim, hidden_size),
+                            dtype=self.quantized_dtype,
+                        ),
+                        out_sharding=wo_sharding,
+                    )
                 return
 
             # Quantize weights along k-dim (axis=1 in [g, k, n] layout)
@@ -437,7 +516,7 @@ class EPMoE(nnx.Module):
                 del self.wo_scale
             self.wo_scale = nnx.Param(
                 wo_scale,
-                out_sharding=P("expert", None, None, None),
+                out_sharding=P("expert", "tensor", None, None),
             )
 
     @named_scope
@@ -514,7 +593,7 @@ class EPMoE(nnx.Module):
                     # scales [g, 1, 1, n]
                     P("expert", None, None, "tensor"),
                     P("expert", None, None, "tensor"),
-                    P("expert", None, None, None),
+                    P("expert", "tensor", None, None),
                     # biases [g, 1, n] (unused)
                     P("expert", None, "tensor"),
                     P("expert", None, "tensor"),
@@ -857,6 +936,7 @@ def create_moe_weights_mapping(
     moe_path: str = "mlp",
     source_expert_pattern: str = "experts.{i}",
     physical_to_logical_map=None,  # np.ndarray shape (num_physical,) or None
+    weight_suffix: str = "weight",
 ) -> dict:
     """Generate a unified mapping dictionary for MoE layer expert weights."""
     if moe_backend == "epmoe":
@@ -884,7 +964,7 @@ def create_moe_weights_mapping(
 
         # Source weight paths for logical experts only
         expert_keys = [
-            f"{prefix}.{moe_path}.{source_expert_pattern.format(i=i)}.{source_name}.weight"
+            f"{prefix}.{moe_path}.{source_expert_pattern.format(i=i)}.{source_name}.{weight_suffix}"
             for i in range(num_experts)
         ]
 

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -220,7 +220,7 @@ class EPMoE(nnx.Module):
                         f"Expected k_blocks dimension to be 1 or {expected_k_blocks}."
                     )
             final_scale_sharding = (
-                P("expert", "tensor", None, None)
+                P("expert", "tensor" if scale.shape[1] > 1 else None, None, None)
                 if scale_name == "wo_scale"
                 else P("expert", None, None, "tensor")
             )
@@ -247,7 +247,7 @@ class EPMoE(nnx.Module):
 
                 if scale.shape == (num_experts, out_dim, expected_k_blocks):
                     final_scale_sharding = (
-                        P("expert", "tensor", None, None)
+                        P("expert", "tensor" if expected_k_blocks > 1 else None, None, None)
                         if scale_name == "wo_scale"
                         else P("expert", None, None, "tensor")
                     )
@@ -261,7 +261,7 @@ class EPMoE(nnx.Module):
                         else P("expert", "tensor", None)
                     )
                     final_scale_sharding = (
-                        P("expert", "tensor", None, None)
+                        P("expert", "tensor" if expected_k_blocks > 1 else None, None, None)
                         if scale_name == "wo_scale"
                         else P("expert", None, None, "tensor")
                     )
@@ -340,7 +340,7 @@ class EPMoE(nnx.Module):
                 k_blocks_wi = (hidden_size // block_size_k) if block_size_k else 1
                 k_blocks_wo = (intermediate_dim // block_size_k) if block_size_k else 1
                 wi_scale_sharding = P("expert", None, None, "tensor")
-                wo_scale_sharding = P("expert", "tensor", None, None)
+                wo_scale_sharding = P("expert", "tensor" if k_blocks_wo > 1 else None, None, None)
                 wi_sharding = P("expert", None, "tensor")
                 wo_sharding = P("expert", "tensor", None)
 
@@ -516,7 +516,7 @@ class EPMoE(nnx.Module):
                 del self.wo_scale
             self.wo_scale = nnx.Param(
                 wo_scale,
-                out_sharding=P("expert", "tensor", None, None),
+                out_sharding=P("expert", "tensor" if wo_scale.shape[1] > 1 else None, None, None),
             )
 
     @named_scope
@@ -593,7 +593,7 @@ class EPMoE(nnx.Module):
                     # scales [g, 1, 1, n]
                     P("expert", None, None, "tensor"),
                     P("expert", None, None, "tensor"),
-                    P("expert", "tensor", None, None),
+                    P("expert", "tensor" if (wo_scale is not None and wo_scale.shape[1] > 1) else None, None, None),
                     # biases [g, 1, n] (unused)
                     P("expert", None, "tensor"),
                     P("expert", None, "tensor"),

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -502,8 +502,12 @@ class ModelRunnerKVCacheMixin:
                 )
             token_capacity = min(token_capacity, max_total_tokens)
 
-        # Page alignment
-        token_capacity = token_capacity // self.server_args.page_size * self.server_args.page_size
+        # Page and Data mesh alignment
+        data_mesh_dim = 1
+        if hasattr(self, "mesh") and self.mesh is not None and "data" in self.mesh.shape:
+            data_mesh_dim = self.mesh.shape["data"]
+        alignment = self.server_args.page_size * max(1, data_mesh_dim)
+        token_capacity = (token_capacity // alignment) * alignment
 
         # DP scale
         token_capacity = token_capacity * dp_size

--- a/python/sgl_jax/srt/models/deepseek_v3.py
+++ b/python/sgl_jax/srt/models/deepseek_v3.py
@@ -815,6 +815,8 @@ class DeepseekV3ForCausalLM(nnx.Module):
         moe_backend = getattr(self.config, "moe_backend", "epmoe")
         use_fused = moe_backend == "fused"
 
+        quant_config = getattr(model_config, "quantization_config", None)
+
         for layer_idx in range(self.config.num_hidden_layers):
             is_moe = (
                 n_routed_experts is not None
@@ -822,7 +824,7 @@ class DeepseekV3ForCausalLM(nnx.Module):
                 and layer_idx % moe_layer_freq == 0
             )
             layer_mappings = self._create_layer_mappings(
-                layer_idx, is_moe, moe_backend, use_fused, is_static_quant
+                layer_idx, is_moe, moe_backend, use_fused, is_static_quant, quant_config=quant_config
             )
             mappings.update(layer_mappings)
 
@@ -835,10 +837,23 @@ class DeepseekV3ForCausalLM(nnx.Module):
         moe_backend: str,
         use_fused: bool,
         is_static_quant: bool = False,
+        quant_config=None,
     ) -> dict:
         prefix = f"{self.hf_weight_prefix}model.layers.{layer_idx}"
         target = f"model.layers.{layer_idx}"
         mappings: dict = {}
+
+        ignored_layers = getattr(quant_config, "ignored_layers", None) or []
+
+        def _is_linear_quantized(subpath: str) -> bool:
+            if not is_static_quant:
+                return False
+            path_parts = subpath.replace("[", ".").replace("]", "").split(".")
+            for ig in ignored_layers:
+                if ig in path_parts or ig == subpath:
+                    return False
+            linear_rules = quant_config.get_linear_rules() if quant_config else []
+            return bool(linear_rules)
 
         def add_linear(hf_prefix: str, target_prefix: str, sharding_std: tuple):
             # HF weights are `[out, in]`.
@@ -847,7 +862,7 @@ class DeepseekV3ForCausalLM(nnx.Module):
             #   Static FP8: loaded into QuantizedLinear.weight_q `[out, in]`
             #   directly; sharding is kernel_axes swapped. Also register the
             #   `weight_scale_inv` sidecar into `weight_scale`.
-            if not is_static_quant:
+            if not _is_linear_quantized(target_prefix):
                 mappings[f"{hf_prefix}.weight"] = WeightMapping(
                     target_path=f"{target_prefix}.weight",
                     sharding=sharding_std,
@@ -940,6 +955,13 @@ class DeepseekV3ForCausalLM(nnx.Module):
             physical_to_logical_map = np.array(jax.device_get(metadata.physical_to_logical_map))
             phy_to_log = physical_to_logical_map[layer_idx]
 
+        int4_types = [
+            getattr(jnp, t) for t in ["int4", "uint4", "float4_e2m1fn"] if hasattr(jnp, t)
+        ]
+        is_int4_moe = getattr(quant_config, "moe_weight_dtype", None) in int4_types
+        weight_suffix = "weight_packed" if is_int4_moe else "weight"
+        scale_suffix = ".weight_scale" if is_int4_moe else ".weight_scale_inv"
+
         moe_mappings = create_moe_weights_mapping(
             prefix=prefix,
             target_prefix=target,
@@ -947,6 +969,7 @@ class DeepseekV3ForCausalLM(nnx.Module):
             expert_type_names=("gate_proj", "up_proj", "down_proj"),
             moe_backend=moe_backend,
             physical_to_logical_map=phy_to_log,
+            weight_suffix=weight_suffix,
         )
         mappings.update(moe_mappings)
 
@@ -967,17 +990,19 @@ class DeepseekV3ForCausalLM(nnx.Module):
                     continue
                 target_base = wm.target_path[0]
                 expert_scale_keys = [
-                    k.replace(".weight", ".weight_scale_inv") for k in wm.target_path[1:]
+                    k.replace(f".{weight_suffix}", scale_suffix) for k in wm.target_path[1:]
                 ]
                 scale_target = f"{target_base}_scale"
-                # Stacked checkpoint scale is `[E, out_blocks, in_blocks]`. Load
-                # replicated on the block dims; _maybe_convert_epmoe_scale_for_kernel
-                # expands via jnp.take, which fails if the gathered axis is
-                # tensor-sharded (ambiguous output sharding). The converter reshards
-                # to model_param.value.sharding at the end.
+                # Stacked checkpoint scale is `[E, out_blocks, in_blocks]`.
+                # For wi_0/wi_1: out_dim (intermediate_dim) is dim 1, sharded on "tensor".
+                # For wo: in_dim (intermediate_dim // 32 = k_blocks_wo) is dim 2, sharded on "tensor".
+                if "wo" in target_base:
+                    scale_sharding = ("expert", None, "tensor")
+                else:
+                    scale_sharding = ("expert", "tensor", None)
                 mappings[f"__MOE_EXPERTS__{scale_target}"] = WeightMapping(
                     target_path=[scale_target] + expert_scale_keys,
-                    sharding=("expert", None, None),
+                    sharding=scale_sharding,
                     transpose=False,
                     physical_to_logical_map=wm.physical_to_logical_map,
                 )

--- a/python/sgl_jax/srt/multimodal/models/kimi_k25/kimi_k25_vl_generation.py
+++ b/python/sgl_jax/srt/multimodal/models/kimi_k25/kimi_k25_vl_generation.py
@@ -32,7 +32,7 @@ class KimiK25ForConditionalGeneration(DeepseekV3ForCausalLM):
         # Clear it here so FusedMoE doesn't receive a raw dict as the config contains 'pack-quantized'
         # format which isn't yet supported.
         if isinstance(getattr(self.text_config, "quantization_config", None), dict):
-            self.text_config.quantization_config = None
+            self.text_config.quantization_config = getattr(config, "quantization_config", None)
 
         super().__init__(
             config=self.text_config,

--- a/python/sgl_jax/srt/utils/quantization/quantization_utils.py
+++ b/python/sgl_jax/srt/utils/quantization/quantization_utils.py
@@ -96,18 +96,12 @@ def apply_linear_quantization(
     from sgl_jax.srt.layers.linear import LinearBase, QuantizedLinear
 
     quant_config = model_config.quantization_config
-    if quant_config is None:
-        raise ValueError(
-            "apply_linear_quantization called but model_config.quantization_config is None. "
-            "Ensure --quantization-config-path is set."
-        )
+    if quant_config is None or not quant_config.has_linear_quantization():
+        return model
 
     linear_rules = quant_config.get_linear_rules()
     if not linear_rules:
-        raise ValueError(
-            "No linear rules found in quantization config. "
-            "Check your quantization config YAML file."
-        )
+        return model
 
     # Compile regex patterns from rules
     compiled_rules = []
@@ -173,9 +167,14 @@ def apply_linear_quantization(
                 if isinstance(attr_value, LinearBase):
                     # Check if this path matches any rule
                     dot_path = child_path.replace("/", ".")
+                    path_parts = dot_path.replace("[", ".").replace("]", "").split(".")
                     if any(
-                        dot_path == ignored or dot_path.endswith(f".{ignored}")
-                        for ignored in ignored_layers
+                        ig in path_parts
+                        or dot_path == ig
+                        or dot_path.endswith(f".{ig}")
+                        or f".{ig}." in dot_path
+                        or dot_path.startswith(f"{ig}.")
+                        for ig in ignored_layers
                     ):
                         logger.info("Skipping %s - in ignored_layers", dot_path)
                         continue
@@ -273,6 +272,10 @@ def apply_moe_quantization(
                 logger.info("Skipping MoE quantization for %s (matched ignored_layers)", log_path)
                 return
             logger.debug("Quantizing MoE weights path=%s", log_path)
+            if hasattr(obj, "quantized_dtype") and obj.quantized_dtype is None:
+                obj.quantized_dtype = quant_config.get_moe_weight_dtype()
+                obj.activation_quantized_dtype = quant_config.get_moe_activation_dtype()
+                obj.weight_block_size = getattr(quant_config, "weight_block_size", None)
             obj.quantize_weights(is_static=is_static_input)
             return
 

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import glob
 import json
 import logging
@@ -67,6 +68,35 @@ def _reinterpret_dtype_if_needed(data: np.ndarray, target_dtype: jnp.dtype) -> n
     elif data.dtype == np.dtype("V2"):
         return data.view(ml_dtypes.bfloat16)
     return data
+
+
+@functools.partial(jax.jit, static_argnames=("target_dtype", "do_transpose"))
+def unpack_4bit_jax(
+    lazy_weight: jax.Array,
+    target_dtype: jnp.dtype,
+    do_transpose: bool = False,
+) -> jax.Array:
+    if lazy_weight.dtype in [jnp.int32, jnp.uint32]:
+        shifts = jnp.arange(0, 32, 4, dtype=jnp.int32)
+        unpacked = (lazy_weight[..., None] >> shifts) & 0x0F
+        unpacked = jnp.reshape(unpacked, lazy_weight.shape[:-1] + (lazy_weight.shape[-1] * 8,))
+    else:
+        unpacked = jnp.stack([lazy_weight & 0x0F, lazy_weight >> 4], axis=-1)
+        unpacked = jnp.reshape(unpacked, lazy_weight.shape[:-1] + (lazy_weight.shape[-1] * 2,))
+
+    int4_dtype = getattr(jnp, "int4", getattr(ml_dtypes, "int4", None))
+    # In compressed-tensors pack-quantized format, signed 4-bit weights are stored
+    # with an offset of +8 (i.e. unsigned 0..15 maps to signed -8..7, centered at 8).
+    unpacked_signed = unpacked.astype(jnp.int8) - 8
+    if int4_dtype is not None and target_dtype == int4_dtype:
+        final_array = unpacked_signed.astype(int4_dtype)
+    else:
+        final_array = unpacked_signed.astype(target_dtype)
+
+    if do_transpose:
+        final_array = jnp.transpose(final_array, (0, 2, 1))
+
+    return final_array
 
 
 @dataclass
@@ -2072,6 +2102,12 @@ class WeightLoader:
                         target_path = mapping.target_path
                         model_param = self._get_param(params, target_path)
 
+                        int4_types = [
+                            getattr(jnp, t) for t in ["int4", "uint4", "float4_e2m1fn"] if hasattr(jnp, t)
+                        ]
+                        if model_param.value.dtype in int4_types and lazy_weight.dtype in [jnp.int32, jnp.uint32, jnp.int8, jnp.uint8]:
+                            lazy_weight = unpack_4bit_jax(lazy_weight, model_param.value.dtype)
+
                         # Expand 2D block-quant scale to 3D kernel-ready layout.
                         lazy_weight = self._maybe_expand_linear_block_scale(
                             lazy_weight, model_param, target_path
@@ -2183,11 +2219,17 @@ class WeightLoader:
                         final_sharding = jax.sharding.NamedSharding(self.mesh, P(*mapping.sharding))
 
                     target_path = mapping.target_path[0]
+                    model_param = self._get_param(params, target_path)
+
+                    int4_types = [
+                        getattr(jnp, t) for t in ["int4", "uint4", "float4_e2m1fn"] if hasattr(jnp, t)
+                    ]
+                    is_int4_weight = model_param.value.dtype in int4_types
+
                     _pd_cache = os.environ.get("SGLANG_PD_WEIGHT_CACHE") == "1"
                     if _pd_cache and target_path in _PD_WEIGHT_CACHE:
                         _t0 = time.monotonic()
                         cached = _PD_WEIGHT_CACHE[target_path]
-                        model_param = self._get_param(params, target_path)
                         model_param.value = jax.device_put(
                             cached, self._pd_remap_sharding(cached.sharding)
                         )
@@ -2199,14 +2241,25 @@ class WeightLoader:
                         )
                         continue
 
+                    load_sharding = final_sharding
+                    if (
+                        is_int4_weight
+                        and mapping.transpose
+                        and isinstance(final_sharding, jax.sharding.NamedSharding)
+                    ):
+                        pspec = final_sharding.spec
+                        if len(pspec) == 3:
+                            load_pspec = jax.sharding.PartitionSpec(pspec[0], pspec[2], pspec[1])
+                            load_sharding = jax.sharding.NamedSharding(final_sharding.mesh, load_pspec)
+
                     # 2. Call creator
                     _t_load_start = time.monotonic()
                     stacked_weight = self._create_stacked_moe_lazy_tensor(
                         expected_hf_keys,
                         weight_info,
                         file_manager,
-                        do_transpose=mapping.transpose,  # CPU transpose
-                        target_sharding=final_sharding,  # Global loading
+                        do_transpose=mapping.transpose if not is_int4_weight else False,
+                        target_sharding=load_sharding,  # Global loading
                         physical_to_logical_map=mapping.physical_to_logical_map,
                     )
                     _t_load = time.monotonic() - _t_load_start
@@ -2219,8 +2272,18 @@ class WeightLoader:
                         axis, times = mapping.repeat
                         stacked_weight = jnp.repeat(stacked_weight, times, axis=axis)
 
+                    # Unpack 4-bit weights if needed (e.g. MoE int4)
+                    if is_int4_weight and stacked_weight.dtype in [jnp.int32, jnp.uint32, jnp.int8, jnp.uint8]:
+                        stacked_weight = unpack_4bit_jax(
+                            stacked_weight,
+                            model_param.value.dtype,
+                            do_transpose=mapping.transpose,
+                        )
+                        param_sharding = getattr(model_param.value, "sharding", None)
+                        if param_sharding is not None:
+                            stacked_weight = jax.sharding.reshard(stacked_weight, param_sharding)
+
                     # 3. Direct assignment
-                    model_param = self._get_param(params, target_path)
                     _t_conv_start = time.monotonic()
                     stacked_weight = self._maybe_convert_epmoe_scale_for_kernel(
                         stacked_weight,
@@ -2252,6 +2315,9 @@ class WeightLoader:
                         _t_assign = time.monotonic() - _t_assign_start
                         if _pd_cache:
                             _PD_WEIGHT_CACHE[target_path] = model_param.value
+                        del stacked_weight
+                        import gc
+                        gc.collect()
                         logger.info(
                             "MoE group %s: load=%.2fs conv=%.2fs assign=%.2fs total=%.2fs "
                             "shape=%s sharding=%s",
@@ -2287,13 +2353,13 @@ class WeightLoader:
                             moe_key,
                             num_logical,
                             num_physical,
-                            stacked_weight.shape,
+                            loaded_shape,
                         )
                     else:
                         logger.info(
                             "Assigned MoE group %s, shape: %s",
                             moe_key,
-                            stacked_weight.shape,
+                            loaded_shape,
                         )
                 else:
                     ep_size = getattr(self.model_config.hf_config, "ep_size", 1)

--- a/python/sgl_jax/test/kernels/test_int4_quantization.py
+++ b/python/sgl_jax/test/kernels/test_int4_quantization.py
@@ -1,0 +1,90 @@
+import jax.numpy as jnp
+import ml_dtypes
+import numpy as np
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.configs.quantization_config import DTYPE_MAP, QuantizationConfig
+from sgl_jax.srt.utils.quantization.quantization_utils import (
+    apply_linear_quantization,
+)
+from sgl_jax.srt.utils.weight_utils import unpack_4bit_jax
+
+
+def test_dtype_map_contains_int4():
+    assert "int4" in DTYPE_MAP
+    assert "uint4" in DTYPE_MAP
+
+
+def test_unpack_4bit_jax_int32():
+    # 8 values packed into one int32: [0, 1, 2, 3, 4, 5, 6, 7]
+    # packed value = sum(v << (4*i))
+    packed_val = sum(i << (4 * i) for i in range(8))
+    packed_arr = jnp.array([[packed_val]], dtype=jnp.int32)  # shape (1, 1)
+
+    int4_dtype = getattr(jnp, "int4", getattr(ml_dtypes, "int4", jnp.int8))
+    unpacked = unpack_4bit_jax(packed_arr, int4_dtype)
+
+    assert unpacked.shape == (1, 8)
+    # The unpack subtracts offset 8: [0-8, 1-8, 2-8, ..., 7-8] = [-8, -7, -6, ..., -1]
+    expected = np.array([[-8, -7, -6, -5, -4, -3, -2, -1]])
+    np.testing.assert_array_equal(np.array(unpacked, dtype=np.int8), expected)
+
+
+def test_unpack_4bit_jax_transpose():
+    packed_val = sum(i << (4 * i) for i in range(8))
+    packed_arr = jnp.array([[[packed_val]]], dtype=jnp.int32)  # shape (1, 1, 1)
+
+    int4_dtype = getattr(jnp, "int4", getattr(ml_dtypes, "int4", jnp.int8))
+    unpacked = unpack_4bit_jax(packed_arr, int4_dtype, do_transpose=True)
+
+    # Original unpacked shape would be (1, 1, 8), transposed (0, 2, 1) -> (1, 8, 1)
+    assert unpacked.shape == (1, 8, 1)
+
+
+def test_model_config_pack_quantized_parsing():
+    hf_quant_config = {
+        "quant_method": "compressed-tensors",
+        "format": "pack-quantized",
+        "config_groups": {
+            "group_0": {
+                "weights": {
+                    "num_bits": 4,
+                    "type": "int",
+                    "symmetric": True,
+                    "strategy": "group",
+                    "group_size": 32,
+                }
+            }
+        },
+        "ignore": ["lm_head", "model.layers.0.mlp"],
+    }
+
+    dummy_config = ModelConfig.__new__(ModelConfig)
+    dummy_config.quantization_config = None
+    dummy_config._get_hf_quant_config = lambda: hf_quant_config
+    quant_cfg = dummy_config._resolve_quantization_config()
+
+    assert quant_cfg is not None
+    assert quant_cfg.is_static_checkpoint is True
+    assert quant_cfg.moe_weight_dtype in (getattr(jnp, "int4", None), getattr(ml_dtypes, "int4", None))
+    assert quant_cfg.ignored_layers == ["lm_head", "model.layers.0.mlp"]
+    assert quant_cfg.weight_block_size == (32, 32)
+    assert quant_cfg.linear_rules == []
+
+
+def test_apply_linear_quantization_noop_when_no_rules():
+    from flax import nnx
+
+    class DummyModel(nnx.Module):
+        def __init__(self):
+            pass
+
+    dummy_model = DummyModel()
+    dummy_model_config = ModelConfig.__new__(ModelConfig)
+    dummy_model_config.quantization_config = QuantizationConfig(
+        is_static_checkpoint=True,
+        linear_rules=[],
+    )
+
+    result = apply_linear_quantization(dummy_model_config, dummy_model)
+    assert result is dummy_model

--- a/python/sgl_jax/test/kernels/test_kimi_int4_e2e_prompt.py
+++ b/python/sgl_jax/test/kernels/test_kimi_int4_e2e_prompt.py
@@ -1,0 +1,233 @@
+import logging
+import os
+import sys
+import time
+from types import SimpleNamespace
+
+# Setup TPU networking environment variables before JAX initializes
+if "TPU_WORKER_HOSTNAMES" not in os.environ:
+    os.environ["TPU_WORKER_HOSTNAMES"] = "localhost"
+if "TPU_PROCESS_PORT" not in os.environ:
+    os.environ["TPU_PROCESS_PORT"] = "8471"
+if "TPU_PROCESS_ADDRESSES" not in os.environ:
+    os.environ["TPU_PROCESS_ADDRESSES"] = "localhost:8471"
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from transformers import AutoTokenizer
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.entrypoints.engine import _set_envs_and_config
+from sgl_jax.srt.hf_transformers_utils import get_tokenizer
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata
+from sgl_jax.srt.managers.schedule_batch import Req, ScheduleBatch
+from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
+from sgl_jax.srt.model_executor.model_runner import ModelRunner
+from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
+from sgl_jax.srt.sampling.sampling_params import SamplingParams
+from sgl_jax.srt.server_args import PortArgs, ServerArgs
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("test_kimi_int4_prompt")
+
+
+def _run_forward_and_sample(model_runner, batch: ScheduleBatch, token_first_arg: int):
+    page_size = model_runner.page_size
+    bs_needed = len(batch.seq_lens)
+    cache_loc_needed = int(
+        np.sum(
+            ((np.array(batch.seq_lens, dtype=np.int64) + page_size - 1) // page_size) * page_size
+        )
+    )
+
+    model_worker_batch = batch.get_model_worker_batch(
+        [token_first_arg],
+        [bs_needed],
+        [cache_loc_needed],
+        page_size,
+        False,
+    )
+
+    forward_metadata = model_runner.attn_backend.get_forward_metadata(model_worker_batch)
+    model_runner.attn_backend.forward_metadata = forward_metadata
+
+    forward_batch = ForwardBatch.init_new(model_worker_batch, model_runner)
+    logits_metadata = LogitsMetadata.from_model_worker_batch(
+        model_worker_batch, mesh=model_runner.mesh
+    )
+    logits_output, _, _ = model_runner.forward(forward_batch, logits_metadata=logits_metadata)
+
+    pad_size = len(model_worker_batch.seq_lens) - model_worker_batch.real_bs
+    sampling_metadata = SamplingMetadata.from_model_worker_batch(
+        model_worker_batch,
+        pad_size=pad_size,
+        mesh=model_runner.mesh,
+        vocab_size=model_runner.model_config.vocab_size,
+    )
+    next_token_ids, _, _ = model_runner.sample(logits_output, sampling_metadata)
+    return next_token_ids, logits_output.next_token_logits
+
+
+def extend(reqs, model_runner):
+    dummy_tree_cache = SimpleNamespace(
+        token_to_kv_pool_allocator=model_runner.token_to_kv_pool_allocator,
+    )
+    batch = ScheduleBatch.init_new(
+        reqs=[reqs],
+        req_to_token_pool=model_runner.req_to_token_pool,
+        token_to_kv_pool_allocator=model_runner.token_to_kv_pool_allocator,
+        tree_cache=dummy_tree_cache,
+        model_config=model_runner.model_config,
+        enable_overlap=False,
+        dp_size=1,
+        enable_custom_logit_processor=False,
+        chunked_reqs=None,
+    )
+    batch.prepare_for_extend()
+    if hasattr(batch, "extend_lens") and batch.extend_lens is not None:
+        token_needed = int(np.sum(np.array(batch.extend_lens, dtype=np.int64)))
+    else:
+        token_needed = int(np.sum(np.array(batch.seq_lens, dtype=np.int64)))
+    next_token_ids, next_token_logits = _run_forward_and_sample(model_runner, batch, token_needed)
+    return next_token_ids, next_token_logits, batch
+
+
+def decode(input_token_ids, batch: ScheduleBatch, model_runner):
+    batch.output_ids = input_token_ids
+    batch.prepare_for_decode()
+    bs_needed = len(batch.seq_lens)
+    next_token_ids, next_token_logits = _run_forward_and_sample(model_runner, batch, bs_needed)
+    return next_token_ids, next_token_logits
+
+
+def generate_for_prompt(prompt: str, model_runner, tokenizer, max_new_tokens: int = 16) -> str:
+    logger.info("Generating for prompt: %r (max_new_tokens=%d)", prompt, max_new_tokens)
+    input_ids = tokenizer.encode(prompt)
+    sampling_params = SamplingParams(
+        temperature=0.0,
+        max_new_tokens=max_new_tokens,
+    )
+
+    req = Req(
+        rid=0,
+        origin_input_text=prompt,
+        origin_input_ids=input_ids,
+        sampling_params=sampling_params,
+    )
+    req.prefix_indices = []
+    req.fill_ids = req.origin_input_ids
+    req.extend_input_len = len(req.fill_ids)
+    req.logprob_start_len = len(req.origin_input_ids) - 1
+
+    # Clear memory pools for fresh request
+    model_runner.req_to_token_pool.clear()
+    model_runner.token_to_kv_pool_allocator.clear()
+
+    # Prefill step
+    next_token_ids, _, batch = extend([req], model_runner)
+    first_tok = int(np.array(next_token_ids)[0])
+    generated_tokens = [first_tok]
+
+    # Decode steps
+    next_token_ids_cpu = np.array([first_tok])
+    for step in range(max_new_tokens - 1):
+        next_token_ids, _ = decode(next_token_ids_cpu, batch, model_runner)
+        next_tok = int(np.array(next_token_ids)[0])
+        generated_tokens.append(next_tok)
+        next_token_ids_cpu = np.array([next_tok])
+        if next_tok in (tokenizer.eos_token_id, 151643, 151645):
+            break
+
+    generated_text = tokenizer.decode(generated_tokens)
+    full_text = tokenizer.decode(input_ids + generated_tokens)
+    logger.info("Generated tokens: %s", generated_tokens)
+    logger.info("Generated text: %r", generated_text)
+    logger.info("Full response: %r", full_text)
+    return generated_text
+
+
+def main():
+    model_path = os.environ.get("MODEL_PATH", "/dsk/kimi_original_new")
+    logger.info("Initializing JAX and TPU devices...")
+    logger.info("Devices available: %s", jax.devices())
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    logger.info("Tokenizer loaded from %s with vocab size %d", model_path, len(tokenizer))
+
+    tp_size = int(os.environ.get("TP_SIZE", str(len(jax.devices()))))
+    logger.info("Using TP size: %d", tp_size)
+    server_args = ServerArgs(
+        model_path=model_path,
+        tokenizer_path=model_path,
+        trust_remote_code=True,
+        tp_size=tp_size,
+        ep_size=1,
+        device="tpu",
+        dtype="bfloat16",
+        attention_backend="fa",
+        mem_fraction_static=0.8,
+        page_size=64,
+        max_running_requests=1,
+        skip_server_warmup=True,
+        log_level="info",
+    )
+    _set_envs_and_config(server_args)
+
+    model_config = ModelConfig.from_server_args(server_args)
+
+    num_layers_env = os.environ.get("NUM_LAYERS")
+    if num_layers_env is not None:
+        num_layers = int(num_layers_env)
+        logger.info("Overriding num_hidden_layers to %d for prompt testing...", num_layers)
+        model_config.hf_text_config.num_hidden_layers = num_layers
+        model_config.num_hidden_layers = num_layers
+        if (
+            hasattr(model_config.hf_config, "text_config")
+            and model_config.hf_config.text_config is not None
+        ):
+            model_config.hf_config.text_config.num_hidden_layers = num_layers
+
+    # Create mesh
+    all_devices = jax.devices()
+    tp = min(server_args.tp_size, len(all_devices))
+    mesh = create_device_mesh(
+        ici_parallelism=[-1, tp],
+        dcn_parallelism=[1, 1],
+    )
+
+    logger.info("Instantiating ModelRunner with mesh %s...", mesh)
+    model_runner = ModelRunner(
+        model_config=model_config,
+        mem_fraction_static=server_args.mem_fraction_static,
+        tp_size=tp,
+        dp_size=1,
+        server_args=server_args,
+        mesh=mesh,
+    )
+    model_runner.req_to_token_pool.init_cache_loc_host_buffer(model_runner.max_total_num_tokens)
+    logger.info("ModelRunner successfully initialized and weights loaded onto TPU!")
+
+    # Test prompts for verification
+    prompts = [
+        "The capital of France is",
+        "What is the boiling point of water in Celsius? Answer:",
+        "Translate 'Good morning' into Spanish: ",
+        "Calculate: 25 * 4 = ",
+        "Python function to add two numbers:\ndef add(a, b):",
+    ]
+
+    for p in prompts:
+        print("\n" + "=" * 50)
+        print(f"PROMPT: {p}")
+        out = generate_for_prompt(p, model_runner, tokenizer, max_new_tokens=32)
+        print(f"RESPONSE: {out}")
+        print("=" * 50 + "\n")
+        assert len(out.strip()) > 0, f"Empty response generated for prompt: {p}"
+
+    logger.info("SUCCESS: All prompt generation tests passed with verified legible responses!")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sgl_jax/test/kernels/test_kimi_int4_loading.py
+++ b/python/sgl_jax/test/kernels/test_kimi_int4_loading.py
@@ -1,0 +1,198 @@
+import logging
+import os
+
+host0 = "10.128.0.2"
+host1 = "10.128.0.4"
+os.environ["TPU_WORKER_HOSTNAMES"] = f"{host0},{host1}"
+os.environ["TPU_PROCESS_ADDRESSES"] = f"{host0}:8471,{host1}:8471"
+
+# Override coordinator port to avoid "newer incarnation" crashes
+if "JAX_COORDINATOR_ADDRESS" in os.environ:
+    os.environ["JAX_COORDINATOR_ADDRESS"] = os.environ["JAX_COORDINATOR_ADDRESS"].rsplit(":", 1)[0] + ":10025"
+if "MEGASCALE_COORDINATOR_ADDRESS" in os.environ:
+    os.environ["MEGASCALE_COORDINATOR_ADDRESS"] = os.environ["MEGASCALE_COORDINATOR_ADDRESS"].rsplit(":", 1)[0] + ":10026"
+
+import jax
+
+# Set up logging immediately
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("test_kimi_int4_loading")
+
+# Set TPU overrides before JAX init and backend init
+process_id = int(os.environ.get("JAX_PROCESS_ID", 0))
+
+if process_id == 0:
+    os.environ["TPU_WORKER_HOSTNAMES"] = host0
+    os.environ["TPU_PROCESS_ADDRESSES"] = f"{host0}:8471"
+    os.environ["TPU_HOSTNAME_OVERRIDE"] = host0
+    os.environ["MEGASCALE_SLICE_ID"] = "0"
+elif process_id == 1:
+    os.environ["TPU_WORKER_HOSTNAMES"] = host1
+    os.environ["TPU_PROCESS_ADDRESSES"] = f"{host1}:8471"
+    os.environ["TPU_HOSTNAME_OVERRIDE"] = host1
+    os.environ["MEGASCALE_SLICE_ID"] = "1"
+
+os.environ["TPU_HOST_BOUNDS"] = "1,1,1"
+os.environ["MEGASCALE_NUM_SLICES"] = "2"
+os.environ["MEGASCALE_COORDINATOR_ADDRESS"] = f"{host0}:9915"
+
+logger.info(
+    "TPU overrides set in Python: TPU_WORKER_HOSTNAMES=%s, TPU_HOSTNAME_OVERRIDE=%s, MEGASCALE_SLICE_ID=%s, TPU_HOST_BOUNDS=%s",
+    os.environ["TPU_WORKER_HOSTNAMES"],
+    os.environ["TPU_HOSTNAME_OVERRIDE"],
+    os.environ["MEGASCALE_SLICE_ID"],
+    os.environ["TPU_HOST_BOUNDS"],
+)
+
+# Initialize JAX distributed as early as possible to avoid backend init issues
+if "JAX_COORDINATOR_ADDRESS" in os.environ:
+    logger.info("Initializing JAX distributed at startup...")
+    try:
+        jax.distributed.initialize()
+        logger.info("JAX Distributed Initialized successfully at startup.")
+    except Exception as e:
+        logger.info("JAX distributed init failed or already initialized: %s", e)
+
+import numpy as np
+import jax.numpy as jnp
+from flax import nnx
+from jax.sharding import AxisType, Mesh
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.multimodal.models.kimi_k25.kimi_k25_vl_generation import (
+    KimiK25ForConditionalGeneration,
+)
+from sgl_jax.srt.utils.quantization.quantization_utils import (
+    apply_linear_quantization,
+    apply_moe_quantization,
+)
+
+
+def main():
+    model_path = os.environ.get("MODEL_PATH", "/dsk/models/kimi_original_new")
+
+    # 1. Build TPU Mesh
+    devices = jax.devices()
+    logger.info("Available JAX devices: %d (%s)", len(devices), [d.platform for d in devices])
+    mesh = Mesh(
+        np.array(devices).reshape(1, len(devices)),
+        axis_names=("data", "tensor"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit),
+    )
+
+    # 2. Create ModelConfig
+    logger.info("Creating ModelConfig for: %s", model_path)
+    model_config = ModelConfig(
+        model_path=model_path,
+        trust_remote_code=True,
+        dtype="bfloat16",
+    )
+
+    # Configure ideal sharding for available devices
+    ep_size = int(os.environ.get("EP_SIZE", len(devices)))
+    model_config.ep_size = ep_size
+    if hasattr(model_config, "hf_config"):
+        model_config.hf_config.ep_size = ep_size
+        if (
+            hasattr(model_config.hf_config, "text_config")
+            and model_config.hf_config.text_config is not None
+        ):
+            model_config.hf_config.text_config.ep_size = ep_size
+    if hasattr(model_config, "hf_text_config") and model_config.hf_text_config is not None:
+        model_config.hf_text_config.ep_size = ep_size
+
+    num_layers_env = os.environ.get("NUM_LAYERS")
+    if num_layers_env is not None:
+        num_layers = int(num_layers_env)
+        logger.info("Patching ModelConfig to %d layers for custom verification...", num_layers)
+        model_config.hf_text_config.num_hidden_layers = num_layers
+        model_config.num_hidden_layers = num_layers
+        if (
+            hasattr(model_config.hf_config, "text_config")
+            and model_config.hf_config.text_config is not None
+        ):
+            model_config.hf_config.text_config.num_hidden_layers = num_layers
+
+    # 3. Instantiate ABSTRACT model under nnx.eval_shape to avoid HBM out-of-memory
+    logger.info("Instantiating abstract KimiK25ForConditionalGeneration under nnx.eval_shape...")
+    with jax.set_mesh(mesh):
+        model = nnx.eval_shape(
+            lambda: KimiK25ForConditionalGeneration(
+                model_config.hf_config,
+                dtype=model_config.dtype,
+                mesh=mesh,
+            )
+        )
+
+    # 4. Apply Selective Quantization structure modifications on the abstract model
+    logger.info("Applying selective linear quantization (is_static_input=True) on abstract model...")
+    model = apply_linear_quantization(model_config, model, is_static_input=True)
+
+    logger.info("Applying MoE quantization (is_static_input=True) on abstract model...")
+    model = apply_moe_quantization(model_config, model, is_static_input=True)
+
+    layers = model.model.layers
+    moe_layer = layers[1]
+
+    # 5. Load weights via WeightLoader
+    logger.info("Loading weights from safetensors onto TPU...")
+    model.load_weights(model_config)
+
+    # 6. Verify loaded parameters are materialized and in JAX-native int4
+    if hasattr(moe_layer.mlp, "wi_0"):
+        param_after = moe_layer.mlp.wi_0.value
+        logger.info("Parameter type after loading: %s", type(param_after))
+        logger.info("Loaded Parameter shape: %s, dtype: %s", param_after.shape, param_after.dtype)
+
+        assert not isinstance(
+            param_after, jax.ShapeDtypeStruct
+        ), "Weight is still abstract after loading!"
+        int4_types = [getattr(jnp, t) for t in ["int4", "uint4"] if hasattr(jnp, t)]
+        assert (
+            param_after.dtype in int4_types
+        ), f"Weight dtype is {param_after.dtype}, expected jnp.int4!"
+
+    # 7. Run a dummy forward pass on both dense MLP and EPMoE to verify dynamic compilation & device execution dtypes
+    logger.info("Constructing dummy inputs to trigger execution...")
+    batch_seq = 16
+    hidden_size = moe_layer.mlp.hidden_size
+    num_experts_per_tok = moe_layer.mlp.num_experts_per_tok
+
+    dummy_hidden_states = jax.random.normal(
+        jax.random.PRNGKey(42), (batch_seq, hidden_size), dtype=jnp.bfloat16
+    )
+    dummy_topk_weights = jax.random.uniform(
+        jax.random.key(43), (batch_seq, num_experts_per_tok), dtype=jnp.bfloat16
+    )
+    dummy_topk_ids = jax.random.randint(
+        jax.random.key(44), (batch_seq, num_experts_per_tok), 0, moe_layer.mlp.num_experts
+    )
+
+    # 7a. Execute Dense FFN (Layer 0 MLP)
+    dense_mlp = layers[0].mlp
+    logger.info("Executing Dense FFN forward pass on TPU...")
+    with jax.set_mesh(mesh):
+        output_dense = dense_mlp(dummy_hidden_states)
+        output_dense.block_until_ready()
+    logger.info(
+        "Dense FFN Output successfully materialized on TPU - shape: %s, dtype: %s",
+        output_dense.shape,
+        output_dense.dtype,
+    )
+
+    # 7b. Execute Sparse FFN (MoE Layer MLP)
+    logger.info("Executing EPMoE forward pass (GMM Kernel on TPU)...")
+    with jax.set_mesh(mesh):
+        output_moe = moe_layer.mlp(dummy_hidden_states, dummy_topk_weights, dummy_topk_ids)
+        output_moe.block_until_ready()
+    logger.info(
+        "EPMoE Output successfully materialized on TPU - shape: %s, dtype: %s",
+        output_moe.shape,
+        output_moe.dtype,
+    )
+
+    logger.info("SUCCESS: Kimi K2.5 Raw INT4 Weights Successfully Unpacked, Loaded and Verified!")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sgl_jax/test/kernels/test_kimi_int4_loading_single.py
+++ b/python/sgl_jax/test/kernels/test_kimi_int4_loading_single.py
@@ -1,0 +1,151 @@
+import logging
+import os
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+from jax.sharding import AxisType, Mesh
+
+from sgl_jax.srt.configs.model_config import ModelConfig
+from sgl_jax.srt.multimodal.models.kimi_k25.kimi_k25_vl_generation import (
+    KimiK25ForConditionalGeneration,
+)
+from sgl_jax.srt.utils.quantization.quantization_utils import (
+    apply_linear_quantization,
+    apply_moe_quantization,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("test_kimi_int4_loading_single")
+
+
+def main():
+    model_path = os.environ.get("MODEL_PATH", "/dsk/models/kimi_original_new")
+
+    # 1. Build TPU Mesh
+    devices = jax.devices()
+    logger.info("Available JAX devices: %d (%s)", len(devices), [d.platform for d in devices])
+    mesh = Mesh(
+        np.array(devices).reshape(1, len(devices)),
+        axis_names=("data", "tensor"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit),
+    )
+
+    # 2. Create ModelConfig
+    logger.info("Creating ModelConfig for: %s", model_path)
+    model_config = ModelConfig(
+        model_path=model_path,
+        trust_remote_code=True,
+        dtype="bfloat16",
+    )
+
+    # Configure ideal sharding for available devices (EP=1, TP=len(devices))
+    model_config.ep_size = 1
+    if hasattr(model_config, "hf_config"):
+        model_config.hf_config.ep_size = 1
+        if (
+            hasattr(model_config.hf_config, "text_config")
+            and model_config.hf_config.text_config is not None
+        ):
+            model_config.hf_config.text_config.ep_size = 1
+            model_config.hf_config.text_config.n_routed_experts = 16
+    if hasattr(model_config, "hf_text_config") and model_config.hf_text_config is not None:
+        model_config.hf_text_config.ep_size = 1
+        model_config.hf_text_config.n_routed_experts = 16
+
+    num_layers_env = os.environ.get("NUM_LAYERS")
+    if num_layers_env is not None:
+        num_layers = int(num_layers_env)
+        logger.info("Patching ModelConfig to %d layers for custom verification...", num_layers)
+        model_config.hf_text_config.num_hidden_layers = num_layers
+        model_config.num_hidden_layers = num_layers
+        if (
+            hasattr(model_config.hf_config, "text_config")
+            and model_config.hf_config.text_config is not None
+        ):
+            model_config.hf_config.text_config.num_hidden_layers = num_layers
+
+    # 3. Instantiate ABSTRACT model under nnx.eval_shape to avoid HBM out-of-memory
+    logger.info("Instantiating abstract KimiK25ForConditionalGeneration under nnx.eval_shape...")
+    with jax.set_mesh(mesh):
+        model = nnx.eval_shape(
+            lambda: KimiK25ForConditionalGeneration(
+                model_config.hf_config,
+                dtype=model_config.dtype,
+                mesh=mesh,
+            )
+        )
+
+    # 4. Apply Selective Quantization structure modifications on the abstract model
+    logger.info("Applying selective linear quantization (is_static_input=True) on abstract model...")
+    model = apply_linear_quantization(model_config, model, is_static_input=True)
+
+    logger.info("Applying MoE quantization (is_static_input=True) on abstract model...")
+    model = apply_moe_quantization(model_config, model, is_static_input=True)
+
+    layers = model.model.layers
+    moe_layer = layers[1]
+
+    # 5. Load weights via WeightLoader
+    logger.info("Loading weights from safetensors onto TPU...")
+    model.load_weights(model_config)
+
+    # 6. Verify loaded parameters are materialized and in JAX-native int4
+    if hasattr(moe_layer.mlp, "wi_0"):
+        param_after = moe_layer.mlp.wi_0.value
+        logger.info("Parameter type after loading: %s", type(param_after))
+        logger.info("Loaded Parameter shape: %s, dtype: %s", param_after.shape, param_after.dtype)
+
+        assert not isinstance(
+            param_after, jax.ShapeDtypeStruct
+        ), "Weight is still abstract after loading!"
+        int4_types = [getattr(jnp, t) for t in ["int4", "uint4"] if hasattr(jnp, t)]
+        assert (
+            param_after.dtype in int4_types
+        ), f"Weight dtype is {param_after.dtype}, expected jnp.int4!"
+
+    # 7. Run a dummy forward pass on both dense MLP and EPMoE to verify dynamic compilation & device execution dtypes
+    logger.info("Constructing dummy inputs to trigger execution...")
+    batch_seq = 16
+    hidden_size = moe_layer.mlp.hidden_size
+    num_experts_per_tok = moe_layer.mlp.num_experts_per_tok
+
+    dummy_hidden_states = jax.random.normal(
+        jax.random.PRNGKey(42), (batch_seq, hidden_size), dtype=jnp.bfloat16
+    )
+    dummy_topk_weights = jax.random.uniform(
+        jax.random.key(43), (batch_seq, num_experts_per_tok), dtype=jnp.bfloat16
+    )
+    dummy_topk_ids = jax.random.randint(
+        jax.random.key(44), (batch_seq, num_experts_per_tok), 0, moe_layer.mlp.num_experts
+    )
+
+    # 7a. Execute Dense FFN (Layer 0 MLP)
+    dense_mlp = layers[0].mlp
+    logger.info("Executing Dense FFN forward pass on TPU...")
+    with jax.set_mesh(mesh):
+        output_dense = dense_mlp(dummy_hidden_states)
+        output_dense.block_until_ready()
+    logger.info(
+        "Dense FFN Output successfully materialized on TPU - shape: %s, dtype: %s",
+        output_dense.shape,
+        output_dense.dtype,
+    )
+
+    # 7b. Execute Sparse FFN (MoE Layer MLP)
+    logger.info("Executing EPMoE forward pass (GMM Kernel on TPU)...")
+    with jax.set_mesh(mesh):
+        output_moe = moe_layer.mlp(dummy_hidden_states, dummy_topk_weights, dummy_topk_ids)
+        output_moe.block_until_ready()
+    logger.info(
+        "EPMoE Output successfully materialized on TPU - shape: %s, dtype: %s",
+        output_moe.shape,
+        output_moe.dtype,
+    )
+
+    logger.info("SUCCESS: Kimi K2.5 Raw INT4 Weights Successfully Unpacked, Loaded and Verified!")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sgl_jax/test/multimodal/test_kimi_k25_weight_mapping.py
+++ b/python/sgl_jax/test/multimodal/test_kimi_k25_weight_mapping.py
@@ -2,7 +2,9 @@ import types
 from types import SimpleNamespace
 
 
-def _make_stub(num_hidden_layers, first_k_dense_replace, n_routed_experts):
+def _make_stub(
+    num_hidden_layers, first_k_dense_replace, n_routed_experts, quant_config=None
+):
     from sgl_jax.srt.multimodal.models.kimi_k25.kimi_k25_vl_generation import (
         KimiK25ForConditionalGeneration,
     )
@@ -17,7 +19,7 @@ def _make_stub(num_hidden_layers, first_k_dense_replace, n_routed_experts):
         ),
         hf_weight_prefix="language_model.",
         loader=SimpleNamespace(
-            is_static_quant=False,
+            is_static_quant=quant_config.is_static_checkpoint if quant_config else False,
             is_quant_ignored=lambda k: False,
         ),
     )
@@ -29,7 +31,7 @@ def _make_stub(num_hidden_layers, first_k_dense_replace, n_routed_experts):
         num_hidden_layers=num_hidden_layers,
         first_k_dense_replace=first_k_dense_replace,
         n_routed_experts=n_routed_experts,
-        quantization_config=None,
+        quantization_config=quant_config,
     )
     return KimiK25ForConditionalGeneration._create_weight_mappings(model, config)
 
@@ -67,3 +69,32 @@ def test_no_target_has_language_model_prefix():
         targets = m.target_path[0] if isinstance(m.target_path, list) else [m.target_path]
         for t in targets:
             assert not t.startswith("language_model."), f"target_path should not have prefix: {t}"
+
+
+def test_int4_moe_weight_mappings():
+    import jax.numpy as jnp
+    from sgl_jax.srt.configs.quantization_config import QuantizationConfig
+
+    quant_config = QuantizationConfig(
+        is_static_checkpoint=True,
+        linear_rules=[],
+        moe_weight_dtype=getattr(jnp, "int4", None) or getattr(jnp, "uint4", None),
+    )
+    mappings = _make_stub(
+        num_hidden_layers=2,
+        first_k_dense_replace=1,
+        n_routed_experts=16,
+        quant_config=quant_config,
+    )
+
+    # Layer 0 (dense) linear weights should be unquantized (.weight)
+    assert "language_model.model.layers.0.mlp.gate_proj.weight" in mappings
+
+    # Layer 1 (MoE) expert weights should use weight_packed
+    expert_group_wi_0 = mappings["__MOE_EXPERTS__model.layers.1.mlp.wi_0"]
+    assert any(".weight_packed" in k for k in expert_group_wi_0.target_path[1:])
+
+    # Layer 1 (MoE) scales should use .weight_scale
+    scale_group_wi_0 = mappings["__MOE_EXPERTS__model.layers.1.mlp.wi_0_scale"]
+    assert any(".weight_scale" in k for k in scale_group_wi_0.target_path[1:])
+


### PR DESCRIPTION
## Motivation

The goal of this Pull Request is to support loading and running inference on the official Kimi K2.5 / DeepSeek-V3 compressed-tensors INT4 pack-quantized weights in both single-host and multi-host TPU environments.

Previously, sglang-jax lacked a pipeline to load and unpack packed 4-bit checkpoint formats dynamically on TPUs. This PR introduces:

Dynamic On-Device Bit-Unpacking: JIT-compiled unpack_4bit_jax on TPU that unpacks int32/uint32/int8 packed arrays with the -8 offset correction required by the compressed-tensors signed 4-bit format.
Deferred Transposition: Prevents premature CPU/packed transpositions to eliminate bit corruption, performing the transpose in JAX on-device post-unpacking.
Abstract Memory Initialization: Introduces abstract jax.ShapeDtypeStruct parameter instantiation under nnx.eval_shape to prevent host RAM / TPU HBM out-of-memory errors when initializing large MoE models (e.g. 61 layers, 384 experts).
Scale Sharding Alignment: Corrects wo_scale and wi_scale tensor parallel sharding in EPMoE and DeepSeek-V3 weight mappings to match Megablox GMM kernel contracts, making wo_scale sharding conditional on block quantization (k_blocks > 1).
KV Cache Data Mesh Alignment: Aligns KV token capacity with the data mesh dimension in ModelRunnerKVCacheMixin.

## Modifications



## Accuracy Tests

All unit tests and end-to-end forward/decode passes have been verified on TPU:

Test Environment:
Hardware: TPU v7x (8 devices single-host, 16 devices multi-host).
Model: Kimi K2.5 (/dsk/models/kimi_original_new, 61 layers, 384 experts, packed INT4 safetensors).
Execution Verification:
Abstract initialization under nnx.eval_shape passed without OOM.
Both Dense FFN (Layer 0) and Sparse MoE (Layer 1 EPMoE) compiled and executed on TPU.
Full 61-layer model prompt generation tested with greedy sampling producing accurate responses:
Prompt: "The capital of France is" 
→
→ Output: "Paris."
Prompt: "What is the boiling point of water in Celsius? Answer:" 
→
→ Output: "100"
Prompt: "Calculate: 25 * 4 = " 
→
→ Output: "100"
Weight Loader Datatype Lifecycle Logs
JAX TPU Bit-Unpacking: Unpacks raw int32 tensors from safetensors into JAX int4 weights with centering:
INFO:root:Unpacking 4-bit weights with -8 offset on TPU: int32 -> int4
Materialized Parameter Shape & Dtype:


INFO:test_kimi_int4_loading:Parameter type after loading: <class 'jaxlib._jax.ArrayImpl'>
INFO:test_kimi_int4_loading:Loaded Parameter shape: (384, 7168, 2048), dtype: int4
Megablox GMM Execution:
INFO:sgl_jax.srt.layers.moe:EPMoE GMM stage - LHS activation shape: (16, 7168), dtype: bfloat16 | RHS weight shape: (384, 7168, 2048), dtype: int4 | RHS scale shape: (384, 224, 1, 2048), dtype: bfloat16

In addition to this, MMMU benchmarks were run and 78.11% accuracy was obtained using 32k token budget. 
The changes included in this PR along with https://github.com/sgl-project/sglang-jax/pull/1314 were done to test the model accuracy using evalscope. 

https://gist.github.com/chaitanyapk/b07160398746c2c37818506f7993376d

This has the initial 16k token budget run log with 75.11% accuracy and the 6 underperforming subjects that were hitting token budget were re-run with 32k budget to get the reported 78.11% accuracy.



## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
