### PR TITLE
perf(rpa): reuse the resident KV block instead of refetching it every query block

### DIFF
--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -222,7 +222,7 @@ def get_smem_estimate_bytes(max_num_seqs, pages_per_seq):
         # distribution_ref: i32[3]
         128 * 32
         +
-        # sem_ids_ref: i32[3]
+        # sem_ids_ref: i32[5]
         128 * 32
         +
         # bo_ids_ref: i32[4]
@@ -336,7 +336,7 @@ def _ragged_paged_attention_kernel_loop(
     cu_kv_lens_ref,  # [max_num_seqs + 1]
     cu_seq_mask_lens,  # [1], unused placeholder
     distribution_ref,  # [3] (decode_end, prefill_end, mixed_end)
-    sem_ids_ref,  # [3] (bq_sem_idx, bkv_sem_idx, bo_sem_idx)
+    sem_ids_ref,  # [5] (bq_sem_idx, bkv_sem_idx, bo_sem_idx, bkv0_pending, bkv1_pending)
     bo_ids_ref,  # [4]
     bkv_update_ids_ref,  # [6]
     # Input
@@ -661,14 +661,20 @@ def _ragged_paged_attention_kernel_loop(
                 sem,
                 wait,
             )
+            sem_ids_ref[3 + bkv_sem_idx] = 1
         else:
-            dst = vmem_ref.at[pl.ds(0, bkv_sz_frm_cache + bkv_sz_frm_new)]
-            _async_copy(
-                src=dst,
-                dst=dst,
-                sem=sem,
-                wait=True,
-            )
+            # A buffer kept for the same block by the previous step was already
+            # waited on and has no DMA in flight.
+            @pl.when(sem_ids_ref[3 + bkv_sem_idx] != 0)
+            def _():
+                sem_ids_ref[3 + bkv_sem_idx] = 0
+                dst = vmem_ref.at[pl.ds(0, bkv_sz_frm_cache + bkv_sz_frm_new)]
+                _async_copy(
+                    src=dst,
+                    dst=dst,
+                    sem=sem,
+                    wait=True,
+                )
         return kv_len_start + bkv_sz_frm_cache, bkv_sz_frm_new
 
     def _update_kv_cache(seq_idx, bkv_sem_idx, offset, update_sz, *, wait=False):
@@ -994,8 +1000,19 @@ def _ragged_paged_attention_kernel_loop(
                 )
                 processed_kv_len = bkv_idx * bkv_sz
 
-                # Prefetch next bkv
-                @pl.when(next_seq_idx < end_seq_idx)
+                # Prefetch next bkv. If the next step reads this same block (the
+                # visible KV fits in one bkv tile, e.g. every bq of a prefill of at
+                # most bkv_sz tokens), keep it in the current buffer instead of
+                # copying it from HBM again. Custom masks are per bq and share the
+                # buffer index, so they always fetch.
+                fetch_next_bkv = next_seq_idx < end_seq_idx
+                if custom_mask_ref is None:
+                    fetch_next_bkv = jnp.logical_and(
+                        fetch_next_bkv,
+                        jnp.logical_or(next_seq_idx != seq_idx, next_bkv_idx != bkv_idx),
+                    )
+
+                @pl.when(fetch_next_bkv)
                 def prefetch_next_bkv():
                     sem_ids_ref[1] = next_bkv_sem_idx
                     start_fetch_bkv(next_seq_idx, next_bkv_idx, next_bkv_sem_idx)
@@ -1827,7 +1844,7 @@ def ragged_paged_attention(
     cu_seq_mask_lens = jnp.array([0], dtype=jnp.int32)
 
     # Scalar prefetch init values.
-    init_sem_ids = jnp.zeros((3,), jnp.int32)
+    init_sem_ids = jnp.zeros((5,), jnp.int32)
     init_bo_ids = jnp.full((4,), -1, jnp.int32)
     init_bkv_update_ids = jnp.full((6,), -1, jnp.int32)
 


### PR DESCRIPTION
## Motivation

In the ragged paged attention v3 kernel, the double-buffer pipeline issues a fresh HBM→VMEM fetch of the next KV block for every query-block step even when the next step attends to the KV block that is already resident. In the captured 2,048-token prefill (one sequence, tuned v7 MIXED tiles bq=32, bkv=2048) all 64 query blocks attend to the same KV block, so each step re-issues 16 zero-length page DMAs, one 1 MB new-KV DMA and about 160 bundles of scalar bookkeeping, then blocks on the wait before computing. The RPAm kernel is 83.7 µs of the 97.4 µs module.

## Modifications

- Skip the prefetch when the next step reads the same (sequence, KV block) as the current one, keeping it in the current buffer; two per-buffer pending flags (the semaphore-id scratch grows from 3 to 5 words) record whether a DMA is in flight so the wait is only issued for buffers that were actually fetched. Custom-mask kernels always fetch, as before.
- No interface, tiling or numerical change. One file: `python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py`.
- Static instruction count grows slightly (10,353 → 10,392 bundles) for the guard; the effect is fewer DMAs executed at run time.

## Accuracy Tests

The module imports on CPU with JAX 0.11.1. On TPU7x the candidate's outputs matched the retained Phase 1 reference outputs in all three hardware repetitions (exact comparison on the captured inputs; both the decode and the mixed kernel variants of the module were compiled and run). The TPU-only attention tests were not run in this environment.

## Benchmarking and Profiling

Candidate-only runs on TPU7x compared with the saved Phase 1 profile of the same workload (RPA v3, 2,048-token prefill):

| 2,048-token TPU7x ragged paged attention | Device span (µs) |
| --- | ---: |
| Saved baseline | 97.385 |
| Candidate repetition 1 | 90.304 |
| Candidate repetition 2 | 90.463 |
| Candidate repetition 3 | 90.280 |

**−7.2 %** device span; the RPAm kernel itself went from 83.7 µs to 76.6 µs per invocation in the post-modification profile. The gain depends on consecutive query blocks sharing a KV block (long single sequences); multi-sequence batches with changing KV blocks take the unchanged path.

---
Produced by the HierEvo v2 Phase 2 loop (Lowering–Exposure Graph localization + Claude Opus 5 oracle); candidate-only measurements on TPU7x via GKE. Receipts, LLO diffs and post-modification traces are retained in the HierEvo campaign record (`docs/leg_campaign_20260910.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GXDwgzoD3AKyC5HGBUS1U
