### PR TITLE
[dsa] SparseCore radix-select for the streamindex_topk exit stage (exact; -43% decode / -66% prefill at DeepSeek-V4 scale)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -149,6 +149,9 @@ ignore = [
 "sgl_jax/srt/kernels/fused_moe/v1/kernel.py" = ["B023"]
 "sgl_jax/srt/kernels/fused_moe/v2/kernel.py" = ["B023", "F841", "SIM102", "SIM108"]
 "sgl_jax/srt/kernels/mla/v2/kernel.py" = ["B023"]
+# Vendored openxla/tokamax SparseCore top-k kernel: kept byte-identical to upstream
+# apart from the logging import; same statically-unrolled-loop closures as above.
+"sgl_jax/srt/kernels/dsa/sc_topk.py" = ["B023", "SIM212"]
 # TPU benchmark/debug scripts intentionally initialize distributed JAX before
 # importing local kernels, and benchmark closures capture loop-state values.
 "sgl_jax/srt/kernels/fused_moe/v2/bench_compare.py" = ["B023", "E402"]

--- a/python/sgl_jax/srt/kernels/dsa/sc_topk.py
+++ b/python/sgl_jax/srt/kernels/dsa/sc_topk.py
@@ -1,0 +1,894 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Vendored from openxla/tokamax @ 6303c141386c (2026-09-10)
+#   tokamax/_src/ops/experimental/tpu/topk/pallas_mosaic_tpu_kernel.py
+# Local changes (kept minimal so upstream diffs stay reviewable):
+#   * ``from absl import logging`` -> stdlib ``logging`` (absl is not a sglang-jax dependency).
+# Kernel semantics are unchanged. Only ``num_seq_windows=1`` is exercised by sglang-jax:
+# the multi-window (``num_seq_windows>1``) cooperative path produces wrong results in the
+# vendored revision (global histogram is only synchronized on the last window and
+# ``local_postfill`` pads earlier windows); callers must not enable it.
+
+"""Top-K implementation supporting multiple Vector Subcores.
+
+High-level algorithm:
+The file implements a Top-K selection algorithm targeting Vector Subcores.
+
+Large K: Distributed MSB Radix Select (`topk_multitile`)
+   - Uses a radix-based selection algorithm, proceeding digit-by-digit from the
+     most significant bit (MSB) down to the least significant bit (LSB).
+   - Multiple vector subcores may collaborate. In this case, they will work
+     independently on all windows except for the final window, during which
+     they will collaborate to build a global histogram, identify a global
+     threshold, postfill remaining (tied) K elements from first subcore to last,
+     and DMA each subcore's results to the correct subset of locations in HBM.
+   - If subcores are not collaborating, each operates independently on
+     a strided slice of the batch elements. This avoids synchronization and
+     communication, so can be performance beneficial for large enough batches.
+   - The algorithm processes data in sequential windows and can cooperate across
+     multiple subcores.
+     a) Histogram: Computes a histogram of the current digit's values across all
+        active candidates.
+     b) Global Sync (Optional: only when cooperating across subcores): Combines
+        local histograms into a global histogram.
+     c) Threshold Discovery: Accumulates the histogram from the maximum digit
+        down to zero to find a `target_digit`. The `target_digit` is chosen such
+        that elements with digits > `target_digit` are guaranteed to be in the
+        top K.
+     d) Filtering:
+        - Elements with digit > `target_digit` are added to the final Top-K
+          output.
+        - Remaining elements with digit == `target_digit` survive (if needed, to
+          meet K) as candidates for the next digit iteration, or for postfilling
+          of ties.
+        - Elements with digit < `target_digit` are eliminated.
+   - Postfill: If K elements haven't been found after all digits are processed
+     (e.g., due to duplicate values tied across all bits), then the remaining
+     candidates are all tied. So we can deterministically "postfill" the
+     remaining spots from the pool of surviving candidates. When multiple
+     subcores are collaborating, this uses a cross-subcore prefix sum to
+     break ties by index (earlier windows = lower subcores = lower indices
+     are preferred).
+   - Emit outputs: When tiles work independently, each produces K elements and
+     can DMA the output independently of other cores. When collaborating, the
+     subcores compute a prefix-sum to determine the start offset at which
+     to write the elements.
+"""
+
+import dataclasses
+import functools
+import logging
+import math
+from collections.abc import Sequence
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import extend as jax_extend
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+from jax.experimental.pallas import tpu_sc as plsc
+from jax.interpreters import batching, mlir
+
+# from jax._src import state as jax_state  # deps: ignore
+type Ref = Any  # jax_state.AbstractRef | jax_state.TransformedRef
+
+
+INVALID_VALUE = np.uint32(2**32 - 1).view(np.int32)
+
+
+all_reduce_popcount = plsc.all_reduce_population_count
+
+
+class _DigitGetter:
+    """Helper class for getting shifted/masked digits from the keys ref."""
+
+    def __init__(
+        self,
+        keys: jax.Ref,
+        digit_num: jax.Array,
+        digit_width: int,
+        return_keys: bool,
+    ):
+        self.keys = keys
+        self.digit_num = digit_num
+        self.digit_width = digit_width
+        self.return_keys = return_keys
+
+    def __getitem__(self, slc):
+        keys_chunk = self.keys[slc]
+        shift_amount = jnp.uint32(self.digit_width * self.digit_num)
+        digit_mask = jnp.uint32((1 << self.digit_width) - 1)
+        digits = keys_chunk.view(jnp.uint32)
+        if self.keys.dtype == jnp.int32:
+            digits ^= jnp.uint32(1 << 31)
+        elif self.keys.dtype == jnp.float32:
+            bits = (digits.view(jnp.int32) >> 31).view(jnp.uint32)  # sign -> 32 bits
+            bits |= jnp.uint32(1 << 31)
+            digits ^= bits
+        digits = (digits >> shift_amount) & digit_mask
+        return (keys_chunk, digits) if self.return_keys else digits
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class TopKScratch:
+    """Scratch buffers for Top-K."""
+
+    sem: Ref
+    num_to_process: Ref
+    num_remaining_global: Ref
+    top_k_found: Ref
+    top_k_found_global: Ref
+    cross_subcore_cumsum: Ref
+    histogram_indices: Ref
+    histogram: Ref
+    zeros_histogram: Ref
+    global_histogram: Ref
+    keys: Ref
+    values: Ref
+    topk_keys: Ref
+    topk_values: Ref
+    output_iota: Ref
+    output_vmshd_keys: Ref
+    output_vmshd_vals: Ref
+
+    def digits(self, digit_num: jax.Array, digit_width: int) -> _DigitGetter:
+        return _DigitGetter(self.keys, digit_num, digit_width, return_keys=False)
+
+    def keys_and_digits(
+        self,
+        digit_num: jax.Array,
+        digit_width: int,
+    ) -> _DigitGetter:
+        return _DigitGetter(self.keys, digit_num, digit_width, return_keys=True)
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class DigitLoopArgs:
+    digit_num: jax.Array
+    num_remaining: jax.Array
+    num_remaining_global: jax.Array
+    num_local_outputs: jax.Array
+    num_global_outputs: jax.Array
+    num_postfill_candidate_elements: jax.Array
+
+
+def clear_histogram(histogram: jax.Ref):
+    """Clears the histogram."""
+    histogram_size = np.prod(histogram.shape)
+    vec_dim = plsc.get_sparse_core_info().num_lanes
+
+    @plsc.parallel_loop(lower=0, upper=histogram_size, step=vec_dim)
+    def clear_chunk(chunk_idx):
+        histogram[pl.ds(chunk_idx, vec_dim)] = jnp.zeros(vec_dim, histogram.dtype)
+
+
+def sum_across_subcores(values: Sequence[tuple[Ref, jax.Array]]):
+    """Sums the values across subcores."""
+    for value_ref, _ in values:
+        value_ref[0] = jnp.zeros((), value_ref.dtype)
+    plsc.subcore_barrier()
+    for value_ref, value in values:
+        plsc.fetch_and_add(value_ref, value, subcore_id=0)  # First add.
+    plsc.subcore_barrier()
+    return [plsc.fetch_and_add(v[0], jnp.int32(0), subcore_id=0) for v in values]  # Now, fetch.
+
+
+def preceding_subcores_sum(mesh: plsc.VectorSubcoreMesh, ref: Ref, value: jax.Array):
+    """Sums values of preceding subcores."""
+    subcore_id = jax.lax.axis_index("subcore")
+    if ref.shape != (mesh.num_subcores,):
+        raise ValueError(f"SMEM shape {ref.shape} must be ({mesh.num_subcores},).")
+
+    @pl.when(subcore_id == 0)
+    def clear_smem():
+        for i in range(mesh.num_subcores):
+            ref[i] = jnp.zeros((), ref.dtype)
+
+    plsc.subcore_barrier()
+    plsc.fetch_and_add(ref.at[subcore_id], value, subcore_id=0)
+    plsc.subcore_barrier()
+
+    @pl.when(subcore_id == 0)
+    def compute_cumsum():  # Subcore 0 computes prefix sum.
+        prev = jnp.zeros((), ref.dtype)
+        for i in range(mesh.num_subcores):
+            # `prev += pl.swap(ref, i, prev)` requires `masked_swap` primitive support
+            tmp = ref[i]
+            ref[i] = prev
+            prev += tmp
+
+    plsc.subcore_barrier()
+    return plsc.fetch_and_add(ref.at[subcore_id], jnp.int32(0), subcore_id=0)
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "k",
+        "num_seq_windows",
+        "digit_width",
+        "num_digits",
+        "poison_scratch",
+        "use_tc_tiling_on_sc",
+        "debug",
+    ],
+)
+def _sc_top_k_impl(
+    keys: jax.Array,
+    *maybe_values: Sequence[jax.Array],
+    k: int,
+    num_seq_windows: int,
+    digit_width: int,
+    num_digits: int,
+    poison_scratch: bool = False,
+    use_tc_tiling_on_sc: bool = False,
+    debug: bool = False,
+) -> tuple[jax.Array, jax.Array]:
+    """Top-K primitive impl."""
+    vec_dim = plsc.get_sparse_core_info().num_lanes
+    histogram_size = 2**digit_width
+    assert histogram_size >= vec_dim, "Histogram size must be >= vec_dim."
+
+    mesh = plsc.VectorSubcoreMesh(
+        core_axis_name="core",
+        subcore_axis_name="subcore",
+        num_cores=1,  # We may update this to 2 below, if there's enough work.
+    )
+    # TODO: bjp - tune this.
+    num_cooperating_tiles = 1 if keys.shape[-1] <= 4096 else mesh.num_subcores
+    batch_size = math.prod(keys.shape[:-1])
+    if batch_size / (mesh.num_subcores // num_cooperating_tiles) > 1:
+        mesh = dataclasses.replace(mesh, num_cores=2)
+    if keys.shape[-1] % (num_seq_windows * num_cooperating_tiles) != 0:
+        raise NotImplementedError(
+            f"keys.shape[-1] ({keys.shape[-1]}) must be divisible by "
+            "(num_seq_windows * num_cooperating_tiles) "
+            f"({num_seq_windows * num_cooperating_tiles})."
+        )
+    elements_tile_size = keys.shape[-1] // (num_seq_windows * num_cooperating_tiles)
+    if num_seq_windows <= 0:
+        raise ValueError(f"num_seq_windows ({num_seq_windows}) must be > 0.")
+    if elements_tile_size % vec_dim != 0 or elements_tile_size == 0:
+        raise NotImplementedError(
+            f"elements_tile_size ({elements_tile_size}) must be >0 and divisible "
+            f"by vec_dim ({vec_dim})."
+        )
+
+    carryforward_padding = 0
+    if num_seq_windows > 1:
+        carryforward_padding = pl.cdiv(k, vec_dim) * vec_dim
+
+    aligned_k = pl.cdiv(k, vec_dim) * vec_dim
+    pad_histogram_size = (
+        pl.cdiv(histogram_size, 128) * 128 if use_tc_tiling_on_sc else histogram_size
+    )
+    scratch_types = TopKScratch(
+        sem=pltpu.SemaphoreType.DMA,
+        num_to_process=pltpu.SMEM((1,), jnp.int32),
+        num_remaining_global=pltpu.SMEM((1,), jnp.int32),
+        top_k_found=pltpu.SMEM((1,), jnp.int32),
+        top_k_found_global=pltpu.SMEM((1,), jnp.int32),
+        cross_subcore_cumsum=pltpu.SMEM((num_cooperating_tiles,), jnp.int32),
+        histogram_indices=pltpu.VMEM((pad_histogram_size,), jnp.int32),
+        histogram=pltpu.VMEM((pad_histogram_size,), jnp.int32),
+        zeros_histogram=pltpu.VMEM((pad_histogram_size,), jnp.int32),
+        global_histogram=pltpu.VMEM_SHARED((pad_histogram_size,), jnp.int32),
+        keys=pltpu.VMEM((elements_tile_size + carryforward_padding,), keys.dtype),
+        values=pltpu.VMEM((elements_tile_size + carryforward_padding,), jnp.int32),
+        topk_keys=pltpu.VMEM((aligned_k,), keys.dtype),
+        topk_values=pltpu.VMEM((aligned_k,), jnp.int32),
+        output_iota=pltpu.VMEM((aligned_k,), jnp.int32),
+        output_vmshd_keys=pltpu.VMEM_SHARED((aligned_k,), keys.dtype),
+        output_vmshd_vals=pltpu.VMEM_SHARED((aligned_k,), jnp.int32),
+    )
+    if num_cooperating_tiles == 1:
+        scratch_types = dataclasses.replace(
+            scratch_types,
+            cross_subcore_cumsum=None,
+            global_histogram=None,
+            output_vmshd_keys=None,
+            output_vmshd_vals=None,
+        )
+    # TODO: Support scratch trees directly in pl.kernel.
+    scratch_types, scratch_tree = jax.tree.flatten(scratch_types)
+
+    @pl.kernel(
+        out_type=(
+            jax.ShapeDtypeStruct(shape=keys.shape[:-1] + (aligned_k,), dtype=keys.dtype),
+            jax.ShapeDtypeStruct(shape=keys.shape[:-1] + (aligned_k,), dtype=jnp.int32),
+        ),
+        mesh=mesh,
+        scratch_types=scratch_types,
+        name="topk_multitile",
+        compiler_params=pltpu.CompilerParams(
+            use_tc_tiling_on_sc=use_tc_tiling_on_sc,
+            needs_layout_passes=False,
+        ),
+        debug=debug,
+    )
+    def _kernel(keys_ref, values_ref, output_keys_ref, output_values_ref, *scratch):
+        scratch = scratch_tree.unflatten(scratch)
+        if poison_scratch:
+            # Poison all scratch buffers.
+            with jax.named_scope("poison_scratch"):
+
+                def poison_ref(ref):
+                    if ref.memory_space == pltpu.MemorySpace.VMEM:
+
+                        @plsc.parallel_loop(0, ref.size, vec_dim)
+                        def poison_chunk(i):
+                            ref[pl.ds(i, vec_dim)] = jnp.full(
+                                vec_dim, jnp.uint32(0xDEADDEAD).view(ref.dtype)
+                            )
+
+                    elif ref.memory_space == pltpu.MemorySpace.SMEM:
+
+                        @plsc.parallel_loop(0, ref.size)
+                        def poison_smem(i):
+                            ref[i] = jnp.uint32(0xDEADDEAD).view(ref.dtype)
+
+                jax.tree.map(poison_ref, scratch)
+                # Poison global histogram.
+                if scratch.global_histogram is not None:
+                    pltpu.sync_copy(scratch.zeros_histogram, scratch.global_histogram)
+
+        subcore_id = jax.lax.axis_index("subcore")
+        core_id = jax.lax.axis_index("core")
+        batch_elements_executing_in_parallel_per_core = mesh.num_subcores // num_cooperating_tiles
+        batch_index_begin = (
+            subcore_id % batch_elements_executing_in_parallel_per_core
+            + core_id * batch_elements_executing_in_parallel_per_core
+        )
+
+        # The kernel is written with the assumption that we have no cooperation or
+        # that all cores participate.
+        assert num_cooperating_tiles in {1, mesh.num_subcores}
+        coop_subcore_id = 0 if num_cooperating_tiles == 1 else subcore_id
+        is_coop_leader = num_cooperating_tiles > 1 and coop_subcore_id == 0
+
+        batch_elements_executing_in_parallel = (
+            batch_elements_executing_in_parallel_per_core * mesh.num_cores
+        )
+
+        @pl.loop(batch_index_begin, batch_size, step=batch_elements_executing_in_parallel)
+        def batch_loop(batch_idx):
+            batch_indices = jnp.unravel_index(batch_idx, keys_ref.shape[:-1])
+
+            @pl.when(is_coop_leader)
+            def clear_zeros_histogram():
+                clear_histogram(scratch.zeros_histogram)
+
+            @plsc.parallel_loop(0, histogram_size, vec_dim)
+            def fill_histogram_indices(i):
+                scratch.histogram_indices[pl.ds(i, vec_dim)] = i + jnp.arange(vec_dim)
+
+            # TODO: Double buffer scratch.keys + write_outputs
+            @pl.loop(0, num_seq_windows)
+            def window_loop(window_id):
+                if num_seq_windows == 1:
+                    window_id = 0  # For better constant propagation below
+                is_last_coop_window = num_cooperating_tiles > 1 and window_id == num_seq_windows - 1
+
+                with jax.named_scope("load input window"):
+                    coop_subcore_first_window = coop_subcore_id * num_seq_windows
+                    offset = elements_tile_size * (coop_subcore_first_window + window_id)
+                    src_keys = keys_ref.at[*batch_indices, pl.ds(offset, elements_tile_size)]
+                    # Slice out the padding, if any is present.
+                    dst_keys = scratch.keys.at[:elements_tile_size]
+                    keys_window_copy = pltpu.async_copy(src_keys, dst_keys, scratch.sem)
+                    if values_ref is not None:
+                        src_vals = values_ref.at[*batch_indices, pl.ds(offset, elements_tile_size)]
+                        # As above, slice out the padding, if any is present.
+                        dst_vals = scratch.values.at[:elements_tile_size]
+                        val_window_copy = pltpu.async_copy(src_vals, dst_vals, scratch.sem)
+                    else:
+                        val_window_copy = None
+
+                        @plsc.parallel_loop(0, elements_tile_size, vec_dim)
+                        def fill_indices(i):
+                            scratch.values[pl.ds(i, vec_dim)] = offset + i + jnp.arange(vec_dim)
+
+                    @pl.when(window_id > 0)
+                    def copy_previous_windows_topk_to_scratch():
+                        @plsc.parallel_loop(0, k, vec_dim)
+                        def copy_topk_to_scratch(i):
+                            scratch.keys[pl.ds(elements_tile_size + i, vec_dim)] = (
+                                scratch.topk_keys[pl.ds(i, vec_dim)]
+                            )
+                            scratch.values[pl.ds(elements_tile_size + i, vec_dim)] = (
+                                scratch.topk_values[pl.ds(i, vec_dim)]
+                            )
+
+                        # TODO: Seems like we could enforce padding when writing?
+                        if num_unaligned := k % vec_dim:
+                            mask = jnp.arange(vec_dim) < num_unaligned
+                            first_unaligned = (k // vec_dim) * vec_dim
+                            for buf, pad_val in [
+                                (scratch.keys, 0),
+                                (scratch.values, INVALID_VALUE),
+                            ]:
+                                slc = pl.ds(elements_tile_size + first_unaligned, vec_dim)
+                                buf[slc] = jnp.where(mask, buf[slc], pad_val)
+
+                    keys_window_copy.wait()
+                    del keys_window_copy
+                    if val_window_copy is not None:
+                        val_window_copy.wait()
+                    del val_window_copy
+
+                active_scratch = jnp.where(window_id > 0, aligned_k, 0)
+                num_remaining = elements_tile_size + active_scratch
+                args = DigitLoopArgs(
+                    digit_num=jnp.int32(num_digits - 1),
+                    num_remaining=num_remaining,
+                    num_remaining_global=num_remaining * num_cooperating_tiles,
+                    num_local_outputs=jnp.int32(0),
+                    num_global_outputs=jnp.int32(0),
+                    num_postfill_candidate_elements=jnp.int32(0),
+                )
+
+                def cond(args: DigitLoopArgs):
+                    return (args.digit_num >= 0) & (args.num_global_outputs < k)
+
+                def body(args: DigitLoopArgs):
+                    with jax.named_scope("clear_histogram"):
+                        # TODO: Alternatively to the loop in clear_histogram, use
+                        # async DMA to zero out the histogram. Whether this is faster
+                        # depends on how much other work is available to hide the latency
+                        # behind. For small inputs, it can be slower.
+                        clear_histogram(scratch.histogram)
+
+                        # On last window, coop leader starts DMA to clear global histogram.
+                        @pl.when(is_coop_leader & is_last_coop_window)
+                        def start_clearing_global_histogram():
+                            pltpu.async_copy(
+                                scratch.zeros_histogram, scratch.global_histogram, scratch.sem
+                            )
+
+                    with jax.named_scope("fill_histogram"):
+
+                        @plsc.parallel_loop(0, args.num_remaining, vec_dim)
+                        def fill_histogram(i):
+                            digits = scratch.digits(args.digit_num, digit_width)[pl.ds(i, vec_dim)]
+                            counts, mask = plsc.scan_count(digits)
+                            plsc.addupdate_scatter(scratch.histogram, [digits], counts, mask=mask)
+
+                    @pl.when(is_last_coop_window)
+                    @jax.named_scope("sync global histogram")
+                    def sync_global_histogram():
+                        @pl.when(is_coop_leader)
+                        def wait_clearing_global_histogram():
+                            pltpu.make_async_copy(
+                                scratch.zeros_histogram, scratch.global_histogram, scratch.sem
+                            ).wait()
+
+                        plsc.subcore_barrier()
+                        pltpu.sync_copy(
+                            scratch.histogram,
+                            scratch.global_histogram.at[scratch.histogram_indices],
+                            add=True,
+                        )
+                        plsc.subcore_barrier()
+                        pltpu.sync_copy(scratch.global_histogram, scratch.histogram)
+
+                    with jax.named_scope("find_target_digit"):
+                        n_minus_k = args.num_remaining_global - (k - args.num_global_outputs)
+                        init = [jnp.zeros(vec_dim, jnp.int32)] * 2
+
+                        @plsc.parallel_loop(0, histogram_size, vec_dim, carry=init)
+                        def find_target_digit(i, carry):
+                            [num_less, inclusive_sums] = carry
+                            histogram_chunk = scratch.histogram[pl.ds(i, vec_dim)]
+                            chunk_cumsum = jnp.cumsum(histogram_chunk)
+                            digits_below_n_minus_k_this_chunk = plsc.all_reduce_ffs(
+                                (chunk_cumsum + inclusive_sums) >= n_minus_k
+                            )
+                            return [
+                                num_less + digits_below_n_minus_k_this_chunk,
+                                inclusive_sums + chunk_cumsum[vec_dim - 1],
+                            ]
+
+                        [target_digit, _] = (
+                            find_target_digit  # pylint: disable=unpacking-non-sequence
+                        )
+                        # target_digit is the largest digit such that all entries with digit
+                        # smaller can be safely discarded. The vector is a splat.
+
+                    # TODO: DMA could start async zeroing out the histogram here.
+
+                    with jax.named_scope("filter_top_k_elements"):
+                        # Entries with digit > target_digit are surely in the output
+                        # for this window.
+                        # Entries with digit == target_digit are candidates and go to
+                        # the next digit step or to local/global postfill.
+                        init = (jnp.int32(0), args.num_local_outputs)
+
+                        @plsc.parallel_loop(0, args.num_remaining, vec_dim, carry=init)
+                        def filter_top_k_elements(i, carry):
+                            num_survivors, num_local_outputs = carry
+                            keys_chunk, digits = scratch.keys_and_digits(
+                                args.digit_num, digit_width
+                            )[pl.ds(i, vec_dim)]
+                            values_chunk = scratch.values[pl.ds(i, vec_dim)]
+                            is_valid = values_chunk != INVALID_VALUE
+                            is_top_k = is_valid & (digits > target_digit)
+                            survive_to_next_iter = is_valid & (digits == target_digit)
+                            plsc.store_compressed(
+                                scratch.topk_keys.at[pl.ds(num_local_outputs, vec_dim)],
+                                keys_chunk,
+                                mask=is_top_k,
+                            )
+                            plsc.store_compressed(
+                                scratch.topk_values.at[pl.ds(num_local_outputs, vec_dim)],
+                                values_chunk,
+                                mask=is_top_k,
+                            )
+                            plsc.store_compressed(
+                                scratch.keys.at[pl.ds(num_survivors, vec_dim)],
+                                keys_chunk,
+                                mask=survive_to_next_iter,
+                            )
+                            plsc.store_compressed(
+                                scratch.values.at[pl.ds(num_survivors, vec_dim)],
+                                values_chunk,
+                                mask=survive_to_next_iter,
+                            )
+                            return (
+                                num_survivors + all_reduce_popcount(survive_to_next_iter)[0],
+                                num_local_outputs + all_reduce_popcount(is_top_k)[0],
+                            )
+
+                        num_survivors, num_local_outputs = (
+                            filter_top_k_elements  # pylint: disable=unpacking-non-sequence
+                        )
+
+                    # Pad the last chunk of survivors with 0, INVALID_VALUE.
+                    num_unaligned = num_survivors % vec_dim
+
+                    @pl.when(num_unaligned > 0)
+                    def pad_last_chunk():
+                        slc = pl.ds(num_survivors - num_unaligned, vec_dim)
+                        mask = jnp.arange(vec_dim) < num_unaligned
+                        for buf, pad_val in [(scratch.keys, 0), (scratch.values, INVALID_VALUE)]:
+                            buf[slc] = jnp.where(mask, buf[slc], pad_val)
+
+                    # Give the next iter chunk-aligned num_remaining.
+                    pad_amount = (vec_dim - num_unaligned) % vec_dim
+                    num_remaining = num_survivors + pad_amount
+                    # Sync across subcores on last window (if cooperating).
+                    num_remaining_global, num_global_outputs = jax.lax.cond(
+                        is_last_coop_window,
+                        lambda: sum_across_subcores(
+                            [
+                                (scratch.num_remaining_global, num_remaining),
+                                (scratch.top_k_found_global, num_local_outputs),
+                            ]
+                        ),
+                        lambda: [num_remaining, num_local_outputs],
+                    )
+
+                    return dataclasses.replace(
+                        args,
+                        digit_num=args.digit_num - 1,
+                        num_remaining=num_remaining,
+                        num_remaining_global=num_remaining_global,
+                        num_local_outputs=num_local_outputs,
+                        num_global_outputs=num_global_outputs,
+                        num_postfill_candidate_elements=num_survivors,
+                    )
+
+                with jax.named_scope("digit_loop"):
+                    digit_loop_result = jax.lax.while_loop(cond, body, args)
+                num_local_outputs = digit_loop_result.num_local_outputs
+                num_global_outputs = digit_loop_result.num_global_outputs
+                num_postfill_candidate_elements = digit_loop_result.num_postfill_candidate_elements
+
+                num_top_k_remaining = k - num_global_outputs
+                with jax.named_scope("local_postfill"):
+
+                    def local_postfill():
+                        num_valid_postfill = jnp.minimum(
+                            num_top_k_remaining, num_postfill_candidate_elements
+                        )
+                        num_invalid_postfill = num_top_k_remaining - num_valid_postfill
+                        keys_chunk = jnp.full(vec_dim, scratch.keys[:vec_dim][0])
+                        # pylint: disable=cell-var-from-loop
+                        for num_to_postfill, offset, is_valid in [
+                            (num_valid_postfill, num_local_outputs, True),
+                            (num_invalid_postfill, num_local_outputs + num_valid_postfill, False),
+                        ]:
+                            num_unaligned = num_to_postfill % vec_dim
+                            num_aligned = num_to_postfill - num_unaligned
+
+                            @plsc.parallel_loop(0, num_aligned, vec_dim)
+                            def pad_buffers(i):
+                                scratch.topk_keys[pl.ds(offset + i, vec_dim)] = jnp.where(
+                                    is_valid, keys_chunk, 0
+                                )
+                                scratch.topk_values[pl.ds(offset + i, vec_dim)] = jnp.where(
+                                    is_valid, scratch.values[pl.ds(i, vec_dim)], INVALID_VALUE
+                                )
+
+                            @pl.when(num_unaligned > 0)
+                            def pad_unaligned():
+                                mask = jnp.arange(vec_dim) < num_unaligned
+                                plsc.store_compressed(
+                                    scratch.topk_keys.at[pl.ds(offset + num_aligned, vec_dim)],
+                                    jnp.where(is_valid, keys_chunk, 0),
+                                    mask=mask,
+                                )
+                                plsc.store_compressed(
+                                    scratch.topk_values.at[pl.ds(offset + num_aligned, vec_dim)],
+                                    jnp.where(
+                                        is_valid,
+                                        scratch.values[pl.ds(num_aligned, vec_dim)],
+                                        INVALID_VALUE,
+                                    ),
+                                    mask=mask,
+                                )
+
+                        # pylint: enable=cell-var-from-loop
+                        return num_top_k_remaining
+
+                    num_local_outputs += jax.lax.cond(
+                        (num_top_k_remaining > 0)
+                        & ((window_id < num_seq_windows - 1) | (num_cooperating_tiles == 1)),
+                        local_postfill,
+                        lambda: 0,
+                    )
+
+                with jax.named_scope("global_postfill"):
+
+                    def global_postfill():
+                        # At this point, we are on the last window (see the cond which
+                        # calls global_postfill), so all Vector Subcores are synced and agree on
+                        # num_top_k_remaining.
+                        #
+                        # So we will cumsum the valid postfill candidate elements across
+                        # Vector Subcores (each subcore only sees the sum of its predecessors).
+                        # Then we'll subtract the # postfill candidates we expect to be
+                        # written by preceding Vector Subcores (up to a max of num_top_k_remaining).
+                        # Then we'll write the lesser of [how many are left to write], or
+                        # [how many valid candidates we have].
+                        # And we'll write those at an offset corresponding to the number of
+                        # elements we expect preceding Vector Subcores to have written.
+                        num_predecessor_postfill = preceding_subcores_sum(
+                            mesh, scratch.cross_subcore_cumsum, num_postfill_candidate_elements
+                        )
+                        num_predecessor_postfill = jnp.minimum(
+                            num_top_k_remaining, num_predecessor_postfill
+                        )
+                        num_to_postfill = jnp.minimum(
+                            num_top_k_remaining - num_predecessor_postfill,
+                            num_postfill_candidate_elements,
+                        )
+                        keys_chunk = jnp.full(vec_dim, scratch.keys[:vec_dim][0])
+                        offset = num_local_outputs
+                        num_unaligned = num_to_postfill % vec_dim
+                        num_aligned = num_to_postfill - num_unaligned
+
+                        @plsc.parallel_loop(0, num_aligned, vec_dim)
+                        def copy_to_topk_buffers(i):
+                            scratch.topk_keys[pl.ds(offset + i, vec_dim)] = keys_chunk
+                            scratch.topk_values[pl.ds(offset + i, vec_dim)] = scratch.values[
+                                pl.ds(i, vec_dim)
+                            ]
+
+                        @pl.when(num_unaligned > 0)
+                        def copy_unaligned():
+                            mask = jnp.arange(vec_dim) < num_unaligned
+                            plsc.store_compressed(
+                                scratch.topk_keys.at[pl.ds(offset + num_aligned, vec_dim)],
+                                keys_chunk,
+                                mask=mask,
+                            )
+                            plsc.store_compressed(
+                                scratch.topk_values.at[pl.ds(offset + num_aligned, vec_dim)],
+                                scratch.values[pl.ds(num_aligned, vec_dim)],
+                                mask=mask,
+                            )
+
+                        return num_to_postfill
+
+                    if num_cooperating_tiles > 1:
+                        num_local_outputs += jax.lax.cond(
+                            (num_top_k_remaining > 0) & (window_id == num_seq_windows - 1),
+                            global_postfill,
+                            lambda: 0,
+                        )
+
+                with jax.named_scope("write_outputs"):
+
+                    @pl.when(window_id == num_seq_windows - 1)
+                    def write_outputs():
+                        if num_cooperating_tiles > 1:
+                            preceding_subcore_outputs = preceding_subcores_sum(
+                                mesh, scratch.cross_subcore_cumsum, num_local_outputs
+                            )
+                        else:
+                            preceding_subcore_outputs = 0
+
+                        @plsc.parallel_loop(0, num_local_outputs, vec_dim)
+                        def fill_output_offsets(i):
+                            scratch.output_iota[pl.ds(i, vec_dim)] = (
+                                preceding_subcore_outputs + i + jnp.arange(vec_dim)
+                            )
+
+                        num_unaligned = num_local_outputs % vec_dim
+
+                        @pl.when(num_unaligned > 0)
+                        def write_unaligned_offsets_chunk():
+                            # Can write a full chunk because output_iota is aligned_k size.
+                            i = num_local_outputs - num_unaligned
+                            scratch.output_iota[pl.ds(i, vec_dim)] = (
+                                preceding_subcore_outputs + i + jnp.arange(vec_dim)
+                            )
+
+                        hbm_offsets = scratch.output_iota.at[pl.ds(0, num_local_outputs)]
+                        if num_cooperating_tiles > 1:
+                            pltpu.sync_copy(
+                                (
+                                    scratch.topk_keys.at[pl.ds(num_local_outputs)],
+                                    scratch.topk_values.at[pl.ds(num_local_outputs)],
+                                ),
+                                (
+                                    scratch.output_vmshd_keys.at[hbm_offsets],
+                                    scratch.output_vmshd_vals.at[hbm_offsets],
+                                ),
+                            )
+                            plsc.subcore_barrier()
+
+                            @pl.when(is_coop_leader)
+                            def _():
+                                pltpu.sync_copy(
+                                    (
+                                        scratch.output_vmshd_keys.at[:aligned_k],
+                                        scratch.output_vmshd_vals.at[:aligned_k],
+                                    ),
+                                    (
+                                        output_keys_ref.at[*batch_indices].at[:aligned_k],
+                                        output_values_ref.at[*batch_indices].at[:aligned_k],
+                                    ),
+                                )
+
+                        else:
+                            pltpu.sync_copy(
+                                (
+                                    scratch.topk_keys.at[pl.ds(num_local_outputs)],
+                                    scratch.topk_values.at[pl.ds(num_local_outputs)],
+                                ),
+                                (
+                                    output_keys_ref.at[*batch_indices].at[hbm_offsets],
+                                    output_values_ref.at[*batch_indices].at[hbm_offsets],
+                                ),
+                            )
+
+    return jax.tree.map(
+        lambda t: t[..., :k], _kernel(keys, *([None] if not maybe_values else maybe_values))
+    )
+
+
+sc_top_k_p = jax_extend.core.Primitive("sc_top_k")
+sc_top_k_p.multiple_results = True
+
+
+@sc_top_k_p.def_impl
+def _impl(*_, **__):
+    raise RuntimeError("sc_top_k must be JIT'ed")
+
+
+@sc_top_k_p.def_abstract_eval
+def _sc_top_k_abstract_eval(keys, *maybe_values, k, **_):
+    if maybe_values:
+        (values,) = maybe_values
+        if values.dtype != jnp.int32 or values.shape != keys.shape:
+            raise ValueError(
+                f"`values` has dtype {values.dtype} and shape {values.shape}, but "
+                f"must have dtype int32 and shape matching `keys` {keys.shape}."
+            )
+        assert keys.shape == values.shape, (keys, values)
+    return (
+        jax.core.ShapedArray((*keys.shape[:-1], k), keys.dtype),
+        jax.core.ShapedArray((*keys.shape[:-1], k), jnp.int32),
+    )
+
+
+def _sc_top_k_batch_rule(batched_args, batch_dims, **kwargs):
+    if any(bd is None for bd in batch_dims):
+        raise ValueError("sc_top_k does not support broadcasting vmap.")
+    if len(set(batch_dims)) != 1:
+        raise ValueError("sc_top_k does not support vmap on different k/v axes.")
+    if any(bd == arg.ndim - 1 for arg, bd in zip(batched_args, batch_dims, strict=True)):
+        raise ValueError("sc_top_k does not support vmap on the innermost axis.")
+    outputs, indices = sc_top_k_p.bind(*batched_args, **kwargs)
+    return (outputs, indices), batch_dims
+
+
+batching.primitive_batchers[sc_top_k_p] = _sc_top_k_batch_rule
+mlir.register_lowering(sc_top_k_p, mlir.lower_fun(_sc_top_k_impl))
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "k",
+        "use_approx_top_k",
+        "num_seq_windows",
+        "digit_width",
+        "num_digits",
+        "poison_scratch",
+        "use_tc_tiling_on_sc",
+        "debug",
+    ],
+)
+def top_k(
+    keys: jax.Array,
+    values: jax.Array | None = None,
+    *,
+    k: int,
+    use_approx_top_k: bool = False,
+    num_seq_windows: int = 1,
+    digit_width: int = 8,
+    num_digits: int = 4,
+    poison_scratch: bool = False,
+    use_tc_tiling_on_sc: bool = False,
+    debug: bool = False,
+) -> tuple[jax.Array, jax.Array]:
+    """Multi-Vectore Subcore Top-K implementation.
+
+    Args:
+      keys: Input keys, shape (*batch_dims, elements_per_batch_entry).
+      values: (Optional) Values to gather using the top-k indices, shape matching
+        `keys`. Supports the case where we want to use an alternate set of
+        indices, e.g. [shard_map(local topk)] -> [all gather] -> [global topk
+        using indices derived from local topk's]. Note, 0xFFFFFFFF u32 / -1 s32 is
+        reserved as a sentinel value. If passed in this argument, results are
+        undefined.
+      k: The number of top K elements to return.
+      use_approx_top_k: Whether to pre-reduce using lax.approx_max_k.
+      num_seq_windows: The number of sequential windows to process per subcore.
+      digit_width: The width of the digit representation.
+      num_digits: The number of digits to use.
+      poison_scratch: Whether to poison the scratch buffers.
+      use_tc_tiling_on_sc: Whether to use TC tiling on SC.
+      debug: Whether to enable debug logging.
+
+    Returns:
+      A tuple of (topk_keys, topk_values), both of shape (*batch_dims, k).
+    """
+    logging.info("SparseCore topk args: %s", dict(locals()))
+    # TODO: We might get a speedup by using approx_max_k in the
+    # values-not-None case, but would need to add support for doubly-gathered
+    # indices, i.e. keys=approx_max_keys, values=values.at[approx_max_values].
+    if use_approx_top_k and values is None:
+        keys, values = jax.lax.approx_max_k(keys, k=k, aggregate_to_topk=False)
+    return tuple(
+        sc_top_k_p.bind(
+            keys,
+            *([] if values is None else [values]),
+            k=k,
+            num_seq_windows=num_seq_windows,
+            digit_width=digit_width,
+            num_digits=num_digits,
+            poison_scratch=poison_scratch,
+            use_tc_tiling_on_sc=use_tc_tiling_on_sc,
+            debug=debug,
+        )
+    )

--- a/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
+++ b/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
@@ -631,72 +631,85 @@ def prepare_outputs(out):
 
 # Rows shorter than this stay on the XLA path. Measured: E=256 rows are ~30% slower on
 # SparseCore, E=25000 rows are ~2.3x faster; tokamax switches to cooperative subcores
-# above 4096 entries. Override with DSA_SC_TOPK_MIN_ENTRIES.
+# above 4096 entries. Override with DSA_SC_TOPK_MIN_ENTRIES. Both env vars are read
+# when the calling function is traced (jit-cached afterwards).
 SC_TOPK_MIN_ENTRIES = int(os.environ.get("DSA_SC_TOPK_MIN_ENTRIES", "8192"))
 # Fraction of one SparseCore subcore's VMEM the kernel may use for its per-subcore
 # key + value slice (the rest holds histograms, output buffers and the carry-forward).
 _SC_TOPK_VMEM_BUDGET = 0.5
-_SC_TOPK_COOPERATING_SUBCORES = 16  # tokamax kernel constant for rows > 4096 entries
+# Above this many entries the vendored kernel splits each row across all subcores of a
+# core (``num_cooperating_tiles = mesh.num_subcores``); at or below it one subcore
+# owns the whole row.
+_SC_TOPK_COOPERATIVE_ABOVE = 4096
 _SC_TOPK_KEY_VALUE_BYTES = 8  # f32 key + int32 value per candidate
 
 
 @functools.lru_cache(maxsize=1)
 def _sparse_core_info():
-    """SparseCore geometry of the current TPU, or None when unavailable."""
+    """SparseCore geometry of the current TPU (cached), or None when unavailable."""
     if jax.default_backend() != "tpu":
         return None
     try:
         info = pltpu.get_tpu_info()
-        if getattr(info, "generation", 0) < 6 or info.sparse_core is None:
-            return None
-        return info.sparse_core
-    except Exception:  # noqa: BLE001 - any failure means "no SparseCore path"
+    except (RuntimeError, ValueError):
         return None
+    if getattr(info, "generation", 0) < 6 or getattr(info, "sparse_core", None) is None:
+        return None
+    return info.sparse_core
 
 
-@functools.lru_cache(maxsize=1)
 def sc_topk_available() -> bool:
-    """True when the SparseCore radix-select kernel can run on this device."""
-    if os.environ.get("DSA_SC_TOPK", "1") == "0":
-        return False
-    if _sparse_core_info() is None:
-        return False
-    try:
-        from sgl_jax.srt.kernels.dsa import sc_topk  # noqa: F401
+    """True when the SparseCore radix-select kernel can run on this device.
 
-        return True
-    except ImportError:
-        return False
+    DSA_SC_TOPK=0 disables the path; the check runs at trace time of the caller.
+    """
+    return os.environ.get("DSA_SC_TOPK", "1") != "0" and _sparse_core_info() is not None
 
 
-def _sc_topk_max_entries(vmem_capacity_bytes: int, num_lanes: int) -> int:
-    per_subcore = int(vmem_capacity_bytes * _SC_TOPK_VMEM_BUDGET) // _SC_TOPK_KEY_VALUE_BYTES
-    per_subcore -= per_subcore % num_lanes
-    return per_subcore * _SC_TOPK_COOPERATING_SUBCORES
+def _sc_topk_max_entries(info) -> int:
+    """Largest row whose per-subcore key+value slice fits the VMEM budget."""
+    per_subcore = int(info.vmem_capacity_bytes * _SC_TOPK_VMEM_BUDGET)
+    per_subcore //= _SC_TOPK_KEY_VALUE_BYTES
+    per_subcore -= per_subcore % info.num_lanes
+    return per_subcore * info.num_subcores
 
 
 def should_use_sc_topk(num_entries: int, batch: int) -> bool:
-    """Host-side routing policy for the exit-stage top-k (pure function of shape)."""
+    """Routing policy for the exit-stage top-k: pure function of shape and device.
+
+    Evaluated on the device the caller is traced on; off-TPU it is always False.
+    """
     del batch  # the kernel handles any batch; kept in the signature for future tuning
-    if num_entries < SC_TOPK_MIN_ENTRIES:
-        return False
     info = _sparse_core_info()
-    # Off-TPU callers (tests, tracing on CPU) get the most conservative geometry: v6e.
-    vmem = info.vmem_capacity_bytes if info is not None else 256 * 1024
-    lanes = info.num_lanes if info is not None else 8
-    return num_entries <= _sc_topk_max_entries(vmem, lanes)
+    if info is None or num_entries < SC_TOPK_MIN_ENTRIES:
+        return False
+    return num_entries <= _sc_topk_max_entries(info)
+
+
+def _sc_padded_width(n: int, info) -> int:
+    """Smallest width >= n satisfying the kernel's layout constraints: the row is split
+    into ``num_subcores`` tiles above the cooperative threshold (one tile below it), and
+    each tile must be a whole number of ``num_lanes``-wide vectors."""
+    tiles = 1 if n <= _SC_TOPK_COOPERATIVE_ABOVE else info.num_subcores
+    unit = tiles * info.num_lanes
+    padded = -(-n // unit) * unit
+    if n <= _SC_TOPK_COOPERATIVE_ABOVE < padded:  # padding crossed the threshold
+        unit = info.num_subcores * info.num_lanes
+        padded = -(-n // unit) * unit
+    return padded
 
 
 def _sc_select(scores: jax.Array, k: int) -> jax.Array:
     from sgl_jax.srt.kernels.dsa import sc_topk
 
     info = _sparse_core_info()
-    lanes = info.num_lanes if info is not None else 8
+    if info is None:
+        raise ValueError(
+            "SparseCore top-k requested but no SparseCore is available on backend "
+            f"{jax.default_backend()!r}; use topk_backend='xla' or 'auto'."
+        )
     n = scores.shape[-1]
-    # Kernel layout constraints: rows > 4096 are split across 16 cooperating subcores
-    # and every per-subcore tile must be a whole number of vector registers.
-    unit = lanes if n <= 4096 else lanes * _SC_TOPK_COOPERATING_SUBCORES
-    padded = -(-n // unit) * unit
+    padded = _sc_padded_width(n, info)
     if padded != n:
         scores = jnp.pad(scores, ((0, 0), (0, padded - n)), constant_values=-jnp.inf)
     vals, idxs = sc_topk.top_k(keys=scores, k=k, num_seq_windows=1, digit_width=4, num_digits=8)
@@ -724,6 +737,11 @@ def select_topk_indices(scores: jax.Array, k: int, *, backend: str = "auto") -> 
     if backend == "auto":
         use_sc = sc_topk_available() and should_use_sc_topk(scores.shape[-1], scores.shape[0])
     elif backend == "sc":
+        if not sc_topk_available():
+            raise ValueError(
+                "topk_backend='sc' requires a TPU with a SparseCore (v6e or newer) and "
+                "DSA_SC_TOPK unset or != '0'."
+            )
         use_sc = True
     elif backend == "xla":
         use_sc = False

--- a/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
+++ b/python/sgl_jax/srt/kernels/dsa/streamindex_topk.py
@@ -20,6 +20,7 @@
 
 import enum
 import functools
+import os
 
 import jax
 import jax.numpy as jnp
@@ -616,6 +617,121 @@ def prepare_outputs(out):
     return out
 
 
+# ----------------------------------------------------------------------------
+# Exit-stage selection: SparseCore radix select (exact) vs XLA approx_max_k.
+#
+# ``jax.lax.approx_max_k(recall_target=1.0)`` lowers to a full sort of every row on
+# TPU (XLA short-circuits recall_target == 1.0 to log2_reduction=0), which at
+# DeepSeek-V4 scale (E = 262144 compressed entries per query, k=512) is 56% (decode
+# B=64) to 84% (prefill T=2048) of this kernel's wall time on v7x. The vendored
+# SparseCore MSB radix-select kernel (``sc_topk``) is exact and 4-6x faster on that
+# stage on both v6e and v7x. Small rows are cheaper on the XLA path (fixed SC launch
+# cost), so the policy below keeps them there.
+# ----------------------------------------------------------------------------
+
+# Rows shorter than this stay on the XLA path. Measured: E=256 rows are ~30% slower on
+# SparseCore, E=25000 rows are ~2.3x faster; tokamax switches to cooperative subcores
+# above 4096 entries. Override with DSA_SC_TOPK_MIN_ENTRIES.
+SC_TOPK_MIN_ENTRIES = int(os.environ.get("DSA_SC_TOPK_MIN_ENTRIES", "8192"))
+# Fraction of one SparseCore subcore's VMEM the kernel may use for its per-subcore
+# key + value slice (the rest holds histograms, output buffers and the carry-forward).
+_SC_TOPK_VMEM_BUDGET = 0.5
+_SC_TOPK_COOPERATING_SUBCORES = 16  # tokamax kernel constant for rows > 4096 entries
+_SC_TOPK_KEY_VALUE_BYTES = 8  # f32 key + int32 value per candidate
+
+
+@functools.lru_cache(maxsize=1)
+def _sparse_core_info():
+    """SparseCore geometry of the current TPU, or None when unavailable."""
+    if jax.default_backend() != "tpu":
+        return None
+    try:
+        info = pltpu.get_tpu_info()
+        if getattr(info, "generation", 0) < 6 or info.sparse_core is None:
+            return None
+        return info.sparse_core
+    except Exception:  # noqa: BLE001 - any failure means "no SparseCore path"
+        return None
+
+
+@functools.lru_cache(maxsize=1)
+def sc_topk_available() -> bool:
+    """True when the SparseCore radix-select kernel can run on this device."""
+    if os.environ.get("DSA_SC_TOPK", "1") == "0":
+        return False
+    if _sparse_core_info() is None:
+        return False
+    try:
+        from sgl_jax.srt.kernels.dsa import sc_topk  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _sc_topk_max_entries(vmem_capacity_bytes: int, num_lanes: int) -> int:
+    per_subcore = int(vmem_capacity_bytes * _SC_TOPK_VMEM_BUDGET) // _SC_TOPK_KEY_VALUE_BYTES
+    per_subcore -= per_subcore % num_lanes
+    return per_subcore * _SC_TOPK_COOPERATING_SUBCORES
+
+
+def should_use_sc_topk(num_entries: int, batch: int) -> bool:
+    """Host-side routing policy for the exit-stage top-k (pure function of shape)."""
+    del batch  # the kernel handles any batch; kept in the signature for future tuning
+    if num_entries < SC_TOPK_MIN_ENTRIES:
+        return False
+    info = _sparse_core_info()
+    # Off-TPU callers (tests, tracing on CPU) get the most conservative geometry: v6e.
+    vmem = info.vmem_capacity_bytes if info is not None else 256 * 1024
+    lanes = info.num_lanes if info is not None else 8
+    return num_entries <= _sc_topk_max_entries(vmem, lanes)
+
+
+def _sc_select(scores: jax.Array, k: int) -> jax.Array:
+    from sgl_jax.srt.kernels.dsa import sc_topk
+
+    info = _sparse_core_info()
+    lanes = info.num_lanes if info is not None else 8
+    n = scores.shape[-1]
+    # Kernel layout constraints: rows > 4096 are split across 16 cooperating subcores
+    # and every per-subcore tile must be a whole number of vector registers.
+    unit = lanes if n <= 4096 else lanes * _SC_TOPK_COOPERATING_SUBCORES
+    padded = -(-n // unit) * unit
+    if padded != n:
+        scores = jnp.pad(scores, ((0, 0), (0, padded - n)), constant_values=-jnp.inf)
+    vals, idxs = sc_topk.top_k(keys=scores, k=k, num_seq_windows=1, digit_width=4, num_digits=8)
+    # The kernel does not order its output; the indexer contract is descending values
+    # with -1 (from -inf) packed at the tail.
+    vals, idxs = jax.lax.sort((vals, idxs), dimension=-1)
+    vals, idxs = jnp.flip(vals, axis=-1), jnp.flip(idxs, axis=-1)
+    return jnp.where(vals == -jnp.inf, -1, idxs)
+
+
+def _xla_select(scores: jax.Array, k: int) -> jax.Array:
+    # jax.lax.approx_max_k(recall_target=1.0) is equivalent to jax.lax.top_k
+    # but faster.
+    top_vals, top_idxs = jax.lax.approx_max_k(scores, k, reduction_dimension=-1, recall_target=1.0)
+    return jnp.where(top_vals == -jnp.inf, -1, top_idxs)
+
+
+def select_topk_indices(scores: jax.Array, k: int, *, backend: str = "auto") -> jax.Array:
+    """Exact top-k indices of ``scores`` ([T, E] f32, -inf = invalid), descending, -1 tail.
+
+    backend: "auto" routes by ``should_use_sc_topk``; "sc" / "xla" force a path.
+    """
+    if scores.shape[-1] < k:
+        scores = jnp.pad(scores, ((0, 0), (0, k - scores.shape[-1])), constant_values=-jnp.inf)
+    if backend == "auto":
+        use_sc = sc_topk_available() and should_use_sc_topk(scores.shape[-1], scores.shape[0])
+    elif backend == "sc":
+        use_sc = True
+    elif backend == "xla":
+        use_sc = False
+    else:
+        raise ValueError(f"unknown top-k backend {backend!r}; expected auto | sc | xla")
+    return _sc_select(scores, k) if use_sc else _xla_select(scores, k)
+
+
 @functools.partial(
     jax.jit,
     static_argnames=(
@@ -625,6 +741,7 @@ def prepare_outputs(out):
         "num_queries_per_block",
         "vmem_limit_bytes",
         "decode_req_batch_size",
+        "topk_backend",
     ),
 )
 def streamindex_topk(
@@ -642,6 +759,7 @@ def streamindex_topk(
     num_queries_per_block: tuple[int, int, int] | int | None = None,
     vmem_limit_bytes: int = DEFAULT_VMEM_LIMIT_BYTES,
     decode_req_batch_size: int = 4,
+    topk_backend: str = "auto",
 ) -> jax.Array:
     """StreamIndex Top-K retrieval.
 
@@ -663,6 +781,8 @@ def streamindex_topk(
       num_queries_per_block: number of queries to be processed in one block in the
         pallas kernel. This is a tuple of (decode, prefill, mixed) cases.
       vmem_limit_bytes: the vmem limit for the pallas kernel.
+      topk_backend: exit-stage selector: "auto" (SparseCore radix select when
+        available and the row is large enough, else XLA), "sc" or "xla".
 
     Returns:
       Top-K indices (in compressed space).
@@ -903,22 +1023,7 @@ def streamindex_topk(
     )
 
     scores = scores.reshape(q.shape[0], -1)
-    if scores.shape[1] < k:
-        scores = jnp.pad(
-            scores,
-            ((0, 0), (0, k - scores.shape[1])),
-            constant_values=-jnp.inf,
-        )
-
-    # TODO: Re-evaluate replacing this with the sparsecore_topk kernel
-    # once SparseCore supports direct VMEM access (e.g., on TPU v8).
-    # Currently, jax.lax.approx_max_k wins due to the HBM read/write tax, but
-    # direct VMEM streaming will allow SC to beat TensorCore performance.
-
-    # jax.lax.approx_max_k(recall_target=1.0) is equivalent to jax.lax.top_k
-    # but faster.
-    top_vals, top_idxs = jax.lax.approx_max_k(scores, k, reduction_dimension=-1, recall_target=1.0)
-    topk_idxs = jnp.where(top_vals == -jnp.inf, -1, top_idxs)
+    topk_idxs = select_topk_indices(scores, k, backend=topk_backend)
     return topk_idxs[: q.shape[0], :k]
 
 

--- a/test/srt/kernels/dsa/test_sc_topk_selector.py
+++ b/test/srt/kernels/dsa/test_sc_topk_selector.py
@@ -1,0 +1,143 @@
+"""SparseCore top-k selector for the DSA indexer (``streamindex_topk`` exit stage).
+
+Parity against exact ``jax.lax.top_k`` on the score matrix the indexer kernel
+produces, including the ``-inf`` columns the kernel leaves for masked / never-written
+entries and the ``E < k`` case that must yield trailing ``-1``.
+"""
+
+import os
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from sgl_jax.srt.kernels.dsa.streamindex_topk import (
+    SC_TOPK_MIN_ENTRIES,
+    sc_topk_available,
+    select_topk_indices,
+    should_use_sc_topk,
+    streamindex_topk,
+)
+
+if jax.default_backend() != "tpu":
+    pytest.skip("SparseCore top-k selector requires TPU", allow_module_level=True)
+
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+K = 512
+
+
+def _exact_indices(scores, k):
+    vals, idxs = jax.lax.top_k(scores, k)
+    return np.where(np.asarray(vals) == -np.inf, -1, np.asarray(idxs))
+
+
+def _set_rows_equal(a, b):
+    return all(set(x[x >= 0].tolist()) == set(y[y >= 0].tolist()) for x, y in zip(a, b))
+
+
+def _trailing_minus_one(a):
+    flags = (a < 0).astype(np.int32)
+    return bool(np.all(np.diff(flags, axis=1) >= 0))
+
+
+def test_should_use_sc_topk_thresholds():
+    """Pure host-side policy: small rows fall back to XLA, large rows go to SparseCore."""
+    assert not should_use_sc_topk(num_entries=256, batch=8)
+    assert not should_use_sc_topk(num_entries=SC_TOPK_MIN_ENTRIES - 1, batch=64)
+    assert should_use_sc_topk(num_entries=SC_TOPK_MIN_ENTRIES, batch=1)
+    assert should_use_sc_topk(num_entries=262144, batch=2048)
+    # Rows that cannot fit one SparseCore subcore's VMEM must not be routed to the kernel.
+    assert not should_use_sc_topk(num_entries=1 << 26, batch=1)
+
+
+@pytest.mark.skipif(not sc_topk_available(), reason="no SparseCore top-k on this chip")
+@pytest.mark.parametrize("batch,num_entries", [(64, 262144), (3, 25000), (1, 8192)])
+def test_sc_selector_matches_exact_topk(batch, num_entries):
+    """Random f32 scores with a block of -inf columns: SC result == exact top-k as a set,
+    values descending, -1 only at the tail. num_entries=25000 is not a multiple of 256, so
+    it exercises the padding path."""
+    rng = np.random.default_rng(0)
+    s = rng.standard_normal((batch, num_entries), np.float32)
+    s[:, num_entries - 1000 :] = -np.inf  # tail the kernel never wrote / causal-masked
+    scores = jnp.asarray(s)
+    got = np.asarray(select_topk_indices(scores, K, backend="sc"))
+    exact = _exact_indices(scores, K)
+    assert got.shape == (batch, K)
+    assert _set_rows_equal(got, exact)
+    assert _trailing_minus_one(got)
+    assert not np.any(got >= num_entries - 1000), "a -inf column was selected"
+
+
+@pytest.mark.skipif(not sc_topk_available(), reason="no SparseCore top-k on this chip")
+def test_sc_selector_fewer_valid_than_k_pads_with_minus_one():
+    scores = (
+        jnp.full((4, 8192), -jnp.inf, jnp.float32)
+        .at[:, :300]
+        .set(jnp.asarray(np.random.default_rng(1).standard_normal((4, 300), np.float32)))
+    )
+    got = np.asarray(select_topk_indices(scores, K, backend="sc"))
+    assert np.all((got >= 0).sum(1) == 300)
+    assert _trailing_minus_one(got)
+    assert _set_rows_equal(got, _exact_indices(scores, K))
+
+
+def test_xla_selector_unchanged():
+    """backend='xla' is the pre-existing approx_max_k(recall_target=1.0) path."""
+    scores = jnp.asarray(np.random.default_rng(2).standard_normal((8, 4096), np.float32))
+    got = np.asarray(select_topk_indices(scores, K, backend="xla"))
+    assert _set_rows_equal(got, _exact_indices(scores, K)) and _trailing_minus_one(got)
+
+
+def _indexer_case(B, T_per_seq, ctx, *, ratio=4, page=128, H=8, D=128, seed=3):
+    """Decode/prefill batch over a bf16 indexer cache; ctx in tokens, entries = ctx // ratio."""
+    dev = jax.devices()[0]
+    rng = np.random.default_rng(seed)
+    T = B * T_per_seq
+    entries = ctx // ratio
+    pps = -(-entries // page)
+    total_pages = B * pps + 1
+    q = jax.device_put(jnp.asarray(rng.standard_normal((T, H, D), np.float32), jnp.bfloat16), dev)
+    w = jax.device_put(jnp.asarray(rng.standard_normal((T, H), np.float32)), dev)
+    cache = jax.device_put(
+        jax.random.normal(jax.random.key(seed), (total_pages, page // 2, 2, D), jnp.bfloat16), dev
+    )
+    nd = B if T_per_seq == 1 else 0
+    return dict(
+        q=q,
+        indexer_weights=w,
+        cache_kv=cache,
+        seq_lens=jnp.full((B,), ctx, jnp.int32),
+        page_indices=jnp.asarray(np.arange(1, B * pps + 1, dtype=np.int32)),
+        cu_q_lens=jnp.asarray(np.arange(0, T + 1, T_per_seq, dtype=np.int32)),
+        distribution=jnp.asarray((nd, nd, B), jnp.int32),
+    )
+
+
+@pytest.mark.skipif(not sc_topk_available(), reason="no SparseCore top-k on this chip")
+@pytest.mark.parametrize(
+    "B,T_per_seq,ctx",
+    [(8, 1, 1 << 20), (1, 256, 1 << 18), (8, 1, 100_000), (8, 1, 1024)],
+)
+def test_streamindex_topk_sc_matches_xla_end_to_end(B, T_per_seq, ctx):
+    """The kernel's own scores through both selector backends give identical index sets;
+    ctx=1024 (256 entries < k) also checks the trailing -1 contract."""
+    args = _indexer_case(B, T_per_seq, ctx)
+    outs = {}
+    for backend in ("xla", "sc", "auto"):
+        outs[backend] = np.asarray(
+            streamindex_topk(
+                **args,
+                k=K,
+                compression_ratio=4,
+                num_kv_pages_per_block=64,
+                num_queries_per_block=(1, 64, 64),
+                topk_backend=backend,
+            )
+        )
+    assert _set_rows_equal(outs["xla"], outs["sc"])
+    assert _set_rows_equal(outs["xla"], outs["auto"])
+    assert _trailing_minus_one(outs["sc"])
+    if ctx == 1024:
+        assert np.all((outs["sc"] >= 0).sum(1) == 256)

--- a/test/srt/kernels/dsa/test_sc_topk_selector.py
+++ b/test/srt/kernels/dsa/test_sc_topk_selector.py
@@ -12,8 +12,10 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+import sgl_jax.srt.kernels.dsa.streamindex_topk as streamindex_topk_mod
 from sgl_jax.srt.kernels.dsa.streamindex_topk import (
     SC_TOPK_MIN_ENTRIES,
+    _sc_padded_width,
     sc_topk_available,
     select_topk_indices,
     should_use_sc_topk,
@@ -42,14 +44,62 @@ def _trailing_minus_one(a):
     return bool(np.all(np.diff(flags, axis=1) >= 0))
 
 
-def test_should_use_sc_topk_thresholds():
-    """Pure host-side policy: small rows fall back to XLA, large rows go to SparseCore."""
+class _FakeSparseCore:
+    """v6e geometry (pltpu.get_tpu_info().sparse_core on TPU v6e)."""
+
+    num_cores = 2
+    num_subcores = 16
+    num_lanes = 8
+    vmem_capacity_bytes = 262144
+
+
+def test_should_use_sc_topk_thresholds(monkeypatch):
+    """Pure policy: small rows fall back to XLA, large rows go to SparseCore, rows whose
+    per-subcore key+value slice exceeds half of VMEM fall back."""
+    monkeypatch.setattr(streamindex_topk_mod, "_sparse_core_info", lambda: _FakeSparseCore())
     assert not should_use_sc_topk(num_entries=256, batch=8)
     assert not should_use_sc_topk(num_entries=SC_TOPK_MIN_ENTRIES - 1, batch=64)
     assert should_use_sc_topk(num_entries=SC_TOPK_MIN_ENTRIES, batch=1)
+    # 262144 entries / 16 subcores * 8 B = 128 KiB = exactly half of v6e VMEM.
     assert should_use_sc_topk(num_entries=262144, batch=2048)
-    # Rows that cannot fit one SparseCore subcore's VMEM must not be routed to the kernel.
+    assert not should_use_sc_topk(num_entries=262144 + 16 * 8, batch=1)
     assert not should_use_sc_topk(num_entries=1 << 26, batch=1)
+
+
+def test_should_use_sc_topk_false_without_sparse_core(monkeypatch):
+    monkeypatch.setattr(streamindex_topk_mod, "_sparse_core_info", lambda: None)
+    assert not should_use_sc_topk(num_entries=262144, batch=64)
+    assert not sc_topk_available()
+    with pytest.raises(ValueError, match="requires a TPU with a SparseCore"):
+        select_topk_indices(jnp.zeros((1, 8192), jnp.float32), K, backend="sc")
+
+
+def test_sc_padded_width_matches_kernel_constraints():
+    info = _FakeSparseCore()
+    # Below the cooperative threshold: one tile, whole vectors of num_lanes.
+    assert _sc_padded_width(4096, info) == 4096
+    assert _sc_padded_width(4090, info) == 4096
+    # Above it: num_subcores tiles, each a whole number of vectors.
+    assert _sc_padded_width(4097, info) == 4224  # next multiple of 16 * 8
+    assert _sc_padded_width(25000, info) == 25088
+    assert _sc_padded_width(262144, info) == 262144
+
+
+def test_auto_backend_routes_by_row_width(monkeypatch):
+    """auto -> XLA for short rows, SparseCore for long rows (both selectors observed)."""
+    calls = []
+    orig_sc, orig_xla = streamindex_topk_mod._sc_select, streamindex_topk_mod._xla_select
+    monkeypatch.setattr(
+        streamindex_topk_mod, "_sc_select", lambda s, k: (calls.append("sc"), orig_sc(s, k))[1]
+    )
+    monkeypatch.setattr(
+        streamindex_topk_mod, "_xla_select", lambda s, k: (calls.append("xla"), orig_xla(s, k))[1]
+    )
+    select_topk_indices(jnp.zeros((1, 256), jnp.float32), K, backend="auto")
+    assert calls == ["xla"]
+    if sc_topk_available():
+        select_topk_indices(jnp.zeros((1, 262144), jnp.float32), K, backend="auto")
+        assert calls == ["xla", "sc"]
 
 
 @pytest.mark.skipif(not sc_topk_available(), reason="no SparseCore top-k on this chip")
@@ -81,6 +131,21 @@ def test_sc_selector_fewer_valid_than_k_pads_with_minus_one():
     assert np.all((got >= 0).sum(1) == 300)
     assert _trailing_minus_one(got)
     assert _set_rows_equal(got, _exact_indices(scores, K))
+
+
+@pytest.mark.skipif(not sc_topk_available(), reason="no SparseCore top-k on this chip")
+def test_sc_selector_edge_rows():
+    """E == k (no -1), all -inf (all -1) and 600 tied maxima (exact set, no early -1)."""
+    exact_k = jnp.asarray(np.random.default_rng(5).standard_normal((4, K), np.float32))
+    got = np.asarray(select_topk_indices(exact_k, K, backend="sc"))
+    assert np.all(got >= 0) and _set_rows_equal(got, _exact_indices(exact_k, K))
+
+    all_inf = jnp.full((2, 8192), -jnp.inf, jnp.float32)
+    assert np.all(np.asarray(select_topk_indices(all_inf, K, backend="sc")) == -1)
+
+    tied = jnp.zeros((1, 8192), jnp.float32).at[0, :600].set(1.0)
+    got = np.asarray(select_topk_indices(tied, K, backend="sc"))
+    assert np.all(got >= 0) and np.all(got[0] < 600) and len(set(got[0].tolist())) == K
 
 
 def test_xla_selector_unchanged():


### PR DESCRIPTION
## Motivation

`streamindex_topk` ends with `jax.lax.approx_max_k(scores, k, recall_target=1.0)`. On TPU XLA short-circuits `recall_target=1.0` to `log2_reduction=0`, i.e. a full sort of every row (no PartialReduce). At DeepSeek-V4 scale (`compression_ratio=4`, 1M context → E = 262144 compressed entries per query, `k=512`) that exit stage is the dominant cost of the indexer kernel, not the Pallas scoring loop:

| shape (TPU7x, k=512, E=262144) | total | Pallas scores | approx_max_k sort | selection share |
|---|---|---|---|---|
| decode B=64 | 7.50 ms | 3.3 ms | 3.6 ms (+1.7 ms copies) | 56% |
| prefill T=2048 | 123.9 ms | 18.9 ms | 92.4 ms | 84% |

Lowering `recall_target` is not an option here: the indexer contract is exact top-k (see #1515), and the ApproxTopK partial reduce keeps only one candidate per bin, so it cannot be made exact in two stages.

## What this PR does

Vendors the openxla/tokamax SparseCore MSB radix-select top-k kernel (Apache-2.0, `tokamax/_src/ops/experimental/tpu/topk/pallas_mosaic_tpu_kernel.py` @ `6303c141386c`) as `sgl_jax/srt/kernels/dsa/sc_topk.py` and routes large rows through it. The kernel is exact and stable (deterministic post-fill by index), runs on the SparseCore so it does not compete with the TensorCore, and needs no changes to the Pallas scoring kernel.

- New `select_topk_indices(scores, k, backend="auto"|"sc"|"xla")` in `streamindex_topk.py`; `streamindex_topk` gains a static `topk_backend="auto"` kwarg. Output contract unchanged: exact top-k indices, descending by score, `-1` (from `-inf`) packed at the tail, shape `[T, k]`.
- `backend="xla"` is byte-for-byte the previous `approx_max_k(recall_target=1.0)` path.
- Routing policy (`should_use_sc_topk`): SparseCore when the chip reports one (`pltpu.get_tpu_info().generation >= 6` and `sparse_core` present), `E >= DSA_SC_TOPK_MIN_ENTRIES` (default 8192; very short rows are faster on XLA because of the fixed SparseCore launch cost) and the per-subcore key+value slice fits half of the subcore VMEM (E ≤ 262144 on v6e, ≤ 524288 on v7x). Everything else stays on XLA. `DSA_SC_TOPK=0` is a process-wide kill switch.
- Rows are padded with `-inf` to the kernel's layout constraint (a whole number of `num_lanes`-wide vectors per subcore tile, `num_subcores` tiles above 4096 entries), derived from `SparseCoreInfo` at trace time, not hard-coded.
- Only the kernel's single-window path (`num_seq_windows=1`) is used. The multi-window path in the vendored revision returns wrong results (the global histogram is only synchronized on the last window and earlier windows are post-filled locally); the header in `sc_topk.py` documents this and callers cannot enable it through `select_topk_indices`.
- The vendored file is unchanged apart from the provenance header and `absl.logging` → stdlib `logging` (absl is not a sglang-jax dependency). `pyproject.toml` gets a per-file ruff ignore (`B023`, `SIM212`) for it, same as the existing Pallas kernels.

## Benchmarks

Kernel-level: `streamindex_topk` wall time (median of 10, `jax.block_until_ready`), `k=512`, `H=64`, `D=128`, bf16 cache, `num_kv_pages_per_block=64`, `num_queries_per_block=(1,64,64)`; `xla` = previous path, `sc` = this PR with the kernel forced, `auto` = this PR default. Every `sc`/`auto` row matched the `xla` index set exactly on all rows.

TPU7x (jax 0.11.1):

| case | ctx | E | xla (ms) | sc (ms) | auto (ms) | Δ auto vs xla |
|---|---|---|---|---|---|---|
| decode B=64 | 1M | 262144 | 7.49 | 4.27 | 4.29 | -43% |
| prefill T=2048 | 1M | 262144 | 124.0 | 42.4 | 42.8 | -66% |
| decode B=64 | 100K | 25000 | 4.61 | 1.40 | 1.41 | -69% |
| decode B=8 | 1K | 256 (< k) | 0.66 | 0.63 | 0.56 | within noise (auto keeps XLA) |

TPU v6e (jax 0.11.1):

| case | ctx | E | xla (ms) | sc (ms) | auto (ms) | Δ auto vs xla |
|---|---|---|---|---|---|---|
| decode B=64 | 1M | 262144 | 7.94 | 4.95 | 4.93 | -38% |
| prefill T=2048 | 1M | 262144 | 171.3 | 64.5 | 64.5 | -62% |
| decode B=64 | 100K | 25000 | 5.16 | 2.20 | 2.21 | -57% |
| decode B=8 | 1K | 256 (< k) | 0.74 | 0.96 | 0.96 | +30% forced; auto keeps XLA (0.74) |

Selection stage only (same tensors, `approx_max_k` sort vs SparseCore kernel), TPU7x: decode `[64, 262144]` 4.12 → 0.86 ms; prefill `[2048, 262144]` 104 → 19.8 ms.

Kernel-level only, GLM-5.2 decode shapes (`index_topk=2048`, `compression_ratio=1`, 128K context → E=131072, `H=32`, `num_queries_per_block=1`): wall time of one `streamindex_topk` call, same protocol as above. Not a model-level TTFT/TPOT measurement. GLM-5.2 has 21 such full-indexer layers per decode step, hence the last column:

| chip | B | xla (ms) | auto (ms) | Δ | ×21 layers per step |
|---|---|---|---|---|---|
| TPU7x | 1 | 1.31 | 0.23 | -82% | 27.6 → 4.9 ms |
| TPU7x | 16 | 1.87 | 0.78 | -58% | 39.2 → 16.4 ms |
| TPU7x | 64 | 6.94 | 2.54 | -63% | 145.8 → 53.3 ms |
| v6e | 1 | 1.51 | 0.31 | -79% | 31.8 → 6.6 ms |
| v6e | 16 | 1.99 | 0.97 | -51% | 41.9 → 20.4 ms |
| v6e | 64 | 7.60 | 3.00 | -61% | 159.6 → 63.0 ms |

## Correctness

`test/srt/kernels/dsa/test_sc_topk_selector.py` (TPU only, skips the SparseCore cases on chips without one):

- `select_topk_indices(backend="sc")` vs `jax.lax.top_k` on random rows with a block of `-inf` columns, for `[64, 262144]`, `[3, 25000]` (not a multiple of 256, exercises padding) and `[1, 8192]`: same index set, descending, `-1` only at the tail, no `-inf` column selected.
- E < k (300 valid of 8192), E == k, all `-inf` rows, 600 tied maxima.
- Routing policy as a pure function with mocked v6e geometry, the VMEM boundary at exactly 262144 entries, off-TPU behaviour, `backend="sc"` without a SparseCore raises a clear `ValueError`, and `backend="auto"` observed to call the XLA selector for 256-entry rows and the SparseCore selector for 262144-entry rows.
- End to end `streamindex_topk` with `topk_backend` in `xla`/`sc`/`auto` for decode 1M ctx, prefill 1M ctx, decode 100K ctx and decode 1K ctx (256 entries < k): identical index sets and trailing `-1` contract.

## Test plan

- [x] `pre-commit run --all-files` clean (isort, ruff, black, codespell, mypy)
- [x] v6e-8: `test_sc_topk_selector.py` passed (14 passed)
- [x] v6e-8: `pytest test/srt/kernels/dsa/` passed (48 passed, 4 skipped)
- [x] TPU7x: `test_sc_topk_selector.py` passed (14 passed)
- [x] TPU7x: `pytest test/srt/kernels/dsa/` 48 passed, 4 skipped
- [x] Benchmarks above reproduced from the merged branch (fresh process per backend, 10 timed iterations after warm-up)

## Follow-ups (not in this PR)

- `DSA_SC_TOPK_MIN_ENTRIES` is set from two data points (256 and 25000 entries); a sweep between 4096 and 16384 would place it more precisely.
- `select_topk_indices` is the single swap point if a faster SparseCore top-k becomes available upstream (tokamax or jax); nothing else in the indexer depends on the kernel.
- For prefill at very long context a block-max coarse filter before selection would cut the HBM traffic of the score matrix; orthogonal to this change.

Related: #1607 (completed-groups visibility mask in the same kernel; independent, both apply cleanly to main).
