### PR TITLE
perf(mla): skip the identity KV merge loop for word-aligned new KV

### DIFF
--- a/python/sgl_jax/srt/kernels/mla/v2/kernel.py
+++ b/python/sgl_jax/srt/kernels/mla/v2/kernel.py
@@ -670,12 +670,23 @@ def _mla_ragged_paged_attention_kernel(
                 q_end = cu_q_lens_ref[seq_idx + 1]
                 kv_len = kv_lens_ref[seq_idx]
 
-                update_kv_packing_iters = cdiv_on_kv_packing(
-                    (offset % kv_packing) + update_sz, kv_packing
-                )
                 kv_packing_offset = offset % kv_packing
                 new_kv_len_start = q_end - kv_len + offset
                 new_kv_packing_offset = new_kv_len_start % kv_packing
+
+                # _fetch_bkv appends the new KV words right after the last word holding
+                # cached KV. If both the destination and the source token offsets are
+                # word-aligned (e.g. a prefill without cached prefix), those words are
+                # already in their final position and each merge_loop_body iteration
+                # would store a word back unchanged, so merge no words at all.
+                new_kv_in_place = jnp.logical_and(
+                    kv_packing_offset == 0, new_kv_packing_offset == 0
+                )
+                update_kv_packing_iters = jnp.where(
+                    new_kv_in_place,
+                    0,
+                    cdiv_on_kv_packing(kv_packing_offset + update_sz, kv_packing),
+                )
 
                 token_offset_in_bkv = offset % bkv_sz
                 kv_packing_idx = floor_div_on_kv_packing(token_offset_in_bkv, kv_packing)


### PR DESCRIPTION
## Motivation

In the MLA v2 Pallas kernel, `_pack_new_kv` runs a merge loop that shifts the new KV words fetched by `_fetch_bkv` into their packed position. When both the destination token offset and the source token offset are multiples of `kv_packing`, every merge iteration is an identity: the words already sit at their final position. The captured 2,048-token MLA case spends most of its 380 µs in exactly that loop.

## Modifications

- `_pack_new_kv` merges zero words when the alignment condition holds, and keeps the existing merge path otherwise. The condition is evaluated from the same scalar metadata the loop already reads; no shape, dtype or interface change. One file: `python/sgl_jax/srt/kernels/mla/v2/kernel.py`.
- Static instruction count is essentially unchanged (18,011 → 18,017 bundles); the effect is fewer executed loop trips.

## Accuracy Tests

The module imports on CPU with JAX 0.11.1. On TPU7x the candidate's outputs matched the retained Phase 1 reference outputs in all three hardware repetitions (exact comparison on the captured inputs). The TPU-only MLA tests (`python/sgl_jax/test/test_mla_attention.py`) were not run in this environment.

## Benchmarking and Profiling

Candidate-only runs on TPU7x compared with the saved Phase 1 profile of the same workload (MLA v2, 2,048 tokens, three MLA kernel variants in one module):

| 2,048-token TPU7x MLA | Device span (µs) |
| --- | ---: |
| Saved baseline | 380.321 |
| Candidate repetition 1 | 87.410 |
| Candidate repetition 2 | 87.736 |
| Candidate repetition 3 | 87.702 |

**−77.0 %** device span for this captured shape. The gain depends on the alignment condition being true for the captured offsets; unaligned cases take the unchanged merge path and are not faster. Please treat the number as shape-specific until measured on more configurations.

---
Produced by the HierEvo v2 Phase 2 loop (Lowering–Exposure Graph localization + Claude Opus 5 oracle); candidate-only measurements on TPU7x via GKE. Receipts, LLO diffs and post-modification traces are retained in the HierEvo campaign record (`docs/leg_campaign_20260910.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GXDwgzoD3AKyC5HGBUS1U
