### PR TITLE
fix(qmm): align borrowed batch_block_size to the operand sublane tiling (deterministic server crash on jax >= 0.11.1)

### DIFF
--- a/python/sgl_jax/srt/kernels/quantized_matmul/blockwise_utils.py
+++ b/python/sgl_jax/srt/kernels/quantized_matmul/blockwise_utils.py
@@ -367,14 +367,21 @@ def get_safe_blockwise_tuned_value(
     n_lane_multiplier = max(1, int(tuned.n_lane_multiplier))
     compute_tile_n = 256 * n_lane_multiplier
 
-    # batch: cap to actual batch size, then enforce the Pallas TPU block-shape
-    # constraint (block_m % 8 == 0 OR block_m == array_m). When Tier-1 fuzzy
-    # match returns a small batch_block_size (e.g. 1 from a #1191 entry) but
-    # n_batch is in (1, 8), the unaligned block triggers a lowering ValueError.
+    # batch: cap to actual batch size, then enforce the Mosaic block-shape
+    # constraint: block_m must equal array_m or divide the operand's sublane
+    # tiling evenly. jax >= 0.11 tiles operands at their native sublane
+    # granularity (256 / dtype_bits rows: fp32 8, bf16 16, fp8/int8 32) and
+    # rejects smaller blocks with E2002, so a borrowed batch_block_size from a
+    # nearest-neighbour table entry (e.g. the n_batch=8 entry serving a padded
+    # 16-row decode bucket) must be aligned up to the tile floor.
     n_batch_i = int(n_batch)
+    sublane_m = max(8, 256 // max(8, jnp.dtype(x_q_dtype).itemsize * 8))
     batch_block_size = max(1, min(int(tuned.batch_block_size), n_batch_i))
-    if batch_block_size < n_batch_i and batch_block_size % 8 != 0:
-        batch_block_size = n_batch_i if n_batch_i <= 8 else max(8, batch_block_size & ~7)
+    if batch_block_size < n_batch_i and batch_block_size % sublane_m != 0:
+        if n_batch_i <= sublane_m:
+            batch_block_size = n_batch_i
+        else:
+            batch_block_size = min(n_batch_i, _next_multiple(batch_block_size, sublane_m))
 
     # out (N): round up to compute_tile_n, cap to matrix N, then snap to
     # nearest power-of-two multiple for TPU alignment.

--- a/python/sgl_jax/test/kernels/blockwise_tuned_value_test.py
+++ b/python/sgl_jax/test/kernels/blockwise_tuned_value_test.py
@@ -1,0 +1,56 @@
+"""Snap constraints in get_safe_blockwise_tuned_value must respect Mosaic sublane tiling.
+
+Regression for the jax 0.11.1 E2002 crash: the nearest-neighbour table match can
+borrow batch_block_size=8 (from the n_batch=8 entry) for a padded 16-row decode
+bucket, and jax >= 0.11 rejects an 8-row block on a bf16 operand tiled (16, 128).
+"""
+
+from unittest import mock
+
+import jax.numpy as jnp
+import pytest
+
+from sgl_jax.srt.kernels.quantized_matmul import blockwise_utils
+
+
+def _tuned(n_batch, x_dtype=jnp.bfloat16):
+    with mock.patch.object(blockwise_utils, "_get_current_tpu_version", return_value=7):
+        return blockwise_utils.get_safe_blockwise_tuned_value(
+            n_batch=n_batch,
+            n_out=576,
+            n_in=6144,
+            x_q_dtype=x_dtype,
+            w_q_dtype=jnp.float8_e4m3fn,
+            block_size_in=128,
+        )
+
+
+@pytest.mark.parametrize(
+    "n_batch,x_dtype,min_ok",
+    [
+        (16, jnp.bfloat16, 16),  # the crashing bucket: borrowed 8 must align to 16
+        (24, jnp.bfloat16, 16),
+        (16, jnp.float8_e4m3fn, 16),  # 8-bit activations tile at 32 rows
+    ],
+)
+def test_borrowed_block_respects_sublane_tiling(n_batch, x_dtype, min_ok):
+    tuned = _tuned(n_batch, x_dtype)
+    if tuned is None:
+        pytest.skip("blockwise tuning API unavailable")
+    bm = tuned.batch_block_size
+    sublane = max(8, 256 // (jnp.dtype(x_dtype).itemsize * 8))
+    assert bm == n_batch or bm % sublane == 0, (
+        f"batch_block_size={bm} is neither the full batch ({n_batch}) nor a "
+        f"multiple of the {sublane}-row sublane tile"
+    )
+    assert bm <= n_batch
+
+
+@pytest.mark.parametrize("n_batch", [1, 4, 8, 32])
+def test_exact_and_small_batches_unchanged(n_batch):
+    tuned = _tuned(n_batch)
+    if tuned is None:
+        pytest.skip("blockwise tuning API unavailable")
+    bm = tuned.batch_block_size
+    assert bm == n_batch or bm % 8 == 0
+    assert bm <= n_batch


### PR DESCRIPTION
## Motivation

Yet another jax 0.11.1 casualty, same Mosaic-tiling family as the qblock regression fixed in #1631. Serving GLM-5.2 FP8 (static quantized-matmul path) on TPU v7x tp16, any variable-length workload deterministically kills the whole server the moment the number of in-flight requests drains down to 16 — the first time the bs=16 decode bucket is compiled. With 200 GSM8K questions at client concurrency 32 it dies at 184 completed, with 180 questions at 164, always N-16, five out of five runs across three server pairs including the pristine 64dd38e5 merge commit:

```
jax.errors.JaxRuntimeError: INVALID_ARGUMENT: Mosaic failed to compile TPU kernel with MLIR module name `<no name>` HLO name `quantized_matmul_kernel_8_256_2048.499`: Failed to set window params for output 0: E2002: CompileTimeMosaicMisalignedBlockAndTiling:
Operand of shape (..., 16, 256) has tiling (16, 128), but its block shape (..., 8, 256) is not divisible by tiling evenly nor matches the full shape
```

The scheduler thread dies (`ModelWorkerClient hit an exception`), the server exits, and all in-flight requests are dropped. Fixed-length benchmarks never see this because all requests finish together and the drain jumps straight past the 16 bucket, which is why routine benches and CI stay green while any real variable-length traffic at concurrency >= 16 is guaranteed to hit it.

## Root cause

Three layers stack up:

1. The tuned table has entries for these GLM shapes (n_out=576, n_in=6144 — kv_a_proj) only at n_batch=8 and n_batch=32; there is no n_batch=16 entry.
2. `blockwise_utils.get_safe_blockwise_tuned_value` borrows the nearest entry (n_batch=8, so batch_block_size=8), and its snap step only enforces the pre-0.11 rule `block_m % 8 == 0 OR block_m == array_m`, letting the 8-row block through for the 16-row padded operand.
3. jax 0.11.1 tightened Mosaic sublane tiling for this operand from (8, 128) to (16, 128), so a block that compiled fine on jax 0.10.2 is now rejected with E2002. The identical GSM8K drain ran clean on a jax 0.10.2 image.

## Modification

In the snap step, align a borrowed `batch_block_size` up to the operand's native sublane tile (256 / dtype_bits rows: fp32 8, bf16 16, fp8/int8 32) whenever it does not already match the full padded batch. For the crashing bucket this turns the borrowed 8 into 16. Exact-match lookups and batches at or below the tile floor are unchanged.

Note for upstream consumers: this util is adapted from vllm-project/tpu-inference (currently pinned to jax 0.11.0); the same constraint will apply there once it moves to jax >= 0.11.1.

## Test plan

- [x] New `blockwise_tuned_value_test.py`: the crashing (n_batch=16, n_out=576, n_in=6144, bf16 x fp8) lookup now yields batch_block_size=16; parametrized over bf16/fp8 activations and n_batch in {1, 4, 8, 16, 24, 32}; 7/7 on CPU
- [x] TPU e2e repro-then-fix pair on main @ 64dd38e5 (GLM-5.2 FP8, v7x tp16): unpatched reproduces the crash at in-flight=16; with this fix the same GSM8K 200q at client concurrency 32 drains to completion — 200/200, accuracy 0.945, Invalid 0, no Mosaic errors
- [x] pre-commit clean
