### PR TITLE
Enabling Spec decode for GLM 5.2

### DIFF
--- a/python/sgl_jax/bench_one_batch_server.py
+++ b/python/sgl_jax/bench_one_batch_server.py
@@ -21,11 +21,7 @@ import time
 
 import requests
 
-from sgl_jax.bench_serving import (
-    get_tokenizer,
-    sample_random_requests,
-    sample_generated_shared_prefix_requests,
-)
+from sgl_jax.bench_serving import get_tokenizer, sample_random_requests
 from sgl_jax.profiler import run_profile
 from sgl_jax.srt.entrypoints import http_server
 from sgl_jax.srt.server_args import ServerArgs
@@ -50,18 +46,6 @@ class BenchArgs:
     profile: bool = False
     profile_by_stage: bool = False
     api_type: str = "native"  # "native" or "openai"
-    dataset_name: str = "random"
-    gsp_num_groups: int = 1
-    gsp_prompts_per_group: int = 1
-    gsp_system_prompt_len: int = 1024
-    gsp_question_len: int = 100
-    gsp_output_len: int = 16
-    gsp_range_ratio: float = 1.0
-    seed: int = 1
-    gsp_send_routing_key: bool = False
-    gsp_num_turns: int = 1
-    gsp_fast_prepare: bool = False
-    gsp_ordered: bool = False
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):
@@ -94,25 +78,12 @@ class BenchArgs:
             choices=["native", "openai"],
             help="API type to use: 'native' for /generate or 'openai' for /v1/completions",
         )
-        parser.add_argument("--dataset-name", type=str, default=BenchArgs.dataset_name)
-        parser.add_argument("--gsp-num-groups", type=int, default=BenchArgs.gsp_num_groups)
-        parser.add_argument("--gsp-prompts-per-group", type=int, default=BenchArgs.gsp_prompts_per_group)
-        parser.add_argument("--gsp-system-prompt-len", type=int, default=BenchArgs.gsp_system_prompt_len)
-        parser.add_argument("--gsp-question-len", type=int, default=BenchArgs.gsp_question_len)
-        parser.add_argument("--gsp-output-len", type=int, default=BenchArgs.gsp_output_len)
-        parser.add_argument("--gsp-range-ratio", type=float, default=BenchArgs.gsp_range_ratio)
-        parser.add_argument("--seed", type=int, default=BenchArgs.seed)
-        parser.add_argument("--gsp-send-routing-key", action="store_true", default=BenchArgs.gsp_send_routing_key)
-        parser.add_argument("--gsp-num-turns", type=int, default=BenchArgs.gsp_num_turns)
-        parser.add_argument("--gsp-fast-prepare", action="store_true", default=BenchArgs.gsp_fast_prepare)
-        parser.add_argument("--gsp-ordered", action="store_true", default=BenchArgs.gsp_ordered)
 
     @classmethod
     def from_cli_args(cls, args: argparse.Namespace):
         # use the default value's type to cast the args into correct types.
         attrs = [(attr.name, type(attr.default)) for attr in dataclasses.fields(cls)]
-        # Use default from dataclass if argument isn't present in args
-        return cls(**{attr: attr_type(getattr(args, attr, getattr(cls, attr))) for attr, attr_type in attrs})
+        return cls(**{attr: attr_type(getattr(args, attr)) for attr, attr_type in attrs})
 
 
 def launch_server_internal(server_args):
@@ -160,42 +131,21 @@ def run_one_case(
     profile: bool = False,
     profile_by_stage: bool = False,
     api_type: str = "native",
-    bench_args: BenchArgs = None,
 ):
     requests.post(url + "/flush_cache")
 
     # Determine whether to use text or input_ids based on API type
     return_text = api_type == "openai"
-    
-    if bench_args is not None and getattr(bench_args, "dataset_name", "") == "generated-shared-prefix":
-        # Override prompts_per_group so we can test different batch sizes in one run
-        dynamic_prompts_per_group = max(1, batch_size // bench_args.gsp_num_groups)
-        bench_args.gsp_prompts_per_group = dynamic_prompts_per_group
-        
-        input_requests = sample_generated_shared_prefix_requests(
-            num_groups=bench_args.gsp_num_groups,
-            prompts_per_group=dynamic_prompts_per_group,
-            system_prompt_len=bench_args.gsp_system_prompt_len,
-            question_len=bench_args.gsp_question_len,
-            output_len=bench_args.gsp_output_len,
-            range_ratio=getattr(bench_args, "gsp_range_ratio", 1.0),
-            tokenizer=tokenizer,
-            args=bench_args,
-        )
-        batch_size = len(input_requests)
-        input_len = bench_args.gsp_system_prompt_len + bench_args.gsp_question_len
-        output_len = bench_args.gsp_output_len
-    else:
-        input_requests = sample_random_requests(
-            input_len=input_len,
-            output_len=output_len,
-            num_prompts=batch_size,
-            range_ratio=1.0,
-            tokenizer=tokenizer,
-            dataset_path="",
-            random_sample=True,
-            return_text=return_text,
-        )
+    input_requests = sample_random_requests(
+        input_len=input_len,
+        output_len=output_len,
+        num_prompts=batch_size,
+        range_ratio=1.0,
+        tokenizer=tokenizer,
+        dataset_path="",
+        random_sample=True,
+        return_text=return_text,
+    )
 
     use_structured_outputs = False
     if use_structured_outputs:
@@ -271,25 +221,20 @@ def run_one_case(
                     total_chunks += 1
     else:
         # Use native API
-        json_data = {
-            "sampling_params": {
-                "temperature": temperature,
-                "max_new_tokens": output_len,
-                "ignore_eos": True,
-                "json_schema": json_schema,
-                "stream_interval": stream_interval,
-            },
-            "return_logprob": return_logprob,
-            "stream": True,
-        }
-        if getattr(bench_args, "dataset_name", "") == "generated-shared-prefix":
-            json_data["text"] = [req.prompt for req in input_requests]
-        else:
-            json_data["input_ids"] = [req.prompt for req in input_requests]
-
         response = requests.post(
             url + "/generate",
-            json=json_data,
+            json={
+                "input_ids": [req.prompt for req in input_requests],
+                "sampling_params": {
+                    "temperature": temperature,
+                    "max_new_tokens": output_len,
+                    "ignore_eos": True,
+                    "json_schema": json_schema,
+                    "stream_interval": stream_interval,
+                },
+                "return_logprob": return_logprob,
+                "stream": True,
+            },
             stream=True,
         )
 
@@ -386,7 +331,6 @@ def run_benchmark(server_args: ServerArgs, bench_args: BenchArgs):
             result_filename="",
             tokenizer=tokenizer,
             api_type=bench_args.api_type,
-            bench_args=bench_args,
         )
         print("=" * 8 + " Warmup End   " + "=" * 8 + "\n")
 
@@ -411,7 +355,6 @@ def run_benchmark(server_args: ServerArgs, bench_args: BenchArgs):
                     result_filename=bench_args.result_filename,
                     tokenizer=tokenizer,
                     api_type=bench_args.api_type,
-                    bench_args=bench_args,
                 )
             )
 
@@ -437,7 +380,6 @@ def run_benchmark(server_args: ServerArgs, bench_args: BenchArgs):
                                 profile=bench_args.profile,
                                 profile_by_stage=bench_args.profile_by_stage,
                                 api_type=bench_args.api_type,
-                                bench_args=bench_args,
                             )[-1],
                         )
                     )

--- a/python/sgl_jax/bench_one_batch_server.py
+++ b/python/sgl_jax/bench_one_batch_server.py
@@ -21,7 +21,11 @@ import time
 
 import requests
 
-from sgl_jax.bench_serving import get_tokenizer, sample_random_requests
+from sgl_jax.bench_serving import (
+    get_tokenizer,
+    sample_random_requests,
+    sample_generated_shared_prefix_requests,
+)
 from sgl_jax.profiler import run_profile
 from sgl_jax.srt.entrypoints import http_server
 from sgl_jax.srt.server_args import ServerArgs
@@ -46,6 +50,18 @@ class BenchArgs:
     profile: bool = False
     profile_by_stage: bool = False
     api_type: str = "native"  # "native" or "openai"
+    dataset_name: str = "random"
+    gsp_num_groups: int = 1
+    gsp_prompts_per_group: int = 1
+    gsp_system_prompt_len: int = 1024
+    gsp_question_len: int = 100
+    gsp_output_len: int = 16
+    gsp_range_ratio: float = 1.0
+    seed: int = 1
+    gsp_send_routing_key: bool = False
+    gsp_num_turns: int = 1
+    gsp_fast_prepare: bool = False
+    gsp_ordered: bool = False
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):
@@ -78,12 +94,25 @@ class BenchArgs:
             choices=["native", "openai"],
             help="API type to use: 'native' for /generate or 'openai' for /v1/completions",
         )
+        parser.add_argument("--dataset-name", type=str, default=BenchArgs.dataset_name)
+        parser.add_argument("--gsp-num-groups", type=int, default=BenchArgs.gsp_num_groups)
+        parser.add_argument("--gsp-prompts-per-group", type=int, default=BenchArgs.gsp_prompts_per_group)
+        parser.add_argument("--gsp-system-prompt-len", type=int, default=BenchArgs.gsp_system_prompt_len)
+        parser.add_argument("--gsp-question-len", type=int, default=BenchArgs.gsp_question_len)
+        parser.add_argument("--gsp-output-len", type=int, default=BenchArgs.gsp_output_len)
+        parser.add_argument("--gsp-range-ratio", type=float, default=BenchArgs.gsp_range_ratio)
+        parser.add_argument("--seed", type=int, default=BenchArgs.seed)
+        parser.add_argument("--gsp-send-routing-key", action="store_true", default=BenchArgs.gsp_send_routing_key)
+        parser.add_argument("--gsp-num-turns", type=int, default=BenchArgs.gsp_num_turns)
+        parser.add_argument("--gsp-fast-prepare", action="store_true", default=BenchArgs.gsp_fast_prepare)
+        parser.add_argument("--gsp-ordered", action="store_true", default=BenchArgs.gsp_ordered)
 
     @classmethod
     def from_cli_args(cls, args: argparse.Namespace):
         # use the default value's type to cast the args into correct types.
         attrs = [(attr.name, type(attr.default)) for attr in dataclasses.fields(cls)]
-        return cls(**{attr: attr_type(getattr(args, attr)) for attr, attr_type in attrs})
+        # Use default from dataclass if argument isn't present in args
+        return cls(**{attr: attr_type(getattr(args, attr, getattr(cls, attr))) for attr, attr_type in attrs})
 
 
 def launch_server_internal(server_args):
@@ -131,21 +160,42 @@ def run_one_case(
     profile: bool = False,
     profile_by_stage: bool = False,
     api_type: str = "native",
+    bench_args: BenchArgs = None,
 ):
     requests.post(url + "/flush_cache")
 
     # Determine whether to use text or input_ids based on API type
     return_text = api_type == "openai"
-    input_requests = sample_random_requests(
-        input_len=input_len,
-        output_len=output_len,
-        num_prompts=batch_size,
-        range_ratio=1.0,
-        tokenizer=tokenizer,
-        dataset_path="",
-        random_sample=True,
-        return_text=return_text,
-    )
+    
+    if bench_args is not None and getattr(bench_args, "dataset_name", "") == "generated-shared-prefix":
+        # Override prompts_per_group so we can test different batch sizes in one run
+        dynamic_prompts_per_group = max(1, batch_size // bench_args.gsp_num_groups)
+        bench_args.gsp_prompts_per_group = dynamic_prompts_per_group
+        
+        input_requests = sample_generated_shared_prefix_requests(
+            num_groups=bench_args.gsp_num_groups,
+            prompts_per_group=dynamic_prompts_per_group,
+            system_prompt_len=bench_args.gsp_system_prompt_len,
+            question_len=bench_args.gsp_question_len,
+            output_len=bench_args.gsp_output_len,
+            range_ratio=getattr(bench_args, "gsp_range_ratio", 1.0),
+            tokenizer=tokenizer,
+            args=bench_args,
+        )
+        batch_size = len(input_requests)
+        input_len = bench_args.gsp_system_prompt_len + bench_args.gsp_question_len
+        output_len = bench_args.gsp_output_len
+    else:
+        input_requests = sample_random_requests(
+            input_len=input_len,
+            output_len=output_len,
+            num_prompts=batch_size,
+            range_ratio=1.0,
+            tokenizer=tokenizer,
+            dataset_path="",
+            random_sample=True,
+            return_text=return_text,
+        )
 
     use_structured_outputs = False
     if use_structured_outputs:
@@ -221,20 +271,25 @@ def run_one_case(
                     total_chunks += 1
     else:
         # Use native API
+        json_data = {
+            "sampling_params": {
+                "temperature": temperature,
+                "max_new_tokens": output_len,
+                "ignore_eos": True,
+                "json_schema": json_schema,
+                "stream_interval": stream_interval,
+            },
+            "return_logprob": return_logprob,
+            "stream": True,
+        }
+        if getattr(bench_args, "dataset_name", "") == "generated-shared-prefix":
+            json_data["text"] = [req.prompt for req in input_requests]
+        else:
+            json_data["input_ids"] = [req.prompt for req in input_requests]
+
         response = requests.post(
             url + "/generate",
-            json={
-                "input_ids": [req.prompt for req in input_requests],
-                "sampling_params": {
-                    "temperature": temperature,
-                    "max_new_tokens": output_len,
-                    "ignore_eos": True,
-                    "json_schema": json_schema,
-                    "stream_interval": stream_interval,
-                },
-                "return_logprob": return_logprob,
-                "stream": True,
-            },
+            json=json_data,
             stream=True,
         )
 
@@ -331,6 +386,7 @@ def run_benchmark(server_args: ServerArgs, bench_args: BenchArgs):
             result_filename="",
             tokenizer=tokenizer,
             api_type=bench_args.api_type,
+            bench_args=bench_args,
         )
         print("=" * 8 + " Warmup End   " + "=" * 8 + "\n")
 
@@ -355,6 +411,7 @@ def run_benchmark(server_args: ServerArgs, bench_args: BenchArgs):
                     result_filename=bench_args.result_filename,
                     tokenizer=tokenizer,
                     api_type=bench_args.api_type,
+                    bench_args=bench_args,
                 )
             )
 
@@ -380,6 +437,7 @@ def run_benchmark(server_args: ServerArgs, bench_args: BenchArgs):
                                 profile=bench_args.profile,
                                 profile_by_stage=bench_args.profile_by_stage,
                                 api_type=bench_args.api_type,
+                                bench_args=bench_args,
                             )[-1],
                         )
                     )

--- a/python/sgl_jax/srt/configs/model_config.py
+++ b/python/sgl_jax/srt/configs/model_config.py
@@ -189,6 +189,9 @@ class ModelConfig:
         if is_draft_model and self.hf_config.architectures[0] == "DeepseekV3ForCausalLM":
             self.hf_config.architectures[0] = "DeepseekV3ForCausalLMNextN"
 
+        if is_draft_model and self.hf_config.architectures[0] == "GlmMoeDsaForCausalLM":
+            self.hf_config.architectures[0] = "GlmMoeDsaForCausalLMNextN"
+
         if is_draft_model and self.hf_config.architectures[0] == "LlamaForCausalLM":
             self.hf_config.architectures[0] = "LlamaForCausalLMEagle3"
 

--- a/python/sgl_jax/srt/kernels/fused_mlp.py
+++ b/python/sgl_jax/srt/kernels/fused_mlp.py
@@ -139,7 +139,6 @@ def apply_fused_mlp_sharded(
         mesh=mesh,
         in_specs=in_specs,
         out_specs=out_specs,
-        check_rep=False,
     )
     def local_fused_mlp(x_loc, w_gu_loc, wd_loc):
         seq_len, hidden_size = x_loc.shape

--- a/python/sgl_jax/srt/kernels/fused_mlp.py
+++ b/python/sgl_jax/srt/kernels/fused_mlp.py
@@ -137,8 +137,6 @@ def apply_fused_mlp_sharded(
     @functools.partial(
         shard_map,
         mesh=mesh,
-        in_specs=in_specs,
-        out_specs=out_specs,
     )
     def local_fused_mlp(x_loc, w_gu_loc, wd_loc):
         seq_len, hidden_size = x_loc.shape

--- a/python/sgl_jax/srt/kernels/fused_mlp.py
+++ b/python/sgl_jax/srt/kernels/fused_mlp.py
@@ -128,11 +128,11 @@ def apply_fused_mlp_sharded(
     b_inter: int = 128,
 ) -> jax.Array:
     in_specs = (
-        P(None, None),  # x
+        x.sharding.spec if hasattr(x, "sharding") else P(None, None),  # dynamically infer x sharding
         P(None, "tensor"),  # w_gu (combined gate/up weight, sharded along tensor axis)
         P("tensor", None),  # wd (down weight, sharded along tensor axis)
     )
-    out_specs = P(None, None)
+    out_specs = x.sharding.spec if hasattr(x, "sharding") else P(None, None)
 
     @functools.partial(
         shard_map,

--- a/python/sgl_jax/srt/kernels/fused_mlp.py
+++ b/python/sgl_jax/srt/kernels/fused_mlp.py
@@ -144,6 +144,7 @@ def apply_fused_mlp_sharded(
         mesh=mesh,
         in_specs=in_specs,
         out_specs=out_specs,
+        check_vma=False,
     )
     def local_fused_mlp(x_loc, w_gu_loc, wd_loc):
         seq_len, hidden_size = x_loc.shape

--- a/python/sgl_jax/srt/kernels/fused_mlp.py
+++ b/python/sgl_jax/srt/kernels/fused_mlp.py
@@ -132,11 +132,18 @@ def apply_fused_mlp_sharded(
         P(None, "tensor"),  # w_gu (combined gate/up weight, sharded along tensor axis)
         P("tensor", None),  # wd (down weight, sharded along tensor axis)
     )
-    out_specs = x.sharding.spec if hasattr(x, "sharding") else P(None, None)
+    in_specs = (
+        jax.sharding.PartitionSpec("data", None),  # x
+        jax.sharding.PartitionSpec(None, "tensor"),  # w_gu (combined gate/up weight, sharded along tensor axis)
+        jax.sharding.PartitionSpec("tensor", None),  # wd (down weight, sharded along tensor axis)
+    )
+    out_specs = jax.sharding.PartitionSpec("data", None)
 
     @functools.partial(
         shard_map,
         mesh=mesh,
+        in_specs=in_specs,
+        out_specs=out_specs,
     )
     def local_fused_mlp(x_loc, w_gu_loc, wd_loc):
         seq_len, hidden_size = x_loc.shape

--- a/python/sgl_jax/srt/layers/attention/mla_backend.py
+++ b/python/sgl_jax/srt/layers/attention/mla_backend.py
@@ -387,3 +387,42 @@ class MLAAttentionBackend(AttentionBackend):
             res > 0
         ), f"max running requests: {res} must larger than 0, please increase page size or decrease max context length"
         return res
+
+    def get_eagle_forward_metadata(self, batch, **kwargs):
+        # We don't support custom_mask in MLA yet, but for NEXTN it's just sequential draft tokens.
+        import numpy as np
+        from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+        metadata = MLAAttentionMetadata()
+        
+        dp_size = batch.dp_size
+        per_dp_bs = batch.per_dp_bs_size if dp_size > 1 else len(batch.seq_lens)
+        
+        if batch.forward_mode.is_target_verify():
+            padded_batch_size = len(batch.seq_lens)
+            extend_seq_lens = np.zeros(padded_batch_size, dtype=np.int32)
+            extend_seq_lens[batch.logits_indices_selector] = batch.spec_info_padded.draft_token_num
+        else:
+            extend_seq_lens = batch.extend_seq_lens
+            
+        ext_2d = extend_seq_lens.reshape(dp_size, per_dp_bs)
+        cu_q_2d = np.zeros((dp_size, per_dp_bs + 1), dtype=np.int32)
+        cu_q_2d[:, 1:] = np.cumsum(ext_2d, axis=1)
+        metadata.cu_q_lens = cu_q_2d.ravel()
+        
+        total_loc_len = len(batch.cache_loc)
+        per_dp_loc_len = total_loc_len // batch.dp_size
+        cache_loc_2d = batch.cache_loc.reshape(batch.dp_size, per_dp_loc_len)
+        strided_2d = cache_loc_2d[:, :: self.page_size]
+        metadata.page_indices = (strided_2d // self.page_size).ravel()
+        
+        aligned_seq_lens = ((batch.seq_lens + self.page_size - 1) // self.page_size) * self.page_size
+        aligned_2d = aligned_seq_lens.reshape(batch.dp_size, per_dp_bs)
+        cu_kv_2d = np.zeros((batch.dp_size, per_dp_bs + 1), dtype=np.int32)
+        cu_kv_2d[:, 1:] = np.cumsum(aligned_2d, axis=1)
+        metadata.cu_kv_lens = cu_kv_2d.ravel()
+        
+        seq_lens_2d = batch.seq_lens.reshape(batch.dp_size, per_dp_bs)
+        metadata.seq_lens = seq_lens_2d.ravel()
+        metadata.distribution = self.forward_metadata.distribution
+        
+        return metadata

--- a/python/sgl_jax/srt/layers/attention/mla_backend.py
+++ b/python/sgl_jax/srt/layers/attention/mla_backend.py
@@ -423,7 +423,15 @@ class MLAAttentionBackend(AttentionBackend):
         
         seq_lens_2d = batch.seq_lens.reshape(batch.dp_size, per_dp_bs)
         metadata.seq_lens = seq_lens_2d.ravel()
-        metadata.distribution = self.forward_metadata.distribution
+        
+        local_num_seqs = np.sum(seq_lens_2d > 0, axis=1, dtype=np.int32)
+        if batch.forward_mode == ForwardMode.DECODE:
+            distribution = np.repeat(local_num_seqs, 3)
+        else:
+            distribution = np.column_stack(
+                [np.zeros_like(local_num_seqs), np.zeros_like(local_num_seqs), local_num_seqs]
+            ).ravel()
+        metadata.distribution = distribution
         
         from sgl_jax.srt.utils.jax_utils import device_array
         from jax.sharding import NamedSharding, PartitionSpec as P
@@ -433,8 +441,9 @@ class MLAAttentionBackend(AttentionBackend):
             metadata.cu_kv_lens,
             metadata.page_indices,
             metadata.seq_lens,
+            metadata.distribution,
         ) = device_array(
-            (metadata.cu_q_lens, metadata.cu_kv_lens, metadata.page_indices, metadata.seq_lens),
+            (metadata.cu_q_lens, metadata.cu_kv_lens, metadata.page_indices, metadata.seq_lens, metadata.distribution),
             sharding=(NamedSharding(self.mesh, P(self.attention_data_partition_axis))),
         )
         

--- a/python/sgl_jax/srt/layers/attention/mla_backend.py
+++ b/python/sgl_jax/srt/layers/attention/mla_backend.py
@@ -425,4 +425,17 @@ class MLAAttentionBackend(AttentionBackend):
         metadata.seq_lens = seq_lens_2d.ravel()
         metadata.distribution = self.forward_metadata.distribution
         
+        from sgl_jax.srt.utils.jax_utils import device_array
+        from jax.sharding import NamedSharding, PartitionSpec as P
+        
+        (
+            metadata.cu_q_lens,
+            metadata.cu_kv_lens,
+            metadata.page_indices,
+            metadata.seq_lens,
+        ) = device_array(
+            (metadata.cu_q_lens, metadata.cu_kv_lens, metadata.page_indices, metadata.seq_lens),
+            sharding=(NamedSharding(self.mesh, P(self.attention_data_partition_axis))),
+        )
+        
         return metadata

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -429,20 +429,16 @@ class ModelRunnerKVCacheMixin:
 
         cell_size = self._compute_cell_size()
         
-        # Accommodate Draft KV Cache Memory Footprint
+        # Accommodate Draft KV Cache Memory Footprint + Spec Headroom
         if (
             not self.is_draft_worker
             and self.spec_algorithm is not None
             and not self.spec_algorithm.is_none()
         ):
-            draft_layer_count = 1
-            if hasattr(self.server_args, "speculative_draft_model_path") and self.server_args.speculative_draft_model_path:
-                draft_layer_count = max(1, self._kv_pool_layer_count() // 5)
-            
-            target_layers = max(1, self._kv_pool_layer_count())
-            draft_cell_size = (cell_size // target_layers) * draft_layer_count
-            logger.info(f"Adding draft KV cache footprint overhead: {draft_cell_size} bytes per token")
-            cell_size += draft_cell_size
+            # Reserve 2 GB entirely for the Draft Worker's KV buffer and XLA fragmentation.
+            overhead_bytes = 2 * 1024 * 1024 * 1024
+            logger.info(f"Deducting {overhead_bytes} bytes from available KV cache for draft memory overhead")
+            available_kv_cache_bytes -= overhead_bytes
 
         max_tokens = max(1, int(available_kv_cache_bytes // cell_size))
 

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -436,7 +436,7 @@ class ModelRunnerKVCacheMixin:
             and not self.spec_algorithm.is_none()
         ):
             # Reserve 2 GB entirely for the Draft Worker's KV buffer and XLA fragmentation.
-            overhead_bytes = 2 * 1024 * 1024 * 1024
+            overhead_bytes = 8 * 1024 * 1024 * 1024
             logger.info(f"Deducting {overhead_bytes} bytes from available KV cache for draft memory overhead")
             available_kv_cache_bytes -= overhead_bytes
 

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -436,7 +436,7 @@ class ModelRunnerKVCacheMixin:
             and not self.spec_algorithm.is_none()
         ):
             # Reserve 2 GB entirely for the Draft Worker's KV buffer and XLA fragmentation.
-            overhead_bytes = 8 * 1024 * 1024 * 1024
+            overhead_bytes = 18 * 1024 * 1024 * 1024
             logger.info(f"Deducting {overhead_bytes} bytes from available KV cache for draft memory overhead")
             available_kv_cache_bytes -= overhead_bytes
 

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -436,7 +436,7 @@ class ModelRunnerKVCacheMixin:
             and not self.spec_algorithm.is_none()
         ):
             # Reserve 2 GB entirely for the Draft Worker's KV buffer and XLA fragmentation.
-            overhead_bytes = 18 * 1024 * 1024 * 1024
+            overhead_bytes = 3 * 1024 * 1024 * 1024
             logger.info(f"Deducting {overhead_bytes} bytes from available KV cache for draft memory overhead")
             available_kv_cache_bytes -= overhead_bytes
 
@@ -873,6 +873,10 @@ class ModelRunnerKVCacheMixin:
 
         For hybrid recurrent models, only full-attention layers need KV cache.
         """
+
+        if getattr(self, "is_draft_worker", False):
+            return 1
+
         cfg = self.linear_recurrent_config
         if cfg is not None:
             return len(cfg.full_attention_layer_ids)

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -436,7 +436,7 @@ class ModelRunnerKVCacheMixin:
             and not self.spec_algorithm.is_none()
         ):
             # Reserve 2 GB entirely for the Draft Worker's KV buffer and XLA fragmentation.
-            overhead_bytes = 3 * 1024 * 1024 * 1024
+            overhead_bytes = 1 * 1024 * 1024 * 1024
             logger.info(f"Deducting {overhead_bytes} bytes from available KV cache for draft memory overhead")
             available_kv_cache_bytes -= overhead_bytes
 

--- a/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sgl_jax/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -428,6 +428,22 @@ class ModelRunnerKVCacheMixin:
         available_kv_cache_bytes = self._profile_available_bytes(total_device_memory)
 
         cell_size = self._compute_cell_size()
+        
+        # Accommodate Draft KV Cache Memory Footprint
+        if (
+            not self.is_draft_worker
+            and self.spec_algorithm is not None
+            and not self.spec_algorithm.is_none()
+        ):
+            draft_layer_count = 1
+            if hasattr(self.server_args, "speculative_draft_model_path") and self.server_args.speculative_draft_model_path:
+                draft_layer_count = max(1, self._kv_pool_layer_count() // 5)
+            
+            target_layers = max(1, self._kv_pool_layer_count())
+            draft_cell_size = (cell_size // target_layers) * draft_layer_count
+            logger.info(f"Adding draft KV cache footprint overhead: {draft_cell_size} bytes per token")
+            cell_size += draft_cell_size
+
         max_tokens = max(1, int(available_kv_cache_bytes // cell_size))
 
         logger.info(

--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -1108,14 +1108,14 @@ class Glm5ForCausalLM(nnx.Module):
 
 
     def get_embed_and_head(self):
-        return self.embed_tokens.embedding.value, self.lm_head.embedding.value
+        return self.model.embed_tokens.embedding.value, self.lm_head.embedding.value
 
     def set_embed_and_head(self, embed, head) -> None:
-        self.embed_tokens.embedding.value = embed
+        self.model.embed_tokens.embedding.value = embed
         self.lm_head.embedding.value = head
 
     def set_embed(self, embed) -> None:
-        self.embed_tokens.embedding.value = embed
+        self.model.embed_tokens.embedding.value = embed
 
     def load_weights(self, model_config: ModelConfig):
         loader = WeightLoader(

--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -721,6 +721,7 @@ class Glm5DecoderLayer(nnx.Module):
         mesh: jax.sharding.Mesh,
         layer_id: int = 0,
         dtype: jnp.dtype = jnp.bfloat16,
+        force_moe: bool = False,
     ):
         self.layer_id = layer_id
         self.hidden_size = config.hidden_size
@@ -766,7 +767,7 @@ class Glm5DecoderLayer(nnx.Module):
         first_k_dense_replace = getattr(config, "first_k_dense_replace", 0)
         use_fused_mlp = getattr(config, "_sgl_use_fused_mlp", True)
 
-        if layer_id < first_k_dense_replace:
+        if layer_id < first_k_dense_replace and not force_moe:
             self.mlp = Glm5MLP(
                 hidden_size=config.hidden_size,
                 intermediate_size=config.intermediate_size,
@@ -1441,7 +1442,7 @@ class GlmMoeDsaForCausalLMNextN(nnx.Module):
             params_dtype=dtype,
             mesh=mesh,
         )
-        self.mtp_block = Glm5DecoderLayer(config, layer_id=self.mtp_layer_idx, dtype=dtype, mesh=mesh)
+        self.mtp_block = Glm5DecoderLayer(config, layer_id=self.mtp_layer_idx, dtype=dtype, mesh=mesh, force_moe=True)
         self.shared_head = nnx.Module()
         self.shared_head.norm = RMSNorm(
             config.hidden_size, epsilon=config.rms_norm_eps, param_dtype=dtype, scope_name="norm"

--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -1415,7 +1415,9 @@ class GlmMoeDsaForCausalLMNextN(nnx.Module):
         self.config = config
         self.mesh = mesh
         self.dtype = dtype
-        self.mtp_layer_idx = getattr(config, "num_hidden_layers", 78)
+        # The Draft Worker only passes its own isolated memory pool (which inherits model_config.num_hidden_layers length)
+        # We must index layer_id=0 so it does not exceed the KV buffer array bounds!
+        self.mtp_layer_idx = 0
 
         self.embed_tokens = Embed(
             num_embeddings=config.vocab_size,

--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -1106,6 +1106,17 @@ class Glm5ForCausalLM(nnx.Module):
         kv_update = (layers_kv_fused, layers_idx_fused) if layers_idx_fused else layers_kv_fused
         return output, {"token_to_kv_pool": kv_update}, True, layers_topk_ids
 
+
+    def get_embed_and_head(self):
+        return self.embed_tokens.embedding.value, self.lm_head.embedding.value
+
+    def set_embed_and_head(self, embed, head) -> None:
+        self.embed_tokens.embedding.value = embed
+        self.lm_head.embedding.value = head
+
+    def set_embed(self, embed) -> None:
+        self.embed_tokens.embedding.value = embed
+
     def load_weights(self, model_config: ModelConfig):
         loader = WeightLoader(
             model=self,

--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -738,7 +738,7 @@ class Glm5DecoderLayer(nnx.Module):
         # layer's top-k and ship no indexer weights. Dense MLA discards indexer
         # output anyway, so just skip building the module on shared layers.
         indexer_types = getattr(config, "indexer_types", None)
-        indexer_type = "full" if indexer_types is None else indexer_types[layer_id]
+        indexer_type = "full" if (indexer_types is None or layer_id >= len(indexer_types)) else indexer_types[layer_id]
         has_indexer = indexer_type == "full"
         use_dsa_sparse = getattr(config, "use_dsa_sparse", False)
 
@@ -1387,4 +1387,145 @@ class GlmMoeDsaForCausalLM(Glm5ForCausalLM):
         mc.hf_config._sgl_use_fused_mlp = mc.quantization_config is None
 
 
-EntryClass = [Glm5ForCausalLM, GlmMoeDsaForCausalLM]
+
+class GlmMoeDsaForCausalLMNextN(nnx.Module):
+    load_lm_head_from_target = True
+
+    @classmethod
+    def patch_model_config(cls, mc: ModelConfig) -> None:
+        return GlmMoeDsaForCausalLM.patch_model_config(mc)
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh | None = None,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        self.config = config
+        self.mesh = mesh
+        self.dtype = dtype
+        self.mtp_layer_idx = getattr(config, "num_hidden_layers", 78)
+
+        self.embed_tokens = Embed(
+            num_embeddings=config.vocab_size,
+            features=config.hidden_size,
+            dtype=dtype,
+            kernel_axes=("tensor", None),
+            param_dtype=dtype,
+            mesh=mesh,
+        )
+        self.enorm = RMSNorm(
+            config.hidden_size, epsilon=config.rms_norm_eps, param_dtype=dtype, scope_name="enorm"
+        )
+        self.hnorm = RMSNorm(
+            config.hidden_size, epsilon=config.rms_norm_eps, param_dtype=dtype, scope_name="hnorm"
+        )
+        self.eh_proj = LinearBase(
+            input_size=2 * config.hidden_size,
+            output_size=config.hidden_size,
+            use_bias=False,
+            kernel_axes=(None, None),
+            params_dtype=dtype,
+            mesh=mesh,
+        )
+        self.mtp_block = Glm5DecoderLayer(config, layer_id=self.mtp_layer_idx, dtype=dtype, mesh=mesh)
+        self.shared_head = nnx.Module()
+        self.shared_head.norm = RMSNorm(
+            config.hidden_size, epsilon=config.rms_norm_eps, param_dtype=dtype, scope_name="norm"
+        )
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            dtype=dtype,
+            param_dtype=dtype,
+            kernel_axes=("tensor", None),
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size, mesh=self.mesh)
+        self.hot_token_ids = None
+
+    def __call__(
+        self,
+        forward_batch: ForwardBatch,
+        memory_pools,
+        logits_metadata: LogitsMetadata,
+    ):
+        from sgl_jax.srt.layers.attention.dsa_sparse_backend import DSAFusedCache
+
+        embed = self.embed_tokens(forward_batch.input_ids)
+        hidden_in = forward_batch.spec_info.hidden_states
+        emb_sh = jax.typeof(embed).sharding
+        if isinstance(emb_sh, jax.sharding.NamedSharding):
+            hidden_in = jax.sharding.reshard(hidden_in, emb_sh)
+
+        concat_in = jnp.concatenate((self.enorm(embed), self.hnorm(hidden_in)), axis=-1)
+        hidden_states, _ = self.eh_proj(concat_in)
+
+        token_to_kv_pool = memory_pools.token_to_kv_pool if hasattr(memory_pools, "token_to_kv_pool") else memory_pools
+        hidden_states, residual, kv_fused, _ = self.mtp_block(
+            forward_batch.positions, hidden_states, forward_batch, token_to_kv_pool, None,
+            dispatch_info=forward_batch.expert_location_metadata,
+            dsa_topk_in=None,
+            dsa_topk_pages_in=None
+        )
+        
+        if residual is not None:
+            hidden_states = hidden_states + residual
+            
+        hidden_states = self.shared_head.norm(hidden_states)
+        output = self.logits_processor(
+            hidden_states, self.lm_head, logits_metadata, aux_hidden_states=None
+        )
+        
+        kv_cache_list = [kv_fused.kv] if isinstance(kv_fused, DSAFusedCache) else [kv_fused]
+        return output, kv_cache_list, True, None
+
+    def load_weights(self, model_config: ModelConfig):
+        self.loader = WeightLoader(model=self, model_config=model_config, mesh=self.mesh, dtype=self.dtype)
+        mappings = self._create_weight_mappings(model_config)
+        self.loader.load_weights_from_safetensors(mappings)
+
+    @classmethod
+    def _create_weight_mappings(cls, model_config: ModelConfig) -> dict[str, WeightMapping]:
+        mappings = {}
+        idx = getattr(model_config.hf_config, "num_hidden_layers", 78)
+        prefix = f"model.layers.{idx}"
+        
+        mappings[f"{prefix}.enorm.weight"] = WeightMapping(target_path="enorm.scale", sharding=(None,), transpose=False)
+        mappings[f"{prefix}.hnorm.weight"] = WeightMapping(target_path="hnorm.scale", sharding=(None,), transpose=False)
+        mappings[f"{prefix}.eh_proj.weight"] = WeightMapping(target_path="eh_proj.weight", sharding=(None, None), transpose=True)
+        mappings[f"{prefix}.shared_head.norm.weight"] = WeightMapping(target_path="shared_head.norm.scale", sharding=(None,), transpose=False)
+        
+        class MockConfig:
+            pass
+        mock_self = MockConfig()
+        mock_self.config = model_config.hf_config
+        is_static_quant = getattr(model_config, "quantization_config", None) is not None
+        
+        decoder_mappings = Glm5ForCausalLM._create_moe_layer_mappings(
+            mock_self,
+            layer_idx=idx, 
+            target_idx=idx, 
+            is_mlp_layer=False, 
+            is_static_quant=is_static_quant,
+            has_indexer=True
+        )
+        for k, v in decoder_mappings.items():    
+            if isinstance(v.target_path, str):
+                v.target_path = v.target_path.replace(f"model.layers.{idx}", "mtp_block")
+            elif isinstance(v.target_path, list):
+                v.target_path = [p.replace(f"model.layers.{idx}", "mtp_block") for p in v.target_path]
+            mappings[k] = v
+        
+        return mappings
+
+    def get_embed_and_head(self):
+        return self.embed_tokens.embedding.value, self.lm_head.embedding.value
+
+    def set_embed_and_head(self, embed: jax.Array, head: jax.Array) -> None:
+        self.embed_tokens.embedding.value = embed
+        self.lm_head.embedding.value = head
+
+    def set_embed(self, embed: jax.Array) -> None:
+        self.embed_tokens.embedding.value = embed
+
+EntryClass = [Glm5ForCausalLM, GlmMoeDsaForCausalLM, GlmMoeDsaForCausalLMNextN]

--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -1498,6 +1498,13 @@ class GlmMoeDsaForCausalLMNextN(nnx.Module):
         mappings = self._create_weight_mappings(model_config)
         self.loader.load_weights_from_safetensors(mappings)
 
+        # Apply post_load_weights logic for Draft
+        self.mtp_block.self_attn.post_load_weights()
+        if hasattr(self.mtp_block, "mlp") and hasattr(self.mtp_block.mlp, "post_load_weights"):
+            self.mtp_block.mlp.post_load_weights()
+        if hasattr(self.mtp_block, "shared_experts") and self.mtp_block.shared_experts is not None and hasattr(self.mtp_block.shared_experts, "post_load_weights"):
+            self.mtp_block.shared_experts.post_load_weights()
+
     @classmethod
     def _create_weight_mappings(cls, model_config: ModelConfig) -> dict[str, WeightMapping]:
         mappings = {}

--- a/python/sgl_jax/srt/models/glm5_moe.py
+++ b/python/sgl_jax/srt/models/glm5_moe.py
@@ -1527,7 +1527,9 @@ class GlmMoeDsaForCausalLMNextN(nnx.Module):
             if isinstance(v.target_path, str):
                 v.target_path = v.target_path.replace(f"model.layers.{idx}", "mtp_block")
             elif isinstance(v.target_path, list):
-                v.target_path = [p.replace(f"model.layers.{idx}", "mtp_block") for p in v.target_path]
+                new_path = [v.target_path[0].replace(f"model.layers.{idx}", "mtp_block")]
+                new_path.extend(v.target_path[1:])
+                v.target_path = new_path
             mappings[k] = v
         
         return mappings

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -915,7 +915,6 @@ def _build_verify(topk: int):
             b = relay_new_seq_lens - 1
             
             if hasattr(jax.lax, "with_sharding_constraint"):
-                import jax.sharding
                 zeros = jax.lax.with_sharding_constraint(zeros, jax.sharding.PartitionSpec("data"))
                 b = jax.lax.with_sharding_constraint(b, jax.sharding.PartitionSpec("data"))
                 valid_seq_lens = jax.lax.with_sharding_constraint(valid_seq_lens, jax.sharding.PartitionSpec("data"))

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -562,13 +562,15 @@ def _build_draft_extend(num_layers: int, topk: int):
             )
 
         for i in range(num_layers):
-            state = jax.tree_util.tree_unflatten(model_state_def, all_leaves[i])
+            leaf_idx = i if i < len(all_leaves) else -1
+            pool_idx = i if i < len(all_memory_pools) else -1
+            state = jax.tree_util.tree_unflatten(model_state_def, all_leaves[leaf_idx])
             model = nnx.merge(model_def, state)
 
             forward_batch.spec_info.hidden_states = target_hidden
             forward_batch.input_ids = input_ids
 
-            output, pool_updates, _, _ = model(forward_batch, all_memory_pools[i], logits_metadata)
+            output, pool_updates, _, _ = model(forward_batch, all_memory_pools[pool_idx], logits_metadata)
             all_pool_updates.append(pool_updates)
 
             sh = jax.typeof(output.next_token_logits).sharding
@@ -1164,13 +1166,15 @@ def _build_prefill(num_layers: int, topk: int):
 
         draft_forward_batch.spec_info.hidden_states = target_hidden
         for i in range(num_layers):
-            state = jax.tree_util.tree_unflatten(draft_model_state_def, draft_all_leaves[i])
+            leaf_idx = i if i < len(draft_all_leaves) else -1
+            pool_idx = i if i < len(all_memory_pools) else -1
+            state = jax.tree_util.tree_unflatten(draft_model_state_def, draft_all_leaves[leaf_idx])
             model = nnx.merge(draft_model_def, state)
 
             draft_forward_batch.input_ids = input_ids
             draft_forward_batch.spec_info.hidden_states = target_hidden
             output, pool_updates, _, _ = model(
-                draft_forward_batch, all_memory_pools[i], draft_logits_metadata
+                draft_forward_batch, all_memory_pools[pool_idx], draft_logits_metadata
             )
             all_pool_updates.append(pool_updates)
 

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -829,6 +829,16 @@ def _make_draft_extend_metadata(
         axis=1,
     ).reshape((dp_size * 3,))
 
+    data_sharding = jax.typeof(old_metadata.seq_lens).sharding
+    if isinstance(data_sharding, NamedSharding) and not data_sharding.mesh.empty:
+        cu_q_lens = jax.sharding.reshard(cu_q_lens, data_sharding)
+        cu_kv_lens = jax.sharding.reshard(cu_kv_lens, data_sharding)
+        page_indices = jax.sharding.reshard(page_indices, data_sharding)
+        draft_seq_lens = jax.sharding.reshard(draft_seq_lens, data_sharding)
+        distribution = jax.sharding.reshard(distribution, data_sharding)
+        if swa_page_indices is not None:
+            swa_page_indices = jax.sharding.reshard(swa_page_indices, data_sharding)
+
     kwargs = {
         "cu_q_lens": cu_q_lens,
         "cu_kv_lens": cu_kv_lens,

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -481,9 +481,15 @@ def _rotate_prefill_input_ids(input_ids, extend_seq_lens, verified_id, dp_size, 
         shifted_index = jnp.minimum(tok + 1, per_dp_tokens - 1)
         one_hot_shifted = jax.nn.one_hot(shifted_index, per_dp_tokens, dtype=starts.dtype)
         shifted = jnp.dot(one_hot_shifted, ids_rank)
+        
+        # Bypass jnp.where ShardingTypeError by using algebraic boolean masks!
+        # Multiplication automatically promotes sharding constraints!
         is_last = has_req & ((tok - req_starts) == (req_lens - 1))
-        rotated = jnp.where(is_last, req_verified, shifted)
-        return jnp.where(has_req, rotated, ids_rank)
+        is_last_int = is_last.astype(jnp.int32)
+        rotated = is_last_int * req_verified + (1 - is_last_int) * shifted
+        
+        has_req_int = has_req.astype(jnp.int32)
+        return has_req_int * rotated + (1 - has_req_int) * ids_rank
 
     return jax.vmap(rotate_rank)(ids, ext, verified).reshape(input_ids.shape)
 

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -457,6 +457,7 @@ def _rotate_prefill_input_ids(input_ids, extend_seq_lens, verified_id, dp_size, 
         # We can implement a cumsum as a matrix multiplication!
         # A lower triangular matrix of ones multiplied by ext_rank gives the cumsum!
         import jax.numpy as jnp
+        import jax
         
         N = ext_rank.shape[0]
         idx = jnp.arange(N)
@@ -470,9 +471,13 @@ def _rotate_prefill_input_ids(input_ids, extend_seq_lens, verified_id, dp_size, 
         in_req = (tok[None, :] >= starts[:, None]) & (tok[None, :] < ends[:, None])
         has_req = jnp.any(in_req, axis=0)
         slot = jnp.argmax(in_req.astype(jnp.int32), axis=0)
-        req_starts = starts.at[slot].get()
-        req_lens = ext_rank.at[slot].get()
-        req_verified = verified_rank.at[slot].get()
+        
+        # Matrix multiply bypassing JAX gather layout check
+        one_hot_slot = jax.nn.one_hot(slot, N, dtype=starts.dtype)
+        req_starts = jnp.dot(one_hot_slot, starts)
+        req_lens = jnp.dot(one_hot_slot, ext_rank)
+        req_verified = jnp.dot(one_hot_slot, verified_rank)
+        
         shifted_index = jnp.minimum(tok + 1, per_dp_tokens - 1)
         shifted = ids_rank.at[shifted_index].get()
         is_last = has_req & ((tok - req_starts) == (req_lens - 1))

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -910,10 +910,13 @@ def _build_verify(topk: int):
                 dp_size=dp_size,
             )
             valid_seq_lens = target_forward_batch.seq_lens > 0
+            zeros = target_forward_batch.seq_lens * 0
+            b = relay_new_seq_lens - 1
+            
             target_forward_batch.seq_lens = jnp.where(
                 valid_seq_lens,
-                relay_new_seq_lens - 1,
-                jnp.zeros_like(target_forward_batch.seq_lens),
+                b,
+                zeros,
             )
             target_forward_batch.attn_backend.forward_metadata = _make_target_verify_metadata(
                 target_forward_batch.attn_backend.forward_metadata,

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -909,9 +909,16 @@ def _build_verify(topk: int):
                 relay_future_indices,
                 dp_size=dp_size,
             )
+            # Force explicit P("data") without mesh using PartitionSpec
+            from jax.sharding import PartitionSpec as P
             valid_seq_lens = target_forward_batch.seq_lens > 0
-            zeros = target_forward_batch.seq_lens * 0
+            zeros = jnp.zeros_like(target_forward_batch.seq_lens)
             b = relay_new_seq_lens - 1
+            
+            if hasattr(jax.lax, "with_sharding_constraint"):
+                zeros = jax.lax.with_sharding_constraint(zeros, P("data"))
+                b = jax.lax.with_sharding_constraint(b, P("data"))
+                valid_seq_lens = jax.lax.with_sharding_constraint(valid_seq_lens, P("data"))
             
             target_forward_batch.seq_lens = jnp.where(
                 valid_seq_lens,

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -910,15 +910,15 @@ def _build_verify(topk: int):
                 dp_size=dp_size,
             )
             # Force explicit P("data") without mesh using PartitionSpec
-            from jax.sharding import PartitionSpec as P
             valid_seq_lens = target_forward_batch.seq_lens > 0
             zeros = jnp.zeros_like(target_forward_batch.seq_lens)
             b = relay_new_seq_lens - 1
             
             if hasattr(jax.lax, "with_sharding_constraint"):
-                zeros = jax.lax.with_sharding_constraint(zeros, P("data"))
-                b = jax.lax.with_sharding_constraint(b, P("data"))
-                valid_seq_lens = jax.lax.with_sharding_constraint(valid_seq_lens, P("data"))
+                import jax.sharding
+                zeros = jax.lax.with_sharding_constraint(zeros, jax.sharding.PartitionSpec("data"))
+                b = jax.lax.with_sharding_constraint(b, jax.sharding.PartitionSpec("data"))
+                valid_seq_lens = jax.lax.with_sharding_constraint(valid_seq_lens, jax.sharding.PartitionSpec("data"))
             
             target_forward_batch.seq_lens = jnp.where(
                 valid_seq_lens,

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -581,6 +581,7 @@ def _build_draft_extend(num_layers: int, topk: int):
 
             topk_idx = _topk1_index_from_logits(output.next_token_logits)
             all_topk_index.append(topk_idx)
+            jax.debug.print("[SPEC_DRAFT_EXTEND] Step {step} predicted draft token IDs: {tok}", step=i, tok=topk_idx[:, 0])
 
             if i < num_layers - 1:
                 ext_lens = forward_batch.extend_seq_lens
@@ -757,10 +758,16 @@ def _make_target_verify_metadata(
 
     valid_rows = _reshape_per_dp_rows(valid, dp_size)
     local_num_seqs = jnp.sum(valid_rows.astype(jnp.int32), axis=1)
-    distribution = jnp.stack(
-        [jnp.zeros_like(local_num_seqs), local_num_seqs, local_num_seqs],
-        axis=1,
-    ).reshape((dp_size * 3,))
+    if type(old_metadata).__name__ == "MLAAttentionMetadata":
+        distribution = jnp.stack(
+            [jnp.zeros_like(local_num_seqs), jnp.zeros_like(local_num_seqs), local_num_seqs],
+            axis=1,
+        ).reshape((dp_size * 3,))
+    else:
+        distribution = jnp.stack(
+            [jnp.zeros_like(local_num_seqs), local_num_seqs, local_num_seqs],
+            axis=1,
+        ).reshape((dp_size * 3,))
 
     data_sharding = jax.typeof(old_metadata.seq_lens).sharding
     if isinstance(data_sharding, NamedSharding) and not data_sharding.mesh.empty:
@@ -824,10 +831,16 @@ def _make_draft_extend_metadata(
 
     valid_rows = _reshape_per_dp_rows(valid, dp_size)
     local_num_seqs = jnp.sum(valid_rows.astype(jnp.int32), axis=1)
-    distribution = jnp.stack(
-        [jnp.zeros_like(local_num_seqs), local_num_seqs, local_num_seqs],
-        axis=1,
-    ).reshape((dp_size * 3,))
+    if type(old_metadata).__name__ == "MLAAttentionMetadata":
+        distribution = jnp.stack(
+            [jnp.zeros_like(local_num_seqs), jnp.zeros_like(local_num_seqs), local_num_seqs],
+            axis=1,
+        ).reshape((dp_size * 3,))
+    else:
+        distribution = jnp.stack(
+            [jnp.zeros_like(local_num_seqs), local_num_seqs, local_num_seqs],
+            axis=1,
+        ).reshape((dp_size * 3,))
 
     data_sharding = jax.typeof(old_metadata.seq_lens).sharding
     if isinstance(data_sharding, NamedSharding) and not data_sharding.mesh.empty:
@@ -1050,6 +1063,14 @@ def _build_verify(topk: int):
         prepared_sel_pos = prepared.sel_pos
         prepared_sel_pos_data = prepared.sel_pos
         prepared_predict = prepared.predict
+        
+        jax.debug.print(
+            "\n[SPEC_VERIFY]\n  Draft tokens: {d}\n  Target predicted: {t}\n  Accept length: {a}\n  Verified tokens: {v}",
+            d=draft_tokens,
+            t=prepared.predict,
+            a=prepared.accept_lens,
+            v=prepared.verified_id,
+        )
         prepared_positions = prepared.positions
         prepared_positions_data = prepared.positions
         prepared_verify_seq_lens = target_forward_batch.seq_lens

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -1897,7 +1897,7 @@ def spec_decode_verify(spec_worker, model_worker_batch, cur_allocate_lens):
     target_mr.attn_backend.forward_metadata = target_mr.attn_backend.get_eagle_forward_metadata(
         model_worker_batch
     )
-    if use_relay_state and target_mr.attn_backend.forward_metadata.custom_mask is not None:
+    if use_relay_state and getattr(target_mr.attn_backend.forward_metadata, 'custom_mask', None) is not None:
         raise NotImplementedError("Spec decode overlap relay path does not support custom_mask.")
     target_forward_batch = _make_forward_batch(model_worker_batch, target_mr)
     target_forward_batch.bid = model_worker_batch.bid

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -1018,13 +1018,15 @@ def _build_verify(topk: int):
             jnp.full_like(target_forward_batch.seq_lens, speculative_num_draft_tokens),
             jnp.zeros_like(target_forward_batch.seq_lens),
         ).astype(jnp.int32)
+        
+        prepared_extend_seq_lens_reshaped = _reshape_per_dp_rows(prepared_extend_seq_lens, dp_size)
         prepared_logits_indices = (
-            jnp.cumsum(
-                prepared_extend_seq_lens.reshape(dp_size, target_bs // dp_size),
-                axis=1,
-            ).reshape(-1)
-            - 1
+            jnp.cumsum(prepared_extend_seq_lens_reshaped, axis=1).reshape(-1) - 1
         ).astype(jnp.int32)
+        
+        sharding = jax.typeof(prepared_extend_seq_lens).sharding
+        if isinstance(sharding, NamedSharding) and not sharding.mesh.empty:
+            prepared_logits_indices = jax.sharding.reshard(prepared_logits_indices, sharding)
         prepared_sel_pos = prepared.sel_pos
         prepared_sel_pos_data = prepared.sel_pos
         prepared_predict = prepared.predict

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -479,7 +479,8 @@ def _rotate_prefill_input_ids(input_ids, extend_seq_lens, verified_id, dp_size, 
         req_verified = jnp.dot(one_hot_slot, verified_rank)
         
         shifted_index = jnp.minimum(tok + 1, per_dp_tokens - 1)
-        shifted = ids_rank.at[shifted_index].get()
+        one_hot_shifted = jax.nn.one_hot(shifted_index, per_dp_tokens, dtype=starts.dtype)
+        shifted = jnp.dot(one_hot_shifted, ids_rank)
         is_last = has_req & ((tok - req_starts) == (req_lens - 1))
         rotated = jnp.where(is_last, req_verified, shifted)
         return jnp.where(has_req, rotated, ids_rank)

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -454,15 +454,24 @@ def _rotate_prefill_input_ids(input_ids, extend_seq_lens, verified_id, dp_size, 
     tok = jnp.arange(per_dp_tokens, dtype=jnp.int32)
 
     def rotate_rank(ids_rank, ext_rank, verified_rank):
-        import jax
-        ext_rank_replicated = jax.lax.with_sharding_constraint(ext_rank, jax.sharding.PartitionSpec(None))
-        starts = jnp.cumsum(ext_rank_replicated, axis=0) - ext_rank_replicated
-        ends = starts + ext_rank_replicated
+        # We can implement a cumsum as a matrix multiplication!
+        # A lower triangular matrix of ones multiplied by ext_rank gives the cumsum!
+        import jax.numpy as jnp
+        
+        N = ext_rank.shape[0]
+        idx = jnp.arange(N)
+        mask = (idx[:, None] >= idx[None, :]).astype(jnp.int32)
+        
+        # This is exactly the inclusive cumsum!
+        ext_rank_cumsum = jnp.dot(mask, ext_rank)
+        
+        starts = ext_rank_cumsum - ext_rank
+        ends = starts + ext_rank
         in_req = (tok[None, :] >= starts[:, None]) & (tok[None, :] < ends[:, None])
         has_req = jnp.any(in_req, axis=0)
         slot = jnp.argmax(in_req.astype(jnp.int32), axis=0)
         req_starts = starts.at[slot].get()
-        req_lens = ext_rank_replicated.at[slot].get()
+        req_lens = ext_rank.at[slot].get()
         req_verified = verified_rank.at[slot].get()
         shifted_index = jnp.minimum(tok + 1, per_dp_tokens - 1)
         shifted = ids_rank.at[shifted_index].get()

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -746,7 +746,7 @@ def _make_target_verify_metadata(
         dp_size=dp_size,
     )
     swa_page_indices = None
-    if old_metadata.swa_page_indices is not None:
+    if getattr(old_metadata, 'swa_page_indices', None) is not None:
         swa_page_indices = _repack_page_indices(
             old_metadata.swa_page_indices,
             allocated_lens,
@@ -772,15 +772,18 @@ def _make_target_verify_metadata(
         if swa_page_indices is not None:
             swa_page_indices = jax.sharding.reshard(swa_page_indices, data_sharding)
 
-    return FlashAttentionMetadata(
-        cu_q_lens=cu_q_lens,
-        cu_kv_lens=cu_kv_lens,
-        page_indices=page_indices,
-        swa_page_indices=swa_page_indices,
-        seq_lens=metadata_seq_lens,
-        distribution=distribution,
-        custom_mask=old_metadata.custom_mask,
-    )
+    kwargs = {
+        "cu_q_lens": cu_q_lens,
+        "cu_kv_lens": cu_kv_lens,
+        "page_indices": page_indices,
+        "seq_lens": metadata_seq_lens,
+        "distribution": distribution,
+    }
+    if hasattr(old_metadata, "swa_page_indices"):
+        kwargs["swa_page_indices"] = swa_page_indices
+    if hasattr(old_metadata, "custom_mask"):
+        kwargs["custom_mask"] = old_metadata.custom_mask
+    return type(old_metadata)(**kwargs)
 
 
 def _make_draft_extend_metadata(
@@ -810,7 +813,7 @@ def _make_draft_extend_metadata(
         dp_size=dp_size,
     )
     swa_page_indices = None
-    if old_metadata.swa_page_indices is not None:
+    if getattr(old_metadata, 'swa_page_indices', None) is not None:
         swa_page_indices = _repack_page_indices(
             old_metadata.swa_page_indices,
             allocated_lens,
@@ -826,15 +829,18 @@ def _make_draft_extend_metadata(
         axis=1,
     ).reshape((dp_size * 3,))
 
-    return FlashAttentionMetadata(
-        cu_q_lens=cu_q_lens,
-        cu_kv_lens=cu_kv_lens,
-        page_indices=page_indices,
-        swa_page_indices=swa_page_indices,
-        seq_lens=draft_seq_lens,
-        distribution=distribution,
-        custom_mask=old_metadata.custom_mask,
-    )
+    kwargs = {
+        "cu_q_lens": cu_q_lens,
+        "cu_kv_lens": cu_kv_lens,
+        "page_indices": page_indices,
+        "seq_lens": draft_seq_lens,
+        "distribution": distribution,
+    }
+    if hasattr(old_metadata, "swa_page_indices"):
+        kwargs["swa_page_indices"] = swa_page_indices
+    if hasattr(old_metadata, "custom_mask"):
+        kwargs["custom_mask"] = old_metadata.custom_mask
+    return type(old_metadata)(**kwargs)
 
 
 def _build_verify(topk: int):

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -454,13 +454,15 @@ def _rotate_prefill_input_ids(input_ids, extend_seq_lens, verified_id, dp_size, 
     tok = jnp.arange(per_dp_tokens, dtype=jnp.int32)
 
     def rotate_rank(ids_rank, ext_rank, verified_rank):
-        starts = jnp.cumsum(ext_rank, axis=0) - ext_rank
-        ends = starts + ext_rank
+        import jax
+        ext_rank_replicated = jax.lax.with_sharding_constraint(ext_rank, jax.sharding.PartitionSpec(None))
+        starts = jnp.cumsum(ext_rank_replicated, axis=0) - ext_rank_replicated
+        ends = starts + ext_rank_replicated
         in_req = (tok[None, :] >= starts[:, None]) & (tok[None, :] < ends[:, None])
         has_req = jnp.any(in_req, axis=0)
         slot = jnp.argmax(in_req.astype(jnp.int32), axis=0)
         req_starts = starts.at[slot].get()
-        req_lens = ext_rank.at[slot].get()
+        req_lens = ext_rank_replicated.at[slot].get()
         req_verified = verified_rank.at[slot].get()
         shifted_index = jnp.minimum(tok + 1, per_dp_tokens - 1)
         shifted = ids_rank.at[shifted_index].get()

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -581,7 +581,7 @@ def _build_draft_extend(num_layers: int, topk: int):
 
             topk_idx = _topk1_index_from_logits(output.next_token_logits)
             all_topk_index.append(topk_idx)
-            jax.debug.print("[SPEC_DRAFT_EXTEND] Step {step} predicted draft token IDs: {tok}", step=i, tok=topk_idx[:, 0])
+            # jax.debug.print("[SPEC_DRAFT_EXTEND] Step {step} predicted draft token IDs: {tok}", step=i, tok=topk_idx[:, 0])
 
             if i < num_layers - 1:
                 ext_lens = forward_batch.extend_seq_lens
@@ -1064,13 +1064,13 @@ def _build_verify(topk: int):
         prepared_sel_pos_data = prepared.sel_pos
         prepared_predict = prepared.predict
         
-        jax.debug.print(
-            "\n[SPEC_VERIFY]\n  Draft tokens: {d}\n  Target predicted: {t}\n  Accept length: {a}\n  Verified tokens: {v}",
-            d=draft_tokens,
-            t=prepared.predict,
-            a=prepared.accept_lens,
-            v=prepared.verified_id,
-        )
+        # jax.debug.print(
+        #     "\n[SPEC_VERIFY]\n  Draft tokens: {d}\n  Target predicted: {t}\n  Accept length: {a}\n  Verified tokens: {v}",
+        #     d=draft_tokens,
+        #     t=prepared.predict,
+        #     a=prepared.accept_lens,
+        #     v=prepared.verified_id,
+        # )
         prepared_positions = prepared.positions
         prepared_positions_data = prepared.positions
         prepared_verify_seq_lens = target_forward_batch.seq_lens

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -912,12 +912,7 @@ def _build_verify(topk: int):
             # Force explicit P("data") without mesh using PartitionSpec
             valid_seq_lens = target_forward_batch.seq_lens > 0
             zeros = jnp.zeros_like(target_forward_batch.seq_lens)
-            b = relay_new_seq_lens - 1
-            
-            if hasattr(jax.lax, "with_sharding_constraint"):
-                zeros = jax.lax.with_sharding_constraint(zeros, jax.sharding.PartitionSpec("data"))
-                b = jax.lax.with_sharding_constraint(b, jax.sharding.PartitionSpec("data"))
-                valid_seq_lens = jax.lax.with_sharding_constraint(valid_seq_lens, jax.sharding.PartitionSpec("data"))
+            b = relay_new_seq_lens - 1 + zeros
             
             target_forward_batch.seq_lens = jnp.where(
                 valid_seq_lens,

--- a/python/sgl_jax/srt/speculative/draft_extend_fused.py
+++ b/python/sgl_jax/srt/speculative/draft_extend_fused.py
@@ -1500,14 +1500,14 @@ def launch_fused_draft_extend_for_decode(
     else:
         sel_pos = jnp.clip(batch_output.accept_lens - 1, 0, None).astype(jnp.int32)
 
-    mr0 = draft_worker._workers[0].model_runner
+    mr0 = draft_worker._worker.model_runner
     mwb.spec_info_padded.hidden_states = target_hidden
     shared_fb = _make_forward_batch(mwb, mr0)
     shared_fb.bid = model_worker_batch.bid
 
     all_memory_pools = []
     all_leaves = []
-    for w in draft_worker._workers:
+    for w in [draft_worker._worker]:
         mr = w.model_runner
         all_memory_pools.append(mr.memory_pools)
         all_leaves.append(tuple(mr.model_state_leaves))
@@ -1580,7 +1580,7 @@ def launch_fused_draft_extend_for_decode(
             dp_size=model_worker_batch.dp_size,
         )
 
-    for i, w in enumerate(draft_worker._workers):
+    for i, w in enumerate([draft_worker._worker]):
         w.model_runner.memory_pools.replace_all(all_pool_updates[i])
 
     return FusedDraftExtendPendingResult(
@@ -1671,7 +1671,7 @@ def spec_prefill(spec_worker, model_worker_batch, launch_done=None, *, update_re
     model_worker_batch.spec_info_padded.capture_hidden_mode = CaptureHiddenMode.FULL
     model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
 
-    draft_mr0 = draft_worker._workers[0].model_runner
+    draft_mr0 = draft_worker._worker.model_runner
     draft_mr0.attn_backend.forward_metadata = draft_mr0.attn_backend.get_eagle_forward_metadata(
         model_worker_batch
     )
@@ -1687,7 +1687,7 @@ def spec_prefill(spec_worker, model_worker_batch, launch_done=None, *, update_re
 
     all_memory_pools = []
     all_leaves = []
-    for w in draft_worker._workers:
+    for w in [draft_worker._worker]:
         mr = w.model_runner
         all_memory_pools.append(mr.memory_pools)
         all_leaves.append(tuple(mr.model_state_leaves))
@@ -1760,7 +1760,7 @@ def spec_prefill(spec_worker, model_worker_batch, launch_done=None, *, update_re
         launch_done.set()
 
     target_mr.memory_pools.replace_all(target_pool_updates)
-    for i, w in enumerate(draft_worker._workers):
+    for i, w in enumerate([draft_worker._worker]):
         w.model_runner.memory_pools.replace_all(all_pool_updates[i])
     if update_relay:
         spec_worker.spec_relay_buffers = updated_relay_buffers

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -232,7 +232,7 @@ class EAGLEWorker(BaseSpecWorker):
                     MultiLayerDraftWorker,
                 )
 
-                is_multi_layer = isinstance(self.draft_worker, MultiLayerDraftWorker)
+                is_multi_layer = isinstance(self.draft_worker, MultiLayerDraftWorker) or self.server_args.speculative_algorithm == "NEXTN"
                 if is_multi_layer and self.topk == 1:
                     topk_shape = (bs, num_steps)
                 else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

GLM-5.2 MoE checkpoints ship a native Multi-Token Prediction (MTP) module, but sglang-jax had no way to use it: the speculative decoding path only knew how to build draft models for a limited set of architectures, and the GLM decoder/model code had no MTP entrypoint. As a result, GLM MoE models could only run in plain autoregressive decode mode, leaving a large amount of decode throughput on the table.

This PR adds end-to-end support for NEXTN / MTP speculative decoding for GLM-5.x MoE models, so the native MTP layer that already exists in the released weights can be used as the draft model at serving time.

## Modifications

**Draft model architecture routing**
- Added draft-model architecture remapping so that when a GLM MoE checkpoint is loaded as a draft model, it is routed to the dedicated NextN architecture instead of the full target architecture. This mirrors the existing remapping done for other MTP-capable model families.

**GLM NextN (MTP) draft model**
- Implemented a new `GlmMoeDsaForCausalLMNextN` module and registered it as an entry class. It implements the standard MTP structure: token embedding, `enorm` / `hnorm` normalization of the embedding and the target hidden state, an `eh_proj` fusion projection, a single decoder block, a shared head norm, and the LM head + logits processor.
- The draft forward pass reshards the incoming target hidden states to match the embedding sharding before concatenation, so the draft step stays consistent with the target model's sharding under multi-device meshes.
- Added weight loading for the MTP layer: the MTP block's weights are discovered at the checkpoint's trailing layer index and remapped onto the local draft module paths, reusing the existing MoE layer mapping logic so quantized and unquantized checkpoints are handled the same way. Post-load hooks are invoked for attention, MLP and shared experts so the draft block goes through the same weight post-processing as the target model.
- The draft's KV output is normalized into the format expected by the KV pool, including the fused-cache variant.

**Shared embedding / LM head between target and draft**
- Added `get_embed_and_head` / `set_embed_and_head` / `set_embed` accessors on both the target and the draft model, so the draft worker can share the target model's embedding and LM head instead of holding a duplicate copy. This avoids redundant memory and keeps draft and target token spaces exactly aligned.

**Decoder layer reuse for the MTP block**
- Made the shared GLM decoder layer usable as an MTP block:
  - Added a `force_moe` flag so the MTP block always builds the MoE MLP, instead of falling back to a dense MLP when its layer index happens to be below `first_k_dense_replace`.
  - Made indexer-type lookup bounds-safe, since the MTP layer index can sit outside the target model's per-layer indexer configuration.

**KV cache and memory accounting for speculative decoding**
- The draft worker now reports a single KV-cache layer, matching the fact that the NextN module only has one decoder block. Previously it inherited the target model's layer count, which over-allocated the draft KV pool and could push allocations out of bounds.
- When speculative decoding is enabled, the target model runner now reserves headroom out of the profiled KV-cache budget for the draft worker's KV buffer and allocator fragmentation, preventing OOM during draft worker initialization.

**Speculative worker fixes**
- Fixed the draft output buffer shape selection so `NEXTN` with `topk == 1` uses the multi-layer/step-shaped buffers, matching what the NextN draft actually produces.

## Accuracy Tests

Tried with a simple curl request : 

Request : 
```bash
 curl -X POST http://${SERVER}:30271/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "/weights",
    "messages": [
      {"role": "user", "content": "Hello! Give me a quick introduction to JAX."}
    ],
    "temperature": 0.0,
    "max_tokens": 128
  }'
```

Response : 

```bash
{"id":"d2b93f75dc7e43bb8de9eac288ab4dc7","object":"chat.completion","created":1785766167,"model":"/weights","choices":[{"index":0,"message":{"role":"assistant","content":"1.  **Understand the User's Request:**\n    *   **Topic:** JAX (a numerical computing library in Python).\n    *   **Goal:** Provide a quick introduction.\n    *   **Tone:** Friendly, informative, concise.\n\n2.  **Identify Key Concepts of JAX:**\n    *   What is it? (NumPy on steroids, developed by Google/DeepMind).\n    *   Core features/philosophy:\n        *   Autograd (automatic differentiation).\n        *   JIT (Just-In-Time compilation) via XLA.\n        *   Vectorization (vmap).\n       ","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"length","matched_stop":null,"hidden_states":null}],"usage":{"prompt_tokens":23,"total_tokens":151,"completion_tokens":128,"prompt_tokens_details":null}}

```

## Benchmarking and Profiling

Benchmarked with `sgl_jax.bench_one_batch_server`, input length 8192, output length 1024:

### Baseline (no speculative decoding)

| Batch size | Latency (s) | Input throughput (tok/s) | Output throughput (tok/s) | ITL (ms) | Input cost ($/1M) | Output cost ($/1M) |
| ---------- | ----------- | ------------------------ | ------------------------- | -------- | ----------------- | ------------------ |
| 1          | 36.21       | 8201.01                  | 29.09                     | 34.38    | 0.10              | 19.10              |
| 4          | 46.76       | 8324.03                  | 95.64                     | 41.82    | 0.10              | 5.81               |
| 8          | 59.15       | 8382.38                  | 159.60                    | 50.12    | 0.09              | 3.48               |
| 16         | 79.66       | 8363.95                  | 256.05                    | 62.49    | 0.09              | 2.17               |
| 32         | 118.38      | 8398.50                  | 375.93                    | 85.12    | 0.09              | 1.48               |
| 64         | 236.35      | 3127.98                  | 953.38                    | 67.13    | 0.25              | 0.58               |

### With NEXTN / MTP speculative decoding (num speculative tokens = 3)

| Batch size | Latency (s) | Input throughput (tok/s) | Output throughput (tok/s) | ITL (ms) | Input cost ($/1M) | Output cost ($/1M) |
| ---------- | ----------- | ------------------------ | ------------------------- | -------- | ----------------- | ------------------ |
| 1          | 10.08       | 9690.97                  | 110.93                    | 9.01     | 0.08              | 5.01               |
| 4          | 19.78       | 10975.13                 | 243.96                    | 16.40    | 0.07              | 2.28               |
| 8          | 27.30       | 11063.69                 | 383.27                    | 20.87    | 0.07              | 1.45               |
| 16         | 42.00       | 11016.48                 | 544.28                    | 29.40    | 0.07              | 1.02               |
| 32         | 68.25       | 11086.87                 | 734.57                    | 43.56    | 0.07              | 0.76               |
| 64         | 129.48      | 5411.68                  | 2010.05                   | 31.84    | 0.15              | 0.28               |

### Speedup summary

| Batch size | Latency (s) base → MTP | Speedup | Output tok/s base → MTP | Speedup | ITL (ms) base → MTP | Output cost ($/1M) base → MTP |
| ---------- | ---------------------- | ------- | ----------------------- | ------- | ------------------- | ----------------------------- |
| 1          | 36.21 → 10.08          | 3.59x   | 29.09 → 110.93          | 3.81x   | 34.38 → 9.01        | 19.10 → 5.01                  |
| 4          | 46.76 → 19.78          | 2.36x   | 95.64 → 243.96          | 2.55x   | 41.82 → 16.40       | 5.81 → 2.28                   |
| 8          | 59.15 → 27.30          | 2.17x   | 159.60 → 383.27         | 2.40x   | 50.12 → 20.87       | 3.48 → 1.45                   |
| 16         | 79.66 → 42.00          | 1.90x   | 256.05 → 544.28         | 2.13x   | 62.49 → 29.40       | 2.17 → 1.02                   |
| 32         | 118.38 → 68.25         | 1.73x   | 375.93 → 734.57         | 1.95x   | 85.12 → 43.56       | 1.48 → 0.76                   |
| 64         | 236.35 → 129.48        | 1.83x   | 953.38 → 2010.05        | 2.11x   | 67.13 → 31.84       | 0.58 → 0.28                   |

Across batch sizes 1–64, enabling native MTP speculative decoding gives roughly a **1.7x–3.6x** end-to-end latency reduction and **~2x–3.8x** higher output throughput, with a corresponding drop in per-token output cost. Prefill throughput is also slightly higher since the draft KV pool is now sized correctly and frees up headroom.

## Checklist

- [ ] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
